### PR TITLE
feat: apply CLI doctor automatic remediations from App Doctor

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1386,6 +1386,9 @@ pub async fn doctor_report() -> Result<serde_json::Value, String> {
 /// Timeout for `grok doctor --json` (host env probes; keep short).
 const CLI_DOCTOR_TIMEOUT_SECS: u64 = 15;
 
+/// Timeout for `grok doctor fix <id> --yes` (may rewrite shell rc / config).
+const CLI_DOCTOR_FIX_TIMEOUT_SECS: u64 = 30;
+
 /// Run probed CLI `doctor --json`. Returns a stable envelope for the UI parser.
 /// Never includes secret values — only CLI doctor facts/findings/probeNotes.
 fn run_cli_doctor_json() -> serde_json::Value {
@@ -1436,6 +1439,95 @@ fn truncate_cli_err(s: &str, max: usize) -> String {
     }
     let head: String = t.chars().take(max).collect();
     format!("{head}…")
+}
+
+/// Safe fix-id shape: short handle (`ssh-wrap`) or canonical (`terminal.ssh-wrap`).
+/// Rejects flags, paths, and shell metacharacters before invoking the CLI.
+fn is_safe_doctor_fix_id(id: &str) -> bool {
+    let t = id.trim();
+    if t.is_empty() || t.len() > 128 {
+        return false;
+    }
+    let mut chars = t.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphanumeric() {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+}
+
+/// Redact + cap CLI doctor fix stdout/stderr for the UI (no secrets, no huge dumps).
+fn redact_doctor_fix_output(s: &str, max: usize) -> String {
+    let scrubbed = store::redact_text(s);
+    truncate_cli_err(&scrubbed, max)
+}
+
+/// Apply a CLI automatic remediation: `grok doctor fix <id> --yes`.
+/// Returns redacted stdout/stderr; never throws on non-zero exit (ok=false).
+#[tauri::command]
+pub async fn cli_doctor_fix(id: String) -> Result<serde_json::Value, String> {
+    let id = id.trim().to_string();
+    if id.is_empty() {
+        return Err("doctor fix id required".into());
+    }
+    if !is_safe_doctor_fix_id(&id) {
+        return Err(format!("invalid doctor fix id: {id}"));
+    }
+
+    let id_for_cmd = id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        run_grok_cli_args(
+            &["doctor", "fix", &id_for_cmd, "--yes"],
+            CLI_DOCTOR_FIX_TIMEOUT_SECS,
+        )
+    })
+    .await
+    .map_err(|e| format!("doctor fix worker panicked: {e}"))?;
+
+    match result {
+        Ok((stdout, stderr, exit_ok)) => Ok(serde_json::json!({
+            "ok": exit_ok,
+            "id": id,
+            "stdout": redact_doctor_fix_output(&stdout, 2000),
+            "stderr": redact_doctor_fix_output(&stderr, 800),
+            "exitOk": exit_ok,
+        })),
+        Err(e) => {
+            // Missing CLI / timeout — surface as structured failure, not panic.
+            Ok(serde_json::json!({
+                "ok": false,
+                "id": id,
+                "stdout": "",
+                "stderr": redact_doctor_fix_output(&e, 400),
+                "exitOk": false,
+                "error": redact_doctor_fix_output(&e, 400),
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod doctor_fix_id_tests {
+    use super::is_safe_doctor_fix_id;
+
+    #[test]
+    fn accepts_short_and_canonical_handles() {
+        assert!(is_safe_doctor_fix_id("ssh-wrap"));
+        assert!(is_safe_doctor_fix_id("terminal.ssh-wrap"));
+        assert!(is_safe_doctor_fix_id("tmux-clipboard"));
+    }
+
+    #[test]
+    fn rejects_flags_paths_and_injection() {
+        assert!(!is_safe_doctor_fix_id(""));
+        assert!(!is_safe_doctor_fix_id("--yes"));
+        assert!(!is_safe_doctor_fix_id("a b"));
+        assert!(!is_safe_doctor_fix_id("../etc/passwd"));
+        assert!(!is_safe_doctor_fix_id("ssh-wrap;rm"));
+        assert!(!is_safe_doctor_fix_id("-ssh-wrap"));
+    }
 }
 
 /// Write a redacted support zip (Doctor JSON + logs) and return its path.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -186,6 +186,7 @@ pub fn run() {
             commands::import_grok_cli_config,
             commands::import_grok_go_config,
             commands::doctor_report,
+            commands::cli_doctor_fix,
             commands::export_support_bundle,
             commands::export_session_bundle,
             commands::reset_app_data,

--- a/src/components/DoctorModal.tsx
+++ b/src/components/DoctorModal.tsx
@@ -17,11 +17,14 @@ import * as api from "@/lib/api";
 import type { DoctorCheck, DoctorLevel, DoctorReport } from "@/lib/api";
 import {
   CLI_DOCTOR_FACT_KEYS,
+  extractFixIds,
   formatFactValue,
   hasAnySafeFact,
   parseCliDoctorEnvelope,
+  type CliDoctorCheck,
   type CliDoctorSafeFacts,
   type CliDoctorView,
+  type DoctorFixHandle,
 } from "@/lib/cliDoctor";
 import { redact } from "@/lib/redact";
 
@@ -128,7 +131,9 @@ export function DoctorModal({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [busy, setBusy] = useState<"zip" | "reset" | null>(null);
+  const [busy, setBusy] = useState<"zip" | "reset" | "fix" | null>(null);
+  /** Which fix id is currently running (for per-row spinner). */
+  const [fixingId, setFixingId] = useState<string | null>(null);
   const [keepSecrets, setKeepSecrets] = useState(true);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
 
@@ -238,6 +243,97 @@ export function DoctorModal({
     if (!report) return null;
     return parseCliDoctorEnvelope(report.cliDoctor ?? null);
   }, [report]);
+
+  /** Fix handles from CLI findings (automaticRemediation / fixId). */
+  const cliFixes: DoctorFixHandle[] = useMemo(() => {
+    if (!report?.cliDoctor) return [];
+    return extractFixIds(report.cliDoctor);
+  }, [report]);
+
+  const applyFix = useCallback(
+    async (fixId: string) => {
+      setBusy("fix");
+      setFixingId(fixId);
+      setError(null);
+      setStatusMsg(null);
+      try {
+        const res = await api.cliDoctorFix(fixId);
+        // Re-run doctor so findings refresh; then restore fix outcome
+        // (run() clears status/error at start).
+        await run();
+        if (res.ok) {
+          const preview = (res.stdout || res.stderr || "").trim();
+          setStatusMsg(
+            preview
+              ? t("doctor.cliDoctorFixDoneDetail", {
+                  id: fixId,
+                  detail: redact(preview).slice(0, 240),
+                })
+              : t("doctor.cliDoctorFixDone", { id: fixId }),
+          );
+        } else {
+          const detail = redact(
+            (
+              res.error ||
+              res.stderr ||
+              res.stdout ||
+              t("doctor.cliDoctorFixFail")
+            ).trim(),
+          ).slice(0, 320);
+          setError(`${t("doctor.cliDoctorFixFail")}: ${detail}`);
+        }
+      } catch (e) {
+        setError(`${t("doctor.cliDoctorFixFail")}: ${String(e)}`);
+      } finally {
+        setBusy(null);
+        setFixingId(null);
+      }
+    },
+    [run, t],
+  );
+
+  const onApplyFix = useCallback(
+    (handle: { fixId: string; message?: string; destructive?: boolean }) => {
+      const runFix = () => {
+        void applyFix(handle.fixId);
+      };
+      // Destructive (shell/config) fixes always go through in-app confirm.
+      if (handle.destructive !== false && onConfirm) {
+        onConfirm({
+          title: t("doctor.cliDoctorFixConfirmTitle"),
+          message: t("doctor.cliDoctorFixConfirmBody", {
+            id: handle.fixId,
+            message: handle.message?.trim() || handle.fixId,
+          }),
+          confirmLabel: t("doctor.cliDoctorFix"),
+          danger: true,
+          onConfirm: runFix,
+        });
+        return;
+      }
+      runFix();
+    },
+    [applyFix, onConfirm, t],
+  );
+
+  const fixForCheck = useCallback(
+    (c: CliDoctorCheck): DoctorFixHandle | null => {
+      if (c.fixId) {
+        return {
+          fixId: c.fixId,
+          findingId: c.id,
+          message: c.title,
+          destructive: c.destructive !== false,
+        };
+      }
+      return (
+        cliFixes.find(
+          (f) => f.findingId === c.id || f.fixId === c.id,
+        ) ?? null
+      );
+    },
+    [cliFixes],
+  );
 
   if (!open) return null;
 
@@ -374,35 +470,98 @@ export function DoctorModal({
 
               {cliDoctor.available && cliDoctor.checks.length > 0 && (
                 <ul className="doctor-checks">
-                  {cliDoctor.checks.map((c) => (
-                    <li
-                      key={c.id}
-                      className={`doctor-check doctor-check--${c.level}`}
-                    >
-                      <div className="doctor-check__badge" aria-hidden>
-                        <LevelIcon level={c.level} />
-                      </div>
-                      <div className="doctor-check__main">
-                        <div className="doctor-check__row">
-                          <span className="doctor-check__title">
-                            {c.id === "cli-doctor-clean"
-                              ? t("doctor.cliDoctorEmpty")
-                              : c.title}
-                          </span>
-                          <span
-                            className={`doctor-check__level doctor-check__level--${c.level}`}
-                          >
-                            {t(levelLabelKey(c.level))}
-                          </span>
+                  {cliDoctor.checks.map((c) => {
+                    const fix = fixForCheck(c);
+                    const isThisFixing =
+                      busy === "fix" && fixingId === fix?.fixId;
+                    return (
+                      <li
+                        key={c.id}
+                        className={`doctor-check doctor-check--${c.level}`}
+                      >
+                        <div className="doctor-check__badge" aria-hidden>
+                          <LevelIcon level={c.level} />
                         </div>
-                        {c.detail && c.id !== "cli-doctor-clean" ? (
-                          <p className="doctor-check__detail">{c.detail}</p>
-                        ) : null}
-                      </div>
-                    </li>
-                  ))}
+                        <div className="doctor-check__main">
+                          <div className="doctor-check__row">
+                            <span className="doctor-check__title">
+                              {c.id === "cli-doctor-clean"
+                                ? t("doctor.cliDoctorEmpty")
+                                : c.title}
+                            </span>
+                            <span
+                              className={`doctor-check__level doctor-check__level--${c.level}`}
+                            >
+                              {t(levelLabelKey(c.level))}
+                            </span>
+                          </div>
+                          {c.detail && c.id !== "cli-doctor-clean" ? (
+                            <p className="doctor-check__detail">{c.detail}</p>
+                          ) : null}
+                          {fix ? (
+                            <div className="doctor-check__actions">
+                              <button
+                                type="button"
+                                className="btn btn--ghost btn--sm"
+                                disabled={!!busy || loading}
+                                onClick={() => onApplyFix(fix)}
+                                title={t("doctor.cliDoctorFixHint", {
+                                  id: fix.fixId,
+                                })}
+                              >
+                                {isThisFixing
+                                  ? "…"
+                                  : t("doctor.cliDoctorFix")}
+                              </button>
+                              <span className="doctor-check__fix-id">
+                                {fix.fixId}
+                              </span>
+                            </div>
+                          ) : null}
+                        </div>
+                      </li>
+                    );
+                  })}
                 </ul>
               )}
+
+              {/* Fallback strip when findings carry automaticRemediation but
+                  were not already rendered as check rows (older host shapes). */}
+              {cliDoctor.available &&
+                cliFixes.length > 0 &&
+                !cliDoctor.checks.some((c) => c.fixId) && (
+                  <div className="doctor-cli-fixes">
+                    <div className="doctor-cli-fixes__title">
+                      {t("doctor.cliDoctorFixes")}
+                    </div>
+                    <ul className="doctor-cli-fixes__list">
+                      {cliFixes.map((f) => (
+                        <li key={f.fixId} className="doctor-cli-fixes__item">
+                          <div className="doctor-cli-fixes__text">
+                            <span className="doctor-cli-fixes__id">
+                              {f.fixId}
+                            </span>
+                            {f.message ? (
+                              <span className="doctor-cli-fixes__msg">
+                                {f.message}
+                              </span>
+                            ) : null}
+                          </div>
+                          <button
+                            type="button"
+                            className="btn btn--ghost btn--sm"
+                            disabled={!!busy || loading}
+                            onClick={() => onApplyFix(f)}
+                          >
+                            {busy === "fix" && fixingId === f.fixId
+                              ? "…"
+                              : t("doctor.cliDoctorFix")}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
 
               {cliDoctor.available &&
                 hasAnySafeFact(cliDoctor.facts) &&

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -912,6 +912,15 @@ const en = {
   "doctor.cliDoctorFact.ssh": "SSH",
   "doctor.cliDoctorFact.voice": "Voice",
   "doctor.cliDoctorProbeNotes": "Probe notes ({count})",
+  "doctor.cliDoctorFix": "Apply fix",
+  "doctor.cliDoctorFixes": "Automatic fixes",
+  "doctor.cliDoctorFixHint": "Run `grok doctor fix {id} --yes`",
+  "doctor.cliDoctorFixConfirmTitle": "Apply CLI doctor fix?",
+  "doctor.cliDoctorFixConfirmBody":
+    "This runs `grok doctor fix {id} --yes` and may change shell config or other local files.\n\n{message}",
+  "doctor.cliDoctorFixDone": "Applied fix “{id}”. Doctor re-ran.",
+  "doctor.cliDoctorFixDoneDetail": "Applied fix “{id}”. {detail}",
+  "doctor.cliDoctorFixFail": "Could not apply CLI doctor fix",
 
   // Connection status pill
   "conn.idle": "Idle",
@@ -2118,6 +2127,15 @@ const zh: Record<MessageKey, string> = {
   "doctor.cliDoctorFact.ssh": "SSH",
   "doctor.cliDoctorFact.voice": "语音",
   "doctor.cliDoctorProbeNotes": "探测备注（{count}）",
+  "doctor.cliDoctorFix": "应用修复",
+  "doctor.cliDoctorFixes": "自动修复",
+  "doctor.cliDoctorFixHint": "运行 `grok doctor fix {id} --yes`",
+  "doctor.cliDoctorFixConfirmTitle": "应用 CLI doctor 修复？",
+  "doctor.cliDoctorFixConfirmBody":
+    "将运行 `grok doctor fix {id} --yes`，可能修改 shell 配置或其他本地文件。\n\n{message}",
+  "doctor.cliDoctorFixDone": "已应用修复「{id}」。Doctor 已重新运行。",
+  "doctor.cliDoctorFixDoneDetail": "已应用修复「{id}」。{detail}",
+  "doctor.cliDoctorFixFail": "无法应用 CLI doctor 修复",
 
   "conn.idle": "空闲",
   "conn.connecting": "连接中",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -879,6 +879,15 @@ export const zhTW: Record<MessageKey, string> = {
   "doctor.cliDoctorFact.ssh": "SSH",
   "doctor.cliDoctorFact.voice": "語音",
   "doctor.cliDoctorProbeNotes": "探測備註（{count}）",
+  "doctor.cliDoctorFix": "套用修復",
+  "doctor.cliDoctorFixes": "自動修復",
+  "doctor.cliDoctorFixHint": "執行 `grok doctor fix {id} --yes`",
+  "doctor.cliDoctorFixConfirmTitle": "套用 CLI doctor 修復？",
+  "doctor.cliDoctorFixConfirmBody":
+    "將執行 `grok doctor fix {id} --yes`，可能修改 shell 設定或其他本機檔案。\n\n{message}",
+  "doctor.cliDoctorFixDone": "已套用修復「{id}」。Doctor 已重新執行。",
+  "doctor.cliDoctorFixDoneDetail": "已套用修復「{id}」。{detail}",
+  "doctor.cliDoctorFixFail": "無法套用 CLI doctor 修復",
 
   "conn.idle": "閒置",
   "conn.connecting": "連線中",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1017,6 +1017,24 @@ export async function doctorReport() {
   return invoke<DoctorReport>("doctor_report");
 }
 
+/** Result of `grok doctor fix <id> --yes` (stdout/stderr already redacted). */
+export interface CliDoctorFixResult {
+  ok: boolean;
+  id: string;
+  stdout: string;
+  stderr: string;
+  exitOk?: boolean;
+  error?: string;
+}
+
+/**
+ * Apply a CLI automatic remediation (`doctor fix <id> --yes`).
+ * Prefer confirm in UI for destructive fixes first.
+ */
+export async function cliDoctorFix(id: string) {
+  return invoke<CliDoctorFixResult>("cli_doctor_fix", { id });
+}
+
 export interface SupportBundleResult {
   ok: boolean;
   path: string;

--- a/src/lib/cliDoctor.test.ts
+++ b/src/lib/cliDoctor.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  coerceFixId,
   dispositionToLevel,
+  extractFixIds,
   extractSafeFacts,
   formatFactValue,
   hasAnySafeFact,
+  isDestructiveDoctorFix,
+  isValidDoctorFixId,
   parseCliDoctorEnvelope,
   parseCliDoctorReport,
   parseFinding,
@@ -63,6 +67,14 @@ const FIXTURE = {
       automaticRemediation: null,
       note: null,
     },
+    {
+      id: "terminal.ssh-wrap",
+      disposition: "recommendation",
+      message: "Wrap ssh through grok wrap for better terminal support",
+      remediation: "Add shell alias via doctor fix",
+      automaticRemediation: "ssh-wrap",
+      note: "Writes an interactive-shell alias to ~/.zshrc (with backup).",
+    },
   ],
   probeNotes: [
     {
@@ -73,7 +85,7 @@ const FIXTURE = {
   ],
   counts: {
     issues: 1,
-    recommendations: 1,
+    recommendations: 2,
     probeNotes: 1,
   },
 };
@@ -115,6 +127,114 @@ describe("parseFinding", () => {
     expect(row?.level).toBe("fail");
     expect(row?.title).toContain("NO_COLOR");
     expect(row?.detail).toContain("Unset NO_COLOR");
+    expect(row?.fixId).toBeNull();
+  });
+
+  it("surfaces automaticRemediation as fixId", () => {
+    const row = parseFinding(FIXTURE.findings[2], 2);
+    expect(row?.id).toBe("terminal.ssh-wrap");
+    expect(row?.fixId).toBe("ssh-wrap");
+    expect(row?.destructive).toBe(true);
+    expect(row?.detail).toContain("fix: ssh-wrap");
+  });
+});
+
+describe("extractFixIds", () => {
+  it("extracts unique fix handles from fixture findings", () => {
+    const fixes = extractFixIds(FIXTURE);
+    expect(fixes).toHaveLength(1);
+    expect(fixes[0].fixId).toBe("ssh-wrap");
+    expect(fixes[0].findingId).toBe("terminal.ssh-wrap");
+    expect(fixes[0].destructive).toBe(true);
+    expect(fixes[0].message).toContain("Wrap ssh");
+  });
+
+  it("accepts host envelope and bare findings array", () => {
+    expect(
+      extractFixIds({ available: true, report: FIXTURE }).map((f) => f.fixId),
+    ).toEqual(["ssh-wrap"]);
+    expect(
+      extractFixIds(FIXTURE.findings).map((f) => f.fixId),
+    ).toEqual(["ssh-wrap"]);
+  });
+
+  it("accepts canonical automaticRemediation and fixId field", () => {
+    const fixes = extractFixIds({
+      findings: [
+        {
+          id: "terminal.ssh-wrap",
+          automaticRemediation: "terminal.ssh-wrap",
+          message: "canonical",
+        },
+        {
+          id: "tmux.clipboard",
+          fixId: "tmux-clipboard",
+          automaticRemediation: null,
+          message: "via fixId",
+        },
+        {
+          id: "bad",
+          automaticRemediation: "--yes; rm -rf /",
+          message: "injection",
+        },
+        {
+          id: "obj",
+          automaticRemediation: { handle: "dcs-passthrough" },
+          message: "object form",
+        },
+      ],
+    });
+    expect(fixes.map((f) => f.fixId).sort()).toEqual([
+      "dcs-passthrough",
+      "terminal.ssh-wrap",
+      "tmux-clipboard",
+    ]);
+  });
+
+  it("dedupes the same fix handle", () => {
+    const fixes = extractFixIds({
+      findings: [
+        { id: "a", automaticRemediation: "ssh-wrap" },
+        { id: "b", automaticRemediation: "SSH-WRAP" },
+      ],
+    });
+    expect(fixes).toHaveLength(1);
+  });
+
+  it("returns empty when nothing is fixable", () => {
+    expect(extractFixIds(null)).toEqual([]);
+    expect(extractFixIds({ findings: [] })).toEqual([]);
+    expect(
+      extractFixIds({
+        findings: [{ id: "x", automaticRemediation: null }],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("coerceFixId / isValidDoctorFixId / isDestructiveDoctorFix", () => {
+  it("coerces string and object forms", () => {
+    expect(coerceFixId("ssh-wrap")).toBe("ssh-wrap");
+    expect(coerceFixId({ handle: "ssh-wrap" })).toBe("ssh-wrap");
+    expect(coerceFixId({ id: "terminal.ssh-wrap" })).toBe("terminal.ssh-wrap");
+    expect(coerceFixId(null)).toBeNull();
+    expect(coerceFixId("  ")).toBeNull();
+  });
+
+  it("rejects unsafe fix ids", () => {
+    expect(isValidDoctorFixId("ssh-wrap")).toBe(true);
+    expect(isValidDoctorFixId("terminal.ssh-wrap")).toBe(true);
+    expect(isValidDoctorFixId("--yes")).toBe(false);
+    expect(isValidDoctorFixId("a b")).toBe(false);
+    expect(isValidDoctorFixId("../etc")).toBe(false);
+    expect(isValidDoctorFixId("")).toBe(false);
+  });
+
+  it("flags shell-mutating fixes as destructive", () => {
+    expect(isDestructiveDoctorFix("ssh-wrap")).toBe(true);
+    expect(isDestructiveDoctorFix("terminal.ssh-wrap")).toBe(true);
+    expect(isDestructiveDoctorFix("unknown-thing")).toBe(true);
+    expect(isDestructiveDoctorFix("noop")).toBe(false);
   });
 });
 
@@ -122,11 +242,12 @@ describe("parseCliDoctorReport", () => {
   it("parses fixture JSON into pass/warn/fail rows", () => {
     const view = parseCliDoctorReport(FIXTURE);
     expect(view.schemaVersion).toBe("1");
-    expect(view.checks).toHaveLength(2);
+    expect(view.checks).toHaveLength(3);
     expect(view.checks[0].level).toBe("fail");
     expect(view.checks[1].level).toBe("warn");
+    expect(view.checks[2].fixId).toBe("ssh-wrap");
     expect(view.summary.fail).toBe(1);
-    expect(view.summary.warn).toBe(1);
+    expect(view.summary.warn).toBe(2);
     expect(view.counts?.issues).toBe(1);
     expect(view.probeNotes).toHaveLength(1);
     expect(view.facts.terminal).toBe("iterm2");

--- a/src/lib/cliDoctor.ts
+++ b/src/lib/cliDoctor.ts
@@ -16,6 +16,28 @@ export type CliDoctorCheck = {
   /** Note / remediation / disposition context. */
   detail: string;
   disposition?: string;
+  /**
+   * CLI `doctor fix <id>` handle when `automaticRemediation` is set
+   * (short form e.g. `ssh-wrap`, or canonical `terminal.ssh-wrap`).
+   */
+  fixId?: string | null;
+  /** Whether applying the fix mutates shell/config (needs in-app confirm). */
+  destructive?: boolean;
+};
+
+/**
+ * One automatic remediation extractable from doctor JSON findings.
+ * Used by the pure helper and by DoctorModal “Apply fix”.
+ */
+export type DoctorFixHandle = {
+  /** Id passed to `grok doctor fix <id> --yes`. */
+  fixId: string;
+  /** Finding id (often the canonical form, e.g. `terminal.ssh-wrap`). */
+  findingId: string;
+  /** Finding message when present. */
+  message?: string;
+  /** Shell/config mutation → confirm before apply. */
+  destructive: boolean;
 };
 
 /** Safe, human-readable fact chips (no paths that embed tokens). */
@@ -176,6 +198,113 @@ export function extractSafeFacts(facts: unknown): CliDoctorSafeFacts {
   };
 }
 
+/**
+ * Normalize a fix handle from CLI fields.
+ * Accepts a plain string or a small object `{ id | handle | name }`.
+ */
+export function coerceFixId(raw: unknown): string | null {
+  if (typeof raw === "string") {
+    const t = raw.trim();
+    return t || null;
+  }
+  if (isRecord(raw)) {
+    return (
+      asString(raw.id) ??
+      asString(raw.handle) ??
+      asString(raw.name) ??
+      asString(raw.fixId) ??
+      null
+    );
+  }
+  return null;
+}
+
+/**
+ * Whether applying this fix is expected to mutate shell rc / user config.
+ * Unknown handles default to destructive (safer: always confirm).
+ */
+export function isDestructiveDoctorFix(fixId: string): boolean {
+  const id = fixId.trim().toLowerCase();
+  if (!id) return true;
+  // Explicitly non-mutating placeholders (none today; keep the hook).
+  if (id === "noop" || id === "none" || id === "info") return false;
+  // Shell alias / wrap / profile / config writers.
+  if (
+    id.includes("ssh-wrap") ||
+    id.includes("wrap") ||
+    id.includes("profile") ||
+    id.includes("shell") ||
+    id.includes("tmux") ||
+    id.includes("clipboard") ||
+    id.includes("passthrough") ||
+    id.includes("byobu") ||
+    id.includes("config")
+  ) {
+    return true;
+  }
+  // Default: treat as destructive so --yes never fires without a dialog.
+  return true;
+}
+
+/** Validate fix id shape before invoking the CLI (no spaces / flags). */
+export function isValidDoctorFixId(fixId: string): boolean {
+  const t = fixId.trim();
+  if (!t || t.length > 128) return false;
+  // Short handle or dotted canonical id; reject flags / paths / injection.
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(t);
+}
+
+/**
+ * Pure extract of automatic remediation handles from doctor JSON.
+ * Accepts bare CLI blob, host envelope `{ report }`, or a findings array.
+ */
+export function extractFixIds(input: unknown): DoctorFixHandle[] {
+  let findings: unknown[] | null = null;
+
+  if (Array.isArray(input)) {
+    findings = input;
+  } else if (isRecord(input)) {
+    if (Array.isArray(input.findings)) {
+      findings = input.findings;
+    } else if (Array.isArray(input.checks)) {
+      findings = input.checks;
+    } else if (isRecord(input.report)) {
+      if (Array.isArray(input.report.findings)) {
+        findings = input.report.findings;
+      } else if (Array.isArray(input.report.checks)) {
+        findings = input.report.checks;
+      }
+    }
+  }
+
+  if (!findings) return [];
+
+  const seen = new Set<string>();
+  const out: DoctorFixHandle[] = [];
+
+  findings.forEach((raw, index) => {
+    if (!isRecord(raw)) return;
+    // Prefer automaticRemediation; fall back to fixId field some builds emit.
+    const fixId =
+      coerceFixId(raw.automaticRemediation) ?? coerceFixId(raw.fixId);
+    if (!fixId || !isValidDoctorFixId(fixId)) return;
+    const key = fixId.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    const findingId = asString(raw.id) ?? `finding-${index}`;
+    const message = asString(raw.message) ?? undefined;
+    out.push({
+      fixId,
+      findingId,
+      message,
+      destructive: isDestructiveDoctorFix(fixId),
+    });
+  });
+
+  return out;
+}
+
 export function parseFinding(raw: unknown, index: number): CliDoctorCheck | null {
   if (!isRecord(raw)) return null;
   const id = asString(raw.id) ?? `finding-${index}`;
@@ -183,8 +312,10 @@ export function parseFinding(raw: unknown, index: number): CliDoctorCheck | null
   const message = asString(raw.message) ?? id;
   const note = asString(raw.note);
   const remediation = asString(raw.remediation);
-  const auto = asString(raw.automaticRemediation);
-  const detailParts = [note, remediation, auto].filter(Boolean);
+  const fixId =
+    coerceFixId(raw.automaticRemediation) ?? coerceFixId(raw.fixId);
+  const autoLabel = fixId ? `fix: ${fixId}` : asString(raw.automaticRemediation);
+  const detailParts = [note, remediation, autoLabel].filter(Boolean);
   const detail =
     detailParts.length > 0
       ? detailParts.join(" · ")
@@ -197,6 +328,8 @@ export function parseFinding(raw: unknown, index: number): CliDoctorCheck | null
     title: message,
     detail,
     disposition,
+    fixId: fixId && isValidDoctorFixId(fixId) ? fixId : null,
+    destructive: fixId ? isDestructiveDoctorFix(fixId) : undefined,
   };
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7249,6 +7249,71 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   word-break: break-word;
 }
 
+.doctor-check__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.doctor-check__fix-id {
+  font-size: 11px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.doctor-cli-fixes {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-main);
+}
+
+.doctor-cli-fixes__title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.doctor-cli-fixes__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.doctor-cli-fixes__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.doctor-cli-fixes__text {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.doctor-cli-fixes__id {
+  font-size: 12px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.doctor-cli-fixes__msg {
+  font-size: 12px;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
 .doctor-cli-section {
   margin-top: 16px;
   padding-top: 12px;


### PR DESCRIPTION
## Problem
CLI `grok doctor --json` findings can expose `automaticRemediation` handles (e.g. `ssh-wrap` / `terminal.ssh-wrap`), and the CLI already supports `grok doctor fix [ID] --yes`. App Doctor could show those findings (#76) but could not apply them.

## Changes
- **Parse** (`src/lib/cliDoctor.ts`): pure `extractFixIds` / `coerceFixId` / `isValidDoctorFixId` / `isDestructiveDoctorFix`. Findings with `automaticRemediation` (or `fixId`) surface a `fixId` on each CLI doctor row. Fixture unit tests cover string/object handles, host envelope, injection rejection, and dedupe.
- **Backend** (`cli_doctor_fix`): runs probed CLI `doctor fix <id> --yes` with a 30s timeout; validates id shape before spawn; returns redacted/truncated stdout+stderr (never panics on missing CLI / non-zero exit).
- **UI** (`DoctorModal`): on findings with a fix id, show **Apply fix** → in-app confirm for destructive fixes (no `window.confirm`) → invoke fix → re-run Doctor. Fallback list if findings carry fixes but rows lack `fixId`.
- **i18n**: en + zh + zh-TW.

## Depends on
Stacks on **#76** (`cli-doctor-report` — doctor `--json` display). First commit is that work; the fix-apply commit is `c4f0c7c`. If #76 merges first, rebase this branch onto main for a clean single-commit review.

## Test plan
- [x] `pnpm exec tsc -b` (typecheck clean)
- [x] `pnpm exec vitest run src/lib/cliDoctor.test.ts src/i18n/messages.test.ts` (26 tests)
- [x] `cargo test doctor_fix_id_tests` (2 tests)
- [x] `cargo check`
- [ ] Open Doctor with a finding that has `automaticRemediation` → **Apply fix** visible
- [ ] Confirm dialog appears for destructive fix; cancel does nothing
- [ ] Confirm → CLI runs with `--yes` → Doctor re-runs; status/error shown
- [ ] Invalid / missing CLI path surfaces redacted error without crashing Doctor