### PR TITLE
feat(composer): Enter vs ⌘/Ctrl+Enter send key preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Composer send key preference**: Settings → General → Composer — choose Enter to send (default) or ⌘/Ctrl+Enter to send (Enter inserts newline); stored in localStorage
 - **General workspace**: app-managed `{app_data}/workspaces/general` project (`system:general`) for chats without a user folder — agent can create/edit files without the “bind a project first” toast; always trusted, pinned, not removable
 - **Session Markdown export options**: choose thinking + tool summaries; download `.md` or copy to clipboard (session menu / `/export`)
 - **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -244,6 +244,12 @@ import {
   stepPromptHistory,
   type PromptHistoryEntry,
 } from "@/lib/composerPromptHistory";
+import {
+  COMPOSER_SEND_KEY_CHANGED_EVENT,
+  loadComposerSendKeyPref,
+  shouldSendOnKeydown,
+  type ComposerSendKeyPref,
+} from "@/lib/composerSendKey";
 import { PromptHistoryPanel } from "@/components/PromptHistoryPanel";
 import {
   queuePreviewText,
@@ -1027,6 +1033,15 @@ export default function App() {
   /** Where model/permission chips are remembered. */
   const [prefsScope, setPrefsScope] =
     useState<ComposerPrefsScope>("global");
+  /** Enter vs ⌘/Ctrl+Enter to send (localStorage; Settings → Composer). */
+  const [composerSendKeyPref, setComposerSendKeyPref] =
+    useState<ComposerSendKeyPref>(() => loadComposerSendKeyPref());
+  useEffect(() => {
+    const reload = () => setComposerSendKeyPref(loadComposerSendKeyPref());
+    window.addEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, reload);
+    return () =>
+      window.removeEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, reload);
+  }, []);
   /** Files/folders attached for next send (@path to agent). */
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   /** Chat file/url card → open in right resource pane. */
@@ -11079,7 +11094,7 @@ export default function App() {
                       return;
                     }
                   }
