### PR TITLE
feat: clearer goal mode status and clear control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5084,6 +5084,9 @@ export default function App() {
             applyPermissionPolicy(next, { toastYoloToggle: true });
             return;
           }
+          case "goal-clear":
+            setGoalMode(false);
+            return;
           default:
             return;
         }
@@ -7730,7 +7733,7 @@ export default function App() {
             </div>
           )}
 
-          {mainPane === "chat" && !plan.barDismissed && (
+          {mainPane === "chat" && (!plan.barDismissed || goalMode) && (
             <PlanStatusBar
               goalMode={goalMode}
               mode={mode}
@@ -7750,11 +7753,13 @@ export default function App() {
                 changes: tr("plan.changes"),
                 dismiss: tr("plan.dismiss"),
                 expand: tr("planBar.expand"),
+                clearGoal: tr("planBar.clearGoal"),
                 aria: tr("planBar.aria"),
               }}
               onApprove={() => void approvePlan()}
               onRequestChanges={() => void requestPlanChanges()}
               onDismiss={() => void dismissPlan()}
+              onClearGoal={() => setGoalMode(false)}
               onOpenDetails={() => openPlanInResource()}
             />
           )}
@@ -8267,16 +8272,20 @@ export default function App() {
                   onOpen={refreshGitWorktrees}
                 />
                 {goalMode ? (
-                  <Tip label={tr("composer.goalHint")}>
+                  <Tip label={tr("composer.goalClear")}>
                     <button
                       type="button"
                       className="chip chip--goal"
                       onClick={() => setGoalMode(false)}
                       aria-label={tr("composer.goalClear")}
+                      title={tr("composer.goalClear")}
+                      data-testid="composer-goal-chip"
                     >
                       <IconImagine size={14} />
-                      <span className="chip__label">{tr("composer.goal")}</span>
-                      <IconClose size={12} />
+                      <span className="chip__label">
+                        {tr("composer.goalActive")}
+                      </span>
+                      <IconClose size={12} aria-hidden />
                     </button>
                   </Tip>
                 ) : null}

--- a/src/components/PlanStatusBar.tsx
+++ b/src/components/PlanStatusBar.tsx
@@ -21,6 +21,8 @@ export type PlanStatusBarLabels = {
   changes: string;
   dismiss: string;
   expand: string;
+  /** Exit goal mode (goal strip only). */
+  clearGoal: string;
   aria: string;
 };
 
@@ -35,6 +37,8 @@ export type PlanStatusBarProps = {
   onApprove?: () => void;
   onRequestChanges?: () => void;
   onDismiss?: () => void;
+  /** Exit goal mode from the sticky goal strip. */
+  onClearGoal?: () => void;
   /** Scroll / focus the in-thread plan card when present. */
   onOpenDetails?: () => void;
 };
@@ -67,6 +71,7 @@ export function PlanStatusBar({
   onApprove,
   onRequestChanges,
   onDismiss,
+  onClearGoal,
   onOpenDetails,
 }: PlanStatusBarProps) {
   const model = useMemo(
@@ -102,6 +107,7 @@ export function PlanStatusBar({
       aria-live="polite"
       aria-label={labels.aria}
       data-testid="plan-status-bar"
+      data-kind={model.kind}
     >
       <div className="plan-bar__main">
         <span className="plan-bar__icon" aria-hidden>
@@ -171,6 +177,18 @@ export function PlanStatusBar({
             onClick={onRequestChanges}
           >
             {labels.changes}
+          </button>
+        ) : null}
+        {model.kind === "goal" && onClearGoal ? (
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm plan-bar__btn plan-bar__btn--clear-goal"
+            onClick={onClearGoal}
+            data-testid="plan-status-clear-goal"
+            title={labels.clearGoal}
+          >
+            <IconClose size={12} />
+            <span>{labels.clearGoal}</span>
           </button>
         ) : null}
         {(model.kind === "plan_progress" ||

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -360,6 +360,7 @@ const en = {
   "composer.goalPlaceholder":
     "Describe your goal and define measurable outcomes for best results",
   "composer.goalClear": "Clear goal mode",
+  "composer.goalActive": "Goal active",
   "composer.addFilesHint": "Attach files or folders to the next message",
   "composer.addFolder": "Folder",
   "composer.addFolderHint": "Attach a folder path for the agent",
@@ -556,7 +557,7 @@ const en = {
 
   // Sticky plan/goal bar
   "planBar.aria": "Plan and goal status",
-  "planBar.goal": "Goal mode",
+  "planBar.goal": "Goal active",
   "planBar.planMode": "Plan mode",
   "planBar.progress": "Plan in progress",
   "planBar.review": "Plan ready for review",
@@ -564,6 +565,7 @@ const en = {
   "planBar.fraction": "{n}",
   "planBar.current": "Now",
   "planBar.expand": "Open in resources",
+  "planBar.clearGoal": "Clear goal",
 
   // Settings / onboarding
   "settings.title": "Settings",
@@ -1121,6 +1123,8 @@ const en = {
   "slash.empty": "No matching commands or skills",
   "slash.goal": "Goal",
   "slash.goalDesc": "Set a continuous goal with measurable outcomes",
+  "slash.goalClear": "Clear goal",
+  "slash.goalClearDesc": "Exit goal mode",
   "slash.plan": "Plan mode",
   "slash.planDesc": "Explore and design before coding",
   "slash.compact": "Compact context",
@@ -2020,6 +2024,7 @@ const zh: Record<MessageKey, string> = {
   "composer.goalHint": "设置要持续追求的目标",
   "composer.goalPlaceholder": "描述你的目标，定义可衡量的成果，以获得最佳效果",
   "composer.goalClear": "关闭目标模式",
+  "composer.goalActive": "目标进行中",
   "composer.addFilesHint": "附加文件或文件夹到下一条消息",
   "composer.addFolder": "文件夹",
   "composer.addFolderHint": "附加文件夹路径给 Agent",
@@ -2207,7 +2212,7 @@ const zh: Record<MessageKey, string> = {
 
   // Sticky plan/goal bar
   "planBar.aria": "计划与目标状态",
-  "planBar.goal": "目标模式",
+  "planBar.goal": "目标进行中",
   "planBar.planMode": "计划模式",
   "planBar.progress": "计划进行中",
   "planBar.review": "计划待审阅",
@@ -2215,6 +2220,7 @@ const zh: Record<MessageKey, string> = {
   "planBar.fraction": "{n}",
   "planBar.current": "当前",
   "planBar.expand": "在资源中打开",
+  "planBar.clearGoal": "关闭目标",
 
   "settings.title": "设置",
   "settings.backToApp": "返回应用",
@@ -2757,6 +2763,8 @@ const zh: Record<MessageKey, string> = {
   "slash.empty": "没有匹配的命令或技能",
   "slash.goal": "目标",
   "slash.goalDesc": "设置持续追求的可衡量目标",
+  "slash.goalClear": "关闭目标",
+  "slash.goalClearDesc": "退出目标模式",
   "slash.plan": "计划模式",
   "slash.planDesc": "先探索与设计再写代码",
   "slash.compact": "压缩上下文",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -367,6 +367,7 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.goalHint": "設定要持續追求的目標",
   "composer.goalPlaceholder": "描述你的目標，定義可衡量的成果，以獲得最佳效果",
   "composer.goalClear": "關閉目標模式",
+  "composer.goalActive": "目標進行中",
   "composer.addFilesHint": "附加檔案或資料夾到下一則訊息",
   "composer.addFolder": "資料夾",
   "composer.addFolderHint": "附加資料夾路徑給 Agent",
@@ -529,7 +530,7 @@ export const zhTW: Record<MessageKey, string> = {
 
   // Sticky plan/goal bar
   "planBar.aria": "計劃與目標狀態",
-  "planBar.goal": "目標模式",
+  "planBar.goal": "目標進行中",
   "planBar.planMode": "計劃模式",
   "planBar.progress": "計劃進行中",
   "planBar.review": "計劃待審閱",
@@ -537,6 +538,7 @@ export const zhTW: Record<MessageKey, string> = {
   "planBar.fraction": "{n}",
   "planBar.current": "目前",
   "planBar.expand": "在資源中開啟",
+  "planBar.clearGoal": "關閉目標",
 
   "settings.title": "設定",
   "settings.backToApp": "返回應用程式",
@@ -1079,6 +1081,8 @@ export const zhTW: Record<MessageKey, string> = {
   "slash.empty": "沒有相符的指令或技能",
   "slash.goal": "目標",
   "slash.goalDesc": "設定持續追求的可衡量目標",
+  "slash.goalClear": "關閉目標",
+  "slash.goalClearDesc": "退出目標模式",
   "slash.plan": "計劃模式",
   "slash.planDesc": "先探索與設計再寫程式碼",
   "slash.compact": "壓縮上下文",

--- a/src/lib/slashCatalog.test.ts
+++ b/src/lib/slashCatalog.test.ts
@@ -14,6 +14,7 @@ describe("builtinSlashItems", () => {
     const names = items.map((i) => i.name);
     expect(names).toEqual([
       "goal",
+      "goal-clear",
       "plan",
       "compact",
       "status",
@@ -30,6 +31,12 @@ describe("builtinSlashItems", () => {
     expect(goal.mode).toBe("goal");
     expect(goal.titleKey).toBe("slash.goal");
     expect(goal.descriptionKey).toBe("slash.goalDesc");
+
+    const goalClear = items.find((i) => i.name === "goal-clear")!;
+    expect(goalClear.kind).toBe("action");
+    expect(goalClear.action).toBe("goal-clear");
+    expect(goalClear.titleKey).toBe("slash.goalClear");
+    expect(goalClear.descriptionKey).toBe("slash.goalClearDesc");
 
     const plan = items.find((i) => i.name === "plan")!;
     expect(plan.kind).toBe("mode");

--- a/src/lib/slashCatalog.ts
+++ b/src/lib/slashCatalog.ts
@@ -38,6 +38,14 @@ export function builtinSlashItems(): SlashItem[] {
       mode: "goal",
     },
     {
+      id: "goal-clear",
+      kind: "action",
+      name: "goal-clear",
+      titleKey: "slash.goalClear",
+      descriptionKey: "slash.goalClearDesc",
+      action: "goal-clear",
+    },
+    {
       id: "plan",
       kind: "mode",
       name: "plan",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5414,6 +5414,12 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   font-size: 12px;
 }
 
+.plan-bar__btn--clear-goal {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .plan-bar__close {
   width: 26px;
   height: 26px;
@@ -11911,13 +11917,15 @@ div.composer__input:empty::before {
   font-size: 13px;
 }
 
-/* Goal mode chip */
+/* Goal mode chip — compact “Goal active” status with clear affordance */
 .chip--goal {
-  color: var(--text-primary);
-  background: var(--bg-active);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-active));
+  max-width: 180px;
 }
 .chip--goal:hover {
-  background: var(--bg-hover);
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-hover));
+  color: var(--accent);
 }
 
 /* Status modal */


### PR DESCRIPTION
## Problem
Goal mode was easy to turn on and hard to notice/clear once active.

## Changes
- PlanStatusBar goal strip: “Goal active” + **Clear goal**
- Composer goal chip label/tooltip for clear
- Slash `/goal-clear`
- en / zh / zh-TW

## Test plan
- [x] tsc + slashCatalog/planStatus/i18n tests
- [ ] Enable goal → strip/chip show active state
- [ ] Clear from bar, chip, or `/goal-clear` exits goal mode