### PR TITLE
fix: make LLM session titles follow app locale

### DIFF
--- a/src-tauri/src/session_title.rs
+++ b/src-tauri/src/session_title.rs
@@ -8,6 +8,7 @@ use tauri::{AppHandle, Emitter};
 
 use crate::cli_probe;
 use crate::store::{self, SessionMeta};
+use crate::tray_i18n::{self, Locale};
 
 const PLACEHOLDERS: &[&str] = &[
     "New chat",
@@ -55,7 +56,12 @@ fn clean_llm_title(raw: &str) -> Option<String> {
             t = t[1..t.len() - 1].trim().to_string();
         }
     }
-    if let Some(rest) = t.strip_prefix("标题：").or_else(|| t.strip_prefix("标题:")) {
+    if let Some(rest) = t
+        .strip_prefix("标题：")
+        .or_else(|| t.strip_prefix("标题:"))
+        .or_else(|| t.strip_prefix("Title:"))
+        .or_else(|| t.strip_prefix("Title："))
+    {
         t = rest.trim().to_string();
     }
     if let Some(line) = t.lines().next() {
@@ -67,14 +73,24 @@ fn clean_llm_title(raw: &str) -> Option<String> {
     Some(truncate_chars(&t, 32))
 }
 
+/// Prompt for the headless title LLM, matching the app UI locale.
+fn title_prompt(snippet: &str, locale: Locale) -> String {
+    match locale {
+        Locale::En => format!(
+            "Write a short session title for the user message below.\nRequirements: at most 8 English words (or match the message language if it is not English); output the title only; no quotes, prefixes, or explanation.\n\nUser message:\n{snippet}"
+        ),
+        Locale::Zh => format!(
+            "为下面这条用户消息起一个简短会话标题。要求：最多16个汉字或8个英文单词；只输出标题；不要引号、标点前缀、解释。\n\n用户消息：\n{snippet}"
+        ),
+    }
+}
+
 /// Call Grok CLI headless with low effort.
 fn llm_title_via_cli(message: &str) -> Option<String> {
     let probe = cli_probe::probe_cli(None);
     let path = probe.path?;
     let snippet: String = message.chars().take(400).collect();
-    let prompt = format!(
-        "为下面这条用户消息起一个简短会话标题。要求：最多16个汉字或8个英文单词；只输出标题；不要引号、标点前缀、解释。\n\n用户消息：\n{snippet}"
-    );
+    let prompt = title_prompt(&snippet, tray_i18n::app_locale());
 
     let mut cmd = Command::new(&path);
     cmd.arg("-p")
@@ -190,5 +206,26 @@ mod tests {
             clean_llm_title("  \"修复登录样式\" \n"),
             Some("修复登录样式".into())
         );
+    }
+
+    #[test]
+    fn clean_strips_english_title_prefix() {
+        assert_eq!(
+            clean_llm_title("Title: List open PRs\n"),
+            Some("List open PRs".into())
+        );
+    }
+
+    #[test]
+    fn title_prompt_follows_locale() {
+        let en = title_prompt("list open prs", Locale::En);
+        assert!(en.contains("User message:"));
+        assert!(en.contains("list open prs"));
+        assert!(!en.contains("用户消息"));
+
+        let zh = title_prompt("list open prs", Locale::Zh);
+        assert!(zh.contains("用户消息："));
+        assert!(zh.contains("list open prs"));
+        assert!(!zh.contains("User message:"));
     }
 }


### PR DESCRIPTION
## Summary

Background session auto-title uses a headless Grok CLI prompt that was **hard-coded in Chinese**, regardless of `settings.locale`.

With the UI set to English, the first user message `list open prs` was refined into a Chinese title such as **列出打开的PR**. That is surprising for EN users and makes the sidebar harder to scan.

### Fix

- Build the title LLM prompt from `tray_i18n::app_locale()` (same source as tray / settings language):
  - **en** → English instructions (“User message:”, max ~8 words, title only)
  - **zh** → existing Chinese prompt (unchanged behavior for default locale)
- Also strip English `Title:` / `Title：` prefixes in `clean_llm_title` (mirrors existing `标题：` handling)
- Unit tests for locale prompt selection and English prefix stripping

Heuristic titles (instant offline rename from the first message line) were already language-neutral; only the background LLM refine path was biased to Chinese.

## Test plan

- [x] Code review of `src-tauri/src/session_title.rs`
- [x] Added unit tests: `title_prompt_follows_locale`, `clean_strips_english_title_prefix`
- [ ] `cd src-tauri && cargo test` (if CI / maintainer can run)
- [ ] Manual: set **Settings → Language → English**, start a new chat with an English first message, confirm refined sidebar title is English
- [ ] Manual: set language to **中文**, start a Chinese first message, confirm refined title still Chinese

Thanks for the great unofficial Grok Build workbench!