### PR TITLE
feat: reopen last chat on startup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ import {
   type SessionPlanState,
 } from "@/lib/planSession";
 import * as api from "@/lib/api";
+import { shouldRestoreLastSession } from "@/lib/sessionRestore";
 import { createT, resolveLocale, type Locale } from "@/i18n";
 import {
   DEFAULT_EFFORT,
@@ -775,6 +776,9 @@ export default function App() {
   const [agentCatalog, setAgentCatalog] = useState<
     Array<{ name: string; source: string }>
   >([]);
+  const [reopenLastSession, setReopenLastSession] = useState(true);
+  const [lastSessionId, setLastSessionId] = useState<string | null>(null);
+  const didRestoreLastRef = useRef(false);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
   const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
@@ -1054,6 +1058,12 @@ export default function App() {
         setSandboxProfile(known.includes(sb) ? sb : "off");
       }
       setPreferredAgent((settings.preferredAgent || "").trim());
+      setReopenLastSession(settings.reopenLastSession !== false);
+      setLastSessionId(
+        typeof settings.lastSessionId === "string"
+          ? settings.lastSessionId.trim() || null
+          : null,
+      );
       void api
         .agentsCatalog(null)
         .then((cat) => {
@@ -2297,6 +2307,13 @@ export default function App() {
       setRetryStatus(null);
     }
 
+    if (api.isTauri()) {
+      setLastSessionId(s.id);
+      void api
+        .settingsRememberLastSession(s.id, proj?.id ?? null)
+        .catch(() => {});
+    }
+
     // Warm ACP: connect while the user reads history (trusted project or orphan).
     // Host serializes connect; first send no-ops if already ready, or waits if
     // still handshaking. Process is reused across sessions when cwd/effort match.
@@ -2337,6 +2354,36 @@ export default function App() {
       })();
     }
   };
+
+  const openSessionRef = useRef(openSession);
+  openSessionRef.current = openSession;
+
+  useEffect(() => {
+    if (appGate !== "ready") return;
+    if (didRestoreLastRef.current) return;
+    if (!api.isTauri()) {
+      didRestoreLastRef.current = true;
+      return;
+    }
+    const id = shouldRestoreLastSession({
+      enabled: reopenLastSession,
+      workbenchReady: true,
+      lastSessionId,
+      sessions,
+      currentSessionId: session.sessionId,
+    });
+    didRestoreLastRef.current = true;
+    if (!id) return;
+    const row = sessions.find((s) => s.id === id);
+    if (!row) return;
+    void openSessionRef.current(row);
+  }, [
+    appGate,
+    reopenLastSession,
+    lastSessionId,
+    sessions,
+    session.sessionId,
+  ]);
 
   /**
    * Focus composer after React commit. Retries until the textarea is mounted
@@ -6903,6 +6950,13 @@ export default function App() {
             );
           }}
           agentCatalog={agentCatalog}
+          reopenLastSession={reopenLastSession}
+          onReopenLastSession={(v) => {
+            setReopenLastSession(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, reopenLastSession: v }),
+            );
+          }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
           onOpenShortcutsHelp={() => setShowShortcuts(true)}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -496,6 +496,8 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  reopenLastSession = true,
+  onReopenLastSession,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -1104,6 +1106,23 @@ export function SettingsPage({
                   />
                 </div>
               )}
+              {onReopenLastSession ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.reopenLastSession")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.reopenLastSessionDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={!!reopenLastSession}
+                    onChange={() => onReopenLastSession(!reopenLastSession)}
+                    ariaLabel={t("settings.reopenLastSession")}
+                  />
+                </div>
+              ) : null}
             </div>
           </>
         )}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -699,7 +699,10 @@ const en = {
   "settings.disableWebSearch": "Disable web search & fetch",
   "settings.disableWebSearchDesc":
     "Spawn agents with --disable-web-search so web_search and web_fetch tools are unavailable. Live agents soft-respawn when this changes.",
-  "settings.prefsScope": "Remember model & permission at",
+    "settings.section.agent": "Agent",
+  "settings.reopenLastSession": "Reopen last chat on startup",
+  "settings.reopenLastSessionDesc": "When the app launches, open the chat you were last viewing if it still exists and is not archived.",
+"settings.prefsScope": "Remember model & permission at",
   "settings.prefsScopeDesc":
     "Global: all chats. Project: each workspace. Session: only the current chat.",
   "settings.prefsScope.global": "Global (app-wide)",
@@ -2378,7 +2381,10 @@ const zh: Record<MessageKey, string> = {
   "settings.disableWebSearch": "禁用网页搜索与抓取",
   "settings.disableWebSearchDesc":
     "启动 Agent 时加上 --disable-web-search，移除 web_search / web_fetch 工具。更改后会 soft-respawn 已连接的 Agent。",
-  "settings.prefsScope": "模型与权限记忆范围",
+    "settings.section.agent": "Agent",
+  "settings.reopenLastSession": "启动时恢复上次对话",
+  "settings.reopenLastSessionDesc": "应用启动后，若上次打开的对话仍存在且未归档，则自动打开。",
+"settings.prefsScope": "模型与权限记忆范围",
   "settings.prefsScopeDesc":
     "全局：所有对话共用。项目：按工作区记忆。会话：仅当前聊天。",
   "settings.prefsScope.global": "全局（应用级）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -670,7 +670,10 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.disableWebSearch": "停用網頁搜尋與抓取",
   "settings.disableWebSearchDesc":
     "啟動 Agent 時加上 --disable-web-search，移除 web_search / web_fetch 工具。變更後會 soft-respawn 已連線的 Agent。",
-  "settings.prefsScope": "模型與權限記憶範圍",
+    "settings.section.agent": "Agent",
+  "settings.reopenLastSession": "啟動時還原上次對話",
+  "settings.reopenLastSessionDesc": "應用程式啟動後，若上次開啟的對話仍存在且未封存，則自動開啟。",
+"settings.prefsScope": "模型與權限記憶範圍",
   "settings.prefsScopeDesc":
     "全域：所有對話共用。專案：依工作區記憶。對話：僅目前聊天。",
   "settings.prefsScope.global": "全域（應用程式層級）",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -794,6 +794,12 @@ export interface AppSettings {
   planEnabled?: boolean;
   subagentsEnabled?: boolean;
   useLeader?: boolean;
+  /** Reopen last active chat once after launch (default true). */
+  reopenLastSession?: boolean;
+  /** Last successfully opened session id (startup restore). */
+  lastSessionId?: string | null;
+  /** Project of lastSessionId when it belonged to one (hint only). */
+  lastProjectId?: string | null;
   voiceId?: string;
   voiceDictationAutoSend?: boolean;
   voiceKeepAgentsOnEnd?: boolean;
@@ -1872,6 +1878,17 @@ export async function gitWorktreeRemove(opts: {
     projectPath: opts.projectPath,
     worktreePath: opts.worktreePath,
     force: opts.force ?? false,
+  });
+}
+
+/** Persist last active chat without full settings_set side-effects. */
+export async function settingsRememberLastSession(
+  sessionId?: string | null,
+  projectId?: string | null,
+) {
+  return invoke<void>("settings_remember_last_session", {
+    sessionId: sessionId ?? null,
+    projectId: projectId ?? null,
   });
 }
 


### PR DESCRIPTION
## Problem
Users reopening the app always landed on a blank workbench even though the last chat is usually what they want.

## Changes
- Settings → General: “Reopen last chat on startup” (default on)
- Remember last opened session via `settings_remember_last_session`
- One-shot restore after workbench is ready (`shouldRestoreLastSession`)

## Test plan
- [ ] Open a chat, quit, relaunch → same chat reopens
- [ ] Toggle off → no restore
- [ ] Deleted/archived last chat → no crash, no restore