### PR TITLE
feat: manage Grok Build hooks in Settings → Extensions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4327,6 +4327,98 @@ detached
     }
 }
 
+// ── Hooks manager (list / reveal / open folder) ─────────────────────────────
+
+/// List hook files under `~/.grok/hooks` and optionally `<project>/.grok/hooks`.
+#[tauri::command]
+pub async fn hooks_list(project_path: Option<String>) -> Result<crate::hooks::HooksListResult, String> {
+    let path = project_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::hooks::collect_hooks_list(path.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// Reveal a hook path in the system file manager (Finder / Explorer).
+#[tauri::command]
+pub async fn hooks_reveal(path: String) -> Result<(), String> {
+    path_reveal(path).await
+}
+
+/// Open the user or project hooks directory in the system file manager.
+/// When `create` is true, creates the folder if it is missing.
+#[tauri::command]
+pub async fn hooks_open_dir(
+    scope: Option<String>,
+    project_path: Option<String>,
+    create: Option<bool>,
+) -> Result<serde_json::Value, String> {
+    let scope = scope.unwrap_or_else(|| "user".into());
+    let create = create.unwrap_or(false);
+    let project = project_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let scope_for_block = scope.clone();
+    let project_for_block = project.clone();
+    let dir = tauri::async_runtime::spawn_blocking(move || {
+        if create {
+            crate::hooks::ensure_hooks_dir(&scope_for_block, project_for_block.as_deref())
+        } else {
+            let d = match scope_for_block.trim() {
+                "user" | "" => crate::hooks::user_hooks_dir(),
+                "project" => crate::hooks::project_hooks_dir(project_for_block.as_deref().unwrap_or(""))
+                    .ok_or_else(|| "project path required for project hooks".to_string())?,
+                other => return Err(format!("unknown hooks scope: {other}")),
+            };
+            if !d.exists() {
+                return Err(format!(
+                    "hooks folder not found: {} (use Create folder first)",
+                    d.display()
+                ));
+            }
+            Ok(d)
+        }
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    let path = dir.to_string_lossy().to_string();
+    // Open the directory itself (not reveal-select).
+    path_open(path.clone()).await?;
+    Ok(serde_json::json!({ "path": path, "scope": scope }))
+}
+
+/// Create the user or project hooks directory if missing. Returns the absolute path.
+#[tauri::command]
+pub async fn hooks_ensure_dir(
+    scope: Option<String>,
+    project_path: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let scope = scope.unwrap_or_else(|| "user".into());
+    let project = project_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let scope_for_block = scope.clone();
+    let dir = tauri::async_runtime::spawn_blocking(move || {
+        crate::hooks::ensure_hooks_dir(&scope_for_block, project.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+    Ok(serde_json::json!({
+        "path": dir.to_string_lossy(),
+        "scope": scope,
+    }))
+}
+
 /// Reveal a path in the system file manager (Finder / Explorer).
 #[tauri::command]
 pub async fn path_reveal(path: String) -> Result<(), String> {

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -1,0 +1,351 @@
+//! Grok Build hooks discovery under `~/.grok/hooks` and `<project>/.grok/hooks`.
+//!
+//! Management is list / reveal / open-folder only — no visual JSON editor.
+//! Hook file format lives in the Grok Build user guide (`10-hooks.md`).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use serde::Serialize;
+
+use crate::process_util::user_home;
+
+/// One on-disk entry under a hooks directory (file or subfolder).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HookEntry {
+    /// File or directory name (basename).
+    pub name: String,
+    /// Absolute path.
+    pub path: String,
+    /// `user` (global `~/.grok/hooks`) or `project` (`<cwd>/.grok/hooks`).
+    pub scope: String,
+    /// `file` | `dir`.
+    pub kind: String,
+    /// Lowercased extension without dot (files only; empty for dirs / no ext).
+    pub ext: String,
+    /// Byte size (0 for directories).
+    pub size: u64,
+    /// Last modified time in ms since UNIX epoch (0 when unavailable).
+    pub mtime_ms: u64,
+}
+
+/// Result of scanning user (+ optional project) hooks directories.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HooksListResult {
+    pub hooks: Vec<HookEntry>,
+    pub user_dir: String,
+    pub user_dir_exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_dir_exists: Option<bool>,
+    /// Absolute path to the local Grok Build hooks user-guide page when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docs_path: Option<String>,
+}
+
+/// `~/.grok/hooks` — always-trusted personal hooks.
+pub fn user_hooks_dir() -> PathBuf {
+    user_home().join(".grok").join("hooks")
+}
+
+/// `<project>/.grok/hooks` when `project_path` is a non-empty path.
+pub fn project_hooks_dir(project_path: &str) -> Option<PathBuf> {
+    let root = project_path.trim();
+    if root.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(root).join(".grok").join("hooks"))
+}
+
+/// Local user-guide page shipped with the CLI install (optional).
+pub fn hooks_docs_path() -> PathBuf {
+    user_home()
+        .join(".grok")
+        .join("docs")
+        .join("user-guide")
+        .join("10-hooks.md")
+}
+
+/// Join a hooks directory with a relative file name (pure; no FS access).
+/// Rejects empty names, absolute paths, and parent-directory traversal.
+pub fn join_hooks_path(dir: &Path, name: &str) -> Option<PathBuf> {
+    let n = name.trim();
+    if n.is_empty() || n == "." || n == ".." {
+        return None;
+    }
+    if n.contains('/') || n.contains('\\') {
+        return None;
+    }
+    let p = Path::new(n);
+    if p.is_absolute() {
+        return None;
+    }
+    if p.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+        return None;
+    }
+    Some(dir.join(n))
+}
+
+fn file_mtime_ms(meta: &fs::Metadata) -> u64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn entry_ext(name: &str, is_dir: bool) -> String {
+    if is_dir {
+        return String::new();
+    }
+    Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default()
+}
+
+/// List top-level entries in a hooks directory (non-recursive).
+/// Skips hidden names (leading `.`). Missing / unreadable dirs yield empty vec.
+pub fn list_hooks_in_dir(dir: &Path, scope: &str) -> Vec<HookEntry> {
+    let Ok(rd) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for ent in rd.flatten() {
+        let name = ent.file_name().to_string_lossy().to_string();
+        if name.is_empty() || name.starts_with('.') {
+            continue;
+        }
+        let path = ent.path();
+        let meta = match ent.metadata().or_else(|_| fs::metadata(&path)) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let is_dir = meta.is_dir();
+        let kind = if is_dir { "dir" } else { "file" };
+        let size = if is_dir { 0 } else { meta.len() };
+        out.push(HookEntry {
+            name: name.clone(),
+            path: path.to_string_lossy().to_string(),
+            scope: scope.to_string(),
+            kind: kind.to_string(),
+            ext: entry_ext(&name, is_dir),
+            size,
+            mtime_ms: file_mtime_ms(&meta),
+        });
+    }
+    sort_hook_entries(&mut out);
+    out
+}
+
+/// Stable sort: scope (user then project), then name (case-insensitive).
+pub fn sort_hook_entries(entries: &mut [HookEntry]) {
+    entries.sort_by(|a, b| {
+        let scope_ord = scope_rank(&a.scope).cmp(&scope_rank(&b.scope));
+        if scope_ord != std::cmp::Ordering::Equal {
+            return scope_ord;
+        }
+        a.name
+            .to_ascii_lowercase()
+            .cmp(&b.name.to_ascii_lowercase())
+            .then_with(|| a.path.cmp(&b.path))
+    });
+}
+
+fn scope_rank(scope: &str) -> u8 {
+    match scope {
+        "user" => 0,
+        "project" => 1,
+        _ => 2,
+    }
+}
+
+/// Scan user hooks (+ project hooks when `project_path` is set).
+pub fn collect_hooks_list(project_path: Option<&str>) -> HooksListResult {
+    let user_dir = user_hooks_dir();
+    let user_dir_exists = user_dir.is_dir();
+    let mut hooks = if user_dir_exists {
+        list_hooks_in_dir(&user_dir, "user")
+    } else {
+        Vec::new()
+    };
+
+    let (project_dir, project_dir_exists) = match project_path.and_then(project_hooks_dir) {
+        Some(dir) => {
+            let exists = dir.is_dir();
+            if exists {
+                hooks.extend(list_hooks_in_dir(&dir, "project"));
+            }
+            sort_hook_entries(&mut hooks);
+            (Some(dir.to_string_lossy().to_string()), Some(exists))
+        }
+        None => (None, None),
+    };
+
+    let docs = hooks_docs_path();
+    let docs_path = if docs.is_file() {
+        Some(docs.to_string_lossy().to_string())
+    } else {
+        None
+    };
+
+    HooksListResult {
+        hooks,
+        user_dir: user_dir.to_string_lossy().to_string(),
+        user_dir_exists,
+        project_dir,
+        project_dir_exists,
+        docs_path,
+    }
+}
+
+/// Ensure a hooks directory exists (`user` or `project`). Returns absolute path.
+pub fn ensure_hooks_dir(scope: &str, project_path: Option<&str>) -> Result<PathBuf, String> {
+    let dir = match scope.trim() {
+        "user" | "" => user_hooks_dir(),
+        "project" => project_hooks_dir(project_path.unwrap_or(""))
+            .ok_or_else(|| "project path required for project hooks".to_string())?,
+        other => {
+            return Err(format!("unknown hooks scope: {other}"));
+        }
+    };
+    fs::create_dir_all(&dir).map_err(|e| format!("create hooks dir: {e}"))?;
+    Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn user_hooks_dir_joins_home_dot_grok_hooks() {
+        let dir = user_hooks_dir();
+        let s = dir.to_string_lossy();
+        assert!(s.ends_with(".grok/hooks") || s.ends_with(".grok\\hooks"), "{s}");
+    }
+
+    #[test]
+    fn project_hooks_dir_joins_project_root() {
+        let d = project_hooks_dir("/tmp/my-app").expect("path");
+        assert_eq!(d, PathBuf::from("/tmp/my-app/.grok/hooks"));
+        assert!(project_hooks_dir("").is_none());
+        assert!(project_hooks_dir("   ").is_none());
+    }
+
+    #[test]
+    fn join_hooks_path_accepts_simple_names() {
+        let base = PathBuf::from("/tmp/hooks");
+        assert_eq!(
+            join_hooks_path(&base, "session-start.json"),
+            Some(PathBuf::from("/tmp/hooks/session-start.json"))
+        );
+        assert_eq!(
+            join_hooks_path(&base, "  note.md  "),
+            Some(PathBuf::from("/tmp/hooks/note.md"))
+        );
+    }
+
+    #[test]
+    fn join_hooks_path_rejects_traversal_and_empty() {
+        let base = PathBuf::from("/tmp/hooks");
+        assert!(join_hooks_path(&base, "").is_none());
+        assert!(join_hooks_path(&base, "..").is_none());
+        assert!(join_hooks_path(&base, "../etc/passwd").is_none());
+        assert!(join_hooks_path(&base, "a/b.json").is_none());
+        assert!(join_hooks_path(&base, "a\\b.json").is_none());
+    }
+
+    #[test]
+    fn sort_hook_entries_user_before_project_then_name() {
+        let mut items = vec![
+            HookEntry {
+                name: "z.json".into(),
+                path: "/p/z.json".into(),
+                scope: "project".into(),
+                kind: "file".into(),
+                ext: "json".into(),
+                size: 1,
+                mtime_ms: 0,
+            },
+            HookEntry {
+                name: "b.json".into(),
+                path: "/u/b.json".into(),
+                scope: "user".into(),
+                kind: "file".into(),
+                ext: "json".into(),
+                size: 1,
+                mtime_ms: 0,
+            },
+            HookEntry {
+                name: "a.json".into(),
+                path: "/u/a.json".into(),
+                scope: "user".into(),
+                kind: "file".into(),
+                ext: "json".into(),
+                size: 1,
+                mtime_ms: 0,
+            },
+        ];
+        sort_hook_entries(&mut items);
+        assert_eq!(
+            items.iter().map(|h| h.name.as_str()).collect::<Vec<_>>(),
+            vec!["a.json", "b.json", "z.json"]
+        );
+        assert_eq!(items[0].scope, "user");
+        assert_eq!(items[2].scope, "project");
+    }
+
+    #[test]
+    fn list_hooks_in_dir_reads_real_files() {
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-app-hooks-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("mkdir");
+        let file = tmp.join("session-start.json");
+        {
+            let mut f = fs::File::create(&file).expect("create");
+            write!(f, r#"{{"hooks":{{}}}}"#).expect("write");
+        }
+        fs::create_dir(tmp.join("scripts")).expect("subdir");
+        // hidden skipped
+        let _ = fs::File::create(tmp.join(".hidden"));
+
+        let listed = list_hooks_in_dir(&tmp, "user");
+        let names: Vec<_> = listed.iter().map(|h| h.name.as_str()).collect();
+        assert!(names.contains(&"session-start.json"), "{names:?}");
+        assert!(names.contains(&"scripts"), "{names:?}");
+        assert!(!names.iter().any(|n| n.starts_with('.')), "{names:?}");
+
+        let json = listed
+            .iter()
+            .find(|h| h.name == "session-start.json")
+            .expect("json entry");
+        assert_eq!(json.kind, "file");
+        assert_eq!(json.ext, "json");
+        assert_eq!(json.scope, "user");
+        assert!(json.size > 0);
+        assert!(json.path.ends_with("session-start.json"));
+
+        let dir = listed.iter().find(|h| h.name == "scripts").expect("dir");
+        assert_eq!(dir.kind, "dir");
+        assert_eq!(dir.size, 0);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn entry_ext_for_files() {
+        assert_eq!(entry_ext("a.json", false), "json");
+        assert_eq!(entry_ext("A.JSON", false), "json");
+        assert_eq!(entry_ext("noext", false), "");
+        assert_eq!(entry_ext("scripts", true), "");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod acp_client;
 mod agent_prefs;
 mod app_update;
 mod extensions;
+mod hooks;
 mod supergrok_quota;
 mod cli_probe;
 mod cli_install;
@@ -204,6 +205,10 @@ pub fn run() {
             commands::plugin_details,
             commands::plugin_install,
             commands::plugin_update,
+            commands::hooks_list,
+            commands::hooks_reveal,
+            commands::hooks_open_dir,
+            commands::hooks_ensure_dir,
             commands::pick_directory,
             commands::pick_attach_files,
             commands::pick_attach_folder,

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -1,7 +1,9 @@
 /**
- * Settings → Extensions: Skills + MCP + Plugins.
+ * Settings → Extensions: Skills + MCP + Plugins + Hooks.
  * Skills/MCP from `grok inspect` with enable toggles (extensions.json / ACP inject).
  * Plugins from `grok plugin list/install/update/…` (config.toml disabled list).
+ * Plugins from `grok plugin list/enable/…` (config.toml disabled list).
+ * Hooks: list / reveal / open folder under ~/.grok/hooks (+ project .grok/hooks).
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -11,6 +13,8 @@ import { GlassModal } from "@/components/GlassModal";
 import {
   IconExternalLink,
   IconFolder,
+  IconFolderPlus,
+  IconHooks,
   IconPlug,
   IconPuzzle,
   IconRefresh,
@@ -36,6 +40,11 @@ import {
   sortSkillsByName,
   type PluginFilter,
 } from "@/lib/extensionsUi";
+import {
+  hookMetaLine,
+  hookRowKey,
+  sortHooksByScopeName,
+} from "@/lib/hooksUi";
 
 export interface ExtensionsPanelProps {
   locale: Locale;
@@ -60,9 +69,11 @@ export function ExtensionsPanel({
   const [skills, setSkills] = useState<api.SkillDto[]>([]);
   const [servers, setServers] = useState<api.McpDto[]>([]);
   const [plugins, setPlugins] = useState<api.PluginDto[]>([]);
+  const [hooks, setHooks] = useState<api.HookDto[]>([]);
   const [skillsError, setSkillsError] = useState<string | null>(null);
   const [mcpError, setMcpError] = useState<string | null>(null);
   const [pluginsError, setPluginsError] = useState<string | null>(null);
+  const [hooksError, setHooksError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [agentHome, setAgentHome] = useState<string | null>(null);
   const [configPath, setConfigPath] = useState<string | null>(null);
@@ -80,15 +91,22 @@ export function ExtensionsPanel({
   /** Grok Build Plugins tab filter: all | enabled | disabled */
   const [pluginFilter, setPluginFilter] = useState<PluginFilter>("all");
   const [installSource, setInstallSource] = useState("");
+  const [hooksUserDir, setHooksUserDir] = useState<string | null>(null);
+  const [hooksUserDirExists, setHooksUserDirExists] = useState(false);
+  const [hooksProjectDir, setHooksProjectDir] = useState<string | null>(null);
+  const [hooksProjectDirExists, setHooksProjectDirExists] = useState(false);
+  const [hooksDocsPath, setHooksDocsPath] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!api.isTauri()) {
       setSkills([]);
       setServers([]);
       setPlugins([]);
+      setHooks([]);
       setSkillsError(tr("ext.needTauri"));
       setMcpError(null);
       setPluginsError(null);
+      setHooksError(null);
       setLoading(false);
       return;
     }
@@ -96,29 +114,51 @@ export function ExtensionsPanel({
     setSkillsError(null);
     setMcpError(null);
     setPluginsError(null);
+    setHooksError(null);
     setPathHint(null);
     const cwd = projectPath?.trim() || null;
-    const [skillsRes, mcpRes, pluginsRes, providersRes] = await Promise.all([
-      api.skillsList(cwd).catch((e) => ({
-        skills: [] as api.SkillDto[],
-        error: String(e),
-      })),
-      api.inspectMcp(cwd).catch((e) => ({
-        servers: [] as api.McpDto[],
-        error: String(e),
-      })),
-      api.pluginsList().catch((e) => ({
-        plugins: [] as api.PluginDto[],
-        error: String(e),
-      })),
-      api.providersList().catch(() => null),
-    ]);
+    const [skillsRes, mcpRes, pluginsRes, hooksRes, providersRes] =
+      await Promise.all([
+        api.skillsList(cwd).catch((e) => ({
+          skills: [] as api.SkillDto[],
+          error: String(e),
+        })),
+        api.inspectMcp(cwd).catch((e) => ({
+          servers: [] as api.McpDto[],
+          error: String(e),
+        })),
+        api.pluginsList().catch((e) => ({
+          plugins: [] as api.PluginDto[],
+          error: String(e),
+        })),
+        api.hooksList(cwd).catch((e) => ({
+          hooks: [] as api.HookDto[],
+          userDir: "",
+          userDirExists: false,
+          projectDir: null as string | null,
+          projectDirExists: null as boolean | null,
+          docsPath: null as string | null,
+          error: String(e),
+        })),
+        api.providersList().catch(() => null),
+      ]);
     setSkills(sortSkillsByName(skillsRes.skills ?? []));
     setServers(sortMcpByName(mcpRes.servers ?? []));
     setPlugins(sortPluginsByName(pluginsRes.plugins ?? []));
+    setHooks(sortHooksByScopeName(hooksRes.hooks ?? []));
+    setHooksUserDir(hooksRes.userDir?.trim() || null);
+    setHooksUserDirExists(Boolean(hooksRes.userDirExists));
+    setHooksProjectDir(hooksRes.projectDir?.trim() || null);
+    setHooksProjectDirExists(Boolean(hooksRes.projectDirExists));
+    setHooksDocsPath(hooksRes.docsPath?.trim() || null);
     setSkillsError(skillsRes.error?.trim() ? skillsRes.error : null);
     setMcpError(mcpRes.error?.trim() ? mcpRes.error : null);
     setPluginsError(pluginsRes.error?.trim() ? pluginsRes.error : null);
+    setHooksError(
+      "error" in hooksRes && typeof hooksRes.error === "string" && hooksRes.error.trim()
+        ? hooksRes.error
+        : null,
+    );
     if (providersRes) {
       setAgentHome(providersRes.agentHome?.trim() || null);
       setConfigPath(providersRes.configPath?.trim() || null);
@@ -163,6 +203,47 @@ export function ExtensionsPanel({
     } catch (e) {
       setPathHint(String(e));
     }
+  };
+
+  const runHooksAction = async (
+    key: string,
+    action: () => Promise<unknown>,
+  ) => {
+    setActionBusy(key);
+    setActionError(null);
+    try {
+      await action();
+      await refresh();
+    } catch (e) {
+      setActionError(String(e));
+    } finally {
+      setActionBusy(null);
+    }
+  };
+
+  const openHooksDir = (scope: "user" | "project", create: boolean) => {
+    if (!api.isTauri()) return;
+    const key = `hooks-open:${scope}:${create ? "create" : "open"}`;
+    void runHooksAction(key, async () => {
+      await api.hooksOpenDir({
+        scope,
+        projectPath: projectPath?.trim() || null,
+        create,
+      });
+    });
+  };
+
+  const revealHook = (path: string) => {
+    if (!api.isTauri()) return;
+    void runHooksAction(`hooks-reveal:${path}`, async () => {
+      await api.hooksReveal(path);
+    });
+  };
+
+  const openHooksDocs = () => {
+    const p = hooksDocsPath?.trim();
+    if (!p || !api.isTauri()) return;
+    void reveal(p);
   };
 
   const toggleMcp = async (name: string, next: boolean) => {
@@ -782,6 +863,170 @@ export function ExtensionsPanel({
             })}
           </ul>
         )}
+      </div>
+
+      {/* Hooks — filesystem list under ~/.grok/hooks (+ project) */}
+      <h2 className="settings-page__h2">
+        <IconHooks size={15} />
+        {tr("ext.hooks.title")}
+        {!loading ? <span className="ext-count">{hooks.length}</span> : null}
+      </h2>
+      <div className="settings-card ext-card" data-testid="hooks-section">
+        <div className="ext-toolbar ext-toolbar--hooks">
+          <div className="ext-toolbar__actions">
+            {hooksUserDirExists ? (
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                disabled={!!actionBusy}
+                title={hooksUserDir ?? undefined}
+                onClick={() => openHooksDir("user", false)}
+              >
+                <IconFolder size={13} />
+                <span>{tr("ext.hooks.openUserDir")}</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                disabled={!!actionBusy}
+                onClick={() => openHooksDir("user", true)}
+              >
+                <IconFolderPlus size={13} />
+                <span>{tr("ext.hooks.createUserDir")}</span>
+              </button>
+            )}
+            {projectPath?.trim() ? (
+              hooksProjectDirExists ? (
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  disabled={!!actionBusy}
+                  title={hooksProjectDir ?? undefined}
+                  onClick={() => openHooksDir("project", false)}
+                >
+                  <IconFolder size={13} />
+                  <span>{tr("ext.hooks.openProjectDir")}</span>
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  disabled={!!actionBusy}
+                  onClick={() => openHooksDir("project", true)}
+                >
+                  <IconFolderPlus size={13} />
+                  <span>{tr("ext.hooks.createProjectDir")}</span>
+                </button>
+              )
+            ) : null}
+          </div>
+        </div>
+
+        {hooksError ? (
+          <p className="ext-alert ext-alert--warn" role="status">
+            {hooksError}
+          </p>
+        ) : null}
+
+        {loading && <p className="ext-empty">{tr("ext.hooks.loading")}</p>}
+
+        {!loading && hooks.length === 0 && (
+          <div className="ext-empty">
+            <p>{tr("ext.hooks.empty")}</p>
+            <p className="ext-section-note">{tr("ext.hooks.emptyHint")}</p>
+            {!hooksUserDirExists ? (
+              <p className="ext-section-note">{tr("ext.hooks.missingUser")}</p>
+            ) : null}
+            {projectPath?.trim() && !hooksProjectDirExists ? (
+              <p className="ext-section-note">
+                {tr("ext.hooks.missingProject")}
+              </p>
+            ) : null}
+            {!projectPath?.trim() ? (
+              <p className="ext-section-note">{tr("ext.hooks.noProject")}</p>
+            ) : null}
+          </div>
+        )}
+
+        {!loading && hooks.length > 0 && (
+          <ul className="ext-list">
+            {hooks.map((h) => {
+              const key = hookRowKey(h);
+              const scopeLabel =
+                h.scope === "project"
+                  ? tr("ext.hooks.scope.project")
+                  : tr("ext.hooks.scope.user");
+              const meta = hookMetaLine(h, {
+                scopeLabel: (s) =>
+                  s === "project"
+                    ? tr("ext.hooks.scope.project")
+                    : s === "user"
+                      ? tr("ext.hooks.scope.user")
+                      : s,
+              });
+              return (
+                <li key={key} className="ext-item">
+                  <div className="ext-item__head">
+                    <strong className="ext-item__name">{h.name}</strong>
+                    <span
+                      className={
+                        "ext-badge" +
+                        (h.scope === "project"
+                          ? " ext-badge--project"
+                          : " ext-badge--user")
+                      }
+                    >
+                      {scopeLabel}
+                    </span>
+                    {h.kind === "dir" ? (
+                      <span className="ext-badge ext-badge--muted">dir</span>
+                    ) : h.ext ? (
+                      <span className="ext-badge ext-badge--muted">
+                        {h.ext}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="ext-item__meta">
+                    <span>{meta}</span>
+                    <button
+                      type="button"
+                      className="ext-path-btn"
+                      title={h.path}
+                      disabled={!!actionBusy}
+                      onClick={() => revealHook(h.path)}
+                    >
+                      <IconFolder size={13} />
+                      <span>{shortPathLabel(h.path, 42)}</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm"
+                      disabled={!!actionBusy}
+                      onClick={() => revealHook(h.path)}
+                    >
+                      {tr("ext.hooks.reveal")}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <p className="ext-section-note">{tr("ext.hooks.tip")}</p>
+        {hooksDocsPath ? (
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm"
+            disabled={!!actionBusy}
+            title={hooksDocsPath}
+            onClick={() => openHooksDocs()}
+          >
+            <IconExternalLink size={13} />
+            <span>{tr("ext.hooks.openDocs")}</span>
+          </button>
+        ) : null}
       </div>
 
       <p className="ext-footnote">

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -199,6 +199,8 @@ export const IconAutomations = wrap(TbBolt);
 export const IconScheduled = wrap(TbCalendarTime);
 export const IconClock = wrap(TbClock);
 export const IconSkills = wrap(TbTool);
+/** Lifecycle hooks (PreToolUse / SessionStart, …). */
+export const IconHooks = wrap(TbBolt);
 export const IconChevronDown = wrap(TbChevronDown);
 export const IconChevronLeft = wrap(TbChevronLeft);
 export const IconChevronRight = wrap(TbChevronRight);

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1035,9 +1035,9 @@ const en = {
   "mcpModal.empty": "No MCP servers discovered",
   "mcpModal.manage": "Manage in Settings",
 
-  // Settings → Extensions (Plugins + Skills + MCP)
+  // Settings → Extensions (Plugins + Skills + MCP + Hooks)
   "ext.lead":
-    "Plugins via `grok plugin`, plus Skills/MCP from `grok inspect`. Toggle MCP/skills enable for session inject and slash filter. Project scope uses the active workbench folder as cwd for inspect; plugins are user-global.",
+    "Plugins via `grok plugin`, Skills/MCP from `grok inspect`, and Hooks from `~/.grok/hooks` (plus project `.grok/hooks`). Toggle MCP/skills enable for session inject and slash filter. Hooks are listed read-only — edit JSON on disk.",
   "ext.refresh": "Refresh",
   "ext.refreshing": "Refreshing…",
   "ext.scope.project": "Project",
@@ -1098,11 +1098,32 @@ const en = {
   "ext.mcp.empty": "No MCP servers discovered",
   "ext.mcp.emptyCli": "MCP status is unavailable until the CLI is installed.",
   "ext.mcp.vendor": "Vendor",
+  "ext.hooks.title": "Hooks",
+  "ext.hooks.loading": "Loading hooks…",
+  "ext.hooks.empty": "No hook files yet",
+  "ext.hooks.emptyHint":
+    "Add `*.json` hook files under the hooks folder. Grok loads them on session start.",
+  "ext.hooks.scope.user": "User",
+  "ext.hooks.scope.project": "Project",
+  "ext.hooks.openUserDir": "Open user hooks folder",
+  "ext.hooks.openProjectDir": "Open project hooks folder",
+  "ext.hooks.createUserDir": "Create user hooks folder",
+  "ext.hooks.createProjectDir": "Create project hooks folder",
+  "ext.hooks.reveal": "Reveal in Finder",
+  "ext.hooks.missingUser": "User hooks folder does not exist yet.",
+  "ext.hooks.missingProject": "Project hooks folder does not exist yet.",
+  "ext.hooks.noProject": "Select a project to list project hooks.",
+  "ext.hooks.tip":
+    "Hooks are JSON lifecycle scripts (SessionStart, PreToolUse, Stop, …). Edit them in your editor — this list is read-only. See the Grok Build user guide (Hooks) for the file format.",
+  "ext.hooks.openDocs": "Open hooks guide",
+  "ext.hooks.working": "Working…",
+  "ext.hooks.actionError": "Hooks action failed",
   "ext.enabled": "Enabled",
   "ext.disabled": "Disabled",
   "ext.enableAll": "Enable all",
   "ext.footnote":
     "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Plugin install accepts path/git/GitHub shorthand; full marketplace browse stays CLI-only.",
+    "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Plugin marketplace install remains CLI-only. Hooks are edited on disk under ~/.grok/hooks.",
 
   // Errors / misc
   "error.needTauri": "Folder picker requires the Tauri window",
@@ -2235,9 +2256,9 @@ const zh: Record<MessageKey, string> = {
   "mcpModal.empty": "未发现 MCP 服务器",
   "mcpModal.manage": "在设置中管理",
 
-  // Settings → Extensions (Plugins + Skills + MCP)
+  // Settings → Extensions (Plugins + Skills + MCP + Hooks)
   "ext.lead":
-    "通过 `grok plugin` 管理插件，以及 `grok inspect` 发现的技能与 MCP。开关控制会话注入与斜杠技能过滤；inspect 有当前项目时以该目录为 cwd；插件为用户全局范围。",
+    "通过 `grok plugin` 管理插件，`grok inspect` 发现技能与 MCP，Hooks 来自 `~/.grok/hooks`（及项目 `.grok/hooks`）。开关控制会话注入与斜杠技能过滤；Hooks 只读列表，请在磁盘编辑 JSON。",
   "ext.refresh": "刷新",
   "ext.refreshing": "刷新中…",
   "ext.scope.project": "项目",
@@ -2297,11 +2318,32 @@ const zh: Record<MessageKey, string> = {
   "ext.mcp.empty": "未发现 MCP 服务器",
   "ext.mcp.emptyCli": "安装 CLI 后才能查看 MCP 状态。",
   "ext.mcp.vendor": "供应商",
+  "ext.hooks.title": "Hooks",
+  "ext.hooks.loading": "正在加载 Hooks…",
+  "ext.hooks.empty": "尚未发现 hook 文件",
+  "ext.hooks.emptyHint":
+    "在 hooks 目录下添加 `*.json` 文件即可。Grok 在会话启动时加载它们。",
+  "ext.hooks.scope.user": "用户",
+  "ext.hooks.scope.project": "项目",
+  "ext.hooks.openUserDir": "打开用户 hooks 目录",
+  "ext.hooks.openProjectDir": "打开项目 hooks 目录",
+  "ext.hooks.createUserDir": "创建用户 hooks 目录",
+  "ext.hooks.createProjectDir": "创建项目 hooks 目录",
+  "ext.hooks.reveal": "在 Finder 中显示",
+  "ext.hooks.missingUser": "用户 hooks 目录尚不存在。",
+  "ext.hooks.missingProject": "项目 hooks 目录尚不存在。",
+  "ext.hooks.noProject": "选择项目后可列出项目级 hooks。",
+  "ext.hooks.tip":
+    "Hooks 是生命周期 JSON（SessionStart、PreToolUse、Stop 等）。请在编辑器中修改文件 — 此处只读列表。格式见 Grok Build 用户指南（Hooks）。",
+  "ext.hooks.openDocs": "打开 Hooks 指南",
+  "ext.hooks.working": "处理中…",
+  "ext.hooks.actionError": "Hooks 操作失败",
   "ext.enabled": "已启用",
   "ext.disabled": "已禁用",
   "ext.enableAll": "全部启用",
   "ext.footnote":
     "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。插件安装支持路径/git/GitHub 简写；完整市场浏览仍仅 CLI。",
+    "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。Hooks 在 ~/.grok/hooks 中编辑。",
   "error.needTauri": "需要在 Tauri 窗口中选择目录",
   "common.comingSoon": "即将推出",
   "common.local": "本地",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1122,7 +1122,6 @@ const en = {
   "ext.disabled": "Disabled",
   "ext.enableAll": "Enable all",
   "ext.footnote":
-    "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Plugin install accepts path/git/GitHub shorthand; full marketplace browse stays CLI-only.",
     "Toggles persist under app data and inject enabled MCP into agent sessions. Disabled skills stay on disk but hide from the slash palette. Plugin marketplace install remains CLI-only. Hooks are edited on disk under ~/.grok/hooks.",
 
   // Errors / misc
@@ -2342,7 +2341,6 @@ const zh: Record<MessageKey, string> = {
   "ext.disabled": "已禁用",
   "ext.enableAll": "全部启用",
   "ext.footnote":
-    "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。插件安装支持路径/git/GitHub 简写；完整市场浏览仍仅 CLI。",
     "开关会写入应用数据，并在新会话中注入已启用的 MCP（ACP mcpServers + agent-home 配置）。禁用技能仍保留在磁盘，但不会出现在斜杠面板。Hooks 在 ~/.grok/hooks 中编辑。",
   "error.needTauri": "需要在 Tauri 窗口中选择目录",
   "common.comingSoon": "即将推出",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1082,7 +1082,6 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.disabled": "已停用",
   "ext.enableAll": "全部啟用",
   "ext.footnote":
-    "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。外掛安裝支援路徑/git/GitHub 簡寫；完整市集瀏覽仍僅 CLI。",
     "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。Hooks 在 ~/.grok/hooks 中編輯。",
   "error.needTauri": "需要在 Tauri 視窗中選擇目錄",
   "common.comingSoon": "即將推出",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -996,9 +996,10 @@ export const zhTW: Record<MessageKey, string> = {
   "mcpModal.empty": "未發現 MCP 伺服器",
   "mcpModal.manage": "在設定中管理",
 
-  // Settings → Extensions (Plugins + Skills + MCP)
+  // Settings → Extensions (Plugins + Skills + MCP + Hooks)
   "ext.lead":
-"透過 `grok inspect` 發現的技能與 MCP 伺服器。開關控制對話注入與斜線技能過濾；有目前專案時以該目錄為 cwd。",  "ext.refresh": "重新整理",
+    "透過 `grok plugin` 管理外掛、`grok inspect` 發現技能與 MCP，Hooks 來自 `~/.grok/hooks`（及專案 `.grok/hooks`）。開關控制對話注入與斜線技能過濾；Hooks 為唯讀清單，請在磁碟編輯 JSON。",
+  "ext.refresh": "重新整理",
   "ext.refreshing": "重新整理中…",
   "ext.scope.project": "專案",
   "ext.scope.global": "全域",
@@ -1057,11 +1058,32 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.mcp.empty": "未發現 MCP 伺服器",
   "ext.mcp.emptyCli": "安裝 CLI 後才能查看 MCP 狀態。",
   "ext.mcp.vendor": "供應商",
+  "ext.hooks.title": "Hooks",
+  "ext.hooks.loading": "正在載入 Hooks…",
+  "ext.hooks.empty": "尚未發現 hook 檔案",
+  "ext.hooks.emptyHint":
+    "在 hooks 目錄下新增 `*.json` 檔案即可。Grok 會在工作階段啟動時載入它們。",
+  "ext.hooks.scope.user": "使用者",
+  "ext.hooks.scope.project": "專案",
+  "ext.hooks.openUserDir": "開啟使用者 hooks 目錄",
+  "ext.hooks.openProjectDir": "開啟專案 hooks 目錄",
+  "ext.hooks.createUserDir": "建立使用者 hooks 目錄",
+  "ext.hooks.createProjectDir": "建立專案 hooks 目錄",
+  "ext.hooks.reveal": "在 Finder 中顯示",
+  "ext.hooks.missingUser": "使用者 hooks 目錄尚不存在。",
+  "ext.hooks.missingProject": "專案 hooks 目錄尚不存在。",
+  "ext.hooks.noProject": "選取專案後可列出專案級 hooks。",
+  "ext.hooks.tip":
+    "Hooks 是生命週期 JSON（SessionStart、PreToolUse、Stop 等）。請在編輯器中修改檔案 — 此處僅唯讀清單。格式見 Grok Build 使用指南（Hooks）。",
+  "ext.hooks.openDocs": "開啟 Hooks 指南",
+  "ext.hooks.working": "處理中…",
+  "ext.hooks.actionError": "Hooks 操作失敗",
   "ext.enabled": "已啟用",
   "ext.disabled": "已停用",
   "ext.enableAll": "全部啟用",
   "ext.footnote":
     "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。外掛安裝支援路徑/git/GitHub 簡寫；完整市集瀏覽仍僅 CLI。",
+    "開關會寫入應用資料，並在新對話中注入已啟用的 MCP（ACP mcpServers + agent-home 設定）。停用技能仍保留在磁碟，但不會出現在斜線面板。Hooks 在 ~/.grok/hooks 中編輯。",
   "error.needTauri": "需要在 Tauri 視窗中選擇目錄",
   "common.comingSoon": "即將推出",
   "common.local": "本機",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1176,6 +1176,71 @@ export async function pluginUpdate(name?: string | null) {
   const n = (name ?? "").trim();
   return invoke<PluginActionResult>("plugin_update", {
     name: n ? n : null,
+// ── Hooks manager (`~/.grok/hooks` + project `.grok/hooks`) ─────────────────
+
+export interface HookDto {
+  name: string;
+  path: string;
+  /** `user` | `project` */
+  scope: string;
+  /** `file` | `dir` */
+  kind: string;
+  ext: string;
+  size: number;
+  mtimeMs: number;
+}
+
+export interface HooksListResult {
+  hooks: HookDto[];
+  userDir: string;
+  userDirExists: boolean;
+  projectDir?: string | null;
+  projectDirExists?: boolean | null;
+  /** Local Grok Build user-guide path when present. */
+  docsPath?: string | null;
+}
+
+export interface HooksDirResult {
+  path: string;
+  scope: string;
+}
+
+/** List hook files under user (+ optional project) hooks dirs. */
+export async function hooksList(projectPath?: string | null) {
+  return invoke<HooksListResult>("hooks_list", {
+    projectPath: projectPath ?? null,
+  });
+}
+
+/** Reveal a hook file/folder in Finder / Explorer. */
+export async function hooksReveal(path: string) {
+  return invoke<void>("hooks_reveal", { path });
+}
+
+/**
+ * Open the user or project hooks folder.
+ * @param create when true, create the folder if missing before opening.
+ */
+export async function hooksOpenDir(opts?: {
+  scope?: "user" | "project" | string;
+  projectPath?: string | null;
+  create?: boolean;
+}) {
+  return invoke<HooksDirResult>("hooks_open_dir", {
+    scope: opts?.scope ?? "user",
+    projectPath: opts?.projectPath ?? null,
+    create: opts?.create ?? false,
+  });
+}
+
+/** Create hooks folder if missing (`user` or `project`). */
+export async function hooksEnsureDir(opts?: {
+  scope?: "user" | "project" | string;
+  projectPath?: string | null;
+}) {
+  return invoke<HooksDirResult>("hooks_ensure_dir", {
+    scope: opts?.scope ?? "user",
+    projectPath: opts?.projectPath ?? null,
   });
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1176,6 +1176,9 @@ export async function pluginUpdate(name?: string | null) {
   const n = (name ?? "").trim();
   return invoke<PluginActionResult>("plugin_update", {
     name: n ? n : null,
+  });
+}
+
 // ── Hooks manager (`~/.grok/hooks` + project `.grok/hooks`) ─────────────────
 
 export interface HookDto {

--- a/src/lib/hooksUi.test.ts
+++ b/src/lib/hooksUi.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatHookMtime,
+  formatHookSize,
+  hookMetaLine,
+  hookRowKey,
+  hookTypeLabel,
+  joinHooksPath,
+  projectHooksDir,
+  sortHooksByScopeName,
+} from "./hooksUi";
+
+describe("joinHooksPath", () => {
+  it("joins simple names", () => {
+    expect(joinHooksPath("/Users/me/.grok/hooks", "session-start.json")).toBe(
+      "/Users/me/.grok/hooks/session-start.json",
+    );
+    expect(joinHooksPath("/tmp/hooks/", "  a.md  ")).toBe("/tmp/hooks/a.md");
+  });
+
+  it("uses backslash when dir is Windows-style", () => {
+    expect(joinHooksPath("C:\\Users\\me\\.grok\\hooks", "x.json")).toBe(
+      "C:\\Users\\me\\.grok\\hooks\\x.json",
+    );
+  });
+
+  it("rejects empty, traversal, and absolute names", () => {
+    expect(joinHooksPath("/tmp/hooks", "")).toBeNull();
+    expect(joinHooksPath("", "a.json")).toBeNull();
+    expect(joinHooksPath("/tmp/hooks", "..")).toBeNull();
+    expect(joinHooksPath("/tmp/hooks", "../x")).toBeNull();
+    expect(joinHooksPath("/tmp/hooks", "a/b.json")).toBeNull();
+    expect(joinHooksPath("/tmp/hooks", "/etc/passwd")).toBeNull();
+  });
+});
+
+describe("projectHooksDir", () => {
+  it("joins project root", () => {
+    expect(projectHooksDir("/tmp/my-app")).toBe("/tmp/my-app/.grok/hooks");
+    expect(projectHooksDir("/tmp/my-app/")).toBe("/tmp/my-app/.grok/hooks");
+  });
+
+  it("returns null for empty", () => {
+    expect(projectHooksDir(null)).toBeNull();
+    expect(projectHooksDir("  ")).toBeNull();
+  });
+});
+
+describe("formatHookSize / type / meta", () => {
+  it("formats sizes", () => {
+    expect(formatHookSize(0)).toBe("0 B");
+    expect(formatHookSize(512)).toBe("512 B");
+    expect(formatHookSize(2048)).toBe("2.0 KB");
+    expect(formatHookSize(2 * 1024 * 1024)).toBe("2.0 MB");
+  });
+
+  it("type label prefers ext", () => {
+    expect(hookTypeLabel({ kind: "file", ext: "json" })).toBe("json");
+    expect(hookTypeLabel({ kind: "dir", ext: "" })).toBe("dir");
+    expect(hookTypeLabel({ kind: "file", ext: "" })).toBe("file");
+  });
+
+  it("meta line includes scope type size", () => {
+    const line = hookMetaLine({
+      name: "a.json",
+      path: "/u/a.json",
+      scope: "user",
+      kind: "file",
+      ext: "json",
+      size: 100,
+      mtimeMs: 0,
+    });
+    expect(line).toContain("user");
+    expect(line).toContain("json");
+    expect(line).toContain("100 B");
+  });
+
+  it("row key is stable", () => {
+    expect(
+      hookRowKey({ scope: "user", path: "/h/a.json", name: "a.json" }),
+    ).toBe("user:/h/a.json");
+  });
+});
+
+describe("formatHookMtime", () => {
+  it("empty for zero", () => {
+    expect(formatHookMtime(0)).toBe("");
+    expect(formatHookMtime(undefined)).toBe("");
+  });
+
+  it("formats a real timestamp", () => {
+    const s = formatHookMtime(1_700_000_000_000, "en-US");
+    expect(s.length).toBeGreaterThan(4);
+  });
+});
+
+describe("sortHooksByScopeName", () => {
+  it("orders user before project, then name", () => {
+    const sorted = sortHooksByScopeName([
+      { name: "z.json", scope: "project", path: "/p/z" },
+      { name: "b.json", scope: "user", path: "/u/b" },
+      { name: "a.json", scope: "user", path: "/u/a" },
+    ]);
+    expect(sorted.map((h) => h.name)).toEqual(["a.json", "b.json", "z.json"]);
+    expect(sorted[2].scope).toBe("project");
+  });
+});

--- a/src/lib/hooksUi.ts
+++ b/src/lib/hooksUi.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure helpers for Settings → Extensions → Hooks.
+ * Listing / paths only — no hook JSON editor.
+ */
+
+export type HookScope = "user" | "project" | string;
+
+export type HookLike = {
+  name: string;
+  path: string;
+  scope: HookScope;
+  kind: string;
+  ext?: string;
+  size: number;
+  mtimeMs: number;
+};
+
+/** Join a hooks directory with a simple file name (no traversal). */
+export function joinHooksPath(
+  dir: string | null | undefined,
+  name: string | null | undefined,
+): string | null {
+  const d = (dir ?? "").trim().replace(/[/\\]+$/, "");
+  const n = (name ?? "").trim();
+  if (!d || !n) return null;
+  if (n === "." || n === ".." || n.includes("/") || n.includes("\\")) return null;
+  if (/^[A-Za-z]:[\\/]/.test(n) || n.startsWith("/")) return null;
+  const sep = d.includes("\\") && !d.includes("/") ? "\\" : "/";
+  return `${d}${sep}${n}`;
+}
+
+/** Project hooks dir: `<project>/.grok/hooks`. */
+export function projectHooksDir(projectPath: string | null | undefined): string | null {
+  const root = (projectPath ?? "").trim().replace(/[/\\]+$/, "");
+  if (!root) return null;
+  const sep = root.includes("\\") && !root.includes("/") ? "\\" : "/";
+  return `${root}${sep}.grok${sep}hooks`;
+}
+
+/** Human file size (B / KB / MB). */
+export function formatHookSize(bytes: number | null | undefined): string {
+  const n = typeof bytes === "number" && Number.isFinite(bytes) ? Math.max(0, bytes) : 0;
+  if (n < 1024) return `${Math.round(n)} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Compact local mtime for list rows. */
+export function formatHookMtime(
+  mtimeMs: number | null | undefined,
+  locale?: string,
+): string {
+  const ms = typeof mtimeMs === "number" && mtimeMs > 0 ? mtimeMs : 0;
+  if (!ms) return "";
+  try {
+    return new Date(ms).toLocaleString(locale || undefined, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return new Date(ms).toISOString();
+  }
+}
+
+/** Badge / type label: dir, json, sh, … */
+export function hookTypeLabel(hook: Pick<HookLike, "kind" | "ext">): string {
+  if ((hook.kind ?? "").toLowerCase() === "dir") return "dir";
+  const ext = (hook.ext ?? "").trim().toLowerCase();
+  return ext || "file";
+}
+
+/** Meta line under a hook name: scope · type · size · mtime. */
+export function hookMetaLine(
+  hook: HookLike,
+  opts?: { locale?: string; scopeLabel?: (scope: string) => string },
+): string {
+  const scopeRaw = (hook.scope ?? "").trim() || "user";
+  const scope =
+    opts?.scopeLabel?.(scopeRaw) ??
+    (scopeRaw === "project" ? "project" : scopeRaw === "user" ? "user" : scopeRaw);
+  const parts: string[] = [scope, hookTypeLabel(hook)];
+  if ((hook.kind ?? "").toLowerCase() !== "dir") {
+    parts.push(formatHookSize(hook.size));
+  }
+  const mt = formatHookMtime(hook.mtimeMs, opts?.locale);
+  if (mt) parts.push(mt);
+  return parts.join(" · ");
+}
+
+/** User hooks first, then project; name A–Z within scope. */
+export function sortHooksByScopeName<T extends { name: string; scope: string; path?: string }>(
+  hooks: T[],
+): T[] {
+  const rank = (s: string) => {
+    const t = (s ?? "").trim().toLowerCase();
+    if (t === "user") return 0;
+    if (t === "project") return 1;
+    return 2;
+  };
+  return [...hooks].sort((a, b) => {
+    const sr = rank(a.scope) - rank(b.scope);
+    if (sr !== 0) return sr;
+    const nc = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    if (nc !== 0) return nc;
+    return (a.path ?? "").localeCompare(b.path ?? "");
+  });
+}
+
+/** Row key stable across refresh. */
+export function hookRowKey(hook: Pick<HookLike, "scope" | "path" | "name">): string {
+  return `${hook.scope}:${hook.path || hook.name}`;
+}


### PR DESCRIPTION
## Problem
Grok Build loads lifecycle hooks from `~/.grok/hooks/*.json` (and project `.grok/hooks`), but the App had no way to see those files or open the folders. Users had to hunt paths manually; a full JSON editor is out of scope.

## Changes
- **Scan real files**: `hooks_list(project_path?)` lists name / path / scope / kind / ext / size / mtime from:
  - `~/.grok/hooks` (user)
  - `<project>/.grok/hooks` when a workbench project is selected
- **Commands**: `hooks_list`, `hooks_reveal`, `hooks_open_dir` (optional create), `hooks_ensure_dir`
- **UI**: Settings → Extensions new **Hooks** section — list rows, Reveal in Finder, Open / Create hooks folder, read-only tip + open local CLI guide (`10-hooks.md`) when present
- **i18n**: en + zh + zh-TW
- **Tests**: pure path join / list helpers (`hooksUi` vitest + `hooks` cargo)

## How to test
1. `pnpm typecheck && pnpm test`
2. `cd src-tauri && cargo test --lib hooks::`
3. Open Settings → Extensions → Hooks
4. Click **Create user hooks folder** if missing, then add e.g. `~/.grok/hooks/session-start.json` and **Refresh** — row appears with type/size/mtime
5. **Reveal in Finder** on a row; **Open user hooks folder** opens the directory
6. With a project selected, create/list project hooks under `<project>/.grok/hooks`

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (359 passed, including hooksUi + i18n key parity)
- [x] `cargo test --lib hooks::` (7 passed)
- [ ] Manual: list / reveal / open / create on macOS Finder