### PR TITLE
docs: fix sentence missing main verb in git-worktrees.md

### DIFF
--- a/docs/llm-wiki/git-worktrees.md
+++ b/docs/llm-wiki/git-worktrees.md
@@ -43,7 +43,7 @@ Example: main `/Users/me/repo` + name `feat` → `/Users/me/repo-feat`.
 
 Name rules: letters, digits, `.` `_` `-` only; max 64; no path separators; must not start with `-` (so it cannot look like a git flag).
 
-Errors when the folder is not a git repository, `git` is missing, the path already exists, or `git worktree add` fails (message surfaced in the dialog).
+Errors are shown when the folder is not a git repository, `git` is missing, the path already exists, or `git worktree add` fails (message surfaced in the dialog).
 
 ### GC / prune
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/llm-wiki/git-worktrees.md` (line 46).

## Problem

The sentence is missing a main verb — "Errors when..." should be "Errors are shown when..." or "Errors occur when...".

The problematic text:

```markdown
Errors when the folder is not a git repository, `git` is missing, the path already exists, or `git worktree add` fails (message surfaced in the dialog).
```

## Fix

Replaced with:

```markdown
Errors are shown when the folder is not a git repository, `git` is missing, the path already exists, or `git worktree add` fails (message surfaced in the dialog).
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text