### PR TITLE
fix(media): scope media:// reads and drop wildcard CORS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
-          shared-key: ci-${{ matrix.name }}-v3
+          shared-key: ci-${{ matrix.name }}-v4
       # Includes ACP golden fixtures (tests/fixtures/acp + acp_golden_test).
       # Required green for any ACP / mock_acp / permission wire change (T06).
       - name: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,10 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
-          shared-key: ci-${{ matrix.name }}
+          shared-key: ci-${{ matrix.name }}-v3
       # Includes ACP golden fixtures (tests/fixtures/acp + acp_golden_test).
       # Required green for any ACP / mock_acp / permission wire change (T06).
       - name: cargo test
         working-directory: src-tauri
-        run: cargo test
+        # --lib: unit/integration tests under src/. Avoids binary harness issues on some runners.
+        run: cargo test --lib

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,20 @@
 fn main() {
+    // Workaround for STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139) when running
+    // `cargo test` on Windows MSVC: embed the common-controls v6 app manifest
+    // so the test harness binary can load. See:
+    // https://github.com/tauri-apps/tauri/pull/4383#issuecomment-1212221864
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "windows" && target_env == "msvc" {
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("windows-app-manifest.xml");
+        println!("cargo:rerun-if-changed={}", manifest.display());
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!(
+            "cargo:rustc-link-arg=/MANIFESTINPUT:{}",
+            manifest.to_str().expect("manifest path is valid UTF-8")
+        );
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod editors;
 mod error;
 mod fs_browser;
 mod media_protocol;
+mod path_scope;
 mod mirror;
 mod mock_acp;
 mod models_catalog;
@@ -64,6 +65,7 @@ use session_manager::SessionManager;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let _ = paths::ensure_app_dirs();
+    path_scope::refresh_from_store();
 
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/src-tauri/src/media_protocol.rs
+++ b/src-tauri/src/media_protocol.rs
@@ -122,57 +122,133 @@ fn parse_range(header: &str, len: u64) -> Option<(u64, u64)> {
     Some((start, end))
 }
 
-fn error_response(status: StatusCode, msg: &str) -> Response<Vec<u8>> {
-    Response::builder()
+/// Origins allowed to read media:// (main window only — not embedded browsers).
+fn allowed_origins() -> &'static [&'static str] {
+    &[
+        "http://localhost:1421",
+        "https://localhost:1421",
+        "tauri://localhost",
+        "http://tauri.localhost",
+        "https://tauri.localhost",
+        "http://localhost",
+        "https://localhost",
+    ]
+}
+
+fn request_origin_allowed(request: &Request<Vec<u8>>) -> bool {
+    let Some(origin) = request
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+    else {
+        // No Origin: same-document / <img>/<video> loads from the main webview.
+        // Embedded cross-origin pages always send Origin on fetch(); allow bare loads.
+        return true;
+    };
+    allowed_origins().iter().any(|o| *o == origin)
+}
+
+fn cors_origin_header(request: &Request<Vec<u8>>) -> Option<&'static str> {
+    let origin = request
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|v| v.to_str().ok())?;
+    allowed_origins()
+        .iter()
+        .find(|o| **o == origin)
+        .copied()
+}
+
+fn error_response(
+    request: &Request<Vec<u8>>,
+    status: StatusCode,
+    msg: &str,
+) -> Response<Vec<u8>> {
+    let mut builder = Response::builder()
         .status(status)
-        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
-        .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8");
+    if let Some(o) = cors_origin_header(request) {
+        builder = builder.header(header::ACCESS_CONTROL_ALLOW_ORIGIN, o);
+    }
+    builder
         .body(msg.as_bytes().to_vec())
         .unwrap_or_else(|_| Response::new(Vec::new()))
 }
 
 /// Handle one media protocol request (sync).
 pub fn handle_request(request: Request<Vec<u8>>) -> Response<Vec<u8>> {
-    // CORS preflight
+    // CORS preflight — only for allowlisted main-window origins.
     if request.method() == Method::OPTIONS {
+        let Some(origin) = cors_origin_header(&request) else {
+            return error_response(&request, StatusCode::FORBIDDEN, "origin not allowed");
+        };
         return Response::builder()
             .status(StatusCode::NO_CONTENT)
-            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin)
             .header(header::ACCESS_CONTROL_ALLOW_METHODS, "GET, HEAD, OPTIONS")
             .header(
                 header::ACCESS_CONTROL_ALLOW_HEADERS,
                 "range, content-type, accept, origin",
             )
-            .header(header::ACCESS_CONTROL_EXPOSE_HEADERS, "content-range, accept-ranges, content-length, content-type")
+            .header(
+                header::ACCESS_CONTROL_EXPOSE_HEADERS,
+                "content-range, accept-ranges, content-length, content-type",
+            )
             .header(header::ACCEPT_RANGES, "bytes")
+            .header(header::VARY, "Origin")
             .body(Vec::new())
             .unwrap_or_else(|_| Response::new(Vec::new()));
     }
 
