### PR TITLE
feat: surface ask_user_question with in-app questionnaire UI

### DIFF
--- a/docs/SPIKE-ACP.md
+++ b/docs/SPIKE-ACP.md
@@ -31,6 +31,16 @@ Optional: `authenticate { methodId: "cached_token" }` uses `~/.grok/auth.json`.
 
 Client must handle server→client RPC: `session/request_permission` (allow/deny options).
 
+### `_x.ai/ask_user_question` (Host UI)
+
+Agent reverse-request when the `ask_user_question` tool needs answers. Wire method is `_x.ai/ask_user_question` (leading `_` on the wire).
+
+- **Params (flat):** `{ sessionId, toolCallId?, questions: [{ question, options, multiSelect? }] }` — also accepts a single flat `{ question, options|choices }` form.
+- **Host:** parse → `AcpEvent::AskUserQuestion` → emit `session://ask_user` → App GlassModal.
+- **Reply (`session_resolve_ask_user`):**
+  - Accepted: `{ "outcome": "accepted", "answers": { "<question>": "<answer>" }, "partial_answers": {} }`
+  - Dismiss: `{ "outcome": "cancelled" }`
+
 ## Stop
 
 `session/cancel { sessionId }` cancels in-flight prompt; Host maps to FSM Streaming→Ready.
@@ -62,3 +72,4 @@ Client must handle server→client RPC: `session/request_permission` (allow/deny
 - Handshake + `PONG_SPIKE` / `M01_OK` stream logs.
 - Tool write: `.spike-proj/SPIKE_PERM*.txt`.
 - Host permission unit/integration: `cargo test permission` / `permission_host_test`.
+- Host ask_user parse unit tests: `cargo test ask_user_question`.

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -46,6 +46,13 @@ pub enum AcpEvent {
         rpc_id: Option<u64>,
         tool_call_id: Option<String>,
     },
+    /// Agent reverse-request `_x.ai/ask_user_question` (questionnaire / choices).
+    AskUserQuestion {
+        rpc_id: u64,
+        tool_call_id: Option<String>,
+        questions: Vec<AskUserQuestionItem>,
+        raw: Value,
+    },
     PermissionRequest {
         rpc_id: u64,
         tool_call_id: String,
@@ -569,15 +576,31 @@ impl AcpClient {
                             tool_call_id,
                         });
                     } else {
-                        // ask_user_question: cancel for now so the agent does not hang.
-                        info!("acp ask_user_question id={rpc_id} — auto-cancel (UI not implemented)");
-                        let reply = json!({
-                            "jsonrpc": "2.0",
-                            "id": rpc_id,
-                            "result": { "outcome": "cancelled" }
-                        });
-                        if let Err(e) = self.write_line(&reply).await {
-                            warn!("failed to auto-cancel ask_user_question: {e}");
+                        // ask_user_question: surface UI; reply via respond_ask_user_question.
+                        let parsed = parse_ask_user_question_params(&params);
+                        info!(
+                            "acp ask_user_question id={rpc_id} questions={} tool_call={:?}",
+                            parsed.questions.len(),
+                            parsed.tool_call_id
+                        );
+                        if parsed.questions.is_empty() {
+                            // Nothing to show — cancel so the agent does not hang.
+                            warn!("ask_user_question id={rpc_id}: empty questions, auto-cancel");
+                            let reply = json!({
+                                "jsonrpc": "2.0",
+                                "id": rpc_id,
+                                "result": { "outcome": "cancelled" }
+                            });
+                            if let Err(e) = self.write_line(&reply).await {
+                                warn!("failed to auto-cancel empty ask_user_question: {e}");
+                            }
+                        } else {
+                            let _ = self.event_tx.send(AcpEvent::AskUserQuestion {
+                                rpc_id,
+                                tool_call_id: parsed.tool_call_id,
+                                questions: parsed.questions,
+                                raw: params,
+                            });
                         }
                     }
                     return;
@@ -1451,6 +1474,42 @@ impl AcpClient {
         self.write_line(&msg).await
     }
 
+    /// Reply to `_x.ai/ask_user_question` reverse-request.
+    ///
+    /// Wire (internally-tagged `AskUserQuestionExtResponse`):
+    /// - `{ "outcome": "accepted", "answers": { "<question>": "<answer>" }, "partial_answers": {} }`
+    /// - `{ "outcome": "cancelled" }` when the user dismisses
+    pub async fn respond_ask_user_question(
+        &self,
+        rpc_id: u64,
+        outcome: AskUserOutcome,
+    ) -> Result<(), String> {
+        let result = match outcome {
+            AskUserOutcome::Accepted { answers } => {
+                json!({
+                    "outcome": "accepted",
+                    "answers": answers,
+                    "partial_answers": {},
+                })
+            }
+            AskUserOutcome::Cancelled => json!({ "outcome": "cancelled" }),
+        };
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": rpc_id,
+            "result": result,
+        });
+        info!(
+            "acp → ask_user_question reply id={rpc_id} outcome={}",
+            if matches!(result.get("outcome").and_then(|v| v.as_str()), Some("accepted")) {
+                "accepted"
+            } else {
+                "cancelled"
+            }
+        );
+        self.write_line(&msg).await
+    }
+
     pub fn agent_session_id(&self) -> Option<String> {
         self.agent_session_id.lock().clone()
     }
