### PR TITLE
feat: default line-wrap for chat code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Default code line-wrap**: Settings → Appearance toggle “Wrap code lines by default” (`localStorage`); chat code blocks honor it on mount; per-block wrap still works
 - **General workspace**: app-managed `{app_data}/workspaces/general` project (`system:general`) for chats without a user folder — agent can create/edit files without the “bind a project first” toast; always trusted, pinned, not removable
 - **Session Markdown export options**: choose thinking + tool summaries; download `.md` or copy to clipboard (session menu / `/export`)
 - **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -84,6 +84,10 @@ import {
 } from "@/i18n";
 import { useUpdaterContext } from "@/hooks/UpdaterProvider";
 import {
+  loadCodeWrapPref,
+  saveCodeWrapPref,
+} from "@/lib/codeWrapPref";
+import {
   SETTINGS_NAV,
   buildSettingsHash,
   defaultTabFor,
@@ -735,6 +739,10 @@ export function SettingsPage({
   const [wallpaperBusy, setWallpaperBusy] = useState(false);
   const [wallpaperError, setWallpaperError] = useState<string | null>(null);
   const [wallpaperFocusOpen, setWallpaperFocusOpen] = useState(false);
+  /** Chat code-block wrap default — frontend-only localStorage. */
+  const [codeWrapDefault, setCodeWrapDefault] = useState(() =>
+    loadCodeWrapPref(),
+  );
   const marqueeRef = useRef<{
     active: boolean;
     dragging: boolean;
@@ -2231,6 +2239,33 @@ export function SettingsPage({
                 ) : null}
               </div>
             ) : null}
+            <div
+              className={
+                "settings-card" +
+                rowHighlight("settings-anchor-codeWrapDefault")
+              }
+              id="settings-anchor-codeWrapDefault"
+            >
+              <div className="settings-row">
+                <div className="settings-row__text">
+                  <div className="settings-row__label">
+                    {t("settings.codeWrapDefault")}
+                  </div>
+                  <div className="settings-row__desc">
+                    {t("settings.codeWrapDefaultDesc")}
+                  </div>
+                </div>
+                <UiCheck
+                  checked={codeWrapDefault}
+                  onChange={() => {
+                    const next = !codeWrapDefault;
+                    setCodeWrapDefault(next);
+                    saveCodeWrapPref(next);
+                  }}
+                  ariaLabel={t("settings.codeWrapDefault")}
+                />
+              </div>
+            </div>
           </>
         )}
 

--- a/src/components/lobe-chat/CodeBlock.tsx
+++ b/src/components/lobe-chat/CodeBlock.tsx
@@ -5,6 +5,7 @@
 import { useState, type ReactNode } from "react";
 import { IconCheck, IconCopy } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
+import { loadCodeWrapPref } from "@/lib/codeWrapPref";
 import { cn } from "@/lib/utils";
 
 function extractText(node: ReactNode): string {
@@ -31,7 +32,7 @@ export function CodeBlock({
   unwrapLabel?: string;
   copyLabel?: string;
 }) {
-  const [wrap, setWrap] = useState(false);
+  const [wrap, setWrap] = useState(() => loadCodeWrapPref());
   const [copied, setCopied] = useState(false);
   const lang = (language || "text").replace(/^language-/, "") || "text";
   const text = extractText(children).replace(/\n$/, "");

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -857,6 +857,9 @@ const en = {
   "settings.themeSystem": "System",
   "settings.themeLight": "Light",
   "settings.themeDark": "Dark",
+  "settings.codeWrapDefault": "Wrap code lines by default",
+  "settings.codeWrapDefaultDesc":
+    "New chat code blocks start with soft wrap on. You can still toggle wrap on each block.",
   "settings.skin": "Color skin",
   "settings.skinDesc": "Accent and surface palette (works with light/dark)",
   "settings.skin.default": "Default",
@@ -2942,6 +2945,9 @@ const zh: Record<MessageKey, string> = {
   "settings.themeSystem": "跟随系统",
   "settings.themeLight": "浅色",
   "settings.themeDark": "深色",
+  "settings.codeWrapDefault": "默认自动换行代码",
+  "settings.codeWrapDefaultDesc":
+    "新的聊天代码块默认开启软换行。仍可在每个代码块上单独切换。",
   "settings.skin": "配色皮肤",
   "settings.skinDesc": "强调色与表面色板（可与浅/深色叠加）",
   "settings.skin.default": "默认",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -823,6 +823,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.themeSystem": "跟隨系統",
   "settings.themeLight": "淺色",
   "settings.themeDark": "深色",
+  "settings.codeWrapDefault": "預設自動換行程式碼",
+  "settings.codeWrapDefaultDesc":
+    "新的聊天程式碼區塊預設開啟軟換行。仍可在每個區塊上單獨切換。",
   "settings.skin": "配色皮膚",
   "settings.skinDesc": "強調色與表面色板（可與淺/深色疊加）",
   "settings.skin.default": "預設",

--- a/src/lib/codeWrapPref.test.ts
+++ b/src/lib/codeWrapPref.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CODE_WRAP_PREF_EVENT,
+  CODE_WRAP_PREF_KEY,
+  loadCodeWrapPref,
+  saveCodeWrapPref,
+} from "./codeWrapPref";
+
+function memoryStorage(seed: Record<string, string> = {}): Storage {
+  const map = new Map(Object.entries(seed));
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => map.get(k) ?? null,
+    key: (i) => [...map.keys()][i] ?? null,
+    removeItem: (k) => {
+      map.delete(k);
+    },
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+  };
+}
+
+describe("codeWrapPref", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to false (scroll / no wrap)", () => {
+    expect(loadCodeWrapPref(memoryStorage())).toBe(false);
+  });
+
+  it("round-trips preference", () => {
+    const s = memoryStorage();
+    saveCodeWrapPref(true, s);
+    expect(s.getItem(CODE_WRAP_PREF_KEY)).toBe("wrap");
+    expect(loadCodeWrapPref(s)).toBe(true);
+    saveCodeWrapPref(false, s);
+    expect(s.getItem(CODE_WRAP_PREF_KEY)).toBe("scroll");
+    expect(loadCodeWrapPref(s)).toBe(false);
+  });
+
+  it("accepts legacy true/false and 1/0 values", () => {
+    expect(loadCodeWrapPref(memoryStorage({ [CODE_WRAP_PREF_KEY]: "true" }))).toBe(
+      true,
+    );
+    expect(loadCodeWrapPref(memoryStorage({ [CODE_WRAP_PREF_KEY]: "1" }))).toBe(
+      true,
+    );
+    expect(
+      loadCodeWrapPref(memoryStorage({ [CODE_WRAP_PREF_KEY]: "false" })),
+    ).toBe(false);
+    expect(loadCodeWrapPref(memoryStorage({ [CODE_WRAP_PREF_KEY]: "0" }))).toBe(
+      false,
+    );
+  });
+
+  it("ignores unknown values", () => {
+    expect(
+      loadCodeWrapPref(memoryStorage({ [CODE_WRAP_PREF_KEY]: "maybe" })),
+    ).toBe(false);
+  });
+
+  it("dispatches grok:codeWrapPref on save when window exists", () => {
+    const listeners = new Map<string, Set<EventListener>>();
+    const stubWindow = {
+      addEventListener(type: string, listener: EventListener) {
+        if (!listeners.has(type)) listeners.set(type, new Set());
+        listeners.get(type)!.add(listener);
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners.get(type)?.delete(listener);
+      },
+      dispatchEvent(ev: Event) {
+        const set = listeners.get(ev.type);
+        if (set) for (const fn of set) fn(ev);
+        return true;
+      },
+    };
+    vi.stubGlobal("window", stubWindow);
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent<T = unknown> extends Event {
+        detail: T;
+        constructor(type: string, init?: CustomEventInit<T>) {
+          super(type);
+          this.detail = init?.detail as T;
+        }
+      },
+    );
+
+    const handler = vi.fn();
+    stubWindow.addEventListener(CODE_WRAP_PREF_EVENT, handler);
+    saveCodeWrapPref(true, memoryStorage());
+    expect(handler).toHaveBeenCalledTimes(1);
+    const ev = handler.mock.calls[0][0] as CustomEvent;
+    expect(ev.detail).toBe(true);
+  });
+});
+

