### PR TITLE
feat: search session message content from palette

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -347,6 +347,23 @@ pub async fn sessions_list() -> Result<Vec<SessionMeta>, String> {
     Ok(store::load_sessions_index())
 }
 
+/// Scan App journal messages for case-insensitive content matches.
+/// Returns session id, title, snippet, match count (capped work).
+#[tauri::command]
+pub async fn sessions_search(
+    query: String,
+    limit: Option<u32>,
+) -> Result<Vec<crate::session_content_search::SessionContentHit>, String> {
+    let lim = limit.unwrap_or(20).min(50) as usize;
+    // Blocking disk scan — run off the async runtime.
+    let q = query;
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::session_content_search::search_sessions(&q, lim)
+    })
+    .await
+    .map_err(|e| e.to_string())
+}
+
 /// List Grok Build CLI sessions under GROK_HOME (shared-mode discovery, E03).
 #[tauri::command]
 pub async fn cli_sessions_list() -> Result<Vec<crate::cli_sessions::CliSessionSummary>, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ mod permission;
 mod providers;
 mod secrets;
 mod session_import;
+mod session_content_search;
 mod session_title;
 #[cfg(test)]
 mod permission_host_test;
@@ -151,6 +152,7 @@ pub fn run() {
             commands::project_reveal,
             commands::project_archive_sessions,
             commands::sessions_list,
+            commands::sessions_search,
             commands::cli_sessions_list,
             commands::cli_session_import,
             commands::cli_sessions_import_all,

--- a/src-tauri/src/session_content_search.rs
+++ b/src-tauri/src/session_content_search.rs
@@ -1,0 +1,268 @@
+//! Search App journal message bodies (messages.json) for sidebar content hits.
+//!
+//! Pure match/snippet helpers are unit-tested; `search_sessions` scans on-disk
+//! journals with hard caps so the palette stays responsive.
+
+use std::fs;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::paths::session_dir;
+use crate::store::{self, ChatMessageStored, SessionMeta};
+
+/// Max sessions to open on disk (most recently updated first).
+const MAX_SESSIONS_SCAN: usize = 200;
+/// Skip journals larger than this (bytes).
+const MAX_MESSAGES_FILE_BYTES: u64 = 2 * 1024 * 1024;
+/// Snippet half-window around the first match (chars).
+const SNIPPET_RADIUS: usize = 48;
+/// Max snippet length returned to the UI.
+const SNIPPET_MAX: usize = 120;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionContentHit {
+    pub id: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    /// First matching excerpt with optional ellipsis.
+    pub snippet: String,
+    /// How many user/assistant messages contain the query.
+    pub match_count: u32,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub archived: bool,
+}
+
+/// Count matching user/assistant messages and build a snippet from the first hit.
+/// Case-insensitive substring. Empty query → `None`.
+pub fn match_messages<'a, I>(query: &str, messages: I) -> Option<(u32, String)>
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    let q = query.trim();
+    if q.is_empty() {
+        return None;
+    }
+    let q_lower = q.to_lowercase();
+    let mut match_count = 0u32;
+    let mut first_snippet: Option<String> = None;
+
+    for (role, content) in messages {
+        if role != "user" && role != "assistant" {
+            continue;
+        }
+        if content.is_empty() {
+            continue;
+        }
+        let lower = content.to_lowercase();
+        if let Some(byte_idx) = lower.find(&q_lower) {
+            match_count = match_count.saturating_add(1);
+            if first_snippet.is_none() {
+                first_snippet = Some(make_snippet(content, byte_idx, q.len()));
+            }
+        }
+    }
+
+    if match_count == 0 {
+        None
+    } else {
+        Some((match_count, first_snippet.unwrap_or_default()))
+    }
+}
+
+/// Build a single-line snippet around a UTF-8 byte offset into `content`.
+pub fn make_snippet(content: &str, match_byte_idx: usize, match_len: usize) -> String {
+    // Clamp to char boundaries.
+    let start_byte = floor_char_boundary(content, match_byte_idx);
+    let end_byte = ceil_char_boundary(
+        content,
+        match_byte_idx.saturating_add(match_len).min(content.len()),
+    );
+
+    let prefix = &content[..start_byte];
+    let matched = &content[start_byte..end_byte];
+    let suffix = &content[end_byte..];
+
+    let prefix_chars: Vec<char> = prefix.chars().collect();
+    let suffix_chars: Vec<char> = suffix.chars().collect();
+    let matched_chars: Vec<char> = matched.chars().collect();
+
+    let take_pre = SNIPPET_RADIUS.min(prefix_chars.len());
+    let pre_slice = &prefix_chars[prefix_chars.len().saturating_sub(take_pre)..];
+    let lead_ellipsis = prefix_chars.len() > take_pre;
+
+    let mut out = String::new();
+    if lead_ellipsis {
+        out.push('…');
+    }
+    out.extend(pre_slice.iter().copied());
+    out.extend(matched_chars.iter().copied());
+
+    let room = SNIPPET_MAX.saturating_sub(out.chars().count());
+    let take_suf = room.min(suffix_chars.len()).min(SNIPPET_RADIUS + 16);
+    out.extend(suffix_chars.iter().take(take_suf).copied());
+    if suffix_chars.len() > take_suf {
+        out.push('…');
+    }
+
+    // Collapse whitespace for a single-line palette row.
+    let collapsed: String = out.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() > SNIPPET_MAX {
+        let trimmed: String = collapsed
+            .chars()
+            .take(SNIPPET_MAX.saturating_sub(1))
+            .collect();
+        format!("{trimmed}…")
+    } else {
+        collapsed
+    }
+}
+
+fn floor_char_boundary(s: &str, i: usize) -> usize {
+    if i >= s.len() {
+        return s.len();
+    }
+    let mut i = i;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+fn ceil_char_boundary(s: &str, i: usize) -> usize {
+    if i >= s.len() {
+        return s.len();
+    }
+    let mut i = i;
+    while i < s.len() && !s.is_char_boundary(i) {
+        i += 1;
+    }
+    i
+}
+
+/// Scan App journal sessions for `query`. Caps work; skips huge files.
+pub fn search_sessions(query: &str, limit: usize) -> Vec<SessionContentHit> {
+    let q = query.trim();
+    if q.is_empty() {
+        return Vec::new();
+    }
+    let limit = limit.clamp(1, 50);
+    let index = store::load_sessions_index();
+    let mut hits = Vec::new();
+
+    for meta in index.into_iter().take(MAX_SESSIONS_SCAN) {
+        // Match sidebar default: hide archived from content hits.
+        if meta.archived {
+            continue;
+        }
+        if let Some(hit) = scan_session(&meta, q) {
+            hits.push(hit);
+            if hits.len() >= limit {
+                break;
+            }
+        }
+    }
+    hits
+}
+
+fn scan_session(meta: &SessionMeta, query: &str) -> Option<SessionContentHit> {
+    let path = session_dir(&meta.id).join("messages.json");
+    if !path.is_file() {
+        return None;
+    }
+    if file_too_large(&path) {
+        return None;
+    }
+    let messages: Vec<ChatMessageStored> = match fs::read_to_string(&path) {
+        Ok(s) if s.trim().is_empty() => return None,
+        Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
+        Err(_) => return None,
+    };
+    let iter = messages
+        .iter()
+        .map(|m| (m.role.as_str(), m.content.as_str()));
+    let (match_count, snippet) = match_messages(query, iter)?;
+    Some(SessionContentHit {
+        id: meta.id.clone(),
+        title: meta.title.clone(),
+        project_id: meta.project_id.clone(),
+        snippet,
+        match_count,
+        updated_at: meta.updated_at,
+        archived: meta.archived,
+    })
+}
+
+fn file_too_large(path: &Path) -> bool {
+    match fs::metadata(path) {
+        Ok(m) => m.len() > MAX_MESSAGES_FILE_BYTES,
+        Err(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_yields_none() {
+        let msgs = [("user", "hello world")];
+        assert!(match_messages("", msgs).is_none());
+        assert!(match_messages("   ", msgs).is_none());
+    }
+
+    #[test]
+    fn case_insensitive_substring() {
+        let msgs = [
+            ("user", "Please fix the Doctor reset button"),
+            ("assistant", "Sure, I will patch it."),
+            ("system", "doctor ignore me"),
+        ];
+        let (n, snip) = match_messages("doctor", msgs).expect("hit");
+        // system role ignored; only user matches
+        assert_eq!(n, 1);
+        assert!(snip.to_lowercase().contains("doctor"));
+    }
+
+    #[test]
+    fn counts_multiple_message_hits() {
+        let msgs = [
+            ("user", "alpha beta"),
+            ("assistant", "reply without key"),
+            ("user", "gamma beta again"),
+            ("assistant", "BETA uppercase"),
+        ];
+        let (n, _) = match_messages("beta", msgs).expect("hit");
+        assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn snippet_truncates_with_ellipsis() {
+        let long_prefix = "word ".repeat(40);
+        let content = format!("{long_prefix}TARGET rest of the message body continues here");
+        let lower = content.to_lowercase();
+        let idx = lower.find("target").unwrap();
+        let snip = make_snippet(&content, idx, "TARGET".len());
+        assert!(snip.contains("TARGET"));
+        assert!(snip.starts_with('…'));
+        assert!(snip.chars().count() <= SNIPPET_MAX + 1);
+    }
+
+    #[test]
+    fn unicode_safe_snippet() {
+        let content = "你好世界测试内容 TARGET 后面还有更多中文内容用于截断";
+        let idx = content.find("TARGET").unwrap();
+        let snip = make_snippet(content, idx, 6);
+        assert!(snip.contains("TARGET"));
+        assert!(!snip.is_empty());
+    }
+
+    #[test]
+    fn search_sessions_empty_query() {
+        assert!(search_sessions("", 10).is_empty());
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,11 @@ import {
 } from "@/lib/permissionOptions";
 import { AskUserModal } from "@/components/AskUserModal";
 import { DoctorModal } from "@/components/DoctorModal";
-import { filterSessionSearch } from "@/lib/sessionSearch";
+import {
+  filterSessionSearch,
+  mergeSessionSearchHits,
+  type SessionContentHit,
+} from "@/lib/sessionSearch";
 import {
   sessionExportFilename,
   sessionToMarkdown,
@@ -402,6 +406,12 @@ export default function App() {
   appDialogRef.current = appDialog;
   const [showSearch, setShowSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  /** Debounced journal content hits from `sessions_search`. */
+  const [contentSearchHits, setContentSearchHits] = useState<
+    SessionContentHit[]
+  >([]);
+  const [contentSearchLoading, setContentSearchLoading] = useState(false);
+  const contentSearchSeq = useRef(0);
   const [showComposerPlus, setShowComposerPlus] = useState(false);
   showComposerPlusRef.current = showComposerPlus;
   const composerPlusTriggerRef = useRef<HTMLButtonElement>(null);
@@ -508,6 +518,50 @@ export default function App() {
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [showSearch]);
+
+  // Debounced content search over App journals (title filter stays instant).
+  useEffect(() => {
+    if (!showSearch) {
+      setContentSearchHits([]);
+      setContentSearchLoading(false);
+      return;
+    }
+    const q = searchQuery.trim();
+    if (!q) {
+      setContentSearchHits([]);
+      setContentSearchLoading(false);
+      return;
+    }
+    setContentSearchLoading(true);
+    const seq = ++contentSearchSeq.current;
+    const t = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const hits = await api.sessionsSearch(q, 20);
+          if (contentSearchSeq.current !== seq) return;
+          setContentSearchHits(
+            hits.map((h) => ({
+              id: h.id,
+              title: h.title,
+              projectId: h.projectId,
+              snippet: h.snippet,
+              matchCount: h.matchCount,
+              updatedAt: h.updatedAt,
+              archived: h.archived,
+            })),
+          );
+        } catch {
+          if (contentSearchSeq.current !== seq) return;
+          setContentSearchHits([]);
+        } finally {
+          if (contentSearchSeq.current === seq) {
+            setContentSearchLoading(false);
+          }
+        }
+      })();
+    }, 280);
+    return () => window.clearTimeout(t);
+  }, [searchQuery, showSearch]);
 
   // Global shortcuts: search, help, doctor, new chat, settings.
   // Handlers go through refs so we don't re-bind every render.
@@ -2796,6 +2850,16 @@ export default function App() {
         projects.map((p) => ({ id: p.id, name: p.name, path: p.path })),
       ),
     [searchQuery, sessions, projects],
+  );
+
+  const mergedSessionHits = useMemo(
+    () =>
+      mergeSessionSearchHits(
+        searchQuery,
+        searchHits.matchedSessions,
+        contentSearchHits,
+      ),
+    [searchQuery, searchHits.matchedSessions, contentSearchHits],
   );
 
   const connPill = useMemo(
@@ -7970,33 +8034,58 @@ export default function App() {
             )}
             <div className="search-panel__section">
               {tr("search.chats")}
+              {contentSearchLoading && searchQuery.trim()
+                ? ` · ${tr("search.searchingContent")}`
+                : null}
             </div>
-            {searchHits.matchedSessions.length === 0 && (
+            {mergedSessionHits.length === 0 && !contentSearchLoading && (
               <div className="sidebar-empty" style={{ padding: 12 }}>
                 {tr("search.noMatches")}
               </div>
             )}
-            {searchHits.matchedSessions.map((hit, i) => {
+            {mergedSessionHits.map((hit, i) => {
               const s = sessions.find((x) => x.id === hit.id);
-              if (!s) return null;
-              const proj = projects.find((p) => p.id === s.projectId);
+              // Content-only hits may lack a live row if the list is stale; still open by id.
+              const row: SessionRow = s ?? {
+                id: hit.id,
+                title: hit.title,
+                projectId: hit.projectId ?? null,
+                updatedAt: "",
+              };
+              const proj = projects.find(
+                (p) => p.id === (row.projectId ?? hit.projectId),
+              );
+              const metaParts: string[] = [];
+              if (proj?.name) metaParts.push(proj.name);
+              if (hit.contentMatch && hit.matchCount && hit.matchCount > 0) {
+                metaParts.push(
+                  tr("search.matchCount", { n: String(hit.matchCount) }),
+                );
+              }
+              if (i < 9) metaParts.push(`⌘${i + 1}`);
               return (
                 <button
-                  key={s.id}
+                  key={hit.id}
                   type="button"
                   className="search-panel__row"
                   onClick={() => {
                     setShowSearch(false);
-                    void openSession(s, proj ?? null);
+                    void openSession(row, proj ?? null);
                   }}
                 >
                   <IconSquarePen size={15} />
-                  <span className="search-panel__title">
-                    {s.title || "Untitled"}
+                  <span className="search-panel__body">
+                    <span className="search-panel__title">
+                      {hit.title || s?.title || "Untitled"}
+                    </span>
+                    {hit.snippet ? (
+                      <span className="search-panel__snippet">
+                        {hit.snippet}
+                      </span>
+                    ) : null}
                   </span>
                   <span className="search-panel__meta">
-                    {proj?.name ?? "—"}
-                    {i < 9 ? `  ⌘${i + 1}` : ""}
+                    {metaParts.join(" · ") || "—"}
                   </span>
                 </button>
               );

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -433,12 +433,14 @@ const en = {
 
   // Search panel
   "search.title": "Search",
-  "search.placeholder": "Search chats / projects…",
+  "search.placeholder": "Search chats, projects, or message content…",
   "search.projects": "Projects",
   "search.chats": "Chats",
   "search.noMatches": "No matches",
   "search.newChat": "New chat",
   "search.addProject": "Add project",
+  "search.matchCount": "{n} matches",
+  "search.searchingContent": "Searching messages…",
 
   // Plan card
   "plan.waiting": "Waiting for plan",
@@ -1539,12 +1541,14 @@ const zh: Record<MessageKey, string> = {
   "policy.yoloConfirm2": "再次确认：启用始终批准？工具将不再弹窗询问。",
 
   "search.title": "搜索",
-  "search.placeholder": "搜索会话 / 项目…",
+  "search.placeholder": "搜索会话、项目或消息内容…",
   "search.projects": "项目",
   "search.chats": "会话",
   "search.noMatches": "无匹配结果",
   "search.newChat": "新建会话",
   "search.addProject": "添加项目",
+  "search.matchCount": "{n} 处匹配",
+  "search.searchingContent": "正在搜索消息…",
 
   "plan.waiting": "等待计划",
   "plan.ready": "计划待审阅",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -409,12 +409,14 @@ export const zhTW: Record<MessageKey, string> = {
   "policy.yoloConfirm2": "再次確認：啟用一律核准？工具將不再彈出視窗詢問。",
 
   "search.title": "搜尋",
-  "search.placeholder": "搜尋對話 / 專案…",
+  "search.placeholder": "搜尋對話、專案或訊息內容…",
   "search.projects": "專案",
   "search.chats": "對話",
   "search.noMatches": "無相符結果",
   "search.newChat": "新增對話",
   "search.addProject": "新增專案",
+  "search.matchCount": "{n} 處相符",
+  "search.searchingContent": "正在搜尋訊息…",
 
   "plan.waiting": "等待計劃",
   "plan.ready": "計劃待審閱",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -562,6 +562,30 @@ export async function sessionsList() {
   >("sessions_list");
 }
 
+/** Journal content hit from `sessions_search`. */
+export type SessionContentSearchHit = {
+  id: string;
+  title: string;
+  projectId?: string | null;
+  snippet: string;
+  matchCount: number;
+  updatedAt: string;
+  archived?: boolean;
+};
+
+/**
+ * Scan App session journals for case-insensitive content matches.
+ * Empty query returns []. Caps scan work on the host.
+ */
+export async function sessionsSearch(query: string, limit = 20) {
+  if (!query.trim()) return [] as SessionContentSearchHit[];
+  if (!isTauri()) return [] as SessionContentSearchHit[];
+  return invoke<SessionContentSearchHit[]>("sessions_search", {
+    query,
+    limit,
+  });
+}
+
 /** CLI sessions under GROK_HOME (shared-mode discovery). */
 export type CliSessionSummary = {
   agentSessionId: string;

--- a/src/lib/sessionSearch.test.ts
+++ b/src/lib/sessionSearch.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { filterSessionSearch } from "./sessionSearch";
+import {
+  filterSessionSearch,
+  matchMessageContent,
+  mergeSessionSearchHits,
+} from "./sessionSearch";
 
 const projects = [
   { id: "p1", name: "grok-app", path: "/Users/me/Code/oss/grok-app" },
@@ -46,5 +50,73 @@ describe("filterSessionSearch", () => {
       includeArchived: true,
     });
     expect(hits.matchedSessions.map((s) => s.id)).toEqual(["s4"]);
+  });
+});
+
+describe("matchMessageContent", () => {
+  const messages = [
+    { role: "user", content: "Please fix the Doctor reset button" },
+    { role: "assistant", content: "Sure, I will patch doctor later." },
+    { role: "system", content: "doctor should be ignored" },
+    { role: "user", content: "unrelated" },
+  ];
+
+  it("returns null for empty query", () => {
+    expect(matchMessageContent("", messages)).toBeNull();
+    expect(matchMessageContent("  ", messages)).toBeNull();
+  });
+
+  it("matches case-insensitively and skips non user/assistant", () => {
+    const hit = matchMessageContent("doctor", messages);
+    expect(hit).not.toBeNull();
+    expect(hit!.matchCount).toBe(2);
+    expect(hit!.snippet.toLowerCase()).toContain("doctor");
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(matchMessageContent("zzzz", messages)).toBeNull();
+  });
+});
+
+describe("mergeSessionSearchHits", () => {
+  it("keeps title hits first and attaches content snippets", () => {
+    const title = [{ id: "s1", title: "Fix doctor reset", projectId: "p1" }];
+    const content = [
+      {
+        id: "s1",
+        title: "Fix doctor reset",
+        projectId: "p1",
+        snippet: "…fix the Doctor…",
+        matchCount: 2,
+      },
+      {
+        id: "s9",
+        title: "Other chat",
+        projectId: null,
+        snippet: "body mentions doctor",
+        matchCount: 1,
+      },
+    ];
+    const merged = mergeSessionSearchHits("doctor", title, content);
+    expect(merged.map((h) => h.id)).toEqual(["s1", "s9"]);
+    expect(merged[0].titleMatch).toBe(true);
+    expect(merged[0].contentMatch).toBe(true);
+    expect(merged[0].snippet).toContain("Doctor");
+    expect(merged[1].titleMatch).toBe(false);
+    expect(merged[1].matchCount).toBe(1);
+  });
+
+  it("empty query does not append content-only rows", () => {
+    const title = [{ id: "s1", title: "A", projectId: null }];
+    const content = [
+      {
+        id: "s9",
+        title: "B",
+        snippet: "x",
+        matchCount: 3,
+      },
+    ];
+    const merged = mergeSessionSearchHits("", title, content);
+    expect(merged.map((h) => h.id)).toEqual(["s1"]);
   });
 });

--- a/src/lib/sessionSearch.ts
+++ b/src/lib/sessionSearch.ts
@@ -13,9 +13,34 @@ export type SearchableProject = {
   path: string;
 };
 
+/** Content hit from journal scan (`sessions_search`). */
+export type SessionContentHit = {
+  id: string;
+  title: string;
+  projectId?: string | null;
+  snippet: string;
+  matchCount: number;
+  updatedAt?: string;
+  archived?: boolean;
+};
+
 export type SessionSearchHits = {
   matchedSessions: SearchableSession[];
   matchedProjects: SearchableProject[];
+};
+
+/** Palette row: title/project hit and/or content match. */
+export type MergedSessionHit = {
+  id: string;
+  title: string;
+  projectId?: string | null;
+  /** First content snippet when the journal matched. */
+  snippet?: string;
+  matchCount?: number;
+  /** True when title/id/project matched the query. */
+  titleMatch: boolean;
+  /** True when message body matched. */
+  contentMatch: boolean;
 };
 
 /**
@@ -77,4 +102,120 @@ export function filterSessionSearch(
     .slice(0, maxSessions);
 
   return { matchedSessions, matchedProjects };
+}
+
+/**
+ * Pure content matcher: case-insensitive substring over user/assistant texts.
+ * Returns match count (messages that hit) and a short snippet from the first hit.
+ * Used for unit tests; runtime search scans on the host via `sessions_search`.
+ */
+export function matchMessageContent(
+  query: string,
+  messages: Array<{ role: string; content: string }>,
+  opts?: { snippetRadius?: number; snippetMax?: number },
+): { matchCount: number; snippet: string } | null {
+  const q = query.trim().toLowerCase();
+  if (!q) return null;
+
+  const radius = opts?.snippetRadius ?? 48;
+  const maxLen = opts?.snippetMax ?? 120;
+  let matchCount = 0;
+  let snippet: string | undefined;
+
+  for (const m of messages) {
+    if (m.role !== "user" && m.role !== "assistant") continue;
+    const content = m.content ?? "";
+    if (!content) continue;
+    const lower = content.toLowerCase();
+    const idx = lower.indexOf(q);
+    if (idx < 0) continue;
+    matchCount += 1;
+    if (snippet === undefined) {
+      snippet = makeContentSnippet(content, idx, q.length, radius, maxLen);
+    }
+  }
+
+  if (matchCount === 0) return null;
+  return { matchCount, snippet: snippet ?? "" };
+}
+
+/** Single-line snippet around a match index (character-based). */
+export function makeContentSnippet(
+  content: string,
+  matchIndex: number,
+  matchLen: number,
+  radius = 48,
+  maxLen = 120,
+): string {
+  const start = Math.max(0, matchIndex - radius);
+  const end = Math.min(content.length, matchIndex + matchLen + radius + 16);
+  let slice = content.slice(start, end);
+  if (start > 0) slice = `…${slice}`;
+  if (end < content.length) slice = `${slice}…`;
+  const collapsed = slice.split(/\s+/).filter(Boolean).join(" ");
+  if (collapsed.length <= maxLen) return collapsed;
+  return `${collapsed.slice(0, Math.max(0, maxLen - 1))}…`;
+}
+
+/**
+ * Merge title/project hits with journal content hits for the palette.
+ * Title matches first; content-only rows append. Empty query → title list only.
+ */
+export function mergeSessionSearchHits(
+  query: string,
+  titleHits: SearchableSession[],
+  contentHits: SessionContentHit[],
+  opts?: { maxSessions?: number; includeArchived?: boolean },
+): MergedSessionHit[] {
+  const maxSessions = opts?.maxSessions ?? 20;
+  const includeArchived = opts?.includeArchived ?? false;
+  const q = query.trim();
+
+  const contentById = new Map<string, SessionContentHit>();
+  for (const h of contentHits) {
+    if (!includeArchived && h.archived) continue;
+    contentById.set(h.id, h);
+  }
+
+  const out: MergedSessionHit[] = [];
+  const seen = new Set<string>();
+
+  for (const s of titleHits) {
+    if (!includeArchived && s.archived) continue;
+    const c = contentById.get(s.id);
+    out.push({
+      id: s.id,
+      title: s.title,
+      projectId: s.projectId,
+      snippet: c?.snippet,
+      matchCount: c?.matchCount,
+      titleMatch: q.length > 0,
+      contentMatch: !!c,
+    });
+    seen.add(s.id);
+    if (out.length >= maxSessions) return out;
+  }
+
+  if (!q) return out;
+
+  // Content-only: prefer higher match counts, then original order.
+  const contentOnly = contentHits
+    .filter((h) => !seen.has(h.id) && (includeArchived || !h.archived))
+    .slice()
+    .sort((a, b) => (b.matchCount ?? 0) - (a.matchCount ?? 0));
+
+  for (const h of contentOnly) {
+    out.push({
+      id: h.id,
+      title: h.title,
+      projectId: h.projectId,
+      snippet: h.snippet,
+      matchCount: h.matchCount,
+      titleMatch: false,
+      contentMatch: true,
+    });
+    if (out.length >= maxSessions) break;
+  }
+
+  return out;
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -882,6 +882,14 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   color: var(--text-primary);
 }
 
+.search-panel__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 .search-panel__title {
   flex: 1;
   min-width: 0;
@@ -891,6 +899,15 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   color: inherit;
 }
 
+.search-panel__snippet {
+  font-size: 11px;
+  line-height: 1.3;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .search-panel__meta {
   font-size: 11px;
   color: var(--text-tertiary);
@@ -898,6 +915,7 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .search-panel__foot {


### PR DESCRIPTION
## Problem
Sidebar / command palette search only matched session titles, ids, and project name/path. Chats whose useful text lived only in the journal were hard to find. CLI has `grok sessions search`; the App did not.

## Changes
- Host command `sessions_search(query, limit)` scans App journal `messages.json` for case-insensitive substrings in user/assistant content
- Returns session id, title, projectId, snippet, match count, updatedAt
- Work caps: 200 sessions max scan, skip files > 2 MiB, result limit default 20 (max 50); archived sessions skipped
- Pure matcher + snippet helpers with Rust unit tests
- Palette: debounced content search (~280ms); empty query keeps the normal recent list
- Content hits show a snippet line under the title and “N matches” in the meta column; click opens the session
- Title/project hits still win and get snippets attached when the journal also matches
- i18n en + zh + zh-TW (`search.matchCount`, `search.searchingContent`, updated placeholder)
- TS pure matcher / merge helpers + vitest coverage

Out of scope for v1: CLI shared-mode session roots (App journal only).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (includes `sessionSearch` matcher/merge tests)
- [x] `cargo test session_content_search` (6 unit tests)
- [ ] Manual: open search palette, type a word that appears only in message body → session listed with snippet; click opens chat
- [ ] Manual: empty query still shows recent chats/projects
- [ ] Manual: title-only match still works without waiting for content scan