### PR TITLE
feat: experimental cross-session memory toggle + clear

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -654,6 +654,8 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    }
+
     if memory_flip {
         if let Err(e) = crate::agent_memory::sync_memory_to_agent_profile(
             &settings.session_data_mode,


### PR DESCRIPTION
## Summary

- **Settings `experimentalMemory`** (default `false`): enables Grok Build cross-session memory for App agents.
- **Spawn policy**: when on → top-level `--experimental-memory` + `GROK_MEMORY=1` (+ independent `[memory] enabled = true`); when off → force `--no-memory` + `GROK_MEMORY=0` so config cannot re-enable memory (independent isolation). Soft-respawns live agent on toggle.
- **Settings → General UI**: experimental toggle + description; **Clear workspace memory** runs `grok memory clear --workspace -y` with project cwd (when available), confirmed via App dialog (`setAppDialog`), not `window.confirm`.
- **i18n**: en + zh + zh-TW.
- **Tests**: pure flag/env helpers in `src/lib/agentMemory.ts` (vitest) + Rust unit tests in `agent_memory.rs`.

## CLI surface

| Mechanism | Behavior |
|-----------|----------|
| `--experimental-memory` / `--no-memory` | Top-level `grok` flags before `agent stdio` |
| `GROK_MEMORY=1\|0` | Env on agent process |
| `[memory] enabled` | Written to independent agent-home `config.toml` only |
| `grok memory clear` | Workspace-scoped clear from Settings |

## Test plan

- [x] `pnpm test -- src/lib/agentMemory.test.ts src/i18n/messages.test.ts`
- [x] `cargo test --lib agent_memory`
- [x] `cargo test --lib default_settings_independent_mode`
- [x] `pnpm typecheck`
- [ ] Manual: Settings → General toggle on → new chat spawn log shows `experimental_memory=true`
- [ ] Manual: toggle off → spawn uses `--no-memory` / isolation
- [ ] Manual: Clear workspace memory → in-app confirm → success toast; no `window.confirm`