### PR TITLE
feat: list agent and persona definition files in Extensions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1726,6 +1726,346 @@ fn parse_mcp_servers(v: &serde_json::Value) -> Vec<McpDto> {
     out
 }
 
+// ── Agent / persona definition files (disk discovery) ───────────────────────
+//
+// Grok Build loads agents from:
+//   {project}/.grok/agents/*.md   (project)
+//   ~/.grok/agents/*.md           (user)
+//   ~/.grok/bundled/agents/*.md   (bundled)
+// Personas: .grok/personas/*.{toml,md} under the same scopes.
+// The App only lists + opens files. Session agent selection is CLI/config
+// (`--agent`, `[agent]`, GROK_AGENT) — ACP has no session agent switch.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentDefDto {
+    pub name: String,
+    pub path: String,
+    /// "project" | "user" | "bundled"
+    pub scope: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersonaDefDto {
+    pub name: String,
+    pub path: String,
+    pub scope: String,
+}
+
+fn is_agent_def_file(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    !name.starts_with('.')
+        && (lower.ends_with(".md") || lower.ends_with(".markdown"))
+}
+
+fn is_persona_def_file(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    !name.starts_with('.')
+        && (lower.ends_with(".toml")
+            || lower.ends_with(".md")
+            || lower.ends_with(".markdown"))
+}
+
+fn stem_name(file_name: &str) -> String {
+    let path = std::path::Path::new(file_name);
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(file_name)
+        .to_string()
+}
+
+/// Best-effort YAML frontmatter `description:` (first line / plain value).
+fn extract_agent_description_from_content(content: &str) -> Option<String> {
+    if !content.starts_with("---") {
+        return None;
+    }
+    let rest = &content[3..];
+    let end = rest.find("\n---")?;
+    let fm = &rest[..end];
+    for (i, line) in fm.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if let Some(val) = trimmed.strip_prefix("description:") {
+            let v = val.trim();
+            if v == ">" || v == "|" || v == ">-" || v == "|-" {
+                // Folded block: first non-empty indented line after this one.
+                for next in fm.lines().skip(i + 1) {
+                    if next.starts_with(' ') || next.starts_with('\t') {
+                        let t = next.trim();
+                        if !t.is_empty() {
+                            return Some(t.to_string());
+                        }
+                    } else if !next.trim().is_empty() {
+                        break;
+                    }
+                }
+                return None;
+            }
+            if v.is_empty() {
+                return None;
+            }
+            let unquoted = v
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                .or_else(|| v.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+                .unwrap_or(v);
+            let cleaned = unquoted.split_whitespace().collect::<Vec<_>>().join(" ");
+            if cleaned.is_empty() {
+                return None;
+            }
+            return Some(cleaned);
+        }
+    }
+    None
+}
+
+fn read_agent_description(path: &std::path::Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    // Frontmatter is near the top; cap read size.
+    let take = bytes.len().min(4096);
+    let content = String::from_utf8_lossy(&bytes[..take]);
+    extract_agent_description_from_content(&content)
+}
+
+fn scan_agent_dir(dir: &std::path::Path, scope: &str) -> Vec<AgentDefDto> {
+    let mut out = Vec::new();
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return out,
+    };
+    for entry in rd.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let file_name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if !is_agent_def_file(&file_name) {
+            continue;
+        }
+        let name = stem_name(&file_name);
+        if name.is_empty() {
+            continue;
+        }
+        let path_str = path.to_string_lossy().to_string();
+        let description = read_agent_description(&path);
+        out.push(AgentDefDto {
+            name,
+            path: path_str,
+            scope: scope.to_string(),
+            description,
+        });
+    }
+    out
+}
+
+fn scan_persona_dir(dir: &std::path::Path, scope: &str) -> Vec<PersonaDefDto> {
+    let mut out = Vec::new();
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return out,
+    };
+    for entry in rd.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let file_name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if !is_persona_def_file(&file_name) {
+            continue;
+        }
+        let name = stem_name(&file_name);
+        if name.is_empty() {
+            continue;
+        }
+        out.push(PersonaDefDto {
+            name,
+            path: path.to_string_lossy().to_string(),
+            scope: scope.to_string(),
+        });
+    }
+    out
+}
+
+fn scope_rank(scope: &str) -> u8 {
+    match scope {
+        "project" => 0,
+        "user" => 1,
+        "bundled" => 2,
+        _ => 9,
+    }
+}
+
+fn sort_agent_defs(mut agents: Vec<AgentDefDto>) -> Vec<AgentDefDto> {
+    agents.sort_by(|a, b| {
+        scope_rank(&a.scope)
+            .cmp(&scope_rank(&b.scope))
+            .then_with(|| {
+                a.name
+                    .to_ascii_lowercase()
+                    .cmp(&b.name.to_ascii_lowercase())
+            })
+    });
+    agents
+}
+
+fn sort_persona_defs(mut personas: Vec<PersonaDefDto>) -> Vec<PersonaDefDto> {
+    personas.sort_by(|a, b| {
+        scope_rank(&a.scope)
+            .cmp(&scope_rank(&b.scope))
+            .then_with(|| {
+                a.name
+                    .to_ascii_lowercase()
+                    .cmp(&b.name.to_ascii_lowercase())
+            })
+    });
+    personas
+}
+
+/// List agent + persona definition files from user / project / bundled scopes.
+/// Does not require the CLI binary (pure filesystem discovery under `~/.grok`
+/// and optional `{project}/.grok`). Always returns Ok.
+#[tauri::command]
+pub async fn agents_list(project_path: Option<String>) -> Result<serde_json::Value, String> {
+    let project = project_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let home = crate::process_util::user_home();
+        let grok = home.join(".grok");
+        let user_agents = grok.join("agents");
+        let bundled_agents = grok.join("bundled").join("agents");
+        let user_personas = grok.join("personas");
+        let bundled_personas = grok.join("bundled").join("personas");
+
+        let project_agents = project.as_ref().map(|p| {
+            std::path::PathBuf::from(p).join(".grok").join("agents")
+        });
+        let project_personas = project.as_ref().map(|p| {
+            std::path::PathBuf::from(p).join(".grok").join("personas")
+        });
+
+        let mut agents = Vec::new();
+        if let Some(ref dir) = project_agents {
+            agents.extend(scan_agent_dir(dir, "project"));
+        }
+        agents.extend(scan_agent_dir(&user_agents, "user"));
+        agents.extend(scan_agent_dir(&bundled_agents, "bundled"));
+        let agents = sort_agent_defs(agents);
+
+        let mut personas = Vec::new();
+        if let Some(ref dir) = project_personas {
+            personas.extend(scan_persona_dir(dir, "project"));
+        }
+        personas.extend(scan_persona_dir(&user_personas, "user"));
+        personas.extend(scan_persona_dir(&bundled_personas, "bundled"));
+        let personas = sort_persona_defs(personas);
+
+        serde_json::json!({
+            "agents": agents,
+            "personas": personas,
+            "userAgentsDir": user_agents.to_string_lossy(),
+            "projectAgentsDir": project_agents
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string()),
+            "bundledAgentsDir": bundled_agents.to_string_lossy(),
+            "userPersonasDir": user_personas.to_string_lossy(),
+            "projectPersonasDir": project_personas
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string()),
+            "bundledPersonasDir": bundled_personas.to_string_lossy(),
+        })
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod agents_discovery_tests {
+    use super::*;
+
+    #[test]
+    fn agent_file_filter() {
+        assert!(is_agent_def_file("explore.md"));
+        assert!(is_agent_def_file("plan.markdown"));
+        assert!(!is_agent_def_file("explore.toml"));
+        assert!(!is_agent_def_file(".hidden.md"));
+    }
+
+    #[test]
+    fn persona_file_filter() {
+        assert!(is_persona_def_file("reviewer.toml"));
+        assert!(is_persona_def_file("concise.md"));
+        assert!(!is_persona_def_file("notes.txt"));
+    }
+
+    #[test]
+    fn description_plain() {
+        let md = "---\nname: x\ndescription: Fast explorer\n---\nbody\n";
+        assert_eq!(
+            extract_agent_description_from_content(md).as_deref(),
+            Some("Fast explorer")
+        );
+    }
+
+    #[test]
+    fn description_folded() {
+        let md = "---\ndescription: >\n  First line of desc.\n  Second.\n---\nbody\n";
+        assert_eq!(
+            extract_agent_description_from_content(md).as_deref(),
+            Some("First line of desc.")
+        );
+    }
+
+    #[test]
+    fn description_missing() {
+        assert!(extract_agent_description_from_content("no fm").is_none());
+    }
+
+    #[test]
+    fn sort_prefers_project_scope() {
+        let sorted = sort_agent_defs(vec![
+            AgentDefDto {
+                name: "z".into(),
+                path: "/u/z.md".into(),
+                scope: "user".into(),
+                description: None,
+            },
+            AgentDefDto {
+                name: "a".into(),
+                path: "/b/a.md".into(),
+                scope: "bundled".into(),
+                description: None,
+            },
+            AgentDefDto {
+                name: "m".into(),
+                path: "/p/m.md".into(),
+                scope: "project".into(),
+                description: None,
+            },
+        ]);
+        assert_eq!(
+            sorted
+                .iter()
+                .map(|a| format!("{}:{}", a.scope, a.name))
+                .collect::<Vec<_>>(),
+            vec!["project:m", "user:z", "bundled:a"]
+        );
+    }
+}
+
 /// List invocable skills from `grok inspect --json`.
 /// Always returns Ok; on CLI missing / timeout, `skills` is empty and `error` is set.
 /// Each skill includes `enabled` from App Extensions prefs (default true).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -190,6 +190,7 @@ pub fn run() {
             commands::export_session_bundle,
             commands::reset_app_data,
             commands::skills_list,
