### PR TITLE
feat: structured error deck for CLI/auth/network/crash

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import {
   isSessionLiveStreaming,
   preferSessionMessages,
   presentErrorBanner,
+  type ErrorBannerView,
   buildSegmentsFromLegacy,
   splitThoughtPhases,
   truncateBeforeLastUser,
@@ -4701,6 +4702,45 @@ export default function App() {
     setErrorDetailOpen(false);
   }, [errorBanner?.code, errorBanner?.summary, errorBanner?.detail]);
 
+  /** T04 deck buttons: reconnect / Doctor / Settings sections / dismiss. */
+  const runErrorBannerAction = useCallback(
+    (action: NonNullable<ErrorBannerView["primary"]>) => {
+      setErrorDetailOpen(false);
+      switch (action.id) {
+        case "reconnect":
+          setLocalError(null);
+          void ensureConnected(true).then((sid) => {
+            if (sid) setLocalError(null);
+          });
+          break;
+        case "open_doctor":
+          setLocalError(null);
+          openDoctor();
+          break;
+        case "open_runtime":
+          setLocalError(null);
+          navigateSettings("runtime");
+          break;
+        case "open_account":
+          setLocalError(null);
+          navigateSettings("account");
+          break;
+        case "open_providers":
+          setLocalError(null);
+          // Providers live under account / extensions path — account is the
+          // login+key surface; extensions holds MCP. Prefer account for keys.
+          navigateSettings("account");
+          break;
+        case "dismiss":
+          setLocalError(null);
+          break;
+        default:
+          break;
+      }
+    },
+    [ensureConnected, navigateSettings, openDoctor],
+  );
+
   const refreshAccount = useCallback(
     async (opts?: { refreshBilling?: boolean }) => {
       if (!api.isTauri()) return;
@@ -6477,27 +6517,51 @@ export default function App() {
             />
           )}
 
-          {/* One surface only: turn failures live in chat; banner is for pre-turn/local errors */}
+          {/* Pre-turn / host errors: T04 deck (problem · cause · primary · secondary) */}
           {errorBanner && !hasChatTurnError && (
             <div className="error-banner" role="alert">
+              {errorBanner.code ? (
+                <div className="error-banner__code">{errorBanner.code}</div>
+              ) : null}
               <div className="error-banner__summary">{errorBanner.summary}</div>
-              {(errorBanner.detail ||
-                errorBanner.reconnectHint ||
-                session.state === "disconnected") && (
-                <div className="error-banner__actions">
-                  {errorBanner.detail && (
-                    <button
-                      type="button"
-                      className="error-banner__details-btn"
-                      aria-expanded={errorDetailOpen}
-                      onClick={() => setErrorDetailOpen((v) => !v)}
-                    >
-                      {errorDetailOpen
-                        ? tr("error.hideDetails")
-                        : tr("error.details")}
-                    </button>
-                  )}
-                  {(errorBanner.reconnectHint ||
+              {errorBanner.cause ? (
+                <div className="error-banner__cause">{errorBanner.cause}</div>
+              ) : null}
+              <div className="error-banner__actions">
+                {errorBanner.primary ? (
+                  <button
+                    type="button"
+                    className="btn btn--primary error-banner__primary"
+                    disabled={
+                      connecting && errorBanner.primary.id === "reconnect"
+                    }
+                    onClick={() => {
+                      if (errorBanner.primary) {
+                        runErrorBannerAction(errorBanner.primary);
+                      }
+                    }}
+                  >
+                    {errorBanner.primary.label}
+                  </button>
+                ) : null}
+                {errorBanner.secondary ? (
+                  <button
+                    type="button"
+                    className="btn btn--ghost error-banner__secondary"
+                    disabled={
+                      connecting && errorBanner.secondary.id === "reconnect"
+                    }
+                    onClick={() => {
+                      if (errorBanner.secondary) {
+                        runErrorBannerAction(errorBanner.secondary);
+                      }
+                    }}
+                  >
+                    {errorBanner.secondary.label}
+                  </button>
+                ) : null}
+                {!errorBanner.primary &&
+                  (errorBanner.reconnectHint ||
                     session.state === "disconnected") && (
                     <button
                       type="button"
@@ -6514,8 +6578,19 @@ export default function App() {
                       {tr("main.reconnect")}
                     </button>
                   )}
-                </div>
-              )}
+                {errorBanner.detail ? (
+                  <button
+                    type="button"
+                    className="error-banner__details-btn"
+                    aria-expanded={errorDetailOpen}
+                    onClick={() => setErrorDetailOpen((v) => !v)}
+                  >
+                    {errorDetailOpen
+                      ? tr("error.hideDetails")
+                      : tr("error.details")}
+                  </button>
+                ) : null}
+              </div>
               {errorBanner.detail && errorDetailOpen && (
                 <pre className="error-banner__detail">{errorBanner.detail}</pre>
               )}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -126,6 +126,44 @@ const en = {
   "main.retryingWithReason": "Retrying {attempt}/{max}: {reason}",
   "error.details": "Details",
   "error.hideDetails": "Hide details",
+  "error.action.reconnect": "Reconnect",
+  "error.action.retry": "Retry",
+  "error.action.openDoctor": "Open Doctor",
+  "error.action.setCliPath": "Set CLI path",
+  "error.action.openAccount": "Account & keys",
+  "error.action.openProviders": "Providers",
+  "error.action.openRuntime": "Runtime settings",
+  "error.action.dismiss": "Dismiss",
+  "error.deck.cli.problem": "Grok Build CLI not found",
+  "error.deck.cli.cause":
+    "The desktop app needs the local CLI binary. Install it, or point Settings at an existing path.",
+  "error.deck.auth.problem": "Authentication failed",
+  "error.deck.auth.cause":
+    "Login expired, API key invalid, or the provider rejected the request (401).",
+  "error.deck.network.problem": "Network or model provider error",
+  "error.deck.network.cause":
+    "DNS/timeout, relay 5xx, wrong base URL, or the model id is unavailable.",
+  "error.deck.crash.problem": "Agent process crashed",
+  "error.deck.crash.cause":
+    "The agent exited or the protocol broke. Chat history is kept; reconnect to continue.",
+  "error.deck.quota.problem": "Quota or rate limit",
+  "error.deck.quota.cause":
+    "Usage limit, subscription throttle, or the provider returned 429 / insufficient credits.",
+  "error.deck.connect.problem": "Could not connect the agent",
+  "error.deck.connect.cause":
+    "No live agent for this session. CLI may be offline, or custom provider config is incomplete.",
+  "error.deck.limit.problem": "Agent process limit reached",
+  "error.deck.limit.cause":
+    "Too many warm agent processes. Stop another session or raise the limit under Runtime.",
+  "error.deck.timeout.problem": "This turn timed out",
+  "error.deck.timeout.cause":
+    "The agent stopped after a long wait. Retry — image or heavy tools may need more time.",
+  "error.deck.disconnect.problem": "Agent connection interrupted",
+  "error.deck.disconnect.cause":
+    "The RPC channel closed mid-turn. Reconnect and send again.",
+  "error.deck.generic.problem": "Something went wrong",
+  "error.deck.generic.cause":
+    "Check Doctor for CLI/auth status, then retry the last action.",
   "main.startTitle": "Start chatting",
   "main.startHint": "Type a message — CLI connects silently on send.",
   "main.working": "working…",
@@ -1152,6 +1190,43 @@ const zh: Record<MessageKey, string> = {
   "main.retryingWithReason": "重试 {attempt}/{max}：{reason}",
   "error.details": "详情",
   "error.hideDetails": "收起详情",
+  "error.action.reconnect": "重新连接",
+  "error.action.retry": "重试",
+  "error.action.openDoctor": "打开 Doctor",
+  "error.action.setCliPath": "指定 CLI 路径",
+  "error.action.openAccount": "账号与密钥",
+  "error.action.openProviders": "服务商",
+  "error.action.openRuntime": "运行环境设置",
+  "error.action.dismiss": "关闭",
+  "error.deck.cli.problem": "未找到 Grok Build CLI",
+  "error.deck.cli.cause":
+    "桌面端需要本机 CLI 可执行文件。请安装，或在设置中指定已有路径。",
+  "error.deck.auth.problem": "鉴权失败",
+  "error.deck.auth.cause":
+    "登录过期、API Key 无效，或服务商拒绝了请求（401）。",
+  "error.deck.network.problem": "网络或模型服务异常",
+  "error.deck.network.cause":
+    "DNS/超时、中转 5xx、base URL 错误，或模型 ID 不可用。",
+  "error.deck.crash.problem": "Agent 进程异常退出",
+  "error.deck.crash.cause":
+    "Agent 崩溃或协议中断。对话记录仍保留，可重新连接后继续。",
+  "error.deck.quota.problem": "额度不足或触发限流",
+  "error.deck.quota.cause":
+    "用量上限、订阅限流，或服务商返回 429 / 余额不足。",
+  "error.deck.connect.problem": "无法连接本会话的 Agent",
+  "error.deck.connect.cause":
+    "当前没有可用 Agent。CLI 可能未就绪，或自定义中转配置不完整。",
+  "error.deck.limit.problem": "已达到 Agent 进程上限",
+  "error.deck.limit.cause":
+    "并行 Agent 过多。请先结束其他会话，或在运行环境中提高上限。",
+  "error.deck.timeout.problem": "本轮执行超时",
+  "error.deck.timeout.cause":
+    "等待过久已中止。可重试；生图等长任务可能需要更久。",
+  "error.deck.disconnect.problem": "与 Agent 的连接已中断",
+  "error.deck.disconnect.cause":
+    "传输通道在回合中关闭。请重新连接后再发送。",
+  "error.deck.generic.problem": "出了点问题",
+  "error.deck.generic.cause": "可在 Doctor 查看 CLI/鉴权状态，然后重试上一步操作。",
   "main.startTitle": "开始对话",
   "main.startHint": "输入消息后发送，将在后台静默连接 CLI。",
   "main.working": "工作中…",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -114,6 +114,43 @@ export const zhTW: Record<MessageKey, string> = {
   "main.retryingWithReason": "重試 {attempt}/{max}：{reason}",
   "error.details": "詳情",
   "error.hideDetails": "收合詳情",
+  "error.action.reconnect": "重新連線",
+  "error.action.retry": "重試",
+  "error.action.openDoctor": "開啟 Doctor",
+  "error.action.setCliPath": "指定 CLI 路徑",
+  "error.action.openAccount": "帳號與金鑰",
+  "error.action.openProviders": "服務商",
+  "error.action.openRuntime": "執行環境設定",
+  "error.action.dismiss": "關閉",
+  "error.deck.cli.problem": "找不到 Grok Build CLI",
+  "error.deck.cli.cause":
+    "桌面端需要本機 CLI 可執行檔。請安裝，或在設定中指定既有路徑。",
+  "error.deck.auth.problem": "驗證失敗",
+  "error.deck.auth.cause":
+    "登入過期、API 金鑰無效，或服務商拒絕了請求（401）。",
+  "error.deck.network.problem": "網路或模型服務異常",
+  "error.deck.network.cause":
+    "DNS/逾時、中轉 5xx、base URL 錯誤，或模型 ID 不可用。",
+  "error.deck.crash.problem": "Agent 處理程序異常結束",
+  "error.deck.crash.cause":
+    "Agent 當掉或通訊中斷。對話紀錄仍保留，可重新連線後繼續。",
+  "error.deck.quota.problem": "額度不足或觸發限流",
+  "error.deck.quota.cause":
+    "用量上限、訂閱限流，或服務商回傳 429 / 餘額不足。",
+  "error.deck.connect.problem": "無法連線本對話的 Agent",
+  "error.deck.connect.cause":
+    "目前沒有可用 Agent。CLI 可能未就緒，或自訂中轉設定不完整。",
+  "error.deck.limit.problem": "已達 Agent 處理程序上限",
+  "error.deck.limit.cause":
+    "並行 Agent 過多。請先結束其他對話，或在執行環境中提高上限。",
+  "error.deck.timeout.problem": "本輪執行逾時",
+  "error.deck.timeout.cause":
+    "等待過久已中止。可重試；生圖等長任務可能需要更久。",
+  "error.deck.disconnect.problem": "與 Agent 的連線已中斷",
+  "error.deck.disconnect.cause":
+    "傳輸通道在回合中關閉。請重新連線後再傳送。",
+  "error.deck.generic.problem": "出了點問題",
+  "error.deck.generic.cause": "可在 Doctor 查看 CLI/驗證狀態，然後重試上一步操作。",
   "main.startTitle": "開始對話",
   "main.startHint": "輸入訊息後傳送，將在背景靜默連線 CLI。",
   "main.working": "工作中…",

--- a/src/lib/errorDeck.test.ts
+++ b/src/lib/errorDeck.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildErrorDeck,
+  deckCodeFromAgent,
+  isReconnectAction,
+} from "./errorDeck";
+
+describe("buildErrorDeck", () => {
+  it("returns problem/cause/actions for the four product classes (en)", () => {
+    const cli = buildErrorDeck("CLI_NOT_FOUND", "en");
+    expect(cli.problem.toLowerCase()).toMatch(/cli/);
+    expect(cli.cause.length).toBeGreaterThan(8);
+    expect(cli.primary.id).toBe("open_doctor");
+    expect(cli.secondary?.id).toBe("open_runtime");
+
+    const auth = buildErrorDeck("AUTH_FAILED", "en");
+    expect(auth.problem.toLowerCase()).toMatch(/auth|login|key/);
+    expect(auth.primary.id).toBe("open_account");
+
+    const net = buildErrorDeck("NETWORK_PROVIDER", "en");
+    expect(net.problem.toLowerCase()).toMatch(/network|provider|model/);
+    expect(isReconnectAction(net.primary.id)).toBe(true);
+
+    const crash = buildErrorDeck("AGENT_CRASHED", "en");
+    expect(crash.problem.toLowerCase()).toMatch(/agent|crash|process/);
+    expect(crash.primary.id).toBe("reconnect");
+  });
+
+  it("returns Chinese copy for zh", () => {
+    const cli = buildErrorDeck("CLI_NOT_FOUND", "zh");
+    expect(cli.problem).toMatch(/CLI|命令行|未找到/);
+    expect(cli.cause).toMatch(/安装|路径|Doctor|设置/);
+    expect(cli.primary.label.length).toBeGreaterThan(1);
+  });
+
+  it("maps timeout / disconnect specials", () => {
+    expect(deckCodeFromAgent("NETWORK_PROVIDER", { timeout: true })).toBe(
+      "TURN_TIMEOUT",
+    );
+    expect(deckCodeFromAgent(null, { disconnected: true })).toBe(
+      "AGENT_DISCONNECTED",
+    );
+    expect(deckCodeFromAgent("AUTH_FAILED")).toBe("AUTH_FAILED");
+  });
+});

--- a/src/lib/errorDeck.ts
+++ b/src/lib/errorDeck.ts
@@ -1,0 +1,183 @@
+/**
+ * T04 error deck — structured copy for the four product error classes
+ * (plus a few host-side codes): problem / cause / primary / secondary.
+ *
+ * Labels come from i18n; action ids are stable for App handlers.
+ */
+
+import { createT, type Locale, type MessageKey } from "@/i18n";
+
+/** What the banner / toast buttons should do. */
+export type ErrorDeckActionId =
+  | "reconnect"
+  | "open_doctor"
+  | "open_runtime"
+  | "open_account"
+  | "open_providers"
+  | "dismiss";
+
+/** Host / product error classes (aligned with AgentErrorCode + specials). */
+export type ErrorDeckCode =
+  | "CLI_NOT_FOUND"
+  | "AUTH_FAILED"
+  | "NETWORK_PROVIDER"
+  | "AGENT_CRASHED"
+  | "QUOTA_EXCEEDED"
+  | "CONNECT_FAILED"
+  | "PROCESS_LIMIT"
+  | "TURN_TIMEOUT"
+  | "AGENT_DISCONNECTED"
+  | "GENERIC";
+
+export type ErrorDeckAction = {
+  id: ErrorDeckActionId;
+  label: string;
+};
+
+export type ErrorDeckCard = {
+  code: ErrorDeckCode;
+  /** Short headline (what went wrong). */
+  problem: string;
+  /** One-line likely cause / context. */
+  cause: string;
+  primary: ErrorDeckAction;
+  secondary: ErrorDeckAction | null;
+};
+
+type DeckSpec = {
+  problem: MessageKey;
+  cause: MessageKey;
+  primaryId: ErrorDeckActionId;
+  primaryLabel: MessageKey;
+  secondaryId?: ErrorDeckActionId;
+  secondaryLabel?: MessageKey;
+};
+
+const DECK: Record<ErrorDeckCode, DeckSpec> = {
+  CLI_NOT_FOUND: {
+    problem: "error.deck.cli.problem",
+    cause: "error.deck.cli.cause",
+    primaryId: "open_doctor",
+    primaryLabel: "error.action.openDoctor",
+    secondaryId: "open_runtime",
+    secondaryLabel: "error.action.setCliPath",
+  },
+  AUTH_FAILED: {
+    problem: "error.deck.auth.problem",
+    cause: "error.deck.auth.cause",
+    primaryId: "open_account",
+    primaryLabel: "error.action.openAccount",
+    secondaryId: "open_providers",
+    secondaryLabel: "error.action.openProviders",
+  },
+  NETWORK_PROVIDER: {
+    problem: "error.deck.network.problem",
+    cause: "error.deck.network.cause",
+    primaryId: "reconnect",
+    primaryLabel: "error.action.reconnect",
+    secondaryId: "open_providers",
+    secondaryLabel: "error.action.openProviders",
+  },
+  AGENT_CRASHED: {
+    problem: "error.deck.crash.problem",
+    cause: "error.deck.crash.cause",
+    primaryId: "reconnect",
+    primaryLabel: "error.action.reconnect",
+    secondaryId: "open_doctor",
+    secondaryLabel: "error.action.openDoctor",
+  },
+  QUOTA_EXCEEDED: {
+    problem: "error.deck.quota.problem",
+    cause: "error.deck.quota.cause",
+    primaryId: "open_account",
+    primaryLabel: "error.action.openAccount",
+    secondaryId: "dismiss",
+    secondaryLabel: "error.action.dismiss",
+  },
+  CONNECT_FAILED: {
+    problem: "error.deck.connect.problem",
+    cause: "error.deck.connect.cause",
+    primaryId: "reconnect",
+    primaryLabel: "error.action.reconnect",
+    secondaryId: "open_doctor",
+    secondaryLabel: "error.action.openDoctor",
+  },
+  PROCESS_LIMIT: {
+    problem: "error.deck.limit.problem",
+    cause: "error.deck.limit.cause",
+    primaryId: "open_runtime",
+    primaryLabel: "error.action.openRuntime",
+    secondaryId: "dismiss",
+    secondaryLabel: "error.action.dismiss",
+  },
+  TURN_TIMEOUT: {
+    problem: "error.deck.timeout.problem",
+    cause: "error.deck.timeout.cause",
+    primaryId: "reconnect",
+    primaryLabel: "error.action.retry",
+    secondaryId: "dismiss",
+    secondaryLabel: "error.action.dismiss",
+  },
+  AGENT_DISCONNECTED: {
+    problem: "error.deck.disconnect.problem",
+    cause: "error.deck.disconnect.cause",
+    primaryId: "reconnect",
+    primaryLabel: "error.action.reconnect",
+    secondaryId: "open_doctor",
+    secondaryLabel: "error.action.openDoctor",
+  },
+  GENERIC: {
+    problem: "error.deck.generic.problem",
+    cause: "error.deck.generic.cause",
+    primaryId: "dismiss",
+    primaryLabel: "error.action.dismiss",
+    secondaryId: "open_doctor",
+    secondaryLabel: "error.action.openDoctor",
+  },
+};
+
+export function buildErrorDeck(
+  code: ErrorDeckCode,
+  locale: Locale = "zh",
+): ErrorDeckCard {
+  const t = createT(locale);
+  const spec = DECK[code] ?? DECK.GENERIC;
+  return {
+    code,
+    problem: t(spec.problem),
+    cause: t(spec.cause),
+    primary: { id: spec.primaryId, label: t(spec.primaryLabel) },
+    secondary:
+      spec.secondaryId && spec.secondaryLabel
+        ? { id: spec.secondaryId, label: t(spec.secondaryLabel) }
+        : null,
+  };
+}
+
+const AGENT_DECK_CODES: ErrorDeckCode[] = [
+  "CLI_NOT_FOUND",
+  "AUTH_FAILED",
+  "NETWORK_PROVIDER",
+  "AGENT_CRASHED",
+  "QUOTA_EXCEEDED",
+  "CONNECT_FAILED",
+  "PROCESS_LIMIT",
+];
+
+/** Map a classified agent code (or special timeout/disconnect) to a deck code. */
+export function deckCodeFromAgent(
+  code: string | null | undefined,
+  opts?: { timeout?: boolean; disconnected?: boolean },
+): ErrorDeckCode {
+  if (opts?.timeout) return "TURN_TIMEOUT";
+  if (opts?.disconnected) return "AGENT_DISCONNECTED";
+  if (code && (AGENT_DECK_CODES as string[]).includes(code)) {
+    return code as ErrorDeckCode;
+  }
+  return "GENERIC";
+}
+
+/** Whether the primary/secondary action should re-open the agent. */
+export function isReconnectAction(id: ErrorDeckActionId): boolean {
+  return id === "reconnect";
+}

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -380,7 +380,7 @@ describe("session projection", () => {
     ).toMatch(/quota|rate/i);
   });
 
-  it("presentErrorBanner shows friendly copy without MCP dumps", () => {
+  it("presentErrorBanner shows friendly deck without MCP dumps", () => {
     const raw =
       'rpc timeout on session/prompt (id=4) after 600s; stderr: ...\nERROR worker quit with fatal: Connection refused';
     const fromAgent = presentErrorBanner(
@@ -388,10 +388,12 @@ describe("session projection", () => {
       null,
       "zh",
     );
-    expect(fromAgent?.summary).toMatch(/超时|中止/);
+    expect(fromAgent?.summary).toMatch(/超时|网络|模型/);
+    expect(fromAgent?.cause).toBeTruthy();
     expect(fromAgent?.summary).not.toMatch(/Connection refused/);
     expect(fromAgent?.summary).not.toMatch(/stderr/i);
     expect(fromAgent?.detail).toBeNull();
+    expect(fromAgent?.primary?.id).toBeTruthy();
     expect(fromAgent?.reconnectHint).toBe(true);
 
     const fromLocal = presentErrorBanner(
@@ -400,12 +402,38 @@ describe("session projection", () => {
       "zh",
     );
     expect(fromLocal?.code).toBe("NETWORK_PROVIDER");
-    expect(fromLocal?.summary).toMatch(/超时|中止/);
+    expect(fromLocal?.summary).toMatch(/超时|网络|模型/);
     expect(fromLocal?.detail).toBeNull();
+    expect(fromLocal?.primary?.label.length).toBeGreaterThan(0);
 
     const short = presentErrorBanner(null, "请先选择项目", "zh");
     expect(short?.summary).toBe("请先选择项目");
     expect(short?.detail).toBeNull();
+    expect(short?.primary?.id).toBe("dismiss");
+  });
+
+  it("presentErrorBanner decks the four product classes", () => {
+    const cli = presentErrorBanner(
+      { code: "CLI_NOT_FOUND", message: "missing" },
+      null,
+      "en",
+    );
+    expect(cli?.primary?.id).toBe("open_doctor");
+    expect(cli?.secondary?.id).toBe("open_runtime");
+
+    const auth = presentErrorBanner(
+      { code: "AUTH_FAILED", message: "401" },
+      null,
+      "en",
+    );
+    expect(auth?.primary?.id).toBe("open_account");
+
+    const crash = presentErrorBanner(
+      { code: "AGENT_CRASHED", message: "exit 1" },
+      null,
+      "en",
+    );
+    expect(crash?.primary?.id).toBe("reconnect");
   });
 
   it("formatTurnErrorBody maps turn_timeout tag", () => {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,4 +1,6 @@
 import type { Locale } from "../i18n";
+import { buildErrorDeck, deckCodeFromAgent } from "./errorDeck";
+import type { ErrorDeckAction, ErrorDeckCard } from "./errorDeck";
 
 export type SessionState =
   | "idle"
@@ -1177,47 +1179,19 @@ export function isAgentErrorCode(code: string | undefined | null): code is Agent
 }
 
 export function errorCopy(code: AgentErrorCode, locale: Locale = "zh"): string {
-  const zh: Record<AgentErrorCode, string> = {
-    CLI_NOT_FOUND: "未找到 Grok Build CLI。请安装或在设置中指定路径。",
-    AUTH_FAILED: "鉴权失败。请重新登录、更换 Key，或改用设置里的自定义中转。",
-    NETWORK_PROVIDER:
-      "网络或模型服务异常。请检查网络、额度，或切换模型/渠道后重试。",
-    AGENT_CRASHED: "Agent 进程异常退出。可尝试重新连接。",
-    QUOTA_EXCEEDED:
-      "额度不足或订阅已限流。请到 Grok 账户查看用量，或切换模型/等待重置。",
-    CONNECT_FAILED:
-      "无法连接本会话的 Agent。请点重新连接；确认 CLI 已登录或中转配置正确。",
-    PROCESS_LIMIT:
-      "已达到 Agent 进程上限。请先停止或等待其他会话，或在设置 → 运行环境中提高并发上限。",
-  };
-  const en: Record<AgentErrorCode, string> = {
-    CLI_NOT_FOUND: "Grok Build CLI not found. Install or set path in Settings.",
-    AUTH_FAILED:
-      "Authentication failed. Re-login, change key, or use a custom provider in Settings.",
-    NETWORK_PROVIDER:
-      "Network or model provider error. Check connection, quota, or switch model/provider, then retry.",
-    AGENT_CRASHED: "Agent process crashed. Try reconnect.",
-    QUOTA_EXCEEDED:
-      "Quota exceeded or rate-limited. Check Grok usage, switch model, or wait for reset.",
-    CONNECT_FAILED:
-      "Could not connect the agent for this session. Reconnect; confirm CLI login or custom provider.",
-    PROCESS_LIMIT:
-      "Agent process limit reached. Stop or wait for another session, or raise the limit in Settings → Runtime.",
-  };
-  return (locale === "en" ? en : zh)[code];
+  const card = buildErrorDeck(code, locale);
+  return `${card.problem} ${card.cause}`.trim();
 }
 
 /** Turn took too long (Host session/prompt timeout) — more specific than generic network. */
 export function turnTimeoutCopy(locale: Locale = "zh"): string {
-  return locale === "en"
-    ? "This turn timed out and was stopped. You can retry — long tasks (e.g. image generation) may need more time."
-    : "本轮执行超时已中止。可重试；生图等长任务可能需要更久。";
+  const card = buildErrorDeck("TURN_TIMEOUT", locale);
+  return `${card.problem} ${card.cause}`.trim();
 }
 
 export function agentDisconnectedCopy(locale: Locale = "zh"): string {
-  return locale === "en"
-    ? "The agent connection was interrupted. Try reconnecting and send again."
-    : "与 Agent 的连接已中断。请重新连接后再试。";
+  const card = buildErrorDeck("AGENT_DISCONNECTED", locale);
+  return `${card.problem} ${card.cause}`.trim();
 }
 
 const AGENT_ERROR_CODE_RE =
@@ -1321,31 +1295,61 @@ export function formatTurnErrorBody(
   return first.length > 200 ? `${first.slice(0, 200)}…` : first;
 }
 
+export type ErrorBannerView = {
+  code: string | null;
+  /** Headline (deck problem). */
+  summary: string;
+  /** Supporting line (deck cause). */
+  cause: string | null;
+  detail: string | null;
+  reconnectHint: boolean;
+  primary: ErrorDeckAction | null;
+  secondary: ErrorDeckAction | null;
+  deck: ErrorDeckCard | null;
+};
+
+function bannerFromDeck(
+  deck: ErrorDeckCard,
+  code: string | null,
+  detail: string | null,
+): ErrorBannerView {
+  return {
+    code,
+    summary: deck.problem,
+    cause: deck.cause,
+    detail,
+    reconnectHint:
+      deck.primary.id === "reconnect" || deck.secondary?.id === "reconnect",
+    primary: deck.primary,
+    secondary: deck.secondary,
+    deck,
+  };
+}
+
 /**
- * Compact banner copy: short user-facing summary by default;
- * technical detail only when short and non-noisy (no MCP stderr walls).
+ * Compact banner: T04 deck (problem / cause / primary / secondary).
+ * Technical detail only when short and non-noisy (no MCP stderr walls).
  */
 export function presentErrorBanner(
   error: AgentError | null,
   localError: string | null,
   locale: Locale = "zh",
-): {
-  code: string | null;
-  summary: string;
-  detail: string | null;
-  reconnectHint: boolean;
-} | null {
+): ErrorBannerView | null {
   if (error) {
-    const summary = formatTurnErrorBody(
+    const body = formatTurnErrorBody(
       { code: error.code, message: error.message, content: undefined },
       locale,
     );
-    return {
-      code: error.code,
-      summary,
-      detail: null,
-      reconnectHint: true,
-    };
+    const lower = `${error.message}\n${body}`.toLowerCase();
+    const timeout =
+      error.message === "turn_timeout" ||
+      /timeout|超时/.test(lower);
+    const disconnected =
+      error.message === "agent_disconnected" ||
+      /disconnect|中断|rpc channel closed/i.test(lower);
+    const deckCode = deckCodeFromAgent(error.code, { timeout, disconnected });
+    const deck = buildErrorDeck(deckCode, locale);
+    return bannerFromDeck(deck, error.code, null);
   }
   if (!localError?.trim()) return null;
 
@@ -1353,15 +1357,16 @@ export function presentErrorBanner(
   const coded = cleaned.match(AGENT_ERROR_CODE_RE);
   if (coded) {
     const code = coded[1] as AgentErrorCode;
-    return {
-      code,
-      summary: formatTurnErrorBody(
-        { code, message: coded[2] || "", content: undefined },
-        locale,
-      ),
-      detail: null,
-      reconnectHint: true,
-    };
+    const rest = stripErrorNoise(coded[2] || "");
+    const lower = rest.toLowerCase();
+    const timeout = rest === "turn_timeout" || /timeout|超时/.test(lower);
+    const disconnected =
+      rest === "agent_disconnected" || /disconnect|中断/i.test(lower);
+    const deck = buildErrorDeck(
+      deckCodeFromAgent(code, { timeout, disconnected }),
+      locale,
+    );
+    return bannerFromDeck(deck, code, null);
   }
 
   const summary = formatTurnErrorBody(
@@ -1369,10 +1374,26 @@ export function presentErrorBanner(
     locale,
   );
   const isTimeoutish = /timeout|超时|中断|disconnect/i.test(summary);
+  if (isTimeoutish) {
+    const deck = buildErrorDeck(
+      /disconnect|中断/i.test(summary)
+        ? "AGENT_DISCONNECTED"
+        : "TURN_TIMEOUT",
+      locale,
+    );
+    return bannerFromDeck(deck, null, null);
+  }
+
+  // Local UX strings (e.g. "select a project") — show as-is, soft dismiss.
+  const deck = buildErrorDeck("GENERIC", locale);
   return {
     code: null,
-    summary,
+    summary: cleaned.length > 200 ? `${cleaned.slice(0, 200)}…` : cleaned,
+    cause: null,
     detail: null,
-    reconnectHint: isTimeoutish || /AGENT_CRASHED|NETWORK_PROVIDER/i.test(cleaned),
+    reconnectHint: false,
+    primary: { id: "dismiss", label: deck.primary.label },
+    secondary: null,
+    deck: null,
   };
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5150,6 +5150,14 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
 
 .error-banner__summary {
   color: var(--text-primary);
+  font-weight: 600;
+}
+
+.error-banner__cause {
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  line-height: 1.45;
 }
 
 .error-banner__actions {
@@ -5158,6 +5166,16 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   align-items: center;
   gap: 8px;
   margin-top: 8px;
+}
+
+.error-banner__primary {
+  height: 28px;
+  font-size: 12px;
+}
+
+.error-banner__secondary {
+  height: 28px;
+  font-size: 12px;
 }
 
 .error-banner__details-btn {


### PR DESCRIPTION
Errors were one short line and often only “Reconnect”. Product deck (T04) wants four classes with problem / cause / primary / secondary.

- CLI not found → Open Doctor / Set CLI path  
- Auth failed → Account & keys / Providers  
- Network or provider → Reconnect / Providers  
- Agent crashed → Reconnect / Doctor  
- Plus quota, connect, process limit, timeout, disconnect  

Banner shows code chip, problem, cause, and the two actions. Copy is i18n en + zh + zh-TW. Unit tests for deck mapping and banner wiring.

### Test plan
- [x] `pnpm typecheck && pnpm test`
- [ ] Point manual CLI path to missing binary → CLI deck + Doctor / Runtime
- [ ] Bad key / logout → auth deck → Account
- [ ] Kill agent mid-turn → crash or disconnect deck → Reconnect
- [ ] Local “select a project” still plain text + Dismiss