### PR TITLE
fix: ship 0.1.9 — Windows console, LINE webhook, installer download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-07-27
+
+> **Highlight:** Windows no more cmd flashes; LINE webhook actually listens on the documented port; installers downloadable from About.
+>
+> **中文 · 亮点：** Windows 不再狂闪 cmd；LINE Webhook 与文档端口一致；关于页可下载本机安装包。
+
+### Added
+- Settings → About: **Download installer** for the current OS when GitHub Release lists a matching asset (L08 tier B)
+- LINE webhook: HMAC `X-Line-Signature` verification; loopback bind by default
+- Remote IM: require non-empty allow-from before enable (`*` still allowed)
+- Session data mode help copy; CLI session import only in shared mode
+- Broader effort tokens for live switch (catalog-aligned)
+
+### Fixed
+- **Windows (#162):** hide console for git/CLI/open-url child processes (`CREATE_NO_WINDOW` / rundll32)
+- **LINE (#161):** default webhook port **8081** (was 8082) matching UI cloudflared hint; bind errors write `lastError`
+- Windows http(s) open no longer splits query `&` via `cmd /C start`
+- Secrets writes use atomic lock + rename
+- Sidebar busy settles when stop resolves without a final host event (#134, already on main)
+
+### Changed
+- CLI install: optional `GROK_CLI_REQUIRE_CHECKSUM=1` refuse unverified downloads
+
+**中文 · 新增**
+- 关于页：可下载本机对应安装包（L08 档 B）
+- LINE：签名校验；默认仅本机回环监听
+- 远程 IM：启用前必须填写 allow-from
+- 会话数据模式说明；CLI 会话导入仅共享模式
+- 思考力度取值与 CLI 目录对齐
+
+**中文 · 修复**
+- **Windows (#162)：** 子进程不再弹黑框
+- **LINE (#161)：** 默认端口 8081；监听失败写入 lastError
+- Windows 外链 `&` 不再被 cmd 截断
+- 密钥文件原子写入
+
+**中文 · 变更**
+- CLI 安装可选强制校验和
+
 ## [0.1.8] - 2026-07-26
 
 > **Highlight:** Multi-session chats keep running in the background; stabler replies; cleaner launch.

--- a/docs/features/app-update-flow.md
+++ b/docs/features/app-update-flow.md
@@ -1,0 +1,16 @@
+# App update flow
+
+Settings → About → Check for updates.
+
+## Behaviour
+
+1. Query GitHub Releases for the latest tag.
+2. Compare semver to the running app.
+3. When newer: offer **Download installer** (platform asset) and **Open release page**.
+
+Unsigned community builds do not silent-install; the handoff is download + user install.
+
+## Verify
+
+1. Check update against a known newer release — download URL points at the matching asset when present.
+2. When already latest — status says up to date.

--- a/docs/features/desktop-shell.md
+++ b/docs/features/desktop-shell.md
@@ -1,0 +1,5 @@
+# Desktop shell
+
+- http(s) links open without Windows `cmd /C start` query splitting.
+- `secrets.json` writes use atomic lock + rename.
+- Child processes use CREATE_NO_WINDOW on Windows to avoid console flash (Fixes #162).

--- a/docs/features/remote-security.md
+++ b/docs/features/remote-security.md
@@ -1,0 +1,6 @@
+# Remote control security
+
+- IM channels require a non-empty allow-from list before enable (`*` allowed).
+- LINE webhook defaults to **127.0.0.1:8081**, loopback bind; optional `allow_external`.
+- LINE validates `X-Line-Signature` (HMAC-SHA256).
+- Connector bind/exit errors write `lastError` so UI is not a false green "connected".

--- a/docs/plans/2026-07-27-issues-prs-update-ship-plan.md
+++ b/docs/plans/2026-07-27-issues-prs-update-ship-plan.md
@@ -1,0 +1,463 @@
+# Issues / PRs 清理 · 修复合并 · 新功能 · 自动更新 完整方案
+
+> **日期：** 2026-07-27  
+> **基线：** `main` @ v0.1.8（`9688b62` 附近）  
+> **范围：** 当前 GitHub Issues / Open PRs 分流、修复优先级、功能批整合策略、Tauri + GitHub Release 自动更新路线、日常开发与发版闭环  
+> **对齐：** [maintain.md](../llm-wiki/maintain.md) · [release.md](../llm-wiki/release.md) · [remote-im.md](../llm-wiki/remote-im.md) · [P0-能力矩阵 L08](../P0-能力矩阵.md)
+
+---
+
+## 0. 一句话结论
+
+| 维度 | 现状 | 动作 |
+|------|------|------|
+| **Issues** | 仅 2 个 OPEN，均为真实日用 bug | 立刻打标 + 进 **0.1.9 热修** |
+| **社区小 PR** | #131–#133 文档、#134 侧栏 busy | 可直接审并 merge |
+| **功能大 PR 批** | #151–#160 全部 **CONFLICTING**；前身 #135–#150 **CLOSED 未 merge** | **禁止逐个硬合**；改「主题切片 + 基于最新 main 重开 / 本地 integrate」 |
+| **自动更新** | L08 仅 **半成品**：能查 Release，**不**装、**不**用 `tauri-plugin-updater` | 分 **三档**推进；当前不启用静默 updater |
+| **发版** | 流程健康（tag → CI → 多端资产 + SHA256SUMS） | 热修走 patch；功能批走 minor 或下一 patch 分批 |
+
+---
+
+## 1. 当前库存盘点（2026-07-27）
+
+### 1.1 Open Issues
+
+| # | 标题 | 建议标签 | 优先级 | 根因线索（代码） |
+|---|------|----------|--------|------------------|
+| **#162** | Win11 0.1.8 新建项目时大量无效 cmd 弹窗 | `bug` `priority:p0` `platform:windows` `area:session` | **P0** | 多处 `Command::new` 未统一走 `process_util::apply_no_window_*`；新建项目会连打 CLI 探测 / PATH / 编辑器 / 代理探测，Windows GUI 子进程会闪 console |
+| **#161** | LINE UI「已连线」但 8081 无监听 | `bug` `priority:p0` `platform:macos` `area:session`（或新增 `area:remote-im`） | **P0** | ① UI 写死 `127.0.0.1:**8081**`（`RemoteImChannelPanel.tsx`），Rust 默认端口 **8082**（`line.rs`）；② 「已连接」= 凭证校验 / Bridge 状态，**≠** webhook listener 已 bind；③ `channel_secret` 未做签名校验（`let _ = channel_secret`） |
+
+Closed 近期：#128 等已在 0.1.8 一带合入，无需再开。
+
+### 1.2 Open PRs（14）
+
+#### A. 可快合（小、MERGEABLE）
+
+| PR | 作者 | 内容 | 决策 |
+|----|------|------|------|
+| **#134** | tisrop | 会话 stop 后侧栏 busy 未清除 | **优先审 merge**（真实 UX bug，+tests） |
+| **#131** | lunar-me | providers.md 语法 | 合或 batch docs |
+| **#132** | lunar-me | SPIKE-ACP 用词 | 合或 batch docs |
+| **#133** | lunar-me | git-worktrees.md 缺动词 | 合或 batch docs |
+
+#### B. 功能批（sonnemusk #151–#160）— 全部 CONFLICTING
+
+| PR | 主题 | 体量 | 与前身关系 |
+|----|------|------|------------|
+| #151 | trust-sandbox（path_scope / CSP / media） | +478 | 叠 #135–#138 等已关未合 PR |
+| #152 | remote-security（allow_from / webhook / mirror RO） | +483 | 叠 #139–#141 |
+| #153 | desktop-shell（安全开 URL / secrets 原子写） | +65 | 叠 #142/#144 |
+| #154 | composer-control（model/effort 失败可见） | +74 | 叠 #145 |
+| #155 | diagnostics（error deck / CLI trust） | +198 | 叠 #146/#147 |
+| #156 | session-data modes | +68 | 叠 #148 |
+| **#157** | **app-update 平台安装包下载** | +133 | 叠 #149；**L08 第二档** |
+| #158 | windows-dayuse 验收 + safe links | +119 | 叠 #142/#150 |
+| #159 | remote-im ready（ACL + webhook GUI） | +262 | 与 #152 重叠，需去重 |
+| #160 | resource-workbench | +324 | 依赖 #151 path_scope |
+
+**关键事实：**
+
+- CI 对多数 PR 曾报 4 绿，但 **mergeable=CONFLICTING**（main 已前进，含 0.1.8 热修）。
+- #140–#150 **全部 CLOSED 且 `mergedAt=null`** → 内容**不在 main**，不能当「已合」关 Issue。
+- 多 PR 重复改：`build.rs` / `windows-app-manifest.xml` / `ci.yml` / `errorDeck.test.ts` → **串行 rebase 必炸**，必须主题切片或 monorepo integrate 分支。
+
+### 1.3 自动更新现状（L08）
+
+| 能力 | 状态 | 落点 |
+|------|------|------|
+| 查 GitHub `releases/latest` | ✅ | `src-tauri/src/app_update.rs` + Settings About |
+| API 限流 HTML 回退 | ✅ | 同上 |
+| 打开 Release 页 | ✅ | `openExternalUrl` |
+| 按平台选资产并下载 | ❌（在 #157） | 未入 main |
+| `tauri-plugin-updater` 静默安装 | ❌ | `tauri.conf.json` 无 `plugins.updater`；`release.yml` `includeUpdaterJson: false` |
+| Updater 签名密钥 | ❌ | 无 `TAURI_SIGNING_*` secrets（且空值会弄挂 build） |
+| OS 代码签名 / 公证 | ❌ | 与 updater 签名是**两件事**（见开源诊断 NEW-06） |
+
+`app_update.rs` 顶部注释已写明产品立场：**未签名社区构建 + 无 signing secrets → 静默 updater 不可靠**，先走「有新版本 → 打开/下载安装包」。
+
+---
+
+## 2. Issues 清理 SOP
+
+### 2.1 立刻（今天，无需写代码）
+
+```bash
+# 打标（示例）
+gh issue edit 162 --add-label "bug,priority:p0,platform:windows"
+gh issue edit 161 --add-label "bug,priority:p0,platform:macos,from:community"
+# 可选：写首评「已复现线索 / 目标进 0.1.9」
+```
+
+| 动作 | 说明 |
+|------|------|
+| 补标签 | 按 maintain.md 词汇表：type + priority + platform + area |
+| 首评 | 写清根因假设 + 目标版本，避免用户重复开 Issue |
+| 不关 Issue | 修复合并后用 `Fixes #162` 自动关 |
+
+### 2.2 日常 triage（维持）
+
+```text
+New Issue
+  → type + platform + area + priority:p0|p1|p2
+  → P0：当日开 fix 分支或挂进当前热修里程碑
+  → P1：进下一 patch
+  → P2：backlog / good first issue
+  → 重复 → duplicate + 关
+```
+
+社区 X/群反馈：转 Issue 并打 `from:community`（maintain.md）。
+
+---
+
+## 3. PR 清理与合并策略
+
+### 3.1 总原则
+
+1. **main 为唯一真相**；Open PR 不代表已交付。  
+2. **冲突功能批不逐个 Merge**，避免半合状态与重复 manifest。  
+3. **小而正确的修优先**（#134、docs）。  
+4. 合入后：CHANGELOG Unreleased → 删远程分支 → `git fetch --prune`（branch hygiene）。  
+5. 已关未合的 #135–#150：在对应主题真正落地后 **comment + 保持 closed**（或 label `superseded` 说明），不要重新 open 一堆僵尸 PR。
+
+### 3.2 轨道 A — 热修 / 社区小 PR（本周前半）
+
+**顺序：**
+
+```text
+1) #134 侧栏 busy settle
+2) #131 + #132 + #133 文档（可 squash 或连合）
+3) #162 Windows cmd 闪窗（新分支 fix/win-no-console）
+4) #161 LINE 端口 + 状态语义（新分支 fix/line-webhook-listen）
+5) 需要时 cherry-pick 功能批中「已可独立」的安全小切片（见轨道 B 切片表）
+→ tag v0.1.9
+```
+
+**#134 审查要点：**
+
+- [ ] `sessionLiveStore` 单测覆盖 stop 后 busy 清零  
+- [ ] 不误清其他 live session  
+- [ ] `pnpm test` / typecheck  
+
+**#162 实施要点：**
+
+- 审计所有 `Command::new` / `tokio::process::Command`：  
+  `acp_client` · `cli_probe` · `cli_install` · `cli_update` · `account` · `editors` · `extensions` · `agent_memory` · `proxy` 探测 · `remote_im/grok_agent`  
+- 统一 `process_util::apply_no_window_std` / `apply_no_window_tokio`  
+- 禁止用 `cmd /C start ...` 开 URL 时留下可见 console（与 #142/#153 主题对齐）  
+- 验收：Win11 新建项目 / 打开会话 / Doctor 探测 **零闪窗**
+
+**#161 实施要点：**
+
+| 项 | 做法 |
+|----|------|
+| 端口单一真相 | 默认端口与 UI / cloudflared 提示同源（建议 **统一 8082** 或统一 8081，写进 options + i18n 动态插值，禁止硬编码） |
+| 状态机 | `configured`（有凭证）≠ `listening`（bind 成功）≠ `connected`（端到端可收） |
+| UI | listener 未起来时 **禁止绿灯「已连接」**；显示 bind 错误 / 实际 `127.0.0.1:port` |
+| 运行时 | Bridge start 时确认 LINE `run()` task 存活；bind 失败写 `lastError` |
+| 安全 | 补 LINE `X-Line-Signature` 校验（#152/#159 有现成方向，可先热修最小实现） |
+| 验收 | `lsof -iTCP:<port>` 有监听；cloudflared 不 502；私讯能进 Bridge |
+
+### 3.3 轨道 B — 功能批 #151–#160 整合（本周后半 → 下一版）
+
+#### 推荐方式：**主题切片 integrate，而非 10 个 PR 串行 rebase**
+
+```text
+origin/main
+    └─ integrate/hardening-0.2   （维护者本地或 worktree）
+         ├─ slice-1 trust + resource   （#151 核心 + #160 去重）
+         ├─ slice-2 remote security    （#152 + #159 去重，含 LINE/allow_from）
+         ├─ slice-3 desktop shell      （#153 + #158 的 opener 部分）
+         ├─ slice-4 session UX         （#154 + #156）
+         ├─ slice-5 diagnostics        （#155）
+         └─ slice-6 app-update L08-B   （#157）
+```
+
+每 slice：
+
+1. 从最新 `main` 开分支（或 re-apply 原 PR diff）。  
+2. `pnpm typecheck && pnpm test && cd src-tauri && cargo test`。  
+3. 独立 PR 或同一 integrate PR 的有序 commit。  
+4. 原 sonnemusk PR 评论「landed via #xxx / integrate」后 **close**。  
+5. 重复的 `windows-app-manifest.xml` / `build.rs` **只保留一份**最终形态。
+
+#### 切片优先级（安全 > 日用 > 体验）
+
+| 顺序 | Slice | 来源 PR | 用户价值 | 风险 |
+|------|-------|---------|----------|------|
+| 1 | desktop opener + secrets 原子写 | #153（+ #158 链接） | Win 登录/文档不裂 URL；密钥不截断 | 低 |
+| 2 | remote-im fail-closed + LINE | #152/#159 + **#161 热修** | 远程控权安全；LINE 真能用 | 中 |
+| 3 | path_scope / CSP / media | #151 | 本地文件信任边界 | 中高 |
+| 4 | resource workbench | #160 | 依赖 path_scope | 中 |
+| 5 | error deck + CLI trust | #155 | 首跑可行动诊断 | 中 |
+| 6 | model/effort + session modes | #154/#156 | 设置语义闭合 | 低 |
+| 7 | **app-update 下载安装包** | **#157** | L08 第二档 | 低 |
+| 8 | windows day-use 文档/验收 | #158 文档部分 | 可延后 | 低 |
+
+#### 明确 **不要** 在 0.1.x 做的
+
+- 一次性 merge 全部 10 个冲突 PR  
+- 在未生成 updater 密钥前打开 `includeUpdaterJson: true`  
+- 用空的 `APPLE_*` / `TAURI_SIGNING_*` 填进 CI（已踩坑）
+
+### 3.4 关 PR 话术模板
+
+```text
+Thanks — this work is being re-landed against current main as part of
+integrate/<slice> (see docs/plans/2026-07-27-issues-prs-update-ship-plan.md).
+Closing this PR to avoid conflict noise; credit remains in the integrate PR.
+```
+
+---
+
+## 4. 自动更新完整方案（Tauri × GitHub Release）
+
+### 4.1 目标分层（对齐 L08 / 项目需求 P1）
+
+| 档 | 名称 | 用户体验 | 前置条件 | 目标版本 |
+|----|------|----------|----------|----------|
+| **A** | 发现更新 | Settings → 检查；有新版本打开 Release | 无 | ✅ 已在 main |
+| **B** | 引导安装 | 按 OS/arch 选 dmg/setup/AppImage；浏览器或系统下载；展示 SHA256 | Release 资产命名稳定；#157 | **0.1.9 / 0.2.0** |
+| **C** | 应用内更新 | 下载 → 校验签名 → 提示重启安装 | `tauri-plugin-updater` + minisign 密钥 + CI 产 `latest.json` | **证书/密钥就位后** |
+| **D** | 静默/后台 | 可选自动下载；仍需用户确认安装 | 档 C + 产品开关 + 崩溃回滚策略 | 更后 |
+
+**当前产品默认：停在 A，尽快到 B；C 不作为 0.1.x 阻塞。**
+
+### 4.2 档 B — 平台安装包下载（落地 #157 思路）
+
+**行为：**
+
+1. `app_check_update` 返回 `updateAvailable` + `assetNames` + `htmlUrl`（已有）。  
+2. 扩展：`recommendedAsset`（名 + browser_download_url），按：
+
+| OS | Arch | 匹配规则（建议） |
+|----|------|------------------|
+| macOS | aarch64 | `*aarch64*.dmg` / `*aarch64-apple*` |
+| macOS | x86_64 | `*x64*.dmg` 且非 arm |
+| Windows | x64 | `*-setup.exe` 优先，其次 `*portable*.zip` |
+| Linux | x64 | `*.AppImage` 优先，其次 `.deb` / `.rpm` |
+
+3. UI：`检查更新` → 有更新时 **「下载本机安装包」** + **「打开发布页」**。  
+4. 下载：优先 `openExternalUrl(assetUrl)`（简单、复用系统下载器）；进阶再用 Tauri `http` + 进度条 + 与 `SHA256SUMS` 比对。  
+5. i18n 文案明确：**不会静默替换当前 App**（与档 C 区分）。
+
+**CI 侧（已有，保持）：**
+
+- tag `v*` → `release.yml` 四平台  
+- `includeUpdaterJson: false`（档 B 阶段保持 false）  
+- `checksums` job 上传 `SHA256SUMS`
+
+**验收：**
+
+- [ ] 0.1.8 客户端对 mock 更高 tag 显示下载按钮  
+- [ ] mac arm / win 能匹配到正确资产名  
+- [ ] 无匹配时仅「打开发布页」  
+- [ ] `cargo test` `app_update::` 覆盖 semver + asset pick
+
+### 4.3 档 C — 真·Tauri Updater + GitHub Release
+
+#### 架构
+
+```text
+CI (tag vX.Y.Z)
+  → tauri build (各 target)
+  → 用 TAURI_SIGNING_PRIVATE_KEY 签名更新包
+  → 上传 .dmg / .msi|nsis / .AppImage …
+  → 生成/更新 latest.json（或 static endpoint）
+  → GitHub Release assets
+
+App (runtime)
+  → plugins.updater.endpoints = [
+      "https://github.com/RongleCat/grok-app/releases/latest/download/latest.json"
+    ]
+  → pubkey = 内嵌公钥（tauri.conf）
+  → check() → download_and_install() → relaunch
+```
+
+#### 一次性密钥（人类操作）
+
+```bash
+# 本地生成（勿提交私钥）
+npm run tauri signer generate -w ~/.tauri/grok-app.key
+# 公钥 → tauri.conf.json plugins.updater.pubkey
+# 私钥 → GitHub Secrets: TAURI_SIGNING_PRIVATE_KEY
+# 口令 → TAURI_SIGNING_PRIVATE_KEY_PASSWORD（若有）
+```
+
+#### 配置变更清单
+
+| 文件 | 变更 |
+|------|------|
+| `src-tauri/Cargo.toml` | `tauri-plugin-updater` |
+| `src-tauri/tauri.conf.json` | `plugins.updater`：`pubkey` + `endpoints`；`bundle.createUpdaterArtifacts` |
+| `src-tauri/src/lib.rs` | `.plugin(tauri_plugin_updater::Builder::new().build())` |
+| `.github/workflows/release.yml` | `includeUpdaterJson: true`；注入非空 signing env |
+| `src/components/SettingsPage.tsx` | 有签名更新时走 plugin；失败回退档 B |
+| `docs/llm-wiki/release.md` | 补充 updater 发版检查项 |
+| `docs/P0-能力矩阵.md` | L08 → 分档勾选 |
+
+#### 与 OS 代码签名的关系（勿混淆）
+
+| 机制 | 解决什么 | 不解决什么 |
+|------|----------|------------|
+| **Tauri updater minisign** | 更新包未被篡改 | SmartScreen / Gatekeeper |
+| **Windows Authenticode** | SmartScreen 信誉 | 自动更新通道 |
+| **Apple Developer ID + notarization** | Gatekeeper | Windows |
+
+档 C 可在 **无** Authenticode/公证时上线，但用户仍可能被系统拦截安装；README 继续写 `xattr` / SmartScreen 说明。
+
+#### 档 C 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 私钥泄漏 | 仅 Secrets；轮换密钥需发「强制网页下载」过渡版 |
+| 半包更新 | 校验完整后再 install；失败保留旧版 |
+| 绿色版 portable | updater 主要服务安装版；portable 仍走档 B |
+| 代理环境 | 复用 `proxy::apply_to_reqwest` / 系统代理（与 NEW-02 一致） |
+
+#### 档 C 验收
+
+- [ ] 预发 prerelease tag 客户端能 check 到更新  
+- [ ] 签名错误的包被拒绝  
+- [ ] 断网 / 限流有可读错误（error deck）  
+- [ ] 更新后 `CARGO_PKG_VERSION` 与 About 一致  
+- [ ] 无密钥的 fork 构建仍可运行（updater disable 或仅档 B）
+
+### 4.4 档 D（可选，不排期）
+
+- 设置项：`自动检查`（默认开）/ `自动下载`（默认关）  
+- 启动后空闲检查（节流 24h）  
+- 与 CLI 的 `grok` 自更新 **分离**（App 已对 agent 使用 `--no-auto-update`）
+
+---
+
+## 5. 修复 · 合并 · 新功能 完整工作流
+
+### 5.1 三条并行轨道
+
+```text
+        ┌──────────── 轨道 A：热修 / 社区 ────────────┐
+Issues ─┤  #162 #161 #134 docs → v0.1.9               │
+        └────────────────────────────────────────────┘
+        ┌──────────── 轨道 B：硬化功能批 ────────────┐
+PRs ────┤  integrate slices → v0.2.0（或 0.1.10+）   │
+        └────────────────────────────────────────────┘
+        ┌──────────── 轨道 C：产品新功能 ────────────┐
+Roadmap ┤  L 矩阵 / Remote IM / 会话 UX …            │
+        │  必须从最新 main 拉分支；禁止堆在冲突 PR 上 │
+        └────────────────────────────────────────────┘
+```
+
+### 5.2 单任务开发闭环（所有轨道共用）
+
+```text
+1. Issue / 设计一页纸（大功能走 docs/plans 或 llm-wiki）
+2. 分支：fix/… · feat/… · 基于 origin/main
+3. 实现 + 单测；i18n en+zh；无 window.confirm
+4. 本地：pnpm typecheck && pnpm test && cargo test
+5. PR：关联 Fixes #n；CI 绿
+6. 审查清单（maintain.md）
+7. squash/merge → 删分支 → CHANGELOG [Unreleased]
+8. 一批可交付 → release-tag.sh → 看 Release 资产
+```
+
+### 5.3 新功能准入（避免再次出现「10 个冲突 PR」）
+
+| 规则 | 说明 |
+|------|------|
+| 一 PR 一主题 | 禁止「安全 + UI + CI manifest」大杂烩 |
+| 共享脚手架先合 | `windows-app-manifest` / CSP 地基单独先合 |
+| 48h 内 rebase | 冲突超过 2 天未处理 → 维护者 integrate 或 close |
+| 依赖写清 | 如 #160 depends on #151 path_scope |
+| 文档 | 用户可见行为 → `docs/llm-wiki` 或 `docs/features`；发版进 CHANGELOG |
+
+### 5.4 发版节奏建议
+
+| 版本 | 内容 | 触发 |
+|------|------|------|
+| **v0.1.9** | #162 #161 #134 + 可选 opener/secrets 小切片 + CHANGELOG | P0 修完即发 |
+| **v0.1.10** | 档 B 更新下载 + remote-im 安全默认 | slice 1–2+7 |
+| **v0.2.0** | trust sandbox + resource + diagnostics 整包 | slice 3–6 稳后 |
+| **v0.x + updater** | 档 C | 密钥与 CI 验证后单独小版本 |
+
+流程仍只认 [release.md](../llm-wiki/release.md)：三处 version + CHANGELOG 章节 + tag + CI。
+
+---
+
+## 6. 两周执行清单（可勾选）
+
+### Week 1 — 止血与清理
+
+- [ ] Issue #162 #161 打标 + 里程碑 `v0.1.9`
+- [ ] Merge #134；merge #131–#133
+- [ ] 修复 #162（全路径 `CREATE_NO_WINDOW`）
+- [ ] 修复 #161（端口统一 + 状态语义 + bind 错误上浮）
+- [ ] 在 #151–#160 下评论 integrate 计划；避免贡献者继续基于旧 tip 推
+- [ ] tag **v0.1.9**，验证四平台 Release + SHA256SUMS
+- [ ] `git fetch --prune`；删已合远程分支
+
+### Week 2 — 硬化与更新档 B
+
+- [ ] integrate slice-1 desktop shell（opener + secrets）
+- [ ] integrate slice-2 remote security（与 #161 不重复）
+- [ ] 落地 #157 思路 → 档 B 安装包下载
+- [ ] 视稳定度 tag **v0.1.10** 或并入 0.2.0 准备
+- [ ] 人类决策：是否采购代码签名 / 生成 Tauri updater 密钥（档 C 开关）
+
+### Backlog（不阻塞上述）
+
+- [ ] path_scope + resource workbench  
+- [ ] diagnostics 全量  
+- [ ] L 矩阵其余：托盘增强、导出 MD、MCP GUI…  
+- [ ] 档 C updater  
+- [ ] Authenticode / Apple 公证（商业决策）
+
+---
+
+## 7. 角色分工
+
+| 角色 | 职责 |
+|------|------|
+| **维护者 / 集成 Agent** | 热修、integrate 切片、发版、关冲突 PR |
+| **功能 Agent** | 只从最新 main 开主题分支；不叠在 #151–#160 上 |
+| **人类** | Secrets（签名密钥、Apple/Win 证书）、Workflow 写权限、是否上档 C |
+| **社区** | 小 docs / good first issue；大功能先开 Issue 讨论 |
+
+---
+
+## 8. 成功标准
+
+1. **Open Issues = 0 P0**（#161 #162 关闭或有明确 workaround + 修复 PR）。  
+2. **Open PR 列表干净**：无长期 CONFLICTING 僵尸；功能批要么 landed 要么 closed 并指向 integrate。  
+3. **用户更新路径清晰**：About 能发现新版本；档 B 能下到对应安装包；档 C 有书面开关条件。  
+4. **发版可重复**：任意 Agent 只读 `release.md` 即可 ship。  
+5. **Windows 日用**：无 cmd 风暴；链接可点；SmartScreen 说明诚实。  
+6. **Remote IM LINE**：绿灯 ⇒ 本机 webhook 真监听；文档端口与代码一致。
+
+---
+
+## 9. 相关命令速查
+
+```bash
+# 库存
+gh issue list --state open
+gh pr list --state open
+
+# 热修后发版
+pnpm typecheck && pnpm test
+cd src-tauri && cargo test
+# 写 CHANGELOG ## [0.1.9]
+./scripts/release-tag.sh 0.1.9 --push
+
+# 分支卫生
+git fetch --prune origin
+gh pr list --state merged --limit 20
+```
+
+---
+
+## 10. 修订记录
+
+| 日期 | 说明 |
+|------|------|
+| 2026-07-27 | 初版：基于 open #161/#162、PR #131–#134/#151–#160、app_update 与 release.yml 实态 |

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1700,6 +1700,7 @@ dependencies = [
  "fs2",
  "futures-util",
  "hex",
+ "hmac",
  "image",
  "keyring",
  "parking_lot",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 futures-util = "0.3"
 base64 = "0.22"
 sha2 = "0.10"
+hmac = "0.12"
 hex = "0.4"
 rfd = "0.15"
 window-vibrancy = "0.6"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,18 @@
 fn main() {
+    // Workaround for STATUS_ENTRYPOINT_NOT_FOUND when running `cargo test` on
+    // Windows MSVC: embed common-controls v6 so the test harness can start.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "windows" && target_env == "msvc" {
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("windows-app-manifest.xml");
+        println!("cargo:rerun-if-changed={}", manifest.display());
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!(
+            "cargo:rustc-link-arg=/MANIFESTINPUT:{}",
+            manifest.to_str().expect("manifest path is valid UTF-8")
+        );
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -1604,30 +1604,7 @@ pub fn open_browser_url(url: &str) -> Result<(), String> {
 }
 
 fn open_url(url: &str) -> Result<(), String> {
-    #[cfg(target_os = "macos")]
-    {
-        Command::new("open")
-            .arg(url)
-            .status()
-            .map_err(|e| e.to_string())?;
-        return Ok(());
-    }
-    #[cfg(target_os = "windows")]
-    {
-        Command::new("cmd")
-            .args(["/C", "start", "", url])
-            .status()
-            .map_err(|e| e.to_string())?;
-        return Ok(());
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        Command::new("xdg-open")
-            .arg(url)
-            .status()
-            .map_err(|e| e.to_string())?;
-        Ok(())
-    }
+    crate::commands::open_http_url(url)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/app_update.rs
+++ b/src-tauri/src/app_update.rs
@@ -36,6 +36,9 @@ pub struct AppUpdateCheck {
     pub body: Option<String>,
     /// Download asset names on the release (for UI hints; not auto-fetched).
     pub asset_names: Vec<String>,
+    /// Best-effort direct installer URL for this platform (if assets list one).
+    pub download_url: Option<String>,
+    pub download_name: Option<String>,
 }
 
 /// Strip optional `v` / `V` prefix and parse `major.minor.patch` (extra suffix ignored).
@@ -58,6 +61,66 @@ pub fn is_remote_newer(current: &str, remote: &str) -> bool {
     match (parse_semver(current), parse_semver(remote)) {
         (Some(a), Some(b)) => b > a,
         _ => false,
+    }
+}
+
+fn pick_platform_asset(assets: Option<&Vec<Value>>) -> (Option<String>, Option<String>) {
+    let Some(arr) = assets else {
+        return (None, None);
+    };
+    // Prefer exact installers first (setup.exe / dmg / AppImage), then arch tokens.
+    let prefer: &[&str] = if cfg!(target_os = "macos") {
+        if cfg!(target_arch = "aarch64") {
+            &["aarch64", "arm64", "apple-silicon", ".dmg", "macos"]
+        } else {
+            &["x64", "x86_64", ".dmg", "macos"]
+        }
+    } else if cfg!(target_os = "windows") {
+        &["-setup.exe", "setup.exe", ".msi", "x64", "windows", ".exe"]
+    } else {
+        &[".appimage", "appimage", ".deb", "linux"]
+    };
+    let mut best: Option<(usize, String, String)> = None; // score, name, url
+    for a in arr {
+        let name = match a.get("name").and_then(|n| n.as_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let url = match a.get("browser_download_url").and_then(|u| u.as_str()) {
+            Some(u) if u.starts_with("https://") => u.to_string(),
+            _ => continue,
+        };
+        let lower = name.to_ascii_lowercase();
+        // Skip checksum / signature sidecars.
+        if lower.ends_with(".sig")
+            || lower == "sha256sums"
+            || lower.contains("sha256")
+            || lower.ends_with(".json")
+        {
+            continue;
+        }
+        let mut score = 0usize;
+        for (i, token) in prefer.iter().enumerate() {
+            if lower.contains(token) {
+                score += 100 - i;
+            }
+        }
+        // Prefer non-portable on Windows when both match.
+        if cfg!(target_os = "windows") && lower.contains("portable") {
+            score = score.saturating_sub(30);
+        }
+        if score == 0 {
+            continue;
+        }
+        match &best {
+            None => best = Some((score, name, url)),
+            Some((s, _, _)) if score > *s => best = Some((score, name, url)),
+            _ => {}
+        }
+    }
+    match best {
+        Some((_, n, u)) => (Some(u), Some(n)),
+        None => (None, None),
     }
 }
 
@@ -91,15 +154,15 @@ pub fn parse_github_release(current_version: &str, v: &Value) -> Result<AppUpdat
         .and_then(|x| x.as_str())
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
-    let asset_names = v
-        .get("assets")
-        .and_then(|a| a.as_array())
+    let assets = v.get("assets").and_then(|a| a.as_array());
+    let asset_names = assets
         .map(|arr| {
             arr.iter()
                 .filter_map(|a| a.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
-                .collect()
+                .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    let (download_url, download_name) = pick_platform_asset(assets);
 
     let latest_version = tag.trim_start_matches(['v', 'V']).to_string();
     let update_available = is_remote_newer(current_version, tag);
@@ -113,6 +176,8 @@ pub fn parse_github_release(current_version: &str, v: &Value) -> Result<AppUpdat
         published_at,
         body,
         asset_names,
+        download_url,
+        download_name,
     })
 }
 
@@ -157,6 +222,8 @@ fn build_check_from_tag(current_version: &str, tag: &str, html_url: &str) -> App
         published_at: None,
         body: None,
         asset_names: vec![],
+        download_url: None,
+        download_name: None,
     }
 }
 
@@ -396,6 +463,8 @@ mod tests {
         assert_eq!(up.current_version, "0.1.5");
         assert_eq!(up.asset_names.len(), 2);
         assert!(up.body.as_deref().unwrap().contains("hello"));
+        // Platform pick is compile-time; at least one of name/url fields is set or both None.
+        assert_eq!(up.download_url.is_some(), up.download_name.is_some());
 
         let same = parse_github_release("0.2.0", &sample).unwrap();
         assert!(!same.update_available);

--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -721,8 +721,20 @@ pub async fn install_cli_latest(app: AppHandle) -> Result<CliInstallResult, Stri
             true
         }
         None => {
-            // Official mirrors do not publish sidecars today. We still compute and surface
-            // the hash, enforce allowlist + size + --version, and never install off-list.
+            // Prefer published sidecars. Without one we still enforce URL allowlist +
+            // size + binary --version, and mark the install as unverified.
+            let require = std::env::var("GROK_CLI_REQUIRE_CHECKSUM")
+                .map(|v| {
+                    let v = v.trim().to_ascii_lowercase();
+                    matches!(v.as_str(), "1" | "true" | "yes" | "on")
+                })
+                .unwrap_or(false);
+            if require {
+                let _ = fs::remove_file(&tmp_path);
+                return Err(format!(
+                    "No published SHA-256 for {artifact_name}. Refusing install because GROK_CLI_REQUIRE_CHECKSUM is set. hash={digest}"
+                ));
+            }
             warn!(
                 "cli_install: no published checksum for {artifact_name}; \
                  continuing with allowlist + binary probe (hash={digest})"

--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -422,6 +422,12 @@ pub fn import_cli_session(
     project_id: Option<String>,
     session_data_mode: &str,
 ) -> Result<SessionMeta, String> {
+    if session_data_mode != "shared" {
+        return Err(
+            "CLI session import requires shared session data mode (Settings → General)".into(),
+        );
+    }
+
     let dir = if let Some(d) = dir.filter(|s| !s.is_empty()) {
         PathBuf::from(d)
     } else {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -251,6 +251,14 @@ pub async fn app_check_update() -> Result<crate::app_update::AppUpdateCheck, Str
 /// Open a URL in the system browser (docs, install pages).
 #[tauri::command]
 pub async fn open_external_url(url: String) -> Result<(), String> {
+    open_http_url(url.trim())
+}
+
+/// Shared http(s) open helper (also used by account login).
+///
+/// Windows uses `rundll32 url.dll,FileProtocolHandler` so query `&` is not
+/// split by `cmd /C start`, and no console window flashes (Fixes #162).
+pub fn open_http_url(url: &str) -> Result<(), String> {
     let url = url.trim();
     if url.is_empty() {
         return Err("empty url".into());
@@ -258,9 +266,13 @@ pub async fn open_external_url(url: String) -> Result<(), String> {
     if !(url.starts_with("https://") || url.starts_with("http://")) {
         return Err("only http(s) URLs allowed".into());
     }
+    // Reject control characters that could smuggle extra commands.
+    if url.bytes().any(|b| b == 0 || b == b'\n' || b == b'\r') {
+        return Err("invalid url".into());
+    }
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
+        crate::process_util::command("open")
             .arg(url)
             .status()
             .map_err(|e| e.to_string())?;
@@ -268,15 +280,16 @@ pub async fn open_external_url(url: String) -> Result<(), String> {
     }
     #[cfg(target_os = "windows")]
     {
-        std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
+        // Avoid `cmd /C start` — it re-parses `&` in query strings as command separators.
+        crate::process_util::command("rundll32")
+            .args(["url.dll,FileProtocolHandler", url])
             .status()
             .map_err(|e| e.to_string())?;
         return Ok(());
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        std::process::Command::new("xdg-open")
+        crate::process_util::command("xdg-open")
             .arg(url)
             .status()
             .map_err(|e| e.to_string())?;
@@ -357,21 +370,21 @@ pub async fn project_reveal(id: String) -> Result<(), String> {
     let path = p.path.clone();
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
+        crate::process_util::command("open")
             .arg(&path)
             .spawn()
             .map_err(|e| e.to_string())?;
     }
     #[cfg(target_os = "windows")]
     {
-        std::process::Command::new("explorer")
+        crate::process_util::command("explorer")
             .arg(&path)
             .spawn()
             .map_err(|e| e.to_string())?;
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        std::process::Command::new("xdg-open")
+        crate::process_util::command("xdg-open")
             .arg(&path)
             .spawn()
             .map_err(|e| e.to_string())?;
@@ -1827,13 +1840,13 @@ fn save_and_reveal_file(
     let path_s = final_path.display().to_string();
     #[cfg(target_os = "macos")]
     {
-        let _ = std::process::Command::new("open")
+        let _ = crate::process_util::command("open")
             .args(["-R", &path_s])
             .status();
     }
     #[cfg(target_os = "windows")]
     {
-        let _ = std::process::Command::new("explorer")
+        let _ = crate::process_util::command("explorer")
             .args(["/select,", &path_s])
             .status();
     }
@@ -3901,21 +3914,21 @@ pub async fn path_open(path: String) -> Result<(), String> {
     }
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
+        crate::process_util::command("open")
             .arg(&p)
             .spawn()
             .map_err(|e| e.to_string())?;
     }
     #[cfg(target_os = "windows")]
     {
-        std::process::Command::new("cmd")
+        crate::process_util::command("cmd")
             .args(["/C", "start", "", &p])
             .spawn()
             .map_err(|e| e.to_string())?;
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        std::process::Command::new("xdg-open")
+        crate::process_util::command("xdg-open")
             .arg(&p)
             .spawn()
             .map_err(|e| e.to_string())?;
@@ -3987,7 +4000,7 @@ pub async fn git_file_diff(
     }
 
     // Soft check: is git on PATH?
-    let git_ok = std::process::Command::new("git")
+    let git_ok = crate::process_util::command("git")
         .arg("--version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -4004,7 +4017,7 @@ pub async fn git_file_diff(
     }
 
     // Confirm we are inside a work tree
-    let inside = std::process::Command::new("git")
+    let inside = crate::process_util::command("git")
         .args(["-C", &project, "rev-parse", "--is-inside-work-tree"])
         .output();
     let inside_ok = inside
@@ -4021,7 +4034,7 @@ pub async fn git_file_diff(
     }
 
     // Working tree + index vs HEAD (covers staged and unstaged edits).
-    let out = std::process::Command::new("git")
+    let out = crate::process_util::command("git")
         .args([
             "-C",
             &project,
@@ -4037,7 +4050,7 @@ pub async fn git_file_diff(
 
     if !out.status.success() {
         // Untracked new file: try against empty tree
-        let untracked = std::process::Command::new("git")
+        let untracked = crate::process_util::command("git")
             .args([
                 "-C",
                 &project,
@@ -4078,7 +4091,7 @@ pub async fn git_file_diff(
     let text = String::from_utf8_lossy(&out.stdout).to_string();
     if text.trim().is_empty() {
         // Maybe untracked
-        let untracked = std::process::Command::new("git")
+        let untracked = crate::process_util::command("git")
             .args([
                 "-C",
                 &project,
@@ -4093,7 +4106,7 @@ pub async fn git_file_diff(
             // Show full file as addition via --no-index when possible
             let abs = proj.join(&rel);
             if abs.is_file() {
-                let u = std::process::Command::new("git")
+                let u = crate::process_util::command("git")
                     .args([
                         "-C",
                         &project,
@@ -4139,7 +4152,7 @@ pub async fn git_file_diff(
 
 /// Soft-check git on PATH + project is inside a work tree.
 fn git_probe_work_tree(project: &str) -> Result<(), String> {
-    let git_ok = std::process::Command::new("git")
+    let git_ok = crate::process_util::command("git")
         .arg("--version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -4149,7 +4162,7 @@ fn git_probe_work_tree(project: &str) -> Result<(), String> {
     if !git_ok {
         return Err("git not available".into());
     }
-    let inside = std::process::Command::new("git")
+    let inside = crate::process_util::command("git")
         .args(["-C", project, "rev-parse", "--is-inside-work-tree"])
         .output();
     let inside_ok = inside
@@ -4329,7 +4342,7 @@ pub async fn git_status(project_path: String) -> Result<GitStatusResult, String>
         });
     }
 
-    let branch = std::process::Command::new("git")
+    let branch = crate::process_util::command("git")
         .args(["-C", &project, "rev-parse", "--abbrev-ref", "HEAD"])
         .output()
         .ok()
@@ -4347,7 +4360,7 @@ pub async fn git_status(project_path: String) -> Result<GitStatusResult, String>
         });
 
     // Porcelain v1: untracked as `??`, no ignored noise, relative paths.
-    let out = std::process::Command::new("git")
+    let out = crate::process_util::command("git")
         .args([
             "-C",
             &project,
@@ -4520,7 +4533,7 @@ pub async fn git_show_file(
     }
 
     // `git show HEAD:path` — fails for untracked / missing at HEAD
-    let out = std::process::Command::new("git")
+    let out = crate::process_util::command("git")
         .args(["-C", &project, "show", &format!("HEAD:{rel}")])
         .output()
         .map_err(|e| e.to_string())?;
@@ -4740,7 +4753,7 @@ pub async fn git_worktrees_list(project_path: String) -> Result<GitWorktreesResu
         });
     }
 
-    let out = std::process::Command::new("git")
+    let out = crate::process_util::command("git")
         .args(["-C", &project, "worktree", "list", "--porcelain"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -4815,7 +4828,7 @@ pub async fn path_reveal(path: String) -> Result<(), String> {
     }
     #[cfg(target_os = "macos")]
     {
-        std::process::Command::new("open")
+        crate::process_util::command("open")
             .args(["-R", &p])
             .spawn()
             .map_err(|e| e.to_string())?;
@@ -4823,7 +4836,7 @@ pub async fn path_reveal(path: String) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         // explorer /select,<path> — works with spaces on modern Windows.
-        std::process::Command::new("explorer")
+        crate::process_util::command("explorer")
             .arg(format!("/select,{p}"))
             .spawn()
             .map_err(|e| e.to_string())?;
@@ -4835,7 +4848,7 @@ pub async fn path_reveal(path: String) -> Result<(), String> {
             .parent()
             .map(|x| x.to_path_buf())
             .unwrap_or(pb.clone());
-        std::process::Command::new("xdg-open")
+        crate::process_util::command("xdg-open")
             .arg(parent)
             .spawn()
             .map_err(|e| e.to_string())?;
@@ -5635,7 +5648,7 @@ pub async fn git_worktree_add(
     let start = sanitize_worktree_ref(start_point.as_deref())?;
 
     // Resolve main worktree path (first porcelain entry) for sibling placement.
-    let list_out = std::process::Command::new("git")
+    let list_out = crate::process_util::command("git")
         .args(["-C", &project, "worktree", "list", "--porcelain"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -5682,7 +5695,7 @@ pub async fn git_worktree_add(
         args.push(sp.clone());
     }
 
-    let out = std::process::Command::new("git")
+    let out = crate::process_util::command("git")
         .args(&args)
         .output()
         .map_err(|e| e.to_string())?;
@@ -5702,7 +5715,7 @@ pub async fn git_worktree_add(
 
     // Best-effort: re-list to pick up branch field for the new path.
     let branch = {
-        let re = std::process::Command::new("git")
+        let re = crate::process_util::command("git")
             .args(["-C", &project, "worktree", "list", "--porcelain"])
             .output()
             .ok();
@@ -5759,7 +5772,7 @@ pub async fn git_worktree_gc(
 
     // Snapshot prunable entries before prune for UI preview / summary.
     let prunable = {
-        let list_out = std::process::Command::new("git")
+        let list_out = crate::process_util::command("git")
             .args(["-C", &project, "worktree", "list", "--porcelain"])
             .output()
             .map_err(|e| e.to_string())?;
@@ -5781,7 +5794,7 @@ pub async fn git_worktree_gc(
         age.as_deref(),
     )?;
 
-    let out = std::process::Command::new("git")
+    let out = crate::process_util::command("git")
         .args(&args)
         .output()
         .map_err(|e| e.to_string())?;
@@ -5864,7 +5877,7 @@ pub async fn git_worktree_remove(
         return Err("invalid worktree path".into());
     }
 
-    let list_out = std::process::Command::new("git")
+    let list_out = crate::process_util::command("git")
         .args(["-C", &project, "worktree", "list", "--porcelain"])
         .output()
         .map_err(|e| e.to_string())?;
@@ -5909,7 +5922,7 @@ pub async fn git_worktree_remove(
     }
     args.push(remove_path.clone());
 
-    let out = std::process::Command::new("git")
+    let out = crate::process_util::command("git")
         .args(&args)
         .output()
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/editors.rs
+++ b/src-tauri/src/editors.rs
@@ -422,8 +422,8 @@ pub fn open_in_editor(
         } else {
             args.push(abs.clone());
         }
-        Command::new(&cmd)
-            .args(&args)
+        let mut c = crate::process_util::command(&cmd);
+        c.args(&args)
             .spawn()
             .map_err(|e| format!("failed to open editor `{cmd}`: {e}"))?;
         return Ok(());
@@ -432,21 +432,22 @@ pub fn open_in_editor(
     // Fallback: OS default open
     #[cfg(target_os = "macos")]
     {
-        Command::new("open")
+        crate::process_util::command("open")
             .arg(&abs)
             .spawn()
             .map_err(|e| e.to_string())?;
     }
     #[cfg(target_os = "windows")]
     {
-        Command::new("cmd")
-            .args(["/C", "start", "", &abs])
+        // rundll32 avoids cmd console flash and handles paths with spaces.
+        crate::process_util::command("rundll32")
+            .args(["url.dll,FileProtocolHandler", &abs])
             .spawn()
             .map_err(|e| e.to_string())?;
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        Command::new("xdg-open")
+        crate::process_util::command("xdg-open")
             .arg(&abs)
             .spawn()
             .map_err(|e| e.to_string())?;

--- a/src-tauri/src/process_util.rs
+++ b/src-tauri/src/process_util.rs
@@ -72,6 +72,20 @@ pub fn apply_no_window_tokio(cmd: &mut tokio::process::Command) {
     let _ = cmd;
 }
 
+/// Build a `std::process::Command` with Windows console hidden (Fixes #162).
+pub fn command(program: impl AsRef<std::ffi::OsStr>) -> StdCommand {
+    let mut cmd = StdCommand::new(program);
+    apply_no_window_std(&mut cmd);
+    cmd
+}
+
+/// Build a `tokio::process::Command` with Windows console hidden.
+pub fn tokio_command(program: impl AsRef<std::ffi::OsStr>) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new(program);
+    apply_no_window_tokio(&mut cmd);
+    cmd
+}
+
 /// Whether a path looks runnable as a CLI binary on this OS.
 ///
 /// Follows symlinks (`is_file` / metadata). On Windows accepts `.exe`/`.cmd`/`.bat`/`.com`

--- a/src-tauri/src/remote_im/channels/line.rs
+++ b/src-tauri/src/remote_im/channels/line.rs
@@ -7,6 +7,9 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, watch};
 
+/// Default local webhook port (must match Settings UI / cloudflared callout).
+pub const DEFAULT_WEBHOOK_PORT: u16 = 8081;
+
 pub async fn run(
     inst: ChannelInstance,
     tx: mpsc::Sender<IncomingMessage>,
@@ -14,7 +17,6 @@ pub async fn run(
 ) -> Result<(), String> {
     let channel_secret = secret_or_opt(&inst.secrets, &inst.options, "channel_secret")
         .ok_or_else(|| "line: missing channel_secret".to_string())?;
-    let _ = channel_secret; // signature verification can be added
     let access_token = secret_or_opt(&inst.secrets, &inst.options, "channel_access_token")
         .ok_or_else(|| "line: missing channel_access_token".to_string())?;
     let _ = access_token;
@@ -27,21 +29,45 @@ pub async fn run(
                 .and_then(|x| x.as_u64())
                 .map(|n| n as u16)
         })
-        .unwrap_or(8082);
+        .unwrap_or(DEFAULT_WEBHOOK_PORT);
     let path = secret_or_opt(&inst.secrets, &inst.options, "callback_path")
         .unwrap_or_else(|| "/line/callback".into());
 
-    tracing::info!(instance = %inst.id, port, %path, "line webhook server starting");
+    // Default loopback; opt-in LAN bind only with allow_external=true.
+    let allow_external = inst
+        .options
+        .get("allow_external")
+        .or_else(|| inst.options.get("allowExternal"))
+        .and_then(|x| x.as_bool())
+        .unwrap_or(false);
+    let bind_ip = if allow_external {
+        [0, 0, 0, 0]
+    } else {
+        [127, 0, 0, 1]
+    };
+    tracing::info!(
+        instance = %inst.id,
+        port,
+        %path,
+        allow_external,
+        "line webhook server starting"
+    );
 
-    // Minimal raw TCP HTTP server to avoid new deps — use hyper via reqwest not available.
-    // Use tokio TcpListener + very small request parser.
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let addr = SocketAddr::from((bind_ip, port));
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .map_err(|e| format!("line bind {port}: {e}"))?;
+    // Clear prior bind errors once the listener is up (UI green only if bridge + no lastError).
+    let _ = super::super::config::set_instance_last_error(&inst.id, None);
+    tracing::info!(
+        instance = %inst.id,
+        %addr,
+        "line webhook listening"
+    );
 
     let inst = Arc::new(inst);
     let path = Arc::new(path);
+    let channel_secret = Arc::new(channel_secret);
 
     loop {
         tokio::select! {
@@ -53,6 +79,7 @@ pub async fn run(
                 let tx = tx.clone();
                 let inst = inst.clone();
                 let path = path.clone();
+                let channel_secret = channel_secret.clone();
                 tokio::spawn(async move {
                     use tokio::io::{AsyncReadExt, AsyncWriteExt};
                     let mut buf = vec![0u8; 65536];
@@ -64,6 +91,20 @@ pub async fn run(
                     let body = req.split("\r\n\r\n").nth(1).unwrap_or("");
                     if !req.contains(path.as_str()) {
                         let _ = socket.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n").await;
+                        return;
+                    }
+                    // require X-Line-Signature (HMAC-SHA256 of raw body).
+                    let sig = req
+                        .lines()
+                        .find(|l| l.to_ascii_lowercase().starts_with("x-line-signature:"))
+                        .and_then(|l| l.split_once(':'))
+                        .map(|(_, v)| v.trim().to_string());
+                    if !line_signature_ok(channel_secret.as_str(), body.as_bytes(), sig.as_deref())
+                    {
+                        tracing::warn!(instance = %inst.id, "line: bad or missing X-Line-Signature");
+                        let _ = socket
+                            .write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n")
+                            .await;
                         return;
                     }
                     if let Ok(v) = serde_json::from_str::<Value>(body) {
@@ -118,11 +159,66 @@ pub async fn send_text(
         .await
         .map_err(|e| e.to_string())?;
     if !res.status().is_success() {
-        return Err(format!("line push: {}", res.status()));
+        let body = res.text().await.unwrap_or_default();
+        return Err(format!("line push failed: {body}"));
     }
     Ok(())
 }
 
 pub fn protocol_name() -> &'static str {
     "line-webhook"
+}
+
+fn const_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.as_bytes().iter().zip(b.as_bytes().iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// LINE: `X-Line-Signature` = Base64(HMAC-SHA256(channel_secret, raw_body)).
+fn line_signature_ok(channel_secret: &str, body: &[u8], header_sig: Option<&str>) -> bool {
+    use base64::Engine;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let Some(sig) = header_sig.map(str::trim).filter(|s| !s.is_empty()) else {
+        return false;
+    };
+    let mut mac = match Hmac::<Sha256>::new_from_slice(channel_secret.as_bytes()) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    mac.update(body);
+    let expected = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+    const_time_eq(&expected, sig)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_signature_accepts_valid() {
+        use base64::Engine;
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let secret = "test_secret";
+        let body = br#"{"events":[]}"#;
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let sig = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        assert!(line_signature_ok(secret, body, Some(&sig)));
+        assert!(!line_signature_ok(secret, body, Some("bad")));
+        assert!(!line_signature_ok(secret, body, None));
+    }
+
+    #[test]
+    fn default_port_matches_ui_callout() {
+        assert_eq!(DEFAULT_WEBHOOK_PORT, 8081);
+    }
 }

--- a/src-tauri/src/remote_im/channels/mod.rs
+++ b/src-tauri/src/remote_im/channels/mod.rs
@@ -96,6 +96,8 @@ pub fn spawn_instance(
         };
         if let Err(e) = result {
             tracing::error!(instance = %id, channel = %channel, "channel connector exited: {e}");
+            // Surface bind/auth failures so Settings does not keep a green "connected".
+            let _ = super::config::set_instance_last_error(&id, Some(e));
         }
     })
 }

--- a/src-tauri/src/remote_im/config.rs
+++ b/src-tauri/src/remote_im/config.rs
@@ -146,6 +146,22 @@ pub fn delete_instance(instance_id: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Persist connector exit / bind errors so UI does not show a false "connected".
+pub fn set_instance_last_error(instance_id: &str, err: Option<String>) -> Result<(), String> {
+    let mut list = list_instances();
+    let Some(row) = list.iter_mut().find(|x| x.id == instance_id) else {
+        return Ok(());
+    };
+    row.last_error = err.clone();
+    if err.is_some() {
+        row.status = "error".into();
+    } else if row.has_credentials {
+        row.status = "configured".into();
+    }
+    write_instances(&list)?;
+    Ok(())
+}
+
 /// Legacy path kept for doctor/docs; Rust runtime does not require Node config.toml.
 pub fn bridge_data_dir() -> PathBuf {
     let dir = app_data_root().join("remote").join("bridge-data");

--- a/src-tauri/src/remote_im/outbound.rs
+++ b/src-tauri/src/remote_im/outbound.rs
@@ -217,6 +217,11 @@ pub fn secret_or_opt(
         .or_else(|| opt_str(options, key))
 }
 
+/// Parse allow-from ACL.
+///
+/// - `*` or missing → open (None)
+/// - empty string → fail-closed empty list
+/// - comma list → allow only those senders
 pub fn allow_from_list(acl: &serde_json::Value) -> Option<Vec<String>> {
     let raw = acl
         .get("allowFrom")
@@ -224,8 +229,11 @@ pub fn allow_from_list(acl: &serde_json::Value) -> Option<Vec<String>> {
         .and_then(|x| x.as_str())
         .unwrap_or("*")
         .trim();
-    if raw.is_empty() || raw == "*" {
+    if raw == "*" {
         return None;
+    }
+    if raw.is_empty() {
+        return Some(vec![]);
     }
     Some(
         raw.split(',')
@@ -238,8 +246,14 @@ pub fn allow_from_list(acl: &serde_json::Value) -> Option<Vec<String>> {
 pub fn sender_allowed(acl: &serde_json::Value, sender_id: &str) -> bool {
     match allow_from_list(acl) {
         None => true,
+        Some(list) if list.is_empty() => false,
         Some(list) => list.iter().any(|x| x == sender_id || x == "*"),
     }
+}
+
+/// True when enable should be refused (empty allow list, not `*`).
+pub fn allow_from_blocks_enable(acl: &serde_json::Value) -> bool {
+    matches!(allow_from_list(acl), Some(list) if list.is_empty())
 }
 
 pub fn require_mention(options: &serde_json::Value, acl: &serde_json::Value) -> bool {

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -215,10 +215,12 @@ fn write_disk_secrets(path: &PathBuf, value: &SecretsFile) -> Result<(), String>
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let s = serde_json::to_string_pretty(value).map_err(|e| e.to_string())?;
-    fs::write(path, s).map_err(|e| e.to_string())?;
+    // Same exclusive-lock + temp-rename path as the session store.
+    crate::store_lock::write_bytes_atomic(path, s.as_bytes())?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
+        // write_bytes_atomic creates the final file; ensure mode is private.
         let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
     }
     Ok(())

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -4686,7 +4686,13 @@ impl SessionManager {
         effort: String,
     ) -> Result<(), String> {
         let effort = effort.trim().to_string();
-        if !matches!(effort.as_str(), "high" | "medium" | "low") {
+        // Accept CLI catalog values; unknown efforts still fail closed with a clear error.
+        let ok = matches!(
+            effort.as_str(),
+            "low" | "medium" | "high" | "xhigh" | "max" | "none"
+        ) || (effort.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            && (2..=32).contains(&effort.len()));
+        if !ok {
             return Err(format!("invalid effort: {effort}"));
         }
         let need = {

--- a/src-tauri/windows-app-manifest.xml
+++ b/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/components/RemoteImChannelPanel.tsx
+++ b/src/components/RemoteImChannelPanel.tsx
@@ -229,6 +229,13 @@ export function RemoteImChannelPanel({
         options.allow_from = acl.allowFrom;
       }
 
+      // Fail-closed: empty allow list cannot enable (security default).
+      const allowRaw = String(acl.allowFrom ?? "").trim();
+      if (!allowRaw) {
+        setFormError(t("settings.remoteIm.err.allowFromRequired"));
+        return false;
+      }
+
       const nextAcl: AclConfig = {
         ...acl,
         shareSessionInChannel:
@@ -815,7 +822,9 @@ export function RemoteImChannelPanel({
             </div>
             <p>{t("settings.remoteIm.publicUrl.body")}</p>
             <code className="rim-callout__code">
-              cloudflared tunnel --url http://127.0.0.1:8081
+              {`cloudflared tunnel --url http://127.0.0.1:${
+                String(values.port ?? secrets.port ?? "").trim() || "8081"
+              }`}
             </code>
           </div>
         ) : null}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1788,6 +1788,7 @@ export function SettingsPage({
                   ]}
                 />
               </div>
+              <p className="settings-page__hint">{t("settings.sessionModeHelp")}</p>
               {sessionDataMode === "shared" ? (
                 <CliSessionsPanel
                   t={t}
@@ -3375,13 +3376,24 @@ function AboutUpdateRow({
               : t("settings.checkUpdate")}
           </button>
           {result?.updateAvailable ? (
-            <button
-              type="button"
-              className="btn btn--ghost"
-              onClick={() => void openRelease(result.htmlUrl)}
-            >
-              {t("settings.checkUpdateOpen")}
-            </button>
+            <>
+              {result.downloadUrl ? (
+                <button
+                  type="button"
+                  className="btn btn--solid"
+                  onClick={() => void openRelease(result.downloadUrl!)}
+                >
+                  {t("settings.checkUpdateDownload")}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="btn btn--ghost"
+                onClick={() => void openRelease(result.htmlUrl)}
+              >
+                {t("settings.checkUpdateOpen")}
+              </button>
+            </>
           ) : null}
         </div>
         {error ? (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -950,18 +950,21 @@ const en = {
   "settings.aboutApp": "About Grok App",
   "settings.checkUpdate": "Check for updates",
   "settings.checkUpdateDesc":
-    "Look up the latest GitHub release. Download installers from the release page — this app does not auto-install yet.",
+    "Look up the latest GitHub release. Download the installer for this OS when available — silent in-app install is not enabled yet.",
   "settings.checkUpdateChecking": "Checking…",
   "settings.checkUpdateLatest": "You are on the latest version ({version}).",
   "settings.checkUpdateAvailable":
     "Version {latest} is available (you have {current}).",
   "settings.checkUpdateOpen": "Open release page",
+  "settings.checkUpdateDownload": "Download installer",
   "settings.checkUpdateFailed": "Could not check: {error}",
   "settings.close": "Close",
   "settings.sharedConfirm":
     "Switch to shared ~/.grok? Data will not merge silently. Confirm?",
   "settings.modeIndependent": "independent (~/.grok-app)",
   "settings.modeShared": "shared (~/.grok)",
+  "settings.sessionModeHelp":
+    "Independent keeps chats in the app data dir. Shared uses the CLI home so App and terminal see the same sessions. CLI import requires shared mode.",
   "settings.tabOfficial": "Official account",
   "settings.tabProviders": "Custom providers",
   "settings.tabOfficialHint":
@@ -1890,6 +1893,8 @@ const en = {
   "settings.remoteIm.err.pairPaste": "Could not parse id:secret pair.",
   "settings.remoteIm.err.missingFields": "Missing required fields: {fields}",
   "settings.remoteIm.err.needSecrets": "Enter credentials before saving.",
+  "settings.remoteIm.err.allowFromRequired":
+    "Add at least one allow-from user id (or * for any) before enabling this channel.",
   "settings.remoteIm.test.ok": "Connection test succeeded.",
   "settings.remoteIm.test.fail": "Connection test failed: {error}",
   "settings.remoteIm.status.connected": "Connected",
@@ -2931,18 +2936,21 @@ const zh: Record<MessageKey, string> = {
   "settings.aboutApp": "关于 Grok App",
   "settings.checkUpdate": "检查更新",
   "settings.checkUpdateDesc":
-    "查询 GitHub 最新 Release。安装包请在发布页下载 — 应用暂不自动安装。",
+    "查询 GitHub 最新 Release。有新版本时可下载本机安装包 — 应用暂不静默安装。",
   "settings.checkUpdateChecking": "检查中…",
   "settings.checkUpdateLatest": "已是最新版本（{version}）。",
   "settings.checkUpdateAvailable":
     "有新版本 {latest}（当前 {current}）。",
   "settings.checkUpdateOpen": "打开发布页",
+  "settings.checkUpdateDownload": "下载安装包",
   "settings.checkUpdateFailed": "检查失败：{error}",
   "settings.close": "关闭",
   "settings.sharedConfirm":
     "切换到共享 ~/.grok？数据不会静默合并，请确认。",
   "settings.modeIndependent": "独立（~/.grok-app）",
   "settings.modeShared": "共享（~/.grok）",
+  "settings.sessionModeHelp":
+    "独立模式会话存在应用目录；共享模式使用 CLI 主目录，与终端共用会话。导入 CLI 会话仅共享模式可用。",
   "settings.tabOfficial": "官方账户",
   "settings.tabProviders": "自定义提供商",
   "settings.tabOfficialHint":
@@ -3850,6 +3858,8 @@ const zh: Record<MessageKey, string> = {
   "settings.remoteIm.err.pairPaste": "无法解析 id:secret 格式。",
   "settings.remoteIm.err.missingFields": "缺少必填字段：{fields}",
   "settings.remoteIm.err.needSecrets": "请先填写凭证再保存。",
+  "settings.remoteIm.err.allowFromRequired":
+    "启用前请至少填写一个 allow-from 用户 ID（或 * 表示允许任意）。",
   "settings.remoteIm.test.ok": "连接测试成功。",
   "settings.remoteIm.test.fail": "连接测试失败：{error}",
   "settings.remoteIm.status.connected": "已连接",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -918,12 +918,15 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.checkUpdateAvailable":
     "有新版本 {latest}（目前 {current}）。",
   "settings.checkUpdateOpen": "開啟發佈頁",
+  "settings.checkUpdateDownload": "下載安裝包",
   "settings.checkUpdateFailed": "檢查失敗：{error}",
   "settings.close": "關閉",
   "settings.sharedConfirm":
     "切換到共用 ~/.grok？資料不會靜默合併，請確認。",
   "settings.modeIndependent": "獨立（~/.grok-app）",
   "settings.modeShared": "共用（~/.grok）",
+  "settings.sessionModeHelp":
+    "獨立模式會話存在應用目錄；共享模式使用 CLI 主目錄，與終端共用會話。匯入 CLI 會話僅共享模式可用。",
   "settings.tabOfficial": "官方帳戶",
   "settings.tabProviders": "自訂供應商",
   "settings.tabOfficialHint":
@@ -1831,6 +1834,8 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.remoteIm.err.pairPaste": "無法解析 id:secret 格式。",
   "settings.remoteIm.err.missingFields": "缺少必填欄位：{fields}",
   "settings.remoteIm.err.needSecrets": "請先填寫憑證再儲存。",
+  "settings.remoteIm.err.allowFromRequired":
+    "啟用前請至少填寫一個 allow-from 使用者 ID（或 * 表示允許任意）。",
   "settings.remoteIm.test.ok": "連線測試成功。",
   "settings.remoteIm.test.fail": "連線測試失敗：{error}",
   "settings.remoteIm.status.connected": "已連線",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -359,6 +359,9 @@ export type AppUpdateCheck = {
   publishedAt: string | null;
   body: string | null;
   assetNames: string[];
+  /** Best-effort platform installer URL from the release assets. */
+  downloadUrl: string | null;
+  downloadName: string | null;
 };
 
 export async function appCheckUpdate() {


### PR DESCRIPTION
## Summary
Implements the 2026-07-27 ship plan for P0 fixes + update tier B + security defaults.

- **Fixes #162** — Windows CREATE_NO_WINDOW / rundll32 open (no cmd flash / `&` split)
- **Fixes #161** — LINE port **8081**, loopback, `X-Line-Signature`, `lastError` on bind fail
- **L08 tier B** — About → download platform installer from GitHub Releases
- Remote IM require allow-from; atomic secrets; shared-mode CLI import; effort catalog
- Supersedes community/feature PR batch content partially (#151–#160 slices)

## Test plan
- [x] `pnpm typecheck` / `pnpm test` (814)
- [x] `cargo test --lib app_update` + line signature tests
- [ ] Win11: create project — no cmd storm
- [ ] LINE: lsof shows 8081 after bridge start; cloudflared matches callout
- [ ] About: with older local version, Download installer appears for this OS