### PR TITLE
feat(worktree): remove linked worktree from UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Remove linked git worktree from UI**: branch/worktree menu trash on non-main rows; in-app confirm (force retry if dirty); host `git_worktree_remove`; switches to main when removing the active cwd
 - **General workspace**: app-managed `{app_data}/workspaces/general` project (`system:general`) for chats without a user folder — agent can create/edit files without the “bind a project first” toast; always trusted, pinned, not removable
 - **Session Markdown export options**: choose thinking + tool summaries; download `.md` or copy to clipboard (session menu / `/export`)
 - **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)

--- a/docs/llm-wiki/git-worktrees.md
+++ b/docs/llm-wiki/git-worktrees.md
@@ -14,8 +14,8 @@ git worktree list --porcelain
 - If the path is already a project, switch only; otherwise `project_add` (trust inherited from the current project when possible).
 - Soft-fail when `git` is missing or the folder is not a repo (same spirit as Workspace Changes git status).
 - **UI:** branch chip is hidden until host confirms `available: true` (non-git → no branch chip). Project menu no longer embeds worktrees.
-- **Create / GC** live in the branch menu (not the project menu).
-- **Remove:** host supports `git_worktree_remove` for non-main trees; UI wiring may lag — prefer GC for stale admin records.
+- **Create / remove / GC** live in the branch menu (not the project menu).
+- **Remove:** per-row trash on **non-main** linked worktrees → in-app confirm → host `git_worktree_remove` (force retry if dirty). Never removes main. Removing the active cwd switches to main. Use **GC** for stale admin records of folders already gone.
 
 ### Create worktree
 
@@ -45,6 +45,15 @@ Name rules: letters, digits, `.` `_` `-` only; max 64; no path separators; must 
 
 Errors are shown when the folder is not a git repository, `git` is missing, the path already exists, or `git worktree add` fails (message surfaced in the dialog).
 
+### Remove live worktree
+
+Per-row trash icon on linked (non-main) entries in the branch menu:
+
+1. In-app confirm shows path + branch; warns if removing the active cwd.
+2. Host runs `git worktree remove [--force] <path>` with argv (no shell); refuses main.
+3. On dirty/locked failure, second confirm offers force.
+4. Refresh list; if the removed path was the active project, switch to main worktree.
+
 ### GC / prune
 
 Menu action **Clean stale worktrees…** → GlassModal dry-run preview (`git worktree prune -v --dry-run`), then apply. Optional force → `--expire now`. Does **not** delete live worktrees. Host: `git_worktree_gc`.
