### PR TITLE
feat: use per-model reasoning efforts from CLI catalog

### DIFF
--- a/docs/llm-wiki/catalog.md
+++ b/docs/llm-wiki/catalog.md
@@ -23,11 +23,9 @@ Flags **必须在** `stdio` 之前。连接后 `session/set_model` 再对齐一�
 
 ## 推理强度（effort）
 
-`low` | `medium` | `high` → `--reasoning-effort`。
+CLI `models_cache.json` 每模型可带 `info.reasoning_efforts: [{id,value,label,description,default}]`。Host 经 `AvailableModel.reasoningEfforts`（`isDefault`）下发；composer 列表优先用该数组，空则回退静态 `GROK_BUILD_EFFORTS`（`low` | `medium` | `high`）。展示标签优先用 catalog `label`，否则 i18n `effort.high|medium|low`。
 
-**默认 `medium`**（速度与质量折中）。延迟敏感可降到 low；难任务升到 high。
-
-中途修改：soft-disconnect agent → 下一条消息重连。无 `session/set_effort` RPC。
+Spawn：`--reasoning-effort <id>`。无模型级默认时 App 默认 **`medium`**；有 `default: true` 时用模型默认。中途修改：soft-disconnect agent → 下一条消息重连。无 `session/set_effort` RPC。
 
 ### 连接加速（Host）
 

