### PR TITLE
feat: optional file restore when rewinding a chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -437,6 +437,13 @@ export default function App() {
     points: Array<{ promptIndex: number; messageId?: string | null; preview: string }>;
   } | null>(null);
   const [rewindBusy, setRewindBusy] = useState(false);
+  /** Confirm rewind target + optional file restore (default off). */
+  const [rewindConfirm, setRewindConfirm] = useState<{
+    sessionId: string;
+    targetPromptIndex: number;
+    preview?: string;
+  } | null>(null);
+  const [rewindRestoreFiles, setRewindRestoreFiles] = useState(false);
   /** Last user message open in inline edit (not main composer). */
   const [editingUserMessageId, setEditingUserMessageId] = useState<
     string | null
@@ -4840,9 +4847,14 @@ export default function App() {
 
   /**
    * Apply rewind: truncate local journal (+ agent when live), refresh messages UI.
+   * `restoreFiles` is opt-in (safe default off) — reverts workspace files when agent supports it.
    */
   const runRewindToPrompt = useCallback(
-    async (sessionId: string, targetPromptIndex: number) => {
+    async (
+      sessionId: string,
+      targetPromptIndex: number,
+      restoreFiles = false,
+    ) => {
       if (!api.isTauri()) {
         showToast(tr("error.needTauri"));
         return;
@@ -4868,7 +4880,7 @@ export default function App() {
 
         const result = await api.sessionRewindExecute(targetPromptIndex, {
           sessionId,
-          restoreFiles: false,
+          restoreFiles,
         });
 
         // Refresh UI from truncated journal.
@@ -4904,6 +4916,8 @@ export default function App() {
         }
 
         setRewindTimeline(null);
+        setRewindConfirm(null);
+        setRewindRestoreFiles(false);
         if (result.agentOk) {
           showToast(tr("session.rewindOk"), 2600);
         } else {
@@ -4924,21 +4938,15 @@ export default function App() {
   const confirmRewindToPrompt = useCallback(
     (sessionId: string, targetPromptIndex: number, preview?: string) => {
       setCtxMenu(null);
-      const msgPreview = preview?.trim()
-        ? `\n\n“${preview.trim()}”`
-        : "";
-      setAppDialog({
-        kind: "confirm",
-        title: tr("session.rewindTitle"),
-        message: tr("session.rewindConfirm") + msgPreview,
-        confirmLabel: tr("session.rewindConfirmLabel"),
-        danger: true,
-        onConfirm: () => {
-          void runRewindToPrompt(sessionId, targetPromptIndex);
-        },
+      // GlassModal with restore-files checkbox (default off) — not bare setAppDialog.
+      setRewindRestoreFiles(false);
+      setRewindConfirm({
+        sessionId,
+        targetPromptIndex,
+        preview: preview?.trim() || undefined,
       });
     },
-    [runRewindToPrompt, tr],
+    [],
   );
 
   const openRewindTimeline = useCallback(
@@ -8954,6 +8962,73 @@ export default function App() {
           </div>
         </div>
       )}
+
+      <GlassModal
+        open={!!rewindConfirm}
+        onClose={() => {
+          if (rewindBusy) return;
+          setRewindConfirm(null);
+          setRewindRestoreFiles(false);
+        }}
+        title={tr("session.rewindTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        closeOnOverlay={!rewindBusy}
+        showClose={!rewindBusy}
+        wrapBody
+        className="rewind-confirm-modal"
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={rewindBusy}
+              onClick={() => {
+                setRewindConfirm(null);
+                setRewindRestoreFiles(false);
+              }}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--danger"
+              disabled={rewindBusy || !rewindConfirm}
+              onClick={() => {
+                if (!rewindConfirm) return;
+                void runRewindToPrompt(
+                  rewindConfirm.sessionId,
+                  rewindConfirm.targetPromptIndex,
+                  rewindRestoreFiles,
+                );
+              }}
+            >
+              {tr("session.rewindConfirmLabel")}
+            </button>
+          </>
+        }
+      >
+        <div className="rewind-confirm">
+          <p className="rewind-confirm__msg">
+            {tr("session.rewindConfirm")}
+            {rewindConfirm?.preview
+              ? `\n\n“${rewindConfirm.preview}”`
+              : ""}
+          </p>
+          <label className="rewind-confirm__restore">
+            <input
+              type="checkbox"
+              checked={rewindRestoreFiles}
+              disabled={rewindBusy}
+              onChange={(e) => setRewindRestoreFiles(e.target.checked)}
+            />
+            <span>{tr("session.rewindRestoreFiles")}</span>
+          </label>
+          <p className="rewind-confirm__hint">
+            {tr("session.rewindRestoreFilesHint")}
+          </p>
+        </div>
+      </GlassModal>
 
       {showCompactModal && (
         <div

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -116,6 +116,9 @@ const en = {
   "session.rewindConfirm":
     "Rewind to this turn and discard everything after it? This cannot be undone for this chat.",
   "session.rewindConfirmLabel": "Rewind",
+  "session.rewindRestoreFiles": "Also restore workspace files to this point",
+  "session.rewindRestoreFilesHint":
+    "Reverts file changes made after this turn when the agent supports it. Off by default (safer).",
   "session.rewindOk": "Conversation rewound",
   "session.rewindLocalOnly":
     "Conversation rewound locally. Agent history was not updated (unsupported or disconnected).",
@@ -1813,6 +1816,9 @@ const zh: Record<MessageKey, string> = {
   "session.rewindConfirm":
     "回退到此回合并丢弃之后的全部内容？此操作对当前会话不可撤销。",
   "session.rewindConfirmLabel": "回退",
+  "session.rewindRestoreFiles": "同时将工作区文件恢复到此节点",
+  "session.rewindRestoreFilesHint":
+    "回退此回合之后的文件改动（需 Agent 支持）。默认关闭，更安全。",
   "session.rewindOk": "对话已回退",
   "session.rewindLocalOnly":
     "已在本地回退对话。Agent 历史未更新（不支持或未连接）。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -105,6 +105,9 @@ export const zhTW: Record<MessageKey, string> = {
   "session.rewindConfirm":
     "回退到此回合並捨棄之後的全部內容？此操作對目前對話無法復原。",
   "session.rewindConfirmLabel": "回退",
+  "session.rewindRestoreFiles": "同時將工作區檔案還原到此節點",
+  "session.rewindRestoreFilesHint":
+    "回退此回合之後的檔案變更（需 Agent 支援）。預設關閉，更安全。",
   "session.rewindOk": "對話已回退",
   "session.rewindLocalOnly":
     "已在本機回退對話。Agent 歷史未更新（不支援或未連線）。",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12258,6 +12258,44 @@ div.composer__input:empty::before {
   -webkit-box-orient: vertical;
 }
 
+/* Rewind confirm (optional file restore) */
+.rewind-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rewind-confirm__msg {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.rewind-confirm__restore {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.35;
+  color: var(--text-primary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.rewind-confirm__restore input {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.rewind-confirm__hint {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
 /* Compact confirm */
 .compact-modal {
   width: min(var(--modal-width-sm, 420px), 100%);


### PR DESCRIPTION
## Problem
Rewind always called the agent with `restoreFiles: false`. Users who wanted the workspace rolled back with the transcript had no control.

## Changes
- Rewind confirm uses GlassModal with a **default-off** checkbox to restore workspace files
- Passes `restoreFiles` into `sessionRewindExecute`
- Existing agentOk vs local-only toasts unchanged
- en / zh / zh-TW

## Test plan
- [x] tsc + i18n tests
- [ ] Rewind with checkbox off → history truncated, files untouched
- [ ] Rewind with checkbox on → agent restore path attempted when live