+            commands::agents_list,
             commands::inspect_mcp,
             commands::project_inspect,
             commands::extensions_get,

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -1,7 +1,9 @@
 /**
- * Settings → Extensions: Skills + MCP + Plugins.
+ * Settings → Extensions: Skills + MCP + Plugins + Agents/Personas.
  * Skills/MCP from `grok inspect` with enable toggles (extensions.json / ACP inject).
  * Plugins from `grok plugin list/install/update/…` (config.toml disabled list).
+ * Plugins from `grok plugin list/enable/…` (config.toml disabled list).
+ * Agents/personas: definition files under ~/.grok and project .grok (list + open).
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -14,9 +16,18 @@ import {
   IconPlug,
   IconPuzzle,
   IconRefresh,
+  IconRobot,
   IconSkills,
   IconTrash,
+  IconUser,
 } from "@/components/icons";
+import {
+  agentMetaLine,
+  agentScopeTone,
+  personaMetaLine,
+  sortAgentDefs,
+  sortPersonaDefs,
+} from "@/lib/agentsDiscovery";
 import {
   filterPluginsByLoadState,
   isCliMissingError,
@@ -60,9 +71,15 @@ export function ExtensionsPanel({
   const [skills, setSkills] = useState<api.SkillDto[]>([]);
   const [servers, setServers] = useState<api.McpDto[]>([]);
   const [plugins, setPlugins] = useState<api.PluginDto[]>([]);
+  const [agents, setAgents] = useState<api.AgentDefDto[]>([]);
+  const [personas, setPersonas] = useState<api.PersonaDefDto[]>([]);
+  const [userAgentsDir, setUserAgentsDir] = useState<string | null>(null);
+  const [projectAgentsDir, setProjectAgentsDir] = useState<string | null>(null);
+  const [userPersonasDir, setUserPersonasDir] = useState<string | null>(null);
   const [skillsError, setSkillsError] = useState<string | null>(null);
   const [mcpError, setMcpError] = useState<string | null>(null);
   const [pluginsError, setPluginsError] = useState<string | null>(null);
+  const [agentsError, setAgentsError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [agentHome, setAgentHome] = useState<string | null>(null);
   const [configPath, setConfigPath] = useState<string | null>(null);
@@ -86,9 +103,15 @@ export function ExtensionsPanel({
       setSkills([]);
       setServers([]);
       setPlugins([]);
+      setAgents([]);
+      setPersonas([]);
+      setUserAgentsDir(null);
+      setProjectAgentsDir(null);
+      setUserPersonasDir(null);
       setSkillsError(tr("ext.needTauri"));
       setMcpError(null);
       setPluginsError(null);
+      setAgentsError(null);
       setLoading(false);
       return;
     }
@@ -96,29 +119,44 @@ export function ExtensionsPanel({
     setSkillsError(null);
     setMcpError(null);
     setPluginsError(null);
+    setAgentsError(null);
     setPathHint(null);
     const cwd = projectPath?.trim() || null;
-    const [skillsRes, mcpRes, pluginsRes, providersRes] = await Promise.all([
-      api.skillsList(cwd).catch((e) => ({
-        skills: [] as api.SkillDto[],
-        error: String(e),
-      })),
-      api.inspectMcp(cwd).catch((e) => ({
-        servers: [] as api.McpDto[],
-        error: String(e),
-      })),
-      api.pluginsList().catch((e) => ({
-        plugins: [] as api.PluginDto[],
-        error: String(e),
-      })),
-      api.providersList().catch(() => null),
-    ]);
+    const [skillsRes, mcpRes, pluginsRes, agentsRes, providersRes] =
+      await Promise.all([
+        api.skillsList(cwd).catch((e) => ({
+          skills: [] as api.SkillDto[],
+          error: String(e),
+        })),
+        api.inspectMcp(cwd).catch((e) => ({
+          servers: [] as api.McpDto[],
+          error: String(e),
+        })),
+        api.pluginsList().catch((e) => ({
+          plugins: [] as api.PluginDto[],
+          error: String(e),
+        })),
+        api.agentsList(cwd).catch(
+          (e): api.AgentsListResult => ({
+            agents: [],
+            personas: [],
+            error: String(e),
+          }),
+        ),
+        api.providersList().catch(() => null),
+      ]);
     setSkills(sortSkillsByName(skillsRes.skills ?? []));
     setServers(sortMcpByName(mcpRes.servers ?? []));
     setPlugins(sortPluginsByName(pluginsRes.plugins ?? []));
+    setAgents(sortAgentDefs(agentsRes.agents ?? []));
+    setPersonas(sortPersonaDefs(agentsRes.personas ?? []));
+    setUserAgentsDir(agentsRes.userAgentsDir?.trim() || null);
+    setProjectAgentsDir(agentsRes.projectAgentsDir?.trim() || null);
+    setUserPersonasDir(agentsRes.userPersonasDir?.trim() || null);
     setSkillsError(skillsRes.error?.trim() ? skillsRes.error : null);
     setMcpError(mcpRes.error?.trim() ? mcpRes.error : null);
     setPluginsError(pluginsRes.error?.trim() ? pluginsRes.error : null);
+    setAgentsError(agentsRes.error?.trim() ? agentsRes.error : null);
     if (providersRes) {
       setAgentHome(providersRes.agentHome?.trim() || null);
       setConfigPath(providersRes.configPath?.trim() || null);
@@ -162,6 +200,35 @@ export function ExtensionsPanel({
       setPathHint(null);
     } catch (e) {
       setPathHint(String(e));
+    }
+  };
+
+  const openPath = async (path: string | null | undefined) => {
+    const p = (path ?? "").trim();
+    if (!p || !api.isTauri()) return;
+    try {
+      await api.pathOpen(p);
+      setPathHint(null);
+    } catch (e) {
+      setPathHint(String(e));
+    }
+  };
+
+  /** Open folder if it exists; otherwise reveal/create parent hint. */
+  const openFolder = async (path: string | null | undefined) => {
+    const p = (path ?? "").trim();
+    if (!p || !api.isTauri()) return;
+    try {
+      await api.pathOpen(p);
+      setPathHint(null);
+    } catch {
+      // Dir may not exist yet — try reveal so Finder focuses parent path area.
+      try {
+        await api.pathReveal(p);
+        setPathHint(null);
+      } catch (e) {
+        setPathHint(String(e));
+      }
     }
   };
 
