### PR TITLE
feat: keep busy sessions streaming after switching chats

### DIFF
--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -484,8 +484,11 @@ fn attachment_from_path(path: &str) -> MessageAttachmentStored {
 }
 
 pub struct SessionManager {
-    /// Currently focused live session (UI-bound).
+    /// Currently focused live session (UI-bound for send).
     inner: Mutex<Option<LiveSession>>,
+    /// Busy sessions still receiving ACP events (streaming / permission).
+    /// Keyed by app session id. Enables multi-session parallel streaming.
+    background: Mutex<HashMap<String, LiveSession>>,
     /// Warm Ready agents for other App sessions (keyed by app session id).
     parked: Mutex<HashMap<String, ParkedAgent>>,
     /// Serialize connect / park / unpark so openSession prefetch cannot race first send.
@@ -502,6 +505,7 @@ impl SessionManager {
     pub fn new() -> Self {
         Self {
             inner: Mutex::new(None),
+            background: Mutex::new(HashMap::new()),
             parked: Mutex::new(HashMap::new()),
             connect_lock: tokio::sync::Mutex::new(()),
         }
@@ -640,7 +644,7 @@ impl SessionManager {
         Self::emit_stream_stall(app, &sid, stall_secs);
     }
 
-    /// Live + parked processes that still have a living ACP child.
+    /// Live + background + parked processes that still have a living ACP child.
     fn active_process_count(&self) -> u32 {
         let live = self
             .inner
@@ -649,13 +653,19 @@ impl SessionManager {
             .and_then(|s| s.acp.as_ref())
             .filter(|c| c.is_alive())
             .is_some() as u32;
+        let background = self
+            .background
+            .lock()
+            .values()
+            .filter(|s| s.acp.as_ref().is_some_and(|c| c.is_alive()))
+            .count() as u32;
         let parked = self
             .parked
             .lock()
             .values()
             .filter(|p| p.acp.is_alive())
             .count() as u32;
-        live + parked
+        live + background + parked
     }
 
     fn max_concurrent_from_settings() -> u32 {
@@ -696,9 +706,11 @@ impl SessionManager {
         before.saturating_sub(parked.len())
     }
 
-    /// Park the current live session if it is Ready with a living agent.
-    /// Returns true if parked (or there was nothing to park).
-    /// Returns false if live is busy (streaming / permission / connecting).
+    /// Park or background the current live session so focus can move.
+    ///
+    /// - Ready → warm `parked` (idle process).
+    /// - Streaming / AwaitingPermission → `background` (keeps full LiveSession + event pump).
+    /// - Capacity exceeded → error (PROCESS_LIMIT).
     fn try_park_live(&self) -> Result<(), AgentError> {
         let max = Self::max_concurrent_from_settings();
         let mut guard = self.inner.lock();
@@ -710,24 +722,88 @@ impl SessionManager {
             return Ok(());
         }
         match s.fsm.state() {
-            SessionState::Ready if s.streaming_message_id.is_none() => {}
-            SessionState::Idle | SessionState::Disconnected => return Ok(()),
-            other => {
-                return Err(AgentError::new(
-                    AgentErrorCode::ProcessLimit,
-                    format!(
-                        "Session is busy ({other:?}). Stop the turn or wait, then switch chats. {}",
-                        process_limit_message(max)
-                    ),
-                ));
+            SessionState::Ready if s.streaming_message_id.is_none() => {
+                let acp = match s.acp.take() {
+                    Some(c) if c.is_alive() => c,
+                    Some(_) | None => return Ok(()),
+                };
+                let parked = ParkedAgent {
+                    process_id: s.process_id.clone(),
+                    app_session_id: s.app_session_id.clone(),
+                    meta: s.meta.clone(),
+                    acp,
+                    last_activity: s.last_activity,
+                    model_id: s.model_id.clone(),
+                    effort: s.effort.clone(),
+                    product_mode: s.product_mode.clone(),
+                    project_path: s.project_path.clone(),
+                    policy: s.policy,
+                    needs_history_bootstrap: s.needs_history_bootstrap,
+                    backend: s.backend.clone(),
+                };
+                let _ = guard.take();
+                drop(guard);
+                self.parked
+                    .lock()
+                    .insert(parked.app_session_id.clone(), parked);
+                Ok(())
             }
+            SessionState::Idle | SessionState::Disconnected => Ok(()),
+            // Busy: keep full LiveSession in background so streaming continues.
+            SessionState::Streaming
+            | SessionState::AwaitingPermission
+            | SessionState::Connecting => {
+                // +1 for the demoted session already counted as live; need room.
+                let others = self.active_process_count().saturating_sub(1);
+                if others.saturating_add(1) > max {
+                    return Err(AgentError::new(
+                        AgentErrorCode::ProcessLimit,
+                        format!(
+                            "Session is busy and process limit ({max}) is full. Stop a turn or raise the limit. {}",
+                            process_limit_message(max)
+                        ),
+                    ));
+                }
+                let Some(live) = guard.take() else {
+                    return Ok(());
+                };
+                let sid = live.app_session_id.clone();
+                drop(guard);
+                tracing::info!(
+                    "acp demote busy session to background sid={sid} state={:?}",
+                    live.fsm.state()
+                );
+                self.background.lock().insert(sid, live);
+                Ok(())
+            }
+            other => Err(AgentError::new(
+                AgentErrorCode::ProcessLimit,
+                format!(
+                    "Session is busy ({other:?}). Stop the turn or wait, then switch chats. {}",
+                    process_limit_message(max)
+                ),
+            )),
         }
+    }
 
-        let acp = match s.acp.take() {
-            Some(c) if c.is_alive() => c,
-            Some(_) | None => return Ok(()),
+    /// If a background session finished its turn (Ready), convert to warm parked.
+    fn promote_background_ready_to_parked(&self, app_session_id: &str) {
+        let mut bg = self.background.lock();
+        let ready = bg.get(app_session_id).is_some_and(|s| {
+            matches!(s.fsm.state(), SessionState::Ready)
+                && s.streaming_message_id.is_none()
+                && s.acp.as_ref().is_some_and(|c| c.is_alive())
+        });
+        if !ready {
+            return;
+        }
+        let Some(mut s) = bg.remove(app_session_id) else {
+            return;
         };
-
+        drop(bg);
+        let Some(acp) = s.acp.take() else {
+            return;
+        };
         let parked = ParkedAgent {
             process_id: s.process_id.clone(),
             app_session_id: s.app_session_id.clone(),
@@ -742,13 +818,13 @@ impl SessionManager {
             needs_history_bootstrap: s.needs_history_bootstrap,
             backend: s.backend.clone(),
         };
-        // Drop LiveSession shell — focus moves away; meta remains on disk.
-        let _ = guard.take();
-        drop(guard);
         self.parked
             .lock()
             .insert(parked.app_session_id.clone(), parked);
-        Ok(())
+        tracing::info!(
+            "acp background session ready → parked sid={}",
+            app_session_id
+        );
     }
 
     /// Promote a parked agent into the live slot (caller must have cleared live).
@@ -1066,9 +1142,24 @@ impl SessionManager {
             }
         }
 
+        // Target already streaming in background → promote to focus.
+        if self.background.lock().contains_key(&meta.id) {
+            if let Err(e) = self.try_park_live() {
+                Self::emit_process_limit(&app, Some(&meta.id), max_concurrent);
+                return Err(format!("{}: {}", e.code.as_str(), e.message));
+            }
+            if let Some(live) = self.background.lock().remove(&meta.id) {
+                *self.inner.lock() = Some(live);
+                let snap = self.snapshot();
+                Self::emit_state(&app, &snap);
+                tracing::info!("acp promoted background session to live sid={}", meta.id);
+                return Ok(snap);
+            }
+        }
+
         // Target already parked (warm multi-session) → unpark.
         if self.parked.lock().contains_key(&meta.id) {
-            // Park current live if needed (busy → error).
+            // Park current live if needed (busy → demote to background / park).
             if let Err(e) = self.try_park_live() {
                 Self::emit_process_limit(&app, Some(&meta.id), max_concurrent);
                 return Err(format!("{}: {}", e.code.as_str(), e.message));
@@ -1470,18 +1561,34 @@ impl SessionManager {
     }
 
     async fn handle_acp_event(self: &Arc<Self>, app: &AppHandle, process_id: &str, ev: AcpEvent) {
-        // Drop events from non-focused processes (parked agents should be idle).
-        // ProcessExited still cleans parked map entries.
+        // Route events to the focused live session **or** a background busy session
+        // (multi-session parallel streaming). Idle parked agents should not emit.
         let is_live = self
             .inner
             .lock()
             .as_ref()
             .map(|s| s.process_id == process_id)
             .unwrap_or(false);
+        let bg_sid = if !is_live {
+            self.background
+                .lock()
+                .iter()
+                .find(|(_, s)| s.process_id == process_id)
+                .map(|(id, _)| id.clone())
+        } else {
+            None
+        };
+
         if !is_live {
+            if let Some(sid) = bg_sid {
+                self.handle_acp_event_on_background(app, &sid, ev).await;
+                return;
+            }
             if let AcpEvent::ProcessExited { .. } = &ev {
                 let mut parked = self.parked.lock();
                 parked.retain(|_, p| p.process_id != process_id);
+                let mut bg = self.background.lock();
+                bg.retain(|_, s| s.process_id != process_id);
             }
             return;
         }
@@ -2133,6 +2240,280 @@ impl SessionManager {
                         "content": content,
                     }),
                 );
+            }
+        }
+    }
+
+    /// Apply ACP events for a session demoted to background (still streaming).
+    /// Emits the same `session://*` events with that session's id so the UI can
+    /// update caches without focus, and permissions are not applied to the wrong chat.
+    async fn handle_acp_event_on_background(
+        self: &Arc<Self>,
+        app: &AppHandle,
+        app_session_id: &str,
+        ev: AcpEvent,
+    ) {
+        match ev {
+            AcpEvent::Stream {
+                kind,
+                text,
+                message_id,
+                done,
+            } => {
+                let (app_sid, mid, thought_phase) = {
+                    let mut bg = self.background.lock();
+                    let Some(s) = bg.get_mut(app_session_id) else {
+                        return;
+                    };
+                    if !matches!(
+                        s.fsm.state(),
+                        SessionState::Streaming | SessionState::AwaitingPermission
+                    ) {
+                        return;
+                    }
+                    Self::touch_stream_progress_locked(s);
+                    if let Some(ref mid_in) = message_id {
+                        if s.streaming_message_id.as_ref() != Some(mid_in)
+                            && (s.streaming_message_id.is_none()
+                                || matches!(kind, StreamKind::Assistant))
+                        {
+                            s.streaming_message_id = Some(mid_in.clone());
+                        }
+                    }
+                    if s.streaming_message_id.is_none() {
+                        s.streaming_message_id =
+                            Some(message_id.unwrap_or_else(|| Uuid::new_v4().to_string()));
+                    }
+                    let thought_phase = match kind {
+                        StreamKind::Thought => {
+                            let phase = if s.stream_last_was_assistant {
+                                if !s.stream_thought.is_empty() {
+                                    s.stream_thought.push_str("\n\n⟪phase⟫\n\n");
+                                }
+                                s.stream_last_was_assistant = false;
+                                "new"
+                            } else if s.stream_thought.is_empty() {
+                                "open"
+                            } else {
+                                "continue"
+                            };
+                            s.stream_thought.push_str(&text);
+                            phase
+                        }
+                        StreamKind::Assistant => {
+                            s.stream_buf.push_str(&text);
+                            s.stream_last_was_assistant = true;
+                            "none"
+                        }
+                    };
+                    let para = is_paragraph_break(&text);
+                    Self::maybe_flush_stream_journal(s, done, para);
+                    (
+                        s.app_session_id.clone(),
+                        s.streaming_message_id.clone().unwrap_or_default(),
+                        thought_phase,
+                    )
+                };
+                let _ = app.emit(
+                    "session://stream",
+                    serde_json::json!({
+                        "sessionId": app_sid,
+                        "messageId": mid,
+                        "text": text,
+                        "done": done,
+                        "kind": match kind {
+                            StreamKind::Assistant => "assistant",
+                            StreamKind::Thought => "thought",
+                        },
+                        "thoughtPhase": thought_phase,
+                    }),
+                );
+            }
+            AcpEvent::PromptComplete { stop_reason: _ } => {
+                {
+                    let mut bg = self.background.lock();
+                    if let Some(s) = bg.get_mut(app_session_id) {
+                        Self::touch_stream_progress_locked(s);
+                        Self::maybe_flush_stream_journal(s, true, false);
+                        s.stream_buf.clear();
+                        s.stream_thought.clear();
+                        s.stream_last_was_assistant = false;
+                        s.stream_attachments.clear();
+                        s.journal_throttle.reset();
+                        if matches!(
+                            s.fsm.state(),
+                            SessionState::Streaming | SessionState::AwaitingPermission
+                        ) {
+                            let _ = s.fsm.end_stream();
+                        }
+                        s.streaming_message_id = None;
+                        s.last_stall_emit = None;
+                    }
+                }
+                self.promote_background_ready_to_parked(app_session_id);
+                // Snapshot is focused live — still emit so sidebar busy flags can refresh.
+                Self::emit_state(app, &self.snapshot());
+            }
+            AcpEvent::PermissionRequest {
+                rpc_id,
+                tool_call_id,
+                tool_name,
+                title,
+                options,
+                raw,
+            } => {
+                let preview = raw.to_string();
+                let path_target = extract_path_target(&raw);
+                let shell_command = extract_shell_command(&raw);
+                let sk_source = if path_target.is_empty() {
+                    title.clone()
+                } else {
+                    path_target.clone()
+                };
+                let sk = scope_key(&tool_name, &sk_source);
+                let (auto, auto_deny, session_id, project_path, acp) = {
+                    let mut bg = self.background.lock();
+                    if let Some(s) = bg.get_mut(app_session_id) {
+                        Self::touch_activity_locked(s);
+                        let _ = s.fsm.await_permission();
+                        let root = s.project_path.as_ref().map(std::path::PathBuf::from);
+                        let auto = may_auto_allow(
+                            s.policy,
+                            &s.allow_cache,
+                            &sk,
+                            root.as_deref(),
+                            &path_target,
+                            &tool_name,
+                            &shell_command,
+                        );
+                        let auto_deny = may_auto_deny(s.policy) && !auto;
+                        (
+                            auto,
+                            auto_deny,
+                            s.app_session_id.clone(),
+                            s.project_path.clone(),
+                            s.acp.clone(),
+                        )
+                    } else {
+                        return;
+                    }
+                };
+                let _ = project_path;
+                if auto {
+                    if let Some(acp) = acp {
+                        let option_id = pick_option_id(&options, "allow_once")
+                            .or_else(|| pick_option_id(&options, "allow"))
+                            .unwrap_or_else(|| "allow_once".into());
+                        let _ = acp
+                            .respond_permission(
+                                rpc_id,
+                                PermissionOutcome::Selected { option_id },
+                            )
+                            .await;
+                        let mut bg = self.background.lock();
+                        if let Some(s) = bg.get_mut(app_session_id) {
+                            if s.fsm.state() == SessionState::AwaitingPermission {
+                                let _ = s.fsm.permission_resolved_continue();
+                            }
+                        }
+                    }
+                } else if auto_deny {
+                    if let Some(acp) = acp {
+                        let option_id = pick_option_id(&options, "reject_once")
+                            .or_else(|| pick_option_id(&options, "reject"))
+                            .unwrap_or_else(|| "reject".into());
+                        let _ = acp
+                            .respond_permission(
+                                rpc_id,
+                                PermissionOutcome::Selected { option_id },
+                            )
+                            .await;
+                        let mut bg = self.background.lock();
+                        if let Some(s) = bg.get_mut(app_session_id) {
+                            if s.fsm.state() == SessionState::AwaitingPermission {
+                                let _ = s.fsm.permission_resolved_continue();
+                            }
+                        }
+                    }
+                } else {
+                    let req = UiPermissionRequest {
+                        rpc_id,
+                        session_id: session_id.clone(),
+                        tool_call_id,
+                        tool_name,
+                        title,
+                        preview: preview.chars().take(2000).collect(),
+                        scope_key: sk,
+                        options,
+                    };
+                    let _ = app.emit("session://permission", &req);
+                    // Tell UI this permission belongs to a non-focused session.
+                    let _ = app.emit(
+                        "session://background_permission",
+                        serde_json::json!({ "sessionId": session_id }),
+                    );
+                    Self::emit_state(app, &self.snapshot());
+                }
+            }
+            AcpEvent::ToolCall {
+                tool_call_id,
+                title,
+                kind,
+                status,
+                raw: _,
+            } => {
+                let app_sid = {
+                    let mut bg = self.background.lock();
+                    if let Some(s) = bg.get_mut(app_session_id) {
+                        Self::touch_stream_progress_locked(s);
+                        s.app_session_id.clone()
+                    } else {
+                        return;
+                    }
+                };
+                let live_title = if !title.is_empty() {
+                    title
+                } else {
+                    kind.clone()
+                };
+                let st = if status.is_empty() {
+                    "in_progress"
+                } else {
+                    status.as_str()
+                };
+                let _ = app.emit(
+                    "session://tool",
+                    serde_json::json!({
+                        "sessionId": app_sid,
+                        "toolCallId": tool_call_id,
+                        "title": live_title,
+                        "kind": kind,
+                        "status": st,
+                    }),
+                );
+            }
+            AcpEvent::ProcessExited { .. } => {
+                let mut bg = self.background.lock();
+                if let Some(mut s) = bg.remove(app_session_id) {
+                    let _ = s.fsm.crash("Agent process exited (background)");
+                    s.acp = None;
+                }
+                Self::emit_state(app, &self.snapshot());
+            }
+            AcpEvent::Error { error } => {
+                {
+                    let mut bg = self.background.lock();
+                    if let Some(s) = bg.get_mut(app_session_id) {
+                        Self::record_turn_error(s, app, &error);
+                        let _ = s.fsm.fail_with(error);
+                    }
+                }
+                self.promote_background_ready_to_parked(app_session_id);
+                Self::emit_state(app, &self.snapshot());
+            }
+            _ => {
+                // ask_user / plan / stderr / retry — still forward with session id when possible
+                tracing::debug!("background acp event ignored variant for sid={app_session_id}");
             }
         }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1437,6 +1437,15 @@ export default function App() {
               p.sessionId &&
               p.sessionId !== viewingSessionIdRef.current
             ) {
+              // Multi-session stream: another chat needs approval — nudge user.
+              setToast(trRef.current("session.backgroundPermission"));
+              window.setTimeout(() => setToast(null), 4200);
+              showDesktopNotification({
+                title: trRef.current("notify.permissionTitle"),
+                body: trRef.current("session.backgroundPermission"),
+                tag: `perm-bg-${p.rpcId}`,
+                force: true,
+              });
               return;
             }
             setPerm(p);

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -94,6 +94,8 @@ const en = {
     "Create a new chat with messages up to this point? Later turns are not copied.",
   "session.forkOk": "Forked · opened new chat",
   "session.forkFailed": "Could not fork chat",
+  "session.backgroundPermission":
+    "Another chat needs permission — switch to it to approve or deny.",
   "session.rewind": "Rewind timeline",
   "session.rewindTitle": "Rewind conversation",
   "session.rewindHint":
@@ -1188,6 +1190,8 @@ const zh: Record<MessageKey, string> = {
   "session.forkConfirmPartial":
     "复制到此为止的消息并新建会话？之后的回合不会复制。",
   "session.forkOk": "已分叉 · 已打开新会话",
+  "session.backgroundPermission":
+    "另一个会话需要权限批准 — 请切换过去以允许或拒绝。",
   "session.forkFailed": "分叉会话失败",
   "session.rewind": "回退时间线",
   "session.rewindTitle": "回退对话",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -83,6 +83,8 @@ export const zhTW: Record<MessageKey, string> = {
     "複製到此為止的訊息並建立新對話？之後的回合不會複製。",
   "session.forkOk": "已分叉 · 已開啟新對話",
   "session.forkFailed": "分叉對話失敗",
+  "session.backgroundPermission":
+    "另一個對話需要權限批准 — 請切換過去以允許或拒絕。",
   "session.rewind": "回退時間線",
   "session.rewindTitle": "回退對話",
   "session.rewindHint":


### PR DESCRIPTION
Kickoff item 6 (first slice): real multi-session streaming while under the process cap.

## Before
Switching chats while a turn was streaming/permission returned PROCESS_LIMIT / “session is busy”. Only one live ACP process received events.

## After
- **Ready** sessions still go to warm `parked` (unchanged).
- **Streaming / AwaitingPermission** demote to `background` with the full LiveSession + event pump.
- ACP events for background process ids are routed and re-emitted with the correct `sessionId` (stream cache keeps updating).
- Re-opening that chat promotes background → focused live.
- When the background turn finishes (Ready), it becomes normal parked.
- Permission for a non-focused chat: toast + notification; bar only shows when you switch to that chat (no cross-session approve).

Capacity still respects `maxConcurrentAgents` (live + background + parked).

### Test plan
- [x] `pnpm typecheck && pnpm test`
- [x] `cargo check` / session_manager builds
- [ ] Start a long turn → switch to another chat → first chat’s transcript still grows when you switch back
- [ ] Background permission → toast; switch to that chat → perm bar
- [ ] Ready-only switch still parks without error