### PR TITLE
feat: choose agent definition when starting a session

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -193,6 +193,31 @@ impl SandboxSpawnSpec {
 pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
     let spec = SandboxSpawnSpec::from_setting(profile)?;
     Some((spec.cli_args().to_vec(), spec.env_pair()))
+/// Pure spawn plan for top-level `--agent <NAME>`.
+///
+/// `--agent` is a **top-level** `grok` flag (not under `agent` / `stdio`).
+/// Empty / `default` / `none` omit the flag so the CLI keeps its built-in default.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentSpawnSpec {
+    pub name: String,
+}
+
+impl AgentSpawnSpec {
+    /// Build from settings. `None` means do not pass `--agent`.
+    pub fn from_setting(raw: &str) -> Option<Self> {
+        let name = crate::agents_catalog::normalize_preferred_agent(raw)?;
+        Some(Self { name })
+    }
+
+    /// Top-level CLI args: `["--agent", "<name>"]` (before `agent`).
+    pub fn cli_args(&self) -> [String; 2] {
+        ["--agent".into(), self.name.clone()]
+    }
+}
+
+/// Pure helper used by spawn + unit tests.
+pub fn preferred_agent_spawn_flags(raw: &str) -> Option<Vec<String>> {
+    crate::agents_catalog::agent_spawn_cli_args(raw)
 }
 
 impl AcpClient {
@@ -286,6 +311,17 @@ impl AcpClient {
         cmd.arg("--no-auto-update");
         if let Some(ref sb) = sandbox {
             for a in sb.cli_args() {
+        //   top-level: `grok --no-auto-update [--agent NAME] agent …`
+        //   agent opts: `--model` / `--reasoning-effort` / `--always-approve` before `stdio`
+        // Skip background update checks so ACP handshakes are not delayed on launch.
+        // `--agent` is top-level only (agent definition name or path).
+        let settings_for_spawn = crate::store::load_settings();
+        let preferred_agent = AgentSpawnSpec::from_setting(&settings_for_spawn.preferred_agent);
+
+        let mut cmd = Command::new(&cli_path);
+        cmd.arg("--no-auto-update");
+        if let Some(ref agent) = preferred_agent {
+            for a in agent.cli_args() {
                 cmd.arg(a);
             }
         }
@@ -322,6 +358,7 @@ impl AcpClient {
         }
         tracing::info!(
             "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} sandbox={:?}",
+            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} preferred_agent={:?}",
             grok_home.display(),
             session_data_mode,
             grok_home.join("auth.json").is_file(),
@@ -333,6 +370,7 @@ impl AcpClient {
                 .map(cli_permission_mode)
                 == Some("bypassPermissions"),
             sandbox.as_ref().map(|s| s.profile.as_str())
+            preferred_agent.as_ref().map(|a| a.name.as_str())
         );
 
         let mut child = cmd.spawn().map_err(|e| {
@@ -2260,5 +2298,45 @@ mod live_handshake_tests {
         eprintln!("OK session={} in {:?}", sid, t0.elapsed());
         client.kill().await;
         assert!(!sid.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod preferred_agent_spawn_tests {
+    use super::*;
+
+    #[test]
+    fn empty_and_sentinels_yield_no_flags() {
+        assert!(AgentSpawnSpec::from_setting("").is_none());
+        assert!(AgentSpawnSpec::from_setting("default").is_none());
+        assert!(AgentSpawnSpec::from_setting("NONE").is_none());
+        assert!(preferred_agent_spawn_flags("").is_none());
+        assert!(preferred_agent_spawn_flags("grok-build").is_none());
+    }
+
+    #[test]
+    fn known_agents_build_top_level_args() {
+        for name in ["explore", "plan", "general-purpose", "my-custom"] {
+            let spec = AgentSpawnSpec::from_setting(name).expect(name);
+            assert_eq!(spec.name, name);
+            assert_eq!(
+                spec.cli_args(),
+                ["--agent".to_string(), name.to_string()]
+            );
+            assert_eq!(
+                preferred_agent_spawn_flags(name),
+                Some(vec!["--agent".to_string(), name.to_string()])
+            );
+        }
+    }
+
+    #[test]
+    fn trims_preferred_agent() {
+        let spec = AgentSpawnSpec::from_setting("  explore  ").unwrap();
+        assert_eq!(spec.name, "explore");
+        assert_eq!(
+            spec.cli_args(),
+            ["--agent".to_string(), "explore".to_string()]
+        );
     }
 }

--- a/src-tauri/src/agents_catalog.rs
+++ b/src-tauri/src/agents_catalog.rs
@@ -1,0 +1,324 @@
+//! Discover selectable Grok Build agent definition names for Settings.
+//!
+//! Sources mirror CLI `--agent <NAME>` resolution:
+//! - Built-ins: explore, plan, general-purpose
+//! - User: `~/.grok/agents/*.md`
+//! - Project: `<cwd>/.grok/agents/*.md`
+//! - Bundled reference: `~/.grok/bundled/agents/*.md` (same names as built-ins)
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// Well-known built-in agent names (always listed even if files are missing).
+pub const BUILTIN_AGENT_NAMES: &[&str] = &["explore", "general-purpose", "plan"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AgentCatalogSource {
+    Builtin,
+    User,
+    Project,
+    Bundled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCatalogEntry {
+    pub name: String,
+    pub source: AgentCatalogSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentsCatalogResult {
+    pub agents: Vec<AgentCatalogEntry>,
+    pub user_dir: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_dir: Option<String>,
+    pub bundled_dir: String,
+}
+
+/// Pure: normalize settings value → spawn name, or `None` for CLI default.
+pub fn normalize_preferred_agent(raw: &str) -> Option<String> {
+    let name = raw.trim();
+    if name.is_empty() {
+        return None;
+    }
+    let lower = name.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "default" | "none" | "cli-default" | "grok-build"
+    ) {
+        return None;
+    }
+    if name.chars().any(|c| c == '\0' || c == '\n' || c == '\r') {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+/// Pure: top-level CLI args `["--agent", name]` when set.
+pub fn agent_spawn_cli_args(raw: &str) -> Option<Vec<String>> {
+    let name = normalize_preferred_agent(raw)?;
+    Some(vec!["--agent".into(), name])
+}
+
+/// File stem for agent def (`explore.md` → `explore`).
+pub fn agent_name_from_file_name(file_name: &str) -> Option<String> {
+    let base = Path::new(file_name)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(file_name)
+        .trim();
+    if base.is_empty() || base.starts_with('.') {
+        return None;
+    }
+    let lower = base.to_ascii_lowercase();
+    let stem = if let Some(s) = lower.strip_suffix(".markdown") {
+        &base[..s.len()]
+    } else if let Some(s) = lower.strip_suffix(".md") {
+        &base[..s.len()]
+    } else {
+        return None;
+    };
+    let stem = stem.trim();
+    if stem.is_empty() || stem.eq_ignore_ascii_case("readme") {
+        return None;
+    }
+    Some(stem.to_string())
+}
+
+fn is_agent_md(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .and_then(agent_name_from_file_name)
+        .is_some()
+}
+
+fn scan_agent_dir(dir: &Path) -> Vec<(String, PathBuf)> {
+    let mut out = Vec::new();
+    let rd = match fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(_) => return out,
+    };
+    for ent in rd.flatten() {
+        let path = ent.path();
+        if !path.is_file() {
+            continue;
+        }
+        if !is_agent_md(&path) {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .and_then(agent_name_from_file_name);
+        if let Some(name) = name {
+            out.push((name, path));
+        }
+    }
+    out.sort_by(|a, b| a.0.to_ascii_lowercase().cmp(&b.0.to_ascii_lowercase()));
+    out
+}
+
+/// Pure merge: project > user > bundled file > builtin name-only.
+pub fn merge_agent_catalog(
+    builtins: &[&str],
+    user: &[(String, PathBuf)],
+    project: &[(String, PathBuf)],
+    bundled: &[(String, PathBuf)],
+) -> Vec<AgentCatalogEntry> {
+    use std::collections::BTreeMap;
+    // BTreeMap keyed by lowercase name for stable sort of keys; we re-sort at end by display name.
+    let mut map: BTreeMap<String, AgentCatalogEntry> = BTreeMap::new();
+
+    for name in builtins {
+        let n = name.trim();
+        if n.is_empty() {
+            continue;
+        }
+        map.insert(
+            n.to_ascii_lowercase(),
+            AgentCatalogEntry {
+                name: n.to_string(),
+                source: AgentCatalogSource::Builtin,
+                path: None,
+            },
+        );
+    }
+
+    for (name, path) in bundled {
+        map.insert(
+            name.to_ascii_lowercase(),
+            AgentCatalogEntry {
+                name: name.clone(),
+                source: AgentCatalogSource::Bundled,
+                path: Some(path.display().to_string()),
+            },
+        );
+    }
+
+    for (name, path) in user {
+        map.insert(
+            name.to_ascii_lowercase(),
+            AgentCatalogEntry {
+                name: name.clone(),
+                source: AgentCatalogSource::User,
+                path: Some(path.display().to_string()),
+            },
+        );
+    }
+
+    for (name, path) in project {
+        map.insert(
+            name.to_ascii_lowercase(),
+            AgentCatalogEntry {
+                name: name.clone(),
+                source: AgentCatalogSource::Project,
+                path: Some(path.display().to_string()),
+            },
+        );
+    }
+
+    let mut agents: Vec<_> = map.into_values().collect();
+    agents.sort_by(|a, b| {
+        a.name
+            .to_ascii_lowercase()
+            .cmp(&b.name.to_ascii_lowercase())
+    });
+    agents
+}
+
+fn user_grok_home() -> PathBuf {
+    crate::process_util::user_home().join(".grok")
+}
+
+/// Live catalog for Settings agent picker.
+pub fn list_agents_catalog(project_path: Option<&str>) -> AgentsCatalogResult {
+    let grok = user_grok_home();
+    let user_dir = grok.join("agents");
+    let bundled_dir = grok.join("bundled").join("agents");
+    let project_dir = project_path
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|p| PathBuf::from(p).join(".grok").join("agents"));
+
+    let user = scan_agent_dir(&user_dir);
+    let bundled = scan_agent_dir(&bundled_dir);
+    let project = project_dir
+        .as_ref()
+        .map(|d| scan_agent_dir(d))
+        .unwrap_or_default();
+
+    let agents = merge_agent_catalog(BUILTIN_AGENT_NAMES, &user, &project, &bundled);
+
+    AgentsCatalogResult {
+        agents,
+        user_dir: user_dir.display().to_string(),
+        project_dir: project_dir.map(|p| p.display().to_string()),
+        bundled_dir: bundled_dir.display().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn normalize_empty_and_sentinels() {
+        assert!(normalize_preferred_agent("").is_none());
+        assert!(normalize_preferred_agent("  ").is_none());
+        assert!(normalize_preferred_agent("default").is_none());
+        assert!(normalize_preferred_agent("NONE").is_none());
+        assert!(normalize_preferred_agent("grok-build").is_none());
+        assert!(normalize_preferred_agent("cli-default").is_none());
+        assert!(normalize_preferred_agent("ex\nplore").is_none());
+    }
+
+    #[test]
+    fn normalize_keeps_names() {
+        assert_eq!(
+            normalize_preferred_agent("  explore  ").as_deref(),
+            Some("explore")
+        );
+        assert_eq!(
+            normalize_preferred_agent("general-purpose").as_deref(),
+            Some("general-purpose")
+        );
+        assert_eq!(
+            normalize_preferred_agent("/tmp/a.md").as_deref(),
+            Some("/tmp/a.md")
+        );
+    }
+
+    #[test]
+    fn spawn_args_top_level() {
+        assert!(agent_spawn_cli_args("").is_none());
+        assert!(agent_spawn_cli_args("default").is_none());
+        assert_eq!(
+            agent_spawn_cli_args("explore"),
+            Some(vec!["--agent".into(), "explore".into()])
+        );
+        assert_eq!(
+            agent_spawn_cli_args("  plan  "),
+            Some(vec!["--agent".into(), "plan".into()])
+        );
+    }
+
+    #[test]
+    fn file_name_stems() {
+        assert_eq!(
+            agent_name_from_file_name("explore.md").as_deref(),
+            Some("explore")
+        );
+        assert_eq!(
+            agent_name_from_file_name("my.markdown").as_deref(),
+            Some("my")
+        );
+        assert!(agent_name_from_file_name("x.txt").is_none());
+        assert!(agent_name_from_file_name(".hidden.md").is_none());
+        assert!(agent_name_from_file_name("README.md").is_none());
+        assert_eq!(
+            agent_name_from_file_name("/a/b/plan.md").as_deref(),
+            Some("plan")
+        );
+    }
+
+    #[test]
+    fn merge_priority_project_user_bundled_builtin() {
+        let user = vec![(
+            "explore".into(),
+            PathBuf::from("/u/.grok/agents/explore.md"),
+        )];
+        let project = vec![(
+            "explore".into(),
+            PathBuf::from("/p/.grok/agents/explore.md"),
+        )];
+        let bundled = vec![(
+            "plan".into(),
+            PathBuf::from("/u/.grok/bundled/agents/plan.md"),
+        )];
+        let custom = vec![(
+            "custom".into(),
+            PathBuf::from("/u/.grok/agents/custom.md"),
+        )];
+        let user_all = [user, custom].concat();
+        let agents = merge_agent_catalog(BUILTIN_AGENT_NAMES, &user_all, &project, &bundled);
+        let by: std::collections::HashMap<_, _> =
+            agents.into_iter().map(|e| (e.name.clone(), e)).collect();
+        assert_eq!(by["explore"].source, AgentCatalogSource::Project);
+        assert_eq!(
+            by["explore"].path.as_deref(),
+            Some("/p/.grok/agents/explore.md")
+        );
+        assert_eq!(by["custom"].source, AgentCatalogSource::User);
+        assert_eq!(by["plan"].source, AgentCatalogSource::Bundled);
+        assert_eq!(by["general-purpose"].source, AgentCatalogSource::Builtin);
+        assert!(by["general-purpose"].path.is_none());
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -634,6 +634,7 @@ pub async fn settings_set(
         prev.store_api_keys_in_keychain != settings.store_api_keys_in_keychain;
     let session_data_mode_changed =
         prev.session_data_mode != settings.session_data_mode;
+    let preferred_agent_flip = prev.preferred_agent.trim() != settings.preferred_agent.trim();
 
     store::save_settings(&settings)?;
 
@@ -653,6 +654,9 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    if preferred_agent_flip {
+        // `--agent` is spawn-only — soft-respawn so the next turn uses the new definition.
+        mgr.soft_respawn(&app).await;
     }
 
     // Full permission apply: Host + agent-home + soft-respawn if needed
@@ -672,6 +676,16 @@ pub async fn settings_set(
 #[tauri::command]
 pub async fn models_list_available() -> Result<crate::models_catalog::AvailableModelsResult, String> {
     Ok(crate::models_catalog::list_available_models())
+}
+
+/// Selectable agent definitions for Settings → Runtime (built-ins + user/project `.md`).
+#[tauri::command]
+pub async fn agents_catalog(
+    project_path: Option<String>,
+) -> Result<crate::agents_catalog::AgentsCatalogResult, String> {
+    Ok(crate::agents_catalog::list_agents_catalog(
+        project_path.as_deref(),
+    ))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 mod account;
 mod account_profiles;
 mod acp_client;
+mod agents_catalog;
 mod agent_prefs;
 mod app_update;
 mod extensions;
@@ -172,6 +173,7 @@ pub fn run() {
             commands::settings_get,
             commands::settings_set,
             commands::models_list_available,
+            commands::agents_catalog,
             commands::composer_prefs_resolve,
             commands::composer_prefs_set,
             commands::session_set_policy,

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -168,6 +168,12 @@ pub struct AppSettings {
     /// Passed as top-level `grok --sandbox <profile>` / `GROK_SANDBOX` at spawn.
     #[serde(default = "default_sandbox_profile")]
     pub sandbox_profile: String,
+    /// Preferred Grok Build agent definition for new agent processes
+    /// (`explore` / `plan` / `general-purpose` / custom name under `~/.grok/agents`).
+    /// Empty / `default` / `none` → omit top-level `--agent` (CLI default).
+    /// Applied at spawn only; changing it soft-respawns the live agent.
+    #[serde(default)]
+    pub preferred_agent: String,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -217,6 +223,7 @@ impl Default for AppSettings {
             stream_stall_seconds: default_stream_stall_seconds(),
             store_api_keys_in_keychain: false,
             sandbox_profile: default_sandbox_profile(),
+            preferred_agent: String::new(),
         }
     }
 }
@@ -1302,6 +1309,11 @@ mod tests {
     #[test]
     fn sandbox_profile_defaults_when_missing_from_json() {
         // Old settings files without the field must deserialize to "off".
+        assert_eq!(s.preferred_agent, "");
+    }
+
+    #[test]
+    fn preferred_agent_defaults_when_missing_from_json() {
         let raw = r#"{
             "theme": "dark",
             "locale": "en",
@@ -1361,5 +1373,6 @@ mod tests {
         let m: SessionMeta = serde_json::from_str(raw).expect("deserialize legacy session");
         assert!(!m.pinned);
         assert!(!m.archived);
+        assert_eq!(s.preferred_agent, "");
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -692,6 +692,11 @@ export default function App() {
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
   const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
   const [sandboxProfile, setSandboxProfile] = useState("off");
+  /** Preferred CLI agent definition for spawn (`""` = CLI default). */
+  const [preferredAgent, setPreferredAgent] = useState("");
+  const [agentCatalog, setAgentCatalog] = useState<
+    Array<{ name: string; source: string }>
+  >([]);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -922,6 +927,25 @@ export default function App() {
         const known = ["off", "workspace", "read-only", "strict", "devbox"];
         setSandboxProfile(known.includes(sb) ? sb : "off");
       }
+      setPreferredAgent((settings.preferredAgent || "").trim());
+      void api
+        .agentsCatalog(null)
+        .then((cat) => {
+          setAgentCatalog(
+            (cat.agents ?? []).map((a) => ({
+              name: a.name,
+              source: a.source,
+            })),
+          );
+        })
+        .catch(() => {
+          setAgentCatalog(
+            ["explore", "general-purpose", "plan"].map((name) => ({
+              name,
+              source: "builtin",
+            })),
+          );
+        });
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -3896,6 +3920,29 @@ export default function App() {
   /** Bumped when Extensions skill toggles change so slash palette refilters. */
   const [skillsReloadToken, setSkillsReloadToken] = useState(0);
 
+  // Refresh agent definition catalog when the active project changes.
+  useEffect(() => {
+    if (!api.isTauri()) return;
+    let cancelled = false;
+    void api
+      .agentsCatalog(activeProject?.path ?? null)
+      .then((cat) => {
+        if (cancelled) return;
+        setAgentCatalog(
+          (cat.agents ?? []).map((a) => ({
+            name: a.name,
+            source: a.source,
+          })),
+        );
+      })
+      .catch(() => {
+        /* keep previous catalog */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeProject?.path]);
+
   // Load skills catalog for slash palette (Grok inspect).
   useEffect(() => {
     if (!api.isTauri()) return;
@@ -5893,6 +5940,13 @@ export default function App() {
       "settings.cliNotFound",
       "settings.permissionDeep",
       "settings.permissionDeepDesc",
+      "settings.preferredAgent",
+      "settings.preferredAgentDesc",
+      "settings.preferredAgent.default",
+      "settings.preferredAgent.source.builtin",
+      "settings.preferredAgent.source.bundled",
+      "settings.preferredAgent.source.user",
+      "settings.preferredAgent.source.project",
       "settings.prefsScope",
       "settings.prefsScopeDesc",
       "settings.prefsScope.global",
@@ -6227,6 +6281,14 @@ export default function App() {
               api.settingsSet({ ...s, sandboxProfile: v }),
             );
           }}
+          preferredAgent={preferredAgent}
+          onPreferredAgent={(v) => {
+            setPreferredAgent(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, preferredAgent: v }),
+            );
+          }}
+          agentCatalog={agentCatalog}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
           versionFooter={tr("app.versionFooter")}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -115,6 +115,14 @@ export interface SettingsPageProps {
   /** OS sandbox for agent spawn: off | workspace | read-only | strict | devbox. */
   sandboxProfile?: string;
   onSandboxProfile?: (v: string) => void;
+  /**
+   * Preferred agent definition for ACP spawn (`""` = CLI default).
+   * Spawn-only: reconnect / new session applies; no mid-turn hot-swap.
+   */
+  preferredAgent?: string;
+  onPreferredAgent?: (v: string) => void;
+  /** Catalog rows for the agent picker (built-ins + discovered defs). */
+  agentCatalog?: Array<{ name: string; source: string }>;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -418,6 +426,9 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  preferredAgent = "",
+  onPreferredAgent,
+  agentCatalog = [],
   cliInfo,
   onDoctor,
   versionFooter,
@@ -1457,6 +1468,55 @@ export function SettingsPage({
                 }}
               />
             </div>
+            {onPreferredAgent ? (
+              <div className="settings-row settings-row--stack">
+                <div className="settings-row__text">
+                  <div className="settings-row__label">
+                    {t("settings.preferredAgent")}
+                  </div>
+                  <div className="settings-row__desc">
+                    {t("settings.preferredAgentDesc")}
+                  </div>
+                </div>
+                <Select
+                  value={preferredAgent || ""}
+                  onChange={(v) => onPreferredAgent(v)}
+                  options={[
+                    {
+                      value: "",
+                      label: t("settings.preferredAgent.default"),
+                    },
+                    ...(() => {
+                      const seen = new Set<string>();
+                      const opts: { value: string; label: string }[] = [];
+                      for (const a of agentCatalog) {
+                        const name = (a.name || "").trim();
+                        if (!name || seen.has(name)) continue;
+                        seen.add(name);
+                        const srcKey =
+                          a.source === "project"
+                            ? "settings.preferredAgent.source.project"
+                            : a.source === "user"
+                              ? "settings.preferredAgent.source.user"
+                              : a.source === "bundled"
+                                ? "settings.preferredAgent.source.bundled"
+                                : "settings.preferredAgent.source.builtin";
+                        opts.push({
+                          value: name,
+                          label: `${name} · ${t(srcKey)}`,
+                        });
+                      }
+                      // Keep current value visible even if not in catalog yet.
+                      const cur = (preferredAgent || "").trim();
+                      if (cur && !seen.has(cur)) {
+                        opts.unshift({ value: cur, label: cur });
+                      }
+                      return opts;
+                    })(),
+                  ]}
+                />
+              </div>
+            ) : null}
             <div className="settings-row">
               <div className="settings-row__text">
                 <div className="settings-row__label">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -565,6 +565,14 @@ const en = {
   "settings.streamStallSeconds": "Stream stall timeout (seconds)",
   "settings.streamStallSecondsDesc":
     "If a turn has no stream chunks or tool activity for this long, show a Cancel / Keep waiting prompt (default 120). Long-running tools that still emit events do not count as stalled.",
+  "settings.preferredAgent": "Agent definition",
+  "settings.preferredAgentDesc":
+    "Passed as top-level grok --agent <name> when starting the agent process (built-ins: explore, plan, general-purpose; plus ~/.grok/agents and project .grok/agents). Applies on reconnect or new session — not mid-turn.",
+  "settings.preferredAgent.default": "Default (CLI)",
+  "settings.preferredAgent.source.builtin": "built-in",
+  "settings.preferredAgent.source.bundled": "bundled",
+  "settings.preferredAgent.source.user": "user",
+  "settings.preferredAgent.source.project": "project",
   "agent.idleRecycledToast":
     "Agent process recycled after idle — session kept; next message will reconnect.",
   "agent.dataModeRecycledToast":
@@ -1777,6 +1785,14 @@ const zh: Record<MessageKey, string> = {
   "settings.streamStallSeconds": "流式卡顿超时（秒）",
   "settings.streamStallSecondsDesc":
     "若一轮对话在该时间内无任何流式片段或工具活动，将提示「取消本轮 / 继续等待」（默认 120）。仍有工具事件的长任务不会误判为卡顿。",
+  "settings.preferredAgent": "Agent 定义",
+  "settings.preferredAgentDesc":
+    "启动 Agent 进程时作为顶层 grok --agent <name> 传入（内置 explore / plan / general-purpose，以及 ~/.grok/agents 与项目 .grok/agents）。在重连或新会话时生效，不会在一轮对话中途热切换。",
+  "settings.preferredAgent.default": "默认（CLI）",
+  "settings.preferredAgent.source.builtin": "内置",
+  "settings.preferredAgent.source.bundled": "捆绑",
+  "settings.preferredAgent.source.user": "用户",
+  "settings.preferredAgent.source.project": "项目",
   "agent.idleRecycledToast":
     "Agent 进程因闲置已回收 — 会话仍在；下次发送将重新连接。",
   "agent.dataModeRecycledToast":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -538,6 +538,14 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.streamStallSeconds": "串流停滯逾時（秒）",
   "settings.streamStallSecondsDesc":
     "若一輪對話在該時間內無任何串流片段或工具活動，將提示「取消本輪 / 繼續等待」（預設 120）。仍有工具事件的長任務不會誤判為停滯。",
+  "settings.preferredAgent": "Agent 定義",
+  "settings.preferredAgentDesc":
+    "啟動 Agent 行程時作為頂層 grok --agent <name> 傳入（內建 explore / plan / general-purpose，以及 ~/.grok/agents 與專案 .grok/agents）。在重連或新工作階段時生效，不會在一輪對話中途熱切換。",
+  "settings.preferredAgent.default": "預設（CLI）",
+  "settings.preferredAgent.source.builtin": "內建",
+  "settings.preferredAgent.source.bundled": "捆綁",
+  "settings.preferredAgent.source.user": "使用者",
+  "settings.preferredAgent.source.project": "專案",
   "agent.idleRecycledToast":
     "Agent 行程因閒置已回收 — 工作階段仍在；下次傳送將重新連線。",
   "agent.dataModeRecycledToast":

--- a/src/lib/agentsCatalog.test.ts
+++ b/src/lib/agentsCatalog.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentNameFromFileName,
+  agentNamesFromFileList,
+  agentSpawnCliArgs,
+  BUILTIN_AGENT_NAMES,
+  mergeAgentCatalog,
+  normalizePreferredAgent,
+  resolveAgentCatalogDirs,
+} from "./agentsCatalog";
+
+describe("normalizePreferredAgent", () => {
+  it("treats empty and sentinels as CLI default", () => {
+    expect(normalizePreferredAgent(null)).toBeNull();
+    expect(normalizePreferredAgent(undefined)).toBeNull();
+    expect(normalizePreferredAgent("")).toBeNull();
+    expect(normalizePreferredAgent("   ")).toBeNull();
+    expect(normalizePreferredAgent("default")).toBeNull();
+    expect(normalizePreferredAgent("NONE")).toBeNull();
+    expect(normalizePreferredAgent("grok-build")).toBeNull();
+    expect(normalizePreferredAgent("cli-default")).toBeNull();
+  });
+
+  it("keeps real agent names trimmed", () => {
+    expect(normalizePreferredAgent("  explore  ")).toBe("explore");
+    expect(normalizePreferredAgent("general-purpose")).toBe("general-purpose");
+    expect(normalizePreferredAgent("/path/to/agent.md")).toBe(
+      "/path/to/agent.md",
+    );
+  });
+
+  it("rejects control characters", () => {
+    expect(normalizePreferredAgent("ex\nplore")).toBeNull();
+    expect(normalizePreferredAgent("a\0b")).toBeNull();
+  });
+});
+
+describe("agentSpawnCliArgs", () => {
+  it("omits flag when unset", () => {
+    expect(agentSpawnCliArgs("")).toBeNull();
+    expect(agentSpawnCliArgs("default")).toBeNull();
+    expect(agentSpawnCliArgs(null)).toBeNull();
+  });
+
+  it("builds top-level --agent NAME", () => {
+    expect(agentSpawnCliArgs("explore")).toEqual(["--agent", "explore"]);
+    expect(agentSpawnCliArgs("  plan  ")).toEqual(["--agent", "plan"]);
+  });
+});
+
+describe("agent file discovery", () => {
+  it("parses markdown stems and skips noise", () => {
+    expect(agentNameFromFileName("explore.md")).toBe("explore");
+    expect(agentNameFromFileName("my-agent.markdown")).toBe("my-agent");
+    expect(agentNameFromFileName("notes.txt")).toBeNull();
+    expect(agentNameFromFileName(".hidden.md")).toBeNull();
+    expect(agentNameFromFileName("README.md")).toBeNull();
+    expect(agentNameFromFileName("/tmp/agents/plan.md")).toBe("plan");
+  });
+
+  it("lists unique sorted names from a dir listing", () => {
+    expect(
+      agentNamesFromFileList([
+        "plan.md",
+        "Explore.md",
+        "readme.md",
+        "foo.txt",
+        "plan.md",
+      ]),
+    ).toEqual(["Explore", "plan"]);
+  });
+});
+
+describe("mergeAgentCatalog", () => {
+  it("includes built-ins by default", () => {
+    const cat = mergeAgentCatalog({});
+    expect(cat.map((e) => e.name).sort()).toEqual(
+      [...BUILTIN_AGENT_NAMES].sort(),
+    );
+    expect(cat.every((e) => e.source === "builtin")).toBe(true);
+  });
+
+  it("prefers project over user over builtin for the same name", () => {
+    const cat = mergeAgentCatalog({
+      userFiles: ["explore.md", "custom.md"],
+      projectFiles: ["explore.md", "proj-only.md"],
+      userDir: "/home/u/.grok/agents",
+      projectDir: "/repo/.grok/agents",
+    });
+    const byName = Object.fromEntries(cat.map((e) => [e.name, e]));
+    expect(byName.explore.source).toBe("project");
+    expect(byName.explore.path).toBe("/repo/.grok/agents/explore.md");
+    expect(byName.custom.source).toBe("user");
+    expect(byName.custom.path).toBe("/home/u/.grok/agents/custom.md");
+    expect(byName["proj-only"].source).toBe("project");
+    expect(byName.plan.source).toBe("builtin");
+    expect(byName["general-purpose"].source).toBe("builtin");
+  });
+});
+
+describe("resolveAgentCatalogDirs", () => {
+  it("builds user/project/bundled paths", () => {
+    expect(resolveAgentCatalogDirs("/home/u", "/work/app")).toEqual({
+      user: "/home/u/.grok/agents",
+      project: "/work/app/.grok/agents",
+      bundled: "/home/u/.grok/bundled/agents",
+    });
+    expect(resolveAgentCatalogDirs("/home/u", null).project).toBeNull();
+  });
+});

--- a/src/lib/agentsCatalog.ts
+++ b/src/lib/agentsCatalog.ts
@@ -1,0 +1,160 @@
+/**
+ * Pure helpers for discovering selectable Grok Build agent definitions.
+ *
+ * Sources (CLI `--agent <NAME>`):
+ * - Built-ins: explore, plan, general-purpose
+ * - User: ~/.grok/agents/*.md
+ * - Project: <project>/.grok/agents/*.md
+ *
+ * Runtime selection is spawn-time only (`grok --agent NAME agent stdio`).
+ * Changing the preferred agent requires reconnect / new session — no mid-turn
+ * hot-swap over ACP.
+ */
+
+export type AgentCatalogSource = "builtin" | "user" | "project";
+
+export type AgentCatalogEntry = {
+  /** CLI name (file stem or built-in id). */
+  name: string;
+  source: AgentCatalogSource;
+  /** Absolute path when discovered from a file; omitted for pure built-ins. */
+  path?: string | null;
+};
+
+/** Well-known built-in agent names shipped with Grok Build. */
+export const BUILTIN_AGENT_NAMES = [
+  "explore",
+  "general-purpose",
+  "plan",
+] as const;
+
+export type BuiltinAgentName = (typeof BUILTIN_AGENT_NAMES)[number];
+
+const AGENT_MD_RE = /\.(md|markdown)$/i;
+
+/** Values that mean "use CLI default — do not pass --agent". */
+export const DEFAULT_AGENT_SENTINELS = new Set([
+  "",
+  "default",
+  "none",
+  "cli-default",
+  "grok-build",
+]);
+
+/**
+ * Normalize a settings / UI value into a spawn agent name.
+ * Returns null when the CLI default should be used (no `--agent` flag).
+ */
+export function normalizePreferredAgent(
+  raw: string | null | undefined,
+): string | null {
+  const name = (raw ?? "").trim();
+  if (!name) return null;
+  if (DEFAULT_AGENT_SENTINELS.has(name.toLowerCase())) return null;
+  // Reject control chars / path traversal noise in the name form.
+  if (/[\0\r\n]/.test(name)) return null;
+  return name;
+}
+
+/** Top-level CLI args when a preferred agent is set: `["--agent", name]`. */
+export function agentSpawnCliArgs(
+  raw: string | null | undefined,
+): string[] | null {
+  const name = normalizePreferredAgent(raw);
+  if (!name) return null;
+  return ["--agent", name];
+}
+
+/** Definition name = file stem (`explore.md` → `explore`). */
+export function agentNameFromFileName(fileName: string): string | null {
+  const base = fileName.replace(/^.*[/\\]/, "").trim();
+  if (!base || base.startsWith(".")) return null;
+  if (!AGENT_MD_RE.test(base)) return null;
+  const stem = base.replace(AGENT_MD_RE, "").trim();
+  if (!stem || stem === "README" || stem.toLowerCase() === "readme") return null;
+  return stem;
+}
+
+/** Collect agent names from bare file basenames in a directory listing. */
+export function agentNamesFromFileList(fileNames: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const f of fileNames) {
+    const name = agentNameFromFileName(f);
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(name);
+  }
+  out.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+  return out;
+}
+
+/**
+ * Merge built-ins + user + project agent names.
+ * Priority when the same name appears in multiple scopes: project > user > builtin.
+ */
+export function mergeAgentCatalog(input: {
+  userFiles?: string[];
+  projectFiles?: string[];
+  /** Extra built-in names (defaults to BUILTIN_AGENT_NAMES). */
+  builtins?: readonly string[];
+  userDir?: string | null;
+  projectDir?: string | null;
+}): AgentCatalogEntry[] {
+  const builtins = input.builtins ?? BUILTIN_AGENT_NAMES;
+  const byKey = new Map<string, AgentCatalogEntry>();
+
+  for (const name of builtins) {
+    const n = name.trim();
+    if (!n) continue;
+    byKey.set(n.toLowerCase(), { name: n, source: "builtin" });
+  }
+
+  const userDir = (input.userDir ?? "").trim() || null;
+  for (const name of agentNamesFromFileList(input.userFiles ?? [])) {
+    const path = userDir ? joinDirFile(userDir, `${name}.md`) : null;
+    byKey.set(name.toLowerCase(), {
+      name,
+      source: "user",
+      path,
+    });
+  }
+
+  const projectDir = (input.projectDir ?? "").trim() || null;
+  for (const name of agentNamesFromFileList(input.projectFiles ?? [])) {
+    const path = projectDir ? joinDirFile(projectDir, `${name}.md`) : null;
+    byKey.set(name.toLowerCase(), {
+      name,
+      source: "project",
+      path,
+    });
+  }
+
+  return Array.from(byKey.values()).sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  );
+}
+
+function joinDirFile(dir: string, file: string): string {
+  const d = dir.replace(/[/\\]+$/g, "");
+  const sep = d.includes("\\") && !d.includes("/") ? "\\" : "/";
+  return `${d}${sep}${file}`;
+}
+
+/** Absolute dirs the catalog scans (mirrors CLI discovery roots). */
+export function resolveAgentCatalogDirs(
+  userHome: string,
+  projectPath?: string | null,
+): { user: string; project: string | null; bundled: string } {
+  const home = (userHome ?? "").trim().replace(/[/\\]+$/g, "");
+  const sep =
+    home.includes("\\") && !home.includes("/") ? "\\" : "/";
+  const grok = home ? `${home}${sep}.grok` : `.grok`;
+  const user = `${grok}${sep}agents`;
+  const bundled = `${grok}${sep}bundled${sep}agents`;
+  const proj = (projectPath ?? "").trim().replace(/[/\\]+$/g, "");
+  const project = proj ? `${proj}${sep}.grok${sep}agents` : null;
+  return { user, project, bundled };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,26 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+   * Preferred Grok Build agent definition for spawn (`explore` / `plan` / …).
+   * Empty / "default" / "none" → omit top-level `--agent` (CLI default).
+   * Applied at agent process start; changing soft-respawns the live agent.
+   */
+  preferredAgent?: string;
+}
+
+export type AgentCatalogSource = "builtin" | "user" | "project" | "bundled";
+
+export interface AgentCatalogEntry {
+  name: string;
+  source: AgentCatalogSource;
+  path?: string | null;
+}
+
+export interface AgentsCatalogResult {
+  agents: AgentCatalogEntry[];
+  userDir: string;
+  projectDir?: string | null;
+  bundledDir: string;
 }
 
 export interface AvailableModel {
@@ -817,6 +837,13 @@ export async function settingsGet() {
 
 export async function modelsListAvailable() {
   return invoke<AvailableModelsResult>("models_list_available");
+}
+
+/** Built-ins + ~/.grok/agents + project .grok/agents for the agent picker. */
+export async function agentsCatalog(projectPath?: string | null) {
+  return invoke<AgentsCatalogResult>("agents_catalog", {
+    projectPath: projectPath ?? null,
+  });
 }
 
 export async function composerPrefsResolve(opts?: {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,7 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+  /**
    * Preferred Grok Build agent definition for spawn (`explore` / `plan` / …).
    * Empty / "default" / "none" → omit top-level `--agent` (CLI default).
    * Applied at agent process start; changing soft-respawns the live agent.


### PR DESCRIPTION
## Problem
Grok Build supports `--agent <NAME>` (built-ins `explore` / `plan` / `general-purpose`, plus defs under `~/.grok/agents` and project `.grok/agents`), but the App always spawned the CLI default agent. There was no way to pick a definition for session spawn.

Related but separate from #77 (browse agent/persona files in Extensions) — this PR is **select agent for spawn**, not a list panel.

## Changes
- **Discovery**: pure catalog helpers (TS + Rust) merge built-ins + user/project `.md` agent defs; Tauri `agents_catalog(projectPath?)` for the picker.
- **Setting**: `AppSettings.preferredAgent` (empty / `default` / `none` = CLI default — no `--agent` flag).
- **UI**: Settings → Runtime → Agent definition select. Copy states reconnect / new session applies; no mid-turn hot-swap.
- **Spawn**: top-level `grok --agent <name> agent … stdio` when set (verified against CLI help / local `grok --agent explore …`).
- **On change**: `settings_set` soft-respawns the live agent so the next turn uses the new definition.
- i18n: en + zh + zh-TW.
- Tests: `agentsCatalog.test.ts`, Rust `agents_catalog` + `preferred_agent_spawn` unit tests.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (includes `agentsCatalog.test.ts` + i18n key parity)
- [x] `cargo test agent` / `preferred_agent` (catalog normalize/merge + spawn flags)
- [ ] Manual: Settings → Runtime → pick `explore` → reconnect or send a message after soft-respawn; process should start with `--agent explore`. Switch back to Default (CLI); new spawn omits `--agent`. With a project that has `.grok/agents/foo.md`, `foo` appears in the list.