### PR TITLE
feat: Settings → Keyboard shortcuts (read-only)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1766,6 +1766,7 @@ export default function App() {
           "archived",
           "extensions",
           "runtime",
+          "shortcuts",
           "about",
         ];
         setSettingsSection(
@@ -5155,6 +5156,7 @@ export default function App() {
               "archived",
               "extensions",
               "runtime",
+              "shortcuts",
               "about",
             ];
             trayHandlersRef.current.openSettings(
@@ -5870,7 +5872,10 @@ export default function App() {
       "settings.nav.archived",
       "settings.nav.extensions",
       "settings.nav.runtime",
+      "settings.nav.shortcuts",
       "settings.nav.about",
+      "settings.shortcuts.title",
+      "settings.shortcuts.desc",
       "settings.archived.desc",
       "settings.archived.empty",
       "settings.archived.restore",
@@ -6229,6 +6234,7 @@ export default function App() {
           }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
+          onOpenShortcutsHelp={() => setShowShortcuts(true)}
           versionFooter={tr("app.versionFooter")}
           account={account}
           accountLoading={accountLoading}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -20,6 +20,7 @@ import {
   IconCheck,
   IconDoctor,
   IconInfo,
+  IconKeyboard,
   IconLanguage,
   IconMinimize,
   IconPuzzle,
@@ -29,6 +30,11 @@ import {
   IconTrash,
   IconUser,
 } from "@/components/icons";
+import {
+  detectShortcutPlatform,
+  shortcutsByGroup,
+  type ShortcutGroup,
+} from "@/lib/shortcuts";
 import type { Theme } from "@/lib/theme";
 import type {
   ComposerPrefsScope,
@@ -59,6 +65,7 @@ export type SettingsSectionId =
   | "archived"
   | "extensions"
   | "runtime"
+  | "shortcuts"
   | "about";
 
 export type ArchivedSessionRow = {
@@ -159,6 +166,8 @@ export interface SettingsPageProps {
   projectPath?: string | null;
   /** After skill enable toggle — refresh slash palette in App. */
   onSkillsPrefsChanged?: () => void;
+  /** Open the same shortcuts help modal as ⌘/ / Ctrl+/. */
+  onOpenShortcutsHelp?: () => void;
 }
 
 const NAV: {
@@ -170,6 +179,7 @@ const NAV: {
     | "archive"
     | "extensions"
     | "doctor"
+    | "keyboard"
     | "info";
   labelKey: string;
   group: "personal" | "system";
@@ -185,6 +195,12 @@ const NAV: {
     group: "system",
   },
   { id: "runtime", icon: "doctor", labelKey: "settings.nav.runtime", group: "system" },
+  {
+    id: "shortcuts",
+    icon: "keyboard",
+    labelKey: "settings.nav.shortcuts",
+    group: "system",
+  },
   { id: "about", icon: "info", labelKey: "settings.nav.about", group: "system" },
 ];
 
@@ -198,6 +214,7 @@ function NavIcon({
   if (name === "appearance") return <IconAppearance size={size} />;
   if (name === "user") return <IconUser size={size} />;
   if (name === "archive") return <IconArchive size={size} />;
+  if (name === "keyboard") return <IconKeyboard size={size} />;
   if (name === "extensions") return <IconPuzzle size={size} />;
   if (name === "doctor") return <IconDoctor size={size} />;
   if (name === "info") return <IconInfo size={size} />;
@@ -447,6 +464,7 @@ export function SettingsPage({
   onDeleteArchivedSessions,
   projectPath = null,
   onSkillsPrefsChanged,
+  onOpenShortcutsHelp,
 }: SettingsPageProps) {
   const [query, setQuery] = useState("");
   const [accountTab, setAccountTab] = useState<"official" | "providers">(
@@ -675,7 +693,9 @@ export function SettingsPage({
               ? t("settings.nav.extensions")
               : section === "runtime"
                 ? t("settings.nav.runtime")
-                : t("settings.nav.about");
+                : section === "shortcuts"
+                  ? t("settings.nav.shortcuts")
+                  : t("settings.nav.about");
 
   return (
     <div className="settings-page" data-testid="settings-page">
@@ -1485,6 +1505,13 @@ export function SettingsPage({
           </div>
         )}
 
+        {section === "shortcuts" && (
+          <ShortcutsSettingsPanel
+            t={t}
+            onOpenHelp={onOpenShortcutsHelp}
+          />
+        )}
+
         {section === "about" && (
           <div className="settings-card">
             <div className="settings-row settings-row--stack">
@@ -1501,6 +1528,87 @@ export function SettingsPage({
         )}
       </main>
       </div>
+    </div>
+  );
+}
+
+function ShortcutsSettingsPanel({
+  t,
+  onOpenHelp,
+}: {
+  t: (key: MessageKey, vars?: Vars) => string;
+  onOpenHelp?: () => void;
+}) {
+  const platform = useMemo(() => detectShortcutPlatform(), []);
+  const groups = useMemo(() => shortcutsByGroup(), []);
+
+  const groupLabel = (g: ShortcutGroup) =>
+    t(`settings.shortcuts.group.${g}` as MessageKey);
+
+  return (
+    <div className="settings-card">
+      <div className="settings-row settings-row--stack">
+        <div className="settings-row__text">
+          <div className="settings-row__label">
+            <IconKeyboard size={16} />
+            {t("settings.shortcuts.title")}
+          </div>
+          <div className="settings-row__desc">{t("settings.shortcuts.desc")}</div>
+        </div>
+        {onOpenHelp ? (
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={() => onOpenHelp()}
+          >
+            {t("settings.shortcuts.openHelp")}
+          </button>
+        ) : null}
+      </div>
+      {groups.map(({ group, rows }) => (
+        <div key={group} className="settings-shortcuts-group">
+          <div className="settings-shortcuts-group__title">{groupLabel(group)}</div>
+          <table className="settings-shortcuts-table">
+            <thead>
+              <tr>
+                <th scope="col">{t("settings.shortcuts.colAction")}</th>
+                <th
+                  scope="col"
+                  className={
+                    platform === "mac" ? "is-platform-active" : undefined
+                  }
+                >
+                  {t("settings.shortcuts.colMac")}
+                </th>
+                <th
+                  scope="col"
+                  className={
+                    platform === "win" || platform === "other"
+                      ? "is-platform-active"
+                      : undefined
+                  }
+                >
+                  {t("settings.shortcuts.colWin")}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id}>
+                  <td>{t(row.labelKey as MessageKey)}</td>
+                  <td>
+                    <kbd className="settings-shortcuts-kbd">{row.mac}</kbd>
+                  </td>
+                  <td>
+                    <kbd className="settings-shortcuts-kbd">{row.win}</kbd>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+      <p className="settings-shortcuts-note">{t("settings.shortcuts.note")}</p>
     </div>
   );
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -35,6 +35,7 @@ import {
   IconFolderPlus as TbFolderPlus,
   IconHandStop as TbHandStop,
   IconInfoCircle as TbInfoCircle,
+  IconKeyboard as TbKeyboard,
   IconLanguage as TbLanguage,
   IconExternalLink as TbExternalLink,
   IconLayoutSidebar as TbLayoutSidebar,
@@ -265,6 +266,7 @@ export const IconUser = wrap(TbUser);
 export const IconAppearance = wrap(TbBrush);
 export const IconLanguage = wrap(TbLanguage);
 export const IconInfo = wrap(TbInfoCircle);
+export const IconKeyboard = wrap(TbKeyboard);
 /** Slash palette / goal mode */
 export const IconTarget = wrap(TbTarget);
 export const IconClipboardList = wrap(TbClipboardList);

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -510,7 +510,21 @@ const en = {
   "settings.nav.archived": "Archived chats",
   "settings.nav.extensions": "Extensions",
   "settings.nav.runtime": "CLI / Runtime",
+  "settings.nav.shortcuts": "Keyboard",
   "settings.nav.about": "About",
+  "settings.shortcuts.title": "Keyboard shortcuts",
+  "settings.shortcuts.desc":
+    "Bindings that already work in the app. Read-only for now — remapping comes later.",
+  "settings.shortcuts.colAction": "Action",
+  "settings.shortcuts.colMac": "macOS",
+  "settings.shortcuts.colWin": "Windows / Linux",
+  "settings.shortcuts.group.workbench": "Workbench",
+  "settings.shortcuts.group.navigation": "Navigation",
+  "settings.shortcuts.group.diagnostics": "Diagnostics",
+  "settings.shortcuts.group.input": "Input",
+  "settings.shortcuts.note":
+    "Some chords may be taken by the OS (e.g. input sources). Composer buttons stay available as a fallback.",
+  "settings.shortcuts.openHelp": "Open shortcuts help",
   "settings.archived.desc":
     "Chats you archived are listed by project. Select multiple to restore or delete.",
   "settings.archived.empty": "No archived chats.",
@@ -1723,7 +1737,21 @@ const zh: Record<MessageKey, string> = {
   "settings.nav.archived": "已归档会话",
   "settings.nav.extensions": "扩展",
   "settings.nav.runtime": "CLI / 运行时",
+  "settings.nav.shortcuts": "键盘",
   "settings.nav.about": "关于",
+  "settings.shortcuts.title": "键盘快捷键",
+  "settings.shortcuts.desc":
+    "应用内已生效的绑定。当前为只读列表，自定义改键稍后提供。",
+  "settings.shortcuts.colAction": "操作",
+  "settings.shortcuts.colMac": "macOS",
+  "settings.shortcuts.colWin": "Windows / Linux",
+  "settings.shortcuts.group.workbench": "工作台",
+  "settings.shortcuts.group.navigation": "导航",
+  "settings.shortcuts.group.diagnostics": "诊断",
+  "settings.shortcuts.group.input": "输入",
+  "settings.shortcuts.note":
+    "部分组合键可能被系统占用（如输入法切换）。输入区按钮仍可作为后备。",
+  "settings.shortcuts.openHelp": "打开快捷键帮助",
   "settings.archived.desc":
     "已归档的会话按项目分组。可多选后批量还原或删除。",
   "settings.archived.empty": "暂无已归档会话。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -484,7 +484,21 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.nav.archived": "已封存對話",
   "settings.nav.extensions": "擴充功能",
   "settings.nav.runtime": "CLI / 執行環境",
+  "settings.nav.shortcuts": "鍵盤",
   "settings.nav.about": "關於",
+  "settings.shortcuts.title": "鍵盤快捷鍵",
+  "settings.shortcuts.desc":
+    "應用程式內已生效的綁定。目前為唯讀列表，自訂改鍵稍後提供。",
+  "settings.shortcuts.colAction": "操作",
+  "settings.shortcuts.colMac": "macOS",
+  "settings.shortcuts.colWin": "Windows / Linux",
+  "settings.shortcuts.group.workbench": "工作台",
+  "settings.shortcuts.group.navigation": "導覽",
+  "settings.shortcuts.group.diagnostics": "診斷",
+  "settings.shortcuts.group.input": "輸入",
+  "settings.shortcuts.note":
+    "部分組合鍵可能被系統占用（如輸入法切換）。輸入區按鈕仍可作為後備。",
+  "settings.shortcuts.openHelp": "開啟快捷鍵說明",
   "settings.archived.desc":
     "已封存的對話依專案分組。可多選後批次還原或刪除。",
   "settings.archived.empty": "尚無已封存對話。",

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { SHORTCUTS, shortcutsForPlatform } from "./shortcuts";
+import {
+  SHORTCUTS,
+  shortcutsByGroup,
+  shortcutsForPlatform,
+} from "./shortcuts";
 
 describe("shortcuts catalog", () => {
   it("has stable unique ids", () => {
@@ -7,11 +11,12 @@ describe("shortcuts catalog", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("every row has mac and win bindings", () => {
+  it("every row has mac and win bindings and a group", () => {
     for (const s of SHORTCUTS) {
       expect(s.mac.trim().length).toBeGreaterThan(0);
       expect(s.win.trim().length).toBeGreaterThan(0);
       expect(s.labelKey.startsWith("shortcuts.")).toBe(true);
+      expect(s.group).toBeTruthy();
     }
   });
 
@@ -22,5 +27,11 @@ describe("shortcuts catalog", () => {
     const searchWin = win.find((s) => s.id === "search");
     expect(searchMac?.keys).toContain("⌘");
     expect(searchWin?.keys.toLowerCase()).toContain("ctrl");
+  });
+
+  it("groups for settings panel cover every shortcut once", () => {
+    const grouped = shortcutsByGroup();
+    const flat = grouped.flatMap((g) => g.rows.map((r) => r.id));
+    expect(flat.sort()).toEqual([...SHORTCUTS.map((s) => s.id)].sort());
   });
 });

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,9 +1,12 @@
-/** Keyboard shortcut catalog for the help panel. */
+/** Keyboard shortcut catalog — help panel + Settings → Keyboard. */
+
+export type ShortcutGroup = "workbench" | "navigation" | "diagnostics" | "input";
 
 export type ShortcutRow = {
   id: string;
   /** i18n message key for the action label */
   labelKey: string;
+  group: ShortcutGroup;
   /** Display keys for mac (⌘ is replaced at render time if needed) */
   mac: string;
   /** Display keys for win/linux */
@@ -13,58 +16,97 @@ export type ShortcutRow = {
 /**
  * Shipped shortcuts that already work in the app.
  * Keep this list honest — only document real bindings.
+ * Single source for the help modal and Settings → Keyboard.
  */
 export const SHORTCUTS: ShortcutRow[] = [
   {
     id: "search",
     labelKey: "shortcuts.search",
+    group: "workbench",
     mac: "⌘ K",
     win: "Ctrl K",
   },
   {
     id: "newChat",
     labelKey: "shortcuts.newChat",
+    group: "workbench",
     mac: "⌘ N",
     win: "Ctrl N",
   },
   {
-    id: "settings",
-    labelKey: "shortcuts.settings",
-    mac: "⌘ ,",
-    win: "Ctrl ,",
-  },
-  {
-    id: "doctor",
-    labelKey: "shortcuts.doctor",
-    mac: "⌘ ⇧ D",
-    win: "Ctrl Shift D",
-  },
-  {
-    id: "stop",
-    labelKey: "shortcuts.stop",
-    mac: "Esc",
-    win: "Esc",
-  },
-  {
     id: "send",
     labelKey: "shortcuts.send",
+    group: "workbench",
     mac: "⌘ ↵",
     win: "Ctrl Enter",
   },
   {
+    id: "stop",
+    labelKey: "shortcuts.stop",
+    group: "workbench",
+    mac: "Esc",
+    win: "Esc",
+  },
+  {
+    id: "settings",
+    labelKey: "shortcuts.settings",
+    group: "navigation",
+    mac: "⌘ ,",
+    win: "Ctrl ,",
+  },
+  {
     id: "help",
     labelKey: "shortcuts.help",
+    group: "navigation",
     mac: "⌘ /",
     win: "Ctrl /",
   },
+  {
+    id: "doctor",
+    labelKey: "shortcuts.doctor",
+    group: "diagnostics",
+    mac: "⌘ ⇧ D",
+    win: "Ctrl Shift D",
+  },
+];
+
+/** Group order for Settings → Keyboard (and optional help grouping). */
+export const SHORTCUT_GROUP_ORDER: ShortcutGroup[] = [
+  "workbench",
+  "navigation",
+  "diagnostics",
+  "input",
 ];
 
 export function shortcutsForPlatform(
   platform: "mac" | "win" | "other",
-): Array<{ id: string; labelKey: string; keys: string }> {
+): Array<{ id: string; labelKey: string; keys: string; group: ShortcutGroup }> {
   return SHORTCUTS.map((s) => ({
     id: s.id,
     labelKey: s.labelKey,
+    group: s.group,
     keys: platform === "mac" ? s.mac : s.win,
   }));
+}
+
+/** Detect host OS for highlighting the active column in Settings. */
+export function detectShortcutPlatform(): "mac" | "win" | "other" {
+  if (typeof navigator === "undefined") return "other";
+  const ua = navigator.userAgent || "";
+  const p = navigator.platform || "";
+  if (/Mac|iPhone|iPad|iPod/i.test(p) || /Mac OS X|Macintosh/i.test(ua)) {
+    return "mac";
+  }
+  if (/Win/i.test(p) || /Windows/i.test(ua)) return "win";
+  return "other";
+}
+
+export function shortcutsByGroup(): Array<{
+  group: ShortcutGroup;
+  rows: ShortcutRow[];
+}> {
+  return SHORTCUT_GROUP_ORDER.map((group) => ({
+    group,
+    rows: SHORTCUTS.filter((s) => s.group === group),
+  })).filter((g) => g.rows.length > 0);
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3489,6 +3489,75 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   align-items: stretch;
 }
 
+/* Settings → Keyboard (read-only shortcut catalog) */
+.settings-shortcuts-group {
+  padding: 8px 16px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settings-shortcuts-group:last-of-type {
+  border-bottom: none;
+}
+
+.settings-shortcuts-group__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 8px 0 10px;
+}
+
+.settings-shortcuts-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.settings-shortcuts-table th,
+.settings-shortcuts-table td {
+  text-align: left;
+  padding: 8px 10px 8px 0;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+}
+
+.settings-shortcuts-table th {
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+}
+
+.settings-shortcuts-table th.is-platform-active {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.settings-shortcuts-table tr:last-child td {
+  border-bottom: none;
+}
+
+.settings-shortcuts-kbd {
+  display: inline-block;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  padding: 2px 7px;
+  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated, var(--bg-input));
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.settings-shortcuts-note {
+  margin: 0;
+  padding: 12px 16px 16px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+}
+
 .settings-row__text {
   min-width: 0;
   flex: 1;


### PR DESCRIPTION
## Summary
Settings gains a **Keyboard** section so users can find app shortcuts without remembering ⌘/ / Ctrl+/.

## What
- Nav: **Settings → Keyboard** (`#/settings/shortcuts`)
- Read-only table grouped by workbench / navigation / diagnostics
- Columns: Action · macOS · Windows/Linux (active OS column highlighted)
- Same data source as the help modal (`src/lib/shortcuts.ts`)
- “Open shortcuts help” opens the existing help overlay
- Note about OS-level chord conflicts
- en / zh / zh-TW

## Not in this PR
- Remapping / custom key chords (phase 2)
- Voice row (lands with voice PR when that merges; catalog is the single source)

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/lib/shortcuts.test.ts src/i18n/messages.test.ts`
- [ ] Open Settings → Keyboard → list matches help modal
- [ ] Hash `#/settings/shortcuts` opens the section
- [ ] “Open shortcuts help” shows the overlay