### PR TITLE
feat(plan): resource-pane review, top progress only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ### Added
 
 - **Sticky Plan/Goal status bar** (L04): progress meter + review actions stay above the chat while the in-thread card scrolls away — community PR #41.
+- **Plan resource review**: 「在资源中打开」opens the right pane Plan workbench with full **Markdown** body, steps, and approve/request-changes; auto-opens when `exit_plan_mode` is ready. Accent-tinted bar (theme-aware) with top spacing under chrome.
 
 ### Fixed
 
@@ -21,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **Composer placeholder**: hide overlay as soon as the DOM has typed/IME glyphs (no more “随心输入” showing through input).
 - **Chat scroll flicker**: ignore sub-4px content height noise while stick-to-bottom follows (thinking / reflow thrash).
 - **Dead copy**: remove obsolete `composer.attachLater` (“attachments coming later”) now that paste/file pick ship.
+- **Plan “Details” no-op**: was only scrolling the in-thread card; now opens the resource Plan panel.
 
 ## [0.1.3] - 2026-07-24
 

--- a/docs/llm-wiki/agent-gui-reference.md
+++ b/docs/llm-wiki/agent-gui-reference.md
@@ -12,6 +12,7 @@
 | **OpenHands Canvas / 通用三栏** | 左会话 / 中对话 / 右资源，侧栏可关 | `sidebar--hidden` / `aside--hidden` + 顶栏 icon |
 | **会话变更审阅（L06）** | Agent 写/改文件列表 + unified diff / 外开编辑器 | `ResourceViewer` Changes 模式 + `sessionChanges` + 可选 `git_file_diff` |
 | **工作区 git 变更** | 项目 `git status` 列表 + 点击看 diff | `git_status` / `git_show_file` + Changes → **Workspace** 段 |
+| **Plan 审阅** | 待审阅计划 Markdown 全文 + 批准/修改 | `ResourceViewer` **Plan** 模式 + sticky `PlanStatusBar` |
 
 ## 交互约定
 
@@ -24,3 +25,8 @@
    - 点击条目：优先工具 payload 的 before/after → 本地 unified diff；否则 `git_file_diff`；再否则 `git_show_file`（HEAD）+ 工作区内容；再否则当前文件内容。  
    - 行操作：打开编辑器 / Reveal / 复制路径（**不做**危险 discard，避免误清工作区）。  
    - 纯 helper：`src/lib/sessionChanges.ts`、`src/lib/workspaceGit.ts`。
+5. **Plan（资源审阅）**：顶条「在资源中打开」/ `exit_plan_mode` 就绪时自动开右栏 **Plan** 模式。  
+   - 正文：`MarkdownBody`（`planContent` 优先，否则 entries 合成 markdown）。  
+   - 操作：批准 / 请求修改 / 关闭（与顶条共用 `sessionResolvePlan`）。  
+   - 线程内保留紧凑预览卡；主审阅面在资源面板。  
+   - helper：`src/lib/planBody.ts`、`PlanReviewPanel`。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -289,6 +289,11 @@ interface PlanState {
   /** Pending exit_plan_mode JSON-RPC id */
   rpcId?: number | null;
   toolCallId?: string | null;
+  /**
+   * Soft-hide the top PlanStatusBar without clearing progress.
+   * Cleared when new plan events arrive or review gate opens.
+   */
+  barDismissed?: boolean;
 }
 
 export default function App() {
@@ -565,6 +570,7 @@ export default function App() {
     visible: false,
     rpcId: null,
     toolCallId: null,
+    barDismissed: false,
   });
   const [locale, setLocale] = useState<Locale>("zh");
   const localeRef = useRef(locale);
@@ -1512,6 +1518,8 @@ export default function App() {
                     : prev.visible
                       ? (prev.toolCallId ?? null)
                       : null,
+                // New plan activity always resurfaces the top progress bar.
+                barDismissed: false,
               };
             });
           }),
