### PR TITLE
fix: stop re-streaming history on session switch

### DIFF
--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -1356,6 +1356,21 @@ impl SessionManager {
                     let mut guard = self.inner.lock();
                     if let Some(s) = guard.as_mut() {
                         Self::touch_activity_locked(s);
+                        // Drop stream chunks that arrive while no turn is in flight.
+                        // On session resume (session/load) the CLI may replay the past
+                        // transcript as agent_message_chunk notifications; without this
+                        // guard they'd be re-emitted as live session://stream and the
+                        // UI would re-type the whole history on every session switch.
+                        if !matches!(
+                            s.fsm.state(),
+                            SessionState::Streaming | SessionState::AwaitingPermission
+                        ) {
+                            tracing::debug!(
+                                "acp stream dropped: fsm={:?} (not in a live turn)",
+                                s.fsm.state()
+                            );
+                            return;
+                        }
                         // Prefer agent-supplied messageId; otherwise keep the turn id.
                         if let Some(ref mid_in) = message_id {
                             if s.streaming_message_id.as_ref() != Some(mid_in) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import {
   canType,
   clearPriorTurnStreaming,
   isSessionBusy,
+  isSessionLiveStreaming,
   preferSessionMessages,
   presentErrorBanner,
   buildSegmentsFromLegacy,
@@ -1120,6 +1121,15 @@ export default function App() {
             if (cancelled) return;
             // Ignore empty terminal ticks that only flip done
             if (!chunk.text && !chunk.done) return;
+            // Defense-in-depth: drop stream chunks that arrive while no live turn
+            // is active (the host already gates this on FSM Streaming, but stale
+            // or replayed chunks must never re-type history on session switch).
+            if (
+              chunk.text &&
+              !isSessionLiveStreaming(liveHostRef.current.state)
+            ) {
+              return;
+            }
             if (
               chunk.text &&
               chunk.sessionId === viewingSessionIdRef.current

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -701,6 +701,15 @@ export function isSessionBusy(state: SessionState): boolean {
 }
 
 /**
+ * Whether a live LLM turn is actually producing output right now.
+ * Stricter than {@link isSessionBusy}: excludes `connecting`, so replayed or
+ * stale stream chunks arriving mid-connect cannot re-type history.
+ */
+export function isSessionLiveStreaming(state: SessionState): boolean {
+  return state === "streaming" || state === "awaiting_permission";
+}
+
+/**
  * Drop the last user message and everything after it (assistant reply, errors, tools).
  * Used by edit-resend so the prior turn is fully replaced, not stacked.
  */


### PR DESCRIPTION
## Problem

Clicking a historical session in the sidebar (just switching — **no message sent**) **replays the entire assistant transcript as if it were live streaming**, with the sidebar spinner spinning. Switching back and forth re-types the history every time. No API call is made (it's a local replay).

## Root cause

On session resume (\`session/load\`), the Grok Build CLI emits the restored transcript as \`session/update\` \`agent_message_chunk\` notifications. The Host's \`AcpEvent::Stream\` handler forwarded **every** chunk to \`session://stream\` with no guard, so replay chunks were re-emitted as live stream → \`applyStreamChunk\` appended \`streaming:true\` messages → the UI re-typed the whole history.

This matched every symptom: no API request (local replay), re-output every switch (each \`openSession\` triggers a warm \`session_connect\`), sidebar spinner (FSM=\`Connecting\` during connect).

## Fix

**Drop stream chunks unless the FSM is in \`Streaming | AwaitingPermission\`** (a real turn in flight).

- \`send_message\` calls \`begin_stream()\` (FSM Ready → Streaming) **before** the first chunk arrives, so live streaming is unaffected.
- Resume replays arrive while FSM is \`Ready\`/\`Connecting\` → now dropped.

This mirrors the existing \`Streaming || AwaitingPermission\` guard pattern already used elsewhere in the same file (e.g. ~L991, L1290, L1514).

### Changes
- \`src-tauri/src/session_manager.rs\`: gate the \`AcpEvent::Stream\` arm on FSM state (+ a \`tracing::debug!\` on drop).
- \`src/App.tsx\` + \`src/lib/session.ts\`: defense-in-depth — the \`session://stream\` listener also drops chunks when \`liveHost\` is not streaming/awaiting_permission, via a new \`isSessionLiveStreaming\` helper (stricter than \`isSessionBusy\`, excludes \`connecting\`).

## Verification
- \`cargo test\` (src-tauri): **93 passed**
- \`tsc -b\`: clean
- \`vitest\`: **180 passed**
- \`cargo build --release\`: ok
- **Manual**: rebuilt & reinstalled → switch between historical sessions → **no re-streaming**, spinner only shows briefly during connect then stops (normal warm-connect loading). Sent a new message → **live streaming reply works normally** (the guard does not affect real turns).

## Note
The brief spinner on switch is expected: \`openSession\` does a warm ACP connect (FSM=\`Connecting\`) so the next message sends instantly; it clears to \`Ready\` once the handshake completes. This is not part of this bug.

## Scope
Backend guard (root cause) + frontend defense-in-depth. No new deps, no i18n, no behavior change for real turns.