@@ -1467,6 +1526,316 @@ impl AcpClient {
 pub enum PermissionOutcome {
     Selected { option_id: String },
     Cancelled,
+}
+
+/// Client reply to `_x.ai/ask_user_question`.
+#[derive(Debug, Clone)]
+pub enum AskUserOutcome {
+    /// Map of question text → selected label(s) and/or free-text answer.
+    Accepted { answers: Value },
+    Cancelled,
+}
+
+/// One choice inside an ask-user question.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AskUserOption {
+    pub id: String,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// One question presented by the agent.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AskUserQuestionItem {
+    pub id: String,
+    pub question: String,
+    #[serde(default)]
+    pub options: Vec<AskUserOption>,
+    #[serde(default)]
+    pub multi_select: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedAskUserQuestion {
+    pub tool_call_id: Option<String>,
+    pub questions: Vec<AskUserQuestionItem>,
+}
+
+/// Parse flat `_x.ai/ask_user_question` params into UI-friendly questions.
+///
+/// Accepts several shapes seen on the wire / in tool schemas:
+/// - `{ questions: [{ question, options, multiSelect? }] }`
+/// - `{ question|prompt|text, options|choices }` (single question)
+/// - option entries as strings or `{ label, description, id? }`
+pub fn parse_ask_user_question_params(params: &Value) -> ParsedAskUserQuestion {
+    let tool_call_id = params
+        .get("toolCallId")
+        .or_else(|| params.get("tool_call_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let mut questions = Vec::new();
+
+    if let Some(arr) = params
+        .get("questions")
+        .and_then(|v| v.as_array())
+        .filter(|a| !a.is_empty())
+    {
+        for (i, q) in arr.iter().enumerate() {
+            if let Some(item) = parse_one_question(q, i) {
+                questions.push(item);
+            }
+        }
+    }
+
+    if questions.is_empty() {
+        // Flat single-question form.
+        if let Some(item) = parse_one_question(params, 0) {
+            // Only keep if there is real question text or options.
+            if !item.question.is_empty() || !item.options.is_empty() {
+                questions.push(item);
+            }
+        }
+    }
+
+    // Last-resort: string prompt field only.
+    if questions.is_empty() {
+        let text = params
+            .get("prompt")
+            .or_else(|| params.get("message"))
+            .or_else(|| params.get("text"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if !text.is_empty() {
+            questions.push(AskUserQuestionItem {
+                id: "0".into(),
+                question: text,
+                options: Vec::new(),
+                multi_select: false,
+            });
+        }
+    }
+
+    ParsedAskUserQuestion {
+        tool_call_id,
+        questions,
+    }
+}
+
+fn parse_one_question(q: &Value, index: usize) -> Option<AskUserQuestionItem> {
+    if q.is_null() {
+        return None;
+    }
+    // Bare string → free-text question.
+    if let Some(s) = q.as_str() {
+        let s = s.trim();
+        if s.is_empty() {
+            return None;
+        }
+        return Some(AskUserQuestionItem {
+            id: index.to_string(),
+            question: s.to_string(),
+            options: Vec::new(),
+            multi_select: false,
+        });
+    }
+
+    let obj = q.as_object()?;
+    let question = obj
+        .get("question")
+        .or_else(|| obj.get("prompt"))
+        .or_else(|| obj.get("text"))
+        .or_else(|| obj.get("header"))
+        .or_else(|| obj.get("title"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    let multi_select = obj
+        .get("multiSelect")
+        .or_else(|| obj.get("multi_select"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let id = obj
+        .get("id")
+        .or_else(|| obj.get("questionId"))
+        .or_else(|| obj.get("question_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| index.to_string());
+
+    let options_val = obj
+        .get("options")
+        .or_else(|| obj.get("choices"))
+        .cloned()
+        .unwrap_or(json!([]));
+    let options = parse_ask_user_options(&options_val);
+
+    if question.is_empty() && options.is_empty() {
+        return None;
+    }
+
+    Some(AskUserQuestionItem {
+        id,
+        question: if question.is_empty() {
+            format!("Question {}", index + 1)
+        } else {
+            question
+        },
+        options,
+        multi_select,
+    })
+}
+
+fn parse_ask_user_options(v: &Value) -> Vec<AskUserOption> {
+    let Some(arr) = v.as_array() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (i, item) in arr.iter().enumerate() {
+        if let Some(s) = item.as_str() {
+            let label = s.trim();
+            if label.is_empty() {
+                continue;
+            }
+            out.push(AskUserOption {
+                id: format!("opt-{i}"),
+                label: label.to_string(),
+                description: None,
+            });
+            continue;
+        }
+        let Some(obj) = item.as_object() else {
+            continue;
+        };
+        let label = obj
+            .get("label")
+            .or_else(|| obj.get("name"))
+            .or_else(|| obj.get("text"))
+            .or_else(|| obj.get("title"))
+            .or_else(|| obj.get("value"))
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if label.is_empty() {
+            continue;
+        }
+        let id = obj
+            .get("id")
+            .or_else(|| obj.get("optionId"))
+            .or_else(|| obj.get("option_id"))
+            .or_else(|| obj.get("value"))
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("opt-{i}"));
+        let description = obj
+            .get("description")
+            .or_else(|| obj.get("desc"))
+            .or_else(|| obj.get("detail"))
+            .and_then(|x| x.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        out.push(AskUserOption {
+            id,
+            label,
+            description,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod ask_user_question_tests {
+    use super::*;
+
+    #[test]
+    fn parse_questions_array_with_object_options() {
+        let params = json!({
+            "sessionId": "s1",
+            "toolCallId": "call-1",
+            "questions": [{
+                "question": "Which store?",
+                "multiSelect": false,
+                "options": [
+                    { "label": "SQLite", "description": "Local file" },
+                    { "label": "Postgres", "description": "Server" }
+                ]
+            }]
+        });
+        let p = parse_ask_user_question_params(&params);
+        assert_eq!(p.tool_call_id.as_deref(), Some("call-1"));
+        assert_eq!(p.questions.len(), 1);
+        assert_eq!(p.questions[0].question, "Which store?");
+        assert!(!p.questions[0].multi_select);
+        assert_eq!(p.questions[0].options.len(), 2);
+        assert_eq!(p.questions[0].options[0].label, "SQLite");
+        assert_eq!(
+            p.questions[0].options[0].description.as_deref(),
+            Some("Local file")
+        );
+    }
+
+    #[test]
+    fn parse_flat_single_question_string_options() {
+        let params = json!({
+            "question": "Ship it?",
+            "options": ["Yes", "No", "Later"]
+        });
+        let p = parse_ask_user_question_params(&params);
+        assert_eq!(p.questions.len(), 1);
+        assert_eq!(p.questions[0].question, "Ship it?");
+        assert_eq!(
+            p.questions[0]
+                .options
+                .iter()
+                .map(|o| o.label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Yes", "No", "Later"]
+        );
+    }
+
+    #[test]
+    fn parse_multi_select_and_snake_case() {
+        let params = json!({
+            "questions": [{
+                "question": "Pick targets",
+                "multi_select": true,
+                "choices": [
+                    { "name": "macOS" },
+                    { "name": "Windows" }
+                ]
+            }]
+        });
+        let p = parse_ask_user_question_params(&params);
+        assert_eq!(p.questions.len(), 1);
+        assert!(p.questions[0].multi_select);
+        assert_eq!(p.questions[0].options.len(), 2);
+        assert_eq!(p.questions[0].options[1].label, "Windows");
+    }
+
+    #[test]
+    fn parse_prompt_only_free_text() {
+        let params = json!({ "prompt": "What should the package be named?" });
+        let p = parse_ask_user_question_params(&params);
+        assert_eq!(p.questions.len(), 1);
+        assert_eq!(p.questions[0].question, "What should the package be named?");
+        assert!(p.questions[0].options.is_empty());
+    }
+
+    #[test]
+    fn parse_empty_params_yields_no_questions() {
+        let p = parse_ask_user_question_params(&json!({}));
+        assert!(p.questions.is_empty());
+        assert!(p.tool_call_id.is_none());
+    }
 }
 
 fn format_jsonrpc_error(err: &Value) -> String {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -88,6 +88,18 @@ pub async fn session_resolve_plan(
     mgr.resolve_plan(app, decision, feedback, rpc_id).await
 }
 
+/// Answer or dismiss pending `_x.ai/ask_user_question`.
+#[tauri::command]
+pub async fn session_resolve_ask_user(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    decision: String,
+    answers: Option<serde_json::Value>,
+    rpc_id: Option<u64>,
+) -> Result<SessionSnapshot, String> {
+    mgr.resolve_ask_user(app, decision, answers, rpc_id).await
+}
+
 #[tauri::command]
 pub async fn session_disconnect(
     app: tauri::AppHandle,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,7 @@ pub fn run() {
             commands::session_reattach,
             commands::session_resolve_permission,
             commands::session_resolve_plan,
+            commands::session_resolve_ask_user,
             commands::probe_cli,
             commands::cli_install_latest,
             commands::cli_install_commands,

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -9,8 +9,8 @@ use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
 use crate::acp_client::{
-    should_abort_provider_retry, AcpClient, AcpEvent, PermissionOutcome, StreamKind,
-    HOST_PROVIDER_MAX_RETRIES,
+    should_abort_provider_retry, AcpClient, AcpEvent, AskUserOutcome, PermissionOutcome,
+    StreamKind, HOST_PROVIDER_MAX_RETRIES,
 };
 use crate::cli_probe;
 use crate::error::{AgentError, AgentErrorCode};
@@ -133,6 +133,8 @@ struct LiveSession {
     needs_history_bootstrap: bool,
     /// Pending `_x.ai/exit_plan_mode` JSON-RPC id awaiting user Approve / revise.
     pending_plan_rpc_id: Option<u64>,
+    /// Pending `_x.ai/ask_user_question` JSON-RPC id awaiting user answers.
+    pending_ask_user_rpc_id: Option<u64>,
 }
 
 /// How many journal messages (user+assistant) to carry when session/load fails.
@@ -636,6 +638,7 @@ impl SessionManager {
                 provider_retry_aborted: false,
                 needs_history_bootstrap: false,
                 pending_plan_rpc_id: None,
+                pending_ask_user_rpc_id: None,
             });
         }
         Self::emit_state(&app, &self.snapshot());
@@ -1265,6 +1268,31 @@ impl SessionManager {
                         "rpcId": rpc_id,
                         "toolCallId": tool_call_id,
                         "waiting": rpc_id.is_none(),
+                    }),
+                );
+            }
+            AcpEvent::AskUserQuestion {
+                rpc_id,
+                tool_call_id,
+                questions,
+                raw: _,
+            } => {
+                let app_sid = {
+                    let mut guard = self.inner.lock();
+                    if let Some(s) = guard.as_mut() {
+                        s.pending_ask_user_rpc_id = Some(rpc_id);
+                        s.app_session_id.clone()
+                    } else {
+                        String::new()
+                    }
+                };
+                let _ = app.emit(
+                    "session://ask_user",
+                    serde_json::json!({
+                        "rpcId": rpc_id,
+                        "sessionId": app_sid,
+                        "toolCallId": tool_call_id,
+                        "questions": questions,
                     }),
                 );
             }
@@ -2039,6 +2067,42 @@ impl SessionManager {
         let id = id.ok_or_else(|| "no pending plan approval".to_string())?;
         let acp = acp.ok_or_else(|| "ACP client missing".to_string())?;
         acp.respond_exit_plan_mode(id, &decision, feedback).await?;
+        let snap = self.snapshot();
+        Self::emit_state(&app, &snap);
+        Ok(snap)
+    }
+
+    /// Resolve pending `_x.ai/ask_user_question` (answers or cancel).
+    ///
+    /// `decision`: "accepted" | "cancelled"
+    /// `answers`: object map of question text → answer string (required for accepted).
+    pub async fn resolve_ask_user(
+        &self,
+        app: AppHandle,
+        decision: String,
+        answers: Option<serde_json::Value>,
+        rpc_id: Option<u64>,
+    ) -> Result<SessionSnapshot, String> {
+        let (acp, id) = {
+            let mut guard = self.inner.lock();
+            let s = guard.as_mut().ok_or("no session")?;
+            let id = rpc_id.or(s.pending_ask_user_rpc_id.take());
+            // Clear pending id even if rpc_id was explicit.
+            if rpc_id.is_some() {
+                s.pending_ask_user_rpc_id = None;
+            }
+            (s.acp.clone(), id)
+        };
+        let id = id.ok_or_else(|| "no pending ask_user_question".to_string())?;
+        let acp = acp.ok_or_else(|| "ACP client missing".to_string())?;
+        let outcome = match decision.as_str() {
+            "accepted" | "answered" | "accept" => {
+                let answers = answers.unwrap_or_else(|| serde_json::json!({}));
+                AskUserOutcome::Accepted { answers }
+            }
+            _ => AskUserOutcome::Cancelled,
+        };
+        acp.respond_ask_user_question(id, outcome).await?;
         let snap = self.snapshot();
         Self::emit_state(&app, &snap);
         Ok(snap)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import {
   splitThoughtPhases,
   truncateBeforeLastUser,
   IDLE_SNAPSHOT,
+  type AskUserPayload,
   type ChatMessage,
   type GeneratedImagePayload,
   type PermissionPayload,
@@ -71,6 +72,7 @@ import {
   type PermissionPolicyId,
 } from "@/lib/grokCatalog";
 import { mapPermissionButtons } from "@/lib/permissionOptions";
+import { AskUserModal } from "@/components/AskUserModal";
 import { DoctorModal } from "@/components/DoctorModal";
 import {
   applyResolvedSessionMedia,
@@ -425,6 +427,7 @@ export default function App() {
   const [setupCliSeed, setSetupCliSeed] = useState<SetupCliInfo | null>(null);
   const [showDoctor, setShowDoctor] = useState(false);
   const [perm, setPerm] = useState<PermissionPayload | null>(null);
+  const [askUser, setAskUser] = useState<AskUserPayload | null>(null);
   const [plan, setPlan] = useState<PlanState & { visible: boolean }>({
     title: "Plan ready for review",
     body: "",
@@ -1137,6 +1140,21 @@ export default function App() {
           }),
         );
         await track(
+          api.listen<AskUserPayload>("session://ask_user", (p) => {
+            if (cancelled) return;
+            if (
+              p.sessionId &&
+              p.sessionId !== viewingSessionIdRef.current
+            ) {
+              return;
+            }
+            if (!p?.rpcId || !Array.isArray(p.questions) || !p.questions.length) {
+              return;
+            }
+            setAskUser(p);
+          }),
+        );
+        await track(
           api.listen<{
             entries?: unknown[];
             body?: string | null;
@@ -1538,9 +1556,10 @@ export default function App() {
       openingSessionIdRef.current = null;
     }
     setLocalError(null);
-    // Permission / retry chrome only apply to the live viewed session.
+    // Permission / retry / ask-user chrome only apply to the live viewed session.
     if (live.sessionId !== s.id) {
       setPerm(null);
+      setAskUser(null);
       setRetryStatus(null);
     }
 
@@ -1680,6 +1699,7 @@ export default function App() {
       visible: false,
     });
     setPerm(null);
+    setAskUser(null);
     setRetryStatus(null);
     setSession({
       ...IDLE_SNAPSHOT,
@@ -1818,6 +1838,7 @@ export default function App() {
         setMessages([]);
         setAttachments([]);
         setPerm(null);
+        setAskUser(null);
         setRetryStatus(null);
         setLocalError(null);
         setDraft("");
@@ -5742,6 +5763,43 @@ export default function App() {
         open={showDoctor}
         onClose={() => setShowDoctor(false)}
         locale={locale}
+      />
+      <AskUserModal
+        payload={askUser}
+        labels={{
+          title: tr("askUser.title"),
+          submit: tr("askUser.submit"),
+          cancel: tr("askUser.cancel"),
+          otherPlaceholder: tr("askUser.otherPlaceholder"),
+          freeTextHint: tr("askUser.freeTextHint"),
+          multiHint: tr("askUser.multiHint"),
+          close: tr("common.close"),
+        }}
+        onSubmit={async (answers) => {
+          if (!askUser) return;
+          try {
+            await api.sessionResolveAskUser({
+              decision: "accepted",
+              answers,
+              rpcId: askUser.rpcId,
+            });
+            setAskUser(null);
+          } catch (e) {
+            showToast(String(e), 4500);
+          }
+        }}
+        onCancel={async () => {
+          if (!askUser) return;
+          try {
+            await api.sessionResolveAskUser({
+              decision: "cancelled",
+              rpcId: askUser.rpcId,
+            });
+          } catch {
+            /* still hide UI */
+          }
+          setAskUser(null);
+        }}
       />
       <StatusModal
         open={showStatusModal}

--- a/src/components/AskUserModal.tsx
+++ b/src/components/AskUserModal.tsx
@@ -1,0 +1,229 @@
+/**
+ * Agent questionnaire for `_x.ai/ask_user_question`.
+ * GlassModal shell — no window.confirm / prompt / alert.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { GlassModal } from "@/components/GlassModal";
+import type { AskUserPayload, AskUserQuestionItem } from "@/lib/session";
+
+export type AskUserLabels = {
+  title: string;
+  submit: string;
+  cancel: string;
+  otherPlaceholder: string;
+  freeTextHint: string;
+  multiHint: string;
+  close: string;
+};
+
+type Props = {
+  payload: AskUserPayload | null;
+  labels: AskUserLabels;
+  onSubmit: (answers: Record<string, string>) => void | Promise<void>;
+  onCancel: () => void | Promise<void>;
+};
+
+function questionKey(q: AskUserQuestionItem, index: number): string {
+  return q.question?.trim() || q.id || String(index);
+}
+
+export function AskUserModal({ payload, labels, onSubmit, onCancel }: Props) {
+  const questions = payload?.questions ?? [];
+  const open = Boolean(payload && questions.length > 0);
+
+  // Per-question selected option ids (multi = set of ids).
+  const [selected, setSelected] = useState<Record<string, string[]>>({});
+  // Per-question free-text override / free-text-only answer.
+  const [freeText, setFreeText] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+
+  // Reset when a new questionnaire arrives.
+  useEffect(() => {
+    if (!payload) {
+      setSelected({});
+      setFreeText({});
+      setBusy(false);
+      return;
+    }
+    setSelected({});
+    setFreeText({});
+    setBusy(false);
+  }, [payload?.rpcId]);
+
+  const canSubmit = useMemo(() => {
+    if (!questions.length) return false;
+    return questions.every((q, i) => {
+      const key = questionKey(q, i);
+      const text = (freeText[key] || "").trim();
+      if (text) return true;
+      const sel = selected[key] || [];
+      return sel.length > 0;
+    });
+  }, [questions, selected, freeText]);
+
+  const toggleOption = (q: AskUserQuestionItem, index: number, optionId: string) => {
+    const key = questionKey(q, index);
+    setSelected((prev) => {
+      const cur = prev[key] || [];
+      if (q.multiSelect) {
+        const has = cur.includes(optionId);
+        return {
+          ...prev,
+          [key]: has ? cur.filter((id) => id !== optionId) : [...cur, optionId],
+        };
+      }
+      return { ...prev, [key]: [optionId] };
+    });
+    // Choosing an option clears free-text for that question.
+    setFreeText((prev) => {
+      if (!prev[key]) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const buildAnswers = (): Record<string, string> => {
+    const answers: Record<string, string> = {};
+    questions.forEach((q, i) => {
+      const key = questionKey(q, i);
+      const text = (freeText[key] || "").trim();
+      if (text) {
+        answers[key] = text;
+        return;
+      }
+      const sel = selected[key] || [];
+      if (!sel.length) return;
+      const labelsFor = sel.map((id) => {
+        const opt = q.options.find((o) => o.id === id);
+        return opt?.label || id;
+      });
+      answers[key] = labelsFor.join(", ");
+    });
+    return answers;
+  };
+
+  const submit = async (answers: Record<string, string>) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onSubmit(answers);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const cancel = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onCancel();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Single-select, single question, option click → immediate answer.
+  const quickPick =
+    questions.length === 1 &&
+    !questions[0]?.multiSelect &&
+    (questions[0]?.options?.length ?? 0) > 0;
+
+  return (
+    <GlassModal
+      open={open}
+      onClose={() => void cancel()}
+      title={labels.title}
+      size="md"
+      closeLabel={labels.close}
+      closeOnOverlay={false}
+      wrapBody
+      footer={
+        <>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            disabled={busy}
+            onClick={() => void cancel()}
+          >
+            {labels.cancel}
+          </button>
+          <button
+            type="button"
+            className="btn btn--solid"
+            disabled={busy || !canSubmit}
+            onClick={() => void submit(buildAnswers())}
+          >
+            {labels.submit}
+          </button>
+        </>
+      }
+    >
+      <div className="ask-user">
+        {questions.map((q, qi) => {
+          const key = questionKey(q, qi);
+          const sel = selected[key] || [];
+          const text = freeText[key] || "";
+          return (
+            <div key={q.id || key} className="ask-user__q">
+              <div className="ask-user__prompt">{q.question}</div>
+              {q.multiSelect ? (
+                <div className="ask-user__hint">{labels.multiHint}</div>
+              ) : null}
+              {q.options?.length ? (
+                <div className="ask-user__options" role="group">
+                  {q.options.map((opt) => {
+                    const active = sel.includes(opt.id);
+                    return (
+                      <button
+                        key={opt.id}
+                        type="button"
+                        className={
+                          "ask-user__opt" + (active ? " ask-user__opt--active" : "")
+                        }
+                        disabled={busy}
+                        onClick={() => {
+                          if (quickPick) {
+                            void submit({ [key]: opt.label });
+                            return;
+                          }
+                          toggleOption(q, qi, opt.id);
+                        }}
+                      >
+                        <span className="ask-user__opt-label">{opt.label}</span>
+                        {opt.description ? (
+                          <span className="ask-user__opt-desc">{opt.description}</span>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : null}
+              <label className="ask-user__free">
+                <span className="ask-user__free-hint">
+                  {q.options?.length ? labels.freeTextHint : labels.otherPlaceholder}
+                </span>
+                <textarea
+                  className="ask-user__textarea"
+                  rows={2}
+                  value={text}
+                  disabled={busy}
+                  placeholder={labels.otherPlaceholder}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setFreeText((prev) => ({ ...prev, [key]: v }));
+                    if (v.trim() && !q.multiSelect) {
+                      // Free text replaces single selection.
+                      setSelected((prev) => ({ ...prev, [key]: [] }));
+                    }
+                  }}
+                />
+              </label>
+            </div>
+          );
+        })}
+      </div>
+    </GlassModal>
+  );
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -652,6 +652,14 @@ const en = {
   "perm.allowSession": "Allow for session",
   "perm.deny": "Deny",
 
+  // Agent ask_user_question
+  "askUser.title": "Agent question",
+  "askUser.submit": "Submit",
+  "askUser.cancel": "Dismiss",
+  "askUser.otherPlaceholder": "Type your answer…",
+  "askUser.freeTextHint": "Or type a custom answer",
+  "askUser.multiHint": "Select one or more options",
+
   "message.copy": "Copy",
   "message.copied": "Copied",
   "message.edit": "Edit",
@@ -1387,6 +1395,13 @@ const zh: Record<MessageKey, string> = {
   "perm.allowOnce": "允许一次",
   "perm.allowSession": "会话内允许",
   "perm.deny": "拒绝",
+
+  "askUser.title": "Agent 提问",
+  "askUser.submit": "提交",
+  "askUser.cancel": "忽略",
+  "askUser.otherPlaceholder": "输入你的回答…",
+  "askUser.freeTextHint": "或输入自定义回答",
+  "askUser.multiHint": "可多选",
 
   "message.copy": "复制",
   "message.copied": "已复制",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -625,6 +625,13 @@ export const zhTW: Record<MessageKey, string> = {
   "perm.allowSession": "對話內允許",
   "perm.deny": "拒絕",
 
+  "askUser.title": "Agent 提問",
+  "askUser.submit": "提交",
+  "askUser.cancel": "略過",
+  "askUser.otherPlaceholder": "輸入你的回答…",
+  "askUser.freeTextHint": "或輸入自訂回答",
+  "askUser.multiHint": "可多選",
+
   "message.copy": "複製",
   "message.copied": "已複製",
   "message.edit": "編輯",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -102,6 +102,19 @@ export async function sessionResolvePlan(args: {
   });
 }
 
+/** Answer or dismiss pending `_x.ai/ask_user_question`. */
+export async function sessionResolveAskUser(args: {
+  decision: "accepted" | "cancelled" | string;
+  answers?: Record<string, string> | null;
+  rpcId?: number | null;
+}): Promise<SessionSnapshot> {
+  return invoke("session_resolve_ask_user", {
+    decision: args.decision,
+    answers: args.answers ?? null,
+    rpcId: args.rpcId ?? null,
+  });
+}
+
 export async function probeCli(manualPath?: string) {
   return invoke<{
     found: boolean;

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -615,6 +615,27 @@ export interface PermissionPayload {
   options: unknown;
 }
 
+export interface AskUserOption {
+  id: string;
+  label: string;
+  description?: string | null;
+}
+
+export interface AskUserQuestionItem {
+  id: string;
+  question: string;
+  options: AskUserOption[];
+  multiSelect?: boolean;
+}
+
+/** Payload for `session://ask_user` (`_x.ai/ask_user_question`). */
+export interface AskUserPayload {
+  rpcId: number;
+  sessionId: string;
+  toolCallId?: string | null;
+  questions: AskUserQuestionItem[];
+}
+
 export const IDLE_SNAPSHOT: SessionSnapshot = {
   sessionId: null,
   agentSessionId: null,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4484,6 +4484,110 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   color: var(--text-primary);
 }
 
+/* Agent ask_user_question questionnaire (GlassModal body) */
+.ask-user {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ask-user__q {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ask-user__prompt {
+  font-size: 13.5px;
+  font-weight: 550;
+  line-height: 1.45;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ask-user__hint {
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+}
+
+.ask-user__options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ask-user__opt {
+  appearance: none;
+  text-align: left;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-input, var(--bg-hover));
+  color: var(--text-primary);
+  border-radius: 10px;
+  padding: 9px 11px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.ask-user__opt:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+
+.ask-user__opt--active {
+  border-color: var(--text-primary);
+  background: color-mix(in srgb, var(--text-primary) 8%, var(--bg-input, var(--bg-hover)));
+}
+
+.ask-user__opt-label {
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 1.3;
+}
+
+.ask-user__opt-desc {
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  line-height: 1.35;
+}
+
+.ask-user__free {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ask-user__free-hint {
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+}
+
+.ask-user__textarea {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 2.6em;
+  max-height: 8em;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 8px 10px;
+}
+
+.ask-user__textarea:focus {
+  outline: none;
+  border-color: var(--border-strong);
+}
+
 /* In-thread turn failure (retries exhausted / provider error) */
 .chat-turn-error {
   width: 100%;


### PR DESCRIPTION
## Problem

When Grok Build calls `_x.ai/ask_user_question`, the app always replied with `{ outcome: "cancelled" }`. Agents that need a real choice or free-text answer never got a usable host UI, so plan-mode clarification and similar flows failed open as cancel.

## Changes

- Parse flat ask-user params (questions array, single question + options/choices, multi-select, free-text-only) in `acp_client` and emit `AcpEvent::AskUserQuestion`
- Session manager stores the pending RPC id and emits `session://ask_user`
- New `session_resolve_ask_user` command replies with:
  - accepted: `{ outcome: "accepted", answers: { "<question>": "<answer>" }, partial_answers: {} }`
  - dismiss: `{ outcome: "cancelled" }`
- Frontend `AskUserModal` (GlassModal, no `window.confirm`/`prompt`/`alert`) with option buttons, multi-select, and free-text
- i18n keys for en / zh / zh-TW
- SPIKE-ACP note + unit tests for param parsing
- Empty questionnaire still auto-cancels so the agent cannot hang

## How tested

- `cargo test ask_user_question --lib` (5 parse tests)
- `cargo test --lib` (98 passed)
- `tsc -b` clean
- `vitest run` (180 passed)