### PR TITLE
feat: choose preferred agent definition in Settings

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -496,6 +496,9 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  preferredAgent = "",
+  onPreferredAgent,
+  agentCatalog = [],
   cliInfo,
   onDoctor,
   versionFooter,
@@ -1013,7 +1016,48 @@ export function SettingsPage({
               ) : null}
             </div>
 
-            <h2 className="settings-page__h2">{t("settings.section.general")}</h2>
+                        <h2 className="settings-page__h2">{t("settings.section.agent")}</h2>
+            <div className="settings-card" id="settings-agent-card">
+              {onPreferredAgent ? (
+                <div className="settings-row settings-row--stack">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.preferredAgent")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.preferredAgentDesc")}
+                    </div>
+                  </div>
+                  <Select
+                    value={preferredAgent || ""}
+                    onChange={(v) => onPreferredAgent(v)}
+                    options={[
+                      {
+                        value: "",
+                        label: t("settings.preferredAgent.default"),
+                      },
+                      ...agentCatalog.map((a) => {
+                        const srcKey = (
+                          {
+                            builtin: "settings.preferredAgent.source.builtin",
+                            bundled: "settings.preferredAgent.source.bundled",
+                            user: "settings.preferredAgent.source.user",
+                            project: "settings.preferredAgent.source.project",
+                          } as const
+                        )[a.source as "builtin" | "bundled" | "user" | "project"];
+                        const srcLabel = srcKey ? t(srcKey) : a.source || "other";
+                        return {
+                          value: a.name,
+                          label: `${a.name} · ${srcLabel}`,
+                        };
+                      }),
+                    ]}
+                  />
+                </div>
+              ) : null}
+            </div>
+
+<h2 className="settings-page__h2">{t("settings.section.general")}</h2>
             <div className="settings-card">
               <div className="settings-row">
                 <div className="settings-row__text">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -699,7 +699,8 @@ const en = {
   "settings.disableWebSearch": "Disable web search & fetch",
   "settings.disableWebSearchDesc":
     "Spawn agents with --disable-web-search so web_search and web_fetch tools are unavailable. Live agents soft-respawn when this changes.",
-  "settings.prefsScope": "Remember model & permission at",
+    "settings.section.agent": "Agent",
+"settings.prefsScope": "Remember model & permission at",
   "settings.prefsScopeDesc":
     "Global: all chats. Project: each workspace. Session: only the current chat.",
   "settings.prefsScope.global": "Global (app-wide)",
@@ -2378,7 +2379,8 @@ const zh: Record<MessageKey, string> = {
   "settings.disableWebSearch": "禁用网页搜索与抓取",
   "settings.disableWebSearchDesc":
     "启动 Agent 时加上 --disable-web-search，移除 web_search / web_fetch 工具。更改后会 soft-respawn 已连接的 Agent。",
-  "settings.prefsScope": "模型与权限记忆范围",
+    "settings.section.agent": "Agent",
+"settings.prefsScope": "模型与权限记忆范围",
   "settings.prefsScopeDesc":
     "全局：所有对话共用。项目：按工作区记忆。会话：仅当前聊天。",
   "settings.prefsScope.global": "全局（应用级）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -670,7 +670,8 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.disableWebSearch": "停用網頁搜尋與抓取",
   "settings.disableWebSearchDesc":
     "啟動 Agent 時加上 --disable-web-search，移除 web_search / web_fetch 工具。變更後會 soft-respawn 已連線的 Agent。",
-  "settings.prefsScope": "模型與權限記憶範圍",
+    "settings.section.agent": "Agent",
+"settings.prefsScope": "模型與權限記憶範圍",
   "settings.prefsScopeDesc":
     "全域：所有對話共用。專案：依工作區記憶。對話：僅目前聊天。",
   "settings.prefsScope.global": "全域（應用程式層級）",


### PR DESCRIPTION
## Problem
`preferredAgent` / `agentsCatalog` were already loaded and passed into Settings props, but there was no control to pick a definition for spawn (`--agent`).

## Changes
- Settings → Agent select: default (CLI) or catalog entries (builtin / bundled / user / project)
- Uses existing `agentsCatalog` + `preferredAgent` settings path

## Test plan
- [ ] Settings → Agent → pick a definition → new session spawn uses `--agent <name>`
- [ ] Default clears preferred agent again