### PR TITLE
feat(security): CLI install fail-closed without published checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Security
+
+- **CLI install fail-closed on missing checksum**: App-managed Grok Build download refuses install when the mirror has no published SHA-256 (default). Mismatch still always aborts. Escape hatch: Settings → Runtime → “Allow unverified CLI install”, or `GROK_CLI_ALLOW_UNVERIFIED=1`. Last install verification is remembered for Doctor/CLI status.
+
 ### Added
 
 - **Import providers from CC Switch** (#167): Settings → Account → Custom providers → scan local `cc-switch.db` (Grok Build tab), multi-select preview, import into agent-home (macOS / Windows / Linux path resolution + optional override)

--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -4,10 +4,12 @@
 //! 1. Direct GCS `https://storage.googleapis.com/grok-build-public-artifacts/cli`
 //! 2. Cloudflare-fronted `https://x.ai/cli`
 //!
-//! Trust chain (fail-closed where possible):
+//! Trust chain (fail-closed by default):
 //! - HTTPS only, URL must be under a known mirror base
 //! - Streaming SHA-256 of the downloaded bytes
-//! - Optional published checksum sidecar (`.sha256` / `SHA256SUMS`); mismatch aborts
+//! - Published checksum sidecar (`.sha256` / `SHA256SUMS` / `checksums.txt`);
+//!   **mismatch always aborts**; **missing sidecar aborts** unless the user opts
+//!   into unverified install (settings or `GROK_CLI_ALLOW_UNVERIFIED=1`)
 //! - Architecture match via platform triple; size / `--version` gates after install
 //!
 //! Each mirror is retried a few times before falling through. Progress is emitted
@@ -653,8 +655,42 @@ async fn try_download_all_mirrors(
     ))
 }
 
+/// Whether a published checksum is **required** (fail-closed).
+///
+/// Default **true**. Unverified install is allowed only when:
+/// - `allow_unverified` argument is true (from App settings), or
+/// - env `GROK_CLI_ALLOW_UNVERIFIED` is 1/true/yes/on
+///
+/// Mismatch always fails regardless of this flag.
+pub fn require_published_checksum(allow_unverified: bool) -> bool {
+    if env_flag_truthy("GROK_CLI_ALLOW_UNVERIFIED") {
+        return false;
+    }
+    if allow_unverified {
+        return false;
+    }
+    // Legacy force-require stays redundant (default already requires).
+    // `GROK_CLI_REQUIRE_CHECKSUM=0` is **not** honored — use ALLOW_UNVERIFIED.
+    true
+}
+
+fn env_flag_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            matches!(v.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
+}
+
 /// Download latest stable Grok Build and install into `~/.grok`.
-pub async fn install_cli_latest(app: AppHandle) -> Result<CliInstallResult, String> {
+///
+/// `allow_unverified`: when true, continue if the mirror has no published
+/// checksum (still fail on mismatch). Default path should pass `false`.
+pub async fn install_cli_latest(
+    app: AppHandle,
+    allow_unverified: bool,
+) -> Result<CliInstallResult, String> {
     let client = http_client()?;
     let (version, preferred) = resolve_version(&app, &client).await?;
 
@@ -721,23 +757,18 @@ pub async fn install_cli_latest(app: AppHandle) -> Result<CliInstallResult, Stri
             true
         }
         None => {
-            // Prefer published sidecars. Without one we still enforce URL allowlist +
-            // size + binary --version, and mark the install as unverified.
-            let require = std::env::var("GROK_CLI_REQUIRE_CHECKSUM")
-                .map(|v| {
-                    let v = v.trim().to_ascii_lowercase();
-                    matches!(v.as_str(), "1" | "true" | "yes" | "on")
-                })
-                .unwrap_or(false);
-            if require {
+            // Fail-closed: no published sidecar → refuse unless user opted in.
+            if require_published_checksum(allow_unverified) {
                 let _ = fs::remove_file(&tmp_path);
                 return Err(format!(
-                    "No published SHA-256 for {artifact_name}. Refusing install because GROK_CLI_REQUIRE_CHECKSUM is set. hash={digest}"
+                    "No published SHA-256 for {artifact_name}. Refusing install (checksum required). \
+                     Enable “Allow unverified CLI install” in Settings → Runtime, or set \
+                     GROK_CLI_ALLOW_UNVERIFIED=1. hash={digest}"
                 ));
             }
             warn!(
                 "cli_install: no published checksum for {artifact_name}; \
-                 continuing with allowlist + binary probe (hash={digest})"
+                 continuing with allowlist + binary probe (unverified, hash={digest})"
             );
             false
         }
@@ -917,6 +948,14 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb *other-file
         let body = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  wrong-name\n";
         // multi-line with name mismatch → None (no bare single-line fallback when name present)
         assert!(parse_checksum_for_file(body, "right-name").is_none());
+    }
+
+    #[test]
+    fn require_checksum_defaults_fail_closed() {
+        // Clear both envs for the test process when possible.
+        std::env::remove_var("GROK_CLI_ALLOW_UNVERIFIED");
+        assert!(require_published_checksum(false));
+        assert!(!require_published_checksum(true));
     }
 
     #[test]

--- a/src-tauri/src/cli_update.rs
+++ b/src-tauri/src/cli_update.rs
@@ -213,7 +213,12 @@ pub async fn install_cli_update(app: tauri::AppHandle) -> Result<CliInstallResul
     }
 
     info!("cli_update_install: using cli_install trust-chain");
