### PR TITLE
feat(acp): API-mode connection test + server setup helper

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -882,6 +882,80 @@ impl AcpClient {
     }
 }
 
+/// Result of an API-mode connectivity probe (see [`probe_acp_server`]).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpProbeResult {
+    /// The server accepted a TCP connection and returned a valid ACP
+    /// `initialize` result.
+    pub ok: bool,
+    pub agent_version: Option<String>,
+    pub model: Option<String>,
+    pub error: Option<String>,
+}
+
+impl AcpProbeResult {
+    fn fail(error: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            agent_version: None,
+            model: None,
+            error: Some(error.into()),
+        }
+    }
+}
+
+/// Lightweight connectivity check for **API mode**: TCP-connect to an ACP
+/// server (`host:port`), perform the `initialize` handshake, and report the
+/// agent version / current model. Creates no client and no session — just
+/// confirms the address is reachable and speaks ACP. Bounded by timeouts so
+/// a wrong address / silent port fails fast.
+pub async fn probe_acp_server(addr: &str) -> AcpProbeResult {
+    use tokio::time::{timeout, Duration};
+
+    let stream = match timeout(Duration::from_secs(5), TcpStream::connect(addr)).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => return AcpProbeResult::fail(format!("connect failed: {e}")),
+        Err(_) => return AcpProbeResult::fail("connect timed out (5s)"),
+    };
+    let _ = stream.set_nodelay(true);
+    let (rd, mut wr) = stream.into_split();
+
+    let req = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientInfo":{"name":"grok-app-probe","version":"0"},"capabilities":{}}}"#;
+    let write = async {
+        wr.write_all(req.as_bytes()).await?;
+        wr.write_all(b"\n").await?;
+        wr.flush().await
+    };
+    if let Err(e) = write.await {
+        return AcpProbeResult::fail(format!("write failed: {e}"));
+    }
+
+    let mut reader = BufReader::new(rd);
+    let mut line = String::new();
+    match timeout(Duration::from_secs(20), reader.read_line(&mut line)).await {
+        Ok(Ok(n)) if n > 0 => {
+            let v: Value = serde_json::from_str(line.trim()).unwrap_or(Value::Null);
+            let result = &v["result"];
+            if !result.is_object() {
+                return AcpProbeResult::fail("connected, but no ACP initialize result in response");
+            }
+            let meta = &result["_meta"];
+            AcpProbeResult {
+                ok: true,
+                agent_version: meta["agentVersion"].as_str().map(String::from),
+                model: meta["modelState"]["currentModelId"]
+                    .as_str()
+                    .map(String::from),
+                error: None,
+            }
+        }
+        Ok(Ok(_)) => AcpProbeResult::fail("server closed the connection (EOF) before responding"),
+        Ok(Err(e)) => AcpProbeResult::fail(format!("read failed: {e}")),
+        Err(_) => AcpProbeResult::fail("connected, but no ACP response within 20s"),
+    }
+}
+
 /// Parse compact-related sessionUpdate → (trigger, before, after, summary, note)
 fn parse_context_compact_update(
     kind: &str,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -122,6 +122,18 @@ pub async fn probe_cli(manual_path: Option<String>) -> Result<CliProbeResult, St
     Ok(cli_probe::probe_cli(manual_path.as_deref()))
 }
 
