### PR TITLE
feat: Settings → Voice for live speaker and dictation prefs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -819,6 +819,11 @@ export default function App() {
     Array<{ name: string; source: string }>
   >([]);
   const [experimentalMemory, setExperimentalMemory] = useState(false);
+  const [voiceId, setVoiceId] = useState("eve");
+  const [voiceDictationAutoSend, setVoiceDictationAutoSend] = useState(false);
+  const [voiceKeepAgentsOnEnd, setVoiceKeepAgentsOnEnd] = useState(true);
+  const voiceDictationAutoSendRef = useRef(false);
+  const sendRef = useRef<(() => Promise<void>) | null>(null);
   const [subagentsEnabled, setSubagentsEnabled] = useState(true);
   const [planEnabled, setPlanEnabled] = useState(true);
   const [disableWebSearch, setDisableWebSearch] = useState(false);
@@ -1142,6 +1147,11 @@ export default function App() {
       }
       setPreferredAgent((settings.preferredAgent || "").trim());
       setExperimentalMemory(!!settings.experimentalMemory);
+      setVoiceId((settings.voiceId || "eve").trim() || "eve");
+      setVoiceDictationAutoSend(!!settings.voiceDictationAutoSend);
+      setVoiceKeepAgentsOnEnd(
+        settings.voiceKeepAgentsOnEnd !== false,
+      );
       setSubagentsEnabled(settings.subagentsEnabled !== false);
       setPlanEnabled(settings.planEnabled !== false);
       setDisableWebSearch(!!settings.disableWebSearch);
@@ -3886,6 +3896,8 @@ export default function App() {
       targetSessionId: session.sessionId,
     });
   };
+  sendRef.current = send;
+  voiceDictationAutoSendRef.current = voiceDictationAutoSend;
 
   executeSendFromQueueRef.current = (opts) => executeSend(opts);
 
@@ -4688,12 +4700,22 @@ export default function App() {
         }
         if (!voiceResultStillCurrent(gen, voiceGenRef.current)) return;
         const caret = voiceCaretRef.current;
+        let inserted = "";
         setDraft((d) => {
           const at =
             caret == null ? d.length : Math.max(0, Math.min(caret, d.length));
-          return insertTranscriptIntoDraft(d, res.text!, at).text;
+          inserted = insertTranscriptIntoDraft(d, res.text!, at).text;
+          return inserted;
         });
         setVoice((s) => reduceVoice(s, { type: "transcribe_ok" }));
+        if (
+          voiceDictationAutoSendRef.current &&
+          inserted.trim().length > 0
+        ) {
+          window.setTimeout(() => {
+            void sendRef.current?.();
+          }, 0);
+        }
       } catch (e) {
         if (!voiceResultStillCurrent(gen, voiceGenRef.current)) return;
         const cls = classifyVoiceError(String(e));
@@ -7390,6 +7412,28 @@ export default function App() {
               api.settingsSet({ ...s, experimentalMemory: v }),
             );
           }}