@@ -617,6 +684,187 @@ export function ExtensionsPanel({
         {!loading ? (
           <p className="ext-section-note">{tr("ext.plugins.note")}</p>
         ) : null}
+      </div>
+
+      {/* Agents — markdown defs under ~/.grok/agents and project .grok/agents */}
+      <h2 className="settings-page__h2">
+        <IconRobot size={15} />
+        {tr("ext.agents.title")}
+        {!loading ? (
+          <span className="ext-count">{agents.length}</span>
+        ) : null}
+      </h2>
+      <div className="settings-card ext-card" data-testid="ext-agents">
+        <p className="ext-section-note ext-section-note--top">
+          {tr("ext.agents.blurb")}
+        </p>
+        {agentsError ? (
+          <p className="ext-alert ext-alert--warn" role="status">
+            {agentsError}
+          </p>
+        ) : null}
+        {(userAgentsDir || projectAgentsDir) && (
+          <div className="ext-folder-actions">
+            {userAgentsDir ? (
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                title={userAgentsDir}
+                onClick={() => void openFolder(userAgentsDir)}
+              >
+                <IconFolder size={13} />
+                <span>{tr("ext.agents.openUserFolder")}</span>
+              </button>
+            ) : null}
+            {projectAgentsDir ? (
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                title={projectAgentsDir}
+                onClick={() => void openFolder(projectAgentsDir)}
+              >
+                <IconFolder size={13} />
+                <span>{tr("ext.agents.openProjectFolder")}</span>
+              </button>
+            ) : null}
+          </div>
+        )}
+        {loading && <p className="ext-empty">{tr("ext.agents.loading")}</p>}
+        {!loading && agents.length === 0 && (
+          <p className="ext-empty">{tr("ext.agents.empty")}</p>
+        )}
+        {!loading && agents.length > 0 && (
+          <ul className="ext-list">
+            {agents.map((a) => {
+              const tone = agentScopeTone(a.scope);
+              const meta = agentMetaLine(a);
+              return (
+                <li key={`${a.scope}:${a.path}`} className="ext-item">
+                  <div className="ext-item__head">
+                    <strong className="ext-item__name">{a.name}</strong>
+                    <span className={`ext-badge ext-badge--${tone}`}>
+                      {a.scope}
+                    </span>
+                  </div>
+                  {meta ? <p className="ext-item__desc">{meta}</p> : null}
+                  <div className="ext-item__meta">
+                    {a.path ? (
+                      <button
+                        type="button"
+                        className="ext-path-btn"
+                        title={a.path}
+                        onClick={() => void reveal(a.path)}
+                      >
+                        <IconFolder size={13} />
+                        <span>{shortPathLabel(a.path, 42)}</span>
+                      </button>
+                    ) : null}
+                  </div>
+                  <div className="ext-item__actions">
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm"
+                      disabled={!a.path}
+                      onClick={() => void openPath(a.path)}
+                    >
+                      {tr("ext.agents.openFile")}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm"
+                      disabled={!a.path}
+                      onClick={() => void reveal(a.path)}
+                    >
+                      {tr("ext.reveal")}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <p className="ext-section-note">{tr("ext.agents.note")}</p>
+      </div>
+
+      {/* Personas — subagent tone files */}
+      <h2 className="settings-page__h2">
+        <IconUser size={15} />
+        {tr("ext.personas.title")}
+        {!loading ? (
+          <span className="ext-count">{personas.length}</span>
+        ) : null}
+      </h2>
+      <div className="settings-card ext-card" data-testid="ext-personas">
+        <p className="ext-section-note ext-section-note--top">
+          {tr("ext.personas.blurb")}
+        </p>
+        {userPersonasDir ? (
+          <div className="ext-folder-actions">
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              title={userPersonasDir}
+              onClick={() => void openFolder(userPersonasDir)}
+            >
+              <IconFolder size={13} />
+              <span>{tr("ext.personas.openUserFolder")}</span>
+            </button>
+          </div>
+        ) : null}
+        {loading && <p className="ext-empty">{tr("ext.personas.loading")}</p>}
+        {!loading && personas.length === 0 && (
+          <p className="ext-empty">{tr("ext.personas.empty")}</p>
+        )}
+        {!loading && personas.length > 0 && (
+          <ul className="ext-list">
+            {personas.map((p) => {
+              const tone = agentScopeTone(p.scope);
+              const meta = personaMetaLine(p);
+              return (
+                <li key={`${p.scope}:${p.path}`} className="ext-item">
+                  <div className="ext-item__head">
+                    <strong className="ext-item__name">{p.name}</strong>
+                    <span className={`ext-badge ext-badge--${tone}`}>
+                      {p.scope}
+                    </span>
+                  </div>
+                  {meta ? <p className="ext-item__desc">{meta}</p> : null}
+                  <div className="ext-item__meta">
+                    {p.path ? (
+                      <button
+                        type="button"
+                        className="ext-path-btn"
+                        title={p.path}
+                        onClick={() => void reveal(p.path)}
+                      >
+                        <IconFolder size={13} />
+                        <span>{shortPathLabel(p.path, 42)}</span>
+                      </button>
+                    ) : null}
+                  </div>
+                  <div className="ext-item__actions">
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm"
+                      disabled={!p.path}
+                      onClick={() => void openPath(p.path)}
+                    >
+                      {tr("ext.agents.openFile")}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm"
+                      disabled={!p.path}
+                      onClick={() => void reveal(p.path)}
+                    >
+                      {tr("ext.reveal")}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </div>
 
       {/* Skills */}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1121,7 +1121,6 @@ const en = {
   "ext.enableAll": "Enable all",
   "ext.footnote":
     "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Plugin install accepts path/git/GitHub shorthand; full marketplace browse stays CLI-only.",
-    "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Agent/persona defs are opened as files — selection is CLI/config. Plugin marketplace install remains CLI-only.",
 
   // Errors / misc
   "error.needTauri": "Folder picker requires the Tauri window",
@@ -2339,7 +2338,6 @@ const zh: Record<MessageKey, string> = {
   "ext.enableAll": "全部启用",
   "ext.footnote":
     "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。插件安装支持路径/git/GitHub 简写；完整市场浏览仍仅 CLI。",
-    "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。Agent/Persona 定义仅打开文件，选用由 CLI/配置决定。",
   "error.needTauri": "需要在 Tauri 窗口中选择目录",
   "common.comingSoon": "即将推出",
   "common.local": "本地",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1035,9 +1035,9 @@ const en = {
   "mcpModal.empty": "No MCP servers discovered",
   "mcpModal.manage": "Manage in Settings",
 
-  // Settings → Extensions (Plugins + Skills + MCP)
+  // Settings → Extensions (Plugins + Skills + MCP + Agents)
   "ext.lead":
-    "Plugins via `grok plugin`, plus Skills/MCP from `grok inspect`. Toggle MCP/skills enable for session inject and slash filter. Project scope uses the active workbench folder as cwd for inspect; plugins are user-global.",
+    "Plugins via `grok plugin`, Skills/MCP from `grok inspect`, and agent/persona definition files under ~/.grok (plus project .grok). Toggle MCP/skills enable for session inject and slash filter. Project scope uses the active workbench folder as cwd for inspect; plugins are user-global.",
   "ext.refresh": "Refresh",
   "ext.refreshing": "Refreshing…",
   "ext.scope.project": "Project",
@@ -1093,6 +1093,24 @@ const en = {
   "ext.skills.empty": "No skills discovered",
   "ext.skills.emptyCli": "Skills are unavailable until the CLI is installed.",
   "ext.skills.invocable": "Slash",
+  "ext.agents.title": "Agents",
+  "ext.agents.loading": "Loading agent definitions…",
+  "ext.agents.empty":
+    "No agent definition files found. Add markdown under ~/.grok/agents or .grok/agents in a project.",
+  "ext.agents.blurb":
+    "Definition files Grok Build discovers for profiles and subagents. Open or reveal a file to edit it; runtime selection uses CLI flags / config, not this panel.",
+  "ext.agents.note":
+    "Pick an agent at spawn with `grok --agent <name>`, `[agent]` in config.toml, or GROK_AGENT. The App does not switch the live ACP session agent (protocol has no session agent switch).",
+  "ext.agents.openFile": "Open file",
+  "ext.agents.openUserFolder": "Open user agents folder",
+  "ext.agents.openProjectFolder": "Open project agents folder",
+  "ext.personas.title": "Personas",
+  "ext.personas.loading": "Loading personas…",
+  "ext.personas.empty":
+    "No persona files found. Add .toml or .md under ~/.grok/personas or project .grok/personas.",
+  "ext.personas.blurb":
+    "Subagent personas layer tone and instructions when a child agent is spawned. Edit files on disk; the CLI loads them at runtime.",
+  "ext.personas.openUserFolder": "Open user personas folder",
   "ext.mcp.title": "MCP servers",
   "ext.mcp.loading": "Loading MCP servers…",
   "ext.mcp.empty": "No MCP servers discovered",
@@ -1103,6 +1121,7 @@ const en = {
   "ext.enableAll": "Enable all",
   "ext.footnote":
     "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Plugin install accepts path/git/GitHub shorthand; full marketplace browse stays CLI-only.",
+    "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Agent/persona defs are opened as files — selection is CLI/config. Plugin marketplace install remains CLI-only.",
 
   // Errors / misc
   "error.needTauri": "Folder picker requires the Tauri window",
@@ -2235,9 +2254,9 @@ const zh: Record<MessageKey, string> = {
   "mcpModal.empty": "未发现 MCP 服务器",
   "mcpModal.manage": "在设置中管理",
 
-  // Settings → Extensions (Plugins + Skills + MCP)
+  // Settings → Extensions (Plugins + Skills + MCP + Agents)
   "ext.lead":
-    "通过 `grok plugin` 管理插件，以及 `grok inspect` 发现的技能与 MCP。开关控制会话注入与斜杠技能过滤；inspect 有当前项目时以该目录为 cwd；插件为用户全局范围。",
+    "通过 `grok plugin` 管理插件、`grok inspect` 发现技能与 MCP，并列出 ~/.grok（及项目 .grok）下的 Agent/Persona 定义文件。开关控制会话注入与斜杠技能过滤；inspect 有当前项目时以该目录为 cwd；插件为用户全局范围。",
   "ext.refresh": "刷新",
   "ext.refreshing": "刷新中…",
   "ext.scope.project": "项目",
@@ -2292,6 +2311,24 @@ const zh: Record<MessageKey, string> = {
   "ext.skills.empty": "未发现技能",
   "ext.skills.emptyCli": "安装 CLI 后才能查看技能。",
   "ext.skills.invocable": "斜杠",
+  "ext.agents.title": "Agents",
+  "ext.agents.loading": "正在加载 Agent 定义…",
+  "ext.agents.empty":
+    "未发现 Agent 定义文件。可在 ~/.grok/agents 或项目 .grok/agents 下添加 Markdown。",
+  "ext.agents.blurb":
+    "Grok Build 用于配置文件与子代理的定义文件。可打开或在文件管理器中显示以便编辑；运行时选用依赖 CLI 参数 / 配置，而非本面板。",
+  "ext.agents.note":
+    "启动时用 `grok --agent <name>`、config.toml 的 `[agent]` 或 GROK_AGENT 选择 Agent。应用不会切换当前 ACP 会话的 Agent（协议不支持会话级切换）。",
+  "ext.agents.openFile": "打开文件",
+  "ext.agents.openUserFolder": "打开用户 agents 目录",
+  "ext.agents.openProjectFolder": "打开项目 agents 目录",
+  "ext.personas.title": "Personas",
+  "ext.personas.loading": "正在加载 Persona…",
+  "ext.personas.empty":
+    "未发现 Persona 文件。可在 ~/.grok/personas 或项目 .grok/personas 下添加 .toml / .md。",
+  "ext.personas.blurb":
+    "子代理 Persona 在派生子会话时叠加语气与指令。在磁盘上编辑文件即可；CLI 在运行时加载。",
+  "ext.personas.openUserFolder": "打开用户 personas 目录",
   "ext.mcp.title": "MCP 服务器",
   "ext.mcp.loading": "正在加载 MCP…",
   "ext.mcp.empty": "未发现 MCP 服务器",
@@ -2302,6 +2339,7 @@ const zh: Record<MessageKey, string> = {
   "ext.enableAll": "全部启用",
   "ext.footnote":
     "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。插件安装支持路径/git/GitHub 简写；完整市场浏览仍仅 CLI。",
+    "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。Agent/Persona 定义仅打开文件，选用由 CLI/配置决定。",
   "error.needTauri": "需要在 Tauri 窗口中选择目录",
   "common.comingSoon": "即将推出",
   "common.local": "本地",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1081,7 +1081,6 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.enableAll": "全部啟用",
   "ext.footnote":
     "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。外掛安裝支援路徑/git/GitHub 簡寫；完整市集瀏覽仍僅 CLI。",
-    "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。Agent/Persona 定義僅開啟檔案，選用由 CLI/設定決定。",
   "error.needTauri": "需要在 Tauri 視窗中選擇目錄",
   "common.comingSoon": "即將推出",
   "common.local": "本機",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -996,9 +996,10 @@ export const zhTW: Record<MessageKey, string> = {
   "mcpModal.empty": "未發現 MCP 伺服器",
   "mcpModal.manage": "在設定中管理",
 
-  // Settings → Extensions (Plugins + Skills + MCP)
+  // Settings → Extensions (Plugins + Skills + MCP + Agents)
   "ext.lead":
-"透過 `grok inspect` 發現的技能與 MCP 伺服器。開關控制對話注入與斜線技能過濾；有目前專案時以該目錄為 cwd。",  "ext.refresh": "重新整理",
+    "透過 `grok plugin` 管理外掛、`grok inspect` 發現技能與 MCP，並列出 ~/.grok（及專案 .grok）下的 Agent/Persona 定義檔。開關控制對話注入與斜線技能過濾；有目前專案時以該目錄為 cwd。",
+  "ext.refresh": "重新整理",
   "ext.refreshing": "重新整理中…",
   "ext.scope.project": "專案",
   "ext.scope.global": "全域",
@@ -1052,6 +1053,24 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.skills.empty": "未發現技能",
   "ext.skills.emptyCli": "安裝 CLI 後才能查看技能。",
   "ext.skills.invocable": "斜線指令",
+  "ext.agents.title": "Agents",
+  "ext.agents.loading": "正在載入 Agent 定義…",
+  "ext.agents.empty":
+    "未發現 Agent 定義檔。可在 ~/.grok/agents 或專案 .grok/agents 下新增 Markdown。",
+  "ext.agents.blurb":
+    "Grok Build 用於設定檔與子代理的定義檔。可開啟或在檔案總管中顯示以便編輯；執行時選用依賴 CLI 參數 / 設定，而非本面板。",
+  "ext.agents.note":
+    "啟動時用 `grok --agent <name>`、config.toml 的 `[agent]` 或 GROK_AGENT 選擇 Agent。應用不會切換目前 ACP 工作階段的 Agent（協定不支援工作階段級切換）。",
+  "ext.agents.openFile": "開啟檔案",
+  "ext.agents.openUserFolder": "開啟使用者 agents 目錄",
+  "ext.agents.openProjectFolder": "開啟專案 agents 目錄",
+  "ext.personas.title": "Personas",
+  "ext.personas.loading": "正在載入 Persona…",
+  "ext.personas.empty":
+    "未發現 Persona 檔。可在 ~/.grok/personas 或專案 .grok/personas 下新增 .toml / .md。",
+  "ext.personas.blurb":
+    "子代理 Persona 在派生子工作階段時疊加語氣與指令。在磁碟上編輯檔案即可；CLI 在執行時載入。",
+  "ext.personas.openUserFolder": "開啟使用者 personas 目錄",
   "ext.mcp.title": "MCP 伺服器",
   "ext.mcp.loading": "正在載入 MCP…",
   "ext.mcp.empty": "未發現 MCP 伺服器",
@@ -1062,6 +1081,7 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.enableAll": "全部啟用",
   "ext.footnote":
     "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。外掛安裝支援路徑/git/GitHub 簡寫；完整市集瀏覽仍僅 CLI。",
+    "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。Agent/Persona 定義僅開啟檔案，選用由 CLI/設定決定。",
   "error.needTauri": "需要在 Tauri 視窗中選擇目錄",
   "common.comingSoon": "即將推出",
   "common.local": "本機",

--- a/src/lib/agentsDiscovery.test.ts
+++ b/src/lib/agentsDiscovery.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentEntriesFromFileNames,
+  agentMetaLine,
+  agentScopeRank,
+  agentScopeTone,
+  collectAgentDefs,
+  collectPersonaDefs,
+  definitionNameFromFileName,
+  extractAgentDescription,
+  grokHomeFromUserHome,
+  isAgentDefinitionFileName,
+  isPersonaDefinitionFileName,
+  personaEntriesFromFileNames,
+  resolveAgentsDirs,
+  resolvePersonasDirs,
+  sortAgentDefs,
+} from "./agentsDiscovery";
+
+describe("file name filters", () => {
+  it("accepts agent markdown only", () => {
+    expect(isAgentDefinitionFileName("explore.md")).toBe(true);
+    expect(isAgentDefinitionFileName("plan.markdown")).toBe(true);
+    expect(isAgentDefinitionFileName("explore.toml")).toBe(false);
+    expect(isAgentDefinitionFileName(".hidden.md")).toBe(false);
+    expect(isAgentDefinitionFileName("")).toBe(false);
+    expect(isAgentDefinitionFileName(null)).toBe(false);
+  });
+
+  it("accepts persona toml and markdown", () => {
+    expect(isPersonaDefinitionFileName("reviewer.toml")).toBe(true);
+    expect(isPersonaDefinitionFileName("concise.md")).toBe(true);
+    expect(isPersonaDefinitionFileName("notes.txt")).toBe(false);
+  });
+
+  it("stems names from file names", () => {
+    expect(definitionNameFromFileName("explore.md")).toBe("explore");
+    expect(definitionNameFromFileName("my-agent.markdown")).toBe("my-agent");
+    expect(definitionNameFromFileName("path/to/plan.md")).toBe("plan");
+  });
+});
+
+describe("path resolution", () => {
+  it("builds ~/.grok from home", () => {
+    expect(grokHomeFromUserHome("/Users/me")).toBe("/Users/me/.grok");
+    expect(grokHomeFromUserHome("/Users/me/")).toBe("/Users/me/.grok");
+  });
+
+  it("resolves user / project / bundled agent dirs", () => {
+    const dirs = resolveAgentsDirs("/home/dev", "/work/app");
+    expect(dirs.user).toBe("/home/dev/.grok/agents");
+    expect(dirs.project).toBe("/work/app/.grok/agents");
+    expect(dirs.bundled).toBe("/home/dev/.grok/bundled/agents");
+  });
+
+  it("omits project dir when no project", () => {
+    const dirs = resolveAgentsDirs("/home/dev", null);
+    expect(dirs.project).toBeNull();
+    expect(dirs.user).toBe("/home/dev/.grok/agents");
+  });
+
+  it("resolves persona dirs similarly", () => {
+    const dirs = resolvePersonasDirs("/home/dev", "/work/app");
+    expect(dirs.user).toBe("/home/dev/.grok/personas");
+    expect(dirs.project).toBe("/work/app/.grok/personas");
+    expect(dirs.bundled).toBe("/home/dev/.grok/bundled/personas");
+  });
+});
+
+describe("entries from listings", () => {
+  it("builds agent entries and skips junk", () => {
+    const entries = agentEntriesFromFileNames(
+      ["explore.md", "README.txt", ".DS_Store", "plan.md"],
+      "/home/dev/.grok/agents",
+      "user",
+    );
+    expect(entries).toEqual([
+      {
+        name: "explore",
+        path: "/home/dev/.grok/agents/explore.md",
+        scope: "user",
+      },
+      {
+        name: "plan",
+        path: "/home/dev/.grok/agents/plan.md",
+        scope: "user",
+      },
+    ]);
+  });
+
+  it("builds persona entries", () => {
+    const entries = personaEntriesFromFileNames(
+      ["reviewer.toml", "notes.txt"],
+      "/proj/.grok/personas",
+      "project",
+    );
+    expect(entries).toEqual([
+      {
+        name: "reviewer",
+        path: "/proj/.grok/personas/reviewer.toml",
+        scope: "project",
+      },
+    ]);
+  });
+});
+
+describe("sort / scope", () => {
+  it("ranks project before user before bundled", () => {
+    expect(agentScopeRank("project")).toBeLessThan(agentScopeRank("user"));
+    expect(agentScopeRank("user")).toBeLessThan(agentScopeRank("bundled"));
+  });
+
+  it("sorts by scope then name", () => {
+    const sorted = sortAgentDefs([
+      { name: "zeta", scope: "user" },
+      { name: "alpha", scope: "bundled" },
+      { name: "beta", scope: "project" },
+      { name: "alpha", scope: "user" },
+    ]);
+    expect(sorted.map((a) => `${a.scope}:${a.name}`)).toEqual([
+      "project:beta",
+      "user:alpha",
+      "user:zeta",
+      "bundled:alpha",
+    ]);
+  });
+
+  it("maps scope to badge tone", () => {
+    expect(agentScopeTone("user")).toBe("user");
+    expect(agentScopeTone("project")).toBe("project");
+    expect(agentScopeTone("bundled")).toBe("plugin");
+    expect(agentScopeTone("other")).toBe("muted");
+  });
+});
+
+describe("collect multi-scope", () => {
+  it("merges scopes without dropping same-name defs", () => {
+    const agents = collectAgentDefs({
+      projectFiles: ["explore.md"],
+      projectDir: "/p/.grok/agents",
+      userFiles: ["explore.md", "custom.md"],
+      userDir: "/h/.grok/agents",
+      bundledFiles: ["plan.md"],
+      bundledDir: "/h/.grok/bundled/agents",
+    });
+    expect(agents.map((a) => `${a.scope}:${a.name}`)).toEqual([
+      "project:explore",
+      "user:custom",
+      "user:explore",
+      "bundled:plan",
+    ]);
+  });
+
+  it("collects personas across scopes", () => {
+    const personas = collectPersonaDefs({
+      userFiles: ["thorough.toml"],
+      userDir: "/h/.grok/personas",
+      bundledFiles: ["reviewer.toml"],
+      bundledDir: "/h/.grok/bundled/personas",
+    });
+    expect(personas.map((p) => p.name)).toEqual(["thorough", "reviewer"]);
+  });
+});
+
+describe("frontmatter description", () => {
+  it("reads plain description", () => {
+    const md = `---
+name: explore
+description: Fast explorer
+---
+body`;
+    expect(extractAgentDescription(md)).toBe("Fast explorer");
+  });
+
+  it("reads folded description first line", () => {
+    const md = `---
+description: >
+  Fast agent specialized for exploring.
+  Second line ignored for short meta.
+---
+body`;
+    expect(extractAgentDescription(md)).toBe(
+      "Fast agent specialized for exploring.",
+    );
+  });
+
+  it("returns null without frontmatter", () => {
+    expect(extractAgentDescription("no frontmatter")).toBeNull();
+    expect(extractAgentDescription(null)).toBeNull();
+  });
+});
+
+describe("meta line", () => {
+  it("includes scope and truncated description", () => {
+    expect(
+      agentMetaLine({
+        scope: "user",
+        description: "hello",
+      }),
+    ).toBe("user · hello");
+    const long = "x".repeat(100);
+    const line = agentMetaLine({
+      scope: "project",
+      description: long,
+    });
+    expect(line.startsWith("project · ")).toBe(true);
+    expect(line.endsWith("…")).toBe(true);
+  });
+});

--- a/src/lib/agentsDiscovery.ts
+++ b/src/lib/agentsDiscovery.ts
@@ -1,0 +1,377 @@
+/**
+ * Pure helpers for Settings → Extensions → Agents / Personas.
+ * Definition files live under ~/.grok/agents (+ project .grok/agents)
+ * and ~/.grok/personas (+ project .grok/personas). Bundled agents are
+ * under ~/.grok/bundled/agents (read-only reference).
+ *
+ * Runtime selection uses CLI flags / config — the App only lists and opens
+ * files (no fake "set active agent" without ACP session switch support).
+ */
+
+export type AgentScope = "project" | "user" | "bundled";
+
+export type PersonaScope = "project" | "user" | "bundled";
+
+export type AgentDefLike = {
+  name: string;
+  path: string;
+  scope: AgentScope;
+  description?: string | null;
+};
+
+export type PersonaDefLike = {
+  name: string;
+  path: string;
+  scope: PersonaScope;
+};
+
+/** Relative dir segments under a GROK home root. */
+export const AGENTS_DIR_SEGMENTS = ["agents"] as const;
+export const PERSONAS_DIR_SEGMENTS = ["personas"] as const;
+export const BUNDLED_AGENTS_SEGMENTS = ["bundled", "agents"] as const;
+export const BUNDLED_PERSONAS_SEGMENTS = ["bundled", "personas"] as const;
+
+const AGENT_EXTS = new Set([".md", ".markdown"]);
+const PERSONA_EXTS = new Set([".toml", ".md", ".markdown"]);
+
+function joinPath(...parts: string[]): string {
+  const cleaned = parts
+    .map((p) => p.replace(/[/\\]+$/g, "").replace(/^[/\\]+/g, (m) => m))
+    .filter((p, i) => (i === 0 ? p.length > 0 : p.length > 0));
+  if (cleaned.length === 0) return "";
+  const first = cleaned[0];
+  const sep = first.includes("\\") && !first.includes("/") ? "\\" : "/";
+  // Absolute root: keep leading slash or drive letter
+  const isAbsUnix = first.startsWith("/");
+  const isAbsWin = /^[A-Za-z]:/.test(first);
+  const segs: string[] = [];
+  for (let i = 0; i < cleaned.length; i++) {
+    const piece = cleaned[i].replace(/\\/g, "/");
+    for (const s of piece.split("/").filter(Boolean)) segs.push(s);
+  }
+  if (isAbsWin) {
+    const drive = cleaned[0].slice(0, 2);
+    const rest = segs.slice(1); // first seg may be "C:"
+    const afterDrive = segs[0]?.includes(":") ? segs.slice(1) : rest;
+    return `${drive}\\${afterDrive.join("\\")}`;
+  }
+  if (isAbsUnix) return `/${segs.join("/")}`;
+  return segs.join(sep);
+}
+
+/** `~/.grok` style root from a user home directory. */
+export function grokHomeFromUserHome(userHome: string): string {
+  const home = (userHome ?? "").trim().replace(/[/\\]+$/g, "");
+  if (!home) return ".grok";
+  const sep = home.includes("\\") && !home.includes("/") ? "\\" : "/";
+  return `${home}${sep}.grok`;
+}
+
+/**
+ * Absolute directories where agent definition files are discovered.
+ * `projectPath` is the workbench project root (not GROK_HOME).
+ */
+export function resolveAgentsDirs(
+  userHome: string,
+  projectPath?: string | null,
+): {
+  user: string;
+  project: string | null;
+  bundled: string;
+} {
+  const grok = grokHomeFromUserHome(userHome);
+  const user = joinPath(grok, "agents");
+  const bundled = joinPath(grok, "bundled", "agents");
+  const proj = (projectPath ?? "").trim().replace(/[/\\]+$/g, "");
+  const project = proj ? joinPath(proj, ".grok", "agents") : null;
+  return { user, project, bundled };
+}
+
+/** Absolute directories for persona definition files. */
+export function resolvePersonasDirs(
+  userHome: string,
+  projectPath?: string | null,
+): {
+  user: string;
+  project: string | null;
+  bundled: string;
+} {
+  const grok = grokHomeFromUserHome(userHome);
+  const user = joinPath(grok, "personas");
+  const bundled = joinPath(grok, "bundled", "personas");
+  const proj = (projectPath ?? "").trim().replace(/[/\\]+$/g, "");
+  const project = proj ? joinPath(proj, ".grok", "personas") : null;
+  return { user, project, bundled };
+}
+
+function extensionOf(fileName: string): string {
+  const base = fileName.split(/[/\\]/).pop() ?? fileName;
+  const i = base.lastIndexOf(".");
+  if (i <= 0) return "";
+  return base.slice(i).toLowerCase();
+}
+
+/** True when a file name is a Grok agent definition (markdown). */
+export function isAgentDefinitionFileName(
+  fileName: string | null | undefined,
+): boolean {
+  const base = (fileName ?? "").trim().split(/[/\\]/).pop() ?? "";
+  if (!base || base.startsWith(".")) return false;
+  return AGENT_EXTS.has(extensionOf(base));
+}
+
+/** True when a file name is a persona definition (.toml / .md). */
+export function isPersonaDefinitionFileName(
+  fileName: string | null | undefined,
+): boolean {
+  const base = (fileName ?? "").trim().split(/[/\\]/).pop() ?? "";
+  if (!base || base.startsWith(".")) return false;
+  return PERSONA_EXTS.has(extensionOf(base));
+}
+
+/** Definition name = file stem (e.g. `explore.md` → `explore`). */
+export function definitionNameFromFileName(
+  fileName: string | null | undefined,
+): string {
+  const base = (fileName ?? "").trim().split(/[/\\]/).pop() ?? "";
+  if (!base) return "";
+  const ext = extensionOf(base);
+  if (ext && base.toLowerCase().endsWith(ext)) {
+    return base.slice(0, -ext.length);
+  }
+  return base;
+}
+
+/**
+ * Build agent entries from a flat directory listing (no recursion).
+ * Ignores non-definition files and empty names.
+ */
+export function agentEntriesFromFileNames(
+  fileNames: string[],
+  dir: string,
+  scope: AgentScope,
+): AgentDefLike[] {
+  const root = (dir ?? "").replace(/[/\\]+$/g, "");
+  const sep = root.includes("\\") && !root.includes("/") ? "\\" : "/";
+  const out: AgentDefLike[] = [];
+  for (const raw of fileNames) {
+    const base = (raw ?? "").trim().split(/[/\\]/).pop() ?? "";
+    if (!isAgentDefinitionFileName(base)) continue;
+    const name = definitionNameFromFileName(base);
+    if (!name) continue;
+    out.push({
+      name,
+      path: root ? `${root}${sep}${base}` : base,
+      scope,
+    });
+  }
+  return out;
+}
+
+/** Build persona entries from a flat directory listing. */
+export function personaEntriesFromFileNames(
+  fileNames: string[],
+  dir: string,
+  scope: PersonaScope,
+): PersonaDefLike[] {
+  const root = (dir ?? "").replace(/[/\\]+$/g, "");
+  const sep = root.includes("\\") && !root.includes("/") ? "\\" : "/";
+  const out: PersonaDefLike[] = [];
+  for (const raw of fileNames) {
+    const base = (raw ?? "").trim().split(/[/\\]/).pop() ?? "";
+    if (!isPersonaDefinitionFileName(base)) continue;
+    const name = definitionNameFromFileName(base);
+    if (!name) continue;
+    out.push({
+      name,
+      path: root ? `${root}${sep}${base}` : base,
+      scope,
+    });
+  }
+  return out;
+}
+
+/** Scope sort key: project (overrides) → user → bundled. */
+export function agentScopeRank(scope: string | null | undefined): number {
+  switch ((scope ?? "").trim().toLowerCase()) {
+    case "project":
+      return 0;
+    case "user":
+      return 1;
+    case "bundled":
+    case "builtin":
+    case "built-in":
+      return 2;
+    default:
+      return 9;
+  }
+}
+
+/** Sort: scope rank, then name (case-insensitive). Stable copy. */
+export function sortAgentDefs<T extends { name: string; scope: string }>(
+  agents: T[],
+): T[] {
+  return [...agents].sort((a, b) => {
+    const sr = agentScopeRank(a.scope) - agentScopeRank(b.scope);
+    if (sr !== 0) return sr;
+    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  });
+}
+
+export function sortPersonaDefs<T extends { name: string; scope: string }>(
+  personas: T[],
+): T[] {
+  return sortAgentDefs(personas);
+}
+
+/** Badge tone aligned with skill source colors. */
+export function agentScopeTone(
+  scope: string | null | undefined,
+): "user" | "project" | "plugin" | "muted" {
+  switch ((scope ?? "").trim().toLowerCase()) {
+    case "user":
+      return "user";
+    case "project":
+      return "project";
+    case "bundled":
+    case "builtin":
+    case "built-in":
+      return "plugin";
+    default:
+      return "muted";
+  }
+}
+
+/**
+ * Pull a short description from agent markdown frontmatter when present.
+ * Handles `description: text` and multi-line `description: >` blocks (first line).
+ */
+export function extractAgentDescription(
+  content: string | null | undefined,
+): string | null {
+  const raw = content ?? "";
+  if (!raw.startsWith("---")) return null;
+  const end = raw.indexOf("\n---", 3);
+  if (end < 0) return null;
+  const fm = raw.slice(3, end);
+  // description: plain value
+  const plain = fm.match(/^\s*description:\s*(.+)\s*$/m);
+  if (plain) {
+    let v = plain[1].trim();
+    if (v === ">" || v === "|" || v === ">-" || v === "|-") {
+      // Folded block: take first non-empty indented line after description
+      const after = fm.slice(plain.index! + plain[0].length);
+      const line = after.match(/^\s+(.+)$/m);
+      if (line) {
+        v = line[1].trim();
+      } else {
+        return null;
+      }
+    }
+    // Strip surrounding quotes
+    if (
+      (v.startsWith('"') && v.endsWith('"')) ||
+      (v.startsWith("'") && v.endsWith("'"))
+    ) {
+      v = v.slice(1, -1);
+    }
+    v = v.replace(/\s+/g, " ").trim();
+    return v || null;
+  }
+  return null;
+}
+
+/** Compact meta under an agent row (scope · optional description snippet). */
+export function agentMetaLine(agent: {
+  scope?: string | null;
+  description?: string | null;
+}): string {
+  const parts: string[] = [(agent.scope ?? "").trim() || "unknown"];
+  const desc = (agent.description ?? "").trim();
+  if (desc) {
+    const short = desc.length > 80 ? `${desc.slice(0, 77)}…` : desc;
+    parts.push(short);
+  }
+  return parts.join(" · ");
+}
+
+export function personaMetaLine(persona: {
+  scope?: string | null;
+}): string {
+  return (persona.scope ?? "").trim() || "unknown";
+}
+
+/**
+ * Merge multi-scope directory listings into one sorted agent list.
+ * Later scopes do not dedupe — Grok keeps same-name defs visible per scope;
+ * project still wins at runtime via CLI priority.
+ */
+export function collectAgentDefs(input: {
+  projectFiles?: string[];
+  projectDir?: string | null;
+  userFiles?: string[];
+  userDir?: string | null;
+  bundledFiles?: string[];
+  bundledDir?: string | null;
+}): AgentDefLike[] {
+  const out: AgentDefLike[] = [];
+  if (input.projectDir && input.projectFiles) {
+    out.push(
+      ...agentEntriesFromFileNames(
+        input.projectFiles,
+        input.projectDir,
+        "project",
+      ),
+    );
+  }
+  if (input.userDir && input.userFiles) {
+    out.push(
+      ...agentEntriesFromFileNames(input.userFiles, input.userDir, "user"),
+    );
+  }
+  if (input.bundledDir && input.bundledFiles) {
+    out.push(
+      ...agentEntriesFromFileNames(
+        input.bundledFiles,
+        input.bundledDir,
+        "bundled",
+      ),
+    );
+  }
+  return sortAgentDefs(out);
+}
+
+export function collectPersonaDefs(input: {
+  projectFiles?: string[];
+  projectDir?: string | null;
+  userFiles?: string[];
+  userDir?: string | null;
+  bundledFiles?: string[];
+  bundledDir?: string | null;
+}): PersonaDefLike[] {
+  const out: PersonaDefLike[] = [];
+  if (input.projectDir && input.projectFiles) {
+    out.push(
+      ...personaEntriesFromFileNames(
+        input.projectFiles,
+        input.projectDir,
+        "project",
+      ),
+    );
+  }
+  if (input.userDir && input.userFiles) {
+    out.push(
+      ...personaEntriesFromFileNames(input.userFiles, input.userDir, "user"),
+    );
+  }
+  if (input.bundledDir && input.bundledFiles) {
+    out.push(
+      ...personaEntriesFromFileNames(
+        input.bundledFiles,
+        input.bundledDir,
+        "bundled",
+      ),
+    );
+  }
+  return sortPersonaDefs(out);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1064,6 +1064,46 @@ export async function skillsList(projectPath?: string | null) {
   });
 }
 
+/** Agent definition file discovered under user / project / bundled scopes. */
+export interface AgentDefDto {
+  name: string;
+  path: string;
+  /** "project" | "user" | "bundled" */
+  scope: string;
+  description?: string | null;
+}
+
+/** Persona definition file (subagent tone/instructions). */
+export interface PersonaDefDto {
+  name: string;
+  path: string;
+  scope: string;
+}
+
+/** Disk discovery for Grok Build agent / persona definition files. */
+export interface AgentsListResult {
+  agents: AgentDefDto[];
+  personas: PersonaDefDto[];
+  userAgentsDir?: string | null;
+  projectAgentsDir?: string | null;
+  bundledAgentsDir?: string | null;
+  userPersonasDir?: string | null;
+  projectPersonasDir?: string | null;
+  bundledPersonasDir?: string | null;
+  /** Host-side failure (rare; discovery is filesystem-only). */
+  error?: string | null;
+}
+
+/**
+ * List agent + persona definition files from ~/.grok and optional project
+ * `.grok` dirs. Does not require the CLI binary.
+ */
+export async function agentsList(projectPath?: string | null) {
+  return invoke<AgentsListResult>("agents_list", {
+    projectPath: projectPath ?? null,
+  });
+}
+
 /** List MCP servers via `grok inspect --json` (optional project cwd). */
 export async function inspectMcp(projectPath?: string | null) {
   return invoke<InspectMcpResult>("inspect_mcp", {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11827,6 +11827,26 @@ div.composer__input:empty::before {
   border-top: 1px solid var(--border-subtle);
 }
 
+.ext-section-note--top {
+  border-top: none;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-top: 12px;
+}
+
+.ext-folder-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 14px 10px;
+}
+
+.ext-folder-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .ext-details-pre {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Problem
Grok Build loads agent profiles and personas from markdown/TOML under `~/.grok/agents`, project `.grok/agents`, and the matching `personas` dirs, but the App had no way to browse those definition files.

## Changes
- **`agents_list(project_path?)`** Tauri command: filesystem discovery of agent (`.md`) and persona (`.toml`/`.md`) defs for **project**, **user**, and **bundled** scopes. Returns name, path, scope, optional frontmatter description, and dir paths.
- **Settings → Extensions**: Agents + Personas sections with Open file, Reveal, and open-folder actions (reuses `path_open` / `path_reveal`).
- Honest blurb: runtime selection is CLI/config (`--agent`, `[agent]`, `GROK_AGENT`); **no fake “set active agent”** — ACP has no session agent switch.
- Pure discovery helpers + unit tests (`agentsDiscovery.ts`); Rust unit tests for filters/frontmatter/sort.
- i18n: en + zh + zh-TW.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (includes `agentsDiscovery.test.ts` + i18n key parity)
- [x] `cargo test agents_discovery` (6 unit tests)
- [ ] Manual: Settings → Extensions → Agents lists bundled + any `~/.grok/agents/*.md`; Open file / Reveal work; open user agents folder; with a project that has `.grok/agents`, project-scope rows appear.