### PR TITLE
feat: cancel stalled streams and throttle journal writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Stream stall cancel (I06)**: host watchdog emits `session://stream_stall` after pure silence (default 120s, Settings → Runtime); banner with Cancel turn / Keep waiting; tool events count as progress.
+- **Journal write throttle (I04)**: mid-stream assistant journal flushes ≥500ms or on paragraph / turn end / stop / disconnect — avoids per-token disk spikes.
+
 ## [0.1.2] - 2026-07-24
 
 > 中英文对照 / Bilingual notes.

--- a/docs/P0-能力矩阵.md
+++ b/docs/P0-能力矩阵.md
@@ -147,9 +147,9 @@
 | I01 | 每会话一进程 | 两活跃会话为两个 Agent 进程 | All | P0 | ☑ 热驻留（parked）按会话保留进程；同 cwd 仍可 warm-reuse |
 | I02 | 并发上限 | 默认最多 3；第 4 个提示/排队 | All | P0 | ☑ `maxConcurrentAgents`（默认 3）；超限 PROCESS_LIMIT + toast |
 | I03 | 闲置回收 | 空闲约 30min 回收进程，元数据保留 | All | P0 | ☑ `agentIdleMinutes`（默认 30）；软断开保留 meta |
-| I04 | 流式不狂写盘 | 流式过程落盘节流（≥500ms 或段落）；5min 对话无磁盘尖刺 | All | P0 | ☐ |
+| I04 | 流式不狂写盘 | 流式过程落盘节流（≥500ms 或段落）；5min 对话无磁盘尖刺 | All | P0 | ☑ `JournalWriteThrottle`（默认 500ms / 段落 / 强制 flush）；turn complete / stop / disconnect 强制落盘 |
 | I05 | 冷启动 | 已装 CLI+已登录，到可输入 ≤3s（mac 指导值，实测记录） | mac | P0 | ☐ |
