### PR TITLE
feat(automations): host scheduler runs while app is in tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Host automation scheduler**: due tasks fire while the app process is alive (including tray-hidden window); create session → connect → send without relying on WebView timers
 - **General workspace**: app-managed `{app_data}/workspaces/general` project (`system:general`) for chats without a user folder — agent can create/edit files without the “bind a project first” toast; always trusted, pinned, not removable
 - **Session Markdown export options**: choose thinking + tool summaries; download `.md` or copy to clipboard (session menu / `/export`)
 - **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)

--- a/docs/llm-wiki/automations.md
+++ b/docs/llm-wiki/automations.md
@@ -38,12 +38,12 @@
 
 ## 执行
 
-1. 壳层每 30s 检查 `enabled` 且 `nextRunAt` 到期的任务。
-2. 不打断 `streaming` / 连接中会话；**busy 时不标记 fired**，空闲后可补跑。
-3. 触发时：`session_create` → 写 session prefs（model/effort）→ `session_connect` → `session_send` prompt。
-4. **connect 失败**：删除空壳 session，避免侧栏「空 SuperGrok」幽灵会话；不 `mark_run`。
-5. **send 失败**：在会话内留下 user + error 气泡；不 `mark_run`。
-6. 成功：`lastRunAt` / `nextRunAt`；`once` 跑完后 `enabled=false`。
+1. **Host 调度**（`automation_runner`）：进程存活期间每 30s 检查 `enabled` 且 `nextRunAt` 到期的任务（**含窗口收起到托盘**）。
+2. 任一会话 mid-turn（streaming / permission / connecting / open tools）时不抢跑；空闲后下一 tick 补跑。
+3. 触发：Host `session_create(scheduled)` → `connect` → `send_message`；成功 `mark_run`；`once` 后 `enabled=false`。
+4. **connect 失败**：删除空壳 session；发 `automation://error`。
+5. UI 监听 `automation://ran` / `automation://error` 做 toast；**不再**用 WebView `setInterval` 双触发。
+6. 手动「立即执行」仍走前端 `runAutomation`。
 
 与 Build 的 `/loop`、`scheduler_*` 可并存：用户也可在会话里让 Agent 直接调度；壳层清单是独立 SoT。
 
@@ -70,5 +70,6 @@
 - [x] 助手 fence 自动 `automation_create`，气泡不展示配置块
 - [x] 应用打开时到期可触发（不阻塞主对话架构）
 - [x] connect 失败不留空壳会话；已有空会话不伪装成新建页
-- [ ] 后台无窗口常驻触发（可选 P2：系统服务 / headless CLI）
+- [x] 托盘收起时 Host 仍可触发（进程常驻；完全退出则暂停）
 - [ ] 与 CLI scheduler 双向同步（可选 P2）
+- [ ] 登录项 / 系统服务无 UI 进程（可选 P2）

