### PR TITLE
test(acp): golden fixtures for mock host wire paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           workspaces: "./src-tauri -> target"
           shared-key: ci-${{ matrix.name }}
+      # Includes ACP golden fixtures (tests/fixtures/acp + acp_golden_test).
+      # Required green for any ACP / mock_acp / permission wire change (T06).
       - name: cargo test
         working-directory: src-tauri
         run: cargo test

--- a/docs/SPIKE-ACP.md
+++ b/docs/SPIKE-ACP.md
@@ -73,3 +73,33 @@ Agent reverse-request when the `ask_user_question` tool needs answers. Wire meth
 - Tool write: `.spike-proj/SPIKE_PERM*.txt`.
 - Host permission unit/integration: `cargo test permission` / `permission_host_test`.
 - Host ask_user parse unit tests: `cargo test ask_user_question`.
+
+## Golden fixtures (T06 · required for ACP changes)
+
+Protocol regression samples live under:
+
+```text
+src-tauri/tests/fixtures/acp/
+```
+
+| Fixture | Asserts |
+|---------|---------|
+| `handshake_initialize.json` | Host `initialize` params (`wire_initialize_params`) |
+| `stream_chunks.json` | `session/update` thought + assistant → `decode_session_update` |
+| `stop_cancel.json` | `session/cancel` params + mock mid-stream stop done chunk |
+| `permission_request.json` | `decode_permission_request` + `pick_option_id` + reply envelopes |
+| `ask_user_question.json` | `parse_ask_user_question_params` + Host replies |
+| `exit_plan_mode.json` | plan update decode + `wire_exit_plan_mode_result` |
+| `mock_stream.json` | `mock_acp` deterministic chunks for prompt `hi` |
+
+**CI:** `.github/workflows/ci.yml` `cargo test` runs the suite on every PR (macOS / Windows / Linux). Any ACP wire or mock change **must** keep `cargo test --lib acp_golden` green.
+
+**Regenerate** when the protocol or mock reply drifts — see  
+[`src-tauri/tests/fixtures/acp/README.md`](../src-tauri/tests/fixtures/acp/README.md):
+
+```bash
+cd src-tauri
+cargo test --lib acp_golden
+# mock chunks only:
+cargo test --lib acp_golden::print_mock_stream_chunks -- --ignored --nocapture
+```

--- a/docs/TODOS.md
+++ b/docs/TODOS.md
@@ -11,7 +11,7 @@
 | T03 | Host FSM + 事件契约一页纸 | 防双 SoT | S | P0 |
 | T04 | 错误文案 Deck zh/en | 可行动诊断 | S | P0 |
 | T05 | Permission scope_key 单测 | 默认安全可证明 | S | P0 |
