### PR TITLE
feat: disable web search/fetch for agents

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -343,8 +343,7 @@ impl AcpClient {
             cmd.env(k, v);
         }
         tracing::info!(
-            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} sandbox={:?}",
-            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} disable_web_search={}",
+            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} sandbox={:?} disable_web_search={}",
             grok_home.display(),
             session_data_mode,
             grok_home.join("auth.json").is_file(),
@@ -355,7 +354,7 @@ impl AcpClient {
                 .as_deref()
                 .map(cli_permission_mode)
                 == Some("bypassPermissions"),
-            sandbox.as_ref().map(|s| s.profile.as_str())
+            sandbox.as_ref().map(|s| s.profile.as_str()),
             disable_web_search
         );
 

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -193,6 +193,8 @@ impl SandboxSpawnSpec {
 pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
     let spec = SandboxSpawnSpec::from_setting(profile)?;
     Some((spec.cli_args().to_vec(), spec.env_pair()))
+}
+
 /// Pure helper: top-level CLI flags for the disable_web_search setting.
 ///
 /// When true, returns `["--disable-web-search"]` (before `agent`).

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -193,6 +193,16 @@ impl SandboxSpawnSpec {
 pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
     let spec = SandboxSpawnSpec::from_setting(profile)?;
     Some((spec.cli_args().to_vec(), spec.env_pair()))
+/// Pure helper: top-level CLI flags for the disable_web_search setting.
+///
+/// When true, returns `["--disable-web-search"]` (before `agent`).
+/// When false, returns no flags so the CLI keeps web_search / web_fetch.
+pub fn disable_web_search_spawn_flags(disable: bool) -> Vec<&'static str> {
+    if disable {
+        vec!["--disable-web-search"]
+    } else {
+        vec![]
+    }
 }
 
 impl AcpClient {
@@ -288,6 +298,16 @@ impl AcpClient {
             for a in sb.cli_args() {
                 cmd.arg(a);
             }
+        //   top-level: `grok --no-auto-update [--disable-web-search] agent …`
+        //   agent opts: `--model` / `--reasoning-effort` / `--always-approve` before `stdio`
+        // Skip background update checks so ACP handshakes are not delayed on launch.
+        // `--disable-web-search` is top-level only (removes web_search / web_fetch tools).
+        let disable_web_search = crate::store::load_settings().disable_web_search;
+
+        let mut cmd = Command::new(&cli_path);
+        cmd.arg("--no-auto-update");
+        for flag in disable_web_search_spawn_flags(disable_web_search) {
+            cmd.arg(flag);
         }
         cmd.arg("agent");
         if !spawn_model.is_empty() {
@@ -322,6 +342,7 @@ impl AcpClient {
         }
         tracing::info!(
             "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} sandbox={:?}",
+            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} disable_web_search={}",
             grok_home.display(),
             session_data_mode,
             grok_home.join("auth.json").is_file(),
@@ -333,6 +354,7 @@ impl AcpClient {
                 .map(cli_permission_mode)
                 == Some("bypassPermissions"),
             sandbox.as_ref().map(|s| s.profile.as_str())
+            disable_web_search
         );
 
         let mut child = cmd.spawn().map_err(|e| {
@@ -2260,5 +2282,23 @@ mod live_handshake_tests {
         eprintln!("OK session={} in {:?}", sid, t0.elapsed());
         client.kill().await;
         assert!(!sid.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod disable_web_search_spawn_tests {
+    use super::disable_web_search_spawn_flags;
+
+    #[test]
+    fn off_adds_no_flags() {
+        assert!(disable_web_search_spawn_flags(false).is_empty());
+    }
+
+    #[test]
+    fn on_adds_top_level_flag() {
+        assert_eq!(
+            disable_web_search_spawn_flags(true),
+            vec!["--disable-web-search"]
+        );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -654,6 +654,8 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    }
+
     if web_search_flip {
         // Spawn flag changes — soft-respawn so the next turn drops/restores web tools.
         mgr.soft_respawn(&app).await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -634,6 +634,7 @@ pub async fn settings_set(
         prev.store_api_keys_in_keychain != settings.store_api_keys_in_keychain;
     let session_data_mode_changed =
         prev.session_data_mode != settings.session_data_mode;
+    let web_search_flip = prev.disable_web_search != settings.disable_web_search;
 
     store::save_settings(&settings)?;
 
@@ -653,6 +654,9 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    if web_search_flip {
+        // Spawn flag changes — soft-respawn so the next turn drops/restores web tools.
+        mgr.soft_respawn(&app).await;
     }
 
     // Full permission apply: Host + agent-home + soft-respawn if needed

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -168,6 +168,10 @@ pub struct AppSettings {
     /// Passed as top-level `grok --sandbox <profile>` / `GROK_SANDBOX` at spawn.
     #[serde(default = "default_sandbox_profile")]
     pub sandbox_profile: String,
+    /// When true, spawn agents with top-level `--disable-web-search` so
+    /// `web_search` / `web_fetch` tools are removed. Default false (CLI default).
+    #[serde(default)]
+    pub disable_web_search: bool,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -217,6 +221,7 @@ impl Default for AppSettings {
             stream_stall_seconds: default_stream_stall_seconds(),
             store_api_keys_in_keychain: false,
             sandbox_profile: default_sandbox_profile(),
+            disable_web_search: false,
         }
     }
 }
@@ -1305,6 +1310,15 @@ mod tests {
         let raw = r#"{
             "theme": "dark",
             "locale": "en",
+        assert!(!s.disable_web_search);
+    }
+
+    #[test]
+    fn disable_web_search_defaults_when_missing_from_json() {
+        // Older settings files omit the field — serde default keeps web tools on.
+        let raw = r#"{
+            "theme": "dark",
+            "locale": "zh",
             "sessionDataMode": "independent",
             "manualCliPath": null,
             "permissionPolicy": "ask",
@@ -1361,5 +1375,6 @@ mod tests {
         let m: SessionMeta = serde_json::from_str(raw).expect("deserialize legacy session");
         assert!(!m.pinned);
         assert!(!m.archived);
+        assert!(!s.disable_web_search);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -692,6 +692,7 @@ export default function App() {
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
   const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
   const [sandboxProfile, setSandboxProfile] = useState("off");
+  const [disableWebSearch, setDisableWebSearch] = useState(false);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -922,6 +923,7 @@ export default function App() {
         const known = ["off", "workspace", "read-only", "strict", "devbox"];
         setSandboxProfile(known.includes(sb) ? sb : "off");
       }
+      setDisableWebSearch(!!settings.disableWebSearch);
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -5893,6 +5895,8 @@ export default function App() {
       "settings.cliNotFound",
       "settings.permissionDeep",
       "settings.permissionDeepDesc",
+      "settings.disableWebSearch",
+      "settings.disableWebSearchDesc",
       "settings.prefsScope",
       "settings.prefsScopeDesc",
       "settings.prefsScope.global",
@@ -6225,6 +6229,11 @@ export default function App() {
             setSandboxProfile(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
+          disableWebSearch={disableWebSearch}
+          onDisableWebSearch={(v) => {
+            setDisableWebSearch(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, disableWebSearch: v }),
             );
           }}
           cliInfo={cliInfo}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6229,6 +6229,8 @@ export default function App() {
             setSandboxProfile(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
+            );
+          }}
           disableWebSearch={disableWebSearch}
           onDisableWebSearch={(v) => {
             setDisableWebSearch(v);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -115,6 +115,9 @@ export interface SettingsPageProps {
   /** OS sandbox for agent spawn: off | workspace | read-only | strict | devbox. */
   sandboxProfile?: string;
   onSandboxProfile?: (v: string) => void;
+  /** When true, agents get top-level `--disable-web-search`. */
+  disableWebSearch?: boolean;
+  onDisableWebSearch?: (v: boolean) => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -418,6 +421,8 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  disableWebSearch = false,
+  onDisableWebSearch,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -886,6 +891,20 @@ export function SettingsPage({
                         label: t("settings.sandbox.devbox"),
                       },
                     ]}
+              {onDisableWebSearch ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.disableWebSearch")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.disableWebSearchDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={disableWebSearch}
+                    onChange={() => onDisableWebSearch(!disableWebSearch)}
+                    ariaLabel={t("settings.disableWebSearch")}
                   />
                 </div>
               ) : null}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -891,6 +891,9 @@ export function SettingsPage({
                         label: t("settings.sandbox.devbox"),
                       },
                     ]}
+                  />
+                </div>
+              ) : null}
               {onDisableWebSearch ? (
                 <div className="settings-row">
                   <div className="settings-row__text">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -586,6 +586,9 @@ const en = {
   "settings.sandbox.readOnly": "Read-only — no project writes",
   "settings.sandbox.strict": "Strict — CWD only, block child network",
   "settings.sandbox.devbox": "Devbox — disposable VM layout",
+  "settings.disableWebSearch": "Disable web search & fetch",
+  "settings.disableWebSearchDesc":
+    "Spawn agents with --disable-web-search so web_search and web_fetch tools are unavailable. Live agents soft-respawn when this changes.",
   "settings.prefsScope": "Remember model & permission at",
   "settings.prefsScopeDesc":
     "Global: all chats. Project: each workspace. Session: only the current chat.",
@@ -1798,6 +1801,9 @@ const zh: Record<MessageKey, string> = {
   "settings.sandbox.readOnly": "只读 — 不可写项目文件",
   "settings.sandbox.strict": "严格 — 仅限 CWD，阻止子进程网络",
   "settings.sandbox.devbox": "Devbox — 一次性开发机布局",
+  "settings.disableWebSearch": "禁用网页搜索与抓取",
+  "settings.disableWebSearchDesc":
+    "启动 Agent 时加上 --disable-web-search，移除 web_search / web_fetch 工具。更改后会 soft-respawn 已连接的 Agent。",
   "settings.prefsScope": "模型与权限记忆范围",
   "settings.prefsScopeDesc":
     "全局：所有对话共用。项目：按工作区记忆。会话：仅当前聊天。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -559,6 +559,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.sandbox.readOnly": "唯讀 — 不可寫專案檔案",
   "settings.sandbox.strict": "嚴格 — 僅限 CWD，封鎖子行程網路",
   "settings.sandbox.devbox": "Devbox — 一次性開發機配置",
+  "settings.disableWebSearch": "停用網頁搜尋與抓取",
+  "settings.disableWebSearchDesc":
+    "啟動 Agent 時加上 --disable-web-search，移除 web_search / web_fetch 工具。變更後會 soft-respawn 已連線的 Agent。",
   "settings.prefsScope": "模型與權限記憶範圍",
   "settings.prefsScopeDesc":
     "全域：所有對話共用。專案：依工作區記憶。對話：僅目前聊天。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,10 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+   * When true, agents spawn with top-level `--disable-web-search`
+   * (removes web_search / web_fetch tools). Default false.
+   */
+  disableWebSearch?: boolean;
 }
 
 export interface AvailableModel {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,7 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+  /**
    * When true, agents spawn with top-level `--disable-web-search`
    * (removes web_search / web_fetch tools). Default false.
    */


### PR DESCRIPTION
## Problem
Agents always get `web_search` / `web_fetch`. Some workspaces want network tool use off without changing CLI config by hand.

## Changes
- `AppSettings.disable_web_search` (bool, serde default **false**)
- Settings → Permissions toggle (en / zh / zh-TW)
- `acp_client` spawn: when true, pass top-level `grok --disable-web-search … agent` (same place as other top-level flags before `agent`)
- `settings_set`: soft-respawn when the flag flips so live agents pick up the new tool set
- Pure helper `disable_web_search_spawn_flags` + unit tests; serde default test for older settings files

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (347 passed)
- [x] `cargo test` (200 passed) including `disable_web_search_spawn_tests` and store default
- [ ] Manual: Settings → Permissions → enable toggle → send a turn that would use web search → tools unavailable; disable → soft-respawn → tools back