### PR TITLE
feat: active agent tasks panel from live tool stream

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,12 @@ import {
   mergePlanFromEvent,
   type SessionPlanState,
 } from "@/lib/planSession";
+import { AgentTasksPanel } from "@/components/AgentTasksPanel";
 import * as api from "@/lib/api";
+import {
+  collectSessionTasks,
+  countRunningTasks,
+} from "@/lib/sessionTasks";
 import { createT, resolveLocale, type Locale } from "@/i18n";
 import {
   DEFAULT_EFFORT,
@@ -239,6 +244,7 @@ import {
   IconRewind,
   IconShield,
   IconCheck,
+  IconList,
 } from "@/components/icons";
 import { AutomationsPage } from "@/components/AutomationsPage";
 import { OpenLocationButton } from "@/components/OpenLocationButton";
@@ -775,6 +781,7 @@ export default function App() {
   const [agentCatalog, setAgentCatalog] = useState<
     Array<{ name: string; source: string }>
   >([]);
+  const [tasksPanelOpen, setTasksPanelOpen] = useState(false);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -5223,6 +5230,15 @@ export default function App() {
     [contextUsage, messages],
   );
 
+  const sessionTasks = useMemo(
+    () => collectSessionTasks(messages),
+    [messages],
+  );
+  const runningTaskCount = useMemo(
+    () => countRunningTasks(sessionTasks),
+    [sessionTasks],
+  );
+
   /**
    * New empty draft only: lift composer and SuperGrok brand.
    * Existing sessions (even with empty journal) must not look like a fresh chat.
@@ -7740,6 +7756,37 @@ export default function App() {
                   }}
                 />
               )}
+              {mainPane === "chat" && session.sessionId ? (
+                <Tip
+                  label={
+                    tasksPanelOpen
+                      ? tr("tasks.hidePanel")
+                      : tr("tasks.showPanel")
+                  }
+                >
+                  <button
+                    type="button"
+                    className={
+                      "chrome-btn main__pane-toggle" +
+                      (tasksPanelOpen ? " is-on" : "")
+                    }
+                    onClick={() => setTasksPanelOpen((v) => !v)}
+                    aria-pressed={tasksPanelOpen}
+                    aria-label={
+                      tasksPanelOpen
+                        ? tr("tasks.hidePanel")
+                        : tr("tasks.showPanel")
+                    }
+                  >
+                    <IconList size={16} />
+                    {runningTaskCount > 0 ? (
+                      <span className="rp-chrome__badge" aria-hidden>
+                        {Math.min(99, runningTaskCount)}
+                      </span>
+                    ) : null}
+                  </button>
+                </Tip>
+              ) : null}
               <Tip
                 label={
                   layout.asideCollapsed
@@ -7885,6 +7932,14 @@ export default function App() {
               onOpenDetails={() => openPlanInResource()}
             />
           )}
+
+          {mainPane === "chat" && tasksPanelOpen && session.sessionId ? (
+            <AgentTasksPanel
+              messages={messages}
+              t={(k, vars) => tr(k, vars)}
+              onClose={() => setTasksPanelOpen(false)}
+            />
+          ) : null}
 
           {/* Pre-turn / host errors: T04 deck (problem · cause · primary · secondary) */}
           {errorBanner && !hasChatTurnError && (

--- a/src/components/AgentTasksPanel.tsx
+++ b/src/components/AgentTasksPanel.tsx
@@ -1,0 +1,190 @@
+/**
+ * Session agent tasks — active + recent tool steps from the live transcript.
+ * No separate ACP task API; derived via collectSessionTasks.
+ */
+
+import { useMemo, useState } from "react";
+import type { MessageKey } from "@/i18n";
+import type { ChatMessage } from "@/lib/session";
+import {
+  collectSessionTasks,
+  countRunningTasks,
+  filterSessionTasks,
+  taskStatusMessageKey,
+  type AgentTask,
+} from "@/lib/sessionTasks";
+import { IconClose, IconList } from "@/components/icons";
+
+type TFn = (key: MessageKey, vars?: Record<string, string | number>) => string;
+
+export type AgentTasksPanelProps = {
+  messages: ChatMessage[];
+  t: TFn;
+  onClose?: () => void;
+  /** Bump to force re-derive (optional; messages already drive updates). */
+  refreshKey?: number;
+};
+
+function TaskRow({
+  task,
+  t,
+}: {
+  task: AgentTask;
+  t: TFn;
+}) {
+  const [open, setOpen] = useState(false);
+  const statusKey = taskStatusMessageKey(task.status);
+  return (
+    <li
+      className={
+        "agent-tasks__row" +
+        (task.status === "running" ? " is-running" : "") +
+        (task.longRunning ? " is-long" : "")
+      }
+    >
+      <button
+        type="button"
+        className="agent-tasks__row-main"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-label={open ? t("tasks.collapse") : t("tasks.expand")}
+      >
+        <span
+          className={`agent-tasks__dot agent-tasks__dot--${task.status}`}
+          aria-hidden
+        />
+        <span className="agent-tasks__name" title={task.name}>
+          {task.name}
+        </span>
+        <span className="agent-tasks__status">{t(statusKey)}</span>
+      </button>
+      {open ? (
+        <div className="agent-tasks__detail">
+          {task.kind ? (
+            <div className="agent-tasks__meta">
+              <span className="agent-tasks__meta-k">{t("tasks.kind")}</span>
+              <code className="agent-tasks__meta-v">{task.kind}</code>
+            </div>
+          ) : null}
+          {task.detail ? (
+            <div className="agent-tasks__meta">
+              <span className="agent-tasks__meta-k">{t("tasks.detail")}</span>
+              <span className="agent-tasks__meta-v" title={task.detail}>
+                {task.detail}
+              </span>
+            </div>
+          ) : null}
+          {task.path ? (
+            <div className="agent-tasks__meta">
+              <span className="agent-tasks__meta-k">{t("tasks.path")}</span>
+              <code className="agent-tasks__meta-v" title={task.path}>
+                {task.path}
+              </code>
+            </div>
+          ) : null}
+          <div className="agent-tasks__meta">
+            <span className="agent-tasks__meta-k">{t("tasks.id")}</span>
+            <code className="agent-tasks__meta-v">{task.id}</code>
+          </div>
+          {task.longRunning ? (
+            <p className="agent-tasks__hint">{t("tasks.longRunning")}</p>
+          ) : null}
+          {task.status === "running" ? (
+            <p className="agent-tasks__hint">{t("tasks.noKill")}</p>
+          ) : null}
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+export function AgentTasksPanel({
+  messages,
+  t,
+  onClose,
+}: AgentTasksPanelProps) {
+  const [query, setQuery] = useState("");
+  const tasks = useMemo(() => collectSessionTasks(messages), [messages]);
+  const filtered = useMemo(
+    () => filterSessionTasks(tasks, query),
+    [tasks, query],
+  );
+  const running = useMemo(() => countRunningTasks(filtered), [filtered]);
+  const active = filtered.filter((x) => x.status === "running");
+  const recent = filtered.filter((x) => x.status !== "running");
+
+  return (
+    <section className="agent-tasks" aria-label={t("tasks.title")}>
+      <header className="agent-tasks__head">
+        <div className="agent-tasks__title-row">
+          <IconList size={15} />
+          <h2 className="agent-tasks__title">{t("tasks.title")}</h2>
+          {running > 0 ? (
+            <span className="agent-tasks__badge">
+              {t("tasks.runningCount", { n: running })}
+            </span>
+          ) : null}
+        </div>
+        <div className="agent-tasks__head-actions">
+          {onClose ? (
+            <button
+              type="button"
+              className="chrome-btn"
+              title={t("tasks.hidePanel")}
+              aria-label={t("tasks.hidePanel")}
+              onClick={onClose}
+            >
+              <IconClose size={14} />
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="agent-tasks__search">
+        <input
+          type="search"
+          className="settings-input agent-tasks__search-input"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t("tasks.searchPlaceholder")}
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="agent-tasks__empty">
+          <p className="agent-tasks__empty-title">{t("tasks.empty")}</p>
+          <p className="agent-tasks__empty-hint">{t("tasks.emptyHint")}</p>
+        </div>
+      ) : (
+        <div className="agent-tasks__body">
+          {active.length > 0 ? (
+            <div className="agent-tasks__section">
+              <h3 className="agent-tasks__section-title">
+                {t("tasks.section.active")}
+              </h3>
+              <ul className="agent-tasks__list">
+                {active.map((task) => (
+                  <TaskRow key={task.id} task={task} t={t} />
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {recent.length > 0 ? (
+            <div className="agent-tasks__section">
+              <h3 className="agent-tasks__section-title">
+                {t("tasks.section.recent")}
+              </h3>
+              <ul className="agent-tasks__list">
+                {recent.map((task) => (
+                  <TaskRow key={task.id} task={task} t={t} />
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -331,7 +331,8 @@ const en = {
   "tasks.noKill": "Per-tool kill is not available over ACP — stop the turn to cancel work.",
   "tasks.expand": "Show details",
   "tasks.collapse": "Hide details",
-  "media.loadError": "Could not load this media in the app preview.",
+    "tasks.searchPlaceholder": "Filter tasks…",
+"media.loadError": "Could not load this media in the app preview.",
   "media.openExternal": "Open with system player",
   "media.loading": "Loading media…",
 
@@ -2023,7 +2024,8 @@ const zh: Record<MessageKey, string> = {
   "tasks.noKill": "ACP 不支持按工具终止 — 如需取消请停止本轮。",
   "tasks.expand": "展开详情",
   "tasks.collapse": "收起详情",
-  "media.loadError": "应用内无法加载此媒体。",
+    "tasks.searchPlaceholder": "筛选任务…",
+"media.loadError": "应用内无法加载此媒体。",
   "media.openExternal": "用系统播放器打开",
   "media.loading": "正在加载媒体…",
 

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -315,7 +315,8 @@ export const zhTW: Record<MessageKey, string> = {
   "tasks.noKill": "ACP 不支援依工具終止 — 如需取消請停止本輪。",
   "tasks.expand": "展開詳情",
   "tasks.collapse": "收合詳情",
-  "media.loadError": "應用程式內無法載入此媒體。",
+    "tasks.searchPlaceholder": "篩選任務…",
+"media.loadError": "應用程式內無法載入此媒體。",
   "media.openExternal": "以系統播放器開啟",
   "media.loading": "正在載入媒體…",
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -13955,3 +13955,156 @@ html[data-theme="light"] .rim-sidebar {
   }
 }
 
+/* ── Agent tasks panel (session tool stream) ── */
+.agent-tasks {
+  border-bottom: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.18));
+  background: var(--bg-elevated, var(--bg-panel, transparent));
+  max-height: min(42vh, 360px);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.agent-tasks__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px 4px;
+}
+.agent-tasks__title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.agent-tasks__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+.agent-tasks__badge {
+  font-size: 11px;
+  opacity: 0.75;
+  white-space: nowrap;
+}
+.agent-tasks__head-actions {
+  display: flex;
+  gap: 4px;
+}
+.agent-tasks__search {
+  padding: 4px 12px 8px;
+}
+.agent-tasks__search-input {
+  width: 100%;
+}
+.agent-tasks__body {
+  overflow: auto;
+  padding: 0 8px 10px;
+  min-height: 0;
+}
+.agent-tasks__section-title {
+  margin: 8px 4px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.65;
+}
+.agent-tasks__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.agent-tasks__row {
+  border-radius: 8px;
+  margin: 2px 0;
+}
+.agent-tasks__row.is-running {
+  background: color-mix(in srgb, var(--accent, #5b8def) 10%, transparent);
+}
+.agent-tasks__row-main {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  padding: 7px 8px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.agent-tasks__row-main:hover {
+  background: var(--hover-bg, rgba(127, 127, 127, 0.1));
+}
+.agent-tasks__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--muted, #888);
+}
+.agent-tasks__dot--running {
+  background: var(--accent, #5b8def);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #5b8def) 28%, transparent);
+}
+.agent-tasks__dot--failed {
+  background: var(--danger, #e35d5d);
+}
+.agent-tasks__dot--completed {
+  background: var(--ok, #3daa6d);
+}
+.agent-tasks__dot--cancelled {
+  background: var(--muted, #888);
+}
+.agent-tasks__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+.agent-tasks__status {
+  font-size: 11px;
+  opacity: 0.7;
+  white-space: nowrap;
+}
+.agent-tasks__detail {
+  padding: 0 10px 8px 26px;
+  font-size: 12px;
+}
+.agent-tasks__meta {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: 6px;
+  margin: 2px 0;
+}
+.agent-tasks__meta-k {
+  opacity: 0.6;
+}
+.agent-tasks__meta-v {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+}
+.agent-tasks__hint {
+  margin: 6px 0 0;
+  opacity: 0.65;
+  font-size: 11px;
+}
+.agent-tasks__empty {
+  padding: 12px 14px 16px;
+}
+.agent-tasks__empty-title {
+  margin: 0 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+}
+.agent-tasks__empty-hint {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.7;
+  line-height: 1.45;
+}


### PR DESCRIPTION
## Problem
When agents spawn subagents, shell jobs, or monitors, the only signal in the App was buried tool rows in the transcript. There was no dedicated place to scan active/recent work for the current turn.

## Changes
- New **Tasks** panel driven by `collectSessionTasks` over live + journal `tool_step` messages
- Top-bar toggle (list icon) with a badge for running tools
- Active / recent sections, filter box, expand for kind / detail / path / call id
- Honest note that per-tool kill is not available over ACP (stop the turn instead)
- en / zh / zh-TW for the search placeholder; other task strings already existed

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec vitest run src/lib/sessionTasks.test.ts src/i18n/messages.test.ts`
- [ ] Open a chat, run a turn with tools → Tasks toggle shows a running badge
- [ ] Panel lists active then recent tools; filter narrows rows
- [ ] Expand a row shows kind / detail when present
- [ ] Close panel from header; reopen from the top bar