### PR TITLE
fix: track custom provider usage and account state

### DIFF
--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -4,7 +4,7 @@
 //! Billing is best-effort HTTP (same field shape as CLI `/usage` / billing extension).
 //! Heatmap + call logs are derived from local CLI session signals (and optional app journal).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -262,6 +262,15 @@ pub fn clear_agent_home_auth() {
 
 fn sessions_root() -> PathBuf {
     grok_home().join("sessions")
+}
+
+fn session_roots() -> Vec<PathBuf> {
+    let mut roots = vec![sessions_root()];
+    let agent_sessions = paths::agent_home_dir().join("sessions");
+    if !roots.contains(&agent_sessions) {
+        roots.push(agent_sessions);
+    }
+    roots
 }
 
 fn usage_cache_path() -> PathBuf {
@@ -919,16 +928,28 @@ async fn fetch_billing_remote(token: &str) -> BillingSnapshot {
 /// Aggregate local CLI session signals into a heatmap and recent call log.
 /// `days` defaults to ~371 like grok-go contribution graph.
 pub fn local_usage(days: u32, log_limit: usize) -> (Vec<HeatmapDay>, Vec<CallLogEntry>) {
+    local_usage_from_roots(days, log_limit, &session_roots())
+}
+
+fn local_usage_from_roots(
+    days: u32,
+    log_limit: usize,
+    roots: &[PathBuf],
+) -> (Vec<HeatmapDay>, Vec<CallLogEntry>) {
     let days = days.clamp(7, 400);
     let log_limit = log_limit.clamp(5, 100);
-    let root = sessions_root();
-    if !root.is_dir() {
+    if !roots.iter().any(|root| root.is_dir()) {
         return (empty_heatmap(days), vec![]);
     }
 
     let mut day_map: BTreeMap<NaiveDate, DayAgg> = BTreeMap::new();
     let mut logs: Vec<(i64, CallLogEntry)> = Vec::new();
-    walk_sessions(&root, 0, &mut logs, &mut day_map);
+    let mut seen_sessions = HashSet::new();
+    for root in roots {
+        if root.is_dir() {
+            walk_sessions(root, 0, &mut logs, &mut day_map, &mut seen_sessions);
+        }
+    }
 
     logs.sort_by(|a, b| b.0.cmp(&a.0));
     logs.truncate(log_limit);
@@ -970,6 +991,7 @@ fn walk_sessions(
     depth: u32,
     logs: &mut Vec<(i64, CallLogEntry)>,
     day_map: &mut BTreeMap<NaiveDate, DayAgg>,
+    seen_sessions: &mut HashSet<String>,
 ) {
     if depth > 6 {
         return;
@@ -985,9 +1007,15 @@ fn walk_sessions(
         }
         let signals = path.join("signals.json");
         if signals.is_file() {
-            ingest_session(&path, &signals, day_map, logs);
+            let id = path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_default();
+            if seen_sessions.insert(id) {
+                ingest_session(&path, &signals, day_map, logs);
+            }
         } else {
-            walk_sessions(&path, depth + 1, logs, day_map);
+            walk_sessions(&path, depth + 1, logs, day_map, seen_sessions);
         }
     }
 }
@@ -1601,6 +1629,45 @@ mod tests {
         let h = empty_heatmap(14);
         assert_eq!(h.len(), 14);
         assert!(h.iter().all(|d| d.requests == 0 && d.tokens == 0));
+    }
+
+    #[test]
+    fn local_usage_combines_cli_and_agent_home_sessions() {
+        let temp = std::env::temp_dir().join(format!(
+            "grok-app-account-usage-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let cli_root = temp.join("cli");
+        let agent_root = temp.join("agent");
+        let sessions = [
+            (cli_root.join("project-a").join("session-a"), 120),
+            (agent_root.join("project-b").join("session-b"), 340),
+        ];
+        for (dir, tokens) in &sessions {
+            fs::create_dir_all(dir).unwrap();
+            fs::write(
+                dir.join("signals.json"),
+                serde_json::json!({
+                    "turnCount": 2,
+                    "contextTokensUsed": tokens,
+                    "primaryModelId": "test-model"
+                })
+                .to_string(),
+            )
+            .unwrap();
+        }
+
+        let (heatmap, logs) =
+            local_usage_from_roots(7, 10, &[cli_root.clone(), agent_root.clone()]);
+        assert_eq!(logs.len(), 2);
+        assert_eq!(heatmap.iter().map(|day| day.requests).sum::<u64>(), 2);
+        assert_eq!(heatmap.iter().map(|day| day.tokens).sum::<u64>(), 460);
+
+        fs::remove_dir_all(temp).unwrap();
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4271,16 +4271,22 @@ export default function App() {
   // welcome logo paints immediately — the SVG itself is inline, not a fetch.
   const [cachedBrandKind, setCachedBrandKind] =
     useState<SuperGrokBrandKind | null>(() => loadCachedSuperGrokBrand());
-  /** Active inference channel: custom relay must not show SuperGrok Heavy. */
-  const [customRouteActive, setCustomRouteActive] = useState(false);
+  /** Active inference channel: custom relay identity replaces official account chrome. */
+  const [activeCustomProvider, setActiveCustomProvider] =
+    useState<api.CustomProvider | null>(null);
+  const customRouteActive = activeCustomProvider != null;
   const refreshProviderRoute = useCallback(async () => {
     if (!api.isTauri()) {
-      setCustomRouteActive(false);
+      setActiveCustomProvider(null);
       return;
     }
     try {
       const list = await api.providersList();
-      setCustomRouteActive(list.activeSource === "custom");
+      const active =
+        list.activeSource === "custom"
+          ? list.providers.find((provider) => provider.id === list.activeProviderId) ?? null
+          : null;
+      setActiveCustomProvider(active);
     } catch {
       /* keep previous */
     }
@@ -5602,6 +5608,7 @@ export default function App() {
                   setSession({ ...IDLE_SNAPSHOT });
                 }
                 await refreshProviderRoute();
+                await refreshAccount({ refreshBilling: false });
                 setToast(tr("prov.switchedHotReload"));
                 window.setTimeout(() => setToast(null), 3200);
               } catch (e) {
@@ -6049,6 +6056,7 @@ export default function App() {
             onClose={() => setShowUserMenu(false)}
             theme={theme}
             account={account}
+            activeProvider={activeCustomProvider}
             accountBusy={accountBusy}
             labels={{
               settings: tr("sidebar.settings"),
@@ -6061,6 +6069,7 @@ export default function App() {
               login: tr("account.login"),
               logout: tr("account.logout"),
               remaining: tr("account.quotaRemaining"),
+              customProvider: tr("prov.customProvider"),
               resetsAt: tr("account.resetsAt"),
             }}
             onSettings={() => navigateSettings("general")}
@@ -6079,23 +6088,31 @@ export default function App() {
               aria-expanded={showUserMenu}
               onClick={() => {
                 setShowUserMenu((v) => !v);
-                if (!showUserMenu) void refreshAccount({ refreshBilling: true });
+                if (!showUserMenu) {
+                  void refreshAccount({ refreshBilling: !customRouteActive });
+                }
               }}
             >
               <div className="user-avatar" aria-hidden>
-                {account?.profile
-                  ? accountInitials(account.profile)
-                  : "G"}
+                {activeCustomProvider
+                  ? Array.from(
+                      activeCustomProvider.name.trim() || activeCustomProvider.id,
+                    )[0]?.toUpperCase() || "P"
+                  : account?.profile
+                    ? accountInitials(account.profile)
+                    : "G"}
               </div>
               <div className="user-meta">
                 <span className="user-meta__name">
-                  {account?.profile
-                    ? accountDisplayName(account.profile, tr("common.local"))
-                    : tr("common.local")}
+                  {activeCustomProvider
+                    ? activeCustomProvider.name.trim() || activeCustomProvider.id
+                    : account?.profile
+                      ? accountDisplayName(account.profile, tr("common.local"))
+                      : tr("common.local")}
                 </span>
                 {(() => {
                   // Only show SuperGrok remaining when officially signed in.
-                  if (!account?.profile?.signedIn) return null;
+                  if (customRouteActive || !account?.profile?.signedIn) return null;
                   const rem = remainingPercent(account);
                   return rem != null ? (
                     <span className="user-meta__quota">{rem.toFixed(0)}%</span>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/icons";
 import type { Theme } from "@/lib/theme";
 import { useFloatingMenu } from "@/lib/floatingMenu";
-import type { AccountStatus } from "@/lib/api";
+import type { AccountStatus, CustomProvider } from "@/lib/api";
 import {
   accountDisplayName,
   accountInitials,
@@ -35,10 +35,12 @@ export interface UserMenuProps {
     login: string;
     logout: string;
     remaining: string;
+    customProvider: string;
     /** Prefix for quota refresh time, e.g. 重置 / Resets */
     resetsAt: string;
   };
   account: AccountStatus | null;
+  activeProvider: CustomProvider | null;
   accountBusy: boolean;
   onSettings: () => void;
   onAccountSettings: () => void;
@@ -65,6 +67,7 @@ export function UserMenu({
   theme,
   labels,
   account,
+  activeProvider,
   accountBusy,
   onSettings,
   onAccountSettings,
@@ -92,11 +95,20 @@ export function UserMenu({
   });
 
   const profile = account?.profile;
-  const signedIn = !!profile?.signedIn;
-  const name = profile
-    ? accountDisplayName(profile, labels.local)
-    : labels.local;
-  const initials = profile ? accountInitials(profile) : "G";
+  const isCustomProvider = activeProvider != null;
+  const signedIn = !isCustomProvider && !!profile?.signedIn;
+  const providerName =
+    activeProvider?.name.trim() || activeProvider?.id.trim() || labels.customProvider;
+  const name = isCustomProvider
+    ? providerName
+    : profile
+      ? accountDisplayName(profile, labels.local)
+      : labels.local;
+  const initials = isCustomProvider
+    ? Array.from(providerName)[0]?.toUpperCase() || "P"
+    : profile
+      ? accountInitials(profile)
+      : "G";
   const channel = account?.channel ?? "none";
   const billing = account?.billing;
   const usedPct = billing ? usagePercent(billing) : null;
@@ -139,7 +151,12 @@ export function UserMenu({
                       </span>
                     ) : null}
                   </div>
-                  {!signedIn ? (
+                  {isCustomProvider ? (
+                    <div className="user-menu__account-sub">
+                      {labels.customProvider}
+                      {activeProvider.model ? ` / ${activeProvider.model}` : ""}
+                    </div>
+                  ) : !signedIn ? (
                     <div className="user-menu__account-sub">
                       {labels.signedOut}
                     </div>
@@ -213,7 +230,7 @@ export function UserMenu({
               </span>
             </button>
 
-            {signedIn ? (
+            {isCustomProvider ? null : signedIn ? (
               <button
                 type="button"
                 className="user-menu__item user-menu__item--danger"

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -525,6 +525,7 @@ const en = {
   "prov.officialName": "Official Grok",
   "prov.officialDesc": "Grok Build official login / API key",
   "prov.active": "Active",
+  "prov.customProvider": "Custom provider",
   "prov.useThis": "Use",
   "prov.switchedHotReload":
     "Provider switched. Next message starts a new session with the new config.",
@@ -1526,6 +1527,7 @@ const zh: Record<MessageKey, string> = {
   "prov.officialName": "官方 Grok",
   "prov.officialDesc": "Grok Build 官方登录 / API Key",
   "prov.active": "使用中",
+  "prov.customProvider": "自定义提供商",
   "prov.useThis": "使用",
   "prov.switchedHotReload":
     "已切换服务商。下一条消息会用新配置启动新会话。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -498,6 +498,7 @@ export const zhTW: Record<MessageKey, string> = {
   "prov.officialName": "官方 Grok",
   "prov.officialDesc": "Grok Build 官方登入 / API Key",
   "prov.active": "使用中",
+  "prov.customProvider": "自訂供應商",
   "prov.useThis": "使用",
   "prov.switchedHotReload":
     "已切換服務商。下一則訊息會用新設定啟動新對話。",


### PR DESCRIPTION
## Summary
- show the active custom provider name and model in the sidebar account menu instead of the official OAuth identity
- hide official quota and login/logout actions while a custom provider route is active
- aggregate local usage from both the standard Grok CLI sessions and the app-owned agent-home sessions
- refresh local usage after switching providers without making an irrelevant official billing request

Custom providers do not expose a standard remote quota API, so this PR intentionally reports their locally recorded session/request/token usage rather than inventing provider balance support.

## Tests
- `tsc -b --pretty false`
- `vitest run` (312 passed)
- `cargo test --lib` (175 passed, 1 ignored)
- `vite build`