### PR TITLE
feat(acp): API mode — connect to a remote ACP server over TCP

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -9,8 +9,9 @@ use std::sync::Arc;
 
 use parking_lot::Mutex as ParkingMutex;
 use serde_json::{json, Value};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, Command};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex};
 use tracing::{debug, error, info, warn};
 
@@ -106,8 +107,12 @@ const PROMPT_TIMEOUT_SECS: u64 = 600;
 const PROMPT_COMPLETE_FALLBACK_GRACE_MS: u64 = 3000;
 
 pub struct AcpClient {
+    /// The spawned CLI process, or `None` in API mode (connected to a remote
+    /// ACP server over TCP instead of spawning `grok agent stdio`).
     child: AsyncMutex<Option<Child>>,
-    stdin: AsyncMutex<Option<ChildStdin>>,
+    /// Write half of the transport (child stdin, or the TCP write half). Both
+    /// impl `AsyncWrite`, so the JSON-RPC line protocol is transport-agnostic.
+    stdin: AsyncMutex<Option<Box<dyn AsyncWrite + Unpin + Send>>>,
     next_id: AtomicU64,
     pending: ParkingMutex<HashMap<u64, Pending>>,
     event_tx: mpsc::UnboundedSender<AcpEvent>,
@@ -174,6 +179,18 @@ impl AcpClient {
         session_data_mode: &str,
         opts: SpawnOptions,
     ) -> Result<(Arc<Self>, mpsc::UnboundedReceiver<AcpEvent>), AgentError> {
+        // API mode: if an ACP server address is configured, connect over TCP
+        // instead of spawning a local CLI. The server drives an agent running
+        // elsewhere (WSL/SSH/container) but speaks the identical ACP protocol.
+        if let Some(addr) = crate::store::load_settings()
+            .acp_server_addr
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return Self::connect_tcp(addr, cwd);
+        }
+
         if !cli_path.exists() {
             return Err(AgentError::new(
                 AgentErrorCode::CliNotFound,
@@ -276,7 +293,7 @@ impl AcpClient {
 
         let client = Arc::new(Self {
             child: AsyncMutex::new(Some(child)),
-            stdin: AsyncMutex::new(Some(stdin)),
+            stdin: AsyncMutex::new(Some(Box::new(stdin) as Box<dyn AsyncWrite + Unpin + Send>)),
             next_id: AtomicU64::new(1),
             pending: ParkingMutex::new(HashMap::new()),
             event_tx: event_tx.clone(),
@@ -288,36 +305,7 @@ impl AcpClient {
             stderr_tail: ParkingMutex::new(Vec::new()),
         });
 
-        // stdout reader
-        {
-            let c = Arc::clone(&client);
-            tokio::spawn(async move {
-                // Large session/update lines (available_commands) can be multi-MB.
-                let mut reader = BufReader::with_capacity(8 * 1024 * 1024, stdout);
-                let mut line = String::new();
-                loop {
-                    line.clear();
-                    match reader.read_line(&mut line).await {
-                        Ok(0) => break,
-                        Ok(_) => {
-                            let trimmed = line.trim();
-                            if trimmed.is_empty() {
-                                continue;
-                            }
-                            Arc::clone(&c).handle_line(trimmed).await;
-                        }
-                        Err(e) => {
-                            error!("acp stdout read error: {e}");
-                            break;
-                        }
-                    }
-                }
-                c.reader_alive.store(false, Ordering::SeqCst);
-                let detail = c.format_exit_detail("Agent process exited (stdout EOF)");
-                c.fail_all_pending(&detail);
-                let _ = c.event_tx.send(AcpEvent::ProcessExited { code: None });
-            });
-        }
+        client.start_read_loop(Box::new(stdout));
 
         // stderr reader (separate tee + ring buffer)
         {
@@ -343,6 +331,87 @@ impl AcpClient {
         }
 
         Ok((client, event_rx))
+    }
+
+    /// **API mode.** Connect to a remote ACP server over TCP (host:port)
+    /// instead of spawning `grok agent stdio`. The server speaks the exact
+    /// same newline-delimited JSON-RPC ACP protocol on the socket — this lets
+    /// the app drive an agent running elsewhere (a WSL/SSH/container agent, a
+    /// shared build host, or a `socat`-fronted CLI). No child process, no
+    /// stderr stream; the read half is wired to the same line reader.
+    ///
+    /// Sync (uses a blocking connect + `from_std`) to match `spawn_with_home`;
+    /// must be called from within the Tokio runtime.
+    pub fn connect_tcp(
+        addr: &str,
+        cwd: PathBuf,
+    ) -> Result<(Arc<Self>, mpsc::UnboundedReceiver<AcpEvent>), AgentError> {
+        let std_stream = std::net::TcpStream::connect(addr).map_err(|e| {
+            AgentError::new(
+                AgentErrorCode::CliNotFound,
+                format!("failed to connect ACP server {addr}: {e}"),
+            )
+        })?;
+        std_stream.set_nonblocking(true).map_err(|e| {
+            AgentError::new(AgentErrorCode::AgentCrashed, format!("socket setup: {e}"))
+        })?;
+        let stream = TcpStream::from_std(std_stream).map_err(|e| {
+            AgentError::new(AgentErrorCode::AgentCrashed, format!("socket adopt: {e}"))
+        })?;
+        let _ = stream.set_nodelay(true);
+        let (read_half, write_half) = stream.into_split();
+
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let client = Arc::new(Self {
+            child: AsyncMutex::new(None),
+            stdin: AsyncMutex::new(Some(
+                Box::new(write_half) as Box<dyn AsyncWrite + Unpin + Send>
+            )),
+            next_id: AtomicU64::new(1),
+            pending: ParkingMutex::new(HashMap::new()),
+            event_tx,
+            agent_session_id: ParkingMutex::new(None),
+            cli_path: PathBuf::from(format!("tcp://{addr}")),
+            cwd,
+            stopped: AtomicBool::new(false),
+            reader_alive: AtomicBool::new(true),
+            stderr_tail: ParkingMutex::new(Vec::new()),
+        });
+        client.start_read_loop(Box::new(read_half));
+        Ok((client, event_rx))
+    }
+
+    /// Spawn the transport read loop over any `AsyncRead` (child stdout or the
+    /// TCP read half). Each newline-delimited JSON-RPC line is dispatched to
+    /// [`handle_line`]; EOF fails pending requests and emits `ProcessExited`.
+    fn start_read_loop(self: &Arc<Self>, reader: Box<dyn AsyncRead + Unpin + Send>) {
+        let c = Arc::clone(self);
+        tokio::spawn(async move {
+            // Large session/update lines (available_commands) can be multi-MB.
+            let mut reader = BufReader::with_capacity(8 * 1024 * 1024, reader);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line).await {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        Arc::clone(&c).handle_line(trimmed).await;
+                    }
+                    Err(e) => {
+                        error!("acp read error: {e}");
+                        break;
+                    }
+                }
+            }
+            c.reader_alive.store(false, Ordering::SeqCst);
+            let detail = c.format_exit_detail("Agent stream closed (EOF)");
+            c.fail_all_pending(&detail);
+            let _ = c.event_tx.send(AcpEvent::ProcessExited { code: None });
+        });
     }
 
     fn push_stderr(&self, line: &str) {

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -140,6 +140,12 @@ pub struct AppSettings {
     /// Remember model / effort / mode / permission at global | project | session.
     #[serde(default = "default_composer_prefs_scope")]
     pub composer_prefs_scope: String,
+    /// **API mode.** When set (`host:port`), sessions connect to a remote ACP
+    /// server over TCP instead of spawning the local `grok agent stdio` — the
+    /// agent can run in WSL, a container, or on another host. Empty/unset uses
+    /// the normal local-CLI spawn path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acp_server_addr: Option<String>,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -167,6 +173,7 @@ impl Default for AppSettings {
             auth_setup_deferred: false,
             default_open_target: default_open_target(),
             composer_prefs_scope: default_composer_prefs_scope(),
+            acp_server_addr: None,
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -453,6 +453,7 @@ export default function App() {
     cliAuthPresent: boolean;
   }>({ found: false, path: null, version: null, source: "", cliAuthPresent: false });
   const [manualCliPath, setManualCliPath] = useState("");
+  const [acpServerAddr, setAcpServerAddr] = useState("");
   const [connecting, setConnecting] = useState(false);
   /** Live provider retry progress (session://retry); cleared on success/stop/error. */
   const [retryStatus, setRetryStatus] = useState<{
@@ -637,6 +638,7 @@ export default function App() {
           "finder",
       );
       setManualCliPath(settings.manualCliPath || cli.path || "");
+      setAcpServerAddr(settings.acpServerAddr || "");
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -4005,6 +4007,13 @@ export default function App() {
                 auth: prev.auth || !!cli.cliAuthPresent,
               }));
             });
+          }}
+          acpServerAddr={acpServerAddr}
+          onAcpServerAddr={(v) => {
+            setAcpServerAddr(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, acpServerAddr: v.trim() || null }),
+            );
           }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -60,6 +60,9 @@ export interface SettingsPageProps {
   manualCliPath: string;
   onManualCliPath: (v: string) => void;
   onCliBlur: (v: string) => void;
+  /** API mode: remote ACP server `host:port` (empty = local CLI spawn). */
+  acpServerAddr: string;
+  onAcpServerAddr: (v: string) => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -139,6 +142,8 @@ export function SettingsPage({
   manualCliPath,
   onManualCliPath,
   onCliBlur,
+  acpServerAddr,
+  onAcpServerAddr,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -632,6 +637,22 @@ export function SettingsPage({
                     : ` · ${t("account.cliAuthMissing")}`}
                 </div>
               )}
+            </div>
+            <div className="settings-row settings-row--stack">
+              <div className="settings-row__text">
+                <div className="settings-row__label">
+                  {t("settings.acpServer")}
+                </div>
+                <div className="settings-row__desc">
+                  {t("settings.acpServerDesc")}
+                </div>
+              </div>
+              <input
+                className="settings-input"
+                value={acpServerAddr}
+                placeholder="e.g. 127.0.0.1:8799"
+                onChange={(e) => onAcpServerAddr(e.target.value)}
+              />
             </div>
             <div className="settings-row">
               <div className="settings-row__text">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -302,6 +302,9 @@ const en = {
   "settings.cliPath": "CLI path",
   "settings.cliPathDesc": "Path to the Grok Build CLI binary",
   "settings.cliNotFound": "(not found)",
+  "settings.acpServer": "ACP server (API mode)",
+  "settings.acpServerDesc":
+    "Connect to a remote ACP agent over TCP (host:port) instead of spawning the local CLI — e.g. an agent in WSL, a container, or another host. Leave empty for local spawn.",
   "settings.permissionDeep": "Default permission",
   "settings.permissionDeepDesc":
     "Applied to new turns and remembered at the scope chosen above. YOLO auto-approves tools.",
@@ -1021,6 +1024,9 @@ const zh: Record<MessageKey, string> = {
   "settings.cliPath": "CLI 路径",
   "settings.cliPathDesc": "Grok Build CLI 可执行文件路径",
   "settings.cliNotFound": "（未找到）",
+  "settings.acpServer": "ACP 服务器（API 模式）",
+  "settings.acpServerDesc":
+    "通过 TCP（host:port）连接远程 ACP Agent，替代启动本地 CLI —— 例如运行在 WSL、容器或另一台主机上的 Agent。留空则使用本地启动。",
   "settings.permissionDeep": "默认权限",
   "settings.permissionDeepDesc":
     "对新一轮对话生效，并按上方选择的范围记忆。YOLO 会自动批准工具调用。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -443,6 +443,9 @@ export interface AppSettings {
   defaultOpenTarget?: string;
   /** global | project | session — where model/permission chips are remembered */
   composerPrefsScope?: ComposerPrefsScope | string;
+  /** API mode: `host:port` of a remote ACP server. When set, sessions connect
+   *  over TCP instead of spawning the local CLI. Empty/unset = local spawn. */
+  acpServerAddr?: string | null;
 }
 
 export interface AvailableModel {


### PR DESCRIPTION
## What

Adds an optional **API mode**: instead of only spawning a local `grok agent stdio` process, grok-app can **connect to an ACP server over TCP** (`host:port`) that speaks the identical newline-delimited JSON-RPC ACP protocol.

This lets the app drive an agent running **elsewhere** — in WSL, a container, an SSH host, or behind a `socat`-fronted CLI — with no local binary. It's opt-in and fully backward compatible: leave the field empty and nothing changes.

### Motivating case
On Windows, the CLI often runs best inside WSL. `socat TCP-LISTEN:8799,fork EXEC:'grok agent --no-leader stdio'` exposes the agent on localhost; grok-app in API mode connects to `127.0.0.1:8799` and everything (sessions, tools, permissions) works over the same ACP protocol — sidestepping cross-boundary stdio quirks.

## Changes

**Backend (`src-tauri`)**
- `acp_client.rs` — make the transport pluggable:
  - `stdin` is now `Box<dyn AsyncWrite + Unpin + Send>` (child stdin **or** the TCP write half).
  - the stdout read loop is factored into `start_read_loop` over any `AsyncRead`.
  - new `AcpClient::connect_tcp` connects a `TcpStream`, splits it, and wires the same line reader (no child, no stderr). Kept **sync** (blocking connect + `TcpStream::from_std`) to match `spawn_with_home`.
  - `spawn_with_home` dispatches to `connect_tcp` when `acpServerAddr` is set; the local-spawn path is otherwise untouched.
- `store.rs` — new `acp_server_addr: Option<String>` setting.

**Frontend**
- `AppSettings.acpServerAddr` (`api.ts`), a text field in the CLI / runtime settings section, `App.tsx` wiring, en/zh strings.

## Verification
- `cargo check`: clean (no new errors/warnings)
- `tsc --noEmit`: clean
- `vitest run`: 171/171 pass
- The TCP path mirrors a `socat`-fronted `grok agent stdio` bridge verified end-to-end (initialize + session/new + prompt).

## Notes / follow-ups
- The remote agent's `cwd` is whatever the server launches it with; when bridging to WSL, the launcher maps the project path (e.g. `/mnt/c/…`). A future enhancement could rewrite `session/new.cwd` per-platform.
- No auth is layered on the socket itself — intended for localhost / trusted networks (same trust model as the local pipe). A TLS/token option could be added later.