### PR TITLE
feat: disable web search/fetch for agents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -775,6 +775,7 @@ export default function App() {
   const [agentCatalog, setAgentCatalog] = useState<
     Array<{ name: string; source: string }>
   >([]);
+  const [disableWebSearch, setDisableWebSearch] = useState(false);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -1054,6 +1055,7 @@ export default function App() {
         setSandboxProfile(known.includes(sb) ? sb : "off");
       }
       setPreferredAgent((settings.preferredAgent || "").trim());
+      setDisableWebSearch(!!settings.disableWebSearch);
       void api
         .agentsCatalog(null)
         .then((cat) => {
@@ -6903,6 +6905,13 @@ export default function App() {
             );
           }}
           agentCatalog={agentCatalog}
+          disableWebSearch={disableWebSearch}
+          onDisableWebSearch={(v) => {
+            setDisableWebSearch(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, disableWebSearch: v }),
+            );
+          }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
           onOpenShortcutsHelp={() => setShowShortcuts(true)}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -496,6 +496,8 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  disableWebSearch = false,
+  onDisableWebSearch,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -1013,7 +1015,28 @@ export function SettingsPage({
               ) : null}
             </div>
 
-            <h2 className="settings-page__h2">{t("settings.section.general")}</h2>
+                        <h2 className="settings-page__h2">{t("settings.section.agent")}</h2>
+            <div className="settings-card" id="settings-agent-card">
+              {onDisableWebSearch ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.disableWebSearch")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.disableWebSearchDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={!!disableWebSearch}
+                    onChange={() => onDisableWebSearch(!disableWebSearch)}
+                    ariaLabel={t("settings.disableWebSearch")}
+                  />
+                </div>
+              ) : null}
+            </div>
+
+<h2 className="settings-page__h2">{t("settings.section.general")}</h2>
             <div className="settings-card">
               <div className="settings-row">
                 <div className="settings-row__text">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -699,7 +699,8 @@ const en = {
   "settings.disableWebSearch": "Disable web search & fetch",
   "settings.disableWebSearchDesc":
     "Spawn agents with --disable-web-search so web_search and web_fetch tools are unavailable. Live agents soft-respawn when this changes.",
-  "settings.prefsScope": "Remember model & permission at",
+    "settings.section.agent": "Agent",
+"settings.prefsScope": "Remember model & permission at",
   "settings.prefsScopeDesc":
     "Global: all chats. Project: each workspace. Session: only the current chat.",
   "settings.prefsScope.global": "Global (app-wide)",
@@ -2378,7 +2379,8 @@ const zh: Record<MessageKey, string> = {
   "settings.disableWebSearch": "禁用网页搜索与抓取",
   "settings.disableWebSearchDesc":
     "启动 Agent 时加上 --disable-web-search，移除 web_search / web_fetch 工具。更改后会 soft-respawn 已连接的 Agent。",
-  "settings.prefsScope": "模型与权限记忆范围",
+    "settings.section.agent": "Agent",
+"settings.prefsScope": "模型与权限记忆范围",
   "settings.prefsScopeDesc":
     "全局：所有对话共用。项目：按工作区记忆。会话：仅当前聊天。",
   "settings.prefsScope.global": "全局（应用级）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -670,7 +670,8 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.disableWebSearch": "停用網頁搜尋與抓取",
   "settings.disableWebSearchDesc":
     "啟動 Agent 時加上 --disable-web-search，移除 web_search / web_fetch 工具。變更後會 soft-respawn 已連線的 Agent。",
-  "settings.prefsScope": "模型與權限記憶範圍",
+    "settings.section.agent": "Agent",
+"settings.prefsScope": "模型與權限記憶範圍",
   "settings.prefsScopeDesc":
     "全域：所有對話共用。專案：依工作區記憶。對話：僅目前聊天。",
   "settings.prefsScope.global": "全域（應用程式層級）",


### PR DESCRIPTION
## Problem
CLI `--disable-web-search` removes web_search / web_fetch, but the App had no Settings surface for it.

## Changes
- Settings → Agent toggle
- Soft-respawns connected agents when changed

## Test plan
- [ ] Enable disable-web-search → agent cannot call web tools
- [ ] Disable → tools available again after respawn