@@ -61,5 +70,5 @@ Menu action **Clean stale worktrees…** → GlassModal dry-run preview (`git wo
 - Frontend pure helpers: `src/lib/gitWorktree.ts` (+ unit tests)
 - UI:
   - Project: `ComposerProjectMenu` (folder only)
-  - Branch / worktree: `ComposerWorktreeMenu` (context bar chip)
-  - Create + GC dialogs in `App.tsx`
+  - Branch / worktree: `ComposerWorktreeMenu` (context bar chip; per-row remove)
+  - Create + remove confirm + GC dialogs in `App.tsx`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -279,9 +279,12 @@ import { ComposerProjectMenu } from "@/components/ComposerProjectMenu";
 import { ComposerWorktreeMenu } from "@/components/ComposerWorktreeMenu";
 import {
   buildWorktreeSiblingPath,
+  canRemoveWorktree,
   mainWorktreePath,
   pathsEqual,
   sanitizeWorktreeName,
+  worktreeLabel,
+  worktreeRemoveErrorSuggestsForce,
 } from "@/lib/gitWorktree";
 import { isProjectPathMissing } from "@/lib/projectPath";
 import {
@@ -7435,6 +7438,106 @@ export default function App() {
     ],
   );
 
+  /**
+   * Remove a live linked worktree via host `git_worktree_remove`.
+   * Never removes main. Dirty trees: first attempt without force, then
+   * in-app confirm for force. If the active cwd is removed, switch to main.
+   */
+  const executeWorktreeRemove = useCallback(
+    async (wt: api.GitWorktreeEntry, force: boolean) => {
+      if (!api.isTauri() || !canRemoveWorktree(wt)) return;
+      const mainPath =
+        mainWorktreePath(gitWorktrees) || activeProject?.path?.trim() || "";
+      if (!mainPath) {
+        showToast(tr("composer.worktreeRemoveFailed"), 4000);
+        return;
+      }
+      const name = worktreeLabel(wt);
+      const wasCurrent = pathsEqual(wt.path, activeProject?.path);
+      try {
+        await api.gitWorktreeRemove({
+          projectPath: mainPath,
+          worktreePath: wt.path,
+          force,
+        });
+        if (wasCurrent) {
+          const main =
+            gitWorktrees.find((w) => w.isMain) ??
+            gitWorktrees.find((w) => pathsEqual(w.path, mainPath)) ??
+            null;
+          if (main) {
+            await switchToWorktree(main);
+          } else {
+            await refreshGitWorktrees();
+          }
+        } else {
+          await refreshGitWorktrees();
+        }
+        showToast(
+          tr("composer.worktreeRemoveDone", { name }),
+          2800,
+        );
+      } catch (e) {
+        const err = String(e);
+        if (!force && worktreeRemoveErrorSuggestsForce(err)) {
+          setAppDialog({
+            kind: "confirm",
+            title: tr("composer.worktreeRemoveTitle"),
+            message: `${tr("composer.worktreeRemoveForce")}\n\n${err}`,
+            confirmLabel: tr("composer.worktreeRemove"),
+            danger: true,
+            onConfirm: () => {
+              void executeWorktreeRemove(wt, true);
+            },
+          });
+          return;
+        }
+        showToast(
+          `${tr("composer.worktreeRemoveFailed")}: ${err}`,
+          5000,
+        );
+      }
+    },
+    [
+      activeProject?.path,
+      gitWorktrees,
+      refreshGitWorktrees,
+      showToast,
+      switchToWorktree,
+      tr,
+    ],
+  );
+
+  const confirmRemoveWorktree = useCallback(
+    (wt: api.GitWorktreeEntry) => {
+      if (!canRemoveWorktree(wt)) return;
+      const branch =
+        wt.branch?.trim() || tr("composer.worktreeDetached");
+      const isCurrent = pathsEqual(wt.path, activeProject?.path);
+      const parts = [
+        tr("composer.worktreeRemoveHint"),
+        tr("composer.worktreeRemoveConfirm", {
+          branch,
+          path: wt.path,
+        }),
+      ];
+      if (isCurrent) {
+        parts.push(tr("composer.worktreeRemoveCurrentWarn"));
+      }
+      setAppDialog({
+        kind: "confirm",
+        title: tr("composer.worktreeRemoveTitle"),
+        message: parts.join("\n\n"),
+        confirmLabel: tr("composer.worktreeRemove"),
+        danger: true,
+        onConfirm: () => {
+          void executeWorktreeRemove(wt, false);
+        },
+      });
+    },
+    [activeProject?.path, executeWorktreeRemove, tr],
+  );
+
   const openWorktreeCreate = useCallback((opts?: { startNewChat?: boolean }) => {
     setWorktreeCreateName("");
     setWorktreeCreateRef("");
@@ -10670,6 +10773,8 @@ export default function App() {
                       worktreeNew: tr("composer.worktreeNew"),
                       worktreeNewChat: tr("composer.worktreeNewChat"),
                       worktreeGc: tr("composer.worktreeGc"),
+                      worktreeRemove: tr("composer.worktreeRemove"),
+                      worktreeRemoveTip: tr("composer.worktreeRemoveTip"),
                     }}
                     onSwitch={(wt) => {
                       void switchToWorktree(wt);
@@ -10679,6 +10784,7 @@ export default function App() {
                       openWorktreeCreate({ startNewChat: true })
                     }
                     onGc={openWorktreeGc}
+                    onRemove={confirmRemoveWorktree}
                     onOpen={refreshGitWorktrees}
                   />
                 ) : null}

--- a/src/components/ComposerWorktreeMenu.tsx
+++ b/src/components/ComposerWorktreeMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Composer branch / worktree chip — switch linked worktrees, create, GC.
+ * Composer branch / worktree chip — switch linked worktrees, create, remove, GC.
  * Lives next to the project picker on the new-session context bar.
  */
 
@@ -13,7 +13,11 @@ import {
 } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { useFloatingMenu } from "@/lib/floatingMenu";
-import { pathsEqual, worktreeLabel } from "@/lib/gitWorktree";
+import {
+  canRemoveWorktree,
+  pathsEqual,
+  worktreeLabel,
+} from "@/lib/gitWorktree";
 import type { GitWorktreeEntry } from "@/lib/api";
 
 export type ComposerWorktreeMenuLabels = {
@@ -29,6 +33,9 @@ export type ComposerWorktreeMenuLabels = {
   worktreeNew: string;
   worktreeNewChat: string;
   worktreeGc: string;
+  /** Per-row remove control (non-main only). */
+  worktreeRemove?: string;
+  worktreeRemoveTip?: string;
 };
 
 type Props = {
@@ -53,6 +60,8 @@ type Props = {
   onCreate: () => void;
   onCreateAndChat: () => void;
   onGc: () => void;
+  /** Remove a live linked worktree (never main). Parent confirms + calls host. */
+  onRemove?: (wt: GitWorktreeEntry) => void;
   onOpen?: () => void;
 };
 
@@ -70,6 +79,7 @@ export function ComposerWorktreeMenu({
   onCreate,
   onCreateAndChat,
   onGc,
+  onRemove,
   onOpen,
 }: Props) {
   const [open, setOpen] = useState(false);
@@ -95,6 +105,10 @@ export function ComposerWorktreeMenu({
   );
   // Soft-refresh loading should not re-anchor / dim when we already have rows.
   const showLoading = worktreesLoading && worktrees.length === 0;
+  const removeLabel =
+    labels.worktreeRemoveTip ||
+    labels.worktreeRemove ||
+    "Remove worktree";
 
   const { pos, style: popStyle } = useFloatingMenu({
     open,
@@ -186,34 +200,62 @@ export function ComposerWorktreeMenu({
                   ]
                     .filter(Boolean)
                     .join(" · ");
+                  const showRemove =
+                    !!onRemove && canRemoveWorktree(wt);
                   return (
                     <li key={wt.path} className="cwm__row">
-                      <button
-                        type="button"
-                        role="menuitem"
-                        className={
-                          "cmm__opt cwm__item" + (isCurrent ? " is-active" : "")
-                        }
-                        title={wt.path}
-                        disabled={isCurrent}
-                        onClick={() => {
-                          if (isCurrent) return;
-                          setOpen(false);
-                          onSwitch(wt);
-                        }}
-                      >
-                        <span className="cwm__item-main">
-                          <span className="cwm__item-name">{name}</span>
-                          {meta ? (
-                            <span className="cwm__item-meta">{meta}</span>
-                          ) : null}
-                        </span>
-                        {isCurrent ? (
-                          <span className="cmm__opt-check" aria-hidden>
-                            <IconCheck size={16} />
+                      <div className="cwm__row-inner">
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className={
+                            "cmm__opt cwm__item" +
+                            (isCurrent ? " is-active" : "")
+                          }
+                          title={wt.path}
+                          disabled={isCurrent}
+                          onClick={() => {
+                            if (isCurrent) return;
+                            setOpen(false);
+                            onSwitch(wt);
+                          }}
+                        >
+                          <span className="cwm__item-main">
+                            <span className="cwm__item-name">{name}</span>
+                            {meta ? (
+                              <span className="cwm__item-meta">{meta}</span>
+                            ) : null}
                           </span>
+                          {isCurrent ? (
+                            <span className="cmm__opt-check" aria-hidden>
+                              <IconCheck size={16} />
+                            </span>
+                          ) : null}
+                        </button>
+                        {showRemove ? (
+                          <Tip label={removeLabel}>
+                            <button
+                              type="button"
+                              className="cwm__row-remove"
+                              aria-label={
+                                labels.worktreeRemove || removeLabel
+                              }
+                              title={removeLabel}
+                              disabled={
+                                disabled || worktreesLoading || showLoading
+                              }
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                setOpen(false);
+                                onRemove?.(wt);
+                              }}
+                            >
+                              <IconTrash size={14} aria-hidden />
+                            </button>
+                          </Tip>
                         ) : null}
-                      </button>
+                      </div>
                     </li>
                   );
                 })}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1870,6 +1870,18 @@ const en = {
   "composer.worktreeGcConfirm": "Clean up",
   "composer.worktreeGcDone": "Cleaned {n} stale worktree record(s)",
   "composer.worktreeGcDoneNone": "Nothing to clean",
+  "composer.worktreeRemove": "Remove worktree",
+  "composer.worktreeRemoveTip": "Remove this linked worktree",
+  "composer.worktreeRemoveTitle": "Remove git worktree",
+  "composer.worktreeRemoveHint":
+    "Permanently deletes this worktree folder via git worktree remove. The branch is kept. This cannot be undone.",
+  "composer.worktreeRemoveConfirm": "{branch}\n{path}",
+  "composer.worktreeRemoveDone": "Removed worktree {name}",
+  "composer.worktreeRemoveFailed": "Could not remove worktree",
+  "composer.worktreeRemoveForce":
+    "This worktree has local changes (or is locked). Force-remove and delete the folder?",
+  "composer.worktreeRemoveCurrentWarn":
+    "You are currently using this worktree. After removal, the session will switch to the main worktree.",
   "settings.preferredAgent": "Agent definition",
   "settings.preferredAgent.source.project": "project",
   "settings.preferredAgent.source.user": "user",
@@ -3929,6 +3941,18 @@ const zh: Record<MessageKey, string> = {
   "composer.worktreeGcConfirm": "清理",
   "composer.worktreeGcDone": "已清理 {n} 条失效 worktree 记录",
   "composer.worktreeGcDoneNone": "没有需要清理的内容",
+  "composer.worktreeRemove": "移除 worktree",
+  "composer.worktreeRemoveTip": "移除此关联 worktree",
+  "composer.worktreeRemoveTitle": "移除 Git worktree",
+  "composer.worktreeRemoveHint":
+    "将通过 git worktree remove 永久删除该 worktree 目录。分支会保留。此操作不可撤销。",
+  "composer.worktreeRemoveConfirm": "{branch}\n{path}",
+  "composer.worktreeRemoveDone": "已移除 worktree {name}",
+  "composer.worktreeRemoveFailed": "无法移除 worktree",
+  "composer.worktreeRemoveForce":
+    "该 worktree 有本地修改（或已锁定）。是否强制移除并删除目录？",
+  "composer.worktreeRemoveCurrentWarn":
+    "当前正在使用此 worktree。移除后会话将切换到主 worktree。",
   "settings.preferredAgent": "Agent definition",
   "settings.preferredAgent.source.project": "project",
   "settings.preferredAgent.source.user": "user",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1810,6 +1810,18 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.worktreeGcConfirm": "清理",
   "composer.worktreeGcDone": "已清理 {n} 條失效 worktree 記錄",
   "composer.worktreeGcDoneNone": "沒有需要清理的內容",
+  "composer.worktreeRemove": "移除 worktree",
+  "composer.worktreeRemoveTip": "移除此關聯 worktree",
+  "composer.worktreeRemoveTitle": "移除 Git worktree",
+  "composer.worktreeRemoveHint":
+    "將透過 git worktree remove 永久刪除該 worktree 目錄。分支會保留。此操作無法復原。",
+  "composer.worktreeRemoveConfirm": "{branch}\n{path}",
+  "composer.worktreeRemoveDone": "已移除 worktree {name}",
+  "composer.worktreeRemoveFailed": "無法移除 worktree",
+  "composer.worktreeRemoveForce":
+    "該 worktree 有本地修改（或已鎖定）。是否強制移除並刪除目錄？",
+  "composer.worktreeRemoveCurrentWarn":
+    "目前正在使用此 worktree。移除後會話將切換到主 worktree。",
   "settings.preferredAgent": "Agent definition",
   "settings.preferredAgent.source.project": "project",
   "settings.preferredAgent.source.user": "user",

--- a/src/lib/gitWorktree.test.ts
+++ b/src/lib/gitWorktree.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildWorktreeGcArgs,
   buildWorktreeSiblingPath,
+  canRemoveWorktree,
   countWorktreePruneLines,
   findWorktreeAt,
   mainWorktreePath,
@@ -12,6 +13,7 @@ import {
   sanitizeWorktreeName,
   siblingWorktrees,
   worktreeLabel,
+  worktreeRemoveErrorSuggestsForce,
 } from "./gitWorktree";
 
 const SAMPLE = `worktree /Users/me/repo
@@ -98,6 +100,31 @@ describe("worktree path builder", () => {
     // Path preview uses main even when active cwd is a linked worktree.
     const main = mainWorktreePath(parseWorktreePorcelain(SAMPLE))!;
     expect(buildWorktreeSiblingPath(main, "new")).toBe("/Users/me/repo-new");
+  });
+});
+
+describe("canRemoveWorktree", () => {
+  it("allows linked worktrees only", () => {
+    const list = parseWorktreePorcelain(SAMPLE);
+    expect(canRemoveWorktree(list[0])).toBe(false);
+    expect(canRemoveWorktree(list[1])).toBe(true);
+    expect(canRemoveWorktree(list[2])).toBe(true);
+    expect(canRemoveWorktree(null)).toBe(false);
+    expect(canRemoveWorktree(undefined)).toBe(false);
+  });
+});
+
+describe("worktreeRemoveErrorSuggestsForce", () => {
+  it("detects dirty / force hints from git", () => {
+    expect(
+      worktreeRemoveErrorSuggestsForce(
+        "fatal: '/tmp/repo-feat' contains modified or untracked files, use --force to delete it",
+      ),
+    ).toBe(true);
+    expect(worktreeRemoveErrorSuggestsForce("use -f to delete")).toBe(true);
+    expect(worktreeRemoveErrorSuggestsForce("worktree is locked")).toBe(true);
+    expect(worktreeRemoveErrorSuggestsForce("not a worktree")).toBe(false);
+    expect(worktreeRemoveErrorSuggestsForce("")).toBe(false);
   });
 });
 

