### PR TITLE
fix: recycle agents when session data mode changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Session data mode switch**: flipping independent↔shared recycles live, background, and parked agents so none keep the old `GROK_HOME`; toast when agents restart. Import still never forces shared mode (E04/E05).
+
 ## [0.1.6] - 2026-07-24
 
 > **Highlight:** early-turn fix (#52), multi-session stream, shared-mode CLI import, store write locks.

--- a/docs/llm-wiki/session-continuity.md
+++ b/docs/llm-wiki/session-continuity.md
@@ -35,6 +35,10 @@ This covers load failure, wiped agent dirs, or agent version mismatches.
 
 Permission / mode soft-respawn **keeps** `agentSessionId` so the next connect prefers `session/load`. Bootstrap runs only if load fails.
 
+### 3b. Session data mode switch (E04)
+
+When Settings flips `session_data_mode` independent↔shared, Host calls `recycle_all_agents` on live + background + parked processes (same kill/soft-disconnect paths as idle recycle). Live `agentSessionId` is cleared so reconnect does not `session/load` against the previous `GROK_HOME`. Journals stay. Emits `session://agents_recycled` for a short toast.
+
 ### 4. Process limits & idle recycle (I01–I03)
 
 | Setting | Default | Behavior |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -597,6 +597,8 @@ pub async fn settings_set(
     let prev = store::load_settings();
     let keychain_flip =
         prev.store_api_keys_in_keychain != settings.store_api_keys_in_keychain;
+    let session_data_mode_changed =
+        prev.session_data_mode != settings.session_data_mode;
 
     store::save_settings(&settings)?;
 
@@ -610,6 +612,12 @@ pub async fn settings_set(
             let _ = store::save_settings(&rolled);
             return Err(e);
         }
+    }
+
+    // independent↔shared changes GROK_HOME — kill live/background/parked agents
+    // so the next connect spawns under the new data root (E04).
+    if session_data_mode_changed {
+        mgr.recycle_all_agents(&app, "session_data_mode").await;
     }
 
     // Full permission apply: Host + agent-home + soft-respawn if needed
@@ -967,6 +975,12 @@ pub async fn provider_ping() -> Result<serde_json::Value, String> {
     }
 }
 
