### PR TITLE
feat: remove git worktree from project chip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,28 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
-- **App update check** (#58): Settings → about / update checks GitHub Releases for newer installers.
-- **Active agent tasks panel** (#59): right pane shows live tool tasks from the current stream.
-- **Session content search** (#60): command palette / search matches journal message text, not only titles.
-- **Plugin install & update** (#61): Settings → Extensions can install and update plugins (not only enable/disable).
-- **Sandbox profile** (#66): Settings → Runtime sandbox (`off` / `workspace` / `read-only` / `strict` / `devbox`) at agent spawn.
-- **Pin sessions** (#73): pin chats to the top of the sidebar (like projects).
-- **Project inspect** (#75): Settings → Runtime summary from `grok inspect --json` (secret-safe).
-- **CLI doctor in App Doctor** (#76): merge `grok doctor --json` findings into the Doctor modal.
-
-### Fixed
-
-- **Session data mode switch** (#62): flipping independent↔shared recycles live/background/parked agents so none keep the old `GROK_HOME`.
-- **Missing project folder** (#65): pathOk UX to relocate deleted/moved project directories.
-
-### Community
-
-- Squash-merged **#58–#62**, **#65–#66**, **#73**, **#75–#76** (sonnemusk).  
-- Remaining open PRs (**#63–#64**, **#67–#72**, **#74**, **#77–#89**) need conflict resolution against this batch (heavy overlap on `App.tsx` / `Settings` / `commands.rs` / spawn flags).
-
-**中文**
-- 新增：应用更新检查、活动任务面板、会话正文搜索、插件安装更新、沙箱配置、会话置顶、项目 inspect、CLI Doctor 合并。  
-- 修复：会话模式切换回收 Agent；缺失项目目录可重定位。
+- **Remove git worktree** from the project chip: confirm dialog (optional force for dirty/locked), host refuses main worktree, then refresh list and carefully leave/remove a matching App project row.
 
 ## [0.1.6] - 2026-07-24
 

--- a/docs/llm-wiki/git-worktrees.md
+++ b/docs/llm-wiki/git-worktrees.md
@@ -14,14 +14,15 @@ git worktree list --porcelain
 - If the path is already a project, switch only; otherwise `project_add` (trust inherited from the current project when possible).
 - Soft-fail when `git` is missing or the folder is not a repo (same spirit as Workspace Changes git status).
 - **UI:** section is hidden until host confirms `available: true` (non-git / loading → no “GIT WORKTREES” block). Rows match project list height; branch + badges on one line.
+- **Remove:** non-main rows expose Remove… → GlassModal confirm (`git worktree remove [--force]`). Main worktree is refused on the host. After success the list refreshes; if the session was on that path it leaves to the main worktree project (or clears). If an App project row still pointed at the deleted path, offer leave/remove that project entry only (other projects untouched).
 
 ## Non-goals (MVP)
 
-- Creating or removing worktrees from the App
+- Creating worktrees from the App (see separate worktree-create PR when open)
 - Full branch browser
 
 ## Implementation
 
-- Host: `git_worktrees_list` (`src-tauri/src/commands.rs`)
-- Pure parse helpers: `src/lib/gitWorktree.ts` (+ unit tests)
-- UI: `ComposerProjectMenu` worktrees section
+- Host: `git_worktrees_list`, `git_worktree_remove` (`src-tauri/src/commands.rs`) — argv only, no shell
+- Pure path helpers + refuse-main tests on the host; parse helpers: `src/lib/gitWorktree.ts` (+ unit tests)
+- UI: `ComposerProjectMenu` worktrees section + remove confirm in `App.tsx`

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4292,6 +4292,152 @@ pub async fn git_worktrees_list(project_path: String) -> Result<GitWorktreesResu
     })
 }
 
+/// Normalize a path for worktree equality checks (slash direction, no trailing
+/// slash, ASCII lowercased so macOS/Windows case-insensitive volumes match).
+pub fn normalize_worktree_path_key(raw: &str) -> String {
+    let mut s = normalize_fs_path(raw).replace('\\', "/");
+    while s.len() > 1 && s.ends_with('/') {
+        s.pop();
+    }
+    s.make_ascii_lowercase();
+    s
+}
+
+/// Case-insensitive path equality after normalization (pure; unit-tested).
+pub fn worktree_paths_equal(a: &str, b: &str) -> bool {
+    let na = normalize_worktree_path_key(a);
+    let nb = normalize_worktree_path_key(b);
+    !na.is_empty() && na == nb
+}
+
+/// Refuse removing the main (primary) worktree. Pure; unit-tested.
+pub fn refuse_remove_main_worktree(
+    listed: &[GitWorktreeEntry],
+    worktree_path: &str,
+) -> Result<(), String> {
+    let target = normalize_fs_path(worktree_path);
+    if target.is_empty() {
+        return Err("empty worktree path".into());
+    }
+    let main = listed
+        .iter()
+        .find(|w| w.is_main)
+        .or_else(|| listed.first());
+    if let Some(m) = main {
+        if worktree_paths_equal(&m.path, &target) {
+            return Err("refusing to remove the main worktree".into());
+        }
+    }
+    Ok(())
+}
+
+/// Result of `git worktree remove`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitWorktreeRemoveResult {
+    /// Absolute path that was removed.
+    pub path: String,
+    /// Whether `--force` was used.
+    pub forced: bool,
+}
+
+/// Remove a linked git worktree via `git worktree remove` (argv only, no shell).
+///
+/// Refuses the main worktree. Optional `force` maps to `--force` (dirty / locked).
+#[tauri::command]
+pub async fn git_worktree_remove(
+    project_path: String,
+    worktree_path: String,
+    force: Option<bool>,
+) -> Result<GitWorktreeRemoveResult, String> {
+    let project = normalize_fs_path(&project_path);
+    if project.is_empty() {
+        return Err("empty path".into());
+    }
+    let proj = std::path::PathBuf::from(&project);
+    if !proj.is_dir() {
+        return Err("project not a directory".into());
+    }
+    git_probe_work_tree(&project)?;
+
+    let target = normalize_fs_path(&worktree_path);
+    if target.is_empty() {
+        return Err("empty worktree path".into());
+    }
+    // Disallow option-like paths so a crafted path cannot become a git flag.
+    if target.starts_with('-') {
+        return Err("invalid worktree path".into());
+    }
+
+    let list_out = std::process::Command::new("git")
+        .args(["-C", &project, "worktree", "list", "--porcelain"])
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !list_out.status.success() {
+        let err = String::from_utf8_lossy(&list_out.stderr).trim().to_string();
+        return Err(if err.is_empty() {
+            "git worktree list failed".into()
+        } else {
+            err.chars().take(200).collect()
+        });
+    }
+    let listed = parse_worktree_porcelain(&String::from_utf8_lossy(&list_out.stdout));
+    if listed.is_empty() {
+        return Err("no worktrees found".into());
+    }
+
+    refuse_remove_main_worktree(&listed, &target)?;
+
+    let registered = listed.iter().any(|w| worktree_paths_equal(&w.path, &target));
+    if !registered {
+        return Err("worktree not registered for this repository".into());
+    }
+
+    // Use the path as listed by git (preserves real casing / form).
+    let remove_path = listed
+        .iter()
+        .find(|w| worktree_paths_equal(&w.path, &target))
+        .map(|w| w.path.clone())
+        .unwrap_or(target.clone());
+
+    let forced = force.unwrap_or(false);
+    // Safe argv — never go through a shell.
+    // `git worktree remove [--force] <path>`
+    let mut args: Vec<String> = vec![
+        "-C".into(),
+        project,
+        "worktree".into(),
+        "remove".into(),
+    ];
+    if forced {
+        args.push("--force".into());
+    }
+    args.push(remove_path.clone());
+
+    let out = std::process::Command::new("git")
+        .args(&args)
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        let err = if err.is_empty() {
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        } else {
+            err
+        };
+        return Err(if err.is_empty() {
+            "git worktree remove failed".into()
+        } else {
+            err.chars().take(400).collect()
+        });
+    }
+
+    Ok(GitWorktreeRemoveResult {
+        path: remove_path,
+        forced,
+    })
+}
+
 #[cfg(test)]
 mod git_worktree_parse_tests {
     use super::*;
@@ -4324,6 +4470,35 @@ detached
     #[test]
     fn empty_input() {
         assert!(parse_worktree_porcelain("").is_empty());
+    }
+
+    #[test]
+    fn worktree_paths_equal_normalizes_slash_and_case() {
+        assert!(worktree_paths_equal("/Users/Me/Repo", "/users/me/repo/"));
+        assert!(worktree_paths_equal(r"C:\Work\App", r"c:/work/app"));
+        assert!(!worktree_paths_equal("/a/b", "/a/c"));
+        assert!(!worktree_paths_equal("", "/a"));
+        assert!(!worktree_paths_equal("", ""));
+    }
+
+    #[test]
+    fn refuse_remove_main_worktree_blocks_primary() {
+        let list = parse_worktree_porcelain(
+            "\
+worktree /Users/me/repo
+HEAD abc
+branch refs/heads/main
+
+worktree /Users/me/repo-feat
+HEAD def
+branch refs/heads/feat
+",
+        );
+        assert!(refuse_remove_main_worktree(&list, "/Users/me/repo").is_err());
+        assert!(refuse_remove_main_worktree(&list, "/Users/me/repo/").is_err());
+        assert!(refuse_remove_main_worktree(&list, "/USERS/ME/REPO").is_err());
+        assert!(refuse_remove_main_worktree(&list, "/Users/me/repo-feat").is_ok());
+        assert!(refuse_remove_main_worktree(&list, "").is_err());
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -215,6 +215,7 @@ pub fn run() {
             commands::git_file_diff,
             commands::git_status,
             commands::git_worktrees_list,
+            commands::git_worktree_remove,
             commands::git_show_file,
             commands::fs_list_dir,
             commands::fs_read_file,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,11 +92,7 @@ import {
 } from "@/lib/permissionOptions";
 import { AskUserModal } from "@/components/AskUserModal";
 import { DoctorModal } from "@/components/DoctorModal";
-import {
-  filterSessionSearch,
-  mergeSessionSearchHits,
-  type SessionContentHit,
-} from "@/lib/sessionSearch";
+import { filterSessionSearch } from "@/lib/sessionSearch";
 import {
   sessionExportFilename,
   sessionToMarkdown,
@@ -153,8 +149,7 @@ import { GrokLogo } from "@/components/GrokLogo";
 import { SetupWizard, type SetupCliInfo } from "@/components/SetupWizard";
 import { ComposerEditor } from "@/components/ComposerEditor";
 import { ComposerProjectMenu } from "@/components/ComposerProjectMenu";
-import { pathsEqual } from "@/lib/gitWorktree";
-import { isProjectPathMissing } from "@/lib/projectPath";
+import { pathsEqual, worktreeLabel } from "@/lib/gitWorktree";
 import {
   ComposerPlusPanel,
   buildComposerPlusEntries,
@@ -269,8 +264,6 @@ interface SessionRow {
   projectId: string | null;
   updatedAt: string;
   archived?: boolean;
-  /** Pinned chats float to the top of the sidebar */
-  pinned?: boolean;
   /** Shell scheduled-automation run */
   scheduled?: boolean;
 }
@@ -409,12 +402,6 @@ export default function App() {
   appDialogRef.current = appDialog;
   const [showSearch, setShowSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  /** Debounced journal content hits from `sessions_search`. */
-  const [contentSearchHits, setContentSearchHits] = useState<
-    SessionContentHit[]
-  >([]);
-  const [contentSearchLoading, setContentSearchLoading] = useState(false);
-  const contentSearchSeq = useRef(0);
   const [showComposerPlus, setShowComposerPlus] = useState(false);
   showComposerPlusRef.current = showComposerPlus;
   const composerPlusTriggerRef = useRef<HTMLButtonElement>(null);
@@ -521,50 +508,6 @@ export default function App() {
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [showSearch]);
-
-  // Debounced content search over App journals (title filter stays instant).
-  useEffect(() => {
-    if (!showSearch) {
-      setContentSearchHits([]);
-      setContentSearchLoading(false);
-      return;
-    }
-    const q = searchQuery.trim();
-    if (!q) {
-      setContentSearchHits([]);
-      setContentSearchLoading(false);
-      return;
-    }
-    setContentSearchLoading(true);
-    const seq = ++contentSearchSeq.current;
-    const t = window.setTimeout(() => {
-      void (async () => {
-        try {
-          const hits = await api.sessionsSearch(q, 20);
-          if (contentSearchSeq.current !== seq) return;
-          setContentSearchHits(
-            hits.map((h) => ({
-              id: h.id,
-              title: h.title,
-              projectId: h.projectId,
-              snippet: h.snippet,
-              matchCount: h.matchCount,
-              updatedAt: h.updatedAt,
-              archived: h.archived,
-            })),
-          );
-        } catch {
-          if (contentSearchSeq.current !== seq) return;
-          setContentSearchHits([]);
-        } finally {
-          if (contentSearchSeq.current === seq) {
-            setContentSearchLoading(false);
-          }
-        }
-      })();
-    }, 280);
-    return () => window.clearTimeout(t);
-  }, [searchQuery, showSearch]);
 
   // Global shortcuts: search, help, doctor, new chat, settings.
   // Handlers go through refs so we don't re-bind every render.
@@ -691,7 +634,6 @@ export default function App() {
   const [agentIdleMinutes, setAgentIdleMinutes] = useState(30);
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
   const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
-  const [sandboxProfile, setSandboxProfile] = useState("off");
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -699,6 +641,14 @@ export default function App() {
   >(null);
   const [gitWorktreesLoading, setGitWorktreesLoading] = useState(false);
   const [gitWorktreesReason, setGitWorktreesReason] = useState<string | null>(
+    null,
+  );
+  /** Confirm remove for a linked (non-main) worktree. */
+  const [worktreeRemoveTarget, setWorktreeRemoveTarget] =
+    useState<api.GitWorktreeEntry | null>(null);
+  const [worktreeRemoveForce, setWorktreeRemoveForce] = useState(false);
+  const [worktreeRemoveBusy, setWorktreeRemoveBusy] = useState(false);
+  const [worktreeRemoveError, setWorktreeRemoveError] = useState<string | null>(
     null,
   );
   /** Host stream-stall prompt (I06); null when dismissed or not stalled. */
@@ -827,20 +777,13 @@ export default function App() {
       );
       setSessions(
         (
-          s as Array<
-            SessionRow & {
-              archived?: boolean;
-              pinned?: boolean;
-              scheduled?: boolean;
-            }
-          >
+          s as Array<SessionRow & { archived?: boolean; scheduled?: boolean }>
         ).map((x) => ({
           id: x.id,
           title: x.title,
           projectId: x.projectId,
           updatedAt: x.updatedAt,
           archived: !!x.archived,
-          pinned: !!x.pinned,
           scheduled: !!x.scheduled,
         })),
       );
@@ -917,11 +860,6 @@ export default function App() {
           : 120,
       );
       setStoreApiKeysInKeychain(!!settings.storeApiKeysInKeychain);
-      {
-        const sb = (settings.sandboxProfile || "off").trim().toLowerCase();
-        const known = ["off", "workspace", "read-only", "strict", "devbox"];
-        setSandboxProfile(known.includes(sb) ? sb : "off");
-      }
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -1417,22 +1355,6 @@ export default function App() {
               ) {
                 setToast(tr("agent.idleRecycledToast"));
                 window.setTimeout(() => setToast(null), 4200);
-              }
-            },
-          ),
-        );
-        await track(
-          api.listen<{ reason?: string; killed?: number }>(
-            "session://agents_recycled",
-            (p) => {
-              if (cancelled || !p) return;
-              // session_data_mode flip (and any future full recycle).
-              if (
-                p.reason === "session_data_mode" ||
-                (p.killed != null && p.killed > 0)
-              ) {
-                setToast(tr("agent.dataModeRecycledToast"));
-                window.setTimeout(() => setToast(null), 4800);
               }
             },
           ),
@@ -2047,10 +1969,9 @@ export default function App() {
     // Warm ACP: connect while the user reads history (trusted project or orphan).
     // Host serializes connect; first send no-ops if already ready, or waits if
     // still handshaking. Process is reused across sessions when cwd/effort match.
-    // Skip when project folder is missing (D05) — user must relocate first.
     if (
       api.isTauri() &&
-      (!proj || (proj.trusted && !isProjectPathMissing(proj.pathOk))) &&
+      (!proj || proj.trusted) &&
       !(live.sessionId === s.id && live.state === "ready")
     ) {
       const warmId = s.id;
@@ -2148,10 +2069,6 @@ export default function App() {
     }
     if (proj && !proj.trusted) {
       setLocalError(tr("project.trustFirst", { name: proj.name }));
-      return;
-    }
-    if (proj && isProjectPathMissing(proj.pathOk)) {
-      setLocalError(tr("project.pathMissing", { name: proj.name }));
       return;
     }
     automationSetupDraftRef.current = !!opts?.automationSetup;
@@ -2280,7 +2197,6 @@ export default function App() {
           projectId: s.projectId,
           updatedAt: s.updatedAt,
           archived: !!s.archived,
-          pinned: !!s.pinned,
           scheduled: !!s.scheduled,
         })),
       );
@@ -2312,10 +2228,6 @@ export default function App() {
           : null;
         if (proj && !proj.trusted) {
           setLocalError(tr("project.trustFirst", { name: proj.name }));
-          return false;
-        }
-        if (proj && isProjectPathMissing(proj.pathOk)) {
-          setLocalError(tr("project.pathMissing", { name: proj.name }));
           return false;
         }
         setMainPane("chat");
@@ -2550,16 +2462,12 @@ export default function App() {
   const refreshProjects = async () => {
     try {
       const list = await api.projectsList();
-      const mapped = list.map((p) => ({
-        ...p,
-        pinned: !!p.pinned,
-      })) as Project[];
-      setProjects(mapped);
-      // Keep active project pathOk/path in sync with Host re-check.
-      setActiveProject((prev) => {
-        if (!prev) return prev;
-        return mapped.find((x) => x.id === prev.id) ?? prev;
-      });
+      setProjects(
+        list.map((p) => ({
+          ...p,
+          pinned: !!p.pinned,
+        })),
+      );
     } catch {
       /* ignore */
     }
@@ -2599,55 +2507,6 @@ export default function App() {
         }
       },
     });
-  };
-
-  /**
-   * Pick a new folder for a project whose path is gone or moved (D05).
-   * Host persists path and re-checks is_dir → pathOk true.
-   */
-  const relocateProject = async (proj: Project) => {
-    setCtxMenu(null);
-    if (!api.isTauri()) {
-      setLocalError(tr("error.needTauri"));
-      return;
-    }
-    try {
-      const dir = await api.pickDirectory();
-      if (!dir) return;
-      const updated = (await api.projectRelocate(proj.id, dir)) as Project;
-      await refreshProjects();
-      void api.trayRefresh();
-      if (activeProject?.id === proj.id) {
-        setActiveProject(updated);
-        // Force reconnect on next send — cwd changed.
-        setSession((prev) =>
-          prev.sessionId
-            ? {
-                ...IDLE_SNAPSHOT,
-                sessionId: prev.sessionId,
-                title: prev.title,
-                state: "idle",
-                backend: prev.backend || "grok_agent_stdio",
-              }
-            : prev,
-        );
-        setLiveHost((prev) =>
-          prev.sessionId ? { ...IDLE_SNAPSHOT } : prev,
-        );
-      }
-      setLocalError(null);
-      const msg = tr("project.relocateOk", {
-        name: updated.name,
-        path: updated.path,
-      });
-      setToast(msg);
-      window.setTimeout(
-        () => setToast((cur) => (cur === msg ? null : cur)),
-        3200,
-      );
-    } catch (e) {
-      setLocalError(String(e));
-    }
   };
 
   /**
@@ -2812,17 +2671,6 @@ export default function App() {
     }
   };
 
-  /** Pin / unpin a session (floats to top of its sidebar group). */
-  const pinSession = async (s: SessionRow, pinned = true) => {
-    setCtxMenu(null);
-    try {
-      await api.sessionSetPinned(s.id, pinned);
-      await refreshSessions();
-    } catch (e) {
-      setLocalError(String(e));
-    }
-  };
-
   /** Permanent delete — confirm first; leave workbench if viewing that chat. */
   const deleteSessionConfirm = (s: SessionRow) => {
     deleteSessionsConfirm([s]);
@@ -2958,16 +2806,6 @@ export default function App() {
     [searchQuery, sessions, projects],
   );
 
-  const mergedSessionHits = useMemo(
-    () =>
-      mergeSessionSearchHits(
-        searchQuery,
-        searchHits.matchedSessions,
-        contentSearchHits,
-      ),
-    [searchQuery, searchHits.matchedSessions, contentSearchHits],
-  );
-
   const connPill = useMemo(
     () => connPillForState(session.state, connecting),
     [session.state, connecting],
@@ -3021,12 +2859,6 @@ export default function App() {
     // Project-less (orphan) sessions are allowed: cwd falls back on Host.
     if (activeProject && !activeProject.trusted) {
       setLocalError(tr("project.trustFirst", { name: activeProject.name }));
-      return null;
-    }
-    if (activeProject && isProjectPathMissing(activeProject.pathOk)) {
-      setLocalError(
-        tr("project.pathMissing", { name: activeProject.name }),
-      );
       return null;
     }
     // Fast path: already ready on the *preferred* session (not merely "any" ready).
@@ -4250,7 +4082,6 @@ export default function App() {
           projectId: meta.projectId ?? source.projectId,
           updatedAt: meta.updatedAt || new Date().toISOString(),
           archived: meta.archived,
-          pinned: !!(meta as SessionRow).pinned,
           scheduled: meta.scheduled,
         };
         const proj = row.projectId
@@ -4818,10 +4649,6 @@ export default function App() {
         setLocalError(tr("project.trustFirst", { name: proj.name }));
         return;
       }
-      if (proj && isProjectPathMissing(proj.pathOk)) {
-        setLocalError(tr("project.pathMissing", { name: proj.name }));
-        return;
-      }
       try {
         await api.sessionSetProject(sid, proj?.id ?? null);
         setActiveProject(proj);
@@ -5013,6 +4840,111 @@ export default function App() {
       tr,
     ],
   );
+
+  const openWorktreeRemove = useCallback((wt: api.GitWorktreeEntry) => {
+    if (wt.isMain) return;
+    setWorktreeRemoveTarget(wt);
+    setWorktreeRemoveForce(false);
+    setWorktreeRemoveError(null);
+    setWorktreeRemoveBusy(false);
+  }, []);
+
+  /**
+   * Remove linked worktree via host, refresh list, leave active session if needed,
+   * and carefully offer dropping a matching App project row (folder is gone).
+   */
+  const submitWorktreeRemove = useCallback(async () => {
+    if (!api.isTauri() || !activeProject?.path || !worktreeRemoveTarget) return;
+    const wt = worktreeRemoveTarget;
+    if (wt.isMain) {
+      setWorktreeRemoveError(tr("composer.worktreeRemoveMainBlocked"));
+      return;
+    }
+    const removedPath = wt.path;
+    const wasActive = pathsEqual(activeProject.path, removedPath);
+    const matchedProject = projects.find((p) => pathsEqual(p.path, removedPath));
+    // Main worktree project to fall back to after removing the active path.
+    const mainWt = gitWorktrees.find((w) => w.isMain) ?? gitWorktrees[0] ?? null;
+    const mainProject =
+      mainWt && !pathsEqual(mainWt.path, removedPath)
+        ? projects.find((p) => pathsEqual(p.path, mainWt.path)) ?? null
+        : null;
+
+    setWorktreeRemoveBusy(true);
+    setWorktreeRemoveError(null);
+    try {
+      // Use a cwd that will still exist after remove when deleting the active tree.
+      const gitCwd =
+        wasActive && mainWt?.path
+          ? mainWt.path
+          : activeProject.path;
+      await api.gitWorktreeRemove(
+        gitCwd,
+        removedPath,
+        worktreeRemoveForce,
+      );
+      setWorktreeRemoveTarget(null);
+      setWorktreeRemoveForce(false);
+
+      // Leave the removed cwd before refresh if we were on it.
+      if (wasActive) {
+        if (mainProject) {
+          await bindSessionProject(mainProject, { silent: true });
+        } else {
+          await bindSessionProject(null, { silent: true });
+        }
+      }
+
+      await refreshGitWorktrees();
+
+      const label = worktreeLabel(wt);
+      showToast(tr("composer.worktreeRemoved", { name: label }), 2800);
+
+      // Prefer leaving other projects alone. Only offer removing the App row
+      // that pointed at the deleted path (folder is gone; pathOk would fail).
+      if (matchedProject) {
+        const leaveId = matchedProject.id;
+        const leaveName = matchedProject.name;
+        setAppDialog({
+          kind: "confirm",
+          title: tr("composer.worktreeLeaveProjectTitle"),
+          message: tr("composer.worktreeLeaveProjectMsg", {
+            name: leaveName,
+          }),
+          confirmLabel: tr("project.remove"),
+          danger: true,
+          onConfirm: async () => {
+            try {
+              await api.projectRemove(leaveId);
+              await refreshProjects();
+              await refreshSessions();
+            } catch (e) {
+              showToast(String(e), 4500);
+            }
+          },
+        });
+      }
+    } catch (e) {
+      const msg = String(e);
+      setWorktreeRemoveError(msg);
+      // Dirty trees often need --force; surface that without closing the modal.
+      if (!worktreeRemoveForce && /force|dirty|locked|modified/i.test(msg)) {
+        setWorktreeRemoveForce(true);
+      }
+    } finally {
+      setWorktreeRemoveBusy(false);
+    }
+  }, [
+    activeProject?.path,
+    bindSessionProject,
+    gitWorktrees,
+    projects,
+    refreshGitWorktrees,
+    showToast,
+    tr,
+    worktreeRemoveForce,
+    worktreeRemoveTarget,
+  ]);
 
   /**
    * Pick folder → add project (name = folder basename; no rename prompt).
@@ -6220,13 +6152,6 @@ export default function App() {
                 showToast(String(e), 4500);
               });
           }}
-          sandboxProfile={sandboxProfile}
-          onSandboxProfile={(v) => {
-            setSandboxProfile(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, sandboxProfile: v }),
-            );
-          }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
           versionFooter={tr("app.versionFooter")}
@@ -6428,12 +6353,7 @@ export default function App() {
                   <div key={proj.id} className="tree-project">
                     {/* L2 — project folder: expand/collapse only (not selectable) */}
                     <div
-                      className={
-                        "tree-l2" +
-                        (isProjectPathMissing(proj.pathOk)
-                          ? " tree-l2--path-missing"
-                          : "")
-                      }
+                      className="tree-l2"
                       role="button"
                       tabIndex={0}
                       aria-expanded={open}
@@ -6457,13 +6377,7 @@ export default function App() {
                       <span className="tree-l2__icon">
                         <IconFolder size={15} />
                       </span>
-                      <Tip
-                        label={
-                          isProjectPathMissing(proj.pathOk)
-                            ? tr("project.pathMissing", { name: proj.name })
-                            : proj.path
-                        }
-                      >
+                      <Tip label={proj.path}>
                         <span className="tree-l2__name">
                           {proj.pinned ? (
                             <IconPin size={12} className="tree-l2__pin" />
@@ -6471,24 +6385,17 @@ export default function App() {
                           {proj.name}
                         </span>
                       </Tip>
-                      {isProjectPathMissing(proj.pathOk) ? (
-                        <span className="project-row__badge project-row__badge--path-missing">
-                          {tr("sidebar.pathMissing")}
-                        </span>
-                      ) : !proj.trusted ? (
+                      {!proj.trusted && (
                         <span className="project-row__badge">
                           {tr("sidebar.untrusted")}
                         </span>
-                      ) : null}
+                      )}
                       <span className="tree-l2__actions">
                         <Tip label={tr("sidebar.newConversation")}>
                           <button
                             type="button"
                             className="tree-icon-btn"
-                            disabled={
-                              !proj.trusted ||
-                              isProjectPathMissing(proj.pathOk)
-                            }
+                            disabled={!proj.trusted}
                             onClick={(e) => {
                               e.stopPropagation();
                               void newChat(proj);
@@ -6511,19 +6418,7 @@ export default function App() {
 
                     {open && (
                       <div className="tree-l3-list-wrap">
-                        {isProjectPathMissing(proj.pathOk) && (
-                          <button
-                            type="button"
-                            className="tree-l3 tree-l3--hint"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              void relocateProject(proj);
-                            }}
-                          >
-                            {tr("sidebar.relocateProject")}
-                          </button>
-                        )}
-                        {!proj.trusted && !isProjectPathMissing(proj.pathOk) && (
+                        {!proj.trusted && (
                           <button
                             type="button"
                             className="tree-l3 tree-l3--hint"
@@ -6570,18 +6465,6 @@ export default function App() {
                                   }}
                                 >
                                   <span className="tree-l3__title">
-                                    {s.pinned ? (
-                                      <span
-                                        className="tree-l3__kind"
-                                        title={tr("session.pinned")}
-                                        aria-label={tr("session.pinned")}
-                                      >
-                                        <IconPin
-                                          size={12}
-                                          className="tree-l3__pin"
-                                        />
-                                      </span>
-                                    ) : null}
                                     {s.scheduled ? (
                                       <span
                                         className="tree-l3__kind"
@@ -6610,29 +6493,7 @@ export default function App() {
                                       </span>
                                     </Tip>
                                   ) : (
-                                    <span className="tree-l3__actions tree-l3__actions--triple">
-                                      <Tip
-                                        label={
-                                          s.pinned
-                                            ? tr("session.unpin")
-                                            : tr("session.pin")
-                                        }
-                                      >
-                                        <button
-                                          type="button"
-                                          className="tree-icon-btn"
-                                          onClick={(e) => {
-                                            e.stopPropagation();
-                                            void pinSession(s, !s.pinned);
-                                          }}
-                                        >
-                                          {s.pinned ? (
-                                            <IconPinOff size={13} />
-                                          ) : (
-                                            <IconPin size={13} />
-                                          )}
-                                        </button>
-                                      </Tip>
+                                    <span className="tree-l3__actions">
                                       <Tip
                                         label={
                                           s.archived
@@ -6733,18 +6594,6 @@ export default function App() {
                       }}
                     >
                       <span className="tree-l3__title">
-                        {s.pinned ? (
-                          <span
-                            className="tree-l3__kind"
-                            title={tr("session.pinned")}
-                            aria-label={tr("session.pinned")}
-                          >
-                            <IconPin
-                              size={12}
-                              className="tree-l3__pin"
-                            />
-                          </span>
-                        ) : null}
                         {s.scheduled ? (
                           <span
                             className="tree-l3__kind"
@@ -6771,29 +6620,7 @@ export default function App() {
                           </span>
                         </Tip>
                       ) : (
-                        <span className="tree-l3__actions tree-l3__actions--triple">
-                          <Tip
-                            label={
-                              s.pinned
-                                ? tr("session.unpin")
-                                : tr("session.pin")
-                            }
-                          >
-                            <button
-                              type="button"
-                              className="tree-icon-btn"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                void pinSession(s, !s.pinned);
-                              }}
-                            >
-                              {s.pinned ? (
-                                <IconPinOff size={13} />
-                              ) : (
-                                <IconPin size={13} />
-                              )}
-                            </button>
-                          </Tip>
+                        <span className="tree-l3__actions">
                           <Tip label={tr("sidebar.archive")}>
                             <button
                               type="button"
@@ -7109,24 +6936,7 @@ export default function App() {
             />
           ) : (
           <>
-          {activeProject && isProjectPathMissing(activeProject.pathOk) && (
-            <div className="conn-bar">
-              <span style={{ fontSize: 12, opacity: 0.9, marginRight: 8 }}>
-                {tr("project.pathMissingShort")}
-              </span>
-              <button
-                type="button"
-                className="btn btn--primary"
-                style={{ height: 24, fontSize: 11 }}
-                onClick={() => void relocateProject(activeProject)}
-              >
-                {tr("project.relocateToSend")}
-              </button>
-            </div>
-          )}
-          {activeProject &&
-            !isProjectPathMissing(activeProject.pathOk) &&
-            !activeProject.trusted && (
+          {activeProject && !activeProject.trusted && (
             <div className="conn-bar">
               <button
                 type="button"
@@ -7690,7 +7500,7 @@ export default function App() {
                     worktreeSwitch: tr("composer.worktreeSwitch"),
                     worktreeMain: tr("composer.worktreeMain"),
                     worktreeDetached: tr("composer.worktreeDetached"),
-                    pathMissing: tr("project.pathMissingShort"),
+                    worktreeRemove: tr("composer.worktreeRemove"),
                   }}
                   worktrees={gitWorktrees}
                   worktreesAvailable={gitWorktreesAvailable}
@@ -7708,6 +7518,9 @@ export default function App() {
                   }}
                   onSwitchWorktree={(wt) => {
                     void switchToWorktree(wt);
+                  }}
+                  onRemoveWorktree={(wt) => {
+                    openWorktreeRemove(wt);
                   }}
                   onOpen={refreshGitWorktrees}
                 />
@@ -7927,7 +7740,6 @@ export default function App() {
               sessionChanges={
                 sessionChangesById[session.sessionId || ""] ?? []
               }
-              sessionMessages={messages}
               plan={plan}
               planFocusKey={planFocusKey}
               onApprovePlan={() => void approvePlan()}
@@ -7964,6 +7776,79 @@ export default function App() {
           void refreshLists();
         }}
       />
+      <GlassModal
+        open={!!worktreeRemoveTarget}
+        onClose={() => {
+          if (worktreeRemoveBusy) return;
+          setWorktreeRemoveTarget(null);
+          setWorktreeRemoveError(null);
+          setWorktreeRemoveForce(false);
+        }}
+        title={tr("composer.worktreeRemoveTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        closeOnOverlay={!worktreeRemoveBusy}
+        showClose={!worktreeRemoveBusy}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={worktreeRemoveBusy}
+              onClick={() => {
+                setWorktreeRemoveTarget(null);
+                setWorktreeRemoveError(null);
+                setWorktreeRemoveForce(false);
+              }}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--danger"
+              disabled={worktreeRemoveBusy || !worktreeRemoveTarget}
+              onClick={() => {
+                void submitWorktreeRemove();
+              }}
+            >
+              {worktreeRemoveBusy
+                ? tr("composer.worktreeRemoving")
+                : tr("composer.worktreeRemoveConfirm")}
+            </button>
+          </>
+        }
+      >
+        {worktreeRemoveTarget ? (
+          <div className="wt-remove">
+            <p className="wt-remove__msg">
+              {tr("composer.worktreeRemoveMsg", {
+                name: worktreeLabel(worktreeRemoveTarget),
+                branch:
+                  worktreeRemoveTarget.branch?.trim() ||
+                  tr("composer.worktreeDetached"),
+              })}
+            </p>
+            <p className="wt-remove__path" title={worktreeRemoveTarget.path}>
+              {worktreeRemoveTarget.path}
+            </p>
+            <label className="wt-remove__force">
+              <input
+                type="checkbox"
+                checked={worktreeRemoveForce}
+                disabled={worktreeRemoveBusy}
+                onChange={(e) => setWorktreeRemoveForce(e.target.checked)}
+              />
+              <span>{tr("composer.worktreeRemoveForce")}</span>
+            </label>
+            {worktreeRemoveError ? (
+              <p className="wt-remove__error" role="alert">
+                {worktreeRemoveError}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </GlassModal>
       <GlassModal
         open={showShortcuts}
         onClose={() => setShowShortcuts(false)}
@@ -8275,58 +8160,33 @@ export default function App() {
             )}
             <div className="search-panel__section">
               {tr("search.chats")}
-              {contentSearchLoading && searchQuery.trim()
-                ? ` · ${tr("search.searchingContent")}`
-                : null}
             </div>
-            {mergedSessionHits.length === 0 && !contentSearchLoading && (
+            {searchHits.matchedSessions.length === 0 && (
               <div className="sidebar-empty" style={{ padding: 12 }}>
                 {tr("search.noMatches")}
               </div>
             )}
-            {mergedSessionHits.map((hit, i) => {
+            {searchHits.matchedSessions.map((hit, i) => {
               const s = sessions.find((x) => x.id === hit.id);
-              // Content-only hits may lack a live row if the list is stale; still open by id.
-              const row: SessionRow = s ?? {
-                id: hit.id,
-                title: hit.title,
-                projectId: hit.projectId ?? null,
-                updatedAt: "",
-              };
-              const proj = projects.find(
-                (p) => p.id === (row.projectId ?? hit.projectId),
-              );
-              const metaParts: string[] = [];
-              if (proj?.name) metaParts.push(proj.name);
-              if (hit.contentMatch && hit.matchCount && hit.matchCount > 0) {
-                metaParts.push(
-                  tr("search.matchCount", { n: String(hit.matchCount) }),
-                );
-              }
-              if (i < 9) metaParts.push(`⌘${i + 1}`);
+              if (!s) return null;
+              const proj = projects.find((p) => p.id === s.projectId);
               return (
                 <button
-                  key={hit.id}
+                  key={s.id}
                   type="button"
                   className="search-panel__row"
                   onClick={() => {
                     setShowSearch(false);
-                    void openSession(row, proj ?? null);
+                    void openSession(s, proj ?? null);
                   }}
                 >
                   <IconSquarePen size={15} />
-                  <span className="search-panel__body">
-                    <span className="search-panel__title">
-                      {hit.title || s?.title || "Untitled"}
-                    </span>
-                    {hit.snippet ? (
-                      <span className="search-panel__snippet">
-                        {hit.snippet}
-                      </span>
-                    ) : null}
+                  <span className="search-panel__title">
+                    {s.title || "Untitled"}
                   </span>
                   <span className="search-panel__meta">
-                    {metaParts.join(" · ") || "—"}
+                    {proj?.name ?? "—"}
+                    {i < 9 ? `  ⌘${i + 1}` : ""}
                   </span>
                 </button>
               );
@@ -8498,14 +8358,6 @@ export default function App() {
                 },
               },
               {
-                id: "relocate",
-                label: tr("project.relocate"),
-                icon: <IconFolderPlus size={16} />,
-                onClick: () => {
-                  void relocateProject(proj);
-                },
-              },
-              {
                 id: "rename",
                 label: tr("project.rename"),
                 icon: <IconRename size={16} />,
@@ -8588,18 +8440,6 @@ export default function App() {
               session.sessionId === s.id ||
               viewingSessionIdRef.current === s.id;
             items = [
-              {
-                id: "pin",
-                label: s.pinned ? tr("session.unpin") : tr("session.pin"),
-                icon: s.pinned ? (
-                  <IconPinOff size={16} />
-                ) : (
-                  <IconPin size={16} />
-                ),
-                onClick: () => {
-                  void pinSession(s, !s.pinned);
-                },
-              },
               {
                 id: "rename",
                 label: tr("session.rename"),

--- a/src/components/ComposerProjectMenu.tsx
+++ b/src/components/ComposerProjectMenu.tsx
@@ -9,6 +9,7 @@ import {
   IconChevronDown,
   IconFolder,
   IconPlus,
+  IconTrash,
 } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { useFloatingMenu } from "@/lib/floatingMenu";
@@ -39,8 +40,8 @@ type Props = {
     worktreeSwitch: string;
     worktreeMain: string;
     worktreeDetached: string;
-    /** Badge when project folder is missing on disk. */
-    pathMissing?: string;
+    /** Remove linked worktree (non-main). */
+    worktreeRemove?: string;
   };
   /** Linked worktrees for the active project (loaded by parent). */
   worktrees?: GitWorktreeEntry[];
@@ -57,6 +58,8 @@ type Props = {
   onAdd: () => void;
   /** Switch agent cwd to this worktree path (add project if needed + bind). */
   onSwitchWorktree?: (wt: GitWorktreeEntry) => void;
+  /** Open confirm to remove a linked (non-main) worktree. */
+  onRemoveWorktree?: (wt: GitWorktreeEntry) => void;
   onOpen?: () => void;
 };
 
@@ -74,6 +77,7 @@ export function ComposerProjectMenu({
   onSelect,
   onAdd,
   onSwitchWorktree,
+  onRemoveWorktree,
   onOpen,
 }: Props) {
   const [open, setOpen] = useState(false);
@@ -116,12 +120,7 @@ export function ComposerProjectMenu({
   }, [open]);
 
   const label = activeProject?.name ?? labels.noProject;
-  const activeMissing = activeProject?.pathOk === false;
-  const tip = activeMissing
-    ? (labels.pathMissing
-        ? `${labels.pathMissing}: ${activeProject?.path || ""}`.trim()
-        : activeProject?.path) || labels.pickProject
-    : activeProject?.path || labels.pickProject;
+  const tip = activeProject?.path || labels.pickProject;
 
   return (
     <div ref={rootRef} className={`cpm${open ? " is-open" : ""}`}>
@@ -132,8 +131,7 @@ export function ComposerProjectMenu({
           className={
             "chip chip--project" +
             (open ? " is-open" : "") +
-            (!activeProject ? " chip--muted" : "") +
-            (activeMissing ? " chip--project-path-missing" : "")
+            (!activeProject ? " chip--muted" : "")
           }
           disabled={disabled}
           aria-haspopup="menu"
@@ -193,22 +191,15 @@ export function ComposerProjectMenu({
               >
                 {projects.map((p) => {
                   const active = activeProject?.id === p.id;
-                  const missing = p.pathOk === false;
                   return (
                     <button
                       key={p.id}
                       type="button"
                       role="menuitem"
                       className={
-                        "cmm__opt cpm__item" +
-                        (active ? " is-active" : "") +
-                        (missing ? " cpm__item--path-missing" : "")
+                        "cmm__opt cpm__item" + (active ? " is-active" : "")
                       }
-                      title={
-                        missing && labels.pathMissing
-                          ? `${labels.pathMissing}: ${p.path}`
-                          : p.path
-                      }
+                      title={p.path}
                       onClick={() => {
                         onSelect(p);
                         setOpen(false);
@@ -216,11 +207,6 @@ export function ComposerProjectMenu({
                     >
                       <span className="cmm__opt-main">
                         <span className="cmm__opt-title">{p.name}</span>
-                        {missing && labels.pathMissing ? (
-                          <span className="cpm__path-badge">
-                            {labels.pathMissing}
-                          </span>
-                        ) : null}
                       </span>
                       {active ? (
                         <span className="cmm__opt-check" aria-hidden>
@@ -254,8 +240,15 @@ export function ComposerProjectMenu({
                       ]
                         .filter(Boolean)
                         .join(" · ");
+                      const canRemove =
+                        !wt.isMain && !!onRemoveWorktree && !!labels.worktreeRemove;
                       return (
-                        <li key={wt.path}>
+                        <li
+                          key={wt.path}
+                          className={
+                            "cpm__worktree-li" + (canRemove ? " has-remove" : "")
+                          }
+                        >
                           <button
                             type="button"
                             role="menuitem"
@@ -283,6 +276,24 @@ export function ComposerProjectMenu({
                               </span>
                             ) : null}
                           </button>
+                          {canRemove ? (
+                            <Tip label={labels.worktreeRemove!}>
+                              <button
+                                type="button"
+                                className="cpm__worktree-remove"
+                                aria-label={labels.worktreeRemove}
+                                title={labels.worktreeRemove}
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  setOpen(false);
+                                  onRemoveWorktree?.(wt);
+                                }}
+                              >
+                                <IconTrash size={14} />
+                              </button>
+                            </Tip>
+                          ) : null}
                         </li>
                       );
                     })}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -373,6 +373,20 @@ const en = {
   "composer.worktreeMain": "main",
   "composer.worktreeDetached": "detached",
   "composer.worktreeSwitched": "Using worktree {name} ({branch})",
+  "composer.worktreeRemove": "Remove…",
+  "composer.worktreeRemoveTitle": "Remove git worktree",
+  "composer.worktreeRemoveMsg":
+    "Remove worktree “{name}” ({branch})? This deletes the worktree folder on disk (not the branch).",
+  "composer.worktreeRemoveForce":
+    "Force remove (dirty or locked worktree)",
+  "composer.worktreeRemoveConfirm": "Remove worktree",
+  "composer.worktreeRemoving": "Removing…",
+  "composer.worktreeRemoved": "Removed worktree {name}",
+  "composer.worktreeRemoveMainBlocked":
+    "The main worktree cannot be removed",
+  "composer.worktreeLeaveProjectTitle": "Leave project entry?",
+  "composer.worktreeLeaveProjectMsg":
+    "The folder for “{name}” is gone. Remove it from your project list? Chats stay; only the project row is removed.",
   "composer.clearProject": "No project (orphan chat)",
   "composer.projectUntrusted": "Not trusted yet",
   "composer.projectBound": "Session bound to “{name}”",
@@ -1591,6 +1605,18 @@ const zh: Record<MessageKey, string> = {
   "composer.worktreeMain": "主目录",
   "composer.worktreeDetached": "游离 HEAD",
   "composer.worktreeSwitched": "已切换到 worktree {name}（{branch}）",
+  "composer.worktreeRemove": "移除…",
+  "composer.worktreeRemoveTitle": "移除 git worktree",
+  "composer.worktreeRemoveMsg":
+    "移除 worktree「{name}」（{branch}）？会删除磁盘上的 worktree 目录（不会删除分支）。",
+  "composer.worktreeRemoveForce": "强制移除（有未提交改动或已锁定）",
+  "composer.worktreeRemoveConfirm": "移除 worktree",
+  "composer.worktreeRemoving": "正在移除…",
+  "composer.worktreeRemoved": "已移除 worktree {name}",
+  "composer.worktreeRemoveMainBlocked": "不能移除主 worktree",
+  "composer.worktreeLeaveProjectTitle": "从项目列表移出？",
+  "composer.worktreeLeaveProjectMsg":
+    "「{name}」对应的文件夹已不存在。要从项目列表移出吗？会话保留，只去掉项目条目。",
   "composer.clearProject": "无项目（其他会话）",
   "composer.projectUntrusted": "尚未信任",
   "composer.projectBound": "会话已绑定到「{name}」",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -315,6 +315,18 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.worktreeMain": "主目錄",
   "composer.worktreeDetached": "游離 HEAD",
   "composer.worktreeSwitched": "已切換到 worktree {name}（{branch}）",
+  "composer.worktreeRemove": "移除…",
+  "composer.worktreeRemoveTitle": "移除 git worktree",
+  "composer.worktreeRemoveMsg":
+    "移除 worktree「{name}」（{branch}）？會刪除磁碟上的 worktree 目錄（不會刪除分支）。",
+  "composer.worktreeRemoveForce": "強制移除（有未提交變更或已鎖定）",
+  "composer.worktreeRemoveConfirm": "移除 worktree",
+  "composer.worktreeRemoving": "正在移除…",
+  "composer.worktreeRemoved": "已移除 worktree {name}",
+  "composer.worktreeRemoveMainBlocked": "不能移除主 worktree",
+  "composer.worktreeLeaveProjectTitle": "從專案列表移出？",
+  "composer.worktreeLeaveProjectMsg":
+    "「{name}」對應的資料夾已不存在。要從專案列表移出嗎？會話保留，只去掉專案項目。",
   "composer.addFiles": "上傳檔案",
   "composer.planMode": "計劃模式",
   "composer.planModeHint": "開啟計劃模式",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -299,6 +299,28 @@ export async function gitWorktreesList(projectPath: string) {
   return invoke<GitWorktreesResult>("git_worktrees_list", { projectPath });
 }
 
+/** Result of `git worktree remove`. */
+export interface GitWorktreeRemoveResult {
+  path: string;
+  forced: boolean;
+}
+
+/**
+ * Remove a linked worktree (`git worktree remove [--force] <path>`).
+ * Host refuses the main worktree. Throws on git errors (dirty without force, etc.).
+ */
+export async function gitWorktreeRemove(
+  projectPath: string,
+  worktreePath: string,
+  force?: boolean,
+) {
+  return invoke<GitWorktreeRemoveResult>("git_worktree_remove", {
+    projectPath,
+    worktreePath,
+    force: force ?? false,
+  });
+}
+
 /** Native folder dialog → add project. Returns null if user cancels. */
 export async function projectAddDialog(trust: boolean) {
   return invoke<{

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2643,6 +2643,18 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 }
 
 /* Match project row height; title + badges on one horizontal line */
+.cpm__worktree-li {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cpm__worktree-li .cpm__worktree {
+  flex: 1;
+  min-width: 0;
+}
+
 .cpm__pop .cpm__worktree {
   align-items: center;
   min-height: 36px;
@@ -2681,6 +2693,80 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   line-height: 1.2;
   color: var(--text-tertiary);
   white-space: nowrap;
+}
+
+.cpm__worktree-remove {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  min-height: 36px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: var(--menu-radius-item, 8px);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.cpm__worktree-remove:hover {
+  color: var(--danger, #e5484d);
+  background: var(--menu-item-hover, rgba(127, 127, 127, 0.12));
+}
+
+.cpm__worktree-remove:focus-visible {
+  outline: 2px solid var(--accent, #5b8def);
+  outline-offset: -2px;
+}
+
+/* Remove worktree confirm dialog */
+.wt-remove {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.wt-remove__msg {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.wt-remove__path {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--surface-2, rgba(127, 127, 127, 0.08));
+  font-size: 12px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.wt-remove__force {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.35;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.wt-remove__force input {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.wt-remove__error {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--danger, #e5484d);
 }
 
 .account-link:hover {


### PR DESCRIPTION
## Problem
The project chip can list and switch git worktrees, but there is no way to remove a linked worktree from the App. Users still have to drop to a terminal for `git worktree remove`.

## Changes
- **Host:** `git_worktree_remove(project_path, worktree_path, force?)` runs `git worktree remove [--force] <path>` with argv only (no shell). Refuses the main worktree; requires the path to be registered for that repo.
- **UI:** non-main worktree rows get **Remove…** → GlassModal confirm (optional force for dirty/locked). No `window.confirm`.
- **After remove:** refresh worktree list; if the session was on that path, leave to the main worktree project (or clear). If an App project row still points at the deleted folder, offer leave/remove **only that** project entry.
- **i18n:** en + zh + zh-TW
- **Tests:** Rust unit tests for path equality (slash/case) and refuse-main

Does **not** include create-worktree (see open #64).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/gitWorktree.test.ts`
- [x] `cargo test --lib git_worktree` (4 passed: parse, path equality, refuse main)
- [ ] Manual: open project chip on a multi-worktree repo → Remove… on a linked tree → confirm → list updates
- [ ] Manual: force checkbox when tree is dirty
- [ ] Manual: main worktree has no remove control; host refuses if forced
- [ ] Manual: removing the active worktree leaves to main (or clears project)
- [ ] Manual: if path was an App project, leave-project dialog only affects that row