### PR TITLE
feat: enable MCP servers and inject them into agent sessions

### DIFF
--- a/docs/SPIKE-ACP.md
+++ b/docs/SPIKE-ACP.md
@@ -9,8 +9,9 @@
 ```text
 → initialize { protocolVersion: 1, clientInfo, capabilities }
 ← result { protocolVersion: 1, agentCapabilities, authMethods, _meta.agentVersion }
-→ session/new { cwd, mcpServers: [] }
-  or session/load { sessionId, cwd, mcpServers: [] }  // App: resume prior agentSessionId when possible
+→ session/new { cwd, mcpServers: [/* enabled MCP from Extensions prefs + grok mcp list */] }
+  or session/load { sessionId, cwd, mcpServers: [...] }  // App: resume prior agentSessionId when possible
+  // Empty only when no servers discovered or all disabled in Settings → Extensions
 ← result { sessionId, models }
 → session/prompt { sessionId, prompt: [{type:"text", text}] }
   // App: if load failed and journal has turns, first prompt may be prefixed with history bootstrap

--- a/docs/llm-wiki/slash-composer.md
+++ b/docs/llm-wiki/slash-composer.md
@@ -48,14 +48,23 @@ Full management surface: **Settings → Extensions** (`#/settings/extensions`).
 
 | Surface | Role |
 |---------|------|
-| Settings → Extensions | Skills list + MCP servers (name, source/transport, path/target, vendor, compatibility); refresh; project cwd when a workbench project is active |
+| Settings → Extensions | Skills + MCP list with **per-item enable toggles**, bulk **Enable all**, refresh; project cwd when a workbench project is active |
 | `/mcp` slash | Quick `McpStatusModal`; **Manage in Settings** opens Extensions |
-| Composer `+` / slash skills | Invocable skills only (chips); loaded via `skills_list` |
+| Composer `+` / slash skills | Invocable **and enabled** skills only (chips); loaded via `skills_list` |
 
-Host commands: `skills_list`, `inspect_mcp` (both optional `projectPath` → `grok inspect --json` cwd).  
+### Enable + inject (L03)
+
+- **Prefs:** `{app_data}/extensions.json` — `mcp` / `skills` name → `bool`. Missing name = **enabled** (opt-out).
+- **UI:** Toggle persists immediately (`extensions_set_mcp` / `extensions_set_skill`). Bulk enable via `extensions_enable_all_*`.
+- **MCP inject (session open):** Host builds ACP `mcpServers` from `grok mcp list --json` (full command/args/env or url) filtered by prefs, and passes them on `session/new` / `session/load` (see `acp_client::open_session`).
+- **Dual write:** Independent mode also mirrors `enabled` under agent-home `config.toml` (`[mcp_servers.<name>]`). Shared mode updates `~/.grok/config.toml` enabled flags on user toggle.
+- **Live agent:** MCP pref change → `SessionManager::apply_extensions_mcp_change` soft-respawns so the next connect re-injects.
+- **Skills:** App filter only (slash palette / chips). Agent still discovers skill files on disk.
+
+Host commands: `skills_list`, `inspect_mcp`, `extensions_get`, `extensions_set_mcp`, `extensions_set_skill`, `extensions_enable_all_mcp`, `extensions_enable_all_skills`.  
 CLI missing → actionable error with link to **Settings → CLI / Runtime**.  
 Reveal skill paths / agent-home when paths are available (`path_reveal`).  
-Pure helpers: `src/lib/extensionsUi.ts`. UI: `src/components/ExtensionsPanel.tsx`.
+Pure helpers: `src/lib/extensionsUi.ts` (+ enable-set merge/filter). Host: `src-tauri/src/extensions.rs`. UI: `src/components/ExtensionsPanel.tsx`.
 
 ## Acceptance (Wave A)
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "grok-app"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -1114,6 +1114,9 @@ impl AcpClient {
     /// Used for cold connect after `initialize` and for warm process reuse when
     /// switching App sessions without respawning CLI.
     /// Returns `(session_id, resumed)`.
+    ///
+    /// Injects **enabled** MCP servers (App Extensions prefs + `grok mcp list`)
+    /// into `mcpServers` so independent GROK_HOME and shared mode both see tools.
     pub async fn open_session(
         &self,
         resume_session_id: Option<&str>,
@@ -1126,6 +1129,16 @@ impl AcpClient {
             ));
         }
 
