### PR TITLE
feat: add message tree node

### DIFF
--- a/docs/plans/2026-07-28-session-message-nodes-design.md
+++ b/docs/plans/2026-07-28-session-message-nodes-design.md
@@ -1,0 +1,351 @@
+# 设计文档：会话内「消息节点」定位
+
+> **状态**：设计 only（不改代码）  
+> **日期**：2026-07-28（粒度决策：逐条消息）  
+> **澄清**：此处「会话节点」**不是**多分支 / Fork 树，而是 **同一个 session 里，用户消息与 Grok 回复作为消息节点的定位与导航**。  
+> **粒度（已拍板）**：**逐条消息（per-message）** — 每条合格的 user / assistant 气泡各为一个节点；**不是**「一问一答」合并成一个回合节点。  
+> **约束**：尽量对当前代码改动小。  
+> **误读归档**：此前「分支快照 / branches.json」方案见同目录 `2026-07-28-session-nodes-design.md`，**不作为本需求方案**。
+
+---
+
+## 1. 需求定义（校正后）
+
+### 1.1 一句话
+
+在**一条会话（session）**的对话流中，把**每一条**用户消息和**每一条** Grok 回复视为可独立定位的 **消息节点（message node）**，支持：
+
+- 知道「当前在哪一条消息节点」；
+- 快速跳到某一条消息节点；
+- 长对话中不迷路。
+
+### 1.2 不是什么
+
+| 易混淆概念 | 本需求是否包含 |
+|------------|----------------|
+| 同问多答、◀▶ 兄弟分支 | **否** |
+| 侧栏多 session 血缘树 | **否** |
+| 以「回合」合并 user+assistant 为单节点 | **否**（已否决；见 §3.1） |
+| `session_fork` / rewind 产品改造 | **否**（可作跳转后的附属操作，非本设计核心） |
+| 全文搜索 Cmd/Ctrl+F | **相关但更窄**；搜索是「按关键字命中」，节点定位是「按消息结构定位」 |
+
+### 1.3 对标直觉（网页端常见形态）
+
+用户感知通常是其中一种或组合：
+
+1. **消息节点轨**：侧边或边缘一列圆点 / 短条，**每条 user、每条 assistant 各一格**（可用形状或颜色区分角色），点击滚到对应气泡。  
+2. **当前位置同步**：滚动 transcript 时，高亮「当前视口内」的那条消息节点。  
+3. **上一条 / 下一条消息**：快捷键或按钮按 **节点列表顺序**（逐条 message）步进，而不是按「上一问 / 下一问」跳过 assistant。  
+4. **稳定锚点**：URL / 深链 / 从搜索、引用、Changes 跳回时，精确滚到某条 `messageId`。
+
+本设计以 **1 + 2 + 稳定锚点** 为主；**3** 为低成本增强。
+
+---
+
+## 2. 现状（可复用，少造轮子）
+
+| 已有能力 | 位置 | 与「节点定位」关系 |
+|----------|------|---------------------|
+| 每条消息稳定 `id` | `ChatMessage.id` / journal | **节点主键（1:1）** |
+| DOM 锚点 `data-message-id` | `ChatItem` / `ConversationThread` | **已具备 scroll 目标** |
+| Find 命中后 `scrollIntoView` | `ConversationThread` | **已有「滚到某 messageId」路径** |
+| 会话内查找 | `chatFind.ts` + UI | 按文本；节点定位按结构，可共享滚动 |
+| 虚拟列表（≥36 条） | `chatVirtualList` / `useChatMessageVirtualizer` | 定位时必须先保证目标行 **mounted** 或虚拟滚动定位 |
+| `role` / `marker` | `ChatMessage` | 过滤哪些行算节点（见 §5.4） |
+| User turn 判定 | `isTurnPromptMessage` | **不**用于合并节点；仅可选地给 user 节点标注 `promptIndex` 元数据 |
+
+**结论**：数据与滚动手感的骨架已在；缺的是 **「逐条消息节点」产品层**（节点列表、当前节点、导航 UI），不是新的消息存储模型。节点与 journal 行在合格集合上 **一一对应**。
+
+---
+
+## 3. 概念模型
+
+### 3.1 消息节点（Message Node）— 粒度已定
+
+| 粒度 | 定义 | 本需求 |
+|------|------|--------|
+| **A. 逐条消息** | 每个合格的 `user` / `assistant` 气泡 = **独立一节点** | **采用（唯一默认）** |
+| B. 回合节点 | 一次 user prompt + 其后回复合并为一节点 | **不采用** |
+
+规则：
+
+- **一条 user 消息 → 一个节点**  
+- **一条 assistant 消息 → 一个节点**（同一回合若有多条 assistant 气泡，则多个节点）  
+- 节点 id **等于** `message.id`（不再发明 `turn-${n}` 作为主键）  
+- 定位目标 **永远是该条消息的气泡**，不是「回合头」代理锚点  
+
+View-model（纯前端派生，**不必改 journal schema**）：
+
+```ts
+type SessionMessageNode = {
+  /** 与 ChatMessage.id 相同 */
+  id: string;
+  /** 在 messages[] 中的下标（便于虚拟列表 scrollToIndex） */
+  messageIndex: number;
+  /** 在「节点列表」中的 0-based 序号（仅计合格节点） */
+  nodeIndex: number;
+  role: "user" | "assistant";
+  preview: string;           // 该条 content 截断
+  /** 流式 / 错误等，用于轨上样式 */
+  status?: "pending" | "done" | "error";
+  /**
+   * 可选元数据：若该条是真 user prompt，带上 0-based promptIndex，
+   * 便于 UI 展示「第 n 问」标签；assistant 可为 null。
+   * 不改变「一消息一节点」的主键与步进语义。
+   */
+  promptIndex?: number | null;
+};
+```
+
+由现有 `messages[]` **派生**，不落盘第二套图。
+
+```ts
+// 伪代码
+function buildSessionMessageNodes(messages: ChatMessage[]): SessionMessageNode[] {
+  const out: SessionMessageNode[] = [];
+  let nodeIndex = 0;
+  let promptIndex = 0;
+  messages.forEach((m, messageIndex) => {
+    if (!isMessageNodeCandidate(m)) return;
+    const node: SessionMessageNode = {
+      id: m.id,
+      messageIndex,
+      nodeIndex: nodeIndex++,
+      role: m.role === "user" ? "user" : "assistant",
+      preview: truncatePreview(m.content),
+      status: nodeStatus(m),
+      promptIndex:
+        m.role === "user" && isTurnPromptMessage(m) ? promptIndex++ : null,
+    };
+    out.push(node);
+  });
+  return out;
+}
+```
+
+### 3.2 当前节点（Active / Focused Node）
+
+定义（实现简单、可测）：
+
+- 视口中线（或上 1/3）附近，**最靠近中心的那条已挂载消息节点**；或  
+- 虚拟列表：`range` 内最靠近视口中心的 **合格 message 行**（按 `messageIndex`）。
+
+用于：节点轨高亮、顶栏「第 k / M 条消息节点」（M = 节点总数，不是「总问数」）。
+
+若产品文案需要同时显示「第 n 问」，可从当前节点的 `promptIndex` 或向上找最近的 user 节点推导——**展示层**问题，不改节点粒度。
+
+### 3.3 定位（Locate）动作
+
+```
+locate(messageId)   // nodeId === messageId
+  → 若虚拟列表：scrollToIndex(messageIndex) 并等待行挂载
+  → query [data-message-id="…"]
+  → scrollIntoView({ block: "center" })  // 与 chatFind 同策略
+  → 短暂高亮（CSS class，1.5s）
+```
+
+**尽量复用** Find 的 scroll 逻辑，抽成 `scrollToMessageId(id)` 共用。  
+因粒度是逐条消息，Locate 与 Find 的目标粒度一致（都是单条 `messageId`）。
+
+---
+
+## 4. UX 方案（由简到繁）
+
+### 4.1 P0 — 最小可用（改动最小，推荐先做）
+
+**不新增侧栏大面板**，只做：
+
+1. **派生节点列表**（纯函数 `buildSessionMessageNodes(messages)`，**逐条**）。  
+2. **快捷导航**：  
+   - 按钮或快捷键：**「上一条消息 / 下一条消息」**（按 `nodeIndex` ±1，`locate(node.id)`）。  
+   - 可选：顶条显示 `k / M`（当前节点序 / 节点总数）。  
+   - 可选增强（非默认步进）：「上一问 / 下一问」仅在 **user 节点** 间跳——作为过滤器，**不**把 assistant 从节点列表里删掉。  
+3. **统一 `scrollToMessageId`**：Find、节点跳转、外部深链共用。
+
+触及面：
+
+- 新建小 lib + 单测；  
+- `ConversationThread` 或 composer 附近 1～2 个控件；  
+- 虚拟列表补 `scrollToIndex` 若尚未暴露。
+
+**不改** Rust store、不改 journal、不动 fork/rewind。
+
+### 4.2 P1 — 节点轨（更接近「网页端会话节点」视觉）
+
+在主对话区 **右侧边缘**（或滚动条内侧）一条细轨：
+
+- **每条消息节点**一个小点（user / assistant **异形或异色**，避免连成「一问一答一格」的误解）；  
+- 当前节点加粗 / 主题色；  
+- hover 显示 `role` + `preview`；  
+- click → `locate(messageId)`。
+
+注意：
+
+- 长会话节点数 ≈ 合格气泡数，可能明显多于「问数」：轨需 **可滚动** 或密度自适应（最小间距、可压缩），避免上百点挤爆；  
+- 与现有右侧 **Files pane** 不抢空间：轨贴在 chat 列内缘，宽度 ~8–12px。  
+
+### 4.3 P2 — 消息大纲抽屉（可选）
+
+轻量列表：按节点顺序列出，例如：
+
+- `用户 · preview…`  
+- `Grok · preview…`  
+
+点击跳到**该条**。可从顶栏打开，**不要**默认占侧栏 session 树。  
+若列表过长，可虚拟滚动大纲本身。
+
+### 4.4 与 Chat Find 的分工
+
+| | 消息节点定位 | Chat Find |
+|--|--------------|-----------|
+| 索引键 | **逐条** `messageId` 结构序 | 关键字 |
+| UI | 轨 / 上一条下一条 / 大纲 | 搜索框 prev/next |
+| 高亮 | 整气泡短暂强调 | 文本 mark |
+| 步进 | 所有合格消息节点 | 仅含匹配文本的命中 |
+
+两者共享 `scrollToMessageId`，数据源都是当前 session 的 `messages`。
+
+---
+
+## 5. 技术设计（贴合现架构）
+
+### 5.1 数据流
+
+```
+messages[] (App state / journal)
+        │
+        ▼
+buildSessionMessageNodes()     // 逐条；src/lib/sessionMessageNodes.ts（建议新建）
+        │
+        ├── NodeRail / MessageNav UI
+        ├── activeNodeId ← IntersectionObserver 或 virtual range（message 级）
+        └── locate(messageId) → scrollToMessageId → data-message-id
+```
+
+### 5.2 虚拟列表（关键正确性）
+
+当 `messages.length >= 36` 走虚拟窗口时：
+
+1. `locate` 不能只靠 `querySelector`（目标可能未挂载）。  
+2. 用节点上的 **`messageIndex`**（原数组下标）调用 `virtualizer.scrollToIndex`，再 rAF 后 `scrollIntoView` 微调。  
+3. 单测或手工验收：第一条 user、第一条 assistant、中间任意条、最后一条、流式中的 pending assistant。
+
+### 5.3 流式中的节点
+
+- 正在生成的 assistant：只要已有 `id` 并进入 `messages[]`，即占一个节点，`status: pending`。  
+- 自动跟随底部时，**active 自然为最后一条消息节点**；用户上翻后 active 随视口变，不要强行抢滚动。
+
+### 5.4 哪些行不算节点
+
+**排除**（不进入节点列表，也无轨点）：
+
+- `role === "tool"` 以及 `marker === "tool_step"` 等工具行（首版不要「工具节点」）  
+- 纯系统 marker（如 `context_compact`、`turn_cancelled` 等，按现网 marker 枚举过滤）  
+- `marker === "interjection"`：若产品视其为独立 user 气泡，**可计入** user 节点；若视为中途插话噪音，可排除——**默认：排除 interjection**，与「主对话节点」更干净；实现前若要计入，只改 `isMessageNodeCandidate`  
+- 非 user/assistant 的其它 role  
+
+**计入**：
+
+- 普通 `user` 气泡  
+- 普通 `assistant` 气泡（含 `isError` 的失败回复 — 仍占一节点，`status: "error"`）  
+- 流式中、内容仍空的 assistant 占位（可选计入，便于跳到「正在生成」；默认 **计入**）
+
+**不做**：把多条 assistant 合并成一个节点，或把 user+assistant 绑成一对再定位。
+
+### 5.5 要不要改 Host / 磁盘？
+
+**首版：不需要。**
+
+节点 = 内存派生。深链直接：
+
+- `?message=<messageId>`  
+
+与逐条粒度一致；**不必** `?turn=3` 作为主键（turn 仅可作可选 UX 文案）。
+
+---
+
+## 6. 「尽量少改代码」的落点
+
+| 做法 | 说明 |
+|------|------|
+| 纯函数按条派生节点 | 不改 `SessionMeta` / journal；id = message.id |
+| 复用 `data-message-id` + Find 滚动 | 不新造锚点体系 |
+| `promptIndex` 仅作可选标签 | 不依赖 turn 合并 |
+| UI 增量组件 | `SessionNodeRail` / `MessageNavigator`，少塞 `App.tsx` |
+| 不碰 ACP / fork / agent pool | 与 agent 连续性无关 |
+
+预计主 diff 热点：
+
+- `src/lib/sessionMessageNodes.ts` + test  
+- `ConversationThread` 或 chat 壳上挂轨 / 导航  
+- 虚拟列表 scrollTo API 补强（若缺）  
+- 少量 i18n（`session.nodes.*` / `chat.messageNav.*`）
+
+---
+
+## 7. 交互与无障碍
+
+- 节点轨：`aria-label` 区分角色，例如「用户消息：{preview}」「助手消息：{preview}」；当前节点 `aria-current`。  
+- 快捷键建议（可配置，避免与 Find 冲突）：  
+  - **上一条 / 下一条消息节点**（例如 `Alt+↑` / `Alt+↓`，具体键位实现时再定并写进快捷键表）。  
+  - 若另提供「上一问 / 下一问」，须在文案与快捷键上与「上一条消息」区分，避免用户以为节点是按回合合并的。  
+- 高对比主题下 user/assistant 轨点仍可分辨（token 色 + 形状，不唯独靠色盲不友好的单色差）。  
+- 不引入 `window.prompt`；无阻塞 dialog 需求。
+
+---
+
+## 8. 成功标准
+
+1. 长会话中可通过「上一条 / 下一条」或节点轨，**稳定滚到对应那一条** user 或 assistant 气泡中心附近。  
+2. 同一回合内的 user 与 assistant **可分别**作为当前节点被高亮与选中。  
+3. 虚拟列表开关两种模式下定位都正确。  
+4. 滚动时当前节点高亮与视口大致一致（允许一层滞后，不抖动狂跳）。  
+5. 无节点 UI 时（未做 P1）也不破坏现有 Find / 气泡操作。  
+6. **零** journal / session 索引格式变更。  
+7. 与「多分支会话树」无关，不引入 `branches.json`。  
+8. 节点列表长度在过滤后等于合格 user+assistant 条数（一消息一节点可测）。
+
+---
+
+## 9. 分阶段
+
+| 阶段 | 内容 | 改动量 |
+|------|------|--------|
+| **P0** | `buildSessionMessageNodes`（逐条）+ `scrollToMessageId` + 上一条/下一条 + 可选 `k/M` | 小 |
+| **P1** | 对话区边缘节点轨（user/assistant 可区分）+ hover preview + 当前高亮 | 小–中（纯 UI） |
+| **P2** | 逐条消息大纲列表、深链 `messageId`、快捷键正式化；可选「仅 user 间跳转」过滤器 | 小 |
+| **非目标** | 回合合并节点、分支兄弟、侧栏 session 树、每节点独立 agent | — |
+
+---
+
+## 10. 决策记录 / 开放问题
+
+### 已决策
+
+| 项 | 决策 |
+|----|------|
+| 节点粒度 | **逐条消息**（user / assistant 各算一节点） |
+| 节点主键 | `message.id` |
+| 回合合并 | **不做** |
+| 分支树 | **不做**（本需求） |
+
+### 仍可实现时微调
+
+1. **导航入口**：仅快捷键 + 顶条，还是必须上节点轨？ → 建议 **P0 无轨也能用，P1 再上轨**。  
+2. **interjection 是否计入节点**：默认排除；若要计入只改 candidate 谓词。  
+3. **空占位 assistant**：默认计入（pending）。  
+
+---
+
+## 11. 一句话总结
+
+> **会话节点 = 单 session 里每一条用户消息、每一条 Grok 回复的可定位点（一消息一节点）**；用现有 `message.id` + `data-message-id` 派生与跳转即可，**不必**按回合合并，也**不必**引入分支图或改 journal。
+
+---
+
+## 参考代码锚点
+
+- 消息类型：`src/lib/session.ts`（`ChatMessage`；`isTurnPromptMessage` 仅作 user 节点可选 `promptIndex`）  
+- 查找与命中：`src/lib/chatFind.ts`  
+- 滚动与锚点：`src/components/lobe-chat/ConversationThread.tsx`（`data-message-id`、`scrollIntoView`）  
+- 气泡锚点：`src/components/lobe-chat/ChatItem.tsx`  

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -25,6 +25,7 @@ import {
   IconChevronDown as TbChevronDown,
   IconChevronLeft as TbChevronLeft,
   IconChevronRight as TbChevronRight,
+  IconChevronUp as TbChevronUp,
   IconChevronsLeft as TbChevronsLeft,
   IconCircleDashed as TbCircleDashed,
   IconCopy as TbCopy,
@@ -233,6 +234,7 @@ export const IconHooks = wrap(TbBolt);
 export const IconChevronDown = wrap(TbChevronDown);
 export const IconChevronLeft = wrap(TbChevronLeft);
 export const IconChevronRight = wrap(TbChevronRight);
+export const IconChevronUp = wrap(TbChevronUp);
 export const IconFolderPlus = wrap(TbFolderPlus);
 export const IconPlus = wrap(TbPlus);
 export const IconMore = wrap(TbDots);

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -3,7 +3,16 @@
  * Replaces AI Elements / previous ConversationThread.
  */
 
-import { memo, useCallback, useEffect, useMemo, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type UIEvent,
+} from "react";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
 import {
@@ -14,6 +23,16 @@ import {
   type ChatMessage,
   type SessionState,
 } from "@/lib/session";
+import {
+  adjacentNode,
+  buildSessionMessageNodes,
+  estimateMessageIndexAtY,
+  estimateStartScrollTop,
+  nearestNodeForMessageIndex,
+  pickActiveNodeIdFromRects,
+  type SessionMessageNode,
+} from "@/lib/sessionMessageNodes";
+import { MessageNodeRail } from "./MessageNodeRail";
 import { isEndOfTurnMarker } from "@/lib/endOfTurn";
 import type { Attachment } from "@/lib/attachments";
 import {
@@ -417,6 +436,213 @@ export function ConversationThread({
   void _onOpenSessionChanges;
   void _onOpenModifiedPath;
 
+  // Re-pin when user sends (even if they had scrolled up to read history).
+  const forceStickKey = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.role === "user") return messages[i]!.id;
+    }
+    return null;
+  }, [messages]);
+
+  const {
+    viewportRef: scrollRef,
+    contentRef,
+    onScroll: onStickScroll,
+    scrollToBottom,
+    isPinnedRef,
+    showBack,
+  } = useStickToBottom({
+    conversationKey: sessionKey ?? "chat",
+    forceStickKey,
+  });
+
+  const messageNodes = useMemo(
+    () => buildSessionMessageNodes(messages),
+    [messages],
+  );
+  const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
+  const [locateTargetId, setLocateTargetId] = useState<string | null>(null);
+  const [focusMessageId, setFocusMessageId] = useState<string | null>(null);
+  const focusClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const locateClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const locateRafRef = useRef<number | null>(null);
+  /** While set, scroll-sync must not overwrite the rail cursor (nav in flight). */
+  const navLockUntilRef = useRef(0);
+  /** Authoritative cursor for prev/next — survives brief active-id flicker. */
+  const railCursorRef = useRef<string | null>(null);
+
+  const syncActiveNodeFromScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el || messageNodes.length === 0) return;
+    // Programmatic next/prev owns the highlight until the jump settles.
+    if (performance.now() < navLockUntilRef.current) return;
+
+    const viewportRect = el.getBoundingClientRect();
+    const focusY = viewportRect.top + el.clientHeight * 0.28;
+
+    const rects: { id: string; top: number; bottom: number }[] = [];
+    for (const node of messageNodes) {
+      const row = el.querySelector(
+        `[data-message-id="${CSS.escape(node.id)}"]`,
+      ) as HTMLElement | null;
+      if (!row) continue;
+      const r = row.getBoundingClientRect();
+      rects.push({ id: node.id, top: r.top, bottom: r.bottom });
+    }
+
+    let bestId = pickActiveNodeIdFromRects(rects, focusY);
+
+    if (!bestId) {
+      const y = el.scrollTop + el.clientHeight * 0.28;
+      const msgIdx = estimateMessageIndexAtY(messages, y);
+      bestId = nearestNodeForMessageIndex(messageNodes, msgIdx)?.id ?? null;
+    }
+
+    if (bestId) railCursorRef.current = bestId;
+    setActiveNodeId((prev) => (prev === bestId ? prev : bestId));
+  }, [messageNodes, messages, scrollRef]);
+
+  const onScroll = useCallback(
+    (e: UIEvent<HTMLDivElement>) => {
+      onStickScroll(e);
+      syncActiveNodeFromScroll();
+    },
+    [onStickScroll, syncActiveNodeFromScroll],
+  );
+
+  // Keep rail highlight in sync on mount / message growth / session switch.
+  useEffect(() => {
+    const t = window.requestAnimationFrame(() => syncActiveNodeFromScroll());
+    return () => window.cancelAnimationFrame(t);
+  }, [syncActiveNodeFromScroll, sessionKey, messages.length]);
+
+  const applyScrollToNodeDom = useCallback(
+    (node: SessionMessageNode, attempt = 0) => {
+      const viewport = scrollRef.current;
+      if (!viewport) return;
+
+      const root = viewport.querySelector(
+        `[data-message-id="${CSS.escape(node.id)}"]`,
+      ) as HTMLElement | null;
+
+      if (!root) {
+        // Virtual window may still be mounting the forced row.
+        if (attempt < 8) {
+          locateRafRef.current = window.requestAnimationFrame(() => {
+            locateRafRef.current = null;
+            applyScrollToNodeDom(node, attempt + 1);
+          });
+        }
+        return;
+      }
+
+      // Align to the upper band so tall previous messages leave the focus line.
+      // Instant first — smooth often no-ops when the row is already partially on screen.
+      root.scrollIntoView({ block: "start", behavior: "instant" });
+      // Nudge: keep a small top inset so the bubble isn't under chrome.
+      const vr = viewport.getBoundingClientRect();
+      const rr = root.getBoundingClientRect();
+      const desiredTop = vr.top + Math.min(48, viewport.clientHeight * 0.1);
+      const delta = rr.top - desiredTop;
+      if (Math.abs(delta) > 2) {
+        viewport.scrollTop += delta;
+      }
+
+      if (locateClearTimerRef.current) clearTimeout(locateClearTimerRef.current);
+      // Keep force-mount until layout + scroll settle (virtual list).
+      locateClearTimerRef.current = setTimeout(() => {
+        setLocateTargetId((cur) => (cur === node.id ? null : cur));
+        locateClearTimerRef.current = null;
+        // Release nav lock shortly after so free scroll can update the rail.
+        navLockUntilRef.current = performance.now() + 120;
+        syncActiveNodeFromScroll();
+      }, 700);
+    },
+    [scrollRef, syncActiveNodeFromScroll],
+  );
+
+  const scrollToMessageNode = useCallback(
+    (node: SessionMessageNode) => {
+      const viewport = scrollRef.current;
+      if (!viewport) return;
+
+      // Leave stick-to-bottom so programmatic jumps are not yanked back.
+      isPinnedRef.current = false;
+
+      railCursorRef.current = node.id;
+      navLockUntilRef.current = performance.now() + 1200;
+      setLocateTargetId(node.id);
+      setActiveNodeId(node.id);
+      setFocusMessageId(node.id);
+      if (focusClearTimerRef.current) clearTimeout(focusClearTimerRef.current);
+      focusClearTimerRef.current = setTimeout(() => {
+        setFocusMessageId((cur) => (cur === node.id ? null : cur));
+        focusClearTimerRef.current = null;
+      }, 1600);
+
+      // Coarse jump via estimates so the virtual window moves near the target
+      // even before the row is mounted.
+      const approx = estimateStartScrollTop(
+        messages,
+        node.messageIndex,
+        viewport.clientHeight,
+      );
+      const prevBehavior = viewport.style.scrollBehavior;
+      viewport.style.scrollBehavior = "auto";
+      viewport.scrollTop = approx;
+      if (prevBehavior) viewport.style.scrollBehavior = prevBehavior;
+      else viewport.style.removeProperty("scroll-behavior");
+
+      if (locateRafRef.current != null) {
+        window.cancelAnimationFrame(locateRafRef.current);
+      }
+      // Wait a frame for React to apply forceIndices + virtual recompute.
+      locateRafRef.current = window.requestAnimationFrame(() => {
+        locateRafRef.current = window.requestAnimationFrame(() => {
+          locateRafRef.current = null;
+          applyScrollToNodeDom(node, 0);
+        });
+      });
+    },
+    [applyScrollToNodeDom, isPinnedRef, messages, scrollRef],
+  );
+
+  // After force-mount state commits, finish the jump (virtual list needs a paint).
+  useEffect(() => {
+    if (!locateTargetId) return;
+    const node = messageNodes.find((n) => n.id === locateTargetId);
+    if (!node) return;
+    const t = window.requestAnimationFrame(() => applyScrollToNodeDom(node, 0));
+    return () => window.cancelAnimationFrame(t);
+  }, [locateTargetId, messageNodes, applyScrollToNodeDom]);
+
+  const onNodePrev = useCallback(() => {
+    const cur = railCursorRef.current ?? activeNodeId;
+    const next = adjacentNode(messageNodes, cur, -1);
+    if (next) scrollToMessageNode(next);
+  }, [messageNodes, activeNodeId, scrollToMessageNode]);
+
+  const onNodeNext = useCallback(() => {
+    const cur = railCursorRef.current ?? activeNodeId;
+    const next = adjacentNode(messageNodes, cur, 1);
+    if (next) scrollToMessageNode(next);
+  }, [messageNodes, activeNodeId, scrollToMessageNode]);
+
+  const railLabels = useMemo(
+    () => ({
+      aria: tr("message.nodes.aria"),
+      prev: tr("message.nodes.prev"),
+      next: tr("message.nodes.next"),
+      userRole: tr("message.nodes.user"),
+      assistantRole: tr("message.nodes.assistant"),
+      count: (current: number, total: number) =>
+        tr("message.nodes.count", { current, total }),
+    }),
+    [tr],
+  );
+
   // Scroll the current find match into view (mark if present, else message).
   useEffect(() => {
     if (!findActive?.messageId) return;
@@ -437,25 +663,15 @@ export function ConversationThread({
     return () => window.cancelAnimationFrame(t);
   }, [findActive?.messageId, findActive?.occurrence, findQuery]);
 
-  // Re-pin when user sends (even if they had scrolled up to read history).
-  const forceStickKey = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]?.role === "user") return messages[i]!.id;
-    }
-    return null;
-  }, [messages]);
-
-  const {
-    viewportRef: scrollRef,
-    contentRef,
-    onScroll,
-    scrollToBottom,
-    isPinnedRef,
-    showBack,
-  } = useStickToBottom({
-    conversationKey: sessionKey ?? "chat",
-    forceStickKey,
-  });
+  useEffect(() => {
+    return () => {
+      if (focusClearTimerRef.current) clearTimeout(focusClearTimerRef.current);
+      if (locateClearTimerRef.current) clearTimeout(locateClearTimerRef.current);
+      if (locateRafRef.current != null) {
+        window.cancelAnimationFrame(locateRafRef.current);
+      }
+    };
+  }, []);
 
   const turnBusy =
     sessionState === "streaming" || sessionState === "awaiting_permission";
