### PR TITLE
feat: toast when corrupt store files are quarantined

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -625,6 +625,12 @@ pub async fn settings_get() -> Result<AppSettings, String> {
     Ok(store::load_settings())
 }
 
+/// One-shot notice after corrupt store files were quarantined on load.
+#[tauri::command]
+pub fn store_take_quarantine() -> Option<String> {
+    store::take_store_quarantine()
+}
+
 #[tauri::command]
 pub async fn settings_set(
     app: tauri::AppHandle,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,6 +204,7 @@ pub fn run() {
             commands::session_media_root,
             commands::session_resolve_relative_media,
             commands::settings_get,
+            commands::store_take_quarantine,
             commands::settings_set,
             commands::memory_clear,
             commands::settings_remember_last_session,

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -1,5 +1,6 @@
 //! Independent store under ~/.grok-app: projects, sessions index, settings, secrets.
 
+use std::sync::Mutex;
 use std::fs;
 use std::path::PathBuf;
 
@@ -359,6 +360,10 @@ fn read_json<T: for<'de> Deserialize<'de> + Default>(path: &PathBuf) -> T {
     }
 }
 
+
+/// Last quarantined store path (corrupt JSON recovered). Taken once by the UI.
+static LAST_STORE_QUARANTINE: Mutex<Option<String>> = Mutex::new(None);
+
 /// Read JSON; if the file exists but is corrupt, quarantine it and return default.
 fn read_json_recover<T: for<'de> Deserialize<'de> + Default>(path: &PathBuf) -> T {
     match fs::read_to_string(path) {
@@ -373,11 +378,20 @@ fn read_json_recover<T: for<'de> Deserialize<'de> + Default>(path: &PathBuf) -> 
                 let stamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
                 let bak = path.with_extension(format!("corrupt-{stamp}.json"));
                 let _ = fs::rename(path, &bak);
+                if let Ok(mut g) = LAST_STORE_QUARANTINE.lock() {
+                    *g = Some(bak.display().to_string());
+                }
                 T::default()
             }
         },
         Err(_) => T::default(),
     }
+}
+
+
+/// Pop the most recent store quarantine path (if any) for a one-shot UI notice.
+pub fn take_store_quarantine() -> Option<String> {
+    LAST_STORE_QUARANTINE.lock().ok().and_then(|mut g| g.take())
 }
 
 fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<(), String> {
@@ -1365,6 +1379,18 @@ mod tests {
                 || r.contains("sk-")
         );
         assert!(!r.is_empty());
+    }
+
+    #[test]
+    fn take_store_quarantine_is_one_shot() {
+        // Seed the static as if a corrupt file was recovered.
+        {
+            let mut g = LAST_STORE_QUARANTINE.lock().unwrap();
+            *g = Some("/tmp/fake-corrupt-store.json".into());
+        }
+        let first = take_store_quarantine();
+        assert_eq!(first.as_deref(), Some("/tmp/fake-corrupt-store.json"));
+        assert!(take_store_quarantine().is_none());
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1123,6 +1123,20 @@ export default function App() {
         setAppGate("ready");
       }
 
+      // One-shot: corrupt store JSON was renamed aside on load (shared-mode safety).
+      void api
+        .storeTakeQuarantine()
+        .then((path) => {
+          if (!path) return;
+          const msg = createT(resolveLocale(settings.locale))(
+            "store.quarantineNotice",
+            { path },
+          );
+          setToast(msg);
+          window.setTimeout(() => setToast(null), 9000);
+        })
+        .catch(() => {});
+
       // Prefer first trusted project; keep selection if still present
       setActiveProject((prev) => {
         if (prev && (p as Project[]).some((x) => x.id === prev.id)) {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -607,6 +607,8 @@ const en = {
   "settings.section.general": "General",
   "settings.language": "Language",
   "settings.languageDesc": "App UI language",
+  "store.quarantineNotice":
+    "A damaged settings/sessions file was set aside ({path}). The app started with defaults for that file.",
   "settings.sessionDataMode": "Session data mode",
   "settings.sessionDataModeDesc":
     "Where chat history is stored (independent app dir or shared with CLI)",
@@ -2287,6 +2289,8 @@ const zh: Record<MessageKey, string> = {
   "settings.section.general": "常规",
   "settings.language": "语言",
   "settings.languageDesc": "应用界面语言",
+  "store.quarantineNotice":
+    "检测到损坏的配置/会话文件，已隔离备份（{path}）。该文件已按默认值启动。",
   "settings.sessionDataMode": "会话数据模式",
   "settings.sessionDataModeDesc": "会话历史存储位置（应用独立目录或与 CLI 共享）",
   "settings.cliSessions": "CLI 会话",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -579,6 +579,8 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.section.general": "一般",
   "settings.language": "語言",
   "settings.languageDesc": "應用程式介面語言",
+  "store.quarantineNotice":
+    "偵測到損壞的設定/工作階段檔，已隔離備份（{path}）。該檔已以預設值啟動。",
   "settings.sessionDataMode": "對話資料模式",
   "settings.sessionDataModeDesc": "對話歷史儲存位置（應用程式獨立目錄或與 CLI 共用）",
   "settings.cliSessions": "CLI 工作階段",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -826,6 +826,11 @@ export async function settingsGet() {
   return invoke<AppSettings>("settings_get");
 }
 
+/** Path of a store JSON file quarantined after corrupt parse (one-shot). */
+export async function storeTakeQuarantine() {
+  return invoke<string | null>("store_take_quarantine");
+}
+
 export async function modelsListAvailable() {
   return invoke<AvailableModelsResult>("models_list_available");
 }


### PR DESCRIPTION
## Problem
When sessions/settings JSON is corrupt, the host quarantines the file and starts empty — but the UI stayed silent, so shared-mode damage looked like “data vanished.”

## Changes
- Record quarantine backup path on recovery
- `store_take_quarantine` one-shot command
- Startup toast with path (en / zh / zh-TW)
- Unit test: notice is one-shot

## Test plan
- [x] `pnpm typecheck`
- [x] `cargo test --lib store::tests::take_store_quarantine_is_one_shot`
- [ ] Break a store JSON file → restart → toast + `.corrupt-*.json` backup