### PR TITLE
feat: optional close-to-tray vs quit on window close

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,13 +97,17 @@ pub fn run() {
                 responder.respond(response);
             });
         })
-        // Close button / Alt+F4 → hide to tray only (no Dock / taskbar icon).
-        // Full exit: tray "Quit Grok" or Cmd+Q.
+        // Close button / Alt+F4: hide to tray (default) or quit — Settings → General.
+        // Full exit always available via tray "Quit Grok" or Cmd+Q.
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 use tauri::Manager;
-                api.prevent_close();
-                tray::hide_to_tray(window.app_handle());
+                let close_to_tray = store::load_settings().close_to_tray;
+                if close_to_tray {
+                    api.prevent_close();
+                    tray::hide_to_tray(window.app_handle());
+                }
+                // else: allow default close → process exit
             }
         })
         .setup(|app| {

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -214,6 +214,9 @@ pub struct AppSettings {
     /// xAI realtime voice id (e.g. `eve`).
     #[serde(default = "default_voice_id")]
     pub voice_id: String,
+    /// When true, window close hides to tray. When false, close quits the app.
+    #[serde(default = "default_close_to_tray")]
+    pub close_to_tray: bool,
     /// When true, dictation auto-sends on end-of-speech silence.
     #[serde(default)]
     pub voice_dictation_auto_send: bool,
@@ -258,6 +261,10 @@ fn default_voice_id() -> String {
     "eve".into()
 }
 
+fn default_close_to_tray() -> bool {
+    true
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -295,6 +302,7 @@ impl Default for AppSettings {
             voice_id: default_voice_id(),
             voice_dictation_auto_send: false,
             voice_keep_agents_on_end: true,
+            close_to_tray: default_close_to_tray(),
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -824,6 +824,7 @@ export default function App() {
   const [disableWebSearch, setDisableWebSearch] = useState(false);
   const [useLeader, setUseLeader] = useState(false);
   const [reopenLastSession, setReopenLastSession] = useState(true);
+  const [closeToTray, setCloseToTray] = useState(true);
   const [lastSessionId, setLastSessionId] = useState<string | null>(null);
   const didRestoreLastRef = useRef(false);
   const [tasksPanelOpen, setTasksPanelOpen] = useState(false);
@@ -1147,6 +1148,7 @@ export default function App() {
       setDisableWebSearch(!!settings.disableWebSearch);
       setUseLeader(!!settings.useLeader);
       setReopenLastSession(settings.reopenLastSession !== false);
+      setCloseToTray(settings.closeToTray !== false);
       setLastSessionId(
         typeof settings.lastSessionId === "string"
           ? settings.lastSessionId.trim() || null
@@ -7423,6 +7425,13 @@ export default function App() {
             setReopenLastSession(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, reopenLastSession: v }),
+            );
+          }}
+          closeToTray={closeToTray}
+          onCloseToTray={(v) => {
+            setCloseToTray(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, closeToTray: v }),
             );
           }}
           cliInfo={cliInfo}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -157,6 +157,8 @@ export interface SettingsPageProps {
   onDisableWebSearch?: (v: boolean) => void;
   reopenLastSession?: boolean;
   onReopenLastSession?: (v: boolean) => void;
+  closeToTray?: boolean;
+  onCloseToTray?: (v: boolean) => void;
   planEnabled?: boolean;
   onPlanEnabled?: (v: boolean) => void;
   subagentsEnabled?: boolean;
@@ -516,6 +518,8 @@ export function SettingsPage({
   onUseLeader,
   reopenLastSession = true,
   onReopenLastSession,
+  closeToTray = true,
+  onCloseToTray,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -1318,6 +1322,23 @@ export function SettingsPage({
                     checked={!!reopenLastSession}
                     onChange={() => onReopenLastSession(!reopenLastSession)}
                     ariaLabel={t("settings.reopenLastSession")}
+                  />
+                </div>
+              ) : null}
+              {onCloseToTray ? (
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.closeToTray")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.closeToTrayDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={!!closeToTray}
+                    onChange={() => onCloseToTray(!closeToTray)}
+                    ariaLabel={t("settings.closeToTray")}
                   />
                 </div>
               ) : null}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -721,6 +721,9 @@ const en = {
   "settings.planEnabledDesc": "When off, spawn with --no-plan so the agent cannot enter plan mode. Soft-respawns after change.",
   "settings.useLeader": "Share agent backend (leader)",
   "settings.useLeaderDesc": "Connect with --leader so multiple clients can share one backend process. Off uses --no-leader (default). Soft-respawns after change.",
+  "settings.closeToTray": "Close window to tray",
+  "settings.closeToTrayDesc":
+    "When on, the red close button hides the app to the menu bar / system tray. Turn off to quit the app on close (Quit from the tray still works either way).",
   "settings.reopenLastSession": "Reopen last chat on startup",
   "settings.reopenLastSessionDesc": "When the app launches, open the chat you were last viewing if it still exists and is not archived.",
 "settings.prefsScope": "Remember model & permission at",
@@ -2494,6 +2497,9 @@ const zh: Record<MessageKey, string> = {
   "settings.planEnabledDesc": "关闭时启动加上 --no-plan，Agent 无法进入计划模式。更改后 soft-respawn。",
   "settings.useLeader": "共享 Agent 后端（leader）",
   "settings.useLeaderDesc": "使用 --leader 让多个客户端共用一个后端进程；关闭则 --no-leader（默认）。更改后 soft-respawn。",
+  "settings.closeToTray": "关闭窗口时最小化到托盘",
+  "settings.closeToTrayDesc":
+    "开启后，关闭按钮会隐藏到菜单栏/系统托盘。关闭此项则关闭窗口即退出（托盘「退出」始终可用）。",
   "settings.reopenLastSession": "启动时恢复上次对话",
   "settings.reopenLastSessionDesc": "应用启动后，若上次打开的对话仍存在且未归档，则自动打开。",
 "settings.prefsScope": "模型与权限记忆范围",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -692,6 +692,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.planEnabledDesc": "關閉時啟動加上 --no-plan，Agent 無法進入計畫模式。變更後 soft-respawn。",
   "settings.useLeader": "共用 Agent 後端（leader）",
   "settings.useLeaderDesc": "使用 --leader 讓多個用戶端共用一個後端行程；關閉則 --no-leader（預設）。變更後 soft-respawn。",
+  "settings.closeToTray": "關閉視窗時縮到系統匣",
+  "settings.closeToTrayDesc":
+    "開啟後，關閉按鈕會隱藏到選單列/系統匣。關閉此項則關閉視窗即結束（系統匣「結束」始終可用）。",
   "settings.reopenLastSession": "啟動時還原上次對話",
   "settings.reopenLastSessionDesc": "應用程式啟動後，若上次開啟的對話仍存在且未封存，則自動開啟。",
 "settings.prefsScope": "模型與權限記憶範圍",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -828,6 +828,8 @@ export interface AppSettings {
   voiceId?: string;
   voiceDictationAutoSend?: boolean;
   voiceKeepAgentsOnEnd?: boolean;
+  /** Window close hides to tray when true (default). */
+  closeToTray?: boolean;
 }
 
 export interface ReasoningEffort {


### PR DESCRIPTION
## Problem
Window close always hid to tray. Some users expect the red button to quit.

## Changes
- `closeToTray` setting (default on)
- Settings → General toggle
- Host respects setting on `CloseRequested`

## Test plan
- [x] `pnpm typecheck` + `cargo check --lib`
- [ ] Default: close → tray
- [ ] Toggle off: close → app exits