### PR TITLE
feat: surface permission rules editor in Settings

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -52,6 +52,7 @@ import { AccountPanel } from "@/components/AccountPanel";
 import { ProvidersPanel } from "@/components/ProvidersPanel";
 import { ExtensionsPanel } from "@/components/ExtensionsPanel";
 import { ProjectInspectPanel } from "@/components/ProjectInspectPanel";
+import { PermissionRulesPanel } from "@/components/PermissionRulesPanel";
 import { RemoteImLayout } from "@/components/RemoteImLayout";
 import {
   createT,
@@ -951,6 +952,7 @@ export function SettingsPage({
                   />
                 </div>
               ) : null}
+              <PermissionRulesPanel t={t} />
             </div>
 
             <h2 className="settings-page__h2">{t("settings.section.general")}</h2>


### PR DESCRIPTION
## Problem
Permission allow/deny/ask rule editing lived in a finished panel component, but Settings never mounted it. Backend/config helpers were already on main.

## Changes
- Mount `PermissionRulesPanel` under **Settings → Permissions** (below the default policy / sandbox controls)
- No `window.confirm` — the panel already uses in-app modals for remove

## Test plan
- [x] `pnpm exec tsc --noEmit` (local)
- [ ] Open Settings → Permissions → rules list loads from agent config.toml
- [ ] Add allow/deny/ask rule → persists
- [ ] Remove rule confirms in-app and updates the list