### PR TITLE
fix: do not end turns while tools or permission are still open

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod process_util;
 mod process_limits;
 mod journal_throttle;
 mod stream_stall;
+mod turn_complete;
 mod permission;
 mod providers;
 mod secrets;

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -9,7 +9,7 @@
 //! - Mid-stream journal upserts are throttled (≥500ms or paragraph / force).
 //! - Pure stream silence past `streamStallSeconds` emits `session://stream_stall`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -39,6 +39,7 @@ use crate::store::{self, ChatMessageStored, MessageAttachmentStored, SessionMeta
 use crate::stream_stall::{
     normalize_stream_stall_seconds, should_emit_stall, stream_stall_message,
 };
+use crate::turn_complete::{is_terminal_tool_status, should_defer_prompt_complete};
 
 /// Strip bulky MCP/RPC dumps so chat errors stay human-readable.
 /// Full stderr is still logged via `tracing` on the ACP client side.
@@ -186,6 +187,10 @@ struct LiveSession {
     last_stall_emit: Option<Instant>,
     /// Throttle mid-stream assistant journal upserts (I04).
     journal_throttle: JournalWriteThrottle,
+    /// Tool calls still pending/in_progress this turn (#52 early prompt_complete).
+    open_tool_ids: HashSet<String>,
+    /// `prompt_complete` arrived while tools/gates still open; finish when clear.
+    deferred_prompt_complete: Option<String>,
 }
 
 /// Ready agent process parked while another App session is focused (I01/I02).
@@ -538,6 +543,43 @@ impl SessionManager {
     }
 
     /// Stream chunk or tool activity — advances stall deadline (I06).
+    /// Finish turn when a deferred `prompt_complete` is safe (#52).
+    /// Returns true if the FSM left Streaming / busy states.
+    fn try_finish_deferred_prompt_complete(s: &mut LiveSession) -> bool {
+        let Some(stop_reason) = s.deferred_prompt_complete.clone() else {
+            return false;
+        };
+        let awaiting_perm = s.fsm.state() == SessionState::AwaitingPermission;
+        if should_defer_prompt_complete(
+            awaiting_perm,
+            s.pending_plan_rpc_id.is_some(),
+            s.pending_ask_user_rpc_id.is_some(),
+            s.open_tool_ids.len(),
+        ) {
+            return false;
+        }
+        s.deferred_prompt_complete = None;
+        // Force-flush assistant turn (I04 end-of-turn path).
+        Self::maybe_flush_stream_journal(s, true, false);
+        s.stream_buf.clear();
+        s.stream_thought.clear();
+        s.stream_last_was_assistant = false;
+        s.stream_attachments.clear();
+        s.journal_throttle.reset();
+        s.open_tool_ids.clear();
+        if s.fsm.state() == SessionState::Streaming
+            || s.fsm.state() == SessionState::AwaitingPermission
+        {
+            let _ = s.fsm.end_stream();
+        }
+        s.streaming_message_id = None;
+        s.last_stall_emit = None;
+        tracing::info!(
+            "acp turn finished after deferred prompt_complete stop={stop_reason}"
+        );
+        true
+    }
+
     fn touch_stream_progress_locked(s: &mut LiveSession) {
         let now = Instant::now();
         s.last_activity = now;
@@ -790,6 +832,8 @@ impl SessionManager {
             last_stream_progress: now,
             last_stall_emit: None,
             journal_throttle: JournalWriteThrottle::with_default_interval(),
+            open_tool_ids: HashSet::new(),
+            deferred_prompt_complete: None,
         })
     }
 
@@ -1206,6 +1250,8 @@ impl SessionManager {
                 last_stream_progress: now,
                 last_stall_emit: None,
                 journal_throttle: JournalWriteThrottle::with_default_interval(),
+                open_tool_ids: HashSet::new(),
+                deferred_prompt_complete: None,
             });
         }
         Self::emit_state(&app, &self.snapshot());
@@ -1577,25 +1623,23 @@ impl SessionManager {
                 });
                 let _ = app.emit("session://stream", payload);
             }