+/// Mark onboarding complete after a config import. Never flips `session_data_mode`
+/// (E05: import ≠ shared — user must switch mode explicitly).
+fn apply_import_onboarding_done(settings: &mut AppSettings) {
+    settings.onboarding_done = true;
+}
+
 #[tauri::command]
 pub async fn import_grok_cli_config() -> Result<serde_json::Value, String> {
     let home = crate::process_util::user_home();
@@ -982,7 +996,7 @@ pub async fn import_grok_cli_config() -> Result<serde_json::Value, String> {
         msg.push("Found ~/.grok/config.toml".to_string());
     }
     let mut settings = store::load_settings();
-    settings.onboarding_done = true;
+    apply_import_onboarding_done(&mut settings);
     store::save_settings(&settings)?;
     Ok(serde_json::json!({
         "ok": auth.is_file(),
@@ -1030,7 +1044,7 @@ pub async fn import_grok_go_config() -> Result<serde_json::Value, String> {
             }
             store::save_secrets(&secrets)?;
             let mut settings = store::load_settings();
-            settings.onboarding_done = true;
+            apply_import_onboarding_done(&mut settings);
             store::save_settings(&settings)?;
             return Ok(serde_json::json!({
                 "ok": true,
@@ -1040,6 +1054,27 @@ pub async fn import_grok_go_config() -> Result<serde_json::Value, String> {
         }
     }
     Err("grok-go config not found in known locations".into())
+}
+
+#[cfg(test)]
+mod import_settings_tests {
+    use super::*;
+
+    #[test]
+    fn import_onboarding_does_not_force_shared_mode() {
+        // E05: import_grok_* must not flip session_data_mode to shared.
+        let mut s = AppSettings::default();
+        assert_eq!(s.session_data_mode, "independent");
+        s.onboarding_done = false;
+        apply_import_onboarding_done(&mut s);
+        assert!(s.onboarding_done);
+        assert_eq!(s.session_data_mode, "independent");
+
+        // If user already chose shared, import still leaves it alone.
+        s.session_data_mode = "shared".into();
+        apply_import_onboarding_done(&mut s);
+        assert_eq!(s.session_data_mode, "shared");
+    }
 }
 
 /// Structured Doctor check row (UI consumes `checks`; `raw` is for copy/export).

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -3230,6 +3230,124 @@ impl SessionManager {
         }
     }
 
+    /// Counts of tracked live shell / background / parked entries (alive or not).
+    /// Used by diagnostics and unit tests — not the same as `active_process_count`.
+    pub fn tracked_agent_map_counts(&self) -> (usize, usize, usize) {
+        let live = self.inner.lock().is_some() as usize;
+        let background = self.background.lock().len();
+        let parked = self.parked.lock().len();
+        (live, background, parked)
+    }
+
+    /// Drop every warm agent process (live + background + parked).
+    ///
+    /// Used when `session_data_mode` flips independent↔shared so no process keeps
+    /// the previous `GROK_HOME`. App session meta + journals stay; live shell is
+    /// soft-disconnected and its `agent_session_id` is cleared (old agent dirs are
+    /// under a different data root — reconnect should `session/new` + bootstrap).
+    /// Emits `session://agents_recycled` for UI toasts.
+    pub async fn recycle_all_agents(&self, app: &AppHandle, reason: &str) {
+        let drained = self.drain_all_agent_slots();
+        let total = drained.acps.len();
+        for acp in drained.acps {
+            acp.kill().await;
+        }
+        tracing::info!(
+            "recycle_all_agents reason={reason} killed={total} (live_shell={} bg={} parked={})",
+            drained.had_live_shell as u8,
+            drained.background_count,
+            drained.parked_count
+        );
+        let _ = app.emit(
+            "session://agents_recycled",
+            serde_json::json!({
+                "reason": reason,
+                "killed": total,
+                "background": drained.background_count,
+                "parked": drained.parked_count,
+            }),
+        );
+        Self::emit_state(app, &self.snapshot());
+    }
+
+    /// Take live ACP + all background/parked agents out of maps (no kill).
+    /// Live shell stays (soft-disconnected, agent_session_id cleared when present).
+    /// Background/parked maps are emptied.
+    fn drain_all_agent_slots(&self) -> DrainedAgents {
+        let mut acps: Vec<Arc<AcpClient>> = Vec::new();
+        let mut had_live_shell = false;
+
+        // Live
+        {
+            let mut guard = self.inner.lock();
+            if let Some(s) = guard.as_mut() {
+                had_live_shell = true;
+                if let Some(h) = s.mock_stream.take() {
+                    h.request_stop();
+                }
+                // Persist any in-flight assistant text before we drop the process.
+                Self::maybe_flush_stream_journal(s, true, false);
+                s.stream_buf.clear();
+                s.stream_thought.clear();
+                s.stream_last_was_assistant = false;
+                s.stream_attachments.clear();
+                s.journal_throttle.reset();
+                s.streaming_message_id = None;
+                s.open_tool_ids.clear();
+                s.deferred_prompt_complete = None;
+                s.tools_this_turn = 0;
+                s.pending_plan_rpc_id = None;
+                s.pending_ask_user_rpc_id = None;
+                s.provider_retry_attempt = 0;
+                s.provider_retry_aborted = false;
+                if let Some(acp) = s.acp.take() {
+                    acps.push(acp);
+                }
+                s.fsm.soft_disconnect();
+                s.process_id = String::new();
+                // Old agent session lives under previous GROK_HOME — do not resume.
+                if s.meta.agent_session_id.take().is_some() {
+                    let _ = store::update_session_meta(&s.meta);
+                }
+                // Connect will set bootstrap from journal when session/new runs.
+                s.needs_history_bootstrap = false;
+            }
+        }
+
+        // Background busy streams
+        let background: HashMap<String, LiveSession> = {
+            let mut bg = self.background.lock();
+            std::mem::take(&mut *bg)
+        };
+        let background_count = background.len();
+        for (_, mut s) in background {
+            if let Some(h) = s.mock_stream.take() {
+                h.request_stop();
+            }
+            Self::maybe_flush_stream_journal(&mut s, true, false);
+            if let Some(acp) = s.acp.take() {
+                acps.push(acp);
+            }
+        }
+
+        // Parked warm agents
+        let parked: HashMap<String, ParkedAgent> = {
+            let mut p = self.parked.lock();
+            std::mem::take(&mut *p)
+        };
+        let parked_count = parked.len();
+        for (_, p) in parked {
+            acps.push(p.acp);
+        }
+
+        DrainedAgents {
+            acps,
+            had_live_shell,
+            background_count,
+            parked_count,
+        }
+    }
+
     /// Apply permission: Host policy + agent-home config + respawn when process flags change.
     pub async fn apply_permission_policy(
         &self,
@@ -3537,5 +3655,39 @@ impl SessionManager {
             }
         };
         self.connect(app, project, sid, None).await
+    }
+}
+
+/// Result of taking agent processes out of live / background / parked maps.
+struct DrainedAgents {
+    acps: Vec<Arc<AcpClient>>,
+    had_live_shell: bool,
+    background_count: usize,
+    parked_count: usize,
+}
+
+#[cfg(test)]
+mod recycle_tests {
+    use super::*;
+
+    #[test]
+    fn drain_all_agent_slots_clears_empty_maps() {
+        let mgr = SessionManager::new();
+        assert_eq!(mgr.tracked_agent_map_counts(), (0, 0, 0));
+        assert_eq!(mgr.active_process_count(), 0);
+
+        let drained = mgr.drain_all_agent_slots();
+        assert!(drained.acps.is_empty());
+        assert!(!drained.had_live_shell);
+        assert_eq!(drained.background_count, 0);
+        assert_eq!(drained.parked_count, 0);
+
+        // Maps stay empty; safe to call again (idempotent).
+        assert_eq!(mgr.tracked_agent_map_counts(), (0, 0, 0));
+        assert_eq!(mgr.active_process_count(), 0);
+        let again = mgr.drain_all_agent_slots();
+        assert!(again.acps.is_empty());
+        assert_eq!(again.background_count, 0);
+        assert_eq!(again.parked_count, 0);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1352,6 +1352,22 @@ export default function App() {
           ),
         );
         await track(
+          api.listen<{ reason?: string; killed?: number }>(
+            "session://agents_recycled",
+            (p) => {
+              if (cancelled || !p) return;
+              // session_data_mode flip (and any future full recycle).
+              if (
+                p.reason === "session_data_mode" ||
+                (p.killed != null && p.killed > 0)
+              ) {
+                setToast(tr("agent.dataModeRecycledToast"));
+                window.setTimeout(() => setToast(null), 4800);
+              }
+            },
+          ),
+        );
+        await track(
           api.listen<{
             sessionId?: string;
             stopReason?: string;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -537,6 +537,8 @@ const en = {
     "If a turn has no stream chunks or tool activity for this long, show a Cancel / Keep waiting prompt (default 120). Long-running tools that still emit events do not count as stalled.",
   "agent.idleRecycledToast":
     "Agent process recycled after idle — session kept; next message will reconnect.",
+  "agent.dataModeRecycledToast":
+    "Agents restarted after data mode change — next message reconnects under the new home.",
   "agent.processLimitToast":
     "Agent process limit reached. Stop another session or raise the limit in Settings → Runtime.",
   "agent.streamStallBanner":
@@ -1640,6 +1642,8 @@ const zh: Record<MessageKey, string> = {
     "若一轮对话在该时间内无任何流式片段或工具活动，将提示「取消本轮 / 继续等待」（默认 120）。仍有工具事件的长任务不会误判为卡顿。",
   "agent.idleRecycledToast":
     "Agent 进程因闲置已回收 — 会话仍在；下次发送将重新连接。",
+  "agent.dataModeRecycledToast":
+    "数据模式切换后已重启 Agent — 下次发送将在新目录下重连。",
   "agent.processLimitToast":
     "已达 Agent 进程上限。请先停止其他会话，或在设置 → 运行环境中提高上限。",
   "agent.streamStallBanner":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -510,6 +510,8 @@ export const zhTW: Record<MessageKey, string> = {
     "若一輪對話在該時間內無任何串流片段或工具活動，將提示「取消本輪 / 繼續等待」（預設 120）。仍有工具事件的長任務不會誤判為停滯。",
   "agent.idleRecycledToast":
     "Agent 行程因閒置已回收 — 工作階段仍在；下次傳送將重新連線。",
+  "agent.dataModeRecycledToast":
+    "資料模式切換後已重啟 Agent — 下次傳送將在新目錄下重連。",
   "agent.processLimitToast":
     "已達 Agent 行程上限。請先停止其他工作階段，或在設定 → 執行環境中提高上限。",
   "agent.streamStallBanner":


### PR DESCRIPTION
## Problem

Flipping Settings → General session data mode (independent ↔ shared) changes `GROK_HOME` for the next agent spawn, but live / background / parked processes kept the old home. That quietly mixes two data roots after a mode switch (E04).

## Changes

- `SessionManager::recycle_all_agents(reason)` drains live + background + parked, kills ACP clients via existing paths, soft-disconnects the live shell, and clears live `agentSessionId` so reconnect does `session/new` + journal bootstrap instead of loading from the previous home.
- `settings_set` calls recycle when `session_data_mode` actually changes.
- Emits `session://agents_recycled`; UI toasts “Agents restarted after data mode change” (en / zh / zh-TW).
- Shared-mode confirm dialog is unchanged (still only when switching *to* shared).
- Import helpers still only set `onboarding_done` — never force shared (E05).

## Tests

```text
cd src-tauri
cargo test --lib drain_all_agent
# session_manager::recycle_tests::drain_all_agent_slots_clears_empty_maps

cargo test --lib import_onboarding
# commands::import_settings_tests::import_onboarding_does_not_force_shared_mode

pnpm typecheck
```

Manual: Settings → General → switch independent→shared (confirm dialog), then shared→independent; with a warm agent open, next send should reconnect under the new home; toast should fire after the flip.