### PR TITLE
feat: install and update plugins from Settings → Extensions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1730,6 +1730,8 @@ pub async fn extensions_enable_all_skills(
 // Do not invent a parallel store or rewrite CLI `status` values.
 
 const PLUGIN_CMD_TIMEOUT_SECS: u64 = 30;
+/// Install / update pull git or marketplace cache; allow longer than enable/list.
+const PLUGIN_MUTATE_TIMEOUT_SECS: u64 = 180;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -2321,6 +2323,97 @@ pub async fn plugin_details(name: String) -> Result<serde_json::Value, String> {
     }))
 }
 
+/// Trim install source; reject empty. Accepts path, git URL, or GitHub shorthand.
+pub fn normalize_plugin_install_source(source: &str) -> Result<String, String> {
+    let s = source.trim();
+    if s.is_empty() {
+        return Err("plugin source required".into());
+    }
+    Ok(s.to_string())
+}
+
+/// Optional update target: empty / whitespace → update all (`None`).
+pub fn normalize_plugin_update_name(name: Option<&str>) -> Option<String> {
+    name.map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Install from path / git URL / GitHub shorthand (`grok plugin install <source> --trust`).
+/// Soft-respawns agent on success. `--trust` is required for non-interactive UI.
+#[tauri::command]
+pub async fn plugin_install(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    source: String,
+) -> Result<serde_json::Value, String> {
+    let source = normalize_plugin_install_source(&source)?;
+    let source_for_cmd = source.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        run_grok_cli_args(
+            &["plugin", "install", &source_for_cmd, "--trust"],
+            PLUGIN_MUTATE_TIMEOUT_SECS,
+        )
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    let (stdout, stderr, ok) = result;
+    if !ok {
+        let msg = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("failed to install plugin from {source}")
+        };
+        return Err(msg.chars().take(400).collect());
+    }
+    mgr.soft_respawn(&app).await;
+    Ok(serde_json::json!({
+        "ok": true,
+        "name": source,
+        "message": stdout.chars().take(400).collect::<String>(),
+    }))
+}
+
+/// Update one plugin by name, or all when `name` is null/empty (`grok plugin update [name]`).
+/// Soft-respawns agent on success.
+#[tauri::command]
+pub async fn plugin_update(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    name: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let target = normalize_plugin_update_name(name.as_deref());
+    let target_for_cmd = target.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || match target_for_cmd.as_deref() {
+        Some(n) => run_grok_cli_args(&["plugin", "update", n], PLUGIN_MUTATE_TIMEOUT_SECS),
+        None => run_grok_cli_args(&["plugin", "update"], PLUGIN_MUTATE_TIMEOUT_SECS),
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    let (stdout, stderr, ok) = result;
+    if !ok {
+        let label = target.as_deref().unwrap_or("all");
+        let msg = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("failed to update plugin(s): {label}")
+        };
+        return Err(msg.chars().take(400).collect());
+    }
+    mgr.soft_respawn(&app).await;
+    Ok(serde_json::json!({
+        "ok": true,
+        "name": target.unwrap_or_default(),
+        "message": stdout.chars().take(400).collect::<String>(),
+    }))
+}
+
 #[cfg(test)]
 mod plugin_config_tests {
     use super::*;
@@ -2429,6 +2522,35 @@ disabled = ["yes"]
         assert_eq!(plugins[0].provides.as_ref().unwrap().skills, 14);
         assert!(plugins[0].provides.as_ref().unwrap().hooks);
         assert!(plugins[0].enabled);
+    }
+
+    #[test]
+    fn normalize_install_source_trims_and_rejects_empty() {
+        assert_eq!(
+            normalize_plugin_install_source("  owner/repo  ").unwrap(),
+            "owner/repo"
+        );
+        assert_eq!(
+            normalize_plugin_install_source("https://github.com/a/b.git").unwrap(),
+            "https://github.com/a/b.git"
+        );
+        assert_eq!(
+            normalize_plugin_install_source("/tmp/my-plugin").unwrap(),
+            "/tmp/my-plugin"
+        );
+        assert!(normalize_plugin_install_source("").is_err());
+        assert!(normalize_plugin_install_source("   ").is_err());
+    }
+
+    #[test]
+    fn normalize_update_name_empty_means_all() {
+        assert_eq!(
+            normalize_plugin_update_name(Some("  chrome-devtools-mcp ")).as_deref(),
+            Some("chrome-devtools-mcp")
+        );
+        assert_eq!(normalize_plugin_update_name(Some("")), None);
+        assert_eq!(normalize_plugin_update_name(Some("   ")), None);
+        assert_eq!(normalize_plugin_update_name(None), None);
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -195,6 +195,8 @@ pub fn run() {
             commands::plugin_disable,
             commands::plugin_uninstall,
             commands::plugin_details,
+            commands::plugin_install,
+            commands::plugin_update,
             commands::pick_directory,
             commands::pick_attach_files,
             commands::pick_attach_folder,

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -1,7 +1,7 @@
 /**
  * Settings → Extensions: Skills + MCP + Plugins.
  * Skills/MCP from `grok inspect` with enable toggles (extensions.json / ACP inject).
- * Plugins from `grok plugin list/enable/…` (config.toml disabled list).
+ * Plugins from `grok plugin list/install/update/…` (config.toml disabled list).
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -23,6 +23,7 @@ import {
   isExtensionEnabled,
   mcpMetaLine,
   mergeInspectErrors,
+  normalizePluginInstallSource,
   pluginMetaLine,
   pluginProvidesLine,
   pluginRowKey,
@@ -78,6 +79,7 @@ export function ExtensionsPanel({
   const [detailsLoading, setDetailsLoading] = useState(false);
   /** Grok Build Plugins tab filter: all | enabled | disabled */
   const [pluginFilter, setPluginFilter] = useState<PluginFilter>("all");
+  const [installSource, setInstallSource] = useState("");
 
   const refresh = useCallback(async () => {
     if (!api.isTauri()) {
@@ -268,6 +270,35 @@ export function ExtensionsPanel({
     });
   };
 
+  const installPlugin = async () => {
+    if (!api.isTauri() || actionBusy || cliMissing) return;
+    const source = normalizePluginInstallSource(installSource);
+    if (!source) {
+      setActionError(tr("ext.plugins.installEmpty"));
+      return;
+    }
+    await runPluginAction("install", async () => {
+      await api.pluginInstall(source);
+      setInstallSource("");
+    });
+  };
+
+  const updatePlugin = (p: api.PluginDto) => {
+    const key = `update:${pluginRowKey(p)}`;
+    void runPluginAction(key, async () => {
+      await api.pluginUpdate(p.name);
+    });
+  };
+
+  const updateAllPlugins = () => {
+    if (!api.isTauri() || actionBusy || cliMissing || plugins.length === 0) {
+      return;
+    }
+    void runPluginAction("update:all", async () => {
+      await api.pluginUpdate(null);
+    });
+  };
+
   const showDetails = async (p: api.PluginDto) => {
     setDetailsTitle(p.name);
     setDetailsBody("");
@@ -392,8 +423,59 @@ export function ExtensionsPanel({
         {!loading ? (
           <span className="ext-count">{plugins.length}</span>
         ) : null}
+        {!loading && plugins.length > 0 ? (
+          <button
+            type="button"
+            className="btn btn--ghost ext-bulk-btn"
+            disabled={!!actionBusy || !!busyKey || cliMissing}
+            onClick={() => updateAllPlugins()}
+          >
+            {actionBusy === "update:all"
+              ? tr("ext.plugins.updating")
+              : tr("ext.plugins.updateAll")}
+          </button>
+        ) : null}
       </h2>
       <div className="settings-card ext-card">
+        <div className="ext-plugin-install">
+          <label className="ext-plugin-install__label" htmlFor="ext-plugin-source">
+            {tr("ext.plugins.installLabel")}
+          </label>
+          <div className="ext-plugin-install__row">
+            <input
+              id="ext-plugin-source"
+              type="text"
+              className="settings-input ext-plugin-install__input"
+              value={installSource}
+              placeholder={tr("ext.plugins.installPlaceholder")}
+              disabled={!!actionBusy || cliMissing}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(e) => setInstallSource(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void installPlugin();
+                }
+              }}
+            />
+            <button
+              type="button"
+              className="btn btn--solid btn--sm"
+              disabled={
+                !!actionBusy ||
+                cliMissing ||
+                !normalizePluginInstallSource(installSource)
+              }
+              onClick={() => void installPlugin()}
+            >
+              {actionBusy === "install"
+                ? tr("ext.plugins.installing")
+                : tr("ext.plugins.install")}
+            </button>
+          </div>
+          <p className="ext-plugin-install__hint">{tr("ext.plugins.installHint")}</p>
+        </div>
         {!loading && plugins.length > 0 ? (
           <div
             className="ext-plugin-filters"
@@ -435,7 +517,9 @@ export function ExtensionsPanel({
           <ul className="ext-list">
             {visiblePlugins.map((p) => {
               const key = pluginRowKey(p);
-              const busy = actionBusy === key;
+              const rowBusy = actionBusy === key;
+              const updating = actionBusy === `update:${key}`;
+              const busy = rowBusy || updating;
               const tone = pluginStatusTone(p.status, p.enabled);
               const meta = pluginMetaLine(p);
               const provides = pluginProvidesLine(p);
@@ -491,11 +575,21 @@ export function ExtensionsPanel({
                       disabled={busy || !!actionBusy}
                       onClick={() => togglePlugin(p)}
                     >
-                      {busy
+                      {rowBusy
                         ? tr("ext.plugins.working")
                         : p.enabled
                           ? tr("ext.plugins.disable")
                           : tr("ext.plugins.enable")}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm"
+                      disabled={busy || !!actionBusy || cliMissing}
+                      onClick={() => updatePlugin(p)}
+                    >
+                      {updating
+                        ? tr("ext.plugins.updating")
+                        : tr("ext.plugins.update")}
                     </button>
                     <button
                       type="button"
@@ -520,7 +614,7 @@ export function ExtensionsPanel({
             })}
           </ul>
         )}
-        {!loading && plugins.length > 0 ? (
+        {!loading ? (
           <p className="ext-section-note">{tr("ext.plugins.note")}</p>
         ) : null}
       </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -977,8 +977,19 @@ const en = {
   "ext.plugins.filter.enabled": "Enabled",
   "ext.plugins.filter.disabled": "Disabled",
   "ext.plugins.filterEmpty": "No plugins match this filter.",
+  "ext.plugins.installLabel": "Install plugin",
+  "ext.plugins.installPlaceholder":
+    "Local path, git URL, or owner/repo[@ref]",
+  "ext.plugins.install": "Install",
+  "ext.plugins.installing": "Installing…",
+  "ext.plugins.installHint":
+    "Uses `grok plugin install --trust` (path, git URL, or GitHub shorthand). Not a full marketplace browser.",
+  "ext.plugins.installEmpty": "Enter a path, git URL, or owner/repo to install.",
+  "ext.plugins.update": "Update",
+  "ext.plugins.updateAll": "Update all",
+  "ext.plugins.updating": "Updating…",
   "ext.plugins.note":
-    "Same inventory as Grok Build (`grok plugin list`). Enable/disable writes `~/.grok/config.toml`; the agent soft-respawns so the next turn reloads plugins.",
+    "Same inventory as Grok Build (`grok plugin list`). Install/update/enable/disable call the CLI; enable state lives in `~/.grok/config.toml`. The agent soft-respawns after mutations so the next turn reloads plugins.",
   "ext.skills.title": "Skills",
   "ext.skills.loading": "Loading skills…",
   "ext.skills.empty": "No skills discovered",
@@ -993,7 +1004,7 @@ const en = {
   "ext.disabled": "Disabled",
   "ext.enableAll": "Enable all",
   "ext.footnote":
-    "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Plugin marketplace install remains CLI-only.",
+    "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Plugin install accepts path/git/GitHub shorthand; full marketplace browse stays CLI-only.",
 
   // Errors / misc
   "error.needTauri": "Folder picker requires the Tauri window",
@@ -2070,8 +2081,18 @@ const zh: Record<MessageKey, string> = {
   "ext.plugins.filter.enabled": "已启用",
   "ext.plugins.filter.disabled": "已禁用",
   "ext.plugins.filterEmpty": "没有符合筛选条件的插件。",
+  "ext.plugins.installLabel": "安装插件",
+  "ext.plugins.installPlaceholder": "本地路径、git URL 或 owner/repo[@ref]",
+  "ext.plugins.install": "安装",
+  "ext.plugins.installing": "正在安装…",
+  "ext.plugins.installHint":
+    "调用 `grok plugin install --trust`（路径、git URL 或 GitHub 简写）。不是完整的市场浏览界面。",
+  "ext.plugins.installEmpty": "请输入路径、git URL 或 owner/repo。",
+  "ext.plugins.update": "更新",
+  "ext.plugins.updateAll": "全部更新",
+  "ext.plugins.updating": "正在更新…",
   "ext.plugins.note":
-    "与 Grok Build 共用同一清单（`grok plugin list`）。启用/禁用写入 `~/.grok/config.toml`；agent soft-respawn 后下一轮对话重新加载插件。",
+    "与 Grok Build 共用同一清单（`grok plugin list`）。安装/更新/启用/禁用走 CLI；启用状态写入 `~/.grok/config.toml`。变更后 agent soft-respawn，下一轮对话重新加载插件。",
   "ext.skills.title": "技能",
   "ext.skills.loading": "正在加载技能…",
   "ext.skills.empty": "未发现技能",
@@ -2086,7 +2107,7 @@ const zh: Record<MessageKey, string> = {
   "ext.disabled": "已禁用",
   "ext.enableAll": "全部启用",
   "ext.footnote":
-"开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。",
+    "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。插件安装支持路径/git/GitHub 简写；完整市场浏览仍仅 CLI。",
   "error.needTauri": "需要在 Tauri 窗口中选择目录",
   "common.comingSoon": "即将推出",
   "common.local": "本地",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -939,8 +939,18 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.plugins.filter.enabled": "已啟用",
   "ext.plugins.filter.disabled": "已停用",
   "ext.plugins.filterEmpty": "沒有符合篩選條件的外掛。",
+  "ext.plugins.installLabel": "安裝外掛",
+  "ext.plugins.installPlaceholder": "本機路徑、git URL 或 owner/repo[@ref]",
+  "ext.plugins.install": "安裝",
+  "ext.plugins.installing": "正在安裝…",
+  "ext.plugins.installHint":
+    "呼叫 `grok plugin install --trust`（路徑、git URL 或 GitHub 簡寫）。不是完整的市集瀏覽介面。",
+  "ext.plugins.installEmpty": "請輸入路徑、git URL 或 owner/repo。",
+  "ext.plugins.update": "更新",
+  "ext.plugins.updateAll": "全部更新",
+  "ext.plugins.updating": "正在更新…",
   "ext.plugins.note":
-    "與 Grok Build 共用同一清單（`grok plugin list`）。啟用/停用寫入 `~/.grok/config.toml`；agent soft-respawn 後下一輪對話重新載入外掛。",
+    "與 Grok Build 共用同一清單（`grok plugin list`）。安裝/更新/啟用/停用走 CLI；啟用狀態寫入 `~/.grok/config.toml`。變更後 agent soft-respawn，下一輪對話重新載入外掛。",
   "ext.skills.title": "技能",
   "ext.skills.loading": "正在載入技能…",
   "ext.skills.empty": "未發現技能",
@@ -955,7 +965,7 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.disabled": "已停用",
   "ext.enableAll": "全部啟用",
   "ext.footnote":
-"開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。",
+    "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。外掛安裝支援路徑/git/GitHub 簡寫；完整市集瀏覽仍僅 CLI。",
   "error.needTauri": "需要在 Tauri 視窗中選擇目錄",
   "common.comingSoon": "即將推出",
   "common.local": "本機",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1058,6 +1058,25 @@ export async function pluginDetails(name: string) {
   return invoke<PluginDetailsResult>("plugin_details", { name });
 }
 
+/**
+ * Install from path, git URL, or GitHub shorthand (`grok plugin install --trust`).
+ * Soft-respawns agent on success.
+ */
+export async function pluginInstall(source: string) {
+  return invoke<PluginActionResult>("plugin_install", { source });
+}
+
+/**
+ * Update one plugin by name, or all when name is omitted/null/empty.
+ * Soft-respawns agent on success.
+ */
+export async function pluginUpdate(name?: string | null) {
+  const n = (name ?? "").trim();
+  return invoke<PluginActionResult>("plugin_update", {
+    name: n ? n : null,
+  });
+}
+
 // ── Official Grok Build account ─────────────────────────────────────────────
 
 export interface AccountProfile {

--- a/src/lib/extensionsUi.test.ts
+++ b/src/lib/extensionsUi.test.ts
@@ -8,6 +8,8 @@ import {
   mergeEnableSet,
   mergeInspectErrors,
   mcpMetaLine,
+  normalizePluginInstallSource,
+  normalizePluginUpdateName,
   normalizeSkillSource,
   pluginLoadLabel,
   pluginMetaLine,
@@ -254,5 +256,20 @@ describe("plugin helpers", () => {
     expect(filterPluginsByLoadState(rows, "disabled").map((p) => p.name)).toEqual([
       "b",
     ]);
+  });
+
+  it("normalizes install source and update name", () => {
+    expect(normalizePluginInstallSource("  owner/repo  ")).toBe("owner/repo");
+    expect(
+      normalizePluginInstallSource("https://github.com/a/b.git"),
+    ).toBe("https://github.com/a/b.git");
+    expect(normalizePluginInstallSource("/tmp/plugin")).toBe("/tmp/plugin");
+    expect(normalizePluginInstallSource("")).toBeNull();
+    expect(normalizePluginInstallSource("   ")).toBeNull();
+    expect(normalizePluginInstallSource(null)).toBeNull();
+
+    expect(normalizePluginUpdateName("  demo ")).toBe("demo");
+    expect(normalizePluginUpdateName("")).toBeNull();
+    expect(normalizePluginUpdateName(undefined)).toBeNull();
   });
 });

--- a/src/lib/extensionsUi.ts
+++ b/src/lib/extensionsUi.ts
@@ -272,3 +272,24 @@ export function filterPluginsByLoadState<T extends { enabled?: boolean }>(
   if (filter === "disabled") return plugins.filter((p) => p.enabled === false);
   return plugins;
 }
+
+/**
+ * Normalize `grok plugin install <source>` input (path, git URL, owner/repo).
+ * Empty / whitespace → null.
+ */
+export function normalizePluginInstallSource(
+  raw: string | null | undefined,
+): string | null {
+  const s = (raw ?? "").trim();
+  return s ? s : null;
+}
+
+/**
+ * Normalize optional update target. Empty → null meaning "update all".
+ */
+export function normalizePluginUpdateName(
+  raw: string | null | undefined,
+): string | null {
+  const s = (raw ?? "").trim();
+  return s ? s : null;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11312,6 +11312,39 @@ div.composer__input:empty::before {
   max-width: 100%;
 }
 
+.ext-plugin-install {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ext-plugin-install__label {
+  font-size: 12.5px;
+  font-weight: 560;
+  color: var(--text-primary);
+}
+
+.ext-plugin-install__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.ext-plugin-install__input {
+  flex: 1;
+  min-width: 0;
+}
+
+.ext-plugin-install__hint {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--text-tertiary);
+}
+
 .ext-plugin-filters {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Problem
Settings → Extensions already lists plugins and can enable / disable / uninstall / show details, but install and update still required dropping to the CLI.

## Changes
- Tauri commands `plugin_install` / `plugin_update` wrap `grok plugin install <source> --trust` and `grok plugin update [name]` (omit name = all), with a longer timeout for git pulls
- Soft-respawn the agent after successful install/update, same as enable/uninstall
- Extensions panel: install field + button; per-row Update; Update all when the list is non-empty
- Install/update disabled with clear banner when the CLI is missing
- i18n en + zh + zh-TW
- Light tests for source/name normalize helpers (TS + Rust)

## How to test
- [x] `pnpm typecheck`
- [x] `pnpm test` (includes `normalizePluginInstallSource` / update name)
- [x] `cargo test plugin_config` (includes install/update normalize)
- [ ] App: Settings → Extensions → paste a local path or `owner/repo` → Install → list refreshes
- [ ] Per-row Update and Update all succeed (or show CLI stderr)
- [ ] With CLI path broken / CLI not found: install UI disabled and existing CLI error banner still shows

## Notes
Not a marketplace browser — path / git URL / GitHub shorthand only, matching `grok plugin install`.