### PR TITLE
feat: check for App updates from GitHub Releases

### DIFF
--- a/src-tauri/src/app_update.rs
+++ b/src-tauri/src/app_update.rs
@@ -1,0 +1,200 @@
+//! Check for newer App releases on GitHub (L08 first slice).
+//!
+//! Does **not** auto-install: unsigned community builds and missing
+//! `TAURI_SIGNING_*` secrets make silent Tauri updater unreliable. Users get a
+//! clear "newer version / open release page" path from Settings → About.
+
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::Value;
+
+const DEFAULT_RELEASES_URL: &str =
+    "https://api.github.com/repos/RongleCat/grok-app/releases/latest";
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(12);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppUpdateCheck {
+    pub current_version: String,
+    pub latest_version: String,
+    pub update_available: bool,
+    pub release_name: Option<String>,
+    pub html_url: String,
+    pub published_at: Option<String>,
+    pub body: Option<String>,
+    /// Download asset names on the release (for UI hints; not auto-fetched).
+    pub asset_names: Vec<String>,
+}
+
+/// Strip optional `v` / `V` prefix and parse `major.minor.patch` (extra suffix ignored).
+pub fn parse_semver(raw: &str) -> Option<(u64, u64, u64)> {
+    let s = raw.trim().trim_start_matches(['v', 'V']);
+    if s.is_empty() {
+        return None;
+    }
+    // Drop pre-release / build metadata: 1.2.3-beta.1+meta → 1.2.3
+    let core = s
+        .split(['-', '+'])
+        .next()
+        .unwrap_or(s);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    Some((major, minor, patch))
+}
+
+/// True when `remote` is a higher semver than `current`.
+pub fn is_remote_newer(current: &str, remote: &str) -> bool {
+    match (parse_semver(current), parse_semver(remote)) {
+        (Some(a), Some(b)) => b > a,
+        _ => false,
+    }
+}
+
+/// Map GitHub `/releases/latest` JSON into [`AppUpdateCheck`].
+pub fn parse_github_release(current_version: &str, v: &Value) -> Result<AppUpdateCheck, String> {
+    let tag = v
+        .get("tag_name")
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| "release missing tag_name".to_string())?
+        .trim();
+    if tag.is_empty() {
+        return Err("empty tag_name".into());
+    }
+    let html_url = v
+        .get("html_url")
+        .and_then(|x| x.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("https://github.com/RongleCat/grok-app/releases")
+        .to_string();
+    let release_name = v
+        .get("name")
+        .and_then(|x| x.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let published_at = v
+        .get("published_at")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string());
+    let body = v
+        .get("body")
+        .and_then(|x| x.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let asset_names = v
+        .get("assets")
+        .and_then(|a| a.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| a.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let latest_version = tag.trim_start_matches(['v', 'V']).to_string();
+    let update_available = is_remote_newer(current_version, tag);
+
+    Ok(AppUpdateCheck {
+        current_version: current_version.to_string(),
+        latest_version,
+        update_available,
+        release_name,
+        html_url,
+        published_at,
+        body,
+        asset_names,
+    })
+}
+
+/// Query GitHub for the latest release and compare to this build.
+pub async fn check_app_update() -> Result<AppUpdateCheck, String> {
+    let current = env!("CARGO_PKG_VERSION");
+    let url = std::env::var("GROK_APP_RELEASES_URL").unwrap_or_else(|_| DEFAULT_RELEASES_URL.into());
+    if !(url.starts_with("https://") || url.starts_with("http://127.0.0.1") || url.starts_with("http://localhost")) {
+        return Err("update check URL must be https (or localhost for tests)".into());
+    }
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .user_agent(format!(
+            "GrokApp/{} (desktop; check-update; +https://github.com/RongleCat/grok-app)",
+            current
+        ))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let res = client
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .await
+        .map_err(|e| format!("update check network: {e}"))?;
+
+    if !res.status().is_success() {
+        return Err(format!(
+            "GitHub releases returned HTTP {}",
+            res.status().as_u16()
+        ));
+    }
+
+    let v: Value = res
+        .json()
+        .await
+        .map_err(|e| format!("update check parse: {e}"))?;
+    parse_github_release(current, &v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_semver_strips_v_and_prerelease() {
+        assert_eq!(parse_semver("v0.1.5"), Some((0, 1, 5)));
+        assert_eq!(parse_semver("0.1.5"), Some((0, 1, 5)));
+        assert_eq!(parse_semver("1.2.3-beta.1"), Some((1, 2, 3)));
+        assert_eq!(parse_semver("2.0"), Some((2, 0, 0)));
+        assert!(parse_semver("").is_none());
+        assert!(parse_semver("nope").is_none());
+    }
+
+    #[test]
+    fn is_remote_newer_orders() {
+        assert!(!is_remote_newer("0.1.5", "v0.1.5"));
+        assert!(!is_remote_newer("0.1.5", "0.1.4"));
+        assert!(is_remote_newer("0.1.5", "v0.1.6"));
+        assert!(is_remote_newer("0.1.5", "0.2.0"));
+        assert!(is_remote_newer("0.9.9", "1.0.0"));
+        assert!(!is_remote_newer("bad", "0.1.0"));
+    }
+
+    #[test]
+    fn parse_github_release_update_and_same() {
+        let sample = json!({
+            "tag_name": "v0.2.0",
+            "name": "Grok App v0.2.0",
+            "html_url": "https://github.com/RongleCat/grok-app/releases/tag/v0.2.0",
+            "published_at": "2026-07-24T00:00:00Z",
+            "body": "### Added\n- hello",
+            "assets": [
+                {"name": "Grok_0.2.0_aarch64.dmg"},
+                {"name": "Grok_0.2.0_x64-setup.exe"}
+            ]
+        });
+        let up = parse_github_release("0.1.5", &sample).unwrap();
+        assert!(up.update_available);
+        assert_eq!(up.latest_version, "0.2.0");
+        assert_eq!(up.current_version, "0.1.5");
+        assert_eq!(up.asset_names.len(), 2);
+        assert!(up.body.as_deref().unwrap().contains("hello"));
+
+        let same = parse_github_release("0.2.0", &sample).unwrap();
+        assert!(!same.update_available);
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -213,6 +213,12 @@ pub async fn pick_cli_binary() -> Result<Option<String>, String> {
     Ok(file.map(|p| p.display().to_string()))
 }
 
+/// Query GitHub Releases for a newer App version (Settings → About).
+#[tauri::command]
+pub async fn app_check_update() -> Result<crate::app_update::AppUpdateCheck, String> {
+    crate::app_update::check_app_update().await
+}
+
 /// Open a URL in the system browser (docs, install pages).
 #[tauri::command]
 pub async fn open_external_url(url: String) -> Result<(), String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod account;
 mod account_profiles;
 mod acp_client;
 mod agent_prefs;
+mod app_update;
 mod extensions;
 mod supergrok_quota;
 mod cli_probe;
@@ -140,6 +141,7 @@ pub fn run() {
             commands::cli_install_commands,
             commands::pick_cli_binary,
             commands::open_external_url,
+            commands::app_check_update,
             commands::projects_list,
             commands::project_add,
             commands::project_add_dialog,

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1445,6 +1445,7 @@ export function SettingsPage({
                 <div className="settings-row__desc">{versionFooter}</div>
               </div>
             </div>
+            <AboutUpdateRow t={t} />
           </div>
         )}
       </main>
@@ -1600,6 +1601,102 @@ function CliSessionsPanel({
             ))}
           </ul>
         )}
+      </div>
+    </div>
+  );
+}
+
+function AboutUpdateRow({
+  t,
+}: {
+  t: (key: MessageKey, vars?: Record<string, string | number>) => string;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<api.AppUpdateCheck | null>(null);
+
+  const check = async () => {
+    if (!api.isTauri()) {
+      setError("not in Tauri");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const r = await api.appCheckUpdate();
+      setResult(r);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const openRelease = async (url: string) => {
+    try {
+      await api.openExternalUrl(url);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  return (
+    <div className="settings-row settings-row--stack">
+      <div className="settings-row__text">
+        <div className="settings-row__label">{t("settings.checkUpdate")}</div>
+        <div className="settings-row__desc">{t("settings.checkUpdateDesc")}</div>
+      </div>
+      <div className="settings-about-update">
+        <div className="settings-about-update__actions">
+          <button
+            type="button"
+            className="btn btn--solid"
+            disabled={busy}
+            onClick={() => void check()}
+          >
+            {busy
+              ? t("settings.checkUpdateChecking")
+              : t("settings.checkUpdate")}
+          </button>
+          {result?.updateAvailable ? (
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => void openRelease(result.htmlUrl)}
+            >
+              {t("settings.checkUpdateOpen")}
+            </button>
+          ) : null}
+        </div>
+        {error ? (
+          <div className="settings-about-update__err" role="alert">
+            {t("settings.checkUpdateFailed", { error })}
+          </div>
+        ) : null}
+        {result && !error ? (
+          <div
+            className={
+              "settings-about-update__status" +
+              (result.updateAvailable ? " is-available" : "")
+            }
+            role="status"
+          >
+            {result.updateAvailable
+              ? t("settings.checkUpdateAvailable", {
+                  latest: result.latestVersion,
+                  current: result.currentVersion,
+                })
+              : t("settings.checkUpdateLatest", {
+                  version: result.currentVersion,
+                })}
+          </div>
+        ) : null}
+        {result?.updateAvailable && result.assetNames.length > 0 ? (
+          <div className="settings-about-update__assets">
+            {result.assetNames.slice(0, 6).join(" · ")}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -563,6 +563,15 @@ const en = {
   "settings.doctorDesc": "Diagnose CLI, auth, and provider connectivity",
   "settings.runDoctor": "Run Doctor",
   "settings.aboutApp": "About Grok App",
+  "settings.checkUpdate": "Check for updates",
+  "settings.checkUpdateDesc":
+    "Look up the latest GitHub release. Download installers from the release page — this app does not auto-install yet.",
+  "settings.checkUpdateChecking": "Checking…",
+  "settings.checkUpdateLatest": "You are on the latest version ({version}).",
+  "settings.checkUpdateAvailable":
+    "Version {latest} is available (you have {current}).",
+  "settings.checkUpdateOpen": "Open release page",
+  "settings.checkUpdateFailed": "Could not check: {error}",
   "settings.close": "Close",
   "settings.sharedConfirm":
     "Switch to shared ~/.grok? Data will not merge silently. Confirm?",
@@ -1666,6 +1675,15 @@ const zh: Record<MessageKey, string> = {
   "settings.doctorDesc": "诊断 CLI、鉴权与供应商连通性",
   "settings.runDoctor": "运行 Doctor",
   "settings.aboutApp": "关于 Grok App",
+  "settings.checkUpdate": "检查更新",
+  "settings.checkUpdateDesc":
+    "查询 GitHub 最新 Release。安装包请在发布页下载 — 应用暂不自动安装。",
+  "settings.checkUpdateChecking": "检查中…",
+  "settings.checkUpdateLatest": "已是最新版本（{version}）。",
+  "settings.checkUpdateAvailable":
+    "有新版本 {latest}（当前 {current}）。",
+  "settings.checkUpdateOpen": "打开发布页",
+  "settings.checkUpdateFailed": "检查失败：{error}",
   "settings.close": "关闭",
   "settings.sharedConfirm":
     "切换到共享 ~/.grok？数据不会静默合并，请确认。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -536,6 +536,15 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.doctorDesc": "診斷 CLI、驗證與供應商連通性",
   "settings.runDoctor": "執行 Doctor",
   "settings.aboutApp": "關於 Grok App",
+  "settings.checkUpdate": "檢查更新",
+  "settings.checkUpdateDesc":
+    "查詢 GitHub 最新 Release。安裝包請在發佈頁下載 — 應用程式暫不自動安裝。",
+  "settings.checkUpdateChecking": "檢查中…",
+  "settings.checkUpdateLatest": "已是最新版本（{version}）。",
+  "settings.checkUpdateAvailable":
+    "有新版本 {latest}（目前 {current}）。",
+  "settings.checkUpdateOpen": "開啟發佈頁",
+  "settings.checkUpdateFailed": "檢查失敗：{error}",
   "settings.close": "關閉",
   "settings.sharedConfirm":
     "切換到共用 ~/.grok？資料不會靜默合併，請確認。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -244,6 +244,22 @@ export async function openExternalUrl(url: string) {
   return invoke<void>("open_external_url", { url });
 }
 
+/** GitHub Releases check (Settings → About). Does not auto-install. */
+export type AppUpdateCheck = {
+  currentVersion: string;
+  latestVersion: string;
+  updateAvailable: boolean;
+  releaseName: string | null;
+  htmlUrl: string;
+  publishedAt: string | null;
+  body: string | null;
+  assetNames: string[];
+};
+
+export async function appCheckUpdate() {
+  return invoke<AppUpdateCheck>("app_check_update");
+}
+
 export async function projectsList() {
   return invoke<
     Array<{

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3647,6 +3647,47 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   padding: 4px 2px;
 }
 
+/* Settings → About: GitHub release check */
+.settings-about-update {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  margin-top: 4px;
+}
+
+.settings-about-update__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-about-update__status {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.settings-about-update__status.is-available {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.settings-about-update__err {
+  font-size: 12.5px;
+  color: var(--danger, #d33);
+  line-height: 1.45;
+}
+
+.settings-about-update__assets {
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  line-height: 1.4;
+  word-break: break-all;
+}
+
 /* ===== Drag-drop zone overlays (OS file drop) =====
    Full-bleed wash + inset ring (no dashed frame with margins).
    Hint card floats center; icons from Tabler only. */


### PR DESCRIPTION
L08 first slice: honest update check without auto-install.

## Why not full Tauri updater yet
Release workflow does not ship signed updater payloads / `TAURI_SIGNING_*` is optional. Silent auto-install would be incomplete or brittle for community builds.

## What this does
- **Settings → About → Check for updates**
- Backend hits `api.github.com/repos/RongleCat/grok-app/releases/latest`
- Semver compare (`v` prefix / pre-release stripped)
- Shows “latest” or “{latest} available (you have {current})”
- **Open release page** via existing `open_external_url`
- Lists asset names as a hint (dmg / setup / AppImage / …)
- en / zh / zh-TW

No download/install of the App binary inside the client.

### Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/i18n/messages.test.ts`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml app_update`
- [ ] Settings → About → Check for updates → “latest” on v0.1.5 when 0.1.5 is newest
- [ ] Bump local cargo version mentally / mock newer tag → available + Open release page
- [ ] Offline → error string, no crash