@@ -523,6 +739,7 @@ export function ConversationThread({
       if (i >= 0) out.push(i);
     };
     pushId(findActive?.messageId);
+    pushId(locateTargetId);
     pushId(activeAssistantId);
     // While following the live turn, keep the last user + tail mounted.
     if (turnBusy) {
@@ -534,6 +751,7 @@ export function ConversationThread({
   }, [
     messages,
     findActive?.messageId,
+    locateTargetId,
     activeAssistantId,
     lastUserMessageId,
     turnBusy,
@@ -738,6 +956,7 @@ export function ConversationThread({
               const timeLabel = formatMessageTime(m.createdAt, locale);
               const isFindHit = !!findHitMessageIds?.has(m.id);
               const isFindCurrent = findActive?.messageId === m.id;
+              const isNodeFocus = focusMessageId === m.id;
               return wrap(
                 <ChatItem
                   key={m.id}
@@ -747,7 +966,8 @@ export function ConversationThread({
                   showTitle={false}
                   className={
                     (isFindHit ? " lobe-chat-item--find-hit" : "") +
-                    (isFindCurrent ? " lobe-chat-item--find-current" : "")
+                    (isFindCurrent ? " lobe-chat-item--find-current" : "") +
+                    (isNodeFocus ? " lobe-chat-item--node-focus" : "")
                   }
                   message={
                     <div
@@ -887,13 +1107,15 @@ export function ConversationThread({
               );
               const isFindHit = !!findHitMessageIds?.has(m.id);
               const isFindCurrent = findActive?.messageId === m.id;
+              const isNodeFocus = focusMessageId === m.id;
               return wrap(
                 <div
                   key={m.id}
                   className={
                     "lobe-chat-error" +
                     (isFindHit ? " lobe-chat-item--find-hit" : "") +
-                    (isFindCurrent ? " lobe-chat-item--find-current" : "")
+                    (isFindCurrent ? " lobe-chat-item--find-current" : "") +
+                    (isNodeFocus ? " lobe-chat-item--node-focus" : "")
                   }
                   role="alert"
                   data-testid="chat-turn-error"
@@ -947,6 +1169,7 @@ export function ConversationThread({
 
             const isFindHit = !!findHitMessageIds?.has(m.id);
             const isFindCurrent = findActive?.messageId === m.id;
+            const isNodeFocus = focusMessageId === m.id;
             // Phase projection: thought+tools collapse when phase ends (content
             // / next thought), not only when the full answer is done.
             const timelineUnits = buildTimelineUnits(segs, {
@@ -962,7 +1185,8 @@ export function ConversationThread({
                 loading={!!m.streaming}
                 className={
                   (isFindHit ? " lobe-chat-item--find-hit" : "") +
-                  (isFindCurrent ? " lobe-chat-item--find-current" : "")
+                  (isFindCurrent ? " lobe-chat-item--find-current" : "") +
+                  (isNodeFocus ? " lobe-chat-item--node-focus" : "")
                 }
                 message={
                   <div
@@ -1166,6 +1390,15 @@ export function ConversationThread({
           {/* Plan UI lives only in PlanStatusBar (top) + ResourceViewer Plan mode. */}
         </div>
       </div>
+
+      <MessageNodeRail
+        nodes={messageNodes}
+        activeId={activeNodeId}
+        onSelect={scrollToMessageNode}
+        onPrev={onNodePrev}
+        onNext={onNodeNext}
+        labels={railLabels}
+      />
 
       <BackBottom
         visible={showBack}

--- a/src/components/lobe-chat/MessageNodeRail.tsx
+++ b/src/components/lobe-chat/MessageNodeRail.tsx
@@ -1,0 +1,167 @@
+/**
+ * Grok-web-style message node rail (right edge of the transcript).
+ * One tick per user/assistant message; hover preview; prev/next steppers.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { IconChevronDown, IconChevronUp } from "@/components/icons";
+import type { SessionMessageNode } from "@/lib/sessionMessageNodes";
+import { cn } from "@/lib/utils";
+
+export type MessageNodeRailLabels = {
+  aria: string;
+  prev: string;
+  next: string;
+  userRole: string;
+  assistantRole: string;
+  /** "{current} / {total}" */
+  count: (current: number, total: number) => string;
+};
+
+type TipState = {
+  node: SessionMessageNode;
+  top: number;
+  right: number;
+};
+
+export function MessageNodeRail({
+  nodes,
+  activeId,
+  onSelect,
+  onPrev,
+  onNext,
+  labels,
+}: {
+  nodes: readonly SessionMessageNode[];
+  activeId: string | null;
+  onSelect: (node: SessionMessageNode) => void;
+  onPrev: () => void;
+  onNext: () => void;
+  labels: MessageNodeRailLabels;
+}) {
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const [tip, setTip] = useState<TipState | null>(null);
+
+  const activeIndex = useMemo(() => {
+    if (!activeId) return -1;
+    return nodes.findIndex((n) => n.id === activeId);
+  }, [nodes, activeId]);
+
+  const canPrev = activeIndex > 0 || (activeIndex < 0 && nodes.length > 0);
+  const canNext =
+    (activeIndex >= 0 && activeIndex < nodes.length - 1) ||
+    (activeIndex < 0 && nodes.length > 0);
+
+  // Keep the active tick roughly in view inside a long rail.
+  useEffect(() => {
+    if (activeIndex < 0 || !listRef.current) return;
+    const tick = listRef.current.querySelector(
+      `[data-node-id="${CSS.escape(nodes[activeIndex]!.id)}"]`,
+    ) as HTMLElement | null;
+    tick?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [activeIndex, nodes]);
+
+  const showTipFor = (node: SessionMessageNode, el: HTMLElement) => {
+    const r = el.getBoundingClientRect();
+    setTip({
+      node,
+      top: r.top + r.height / 2,
+      right: window.innerWidth - r.left + 8,
+    });
+  };
+
+  const clearTip = (id: string) => {
+    setTip((cur) => (cur?.node.id === id ? null : cur));
+  };
+
+  if (nodes.length < 2) return null;
+
+  const tipRole =
+    tip == null
+      ? ""
+      : tip.node.role === "user"
+        ? labels.userRole
+        : labels.assistantRole;
+
+  return (
+    <nav
+      className="lobe-msg-rail"
+      aria-label={labels.aria}
+      data-slot="message-node-rail"
+    >
+      <button
+        type="button"
+        className="lobe-msg-rail__step"
+        aria-label={labels.prev}
+        disabled={!canPrev}
+        onClick={onPrev}
+      >
+        <IconChevronUp size={14} />
+      </button>
+
+      <div ref={listRef} className="lobe-msg-rail__list" role="list">
+        {nodes.map((n) => {
+          const isActive = n.id === activeId;
+          const isHover = tip?.node.id === n.id;
+          const roleLabel =
+            n.role === "user" ? labels.userRole : labels.assistantRole;
+          return (
+            <button
+              key={n.id}
+              type="button"
+              role="listitem"
+              data-node-id={n.id}
+              className={cn(
+                "lobe-msg-rail__tick",
+                n.role === "user" && "lobe-msg-rail__tick--user",
+                n.role === "assistant" && "lobe-msg-rail__tick--assistant",
+                isActive && "is-active",
+                isHover && "is-hover",
+                n.status === "error" && "is-error",
+                n.status === "pending" && "is-pending",
+              )}
+              aria-label={`${roleLabel}: ${n.preview}`}
+              aria-current={isActive ? "true" : undefined}
+              onMouseEnter={(e) => showTipFor(n, e.currentTarget)}
+              onMouseLeave={() => clearTip(n.id)}
+              onFocus={(e) => showTipFor(n, e.currentTarget)}
+              onBlur={() => clearTip(n.id)}
+              onClick={() => onSelect(n)}
+            />
+          );
+        })}
+      </div>
+
+      <button
+        type="button"
+        className="lobe-msg-rail__step"
+        aria-label={labels.next}
+        disabled={!canNext}
+        onClick={onNext}
+      >
+        <IconChevronDown size={14} />
+      </button>
+
+      {tip && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              className="lobe-msg-rail__tip lobe-msg-rail__tip--portal"
+              role="tooltip"
+              style={{
+                top: tip.top,
+                right: tip.right,
+              }}
+            >
+              <div className="lobe-msg-rail__tip-role">{tipRole}</div>
+              <div className="lobe-msg-rail__tip-body">{tip.node.preview}</div>
+              <div className="lobe-msg-rail__tip-count">
+                {labels.count(tip.node.nodeIndex + 1, nodes.length)}
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+    </nav>
+  );
+}

--- a/src/components/lobe-chat/index.ts
+++ b/src/components/lobe-chat/index.ts
@@ -1,2 +1,4 @@
 export { ConversationThread } from "./ConversationThread";
 export type { ConversationThreadProps } from "./ConversationThread";
+export { MessageNodeRail } from "./MessageNodeRail";
+export type { MessageNodeRailLabels } from "./MessageNodeRail";

--- a/src/components/lobe-chat/lobe-chat.css
+++ b/src/components/lobe-chat/lobe-chat.css
@@ -1301,6 +1301,201 @@
  * measured shell height). Centered so narrow panes don't overlap the
  * composer card / side controls.
  */
+/* ── Message node rail (Grok-web style, right edge) ── */
+.lobe-msg-rail {
+  position: absolute;
+  z-index: 40;
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  max-height: min(70vh, 520px);
+  padding: 4px 2px;
+  pointer-events: none;
+}
+
+.lobe-msg-rail__step,
+.lobe-msg-rail__tick,
+.lobe-msg-rail__list {
+  pointer-events: auto;
+}
+
+.lobe-msg-rail__step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--chat-text-3, var(--text-tertiary, #6e6e73));
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.lobe-msg-rail__step:hover:not(:disabled) {
+  color: var(--chat-text, var(--text-primary));
+  background: color-mix(in srgb, var(--chat-text) 8%, transparent);
+}
+
+.lobe-msg-rail__step:disabled {
+  opacity: 0.28;
+  cursor: default;
+}
+
+.lobe-msg-rail__list {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: min(56vh, 420px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 4px 0;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.lobe-msg-rail__list::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.lobe-msg-rail__tick {
+  position: relative;
+  flex: 0 0 auto;
+  width: 14px;
+  height: 10px;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+/* Short horizontal dash — matches grok.com node ticks */
+.lobe-msg-rail__tick::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 10px;
+  height: 2px;
+  border-radius: 1px;
+  transform: translate(-50%, -50%);
+  background: color-mix(in srgb, var(--chat-text-3, #6e6e73) 55%, transparent);
+  transition:
+    width 120ms ease,
+    background 120ms ease,
+    opacity 120ms ease;
+}
+
+.lobe-msg-rail__tick--user::before {
+  width: 8px;
+  opacity: 0.75;
+}
+
+.lobe-msg-rail__tick--assistant::before {
+  width: 11px;
+}
+
+.lobe-msg-rail__tick.is-hover::before,
+.lobe-msg-rail__tick:hover::before {
+  width: 14px;
+  background: color-mix(in srgb, var(--chat-text-2, #a1a1a6) 90%, transparent);
+}
+
+.lobe-msg-rail__tick.is-active::before {
+  width: 14px;
+  height: 2.5px;
+  background: var(--chat-text, var(--text-primary, #e8e8ea));
+}
+
+.lobe-msg-rail__tick.is-pending::before {
+  opacity: 0.45;
+}
+
+.lobe-msg-rail__tick.is-error::before {
+  background: var(--chat-danger, #f07178);
+}
+
+.lobe-msg-rail__tip {
+  box-sizing: border-box;
+  width: max-content;
+  max-width: min(280px, 42vw);
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--chat-card-border, rgba(0, 0, 0, 0.08));
+  background: color-mix(
+    in srgb,
+    var(--chat-card, #f5f5f7) 92%,
+    var(--chat-bg, #fff)
+  );
+  box-shadow:
+    0 4px 18px rgba(0, 0, 0, 0.1),
+    0 1px 3px rgba(0, 0, 0, 0.06);
+  color: var(--chat-text, var(--text-primary));
+  pointer-events: none;
+  text-align: start;
+}
+
+.lobe-msg-rail__tip--portal {
+  position: fixed;
+  z-index: 80;
+  transform: translateY(-50%);
+}
+
+[data-theme="dark"] .lobe-msg-rail__tip {
+  background: color-mix(in srgb, var(--chat-card, #2a2a2e) 94%, #000);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+}
+
+.lobe-msg-rail__tip-role {
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--chat-text, var(--text-primary));
+  margin-bottom: 4px;
+}
+
+.lobe-msg-rail__tip-body {
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--chat-text-2, var(--text-secondary));
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+
+.lobe-msg-rail__tip-count {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--chat-text-3, var(--text-tertiary));
+  font-variant-numeric: tabular-nums;
+}
+
+.lobe-chat-item--node-focus {
+  outline: 1.5px solid color-mix(in srgb, var(--chat-link, #6db3f2) 55%, transparent);
+  outline-offset: 4px;
+  border-radius: 12px;
+  transition: outline-color 0.2s ease;
+}
+
+@media (max-width: 720px) {
+  .lobe-msg-rail {
+    display: none;
+  }
+}
+
 .lobe-chat-back-bottom {
   pointer-events: none;
   position: absolute;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -130,6 +130,12 @@ const en = {
   "session.rewindNoop": "Already at this point — nothing to discard",
   "message.rewindHere": "Rewind to here",
   "message.forkHere": "Fork from here",
+  "message.nodes.aria": "Message nodes in this conversation",
+  "message.nodes.prev": "Previous message",
+  "message.nodes.next": "Next message",
+  "message.nodes.user": "You",
+  "message.nodes.assistant": "Grok",
+  "message.nodes.count": "{current} / {total}",
 
   // Main
   "main.rightPane": "Files pane",
@@ -2232,6 +2238,12 @@ const zh: Record<MessageKey, string> = {
   "session.rewindNoop": "已在此位置，没有可丢弃的内容",
   "message.rewindHere": "回退到此处",
   "message.forkHere": "从此处分叉",
+  "message.nodes.aria": "本会话消息节点",
+  "message.nodes.prev": "上一条消息",
+  "message.nodes.next": "下一条消息",
+  "message.nodes.user": "你",
+  "message.nodes.assistant": "Grok",
+  "message.nodes.count": "{current} / {total}",
 
   "main.rightPane": "文件栏",
   "main.leftPane": "侧栏",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -119,6 +119,12 @@ export const zhTW: Record<MessageKey, string> = {
   "session.rewindNoop": "已在此位置，沒有可捨棄的內容",
   "message.rewindHere": "回退到此處",
   "message.forkHere": "從此處分叉",
+  "message.nodes.aria": "本對話訊息節點",
+  "message.nodes.prev": "上一則訊息",
+  "message.nodes.next": "下一則訊息",
+  "message.nodes.user": "你",
+  "message.nodes.assistant": "Grok",
+  "message.nodes.count": "{current} / {total}",
 
   "main.rightPane": "檔案欄",
   "main.leftPane": "側邊欄",

--- a/src/lib/sessionMessageNodes.test.ts
+++ b/src/lib/sessionMessageNodes.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "./session";
+import {
+  adjacentNode,
+  buildSessionMessageNodes,
+  isMessageNodeCandidate,
+  isThoughtOnlyAssistant,
+  nearestNodeForMessageIndex,
+  pickActiveNodeIdFromRects,
+  truncateNodePreview,
+} from "./sessionMessageNodes";
+
+function msg(
+  partial: Partial<ChatMessage> & Pick<ChatMessage, "id" | "role">,
+): ChatMessage {
+  return {
+    content: partial.content ?? "",
+    ...partial,
+  };
+}
+
+describe("isMessageNodeCandidate", () => {
+  it("accepts user and assistant", () => {
+    expect(isMessageNodeCandidate(msg({ id: "u", role: "user" }))).toBe(true);
+    expect(
+      isMessageNodeCandidate(msg({ id: "a", role: "assistant", content: "hi" })),
+    ).toBe(true);
+  });
+
+  it("rejects tool, interjection, end markers", () => {
+    expect(
+      isMessageNodeCandidate(msg({ id: "t", role: "tool", marker: "tool_step" })),
+    ).toBe(false);
+    expect(
+      isMessageNodeCandidate(
+        msg({ id: "i", role: "user", marker: "interjection", content: "steer" }),
+      ),
+    ).toBe(false);
+    expect(
+      isMessageNodeCandidate(
+        msg({ id: "e", role: "assistant", marker: "turn_cancelled" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects thought-only / empty streaming assistant (not a reply node)", () => {
+    expect(
+      isMessageNodeCandidate(
+        msg({
+          id: "think",
+          role: "assistant",
+          content: "",
+          thought: "reasoning…",
+          streaming: true,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isMessageNodeCandidate(
+        msg({
+          id: "shell",
+          role: "assistant",
+          content: "   ",
+          streaming: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts assistant once reply body exists (thought may still be present)", () => {
+    expect(
+      isMessageNodeCandidate(
+        msg({
+          id: "a",
+          role: "assistant",
+          content: "Here is the answer",
+          thought: "I should explain…",
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("isThoughtOnlyAssistant", () => {
+  it("is true for empty-body assistant, false when body or error", () => {
+    expect(
+      isThoughtOnlyAssistant(
+        msg({ id: "t", role: "assistant", content: "", thought: "…" }),
+      ),
+    ).toBe(true);
+    expect(
+      isThoughtOnlyAssistant(
+        msg({ id: "a", role: "assistant", content: "hi", thought: "…" }),
+      ),
+    ).toBe(false);
+    expect(
+      isThoughtOnlyAssistant(
+        msg({ id: "e", role: "assistant", content: "", isError: true }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("buildSessionMessageNodes", () => {
+  it("emits one node per user/assistant in order", () => {
+    const messages = [
+      msg({ id: "u1", role: "user", content: "Hello world" }),
+      msg({ id: "a1", role: "assistant", content: "Hi there" }),
+      msg({
+        id: "t1",
+        role: "tool",
+        marker: "tool_step",
+        content: "tool_step|done|shell|ls",
+      }),
+      msg({ id: "u2", role: "user", content: "Next" }),
+      msg({ id: "a2", role: "assistant", content: "Ok", isError: true }),
+    ];
+    const nodes = buildSessionMessageNodes(messages);
+    expect(nodes.map((n) => n.id)).toEqual(["u1", "a1", "u2", "a2"]);
+    expect(nodes.map((n) => n.nodeIndex)).toEqual([0, 1, 2, 3]);
+    expect(nodes[0]?.role).toBe("user");
+    expect(nodes[0]?.promptIndex).toBe(0);
+    expect(nodes[1]?.role).toBe("assistant");
+    expect(nodes[1]?.promptIndex).toBeNull();
+    expect(nodes[2]?.promptIndex).toBe(1);
+    expect(nodes[3]?.status).toBe("error");
+    expect(nodes[0]?.messageIndex).toBe(0);
+    expect(nodes[1]?.messageIndex).toBe(1);
+    expect(nodes[2]?.messageIndex).toBe(3);
+  });
+
+  it("does not add a node while assistant is thinking with no body", () => {
+    const nodes = buildSessionMessageNodes([
+      msg({ id: "u", role: "user", content: "q" }),
+      msg({
+        id: "a",
+        role: "assistant",
+        content: "",
+        thought: "planning…",
+        streaming: true,
+      }),
+    ]);
+    expect(nodes.map((n) => n.id)).toEqual(["u"]);
+  });
+
+  it("adds assistant node after reply body appears (pending while streaming)", () => {
+    const nodes = buildSessionMessageNodes([
+      msg({ id: "u", role: "user", content: "q" }),
+      msg({
+        id: "a",
+        role: "assistant",
+        content: "partial answer",
+        thought: "planning…",
+        streaming: true,
+      }),
+    ]);
+    expect(nodes.map((n) => n.id)).toEqual(["u", "a"]);
+    expect(nodes[1]?.status).toBe("pending");
+    expect(nodes[1]?.preview).toContain("partial answer");
+  });
+});
+
+describe("truncateNodePreview", () => {
+  it("collapses whitespace and ellipsizes", () => {
+    expect(truncateNodePreview("  a   b  ")).toBe("a b");
+    expect(truncateNodePreview("x".repeat(100)).endsWith("…")).toBe(true);
+  });
+});
+
+describe("nearestNodeForMessageIndex / adjacentNode", () => {
+  const nodes = buildSessionMessageNodes([
+    msg({ id: "u1", role: "user", content: "a" }),
+    msg({ id: "a1", role: "assistant", content: "b" }),
+    msg({ id: "u2", role: "user", content: "c" }),
+  ]);
+
+  it("picks nearest node at or before index", () => {
+    expect(nearestNodeForMessageIndex(nodes, 0)?.id).toBe("u1");
+    expect(nearestNodeForMessageIndex(nodes, 1)?.id).toBe("a1");
+    // tool gap would be index 2 → still a1 if only 0,1,2 user/asst
+    expect(nearestNodeForMessageIndex(nodes, 2)?.id).toBe("u2");
+  });
+
+  it("steps adjacent nodes", () => {
+    expect(adjacentNode(nodes, "u1", 1)?.id).toBe("a1");
+    expect(adjacentNode(nodes, "a1", -1)?.id).toBe("u1");
+    expect(adjacentNode(nodes, "u1", -1)).toBeNull();
+    expect(adjacentNode(nodes, "u2", 1)).toBeNull();
+  });
+});
+
+describe("pickActiveNodeIdFromRects", () => {
+  it("prefers the last node whose top is above the focus line (tall prev)", () => {
+    // Long first message still covers the viewport center, but second has
+    // started — reading position should be the second node.
+    const id = pickActiveNodeIdFromRects(
+      [
+        { id: "a", top: 0, bottom: 800 },
+        { id: "b", top: 200, bottom: 280 },
+      ],
+      250,
+    );
+    expect(id).toBe("b");
+  });
+
+  it("falls back to nearest center when all nodes are below focus", () => {
+    const id = pickActiveNodeIdFromRects(
+      [
+        { id: "a", top: 400, bottom: 480 },
+        { id: "b", top: 500, bottom: 560 },
+      ],
+      100,
+    );
+    expect(id).toBe("a");
+  });
+});

--- a/src/lib/sessionMessageNodes.ts
+++ b/src/lib/sessionMessageNodes.ts
@@ -1,0 +1,263 @@
+/**
+ * Per-message session nodes for transcript navigation (Grok-web-style rail).
+ * Pure view-model derived from the linear journal — no disk schema change.
+ */
+
+import { estimateChatRowHeight } from "./chatVirtualList";
+import { isEndOfTurnMarker } from "./endOfTurn";
+import { isTurnPromptMessage, type ChatMessage } from "./session";
+
+export type SessionMessageNodeRole = "user" | "assistant";
+
+export type SessionMessageNodeStatus = "pending" | "done" | "error";
+
+export type SessionMessageNode = {
+  /** Same as ChatMessage.id */
+  id: string;
+  /** Index in the full messages[] array (for virtual scroll). */
+  messageIndex: number;
+  /** 0-based index among node candidates only. */
+  nodeIndex: number;
+  role: SessionMessageNodeRole;
+  preview: string;
+  status: SessionMessageNodeStatus;
+  /** Set only for true user prompts (excludes interjection). */
+  promptIndex: number | null;
+};
+
+const PREVIEW_MAX = 72;
+
+/**
+ * True when an assistant row is only the thinking process (or an empty
+ * streaming placeholder) with no user-visible reply body yet.
+ * Thinking lives as segments/thought on the same ChatMessage — it must not
+ * become its own rail node.
+ */
+export function isThoughtOnlyAssistant(
+  message: ChatMessage | undefined | null,
+): boolean {
+  if (!message || message.role !== "assistant") return false;
+  if (message.isError) return false;
+  const body = (message.content ?? "").trim();
+  if (body) return false;
+  // No reply text yet: thought-only, streaming "思考中…", or empty shell.
+  return true;
+}
+
+/** Rows that become navigable message nodes (one bubble = one node). */
+export function isMessageNodeCandidate(
+  message: ChatMessage | undefined | null,
+): boolean {
+  if (!message) return false;
+  if (message.role === "user") {
+    // Interjections are steer noise — keep the rail on main dialogue.
+    if (message.marker === "interjection") return false;
+    return true;
+  }
+  if (message.role === "assistant") {
+    if (isEndOfTurnMarker(message.marker)) return false;
+    if (message.marker === "turn_cancelled") return false;
+    if (message.marker === "context_compact") return false;
+    // Do not treat Grok thinking / empty streaming shells as nodes.
+    // A node appears only once there is reply body (or an error record).
+    if (isThoughtOnlyAssistant(message)) return false;
+    return true;
+  }
+  return false;
+}
+
+export function truncateNodePreview(
+  content: string | undefined | null,
+  max = PREVIEW_MAX,
+): string {
+  const raw = (content ?? "").replace(/\s+/g, " ").trim();
+  if (!raw) return "…";
+  if (raw.length <= max) return raw;
+  return `${raw.slice(0, Math.max(1, max - 1))}…`;
+}
+
+function nodeStatus(m: ChatMessage): SessionMessageNodeStatus {
+  if (m.isError) return "error";
+  if (m.streaming) return "pending";
+  return "done";
+}
+
+/**
+ * Build ordered per-message nodes from the live journal.
+ * user + assistant only; tools / markers excluded.
+ */
+export function buildSessionMessageNodes(
+  messages: readonly ChatMessage[],
+): SessionMessageNode[] {
+  const out: SessionMessageNode[] = [];
+  let nodeIndex = 0;
+  let promptIndex = 0;
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+    const m = messages[messageIndex]!;
+    if (!isMessageNodeCandidate(m)) continue;
+    const role: SessionMessageNodeRole =
+      m.role === "user" ? "user" : "assistant";
+    const isPrompt = role === "user" && isTurnPromptMessage(m);
+    out.push({
+      id: m.id,
+      messageIndex,
+      nodeIndex: nodeIndex++,
+      role,
+      // Always preview the reply/user body — never thought/reasoning text.
+      preview: truncateNodePreview(m.content),
+      status: nodeStatus(m),
+      promptIndex: isPrompt ? promptIndex++ : null,
+    });
+  }
+  return out;
+}
+
+/** Cumulative content offset (px estimate) before messages[index]. */
+export function estimateOffsetBeforeMessage(
+  messages: readonly ChatMessage[],
+  index: number,
+): number {
+  const n = Math.max(0, Math.min(index, messages.length));
+  let top = 0;
+  for (let i = 0; i < n; i++) {
+    const m = messages[i]!;
+    top += estimateChatRowHeight({
+      contentLength: m.content?.length ?? 0,
+      thoughtLength: m.thought?.length ?? 0,
+      role: m.role,
+    });
+  }
+  return top;
+}
+
+/** scrollTop that roughly centers messages[index] in the viewport. */
+export function estimateCenteredScrollTop(
+  messages: readonly ChatMessage[],
+  index: number,
+  viewportHeight: number,
+): number {
+  if (index < 0 || index >= messages.length) return 0;
+  const top = estimateOffsetBeforeMessage(messages, index);
+  const m = messages[index]!;
+  const h = estimateChatRowHeight({
+    contentLength: m.content?.length ?? 0,
+    thoughtLength: m.thought?.length ?? 0,
+    role: m.role,
+  });
+  const vh = Math.max(1, viewportHeight);
+  return Math.max(0, top - vh / 2 + h / 2);
+}
+
+/**
+ * scrollTop so messages[index] starts near the upper band of the viewport.
+ * More reliable than center for next/prev when the previous bubble is very tall
+ * (centering leaves the old message dominating the viewport).
+ */
+export function estimateStartScrollTop(
+  messages: readonly ChatMessage[],
+  index: number,
+  viewportHeight: number,
+  topFraction = 0.12,
+): number {
+  if (index < 0 || index >= messages.length) return 0;
+  const top = estimateOffsetBeforeMessage(messages, index);
+  const vh = Math.max(1, viewportHeight);
+  const frac = Math.min(0.4, Math.max(0, topFraction));
+  return Math.max(0, top - vh * frac);
+}
+
+export type NodeViewportRect = {
+  id: string;
+  top: number;
+  bottom: number;
+};
+
+/**
+ * Pick the active rail node from mounted row geometry.
+ * Prefer the last node whose top edge is at or above the focus line (reading
+ * position) — stable for tall messages. Fall back to nearest center.
+ */
+export function pickActiveNodeIdFromRects(
+  rects: readonly NodeViewportRect[],
+  focusY: number,
+): string | null {
+  if (rects.length === 0) return null;
+  let reading: NodeViewportRect | null = null;
+  for (const r of rects) {
+    if (r.top <= focusY + 1) reading = r;
+  }
+  if (reading) return reading.id;
+
+  let bestId: string | null = null;
+  let bestDist = Infinity;
+  for (const r of rects) {
+    const center = (r.top + r.bottom) / 2;
+    const dist = Math.abs(center - focusY);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestId = r.id;
+    }
+  }
+  return bestId;
+}
+
+/**
+ * Which messages[] index is nearest the given document Y (scroll space).
+ */
+export function estimateMessageIndexAtY(
+  messages: readonly ChatMessage[],
+  y: number,
+): number {
+  if (messages.length === 0) return -1;
+  let acc = 0;
+  const target = Math.max(0, y);
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i]!;
+    const h = estimateChatRowHeight({
+      contentLength: m.content?.length ?? 0,
+      thoughtLength: m.thought?.length ?? 0,
+      role: m.role,
+    });
+    if (acc + h > target) return i;
+    acc += h;
+  }
+  return messages.length - 1;
+}
+
+/** Nearest node at or before the given message index; else first node after. */
+export function nearestNodeForMessageIndex(
+  nodes: readonly SessionMessageNode[],
+  messageIndex: number,
+): SessionMessageNode | null {
+  if (nodes.length === 0) return null;
+  let best: SessionMessageNode | null = null;
+  for (const n of nodes) {
+    if (n.messageIndex <= messageIndex) best = n;
+    else break;
+  }
+  if (best) return best;
+  return nodes[0] ?? null;
+}
+
+export function nodeById(
+  nodes: readonly SessionMessageNode[],
+  id: string | null | undefined,
+): SessionMessageNode | null {
+  if (!id) return null;
+  return nodes.find((n) => n.id === id) ?? null;
+}
+
+export function adjacentNode(
+  nodes: readonly SessionMessageNode[],
+  currentId: string | null | undefined,
+  delta: -1 | 1,
+): SessionMessageNode | null {
+  if (nodes.length === 0) return null;
+  const cur = currentId ? nodes.findIndex((n) => n.id === currentId) : -1;
+  if (cur < 0) {
+    return delta > 0 ? (nodes[0] ?? null) : (nodes[nodes.length - 1] ?? null);
+  }
+  const next = cur + delta;
+  if (next < 0 || next >= nodes.length) return null;
+  return nodes[next] ?? null;
+}


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->

## Type of change
- [ ] Bug fix
- [√] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [√] I ran `pnpm typecheck` and `pnpm test`
- [√] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [√] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [√] No `window.confirm` / `prompt` / `alert` for product dialogs
- [√] Docs / `docs/llm-wiki` updated if behavior changed
- [√] No secrets (`secrets.json`, tokens, `auth.json`) included

## describe
Summary



Add a Grok web–style message node rail on the right edge of the conversation transcript so users can orient and jump within a long session.



Motivation

Long chats are hard to navigate with only scroll + find. Grok.com exposes a right-side node strip (ticks + prev/next + hover preview). This PR brings that pattern into Grok App without changing journal schema, session fork/rewind, or the agent runtime.



What changed

• Per-message nodes (not turn-merged, not branch tree): one rail tick per eligible user / assistant bubble.

• Right-side MessageNodeRail: short ticks, ↑/↓ steppers, hover preview portal (role + snippet + n / total).

• Click / prev / next scrolls the transcript to that message (data-message-id), with a short focus ring.

• Thinking is not a node: assistant rows with empty reply body (thought-only / streaming shell) are excluded; preview always uses reply body text.

• Navigation reliability: nav lock + rail cursor so “next” does not snap back on tall messages; virtual-list force-mount + start-aligned scroll; reading-position active highlight.

• i18n: message.nodes.* in en / zh / zh-TW.

• Design note: docs/plans/2026-07-28-session-message-nodes-design.md.

• Tests: src/lib/sessionMessageNodes.test.ts (candidate filter, thought-only, adjacent, active-from-rects).


<img width="839" height="476" alt="image" src="https://github.com/user-attachments/assets/ef51adc6-d246-4350-bc2d-1239d4dfaedf" />
