### PR TITLE
feat: find in current conversation (Cmd/Ctrl+F)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,11 +98,17 @@ import {
   type SessionContentHit,
 } from "@/lib/sessionSearch";
 import {
+  findChatMatches,
+  stepChatFindIndex,
+  type ChatFindMatch,
+} from "@/lib/chatFind";
+import {
   sessionExportFilename,
   sessionToMarkdown,
 } from "@/lib/sessionExport";
 import { connPillForState } from "@/lib/connStatus";
 import { shortcutsForPlatform } from "@/lib/shortcuts";
+import { ChatFindBar } from "@/components/ChatFindBar";
 import {
   ensureNotifyPermission,
   showDesktopNotification,
@@ -567,10 +573,12 @@ export default function App() {
   }, [searchQuery, showSearch]);
 
   // Global shortcuts: search, help, doctor, new chat, settings.
+  // Global shortcuts: search, find-in-chat, help, doctor, new chat, settings.
   // Handlers go through refs so we don't re-bind every render.
   const shortcutHandlersRef = useRef({
     newChat: () => {},
     openSettings: () => {},
+    openChatFind: () => {},
   });
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -584,6 +592,12 @@ export default function App() {
         tag === "textarea" ||
         !!target?.isContentEditable;
       const key = e.key.toLowerCase();
+      // In-chat find — open even while typing in the composer.
+      if (key === "f" && !e.shiftKey) {
+        e.preventDefault();
+        shortcutHandlersRef.current.openChatFind();
+        return;
+      }
       if (key === "k") {
         e.preventDefault();
         setShowSearch(true);
@@ -626,6 +640,10 @@ export default function App() {
   const [setupCliSeed, setSetupCliSeed] = useState<SetupCliInfo | null>(null);
   const [showDoctor, setShowDoctor] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
+  /** In-conversation find (Cmd/Ctrl+F) — not the palette/session search. */
+  const [showChatFind, setShowChatFind] = useState(false);
+  const [chatFindQuery, setChatFindQuery] = useState("");
+  const [chatFindIndex, setChatFindIndex] = useState(0);
   const [savedAccounts, setSavedAccounts] = useState<api.SavedAccount[]>([]);
   const [activeAccountId, setActiveAccountId] = useState<string | null>(null);
   const [perm, setPerm] = useState<PermissionPayload | null>(null);
@@ -4680,6 +4698,106 @@ export default function App() {
   );
 
   /**
+   * In-chat find matches — user + assistant bodies only.
+   * Historical tool_step rows are not rendered in the transcript, so matching
+   * them would land on invisible hits.
+   */
+  const chatFindMatches = useMemo((): ChatFindMatch[] => {
+    if (!showChatFind) return [];
+    return findChatMatches(
+      chatFindQuery,
+      messages
+        .filter((m) => m.role === "user" || m.role === "assistant")
+        .map((m) => ({
+          id: m.id,
+          role: m.role,
+          content: m.content,
+          marker: m.marker,
+        })),
+    );
+  }, [showChatFind, chatFindQuery, messages]);
+
+  const chatFindHitIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const m of chatFindMatches) s.add(m.messageId);
+    return s;
+  }, [chatFindMatches]);
+
+  const chatFindActive = useMemo(() => {
+    if (!showChatFind || chatFindMatches.length === 0) return null;
+    const idx =
+      chatFindIndex >= 0 && chatFindIndex < chatFindMatches.length
+        ? chatFindIndex
+        : 0;
+    const hit = chatFindMatches[idx]!;
+    return { messageId: hit.messageId, occurrence: hit.occurrence };
+  }, [showChatFind, chatFindMatches, chatFindIndex]);
+
+  // Clamp active index when the match list shrinks (query edit / new messages).
+  useEffect(() => {
+    if (!showChatFind) return;
+    if (chatFindMatches.length === 0) {
+      if (chatFindIndex !== 0) setChatFindIndex(0);
+      return;
+    }
+    if (chatFindIndex >= chatFindMatches.length) {
+      setChatFindIndex(0);
+    }
+  }, [showChatFind, chatFindMatches.length, chatFindIndex]);
+
+  // Reset find when switching conversation (keep open across same session).
+  useEffect(() => {
+    setShowChatFind(false);
+    setChatFindQuery("");
+    setChatFindIndex(0);
+  }, [session.sessionId]);
+
+  // Close find when leaving the chat pane (not when opening from another pane).
+  useEffect(() => {
+    if (mainPane !== "chat") {
+      setShowChatFind(false);
+    }
+  }, [mainPane]);
+
+  useEffect(() => {
+    if (!showChatFind) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (e.isComposing) return;
+      // Permission bar / dialogs own Escape when open.
+      if (perm || appDialog) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setShowChatFind(false);
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [showChatFind, perm, appDialog]);
+
+  const [chatFindFocusKey, setChatFindFocusKey] = useState(0);
+  const openChatFind = useCallback(() => {
+    // Ensure chat pane first; opening find after pane switch is handled by
+    // setting show true in the same tick (pane effect only closes on leave).
+    if (mainPane !== "chat") {
+      setMainPane("chat");
+    }
+    setShowChatFind(true);
+    setChatFindFocusKey((k) => k + 1);
+  }, [mainPane]);
+
+  const chatFindNext = useCallback(() => {
+    setChatFindIndex((i) =>
+      stepChatFindIndex(i, chatFindMatches.length, 1),
+    );
+  }, [chatFindMatches.length]);
+
+  const chatFindPrev = useCallback(() => {
+    setChatFindIndex((i) =>
+      stepChatFindIndex(i, chatFindMatches.length, -1),
+    );
+  }, [chatFindMatches.length]);
+
+  /**
    * New empty draft only: lift composer and SuperGrok brand.
    * Existing sessions (even with empty journal) must not look like a fresh chat.
    */
@@ -5074,6 +5192,9 @@ export default function App() {
       setAppView("settings");
       setSettingsSection("general");
       window.location.hash = "#/settings/general";
+    },
+    openChatFind: () => {
+      openChatFind();
     },
   };
   trayHandlersRef.current = {
@@ -7206,6 +7327,31 @@ export default function App() {
             />
           )}
 
