### PR TITLE
fix: use Grok Build permission optionIds (underscore)

### DIFF
--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -902,10 +902,15 @@ impl SessionManager {
                 if auto {
                     let acp = self.inner.lock().as_ref().and_then(|s| s.acp.clone());
                     if let Some(acp) = acp {
+                        // Grok Build shell prompts use underscore optionIds (allow_once /
+                        // allow_command_always / reject). Hyphenated ACP-style fallbacks
+                        // are rejected as "unknown permission option".
                         let option_id = pick_option_id(&options, "allow_once")
                             .or_else(|| pick_option_id(&options, "allow_always"))
+                            .or_else(|| pick_option_id(&options, "allow_command_always"))
+                            .or_else(|| pick_option_id(&options, "always_allow_all_sessions"))
                             .or_else(|| pick_option_id(&options, "allow"))
-                            .unwrap_or_else(|| "allow-once".into());
+                            .unwrap_or_else(|| "allow_once".into());
                         let _ = acp
                             .respond_permission(
                                 rpc_id,
@@ -923,9 +928,10 @@ impl SessionManager {
                     let acp = self.inner.lock().as_ref().and_then(|s| s.acp.clone());
                     if let Some(acp) = acp {
                         let option_id = pick_option_id(&options, "reject_once")
+                            .or_else(|| pick_option_id(&options, "reject_always"))
                             .or_else(|| pick_option_id(&options, "reject"))
                             .or_else(|| pick_option_id(&options, "deny"))
-                            .unwrap_or_else(|| "reject-once".into());
+                            .unwrap_or_else(|| "reject".into());
                         let _ = acp
                             .respond_permission(
                                 rpc_id,
@@ -1811,11 +1817,11 @@ impl SessionManager {
             let outcome = match decision.as_str() {
                 "cancel" => PermissionOutcome::Cancelled,
                 "deny" => PermissionOutcome::Selected {
-                    option_id: option_id.unwrap_or_else(|| "reject-once".into()),
+                    option_id: option_id.unwrap_or_else(|| "reject".into()),
                 },
                 _ => PermissionOutcome::Selected {
                     // Prefer client-supplied optionId from Agent options list
-                    option_id: option_id.unwrap_or_else(|| "allow-once".into()),
+                    option_id: option_id.unwrap_or_else(|| "allow_once".into()),
                 },
             };
             acp.respond_permission(rpc_id, outcome)

--- a/src/lib/permissionOptions.test.ts
+++ b/src/lib/permissionOptions.test.ts
@@ -4,14 +4,14 @@ import { mapPermissionButtons } from "./permissionOptions";
 describe("mapPermissionButtons (shipped)", () => {
   it("maps ACP optionIds from real options list", () => {
     const buttons = mapPermissionButtons([
-      { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
-      { optionId: "allow-always", name: "Allow always", kind: "allow_always" },
-      { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+      { optionId: "allow_once", name: "Allow once", kind: "allow_once" },
+      { optionId: "allow_always", name: "Allow always", kind: "allow_always" },
+      { optionId: "reject", name: "Reject", kind: "reject_once" },
     ]);
     expect(buttons.map((b) => b.optionId)).toEqual([
-      "allow-once",
-      "allow-always",
-      "reject-once",
+      "allow_once",
+      "allow_always",
+      "reject",
     ]);
     expect(buttons.map((b) => b.decision)).toEqual([
       "allow_once",

--- a/src/lib/permissionOptions.ts
+++ b/src/lib/permissionOptions.ts
@@ -74,7 +74,7 @@ export function mapPermissionButtons(
   } else {
     out.push({
       decision: "allow_once",
-      optionId: "allow-once",
+      optionId: "allow_once",
       label: L.allowOnce,
     });
   }
@@ -88,7 +88,7 @@ export function mapPermissionButtons(
   } else {
     out.push({
       decision: "allow_session",
-      optionId: "allow-always",
+      optionId: "allow_always",
       label: L.allowSession,
     });
   }
@@ -99,7 +99,7 @@ export function mapPermissionButtons(
       label: L.deny,
     });
   } else {
-    out.push({ decision: "deny", optionId: "reject-once", label: L.deny });
+    out.push({ decision: "deny", optionId: "reject", label: L.deny });
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Shell / terminal tools fail under Grok App with:

```text
Failed to request permission from user: unknown permission option for tool `run_terminal_command`
```

The turn then looks “stuck”: thoughts appear, tool steps fail, assistant body stays empty.

### Cause

When auto-approving or when mapping UI buttons without a full Agent options list, the host used **hyphenated** fallback optionIds (`allow-once`, `allow-always`, `reject-once`).

Grok Build’s permission prompter for shell tools expects **underscore** ids (see CLI docs / `[ui] default_selected_permission`):

| optionId | Row |
|----------|-----|
| `always_allow_all_sessions` | Always allow on all sessions |
| `allow_once` | Allow once |
| `allow_command_always` | Always allow this command |
| `reject` | Reject |

Unknown optionIds are treated as a failed permission → tool status `failed` → turn cancelled.

### Fix

- Rust auto-allow / auto-deny / resolve_permission fallbacks → `allow_once` / `reject` (+ try `allow_command_always` / `always_allow_all_sessions`)
- Frontend `mapPermissionButtons` fallbacks → same ids

Still prefers real `optionId`s from the Agent when present.

## Test plan

- [ ] Start session with Ask / Approve-for-me (not YOLO)
- [ ] Prompt that needs `run_terminal_command` (e.g. `list open prs` / `gh pr list`)
- [ ] Click **Allow once** → command runs (no “unknown permission option”)
- [ ] YOLO / always-approve still works as before

Related: #1 (locale-aware session titles)