### PR TITLE
feat(appearance): always-show message action buttons preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Message action buttons visibility**: Settings → Appearance — On hover (default) or Always show Copy / Export / Regenerate / Edit (`html[data-msg-actions]`, localStorage `grok.messageActionsVisibility`; better for trackpads and accessibility)
 - **General workspace**: app-managed `{app_data}/workspaces/general` project (`system:general`) for chats without a user folder — agent can create/edit files without the “bind a project first” toast; always trusted, pinned, not removable
 - **Session Markdown export options**: choose thinking + tool summaries; download `.md` or copy to clipboard (session menu / `/export`)
 - **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -56,6 +56,13 @@ import {
   type WallpaperFocusApplyResult,
 } from "@/components/WallpaperFocusEditor";
 import { WallpaperMediaLayer } from "@/components/WallpaperMediaLayer";
+import {
+  MESSAGE_ACTIONS_VISIBILITIES,
+  applyMessageActionsVisibility,
+  loadMessageActionsVisibility,
+  saveMessageActionsVisibility,
+  type MessageActionsVisibility,
+} from "@/lib/messageActionsPref";
 import type {
   ComposerPrefsScope,
   ModelOption,
@@ -735,6 +742,20 @@ export function SettingsPage({
   const [wallpaperBusy, setWallpaperBusy] = useState(false);
   const [wallpaperError, setWallpaperError] = useState<string | null>(null);
   const [wallpaperFocusOpen, setWallpaperFocusOpen] = useState(false);
+  /** Message action buttons visibility — localStorage only (no AppSettings). */
+  const [messageActionsVisibility, setMessageActionsVisibilityState] =
+    useState<MessageActionsVisibility>(() => loadMessageActionsVisibility());
+  useEffect(() => {
+    applyMessageActionsVisibility(loadMessageActionsVisibility());
+  }, []);
+  const onMessageActionsVisibility = useCallback(
+    (next: MessageActionsVisibility) => {
+      setMessageActionsVisibilityState(next);
+      saveMessageActionsVisibility(next);
+      applyMessageActionsVisibility(next);
+    },
+    [],
+  );
   const marqueeRef = useRef<{
     active: boolean;
     dragging: boolean;
@@ -1973,6 +1994,45 @@ export function SettingsPage({
                   >
                     {t("settings.themeDark")}
                   </button>
+                </div>
+              </div>
+            </div>
+            <div
+              className={
+                "settings-card" +
+                rowHighlight("settings-anchor-messageActions")
+              }
+              id="settings-anchor-messageActions"
+            >
+              <div className="settings-row">
+                <div className="settings-row__text">
+                  <div className="settings-row__label">
+                    {t("settings.messageActions")}
+                  </div>
+                  <div className="settings-row__desc">
+                    {t("settings.messageActionsDesc")}
+                  </div>
+                </div>
+                <div
+                  className="settings-seg"
+                  role="radiogroup"
+                  aria-label={t("settings.messageActions")}
+                >
+                  {MESSAGE_ACTIONS_VISIBILITIES.map((mode) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      role="radio"
+                      aria-checked={messageActionsVisibility === mode}
+                      className={
+                        "settings-seg__btn" +
+                        (messageActionsVisibility === mode ? " is-on" : "")
+                      }
+                      onClick={() => onMessageActionsVisibility(mode)}
+                    >
+                      {t(`settings.messageActions.${mode}`)}
+                    </button>
+                  ))}
                 </div>
               </div>
             </div>

--- a/src/components/lobe-chat/lobe-chat.css
+++ b/src/components/lobe-chat/lobe-chat.css
@@ -268,7 +268,7 @@
   color: var(--chat-text, inherit);
 }
 
-/* Hover actions */
+/* Hover actions (default) — focus-within keeps keyboard a11y */
 .lobe-chat-item__actions {
   display: flex;
   align-items: center;
@@ -280,6 +280,12 @@
 
 .lobe-chat-item:hover .lobe-chat-item__actions,
 .lobe-chat-item:focus-within .lobe-chat-item__actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Settings → Appearance: always show message action buttons */
+html[data-msg-actions="always"] .lobe-chat-item__actions {
   opacity: 1;
   pointer-events: auto;
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -857,6 +857,11 @@ const en = {
   "settings.themeSystem": "System",
   "settings.themeLight": "Light",
   "settings.themeDark": "Dark",
+  "settings.messageActions": "Message actions",
+  "settings.messageActionsDesc":
+    "Show Copy, Export, Regenerate, and Edit on hover, or keep them always visible (better for trackpads and accessibility)",
+  "settings.messageActions.hover": "On hover",
+  "settings.messageActions.always": "Always show",
   "settings.skin": "Color skin",
   "settings.skinDesc": "Accent and surface palette (works with light/dark)",
   "settings.skin.default": "Default",
@@ -2942,6 +2947,11 @@ const zh: Record<MessageKey, string> = {
   "settings.themeSystem": "跟随系统",
   "settings.themeLight": "浅色",
   "settings.themeDark": "深色",
+  "settings.messageActions": "消息操作按钮",
+  "settings.messageActionsDesc":
+    "复制、导出、重新生成、编辑：悬停显示，或始终可见（触控板与无障碍更友好）",
+  "settings.messageActions.hover": "悬停显示",
+  "settings.messageActions.always": "始终显示",
   "settings.skin": "配色皮肤",
   "settings.skinDesc": "强调色与表面色板（可与浅/深色叠加）",
   "settings.skin.default": "默认",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -823,6 +823,11 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.themeSystem": "跟隨系統",
   "settings.themeLight": "淺色",
   "settings.themeDark": "深色",
+  "settings.messageActions": "訊息操作按鈕",
+  "settings.messageActionsDesc":
+    "複製、匯出、重新生成、編輯：懸停顯示，或始終可見（觸控板與無障礙更友善）",
+  "settings.messageActions.hover": "懸停顯示",
+  "settings.messageActions.always": "始終顯示",
   "settings.skin": "配色皮膚",
   "settings.skinDesc": "強調色與表面色板（可與淺/深色疊加）",
   "settings.skin.default": "預設",

--- a/src/lib/messageActionsPref.test.ts
+++ b/src/lib/messageActionsPref.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MESSAGE_ACTIONS_VISIBILITY,
+  MESSAGE_ACTIONS_VISIBILITIES,
+  MESSAGE_ACTIONS_VISIBILITY_ATTR,
+  MESSAGE_ACTIONS_VISIBILITY_STORAGE_KEY,
+  applyMessageActionsVisibility,
+  isMessageActionsVisibility,
+  loadMessageActionsVisibility,
+  parseMessageActionsVisibility,
+  saveMessageActionsVisibility,
+  setMessageActionsVisibility,
+  type MessageActionsPrefStorage,
+} from "./messageActionsPref";
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+): MessageActionsPrefStorage & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    getItem(key) {
+      return key in data ? data[key]! : null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+  };
+}
+
+describe("messageActionsPref", () => {
+  it("defaults to hover and rejects unknown values", () => {
+    expect(DEFAULT_MESSAGE_ACTIONS_VISIBILITY).toBe("hover");
+    expect(parseMessageActionsVisibility(null)).toBe("hover");
+    expect(parseMessageActionsVisibility("")).toBe("hover");
+    expect(parseMessageActionsVisibility("visible")).toBe("hover");
+    expect(isMessageActionsVisibility("hover")).toBe(true);
+    expect(isMessageActionsVisibility("always")).toBe(true);
+    expect(isMessageActionsVisibility("never")).toBe(false);
+    expect(MESSAGE_ACTIONS_VISIBILITIES).toEqual(["hover", "always"]);
+  });
+
+  it("persists and reloads after simulated relaunch", () => {
+    const storage = memoryStorage();
+    expect(loadMessageActionsVisibility(storage)).toBe("hover");
+    saveMessageActionsVisibility("always", storage);
+    expect(storage.data[MESSAGE_ACTIONS_VISIBILITY_STORAGE_KEY]).toBe(
+      "always",
+    );
+    expect(loadMessageActionsVisibility(storage)).toBe("always");
+    saveMessageActionsVisibility("hover", storage);
+    expect(loadMessageActionsVisibility(storage)).toBe("hover");
+  });
+
+  it("applyMessageActionsVisibility sets data-msg-actions", () => {
+    const attrs = new Map<string, string>();
+    const el = {
+      setAttribute(name: string, value: string) {
+        attrs.set(name, value);
+      },
+    };
+    applyMessageActionsVisibility("always", el);
+    expect(attrs.get(MESSAGE_ACTIONS_VISIBILITY_ATTR)).toBe("always");
+    applyMessageActionsVisibility("hover", el);
+    expect(attrs.get(MESSAGE_ACTIONS_VISIBILITY_ATTR)).toBe("hover");
+  });
+
+  it("setMessageActionsVisibility saves and applies", () => {
+    const storage = memoryStorage();
+    const attrs = new Map<string, string>();
+    const el = {
+      setAttribute(name: string, value: string) {
+        attrs.set(name, value);
+      },
+    };
+    setMessageActionsVisibility("always", storage, el);
+    expect(storage.data[MESSAGE_ACTIONS_VISIBILITY_STORAGE_KEY]).toBe(
+      "always",
+    );
+    expect(attrs.get(MESSAGE_ACTIONS_VISIBILITY_ATTR)).toBe("always");
+  });
+});

--- a/src/lib/messageActionsPref.ts
+++ b/src/lib/messageActionsPref.ts
@@ -1,0 +1,112 @@
+/**
+ * Message action button visibility (Appearance).
+ * localStorage-only — no Rust AppSettings (avoids prefs schema conflicts).
+ * Applied via `data-msg-actions` on `document.documentElement`.
+ *
+ * - `hover` (default): show on hover / focus-within (existing CSS)
+ * - `always`: keep Copy / Export / Regenerate / Edit visible
+ */
+
+export type MessageActionsVisibility = "hover" | "always";
+
+export const MESSAGE_ACTIONS_VISIBILITY_STORAGE_KEY =
+  "grok.messageActionsVisibility";
+export const DEFAULT_MESSAGE_ACTIONS_VISIBILITY: MessageActionsVisibility =
+  "hover";
+export const MESSAGE_ACTIONS_VISIBILITY_ATTR = "data-msg-actions";
+/** Optional window event after save/apply (detail = preference). */
+export const MESSAGE_ACTIONS_VISIBILITY_EVENT =
+  "grok-message-actions-visibility";
+
+export const MESSAGE_ACTIONS_VISIBILITIES: readonly MessageActionsVisibility[] =
+  ["hover", "always"] as const;
+
+export interface MessageActionsPrefStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export function isMessageActionsVisibility(
+  value: unknown,
+): value is MessageActionsVisibility {
+  return value === "hover" || value === "always";
+}
+
+export function parseMessageActionsVisibility(
+  raw: unknown,
+): MessageActionsVisibility {
+  if (typeof raw === "string" && isMessageActionsVisibility(raw)) return raw;
+  return DEFAULT_MESSAGE_ACTIONS_VISIBILITY;
+}
+
+export function loadMessageActionsVisibility(
+  storage: MessageActionsPrefStorage = typeof localStorage !== "undefined"
+    ? localStorage
+    : { getItem: () => null, setItem: () => {} },
+): MessageActionsVisibility {
+  try {
+    return parseMessageActionsVisibility(
+      storage.getItem(MESSAGE_ACTIONS_VISIBILITY_STORAGE_KEY),
+    );
+  } catch {
+    return DEFAULT_MESSAGE_ACTIONS_VISIBILITY;
+  }
+}
+
+export function saveMessageActionsVisibility(
+  pref: MessageActionsVisibility,
+  storage: MessageActionsPrefStorage = typeof localStorage !== "undefined"
+    ? localStorage
+    : { getItem: () => null, setItem: () => {} },
+): void {
+  try {
+    storage.setItem(MESSAGE_ACTIONS_VISIBILITY_STORAGE_KEY, pref);
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+/** Minimal DOM surface so unit tests need no jsdom. */
+export interface MessageActionsPrefRoot {
+  setAttribute(name: string, value: string): void;
+  removeAttribute?(name: string): void;
+}
+
+/**
+ * Apply visibility to document via `data-msg-actions`.
+ * CSS: `html[data-msg-actions="always"] .lobe-chat-item__actions { … }`.
+ * Missing attribute or `"hover"` keeps the default hover/focus-within rules.
+ */
+export function applyMessageActionsVisibility(
+  pref: MessageActionsVisibility,
+  root: MessageActionsPrefRoot = typeof document !== "undefined"
+    ? document.documentElement
+    : { setAttribute: () => {} },
+): void {
+  root.setAttribute(MESSAGE_ACTIONS_VISIBILITY_ATTR, pref);
+}
+
+/** Fire optional change event for listeners (no-op outside browser). */
+export function dispatchMessageActionsVisibilityChange(
+  pref: MessageActionsVisibility,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent(MESSAGE_ACTIONS_VISIBILITY_EVENT, { detail: pref }),
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Persist + apply (+ optional event) in one step (Settings onChange). */
+export function setMessageActionsVisibility(
+  pref: MessageActionsVisibility,
+  storage?: MessageActionsPrefStorage,
+  root?: MessageActionsPrefRoot,
+): void {
+  saveMessageActionsVisibility(pref, storage);
+  applyMessageActionsVisibility(pref, root);
+  dispatchMessageActionsVisibilityChange(pref);
+}

--- a/src/lib/settingsCatalog.test.ts
+++ b/src/lib/settingsCatalog.test.ts
@@ -89,10 +89,11 @@ describe("settingsCatalog", () => {
     expect(isSettingsSectionId("nope")).toBe(false);
   });
 
-  it("keywordKeysForSection includes skin/wallpaper and remote control", () => {
+  it("keywordKeysForSection includes skin/wallpaper/message actions and remote control", () => {
     const appearance = keywordKeysForSection("appearance");
     expect(appearance).toContain("settings.skin");
     expect(appearance).toContain("settings.wallpaper");
+    expect(appearance).toContain("settings.messageActions");
     const rim = keywordKeysForSection("remote_im");
     expect(rim).toContain("settings.nav.remoteIm");
     expect(rim).toContain("settings.tab.remoteIm");
@@ -121,7 +122,7 @@ describe("settingsCatalog", () => {
     );
   });
 
-  it("search finds mcp / wallpaper / cli path (zh + en)", () => {
+  it("search finds mcp / wallpaper / message actions / cli path (zh + en)", () => {
     const tZh = createT("zh");
     const tEn = createT("en");
     const mcp = searchSettingsEntries("mcp", tZh, tEn);
@@ -135,6 +136,14 @@ describe("settingsCatalog", () => {
     expect(wallpaperHits.some((h) => h.entry.id === "appearance.wallpaper")).toBe(
       true,
     );
+    const actions = searchSettingsEntries("操作", tZh, tEn);
+    expect(
+      actions.some((h) => h.entry.id === "appearance.messageActions"),
+    ).toBe(true);
+    const actionsEn = searchSettingsEntries("copy buttons", tZh, tEn);
+    expect(
+      actionsEn.some((h) => h.entry.id === "appearance.messageActions"),
+    ).toBe(true);
     const cli = searchSettingsEntries("CLI", tZh, tEn);
     expect(cli.some((h) => h.entry.section === "runtime")).toBe(true);
   });

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -451,6 +451,29 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     ],
     keywords: ["wallpaper", "background", "scrim"],
   },
+  {
+    id: "appearance.messageActions",
+    section: "appearance",
+    anchorId: "settings-anchor-messageActions",
+    labelKey: "settings.messageActions",
+    descKeys: [
+      "settings.messageActionsDesc",
+      "settings.messageActions.hover",
+      "settings.messageActions.always",
+    ],
+    keywords: [
+      "actions",
+      "hover",
+      "copy buttons",
+      "message actions",
+      "always show",
+      "操作",
+      "按钮",
+      "按鈕",
+      "复制",
+      "複製",
+    ],
+  },
   // ── account ──
   {
     id: "account.official",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,12 +23,18 @@ import {
   loadWallpaperMeta,
   loadWallpaperScrim,
 } from "./lib/themeSkin";
+import {
+  applyMessageActionsVisibility,
+  loadMessageActionsVisibility,
+} from "./lib/messageActionsPref";
 
 // Apply persisted theme preference (default: system) before first React paint.
 const bootPref = loadThemePreference(localStorage);
 const bootTheme = resolveTheme(bootPref, getSystemTheme());
 applyThemeToDocument(bootTheme);
 applySkinToDocument(loadSkin(localStorage));
+// Message action buttons (Appearance) — html[data-msg-actions].
+applyMessageActionsVisibility(loadMessageActionsVisibility(localStorage));
 // Only the data-wallpaper flag is set synchronously (so the shell flips to
 // transparent + scrim instantly). The media layer is rendered by App after
 // the IndexedDB blob is loaded — no synchronous access to IDB is possible.


### PR DESCRIPTION
## Summary

- Add Settings → Appearance control for message action button visibility: **On hover** (default) vs **Always show**
- Persist via localStorage `grok.messageActionsVisibility` and apply as `html[data-msg-actions="hover"|"always"]` (boot in `main.tsx`)
- Keep hover + `focus-within` accessibility for the default mode; always mode forces opacity/pointer-events so trackpad and a11y users can find Copy / Export / Regenerate / Edit

## Changes

| Area | Detail |
|------|--------|
| Pure module | `src/lib/messageActionsPref.ts` + unit tests |
| CSS | `lobe-chat.css` override for `html[data-msg-actions="always"]` |
| Boot | `main.tsx` applies stored pref before React paint |
| Settings | Appearance segment + catalog `settings-anchor-messageActions` |
| i18n | en / zh / zh-TW |
| Changelog | Unreleased → Added |

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/messageActionsPref.test.ts src/lib/settingsCatalog.test.ts src/i18n/messages.test.ts`
- [ ] Manual: Settings → Appearance → switch Always show → message actions stay visible without hover
- [ ] Manual: On hover restores hide-until-hover / focus-within behavior
- [ ] Manual: settings search finds entry via “actions” / “操作” / “copy buttons”