### PR TITLE
feat(composer): make skills picker fully invocable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Composer skills picker**: skills missing `userInvocable` in `grok inspect` are treated as invocable (only explicit `false` hides them). Extensions-disabled skills stay hidden. Empty / CLI-error states replace the old “Coming soon” dead end.
+
 ### Added
 
 - **Import providers from CC Switch** (#167): Settings → Account → Custom providers → scan local `cc-switch.db` (Grok Build tab), multi-select preview, import into agent-home (macOS / Windows / Linux path resolution + optional override)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2045,11 +2045,14 @@ fn parse_skills(v: &serde_json::Value) -> Vec<SkillDto> {
             .and_then(|x| x.as_str())
             .map(|s| s.to_string())
             .or(path_from_source);
+        // Missing field ⇒ treat as invocable. Only explicit `false` hides a skill
+        // from the composer/slash picker (agent-only / disable-model-invocation).
         let user_invocable = item
             .get("userInvocable")
             .or_else(|| item.get("user_invocable"))
+            .or_else(|| item.get("user-invocable"))
             .and_then(|x| x.as_bool())
-            .unwrap_or(false);
+            .unwrap_or(true);
         out.push(SkillDto {
             name,
             description,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -593,6 +593,8 @@ export default function App() {
   );
   const [skillInfos, setSkillInfos] = useState<SkillInfo[]>([]);
   const [skillsLoading, setSkillsLoading] = useState(false);
+  /** Host `skills_list` error (CLI missing / inspect fail); empty when ok. */
+  const [skillsLoadError, setSkillsLoadError] = useState<string | null>(null);
   const [slashQuery, setSlashQuery] = useState<{
     start: number;
     query: string;
@@ -5446,7 +5448,7 @@ export default function App() {
     };
   }, [activeProject?.path]);
 
-  // Load skills catalog for slash palette (Grok inspect).
+  // Load skills catalog for slash / + palette (Grok inspect + Extensions enable).
   useEffect(() => {
     if (!api.isTauri()) return;
     let cancelled = false;
@@ -5455,20 +5457,23 @@ export default function App() {
       .skillsList(activeProject?.path ?? null)
       .then((res) => {
         if (cancelled) return;
+        const err = (res.error ?? "").trim();
+        setSkillsLoadError(err || null);
         setSkillInfos(
-          (res.skills ?? [])
-            // Extensions enable flag (default on); hide disabled from slash palette.
-            .filter((s) => s.enabled !== false)
-            .map((s) => ({
-              name: s.name,
-              description: s.description ?? "",
-              source: s.source,
-              userInvocable: s.userInvocable,
-            })),
+          (res.skills ?? []).map((s) => ({
+            name: s.name,
+            description: s.description ?? "",
+            source: s.source,
+            // Host omits or defaults invocable; explicit false stays false.
+            userInvocable: s.userInvocable !== false,
+            enabled: s.enabled !== false,
+          })),
         );
       })
-      .catch(() => {
-        if (!cancelled) setSkillInfos([]);
+      .catch((e) => {
+        if (cancelled) return;
+        setSkillInfos([]);
+        setSkillsLoadError(String(e));
       })
       .finally(() => {
         if (!cancelled) setSkillsLoading(false);
@@ -10610,6 +10615,8 @@ export default function App() {
                       liveSlash.present ? slashFilterQuery : undefined
                     }
                     skillsLoading={skillsLoading}
+                    skillsError={skillsLoadError}
+                    skillCount={slashCatalog.skills.length}
                     activeIndex={slashActiveIndex}
                     onActiveIndexChange={setSlashActiveIndex}
                     onSelectUpload={() => {

--- a/src/components/ComposerPlusPanel.tsx
+++ b/src/components/ComposerPlusPanel.tsx
@@ -177,6 +177,8 @@ export function ComposerPlusPanel({
   entries,
   filterQuery,
   skillsLoading,
+  skillsError,
+  skillCount,
   activeIndex,
   onActiveIndexChange,
   onSelectUpload,
@@ -193,6 +195,10 @@ export function ComposerPlusPanel({
   /** Live filter string (shown in header when non-empty). */
   filterQuery?: string;
   skillsLoading?: boolean;
+  /** Host skills_list error (CLI missing / inspect fail). */
+  skillsError?: string | null;
+  /** Number of invocable skills after enable filter (0 when empty catalog). */
+  skillCount?: number;
   activeIndex: number;
   onActiveIndexChange: (i: number) => void;
   onSelectUpload: () => void;
@@ -358,10 +364,53 @@ export function ComposerPlusPanel({
       {empty && (
         <div className="composer-plus__item composer-plus__item--muted">
           <span className="composer-plus__title">
-            {q ? tr("slash.empty") : tr("composer.skillsEmpty")}
+            {q
+              ? tr("slash.empty")
+              : skillsError
+                ? tr("composer.skillsLoadError")
+                : tr("slash.empty")}
           </span>
+          {!q && skillsError ? (
+            <span className="composer-plus__desc" title={skillsError}>
+              {skillsError}
+            </span>
+          ) : null}
         </div>
       )}
+
+      {/* Skills section empty hint when commands exist but no invocable skills */}
+      {!empty &&
+      !skillsLoading &&
+      !q &&
+      (skillCount ?? 0) === 0 &&
+      !entries.some((e) => e.kind === "slash" && e.item.kind === "skill") ? (
+        <div className="composer-plus__section">{tr("composer.skills")}</div>
+      ) : null}
+      {!empty &&
+      !skillsLoading &&
+      !q &&
+      (skillCount ?? 0) === 0 &&
+      !entries.some((e) => e.kind === "slash" && e.item.kind === "skill") ? (
+        <div className="composer-plus__item composer-plus__item--muted">
+          <span className="composer-plus__ico" aria-hidden>
+            <IconSkills size={ICON_SIZE} />
+          </span>
+          <span className="composer-plus__title">
+            {skillsError
+              ? tr("composer.skillsLoadError")
+              : tr("composer.skillsEmpty")}
+          </span>
+          {skillsError ? (
+            <span className="composer-plus__desc" title={skillsError}>
+              {skillsError}
+            </span>
+          ) : (
+            <span className="composer-plus__desc">
+              {tr("composer.skillsEmptyHint")}
+            </span>
+          )}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -382,8 +382,10 @@ const en = {
   "composer.planMode": "Plan mode",
   "composer.planModeHint": "Turn on plan mode",
   "composer.skills": "Skills",
-  "composer.skillsSoon": "Coming soon",
   "composer.skillsEmpty": "No invocable skills found",
+  "composer.skillsEmptyHint":
+    "Install from Extensions → Marketplace, or enable skills under Extensions → Skills.",
+  "composer.skillsLoadError": "Could not load skills",
   "composer.skillsLoading": "Loading skills…",
   "composer.goal": "Goal",
   "composer.goalHint": "Set a goal to pursue continuously",
@@ -2444,8 +2446,10 @@ const zh: Record<MessageKey, string> = {
   "composer.planMode": "计划模式",
   "composer.planModeHint": "开启计划模式",
   "composer.skills": "技能",
-  "composer.skillsSoon": "即将推出",
   "composer.skillsEmpty": "未发现可调用的技能",
+  "composer.skillsEmptyHint":
+    "可在「扩展 → 插件市场」安装，或在「扩展 → 技能」中启用。",
+  "composer.skillsLoadError": "无法加载技能",
   "composer.skillsLoading": "正在加载技能…",
   "composer.goal": "目标",
   "composer.goalHint": "设置要持续追求的目标",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -398,8 +398,10 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.planMode": "計劃模式",
   "composer.planModeHint": "開啟計劃模式",
   "composer.skills": "技能",
-  "composer.skillsSoon": "即將推出",
   "composer.skillsEmpty": "未發現可呼叫的技能",
+  "composer.skillsEmptyHint":
+    "可在「擴充 → 插件市集」安裝，或在「擴充 → 技能」中啟用。",
+  "composer.skillsLoadError": "無法載入技能",
   "composer.skillsLoading": "正在載入技能…",
   "composer.goal": "目標",
   "composer.goalHint": "設定要持續追求的目標",

--- a/src/lib/slashCatalog.test.ts
+++ b/src/lib/slashCatalog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildSlashCatalog,
   builtinSlashItems,
+  filterPickerSkills,
   filterSlashItems,
   skillsToSlashItems,
   type SkillInfo,
@@ -118,6 +119,31 @@ describe("skillsToSlashItems", () => {
     expect(
       skillsToSlashItems([{ name: "x", description: "d" }]),
     ).toHaveLength(1);
+  });
+
+  it("hides Extension-disabled skills", () => {
+    const skills: SkillInfo[] = [
+      { name: "on", description: "yes", enabled: true },
+      { name: "off", description: "no", enabled: false },
+      { name: "default", description: "yes" },
+    ];
+    expect(skillsToSlashItems(skills).map((i) => i.name)).toEqual([
+      "on",
+      "default",
+    ]);
+  });
+});
+
+describe("filterPickerSkills", () => {
+  it("keeps only enabled + invocable named skills", () => {
+    const got = filterPickerSkills([
+      { name: "a", description: "A", userInvocable: true, enabled: true },
+      { name: "b", description: "B", userInvocable: false },
+      { name: "c", description: "C", enabled: false },
+      { name: "  ", description: "blank" },
+      { name: "d", description: "D" },
+    ]);
+    expect(got.map((s) => s.name)).toEqual(["a", "d"]);
   });
 });
 

--- a/src/lib/slashCatalog.ts
+++ b/src/lib/slashCatalog.ts
@@ -23,8 +23,35 @@ export type SkillInfo = {
   name: string;
   description: string;
   source?: string;
+  /** Explicit false = agent-only / not slash-invocable. Missing ⇒ invocable. */
   userInvocable?: boolean;
+  /** App Extensions toggle. Explicit false hides from picker. Missing ⇒ on. */
+  enabled?: boolean;
 };
+
+/**
+ * Skills shown in composer `+` / `/` pickers.
+ * Keeps only enabled + user-invocable skills with a non-empty name.
+ */
+export function filterPickerSkills(skills: SkillInfo[]): SkillInfo[] {
+  const seen = new Set<string>();
+  const out: SkillInfo[] = [];
+  for (const s of skills) {
+    if (s.enabled === false) continue;
+    if (s.userInvocable === false) continue;
+    const name = (s.name ?? "").trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    out.push({
+      name,
+      description: (s.description ?? "").trim(),
+      source: s.source,
+      userInvocable: true,
+      enabled: true,
+    });
+  }
+  return out;
+}
 
 /** Built-in slash commands (modes, prompts, host actions). */
 export function builtinSlashItems(): SlashItem[] {
@@ -160,27 +187,18 @@ export function builtinSlashItems(): SlashItem[] {
   ];
 }
 
-/** Map skill metadata to slash items (skips `userInvocable: false`). */
+/** Map skill metadata to slash items (enabled + invocable only). */
 export function skillsToSlashItems(skills: SkillInfo[]): SlashItem[] {
   // Dedupe by name — duplicate ids (`skill:foo`) break React keys and leave
   // ghost rows that ignore filter updates (always visible, not keyboard-navable).
-  const seen = new Set<string>();
-  const out: SlashItem[] = [];
-  for (const s of skills) {
-    if (s.userInvocable === false) continue;
-    const name = (s.name ?? "").trim();
-    if (!name || seen.has(name)) continue;
-    seen.add(name);
-    out.push({
-      id: `skill:${name}`,
-      kind: "skill" as const,
-      name,
-      displayTitle: name,
-      displayDescription: s.description,
-      source: s.source,
-    });
-  }
-  return out;
+  return filterPickerSkills(skills).map((s) => ({
+    id: `skill:${s.name}`,
+    kind: "skill" as const,
+    name: s.name,
+    displayTitle: s.name,
+    displayDescription: s.description,
+    source: s.source,
+  }));
 }
 
 /** Optional resolved UI strings (i18n titles / descriptions) for search. */


### PR DESCRIPTION
## Summary
- Treat missing `userInvocable` from `grok inspect` as **invocable** (only explicit `false` hides a skill)
- Unified picker filter: enabled + invocable + non-empty name (`filterPickerSkills`)
- Composer `+` / `/` empty states for load error and “no skills” (replaces dead “Coming soon”)
- Surface Host `skills_list` error (CLI missing / inspect fail)

## Milestone
- M1 / SKL

## Test plan
- [x] `vitest` `src/lib/slashCatalog.test.ts` (14 tests)
- [ ] Manual: install/enable invocable skill → appears in `+` and `/` → insert chip → send as `/name`
- [ ] Manual: Extensions disable skill → disappears from picker
- [ ] Manual: no CLI → skills error hint, not “coming soon”

## Out of scope
- Editing SKILL.md in-app
- Auto-send skill on install