--- a/src-tauri/src/automation_runner.rs
+++ b/src-tauri/src/automation_runner.rs
@@ -1,0 +1,336 @@
+//! Host-side automation scheduler.
+//!
+//! Runs while the process is alive — including when the main window is hidden
+//! to the tray — so due tasks do not depend on WebView timers.
+//!
+//! Execution reuses `SessionManager` (create → connect → send). UI is notified
+//! via `automation://ran` / `automation://skipped` / `automation://error`.
+
+use std::collections::HashSet;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+use chrono::{Datelike, Duration as ChronoDuration, Local, Timelike, Utc, Weekday};
+use tauri::{AppHandle, Emitter};
+use tracing::{info, warn};
+
+use crate::session_fsm::SessionState;
+use crate::session_manager::SessionManager;
+use crate::store::{self, Automation};
+
+const TICK: Duration = Duration::from_secs(30);
+const BOOT_DELAY: Duration = Duration::from_secs(12);
+
+/// Process-wide claimed fire keys (`id:nextRunAt`) for this process lifetime.
+static FIRED: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// Start the background tick loop (call once from app setup).
+pub fn start(app: AppHandle, mgr: Arc<SessionManager>) {
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(BOOT_DELAY).await;
+        info!(target: "automation_runner", "host automation scheduler started");
+        loop {
+            if let Err(e) = tick_once(&app, &mgr).await {
+                warn!(target: "automation_runner", "tick error: {e}");
+            }
+            tokio::time::sleep(TICK).await;
+        }
+    });
+}
+
+async fn tick_once(app: &AppHandle, mgr: &Arc<SessionManager>) -> Result<(), String> {
+    // Do not steal the agent while a turn is actively streaming.
+    if mgr.any_turn_busy() {
+        return Ok(());
+    }
+
+    let list = store::load_automations();
+    let now = Utc::now();
+    let due = list.into_iter().find(|a| a.enabled && is_due(a, now));
+    let Some(auto) = due else {
+        return Ok(());
+    };
+
+    let fire_key = format!(
+        "{}:{}",
+        auto.id,
+        auto.next_run_at
+            .map(|t| t.to_rfc3339())
+            .unwrap_or_else(|| "none".into())
+    );
+    {
+        let mut fired = FIRED.lock().unwrap_or_else(|e| e.into_inner());
+        if fired.contains(&fire_key) {
+            return Ok(());
+        }
+        fired.insert(fire_key.clone());
+    }
+
+    match run_one(app, mgr, &auto).await {
+        Ok(session_id) => {
+            let _ = app.emit(
+                "automation://ran",
+                serde_json::json!({
+                    "automationId": auto.id,
+                    "title": auto.title,
+                    "sessionId": session_id,
+                }),
+            );
+            Ok(())
+        }
+        Err(e) => {
+            // Allow retry next tick.
+            FIRED
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&fire_key);
+            let _ = app.emit(
+                "automation://error",
+                serde_json::json!({
+                    "automationId": auto.id,
+                    "title": auto.title,
+                    "error": e,
+                }),
+            );
+            Err(e)
+        }
+    }
+}
+
+async fn run_one(
+    app: &AppHandle,
+    mgr: &Arc<SessionManager>,
+    auto: &Automation,
+) -> Result<String, String> {
+    let projects = store::load_projects();
+    let proj = auto
+        .project_id
+        .as_ref()
+        .and_then(|pid| projects.iter().find(|p| &p.id == pid));
+
+    if let Some(p) = proj {
+        if !p.trusted {
+            return Err(format!("project not trusted: {}", p.name));
+        }
+        if !p.path_ok {
+            return Err(format!("project path missing: {}", p.name));
+        }
+    }
+
+    let title = if auto.title.trim().is_empty() {
+        "Scheduled".into()
+    } else {
+        auto.title.clone()
+    };
+
+    let meta = store::create_session(auto.project_id.clone(), Some(title.clone()), true)
+        .map_err(|e| format!("create session: {e}"))?;
+    let session_id = meta.id.clone();
+
+    // Optional session prefs (model / effort) before connect.
+    if auto.model_id.is_some() || auto.effort.is_some() {
+        let mut m = meta.clone();
+        if let Some(ref mid) = auto.model_id {
+            m.model_id = Some(mid.clone());
+        }
+        if let Some(ref ef) = auto.effort {
+            m.effort = Some(ef.clone());
+        }
+        let _ = store::update_session_meta(&m);
+    }
+
+    let project_path = proj.map(|p| p.path.clone());
+    let snap = mgr
+        .connect(
+            app.clone(),
+            project_path,
+            Some(session_id.clone()),
+            None,
+        )
+        .await
+        .map_err(|e| {
+            // Drop empty shell so sidebar stays clean.
+            let _ = store::delete_session(&session_id);
+            format!("connect failed: {e}")
+        })?;
+
+    if snap.state != SessionState::Ready {
+        let detail = snap
+            .last_error
+            .as_ref()
+            .map(|e| format!("{}: {}", e.code.as_str(), e.message))
+            .unwrap_or_else(|| format!("state={:?}", snap.state));
+        let _ = store::delete_session(&session_id);
+        return Err(format!("connect not ready: {detail}"));
+    }
+
+    let prompt = format!("[Scheduled: {}]\n\n{}", auto.title, auto.prompt);
+    mgr.send_message(app.clone(), prompt, None, Some(session_id.clone()))
+        .await
+        .map_err(|e| format!("send failed: {e}"))?;
+
+    let last_run = Utc::now();
+    let next = if auto.frequency.eq_ignore_ascii_case("once") {
+        None
+    } else {
+        compute_next_run_at(auto, last_run + ChronoDuration::minutes(1))
+    };
+    let _ = store::mark_automation_run(&auto.id, last_run, next);
+    if auto.frequency.eq_ignore_ascii_case("once") {
+        let _ = store::set_automation_enabled(&auto.id, false);
+    }
+
+    info!(
+        target: "automation_runner",
+        id = %auto.id,
+        session = %session_id,
+        "automation fired"
+    );
+    Ok(session_id)
+}
+
+/// Due if enabled and `next_run_at` is in the past (or missing but wall-clock matches window).
+pub fn is_due(auto: &Automation, now: chrono::DateTime<Utc>) -> bool {
+    if !auto.enabled {
+        return false;
+    }
+    if let Some(next) = auto.next_run_at {
+        return next <= now;
+    }
+    // Lazy schedule: treat as due if we can compute a next within the last 90s.
+    if let Some(next) = compute_next_run_at(auto, now - ChronoDuration::seconds(90)) {
+        let age = now.signed_duration_since(next);
+        return age.num_seconds() >= 0 && age.num_seconds() < 90;
+    }
+    false
+}
+
+/// Next local wall-clock occurrence for the automation schedule.
+pub fn compute_next_run_at(
+    auto: &Automation,
+    after: chrono::DateTime<Utc>,
+) -> Option<chrono::DateTime<Utc>> {
+    let (hour, minute) = parse_hhmm(&auto.time)?;
+    let local_after = after.with_timezone(&Local);
+    let freq = auto.frequency.to_ascii_lowercase();
+
+    // Search up to 14 days ahead for a matching slot.
+    for day_offset in 0..14 {
+        let day = local_after.date_naive() + ChronoDuration::days(day_offset);
+        let candidate = day
+            .and_hms_opt(hour, minute, 0)?
+            .and_local_timezone(Local)
+            .single()?;
+        if candidate <= local_after {
+            continue;
+        }
+        let wd = candidate.weekday();
+        let ok = match freq.as_str() {
+            "once" | "daily" => true,
+            "weekdays" => {
+                matches!(
+                    wd,
+                    Weekday::Mon
+                        | Weekday::Tue
+                        | Weekday::Wed
+                        | Weekday::Thu
+                        | Weekday::Fri
+                )
+            }
+            "weekly" => {
+                if auto.weekdays.is_empty() {
+                    true
+                } else {
+                    let js = weekday_to_js(wd);
+                    auto.weekdays.contains(&js)
+                }
+            }
+            _ => true,
+        };
+        if ok {
+            return Some(candidate.with_timezone(&Utc));
+        }
+    }
+    None
+}
+
+fn parse_hhmm(s: &str) -> Option<(u32, u32)> {
+    let parts: Vec<_> = s.trim().split(':').collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let h: u32 = parts[0].parse().ok()?;
+    let m: u32 = parts[1].parse().ok()?;
+    if h > 23 || m > 59 {
+        return None;
+    }
+    Some((h, m))
+}
+
+fn weekday_to_js(wd: Weekday) -> u8 {
+    // JS: 0=Sun … 6=Sat
+    match wd {
+        Weekday::Sun => 0,
+        Weekday::Mon => 1,
+        Weekday::Tue => 2,
+        Weekday::Wed => 3,
+        Weekday::Thu => 4,
+        Weekday::Fri => 5,
+        Weekday::Sat => 6,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn sample(freq: &str, time: &str, weekdays: Vec<u8>) -> Automation {
+        Automation {
+            id: "a1".into(),
+            title: "t".into(),
+            prompt: "p".into(),
+            enabled: true,
+            project_id: None,
+            model_id: None,
+            effort: None,
+            frequency: freq.into(),
+            time: time.into(),
+            weekdays,
+            notify: "all".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            last_run_at: None,
+            next_run_at: None,
+        }
+    }
+
+    #[test]
+    fn is_due_respects_next_run_at() {
+        let mut a = sample("daily", "09:00", vec![]);
+        a.next_run_at = Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap());
+        assert!(is_due(&a, Utc::now()));
+        a.next_run_at = Some(Utc::now() + ChronoDuration::hours(2));
+        assert!(!is_due(&a, Utc::now()));
+        a.enabled = false;
+        a.next_run_at = Some(Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap());
+        assert!(!is_due(&a, Utc::now()));
+    }
+
+    #[test]
+    fn parse_hhmm_ok() {
+        assert_eq!(parse_hhmm("09:30"), Some((9, 30)));
+        assert_eq!(parse_hhmm("23:59"), Some((23, 59)));
+        assert!(parse_hhmm("25:00").is_none());
+        assert!(parse_hhmm("bad").is_none());
+    }
+
+    #[test]
+    fn compute_next_daily_in_future() {
+        let a = sample("daily", "23:59", vec![]);
+        let after = Utc::now() - ChronoDuration::minutes(5);
+        let next = compute_next_run_at(&a, after).expect("next");
+        assert!(next > after);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ mod tool_heartbeat;
 mod cli_sessions;
 mod turn_complete;
 mod store_lock;
+mod automation_runner;
 mod permission;
 mod project_rules;
 mod permission_rules;
@@ -179,6 +180,8 @@ pub fn run() {
                 let mgr = app.state::<Arc<SessionManager>>().inner().clone();
                 mgr.start_idle_watchdog(app.handle().clone());
                 mgr.start_stream_stall_watchdog(app.handle().clone());
+                // Scheduled automations: host tick works while window is in tray.
+                automation_runner::start(app.handle().clone(), mgr);
             }
             // Remote IM: restore Feishu/Weixin connectors after App restart so
             // already-bound channels keep receiving messages without a manual Start.

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -588,6 +588,42 @@ impl SessionManager {
         }
     }
 
+    /// True when any live or background session is mid-turn (streaming / tools / connect).
+    /// Used by the host automation scheduler to avoid stealing agent slots.
+    pub fn any_turn_busy(&self) -> bool {
+        {
+            let guard = self.inner.lock();
+            if let Some(s) = guard.as_ref() {
+                if s.prompt_in_flight
+                    || matches!(
+                        s.fsm.state(),
+                        SessionState::Streaming
+                            | SessionState::AwaitingPermission
+                            | SessionState::Connecting
+                    )
+                    || !s.open_tool_ids.is_empty()
+                {
+                    return true;
+                }
+            }
+        }
+        let bg = self.background.lock();
+        for s in bg.values() {
+            if s.prompt_in_flight
+                || matches!(
+                    s.fsm.state(),
+                    SessionState::Streaming
+                        | SessionState::AwaitingPermission
+                        | SessionState::Connecting
+                )
+                || !s.open_tool_ids.is_empty()
+            {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Background idle recycle loop (I03). Safe to call once from app setup.
     pub fn start_idle_watchdog(self: &Arc<Self>, app: AppHandle) {
         let mgr = Arc::clone(self);

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -1090,8 +1090,9 @@ pub fn fork_session(
 
 // ─── Automations (scheduled tasks shell) ───────────────────────────────────
 
-/// Host-side scheduled automation. Execution is driven by the UI when the app is open
-/// (or later by CLI headless); this store is the source of truth for the list.
+/// Host-side scheduled automation. Execution is driven by the host scheduler
+/// (`automation_runner`) while the process is alive (including tray-hidden UI);
+/// this store is the source of truth for the list.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Automation {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -771,7 +771,6 @@ export default function App() {
   );
   /** Prevent overlapping automation runs. */
   const automationRunLock = useRef(false);
-  const firedAutomationIds = useRef<Set<string>>(new Set());
   /** Conversation is guiding the user to create a scheduled task. */
   const automationSetupDraftRef = useRef(false);
   const automationSetupSessionsRef = useRef<Set<string>>(new Set());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -359,7 +359,7 @@ import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import {
   aiCreateSeedPrompt,
   computeNextRunAt,
-  isDue,
+
   parseScheduledUserContent,
   type Automation,
 } from "@/lib/automations";
@@ -3959,42 +3959,53 @@ export default function App() {
     [projects, session.state, connecting, tr],
   );
 
-  // Shell scheduler: poll enabled automations while app is open.
+  // Host automation_runner ticks while the process is alive (including tray).
+  // UI only surfaces toasts / refreshes list — do not double-fire from WebView.
   useEffect(() => {
-    if (!api.isTauri() && typeof window === "undefined") return;
-    const tick = async () => {
-      if (automationRunLock.current || connecting) return;
-      if (session.state === "streaming") return;
+    if (!api.isTauri()) return;
+    let cancelled = false;
+    const unsubs: Array<() => void> = [];
+    const track = async (p: Promise<() => void>) => {
       try {
-        const rows = await api.automationsList();
-        const due = rows.find(
-          (r) =>
-            r.enabled &&
-            isDue(r as Automation) &&
-            !firedAutomationIds.current.has(`${r.id}:${r.nextRunAt ?? ""}`),
-        );
-        if (!due) return;
-        const fireKey = `${due.id}:${due.nextRunAt ?? ""}`;
-        // Claim only after we know we will attempt; release on failure so due tasks retry.
-        firedAutomationIds.current.add(fireKey);
-        const ok = await runAutomation(due as Automation, {
-          fromScheduler: true,
-        });
-        if (!ok) {
-          firedAutomationIds.current.delete(fireKey);
-        }
+        const u = await p;
+        if (cancelled) u();
+        else unsubs.push(u);
       } catch {
-        /* ignore tick errors */
+        /* ignore */
       }
     };
-    const id = window.setInterval(() => void tick(), 30_000);
-    // First check shortly after mount.
-    const boot = window.setTimeout(() => void tick(), 8_000);
+    void track(
+      api.listen<{ title?: string; sessionId?: string }>(
+        "automation://ran",
+        (p) => {
+          if (cancelled) return;
+          const title = (p?.title || "").trim() || "automation";
+          setToast(tr("automations.runningToast", { title }));
+          window.setTimeout(() => setToast(null), 3200);
+          void refreshSessions();
+        },
+      ),
+    );
+    void track(
+      api.listen<{ title?: string; error?: string }>(
+        "automation://error",
+        (p) => {
+          if (cancelled) return;
+          const title = (p?.title || "").trim() || "automation";
+          const err = (p?.error || "").trim() || "failed";
+          setLocalError(
+            tr("automations.hostRunFailed", { title, detail: err }),
+          );
+        },
+      ),
+    );
     return () => {
-      window.clearInterval(id);
-      window.clearTimeout(boot);
+      cancelled = true;
+      for (const u of unsubs) u();
     };
-  }, [runAutomation, connecting, session.state]);
+    // refreshSessions is stable enough via closure for mount-only listen
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tr]);
 
   const refreshProjects = async () => {
     try {

--- a/src/components/AutomationsPage.tsx
+++ b/src/components/AutomationsPage.tsx
@@ -374,6 +374,9 @@ export function AutomationsPage({
         <div className="auto-page__titles">
           <h1 className="auto-page__title">{t("automations.title")}</h1>
           <p className="auto-page__subtitle">{t("automations.subtitle")}</p>
+          <p className="auto-page__subtitle auto-page__subtitle--hint">
+            {t("automations.trayHint")}
+          </p>
         </div>
         <div className="auto-page__create-wrap">
           <button

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1775,6 +1775,9 @@ const en = {
   "automations.next.inDays": "Next run in {n} d",
   "automations.next.unknown": "Not scheduled",
   "automations.runningToast": "Started scheduled task: {title}",
+  "automations.hostRunFailed": "Scheduled “{title}” failed: {detail}",
+  "automations.trayHint":
+    "Scheduled tasks run while Grok App is open or in the tray. Fully quitting the app pauses them.",
   "automations.aiComposerHint":
     "Describe what to run and how often — Grok will schedule it for you when ready.",
   "automations.createdToast": "Scheduled: {title}",
@@ -3836,6 +3839,9 @@ const zh: Record<MessageKey, string> = {
   "automations.next.inDays": "下次运行 {n} 天后",
   "automations.next.unknown": "未排程",
   "automations.runningToast": "已启动已安排任务：{title}",
+  "automations.hostRunFailed": "已安排任务「{title}」失败：{detail}",
+  "automations.trayHint":
+    "应用打开或收起到托盘时都会执行已安排任务；完全退出应用后暂停。",
   "automations.aiComposerHint":
     "用自然语言描述要做什么、多久一次——准备好后 Grok 会自动创建已安排任务。",
   "automations.createdToast": "已安排：{title}",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1717,6 +1717,9 @@ export const zhTW: Record<MessageKey, string> = {
   "automations.next.inDays": "下次執行 {n} 天後",
   "automations.next.unknown": "未排程",
   "automations.runningToast": "已啟動已排程任務：{title}",
+  "automations.hostRunFailed": "已排程任務「{title}」失敗：{detail}",
+  "automations.trayHint":
+    "應用開啟或收進選單列時都會執行已排程任務；完全結束應用後暫停。",
   "automations.aiComposerHint":
     "用自然語言描述要做什麼、多久一次——準備好後 Grok 會自動建立已排程任務。",
   "automations.createdToast": "已排程：{title}",


### PR DESCRIPTION
## Summary
- Host `automation_runner` ticks every 30s while the process is alive (including close-to-tray)
- Fires due tasks via create session → connect → send (no WebView timer dependency)
- Skips when any session is mid-turn; retries next tick
- UI listens for `automation://ran` / `automation://error` (removed frontend double-fire poll)
- Automations page notes tray vs full-quit behavior

## Milestone
- M8 / AUT

## Test plan
- [x] `cargo test --lib automation_runner::` (3)
- [ ] Manual: enable close-to-tray; schedule once ~1 min ahead; hide to tray; task fires and appears in sidebar
- [ ] Manual: while a chat is streaming, due task waits; after idle, fires
- [ ] Manual: full Quit → no fire (expected)

## Out of scope
- Login-item / headless service without any app process
- CLI scheduler two-way sync