--- a/src-tauri/src/models_catalog.rs
+++ b/src-tauri/src/models_catalog.rs
@@ -12,6 +12,18 @@ use serde::{Deserialize, Serialize};
 use crate::paths::resolve_agent_grok_home;
 use crate::store;
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReasoningEffort {
+    pub id: String,
+    pub value: String,
+    pub label: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub is_default: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AvailableModel {
@@ -21,6 +33,9 @@ pub struct AvailableModel {
     pub source: String,
     #[serde(default)]
     pub is_default: bool,
+    /// Per-model reasoning efforts from CLI `info.reasoning_efforts` (may be empty).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasoning_efforts: Vec<ReasoningEffort>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,13 +47,71 @@ pub struct AvailableModelsResult {
     pub fetched_at: Option<String>,
 }
 
+struct ParsedCacheModel {
+    label: String,
+    reasoning_efforts: Vec<ReasoningEffort>,
+}
+
 fn user_grok_home() -> PathBuf {
     crate::process_util::user_home().join(".grok")
 }
 
+/// Parse `/info/reasoning_efforts` from a models_cache entry body.
+fn parse_reasoning_efforts(body: &serde_json::Value) -> Vec<ReasoningEffort> {
+    let Some(arr) = body
+        .pointer("/info/reasoning_efforts")
+        .and_then(|x| x.as_array())
+    else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|item| {
+            let id = item.get("id")?.as_str()?.trim();
+            if id.is_empty() {
+                return None;
+            }
+            let value = item
+                .get("value")
+                .and_then(|x| x.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(id)
+                .to_string();
+            let label = item
+                .get("label")
+                .and_then(|x| x.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(id)
+                .to_string();
+            let description = item
+                .get("description")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
+            // CLI cache uses `"default": true`; host API exposes `isDefault`.
+            let is_default = item
+                .get("default")
+                .and_then(|x| x.as_bool())
+                .or_else(|| item.get("isDefault").and_then(|x| x.as_bool()))
+                .or_else(|| item.get("is_default").and_then(|x| x.as_bool()))
+                .unwrap_or(false);
+            Some(ReasoningEffort {
+                id: id.to_string(),
+                value,
+                label,
+                description,
+                is_default,
+            })
+        })
+        .collect()
+}
+
 fn read_models_cache(
     path: &PathBuf,
-) -> Option<(BTreeMap<String, String>, Option<String>, Option<String>)> {
+) -> Option<(
+    BTreeMap<String, ParsedCacheModel>,
+    Option<String>,
+    Option<String>,
+)> {
     let raw = fs::read_to_string(path).ok()?;
     let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
     let models_obj = v.get("models")?.as_object()?;
@@ -63,7 +136,14 @@ fn read_models_cache(
             .filter(|s| !s.is_empty())
             .unwrap_or(id)
             .to_string();
-        map.insert(id.clone(), label);
+        let reasoning_efforts = parse_reasoning_efforts(body);
+        map.insert(
+            id.clone(),
+            ParsedCacheModel {
+                label,
+                reasoning_efforts,
+            },
+        );
     }
     let origin = v
         .get("origin")
@@ -102,12 +182,13 @@ pub fn list_available_models() -> AvailableModelsResult {
             if fetched_at.is_none() {
                 fetched_at = f;
             }
-            for (id, label) in map {
+            for (id, parsed) in map {
                 by_id.entry(id.clone()).or_insert(AvailableModel {
                     id,
-                    label,
+                    label: parsed.label,
                     source: "official".into(),
                     is_default: false,
+                    reasoning_efforts: parsed.reasoning_efforts,
                 });
             }
             if !by_id.is_empty() {
@@ -125,6 +206,7 @@ pub fn list_available_models() -> AvailableModelsResult {
                 label: "Grok 4.5".into(),
                 source: "official".into(),
                 is_default: true,
+                reasoning_efforts: Vec::new(),
             },
         );
     }
@@ -189,8 +271,120 @@ mod tests {
         )
         .unwrap();
         let (map, origin, _) = read_models_cache(&path).expect("cache");
-        assert_eq!(map.get("grok-4.5").map(String::as_str), Some("Grok 4.5"));
+        assert_eq!(
+            map.get("grok-4.5").map(|m| m.label.as_str()),
+            Some("Grok 4.5")
+        );
+        assert!(map
+            .get("grok-4.5")
+            .map(|m| m.reasoning_efforts.is_empty())
+            .unwrap_or(false));
         assert!(origin.unwrap().contains("cli-chat-proxy"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn parse_reasoning_efforts_from_cache_pointer() {
+        let body: serde_json::Value = serde_json::from_str(
+            r#"{
+              "info": {
+                "reasoning_efforts": [
+                  {
+                    "id": "high",
+                    "value": "high",
+                    "label": "High Effort",
+                    "description": "Highest quality",
+                    "default": true
+                  },
+                  {
+                    "id": "medium",
+                    "value": "medium",
+                    "label": "Medium Effort",
+                    "description": "Balanced",
+                    "default": false
+                  },
+                  {
+                    "id": "low",
+                    "value": "low",
+                    "label": "Low Effort",
+                    "description": "Quick",
+                    "default": false
+                  }
+                ]
+              }
+            }"#,
+        )
+        .unwrap();
+        let efforts = parse_reasoning_efforts(&body);
+        assert_eq!(efforts.len(), 3);
+        assert_eq!(efforts[0].id, "high");
+        assert_eq!(efforts[0].value, "high");
+        assert_eq!(efforts[0].label, "High Effort");
+        assert_eq!(efforts[0].description, "Highest quality");
+        assert!(efforts[0].is_default);
+        assert!(!efforts[1].is_default);
+        assert_eq!(efforts[2].id, "low");
+    }
+
+    #[test]
+    fn parse_reasoning_efforts_skips_empty_id() {
+        let body: serde_json::Value = serde_json::from_str(
+            r#"{
+              "info": {
+                "reasoning_efforts": [
+                  { "id": "", "value": "x", "label": "X" },
+                  { "id": "medium", "label": "Med" }
+                ]
+              }
+            }"#,
+        )
+        .unwrap();
+        let efforts = parse_reasoning_efforts(&body);
+        assert_eq!(efforts.len(), 1);
+        assert_eq!(efforts[0].id, "medium");
+        assert_eq!(efforts[0].value, "medium");
+        assert_eq!(efforts[0].label, "Med");
+    }
+
+    #[test]
+    fn read_cache_includes_reasoning_efforts() {
+        let dir = std::env::temp_dir().join(format!(
+            "grok-app-models-efforts-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("models_cache.json");
+        fs::write(
+            &path,
+            r#"{
+              "fetched_at": "2026-07-25T00:00:00Z",
+              "origin": "https://cli-chat-proxy.grok.com/v1/models",
+              "models": {
+                "grok-4.5": {
+                  "info": {
+                    "id": "grok-4.5",
+                    "name": "Grok 4.5",
+                    "hidden": false,
+                    "reasoning_efforts": [
+                      {
+                        "id": "high",
+                        "value": "high",
+                        "label": "High Effort",
+                        "description": "Deep",
+                        "default": true
+                      }
+                    ]
+                  }
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        let (map, _, _) = read_models_cache(&path).expect("cache");
+        let m = map.get("grok-4.5").expect("model");
+        assert_eq!(m.reasoning_efforts.len(), 1);
+        assert_eq!(m.reasoning_efforts[0].id, "high");
+        assert!(m.reasoning_efforts[0].is_default);
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,12 +83,15 @@ import {
   DEFAULT_MODEL_ID,
   GROK_BUILD_MODELS,
   PERMISSION_POLICIES,
+  findModel,
   isValidEffort,
   isValidModelId,
   isValidPolicy,
   isValidPrefsScope,
+  pickDefaultEffort,
   pickDefaultModelId,
   type ComposerPrefsScope,
+  type EffortOption,
   type ModelOption,
   type PermissionPolicyId,
 } from "@/lib/grokCatalog";
@@ -845,13 +848,18 @@ export default function App() {
   const applyComposerPrefs = useCallback(
     (prefs: api.ComposerPrefs, catalog: ModelOption[]) => {
       const models = catalog.length > 0 ? catalog : GROK_BUILD_MODELS;
+      let nextModelId: string;
       if (prefs.modelId && isValidModelId(prefs.modelId, models)) {
-        setModelId(prefs.modelId);
+        nextModelId = prefs.modelId;
       } else {
-        setModelId(pickDefaultModelId(models));
+        nextModelId = pickDefaultModelId(models);
       }
+      setModelId(nextModelId);
+      const model = findModel(nextModelId, models);
       setEffort(
-        isValidEffort(prefs.effort) ? prefs.effort : DEFAULT_EFFORT,
+        isValidEffort(prefs.effort, model)
+          ? prefs.effort
+          : pickDefaultEffort(model),
       );
       setMode(prefs.mode || "agent");
       setPolicy(
@@ -914,12 +922,25 @@ export default function App() {
       setLocale(resolveLocale(settings.locale));
       const catalog: ModelOption[] =
         modelsRes?.models?.length
-          ? modelsRes.models.map((m) => ({
-              id: m.id,
-              label: m.label || m.id,
-              source: m.source,
-              isDefault: m.isDefault,
-            }))
+          ? modelsRes.models.map((m) => {
+              const efforts: EffortOption[] | undefined =
+                m.reasoningEfforts?.length
+                  ? m.reasoningEfforts.map((e) => ({
+                      id: e.id,
+                      value: e.value,
+                      label: e.label,
+                      description: e.description,
+                      isDefault: e.isDefault,
+                    }))
+                  : undefined;
+              return {
+                id: m.id,
+                label: m.label || m.id,
+                source: m.source,
+                isDefault: m.isDefault,
+                reasoningEfforts: efforts,
+              };
+            })
           : GROK_BUILD_MODELS;
       setAvailableModels(catalog);
       if (
@@ -940,11 +961,18 @@ export default function App() {
             ? settings.permissionPolicy
             : "ask",
         );
-        setEffort(
-          isValidEffort(settings.effort || "")
-            ? (settings.effort as typeof effort)
-            : DEFAULT_EFFORT,
-        );
+        {
+          const mid =
+            settings.modelId && isValidModelId(settings.modelId, catalog)
+              ? settings.modelId
+              : pickDefaultModelId(catalog);
+          const model = findModel(mid, catalog);
+          setEffort(
+            isValidEffort(settings.effort || "", model)
+              ? settings.effort!
+              : pickDefaultEffort(model),
+          );
+        }
         setMode(settings.mode || "agent");
         if (settings.modelId && isValidModelId(settings.modelId, catalog)) {
           setModelId(settings.modelId);
@@ -8294,16 +8322,24 @@ export default function App() {
                   onModel={(v) => {
                     if (!isValidModelId(v, availableModels)) return;
                     setModelId(v);
+                    const nextModel = findModel(v, availableModels);
+                    if (!isValidEffort(effort, nextModel)) {
+                      setEffort(pickDefaultEffort(nextModel));
+                    }
                     void api
                       .composerPrefsSet({
                         projectId: activeProject?.id ?? null,
                         sessionId: session.sessionId ?? null,
                         modelId: v,
+                        ...(!isValidEffort(effort, nextModel)
+                          ? { effort: pickDefaultEffort(nextModel) }
+                          : {}),
                       })
                       .catch((e) => showToast(String(e), 4000));
                   }}
                   onEffort={(v) => {
-                    if (!isValidEffort(v)) return;
+                    const model = findModel(modelId, availableModels);
+                    if (!isValidEffort(v, model)) return;
                     setEffort(v);
                     void api
                       .composerPrefsSet({

--- a/src/components/ComposerModelMenu.tsx
+++ b/src/components/ComposerModelMenu.tsx
@@ -15,11 +15,12 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import {
-  GROK_BUILD_EFFORTS,
   GROK_BUILD_MODELS,
   PERMISSION_POLICIES,
   SESSION_MODES,
-  type EffortOption,
+  effortDisplayLabel,
+  effortsForModel,
+  findModel,
   type ModelOption,
   type PermissionPolicyId,
 } from "@/lib/grokCatalog";
@@ -38,7 +39,6 @@ import {
 } from "@/components/icons";
 import { useFloatingMenu, type FloatingPos } from "@/lib/floatingMenu";
 
-type EffortId = EffortOption["id"];
 type Nested = "model" | "effort" | null;
 
 function usePortalMenu(estHeight = 220, _width = 300, nestedKey?: string) {
@@ -193,21 +193,20 @@ export interface ComposerModelMenuProps {
     effortLow: string;
   };
   onModel: (id: string) => void;
-  onEffort: (id: EffortId) => void;
+  onEffort: (id: string) => void;
 }
 
-function effortLabel(
-  id: string,
+function resolveEffortLabel(
+  effortId: string,
+  effortList: ReturnType<typeof effortsForModel>,
   labels: ComposerModelMenuProps["labels"],
 ): string {
-  if (id === "high") return labels.effortHigh;
-  if (id === "medium") return labels.effortMedium;
-  return labels.effortLow;
-}
-
-function effortShort(id: string, labels: ComposerModelMenuProps["labels"]): string {
-  // Compact: just effort word (icon carries model)
-  return effortLabel(id, labels);
+  const entry = effortList.find((e) => e.id === effortId);
+  return effortDisplayLabel(entry ?? effortId, {
+    high: labels.effortHigh,
+    medium: labels.effortMedium,
+    low: labels.effortLow,
+  });
 }
 
 export function ComposerModelMenu({
@@ -221,6 +220,8 @@ export function ComposerModelMenu({
   const [nested, setNested] = useState<Nested>(null);
   const menu = usePortalMenu(240, 280, nested ?? "root");
   const modelList = models.length > 0 ? models : GROK_BUILD_MODELS;
+  const activeModel = findModel(modelId, modelList);
+  const effortList = effortsForModel(activeModel);
 
   useEffect(() => {
     if (!menu.open) setNested(null);
@@ -238,9 +239,8 @@ export function ComposerModelMenu({
     return () => document.removeEventListener("keydown", onKey);
   }, [menu.open, nested]);
 
-  const modelLabel =
-    modelList.find((m) => m.id === modelId)?.label ?? modelId;
-  const eLabel = effortLabel(effort, labels);
+  const modelLabel = activeModel?.label ?? modelId;
+  const eLabel = resolveEffortLabel(effort, effortList, labels);
   const triggerText = `${modelLabel} · ${eLabel}`;
   const title = `${labels.model}: ${modelLabel} · ${labels.effort}: ${eLabel}`;
 
@@ -250,7 +250,7 @@ export function ComposerModelMenu({
       className="cmm--model"
       triggerIcon={<IconBolt size={14} />}
       triggerText={triggerText}
-      triggerShort={effortShort(effort, labels)}
+      triggerShort={eLabel}
       ariaLabel={labels.model}
       title={title}
       onOpenChange={(o) => {
@@ -323,7 +323,7 @@ export function ComposerModelMenu({
               ))
             ))}
           {nested === "effort" &&
-            GROK_BUILD_EFFORTS.map((e) => (
+            effortList.map((e) => (
               <button
                 key={e.id}
                 type="button"
@@ -335,7 +335,7 @@ export function ComposerModelMenu({
               >
                 <span className="cmm__opt-main">
                   <span className="cmm__opt-title">
-                    {effortLabel(e.id, labels)}
+                    {resolveEffortLabel(e.id, effortList, labels)}
                   </span>
                 </span>
                 {e.id === effort && (

--- a/src/components/EffortPanel.tsx
+++ b/src/components/EffortPanel.tsx
@@ -5,13 +5,12 @@
 
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import type { EffortOption } from "@/lib/grokCatalog";
 import { GROK_BUILD_EFFORTS } from "@/lib/grokCatalog";
 import { IconChevronDown } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { useFloatingMenu } from "@/lib/floatingMenu";
 
-type EffortId = EffortOption["id"];
+type EffortId = "low" | "medium" | "high";
 
 const ORDER: EffortId[] = ["low", "medium", "high"];
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -799,11 +799,21 @@ export interface AppSettings {
   voiceKeepAgentsOnEnd?: boolean;
 }
 
+export interface ReasoningEffort {
+  id: string;
+  value: string;
+  label: string;
+  description?: string;
+  isDefault?: boolean;
+}
+
 export interface AvailableModel {
   id: string;
   label: string;
   source: string;
   isDefault?: boolean;
+  /** Per-model efforts from CLI models_cache; omit/empty → static fallback. */
+  reasoningEfforts?: ReasoningEffort[];
 }
 
 export interface AvailableModelsResult {

--- a/src/lib/grokCatalog.test.ts
+++ b/src/lib/grokCatalog.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_EFFORT,
+  GROK_BUILD_EFFORTS,
+  effortDisplayLabel,
+  effortsForModel,
+  isValidEffort,
+  pickDefaultEffort,
+  type ModelOption,
+} from "./grokCatalog";
+
+const modelWithEfforts: ModelOption = {
+  id: "grok-4.5",
+  label: "Grok 4.5",
+  reasoningEfforts: [
+    {
+      id: "high",
+      value: "high",
+      label: "High Effort",
+      description: "Deep",
+      isDefault: true,
+    },
+    {
+      id: "medium",
+      value: "medium",
+      label: "Medium Effort",
+      isDefault: false,
+    },
+    {
+      id: "low",
+      value: "low",
+      label: "Low Effort",
+      isDefault: false,
+    },
+  ],
+};
+
+const modelCustomOnly: ModelOption = {
+  id: "custom-model",
+  label: "Custom",
+  reasoningEfforts: [
+    { id: "max", value: "max", label: "Max", isDefault: true },
+    { id: "min", value: "min", label: "Min" },
+  ],
+};
+
+describe("effortsForModel", () => {
+  it("returns static fallback when model has no efforts", () => {
+    expect(effortsForModel({ id: "x", label: "X" })).toEqual(
+      GROK_BUILD_EFFORTS,
+    );
+    expect(effortsForModel(null)).toEqual(GROK_BUILD_EFFORTS);
+    expect(effortsForModel(undefined)).toEqual(GROK_BUILD_EFFORTS);
+  });
+
+  it("returns model efforts when non-empty", () => {
+    const list = effortsForModel(modelWithEfforts);
+    expect(list).toHaveLength(3);
+    expect(list[0].id).toBe("high");
+    expect(list[0].label).toBe("High Effort");
+  });
+
+  it("prefers explicit catalogEfforts arg over model", () => {
+    const override = [{ id: "only" }];
+    expect(effortsForModel(modelWithEfforts, override)).toEqual(override);
+  });
+});
+
+describe("isValidEffort", () => {
+  it("accepts static low/medium/high without model", () => {
+    expect(isValidEffort("low")).toBe(true);
+    expect(isValidEffort("medium")).toBe(true);
+    expect(isValidEffort("high")).toBe(true);
+    expect(isValidEffort("max")).toBe(false);
+    expect(isValidEffort("")).toBe(false);
+  });
+
+  it("accepts efforts for the selected model when known", () => {
+    expect(isValidEffort("high", modelWithEfforts)).toBe(true);
+    expect(isValidEffort("max", modelCustomOnly)).toBe(true);
+    expect(isValidEffort("min", modelCustomOnly)).toBe(true);
+    expect(isValidEffort("medium", modelCustomOnly)).toBe(false);
+  });
+
+  it("accepts an efforts array directly", () => {
+    expect(isValidEffort("max", modelCustomOnly.reasoningEfforts)).toBe(true);
+    expect(isValidEffort("high", modelCustomOnly.reasoningEfforts)).toBe(
+      false,
+    );
+  });
+});
+
+describe("pickDefaultEffort", () => {
+  it("uses model default flag when present", () => {
+    expect(pickDefaultEffort(modelWithEfforts)).toBe("high");
+    expect(pickDefaultEffort(modelCustomOnly)).toBe("max");
+  });
+
+  it("falls back to medium static default", () => {
+    expect(pickDefaultEffort(null)).toBe(DEFAULT_EFFORT);
+    expect(pickDefaultEffort({ id: "x", label: "X" })).toBe("medium");
+  });
+});
+
+describe("effortDisplayLabel", () => {
+  it("prefers catalog label", () => {
+    expect(
+      effortDisplayLabel(
+        { id: "high", label: "High Effort" },
+        { high: "高" },
+      ),
+    ).toBe("High Effort");
+  });
+
+  it("uses i18n for known ids without catalog label", () => {
+    expect(
+      effortDisplayLabel("high", {
+        high: "High",
+        medium: "Medium",
+        low: "Low",
+      }),
+    ).toBe("High");
+    expect(effortDisplayLabel({ id: "medium" }, { medium: "中" })).toBe(
+      "中",
+    );
+  });
+
+  it("falls back to raw id", () => {
+    expect(effortDisplayLabel("max")).toBe("max");
+  });
+});

--- a/src/lib/grokCatalog.ts
+++ b/src/lib/grokCatalog.ts
@@ -4,6 +4,17 @@
  * Update docs/llm-wiki/catalog.md when defaults change.
  */
 
+export interface EffortOption {
+  /** Effort id passed to `--reasoning-effort` (e.g. low / medium / high). */
+  id: string;
+  /** CLI value when distinct from id; usually equals id. */
+  value?: string;
+  /** Display label from catalog when present. */
+  label?: string;
+  description?: string;
+  isDefault?: boolean;
+}
+
 export interface ModelOption {
   id: string;
   /** Display name (language-neutral product name) */
@@ -12,10 +23,8 @@ export interface ModelOption {
   isDefault?: boolean;
   /** Catalog source; composer only shows official model IDs (not providers). */
   source?: string;
-}
-
-export interface EffortOption {
-  id: "high" | "medium" | "low";
+  /** Per-model reasoning efforts from CLI cache; empty/undefined → static fallback. */
+  reasoningEfforts?: EffortOption[];
 }
 
 export interface SessionModeOption {
@@ -59,7 +68,7 @@ export const GROK_BUILD_MODELS: ModelOption[] = [
 export const DEFAULT_MODEL_ID =
   GROK_BUILD_MODELS.find((m) => m.isDefault)?.id ?? "grok-4.5";
 
-/** Reasoning effort flags: `--reasoning-effort` / `--effort` on grok agent. */
+/** Static fallback when the selected model has no `reasoning_efforts` in cache. */
 export const GROK_BUILD_EFFORTS: EffortOption[] = [
   { id: "medium" },
   { id: "low" },
@@ -69,8 +78,9 @@ export const GROK_BUILD_EFFORTS: EffortOption[] = [
 /**
  * Default reasoning depth. `medium` balances speed vs quality for agentic use;
  * users can lower (faster) or raise (deeper) via the composer chip.
+ * When a model lists a default effort, prefer `pickDefaultEffort(model)`.
  */
-export const DEFAULT_EFFORT: EffortOption["id"] = "medium";
+export const DEFAULT_EFFORT = "medium";
 
 /** Product session modes (desktop shell). */
 export const SESSION_MODES: SessionModeOption[] = [
@@ -101,8 +111,68 @@ export function isValidModelId(
   return catalog.some((m) => m.id === id);
 }
 
-export function isValidEffort(id: string): id is EffortOption["id"] {
-  return GROK_BUILD_EFFORTS.some((e) => e.id === id);
+/**
+ * Efforts list for a model: live catalog when non-empty, else static fallback.
+ */
+export function effortsForModel(
+  model?: ModelOption | null,
+  catalogEfforts?: EffortOption[] | null,
+): EffortOption[] {
+  const fromArg =
+    catalogEfforts && catalogEfforts.length > 0 ? catalogEfforts : null;
+  const fromModel =
+    model?.reasoningEfforts && model.reasoningEfforts.length > 0
+      ? model.reasoningEfforts
+      : null;
+  return fromArg ?? fromModel ?? GROK_BUILD_EFFORTS;
+}
+
+/**
+ * Validate an effort id against the selected model's efforts when known;
+ * otherwise against the static GROK_BUILD_EFFORTS fallback.
+ */
+export function isValidEffort(
+  id: string,
+  modelOrEfforts?: ModelOption | EffortOption[] | null,
+): boolean {
+  if (!id) return false;
+  if (Array.isArray(modelOrEfforts)) {
+    return effortsForModel(null, modelOrEfforts).some((e) => e.id === id);
+  }
+  return effortsForModel(modelOrEfforts).some((e) => e.id === id);
+}
+
+/** Default effort for a model (catalog default flag, else first, else medium). */
+export function pickDefaultEffort(
+  model?: ModelOption | null,
+  catalogEfforts?: EffortOption[] | null,
+): string {
+  const list = effortsForModel(model, catalogEfforts);
+  return (
+    list.find((e) => e.isDefault)?.id ?? list[0]?.id ?? DEFAULT_EFFORT
+  );
+}
+
+/**
+ * Display label for an effort: prefer catalog label, else i18n via known ids.
+ * `i18nLabels` maps high/medium/low (and optionally other ids).
+ */
+export function effortDisplayLabel(
+  effort: EffortOption | string,
+  i18nLabels?: {
+    high?: string;
+    medium?: string;
+    low?: string;
+  },
+): string {
+  if (typeof effort !== "string") {
+    if (effort.label && effort.label.trim()) return effort.label;
+    return effortDisplayLabel(effort.id, i18nLabels);
+  }
+  if (effort === "high" && i18nLabels?.high) return i18nLabels.high;
+  if (effort === "medium" && i18nLabels?.medium) return i18nLabels.medium;
+  if (effort === "low" && i18nLabels?.low) return i18nLabels.low;
+  return effort;
 }
 
 export function isValidPolicy(id: string): id is PermissionPolicyId {
@@ -119,4 +189,12 @@ export function pickDefaultModelId(catalog: ModelOption[]): string {
     catalog[0]?.id ??
     DEFAULT_MODEL_ID
   );
+}
+
+/** Find a model in catalog by id. */
+export function findModel(
+  id: string,
+  catalog: ModelOption[] = GROK_BUILD_MODELS,
+): ModelOption | undefined {
+  return catalog.find((m) => m.id === id);
 }


### PR DESCRIPTION
## Problem
Composer effort choices were hard-coded to low/medium/high. Grok Build already ships per-model `reasoning_efforts` in `models_cache.json` (id/label/default), so the App could offer wrong or incomplete tiers when the catalog changes.

## Changes
- Parse `info.reasoning_efforts` into `AvailableModel.reasoningEfforts` (Host)
- Composer effort menu uses the active model’s list when present; falls back to the static catalog
- Labels prefer CLI text; otherwise existing i18n effort keys
- Validate effort against the selected model; reset if invalid after a model switch
- Unit tests for pure helpers + Rust catalog parse

## Test plan
- [x] `tsc` / `vitest src/lib/grokCatalog.test.ts` / `cargo test models_catalog`
- [ ] Open composer effort menu on grok-4.5 → matches CLI cache tiers
- [ ] Switch model (if multi-model) → effort list updates; invalid effort resets