@@ -3767,6 +3775,7 @@ export default function App() {
   }, [plan.rpcId, showToast, tr]);
 
   const dismissPlan = useCallback(async () => {
+    // Review gate: abandon RPC and clear plan UI entirely.
     if (plan.rpcId != null) {
       try {
         await api.sessionResolvePlan({
@@ -3776,14 +3785,21 @@ export default function App() {
       } catch {
         /* hide UI anyway */
       }
+      setPlan((p) => ({
+        ...p,
+        visible: false,
+        waiting: true,
+        entries: [],
+        body: "",
+        rpcId: null,
+        barDismissed: false,
+      }));
+      return;
     }
+    // Execution progress only: soft-hide top bar; keep entries for later updates.
     setPlan((p) => ({
       ...p,
-      visible: false,
-      waiting: true,
-      entries: [],
-      body: "",
-      rpcId: null,
+      barDismissed: true,
     }));
   }, [plan.rpcId]);
 
@@ -6399,7 +6415,7 @@ export default function App() {
             </div>
           )}
 
-          {mainPane === "chat" && (
+          {mainPane === "chat" && !plan.barDismissed && (
             <PlanStatusBar
               goalMode={goalMode}
               mode={mode}
@@ -6518,11 +6534,6 @@ export default function App() {
               });
               setResourceOpenTarget(target);
             }}
-            plan={plan}
-            onApprovePlan={() => void approvePlan()}
-            onRequestPlanChanges={() => void requestPlanChanges()}
-            onDismissPlan={() => void dismissPlan()}
-            onOpenPlanDetails={() => openPlanInResource()}
             onAddAttachmentToComposer={(att) =>
               setAttachments((prev) => mergeAttachments(prev, [att]))
             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -587,6 +587,8 @@ export default function App() {
   /** Chat file/url card → open in right resource pane. */
   const [resourceOpenTarget, setResourceOpenTarget] =
     useState<ResourceOpenTarget | null>(null);
+  /** Bump to force ResourceViewer into Plan review mode (详情 / auto-open). */
+  const [planFocusKey, setPlanFocusKey] = useState(0);
   /** Live drag-drop target for zone overlays (null = not dragging). */
   const [dragZone, setDragZone] = useState<"sidebar" | "main" | null>(null);
   const [toast, setToast] = useState<string | null>(null);
@@ -1479,6 +1481,20 @@ export default function App() {
                   : prev.visible
                     ? (prev.rpcId ?? null)
                     : null;
+              const becameReview =
+                rpcId != null && (prev.rpcId == null || !prev.visible);
+              if (becameReview) {
+                // Auto-open resource Plan workbench when gate is ready.
+                queueMicrotask(() => {
+                  setLayout((l) => {
+                    if (!l.asideCollapsed) return l;
+                    const n = { ...l, asideCollapsed: false };
+                    saveLayout(localStorage, n);
+                    return n;
+                  });
+                  setPlanFocusKey((k) => k + 1);
+                });
+              }
               return {
                 title: tr("plan.ready"),
                 body: displayBody || (prev.visible ? prev.body : ""),
@@ -3770,6 +3786,17 @@ export default function App() {
       rpcId: null,
     }));
   }, [plan.rpcId]);
+
+  /** Open resource pane Plan review (replaces scroll-to-card “详情”). */
+  const openPlanInResource = useCallback(() => {
+    setLayout((l) => {
+      if (!l.asideCollapsed) return l;
+      const n = { ...l, asideCollapsed: false };
+      saveLayout(localStorage, n);
+      return n;
+    });
+    setPlanFocusKey((k) => k + 1);
+  }, []);
 
   const sendQueueLabels = useMemo(
     () => ({
@@ -6397,13 +6424,7 @@ export default function App() {
               onApprove={() => void approvePlan()}
               onRequestChanges={() => void requestPlanChanges()}
               onDismiss={() => void dismissPlan()}
-              onOpenDetails={() => {
-                document
-                  .querySelector<HTMLElement>(
-                    ".lobe-chat-plan, .plan-card, [data-plan-card]",
-                  )
-                  ?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-              }}
+              onOpenDetails={() => openPlanInResource()}
             />
           )}
 
@@ -6501,6 +6522,7 @@ export default function App() {
             onApprovePlan={() => void approvePlan()}
             onRequestPlanChanges={() => void requestPlanChanges()}
             onDismissPlan={() => void dismissPlan()}
+            onOpenPlanDetails={() => openPlanInResource()}
             onAddAttachmentToComposer={(att) =>
               setAttachments((prev) => mergeAttachments(prev, [att]))
             }
@@ -7067,6 +7089,11 @@ export default function App() {
               sessionChanges={
                 sessionChangesById[session.sessionId || ""] ?? []
               }
+              plan={plan}
+              planFocusKey={planFocusKey}
+              onApprovePlan={() => void approvePlan()}
+              onRequestPlanChanges={() => void requestPlanChanges()}
+              onDismissPlan={() => void dismissPlan()}
               onClose={() =>
                 setLayout((l) => {
                   const n = { ...l, asideCollapsed: true };

--- a/src/components/PlanReviewPanel.tsx
+++ b/src/components/PlanReviewPanel.tsx
@@ -1,40 +1,51 @@
 /**
- * Plan review workbench — full markdown body + step list + approve/revise.
- * Used by ResourceViewer (primary) and optionally thread compact views.
+ * Plan review workbench (resource pane).
+ *
+ * - **Awaiting review** (`rpcId`): expand by default — Markdown + approve/revise.
+ * - **In progress** (entries, no gate): collapsed by default — top progress only;
+ *   click header / expand control to show steps + detail body.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { MarkdownBody } from "@/components/MarkdownBody";
 import { OverlayScroll } from "@/components/OverlayScroll";
-import { IconPlan } from "@/components/icons";
+import { IconChevronDown, IconChevronRight, IconPlan } from "@/components/icons";
 import {
   planActionsEnabled,
   planDisplayMarkdown,
+  planIsAwaitingReview,
   type PlanReviewState,
 } from "@/lib/planBody";
 import {
   computePlanProgress,
   formatPlanFraction,
   parsePlanEntries,
+  resolvePlanBarModel,
 } from "@/lib/planStatus";
 
 export type PlanReviewPanelLabels = {
   ready: string;
   waiting: string;
+  progress: string;
+  done: string;
   empty: string;
   approve: string;
   changes: string;
   dismiss: string;
   steps: string;
   fraction: string;
-  openInResources?: string;
+  /** Expand control when collapsed. */
+  expandDetails: string;
+  /** Collapse control when expanded. */
+  collapseDetails: string;
+  current: string;
 };
 
 export type PlanReviewPanelProps = {
   plan: PlanReviewState;
   labels: PlanReviewPanelLabels;
-  /** Compact: shorter header, used if ever embedded elsewhere. */
-  compact?: boolean;
+  /** When set, forces expand (e.g. user clicked 详情 during progress). */
+  forceExpandKey?: number | null;
   onApprove?: () => void;
   onRequestChanges?: () => void;
   onDismiss?: () => void;
@@ -43,16 +54,12 @@ export type PlanReviewPanelProps = {
 export function PlanReviewPanel({
   plan,
   labels,
-  compact = false,
+  forceExpandKey = null,
   onApprove,
   onRequestChanges,
   onDismiss,
 }: PlanReviewPanelProps) {
   const hasBody = !!plan.body.trim();
-  const markdown = useMemo(
-    () => planDisplayMarkdown(plan.body, plan.entries),
-    [plan.body, plan.entries],
-  );
   const entries = useMemo(
     () => parsePlanEntries(plan.entries),
     [plan.entries],
@@ -60,33 +67,113 @@ export function PlanReviewPanel({
   const progress = useMemo(() => computePlanProgress(entries), [entries]);
   const fraction = formatPlanFraction(progress);
   const canAct = planActionsEnabled(plan);
-  const statusLabel = plan.waiting && !canAct ? labels.waiting : labels.ready;
-  // Steps list only when body is real planContent (avoid duplicating synthesized MD).
-  const showStepsList = hasBody && entries.length > 0;
+  const awaitingReview = planIsAwaitingReview(plan);
+
+  const model = useMemo(
+    () =>
+      resolvePlanBarModel({
+        goalMode: false,
+        mode: "agent",
+        planVisible: plan.visible,
+        planWaiting: plan.waiting,
+        planRpcId: plan.rpcId,
+        entries: plan.entries,
+      }),
+    [plan.visible, plan.waiting, plan.rpcId, plan.entries],
+  );
+
+  // Real planContent markdown only (do not dump raw entries as MD when collapsed).
+  const detailMarkdown = useMemo(() => {
+    if (hasBody) return plan.body.trim();
+    // Review with only entries: still show structured list below, no raw dump.
+    if (awaitingReview && !entries.length) {
+      return planDisplayMarkdown(plan.body, plan.entries);
+    }
+    return "";
+  }, [hasBody, plan.body, plan.entries, awaitingReview, entries.length]);
+
+  const statusLabel =
+    model.headlineKey === "planBar.progress"
+      ? labels.progress
+      : model.headlineKey === "planBar.done"
+        ? labels.done
+        : model.headlineKey === "planBar.review"
+          ? labels.ready
+          : plan.waiting && !canAct
+            ? labels.waiting
+            : labels.ready;
+
+  // Review gate → expanded; pure progress → collapsed until user opens.
+  const defaultExpanded = awaitingReview || (hasBody && entries.length === 0);
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  // When plan identity / gate flips, reset expand policy.
+  useEffect(() => {
+    setExpanded(defaultExpanded);
+  }, [defaultExpanded, plan.rpcId, plan.title]);
+
+  // 详情 / planFocusKey: force expand so steps+detail are visible.
+  useEffect(() => {
+    if (forceExpandKey == null) return;
+    setExpanded(true);
+  }, [forceExpandKey]);
+
+  const hasExpandableContent =
+    entries.length > 0 || !!detailMarkdown || !!planDisplayMarkdown(plan.body, plan.entries);
+
+  const toggleExpand = () => {
+    if (!hasExpandableContent) return;
+    setExpanded((v) => !v);
+  };
 
   return (
     <div
       className={
-        "plan-review" + (compact ? " plan-review--compact" : "")
+        "plan-review" +
+        (expanded ? " plan-review--expanded" : " plan-review--collapsed")
       }
       data-testid="plan-review-panel"
       data-plan-card
     >
       <header className="plan-review__header">
-        <div className="plan-review__title-row">
+        <button
+          type="button"
+          className="plan-review__title-row plan-review__title-row--btn"
+          onClick={toggleExpand}
+          disabled={!hasExpandableContent}
+          aria-expanded={expanded}
+        >
           <span className="plan-review__icon" aria-hidden>
             <IconPlan size={16} />
           </span>
           <div className="plan-review__titles">
             <div className="plan-review__status">{statusLabel}</div>
             <h2 className="plan-review__title">{plan.title || statusLabel}</h2>
+            {!expanded && model.currentLabel ? (
+              <div className="plan-review__current" title={model.currentLabel}>
+                <span className="plan-review__current-label">{labels.current}</span>
+                <span className="plan-review__current-step">
+                  {model.currentLabel}
+                </span>
+              </div>
+            ) : null}
           </div>
           {fraction ? (
             <span className="plan-review__fraction">
               {labels.fraction.replace("{n}", fraction)}
             </span>
           ) : null}
-        </div>
+          {hasExpandableContent ? (
+            <span className="plan-review__chevron" aria-hidden>
+              {expanded ? (
+                <IconChevronDown size={16} />
+              ) : (
+                <IconChevronRight size={16} />
+              )}
+            </span>
+          ) : null}
+        </button>
+
         {progress.total > 0 ? (
           <div
             className="plan-review__meter"
@@ -101,22 +188,30 @@ export function PlanReviewPanel({
             />
           </div>
         ) : null}
+
         <div className="plan-review__actions">
-          {onApprove ? (
+          {hasExpandableContent ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={toggleExpand}
+            >
+              {expanded ? labels.collapseDetails : labels.expandDetails}
+            </button>
+          ) : null}
+          {canAct && onApprove ? (
             <button
               type="button"
               className="btn btn--solid btn--sm"
-              disabled={!canAct}
               onClick={onApprove}
             >
               {labels.approve}
             </button>
           ) : null}
-          {onRequestChanges ? (
+          {canAct && onRequestChanges ? (
             <button
               type="button"
               className="btn btn--ghost btn--sm"
-              disabled={!canAct}
               onClick={onRequestChanges}
             >
               {labels.changes}
@@ -134,44 +229,51 @@ export function PlanReviewPanel({
         </div>
       </header>
 
-      <OverlayScroll className="plan-review__scroll">
-        <div className="plan-review__body">
-          {markdown ? (
-            <div className="plan-review__md">
-              <MarkdownBody>{markdown}</MarkdownBody>
-            </div>
-          ) : (
-            <p className="plan-review__empty">{labels.empty}</p>
-          )}
+      {expanded ? (
+        <OverlayScroll className="plan-review__scroll">
+          <div className="plan-review__body">
+            {entries.length > 0 ? (
+              <section className="plan-review__steps">
+                <h3 className="plan-review__steps-title">{labels.steps}</h3>
+                <ol className="plan-review__steps-list">
+                  {entries.map((e, i) => (
+                    <li
+                      key={`${i}-${e.content.slice(0, 24)}`}
+                      className={
+                        "plan-review__step plan-review__step--" + e.status
+                      }
+                    >
+                      <span className="plan-review__step-status" aria-hidden>
+                        {e.status === "completed"
+                          ? "✓"
+                          : e.status === "in_progress"
+                            ? "●"
+                            : e.status === "cancelled"
+                              ? "–"
+                              : "○"}
+                      </span>
+                      <span className="plan-review__step-text">{e.content}</span>
+                    </li>
+                  ))}
+                </ol>
+              </section>
+            ) : null}
 
-          {showStepsList ? (
-            <section className="plan-review__steps">
-              <h3 className="plan-review__steps-title">{labels.steps}</h3>
-              <ol className="plan-review__steps-list">
-                {entries.map((e, i) => (
-                  <li
-                    key={`${i}-${e.content.slice(0, 24)}`}
-                    className={
-                      "plan-review__step plan-review__step--" + e.status
-                    }
-                  >
-                    <span className="plan-review__step-status" aria-hidden>
-                      {e.status === "completed"
-                        ? "✓"
-                        : e.status === "in_progress"
-                          ? "●"
-                          : e.status === "cancelled"
-                            ? "–"
-                            : "○"}
-                    </span>
-                    <span className="plan-review__step-text">{e.content}</span>
-                  </li>
-                ))}
-              </ol>
-            </section>
-          ) : null}
-        </div>
-      </OverlayScroll>
+            {detailMarkdown ? (
+              <div
+                className={
+                  "plan-review__md" +
+                  (entries.length > 0 ? " plan-review__md--after-steps" : "")
+                }
+              >
+                <MarkdownBody>{detailMarkdown}</MarkdownBody>
+              </div>
+            ) : !entries.length ? (
+              <p className="plan-review__empty">{labels.empty}</p>
+            ) : null}
+          </div>
+        </OverlayScroll>
+      ) : null}
     </div>
   );
 }

--- a/src/components/PlanReviewPanel.tsx
+++ b/src/components/PlanReviewPanel.tsx
@@ -1,0 +1,177 @@
+/**
+ * Plan review workbench — full markdown body + step list + approve/revise.
+ * Used by ResourceViewer (primary) and optionally thread compact views.
+ */
+
+import { useMemo } from "react";
+import { MarkdownBody } from "@/components/MarkdownBody";
+import { OverlayScroll } from "@/components/OverlayScroll";
+import { IconPlan } from "@/components/icons";
+import {
+  planActionsEnabled,
+  planDisplayMarkdown,
+  type PlanReviewState,
+} from "@/lib/planBody";
+import {
+  computePlanProgress,
+  formatPlanFraction,
+  parsePlanEntries,
+} from "@/lib/planStatus";
+
+export type PlanReviewPanelLabels = {
+  ready: string;
+  waiting: string;
+  empty: string;
+  approve: string;
+  changes: string;
+  dismiss: string;
+  steps: string;
+  fraction: string;
+  openInResources?: string;
+};
+
+export type PlanReviewPanelProps = {
+  plan: PlanReviewState;
+  labels: PlanReviewPanelLabels;
+  /** Compact: shorter header, used if ever embedded elsewhere. */
+  compact?: boolean;
+  onApprove?: () => void;
+  onRequestChanges?: () => void;
+  onDismiss?: () => void;
+};
+
+export function PlanReviewPanel({
+  plan,
+  labels,
+  compact = false,
+  onApprove,
+  onRequestChanges,
+  onDismiss,
+}: PlanReviewPanelProps) {
+  const hasBody = !!plan.body.trim();
+  const markdown = useMemo(
+    () => planDisplayMarkdown(plan.body, plan.entries),
+    [plan.body, plan.entries],
+  );
+  const entries = useMemo(
+    () => parsePlanEntries(plan.entries),
+    [plan.entries],
+  );
+  const progress = useMemo(() => computePlanProgress(entries), [entries]);
+  const fraction = formatPlanFraction(progress);
+  const canAct = planActionsEnabled(plan);
+  const statusLabel = plan.waiting && !canAct ? labels.waiting : labels.ready;
+  // Steps list only when body is real planContent (avoid duplicating synthesized MD).
+  const showStepsList = hasBody && entries.length > 0;
+
+  return (
+    <div
+      className={
+        "plan-review" + (compact ? " plan-review--compact" : "")
+      }
+      data-testid="plan-review-panel"
+      data-plan-card
+    >
+      <header className="plan-review__header">
+        <div className="plan-review__title-row">
+          <span className="plan-review__icon" aria-hidden>
+            <IconPlan size={16} />
+          </span>
+          <div className="plan-review__titles">
+            <div className="plan-review__status">{statusLabel}</div>
+            <h2 className="plan-review__title">{plan.title || statusLabel}</h2>
+          </div>
+          {fraction ? (
+            <span className="plan-review__fraction">
+              {labels.fraction.replace("{n}", fraction)}
+            </span>
+          ) : null}
+        </div>
+        {progress.total > 0 ? (
+          <div
+            className="plan-review__meter"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={progress.total}
+            aria-valuenow={progress.completed}
+          >
+            <div
+              className="plan-review__meter-fill"
+              style={{ width: `${progress.percent}%` }}
+            />
+          </div>
+        ) : null}
+        <div className="plan-review__actions">
+          {onApprove ? (
+            <button
+              type="button"
+              className="btn btn--solid btn--sm"
+              disabled={!canAct}
+              onClick={onApprove}
+            >
+              {labels.approve}
+            </button>
+          ) : null}
+          {onRequestChanges ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              disabled={!canAct}
+              onClick={onRequestChanges}
+            >
+              {labels.changes}
+            </button>
+          ) : null}
+          {onDismiss ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={onDismiss}
+            >
+              {labels.dismiss}
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      <OverlayScroll className="plan-review__scroll">
+        <div className="plan-review__body">
+          {markdown ? (
+            <div className="plan-review__md">
+              <MarkdownBody>{markdown}</MarkdownBody>
+            </div>
+          ) : (
+            <p className="plan-review__empty">{labels.empty}</p>
+          )}
+
+          {showStepsList ? (
+            <section className="plan-review__steps">
+              <h3 className="plan-review__steps-title">{labels.steps}</h3>
+              <ol className="plan-review__steps-list">
+                {entries.map((e, i) => (
+                  <li
+                    key={`${i}-${e.content.slice(0, 24)}`}
+                    className={
+                      "plan-review__step plan-review__step--" + e.status
+                    }
+                  >
+                    <span className="plan-review__step-status" aria-hidden>
+                      {e.status === "completed"
+                        ? "✓"
+                        : e.status === "in_progress"
+                          ? "●"
+                          : e.status === "cancelled"
+                            ? "–"
+                            : "○"}
+                    </span>
+                    <span className="plan-review__step-text">{e.content}</span>
+                  </li>
+                ))}
+              </ol>
+            </section>
+          ) : null}
+        </div>
+      </OverlayScroll>
+    </div>
+  );
+}

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -31,9 +31,12 @@ import {
   IconFolder,
   IconFiles,
   IconListTree,
+  IconPlan,
   IconRefresh,
   IconSearch,
 } from "@/components/icons";
+import { PlanReviewPanel } from "@/components/PlanReviewPanel";
+import type { PlanReviewState } from "@/lib/planBody";
 import { OfficeDocumentPreview } from "@/components/OfficeDocumentPreview";
 import { CodePreview } from "@/components/CodePreview";
 import { isOfficeKind } from "@/lib/filePreviewSrc";
@@ -106,9 +109,18 @@ export interface ResourceViewerProps {
    * Files written/edited by agent tools in the active session (Changes panel).
    */
   sessionChanges?: SessionFileChange[];
+  /**
+   * Live plan snapshot for Plan review mode (exit_plan_mode / progress).
+   */
+  plan?: PlanReviewState | null;
+  /** Increment / change to force switch into Plan mode (详情 / auto-open). */
+  planFocusKey?: number | null;
+  onApprovePlan?: () => void;
+  onRequestPlanChanges?: () => void;
+  onDismissPlan?: () => void;
 }
 
-type SideMode = "files" | "changes";
+type SideMode = "files" | "changes" | "plan";
 
 type DiffViewState = {
   path: string;
@@ -210,6 +222,11 @@ export function ResourceViewer({
   onOpenRequestConsumed,
   paneActive = true,
   sessionChanges = [],
+  plan = null,
+  planFocusKey = null,
+  onApprovePlan,
+  onRequestPlanChanges,
+  onDismissPlan,
 }: ResourceViewerProps) {
   const tr = useMemo(() => createT(locale), [locale]);
   const [root, setRoot] = useState<TreeNode[]>([]);
@@ -224,6 +241,7 @@ export function ResourceViewer({
   // Default closed; session-only — not persisted; reset when pane hides.
   const [treeVisible, setTreeVisible] = useState(false);
   const [sideMode, setSideMode] = useState<SideMode>("files");
+  const lastPlanFocusKey = useRef<number | null>(null);
   const [treeWidth, setTreeWidth] = useState(loadTreeWidth);
   const [resizingTree, setResizingTree] = useState(false);
   const splitRef = useRef<HTMLDivElement>(null);
@@ -637,6 +655,12 @@ export function ResourceViewer({
   }, [tr, workspaceReason]);
 
   const showSidePanel = (mode: SideMode) => {
+    // Plan mode uses full-width review (no side tree).
+    if (mode === "plan") {
+      setSideMode("plan");
+      setTreeVisible(false);
+      return;
+    }
     if (treeVisible && sideMode === mode) {
       setTreeVisible(false);
       return;
@@ -644,6 +668,22 @@ export function ResourceViewer({
     setSideMode(mode);
     setTreeVisible(true);
   };
+
+  // External “open plan in resources” (详情 / auto-open on review).
+  useEffect(() => {
+    if (planFocusKey == null) return;
+    if (lastPlanFocusKey.current === planFocusKey) return;
+    lastPlanFocusKey.current = planFocusKey;
+    setSideMode("plan");
+    setTreeVisible(false);
+  }, [planFocusKey]);
+
+  // Plan dismissed while viewing plan → fall back to files empty preview.
+  useEffect(() => {
+    if (sideMode === "plan" && plan && !plan.visible) {
+      setSideMode("files");
+    }
+  }, [plan, sideMode]);
 
   // Drag-resize preview | file-tree split
   useEffect(() => {
@@ -1486,6 +1526,21 @@ export function ResourceViewer({
               }}
             />
           ) : null}
+          {plan?.visible ? (
+            <Tip label={tr("resources.plan")}>
+              <button
+                type="button"
+                className={
+                  "chrome-btn main__pane-toggle rp-chrome__plan-btn" +
+                  (sideMode === "plan" ? " is-on" : "")
+                }
+                onClick={() => showSidePanel("plan")}
+                aria-label={tr("resources.plan")}
+              >
+                <IconPlan size={16} />
+              </button>
+            </Tip>
+          ) : null}
           <Tip
             label={
               treeVisible && sideMode === "changes"
@@ -1572,7 +1627,29 @@ export function ResourceViewer({
         }
       >
         <div className="rp-split__preview">
-          {sideMode === "changes" && diffView ? (
+          {sideMode === "plan" && plan?.visible ? (
+            <PlanReviewPanel
+              plan={plan}
+              labels={{
+                ready: tr("plan.ready"),
+                waiting: tr("plan.waiting"),
+                empty: tr("plan.empty"),
+                approve: tr("plan.approve"),
+                changes: tr("plan.changes"),
+                dismiss: tr("plan.dismiss"),
+                steps: tr("plan.steps"),
+                fraction: tr("planBar.fraction"),
+              }}
+              onApprove={onApprovePlan}
+              onRequestChanges={onRequestPlanChanges}
+              onDismiss={onDismissPlan}
+            />
+          ) : sideMode === "plan" ? (
+            <div className="rp__empty-state">
+              <div className="rp__empty-title">{tr("resources.plan")}</div>
+              <div className="rp__empty-desc">{tr("resources.planEmpty")}</div>
+            </div>
+          ) : sideMode === "changes" && diffView ? (
             diffView.loading ? (
               <div className="rp__empty-state">
                 <div className="rp__empty-desc">{tr("changes.loadingDiff")}</div>
@@ -1691,6 +1768,20 @@ export function ResourceViewer({
                     </span>
                   ) : null}
                 </button>
+                {plan?.visible ? (
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={sideMode === "plan"}
+                    className={
+                      "rp-side-modes__btn" +
+                      (sideMode === "plan" ? " is-active" : "")
+                    }
+                    onClick={() => showSidePanel("plan")}
+                  >
+                    {tr("resources.plan")}
+                  </button>
+                ) : null}
               </div>
               <div className="rp-tree-search">
                 <IconSearch size={14} />

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -1630,15 +1630,21 @@ export function ResourceViewer({
           {sideMode === "plan" && plan?.visible ? (
             <PlanReviewPanel
               plan={plan}
+              forceExpandKey={planFocusKey}
               labels={{
                 ready: tr("plan.ready"),
                 waiting: tr("plan.waiting"),
+                progress: tr("planBar.progress"),
+                done: tr("planBar.done"),
                 empty: tr("plan.empty"),
                 approve: tr("plan.approve"),
                 changes: tr("plan.changes"),
                 dismiss: tr("plan.dismiss"),
                 steps: tr("plan.steps"),
                 fraction: tr("planBar.fraction"),
+                expandDetails: tr("plan.expandDetails"),
+                collapseDetails: tr("plan.collapseDetails"),
+                current: tr("planBar.current"),
               }}
               onApprove={onApprovePlan}
               onRequestChanges={onRequestPlanChanges}

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -44,11 +44,9 @@ import { Thinking } from "./Thinking";
 import { BackBottom } from "./BackBottom";
 import { InlineUserEdit } from "./InlineUserEdit";
 import { SkillChip } from "@/components/SkillChip";
-import { MarkdownBody } from "@/components/MarkdownBody";
 import { hydrateDisplayContent, parseStoredContent } from "@/lib/draftDoc";
 import { parseScheduledUserContent } from "@/lib/automations";
 import { extractAutomationPayload } from "@/lib/automationSetup";
-import { planDisplayMarkdown } from "@/lib/planBody";
 import {
   isToolStepMessage,
   LiveToolText,
@@ -749,49 +747,45 @@ export function ConversationThread({
           ) : null}
 
           {plan?.visible ? (
-            <div className="lobe-chat-plan" data-plan-card>
+            <div className="lobe-chat-plan lobe-chat-plan--chip" data-plan-card>
               <div className="lobe-chat-plan__head">
                 <IconPlan size={14} />
                 <span className="lobe-chat-plan__status">
-                  {plan.waiting && plan.rpcId == null
-                    ? tr("plan.waiting")
-                    : tr("plan.ready")}
+                  {plan.rpcId != null
+                    ? tr("plan.ready")
+                    : Array.isArray(plan.entries) && plan.entries.length > 0
+                      ? tr("planBar.progress")
+                      : plan.waiting
+                        ? tr("plan.waiting")
+                        : tr("plan.ready")}
                 </span>
                 <strong className="lobe-chat-plan__title">{plan.title}</strong>
               </div>
-              <div className="lobe-chat-plan__body">
-                {(() => {
-                  const md = planDisplayMarkdown(plan.body, plan.entries);
-                  if (!md) {
-                    return (
-                      <p className="lobe-chat-plan__empty">{tr("plan.empty")}</p>
-                    );
-                  }
-                  return <MarkdownBody locale={locale}>{md}</MarkdownBody>;
-                })()}
-              </div>
+              {/* Execution list stays out of the transcript — open resources for steps. */}
               <div className="lobe-chat-plan__actions">
                 {onOpenPlanDetails ? (
                   <Button type="button" onClick={onOpenPlanDetails}>
                     {tr("plan.openInResources")}
                   </Button>
                 ) : null}
-                <Button
-                  type="button"
-                  variant="ghost"
-                  disabled={plan.rpcId == null}
-                  onClick={onApprovePlan}
-                >
-                  {tr("plan.approve")}
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  disabled={plan.rpcId == null}
-                  onClick={onRequestPlanChanges}
-                >
-                  {tr("plan.changes")}
-                </Button>
+                {plan.rpcId != null ? (
+                  <>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={onApprovePlan}
+                    >
+                      {tr("plan.approve")}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={onRequestPlanChanges}
+                    >
+                      {tr("plan.changes")}
+                    </Button>
+                  </>
+                ) : null}
                 <Button type="button" variant="ghost" onClick={onDismissPlan}>
                   {tr("plan.dismiss")}
                 </Button>

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -44,9 +44,11 @@ import { Thinking } from "./Thinking";
 import { BackBottom } from "./BackBottom";
 import { InlineUserEdit } from "./InlineUserEdit";
 import { SkillChip } from "@/components/SkillChip";
+import { MarkdownBody } from "@/components/MarkdownBody";
 import { hydrateDisplayContent, parseStoredContent } from "@/lib/draftDoc";
 import { parseScheduledUserContent } from "@/lib/automations";
 import { extractAutomationPayload } from "@/lib/automationSetup";
+import { planDisplayMarkdown } from "@/lib/planBody";
 import {
   isToolStepMessage,
   LiveToolText,
@@ -241,6 +243,8 @@ export interface ConversationThreadProps {
   onApprovePlan?: () => void;
   onRequestPlanChanges?: () => void;
   onDismissPlan?: () => void;
+  /** Open full plan in the resource pane (preferred review surface). */
+  onOpenPlanDetails?: () => void;
   onAddAttachmentToComposer?: (att: Attachment) => void;
   attachLabels: {
     open: string;
@@ -281,6 +285,7 @@ export function ConversationThread({
   onApprovePlan,
   onRequestPlanChanges,
   onDismissPlan,
+  onOpenPlanDetails,
   onAddAttachmentToComposer,
   attachLabels,
 }: ConversationThreadProps) {
@@ -744,67 +749,37 @@ export function ConversationThread({
           ) : null}
 
           {plan?.visible ? (
-            <div className="lobe-chat-plan">
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  marginBottom: 8,
-                  color: "var(--lobe-color-text-secondary)",
-                  fontSize: 14,
-                }}
-              >
+            <div className="lobe-chat-plan" data-plan-card>
+              <div className="lobe-chat-plan__head">
                 <IconPlan size={14} />
-                <span style={{ fontWeight: 500, color: "var(--lobe-color-text)" }}>
-                  {plan.waiting ? tr("plan.waiting") : tr("plan.ready")}
+                <span className="lobe-chat-plan__status">
+                  {plan.waiting && plan.rpcId == null
+                    ? tr("plan.waiting")
+                    : tr("plan.ready")}
                 </span>
+                <strong className="lobe-chat-plan__title">{plan.title}</strong>
               </div>
-              <h3
-                style={{
-                  margin: "0 0 8px",
-                  fontSize: 15,
-                  fontWeight: 600,
-                  color: "var(--lobe-color-text)",
-                }}
-              >
-                {plan.title}
-              </h3>
-              <div
-                className="lobe-chat-plan__body"
-                style={{
-                  margin: "0 0 12px",
-                  maxHeight: "16rem",
-                  overflow: "auto",
-                  padding: 12,
-                  borderRadius: 8,
-                  background: "var(--lobe-color-fill-quaternary)",
-                  border: "1px solid var(--lobe-color-border-secondary)",
-                  fontSize: 13,
-                  lineHeight: 1.5,
-                  color: "var(--lobe-color-text-secondary)",
-                  whiteSpace: "pre-wrap",
-                  wordBreak: "break-word",
-                }}
-              >
-                {plan.body?.trim()
-                  ? plan.body
-                  : Array.isArray(plan.entries) && plan.entries.length
-                    ? plan.entries
-                        .map((e, i) => {
-                          if (e && typeof e === "object") {
-                            const o = e as Record<string, unknown>;
-                            return `${i + 1}. ${String(o.content ?? o.title ?? o.text ?? "")}`;
-                          }
-                          return `${i + 1}. ${String(e)}`;
-                        })
-                        .join("\n")
-                    : tr("plan.empty")}
+              <div className="lobe-chat-plan__body">
+                {(() => {
+                  const md = planDisplayMarkdown(plan.body, plan.entries);
+                  if (!md) {
+                    return (
+                      <p className="lobe-chat-plan__empty">{tr("plan.empty")}</p>
+                    );
+                  }
+                  return <MarkdownBody locale={locale}>{md}</MarkdownBody>;
+                })()}
               </div>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+              <div className="lobe-chat-plan__actions">
+                {onOpenPlanDetails ? (
+                  <Button type="button" onClick={onOpenPlanDetails}>
+                    {tr("plan.openInResources")}
+                  </Button>
+                ) : null}
                 <Button
                   type="button"
-                  disabled={plan.waiting && plan.rpcId == null}
+                  variant="ghost"
+                  disabled={plan.rpcId == null}
                   onClick={onApprovePlan}
                 >
                   {tr("plan.approve")}
@@ -812,7 +787,7 @@ export function ConversationThread({
                 <Button
                   type="button"
                   variant="ghost"
-                  disabled={plan.waiting && plan.rpcId == null}
+                  disabled={plan.rpcId == null}
                   onClick={onRequestPlanChanges}
                 >
                   {tr("plan.changes")}

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -26,7 +26,6 @@ import {
   IconClock,
   IconExportMd,
   IconFork,
-  IconPlan,
   IconRename,
   IconRewind,
 } from "@/components/icons";
@@ -37,7 +36,6 @@ import {
   MessageActionButton,
   MessageCopyButton,
 } from "./MessageAction";
-import { Button } from "@/components/ui/button";
 import { ChatItem } from "./ChatItem";
 import { MarkdownChat } from "./MarkdownChat";
 import { Thinking } from "./Thinking";
@@ -230,19 +228,6 @@ export interface ConversationThreadProps {
   onOpenResource?: (
     target: import("@/components/ResourceViewer").ResourceOpenTarget,
   ) => void;
-  plan?: {
-    visible: boolean;
-    waiting: boolean;
-    title: string;
-    body: string;
-    entries: unknown[];
-    rpcId?: number | null;
-  };
-  onApprovePlan?: () => void;
-  onRequestPlanChanges?: () => void;
-  onDismissPlan?: () => void;
-  /** Open full plan in the resource pane (preferred review surface). */
-  onOpenPlanDetails?: () => void;
   onAddAttachmentToComposer?: (att: Attachment) => void;
   attachLabels: {
     open: string;
@@ -279,11 +264,6 @@ export function ConversationThread({
   onRewindToUserMessage,
   onForkFromUserMessage,
   onOpenResource,
-  plan,
-  onApprovePlan,
-  onRequestPlanChanges,
-  onDismissPlan,
-  onOpenPlanDetails,
   onAddAttachmentToComposer,
   attachLabels,
 }: ConversationThreadProps) {
@@ -352,8 +332,7 @@ export function ConversationThread({
     messages.length === 0 &&
     !showQuietThinking &&
     !liveTool &&
-    !turnBusy &&
-    !plan?.visible;
+    !turnBusy;
 
   return (
     <div className="lobe-chat" data-slot="lobe-chat">
@@ -746,52 +725,7 @@ export function ConversationThread({
             </div>
           ) : null}
 
-          {plan?.visible ? (
-            <div className="lobe-chat-plan lobe-chat-plan--chip" data-plan-card>
-              <div className="lobe-chat-plan__head">
-                <IconPlan size={14} />
-                <span className="lobe-chat-plan__status">
-                  {plan.rpcId != null
-                    ? tr("plan.ready")
-                    : Array.isArray(plan.entries) && plan.entries.length > 0
-                      ? tr("planBar.progress")
-                      : plan.waiting
-                        ? tr("plan.waiting")
-                        : tr("plan.ready")}
-                </span>
-                <strong className="lobe-chat-plan__title">{plan.title}</strong>
-              </div>
-              {/* Execution list stays out of the transcript — open resources for steps. */}
-              <div className="lobe-chat-plan__actions">
-                {onOpenPlanDetails ? (
-                  <Button type="button" onClick={onOpenPlanDetails}>
-                    {tr("plan.openInResources")}
-                  </Button>
-                ) : null}
-                {plan.rpcId != null ? (
-                  <>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      onClick={onApprovePlan}
-                    >
-                      {tr("plan.approve")}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      onClick={onRequestPlanChanges}
-                    >
-                      {tr("plan.changes")}
-                    </Button>
-                  </>
-                ) : null}
-                <Button type="button" variant="ghost" onClick={onDismissPlan}>
-                  {tr("plan.dismiss")}
-                </Button>
-              </div>
-            </div>
-          ) : null}
+          {/* Plan UI lives only in PlanStatusBar (top) + ResourceViewer Plan mode. */}
         </div>
       </div>
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -382,6 +382,8 @@ const en = {
   "plan.phaseLabel": "Thinking {n}",
   "plan.steps": "Steps",
   "plan.openInResources": "Open in resources",
+  "plan.expandDetails": "Show steps & details",
+  "plan.collapseDetails": "Hide steps & details",
 
   // Sticky plan/goal bar
   "planBar.aria": "Plan and goal status",
@@ -1390,6 +1392,8 @@ const zh: Record<MessageKey, string> = {
   "plan.phaseLabel": "思考 {n}",
   "plan.steps": "步骤",
   "plan.openInResources": "在资源中打开",
+  "plan.expandDetails": "展开步骤与详情",
+  "plan.collapseDetails": "收起步骤与详情",
 
   // Sticky plan/goal bar
   "planBar.aria": "计划与目标状态",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -156,6 +156,8 @@ const en = {
   "resources.emptyPreview": "No file open",
   "resources.emptyPreviewHint":
     "Pick a file from the tree on the right to preview it here.",
+  "resources.plan": "Plan",
+  "resources.planEmpty": "No plan is waiting for review in this session.",
   "resources.copyPathShort": "Path",
   "resources.tabClose": "Close tab",
   "resources.tabCloseOthers": "Close other tabs",
@@ -378,6 +380,8 @@ const en = {
   "plan.reviseToast": "Asked agent to revise the plan",
   "plan.reviseFeedback": "Please revise the plan based on user feedback.",
   "plan.phaseLabel": "Thinking {n}",
+  "plan.steps": "Steps",
+  "plan.openInResources": "Open in resources",
 
   // Sticky plan/goal bar
   "planBar.aria": "Plan and goal status",
@@ -388,7 +392,7 @@ const en = {
   "planBar.done": "Plan complete",
   "planBar.fraction": "{n}",
   "planBar.current": "Now",
-  "planBar.expand": "Details",
+  "planBar.expand": "Open in resources",
 
   // Settings / onboarding
   "settings.title": "Settings",
@@ -1171,6 +1175,8 @@ const zh: Record<MessageKey, string> = {
   "resources.needProject": "添加或选择项目后，即可在此浏览文件。",
   "resources.emptyPreview": "尚未打开文件",
   "resources.emptyPreviewHint": "从右侧文件树选择文件进行预览。",
+  "resources.plan": "计划",
+  "resources.planEmpty": "当前会话没有待审阅的计划。",
   "resources.copyPathShort": "路径",
   "resources.tabClose": "关闭标签",
   "resources.tabCloseOthers": "关闭其他标签",
@@ -1382,6 +1388,8 @@ const zh: Record<MessageKey, string> = {
   "plan.reviseToast": "已请 Agent 修改计划",
   "plan.reviseFeedback": "请根据反馈修改计划。",
   "plan.phaseLabel": "思考 {n}",
+  "plan.steps": "步骤",
+  "plan.openInResources": "在资源中打开",
 
   // Sticky plan/goal bar
   "planBar.aria": "计划与目标状态",
@@ -1392,7 +1400,7 @@ const zh: Record<MessageKey, string> = {
   "planBar.done": "计划已完成",
   "planBar.fraction": "{n}",
   "planBar.current": "当前",
-  "planBar.expand": "详情",
+  "planBar.expand": "在资源中打开",
 
   "settings.title": "设置",
   "settings.backToApp": "返回应用",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -358,6 +358,8 @@ export const zhTW: Record<MessageKey, string> = {
   "plan.phaseLabel": "思考 {n}",
   "plan.steps": "步驟",
   "plan.openInResources": "在資源中開啟",
+  "plan.expandDetails": "展開步驟與詳情",
+  "plan.collapseDetails": "收起步驟與詳情",
 
   // Sticky plan/goal bar
   "planBar.aria": "計劃與目標狀態",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -143,6 +143,8 @@ export const zhTW: Record<MessageKey, string> = {
   "resources.needProject": "新增或選擇專案後，即可在此瀏覽檔案。",
   "resources.emptyPreview": "尚未開啟檔案",
   "resources.emptyPreviewHint": "從右側檔案樹選擇檔案進行預覽。",
+  "resources.plan": "計劃",
+  "resources.planEmpty": "目前對話沒有待審閱的計劃。",
   "resources.copyPathShort": "路徑",
   "resources.tabClose": "關閉分頁",
   "resources.tabCloseOthers": "關閉其他分頁",
@@ -354,6 +356,8 @@ export const zhTW: Record<MessageKey, string> = {
   "plan.reviseToast": "已請 Agent 修改計劃",
   "plan.reviseFeedback": "請根據回饋修改計劃。",
   "plan.phaseLabel": "思考 {n}",
+  "plan.steps": "步驟",
+  "plan.openInResources": "在資源中開啟",
 
   // Sticky plan/goal bar
   "planBar.aria": "計劃與目標狀態",
@@ -364,7 +368,7 @@ export const zhTW: Record<MessageKey, string> = {
   "planBar.done": "計劃已完成",
   "planBar.fraction": "{n}",
   "planBar.current": "目前",
-  "planBar.expand": "詳情",
+  "planBar.expand": "在資源中開啟",
 
   "settings.title": "設定",
   "settings.backToApp": "返回應用程式",

--- a/src/lib/planBody.test.ts
+++ b/src/lib/planBody.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  planActionsEnabled,
+  planDisplayMarkdown,
+  planEntriesToMarkdown,
+  planIsAwaitingReview,
+} from "./planBody";
+import type { PlanEntry } from "./planStatus";
+
+describe("planEntriesToMarkdown", () => {
+  it("formats statuses as task markers", () => {
+    const entries: PlanEntry[] = [
+      { content: "A", status: "completed" },
+      { content: "B", status: "in_progress", priority: "high" },
+      { content: "C", status: "pending" },
+    ];
+    const md = planEntriesToMarkdown(entries);
+    expect(md).toContain("1. [x] A");
+    expect(md).toContain("2. [~] B *(high)*");
+    expect(md).toContain("3. [ ] C");
+  });
+});
+
+describe("planDisplayMarkdown", () => {
+  it("prefers body over entries", () => {
+    expect(
+      planDisplayMarkdown("# Hello", [{ content: "step", status: "pending" }]),
+    ).toBe("# Hello");
+  });
+
+  it("falls back to entries markdown", () => {
+    const md = planDisplayMarkdown("", [
+      { content: "Do thing", status: "pending" },
+    ]);
+    expect(md).toContain("Do thing");
+    expect(md).toMatch(/\[ \]/);
+  });
+
+  it("returns empty when both missing", () => {
+    expect(planDisplayMarkdown("", [])).toBe("");
+    expect(planDisplayMarkdown(null, null)).toBe("");
+  });
+});
+
+describe("plan gate helpers", () => {
+  it("actions enabled only with rpcId", () => {
+    expect(planActionsEnabled({ rpcId: 3 })).toBe(true);
+    expect(planActionsEnabled({ rpcId: null })).toBe(false);
+  });
+
+  it("awaiting review needs visible + rpcId", () => {
+    expect(planIsAwaitingReview({ visible: true, rpcId: 1 })).toBe(true);
+    expect(planIsAwaitingReview({ visible: true, rpcId: null })).toBe(false);
+    expect(planIsAwaitingReview({ visible: false, rpcId: 1 })).toBe(false);
+  });
+});

--- a/src/lib/planBody.ts
+++ b/src/lib/planBody.ts
@@ -1,0 +1,66 @@
+/**
+ * Plan body helpers — markdown for resource review + entry fallbacks.
+ */
+
+import {
+  parsePlanEntries,
+  type PlanEntry,
+  type PlanEntryStatus,
+} from "@/lib/planStatus";
+
+/** Shared plan snapshot shape (App + ResourceViewer + thread). */
+export type PlanReviewState = {
+  visible: boolean;
+  waiting: boolean;
+  title: string;
+  body: string;
+  entries: unknown[];
+  rpcId?: number | null;
+  toolCallId?: string | null;
+};
+
+/** Checkbox-style prefix for markdown step lists. */
+function statusMdMarker(status: PlanEntryStatus): string {
+  if (status === "completed") return "[x]";
+  if (status === "cancelled") return "[-]";
+  if (status === "in_progress") return "[~]";
+  return "[ ]";
+}
+
+/** Build a markdown steps section from parsed entries. */
+export function planEntriesToMarkdown(entries: PlanEntry[]): string {
+  if (!entries.length) return "";
+  const lines = entries.map((e, i) => {
+    const mark = statusMdMarker(e.status);
+    const pri = e.priority ? ` *(${e.priority})*` : "";
+    return `${i + 1}. ${mark} ${e.content}${pri}`;
+  });
+  return lines.join("\n");
+}
+
+/**
+ * Prefer ACP planContent body; if empty, synthesize a readable markdown list
+ * from plan entries so the review panel is never blank when steps exist.
+ */
+export function planDisplayMarkdown(
+  body: string | null | undefined,
+  entries: unknown[] | null | undefined,
+): string {
+  const trimmed = (body ?? "").trim();
+  if (trimmed) return trimmed;
+  const parsed = parsePlanEntries(entries ?? []);
+  if (!parsed.length) return "";
+  return planEntriesToMarkdown(parsed);
+}
+
+/** True when approve / request-changes should be enabled (exit_plan_mode gate). */
+export function planActionsEnabled(plan: Pick<PlanReviewState, "rpcId">): boolean {
+  return plan.rpcId != null;
+}
+
+/** Review gate ready for user decision. */
+export function planIsAwaitingReview(
+  plan: Pick<PlanReviewState, "visible" | "rpcId">,
+): boolean {
+  return plan.visible && plan.rpcId != null;
+}

--- a/src/lib/planStatus.test.ts
+++ b/src/lib/planStatus.test.ts
@@ -140,11 +140,11 @@ describe("resolvePlanBarModel", () => {
     expect(m.showActions).toBe(false);
   });
 
-  it("shows progress while entries update (card may be dismissed)", () => {
+  it("shows progress while entries update (requires planVisible)", () => {
     const m = resolvePlanBarModel({
       goalMode: false,
       mode: "agent",
-      planVisible: false,
+      planVisible: true,
       planWaiting: true,
       planRpcId: null,
       entries: [
@@ -158,11 +158,26 @@ describe("resolvePlanBarModel", () => {
     expect(formatPlanFraction(m.progress)).toBe("1/2");
   });
 
-  it("marks done when all completed", () => {
+  it("hides progress entries when plan not visible (soft-dismiss)", () => {
     const m = resolvePlanBarModel({
       goalMode: false,
       mode: "agent",
       planVisible: false,
+      planWaiting: true,
+      planRpcId: null,
+      entries: [
+        { content: "a", status: "completed" },
+        { content: "b", status: "in_progress" },
+      ],
+    });
+    expect(m.kind).toBe("hidden");
+  });
+
+  it("marks done when all completed", () => {
+    const m = resolvePlanBarModel({
+      goalMode: false,
+      mode: "agent",
+      planVisible: true,
       planWaiting: true,
       entries: [
         { content: "a", status: "completed" },

--- a/src/lib/planStatus.ts
+++ b/src/lib/planStatus.ts
@@ -169,7 +169,9 @@ export function resolvePlanBarModel(input: {
   }
 
   // Live step list (while planning, after approve, or mid-execution).
-  if (hasEntries) {
+  // Require planVisible so soft-dismiss of the top bar can hide progress without
+  // wiping entries (progress still updates when a new plan event re-shows the bar).
+  if (hasEntries && input.planVisible) {
     const allDone =
       progress.completed + progress.cancelled >= progress.total &&
       progress.inProgress === 0 &&

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4552,6 +4552,66 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   gap: 10px;
   min-width: 0;
 }
+.plan-review__title-row--btn {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+.plan-review__title-row--btn:disabled {
+  cursor: default;
+}
+.plan-review__title-row--btn:not(:disabled):hover .plan-review__title {
+  color: var(--accent);
+}
+.plan-review__chevron {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+.plan-review__current {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 4px;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.plan-review__current-label {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  font-size: 11px;
+}
+.plan-review__current-step {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.plan-review--collapsed {
+  /* Header-only: no scroll region taking empty space */
+  height: auto;
+  min-height: 0;
+}
+.plan-review--collapsed .plan-review__header {
+  border-bottom: none;
+}
+.plan-review__md--after-steps {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+.lobe-chat-plan--chip .lobe-chat-plan__body {
+  display: none;
+}
 .plan-review__icon {
   display: inline-flex;
   align-items: center;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4377,40 +4377,37 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   }
 }
 
-/* Sticky plan/goal bar above the chat stage */
+/* Sticky plan/goal bar above the chat stage — accent blue-violet, theme-aware */
 .plan-bar {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px 12px;
-  margin: 0 var(--space-5) 8px;
+  /* Clear main__top: leave breathing room under titlebar chrome */
+  margin: 12px var(--space-5) 10px;
   padding: 8px 12px;
   border-radius: 12px;
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-card, var(--bg-elevated));
+  border: 1px solid var(--plan-bar-border, var(--border-subtle));
+  background: var(--plan-bar-bg, var(--bg-card, var(--bg-elevated)));
   min-width: 0;
 }
 
-.plan-bar--goal {
-  border-color: color-mix(in srgb, var(--accent, #6b8cff) 32%, var(--border-subtle));
-  background: color-mix(in srgb, var(--accent, #6b8cff) 8%, var(--bg-card, var(--bg-elevated)));
-}
-
-.plan-bar--mode {
-  border-color: color-mix(in srgb, #c49bff 30%, var(--border-subtle));
-}
-
-.plan-bar--progress {
-  border-color: color-mix(in srgb, #5b9fd4 32%, var(--border-subtle));
+.plan-bar--goal,
+.plan-bar--mode,
+.plan-bar--progress,
+.plan-bar--review {
+  border-color: color-mix(in srgb, var(--accent) 36%, var(--border-subtle));
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-card, var(--bg-elevated)));
 }
 
 .plan-bar--review {
-  border-color: color-mix(in srgb, var(--warning, #e0b44a) 40%, var(--border-subtle));
-  background: color-mix(
-    in srgb,
-    var(--warning, #e0b44a) 10%,
-    var(--bg-card, var(--bg-elevated))
-  );
+  /* Slightly stronger fill when action is required */
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--border-subtle));
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg-card, var(--bg-elevated)));
+}
+
+.plan-bar--progress {
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--border-subtle));
 }
 
 .plan-bar__main {
@@ -4434,8 +4431,11 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   flex-shrink: 0;
 }
 
-.plan-bar--review .plan-bar__icon {
-  color: var(--warning, #e0b44a);
+.plan-bar--review .plan-bar__icon,
+.plan-bar--progress .plan-bar__icon,
+.plan-bar--goal .plan-bar__icon {
+  color: var(--accent);
+  background: var(--accent-muted);
 }
 
 .plan-bar__text {
@@ -4500,12 +4500,12 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
 .plan-bar__meter-fill {
   height: 100%;
   border-radius: inherit;
-  background: color-mix(in srgb, var(--accent, #6b8cff) 75%, #5b9fd4);
+  background: var(--accent);
   transition: width 0.25s ease;
 }
 
 .plan-bar--review .plan-bar__meter-fill {
-  background: color-mix(in srgb, var(--warning, #e0b44a) 80%, #e05a5a);
+  background: var(--accent-hover, var(--accent));
 }
 
 .plan-bar__actions {
@@ -4527,6 +4527,194 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   width: 26px;
   height: 26px;
   color: var(--text-tertiary);
+}
+
+/* Plan review workbench (resource pane) */
+.plan-review {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-main, var(--bg-elevated));
+}
+.plan-review__header {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-elevated));
+}
+.plan-review__title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+}
+.plan-review__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  color: var(--accent);
+  background: var(--accent-muted);
+  flex-shrink: 0;
+}
+.plan-review__titles {
+  min-width: 0;
+  flex: 1;
+}
+.plan-review__status {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.plan-review__title {
+  margin: 2px 0 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+  word-break: break-word;
+}
+.plan-review__fraction {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.plan-review__meter {
+  height: 3px;
+  border-radius: 999px;
+  background: var(--bg-hover);
+  overflow: hidden;
+}
+.plan-review__meter-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  transition: width 0.25s ease;
+}
+.plan-review__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.plan-review__scroll {
+  flex: 1;
+  min-height: 0;
+}
+.plan-review__body {
+  padding: 16px 18px 28px;
+  max-width: 720px;
+}
+.plan-review__md {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--text-primary);
+}
+.plan-review__empty {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+.plan-review__steps {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+.plan-review__steps-title {
+  margin: 0 0 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.plan-review__steps-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.plan-review__step {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+.plan-review__step-status {
+  flex-shrink: 0;
+  width: 1.1em;
+  color: var(--accent);
+  opacity: 0.85;
+}
+.plan-review__step--completed .plan-review__step-text {
+  color: var(--text-secondary);
+  text-decoration: line-through;
+  text-decoration-color: var(--border-strong);
+}
+.plan-review__step--cancelled {
+  opacity: 0.55;
+}
+
+/* Thread plan card (compact preview; full review in resources) */
+.lobe-chat-plan {
+  max-width: 720px;
+  margin: 8px 0 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border-subtle));
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-card, var(--bg-elevated)));
+}
+.lobe-chat-plan__head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.lobe-chat-plan__status {
+  font-weight: 600;
+  color: var(--accent);
+}
+.lobe-chat-plan__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 0;
+}
+.lobe-chat-plan__body {
+  max-height: 12rem;
+  overflow: auto;
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.lobe-chat-plan__empty {
+  margin: 0;
+  color: var(--text-tertiary);
+}
+.lobe-chat-plan__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 /* Plan card (reference) */


### PR DESCRIPTION
## Summary

Plan UX redesign based on product feedback:

- **Top bar only** for execution progress (`2/7`, current step, meter)
- **Resource pane Plan mode** for full Markdown + steps (expand on demand) + approve / request changes
- **No plan card** in the chat transcript (closing it no longer wipes all plan UI)
- Soft-dismiss top bar during progress (`barDismissed`); review-gate dismiss still abandons RPC
- Accent blue-violet styling; margin under chrome

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] Desktop: plan progress bar only at top
- [ ] Desktop: 在资源中打开 → right pane Plan with expand steps
- [ ] Desktop: review gate auto-opens resource; approve works
- [ ] Desktop: X on progress bar soft-hides; next plan update resurfaces