### PR TITLE
feat: Settings → Extensions for Skills and MCP management

### DIFF
--- a/docs/llm-wiki/dialogs.md
+++ b/docs/llm-wiki/dialogs.md
@@ -132,6 +132,7 @@ setAppDialog({
 - `src/styles/tokens.css` — `--menu-*` / `--modal-*` / 可选 `--glass-*`  
 - `src/styles/app.css` — modal / menu / cmm 布局  
 - `src/components/ComposerModelMenu.tsx` / `ComposerProjectMenu.tsx` — composer 芯片菜单范例  
-- `src/components/StatusModal.tsx` / `McpStatusModal.tsx` — GlassModal 范例  
+- `src/components/StatusModal.tsx` / `McpStatusModal.tsx` — GlassModal 范例（MCP 弹窗可跳转 Settings → Extensions）
+- `src/components/ExtensionsPanel.tsx` — Settings → Extensions 全页技能 / MCP 管理  
 - `src/components/AutomationsPage.tsx` — 子页面自建删除确认范例  
 - `src/i18n/messages.ts` — `common.cancel` / `common.confirm` / `common.close` 等  

--- a/docs/llm-wiki/slash-composer.md
+++ b/docs/llm-wiki/slash-composer.md
@@ -41,6 +41,21 @@ Doctor is a **structured health UI**, not a raw JSON dump.
 - UI: pass/warn/fail rows, summary, copy, re-run, close.
 - Entry points: sidebar/settings/tray/slash `/doctor` all open the same modal.
 
+## Skills / MCP management (Extensions)
+
+Full management surface: **Settings → Extensions** (`#/settings/extensions`).
+
+| Surface | Role |
+|---------|------|
+| Settings → Extensions | Skills list + MCP servers (name, source/transport, path/target, vendor, compatibility); refresh; project cwd when a workbench project is active |
+| `/mcp` slash | Quick `McpStatusModal`; **Manage in Settings** opens Extensions |
+| Composer `+` / slash skills | Invocable skills only (chips); loaded via `skills_list` |
+
+Host commands: `skills_list`, `inspect_mcp` (both optional `projectPath` → `grok inspect --json` cwd).  
+CLI missing → actionable error with link to **Settings → CLI / Runtime**.  
+Reveal skill paths / agent-home when paths are available (`path_reveal`).  
+Pure helpers: `src/lib/extensionsUi.ts`. UI: `src/components/ExtensionsPanel.tsx`.
+
 ## Acceptance (Wave A)
 
 See `docs/ACCEPTANCE-slash-composer.md`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1301,6 +1301,7 @@ export default function App() {
           "appearance",
           "account",
           "archived",
+          "extensions",
           "runtime",
           "about",
         ];
@@ -4106,6 +4107,7 @@ export default function App() {
       "settings.nav.appearance",
       "settings.nav.account",
       "settings.nav.archived",
+      "settings.nav.extensions",
       "settings.nav.runtime",
       "settings.nav.about",
       "settings.archived.desc",
@@ -4448,6 +4450,7 @@ export default function App() {
               .filter((s): s is SessionRow => !!s);
             deleteSessionsConfirm(rows);
           }}
+          projectPath={activeProject?.path ?? null}
           onProviderActivated={() => {
             // Hot-reload Grok Build: drop live ACP so next send re-spawns with new GROK_HOME config.
             void (async () => {
@@ -5763,6 +5766,7 @@ export default function App() {
         error={mcpError}
         loading={mcpLoading}
         onClose={() => setShowMcpModal(false)}
+        onManage={() => navigateSettings("extensions")}
       />
       {showCompactModal && (
         <div

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -1,0 +1,347 @@
+/**
+ * Settings → Extensions: Skills + MCP servers from `grok inspect --json`.
+ * Full card layout (not a modal stub). Project cwd when available.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import * as api from "@/lib/api";
+import { createT, type Locale } from "@/i18n";
+import {
+  IconExternalLink,
+  IconFolder,
+  IconPlug,
+  IconPuzzle,
+  IconRefresh,
+  IconSkills,
+} from "@/components/icons";
+import {
+  isCliMissingError,
+  mcpMetaLine,
+  mergeInspectErrors,
+  shortPathLabel,
+  skillMetaLine,
+  skillSourceTone,
+  sortMcpByName,
+  sortSkillsByName,
+} from "@/lib/extensionsUi";
+
+export interface ExtensionsPanelProps {
+  locale: Locale;
+  /** Active workbench project path (inspect cwd). */
+  projectPath?: string | null;
+  /** Whether CLI probe found a binary (for empty-state copy). */
+  cliFound?: boolean;
+  /** Navigate to Settings → Runtime when CLI is missing. */
+  onOpenRuntime?: () => void;
+}
+
+export function ExtensionsPanel({
+  locale,
+  projectPath = null,
+  cliFound = true,
+  onOpenRuntime,
+}: ExtensionsPanelProps) {
+  const tr = useMemo(() => createT(locale), [locale]);
+  const [skills, setSkills] = useState<api.SkillDto[]>([]);
+  const [servers, setServers] = useState<api.McpDto[]>([]);
+  const [skillsError, setSkillsError] = useState<string | null>(null);
+  const [mcpError, setMcpError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [agentHome, setAgentHome] = useState<string | null>(null);
+  const [configPath, setConfigPath] = useState<string | null>(null);
+  const [pathHint, setPathHint] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!api.isTauri()) {
+      setSkills([]);
+      setServers([]);
+      setSkillsError(tr("ext.needTauri"));
+      setMcpError(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setSkillsError(null);
+    setMcpError(null);
+    setPathHint(null);
+    const cwd = projectPath?.trim() || null;
+    const [skillsRes, mcpRes, providersRes] = await Promise.all([
+      api.skillsList(cwd).catch((e) => ({
+        skills: [] as api.SkillDto[],
+        error: String(e),
+      })),
+      api.inspectMcp(cwd).catch((e) => ({
+        servers: [] as api.McpDto[],
+        error: String(e),
+      })),
+      api.providersList().catch(() => null),
+    ]);
+    setSkills(sortSkillsByName(skillsRes.skills ?? []));
+    setServers(sortMcpByName(mcpRes.servers ?? []));
+    setSkillsError(skillsRes.error?.trim() ? skillsRes.error : null);
+    setMcpError(mcpRes.error?.trim() ? mcpRes.error : null);
+    if (providersRes) {
+      setAgentHome(providersRes.agentHome?.trim() || null);
+      setConfigPath(providersRes.configPath?.trim() || null);
+    }
+    setLoading(false);
+  }, [projectPath, tr]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const bannerError = useMemo(
+    () => mergeInspectErrors(skillsError, mcpError),
+    [skillsError, mcpError],
+  );
+  const cliMissing =
+    !cliFound || isCliMissingError(skillsError) || isCliMissingError(mcpError);
+
+  const scopeLabel = projectPath?.trim()
+    ? tr("ext.scope.project")
+    : tr("ext.scope.global");
+  const scopePath = projectPath?.trim() || null;
+
+  const reveal = async (path: string | null | undefined) => {
+    const p = (path ?? "").trim();
+    if (!p || !api.isTauri()) return;
+    try {
+      await api.pathReveal(p);
+      setPathHint(null);
+    } catch (e) {
+      setPathHint(String(e));
+    }
+  };
+
+  return (
+    <div className="ext-panel" data-testid="extensions-panel">
+      <p className="settings-page__lead">{tr("ext.lead")}</p>
+
+      <div className="ext-toolbar">
+        <div className="ext-toolbar__scope">
+          <span className="ext-badge ext-badge--scope">{scopeLabel}</span>
+          {scopePath ? (
+            <button
+              type="button"
+              className="ext-path-btn"
+              title={scopePath}
+              onClick={() => void reveal(scopePath)}
+            >
+              <IconFolder size={14} />
+              <span>{shortPathLabel(scopePath, 48)}</span>
+            </button>
+          ) : (
+            <span className="ext-toolbar__hint">{tr("ext.scope.globalHint")}</span>
+          )}
+        </div>
+        <div className="ext-toolbar__actions">
+          {(agentHome || configPath) && (
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => void reveal(configPath || agentHome)}
+              title={configPath || agentHome || undefined}
+            >
+              <IconExternalLink size={14} />
+              <span>{tr("ext.openAgentHome")}</span>
+            </button>
+          )}
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={() => void refresh()}
+            disabled={loading}
+          >
+            <IconRefresh size={14} />
+            <span>{loading ? tr("ext.refreshing") : tr("ext.refresh")}</span>
+          </button>
+        </div>
+      </div>
+
+      {pathHint && (
+        <p className="ext-alert ext-alert--warn" role="status">
+          {pathHint}
+        </p>
+      )}
+
+      {bannerError && (
+        <div
+          className={
+            "ext-alert" + (cliMissing ? " ext-alert--error" : " ext-alert--warn")
+          }
+          role="alert"
+        >
+          <div className="ext-alert__title">
+            {cliMissing ? tr("ext.error.cliTitle") : tr("ext.error.title")}
+          </div>
+          <p className="ext-alert__body">
+            {cliMissing ? tr("ext.error.cliBody") : bannerError}
+          </p>
+          {cliMissing && onOpenRuntime ? (
+            <button
+              type="button"
+              className="btn btn--solid ext-alert__cta"
+              onClick={onOpenRuntime}
+            >
+              {tr("ext.error.openRuntime")}
+            </button>
+          ) : null}
+          {cliMissing && bannerError && !isCliMissingError(bannerError) ? (
+            <p className="ext-alert__detail">{bannerError}</p>
+          ) : null}
+          {cliMissing && isCliMissingError(bannerError) ? (
+            <p className="ext-alert__detail">{bannerError}</p>
+          ) : null}
+        </div>
+      )}
+
+      {/* Skills */}
+      <h2 className="settings-page__h2">
+        <IconSkills size={15} />
+        {tr("ext.skills.title")}
+        {!loading ? (
+          <span className="ext-count">{skills.length}</span>
+        ) : null}
+      </h2>
+      <div className="settings-card ext-card">
+        {loading && (
+          <p className="ext-empty">{tr("ext.skills.loading")}</p>
+        )}
+        {!loading && skills.length === 0 && (
+          <p className="ext-empty">
+            {cliMissing ? tr("ext.skills.emptyCli") : tr("ext.skills.empty")}
+          </p>
+        )}
+        {!loading && skills.length > 0 && (
+          <ul className="ext-list">
+            {skills.map((s) => {
+              const tone = skillSourceTone(s.source);
+              return (
+                <li key={`${s.source}:${s.name}:${s.path ?? ""}`} className="ext-item">
+                  <div className="ext-item__head">
+                    <strong className="ext-item__name">{s.name}</strong>
+                    <span className={`ext-badge ext-badge--${tone}`}>
+                      {normalizeSourceLabel(s.source)}
+                    </span>
+                    {s.userInvocable ? (
+                      <span className="ext-badge ext-badge--invocable">
+                        {tr("ext.skills.invocable")}
+                      </span>
+                    ) : null}
+                  </div>
+                  {s.description ? (
+                    <p className="ext-item__desc">{s.description}</p>
+                  ) : null}
+                  <div className="ext-item__meta">
+                    <span>{skillMetaLine(s)}</span>
+                    {s.path ? (
+                      <button
+                        type="button"
+                        className="ext-path-btn"
+                        title={s.path}
+                        onClick={() => void reveal(s.path)}
+                      >
+                        <IconFolder size={13} />
+                        <span>{shortPathLabel(s.path, 42)}</span>
+                      </button>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {/* MCP */}
+      <h2 className="settings-page__h2">
+        <IconPlug size={15} />
+        {tr("ext.mcp.title")}
+        {!loading ? (
+          <span className="ext-count">{servers.length}</span>
+        ) : null}
+      </h2>
+      <div className="settings-card ext-card">
+        {loading && <p className="ext-empty">{tr("ext.mcp.loading")}</p>}
+        {!loading && servers.length === 0 && (
+          <p className="ext-empty">
+            {cliMissing ? tr("ext.mcp.emptyCli") : tr("ext.mcp.empty")}
+          </p>
+        )}
+        {!loading && servers.length > 0 && (
+          <ul className="ext-list">
+            {servers.map((s) => {
+              const meta = mcpMetaLine(s);
+              return (
+                <li key={s.name} className="ext-item">
+                  <div className="ext-item__head">
+                    <strong className="ext-item__name">{s.name}</strong>
+                    {s.transport ? (
+                      <span className="ext-badge ext-badge--muted">
+                        {s.transport}
+                      </span>
+                    ) : null}
+                    {s.compatibilityStatus ? (
+                      <span className="ext-badge ext-badge--compat">
+                        {s.compatibilityStatus}
+                      </span>
+                    ) : null}
+                  </div>
+                  {meta ? <p className="ext-item__desc">{meta}</p> : null}
+                  {s.target ? (
+                    <div className="ext-item__meta">
+                      <em className="ext-item__target" title={s.target}>
+                        {shortPathLabel(s.target, 64) || s.target}
+                      </em>
+                      {looksLikePath(s.target) ? (
+                        <button
+                          type="button"
+                          className="ext-path-btn"
+                          title={s.target}
+                          onClick={() => void reveal(s.target)}
+                        >
+                          <IconFolder size={13} />
+                          <span>{tr("ext.reveal")}</span>
+                        </button>
+                      ) : null}
+                    </div>
+                  ) : null}
+                  {s.vendor ? (
+                    <div className="ext-item__meta">
+                      <span>
+                        {tr("ext.mcp.vendor")}: {s.vendor}
+                      </span>
+                    </div>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <p className="ext-footnote">
+        <IconPuzzle size={13} />
+        <span>{tr("ext.footnote")}</span>
+      </p>
+    </div>
+  );
+}
+
+function normalizeSourceLabel(source: string): string {
+  const s = (source ?? "").trim();
+  return s || "unknown";
+}
+
+function looksLikePath(target: string): boolean {
+  const t = target.trim();
+  if (!t) return false;
+  if (t.startsWith("/") || /^[A-Za-z]:[\\/]/.test(t)) return true;
+  if (t.startsWith("~")) return true;
+  // npx / command-style targets are not filesystem paths
+  if (/\s/.test(t) || t.startsWith("http://") || t.startsWith("https://")) {
+    return false;
+  }
+  return t.includes("/") || t.includes("\\");
+}

--- a/src/components/McpStatusModal.tsx
+++ b/src/components/McpStatusModal.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
 import { GlassModal } from "@/components/GlassModal";
+import { mcpMetaLine } from "@/lib/extensionsUi";
 
 export type McpServerRow = {
   name: string;
@@ -18,6 +19,7 @@ export function McpStatusModal({
   error,
   loading,
   onClose,
+  onManage,
 }: {
   open: boolean;
   locale: Locale;
@@ -25,6 +27,8 @@ export function McpStatusModal({
   error?: string | null;
   loading?: boolean;
   onClose: () => void;
+  /** Open Settings → Extensions for full Skills/MCP management. */
+  onManage?: () => void;
 }) {
   const tr = useMemo(() => createT(locale), [locale]);
 
@@ -38,9 +42,23 @@ export function McpStatusModal({
       size="md"
       className="mcp-modal"
       footer={
-        <button type="button" className="btn btn--solid" onClick={onClose}>
-          {tr("common.close")}
-        </button>
+        <div className="mcp-modal__footer">
+          {onManage ? (
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => {
+                onManage();
+                onClose();
+              }}
+            >
+              {tr("mcpModal.manage")}
+            </button>
+          ) : null}
+          <button type="button" className="btn btn--solid" onClick={onClose}>
+            {tr("common.close")}
+          </button>
+        </div>
       }
     >
       <p className="mcp-modal__hint">{tr("mcpModal.hint")}</p>
@@ -53,17 +71,16 @@ export function McpStatusModal({
       )}
       {servers.length > 0 ? (
         <ul className="mcp-modal__list">
-          {servers.map((s) => (
-            <li key={s.name} className="mcp-modal__item">
-              <strong>{s.name}</strong>
-              <span>
-                {[s.transport, s.compatibilityStatus, s.vendor]
-                  .filter(Boolean)
-                  .join(" · ")}
-              </span>
-              {s.target ? <em title={s.target}>{s.target}</em> : null}
-            </li>
-          ))}
+          {servers.map((s) => {
+            const meta = mcpMetaLine(s);
+            return (
+              <li key={s.name} className="mcp-modal__item">
+                <strong>{s.name}</strong>
+                {meta ? <span>{meta}</span> : null}
+                {s.target ? <em title={s.target}>{s.target}</em> : null}
+              </li>
+            );
+          })}
         </ul>
       ) : null}
     </GlassModal>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -22,6 +22,7 @@ import {
   IconInfo,
   IconLanguage,
   IconMinimize,
+  IconPuzzle,
   IconSearch,
   IconSettings,
   IconShield,
@@ -42,6 +43,7 @@ import type { AccountStatus, DetectedEditor } from "@/lib/api";
 import * as api from "@/lib/api";
 import { AccountPanel } from "@/components/AccountPanel";
 import { ProvidersPanel } from "@/components/ProvidersPanel";
+import { ExtensionsPanel } from "@/components/ExtensionsPanel";
 import { resolveLocale } from "@/i18n";
 
 export type SettingsSectionId =
@@ -49,6 +51,7 @@ export type SettingsSectionId =
   | "appearance"
   | "account"
   | "archived"
+  | "extensions"
   | "runtime"
   | "about";
 
@@ -127,11 +130,20 @@ export interface SettingsPageProps {
   onRestoreArchivedSessions?: (ids: string[]) => void;
   /** Delete one or more archived sessions after confirm (ids). */
   onDeleteArchivedSessions?: (ids: string[]) => void;
+  /** Active project path for Skills/MCP inspect cwd. */
+  projectPath?: string | null;
 }
 
 const NAV: {
   id: SettingsSectionId;
-  icon: "settings" | "appearance" | "user" | "archive" | "doctor" | "info";
+  icon:
+    | "settings"
+    | "appearance"
+    | "user"
+    | "archive"
+    | "extensions"
+    | "doctor"
+    | "info";
   labelKey: string;
   group: "personal" | "system";
 }[] = [
@@ -139,6 +151,12 @@ const NAV: {
   { id: "appearance", icon: "appearance", labelKey: "settings.nav.appearance", group: "personal" },
   { id: "account", icon: "user", labelKey: "settings.nav.account", group: "personal" },
   { id: "archived", icon: "archive", labelKey: "settings.nav.archived", group: "personal" },
+  {
+    id: "extensions",
+    icon: "extensions",
+    labelKey: "settings.nav.extensions",
+    group: "system",
+  },
   { id: "runtime", icon: "doctor", labelKey: "settings.nav.runtime", group: "system" },
   { id: "about", icon: "info", labelKey: "settings.nav.about", group: "system" },
 ];
@@ -153,6 +171,7 @@ function NavIcon({
   if (name === "appearance") return <IconAppearance size={size} />;
   if (name === "user") return <IconUser size={size} />;
   if (name === "archive") return <IconArchive size={size} />;
+  if (name === "extensions") return <IconPuzzle size={size} />;
   if (name === "doctor") return <IconDoctor size={size} />;
   if (name === "info") return <IconInfo size={size} />;
   return <IconSettings size={size} />;
@@ -291,6 +310,7 @@ export function SettingsPage({
   archivedGroups = [],
   onRestoreArchivedSessions,
   onDeleteArchivedSessions,
+  projectPath = null,
 }: SettingsPageProps) {
   const [query, setQuery] = useState("");
   const [accountTab, setAccountTab] = useState<"official" | "providers">(
@@ -509,9 +529,11 @@ export function SettingsPage({
           ? t("settings.nav.account")
           : section === "archived"
             ? t("settings.nav.archived")
-            : section === "runtime"
-              ? t("settings.nav.runtime")
-              : t("settings.nav.about");
+            : section === "extensions"
+              ? t("settings.nav.extensions")
+              : section === "runtime"
+                ? t("settings.nav.runtime")
+                : t("settings.nav.about");
 
   return (
     <div className="settings-page" data-testid="settings-page">
@@ -1108,6 +1130,15 @@ export function SettingsPage({
               </>
             )}
           </>
+        )}
+
+        {section === "extensions" && (
+          <ExtensionsPanel
+            locale={resolveLocale(locale)}
+            projectPath={projectPath}
+            cliFound={cliInfo.found}
+            onOpenRuntime={() => onSection("runtime")}
+          />
         )}
 
         {section === "runtime" && (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -301,6 +301,7 @@ const en = {
   "settings.nav.appearance": "Appearance",
   "settings.nav.account": "Account",
   "settings.nav.archived": "Archived chats",
+  "settings.nav.extensions": "Extensions",
   "settings.nav.runtime": "CLI / Runtime",
   "settings.nav.about": "About",
   "settings.archived.desc":
@@ -641,6 +642,36 @@ const en = {
     "Servers discovered by Grok Build (inspect). Agent session MCP injection is separate.",
   "mcpModal.loading": "Loading MCP servers…",
   "mcpModal.empty": "No MCP servers discovered",
+  "mcpModal.manage": "Manage in Settings",
+
+  // Settings → Extensions (Skills + MCP)
+  "ext.lead":
+    "Skills and MCP servers discovered via `grok inspect`. Project scope uses the active workbench folder as cwd; without a project, inspect runs globally.",
+  "ext.refresh": "Refresh",
+  "ext.refreshing": "Refreshing…",
+  "ext.scope.project": "Project",
+  "ext.scope.global": "Global",
+  "ext.scope.globalHint": "No active project — listing global / user scope",
+  "ext.openAgentHome": "Reveal agent home",
+  "ext.reveal": "Reveal",
+  "ext.needTauri": "Extensions require the Grok desktop window.",
+  "ext.error.title": "Could not inspect",
+  "ext.error.cliTitle": "Grok Build CLI not found",
+  "ext.error.cliBody":
+    "Install or set the CLI path under Settings → CLI / Runtime, then refresh this page.",
+  "ext.error.openRuntime": "Open CLI / Runtime",
+  "ext.skills.title": "Skills",
+  "ext.skills.loading": "Loading skills…",
+  "ext.skills.empty": "No skills discovered",
+  "ext.skills.emptyCli": "Skills are unavailable until the CLI is installed.",
+  "ext.skills.invocable": "Slash",
+  "ext.mcp.title": "MCP servers",
+  "ext.mcp.loading": "Loading MCP servers…",
+  "ext.mcp.empty": "No MCP servers discovered",
+  "ext.mcp.emptyCli": "MCP status is unavailable until the CLI is installed.",
+  "ext.mcp.vendor": "Vendor",
+  "ext.footnote":
+    "Session MCP injection is separate from this inspect list. Configure servers in Grok Build / agent config.",
 
   // Errors / misc
   "error.needTauri": "Folder picker requires the Tauri window",
@@ -1044,6 +1075,7 @@ const zh: Record<MessageKey, string> = {
   "settings.nav.appearance": "外观",
   "settings.nav.account": "账户",
   "settings.nav.archived": "已归档会话",
+  "settings.nav.extensions": "扩展",
   "settings.nav.runtime": "CLI / 运行时",
   "settings.nav.about": "关于",
   "settings.archived.desc":
@@ -1378,6 +1410,36 @@ const zh: Record<MessageKey, string> = {
     "由 Grok Build inspect 发现的服务器。与 Agent 会话是否注入 MCP 是分开的。",
   "mcpModal.loading": "正在加载 MCP…",
   "mcpModal.empty": "未发现 MCP 服务器",
+  "mcpModal.manage": "在设置中管理",
+
+  // Settings → Extensions (Skills + MCP)
+  "ext.lead":
+    "通过 `grok inspect` 发现的技能与 MCP 服务器。有当前项目时以该目录为 cwd；无项目时为全局范围。",
+  "ext.refresh": "刷新",
+  "ext.refreshing": "刷新中…",
+  "ext.scope.project": "项目",
+  "ext.scope.global": "全局",
+  "ext.scope.globalHint": "当前无活动项目 — 列出全局 / 用户范围",
+  "ext.openAgentHome": "打开 agent-home",
+  "ext.reveal": "在文件管理器中显示",
+  "ext.needTauri": "扩展管理需要在 Grok 桌面窗口中使用。",
+  "ext.error.title": "无法检查",
+  "ext.error.cliTitle": "未找到 Grok Build CLI",
+  "ext.error.cliBody":
+    "请先在「设置 → CLI / 运行时」安装或指定 CLI 路径，然后返回此页刷新。",
+  "ext.error.openRuntime": "打开 CLI / 运行时",
+  "ext.skills.title": "技能",
+  "ext.skills.loading": "正在加载技能…",
+  "ext.skills.empty": "未发现技能",
+  "ext.skills.emptyCli": "安装 CLI 后才能查看技能。",
+  "ext.skills.invocable": "斜杠",
+  "ext.mcp.title": "MCP 服务器",
+  "ext.mcp.loading": "正在加载 MCP…",
+  "ext.mcp.empty": "未发现 MCP 服务器",
+  "ext.mcp.emptyCli": "安装 CLI 后才能查看 MCP 状态。",
+  "ext.mcp.vendor": "供应商",
+  "ext.footnote":
+    "会话内 MCP 注入与此 inspect 列表相互独立。请在 Grok Build / agent 配置中管理服务器。",
 
   "error.needTauri": "需要在 Tauri 窗口中选择目录",
   "common.comingSoon": "即将推出",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -281,6 +281,7 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.nav.appearance": "外觀",
   "settings.nav.account": "帳戶",
   "settings.nav.archived": "已封存對話",
+  "settings.nav.extensions": "擴充功能",
   "settings.nav.runtime": "CLI / 執行環境",
   "settings.nav.about": "關於",
   "settings.archived.desc":
@@ -615,6 +616,36 @@ export const zhTW: Record<MessageKey, string> = {
     "由 Grok Build inspect 發現的伺服器。與 Agent 對話是否注入 MCP 是分開的。",
   "mcpModal.loading": "正在載入 MCP…",
   "mcpModal.empty": "未發現 MCP 伺服器",
+  "mcpModal.manage": "在設定中管理",
+
+  // Settings → Extensions (Skills + MCP)
+  "ext.lead":
+    "透過 `grok inspect` 發現的技能與 MCP 伺服器。有目前專案時以該目錄為 cwd；無專案時為全域範圍。",
+  "ext.refresh": "重新整理",
+  "ext.refreshing": "重新整理中…",
+  "ext.scope.project": "專案",
+  "ext.scope.global": "全域",
+  "ext.scope.globalHint": "目前無活動專案 — 列出全域 / 使用者範圍",
+  "ext.openAgentHome": "開啟 agent-home",
+  "ext.reveal": "在檔案總管中顯示",
+  "ext.needTauri": "擴充管理需要在 Grok 桌面視窗中使用。",
+  "ext.error.title": "無法檢查",
+  "ext.error.cliTitle": "找不到 Grok Build CLI",
+  "ext.error.cliBody":
+    "請先在「設定 → CLI / 執行環境」安裝或指定 CLI 路徑，然後返回此頁重新整理。",
+  "ext.error.openRuntime": "開啟 CLI / 執行環境",
+  "ext.skills.title": "技能",
+  "ext.skills.loading": "正在載入技能…",
+  "ext.skills.empty": "未發現技能",
+  "ext.skills.emptyCli": "安裝 CLI 後才能查看技能。",
+  "ext.skills.invocable": "斜線指令",
+  "ext.mcp.title": "MCP 伺服器",
+  "ext.mcp.loading": "正在載入 MCP…",
+  "ext.mcp.empty": "未發現 MCP 伺服器",
+  "ext.mcp.emptyCli": "安裝 CLI 後才能查看 MCP 狀態。",
+  "ext.mcp.vendor": "供應商",
+  "ext.footnote":
+    "對話內 MCP 注入與此 inspect 清單相互獨立。請在 Grok Build / agent 設定中管理伺服器。",
 
   "error.needTauri": "需要在 Tauri 視窗中選擇目錄",
   "common.comingSoon": "即將推出",

--- a/src/lib/extensionsUi.test.ts
+++ b/src/lib/extensionsUi.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  isCliMissingError,
+  mergeInspectErrors,
+  mcpMetaLine,
+  normalizeSkillSource,
+  shortPathLabel,
+  skillMetaLine,
+  skillSourceTone,
+  sortMcpByName,
+  sortSkillsByName,
+} from "./extensionsUi";
+
+describe("isCliMissingError", () => {
+  it("detects host CLI missing message", () => {
+    expect(isCliMissingError("Grok Build CLI not found")).toBe(true);
+    expect(isCliMissingError("CLI not found")).toBe(true);
+  });
+
+  it("ignores other errors and empty", () => {
+    expect(isCliMissingError(null)).toBe(false);
+    expect(isCliMissingError("")).toBe(false);
+    expect(isCliMissingError("grok inspect timed out after 12s")).toBe(false);
+    expect(isCliMissingError("Failed to parse grok inspect JSON")).toBe(false);
+  });
+});
+
+describe("normalizeSkillSource / skillSourceTone", () => {
+  it("normalizes empty source", () => {
+    expect(normalizeSkillSource("")).toBe("unknown");
+    expect(normalizeSkillSource(null)).toBe("unknown");
+    expect(normalizeSkillSource("  project  ")).toBe("project");
+  });
+
+  it("maps known tones", () => {
+    expect(skillSourceTone("user")).toBe("user");
+    expect(skillSourceTone("project")).toBe("project");
+    expect(skillSourceTone("plugin")).toBe("plugin");
+    expect(skillSourceTone("something-else")).toBe("muted");
+  });
+});
+
+describe("skillMetaLine / mcpMetaLine", () => {
+  it("builds skill meta", () => {
+    expect(
+      skillMetaLine({
+        name: "demo",
+        source: "user",
+        userInvocable: true,
+      }),
+    ).toBe("user · user-invocable");
+    expect(
+      skillMetaLine({ name: "x", source: "project", userInvocable: false }),
+    ).toBe("project");
+  });
+
+  it("builds mcp meta and skips empties", () => {
+    expect(
+      mcpMetaLine({
+        name: "s",
+        transport: "stdio",
+        compatibilityStatus: "ok",
+        vendor: "xai",
+      }),
+    ).toBe("stdio · ok · xai");
+    expect(
+      mcpMetaLine({
+        name: "s",
+        transport: "  ",
+        compatibilityStatus: null,
+        vendor: "acme",
+      }),
+    ).toBe("acme");
+  });
+});
+
+describe("sort helpers", () => {
+  it("sorts skills and mcp by name case-insensitively", () => {
+    expect(sortSkillsByName([{ name: "zeta" }, { name: "Alpha" }]).map((s) => s.name)).toEqual([
+      "Alpha",
+      "zeta",
+    ]);
+    expect(sortMcpByName([{ name: "b" }, { name: "a" }]).map((s) => s.name)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+});
+
+describe("shortPathLabel", () => {
+  it("returns short paths unchanged", () => {
+    expect(shortPathLabel("/tmp/a")).toBe("/tmp/a");
+  });
+
+  it("truncates long paths keeping basename tail", () => {
+    const long =
+      "/Users/someone/Library/Application Support/com.grokapp.grok-app/agent-home/skills/my-skill/SKILL.md";
+    const label = shortPathLabel(long, 40);
+    expect(label.startsWith("…")).toBe(true);
+    expect(label.length).toBeLessThanOrEqual(40);
+    expect(label.includes("SKILL.md") || label.includes("my-skill")).toBe(true);
+  });
+
+  it("handles empty", () => {
+    expect(shortPathLabel("")).toBe("");
+    expect(shortPathLabel(null)).toBe("");
+  });
+});
+
+describe("mergeInspectErrors", () => {
+  it("returns null when both empty", () => {
+    expect(mergeInspectErrors(null, undefined)).toBeNull();
+    expect(mergeInspectErrors("", "")).toBeNull();
+  });
+
+  it("prefers CLI missing message", () => {
+    expect(
+      mergeInspectErrors("Grok Build CLI not found", "timeout"),
+    ).toBe("Grok Build CLI not found");
+    expect(
+      mergeInspectErrors("timeout", "Grok Build CLI not found"),
+    ).toBe("Grok Build CLI not found");
+  });
+
+  it("dedupes identical messages", () => {
+    expect(mergeInspectErrors("same", "same")).toBe("same");
+  });
+
+  it("joins distinct non-cli errors", () => {
+    expect(mergeInspectErrors("a", "b")).toBe("a · b");
+  });
+});

--- a/src/lib/extensionsUi.ts
+++ b/src/lib/extensionsUi.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure helpers for Settings → Extensions (Skills / MCP management).
+ */
+
+export type SkillLike = {
+  name: string;
+  description?: string;
+  source: string;
+  path?: string | null;
+  userInvocable?: boolean;
+};
+
+export type McpLike = {
+  name: string;
+  transport?: string | null;
+  target?: string | null;
+  vendor?: string | null;
+  compatibilityStatus?: string | null;
+};
+
+/** True when inspect/skills host error indicates CLI binary missing. */
+export function isCliMissingError(error: string | null | undefined): boolean {
+  if (!error) return false;
+  const e = error.toLowerCase();
+  return (
+    e.includes("cli not found") ||
+    e.includes("grok build cli not found") ||
+    (e.includes("not found") && e.includes("cli"))
+  );
+}
+
+/** Normalize skill source for badges / meta (never empty). */
+export function normalizeSkillSource(source: string | null | undefined): string {
+  const s = (source ?? "").trim();
+  return s || "unknown";
+}
+
+/** Badge tone for skill source. */
+export function skillSourceTone(
+  source: string | null | undefined,
+): "user" | "project" | "plugin" | "muted" {
+  const s = normalizeSkillSource(source).toLowerCase();
+  if (s === "user" || s === "global") return "user";
+  if (s === "project" || s === "workspace" || s === "local") return "project";
+  if (s === "plugin" || s === "builtin" || s === "built-in") return "plugin";
+  return "muted";
+}
+
+/** Compact meta line under a skill name (source · invocable). */
+export function skillMetaLine(skill: SkillLike): string {
+  const parts: string[] = [normalizeSkillSource(skill.source)];
+  if (skill.userInvocable) parts.push("user-invocable");
+  return parts.join(" · ");
+}
+
+/** Compact meta line under an MCP server name. */
+export function mcpMetaLine(server: McpLike): string {
+  return [server.transport, server.compatibilityStatus, server.vendor]
+    .map((x) => (x ?? "").trim())
+    .filter(Boolean)
+    .join(" · ");
+}
+
+/** Sort skills alphabetically by name (stable copy). */
+export function sortSkillsByName<T extends { name: string }>(skills: T[]): T[] {
+  return [...skills].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  );
+}
+
+/** Sort MCP servers alphabetically by name (stable copy). */
+export function sortMcpByName<T extends { name: string }>(servers: T[]): T[] {
+  return [...servers].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  );
+}
+
+/** Shorten a long absolute path for secondary UI (keeps basename + parent). */
+export function shortPathLabel(
+  path: string | null | undefined,
+  max = 56,
+): string {
+  const p = (path ?? "").trim();
+  if (!p) return "";
+  if (p.length <= max) return p;
+  const sep = p.includes("\\") && !p.includes("/") ? "\\" : "/";
+  const parts = p.split(/[/\\]/).filter(Boolean);
+  if (parts.length <= 2) return `…${sep}${parts.join(sep)}`;
+  const tail = parts.slice(-2).join(sep);
+  const candidate = `…${sep}${tail}`;
+  return candidate.length <= max ? candidate : `…${sep}${parts[parts.length - 1]}`;
+}
+
+/**
+ * Merge skills + MCP host errors into one actionable banner message.
+ * Prefer CLI-missing wording when either side reports it.
+ */
+export function mergeInspectErrors(
+  skillsError: string | null | undefined,
+  mcpError: string | null | undefined,
+): string | null {
+  const a = (skillsError ?? "").trim();
+  const b = (mcpError ?? "").trim();
+  if (!a && !b) return null;
+  if (isCliMissingError(a) || isCliMissingError(b)) {
+    return a && isCliMissingError(a) ? a : b || a;
+  }
+  if (a && b && a === b) return a;
+  if (a && b) return `${a} · ${b}`;
+  return a || b || null;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9301,6 +9301,285 @@ div.composer__input:empty::before {
   white-space: nowrap;
 }
 
+.mcp-modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  width: 100%;
+}
+
+/* ── Settings → Extensions (Skills / MCP) ─────────────────────────────────── */
+.ext-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-width: 0;
+}
+
+.ext-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-card);
+}
+
+.ext-toolbar__scope {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.ext-toolbar__hint {
+  font-size: 12.5px;
+  color: var(--text-tertiary);
+}
+
+.ext-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.ext-toolbar__actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ext-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.3;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.ext-badge--scope {
+  background: color-mix(in srgb, var(--accent, #6b8cff) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent, #6b8cff) 28%, transparent);
+  color: var(--text-primary);
+}
+
+.ext-badge--user {
+  background: color-mix(in srgb, #5b9fd4 16%, transparent);
+  border-color: color-mix(in srgb, #5b9fd4 30%, transparent);
+}
+
+.ext-badge--project {
+  background: color-mix(in srgb, #6bcf8e 16%, transparent);
+  border-color: color-mix(in srgb, #6bcf8e 30%, transparent);
+}
+
+.ext-badge--plugin {
+  background: color-mix(in srgb, #c49bff 16%, transparent);
+  border-color: color-mix(in srgb, #c49bff 30%, transparent);
+}
+
+.ext-badge--invocable {
+  background: color-mix(in srgb, var(--accent, #6b8cff) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent, #6b8cff) 26%, transparent);
+}
+
+.ext-badge--compat {
+  background: color-mix(in srgb, #e0b44a 14%, transparent);
+  border-color: color-mix(in srgb, #e0b44a 28%, transparent);
+}
+
+.ext-badge--muted {
+  opacity: 0.92;
+}
+
+.ext-path-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  margin: 0;
+  padding: 2px 6px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-tertiary);
+  font: inherit;
+  font-size: 11.5px;
+  line-height: 1.3;
+  cursor: pointer;
+  min-width: 0;
+}
+
+.ext-path-btn span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ext-path-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.ext-alert {
+  margin: 0 0 14px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-card);
+}
+
+.ext-alert--error {
+  border-color: color-mix(in srgb, #e05a5a 40%, var(--border-subtle));
+  background: color-mix(in srgb, #e05a5a 10%, var(--bg-card));
+}
+
+.ext-alert--warn {
+  border-color: color-mix(in srgb, #e0b44a 40%, var(--border-subtle));
+  background: color-mix(in srgb, #e0b44a 10%, var(--bg-card));
+}
+
+.ext-alert__title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 4px;
+}
+
+.ext-alert__body {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.ext-alert__detail {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  word-break: break-word;
+}
+
+.ext-alert__cta {
+  margin-top: 10px;
+}
+
+.ext-card {
+  margin-bottom: 4px;
+}
+
+.ext-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.ext-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  min-width: 0;
+}
+
+.ext-item:last-child {
+  border-bottom: none;
+}
+
+.ext-item__head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  min-width: 0;
+}
+
+.ext-item__name {
+  font-size: 13.5px;
+  font-weight: 560;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.ext-item__desc {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.ext-item__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  min-width: 0;
+}
+
+.ext-item__target {
+  font-style: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.ext-empty {
+  margin: 0;
+  padding: 22px 16px;
+  text-align: center;
+  font-size: 13.5px;
+  color: var(--text-tertiary);
+}
+
+.ext-count {
+  margin-left: 4px;
+  padding: 0 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  background: var(--bg-hover);
+  border: 1px solid var(--border-subtle);
+}
+
+.ext-footnote {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 16px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+}
+
+.ext-footnote svg {
+  flex-shrink: 0;
+  margin-top: 1px;
+  opacity: 0.8;
+}
+
 /* Compact confirm */
 .compact-modal {
   width: min(var(--modal-width-sm, 420px), 100%);


### PR DESCRIPTION
## Summary

Adds a full **Settings → Extensions** management surface for Grok Build skills and MCP servers (beyond the thin `/mcp` modal).

### What's included
- New system nav item **Extensions** (`#/settings/extensions`)
- **Skills list**: name, description, source badge, path (reveal), `user_invocable`
- **MCP servers list**: name, transport, target, vendor, compatibility
- **Refresh** + project-scoped inspect (active workbench project path as cwd; global when none)
- Actionable **CLI missing** error with jump to **CLI / Runtime**
- Optional **Reveal agent home** when `providers_list` returns paths
- `/mcp` modal kept; adds **Manage in Settings**
- i18n **en / zh / zh-TW** for all new strings
- Unit tests for pure helpers (`src/lib/extensionsUi.ts`)
- llm-wiki notes in `slash-composer.md` + `dialogs.md`

### Host APIs (existing)
- `skills_list` / `inspect_mcp` with optional `projectPath`
- `path_reveal` for skill / config paths

## Test plan
- [x] `tsc -b` (typecheck)
- [x] `vitest run` (194 tests, including `extensionsUi.test.ts` + i18n key parity)
- [x] `cargo test` (93 tests)
- [ ] Manual: Settings → Extensions with CLI present → skills/MCP populate
- [ ] Manual: no project vs active project scope badge / cwd
- [ ] Manual: CLI missing → error CTA opens Runtime
- [ ] Manual: `/mcp` modal still works + Manage navigates to Extensions
- [ ] Manual: reveal skill path / agent home when paths exist