### PR TITLE
feat(appearance): show/hide message timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Message timestamps toggle**: Settings → Appearance — show/hide send times on message actions (`localStorage` `grok.messageTimestamps`; default on). Hides UI only; `createdAt` data is kept.
 - **General workspace**: app-managed `{app_data}/workspaces/general` project (`system:general`) for chats without a user folder — agent can create/edit files without the “bind a project first” toast; always trusted, pinned, not removable
 - **Session Markdown export options**: choose thinking + tool summaries; download `.md` or copy to clipboard (session menu / `/export`)
 - **Updater production status**: About shows silent vs GitHub update channel; Host `updater_status` DTO; `scripts/verify-updater-setup.sh` for maintainer/CI prerequisites (no secret values printed)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,11 @@ import {
   type WallpaperFocus,
   type WallpaperRecord,
 } from "@/lib/themeSkin";
+import {
+  loadMessageTimestampsPref,
+  MESSAGE_TIMESTAMPS_CHANGE_EVENT,
+  saveMessageTimestampsPref,
+} from "@/lib/messageTimestampsPref";
 import { WallpaperMediaLayer } from "@/components/WallpaperMediaLayer";
 import {
   DEFAULT_LAYOUT,
@@ -520,6 +525,9 @@ export default function App() {
   const wallpaperUrlRef = useRef<string | null>(null);
   const [wallpaperScrim, setWallpaperScrim] = useState(() =>
     loadWallpaperScrim(localStorage),
+  );
+  const [showMessageTimestamps, setShowMessageTimestamps] = useState(() =>
+    loadMessageTimestampsPref(localStorage),
   );
   const [layout, setLayout] = useState(() => {
     // Platform UA is available at first paint; reserve window-control inset on Win.
@@ -1917,6 +1925,21 @@ export default function App() {
       for (const u of cleanups) u();
     };
   }, [tr]);
+
+  // Message timestamps visibility (localStorage; Settings dispatches change event).
+  useEffect(() => {
+    const onChange = (ev: Event) => {
+      const detail = (ev as CustomEvent<unknown>).detail;
+      if (typeof detail === "boolean") {
+        setShowMessageTimestamps(detail);
+        return;
+      }
+      setShowMessageTimestamps(loadMessageTimestampsPref(localStorage));
+    };
+    window.addEventListener(MESSAGE_TIMESTAMPS_CHANGE_EVENT, onChange);
+    return () =>
+      window.removeEventListener(MESSAGE_TIMESTAMPS_CHANGE_EVENT, onChange);
+  }, []);
 
   // Phone layout flag: mirror client + ≤820px only (desktop ≥821px unchanged).
   useEffect(() => {
@@ -8830,6 +8853,11 @@ export default function App() {
           theme={theme}
           themePreference={themePreference}
           onTheme={applyThemeChoice}
+          showMessageTimestamps={showMessageTimestamps}
+          onShowMessageTimestamps={(v) => {
+            saveMessageTimestampsPref(v, localStorage);
+            setShowMessageTimestamps(v);
+          }}
           skin={skin}
           onSkin={applySkinChoice}
           wallpaperUrl={wallpaperUrl}
@@ -10482,6 +10510,7 @@ export default function App() {
             findQuery={showChatFind ? chatFindQuery : ""}
             findHitMessageIds={showChatFind ? chatFindHitIds : undefined}
             findActive={showChatFind ? chatFindActive : null}
+            showTimestamps={showMessageTimestamps}
           />
           </UiErrorBoundary>
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -133,6 +133,9 @@ export interface SettingsPageProps {
   /** User preference including "system" (drives the appearance segment). */
   themePreference?: ThemePreference;
   onTheme: (v: ThemePreference) => void;
+  /** Show message timestamps in chat action rows (localStorage). */
+  showMessageTimestamps?: boolean;
+  onShowMessageTimestamps?: (v: boolean) => void;
   /** Color skin pack on top of light/dark (optional for older callers). */
   skin?: ThemeSkinId;
   onSkin?: (v: ThemeSkinId) => void;
@@ -603,6 +606,8 @@ export function SettingsPage({
   theme,
   themePreference: themePreferenceProp,
   onTheme,
+  showMessageTimestamps = true,
+  onShowMessageTimestamps,
   skin = "default",
   onSkin,
   wallpaperUrl = null,
@@ -2229,6 +2234,33 @@ export function SettingsPage({
                     </div>
                   </div>
                 ) : null}
+              </div>
+            ) : null}
+            {onShowMessageTimestamps ? (
+              <div
+                className={
+                  "settings-card" +
+                  rowHighlight("settings-anchor-messageTimestamps")
+                }
+                id="settings-anchor-messageTimestamps"
+              >
+                <div className="settings-row">
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.messageTimestamps")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.messageTimestampsDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={!!showMessageTimestamps}
+                    onChange={() =>
+                      onShowMessageTimestamps(!showMessageTimestamps)
+                    }
+                    ariaLabel={t("settings.messageTimestamps")}
+                  />
+                </div>
               </div>
             ) : null}
           </>

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -402,6 +402,12 @@ export interface ConversationThreadProps {
   onOpenSessionChanges?: () => void;
   /** Open a modified path from turn activity. */
   onOpenModifiedPath?: (path: string) => void;
+  /**
+   * When false, hide message time labels in action rows.
+   * createdAt data is still kept on messages — UI only.
+   * Default true.
+   */
+  showTimestamps?: boolean;
 }
 
 export function ConversationThread({
@@ -431,6 +437,7 @@ export function ConversationThread({
   findActive = null,
   onOpenSessionChanges: _onOpenSessionChanges,
   onOpenModifiedPath: _onOpenModifiedPath,
+  showTimestamps = true,
 }: ConversationThreadProps) {
   const tr = useMemo(() => createT(locale), [locale]);
   void _onOpenSessionChanges;
@@ -953,7 +960,9 @@ export function ConversationThread({
               const isInterjection = m.marker === "interjection";
               const isLastUser = !isInterjection && lastUserMessageId === m.id;
               const isEditing = editingUserMessageId === m.id;
-              const timeLabel = formatMessageTime(m.createdAt, locale);
+              const timeLabel = showTimestamps
+                ? formatMessageTime(m.createdAt, locale)
+                : null;
               const isFindHit = !!findHitMessageIds?.has(m.id);
               const isFindCurrent = findActive?.messageId === m.id;
               const isNodeFocus = focusMessageId === m.id;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -857,6 +857,9 @@ const en = {
   "settings.themeSystem": "System",
   "settings.themeLight": "Light",
   "settings.themeDark": "Dark",
+  "settings.messageTimestamps": "Show message timestamps",
+  "settings.messageTimestampsDesc":
+    "Show the send time next to message actions. Turn off for a cleaner transcript.",
   "settings.skin": "Color skin",
   "settings.skinDesc": "Accent and surface palette (works with light/dark)",
   "settings.skin.default": "Default",
@@ -2942,6 +2945,9 @@ const zh: Record<MessageKey, string> = {
   "settings.themeSystem": "跟随系统",
   "settings.themeLight": "浅色",
   "settings.themeDark": "深色",
+  "settings.messageTimestamps": "显示消息时间戳",
+  "settings.messageTimestampsDesc":
+    "在消息操作区显示发送时间。关闭后对话更简洁。",
   "settings.skin": "配色皮肤",
   "settings.skinDesc": "强调色与表面色板（可与浅/深色叠加）",
   "settings.skin.default": "默认",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -823,6 +823,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.themeSystem": "跟隨系統",
   "settings.themeLight": "淺色",
   "settings.themeDark": "深色",
+  "settings.messageTimestamps": "顯示訊息時間戳",
+  "settings.messageTimestampsDesc":
+    "在訊息操作區顯示傳送時間。關閉後對話更簡潔。",
   "settings.skin": "配色皮膚",
   "settings.skinDesc": "強調色與表面色板（可與淺/深色疊加）",
   "settings.skin.default": "預設",

--- a/src/lib/messageTimestampsPref.test.ts
+++ b/src/lib/messageTimestampsPref.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SHOW_MESSAGE_TIMESTAMPS,
+  MESSAGE_TIMESTAMPS_STORAGE_KEY,
+  loadMessageTimestampsPref,
+  parseMessageTimestampsPref,
+  saveMessageTimestampsPref,
+  type MessageTimestampsStorage,
+} from "./messageTimestampsPref";
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+): MessageTimestampsStorage & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    getItem(key) {
+      return key in data ? data[key]! : null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+  };
+}
+
+describe("messageTimestampsPref", () => {
+  it("defaults to true", () => {
+    expect(DEFAULT_SHOW_MESSAGE_TIMESTAMPS).toBe(true);
+    expect(parseMessageTimestampsPref(null)).toBe(true);
+    expect(parseMessageTimestampsPref("")).toBe(true);
+    expect(parseMessageTimestampsPref("maybe")).toBe(true);
+    expect(loadMessageTimestampsPref(memoryStorage())).toBe(true);
+  });
+
+  it("parses true/false variants", () => {
+    expect(parseMessageTimestampsPref("1")).toBe(true);
+    expect(parseMessageTimestampsPref("true")).toBe(true);
+    expect(parseMessageTimestampsPref(true)).toBe(true);
+    expect(parseMessageTimestampsPref("0")).toBe(false);
+    expect(parseMessageTimestampsPref("false")).toBe(false);
+    expect(parseMessageTimestampsPref(false)).toBe(false);
+  });
+
+  it("round-trips preference", () => {
+    const s = memoryStorage();
+    saveMessageTimestampsPref(false, s);
+    expect(s.data[MESSAGE_TIMESTAMPS_STORAGE_KEY]).toBe("0");
+    expect(loadMessageTimestampsPref(s)).toBe(false);
+    saveMessageTimestampsPref(true, s);
+    expect(s.data[MESSAGE_TIMESTAMPS_STORAGE_KEY]).toBe("1");
+    expect(loadMessageTimestampsPref(s)).toBe(true);
+  });
+});

--- a/src/lib/messageTimestampsPref.ts
+++ b/src/lib/messageTimestampsPref.ts
@@ -1,0 +1,63 @@
+/**
+ * User preference: show message timestamps in chat action rows.
+ * localStorage-only — does not touch Host AppSettings.
+ * Default: true (timestamps visible when createdAt exists).
+ */
+
+export const MESSAGE_TIMESTAMPS_STORAGE_KEY = "grok.messageTimestamps";
+
+/** Fired on `window` after a successful save (detail = boolean show). */
+export const MESSAGE_TIMESTAMPS_CHANGE_EVENT = "grok-message-timestamps-change";
+
+export const DEFAULT_SHOW_MESSAGE_TIMESTAMPS = true;
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface MessageTimestampsStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): MessageTimestampsStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+/** Parse stored value; invalid / empty → default true. */
+export function parseMessageTimestampsPref(raw: unknown): boolean {
+  if (raw === "0" || raw === "false" || raw === false) return false;
+  if (raw === "1" || raw === "true" || raw === true) return true;
+  return DEFAULT_SHOW_MESSAGE_TIMESTAMPS;
+}
+
+export function loadMessageTimestampsPref(
+  storage: MessageTimestampsStorage = defaultStorage(),
+): boolean {
+  try {
+    return parseMessageTimestampsPref(
+      storage.getItem(MESSAGE_TIMESTAMPS_STORAGE_KEY),
+    );
+  } catch {
+    /* private mode */
+    return DEFAULT_SHOW_MESSAGE_TIMESTAMPS;
+  }
+}
+
+export function saveMessageTimestampsPref(
+  show: boolean,
+  storage: MessageTimestampsStorage = defaultStorage(),
+): void {
+  try {
+    storage.setItem(MESSAGE_TIMESTAMPS_STORAGE_KEY, show ? "1" : "0");
+  } catch {
+    /* private mode / quota */
+  }
+  if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(MESSAGE_TIMESTAMPS_CHANGE_EVENT, { detail: show }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/lib/settingsCatalog.test.ts
+++ b/src/lib/settingsCatalog.test.ts
@@ -89,10 +89,11 @@ describe("settingsCatalog", () => {
     expect(isSettingsSectionId("nope")).toBe(false);
   });
 
-  it("keywordKeysForSection includes skin/wallpaper and remote control", () => {
+  it("keywordKeysForSection includes skin/wallpaper/timestamps and remote control", () => {
     const appearance = keywordKeysForSection("appearance");
     expect(appearance).toContain("settings.skin");
     expect(appearance).toContain("settings.wallpaper");
+    expect(appearance).toContain("settings.messageTimestamps");
     const rim = keywordKeysForSection("remote_im");
     expect(rim).toContain("settings.nav.remoteIm");
     expect(rim).toContain("settings.tab.remoteIm");

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -451,6 +451,22 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     ],
     keywords: ["wallpaper", "background", "scrim"],
   },
+  {
+    id: "appearance.messageTimestamps",
+    section: "appearance",
+    anchorId: "settings-anchor-messageTimestamps",
+    labelKey: "settings.messageTimestamps",
+    descKeys: ["settings.messageTimestampsDesc"],
+    keywords: [
+      "timestamp",
+      "timestamps",
+      "message time",
+      "time label",
+      "时间戳",
+      "时间",
+      "時間戳",
+    ],
+  },
   // ── account ──
   {
     id: "account.official",


### PR DESCRIPTION
## Summary

- Settings → **Appearance**: toggle **Show message timestamps** (`id=settings-anchor-messageTimestamps`)
- Preference is **localStorage-only** (`grok.messageTimestamps`, default **on**); optional `grok-message-timestamps-change` window event
- `ConversationThread` takes `showTimestamps?: boolean` (default true) and skips the action-row time label when off — **does not** drop `createdAt` data
- Registered in `settingsCatalog` + en/zh/zh-TW i18n

## Verify

```bash
pnpm typecheck
pnpm test -- src/lib/messageTimestampsPref.test.ts src/lib/settingsCatalog.test.ts src/i18n/messages.test.ts
```

## Test plan

- [ ] Open a chat with messages that have `createdAt` — timestamps visible by default
- [ ] Settings → Appearance → turn off “Show message timestamps” — times disappear on action rows
- [ ] Reload app — preference persists
- [ ] Turn back on — times return
- [ ] Settings search finds “timestamp” / “时间戳”