### PR TITLE
feat: reopen last chat on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ See `docs/llm-wiki/release.md`.
 **中文**
 - 新增：应用更新检查、活动任务面板、会话正文搜索、插件安装更新、沙箱配置、会话置顶、项目 inspect、CLI Doctor 合并。  
 - 修复：会话模式切换回收 Agent；缺失项目目录可重定位。
+- **Reopen last chat on startup**: remembers the last opened session and restores it once after launch (Settings → General toggle, on by default; skips archived / missing / setup wizard).
 
 ## [0.1.6] - 2026-07-24
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -669,6 +669,38 @@ pub async fn settings_set(
     Ok(settings)
 }
 
+/// Persist last active chat without permission/tray side-effects of `settings_set`.
+/// Called on every successful open/switch so startup can restore once.
+#[tauri::command]
+pub async fn settings_remember_last_session(
+    session_id: Option<String>,
+    project_id: Option<String>,
+) -> Result<(), String> {
+    let mut s = store::load_settings();
+    let next_session = session_id.and_then(|id| {
+        let t = id.trim().to_string();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t)
+        }
+    });
+    let next_project = project_id.and_then(|id| {
+        let t = id.trim().to_string();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t)
+        }
+    });
+    if s.last_session_id == next_session && s.last_project_id == next_project {
+        return Ok(());
+    }
+    s.last_session_id = next_session;
+    s.last_project_id = next_project;
+    store::save_settings(&s)
+}
+
 #[tauri::command]
 pub async fn models_list_available() -> Result<crate::models_catalog::AvailableModelsResult, String> {
     Ok(crate::models_catalog::list_available_models())

--- a/src-tauri/src/integration_test.rs
+++ b/src-tauri/src/integration_test.rs
@@ -119,6 +119,8 @@ mod integration {
         assert_eq!(factory.session_data_mode, "independent");
         assert_eq!(factory.permission_policy, "ask");
         assert_eq!(factory.sandbox_profile, "off");
+        assert!(factory.reopen_last_session);
+        assert!(factory.last_session_id.is_none());
         // Disk load + save same content must not corrupt
         let s = load_settings();
         save_settings(&s).expect("save");
@@ -126,6 +128,7 @@ mod integration {
         assert_eq!(s2.session_data_mode, s.session_data_mode);
         assert_eq!(s2.permission_policy, s.permission_policy);
         assert_eq!(s2.sandbox_profile, s.sandbox_profile);
+        assert_eq!(s2.reopen_last_session, s.reopen_last_session);
         let root = app_data_root();
         assert!(!root.as_os_str().is_empty());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -171,6 +171,7 @@ pub fn run() {
             commands::session_resolve_relative_media,
             commands::settings_get,
             commands::settings_set,
+            commands::settings_remember_last_session,
             commands::models_list_available,
             commands::composer_prefs_resolve,
             commands::composer_prefs_set,

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -201,6 +201,8 @@ fn default_stream_stall_seconds() -> u32 {
 
 fn default_sandbox_profile() -> String {
     "off".into()
+}
+
 fn default_reopen_last_session() -> bool {
     true
 }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -168,6 +168,15 @@ pub struct AppSettings {
     /// Passed as top-level `grok --sandbox <profile>` / `GROK_SANDBOX` at spawn.
     #[serde(default = "default_sandbox_profile")]
     pub sandbox_profile: String,
+    /// Reopen the last active chat once after launch (default true).
+    #[serde(default = "default_reopen_last_session")]
+    pub reopen_last_session: bool,
+    /// Last successfully opened / switched session (for startup restore).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_session_id: Option<String>,
+    /// Project of [`Self::last_session_id`] when it belonged to one (hint only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_project_id: Option<String>,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -192,6 +201,8 @@ fn default_stream_stall_seconds() -> u32 {
 
 fn default_sandbox_profile() -> String {
     "off".into()
+fn default_reopen_last_session() -> bool {
+    true
 }
 
 impl Default for AppSettings {
@@ -217,6 +228,9 @@ impl Default for AppSettings {
             stream_stall_seconds: default_stream_stall_seconds(),
             store_api_keys_in_keychain: false,
             sandbox_profile: default_sandbox_profile(),
+            reopen_last_session: default_reopen_last_session(),
+            last_session_id: None,
+            last_project_id: None,
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,6 +101,7 @@ import {
   sessionExportFilename,
   sessionToMarkdown,
 } from "@/lib/sessionExport";
+import { shouldRestoreLastSession } from "@/lib/sessionRestore";
 import { connPillForState } from "@/lib/connStatus";
 import { shortcutsForPlatform } from "@/lib/shortcuts";
 import {
@@ -692,6 +693,12 @@ export default function App() {
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
   const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
   const [sandboxProfile, setSandboxProfile] = useState("off");
+  /** Reopen last chat on launch (default on; loaded from settings). */
+  const [reopenLastSession, setReopenLastSession] = useState(true);
+  const [lastSessionId, setLastSessionId] = useState<string | null>(null);
+  /** Settings + sessions finished first bootstrap (gate for one-shot restore). */
+  const settingsBootstrappedRef = useRef(false);
+  const startupRestoreDoneRef = useRef(false);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -922,6 +929,14 @@ export default function App() {
         const known = ["off", "workspace", "read-only", "strict", "devbox"];
         setSandboxProfile(known.includes(sb) ? sb : "off");
       }
+      setReopenLastSession(settings.reopenLastSession !== false);
+      setLastSessionId(
+        typeof settings.lastSessionId === "string" &&
+          settings.lastSessionId.trim()
+          ? settings.lastSessionId.trim()
+          : null,
+      );
+      settingsBootstrappedRef.current = true;
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -2044,6 +2059,14 @@ export default function App() {
       setRetryStatus(null);
     }
 
+    // Remember for "reopen last chat on startup".
+    setLastSessionId(s.id);
+    if (api.isTauri()) {
+      void api
+        .settingsRememberLastSession(s.id, proj?.id ?? s.projectId ?? null)
+        .catch(() => {});
+    }
+
     // Warm ACP: connect while the user reads history (trusted project or orphan).
     // Host serializes connect; first send no-ops if already ready, or waits if
     // still handshaking. Process is reused across sessions when cwd/effort match.
@@ -2084,6 +2107,46 @@ export default function App() {
       })();
     }
   };
+
+  // Once after setup/onboarding: reopen last chat if it still exists.
+  useEffect(() => {
+    if (startupRestoreDoneRef.current) return;
+    if (!settingsBootstrappedRef.current) return;
+    if (appGate !== "ready") return;
+    if (!api.isTauri()) {
+      startupRestoreDoneRef.current = true;
+      return;
+    }
+    // Don't steal hash routes (settings / automations).
+    const raw = window.location.hash.replace(/^#\/?/, "");
+    if (raw.startsWith("settings") || raw.startsWith("automations")) {
+      startupRestoreDoneRef.current = true;
+      return;
+    }
+
+    const restoreId = shouldRestoreLastSession({
+      enabled: reopenLastSession,
+      workbenchReady: true,
+      lastSessionId,
+      sessions,
+      currentSessionId: session.sessionId ?? viewingSessionIdRef.current,
+    });
+    startupRestoreDoneRef.current = true;
+    if (!restoreId) return;
+
+    const row = sessions.find((s) => s.id === restoreId);
+    if (!row) return;
+    const proj =
+      projects.find((p) => p.id === row.projectId) ?? null;
+    if (row.projectId) {
+      setExpandedProjects((e) => ({ ...e, [row.projectId!]: true }));
+    } else {
+      setHistoryOpen(true);
+    }
+    void openSession(row, proj);
+    // openSession closes over latest projects/sessions; run once at ready.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot startup
+  }, [appGate, sessions, reopenLastSession, lastSessionId, projects, session.sessionId]);
 
   /**
    * Focus composer after React commit. Retries until the textarea is mounted
@@ -3086,6 +3149,16 @@ export default function App() {
           setExpandedProjects((e) => ({ ...e, [activeProject.id]: true }));
         } else {
           setHistoryOpen(true);
+        }
+        // First send materializes a real session — treat as active for restore.
+        setLastSessionId(meta.id);
+        if (api.isTauri()) {
+          void api
+            .settingsRememberLastSession(
+              meta.id,
+              activeProject?.id ?? null,
+            )
+            .catch(() => {});
         }
         await refreshSessions();
       }
@@ -6225,6 +6298,11 @@ export default function App() {
             setSandboxProfile(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
+          reopenLastSession={reopenLastSession}
+          onReopenLastSession={(v) => {
+            setReopenLastSession(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, reopenLastSession: v }),
             );
           }}
           cliInfo={cliInfo}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6298,6 +6298,8 @@ export default function App() {
             setSandboxProfile(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
+            );
+          }}
           reopenLastSession={reopenLastSession}
           onReopenLastSession={(v) => {
             setReopenLastSession(v);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -115,6 +115,9 @@ export interface SettingsPageProps {
   /** OS sandbox for agent spawn: off | workspace | read-only | strict | devbox. */
   sandboxProfile?: string;
   onSandboxProfile?: (v: string) => void;
+  /** Reopen last active chat once after launch (default on). */
+  reopenLastSession?: boolean;
+  onReopenLastSession?: (v: boolean) => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -418,6 +421,8 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  reopenLastSession = true,
+  onReopenLastSession,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -956,6 +961,25 @@ export function SettingsPage({
                       onStoreApiKeysInKeychain(!storeApiKeysInKeychain)
                     }
                     ariaLabel={t("settings.storeApiKeysInKeychain")}
+                  />
+                </div>
+              ) : null}
+              {onReopenLastSession ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.reopenLastSession")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.reopenLastSessionDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={reopenLastSession}
+                    onChange={() =>
+                      onReopenLastSession(!reopenLastSession)
+                    }
+                    ariaLabel={t("settings.reopenLastSession")}
                   />
                 </div>
               ) : null}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -544,6 +544,9 @@ const en = {
   "settings.storeApiKeysInKeychain": "Store API keys in system keychain",
   "settings.storeApiKeysInKeychainDesc":
     "Off by default: keys stay in the app data folder (mode 0600). Turn on to use the OS keychain — the system may ask once. Official login still uses Grok Build auth.",
+  "settings.reopenLastSession": "Reopen last chat on startup",
+  "settings.reopenLastSessionDesc":
+    "When you quit and reopen the app, restore the chat you were last viewing (if it still exists and is not archived).",
   "settings.cliPath": "CLI path",
   "settings.cliPathDesc": "Path to the Grok Build CLI binary",
   "settings.cliNotFound": "(not found)",
@@ -1756,6 +1759,9 @@ const zh: Record<MessageKey, string> = {
   "settings.storeApiKeysInKeychain": "用系统钥匙串保存 API Key",
   "settings.storeApiKeysInKeychainDesc":
     "默认关闭：密钥写在应用数据目录（0600）。开启后写入系统钥匙串，系统可能要求一次授权。官方登录仍走 Grok Build 鉴权，不受此项影响。",
+  "settings.reopenLastSession": "启动时恢复上次会话",
+  "settings.reopenLastSessionDesc":
+    "退出并重新打开应用时，自动打开你上次查看的会话（若仍存在且未归档）。",
   "settings.cliPath": "CLI 路径",
   "settings.cliPathDesc": "Grok Build CLI 可执行文件路径",
   "settings.cliNotFound": "（未找到）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -517,6 +517,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.storeApiKeysInKeychain": "以系統鑰匙圈儲存 API Key",
   "settings.storeApiKeysInKeychainDesc":
     "預設關閉：金鑰寫在應用資料目錄（0600）。開啟後寫入系統鑰匙圈，系統可能要求一次授權。官方登入仍走 Grok Build 驗證，不受此項影響。",
+  "settings.reopenLastSession": "啟動時還原上次對話",
+  "settings.reopenLastSessionDesc":
+    "結束並重新開啟應用程式時，自動開啟你上次檢視的對話（若仍存在且未封存）。",
   "settings.cliPath": "CLI 路徑",
   "settings.cliPathDesc": "Grok Build CLI 可執行檔路徑",
   "settings.cliNotFound": "（未找到）",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,12 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+  /** Reopen last active chat once after launch (default true). */
+  reopenLastSession?: boolean;
+  /** Last successfully opened session id (startup restore). */
+  lastSessionId?: string | null;
+  /** Project id for lastSessionId when it had one. */
+  lastProjectId?: string | null;
 }
 
 export interface AvailableModel {
@@ -813,6 +819,17 @@ export interface ComposerPrefs {
 
 export async function settingsGet() {
   return invoke<AppSettings>("settings_get");
+}
+
+/** Persist last active chat without full settings_set side-effects. */
+export async function settingsRememberLastSession(
+  sessionId: string | null,
+  projectId: string | null = null,
+) {
+  return invoke<void>("settings_remember_last_session", {
+    sessionId,
+    projectId,
+  });
 }
 
 export async function modelsListAvailable() {

--- a/src/lib/sessionRestore.test.ts
+++ b/src/lib/sessionRestore.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { shouldRestoreLastSession } from "./sessionRestore";
+
+const sessions = [
+  { id: "s1", archived: false },
+  { id: "s2", archived: true },
+  { id: "s3" },
+];
+
+describe("shouldRestoreLastSession", () => {
+  it("restores when enabled, workbench ready, and session is live", () => {
+    expect(
+      shouldRestoreLastSession({
+        enabled: true,
+        workbenchReady: true,
+        lastSessionId: "s1",
+        sessions,
+      }),
+    ).toBe("s1");
+    expect(
+      shouldRestoreLastSession({
+        enabled: true,
+        workbenchReady: true,
+        lastSessionId: "  s3  ",
+        sessions,
+      }),
+    ).toBe("s3");
+  });
+
+  it("no-ops when toggle is off or workbench not ready", () => {
+    expect(
+      shouldRestoreLastSession({
+        enabled: false,
+        workbenchReady: true,
+        lastSessionId: "s1",
+        sessions,
+      }),
+    ).toBeNull();
+    expect(
+      shouldRestoreLastSession({
+        enabled: true,
+        workbenchReady: false,
+        lastSessionId: "s1",
+        sessions,
+      }),
+    ).toBeNull();
+  });
+
+  it("no-ops when id missing, unknown, or archived", () => {
+    expect(
+      shouldRestoreLastSession({
+        enabled: true,
+        workbenchReady: true,
+        lastSessionId: null,
+        sessions,
+      }),
+    ).toBeNull();
+    expect(
+      shouldRestoreLastSession({
+        enabled: true,
+        workbenchReady: true,
+        lastSessionId: "   ",
+        sessions,
+      }),
+    ).toBeNull();
+    expect(
+      shouldRestoreLastSession({
+        enabled: true,
+        workbenchReady: true,
+        lastSessionId: "gone",
+        sessions,
+      }),
+    ).toBeNull();
+    expect(
+      shouldRestoreLastSession({
+        enabled: true,
+        workbenchReady: true,
+        lastSessionId: "s2",
+        sessions,
+      }),
+    ).toBeNull();
+  });
+
+  it("no-ops when already viewing a session", () => {
+    expect(
+      shouldRestoreLastSession({
+        enabled: true,
+        workbenchReady: true,
+        lastSessionId: "s1",
+        sessions,
+        currentSessionId: "s1",
+      }),
+    ).toBeNull();
+    expect(
+      shouldRestoreLastSession({
+        enabled: true,
+        workbenchReady: true,
+        lastSessionId: "s1",
+        sessions,
+        currentSessionId: "other",
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/sessionRestore.ts
+++ b/src/lib/sessionRestore.ts
@@ -1,0 +1,40 @@
+/**
+ * Startup restore of the last active chat — pure decision helper.
+ *
+ * Product rule: after onboarding/workbench is ready, if the user left the
+ * setting on (default), open the remembered session once when it still exists
+ * and is not archived. No I/O here; App performs open + persistence.
+ */
+
+export type RestorableSession = {
+  id: string;
+  archived?: boolean;
+};
+
+export type ShouldRestoreLastSessionInput = {
+  /** Settings → General toggle (default true). */
+  enabled: boolean;
+  /** Setup wizard / onboarding finished; workbench is showing. */
+  workbenchReady: boolean;
+  lastSessionId?: string | null;
+  sessions: RestorableSession[];
+  /** Already viewing a session (tray / race) — skip restore. */
+  currentSessionId?: string | null;
+};
+
+/**
+ * Returns the session id to open once on launch, or null for no-op.
+ */
+export function shouldRestoreLastSession(
+  input: ShouldRestoreLastSessionInput,
+): string | null {
+  if (!input.enabled) return null;
+  if (!input.workbenchReady) return null;
+  const id = (input.lastSessionId ?? "").trim();
+  if (!id) return null;
+  if (input.currentSessionId) return null;
+  const row = input.sessions.find((s) => s.id === id);
+  if (!row) return null;
+  if (row.archived) return null;
+  return id;
+}


### PR DESCRIPTION
## Problem
After quitting the app, users land on an empty workbench and have to find the chat they were last in.

## Changes
- Persist `lastSessionId` / `lastProjectId` and a `reopenLastSession` toggle (default **on**) in `AppSettings` (serde defaults for older settings files).
- Update the remembered session whenever the user successfully opens/switches a chat (and when the first send materializes a draft).
- Lightweight `settings_remember_last_session` command so open/switch does not run full `settings_set` permission/tray side-effects.
- After setup/onboarding (`appGate === "ready"`) and sessions are loaded: restore once if the session still exists and is not archived.
- Skip restore when the URL hash is settings/automations, or during the setup wizard.
- Settings → General: **Reopen last chat on startup** (en / zh / zh-TW).
- Pure helper `shouldRestoreLastSession` + unit tests.

## How to test
1. Open a chat, quit the app, relaunch → same chat should open (toggle on by default).
2. Archive or delete that chat, relaunch → no crash; empty workbench (no-op).
3. Settings → General → turn the toggle **off**, open another chat, quit, relaunch → does not auto-open.
4. Fresh install / setup wizard still in progress → does not restore until workbench is ready.
5. `pnpm test -- src/lib/sessionRestore.test.ts src/i18n/messages.test.ts`
6. `cd src-tauri && cargo test settings_default_factory`

## Test plan
- [x] Unit: `shouldRestoreLastSession` cases (enabled/disabled, missing, archived, already viewing)
- [x] i18n key parity en / zh / zh-TW
- [x] Rust settings default + disk roundtrip includes new fields
- [ ] Manual: quit/relaunch restores last chat
- [ ] Manual: toggle off disables restore
- [ ] Manual: archived last chat → no-op