### PR TITLE
feat: sticky Plan/Goal status bar with live step progress

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3713,6 +3713,64 @@ export default function App() {
     }, ms);
   }, []);
 
+  const approvePlan = useCallback(async () => {
+    try {
+      await api.sessionResolvePlan({
+        decision: "approved",
+        rpcId: plan.rpcId,
+      });
+      setPlan((p) => ({
+        ...p,
+        visible: false,
+        waiting: false,
+        rpcId: null,
+      }));
+      showToast(tr("plan.approvedToast"), 2500);
+    } catch (e) {
+      showToast(String(e), 4500);
+    }
+  }, [plan.rpcId, showToast, tr]);
+
+  const requestPlanChanges = useCallback(async () => {
+    try {
+      await api.sessionResolvePlan({
+        decision: "cancelled",
+        feedback: tr("plan.reviseFeedback"),
+        rpcId: plan.rpcId,
+      });
+      setPlan((p) => ({
+        ...p,
+        visible: false,
+        waiting: false,
+        rpcId: null,
+      }));
+      showToast(tr("plan.reviseToast"), 2800);
+    } catch (e) {
+      showToast(String(e), 4500);
+    }
+  }, [plan.rpcId, showToast, tr]);
+
+  const dismissPlan = useCallback(async () => {
+    if (plan.rpcId != null) {
+      try {
+        await api.sessionResolvePlan({
+          decision: "abandoned",
+          rpcId: plan.rpcId,
+        });
+      } catch {
+        /* hide UI anyway */
+      }
+    }
+    setPlan((p) => ({
+      ...p,
+      visible: false,
+      waiting: true,
+      entries: [],
+      body: "",
+      rpcId: null,
+    }));
+  }, [plan.rpcId]);
+
   const sendQueueLabels = useMemo(
     () => ({
       queued: tr("composer.queued"),
@@ -6314,7 +6372,6 @@ export default function App() {
             </div>
           )}
 
-          {/* L04: Plan / Goal sticky status — visible while mode or live plan steps active */}
           {mainPane === "chat" && (
             <PlanStatusBar
               goalMode={goalMode}
@@ -6337,72 +6394,15 @@ export default function App() {
                 expand: tr("planBar.expand"),
                 aria: tr("planBar.aria"),
               }}
-              onApprove={() => {
-                void (async () => {
-                  try {
-                    await api.sessionResolvePlan({
-                      decision: "approved",
-                      rpcId: plan.rpcId,
-                    });
-                    setPlan((p) => ({
-                      ...p,
-                      visible: false,
-                      waiting: false,
-                      rpcId: null,
-                    }));
-                    showToast(tr("plan.approvedToast"), 2500);
-                  } catch (e) {
-                    showToast(String(e), 4500);
-                  }
-                })();
-              }}
-              onRequestChanges={() => {
-                void (async () => {
-                  try {
-                    await api.sessionResolvePlan({
-                      decision: "cancelled",
-                      feedback: tr("plan.reviseFeedback"),
-                      rpcId: plan.rpcId,
-                    });
-                    setPlan((p) => ({
-                      ...p,
-                      visible: false,
-                      waiting: false,
-                      rpcId: null,
-                    }));
-                    showToast(tr("plan.reviseToast"), 2800);
-                  } catch (e) {
-                    showToast(String(e), 4500);
-                  }
-                })();
-              }}
-              onDismiss={() => {
-                void (async () => {
-                  if (plan.rpcId != null) {
-                    try {
-                      await api.sessionResolvePlan({
-                        decision: "abandoned",
-                        rpcId: plan.rpcId,
-                      });
-                    } catch {
-                      /* still hide UI */
-                    }
-                  }
-                  setPlan((p) => ({
-                    ...p,
-                    visible: false,
-                    waiting: true,
-                    entries: [],
-                    body: "",
-                    rpcId: null,
-                  }));
-                })();
-              }}
+              onApprove={() => void approvePlan()}
+              onRequestChanges={() => void requestPlanChanges()}
+              onDismiss={() => void dismissPlan()}
               onOpenDetails={() => {
-                const el = document.querySelector<HTMLElement>(
-                  ".lobe-chat-plan, .plan-card, [data-plan-card]",
-                );
-                el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+                document
+                  .querySelector<HTMLElement>(
+                    ".lobe-chat-plan, .plan-card, [data-plan-card]",
+                  )
+                  ?.scrollIntoView({ behavior: "smooth", block: "nearest" });
               }}
             />
           )}
@@ -6498,67 +6498,9 @@ export default function App() {
               setResourceOpenTarget(target);
             }}
             plan={plan}