--- a/src/lib/codeWrapPref.ts
+++ b/src/lib/codeWrapPref.ts
@@ -1,0 +1,46 @@
+/**
+ * User preference for default line-wrap on chat markdown code blocks.
+ * Per-block toggle still works independently; this only sets the initial state.
+ */
+
+export const CODE_WRAP_PREF_KEY = "grok.codeWrapDefault";
+
+/** Dispatched on `window` after a successful save (detail = new pref). */
+export const CODE_WRAP_PREF_EVENT = "grok:codeWrapPref";
+
+/** `true` = wrap lines by default; `false` = horizontal scroll (no wrap). */
+export type CodeWrapPref = boolean;
+
+export function loadCodeWrapPref(
+  storage: Storage = localStorage,
+): CodeWrapPref {
+  try {
+    const v = storage.getItem(CODE_WRAP_PREF_KEY);
+    if (v === "1" || v === "true" || v === "wrap") return true;
+    if (v === "0" || v === "false" || v === "scroll") return false;
+  } catch {
+    /* private mode */
+  }
+  // Default: no wrap (current CodeBlock behavior).
+  return false;
+}
+
+export function saveCodeWrapPref(
+  pref: CodeWrapPref,
+  storage: Storage = localStorage,
+): void {
+  try {
+    storage.setItem(CODE_WRAP_PREF_KEY, pref ? "wrap" : "scroll");
+  } catch {
+    /* ignore */
+  }
+  try {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent(CODE_WRAP_PREF_EVENT, { detail: pref }),
+      );
+    }
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -451,6 +451,22 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     ],
     keywords: ["wallpaper", "background", "scrim"],
   },
+  {
+    id: "appearance.codeWrapDefault",
+    section: "appearance",
+    anchorId: "settings-anchor-codeWrapDefault",
+    labelKey: "settings.codeWrapDefault",
+    descKeys: ["settings.codeWrapDefaultDesc"],
+    keywords: [
+      "code wrap",
+      "line wrap",
+      "word wrap",
+      "soft wrap",
+      "代码换行",
+      "自動換行",
+      "自动换行",
+    ],
+  },
   // ── account ──
   {
     id: "account.official",


### PR DESCRIPTION
## Summary
- Add `src/lib/codeWrapPref.ts` (localStorage `grok.codeWrapDefault`, default scroll/no wrap) with unit tests and optional `grok:codeWrapPref` event on save
- Chat `CodeBlock` initializes wrap from the preference; per-block toggle still works
- Settings → Appearance toggle “Wrap code lines by default” (`settings-anchor-codeWrapDefault`) + settings catalog entry
- i18n en / zh / zh-TW; CHANGELOG Unreleased

## Frontend-only
No Host / Tauri changes. Preference is self-contained localStorage.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/codeWrapPref.test.ts src/lib/settingsCatalog.test.ts src/i18n/messages.test.ts`
- [ ] Settings → Appearance: enable wrap default → new code blocks start wrapped
- [ ] Disable toggle → new blocks start unwrapped (scroll)
- [ ] Per-block wrap button still toggles independently
- [ ] Search settings for “code wrap” / “自动换行” hits Appearance entry