-| I06 | 取消卡住流 | 长时间无 chunk 可提示并取消 | All | P0 | ☐ |
+| I06 | 取消卡住流 | 长时间无 chunk 可提示并取消 | All | P0 | ☑ `streamStallSeconds`（默认 120）；`session://stream_stall` + 取消本轮 / 继续等待；工具事件算进度 |
 
 ---
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "grok-app"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/journal_throttle.rs
+++ b/src-tauri/src/journal_throttle.rs
@@ -1,0 +1,184 @@
+//! Streaming journal write throttle (I04).
+//!
+//! Mid-stream assistant persistence must not rewrite `messages.json` on every
+//! token. Flush at most every [`DEFAULT_JOURNAL_FLUSH_MS`], on paragraph
+//! boundaries, or when forced (turn end / stop / disconnect).
+
+use std::time::{Duration, Instant};
+
+/// Spec default: ≥500ms between mid-stream journal flushes.
+pub const DEFAULT_JOURNAL_FLUSH_MS: u64 = 500;
+
+/// Hard clamp for custom intervals (tests / future settings).
+pub const MIN_JOURNAL_FLUSH_MS: u64 = 50;
+pub const MAX_JOURNAL_FLUSH_MS: u64 = 10_000;
+
+/// Normalize a raw flush interval to a safe range.
+pub fn normalize_journal_flush_ms(raw: u64) -> u64 {
+    raw.clamp(MIN_JOURNAL_FLUSH_MS, MAX_JOURNAL_FLUSH_MS)
+}
+
+/// True when a stream chunk is a natural paragraph boundary (double newline).
+pub fn is_paragraph_break(chunk: &str) -> bool {
+    chunk.contains("\n\n")
+}
+
+/// Pure decision: whether a journal flush is allowed at `now`.
+pub fn should_flush_journal(
+    last_flush: Option<Instant>,
+    min_interval: Duration,
+    now: Instant,
+    force: bool,
+    paragraph_break: bool,
+) -> bool {
+    if force || paragraph_break {
+        return true;
+    }
+    match last_flush {
+        None => true,
+        Some(t) => now.saturating_duration_since(t) >= min_interval,
+    }
+}
+
+/// Tracks last mid-stream journal flush for one live session turn.
+#[derive(Debug, Clone)]
+pub struct JournalWriteThrottle {
+    last_flush: Option<Instant>,
+    min_interval: Duration,
+}
+
+impl Default for JournalWriteThrottle {
+    fn default() -> Self {
+        Self::with_default_interval()
+    }
+}
+
+impl JournalWriteThrottle {
+    pub fn new(min_interval_ms: u64) -> Self {
+        Self {
+            last_flush: None,
+            min_interval: Duration::from_millis(normalize_journal_flush_ms(min_interval_ms)),
+        }
+    }
+
+    pub fn with_default_interval() -> Self {
+        Self::new(DEFAULT_JOURNAL_FLUSH_MS)
+    }
+
+    pub fn min_interval(&self) -> Duration {
+        self.min_interval
+    }
+
+    pub fn last_flush(&self) -> Option<Instant> {
+        self.last_flush
+    }
+
+    /// Whether a flush should run now.
+    pub fn should_flush(&self, now: Instant, force: bool, paragraph_break: bool) -> bool {
+        should_flush_journal(self.last_flush, self.min_interval, now, force, paragraph_break)
+    }
+
+    pub fn mark_flushed(&mut self, now: Instant) {
+        self.last_flush = Some(now);
+    }
+
+    /// Reset at turn start / after force end-of-turn flush.
+    pub fn reset(&mut self) {
+        self.last_flush = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_clamps() {
+        assert_eq!(normalize_journal_flush_ms(0), MIN_JOURNAL_FLUSH_MS);
+        assert_eq!(normalize_journal_flush_ms(500), 500);
+        assert_eq!(normalize_journal_flush_ms(99_999), MAX_JOURNAL_FLUSH_MS);
+    }
+
+    #[test]
+    fn paragraph_break_detects_double_newline() {
+        assert!(is_paragraph_break("hello\n\nworld"));
+        assert!(is_paragraph_break("\n\n"));
+        assert!(!is_paragraph_break("hello\nworld"));
+        assert!(!is_paragraph_break("token"));
+    }
+
+    #[test]
+    fn first_flush_allowed_without_prior() {
+        let t0 = Instant::now();
+        assert!(should_flush_journal(
+            None,
+            Duration::from_millis(500),
+            t0,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn throttle_blocks_within_interval() {
+        let t0 = Instant::now();
+        let t1 = t0 + Duration::from_millis(100);
+        assert!(!should_flush_journal(
+            Some(t0),
+            Duration::from_millis(500),
+            t1,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn throttle_allows_after_interval() {
+        let t0 = Instant::now();
+        let t1 = t0 + Duration::from_millis(500);
+        assert!(should_flush_journal(
+            Some(t0),
+            Duration::from_millis(500),
+            t1,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn force_and_paragraph_bypass_interval() {
+        let t0 = Instant::now();
+        let t1 = t0 + Duration::from_millis(10);
+        assert!(should_flush_journal(
+            Some(t0),
+            Duration::from_millis(500),
+            t1,
+            true,
+            false
+        ));
+        assert!(should_flush_journal(
+            Some(t0),
+            Duration::from_millis(500),
+            t1,
+            false,
+            true
+        ));
+    }
+
+    #[test]
+    fn struct_tracks_mark_and_reset() {
+        let mut th = JournalWriteThrottle::with_default_interval();
+        assert_eq!(th.min_interval(), Duration::from_millis(500));
+        let t0 = Instant::now();
+        assert!(th.should_flush(t0, false, false));
+        th.mark_flushed(t0);
+        assert!(!th.should_flush(t0 + Duration::from_millis(100), false, false));
+        th.reset();
+        assert!(th.should_flush(t0 + Duration::from_millis(100), false, false));
+    }
+
+    #[test]
+    fn default_matches_spec() {
+        assert_eq!(DEFAULT_JOURNAL_FLUSH_MS, 500);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,8 @@ mod models_catalog;
 mod paths;
 mod process_util;
 mod process_limits;
+mod journal_throttle;
+mod stream_stall;
 mod permission;
 mod providers;
 mod session_import;
@@ -106,10 +108,12 @@ pub fn run() {
                 tracing::warn!("tray setup: {e}");
             }
             // I03: recycle idle agent processes; session metadata stays on disk.
+            // I06: surface cancel UI when a stream is pure-silent for too long.
             {
                 use tauri::Manager;
                 let mgr = app.state::<Arc<SessionManager>>().inner().clone();
                 mgr.start_idle_watchdog(app.handle().clone());
+                mgr.start_stream_stall_watchdog(app.handle().clone());
             }
             Ok(())
         })

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -4,6 +4,10 @@
 //! - One ACP process per live/parked App session (up to `maxConcurrentAgents`, default 3).
 //! - Switching chats parks a Ready process instead of killing it (when under the cap).
 //! - Idle processes are soft-recycled after `agentIdleMinutes` (default 30); session meta stays.
+//!
+//! Streaming performance (I04 / I06):
+//! - Mid-stream journal upserts are throttled (≥500ms or paragraph / force).
+//! - Pure stream silence past `streamStallSeconds` emits `session://stream_stall`.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -20,6 +24,7 @@ use crate::acp_client::{
 };
 use crate::cli_probe;
 use crate::error::{AgentError, AgentErrorCode};
+use crate::journal_throttle::{is_paragraph_break, JournalWriteThrottle};
 use crate::mock_acp::{self, MockConnectMode, MockStreamHandle, StreamChunk};
 use crate::permission::{
     extract_path_target, extract_shell_command, may_auto_allow, may_auto_deny, pick_option_id,
@@ -31,6 +36,9 @@ use crate::process_limits::{
 };
 use crate::session_fsm::{SessionFsm, SessionState};
 use crate::store::{self, ChatMessageStored, MessageAttachmentStored, SessionMeta};
+use crate::stream_stall::{
+    normalize_stream_stall_seconds, should_emit_stall, stream_stall_message,
+};
 
 /// Strip bulky MCP/RPC dumps so chat errors stay human-readable.
 /// Full stderr is still logged via `tracing` on the ACP client side.
@@ -172,6 +180,12 @@ struct LiveSession {
     pending_ask_user_rpc_id: Option<u64>,
     /// Last user/agent activity (send, stream, permission, connect).
     last_activity: Instant,
+    /// Last stream chunk or tool event (I06 stall watchdog). Permission waits do not update this.
+    last_stream_progress: Instant,
+    /// Last time we emitted `session://stream_stall` for the current silence window.
+    last_stall_emit: Option<Instant>,
+    /// Throttle mid-stream assistant journal upserts (I04).
+    journal_throttle: JournalWriteThrottle,
 }
 
 /// Ready agent process parked while another App session is focused (I01/I02).
@@ -506,8 +520,124 @@ impl SessionManager {
         });
     }
 
+    /// Background stream stall detector (I06). Safe to call once from app setup.
+    pub fn start_stream_stall_watchdog(self: &Arc<Self>, app: AppHandle) {
+        let mgr = Arc::clone(self);
+        tauri::async_runtime::spawn(async move {
+            let mut ticker = tokio::time::interval(Duration::from_secs(5));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                mgr.tick_stream_stall(&app);
+            }
+        });
+    }
+
     fn touch_activity_locked(s: &mut LiveSession) {
         s.last_activity = Instant::now();
+    }
+
+    /// Stream chunk or tool activity — advances stall deadline (I06).
+    fn touch_stream_progress_locked(s: &mut LiveSession) {
+        let now = Instant::now();
+        s.last_activity = now;
+        s.last_stream_progress = now;
+        s.last_stall_emit = None;
+    }
+
+    fn stream_stall_seconds_from_settings() -> u32 {
+        normalize_stream_stall_seconds(store::load_settings().stream_stall_seconds)
+    }
+
+    fn emit_stream_stall(app: &AppHandle, session_id: &str, stall_seconds: u32) {
+        let _ = app.emit(
+            "session://stream_stall",
+            serde_json::json!({
+                "sessionId": session_id,
+                "stallSeconds": stall_seconds,
+                "code": "STREAM_STALL",
+                "message": stream_stall_message(stall_seconds),
+            }),
+        );
+    }
+
+    /// Persist accumulated assistant stream (I04). `force` bypasses the throttle.
+    fn maybe_flush_stream_journal(s: &mut LiveSession, force: bool, paragraph_break: bool) {
+        let has_content = !s.stream_buf.is_empty()
+            || !s.stream_thought.is_empty()
+            || !s.stream_attachments.is_empty();
+        if !has_content {
+            return;
+        }
+        let now = Instant::now();
+        if !s
+            .journal_throttle
+            .should_flush(now, force, paragraph_break)
+        {
+            return;
+        }
+        let mid = s
+            .streaming_message_id
+            .clone()
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        if s.streaming_message_id.is_none() {
+            s.streaming_message_id = Some(mid.clone());
+        }
+        let atts = if s.stream_attachments.is_empty() {
+            None
+        } else {
+            Some(s.stream_attachments.clone())
+        };
+        let _ = store::append_message(
+            &s.app_session_id,
+            ChatMessageStored {
+                id: mid,
+                role: "assistant".into(),
+                content: s.stream_buf.clone(),
+                thought: if s.stream_thought.is_empty() {
+                    None
+                } else {
+                    Some(s.stream_thought.clone())
+                },
+                created_at: chrono::Utc::now(),
+                is_error: false,
+                attachments: atts,
+                marker: None,
+            },
+        );
+        s.meta.updated_at = chrono::Utc::now();
+        let _ = store::update_session_meta(&s.meta);
+        s.journal_throttle.mark_flushed(now);
+        if force {
+            s.journal_throttle.reset();
+        }
+    }
+
+    /// I06: if live session is Streaming with pure silence, emit cancel prompt.
+    fn tick_stream_stall(&self, app: &AppHandle) {
+        let stall_secs = Self::stream_stall_seconds_from_settings();
+        let now = Instant::now();
+        let mut guard = self.inner.lock();
+        let Some(s) = guard.as_mut() else {
+            return;
+        };
+        // Only pure streaming silence — not permission / plan / ask-user waits.
+        if s.fsm.state() != SessionState::Streaming {
+            return;
+        }
+        if s.streaming_message_id.is_none() {
+            return;
+        }
+        if !should_emit_stall(s.last_stream_progress, s.last_stall_emit, stall_secs, now) {
+            return;
+        }
+        s.last_stall_emit = Some(now);
+        let sid = s.app_session_id.clone();
+        drop(guard);
+        tracing::warn!(
+            "stream stall: session={sid} silence≥{stall_secs}s — emitting cancel prompt"
+        );
+        Self::emit_stream_stall(app, &sid, stall_secs);
     }
 
     /// Live + parked processes that still have a living ACP child.
@@ -631,6 +761,7 @@ impl SessionManager {
         // Parked agents were Ready; restore Ready without connect handshake.
         let _ = fsm.start_connect();
         let _ = fsm.handshake_ok();
+        let now = Instant::now();
         Some(LiveSession {
             app_session_id: parked.app_session_id,
             process_id: parked.process_id,
@@ -655,7 +786,10 @@ impl SessionManager {
             needs_history_bootstrap: parked.needs_history_bootstrap,
             pending_plan_rpc_id: None,
             pending_ask_user_rpc_id: None,
-            last_activity: Instant::now(),
+            last_activity: now,
+            last_stream_progress: now,
+            last_stall_emit: None,
+            journal_throttle: JournalWriteThrottle::with_default_interval(),
         })
     }
 
@@ -845,7 +979,10 @@ impl SessionManager {
         s.stream_buf.clear();
         s.stream_thought.clear();
         s.stream_last_was_assistant = false;
+        s.stream_attachments.clear();
         s.streaming_message_id = None;
+        s.journal_throttle.reset();
+        s.last_stall_emit = None;
 
         let _ = app.emit(
             "session://turn_error",
@@ -1040,6 +1177,7 @@ impl SessionManager {
         {
             let mut fsm = SessionFsm::new();
             fsm.start_connect().map_err(|e| e.to_string())?;
+            let now = Instant::now();
             *self.inner.lock() = Some(LiveSession {
                 app_session_id: meta.id.clone(),
                 process_id: process_id.clone(),
@@ -1064,7 +1202,10 @@ impl SessionManager {
                 needs_history_bootstrap: false,
                 pending_plan_rpc_id: None,
                 pending_ask_user_rpc_id: None,
-                last_activity: Instant::now(),
+                last_activity: now,
+                last_stream_progress: now,
+                last_stall_emit: None,
+                journal_throttle: JournalWriteThrottle::with_default_interval(),
             });
         }
         Self::emit_state(&app, &self.snapshot());
@@ -1355,7 +1496,8 @@ impl SessionManager {
                 let (app_sid, mid, thought_phase) = {
                     let mut guard = self.inner.lock();
                     if let Some(s) = guard.as_mut() {
-                        Self::touch_activity_locked(s);
+                        // Stream chunk = progress (I06); not pure silence.
+                        Self::touch_stream_progress_locked(s);
                         // Prefer agent-supplied messageId; otherwise keep the turn id.
                         if let Some(ref mid_in) = message_id {
                             if s.streaming_message_id.as_ref() != Some(mid_in) {
@@ -1395,6 +1537,9 @@ impl SessionManager {
                                 "none"
                             }
                         };
+                        // I04: throttled mid-stream journal (force on terminal done chunk).
+                        let para = is_paragraph_break(&text);
+                        Self::maybe_flush_stream_journal(s, done, para);
                         (
                             s.app_session_id.clone(),
                             s.streaming_message_id.clone().unwrap_or_default(),
@@ -1421,49 +1566,21 @@ impl SessionManager {
                 {
                     let mut guard = self.inner.lock();
                     if let Some(s) = guard.as_mut() {
-                        Self::touch_activity_locked(s);
-                        // Persist assistant turn to independent session store
-                        let has_atts = !s.stream_attachments.is_empty();
-                        if !s.stream_buf.is_empty() || !s.stream_thought.is_empty() || has_atts {
-                            let mid = s
-                                .streaming_message_id
-                                .clone()
-                                .unwrap_or_else(|| Uuid::new_v4().to_string());
-                            let atts = if has_atts {
-                                Some(std::mem::take(&mut s.stream_attachments))
-                            } else {
-                                None
-                            };
-                            let _ = store::append_message(
-                                &s.app_session_id,
-                                ChatMessageStored {
-                                    id: mid,
-                                    role: "assistant".into(),
-                                    content: s.stream_buf.clone(),
-                                    thought: if s.stream_thought.is_empty() {
-                                        None
-                                    } else {
-                                        Some(s.stream_thought.clone())
-                                    },
-                                    created_at: chrono::Utc::now(),
-                                    is_error: false,
-                                    attachments: atts,
-                                    marker: None,
-                                },
-                            );
-                            s.meta.updated_at = chrono::Utc::now();
-                            let _ = store::update_session_meta(&s.meta);
-                        }
+                        Self::touch_stream_progress_locked(s);
+                        // Force-flush assistant turn (I04 end-of-turn path).
+                        Self::maybe_flush_stream_journal(s, true, false);
                         s.stream_buf.clear();
                         s.stream_thought.clear();
                         s.stream_last_was_assistant = false;
                         s.stream_attachments.clear();
+                        s.journal_throttle.reset();
                         if s.fsm.state() == SessionState::Streaming
                             || s.fsm.state() == SessionState::AwaitingPermission
                         {
                             let _ = s.fsm.end_stream();
                         }
                         s.streaming_message_id = None;
+                        s.last_stall_emit = None;
                     }
                 }
                 Self::emit_state(app, &self.snapshot());
@@ -1603,6 +1720,7 @@ impl SessionManager {
                     let (app_sid, mid) = {
                         let mut guard = self.inner.lock();
                         if let Some(s) = guard.as_mut() {
+                            Self::touch_stream_progress_locked(s);
                             if !s.stream_attachments.iter().any(|a| a.path == att.path) {
                                 s.stream_attachments.push(att.clone());
                             }
@@ -1629,11 +1747,14 @@ impl SessionManager {
                 }
 
                 let app_sid = {
-                    let guard = self.inner.lock();
-                    guard
-                        .as_ref()
-                        .map(|s| s.app_session_id.clone())
-                        .unwrap_or_default()
+                    let mut guard = self.inner.lock();
+                    if let Some(s) = guard.as_mut() {
+                        // Tool events count as progress so long tools never false-stall (I06).
+                        Self::touch_stream_progress_locked(s);
+                        s.app_session_id.clone()
+                    } else {
+                        String::new()
+                    }
                 };
 
                 // Live tool activity for UI — prefer human call text over bare "tool".
@@ -1789,6 +1910,8 @@ impl SessionManager {
                             st,
                             SessionState::Streaming | SessionState::AwaitingPermission
                         ) {
+                            // I04: flush partial assistant before cancel marker.
+                            Self::maybe_flush_stream_journal(s, true, false);
                             let mid = Uuid::new_v4().to_string();
                             let content = "turn_cancelled|agent_exit".to_string();
                             let _ = store::append_message(
@@ -2276,13 +2399,15 @@ impl SessionManager {
             let mut guard = self.inner.lock();
             let s = guard.as_mut().ok_or("no active session")?;
             s.fsm.begin_stream().map_err(|e| e.to_string())?;
-            Self::touch_activity_locked(s);
+            Self::touch_stream_progress_locked(s);
             let mid = Uuid::new_v4().to_string();
             s.streaming_message_id = Some(mid.clone());
             s.stream_buf.clear();
             s.stream_thought.clear();
             s.stream_last_was_assistant = false;
             s.stream_attachments.clear();
+            s.journal_throttle.reset();
+            s.last_stall_emit = None;
             s.provider_retry_attempt = 0;
             s.provider_retry_aborted = false;
 
@@ -2352,42 +2477,26 @@ impl SessionManager {
                             "kind": "assistant"
                         }),
                     );
-                    if chunk.done {
-                        let mut guard = mgr.inner.lock();
-                        if let Some(s) = guard.as_mut() {
-                            s.stream_buf.push_str(&chunk.text);
-                            if !s.stream_buf.is_empty() {
-                                let mid = s
-                                    .streaming_message_id
-                                    .clone()
-                                    .unwrap_or_else(|| Uuid::new_v4().to_string());
-                                let _ = store::append_message(
-                                    &s.app_session_id,
-                                    ChatMessageStored {
-                                        id: mid,
-                                        role: "assistant".into(),
-                                        content: s.stream_buf.clone(),
-                                        thought: None,
-                                        created_at: chrono::Utc::now(),
-                                        is_error: false,
-                                        attachments: None,
-                                        marker: None,
-                                    },
-                                );
-                            }
+                    let mut guard = mgr.inner.lock();
+                    if let Some(s) = guard.as_mut() {
+                        SessionManager::touch_stream_progress_locked(s);
+                        s.stream_buf.push_str(&chunk.text);
+                        // I04: throttle mid-stream; force on terminal done.
+                        let para = is_paragraph_break(&chunk.text);
+                        SessionManager::maybe_flush_stream_journal(s, chunk.done, para);
+                        if chunk.done {
                             s.stream_buf.clear();
+                            s.journal_throttle.reset();
+                            s.last_stall_emit = None;
                             if s.fsm.state() == SessionState::Streaming {
                                 let _ = s.fsm.end_stream();
                                 s.streaming_message_id = None;
                             }
                         }
-                        drop(guard);
+                    }
+                    drop(guard);
+                    if chunk.done {
                         SessionManager::emit_state(&app_done, &mgr.snapshot());
-                    } else {
-                        let mut guard = mgr.inner.lock();
-                        if let Some(s) = guard.as_mut() {
-                            s.stream_buf.push_str(&chunk.text);
-                        }
                     }
                 },
             );
@@ -2431,6 +2540,8 @@ impl SessionManager {
             let partial = s.stream_buf.trim().to_string();
             // Journal a cancel marker so UI history is not left as user-only silence.
             if was_busy {
+                // I04: force-flush partial assistant before cancel marker.
+                Self::maybe_flush_stream_journal(s, true, false);
                 let mid = Uuid::new_v4().to_string();
                 let content = if partial.is_empty() {
                     "turn_cancelled|user_stop".to_string()
@@ -2468,6 +2579,9 @@ impl SessionManager {
             s.stream_buf.clear();
             s.stream_thought.clear();
             s.stream_last_was_assistant = false;
+            s.stream_attachments.clear();
+            s.journal_throttle.reset();
+            s.last_stall_emit = None;
             s.acp.clone()
         };
         if let Some(acp) = acp {
@@ -2754,6 +2868,8 @@ impl SessionManager {
                 if let Some(h) = s.mock_stream.take() {
                     h.request_stop();
                 }
+                // I04: flush any in-flight stream before dropping the process.
+                Self::maybe_flush_stream_journal(&mut s, true, false);
                 s.acp.take()
             } else {
                 None

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -152,6 +152,9 @@ pub struct AppSettings {
     /// Recycle idle agent processes after this many minutes (I03). Default 30.
     #[serde(default = "default_agent_idle_minutes")]
     pub agent_idle_minutes: u32,
+    /// Pure stream silence before cancel prompt (I06). Default 120 seconds.
+    #[serde(default = "default_stream_stall_seconds")]
+    pub stream_stall_seconds: u32,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -168,6 +171,10 @@ fn default_max_concurrent_agents() -> u32 {
 
 fn default_agent_idle_minutes() -> u32 {
     crate::process_limits::DEFAULT_AGENT_IDLE_MINUTES
+}
+
+fn default_stream_stall_seconds() -> u32 {
+    crate::stream_stall::DEFAULT_STREAM_STALL_SECONDS
 }
 
 impl Default for AppSettings {
@@ -190,6 +197,7 @@ impl Default for AppSettings {
             acp_server_addr: None,
             max_concurrent_agents: default_max_concurrent_agents(),
             agent_idle_minutes: default_agent_idle_minutes(),
+            stream_stall_seconds: default_stream_stall_seconds(),
         }
     }
 }
@@ -1137,5 +1145,6 @@ mod tests {
         assert_eq!(s.theme, "dark");
         assert_eq!(s.max_concurrent_agents, 3);
         assert_eq!(s.agent_idle_minutes, 30);
+        assert_eq!(s.stream_stall_seconds, 120);
     }
 }

--- a/src-tauri/src/stream_stall.rs
+++ b/src-tauri/src/stream_stall.rs
@@ -1,0 +1,145 @@
+//! Stream stall watchdog policy (I06).
+//!
+//! While a turn is streaming, pure silence (no stream chunks / tool activity)
+//! past a configurable timeout surfaces a cancel prompt. Long-running tools
+//! that still emit tool events must not count as stalled.
+
+use std::time::{Duration, Instant};
+
+/// Spec default: 120s without stream/tool progress.
+pub const DEFAULT_STREAM_STALL_SECONDS: u32 = 120;
+
+/// Hard clamp for settings (avoid 0 / absurd values).
+pub const MIN_STREAM_STALL_SECONDS: u32 = 15;
+pub const MAX_STREAM_STALL_SECONDS: u32 = 15 * 60;
+
+/// Normalize user/settings value for stream stall timeout (seconds).
+pub fn normalize_stream_stall_seconds(raw: u32) -> u32 {
+    raw.clamp(MIN_STREAM_STALL_SECONDS, MAX_STREAM_STALL_SECONDS)
+}
+
+/// Stall window from settings seconds.
+pub fn stall_duration(stall_seconds: u32) -> Duration {
+    Duration::from_secs(u64::from(normalize_stream_stall_seconds(stall_seconds)))
+}
+
+/// Instant when a turn with `last_progress` becomes eligible for stall UI.
+pub fn stall_deadline(last_progress: Instant, stall_seconds: u32) -> Instant {
+    last_progress + stall_duration(stall_seconds)
+}
+
+/// True when `now` is at or past the stall deadline.
+pub fn is_stream_stalled(last_progress: Instant, stall_seconds: u32, now: Instant) -> bool {
+    now >= stall_deadline(last_progress, stall_seconds)
+}
+
+/// Whether the host should emit another `session://stream_stall` notification.
+///
+/// Emits on first cross into stalled, then again every full stall window while
+/// silence continues (so “Keep waiting” can re-prompt later).
+pub fn should_emit_stall(
+    last_progress: Instant,
+    last_emit: Option<Instant>,
+    stall_seconds: u32,
+    now: Instant,
+) -> bool {
+    if !is_stream_stalled(last_progress, stall_seconds, now) {
+        return false;
+    }
+    match last_emit {
+        None => true,
+        Some(t) => is_stream_stalled(t, stall_seconds, now),
+    }
+}
+
+/// Human-readable stall message (English; UI maps via i18n).
+pub fn stream_stall_message(stall_seconds: u32) -> String {
+    let secs = normalize_stream_stall_seconds(stall_seconds);
+    format!(
+        "No stream or tool progress for about {secs}s. Cancel this turn or keep waiting."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_clamps() {
+        assert_eq!(normalize_stream_stall_seconds(0), MIN_STREAM_STALL_SECONDS);
+        assert_eq!(normalize_stream_stall_seconds(120), 120);
+        assert_eq!(
+            normalize_stream_stall_seconds(99_999),
+            MAX_STREAM_STALL_SECONDS
+        );
+    }
+
+    #[test]
+    fn not_stalled_before_deadline() {
+        let t0 = Instant::now();
+        let now = t0 + Duration::from_secs(60);
+        assert!(!is_stream_stalled(t0, 120, now));
+    }
+
+    #[test]
+    fn stalled_at_and_after_deadline() {
+        let t0 = Instant::now();
+        let at = t0 + Duration::from_secs(120);
+        let after = at + Duration::from_secs(1);
+        assert!(is_stream_stalled(t0, 120, at));
+        assert!(is_stream_stalled(t0, 120, after));
+    }
+
+    #[test]
+    fn tool_progress_resets_deadline() {
+        let t0 = Instant::now();
+        let tool = t0 + Duration::from_secs(100);
+        // 50s after last tool event with 120s window — not stalled.
+        assert!(!is_stream_stalled(tool, 120, tool + Duration::from_secs(50)));
+        assert!(is_stream_stalled(tool, 120, tool + Duration::from_secs(120)));
+    }
+
+    #[test]
+    fn emit_once_then_again_after_full_window() {
+        let t0 = Instant::now();
+        let stall_at = t0 + Duration::from_secs(120);
+        assert!(should_emit_stall(t0, None, 120, stall_at));
+        // Just after first emit: do not re-spam.
+        assert!(!should_emit_stall(
+            t0,
+            Some(stall_at),
+            120,
+            stall_at + Duration::from_secs(10)
+        ));
+        // Full window after last emit: re-prompt (Keep waiting).
+        assert!(should_emit_stall(
+            t0,
+            Some(stall_at),
+            120,
+            stall_at + Duration::from_secs(120)
+        ));
+    }
+
+    #[test]
+    fn no_emit_when_not_stalled() {
+        let t0 = Instant::now();
+        assert!(!should_emit_stall(
+            t0,
+            None,
+            120,
+            t0 + Duration::from_secs(30)
+        ));
+    }
+
+    #[test]
+    fn message_includes_seconds() {
+        let m = stream_stall_message(120);
+        assert!(m.contains("120"), "{m}");
+    }
+
+    #[test]
+    fn defaults_match_spec() {
+        assert_eq!(DEFAULT_STREAM_STALL_SECONDS, 120);
+        assert_eq!(MIN_STREAM_STALL_SECONDS, 15);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -587,6 +587,12 @@ export default function App() {
   const [acpServerAddr, setAcpServerAddr] = useState("");
   const [maxConcurrentAgents, setMaxConcurrentAgents] = useState(3);
   const [agentIdleMinutes, setAgentIdleMinutes] = useState(30);
+  const [streamStallSeconds, setStreamStallSeconds] = useState(120);
+  /** Host stream-stall prompt (I06); null when dismissed or not stalled. */
+  const [streamStall, setStreamStall] = useState<{
+    sessionId?: string;
+    stallSeconds: number;
+  } | null>(null);
   const [connecting, setConnecting] = useState(false);
   /** Live provider retry progress (session://retry); cleared on success/stop/error. */
   const [retryStatus, setRetryStatus] = useState<{
@@ -783,6 +789,12 @@ export default function App() {
           settings.agentIdleMinutes >= 1
           ? Math.min(1440, Math.round(settings.agentIdleMinutes))
           : 30,
+      );
+      setStreamStallSeconds(
+        typeof settings.streamStallSeconds === "number" &&
+          settings.streamStallSeconds >= 15
+          ? Math.min(900, Math.round(settings.streamStallSeconds))
+          : 120,
       );
       setCliInfo({
         found: cli.found,
@@ -1041,9 +1053,10 @@ export default function App() {
               s.sessionId === viewingSessionIdRef.current
             ) {
               setSession(s);
-              // Clear retry chip / turn timer when turn ends or errors out
+              // Clear retry chip / turn timer / stall banner when turn ends or errors out
               if (s.state !== "streaming" && s.state !== "awaiting_permission") {
                 setRetryStatus(null);
+                setStreamStall(null);
                 setTurnStartedAt(null);
                 // Ensure no assistant is left with streaming=true after the turn
                 // (missed done chunk) — otherwise the next send can bind to it.
@@ -1125,6 +1138,8 @@ export default function App() {
               chunk.sessionId === viewingSessionIdRef.current
             ) {
               setRetryStatus(null);
+              // Progress clears stall banner (I06).
+              setStreamStall(null);
             }
             patchSessionMessages(chunk.sessionId, (prev) => {
               const next = applyStreamChunk(prev, chunk);
@@ -1222,6 +1237,8 @@ export default function App() {
             });
             if (sid === viewingSessionIdRef.current) {
               setTurnStartedAt((t) => t ?? Date.now());
+              // Tool activity counts as progress — clear stall banner (I06).
+              setStreamStall(null);
             }
           }),
         );
@@ -1239,6 +1256,7 @@ export default function App() {
             patchSessionMessages(sid, (prev) => applyTurnMarker(prev, p));
             if (sid === viewingSessionIdRef.current) {
               setTurnStartedAt(null);
+              setStreamStall(null);
               if (p.marker === "turn_cancelled") {
                 setToast(tr("activity.cancelledToast"));
                 window.setTimeout(() => setToast(null), 2800);
@@ -1287,6 +1305,31 @@ export default function App() {
                   : "PROCESS_LIMIT",
               );
             }
+          }),
+        );
+        await track(
+          api.listen<{
+            sessionId?: string;
+            stallSeconds?: number;
+            code?: string;
+            message?: string;
+          }>("session://stream_stall", (p) => {
+            if (cancelled || !p) return;
+            // Only prompt for the viewed session (or unknown id).
+            if (
+              p.sessionId &&
+              p.sessionId !== viewingSessionIdRef.current
+            ) {
+              return;
+            }
+            const secs =
+              typeof p.stallSeconds === "number" && p.stallSeconds > 0
+                ? Math.round(p.stallSeconds)
+                : 120;
+            setStreamStall({
+              sessionId: p.sessionId,
+              stallSeconds: secs,
+            });
           }),
         );
         await track(
@@ -4034,6 +4077,7 @@ export default function App() {
     try {
       await api.sessionStop();
       setRetryStatus(null);
+      setStreamStall(null);
       setTurnStartedAt(null);
       setTurnStartedAt(null);
       const liveId = liveHostRef.current.sessionId;
@@ -5225,6 +5269,13 @@ export default function App() {
               api.settingsSet({ ...s, agentIdleMinutes: v }),
             );
           }}
+          streamStallSeconds={streamStallSeconds}
+          onStreamStallSeconds={(v) => {
+            setStreamStallSeconds(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, streamStallSeconds: v }),
+            );
+          }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
           versionFooter={tr("app.versionFooter")}
@@ -5970,6 +6021,36 @@ export default function App() {
               <span style={{ fontSize: 12, opacity: 0.85 }}>
                 {tr("automations.emptySession")}
               </span>
+            </div>
+          )}
+
+          {/* I06: pure stream silence — cancel or keep waiting */}
+          {streamStall && mainPane === "chat" && (
+            <div className="stall-banner" role="status">
+              <div className="stall-banner__summary">
+                {tr("agent.streamStallBanner", {
+                  seconds: String(streamStall.stallSeconds),
+                })}
+              </div>
+              <div className="stall-banner__actions">
+                <button
+                  type="button"
+                  className="btn btn--ghost stall-banner__btn"
+                  onClick={() => setStreamStall(null)}
+                >
+                  {tr("agent.streamStallKeepWaiting")}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn--primary stall-banner__btn stall-banner__btn--danger"
+                  onClick={() => {
+                    setStreamStall(null);
+                    void stop();
+                  }}
+                >
+                  {tr("agent.streamStallCancel")}
+                </button>
+              </div>
             </div>
           )}
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -103,6 +103,9 @@ export interface SettingsPageProps {
   /** Idle recycle minutes (I03). */
   agentIdleMinutes?: number;
   onAgentIdleMinutes?: (v: number) => void;
+  /** Stream stall silence timeout seconds (I06). */
+  streamStallSeconds?: number;
+  onStreamStallSeconds?: (v: number) => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -397,6 +400,8 @@ export function SettingsPage({
   onMaxConcurrentAgents,
   agentIdleMinutes = 30,
   onAgentIdleMinutes,
+  streamStallSeconds = 120,
+  onStreamStallSeconds,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -1342,6 +1347,31 @@ export function SettingsPage({
                   if (!Number.isFinite(n)) return;
                   onAgentIdleMinutes?.(
                     Math.min(1440, Math.max(1, Math.round(n))),
+                  );
+                }}
+              />
+            </div>
+            <div className="settings-row settings-row--stack">
+              <div className="settings-row__text">
+                <div className="settings-row__label">
+                  {t("settings.streamStallSeconds")}
+                </div>
+                <div className="settings-row__desc">
+                  {t("settings.streamStallSecondsDesc")}
+                </div>
+              </div>
+              <input
+                className="settings-input"
+                type="number"
+                min={15}
+                max={900}
+                step={15}
+                value={streamStallSeconds}
+                onChange={(e) => {
+                  const n = Number(e.target.value);
+                  if (!Number.isFinite(n)) return;
+                  onStreamStallSeconds?.(
+                    Math.min(900, Math.max(15, Math.round(n))),
                   );
                 }}
               />

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -388,10 +388,17 @@ const en = {
   "settings.agentIdleMinutes": "Idle recycle (minutes)",
   "settings.agentIdleMinutesDesc":
     "After this many minutes without activity, the agent process is recycled. Chat history is kept; the next message reconnects.",
+  "settings.streamStallSeconds": "Stream stall timeout (seconds)",
+  "settings.streamStallSecondsDesc":
+    "If a turn has no stream chunks or tool activity for this long, show a Cancel / Keep waiting prompt (default 120). Long-running tools that still emit events do not count as stalled.",
   "agent.idleRecycledToast":
     "Agent process recycled after idle — session kept; next message will reconnect.",
   "agent.processLimitToast":
     "Agent process limit reached. Stop another session or raise the limit in Settings → Runtime.",
+  "agent.streamStallBanner":
+    "No stream or tool progress for about {seconds}s. Cancel this turn or keep waiting.",
+  "agent.streamStallCancel": "Cancel turn",
+  "agent.streamStallKeepWaiting": "Keep waiting",
   "settings.permissionDeep": "Default permission",
   "settings.permissionDeepDesc":
     "Applied to new turns and remembered at the scope chosen above. YOLO auto-approves tools.",
@@ -1307,10 +1314,17 @@ const zh: Record<MessageKey, string> = {
   "settings.agentIdleMinutes": "闲置回收（分钟）",
   "settings.agentIdleMinutesDesc":
     "超过该分钟数无活动后回收 Agent 进程。对话记录保留，下次发送会自动重连。",
+  "settings.streamStallSeconds": "流式卡顿超时（秒）",
+  "settings.streamStallSecondsDesc":
+    "若一轮对话在该时间内无任何流式片段或工具活动，将提示「取消本轮 / 继续等待」（默认 120）。仍有工具事件的长任务不会误判为卡顿。",
   "agent.idleRecycledToast":
     "Agent 进程因闲置已回收 — 会话仍在；下次发送将重新连接。",
   "agent.processLimitToast":
     "已达 Agent 进程上限。请先停止其他会话，或在设置 → 运行环境中提高上限。",
+  "agent.streamStallBanner":
+    "约 {seconds} 秒无流式片段或工具活动。可取消本轮或继续等待。",
+  "agent.streamStallCancel": "取消本轮",
+  "agent.streamStallKeepWaiting": "继续等待",
   "settings.permissionDeep": "默认权限",
   "settings.permissionDeepDesc":
     "对新一轮对话生效，并按上方选择的范围记忆。YOLO 会自动批准工具调用。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -366,10 +366,17 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.agentIdleMinutes": "閒置回收（分鐘）",
   "settings.agentIdleMinutesDesc":
     "超過該分鐘數無活動後回收 Agent 行程。對話紀錄保留，下次傳送會自動重連。",
+  "settings.streamStallSeconds": "串流停滯逾時（秒）",
+  "settings.streamStallSecondsDesc":
+    "若一輪對話在該時間內無任何串流片段或工具活動，將提示「取消本輪 / 繼續等待」（預設 120）。仍有工具事件的長任務不會誤判為停滯。",
   "agent.idleRecycledToast":
     "Agent 行程因閒置已回收 — 工作階段仍在；下次傳送將重新連線。",
   "agent.processLimitToast":
     "已達 Agent 行程上限。請先停止其他工作階段，或在設定 → 執行環境中提高上限。",
+  "agent.streamStallBanner":
+    "約 {seconds} 秒無串流片段或工具活動。可取消本輪或繼續等待。",
+  "agent.streamStallCancel": "取消本輪",
+  "agent.streamStallKeepWaiting": "繼續等待",
   "settings.permissionDeep": "預設權限",
   "settings.permissionDeepDesc":
     "對新一輪對話生效，並依上方選擇的範圍記憶。YOLO 會自動核准工具呼叫。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -551,6 +551,8 @@ export interface AppSettings {
   maxConcurrentAgents?: number;
   /** Recycle idle agent processes after N minutes (default 30). */
   agentIdleMinutes?: number;
+  /** Pure stream silence before cancel prompt, seconds (default 120). */
+  streamStallSeconds?: number;
 }
 
 export interface AvailableModel {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4668,6 +4668,49 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   line-height: 1.5;
 }
 
+/* Stream stall banner (I06) — warning surface with cancel / keep waiting */
+.stall-banner {
+  margin: 0 var(--space-5) var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--warning-muted);
+  border: 1px solid color-mix(in srgb, var(--warning) 45%, transparent);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 12px;
+}
+
+.stall-banner__summary {
+  flex: 1 1 220px;
+  color: var(--text-primary);
+  min-width: 0;
+}
+
+.stall-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.stall-banner__btn {
+  height: 28px;
+  font-size: 12px;
+}
+
+.stall-banner__btn--danger {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: #fff;
+}
+
+.stall-banner__btn--danger:hover {
+  filter: brightness(1.05);
+}
+
 /* Error banner — compact summary; full dump behind Details */
 .error-banner {
   margin: 0 var(--space-5) var(--space-2);


### PR DESCRIPTION
## Summary

Implements two P0 process/performance items from the capability matrix:

### I06 — Stream stall cancel
- Host tracks last **stream chunk / tool activity** timestamp while a turn is `Streaming`.
- After pure silence for configurable **`streamStallSeconds`** (default **120**, Settings → CLI / Runtime, clamp 15–900), emits `session://stream_stall`.
- UI banner: **Cancel turn** (existing `session_stop`) / **Keep waiting** (dismiss; re-prompts after another full window if still silent).
- Tool events count as progress — long tools do not false-positive.
- Permission / plan / ask-user waits do **not** trigger the stall prompt.

### I04 — Journal write throttle
- Mid-stream assistant journal upserts go through `JournalWriteThrottle` (≥**500ms**, or paragraph break, or **force**).
- Force flush on: turn complete, stop, process exit, disconnect.
- Pure helpers unit-tested in `journal_throttle.rs` / `stream_stall.rs`.

## i18n
- Honest en / zh / zh-TW strings for settings + banner actions.

## Test plan
- [x] `cargo test --lib` (133 passed, including journal_throttle + stream_stall)
- [x] `pnpm test` (251 passed)
- [x] `pnpm typecheck`
- [ ] Manual: start a stream, kill network / hang agent → banner after ~timeout → Cancel stops turn
- [ ] Manual: long tool with status updates → no stall banner
- [ ] Manual: Settings → Runtime change stall seconds and verify reload

## Notes
- Event: `session://stream_stall` `{ sessionId, stallSeconds, code: "STREAM_STALL", message }`
- Matrix docs + CHANGELOG Unreleased updated.