### PR TITLE
feat: start a new chat in a fresh git worktree

### DIFF
--- a/docs/llm-wiki/git-worktrees.md
+++ b/docs/llm-wiki/git-worktrees.md
@@ -18,11 +18,14 @@ git worktree list --porcelain
 
 ### Create worktree
 
-From the same menu: **New worktree…**
+From the same menu:
+
+- **New worktree…** — create + bind current session/cwd to the new path.
+- **New worktree & chat…** — create, then open a **draft new chat** whose project path is the worktree (agent cwd).
 
 1. User enters a **name** (required) and optional **start point** (branch / tag / commit).
 2. Host runs `git worktree add -b <name> <path> [<start_point>]` with argv (no shell).
-3. On success: refresh the list, `project_add` with trust inherited from the source project when possible, then bind session cwd to the new path.
+3. On success: refresh the list, `project_add` with trust inherited from the source project when possible, then either bind the open session or call `newChat(worktreeProject)`.
 
 **Path layout (sibling of main worktree):**
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,7 +162,12 @@ import {
   getComposerCaretOffset,
 } from "@/components/ComposerEditor";
 import { ComposerProjectMenu } from "@/components/ComposerProjectMenu";
-import { pathsEqual } from "@/lib/gitWorktree";
+import {
+  buildWorktreeSiblingPath,
+  mainWorktreePath,
+  pathsEqual,
+  sanitizeWorktreeName,
+} from "@/lib/gitWorktree";
 import { isProjectPathMissing } from "@/lib/projectPath";
 import {
   classifyVoiceError,
@@ -759,6 +764,16 @@ export default function App() {
   const [gitWorktreesReason, setGitWorktreesReason] = useState<string | null>(
     null,
   );
+  /** New worktree dialog (name + optional start-point). */
+  const [worktreeCreateOpen, setWorktreeCreateOpen] = useState(false);
+  const [worktreeCreateName, setWorktreeCreateName] = useState("");
+  const [worktreeCreateRef, setWorktreeCreateRef] = useState("");
+  const [worktreeCreateBusy, setWorktreeCreateBusy] = useState(false);
+  const [worktreeCreateError, setWorktreeCreateError] = useState<string | null>(
+    null,
+  );
+  /** When true, after create bind cwd and open a draft chat on that path. */
+  const [worktreeCreateStartChat, setWorktreeCreateStartChat] = useState(false);
   /** Clean stale worktrees (git worktree prune) dialog. */
   const [worktreeGcOpen, setWorktreeGcOpen] = useState(false);
   const [worktreeGcForce, setWorktreeGcForce] = useState(false);
@@ -5525,6 +5540,123 @@ export default function App() {
     ],
   );
 
+  const openWorktreeCreate = useCallback((opts?: { startNewChat?: boolean }) => {
+    setWorktreeCreateName("");
+    setWorktreeCreateRef("");
+    setWorktreeCreateError(null);
+    setWorktreeCreateBusy(false);
+    setWorktreeCreateStartChat(!!opts?.startNewChat);
+    setWorktreeCreateOpen(true);
+  }, []);
+
+  const worktreeCreatePreviewPath = (() => {
+    try {
+      const main = mainWorktreePath(gitWorktrees) || activeProject?.path || "";
+      if (!main || !worktreeCreateName.trim()) return null;
+      return buildWorktreeSiblingPath(main, worktreeCreateName.trim());
+    } catch {
+      return null;
+    }
+  })();
+
+  /**
+   * Create worktree → refresh list → add as project (trust inherited) →
+   * either bind current session or start a draft chat on that path.
+   */
+  const submitWorktreeCreate = useCallback(async () => {
+    if (!api.isTauri() || !activeProject?.path) return;
+    const rawName = worktreeCreateName.trim();
+    if (!rawName) {
+      setWorktreeCreateError(tr("composer.worktreeNameRequired"));
+      return;
+    }
+    let safeName: string;
+    try {
+      safeName = sanitizeWorktreeName(rawName);
+    } catch {
+      setWorktreeCreateError(tr("composer.worktreeNameInvalid"));
+      return;
+    }
+    setWorktreeCreateBusy(true);
+    setWorktreeCreateError(null);
+    try {
+      const start = worktreeCreateRef.trim() || null;
+      const created = await api.gitWorktreeAdd(
+        activeProject.path,
+        safeName,
+        start,
+      );
+      setWorktreeCreateOpen(false);
+      await refreshGitWorktrees();
+
+      const path = created.path;
+      const branch =
+        created.branch?.trim() ||
+        created.name ||
+        tr("composer.worktreeDetached");
+      const trust = !!activeProject.trusted;
+      const startChat = worktreeCreateStartChat;
+      const existing = projects.find((p) => pathsEqual(p.path, path));
+      let target: Project | null = existing ?? null;
+      if (!target) {
+        const added = (await api.projectAdd(path, trust)) as Project;
+        const list = (await api.projectsList()) as Project[];
+        setProjects(list);
+        target = list.find((p) => p.id === added.id) ?? added;
+      }
+
+      if (!target.trusted) {
+        // Trust prompt first; bind only (chat requires trusted project).
+        await finalizeAddedProject(target, { bindSession: true });
+        showToast(
+          tr("composer.worktreeCreated", {
+            name: created.name,
+            branch,
+          }),
+          2800,
+        );
+        return;
+      }
+
+      if (startChat) {
+        await newChat(target, { switchToChat: true });
+        showToast(
+          tr("composer.worktreeCreatedChat", {
+            name: created.name,
+            branch,
+          }),
+          2800,
+        );
+      } else {
+        await bindSessionProject(target, { silent: true });
+        showToast(
+          tr("composer.worktreeCreated", {
+            name: created.name,
+            branch,
+          }),
+          2800,
+        );
+      }
+    } catch (e) {
+      setWorktreeCreateError(String(e));
+    } finally {
+      setWorktreeCreateBusy(false);
+    }
+  }, [
+    activeProject?.path,
+    activeProject?.trusted,
+    bindSessionProject,
+    finalizeAddedProject,
+    newChat,
+    projects,
+    refreshGitWorktrees,
+    showToast,
+    tr,
+    worktreeCreateName,
+    worktreeCreateRef,
+    worktreeCreateStartChat,
+  ]);
+
   /**
    * Pick folder → add project (name = folder basename; no rename prompt).
    * `bindSession` also attaches the open chat under the new project.
@@ -8244,6 +8376,8 @@ export default function App() {
                     worktreeMain: tr("composer.worktreeMain"),
                     worktreeDetached: tr("composer.worktreeDetached"),
                     pathMissing: tr("project.pathMissingShort"),
+                    worktreeNew: tr("composer.worktreeNew"),
+                    worktreeNewChat: tr("composer.worktreeNewChat"),
                     worktreeGc: tr("composer.worktreeGc"),
                   }}
                   worktrees={gitWorktrees}
@@ -8263,6 +8397,10 @@ export default function App() {
                   onSwitchWorktree={(wt) => {
                     void switchToWorktree(wt);
                   }}
+                  onCreateWorktree={() => openWorktreeCreate()}
+                  onCreateWorktreeAndChat={() =>
+                    openWorktreeCreate({ startNewChat: true })
+                  }
                   onGcWorktrees={openWorktreeGc}
                   onOpen={refreshGitWorktrees}
                 />
@@ -8560,6 +8698,111 @@ export default function App() {
           void refreshLists();
         }}
       />
+      <GlassModal
+        open={worktreeCreateOpen}
+        onClose={() => {
+          if (worktreeCreateBusy) return;
+          setWorktreeCreateOpen(false);
+        }}
+        title={
+          worktreeCreateStartChat
+            ? tr("composer.worktreeNewChatTitle")
+            : tr("composer.worktreeNewTitle")
+        }
+        size="sm"
+        closeLabel={tr("common.close")}
+        closeOnOverlay={!worktreeCreateBusy}
+        showClose={!worktreeCreateBusy}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={worktreeCreateBusy}
+              onClick={() => setWorktreeCreateOpen(false)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={worktreeCreateBusy || !worktreeCreateName.trim()}
+              onClick={() => {
+                void submitWorktreeCreate();
+              }}
+            >
+              {worktreeCreateBusy
+                ? tr("composer.worktreeCreating")
+                : worktreeCreateStartChat
+                  ? tr("composer.worktreeCreateChat")
+                  : tr("composer.worktreeCreate")}
+            </button>
+          </>
+        }
+      >
+        <form
+          className="wt-create"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (worktreeCreateBusy) return;
+            void submitWorktreeCreate();
+          }}
+        >
+          <p className="wt-create__hint">
+            {worktreeCreateStartChat
+              ? tr("composer.worktreeNewChatHint")
+              : tr("composer.worktreeNewHint")}
+          </p>
+          <label className="wt-create__field">
+            <span className="wt-create__label">
+              {tr("composer.worktreeName")}
+            </span>
+            <input
+              className="settings-input"
+              value={worktreeCreateName}
+              onChange={(e) => {
+                setWorktreeCreateName(e.target.value);
+                setWorktreeCreateError(null);
+              }}
+              placeholder={tr("composer.worktreeNamePlaceholder")}
+              autoComplete="off"
+              autoFocus
+              disabled={worktreeCreateBusy}
+              spellCheck={false}
+            />
+          </label>
+          <label className="wt-create__field">
+            <span className="wt-create__label">
+              {tr("composer.worktreeRef")}
+            </span>
+            <input
+              className="settings-input"
+              value={worktreeCreateRef}
+              onChange={(e) => {
+                setWorktreeCreateRef(e.target.value);
+                setWorktreeCreateError(null);
+              }}
+              placeholder={tr("composer.worktreeRefPlaceholder")}
+              autoComplete="off"
+              disabled={worktreeCreateBusy}
+              spellCheck={false}
+            />
+          </label>
+          {worktreeCreatePreviewPath ? (
+            <p className="wt-create__preview">
+              {tr("composer.worktreePathPreview", {
+                path: worktreeCreatePreviewPath,
+              })}
+            </p>
+          ) : null}
+          {worktreeCreateError ? (
+            <p className="wt-create__error" role="alert">
+              {worktreeCreateError}
+            </p>
+          ) : null}
+        </form>
+      </GlassModal>
       <GlassModal
         open={worktreeGcOpen}
         onClose={() => {

--- a/src/components/ComposerProjectMenu.tsx
+++ b/src/components/ComposerProjectMenu.tsx
@@ -42,6 +42,10 @@ type Props = {
     worktreeDetached: string;
     /** Badge when project folder is missing on disk. */
     pathMissing?: string;
+    /** New worktree… (create + switch). */
+    worktreeNew?: string;
+    /** New worktree & chat… (create + start draft chat there). */
+    worktreeNewChat?: string;
     /** Clean stale worktree admin records (prune). */
     worktreeGc?: string;
   };
