### PR TITLE
fix: lock store JSON writes against concurrent corruption

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1268,6 +1268,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,12 +1617,13 @@ dependencies = [
 
 [[package]]
 name = "grok-app"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arboard",
  "base64 0.22.1",
  "chrono",
  "directories",
+ "fs2",
  "futures-util",
  "hex",
  "image",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,7 @@ keyring = { version = "3.6", features = [
 ] }
 arboard = "3"
 image = { version = "0.25", default-features = false, features = ["png"] }
+fs2 = "0.4"
 
 [profile.release]
 codegen-units = 1

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod process_util;
 mod process_limits;
 mod journal_throttle;
 mod stream_stall;
+mod store_lock;
 mod permission;
 mod providers;
 mod secrets;

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -269,12 +269,32 @@ fn read_json<T: for<'de> Deserialize<'de> + Default>(path: &PathBuf) -> T {
     }
 }
 
-fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+/// Read JSON; if the file exists but is corrupt, quarantine it and return default.
+fn read_json_recover<T: for<'de> Deserialize<'de> + Default>(path: &PathBuf) -> T {
+    match fs::read_to_string(path) {
+        Ok(s) if s.trim().is_empty() => T::default(),
+        Ok(s) => match serde_json::from_str(&s) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!(
+                    "corrupt store file {} ({e}); quarantining and starting empty",
+                    path.display()
+                );
+                let stamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+                let bak = path.with_extension(format!("corrupt-{stamp}.json"));
+                let _ = fs::rename(path, &bak);
+                T::default()
+            }
+        },
+        Err(_) => T::default(),
     }
