### PR TITLE
feat: show max agent turns control in Settings

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -469,6 +469,8 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  maxAgentTurns = 0,
+  onMaxAgentTurns,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -953,7 +955,42 @@ export function SettingsPage({
               ) : null}
             </div>
 
-            <h2 className="settings-page__h2">{t("settings.section.general")}</h2>
+                        <h2 className="settings-page__h2">{t("settings.section.agent")}</h2>
+            <div className="settings-card" id="settings-agent-card">
+              {onMaxAgentTurns ? (
+                <div className="settings-row settings-row--stack">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.maxAgentTurns")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.maxAgentTurnsDesc")}
+                    </div>
+                  </div>
+                  <input
+                    className="settings-input"
+                    type="number"
+                    min={0}
+                    max={200}
+                    step={1}
+                    placeholder={t("settings.maxAgentTurnsPlaceholder")}
+                    value={maxAgentTurns > 0 ? maxAgentTurns : ""}
+                    onChange={(e) => {
+                      const raw = e.target.value.trim();
+                      if (!raw) {
+                        onMaxAgentTurns(0);
+                        return;
+                      }
+                      const n = Number(raw);
+                      if (!Number.isFinite(n)) return;
+                      onMaxAgentTurns(Math.min(200, Math.max(0, Math.round(n))));
+                    }}
+                  />
+                </div>
+              ) : null}
+            </div>
+
+<h2 className="settings-page__h2">{t("settings.section.general")}</h2>
             <div className="settings-card">
               <div className="settings-row">
                 <div className="settings-row__text">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -699,7 +699,8 @@ const en = {
   "settings.disableWebSearch": "Disable web search & fetch",
   "settings.disableWebSearchDesc":
     "Spawn agents with --disable-web-search so web_search and web_fetch tools are unavailable. Live agents soft-respawn when this changes.",
-  "settings.prefsScope": "Remember model & permission at",
+    "settings.section.agent": "Agent",
+"settings.prefsScope": "Remember model & permission at",
   "settings.prefsScopeDesc":
     "Global: all chats. Project: each workspace. Session: only the current chat.",
   "settings.prefsScope.global": "Global (app-wide)",
@@ -2348,7 +2349,8 @@ const zh: Record<MessageKey, string> = {
   "settings.disableWebSearch": "禁用网页搜索与抓取",
   "settings.disableWebSearchDesc":
     "启动 Agent 时加上 --disable-web-search，移除 web_search / web_fetch 工具。更改后会 soft-respawn 已连接的 Agent。",
-  "settings.prefsScope": "模型与权限记忆范围",
+    "settings.section.agent": "Agent",
+"settings.prefsScope": "模型与权限记忆范围",
   "settings.prefsScopeDesc":
     "全局：所有对话共用。项目：按工作区记忆。会话：仅当前聊天。",
   "settings.prefsScope.global": "全局（应用级）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -670,7 +670,8 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.disableWebSearch": "停用網頁搜尋與抓取",
   "settings.disableWebSearchDesc":
     "啟動 Agent 時加上 --disable-web-search，移除 web_search / web_fetch 工具。變更後會 soft-respawn 已連線的 Agent。",
-  "settings.prefsScope": "模型與權限記憶範圍",
+    "settings.section.agent": "Agent",
+"settings.prefsScope": "模型與權限記憶範圍",
   "settings.prefsScopeDesc":
     "全域：所有對話共用。專案：依工作區記憶。對話：僅目前聊天。",
   "settings.prefsScope.global": "全域（應用程式層級）",


### PR DESCRIPTION
## Problem
`maxAgentTurns` was already stored and passed into agent spawn (`--max-turns`), and App already threaded the value into Settings props — but Settings never rendered a control.

## Changes
- **Settings → Agent** section with a numeric max-turns field (0 / empty = CLI default)
- i18n key `settings.section.agent` (en / zh / zh-TW)

## Test plan
- [x] Typecheck clean on branch
- [ ] Settings → Agent → set turns to 20 → reconnect session → spawn uses `--max-turns 20`
- [ ] Clear field / 0 omits the flag again