+          voiceId={voiceId}
+          onVoiceId={(v) => {
+            const next = (v || "eve").trim() || "eve";
+            setVoiceId(next);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, voiceId: next }),
+            );
+          }}
+          voiceDictationAutoSend={voiceDictationAutoSend}
+          onVoiceDictationAutoSend={(v) => {
+            setVoiceDictationAutoSend(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, voiceDictationAutoSend: v }),
+            );
+          }}
+          voiceKeepAgentsOnEnd={voiceKeepAgentsOnEnd}
+          onVoiceKeepAgentsOnEnd={(v) => {
+            setVoiceKeepAgentsOnEnd(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, voiceKeepAgentsOnEnd: v }),
+            );
+          }}
           subagentsEnabled={subagentsEnabled}
           onSubagentsEnabled={(v) => {
             setSubagentsEnabled(v);
@@ -9606,6 +9650,8 @@ export default function App() {
         projectPath={activeProject?.path ?? null}
         projectId={activeProject?.id ?? null}
         projectName={activeProject?.name ?? null}
+        voiceId={voiceId}
+        keepAgentsOnEnd={voiceKeepAgentsOnEnd}
         onClose={() => setLiveVoiceOpen(false)}
         onOpenSession={(id) => {
           setLiveVoiceOpen(false);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -163,6 +163,15 @@ export interface SettingsPageProps {
   onSubagentsEnabled?: (v: boolean) => void;
   useLeader?: boolean;
   onUseLeader?: (v: boolean) => void;
+  /** Live voice speaker id (xAI realtime), e.g. eve. */
+  voiceId?: string;
+  onVoiceId?: (v: string) => void;
+  /** After dictation STT, send the prompt immediately. */
+  voiceDictationAutoSend?: boolean;
+  onVoiceDictationAutoSend?: (v: boolean) => void;
+  /** Keep delegated agent sessions when Live Voice ends. */
+  voiceKeepAgentsOnEnd?: boolean;
+  onVoiceKeepAgentsOnEnd?: (v: boolean) => void;
   /** Store App API keys in OS keychain (default off → secrets.json). */
   storeApiKeysInKeychain?: boolean;
   onStoreApiKeysInKeychain?: (v: boolean) => void;
@@ -514,6 +523,12 @@ export function SettingsPage({
   onDisableWebSearch,
   useLeader = false,
   onUseLeader,
+  voiceId = "eve",
+  onVoiceId,
+  voiceDictationAutoSend = false,
+  onVoiceDictationAutoSend,
+  voiceKeepAgentsOnEnd = true,
+  onVoiceKeepAgentsOnEnd,
   reopenLastSession = true,
   onReopenLastSession,
   cliInfo,
@@ -1213,8 +1228,76 @@ export function SettingsPage({
               ) : null}
             </div>
 
+            <h2 className="settings-page__h2">{t("settings.section.voice")}</h2>
+            <div className="settings-card" id="settings-voice-card">
+              {onVoiceId ? (
+                <div className="settings-row settings-row--stack">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.voiceId")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.voiceIdDesc")}
+                    </div>
+                  </div>
+                  <Select
+                    value={voiceId || "eve"}
+                    onChange={(v) => onVoiceId(v)}
+                    options={[
+                      { value: "eve", label: "Eve" },
+                      { value: "ara", label: "Ara" },
+                      { value: "rex", label: "Rex" },
+                      { value: "sal", label: "Sal" },
+                      { value: "leo", label: "Leo" },
+                      ...(voiceId &&
+                      !["eve", "ara", "rex", "sal", "leo"].includes(voiceId)
+                        ? [{ value: voiceId, label: voiceId }]
+                        : []),
+                    ]}
+                  />
+                </div>
+              ) : null}
+              {onVoiceDictationAutoSend ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.voiceDictationAutoSend")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.voiceDictationAutoSendDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={!!voiceDictationAutoSend}
+                    onChange={() =>
+                      onVoiceDictationAutoSend(!voiceDictationAutoSend)
+                    }
+                    ariaLabel={t("settings.voiceDictationAutoSend")}
+                  />
+                </div>
+              ) : null}
+              {onVoiceKeepAgentsOnEnd ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.voiceKeepAgentsOnEnd")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.voiceKeepAgentsOnEndDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={!!voiceKeepAgentsOnEnd}
+                    onChange={() =>
+                      onVoiceKeepAgentsOnEnd(!voiceKeepAgentsOnEnd)
+                    }
+                    ariaLabel={t("settings.voiceKeepAgentsOnEnd")}
+                  />
+                </div>
+              ) : null}
+            </div>
 
-<h2 className="settings-page__h2">{t("settings.section.general")}</h2>
+            <h2 className="settings-page__h2">{t("settings.section.general")}</h2>
             <div className="settings-card">
               <div className="settings-row">
                 <div className="settings-row__text">

--- a/src/components/VoiceOverlay.tsx
+++ b/src/components/VoiceOverlay.tsx
@@ -29,6 +29,8 @@ export type VoiceOverlayProps = {
   projectPath?: string | null;
   projectId?: string | null;
   projectName?: string | null;
+  voiceId?: string | null;
+  keepAgentsOnEnd?: boolean;
   onClose: () => void;
   onOpenSession?: (sessionId: string) => void;
 };
@@ -39,6 +41,8 @@ export function VoiceOverlay({
   projectPath,
   projectId,
   projectName,
+  voiceId,
+  keepAgentsOnEnd = true,
   onClose,
   onOpenSession,
 }: VoiceOverlayProps) {
@@ -94,6 +98,8 @@ export function VoiceOverlay({
           projectPath,
           projectId,
           projectName,
+          voiceId: voiceId ?? null,
+          keepAgentsOnEnd,
         });
         setState(st);
         appendLine(
@@ -167,7 +173,16 @@ export function VoiceOverlay({
         }
       });
     };
-  }, [open, projectPath, projectId, projectName, appendLine, tt]);
+  }, [
+    open,
+    projectPath,
+    projectId,
+    projectName,
+    voiceId,
+    keepAgentsOnEnd,
+    appendLine,
+    tt,
+  ]);
 
   const handleEnd = async () => {
     stopCapture.current?.();

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -617,7 +617,17 @@ const en = {
   "settings.archived.totalCount": "{n} archived",
   "settings.section.permissions": "Permissions",
   "settings.section.composer": "Composer prefs",
+  "settings.section.voice": "Voice",
   "settings.section.general": "General",
+  "settings.voiceId": "Live voice speaker",
+  "settings.voiceIdDesc":
+    "Voice used for full-duplex Live Voice (xAI realtime).",
+  "settings.voiceDictationAutoSend": "Send after dictation",
+  "settings.voiceDictationAutoSendDesc":
+    "When mic dictation finishes, send the prompt instead of only inserting text.",
+  "settings.voiceKeepAgentsOnEnd": "Keep coding sessions after Live Voice",
+  "settings.voiceKeepAgentsOnEndDesc":
+    "If off, ending Live Voice may stop sessions started from voice.",
   "settings.language": "Language",
   "settings.languageDesc": "App UI language",
   "store.quarantineNotice":
@@ -2391,7 +2401,16 @@ const zh: Record<MessageKey, string> = {
   "settings.archived.totalCount": "共 {n} 条",
   "settings.section.permissions": "权限",
   "settings.section.composer": "对话偏好",
+  "settings.section.voice": "语音",
   "settings.section.general": "常规",
+  "settings.voiceId": "实时语音音色",
+  "settings.voiceIdDesc": "全双工实时语音使用的音色（xAI realtime）。",
+  "settings.voiceDictationAutoSend": "听写结束后直接发送",
+  "settings.voiceDictationAutoSendDesc":
+    "麦克风听写转写完成后直接发送，而不是只插入输入框。",
+  "settings.voiceKeepAgentsOnEnd": "结束实时语音后保留编码会话",
+  "settings.voiceKeepAgentsOnEndDesc":
+    "关闭后，结束实时语音可能会停止由语音发起的编码会话。",
   "settings.language": "语言",
   "settings.languageDesc": "应用界面语言",
   "store.quarantineNotice":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -589,7 +589,16 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.archived.totalCount": "共 {n} 條",
   "settings.section.permissions": "權限",
   "settings.section.composer": "對話偏好",
+  "settings.section.voice": "語音",
   "settings.section.general": "一般",
+  "settings.voiceId": "即時語音音色",
+  "settings.voiceIdDesc": "全雙工即時語音使用的音色（xAI realtime）。",
+  "settings.voiceDictationAutoSend": "聽寫結束後直接傳送",
+  "settings.voiceDictationAutoSendDesc":
+    "麥克風聽寫轉寫完成後直接傳送，而不是只插入輸入框。",
+  "settings.voiceKeepAgentsOnEnd": "結束即時語音後保留編碼工作階段",
+  "settings.voiceKeepAgentsOnEndDesc":
+    "關閉後，結束即時語音可能會停止由語音發起的編碼工作階段。",
   "settings.language": "語言",
   "settings.languageDesc": "應用程式介面語言",
   "store.quarantineNotice":


### PR DESCRIPTION
## Problem
`voiceId`, dictation auto-send, and keep-agents-on-end were stored and used by the host, but Settings had no controls and Live Voice start did not pass them.

## Changes
- Settings → Voice: speaker select, send-after-dictation, keep agents after Live Voice ends
- Wire into App settings load/save
- Live Voice start uses stored voice id + keep-agents flag
- Optional auto-send after mic dictation STT

## Test plan
- [x] `pnpm typecheck`
- [ ] Settings → Voice toggles persist after restart
- [ ] Live Voice uses selected speaker (or mock path)
- [ ] Dictation auto-send sends when enabled