### PR TITLE
feat(chat): optional line numbers on code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ### Added
 
 - Desktop notification when the agent asks a question (`session://ask_user`), gated by the existing “Notify on permission” setting
+- **Optional line numbers** on chat fenced code blocks (Settings → Appearance → Interface; default off)
 
 ## [0.2.1] - 2026-07-29
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -102,6 +102,10 @@ import {
 } from "@/i18n";
 import { useUpdaterContext } from "@/hooks/UpdaterProvider";
 import {
+  loadCodeLineNumbersPref,
+  saveCodeLineNumbersPref,
+} from "@/lib/codeLineNumbersPref";
+import {
   loadCodeWrapPref,
   saveCodeWrapPref,
 } from "@/lib/codeWrapPref";
@@ -845,6 +849,10 @@ export function SettingsPage({
 /** Chat code-block wrap default — frontend-only localStorage. */
   const [codeWrapDefault, setCodeWrapDefault] = useState(() =>
     loadCodeWrapPref(),
+  );
+  /** Chat code-block line numbers — frontend-only localStorage. */
+  const [codeLineNumbers, setCodeLineNumbers] = useState(() =>
+    loadCodeLineNumbersPref(),
   );
   /** Message action buttons: hover vs always visible. */
   const [messageActionsVisibility, setMessageActionsVisibilityState] =
@@ -2658,6 +2666,31 @@ export function SettingsPage({
                         saveCodeWrapPref(next);
                       }}
                       ariaLabel={t("settings.codeWrapDefault")}
+                    />
+                  </div>
+                </div>
+                <div
+                  className={
+                    "settings-card" +
+                    rowHighlight("settings-anchor-codeLineNumbers")
+                  }
+                  id="settings-anchor-codeLineNumbers"
+                >
+                  <div className="settings-row">
+                    <div className="settings-row__text">
+                      <SettingsLabelWithTip
+                        label={t("settings.codeLineNumbers")}
+                        tip={t("settings.codeLineNumbersDesc")}
+                      />
+                    </div>
+                    <UiCheck
+                      checked={codeLineNumbers}
+                      onChange={() => {
+                        const next = !codeLineNumbers;
+                        setCodeLineNumbers(next);
+                        saveCodeLineNumbersPref(next);
+                      }}
+                      ariaLabel={t("settings.codeLineNumbers")}
                     />
                   </div>
                 </div>

--- a/src/components/lobe-chat/CodeBlock.tsx
+++ b/src/components/lobe-chat/CodeBlock.tsx
@@ -2,9 +2,13 @@
  * Path / code block — Cursor-style soft chrome (label + wrap + copy).
  */
 
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { IconCheck, IconCopy } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
+import {
+  CODE_LINE_NUMBERS_PREF_EVENT,
+  loadCodeLineNumbersPref,
+} from "@/lib/codeLineNumbersPref";
 import { loadCodeWrapPref } from "@/lib/codeWrapPref";
 import { cn } from "@/lib/utils";
 
@@ -25,17 +29,36 @@ export function CodeBlock({
   wrapLabel = "Wrap",
   unwrapLabel = "No wrap",
   copyLabel = "Copy",
+  showLineNumbers: showLineNumbersProp,
 }: {
   language?: string;
   children: ReactNode;
   wrapLabel?: string;
   unwrapLabel?: string;
   copyLabel?: string;
+  /** Override global line-numbers pref when set. */
+  showLineNumbers?: boolean;
 }) {
   const [wrap, setWrap] = useState(() => loadCodeWrapPref());
+  const [prefLineNumbers, setPrefLineNumbers] = useState(() =>
+    loadCodeLineNumbersPref(),
+  );
   const [copied, setCopied] = useState(false);
   const lang = (language || "text").replace(/^language-/, "") || "text";
   const text = extractText(children).replace(/\n$/, "");
+  const showLineNumbers = showLineNumbersProp ?? prefLineNumbers;
+  const lineCount = Math.max(1, text.split("\n").length);
+
+  useEffect(() => {
+    if (showLineNumbersProp !== undefined) return;
+    const onPref = (ev: Event) => {
+      const detail = (ev as CustomEvent).detail;
+      if (typeof detail === "boolean") setPrefLineNumbers(detail);
+      else setPrefLineNumbers(loadCodeLineNumbersPref());
+    };
+    window.addEventListener(CODE_LINE_NUMBERS_PREF_EVENT, onPref);
+    return () => window.removeEventListener(CODE_LINE_NUMBERS_PREF_EVENT, onPref);
+  }, [showLineNumbersProp]);
 
   const onCopy = async () => {
     try {
@@ -48,7 +71,7 @@ export function CodeBlock({
   };
 
   return (
-    <div className="chat-code">
+    <div className={cn("chat-code", showLineNumbers && "chat-code--lines")}>
       <div className="chat-code__bar">
         <span className="chat-code__lang">{lang}</span>
         <div className="chat-code__bar-actions">
@@ -77,9 +100,20 @@ export function CodeBlock({
           </Tip>
         </div>
       </div>
-      <pre className={cn("chat-code__pre", wrap && "is-wrap")}>
-        <code>{children}</code>
-      </pre>
+      <div className="chat-code__body">
+        {showLineNumbers ? (
+          <div className="chat-code__gutter" aria-hidden>
+            {Array.from({ length: lineCount }, (_, i) => (
+              <span key={i} className="chat-code__ln">
+                {i + 1}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        <pre className={cn("chat-code__pre", wrap && "is-wrap")}>
+          <code>{children}</code>
+        </pre>
+      </div>
     </div>
   );
 }

--- a/src/components/lobe-chat/lobe-chat.css
+++ b/src/components/lobe-chat/lobe-chat.css
@@ -526,6 +526,11 @@ html[data-msg-actions="always"] .lobe-chat-item__actions {
   color: var(--chat-icon-btn-hover);
 }
 
+.chat-code__body {
+  display: block;
+  min-width: 0;
+}
+
 .chat-code__pre {
   margin: 0;
   padding: 10px 14px 14px;
@@ -557,6 +562,45 @@ html[data-msg-actions="always"] .lobe-chat-item__actions {
   border: none;
   padding: 0;
   white-space: inherit;
+}
+
+/* Optional line-number gutter (Settings → Appearance → Interface). */
+.chat-code--lines .chat-code__body {
+  display: flex;
+  align-items: stretch;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.chat-code--lines .chat-code__gutter {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  padding: 10px 0 14px 12px;
+  margin: 0;
+  font-family: var(--chat-mono);
+  font-size: var(--chat-fs-sm);
+  line-height: 1.55;
+  color: var(--chat-text-3);
+  user-select: none;
+  pointer-events: none;
+  border-right: 1px solid var(--chat-code-border);
+}
+
+.chat-code--lines .chat-code__ln {
+  display: block;
+  min-width: 1.5em;
+  padding-right: 10px;
+  text-align: right;
+  opacity: 0.72;
+}
+
+.chat-code--lines .chat-code__pre {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: visible;
+  padding-left: 12px;
 }
 
 /*

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -888,6 +888,9 @@ const en = {
   "settings.codeWrapDefault": "Wrap code lines by default",
   "settings.codeWrapDefaultDesc":
     "New chat code blocks start with soft wrap on. You can still toggle wrap on each block.",
+  "settings.codeLineNumbers": "Show line numbers on code blocks",
+  "settings.codeLineNumbersDesc":
+    "Display a line-number gutter on the left of fenced code in chat. Off by default.",
   "settings.messageActions": "Message actions",
   "settings.messageActionsDesc":
     "Show Copy, Export, Regenerate, and Edit on hover, or keep them always visible (better for trackpads and accessibility)",
@@ -1811,6 +1814,7 @@ const en = {
   "chat.scrollBottom": "Scroll to latest",
   "chat.codeWrap": "Wrap lines",
   "chat.codeUnwrap": "No wrap",
+  "chat.lineNumbers": "Line numbers",
   "composer.effortPanelHint": "Drag to set reasoning depth",
   "automations.menu": "Create automation",
   "automations.menuHint": "Schedule a recurring task",
@@ -3084,6 +3088,9 @@ const zh: Record<MessageKey, string> = {
   "settings.codeWrapDefault": "默认自动换行代码",
   "settings.codeWrapDefaultDesc":
     "新的聊天代码块默认开启软换行。仍可在每个代码块上单独切换。",
+  "settings.codeLineNumbers": "代码块显示行号",
+  "settings.codeLineNumbersDesc":
+    "在聊天中的围栏代码块左侧显示行号栏。默认关闭。",
   "settings.messageActions": "消息操作按钮",
   "settings.messageActionsDesc":
     "复制、导出、重新生成、编辑：悬停显示，或始终可见（触控板与无障碍更友好）",
@@ -3979,6 +3986,7 @@ const zh: Record<MessageKey, string> = {
   "chat.scrollBottom": "回到最新",
   "chat.codeWrap": "启用自动换行",
   "chat.codeUnwrap": "取消自动换行",
+  "chat.lineNumbers": "行号",
   "composer.effortPanelHint": "拖动设置思考深度",
   "automations.menu": "创建自动化",
   "automations.menuHint": "安排周期任务",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -853,6 +853,9 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.codeWrapDefault": "預設自動換行程式碼",
   "settings.codeWrapDefaultDesc":
     "新的聊天程式碼區塊預設開啟軟換行。仍可在每個區塊上單獨切換。",
+  "settings.codeLineNumbers": "程式碼區塊顯示行號",
+  "settings.codeLineNumbersDesc":
+    "在聊天中的圍欄程式碼區塊左側顯示行號欄。預設關閉。",
   "settings.messageActions": "訊息操作按鈕",
   "settings.messageActionsDesc":
     "複製、匯出、重新生成、編輯：懸停顯示，或始終可見（觸控板與無障礙更友善）",
@@ -1748,6 +1751,7 @@ export const zhTW: Record<MessageKey, string> = {
   "chat.scrollBottom": "回到最新",
   "chat.codeWrap": "啟用自動換行",
   "chat.codeUnwrap": "取消自動換行",
+  "chat.lineNumbers": "行號",
   "composer.effortPanelHint": "拖動設定思考深度",
   "automations.menu": "建立自動化",
   "automations.menuHint": "排程週期任務",

--- a/src/lib/codeLineNumbersPref.test.ts
+++ b/src/lib/codeLineNumbersPref.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CODE_LINE_NUMBERS_PREF_EVENT,
+  CODE_LINE_NUMBERS_PREF_KEY,
+  loadCodeLineNumbersPref,
+  saveCodeLineNumbersPref,
+} from "./codeLineNumbersPref";
+
+function memoryStorage(seed: Record<string, string> = {}): Storage {
+  const map = new Map(Object.entries(seed));
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => map.get(k) ?? null,
+    key: (i) => [...map.keys()][i] ?? null,
+    removeItem: (k) => {
+      map.delete(k);
+    },
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+  };
+}
+
+describe("codeLineNumbersPref", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to false (no line numbers)", () => {
+    expect(loadCodeLineNumbersPref(memoryStorage())).toBe(false);
+  });
+
+  it("round-trips preference", () => {
+    const s = memoryStorage();
+    saveCodeLineNumbersPref(true, s);
+    expect(s.getItem(CODE_LINE_NUMBERS_PREF_KEY)).toBe("1");
+    expect(loadCodeLineNumbersPref(s)).toBe(true);
+    saveCodeLineNumbersPref(false, s);
+    expect(s.getItem(CODE_LINE_NUMBERS_PREF_KEY)).toBe("0");
+    expect(loadCodeLineNumbersPref(s)).toBe(false);
+  });
+
+  it("accepts true/false, 1/0, and on/off values", () => {
+    expect(
+      loadCodeLineNumbersPref(
+        memoryStorage({ [CODE_LINE_NUMBERS_PREF_KEY]: "true" }),
+      ),
+    ).toBe(true);
+    expect(
+      loadCodeLineNumbersPref(
+        memoryStorage({ [CODE_LINE_NUMBERS_PREF_KEY]: "1" }),
+      ),
+    ).toBe(true);
+    expect(
+      loadCodeLineNumbersPref(
+        memoryStorage({ [CODE_LINE_NUMBERS_PREF_KEY]: "on" }),
+      ),
+    ).toBe(true);
+    expect(
+      loadCodeLineNumbersPref(
+        memoryStorage({ [CODE_LINE_NUMBERS_PREF_KEY]: "false" }),
+      ),
+    ).toBe(false);
+    expect(
+      loadCodeLineNumbersPref(
+        memoryStorage({ [CODE_LINE_NUMBERS_PREF_KEY]: "0" }),
+      ),
+    ).toBe(false);
+    expect(
+      loadCodeLineNumbersPref(
+        memoryStorage({ [CODE_LINE_NUMBERS_PREF_KEY]: "off" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores unknown values", () => {
+    expect(
+      loadCodeLineNumbersPref(
+        memoryStorage({ [CODE_LINE_NUMBERS_PREF_KEY]: "maybe" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("dispatches grok:codeLineNumbersPref on save when window exists", () => {
+    const listeners = new Map<string, Set<EventListener>>();
+    const stubWindow = {
+      addEventListener(type: string, listener: EventListener) {
+        if (!listeners.has(type)) listeners.set(type, new Set());
+        listeners.get(type)!.add(listener);
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners.get(type)?.delete(listener);
+      },
+      dispatchEvent(ev: Event) {
+        const set = listeners.get(ev.type);
+        if (set) for (const fn of set) fn(ev);
+        return true;
+      },
+    };
+    vi.stubGlobal("window", stubWindow);
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent<T = unknown> extends Event {
+        detail: T;
+        constructor(type: string, init?: CustomEventInit<T>) {
+          super(type);
+          this.detail = init?.detail as T;
+        }
+      },
+    );
+
+    const handler = vi.fn();
+    stubWindow.addEventListener(CODE_LINE_NUMBERS_PREF_EVENT, handler);
+    saveCodeLineNumbersPref(true, memoryStorage());
+    expect(handler).toHaveBeenCalledTimes(1);
+    const ev = handler.mock.calls[0][0] as CustomEvent;
+    expect(ev.detail).toBe(true);
+  });
+});

--- a/src/lib/codeLineNumbersPref.ts
+++ b/src/lib/codeLineNumbersPref.ts
@@ -1,0 +1,45 @@
+/**
+ * User preference for line numbers on chat markdown code blocks.
+ * Frontend-only localStorage; default off.
+ */
+
+export const CODE_LINE_NUMBERS_PREF_KEY = "grok.codeLineNumbers";
+
+/** Dispatched on `window` after a successful save (detail = new pref). */
+export const CODE_LINE_NUMBERS_PREF_EVENT = "grok:codeLineNumbersPref";
+
+/** `true` = show line number gutter; `false` = no gutter (default). */
+export type CodeLineNumbersPref = boolean;
+
+export function loadCodeLineNumbersPref(
+  storage: Storage = localStorage,
+): CodeLineNumbersPref {
+  try {
+    const v = storage.getItem(CODE_LINE_NUMBERS_PREF_KEY);
+    if (v === "1" || v === "true" || v === "on") return true;
+    if (v === "0" || v === "false" || v === "off") return false;
+  } catch {
+    /* private mode */
+  }
+  return false;
+}
+
+export function saveCodeLineNumbersPref(
+  pref: CodeLineNumbersPref,
+  storage: Storage = localStorage,
+): void {
+  try {
+    storage.setItem(CODE_LINE_NUMBERS_PREF_KEY, pref ? "1" : "0");
+  } catch {
+    /* ignore */
+  }
+  try {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent(CODE_LINE_NUMBERS_PREF_EVENT, { detail: pref }),
+      );
+    }
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -586,6 +586,23 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     ],
   },
   {
+    id: "appearance.codeLineNumbers",
+    section: "appearance",
+    tab: "interface",
+    anchorId: "settings-anchor-codeLineNumbers",
+    labelKey: "settings.codeLineNumbers",
+    descKeys: ["settings.codeLineNumbersDesc"],
+    keywords: [
+      "line numbers",
+      "code lines",
+      "gutter",
+      "行号",
+      "行號",
+      "代码行号",
+      "程式碼行號",
+    ],
+  },
+  {
     id: "appearance.messageActions",
     section: "appearance",
     tab: "interface",


### PR DESCRIPTION
## Summary
- Setting to show line numbers on fenced code in chat (default off).
- CodeBlock reads the pref; wrap/copy unchanged.

## Test plan
- [ ] Toggle on in Appearance → Interface
- [ ] New code blocks show gutter
- [ ] Copy still full text