### PR TITLE
feat(shortcuts): Esc stops active generation when free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Esc stops generation**: when a turn is streaming (Stop available) and no dialog/menu/find/permission/voice owns Escape, Esc calls the same `stop()` as the composer Stop button (honors shortcuts catalog)
 - **General workspace**: app-managed `{app_data}/workspaces/general` project (`system:general`) for chats without a user folder — agent can create/edit files without the “bind a project first” toast; always trusted, pinned, not removable
 - **Session Markdown export options**: choose thinking + tool summaries; download `.md` or copy to clipboard (session menu / `/export`)
 - **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,6 +138,7 @@ import {
   type StopLatchState,
   STOP_LATCH_MS,
 } from "@/lib/stopLatch";
+import { shouldEscapeStopGeneration } from "@/lib/escapeStop";
 import {
   isSameView,
   isViewingSendTarget,
@@ -880,7 +881,7 @@ export default function App() {
     return () => window.clearTimeout(t);
   }, [searchQuery, showSearch]);
 
-  // Global shortcuts: search, find-in-chat, help, doctor, new chat, settings, voice.
+  // Global shortcuts: search, find-in-chat, help, doctor, new chat, settings, voice, Esc-stop.
   // Handlers go through refs so we don't re-bind every render.
   const shortcutHandlersRef = useRef({
     newChat: () => {},
@@ -888,6 +889,17 @@ export default function App() {
     openChatFind: () => {},
     toggleVoice: () => {},
     cancelVoice: () => {},
+    stopGeneration: () => {},
+  });
+  /** Live Esc→stop gate (overlays / menus / busy) for the capture-phase handler. */
+  const escapeStopLiveRef = useRef({
+    streamingOrBusy: false,
+    overlayOpen: false,
+    permOpen: false,
+    askUserOpen: false,
+    chatFindOpen: false,
+    slashOrMenuOpen: false,
+    promptHistoryOpen: false,
   });
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -898,6 +910,21 @@ export default function App() {
         e.stopPropagation();
         shortcutHandlersRef.current.cancelVoice();
         return;
+      }
+      // Esc stops the active turn when nothing else owns Escape (catalog: shortcuts.stop).
+      if (e.key === "Escape") {
+        const gate = escapeStopLiveRef.current;
+        if (
+          shouldEscapeStopGeneration({
+            ...gate,
+            voiceStealsEscape: voiceStealsEscape(voiceRef.current.phase),
+          })
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          shortcutHandlersRef.current.stopGeneration();
+          return;
+        }
       }
       // Ctrl+Space toggles voice (not Cmd+Space — Spotlight on macOS).
       if (isVoiceToggleKey(e)) {
@@ -7632,6 +7659,9 @@ export default function App() {
     cancelVoice: () => {
       cancelVoice();
     },
+    stopGeneration: () => {
+      void stop();
+    },
   };
   trayHandlersRef.current = {
     newChat: () => {
@@ -8716,6 +8746,30 @@ export default function App() {
     for (const k of keys) out[k] = tr(k);
     return out;
   }, [tr]);
+
+  // Keep Esc→stop gate current for the capture-phase shortcut listener.
+  escapeStopLiveRef.current = {
+    streamingOrBusy: effectiveCanStop,
+    overlayOpen: Boolean(
+      appDialog ||
+        showSearch ||
+        showDoctor ||
+        showShortcuts ||
+        showStatusModal ||
+        showMcpModal ||
+        showCompactModal ||
+        exportMdTarget ||
+        rewindConfirm ||
+        worktreeCreateOpen ||
+        projectRulesTarget,
+    ),
+    permOpen: !!perm,
+    askUserOpen: !!askUser,
+    chatFindOpen: showChatFind,
+    slashOrMenuOpen:
+      composerMenuOpen || phoneToolsOpen || !!ctxMenu || showUserMenu,
+    promptHistoryOpen,
+  };
 
   return (
     <ImageViewerProvider locale={locale}>

--- a/src/lib/escapeStop.test.ts
+++ b/src/lib/escapeStop.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { shouldEscapeStopGeneration, type EscapeStopOpts } from "./escapeStop";
+
+const free: EscapeStopOpts = {
+  streamingOrBusy: true,
+  overlayOpen: false,
+  permOpen: false,
+  askUserOpen: false,
+  chatFindOpen: false,
+  slashOrMenuOpen: false,
+  promptHistoryOpen: false,
+  voiceStealsEscape: false,
+};
+
+describe("shouldEscapeStopGeneration", () => {
+  it("stops when streaming and nothing owns Escape", () => {
+    expect(shouldEscapeStopGeneration(free)).toBe(true);
+  });
+
+  it("does not stop when idle / not busy", () => {
+    expect(
+      shouldEscapeStopGeneration({ ...free, streamingOrBusy: false }),
+    ).toBe(false);
+  });
+
+  it("defers to voice dictation", () => {
+    expect(
+      shouldEscapeStopGeneration({ ...free, voiceStealsEscape: true }),
+    ).toBe(false);
+  });
+
+  it("defers to overlays (search, dialog, doctor, shortcuts, export)", () => {
+    expect(shouldEscapeStopGeneration({ ...free, overlayOpen: true })).toBe(
+      false,
+    );
+  });
+
+  it("defers to permission bar (Esc → deny)", () => {
+    expect(shouldEscapeStopGeneration({ ...free, permOpen: true })).toBe(
+      false,
+    );
+  });
+
+  it("defers to ask-user modal", () => {
+    expect(shouldEscapeStopGeneration({ ...free, askUserOpen: true })).toBe(
+      false,
+    );
+  });
+
+  it("defers to chat find", () => {
+    expect(shouldEscapeStopGeneration({ ...free, chatFindOpen: true })).toBe(
+      false,
+    );
+  });
+
+  it("defers to slash / composer menus", () => {
+    expect(
+      shouldEscapeStopGeneration({ ...free, slashOrMenuOpen: true }),
+    ).toBe(false);
+  });
+
+  it("defers to prompt history picker", () => {
+    expect(
+      shouldEscapeStopGeneration({ ...free, promptHistoryOpen: true }),
+    ).toBe(false);
+  });
+
+  it("treats missing optional flags as not open", () => {
+    expect(
+      shouldEscapeStopGeneration({
+        streamingOrBusy: true,
+        overlayOpen: false,
+        permOpen: false,
+        askUserOpen: false,
+        chatFindOpen: false,
+        slashOrMenuOpen: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/lib/escapeStop.ts
+++ b/src/lib/escapeStop.ts
@@ -1,0 +1,43 @@
+/**
+ * Esc → stop generation gate.
+ *
+ * Shortcuts catalog documents Esc as “Stop generation / close overlay”.
+ * Overlays, permission, ask-user, find, menus, and voice own Escape first;
+ * stop only when the turn is busy and nothing else claims the key.
+ */
+
+export type EscapeStopOpts = {
+  /** True when Stop is available (streaming / awaiting permission / latch). */
+  streamingOrBusy: boolean;
+  /** Search, dialogs, doctor, shortcuts help, export modal, etc. */
+  overlayOpen: boolean;
+  /** Permission bar owns Esc → deny. */
+  permOpen: boolean;
+  /** Ask-user questionnaire modal. */
+  askUserOpen: boolean;
+  /** In-chat find bar. */
+  chatFindOpen: boolean;
+  /** Slash palette, composer +, context menu, user menu, phone tools. */
+  slashOrMenuOpen: boolean;
+  /** Prompt history picker. */
+  promptHistoryOpen?: boolean;
+  /** In-progress voice dictation steals Esc. */
+  voiceStealsEscape?: boolean;
+};
+
+/**
+ * Whether global Escape should call `stop()` instead of doing nothing.
+ * True only when a stoppable turn is active and no higher-priority owner
+ * of Escape is open.
+ */
+export function shouldEscapeStopGeneration(opts: EscapeStopOpts): boolean {
+  if (!opts.streamingOrBusy) return false;
+  if (opts.voiceStealsEscape) return false;
+  if (opts.overlayOpen) return false;
+  if (opts.permOpen) return false;
+  if (opts.askUserOpen) return false;
+  if (opts.chatFindOpen) return false;
+  if (opts.slashOrMenuOpen) return false;
+  if (opts.promptHistoryOpen) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary

- Esc now stops the active generation when nothing else owns the key (dialogs, menus, chat find, permission bar, ask-user, voice, prompt history).
- Pure gate `shouldEscapeStopGeneration` in `src/lib/escapeStop.ts` with unit tests; App wires capture-phase Escape to the existing `stop()` (same as composer Stop / `effectiveCanStop`).
- Shortcuts catalog already documents Esc as stop — behavior now matches.
- CHANGELOG Unreleased Added entry.

## Problem

The shortcuts help listed Esc as “Stop generation / close overlay”, and the composer Stop button called `stop()`, but Esc only closed overlays (search/find/menus/voice/permission). Users expected Esc to cancel a streaming turn when free.

## Test plan

- [x] `pnpm test -- src/lib/escapeStop.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: start a long generation → press Esc → turn stops (Stop button path)
- [ ] Manual: open permission bar while busy → Esc denies (does not stop first)
- [ ] Manual: open search / chat find / slash menu / dialog while streaming → Esc closes overlay only
- [ ] Manual: voice dictation active → Esc cancels voice, not stop
- [ ] Manual: idle composer → Esc does nothing special (no false stop)