### PR TITLE
feat(chat): add queued follow-ups and mid-turn steering

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,9 @@ fs2 = "0.4"
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 url = "2"
 
+[dev-dependencies]
+tauri = { version = "2", features = ["test"] }
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -1321,6 +1321,27 @@ impl AcpClient {
         Ok(())
     }
 
+    /// Inject guidance into the active prompt without cancelling the turn.
+    /// Grok Build extension: `_x.ai/interject`.
+    pub async fn interject(&self, text: &str) -> Result<(), String> {
+        let text = text.trim();
+        if text.is_empty() {
+            return Err("empty interjection".into());
+        }
+        let sid = self
+            .agent_session_id
+            .lock()
+            .clone()
+            .ok_or_else(|| "no agent session".to_string())?;
+        self.request(
+            "_x.ai/interject",
+            wire_session_interject_params(&sid, text),
+        )
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("_x.ai/interject: {e}"))
+    }
+
     /// Cancel in-flight prompt (ACP notification — no id).
     pub async fn cancel(&self) -> Result<(), String> {
         let sid = self
@@ -1484,6 +1505,14 @@ pub fn wire_session_prompt_params(session_id: &str, text: &str) -> Value {
     json!({
         "sessionId": session_id,
         "prompt": [{ "type": "text", "text": text }]
+    })
+}
+
+/// Host → agent `_x.ai/interject` params.
+pub fn wire_session_interject_params(session_id: &str, text: &str) -> Value {
+    json!({
+        "sessionId": session_id,
+        "text": text,
     })
 }
 

--- a/src-tauri/src/acp_golden_test.rs
+++ b/src-tauri/src/acp_golden_test.rs
@@ -12,8 +12,8 @@ use serde_json::{json, Value};
 use crate::acp_client::{
     decode_permission_request, decode_session_update, parse_ask_user_question_params,
     wire_ask_user_result, wire_exit_plan_mode_result, wire_initialize_params, wire_jsonrpc_result,
-    wire_permission_result, wire_session_cancel_params, wire_session_prompt_params, AcpEvent,
-    AskUserOutcome, PermissionOutcome, StreamKind,
+    wire_permission_result, wire_session_cancel_params, wire_session_interject_params,
+    wire_session_prompt_params, AcpEvent, AskUserOutcome, PermissionOutcome, StreamKind,
 };
 use crate::mock_acp::{chunk_text, mock_reply_for, spawn_fake_stream_channel};
 use crate::permission::pick_option_id;
@@ -75,6 +75,13 @@ fn session_prompt_and_cancel_wire_shapes() {
     assert_eq!(
         prompt["prompt"],
         json!([{ "type": "text", "text": "hello" }])
+    );
+    assert_eq!(
+        wire_session_interject_params("sess-a", "use the existing component"),
+        json!({
+            "sessionId": "sess-a",
+            "text": "use the existing component"
+        })
     );
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,7 +7,7 @@ use tauri::State;
 
 use crate::cli_probe::{self, CliProbeResult};
 use crate::session_manager::{SessionManager, SessionSnapshot};
-use crate::store::{self, AppSettings, Project, SessionMeta};
+use crate::store::{self, AppSettings, MessageAttachmentStored, Project, SessionMeta};
 
 fn windows_grok_go_config_candidates() -> Option<Vec<String>> {
     #[cfg(target_os = "windows")]
@@ -57,6 +57,19 @@ pub async fn session_send(
     display_text: Option<String>,
 ) -> Result<SessionSnapshot, String> {
     mgr.send_message(app, text, display_text).await
+}
+
+/// Inject guidance into the active turn without cancelling the running prompt.
+#[tauri::command]
+pub async fn session_interject(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    text: String,
+    display_text: Option<String>,
+    attachments: Option<Vec<MessageAttachmentStored>>,
+) -> Result<SessionSnapshot, String> {
+    mgr.interject_message(app, text, display_text, attachments)
+        .await
 }
 
 /// Drop last user turn on agent + local journal (edit & resend).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -158,6 +158,7 @@ pub fn run() {
             commands::session_get_state,
             commands::session_connect,
             commands::session_send,
+            commands::session_interject,
             commands::session_stop,
             commands::session_disconnect,
             commands::session_reattach,

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -5,6 +5,9 @@ use std::path::{Path, PathBuf};
 
 use directories::ProjectDirs;
 
+#[cfg(test)]
+pub(crate) static APP_HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub fn app_data_root() -> PathBuf {
     if let Ok(custom) = std::env::var("GROK_APP_HOME") {
         return PathBuf::from(custom);

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -152,7 +152,15 @@ struct LiveSession {
     backend: String,
     acp: Option<Arc<AcpClient>>,
     mock_stream: Option<MockStreamHandle>,
+    /// Stable identity for one user prompt turn. Unlike streaming_message_id,
+    /// this does not change when the agent changes message ids or Steer splits
+    /// one turn into multiple assistant rows.
+    active_turn_id: Option<String>,
     streaming_message_id: Option<String>,
+    /// Keep the host-created assistant id after an interjection splits the turn.
+    /// The agent may continue emitting its original messageId, which must not
+    /// merge post-interjection output back into the frozen pre-interjection row.
+    stream_message_id_locked: bool,
     /// Accumulated assistant text for current turn (persisted on complete).
     stream_buf: String,
     stream_thought: String,
@@ -193,6 +201,17 @@ struct LiveSession {
     deferred_prompt_complete: Option<String>,
     /// Tool events observed during the current turn (empty-run soft signal).
     tools_this_turn: u32,
+}
+
+impl LiveSession {
+    /// Drop the current turn's stream identity so the next prompt starts clean.
+    /// Deliberately narrow: buffers, tool state and throttles are reset by the
+    /// caller, since which of those survive differs per call site.
+    fn reset_stream_state(&mut self) {
+        self.active_turn_id = None;
+        self.streaming_message_id = None;
+        self.stream_message_id_locked = false;
+    }
 }
 
 /// Ready agent process parked while another App session is focused (I01/I02).
@@ -608,7 +627,7 @@ impl SessionManager {
         {
             let _ = s.fsm.end_stream();
         }
-        s.streaming_message_id = None;
+        s.reset_stream_state();
         s.last_stall_emit = None;
         tracing::info!(
             "acp turn finished after deferred prompt_complete stop={stop_reason}"
@@ -714,6 +733,92 @@ impl SessionManager {
         s.journal_throttle.mark_flushed(now);
         if force {
             s.journal_throttle.reset();
+        }
+    }
+
+    /// Start a fresh assistant journal/UI row after a mid-turn interjection.
+    /// Existing body, thought phases, and attachments have already been force-
+    /// flushed into the previous row and must not leak into the new segment.
+    fn begin_post_interjection_stream(s: &mut LiveSession) {
+        s.streaming_message_id = Some(Uuid::new_v4().to_string());
+        s.stream_message_id_locked = true;
+        s.stream_buf.clear();
+        s.stream_thought.clear();
+        s.stream_last_was_assistant = false;
+        s.stream_attachments.clear();
+        s.journal_throttle.reset();
+    }
+
+    fn is_interjection_turn_active(
+        s: &LiveSession,
+        app_session_id: &str,
+        turn_id: &str,
+    ) -> bool {
+        s.app_session_id == app_session_id
+            && s.active_turn_id.as_deref() == Some(turn_id)
+            && matches!(
+                s.fsm.state(),
+                SessionState::Streaming | SessionState::AwaitingPermission
+            )
+    }
+
+    /// Persist an interjection at the current stream boundary while holding the
+    /// session lock. Emitting before the lock is released guarantees the UI sees
+    /// the user row before any post-interjection stream chunk.
+    fn commit_interjection_boundary<R: tauri::Runtime>(
+        s: &mut LiveSession,
+        app: &AppHandle<R>,
+        message: &ChatMessageStored,
+        expected_app_session_id: &str,
+        expected_turn_id: &str,
+    ) -> Result<(), String> {
+        if !Self::is_interjection_turn_active(
+            s,
+            expected_app_session_id,
+            expected_turn_id,
+        ) {
+            return Err("interjection turn is no longer active".into());
+        }
+        Self::maybe_flush_stream_journal(s, true, false);
+        // The ACP interject has already landed and cannot be rolled back: the
+        // agent has split its turn and will emit post-interjection chunks
+        // whatever happens here. So journal writes stay best-effort (as on every
+        // other stream path) — bailing out on one would skip the stream-id split
+        // below and merge those chunks back into the frozen pre-interjection row.
+        if let Err(e) = store::append_message(&s.app_session_id, message.clone()) {
+            tracing::error!("interjection journal append failed: {e}");
+        }
+        s.meta.updated_at = message.created_at;
+        if let Err(e) = store::update_session_meta(&s.meta) {
+            tracing::warn!("interjection meta update failed: {e}");
+        }
+
+        Self::begin_post_interjection_stream(s);
+
+        let _ = app.emit(
+            "session://interjection",
+            serde_json::json!({
+                "sessionId": s.app_session_id,
+                "message": message,
+            }),
+        );
+        Ok(())
+    }
+
+    /// Adopt the agent's message id unless the host deliberately split this
+    /// turn at an interjection boundary.
+    fn ensure_stream_message_id(s: &mut LiveSession, kind: StreamKind, message_id: Option<String>) {
+        if !s.stream_message_id_locked {
+            if let Some(ref mid_in) = message_id {
+                if s.streaming_message_id.as_ref() != Some(mid_in)
+                    && (s.streaming_message_id.is_none() || matches!(kind, StreamKind::Assistant))
+                {
+                    s.streaming_message_id = Some(mid_in.clone());
+                }
+            }
+        }
+        if s.streaming_message_id.is_none() {
+            s.streaming_message_id = Some(message_id.unwrap_or_else(|| Uuid::new_v4().to_string()));
         }
     }
 
@@ -946,7 +1051,9 @@ impl SessionManager {
             backend: parked.backend,
             acp: Some(parked.acp),
             mock_stream: None,
+            active_turn_id: None,
             streaming_message_id: None,
+            stream_message_id_locked: false,
             stream_buf: String::new(),
             stream_thought: String::new(),
             stream_last_was_assistant: false,
@@ -1218,7 +1325,7 @@ impl SessionManager {
         s.stream_thought.clear();
         s.stream_last_was_assistant = false;
         s.stream_attachments.clear();
-        s.streaming_message_id = None;
+        s.reset_stream_state();
         s.journal_throttle.reset();
         s.last_stall_emit = None;
 
@@ -1448,7 +1555,9 @@ impl SessionManager {
                 backend: Self::backend_name(),
                 acp: None,
                 mock_stream: None,
+                active_turn_id: None,
                 streaming_message_id: None,
+                stream_message_id_locked: false,
                 stream_buf: String::new(),
                 stream_thought: String::new(),
                 stream_last_was_assistant: false,
@@ -1794,21 +1903,9 @@ impl SessionManager {
                         }
                         // Stream chunk = progress (I06); not pure silence.
                         Self::touch_stream_progress_locked(s);
-                        // Prefer agent-supplied messageId; otherwise keep the turn id.
-                        if let Some(ref mid_in) = message_id {
-                            if s.streaming_message_id.as_ref() != Some(mid_in) {
-                                // New assistant message id mid-turn (rare) — adopt it.
-                                if s.streaming_message_id.is_none()
-                                    || matches!(kind, StreamKind::Assistant)
-                                {
-                                    s.streaming_message_id = Some(mid_in.clone());
-                                }
-                            }
-                        }
-                        if s.streaming_message_id.is_none() {
-                            s.streaming_message_id =
-                                Some(message_id.unwrap_or_else(|| Uuid::new_v4().to_string()));
-                        }
+                        // Prefer agent-supplied messageId unless an interjection
+                        // deliberately split this turn into a new host-owned row.
+                        Self::ensure_stream_message_id(s, kind, message_id);
                         // Split thinking whenever it resumes after body text so the UI
                         // can interleave thought ↔ content (not stack all thoughts on top).
                         let thought_phase = match kind {
@@ -2474,18 +2571,7 @@ impl SessionManager {
                         return;
                     }
                     Self::touch_stream_progress_locked(s);
-                    if let Some(ref mid_in) = message_id {
-                        if s.streaming_message_id.as_ref() != Some(mid_in)
-                            && (s.streaming_message_id.is_none()
-                                || matches!(kind, StreamKind::Assistant))
-                        {
-                            s.streaming_message_id = Some(mid_in.clone());
-                        }
-                    }
-                    if s.streaming_message_id.is_none() {
-                        s.streaming_message_id =
-                            Some(message_id.unwrap_or_else(|| Uuid::new_v4().to_string()));
-                    }
+                    Self::ensure_stream_message_id(s, kind, message_id);
                     let thought_phase = match kind {
                         StreamKind::Thought => {
                             let phase = if s.stream_last_was_assistant {
@@ -2548,7 +2634,7 @@ impl SessionManager {
                         ) {
                             let _ = s.fsm.end_stream();
                         }
-                        s.streaming_message_id = None;
+                        s.reset_stream_state();
                         s.last_stall_emit = None;
                     }
                 }
@@ -2739,7 +2825,10 @@ impl SessionManager {
                 return Err("cannot edit while a turn is running".into());
             }
             let msgs = store::load_messages(&s.app_session_id);
-            let user_prompt_count = msgs.iter().filter(|m| m.role == "user").count() as u32;
+            let user_prompt_count = msgs
+                .iter()
+                .filter(|m| store::is_user_prompt_message(m))
+                .count() as u32;
             if user_prompt_count == 0 {
                 return Err("no user message to rewind".into());
             }
@@ -2795,7 +2884,7 @@ impl SessionManager {
         let msgs = store::load_messages(&app_sid);
         let mut cut = msgs.len();
         for (i, m) in msgs.iter().enumerate().rev() {
-            if m.role == "user" {
+            if store::is_user_prompt_message(m) {
                 cut = i;
                 break;
             }
@@ -2841,7 +2930,7 @@ impl SessionManager {
         let mut out = Vec::new();
         let mut idx = 0u32;
         for m in msgs {
-            if m.role != "user" {
+            if !store::is_user_prompt_message(&m) {
                 continue;
             }
             let raw = m.content.split_whitespace().collect::<Vec<_>>().join(" ");
@@ -2899,7 +2988,10 @@ impl SessionManager {
         }
 
         let msgs = store::load_messages(&app_sid);
-        let user_count = msgs.iter().filter(|m| m.role == "user").count() as u32;
+        let user_count = msgs
+            .iter()
+            .filter(|m| store::is_user_prompt_message(m))
+            .count() as u32;
         if user_count == 0 {
             return Err("no user messages to rewind".into());
         }
@@ -2998,8 +3090,10 @@ impl SessionManager {
             let s = guard.as_mut().ok_or("no active session")?;
             s.fsm.begin_stream().map_err(|e| e.to_string())?;
             Self::touch_stream_progress_locked(s);
+            s.active_turn_id = Some(Uuid::new_v4().to_string());
             let mid = Uuid::new_v4().to_string();
             s.streaming_message_id = Some(mid.clone());
+            s.stream_message_id_locked = false;
             s.stream_buf.clear();
             s.stream_thought.clear();
             s.stream_last_was_assistant = false;
@@ -3068,34 +3162,41 @@ impl SessionManager {
                 agent_prompt,
                 Duration::from_millis(25),
                 move |chunk: StreamChunk| {
-                    let _ = app_done.emit(
-                        "session://stream",
-                        serde_json::json!({
-                            "sessionId": chunk.session_id,
-                            "messageId": chunk.message_id,
-                            "text": chunk.text,
-                            "done": chunk.done,
-                            "kind": "assistant"
-                        }),
-                    );
-                    let mut guard = mgr.inner.lock();
-                    if let Some(s) = guard.as_mut() {
+                    let mid = {
+                        let mut guard = mgr.inner.lock();
+                        let Some(s) = guard.as_mut() else {
+                            return;
+                        };
                         SessionManager::touch_stream_progress_locked(s);
                         s.stream_buf.push_str(&chunk.text);
                         // I04: throttle mid-stream; force on terminal done.
                         let para = is_paragraph_break(&chunk.text);
                         SessionManager::maybe_flush_stream_journal(s, chunk.done, para);
+                        let mid = s
+                            .streaming_message_id
+                            .clone()
+                            .unwrap_or_else(|| chunk.message_id.clone());
                         if chunk.done {
                             s.stream_buf.clear();
                             s.journal_throttle.reset();
                             s.last_stall_emit = None;
                             if s.fsm.state() == SessionState::Streaming {
                                 let _ = s.fsm.end_stream();
-                                s.streaming_message_id = None;
+                                s.reset_stream_state();
                             }
                         }
-                    }
-                    drop(guard);
+                        mid
+                    };
+                    let _ = app_done.emit(
+                        "session://stream",
+                        serde_json::json!({
+                            "sessionId": chunk.session_id,
+                            "messageId": mid,
+                            "text": chunk.text,
+                            "done": chunk.done,
+                            "kind": "assistant"
+                        }),
+                    );
                     if chunk.done {
                         SessionManager::emit_state(&app_done, &mgr.snapshot());
                     }
@@ -3127,6 +3228,106 @@ impl SessionManager {
         });
 
         Ok(self.snapshot())
+    }
+
+    /// Inject a queued follow-up into the currently streaming turn without cancelling it.
+    pub async fn interject_message<R: tauri::Runtime>(
+        &self,
+        app: AppHandle<R>,
+        text: String,
+        display_text: Option<String>,
+        attachments: Option<Vec<MessageAttachmentStored>>,
+    ) -> Result<SessionSnapshot, String> {
+        let text = text.trim().to_string();
+        if text.is_empty() {
+            return Err("empty interjection".into());
+        }
+        let journal_content = display_text
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| text.clone());
+        let attachments = attachments.filter(|items| !items.is_empty());
+
+        let (backend, app_sid, turn_id, acp) = {
+            let guard = self.inner.lock();
+            let s = guard.as_ref().ok_or("no active session")?;
+            if s.fsm.state() != SessionState::Streaming {
+                return Err("interjection requires a streaming turn".into());
+            }
+            let turn_id = s
+                .active_turn_id
+                .clone()
+                .ok_or("interjection requires an active turn")?;
+            (
+                s.backend.clone(),
+                s.app_session_id.clone(),
+                turn_id,
+                s.acp.clone(),
+            )
+        };
+
+        if backend != "mock_acp" && !AcpClient::use_mock() {
+            acp.ok_or("ACP client missing")?.interject(&text).await?;
+        }
+
+        let created_at = chrono::Utc::now();
+        let message = ChatMessageStored {
+            id: Uuid::new_v4().to_string(),
+            role: "user".into(),
+            content: journal_content,
+            thought: None,
+            created_at,
+            is_error: false,
+            attachments,
+            marker: Some("interjection".into()),
+        };
+
+        // Keep journal and UI event order atomic with respect to stream/tool
+        // handlers. The session may have moved to the background while the ACP
+        // interject RPC was in flight, so handle both routing slots.
+        let committed_live = {
+            let mut guard = self.inner.lock();
+            if let Some(s) = guard.as_mut() {
+                if s.app_session_id == app_sid {
+                    Self::commit_interjection_boundary(
+                        s,
+                        &app,
+                        &message,
+                        &app_sid,
+                        &turn_id,
+                    )?;
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+        if committed_live {
+            return Ok(self.snapshot());
+        }
+
+        let committed_background = {
+            let mut background = self.background.lock();
+            if let Some(s) = background.get_mut(&app_sid) {
+                Self::commit_interjection_boundary(
+                    s,
+                    &app,
+                    &message,
+                    &app_sid,
+                    &turn_id,
+                )?;
+                true
+            } else {
+                false
+            }
+        };
+        if committed_background {
+            return Ok(self.snapshot());
+        }
+
+        Err("interjection turn is no longer active".into())
     }
 
     pub async fn stop(self: &Arc<Self>, app: AppHandle) -> Result<SessionSnapshot, String> {
@@ -3176,7 +3377,7 @@ impl SessionManager {
             if was_busy {
                 let _ = s.fsm.end_stream();
             }
-            s.streaming_message_id = None;
+            s.reset_stream_state();
             s.stream_buf.clear();
             s.stream_thought.clear();
             s.stream_last_was_assistant = false;
@@ -3292,7 +3493,7 @@ impl SessionManager {
                 s.stream_last_was_assistant = false;
                 s.stream_attachments.clear();
                 s.journal_throttle.reset();
-                s.streaming_message_id = None;
+                s.reset_stream_state();
                 s.open_tool_ids.clear();
                 s.deferred_prompt_complete = None;
                 s.tools_this_turn = 0;
@@ -3670,6 +3871,63 @@ struct DrainedAgents {
 mod recycle_tests {
     use super::*;
 
+    fn sample_live_session() -> LiveSession {
+        let now = chrono::Utc::now();
+        let instant = Instant::now();
+        let mut fsm = SessionFsm::new();
+        fsm.start_connect().unwrap();
+        fsm.handshake_ok().unwrap();
+        fsm.begin_stream().unwrap();
+        LiveSession {
+            app_session_id: "session-1".into(),
+            process_id: "process-1".into(),
+            meta: SessionMeta {
+                id: "session-1".into(),
+                project_id: None,
+                title: "Test".into(),
+                agent_session_id: None,
+                created_at: now,
+                updated_at: now,
+                model_id: None,
+                archived: false,
+                pinned: false,
+                effort: None,
+                mode: None,
+                permission_policy: None,
+                scheduled: false,
+            },
+            fsm,
+            backend: "mock_acp".into(),
+            acp: None,
+            mock_stream: None,
+            active_turn_id: Some("turn-1".into()),
+            streaming_message_id: Some("agent-message-1".into()),
+            stream_message_id_locked: false,
+            stream_buf: "before".into(),
+            stream_thought: "thinking before".into(),
+            stream_last_was_assistant: true,
+            stream_attachments: Vec::new(),
+            model_id: None,
+            effort: None,
+            product_mode: None,
+            project_path: None,
+            allow_cache: SessionAllowCache::default(),
+            policy: PermissionPolicy::default(),
+            provider_retry_attempt: 0,
+            provider_retry_aborted: false,
+            needs_history_bootstrap: false,
+            pending_plan_rpc_id: None,
+            pending_ask_user_rpc_id: None,
+            last_activity: instant,
+            last_stream_progress: instant,
+            last_stall_emit: None,
+            journal_throttle: JournalWriteThrottle::with_default_interval(),
+            open_tool_ids: HashSet::new(),
+            deferred_prompt_complete: None,
+            tools_this_turn: 0,
+        }
+    }
+
     #[test]
     fn drain_all_agent_slots_clears_empty_maps() {
         let mgr = SessionManager::new();
@@ -3689,5 +3947,202 @@ mod recycle_tests {
         assert!(again.acps.is_empty());
         assert_eq!(again.background_count, 0);
         assert_eq!(again.parked_count, 0);
+    }
+
+    #[tokio::test]
+    async fn interject_message_rejects_non_streaming_session() {
+        let mgr = SessionManager::new();
+        let mut session = sample_live_session();
+        session.fsm.end_stream().unwrap();
+        session.active_turn_id = None;
+        *mgr.inner.lock() = Some(session);
+        let app = tauri::test::mock_app();
+
+        let err = mgr
+            .interject_message(
+                app.handle().clone(),
+                "Use the existing component".into(),
+                None,
+                None,
+            )
+            .await
+            .expect_err("ready session must reject interjection");
+
+        assert_eq!(err, "interjection requires a streaming turn");
+    }
+
+    #[tokio::test]
+    async fn interject_message_commits_marker_emits_event_and_splits_assistant_stream() {
+        use std::ffi::OsString;
+        use std::fs;
+        use std::sync::{Arc, Mutex as StdMutex};
+        use tauri::Listener;
+
+        struct TestHome {
+            path: std::path::PathBuf,
+            previous: Option<OsString>,
+        }
+
+        impl Drop for TestHome {
+            fn drop(&mut self) {
+                if let Some(previous) = self.previous.take() {
+                    std::env::set_var("GROK_APP_HOME", previous);
+                } else {
+                    std::env::remove_var("GROK_APP_HOME");
+                }
+                let _ = fs::remove_dir_all(&self.path);
+            }
+        }
+
+        let _env_guard = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let path = std::env::temp_dir().join(format!(
+            "grok-app-interjection-test-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let home = TestHome {
+            previous: std::env::var_os("GROK_APP_HOME"),
+            path: path.clone(),
+        };
+        std::env::set_var("GROK_APP_HOME", &home.path);
+
+        let session = sample_live_session();
+        fs::create_dir_all(home.path.join("sessions").join(&session.app_session_id)).unwrap();
+        fs::write(home.path.join("sessions_index.json"), "[]").unwrap();
+        fs::write(
+            home.path
+                .join("sessions")
+                .join(&session.app_session_id)
+                .join("messages.json"),
+            "[]",
+        )
+        .unwrap();
+
+        let mgr = SessionManager::new();
+        *mgr.inner.lock() = Some(session);
+        let app = tauri::test::mock_app();
+        let emitted_payload = Arc::new(StdMutex::new(None::<String>));
+        let payload_slot = Arc::clone(&emitted_payload);
+        app.listen("session://interjection", move |event| {
+            *payload_slot.lock().unwrap() = Some(event.payload().to_string());
+        });
+
+        mgr.interject_message(
+            app.handle().clone(),
+            "Use the existing component".into(),
+            Some("Use the existing component".into()),
+            None,
+        )
+        .await
+        .expect("mock interjection should commit");
+
+        let post_interjection_id = {
+            let mut live = mgr.inner.lock();
+            let live = live.as_mut().expect("live session remains attached");
+            let post_interjection_id = live
+                .streaming_message_id
+                .clone()
+                .expect("post-interjection assistant id");
+            assert!(live.stream_message_id_locked);
+            assert!(live.stream_buf.is_empty());
+            live.stream_buf.push_str("after");
+            SessionManager::maybe_flush_stream_journal(live, true, false);
+            post_interjection_id
+        };
+        assert_ne!(post_interjection_id, "agent-message-1");
+
+        let messages = store::load_messages("session-1");
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].role, "assistant");
+        assert_eq!(messages[0].id, "agent-message-1");
+        assert_eq!(messages[0].content, "before");
+        assert_eq!(messages[1].role, "user");
+        assert_eq!(messages[1].content, "Use the existing component");
+        assert_eq!(messages[1].marker.as_deref(), Some("interjection"));
+        assert_eq!(messages[2].role, "assistant");
+        assert_eq!(messages[2].id, post_interjection_id);
+        assert_eq!(messages[2].content, "after");
+
+        let payload = emitted_payload
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("session://interjection payload");
+        let payload: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(payload["sessionId"], "session-1");
+        assert_eq!(payload["message"]["id"], messages[1].id);
+        assert_eq!(payload["message"]["content"], "Use the existing component");
+        assert_eq!(payload["message"]["marker"], "interjection");
+    }
+
+    #[test]
+    fn interjection_turn_validation_rejects_finished_replaced_or_other_session() {
+        let mut session = sample_live_session();
+
+        assert!(SessionManager::is_interjection_turn_active(
+            &session,
+            "session-1",
+            "turn-1",
+        ));
+        assert!(!SessionManager::is_interjection_turn_active(
+            &session,
+            "session-2",
+            "turn-1",
+        ));
+
+        session.fsm.await_permission().unwrap();
+        assert!(SessionManager::is_interjection_turn_active(
+            &session,
+            "session-1",
+            "turn-1",
+        ));
+
+        session.fsm.end_stream().unwrap();
+        session.active_turn_id = None;
+        assert!(!SessionManager::is_interjection_turn_active(
+            &session,
+            "session-1",
+            "turn-1",
+        ));
+
+        session.fsm.begin_stream().unwrap();
+        session.active_turn_id = Some("turn-2".into());
+        assert!(!SessionManager::is_interjection_turn_active(
+            &session,
+            "session-1",
+            "turn-1",
+        ));
+        assert!(SessionManager::is_interjection_turn_active(
+            &session,
+            "session-1",
+            "turn-2",
+        ));
+    }
+
+    #[test]
+    fn interjection_starts_host_owned_stream_segment() {
+        let mut session = sample_live_session();
+
+        SessionManager::begin_post_interjection_stream(&mut session);
+        let post_interjection_id = session
+            .streaming_message_id
+            .clone()
+            .expect("post-interjection message id");
+
+        assert_ne!(post_interjection_id, "agent-message-1");
+        assert!(session.stream_message_id_locked);
+        assert!(session.stream_buf.is_empty());
+        assert!(session.stream_thought.is_empty());
+        assert!(!session.stream_last_was_assistant);
+
+        SessionManager::ensure_stream_message_id(
+            &mut session,
+            StreamKind::Assistant,
+            Some("agent-message-1".into()),
+        );
+        assert_eq!(
+            session.streaming_message_id.as_deref(),
+            Some(post_interjection_id.as_str())
+        );
     }
 }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -777,6 +777,12 @@ pub fn append_message(session_id: &str, msg: ChatMessageStored) -> Result<(), St
     save_messages(session_id, &msgs)
 }
 
+/// True for a normal user prompt turn. Mid-turn interjections belong to the
+/// surrounding turn and are excluded from rewind prompt indexes.
+pub fn is_user_prompt_message(message: &ChatMessageStored) -> bool {
+    message.role == "user" && message.marker.as_deref() != Some("interjection")
+}
+
 /// End index (exclusive) of the full turn for `user_prompt_index` (0-based).
 /// Turn = that user message + following non-user rows until the next user.
 pub fn end_index_through_user_prompt(
@@ -785,12 +791,12 @@ pub fn end_index_through_user_prompt(
 ) -> Option<usize> {
     let mut user_i = 0u32;
     for (i, m) in messages.iter().enumerate() {
-        if m.role != "user" {
+        if !is_user_prompt_message(m) {
             continue;
         }
         if user_i == user_prompt_index {
             let mut j = i + 1;
-            while j < messages.len() && messages[j].role != "user" {
+            while j < messages.len() && !is_user_prompt_message(&messages[j]) {
                 j += 1;
             }
             return Some(j);
@@ -1493,6 +1499,47 @@ mod tests {
             permission_policy: None,
             scheduled: false,
         }
+    }
+
+    fn sample_message(
+        id: &str,
+        role: &str,
+        marker: Option<&str>,
+    ) -> ChatMessageStored {
+        ChatMessageStored {
+            id: id.into(),
+            role: role.into(),
+            content: id.into(),
+            thought: None,
+            created_at: Utc::now(),
+            is_error: false,
+            attachments: None,
+            marker: marker.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn interjection_stays_inside_surrounding_rewind_turn() {
+        let messages = vec![
+            sample_message("u1", "user", None),
+            sample_message("a1", "assistant", None),
+            sample_message("i1", "user", Some("interjection")),
+            sample_message("u2", "user", None),
+        ];
+
+        assert_eq!(
+            messages.iter().filter(|m| is_user_prompt_message(m)).count(),
+            2
+        );
+        assert_eq!(end_index_through_user_prompt(&messages, 0), Some(3));
+        assert_eq!(
+            truncate_through_user_prompt(&messages, 0)
+                .expect("truncate first turn")
+                .iter()
+                .map(|m| m.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["u1", "a1", "i1"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/support_bundle.rs
+++ b/src-tauri/src/support_bundle.rs
@@ -687,13 +687,9 @@ pub fn reset_app_data(keep_secrets: bool) -> Result<serde_json::Value, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
     #[test]
     fn reset_keeps_secrets_when_requested() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-reset-test-{}",
             std::process::id()
@@ -716,7 +712,7 @@ mod tests {
 
     #[test]
     fn support_bundle_creates_zip_without_secrets() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-bundle-test-{}",
             std::process::id()
@@ -742,7 +738,7 @@ mod tests {
 
     #[test]
     fn session_bundle_includes_messages_without_secrets() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-session-bundle-test-{}",
             std::process::id()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import {
 import {
   applyContextCompact,
   applyGeneratedImage,
+  applyInterjection,
   applyStreamChunk,
   applyToolEvent,
   applyTurnError,
@@ -58,6 +59,7 @@ import {
   clearPriorTurnStreaming,
   isSessionBusy,
   isSessionLiveStreaming,
+  isTurnPromptMessage,
   preferSessionMessages,
   presentErrorBanner,
   type ErrorBannerView,
@@ -168,10 +170,7 @@ import {
   shouldHandlePromptHistoryKey,
   stepPromptHistory,
 } from "@/lib/composerPromptHistory";
-import {
-  queuePreviewText,
-  shouldEnqueueSend,
-} from "@/lib/sendQueue";
+import { shouldEnqueueSend, type QueuedSend } from "@/lib/sendQueue";
 import {
   useSendQueue,
   type ExecuteSendFromQueue,
@@ -198,6 +197,7 @@ import {
   getComposerCaretOffset,
 } from "@/components/ComposerEditor";
 import { ComposerProjectMenu } from "@/components/ComposerProjectMenu";
+import { ComposerQueue } from "@/components/ComposerQueue";
 import {
   buildWorktreeSiblingPath,
   mainWorktreePath,
@@ -241,9 +241,9 @@ import {
   IconSearch,
   IconAttach,
   IconSend,
+  IconQueue,
   IconMic,
   IconLiveVoice,
-  IconQueue,
   IconStop,
   IconFolder,
   IconFolderPlus,
@@ -411,6 +411,8 @@ export default function App() {
   >({});
   /** Composer stored form (may include [[skill:name]] tokens). */
   const [draft, setDraft] = useState("");
+  const [guidingQueueItemId, setGuidingQueueItemId] = useState<string | null>(null);
+  const queueGuideInFlightRef = useRef(false);
   /**
    * CLI-like prompt history browse index (0 = newest user msg).
    * null = not browsing; only engaged when draft empty (or already browsing).
@@ -1558,6 +1560,19 @@ export default function App() {
               void tryApplyAutomationFromSession(chunk.sessionId);
             }
           }),
+        );
+        await track(
+          api.listen<{ sessionId: string; message: ChatMessage }>(
+            "session://interjection",
+            (payload) => {
+              if (cancelled || !payload?.sessionId || !payload.message?.id) {
+                return;
+              }
+              patchSessionMessages(payload.sessionId, (prev) =>
+                applyInterjection(prev, payload.message),
+              );
+            },
+          ),
         );
         await track(
           api.listen<GeneratedImagePayload>(
@@ -3585,7 +3600,7 @@ export default function App() {
 
   const lastUserMessageId = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]?.role === "user") return messages[i]!.id;
+      if (isTurnPromptMessage(messages[i])) return messages[i]!.id;
     }
     return null;
   }, [messages]);
@@ -3888,15 +3903,6 @@ export default function App() {
   };
 
   executeSendFromQueueRef.current = (opts) => executeSend(opts);
-
-  const queuePreviewLabels = useMemo(
-    () => ({
-      filesCount: (n: number) =>
-        tr("composer.queueFilesCount", { n: String(n) }),
-      empty: tr("composer.queueEmptyPreview"),
-    }),
-    [tr],
-  );
 
   const addAttachmentsFromPaths = useCallback(
 
@@ -4946,10 +4952,58 @@ export default function App() {
     liveHostRef,
     viewingSessionIdRef,
     sendInFlightRef,
+    flushPaused: guidingQueueItemId !== null,
+    flushPauseRef: queueGuideInFlightRef,
     executeSendRef: executeSendFromQueueRef,
     showToast,
     labels: sendQueueLabels,
   });
+
+  const canGuideQueuedMessage =
+    session.state === "streaming" &&
+    !connecting &&
+    !!session.sessionId &&
+    liveHost.sessionId === session.sessionId &&
+    liveHost.state === "streaming";
+
+  const guideQueuedMessage = useCallback(
+    async (item: QueuedSend) => {
+      if (guidingQueueItemId || !canGuideQueuedMessage) return;
+      const segments = parseStoredContent(item.storedDisplay);
+      const agentBody = serializeForAgent(segments, { goalMode: item.goalMode });
+      const agentText = buildAgentPrompt(agentBody, item.attachments);
+      if (!agentText.trim()) return;
+
+      queueGuideInFlightRef.current = true;
+      setGuidingQueueItemId(item.id);
+      try {
+        await api.sessionInterject(
+          agentText,
+          item.storedDisplay,
+          item.attachments.map((attachment) => ({
+            path: attachment.path,
+            name: attachment.name,
+            isDir: attachment.isDir,
+          })),
+        );
+        sendQueue.removeItem(item.id);
+      } catch {
+        showToast(tr("composer.queueGuideFailed"), 3600);
+      } finally {
+        queueGuideInFlightRef.current = false;
+        setGuidingQueueItemId((current) =>
+          current === item.id ? null : current,
+        );
+      }
+    },
+    [
+      canGuideQueuedMessage,
+      guidingQueueItemId,
+      sendQueue.removeItem,
+      showToast,
+      tr,
+    ],
+  );
 
   /**
    * Fork a session (full history or through a user-prompt index) and open it.
@@ -8710,77 +8764,17 @@ export default function App() {
                 (dragZone === "main" ? " composer--drop-ready" : "")
               }
             >
-              {sendQueue.activeQueue.length > 0 && (
-                <div
-                  className="composer__queue"
-                  aria-label={tr("composer.queueCount", {
-                    n: String(sendQueue.activeQueue.length),
-                  })}
-                >
-                  <div className="composer__queue-head">
-                    <IconClock size={14} aria-hidden />
-                    <span className="composer__queue-title">
-                      {tr("composer.queueCount", {
-                        n: String(sendQueue.activeQueue.length),
-                      })}
-                    </span>
-                    <button
-                      type="button"
-                      className="composer__queue-clear"
-                      onClick={sendQueue.clearQueue}
-                    >
-                      {tr("composer.queueClear")}
-                    </button>
-                  </div>
-                  {sendQueue.flushHold ? (
-                    <div className="composer__queue-hold" role="status">
-                      <span className="composer__queue-hold-text">
-                        {tr("composer.queueHold")}
-                      </span>
-                      <button
-                        type="button"
-                        className="composer__queue-hold-retry"
-                        onClick={() => sendQueue.resumeFlush()}
-                      >
-                        {tr("composer.queueHoldRetry")}
-                      </button>
-                    </div>
-                  ) : null}
-                  <ul className="composer__queue-list">
-                    {sendQueue.activeQueue.map((item, idx) => (
-                      <li key={item.id} className="composer__queue-item">
-                        <span className="composer__queue-idx" aria-hidden>
-                          {idx + 1}
-                        </span>
-                        <span
-                          className="composer__queue-text"
-                          title={queuePreviewText(
-                            item.storedDisplay,
-                            item.attachments,
-                            200,
-                            queuePreviewLabels,
-                          )}
-                        >
-                          {queuePreviewText(
-                            item.storedDisplay,
-                            item.attachments,
-                            72,
-                            queuePreviewLabels,
-                          )}
-                        </span>
-                        <button
-                          type="button"
-                          className="composer__queue-remove"
-                          aria-label={tr("composer.queueRemove")}
-                          onClick={() => sendQueue.removeItem(item.id)}
-                        >
-                          <IconClose size={12} />
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
+              <ComposerQueue
+                items={sendQueue.activeQueue}
+                flushHold={sendQueue.flushHold}
+                guidingItemId={guidingQueueItemId}
+                canGuide={canGuideQueuedMessage}
+                tr={tr}
+                onClear={sendQueue.clearQueue}
+                onRemove={sendQueue.removeItem}
+                onGuide={guideQueuedMessage}
+                onRetry={sendQueue.resumeFlush}
+              />
               {attachments.length > 0 && (
                 <div
                   className="composer__attachments"

--- a/src/components/ComposerQueue.spec.tsx
+++ b/src/components/ComposerQueue.spec.tsx
@@ -1,0 +1,115 @@
+import React, { isValidElement, type ReactElement, type ReactNode } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { createT } from "@/i18n";
+import { makeQueuedSend, type QueuedSend } from "@/lib/sendQueue";
+import { ComposerQueue, type ComposerQueueProps } from "./ComposerQueue";
+
+const item = makeQueuedSend({
+  storedDisplay: "Use the existing component",
+  attachments: [],
+  goalMode: false,
+  now: 123,
+});
+
+function queueProps(
+  overrides: Partial<ComposerQueueProps> = {},
+): ComposerQueueProps {
+  return {
+    items: [item],
+    flushHold: false,
+    guidingItemId: null,
+    canGuide: true,
+    tr: createT("en"),
+    onClear: () => {},
+    onRemove: () => {},
+    onGuide: () => {},
+    onRetry: () => {},
+    ...overrides,
+  };
+}
+
+function findElement(
+  node: ReactNode,
+  predicate: (element: ReactElement<Record<string, unknown>>) => boolean,
+): ReactElement<Record<string, unknown>> {
+  if (isValidElement<Record<string, unknown>>(node)) {
+    if (predicate(node)) return node;
+    const children = node.props.children;
+    const childNodes = Array.isArray(children) ? children : [children];
+    for (const child of childNodes) {
+      try {
+        return findElement(child as ReactNode, predicate);
+      } catch {
+        // Keep searching sibling branches.
+      }
+    }
+  }
+  throw new Error("matching element not found");
+}
+
+function renderQueue(overrides: Partial<ComposerQueueProps> = {}) {
+  return ComposerQueue(queueProps(overrides));
+}
+
+function guideButton(overrides: Partial<ComposerQueueProps> = {}) {
+  return findElement(
+    renderQueue(overrides),
+    (element) => element.props["data-testid"] === "queue-guide",
+  );
+}
+
+describe("ComposerQueue", () => {
+  it("keeps follow-ups above the composer and exposes a Steer action", () => {
+    const html = renderToString(
+      React.createElement(ComposerQueue, queueProps()),
+    );
+
+    expect(html).toContain('data-testid="composer-queue"');
+    expect(html).toContain("Use the existing component");
+    expect(html).toContain('data-testid="queue-guide"');
+    expect(html).toContain("Steer");
+    expect(html).not.toContain("queued-guidance");
+  });
+
+  it("shows the retry action while queue flushing is held", () => {
+    const html = renderToString(
+      React.createElement(ComposerQueue, queueProps({ flushHold: true })),
+    );
+
+    expect(html).toContain('class="composer__queue-hold"');
+    expect(html).toContain('class="composer__queue-hold-retry"');
+    expect(html).toContain("Retry");
+  });
+
+  it("disables Steer and explains why outside active generation", () => {
+    const button = guideButton({ canGuide: false });
+
+    expect(button.props.disabled).toBe(true);
+    expect(button.props.title).toBe(
+      "Steer is available only while the agent is generating",
+    );
+    expect(button.props["aria-label"]).toBe(
+      "Steer is available only while the agent is generating",
+    );
+  });
+
+  it("disables Steer while another queue item is being guided", () => {
+    const button = guideButton({ guidingItemId: item.id });
+
+    expect(button.props.disabled).toBe(true);
+    expect(button.props.title).toBe("Steering…");
+    expect(button.props.children).toBe("Steering…");
+  });
+
+  it("invokes onGuide with the clicked queue item", () => {
+    const onGuide = vi.fn<(guidedItem: QueuedSend) => void>();
+    const button = guideButton({ onGuide });
+    const onClick = button.props.onClick as () => void;
+
+    onClick();
+
+    expect(onGuide).toHaveBeenCalledOnce();
+    expect(onGuide).toHaveBeenCalledWith(item);
+  });
+});

--- a/src/components/ComposerQueue.tsx
+++ b/src/components/ComposerQueue.tsx
@@ -1,0 +1,140 @@
+import { IconClock, IconClose } from "@/components/icons";
+import type { Vars } from "@/i18n";
+import type { MessageKey } from "@/i18n";
+import { queuePreviewText, type QueuedSend } from "@/lib/sendQueue";
+
+export interface ComposerQueueProps {
+  items: QueuedSend[];
+  flushHold: boolean;
+  guidingItemId: string | null;
+  canGuide: boolean;
+  tr: (key: MessageKey, vars?: Vars) => string;
+  onClear: () => void;
+  onRemove: (id: string) => void;
+  onGuide: (item: QueuedSend) => void | Promise<void>;
+  onRetry: () => void;
+}
+
+export function ComposerQueue({
+  items,
+  flushHold,
+  guidingItemId,
+  canGuide,
+  tr,
+  onClear,
+  onRemove,
+  onGuide,
+  onRetry,
+}: ComposerQueueProps) {
+  if (!items.length) return null;
+
+  const previewLabels = {
+    filesCount: (n: number) =>
+      tr("composer.queueFilesCount", { n: String(n) }),
+    empty: tr("composer.queueEmptyPreview"),
+  };
+
+  return (
+    <div
+      className="composer__queue"
+      data-testid="composer-queue"
+      aria-label={tr("composer.queueCount", { n: String(items.length) })}
+    >
+      <div className="composer__queue-head">
+        <IconClock size={14} aria-hidden />
+        <span className="composer__queue-title">
+          {tr("composer.queueCount", { n: String(items.length) })}
+        </span>
+        <button
+          type="button"
+          className="composer__queue-clear"
+          onClick={onClear}
+        >
+          {tr("composer.queueClear")}
+        </button>
+      </div>
+      {flushHold ? (
+        <div className="composer__queue-hold" role="status">
+          <span className="composer__queue-hold-text">
+            {tr("composer.queueHold")}
+          </span>
+          <button
+            type="button"
+            className="composer__queue-hold-retry"
+            onClick={onRetry}
+          >
+            {tr("composer.queueHoldRetry")}
+          </button>
+        </div>
+      ) : null}
+      <ul className="composer__queue-list">
+        {items.map((item, index) => {
+          const guiding = guidingItemId === item.id;
+          const preview = queuePreviewText(
+            item.storedDisplay,
+            item.attachments,
+            72,
+            previewLabels,
+          );
+          return (
+            <li key={item.id} className="composer__queue-item">
+              <span className="composer__queue-idx" aria-hidden>
+                {index + 1}
+              </span>
+              <span
+                className="composer__queue-text"
+                title={queuePreviewText(
+                  item.storedDisplay,
+                  item.attachments,
+                  200,
+                  previewLabels,
+                )}
+              >
+                {preview}
+              </span>
+              <button
+                type="button"
+                className="composer__queue-guide"
+                data-testid="queue-guide"
+                aria-label={
+                  guiding || guidingItemId !== null
+                    ? tr("composer.queueGuiding")
+                    : canGuide
+                      ? tr("composer.queueGuide")
+                      : tr("composer.queueGuideUnavailable")
+                }
+                title={
+                  guiding || guidingItemId !== null
+                    ? tr("composer.queueGuiding")
+                    : canGuide
+                      ? tr("composer.queueGuide")
+                      : tr("composer.queueGuideUnavailable")
+                }
+                disabled={!canGuide || guidingItemId !== null}
+                onClick={() =>
+                  void Promise.resolve(onGuide(item)).catch((e) => {
+                    console.error("[ComposerQueue] onGuide failed", e);
+                  })
+                }
+              >
+                {guiding
+                  ? tr("composer.queueGuiding")
+                  : tr("composer.queueGuide")}
+              </button>
+              <button
+                type="button"
+                className="composer__queue-remove"
+                aria-label={tr("composer.queueRemove")}
+                title={tr("composer.queueRemove")}
+                disabled={guiding}
+                onClick={() => onRemove(item.id)}
+              >
+                <IconClose size={12} />
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/lobe-chat/ConversationThread.spec.tsx
+++ b/src/components/lobe-chat/ConversationThread.spec.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  ConversationThread,
+  findForceStickMessageId,
+} from "./ConversationThread";
+
+const attachLabels = {
+  open: "Open",
+  reveal: "Reveal",
+  copyPath: "Copy path",
+  copyImage: "Copy image",
+  addToComposer: "Add",
+  remove: "Remove",
+};
+
+describe("ConversationThread force-stick key", () => {
+  it("intentionally re-pins when a Steer interjection is appended", () => {
+    expect(
+      findForceStickMessageId([
+        { id: "u1", role: "user", content: "Build a form" },
+        { id: "a1", role: "assistant", content: "Starting" },
+        {
+          id: "i1",
+          role: "user",
+          content: "Use existing components",
+          marker: "interjection",
+        },
+      ]),
+    ).toBe("i1");
+  });
+});
+
+describe("ConversationThread interjection marker", () => {
+  it("renders a Steer label on mid-turn user interjections", () => {
+    const html = renderToString(
+      React.createElement(ConversationThread, {
+        locale: "en",
+        sessionState: "streaming",
+        sessionKey: "session-1",
+        messages: [
+          { id: "u1", role: "user", content: "Build a form" },
+          {
+            id: "i1",
+            role: "user",
+            content: "Use existing components",
+            marker: "interjection",
+          },
+        ],
+        attachLabels,
+      }),
+    );
+
+    expect(html).toContain('data-message-marker="interjection"');
+    expect(html).toContain("lobe-chat-bubble--interjection");
+    expect(html).toContain("lobe-chat-interjection-tag");
+    expect(html).toContain(">Steer</span>");
+  });
+});

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -8,6 +8,7 @@ import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
 import {
   formatTurnErrorBody,
+  isTurnPromptMessage,
   messageSegments,
   type ChatMessage,
   type SessionState,
@@ -29,6 +30,7 @@ import {
   IconFork,
   IconRename,
   IconRewind,
+  IconTarget,
 } from "@/components/icons";
 import { formatMessageTime } from "@/lib/accountUi";
 import { formatTokenCount } from "@/lib/contextUsage";
@@ -358,6 +360,18 @@ export interface ConversationThreadProps {
   findActive?: { messageId: string; occurrence: number } | null;
 }
 
+/**
+ * Return the latest user-row id that should re-pin the transcript.
+ * This intentionally includes mid-turn interjections: Steer inserts a visible
+ * user row and the following assistant segment should remain in view.
+ */
+export function findForceStickMessageId(messages: ChatMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") return messages[i]!.id;
+  }
+  return null;
+}
+
 export function ConversationThread({
   locale,
   messages,
@@ -406,13 +420,11 @@ export function ConversationThread({
     return () => window.cancelAnimationFrame(t);
   }, [findActive?.messageId, findActive?.occurrence, findQuery]);
 
-  // Re-pin when user sends (even if they had scrolled up to read history).
-  const forceStickKey = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]?.role === "user") return messages[i]!.id;
-    }
-    return null;
-  }, [messages]);
+  // Re-pin for normal prompts and Steer rows, even after scrolling up.
+  const forceStickKey = useMemo(
+    () => findForceStickMessageId(messages),
+    [messages],
+  );
 
   const {
     viewportRef: scrollRef,
@@ -441,7 +453,7 @@ export function ConversationThread({
   const activeAssistantId = useMemo(() => {
     let lastUser = -1;
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]!.role === "user") {
+      if (isTurnPromptMessage(messages[i])) {
         lastUser = i;
         break;
       }
@@ -559,7 +571,8 @@ export function ConversationThread({
             }
 
             if (m.role === "user") {
-              const isLastUser = lastUserMessageId === m.id;
+              const isInterjection = m.marker === "interjection";
+              const isLastUser = !isInterjection && lastUserMessageId === m.id;
               const isEditing = editingUserMessageId === m.id;
               const timeLabel = formatMessageTime(m.createdAt, locale);
               const isFindHit = !!findHitMessageIds?.has(m.id);
@@ -617,7 +630,21 @@ export function ConversationThread({
                           onRemoveAttachment={onRemoveEditAttachment}
                         />
                       ) : m.content.trim() ? (
-                        <div className="lobe-chat-bubble">
+                        <div
+                          className={
+                            "lobe-chat-bubble" +
+                            (isInterjection
+                              ? " lobe-chat-bubble--interjection"
+                              : "")
+                          }
+                          data-message-marker={m.marker}
+                        >
+                          {isInterjection ? (
+                            <div className="lobe-chat-interjection-tag">
+                              <IconTarget size={12} aria-hidden />
+                              <span>{tr("message.interjectionTag")}</span>
+                            </div>
+                          ) : null}
                           <UserMessageBody
                             content={m.content}
                             scheduledLabel={tr("automations.msgTag")}
@@ -661,7 +688,7 @@ export function ConversationThread({
                             <IconRename size={15} />
                           </MessageActionButton>
                         ) : null}
-                        {onRewindToUserMessage ? (
+                        {onRewindToUserMessage && !isInterjection ? (
                           <MessageActionButton
                             label={tr("message.rewindHere")}
                             disabled={!canRewindSession}
@@ -673,7 +700,7 @@ export function ConversationThread({
                             <IconRewind size={15} />
                           </MessageActionButton>
                         ) : null}
-                        {onForkFromUserMessage ? (
+                        {onForkFromUserMessage && !isInterjection ? (
                           <MessageActionButton
                             label={tr("message.forkHere")}
                             disabled={!canRewindSession}

--- a/src/components/lobe-chat/lobe-chat.css
+++ b/src/components/lobe-chat/lobe-chat.css
@@ -164,6 +164,27 @@
   box-shadow: none;
 }
 
+.lobe-chat-bubble--interjection {
+  border: 1px solid color-mix(in srgb, var(--chat-link) 24%, transparent);
+  background: color-mix(in srgb, var(--chat-link) 8%, var(--chat-bubble));
+}
+
+.lobe-chat-interjection-tag {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-block-end: 6px;
+  color: color-mix(in srgb, var(--chat-link) 78%, var(--chat-text));
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+}
+
+.lobe-chat-interjection-tag svg {
+  flex: 0 0 auto;
+}
+
 /* Scheduled automation user card: clock tag + body */
 .lobe-chat-user-msg {
   display: flex;

--- a/src/hooks/useSendQueue.test.ts
+++ b/src/hooks/useSendQueue.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { getQueueForKey, makeQueuedSend } from "@/lib/sendQueue";
+import { claimQueueHeadForFlush } from "./useSendQueue";
+
+function queueMap() {
+  return {
+    "session-1": [
+      makeQueuedSend({
+        storedDisplay: "queued follow-up",
+        attachments: [],
+        goalMode: false,
+        now: 1,
+      }),
+    ],
+  };
+}
+
+function claim(
+  byKey: ReturnType<typeof queueMap>,
+  pause: { flushPaused: boolean; flushPauseCurrent: boolean },
+) {
+  return claimQueueHeadForFlush({
+    byKey,
+    liveState: "ready",
+    liveSessionId: "session-1",
+    viewingSessionId: "session-1",
+    sendInFlight: false,
+    connecting: false,
+    flushHeld: false,
+    ...pause,
+  });
+}
+
+describe("useSendQueue flush pause", () => {
+  it("does not claim while flushPaused is rendered true", () => {
+    const byKey = queueMap();
+
+    expect(
+      claim(byKey, { flushPaused: true, flushPauseCurrent: false }),
+    ).toBeNull();
+    expect(getQueueForKey(byKey, "session-1")).toHaveLength(1);
+  });
+
+  it("does not claim when the synchronous pause ref leads the render state", () => {
+    const byKey = queueMap();
+
+    expect(
+      claim(byKey, { flushPaused: false, flushPauseCurrent: true }),
+    ).toBeNull();
+    expect(getQueueForKey(byKey, "session-1")).toHaveLength(1);
+  });
+
+  it("resumes claiming once pause is released and the session is idle", () => {
+    const byKey = queueMap();
+
+    expect(
+      claim(byKey, { flushPaused: true, flushPauseCurrent: true }),
+    ).toBeNull();
+
+    const resumed = claim(byKey, {
+      flushPaused: false,
+      flushPauseCurrent: false,
+    });
+    expect(resumed?.head.storedDisplay).toBe("queued follow-up");
+    expect(getQueueForKey(resumed?.byKey ?? byKey, "session-1")).toEqual([]);
+  });
+});

--- a/src/hooks/useSendQueue.ts
+++ b/src/hooks/useSendQueue.ts
@@ -34,6 +34,59 @@ export type ExecuteSendFromQueue = (opts: {
   targetSessionId: string | null;
 }) => Promise<boolean>;
 
+export type QueueFlushClaim = {
+  head: QueuedSend;
+  byKey: Record<string, QueuedSend[]>;
+  claimKey: string;
+  targetSessionId: string | null;
+};
+
+/**
+ * Atomically apply the latest flush guards before claiming a queue head.
+ * Keeping the synchronous pause ref in this final gate closes the window before
+ * React re-renders `flushPaused` after a Steer starts.
+ */
+export function claimQueueHeadForFlush(input: {
+  byKey: Record<string, QueuedSend[]>;
+  liveState: SessionState;
+  liveSessionId: string | null;
+  viewingSessionId: string | null;
+  sendInFlight: boolean;
+  connecting: boolean;
+  flushPaused: boolean;
+  flushPauseCurrent: boolean;
+  flushHeld: boolean;
+}): QueueFlushClaim | null {
+  if (
+    input.sendInFlight ||
+    input.connecting ||
+    input.flushPaused ||
+    input.flushPauseCurrent ||
+    input.flushHeld
+  ) {
+    return null;
+  }
+  if (
+    input.liveSessionId &&
+    input.viewingSessionId &&
+    input.liveSessionId !== input.viewingSessionId
+  ) {
+    return null;
+  }
+  if (shouldEnqueueSend(input.liveState, false)) return null;
+
+  const claimKey = queueSessionKey(
+    input.viewingSessionId ?? input.liveSessionId,
+  );
+  const claimed = claimQueueHead(input.byKey, claimKey);
+  if (!claimed) return null;
+  return {
+    ...claimed,
+    claimKey,
+    targetSessionId: claimKey === "__draft__" ? null : claimKey,
+  };
+}
+
 export type UseSendQueueOptions = {
   sessionId: string | null;
   sessionState: SessionState;
@@ -41,6 +94,10 @@ export type UseSendQueueOptions = {
   liveHostRef: RefObject<SessionSnapshot>;
   viewingSessionIdRef: MutableRefObject<string | null>;
   sendInFlightRef: MutableRefObject<boolean>;
+  /** Pause auto-flush while a queued item is being steered into the active turn. */
+  flushPaused: boolean;
+  /** Synchronous guard for state-transition races before `flushPaused` re-renders. */
+  flushPauseRef: RefObject<boolean>;
   /** Always call via ref so flush sees the latest executeSend. */
   executeSendRef: MutableRefObject<ExecuteSendFromQueue>;
   showToast: (msg: string, ms?: number) => void;
@@ -62,6 +119,8 @@ export function useSendQueue({
   liveHostRef,
   viewingSessionIdRef,
   sendInFlightRef,
+  flushPaused,
+  flushPauseRef,
   executeSendRef,
   showToast,
   labels,
@@ -170,19 +229,20 @@ export function useSendQueue({
   );
 
   const flush = useCallback(() => {
-    if (sendInFlightRef.current) return;
-    if (connecting) return;
-    if (queueFlushHoldRef.current) return;
     const live = liveHostRef.current;
-    const viewId = viewingSessionIdRef.current;
-    if (live.sessionId && viewId && live.sessionId !== viewId) return;
-    if (shouldEnqueueSend(live.state, false)) return;
-
-    const claimKey = queueSessionKey(viewId ?? live.sessionId);
-    const claimed = claimQueueHead(sendQueueByKeyRef.current, claimKey);
+    const claimed = claimQueueHeadForFlush({
+      byKey: sendQueueByKeyRef.current,
+      liveState: live.state,
+      liveSessionId: live.sessionId,
+      viewingSessionId: viewingSessionIdRef.current,
+      sendInFlight: sendInFlightRef.current,
+      connecting,
+      flushPaused,
+      flushPauseCurrent: flushPauseRef.current,
+      flushHeld: queueFlushHoldRef.current,
+    });
     if (!claimed) return;
-    const { head } = claimed;
-    const targetSessionId = claimKey === "__draft__" ? null : claimKey;
+    const { head, claimKey, targetSessionId } = claimed;
     writeMap(claimed.byKey);
 
     void (async () => {
@@ -212,6 +272,8 @@ export function useSendQueue({
     liveHostRef,
     viewingSessionIdRef,
     sendInFlightRef,
+    flushPaused,
+    flushPauseRef,
     executeSendRef,
     showToast,
     labels,
@@ -232,7 +294,13 @@ export function useSendQueue({
   // Auto-send next queued follow-up when the agent becomes idle.
   useEffect(() => {
     if (sessionState !== "ready" && sessionState !== "idle") return;
-    if (connecting || sendInFlightRef.current || queueFlushHoldRef.current) {
+    if (
+      connecting ||
+      flushPaused ||
+      flushPauseRef.current ||
+      sendInFlightRef.current ||
+      queueFlushHoldRef.current
+    ) {
       return;
     }
     const key = queueSessionKey(sessionId);
@@ -247,6 +315,8 @@ export function useSendQueue({
     sessionState,
     sessionId,
     connecting,
+    flushPaused,
+    flushPauseRef,
     sendQueueByKey,
     flush,
     cancelFlushTimer,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -396,6 +396,12 @@ const en = {
   "composer.queueDroppedOldest":
     "Queue full ({max}) — dropped {n} oldest",
   "composer.queueCount": "{n} queued in this chat",
+  "composer.queueGuide": "Steer",
+  "composer.queueGuiding": "Steering…",
+  "composer.queueGuideUnavailable":
+    "Steer is available only while the agent is generating",
+  "composer.queueGuideFailed":
+    "Could not steer the current task. The follow-up remains queued.",
   "composer.queueHold":
     "Auto-send paused — retry or send again to resume",
   "composer.queueHoldRetry": "Retry",
@@ -1438,6 +1444,7 @@ const en = {
   "askUser.freeTextHint": "Or type a custom answer",
   "askUser.multiHint": "Select one or more options",
 
+  "message.interjectionTag": "Steer",
   "message.copy": "Copy",
   "message.copied": "Copied",
   "message.edit": "Edit",
@@ -2177,6 +2184,10 @@ const zh: Record<MessageKey, string> = {
   "composer.queueBlockedPermission": "请先处理权限请求",
   "composer.queueDroppedOldest": "队列已满（{max}）— 已丢弃最旧 {n} 条",
   "composer.queueCount": "本会话队列 {n} 条",
+  "composer.queueGuide": "引导",
+  "composer.queueGuiding": "正在引导…",
+  "composer.queueGuideUnavailable": "仅在 Agent 正在生成时可引导",
+  "composer.queueGuideFailed": "引导当前任务失败，消息仍保留在队列中。",
   "composer.queueHold": "自动发送已暂停 — 点重试或再发送以继续",
   "composer.queueHoldRetry": "重试",
   "composer.queueClear": "清空",
@@ -3193,6 +3204,7 @@ const zh: Record<MessageKey, string> = {
   "askUser.freeTextHint": "或输入自定义回答",
   "askUser.multiHint": "可多选",
 
+  "message.interjectionTag": "引导",
   "message.copy": "复制",
   "message.copied": "已复制",
   "message.edit": "编辑",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -407,6 +407,10 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.queueBlockedPermission": "請先處理權限請求",
   "composer.queueDroppedOldest": "佇列已滿（{max}）— 已丟棄最舊 {n} 則",
   "composer.queueCount": "此對話佇列 {n} 則",
+  "composer.queueGuide": "引導",
+  "composer.queueGuiding": "正在引導…",
+  "composer.queueGuideUnavailable": "僅在 Agent 正在生成時可引導",
+  "composer.queueGuideFailed": "引導目前任務失敗，訊息仍保留在佇列中。",
   "composer.queueHold": "自動傳送已暫停 — 點重試或再傳送以繼續",
   "composer.queueHoldRetry": "重試",
   "composer.queueClear": "清空",
@@ -1391,6 +1395,7 @@ export const zhTW: Record<MessageKey, string> = {
   "askUser.freeTextHint": "或輸入自訂回答",
   "askUser.multiHint": "可多選",
 
+  "message.interjectionTag": "引導",
   "message.copy": "複製",
   "message.copied": "已複製",
   "message.edit": "編輯",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -58,6 +58,19 @@ export async function sessionSend(
   });
 }
 
+/** Inject guidance into the active turn without cancelling it. */
+export async function sessionInterject(
+  text: string,
+  displayText?: string | null,
+  attachments?: Array<{ path: string; name: string; isDir: boolean }>,
+): Promise<SessionSnapshot> {
+  return invoke("session_interject", {
+    text,
+    displayText: displayText ?? null,
+    attachments: attachments?.length ? attachments : null,
+  });
+}
+
 /** Drop last user turn (agent rewind + local journal) before edit-resend. */
 export async function sessionRewindDropLastUser(): Promise<SessionSnapshot> {
   return invoke("session_rewind_drop_last_user");

--- a/src/lib/composerPromptHistory.test.ts
+++ b/src/lib/composerPromptHistory.test.ts
@@ -29,6 +29,22 @@ describe("collectUserPromptHistory", () => {
     expect(history).toEqual(["keep"]);
   });
 
+  it("skips mid-turn interjections", () => {
+    const history = collectUserPromptHistory([
+      { role: "user", content: "build a form" },
+      { role: "assistant", content: "working" },
+      {
+        role: "user",
+        content: "use existing components",
+        marker: "interjection",
+      },
+      { role: "assistant", content: "done" },
+      { role: "user", content: "add validation" },
+    ]);
+
+    expect(history).toEqual(["add validation", "build a form"]);
+  });
+
   it("preserves stored skill tokens", () => {
     const history = collectUserPromptHistory([
       { role: "user", content: "[[skill:foo]] hello" },

--- a/src/lib/composerPromptHistory.ts
+++ b/src/lib/composerPromptHistory.ts
@@ -14,16 +14,20 @@ export type PromptHistoryStep = {
 
 /**
  * Extract prior user prompt strings from session messages, newest first.
- * Skips empty / whitespace-only content. Keeps stored display form
+ * Skips mid-turn interjections and empty / whitespace-only content. Keeps stored display form
  * (`[[skill:…]]` tokens) so the composer can re-render chips.
  */
 export function collectUserPromptHistory(
-  messages: ReadonlyArray<{ role: string; content?: string | null }>,
+  messages: ReadonlyArray<{
+    role: string;
+    content?: string | null;
+    marker?: string;
+  }>,
 ): string[] {
   const out: string[] = [];
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
-    if (!m || m.role !== "user") continue;
+    if (!m || m.role !== "user" || m.marker === "interjection") continue;
     const c = m.content ?? "";
     if (!c.trim()) continue;
     out.push(c);

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyContextCompact,
   applyGeneratedImage,
+  applyInterjection,
   applyStreamChunk,
   applyToolEvent,
   applyTurnError,
@@ -112,6 +113,24 @@ describe("session projection", () => {
     expect(countUserPrompts(msgs)).toBe(2);
   });
 
+  it("keeps interjections inside the surrounding rewind turn", () => {
+    const messages: ChatMessage[] = [
+      { id: "u1", role: "user", content: "first" },
+      { id: "a1", role: "assistant", content: "working" },
+      {
+        id: "i1",
+        role: "user",
+        content: "steer",
+        marker: "interjection",
+      },
+      { id: "u2", role: "user", content: "next" },
+    ];
+
+    expect(countUserPrompts(messages)).toBe(2);
+    expect(userPromptIndexOf(messages, "i1")).toBe(-1);
+    expect(endIndexThroughUserPrompt(messages, 0)).toBe(3);
+  });
+
   it("localRewindPoints lists one entry per user prompt", () => {
     const msgs: ChatMessage[] = [
       { id: "u1", role: "user", content: "  hello   world  " },
@@ -215,6 +234,101 @@ describe("session projection", () => {
     expect(messages).toHaveLength(1);
     expect(messages[0]!.content).toBe("Hello");
     expect(messages[0]!.streaming).toBe(false);
+  });
+
+  it("starts a new assistant row after a mid-turn interjection", () => {
+    let messages: ChatMessage[] = [
+      { id: "u1", role: "user", content: "build it" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Working",
+        streaming: true,
+      },
+    ];
+
+    messages = applyInterjection(messages, {
+      id: "i1",
+      role: "user",
+      content: "Use the existing component",
+      marker: "interjection",
+    });
+
+    messages = applyStreamChunk(messages, {
+      sessionId: "s",
+      messageId: "a2",
+      text: " on it",
+      done: false,
+      kind: "assistant",
+    });
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "u1",
+      "a1",
+      "i1",
+      "a2",
+    ]);
+    expect(messages[1]).toMatchObject({
+      id: "a1",
+      content: "Working",
+      streaming: false,
+    });
+    expect(messages[3]).toMatchObject({
+      id: "a2",
+      content: " on it",
+      streaming: true,
+    });
+  });
+
+  it("drops an empty optimistic assistant when interjected before output", () => {
+    const messages = applyInterjection(
+      [
+        { id: "u1", role: "user", content: "build it" },
+        {
+          id: "a-pending-1",
+          role: "assistant",
+          content: "",
+          streaming: true,
+        },
+      ],
+      {
+        id: "i1",
+        role: "user",
+        content: "Use the existing component",
+        marker: "interjection",
+      },
+    );
+
+    expect(messages.map((message) => message.id)).toEqual(["u1", "i1"]);
+  });
+
+  it("does not freeze post-interjection output when the event is replayed", () => {
+    const messages = applyInterjection(
+      [
+        { id: "u1", role: "user", content: "build it" },
+        { id: "a1", role: "assistant", content: "Working" },
+        {
+          id: "i1",
+          role: "user",
+          content: "Use the existing component",
+          marker: "interjection",
+        },
+        {
+          id: "a2",
+          role: "assistant",
+          content: "Continuing",
+          streaming: true,
+        },
+      ],
+      {
+        id: "i1",
+        role: "user",
+        content: "Use the existing component",
+        marker: "interjection",
+      },
+    );
+
+    expect(messages[3]).toMatchObject({ id: "a2", streaming: true });
   });
 
   it("does not double-append when same sequence applied once", () => {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -289,7 +289,7 @@ export function pickLatestTurnTool(
 ): ChatMessage | null {
   let lastUser = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i]!.role === "user") {
+    if (isTurnPromptMessage(messages[i])) {
       lastUser = i;
       break;
     }
@@ -316,7 +316,7 @@ export function pickRunningTurnTool(
 ): ChatMessage | null {
   let lastUser = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i]!.role === "user") {
+    if (isTurnPromptMessage(messages[i])) {
       lastUser = i;
       break;
     }
@@ -711,6 +711,11 @@ export function isSessionLiveStreaming(state: SessionState): boolean {
   return state === "streaming" || state === "awaiting_permission";
 }
 
+/** A real prompt turn boundary. Mid-turn steering messages stay inside the active turn. */
+export function isTurnPromptMessage(message: ChatMessage | undefined): boolean {
+  return message?.role === "user" && message.marker !== "interjection";
+}
+
 /**
  * Drop the last user message and everything after it (assistant reply, errors, tools).
  * Used by edit-resend so the prior turn is fully replaced, not stacked.
@@ -718,7 +723,7 @@ export function isSessionLiveStreaming(state: SessionState): boolean {
 export function truncateBeforeLastUser(messages: ChatMessage[]): ChatMessage[] {
   let cut = messages.length;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i]?.role === "user") {
+    if (isTurnPromptMessage(messages[i])) {
       cut = i;
       break;
     }
@@ -728,7 +733,7 @@ export function truncateBeforeLastUser(messages: ChatMessage[]): ChatMessage[] {
 
 /** Number of user-role messages (0-based prompt index length). */
 export function countUserPrompts(messages: ChatMessage[]): number {
-  return messages.reduce((n, m) => (m.role === "user" ? n + 1 : n), 0);
+  return messages.reduce((n, m) => (isTurnPromptMessage(m) ? n + 1 : n), 0);
 }
 
 /**
@@ -740,7 +745,7 @@ export function userPromptIndexOf(
 ): number {
   let idx = 0;
   for (const m of messages) {
-    if (m.role !== "user") continue;
+    if (!isTurnPromptMessage(m)) continue;
     if (m.id === messageId) return idx;
     idx += 1;
   }
@@ -759,10 +764,10 @@ export function endIndexThroughUserPrompt(
   if (userPromptIndex < 0 || !Number.isFinite(userPromptIndex)) return -1;
   let userI = 0;
   for (let i = 0; i < messages.length; i++) {
-    if (messages[i]?.role !== "user") continue;
+    if (!isTurnPromptMessage(messages[i])) continue;
     if (userI === userPromptIndex) {
       let j = i + 1;
-      while (j < messages.length && messages[j]?.role !== "user") j += 1;
+      while (j < messages.length && !isTurnPromptMessage(messages[j])) j += 1;
       return j;
     }
     userI += 1;
@@ -808,7 +813,7 @@ export function localRewindPoints(
   const out: LocalRewindPoint[] = [];
   let idx = 0;
   for (const m of messages) {
-    if (m.role !== "user") continue;
+    if (!isTurnPromptMessage(m)) continue;
     const raw = (m.content || "").replace(/\s+/g, " ").trim();
     const preview =
       raw.length > max ? `${raw.slice(0, Math.max(1, max - 1))}…` : raw || "…";
@@ -1001,13 +1006,13 @@ export function applyGeneratedImage(
 }
 
 /**
- * Index of the last user message — stream chunks only bind to the current turn
+ * Index of the last prompt-turn user message — steering messages do not start a new turn
  * (after this index). Prevents a late/orphan chunk from appending onto an older
  * assistant and looking like "history re-appeared after the new question".
  */
 export function lastUserMessageIndex(messages: ChatMessage[]): number {
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i]?.role === "user") return i;
+    if (isTurnPromptMessage(messages[i])) return i;
   }
   return -1;
 }
@@ -1179,6 +1184,50 @@ export function applyStreamChunk(
     streaming: !chunk.done,
   };
   return next;
+}
+
+/**
+ * Insert a mid-turn user interjection and freeze the assistant segment above it.
+ * Post-interjection stream chunks carry a fresh host message id and therefore
+ * append a new assistant row below this boundary.
+ */
+export function applyInterjection(
+  messages: ChatMessage[],
+  interjection: ChatMessage,
+): ChatMessage[] {
+  const existingIndex = messages.findIndex(
+    (message) => message.id === interjection.id,
+  );
+  const boundaryIndex = existingIndex < 0 ? messages.length : existingIndex;
+  const frozenBefore = messages
+    .slice(0, boundaryIndex)
+    .filter((message) => {
+      if (
+        message.role !== "assistant" ||
+        !message.streaming ||
+        !message.id.startsWith("a-pending-")
+      ) {
+        return true;
+      }
+      const hasVisibleContent =
+        !!message.content.trim() ||
+        !!message.thought?.trim() ||
+        !!message.segments?.some((segment) => segment.text.trim()) ||
+        !!message.attachments?.length;
+      return hasVisibleContent;
+    })
+    .map((message) =>
+      message.role === "assistant" && message.streaming
+        ? { ...message, streaming: false }
+        : message,
+    );
+
+  if (existingIndex < 0) return [...frozenBefore, interjection];
+  return [
+    ...frozenBefore,
+    interjection,
+    ...messages.slice(existingIndex + 1),
+  ];
 }
 
 /**

--- a/src/lib/sessionTasks.test.ts
+++ b/src/lib/sessionTasks.test.ts
@@ -160,6 +160,41 @@ describe("collectSessionTasks", () => {
     expect(tasks.find((t) => t.id === "old")).toBeUndefined();
   });
 
+  it("keeps completed tools before a mid-turn interjection", () => {
+    const msgs: ChatMessage[] = [
+      { id: "u1", role: "user", content: "build a form" },
+      tool({
+        id: "tool-before",
+        toolCallId: "before",
+        content: "inspect components",
+        toolKind: "read_file",
+        toolStatus: "completed",
+        streaming: false,
+        createdAt: "2026-01-02T00:00:01.000Z",
+      }),
+      {
+        id: "i1",
+        role: "user",
+        content: "use existing components",
+        marker: "interjection",
+      },
+      tool({
+        id: "tool-after",
+        toolCallId: "after",
+        content: "update form",
+        toolKind: "write_file",
+        toolStatus: "completed",
+        streaming: false,
+        createdAt: "2026-01-02T00:00:02.000Z",
+      }),
+    ];
+
+    expect(collectSessionTasks(msgs).map((task) => task.id)).toEqual([
+      "after",
+      "before",
+    ]);
+  });
+
   it("keeps a still-running tool from before the last user message", () => {
     const msgs: ChatMessage[] = [
       { id: "u0", role: "user", content: "start" },

--- a/src/lib/sessionTasks.ts
+++ b/src/lib/sessionTasks.ts
@@ -9,6 +9,7 @@
 import type { ChatMessage } from "./session";
 import {
   isToolStepMessage,
+  isTurnPromptMessage,
   parseToolStepContent,
   toolStepDisplayTitle,
 } from "./session";
@@ -174,7 +175,7 @@ export interface CollectSessionTasksOptions {
   /** Cap on non-running rows (default SESSION_TASKS_RECENT_LIMIT). */
   recentLimit?: number;
   /**
-   * When true (default), prefer tools after the last user message.
+   * When true (default), prefer tools after the last real turn prompt.
    * Still-running tools from earlier in the list are always kept.
    */
   currentTurnOnly?: boolean;
@@ -194,7 +195,7 @@ export function collectSessionTasks(
   let from = 0;
   if (currentTurnOnly) {
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]!.role === "user") {
+      if (isTurnPromptMessage(messages[i])) {
         from = i + 1;
         break;
       }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6554,7 +6554,7 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  max-height: 120px;
+  max-height: 132px;
   overflow-y: auto;
 }
 
@@ -6562,11 +6562,11 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   display: flex;
   align-items: center;
   gap: 8px;
-  min-height: 28px;
-  padding: 4px 6px;
+  min-height: 32px;
+  padding: 4px 5px 4px 6px;
   border-radius: 8px;
-  background: var(--bg-hover);
   border: 1px solid var(--border-subtle);
+  background: var(--bg-hover);
   font-size: 12px;
   color: var(--text-secondary);
 }
@@ -6588,13 +6588,36 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   color: var(--text-primary);
 }
 
+.composer__queue-guide {
+  flex: 0 0 auto;
+  min-width: 48px;
+  height: 24px;
+  padding: 0 9px;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border-subtle));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+  font: inherit;
+  font-weight: 550;
+  cursor: pointer;
+}
+
+.composer__queue-guide:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 17%, transparent);
+}
+
+.composer__queue-guide:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 .composer__queue-remove {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border: none;
   border-radius: 6px;
   background: transparent;
@@ -6602,9 +6625,14 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   cursor: pointer;
 }
 
-.composer__queue-remove:hover {
+.composer__queue-remove:hover:not(:disabled) {
   background: var(--bg-elevated, var(--bg-hover));
   color: var(--text-primary);
+}
+
+.composer__queue-remove:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .composer__attachments {


### PR DESCRIPTION
## Summary

Allow follow-ups to queue while a turn is streaming, and **Steer** a queued item into the active turn without cancelling it.

- Backend: `session_interject` + mid-turn journal/stream split (`marker: interjection`)
- UI: `ComposerQueue` Steer action; interjection rows tagged in the thread
- Queue flush pauses during steer to avoid racing the next auto-send
- i18n (en / zh / zh-TW); tests for queue, session projection, and thread rendering

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [ ] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included