### PR TITLE
feat: allow/disable subagent spawning via settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ See `docs/llm-wiki/release.md`.
 **中文**
 - 新增：应用更新检查、活动任务面板、会话正文搜索、插件安装更新、沙箱配置、会话置顶、项目 inspect、CLI Doctor 合并。  
 - 修复：会话模式切换回收 Agent；缺失项目目录可重定位。
+- **Allow subagent spawning toggle**: Settings → Permissions; default on. When off, agents spawn with `--no-subagents` / `GROK_SUBAGENTS=0` (independent mode also writes `[subagents] enabled = false`). Soft-respawn on flip.
 
 ## [0.1.6] - 2026-07-24
 

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -289,6 +289,22 @@ impl AcpClient {
                 cmd.arg(a);
             }
         }
+        //   top-level: `grok --no-auto-update [--no-subagents] agent …`
+        //   agent opts: `--model` / `--reasoning-effort` / `--always-approve` before `stdio`
+        // Skip background update checks so ACP handshakes are not delayed on launch.
+        // Subagents default on; when off, force --no-subagents + GROK_SUBAGENTS=0 so
+        // agent-home / user config cannot re-enable them.
+        let subagents_enabled = crate::store::load_settings().subagents_enabled;
+        if session_data_mode != "shared" {
+            let _ = crate::agent_subagents::sync_subagents_to_agent_profile(
+                session_data_mode,
+                subagents_enabled,
+            );
+        }
+
+        let mut cmd = Command::new(&cli_path);
+        cmd.arg("--no-auto-update");
+        crate::agent_subagents::apply_subagents_to_command(&mut cmd, subagents_enabled);
         cmd.arg("agent");
         if !spawn_model.is_empty() {
             cmd.args(["--model", &spawn_model]);
@@ -322,6 +338,7 @@ impl AcpClient {
         }
         tracing::info!(
             "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} sandbox={:?}",
+            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} subagents_enabled={}",
             grok_home.display(),
             session_data_mode,
             grok_home.join("auth.json").is_file(),
@@ -333,6 +350,7 @@ impl AcpClient {
                 .map(cli_permission_mode)
                 == Some("bypassPermissions"),
             sandbox.as_ref().map(|s| s.profile.as_str())
+            subagents_enabled
         );
 
         let mut child = cmd.spawn().map_err(|e| {

--- a/src-tauri/src/agent_subagents.rs
+++ b/src-tauri/src/agent_subagents.rs
@@ -1,0 +1,145 @@
+//! Subagent spawning — spawn flags, env, config.
+//!
+//! CLI: `--no-subagents`, `GROK_SUBAGENTS`, `[subagents] enabled`.
+//! Enabled by default; when App setting is off, force-disable at spawn.
+
+use std::fs;
+
+use crate::paths::{agent_config_toml, ensure_app_dirs};
+
+/// Top-level CLI flags (before `agent`) for the subagents_enabled setting.
+/// Empty when enabled (CLI default on); `["--no-subagents"]` when disabled.
+pub fn subagents_spawn_flags(enabled: bool) -> Vec<&'static str> {
+    if enabled {
+        vec![]
+    } else {
+        vec!["--no-subagents"]
+    }
+}
+
+/// `GROK_SUBAGENTS` env value when force-disabling. `None` when enabled.
+pub fn subagents_spawn_env_value(enabled: bool) -> Option<&'static str> {
+    if enabled {
+        None
+    } else {
+        Some("0")
+    }
+}
+
+/// When off, always force-disable so config cannot re-enable subagents.
+pub fn should_force_disable_subagents(subagents_enabled: bool) -> bool {
+    !subagents_enabled
+}
+
+/// Upsert `[subagents] enabled = bool` in a TOML-ish text blob.
+pub fn set_subagents_enabled_in_toml(text: &str, enabled: bool) -> String {
+    set_table_bool(text, "subagents", "enabled", enabled)
+}
+
+fn set_table_bool(text: &str, table: &str, key: &str, value: bool) -> String {
+    let header = format!("[{table}]");
+    let line_val = format!("{key} = {value}");
+    let mut lines: Vec<String> = text.lines().map(|s| s.to_string()).collect();
+    let mut in_table = false;
+    let mut table_start: Option<usize> = None;
+    for i in 0..lines.len() {
+        let trimmed = lines[i].trim().to_string();
+        if trimmed.starts_with('[') {
+            if trimmed == header {
+                in_table = true;
+                table_start = Some(i);
+            } else if in_table {
+                lines.insert(i, line_val);
+                return lines.join("\n") + "\n";
+            } else {
+                in_table = false;
+            }
+            continue;
+        }
+        if in_table {
+            let key_part = trimmed.split('=').next().map(str::trim).unwrap_or("");
+            if key_part == key {
+                lines[i] = line_val;
+                return lines.join("\n") + "\n";
+            }
+        }
+    }
+    if let Some(start) = table_start {
+        lines.insert(start + 1, line_val);
+        return lines.join("\n") + "\n";
+    }
+    let block = format!("\n{header}\n{line_val}\n");
+    let base = text.trim_end();
+    if base.is_empty() {
+        format!("{header}\n{line_val}\n")
+    } else {
+        format!("{base}{block}")
+    }
+}
+
+/// Write `[subagents] enabled` into App agent-home (independent GROK_HOME only).
+pub fn sync_subagents_to_agent_profile(
+    session_data_mode: &str,
+    subagents_enabled: bool,
+) -> Result<(), String> {
+    if session_data_mode == "shared" {
+        // Never rewrite the user's personal ~/.grok/config.toml from the App.
+        return Ok(());
+    }
+    let _ = ensure_app_dirs();
+    let path = agent_config_toml();
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    let next = set_subagents_enabled_in_toml(&existing, subagents_enabled);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    fs::write(&path, next).map_err(|e| e.to_string())?;
+    tracing::info!(
+        "agent_subagents: synced [subagents] enabled={} → {}",
+        subagents_enabled,
+        path.display()
+    );
+    Ok(())
+}
+
+/// Apply spawn flag + env on a tokio Command (top-level, before `agent`).
+/// When enabled, leaves CLI defaults alone; when disabled, force-disables.
+pub fn apply_subagents_to_command(cmd: &mut tokio::process::Command, enabled: bool) {
+    for flag in subagents_spawn_flags(enabled) {
+        cmd.arg(flag);
+    }
+    if let Some(v) = subagents_spawn_env_value(enabled) {
+        cmd.env("GROK_SUBAGENTS", v);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_and_env() {
+        assert!(subagents_spawn_flags(true).is_empty());
+        assert_eq!(subagents_spawn_flags(false), vec!["--no-subagents"]);
+        assert_eq!(subagents_spawn_env_value(true), None);
+        assert_eq!(subagents_spawn_env_value(false), Some("0"));
+        assert!(should_force_disable_subagents(false));
+        assert!(!should_force_disable_subagents(true));
+    }
+
+    #[test]
+    fn upserts_subagents_table() {
+        let t = set_subagents_enabled_in_toml("", false);
+        assert!(t.contains("[subagents]"));
+        assert!(t.contains("enabled = false"));
+        let t2 = set_subagents_enabled_in_toml(&t, true);
+        assert!(t2.contains("enabled = true"));
+        assert_eq!(t2.matches("enabled").count(), 1);
+
+        let existing = "[ui]\nyolo = false\n\n[subagents]\nenabled = true\n";
+        let next = set_subagents_enabled_in_toml(existing, false);
+        assert!(next.contains("[subagents]"));
+        assert!(next.contains("enabled = false"));
+        assert!(next.contains("[ui]"));
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -654,6 +654,8 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    }
+
     if subagents_flip {
         if let Err(e) = crate::agent_subagents::sync_subagents_to_agent_profile(
             &settings.session_data_mode,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -634,6 +634,7 @@ pub async fn settings_set(
         prev.store_api_keys_in_keychain != settings.store_api_keys_in_keychain;
     let session_data_mode_changed =
         prev.session_data_mode != settings.session_data_mode;
+    let subagents_flip = prev.subagents_enabled != settings.subagents_enabled;
 
     store::save_settings(&settings)?;
 
@@ -653,6 +654,15 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    if subagents_flip {
+        if let Err(e) = crate::agent_subagents::sync_subagents_to_agent_profile(
+            &settings.session_data_mode,
+            settings.subagents_enabled,
+        ) {
+            tracing::warn!("settings_set sync subagents profile: {e}");
+        }
+        // Spawn flags change — soft-respawn so the next turn uses the new policy.
+        mgr.soft_respawn(&app).await;
     }
 
     // Full permission apply: Host + agent-home + soft-respawn if needed

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod account_profiles;
 mod acp_client;
 mod agent_prefs;
 mod app_update;
+mod agent_subagents;
 mod extensions;
 mod supergrok_quota;
 mod cli_probe;

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -168,6 +168,11 @@ pub struct AppSettings {
     /// Passed as top-level `grok --sandbox <profile>` / `GROK_SANDBOX` at spawn.
     #[serde(default = "default_sandbox_profile")]
     pub sandbox_profile: String,
+    /// Allow Grok Build subagent spawning (`Agent` / task tools). Default **true**
+    /// (CLI default). When false, spawn forces `--no-subagents` + `GROK_SUBAGENTS=0`
+    /// and independent mode writes `[subagents] enabled = false`.
+    #[serde(default = "default_true")]
+    pub subagents_enabled: bool,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -217,6 +222,7 @@ impl Default for AppSettings {
             stream_stall_seconds: default_stream_stall_seconds(),
             store_api_keys_in_keychain: false,
             sandbox_profile: default_sandbox_profile(),
+            subagents_enabled: true,
         }
     }
 }
@@ -1305,6 +1311,15 @@ mod tests {
         let raw = r#"{
             "theme": "dark",
             "locale": "en",
+        assert!(s.subagents_enabled);
+    }
+
+    #[test]
+    fn subagents_enabled_defaults_true_when_missing_from_json() {
+        // Older settings files omit the field — serde default keeps subagents on.
+        let raw = r#"{
+            "theme": "dark",
+            "locale": "zh",
             "sessionDataMode": "independent",
             "manualCliPath": null,
             "permissionPolicy": "ask",
@@ -1361,5 +1376,6 @@ mod tests {
         let m: SessionMeta = serde_json::from_str(raw).expect("deserialize legacy session");
         assert!(!m.pinned);
         assert!(!m.archived);
+        assert!(s.subagents_enabled);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6231,6 +6231,7 @@ export default function App() {
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
             );
+          }}
           subagentsEnabled={subagentsEnabled}
           onSubagentsEnabled={(v) => {
             const prev = subagentsEnabled;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -692,6 +692,7 @@ export default function App() {
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
   const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
   const [sandboxProfile, setSandboxProfile] = useState("off");
+  const [subagentsEnabled, setSubagentsEnabled] = useState(true);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -922,6 +923,8 @@ export default function App() {
         const known = ["off", "workspace", "read-only", "strict", "devbox"];
         setSandboxProfile(known.includes(sb) ? sb : "off");
       }
+      // Default true when field is missing from older settings files.
+      setSubagentsEnabled(settings.subagentsEnabled !== false);
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -5893,6 +5896,8 @@ export default function App() {
       "settings.cliNotFound",
       "settings.permissionDeep",
       "settings.permissionDeepDesc",
+      "settings.subagentsEnabled",
+      "settings.subagentsEnabledDesc",
       "settings.prefsScope",
       "settings.prefsScopeDesc",
       "settings.prefsScope.global",
@@ -6226,6 +6231,17 @@ export default function App() {
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
             );
+          subagentsEnabled={subagentsEnabled}
+          onSubagentsEnabled={(v) => {
+            const prev = subagentsEnabled;
+            setSubagentsEnabled(v);
+            void api
+              .settingsGet()
+              .then((s) => api.settingsSet({ ...s, subagentsEnabled: v }))
+              .catch((e) => {
+                setSubagentsEnabled(prev);
+                showToast(String(e), 4500);
+              });
           }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -891,6 +891,9 @@ export function SettingsPage({
                         label: t("settings.sandbox.devbox"),
                       },
                     ]}
+                  />
+                </div>
+              ) : null}
               {onSubagentsEnabled ? (
                 <div className="settings-row">
                   <div className="settings-row__text">

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -115,6 +115,9 @@ export interface SettingsPageProps {
   /** OS sandbox for agent spawn: off | workspace | read-only | strict | devbox. */
   sandboxProfile?: string;
   onSandboxProfile?: (v: string) => void;
+  /** Allow Grok Build subagent spawning (default on). */
+  subagentsEnabled?: boolean;
+  onSubagentsEnabled?: (v: boolean) => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -418,6 +421,8 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  subagentsEnabled = true,
+  onSubagentsEnabled,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -886,6 +891,20 @@ export function SettingsPage({
                         label: t("settings.sandbox.devbox"),
                       },
                     ]}
+              {onSubagentsEnabled ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.subagentsEnabled")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.subagentsEnabledDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={subagentsEnabled}
+                    onChange={() => onSubagentsEnabled(!subagentsEnabled)}
+                    ariaLabel={t("settings.subagentsEnabled")}
                   />
                 </div>
               ) : null}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -586,6 +586,9 @@ const en = {
   "settings.sandbox.readOnly": "Read-only — no project writes",
   "settings.sandbox.strict": "Strict — CWD only, block child network",
   "settings.sandbox.devbox": "Devbox — disposable VM layout",
+  "settings.subagentsEnabled": "Allow subagent spawning",
+  "settings.subagentsEnabledDesc":
+    "On by default. When off, agents spawn with --no-subagents / GROK_SUBAGENTS=0 so child Agent/task sessions cannot start. Live agents soft-respawn when this changes.",
   "settings.prefsScope": "Remember model & permission at",
   "settings.prefsScopeDesc":
     "Global: all chats. Project: each workspace. Session: only the current chat.",
@@ -1798,6 +1801,9 @@ const zh: Record<MessageKey, string> = {
   "settings.sandbox.readOnly": "只读 — 不可写项目文件",
   "settings.sandbox.strict": "严格 — 仅限 CWD，阻止子进程网络",
   "settings.sandbox.devbox": "Devbox — 一次性开发机布局",
+  "settings.subagentsEnabled": "允许子 Agent 派生",
+  "settings.subagentsEnabledDesc":
+    "默认开启。关闭时启动 Agent 会加上 --no-subagents / GROK_SUBAGENTS=0，禁止子会话（Agent/task）。更改后会 soft-respawn 已连接的 Agent。",
   "settings.prefsScope": "模型与权限记忆范围",
   "settings.prefsScopeDesc":
     "全局：所有对话共用。项目：按工作区记忆。会话：仅当前聊天。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -559,6 +559,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.sandbox.readOnly": "唯讀 — 不可寫專案檔案",
   "settings.sandbox.strict": "嚴格 — 僅限 CWD，封鎖子行程網路",
   "settings.sandbox.devbox": "Devbox — 一次性開發機配置",
+  "settings.subagentsEnabled": "允許子 Agent 衍生",
+  "settings.subagentsEnabledDesc":
+    "預設開啟。關閉時啟動 Agent 會加上 --no-subagents / GROK_SUBAGENTS=0，禁止子工作階段（Agent/task）。變更後會 soft-respawn 已連線的 Agent。",
   "settings.prefsScope": "模型與權限記憶範圍",
   "settings.prefsScopeDesc":
     "全域：所有對話共用。專案：依工作區記憶。對話：僅目前聊天。",

--- a/src/lib/agentSubagents.test.ts
+++ b/src/lib/agentSubagents.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveSubagentsEnabled,
+  shouldForceDisableSubagents,
+  subagentsConfigEnabled,
+  subagentsSpawnEnv,
+  subagentsSpawnFlags,
+} from "./agentSubagents";
+
+describe("subagentsSpawnFlags", () => {
+  it("adds no flags when subagents are enabled (CLI default)", () => {
+    expect(subagentsSpawnFlags(true)).toEqual([]);
+  });
+
+  it("disables with --no-subagents", () => {
+    expect(subagentsSpawnFlags(false)).toEqual(["--no-subagents"]);
+  });
+});
+
+describe("subagentsSpawnEnv", () => {
+  it("sets no env when enabled", () => {
+    expect(subagentsSpawnEnv(true)).toEqual({});
+  });
+
+  it("sets GROK_SUBAGENTS=0 when disabled", () => {
+    expect(subagentsSpawnEnv(false)).toEqual({ GROK_SUBAGENTS: "0" });
+  });
+});
+
+describe("shouldForceDisableSubagents", () => {
+  it("forces disable only when the setting is off", () => {
+    expect(shouldForceDisableSubagents(false)).toBe(true);
+    expect(shouldForceDisableSubagents(true)).toBe(false);
+  });
+});
+
+describe("subagentsConfigEnabled", () => {
+  it("mirrors the settings boolean for [subagents] enabled", () => {
+    expect(subagentsConfigEnabled(true)).toBe(true);
+    expect(subagentsConfigEnabled(false)).toBe(false);
+  });
+});
+
+describe("resolveSubagentsEnabled", () => {
+  it("prefers settings boolean over env", () => {
+    expect(
+      resolveSubagentsEnabled({ settingsEnabled: true, envValue: "0" }),
+    ).toBe(true);
+    expect(
+      resolveSubagentsEnabled({ settingsEnabled: false, envValue: "1" }),
+    ).toBe(false);
+  });
+
+  it("defaults to true when settings and env are unset", () => {
+    expect(resolveSubagentsEnabled({})).toBe(true);
+    expect(resolveSubagentsEnabled({ envValue: "  " })).toBe(true);
+  });
+
+  it("parses common env truthy/falsey forms when settings unset", () => {
+    expect(resolveSubagentsEnabled({ envValue: "1" })).toBe(true);
+    expect(resolveSubagentsEnabled({ envValue: "true" })).toBe(true);
+    expect(resolveSubagentsEnabled({ envValue: "YES" })).toBe(true);
+    expect(resolveSubagentsEnabled({ envValue: "0" })).toBe(false);
+    expect(resolveSubagentsEnabled({ envValue: "false" })).toBe(false);
+    expect(resolveSubagentsEnabled({ envValue: "off" })).toBe(false);
+    expect(resolveSubagentsEnabled({ envValue: "maybe" })).toBe(true);
+  });
+});

--- a/src/lib/agentSubagents.ts
+++ b/src/lib/agentSubagents.ts
@@ -1,0 +1,59 @@
+/**
+ * Subagent spawning — pure flag / env helpers for Grok Build agents.
+ *
+ * CLI surface (enabled by default):
+ *   - `--no-subagents` (top-level `grok` flag, before `agent`)
+ *   - `GROK_SUBAGENTS=0|1`
+ *   - config.toml `[subagents] enabled = true|false`
+ *
+ * When disabled, App always forces `--no-subagents` + `GROK_SUBAGENTS=0` so a
+ * user `~/.grok` config (shared mode) or leftover agent-home config cannot
+ * re-enable subagents. When enabled, spawn leaves CLI defaults alone (on).
+ */
+
+/** Top-level CLI flags placed before `agent` (e.g. `grok --no-auto-update …`). */
+export function subagentsSpawnFlags(enabled: boolean): string[] {
+  return enabled ? [] : ["--no-subagents"];
+}
+
+/** Env overrides applied to the agent process when disabling. */
+export function subagentsSpawnEnv(
+  enabled: boolean,
+): Record<"GROK_SUBAGENTS", string> | Record<string, never> {
+  return enabled ? {} : { GROK_SUBAGENTS: "0" };
+}
+
+/**
+ * Whether spawn must force-disable subagents.
+ * Always true when the setting is off (independent or shared).
+ */
+export function shouldForceDisableSubagents(subagentsEnabled: boolean): boolean {
+  return !subagentsEnabled;
+}
+
+/** `[subagents] enabled` value written into agent config.toml (independent mode). */
+export function subagentsConfigEnabled(subagentsEnabled: boolean): boolean {
+  return subagentsEnabled;
+}
+
+/**
+ * Resolve whether subagents are on from settings + optional env override
+ * (App settings win over process env for spawn decisions). Default true.
+ */
+export function resolveSubagentsEnabled(input: {
+  settingsEnabled?: boolean | null;
+  envValue?: string | null;
+}): boolean {
+  if (typeof input.settingsEnabled === "boolean") {
+    return input.settingsEnabled;
+  }
+  const raw = (input.envValue ?? "").trim().toLowerCase();
+  if (!raw) return true;
+  if (raw === "0" || raw === "false" || raw === "no" || raw === "off") {
+    return false;
+  }
+  if (raw === "1" || raw === "true" || raw === "yes" || raw === "on") {
+    return true;
+  }
+  return true;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,7 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+  /**
    * Allow Grok Build subagent spawning (default true).
    * When false: force --no-subagents / GROK_SUBAGENTS=0 / [subagents] enabled = false.
    */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,10 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+   * Allow Grok Build subagent spawning (default true).
+   * When false: force --no-subagents / GROK_SUBAGENTS=0 / [subagents] enabled = false.
+   */
+  subagentsEnabled?: boolean;
 }
 
 export interface AvailableModel {


### PR DESCRIPTION
## Summary

- **Settings `subagentsEnabled`** (default **true**): controls whether Grok Build agents can spawn subagents (`Agent` / task tools).
- **Spawn policy**: when off → top-level `--no-subagents` + `GROK_SUBAGENTS=0` (+ independent `[subagents] enabled = false`); when on → leave CLI defaults (subagents enabled). Soft-respawns live agent on toggle.
- **Settings → Permissions UI**: toggle + short description (en / zh / zh-TW).
- **Tests**: pure flag/env helpers in `src/lib/agentSubagents.ts` (vitest) + Rust unit tests in `agent_subagents.rs` + serde default for older settings files.

## CLI surface

| Mechanism | Behavior |
|-----------|----------|
| `--no-subagents` | Top-level `grok` flag before `agent stdio` (when disabled) |
| `GROK_SUBAGENTS=0` | Env on agent process (when disabled) |
| `[subagents] enabled` | Written to independent agent-home `config.toml` only |

## Test plan

- [x] `pnpm test -- src/lib/agentSubagents.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [x] `cargo test --lib agent_subagents`
- [x] `cargo test --lib subagents_enabled`
- [x] `cargo test --lib default_settings_independent_mode`
- [ ] Manual: Settings → Permissions → turn off → spawn log shows `subagents_enabled=false` and agent cannot spawn children
- [ ] Manual: turn on → soft-respawn → subagents available again