### PR TITLE
feat(search): command palette quick actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Command palette actions**: search panel lists filterable quick actions (Settings sections, Doctor, shortcuts help, automations, tasks panel, new chat, add project) above chats/projects
 - **General workspace**: app-managed `{app_data}/workspaces/general` project (`system:general`) for chats without a user folder — agent can create/edit files without the “bind a project first” toast; always trusted, pinned, not removable
 - **Session Markdown export options**: choose thinking + tool summaries; download `.md` or copy to clipboard (session menu / `/export`)
 - **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,6 +202,11 @@ import {
   type SessionContentHit,
 } from "@/lib/sessionSearch";
 import {
+  defaultPaletteActions,
+  filterPaletteActions,
+  type PaletteActionDef,
+} from "@/lib/paletteActions";
+import {
   sessionExportFilename,
   sessionToMarkdown,
 } from "@/lib/sessionExport";
@@ -350,6 +355,12 @@ import {
   IconCheck,
   IconList,
   IconFileText,
+  IconSettings,
+  IconDoctor,
+  IconKeyboard,
+  IconAppearance,
+  IconInfo,
+  IconPlug,
 } from "@/components/icons";
 import { PhoneAccountSheet } from "@/components/PhoneAccountSheet";
 import { PhoneComposerToolsSheet } from "@/components/PhoneComposerToolsSheet";
@@ -418,6 +429,41 @@ import {
   WindowControls,
   toggleMaximizeFromTitlebar,
 } from "@/components/WindowControls";
