### PR TITLE
feat: optional leader mode for shared agent backend

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -193,6 +193,8 @@ impl SandboxSpawnSpec {
 pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
     let spec = SandboxSpawnSpec::from_setting(profile)?;
     Some((spec.cli_args().to_vec(), spec.env_pair()))
+}
+
 /// Pure spawn flag for Settings → Runtime leader mode.
 ///
 /// Always returns an explicit agent-level flag so App settings win over

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -193,6 +193,18 @@ impl SandboxSpawnSpec {
 pub fn sandbox_spawn_flags(profile: &str) -> Option<(Vec<String>, (String, String))> {
     let spec = SandboxSpawnSpec::from_setting(profile)?;
     Some((spec.cli_args().to_vec(), spec.env_pair()))
+/// Pure spawn flag for Settings → Runtime leader mode.
+///
+/// Always returns an explicit agent-level flag so App settings win over
+/// `[cli] use_leader` in the user's `config.toml`:
+/// - `true`  → `--leader`   (connect to / share a leader backend)
+/// - `false` → `--no-leader` (standalone agent process; default)
+pub fn leader_spawn_flag(use_leader: bool) -> &'static str {
+    if use_leader {
+        "--leader"
+    } else {
+        "--no-leader"
+    }
 }
 
 impl AcpClient {
@@ -281,6 +293,13 @@ impl AcpClient {
         // also set GROK_SANDBOX so nested tools inherit the same profile.
         let settings = crate::store::load_settings();
         let sandbox = SandboxSpawnSpec::from_setting(&settings.sandbox_profile);
+        //   top-level: `grok --no-auto-update agent …`
+        //   agent opts: `--leader` / `--no-leader` / `--model` / `--reasoning-effort`
+        //               / `--always-approve` before `stdio`
+        // Skip background update checks so ACP handshakes are not delayed on launch.
+        // Leader flag is always explicit so App `use_leader` overrides config.toml.
+        let use_leader = crate::store::load_settings().use_leader;
+        let leader_flag = leader_spawn_flag(use_leader);
 
         let mut cmd = Command::new(&cli_path);
         cmd.arg("--no-auto-update");
@@ -290,6 +309,7 @@ impl AcpClient {
             }
         }
         cmd.arg("agent");
+        cmd.arg(leader_flag);
         if !spawn_model.is_empty() {
             cmd.args(["--model", &spawn_model]);
         }
@@ -322,6 +342,7 @@ impl AcpClient {
         }
         tracing::info!(
             "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} sandbox={:?}",
+            "acp: spawn GROK_HOME={} mode={} auth_present={} route={:?} composer_model={:?} spawn_model={} yolo={} leader={}",
             grok_home.display(),
             session_data_mode,
             grok_home.join("auth.json").is_file(),
@@ -333,6 +354,7 @@ impl AcpClient {
                 .map(cli_permission_mode)
                 == Some("bypassPermissions"),
             sandbox.as_ref().map(|s| s.profile.as_str())
+            use_leader
         );
 
         let mut child = cmd.spawn().map_err(|e| {
@@ -2260,5 +2282,20 @@ mod live_handshake_tests {
         eprintln!("OK session={} in {:?}", sid, t0.elapsed());
         client.kill().await;
         assert!(!sid.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod leader_spawn_tests {
+    use super::leader_spawn_flag;
+
+    #[test]
+    fn default_off_uses_no_leader() {
+        assert_eq!(leader_spawn_flag(false), "--no-leader");
+    }
+
+    #[test]
+    fn enabled_uses_leader() {
+        assert_eq!(leader_spawn_flag(true), "--leader");
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -654,6 +654,8 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    }
+
     // Leader mode is a spawn-time flag — soft-respawn so the next connect uses
     // `--leader` / `--no-leader` matching the new setting.
     if use_leader_changed {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -634,6 +634,7 @@ pub async fn settings_set(
         prev.store_api_keys_in_keychain != settings.store_api_keys_in_keychain;
     let session_data_mode_changed =
         prev.session_data_mode != settings.session_data_mode;
+    let use_leader_changed = prev.use_leader != settings.use_leader;
 
     store::save_settings(&settings)?;
 
@@ -653,6 +654,15 @@ pub async fn settings_set(
     // so the next connect spawns under the new data root (E04).
     if session_data_mode_changed {
         mgr.recycle_all_agents(&app, "session_data_mode").await;
+    // Leader mode is a spawn-time flag — soft-respawn so the next connect uses
+    // `--leader` / `--no-leader` matching the new setting.
+    if use_leader_changed {
+        tracing::info!(
+            "settings: use_leader {} → {} — soft-respawn live agent",
+            prev.use_leader,
+            settings.use_leader
+        );
+        mgr.soft_respawn(&app).await;
     }
 
     // Full permission apply: Host + agent-home + soft-respawn if needed
@@ -2881,6 +2891,121 @@ pub async fn plugin_update(
     let result = tauri::async_runtime::spawn_blocking(move || match target_for_cmd.as_deref() {
         Some(n) => run_grok_cli_args(&["plugin", "update", n], PLUGIN_MUTATE_TIMEOUT_SECS),
         None => run_grok_cli_args(&["plugin", "update"], PLUGIN_MUTATE_TIMEOUT_SECS),
+const LEADER_CMD_TIMEOUT_SECS: u64 = 15;
+
+/// One row from `grok leader list --json` (fields vary by CLI version).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeaderProcessDto {
+    pub pid: Option<u64>,
+    pub socket_path: Option<String>,
+    pub version: Option<String>,
+    /// Original object for debugging / future UI fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw: Option<serde_json::Value>,
+}
+
+/// Pure parse helper for `grok leader list --json` (unit-tested).
+pub fn parse_leader_list_json(stdout: &str) -> Result<Vec<LeaderProcessDto>, String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let value: serde_json::Value = serde_json::from_str(trimmed)
+        .map_err(|e| format!("invalid leader list JSON: {e}"))?;
+    let items: Vec<serde_json::Value> = if let Some(arr) = value.as_array() {
+        arr.clone()
+    } else if let Some(arr) = value
+        .get("leaders")
+        .or_else(|| value.get("processes"))
+        .and_then(|v| v.as_array())
+    {
+        arr.clone()
+    } else if value.is_object() {
+        // Single leader object.
+        vec![value]
+    } else {
+        return Ok(Vec::new());
+    };
+
+    let mut out = Vec::with_capacity(items.len());
+    for item in items {
+        let pid = item
+            .get("pid")
+            .or_else(|| item.get("leader_pid"))
+            .or_else(|| item.get("leaderPid"))
+            .and_then(|v| v.as_u64().or_else(|| v.as_i64().map(|i| i as u64)));
+        let socket_path = item
+            .get("socket_path")
+            .or_else(|| item.get("socketPath"))
+            .or_else(|| item.get("socket"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let version = item
+            .get("version")
+            .or_else(|| item.get("leader_version"))
+            .or_else(|| item.get("leaderVersion"))
+            .or_else(|| item.get("leader_binary_version"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        out.push(LeaderProcessDto {
+            pid,
+            socket_path,
+            version,
+            raw: Some(item),
+        });
+    }
+    Ok(out)
+}
+
+/// List running leader processes (`grok leader list --json`).
+/// Always returns Ok; on CLI missing / failure, `leaders` is empty and `error` is set.
+#[tauri::command]
+pub async fn leader_list() -> Result<serde_json::Value, String> {
+    let result = tauri::async_runtime::spawn_blocking(|| {
+        run_grok_cli_args(&["leader", "list", "--json"], LEADER_CMD_TIMEOUT_SECS)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    match result {
+        Ok((stdout, stderr, ok)) => {
+            if !ok {
+                let msg = if !stderr.is_empty() {
+                    stderr
+                } else if !stdout.is_empty() {
+                    stdout
+                } else {
+                    "grok leader list failed".into()
+                };
+                return Ok(serde_json::json!({
+                    "leaders": [],
+                    "error": msg.chars().take(400).collect::<String>(),
+                }));
+            }
+            match parse_leader_list_json(&stdout) {
+                Ok(leaders) => Ok(serde_json::json!({ "leaders": leaders })),
+                Err(e) => Ok(serde_json::json!({
+                    "leaders": [],
+                    "error": e,
+                })),
+            }
+        }
+        Err(e) => Ok(serde_json::json!({
+            "leaders": [],
+            "error": e,
+        })),
+    }
+}
+
+/// Stop all running leader processes (`grok leader kill`). Soft-respawns the app agent.
+#[tauri::command]
+pub async fn leader_kill_all(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+) -> Result<serde_json::Value, String> {
+    let result = tauri::async_runtime::spawn_blocking(|| {
+        run_grok_cli_args(&["leader", "kill"], LEADER_CMD_TIMEOUT_SECS)
     })
     .await
     .map_err(|e| e.to_string())??;
@@ -2903,6 +3028,66 @@ pub async fn plugin_update(
         "name": target.unwrap_or_default(),
         "message": stdout.chars().take(400).collect::<String>(),
     }))
+}
+
+            "grok leader kill failed".into()
+        };
+        return Err(msg.chars().take(400).collect());
+    }
+    // Live agent may have been attached to a killed leader — soft-respawn.
+    mgr.soft_respawn(&app).await;
+    Ok(serde_json::json!({
+        "ok": true,
+        "message": if stdout.is_empty() {
+            stderr.chars().take(200).collect::<String>()
+        } else {
+            stdout.chars().take(200).collect::<String>()
+        },
+    }))
+}
+
+#[cfg(test)]
+mod leader_list_parse_tests {
+    use super::parse_leader_list_json;
+
+    #[test]
+    fn empty_array_and_blank() {
+        assert!(parse_leader_list_json("[]").unwrap().is_empty());
+        assert!(parse_leader_list_json("").unwrap().is_empty());
+        assert!(parse_leader_list_json("   ").unwrap().is_empty());
+    }
+
+    #[test]
+    fn array_of_objects_extracts_fields() {
+        let raw = r#"[
+            {"pid": 42, "socket_path": "/tmp/leader.sock", "leader_version": "0.2.1"},
+            {"leader_pid": 99, "socketPath": "~/.grok/leader.sock"}
+        ]"#;
+        let rows = parse_leader_list_json(raw).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].pid, Some(42));
+        assert_eq!(rows[0].socket_path.as_deref(), Some("/tmp/leader.sock"));
+        assert_eq!(rows[0].version.as_deref(), Some("0.2.1"));
+        assert_eq!(rows[1].pid, Some(99));
+        assert_eq!(
+            rows[1].socket_path.as_deref(),
+            Some("~/.grok/leader.sock")
+        );
+    }
+
+    #[test]
+    fn wrapped_object_and_single() {
+        let wrapped = r#"{"leaders":[{"pid":7}]}"#;
+        let rows = parse_leader_list_json(wrapped).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].pid, Some(7));
+
+        let single = r#"{"pid":11,"socket":"/x.sock"}"#;
+        let rows = parse_leader_list_json(single).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].pid, Some(11));
+        assert_eq!(rows[0].socket_path.as_deref(), Some("/x.sock"));
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,6 +204,8 @@ pub fn run() {
             commands::plugin_details,
             commands::plugin_install,
             commands::plugin_update,
+            commands::leader_list,
+            commands::leader_kill_all,
             commands::pick_directory,
             commands::pick_attach_files,
             commands::pick_attach_folder,

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -168,6 +168,11 @@ pub struct AppSettings {
     /// Passed as top-level `grok --sandbox <profile>` / `GROK_SANDBOX` at spawn.
     #[serde(default = "default_sandbox_profile")]
     pub sandbox_profile: String,
+    /// Connect local ACP agents to a shared Grok Build leader process
+    /// (`grok agent --leader`). Default **false** — each agent is a standalone
+    /// process (`--no-leader`). Advanced; multiple clients can share one backend.
+    #[serde(default)]
+    pub use_leader: bool,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -217,6 +222,7 @@ impl Default for AppSettings {
             stream_stall_seconds: default_stream_stall_seconds(),
             store_api_keys_in_keychain: false,
             sandbox_profile: default_sandbox_profile(),
+            use_leader: false,
         }
     }
 }
@@ -1302,6 +1308,12 @@ mod tests {
     #[test]
     fn sandbox_profile_defaults_when_missing_from_json() {
         // Old settings files without the field must deserialize to "off".
+        assert!(!s.use_leader);
+    }
+
+    #[test]
+    fn use_leader_defaults_when_missing_from_json() {
+        // Old settings files without the field must deserialize to false.
         let raw = r#"{
             "theme": "dark",
             "locale": "en",
@@ -1361,5 +1373,6 @@ mod tests {
         let m: SessionMeta = serde_json::from_str(raw).expect("deserialize legacy session");
         assert!(!m.pinned);
         assert!(!m.archived);
+        assert!(!s.use_leader);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6228,6 +6228,7 @@ export default function App() {
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
             );
+          }}
           useLeader={useLeader}
           onUseLeader={(v) => {
             const prev = useLeader;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -692,6 +692,7 @@ export default function App() {
   const [streamStallSeconds, setStreamStallSeconds] = useState(120);
   const [storeApiKeysInKeychain, setStoreApiKeysInKeychain] = useState(false);
   const [sandboxProfile, setSandboxProfile] = useState("off");
+  const [useLeader, setUseLeader] = useState(false);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -922,6 +923,7 @@ export default function App() {
         const known = ["off", "workspace", "read-only", "strict", "devbox"];
         setSandboxProfile(known.includes(sb) ? sb : "off");
       }
+      setUseLeader(!!settings.useLeader);
       setCliInfo({
         found: cli.found,
         path: cli.path,
@@ -6226,6 +6228,17 @@ export default function App() {
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, sandboxProfile: v }),
             );
+          useLeader={useLeader}
+          onUseLeader={(v) => {
+            const prev = useLeader;
+            setUseLeader(v);
+            void api
+              .settingsGet()
+              .then((s) => api.settingsSet({ ...s, useLeader: v }))
+              .catch((e) => {
+                setUseLeader(prev);
+                showToast(String(e), 4500);
+              });
           }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -45,6 +45,7 @@ import { AccountPanel } from "@/components/AccountPanel";
 import { ProvidersPanel } from "@/components/ProvidersPanel";
 import { ExtensionsPanel } from "@/components/ExtensionsPanel";
 import { ProjectInspectPanel } from "@/components/ProjectInspectPanel";
+import { GlassModal } from "@/components/GlassModal";
 import {
   createT,
   resolveLocale,
@@ -115,6 +116,12 @@ export interface SettingsPageProps {
   /** OS sandbox for agent spawn: off | workspace | read-only | strict | devbox. */
   sandboxProfile?: string;
   onSandboxProfile?: (v: string) => void;
+  /**
+   * Shared leader backend (`grok agent --leader`). Default off (`--no-leader`).
+   * Soft-respawns the live agent when toggled.
+   */
+  useLeader?: boolean;
+  onUseLeader?: (v: boolean) => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -418,6 +425,8 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  useLeader = false,
+  onUseLeader,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -1457,6 +1466,26 @@ export function SettingsPage({
                 }}
               />
             </div>
+            {onUseLeader ? (
+              <>
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.useLeader")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.useLeaderDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={useLeader}
+                    onChange={() => onUseLeader(!useLeader)}
+                    ariaLabel={t("settings.useLeader")}
+                  />
+                </div>
+                {useLeader ? <LeaderStatusPanel t={t} /> : null}
+              </>
+            ) : null}
             <div className="settings-row">
               <div className="settings-row__text">
                 <div className="settings-row__label">
@@ -1658,6 +1687,8 @@ function CliSessionsPanel({
 }
 
 function AboutUpdateRow({
+/** Runtime: list / kill shared leader processes when leader mode is on. */
+function LeaderStatusPanel({
   t,
 }: {
   t: (key: MessageKey, vars?: Record<string, string | number>) => string;
@@ -1689,6 +1720,46 @@ function AboutUpdateRow({
       await api.openExternalUrl(url);
     } catch (e) {
       setError(String(e));
+  const [leaders, setLeaders] = useState<api.LeaderProcessDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [killBusy, setKillBusy] = useState(false);
+  const [confirmKill, setConfirmKill] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!api.isTauri()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.leaderList();
+      setLeaders(res.leaders ?? []);
+      if (res.error) setError(res.error);
+    } catch (e) {
+      setError(String(e));
+      setLeaders([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const doKill = async () => {
+    setConfirmKill(false);
+    setKillBusy(true);
+    setError(null);
+    setStatus(null);
+    try {
+      await api.leaderKillAll();
+      setStatus(t("settings.leaderKillDone"));
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setKillBusy(false);
     }
   };
 
@@ -1749,6 +1820,84 @@ function AboutUpdateRow({
           </div>
         ) : null}
       </div>
+        <div className="settings-row__desc">
+          {loading
+            ? t("settings.leaderRefresh") + "…"
+            : leaders.length === 0
+              ? t("settings.leaderStatusNone")
+              : t("settings.leaderStatusCount", { count: leaders.length })}
+        </div>
+        {leaders.length > 0 ? (
+          <ul className="settings-cli-sessions__list" role="list">
+            {leaders.map((row, i) => {
+              const pid = row.pid != null ? String(row.pid) : "—";
+              const socket = row.socketPath
+                ? ` · ${row.socketPath}`
+                : row.version
+                  ? ` · ${row.version}`
+                  : "";
+              return (
+                <li
+                  key={`${pid}-${i}`}
+                  className="settings-cli-sessions__item"
+                  role="listitem"
+                >
+                  <div className="settings-row__hint">
+                    {t("settings.leaderStatusLine", { pid, socket })}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+        {error ? (
+          <div className="settings-row__hint is-danger">{error}</div>
+        ) : null}
+        {status ? <div className="settings-row__hint">{status}</div> : null}
+      </div>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <button
+          type="button"
+          className="btn btn--ghost settings-row__action"
+          onClick={() => void refresh()}
+          disabled={loading || killBusy}
+        >
+          {t("settings.leaderRefresh")}
+        </button>
+        <button
+          type="button"
+          className="btn btn--ghost btn--danger settings-row__action"
+          onClick={() => setConfirmKill(true)}
+          disabled={killBusy || loading}
+        >
+          {killBusy ? t("settings.leaderKillBusy") : t("settings.leaderKillAll")}
+        </button>
+      </div>
+      <GlassModal
+        open={confirmKill}
+        onClose={() => setConfirmKill(false)}
+        title={t("settings.leaderKillConfirmTitle")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => setConfirmKill(false)}
+            >
+              {t("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--danger"
+              onClick={() => void doKill()}
+            >
+              {t("settings.leaderKillAll")}
+            </button>
+          </>
+        }
+      >
+        <p className="app-dialog__msg">{t("settings.leaderKillConfirmMsg")}</p>
+      </GlassModal>
     </div>
   );
 }

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1687,8 +1687,6 @@ function CliSessionsPanel({
 }
 
 function AboutUpdateRow({
-/** Runtime: list / kill shared leader processes when leader mode is on. */
-function LeaderStatusPanel({
   t,
 }: {
   t: (key: MessageKey, vars?: Record<string, string | number>) => string;
@@ -1720,46 +1718,6 @@ function LeaderStatusPanel({
       await api.openExternalUrl(url);
     } catch (e) {
       setError(String(e));
-  const [leaders, setLeaders] = useState<api.LeaderProcessDto[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<string | null>(null);
-  const [killBusy, setKillBusy] = useState(false);
-  const [confirmKill, setConfirmKill] = useState(false);
-
-  const refresh = useCallback(async () => {
-    if (!api.isTauri()) return;
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await api.leaderList();
-      setLeaders(res.leaders ?? []);
-      if (res.error) setError(res.error);
-    } catch (e) {
-      setError(String(e));
-      setLeaders([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
-
-  const doKill = async () => {
-    setConfirmKill(false);
-    setKillBusy(true);
-    setError(null);
-    setStatus(null);
-    try {
-      await api.leaderKillAll();
-      setStatus(t("settings.leaderKillDone"));
-      await refresh();
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setKillBusy(false);
     }
   };
 
@@ -1820,6 +1778,62 @@ function LeaderStatusPanel({
           </div>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+/** Runtime: list / kill shared leader processes when leader mode is on. */
+function LeaderStatusPanel({
+  t,
+}: {
+  t: (key: MessageKey, vars?: Record<string, string | number>) => string;
+}) {
+  const [leaders, setLeaders] = useState<api.LeaderProcessDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [killBusy, setKillBusy] = useState(false);
+  const [confirmKill, setConfirmKill] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!api.isTauri()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.leaderList();
+      setLeaders(res.leaders ?? []);
+      if (res.error) setError(res.error);
+    } catch (e) {
+      setError(String(e));
+      setLeaders([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const doKill = async () => {
+    setConfirmKill(false);
+    setKillBusy(true);
+    setError(null);
+    setStatus(null);
+    try {
+      await api.leaderKillAll();
+      setStatus(t("settings.leaderKillDone"));
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setKillBusy(false);
+    }
+  };
+
+  return (
+    <div className="settings-row settings-row--stack">
+      <div className="settings-row__text">
         <div className="settings-row__desc">
           {loading
             ? t("settings.leaderRefresh") + "…"

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -565,6 +565,19 @@ const en = {
   "settings.streamStallSeconds": "Stream stall timeout (seconds)",
   "settings.streamStallSecondsDesc":
     "If a turn has no stream chunks or tool activity for this long, show a Cancel / Keep waiting prompt (default 120). Long-running tools that still emit events do not count as stalled.",
+  "settings.useLeader": "Shared leader backend",
+  "settings.useLeaderDesc":
+    "Advanced: connect the agent to a shared Grok Build leader process (`grok agent --leader`) so multiple clients can share one backend. Off by default (`--no-leader`). Changing this soft-respawns the live agent.",
+  "settings.leaderStatusNone": "No leader process running.",
+  "settings.leaderStatusCount": "{count} leader process(es)",
+  "settings.leaderStatusLine": "PID {pid}{socket}",
+  "settings.leaderRefresh": "Refresh",
+  "settings.leaderKillAll": "Stop leaders",
+  "settings.leaderKillConfirmTitle": "Stop all leader processes?",
+  "settings.leaderKillConfirmMsg":
+    "This runs `grok leader kill` and stops every shared leader. Local agents that were attached will reconnect on the next message.",
+  "settings.leaderKillBusy": "Stopping…",
+  "settings.leaderKillDone": "Leader processes stopped.",
   "agent.idleRecycledToast":
     "Agent process recycled after idle — session kept; next message will reconnect.",
   "agent.dataModeRecycledToast":
@@ -1777,6 +1790,19 @@ const zh: Record<MessageKey, string> = {
   "settings.streamStallSeconds": "流式卡顿超时（秒）",
   "settings.streamStallSecondsDesc":
     "若一轮对话在该时间内无任何流式片段或工具活动，将提示「取消本轮 / 继续等待」（默认 120）。仍有工具事件的长任务不会误判为卡顿。",
+  "settings.useLeader": "共享 Leader 后端",
+  "settings.useLeaderDesc":
+    "高级：将 Agent 连接到共享的 Grok Build Leader 进程（`grok agent --leader`），使多个客户端共用一个后端。默认关闭（`--no-leader`）。更改后会软重启当前 Agent。",
+  "settings.leaderStatusNone": "当前没有运行中的 Leader 进程。",
+  "settings.leaderStatusCount": "{count} 个 Leader 进程",
+  "settings.leaderStatusLine": "PID {pid}{socket}",
+  "settings.leaderRefresh": "刷新",
+  "settings.leaderKillAll": "停止 Leader",
+  "settings.leaderKillConfirmTitle": "停止全部 Leader 进程？",
+  "settings.leaderKillConfirmMsg":
+    "将执行 `grok leader kill` 并停止所有共享 Leader。已连接的本地 Agent 会在下次发送消息时重连。",
+  "settings.leaderKillBusy": "正在停止…",
+  "settings.leaderKillDone": "已停止 Leader 进程。",
   "agent.idleRecycledToast":
     "Agent 进程因闲置已回收 — 会话仍在；下次发送将重新连接。",
   "agent.dataModeRecycledToast":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -538,6 +538,19 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.streamStallSeconds": "串流停滯逾時（秒）",
   "settings.streamStallSecondsDesc":
     "若一輪對話在該時間內無任何串流片段或工具活動，將提示「取消本輪 / 繼續等待」（預設 120）。仍有工具事件的長任務不會誤判為停滯。",
+  "settings.useLeader": "共享 Leader 後端",
+  "settings.useLeaderDesc":
+    "進階：將 Agent 連線到共享的 Grok Build Leader 行程（`grok agent --leader`），讓多個用戶端共用一個後端。預設關閉（`--no-leader`）。變更後會軟重啟目前 Agent。",
+  "settings.leaderStatusNone": "目前沒有執行中的 Leader 行程。",
+  "settings.leaderStatusCount": "{count} 個 Leader 行程",
+  "settings.leaderStatusLine": "PID {pid}{socket}",
+  "settings.leaderRefresh": "重新整理",
+  "settings.leaderKillAll": "停止 Leader",
+  "settings.leaderKillConfirmTitle": "停止全部 Leader 行程？",
+  "settings.leaderKillConfirmMsg":
+    "將執行 `grok leader kill` 並停止所有共享 Leader。已連線的本機 Agent 會在下次傳送訊息時重新連線。",
+  "settings.leaderKillBusy": "正在停止…",
+  "settings.leaderKillDone": "已停止 Leader 行程。",
   "agent.idleRecycledToast":
     "Agent 行程因閒置已回收 — 工作階段仍在；下次傳送將重新連線。",
   "agent.dataModeRecycledToast":

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,7 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+  /**
    * Connect agents to a shared Grok Build leader (`grok agent --leader`).
    * Default false: standalone process (`--no-leader`). Soft-respawns on change.
    */
@@ -1181,6 +1182,8 @@ export async function pluginUpdate(name?: string | null) {
   return invoke<PluginActionResult>("plugin_update", {
     name: n ? n : null,
   });
+}
+
 // ── Leader process (shared agent backend) ───────────────────────────────────
 
 export interface LeaderProcessDto {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -786,6 +786,10 @@ export interface AppSettings {
    * Default "off". Passed as `grok --sandbox <profile>` / GROK_SANDBOX on spawn.
    */
   sandboxProfile?: string;
+   * Connect agents to a shared Grok Build leader (`grok agent --leader`).
+   * Default false: standalone process (`--no-leader`). Soft-respawns on change.
+   */
+  useLeader?: boolean;
 }
 
 export interface AvailableModel {
@@ -1177,6 +1181,32 @@ export async function pluginUpdate(name?: string | null) {
   return invoke<PluginActionResult>("plugin_update", {
     name: n ? n : null,
   });
+// ── Leader process (shared agent backend) ───────────────────────────────────
+
+export interface LeaderProcessDto {
+  pid?: number | null;
+  socketPath?: string | null;
+  version?: string | null;
+}
+
+export interface LeaderListResult {
+  leaders: LeaderProcessDto[];
+  error?: string;
+}
+
+export interface LeaderKillResult {
+  ok: boolean;
+  message?: string;
+}
+
+/** List running leader processes (`grok leader list --json`). */
+export async function leaderList() {
+  return invoke<LeaderListResult>("leader_list");
+}
+
+/** Stop all leaders (`grok leader kill`) and soft-respawn the app agent. */
+export async function leaderKillAll() {
+  return invoke<LeaderKillResult>("leader_kill_all");
 }
 
 // ── Official Grok Build account ─────────────────────────────────────────────


### PR DESCRIPTION
## Problem
Grok Build CLI supports a shared leader process (`grok agent --leader` / `--no-leader`, plus `grok leader list|info|kill`) so multiple clients can share one backend. The App always spawned a standalone agent and offered no way to opt into leader mode.

## Changes
- **`AppSettings.useLeader`** (default `false`) — persisted in settings; old files without the field stay off.
- **Settings → Runtime** toggle with description (shared backend / advanced).
- **Spawn path** always passes an explicit agent flag so App settings win over `[cli] use_leader` in `config.toml`:
  - off → `grok … agent --no-leader … stdio`
  - on → `grok … agent --leader … stdio`
- **Soft-respawn** when the toggle changes (live agent picks up the new flag on next connect).
- **Leader helpers** (visible when enabled): `leader list --json` status line + refresh, and `leader kill` with in-app confirm (no `window.confirm`).
- **i18n** en + zh + zh-TW.
- **Tests**: pure spawn-flag helper + leader list JSON parse + settings default/deserialize.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (347 passed)
- [x] `cargo test leader_` — spawn flags + list parse + store default (6 ok)
- [x] Default remains off (`use_leader: false` / `--no-leader`)
- [ ] Manual: Settings → Runtime → enable Shared leader backend → send a message → agent reconnects with leader
- [ ] Manual: status line Refresh shows `grok leader list --json` rows; Stop leaders confirms and clears