-            AcpEvent::PromptComplete { stop_reason: _ } => {
+            AcpEvent::PromptComplete { stop_reason } => {
                 {
                     let mut guard = self.inner.lock();
                     if let Some(s) = guard.as_mut() {
                         Self::touch_stream_progress_locked(s);
-                        // Force-flush assistant turn (I04 end-of-turn path).
-                        Self::maybe_flush_stream_journal(s, true, false);
-                        s.stream_buf.clear();
-                        s.stream_thought.clear();
-                        s.stream_last_was_assistant = false;
-                        s.stream_attachments.clear();
-                        s.journal_throttle.reset();
-                        if s.fsm.state() == SessionState::Streaming
-                            || s.fsm.state() == SessionState::AwaitingPermission
-                        {
-                            let _ = s.fsm.end_stream();
+                        s.deferred_prompt_complete = Some(stop_reason.clone());
+                        // #52: do not Ready the UI while tools / permission / ask_user / plan
+                        // are still open — agent often fires prompt_complete early.
+                        if !Self::try_finish_deferred_prompt_complete(s) {
+                            tracing::info!(
+                                "acp prompt_complete deferred stop={stop_reason} tools={} perm={} plan={} ask={}",
+                                s.open_tool_ids.len(),
+                                s.fsm.state() == SessionState::AwaitingPermission,
+                                s.pending_plan_rpc_id.is_some(),
+                                s.pending_ask_user_rpc_id.is_some(),
+                            );
                         }
-                        s.streaming_message_id = None;
-                        s.last_stall_emit = None;
                     }
                 }
                 Self::emit_state(app, &self.snapshot());
@@ -1672,6 +1716,7 @@ impl SessionManager {
                             if s.fsm.state() == SessionState::AwaitingPermission {
                                 let _ = s.fsm.permission_resolved_continue();
                             }
+                            let _ = Self::try_finish_deferred_prompt_complete(s);
                         }
                     }
                 } else if auto_deny {
@@ -1693,6 +1738,7 @@ impl SessionManager {
                             if s.fsm.state() == SessionState::AwaitingPermission {
                                 let _ = s.fsm.permission_resolved_continue();
                             }
+                            let _ = Self::try_finish_deferred_prompt_complete(s);
                         }
                     }
                 } else {
@@ -1766,6 +1812,15 @@ impl SessionManager {
                     if let Some(s) = guard.as_mut() {
                         // Tool events count as progress so long tools never false-stall (I06).
                         Self::touch_stream_progress_locked(s);
+                        if !tool_call_id.is_empty() {
+                            if is_terminal_tool_status(&status) {
+                                s.open_tool_ids.remove(&tool_call_id);
+                            } else {
+                                s.open_tool_ids.insert(tool_call_id.clone());
+                            }
+                        }
+                        // Tools settled → apply deferred prompt_complete if any (#52).
+                        let _ = Self::try_finish_deferred_prompt_complete(s);
                         s.app_session_id.clone()
                     } else {
                         String::new()
@@ -2423,6 +2478,8 @@ impl SessionManager {
             s.stream_attachments.clear();
             s.journal_throttle.reset();
             s.last_stall_emit = None;
+            s.open_tool_ids.clear();
+            s.deferred_prompt_complete = None;
             s.provider_retry_attempt = 0;
             s.provider_retry_aborted = false;
 
@@ -2807,6 +2864,8 @@ impl SessionManager {
             if s.fsm.state() == SessionState::AwaitingPermission {
                 let _ = s.fsm.permission_resolved_continue();
             }
+            // Permission cleared — may finish a deferred prompt_complete (#52).
+            let _ = Self::try_finish_deferred_prompt_complete(s);
             s.acp.clone()
         };
 
@@ -2851,6 +2910,12 @@ impl SessionManager {
         let id = id.ok_or_else(|| "no pending plan approval".to_string())?;
         let acp = acp.ok_or_else(|| "ACP client missing".to_string())?;
         acp.respond_exit_plan_mode(id, &decision, feedback).await?;
+        {
+            let mut guard = self.inner.lock();
+            if let Some(s) = guard.as_mut() {
+                let _ = Self::try_finish_deferred_prompt_complete(s);
+            }
+        }
         let snap = self.snapshot();
         Self::emit_state(&app, &snap);
         Ok(snap)
@@ -2887,6 +2952,12 @@ impl SessionManager {
             _ => AskUserOutcome::Cancelled,
         };
         acp.respond_ask_user_question(id, outcome).await?;
+        {
+            let mut guard = self.inner.lock();
+            if let Some(s) = guard.as_mut() {
+                let _ = Self::try_finish_deferred_prompt_complete(s);
+            }
+        }
         let snap = self.snapshot();
         Self::emit_state(&app, &snap);
         Ok(snap)

--- a/src-tauri/src/turn_complete.rs
+++ b/src-tauri/src/turn_complete.rs
@@ -1,0 +1,53 @@
+//! When to finish a turn after `_x.ai/session/prompt_complete` (issue #52).
+//!
+//! Agents sometimes emit prompt_complete while tools are still running, or while
+//! the host is waiting on permission / ask_user / plan review. Ending the UI
+//! turn early makes long tasks look "interrupted" even though the agent is busy.
+
+/// Terminal tool statuses — not counted as in-flight.
+pub fn is_terminal_tool_status(status: &str) -> bool {
+    let s = if status.is_empty() {
+        "in_progress"
+    } else {
+        status
+    };
+    let lower = s.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "completed" | "complete" | "failed" | "error" | "cancelled" | "canceled" | "rejected"
+    )
+}
+
+/// Whether PromptComplete should wait before calling `end_stream`.
+pub fn should_defer_prompt_complete(
+    awaiting_permission: bool,
+    pending_plan: bool,
+    pending_ask_user: bool,
+    open_tool_count: usize,
+) -> bool {
+    awaiting_permission || pending_plan || pending_ask_user || open_tool_count > 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_statuses() {
+        assert!(is_terminal_tool_status("completed"));
+        assert!(is_terminal_tool_status("FAILED"));
+        assert!(is_terminal_tool_status("cancelled"));
+        assert!(!is_terminal_tool_status("in_progress"));
+        assert!(!is_terminal_tool_status(""));
+        assert!(!is_terminal_tool_status("pending"));
+    }
+
+    #[test]
+    fn defer_while_tools_or_gates() {
+        assert!(!should_defer_prompt_complete(false, false, false, 0));
+        assert!(should_defer_prompt_complete(true, false, false, 0));
+        assert!(should_defer_prompt_complete(false, true, false, 0));
+        assert!(should_defer_prompt_complete(false, false, true, 0));
+        assert!(should_defer_prompt_complete(false, false, false, 2));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3204,6 +3204,15 @@ export default function App() {
       showToast(tr("composer.queueBlockedPermission"), 2800);
       return;
     }
+    // #52: orphan chats without a folder often stop after planning text —
+    // tools can't land in a workspace until a project is bound.
+    if (
+      !activeProject &&
+      (mode === "agent" || goalMode) &&
+      !shouldEnqueueSend(session.state, connecting)
+    ) {
+      showToast(tr("composer.noProjectWriteHint"), 4500);
+    }
     sendQueue.releaseFlushHold();
 
     if (shouldEnqueueSend(session.state, connecting)) {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -330,6 +330,8 @@ const en = {
   "composer.queueFilesCount": "{n} files",
   "composer.stop": "Stop",
   "composer.noProject": "No project",
+  "composer.noProjectWriteHint":
+    "No project selected — pick a folder first so the agent can create/edit files in a workspace.",
   "composer.pickProject": "Project folder",
   "composer.addProject": "Add project",
   "composer.worktrees": "Git worktrees",
@@ -1414,6 +1416,8 @@ const zh: Record<MessageKey, string> = {
   "composer.queueFilesCount": "{n} 个文件",
   "composer.stop": "停止",
   "composer.noProject": "未选项目",
+  "composer.noProjectWriteHint":
+    "尚未选择项目 — 请先绑定文件夹，Agent 才能在工作区里创建/修改文件。",
   "composer.pickProject": "项目目录",
   "composer.addProject": "添加项目",
   "composer.worktrees": "Git worktrees",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -318,6 +318,8 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.queueFilesCount": "{n} 個檔案",
   "composer.stop": "停止",
   "composer.noProject": "未選專案",
+  "composer.noProjectWriteHint":
+    "尚未選擇專案 — 請先綁定資料夾，Agent 才能在工作區建立/修改檔案。",
   "composer.pickProject": "專案目錄",
   "composer.clearProject": "無專案（其他對話）",
   "composer.projectUntrusted": "尚未信任",


### PR DESCRIPTION
Fixes #52

## What we saw
Screenshot: long build request (pixel Gold Miner), assistant only thinks + announces it will create files, UI goes **就绪**, composer shows **未选项目**. Not a 600s timeout — turn ends almost immediately after planning text.

## Causes addressed
1. Host finished the turn on `_x.ai/session/prompt_complete` even if tools were still running, or while waiting for permission / plan / ask_user — so the workbench looked done while work was incomplete.
2. Sending agent work with **no project** makes file tools fail-closed / awkward; users often get a plan-only reply. Soft toast points them to pick a folder first.

## Changes
- Defer `end_stream` after `prompt_complete` until `open_tool_ids` empty and not in permission/plan/ask gate
- Track in-flight tool call ids from tool status updates
- Apply deferred finish when tools settle or permission/plan/ask resolves
- Agent send without project → toast (`composer.noProjectWriteHint`)
- Unit tests in `turn_complete.rs`

### Test plan
- [x] `pnpm typecheck && pnpm test`
- [x] `cd src-tauri && cargo test turn_complete`
- [ ] Multi-step tool turn: UI stays busy until last tool completes
- [ ] Permission prompt: do not flip to 就绪 until answered
- [ ] Send with 未选项目 in agent mode → toast about picking a folder