+
+/** Icon for a command-palette action row (stable by action id). */
+function paletteActionIcon(id: string) {
+  const size = 15;
+  switch (id) {
+    case "new-chat":
+      return <IconSquarePen size={size} />;
+    case "add-project":
+      return <IconFolder size={size} />;
+    case "open-automations":
+      return <IconScheduled size={size} />;
+    case "open-tasks":
+      return <IconList size={size} />;
+    case "doctor":
+      return <IconDoctor size={size} />;
+    case "shortcuts-help":
+    case "settings-shortcuts":
+      return <IconKeyboard size={size} />;
+    case "settings-appearance":
+      return <IconAppearance size={size} />;
+    case "settings-account":
+      return <IconUser size={size} />;
+    case "settings-extensions":
+      return <IconPlug size={size} />;
+    case "settings-runtime":
+      return <IconDoctor size={size} />;
+    case "settings-remote":
+      return <IconDeviceMobile size={size} />;
+    case "settings-about":
+      return <IconInfo size={size} />;
+    case "settings-general":
+    default:
+      return <IconSettings size={size} />;
+  }
+}
 
 interface Project {
   id: string;
@@ -4427,6 +4473,11 @@ export default function App() {
     [searchQuery, searchHits.matchedSessions, contentSearchHits],
   );
 
+  const paletteActionHits = useMemo(
+    () => filterPaletteActions(searchQuery, defaultPaletteActions(), tr),
+    [searchQuery, tr],
+  );
+
   const connPill = useMemo(
     () => connPillForState(session.state, connecting),
     [session.state, connecting],
@@ -7607,6 +7658,65 @@ export default function App() {
 
   const openDoctor = () => {
     setShowDoctor(true);
+  };
+
+  const runPaletteAction = (action: PaletteActionDef) => {
+    setShowSearch(false);
+    setSearchQuery("");
+    switch (action.id) {
+      case "new-chat":
+        void newChat(activeProject);
+        break;
+      case "add-project":
+        void addProject(false);
+        break;
+      case "open-automations":
+        navigateAutomations();
+        break;
+      case "open-tasks":
+        setAppView("workbench");
+        setMainPane("chat");
+        setTasksPanelOpen(true);
+        if (
+          typeof window !== "undefined" &&
+          window.location.hash.includes("settings")
+        ) {
+          window.location.hash = "#/workbench";
+        }
+        break;
+      case "doctor":
+        setShowDoctor(true);
+        break;
+      case "shortcuts-help":
+        setShowShortcuts(true);
+        break;
+      case "settings-general":
+        navigateSettings("general");
+        break;
+      case "settings-appearance":
+        navigateSettings("appearance");
+        break;
+      case "settings-account":
+        navigateSettings("account");
+        break;
+      case "settings-extensions":
+        navigateSettings("extensions");
+        break;
+      case "settings-runtime":
+        navigateSettings("runtime");
+        break;
+      case "settings-remote":
+        navigateSettings("remote_im");
+        break;
+      case "settings-shortcuts":
+        navigateSettings("shortcuts");
+        break;
+      case "settings-about":
+        navigateSettings("about");
+        break;
+      default:
+        break;
+    }
   };
 
   // Keep tray menu actions on latest closures (listeners registered once).
@@ -12225,6 +12335,26 @@ export default function App() {
                 <IconClose size={16} />
               </button>
             </div>
+            {paletteActionHits.length > 0 && (
+              <>
+                <div className="search-panel__section">
+                  {tr("search.actions")}
+                </div>
+                {paletteActionHits.map((action) => (
+                  <button
+                    key={action.id}
+                    type="button"
+                    className="search-panel__row"
+                    onClick={() => runPaletteAction(action)}
+                  >
+                    {paletteActionIcon(action.id)}
+                    <span className="search-panel__title">
+                      {tr(action.labelKey)}
+                    </span>
+                  </button>
+                ))}
+              </>
+            )}
             {searchHits.matchedProjects.length > 0 && (
               <>
                 <div className="search-panel__section">
@@ -12307,34 +12437,6 @@ export default function App() {
                 </button>
               );
             })}
-            <div className="search-panel__foot">
-              <button
-                type="button"
-                className="search-panel__row"
-                onClick={() => {
-                  setShowSearch(false);
-                  void newChat(activeProject);
-                }}
-              >
-                <IconSquarePen size={15} />
-                <span className="search-panel__title">
-                  {tr("search.newChat")}
-                </span>
-              </button>
-              <button
-                type="button"
-                className="search-panel__row"
-                onClick={() => {
-                  setShowSearch(false);
-                  void addProject(false);
-                }}
-              >
-                <IconFolder size={15} />
-                <span className="search-panel__title">
-                  {tr("sidebar.addProject")}
-                </span>
-              </button>
-            </div>
           </div>
         </div>
       )}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -579,9 +579,10 @@ const en = {
 
   // Search panel
   "search.title": "Search",
-  "search.placeholder": "Search chats, projects, or message content…",
+  "search.placeholder": "Search chats, projects, actions, or message content…",
   "search.projects": "Projects",
   "search.chats": "Chats",
+  "search.actions": "Actions",
   "search.noMatches": "No matches",
   "search.newChat": "New chat",
   "search.addProject": "Add project",
@@ -2671,9 +2672,10 @@ const zh: Record<MessageKey, string> = {
   "policy.yoloConfirm2": "再次确认：启用始终批准？工具将不再弹窗询问。",
 
   "search.title": "搜索",
-  "search.placeholder": "搜索会话、项目或消息内容…",
+  "search.placeholder": "搜索会话、项目、操作或消息内容…",
   "search.projects": "项目",
   "search.chats": "会话",
+  "search.actions": "操作",
   "search.noMatches": "无匹配结果",
   "search.newChat": "新建会话",
   "search.addProject": "添加项目",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -552,9 +552,10 @@ export const zhTW: Record<MessageKey, string> = {
   "policy.yoloConfirm2": "再次確認：啟用一律核准？工具將不再彈出視窗詢問。",
 
   "search.title": "搜尋",
-  "search.placeholder": "搜尋對話、專案或訊息內容…",
+  "search.placeholder": "搜尋對話、專案、操作或訊息內容…",
   "search.projects": "專案",
   "search.chats": "對話",
+  "search.actions": "操作",
   "search.noMatches": "無相符結果",
   "search.newChat": "新增對話",
   "search.addProject": "新增專案",

--- a/src/lib/paletteActions.test.ts
+++ b/src/lib/paletteActions.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultPaletteActions,
+  filterPaletteActions,
+  type PaletteActionDef,
+} from "./paletteActions";
+
+const identityT = (key: string) => key;
+
+describe("defaultPaletteActions", () => {
+  it("includes stable ids for create, navigate, doctor, shortcuts, and settings", () => {
+    const ids = defaultPaletteActions().map((a) => a.id);
+    expect(ids).toEqual([
+      "new-chat",
+      "add-project",
+      "open-automations",
+      "open-tasks",
+      "doctor",
+      "shortcuts-help",
+      "settings-general",
+      "settings-appearance",
+      "settings-account",
+      "settings-extensions",
+      "settings-runtime",
+      "settings-remote",
+      "settings-shortcuts",
+      "settings-about",
+    ]);
+  });
+
+  it("uses MessageKey labelKeys and non-empty keywords", () => {
+    for (const a of defaultPaletteActions()) {
+      expect(a.labelKey.length).toBeGreaterThan(0);
+      expect(a.keywords.length).toBeGreaterThan(0);
+      expect(a.id).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it("has unique ids", () => {
+    const ids = defaultPaletteActions().map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("filterPaletteActions", () => {
+  const catalog = defaultPaletteActions();
+
+  it("empty query returns all actions", () => {
+    const hits = filterPaletteActions("", catalog);
+    expect(hits).toHaveLength(catalog.length);
+    expect(hits.map((h) => h.id)).toEqual(catalog.map((a) => a.id));
+  });
+
+  it("whitespace-only query returns all actions", () => {
+    expect(filterPaletteActions("   ", catalog)).toHaveLength(catalog.length);
+  });
+
+  it("matches by id fragment", () => {
+    const hits = filterPaletteActions("settings-app", catalog);
+    expect(hits.map((h) => h.id)).toContain("settings-appearance");
+  });
+
+  it("matches by keyword", () => {
+    const doctor = filterPaletteActions("diagnostics", catalog);
+    expect(doctor.map((h) => h.id)).toEqual(["doctor"]);
+
+    const theme = filterPaletteActions("wallpaper", catalog);
+    expect(theme.map((h) => h.id)).toEqual(["settings-appearance"]);
+
+    const auto = filterPaletteActions("cron", catalog);
+    expect(auto.map((h) => h.id)).toEqual(["open-automations"]);
+  });
+
+  it("matches translated label when t is provided", () => {
+    const t = (key: string) => {
+      if (key === "doctor.title") return "系统诊断";
+      if (key === "settings.nav.general") return "通用";
+      return key;
+    };
+    expect(filterPaletteActions("诊断", catalog, t).map((h) => h.id)).toEqual([
+      "doctor",
+    ]);
+    expect(filterPaletteActions("通用", catalog, t).map((h) => h.id)).toEqual([
+      "settings-general",
+    ]);
+  });
+
+  it("matches without t only via id/keywords/labelKey", () => {
+    const hits = filterPaletteActions("settings.nav.about", catalog);
+    expect(hits.map((h) => h.id)).toEqual(["settings-about"]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(filterPaletteActions("DOCTOR", catalog).map((h) => h.id)).toEqual([
+      "doctor",
+    ]);
+    expect(filterPaletteActions("New Chat", catalog).map((h) => h.id)).toContain(
+      "new-chat",
+    );
+  });
+
+  it("respects limit", () => {
+    expect(filterPaletteActions("", catalog, undefined, { limit: 3 })).toHaveLength(
+      3,
+    );
+    const manySettings = filterPaletteActions("settings", catalog, identityT, {
+      limit: 2,
+    });
+    expect(manySettings).toHaveLength(2);
+  });
+
+  it("returns empty for nonsense query", () => {
+    expect(filterPaletteActions("zzzz-not-a-real-action", catalog)).toEqual([]);
+  });
+
+  it("works on a custom actions list", () => {
+    const custom: PaletteActionDef[] = [
+      {
+        id: "alpha",
+        labelKey: "search.newChat",
+        keywords: ["foo"],
+      },
+      {
+        id: "beta",
+        labelKey: "search.chats",
+        keywords: ["bar"],
+      },
+    ];
+    expect(filterPaletteActions("foo", custom).map((a) => a.id)).toEqual([
+      "alpha",
+    ]);
+    expect(filterPaletteActions("", custom)).toHaveLength(2);
+  });
+});

--- a/src/lib/paletteActions.ts
+++ b/src/lib/paletteActions.ts
@@ -1,0 +1,206 @@
+/**
+ * Command-palette quick actions — pure catalog + filter.
+ * UI (App search panel) maps ids to existing openers (settings hash, doctor, etc.).
+ */
+
+import type { MessageKey } from "@/i18n";
+
+export type PaletteActionDef = {
+  /** Stable id used by the host to dispatch (e.g. `settings-general`). */
+  id: string;
+  /** i18n key for the row label. */
+  labelKey: MessageKey;
+  /** English (and optional alias) tokens for free-text match. */
+  keywords: string[];
+  /** Optional UI group hint (host may ignore). */
+  group?: string;
+};
+
+/** Full default catalog — only actions that already exist in App. */
+export function defaultPaletteActions(): PaletteActionDef[] {
+  return [
+    {
+      id: "new-chat",
+      labelKey: "search.newChat",
+      keywords: ["new", "chat", "conversation", "session", "compose"],
+      group: "create",
+    },
+    {
+      id: "add-project",
+      labelKey: "sidebar.addProject",
+      keywords: ["add", "project", "folder", "open folder", "workspace"],
+      group: "create",
+    },
+    {
+      id: "open-automations",
+      labelKey: "automations.title",
+      keywords: [
+        "automations",
+        "scheduled",
+        "schedule",
+        "cron",
+        "tasks list",
+        "recurring",
+      ],
+      group: "navigate",
+    },
+    {
+      id: "open-tasks",
+      labelKey: "tasks.showPanel",
+      keywords: [
+        "tasks",
+        "agent tasks",
+        "tools panel",
+        "activity",
+        "running tools",
+      ],
+      group: "navigate",
+    },
+    {
+      id: "doctor",
+      labelKey: "doctor.title",
+      keywords: ["doctor", "diagnostics", "health", "cli check", "troubleshoot"],
+      group: "diagnose",
+    },
+    {
+      id: "shortcuts-help",
+      labelKey: "shortcuts.help",
+      keywords: ["shortcuts", "keyboard", "hotkeys", "keymap", "help", "?"],
+      group: "help",
+    },
+    {
+      id: "settings-general",
+      labelKey: "settings.nav.general",
+      keywords: ["settings", "general", "preferences", "prefs", "composer"],
+      group: "settings",
+    },
+    {
+      id: "settings-appearance",
+      labelKey: "settings.nav.appearance",
+      keywords: [
+        "settings",
+        "appearance",
+        "theme",
+        "dark",
+        "light",
+        "wallpaper",
+        "skin",
+      ],
+      group: "settings",
+    },
+    {
+      id: "settings-account",
+      labelKey: "settings.nav.account",
+      keywords: [
+        "settings",
+        "account",
+        "login",
+        "providers",
+        "api key",
+        "auth",
+      ],
+      group: "settings",
+    },
+    {
+      id: "settings-extensions",
+      labelKey: "settings.nav.extensions",
+      keywords: [
+        "settings",
+        "extensions",
+        "plugins",
+        "skills",
+        "mcp",
+        "hooks",
+        "marketplace",
+      ],
+      group: "settings",
+    },
+    {
+      id: "settings-runtime",
+      labelKey: "settings.nav.runtime",
+      keywords: [
+        "settings",
+        "runtime",
+        "cli",
+        "connection",
+        "network",
+        "pool",
+        "tools",
+      ],
+      group: "settings",
+    },
+    {
+      id: "settings-remote",
+      labelKey: "settings.nav.remoteIm",
+      keywords: [
+        "settings",
+        "remote",
+        "remote control",
+        "im",
+        "mirror",
+        "phone",
+        "feishu",
+        "telegram",
+      ],
+      group: "settings",
+    },
+    {
+      id: "settings-shortcuts",
+      labelKey: "settings.nav.shortcuts",
+      keywords: ["settings", "keyboard", "shortcuts", "hotkeys", "bindings"],
+      group: "settings",
+    },
+    {
+      id: "settings-about",
+      labelKey: "settings.nav.about",
+      keywords: ["settings", "about", "version", "update", "license"],
+      group: "settings",
+    },
+  ];
+}
+
+/**
+ * Filter palette actions by free-text query.
+ * - Empty query → all actions (optionally capped by `limit`).
+ * - Non-empty → match id, keywords, and translated label (when `t` is provided).
+ */
+export function filterPaletteActions(
+  query: string,
+  actions: readonly PaletteActionDef[],
+  t?: (key: MessageKey) => string,
+  opts?: { limit?: number },
+): PaletteActionDef[] {
+  const limit = opts?.limit ?? 50;
+  const q = query.trim().toLowerCase();
+  if (!q) return actions.slice(0, limit);
+
+  const hits: PaletteActionDef[] = [];
+  for (const action of actions) {
+    if (hits.length >= limit) break;
+    if (matchesPaletteAction(action, q, t)) hits.push(action);
+  }
+  return hits;
+}
+
+function matchesPaletteAction(
+  action: PaletteActionDef,
+  q: string,
+  t?: (key: MessageKey) => string,
+): boolean {
+  const hay: string[] = [
+    action.id.toLowerCase(),
+    action.labelKey.toLowerCase(),
+    ...action.keywords.map((k) => k.toLowerCase()),
+  ];
+  if (t) hay.push(t(action.labelKey).toLowerCase());
+
+  // Full-string substring (handles "settings-general", single keywords, labels).
+  if (hay.some((h) => h.includes(q))) return true;
+
+  // Multi-word: every token must hit somewhere (e.g. "New Chat" → new + chat).
+  const tokens = q.split(/[\s/_-]+/).filter(Boolean);
+  if (tokens.length > 1) {
+    return tokens.every((tok) => hay.some((h) => h.includes(tok)));
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- Adds a pure `paletteActions` catalog + `filterPaletteActions` (unit-tested) for command-palette quick actions
- Search panel shows an **Actions** section (filterable) above projects/chats
- Dispatches to existing openers only: Settings deep links (`navigateSettings` / `buildSettingsHash`), Doctor, shortcuts help, automations, tasks panel, new chat, add project
- Reuses existing i18n labels; new keys: `search.actions` + updated `search.placeholder` (en / zh / zh-TW)

## Test plan
- [x] `pnpm test -- src/lib/paletteActions.test.ts`
- [x] `pnpm typecheck`
- [ ] Open search palette (⌘K / Ctrl+K): Actions section lists defaults with empty query
- [ ] Type `doctor` / `theme` / `cron` / locale labels → filtered actions
- [ ] Click Settings · Appearance → settings hash + Appearance section
- [ ] Click Doctor / Shortcuts help / Automations / Tasks → existing UI opens
- [ ] New chat / Add project still work from Actions (footer rows removed as duplicates)