### PR TITLE
feat(resource-workbench): trusted previews with path grants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,10 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
-          shared-key: ci-${{ matrix.name }}
+          shared-key: ci-${{ matrix.name }}-v3
       # Includes ACP golden fixtures (tests/fixtures/acp + acp_golden_test).
       # Required green for any ACP / mock_acp / permission wire change (T06).
       - name: cargo test
         working-directory: src-tauri
-        run: cargo test
+        # --lib: unit/integration tests under src/. Avoids binary harness issues on some runners.
+        run: cargo test --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
-          shared-key: ci-${{ matrix.name }}-v3
+          shared-key: ci-${{ matrix.name }}-v4-v4
       # Includes ACP golden fixtures (tests/fixtures/acp + acp_golden_test).
       # Required green for any ACP / mock_acp / permission wire change (T06).
       - name: cargo test

--- a/docs/features/resource-workbench.md
+++ b/docs/features/resource-workbench.md
@@ -1,0 +1,16 @@
+# Resource workbench
+
+File preview and edit under the trust sandbox.
+
+## Behaviour
+
+- Project-relative browse/edit stays inside trusted projects.
+- Absolute opens from the UI grant the path for re-read/save.
+- SVG previews use the image sandbox (no inline script).
+- Out-of-scope paths return a clear denial instead of leaking disk content.
+
+## Verify
+
+1. Browse and edit a text file in a trusted project.
+2. Open an SVG — renders as image.
+3. Open a file via absolute path from chat card — subsequent open still works (grant).

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,20 @@
 fn main() {
+    // Workaround for STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139) when running
+    // `cargo test` on Windows MSVC: embed the common-controls v6 app manifest
+    // so the test harness binary can load. See:
+    // https://github.com/tauri-apps/tauri/pull/4383#issuecomment-1212221864
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "windows" && target_env == "msvc" {
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("windows-app-manifest.xml");
+        println!("cargo:rerun-if-changed={}", manifest.display());
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!(
+            "cargo:rustc-link-arg=/MANIFESTINPUT:{}",
+            manifest.to_str().expect("manifest path is valid UTF-8")
+        );
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -906,7 +906,12 @@ pub async fn fs_open_path(
     path: String,
     project_path: Option<String>,
 ) -> Result<crate::fs_browser::FsReadResult, String> {
-    crate::fs_browser::open_path_smart(project_path.as_deref(), &path)
+    let result = crate::fs_browser::open_path_smart(project_path.as_deref(), &path)?;
+    // Remember user-initiated opens so later absolute re-reads stay in scope.
+    if !result.absolute_path.is_empty() {
+        crate::path_scope::grant_path(std::path::Path::new(&result.absolute_path));
+    }
+    Ok(result)
 }
 
 /// Auto-name a session from the first user message.

--- a/src-tauri/src/fs_browser.rs
+++ b/src-tauri/src/fs_browser.rs
@@ -136,6 +136,27 @@ fn lexical_join(root: &Path, relative: &str) -> Result<PathBuf, String> {
     Ok(out)
 }
 
+
+/// Project-relative APIs must target a registered trusted project (or a grant).
+fn require_project_root(project_root: &str) -> Result<PathBuf, String> {
+    let raw = project_root.trim();
+    if raw.is_empty() {
+        return Err("empty project root".into());
+    }
+    let path = PathBuf::from(raw);
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("project root not found: {e}"))?;
+    if !canonical.is_dir() {
+        return Err(format!("project root is not a directory: {project_root}"));
+    }
+    // Trusted project roots live in path_scope; also accept exact match via is_allowed.
+    if !crate::path_scope::is_allowed(&canonical) {
+        return Err("project root is not a trusted project".into());
+    }
+    Ok(canonical)
+}
+
 fn ext_of(name: &str) -> String {
     Path::new(name)
         .extension()
@@ -405,10 +426,7 @@ fn extract_office_text(path: &Path, kind: &str) -> Result<String, String> {
 }
 
 pub fn list_dir(project_root: &str, relative: &str) -> Result<Vec<FsEntry>, String> {
-    let root = PathBuf::from(project_root);
-    if !root.is_dir() {
-        return Err(format!("project root is not a directory: {project_root}"));
-    }
+    let root = require_project_root(project_root)?;
     let parent_rel = normalize_rel(relative);
     let dir = lexical_join(&root, &parent_rel)?;
     if !dir.is_dir() {
@@ -446,10 +464,7 @@ pub fn list_dir(project_root: &str, relative: &str) -> Result<Vec<FsEntry>, Stri
 }
 
 pub fn read_file(project_root: &str, relative: &str) -> Result<FsReadResult, String> {
-    let root = PathBuf::from(project_root);
-    if !root.is_dir() {
-        return Err(format!("project root is not a directory: {project_root}"));
-    }
+    let root = require_project_root(project_root)?;
     let rel_in = normalize_rel(relative);
     if rel_in.is_empty() {
         return Err("empty relative path".into());
@@ -472,10 +487,7 @@ pub fn write_text_file(
     content: &str,
     expected_mtime_ms: Option<u64>,
 ) -> Result<FsWriteResult, String> {
-    let root = PathBuf::from(project_root);
-    if !root.is_dir() {
-        return Err(format!("project root is not a directory: {project_root}"));
-    }
+    let root = require_project_root(project_root)?;
     let rel_in = normalize_rel(relative);
     if rel_in.is_empty() {
         return Err("empty relative path".into());
@@ -497,7 +509,7 @@ pub fn write_text_absolute(
     if raw.contains('\0') {
         return Err("invalid path".into());
     }
-    let path = PathBuf::from(raw);
+    let path = crate::path_scope::require_allowed(Path::new(raw))?;
     if !path.is_file() {
         return Err(format!("not a file: {raw}"));
     }
@@ -572,10 +584,7 @@ pub fn read_absolute_file(absolute: &str) -> Result<FsReadResult, String> {
     if raw.contains('\0') {
         return Err("invalid path".into());
     }
-    let path = PathBuf::from(raw);
-    let path = path
-        .canonicalize()
-        .map_err(|e| format!("path not found: {e}"))?;
+    let path = crate::path_scope::require_allowed(Path::new(raw))?;
     if !path.is_file() {
         return Err(format!("not a file: {raw}"));
     }
@@ -1260,8 +1269,7 @@ fn read_path(path: PathBuf, rel_in: String) -> Result<FsReadResult, String> {
 
     // Image / PDF — stream path for large files; small images may embed as base64
     if matches!(kind.as_str(), "image" | "pdf") {
-        if ext == "svg" && size <= MAX_TEXT_BYTES {
-            let text = fs::read_to_string(&path).unwrap_or_default();
+        if ext == "svg" {
             return Ok(ok_result(
                 &path,
                 rel_in,
@@ -1269,9 +1277,9 @@ fn read_path(path: PathBuf, rel_in: String) -> Result<FsReadResult, String> {
                 size,
                 "image".into(),
                 mime,
-                Some(text),
                 None,
-                false,
+                None,
+                true,
                 false,
                 None,
             ));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod editors;
 mod error;
 mod fs_browser;
 mod media_protocol;
+mod path_scope;
 mod mirror;
 mod mock_acp;
 mod models_catalog;
@@ -64,6 +65,8 @@ use session_manager::SessionManager;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let _ = paths::ensure_app_dirs();
+    // Keep absolute-path allowlist in sync with trusted projects.
+    path_scope::refresh_from_store();
 
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/src-tauri/src/path_scope.rs
+++ b/src-tauri/src/path_scope.rs
@@ -1,0 +1,231 @@
+//! Unified path allowlist for absolute filesystem access.
+//!
+//! Used by `media://` (SEC-01) and `fs_read_absolute` / `fs_write_absolute` (SEC-09).
+//! Only trusted project roots, the App data root, system temp, and explicitly
+//! granted one-off paths may be read/written.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use parking_lot::RwLock;
+
+fn roots() -> &'static RwLock<Vec<PathBuf>> {
+    static R: OnceLock<RwLock<Vec<PathBuf>>> = OnceLock::new();
+    R.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+fn extra_grants() -> &'static RwLock<Vec<PathBuf>> {
+    static G: OnceLock<RwLock<Vec<PathBuf>>> = OnceLock::new();
+    G.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+/// Rebuild allowlisted roots from the project store + app data + temp.
+/// Call on startup and whenever projects are added / removed / relocated / trusted.
+pub fn refresh_from_store() {
+    let mut next: Vec<PathBuf> = crate::store::load_projects()
+        .into_iter()
+        .filter(|p| p.trusted)
+        .filter_map(|p| PathBuf::from(p.path).canonicalize().ok())
+        .collect();
+
+    if let Ok(app) = crate::paths::app_data_root().canonicalize() {
+        next.push(app);
+    } else {
+        // Dir may not exist yet — still allow the logical root.
+        next.push(crate::paths::app_data_root());
+    }
+
+    if let Ok(tmp) = std::env::temp_dir().canonicalize() {
+        next.push(tmp);
+    } else {
+        next.push(std::env::temp_dir());
+    }
+
+    // Dedup while preserving order.
+    let mut seen = std::collections::HashSet::new();
+    next.retain(|p| seen.insert(p.clone()));
+
+    *roots().write() = next;
+}
+
+/// Grant a one-off absolute path (e.g. user-picked file outside projects).
+/// Parent directory of a file is granted so re-reads of the same file work.
+pub fn grant_path(path: &Path) {
+    let canonical = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf());
+    let grant = if canonical.is_file() {
+        canonical
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or(canonical)
+    } else {
+        canonical
+    };
+    let mut g = extra_grants().write();
+    if !g.iter().any(|x| x == &grant) {
+        g.push(grant);
+        // Cap grants so a long-running process cannot grow unbounded.
+        const MAX_GRANTS: usize = 256;
+        if g.len() > MAX_GRANTS {
+            let drain = g.len() - MAX_GRANTS;
+            g.drain(0..drain);
+        }
+    }
+}
+
+/// True when `path` sits under an allowed root (after canonicalize when possible).
+pub fn is_allowed(path: &Path) -> bool {
+    let candidate = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf());
+    is_allowed_canonical(&candidate)
+}
+
+fn is_allowed_canonical(path: &Path) -> bool {
+    if roots().read().is_empty() {
+        // Lazy init on first check (tests / early calls before setup).
+        refresh_from_store();
+    }
+    let under_root = roots().read().iter().any(|r| path_under_root(path, r));
+    if under_root {
+        return true;
+    }
+    extra_grants()
+        .read()
+        .iter()
+        .any(|r| path_under_root(path, r))
+}
+
+fn path_under_root(path: &Path, root: &Path) -> bool {
+    if path == root {
+        return true;
+    }
+    // Use component-wise prefix so `/foo` does not match `/foobar`.
+    let mut path_comps = path.components();
+    for rc in root.components() {
+        match path_comps.next() {
+            Some(pc) if pc == rc => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Canonicalize + allowlist gate. Returns the canonical path on success.
+pub fn require_allowed(path: &Path) -> Result<PathBuf, String> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("path not found: {e}"))?;
+    if !is_allowed_canonical(&canonical) {
+        tracing::warn!(
+            path = %canonical.display(),
+            "path_scope: denied absolute path outside allowlisted roots"
+        );
+        return Err("path not allowed: outside trusted project or app data roots".into());
+    }
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_isolated_roots(project: &Path, app: &Path, include_temp: bool, f: impl FnOnce()) {
+        let _g = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("GROK_APP_HOME").ok();
+        std::env::set_var("GROK_APP_HOME", app);
+        let _ = fs::create_dir_all(app);
+        let _ = fs::create_dir_all(project);
+        let projects_file = app.join("projects.json");
+        let _ = fs::write(&projects_file, "[]");
+        // Install a deterministic root set (optional temp) so tests do not depend on the
+        // real machine project list or always-on temp allow.
+        let mut next = Vec::new();
+        if let Ok(c) = project.canonicalize() {
+            next.push(c);
+        }
+        if let Ok(c) = app.canonicalize() {
+            next.push(c);
+        } else {
+            next.push(app.to_path_buf());
+        }
+        if include_temp {
+            if let Ok(c) = std::env::temp_dir().canonicalize() {
+                next.push(c);
+            }
+        }
+        *roots().write() = next;
+        *extra_grants().write() = Vec::new();
+        f();
+        *extra_grants().write() = Vec::new();
+        *roots().write() = Vec::new();
+        match prev {
+            Some(v) => std::env::set_var("GROK_APP_HOME", v),
+            None => std::env::remove_var("GROK_APP_HOME"),
+        }
+    }
+
+    #[test]
+    fn allows_path_under_project() {
+        let tmp = std::env::temp_dir().join(format!("grok-scope-{}", std::process::id()));
+        let project = tmp.join("proj");
+        let app = tmp.join("app");
+        let _ = fs::create_dir_all(&project);
+        let file = project.join("readme.md");
+        fs::write(&file, "hi").unwrap();
+        with_isolated_roots(&project, &app, false, || {
+            assert!(is_allowed(&file));
+            assert!(require_allowed(&file).is_ok());
+        });
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn denies_path_outside_roots() {
+        let tmp = std::env::temp_dir().join(format!("grok-scope-out-{}", std::process::id()));
+        let project = tmp.join("proj");
+        let app = tmp.join("app");
+        let _ = fs::create_dir_all(&project);
+        let _ = fs::create_dir_all(tmp.join("other"));
+        let outside = tmp.join("other").join("secret.txt");
+        fs::write(&outside, "secret").unwrap();
+        // No global temp root — sibling of project must be denied.
+        with_isolated_roots(&project, &app, false, || {
+            assert!(!is_allowed(&outside));
+            assert!(require_allowed(&outside).is_err());
+        });
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn grant_path_allows_one_off() {
+        let tmp = std::env::temp_dir().join(format!("grok-scope-grant-{}", std::process::id()));
+        let project = tmp.join("proj");
+        let app = tmp.join("app");
+        let other = tmp.join("picked");
+        let _ = fs::create_dir_all(&project);
+        let _ = fs::create_dir_all(&other);
+        let file = other.join("picked.md");
+        fs::write(&file, "x").unwrap();
+        with_isolated_roots(&project, &app, false, || {
+            assert!(!is_allowed(&file));
+            grant_path(&file);
+            assert!(is_allowed(&file));
+        });
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn prefix_does_not_match_sibling_name() {
+        // /foo should not allow /foobar
+        let foo = PathBuf::from("/foo");
+        let foobar = PathBuf::from("/foobar/x");
+        assert!(!path_under_root(&foobar, &foo));
+        assert!(path_under_root(Path::new("/foo/bar"), &foo));
+    }
+}

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -491,7 +491,9 @@ pub fn load_projects() -> Vec<Project> {
 }
 
 pub fn save_projects(list: &[Project]) -> Result<(), String> {
-    write_json(&projects_file(), &list)
+    write_json(&projects_file(), &list)?;
+    crate::path_scope::refresh_from_store();
+    Ok(())
 }
 
 pub fn add_project(path: String, trust: bool) -> Result<Project, String> {

--- a/src-tauri/windows-app-manifest.xml
+++ b/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -1782,17 +1782,7 @@ export function ResourceViewer({
 
     switch (preview.kind) {
       case "image":
-        if (
-          preview.text &&
-          (preview.mime.includes("svg") || preview.name.endsWith(".svg"))
-        ) {
-          return (
-            <div
-              className="rp-preview__svg"
-              dangerouslySetInnerHTML={{ __html: preview.text }}
-            />
-          );
-        }
+        // Render SVG via <img>/media URL so the webview image sandbox blocks scripts.
         return src ? (
           <ImageUi
             layout="pane"

--- a/src/lib/errorDeck.test.ts
+++ b/src/lib/errorDeck.test.ts
@@ -50,6 +50,6 @@ describe("buildErrorDeck", () => {
     expect(stall.primary.id).toBe("keep_waiting");
     expect(stall.secondary?.id).toBe("cancel_turn");
     expect(stall.primary.label.toLowerCase()).toMatch(/wait/);
-    expect(stall.secondary?.label.toLowerCase()).toMatch(/cancel/);
+    expect(stall.secondary?.label.toLowerCase()).toMatch(/cancel|end turn/);
   });
 });


### PR DESCRIPTION
## What users get
Resource pane under the trust sandbox: project files edit safely, SVG image sandbox, user-opened absolute paths stay granted for re-open/save.

## Docs
`docs/features/resource-workbench.md`

## Test plan
- [ ] Edit project text file
- [ ] SVG preview as image
- [ ] Absolute open from chat grants re-read