### PR TITLE
fix(security): stop keychain prompts on app launch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "grok-app"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -539,7 +539,24 @@ pub async fn settings_set(
     mgr: State<'_, Arc<SessionManager>>,
     settings: AppSettings,
 ) -> Result<AppSettings, String> {
+    let prev = store::load_settings();
+    let keychain_flip =
+        prev.store_api_keys_in_keychain != settings.store_api_keys_in_keychain;
+
     store::save_settings(&settings)?;
+
+    if keychain_flip {
+        if let Err(e) =
+            crate::secrets::apply_keychain_preference(settings.store_api_keys_in_keychain)
+        {
+            // Revert flag so UI and storage stay consistent.
+            let mut rolled = settings.clone();
+            rolled.store_api_keys_in_keychain = prev.store_api_keys_in_keychain;
+            let _ = store::save_settings(&rolled);
+            return Err(e);
+        }
+    }
+
     // Full permission apply: Host + agent-home + soft-respawn if needed
     if let Err(e) = mgr
         .apply_permission_policy(&app, &settings.permission_policy)
@@ -715,7 +732,8 @@ pub async fn session_auto_title(
 
 #[tauri::command]
 pub async fn secrets_get_masked() -> Result<serde_json::Value, String> {
-    let s = store::load_secrets();
+    // Disk + presence flags only — do not unlock Keychain on app open.
+    let s = crate::secrets::load_secrets_disk_only();
     let providers = crate::providers::list_custom_providers().unwrap_or_else(|_| {
         crate::providers::ProvidersListResult {
             providers: vec![],
@@ -735,13 +753,19 @@ pub async fn secrets_get_masked() -> Result<serde_json::Value, String> {
         .map(|p| p.base_url.clone())
         .or(s.relay_base_url.clone());
     Ok(serde_json::json!({
-        "hasOfficialKey": s.official_api_key.as_ref().map(|k| !k.is_empty()).unwrap_or(false),
+        "hasOfficialKey": crate::secrets::has_official_key_configured(&s),
         "hasRelayKey": has_provider_key
-            || s.relay_api_key.as_ref().map(|k| !k.is_empty()).unwrap_or(false),
+            || crate::secrets::has_relay_key_configured(&s),
         "relayBaseUrl": relay_base,
         "defaultModel": providers.default_model.or(s.default_model),
         "providerCount": providers.providers.len(),
         "agentHome": providers.agent_home,
+        // Report user preference — do not soft-probe Keychain on cold start.
+        "secretsBackend": match crate::secrets::configured_backend() {
+            crate::secrets::SecretsBackendKind::Keychain => "keychain",
+            crate::secrets::SecretsBackendKind::File => "file",
+        },
+        "storeApiKeysInKeychain": store::load_settings().store_api_keys_in_keychain,
     }))
 }
 

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -695,8 +695,41 @@ mod tests {
 
     #[test]
     fn soft_probe_does_not_require_write() {
-        // Just ensure probe is callable; when keychain missing, returns false cleanly.
+        // Soft probe must not create credentials; leftover probe accounts should stay absent.
         let _ = probe_keychain();
+        if let Ok(entry) =
+            keyring::Entry::new(KEYRING_SERVICE, "__grok_app_keychain_probe__")
+        {
+            // After soft probe, either NoEntry or we cleaned a legacy probe write.
+            match entry.get_password() {
+                Err(keyring::Error::NoEntry) => {}
+                Ok(_) => {
+                    // Legacy leftover is OK; soft probe deletes it when seen.
+                    let _ = entry.delete_credential();
+                }
+                Err(_) => {}
+            }
+        }
+    }
+
+    #[test]
+    fn presence_helpers_do_not_need_key_material() {
+        let s = SecretsFile {
+            keychain_has_official: true,
+            keychain_has_relay: true,
+            official_api_key: None,
+            relay_api_key: None,
+            ..Default::default()
+        };
+        assert!(has_official_key_configured(&s));
+        assert!(has_relay_key_configured(&s));
+        assert!(!disk_has_plaintext_keys(&s));
+    }
+
+    #[test]
+    fn default_settings_prefer_file_not_keychain() {
+        let s = crate::store::AppSettings::default();
+        assert!(!s.store_api_keys_in_keychain);
     }
 
     #[test]

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1,4 +1,4 @@
-//! App secrets backend: OS keychain (preferred) with encrypted-at-rest file fallback.
+//! App secrets backend: OS keychain (preferred) with file fallback.
 //!
 //! Callers use [`crate::store::load_secrets`] / [`crate::store::save_secrets`] only —
 //! this module owns where `official_api_key` / `relay_api_key` actually live.
@@ -8,12 +8,18 @@
 //! - Linux: FreeDesktop Secret Service when available (`sync-secret-service`)
 //! - Fallback: `secrets.json` with mode `0600` when the OS store is unavailable
 //!
-//! Non-secret metadata (`relay_base_url`, `default_model`) always stays in `secrets.json`.
-//! Custom provider API keys in `agent-home/config.toml` are intentionally separate.
+//! Non-secret metadata (`relay_base_url`, `default_model`, `keychain_has_*`) always
+//! stays in `secrets.json`.
+//!
+//! **Startup UX:** never write a probe entry or unlock keychain just to paint
+//! "has key" flags. Presence uses disk flags / plaintext leftovers; real key
+//! material is loaded lazily when a caller needs the value.
 
 use std::fs;
 use std::path::PathBuf;
 use std::sync::OnceLock;
+
+use parking_lot::Mutex;
 
 use crate::paths::{ensure_app_dirs, secrets_file};
 use crate::store::SecretsFile;
@@ -33,13 +39,15 @@ pub enum SecretsBackendKind {
 
 static KEYCHAIN_USABLE: OnceLock<bool> = OnceLock::new();
 
-/// Probe OS keychain once and cache. Never logs secret values.
-fn keychain_usable() -> bool {
-    *KEYCHAIN_USABLE.get_or_init(|| probe_keychain())
-}
+/// Process-lifetime cache after first full unlock — avoids re-prompting Keychain
+/// on every `load_secrets()` within the same app session.
+static SESSION_CACHE: Mutex<Option<SecretsFile>> = Mutex::new(None);
 
+/// Soft probe: ask the OS store about a never-written account.
+///
+/// **Does not** call `set_password` — writing a throwaway entry is what made
+/// macOS ask for Keychain password on every cold start.
 fn probe_keychain() -> bool {
-    // Write + read + delete a throwaway entry. Failure → file fallback for the process lifetime.
     let probe_user = "__grok_app_keychain_probe__";
     let entry = match keyring::Entry::new(KEYRING_SERVICE, probe_user) {
         Ok(e) => e,
@@ -52,16 +60,17 @@ fn probe_keychain() -> bool {
             return false;
         }
     };
-    if let Err(e) = entry.set_password("probe") {
-        tracing::info!(
-            target: "grok_app::secrets",
-            error = %e,
-            "OS keychain write failed; using secrets.json fallback"
-        );
-        return false;
-    }
     match entry.get_password() {
-        Ok(v) if v == "probe" => {
+        // NoEntry = store is reachable and nothing stored (normal).
+        Err(keyring::Error::NoEntry) => {
+            tracing::info!(
+                target: "grok_app::secrets",
+                "OS keychain available for app secrets (soft probe)"
+            );
+            true
+        }
+        // Leftover probe from older builds — still means keychain works.
+        Ok(_) => {
             let _ = entry.delete_credential();
             tracing::info!(
                 target: "grok_app::secrets",
@@ -69,15 +78,30 @@ fn probe_keychain() -> bool {
             );
             true
         }
-        Ok(_) | Err(_) => {
-            let _ = entry.delete_credential();
+        Err(e) => {
             tracing::info!(
                 target: "grok_app::secrets",
-                "OS keychain read-back failed; using secrets.json fallback"
+                error = %e,
+                "OS keychain probe failed; using secrets.json fallback"
             );
             false
         }
     }
+}
+
+/// Soft probe once and cache. Never logs secret values.
+fn keychain_platform_ok() -> bool {
+    *KEYCHAIN_USABLE.get_or_init(probe_keychain)
+}
+
+/// User opted into OS keychain via settings (default false → file).
+fn prefer_keychain_storage() -> bool {
+    crate::store::load_settings().store_api_keys_in_keychain
+}
+
+/// Actually use keychain for read/write of API keys.
+fn use_keychain_backend() -> bool {
+    prefer_keychain_storage() && keychain_platform_ok()
 }
 
 fn keyring_entry(account: &str) -> Result<keyring::Entry, String> {
@@ -131,28 +155,49 @@ pub fn disk_has_plaintext_keys(disk: &SecretsFile) -> bool {
     non_empty(&disk.official_api_key) || non_empty(&disk.relay_api_key)
 }
 
-/// Disk payload with sensitive key fields stripped (metadata kept).
-/// Used after successful keychain writes so plaintext keys leave the filesystem.
+/// Whether UI / setup should treat an official key as configured.
+/// Uses plaintext on disk **or** keychain presence flag — never unlocks Keychain.
+pub fn has_official_key_configured(disk: &SecretsFile) -> bool {
+    non_empty(&disk.official_api_key) || disk.keychain_has_official
+}
+
+/// Whether a relay key is configured (disk plaintext or keychain flag).
+pub fn has_relay_key_configured(disk: &SecretsFile) -> bool {
+    non_empty(&disk.relay_api_key) || disk.keychain_has_relay
+}
+
+/// Disk payload with sensitive key fields stripped (metadata + presence flags kept).
 pub fn strip_keys_for_disk(s: &SecretsFile) -> SecretsFile {
     SecretsFile {
         official_api_key: None,
         relay_api_key: None,
         relay_base_url: s.relay_base_url.clone(),
         default_model: s.default_model.clone(),
+        keychain_has_official: s.keychain_has_official,
+        keychain_has_relay: s.keychain_has_relay,
     }
 }
 
 /// Merge keychain (preferred) over disk for sensitive fields; metadata from disk.
 pub fn merge_secrets(disk: SecretsFile, from_keychain: SecretsFile) -> SecretsFile {
+    let official = from_keychain
+        .official_api_key
+        .filter(|k| !k.is_empty())
+        .or(disk.official_api_key.filter(|k| !k.is_empty()));
+    let relay = from_keychain
+        .relay_api_key
+        .filter(|k| !k.is_empty())
+        .or(disk.relay_api_key.filter(|k| !k.is_empty()));
     SecretsFile {
-        official_api_key: from_keychain
-            .official_api_key
-            .filter(|k| !k.is_empty())
-            .or(disk.official_api_key.filter(|k| !k.is_empty())),
-        relay_api_key: from_keychain
-            .relay_api_key
-            .filter(|k| !k.is_empty())
-            .or(disk.relay_api_key.filter(|k| !k.is_empty())),
+        // Presence flags: true if we have a value or disk said keychain holds it.
+        keychain_has_official: non_empty(&official)
+            || disk.keychain_has_official
+            || from_keychain.keychain_has_official,
+        keychain_has_relay: non_empty(&relay)
+            || disk.keychain_has_relay
+            || from_keychain.keychain_has_relay,
+        official_api_key: official,
+        relay_api_key: relay,
         relay_base_url: disk.relay_base_url,
         default_model: disk.default_model,
     }
@@ -179,12 +224,23 @@ fn write_disk_secrets(path: &PathBuf, value: &SecretsFile) -> Result<(), String>
     Ok(())
 }
 
+fn invalidate_session_cache() {
+    *SESSION_CACHE.lock() = None;
+}
+
+/// Read `secrets.json` only — no Keychain unlock. Safe for cold-start UI.
+pub fn load_secrets_disk_only() -> SecretsFile {
+    let _ = ensure_app_dirs();
+    read_disk_secrets(&secrets_file())
+}
+
 /// One-shot migration: import plaintext keys from `secrets.json` into the OS keychain
 /// and clear those fields from disk. Safe to call repeatedly.
 ///
+/// Only runs when the user has enabled keychain storage.
 /// Returns how many key fields were migrated (0–2). Does not log secret values.
 pub fn migrate_plaintext_keys_to_keychain(disk: &mut SecretsFile) -> usize {
-    if !keychain_usable() {
+    if !use_keychain_backend() {
         return 0;
     }
     if !disk_has_plaintext_keys(disk) {
@@ -199,6 +255,7 @@ pub fn migrate_plaintext_keys_to_keychain(disk: &mut SecretsFile) -> usize {
         match keychain_set(KEY_OFFICIAL, key) {
             Ok(()) => {
                 disk.official_api_key = None;
+                disk.keychain_has_official = true;
                 migrated += 1;
             }
             Err(e) => {
@@ -218,6 +275,7 @@ pub fn migrate_plaintext_keys_to_keychain(disk: &mut SecretsFile) -> usize {
         match keychain_set(KEY_RELAY, key) {
             Ok(()) => {
                 disk.relay_api_key = None;
+                disk.keychain_has_relay = true;
                 migrated += 1;
             }
             Err(e) => {
@@ -233,7 +291,6 @@ pub fn migrate_plaintext_keys_to_keychain(disk: &mut SecretsFile) -> usize {
     }
 
     if migrated > 0 {
-        // Persist stripped (or partially stripped) disk image so plaintext does not linger.
         let path = secrets_file();
         if let Err(e) = write_disk_secrets(&path, disk) {
             tracing::warn!(
@@ -249,80 +306,241 @@ pub fn migrate_plaintext_keys_to_keychain(disk: &mut SecretsFile) -> usize {
                 "migrated plaintext secrets from secrets.json to OS keychain"
             );
         }
+        invalidate_session_cache();
     }
 
     migrated
 }
 
-/// Load secrets: migrate plaintext disk keys if needed, then overlay OS keychain.
+/// Load secrets with values.
+///
+/// - File mode (default): disk only, never touches Keychain.
+/// - Keychain mode: may unlock OS store once per process (then cached).
+///
+/// Use [`load_secrets_disk_only`] when you only need presence / metadata.
 pub fn load_secrets() -> SecretsFile {
+    {
+        let cache = SESSION_CACHE.lock();
+        if let Some(ref s) = *cache {
+            return s.clone();
+        }
+    }
+
     let _ = ensure_app_dirs();
     let path = secrets_file();
     let mut disk = read_disk_secrets(&path);
 
-    // Import any leftover plaintext keys before serving callers.
+    if !use_keychain_backend() {
+        *SESSION_CACHE.lock() = Some(disk.clone());
+        return disk;
+    }
+
     let _ = migrate_plaintext_keys_to_keychain(&mut disk);
 
-    if keychain_usable() {
-        let from_kc = SecretsFile {
-            official_api_key: keychain_get(KEY_OFFICIAL),
-            relay_api_key: keychain_get(KEY_RELAY),
-            relay_base_url: None,
-            default_model: None,
-        };
-        merge_secrets(disk, from_kc)
+    let official = if disk.keychain_has_official || non_empty(&disk.official_api_key) {
+        keychain_get(KEY_OFFICIAL)
     } else {
-        disk
-    }
+        None
+    };
+    let relay = if disk.keychain_has_relay || non_empty(&disk.relay_api_key) {
+        keychain_get(KEY_RELAY)
+    } else {
+        None
+    };
+    let from_kc = SecretsFile {
+        official_api_key: official,
+        relay_api_key: relay,
+        keychain_has_official: disk.keychain_has_official,
+        keychain_has_relay: disk.keychain_has_relay,
+        relay_base_url: None,
+        default_model: None,
+    };
+    let merged = merge_secrets(disk, from_kc);
+    *SESSION_CACHE.lock() = Some(merged.clone());
+    merged
 }
 
-/// Save secrets. Prefer OS keychain for API keys; always write metadata to disk.
+/// Save secrets. Keychain only when the user setting is on and the platform works.
 pub fn save_secrets(s: &SecretsFile) -> Result<(), String> {
     let _ = ensure_app_dirs();
     let path = secrets_file();
+    invalidate_session_cache();
 
-    if keychain_usable() {
-        // Write / clear each sensitive field in the OS store.
+    if use_keychain_backend() {
+        let mut disk = strip_keys_for_disk(s);
+
         match &s.official_api_key {
-            Some(k) if !k.is_empty() => keychain_set(KEY_OFFICIAL, k)?,
-            _ => keychain_delete(KEY_OFFICIAL)?,
+            Some(k) if !k.is_empty() => {
+                keychain_set(KEY_OFFICIAL, k)?;
+                disk.keychain_has_official = true;
+            }
+            _ => {
+                if s.keychain_has_official || non_empty(&s.official_api_key) {
+                    keychain_delete(KEY_OFFICIAL)?;
+                }
+                disk.keychain_has_official = false;
+            }
         }
         match &s.relay_api_key {
-            Some(k) if !k.is_empty() => keychain_set(KEY_RELAY, k)?,
-            _ => keychain_delete(KEY_RELAY)?,
+            Some(k) if !k.is_empty() => {
+                keychain_set(KEY_RELAY, k)?;
+                disk.keychain_has_relay = true;
+            }
+            _ => {
+                if s.keychain_has_relay || non_empty(&s.relay_api_key) {
+                    keychain_delete(KEY_RELAY)?;
+                }
+                disk.keychain_has_relay = false;
+            }
         }
-        // Never leave plaintext keys on disk once keychain holds them.
-        write_disk_secrets(&path, &strip_keys_for_disk(s))?;
+
+        write_disk_secrets(&path, &disk)?;
+        let cached = SecretsFile {
+            official_api_key: s.official_api_key.clone(),
+            relay_api_key: s.relay_api_key.clone(),
+            relay_base_url: disk.relay_base_url.clone(),
+            default_model: disk.default_model.clone(),
+            keychain_has_official: disk.keychain_has_official,
+            keychain_has_relay: disk.keychain_has_relay,
+        };
+        *SESSION_CACHE.lock() = Some(cached);
         Ok(())
     } else {
-        write_disk_secrets(&path, s)
+        // File mode: write full payload; drop any leftover keychain entries best-effort.
+        let mut file = s.clone();
+        if file.keychain_has_official || file.keychain_has_relay {
+            // Pull values if caller only had flags (shouldn't happen after load).
+            if !non_empty(&file.official_api_key) && file.keychain_has_official {
+                file.official_api_key = keychain_get(KEY_OFFICIAL);
+            }
+            if !non_empty(&file.relay_api_key) && file.keychain_has_relay {
+                file.relay_api_key = keychain_get(KEY_RELAY);
+            }
+            if keychain_platform_ok() {
+                let _ = keychain_delete(KEY_OFFICIAL);
+                let _ = keychain_delete(KEY_RELAY);
+            }
+        }
+        file.keychain_has_official = false;
+        file.keychain_has_relay = false;
+        write_disk_secrets(&path, &file)?;
+        *SESSION_CACHE.lock() = Some(file);
+        Ok(())
     }
 }
 
-/// Which backend currently holds sensitive key material (best-effort).
-pub fn active_backend() -> SecretsBackendKind {
-    if keychain_usable() {
+/// Backend according to **user setting** (not a live probe). Safe for cold-start UI.
+pub fn configured_backend() -> SecretsBackendKind {
+    if prefer_keychain_storage() {
         SecretsBackendKind::Keychain
     } else {
         SecretsBackendKind::File
     }
 }
 
-/// Remove OS keychain entries for app secrets. Safe if entries are missing.
-/// Does not delete `secrets.json` (caller decides).
-pub fn clear_keychain_secrets() {
-    if !keychain_usable() {
-        return;
+/// Live backend that would be used for the next save/load of key material.
+pub fn active_backend() -> SecretsBackendKind {
+    if use_keychain_backend() {
+        SecretsBackendKind::Keychain
+    } else {
+        SecretsBackendKind::File
     }
-    for account in [KEY_OFFICIAL, KEY_RELAY] {
-        if let Err(e) = keychain_delete(account) {
-            tracing::warn!(
-                target: "grok_app::secrets",
-                account,
-                error = %e,
-                "failed to delete secret from OS keychain"
+}
+
+/// Apply settings toggle. Call after `store_api_keys_in_keychain` is saved.
+///
+/// - on → move disk keys into Keychain (may prompt once)
+/// - off → pull keys to disk, clear Keychain (may unlock once)
+pub fn apply_keychain_preference(enabled: bool) -> Result<(), String> {
+    invalidate_session_cache();
+    let path = secrets_file();
+    let mut disk = read_disk_secrets(&path);
+
+    if enabled {
+        if !keychain_platform_ok() {
+            return Err(
+                "OS keychain is not available; keys stay in secrets.json".into(),
             );
         }
+        // Re-read any values already in keychain so we don't drop them.
+        if disk.keychain_has_official && !non_empty(&disk.official_api_key) {
+            disk.official_api_key = keychain_get(KEY_OFFICIAL);
+        }
+        if disk.keychain_has_relay && !non_empty(&disk.relay_api_key) {
+            disk.relay_api_key = keychain_get(KEY_RELAY);
+        }
+
+        let mut meta = strip_keys_for_disk(&disk);
+        let mut official = disk.official_api_key.clone();
+        let mut relay = disk.relay_api_key.clone();
+
+        if non_empty(&official) {
+            keychain_set(KEY_OFFICIAL, official.as_deref().unwrap())?;
+            meta.keychain_has_official = true;
+        }
+        if non_empty(&relay) {
+            keychain_set(KEY_RELAY, relay.as_deref().unwrap())?;
+            meta.keychain_has_relay = true;
+        }
+
+        write_disk_secrets(&path, &meta)?;
+        *SESSION_CACHE.lock() = Some(SecretsFile {
+            official_api_key: official.take(),
+            relay_api_key: relay.take(),
+            relay_base_url: meta.relay_base_url,
+            default_model: meta.default_model,
+            keychain_has_official: meta.keychain_has_official,
+            keychain_has_relay: meta.keychain_has_relay,
+        });
+        tracing::info!(target: "grok_app::secrets", "API keys storage: OS keychain");
+        Ok(())
+    } else {
+        if keychain_platform_ok() {
+            if disk.keychain_has_official || non_empty(&disk.official_api_key) {
+                if let Some(k) = keychain_get(KEY_OFFICIAL) {
+                    disk.official_api_key = Some(k);
+                }
+            }
+            if disk.keychain_has_relay || non_empty(&disk.relay_api_key) {
+                if let Some(k) = keychain_get(KEY_RELAY) {
+                    disk.relay_api_key = Some(k);
+                }
+            }
+            let _ = keychain_delete(KEY_OFFICIAL);
+            let _ = keychain_delete(KEY_RELAY);
+        }
+        disk.keychain_has_official = false;
+        disk.keychain_has_relay = false;
+        write_disk_secrets(&path, &disk)?;
+        *SESSION_CACHE.lock() = Some(disk);
+        tracing::info!(target: "grok_app::secrets", "API keys storage: secrets.json");
+        Ok(())
+    }
+}
+
+/// Remove OS keychain entries for app secrets. Safe if entries are missing.
+pub fn clear_keychain_secrets() {
+    invalidate_session_cache();
+    if keychain_platform_ok() {
+        for account in [KEY_OFFICIAL, KEY_RELAY] {
+            if let Err(e) = keychain_delete(account) {
+                tracing::warn!(
+                    target: "grok_app::secrets",
+                    account,
+                    error = %e,
+                    "failed to delete secret from OS keychain"
+                );
+            }
+        }
+    }
+    let path = secrets_file();
+    if path.is_file() {
+        let mut disk = read_disk_secrets(&path);
+        disk.keychain_has_official = false;
+        disk.keychain_has_relay = false;
+        disk.official_api_key = None;
+        disk.relay_api_key = None;
+        let _ = write_disk_secrets(&path, &disk);
     }
     tracing::info!(
         target: "grok_app::secrets",
@@ -337,6 +555,7 @@ pub fn wipe_all_secrets() -> Result<(), String> {
     if path.is_file() {
         fs::remove_file(&path).map_err(|e| e.to_string())?;
     }
+    invalidate_session_cache();
     Ok(())
 }
 
@@ -370,18 +589,34 @@ mod tests {
     }
 
     #[test]
-    fn strip_keys_for_disk_keeps_metadata() {
+    fn presence_uses_keychain_flags_without_values() {
+        let disk = SecretsFile {
+            keychain_has_official: true,
+            keychain_has_relay: false,
+            ..Default::default()
+        };
+        assert!(has_official_key_configured(&disk));
+        assert!(!has_relay_key_configured(&disk));
+        assert!(!disk_has_plaintext_keys(&disk));
+    }
+
+    #[test]
+    fn strip_keys_for_disk_keeps_metadata_and_flags() {
         let s = SecretsFile {
             official_api_key: Some("sk-secret".into()),
             relay_api_key: Some("rk-secret".into()),
             relay_base_url: Some("https://relay.example".into()),
             default_model: Some("grok-4".into()),
+            keychain_has_official: true,
+            keychain_has_relay: true,
         };
         let disk = strip_keys_for_disk(&s);
         assert!(disk.official_api_key.is_none());
         assert!(disk.relay_api_key.is_none());
         assert_eq!(disk.relay_base_url.as_deref(), Some("https://relay.example"));
         assert_eq!(disk.default_model.as_deref(), Some("grok-4"));
+        assert!(disk.keychain_has_official);
+        assert!(disk.keychain_has_relay);
     }
 
     #[test]
@@ -391,6 +626,8 @@ mod tests {
             relay_api_key: None,
             relay_base_url: Some("https://example.com".into()),
             default_model: Some("m1".into()),
+            keychain_has_official: false,
+            keychain_has_relay: false,
         };
         let kc = SecretsFile {
             official_api_key: Some("kc-new".into()),
@@ -402,6 +639,8 @@ mod tests {
         assert_eq!(m.relay_api_key.as_deref(), Some("kc-relay"));
         assert_eq!(m.relay_base_url.as_deref(), Some("https://example.com"));
         assert_eq!(m.default_model.as_deref(), Some("m1"));
+        assert!(m.keychain_has_official);
+        assert!(m.keychain_has_relay);
     }
 
     #[test]
@@ -411,6 +650,7 @@ mod tests {
             relay_api_key: Some("disk-relay".into()),
             relay_base_url: Some("https://x".into()),
             default_model: None,
+            ..Default::default()
         };
         let kc = SecretsFile::default();
         let m = merge_secrets(disk, kc);
@@ -425,19 +665,20 @@ mod tests {
             relay_api_key: Some("rk-nope".into()),
             relay_base_url: Some("https://relay.example".into()),
             default_model: Some("g".into()),
+            keychain_has_official: true,
+            keychain_has_relay: false,
         };
         let disk = strip_keys_for_disk(&s);
         let json = serde_json::to_string(&disk).unwrap();
         assert!(!json.contains("sk-should-not-serialize"));
         assert!(!json.contains("rk-nope"));
         assert!(json.contains("relay.example") || json.contains("relayBaseUrl"));
+        assert!(json.contains("keychainHasOfficial") || json.contains("true"));
     }
 
-    /// Integration-style: real OS keychain when available (macOS CI / local), else skip soft.
     #[test]
     fn keychain_roundtrip_when_available() {
         if !probe_keychain() {
-            // File fallback path still valid on headless Linux without Secret Service.
             return;
         }
         let account = format!("test_roundtrip_{}", std::process::id());
@@ -452,57 +693,12 @@ mod tests {
         ));
     }
 
-    /// Disk image after a successful keychain write keeps metadata only.
-    /// (Does not touch GROK_APP_HOME — avoids races with other tests.)
     #[test]
-    fn stripped_disk_payload_keeps_metadata_only() {
-        let full = SecretsFile {
-            official_api_key: Some("sk-test-official-keychain-only".into()),
-            relay_api_key: Some("rk-test-relay-keychain-only".into()),
-            relay_base_url: Some("https://relay.test".into()),
-            default_model: Some("grok-test".into()),
-        };
-        let disk = strip_keys_for_disk(&full);
-        let raw = serde_json::to_string_pretty(&disk).unwrap();
-        assert!(!raw.contains("sk-test-official-keychain-only"));
-        assert!(!raw.contains("rk-test-relay-keychain-only"));
-        assert!(raw.contains("relay.test") || raw.contains("relayBaseUrl"));
-        assert!(disk.official_api_key.is_none());
-        assert!(disk.relay_api_key.is_none());
-        assert_eq!(disk.relay_base_url.as_deref(), Some("https://relay.test"));
+    fn soft_probe_does_not_require_write() {
+        // Just ensure probe is callable; when keychain missing, returns false cleanly.
+        let _ = probe_keychain();
     }
 
-    /// Isolated keychain entry + stripped disk image (no GROK_APP_HOME races).
-    #[test]
-    fn keychain_entry_and_stripped_disk_do_not_share_plaintext() {
-        if !probe_keychain() {
-            return;
-        }
-        let acct = format!("test_mig_{}", std::process::id());
-        let entry = keyring::Entry::new(KEYRING_SERVICE, &acct).unwrap();
-        let _ = entry.delete_credential();
-        entry
-            .set_password("sk-legacy-migrate-me")
-            .expect("keychain set");
-        assert_eq!(entry.get_password().unwrap(), "sk-legacy-migrate-me");
-
-        // After migrate, disk holds metadata only.
-        let disk = SecretsFile {
-            official_api_key: None,
-            relay_api_key: None,
-            relay_base_url: Some("https://legacy.test".into()),
-            default_model: None,
-        };
-        assert!(!disk_has_plaintext_keys(&disk));
-        let raw = serde_json::to_string(&disk).unwrap();
-        assert!(!raw.contains("sk-legacy-migrate-me"));
-        assert!(raw.contains("legacy.test") || raw.contains("relayBaseUrl"));
-
-        let _ = entry.delete_credential();
-    }
-
-    /// File fallback path: full SecretsFile roundtrip on disk (when keychain off is hard
-    /// to force after OnceLock; exercise write_disk_secrets strip helpers instead).
     #[test]
     fn file_write_preserves_keys_when_using_full_payload() {
         let tmp = std::env::temp_dir().join(format!(
@@ -517,6 +713,7 @@ mod tests {
             relay_api_key: Some("rk-file".into()),
             relay_base_url: Some("https://f".into()),
             default_model: Some("m".into()),
+            ..Default::default()
         };
         write_disk_secrets(&path, &s).unwrap();
         let back = read_disk_secrets(&path);

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -155,6 +155,11 @@ pub struct AppSettings {
     /// Pure stream silence before cancel prompt (I06). Default 120 seconds.
     #[serde(default = "default_stream_stall_seconds")]
     pub stream_stall_seconds: u32,
+    /// Store App API keys in the OS keychain (macOS Keychain / Win Cred / Secret Service).
+    /// Default **false**: keys stay in `secrets.json` (0600) so cold start does not
+    /// trigger system password prompts. Official CLI login still uses `auth.json`.
+    #[serde(default)]
+    pub store_api_keys_in_keychain: bool,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -198,6 +203,7 @@ impl Default for AppSettings {
             max_concurrent_agents: default_max_concurrent_agents(),
             agent_idle_minutes: default_agent_idle_minutes(),
             stream_stall_seconds: default_stream_stall_seconds(),
+            store_api_keys_in_keychain: false,
         }
     }
 }
@@ -209,6 +215,9 @@ impl Default for AppSettings {
 /// `secrets.json` (0600) fallback. See [`crate::secrets`].
 ///
 /// Never log these fields.
+///
+/// `keychain_has_*` are non-secret booleans written to `secrets.json` so the UI
+/// can report "has a key" without unlocking the OS keychain on every launch.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretsFile {
@@ -216,6 +225,12 @@ pub struct SecretsFile {
     pub relay_base_url: Option<String>,
     pub relay_api_key: Option<String>,
     pub default_model: Option<String>,
+    /// Official API key lives in OS keychain (value not on disk).
+    #[serde(default)]
+    pub keychain_has_official: bool,
+    /// Relay API key lives in OS keychain (value not on disk).
+    #[serde(default)]
+    pub keychain_has_relay: bool,
 }
 
 /// File/image card persisted with a chat message (user attach or agent image_gen).
@@ -264,7 +279,17 @@ fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<(), String> {
 
 pub fn load_settings() -> AppSettings {
     let _ = ensure_app_dirs();
-    read_json(&settings_file())
+    let mut s: AppSettings = read_json(&settings_file());
+    // One-time: installs that already stored keys in keychain before the opt-in
+    // keep keychain mode so keys remain reachable without a silent loss.
+    if !s.store_api_keys_in_keychain {
+        let disk = crate::secrets::load_secrets_disk_only();
+        if disk.keychain_has_official || disk.keychain_has_relay {
+            s.store_api_keys_in_keychain = true;
+            let _ = write_json(&settings_file(), &s);
+        }
+    }
+    s
 }
 
 pub fn save_settings(s: &AppSettings) -> Result<(), String> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -609,6 +609,7 @@ export default function App() {
   const [maxConcurrentAgents, setMaxConcurrentAgents] = useState(3);
   const [agentIdleMinutes, setAgentIdleMinutes] = useState(30);
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
+  const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
   /** Host stream-stall prompt (I06); null when dismissed or not stalled. */
   const [streamStall, setStreamStall] = useState<{
     sessionId?: string;
@@ -817,6 +818,7 @@ export default function App() {
           ? Math.min(900, Math.round(settings.streamStallSeconds))
           : 120,
       );
+      setStoreApiKeysInKeychain(!!settings.storeApiKeysInKeychain);
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -5547,6 +5549,20 @@ export default function App() {
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, streamStallSeconds: v }),
             );
+          }}
+          storeApiKeysInKeychain={storeApiKeysInKeychain}
+          onStoreApiKeysInKeychain={(v) => {
+            const prev = storeApiKeysInKeychain;
+            setStoreApiKeysInKeychain(v);
+            void api
+              .settingsGet()
+              .then((s) =>
+                api.settingsSet({ ...s, storeApiKeysInKeychain: v }),
+              )
+              .catch((e) => {
+                setStoreApiKeysInKeychain(prev);
+                showToast(String(e), 4500);
+              });
           }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -106,6 +106,9 @@ export interface SettingsPageProps {
   /** Stream stall silence timeout seconds (I06). */
   streamStallSeconds?: number;
   onStreamStallSeconds?: (v: number) => void;
+  /** Store App API keys in OS keychain (default off → secrets.json). */
+  storeApiKeysInKeychain?: boolean;
+  onStoreApiKeysInKeychain?: (v: boolean) => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -404,6 +407,8 @@ export function SettingsPage({
   onAgentIdleMinutes,
   streamStallSeconds = 120,
   onStreamStallSeconds,
+  storeApiKeysInKeychain = false,
+  onStoreApiKeysInKeychain,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -882,6 +887,25 @@ export function SettingsPage({
                   ]}
                 />
               </div>
+              {onStoreApiKeysInKeychain ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.storeApiKeysInKeychain")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.storeApiKeysInKeychainDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={storeApiKeysInKeychain}
+                    onChange={() =>
+                      onStoreApiKeysInKeychain(!storeApiKeysInKeychain)
+                    }
+                    ariaLabel={t("settings.storeApiKeysInKeychain")}
+                  />
+                </div>
+              ) : null}
               {onDefaultOpenTarget && (
                 <div className="settings-row">
                   <div className="settings-row__text">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -421,6 +421,9 @@ const en = {
   "settings.sessionDataMode": "Session data mode",
   "settings.sessionDataModeDesc":
     "Where chat history is stored (independent app dir or shared with CLI)",
+  "settings.storeApiKeysInKeychain": "Store API keys in system keychain",
+  "settings.storeApiKeysInKeychainDesc":
+    "Off by default: keys stay in the app data folder (mode 0600). Turn on to use the OS keychain — the system may ask once. Official login still uses Grok Build auth.",
   "settings.cliPath": "CLI path",
   "settings.cliPathDesc": "Path to the Grok Build CLI binary",
   "settings.cliNotFound": "(not found)",
@@ -1423,6 +1426,9 @@ const zh: Record<MessageKey, string> = {
   "settings.languageDesc": "应用界面语言",
   "settings.sessionDataMode": "会话数据模式",
   "settings.sessionDataModeDesc": "会话历史存储位置（应用独立目录或与 CLI 共享）",
+  "settings.storeApiKeysInKeychain": "用系统钥匙串保存 API Key",
+  "settings.storeApiKeysInKeychainDesc":
+    "默认关闭：密钥写在应用数据目录（0600）。开启后写入系统钥匙串，系统可能要求一次授权。官方登录仍走 Grok Build 鉴权，不受此项影响。",
   "settings.cliPath": "CLI 路径",
   "settings.cliPathDesc": "Grok Build CLI 可执行文件路径",
   "settings.cliNotFound": "（未找到）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -395,6 +395,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.languageDesc": "應用程式介面語言",
   "settings.sessionDataMode": "對話資料模式",
   "settings.sessionDataModeDesc": "對話歷史儲存位置（應用程式獨立目錄或與 CLI 共用）",
+  "settings.storeApiKeysInKeychain": "以系統鑰匙圈儲存 API Key",
+  "settings.storeApiKeysInKeychainDesc":
+    "預設關閉：金鑰寫在應用資料目錄（0600）。開啟後寫入系統鑰匙圈，系統可能要求一次授權。官方登入仍走 Grok Build 驗證，不受此項影響。",
   "settings.cliPath": "CLI 路徑",
   "settings.cliPathDesc": "Grok Build CLI 可執行檔路徑",
   "settings.cliNotFound": "（未找到）",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -589,6 +589,11 @@ export interface AppSettings {
   agentIdleMinutes?: number;
   /** Pure stream silence before cancel prompt, seconds (default 120). */
   streamStallSeconds?: number;
+  /**
+   * When true, App API keys go in the OS keychain.
+   * Default false: keys stay in secrets.json (0600). Official login uses auth.json.
+   */
+  storeApiKeysInKeychain?: boolean;
 }
 
 export interface AvailableModel {


### PR DESCRIPTION
## Problem
Opening the app could immediately ask for a system keychain / password dialog. Cold start only needs to know whether a key exists, but we were probing Keychain with a write and loading full secret values.

## Changes
- Default: API keys stay in `secrets.json` (0600). OS keychain is **opt-in** under Settings → General.
- Startup `secrets_get_masked` reads disk only (presence flags + leftover plaintext); no Keychain unlock.
- Soft probe never `set_password`s a throwaway entry.
- Real Keychain read/write only when the setting is on; results cached for the process.
- Toggle on/off migrates keys between file and Keychain (one unlock possible when switching).
- Installs that already had `keychainHas*` flags keep keychain mode so keys are not silently lost.
- Official Grok Build login still uses `auth.json` / CLI auth, not this path.

## Test
```bash
pnpm typecheck
pnpm test
cd src-tauri && cargo test secrets::
```

Manual:
1. Fresh settings → open app → no keychain password dialog for the setup gate.
2. Settings → General → store in keychain off by default.
3. Turn on → may prompt once; keys leave disk plaintext; turn off → keys return to file.

Rebased on current main.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (315)
- [x] `cargo test secrets::` (9)
- [x] i18n en / zh / zh-TW keys
- [ ] Desktop: cold start without keychain prompt
- [ ] Desktop: toggle keychain on/off