### PR TITLE
fix(i18n): accept case/alias variants of locale ids in resolveLocale

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -34,7 +34,29 @@ export function createT(locale: Locale) {
   return (key: MessageKey, vars?: Vars) => t(locale, key, vars);
 }
 
+/**
+ * Best-effort normalization of a raw locale id to a canonical {@link Locale}.
+ * Accepts common case/alias variants (e.g. "zh-tw", "zh_Hant", "EN-US") so a
+ * hand-edited settings value still resolves. Returns `null` when the id is not
+ * a recognizable variant, leaving the fallback to the caller. Mirrors the
+ * case-insensitive parsing on the Rust side (see tray_i18n.rs `Locale::parse`).
+ */
+function normalizeLocale(raw: string): Locale | null {
+  const v = raw.trim().toLowerCase();
+  if (v === "zh-tw" || v === "zh_tw" || v === "zh-hant" || v === "zh_hant") {
+    return "zh-TW";
+  }
+  if (v === "zh" || v === "zh-cn" || v === "zh_cn" || v === "zh-hans") {
+    return "zh";
+  }
+  if (v === "en" || v === "en-us" || v === "en_us" || v === "en-gb") {
+    return "en";
+  }
+  return null;
+}
+
 export function resolveLocale(raw: string | undefined | null): Locale {
-  if (raw && isLocale(raw)) return raw;
-  return "en";
+  if (!raw) return "en";
+  if (isLocale(raw)) return raw;
+  return normalizeLocale(raw) ?? "en";
 }

--- a/src/i18n/messages.test.ts
+++ b/src/i18n/messages.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { createT, messages, t, type MessageKey } from "./index";
+import {
+  createT,
+  messages,
+  resolveLocale,
+  t,
+  type MessageKey,
+} from "./index";
 
 describe("i18n catalog", () => {
   it("en and zh share the same keys", () => {
@@ -37,5 +43,33 @@ describe("i18n catalog", () => {
   it("type surface accepts known keys only", () => {
     const key: MessageKey = "composer.send";
     expect(t("en", key)).toBeTruthy();
+  });
+});
+
+describe("resolveLocale", () => {
+  it("keeps canonical ids unchanged", () => {
+    expect(resolveLocale("zh-TW")).toBe("zh-TW");
+    expect(resolveLocale("zh")).toBe("zh");
+    expect(resolveLocale("en")).toBe("en");
+  });
+
+  it("accepts case/alias variants of Traditional Chinese", () => {
+    expect(resolveLocale("zh-tw")).toBe("zh-TW");
+    expect(resolveLocale("zh_TW")).toBe("zh-TW");
+    expect(resolveLocale("zh-Hant")).toBe("zh-TW");
+    expect(resolveLocale(" ZH-HANT ")).toBe("zh-TW");
+  });
+
+  it("accepts case/alias variants of Simplified Chinese and English", () => {
+    expect(resolveLocale("ZH")).toBe("zh");
+    expect(resolveLocale("zh-CN")).toBe("zh");
+    expect(resolveLocale("EN-US")).toBe("en");
+  });
+
+  it("falls back to the product default for unknown or empty ids", () => {
+    expect(resolveLocale("fr")).toBe("en");
+    expect(resolveLocale("")).toBe("en");
+    expect(resolveLocale(undefined)).toBe("en");
+    expect(resolveLocale(null)).toBe("en");
   });
 });


### PR DESCRIPTION
## Summary

`resolveLocale()` in `src/i18n/index.ts` used the `isLocale` type guard, which
does an **exact** string comparison (`v === "zh" || v === "zh-TW" || v === "en"`).
Any locale id that is correctly spelled but differently cased or aliased — for
example a `settings.json` hand-edited to `"zh-tw"`, or a value like `"zh_Hant"`
or `"EN-US"` — fails that check and silently falls back to the product default,
so the whole web UI renders in the wrong language.

The Rust side already tolerates these variants: `src-tauri/src/tray_i18n.rs`
`Locale::parse` lowercases the input and accepts `zh-tw | zh_tw | zh-hant |
zh_hant` (and `en | en-us | en_us | en-gb`). That makes the behavior asymmetric:
the native tray menu and auto-generated session titles come out Traditional,
while the web UI stays on the fallback locale for the exact same stored value.

## Cause

- `isLocale(v)` is an exact equality check, by design (it is a TypeScript type
  guard for the `Locale` union).
- `resolveLocale` relied on that guard alone, with no normalization, so only the
  three canonical spellings survived.

## Fix

Add a small `normalizeLocale(raw)` helper and call it as a second step inside
`resolveLocale`:

1. Try `isLocale(raw)` first — canonical values keep their fast path and the
   type guard stays an honest exact check (unchanged).
2. Otherwise `normalizeLocale` lowercases/trims and maps the same reasonable
   variants the Rust side accepts to the canonical `Locale` union value
   (`zh-tw | zh_tw | zh-hant | zh_hant → "zh-TW"`, `zh | zh-cn | zh_cn | zh-hans
   → "zh"`, `en | en-us | en_us | en-gb → "en"`).
3. Anything unrecognized still falls back to the existing default.

This does **not** change the canonical value the settings UI writes; it only
makes reading a locale id more forgiving, and brings the frontend in line with
the existing Rust parsing.

## Tests

Extends `src/i18n/messages.test.ts` with a `resolveLocale` block covering:

- canonical ids unchanged (`"zh-TW"`, `"zh"`, `"en"`)
- Traditional variants: `"zh-tw"`, `"zh_TW"`, `"zh-Hant"`, whitespace/upper-case
- Simplified/English aliases: `"ZH"`, `"zh-CN"`, `"EN-US"`
- unknown / empty / `undefined` / `null` → fallback default

### Verification

```text
$ pnpm typecheck
> tsc -b --pretty false
# exit 0

$ pnpm test
 ✓ src/i18n/messages.test.ts (10 tests)
 Test Files  57 passed (57)
      Tests  551 passed (551)
```

Change is confined to `src/i18n/index.ts` and `src/i18n/messages.test.ts`.

---

## 中文摘要

`src/i18n/index.ts` 的 `resolveLocale()` 通过 `isLocale` 做**精确**字符串匹配
（`v === "zh" || v === "zh-TW" || v === "en"`）。当 `settings.json` 中的语言 id
拼写正确但大小写或别名不同（例如手动改成 `"zh-tw"`，或 `"zh_Hant"`、`"EN-US"`）时，
匹配失败并静默回退到默认语言，导致整个界面显示成错误的语言。而 Rust 端
（`src-tauri/src/tray_i18n.rs` 的 `Locale::parse`）已经不区分大小写地接受
`zh-tw / zh_tw / zh-hant / zh_hant`，造成前后端行为不一致：托盘菜单和自动标题
是繁体，网页 UI 却停在回退语言。本 PR 在 `resolveLocale` 中新增一个
`normalizeLocale` 步骤，把这些合理的大小写/别名变体归一化到规范的 `Locale` 取值，
与 Rust 端保持一致；`isLocale` 仍是精确类型守卫，设置界面写入的规范值也不变。
并补充了相应的 vitest 单元测试。
