### PR TITLE
feat: allow/disable subagent spawning via settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -775,6 +775,7 @@ export default function App() {
   const [agentCatalog, setAgentCatalog] = useState<
     Array<{ name: string; source: string }>
   >([]);
+  const [subagentsEnabled, setSubagentsEnabled] = useState(true);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -1054,6 +1055,7 @@ export default function App() {
         setSandboxProfile(known.includes(sb) ? sb : "off");
       }
       setPreferredAgent((settings.preferredAgent || "").trim());
+      setSubagentsEnabled(settings.subagentsEnabled !== false);
       void api
         .agentsCatalog(null)
         .then((cat) => {
@@ -6903,6 +6905,13 @@ export default function App() {
             );
           }}
           agentCatalog={agentCatalog}
+          subagentsEnabled={subagentsEnabled}
+          onSubagentsEnabled={(v) => {
+            setSubagentsEnabled(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, subagentsEnabled: v }),
+            );
+          }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
           onOpenShortcutsHelp={() => setShowShortcuts(true)}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -496,6 +496,8 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  subagentsEnabled = true,
+  onSubagentsEnabled,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -1013,7 +1015,28 @@ export function SettingsPage({
               ) : null}
             </div>
 
-            <h2 className="settings-page__h2">{t("settings.section.general")}</h2>
+                        <h2 className="settings-page__h2">{t("settings.section.agent")}</h2>
+            <div className="settings-card" id="settings-agent-card">
+              {onSubagentsEnabled ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.subagentsEnabled")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.subagentsEnabledDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={!!subagentsEnabled}
+                    onChange={() => onSubagentsEnabled(!subagentsEnabled)}
+                    ariaLabel={t("settings.subagentsEnabled")}
+                  />
+                </div>
+              ) : null}
+            </div>
+
+<h2 className="settings-page__h2">{t("settings.section.general")}</h2>
             <div className="settings-card">
               <div className="settings-row">
                 <div className="settings-row__text">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -699,7 +699,10 @@ const en = {
   "settings.disableWebSearch": "Disable web search & fetch",
   "settings.disableWebSearchDesc":
     "Spawn agents with --disable-web-search so web_search and web_fetch tools are unavailable. Live agents soft-respawn when this changes.",
-  "settings.prefsScope": "Remember model & permission at",
+    "settings.section.agent": "Agent",
+  "settings.subagentsEnabled": "Allow subagents",
+  "settings.subagentsEnabledDesc": "When off, spawn with --no-subagents so nested Agent / task tools cannot start child sessions. Soft-respawns after change.",
+"settings.prefsScope": "Remember model & permission at",
   "settings.prefsScopeDesc":
     "Global: all chats. Project: each workspace. Session: only the current chat.",
   "settings.prefsScope.global": "Global (app-wide)",
@@ -2378,7 +2381,10 @@ const zh: Record<MessageKey, string> = {
   "settings.disableWebSearch": "禁用网页搜索与抓取",
   "settings.disableWebSearchDesc":
     "启动 Agent 时加上 --disable-web-search，移除 web_search / web_fetch 工具。更改后会 soft-respawn 已连接的 Agent。",
-  "settings.prefsScope": "模型与权限记忆范围",
+    "settings.section.agent": "Agent",
+  "settings.subagentsEnabled": "允许子代理",
+  "settings.subagentsEnabledDesc": "关闭时启动加上 --no-subagents，无法拉起嵌套 Agent / 任务。更改后 soft-respawn。",
+"settings.prefsScope": "模型与权限记忆范围",
   "settings.prefsScopeDesc":
     "全局：所有对话共用。项目：按工作区记忆。会话：仅当前聊天。",
   "settings.prefsScope.global": "全局（应用级）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -670,7 +670,10 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.disableWebSearch": "停用網頁搜尋與抓取",
   "settings.disableWebSearchDesc":
     "啟動 Agent 時加上 --disable-web-search，移除 web_search / web_fetch 工具。變更後會 soft-respawn 已連線的 Agent。",
-  "settings.prefsScope": "模型與權限記憶範圍",
+    "settings.section.agent": "Agent",
+  "settings.subagentsEnabled": "允許子代理",
+  "settings.subagentsEnabledDesc": "關閉時啟動加上 --no-subagents，無法拉起巢狀 Agent / 任務。變更後 soft-respawn。",
+"settings.prefsScope": "模型與權限記憶範圍",
   "settings.prefsScopeDesc":
     "全域：所有對話共用。專案：依工作區記憶。對話：僅目前聊天。",
   "settings.prefsScope.global": "全域（應用程式層級）",


### PR DESCRIPTION
## Problem
CLI supports `--no-subagents`, and the App store already had `subagentsEnabled`, but Settings had no control.

## Changes
- Settings → Agent toggle (default on)
- Off maps to `--no-subagents` on spawn / soft-respawn

## Test plan
- [ ] Disable subagents → nested Agent tools blocked on next spawn
- [ ] Re-enable restores default behavior