+}
+
+fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<(), String> {
     let s = serde_json::to_string_pretty(value).map_err(|e| e.to_string())?;
-    fs::write(path, s).map_err(|e| e.to_string())
+    // Exclusive lock + temp rename so shared-mode / dual-instance writes do not
+    // leave a half-written index (E06).
+    crate::store_lock::write_bytes_atomic(path, s.as_bytes())
 }
 
 pub fn load_settings() -> AppSettings {
@@ -299,7 +319,7 @@ pub fn save_settings(s: &AppSettings) -> Result<(), String> {
 
 pub fn load_projects() -> Vec<Project> {
     let _ = ensure_app_dirs();
-    let mut list: Vec<Project> = read_json(&projects_file());
+    let mut list: Vec<Project> = read_json_recover(&projects_file());
     for p in &mut list {
         p.path_ok = PathBuf::from(&p.path).is_dir();
     }
@@ -442,7 +462,8 @@ pub fn set_project_permission_policy(
 
 pub fn load_sessions_index() -> Vec<SessionMeta> {
     let _ = ensure_app_dirs();
-    let mut list: Vec<SessionMeta> = read_json(&sessions_index_file());
+    // Recover from torn/corrupt index (shared CLI+App or crash mid-write).
+    let mut list: Vec<SessionMeta> = read_json_recover(&sessions_index_file());
     list.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     list
 }
@@ -587,7 +608,7 @@ pub fn archive_project_sessions(project_id: &str) -> Result<usize, String> {
 }
 
 pub fn load_messages(session_id: &str) -> Vec<ChatMessageStored> {
-    read_json(&session_dir(session_id).join("messages.json"))
+    read_json_recover(&session_dir(session_id).join("messages.json"))
 }
 
 pub fn save_messages(session_id: &str, messages: &[ChatMessageStored]) -> Result<(), String> {

--- a/src-tauri/src/store_lock.rs
+++ b/src-tauri/src/store_lock.rs
@@ -1,0 +1,179 @@
+//! Advisory file locks for App JSON store (E06 shared / multi-instance).
+//!
+//! CLI and a second App window may touch the same data root in `shared` mode.
+//! We take an exclusive lock around read-modify-write of index files so the
+//! index is not half-written, and use temp+rename for atomic replace.
+
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+
+/// How long to wait for a lock before failing with a clear error.
+const LOCK_WAIT: Duration = Duration::from_secs(3);
+const LOCK_POLL: Duration = Duration::from_millis(40);
+
+/// Sidecar lock path for `foo.json` → `foo.json.lock`.
+pub fn lock_path_for(target: &Path) -> PathBuf {
+    let mut s = target.as_os_str().to_os_string();
+    s.push(".lock");
+    PathBuf::from(s)
+}
+
+/// Holds an exclusive lock until dropped.
+pub struct ExclusiveLock {
+    _file: File,
+    path: PathBuf,
+}
+
+impl Drop for ExclusiveLock {
+    fn drop(&mut self) {
+        // Best-effort unlock; File drop also releases the lock on most OSes.
+        let _ = self._file.unlock();
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Acquire exclusive lock for `target` (creates `target.lock`).
+pub fn lock_exclusive(target: &Path) -> Result<ExclusiveLock, String> {
+    let path = lock_path_for(target);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("lock dir: {e}"))?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|e| format!("open lock {}: {e}", path.display()))?;
+
+    let deadline = Instant::now() + LOCK_WAIT;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => {
+                return Ok(ExclusiveLock {
+                    _file: file,
+                    path,
+                });
+            }
+            Err(_) if Instant::now() < deadline => {
+                thread::sleep(LOCK_POLL);
+            }
+            Err(e) => {
+                return Err(format!(
+                    "LOCK_BUSY: could not lock {} within {}ms ({e})",
+                    path.display(),
+                    LOCK_WAIT.as_millis()
+                ));
+            }
+        }
+    }
+}
+
+/// Run `body` while holding an exclusive lock on `target`.
+pub fn with_exclusive_lock<T>(
+    target: &Path,
+    body: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    let _lock = lock_exclusive(target)?;
+    body()
+}
+
+/// Write bytes to `path` via temp file + rename under exclusive lock.
+pub fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    with_exclusive_lock(path, || {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let tmp = {
+            let mut p = path.as_os_str().to_os_string();
+            p.push(".tmp");
+            PathBuf::from(p)
+        };
+        fs::write(&tmp, bytes).map_err(|e| format!("write temp: {e}"))?;
+        fs::rename(&tmp, path).map_err(|e| {
+            let _ = fs::remove_file(&tmp);
+            format!("rename into place: {e}")
+        })?;
+        Ok(())
+    })
+}
+
+/// True if error string is a lock contention failure.
+pub fn is_lock_busy(err: &str) -> bool {
+    err.contains("LOCK_BUSY")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    fn tmp_file(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "grok-store-lock-{}-{}-{}",
+            name,
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        p
+    }
+
+    #[test]
+    fn lock_path_suffix() {
+        let p = PathBuf::from("/tmp/sessions_index.json");
+        assert_eq!(
+            lock_path_for(&p),
+            PathBuf::from("/tmp/sessions_index.json.lock")
+        );
+    }
+
+    #[test]
+    fn atomic_write_roundtrip() {
+        let path = tmp_file("atomic.json");
+        write_bytes_atomic(&path, br#"{"ok":true}"#).unwrap();
+        let s = fs::read_to_string(&path).unwrap();
+        assert!(s.contains("ok"));
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(lock_path_for(&path));
+    }
+
+    #[test]
+    fn exclusive_blocks_second_holder() {
+        let path = tmp_file("block.json");
+        let barrier = Arc::new(Barrier::new(2));
+        let path2 = path.clone();
+        let b2 = Arc::clone(&barrier);
+
+        let t = thread::spawn(move || {
+            let _lock = lock_exclusive(&path2).expect("first lock");
+            b2.wait();
+            // Hold long enough for the other thread to time out path.
+            thread::sleep(Duration::from_millis(200));
+        });
+
+        barrier.wait();
+        // Second lock should fail quickly if we shrink wait — use direct try.
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(lock_path_for(&path))
+            .unwrap();
+        let busy = file.try_lock_exclusive().is_err();
+        assert!(busy, "second exclusive lock should be busy");
+        t.join().unwrap();
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(lock_path_for(&path));
+    }
+
+    #[test]
+    fn is_lock_busy_detects_prefix() {
+        assert!(is_lock_busy("LOCK_BUSY: could not lock"));
+        assert!(!is_lock_busy("write temp: disk full"));
+    }
+}


### PR DESCRIPTION
E06-ish: protect on-disk App state when CLI + App (shared) or two windows write at once.

## Changes
- Exclusive lock file next to each JSON target (`foo.json.lock`)
- Atomic write: temp → rename under the lock
- If `sessions_index.json` / `projects.json` / `messages.json` is corrupt, rename to `*.corrupt-*.json` and start empty (log the error) instead of pretending the file was empty forever
- Unit tests for lock + atomic write

Does **not** implement full shared-mode “read CLI session list” (E03). This is the corruption/lock slice.

### Test plan
- [x] `cd src-tauri && cargo test store_lock`
- [ ] Two App instances saving sessions quickly — no torn index
- [ ] Hand-break `sessions_index.json` to invalid JSON → app starts; backup file appears