### PR TITLE
fix(ui): stop Doctor from white-screening the app

### DIFF
--- a/src/components/DoctorModal.tsx
+++ b/src/components/DoctorModal.tsx
@@ -336,12 +336,10 @@ export function DoctorModal({
     [cliFixes],
   );
 
-  if (!open) return null;
-
-  const summary = report?.summary;
-  const checks = report?.checks ?? [];
-
   /** App-resolved CLI path/version/source (probe), separate from `grok doctor` JSON. */
+  // Hooks must run unconditionally — do not place below `if (!open) return null`
+  // or opening Doctor throws "Rendered more hooks than during the previous render"
+  // and white-screens the whole app (DoctorModal sits outside UiErrorBoundary).
   const cliResolved = useMemo(() => {
     const raw = report?.raw as
       | { cli?: { found?: boolean; path?: string | null; version?: string | null; source?: string | null } }
@@ -374,6 +372,11 @@ export function DoctorModal({
     },
     [t],
   );
+
+  if (!open) return null;
+
+  const summary = report?.summary;
+  const checks = report?.checks ?? [];
   const cliFacts = cliDoctor ? factEntries(cliDoctor.facts) : [];
 
   return (


### PR DESCRIPTION
## Summary
- Opening **Doctor** crashed the React tree with a blank white screen because `DoctorModal` called `useMemo` / `useCallback` **after** `if (!open) return null`.
- Closing → opening changed the hook count (`Rendered more hooks than during the previous render`). The modal sits outside `UiErrorBoundary`, so the whole app went white.
- Move those hooks above the early return so they always run.

## Test plan
- [x] Launch app, click sidebar / settings **Doctor** — modal opens, diagnostics load, no white screen
- [x] Close and re-open Doctor several times
- [x] Escape / overlay close still work
- [x] Re-run, copy report, CLI path copy still work when data is present