### PR TITLE
feat(composer): optional spellcheck in the input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ### Added
 
 - Desktop notification when the agent asks a question (`session://ask_user`), gated by the existing “Notify on permission” setting
+- **Composer spellcheck** (Settings → General → Composer): optional browser spellcheck on the main chat input (off by default)
 
 ## [0.2.1] - 2026-07-29
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -270,6 +270,10 @@ import {
   type ComposerSendKeyPref,
 } from "@/lib/composerSendKey";
 import {
+  COMPOSER_SPELLCHECK_CHANGED_EVENT,
+  loadComposerSpellcheck,
+} from "@/lib/composerSpellcheck";
+import {
   clearComposerProjectDraft,
   loadComposerProjectDraft,
   projectDraftKey,
@@ -1173,6 +1177,16 @@ export default function App() {
     window.addEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, reload);
     return () =>
       window.removeEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, reload);
+  }, []);
+  /** Browser spellcheck on main composer (localStorage; Settings → Composer). */
+  const [composerSpellcheck, setComposerSpellcheck] = useState(() =>
+    loadComposerSpellcheck(),
+  );
+  useEffect(() => {
+    const reload = () => setComposerSpellcheck(loadComposerSpellcheck());
+    window.addEventListener(COMPOSER_SPELLCHECK_CHANGED_EVENT, reload);
+    return () =>
+      window.removeEventListener(COMPOSER_SPELLCHECK_CHANGED_EVENT, reload);
   }, []);
   /** Files/folders attached for next send (@path to agent). */
   const [attachments, setAttachments] = useState<Attachment[]>([]);
