### PR TITLE
feat: per-project permission default for trusted folders

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "grok-app"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -270,6 +270,30 @@ pub async fn project_trust(id: String) -> Result<Project, String> {
     store::trust_project(&id)
 }
 
+/// Set or clear the project-level permission tier (L10).
+/// `policy = null` / empty / `"inherit"` → fall back to app default.
+/// When this project is the live Host context, sync agent policy immediately.
+#[tauri::command]
+pub async fn project_set_permission_policy(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    id: String,
+    policy: Option<String>,
+) -> Result<Project, String> {
+    let p = store::set_project_permission_policy(&id, policy)?;
+    let (live_proj, live_sess) = mgr.current_context_ids();
+    if live_proj.as_deref() == Some(id.as_str()) {
+        let prefs = store::resolve_composer_prefs(Some(&id), live_sess.as_deref());
+        if let Err(e) = mgr
+            .apply_permission_policy(&app, &prefs.permission_policy)
+            .await
+        {
+            tracing::warn!("project_set_permission_policy apply live: {e}");
+        }
+    }
+    Ok(p)
+}
+
 #[tauri::command]
 pub async fn project_rename(id: String, name: String) -> Result<Project, String> {
     store::rename_project(&id, &name)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -142,6 +142,7 @@ pub fn run() {
             commands::project_add_dialog,
             commands::project_remove,
             commands::project_trust,
+            commands::project_set_permission_policy,
             commands::project_rename,
             commands::project_set_pinned,
             commands::project_reveal,

--- a/src-tauri/src/permission.rs
+++ b/src-tauri/src/permission.rs
@@ -494,6 +494,34 @@ pub fn may_auto_deny(policy: PermissionPolicy) -> bool {
     matches!(policy, PermissionPolicy::DontAsk | PermissionPolicy::Deny)
 }
 
+/// Resolve effective permission tier for a project/session context (L10).
+///
+/// Cascade (most specific wins): session override → project tier → global default.
+/// Untrusted projects always force **Ask** so a stored relaxed tier cannot apply
+/// before the user trusts the folder.
+pub fn effective_permission_policy(
+    global: &str,
+    project_trusted: Option<bool>,
+    project_policy: Option<&str>,
+    session_policy: Option<&str>,
+) -> PermissionPolicy {
+    if project_trusted == Some(false) {
+        return PermissionPolicy::Ask;
+    }
+    if let Some(s) = session_policy.map(str::trim).filter(|s| !s.is_empty()) {
+        return PermissionPolicy::parse(s);
+    }
+    if let Some(p) = project_policy.map(str::trim).filter(|s| !s.is_empty()) {
+        return PermissionPolicy::parse(p);
+    }
+    let g = global.trim();
+    if g.is_empty() {
+        PermissionPolicy::Ask
+    } else {
+        PermissionPolicy::parse(g)
+    }
+}
+
 /// Pick optionId from ACP permission options by preferred kind.
 pub fn pick_option_id(options: &serde_json::Value, prefer: &str) -> Option<String> {
     let arr = options.as_array()?;
@@ -568,6 +596,68 @@ mod tests {
     #[test]
     fn default_policy_is_ask_not_always() {
         assert_eq!(PermissionPolicy::default(), PermissionPolicy::Ask);
+    }
+
+    #[test]
+    fn effective_permission_defaults_to_ask() {
+        assert_eq!(
+            effective_permission_policy("", None, None, None),
+            PermissionPolicy::Ask
+        );
+        assert_eq!(
+            effective_permission_policy("always_approve", None, None, None),
+            PermissionPolicy::AlwaysApprove
+        );
+    }
+
+    #[test]
+    fn effective_permission_cascades_session_over_project_over_global() {
+        assert_eq!(
+            effective_permission_policy(
+                "ask",
+                Some(true),
+                Some("accept_edits"),
+                Some("always_approve"),
+            ),
+            PermissionPolicy::AlwaysApprove
+        );
+        assert_eq!(
+            effective_permission_policy("ask", Some(true), Some("accept_edits"), None),
+            PermissionPolicy::AcceptEdits
+        );
+        assert_eq!(
+            effective_permission_policy("dont_ask", Some(true), None, None),
+            PermissionPolicy::DontAsk
+        );
+    }
+
+    #[test]
+    fn untrusted_project_forces_ask_despite_relaxed_tiers() {
+        assert_eq!(
+            effective_permission_policy(
+                "always_approve",
+                Some(false),
+                Some("always_approve"),
+                Some("always_approve"),
+            ),
+            PermissionPolicy::Ask
+        );
+        assert_eq!(
+            effective_permission_policy("accept_edits", Some(false), Some("accept_edits"), None),
+            PermissionPolicy::Ask
+        );
+    }
+
+    #[test]
+    fn empty_session_or_project_tier_falls_through() {
+        assert_eq!(
+            effective_permission_policy("ask", Some(true), Some(""), Some("  ")),
+            PermissionPolicy::Ask
+        );
+        assert_eq!(
+            effective_permission_policy("accept_edits", Some(true), Some(""), None),
+            PermissionPolicy::AcceptEdits
+        );
     }
 
     #[test]

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -400,6 +400,46 @@ pub fn trust_project(id: &str) -> Result<Project, String> {
     Ok(clone)
 }
 
+/// Set or clear a project-level permission tier (L10).
+///
+/// `policy = None` / empty / `"inherit"` clears the override so the app default
+/// applies. Untrusted projects cannot store a relaxed tier.
+pub fn set_project_permission_policy(
+    id: &str,
+    policy: Option<String>,
+) -> Result<Project, String> {
+    use crate::permission::PermissionPolicy;
+
+    let mut list = load_projects();
+    let p = list
+        .iter_mut()
+        .find(|p| p.id == id)
+        .ok_or_else(|| "project not found".to_string())?;
+    if !p.trusted {
+        return Err("trust this project before setting a permission tier".into());
+    }
+
+    let next = match policy {
+        None => None,
+        Some(raw) => {
+            let t = raw.trim();
+            if t.is_empty()
+                || t.eq_ignore_ascii_case("inherit")
+                || t.eq_ignore_ascii_case("app_default")
+                || t.eq_ignore_ascii_case("default")
+            {
+                None
+            } else {
+                Some(PermissionPolicy::parse(t).as_str().to_string())
+            }
+        }
+    };
+    p.permission_policy = next;
+    let clone = p.clone();
+    save_projects(&list)?;
+    Ok(clone)
+}
+
 pub fn load_sessions_index() -> Vec<SessionMeta> {
     let _ = ensure_app_dirs();
     let mut list: Vec<SessionMeta> = read_json(&sessions_index_file());
@@ -923,35 +963,59 @@ fn global_prefs(settings: &AppSettings) -> (String, String, String, String) {
 }
 
 /// Resolve effective composer prefs for the active project/session + configured scope.
+///
+/// Model / effort / mode follow `composer_prefs_scope`.
+/// Permission always cascades session → project → global (L10), and untrusted
+/// projects force Ask regardless of stored tiers.
 pub fn resolve_composer_prefs(
     project_id: Option<&str>,
     session_id: Option<&str>,
 ) -> ComposerPrefs {
+    use crate::permission::effective_permission_policy;
+
     let settings = load_settings();
     let scope = ComposerPrefsScope::parse(&settings.composer_prefs_scope);
     let (g_model, g_effort, g_mode, g_policy) = global_prefs(&settings);
+
+    let sess = session_id.and_then(|id| {
+        load_sessions_index()
+            .into_iter()
+            .find(|s| s.id == id)
+    });
+    let proj = sess
+        .as_ref()
+        .and_then(|s| s.project_id.as_deref())
+        .or(project_id)
+        .and_then(|id| load_projects().into_iter().find(|p| p.id == id));
+
+    // Permission: always cascade (independent of model/effort memory scope).
+    let permission_policy = effective_permission_policy(
+        &g_policy,
+        proj.as_ref().map(|p| p.trusted),
+        proj.as_ref()
+            .and_then(|p| p.permission_policy.as_deref()),
+        sess.as_ref()
+            .and_then(|s| s.permission_policy.as_deref()),
+    )
+    .as_str()
+    .to_string();
 
     match scope {
         ComposerPrefsScope::Global => ComposerPrefs {
             model_id: g_model,
             effort: g_effort,
             mode: g_mode,
-            permission_policy: g_policy,
+            permission_policy,
             scope: scope.as_str().into(),
             source: "global".into(),
         },
         ComposerPrefsScope::Project => {
-            let proj = project_id
-                .and_then(|id| load_projects().into_iter().find(|p| p.id == id));
             if let Some(p) = proj {
                 ComposerPrefs {
                     model_id: p.model_id.filter(|s| !s.is_empty()).unwrap_or(g_model),
                     effort: p.effort.filter(|s| !s.is_empty()).unwrap_or(g_effort),
                     mode: p.mode.filter(|s| !s.is_empty()).unwrap_or(g_mode),
-                    permission_policy: p
-                        .permission_policy
-                        .filter(|s| !s.is_empty())
-                        .unwrap_or(g_policy),
+                    permission_policy,
                     scope: scope.as_str().into(),
                     source: "project".into(),
                 }
@@ -960,25 +1024,13 @@ pub fn resolve_composer_prefs(
                     model_id: g_model,
                     effort: g_effort,
                     mode: g_mode,
-                    permission_policy: g_policy,
+                    permission_policy,
                     scope: scope.as_str().into(),
                     source: "global".into(),
                 }
             }
         }
         ComposerPrefsScope::Session => {
-            let sess = session_id.and_then(|id| {
-                load_sessions_index()
-                    .into_iter()
-                    .find(|s| s.id == id)
-            });
-            let proj = sess
-                .as_ref()
-                .and_then(|s| s.project_id.as_deref())
-                .or(project_id)
-                .and_then(|id| load_projects().into_iter().find(|p| p.id == id));
-
-            // Fallback chain: session → project → global
             let p_model = proj
                 .as_ref()
                 .and_then(|p| p.model_id.clone())
@@ -994,21 +1046,13 @@ pub fn resolve_composer_prefs(
                 .and_then(|p| p.mode.clone())
                 .filter(|s| !s.is_empty())
                 .unwrap_or(g_mode.clone());
-            let p_policy = proj
-                .as_ref()
-                .and_then(|p| p.permission_policy.clone())
-                .filter(|s| !s.is_empty())
-                .unwrap_or(g_policy.clone());
 
             if let Some(s) = sess {
                 ComposerPrefs {
                     model_id: s.model_id.filter(|x| !x.is_empty()).unwrap_or(p_model),
                     effort: s.effort.filter(|x| !x.is_empty()).unwrap_or(p_effort),
                     mode: s.mode.filter(|x| !x.is_empty()).unwrap_or(p_mode),
-                    permission_policy: s
-                        .permission_policy
-                        .filter(|x| !x.is_empty())
-                        .unwrap_or(p_policy),
+                    permission_policy,
                     scope: scope.as_str().into(),
                     source: "session".into(),
                 }
@@ -1017,7 +1061,7 @@ pub fn resolve_composer_prefs(
                     model_id: p_model,
                     effort: p_effort,
                     mode: p_mode,
-                    permission_policy: p_policy,
+                    permission_policy,
                     scope: scope.as_str().into(),
                     source: if proj.is_some() { "project" } else { "global" }.into(),
                 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ import {
   DEFAULT_EFFORT,
   DEFAULT_MODEL_ID,
   GROK_BUILD_MODELS,
+  PERMISSION_POLICIES,
   isValidEffort,
   isValidModelId,
   isValidPolicy,
@@ -183,6 +184,8 @@ import {
   IconExternalLink,
   IconFork,
   IconRewind,
+  IconShield,
+  IconCheck,
 } from "@/components/icons";
 import { AutomationsPage } from "@/components/AutomationsPage";
 import { OpenLocationButton } from "@/components/OpenLocationButton";
@@ -245,6 +248,8 @@ interface Project {
   trusted: boolean;
   pathOk: boolean;
   pinned?: boolean;
+  /** Project-level permission tier (L10). Null/undefined → app default. */
+  permissionPolicy?: string | null;
 }
 
 interface SessionRow {
@@ -259,6 +264,7 @@ interface SessionRow {
 
 type ContextMenuState =
   | { kind: "project"; id: string; x: number; y: number }
+  | { kind: "project-policy"; id: string; x: number; y: number }
   | { kind: "session"; id: string; x: number; y: number }
   | null;
 
@@ -917,10 +923,11 @@ export default function App() {
     void refreshLists();
   }, [refreshLists]);
 
-  // Re-resolve model/permission when project or chat changes (project/session scope).
+  // Re-resolve model/permission when project or chat changes.
+  // Permission always cascades project/session tiers (L10), even when model
+  // memory scope is global — so project-level tiers apply after a switch.
   useEffect(() => {
     if (!api.isTauri()) return;
-    if (prefsScope === "global") return;
     let cancelled = false;
     void api
       .composerPrefsResolve({
@@ -2447,6 +2454,88 @@ export default function App() {
         }
       },
     });
+  };
+
+  /**
+   * Apply a project-level permission tier (L10).
+   * `null` clears the override so the app default is used again.
+   * YOLO still requires the same two-step confirm as the composer chip.
+   */
+  const applyProjectPermissionPolicy = (
+    proj: Project,
+    next: PermissionPolicyId | null,
+  ) => {
+    setCtxMenu(null);
+
+    const commit = async () => {
+      try {
+        const updated = (await api.projectSetPermissionPolicy(
+          proj.id,
+          next,
+        )) as Project;
+        await refreshProjects();
+        if (activeProject?.id === proj.id) {
+          setActiveProject((p) =>
+            p
+              ? {
+                  ...p,
+                  permissionPolicy: updated.permissionPolicy ?? null,
+                }
+              : p,
+          );
+          const prefs = await api.composerPrefsResolve({
+            projectId: proj.id,
+            sessionId: session.sessionId ?? null,
+          });
+          applyComposerPrefs(prefs, availableModels);
+        }
+        const msg = next
+          ? tr("project.permissionSet", {
+              name: proj.name,
+              policy: tr(
+                (
+                  {
+                    ask: "policy.short.ask",
+                    accept_edits: "policy.short.accept_edits",
+                    allow_for_session: "policy.short.allow_for_session",
+                    dont_ask: "policy.short.dont_ask",
+                    always_approve: "policy.short.always_approve",
+                  } as const
+                )[next],
+              ),
+            })
+          : tr("project.permissionCleared", { name: proj.name });
+        setToast(msg);
+        window.setTimeout(() => setToast((cur) => (cur === msg ? null : cur)), 2800);
+      } catch (e) {
+        setLocalError(String(e));
+      }
+    };
+
+    if (next === "always_approve") {
+      setAppDialog({
+        kind: "confirm",
+        title: tr("policy.always_approve"),
+        message: tr("policy.yoloConfirm"),
+        confirmLabel: tr("common.confirm"),
+        danger: true,
+        onConfirm: () => {
+          setAppDialog({
+            kind: "confirm",
+            title: tr("policy.always_approve"),
+            message: tr("policy.yoloConfirm2"),
+            confirmLabel: tr("policy.short.always_approve"),
+            danger: true,
+            onConfirm: () => {
+              void commit();
+            },
+          });
+        },
+      });
+      return;
+    }
+
+    void commit();
   };
 
   /** Remove project from app list only (disk folder + chats kept). */
@@ -7683,6 +7772,23 @@ export default function App() {
                 icon: <IconRename size={16} />,
                 onClick: () => renameProject(proj),
               },
+              ...(proj.trusted
+                ? [
+                    {
+                      id: "permission",
+                      label: tr("project.permission"),
+                      icon: <IconShield size={16} />,
+                      onClick: () => {
+                        setCtxMenu({
+                          kind: "project-policy",
+                          id: proj.id,
+                          x: ctxMenu.x,
+                          y: ctxMenu.y,
+                        });
+                      },
+                    } satisfies ContextMenuItem,
+                  ]
+                : []),
               {
                 id: "archive-chats",
                 label: tr("project.archiveChats"),
@@ -7698,6 +7804,42 @@ export default function App() {
                 danger: true,
                 onClick: () => removeProjectFromApp(proj),
               },
+            ];
+          }
+        } else if (ctxMenu?.kind === "project-policy") {
+          const proj = projects.find((p) => p.id === ctxMenu.id);
+          if (proj && proj.trusted) {
+            const current = proj.permissionPolicy?.trim() || null;
+            const policyLabel = (id: PermissionPolicyId) =>
+              tr(
+                (
+                  {
+                    ask: "policy.ask",
+                    accept_edits: "policy.accept_edits",
+                    allow_for_session: "policy.allow_for_session",
+                    dont_ask: "policy.dont_ask",
+                    always_approve: "policy.always_approve",
+                  } as const
+                )[id],
+              );
+            items = [
+              {
+                id: "inherit",
+                label: tr("project.permissionInherit"),
+                icon: !current ? <IconCheck size={16} /> : undefined,
+                onClick: () => applyProjectPermissionPolicy(proj, null),
+              },
+              ...PERMISSION_POLICIES.map(
+                (p) =>
+                  ({
+                    id: `policy-${p.id}`,
+                    label: policyLabel(p.id),
+                    icon:
+                      current === p.id ? <IconCheck size={16} /> : undefined,
+                    danger: !!p.dangerous,
+                    onClick: () => applyProjectPermissionPolicy(proj, p.id),
+                  }) satisfies ContextMenuItem,
+              ),
             ];
           }
         } else if (ctxMenu?.kind === "session") {
@@ -7775,6 +7917,9 @@ export default function App() {
             y={ctxMenu?.y ?? 0}
             onClose={() => setCtxMenu(null)}
             items={items}
+            estimatedHeight={
+              ctxMenu?.kind === "project-policy" ? 280 : 240
+            }
           />
         );
       })()}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -62,6 +62,10 @@ const en = {
   "project.addSelectFirst": "Add and select a project in the sidebar first.",
   "project.trustFirst": 'Trust project "{name}" first.',
   "project.trustTitle": "Trust project",
+  "project.permission": "Permission default",
+  "project.permissionInherit": "Use app default",
+  "project.permissionSet": '"{name}" permission: {policy}',
+  "project.permissionCleared": '"{name}" uses app permission default',
 
   "session.rename": "Rename",
   "session.renamePrompt": "Rename chat",
@@ -1091,6 +1095,10 @@ const zh: Record<MessageKey, string> = {
   "project.addSelectFirst": "请先在左侧添加并选择一个项目。",
   "project.trustFirst": "请先信任项目「{name}」。",
   "project.trustTitle": "信任项目",
+  "project.permission": "项目权限档",
+  "project.permissionInherit": "使用应用默认",
+  "project.permissionSet": "「{name}」权限：{policy}",
+  "project.permissionCleared": "「{name}」已恢复应用默认权限",
 
   "session.rename": "重命名",
   "session.renamePrompt": "重命名会话",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -53,6 +53,10 @@ export const zhTW: Record<MessageKey, string> = {
   "project.selectFirst": "請先選擇一個專案。",
   "project.addSelectFirst": "請先在左側新增並選擇一個專案。",
   "project.trustFirst": "請先信任專案「{name}」。",
+  "project.permission": "專案權限檔",
+  "project.permissionInherit": "使用應用程式預設",
+  "project.permissionSet": "「{name}」權限：{policy}",
+  "project.permissionCleared": "「{name}」已恢復應用程式預設權限",
 
   "session.rename": "重新命名",
   "session.renamePrompt": "重新命名對話",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -442,6 +442,21 @@ export async function projectTrust(id: string) {
   return invoke("project_trust", { id });
 }
 
+/**
+ * Set or clear a project-level permission tier (L10).
+ * Pass `null` / `"inherit"` to fall back to the app default.
+ * When the project is the live Host context, agent policy is synced.
+ */
+export async function projectSetPermissionPolicy(
+  id: string,
+  policy: string | null,
+) {
+  return invoke("project_set_permission_policy", {
+    id,
+    policy,
+  });
+}
+
 /** Remove project from app list only (no disk / session wipe). */
 export async function projectRemove(id: string) {
   return invoke("project_remove", { id });


### PR DESCRIPTION
Trust was just a boolean. Projects already had an optional `permission_policy` field, but it only kicked in if you set composer prefs scope to project/session, so most people never got a real per-project tier.

This always resolves permission as session → project → app default (model/effort/mode still follow the prefs scope setting). Untrusted projects force Ask. Trusted ones get a context-menu item to set or clear the project default; Full access still uses the two-step confirm. Switching projects re-resolves so the chip matches.

### Test plan
- [x] `pnpm typecheck && pnpm test`
- [x] `cd src-tauri && cargo test permission`
- [ ] Trust a project → right-click → Permission default → Accept edits → chip shows Edits
- [ ] Project without a tier still uses the app default
- [ ] Clear with “Use app default”
- [ ] Untrusted: no menu item; stays Ask