### PR TITLE
fix(ci): drop tauri mock_app to unbreak Windows cargo test

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -76,9 +76,6 @@ tracing-appender = "0.2"
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"
 
-[dev-dependencies]
-tauri = { version = "2", features = ["test"] }
-
 [profile.release]
 codegen-units = 1
 lto = true

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -1193,6 +1193,31 @@ impl SessionManager {
                 ))
     }
 
+    /// Select the active interjection target (backend, app session id, turn id,
+    /// optional ACP client) from a live session, validating that a streaming
+    /// turn is in progress.
+    ///
+    /// Pure (no `AppHandle`) so the rejection path is unit-testable on all
+    /// platforms, including Windows where `tauri::test::mock_app()` crashes the
+    /// test binary with `STATUS_ENTRYPOINT_NOT_FOUND` (tauri #14580 / #13419).
+    fn pick_interjection_target(
+        s: &LiveSession,
+    ) -> Result<(String, String, String, Option<Arc<AcpClient>>), String> {
+        if !(s.prompt_in_flight || s.fsm.state() == SessionState::Streaming) {
+            return Err("interjection requires a streaming turn".into());
+        }
+        let turn_id = s
+            .active_turn_id
+            .clone()
+            .ok_or("interjection requires an active turn")?;
+        Ok((
+            s.backend.clone(),
+            s.app_session_id.clone(),
+            turn_id,
+            s.acp.clone(),
+        ))
+    }
+
     /// Persist an interjection at the current stream boundary while holding the
     /// session lock. Emitting before unlock guarantees UI order vs stream chunks.
     fn commit_interjection_boundary<R: tauri::Runtime>(
@@ -4499,39 +4524,23 @@ impl SessionManager {
         let attachments = attachments.filter(|items| !items.is_empty());
         let target = session_id.as_deref();
 
-        let pick = |s: &LiveSession| -> Result<(String, String, String, Option<Arc<AcpClient>>), String> {
-            if !(s.prompt_in_flight || s.fsm.state() == SessionState::Streaming) {
-                return Err("interjection requires a streaming turn".into());
-            }
-            let turn_id = s
-                .active_turn_id
-                .clone()
-                .ok_or("interjection requires an active turn")?;
-            Ok((
-                s.backend.clone(),
-                s.app_session_id.clone(),
-                turn_id,
-                s.acp.clone(),
-            ))
-        };
-
         let (backend, app_sid, turn_id, acp) = {
             if let Some(t) = target {
                 let guard = self.inner.lock();
                 if let Some(s) = guard.as_ref().filter(|s| s.app_session_id == t) {
-                    pick(s)?
+                    Self::pick_interjection_target(s)?
                 } else {
                     drop(guard);
                     let background = self.background.lock();
                     let s = background
                         .get(t)
                         .ok_or_else(|| format!("interjection: chat {t} is not active"))?;
-                    pick(s)?
+                    Self::pick_interjection_target(s)?
                 }
             } else {
                 let guard = self.inner.lock();
                 let s = guard.as_ref().ok_or("no active session")?;
-                pick(s)?
+                Self::pick_interjection_target(s)?
             }
         };
 
@@ -5508,8 +5517,8 @@ mod session_routing_tests {
         let _ = mgr; // keep manager constructed for parity with other tests
     }
 
-    #[tokio::test]
-    async fn interject_message_rejects_non_streaming_session() {
+    #[test]
+    fn pick_interjection_target_rejects_non_streaming_session() {
         let mgr = SessionManager::new();
         let mut fsm = SessionFsm::new();
         let _ = fsm.start_connect();
@@ -5571,18 +5580,17 @@ mod session_routing_tests {
             stream_emit_flush_gen: 0,
             last_tool_heartbeat_emit: None,
         });
-        let app = tauri::test::mock_app();
-        let err = mgr
-            .interject_message(
-                app.handle().clone(),
-                "Use the existing component".into(),
-                None,
-                None,
-                Some("session-1".into()),
-            )
-            .await
-            .expect_err("ready session must reject interjection");
-        assert_eq!(err, "interjection requires a streaming turn");
+        // Exercise the same validation `interject_message` runs first, without
+        // an `AppHandle`. `tauri::test::mock_app()` is the only thing in this
+        // crate that needs the `test` feature, and it crashes the test binary
+        // on Windows (STATUS_ENTRYPOINT_NOT_FOUND, tauri #14580 / #13419).
+        let guard = mgr.inner.lock();
+        match SessionManager::pick_interjection_target(
+            guard.as_ref().expect("live session set"),
+        ) {
+            Ok(_) => panic!("ready session must reject interjection"),
+            Err(err) => assert_eq!(err, "interjection requires a streaming turn"),
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Since 2026-07-26, nearly every `main` push shows a red ❌ on CI. Of the three Rust jobs, **only `Rust Windows` fails** — `frontend`, `Rust macOS`, and `Rust Linux` are all green.

Root cause: `28c0a99` introduced a test using `tauri::test::mock_app()` (the only usage in the repo), which crashes the test binary on Windows MSVC at startup:

```
process didn't exit successfully
(exit code: 0xc0000139, STATUS_ENTRYPOINT_NOT_FOUND)
```

This is a **known, unfixed Tauri defect** — the mock AppHandle touches WebView2 / Common-Controls v6 entry points that don't resolve in the test-runner context:
- tauri-apps/tauri#14580
- tauri-apps/tauri#13419
- tauri-apps/orgs/discussions#11179

The binary **compiles fine** (`Finished in 4m 29s`) — it's a pure runtime crash, unrelated to business logic.

## Fix

Per the maintainer's preferred direction for this class of bug, **eliminate the `mock_app()` dependency** instead of papering over the environment.

`interject_message` validated its target via an inline `pick` closure that reads only `&LiveSession` fields (no `AppHandle`). Extract it into a pure associated fn and test that directly:

```rust
fn pick_interjection_target(s: &LiveSession)
    -> Result<(String, String, String, Option<Arc<AcpClient>>), String>
```

- **Coverage is unchanged** — `pick_interjection_target` is the exact first thing `interject_message` calls. The test still asserts that a Ready (non-streaming) session is rejected with `"interjection requires a streaming turn"`.
- The test no longer needs `AppHandle`, so `mock_app()` and the `tauri` `test` dev-dependency are removed.

### Why not the build.rs manifest workaround?

The commonly suggested fix (embed a Common-Controls v6 manifest via `build.rs`) was already tried here in `ea531e8` and reverted in `f151064`:

- `build.rs` **cannot distinguish test vs release** — `PROFILE`, `OUT_DIR`, and `CARGO_CFG_TEST` are identical for both (empirically verified).
- Unconditional embedding → `CVT1100 duplicate resource` on the release link (Tauri already embeds a manifest via `tauri_build::build()`).
- `cargo:rustc-link-arg-tests` **does not cover lib unit tests** (rust-lang/cargo#10937, still open), and this crate's tests are lib unit tests.

## Changes

| File | Change |
|---|---|
| `src-tauri/src/session_manager.rs` | Extract `pick` closure → `pick_interjection_target` (pure fn); call sites use `Self::pick_interjection_target(s)` |
| `src-tauri/src/session_manager.rs` | Test rewritten to call the pure fn directly; `#[tokio::test]` → `#[test]` (no longer async) |
| `src-tauri/Cargo.toml` | Remove `[dev-dependencies] tauri = { features = ["test"] }` |

`interject_message`'s public signature and behavior are unchanged.

## Verification

- ✅ `cargo test` (macOS): **396 passed; 0 failed**
- ✅ Target test `pick_interjection_target_rejects_non_streaming_session` passes
- ✅ `mock_app` fully removed from code (only referenced in explanatory comments)
- ⏳ Windows CI job expected to turn green on push