### PR TITLE
feat: pin sessions to top of sidebar

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -418,6 +418,11 @@ pub async fn session_set_archived(id: String, archived: bool) -> Result<SessionM
     store::set_session_archived(&id, archived)
 }
 
+#[tauri::command]
+pub async fn session_set_pinned(id: String, pinned: bool) -> Result<SessionMeta, String> {
+    store::set_session_pinned(&id, pinned)
+}
+
 /// Move session under a project (or clear project → orphan / 「其他会话」).
 #[tauri::command]
 pub async fn session_set_project(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -158,6 +158,7 @@ pub fn run() {
             commands::session_delete,
             commands::session_rename,
             commands::session_set_archived,
+            commands::session_set_pinned,
             commands::session_set_project,
             commands::session_set_scheduled,
             commands::session_messages,

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -103,6 +103,9 @@ pub struct SessionMeta {
     /// Archived chats stay on disk but hide from the default tree.
     #[serde(default)]
     pub archived: bool,
+    /// Pinned chats float to the top of the sidebar (within their group).
+    #[serde(default)]
+    pub pinned: bool,
     /// Per-session composer prefs (used when scope = session).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effort: Option<String>,
@@ -460,11 +463,20 @@ pub fn set_project_permission_policy(
     Ok(clone)
 }
 
+/// Pinned first, then newest `updated_at` (mirrors project pin sort).
+pub fn sort_sessions_by_pin_then_updated(list: &mut [SessionMeta]) {
+    list.sort_by(|a, b| match (b.pinned, a.pinned) {
+        (true, false) => std::cmp::Ordering::Greater,
+        (false, true) => std::cmp::Ordering::Less,
+        _ => b.updated_at.cmp(&a.updated_at),
+    });
+}
+
 pub fn load_sessions_index() -> Vec<SessionMeta> {
     let _ = ensure_app_dirs();
     // Recover from torn/corrupt index (shared CLI+App or crash mid-write).
     let mut list: Vec<SessionMeta> = read_json_recover(&sessions_index_file());
-    list.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    sort_sessions_by_pin_then_updated(&mut list);
     list
 }
 
@@ -488,6 +500,7 @@ pub fn create_session(
         updated_at: now,
         model_id: None,
         archived: false,
+        pinned: false,
         effort: None,
         mode: None,
         permission_policy: None,
@@ -559,6 +572,19 @@ pub fn set_session_archived(id: &str, archived: bool) -> Result<SessionMeta, Str
         .ok_or_else(|| "session not found".to_string())?;
     s.archived = archived;
     s.updated_at = Utc::now();
+    let clone = s.clone();
+    save_sessions_index(&list)?;
+    Ok(clone)
+}
+
+pub fn set_session_pinned(id: &str, pinned: bool) -> Result<SessionMeta, String> {
+    let mut list = load_sessions_index();
+    let s = list
+        .iter_mut()
+        .find(|s| s.id == id)
+        .ok_or_else(|| "session not found".to_string())?;
+    s.pinned = pinned;
+    // Do not bump updated_at — pin is organizational (same as project pin).
     let clone = s.clone();
     save_sessions_index(&list)?;
     Ok(clone)
@@ -1217,6 +1243,7 @@ pub fn save_composer_prefs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
 
     #[test]
     fn redact_scrubs_long_tokenish() {
@@ -1236,5 +1263,50 @@ mod tests {
         assert_eq!(s.max_concurrent_agents, 3);
         assert_eq!(s.agent_idle_minutes, 30);
         assert_eq!(s.stream_stall_seconds, 120);
+    }
+
+    fn sample_session(id: &str, pinned: bool, updated: DateTime<Utc>) -> SessionMeta {
+        SessionMeta {
+            id: id.into(),
+            project_id: None,
+            title: id.into(),
+            agent_session_id: None,
+            created_at: updated,
+            updated_at: updated,
+            model_id: None,
+            archived: false,
+            pinned,
+            effort: None,
+            mode: None,
+            permission_policy: None,
+            scheduled: false,
+        }
+    }
+
+    #[test]
+    fn sessions_sort_pinned_first_then_updated_at() {
+        let t1 = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let t2 = Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap();
+        let t3 = Utc.with_ymd_and_hms(2024, 1, 3, 0, 0, 0).unwrap();
+        let mut list = vec![
+            sample_session("unpinned-mid", false, t2),
+            sample_session("pinned-old", true, t1),
+            sample_session("unpinned-new", false, t3),
+            sample_session("pinned-new", true, t3),
+        ];
+        sort_sessions_by_pin_then_updated(&mut list);
+        let ids: Vec<&str> = list.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["pinned-new", "pinned-old", "unpinned-new", "unpinned-mid"]);
+    }
+
+    #[test]
+    fn session_meta_pinned_defaults_false_on_deserialize() {
+        let raw = r#"{
+            "id":"x","title":"t","createdAt":"2024-01-01T00:00:00Z",
+            "updatedAt":"2024-01-01T00:00:00Z"
+        }"#;
+        let m: SessionMeta = serde_json::from_str(raw).expect("deserialize legacy session");
+        assert!(!m.pinned);
+        assert!(!m.archived);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,8 @@ interface SessionRow {
   projectId: string | null;
   updatedAt: string;
   archived?: boolean;
+  /** Pinned chats float to the top of the sidebar */
+  pinned?: boolean;
   /** Shell scheduled-automation run */
   scheduled?: boolean;
 }
@@ -769,13 +771,20 @@ export default function App() {
       );
       setSessions(
         (
-          s as Array<SessionRow & { archived?: boolean; scheduled?: boolean }>
+          s as Array<
+            SessionRow & {
+              archived?: boolean;
+              pinned?: boolean;
+              scheduled?: boolean;
+            }
+          >
         ).map((x) => ({
           id: x.id,
           title: x.title,
           projectId: x.projectId,
           updatedAt: x.updatedAt,
           archived: !!x.archived,
+          pinned: !!x.pinned,
           scheduled: !!x.scheduled,
         })),
       );
@@ -2189,6 +2198,7 @@ export default function App() {
           projectId: s.projectId,
           updatedAt: s.updatedAt,
           archived: !!s.archived,
+          pinned: !!s.pinned,
           scheduled: !!s.scheduled,
         })),
       );
@@ -2658,6 +2668,17 @@ export default function App() {
       } else if (!archived && s.projectId) {
         setExpandedProjects((e) => ({ ...e, [s.projectId!]: true }));
       }
+    } catch (e) {
+      setLocalError(String(e));
+    }
+  };
+
+  /** Pin / unpin a session (floats to top of its sidebar group). */
+  const pinSession = async (s: SessionRow, pinned = true) => {
+    setCtxMenu(null);
+    try {
+      await api.sessionSetPinned(s.id, pinned);
+      await refreshSessions();
     } catch (e) {
       setLocalError(String(e));
     }
@@ -4074,6 +4095,7 @@ export default function App() {
           projectId: meta.projectId ?? source.projectId,
           updatedAt: meta.updatedAt || new Date().toISOString(),
           archived: meta.archived,
+          pinned: !!(meta as SessionRow).pinned,
           scheduled: meta.scheduled,
         };
         const proj = row.projectId
@@ -6352,6 +6374,18 @@ export default function App() {
                                   }}
                                 >
                                   <span className="tree-l3__title">