+/// API mode: test-connect to a remote ACP server and report the handshake.
+#[tauri::command]
+pub async fn acp_test_connection(
+    addr: String,
+) -> Result<crate::acp_client::AcpProbeResult, String> {
+    let addr = addr.trim();
+    if addr.is_empty() {
+        return Err("empty address".into());
+    }
+    Ok(crate::acp_client::probe_acp_server(addr).await)
+}
+
 /// Download + install latest Grok Build (multi-mirror, progress via `setup://cli-install-progress`).
 #[tauri::command]
 pub async fn cli_install_latest(app: tauri::AppHandle) -> Result<crate::cli_install::CliInstallResult, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -115,6 +115,7 @@ pub fn run() {
             commands::session_resolve_permission,
             commands::session_resolve_plan,
             commands::probe_cli,
+            commands::acp_test_connection,
             commands::cli_install_latest,
             commands::cli_install_commands,
             commands::pick_cli_binary,

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -124,6 +124,124 @@ function NavIcon({
   return <IconSettings size={size} />;
 }
 
+/**
+ * API-mode server field: address input + a "Test" button (TCP + ACP
+ * initialize handshake) and a copy-able server-side setup command. The remote
+ * agent could run anywhere (WSL, container, another host), so the app can't
+ * auto-configure it — but it can verify reachability and hand you the exact
+ * `socat` one-liner to expose a local `grok agent stdio` on the chosen port.
+ */
+function AcpServerField({
+  value,
+  onChange,
+  t,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  t: (k: string) => string;
+}) {
+  const [testing, setTesting] = useState(false);
+  const [result, setResult] = useState<api.AcpProbeResult | null>(null);
+  const [copied, setCopied] = useState(false);
+  const addr = value.trim();
+  const port = (addr.split(":")[1] || "").replace(/[^0-9]/g, "") || "8799";
+  const setupCmd = `socat TCP-LISTEN:${port},reuseaddr,fork EXEC:'grok agent --no-leader stdio'`;
+
+  const runTest = async () => {
+    if (!addr || !api.isTauri()) return;
+    setTesting(true);
+    setResult(null);
+    try {
+      setResult(await api.acpTestConnection(addr));
+    } catch (e) {
+      setResult({ ok: false, error: String(e) });
+    } finally {
+      setTesting(false);
+    }
+  };
+  const copyCmd = async () => {
+    try {
+      await navigator.clipboard.writeText(setupCmd);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable — ignore */
+    }
+  };
+  const fill = (k: string, vars: Record<string, string>) =>
+    Object.entries(vars).reduce(
+      (s, [key, val]) => s.replace(`{${key}}`, val),
+      t(k),
+    );
+
+  return (
+    <div className="settings-row settings-row--stack">
+      <div className="settings-row__text">
+        <div className="settings-row__label">{t("settings.acpServer")}</div>
+        <div className="settings-row__desc">{t("settings.acpServerDesc")}</div>
+      </div>
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <input
+          className="settings-input"
+          style={{ flex: 1 }}
+          value={value}
+          placeholder="e.g. 127.0.0.1:8799"
+          onChange={(e) => onChange(e.target.value)}
+        />
+        <button
+          type="button"
+          className="btn btn--ghost"
+          disabled={!addr || testing}
+          onClick={() => void runTest()}
+        >
+          {testing ? t("settings.acpTesting") : t("settings.acpTest")}
+        </button>
+      </div>
+      {result && (
+        <div
+          className="settings-row__hint"
+          style={{ color: result.ok ? undefined : "var(--danger, #d33)" }}
+        >
+          {result.ok
+            ? fill("settings.acpTestOk", {
+                version: result.agentVersion || "?",
+                model: result.model || "?",
+              })
+            : fill("settings.acpTestFail", { error: result.error || "unknown" })}
+        </div>
+      )}
+      {addr && (
+        <div className="settings-row__hint">
+          <div>{t("settings.acpSetupHint")}</div>
+          <code
+            style={{
+              display: "block",
+              marginTop: 4,
+              padding: "6px 8px",
+              borderRadius: 6,
+              background: "var(--surface-2, rgba(127,127,127,0.12))",
+              fontFamily: "var(--mono, monospace)",
+              fontSize: 12,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-all",
+            }}
+          >
+            {setupCmd}
+          </code>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            style={{ marginTop: 6 }}
+            onClick={() => void copyCmd()}
+          >
+            {copied ? t("settings.acpCopied") : t("settings.acpCopy")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function SettingsPage({
   section,
   onSection,
@@ -643,22 +761,11 @@ export function SettingsPage({
                 </div>
               )}
             </div>
-            <div className="settings-row settings-row--stack">
-              <div className="settings-row__text">
-                <div className="settings-row__label">
-                  {t("settings.acpServer")}
-                </div>
-                <div className="settings-row__desc">
-                  {t("settings.acpServerDesc")}
-                </div>
-              </div>
-              <input
-                className="settings-input"
-                value={acpServerAddr}
-                placeholder="e.g. 127.0.0.1:8799"
-                onChange={(e) => onAcpServerAddr(e.target.value)}
-              />
-            </div>
+            <AcpServerField
+              value={acpServerAddr}
+              onChange={onAcpServerAddr}
+              t={t}
+            />
             <div className="settings-row">
               <div className="settings-row__text">
                 <div className="settings-row__label">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -307,6 +307,14 @@ const en = {
   "settings.acpServer": "ACP server (API mode)",
   "settings.acpServerDesc":
     "Connect to a remote ACP agent over TCP (host:port) instead of spawning the local CLI — e.g. an agent in WSL, a container, or another host. Leave empty for local spawn.",
+  "settings.acpTest": "Test",
+  "settings.acpTesting": "Testing…",
+  "settings.acpTestOk": "Connected · Grok Build {version} · {model}",
+  "settings.acpTestFail": "Failed: {error}",
+  "settings.acpSetupHint":
+    "The agent must already be listening on that port. To expose a local Grok Build over TCP, run this on the server:",
+  "settings.acpCopy": "Copy command",
+  "settings.acpCopied": "Copied",
   "settings.permissionDeep": "Default permission",
   "settings.permissionDeepDesc":
     "Applied to new turns and remembered at the scope chosen above. YOLO auto-approves tools.",
@@ -1031,6 +1039,14 @@ const zh: Record<MessageKey, string> = {
   "settings.acpServer": "ACP 服务器（API 模式）",
   "settings.acpServerDesc":
     "通过 TCP（host:port）连接远程 ACP Agent，替代启动本地 CLI —— 例如运行在 WSL、容器或另一台主机上的 Agent。留空则使用本地启动。",
+  "settings.acpTest": "测试",
+  "settings.acpTesting": "测试中…",
+  "settings.acpTestOk": "已连接 · Grok Build {version} · {model}",
+  "settings.acpTestFail": "失败：{error}",
+  "settings.acpSetupHint":
+    "该端口上必须已有 Agent 在监听。要把本地 Grok Build 通过 TCP 暴露出来，在服务器端运行：",
+  "settings.acpCopy": "复制命令",
+  "settings.acpCopied": "已复制",
   "settings.permissionDeep": "默认权限",
   "settings.permissionDeepDesc":
     "对新一轮对话生效，并按上方选择的范围记忆。YOLO 会自动批准工具调用。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -288,6 +288,14 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.acpServer": "ACP 伺服器（API 模式）",
   "settings.acpServerDesc":
     "透過 TCP（host:port）連線遠端 ACP Agent，取代啟動本機 CLI —— 例如執行在 WSL、容器或另一台主機上的 Agent。留空則使用本機啟動。",
+  "settings.acpTest": "測試",
+  "settings.acpTesting": "測試中…",
+  "settings.acpTestOk": "已連線 · Grok Build {version} · {model}",
+  "settings.acpTestFail": "失敗：{error}",
+  "settings.acpSetupHint":
+    "該連接埠上必須已有 Agent 在監聽。要把本機 Grok Build 透過 TCP 暴露出來，在伺服器端執行：",
+  "settings.acpCopy": "複製指令",
+  "settings.acpCopied": "已複製",
   "settings.permissionDeep": "預設權限",
   "settings.permissionDeepDesc":
     "對新一輪對話生效，並依上方選擇的範圍記憶。YOLO 會自動核准工具呼叫。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -113,6 +113,18 @@ export async function probeCli(manualPath?: string) {
   }>("probe_cli", { manualPath: manualPath ?? null });
 }
 
+export interface AcpProbeResult {
+  ok: boolean;
+  agentVersion?: string | null;
+  model?: string | null;
+  error?: string | null;
+}
+
+/** API mode: TCP-connect to an ACP server and run the initialize handshake. */
+export async function acpTestConnection(addr: string) {
+  return invoke<AcpProbeResult>("acp_test_connection", { addr });
+}
+
 export interface CliInstallProgress {
   phase: string;
   message: string;


### PR DESCRIPTION
﻿Follow-up to API mode (#20): in-settings guidance for the server side.

Since an ACP server can run anywhere (WSL / container / remote host), the app can't auto-configure it -- but it can verify reachability and hand over the exact command to expose one.

## Changes

**Backend (src-tauri)**
- `acp_client::probe_acp_server(addr)` -- TCP-connect + ACP `initialize` handshake with bounded timeouts (5s connect, 20s response); returns { ok, agentVersion, model, error }. No client/session created.
- `acp_test_connection` Tauri command (registered in lib.rs).

**Frontend**
- The ACP-server settings field becomes a self-contained `AcpServerField`: address input + **Test** button (shows `Connected -- Grok Build vX -- model` or the failure reason) + a copy-able server-side setup one-liner (`socat TCP-LISTEN:{port},reuseaddr,fork EXEC:'grok agent --no-leader stdio'`, port from the address).
- 7 new i18n keys in en / zh / zh-TW (parity kept).

## Why not fully automatic

The remote agent's environment isn't under the app's control, so a generic one-click start isn't safe. Verify + generate-command covers the practical need. A WSL-specific auto-start could be a future opt-in.

## Verification
- cargo check: clean
- tsc --noEmit: clean
- vitest run: 172/172 pass
