### PR TITLE
fix(session-title): auto-title zh-TW/zh-CN sessions and honor manual CLI path

### DIFF
--- a/src-tauri/src/session_title.rs
+++ b/src-tauri/src/session_title.rs
@@ -13,6 +13,8 @@ use crate::tray_i18n::{self, Locale};
 const PLACEHOLDERS: &[&str] = &[
     "New chat",
     "新会话",
+    "新对话",
+    "新對話",
     "Untitled",
     "未命名",
     "New conversation",
@@ -90,7 +92,9 @@ fn title_prompt(snippet: &str, locale: Locale) -> String {
 
 /// Call Grok CLI headless with low effort.
 fn llm_title_via_cli(message: &str) -> Option<String> {
-    let probe = cli_probe::probe_cli(None);
+    // Same settings path as other CLI call sites (doctor, session spawn, etc.).
+    let settings = store::load_settings();
+    let probe = cli_probe::probe_cli(settings.manual_cli_path.as_deref());
     let path = probe.path?;
     let snippet: String = message.chars().take(400).collect();
     let prompt = title_prompt(&snippet, tray_i18n::app_locale());
@@ -192,8 +196,11 @@ mod tests {
     #[test]
     fn placeholders() {
         assert!(is_placeholder_title("新会话"));
+        assert!(is_placeholder_title("新对话"));
+        assert!(is_placeholder_title("新對話"));
         assert!(is_placeholder_title("New chat"));
         assert!(!is_placeholder_title("修权限条 bug"));
+        assert!(!is_placeholder_title("馬斯克最近有發什麼貼文"));
     }
 
     #[test]
@@ -228,7 +235,15 @@ mod tests {
 
         let zh = title_prompt("list open prs", Locale::Zh);
         assert!(zh.contains("用户消息："));
+        assert!(zh.contains("为下面这条用户消息"));
         assert!(zh.contains("list open prs"));
         assert!(!zh.contains("User message:"));
+
+        let zhtw = title_prompt("list open prs", Locale::ZhTw);
+        assert!(zhtw.contains("為下面這則使用者訊息"));
+        assert!(zhtw.contains("使用者訊息："));
+        assert!(zhtw.contains("list open prs"));
+        assert!(!zhtw.contains("为下面这条用户消息"));
+        assert!(!zhtw.contains("User message:"));
     }
 }


### PR DESCRIPTION
# fix(session-title): auto-title zh-TW / zh-CN sessions and honor the manual CLI path

## Summary

Two small, independent bugs in `src-tauri/src/session_title.rs` prevent
Chinese-locale sessions from ever being auto-titled, and cause background
title refinement to ignore a user-configured CLI path. Both are fixed here,
with unit-test coverage.

## Bug 1 — Chinese default titles are never recognized as placeholders

`PLACEHOLDERS` is the allow-list of "still a default title" strings.
`is_placeholder_title()` uses it to decide whether a session may be
auto-titled from its first message (an existing, user-chosen title is never
overwritten).

The list included the English defaults and `"新会话"`, but was **missing**
the two default titles that new Simplified / Traditional sessions actually
get: `"新对话"` (Simplified) and `"新對話"` (Traditional). As a result those
sessions looked "already named" and were never auto-titled — the exact users
who most benefit from auto-titling.

```rust
const PLACEHOLDERS: &[&str] = &[
    "New chat",
    "新会话",
    "新对话",   // added (Simplified "new conversation")
    "新對話",   // added (Traditional "new conversation")
    "Untitled",
    "未命名",
    "New conversation",
    "新建会话",
];
```

## Bug 2 — background title refine discards the manual CLI path

`llm_title_via_cli()` located the CLI with `cli_probe::probe_cli(None)`,
throwing away `settings.manual_cli_path`. Every other call site
(doctor, session spawn, etc.) passes that path. For users who rely on a
manually configured CLI path, background title refinement silently found no
CLI and fell back to the offline heuristic only.

The fix mirrors the other call sites:

```rust
let settings = store::load_settings();
let probe = cli_probe::probe_cli(settings.manual_cli_path.as_deref());
```

## Tests

Extends the existing `tests` module in the same file:

- `placeholders()` now asserts `"新对话"` and `"新對話"` are placeholders, and
  adds a Traditional-Chinese negative case (`"馬斯克最近有發什麼貼文"`) so a real
  Traditional message is not mistaken for a placeholder.
- `title_prompt_follows_locale()` now also checks the Traditional (`Locale::ZhTw`)
  prompt: it uses the Traditional wording and does not leak the Simplified or
  English prompt text.

## Verification

On this branch, in `src-tauri/`:

```text
$ cargo check
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 58.01s
# 0 unreachable-pattern warnings

$ cargo test session_title
running 5 tests
test session_title::tests::clean_strips_english_title_prefix ... ok
test session_title::tests::clean_strips_quotes ... ok
test session_title::tests::placeholders ... ok
test session_title::tests::heuristic_uses_first_line ... ok
test session_title::tests::title_prompt_follows_locale ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 272 filtered out
```

The change is confined to `src-tauri/src/session_title.rs` (Rust side only);
the emit path is left exactly as upstream (`app.emit(...)`).

---

## 中文摘要

修复 `src-tauri/src/session_title.rs` 中两个互相独立的小问题：

1. **中文默认标题未被识别为占位标题。** `PLACEHOLDERS` 列表缺少简体
   `"新对话"` 和繁体 `"新對話"` 这两个新会话的默认标题，导致这些会话被当作
   "用户已命名"，永远不会根据首条消息自动生成标题。现已补上这两个默认标题。

2. **后台标题精修忽略了手动配置的 CLI 路径。** `llm_title_via_cli()` 调用
   `probe_cli(None)`，丢弃了 `settings.manual_cli_path`；而其他调用点都会传入该
   路径。对依赖手动 CLI 路径的用户，后台精修因此找不到 CLI。现已与其他调用点
   保持一致，读取设置并传入该路径。

同时补充了单元测试：新增占位标题断言（含一个繁体中文的反例），以及繁体
（`Locale::ZhTw`）标题提示词的测试。改动仅限 Rust 端的该文件，事件发送方式
保持与上游一致（`app.emit(...)`）。