+                                    {s.pinned ? (
+                                      <span
+                                        className="tree-l3__kind"
+                                        title={tr("session.pinned")}
+                                        aria-label={tr("session.pinned")}
+                                      >
+                                        <IconPin
+                                          size={12}
+                                          className="tree-l3__pin"
+                                        />
+                                      </span>
+                                    ) : null}
                                     {s.scheduled ? (
                                       <span
                                         className="tree-l3__kind"
@@ -6380,7 +6414,29 @@ export default function App() {
                                       </span>
                                     </Tip>
                                   ) : (
-                                    <span className="tree-l3__actions">
+                                    <span className="tree-l3__actions tree-l3__actions--triple">
+                                      <Tip
+                                        label={
+                                          s.pinned
+                                            ? tr("session.unpin")
+                                            : tr("session.pin")
+                                        }
+                                      >
+                                        <button
+                                          type="button"
+                                          className="tree-icon-btn"
+                                          onClick={(e) => {
+                                            e.stopPropagation();
+                                            void pinSession(s, !s.pinned);
+                                          }}
+                                        >
+                                          {s.pinned ? (
+                                            <IconPinOff size={13} />
+                                          ) : (
+                                            <IconPin size={13} />
+                                          )}
+                                        </button>
+                                      </Tip>
                                       <Tip
                                         label={
                                           s.archived
@@ -6481,6 +6537,18 @@ export default function App() {
                       }}
                     >
                       <span className="tree-l3__title">
+                        {s.pinned ? (
+                          <span
+                            className="tree-l3__kind"
+                            title={tr("session.pinned")}
+                            aria-label={tr("session.pinned")}
+                          >
+                            <IconPin
+                              size={12}
+                              className="tree-l3__pin"
+                            />
+                          </span>
+                        ) : null}
                         {s.scheduled ? (
                           <span
                             className="tree-l3__kind"
@@ -6507,7 +6575,29 @@ export default function App() {
                           </span>
                         </Tip>
                       ) : (
-                        <span className="tree-l3__actions">
+                        <span className="tree-l3__actions tree-l3__actions--triple">
+                          <Tip
+                            label={
+                              s.pinned
+                                ? tr("session.unpin")
+                                : tr("session.pin")
+                            }
+                          >
+                            <button
+                              type="button"
+                              className="tree-icon-btn"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                void pinSession(s, !s.pinned);
+                              }}
+                            >
+                              {s.pinned ? (
+                                <IconPinOff size={13} />
+                              ) : (
+                                <IconPin size={13} />
+                              )}
+                            </button>
+                          </Tip>
                           <Tip label={tr("sidebar.archive")}>
                             <button
                               type="button"
@@ -8250,6 +8340,18 @@ export default function App() {
               session.sessionId === s.id ||
               viewingSessionIdRef.current === s.id;
             items = [
+              {
+                id: "pin",
+                label: s.pinned ? tr("session.unpin") : tr("session.pin"),
+                icon: s.pinned ? (
+                  <IconPinOff size={16} />
+                ) : (
+                  <IconPin size={16} />
+                ),
+                onClick: () => {
+                  void pinSession(s, !s.pinned);
+                },
+              },
               {
                 id: "rename",
                 label: tr("session.rename"),

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -67,6 +67,9 @@ const en = {
   "project.permissionSet": '"{name}" permission: {policy}',
   "project.permissionCleared": '"{name}" uses app permission default',
 
+  "session.pin": "Pin chat",
+  "session.unpin": "Unpin chat",
+  "session.pinned": "Pinned",
   "session.rename": "Rename",
   "session.renamePrompt": "Rename chat",
   "session.renamePlaceholder": "Chat title",
@@ -1188,6 +1191,9 @@ const zh: Record<MessageKey, string> = {
   "project.permissionSet": "「{name}」权限：{policy}",
   "project.permissionCleared": "「{name}」已恢复应用默认权限",
 
+  "session.pin": "置顶会话",
+  "session.unpin": "取消置顶",
+  "session.pinned": "已置顶",
   "session.rename": "重命名",
   "session.renamePrompt": "重命名会话",
   "session.renamePlaceholder": "会话标题",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -58,6 +58,9 @@ export const zhTW: Record<MessageKey, string> = {
   "project.permissionSet": "「{name}」權限：{policy}",
   "project.permissionCleared": "「{name}」已恢復應用程式預設權限",
 
+  "session.pin": "置頂對話",
+  "session.unpin": "取消置頂",
+  "session.pinned": "已置頂",
   "session.rename": "重新命名",
   "session.renamePrompt": "重新命名對話",
   "session.renamePlaceholder": "對話標題",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -556,6 +556,8 @@ export async function sessionsList() {
       updatedAt: string;
       modelId: string | null;
       archived?: boolean;
+      /** Pinned chats float to the top of the sidebar */
+      pinned?: boolean;
       /** Shell automation run */
       scheduled?: boolean;
     }>
@@ -630,6 +632,10 @@ export async function sessionRename(id: string, title: string) {
 
 export async function sessionSetArchived(id: string, archived: boolean) {
   return invoke("session_set_archived", { id, archived });
+}
+
+export async function sessionSetPinned(id: string, pinned: boolean) {
+  return invoke("session_set_pinned", { id, pinned });
 }
 
 /** Bind session to a project, or clear (`projectId: null`) for orphan / 其他会话. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -634,7 +634,8 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   gap: 4px;
 }
 
-.tree-l2__pin {
+.tree-l2__pin,
+.tree-l3__pin {
   flex-shrink: 0;
   opacity: 0.85;
 }
@@ -654,6 +655,12 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   opacity: 0;
   pointer-events: none;
   transition: opacity 100ms ease;
+}
+
+/* pin + archive + menu */
+.tree-l3__actions--triple {
+  width: 72px;
+  min-width: 72px;
 }
 
 .tree-l2:hover .tree-l2__actions,


### PR DESCRIPTION
## Problem
Projects can be pinned to the top of the sidebar; sessions cannot. Long project lists bury important chats.

## Changes
- Add `pinned: bool` to `SessionMeta` (serde default `false`) and persist in the sessions index
- New command `session_set_pinned(id, pinned)`
- Sort: pinned first, then `updated_at` (same pattern as projects)
- UI: context menu pin/unpin, hover pin control, pin icon when pinned
- i18n: `session.pin` / `session.unpin` / `session.pinned` (en, zh, zh-TW)

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- src/i18n/messages.test.ts`
- [x] `cargo test --lib store::tests::sessions_sort_pinned`
- [x] `cargo test --lib store::tests::session_meta_pinned`
- [ ] Manual: pin a chat → floats above unpinned in the same group; unpin restores order by recency; restart keeps pin