--- a/src/lib/gitWorktree.ts
+++ b/src/lib/gitWorktree.ts
@@ -280,3 +280,34 @@ export function mainWorktreePath(
   const main = worktrees.find((w) => w.isMain) ?? worktrees[0];
   return main?.path ?? null;
 }
+
+/**
+ * Whether a worktree may be removed from the UI.
+ * Main / primary checkout is never removable (matches host refuse_remove_main).
+ */
+export function canRemoveWorktree(
+  wt: GitWorktreeEntry | null | undefined,
+): boolean {
+  return !!wt && !wt.isMain;
+}
+
+/**
+ * Heuristic: `git worktree remove` failed because the tree is dirty / locked
+ * and may succeed with `--force`.
+ */
+export function worktreeRemoveErrorSuggestsForce(
+  message: string | null | undefined,
+): boolean {
+  const m = (message ?? "").toLowerCase();
+  if (!m) return false;
+  return (
+    m.includes("--force") ||
+    m.includes("use -f") ||
+    m.includes("modified or untracked") ||
+    m.includes("contains modified") ||
+    m.includes("is dirty") ||
+    m.includes("not empty") ||
+    m.includes("uncommitted") ||
+    m.includes("locked")
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7333,6 +7333,48 @@ button.composer__context-item {
   min-width: 0;
 }
 
+.cwm__row-inner {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cwm__row-inner .cwm__item {
+  flex: 1;
+  min-width: 0;
+}
+
+.cwm__row-remove {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  min-height: 36px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.cwm__row-remove:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--danger, #e5484d);
+}
+
+.cwm__row-remove:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.cwm__row-remove svg {
+  flex-shrink: 0;
+}
+
 .cwm__item {
   width: 100%;
   align-items: center;


### PR DESCRIPTION
## Summary
- Per-row trash control on **non-main** linked worktrees in `ComposerWorktreeMenu` (main is never removable)
- In-app confirm via `setAppDialog` (no `window.confirm`); first attempt without force, second confirm if git reports dirty/locked
- Host `api.gitWorktreeRemove` against main repo path; refresh list; if active cwd was removed, switch session/project to main worktree
- i18n en / zh / zh-TW; pure helpers `canRemoveWorktree` + `worktreeRemoveErrorSuggestsForce` with unit tests; CHANGELOG + wiki note

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/gitWorktree.test.ts` (+ i18n key parity)
- [ ] Manual: open branch chip → trash on linked worktree → confirm → folder gone, list refresh
- [ ] Manual: remove active worktree → switches to main + toast
- [ ] Manual: dirty worktree → force confirm → remove succeeds
- [ ] Manual: main row has no remove control; create/GC still work