### PR TITLE
feat: import Grok Build CLI sessions in shared mode

### DIFF
--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -1,0 +1,424 @@
+//! Discover / import Grok Build CLI sessions from GROK_HOME (shared mode E03).
+//!
+//! Layout: `{GROK_HOME}/sessions/{percent-encoded-cwd}/{agent_session_id}/`
+//!   - summary.json — title, timestamps, cwd
+//!   - chat_history.jsonl — line-delimited messages
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::paths::resolve_agent_grok_home;
+use crate::store::{self, ChatMessageStored, SessionMeta};
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliSessionSummary {
+    pub agent_session_id: String,
+    pub title: String,
+    pub cwd: Option<String>,
+    pub updated_at: String,
+    pub dir: String,
+    pub num_messages: u32,
+    /// App already has a session row pointing at this agent id.
+    pub already_linked: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SummaryFile {
+    #[serde(default)]
+    info: Option<SummaryInfo>,
+    #[serde(default)]
+    session_summary: Option<String>,
+    #[serde(default)]
+    generated_title: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
+    #[serde(default)]
+    last_active_at: Option<String>,
+    #[serde(default)]
+    num_messages: Option<u32>,
+    #[serde(default)]
+    num_chat_messages: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SummaryInfo {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    cwd: Option<String>,
+}
+
+/// List CLI agent sessions under the active GROK_HOME (respects session_data_mode).
+pub fn list_cli_sessions(session_data_mode: &str) -> Result<Vec<CliSessionSummary>, String> {
+    let home = resolve_agent_grok_home(session_data_mode);
+    let sessions = home.join("sessions");
+    if !sessions.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let linked: std::collections::HashSet<String> = store::load_sessions_index()
+        .into_iter()
+        .filter_map(|s| s.agent_session_id)
+        .collect();
+
+    let mut out = Vec::new();
+    let cwd_dirs = fs::read_dir(&sessions).map_err(|e| e.to_string())?;
+    for cwd_ent in cwd_dirs.flatten() {
+        let cwd_path = cwd_ent.path();
+        if !cwd_path.is_dir() {
+            continue;
+        }
+        let cwd_decoded = percent_decode_component(
+            cwd_path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or(""),
+        );
+        let Ok(sid_dirs) = fs::read_dir(&cwd_path) else {
+            continue;
+        };
+        for sid_ent in sid_dirs.flatten() {
+            let dir = sid_ent.path();
+            if !dir.is_dir() {
+                continue;
+            }
+            let agent_id = dir
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+            if agent_id.is_empty() || agent_id.starts_with('.') {
+                continue;
+            }
+            let summary_path = dir.join("summary.json");
+            if !summary_path.is_file() && !dir.join("chat_history.jsonl").is_file() {
+                continue;
+            }
+            let (title, cwd, updated, n) = read_summary_bits(&summary_path, &cwd_decoded, &agent_id);
+            out.push(CliSessionSummary {
+                already_linked: linked.contains(&agent_id),
+                agent_session_id: agent_id,
+                title,
+                cwd,
+                updated_at: updated,
+                dir: dir.display().to_string(),
+                num_messages: n,
+            });
+        }
+    }
+
+    out.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    // Cap list for UI.
+    if out.len() > 200 {
+        out.truncate(200);
+    }
+    Ok(out)
+}
+
+fn read_summary_bits(
+    summary_path: &Path,
+    cwd_fallback: &str,
+    agent_id: &str,
+) -> (String, Option<String>, String, u32) {
+    let raw = fs::read_to_string(summary_path).unwrap_or_default();
+    let parsed: SummaryFile = serde_json::from_str(&raw).unwrap_or(SummaryFile {
+        info: None,
+        session_summary: None,
+        generated_title: None,
+        created_at: None,
+        updated_at: None,
+        last_active_at: None,
+        num_messages: None,
+        num_chat_messages: None,
+    });
+    let title = parsed
+        .generated_title
+        .or(parsed.session_summary)
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| format!("CLI {}", &agent_id.chars().take(8).collect::<String>()));
+    let cwd = parsed
+        .info
+        .as_ref()
+        .and_then(|i| i.cwd.clone())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            if cwd_fallback.is_empty() {
+                None
+            } else {
+                Some(cwd_fallback.to_string())
+            }
+        });
+    let updated = parsed
+        .last_active_at
+        .or(parsed.updated_at)
+        .or(parsed.created_at)
+        .unwrap_or_else(|| Utc::now().to_rfc3339());
+    let n = parsed
+        .num_chat_messages
+        .or(parsed.num_messages)
+        .unwrap_or(0);
+    (title, cwd, updated, n)
+}
+
+/// Decode encodeURIComponent-style path segments used by Grok Build.
+pub fn percent_decode_component(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let h = || {
+                let a = (bytes[i + 1] as char).to_digit(16)?;
+                let b = (bytes[i + 2] as char).to_digit(16)?;
+                Some(((a << 4) | b) as u8)
+            };
+            if let Some(v) = h() {
+                out.push(v);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn content_to_text(content: &Value) -> String {
+    match content {
+        Value::String(s) => s.clone(),
+        Value::Array(arr) => {
+            let mut parts = Vec::new();
+            for item in arr {
+                if let Some(t) = item.get("text").and_then(|v| v.as_str()) {
+                    parts.push(t.to_string());
+                } else if let Some(t) = item.as_str() {
+                    parts.push(t.to_string());
+                }
+            }
+            parts.join("\n")
+        }
+        Value::Object(map) => map
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Parse CLI `chat_history.jsonl` into (role, content) pairs for the App journal.
+pub fn parse_chat_history_jsonl(path: &Path) -> Result<Vec<(String, String)>, String> {
+    let raw = fs::read_to_string(path).map_err(|e| format!("read chat_history: {e}"))?;
+    let mut out = Vec::new();
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue, // skip broken lines
+        };
+        let typ = v
+            .get("type")
+            .or_else(|| v.get("role"))
+            .and_then(|x| x.as_str())
+            .unwrap_or("");
+        let role = match typ {
+            "user" => "user",
+            "assistant" => "assistant",
+            _ => continue,
+        };
+        let content = v
+            .get("content")
+            .map(content_to_text)
+            .unwrap_or_default();
+        let content = content.trim().to_string();
+        if content.is_empty() {
+            continue;
+        }
+        // Drop huge system-y user envelopes when possible — keep query body.
+        let content = extract_user_query(&content).unwrap_or(content);
+        if content.is_empty() {
+            continue;
+        }
+        out.push((role.to_string(), content));
+    }
+    if out.is_empty() {
+        return Err("no user/assistant messages in chat_history.jsonl".into());
+    }
+    Ok(out)
+}
+
+fn extract_user_query(content: &str) -> Option<String> {
+    let start = content.find("<user_query>")?;
+    let rest = &content[start + "<user_query>".len()..];
+    let end = rest.find("</user_query>")?;
+    let q = rest[..end].trim();
+    if q.is_empty() {
+        None
+    } else {
+        Some(q.to_string())
+    }
+}
+
+/// Import one CLI session into the App journal (independent App session row).
+pub fn import_cli_session(
+    agent_session_id: &str,
+    dir: Option<&str>,
+    project_id: Option<String>,
+    session_data_mode: &str,
+) -> Result<SessionMeta, String> {
+    let dir = if let Some(d) = dir.filter(|s| !s.is_empty()) {
+        PathBuf::from(d)
+    } else {
+        crate::paths::find_agent_session_dir(agent_session_id, None, session_data_mode)
+            .ok_or_else(|| format!("CLI session dir not found for {agent_session_id}"))?
+    };
+    if !dir.is_dir() {
+        return Err(format!("not a directory: {}", dir.display()));
+    }
+
+    // Already linked?
+    if let Some(existing) = store::load_sessions_index()
+        .into_iter()
+        .find(|s| s.agent_session_id.as_deref() == Some(agent_session_id))
+    {
+        return Ok(existing);
+    }
+
+    let summary_path = dir.join("summary.json");
+    let cwd_name = dir
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    let (title, cwd, _, _) = read_summary_bits(
+        &summary_path,
+        &percent_decode_component(cwd_name),
+        agent_session_id,
+    );
+
+    let history = dir.join("chat_history.jsonl");
+    let pairs = parse_chat_history_jsonl(&history)?;
+
+    // Prefer matching App project by path.
+    let project_id = project_id.or_else(|| {
+        let cwd = cwd.as_deref()?;
+        store::load_projects()
+            .into_iter()
+            .find(|p| {
+                let a = p.path.trim_end_matches('/').trim_end_matches('\\');
+                let b = cwd.trim_end_matches('/').trim_end_matches('\\');
+                a == b
+            })
+            .map(|p| p.id)
+    });
+
+    let mut meta = store::create_session(project_id, Some(title), false)?;
+    meta.agent_session_id = Some(agent_session_id.to_string());
+    let now = Utc::now();
+    let msgs: Vec<ChatMessageStored> = pairs
+        .into_iter()
+        .enumerate()
+        .map(|(i, (role, content))| ChatMessageStored {
+            id: Uuid::new_v4().to_string(),
+            role,
+            content,
+            thought: None,
+            created_at: now + chrono::Duration::milliseconds(i as i64),
+            is_error: false,
+            attachments: None,
+            marker: None,
+        })
+        .collect();
+    store::save_messages(&meta.id, &msgs)?;
+    meta.updated_at = now;
+    // Persist agent_session_id link.
+    let mut list = store::load_sessions_index();
+    if let Some(row) = list.iter_mut().find(|s| s.id == meta.id) {
+        row.agent_session_id = meta.agent_session_id.clone();
+        row.updated_at = now;
+        meta = row.clone();
+    }
+    store::save_sessions_index(&list)?;
+    Ok(meta)
+}
+
+/// Import all not-yet-linked CLI sessions (capped).
+pub fn import_all_cli_sessions(
+    session_data_mode: &str,
+    limit: usize,
+) -> Result<Vec<SessionMeta>, String> {
+    let list = list_cli_sessions(session_data_mode)?;
+    let mut imported = Vec::new();
+    for s in list.into_iter().filter(|s| !s.already_linked).take(limit) {
+        match import_cli_session(
+            &s.agent_session_id,
+            Some(&s.dir),
+            None,
+            session_data_mode,
+        ) {
+            Ok(m) => imported.push(m),
+            Err(e) => tracing::warn!("cli import skip {}: {e}", s.agent_session_id),
+        }
+    }
+    Ok(imported)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    use crate::paths::percent_encode_path_component;
+
+    #[test]
+    fn percent_decode_roundtrip_path() {
+        let enc = percent_encode_path_component("/Users/me/Code/oss/pq");
+        assert!(enc.contains("%2F"));
+        assert_eq!(
+            percent_decode_component(&enc),
+            "/Users/me/Code/oss/pq"
+        );
+    }
+
+    #[test]
+    fn parse_jsonl_user_assistant() {
+        let dir = std::env::temp_dir().join(format!("cli-hist-{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("chat_history.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"system","content":"sys"}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","content":[{{"type":"text","text":"<user_query>\nhello world\n</user_query>"}}]}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","content":"hi there"}}"#
+        )
+        .unwrap();
+        let pairs = parse_chat_history_jsonl(&path).unwrap();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].0, "user");
+        assert_eq!(pairs[0].1, "hello world");
+        assert_eq!(pairs[1].0, "assistant");
+        assert_eq!(pairs[1].1, "hi there");
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -347,6 +347,37 @@ pub async fn sessions_list() -> Result<Vec<SessionMeta>, String> {
     Ok(store::load_sessions_index())
 }
 