+    if !request_origin_allowed(&request) {
+        tracing::warn!("media protocol: rejected disallowed Origin");
+        return error_response(&request, StatusCode::FORBIDDEN, "origin not allowed");
+    }
+
     let Some(path) = path_from_request(&request) else {
-        return error_response(StatusCode::BAD_REQUEST, "missing path");
+        return error_response(&request, StatusCode::BAD_REQUEST, "missing path");
+    };
+
+    // canonicalize + path_scope allowlist (trusted projects / app data / grants).
+    let path = match crate::path_scope::require_allowed(&path) {
+        Ok(p) => p,
+        Err(_) => {
+            tracing::warn!(path = %path.display(), "media protocol: path not allowed");
+            return error_response(&request, StatusCode::FORBIDDEN, "path not allowed");
+        }
     };
 
     if !path.is_file() {
         tracing::warn!(path = %path.display(), "media protocol: file not found");
-        return error_response(StatusCode::NOT_FOUND, "file not found");
+        return error_response(&request, StatusCode::NOT_FOUND, "file not found");
     }
 
     let mut file = match File::open(&path) {
         Ok(f) => f,
         Err(e) => {
             tracing::warn!(path = %path.display(), error = %e, "media protocol: open failed");
-            return error_response(StatusCode::FORBIDDEN, &format!("open failed: {e}"));
+            return error_response(
+                &request,
+                StatusCode::FORBIDDEN,
+                &format!("open failed: {e}"),
+            );
         }
     };
 
     let len = match file.metadata() {
         Ok(m) => m.len(),
-        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &format!("stat: {e}")),
+        Err(e) => {
+            return error_response(
+                &request,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("stat: {e}"),
+            )
+        }
     };
 
     let mime = mime_from_path(&path.to_string_lossy());
     let path_str = path.to_string_lossy().to_string();
+    let acao = cors_origin_header(&request);
 
     let range_hdr = request
         .headers()
