### PR TITLE
docs: fix missing grammatical subject 'Click card opens' in providers.md

### DIFF
--- a/docs/llm-wiki/providers.md
+++ b/docs/llm-wiki/providers.md
@@ -48,7 +48,7 @@ Left / right split (`ProvidersPanel`):
 | Left | **Add provider** on top; list of cards. Official Grok card first **only if** signed in / CLI auth / official key; otherwise list starts empty. |
 | Right | Create/edit form when adding or selecting a custom card; official detail when selecting the official card; empty placeholder otherwise. |
 
-Each card has **Use** to activate that route (`providers_activate`). Click card opens detail/edit. No long intro copy, agent-home path, or separate “active route” switcher.
+Each card has **Use** to activate that route (`providers_activate`). Clicking a card opens detail/edit. No long intro copy, agent-home path, or separate “active route” switcher.
 
 ## Route switching (auth isolation)
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/llm-wiki/providers.md` (line 51).

## Problem

Missing grammatical subject. "Click card" is not a valid noun phrase; it reads as an imperative verb followed by a noun, making "opens" lack a proper subject. Should use a gerund ("Clicking a card").

The problematic text:

```markdown
Click card opens detail/edit.
```

## Fix

Replaced with:

```markdown
Clicking a card opens detail/edit.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text