+        // Build ACP mcpServers off the async runtime (CLI list / file IO).
+        let project_cwd = cwd.clone();
+        let mcp_servers = tauri::async_runtime::spawn_blocking(move || {
+            crate::extensions::build_session_mcp_servers(Some(project_cwd.as_str()))
+        })
+        .await
+        .unwrap_or_else(|_| serde_json::json!([]));
+        let mcp_count = mcp_servers.as_array().map(|a| a.len()).unwrap_or(0);
+        info!("acp session open injecting mcpServers count={mcp_count}");
+
         // Prefer resuming the previous agent session for full native context.
         if let Some(rid) = resume_session_id.map(str::trim).filter(|s| !s.is_empty()) {
             match self
@@ -1134,7 +1147,7 @@ impl AcpClient {
                     json!({
                         "sessionId": rid,
                         "cwd": cwd,
-                        "mcpServers": []
+                        "mcpServers": mcp_servers.clone()
                     }),
                     HANDSHAKE_TIMEOUT_SECS,
                 )
@@ -1170,7 +1183,7 @@ impl AcpClient {
                 "session/new",
                 json!({
                     "cwd": cwd,
-                    "mcpServers": []
+                    "mcpServers": mcp_servers
                 }),
                 HANDSHAKE_TIMEOUT_SECS,
             )

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1449,6 +1449,7 @@ fn parse_mcp_servers(v: &serde_json::Value) -> Vec<McpDto> {
 
 /// List invocable skills from `grok inspect --json`.
 /// Always returns Ok; on CLI missing / timeout, `skills` is empty and `error` is set.
+/// Each skill includes `enabled` from App Extensions prefs (default true).
 #[tauri::command]
 pub async fn skills_list(project_path: Option<String>) -> Result<serde_json::Value, String> {
     let path = project_path.clone();
@@ -1459,6 +1460,7 @@ pub async fn skills_list(project_path: Option<String>) -> Result<serde_json::Val
     .map_err(|e| e.to_string())?;
 
     let skills = parsed.as_ref().map(parse_skills).unwrap_or_default();
+    let skills = attach_skill_enabled(skills);
     let mut out = serde_json::json!({ "skills": skills });
     if let Some(err) = error {
         out["error"] = serde_json::Value::String(err);
@@ -1468,6 +1470,7 @@ pub async fn skills_list(project_path: Option<String>) -> Result<serde_json::Val
 
 /// List MCP servers from `grok inspect --json`.
 /// Always returns Ok; on CLI missing / timeout, `servers` is empty and `error` is set.
+/// Each server includes `enabled` from App Extensions prefs (default true).
 #[tauri::command]
 pub async fn inspect_mcp(project_path: Option<String>) -> Result<serde_json::Value, String> {
     let path = project_path.clone();
@@ -1477,12 +1480,110 @@ pub async fn inspect_mcp(project_path: Option<String>) -> Result<serde_json::Val
     .await
     .map_err(|e| e.to_string())?;
 
-    let servers = parsed.as_ref().map(parse_mcp_servers).unwrap_or_default();
-    let mut out = serde_json::json!({ "servers": servers });
+    let mut servers = parsed.as_ref().map(parse_mcp_servers).unwrap_or_default();
+    let prefs = crate::extensions::load_prefs();
+    // Enrich with enable state for UI toggles.
+    let mut server_json = Vec::with_capacity(servers.len());
+    for s in servers.drain(..) {
+        let enabled = crate::extensions::is_enabled(&prefs.mcp, &s.name);
+        server_json.push(serde_json::json!({
+            "name": s.name,
+            "transport": s.transport,
+            "target": s.target,
+            "vendor": s.vendor,
+            "compatibilityStatus": s.compatibility_status,
+            "enabled": enabled,
+        }));
+    }
+    let mut out = serde_json::json!({ "servers": server_json });
     if let Some(err) = error {
         out["error"] = serde_json::Value::String(err);
     }
     Ok(out)
+}
+
+/// List skills from `grok inspect --json`, each with App `enabled` (default true).
+/// (skills_list already exists; this keeps enable flags on the existing shape.)
+fn attach_skill_enabled(skills: Vec<SkillDto>) -> Vec<serde_json::Value> {
+    let prefs = crate::extensions::load_prefs();
+    skills
+        .into_iter()
+        .map(|s| {
+            let enabled = crate::extensions::is_enabled(&prefs.skills, &s.name);
+            serde_json::json!({
+                "name": s.name,
+                "description": s.description,
+                "source": s.source,
+                "path": s.path,
+                "userInvocable": s.user_invocable,
+                "enabled": enabled,
+            })
+        })
+        .collect()
+}
+
+/// Current Extensions enable prefs (`extensions.json`).
+#[tauri::command]
+pub async fn extensions_get() -> Result<crate::extensions::ExtensionsPrefs, String> {
+    Ok(crate::extensions::load_prefs())
+}
+
+/// Toggle one MCP server; persists prefs, syncs agent-home/config, soft-respawns.
+#[tauri::command]
+pub async fn extensions_set_mcp(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    name: String,
+    enabled: bool,
+) -> Result<crate::extensions::ExtensionsPrefs, String> {
+    let prefs = tauri::async_runtime::spawn_blocking(move || {
+        crate::extensions::set_mcp_enabled(&name, enabled)
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+    mgr.apply_extensions_mcp_change(&app).await;
+    Ok(prefs)
+}
+
+/// Toggle one skill (App filter for slash/composer); persists immediately.
+#[tauri::command]
+pub async fn extensions_set_skill(
+    name: String,
+    enabled: bool,
+) -> Result<crate::extensions::ExtensionsPrefs, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::extensions::set_skill_enabled(&name, enabled)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Bulk-enable all listed MCP servers; soft-respawns when a live agent exists.
+#[tauri::command]
+pub async fn extensions_enable_all_mcp(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    names: Vec<String>,
+) -> Result<crate::extensions::ExtensionsPrefs, String> {
+    let prefs = tauri::async_runtime::spawn_blocking(move || {
+        crate::extensions::enable_all_mcp(&names)
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+    mgr.apply_extensions_mcp_change(&app).await;
+    Ok(prefs)
+}
+
+/// Bulk-enable all listed skills.
+#[tauri::command]
+pub async fn extensions_enable_all_skills(
+    names: Vec<String>,
+) -> Result<crate::extensions::ExtensionsPrefs, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::extensions::enable_all_skills(&names)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]

--- a/src-tauri/src/extensions.rs
+++ b/src-tauri/src/extensions.rs
@@ -1,0 +1,856 @@
+//! MCP / Skills enable prefs + ACP `mcpServers` injection.
+//!
+//! Prefs live in `{app_data}/extensions.json` (which names are enabled).
+//! On session open the Host injects **enabled** MCP servers into ACP
+//! `session/new` / `session/load`. Independent mode also mirrors `enabled`
+//! flags into agent-home `config.toml`.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::paths::{
+    agent_config_toml, ensure_app_dirs, extensions_file, resolve_agent_grok_home,
+};
+use crate::store;
+
+const MCP_LIST_TIMEOUT_SECS: u64 = 8;
+const MCP_CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// App-side enable prefs for MCP servers and skills.
+/// Missing name defaults to **enabled** (opt-out).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtensionsPrefs {
+    /// MCP server name → enabled.
+    #[serde(default)]
+    pub mcp: HashMap<String, bool>,
+    /// Skill name → enabled (filters slash palette; agent still loads skill files).
+    #[serde(default)]
+    pub skills: HashMap<String, bool>,
+}
+
+/// Full MCP server definition (from `grok mcp list --json` or inspect + config).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerDef {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<HashMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub headers: Option<HashMap<String, String>>,
+    /// `stdio` | `http` | `sse` (optional; inferred from fields).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    /// CLI/config `enabled` flag (informational; App prefs override).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+// ── Enable-set pure helpers ──────────────────────────────────────────────────
+
+/// Missing key → enabled (default-on / opt-out).
+pub fn is_enabled(map: &HashMap<String, bool>, name: &str) -> bool {
+    let key = name.trim();
+    if key.is_empty() {
+        return false;
+    }
+    map.get(key).copied().unwrap_or(true)
+}
+
+/// Insert or update a single enable flag (normalized name).
+pub fn set_enabled(map: &mut HashMap<String, bool>, name: &str, enabled: bool) {
+    let key = name.trim();
+    if key.is_empty() {
+        return;
+    }
+    map.insert(key.to_string(), enabled);
+}
+
+/// Mark every name in `names` as enabled.
+pub fn enable_all(map: &mut HashMap<String, bool>, names: &[String]) {
+    for n in names {
+        set_enabled(map, n, true);
+    }
+}
+
+/// Merge overlay flags into base (overlay wins). Pure helper for tests.
+pub fn merge_enable_maps(
+    base: &HashMap<String, bool>,
+    overlay: &HashMap<String, bool>,
+) -> HashMap<String, bool> {
+    let mut out = base.clone();
+    for (k, v) in overlay {
+        let key = k.trim();
+        if !key.is_empty() {
+            out.insert(key.to_string(), *v);
+        }
+    }
+    out
+}
+
+/// Filter server defs by App prefs (default-on).
+pub fn filter_enabled_mcp<'a>(
+    defs: &'a [McpServerDef],
+    prefs: &ExtensionsPrefs,
+) -> Vec<&'a McpServerDef> {
+    defs.iter()
+        .filter(|d| is_enabled(&prefs.mcp, &d.name))
+        .collect()
+}
+
+/// Filter skill names by App prefs (default-on).
+pub fn filter_enabled_skill_names(names: &[String], prefs: &ExtensionsPrefs) -> Vec<String> {
+    names
+        .iter()
+        .filter(|n| is_enabled(&prefs.skills, n))
+        .cloned()
+        .collect()
+}
+
+// ── ACP mapping ──────────────────────────────────────────────────────────────
+
+/// Map one server definition to an ACP `mcpServers[]` entry.
+/// Returns `None` when the def cannot form a valid transport payload.
+pub fn mcp_def_to_acp(def: &McpServerDef) -> Option<Value> {
+    let name = def.name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    let transport = def
+        .transport
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_ascii_lowercase());
+
+    // Prefer explicit HTTP/SSE when url is present or transport says so.
+    if let Some(url) = def.url.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        let ty = match transport.as_deref() {
+            Some("sse") => "sse",
+            _ => "http",
+        };
+        let headers = env_map_to_named_array(def.headers.as_ref());
+        return Some(json!({
+            "type": ty,
+            "name": name,
+            "url": url,
+            "headers": headers,
+        }));
+    }
+
+    // Stdio: command + args (+ env).
+    let command = def
+        .command
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    let args = def.args.clone().unwrap_or_default();
+    let env = env_map_to_named_array(def.env.as_ref());
+    Some(json!({
+        "name": name,
+        "command": command,
+        "args": args,
+        "env": env,
+    }))
+}
+
+fn env_map_to_named_array(map: Option<&HashMap<String, String>>) -> Vec<Value> {
+    let Some(m) = map else {
+        return Vec::new();
+    };
+    let mut keys: Vec<&String> = m.keys().collect();
+    keys.sort();
+    keys.into_iter()
+        .map(|k| {
+            json!({
+                "name": k,
+                "value": m.get(k).map(|s| s.as_str()).unwrap_or(""),
+            })
+        })
+        .collect()
+}
+
+/// Build the ACP `mcpServers` JSON array from defs + prefs.
+pub fn build_acp_mcp_servers(defs: &[McpServerDef], prefs: &ExtensionsPrefs) -> Value {
+    let arr: Vec<Value> = filter_enabled_mcp(defs, prefs)
+        .into_iter()
+        .filter_map(mcp_def_to_acp)
+        .collect();
+    Value::Array(arr)
+}
+
+// ── Persistence ──────────────────────────────────────────────────────────────
+
+pub fn load_prefs() -> ExtensionsPrefs {
+    let path = extensions_file();
+    match fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str(&raw).unwrap_or_default(),
+        Err(_) => ExtensionsPrefs::default(),
+    }
+}
+
+pub fn save_prefs(prefs: &ExtensionsPrefs) -> Result<(), String> {
+    let _ = ensure_app_dirs();
+    let path = extensions_file();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let raw = serde_json::to_string_pretty(prefs).map_err(|e| e.to_string())?;
+    fs::write(&path, raw).map_err(|e| e.to_string())
+}
+
+// ── MCP definition discovery ─────────────────────────────────────────────────
+
+struct McpCache {
+    at: Instant,
+    /// Config path used for mtime invalidation.
+    config_path: PathBuf,
+    config_mtime_ms: u128,
+    defs: Vec<McpServerDef>,
+}
+
+static MCP_CACHE: Mutex<Option<McpCache>> = Mutex::new(None);
+
+fn file_mtime_ms(path: &Path) -> u128 {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+/// List configured MCP servers (CLI `grok mcp list --json` preferred).
+/// `project_cwd` scopes project-level servers when present.
+pub fn list_mcp_server_defs(project_cwd: Option<&str>) -> Vec<McpServerDef> {
+    let settings = store::load_settings();
+    let config_path = resolve_agent_grok_home(&settings.session_data_mode).join("config.toml");
+    // Also watch user ~/.grok/config.toml — list often sources from there.
+    let user_config = crate::process_util::user_home().join(".grok").join("config.toml");
+    let mtime = file_mtime_ms(&config_path).max(file_mtime_ms(&user_config));
+
+    {
+        let guard = MCP_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(ref c) = *guard {
+            if c.at.elapsed() < MCP_CACHE_TTL
+                && c.config_mtime_ms == mtime
+                && c.config_path == config_path
+            {
+                return c.defs.clone();
+            }
+        }
+    }
+
+    let defs = fetch_mcp_list_json(project_cwd).unwrap_or_else(|| {
+        // Fallback: parse inspect + lightweight config hints.
+        fetch_mcp_from_inspect(project_cwd)
+    });
+
+    if let Ok(mut guard) = MCP_CACHE.lock() {
+        *guard = Some(McpCache {
+            at: Instant::now(),
+            config_path,
+            config_mtime_ms: mtime,
+            defs: defs.clone(),
+        });
+    }
+    defs
+}
+
+/// Invalidate in-process MCP list cache (after toggle / config write).
+pub fn invalidate_mcp_cache() {
+    if let Ok(mut guard) = MCP_CACHE.lock() {
+        *guard = None;
+    }
+}
+
+fn fetch_mcp_list_json(project_cwd: Option<&str>) -> Option<Vec<McpServerDef>> {
+    let settings = store::load_settings();
+    let probe = crate::cli_probe::probe_cli(settings.manual_cli_path.as_deref());
+    let cli_path = probe.path.filter(|_| probe.found)?;
+
+    let cwd = project_cwd
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut cmd = Command::new(&cli_path);
+        cmd.arg("mcp").arg("list").arg("--json");
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
+        }
+        crate::process_util::apply_no_window_std(&mut cmd);
+        if let Some(path_env) = crate::process_util::enriched_path_env() {
+            cmd.env("PATH", path_env);
+        }
+        let _ = tx.send(cmd.output());
+    });
+
+    let output = rx
+        .recv_timeout(Duration::from_secs(MCP_LIST_TIMEOUT_SECS))
+        .ok()?
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_mcp_list_json(stdout.trim())
+}
+
+/// Parse `grok mcp list --json` payload into server defs.
+pub fn parse_mcp_list_json(raw: &str) -> Option<Vec<McpServerDef>> {
+    let v: Value = serde_json::from_str(raw).ok()?;
+    let arr = if let Some(a) = v.as_array() {
+        a.clone()
+    } else if let Some(a) = v.get("servers").and_then(|x| x.as_array()) {
+        a.clone()
+    } else if let Some(a) = v.get("mcpServers").and_then(|x| x.as_array()) {
+        a.clone()
+    } else {
+        return None;
+    };
+
+    let mut out = Vec::with_capacity(arr.len());
+    for item in arr {
+        let name = item
+            .get("name")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let command = item
+            .get("command")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string());
+        let args = item.get("args").and_then(|x| {
+            x.as_array().map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect::<Vec<_>>()
+            })
+        });
+        let env = parse_string_map(item.get("env"));
+        let url = item
+            .get("url")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string());
+        let headers = parse_string_map(item.get("headers"));
+        let transport = item
+            .get("transport")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                if url.is_some() {
+                    Some("http".into())
+                } else if command.is_some() {
+                    Some("stdio".into())
+                } else {
+                    None
+                }
+            });
+        let enabled = item.get("enabled").and_then(|x| x.as_bool());
+        let scope = item
+            .get("scope")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string());
+        out.push(McpServerDef {
+            name,
+            command,
+            args,
+            env,
+            url,
+            headers,
+            transport,
+            enabled,
+            scope,
+        });
+    }
+    Some(out)
+}
+
+fn parse_string_map(v: Option<&Value>) -> Option<HashMap<String, String>> {
+    let obj = v?.as_object()?;
+    let mut m = HashMap::new();
+    for (k, val) in obj {
+        if let Some(s) = val.as_str() {
+            m.insert(k.clone(), s.to_string());
+        } else if !val.is_null() {
+            m.insert(k.clone(), val.to_string());
+        }
+    }
+    if m.is_empty() {
+        None
+    } else {
+        Some(m)
+    }
+}
+
+fn fetch_mcp_from_inspect(project_cwd: Option<&str>) -> Vec<McpServerDef> {
+    // Reuse inspect path via CLI without pulling private helpers — light spawn.
+    let settings = store::load_settings();
+    let probe = crate::cli_probe::probe_cli(settings.manual_cli_path.as_deref());
+    let Some(cli_path) = probe.path.filter(|_| probe.found) else {
+        return Vec::new();
+    };
+    let cwd = project_cwd
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from);
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut cmd = Command::new(&cli_path);
+        cmd.arg("inspect").arg("--json");
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
+        }
+        crate::process_util::apply_no_window_std(&mut cmd);
+        if let Some(path_env) = crate::process_util::enriched_path_env() {
+            cmd.env("PATH", path_env);
+        }
+        let _ = tx.send(cmd.output());
+    });
+    let Ok(Ok(output)) = rx.recv_timeout(Duration::from_secs(MCP_LIST_TIMEOUT_SECS)) else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let Ok(v) = serde_json::from_str::<Value>(stdout.trim()) else {
+        return Vec::new();
+    };
+    let Some(arr) = v
+        .get("mcpServers")
+        .or_else(|| v.get("mcp"))
+        .and_then(|x| x.as_array())
+    else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for item in arr {
+        let name = item
+            .get("name")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let transport = item
+            .get("transport")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_ascii_lowercase());
+        let target = item
+            .get("target")
+            .and_then(|x| x.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let mut command = None;
+        let mut url = None;
+        match transport.as_deref() {
+            Some("http") | Some("sse") => url = target.clone(),
+            _ => {
+                if let Some(ref t) = target {
+                    if t.starts_with("http://") || t.starts_with("https://") {
+                        url = Some(t.clone());
+                    } else {
+                        command = Some(t.clone());
+                    }
+                }
+            }
+        }
+        out.push(McpServerDef {
+            name,
+            command,
+            args: None,
+            env: None,
+            url,
+            headers: None,
+            transport,
+            enabled: None,
+            scope: None,
+        });
+    }
+    out
+}
+
+/// Build ACP mcpServers for the current prefs + discovered defs.
+pub fn build_session_mcp_servers(project_cwd: Option<&str>) -> Value {
+    let prefs = load_prefs();
+    let defs = list_mcp_server_defs(project_cwd);
+    build_acp_mcp_servers(&defs, &prefs)
+}
+
+// ── Config.toml enabled sync ─────────────────────────────────────────────────
+
+/// Upsert `enabled = bool` under `[mcp_servers.<name>]` in TOML text.
+pub fn set_mcp_enabled_in_toml(text: &str, name: &str, enabled: bool) -> String {
+    let name = name.trim();
+    if name.is_empty() {
+        return text.to_string();
+    }
+    let header = format!("[mcp_servers.{name}]");
+    let line_val = format!("enabled = {enabled}");
+    let mut lines: Vec<String> = text.lines().map(|s| s.to_string()).collect();
+    let mut in_table = false;
+    let mut table_start: Option<usize> = None;
+    for i in 0..lines.len() {
+        let trimmed = lines[i].trim().to_string();
+        if trimmed.starts_with('[') {
+            if trimmed == header {
+                in_table = true;
+                table_start = Some(i);
+            } else if in_table {
+                // Leaving our table without finding enabled — insert before next header.
+                lines.insert(i, line_val);
+                return lines.join("\n") + trailing_nl(text);
+            } else {
+                in_table = false;
+            }
+            continue;
+        }
+        if in_table {
+            // Match bare `enabled = …` (not nested env tables).
+            let key = trimmed.split('=').next().map(str::trim).unwrap_or("");
+            if key == "enabled" {
+                lines[i] = line_val;
+                return lines.join("\n") + trailing_nl(text);
+            }
+        }
+    }
+    if let Some(start) = table_start {
+        lines.insert(start + 1, line_val);
+        return lines.join("\n") + trailing_nl(text);
+    }
+    // Section missing — append a minimal table so independent agent-home can gate it.
+    let block = format!("\n{header}\n{line_val}\n");
+    let base = text.trim_end();
+    if base.is_empty() {
+        format!("{header}\n{line_val}\n")
+    } else {
+        format!("{base}{block}")
+    }
+}
+
+fn trailing_nl(text: &str) -> &'static str {
+    if text.ends_with('\n') || text.is_empty() {
+        ""
+    } else {
+        "\n"
+    }
+}
+
+/// Write App enable prefs into the agent GROK_HOME config.toml `enabled` flags.
+/// Independent mode: agent-home. Shared mode: user `~/.grok/config.toml` (user-initiated).
+pub fn sync_mcp_enabled_to_agent_config(
+    session_data_mode: &str,
+    prefs: &ExtensionsPrefs,
+) -> Result<(), String> {
+    let home = resolve_agent_grok_home(session_data_mode);
+    let path = if session_data_mode == "shared" {
+        home.join("config.toml")
+    } else {
+        let _ = ensure_app_dirs();
+        agent_config_toml()
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    let mut next = existing.clone();
+    // Apply every known pref key.
+    for (name, enabled) in &prefs.mcp {
+        next = set_mcp_enabled_in_toml(&next, name, *enabled);
+    }
+    if next != existing {
+        fs::write(&path, next).map_err(|e| e.to_string())?;
+        tracing::info!(
+            "extensions: synced mcp enabled flags → {}",
+            path.display()
+        );
+    }
+    invalidate_mcp_cache();
+    Ok(())
+}
+
+/// Apply a single MCP enable toggle: prefs + agent config + return updated prefs.
+pub fn set_mcp_enabled(name: &str, enabled: bool) -> Result<ExtensionsPrefs, String> {
+    let mut prefs = load_prefs();
+    set_enabled(&mut prefs.mcp, name, enabled);
+    save_prefs(&prefs)?;
+    let settings = store::load_settings();
+    let _ = sync_mcp_enabled_to_agent_config(&settings.session_data_mode, &prefs);
+    Ok(prefs)
+}
+
+/// Apply a single skill enable toggle (App filter only).
+pub fn set_skill_enabled(name: &str, enabled: bool) -> Result<ExtensionsPrefs, String> {
+    let mut prefs = load_prefs();
+    set_enabled(&mut prefs.skills, name, enabled);
+    save_prefs(&prefs)?;
+    Ok(prefs)
+}
+
+/// Enable every known MCP server name.
+pub fn enable_all_mcp(names: &[String]) -> Result<ExtensionsPrefs, String> {
+    let mut prefs = load_prefs();
+    enable_all(&mut prefs.mcp, names);
+    save_prefs(&prefs)?;
+    let settings = store::load_settings();
+    let _ = sync_mcp_enabled_to_agent_config(&settings.session_data_mode, &prefs);
+    Ok(prefs)
+}
+
+/// Enable every known skill name.
+pub fn enable_all_skills(names: &[String]) -> Result<ExtensionsPrefs, String> {
+    let mut prefs = load_prefs();
+    enable_all(&mut prefs.skills, names);
+    save_prefs(&prefs)?;
+    Ok(prefs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_on_when_missing() {
+        let m = HashMap::new();
+        assert!(is_enabled(&m, "foo"));
+        assert!(!is_enabled(&m, ""));
+        let mut m2 = HashMap::new();
+        set_enabled(&mut m2, "foo", false);
+        assert!(!is_enabled(&m2, "foo"));
+        set_enabled(&mut m2, "foo", true);
+        assert!(is_enabled(&m2, "foo"));
+    }
+
+    #[test]
+    fn merge_and_enable_all() {
+        let mut base = HashMap::new();
+        set_enabled(&mut base, "a", false);
+        set_enabled(&mut base, "b", true);
+        let mut over = HashMap::new();
+        set_enabled(&mut over, "a", true);
+        set_enabled(&mut over, "c", false);
+        let m = merge_enable_maps(&base, &over);
+        assert!(is_enabled(&m, "a"));
+        assert!(is_enabled(&m, "b"));
+        assert!(!is_enabled(&m, "c"));
+        assert!(is_enabled(&m, "unknown"));
+
+        let mut all = HashMap::new();
+        set_enabled(&mut all, "x", false);
+        enable_all(&mut all, &["x".into(), "y".into()]);
+        assert!(is_enabled(&all, "x"));
+        assert!(is_enabled(&all, "y"));
+    }
+
+    #[test]
+    fn filter_enabled_mcp_respects_prefs() {
+        let defs = vec![
+            McpServerDef {
+                name: "keep".into(),
+                command: Some("npx".into()),
+                args: Some(vec!["-y".into(), "pkg".into()]),
+                env: None,
+                url: None,
+                headers: None,
+                transport: Some("stdio".into()),
+                enabled: Some(true),
+                scope: None,
+            },
+            McpServerDef {
+                name: "drop".into(),
+                command: None,
+                args: None,
+                env: None,
+                url: Some("https://example.com/mcp".into()),
+                headers: None,
+                transport: Some("http".into()),
+                enabled: Some(true),
+                scope: None,
+            },
+        ];
+        let mut prefs = ExtensionsPrefs::default();
+        set_enabled(&mut prefs.mcp, "drop", false);
+        let filtered = filter_enabled_mcp(&defs, &prefs);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "keep");
+    }
+
+    #[test]
+    fn acp_stdio_and_http_mapping() {
+        let stdio = McpServerDef {
+            name: "chrome-devtools".into(),
+            command: Some("/usr/local/bin/npx".into()),
+            args: Some(vec!["-y".into(), "chrome-devtools-mcp@1.5.0".into()]),
+            env: Some(HashMap::from([("PATH".into(), "/usr/bin".into())])),
+            url: None,
+            headers: None,
+            transport: Some("stdio".into()),
+            enabled: Some(true),
+            scope: None,
+        };
+        let v = mcp_def_to_acp(&stdio).expect("stdio");
+        assert_eq!(v["name"], "chrome-devtools");
+        assert_eq!(v["command"], "/usr/local/bin/npx");
+        assert!(v.get("type").is_none());
+        assert_eq!(v["args"].as_array().unwrap().len(), 2);
+        assert_eq!(v["env"].as_array().unwrap().len(), 1);
+
+        let http = McpServerDef {
+            name: "cf".into(),
+            command: None,
+            args: None,
+            env: None,
+            url: Some("https://mcp.example.com/mcp".into()),
+            headers: Some(HashMap::from([("Authorization".into(), "Bearer x".into())])),
+            transport: Some("http".into()),
+            enabled: Some(true),
+            scope: None,
+        };
+        let v = mcp_def_to_acp(&http).expect("http");
+        assert_eq!(v["type"], "http");
+        assert_eq!(v["url"], "https://mcp.example.com/mcp");
+        assert_eq!(v["headers"].as_array().unwrap().len(), 1);
+
+        let sse = McpServerDef {
+            name: "events".into(),
+            command: None,
+            args: None,
+            env: None,
+            url: Some("https://events.example.com/sse".into()),
+            headers: None,
+            transport: Some("sse".into()),
+            enabled: None,
+            scope: None,
+        };
+        let v = mcp_def_to_acp(&sse).expect("sse");
+        assert_eq!(v["type"], "sse");
+    }
+
+    #[test]
+    fn build_acp_filters_and_skips_invalid() {
+        let defs = vec![
+            McpServerDef {
+                name: "ok".into(),
+                command: Some("npx".into()),
+                args: None,
+                env: None,
+                url: None,
+                headers: None,
+                transport: Some("stdio".into()),
+                enabled: None,
+                scope: None,
+            },
+            McpServerDef {
+                name: "no-target".into(),
+                command: None,
+                args: None,
+                env: None,
+                url: None,
+                headers: None,
+                transport: None,
+                enabled: None,
+                scope: None,
+            },
+            McpServerDef {
+                name: "off".into(),
+                command: Some("x".into()),
+                args: None,
+                env: None,
+                url: None,
+                headers: None,
+                transport: Some("stdio".into()),
+                enabled: None,
+                scope: None,
+            },
+        ];
+        let mut prefs = ExtensionsPrefs::default();
+        set_enabled(&mut prefs.mcp, "off", false);
+        let arr = build_acp_mcp_servers(&defs, &prefs);
+        let a = arr.as_array().unwrap();
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0]["name"], "ok");
+    }
+
+    #[test]
+    fn set_mcp_enabled_in_toml_upserts() {
+        let base = r#"
+[ui]
+yolo = false
+
+[mcp_servers.chrome-devtools]
+command = "/usr/local/bin/npx"
+args = ["-y", "chrome-devtools-mcp"]
+enabled = true
+"#;
+        let next = set_mcp_enabled_in_toml(base, "chrome-devtools", false);
+        assert!(next.contains("enabled = false"));
+        assert_eq!(next.matches("enabled = ").count(), 1);
+        assert!(next.contains("command = \"/usr/local/bin/npx\""));
+
+        // Missing section → append
+        let appended = set_mcp_enabled_in_toml("[ui]\nyolo = false\n", "playwright", true);
+        assert!(appended.contains("[mcp_servers.playwright]"));
+        assert!(appended.contains("enabled = true"));
+    }
+
+    #[test]
+    fn parse_mcp_list_json_shape() {
+        let raw = r#"[
+          {
+            "name": "chrome-devtools",
+            "command": "/usr/local/bin/npx",
+            "args": ["-y", "chrome-devtools-mcp@1.5.0"],
+            "env": {"PATH": "/usr/bin"},
+            "enabled": true,
+            "scope": "user"
+          },
+          {
+            "name": "cloudflare-api",
+            "url": "https://mcp.cloudflare.com/mcp",
+            "enabled": true
+          }
+        ]"#;
+        let defs = parse_mcp_list_json(raw).expect("parse");
+        assert_eq!(defs.len(), 2);
+        assert_eq!(defs[0].command.as_deref(), Some("/usr/local/bin/npx"));
+        assert_eq!(defs[0].args.as_ref().unwrap().len(), 2);
+        assert_eq!(
+            defs[1].url.as_deref(),
+            Some("https://mcp.cloudflare.com/mcp")
+        );
+    }
+
+    #[test]
+    fn filter_skill_names() {
+        let names = vec!["help".into(), "imagine".into(), "code-review".into()];
+        let mut prefs = ExtensionsPrefs::default();
+        set_enabled(&mut prefs.skills, "imagine", false);
+        let f = filter_enabled_skill_names(&names, &prefs);
+        assert_eq!(f, vec!["help".to_string(), "code-review".to_string()]);
+    }
+}

