### PR TITLE
feat: max agent turns limit for agent spawn

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -193,6 +193,46 @@ impl SandboxSpawnSpec {
 pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
     let spec = SandboxSpawnSpec::from_setting(profile)?;
     Some((spec.cli_args().to_vec(), spec.env_pair()))
+/// Hard clamp for Settings → Runtime max agent turns (1–200).
+pub const MAX_AGENT_TURNS_CAP: u32 = 200;
+pub const MIN_AGENT_TURNS: u32 = 1;
+
+/// Pure spawn plan for top-level `--max-turns N`.
+///
+/// `--max-turns` is a **top-level** `grok` flag (same placement as session title
+/// generation). `None` / `0` omit the flag so the CLI keeps its default.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaxTurnsSpawnSpec {
+    pub turns: u32,
+}
+
+impl MaxTurnsSpawnSpec {
+    /// Build from settings. `None` or `0` → do not pass `--max-turns`.
+    pub fn from_setting(raw: Option<u32>) -> Option<Self> {
+        let n = raw?;
+        if n == 0 {
+            return None;
+        }
+        Some(Self {
+            turns: n.clamp(MIN_AGENT_TURNS, MAX_AGENT_TURNS_CAP),
+        })
+    }
+
+    /// Top-level CLI args: `["--max-turns", "<N>"]` (before `agent`).
+    pub fn cli_args(&self) -> [String; 2] {
+        ["--max-turns".into(), self.turns.to_string()]
+    }
+}
+
+/// Normalize settings value: `None`/`0` stay unset; otherwise clamp to 1..=200.
+pub fn normalize_max_agent_turns(raw: Option<u32>) -> Option<u32> {
+    MaxTurnsSpawnSpec::from_setting(raw).map(|s| s.turns)
+}
+
+/// Pure helper used by spawn + unit tests: top-level args when a limit is set.
+pub fn max_turns_cli_args(raw: Option<u32>) -> Option<Vec<String>> {
+    let spec = MaxTurnsSpawnSpec::from_setting(raw)?;
+    Some(spec.cli_args().to_vec())
 }
 
 impl AcpClient {
@@ -286,6 +326,17 @@ impl AcpClient {
         cmd.arg("--no-auto-update");
         if let Some(ref sb) = sandbox {
             for a in sb.cli_args() {
+        //   top-level: `grok --no-auto-update [--max-turns N] agent …`
+        //   agent opts: `--model` / `--reasoning-effort` / `--always-approve` before `stdio`
+        // Skip background update checks so ACP handshakes are not delayed on launch.
+        // `--max-turns` is top-level only (same as headless title generation).
+        let settings = crate::store::load_settings();
+        let max_turns = MaxTurnsSpawnSpec::from_setting(settings.max_agent_turns);
+
+        let mut cmd = Command::new(&cli_path);
+        cmd.arg("--no-auto-update");
+        if let Some(ref mt) = max_turns {
+            for a in mt.cli_args() {
                 cmd.arg(a);
             }
         }
@@ -322,6 +373,7 @@ impl AcpClient {
         }
         tracing::info!(
             "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} sandbox={:?}",
+            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} max_turns={:?}",
             grok_home.display(),
             session_data_mode,
             grok_home.join("auth.json").is_file(),
@@ -333,6 +385,7 @@ impl AcpClient {
                 .map(cli_permission_mode)
                 == Some("bypassPermissions"),
             sandbox.as_ref().map(|s| s.profile.as_str())
+            max_turns.as_ref().map(|s| s.turns)
         );
 
         let mut child = cmd.spawn().map_err(|e| {
@@ -2200,6 +2253,53 @@ mod sandbox_spawn_tests {
         assert_eq!(
             spec.cli_args(),
             ["--sandbox".to_string(), "workspace".to_string()]
+mod max_turns_spawn_tests {
+    use super::*;
+
+    #[test]
+    fn none_and_zero_yield_no_flags() {
+        assert!(MaxTurnsSpawnSpec::from_setting(None).is_none());
+        assert!(MaxTurnsSpawnSpec::from_setting(Some(0)).is_none());
+        assert!(max_turns_cli_args(None).is_none());
+        assert!(max_turns_cli_args(Some(0)).is_none());
+        assert_eq!(normalize_max_agent_turns(None), None);
+        assert_eq!(normalize_max_agent_turns(Some(0)), None);
+    }
+
+    #[test]
+    fn valid_turns_build_top_level_args() {
+        let spec = MaxTurnsSpawnSpec::from_setting(Some(5)).unwrap();
+        assert_eq!(spec.turns, 5);
+        assert_eq!(
+            spec.cli_args(),
+            ["--max-turns".to_string(), "5".to_string()]
+        );
+        assert_eq!(
+            max_turns_cli_args(Some(5)),
+            Some(vec!["--max-turns".to_string(), "5".to_string()])
+        );
+        assert_eq!(normalize_max_agent_turns(Some(5)), Some(5));
+    }
+
+    #[test]
+    fn clamp_to_one_through_two_hundred() {
+        assert_eq!(
+            MaxTurnsSpawnSpec::from_setting(Some(1)).unwrap().turns,
+            1
+        );
+        assert_eq!(
+            MaxTurnsSpawnSpec::from_setting(Some(200)).unwrap().turns,
+            200
+        );
+        // Values above cap clamp down (0 already omitted above).
+        assert_eq!(
+            MaxTurnsSpawnSpec::from_setting(Some(999)).unwrap().turns,
+            MAX_AGENT_TURNS_CAP
+        );
+        assert_eq!(normalize_max_agent_turns(Some(999)), Some(200));
+        assert_eq!(
+            max_turns_cli_args(Some(999)),
+            Some(vec!["--max-turns".to_string(), "200".to_string()])
         );
     }
 }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -168,6 +168,10 @@ pub struct AppSettings {
     /// Passed as top-level `grok --sandbox <profile>` / `GROK_SANDBOX` at spawn.
     #[serde(default = "default_sandbox_profile")]
     pub sandbox_profile: String,
+    /// Cap agent turns per process via top-level `grok --max-turns N`.
+    /// `None` or `0` = omit the flag (CLI default / unlimited).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_agent_turns: Option<u32>,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -217,6 +221,7 @@ impl Default for AppSettings {
             stream_stall_seconds: default_stream_stall_seconds(),
             store_api_keys_in_keychain: false,
             sandbox_profile: default_sandbox_profile(),
+            max_agent_turns: None,
         }
     }
 }
@@ -1302,6 +1307,12 @@ mod tests {
     #[test]
     fn sandbox_profile_defaults_when_missing_from_json() {
         // Old settings files without the field must deserialize to "off".
+        assert_eq!(s.max_agent_turns, None);
+    }
+
+    #[test]
+    fn max_agent_turns_defaults_when_missing_from_json() {
+        // Old settings files without the field must deserialize to None.
         let raw = r#"{
             "theme": "dark",
             "locale": "en",
@@ -1361,5 +1372,6 @@ mod tests {
         let m: SessionMeta = serde_json::from_str(raw).expect("deserialize legacy session");
         assert!(!m.pinned);
         assert!(!m.archived);
+        assert_eq!(s.max_agent_turns, None);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -690,6 +690,8 @@ export default function App() {
   const [maxConcurrentAgents, setMaxConcurrentAgents] = useState(3);
   const [agentIdleMinutes, setAgentIdleMinutes] = useState(30);
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
+  /** 0 = omit `--max-turns` (CLI default). */
+  const [maxAgentTurns, setMaxAgentTurns] = useState(0);
   const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
   const [sandboxProfile, setSandboxProfile] = useState("off");
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
@@ -916,6 +918,14 @@ export default function App() {
           ? Math.min(900, Math.round(settings.streamStallSeconds))
           : 120,
       );
+      {
+        const raw = settings.maxAgentTurns;
+        setMaxAgentTurns(
+          typeof raw === "number" && raw > 0
+            ? Math.min(200, Math.round(raw))
+            : 0,
+        );
+      }
       setStoreApiKeysInKeychain(!!settings.storeApiKeysInKeychain);
       {
         const sb = (settings.sandboxProfile || "off").trim().toLowerCase();
@@ -6204,6 +6214,18 @@ export default function App() {
             setStreamStallSeconds(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, streamStallSeconds: v }),
+            );
+          }}
+          maxAgentTurns={maxAgentTurns}
+          onMaxAgentTurns={(v) => {
+            const n = v > 0 ? Math.min(200, Math.round(v)) : 0;
+            setMaxAgentTurns(n);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({
+                ...s,
+                // null clears the optional field; 0 would also omit on spawn.
+                maxAgentTurns: n > 0 ? n : null,
+              }),
             );
           }}
           storeApiKeysInKeychain={storeApiKeysInKeychain}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -109,6 +109,12 @@ export interface SettingsPageProps {
   /** Stream stall silence timeout seconds (I06). */
   streamStallSeconds?: number;
   onStreamStallSeconds?: (v: number) => void;
+  /**
+   * Max agent turns (`grok --max-turns N`). 0 / empty = CLI default (no flag).
+   * Clamped to 1–200 when set.
+   */
+  maxAgentTurns?: number;
+  onMaxAgentTurns?: (v: number) => void;
   /** Store App API keys in OS keychain (default off → secrets.json). */
   storeApiKeysInKeychain?: boolean;
   onStoreApiKeysInKeychain?: (v: boolean) => void;
@@ -414,6 +420,8 @@ export function SettingsPage({
   onAgentIdleMinutes,
   streamStallSeconds = 120,
   onStreamStallSeconds,
+  maxAgentTurns = 0,
+  onMaxAgentTurns,
   storeApiKeysInKeychain = false,
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
@@ -1453,6 +1461,39 @@ export function SettingsPage({
                   if (!Number.isFinite(n)) return;
                   onStreamStallSeconds?.(
                     Math.min(900, Math.max(15, Math.round(n))),
+                  );
+                }}
+              />
+            </div>
+            <div className="settings-row settings-row--stack">
+              <div className="settings-row__text">
+                <div className="settings-row__label">
+                  {t("settings.maxAgentTurns")}
+                </div>
+                <div className="settings-row__desc">
+                  {t("settings.maxAgentTurnsDesc")}
+                </div>
+              </div>
+              <input
+                className="settings-input"
+                type="number"
+                min={0}
+                max={200}
+                step={1}
+                placeholder={t("settings.maxAgentTurnsPlaceholder")}
+                value={
+                  maxAgentTurns && maxAgentTurns > 0 ? maxAgentTurns : ""
+                }
+                onChange={(e) => {
+                  const raw = e.target.value.trim();
+                  if (raw === "") {
+                    onMaxAgentTurns?.(0);
+                    return;
+                  }
+                  const n = Number(raw);
+                  if (!Number.isFinite(n)) return;
+                  onMaxAgentTurns?.(
+                    Math.min(200, Math.max(0, Math.round(n))),
                   );
                 }}
               />

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -565,6 +565,10 @@ const en = {
   "settings.streamStallSeconds": "Stream stall timeout (seconds)",
   "settings.streamStallSecondsDesc":
     "If a turn has no stream chunks or tool activity for this long, show a Cancel / Keep waiting prompt (default 120). Long-running tools that still emit events do not count as stalled.",
+  "settings.maxAgentTurns": "Max agent turns",
+  "settings.maxAgentTurnsDesc":
+    "Pass `grok --max-turns N` when starting the agent (1–200). Leave empty or 0 for the CLI default. Applies on the next agent start — reconnect the session after changing.",
+  "settings.maxAgentTurnsPlaceholder": "Default (no limit)",
   "agent.idleRecycledToast":
     "Agent process recycled after idle — session kept; next message will reconnect.",
   "agent.dataModeRecycledToast":
@@ -1777,6 +1781,10 @@ const zh: Record<MessageKey, string> = {
   "settings.streamStallSeconds": "流式卡顿超时（秒）",
   "settings.streamStallSecondsDesc":
     "若一轮对话在该时间内无任何流式片段或工具活动，将提示「取消本轮 / 继续等待」（默认 120）。仍有工具事件的长任务不会误判为卡顿。",
+  "settings.maxAgentTurns": "最大 Agent 轮次",
+  "settings.maxAgentTurnsDesc":
+    "启动 Agent 时传入 `grok --max-turns N`（1–200）。留空或 0 表示使用 CLI 默认。下次启动 Agent 时生效——更改后请重连会话。",
+  "settings.maxAgentTurnsPlaceholder": "默认（不限制）",
   "agent.idleRecycledToast":
     "Agent 进程因闲置已回收 — 会话仍在；下次发送将重新连接。",
   "agent.dataModeRecycledToast":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -538,6 +538,10 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.streamStallSeconds": "串流停滯逾時（秒）",
   "settings.streamStallSecondsDesc":
     "若一輪對話在該時間內無任何串流片段或工具活動，將提示「取消本輪 / 繼續等待」（預設 120）。仍有工具事件的長任務不會誤判為停滯。",
+  "settings.maxAgentTurns": "最大 Agent 輪次",
+  "settings.maxAgentTurnsDesc":
+    "啟動 Agent 時傳入 `grok --max-turns N`（1–200）。留空或 0 表示使用 CLI 預設。下次啟動 Agent 時生效——變更後請重新連線工作階段。",
+  "settings.maxAgentTurnsPlaceholder": "預設（不限制）",
   "agent.idleRecycledToast":
     "Agent 行程因閒置已回收 — 工作階段仍在；下次傳送將重新連線。",
   "agent.dataModeRecycledToast":

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,7 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+  /**
    * Cap agent turns via top-level `grok --max-turns N`.
    * null / 0 / unset = omit flag (CLI default). Clamped to 1–200 when set.
    */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,10 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+   * Cap agent turns via top-level `grok --max-turns N`.
+   * null / 0 / unset = omit flag (CLI default). Clamped to 1–200 when set.
+   */
+  maxAgentTurns?: number | null;
 }
 
 export interface AvailableModel {


### PR DESCRIPTION
## Problem
The Grok Build CLI supports top-level `--max-turns N`, and session title generation already uses it, but the main agent stdio spawn path never passed the flag. Long agent runs could not be capped from the app.

## Changes
- `AppSettings.max_agent_turns: Option<u32>` — `None` / `0` omit the flag (CLI default); set values clamp to 1–200
- Settings → Runtime number input (empty or 0 = default)
- Spawn path: `grok --no-auto-update --max-turns N agent … stdio` when set
- i18n: en + zh + zh-TW
- Unit tests for clamp + CLI arg builder

## Test plan
- [x] `pnpm typecheck`
- [x] `cargo test max_turns_spawn` / `max_agent_turns` / `default_settings_independent`
- [x] `pnpm test -- --run src/i18n/messages.test.ts`
- [ ] Settings → Runtime: leave empty → save → no `--max-turns` on next agent start
- [ ] Set to 5 → reconnect session → spawn uses `--max-turns 5`
- [ ] Set to 999 → clamps to 200 in UI/settings path
- [ ] Clear field (0) → flag omitted again