### PR TITLE
fix(lib): settle sidebar busy state when session stops

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,6 +145,8 @@ import {
   markSawToolActivity,
   mergeTurnProgressFromMessages,
   resumeStateForSession,
+  settleStoppedSessionInLiveMap,
+  settleStoppedSessionSnapshot,
   type SessionLiveMap,
 } from "@/lib/sessionLiveStore";
 import { endOfTurnMarkerContent } from "@/lib/endOfTurn";
@@ -3425,6 +3427,19 @@ export default function App() {
     }
     return set;
   }, [liveMap, liveHost.sessionId, liveHost.state]);
+  const settleStoppedSessionUi = useCallback((sessionId: string) => {
+    setLiveMap((prev) => {
+      const next = settleStoppedSessionInLiveMap(prev, sessionId);
+      liveMapRef.current = next;
+      return next;
+    });
+    setLiveHost((prev) => {
+      const next = settleStoppedSessionSnapshot(prev, sessionId);
+      liveHostRef.current = next;
+      return next;
+    });
+    setSession((prev) => settleStoppedSessionSnapshot(prev, sessionId));
+  }, []);
   const stopGate = useMemo(
     () =>
       reconcileUiBusyGate({
@@ -6772,6 +6787,7 @@ export default function App() {
     const armed = armStopLatch(stopLatchRef.current, sid, now);
     stopLatchRef.current = armed;
     setStopLatch(armed);
+    let timeoutSettledSessionId: string | null = null;
     // Force-unlock if Host stays busy past STOP_LATCH_MS.
     window.setTimeout(() => {
       const tick = tickStopLatch(
@@ -6785,6 +6801,8 @@ export default function App() {
       if (tick.forceComplete) {
         const id = sid || liveHostRef.current.sessionId;
         if (id) {
+          timeoutSettledSessionId = id;
+          settleStoppedSessionUi(id);
           patchSessionMessages(id, (prev) =>
             applyTurnMarker(prev, {
               sessionId: id,
@@ -6810,6 +6828,9 @@ export default function App() {
       setTurnStartedAt(null);
       const liveId = sid || liveHostRef.current.sessionId;
       if (liveId) {
+        if (timeoutSettledSessionId !== liveId) {
+          settleStoppedSessionUi(liveId);
+        }
         patchSessionMessages(liveId, (m) =>
           m.map((x) => ({ ...x, streaming: false })),
         );

--- a/src/lib/sessionLiveStore.test.ts
+++ b/src/lib/sessionLiveStore.test.ts
@@ -8,6 +8,8 @@ import {
   mergeTurnProgressFromMessages,
   projectHostIntoLiveMap,
   resumeStateForSession,
+  settleStoppedSessionInLiveMap,
+  settleStoppedSessionSnapshot,
   upsertLiveSnapshot,
 } from "./sessionLiveStore";
 import type { ChatMessage } from "./session";
@@ -48,6 +50,69 @@ describe("sessionLiveStore", () => {
     map = projectHostIntoLiveMap(map, { sessionId: "a", state: "ready" });
     expect(map.a!.liveToolTitle).toBeNull();
     expect(map.a!.state).toBe("ready");
+  });
+
+  it("settles only the stopped session so its sidebar busy state clears", () => {
+    let map = projectHostIntoLiveMap(
+      {},
+      {
+        sessionId: "a",
+        state: "awaiting_permission",
+        streamingMessageId: "m1",
+      },
+      1,
+    );
+    map = projectHostIntoLiveMap(
+      map,
+      { sessionId: "b", state: "streaming", streamingMessageId: "m2" },
+      2,
+    );
+
+    map = settleStoppedSessionInLiveMap(map, "a", 3);
+
+    expect(busySessionIds(map).has("a")).toBe(false);
+    expect(busySessionIds(map).has("b")).toBe(true);
+    expect(map.a).toMatchObject({
+      state: "ready",
+      streamingMessageId: null,
+      awaitingPermission: false,
+      startedAt: null,
+    });
+  });
+
+  it("does not create or rewrite entries when the session is not busy", () => {
+    const empty = {};
+    expect(settleStoppedSessionInLiveMap(empty, "missing", 2)).toBe(empty);
+    expect(empty).not.toHaveProperty("missing");
+
+    const ready = projectHostIntoLiveMap(
+      {},
+      { sessionId: "done", state: "ready" },
+      1,
+    );
+    expect(settleStoppedSessionInLiveMap(ready, "done", 2)).toBe(ready);
+    expect(ready.done!.updatedAt).toBe(1);
+  });
+
+  it("settles matching snapshots but preserves a foreign live host", () => {
+    const viewed = {
+      sessionId: "a",
+      state: "streaming" as const,
+      streamingMessageId: "m1",
+      title: "A",
+    };
+    const foreignHost = {
+      sessionId: "b",
+      state: "streaming" as const,
+      streamingMessageId: "m2",
+    };
+
+    expect(settleStoppedSessionSnapshot(viewed, "a")).toEqual({
+      ...viewed,
+      state: "ready",
+      streamingMessageId: null,
+    });
+    expect(settleStoppedSessionSnapshot(foreignHost, "a")).toBe(foreignHost);
   });
 
   it("empty snapshot defaults", () => {

--- a/src/lib/sessionLiveStore.ts
+++ b/src/lib/sessionLiveStore.ts
@@ -101,6 +101,58 @@ export function projectHostIntoLiveMap(
 }
 
 /**
+ * Settle one stopped turn without disturbing other live sessions.
+ *
+ * `sessionStop` can resolve before (or without) a final Host state event. The
+ * message view already stops locally in that case, so the sidebar projection
+ * must also leave its busy state instead of spinning indefinitely.
+ */
+export function settleStoppedSessionInLiveMap(
+  map: SessionLiveMap,
+  sessionId: string,
+  nowMs: number = Date.now(),
+): SessionLiveMap {
+  const snapshot = map[sessionId];
+  if (
+    !snapshot ||
+    (!snapshot.awaitingPermission &&
+      !isSessionLiveStreaming(snapshot.state))
+  ) {
+    return map;
+  }
+  return projectHostIntoLiveMap(
+    map,
+    {
+      sessionId,
+      state: "ready",
+      streamingMessageId: null,
+    },
+    nowMs,
+  );
+}
+
+/** Settle a matching focused/workbench snapshot after Stop succeeds. */
+export function settleStoppedSessionSnapshot<
+  T extends {
+    sessionId: string | null;
+    state: SessionState;
+    streamingMessageId?: string | null;
+  },
+>(snapshot: T, sessionId: string): T {
+  if (
+    snapshot.sessionId !== sessionId ||
+    !isSessionLiveStreaming(snapshot.state)
+  ) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    state: "ready",
+    streamingMessageId: null,
+  };
+}
+
+/**
  * State to project when (re)opening `sessionId`.
  *
  * The Host live slot wins. Otherwise a *background* turn's snapshot is used, so


### PR DESCRIPTION
## Summary

Session stop could resolve before (or without) a final Host state
event, leaving the sidebar projection in a busy/streaming state
indefinitely. Added `settleStoppedSessionInLiveMap` and
`settleStoppedSessionSnapshot` helpers to clear the stopped session's
busy flags without disturbing other live sessions.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo check` in `src-tauri` (no Rust logic changes)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [ ] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included