@@ -60,6 +64,10 @@ type Props = {
   onAdd: () => void;
   /** Switch agent cwd to this worktree path (add project if needed + bind). */
   onSwitchWorktree?: (wt: GitWorktreeEntry) => void;
+  /** Open “New worktree…” dialog (parent owns modal). */
+  onCreateWorktree?: () => void;
+  /** Open create dialog then start a new chat bound to the worktree path. */
+  onCreateWorktreeAndChat?: () => void;
   /** Open “Clean stale worktrees…” dialog (parent owns modal). */
   onGcWorktrees?: () => void;
   onOpen?: () => void;
@@ -79,6 +87,8 @@ export function ComposerProjectMenu({
   onSelect,
   onAdd,
   onSwitchWorktree,
+  onCreateWorktree,
+  onCreateWorktreeAndChat,
   onGcWorktrees,
   onOpen,
 }: Props) {
@@ -92,7 +102,14 @@ export function ComposerProjectMenu({
 
   // Only for confirmed git work trees — hide while loading / non-git / no project.
   const showWorktrees = !!activeProject && worktreesAvailable === true;
+  const canCreate = showWorktrees && !!onCreateWorktree && !!labels.worktreeNew;
+  const canCreateChat =
+    showWorktrees &&
+    !!onCreateWorktreeAndChat &&
+    !!labels.worktreeNewChat;
   const canGc = showWorktrees && !!onGcWorktrees && !!labels.worktreeGc;
+  const actionRows =
+    (canCreate ? 1 : 0) + (canCreateChat ? 1 : 0) + (canGc ? 1 : 0);
 
   const estHeight = Math.min(
     400,
@@ -101,7 +118,7 @@ export function ComposerProjectMenu({
       (showWorktrees
         ? 28 +
           Math.min(160, Math.max(worktrees.length, 1) * 36 + 8) +
-          (canGc ? 36 : 0)
+          actionRows * 36
         : 0),
   );
   const { pos, style: popStyle } = useFloatingMenu({
@@ -115,7 +132,14 @@ export function ComposerProjectMenu({
     minWidth: 260,
     estHeight,
     gap: 8,
-    deps: [projects.length, worktrees.length, showWorktrees, canGc],
+    deps: [
+      projects.length,
+      worktrees.length,
+      showWorktrees,
+      canCreate,
+      canCreateChat,
+      canGc,
+    ],
   });
 
   // Refresh only when the menu opens — not when parent re-renders with a new onOpen.
@@ -303,6 +327,34 @@ export function ComposerProjectMenu({
                       : labels.worktreesEmpty}
                   </p>
                 )}
+                {canCreate ? (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="cpm__action cpm__worktree-new"
+                    onClick={() => {
+                      setOpen(false);
+                      onCreateWorktree?.();
+                    }}
+                  >
+                    <IconPlus size={14} aria-hidden />
+                    <span>{labels.worktreeNew}</span>
+                  </button>
+                ) : null}
+                {canCreateChat ? (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="cpm__action cpm__worktree-new"
+                    onClick={() => {
+                      setOpen(false);
+                      onCreateWorktreeAndChat?.();
+                    }}
+                  >
+                    <IconPlus size={14} aria-hidden />
+                    <span>{labels.worktreeNewChat}</span>
+                  </button>
+                ) : null}
                 {canGc ? (
                   <button
                     type="button"

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -414,17 +414,24 @@ const en = {
   "composer.worktreeDetached": "detached",
   "composer.worktreeSwitched": "Using worktree {name} ({branch})",
   "composer.worktreeNew": "New worktree…",
+  "composer.worktreeNewChat": "New worktree & chat…",
   "composer.worktreeNewTitle": "New git worktree",
+  "composer.worktreeNewChatTitle": "New worktree & chat",
   "composer.worktreeNewHint":
     "Creates a sibling folder next to the main worktree and checks out a new branch.",
+  "composer.worktreeNewChatHint":
+    "Creates a sibling worktree, then starts a new chat with that folder as the project.",
   "composer.worktreeName": "Name",
   "composer.worktreeNamePlaceholder": "feat-login",
   "composer.worktreeRef": "Start point (optional)",
   "composer.worktreeRefPlaceholder": "main, origin/main, or commit",
   "composer.worktreePathPreview": "Path: {path}",
   "composer.worktreeCreate": "Create",
+  "composer.worktreeCreateChat": "Create & open chat",
   "composer.worktreeCreating": "Creating…",
   "composer.worktreeCreated": "Created worktree {name} ({branch})",
+  "composer.worktreeCreatedChat":
+    "Created worktree {name} ({branch}) · new chat",
   "composer.worktreeNameRequired": "Enter a worktree name",
   "composer.worktreeNameInvalid":
     "Use letters, digits, '.', '_' or '-' (no spaces or slashes)",
@@ -2070,17 +2077,24 @@ const zh: Record<MessageKey, string> = {
   "composer.worktreeDetached": "游离 HEAD",
   "composer.worktreeSwitched": "已切换到 worktree {name}（{branch}）",
   "composer.worktreeNew": "新建 worktree…",
+  "composer.worktreeNewChat": "新建 worktree 并开聊…",
   "composer.worktreeNewTitle": "新建 Git worktree",
+  "composer.worktreeNewChatTitle": "新建 worktree 并开聊",
   "composer.worktreeNewHint":
     "在主 worktree 旁创建同级目录，并检出一条新分支。",
+  "composer.worktreeNewChatHint":
+    "创建同级 worktree，并以该目录为项目开始新对话。",
   "composer.worktreeName": "名称",
   "composer.worktreeNamePlaceholder": "feat-login",
   "composer.worktreeRef": "起始点（可选）",
   "composer.worktreeRefPlaceholder": "main、origin/main 或 commit",
   "composer.worktreePathPreview": "路径：{path}",
   "composer.worktreeCreate": "创建",
+  "composer.worktreeCreateChat": "创建并开聊",
   "composer.worktreeCreating": "正在创建…",
   "composer.worktreeCreated": "已创建 worktree {name}（{branch}）",
+  "composer.worktreeCreatedChat":
+    "已创建 worktree {name}（{branch}）· 已开新对话",
   "composer.worktreeNameRequired": "请输入 worktree 名称",
   "composer.worktreeNameInvalid":
     "仅允许字母、数字、'.'、'_'、'-'（不能含空格或斜杠）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -342,17 +342,24 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.worktreeDetached": "游離 HEAD",
   "composer.worktreeSwitched": "已切換到 worktree {name}（{branch}）",
   "composer.worktreeNew": "新建 worktree…",
+  "composer.worktreeNewChat": "新建 worktree 並開聊…",
   "composer.worktreeNewTitle": "新建 Git worktree",
+  "composer.worktreeNewChatTitle": "新建 worktree 並開聊",
   "composer.worktreeNewHint":
     "在主 worktree 旁建立同級目錄，並檢出一條新分支。",
+  "composer.worktreeNewChatHint":
+    "建立同級 worktree，並以該目錄為專案開始新對話。",
   "composer.worktreeName": "名稱",
   "composer.worktreeNamePlaceholder": "feat-login",
   "composer.worktreeRef": "起始點（可選）",
   "composer.worktreeRefPlaceholder": "main、origin/main 或 commit",
   "composer.worktreePathPreview": "路徑：{path}",
   "composer.worktreeCreate": "建立",
+  "composer.worktreeCreateChat": "建立並開聊",
   "composer.worktreeCreating": "正在建立…",
   "composer.worktreeCreated": "已建立 worktree {name}（{branch}）",
+  "composer.worktreeCreatedChat":
+    "已建立 worktree {name}（{branch}）· 已開新對話",
   "composer.worktreeNameRequired": "請輸入 worktree 名稱",
   "composer.worktreeNameInvalid":
     "僅允許字母、數字、'.'、'_'、'-'（不能含空格或斜線）",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -299,6 +299,31 @@ export async function gitWorktreesList(projectPath: string) {
   return invoke<GitWorktreesResult>("git_worktrees_list", { projectPath });
 }
 
+/** Result of creating a linked worktree (`git worktree add`). */
+export interface GitWorktreeAddResult {
+  path: string;
+  name: string;
+  startPoint?: string | null;
+  branch?: string | null;
+}
+
+/**
+ * Create a linked worktree for a project folder.
+ * Path: `<parent>/<main_basename>-<name>` (see docs/llm-wiki/git-worktrees.md).
+ * Throws when not a git repo / git missing / path exists / invalid name.
+ */
+export async function gitWorktreeAdd(
+  projectPath: string,
+  name: string,
+  startPoint?: string | null,
+) {
+  return invoke<GitWorktreeAddResult>("git_worktree_add", {
+    projectPath,
+    name,
+    startPoint: startPoint?.trim() || null,
+  });
+}
+
 /** Native folder dialog → add project. Returns null if user cancels. */
 export async function projectAddDialog(trust: boolean) {
   return invoke<{

--- a/src/lib/gitWorktree.test.ts
+++ b/src/lib/gitWorktree.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   buildWorktreeGcArgs,
+  buildWorktreeSiblingPath,
   countWorktreePruneLines,
   findWorktreeAt,
+  mainWorktreePath,
   normalizeWorktreePath,
   parseWorktreePorcelain,
   pathsEqual,
   sanitizeWorktreeGcMaxAge,
+  sanitizeWorktreeName,
   siblingWorktrees,
   worktreeLabel,
 } from "./gitWorktree";
@@ -69,6 +72,32 @@ describe("path helpers", () => {
       "/Users/me/repo-detached",
     ]);
     expect(findWorktreeAt(list, "/Users/me/repo-feat")?.branch).toBe("feat/x");
+  });
+});
+
+describe("worktree path builder", () => {
+  it("sanitizes names", () => {
+    expect(sanitizeWorktreeName("  feat-x  ")).toBe("feat-x");
+    expect(sanitizeWorktreeName("v1.2_rc")).toBe("v1.2_rc");
+    expect(() => sanitizeWorktreeName("")).toThrow(/required/);
+    expect(() => sanitizeWorktreeName("a/b")).toThrow(/separator/);
+    expect(() => sanitizeWorktreeName("-lead")).toThrow(/start/);
+    expect(() => sanitizeWorktreeName("has space")).toThrow();
+  });
+
+  it("builds sibling path next to main worktree", () => {
+    expect(buildWorktreeSiblingPath("/Users/me/repo", "feat")).toBe(
+      "/Users/me/repo-feat",
+    );
+    expect(buildWorktreeSiblingPath("/Users/me/repo/", "hot-fix")).toBe(
+      "/Users/me/repo-hot-fix",
+    );
+    expect(mainWorktreePath(parseWorktreePorcelain(SAMPLE))).toBe(
+      "/Users/me/repo",
+    );
+    // Path preview uses main even when active cwd is a linked worktree.
+    const main = mainWorktreePath(parseWorktreePorcelain(SAMPLE))!;
+    expect(buildWorktreeSiblingPath(main, "new")).toBe("/Users/me/repo-new");
   });
 });
 

--- a/src/lib/gitWorktree.ts
+++ b/src/lib/gitWorktree.ts
@@ -196,3 +196,87 @@ export function countWorktreePruneLines(output: string | null | undefined): numb
       );
     }).length;
 }
+
+/**
+ * Sanitize worktree / new-branch name for `git worktree add -b <name>`.
+ * Mirrors host `sanitize_worktree_name`.
+ */
+export function sanitizeWorktreeName(raw: string | null | undefined): string {
+  const name = (raw ?? "").trim();
+  if (!name) {
+    throw new Error("worktree name is required");
+  }
+  if (name === "." || name === "..") {
+    throw new Error("invalid worktree name");
+  }
+  if (name.length > 64) {
+    throw new Error("worktree name too long (max 64)");
+  }
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new Error("worktree name must not contain path separators");
+  }
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+    throw new Error(
+      "worktree name may only contain letters, digits, '.', '_' and '-'",
+    );
+  }
+  if (name.startsWith("-")) {
+    throw new Error("worktree name must not start with '-'");
+  }
+  return name;
+}
+
+/**
+ * Sibling path layout (host + UI preview):
+ *   `<parent>/<main_basename>-<name>`
+ *
+ * Example: main `/Users/me/repo` + `feat` → `/Users/me/repo-feat`.
+ *
+ * Prefer sibling of the **main** worktree over in-repo `.worktrees/<name>`
+ * so linked checkouts sit next to the primary clone (common git worktree UX).
+ */
+export function buildWorktreeSiblingPath(
+  mainWorktreePath: string | null | undefined,
+  name: string | null | undefined,
+): string {
+  const main = normalizeWorktreePath(mainWorktreePath);
+  if (!main) {
+    throw new Error("empty main worktree path");
+  }
+  const safe = sanitizeWorktreeName(name);
+  // Split keeps leading "" for absolute Unix paths: "/Users/me/repo" → ["", "Users", "me", "repo"]
+  const parts = main.split("/");
+  const base = parts.filter(Boolean).pop();
+  if (!base) {
+    throw new Error("cannot derive repo folder name");
+  }
+  const parentParts = parts.slice(0, -1);
+  const parentJoined = parentParts.join("/");
+  const parent =
+    parentParts.length === 0
+      ? ""
+      : parentJoined === "" && main.startsWith("/")
+        ? "/"
+        : parentJoined;
+  const dirName = `${base}-${safe}`;
+  const joined =
+    parent === "/"
+      ? `/${dirName}`
+      : parent
+        ? `${parent}/${dirName}`
+        : dirName;
+  const out = normalizeWorktreePath(joined);
+  if (!out || pathsEqual(out, main)) {
+    throw new Error("resolved worktree path is invalid");
+  }
+  return out;
+}
+
+/** Main worktree path from a porcelain list (first entry), if any. */
+export function mainWorktreePath(
+  worktrees: GitWorktreeEntry[],
+): string | null {
+  if (!worktrees.length) return null;
+  const main = worktrees.find((w) => w.isMain) ?? worktrees[0];
+  return main?.path ?? null;
+}


### PR DESCRIPTION
## Problem
Creating a worktree and starting a chat there required several steps. Day-to-day parallel work wants one flow.

## Changes
- Project chip → Git worktrees: **New worktree…** and **New worktree & chat…**
- Create dialog (name + optional start point), then optional `newChat` bound to the worktree project path
- GlassModal only (no `window.confirm`)
- en / zh / zh-TW

## Test plan
- [x] tsc + gitWorktree/i18n tests
- [ ] New worktree creates sibling path and adds project
- [ ] New worktree & chat opens a draft session on that path