### PR TITLE
feat: toast when the live agent soft-respawns after settings

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -698,7 +698,7 @@ pub async fn settings_set(
         need_soft_respawn = true;
     }
     if need_soft_respawn {
-        mgr.soft_respawn(&app).await;
+        mgr.soft_respawn_with_reason(&app, "settings_spawn").await;
     }
 
     if let Err(e) = mgr

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -3207,6 +3207,11 @@ impl SessionManager {
     /// state (MCP mcpServers injection, plugin enable/disable, prefs) without a full
     /// disconnect toast. Public for Extensions / plugin settings mutations.
     pub async fn soft_respawn(&self, app: &AppHandle) {
+        self.soft_respawn_with_reason(app, "settings").await;
+    }
+
+    /// Soft-respawn and tell the UI why the agent process was reloaded.
+    pub async fn soft_respawn_with_reason(&self, app: &AppHandle, reason: &str) {
         let acp = {
             let mut guard = self.inner.lock();
             if let Some(s) = guard.as_mut() {
@@ -3226,6 +3231,10 @@ impl SessionManager {
         };
         if let Some(acp) = acp {
             acp.kill().await;
+            let _ = app.emit(
+                "session://agent_soft_respawn",
+                serde_json::json!({ "reason": reason }),
+            );
             Self::emit_state(app, &self.snapshot());
         }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1706,6 +1706,17 @@ export default function App() {
           ),
         );
         await track(
+          api.listen<{ reason?: string }>(
+            "session://agent_soft_respawn",
+            (p) => {
+              if (cancelled || !p) return;
+              // Spawn flags / extensions changed while an agent was live.
+              setToast(tr("agent.softRespawnToast"));
+              window.setTimeout(() => setToast(null), 3600);
+            },
+          ),
+        );
+        await track(
           api.listen<{
             sessionId?: string;
             stopReason?: string;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -694,6 +694,8 @@ const en = {
     "Agent process recycled after idle — session kept; next message will reconnect.",
   "agent.dataModeRecycledToast":
     "Agents restarted after data mode change — next message reconnects under the new home.",
+  "agent.softRespawnToast":
+    "Agent reloaded with new settings — next message reconnects.",
   "agent.processLimitToast":
     "Agent process limit reached. Stop another session or raise the limit in Settings → Runtime.",
   "agent.streamStallBanner":
@@ -2467,6 +2469,8 @@ const zh: Record<MessageKey, string> = {
     "Agent 进程因闲置已回收 — 会话仍在；下次发送将重新连接。",
   "agent.dataModeRecycledToast":
     "数据模式切换后已重启 Agent — 下次发送将在新目录下重连。",
+  "agent.softRespawnToast":
+    "已按新设置重载 Agent — 下次发送将重新连接。",
   "agent.processLimitToast":
     "已达 Agent 进程上限。请先停止其他会话，或在设置 → 运行环境中提高上限。",
   "agent.streamStallBanner":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -665,6 +665,8 @@ export const zhTW: Record<MessageKey, string> = {
     "Agent 行程因閒置已回收 — 工作階段仍在；下次傳送將重新連線。",
   "agent.dataModeRecycledToast":
     "資料模式切換後已重啟 Agent — 下次傳送將在新目錄下重連。",
+  "agent.softRespawnToast":
+    "已依新設定重載 Agent — 下次傳送將重新連線。",
   "agent.processLimitToast":
     "已達 Agent 行程上限。請先停止其他工作階段，或在設定 → 執行環境中提高上限。",
   "agent.streamStallBanner":


### PR DESCRIPTION
## Problem
Changing spawn-related settings soft-respawned the agent with no UI feedback, so users thought nothing happened.

## Changes
- Emit `session://agent_soft_respawn` when a live agent is reloaded
- Toast: agent reloaded with new settings

## Test plan
- [x] `cargo check --lib`
- [ ] Connect agent → toggle subagents / plan / web search → toast appears