+          {mainPane === "chat" && showChatFind && (
+            <ChatFindBar
+              key={chatFindFocusKey}
+              query={chatFindQuery}
+              activeIndex={chatFindIndex}
+              matchCount={chatFindMatches.length}
+              labels={{
+                placeholder: tr("chatFind.placeholder"),
+                prev: tr("chatFind.prev"),
+                next: tr("chatFind.next"),
+                close: tr("chatFind.close"),
+                count: tr("chatFind.count"),
+                noMatches: tr("chatFind.noMatches"),
+                aria: tr("chatFind.aria"),
+              }}
+              onQueryChange={(q) => {
+                setChatFindQuery(q);
+                setChatFindIndex(0);
+              }}
+              onPrev={chatFindPrev}
+              onNext={chatFindNext}
+              onClose={() => setShowChatFind(false)}
+            />
+          )}
+
           {/* Pre-turn / host errors: T04 deck (problem · cause · primary · secondary) */}
           {errorBanner && !hasChatTurnError && (
             <div className="error-banner" role="alert">
@@ -7338,6 +7484,9 @@ export default function App() {
               setAttachments((prev) => mergeAttachments(prev, [att]))
             }
             attachLabels={attachLabels}
+            findQuery={showChatFind ? chatFindQuery : ""}
+            findHitMessageIds={showChatFind ? chatFindHitIds : undefined}
+            findActive={showChatFind ? chatFindActive : null}
           />
 
           <div

--- a/src/components/ChatFindBar.tsx
+++ b/src/components/ChatFindBar.tsx
@@ -1,0 +1,144 @@
+/**
+ * In-conversation find bar (Cmd/Ctrl+F).
+ * Query + prev/next + match count; Escape closes via parent.
+ */
+
+import { useEffect, useRef } from "react";
+import {
+  IconChevronDown,
+  IconChevronLeft,
+  IconClose,
+  IconSearch,
+} from "@/components/icons";
+import { formatChatFindCount } from "@/lib/chatFind";
+
+export type ChatFindBarLabels = {
+  placeholder: string;
+  prev: string;
+  next: string;
+  close: string;
+  /** "{current} / {total}" */
+  count: string;
+  noMatches: string;
+  aria: string;
+};
+
+export type ChatFindBarProps = {
+  query: string;
+  activeIndex: number;
+  matchCount: number;
+  labels: ChatFindBarLabels;
+  onQueryChange: (q: string) => void;
+  onPrev: () => void;
+  onNext: () => void;
+  onClose: () => void;
+};
+
+export function ChatFindBar({
+  query,
+  activeIndex,
+  matchCount,
+  labels,
+  onQueryChange,
+  onPrev,
+  onNext,
+  onClose,
+}: ChatFindBarProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  const { current, total } = formatChatFindCount(activeIndex, matchCount);
+  const countText =
+    total === 0
+      ? labels.noMatches
+      : labels.count
+          .replace("{current}", String(current))
+          .replace("{total}", String(total));
+
+  return (
+    <div
+      className="chat-find"
+      role="search"
+      aria-label={labels.aria}
+      data-testid="chat-find-bar"
+    >
+      <span className="chat-find__icon" aria-hidden>
+        <IconSearch size={15} />
+      </span>
+      <input
+        ref={inputRef}
+        type="search"
+        className="chat-find__input"
+        value={query}
+        placeholder={labels.placeholder}
+        autoComplete="off"
+        autoCorrect="off"
+        spellCheck={false}
+        aria-label={labels.placeholder}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            e.stopPropagation();
+            onClose();
+            return;
+          }
+          if (e.key === "Enter") {
+            e.preventDefault();
+            if (e.shiftKey) onPrev();
+            else onNext();
+          }
+        }}
+      />
+      <span
+        className={
+          "chat-find__count" + (total === 0 && query.trim() ? " is-empty" : "")
+        }
+        aria-live="polite"
+      >
+        {query.trim() ? countText : ""}
+      </span>
+      <div className="chat-find__actions">
+        <button
+          type="button"
+          className="chat-find__btn"
+          aria-label={labels.prev}
+          title={labels.prev}
+          disabled={matchCount === 0}
+          onClick={onPrev}
+        >
+          <IconChevronLeft
+            size={16}
+            className="chat-find__chev chat-find__chev--up"
+          />
+        </button>
+        <button
+          type="button"
+          className="chat-find__btn"
+          aria-label={labels.next}
+          title={labels.next}
+          disabled={matchCount === 0}
+          onClick={onNext}
+        >
+          <IconChevronDown size={16} />
+        </button>
+        <button
+          type="button"
+          className="chat-find__btn chat-find__btn--close"
+          aria-label={labels.close}
+          title={labels.close}
+          onClick={onClose}
+        >
+          <IconClose size={15} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HighlightedText.tsx
+++ b/src/components/HighlightedText.tsx
@@ -1,0 +1,45 @@
+/** Case-insensitive query highlight for plain text (in-chat find). */
+
+import { splitHighlightParts } from "@/lib/chatFind";
+
+export function HighlightedText({
+  text,
+  query,
+  activeOccurrence = null,
+}: {
+  text: string;
+  query: string;
+  /** When set, the matching occurrence in this text is marked current. */
+  activeOccurrence?: number | null;
+}) {
+  const q = query.trim();
+  if (!q) return <>{text}</>;
+  const parts = splitHighlightParts(text, q);
+  if (parts.length === 1 && !parts[0]?.match) return <>{text}</>;
+  return (
+    <>
+      {parts.map((p, i) =>
+        p.match ? (
+          <mark
+            key={i}
+            className={
+              "chat-find-mark" +
+              (activeOccurrence != null && p.occurrence === activeOccurrence
+                ? " chat-find-mark--current"
+                : "")
+            }
+            data-find-mark={
+              activeOccurrence != null && p.occurrence === activeOccurrence
+                ? "current"
+                : "hit"
+            }
+          >
+            {p.text}
+          </mark>
+        ) : (
+          <span key={i}>{p.text}</span>
+        ),
+      )}
+    </>
+  );
+}

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -3,7 +3,7 @@
  * Replaces AI Elements / previous ConversationThread.
  */
 
-import { memo, useMemo } from "react";
+import { memo, useEffect, useMemo } from "react";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
 import {
@@ -42,6 +42,8 @@ import { Thinking } from "./Thinking";
 import { BackBottom } from "./BackBottom";
 import { InlineUserEdit } from "./InlineUserEdit";
 import { SkillChip } from "@/components/SkillChip";
+import { HighlightedText } from "@/components/HighlightedText";
+import { findChatMatches } from "@/lib/chatFind";
 import { hydrateDisplayContent, parseStoredContent } from "@/lib/draftDoc";
 import { parseScheduledUserContent } from "@/lib/automations";
 import { extractAutomationPayload } from "@/lib/automationSetup";
@@ -76,6 +78,9 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
   onOpenResource,
   onAddAttachmentToComposer,
   attachLabels,
+  findQuery,
+  findActiveOccurrence,
+  findOccurrenceBase = 0,
 }: {
   content: string;
   attachments?: Attachment[];
@@ -85,6 +90,10 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
   onOpenResource?: (target: ResourceOpenTarget) => void;
   onAddAttachmentToComposer?: (att: Attachment) => void;
   attachLabels: AttachLabels;
+  findQuery?: string;
+  findActiveOccurrence?: number | null;
+  /** Offset into the message-level occurrence index for multi-segment bodies. */
+  findOccurrenceBase?: number;
 }) {
   // Never show silent grok-automation fences in the transcript.
   const displayContent = content?.trim()
@@ -123,6 +132,9 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
           imagePathMap={pathMapProp}
           projectPath={projectPath}
           onOpenResource={onOpenResource}
+          findQuery={findQuery}
+          findActiveOccurrence={findActiveOccurrence}
+          findOccurrenceBase={findOccurrenceBase}
         >
           {displayContent}
         </MarkdownChat>
@@ -146,10 +158,27 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
 });
 
 /** Render skill chips / plain text for the user bubble body. */
