### PR TITLE
feat(updater): production channel status and verify script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)
+
+### Added
+
 - **Import providers from CC Switch** (#167): Settings → Account → Custom providers → scan local `cc-switch.db` (Grok Build tab), multi-select preview, import into agent-home (macOS / Windows / Linux path resolution + optional override)
 - Trust sandbox: `path_scope` allowlist for absolute fs / `media://` (trusted projects, app data, grants)
 - CSP enabled; asset protocol denies common secret paths

--- a/docs/desktop-auto-update.md
+++ b/docs/desktop-auto-update.md
@@ -62,6 +62,23 @@ pnpm tauri signer generate -w ~/.tauri/grok-app.key
 # private key file contents → TAURI_SIGNING_PRIVATE_KEY
 ```
 
+### Maintainer production checklist
+
+Before treating silent update as “on” for users:
+
+1. **Secrets in the shipping repo** (Settings → Secrets and variables → Actions): all four rows above that you use. Empty `TAURI_SIGNING_PRIVATE_KEY` must not be set — omit or set a real key.
+2. **Local dry-run (no secret values printed):**
+   ```sh
+   ./scripts/verify-updater-setup.sh
+   ./scripts/verify-updater-setup.sh --fetch-latest
+   ```
+3. **Release cut:** tag `vX.Y.Z` so CI builds installers **and** refreshes `grok-desktop-latest` + `latest.json` + `.sig`.
+4. **Smoke on a prior signed build:** Settings → About shows **Update channel: in-app (signed release)** → Check → Download → Install and restart → version matches tag.
+5. **Failure path:** if install fails, agents / Remote IM / mirror must keep running (`prepare_for_app_update` only after successful `install()`).
+6. **Unsigned / local builds:** About must show **GitHub download** channel and still open Release / download installer (no crash).
+
+In-app host command `updater_status` reports `{ channel, pluginEnabled, platformSupported, endpoint }` for Doctor / About.
+
 ## Rolling endpoint
 
 ```text

--- a/scripts/verify-updater-setup.sh
+++ b/scripts/verify-updater-setup.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Verify desktop auto-update production prerequisites (local / CI).
+# Does not print secret values. Exit 0 when checks that can run pass.
+#
+# Usage:
+#   ./scripts/verify-updater-setup.sh
+#   ./scripts/verify-updater-setup.sh --fetch-latest   # also HTTP-get latest.json
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+FETCH_LATEST=0
+for arg in "$@"; do
+  case "$arg" in
+    --fetch-latest) FETCH_LATEST=1 ;;
+    -h|--help)
+      sed -n '1,12p' "$0"
+      exit 0
+      ;;
+  esac
+done
+
+ok=0
+warn=0
+fail=0
+
+note() { printf '  · %s\n' "$*"; }
+pass() { ok=$((ok + 1)); printf 'OK   %s\n' "$*"; }
+warn() { warn=$((warn + 1)); printf 'WARN %s\n' "$*"; }
+fail() { fail=$((fail + 1)); printf 'FAIL %s\n' "$*"; }
+
+echo "== Grok App updater setup check =="
+
+# 1) Workflow references required secrets
+WF=".github/workflows/release.yml"
+if [[ -f "$WF" ]]; then
+  if grep -q 'GROK_UPDATER_PUBLIC_KEY' "$WF" \
+    && grep -q 'TAURI_SIGNING_PRIVATE_KEY' "$WF"; then
+    pass "release.yml references updater signing secrets"
+  else
+    fail "release.yml missing GROK_UPDATER_* / TAURI_SIGNING_* wiring"
+  fi
+  if grep -q 'assemble-updater-manifest\|generate-latest-json\|grok-desktop-latest' "$WF"; then
+    pass "release.yml publishes rolling updater assets"
+  else
+    warn "release.yml may not publish grok-desktop-latest / latest.json"
+  fi
+else
+  fail "missing $WF"
+fi
+
+# 2) Local scripts present
+for s in scripts/assemble-updater-manifest.sh scripts/generate-latest-json.sh scripts/build-release-config.mjs; do
+  if [[ -f "$s" ]]; then
+    pass "present $s"
+  else
+    fail "missing $s"
+  fi
+done
+
+# 3) Docs
+if [[ -f docs/desktop-auto-update.md ]]; then
+  pass "docs/desktop-auto-update.md present"
+else
+  fail "missing docs/desktop-auto-update.md"
+fi
+
+# 4) Env presence (names only — never print values)
+has_pub=0
+has_priv=0
+has_ep=0
+[[ -n "${GROK_UPDATER_PUBLIC_KEY:-}" ]] && has_pub=1
+[[ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]] && has_priv=1
+[[ -n "${GROK_UPDATER_ENDPOINT:-}" ]] && has_ep=1
+
+if [[ $has_pub -eq 1 && $has_priv -eq 1 ]]; then
+  pass "local env has GROK_UPDATER_PUBLIC_KEY + TAURI_SIGNING_PRIVATE_KEY"
+else
+  warn "local env missing signing keys (expected on maintainer machines / CI only)"
+  note "Generate: pnpm tauri signer generate -w ~/.tauri/grok-app.key"
+fi
+if [[ $has_ep -eq 1 ]]; then
+  pass "local env has GROK_UPDATER_ENDPOINT"
+else
+  note "GROK_UPDATER_ENDPOINT optional locally; CI sets it for release builds"
+fi
+
+# 5) Optional live latest.json
+REPO="${GITHUB_REPOSITORY:-RongleCat/grok-app}"
+LATEST_URL="https://github.com/${REPO}/releases/download/grok-desktop-latest/latest.json"
+if [[ $FETCH_LATEST -eq 1 ]]; then
+  if command -v curl >/dev/null 2>&1; then
+    code=$(curl -sS -o /tmp/grok-latest.json -w '%{http_code}' -L "$LATEST_URL" || true)
+    if [[ "$code" == "200" ]]; then
+      if command -v python3 >/dev/null 2>&1; then
+        if python3 -c 'import json,sys; json.load(open("/tmp/grok-latest.json"))' 2>/dev/null; then
+          pass "latest.json fetchable and valid JSON ($LATEST_URL)"
+        else
+          fail "latest.json HTTP 200 but not valid JSON"
+        fi
+      else
+        pass "latest.json HTTP 200 ($LATEST_URL)"
+      fi
+    else
+      warn "latest.json not fetchable (HTTP $code) — rolling release may not exist yet"
+    fi
+  else
+    warn "curl not available; skip --fetch-latest"
+  fi
+else
+  note "skip live latest.json (pass --fetch-latest to check $LATEST_URL)"
+fi
+
+echo
+echo "Summary: ok=$ok warn=$warn fail=$fail"
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -20,8 +20,10 @@ fn main() {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
 
-    if updater_public_key.is_some() && updater_endpoint.is_some() {
+    if let (Some(_key), Some(endpoint)) = (updater_public_key, updater_endpoint) {
         println!("cargo:rustc-cfg=grok_updater_enabled");
+        // Expose non-secret endpoint URL to `option_env!` / status DTO.
+        println!("cargo:rustc-env=GROK_UPDATER_ENDPOINT={endpoint}");
     }
 
     tauri_build::build()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -221,6 +221,7 @@ pub fn run() {
             commands::app_check_update,
             updater::is_auto_update_supported,
             updater::is_updater_plugin_enabled,
+            updater::updater_status,
             updater::prepare_for_app_update,
             commands::voice_status,
             commands::voice_transcribe,

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -57,6 +57,46 @@ pub fn is_updater_plugin_enabled() -> bool {
     cfg!(grok_updater_enabled) && !cfg!(debug_assertions)
 }
 
+/// Snapshot for About / Doctor: which update path this binary can use.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdaterStatusDto {
+    /// Platform packaging supports silent install (e.g. not Linux .deb).
+    pub platform_supported: bool,
+    /// Release binary built with signing pubkey + endpoint.
+    pub plugin_enabled: bool,
+    /// `silent` when plugin path is live; otherwise `github_manual`.
+    pub channel: String,
+    /// Compile-time endpoint (empty when plugin off).
+    pub endpoint: String,
+}
+
+#[tauri::command]
+pub fn updater_status() -> UpdaterStatusDto {
+    let platform_supported = is_auto_update_supported();
+    let plugin_enabled = is_updater_plugin_enabled();
+    let channel = if plugin_enabled && platform_supported {
+        "silent".to_string()
+    } else {
+        "github_manual".to_string()
+    };
+    // Endpoint is only meaningful when the plugin was compiled in; avoid leaking
+    // build-time env into debug strings beyond the non-secret public URL.
+    let endpoint = if plugin_enabled {
+        option_env!("GROK_UPDATER_ENDPOINT")
+            .unwrap_or("")
+            .to_string()
+    } else {
+        String::new()
+    };
+    UpdaterStatusDto {
+        platform_supported,
+        plugin_enabled,
+        channel,
+        endpoint,
+    }
+}
+
 /// Stop managed agent children / hosts before process relaunch after a staged install.
 ///
 /// Must run **after** a successful `update.install()` and **before** `relaunch()`
@@ -116,6 +156,17 @@ mod tests {
     fn auto_update_supported_is_bool() {
         let _ = is_auto_update_supported();
         assert!(!is_updater_plugin_enabled() || cfg!(grok_updater_enabled));
+    }
+
+    #[test]
+    fn updater_status_channel_matches_flags() {
+        let s = updater_status();
+        assert!(s.channel == "silent" || s.channel == "github_manual");
+        if s.plugin_enabled && s.platform_supported {
+            assert_eq!(s.channel, "silent");
+        } else {
+            assert_eq!(s.channel, "github_manual");
+        }
     }
 
     #[test]

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -3340,8 +3340,13 @@ function AboutUpdateRow({
   t: (key: MessageKey, vars?: Record<string, string | number>) => string;
 }) {
   // Single authority: useUpdater (plugin path or GitHub fallback).
-  const { status, checkForUpdate, installAndRelaunch, githubReleasesUrl } =
-    useUpdaterContext();
+  const {
+    status,
+    channelInfo,
+    checkForUpdate,
+    installAndRelaunch,
+    githubReleasesUrl,
+  } = useUpdaterContext();
   const [openError, setOpenError] = useState<string | null>(null);
 
   const openRelease = async (url: string) => {
@@ -3406,6 +3411,14 @@ function AboutUpdateRow({
       <div className="settings-row__text">
         <div className="settings-row__label">{t("settings.checkUpdate")}</div>
         <div className="settings-row__desc">{t("settings.checkUpdateDesc")}</div>
+        <div className="settings-row__hint" data-updater-channel={channelInfo.channel}>
+          {channelInfo.channel === "silent"
+            ? t("settings.autoUpdateChannelSilent")
+            : t("settings.autoUpdateChannelManual")}
+          {channelInfo.endpoint
+            ? ` · ${channelInfo.endpoint.replace(/^https:\/\//, "")}`
+            : ""}
+        </div>
       </div>
       <div className="settings-about-update">
         <div className="settings-about-update__actions">

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -101,8 +101,22 @@ async function githubCheckUpdate(): Promise<AppUpdateCheck> {
   return invoke<AppUpdateCheck>("app_check_update");
 }
 
+export type UpdaterChannelInfo = {
+  /** `silent` when signed release plugin path is live; else `github_manual`. */
+  channel: "silent" | "github_manual" | "unknown";
+  pluginEnabled: boolean;
+  platformSupported: boolean;
+  endpoint: string;
+};
+
 export function useUpdater() {
   const [status, setStatusState] = useState<UpdateStatus>(initialUpdateStatus);
+  const [channelInfo, setChannelInfo] = useState<UpdaterChannelInfo>({
+    channel: "unknown",
+    pluginEnabled: false,
+    platformSupported: false,
+    endpoint: "",
+  });
   const statusRef = useRef<UpdateStatus>(initialUpdateStatus());
   const updateRef = useRef<Update | null>(null);
   const checkInFlightRef = useRef(false);
@@ -395,6 +409,33 @@ export function useUpdater() {
     aliveRef.current = true;
     const gen = ++generationRef.current;
 
+    // Resolve channel once for About / Doctor (does not start download).
+    void (async () => {
+      if (!isDesktopHost()) return;
+      try {
+        const s = await invoke<{
+          platformSupported: boolean;
+          pluginEnabled: boolean;
+          channel: string;
+          endpoint: string;
+        }>("updater_status");
+        if (!aliveRef.current || generationRef.current !== gen) return;
+        setChannelInfo({
+          channel:
+            s.channel === "silent"
+              ? "silent"
+              : s.channel === "github_manual"
+                ? "github_manual"
+                : "unknown",
+          pluginEnabled: !!s.pluginEnabled,
+          platformSupported: !!s.platformSupported,
+          endpoint: s.endpoint || "",
+        });
+      } catch {
+        /* ignore — About still works via status machine */
+      }
+    })();
+
     void checkForUpdateInBackground();
 
     const intervalId = window.setInterval(() => {
@@ -412,6 +453,7 @@ export function useUpdater() {
 
   return {
     status,
+    channelInfo,
     checkForUpdate,
     installAndRelaunch,
     githubReleasesUrl: GITHUB_RELEASES_URL,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -969,6 +969,10 @@ const en = {
   "settings.autoUpdateManualRequired":
     "Version {version} is available. This install type cannot auto-update — download from the release page.",
   "settings.autoUpdateError": "Update failed: {error}",
+  "settings.autoUpdateChannelSilent":
+    "Update channel: in-app (signed release)",
+  "settings.autoUpdateChannelManual":
+    "Update channel: GitHub download (unsigned / local build)",
   "settings.close": "Close",
   "settings.sharedConfirm":
     "Switch to shared ~/.grok? Data will not merge silently. Confirm?",
@@ -3010,6 +3014,9 @@ const zh: Record<MessageKey, string> = {
   "settings.autoUpdateManualRequired":
     "有新版本 {version}。当前安装方式不支持应用内更新 — 请到发布页下载。",
   "settings.autoUpdateError": "更新失败：{error}",
+  "settings.autoUpdateChannelSilent": "更新通道：应用内（已签名正式版）",
+  "settings.autoUpdateChannelManual":
+    "更新通道：GitHub 下载（未签名 / 本地构建）",
   "settings.close": "关闭",
   "settings.sharedConfirm":
     "切换到共享 ~/.grok？数据不会静默合并，请确认。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -931,6 +931,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.autoUpdateManualRequired":
     "有新版本 {version}。目前安裝方式不支援應用程式內更新 — 請到發佈頁下載。",
   "settings.autoUpdateError": "更新失敗：{error}",
+  "settings.autoUpdateChannelSilent": "更新通道：應用內（已簽名正式版）",
+  "settings.autoUpdateChannelManual":
+    "更新通道：GitHub 下載（未簽名 / 本地建置）",
   "settings.close": "關閉",
   "settings.sharedConfirm":
     "切換到共用 ~/.grok？資料不會靜默合併，請確認。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -378,6 +378,19 @@ export async function isUpdaterPluginEnabled() {
   return invoke<boolean>("is_updater_plugin_enabled");
 }
 
+export type UpdaterStatus = {
+  platformSupported: boolean;
+  pluginEnabled: boolean;
+  /** `silent` | `github_manual` */
+  channel: string;
+  endpoint: string;
+};
+
+/** About / Doctor: which update path this binary uses. */
+export async function updaterStatus() {
+  return invoke<UpdaterStatus>("updater_status");
+}
+
 /** Stop agents / mirror / voice / IM before install + relaunch. */
 export async function prepareForAppUpdate() {
   return invoke<void>("prepare_for_app_update");


### PR DESCRIPTION
## Summary
- Host `updater_status` reports silent vs GitHub-manual channel
- About shows update channel (signed in-app vs GitHub download)
- `scripts/verify-updater-setup.sh` checks release wiring / docs / env presence (never prints secrets)
- Maintainer production checklist in `docs/desktop-auto-update.md`

## Milestone
- M6 / UPD

## Test plan
- [x] `cargo test --lib updater::` (4 tests)
- [x] `./scripts/verify-updater-setup.sh` (local)
- [ ] Manual: About shows GitHub channel on unsigned/local build
- [ ] With signing secrets in CI: signed build shows silent channel after next release

## Out of scope
- Setting GitHub org secrets from this PR (maintainer action)
- Apple notarization / Authenticode