+/// List Grok Build CLI sessions under GROK_HOME (shared-mode discovery, E03).
+#[tauri::command]
+pub async fn cli_sessions_list() -> Result<Vec<crate::cli_sessions::CliSessionSummary>, String> {
+    let mode = store::load_settings().session_data_mode;
+    crate::cli_sessions::list_cli_sessions(&mode)
+}
+
+/// Import one CLI session (chat_history.jsonl) into the App journal.
+#[tauri::command]
+pub async fn cli_session_import(
+    agent_session_id: String,
+    dir: Option<String>,
+    project_id: Option<String>,
+) -> Result<SessionMeta, String> {
+    let mode = store::load_settings().session_data_mode;
+    crate::cli_sessions::import_cli_session(
+        &agent_session_id,
+        dir.as_deref(),
+        project_id,
+        &mode,
+    )
+}
+
+/// Import up to `limit` not-yet-linked CLI sessions (default 50).
+#[tauri::command]
+pub async fn cli_sessions_import_all(limit: Option<u32>) -> Result<Vec<SessionMeta>, String> {
+    let mode = store::load_settings().session_data_mode;
+    let lim = limit.unwrap_or(50).min(100) as usize;
+    crate::cli_sessions::import_all_cli_sessions(&mode, lim)
+}
+
 #[tauri::command]
 pub async fn session_create(
     project_id: Option<String>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod process_util;
 mod process_limits;
 mod journal_throttle;
 mod stream_stall;
+mod cli_sessions;
 mod permission;
 mod providers;
 mod secrets;
@@ -148,6 +149,9 @@ pub fn run() {
             commands::project_reveal,
             commands::project_archive_sessions,
             commands::sessions_list,
+            commands::cli_sessions_list,
+            commands::cli_session_import,
+            commands::cli_sessions_import_all,
             commands::session_create,
             commands::session_delete,
             commands::session_rename,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5815,6 +5815,9 @@ export default function App() {
           theme={theme}
           onTheme={applyThemeChoice}
           sessionDataMode={sessionDataMode}
+          onCliSessionsImported={() => {
+            void refreshSessions();
+          }}
           onSessionDataMode={(v) => {
             const commit = () => {
               setSessionDataMode(v);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -84,6 +84,8 @@ export interface SettingsPageProps {
   onTheme: (v: Theme) => void;
   sessionDataMode: string;
   onSessionDataMode: (v: string) => void;
+  /** After importing CLI sessions (shared mode) — refresh sidebar. */
+  onCliSessionsImported?: () => void;
   policy: string;
   onPolicy: (v: PermissionPolicyId) => void;
   /** Where model / permission choices are remembered. */
@@ -391,6 +393,7 @@ export function SettingsPage({
   onTheme,
   sessionDataMode,
   onSessionDataMode,
+  onCliSessionsImported,
   policy,
   onPolicy,
   prefsScope = "global",
@@ -887,6 +890,12 @@ export function SettingsPage({
                   ]}
                 />
               </div>
+              {sessionDataMode === "shared" ? (
+                <CliSessionsPanel
+                  t={t}
+                  onImported={onCliSessionsImported}
+                />
+              ) : null}
               {onStoreApiKeysInKeychain ? (
                 <div className="settings-row">
                   <div className="settings-row__text">
@@ -1439,6 +1448,158 @@ export function SettingsPage({
           </div>
         )}
       </main>
+      </div>
+    </div>
+  );
+}
+
+/** Shared-mode: list / import Grok Build CLI sessions from GROK_HOME. */
+function CliSessionsPanel({
+  t,
+  onImported,
+}: {
+  t: (key: MessageKey, vars?: Record<string, string | number>) => string;
+  onImported?: () => void;
+}) {
+  const [rows, setRows] = useState<api.CliSessionSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!api.isTauri()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await api.cliSessionsList();
+      setRows(list);
+    } catch (e) {
+      setError(String(e));
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const importOne = async (row: api.CliSessionSummary) => {
+    setBusyId(row.agentSessionId);
+    setError(null);
+    setStatus(null);
+    try {
+      await api.cliSessionImport(row.agentSessionId, { dir: row.dir });
+      setStatus(t("settings.cliSessionsImportedOne", { title: row.title }));
+      await refresh();
+      onImported?.();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const importAll = async () => {
+    setBusyId("__all__");
+    setError(null);
+    setStatus(null);
+    try {
+      const imported = await api.cliSessionsImportAll(50);
+      setStatus(
+        t("settings.cliSessionsImportedN", { n: String(imported.length) }),
+      );
+      await refresh();
+      onImported?.();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const pending = rows.filter((r) => !r.alreadyLinked).length;
+
+  return (
+    <div className="settings-row settings-row--stack">
+      <div className="settings-row__text">
+        <div className="settings-row__label">{t("settings.cliSessions")}</div>
+        <div className="settings-row__desc">{t("settings.cliSessionsDesc")}</div>
+      </div>
+      <div className="settings-cli-sessions">
+        <div className="settings-cli-sessions__actions">
+          <button
+            type="button"
+            className="btn btn--ghost"
+            disabled={loading || !!busyId}
+            onClick={() => void refresh()}
+          >
+            {t("resources.refresh")}
+          </button>
+          <button
+            type="button"
+            className="btn btn--solid"
+            disabled={loading || !!busyId || pending === 0}
+            onClick={() => void importAll()}
+          >
+            {busyId === "__all__"
+              ? t("settings.cliSessionsImporting")
+              : t("settings.cliSessionsImportAll", { n: String(pending) })}
+          </button>
+        </div>
+        {error ? (
+          <div className="settings-cli-sessions__err" role="alert">
+            {error}
+          </div>
+        ) : null}
+        {status ? (
+          <div className="settings-cli-sessions__ok" role="status">
+            {status}
+          </div>
+        ) : null}
+        {loading && rows.length === 0 ? (
+          <div className="settings-cli-sessions__empty">
+            {t("settings.cliSessionsLoading")}
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="settings-cli-sessions__empty">
+            {t("settings.cliSessionsEmpty")}
+          </div>
+        ) : (
+          <ul className="settings-cli-sessions__list">
+            {rows.slice(0, 40).map((r) => (
+              <li key={r.agentSessionId} className="settings-cli-sessions__item">
+                <div className="settings-cli-sessions__meta">
+                  <div className="settings-cli-sessions__title">{r.title}</div>
+                  <div className="settings-cli-sessions__sub">
+                    {r.cwd || r.agentSessionId.slice(0, 12)}
+                    {r.numMessages
+                      ? ` · ${t("settings.cliSessionsMsgs", { n: String(r.numMessages) })}`
+                      : ""}
+                  </div>
+                </div>
+                {r.alreadyLinked ? (
+                  <span className="settings-cli-sessions__badge">
+                    {t("settings.cliSessionsLinked")}
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    className="btn btn--ghost"
+                    disabled={!!busyId}
+                    onClick={() => void importOne(r)}
+                  >
+                    {busyId === r.agentSessionId
+                      ? t("settings.cliSessionsImporting")
+                      : t("settings.cliSessionsImport")}
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -495,6 +495,18 @@ const en = {
   "settings.sessionDataMode": "Session data mode",
   "settings.sessionDataModeDesc":
     "Where chat history is stored (independent app dir or shared with CLI)",
+  "settings.cliSessions": "CLI sessions",
+  "settings.cliSessionsDesc":
+    "Sessions already on disk under ~/.grok. Import brings chat history into the app sidebar.",
+  "settings.cliSessionsImport": "Import",
+  "settings.cliSessionsImportAll": "Import all ({n})",
+  "settings.cliSessionsImporting": "Importing…",
+  "settings.cliSessionsImportedOne": "Imported “{title}”",
+  "settings.cliSessionsImportedN": "Imported {n} session(s)",
+  "settings.cliSessionsLoading": "Looking for CLI sessions…",
+  "settings.cliSessionsEmpty": "No CLI sessions found under ~/.grok/sessions.",
+  "settings.cliSessionsMsgs": "{n} messages",
+  "settings.cliSessionsLinked": "In app",
   "settings.storeApiKeysInKeychain": "Store API keys in system keychain",
   "settings.storeApiKeysInKeychainDesc":
     "Off by default: keys stay in the app data folder (mode 0600). Turn on to use the OS keychain — the system may ask once. Official login still uses Grok Build auth.",
@@ -1574,6 +1586,18 @@ const zh: Record<MessageKey, string> = {
   "settings.languageDesc": "应用界面语言",
   "settings.sessionDataMode": "会话数据模式",
   "settings.sessionDataModeDesc": "会话历史存储位置（应用独立目录或与 CLI 共享）",
+  "settings.cliSessions": "CLI 会话",
+  "settings.cliSessionsDesc":
+    "已存在于 ~/.grok 的 CLI 会话。导入后会把聊天记录加入应用侧边栏。",
+  "settings.cliSessionsImport": "导入",
+  "settings.cliSessionsImportAll": "全部导入（{n}）",
+  "settings.cliSessionsImporting": "导入中…",
+  "settings.cliSessionsImportedOne": "已导入「{title}」",
+  "settings.cliSessionsImportedN": "已导入 {n} 个会话",
+  "settings.cliSessionsLoading": "正在查找 CLI 会话…",
+  "settings.cliSessionsEmpty": "在 ~/.grok/sessions 下未找到 CLI 会话。",
+  "settings.cliSessionsMsgs": "{n} 条消息",
+  "settings.cliSessionsLinked": "已在应用中",
   "settings.storeApiKeysInKeychain": "用系统钥匙串保存 API Key",
   "settings.storeApiKeysInKeychainDesc":
     "默认关闭：密钥写在应用数据目录（0600）。开启后写入系统钥匙串，系统可能要求一次授权。官方登录仍走 Grok Build 鉴权，不受此项影响。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -468,6 +468,18 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.languageDesc": "應用程式介面語言",
   "settings.sessionDataMode": "對話資料模式",
   "settings.sessionDataModeDesc": "對話歷史儲存位置（應用程式獨立目錄或與 CLI 共用）",
+  "settings.cliSessions": "CLI 工作階段",
+  "settings.cliSessionsDesc":
+    "已存在於 ~/.grok 的 CLI 工作階段。匯入後會把聊天紀錄加入應用程式側邊欄。",
+  "settings.cliSessionsImport": "匯入",
+  "settings.cliSessionsImportAll": "全部匯入（{n}）",
+  "settings.cliSessionsImporting": "匯入中…",
+  "settings.cliSessionsImportedOne": "已匯入「{title}」",
+  "settings.cliSessionsImportedN": "已匯入 {n} 個工作階段",
+  "settings.cliSessionsLoading": "正在尋找 CLI 工作階段…",
+  "settings.cliSessionsEmpty": "在 ~/.grok/sessions 下找不到 CLI 工作階段。",
+  "settings.cliSessionsMsgs": "{n} 則訊息",
+  "settings.cliSessionsLinked": "已在應用程式中",
   "settings.storeApiKeysInKeychain": "以系統鑰匙圈儲存 API Key",
   "settings.storeApiKeysInKeychainDesc":
     "預設關閉：金鑰寫在應用資料目錄（0600）。開啟後寫入系統鑰匙圈，系統可能要求一次授權。官方登入仍走 Grok Build 驗證，不受此項影響。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -562,6 +562,48 @@ export async function sessionsList() {
   >("sessions_list");
 }
 
+/** CLI sessions under GROK_HOME (shared-mode discovery). */
+export type CliSessionSummary = {
+  agentSessionId: string;
+  title: string;
+  cwd: string | null;
+  updatedAt: string;
+  dir: string;
+  numMessages: number;
+  alreadyLinked: boolean;
+};
+
+export async function cliSessionsList() {
+  return invoke<CliSessionSummary[]>("cli_sessions_list");
+}
+
+export async function cliSessionImport(
+  agentSessionId: string,
+  opts?: { dir?: string | null; projectId?: string | null },
+) {
+  return invoke<{
+    id: string;
+    title: string;
+    projectId: string | null;
+    updatedAt: string;
+  }>("cli_session_import", {
+    agentSessionId,
+    dir: opts?.dir ?? null,
+    projectId: opts?.projectId ?? null,
+  });
+}
+
+export async function cliSessionsImportAll(limit?: number) {
+  return invoke<
+    Array<{
+      id: string;
+      title: string;
+      projectId: string | null;
+      updatedAt: string;
+    }>
+  >("cli_sessions_import_all", { limit: limit ?? 50 });
+}
+
 export async function sessionCreate(
   projectId?: string,
   title?: string,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3536,6 +3536,95 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   border: 1px solid var(--border-subtle);
 }
 
+/* Shared-mode: discover / import Grok Build CLI sessions */
+.settings-cli-sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  margin-top: 4px;
+}
+
+.settings-cli-sessions__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-cli-sessions__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 280px;
+  overflow: auto;
+}
+
+.settings-cli-sessions__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated, var(--bg-input));
+  min-width: 0;
+}
+
+.settings-cli-sessions__meta {
+  min-width: 0;
+  flex: 1;
+}
+
+.settings-cli-sessions__title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-cli-sessions__sub {
+  margin-top: 2px;
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-cli-sessions__badge {
+  flex-shrink: 0;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent, #6b8afd) 16%, transparent);
+  color: var(--text-secondary);
+}
+
+.settings-cli-sessions__empty {
+  font-size: 12.5px;
+  color: var(--text-tertiary);
+  padding: 6px 2px;
+}
+
+.settings-cli-sessions__err {
+  font-size: 12.5px;
+  color: var(--danger, #d33);
+  padding: 4px 2px;
+}
+
+.settings-cli-sessions__ok {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  padding: 4px 2px;
+}
+
 /* ===== Drag-drop zone overlays (OS file drop) =====
    Full-bleed wash + inset ring (no dashed frame with margins).
    Hint card floats center; icons from Tabler only. */


### PR DESCRIPTION
Shared-mode E03: discover and import Grok Build CLI sessions from `~/.grok`.

## Before
Shared mode only switches where App writes data. Sessions created in the CLI under `~/.grok/sessions/{cwd}/{id}/` never showed up in the sidebar.

## After
When **Session data mode = shared**, Settings → General shows a **CLI sessions** panel:

- Scans `{GROK_HOME}/sessions/{percent-encoded-cwd}/{agent_session_id}/`
- Reads `summary.json` (title, cwd, message count) + marks rows already linked via `agentSessionId`
- **Import** / **Import all** parse `chat_history.jsonl` (user/assistant; strips `<user_query>` wrappers) into a new App journal row and links the agent id
- Sidebar refreshes after import

Does not claim full bidirectional shared lock (that’s #55). This is list + one-way import only.

### Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/i18n/messages.test.ts`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml cli_sessions`
- [ ] Switch to shared mode → Settings shows CLI sessions from a real `~/.grok/sessions` tree
- [ ] Import one → appears in sidebar with history; badge becomes “In app”
- [ ] Import all (or re-import) skips already-linked ids