--- a/src-tauri/src/extensions.rs
+++ b/src-tauri/src/extensions.rs
@@ -256,10 +256,16 @@ pub fn list_mcp_server_defs(project_cwd: Option<&str>) -> Vec<McpServerDef> {
         }
     }
 
-    let defs = fetch_mcp_list_json(project_cwd).unwrap_or_else(|| {
-        // Fallback: parse inspect + lightweight config hints.
-        fetch_mcp_from_inspect(project_cwd)
-    });
+    // Prefer `grok mcp list --json` (full command/args/env/url).
+    // Fall back to config.toml (stdio args survive; inspect often drops them),
+    // then inspect names/targets as last resort.
+    let mut defs = fetch_mcp_list_json(project_cwd).unwrap_or_default();
+    if defs.is_empty() {
+        defs = load_mcp_defs_from_configs(&settings.session_data_mode);
+    }
+    if defs.is_empty() {
+        defs = fetch_mcp_from_inspect(project_cwd);
+    }
 
     if let Ok(mut guard) = MCP_CACHE.lock() {
         *guard = Some(McpCache {
@@ -270,6 +276,236 @@ pub fn list_mcp_server_defs(project_cwd: Option<&str>) -> Vec<McpServerDef> {
         });
     }
     defs
+}
+
+/// Read MCP server defs from agent-home + user `~/.grok/config.toml`.
+/// Later files do not override earlier names (agent-home wins over user when
+/// independent mode has mirrored sections; otherwise user config is the source).
+fn load_mcp_defs_from_configs(session_data_mode: &str) -> Vec<McpServerDef> {
+    let mut by_name: HashMap<String, McpServerDef> = HashMap::new();
+    // User config first, then agent-home (independent) so App-managed home wins.
+    let user_cfg = crate::process_util::user_home()
+        .join(".grok")
+        .join("config.toml");
+    if let Ok(raw) = fs::read_to_string(&user_cfg) {
+        for d in parse_mcp_servers_from_toml(&raw) {
+            by_name.insert(d.name.clone(), d);
+        }
+    }
+    let agent_cfg = resolve_agent_grok_home(session_data_mode).join("config.toml");
+    if agent_cfg != user_cfg {
+        if let Ok(raw) = fs::read_to_string(&agent_cfg) {
+            for d in parse_mcp_servers_from_toml(&raw) {
+                by_name.insert(d.name.clone(), d);
+            }
+        }
+    }
+    let mut out: Vec<McpServerDef> = by_name.into_values().collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+/// Parse `[mcp_servers.<name>]` tables (and nested `.env`) from config.toml text.
+/// Lightweight — no full TOML dependency; covers command/args/url/enabled/env.
+/// Supports multi-line `args = [ ... ]` arrays used by Grok config.
+pub fn parse_mcp_servers_from_toml(text: &str) -> Vec<McpServerDef> {
+    let mut by_name: HashMap<String, McpServerDef> = HashMap::new();
+    let mut current: Option<String> = None;
+    let mut in_env = false;
+    // Accumulator for multi-line `args = [` … `]`
+    let mut args_buf: Option<String> = None;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(ref mut buf) = args_buf {
+            buf.push(' ');
+            buf.push_str(trimmed);
+            if trimmed.contains(']') {
+                let joined = args_buf.take().unwrap_or_default();
+                if let Some(name) = current.as_ref() {
+                    if let Some(def) = by_name.get_mut(name) {
+                        if let Some(arr) = parse_toml_string_array(&joined) {
+                            def.args = Some(arr);
+                        }
+                    }
+                }
+            }
+            continue;
+        }
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let inner = trimmed[1..trimmed.len() - 1].trim();
+            if let Some(rest) = inner.strip_prefix("mcp_servers.") {
+                if let Some(name) = rest.strip_suffix(".env") {
+                    let name = name.trim();
+                    if !name.is_empty() {
+                        ensure_mcp_def(&mut by_name, name);
+                        current = Some(name.to_string());
+                        in_env = true;
+                    } else {
+                        current = None;
+                        in_env = false;
+                    }
+                } else {
+                    let name = rest.trim();
+                    if !name.is_empty() {
+                        ensure_mcp_def(&mut by_name, name);
+                        current = Some(name.to_string());
+                        in_env = false;
+                    } else {
+                        current = None;
+                        in_env = false;
+                    }
+                }
+            } else {
+                current = None;
+                in_env = false;
+            }
+            continue;
+        }
+        let Some(name) = current.as_ref() else {
+            continue;
+        };
+        let Some(eq) = trimmed.find('=') else {
+            continue;
+        };
+        let key = trimmed[..eq].trim();
+        let val_raw = trimmed[eq + 1..].trim();
+        if key.is_empty() {
+            continue;
+        }
+        let Some(def) = by_name.get_mut(name) else {
+            continue;
+        };
+        if in_env {
+            if let Some(v) = parse_toml_string(val_raw) {
+                def.env
+                    .get_or_insert_with(HashMap::new)
+                    .insert(key.to_string(), v);
+            }
+            continue;
+        }
+        match key {
+            "command" => {
+                if let Some(v) = parse_toml_string(val_raw) {
+                    def.command = Some(v);
+                    if def.transport.is_none() {
+                        def.transport = Some("stdio".into());
+                    }
+                }
+            }
+            "url" => {
+                if let Some(v) = parse_toml_string(val_raw) {
+                    def.url = Some(v);
+                    if def.transport.is_none() {
+                        def.transport = Some("http".into());
+                    }
+                }
+            }
+            "enabled" => {
+                def.enabled = parse_toml_bool(val_raw);
+            }
+            "args" => {
+                if val_raw.contains('[') && !val_raw.contains(']') {
+                    args_buf = Some(val_raw.to_string());
+                } else if let Some(arr) = parse_toml_string_array(val_raw) {
+                    def.args = Some(arr);
+                }
+            }
+            "transport" => {
+                if let Some(v) = parse_toml_string(val_raw) {
+                    def.transport = Some(v);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut out: Vec<McpServerDef> = by_name.into_values().collect();
+    out.retain(|d| !d.name.is_empty() && (d.command.is_some() || d.url.is_some()));
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+fn ensure_mcp_def(map: &mut HashMap<String, McpServerDef>, name: &str) {
+    map.entry(name.to_string()).or_insert_with(|| McpServerDef {
+        name: name.to_string(),
+        command: None,
+        args: None,
+        env: None,
+        url: None,
+        headers: None,
+        transport: None,
+        enabled: None,
+        scope: None,
+    });
+}
+
+fn parse_toml_string(raw: &str) -> Option<String> {
+    let s = raw.trim();
+    if s.len() >= 2 {
+        let b = s.as_bytes()[0];
+        if (b == b'"' || b == b'\'') && s.as_bytes()[s.len() - 1] == b {
+            return Some(s[1..s.len() - 1].to_string());
+        }
+    }
+    // Bare token (rare)
+    if !s.is_empty() && !s.starts_with('[') && !s.starts_with('{') {
+        return Some(s.trim_end_matches(',').to_string());
+    }
+    None
+}
+
+fn parse_toml_bool(raw: &str) -> Option<bool> {
+    match raw.trim().trim_end_matches(',').to_ascii_lowercase().as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+/// Parse a single-line or multi-line-joined TOML string array: `["a", "b"]`.
+fn parse_toml_string_array(raw: &str) -> Option<Vec<String>> {
+    let s = raw.trim();
+    let start = s.find('[')?;
+    let end = s.rfind(']')?;
+    if end <= start {
+        return None;
+    }
+    let inner = &s[start + 1..end];
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut in_str: Option<char> = None;
+    let mut escape = false;
+    for ch in inner.chars() {
+        if escape {
+            cur.push(ch);
+            escape = false;
+            continue;
+        }
+        if let Some(q) = in_str {
+            if ch == '\\' {
+                escape = true;
+                continue;
+            }
+            if ch == q {
+                out.push(cur.clone());
+                cur.clear();
+                in_str = None;
+            } else {
+                cur.push(ch);
+            }
+            continue;
+        }
+        match ch {
+            '"' | '\'' => in_str = Some(ch),
+            ',' | ' ' | '\t' | '\n' | '\r' => {}
+            _ => {}
+        }
+    }
+    Some(out)
 }
 
 /// Invalidate in-process MCP list cache (after toggle / config write).
@@ -852,5 +1088,61 @@ enabled = true
         set_enabled(&mut prefs.skills, "imagine", false);
         let f = filter_enabled_skill_names(&names, &prefs);
         assert_eq!(f, vec!["help".to_string(), "code-review".to_string()]);
+    }
+
+    #[test]
+    fn parse_mcp_servers_from_toml_stdio_and_http() {
+        let raw = r#"
+[ui]
+yolo = false
+
+[mcp_servers.chrome-devtools]
+command = "/usr/local/bin/npx"
+args = [
+    "-y",
+    "chrome-devtools-mcp@1.5.0",
+    "--isolated",
+]
+enabled = true
+
+[mcp_servers.chrome-devtools.env]
+PATH = "/usr/local/bin:/usr/bin"
+
+[mcp_servers.cloudflare-api]
+url = "https://mcp.cloudflare.com/mcp"
+enabled = true
+"#;
+        let defs = parse_mcp_servers_from_toml(raw);
+        assert_eq!(defs.len(), 2, "{defs:?}");
+        let chrome = defs.iter().find(|d| d.name == "chrome-devtools").unwrap();
+        assert_eq!(chrome.command.as_deref(), Some("/usr/local/bin/npx"));
+        assert_eq!(
+            chrome.args.as_ref().map(|a| a.as_slice()),
+            Some(
+                [
+                    "-y".to_string(),
+                    "chrome-devtools-mcp@1.5.0".to_string(),
+                    "--isolated".to_string()
+                ]
+                .as_slice()
+            )
+        );
+        assert_eq!(
+            chrome.env.as_ref().and_then(|e| e.get("PATH")).map(|s| s.as_str()),
+            Some("/usr/local/bin:/usr/bin")
+        );
+        let http = defs.iter().find(|d| d.name == "cloudflare-api").unwrap();
+        assert_eq!(
+            http.url.as_deref(),
+            Some("https://mcp.cloudflare.com/mcp")
+        );
+
+        // ACP mapping must not yield empty array when prefs default-on.
+        let prefs = ExtensionsPrefs::default();
+        let arr = build_acp_mcp_servers(&defs, &prefs);
+        let a = arr.as_array().unwrap();
+        assert_eq!(a.len(), 2);
+        assert!(a.iter().any(|v| v["name"] == "chrome-devtools"));
+        assert!(a.iter().any(|v| v["name"] == "cloudflare-api" && v["type"] == "http"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod account;
 mod account_profiles;
 mod acp_client;
 mod agent_prefs;
+mod extensions;
 mod supergrok_quota;
 mod cli_probe;
 mod cli_install;
@@ -169,6 +170,11 @@ pub fn run() {
             commands::reset_app_data,
             commands::skills_list,
             commands::inspect_mcp,
+            commands::extensions_get,
+            commands::extensions_set_mcp,
+            commands::extensions_set_skill,
+            commands::extensions_enable_all_mcp,
+            commands::extensions_enable_all_skills,
             commands::pick_directory,
             commands::pick_attach_files,
             commands::pick_attach_folder,

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -91,6 +91,11 @@ pub fn automations_file() -> PathBuf {
     app_data_root().join("automations.json")
 }
 
+/// App MCP/Skills enable prefs (`extensions.json`).
+pub fn extensions_file() -> PathBuf {
+    app_data_root().join("extensions.json")
+}
+
 /// Percent-encode a path the way Grok Build names session folders under
 /// `GROK_HOME/sessions/` (encodeURIComponent of the absolute cwd).
 pub fn percent_encode_path_component(s: &str) -> String {

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -2488,7 +2488,8 @@ impl SessionManager {
     /// Soft-drop live agent so next send re-spawns with new spawn flags / config.
     /// Keeps `agent_session_id` so reconnect can `session/load`; if load fails,
     /// journal bootstrap still fills the gap.
-    async fn soft_respawn(&self, app: &AppHandle) {
+    /// Public so Extensions MCP toggles can recycle the process with new mcpServers.
+    pub async fn soft_respawn(&self, app: &AppHandle) {
         let acp = {
             let mut guard = self.inner.lock();
             if let Some(s) = guard.as_mut() {
@@ -2602,6 +2603,19 @@ impl SessionManager {
             }
         }
         Ok(())
+    }
+
+    /// Soft-respawn when MCP enable prefs change so the next connect injects
+    /// the updated `mcpServers` set (and agent-home config is re-read).
+    pub async fn apply_extensions_mcp_change(&self, app: &AppHandle) {
+        let live = {
+            let guard = self.inner.lock();
+            guard.as_ref().map(|s| s.acp.is_some()).unwrap_or(false)
+        };
+        if live {
+            tracing::info!("extensions: MCP prefs changed — soft-respawn live agent");
+            self.soft_respawn(app).await;
+        }
     }
 
     /// Record desired effort. CLI has no mid-session set_effort RPC; soft-drop the

--- a/src-tauri/src/support_bundle.rs
+++ b/src-tauri/src/support_bundle.rs
@@ -188,6 +188,7 @@ pub fn reset_app_data(keep_secrets: bool) -> Result<serde_json::Value, String> {
         "sessions_index.json",
         "automations.json",
         "settings.json",
+        "extensions.json",
     ];
     if !keep_secrets {
         files.push("secrets.json");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3259,6 +3259,9 @@ export default function App() {
     });
   }, []);
 
+  /** Bumped when Extensions skill toggles change so slash palette refilters. */
+  const [skillsReloadToken, setSkillsReloadToken] = useState(0);
+
   // Load skills catalog for slash palette (Grok inspect).
   useEffect(() => {
     if (!api.isTauri()) return;
@@ -3289,7 +3292,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [activeProject?.path]);
+  }, [activeProject?.path, skillsReloadToken]);
 
   const slashCatalog = useMemo(
     () => buildSlashCatalog(skillInfos),
@@ -5270,6 +5273,9 @@ export default function App() {
             deleteSessionsConfirm(rows);
           }}
           projectPath={activeProject?.path ?? null}
+          onSkillsPrefsChanged={() =>
+            setSkillsReloadToken((n) => n + 1)
+          }
           onProviderActivated={() => {
             // Hot-reload Grok Build: drop live ACP so next send re-spawns with new GROK_HOME config.
             void (async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3269,12 +3269,15 @@ export default function App() {
       .then((res) => {
         if (cancelled) return;
         setSkillInfos(
-          (res.skills ?? []).map((s) => ({
-            name: s.name,
-            description: s.description ?? "",
-            source: s.source,
-            userInvocable: s.userInvocable,
-          })),
+          (res.skills ?? [])
+            // Extensions enable flag (default on); hide disabled from slash palette.
+            .filter((s) => s.enabled !== false)
+            .map((s) => ({
+              name: s.name,
+              description: s.description ?? "",
+              source: s.source,
+              userInvocable: s.userInvocable,
+            })),
         );
       })
       .catch(() => {

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Settings → Extensions: Skills + MCP servers from `grok inspect --json`.
- * Full card layout (not a modal stub). Project cwd when available.
+ * Per-item enable toggles persist to extensions.json and inject into ACP sessions.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -16,6 +16,7 @@ import {
 } from "@/components/icons";
 import {
   isCliMissingError,
+  isExtensionEnabled,
   mcpMetaLine,
   mergeInspectErrors,
   shortPathLabel,
@@ -50,6 +51,7 @@ export function ExtensionsPanel({
   const [agentHome, setAgentHome] = useState<string | null>(null);
   const [configPath, setConfigPath] = useState<string | null>(null);
   const [pathHint, setPathHint] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!api.isTauri()) {
@@ -103,6 +105,15 @@ export function ExtensionsPanel({
     : tr("ext.scope.global");
   const scopePath = projectPath?.trim() || null;
 
+  const mcpOffCount = useMemo(
+    () => servers.filter((s) => !isExtensionEnabled(s.enabled)).length,
+    [servers],
+  );
+  const skillsOffCount = useMemo(
+    () => skills.filter((s) => !isExtensionEnabled(s.enabled)).length,
+    [skills],
+  );
+
   const reveal = async (path: string | null | undefined) => {
     const p = (path ?? "").trim();
     if (!p || !api.isTauri()) return;
@@ -111,6 +122,74 @@ export function ExtensionsPanel({
       setPathHint(null);
     } catch (e) {
       setPathHint(String(e));
+    }
+  };
+
+  const toggleMcp = async (name: string, next: boolean) => {
+    if (!api.isTauri() || busyKey) return;
+    setBusyKey(`mcp:${name}`);
+    // Optimistic UI
+    setServers((prev) =>
+      prev.map((s) => (s.name === name ? { ...s, enabled: next } : s)),
+    );
+    try {
+      await api.extensionsSetMcp(name, next);
+    } catch (e) {
+      setPathHint(String(e));
+      // Revert
+      setServers((prev) =>
+        prev.map((s) => (s.name === name ? { ...s, enabled: !next } : s)),
+      );
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const toggleSkill = async (name: string, next: boolean) => {
+    if (!api.isTauri() || busyKey) return;
+    setBusyKey(`skill:${name}`);
+    setSkills((prev) =>
+      prev.map((s) => (s.name === name ? { ...s, enabled: next } : s)),
+    );
+    try {
+      await api.extensionsSetSkill(name, next);
+    } catch (e) {
+      setPathHint(String(e));
+      setSkills((prev) =>
+        prev.map((s) => (s.name === name ? { ...s, enabled: !next } : s)),
+      );
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const enableAllMcp = async () => {
+    if (!api.isTauri() || busyKey || servers.length === 0) return;
+    setBusyKey("mcp:all");
+    const names = servers.map((s) => s.name);
+    setServers((prev) => prev.map((s) => ({ ...s, enabled: true })));
+    try {
+      await api.extensionsEnableAllMcp(names);
+    } catch (e) {
+      setPathHint(String(e));
+      await refresh();
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const enableAllSkills = async () => {
+    if (!api.isTauri() || busyKey || skills.length === 0) return;
+    setBusyKey("skill:all");
+    const names = skills.map((s) => s.name);
+    setSkills((prev) => prev.map((s) => ({ ...s, enabled: true })));
+    try {
+      await api.extensionsEnableAllSkills(names);
+    } catch (e) {
+      setPathHint(String(e));
+      await refresh();
+    } finally {
+      setBusyKey(null);
     }
   };
 
@@ -203,6 +282,16 @@ export function ExtensionsPanel({
         {!loading ? (
           <span className="ext-count">{skills.length}</span>
         ) : null}
+        {!loading && skills.length > 0 && skillsOffCount > 0 ? (
+          <button
+            type="button"
+            className="btn btn--ghost ext-bulk-btn"
+            disabled={!!busyKey}
+            onClick={() => void enableAllSkills()}
+          >
+            {tr("ext.enableAll")}
+          </button>
+        ) : null}
       </h2>
       <div className="settings-card ext-card">
         {loading && (
@@ -217,8 +306,12 @@ export function ExtensionsPanel({
           <ul className="ext-list">
             {skills.map((s) => {
               const tone = skillSourceTone(s.source);
+              const on = isExtensionEnabled(s.enabled);
               return (
-                <li key={`${s.source}:${s.name}:${s.path ?? ""}`} className="ext-item">
+                <li
+                  key={`${s.source}:${s.name}:${s.path ?? ""}`}
+                  className={"ext-item" + (on ? "" : " ext-item--off")}
+                >
                   <div className="ext-item__head">
                     <strong className="ext-item__name">{s.name}</strong>
                     <span className={`ext-badge ext-badge--${tone}`}>
@@ -229,6 +322,12 @@ export function ExtensionsPanel({
                         {tr("ext.skills.invocable")}
                       </span>
                     ) : null}
+                    <ExtensionToggle
+                      checked={on}
+                      disabled={!!busyKey}
+                      label={on ? tr("ext.enabled") : tr("ext.disabled")}
+                      onChange={(next) => void toggleSkill(s.name, next)}
+                    />
                   </div>
                   {s.description ? (
                     <p className="ext-item__desc">{s.description}</p>
@@ -261,6 +360,16 @@ export function ExtensionsPanel({
         {!loading ? (
           <span className="ext-count">{servers.length}</span>
         ) : null}
+        {!loading && servers.length > 0 && mcpOffCount > 0 ? (
+          <button
+            type="button"
+            className="btn btn--ghost ext-bulk-btn"
+            disabled={!!busyKey}
+            onClick={() => void enableAllMcp()}
+          >
+            {tr("ext.enableAll")}
+          </button>
+        ) : null}
       </h2>
       <div className="settings-card ext-card">
         {loading && <p className="ext-empty">{tr("ext.mcp.loading")}</p>}
@@ -273,8 +382,12 @@ export function ExtensionsPanel({
           <ul className="ext-list">
             {servers.map((s) => {
               const meta = mcpMetaLine(s);
+              const on = isExtensionEnabled(s.enabled);
               return (
-                <li key={s.name} className="ext-item">
+                <li
+                  key={s.name}
+                  className={"ext-item" + (on ? "" : " ext-item--off")}
+                >
                   <div className="ext-item__head">
                     <strong className="ext-item__name">{s.name}</strong>
                     {s.transport ? (
@@ -287,6 +400,12 @@ export function ExtensionsPanel({
                         {s.compatibilityStatus}
                       </span>
                     ) : null}
+                    <ExtensionToggle
+                      checked={on}
+                      disabled={!!busyKey}
+                      label={on ? tr("ext.enabled") : tr("ext.disabled")}
+                      onChange={(next) => void toggleMcp(s.name, next)}
+                    />
                   </div>
                   {meta ? <p className="ext-item__desc">{meta}</p> : null}
                   {s.target ? (
@@ -326,6 +445,33 @@ export function ExtensionsPanel({
         <span>{tr("ext.footnote")}</span>
       </p>
     </div>
+  );
+}
+
+function ExtensionToggle({
+  checked,
+  disabled,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  label: string;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      className={"ext-switch" + (checked ? " is-on" : "")}
+      onClick={() => onChange(!checked)}
+    >
+      <span className="ext-switch__thumb" aria-hidden />
+    </button>
   );
 }
 

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -34,6 +34,8 @@ export interface ExtensionsPanelProps {
   cliFound?: boolean;
   /** Navigate to Settings → Runtime when CLI is missing. */
   onOpenRuntime?: () => void;
+  /** Fired after skill enable prefs change so slash palette can refresh. */
+  onSkillsPrefsChanged?: () => void;
 }
 
 export function ExtensionsPanel({
@@ -41,6 +43,7 @@ export function ExtensionsPanel({
   projectPath = null,
   cliFound = true,
   onOpenRuntime,
+  onSkillsPrefsChanged,
 }: ExtensionsPanelProps) {
   const tr = useMemo(() => createT(locale), [locale]);
   const [skills, setSkills] = useState<api.SkillDto[]>([]);
@@ -153,6 +156,7 @@ export function ExtensionsPanel({
     );
     try {
       await api.extensionsSetSkill(name, next);
+      onSkillsPrefsChanged?.();
     } catch (e) {
       setPathHint(String(e));
       setSkills((prev) =>
@@ -185,6 +189,7 @@ export function ExtensionsPanel({
     setSkills((prev) => prev.map((s) => ({ ...s, enabled: true })));
     try {
       await api.extensionsEnableAllSkills(names);
+      onSkillsPrefsChanged?.();
     } catch (e) {
       setPathHint(String(e));
       await refresh();

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -145,6 +145,8 @@ export interface SettingsPageProps {
   onDeleteArchivedSessions?: (ids: string[]) => void;
   /** Active project path for Skills/MCP inspect cwd. */
   projectPath?: string | null;
+  /** After skill enable toggle — refresh slash palette in App. */
+  onSkillsPrefsChanged?: () => void;
 }
 
 const NAV: {
@@ -425,6 +427,7 @@ export function SettingsPage({
   onRestoreArchivedSessions,
   onDeleteArchivedSessions,
   projectPath = null,
+  onSkillsPrefsChanged,
 }: SettingsPageProps) {
   const [query, setQuery] = useState("");
   const [accountTab, setAccountTab] = useState<"official" | "providers">(
@@ -1259,6 +1262,7 @@ export function SettingsPage({
             projectPath={projectPath}
             cliFound={cliInfo.found}
             onOpenRuntime={() => onSection("runtime")}
+            onSkillsPrefsChanged={onSkillsPrefsChanged}
           />
         )}
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -775,14 +775,14 @@ const en = {
 
   "mcpModal.title": "MCP servers",
   "mcpModal.hint":
-    "Servers discovered by Grok Build (inspect). Agent session MCP injection is separate.",
+    "Servers discovered by Grok Build (inspect). Enable or disable them under Settings → Extensions; enabled servers inject into new agent sessions.",
   "mcpModal.loading": "Loading MCP servers…",
   "mcpModal.empty": "No MCP servers discovered",
   "mcpModal.manage": "Manage in Settings",
 
   // Settings → Extensions (Skills + MCP)
   "ext.lead":
-    "Skills and MCP servers discovered via `grok inspect`. Project scope uses the active workbench folder as cwd; without a project, inspect runs globally.",
+    "Skills and MCP servers from `grok inspect`. Toggle enable to inject MCP into agent sessions and filter slash skills. Project scope uses the active workbench folder as cwd.",
   "ext.refresh": "Refresh",
   "ext.refreshing": "Refreshing…",
   "ext.scope.project": "Project",
@@ -806,8 +806,11 @@ const en = {
   "ext.mcp.empty": "No MCP servers discovered",
   "ext.mcp.emptyCli": "MCP status is unavailable until the CLI is installed.",
   "ext.mcp.vendor": "Vendor",
+  "ext.enabled": "Enabled",
+  "ext.disabled": "Disabled",
+  "ext.enableAll": "Enable all",
   "ext.footnote":
-    "Session MCP injection is separate from this inspect list. Configure servers in Grok Build / agent config.",
+    "Toggles persist under app data and inject enabled MCP servers into agent sessions (ACP mcpServers + agent-home config). Disabled skills stay on disk but hide from the slash palette.",
 
   // Errors / misc
   "error.needTauri": "Folder picker requires the Tauri window",
@@ -1684,14 +1687,14 @@ const zh: Record<MessageKey, string> = {
 
   "mcpModal.title": "MCP 服务器",
   "mcpModal.hint":
-    "由 Grok Build inspect 发现的服务器。与 Agent 会话是否注入 MCP 是分开的。",
+    "由 Grok Build inspect 发现的服务器。可在「设置 → 扩展」中启用/禁用；已启用的服务器会注入新会话。",
   "mcpModal.loading": "正在加载 MCP…",
   "mcpModal.empty": "未发现 MCP 服务器",
   "mcpModal.manage": "在设置中管理",
 
   // Settings → Extensions (Skills + MCP)
   "ext.lead":
-    "通过 `grok inspect` 发现的技能与 MCP 服务器。有当前项目时以该目录为 cwd；无项目时为全局范围。",
+    "通过 `grok inspect` 发现的技能与 MCP 服务器。开关控制会话注入与斜杠技能过滤；有当前项目时以该目录为 cwd。",
   "ext.refresh": "刷新",
   "ext.refreshing": "刷新中…",
   "ext.scope.project": "项目",
@@ -1715,8 +1718,11 @@ const zh: Record<MessageKey, string> = {
   "ext.mcp.empty": "未发现 MCP 服务器",
   "ext.mcp.emptyCli": "安装 CLI 后才能查看 MCP 状态。",
   "ext.mcp.vendor": "供应商",
+  "ext.enabled": "已启用",
+  "ext.disabled": "已禁用",
+  "ext.enableAll": "全部启用",
   "ext.footnote":
-    "会话内 MCP 注入与此 inspect 列表相互独立。请在 Grok Build / agent 配置中管理服务器。",
+    "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。",
 
   "error.needTauri": "需要在 Tauri 窗口中选择目录",
   "common.comingSoon": "即将推出",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -743,14 +743,14 @@ export const zhTW: Record<MessageKey, string> = {
 
   "mcpModal.title": "MCP 伺服器",
   "mcpModal.hint":
-    "由 Grok Build inspect 發現的伺服器。與 Agent 對話是否注入 MCP 是分開的。",
+    "由 Grok Build inspect 發現的伺服器。可在「設定 → 擴充」中啟用/停用；已啟用的伺服器會注入新對話。",
   "mcpModal.loading": "正在載入 MCP…",
   "mcpModal.empty": "未發現 MCP 伺服器",
   "mcpModal.manage": "在設定中管理",
 
   // Settings → Extensions (Skills + MCP)
   "ext.lead":
-    "透過 `grok inspect` 發現的技能與 MCP 伺服器。有目前專案時以該目錄為 cwd；無專案時為全域範圍。",
+    "透過 `grok inspect` 發現的技能與 MCP 伺服器。開關控制對話注入與斜線技能過濾；有目前專案時以該目錄為 cwd。",
   "ext.refresh": "重新整理",
   "ext.refreshing": "重新整理中…",
   "ext.scope.project": "專案",
@@ -774,8 +774,11 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.mcp.empty": "未發現 MCP 伺服器",
   "ext.mcp.emptyCli": "安裝 CLI 後才能查看 MCP 狀態。",
   "ext.mcp.vendor": "供應商",
+  "ext.enabled": "已啟用",
+  "ext.disabled": "已停用",
+  "ext.enableAll": "全部啟用",
   "ext.footnote":
-    "對話內 MCP 注入與此 inspect 清單相互獨立。請在 Grok Build / agent 設定中管理伺服器。",
+    "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。",
 
   "error.needTauri": "需要在 Tauri 視窗中選擇目錄",
   "common.comingSoon": "即將推出",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -710,6 +710,8 @@ export interface SkillDto {
   source: string;
   path?: string | null;
   userInvocable: boolean;
+  /** App Extensions enable flag (default true when omitted). */
+  enabled?: boolean;
 }
 
 export interface McpDto {
@@ -718,6 +720,8 @@ export interface McpDto {
   target?: string | null;
   vendor?: string | null;
   compatibilityStatus?: string | null;
+  /** App Extensions enable flag (default true when omitted). */
+  enabled?: boolean;
 }
 
 export interface SkillsListResult {
@@ -728,6 +732,36 @@ export interface SkillsListResult {
 export interface InspectMcpResult {
   servers: McpDto[];
   error?: string;
+}
+
+/** App MCP/Skills enable prefs (`extensions.json`). Missing name = enabled. */
+export interface ExtensionsPrefs {
+  mcp: Record<string, boolean>;
+  skills: Record<string, boolean>;
+}
+
+export async function extensionsGet() {
+  return invoke<ExtensionsPrefs>("extensions_get");
+}
+
+/** Toggle one MCP server; Host persists + injects on next session + soft-respawns. */
+export async function extensionsSetMcp(name: string, enabled: boolean) {
+  return invoke<ExtensionsPrefs>("extensions_set_mcp", { name, enabled });
+}
+
+/** Toggle one skill (slash palette filter). */
+export async function extensionsSetSkill(name: string, enabled: boolean) {
+  return invoke<ExtensionsPrefs>("extensions_set_skill", { name, enabled });
+}
+
+/** Bulk-enable all listed MCP servers. */
+export async function extensionsEnableAllMcp(names: string[]) {
+  return invoke<ExtensionsPrefs>("extensions_enable_all_mcp", { names });
+}
+
+/** Bulk-enable all listed skills. */
+export async function extensionsEnableAllSkills(names: string[]) {
+  return invoke<ExtensionsPrefs>("extensions_enable_all_skills", { names });
 }
 
 export async function doctorReport() {

--- a/src/lib/extensionsUi.test.ts
+++ b/src/lib/extensionsUi.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  countDisabled,
+  filterEnabledByName,
   isCliMissingError,
+  isExtensionEnabled,
+  mergeEnableSet,
   mergeInspectErrors,
   mcpMetaLine,
   normalizeSkillSource,
@@ -10,6 +14,43 @@ import {
   sortMcpByName,
   sortSkillsByName,
 } from "./extensionsUi";
+
+describe("enable-set merge / filter", () => {
+  it("defaults to enabled when missing", () => {
+    expect(isExtensionEnabled(undefined)).toBe(true);
+    expect(isExtensionEnabled(null)).toBe(true);
+    expect(isExtensionEnabled(true)).toBe(true);
+    expect(isExtensionEnabled(false)).toBe(false);
+  });
+
+  it("mergeEnableSet builds default-on map with overlay", () => {
+    expect(mergeEnableSet(["a", "b", "c"], { b: false })).toEqual({
+      a: true,
+      b: false,
+      c: true,
+    });
+    expect(mergeEnableSet(["a"], null)).toEqual({ a: true });
+    expect(mergeEnableSet(["  ", "x"], { x: false })).toEqual({ x: false });
+  });
+
+  it("filterEnabledByName drops only explicit false", () => {
+    const items = [{ name: "keep" }, { name: "drop" }, { name: "default" }];
+    expect(filterEnabledByName(items, { drop: false }).map((i) => i.name)).toEqual([
+      "keep",
+      "default",
+    ]);
+    expect(filterEnabledByName(items, undefined).map((i) => i.name)).toEqual([
+      "keep",
+      "drop",
+      "default",
+    ]);
+  });
+
+  it("countDisabled only counts explicit false", () => {
+    expect(countDisabled(["a", "b", "c"], { a: false, b: true })).toBe(1);
+    expect(countDisabled(["a"], {})).toBe(0);
+  });
+});
 
 describe("isCliMissingError", () => {
   it("detects host CLI missing message", () => {

--- a/src/lib/extensionsUi.ts
+++ b/src/lib/extensionsUi.ts
@@ -8,6 +8,7 @@ export type SkillLike = {
   source: string;
   path?: string | null;
   userInvocable?: boolean;
+  enabled?: boolean;
 };
 
 export type McpLike = {
@@ -16,7 +17,55 @@ export type McpLike = {
   target?: string | null;
   vendor?: string | null;
   compatibilityStatus?: string | null;
+  enabled?: boolean;
 };
+
+/** Missing / undefined → enabled (default-on / opt-out). */
+export function isExtensionEnabled(enabled: boolean | null | undefined): boolean {
+  return enabled !== false;
+}
+
+/**
+ * Apply enable overlay map onto a list of named items.
+ * Overlay wins; missing overlay keys stay default-on.
+ */
+export function mergeEnableSet(
+  names: string[],
+  overlay: Record<string, boolean> | null | undefined,
+): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const raw of names) {
+    const name = (raw ?? "").trim();
+    if (!name) continue;
+    out[name] = overlay && name in overlay ? Boolean(overlay[name]) : true;
+  }
+  return out;
+}
+
+/** Filter items by enable map (default-on when key missing). */
+export function filterEnabledByName<T extends { name: string }>(
+  items: T[],
+  enableMap: Record<string, boolean> | null | undefined,
+): T[] {
+  return items.filter((item) => {
+    const name = (item.name ?? "").trim();
+    if (!name) return false;
+    if (!enableMap || !(name in enableMap)) return true;
+    return enableMap[name] !== false;
+  });
+}
+
+/** Count how many of the given names are currently disabled. */
+export function countDisabled(
+  names: string[],
+  enableMap: Record<string, boolean> | null | undefined,
+): number {
+  return names.filter((n) => {
+    const name = (n ?? "").trim();
+    if (!name) return false;
+    return enableMap && name in enableMap && enableMap[name] === false;
+  }).length;
+}
 
 /** True when inspect/skills host error indicates CLI binary missing. */
 export function isCliMissingError(error: string | null | undefined): boolean {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10229,6 +10229,61 @@ div.composer__input:empty::before {
   flex-direction: column;
 }
 
+.ext-bulk-btn {
+  margin-left: auto;
+  font-size: 12px;
+  padding: 2px 8px;
+  height: auto;
+}
+
+.ext-switch {
+  margin-left: auto;
+  position: relative;
+  flex-shrink: 0;
+  width: 36px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-hover);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.ext-switch.is-on {
+  background: color-mix(in srgb, var(--accent, #6b8cff) 55%, transparent);
+  border-color: color-mix(in srgb, var(--accent, #6b8cff) 40%, transparent);
+}
+
+.ext-switch:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.ext-switch__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--text-primary, #fff);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: transform 0.15s ease;
+}
+
+.ext-switch.is-on .ext-switch__thumb {
+  transform: translateX(16px);
+}
+
+.ext-item--off {
+  opacity: 0.62;
+}
+
+.ext-item--off .ext-item__name {
+  text-decoration: none;
+}
+
 .ext-item {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problem

Settings → Extensions was **inspect-only**: skills and MCP servers were listed from `grok inspect`, but:

- ACP always sent `"mcpServers": []` on `session/new` / `session/load`
- There was no way to enable/disable individual MCP servers (or skills) from the App
- Independent `GROK_HOME` sessions therefore never received the user’s configured MCP tools

L03 in the capability matrix asks for list **and enable**, with real effect on agent sessions.

## Changes

### Persist enable prefs
- New app-data file `{app_data}/extensions.json` with `mcp` / `skills` name → bool maps
- **Default-on / opt-out**: missing name = enabled
- Cleared on `reset_app_data` (with other app files)

### UI (Settings → Extensions)
- Per-item **toggle** for each MCP server and skill
- **Enable all** bulk action when any are disabled
- Immediate persist; optimistic UI with revert on error
- i18n: en / zh / zh-TW

### Inject enabled MCP into agent sessions
- On `session/new` and `session/load`, Host builds ACP `mcpServers` from `grok mcp list --json` (full `command`/`args`/`env` or `url`) filtered by prefs
- Maps stdio / HTTP / SSE into the ACP shape (`acp_client::open_session`)
- **Dual write**: syncs `enabled` under agent-home (independent) or `~/.grok` (shared) `config.toml` `[mcp_servers.<name>]`
- Live agent: soft-respawn on MCP pref change so the next connect re-injects

### Skills
- Enable flag filters slash palette / composer chips (App-side)
- Skill files remain on disk for the agent

### Host API
- `extensions_get`, `extensions_set_mcp`, `extensions_set_skill`, `extensions_enable_all_mcp`, `extensions_enable_all_skills`
- `skills_list` / `inspect_mcp` now include `enabled` on each row

### Docs / tests
- `docs/llm-wiki/slash-composer.md` + SPIKE-ACP note
- Pure enable-set merge/filter tests (Rust `extensions` + vitest `extensionsUi`)

## How tested

- `cargo test --lib` — **125 passed** (incl. 8 `extensions::*` unit tests)
- `pnpm test` — **255 passed**
- `pnpm typecheck` — clean
- Manual shape check: `grok mcp list --json` / inspect fields mapped to ACP stdio + HTTP entries in unit tests

## Notes

- Skills cannot be fully “disabled” at the CLI agent layer without removing files; the App filters UI discovery only.
- MCP injection prefers `grok mcp list --json` for full command/args; falls back to inspect `name`/`transport`/`target` when list fails.