### PR TITLE
feat: recall prior prompts with arrow keys in composer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,6 +133,11 @@ import {
   serializeForAgent,
 } from "@/lib/draftDoc";
 import {
+  collectUserPromptHistory,
+  shouldHandlePromptHistoryKey,
+  stepPromptHistory,
+} from "@/lib/composerPromptHistory";
+import {
   queuePreviewText,
   shouldEnqueueSend,
 } from "@/lib/sendQueue";
@@ -354,6 +359,16 @@ export default function App() {
   >({});
   /** Composer stored form (may include [[skill:name]] tokens). */
   const [draft, setDraft] = useState("");
+  /**
+   * CLI-like prompt history browse index (0 = newest user msg).
+   * null = not browsing; only engaged when draft empty (or already browsing).
+   * Ref tracks live index for key-repeat before React re-renders.
+   */
+  const [promptHistoryIndex, setPromptHistoryIndex] = useState<number | null>(
+    null,
+  );
+  const promptHistoryIndexRef = useRef<number | null>(null);
+  promptHistoryIndexRef.current = promptHistoryIndex;
   /** Composer voice dictation FSM (record → STT → insert draft). */
   const [voice, setVoice] = useState<VoiceFsmState>(() => initialVoiceState());
   const [voiceGate, setVoiceGate] = useState<{
@@ -1136,6 +1151,12 @@ export default function App() {
   useEffect(() => {
     if (openingSessionIdRef.current) return;
     viewingSessionIdRef.current = session.sessionId;
+  }, [session.sessionId]);
+
+  // Prompt history is per viewed session — leave browse mode on switch / new chat.
+  useEffect(() => {
+    promptHistoryIndexRef.current = null;
+    setPromptHistoryIndex(null);
   }, [session.sessionId]);
 
   useEffect(() => {
@@ -3551,6 +3572,8 @@ export default function App() {
 
   const clearComposerAfterSubmit = () => {
     setDraft("");
+    promptHistoryIndexRef.current = null;
+    setPromptHistoryIndex(null);
     setSlashQuery(null);
     setAttachments([]);
     requestAnimationFrame(() => {
@@ -8130,7 +8153,18 @@ export default function App() {
                     ? tr("composer.goalPlaceholder")
                     : tr("composer.placeholder")
                 }
-                onChange={setDraft}
+                onChange={(next) => {
+                  setDraft(next);
+                  // Manual edit exits history browse; same text (DOM re-sync) keeps it.
+                  const idx = promptHistoryIndexRef.current;
+                  if (idx !== null) {
+                    const hist = collectUserPromptHistory(messages);
+                    if (next !== hist[idx]) {
+                      promptHistoryIndexRef.current = null;
+                      setPromptHistoryIndex(null);
+                    }
+                  }
+                }}
                 onPasteFiles={(files) => {
                   void addAttachmentsFromFiles(files);
                 }}
@@ -8191,6 +8225,35 @@ export default function App() {
                         ]!;
                       if (entry.kind === "upload") void pickComposerFiles();
                       else applySlashItem(entry.item);
+                      return;
+                    }
+                  }
+                  // CLI-like prompt history: ↑ on empty draft (or while browsing).
+                  // Only when slash palette is closed so palette ↑/↓ is untouched.
+                  if (
+                    (e.key === "ArrowUp" || e.key === "ArrowDown") &&
+                    !composerMenuOpen
+                  ) {
+                    const history = collectUserPromptHistory(messages);
+                    const draftEmpty = isDraftEmpty(parseStoredContent(draft));
+                    const browsing = promptHistoryIndexRef.current !== null;
+                    if (
+                      shouldHandlePromptHistoryKey({
+                        key: e.key,
+                        draftEmpty,
+                        browsing,
+                        historyLength: history.length,
+                      })
+                    ) {
+                      e.preventDefault();
+                      const step = stepPromptHistory(
+                        history,
+                        promptHistoryIndexRef.current,
+                        e.key === "ArrowUp" ? "up" : "down",
+                      );
+                      promptHistoryIndexRef.current = step.index;
+                      setPromptHistoryIndex(step.index);
+                      setDraft(step.text);
                       return;
                     }
                   }

--- a/src/lib/composerPromptHistory.test.ts
+++ b/src/lib/composerPromptHistory.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectUserPromptHistory,
+  nextPromptHistoryIndex,
+  shouldHandlePromptHistoryKey,
+  stepPromptHistory,
+} from "./composerPromptHistory";
+
+describe("collectUserPromptHistory", () => {
+  it("returns user contents newest first", () => {
+    const history = collectUserPromptHistory([
+      { role: "user", content: "first" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "second" },
+      { role: "assistant", content: "ok2" },
+      { role: "user", content: "third" },
+    ]);
+    expect(history).toEqual(["third", "second", "first"]);
+  });
+
+  it("skips empty / whitespace-only user messages", () => {
+    const history = collectUserPromptHistory([
+      { role: "user", content: "  " },
+      { role: "user", content: "" },
+      { role: "user", content: null },
+      { role: "user", content: "keep" },
+      { role: "tool", content: "tool noise" },
+    ]);
+    expect(history).toEqual(["keep"]);
+  });
+
+  it("preserves stored skill tokens", () => {
+    const history = collectUserPromptHistory([
+      { role: "user", content: "[[skill:foo]] hello" },
+    ]);
+    expect(history).toEqual(["[[skill:foo]] hello"]);
+  });
+
+  it("returns empty for no messages", () => {
+    expect(collectUserPromptHistory([])).toEqual([]);
+  });
+});
+
+describe("nextPromptHistoryIndex", () => {
+  it("starts at newest on first up", () => {
+    expect(nextPromptHistoryIndex(null, 3, "up")).toBe(0);
+  });
+
+  it("walks older on repeated up and clamps", () => {
+    expect(nextPromptHistoryIndex(0, 3, "up")).toBe(1);
+    expect(nextPromptHistoryIndex(1, 3, "up")).toBe(2);
+    expect(nextPromptHistoryIndex(2, 3, "up")).toBe(2);
+  });
+
+  it("walks newer on down and clears past newest", () => {
+    expect(nextPromptHistoryIndex(2, 3, "down")).toBe(1);
+    expect(nextPromptHistoryIndex(1, 3, "down")).toBe(0);
+    expect(nextPromptHistoryIndex(0, 3, "down")).toBe(null);
+    expect(nextPromptHistoryIndex(null, 3, "down")).toBe(null);
+  });
+
+  it("returns null when history is empty", () => {
+    expect(nextPromptHistoryIndex(null, 0, "up")).toBe(null);
+    expect(nextPromptHistoryIndex(0, 0, "down")).toBe(null);
+  });
+});
+
+describe("stepPromptHistory", () => {
+  const history = ["newest", "mid", "oldest"];
+
+  it("fills draft with newest on first up", () => {
+    expect(stepPromptHistory(history, null, "up")).toEqual({
+      index: 0,
+      text: "newest",
+    });
+  });
+
+  it("cycles older then clears past newest on down", () => {
+    expect(stepPromptHistory(history, 0, "up")).toEqual({
+      index: 1,
+      text: "mid",
+    });
+    expect(stepPromptHistory(history, 1, "down")).toEqual({
+      index: 0,
+      text: "newest",
+    });
+    expect(stepPromptHistory(history, 0, "down")).toEqual({
+      index: null,
+      text: "",
+    });
+  });
+
+  it("handles empty history", () => {
+    expect(stepPromptHistory([], null, "up")).toEqual({
+      index: null,
+      text: "",
+    });
+  });
+});
+
+describe("shouldHandlePromptHistoryKey", () => {
+  it("claims ArrowUp only when empty or browsing", () => {
+    expect(
+      shouldHandlePromptHistoryKey({
+        key: "ArrowUp",
+        draftEmpty: true,
+        browsing: false,
+        historyLength: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHandlePromptHistoryKey({
+        key: "ArrowUp",
+        draftEmpty: false,
+        browsing: true,
+        historyLength: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHandlePromptHistoryKey({
+        key: "ArrowUp",
+        draftEmpty: false,
+        browsing: false,
+        historyLength: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("claims ArrowDown only while browsing", () => {
+    expect(
+      shouldHandlePromptHistoryKey({
+        key: "ArrowDown",
+        draftEmpty: true,
+        browsing: false,
+        historyLength: 2,
+      }),
+    ).toBe(false);
+    expect(
+      shouldHandlePromptHistoryKey({
+        key: "ArrowDown",
+        draftEmpty: false,
+        browsing: true,
+        historyLength: 2,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores other keys and empty history", () => {
+    expect(
+      shouldHandlePromptHistoryKey({
+        key: "Enter",
+        draftEmpty: true,
+        browsing: false,
+        historyLength: 2,
+      }),
+    ).toBe(false);
+    expect(
+      shouldHandlePromptHistoryKey({
+        key: "ArrowUp",
+        draftEmpty: true,
+        browsing: false,
+        historyLength: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/composerPromptHistory.ts
+++ b/src/lib/composerPromptHistory.ts
@@ -1,0 +1,93 @@
+/**
+ * Composer prompt history — CLI-like ↑/↓ recall of prior user prompts.
+ *
+ * History is newest-first (index 0 = most recent user message).
+ * Index `null` means not browsing (live draft).
+ */
+
+export type PromptHistoryStep = {
+  /** Index into history (0 = newest), or null when not browsing. */
+  index: number | null;
+  /** Draft text to apply ("" when leaving history). */
+  text: string;
+};
+
+/**
+ * Extract prior user prompt strings from session messages, newest first.
+ * Skips empty / whitespace-only content. Keeps stored display form
+ * (`[[skill:…]]` tokens) so the composer can re-render chips.
+ */
+export function collectUserPromptHistory(
+  messages: ReadonlyArray<{ role: string; content?: string | null }>,
+): string[] {
+  const out: string[] = [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (!m || m.role !== "user") continue;
+    const c = m.content ?? "";
+    if (!c.trim()) continue;
+    out.push(c);
+  }
+  return out;
+}
+
+/**
+ * Compute next history index for ↑ / ↓.
+ * - null means "live empty draft" (not browsing)
+ * - up from null → 0; up clamps at oldest
+ * - down from 0 → null (clear); down from null stays null
+ */
+export function nextPromptHistoryIndex(
+  currentIndex: number | null,
+  historyLength: number,
+  direction: "up" | "down",
+): number | null {
+  if (historyLength <= 0) return null;
+  if (direction === "up") {
+    if (currentIndex == null) return 0;
+    return Math.min(currentIndex + 1, historyLength - 1);
+  }
+  // down
+  if (currentIndex == null) return null;
+  if (currentIndex <= 0) return null;
+  return currentIndex - 1;
+}
+
+/**
+ * Pure step: given history (newest first) and direction, return next
+ * index + text for the composer.
+ */
+export function stepPromptHistory(
+  history: readonly string[],
+  currentIndex: number | null,
+  direction: "up" | "down",
+): PromptHistoryStep {
+  const index = nextPromptHistoryIndex(
+    currentIndex,
+    history.length,
+    direction,
+  );
+  if (index == null) return { index: null, text: "" };
+  return { index, text: history[index] ?? "" };
+}
+
+/**
+ * Whether ↑/↓ should be claimed for history navigation.
+ * Parent must ensure slash palette is closed before calling.
+ *
+ * - ArrowUp: only when draft is empty (start) or already browsing
+ * - ArrowDown: only while already browsing (forward / clear)
+ */
+export function shouldHandlePromptHistoryKey(input: {
+  key: string;
+  draftEmpty: boolean;
+  browsing: boolean;
+  historyLength: number;
+}): boolean {
+  if (input.historyLength <= 0) return false;
+  if (input.key !== "ArrowUp" && input.key !== "ArrowDown") return false;
+  if (input.key === "ArrowUp") {
+    return input.draftEmpty || input.browsing;
+  }
+  return input.browsing;
+}


### PR DESCRIPTION
## Problem
CLI recalls prior prompts with ↑ on an empty prompt. The App composer had no equivalent.

## Changes
- Empty draft + slash palette closed: ↑/↓ cycle user prompts in the current session
- Pure helpers + unit tests
- Does not steal ↑/↓ while slash palette is open

## Test plan
- [x] composerPromptHistory tests + tsc
- [ ] Empty composer ↑ fills last user message; ↑ again goes older; ↓ returns / clears
- [ ] Slash palette ↑/↓ still navigates commands