-| T06 | ACP stub CI + golden fixtures | 协议回归 | M | P0 |
+| T06 | ACP stub CI + golden fixtures | 协议回归 | M | P0 ✅ (`tests/fixtures/acp` + `acp_golden_test`) |
 | T07 | redact 单测门禁 | 密钥泄漏 | S | P0 |
 | T08 | README 暖路径 + Gatekeeper/SmartScreen | 首跑 | S | P0 |
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "grok-app"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -514,33 +514,9 @@ impl AcpClient {
             if method == "session/request_permission" {
                 let rpc_id = req_id.unwrap_or(0);
                 let params = msg.get("params").cloned().unwrap_or(Value::Null);
-                let tool_call = params.get("toolCall").cloned().unwrap_or(Value::Null);
-                let tool_call_id = tool_call
-                    .get("toolCallId")
-                    .or_else(|| tool_call.get("tool_call_id"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let title = tool_call
-                    .get("title")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("Tool permission")
-                    .to_string();
-                let tool_name = tool_call
-                    .get("kind")
-                    .or_else(|| tool_call.get("name"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("tool")
-                    .to_string();
-                let options = params.get("options").cloned().unwrap_or(json!([]));
-                let _ = self.event_tx.send(AcpEvent::PermissionRequest {
-                    rpc_id,
-                    tool_call_id,
-                    tool_name,
-                    title,
-                    options,
-                    raw: params,
-                });
+                let _ = self
+                    .event_tx
+                    .send(decode_permission_request(rpc_id, &params));
                 return;
             }
 
@@ -681,213 +657,41 @@ impl AcpClient {
     }
 
     fn handle_session_update(&self, params: &Value) {
-        let update = params.get("update").unwrap_or(params);
-        let kind = update
-            .get("sessionUpdate")
-            .or_else(|| update.get("session_update"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-
-        match kind {
-            "agent_message_chunk" => {
-                let text = update
-                    .pointer("/content/text")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let message_id = update
-                    .get("messageId")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
-                let _ = self.event_tx.send(AcpEvent::Stream {
-                    kind: StreamKind::Assistant,
-                    text,
-                    message_id,
-                    done: false,
-                });
-            }
-            // Grok/Gemini emit agent_thought_chunk; some paths also use "thought".
-            "agent_thought_chunk" | "thought" => {
-                let text = update
-                    .pointer("/content/text")
-                    .and_then(|v| v.as_str())
-                    .or_else(|| update.get("text").and_then(|v| v.as_str()))
-                    .unwrap_or("")
-                    .to_string();
-                // Prefer explicit messageId (minos-style); host fills from turn if missing.
-                let message_id = update
-                    .get("messageId")
-                    .or_else(|| update.get("message_id"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
-                if text.is_empty() {
-                    return;
-                }
-                let _ = self.event_tx.send(AcpEvent::Stream {
-                    kind: StreamKind::Thought,
-                    text,
-                    message_id,
-                    done: false,
-                });
-            }
-            "plan" => {
-                let entries = update.get("entries").cloned().unwrap_or(json!([]));
-                let body = update
-                    .get("planContent")
-                    .or_else(|| update.get("plan_content"))
-                    .or_else(|| update.get("content"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
-                let _ = self.event_tx.send(AcpEvent::Plan {
-                    entries,
-                    body,
-                    rpc_id: None,
-                    tool_call_id: None,
-                });
-            }
-            "tool_call" | "tool_call_update" => {
-                let tool_call_id = update
-                    .get("toolCallId")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let title = update
-                    .get("title")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let k = update
-                    .get("kind")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let status = update
-                    .get("status")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                // compact_conversation / similar tools
-                let title_l = title.to_ascii_lowercase();
-                let kind_l = k.to_ascii_lowercase();
-                if status == "completed"
-                    && (title_l.contains("compact")
-                        || kind_l.contains("compact")
-                        || tool_call_id.to_ascii_lowercase().contains("compact"))
-                {
-                    let _ = self.event_tx.send(AcpEvent::ContextCompact {
-                        trigger: "manual".into(),
-                        tokens_before: None,
-                        tokens_after: None,
-                        summary_preview: None,
-                        note: Some(title.clone()),
-                    });
-                }
-                let _ = self.event_tx.send(AcpEvent::ToolCall {
-                    tool_call_id,
-                    title,
-                    kind: k,
-                    status,
-                    raw: update.clone(),
-                });
-            }
-            "retry_state" => {
-                let attempt = update
-                    .get("attempt")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0) as u32;
-                let max_retries = update
-                    .get("max_retries")
-                    .or_else(|| update.get("maxRetries"))
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(HOST_PROVIDER_MAX_RETRIES as u64)
-                    as u32;
-                let reason = update
-                    .get("reason")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let status = update
-                    .get("type")
-                    .or_else(|| update.get("status"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("retrying")
-                    .to_string();
+        let events = decode_session_update(params);
+        if events.is_empty() {
+            let update = params.get("update").unwrap_or(params);
+            let kind = update
+                .get("sessionUpdate")
+                .or_else(|| update.get("session_update"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            debug!("acp session/update ignored kind={kind}");
+        }
+        for ev in events {
+            if let AcpEvent::RetryState {
+                attempt,
+                max_retries,
+                reason,
+                status,
+            } = &ev
+            {
                 info!(
                     "acp retry_state attempt={attempt}/{max_retries} status={status} reason={}",
                     reason.chars().take(160).collect::<String>()
                 );
-                let _ = self.event_tx.send(AcpEvent::RetryState {
-                    attempt,
-                    max_retries,
-                    reason,
-                    status,
-                });
             }
-            // Grok auto/manual context compaction
-            "tokens_used"
-            | "compaction"
-            | "compaction_completed"
-            | "context_compact"
-            | "auto_compact"
-            | "compaction_checkpoint" => {
-                if let Some((trigger, before, after, summary, note)) =
-                    parse_context_compact_update(kind, update)
-                {
-                    info!(
-                        "acp context compact trigger={trigger} before={before:?} after={after:?}"
-                    );
-                    let _ = self.event_tx.send(AcpEvent::ContextCompact {
-                        trigger,
-                        tokens_before: before,
-                        tokens_after: after,
-                        summary_preview: summary,
-                        note,
-                    });
-                }
+            if let AcpEvent::ContextCompact {
+                trigger,
+                tokens_before,
+                tokens_after,
+                ..
+            } = &ev
+            {
+                info!(
+                    "acp context compact trigger={trigger} before={tokens_before:?} after={tokens_after:?}"
+                );
             }
-            _ => {
-                if update.get("tokens_before").is_some()
-                    || update.get("tokensBefore").is_some()
-                    || update.get("tokens_after").is_some()
-                    || update.get("tokensAfter").is_some()
-                {
-                    if let Some((trigger, before, after, summary, note)) =
-                        parse_context_compact_update(kind, update)
-                    {
-                        let _ = self.event_tx.send(AcpEvent::ContextCompact {
-                            trigger,
-                            tokens_before: before,
-                            tokens_after: after,
-                            summary_preview: summary,
-                            note,
-                        });
-                        return;
-                    }
-                }
-                let title = update
-                    .get("title")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_ascii_lowercase();
-                if title.contains("compact") {
-                    let _ = self.event_tx.send(AcpEvent::ContextCompact {
-                        trigger: if title.contains("auto") {
-                            "auto".into()
-                        } else {
-                            "manual".into()
-                        },
-                        tokens_before: None,
-                        tokens_after: None,
-                        summary_preview: None,
-                        note: update
-                            .get("title")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string()),
-                    });
-                    return;
-                }
-                debug!("acp session/update ignored kind={kind}");
-            }
+            let _ = self.event_tx.send(ev);
         }
     }
 
@@ -1076,11 +880,7 @@ impl AcpClient {
         let init = self
             .request_timeout(
                 "initialize",
-                json!({
-                    "protocolVersion": 1,
-                    "clientInfo": { "name": "grok-app", "version": "0.1.0" },
-                    "capabilities": {}
-                }),
+                wire_initialize_params(),
                 HANDSHAKE_TIMEOUT_SECS,
             )
             .await
@@ -1319,11 +1119,7 @@ impl AcpClient {
         self.stopped.store(false, Ordering::SeqCst);
 
         // Fire and wait for completion in background via request future
-        let text = text.to_string();
-        let this_params = json!({
-            "sessionId": sid,
-            "prompt": [{ "type": "text", "text": text }]
-        });
+        let this_params = wire_session_prompt_params(&sid, text);
 
         let result = self
             .request_timeout("session/prompt", this_params, PROMPT_TIMEOUT_SECS)
@@ -1356,7 +1152,7 @@ impl AcpClient {
             .clone()
             .ok_or_else(|| "no session".to_string())?;
         self.stopped.store(true, Ordering::SeqCst);
-        self.notify("session/cancel", json!({ "sessionId": sid }))
+        self.notify("session/cancel", wire_session_cancel_params(&sid))
             .await
     }
 
@@ -1423,22 +1219,7 @@ impl AcpClient {
         rpc_id: u64,
         outcome: PermissionOutcome,
     ) -> Result<(), String> {
-        let result = match outcome {
-            PermissionOutcome::Selected { option_id } => json!({
-                "outcome": {
-                    "outcome": "selected",
-                    "optionId": option_id
-                }
-            }),
-            PermissionOutcome::Cancelled => json!({
-                "outcome": { "outcome": "cancelled" }
-            }),
-        };
-        let msg = json!({
-            "jsonrpc": "2.0",
-            "id": rpc_id,
-            "result": result,
-        });
+        let msg = wire_jsonrpc_result(rpc_id, wire_permission_result(&outcome));
         self.write_line(&msg).await
     }
 
@@ -1450,27 +1231,14 @@ impl AcpClient {
         outcome: &str,
         feedback: Option<String>,
     ) -> Result<(), String> {
-        let outcome = match outcome {
-            "approved" | "cancelled" | "abandoned" => outcome,
-            "approve" | "yes" | "accept" => "approved",
-            "abandon" | "quit" => "abandoned",
-            _ => "cancelled",
-        };
-        let mut result = json!({ "outcome": outcome });
-        if outcome == "cancelled" {
-            if let Some(fb) = feedback.filter(|s| !s.trim().is_empty()) {
-                result
-                    .as_object_mut()
-                    .unwrap()
-                    .insert("feedback".into(), Value::String(fb));
-            }
-        }
-        let msg = json!({
-            "jsonrpc": "2.0",
-            "id": rpc_id,
-            "result": result,
-        });
-        info!("acp → exit_plan_mode reply id={rpc_id} outcome={outcome}");
+        let result = wire_exit_plan_mode_result(outcome, feedback);
+        let outcome_s = result
+            .get("outcome")
+            .and_then(|v| v.as_str())
+            .unwrap_or("cancelled")
+            .to_string();
+        let msg = wire_jsonrpc_result(rpc_id, result);
+        info!("acp → exit_plan_mode reply id={rpc_id} outcome={outcome_s}");
         self.write_line(&msg).await
     }
 
@@ -1484,21 +1252,8 @@ impl AcpClient {
         rpc_id: u64,
         outcome: AskUserOutcome,
     ) -> Result<(), String> {
-        let result = match outcome {
-            AskUserOutcome::Accepted { answers } => {
-                json!({
-                    "outcome": "accepted",
-                    "answers": answers,
-                    "partial_answers": {},
-                })
-            }
-            AskUserOutcome::Cancelled => json!({ "outcome": "cancelled" }),
-        };
-        let msg = json!({
-            "jsonrpc": "2.0",
-            "id": rpc_id,
-            "result": result,
-        });
+        let result = wire_ask_user_result(&outcome);
+        let msg = wire_jsonrpc_result(rpc_id, result.clone());
         info!(
             "acp → ask_user_question reply id={rpc_id} outcome={}",
             if matches!(result.get("outcome").and_then(|v| v.as_str()), Some("accepted")) {
@@ -1534,6 +1289,318 @@ pub enum AskUserOutcome {
     /// Map of question text → selected label(s) and/or free-text answer.
     Accepted { answers: Value },
     Cancelled,
+}
+
+// ── Wire builders / pure decoders (locked by tests/fixtures/acp/) ────────────
+
+/// Host → agent `initialize` params. Golden: `handshake_initialize.json`.
+pub fn wire_initialize_params() -> Value {
+    json!({
+        "protocolVersion": 1,
+        "clientInfo": { "name": "grok-app", "version": "0.1.0" },
+        "capabilities": {}
+    })
+}
+
+/// Host → agent `session/prompt` params.
+pub fn wire_session_prompt_params(session_id: &str, text: &str) -> Value {
+    json!({
+        "sessionId": session_id,
+        "prompt": [{ "type": "text", "text": text }]
+    })
+}
+
+/// Host → agent `session/cancel` notification params.
+pub fn wire_session_cancel_params(session_id: &str) -> Value {
+    json!({ "sessionId": session_id })
+}
+
+/// Permission RPC result body (inside JSON-RPC `result`).
+pub fn wire_permission_result(outcome: &PermissionOutcome) -> Value {
+    match outcome {
+        PermissionOutcome::Selected { option_id } => json!({
+            "outcome": {
+                "outcome": "selected",
+                "optionId": option_id
+            }
+        }),
+        PermissionOutcome::Cancelled => json!({
+            "outcome": { "outcome": "cancelled" }
+        }),
+    }
+}
+
+/// Normalize + build `_x.ai/exit_plan_mode` reply body.
+pub fn wire_exit_plan_mode_result(outcome: &str, feedback: Option<String>) -> Value {
+    let outcome = match outcome {
+        "approved" | "cancelled" | "abandoned" => outcome,
+        "approve" | "yes" | "accept" => "approved",
+        "abandon" | "quit" => "abandoned",
+        _ => "cancelled",
+    };
+    let mut result = json!({ "outcome": outcome });
+    if outcome == "cancelled" {
+        if let Some(fb) = feedback.filter(|s| !s.trim().is_empty()) {
+            result
+                .as_object_mut()
+                .unwrap()
+                .insert("feedback".into(), Value::String(fb));
+        }
+    }
+    result
+}
+
+/// `_x.ai/ask_user_question` reply body.
+pub fn wire_ask_user_result(outcome: &AskUserOutcome) -> Value {
+    match outcome {
+        AskUserOutcome::Accepted { answers } => json!({
+            "outcome": "accepted",
+            "answers": answers,
+            "partial_answers": {},
+        }),
+        AskUserOutcome::Cancelled => json!({ "outcome": "cancelled" }),
+    }
+}
+
+/// Full JSON-RPC success envelope for a server→client request reply.
+pub fn wire_jsonrpc_result(rpc_id: u64, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": rpc_id,
+        "result": result,
+    })
+}
+
+/// Decode `session/request_permission` params into a host event.
+pub fn decode_permission_request(rpc_id: u64, params: &Value) -> AcpEvent {
+    let tool_call = params.get("toolCall").cloned().unwrap_or(Value::Null);
+    let tool_call_id = tool_call
+        .get("toolCallId")
+        .or_else(|| tool_call.get("tool_call_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let title = tool_call
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Tool permission")
+        .to_string();
+    let tool_name = tool_call
+        .get("kind")
+        .or_else(|| tool_call.get("name"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("tool")
+        .to_string();
+    let options = params.get("options").cloned().unwrap_or(json!([]));
+    AcpEvent::PermissionRequest {
+        rpc_id,
+        tool_call_id,
+        tool_name,
+        title,
+        options,
+        raw: params.clone(),
+    }
+}
+
+/// Pure decode of `session/update` params → host events (no I/O).
+/// Used by the live client and golden fixture tests.
+pub fn decode_session_update(params: &Value) -> Vec<AcpEvent> {
+    let update = params.get("update").unwrap_or(params);
+    let kind = update
+        .get("sessionUpdate")
+        .or_else(|| update.get("session_update"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let mut out = Vec::new();
+    match kind {
+        "agent_message_chunk" => {
+            let text = update
+                .pointer("/content/text")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let message_id = update
+                .get("messageId")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            out.push(AcpEvent::Stream {
+                kind: StreamKind::Assistant,
+                text,
+                message_id,
+                done: false,
+            });
+        }
+        // Grok/Gemini emit agent_thought_chunk; some paths also use "thought".
+        "agent_thought_chunk" | "thought" => {
+            let text = update
+                .pointer("/content/text")
+                .and_then(|v| v.as_str())
+                .or_else(|| update.get("text").and_then(|v| v.as_str()))
+                .unwrap_or("")
+                .to_string();
+            let message_id = update
+                .get("messageId")
+                .or_else(|| update.get("message_id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            if !text.is_empty() {
+                out.push(AcpEvent::Stream {
+                    kind: StreamKind::Thought,
+                    text,
+                    message_id,
+                    done: false,
+                });
+            }
+        }
+        "plan" => {
+            let entries = update.get("entries").cloned().unwrap_or(json!([]));
+            let body = update
+                .get("planContent")
+                .or_else(|| update.get("plan_content"))
+                .or_else(|| update.get("content"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            out.push(AcpEvent::Plan {
+                entries,
+                body,
+                rpc_id: None,
+                tool_call_id: None,
+            });
+        }
+        "tool_call" | "tool_call_update" => {
+            let tool_call_id = update
+                .get("toolCallId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let title = update
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let k = update
+                .get("kind")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let status = update
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let title_l = title.to_ascii_lowercase();
+            let kind_l = k.to_ascii_lowercase();
+            if status == "completed"
+                && (title_l.contains("compact")
+                    || kind_l.contains("compact")
+                    || tool_call_id.to_ascii_lowercase().contains("compact"))
+            {
+                out.push(AcpEvent::ContextCompact {
+                    trigger: "manual".into(),
+                    tokens_before: None,
+                    tokens_after: None,
+                    summary_preview: None,
+                    note: Some(title.clone()),
+                });
+            }
+            out.push(AcpEvent::ToolCall {
+                tool_call_id,
+                title,
+                kind: k,
+                status,
+                raw: update.clone(),
+            });
+        }
+        "retry_state" => {
+            let attempt = update
+                .get("attempt")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32;
+            let max_retries = update
+                .get("max_retries")
+                .or_else(|| update.get("maxRetries"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(HOST_PROVIDER_MAX_RETRIES as u64) as u32;
+            let reason = update
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let status = update
+                .get("type")
+                .or_else(|| update.get("status"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("retrying")
+                .to_string();
+            out.push(AcpEvent::RetryState {
+                attempt,
+                max_retries,
+                reason,
+                status,
+            });
+        }
+        "tokens_used"
+        | "compaction"
+        | "compaction_completed"
+        | "context_compact"
+        | "auto_compact"
+        | "compaction_checkpoint" => {
+            if let Some((trigger, before, after, summary, note)) =
+                parse_context_compact_update(kind, update)
+            {
+                out.push(AcpEvent::ContextCompact {
+                    trigger,
+                    tokens_before: before,
+                    tokens_after: after,
+                    summary_preview: summary,
+                    note,
+                });
+            }
+        }
+        _ => {
+            if update.get("tokens_before").is_some()
+                || update.get("tokensBefore").is_some()
+                || update.get("tokens_after").is_some()
+                || update.get("tokensAfter").is_some()
+            {
+                if let Some((trigger, before, after, summary, note)) =
+                    parse_context_compact_update(kind, update)
+                {
+                    out.push(AcpEvent::ContextCompact {
+                        trigger,
+                        tokens_before: before,
+                        tokens_after: after,
+                        summary_preview: summary,
+                        note,
+                    });
+                    return out;
+                }
+            }
+            let title = update
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_ascii_lowercase();
+            if title.contains("compact") {
+                out.push(AcpEvent::ContextCompact {
+                    trigger: if title.contains("auto") {
+                        "auto".into()
+                    } else {
+                        "manual".into()
+                    },
+                    tokens_before: None,
+                    tokens_after: None,
+                    summary_preview: None,
+                    note: update
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                });
+            }
+        }
+    }
+    out
 }
 
 /// One choice inside an ask-user question.

--- a/src-tauri/src/acp_golden_test.rs
+++ b/src-tauri/src/acp_golden_test.rs
@@ -1,0 +1,436 @@
+//! ACP golden fixtures — protocol regression suite (T06).
+//!
+//! Loads JSON under `tests/fixtures/acp/` and asserts Host wire builders,
+//! pure decoders, permission option mapping, and mock_acp streaming.
+//! No network, no real CLI. Required for ACP protocol changes (see CI + SPIKE-ACP).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+use crate::acp_client::{
+    decode_permission_request, decode_session_update, parse_ask_user_question_params,
+    wire_ask_user_result, wire_exit_plan_mode_result, wire_initialize_params, wire_jsonrpc_result,
+    wire_permission_result, wire_session_cancel_params, wire_session_prompt_params, AcpEvent,
+    AskUserOutcome, PermissionOutcome, StreamKind,
+};
+use crate::mock_acp::{chunk_text, mock_reply_for, spawn_fake_stream_channel};
+use crate::permission::pick_option_id;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/acp")
+}
+
+fn load_fixture(name: &str) -> Value {
+    let path = fixtures_dir().join(name);
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read fixture {}: {e}", path.display()));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse fixture {name}: {e}"))
+}
+
+// ── Handshake ───────────────────────────────────────────────────────────────
+
+#[test]
+fn handshake_initialize_params_match_fixture() {
+    let fx = load_fixture("handshake_initialize.json");
+    let expected = &fx["hostRequest"]["params"];
+    let actual = wire_initialize_params();
+    assert_eq!(
+        actual, *expected,
+        "wire_initialize_params drifted from handshake_initialize.json"
+    );
+
+    assert_eq!(
+        actual["protocolVersion"],
+        fx["expect"]["protocolVersion"]
+    );
+    assert_eq!(
+        actual["clientInfo"]["name"].as_str(),
+        fx["expect"]["clientName"].as_str()
+    );
+    assert!(
+        actual["capabilities"].is_object(),
+        "capabilities must be object"
+    );
+
+    // Sample agent result must advertise the same protocol version.
+    assert_eq!(
+        fx["sampleAgentResult"]["protocolVersion"],
+        actual["protocolVersion"]
+    );
+}
+
+#[test]
+fn session_prompt_and_cancel_wire_shapes() {
+    let stop = load_fixture("stop_cancel.json");
+    let sid = stop["expect"]["sessionId"].as_str().unwrap();
+    assert_eq!(
+        wire_session_cancel_params(sid),
+        stop["hostNotification"]["params"]
+    );
+
+    let prompt = wire_session_prompt_params("sess-a", "hello");
+    assert_eq!(prompt["sessionId"], "sess-a");
+    assert_eq!(
+        prompt["prompt"],
+        json!([{ "type": "text", "text": "hello" }])
+    );
+}
+
+// ── Stream chunks (real ACP session/update decoder) ─────────────────────────
+
+#[test]
+fn stream_session_update_chunks_match_fixture() {
+    let fx = load_fixture("stream_chunks.json");
+    let inbound = fx["inbound"].as_array().expect("inbound array");
+    let expect_events = fx["expect"]["events"].as_array().expect("expect.events");
+
+    assert_eq!(inbound.len(), expect_events.len());
+
+    let mut assistant_joined = String::new();
+    for (i, (msg, exp)) in inbound.iter().zip(expect_events.iter()).enumerate() {
+        let params = msg.get("params").expect("params");
+        let events = decode_session_update(params);
+        assert_eq!(
+            events.len(),
+            1,
+            "inbound[{i}] should decode to one stream event"
+        );
+        match &events[0] {
+            AcpEvent::Stream {
+                kind,
+                text,
+                message_id,
+                done,
+            } => {
+                let kind_s = match kind {
+                    StreamKind::Assistant => "assistant",
+                    StreamKind::Thought => "thought",
+                };
+                assert_eq!(kind_s, exp["kind"].as_str().unwrap(), "event[{i}].kind");
+                assert_eq!(text, exp["text"].as_str().unwrap(), "event[{i}].text");
+                assert_eq!(
+                    message_id.as_deref(),
+                    exp["messageId"].as_str(),
+                    "event[{i}].messageId"
+                );
+                assert_eq!(*done, exp["done"].as_bool().unwrap(), "event[{i}].done");
+                if matches!(kind, StreamKind::Assistant) {
+                    assistant_joined.push_str(text);
+                }
+            }
+            other => panic!("event[{i}] expected Stream, got {other:?}"),
+        }
+    }
+
+    assert_eq!(
+        assistant_joined,
+        fx["expect"]["joinedAssistantText"].as_str().unwrap()
+    );
+    assert_eq!(
+        fx["sessionPromptResult"]["stopReason"].as_str(),
+        Some("end_turn")
+    );
+}
+
+// ── Stop / cancel ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn stop_mid_stream_emits_done_matching_fixture() {
+    let fx = load_fixture("stop_cancel.json");
+    let done_shape = &fx["mockStopDoneChunk"];
+
+    let (handle, mut rx) = spawn_fake_stream_channel(
+        done_shape["sessionId"].as_str().unwrap().into(),
+        done_shape["messageId"].as_str().unwrap().into(),
+        "long prompt for more chunks than one".into(),
+        Duration::from_millis(40),
+    );
+
+    let first = rx.recv().await.expect("first chunk");
+    assert_eq!(first.session_id, done_shape["sessionId"].as_str().unwrap());
+    handle.request_stop();
+
+    let mut saw_done = false;
+    while let Some(c) = rx.recv().await {
+        if c.done {
+            assert_eq!(c.session_id, done_shape["sessionId"].as_str().unwrap());
+            assert_eq!(c.message_id, done_shape["messageId"].as_str().unwrap());
+            // Stop path: empty text + done (see mock_acp::spawn_fake_stream).
+            assert_eq!(c.text, done_shape["text"].as_str().unwrap_or(""));
+            assert!(c.done);
+            saw_done = true;
+            break;
+        }
+    }
+    let _ = handle.join.await;
+    assert!(saw_done, "stop should finish with done=true");
+}
+
+// ── Permission request options ──────────────────────────────────────────────
+
+#[test]
+fn permission_request_decode_and_option_mapping() {
+    let fx = load_fixture("permission_request.json");
+    let inbound = &fx["inbound"];
+    let params = &inbound["params"];
+    let rpc_id = inbound["id"].as_u64().unwrap();
+
+    let ev = decode_permission_request(rpc_id, params);
+    match ev {
+        AcpEvent::PermissionRequest {
+            rpc_id: rid,
+            tool_call_id,
+            tool_name,
+            title,
+            options,
+            ..
+        } => {
+            assert_eq!(rid, fx["expect"]["rpcId"].as_u64().unwrap());
+            assert_eq!(
+                tool_call_id,
+                fx["expect"]["toolCallId"].as_str().unwrap()
+            );
+            assert_eq!(tool_name, fx["expect"]["toolName"].as_str().unwrap());
+            assert_eq!(title, fx["expect"]["title"].as_str().unwrap());
+
+            let map = &fx["expect"]["optionMap"];
+            for (prefer, expected_id) in map.as_object().unwrap() {
+                let got = pick_option_id(&options, prefer);
+                assert_eq!(
+                    got.as_deref(),
+                    expected_id.as_str(),
+                    "pick_option_id({prefer})"
+                );
+            }
+        }
+        other => panic!("expected PermissionRequest, got {other:?}"),
+    }
+
+    // Host reply envelopes
+    let selected = wire_jsonrpc_result(
+        rpc_id,
+        wire_permission_result(&PermissionOutcome::Selected {
+            option_id: "allow-once".into(),
+        }),
+    );
+    assert_eq!(selected, fx["hostReplySelected"]);
+
+    let cancelled =
+        wire_jsonrpc_result(rpc_id, wire_permission_result(&PermissionOutcome::Cancelled));
+    assert_eq!(cancelled, fx["hostReplyCancelled"]);
+
+    // Underscore optionIds (shell-style)
+    let us = &fx["underscoreOptionIds"];
+    let opts = &us["options"];
+    for (prefer, expected_id) in us["expect"].as_object().unwrap() {
+        assert_eq!(
+            pick_option_id(opts, prefer).as_deref(),
+            expected_id.as_str(),
+            "underscore pick_option_id({prefer})"
+        );
+    }
+}
+
+// ── ask_user_question ───────────────────────────────────────────────────────
+
+#[test]
+fn ask_user_question_parse_and_replies_match_fixture() {
+    let fx = load_fixture("ask_user_question.json");
+    let params = &fx["inbound"]["params"];
+    let parsed = parse_ask_user_question_params(params);
+
+    assert_eq!(
+        parsed.tool_call_id.as_deref(),
+        fx["expect"]["toolCallId"].as_str()
+    );
+    let expect_q = fx["expect"]["questions"].as_array().unwrap();
+    assert_eq!(parsed.questions.len(), expect_q.len());
+    assert_eq!(
+        parsed.questions[0].question,
+        expect_q[0]["question"].as_str().unwrap()
+    );
+    assert_eq!(
+        parsed.questions[0].multi_select,
+        expect_q[0]["multiSelect"].as_bool().unwrap()
+    );
+    let labels: Vec<&str> = parsed.questions[0]
+        .options
+        .iter()
+        .map(|o| o.label.as_str())
+        .collect();
+    let expect_labels: Vec<&str> = expect_q[0]["optionLabels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(labels, expect_labels);
+
+    let rpc_id = fx["inbound"]["id"].as_u64().unwrap();
+    let accepted = wire_jsonrpc_result(
+        rpc_id,
+        wire_ask_user_result(&AskUserOutcome::Accepted {
+            answers: json!({ "Which store?": "SQLite" }),
+        }),
+    );
+    assert_eq!(accepted, fx["hostReplyAccepted"]);
+
+    let cancelled =
+        wire_jsonrpc_result(rpc_id, wire_ask_user_result(&AskUserOutcome::Cancelled));
+    assert_eq!(cancelled, fx["hostReplyCancelled"]);
+}
+
+// ── exit_plan_mode / plan update ────────────────────────────────────────────
+
+#[test]
+fn exit_plan_mode_and_plan_update_match_fixture() {
+    let fx = load_fixture("exit_plan_mode.json");
+    let params = &fx["inbound"]["params"];
+    let plan = params["planContent"].as_str().unwrap();
+    assert!(
+        plan.starts_with(fx["expect"]["planContentStartsWith"].as_str().unwrap()),
+        "planContent prefix"
+    );
+    assert_eq!(
+        params["toolCallId"].as_str(),
+        fx["expect"]["toolCallId"].as_str()
+    );
+
+    let rpc_id = fx["inbound"]["id"].as_u64().unwrap();
+    assert_eq!(
+        wire_jsonrpc_result(rpc_id, wire_exit_plan_mode_result("approved", None)),
+        fx["hostReplyApproved"]
+    );
+    assert_eq!(
+        wire_jsonrpc_result(
+            rpc_id,
+            wire_exit_plan_mode_result("cancelled", Some("Please add tests first".into()))
+        ),
+        fx["hostReplyCancelledWithFeedback"]
+    );
+    assert_eq!(
+        wire_jsonrpc_result(rpc_id, wire_exit_plan_mode_result("abandoned", None)),
+        fx["hostReplyAbandoned"]
+    );
+    // Aliases normalize
+    assert_eq!(
+        wire_exit_plan_mode_result("approve", None)["outcome"],
+        "approved"
+    );
+    assert_eq!(
+        wire_exit_plan_mode_result("quit", None)["outcome"],
+        "abandoned"
+    );
+
+    // session/update plan → Plan event
+    let plan_params = &fx["sessionUpdatePlan"]["params"];
+    let events = decode_session_update(plan_params);
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        AcpEvent::Plan {
+            body,
+            entries,
+            rpc_id,
+            ..
+        } => {
+            assert!(rpc_id.is_none());
+            assert_eq!(body.as_deref(), Some(plan));
+            assert_eq!(entries.as_array().map(|a| a.len()), Some(2));
+        }
+        other => panic!("expected Plan, got {other:?}"),
+    }
+}
+
+// ── mock_acp stream golden ──────────────────────────────────────────────────
+
+#[test]
+fn mock_reply_and_chunks_match_fixture() {
+    let fx = load_fixture("mock_stream.json");
+    let prompt = fx["prompt"].as_str().unwrap();
+    let chunk_chars = fx["chunkChars"].as_u64().unwrap() as usize;
+
+    let full = mock_reply_for(prompt);
+    assert_eq!(full, fx["expectedFullText"].as_str().unwrap());
+
+    let pieces = chunk_text(&full, chunk_chars);
+    let expected: Vec<String> = fx["expectedChunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        pieces, expected,
+        "chunk_text output drifted — regenerate mock_stream.json (see fixtures README)"
+    );
+
+    for needle in fx["expect"]["contains"].as_array().unwrap() {
+        assert!(
+            full.contains(needle.as_str().unwrap()),
+            "reply missing {:?}",
+            needle
+        );
+    }
+}
+
+#[tokio::test]
+async fn mock_stream_emits_fixture_chunks_then_done() {
+    let fx = load_fixture("mock_stream.json");
+    let prompt = fx["prompt"].as_str().unwrap().to_string();
+    let session_id = fx["sessionId"].as_str().unwrap().to_string();
+    let message_id = fx["messageId"].as_str().unwrap().to_string();
+    let expected: Vec<String> = fx["expectedChunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+
+    let (handle, mut rx) = spawn_fake_stream_channel(
+        session_id.clone(),
+        message_id.clone(),
+        prompt,
+        Duration::from_millis(0),
+    );
+
+    let mut texts = Vec::new();
+    let mut last_done = false;
+    while let Some(c) = rx.recv().await {
+        assert_eq!(c.session_id, session_id);
+        assert_eq!(c.message_id, message_id);
+        if !c.text.is_empty() {
+            texts.push(c.text);
+        }
+        if c.done {
+            last_done = true;
+            break;
+        }
+    }
+    handle.join.await.unwrap();
+
+    assert!(last_done);
+    assert!(
+        texts.len() >= fx["expect"]["minChunks"].as_u64().unwrap() as usize
+    );
+    assert_eq!(texts, expected);
+    assert_eq!(
+        texts.concat(),
+        fx["expectedFullText"].as_str().unwrap()
+    );
+}
+
+/// Helper: print regenerated mock_stream chunk list when regenerating fixtures.
+#[test]
+#[ignore = "run with --ignored --nocapture to regenerate mock_stream.json chunks"]
+fn print_mock_stream_chunks() {
+    let prompt = "hi";
+    let full = mock_reply_for(prompt);
+    let pieces = chunk_text(&full, 6);
+    println!("expectedFullText: {full:?}");
+    println!(
+        "expectedChunks:\n{}",
+        serde_json::to_string_pretty(&pieces).unwrap()
+    );
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,8 @@ mod session_title;
 mod permission_host_test;
 #[cfg(test)]
 mod integration_test;
+#[cfg(test)]
+mod acp_golden_test;
 mod session_fsm;
 mod session_manager;
 mod store;

--- a/src-tauri/tests/fixtures/acp/README.md
+++ b/src-tauri/tests/fixtures/acp/README.md
@@ -1,0 +1,50 @@
+# ACP golden fixtures
+
+Deterministic wire samples for the Host ACP surface (`acp_client`, `mock_acp`,
+permission option mapping). Exercised by `src/acp_golden_test.rs` via
+`cargo test --lib acp_golden` — **no network, no real CLI**.
+
+| File | Covers |
+|------|--------|
+| `handshake_initialize.json` | Host `initialize` params |
+| `stream_chunks.json` | `session/update` thought + assistant chunks |
+| `stop_cancel.json` | Host `session/cancel` + mock stop done shape |
+| `permission_request.json` | `session/request_permission` + `pick_option_id` |
+| `ask_user_question.json` | `_x.ai/ask_user_question` parse + replies |
+| `exit_plan_mode.json` | `_x.ai/exit_plan_mode` + plan sessionUpdate |
+| `mock_stream.json` | In-process mock token stream for prompt `hi` |
+
+## When to update
+
+Update fixtures **in the same PR** as any change to:
+
+- `wire_*` / `decode_*` helpers in `src/acp_client.rs`
+- `mock_reply_for` / `chunk_text` / stream spawn in `src/mock_acp.rs`
+- `pick_option_id` mapping in `src/permission.rs`
+- Protocol notes in `docs/SPIKE-ACP.md`
+
+CI runs the full `cargo test` suite on every PR; the golden module is required
+for ACP protocol changes.
+
+## How to regenerate
+
+From repo root (or `src-tauri`):
+
+```bash
+# 1. If mock reply text or chunk size changed, recompute mock_stream.json:
+cd src-tauri
+cargo test --lib acp_golden::mock_stream_matches_fixture -- --nocapture
+
+# 2. Failures print expected vs actual. For mock chunks, run:
+cargo test --lib acp_golden::print_mock_stream_chunks -- --ignored --nocapture
+# then paste the JSON array into mock_stream.json → expectedChunks / expectedFullText.
+
+# 3. For host wire builders, adjust the matching *.json hostRequest / hostReply*
+#    fields to equal the `wire_*` functions (tests assert equality either way).
+
+# 4. Re-run:
+cargo test --lib acp_golden
+```
+
+Do **not** hand-edit fixtures to “make CI green” without updating production
+builders/parsers — the suite is the contract.

--- a/src-tauri/tests/fixtures/acp/ask_user_question.json
+++ b/src-tauri/tests/fixtures/acp/ask_user_question.json
@@ -1,0 +1,50 @@
+{
+  "_comment": "_x.ai/ask_user_question reverse-request + Host replies. Parser: parse_ask_user_question_params().",
+  "inbound": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "method": "_x.ai/ask_user_question",
+    "params": {
+      "sessionId": "agent-sess-1",
+      "toolCallId": "call-ask-1",
+      "questions": [
+        {
+          "question": "Which store?",
+          "multiSelect": false,
+          "options": [
+            { "label": "SQLite", "description": "Local file" },
+            { "label": "Postgres", "description": "Server" }
+          ]
+        }
+      ]
+    }
+  },
+  "expect": {
+    "toolCallId": "call-ask-1",
+    "questions": [
+      {
+        "question": "Which store?",
+        "multiSelect": false,
+        "optionLabels": ["SQLite", "Postgres"]
+      }
+    ]
+  },
+  "hostReplyAccepted": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "result": {
+      "outcome": "accepted",
+      "answers": {
+        "Which store?": "SQLite"
+      },
+      "partial_answers": {}
+    }
+  },
+  "hostReplyCancelled": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "result": {
+      "outcome": "cancelled"
+    }
+  }
+}

--- a/src-tauri/tests/fixtures/acp/exit_plan_mode.json
+++ b/src-tauri/tests/fixtures/acp/exit_plan_mode.json
@@ -1,0 +1,55 @@
+{
+  "_comment": "_x.ai/exit_plan_mode reverse-request + Host replies. Builder: wire_exit_plan_mode_result().",
+  "inbound": {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "method": "_x.ai/exit_plan_mode",
+    "params": {
+      "sessionId": "agent-sess-1",
+      "toolCallId": "call-plan-1",
+      "planContent": "## Plan\n1. Touch fixtures\n2. Run cargo test\n"
+    }
+  },
+  "expect": {
+    "rpcId": 9,
+    "toolCallId": "call-plan-1",
+    "planContentStartsWith": "## Plan"
+  },
+  "hostReplyApproved": {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "result": {
+      "outcome": "approved"
+    }
+  },
+  "hostReplyCancelledWithFeedback": {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "result": {
+      "outcome": "cancelled",
+      "feedback": "Please add tests first"
+    }
+  },
+  "hostReplyAbandoned": {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "result": {
+      "outcome": "abandoned"
+    }
+  },
+  "sessionUpdatePlan": {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "agent-sess-1",
+      "update": {
+        "sessionUpdate": "plan",
+        "entries": [
+          { "content": "Touch fixtures", "status": "pending" },
+          { "content": "Run cargo test", "status": "pending" }
+        ],
+        "planContent": "## Plan\n1. Touch fixtures\n2. Run cargo test\n"
+      }
+    }
+  }
+}

--- a/src-tauri/tests/fixtures/acp/handshake_initialize.json
+++ b/src-tauri/tests/fixtures/acp/handshake_initialize.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Host → agent initialize request params + sample agent result. Locked by wire_initialize_params().",
+  "hostRequest": {
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "params": {
+      "protocolVersion": 1,
+      "clientInfo": {
+        "name": "grok-app",
+        "version": "0.1.0"
+      },
+      "capabilities": {}
+    }
+  },
+  "sampleAgentResult": {
+    "protocolVersion": 1,
+    "agentCapabilities": {
+      "loadSession": true
+    },
+    "authMethods": [
+      { "id": "cached_token", "name": "Cached token" },
+      { "id": "grok.com", "name": "grok.com OAuth" }
+    ],
+    "_meta": {
+      "agentVersion": "0.2.106"
+    }
+  },
+  "expect": {
+    "protocolVersion": 1,
+    "clientName": "grok-app",
+    "capabilitiesIsObject": true
+  }
+}

--- a/src-tauri/tests/fixtures/acp/mock_stream.json
+++ b/src-tauri/tests/fixtures/acp/mock_stream.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "In-process mock_acp stream for prompt «hi», chunk size 6. Regenerated from mock_reply_for + chunk_text.",
+  "prompt": "hi",
+  "sessionId": "s-mock-1",
+  "messageId": "m-mock-1",
+  "chunkChars": 6,
+  "expectedFullText": "Mock ACP reply: I received «hi». This stream is fake token output from the in-process stub — not grok agent stdio. Ready for PR3 swap.",
+  "expectedChunks": [
+    "Mock A",
+    "CP rep",
+    "ly: I ",
+    "receiv",
+    "ed «hi",
+    "». Thi",
+    "s stre",
+    "am is ",
+    "fake t",
+    "oken o",
+    "utput ",
+    "from t",
+    "he in-",
+    "proces",
+    "s stub",
+    " — not",
+    " grok ",
+    "agent ",
+    "stdio.",
+    " Ready",
+    " for P",
+    "R3 swa",
+    "p."
+  ],
+  "expect": {
+    "minChunks": 2,
+    "lastDone": true,
+    "contains": ["Mock ACP", "not grok agent stdio"]
+  }
+}

--- a/src-tauri/tests/fixtures/acp/permission_request.json
+++ b/src-tauri/tests/fixtures/acp/permission_request.json
@@ -1,0 +1,80 @@
+{
+  "_comment": "session/request_permission wire sample + Host optionId mapping (pick_option_id).",
+  "inbound": {
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "session/request_permission",
+    "params": {
+      "sessionId": "agent-sess-1",
+      "toolCall": {
+        "toolCallId": "call-write-1",
+        "title": "Write SPIKE_PERM.txt",
+        "kind": "write",
+        "rawInput": {
+          "file_path": "/tmp/proj/SPIKE_PERM.txt",
+          "content": "PERM_OK\n"
+        }
+      },
+      "options": [
+        {
+          "optionId": "allow-once",
+          "name": "Allow once",
+          "kind": "allow_once"
+        },
+        {
+          "optionId": "allow-always",
+          "name": "Allow always for this session",
+          "kind": "allow_always"
+        },
+        {
+          "optionId": "reject-once",
+          "name": "Reject",
+          "kind": "reject_once"
+        }
+      ]
+    }
+  },
+  "expect": {
+    "rpcId": 42,
+    "toolCallId": "call-write-1",
+    "toolName": "write",
+    "title": "Write SPIKE_PERM.txt",
+    "optionMap": {
+      "allow_once": "allow-once",
+      "allow_always": "allow-always",
+      "reject_once": "reject-once"
+    }
+  },
+  "hostReplySelected": {
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+      "outcome": {
+        "outcome": "selected",
+        "optionId": "allow-once"
+      }
+    }
+  },
+  "hostReplyCancelled": {
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+      "outcome": {
+        "outcome": "cancelled"
+      }
+    }
+  },
+  "underscoreOptionIds": {
+    "_comment": "Grok Build shell prompts sometimes use underscore optionIds",
+    "options": [
+      { "optionId": "allow_once", "name": "Allow once", "kind": "allow_once" },
+      { "optionId": "allow_always", "name": "Allow always", "kind": "allow_always" },
+      { "optionId": "reject_once", "name": "Reject", "kind": "reject_once" }
+    ],
+    "expect": {
+      "allow_once": "allow_once",
+      "allow_always": "allow_always",
+      "reject_once": "reject_once"
+    }
+  }
+}

--- a/src-tauri/tests/fixtures/acp/stop_cancel.json
+++ b/src-tauri/tests/fixtures/acp/stop_cancel.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Host stop → session/cancel notification params. Locked by wire_session_cancel_params().",
+  "hostNotification": {
+    "jsonrpc": "2.0",
+    "method": "session/cancel",
+    "params": {
+      "sessionId": "agent-sess-stop-1"
+    }
+  },
+  "expect": {
+    "method": "session/cancel",
+    "sessionId": "agent-sess-stop-1"
+  },
+  "mockStopDoneChunk": {
+    "sessionId": "s-stop",
+    "messageId": "m-stop",
+    "text": "",
+    "done": true
+  }
+}

--- a/src-tauri/tests/fixtures/acp/stream_chunks.json
+++ b/src-tauri/tests/fixtures/acp/stream_chunks.json
@@ -1,0 +1,75 @@
+{
+  "_comment": "session/update wire samples for assistant + thought chunks. Host decoder: decode_session_update().",
+  "inbound": [
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "agent-sess-1",
+        "update": {
+          "sessionUpdate": "agent_thought_chunk",
+          "content": { "type": "text", "text": "Thinking about the answer…" },
+          "messageId": "msg-thought-1"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "agent-sess-1",
+        "update": {
+          "sessionUpdate": "agent_message_chunk",
+          "content": { "type": "text", "text": "Hello " },
+          "messageId": "msg-1"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "agent-sess-1",
+        "update": {
+          "sessionUpdate": "agent_message_chunk",
+          "content": { "type": "text", "text": "world." },
+          "messageId": "msg-1"
+        }
+      }
+    }
+  ],
+  "expect": {
+    "events": [
+      {
+        "kind": "thought",
+        "text": "Thinking about the answer…",
+        "messageId": "msg-thought-1",
+        "done": false
+      },
+      {
+        "kind": "assistant",
+        "text": "Hello ",
+        "messageId": "msg-1",
+        "done": false
+      },
+      {
+        "kind": "assistant",
+        "text": "world.",
+        "messageId": "msg-1",
+        "done": false
+      }
+    ],
+    "joinedAssistantText": "Hello world."
+  },
+  "promptComplete": {
+    "jsonrpc": "2.0",
+    "method": "_x.ai/session/prompt_complete",
+    "params": {
+      "sessionId": "agent-sess-1",
+      "stopReason": "end_turn"
+    }
+  },
+  "sessionPromptResult": {
+    "stopReason": "end_turn"
+  }
+}


### PR DESCRIPTION
## Summary

Implements **T06 — ACP stub CI + golden fixtures**: deterministic, offline protocol regression samples so ACP wire/mock changes cannot drift silently.

### What landed
- **Fixtures** under `src-tauri/tests/fixtures/acp/`:
  - `handshake_initialize.json` — Host `initialize` params
  - `stream_chunks.json` — `session/update` thought + assistant chunks
  - `stop_cancel.json` — `session/cancel` + mock mid-stream stop done shape
  - `permission_request.json` — `session/request_permission` + `pick_option_id` mapping
  - `ask_user_question.json` — `_x.ai/ask_user_question` parse + Host replies
  - `exit_plan_mode.json` — plan gate replies + plan sessionUpdate
  - `mock_stream.json` — in-process mock stream for prompt `hi`
- **Pure Host helpers** in `acp_client` (`wire_*` / `decode_*`) used by production paths **and** the suite
- **Tests**: `src-tauri/src/acp_golden_test.rs` — no network, no real CLI
- **Docs**: regenerate steps in `docs/SPIKE-ACP.md` + `tests/fixtures/acp/README.md`
- **CI**: comment on `cargo test` step that the golden suite is required for ACP changes

### Why
Protocol regression without a live agent. Any change to wire builders, mock stream, or permission option mapping must keep the suite green.

## Type of change
- [x] New feature
- [x] Documentation

## Checklist
- [x] I ran `cargo test --lib` in `src-tauri` (126 passed, 1 ignored regen helper)
- [x] Docs / `docs/SPIKE-ACP.md` updated
- [x] No secrets included
- [x] User-facing strings: N/A (no UI)
- [x] No `window.confirm` / `prompt` / `alert`

## Test plan
```bash
cd src-tauri
cargo test --lib acp_golden   # golden suite only
cargo test --lib              # full lib suite
# regenerate mock chunks if mock_reply_for/chunk size changes:
cargo test --lib acp_golden::print_mock_stream_chunks -- --ignored --nocapture
```