-function UserPlainOrSkills({ content }: { content: string }) {
+function UserPlainOrSkills({
+  content,
+  findQuery,
+  findActiveOccurrence,
+}: {
+  content: string;
+  findQuery?: string;
+  findActiveOccurrence?: number | null;
+}) {
   const hydrated = hydrateDisplayContent(content);
   const segs = parseStoredContent(hydrated);
   if (!segs.some((s) => s.type === "skill")) {
+    if (findQuery?.trim()) {
+      return (
+        <HighlightedText
+          text={content}
+          query={findQuery}
+          activeOccurrence={findActiveOccurrence ?? null}
+        />
+      );
+    }
     return <>{content}</>;
   }
   return (
@@ -157,6 +186,13 @@ function UserPlainOrSkills({ content }: { content: string }) {
       {segs.map((s, i) =>
         s.type === "skill" ? (
           <SkillChip key={`sk-${i}-${s.name}`} name={s.name} size="sm" />
+        ) : findQuery?.trim() && s.text ? (
+          <HighlightedText
+            key={`t-${i}`}
+            text={s.text}
+            query={findQuery}
+            activeOccurrence={findActiveOccurrence ?? null}
+          />
         ) : (
           <span key={`t-${i}`}>{s.text}</span>
         ),
@@ -172,10 +208,14 @@ function UserPlainOrSkills({ content }: { content: string }) {
 function UserMessageBody({
   content,
   scheduledLabel,
+  findQuery,
+  findActiveOccurrence,
 }: {
   content: string;
   /** Short badge word, e.g. 已安排 / Scheduled */
   scheduledLabel: string;
+  findQuery?: string;
+  findActiveOccurrence?: number | null;
 }) {
   const scheduled = parseScheduledUserContent(content);
   if (scheduled) {
@@ -187,17 +227,37 @@ function UserMessageBody({
           <span className="lobe-scheduled-tag__sep" aria-hidden>
             ·
           </span>
-          <span className="lobe-scheduled-tag__title">{scheduled.title}</span>
+          <span className="lobe-scheduled-tag__title">
+            {findQuery?.trim() ? (
+              <HighlightedText
+                text={scheduled.title}
+                query={findQuery}
+                activeOccurrence={null}
+              />
+            ) : (
+              scheduled.title
+            )}
+          </span>
         </span>
         {scheduled.body.trim() ? (
           <div className="lobe-chat-user-msg__body">
-            <UserPlainOrSkills content={scheduled.body} />
+            <UserPlainOrSkills
+              content={scheduled.body}
+              findQuery={findQuery}
+              findActiveOccurrence={findActiveOccurrence}
+            />
           </div>
         ) : null}
       </div>
     );
   }
-  return <UserPlainOrSkills content={content} />;
+  return (
+    <UserPlainOrSkills
+      content={content}
+      findQuery={findQuery}
+      findActiveOccurrence={findActiveOccurrence}
+    />
+  );
 }
 
 export interface ConversationThreadProps {
@@ -242,6 +302,12 @@ export interface ConversationThreadProps {
    * Retained for callers; not rendered in the transcript.
    */
   turnStartedAt?: number | null;
+  /** In-chat find (Cmd/Ctrl+F) — highlight + scroll. */
+  findQuery?: string;
+  /** Message ids that contain at least one match. */
+  findHitMessageIds?: ReadonlySet<string>;
+  /** Active match target for scroll / current mark. */
+  findActive?: { messageId: string; occurrence: number } | null;
 }
 
 export function ConversationThread({
@@ -266,8 +332,31 @@ export function ConversationThread({
   onOpenResource,
   onAddAttachmentToComposer,
   attachLabels,
+  findQuery = "",
+  findHitMessageIds,
+  findActive = null,
 }: ConversationThreadProps) {
   const tr = useMemo(() => createT(locale), [locale]);
+
+  // Scroll the current find match into view (mark if present, else message).
+  useEffect(() => {
+    if (!findActive?.messageId) return;
+    const q = findQuery.trim();
+    if (!q) return;
+    const id = findActive.messageId;
+    const t = window.requestAnimationFrame(() => {
+      const root = document.querySelector(
+        `[data-message-id="${CSS.escape(id)}"]`,
+      ) as HTMLElement | null;
+      if (!root) return;
+      const currentMark = root.querySelector(
+        '[data-find-mark="current"]',
+      ) as HTMLElement | null;
+      const target = currentMark ?? root;
+      target.scrollIntoView({ block: "center", behavior: "smooth" });
+    });
+    return () => window.cancelAnimationFrame(t);
+  }, [findActive?.messageId, findActive?.occurrence, findQuery]);
 
   // Re-pin when user sends (even if they had scrolled up to read history).
   const forceStickKey = useMemo(() => {
@@ -425,6 +514,8 @@ export function ConversationThread({
               const isLastUser = lastUserMessageId === m.id;
               const isEditing = editingUserMessageId === m.id;
               const timeLabel = formatMessageTime(m.createdAt, locale);
+              const isFindHit = !!findHitMessageIds?.has(m.id);
+              const isFindCurrent = findActive?.messageId === m.id;
               return (
                 <ChatItem
                   key={m.id}
@@ -432,6 +523,10 @@ export function ConversationThread({
                   placement="right"
                   showAvatar={false}
                   showTitle={false}
+                  className={
+                    (isFindHit ? " lobe-chat-item--find-hit" : "") +
+                    (isFindCurrent ? " lobe-chat-item--find-current" : "")
+                  }
                   message={
                     <div
                       className={
@@ -478,6 +573,12 @@ export function ConversationThread({
                           <UserMessageBody
                             content={m.content}
                             scheduledLabel={tr("automations.msgTag")}
+                            findQuery={findQuery}
+                            findActiveOccurrence={
+                              isFindCurrent
+                                ? (findActive?.occurrence ?? null)
+                                : null
+                            }
                           />
                         </div>
                       ) : null}
@@ -546,17 +647,38 @@ export function ConversationThread({
                 { content: m.content, code: undefined, message: undefined },
                 locale === "en" ? "en" : "zh",
               );
+              const isFindHit = !!findHitMessageIds?.has(m.id);
+              const isFindCurrent = findActive?.messageId === m.id;
               return (
                 <div
                   key={m.id}
-                  className="lobe-chat-error"
+                  className={
+                    "lobe-chat-error" +
+                    (isFindHit ? " lobe-chat-item--find-hit" : "") +
+                    (isFindCurrent ? " lobe-chat-item--find-current" : "")
+                  }
                   role="alert"
                   data-testid="chat-turn-error"
+                  data-message-id={m.id}
                 >
                   <div className="lobe-chat-error__label">
                     {tr("chat.turnFailed")}
                   </div>
-                  <div className="lobe-chat-error__body">{friendly}</div>
+                  <div className="lobe-chat-error__body">
+                    {findQuery.trim() ? (
+                      <HighlightedText
+                        text={friendly}
+                        query={findQuery}
+                        activeOccurrence={
+                          isFindCurrent
+                            ? (findActive?.occurrence ?? null)
+                            : null
+                        }
+                      />
+                    ) : (
+                      friendly
+                    )}
+                  </div>
                 </div>
               );
             }
@@ -584,6 +706,9 @@ export function ConversationThread({
               }
             }
 
+            const isFindHit = !!findHitMessageIds?.has(m.id);
+            const isFindCurrent = findActive?.messageId === m.id;
+
             return (
               <ChatItem
                 key={m.id}
@@ -591,11 +716,16 @@ export function ConversationThread({
                 placement="left"
                 showAvatar={false}
                 loading={!!m.streaming}
+                className={
+                  (isFindHit ? " lobe-chat-item--find-hit" : "") +
+                  (isFindCurrent ? " lobe-chat-item--find-current" : "")
+                }
                 message={
                   <div
                     className="lobe-chat-assistant-timeline"
                     aria-busy={m.streaming ? true : undefined}
                     aria-live={m.streaming ? "polite" : undefined}
+                    data-find-assistant={isFindCurrent ? "current" : undefined}
                   >
                     {showThinkingPlaceholder ? (
                       <Thinking
@@ -606,62 +736,84 @@ export function ConversationThread({
                         thoughtForLabel={(n) => tr("chat.thoughtFor", { n })}
                       />
                     ) : null}
-                    {segs.map((seg, si) => {
-                      if (seg.kind === "thought") {
-                        // Skip empty finished phases (avoids "Thought for 0.0s").
-                        if (
-                          !seg.text.trim() &&
-                          !(m.streaming && lastSeg === seg)
-                        ) {
-                          return null;
+                    {(() => {
+                      // Running occurrence base across content segments so
+                      // find marks stay aligned with message-level match index.
+                      let contentOccBase = 0;
+                      return segs.map((seg, si) => {
+                        if (seg.kind === "thought") {
+                          // Skip empty finished phases (avoids "Thought for 0.0s").
+                          if (
+                            !seg.text.trim() &&
+                            !(m.streaming && lastSeg === seg)
+                          ) {
+                            return null;
+                          }
+                          const thoughtIdx = segs
+                            .slice(0, si + 1)
+                            .filter((x) => x.kind === "thought").length;
+                          const phaseStreaming =
+                            !!m.streaming && lastSeg === seg;
+                          const multi = thoughtCount > 1;
+                          const label = multi
+                            ? tr("plan.phaseLabel", { n: String(thoughtIdx) })
+                            : tr("chat.thinking");
+                          return (
+                            <Thinking
+                              key={`${m.id}-th-${si}`}
+                              locale={locale}
+                              thinking={phaseStreaming}
+                              content={seg.text}
+                              streamingLabel={label}
+                              doneLabel={
+                                multi
+                                  ? tr("plan.phaseLabel", {
+                                      n: String(thoughtIdx),
+                                    })
+                                  : tr("chat.thoughtDone")
+                              }
+                              thoughtForLabel={(n) =>
+                                tr("chat.thoughtFor", { n })
+                              }
+                            />
+                          );
                         }
-                        const thoughtIdx = segs
-                          .slice(0, si + 1)
-                          .filter((x) => x.kind === "thought").length;
-                        const phaseStreaming =
-                          !!m.streaming && lastSeg === seg;
-                        const multi = thoughtCount > 1;
-                        const label = multi
-                          ? tr("plan.phaseLabel", { n: String(thoughtIdx) })
-                          : tr("chat.thinking");
+                        const segBase = contentOccBase;
+                        if (findQuery.trim()) {
+                          contentOccBase += findChatMatches(findQuery, [
+                            {
+                              id: `${m.id}-seg-${si}`,
+                              role: "assistant",
+                              content: seg.text,
+                            },
+                          ]).length;
+                        }
                         return (
-                          <Thinking
-                            key={`${m.id}-th-${si}`}
-                            locale={locale}
-                            thinking={phaseStreaming}
+                          <AssistantMessageBody
+                            key={`${m.id}-c-${si}`}
                             content={seg.text}
-                            streamingLabel={label}
-                            doneLabel={
-                              multi
-                                ? tr("plan.phaseLabel", {
-                                    n: String(thoughtIdx),
-                                  })
-                                : tr("chat.thoughtDone")
+                            attachments={
+                              si === lastContentSi ? m.attachments : undefined
                             }
-                            thoughtForLabel={(n) =>
-                              tr("chat.thoughtFor", { n })
+                            streaming={!!m.streaming && lastSeg === seg}
+                            locale={locale}
+                            projectPath={projectPath}
+                            onOpenResource={onOpenResource}
+                            onAddAttachmentToComposer={
+                              onAddAttachmentToComposer
                             }
+                            attachLabels={attachLabels}
+                            findQuery={findQuery}
+                            findActiveOccurrence={
+                              isFindCurrent
+                                ? (findActive?.occurrence ?? null)
+                                : null
+                            }
+                            findOccurrenceBase={segBase}
                           />
                         );
-                      }
-                      return (
-                        <AssistantMessageBody
-                          key={`${m.id}-c-${si}`}
-                          content={seg.text}
-                          attachments={
-                            si === lastContentSi ? m.attachments : undefined
-                          }
-                          streaming={!!m.streaming && lastSeg === seg}
-                          locale={locale}
-                          projectPath={projectPath}
-                          onOpenResource={onOpenResource}
-                          onAddAttachmentToComposer={
-                            onAddAttachmentToComposer
-                          }
-                          attachLabels={attachLabels}
-                        />
-                      );
-                    })}
+                      });
+                    })()}
                     {/* Body-less turn with only attachments */}
                     {!contentSegCount && m.attachments?.length ? (
                       <AssistantMessageBody
@@ -673,6 +825,12 @@ export function ConversationThread({
                         onOpenResource={onOpenResource}
                         onAddAttachmentToComposer={onAddAttachmentToComposer}
                         attachLabels={attachLabels}
+                        findQuery={findQuery}
+                        findActiveOccurrence={
+                          isFindCurrent
+                            ? (findActive?.occurrence ?? null)
+                            : null
+                        }
                       />
                     ) : null}
                   </div>

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -11,6 +11,7 @@ import { ImageUi, imageUiLabels } from "@/components/ImageUi";
 import { VideoUi, videoUiLabels } from "@/components/VideoUi";
 import { FilePathCard } from "@/components/FilePathCard";
 import type { ResourceOpenTarget } from "@/components/ResourceViewer";
+import { HighlightedText } from "@/components/HighlightedText";
 import {
   isImagePath,
   isVideoPath,
@@ -29,6 +30,55 @@ import {
 import { useSmoothStream } from "@/hooks/useSmoothStream";
 import { cn } from "@/lib/utils";
 import { CodeBlock } from "./CodeBlock";
+
+/** Highlight string leaves for in-chat find (markdown-safe). */
+function highlightChildren(
+  children: ReactNode,
+  query: string,
+  activeOccurrence: number | null | undefined,
+  counter: { n: number },
+): ReactNode {
+  const q = query.trim();
+  if (!q) return children;
+  if (typeof children === "string" || typeof children === "number") {
+    const text = String(children);
+    const base = counter.n;
+    // Count matches in this leaf so subsequent leaves get correct indices.
+    const lower = text.toLowerCase();
+    const qLower = q.toLowerCase();
+    let from = 0;
+    let local = 0;
+    while (from < lower.length) {
+      const at = lower.indexOf(qLower, from);
+      if (at < 0) break;
+      local += 1;
+      from = at + q.length;
+    }
+    const activeLocal =
+      activeOccurrence != null &&
+      activeOccurrence >= base &&
+      activeOccurrence < base + local
+        ? activeOccurrence - base
+        : null;
+    counter.n += local;
+    if (local === 0) return text;
+    return (
+      <HighlightedText
+        text={text}
+        query={q}
+        activeOccurrence={activeLocal}
+      />
+    );
+  }
+  if (Array.isArray(children)) {
+    return children.map((c, i) => (
+      <span key={i}>
+        {highlightChildren(c, query, activeOccurrence, counter)}
+      </span>
+    ));
+  }
+  return children;
+}
 
 function softCloseMarkdown(src: string, streaming: boolean): string {
   if (!streaming || !src) return src;
@@ -58,6 +108,9 @@ export const MarkdownChat = memo(function MarkdownChat({
   imagePathMap,
   projectPath,
   onOpenResource,
+  findQuery = "",
+  findActiveOccurrence = null,
+  findOccurrenceBase = 0,
 }: {
   children: string;
   streaming?: boolean;
@@ -67,6 +120,11 @@ export const MarkdownChat = memo(function MarkdownChat({
   imagePathMap?: Record<string, string>;
   projectPath?: string | null;
   onOpenResource?: (target: ResourceOpenTarget) => void;
+  /** In-chat find query — highlights string leaves in markdown. */
+  findQuery?: string;
+  findActiveOccurrence?: number | null;
+  /** Starting occurrence index for multi-segment assistant bodies. */
+  findOccurrenceBase?: number;
 }) {
   const tr = useMemo(() => createT(locale), [locale]);
   const imageLabels = useMemo(() => imageUiLabels(locale), [locale]);
@@ -229,6 +287,14 @@ export const MarkdownChat = memo(function MarkdownChat({
     );
   };
 
+  // Fresh counter each render so occurrence indices stay stable for the mark.
+  const findCounter = { n: findOccurrenceBase };
+  const qFind = findQuery.trim();
+  const paint = (node: ReactNode) =>
+    qFind
+      ? highlightChildren(node, qFind, findActiveOccurrence, findCounter)
+      : node;
+
   return (
     <div
       className={cn(
@@ -241,6 +307,19 @@ export const MarkdownChat = memo(function MarkdownChat({
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
+          p: ({ children: c }) => <p>{paint(c)}</p>,
+          li: ({ children: c }) => <li>{paint(c)}</li>,
+          strong: ({ children: c }) => <strong>{paint(c)}</strong>,
+          em: ({ children: c }) => <em>{paint(c)}</em>,
+          h1: ({ children: c }) => <h1>{paint(c)}</h1>,
+          h2: ({ children: c }) => <h2>{paint(c)}</h2>,
+          h3: ({ children: c }) => <h3>{paint(c)}</h3>,
+          h4: ({ children: c }) => <h4>{paint(c)}</h4>,
+          blockquote: ({ children: c }) => (
+            <blockquote>{paint(c)}</blockquote>
+          ),
+          td: ({ children: c }) => <td>{paint(c)}</td>,
+          th: ({ children: c }) => <th>{paint(c)}</th>,
           a: ({ href, children: c }) => {
             const text = textFromChildren(c).trim();
             const hrefStr = typeof href === "string" ? href : "";
@@ -255,7 +334,7 @@ export const MarkdownChat = memo(function MarkdownChat({
                 target="_blank"
                 rel="noreferrer noopener"
               >
-                {c}
+                {paint(c)}
               </a>
             );
           },
@@ -270,7 +349,9 @@ export const MarkdownChat = memo(function MarkdownChat({
               const raw = textFromChildren(c).replace(/\n$/, "").trim();
               const card = renderPathOrUrl(raw);
               if (card) return card;
-              return <code className="chat-md__inline-code">{c}</code>;
+              return (
+                <code className="chat-md__inline-code">{paint(c)}</code>
+              );
             }
             return (
               <CodeBlock

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -470,6 +470,15 @@ const en = {
   "search.matchCount": "{n} matches",
   "search.searchingContent": "Searching messages…",
 
+  // In-conversation find (Cmd/Ctrl+F)
+  "chatFind.placeholder": "Find in conversation…",
+  "chatFind.prev": "Previous match",
+  "chatFind.next": "Next match",
+  "chatFind.close": "Close find",
+  "chatFind.count": "{current} / {total}",
+  "chatFind.noMatches": "No matches",
+  "chatFind.aria": "Find in conversation",
+
   // Plan card
   "plan.waiting": "Waiting for plan",
   "plan.ready": "Plan ready for review",
@@ -925,6 +934,7 @@ const en = {
   "shortcuts.title": "Keyboard shortcuts",
   "shortcuts.close": "Close",
   "shortcuts.search": "Search chats / projects",
+  "shortcuts.findInChat": "Find in conversation",
   "shortcuts.newChat": "New chat",
   "shortcuts.settings": "Settings",
   "shortcuts.doctor": "Doctor",
@@ -1685,6 +1695,14 @@ const zh: Record<MessageKey, string> = {
   "search.matchCount": "{n} 处匹配",
   "search.searchingContent": "正在搜索消息…",
 
+  "chatFind.placeholder": "在对话中查找…",
+  "chatFind.prev": "上一个匹配",
+  "chatFind.next": "下一个匹配",
+  "chatFind.close": "关闭查找",
+  "chatFind.count": "{current} / {total}",
+  "chatFind.noMatches": "无匹配",
+  "chatFind.aria": "在对话中查找",
+
   "plan.waiting": "等待计划",
   "plan.ready": "计划待审阅",
   "plan.context": "上下文",
@@ -2129,6 +2147,7 @@ const zh: Record<MessageKey, string> = {
   "shortcuts.title": "键盘快捷键",
   "shortcuts.close": "关闭",
   "shortcuts.search": "搜索会话 / 项目",
+  "shortcuts.findInChat": "在对话中查找",
   "shortcuts.newChat": "新建会话",
   "shortcuts.settings": "设置",
   "shortcuts.doctor": "Doctor",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -446,6 +446,14 @@ export const zhTW: Record<MessageKey, string> = {
   "search.matchCount": "{n} 處相符",
   "search.searchingContent": "正在搜尋訊息…",
 
+  "chatFind.placeholder": "在對話中尋找…",
+  "chatFind.prev": "上一個相符",
+  "chatFind.next": "下一個相符",
+  "chatFind.close": "關閉尋找",
+  "chatFind.count": "{current} / {total}",
+  "chatFind.noMatches": "無相符",
+  "chatFind.aria": "在對話中尋找",
+
   "plan.waiting": "等待計劃",
   "plan.ready": "計劃待審閱",
   "plan.context": "上下文",
@@ -890,6 +898,7 @@ export const zhTW: Record<MessageKey, string> = {
   "shortcuts.title": "鍵盤快捷鍵",
   "shortcuts.close": "關閉",
   "shortcuts.search": "搜尋對話 / 專案",
+  "shortcuts.findInChat": "在對話中尋找",
   "shortcuts.newChat": "新增對話",
   "shortcuts.settings": "設定",
   "shortcuts.doctor": "Doctor",

--- a/src/lib/chatFind.test.ts
+++ b/src/lib/chatFind.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  findChatMatches,
+  formatChatFindCount,
+  searchableTextForMessage,
+  splitHighlightParts,
+  stepChatFindIndex,
+  type ChatFindMessage,
+} from "./chatFind";
+
+const msgs: ChatFindMessage[] = [
+  { id: "u1", role: "user", content: "Please fix the Doctor reset flow" },
+  {
+    id: "a1",
+    role: "assistant",
+    content: "I'll inspect Doctor reset and the doctor CLI path.",
+  },
+  {
+    id: "t1",
+    role: "tool",
+    content: "tool_step|completed|read|Read doctor.rs\n/tmp/doctor.rs",
+    toolTitle: "Read doctor.rs",
+    marker: "tool_step",
+  },
+  { id: "u2", role: "user", content: "Also update README" },
+];
+
+describe("searchableTextForMessage", () => {
+  it("uses content for user/assistant", () => {
+    expect(searchableTextForMessage(msgs[0]!)).toContain("Doctor");
+    expect(searchableTextForMessage(msgs[1]!)).toContain("doctor CLI");
+  });
+
+  it("prefers toolTitle for tools", () => {
+    expect(searchableTextForMessage(msgs[2]!)).toBe("Read doctor.rs");
+  });
+
+  it("parses tool_step header when title missing", () => {
+    expect(
+      searchableTextForMessage({
+        id: "t",
+        role: "tool",
+        content: "tool_step|running|bash|Run cargo test",
+        marker: "tool_step",
+      }),
+    ).toBe("Run cargo test");
+  });
+});
+
+describe("findChatMatches", () => {
+  it("returns empty for blank query", () => {
+    expect(findChatMatches("  ", msgs)).toEqual([]);
+    expect(findChatMatches("", msgs)).toEqual([]);
+  });
+
+  it("matches case-insensitively across messages", () => {
+    const hits = findChatMatches("doctor", msgs);
+    expect(hits.length).toBeGreaterThanOrEqual(3);
+    expect(hits[0]?.messageId).toBe("u1");
+    expect(hits.map((h) => h.messageId)).toContain("a1");
+    expect(hits.map((h) => h.messageId)).toContain("t1");
+    // Global indices are dense 0..n-1
+    expect(hits.map((h) => h.index)).toEqual(hits.map((_, i) => i));
+  });
+
+  it("tracks per-message occurrence", () => {
+    const hits = findChatMatches("doctor", msgs);
+    const inA1 = hits.filter((h) => h.messageId === "a1");
+    // "Doctor" + "doctor" in assistant content
+    expect(inA1.length).toBe(2);
+    expect(inA1[0]?.occurrence).toBe(0);
+    expect(inA1[1]?.occurrence).toBe(1);
+  });
+
+  it("records start/end offsets into searchable text", () => {
+    const hits = findChatMatches("README", msgs);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.messageId).toBe("u2");
+    expect(hits[0]?.start).toBe(msgs[3]!.content.indexOf("README"));
+    expect(hits[0]?.end - hits[0]!.start).toBe("README".length);
+  });
+
+  it("does not match roles outside chat findables", () => {
+    const hits = findChatMatches("x", [
+      { id: "sys", role: "system", content: "xxx" },
+    ]);
+    expect(hits).toHaveLength(0);
+  });
+});
+
+describe("stepChatFindIndex", () => {
+  it("wraps forward and backward", () => {
+    expect(stepChatFindIndex(0, 3, 1)).toBe(1);
+    expect(stepChatFindIndex(2, 3, 1)).toBe(0);
+    expect(stepChatFindIndex(0, 3, -1)).toBe(2);
+    expect(stepChatFindIndex(1, 3, -1)).toBe(0);
+  });
+
+  it("handles empty / out-of-range", () => {
+    expect(stepChatFindIndex(0, 0, 1)).toBe(0);
+    expect(stepChatFindIndex(-1, 4, 1)).toBe(0);
+    expect(stepChatFindIndex(99, 4, -1)).toBe(3);
+  });
+});
+
+describe("splitHighlightParts", () => {
+  it("returns plain when no query", () => {
+    expect(splitHighlightParts("Hello", "")).toEqual([
+      { text: "Hello", match: false },
+    ]);
+  });
+
+  it("splits multiple case-insensitive hits", () => {
+    const parts = splitHighlightParts("Foo doctor FOO", "foo");
+    expect(parts.filter((p) => p.match).map((p) => p.text)).toEqual([
+      "Foo",
+      "FOO",
+    ]);
+    expect(parts.filter((p) => p.match).map((p) => p.occurrence)).toEqual([
+      0, 1,
+    ]);
+    expect(parts.map((p) => p.text).join("")).toBe("Foo doctor FOO");
+  });
+});
+
+describe("formatChatFindCount", () => {
+  it("is 1-based for display and zero when empty", () => {
+    expect(formatChatFindCount(0, 5)).toEqual({ current: 1, total: 5 });
+    expect(formatChatFindCount(4, 5)).toEqual({ current: 5, total: 5 });
+    expect(formatChatFindCount(0, 0)).toEqual({ current: 0, total: 0 });
+  });
+});

--- a/src/lib/chatFind.ts
+++ b/src/lib/chatFind.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure in-conversation find helpers (Cmd/Ctrl+F).
+ * Case-insensitive match over user + assistant message text (and tool titles).
+ */
+
+export type ChatFindMessage = {
+  id: string;
+  role: "user" | "assistant" | "tool" | string;
+  content: string;
+  /** Optional tool display title when role is tool / tool_step. */
+  toolTitle?: string | null;
+  marker?: string | null;
+};
+
+export type ChatFindMatch = {
+  /** Global 0-based index among all matches for the query. */
+  index: number;
+  messageId: string;
+  /** 0-based occurrence within this message's searchable text. */
+  occurrence: number;
+  start: number;
+  end: number;
+};
+
+/**
+ * Extract plain text searched for a message.
+ * User/assistant: message body. Tool: title (or content fallback).
+ * Skips empty / non-searchable rows.
+ */
+export function searchableTextForMessage(m: ChatFindMessage): string {
+  if (m.role === "user" || m.role === "assistant") {
+    return m.content ?? "";
+  }
+  if (m.role === "tool" || m.marker === "tool_step") {
+    const title = (m.toolTitle || "").trim();
+    if (title) return title;
+    // tool_step|status|kind|title\n…
+    const raw = m.content ?? "";
+    if (raw.startsWith("tool_step|")) {
+      const header = raw.split("\n")[0] || "";
+      const parts = header.split("|");
+      return parts.slice(3).join("|") || parts[2] || "";
+    }
+    return raw;
+  }
+  return "";
+}
+
+/** Whether this message should participate in find (has searchable text path). */
+export function isChatFindableMessage(m: ChatFindMessage): boolean {
+  return m.role === "user" || m.role === "assistant" || m.role === "tool" || m.marker === "tool_step";
+}
+
+/**
+ * Find all case-insensitive occurrences of `query` across messages
+ * in document order. Empty / whitespace-only query → no matches.
+ */
+export function findChatMatches(
+  query: string,
+  messages: ChatFindMessage[],
+): ChatFindMatch[] {
+  const q = query.trim();
+  if (!q) return [];
+  const qLower = q.toLowerCase();
+  const out: ChatFindMatch[] = [];
+
+  for (const m of messages) {
+    if (!isChatFindableMessage(m)) continue;
+    const text = searchableTextForMessage(m);
+    if (!text) continue;
+    const lower = text.toLowerCase();
+    let from = 0;
+    let occurrence = 0;
+    while (from < lower.length) {
+      const at = lower.indexOf(qLower, from);
+      if (at < 0) break;
+      out.push({
+        index: out.length,
+        messageId: m.id,
+        occurrence,
+        start: at,
+        end: at + q.length,
+      });
+      occurrence += 1;
+      // Advance by query length so overlapping runs (e.g. "aa" in "aaa")
+      // still produce stable non-overlapping hits like browsers.
+      from = at + q.length;
+    }
+  }
+
+  return out;
+}
+
+/** Next / previous match index with wrap-around. */
+export function stepChatFindIndex(
+  current: number,
+  total: number,
+  direction: 1 | -1,
+): number {
+  if (total <= 0) return 0;
+  if (current < 0 || current >= total) {
+    return direction === 1 ? 0 : total - 1;
+  }
+  return (current + direction + total) % total;
+}
+
+export type HighlightPart = {
+  text: string;
+  /** True when this slice is a match for the query. */
+  match: boolean;
+  /** Occurrence index within the full `text` argument (only for match parts). */
+  occurrence?: number;
+};
+
+/**
+ * Split plain text into alternating plain / match parts for rendering
+ * `<mark>` nodes. Case-insensitive; empty query returns a single plain part.
+ */
+export function splitHighlightParts(text: string, query: string): HighlightPart[] {
+  const q = query.trim();
+  if (!q || !text) {
+    return text ? [{ text, match: false }] : [];
+  }
+  const qLower = q.toLowerCase();
+  const lower = text.toLowerCase();
+  const parts: HighlightPart[] = [];
+  let from = 0;
+  let occurrence = 0;
+  while (from < text.length) {
+    const at = lower.indexOf(qLower, from);
+    if (at < 0) {
+      parts.push({ text: text.slice(from), match: false });
+      break;
+    }
+    if (at > from) {
+      parts.push({ text: text.slice(from, at), match: false });
+    }
+    parts.push({
+      text: text.slice(at, at + q.length),
+      match: true,
+      occurrence,
+    });
+    occurrence += 1;
+    from = at + q.length;
+  }
+  return parts;
+}
+
+/** Display label like "3 / 12" or "0 / 0". */
+export function formatChatFindCount(activeIndex: number, total: number): {
+  current: number;
+  total: number;
+} {
+  if (total <= 0) return { current: 0, total: 0 };
+  const current = activeIndex >= 0 && activeIndex < total ? activeIndex + 1 : 1;
+  return { current, total };
+}

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -22,6 +22,12 @@ export const SHORTCUTS: ShortcutRow[] = [
     win: "Ctrl K",
   },
   {
+    id: "findInChat",
+    labelKey: "shortcuts.findInChat",
+    mac: "⌘ F",
+    win: "Ctrl F",
+  },
+  {
     id: "newChat",
     labelKey: "shortcuts.newChat",
     mac: "⌘ N",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4674,6 +4674,134 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   }
 }
 
+/* In-conversation find bar (Cmd/Ctrl+F) */
+.chat-find {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px var(--space-5) 0;
+  padding: 6px 8px 6px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-card, var(--bg-elevated));
+  min-width: 0;
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--border-subtle) 60%, transparent);
+}
+
+.chat-find__icon {
+  display: inline-flex;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.chat-find__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 28px;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.chat-find__input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.chat-find__input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.chat-find__count {
+  flex-shrink: 0;
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+  min-width: 4.5em;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.chat-find__count.is-empty {
+  color: var(--text-secondary);
+}
+
+.chat-find__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.chat-find__btn {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0;
+}
+
+.chat-find__btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.chat-find__btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.chat-find__btn--close {
+  color: var(--text-tertiary);
+}
+
+.chat-find__chev--up {
+  transform: rotate(90deg);
+}
+
+/* Find hit marks + message chrome */
+.chat-find-mark {
+  background: color-mix(in srgb, #e6b800 48%, transparent);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.chat-find-mark--current {
+  background: color-mix(in srgb, #ff9f0a 72%, transparent);
+  outline: 1px solid color-mix(in srgb, #ff9f0a 80%, transparent);
+}
+
+[data-theme="light"] .chat-find-mark {
+  background: color-mix(in srgb, #f5d76e 70%, transparent);
+}
+
+[data-theme="light"] .chat-find-mark--current {
+  background: color-mix(in srgb, #ffb020 78%, transparent);
+}
+
+.lobe-chat-item--find-current {
+  border-radius: 12px;
+  outline: 1px solid color-mix(in srgb, var(--accent) 42%, transparent);
+  outline-offset: 2px;
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+
+.lobe-chat-error.lobe-chat-item--find-current {
+  outline: 1px solid color-mix(in srgb, var(--accent) 42%, transparent);
+  outline-offset: 2px;
+}
+
 /* Sticky plan/goal bar above the chat stage — accent blue-violet, theme-aware */
 .plan-bar {
   display: flex;


### PR DESCRIPTION
## Problem

Sidebar / command-palette search is cross-session (titles, projects). There was no way to search the **open transcript** the way browsers do with Cmd/Ctrl+F.

## Changes

- In-chat find bar (above the stage): query, prev/next, match count, close
- Case-insensitive match over **user + assistant** message text
- Highlights matches (current match stronger); scrolls the current hit into view
- Keyboard:
  - **Cmd/Ctrl+F** open (works even while the composer is focused)
  - **Enter** next / **Shift+Enter** prev (in the find field)
  - **Escape** close
  - Plain typing in the composer is unchanged when the bar is closed
- Pure matcher: `src/lib/chatFind.ts` + vitest
- i18n: en + zh + zh-TW; shortcuts help lists the binding
- CSS aligned with existing plan-bar / chrome tokens

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (360 tests, including `chatFind.test.ts`)
- [ ] Open a chat with several messages → **Cmd/Ctrl+F** shows the bar and focuses the input
- [ ] Type a query present in user and assistant text → count updates; Enter / Shift+Enter / buttons cycle matches
- [ ] Current match scrolls into view and is highlighted; other hits stay lightly marked
- [ ] Escape closes the bar; after close, typing in the composer is normal
- [ ] **Cmd/Ctrl+K** still opens palette search (unchanged)
- [ ] Switch locale (en / 简体 / 繁體) → find bar + shortcuts labels update