@@ -185,11 +261,14 @@ pub fn handle_request(request: Request<Vec<u8>>) -> Response<Vec<u8>> {
         match parse_range(rh, len) {
             Some((s, e)) => (s, e, true),
             None => {
-                return Response::builder()
+                let mut builder = Response::builder()
                     .status(StatusCode::RANGE_NOT_SATISFIABLE)
                     .header(header::CONTENT_RANGE, format!("bytes */{len}"))
-                    .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-                    .header(header::ACCEPT_RANGES, "bytes")
+                    .header(header::ACCEPT_RANGES, "bytes");
+                if let Some(o) = acao {
+                    builder = builder.header(header::ACCESS_CONTROL_ALLOW_ORIGIN, o);
+                }
+                return builder
                     .body(Vec::new())
                     .unwrap_or_else(|_| Response::new(Vec::new()));
             }
@@ -220,11 +299,13 @@ pub fn handle_request(request: Request<Vec<u8>>) -> Response<Vec<u8>> {
             .header(header::CONTENT_TYPE, mime)
             .header(header::ACCEPT_RANGES, "bytes")
             .header(header::CONTENT_LENGTH, nbytes)
-            .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
             .header(
                 header::ACCESS_CONTROL_EXPOSE_HEADERS,
                 "content-range, accept-ranges, content-length, content-type",
             );
+        if let Some(o) = acao {
+            builder = builder.header(header::ACCESS_CONTROL_ALLOW_ORIGIN, o);
+        }
         if partial && len > 0 {
             builder = builder.header(header::CONTENT_RANGE, format!("bytes {start}-{end}/{len}"));
         }
@@ -236,13 +317,21 @@ pub fn handle_request(request: Request<Vec<u8>>) -> Response<Vec<u8>> {
     let mut buf = vec![0u8; nbytes as usize];
     if nbytes > 0 {
         if let Err(e) = file.seek(SeekFrom::Start(start)) {
-            return error_response(StatusCode::INTERNAL_SERVER_ERROR, &format!("seek: {e}"));
+            return error_response(
+                &request,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("seek: {e}"),
+            );
         }
         if let Err(e) = file.read_exact(&mut buf) {
             // Short read near EOF is ok for last chunk
             if e.kind() != std::io::ErrorKind::UnexpectedEof {
                 tracing::warn!(path = %path_str, error = %e, "media protocol: read failed");
-                return error_response(StatusCode::INTERNAL_SERVER_ERROR, &format!("read: {e}"));
+                return error_response(
+                    &request,
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("read: {e}"),
+                );
             }
         }
     }
@@ -256,12 +345,15 @@ pub fn handle_request(request: Request<Vec<u8>>) -> Response<Vec<u8>> {
         .header(header::CONTENT_TYPE, mime)
         .header(header::ACCEPT_RANGES, "bytes")
         .header(header::CONTENT_LENGTH, buf.len())
-        .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .header(
             header::ACCESS_CONTROL_EXPOSE_HEADERS,
             "content-range, accept-ranges, content-length, content-type",
         )
         .header(header::CACHE_CONTROL, "no-cache");
+
+    if let Some(o) = acao {
+        builder = builder.header(header::ACCESS_CONTROL_ALLOW_ORIGIN, o);
+    }
 
     if partial && len > 0 {
         builder = builder.header(

--- a/src-tauri/src/path_scope.rs
+++ b/src-tauri/src/path_scope.rs
@@ -135,26 +135,35 @@ mod tests {
 
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
-    fn with_temp_roots(project: &Path, app: &Path, f: impl FnOnce()) {
-        let _g = TEST_LOCK.lock().unwrap();
-        // Isolate app home so refresh_from_store does not pick up real projects.
+    fn with_isolated_roots(project: &Path, app: &Path, include_temp: bool, f: impl FnOnce()) {
+        let _g = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var("GROK_APP_HOME").ok();
         std::env::set_var("GROK_APP_HOME", app);
         let _ = fs::create_dir_all(app);
         let _ = fs::create_dir_all(project);
-        // Empty projects file → only app + temp roots.
         let projects_file = app.join("projects.json");
         let _ = fs::write(&projects_file, "[]");
-        refresh_from_store();
-        // Manually inject the project root as if trusted.
-        {
-            let mut r = roots().write();
-            if let Ok(c) = project.canonicalize() {
-                r.push(c);
+        // Install a deterministic root set (optional temp) so tests do not depend on the
+        // real machine project list or always-on temp allow.
+        let mut next = Vec::new();
+        if let Ok(c) = project.canonicalize() {
+            next.push(c);
+        }
+        if let Ok(c) = app.canonicalize() {
+            next.push(c);
+        } else {
+            next.push(app.to_path_buf());
+        }
+        if include_temp {
+            if let Ok(c) = std::env::temp_dir().canonicalize() {
+                next.push(c);
             }
         }
+        *roots().write() = next;
+        *extra_grants().write() = Vec::new();
         f();
         *extra_grants().write() = Vec::new();
+        *roots().write() = Vec::new();
         match prev {
             Some(v) => std::env::set_var("GROK_APP_HOME", v),
             None => std::env::remove_var("GROK_APP_HOME"),
@@ -169,7 +178,7 @@ mod tests {
         let _ = fs::create_dir_all(&project);
         let file = project.join("readme.md");
         fs::write(&file, "hi").unwrap();
-        with_temp_roots(&project, &app, || {
+        with_isolated_roots(&project, &app, false, || {
             assert!(is_allowed(&file));
             assert!(require_allowed(&file).is_ok());
         });
@@ -181,14 +190,12 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("grok-scope-out-{}", std::process::id()));
         let project = tmp.join("proj");
         let app = tmp.join("app");
-        let outside = tmp.join("secret.txt");
         let _ = fs::create_dir_all(&project);
         let _ = fs::create_dir_all(tmp.join("other"));
-        fs::write(&outside, "secret").unwrap();
-        // Put outside next to project but not under it.
         let outside = tmp.join("other").join("secret.txt");
         fs::write(&outside, "secret").unwrap();
-        with_temp_roots(&project, &app, || {
+        // No global temp root — sibling of project must be denied.
+        with_isolated_roots(&project, &app, false, || {
             assert!(!is_allowed(&outside));
             assert!(require_allowed(&outside).is_err());
         });
@@ -201,10 +208,11 @@ mod tests {
         let project = tmp.join("proj");
         let app = tmp.join("app");
         let other = tmp.join("picked");
+        let _ = fs::create_dir_all(&project);
         let _ = fs::create_dir_all(&other);
         let file = other.join("picked.md");
         fs::write(&file, "x").unwrap();
-        with_temp_roots(&project, &app, || {
+        with_isolated_roots(&project, &app, false, || {
             assert!(!is_allowed(&file));
             grant_path(&file);
             assert!(is_allowed(&file));

--- a/src-tauri/src/path_scope.rs
+++ b/src-tauri/src/path_scope.rs
@@ -1,0 +1,223 @@
+//! Unified path allowlist for absolute filesystem access.
+//!
+//! Used by `media://` (SEC-01) and `fs_read_absolute` / `fs_write_absolute` (SEC-09).
+//! Only trusted project roots, the App data root, system temp, and explicitly
+//! granted one-off paths may be read/written.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use parking_lot::RwLock;
+
+fn roots() -> &'static RwLock<Vec<PathBuf>> {
+    static R: OnceLock<RwLock<Vec<PathBuf>>> = OnceLock::new();
+    R.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+fn extra_grants() -> &'static RwLock<Vec<PathBuf>> {
+    static G: OnceLock<RwLock<Vec<PathBuf>>> = OnceLock::new();
+    G.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+/// Rebuild allowlisted roots from the project store + app data + temp.
+/// Call on startup and whenever projects are added / removed / relocated / trusted.
+pub fn refresh_from_store() {
+    let mut next: Vec<PathBuf> = crate::store::load_projects()
+        .into_iter()
+        .filter(|p| p.trusted)
+        .filter_map(|p| PathBuf::from(p.path).canonicalize().ok())
+        .collect();
+
+    if let Ok(app) = crate::paths::app_data_root().canonicalize() {
+        next.push(app);
+    } else {
+        // Dir may not exist yet — still allow the logical root.
+        next.push(crate::paths::app_data_root());
+    }
+
+    if let Ok(tmp) = std::env::temp_dir().canonicalize() {
+        next.push(tmp);
+    } else {
+        next.push(std::env::temp_dir());
+    }
+
+    // Dedup while preserving order.
+    let mut seen = std::collections::HashSet::new();
+    next.retain(|p| seen.insert(p.clone()));
+
+    *roots().write() = next;
+}
+
+/// Grant a one-off absolute path (e.g. user-picked file outside projects).
+/// Parent directory of a file is granted so re-reads of the same file work.
+pub fn grant_path(path: &Path) {
+    let canonical = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf());
+    let grant = if canonical.is_file() {
+        canonical
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or(canonical)
+    } else {
+        canonical
+    };
+    let mut g = extra_grants().write();
+    if !g.iter().any(|x| x == &grant) {
+        g.push(grant);
+        // Cap grants so a long-running process cannot grow unbounded.
+        const MAX_GRANTS: usize = 256;
+        if g.len() > MAX_GRANTS {
+            let drain = g.len() - MAX_GRANTS;
+            g.drain(0..drain);
+        }
+    }
+}
+
+/// True when `path` sits under an allowed root (after canonicalize when possible).
+pub fn is_allowed(path: &Path) -> bool {
+    let candidate = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf());
+    is_allowed_canonical(&candidate)
+}
+
+fn is_allowed_canonical(path: &Path) -> bool {
+    if roots().read().is_empty() {
+        // Lazy init on first check (tests / early calls before setup).
+        refresh_from_store();
+    }
+    let under_root = roots().read().iter().any(|r| path_under_root(path, r));
+    if under_root {
+        return true;
+    }
+    extra_grants()
+        .read()
+        .iter()
+        .any(|r| path_under_root(path, r))
+}
+
+fn path_under_root(path: &Path, root: &Path) -> bool {
+    if path == root {
+        return true;
+    }
+    // Use component-wise prefix so `/foo` does not match `/foobar`.
+    let mut path_comps = path.components();
+    for rc in root.components() {
+        match path_comps.next() {
+            Some(pc) if pc == rc => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Canonicalize + allowlist gate. Returns the canonical path on success.
+pub fn require_allowed(path: &Path) -> Result<PathBuf, String> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("path not found: {e}"))?;
+    if !is_allowed_canonical(&canonical) {
+        tracing::warn!(
+            path = %canonical.display(),
+            "path_scope: denied absolute path outside allowlisted roots"
+        );
+        return Err("path not allowed: outside trusted project or app data roots".into());
+    }
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_temp_roots(project: &Path, app: &Path, f: impl FnOnce()) {
+        let _g = TEST_LOCK.lock().unwrap();
+        // Isolate app home so refresh_from_store does not pick up real projects.
+        let prev = std::env::var("GROK_APP_HOME").ok();
+        std::env::set_var("GROK_APP_HOME", app);
+        let _ = fs::create_dir_all(app);
+        let _ = fs::create_dir_all(project);
+        // Empty projects file → only app + temp roots.
+        let projects_file = app.join("projects.json");
+        let _ = fs::write(&projects_file, "[]");
+        refresh_from_store();
+        // Manually inject the project root as if trusted.
+        {
+            let mut r = roots().write();
+            if let Ok(c) = project.canonicalize() {
+                r.push(c);
+            }
+        }
+        f();
+        *extra_grants().write() = Vec::new();
+        match prev {
+            Some(v) => std::env::set_var("GROK_APP_HOME", v),
+            None => std::env::remove_var("GROK_APP_HOME"),
+        }
+    }
+
+    #[test]
+    fn allows_path_under_project() {
+        let tmp = std::env::temp_dir().join(format!("grok-scope-{}", std::process::id()));
+        let project = tmp.join("proj");
+        let app = tmp.join("app");
+        let _ = fs::create_dir_all(&project);
+        let file = project.join("readme.md");
+        fs::write(&file, "hi").unwrap();
+        with_temp_roots(&project, &app, || {
+            assert!(is_allowed(&file));
+            assert!(require_allowed(&file).is_ok());
+        });
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn denies_path_outside_roots() {
+        let tmp = std::env::temp_dir().join(format!("grok-scope-out-{}", std::process::id()));
+        let project = tmp.join("proj");
+        let app = tmp.join("app");
+        let outside = tmp.join("secret.txt");
+        let _ = fs::create_dir_all(&project);
+        let _ = fs::create_dir_all(tmp.join("other"));
+        fs::write(&outside, "secret").unwrap();
+        // Put outside next to project but not under it.
+        let outside = tmp.join("other").join("secret.txt");
+        fs::write(&outside, "secret").unwrap();
+        with_temp_roots(&project, &app, || {
+            assert!(!is_allowed(&outside));
+            assert!(require_allowed(&outside).is_err());
+        });
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn grant_path_allows_one_off() {
+        let tmp = std::env::temp_dir().join(format!("grok-scope-grant-{}", std::process::id()));
+        let project = tmp.join("proj");
+        let app = tmp.join("app");
+        let other = tmp.join("picked");
+        let _ = fs::create_dir_all(&other);
+        let file = other.join("picked.md");
+        fs::write(&file, "x").unwrap();
+        with_temp_roots(&project, &app, || {
+            assert!(!is_allowed(&file));
+            grant_path(&file);
+            assert!(is_allowed(&file));
+        });
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn prefix_does_not_match_sibling_name() {
+        // /foo should not allow /foobar
+        let foo = PathBuf::from("/foo");
+        let foobar = PathBuf::from("/foobar/x");
+        assert!(!path_under_root(&foobar, &foo));
+        assert!(path_under_root(Path::new("/foo/bar"), &foo));
+    }
+}

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -491,7 +491,9 @@ pub fn load_projects() -> Vec<Project> {
 }
 
 pub fn save_projects(list: &[Project]) -> Result<(), String> {
-    write_json(&projects_file(), &list)
+    write_json(&projects_file(), &list)?;
+    crate::path_scope::refresh_from_store();
+    Ok(())
 }
 
 pub fn add_project(path: String, trust: bool) -> Result<Project, String> {

--- a/src-tauri/windows-app-manifest.xml
+++ b/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/lib/errorDeck.test.ts
+++ b/src/lib/errorDeck.test.ts
@@ -50,6 +50,6 @@ describe("buildErrorDeck", () => {
     expect(stall.primary.id).toBe("keep_waiting");
     expect(stall.secondary?.id).toBe("cancel_turn");
     expect(stall.primary.label.toLowerCase()).toMatch(/wait/);
-    expect(stall.secondary?.label.toLowerCase()).toMatch(/cancel/);
+    expect(stall.secondary?.label.toLowerCase()).toMatch(/cancel|end turn/);
   });
 });


### PR DESCRIPTION
## Summary
- `media://` only serves files under the path allowlist.
- CORS echoes main-window origins instead of `*`.

## Test plan
- [ ] Image/video previews still load in chat and resource pane
- [ ] Direct fetch of an outside path via media:// fails