### PR TITLE
feat: managed configuration setup from Settings → Runtime

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -61,6 +61,7 @@ import { AccountPanel } from "@/components/AccountPanel";
 import { ProvidersPanel } from "@/components/ProvidersPanel";
 import { ExtensionsPanel } from "@/components/ExtensionsPanel";
 import { ProjectInspectPanel } from "@/components/ProjectInspectPanel";
+import { ManagedSetupPanel } from "@/components/ManagedSetupPanel";
 import { RemoteImLayout } from "@/components/RemoteImLayout";
 import {
   createT,
@@ -1801,6 +1802,13 @@ export function SettingsPage({
                 locale={resolveLocale(locale)}
                 projectPath={projectPath}
                 cliFound={cliInfo.found}
+              />
+            </div>
+            <div className="settings-card settings-card--nested pi-settings-block">
+              <ManagedSetupPanel
+                locale={resolveLocale(locale)}
+                cliFound={cliInfo.found}
+                onOpenAccount={() => onSection("account")}
               />
             </div>
           </div>


### PR DESCRIPTION
## Problem
`ManagedSetupPanel` (preview/install via `grok setup`) was implemented but never linked from Settings, so teams still had to run managed setup in a terminal.

## Changes
- Mount `ManagedSetupPanel` under **Settings → Runtime** next to Project inspect
- Account deep-link for auth errors (`onOpenAccount`)

## Test plan
- [x] Panel mounts without type errors
- [ ] Settings → Runtime → Managed setup → Preview with CLI present
- [ ] Install confirms in-app (GlassModal) before writing
- [ ] Missing CLI shows the existing runtime/CLI guidance path