-    cli_install::install_cli_latest(app).await
+    let allow = crate::store::load_settings().allow_unverified_cli_install;
+    let result = cli_install::install_cli_latest(app, allow).await?;
+    let mut s = crate::store::load_settings();
+    s.last_cli_checksum_verified = result.checksum_verified;
+    let _ = crate::store::save_settings(&s);
+    Ok(result)
 }
 
 fn extract_version_hint(stdout: &str) -> Option<String> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -213,9 +213,23 @@ pub async fn acp_test_connection(
 }
 
 /// Download + install latest Grok Build (multi-mirror, progress via `setup://cli-install-progress`).
+///
+/// `allow_unverified`: optional; when omitted, uses Settings
+/// `allowUnverifiedCliInstall` (default false → checksum required).
 #[tauri::command]
-pub async fn cli_install_latest(app: tauri::AppHandle) -> Result<crate::cli_install::CliInstallResult, String> {
-    crate::cli_install::install_cli_latest(app).await
+pub async fn cli_install_latest(
+    app: tauri::AppHandle,
+    allow_unverified: Option<bool>,
+) -> Result<crate::cli_install::CliInstallResult, String> {
+    let allow = allow_unverified.unwrap_or_else(|| {
+        store::load_settings().allow_unverified_cli_install
+    });
+    let result = crate::cli_install::install_cli_latest(app, allow).await?;
+    // Remember last install verification for Doctor.
+    let mut s = store::load_settings();
+    s.last_cli_checksum_verified = result.checksum_verified;
+    let _ = store::save_settings(&s);
+    Ok(result)
 }
 
 /// Platform install command + docs URL for manual fallback.

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -248,6 +248,14 @@ pub struct AppSettings {
     /// Comma-separated hosts that bypass the proxy (NO_PROXY semantics).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy_no_proxy: Option<String>,
+    /// Allow CLI download/install when the mirror has **no** published SHA-256
+    /// sidecar. Default **false** (fail-closed). Mismatch always aborts.
+    /// Escape hatch for air-gapped / broken sidecars; prefer fixing the mirror.
+    #[serde(default)]
+    pub allow_unverified_cli_install: bool,
+    /// Result of the last App-managed CLI install (`Some(true)` = sidecar matched).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_cli_checksum_verified: Option<bool>,
 }
 
 fn default_composer_prefs_scope() -> String {
@@ -340,6 +348,8 @@ impl Default for AppSettings {
             proxy_mode: default_proxy_mode(),
             proxy_url: None,
             proxy_no_proxy: None,
+            allow_unverified_cli_install: false,
+            last_cli_checksum_verified: None,
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1047,6 +1047,11 @@ export default function App() {
   const [voiceId, setVoiceId] = useState("eve");
   const [voiceDictationAutoSend, setVoiceDictationAutoSend] = useState(false);
   const [voiceKeepAgentsOnEnd, setVoiceKeepAgentsOnEnd] = useState(true);
+  const [allowUnverifiedCliInstall, setAllowUnverifiedCliInstall] =
+    useState(false);
+  const [lastCliChecksumVerified, setLastCliChecksumVerified] = useState<
+    boolean | null
+  >(null);
   const voiceDictationAutoSendRef = useRef(false);
   const sendRef = useRef<(() => Promise<void>) | null>(null);
   const [subagentsEnabled, setSubagentsEnabled] = useState(true);
@@ -1558,6 +1563,12 @@ export default function App() {
       setVoiceDictationAutoSend(!!settings.voiceDictationAutoSend);
       setVoiceKeepAgentsOnEnd(
         settings.voiceKeepAgentsOnEnd !== false,
+      );
+      setAllowUnverifiedCliInstall(!!settings.allowUnverifiedCliInstall);
+      setLastCliChecksumVerified(
+        typeof settings.lastCliChecksumVerified === "boolean"
+          ? settings.lastCliChecksumVerified
+          : null,
       );
       setSubagentsEnabled(settings.subagentsEnabled !== false);
       setPlanEnabled(settings.planEnabled !== false);
@@ -8735,6 +8746,14 @@ export default function App() {
                 auth: prev.auth || !!cli.cliAuthPresent,
               }));
             });
+          }}
+          allowUnverifiedCliInstall={allowUnverifiedCliInstall}
+          lastCliChecksumVerified={lastCliChecksumVerified}
+          onAllowUnverifiedCliInstall={(v) => {
+            setAllowUnverifiedCliInstall(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, allowUnverifiedCliInstall: v }),
+            );
           }}
           acpServerAddr={acpServerAddr}
           onAcpServerAddr={(v) => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -168,6 +168,11 @@ export interface SettingsPageProps {
   manualCliPath: string;
   onManualCliPath: (v: string) => void;
   onCliBlur: (v: string) => void;
+  /** Escape hatch: allow CLI install without published checksum (default off). */
+  allowUnverifiedCliInstall?: boolean;
+  onAllowUnverifiedCliInstall?: (v: boolean) => void;
+  /** Last install checksum status from Host settings. */
+  lastCliChecksumVerified?: boolean | null;
   /** API mode: remote ACP server `host:port` (empty = local CLI spawn). */
   acpServerAddr: string;
   onAcpServerAddr: (v: string) => void;
@@ -621,6 +626,9 @@ export function SettingsPage({
   manualCliPath,
   onManualCliPath,
   onCliBlur,
+  allowUnverifiedCliInstall = false,
+  onAllowUnverifiedCliInstall,
+  lastCliChecksumVerified = null,
   acpServerAddr,
   onAcpServerAddr,
   proxyMode = "system",
@@ -2707,9 +2715,39 @@ export function SettingsPage({
                       {cliInfo.cliAuthPresent
                         ? ` · ${t("account.cliAuthOk")}`
                         : ` · ${t("account.cliAuthMissing")}`}
+                      {lastCliChecksumVerified === true
+                        ? ` · ${t("settings.cliChecksumVerified")}`
+                        : lastCliChecksumVerified === false
+                          ? ` · ${t("settings.cliChecksumUnverified")}`
+                          : ""}
                     </div>
                   )}
                 </div>
+                {onAllowUnverifiedCliInstall ? (
+                  <div
+                    className={
+                      "settings-row" +
+                      rowHighlight("settings-anchor-allowUnverifiedCli")
+                    }
+                    id="settings-anchor-allowUnverifiedCli"
+                  >
+                    <div className="settings-row__text">
+                      <div className="settings-row__label">
+                        {t("settings.allowUnverifiedCli")}
+                      </div>
+                      <div className="settings-row__desc">
+                        {t("settings.allowUnverifiedCliDesc")}
+                      </div>
+                    </div>
+                    <UiCheck
+                      checked={!!allowUnverifiedCliInstall}
+                      onChange={() =>
+                        onAllowUnverifiedCliInstall(!allowUnverifiedCliInstall)
+                      }
+                      ariaLabel={t("settings.allowUnverifiedCli")}
+                    />
+                  </div>
+                ) : null}
               </div>
             )}
             {activeTab === "connection" && (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -733,6 +733,11 @@ const en = {
   "settings.clearWorkspaceMemoryConfirmMsg":
     "This deletes Grok Build workspace memory for the current project. Chat history in the app is kept. This cannot be undone.",
   "settings.clearWorkspaceMemoryDone": "Workspace memory cleared",
+  "settings.allowUnverifiedCli": "Allow unverified CLI install",
+  "settings.allowUnverifiedCliDesc":
+    "When off (default), install fails if the official mirror has no published SHA-256. Turn on only if checksums are temporarily unavailable. A mismatched checksum always fails.",
+  "settings.cliChecksumVerified": "last install checksum OK",
+  "settings.cliChecksumUnverified": "last install unverified",
   "settings.cliPath": "CLI path",
   "settings.cliPathDesc": "Path to the Grok Build CLI binary",
   "settings.cliNotFound": "(not found)",
@@ -2779,6 +2784,11 @@ const zh: Record<MessageKey, string> = {
   "settings.clearWorkspaceMemoryConfirmMsg":
     "将删除当前项目的 Grok Build 工作区记忆。应用内聊天记录会保留。此操作不可撤销。",
   "settings.clearWorkspaceMemoryDone": "已清除工作区记忆",
+  "settings.allowUnverifiedCli": "允许未校验的 CLI 安装",
+  "settings.allowUnverifiedCliDesc":
+    "关闭时（默认）若官方镜像没有发布 SHA-256 则拒绝安装。仅在校验文件暂时不可用时开启。校验和不一致始终拒绝。",
+  "settings.cliChecksumVerified": "上次安装校验通过",
+  "settings.cliChecksumUnverified": "上次安装未校验",
   "settings.cliPath": "CLI 路径",
   "settings.cliPathDesc": "Grok Build CLI 可执行文件路径",
   "settings.cliNotFound": "（未找到）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -700,6 +700,11 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.clearWorkspaceMemoryConfirmMsg":
     "將刪除目前專案的 Grok Build 工作區記憶。應用程式內聊天紀錄會保留。此操作無法復原。",
   "settings.clearWorkspaceMemoryDone": "已清除工作區記憶",
+  "settings.allowUnverifiedCli": "允許未校驗的 CLI 安裝",
+  "settings.allowUnverifiedCliDesc":
+    "關閉時（預設）若官方鏡像沒有發佈 SHA-256 則拒絕安裝。僅在校驗檔暫時不可用時開啟。校驗和不一致一律拒絕。",
+  "settings.cliChecksumVerified": "上次安裝校驗通過",
+  "settings.cliChecksumUnverified": "上次安裝未校驗",
   "settings.cliPath": "CLI 路徑",
   "settings.cliPathDesc": "Grok Build CLI 可執行檔路徑",
   "settings.cliNotFound": "（未找到）",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -332,9 +332,17 @@ export interface CliInstallCommands {
   mirrors: string[];
 }
 
-/** Download + install latest Grok Build (multi-mirror). Progress via setup://cli-install-progress. */
-export async function cliInstallLatest() {
-  return invoke<CliInstallResult>("cli_install_latest");
+/**
+ * Download + install latest Grok Build (multi-mirror).
+ * Progress via setup://cli-install-progress.
+ * When `allowUnverified` is omitted, Host uses Settings `allowUnverifiedCliInstall`.
+ */
+export async function cliInstallLatest(opts?: {
+  allowUnverified?: boolean | null;
+}) {
+  return invoke<CliInstallResult>("cli_install_latest", {
+    allowUnverified: opts?.allowUnverified ?? null,
+  });
 }
 
 export async function cliInstallCommands() {
@@ -955,6 +963,13 @@ export interface AppSettings {
   voiceKeepAgentsOnEnd?: boolean;
   /** Window close hides to tray when true (default). */
   closeToTray?: boolean;
+  /**
+   * Allow CLI install when the mirror has no published SHA-256 (default false).
+   * Mismatch always fails. Prefer fixing the mirror over enabling this.
+   */
+  allowUnverifiedCliInstall?: boolean;
+  /** Last App-managed CLI install checksum result (`true` = verified). */
+  lastCliChecksumVerified?: boolean | null;
 }
 
 export interface ReasoningEffort {

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -571,6 +571,15 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     keywords: ["cli", "binary", "grok path", "path"],
   },
   {
+    id: "runtime.allowUnverifiedCli",
+    section: "runtime",
+    tab: "cli",
+    anchorId: "settings-anchor-allowUnverifiedCli",
+    labelKey: "settings.allowUnverifiedCli",
+    descKeys: ["settings.allowUnverifiedCliDesc"],
+    keywords: ["checksum", "sha256", "unverified", "cli install", "trust"],
+  },
+  {
     id: "runtime.acp",
     section: "runtime",
     tab: "connection",


### PR DESCRIPTION
## Summary
- App-managed CLI install **requires** published SHA-256 by default (missing sidecar → refuse)
- Checksum **mismatch** still always aborts
- Escape hatch: Settings → Runtime → “Allow unverified CLI install”, or `GROK_CLI_ALLOW_UNVERIFIED=1`
- Remember last install verification status for CLI status line

## Milestone
- M5 / CLI

## Test plan
- [x] `cargo test --lib cli_install::` (8 tests including fail-closed default)
- [ ] Manual: install CLI with normal mirrors → checksum verified
- [ ] Manual: with allow-unverified off, missing sidecar refuses with actionable error
- [ ] Manual: toggle setting persists

## Out of scope
- Changing official mirror publishing process