-            onApprovePlan={() => {
-              void (async () => {
-                try {
-                  await api.sessionResolvePlan({
-                    decision: "approved",
-                    rpcId: plan.rpcId,
-                  });
-                  setPlan((p) => ({
-                    ...p,
-                    visible: false,
-                    waiting: false,
-                    rpcId: null,
-                  }));
-                  showToast(tr("plan.approvedToast"), 2500);
-                } catch (e) {
-                  showToast(String(e), 4500);
-                }
-              })();
-            }}
-            onRequestPlanChanges={() => {
-              void (async () => {
-                try {
-                  await api.sessionResolvePlan({
-                    decision: "cancelled",
-                    feedback: tr("plan.reviseFeedback"),
-                    rpcId: plan.rpcId,
-                  });
-                  setPlan((p) => ({
-                    ...p,
-                    visible: false,
-                    waiting: false,
-                    rpcId: null,
-                  }));
-                  showToast(tr("plan.reviseToast"), 2800);
-                } catch (e) {
-                  showToast(String(e), 4500);
-                }
-              })();
-            }}
-            onDismissPlan={() => {
-              void (async () => {
-                if (plan.rpcId != null) {
-                  try {
-                    await api.sessionResolvePlan({
-                      decision: "abandoned",
-                      rpcId: plan.rpcId,
-                    });
-                  } catch {
-                    /* still hide UI */
-                  }
-                }
-                setPlan((p) => ({
-                  ...p,
-                  visible: false,
-                  waiting: true,
-                  entries: [],
-                  body: "",
-                  rpcId: null,
-                }));
-              })();
-            }}
+            onApprovePlan={() => void approvePlan()}
+            onRequestPlanChanges={() => void requestPlanChanges()}
+            onDismissPlan={() => void dismissPlan()}
             onAddAttachmentToComposer={(att) =>
               setAttachments((prev) => mergeAttachments(prev, [att]))
             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,7 @@ import {
   type ContextUsageState,
 } from "@/lib/contextUsage";
 import { ContextUsageChip } from "@/components/ContextUsageChip";
+import { PlanStatusBar } from "@/components/PlanStatusBar";
 import * as api from "@/lib/api";
 import { createT, resolveLocale, type Locale } from "@/i18n";
 import {
@@ -6311,6 +6312,99 @@ export default function App() {
                 </button>
               </div>
             </div>
+          )}
+
+          {/* L04: Plan / Goal sticky status — visible while mode or live plan steps active */}
+          {mainPane === "chat" && (
+            <PlanStatusBar
+              goalMode={goalMode}
+              mode={mode}
+              planVisible={plan.visible}
+              planWaiting={plan.waiting}
+              planRpcId={plan.rpcId}
+              entries={plan.entries}
+              labels={{
+                goal: tr("planBar.goal"),
+                planMode: tr("planBar.planMode"),
+                progress: tr("planBar.progress"),
+                review: tr("planBar.review"),
+                done: tr("planBar.done"),
+                fraction: tr("planBar.fraction"),
+                current: tr("planBar.current"),
+                approve: tr("plan.approve"),
+                changes: tr("plan.changes"),
+                dismiss: tr("plan.dismiss"),
+                expand: tr("planBar.expand"),
+                aria: tr("planBar.aria"),
+              }}
+              onApprove={() => {
+                void (async () => {
+                  try {
+                    await api.sessionResolvePlan({
+                      decision: "approved",
+                      rpcId: plan.rpcId,
+                    });
+                    setPlan((p) => ({
+                      ...p,
+                      visible: false,
+                      waiting: false,
+                      rpcId: null,
+                    }));
+                    showToast(tr("plan.approvedToast"), 2500);
+                  } catch (e) {
+                    showToast(String(e), 4500);
+                  }
+                })();
+              }}
+              onRequestChanges={() => {
+                void (async () => {
+                  try {
+                    await api.sessionResolvePlan({
+                      decision: "cancelled",
+                      feedback: tr("plan.reviseFeedback"),
+                      rpcId: plan.rpcId,
+                    });
+                    setPlan((p) => ({
+                      ...p,
+                      visible: false,
+                      waiting: false,
+                      rpcId: null,
+                    }));
+                    showToast(tr("plan.reviseToast"), 2800);
+                  } catch (e) {
+                    showToast(String(e), 4500);
+                  }
+                })();
+              }}
+              onDismiss={() => {
+                void (async () => {
+                  if (plan.rpcId != null) {
+                    try {
+                      await api.sessionResolvePlan({
+                        decision: "abandoned",
+                        rpcId: plan.rpcId,
+                      });
+                    } catch {
+                      /* still hide UI */
+                    }
+                  }
+                  setPlan((p) => ({
+                    ...p,
+                    visible: false,
+                    waiting: true,
+                    entries: [],
+                    body: "",
+                    rpcId: null,
+                  }));
+                })();
+              }}
+              onOpenDetails={() => {
+                const el = document.querySelector<HTMLElement>(
+                  ".lobe-chat-plan, .plan-card, [data-plan-card]",
+                );
+                el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+              }}
+            />
           )}
 
           {/* One surface only: turn failures live in chat; banner is for pre-turn/local errors */}

--- a/src/components/PlanStatusBar.tsx
+++ b/src/components/PlanStatusBar.tsx
@@ -1,0 +1,197 @@
+/**
+ * Sticky Plan / Goal status bar (L04).
+ * Always visible while plan mode, goal mode, or live plan entries are active —
+ * complements the in-thread plan card which scrolls away.
+ */
+
+import { useMemo } from "react";
+import { IconCheck, IconPlan, IconClose } from "@/components/icons";
+import {
+  formatPlanFraction,
+  resolvePlanBarModel,
+  shouldShowPlanBar,
+  type PlanBarModel,
+} from "@/lib/planStatus";
+
+export type PlanStatusBarLabels = {
+  goal: string;
+  planMode: string;
+  progress: string;
+  review: string;
+  done: string;
+  fraction: string;
+  current: string;
+  approve: string;
+  changes: string;
+  dismiss: string;
+  expand: string;
+  aria: string;
+};
+
+export type PlanStatusBarProps = {
+  goalMode: boolean;
+  mode: string;
+  planVisible: boolean;
+  planWaiting: boolean;
+  planRpcId?: number | null;
+  entries: unknown[];
+  labels: PlanStatusBarLabels;
+  onApprove?: () => void;
+  onRequestChanges?: () => void;
+  onDismiss?: () => void;
+  /** Scroll / focus the in-thread plan card when present. */
+  onOpenDetails?: () => void;
+};
+
+function headlineFor(model: PlanBarModel, labels: PlanStatusBarLabels): string {
+  switch (model.headlineKey) {
+    case "planBar.goal":
+      return labels.goal;
+    case "planBar.planMode":
+      return labels.planMode;
+    case "planBar.progress":
+      return labels.progress;
+    case "planBar.review":
+      return labels.review;
+    case "planBar.done":
+      return labels.done;
+    default:
+      return labels.planMode;
+  }
+}
+
+export function PlanStatusBar({
+  goalMode,
+  mode,
+  planVisible,
+  planWaiting,
+  planRpcId = null,
+  entries,
+  labels,
+  onApprove,
+  onRequestChanges,
+  onDismiss,
+  onOpenDetails,
+}: PlanStatusBarProps) {
+  const model = useMemo(
+    () =>
+      resolvePlanBarModel({
+        goalMode,
+        mode,
+        planVisible,
+        planWaiting,
+        planRpcId,
+        entries,
+      }),
+    [goalMode, mode, planVisible, planWaiting, planRpcId, entries],
+  );
+
+  if (!shouldShowPlanBar(model)) return null;
+
+  const fraction = formatPlanFraction(model.progress);
+  const headline = headlineFor(model, labels);
+  const kindClass =
+    model.kind === "goal"
+      ? "plan-bar--goal"
+      : model.kind === "plan_review"
+        ? "plan-bar--review"
+        : model.kind === "plan_progress"
+          ? "plan-bar--progress"
+          : "plan-bar--mode";
+
+  return (
+    <div
+      className={`plan-bar ${kindClass}`}
+      role="status"
+      aria-live="polite"
+      aria-label={labels.aria}
+      data-testid="plan-status-bar"
+    >
+      <div className="plan-bar__main">
+        <span className="plan-bar__icon" aria-hidden>
+          {model.headlineKey === "planBar.done" ? (
+            <IconCheck size={14} />
+          ) : (
+            <IconPlan size={14} />
+          )}
+        </span>
+        <div className="plan-bar__text">
+          <div className="plan-bar__headline">
+            <strong>{headline}</strong>
+            {fraction ? (
+              <span className="plan-bar__fraction">
+                {labels.fraction.replace("{n}", fraction)}
+              </span>
+            ) : null}
+          </div>
+          {model.currentLabel ? (
+            <div className="plan-bar__current" title={model.currentLabel}>
+              <span className="plan-bar__current-label">{labels.current}</span>
+              <span className="plan-bar__current-step">{model.currentLabel}</span>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {model.progress.total > 0 ? (
+        <div
+          className="plan-bar__meter"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={model.progress.total}
+          aria-valuenow={model.progress.completed}
+          aria-label={fraction || headline}
+        >
+          <div
+            className="plan-bar__meter-fill"
+            style={{ width: `${model.progress.percent}%` }}
+          />
+        </div>
+      ) : null}
+
+      <div className="plan-bar__actions">
+        {planVisible && onOpenDetails ? (
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm plan-bar__btn"
+            onClick={onOpenDetails}
+          >
+            {labels.expand}
+          </button>
+        ) : null}
+        {model.showActions && onApprove ? (
+          <button
+            type="button"
+            className="btn btn--solid btn--sm plan-bar__btn"
+            onClick={onApprove}
+          >
+            {labels.approve}
+          </button>
+        ) : null}
+        {model.showActions && onRequestChanges ? (
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm plan-bar__btn"
+            onClick={onRequestChanges}
+          >
+            {labels.changes}
+          </button>
+        ) : null}
+        {(model.kind === "plan_progress" ||
+          model.kind === "plan_review" ||
+          planVisible) &&
+        onDismiss ? (
+          <button
+            type="button"
+            className="icon-btn plan-bar__close"
+            onClick={onDismiss}
+            aria-label={labels.dismiss}
+            title={labels.dismiss}
+          >
+            <IconClose size={14} />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PlanStatusBar.tsx
+++ b/src/components/PlanStatusBar.tsx
@@ -1,8 +1,4 @@
-/**
- * Sticky Plan / Goal status bar (L04).
- * Always visible while plan mode, goal mode, or live plan entries are active —
- * complements the in-thread plan card which scrolls away.
- */
+/** Sticky plan/goal strip — stays put while the in-thread plan card scrolls away. */
 
 import { useMemo } from "react";
 import { IconCheck, IconPlan, IconClose } from "@/components/icons";

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -380,6 +380,17 @@ const en = {
   "plan.reviseFeedback": "Please revise the plan based on user feedback.",
   "plan.phaseLabel": "Thinking {n}",
 
+  // Plan / Goal sticky status bar (L04)
+  "planBar.aria": "Plan and goal status",
+  "planBar.goal": "Goal mode",
+  "planBar.planMode": "Plan mode",
+  "planBar.progress": "Plan in progress",
+  "planBar.review": "Plan ready for review",
+  "planBar.done": "Plan complete",
+  "planBar.fraction": "{n}",
+  "planBar.current": "Now",
+  "planBar.expand": "Details",
+
   // Settings / onboarding
   "settings.title": "Settings",
   "settings.backToApp": "Back to app",
@@ -1373,6 +1384,17 @@ const zh: Record<MessageKey, string> = {
   "plan.reviseToast": "已请 Agent 修改计划",
   "plan.reviseFeedback": "请根据反馈修改计划。",
   "plan.phaseLabel": "思考 {n}",
+
+  // Plan / Goal sticky status bar (L04)
+  "planBar.aria": "计划与目标状态",
+  "planBar.goal": "目标模式",
+  "planBar.planMode": "计划模式",
+  "planBar.progress": "计划进行中",
+  "planBar.review": "计划待审阅",
+  "planBar.done": "计划已完成",
+  "planBar.fraction": "{n}",
+  "planBar.current": "当前",
+  "planBar.expand": "详情",
 
   "settings.title": "设置",
   "settings.backToApp": "返回应用",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -380,7 +380,7 @@ const en = {
   "plan.reviseFeedback": "Please revise the plan based on user feedback.",
   "plan.phaseLabel": "Thinking {n}",
 
-  // Plan / Goal sticky status bar (L04)
+  // Sticky plan/goal bar
   "planBar.aria": "Plan and goal status",
   "planBar.goal": "Goal mode",
   "planBar.planMode": "Plan mode",
@@ -1385,7 +1385,7 @@ const zh: Record<MessageKey, string> = {
   "plan.reviseFeedback": "请根据反馈修改计划。",
   "plan.phaseLabel": "思考 {n}",
 
-  // Plan / Goal sticky status bar (L04)
+  // Sticky plan/goal bar
   "planBar.aria": "计划与目标状态",
   "planBar.goal": "目标模式",
   "planBar.planMode": "计划模式",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -356,6 +356,17 @@ export const zhTW: Record<MessageKey, string> = {
   "plan.reviseFeedback": "請根據回饋修改計劃。",
   "plan.phaseLabel": "思考 {n}",
 
+  // Plan / Goal sticky status bar (L04)
+  "planBar.aria": "計劃與目標狀態",
+  "planBar.goal": "目標模式",
+  "planBar.planMode": "計劃模式",
+  "planBar.progress": "計劃進行中",
+  "planBar.review": "計劃待審閱",
+  "planBar.done": "計劃已完成",
+  "planBar.fraction": "{n}",
+  "planBar.current": "目前",
+  "planBar.expand": "詳情",
+
   "settings.title": "設定",
   "settings.backToApp": "返回應用程式",
   "settings.searchPlaceholder": "搜尋設定…",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -356,7 +356,7 @@ export const zhTW: Record<MessageKey, string> = {
   "plan.reviseFeedback": "請根據回饋修改計劃。",
   "plan.phaseLabel": "思考 {n}",
 
-  // Plan / Goal sticky status bar (L04)
+  // Sticky plan/goal bar
   "planBar.aria": "計劃與目標狀態",
   "planBar.goal": "目標模式",
   "planBar.planMode": "計劃模式",

--- a/src/lib/planStatus.test.ts
+++ b/src/lib/planStatus.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import {
+  computePlanProgress,
+  formatPlanFraction,
+  normalizePlanEntryStatus,
+  parsePlanEntries,
+  parsePlanEntry,
+  resolvePlanBarModel,
+  shouldShowPlanBar,
+} from "./planStatus";
+
+describe("normalizePlanEntryStatus", () => {
+  it("maps common ACP statuses", () => {
+    expect(normalizePlanEntryStatus("pending")).toBe("pending");
+    expect(normalizePlanEntryStatus("in_progress")).toBe("in_progress");
+    expect(normalizePlanEntryStatus("in-progress")).toBe("in_progress");
+    expect(normalizePlanEntryStatus("completed")).toBe("completed");
+    expect(normalizePlanEntryStatus("done")).toBe("completed");
+    expect(normalizePlanEntryStatus("cancelled")).toBe("cancelled");
+    expect(normalizePlanEntryStatus("")).toBe("pending");
+    expect(normalizePlanEntryStatus("weird")).toBe("unknown");
+  });
+});
+
+describe("parsePlanEntries", () => {
+  it("parses fixture-shaped entries", () => {
+    const entries = parsePlanEntries([
+      { content: "Touch fixtures", status: "pending" },
+      { content: "Run cargo test", status: "in_progress" },
+      { content: "Ship", status: "completed" },
+    ]);
+    expect(entries).toHaveLength(3);
+    expect(entries[0].content).toBe("Touch fixtures");
+    expect(entries[1].status).toBe("in_progress");
+    expect(entries[2].status).toBe("completed");
+  });
+
+  it("accepts title/text aliases and string rows", () => {
+    expect(parsePlanEntry({ title: "A", status: "todo" })?.content).toBe("A");
+    expect(parsePlanEntry("plain step")?.status).toBe("pending");
+    expect(parsePlanEntry({})).toBeNull();
+    expect(parsePlanEntries(null)).toEqual([]);
+  });
+});
+
+describe("computePlanProgress", () => {
+  it("counts and picks current step", () => {
+    const p = computePlanProgress(
+      parsePlanEntries([
+        { content: "a", status: "completed" },
+        { content: "b", status: "in_progress" },
+        { content: "c", status: "pending" },
+      ]),
+    );
+    expect(p.total).toBe(3);
+    expect(p.completed).toBe(1);
+    expect(p.inProgress).toBe(1);
+    expect(p.pending).toBe(1);
+    expect(p.percent).toBe(33);
+    expect(p.current?.content).toBe("b");
+    expect(formatPlanFraction(p)).toBe("1/3");
+  });
+
+  it("falls back to first pending when none in progress", () => {
+    const p = computePlanProgress(
+      parsePlanEntries([
+        { content: "a", status: "completed" },
+        { content: "b", status: "pending" },
+      ]),
+    );
+    expect(p.current?.content).toBe("b");
+    expect(p.percent).toBe(50);
+  });
+});
+
+describe("resolvePlanBarModel", () => {
+  it("hides when idle", () => {
+    const m = resolvePlanBarModel({
+      goalMode: false,
+      mode: "agent",
+      planVisible: false,
+      planWaiting: true,
+      planRpcId: null,
+      entries: [],
+    });
+    expect(m.kind).toBe("hidden");
+    expect(shouldShowPlanBar(m)).toBe(false);
+  });
+
+  it("shows goal mode strip", () => {
+    const m = resolvePlanBarModel({
+      goalMode: true,
+      mode: "agent",
+      planVisible: false,
+      planWaiting: true,
+      entries: [],
+    });
+    expect(m.kind).toBe("goal");
+    expect(m.headlineKey).toBe("planBar.goal");
+  });
+
+  it("shows plan mode before entries arrive", () => {
+    const m = resolvePlanBarModel({
+      goalMode: false,
+      mode: "plan",
+      planVisible: false,
+      planWaiting: true,
+      entries: [],
+    });
+    expect(m.kind).toBe("plan_mode");
+  });
+
+  it("prefers review when exit_plan_mode is pending", () => {
+    const m = resolvePlanBarModel({
+      goalMode: false,
+      mode: "plan",
+      planVisible: true,
+      planWaiting: false,
+      planRpcId: 9,
+      entries: [
+        { content: "Touch fixtures", status: "pending" },
+        { content: "Run cargo test", status: "pending" },
+      ],
+    });
+    expect(m.kind).toBe("plan_review");
+    expect(m.showActions).toBe(true);
+    expect(m.progress.total).toBe(2);
+  });
+
+  it("does not show review actions without rpc id", () => {
+    const m = resolvePlanBarModel({
+      goalMode: false,
+      mode: "agent",
+      planVisible: true,
+      planWaiting: true,
+      planRpcId: null,
+      entries: [{ content: "draft", status: "pending" }],
+    });
+    expect(m.kind).toBe("plan_progress");
+    expect(m.showActions).toBe(false);
+  });
+
+  it("shows progress while entries update (card may be dismissed)", () => {
+    const m = resolvePlanBarModel({
+      goalMode: false,
+      mode: "agent",
+      planVisible: false,
+      planWaiting: true,
+      planRpcId: null,
+      entries: [
+        { content: "a", status: "completed" },
+        { content: "b", status: "in_progress" },
+      ],
+    });
+    expect(m.kind).toBe("plan_progress");
+    expect(m.headlineKey).toBe("planBar.progress");
+    expect(m.currentLabel).toBe("b");
+    expect(formatPlanFraction(m.progress)).toBe("1/2");
+  });
+
+  it("marks done when all completed", () => {
+    const m = resolvePlanBarModel({
+      goalMode: false,
+      mode: "agent",
+      planVisible: false,
+      planWaiting: true,
+      entries: [
+        { content: "a", status: "completed" },
+        { content: "b", status: "completed" },
+      ],
+    });
+    expect(m.headlineKey).toBe("planBar.done");
+    expect(m.progress.percent).toBe(100);
+  });
+});

--- a/src/lib/planStatus.ts
+++ b/src/lib/planStatus.ts
@@ -1,9 +1,4 @@
-/**
- * Pure helpers for Plan / Goal status bar (L04).
- *
- * Plan entries come from ACP `sessionUpdate: plan` (content + status).
- * Load state / mode chips are separate from the in-thread plan card.
- */
+/** Plan entry parse + progress for the sticky plan/goal bar. */
 
 export type PlanEntryStatus =
   | "pending"

--- a/src/lib/planStatus.ts
+++ b/src/lib/planStatus.ts
@@ -1,0 +1,240 @@
+/**
+ * Pure helpers for Plan / Goal status bar (L04).
+ *
+ * Plan entries come from ACP `sessionUpdate: plan` (content + status).
+ * Load state / mode chips are separate from the in-thread plan card.
+ */
+
+export type PlanEntryStatus =
+  | "pending"
+  | "in_progress"
+  | "completed"
+  | "cancelled"
+  | "unknown";
+
+export type PlanEntry = {
+  content: string;
+  status: PlanEntryStatus;
+  priority?: string | null;
+};
+
+export type PlanProgress = {
+  total: number;
+  completed: number;
+  inProgress: number;
+  pending: number;
+  cancelled: number;
+  /** 0–100; 0 when total is 0 */
+  percent: number;
+  /** First in_progress entry, else first pending, else last completed. */
+  current: PlanEntry | null;
+};
+
+export type PlanBarKind =
+  | "hidden"
+  | "goal"
+  | "plan_mode"
+  | "plan_progress"
+  | "plan_review";
+
+export type PlanBarModel = {
+  kind: PlanBarKind;
+  progress: PlanProgress;
+  /** Short headline for the bar */
+  headlineKey:
+    | "planBar.goal"
+    | "planBar.planMode"
+    | "planBar.progress"
+    | "planBar.review"
+    | "planBar.done";
+  currentLabel: string;
+  showActions: boolean;
+};
+
+const COMPLETED = new Set(["completed", "complete", "done", "success"]);
+const IN_PROGRESS = new Set([
+  "in_progress",
+  "in-progress",
+  "running",
+  "active",
+  "doing",
+]);
+const PENDING = new Set(["pending", "todo", "open", "not_started", ""]);
+const CANCELLED = new Set(["cancelled", "canceled", "skipped", "abandoned"]);
+
+/** Normalize ACP / agent status strings into a fixed set. */
+export function normalizePlanEntryStatus(
+  raw: string | null | undefined,
+): PlanEntryStatus {
+  const s = (raw ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  if (COMPLETED.has(s)) return "completed";
+  if (IN_PROGRESS.has(s)) return "in_progress";
+  if (CANCELLED.has(s)) return "cancelled";
+  if (PENDING.has(s)) return "pending";
+  if (!s) return "pending";
+  return "unknown";
+}
+
+/** Parse one plan entry from ACP JSON (object or string). */
+export function parsePlanEntry(raw: unknown): PlanEntry | null {
+  if (raw == null) return null;
+  if (typeof raw === "string") {
+    const content = raw.trim();
+    if (!content) return null;
+    return { content, status: "pending" };
+  }
+  if (typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const content = String(
+    o.content ?? o.title ?? o.text ?? o.description ?? "",
+  ).trim();
+  if (!content) return null;
+  const status = normalizePlanEntryStatus(
+    o.status != null ? String(o.status) : null,
+  );
+  const priority =
+    o.priority != null && String(o.priority).trim()
+      ? String(o.priority).trim()
+      : null;
+  return { content, status, priority };
+}
+
+export function parsePlanEntries(raw: unknown): PlanEntry[] {
+  if (!Array.isArray(raw)) return [];
+  const out: PlanEntry[] = [];
+  for (const item of raw) {
+    const e = parsePlanEntry(item);
+    if (e) out.push(e);
+  }
+  return out;
+}
+
+export function computePlanProgress(entries: PlanEntry[]): PlanProgress {
+  const total = entries.length;
+  let completed = 0;
+  let inProgress = 0;
+  let pending = 0;
+  let cancelled = 0;
+  for (const e of entries) {
+    if (e.status === "completed") completed += 1;
+    else if (e.status === "in_progress") inProgress += 1;
+    else if (e.status === "cancelled") cancelled += 1;
+    else pending += 1; // pending + unknown count as not done
+  }
+  const denom = total;
+  const percent =
+    denom === 0 ? 0 : Math.min(100, Math.round((completed / denom) * 100));
+
+  let current: PlanEntry | null =
+    entries.find((e) => e.status === "in_progress") ?? null;
+  if (!current) {
+    current = entries.find((e) => e.status === "pending" || e.status === "unknown") ?? null;
+  }
+  if (!current && completed > 0) {
+    current = [...entries].reverse().find((e) => e.status === "completed") ?? null;
+  }
+
+  return {
+    total,
+    completed,
+    inProgress,
+    pending,
+    cancelled,
+    percent,
+    current,
+  };
+}
+
+/**
+ * Decide what the sticky bar should show.
+ * Priority: review gate → live progress → plan card idle → plan mode → goal → hidden.
+ */
+export function resolvePlanBarModel(input: {
+  goalMode: boolean;
+  mode: string;
+  planVisible: boolean;
+  planWaiting: boolean;
+  planRpcId?: number | null;
+  entries: unknown[];
+}): PlanBarModel {
+  const parsed = parsePlanEntries(input.entries);
+  const progress = computePlanProgress(parsed);
+  const hasEntries = progress.total > 0;
+  const canAct = input.planRpcId != null;
+
+  // exit_plan_mode pending — user must approve / revise.
+  if (input.planVisible && canAct) {
+    return {
+      kind: "plan_review",
+      progress,
+      headlineKey: "planBar.review",
+      currentLabel: progress.current?.content ?? "",
+      showActions: true,
+    };
+  }
+
+  // Live step list (while planning, after approve, or mid-execution).
+  if (hasEntries) {
+    const allDone =
+      progress.completed + progress.cancelled >= progress.total &&
+      progress.inProgress === 0 &&
+      progress.pending === 0;
+    return {
+      kind: "plan_progress",
+      progress,
+      headlineKey: allDone ? "planBar.done" : "planBar.progress",
+      currentLabel: progress.current?.content ?? "",
+      showActions: false,
+    };
+  }
+
+  // Card visible but only markdown body so far.
+  if (input.planVisible) {
+    return {
+      kind: "plan_progress",
+      progress,
+      headlineKey: input.planWaiting ? "planBar.planMode" : "planBar.review",
+      currentLabel: "",
+      showActions: false,
+    };
+  }
+
+  if (input.mode === "plan") {
+    return {
+      kind: "plan_mode",
+      progress,
+      headlineKey: "planBar.planMode",
+      currentLabel: "",
+      showActions: false,
+    };
+  }
+
+  if (input.goalMode) {
+    return {
+      kind: "goal",
+      progress,
+      headlineKey: "planBar.goal",
+      currentLabel: "",
+      showActions: false,
+    };
+  }
+
+  return {
+    kind: "hidden",
+    progress,
+    headlineKey: "planBar.planMode",
+    currentLabel: "",
+    showActions: false,
+  };
+}
+
+/** Whether the sticky bar should render. */
+export function shouldShowPlanBar(model: PlanBarModel): boolean {
+  return model.kind !== "hidden";
+}
+
+/** Compact fraction label "2/5". */
+export function formatPlanFraction(progress: PlanProgress): string {
+  if (progress.total <= 0) return "";
+  return `${progress.completed}/${progress.total}`;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4377,7 +4377,7 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   }
 }
 
-/* Plan / Goal sticky status bar (L04) — stays visible while chat scrolls */
+/* Sticky plan/goal bar above the chat stage */
 .plan-bar {
   display: flex;
   flex-wrap: wrap;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4377,6 +4377,158 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   }
 }
 
+/* Plan / Goal sticky status bar (L04) — stays visible while chat scrolls */
+.plan-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  margin: 0 var(--space-5) 8px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-card, var(--bg-elevated));
+  min-width: 0;
+}
+
+.plan-bar--goal {
+  border-color: color-mix(in srgb, var(--accent, #6b8cff) 32%, var(--border-subtle));
+  background: color-mix(in srgb, var(--accent, #6b8cff) 8%, var(--bg-card, var(--bg-elevated)));
+}
+
+.plan-bar--mode {
+  border-color: color-mix(in srgb, #c49bff 30%, var(--border-subtle));
+}
+
+.plan-bar--progress {
+  border-color: color-mix(in srgb, #5b9fd4 32%, var(--border-subtle));
+}
+
+.plan-bar--review {
+  border-color: color-mix(in srgb, var(--warning, #e0b44a) 40%, var(--border-subtle));
+  background: color-mix(
+    in srgb,
+    var(--warning, #e0b44a) 10%,
+    var(--bg-card, var(--bg-elevated))
+  );
+}
+
+.plan-bar__main {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  flex: 1 1 180px;
+}
+
+.plan-bar__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-top: 1px;
+  border-radius: 6px;
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+  flex-shrink: 0;
+}
+
+.plan-bar--review .plan-bar__icon {
+  color: var(--warning, #e0b44a);
+}
+
+.plan-bar__text {
+  min-width: 0;
+  flex: 1;
+}
+
+.plan-bar__headline {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  font-size: 12.5px;
+  color: var(--text-primary);
+}
+
+.plan-bar__headline strong {
+  font-weight: 600;
+}
+
+.plan-bar__fraction {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.plan-bar__current {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 2px;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.plan-bar__current-label {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.plan-bar__current-step {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plan-bar__meter {
+  flex: 1 1 100%;
+  order: 3;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--bg-hover);
+  overflow: hidden;
+}
+
+.plan-bar__meter-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--accent, #6b8cff) 75%, #5b9fd4);
+  transition: width 0.25s ease;
+}
+
+.plan-bar--review .plan-bar__meter-fill {
+  background: color-mix(in srgb, var(--warning, #e0b44a) 80%, #e05a5a);
+}
+
+.plan-bar__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.plan-bar__btn {
+  height: 26px;
+  padding: 0 10px;
+  font-size: 12px;
+}
+
+.plan-bar__close {
+  width: 26px;
+  height: 26px;
+  color: var(--text-tertiary);
+}
+
 /* Plan card (reference) */
 .plan-card {
   max-width: 720px;


### PR DESCRIPTION
## Problem
Plan cards live in the chat thread and scroll away. Goal/Plan mode also has no always-on strip, so progress is easy to lose track of.

## Changes
- Sticky plan/goal bar above the chat stage
- Shows for goal mode, plan mode, live plan entries, and exit_plan_mode review
- Entry progress: `done/total`, meter, current step
- Approve / request changes / dismiss when a plan is waiting for review
- Details jumps to the in-thread plan card
- Shared resolve handlers for the bar and the card
- Helpers + tests in `planStatus.ts`; i18n en / zh / zh-TW

## Test
```bash
pnpm typecheck
pnpm test
```

1. Access → Plan mode → bar shows plan mode
2. Goal chip → bar shows goal mode
3. Agent sends plan entries → fraction + current step
4. exit_plan_mode pending → review actions work
5. Scroll the thread → bar stays put

Rebased on latest `main` (v0.1.3).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Rebased on current upstream/main
- [ ] Desktop smoke: mode bar + review actions