### PR TITLE
feat(settings): thinking expand preference in Appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Thinking expand preference in Settings**: Appearance → Thinking blocks — choose auto-collapse (default) vs keep expanded after a reply finishes; searchable via settings catalog (thinking / reasoning / collapse)
 - **General workspace**: app-managed `{app_data}/workspaces/general` project (`system:general`) for chats without a user folder — agent can create/edit files without the “bind a project first” toast; always trusted, pinned, not removable
 - **Session Markdown export options**: choose thinking + tool summaries; download `.md` or copy to clipboard (session menu / `/export`)
 - **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -94,6 +94,11 @@ import {
   type SettingsSectionId,
   type SettingsTabId,
 } from "@/lib/settingsCatalog";
+import {
+  loadThinkingExpandPref,
+  saveThinkingExpandPref,
+  type ThinkingExpandPref,
+} from "@/lib/thinkingPref";
 
 export type { SettingsSectionId } from "@/lib/settingsCatalog";
 
@@ -735,6 +740,10 @@ export function SettingsPage({
   const [wallpaperBusy, setWallpaperBusy] = useState(false);
   const [wallpaperError, setWallpaperError] = useState<string | null>(null);
   const [wallpaperFocusOpen, setWallpaperFocusOpen] = useState(false);
+  /** Thinking block expand preference (localStorage; self-contained). */
+  const [thinkingExpand, setThinkingExpand] = useState<ThinkingExpandPref>(
+    () => loadThinkingExpandPref(),
+  );
   const marqueeRef = useRef<{
     active: boolean;
     dragging: boolean;
@@ -1974,6 +1983,43 @@ export function SettingsPage({
                     {t("settings.themeDark")}
                   </button>
                 </div>
+              </div>
+            </div>
+            <div
+              className={
+                "settings-card" + rowHighlight("settings-anchor-thinkingExpand")
+              }
+              id="settings-anchor-thinkingExpand"
+            >
+              <div className="settings-row">
+                <div className="settings-row__text">
+                  <div className="settings-row__label">
+                    {t("settings.thinkingExpand")}
+                  </div>
+                  <div className="settings-row__desc">
+                    {t("settings.thinkingExpandDesc")}
+                  </div>
+                </div>
+                <Select
+                  value={thinkingExpand}
+                  aria-label={t("settings.thinkingExpand")}
+                  onChange={(v) => {
+                    const pref: ThinkingExpandPref =
+                      v === "keep-open" ? "keep-open" : "auto-collapse";
+                    saveThinkingExpandPref(pref);
+                    setThinkingExpand(pref);
+                  }}
+                  options={[
+                    {
+                      value: "auto-collapse",
+                      label: t("settings.thinkingExpand.autoCollapse"),
+                    },
+                    {
+                      value: "keep-open",
+                      label: t("settings.thinkingExpand.keepOpen"),
+                    },
+                  ]}
+                />
               </div>
             </div>
             {onSkin || onWallpaper ? (

--- a/src/components/lobe-chat/Thinking.tsx
+++ b/src/components/lobe-chat/Thinking.tsx
@@ -17,6 +17,7 @@ import {
   loadThinkingExpandPref,
   saveThinkingExpandPref,
   thinkingDefaultOpenWhenDone,
+  THINKING_PREF_EVENT,
   type ThinkingExpandPref,
 } from "@/lib/thinkingPref";
 import { extractThinkingSummary } from "@/lib/thinkingSummary";
@@ -45,7 +46,9 @@ export function Thinking({
   expandPref?: ThinkingExpandPref;
   onExpandPrefChange?: (pref: ThinkingExpandPref) => void;
 }) {
-  const pref = expandPref ?? loadThinkingExpandPref();
+  const [pref, setPref] = useState<ThinkingExpandPref>(
+    () => expandPref ?? loadThinkingExpandPref(),
+  );
   const [open, setOpen] = useState(() =>
     thinking ? true : thinkingDefaultOpenWhenDone(pref),
   );
@@ -54,6 +57,44 @@ export function Thinking({
     durationMs,
   );
   const userToggled = useRef(false);
+  const thinkingRef = useRef(!!thinking);
+  thinkingRef.current = !!thinking;
+
+  // Honor prop override (tests / parent).
+  useEffect(() => {
+    if (expandPref != null) setPref(expandPref);
+  }, [expandPref]);
+
+  // Settings (or another tab) changed the preference — apply to finished blocks
+  // the user has not manually toggled.
+  useEffect(() => {
+    if (expandPref != null) return;
+    const apply = (next: ThinkingExpandPref) => {
+      setPref(next);
+      if (!thinkingRef.current && !userToggled.current) {
+        setOpen(thinkingDefaultOpenWhenDone(next));
+      }
+    };
+    const onPref = (e: Event) => {
+      const detail = (e as CustomEvent<ThinkingExpandPref>).detail;
+      apply(
+        detail === "keep-open" || detail === "auto-collapse"
+          ? detail
+          : loadThinkingExpandPref(),
+      );
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === "grok.thinkingExpanded") {
+        apply(loadThinkingExpandPref());
+      }
+    };
+    window.addEventListener(THINKING_PREF_EVENT, onPref);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(THINKING_PREF_EVENT, onPref);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [expandPref]);
 
   useEffect(() => {
     if (thinking) {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -857,6 +857,11 @@ const en = {
   "settings.themeSystem": "System",
   "settings.themeLight": "Light",
   "settings.themeDark": "Dark",
+  "settings.thinkingExpand": "Thinking blocks",
+  "settings.thinkingExpandDesc":
+    "After a reply finishes, keep reasoning expanded or collapse it automatically. Streaming still opens live.",
+  "settings.thinkingExpand.autoCollapse": "Auto-collapse when done",
+  "settings.thinkingExpand.keepOpen": "Keep expanded",
   "settings.skin": "Color skin",
   "settings.skinDesc": "Accent and surface palette (works with light/dark)",
   "settings.skin.default": "Default",
@@ -2942,6 +2947,11 @@ const zh: Record<MessageKey, string> = {
   "settings.themeSystem": "跟随系统",
   "settings.themeLight": "浅色",
   "settings.themeDark": "深色",
+  "settings.thinkingExpand": "思考过程",
+  "settings.thinkingExpandDesc":
+    "回复完成后，思考/推理块保持展开，或自动折叠。流式生成时仍会实时展开。",
+  "settings.thinkingExpand.autoCollapse": "完成后自动折叠",
+  "settings.thinkingExpand.keepOpen": "保持展开",
   "settings.skin": "配色皮肤",
   "settings.skinDesc": "强调色与表面色板（可与浅/深色叠加）",
   "settings.skin.default": "默认",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -823,6 +823,11 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.themeSystem": "跟隨系統",
   "settings.themeLight": "淺色",
   "settings.themeDark": "深色",
+  "settings.thinkingExpand": "思考過程",
+  "settings.thinkingExpandDesc":
+    "回覆完成後，思考/推理區塊保持展開，或自動摺疊。串流生成時仍會即時展開。",
+  "settings.thinkingExpand.autoCollapse": "完成後自動摺疊",
+  "settings.thinkingExpand.keepOpen": "保持展開",
   "settings.skin": "配色皮膚",
   "settings.skinDesc": "強調色與表面色板（可與淺/深色疊加）",
   "settings.skin.default": "預設",

--- a/src/lib/settingsCatalog.test.ts
+++ b/src/lib/settingsCatalog.test.ts
@@ -89,10 +89,11 @@ describe("settingsCatalog", () => {
     expect(isSettingsSectionId("nope")).toBe(false);
   });
 
-  it("keywordKeysForSection includes skin/wallpaper and remote control", () => {
+  it("keywordKeysForSection includes skin/wallpaper/thinking and remote control", () => {
     const appearance = keywordKeysForSection("appearance");
     expect(appearance).toContain("settings.skin");
     expect(appearance).toContain("settings.wallpaper");
+    expect(appearance).toContain("settings.thinkingExpand");
     const rim = keywordKeysForSection("remote_im");
     expect(rim).toContain("settings.nav.remoteIm");
     expect(rim).toContain("settings.tab.remoteIm");
@@ -121,7 +122,7 @@ describe("settingsCatalog", () => {
     );
   });
 
-  it("search finds mcp / wallpaper / cli path (zh + en)", () => {
+  it("search finds mcp / wallpaper / thinking / cli path (zh + en)", () => {
     const tZh = createT("zh");
     const tEn = createT("en");
     const mcp = searchSettingsEntries("mcp", tZh, tEn);
@@ -135,6 +136,14 @@ describe("settingsCatalog", () => {
     expect(wallpaperHits.some((h) => h.entry.id === "appearance.wallpaper")).toBe(
       true,
     );
+    const thinking = searchSettingsEntries("thinking", tZh, tEn);
+    expect(thinking.some((h) => h.entry.id === "appearance.thinkingExpand")).toBe(
+      true,
+    );
+    const reasoning = searchSettingsEntries("reasoning", tZh, tEn);
+    expect(
+      reasoning.some((h) => h.entry.id === "appearance.thinkingExpand"),
+    ).toBe(true);
     const cli = searchSettingsEntries("CLI", tZh, tEn);
     expect(cli.some((h) => h.entry.section === "runtime")).toBe(true);
   });

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -451,6 +451,29 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     ],
     keywords: ["wallpaper", "background", "scrim"],
   },
+  {
+    id: "appearance.thinkingExpand",
+    section: "appearance",
+    anchorId: "settings-anchor-thinkingExpand",
+    labelKey: "settings.thinkingExpand",
+    descKeys: [
+      "settings.thinkingExpandDesc",
+      "settings.thinkingExpand.autoCollapse",
+      "settings.thinkingExpand.keepOpen",
+    ],
+    keywords: [
+      "thinking",
+      "reasoning",
+      "collapse",
+      "expand",
+      "thought",
+      "思考",
+      "推理",
+      "折叠",
+      "展開",
+      "展开",
+    ],
+  },
   // ── account ──
   {
     id: "account.official",

--- a/src/lib/thinkingPref.ts
+++ b/src/lib/thinkingPref.ts
@@ -6,6 +6,9 @@
 
 const STORAGE_KEY = "grok.thinkingExpanded";
 
+/** Fired on `window` after a successful save so open Thinking blocks can re-read. */
+export const THINKING_PREF_EVENT = "grok-thinking-pref";
+
 export type ThinkingExpandPref = "auto-collapse" | "keep-open";
 
 export function loadThinkingExpandPref(
@@ -30,6 +33,21 @@ export function saveThinkingExpandPref(
     storage.setItem(STORAGE_KEY, pref);
   } catch {
     /* ignore */
+  }
+  // Notify live UI (Settings → Thinking blocks) without a full reload.
+  // Only when writing default localStorage — unit tests inject memory Storage.
+  if (
+    typeof window !== "undefined" &&
+    typeof localStorage !== "undefined" &&
+    storage === localStorage
+  ) {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(THINKING_PREF_EVENT, { detail: pref }),
+      );
+    } catch {
+      /* ignore */
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Settings → **Appearance** adds a **Thinking blocks** row (`settings-anchor-thinkingExpand`) with auto-collapse (default) vs keep-open
- Loads/saves via existing `loadThinkingExpandPref` / `saveThinkingExpandPref` (`grok.thinkingExpanded` localStorage) — no Host/AppSettings
- `settingsCatalog` entry + en/zh/zh-TW i18n; searchable by thinking / reasoning / collapse
- `saveThinkingExpandPref` dispatches `grok-thinking-pref`; `Thinking.tsx` listens so open finished blocks re-apply without full reload

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/thinkingPref.test.ts src/lib/settingsCatalog.test.ts src/i18n/messages.test.ts`
- [ ] Settings → Appearance: change preference, confirm localStorage `grok.thinkingExpanded`
- [ ] Settings search: “thinking” / “推理” / “collapse” jumps to the row
- [ ] Finished thinking blocks respect keep-open vs auto-collapse; live stream still opens
- [ ] Changing Settings while chat is open updates finished (non-user-toggled) blocks