### PR TITLE
feat: structured stream-stall banner aligned with error deck

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8380,15 +8380,19 @@ export default function App() {
             </div>
           )}
 
-          {/* I06: pure stream silence — cancel or keep waiting */}
+          {/* I06: pure stream silence — structured deck actions (cancel or keep waiting) */}
           {streamStall && mainPane === "chat" && (
-            <div className="stall-banner" role="status">
-              <div className="stall-banner__summary">
-                {tr("agent.streamStallBanner", {
+            <div className="stall-banner error-banner" role="status">
+              <div className="error-banner__code">STREAM_STALL</div>
+              <div className="error-banner__summary">
+                {tr("error.deck.stall.problem")}
+              </div>
+              <div className="error-banner__cause">
+                {tr("error.deck.stall.cause", {
                   seconds: String(streamStall.stallSeconds),
                 })}
               </div>
-              <div className="stall-banner__actions">
+              <div className="stall-banner__actions error-banner__actions">
                 <button
                   type="button"
                   className="btn btn--ghost stall-banner__btn"

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -182,6 +182,9 @@ const en = {
   "error.deck.disconnect.problem": "Agent connection interrupted",
   "error.deck.disconnect.cause":
     "The RPC channel closed mid-turn. Reconnect and send again.",
+  "error.deck.stall.problem": "Stream looks stuck",
+  "error.deck.stall.cause":
+    "No tokens or tool progress for about {seconds}s. Cancel this turn or keep waiting.",
   "error.deck.generic.problem": "Something went wrong",
   "error.deck.generic.cause":
     "Check Doctor for CLI/auth status, then retry the last action.",
@@ -1972,6 +1975,9 @@ const zh: Record<MessageKey, string> = {
   "error.deck.disconnect.problem": "与 Agent 的连接已中断",
   "error.deck.disconnect.cause":
     "传输通道在回合中关闭。请重新连接后再发送。",
+  "error.deck.stall.problem": "输出似乎卡住了",
+  "error.deck.stall.cause":
+    "约 {seconds} 秒没有新的内容或工具进度。可取消本轮或继续等待。",
   "error.deck.generic.problem": "出了点问题",
   "error.deck.generic.cause": "可在 Doctor 查看 CLI/鉴权状态，然后重试上一步操作。",
   "main.startTitle": "开始对话",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -168,6 +168,9 @@ export const zhTW: Record<MessageKey, string> = {
   "error.deck.timeout.cause":
     "等待過久已中止。可重試；生圖等長任務可能需要更久。",
   "error.deck.disconnect.problem": "與 Agent 的連線已中斷",
+  "error.deck.stall.problem": "輸出似乎卡住了",
+  "error.deck.stall.cause":
+    "約 {seconds} 秒沒有新的內容或工具進度。可取消本輪或繼續等待。",
   "error.deck.disconnect.cause":
     "傳輸通道在回合中關閉。請重新連線後再傳送。",
   "error.deck.generic.problem": "出了點問題",

--- a/src/lib/errorDeck.ts
+++ b/src/lib/errorDeck.ts
@@ -27,6 +27,7 @@ export type ErrorDeckCode =
   | "PROCESS_LIMIT"
   | "TURN_TIMEOUT"
   | "AGENT_DISCONNECTED"
+  | "STREAM_STALL"
   | "GENERIC";
 
 export type ErrorDeckAction = {
@@ -125,6 +126,14 @@ const DECK: Record<ErrorDeckCode, DeckSpec> = {
     primaryLabel: "error.action.reconnect",
     secondaryId: "open_doctor",
     secondaryLabel: "error.action.openDoctor",
+  },
+  STREAM_STALL: {
+    problem: "error.deck.stall.problem",
+    cause: "error.deck.stall.cause",
+    primaryId: "dismiss",
+    primaryLabel: "agent.streamStallKeepWaiting",
+    secondaryId: "dismiss",
+    secondaryLabel: "agent.streamStallCancel",
   },
   GENERIC: {
     problem: "error.deck.generic.problem",


### PR DESCRIPTION
## Problem
Stream stall UI was a one-line banner and did not match the error deck pattern (problem / cause / actions).

## Changes
- `STREAM_STALL` in error deck catalog
- Stall banner shows code + problem + cause with seconds
- Keep waiting / cancel actions unchanged

## Test plan
- [x] `pnpm typecheck` + `errorDeck` tests
- [ ] Lower stream stall seconds → wait → structured banner