### PR TITLE
fix(shortcuts): list find-in-chat and fix send key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ See `docs/llm-wiki/release.md`.
 ### Added
 
 - Desktop notification when the agent asks a question (`session://ask_user`), gated by the existing “Notify on permission” setting
+- **Shortcuts catalog**: list **Find in conversation** (⌘/Ctrl+F) and **voice dictation** (Ctrl+Space; not Cmd)
+
+### Changed
+
+- **Shortcuts catalog**: default **Send** shows plain Enter (not ⌘/Ctrl+Enter); note points to Settings → Composer for mod-enter
+
+**中文 · 新增**
+
+- 快捷键列表：对话内查找（⌘/Ctrl+F）、语音输入（Ctrl+Space）
+
+**中文 · 变更**
+
+- 默认发送键展示为 Enter；说明可在设置 → 对话偏好改用 ⌘/Ctrl+Enter
 
 ## [0.2.1] - 2026-07-29
 

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -1745,7 +1745,19 @@ mod tests {
 
     #[test]
     fn migrate_legacy_general_project_rehomes_sessions() {
+        // Isolate app home — parallel tests share the default data dir and can
+        // wipe sessions_index between seed and assert (Linux CI flake).
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-app-migrate-general-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
         let _ = ensure_app_dirs();
+
         // Seed a legacy system:general row + bound session.
         let mut projects: Vec<Project> = read_json_recover(&projects_file());
         projects.retain(|p| p.id != GENERAL_PROJECT_ID);
@@ -1793,7 +1805,9 @@ mod tests {
         let reloaded = load_sessions_index();
         let hit = reloaded.iter().find(|s| s.id == sid).expect("session");
         assert!(hit.project_id.is_none(), "got {:?}", hit.project_id);
-        let _ = delete_session(&sid);
+
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -699,7 +699,7 @@ const en = {
   "settings.shortcuts.group.diagnostics": "Diagnostics",
   "settings.shortcuts.group.input": "Input",
   "settings.shortcuts.note":
-    "Some chords may be taken by the OS (e.g. input sources). Composer buttons stay available as a fallback.",
+    "Default send is Enter; switch to ⌘/Ctrl+Enter in Settings → Composer. Some chords may be taken by the OS (e.g. input sources).",
   "settings.shortcuts.openHelp": "Open shortcuts help",
   "settings.archived.desc":
     "Chats you archived are listed by project. Select multiple to restore or delete.",
@@ -2899,7 +2899,7 @@ const zh: Record<MessageKey, string> = {
   "settings.shortcuts.group.diagnostics": "诊断",
   "settings.shortcuts.group.input": "输入",
   "settings.shortcuts.note":
-    "部分组合键可能被系统占用（如输入法切换）。输入区按钮仍可作为后备。",
+    "默认 Enter 发送；可在 设置 → 对话偏好 改为 ⌘/Ctrl+Enter。部分组合键可能被系统占用（如输入法切换）。",
   "settings.shortcuts.openHelp": "打开快捷键帮助",
   "settings.archived.desc":
     "已归档的会话按项目分组。可多选后批量还原或删除。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -668,7 +668,7 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.shortcuts.group.diagnostics": "診斷",
   "settings.shortcuts.group.input": "輸入",
   "settings.shortcuts.note":
-    "部分組合鍵可能被系統占用（如輸入法切換）。輸入區按鈕仍可作為後備。",
+    "預設 Enter 傳送；可在 設定 → 對話偏好 改為 ⌘/Ctrl+Enter。部分組合鍵可能被系統占用（如輸入法切換）。",
   "settings.shortcuts.openHelp": "開啟快捷鍵說明",
   "settings.archived.desc":
     "已封存的對話依專案分組。可多選後批次還原或刪除。",

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -34,4 +34,37 @@ describe("shortcuts catalog", () => {
     const flat = grouped.flatMap((g) => g.rows.map((r) => r.id));
     expect(flat.sort()).toEqual([...SHORTCUTS.map((s) => s.id)].sort());
   });
+
+  it("lists find-in-chat (Cmd/Ctrl+F) in workbench near search", () => {
+    const row = SHORTCUTS.find((s) => s.id === "findInChat");
+    expect(row).toBeDefined();
+    expect(row!.labelKey).toBe("shortcuts.findInChat");
+    expect(row!.group).toBe("workbench");
+    expect(row!.mac).toBe("⌘ F");
+    expect(row!.win).toBe("Ctrl F");
+    const searchIdx = SHORTCUTS.findIndex((s) => s.id === "search");
+    const findIdx = SHORTCUTS.findIndex((s) => s.id === "findInChat");
+    expect(findIdx).toBeGreaterThan(searchIdx);
+  });
+
+  it("lists default send as plain Enter, not only mod-enter", () => {
+    const row = SHORTCUTS.find((s) => s.id === "send");
+    expect(row).toBeDefined();
+    // Default product pref is plain Enter; ⌘/Ctrl+Enter is a Settings → Composer option.
+    expect(row!.mac).toMatch(/↵|Return/);
+    expect(row!.win.toLowerCase()).toBe("enter");
+    expect(row!.mac).not.toMatch(/⌘/);
+    expect(row!.win.toLowerCase()).not.toMatch(/ctrl/);
+  });
+
+  it("lists Ctrl+Space dictation on both platforms (not Cmd)", () => {
+    const row = SHORTCUTS.find((s) => s.id === "dictation");
+    expect(row).toBeDefined();
+    expect(row!.group).toBe("input");
+    expect(row!.mac).toMatch(/Ctrl/i);
+    expect(row!.mac).not.toMatch(/⌘/);
+    expect(row!.win).toMatch(/Ctrl/i);
+    expect(row!.mac.toLowerCase()).toContain("space");
+    expect(row!.win.toLowerCase()).toContain("space");
+  });
 });

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -27,6 +27,13 @@ export const SHORTCUTS: ShortcutRow[] = [
     win: "Ctrl K",
   },
   {
+    id: "findInChat",
+    labelKey: "shortcuts.findInChat",
+    group: "workbench",
+    mac: "⌘ F",
+    win: "Ctrl F",
+  },
+  {
     id: "newChat",
     labelKey: "shortcuts.newChat",
     group: "workbench",
@@ -37,8 +44,9 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "send",
     labelKey: "shortcuts.send",
     group: "workbench",
-    mac: "⌘ ↵",
-    win: "Ctrl Enter",
+    // Product default: plain Enter (mod-enter only when Settings → Composer pref is set).
+    mac: "↵",
+    win: "Enter",
   },
   {
     id: "stop",
@@ -74,6 +82,14 @@ export const SHORTCUTS: ShortcutRow[] = [
     group: "input",
     mac: "⌘ ⇧ V",
     win: "Ctrl Shift V",
+  },
+  {
+    // Global Ctrl+Space (not Cmd+Space — Spotlight on macOS). See isVoiceToggleKey.
+    id: "dictation",
+    labelKey: "shortcuts.voice",
+    group: "input",
+    mac: "Ctrl Space",
+    win: "Ctrl Space",
   },
 ];
 


### PR DESCRIPTION
## Summary

- Add **Find in conversation** (`⌘ F` / `Ctrl F`) to the shortcuts catalog (already bound in App).
- Correct **Send** display to plain Enter (product default); mod-enter is a Settings → Composer preference, not always-on.
- Document **voice dictation** (`Ctrl Space` on both platforms; not Cmd).
- Update shortcuts note i18n (en / zh / zh-TW) pointing users to Settings → Composer for ⌘/Ctrl+Enter.

## Verify

- `pnpm typecheck`
- `pnpm test -- src/lib/shortcuts.test.ts src/i18n/messages.test.ts`