### PR TITLE
feat(notify): desktop notify when agent asks the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- Desktop notification when the agent asks a question (`session://ask_user`), gated by the existing “Notify on permission” setting
+
 ## [0.2.1] - 2026-07-29
 
 > **Highlight:** Per-project draft memory, video covers, durable relay retries, and calmer chat errors.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3019,9 +3019,30 @@ export default function App() {
               // Background chat asked a question — answer it on reopen.
               setToast(trRef.current("session.backgroundPermission"));
               window.setTimeout(() => setToast(null), 4200);
+              if (
+                shouldShowDesktopNotify("ask_user", notifyPrefsRef.current)
+              ) {
+                showDesktopNotification({
+                  title: trRef.current("notify.askUserTitle"),
+                  body: trRef.current("notify.askUserBody"),
+                  tag: `ask-bg-${p.rpcId}`,
+                  force: true,
+                });
+              }
               return;
             }
             setAskUser(p);
+            // Agent is blocked on an answer — same as permission bar.
+            if (
+              shouldShowDesktopNotify("ask_user", notifyPrefsRef.current)
+            ) {
+              showDesktopNotification({
+                title: trRef.current("notify.askUserTitle"),
+                body: trRef.current("notify.askUserBody"),
+                tag: `ask-${p.rpcId}`,
+                force: true,
+              });
+            }
           }),
         );
         await track(

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1481,6 +1481,8 @@ const en = {
   "notify.turnDoneBody": "Session is ready for the next message.",
   "notify.permissionTitle": "Permission needed",
   "notify.permissionBody": "The agent is waiting for your approval.",
+  "notify.askUserTitle": "Question from agent",
+  "notify.askUserBody": "The agent is waiting for your answer.",
 
   // Slash palette
   "slash.section.commands": "Commands",
@@ -3656,6 +3658,8 @@ const zh: Record<MessageKey, string> = {
   "notify.turnDoneBody": "会话已就绪，可继续输入。",
   "notify.permissionTitle": "需要授权",
   "notify.permissionBody": "Agent 正在等待你的批准。",
+  "notify.askUserTitle": "Agent 提问",
+  "notify.askUserBody": "Agent 正在等待你的回答。",
 
   "slash.section.commands": "命令",
   "slash.section.skills": "技能",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1427,6 +1427,8 @@ export const zhTW: Record<MessageKey, string> = {
   "notify.turnDoneBody": "對話已就緒，可繼續輸入。",
   "notify.permissionTitle": "需要授權",
   "notify.permissionBody": "Agent 正在等待你的批准。",
+  "notify.askUserTitle": "Agent 提問",
+  "notify.askUserBody": "Agent 正在等待你的回答。",
 
   "slash.section.commands": "指令",
   "slash.section.skills": "技能",

--- a/src/lib/desktopNotify.test.ts
+++ b/src/lib/desktopNotify.test.ts
@@ -132,11 +132,13 @@ describe("desktopNotify", () => {
 });
 
 describe("shouldShowDesktopNotify", () => {
-  it("defaults both kinds to on when prefs missing", () => {
+  it("defaults all kinds to on when prefs missing", () => {
     expect(shouldShowDesktopNotify("turn_done", undefined)).toBe(true);
     expect(shouldShowDesktopNotify("permission", null)).toBe(true);
+    expect(shouldShowDesktopNotify("ask_user", null)).toBe(true);
     expect(shouldShowDesktopNotify("turn_done", {})).toBe(true);
     expect(shouldShowDesktopNotify("permission", {})).toBe(true);
+    expect(shouldShowDesktopNotify("ask_user", {})).toBe(true);
   });
 
   it("respects explicit false prefs", () => {
@@ -145,6 +147,9 @@ describe("shouldShowDesktopNotify", () => {
     ).toBe(false);
     expect(
       shouldShowDesktopNotify("permission", { notifyOnPermission: false }),
+    ).toBe(false);
+    expect(
+      shouldShowDesktopNotify("ask_user", { notifyOnPermission: false }),
     ).toBe(false);
     expect(
       shouldShowDesktopNotify("turn_done", {
@@ -158,6 +163,12 @@ describe("shouldShowDesktopNotify", () => {
         notifyOnPermission: true,
       }),
     ).toBe(true);
+    expect(
+      shouldShowDesktopNotify("ask_user", {
+        notifyOnTurnDone: false,
+        notifyOnPermission: true,
+      }),
+    ).toBe(true);
   });
 
   it("treats true as on", () => {
@@ -167,5 +178,21 @@ describe("shouldShowDesktopNotify", () => {
     expect(
       shouldShowDesktopNotify("permission", { notifyOnPermission: true }),
     ).toBe(true);
+    expect(
+      shouldShowDesktopNotify("ask_user", { notifyOnPermission: true }),
+    ).toBe(true);
+  });
+
+  it("ask_user shares notifyOnPermission with permission", () => {
+    expect(
+      shouldShowDesktopNotify("ask_user", { notifyOnPermission: false }),
+    ).toBe(
+      shouldShowDesktopNotify("permission", { notifyOnPermission: false }),
+    );
+    expect(
+      shouldShowDesktopNotify("ask_user", { notifyOnPermission: true }),
+    ).toBe(
+      shouldShowDesktopNotify("permission", { notifyOnPermission: true }),
+    );
   });
 });

--- a/src/lib/desktopNotify.ts
+++ b/src/lib/desktopNotify.ts
@@ -14,7 +14,8 @@ export type DesktopNotifyOptions = {
 
 export type NotifyPermission = "granted" | "denied" | "default" | "unsupported";
 
-export type DesktopNotifyKind = "turn_done" | "permission";
+/** `ask_user` shares the permission toggle (agent is blocked either way). */
+export type DesktopNotifyKind = "turn_done" | "permission" | "ask_user";
 
 export type DesktopNotifyPrefs = {
   notifyOnTurnDone?: boolean;
@@ -24,6 +25,7 @@ export type DesktopNotifyPrefs = {
 /**
  * Whether user prefs allow a desktop notification of this kind.
  * Missing / undefined prefs default to **on** (product default).
+ * `permission` and `ask_user` both use `notifyOnPermission`.
  */
 export function shouldShowDesktopNotify(
   kind: DesktopNotifyKind,


### PR DESCRIPTION
## What
When the agent fires `session://ask_user`, show a desktop notification (same path as permission requests), gated by the existing **Notify on permission** pref. Background chats still toast; foreground still opens the ask modal.

## Why
Background asks only toasted, so it was easy to miss a blocked agent. Permission already had force desktop notify; ask_user should match because the agent is blocked either way.

## Notes
- No new settings field — reuses `notifyOnPermission` via `DesktopNotifyKind` `"ask_user"`.
- i18n: `notify.askUserTitle` / `notify.askUserBody` (en / zh / zh-TW).