@@ -11692,6 +11706,7 @@ export default function App() {
                 className="composer__input"
                 value={draft}
                 disabled={!canType(session.state)}
+                spellCheck={composerSpellcheck}
                 placeholder={
                   goalMode
                     ? tr("composer.goalPlaceholder")

--- a/src/components/ComposerEditor.tsx
+++ b/src/components/ComposerEditor.tsx
@@ -240,6 +240,8 @@ export type ComposerEditorProps = {
   disabled?: boolean;
   placeholder?: string;
   className?: string;
+  /** Browser spellcheck on the contenteditable root. Default false. */
+  spellCheck?: boolean;
   onKeyDown?: (e: KeyboardEvent<HTMLDivElement>) => void;
   onSlashQueryChange?: (
     q: { start: number; query: string; end: number } | null,
@@ -262,6 +264,7 @@ export function ComposerEditor({
   disabled,
   placeholder,
   className,
+  spellCheck,
   onKeyDown,
   onSlashQueryChange,
   editorRef,
@@ -541,6 +544,7 @@ export function ComposerEditor({
         ref={setRefs}
         className={className ?? "composer__input"}
         contentEditable={!disabled}
+        spellCheck={spellCheck ?? false}
         role="textbox"
         aria-multiline
         aria-placeholder={placeholder}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -83,6 +83,10 @@ import {
   saveComposerSendKeyPref,
   type ComposerSendKeyPref,
 } from "@/lib/composerSendKey";
+import {
+  loadComposerSpellcheck,
+  saveComposerSpellcheck,
+} from "@/lib/composerSpellcheck";
 import type { AccountStatus, DetectedEditor } from "@/lib/api";
 import * as api from "@/lib/api";
 import { AccountPanel } from "@/components/AccountPanel";
@@ -792,6 +796,10 @@ export function SettingsPage({
   /** Composer Enter vs ⌘/Ctrl+Enter — localStorage only (no Host settings). */
   const [composerSendKeyPref, setComposerSendKeyPref] =
     useState<ComposerSendKeyPref>(() => loadComposerSendKeyPref());
+  /** Browser spellcheck on main composer — localStorage only. */
+  const [composerSpellcheck, setComposerSpellcheck] = useState(() =>
+    loadComposerSpellcheck(),
+  );
   /** Pending scroll target after search jump / deep link. */
   const pendingAnchorRef = useRef<string | null>(null);
   const [highlightAnchor, setHighlightAnchor] = useState<string | null>(null);
@@ -1555,6 +1563,31 @@ export function SettingsPage({
                       label: t("settings.composerSendKey.modEnter"),
                     },
                   ]}
+                />
+              </div>
+              <div
+                className={
+                  "settings-row" +
+                  rowHighlight("settings-anchor-composerSpellcheck")
+                }
+                id="settings-anchor-composerSpellcheck"
+              >
+                <div className="settings-row__text">
+                  <div className="settings-row__label">
+                    {t("settings.composerSpellcheck")}
+                  </div>
+                  <div className="settings-row__desc">
+                    {t("settings.composerSpellcheckDesc")}
+                  </div>
+                </div>
+                <UiCheck
+                  checked={composerSpellcheck}
+                  onChange={() => {
+                    const next = !composerSpellcheck;
+                    setComposerSpellcheck(next);
+                    saveComposerSpellcheck(next);
+                  }}
+                  ariaLabel={t("settings.composerSpellcheck")}
                 />
               </div>
             </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -869,6 +869,9 @@ const en = {
     "Choose whether plain Enter sends, or inserts a newline (⌘/Ctrl+Enter sends instead). Applies to the chat composer.",
   "settings.composerSendKey.enter": "Enter to send (Shift+Enter for newline)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter to send (Enter for newline)",
+  "settings.composerSpellcheck": "Spellcheck",
+  "settings.composerSpellcheckDesc":
+    "Underline misspelled words in the chat input using the system dictionary. Off by default.",
   "settings.theme": "Theme",
   "settings.themeDesc": "Follow the system, or lock light / dark",
   "settings.themeSystem": "System",
@@ -3066,6 +3069,9 @@ const zh: Record<MessageKey, string> = {
     "选择 Enter 直接发送，还是 Enter 换行、⌘/Ctrl+Enter 发送。仅作用于对话输入框。",
   "settings.composerSendKey.enter": "Enter 发送（Shift+Enter 换行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 发送（Enter 换行）",
+  "settings.composerSpellcheck": "拼写检查",
+  "settings.composerSpellcheckDesc":
+    "在对话输入框用系统词典标出拼写错误。默认关闭。",
   "settings.theme": "主题",
   "settings.themeDesc": "跟随系统，或固定浅色 / 深色",
   "settings.themeSystem": "跟随系统",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -835,6 +835,9 @@ export const zhTW: Record<MessageKey, string> = {
     "選擇 Enter 直接傳送，或 Enter 換行、⌘/Ctrl+Enter 傳送。僅作用於對話輸入框。",
   "settings.composerSendKey.enter": "Enter 傳送（Shift+Enter 換行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 傳送（Enter 換行）",
+  "settings.composerSpellcheck": "拼字檢查",
+  "settings.composerSpellcheckDesc":
+    "在對話輸入框用系統辭典標出拼字錯誤。預設關閉。",
   "settings.theme": "主題",
   "settings.themeDesc": "跟隨系統，或固定淺色 / 深色",
   "settings.themeSystem": "跟隨系統",

--- a/src/lib/composerSpellcheck.test.ts
+++ b/src/lib/composerSpellcheck.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  COMPOSER_SPELLCHECK_CHANGED_EVENT,
+  COMPOSER_SPELLCHECK_KEY,
+  loadComposerSpellcheck,
+  saveComposerSpellcheck,
+} from "./composerSpellcheck";
+
+function memoryStorage(seed: Record<string, string> = {}): Storage {
+  const map = new Map(Object.entries(seed));
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => map.get(k) ?? null,
+    key: (i) => [...map.keys()][i] ?? null,
+    removeItem: (k) => {
+      map.delete(k);
+    },
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+  };
+}
+
+describe("composerSpellcheck pref storage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to false (current behavior)", () => {
+    expect(loadComposerSpellcheck(memoryStorage())).toBe(false);
+  });
+
+  it("round-trips preference", () => {
+    const s = memoryStorage();
+    saveComposerSpellcheck(true, s);
+    expect(s.getItem(COMPOSER_SPELLCHECK_KEY)).toBe("true");
+    expect(loadComposerSpellcheck(s)).toBe(true);
+    saveComposerSpellcheck(false, s);
+    expect(s.getItem(COMPOSER_SPELLCHECK_KEY)).toBe("false");
+    expect(loadComposerSpellcheck(s)).toBe(false);
+  });
+
+  it("accepts true/false and 1/0 values", () => {
+    expect(
+      loadComposerSpellcheck(
+        memoryStorage({ [COMPOSER_SPELLCHECK_KEY]: "true" }),
+      ),
+    ).toBe(true);
+    expect(
+      loadComposerSpellcheck(memoryStorage({ [COMPOSER_SPELLCHECK_KEY]: "1" })),
+    ).toBe(true);
+    expect(
+      loadComposerSpellcheck(
+        memoryStorage({ [COMPOSER_SPELLCHECK_KEY]: "false" }),
+      ),
+    ).toBe(false);
+    expect(
+      loadComposerSpellcheck(memoryStorage({ [COMPOSER_SPELLCHECK_KEY]: "0" })),
+    ).toBe(false);
+  });
+
+  it("ignores unknown values", () => {
+    expect(
+      loadComposerSpellcheck(
+        memoryStorage({ [COMPOSER_SPELLCHECK_KEY]: "maybe" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("dispatches grok:composerSpellcheck on save when window exists", () => {
+    const listeners = new Map<string, Set<EventListener>>();
+    const stubWindow = {
+      addEventListener(type: string, listener: EventListener) {
+        if (!listeners.has(type)) listeners.set(type, new Set());
+        listeners.get(type)!.add(listener);
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners.get(type)?.delete(listener);
+      },
+      dispatchEvent(ev: Event) {
+        const set = listeners.get(ev.type);
+        if (set) for (const fn of set) fn(ev);
+        return true;
+      },
+    };
+    vi.stubGlobal("window", stubWindow);
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent<T = unknown> extends Event {
+        detail: T;
+        constructor(type: string, init?: CustomEventInit<T>) {
+          super(type);
+          this.detail = init?.detail as T;
+        }
+      },
+    );
+
+    const handler = vi.fn();
+    stubWindow.addEventListener(COMPOSER_SPELLCHECK_CHANGED_EVENT, handler);
+    saveComposerSpellcheck(true, memoryStorage());
+    expect(handler).toHaveBeenCalledTimes(1);
+    const ev = handler.mock.calls[0][0] as CustomEvent;
+    expect(ev.detail).toBe(true);
+  });
+});

--- a/src/lib/composerSpellcheck.ts
+++ b/src/lib/composerSpellcheck.ts
@@ -1,0 +1,44 @@
+/**
+ * User preference for browser spellcheck on the main chat composer.
+ * Default matches current product: spellcheck off.
+ */
+
+export const COMPOSER_SPELLCHECK_KEY = "grok.composerSpellcheck";
+
+/** Fired on `window` after a same-tab preference save (storage events are cross-tab only). */
+export const COMPOSER_SPELLCHECK_CHANGED_EVENT = "grok:composerSpellcheck";
+
+export function loadComposerSpellcheck(
+  storage: Storage = localStorage,
+): boolean {
+  try {
+    const v = storage.getItem(COMPOSER_SPELLCHECK_KEY);
+    if (v === "1" || v === "true") return true;
+    if (v === "0" || v === "false") return false;
+  } catch {
+    /* private mode */
+  }
+  return false;
+}
+
+export function saveComposerSpellcheck(
+  enabled: boolean,
+  storage: Storage = localStorage,
+): void {
+  try {
+    storage.setItem(COMPOSER_SPELLCHECK_KEY, enabled ? "true" : "false");
+  } catch {
+    /* ignore */
+  }
+  try {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent(COMPOSER_SPELLCHECK_CHANGED_EVENT, {
+          detail: enabled,
+        }),
+      );
+    }
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -261,6 +261,25 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "keyboard",
     ],
   },
+  {
+    id: "general.composerSpellcheck",
+    section: "general",
+    tab: "composer",
+    anchorId: "settings-anchor-composerSpellcheck",
+    labelKey: "settings.composerSpellcheck",
+    descKeys: [
+      "settings.composerSpellcheckDesc",
+      "settings.section.composer",
+    ],
+    keywords: [
+      "composer",
+      "spellcheck",
+      "spell check",
+      "spelling",
+      "typo",
+      "autocorrect",
+    ],
+  },
   // ── general / permissions ──
   {
     id: "general.permissionPolicy",


### PR DESCRIPTION
## Summary
- Optional browser spellcheck on the main chat composer (`spellCheck` prop).
- Preference in localStorage (`grok.composerSpellcheck`, default off) with `grok:composerSpellcheck` change event.
- Settings → General → Composer toggle + catalog/i18n (en/zh/zh-TW).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/composerSpellcheck.test.ts src/lib/settingsCatalog.test.ts src/i18n/messages.test.ts`