### PR TITLE
feat: managed configuration setup from Settings → Runtime

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4758,6 +4758,9 @@ mod project_inspect_tests {
         );
         assert_eq!(out["skills"]["total"], 0);
         assert_eq!(out["error"], "Grok Build CLI not found");
+    }
+}
+
 // ── Managed configuration (`grok setup` / `grok setup --json`) ──────────────
 //
 // Team-managed policy for enterprises. Requires team sign-in or GROK_DEPLOYMENT_KEY.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4758,5 +4758,322 @@ mod project_inspect_tests {
         );
         assert_eq!(out["skills"]["total"], 0);
         assert_eq!(out["error"], "Grok Build CLI not found");
+// ── Managed configuration (`grok setup` / `grok setup --json`) ──────────────
+//
+// Team-managed policy for enterprises. Requires team sign-in or GROK_DEPLOYMENT_KEY.
+// Preview never writes; install applies into ~/.grok. Secrets are scrubbed before
+// leaving the host so the UI never receives full keys.
+
+const SETUP_CMD_TIMEOUT_SECS: u64 = 60;
+
+fn setup_error_kind(msg: &str) -> &'static str {
+    let m = msg.to_ascii_lowercase();
+    if m.contains("cli not found") || m.contains("no such file") {
+        return "cli_missing";
+    }
+    if m.contains("timed out") || m.contains("timeout") {
+        return "timeout";
+    }
+    if m.contains("no deployment key")
+        || m.contains("team sign-in")
+        || m.contains("team login")
+        || m.contains("sign in with a team")
+        || m.contains("export grok_deployment_key")
+    {
+        return "missing_auth";
+    }
+    if m.contains("deployment key was rejected")
+        || m.contains("key was rejected")
+        || m.contains("hasn't expired")
+        || m.contains("hasnt expired")
+    {
+        return "rejected";
+    }
+    if m.contains("json") && (m.contains("parse") || m.contains("invalid")) {
+        return "parse";
+    }
+    "other"
+}
+
+fn is_setup_sensitive_key(key: &str) -> bool {
+    let k = key.trim().to_ascii_lowercase();
+    if k.is_empty() {
+        return false;
+    }
+    matches!(
+        k.as_str(),
+        "apikey"
+            | "api_key"
+            | "api-key"
+            | "token"
+            | "secret"
+            | "password"
+            | "passwd"
+            | "authorization"
+            | "auth"
+            | "access_token"
+            | "access-token"
+            | "refresh_token"
+            | "refresh-token"
+            | "client_secret"
+            | "client-secret"
+            | "private_key"
+            | "private-key"
+            | "bearer"
+            | "deployment_key"
+            | "deployment-key"
+            | "deploymentkey"
+            | "xai_api_key"
+            | "xai-api-key"
+            | "env"
+            | "environment"
+            | "headers"
+            | "secrets"
+            | "credentials"
+            | "signatures"
+            | "managed_identity_signatures"
+            | "managedidentitysignatures"
+    ) || k.contains("api_key")
+        || k.contains("api-key")
+        || k.contains("apikey")
+        || k.ends_with("_token")
+        || k.ends_with("-token")
+        || k.ends_with("_secret")
+        || k.ends_with("-secret")
+        || k.ends_with("_password")
+        || k.contains("deployment_key")
+        || k.contains("deploymentkey")
+        || (k.contains("signature") && !k.contains("fingerprint"))
+        || k.ends_with("_sig")
+}
+
+/// In-place redaction of secret-like keys / tokenish strings in managed setup JSON.
+pub fn redact_setup_json_value(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let keys: Vec<String> = map.keys().cloned().collect();
+            for key in keys {
+                if is_setup_sensitive_key(&key) {
+                    map.insert(key, serde_json::Value::String("[REDACTED]".into()));
+                } else if let Some(child) = map.get_mut(&key) {
+                    redact_setup_json_value(child);
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr.iter_mut() {
+                redact_setup_json_value(item);
+            }
+        }
+        serde_json::Value::String(s) => {
+            let scrubbed = store::redact_text(s);
+            *s = scrubbed.trim().to_string();
+        }
+        _ => {}
+    }
+}
+
+fn setup_cli_failure_message(stdout: &str, stderr: &str, fallback: &str) -> String {
+    let msg = if !stderr.trim().is_empty() {
+        stderr.trim()
+    } else if !stdout.trim().is_empty() {
+        stdout.trim()
+    } else {
+        fallback
+    };
+    // Scrub any accidental key material in CLI diagnostics.
+    store::redact_text(msg).trim().chars().take(1200).collect()
+}
+
+/// `grok setup --json` — fetch managed config preview without writing to ~/.grok.
+/// Always returns Ok; failures surface as `{ ok: false, error, errorKind }`.
+#[tauri::command]
+pub async fn setup_preview() -> Result<serde_json::Value, String> {
+    let result = tauri::async_runtime::spawn_blocking(|| {
+        run_grok_cli_args(&["setup", "--json"], SETUP_CMD_TIMEOUT_SECS)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let (stdout, stderr, ok) = match result {
+        Ok(t) => t,
+        Err(e) => {
+            let error = store::redact_text(&e).trim().to_string();
+            let kind = setup_error_kind(&error);
+            return Ok(serde_json::json!({
+                "ok": false,
+                "payload": null,
+                "message": null,
+                "error": error,
+                "errorKind": kind,
+            }));
+        }
+    };
+
+    if !ok {
+        let error = setup_cli_failure_message(
+            &stdout,
+            &stderr,
+            "Could not fetch managed configuration",
+        );
+        let kind = setup_error_kind(&error);
+        return Ok(serde_json::json!({
+            "ok": false,
+            "payload": null,
+            "message": null,
+            "error": error,
+            "errorKind": kind,
+        }));
+    }
+
+    let body = stdout.trim();
+    if body.is_empty() {
+        // Some CLI builds may print JSON on stderr when successful.
+        let alt = stderr.trim();
+        if alt.starts_with('{') || alt.starts_with('[') {
+            return Ok(setup_preview_from_body(alt));
+        }
+        return Ok(serde_json::json!({
+            "ok": true,
+            "payload": null,
+            "message": store::redact_text(alt).trim().chars().take(400).collect::<String>(),
+            "error": null,
+            "errorKind": null,
+        }));
+    }
+
+    Ok(setup_preview_from_body(body))
+}
+
+fn setup_preview_from_body(body: &str) -> serde_json::Value {
+    match serde_json::from_str::<serde_json::Value>(body) {
+        Ok(mut value) => {
+            redact_setup_json_value(&mut value);
+            serde_json::json!({
+                "ok": true,
+                "payload": value,
+                "message": null,
+                "error": null,
+                "errorKind": null,
+            })
+        }
+        Err(_) => {
+            // Not JSON — return scrubbed plain text as message only.
+            let message = store::redact_text(body)
+                .trim()
+                .chars()
+                .take(4000)
+                .collect::<String>();
+            serde_json::json!({
+                "ok": true,
+                "payload": null,
+                "message": message,
+                "error": null,
+                "errorKind": null,
+            })
+        }
+    }
+}
+
+/// `grok setup` — fetch and install managed configuration into ~/.grok.
+/// Soft-respawns the agent on success so new policy is picked up.
+/// Always returns Ok; failures surface as `{ ok: false, error, errorKind }`.
+#[tauri::command]
+pub async fn setup_install(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+) -> Result<serde_json::Value, String> {
+    let result = tauri::async_runtime::spawn_blocking(|| {
+        run_grok_cli_args(&["setup"], SETUP_CMD_TIMEOUT_SECS)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let (stdout, stderr, ok) = match result {
+        Ok(t) => t,
+        Err(e) => {
+            let error = store::redact_text(&e).trim().to_string();
+            let kind = setup_error_kind(&error);
+            return Ok(serde_json::json!({
+                "ok": false,
+                "message": null,
+                "error": error,
+                "errorKind": kind,
+            }));
+        }
+    };
+
+    if !ok {
+        let error =
+            setup_cli_failure_message(&stdout, &stderr, "Could not install managed configuration");
+        let kind = setup_error_kind(&error);
+        return Ok(serde_json::json!({
+            "ok": false,
+            "message": null,
+            "error": error,
+            "errorKind": kind,
+        }));
+    }
+
+    let message = {
+        let raw = if !stdout.trim().is_empty() {
+            stdout.trim()
+        } else if !stderr.trim().is_empty() {
+            stderr.trim()
+        } else {
+            "Applied managed configuration."
+        };
+        store::redact_text(raw)
+            .trim()
+            .chars()
+            .take(800)
+            .collect::<String>()
+    };
+
+    // New managed policy may change models / permissions / MCP — recycle agent.
+    mgr.soft_respawn(&app).await;
+
+    Ok(serde_json::json!({
+        "ok": true,
+        "message": message,
+        "error": null,
+        "errorKind": null,
+    }))
+}
+
+#[cfg(test)]
+mod setup_cmd_tests {
+    use super::*;
+
+    #[test]
+    fn classifies_missing_auth() {
+        let msg = "No deployment key or team sign-in found.\nexport GROK_DEPLOYMENT_KEY=<your-key>";
+        assert_eq!(setup_error_kind(msg), "missing_auth");
+    }
+
+    #[test]
+    fn classifies_rejected() {
+        assert_eq!(
+            setup_error_kind("The deployment key was rejected. Confirm it hasn't expired."),
+            "rejected"
+        );
+    }
+
+    #[test]
+    fn redacts_secret_keys_in_json() {
+        let mut v = serde_json::json!({
+            "deploymentId": "dep_1",
+            "apiKey": "sk-abcdefghijklmnopqrstuvwxyz",
+            "deployment_key": "secret-deploy",
+            "env": { "OPENAI_API_KEY": "sk-nested" },
+            "nested": { "client_secret": "cs", "name": "ok" }
+        });
+        redact_setup_json_value(&mut v);
+        assert_eq!(v["deploymentId"], "dep_1");
+        assert_eq!(v["apiKey"], "[REDACTED]");
+        assert_eq!(v["deployment_key"], "[REDACTED]");
+        assert_eq!(v["env"], "[REDACTED]");
+        assert_eq!(v["nested"]["client_secret"], "[REDACTED]");
+        assert_eq!(v["nested"]["name"], "ok");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,6 +204,8 @@ pub fn run() {
             commands::plugin_details,
             commands::plugin_install,
             commands::plugin_update,
+            commands::setup_preview,
+            commands::setup_install,
             commands::pick_directory,
             commands::pick_attach_files,
             commands::pick_attach_folder,

--- a/src/components/ManagedSetupPanel.tsx
+++ b/src/components/ManagedSetupPanel.tsx
@@ -1,0 +1,283 @@
+/**
+ * Settings → Runtime: managed configuration via `grok setup` / `grok setup --json`.
+ * Preview shows a secret-safe summary; Install confirms then writes ~/.grok.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import * as api from "@/lib/api";
+import { createT, type Locale } from "@/i18n";
+import {
+  classifySetupError,
+  summarizeSetupJson,
+  type ManagedSetupErrorKind,
+  type ManagedSetupSummary,
+} from "@/lib/managedSetup";
+import { isCliMissingError } from "@/lib/extensionsUi";
+import { GlassModal } from "@/components/GlassModal";
+
+export interface ManagedSetupPanelProps {
+  locale: Locale;
+  cliFound?: boolean;
+  onOpenAccount?: () => void;
+}
+
+export function ManagedSetupPanel({
+  locale,
+  cliFound = true,
+  onOpenAccount,
+}: ManagedSetupPanelProps) {
+  const tr = useMemo(() => createT(locale), [locale]);
+
+  const [summary, setSummary] = useState<ManagedSetupSummary | null>(null);
+  const [previewNote, setPreviewNote] = useState<string | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [installing, setInstalling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [errorKind, setErrorKind] = useState<ManagedSetupErrorKind | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const applyError = useCallback((msg: string, kind?: ManagedSetupErrorKind | null) => {
+    const text = (msg ?? "").trim() || tr("managedSetup.error.generic");
+    setError(text);
+    setErrorKind(kind ?? classifySetupError(text));
+    setStatus(null);
+  }, [tr]);
+
+  const onPreview = useCallback(async () => {
+    if (!api.isTauri()) {
+      applyError(tr("managedSetup.needTauri"), "other");
+      return;
+    }
+    setLoadingPreview(true);
+    setError(null);
+    setErrorKind(null);
+    setStatus(null);
+    setPreviewNote(null);
+    try {
+      const res = await api.setupPreview();
+      if (!res.ok) {
+        setSummary(null);
+        applyError(
+          res.error?.trim() || tr("managedSetup.error.generic"),
+          res.errorKind ?? classifySetupError(res.error),
+        );
+        return;
+      }
+      if (res.payload != null) {
+        setSummary(summarizeSetupJson(res.payload));
+        setPreviewNote(null);
+      } else if (res.message?.trim()) {
+        setSummary(summarizeSetupJson(res.message));
+        setPreviewNote(res.message.trim());
+      } else {
+        setSummary(null);
+        setPreviewNote(null);
+      }
+      setStatus(tr("managedSetup.previewOk"));
+    } catch (e) {
+      setSummary(null);
+      applyError(String(e));
+    } finally {
+      setLoadingPreview(false);
+    }
+  }, [applyError, tr]);
+
+  const runInstall = useCallback(async () => {
+    if (!api.isTauri()) {
+      applyError(tr("managedSetup.needTauri"), "other");
+      setConfirmOpen(false);
+      return;
+    }
+    setInstalling(true);
+    setError(null);
+    setErrorKind(null);
+    setStatus(null);
+    try {
+      const res = await api.setupInstall();
+      if (!res.ok) {
+        applyError(
+          res.error?.trim() || tr("managedSetup.error.generic"),
+          res.errorKind ?? classifySetupError(res.error),
+        );
+        return;
+      }
+      setStatus(
+        res.message?.trim() || tr("managedSetup.installOk"),
+      );
+    } catch (e) {
+      applyError(String(e));
+    } finally {
+      setInstalling(false);
+      setConfirmOpen(false);
+    }
+  }, [applyError, tr]);
+
+  const busy = loadingPreview || installing;
+  const cliMissing =
+    !cliFound ||
+    errorKind === "cli_missing" ||
+    isCliMissingError(error);
+
+  const kindHint =
+    errorKind === "missing_auth"
+      ? tr("managedSetup.error.missingAuth")
+      : errorKind === "rejected"
+        ? tr("managedSetup.error.rejected")
+        : errorKind === "cli_missing"
+          ? tr("managedSetup.error.cliBody")
+          : null;
+
+  return (
+    <div className="managed-setup" data-testid="managed-setup-panel">
+      <div className="settings-row settings-row--stack" style={{ borderBottom: "none" }}>
+        <div className="settings-row__text">
+          <div className="settings-row__label">{tr("managedSetup.title")}</div>
+          <div className="settings-row__desc">{tr("managedSetup.desc")}</div>
+        </div>
+        <div className="settings-row__hint">{tr("managedSetup.authHint")}</div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            disabled={busy}
+            onClick={() => void onPreview()}
+          >
+            {loadingPreview
+              ? tr("managedSetup.previewing")
+              : tr("managedSetup.preview")}
+          </button>
+          <button
+            type="button"
+            className="btn btn--solid"
+            disabled={busy}
+            onClick={() => setConfirmOpen(true)}
+          >
+            {installing
+              ? tr("managedSetup.installing")
+              : tr("managedSetup.install")}
+          </button>
+          {onOpenAccount && (
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={busy}
+              onClick={onOpenAccount}
+            >
+              {tr("managedSetup.openAccount")}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {status && !error && (
+        <p className="settings-row__hint" role="status">
+          {status}
+        </p>
+      )}
+
+      {cliMissing && (
+        <div className="ext-alert ext-alert--error" role="alert">
+          <div className="ext-alert__title">{tr("managedSetup.error.cliTitle")}</div>
+          <p className="ext-alert__body">{tr("managedSetup.error.cliBody")}</p>
+        </div>
+      )}
+
+      {!cliMissing && error && (
+        <div className="ext-alert ext-alert--error" role="alert">
+          <div className="ext-alert__title">
+            {errorKind === "missing_auth"
+              ? tr("managedSetup.error.missingAuthTitle")
+              : errorKind === "rejected"
+                ? tr("managedSetup.error.rejectedTitle")
+                : tr("managedSetup.error.title")}
+          </div>
+          {kindHint && <p className="ext-alert__body">{kindHint}</p>}
+          <pre className="ext-alert__detail" style={{ whiteSpace: "pre-wrap" }}>
+            {error}
+          </pre>
+          {errorKind === "missing_auth" && onOpenAccount && (
+            <button
+              type="button"
+              className="btn btn--ghost ext-alert__cta"
+              onClick={onOpenAccount}
+            >
+              {tr("managedSetup.openAccount")}
+            </button>
+          )}
+        </div>
+      )}
+
+      {summary && (
+        <div className="managed-setup__preview" data-testid="managed-setup-preview">
+          <div className="settings-row__label" style={{ marginBottom: 6 }}>
+            {tr("managedSetup.previewTitle")}
+          </div>
+          {summary.facts.length > 0 && (
+            <ul className="managed-setup__facts">
+              {summary.facts.map((f) => (
+                <li key={f.key}>
+                  <span className="managed-setup__fact-key">{f.key}</span>
+                  <span className="managed-setup__fact-val">{f.value}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {summary.sectionCounts.length > 0 && (
+            <p className="settings-row__hint">
+              {tr("managedSetup.sections", {
+                list: summary.sectionCounts
+                  .map((s) => `${s.key} (${s.count})`)
+                  .join(" · "),
+              })}
+            </p>
+          )}
+          {previewNote && !summary.topLevelKeys.length && (
+            <p className="settings-row__hint">{previewNote}</p>
+          )}
+          <pre
+            className="ext-details-pre managed-setup__json"
+            data-testid="managed-setup-json"
+          >
+            {summary.redactedJson}
+          </pre>
+          <p className="settings-row__hint">{tr("managedSetup.redactNote")}</p>
+        </div>
+      )}
+
+      <GlassModal
+        open={confirmOpen}
+        onClose={() => {
+          if (!installing) setConfirmOpen(false);
+        }}
+        title={tr("managedSetup.confirmTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={installing}
+              onClick={() => setConfirmOpen(false)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={installing}
+              onClick={() => void runInstall()}
+            >
+              {installing
+                ? tr("managedSetup.installing")
+                : tr("managedSetup.install")}
+            </button>
+          </>
+        }
+      >
+        <p className="app-dialog__msg">{tr("managedSetup.confirmBody")}</p>
+      </GlassModal>
+    </div>
+  );
+}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -45,6 +45,7 @@ import { AccountPanel } from "@/components/AccountPanel";
 import { ProvidersPanel } from "@/components/ProvidersPanel";
 import { ExtensionsPanel } from "@/components/ExtensionsPanel";
 import { ProjectInspectPanel } from "@/components/ProjectInspectPanel";
+import { ManagedSetupPanel } from "@/components/ManagedSetupPanel";
 import {
   createT,
   resolveLocale,
@@ -1482,6 +1483,11 @@ export function SettingsPage({
                 cliFound={cliInfo.found}
               />
             </div>
+            <ManagedSetupPanel
+              locale={resolveLocale(locale)}
+              cliFound={cliInfo.found}
+              onOpenAccount={() => onSection("account")}
+            />
           </div>
         )}
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -639,6 +639,39 @@ const en = {
   "inspect.section.config": "Config layers",
   "inspect.plugin.disabled": "Disabled",
   "inspect.skills.sample": "Invocable sample: {names}",
+
+  // Managed configuration (`grok setup`)
+  "managedSetup.title": "Managed setup",
+  "managedSetup.desc":
+    "Fetch and install organization-managed configuration (`grok setup`). Preview shows a sanitized summary; Install writes into ~/.grok.",
+  "managedSetup.authHint":
+    "Requires a team sign-in (`grok login`) or GROK_DEPLOYMENT_KEY (env or [endpoints] deployment_key in ~/.grok/config.toml).",
+  "managedSetup.preview": "Preview",
+  "managedSetup.previewing": "Fetching preview…",
+  "managedSetup.previewOk": "Preview ready (nothing written).",
+  "managedSetup.previewTitle": "Preview summary",
+  "managedSetup.install": "Install",
+  "managedSetup.installing": "Installing…",
+  "managedSetup.installOk": "Managed configuration applied.",
+  "managedSetup.confirmTitle": "Install managed configuration?",
+  "managedSetup.confirmBody":
+    "This runs `grok setup` and may overwrite managed files under ~/.grok (for example managed_config.toml). Your personal config.toml is not deleted. Continue?",
+  "managedSetup.openAccount": "Open Account",
+  "managedSetup.needTauri": "Managed setup requires the desktop app.",
+  "managedSetup.sections": "Sections: {list}",
+  "managedSetup.redactNote":
+    "Secrets and key-like fields are redacted. Full values are never shown.",
+  "managedSetup.error.title": "Managed setup failed",
+  "managedSetup.error.generic": "Could not complete managed setup.",
+  "managedSetup.error.cliTitle": "Grok Build CLI not found",
+  "managedSetup.error.cliBody":
+    "Install or locate the CLI under Settings → Runtime, then try again.",
+  "managedSetup.error.missingAuthTitle": "Team login or deployment key required",
+  "managedSetup.error.missingAuth":
+    "Sign in with a team account, or set GROK_DEPLOYMENT_KEY / [endpoints].deployment_key, then retry.",
+  "managedSetup.error.rejectedTitle": "Deployment key rejected",
+  "managedSetup.error.rejected":
+    "The deployment key was rejected or expired. Confirm it with your administrator.",
   "settings.aboutApp": "About Grok App",
   "settings.checkUpdate": "Check for updates",
   "settings.checkUpdateDesc":
@@ -1849,6 +1882,38 @@ const zh: Record<MessageKey, string> = {
   "inspect.section.config": "配置层",
   "inspect.plugin.disabled": "已禁用",
   "inspect.skills.sample": "可调用示例：{names}",
+
+  // Managed configuration (`grok setup`)
+  "managedSetup.title": "托管配置安装",
+  "managedSetup.desc":
+    "拉取并安装组织托管配置（`grok setup`）。预览显示脱敏摘要；安装会写入 ~/.grok。",
+  "managedSetup.authHint":
+    "需要团队登录（`grok login`）或部署密钥 GROK_DEPLOYMENT_KEY（环境变量，或 ~/.grok/config.toml 中 [endpoints] deployment_key）。",
+  "managedSetup.preview": "预览",
+  "managedSetup.previewing": "正在获取预览…",
+  "managedSetup.previewOk": "预览已就绪（未写入任何文件）。",
+  "managedSetup.previewTitle": "预览摘要",
+  "managedSetup.install": "安装",
+  "managedSetup.installing": "正在安装…",
+  "managedSetup.installOk": "已应用托管配置。",
+  "managedSetup.confirmTitle": "安装托管配置？",
+  "managedSetup.confirmBody":
+    "将运行 `grok setup`，可能覆盖 ~/.grok 下的托管文件（例如 managed_config.toml）。不会删除你的个人 config.toml。是否继续？",
+  "managedSetup.openAccount": "打开账户",
+  "managedSetup.needTauri": "托管配置安装需要桌面应用。",
+  "managedSetup.sections": "分区：{list}",
+  "managedSetup.redactNote": "密钥与敏感字段已脱敏，不会显示完整值。",
+  "managedSetup.error.title": "托管配置失败",
+  "managedSetup.error.generic": "无法完成托管配置安装。",
+  "managedSetup.error.cliTitle": "未找到 Grok Build CLI",
+  "managedSetup.error.cliBody":
+    "请先在 设置 → 运行环境 安装或指定 CLI，然后重试。",
+  "managedSetup.error.missingAuthTitle": "需要团队登录或部署密钥",
+  "managedSetup.error.missingAuth":
+    "请使用团队账号登录，或设置 GROK_DEPLOYMENT_KEY / [endpoints].deployment_key 后再试。",
+  "managedSetup.error.rejectedTitle": "部署密钥被拒绝",
+  "managedSetup.error.rejected":
+    "部署密钥无效或已过期，请与管理员确认。",
   "settings.aboutApp": "关于 Grok App",
   "settings.checkUpdate": "检查更新",
   "settings.checkUpdateDesc":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -610,6 +610,38 @@ export const zhTW: Record<MessageKey, string> = {
   "inspect.section.config": "設定層",
   "inspect.plugin.disabled": "已停用",
   "inspect.skills.sample": "可呼叫範例：{names}",
+
+  // Managed configuration (`grok setup`)
+  "managedSetup.title": "託管設定安裝",
+  "managedSetup.desc":
+    "擷取並安裝組織託管設定（`grok setup`）。預覽顯示去敏摘要；安裝會寫入 ~/.grok。",
+  "managedSetup.authHint":
+    "需要團隊登入（`grok login`）或部署金鑰 GROK_DEPLOYMENT_KEY（環境變數，或 ~/.grok/config.toml 中 [endpoints] deployment_key）。",
+  "managedSetup.preview": "預覽",
+  "managedSetup.previewing": "正在取得預覽…",
+  "managedSetup.previewOk": "預覽已就緒（未寫入任何檔案）。",
+  "managedSetup.previewTitle": "預覽摘要",
+  "managedSetup.install": "安裝",
+  "managedSetup.installing": "正在安裝…",
+  "managedSetup.installOk": "已套用託管設定。",
+  "managedSetup.confirmTitle": "安裝託管設定？",
+  "managedSetup.confirmBody":
+    "將執行 `grok setup`，可能覆寫 ~/.grok 下的託管檔案（例如 managed_config.toml）。不會刪除你的個人 config.toml。是否繼續？",
+  "managedSetup.openAccount": "開啟帳戶",
+  "managedSetup.needTauri": "託管設定安裝需要桌面應用程式。",
+  "managedSetup.sections": "區段：{list}",
+  "managedSetup.redactNote": "金鑰與敏感欄位已去敏，不會顯示完整值。",
+  "managedSetup.error.title": "託管設定失敗",
+  "managedSetup.error.generic": "無法完成託管設定安裝。",
+  "managedSetup.error.cliTitle": "找不到 Grok Build CLI",
+  "managedSetup.error.cliBody":
+    "請先在 設定 → 執行環境 安裝或指定 CLI，然後再試。",
+  "managedSetup.error.missingAuthTitle": "需要團隊登入或部署金鑰",
+  "managedSetup.error.missingAuth":
+    "請使用團隊帳號登入，或設定 GROK_DEPLOYMENT_KEY / [endpoints].deployment_key 後再試。",
+  "managedSetup.error.rejectedTitle": "部署金鑰被拒絕",
+  "managedSetup.error.rejected":
+    "部署金鑰無效或已過期，請與管理員確認。",
   "settings.aboutApp": "關於 Grok App",
   "settings.checkUpdate": "檢查更新",
   "settings.checkUpdateDesc":

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1177,6 +1177,41 @@ export async function pluginUpdate(name?: string | null) {
   return invoke<PluginActionResult>("plugin_update", {
     name: n ? n : null,
   });
+// ── Managed configuration (`grok setup` / `grok setup --json`) ──────────────
+
+export type ManagedSetupErrorKind =
+  | "missing_auth"
+  | "rejected"
+  | "cli_missing"
+  | "timeout"
+  | "parse"
+  | "other";
+
+/** Host result of `grok setup --json` (payload already key-redacted). */
+export interface SetupPreviewResult {
+  ok: boolean;
+  payload?: unknown | null;
+  message?: string | null;
+  error?: string | null;
+  errorKind?: ManagedSetupErrorKind | null;
+}
+
+/** Host result of `grok setup` install. */
+export interface SetupInstallResult {
+  ok: boolean;
+  message?: string | null;
+  error?: string | null;
+  errorKind?: ManagedSetupErrorKind | null;
+}
+
+/** Preview managed config without writing (`grok setup --json`). */
+export async function setupPreview() {
+  return invoke<SetupPreviewResult>("setup_preview");
+}
+
+/** Install managed config into ~/.grok (`grok setup`); soft-respawns agent. */
+export async function setupInstall() {
+  return invoke<SetupInstallResult>("setup_install");
 }
 
 // ── Official Grok Build account ─────────────────────────────────────────────

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1177,6 +1177,8 @@ export async function pluginUpdate(name?: string | null) {
   return invoke<PluginActionResult>("plugin_update", {
     name: n ? n : null,
   });
+}
+
 // ── Managed configuration (`grok setup` / `grok setup --json`) ──────────────
 
 export type ManagedSetupErrorKind =

--- a/src/lib/managedSetup.test.ts
+++ b/src/lib/managedSetup.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifySetupError,
+  formatRedactedJson,
+  isSensitiveKey,
+  redactSensitiveValue,
+  summarizeSetupJson,
+} from "./managedSetup";
+
+const SAMPLE_SETUP = {
+  deploymentId: "dep_abc123",
+  teamId: "team_xyz",
+  failClosed: true,
+  managedConfig: {
+    models: { default: "company-grok" },
+    features: { telemetry: false },
+  },
+  requirements: {
+    minimum_version: "0.2.0",
+  },
+  apiKey: "sk-abcdefghijklmnopqrstuvwxyz123456",
+  deployment_key: "deploy-secret-should-never-show",
+  env: {
+    OPENAI_API_KEY: "sk-nestedsecretnestedsecret",
+    PATH: "/usr/bin",
+  },
+  headers: {
+    Authorization: "Bearer supersecrettokenvalue12345",
+  },
+  signatures: {
+    managed_config: "sig-blob-aaaaaaaaaaaaaaaa",
+  },
+  token: "refresh-token-should-redact",
+  nested: {
+    client_secret: "client-secret-value",
+    name: "safe-name",
+  },
+};
+
+describe("isSensitiveKey", () => {
+  it("flags common secret field names", () => {
+    expect(isSensitiveKey("apiKey")).toBe(true);
+    expect(isSensitiveKey("api_key")).toBe(true);
+    expect(isSensitiveKey("OPENAI_API_KEY")).toBe(true);
+    expect(isSensitiveKey("token")).toBe(true);
+    expect(isSensitiveKey("client_secret")).toBe(true);
+    expect(isSensitiveKey("password")).toBe(true);
+    expect(isSensitiveKey("deployment_key")).toBe(true);
+    expect(isSensitiveKey("deploymentKey")).toBe(true);
+  });
+
+  it("allows safe field names", () => {
+    expect(isSensitiveKey("name")).toBe(false);
+    expect(isSensitiveKey("teamId")).toBe(false);
+    expect(isSensitiveKey("deploymentId")).toBe(false);
+    expect(isSensitiveKey("failClosed")).toBe(false);
+    expect(isSensitiveKey("models")).toBe(false);
+  });
+});
+
+describe("redactSensitiveValue", () => {
+  it("redacts key-like fields and secret containers", () => {
+    const safe = redactSensitiveValue(SAMPLE_SETUP) as Record<string, unknown>;
+    expect(safe.apiKey).toBe("[REDACTED]");
+    expect(safe.deployment_key).toBe("[REDACTED]");
+    expect(safe.token).toBe("[REDACTED]");
+    expect(safe.env).toBe("[REDACTED]");
+    expect(safe.headers).toBe("[REDACTED]");
+    expect(safe.signatures).toBe("[REDACTED]");
+    expect(safe.deploymentId).toBe("dep_abc123");
+    expect(safe.teamId).toBe("team_xyz");
+    expect(safe.failClosed).toBe(true);
+
+    const nested = safe.nested as Record<string, unknown>;
+    expect(nested.client_secret).toBe("[REDACTED]");
+    expect(nested.name).toBe("safe-name");
+  });
+
+  it("scrubs sk- tokens inside free-form strings", () => {
+    const safe = redactSensitiveValue({
+      note: "use sk-abcdefghijklmnopqrstuvwxyz with care",
+    }) as { note: string };
+    expect(safe.note).toContain("[REDACTED]");
+    expect(safe.note).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+  });
+});
+
+describe("summarizeSetupJson", () => {
+  it("builds a summary without leaking secrets", () => {
+    const s = summarizeSetupJson(SAMPLE_SETUP);
+    expect(s.topLevelKeys).toContain("deploymentId");
+    expect(s.topLevelKeys).toContain("managedConfig");
+    expect(s.facts.some((f) => f.key === "deploymentId" && f.value === "dep_abc123")).toBe(
+      true,
+    );
+    expect(s.facts.some((f) => f.key === "failClosed" && f.value === "true")).toBe(true);
+    expect(s.sectionCounts.some((c) => c.key === "managedConfig")).toBe(true);
+
+    expect(s.redactedJson).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+    expect(s.redactedJson).not.toContain("deploy-secret-should-never-show");
+    expect(s.redactedJson).not.toContain("client-secret-value");
+    expect(s.redactedJson).toContain("[REDACTED]");
+    expect(s.redactedJson).toContain("dep_abc123");
+  });
+
+  it("parses JSON strings and handles invalid JSON text safely", () => {
+    const fromString = summarizeSetupJson(JSON.stringify(SAMPLE_SETUP));
+    expect(fromString.topLevelKeys).toContain("teamId");
+
+    const plain = summarizeSetupJson("not json but has sk-abcdefghijklmnopqr token");
+    expect(plain.note).toBe("non-json");
+    expect(plain.redactedJson).toContain("[REDACTED]");
+    expect(plain.redactedJson).not.toContain("sk-abcdefghijklmnopqr");
+  });
+});
+
+describe("formatRedactedJson", () => {
+  it("never includes raw api keys", () => {
+    const text = formatRedactedJson(SAMPLE_SETUP);
+    expect(text).not.toMatch(/sk-[A-Za-z0-9]{10,}/);
+    expect(text).not.toContain("deploy-secret");
+  });
+});
+
+describe("classifySetupError", () => {
+  it("detects missing deployment key / team sign-in", () => {
+    const msg = `No deployment key or team sign-in found.
+
+To install managed configuration, sign in with a team using \`grok login\`,
+or set a deployment key:
+
+  export GROK_DEPLOYMENT_KEY=<your-key>
+  grok setup`;
+    expect(classifySetupError(msg)).toBe("missing_auth");
+  });
+
+  it("detects rejected key", () => {
+    expect(
+      classifySetupError(
+        "Couldn't fetch managed configuration. The deployment key was rejected.",
+      ),
+    ).toBe("rejected");
+  });
+
+  it("detects cli missing and timeout", () => {
+    expect(classifySetupError("Grok Build CLI not found")).toBe("cli_missing");
+    expect(classifySetupError("grok command timed out after 30s")).toBe("timeout");
+  });
+});

--- a/src/lib/managedSetup.ts
+++ b/src/lib/managedSetup.ts
@@ -1,0 +1,267 @@
+/**
+ * Pure helpers for managed configuration setup (`grok setup` / `grok setup --json`).
+ * Redacts secret-like fields so Settings never shows full keys.
+ */
+
+import { redact } from "./redact";
+
+/** Known failure modes from the CLI / host wrapper. */
+export type ManagedSetupErrorKind =
+  | "missing_auth"
+  | "rejected"
+  | "cli_missing"
+  | "timeout"
+  | "parse"
+  | "other";
+
+/** Sanitized preview of managed config (safe to show in UI). */
+export type ManagedSetupSummary = {
+  /** Top-level keys present after redaction (stable sort). */
+  topLevelKeys: string[];
+  /** Safe scalar facts (string/number/boolean only, already redacted). */
+  facts: Array<{ key: string; value: string }>;
+  /** Nested section counts (e.g. models → 3). */
+  sectionCounts: Array<{ key: string; count: number }>;
+  /** Pretty JSON with secrets redacted. */
+  redactedJson: string;
+  /** Optional short note (e.g. deployment id fingerprint). */
+  note?: string | null;
+};
+
+export type ManagedSetupResult = {
+  ok: boolean;
+  /** Install stdout message, or preview note. */
+  message?: string | null;
+  summary?: ManagedSetupSummary | null;
+  error?: string | null;
+  errorKind?: ManagedSetupErrorKind | null;
+};
+
+const SENSITIVE_KEY_RE =
+  /^(api[_-]?key|token|secret|password|passwd|authorization|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret|private[_-]?key|bearer|deployment[_-]?key|xai[_-]?api[_-]?key)$/i;
+
+const SENSITIVE_CONTAINER_KEYS = new Set([
+  "env",
+  "environment",
+  "headers",
+  "authorization",
+  "secrets",
+  "credentials",
+  "signatures",
+  "managed_identity_signatures",
+  "managedidentitysignatures",
+]);
+
+/** Max scalar facts / nested keys to list in the summary panel. */
+const MAX_FACTS = 24;
+const MAX_SECTION_COUNTS = 16;
+/** Cap pretty-print size so huge payloads do not freeze the UI. */
+const MAX_JSON_CHARS = 48_000;
+
+export function isSensitiveKey(key: string): boolean {
+  const k = (key ?? "").trim();
+  if (!k) return false;
+  if (SENSITIVE_KEY_RE.test(k)) return true;
+  if (/api[_-]?key/i.test(k)) return true;
+  if (/(^|[_-])(token|secret|password|passwd)($|[_-])/i.test(k)) return true;
+  if (/deployment[_-]?key/i.test(k)) return true;
+  // Signature blobs / fingerprints that are still secret-adjacent
+  if (/(_sig|signature|fingerprint)$/i.test(k) && !/key_fingerprint/i.test(k)) {
+    return /sig|signature/i.test(k);
+  }
+  return false;
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  if (v && typeof v === "object" && !Array.isArray(v)) {
+    return v as Record<string, unknown>;
+  }
+  return null;
+}
+
+/**
+ * Drop secrets from an arbitrary JSON-like value.
+ * Sensitive keys become `"[REDACTED]"`; env/header/signature maps are fully redacted.
+ */
+export function redactSensitiveValue(value: unknown): unknown {
+  if (value == null) return value;
+  if (typeof value === "string") {
+    return redact(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveValue(item));
+  }
+  const obj = asRecord(value);
+  if (!obj) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(obj)) {
+    if (isSensitiveKey(key) || SENSITIVE_CONTAINER_KEYS.has(key.toLowerCase())) {
+      out[key] = "[REDACTED]";
+      continue;
+    }
+    out[key] = redactSensitiveValue(child);
+  }
+  return out;
+}
+
+/** Classify CLI stderr/stdout into a stable error kind for UI copy. */
+export function classifySetupError(message: string | null | undefined): ManagedSetupErrorKind {
+  const m = (message ?? "").toLowerCase();
+  if (!m.trim()) return "other";
+  if (
+    m.includes("cli not found") ||
+    m.includes("grok build cli not found") ||
+    m.includes("no such file")
+  ) {
+    return "cli_missing";
+  }
+  if (m.includes("timed out") || m.includes("timeout")) {
+    return "timeout";
+  }
+  if (
+    m.includes("no deployment key") ||
+    m.includes("team sign-in") ||
+    m.includes("team login") ||
+    m.includes("sign in with a team") ||
+    m.includes("export grok_deployment_key")
+  ) {
+    return "missing_auth";
+  }
+  if (
+    m.includes("deployment key was rejected") ||
+    m.includes("key was rejected") ||
+    m.includes("hasn't expired") ||
+    m.includes("hasnt expired")
+  ) {
+    return "rejected";
+  }
+  if (m.includes("json") && (m.includes("parse") || m.includes("invalid"))) {
+    return "parse";
+  }
+  return "other";
+}
+
+/** Pretty-print redacted JSON, capped for UI. */
+export function formatRedactedJson(value: unknown): string {
+  const safe = redactSensitiveValue(value);
+  let text: string;
+  try {
+    text = JSON.stringify(safe, null, 2);
+  } catch {
+    text = String(safe);
+  }
+  text = redact(text);
+  if (text.length > MAX_JSON_CHARS) {
+    return `${text.slice(0, MAX_JSON_CHARS)}\n… [truncated]`;
+  }
+  return text;
+}
+
+function formatScalar(v: unknown): string | null {
+  if (typeof v === "string") {
+    const s = redact(v.trim());
+    if (!s) return null;
+    // Avoid dumping multi-line blobs into fact rows
+    if (s.length > 120 || s.includes("\n")) {
+      return `${s.slice(0, 80)}…`;
+    }
+    return s;
+  }
+  if (typeof v === "number" && Number.isFinite(v)) return String(v);
+  if (typeof v === "boolean") return v ? "true" : "false";
+  return null;
+}
+
+function countEntries(v: unknown): number | null {
+  if (Array.isArray(v)) return v.length;
+  const obj = asRecord(v);
+  if (obj) return Object.keys(obj).length;
+  return null;
+}
+
+/**
+ * Build a secret-safe summary from raw `grok setup --json` output.
+ * Accepts already-parsed JSON, or a JSON string (will parse).
+ */
+export function summarizeSetupJson(raw: unknown): ManagedSetupSummary {
+  let root: unknown = raw;
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return {
+        topLevelKeys: [],
+        facts: [],
+        sectionCounts: [],
+        redactedJson: "{}",
+        note: null,
+      };
+    }
+    try {
+      root = JSON.parse(trimmed);
+    } catch {
+      // Non-JSON preview (plain text) — still scrub and show
+      const scrubbed = redact(trimmed);
+      return {
+        topLevelKeys: [],
+        facts: [],
+        sectionCounts: [],
+        redactedJson: scrubbed.slice(0, MAX_JSON_CHARS),
+        note: "non-json",
+      };
+    }
+  }
+
+  const redacted = redactSensitiveValue(root);
+  const obj = asRecord(redacted);
+  const topLevelKeys = obj
+    ? Object.keys(obj).sort((a, b) => a.localeCompare(b))
+    : [];
+
+  const facts: ManagedSetupSummary["facts"] = [];
+  const sectionCounts: ManagedSetupSummary["sectionCounts"] = [];
+
+  if (obj) {
+    for (const key of topLevelKeys) {
+      const child = obj[key];
+      const scalar = formatScalar(child);
+      if (scalar != null) {
+        if (facts.length < MAX_FACTS) {
+          facts.push({ key, value: scalar });
+        }
+        continue;
+      }
+      const n = countEntries(child);
+      if (n != null && sectionCounts.length < MAX_SECTION_COUNTS) {
+        sectionCounts.push({ key, count: n });
+      }
+    }
+  } else if (Array.isArray(redacted)) {
+    sectionCounts.push({ key: "items", count: redacted.length });
+  }
+
+  return {
+    topLevelKeys,
+    facts,
+    sectionCounts,
+    redactedJson: formatRedactedJson(root),
+    note: null,
+  };
+}
+
+/** Empty result helper for tests / UI defaults. */
+export function emptySetupResult(
+  partial?: Partial<ManagedSetupResult>,
+): ManagedSetupResult {
+  return {
+    ok: false,
+    message: null,
+    summary: null,
+    error: null,
+    errorKind: null,
+    ...partial,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12024,6 +12024,8 @@ div.composer__input:empty::before {
   font-size: 12px;
   line-height: 1.4;
   color: var(--text-tertiary);
+}
+
 /* ── Managed setup (Settings → Runtime) ─────────────────────────────────── */
 .managed-setup {
   border-top: 1px solid var(--border-subtle);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12024,4 +12024,56 @@ div.composer__input:empty::before {
   font-size: 12px;
   line-height: 1.4;
   color: var(--text-tertiary);
+/* ── Managed setup (Settings → Runtime) ─────────────────────────────────── */
+.managed-setup {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 4px;
+}
+
+.managed-setup__preview {
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated, var(--bg-hover));
+}
+
+.managed-setup__facts {
+  list-style: none;
+  margin: 0 0 8px;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.managed-setup__facts li {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 12px;
+  line-height: 1.4;
+  min-width: 0;
+}
+
+.managed-setup__fact-key {
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11px;
+}
+
+.managed-setup__fact-val {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+}
+
+.managed-setup__json {
+  margin-top: 8px;
+  max-height: 240px;
+  overflow: auto;
+  font-size: 11px;
 }


### PR DESCRIPTION
## Problem
Teams that use Grok Build managed configuration today have to run `grok setup` in a terminal. The desktop app had no path to preview or install org-managed config, and no guardrails against showing deployment keys in the UI.

## Changes
- **Host commands**
  - `setup_preview` → `grok setup --json` (writes nothing)
  - `setup_install` → `grok setup` (applies into `~/.grok`, soft-respawns agent)
  - Failures (missing deployment key / team sign-in, rejected key, CLI missing) return a user-facing `error` + `errorKind` instead of crashing
- **Settings → Runtime → Managed setup**
  - **Preview** shows a sanitized JSON summary
  - **Install** with in-app confirm dialog (no `window.confirm`)
  - Explains need for team login / `GROK_DEPLOYMENT_KEY`
  - Shortcut to Account for team sign-in
- **Redaction**: key-like fields (`apiKey`, `deployment_key`, `token`, `env`, `headers`, signatures, …) scrubbed in both Rust host and TS helpers; never show full secrets
- **i18n**: en + zh + zh-TW

## How to test
1. `pnpm typecheck && pnpm test`
2. `cd src-tauri && cargo test setup_cmd`
3. Settings → Runtime → Managed setup:
   - Without team login / deployment key: **Preview** and **Install** show the CLI’s “No deployment key or team sign-in” style message (no crash)
   - With valid auth: **Preview** shows redacted summary; **Install** confirms then applies
4. Confirm preview JSON never contains raw `sk-…` / deployment key values (see `managedSetup.test.ts`)

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (includes redaction + i18n key parity)
- [x] `cargo test setup_cmd` (classify errors + JSON redaction)
- [x] Manual path: missing-auth error surfaces via CLI message mapping (reproduced with `grok setup --json` locally)