### PR TITLE
feat: disable plan mode via settings (--no-plan at spawn)

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -193,6 +193,8 @@ impl SandboxSpawnSpec {
 pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
     let spec = SandboxSpawnSpec::from_setting(profile)?;
     Some((spec.cli_args().to_vec(), spec.env_pair()))
+}
+
 /// Pure helper: top-level CLI flags for the plan_enabled setting.
 ///
 /// When `plan_enabled` is false, returns `["--no-plan"]` (before `agent`).

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -193,6 +193,16 @@ impl SandboxSpawnSpec {
 pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
     let spec = SandboxSpawnSpec::from_setting(profile)?;
     Some((spec.cli_args().to_vec(), spec.env_pair()))
+/// Pure helper: top-level CLI flags for the plan_enabled setting.
+///
+/// When `plan_enabled` is false, returns `["--no-plan"]` (before `agent`).
+/// When true, returns no flags so the CLI keeps plan mode available.
+pub fn no_plan_spawn_flags(plan_enabled: bool) -> Vec<&'static str> {
+    if plan_enabled {
+        vec![]
+    } else {
+        vec!["--no-plan"]
+    }
 }
 
 impl AcpClient {
@@ -288,6 +298,16 @@ impl AcpClient {
             for a in sb.cli_args() {
                 cmd.arg(a);
             }
+        //   top-level: `grok --no-auto-update [--no-plan] agent …`
+        //   agent opts: `--model` / `--reasoning-effort` / `--always-approve` before `stdio`
+        // Skip background update checks so ACP handshakes are not delayed on launch.
+        // `--no-plan` is top-level only (disables plan mode for the process).
+        let plan_enabled = crate::store::load_settings().plan_enabled;
+
+        let mut cmd = Command::new(&cli_path);
+        cmd.arg("--no-auto-update");
+        for flag in no_plan_spawn_flags(plan_enabled) {
+            cmd.arg(flag);
         }
         cmd.arg("agent");
         if !spawn_model.is_empty() {
@@ -322,6 +342,7 @@ impl AcpClient {
         }
         tracing::info!(
             "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} sandbox={:?}",
+            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} plan_enabled={}",
             grok_home.display(),
             session_data_mode,
             grok_home.join("auth.json").is_file(),
@@ -333,6 +354,7 @@ impl AcpClient {
                 .map(cli_permission_mode)
                 == Some("bypassPermissions"),
             sandbox.as_ref().map(|s| s.profile.as_str())
+            plan_enabled
         );
 
         let mut child = cmd.spawn().map_err(|e| {
@@ -2260,5 +2282,20 @@ mod live_handshake_tests {
         eprintln!("OK session={} in {:?}", sid, t0.elapsed());
         client.kill().await;
         assert!(!sid.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod no_plan_spawn_tests {
+    use super::no_plan_spawn_flags;
+
+    #[test]
+    fn enabled_adds_no_flags() {
+        assert!(no_plan_spawn_flags(true).is_empty());
+    }
+
+    #[test]
+    fn disabled_adds_top_level_flag() {
+        assert_eq!(no_plan_spawn_flags(false), vec!["--no-plan"]);
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -654,6 +654,8 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    }
+
     if plan_enabled_flip {
         // Spawn flag changes — soft-respawn so the next turn drops/restores plan mode.
         mgr.soft_respawn(&app).await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -634,6 +634,7 @@ pub async fn settings_set(
         prev.store_api_keys_in_keychain != settings.store_api_keys_in_keychain;
     let session_data_mode_changed =
         prev.session_data_mode != settings.session_data_mode;
+    let plan_enabled_flip = prev.plan_enabled != settings.plan_enabled;
 
     store::save_settings(&settings)?;
 
@@ -653,6 +654,9 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    if plan_enabled_flip {
+        // Spawn flag changes — soft-respawn so the next turn drops/restores plan mode.
+        mgr.soft_respawn(&app).await;
     }
 
     // Full permission apply: Host + agent-home + soft-respawn if needed

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -196,6 +196,8 @@ fn default_stream_stall_seconds() -> u32 {
 
 fn default_sandbox_profile() -> String {
     "off".into()
+}
+
 fn default_plan_enabled() -> bool {
     true
 }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -168,6 +168,10 @@ pub struct AppSettings {
     /// Passed as top-level `grok --sandbox <profile>` / `GROK_SANDBOX` at spawn.
     #[serde(default = "default_sandbox_profile")]
     pub sandbox_profile: String,
+    /// When true (default), agents may enter plan mode. When false, spawn with
+    /// top-level `--no-plan` so plan mode is disabled for that process.
+    #[serde(default = "default_plan_enabled")]
+    pub plan_enabled: bool,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -192,6 +196,8 @@ fn default_stream_stall_seconds() -> u32 {
 
 fn default_sandbox_profile() -> String {
     "off".into()
+fn default_plan_enabled() -> bool {
+    true
 }
 
 impl Default for AppSettings {
@@ -217,6 +223,7 @@ impl Default for AppSettings {
             stream_stall_seconds: default_stream_stall_seconds(),
             store_api_keys_in_keychain: false,
             sandbox_profile: default_sandbox_profile(),
+            plan_enabled: default_plan_enabled(),
         }
     }
 }
@@ -1305,6 +1312,15 @@ mod tests {
         let raw = r#"{
             "theme": "dark",
             "locale": "en",
+        assert!(s.plan_enabled);
+    }
+
+    #[test]
+    fn plan_enabled_defaults_true_when_missing_from_json() {
+        // Older settings files omit the field — keep plan mode on (CLI default).
+        let raw = r#"{
+            "theme": "dark",
+            "locale": "zh",
             "sessionDataMode": "independent",
             "manualCliPath": null,
             "permissionPolicy": "ask",
@@ -1361,5 +1377,6 @@ mod tests {
         let m: SessionMeta = serde_json::from_str(raw).expect("deserialize legacy session");
         assert!(!m.pinned);
         assert!(!m.archived);
+        assert!(s.plan_enabled);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -692,6 +692,8 @@ export default function App() {
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
   const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
   const [sandboxProfile, setSandboxProfile] = useState("off");
+  /** Default true — false spawns with top-level `--no-plan`. */
+  const [planEnabled, setPlanEnabled] = useState(true);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -922,6 +924,8 @@ export default function App() {
         const known = ["off", "workspace", "read-only", "strict", "devbox"];
         setSandboxProfile(known.includes(sb) ? sb : "off");
       }
+      // Missing field → keep plan mode on (matches AppSettings default).
+      setPlanEnabled(settings.planEnabled !== false);
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -5893,6 +5897,8 @@ export default function App() {
       "settings.cliNotFound",
       "settings.permissionDeep",
       "settings.permissionDeepDesc",
+      "settings.planEnabled",
+      "settings.planEnabledDesc",
       "settings.prefsScope",
       "settings.prefsScopeDesc",
       "settings.prefsScope.global",
@@ -6225,6 +6231,11 @@ export default function App() {
             setSandboxProfile(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
+          planEnabled={planEnabled}
+          onPlanEnabled={(v) => {
+            setPlanEnabled(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, planEnabled: v }),
             );
           }}
           cliInfo={cliInfo}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6231,6 +6231,8 @@ export default function App() {
             setSandboxProfile(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
+            );
+          }}
           planEnabled={planEnabled}
           onPlanEnabled={(v) => {
             setPlanEnabled(v);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -115,6 +115,9 @@ export interface SettingsPageProps {
   /** OS sandbox for agent spawn: off | workspace | read-only | strict | devbox. */
   sandboxProfile?: string;
   onSandboxProfile?: (v: string) => void;
+  /** When true (default), agents may use plan mode; false → spawn with `--no-plan`. */
+  planEnabled?: boolean;
+  onPlanEnabled?: (v: boolean) => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -418,6 +421,8 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  planEnabled = true,
+  onPlanEnabled,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -886,6 +891,20 @@ export function SettingsPage({
                         label: t("settings.sandbox.devbox"),
                       },
                     ]}
+              {onPlanEnabled ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.planEnabled")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.planEnabledDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={planEnabled}
+                    onChange={() => onPlanEnabled(!planEnabled)}
+                    ariaLabel={t("settings.planEnabled")}
                   />
                 </div>
               ) : null}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -891,6 +891,9 @@ export function SettingsPage({
                         label: t("settings.sandbox.devbox"),
                       },
                     ]}
+                  />
+                </div>
+              ) : null}
               {onPlanEnabled ? (
                 <div className="settings-row">
                   <div className="settings-row__text">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -586,6 +586,9 @@ const en = {
   "settings.sandbox.readOnly": "Read-only — no project writes",
   "settings.sandbox.strict": "Strict — CWD only, block child network",
   "settings.sandbox.devbox": "Devbox — disposable VM layout",
+  "settings.planEnabled": "Plan mode",
+  "settings.planEnabledDesc":
+    "Allow agents to enter plan mode. When off, agents spawn with --no-plan. Live agents soft-respawn when this changes.",
   "settings.prefsScope": "Remember model & permission at",
   "settings.prefsScopeDesc":
     "Global: all chats. Project: each workspace. Session: only the current chat.",
@@ -1798,6 +1801,9 @@ const zh: Record<MessageKey, string> = {
   "settings.sandbox.readOnly": "只读 — 不可写项目文件",
   "settings.sandbox.strict": "严格 — 仅限 CWD，阻止子进程网络",
   "settings.sandbox.devbox": "Devbox — 一次性开发机布局",
+  "settings.planEnabled": "计划模式",
+  "settings.planEnabledDesc":
+    "允许 Agent 进入计划模式。关闭时启动会加上 --no-plan。更改后会 soft-respawn 已连接的 Agent。",
   "settings.prefsScope": "模型与权限记忆范围",
   "settings.prefsScopeDesc":
     "全局：所有对话共用。项目：按工作区记忆。会话：仅当前聊天。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -559,6 +559,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.sandbox.readOnly": "唯讀 — 不可寫專案檔案",
   "settings.sandbox.strict": "嚴格 — 僅限 CWD，封鎖子行程網路",
   "settings.sandbox.devbox": "Devbox — 一次性開發機配置",
+  "settings.planEnabled": "計畫模式",
+  "settings.planEnabledDesc":
+    "允許 Agent 進入計畫模式。關閉時啟動會加上 --no-plan。變更後會 soft-respawn 已連線的 Agent。",
   "settings.prefsScope": "模型與權限記憶範圍",
   "settings.prefsScopeDesc":
     "全域：所有對話共用。專案：依工作區記憶。對話：僅目前聊天。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,10 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+   * When true (default), agents may use plan mode.
+   * When false, spawn with top-level `--no-plan`.
+   */
+  planEnabled?: boolean;
 }
 
 export interface AvailableModel {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,7 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+  /**
    * When true (default), agents may use plan mode.
    * When false, spawn with top-level `--no-plan`.
    */


### PR DESCRIPTION
## Problem
Some users want agents that never enter plan mode (no plan cards / exit_plan_mode gates). The CLI already supports top-level `--no-plan`, but the App always spawned without that flag.

## Changes
- `AppSettings.planEnabled` (bool, **default true**). When `false`, spawn passes top-level `--no-plan`.
- Settings → Permissions toggle: **Plan mode** (en/zh/zh-TW).
- Soft-respawn live agents when the setting flips so the next turn uses the new flag set.
- Pure unit tests for spawn flag construction + serde default for older settings files.

Does not touch the existing Plan status bar / plan card UI — only the spawn path.

## Test plan
- [x] `cargo test no_plan_spawn` — enabled → no flags; disabled → `["--no-plan"]`
- [x] `cargo test plan_enabled` — missing JSON field deserializes to `true`
- [x] `cargo test default_settings` — `plan_enabled` defaults true
- [x] `pnpm typecheck`
- [x] `pnpm test` (347 passed)
- [ ] Manual: Settings → Permissions → turn Plan mode off → live agent soft-respawns; next spawn logs `plan_enabled=false` and CLI has `--no-plan`
- [ ] Manual: turn back on → soft-respawn; plan mode available again