### PR TITLE
feat: sandbox profile setting for agent spawn

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -156,6 +156,45 @@ pub fn cli_permission_mode(policy: &str) -> &'static str {
     }
 }
 
+/// Pure spawn plan for the OS-level sandbox profile.
+///
+/// `--sandbox` is a **top-level** `grok` flag (not under `agent` / `stdio`),
+/// and the CLI also reads `GROK_SANDBOX`. When the profile is off/empty we
+/// apply neither so the agent stays unrestricted (CLI default).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxSpawnSpec {
+    pub profile: String,
+}
+
+impl SandboxSpawnSpec {
+    /// Build from a settings value. `None` means do not pass sandbox flags/env.
+    pub fn from_setting(profile: &str) -> Option<Self> {
+        let p = profile.trim();
+        if p.is_empty() || p.eq_ignore_ascii_case("off") {
+            return None;
+        }
+        Some(Self {
+            profile: p.to_ascii_lowercase(),
+        })
+    }
+
+    /// Top-level CLI args: `["--sandbox", "<profile>"]` (before `agent`).
+    pub fn cli_args(&self) -> [String; 2] {
+        ["--sandbox".into(), self.profile.clone()]
+    }
+
+    /// Env var name + value for `GROK_SANDBOX`.
+    pub fn env_pair(&self) -> (String, String) {
+        ("GROK_SANDBOX".into(), self.profile.clone())
+    }
+}
+
+/// Pure helper used by spawn + unit tests: args + env when sandbox is on.
+pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
+    let spec = SandboxSpawnSpec::from_setting(profile)?;
+    Some((spec.cli_args().to_vec(), spec.env_pair()))
+}
+
 impl AcpClient {
     pub fn use_mock() -> bool {
         std::env::var("GROK_APP_ACP")
@@ -235,11 +274,21 @@ impl AcpClient {
         );
 
         // Flag placement (CLI 0.2.x):
-        //   top-level: `grok --no-auto-update agent …`
+        //   top-level: `grok --no-auto-update [--sandbox PROFILE] agent …`
         //   agent opts: `--model` / `--reasoning-effort` / `--always-approve` before `stdio`
         // Skip background update checks so ACP handshakes are not delayed on launch.
+        // `--sandbox` is top-level only (not accepted by `grok agent` / `stdio`);
+        // also set GROK_SANDBOX so nested tools inherit the same profile.
+        let settings = crate::store::load_settings();
+        let sandbox = SandboxSpawnSpec::from_setting(&settings.sandbox_profile);
+
         let mut cmd = Command::new(&cli_path);
         cmd.arg("--no-auto-update");
+        if let Some(ref sb) = sandbox {
+            for a in sb.cli_args() {
+                cmd.arg(a);
+            }
+        }
         cmd.arg("agent");
         if !spawn_model.is_empty() {
             cmd.args(["--model", &spawn_model]);
@@ -267,8 +316,12 @@ impl AcpClient {
             cmd.env("PATH", path);
         }
         cmd.env("GROK_HOME", &grok_home);
+        if let Some(ref sb) = sandbox {
+            let (k, v) = sb.env_pair();
+            cmd.env(k, v);
+        }
         tracing::info!(
-            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={}",
+            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} sandbox={:?}",
             grok_home.display(),
             session_data_mode,
             grok_home.join("auth.json").is_file(),
@@ -278,7 +331,8 @@ impl AcpClient {
             opts.permission_policy
                 .as_deref()
                 .map(cli_permission_mode)
-                == Some("bypassPermissions")
+                == Some("bypassPermissions"),
+            sandbox.as_ref().map(|s| s.profile.as_str())
         );
 
         let mut child = cmd.spawn().map_err(|e| {
@@ -2104,6 +2158,49 @@ mod retry_tests {
     fn respect_lower_agent_max() {
         assert!(!should_abort_provider_retry(1, 3, "retrying"));
         assert!(should_abort_provider_retry(3, 3, "retrying"));
+    }
+}
+
+#[cfg(test)]
+mod sandbox_spawn_tests {
+    use super::*;
+
+    #[test]
+    fn off_and_empty_yield_no_flags() {
+        assert!(SandboxSpawnSpec::from_setting("off").is_none());
+        assert!(SandboxSpawnSpec::from_setting("OFF").is_none());
+        assert!(SandboxSpawnSpec::from_setting("").is_none());
+        assert!(SandboxSpawnSpec::from_setting("   ").is_none());
+        assert!(sandbox_spawn_flags("off").is_none());
+    }
+
+    #[test]
+    fn known_profiles_build_top_level_args_and_env() {
+        for profile in ["workspace", "read-only", "strict", "devbox"] {
+            let spec = SandboxSpawnSpec::from_setting(profile).expect(profile);
+            assert_eq!(spec.profile, profile);
+            assert_eq!(
+                spec.cli_args(),
+                ["--sandbox".to_string(), profile.to_string()]
+            );
+            assert_eq!(
+                spec.env_pair(),
+                ("GROK_SANDBOX".to_string(), profile.to_string())
+            );
+            let (args, env) = sandbox_spawn_flags(profile).unwrap();
+            assert_eq!(args, vec!["--sandbox".to_string(), profile.to_string()]);
+            assert_eq!(env, ("GROK_SANDBOX".to_string(), profile.to_string()));
+        }
+    }
+
+    #[test]
+    fn trims_and_lowercases_profile() {
+        let spec = SandboxSpawnSpec::from_setting("  WorkSpace  ").unwrap();
+        assert_eq!(spec.profile, "workspace");
+        assert_eq!(
+            spec.cli_args(),
+            ["--sandbox".to_string(), "workspace".to_string()]
+        );
     }
 }
 

--- a/src-tauri/src/integration_test.rs
+++ b/src-tauri/src/integration_test.rs
@@ -68,12 +68,14 @@ mod integration {
         let factory = AppSettings::default();
         assert_eq!(factory.session_data_mode, "independent");
         assert_eq!(factory.permission_policy, "ask");
+        assert_eq!(factory.sandbox_profile, "off");
         // Disk load + save same content must not corrupt
         let s = load_settings();
         save_settings(&s).expect("save");
         let s2 = load_settings();
         assert_eq!(s2.session_data_mode, s.session_data_mode);
         assert_eq!(s2.permission_policy, s.permission_policy);
+        assert_eq!(s2.sandbox_profile, s.sandbox_profile);
         let root = app_data_root();
         assert!(!root.as_os_str().is_empty());
     }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -160,6 +160,11 @@ pub struct AppSettings {
     /// trigger system password prompts. Official CLI login still uses `auth.json`.
     #[serde(default)]
     pub store_api_keys_in_keychain: bool,
+    /// OS-level sandbox profile for spawned `grok agent` processes
+    /// (`off` | `workspace` | `read-only` | `strict` | `devbox`). Default off.
+    /// Passed as top-level `grok --sandbox <profile>` / `GROK_SANDBOX` at spawn.
+    #[serde(default = "default_sandbox_profile")]
+    pub sandbox_profile: String,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -180,6 +185,10 @@ fn default_agent_idle_minutes() -> u32 {
 
 fn default_stream_stall_seconds() -> u32 {
     crate::stream_stall::DEFAULT_STREAM_STALL_SECONDS
+}
+
+fn default_sandbox_profile() -> String {
+    "off".into()
 }
 
 impl Default for AppSettings {
@@ -204,6 +213,7 @@ impl Default for AppSettings {
             agent_idle_minutes: default_agent_idle_minutes(),
             stream_stall_seconds: default_stream_stall_seconds(),
             store_api_keys_in_keychain: false,
+            sandbox_profile: default_sandbox_profile(),
         }
     }
 }
@@ -1236,5 +1246,25 @@ mod tests {
         assert_eq!(s.max_concurrent_agents, 3);
         assert_eq!(s.agent_idle_minutes, 30);
         assert_eq!(s.stream_stall_seconds, 120);
+        assert_eq!(s.sandbox_profile, "off");
+    }
+
+    #[test]
+    fn sandbox_profile_defaults_when_missing_from_json() {
+        // Old settings files without the field must deserialize to "off".
+        let raw = r#"{
+            "theme": "dark",
+            "locale": "en",
+            "sessionDataMode": "independent",
+            "manualCliPath": null,
+            "permissionPolicy": "ask",
+            "modelId": null,
+            "effort": "medium",
+            "mode": "agent",
+            "onboardingDone": true,
+            "setupSkipped": false
+        }"#;
+        let s: AppSettings = serde_json::from_str(raw).expect("deserialize");
+        assert_eq!(s.sandbox_profile, "off");
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -634,6 +634,7 @@ export default function App() {
   const [agentIdleMinutes, setAgentIdleMinutes] = useState(30);
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
   const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
+  const [sandboxProfile, setSandboxProfile] = useState("off");
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -852,6 +853,11 @@ export default function App() {
           : 120,
       );
       setStoreApiKeysInKeychain(!!settings.storeApiKeysInKeychain);
+      {
+        const sb = (settings.sandboxProfile || "off").trim().toLowerCase();
+        const known = ["off", "workspace", "read-only", "strict", "devbox"];
+        setSandboxProfile(known.includes(sb) ? sb : "off");
+      }
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -6038,6 +6044,13 @@ export default function App() {
                 setStoreApiKeysInKeychain(prev);
                 showToast(String(e), 4500);
               });
+          }}
+          sandboxProfile={sandboxProfile}
+          onSandboxProfile={(v) => {
+            setSandboxProfile(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, sandboxProfile: v }),
+            );
           }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -111,6 +111,9 @@ export interface SettingsPageProps {
   /** Store App API keys in OS keychain (default off → secrets.json). */
   storeApiKeysInKeychain?: boolean;
   onStoreApiKeysInKeychain?: (v: boolean) => void;
+  /** OS sandbox for agent spawn: off | workspace | read-only | strict | devbox. */
+  sandboxProfile?: string;
+  onSandboxProfile?: (v: string) => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -412,6 +415,8 @@ export function SettingsPage({
   onStreamStallSeconds,
   storeApiKeysInKeychain = false,
   onStoreApiKeysInKeychain,
+  sandboxProfile = "off",
+  onSandboxProfile,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -845,6 +850,44 @@ export function SettingsPage({
                   }))}
                 />
               </div>
+              {onSandboxProfile ? (
+                <div className="settings-row settings-row--stack">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.sandboxProfile")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.sandboxProfileDesc")}
+                    </div>
+                  </div>
+                  <Select
+                    value={sandboxProfile || "off"}
+                    onChange={(v) => onSandboxProfile(v)}
+                    options={[
+                      {
+                        value: "off",
+                        label: t("settings.sandbox.off"),
+                      },
+                      {
+                        value: "workspace",
+                        label: t("settings.sandbox.workspace"),
+                      },
+                      {
+                        value: "read-only",
+                        label: t("settings.sandbox.readOnly"),
+                      },
+                      {
+                        value: "strict",
+                        label: t("settings.sandbox.strict"),
+                      },
+                      {
+                        value: "devbox",
+                        label: t("settings.sandbox.devbox"),
+                      },
+                    ]}
+                  />
+                </div>
+              ) : null}
             </div>
 
             <h2 className="settings-page__h2">{t("settings.section.general")}</h2>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -546,6 +546,14 @@ const en = {
   "settings.permissionDeep": "Default permission",
   "settings.permissionDeepDesc":
     "Applied to new turns and remembered at the scope chosen above. YOLO auto-approves tools.",
+  "settings.sandboxProfile": "Sandbox profile",
+  "settings.sandboxProfileDesc":
+    "OS-level filesystem/network isolation for the agent process (Landlock/Seatbelt). Applied when a new agent starts — reconnect the session after changing.",
+  "settings.sandbox.off": "Off — unrestricted",
+  "settings.sandbox.workspace": "Workspace — write CWD + temp only",
+  "settings.sandbox.readOnly": "Read-only — no project writes",
+  "settings.sandbox.strict": "Strict — CWD only, block child network",
+  "settings.sandbox.devbox": "Devbox — disposable VM layout",
   "settings.prefsScope": "Remember model & permission at",
   "settings.prefsScopeDesc":
     "Global: all chats. Project: each workspace. Session: only the current chat.",
@@ -1649,6 +1657,14 @@ const zh: Record<MessageKey, string> = {
   "settings.permissionDeep": "默认权限",
   "settings.permissionDeepDesc":
     "对新一轮对话生效，并按上方选择的范围记忆。YOLO 会自动批准工具调用。",
+  "settings.sandboxProfile": "沙箱配置",
+  "settings.sandboxProfileDesc":
+    "对 Agent 进程施加操作系统级文件系统/网络隔离（Linux Landlock / macOS Seatbelt）。在新启动 Agent 时生效——更改后请重连会话。",
+  "settings.sandbox.off": "关闭 — 无限制",
+  "settings.sandbox.workspace": "工作区 — 仅可写 CWD 与临时目录",
+  "settings.sandbox.readOnly": "只读 — 不可写项目文件",
+  "settings.sandbox.strict": "严格 — 仅限 CWD，阻止子进程网络",
+  "settings.sandbox.devbox": "Devbox — 一次性开发机布局",
   "settings.prefsScope": "模型与权限记忆范围",
   "settings.prefsScopeDesc":
     "全局：所有对话共用。项目：按工作区记忆。会话：仅当前聊天。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -519,6 +519,14 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.permissionDeep": "預設權限",
   "settings.permissionDeepDesc":
     "對新一輪對話生效，並依上方選擇的範圍記憶。YOLO 會自動核准工具呼叫。",
+  "settings.sandboxProfile": "沙箱設定檔",
+  "settings.sandboxProfileDesc":
+    "對 Agent 行程施加作業系統級檔案系統/網路隔離（Linux Landlock / macOS Seatbelt）。在新啟動 Agent 時生效——變更後請重新連線工作階段。",
+  "settings.sandbox.off": "關閉 — 無限制",
+  "settings.sandbox.workspace": "工作區 — 僅可寫 CWD 與暫存目錄",
+  "settings.sandbox.readOnly": "唯讀 — 不可寫專案檔案",
+  "settings.sandbox.strict": "嚴格 — 僅限 CWD，封鎖子行程網路",
+  "settings.sandbox.devbox": "Devbox — 一次性開發機配置",
   "settings.prefsScope": "模型與權限記憶範圍",
   "settings.prefsScopeDesc":
     "全域：所有對話共用。專案：依工作區記憶。對話：僅目前聊天。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -720,6 +720,11 @@ export interface AppSettings {
    * Default false: keys stay in secrets.json (0600). Official login uses auth.json.
    */
   storeApiKeysInKeychain?: boolean;
+  /**
+   * OS-level sandbox for spawned agents: off | workspace | read-only | strict | devbox.
+   * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
+   */
+  sandboxProfile?: string;
 }
 
 export interface AvailableModel {


### PR DESCRIPTION
## Problem
Grok Build supports OS-level sandbox profiles (`--sandbox` / `GROK_SANDBOX`: off, workspace, read-only, strict, devbox), but the desktop app always spawned agents unsandboxed with no way to configure it.

## Changes
- Add `sandbox_profile` to `AppSettings` (default `"off"`, serde default so old settings files keep working)
- Settings → General → Permissions: select built-in profiles with short descriptions (en / zh / zh-TW)
- When spawning `grok agent stdio`, pass top-level `grok --sandbox <profile>` and set `GROK_SANDBOX` when not off
  - CLI accepts `--sandbox` only on top-level `grok`, not under `agent`/`stdio` (verified against installed CLI)
- Persist via existing `settings_get` / `settings_set` + frontend state
- Pure helper `SandboxSpawnSpec` / `sandbox_spawn_flags` with unit tests; default-off coverage in store/integration tests

## How to test
1. `pnpm typecheck && pnpm test`
2. `cd src-tauri && cargo test sandbox_ && cargo test default_settings && cargo test settings_default`
3. Open Settings → General → Permissions → Sandbox profile; pick `workspace`, save
4. Start/reconnect a session; agent process should run with `--sandbox workspace` (or `GROK_SANDBOX=workspace`)
5. Set back to Off; new agent should not receive sandbox flags

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (347 passed)
- [x] `cargo test sandbox_` (4 passed)
- [x] `cargo test default_settings` / `settings_default`
- [ ] Manual: Settings select + spawn with non-off profile