### PR TITLE
fix: paste images into the composer again

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -68,6 +68,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "ashpd"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +731,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1111,6 +1146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1177,12 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1414,6 +1461,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,13 +1607,15 @@ dependencies = [
 
 [[package]]
 name = "grok-app"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
+ "arboard",
  "base64 0.22.1",
  "chrono",
  "directories",
  "futures-util",
  "hex",
+ "image",
  "keyring",
  "parking_lot",
  "reqwest 0.12.28",
@@ -1628,6 +1687,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1952,6 +2022,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2497,6 +2568,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2986,6 +3058,12 @@ name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4401,6 +4479,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5226,6 +5318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "which"
 version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5789,6 +5887,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6065,6 +6180,21 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,8 @@ keyring = { version = "3.6", features = [
     "sync-secret-service",
     "crypto-rust",
 ] }
+arboard = "3"
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 [profile.release]
 codegen-units = 1

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2432,6 +2432,104 @@ pub async fn save_temp_attachment(
     })
 }
 
+/// Read an image from the OS clipboard (screenshots) and save under attachments/paste.
+/// Used when the WebView paste event has no File objects (common on macOS WKWebView).
+/// Returns `None` when the clipboard has no image.
+#[tauri::command]
+pub async fn clipboard_paste_image() -> Result<Option<PathEntry>, String> {
+    tauri::async_runtime::spawn_blocking(|| clipboard_paste_image_sync())
+        .await
+        .map_err(|e| format!("clipboard task: {e}"))?
+}
+
+fn clipboard_paste_image_sync() -> Result<Option<PathEntry>, String> {
+    use arboard::Clipboard;
+
+    let mut cb = Clipboard::new().map_err(|e| format!("clipboard open: {e}"))?;
+    let img = match cb.get_image() {
+        Ok(img) => img,
+        Err(arboard::Error::ContentNotAvailable) => return Ok(None),
+        Err(e) => return Err(format!("clipboard image: {e}")),
+    };
+
+    let w = img.width;
+    let h = img.height;
+    if w == 0 || h == 0 {
+        return Ok(None);
+    }
+    let expected = w.saturating_mul(h).saturating_mul(4);
+    if img.bytes.len() < expected {
+        return Err(format!(
+            "clipboard image truncated ({} < {})",
+            img.bytes.len(),
+            expected
+        ));
+    }
+
+    let png = rgba_to_png_bytes(w, h, &img.bytes[..expected])?;
+    if png.len() > 40 * 1024 * 1024 {
+        return Err("attachment too large (max 40 MiB)".into());
+    }
+
+    let dir = crate::paths::attachments_paste_dir();
+    let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S-%3f");
+    let file_name = format!("{stamp}-paste.png");
+    let path = dir.join(&file_name);
+    std::fs::write(&path, &png).map_err(|e| format!("write attachment: {e}"))?;
+
+    Ok(Some(PathEntry {
+        path: path.display().to_string(),
+        name: file_name,
+        is_dir: false,
+        exists: true,
+    }))
+}
+
+/// Encode raw RGBA8 pixels as PNG (clipboard / paste path).
+fn rgba_to_png_bytes(width: usize, height: usize, rgba: &[u8]) -> Result<Vec<u8>, String> {
+    use image::ImageEncoder;
+    if width == 0 || height == 0 {
+        return Err("empty image".into());
+    }
+    let expected = width.saturating_mul(height).saturating_mul(4);
+    if rgba.len() < expected {
+        return Err("rgba buffer too short".into());
+    }
+    let mut png = Vec::new();
+    let encoder = image::codecs::png::PngEncoder::new(&mut png);
+    encoder
+        .write_image(
+            &rgba[..expected],
+            width as u32,
+            height as u32,
+            image::ExtendedColorType::Rgba8,
+        )
+        .map_err(|e| format!("png encode: {e}"))?;
+    if png.is_empty() {
+        return Err("png encode produced empty buffer".into());
+    }
+    Ok(png)
+}
+
+#[cfg(test)]
+mod clipboard_paste_tests {
+    use super::rgba_to_png_bytes;
+
+    #[test]
+    fn rgba_one_pixel_encodes_png_signature() {
+        // 1×1 opaque red
+        let rgba = [255u8, 0, 0, 255];
+        let png = rgba_to_png_bytes(1, 1, &rgba).expect("encode");
+        assert!(png.len() > 8);
+        assert_eq!(&png[..8], &[137, 80, 78, 71, 13, 10, 26, 10]);
+    }
+
+    #[test]
+    fn rgba_rejects_short_buffer() {
+        assert!(rgba_to_png_bytes(2, 2, &[0u8; 4]).is_err());
+    }
+}
+
 fn mime_to_ext(mime: &str) -> Option<String> {
     let m = mime.split(';').next().unwrap_or(mime).trim();
     Some(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,6 +191,7 @@ pub fn run() {
             commands::pick_attach_files,
             commands::pick_attach_folder,
             commands::save_temp_attachment,
+            commands::clipboard_paste_image,
             commands::paths_classify,
             commands::path_open,
             commands::path_reveal,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3207,6 +3207,7 @@ export default function App() {
       const intoEdit = !!editingUserMessageIdRef.current;
       const mergeInto = intoEdit ? setEditAttachments : setAttachments;
       try {
+        let lastName = "";
         for (const f of withoutPath) {
           const buf = await f.arrayBuffer();
           const bytes = new Uint8Array(buf);
@@ -3226,6 +3227,7 @@ export default function App() {
                 ? `paste.${(f.type.split("/")[1] || "png").replace("jpeg", "jpg")}`
                 : f.name || "paste.bin";
           const entry = await api.saveTempAttachment(b64, name, f.type || null);
+          lastName = entry.name;
           mergeInto((prev) =>
             mergeAttachments(prev, [
               {
@@ -3237,6 +3239,49 @@ export default function App() {
           );
         }
         setLocalError(null);
+        if (lastName) {
+          const msg = tr("composer.attachSaved", { name: lastName });
+          setToast(msg);
+          window.setTimeout(
+            () => setToast((cur) => (cur === msg ? null : cur)),
+            2200,
+          );
+        }
+      } catch (e) {
+        setLocalError(String(e) || tr("composer.attachPasteFailed"));
+      }
+    },
+    [addAttachmentsFromPaths, tr],
+  );
+
+  /**
+   * Native OS clipboard image (arboard) when WebView paste has no File objects.
+   * Used for macOS screenshots / system image clipboard.
+   */
+  const pasteMediaFromNativeClipboard = useCallback(
+    async (opts?: { expectMedia?: boolean }) => {
+      if (!api.isTauri()) {
+        if (opts?.expectMedia) {
+          setLocalError(tr("composer.attachPasteFailed"));
+        }
+        return;
+      }
+      try {
+        const entry = await api.clipboardPasteImage();
+        if (!entry?.path) {
+          if (opts?.expectMedia) {
+            setLocalError(tr("composer.attachPasteFailed"));
+          }
+          return;
+        }
+        await addAttachmentsFromPaths([entry.path]);
+        setLocalError(null);
+        const msg = tr("composer.attachSaved", { name: entry.name });
+        setToast(msg);
+        window.setTimeout(
+          () => setToast((cur) => (cur === msg ? null : cur)),
+          2200,
+        );
       } catch (e) {
         setLocalError(String(e) || tr("composer.attachPasteFailed"));
       }
@@ -3283,10 +3328,27 @@ export default function App() {
     }
     try {
       const paths = await api.pickAttachFiles();
-      if (!paths.length) return;
+      if (!paths.length) {
+        // Cancelled — no error.
+        return;
+      }
       await addAttachmentsFromPaths(paths);
+      setLocalError(null);
+      const label =
+        paths.length === 1
+          ? paths[0]!.split(/[/\\]/).pop() || paths[0]!
+          : tr("composer.attachCount", { n: String(paths.length) });
+      const msg =
+        paths.length === 1
+          ? tr("composer.attachSaved", { name: label })
+          : tr("composer.attachSaved", { name: label });
+      setToast(msg);
+      window.setTimeout(
+        () => setToast((cur) => (cur === msg ? null : cur)),
+        2200,
+      );
     } catch (e) {
-      setLocalError(String(e));
+      setLocalError(String(e) || tr("composer.attachPasteFailed"));
     }
   }, [addAttachmentsFromPaths, closeComposerMenu, tr]);
 
@@ -6805,6 +6867,9 @@ export default function App() {
                 onChange={setDraft}
                 onPasteFiles={(files) => {
                   void addAttachmentsFromFiles(files);
+                }}
+                onPasteMediaFallback={(opts) => {
+                  void pasteMediaFromNativeClipboard(opts);
                 }}
                 onSlashQueryChange={onSlashQueryChange}
                 onKeyDown={(e) => {

--- a/src/components/ComposerEditor.tsx
+++ b/src/components/ComposerEditor.tsx
@@ -19,6 +19,13 @@ import {
   type Ref,
 } from "react";
 import {
+  clipboardLooksLikeMedia,
+  clipboardPlainText,
+  collectFilesFromDataTransfer,
+  isFileUrlOnlyText,
+  readClipboardMediaFiles,
+} from "@/lib/clipboardPaste";
+import {
   detectSlashQuery,
   parseStoredContent,
   serializeStored,
@@ -180,6 +187,14 @@ export type ComposerEditorProps = {
   ) => void;
   editorRef?: Ref<HTMLDivElement | null>;
   onPasteFiles?: (files: File[]) => void;
+  /**
+   * When the paste event looks like media but has no File objects (and async
+   * Clipboard API also fails), parent should try native OS clipboard.
+   * `expectMedia: true` → show a failure toast if nothing was attached.
+   */
+  onPasteMediaFallback?: (opts?: {
+    expectMedia?: boolean;
+  }) => void | Promise<void>;
 };
 
 export function ComposerEditor({
@@ -192,6 +207,7 @@ export function ComposerEditor({
   onSlashQueryChange,
   editorRef,
   onPasteFiles,
+  onPasteMediaFallback,
 }: ComposerEditorProps) {
   const elRef = useRef<HTMLDivElement | null>(null);
   const lastValue = useRef(value);
@@ -320,35 +336,45 @@ export function ComposerEditor({
     e.preventDefault();
     e.stopPropagation();
 
-    const filesFromList = e.clipboardData?.files
-      ? Array.from(e.clipboardData.files)
-      : [];
-    const filesFromItems: File[] = [];
-    const items = e.clipboardData?.items;
-    if (items) {
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        if (!item || item.kind !== "file") continue;
-        const f = item.getAsFile();
-        if (f) filesFromItems.push(f);
-      }
-    }
-    const fileMap = new Map<string, File>();
-    for (const f of [...filesFromList, ...filesFromItems]) {
-      const key = `${f.name}:${f.size}:${f.type}:${f.lastModified}`;
-      if (!fileMap.has(key)) fileMap.set(key, f);
-    }
-    const files = Array.from(fileMap.values());
+    // Prefer nativeEvent — React's synthetic clipboardData is empty on some WebViews.
+    const cd =
+      e.clipboardData ??
+      (e.nativeEvent as globalThis.ClipboardEvent | undefined)?.clipboardData ??
+      null;
+
+    const files = collectFilesFromDataTransfer(cd);
     if (files.length && onPasteFiles) {
       onPasteFiles(files);
+    } else if (onPasteFiles && clipboardLooksLikeMedia(cd)) {
+      // Screenshot paste: event often has image/* types but no File objects.
+      void (async () => {
+        const asyncFiles = await readClipboardMediaFiles();
+        if (asyncFiles.length) {
+          onPasteFiles(asyncFiles);
+          return;
+        }
+        await onPasteMediaFallback?.({ expectMedia: true });
+      })();
+    } else if (!files.length && onPasteMediaFallback) {
+      // Empty-looking paste on Mac can still be a pure bitmap clipboard.
+      // Only run native fallback when no text is about to be inserted.
+      const plainProbe = clipboardPlainText(cd);
+      if (!plainProbe.trim()) {
+        void (async () => {
+          const asyncFiles = await readClipboardMediaFiles();
+          if (asyncFiles.length) {
+            onPasteFiles?.(asyncFiles);
+            return;
+          }
+          // Soft try — no error toast if clipboard has no image.
+          await onPasteMediaFallback({ expectMedia: false });
+        })();
+      }
     }
 
-    const plain =
-      e.clipboardData?.getData("text/plain") ??
-      e.clipboardData?.getData("text") ??
-      "";
+    const plain = clipboardPlainText(cd);
     if (!plain) return;
-    if (files.length && /^file:\/\//i.test(plain.trim())) return;
+    if (files.length && isFileUrlOnlyText(plain)) return;
     insertPlainTextAtSelection(plain);
     const el = elRef.current;
     if (el) commitFromDom(el);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -302,6 +302,16 @@ export async function saveTempAttachment(
   });
 }
 
+/**
+ * Read an image from the OS clipboard (native) and save under attachments/paste.
+ * Fallback when the WebView paste event has no File objects (macOS screenshots).
+ * Returns null when the clipboard has no image.
+ */
+export async function clipboardPasteImage() {
+  if (!isTauri()) return null;
+  return invoke<PathEntry | null>("clipboard_paste_image");
+}
+
 export interface PathEntry {
   path: string;
   name: string;

--- a/src/lib/clipboardPaste.test.ts
+++ b/src/lib/clipboardPaste.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  clipboardLooksLikeMedia,
+  clipboardPlainText,
+  collectFilesFromDataTransfer,
+  isFileUrlOnlyText,
+} from "./clipboardPaste";
+
+function fakeFile(name: string, type: string, size = 12): File {
+  const buf = new Uint8Array(size);
+  return new File([buf], name, { type, lastModified: 1 });
+}
+
+describe("collectFilesFromDataTransfer", () => {
+  it("returns empty for null", () => {
+    expect(collectFilesFromDataTransfer(null)).toEqual([]);
+  });
+
+  it("collects files from items kind=file", () => {
+    const f = fakeFile("shot.png", "image/png");
+    const data = {
+      files: { length: 0, item: () => null } as unknown as FileList,
+      items: [
+        {
+          kind: "file",
+          type: "image/png",
+          getAsFile: () => f,
+        },
+      ],
+      types: ["Files", "image/png"],
+      getData: () => "",
+    } as unknown as DataTransfer;
+    const files = collectFilesFromDataTransfer(data);
+    expect(files).toHaveLength(1);
+    expect(files[0]?.name).toBe("shot.png");
+  });
+
+  it("dedupes same file from files + items", () => {
+    const f = fakeFile("a.png", "image/png");
+    const data = {
+      files: {
+        length: 1,
+        item: (i: number) => (i === 0 ? f : null),
+        0: f,
+        [Symbol.iterator]: function* () {
+          yield f;
+        },
+      } as unknown as FileList,
+      items: [
+        {
+          kind: "file",
+          type: "image/png",
+          getAsFile: () => f,
+        },
+      ],
+      types: ["Files"],
+      getData: () => "",
+    } as unknown as DataTransfer;
+    expect(collectFilesFromDataTransfer(data)).toHaveLength(1);
+  });
+});
+
+describe("clipboardLooksLikeMedia", () => {
+  it("detects image types without File objects", () => {
+    const data = {
+      files: { length: 0, item: () => null } as unknown as FileList,
+      items: [{ kind: "string", type: "image/png", getAsFile: () => null }],
+      types: ["image/png"],
+      getData: () => "",
+    } as unknown as DataTransfer;
+    expect(clipboardLooksLikeMedia(data)).toBe(true);
+  });
+
+  it("false for plain text only", () => {
+    const data = {
+      files: { length: 0, item: () => null } as unknown as FileList,
+      items: [{ kind: "string", type: "text/plain", getAsFile: () => null }],
+      types: ["text/plain"],
+      getData: () => "hello",
+    } as unknown as DataTransfer;
+    expect(clipboardLooksLikeMedia(data)).toBe(false);
+  });
+});
+
+describe("clipboardPlainText / isFileUrlOnlyText", () => {
+  it("normalizes newlines", () => {
+    const data = {
+      getData: (t: string) => (t === "text/plain" ? "a\r\nb\rc" : ""),
+    } as unknown as DataTransfer;
+    expect(clipboardPlainText(data)).toBe("a\nb\nc");
+  });
+
+  it("detects file url only", () => {
+    expect(isFileUrlOnlyText("file:///tmp/x.png")).toBe(true);
+    expect(isFileUrlOnlyText("hello\nfile:///tmp/x.png")).toBe(false);
+  });
+});

--- a/src/lib/clipboardPaste.ts
+++ b/src/lib/clipboardPaste.ts
@@ -1,0 +1,131 @@
+/**
+ * Composer clipboard helpers — paste images/files into attachments.
+ *
+ * Tauri / WKWebView often omits File objects from the paste event for
+ * screenshots (only `image/png` types, or nothing usable). Callers should:
+ * 1. collectFilesFromDataTransfer(clipboardData)
+ * 2. if empty + clipboardLooksLikeMedia → readClipboardMediaFiles()
+ * 3. if still empty → native Host clipboard (arboard)
+ */
+
+/** Collect File objects from a paste/drop DataTransfer (deduped). */
+export function collectFilesFromDataTransfer(
+  data: DataTransfer | null | undefined,
+): File[] {
+  if (!data) return [];
+  const fileMap = new Map<string, File>();
+
+  if (data.files?.length) {
+    for (let i = 0; i < data.files.length; i++) {
+      const f = data.files.item(i);
+      if (f) fileMap.set(fileKey(f), f);
+    }
+  }
+
+  const items = data.items;
+  if (items) {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (!item) continue;
+      // Screenshots: kind "file" + type image/*; some WebViews only expose type.
+      if (item.kind === "file" || item.type.startsWith("image/")) {
+        const f = item.getAsFile();
+        if (f) fileMap.set(fileKey(f), f);
+      }
+    }
+  }
+
+  return Array.from(fileMap.values());
+}
+
+function fileKey(f: File): string {
+  return `${f.name}:${f.size}:${f.type}:${f.lastModified}`;
+}
+
+/**
+ * True when the paste payload likely carries binary media even if File
+ * extraction returned nothing (common for macOS screenshot → WKWebView).
+ */
+export function clipboardLooksLikeMedia(
+  data: DataTransfer | null | undefined,
+): boolean {
+  if (!data) return false;
+  const types = Array.from(data.types ?? []);
+  if (types.some((t) => t === "Files" || t.startsWith("image/"))) return true;
+  if (data.files && data.files.length > 0) return true;
+  const items = data.items;
+  if (items) {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (!item) continue;
+      if (item.kind === "file") return true;
+      if (item.type.startsWith("image/")) return true;
+    }
+  }
+  return false;
+}
+
+/** Plain text from paste (normalized newlines). */
+export function clipboardPlainText(
+  data: DataTransfer | null | undefined,
+): string {
+  if (!data) return "";
+  const plain =
+    data.getData("text/plain") || data.getData("text") || "";
+  return plain.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/** file:// only paste — skip inserting as text when we already attached files. */
+export function isFileUrlOnlyText(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  return /^file:\/\//i.test(t) && !t.includes("\n");
+}
+
+function extForMime(mime: string): string {
+  const m = mime.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (m === "image/jpeg" || m === "image/jpg") return "jpg";
+  if (m === "image/png") return "png";
+  if (m === "image/gif") return "gif";
+  if (m === "image/webp") return "webp";
+  if (m === "image/bmp") return "bmp";
+  if (m === "image/svg+xml") return "svg";
+  if (m.startsWith("image/")) return m.slice("image/".length) || "png";
+  return "bin";
+}
+
+/**
+ * Async Clipboard API fallback (Chromium / some WKWebView builds).
+ * Returns empty array when denied, unsupported, or no image items.
+ */
+export async function readClipboardMediaFiles(): Promise<File[]> {
+  if (typeof navigator === "undefined" || !navigator.clipboard?.read) {
+    return [];
+  }
+  try {
+    const items = await navigator.clipboard.read();
+    const out: File[] = [];
+    for (const item of items) {
+      for (const type of item.types) {
+        if (!type.startsWith("image/") && type !== "application/pdf") continue;
+        try {
+          const blob = await item.getType(type);
+          if (!blob || blob.size === 0) continue;
+          const ext = extForMime(type);
+          out.push(
+            new File([blob], `paste.${ext}`, {
+              type: type || blob.type || "application/octet-stream",
+              lastModified: Date.now(),
+            }),
+          );
+        } catch {
+          /* type not readable */
+        }
+      }
+    }
+    return out;
+  } catch {
+    // NotAllowedError / empty clipboard / no permission
+    return [];
+  }
+}


### PR DESCRIPTION
Screenshot → paste was a no-op on the desktop app. The WebView paste event usually has no File for clipboard images (esp. mac screenshots), we still preventDefault, so nothing got attached and there was no error.

Now: take Files from the paste event when present, else try `clipboard.read()`, else read the image from the OS clipboard (arboard) and write a PNG under attachments/paste. Success shows a short toast; if we clearly expected media and still got nothing, surface the attach error. + → Files uses the same success toast.

### Test plan
- [x] `pnpm typecheck && pnpm test`
- [x] `cd src-tauri && cargo test clipboard_paste`
- [ ] Desktop build: clipboard screenshot (or copy from Preview) → focus input → ⌘V / Ctrl+V → chip appears
- [ ] + → Files pick an image
- [ ] Plain text paste still works

Browser-only Vite preview still can't save paste files (needs Tauri). On Mac use ⌘V.