-                  if (e.key === "Enter" && !e.shiftKey) {
+                  if (shouldSendOnKeydown(e, composerSendKeyPref)) {
                     e.preventDefault();
                     const hasBody =
                       !isDraftEmpty(parseStoredContent(draft)) ||

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -65,6 +65,11 @@ import {
   COMPOSER_PREFS_SCOPES,
   PERMISSION_POLICIES,
 } from "@/lib/grokCatalog";
+import {
+  loadComposerSendKeyPref,
+  saveComposerSendKeyPref,
+  type ComposerSendKeyPref,
+} from "@/lib/composerSendKey";
 import type { AccountStatus, DetectedEditor } from "@/lib/api";
 import * as api from "@/lib/api";
 import { AccountPanel } from "@/components/AccountPanel";
@@ -705,6 +710,9 @@ export function SettingsPage({
   trustedProjects = [],
 }: SettingsPageProps) {
   const [query, setQuery] = useState("");
+  /** Composer Enter vs ⌘/Ctrl+Enter — localStorage only (no Host settings). */
+  const [composerSendKeyPref, setComposerSendKeyPref] =
+    useState<ComposerSendKeyPref>(() => loadComposerSendKeyPref());
   /** Pending scroll target after search jump / deep link. */
   const pendingAnchorRef = useRef<string | null>(null);
   const [highlightAnchor, setHighlightAnchor] = useState<string | null>(null);
@@ -1390,6 +1398,40 @@ export function SettingsPage({
                     ))
                   )}
                 </div>
+              </div>
+              <div
+                className={
+                  "settings-row settings-row--stack" +
+                  rowHighlight("settings-anchor-composerSendKey")
+                }
+                id="settings-anchor-composerSendKey"
+              >
+                <div className="settings-row__text">
+                  <div className="settings-row__label">
+                    {t("settings.composerSendKey")}
+                  </div>
+                  <div className="settings-row__desc">
+                    {t("settings.composerSendKeyDesc")}
+                  </div>
+                </div>
+                <Select
+                  value={composerSendKeyPref}
+                  onChange={(v) => {
+                    const next = v as ComposerSendKeyPref;
+                    setComposerSendKeyPref(next);
+                    saveComposerSendKeyPref(next);
+                  }}
+                  options={[
+                    {
+                      value: "enter",
+                      label: t("settings.composerSendKey.enter"),
+                    },
+                    {
+                      value: "mod-enter",
+                      label: t("settings.composerSendKey.modEnter"),
+                    },
+                  ]}
+                />
               </div>
             </div>
             </>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -852,6 +852,11 @@ const en = {
   "settings.availableModelsDesc":
     "Official Grok Build model IDs from the CLI catalog. Providers are channels — switch them under Account → Providers.",
   "settings.availableModelsEmpty": "No models detected — check Grok Build CLI login.",
+  "settings.composerSendKey": "Send message with",
+  "settings.composerSendKeyDesc":
+    "Choose whether plain Enter sends, or inserts a newline (⌘/Ctrl+Enter sends instead). Applies to the chat composer.",
+  "settings.composerSendKey.enter": "Enter to send (Shift+Enter for newline)",
+  "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter to send (Enter for newline)",
   "settings.theme": "Theme",
   "settings.themeDesc": "Follow the system, or lock light / dark",
   "settings.themeSystem": "System",
@@ -2937,6 +2942,11 @@ const zh: Record<MessageKey, string> = {
   "settings.availableModelsDesc":
     "来自 Grok Build CLI 官方目录的模型。服务商是后端渠道，请在「账户 → 自定义提供商」切换，不会出现在模型选择里。",
   "settings.availableModelsEmpty": "未检测到模型 — 请检查 Grok Build CLI 登录。",
+  "settings.composerSendKey": "发送消息快捷键",
+  "settings.composerSendKeyDesc":
+    "选择 Enter 直接发送，还是 Enter 换行、⌘/Ctrl+Enter 发送。仅作用于对话输入框。",
+  "settings.composerSendKey.enter": "Enter 发送（Shift+Enter 换行）",
+  "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 发送（Enter 换行）",
   "settings.theme": "主题",
   "settings.themeDesc": "跟随系统，或固定浅色 / 深色",
   "settings.themeSystem": "跟随系统",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -818,6 +818,11 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.availableModelsDesc":
     "來自 Grok Build CLI 官方目錄的模型。服務商是後端通道，請在「帳戶 → 自訂供應商」切換，不會出現在模型選擇裡。",
   "settings.availableModelsEmpty": "未偵測到模型 — 請檢查 Grok Build CLI 登入。",
+  "settings.composerSendKey": "傳送訊息快捷鍵",
+  "settings.composerSendKeyDesc":
+    "選擇 Enter 直接傳送，或 Enter 換行、⌘/Ctrl+Enter 傳送。僅作用於對話輸入框。",
+  "settings.composerSendKey.enter": "Enter 傳送（Shift+Enter 換行）",
+  "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 傳送（Enter 換行）",
   "settings.theme": "主題",
   "settings.themeDesc": "跟隨系統，或固定淺色 / 深色",
   "settings.themeSystem": "跟隨系統",

--- a/src/lib/composerSendKey.test.ts
+++ b/src/lib/composerSendKey.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  loadComposerSendKeyPref,
+  saveComposerSendKeyPref,
+  shouldSendOnKeydown,
+  type ComposerSendKeyEvent,
+} from "./composerSendKey";
+
+function memoryStorage(seed: Record<string, string> = {}): Storage {
+  const map = new Map(Object.entries(seed));
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => map.get(k) ?? null,
+    key: (i) => [...map.keys()][i] ?? null,
+    removeItem: (k) => {
+      map.delete(k);
+    },
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+  };
+}
+
+function key(
+  partial: Partial<ComposerSendKeyEvent> & { key?: string } = {},
+): ComposerSendKeyEvent {
+  return {
+    key: partial.key ?? "Enter",
+    shiftKey: partial.shiftKey ?? false,
+    metaKey: partial.metaKey ?? false,
+    ctrlKey: partial.ctrlKey ?? false,
+    altKey: partial.altKey ?? false,
+  };
+}
+
+describe("composerSendKey pref storage", () => {
+  it("defaults to enter", () => {
+    expect(loadComposerSendKeyPref(memoryStorage())).toBe("enter");
+  });
+
+  it("round-trips preference", () => {
+    const s = memoryStorage();
+    saveComposerSendKeyPref("mod-enter", s);
+    expect(loadComposerSendKeyPref(s)).toBe("mod-enter");
+    saveComposerSendKeyPref("enter", s);
+    expect(loadComposerSendKeyPref(s)).toBe("enter");
+  });
+
+  it("ignores unknown storage values", () => {
+    expect(
+      loadComposerSendKeyPref(memoryStorage({ "grok.composerSendKey": "weird" })),
+    ).toBe("enter");
+  });
+});
+
+describe("shouldSendOnKeydown — enter pref", () => {
+  const pref = "enter" as const;
+
+  it("sends on plain Enter", () => {
+    expect(shouldSendOnKeydown(key(), pref)).toBe(true);
+  });
+
+  it("does not send on Shift+Enter (newline)", () => {
+    expect(shouldSendOnKeydown(key({ shiftKey: true }), pref)).toBe(false);
+  });
+
+  it("does not send on Cmd/Ctrl/Alt+Enter", () => {
+    expect(shouldSendOnKeydown(key({ metaKey: true }), pref)).toBe(false);
+    expect(shouldSendOnKeydown(key({ ctrlKey: true }), pref)).toBe(false);
+    expect(shouldSendOnKeydown(key({ altKey: true }), pref)).toBe(false);
+  });
+
+  it("ignores non-Enter keys", () => {
+    expect(shouldSendOnKeydown(key({ key: "a" }), pref)).toBe(false);
+  });
+});
+
+describe("shouldSendOnKeydown — mod-enter pref", () => {
+  const pref = "mod-enter" as const;
+
+  it("sends on Cmd+Enter or Ctrl+Enter", () => {
+    expect(shouldSendOnKeydown(key({ metaKey: true }), pref)).toBe(true);
+    expect(shouldSendOnKeydown(key({ ctrlKey: true }), pref)).toBe(true);
+  });
+
+  it("does not send on plain Enter (newline)", () => {
+    expect(shouldSendOnKeydown(key(), pref)).toBe(false);
+  });
+
+  it("does not send on Shift+Enter or Alt+Enter", () => {
+    expect(shouldSendOnKeydown(key({ shiftKey: true }), pref)).toBe(false);
+    expect(
+      shouldSendOnKeydown(key({ metaKey: true, shiftKey: true }), pref),
+    ).toBe(false);
+    expect(shouldSendOnKeydown(key({ altKey: true, metaKey: true }), pref)).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/composerSendKey.ts
+++ b/src/lib/composerSendKey.ts
@@ -1,0 +1,69 @@
+/**
+ * User preference for which key sends the composer draft.
+ * Default matches current product: plain Enter sends, Shift+Enter is newline.
+ * Power users can switch to Cmd/Ctrl+Enter to send (Enter inserts newline).
+ */
+
+const STORAGE_KEY = "grok.composerSendKey";
+
+/** Fired on `window` after a same-tab preference save (storage events are cross-tab only). */
+export const COMPOSER_SEND_KEY_CHANGED_EVENT = "grok:composerSendKey";
+
+export type ComposerSendKeyPref = "enter" | "mod-enter";
+
+export function loadComposerSendKeyPref(
+  storage: Storage = localStorage,
+): ComposerSendKeyPref {
+  try {
+    const v = storage.getItem(STORAGE_KEY);
+    if (v === "mod-enter") return "mod-enter";
+    if (v === "enter") return "enter";
+  } catch {
+    /* private mode */
+  }
+  return "enter";
+}
+
+export function saveComposerSendKeyPref(
+  pref: ComposerSendKeyPref,
+  storage: Storage = localStorage,
+): void {
+  try {
+    storage.setItem(STORAGE_KEY, pref);
+  } catch {
+    /* ignore */
+  }
+  try {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event(COMPOSER_SEND_KEY_CHANGED_EVENT));
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+export type ComposerSendKeyEvent = {
+  key: string;
+  shiftKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+};
+
+/**
+ * Whether this keydown should submit the composer (not insert a newline).
+ * - `enter`: plain Enter (no modifiers)
+ * - `mod-enter`: Cmd/Ctrl+Enter (no Shift/Alt)
+ */
+export function shouldSendOnKeydown(
+  e: ComposerSendKeyEvent,
+  pref: ComposerSendKeyPref,
+): boolean {
+  if (e.key !== "Enter") return false;
+  if (e.shiftKey || e.altKey) return false;
+  if (pref === "enter") {
+    return !e.metaKey && !e.ctrlKey;
+  }
+  // mod-enter
+  return e.metaKey || e.ctrlKey;
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -231,6 +231,29 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     descKeys: ["settings.availableModelsDesc"],
     keywords: ["models", "model list"],
   },
+  {
+    id: "general.composerSendKey",
+    section: "general",
+    tab: "composer",
+    anchorId: "settings-anchor-composerSendKey",
+    labelKey: "settings.composerSendKey",
+    descKeys: [
+      "settings.composerSendKeyDesc",
+      "settings.composerSendKey.enter",
+      "settings.composerSendKey.modEnter",
+      "settings.section.composer",
+    ],
+    keywords: [
+      "composer",
+      "send",
+      "enter",
+      "mod-enter",
+      "cmd enter",
+      "ctrl enter",
+      "newline",
+      "keyboard",
+    ],
+  },
   // ── general / permissions ──
   {
     id: "general.permissionPolicy",


### PR DESCRIPTION
## Summary

- Add **Composer send key** preference: **Enter to send** (default, current behavior) or **⌘/Ctrl+Enter to send** (Enter inserts newline).
- Pure localStorage module (`src/lib/composerSendKey.ts`) with unit tests; no Host / AppSettings / Rust changes.
- Settings → General → Composer select (`settings-anchor-composerSendKey`), registered in `settingsCatalog`, i18n en/zh/zh-TW.
- App composer `onKeyDown` uses `shouldSendOnKeydown`; plain Enter is not preventDefault’d under mod-enter so contenteditable newlines work. Slash menu Enter is unchanged.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/composerSendKey.test.ts src/lib/settingsCatalog.test.ts src/i18n/messages.test.ts`
- [ ] Settings → General → Composer: switch to ⌘/Ctrl+Enter; composer Enter inserts newline; ⌘/Ctrl+Enter sends
- [ ] Switch back to Enter to send; plain Enter sends; Shift+Enter newline
- [ ] Settings search finds “send” / “Enter” / 发送