### PR TITLE
feat(composer): draft character and word count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ### Added
 
 - Desktop notification when the agent asks a question (`session://ask_user`), gated by the existing “Notify on permission” setting
+<<<<<<< ours
 - **Shortcuts catalog**: list **Find in conversation** (⌘/Ctrl+F) and **voice dictation** (Ctrl+Space; not Cmd)
 - **Composer spellcheck** (Settings → General → Composer): optional browser spellcheck on the main chat input (off by default)
 - **Session JSON export**: download chat as import-friendly JSON (`{ title, sessionId, exportedAt, messages: [{role,content}] }`) from the session menu; round-trips with existing transcript import
@@ -40,6 +41,9 @@ See `docs/llm-wiki/release.md`.
 **中文 · 变更**
 
 - 默认发送键展示为 Enter；说明可在设置 → 对话偏好改用 ⌘/Ctrl+Enter
+=======
+- **Composer draft stats**: muted character and word count when the input is non-empty (Settings → General → Composer; on by default)
+>>>>>>> theirs
 
 ## [0.2.1] - 2026-07-29
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -277,9 +277,16 @@ import {
   type ComposerSendKeyPref,
 } from "@/lib/composerSendKey";
 import {
+<<<<<<< ours
   COMPOSER_SPELLCHECK_CHANGED_EVENT,
   loadComposerSpellcheck,
 } from "@/lib/composerSpellcheck";
+=======
+  COMPOSER_DRAFT_STATS_CHANGED_EVENT,
+  computeDraftStats,
+  loadComposerDraftStatsPref,
+} from "@/lib/draftStats";
+>>>>>>> theirs
 import {
   clearComposerProjectDraft,
   loadComposerProjectDraft,
@@ -1203,6 +1210,7 @@ export default function App() {
     return () =>
       window.removeEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, reload);
   }, []);
+<<<<<<< ours
   /** Browser spellcheck on main composer (localStorage; Settings → Composer). */
   const [composerSpellcheck, setComposerSpellcheck] = useState(() =>
     loadComposerSpellcheck(),
@@ -1212,6 +1220,17 @@ export default function App() {
     window.addEventListener(COMPOSER_SPELLCHECK_CHANGED_EVENT, reload);
     return () =>
       window.removeEventListener(COMPOSER_SPELLCHECK_CHANGED_EVENT, reload);
+=======
+  /** Muted char/word count on non-empty drafts (localStorage; Settings → Composer). */
+  const [showComposerDraftStats, setShowComposerDraftStats] = useState(() =>
+    loadComposerDraftStatsPref(),
+  );
+  useEffect(() => {
+    const reload = () => setShowComposerDraftStats(loadComposerDraftStatsPref());
+    window.addEventListener(COMPOSER_DRAFT_STATS_CHANGED_EVENT, reload);
+    return () =>
+      window.removeEventListener(COMPOSER_DRAFT_STATS_CHANGED_EVENT, reload);
+>>>>>>> theirs
   }, []);
   /** Files/folders attached for next send (@path to agent). */
   const [attachments, setAttachments] = useState<Attachment[]>([]);
@@ -7525,6 +7544,12 @@ export default function App() {
     [contextUsage, messages],
   );
 
+  /** Char/word counts for the muted composer counter (hidden when empty). */
+  const composerDraftStats = useMemo(
+    () => computeDraftStats(draft),
+    [draft],
+  );
+
   const sessionTasks = useMemo(
     () => collectSessionTasks(messages),
     [messages],
@@ -12444,6 +12469,21 @@ export default function App() {
                       }}
                     />
                   </>
+                ) : null}
+                {showComposerDraftStats &&
+                !composerDraftStats.empty ? (
+                  <span
+                    className="composer__draft-stats"
+                    aria-label={tr("composer.draftStatsAria", {
+                      words: String(composerDraftStats.words),
+                      chars: String(composerDraftStats.chars),
+                    })}
+                  >
+                    {tr("composer.draftStats", {
+                      words: String(composerDraftStats.words),
+                      chars: String(composerDraftStats.chars),
+                    })}
+                  </span>
                 ) : null}
                 <span className="composer__spacer" />
                 {/* Dictation (mic) + Live Voice (headphones): official auth only. */}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -91,9 +91,15 @@ import {
   type ComposerSendKeyPref,
 } from "@/lib/composerSendKey";
 import {
+<<<<<<< ours
   loadComposerSpellcheck,
   saveComposerSpellcheck,
 } from "@/lib/composerSpellcheck";
+=======
+  loadComposerDraftStatsPref,
+  saveComposerDraftStatsPref,
+} from "@/lib/draftStats";
+>>>>>>> theirs
 import type { AccountStatus, DetectedEditor } from "@/lib/api";
 import * as api from "@/lib/api";
 import { AccountPanel } from "@/components/AccountPanel";
@@ -811,9 +817,15 @@ export function SettingsPage({
   /** Composer Enter vs ⌘/Ctrl+Enter — localStorage only (no Host settings). */
   const [composerSendKeyPref, setComposerSendKeyPref] =
     useState<ComposerSendKeyPref>(() => loadComposerSendKeyPref());
+<<<<<<< ours
   /** Browser spellcheck on main composer — localStorage only. */
   const [composerSpellcheck, setComposerSpellcheck] = useState(() =>
     loadComposerSpellcheck(),
+=======
+  /** Show muted char/word count on non-empty drafts — localStorage only. */
+  const [composerDraftStats, setComposerDraftStats] = useState(() =>
+    loadComposerDraftStatsPref(),
+>>>>>>> theirs
   );
   /** Pending scroll target after search jump / deep link. */
   const pendingAnchorRef = useRef<string | null>(null);
@@ -1602,6 +1614,7 @@ export function SettingsPage({
               <div
                 className={
                   "settings-row" +
+<<<<<<< ours
                   rowHighlight("settings-anchor-composerSpellcheck")
                 }
                 id="settings-anchor-composerSpellcheck"
@@ -1622,6 +1635,28 @@ export function SettingsPage({
                     saveComposerSpellcheck(next);
                   }}
                   ariaLabel={t("settings.composerSpellcheck")}
+=======
+                  rowHighlight("settings-anchor-composerDraftStats")
+                }
+                id="settings-anchor-composerDraftStats"
+              >
+                <div className="settings-row__text">
+                  <div className="settings-row__label">
+                    {t("settings.composerDraftStats")}
+                  </div>
+                  <div className="settings-row__desc">
+                    {t("settings.composerDraftStatsDesc")}
+                  </div>
+                </div>
+                <UiCheck
+                  checked={composerDraftStats}
+                  onChange={() => {
+                    const next = !composerDraftStats;
+                    setComposerDraftStats(next);
+                    saveComposerDraftStatsPref(next);
+                  }}
+                  ariaLabel={t("settings.composerDraftStats")}
+>>>>>>> theirs
                 />
               </div>
             </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -440,6 +440,8 @@ const en = {
   "composer.voiceErr.auth": "Speech auth failed. Sign in again under Account.",
   "composer.voiceErr.timeout": "Speech request timed out. Try a shorter clip.",
   "composer.voiceErr.unknown": "Voice dictation failed.",
+  "composer.draftStats": "{words} words · {chars} chars",
+  "composer.draftStatsAria": "Draft length: {words} words, {chars} characters",
   "composer.send": "Send",
   "composer.queue": "Queue — send after this turn (this chat)",
   "composer.queued":
@@ -880,9 +882,15 @@ const en = {
     "Choose whether plain Enter sends, or inserts a newline (⌘/Ctrl+Enter sends instead). Applies to the chat composer.",
   "settings.composerSendKey.enter": "Enter to send (Shift+Enter for newline)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter to send (Enter for newline)",
+<<<<<<< ours
   "settings.composerSpellcheck": "Spellcheck",
   "settings.composerSpellcheckDesc":
     "Underline misspelled words in the chat input using the system dictionary. Off by default.",
+=======
+  "settings.composerDraftStats": "Draft character count",
+  "settings.composerDraftStatsDesc":
+    "Show a muted character and word count when the chat input is not empty.",
+>>>>>>> theirs
   "settings.theme": "Theme",
   "settings.themeDesc": "Follow the system, or lock light / dark",
   "settings.themeSystem": "System",
@@ -2684,6 +2692,8 @@ const zh: Record<MessageKey, string> = {
   "composer.voiceErr.auth": "语音鉴权失败，请在账户中重新登录。",
   "composer.voiceErr.timeout": "转写超时，请缩短说话时长后重试。",
   "composer.voiceErr.unknown": "语音输入失败。",
+  "composer.draftStats": "{words} 词 · {chars} 字",
+  "composer.draftStatsAria": "草稿长度：{words} 词，{chars} 字",
   "composer.send": "发送",
   "composer.queue": "入队 — 本轮结束后发送（当前会话）",
   "composer.queued": "已入当前会话队列 — 留在本会话且本轮结束后自动发送",
@@ -3108,9 +3118,15 @@ const zh: Record<MessageKey, string> = {
     "选择 Enter 直接发送，还是 Enter 换行、⌘/Ctrl+Enter 发送。仅作用于对话输入框。",
   "settings.composerSendKey.enter": "Enter 发送（Shift+Enter 换行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 发送（Enter 换行）",
+<<<<<<< ours
   "settings.composerSpellcheck": "拼写检查",
   "settings.composerSpellcheckDesc":
     "在对话输入框用系统词典标出拼写错误。默认关闭。",
+=======
+  "settings.composerDraftStats": "草稿字数",
+  "settings.composerDraftStatsDesc":
+    "输入框有内容时以低调样式显示字符数与词数。",
+>>>>>>> theirs
   "settings.theme": "主题",
   "settings.themeDesc": "跟随系统，或固定浅色 / 深色",
   "settings.themeSystem": "跟随系统",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -455,6 +455,8 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.voiceErr.auth": "語音驗證失敗，請在帳戶中重新登入。",
   "composer.voiceErr.timeout": "轉寫逾時，請縮短說話時長後重試。",
   "composer.voiceErr.unknown": "語音輸入失敗。",
+  "composer.draftStats": "{words} 詞 · {chars} 字",
+  "composer.draftStatsAria": "草稿長度：{words} 詞，{chars} 字",
   "composer.send": "傳送",
   "composer.queue": "入佇列 — 本輪結束後傳送（目前對話）",
   "composer.queued": "已入目前對話佇列 — 留在此對話且本輪結束後自動傳送",
@@ -846,9 +848,15 @@ export const zhTW: Record<MessageKey, string> = {
     "選擇 Enter 直接傳送，或 Enter 換行、⌘/Ctrl+Enter 傳送。僅作用於對話輸入框。",
   "settings.composerSendKey.enter": "Enter 傳送（Shift+Enter 換行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 傳送（Enter 換行）",
+<<<<<<< ours
   "settings.composerSpellcheck": "拼字檢查",
   "settings.composerSpellcheckDesc":
     "在對話輸入框用系統辭典標出拼字錯誤。預設關閉。",
+=======
+  "settings.composerDraftStats": "草稿字數",
+  "settings.composerDraftStatsDesc":
+    "輸入框有內容時以低調樣式顯示字元數與詞數。",
+>>>>>>> theirs
   "settings.theme": "主題",
   "settings.themeDesc": "跟隨系統，或固定淺色 / 深色",
   "settings.themeSystem": "跟隨系統",

--- a/src/lib/draftStats.test.ts
+++ b/src/lib/draftStats.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPOSER_DRAFT_STATS_KEY,
+  DEFAULT_SHOW_COMPOSER_DRAFT_STATS,
+  computeDraftStats,
+  countDraftChars,
+  countDraftWords,
+  loadComposerDraftStatsPref,
+  parseComposerDraftStatsPref,
+  saveComposerDraftStatsPref,
+  type DraftStatsStorage,
+} from "./draftStats";
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+): DraftStatsStorage & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    getItem(key) {
+      return key in data ? data[key]! : null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+  };
+}
+
+describe("countDraftChars", () => {
+  it("counts empty as 0", () => {
+    expect(countDraftChars("")).toBe(0);
+  });
+
+  it("counts ASCII characters including spaces and newlines", () => {
+    expect(countDraftChars("hi")).toBe(2);
+    expect(countDraftChars("a b")).toBe(3);
+    expect(countDraftChars("a\nb")).toBe(3);
+  });
+
+  it("counts Unicode code points (emoji-safe)", () => {
+    expect(countDraftChars("你好")).toBe(2);
+    // Single emoji may be one or more code points; surrogate pairs collapse via [...]
+    expect(countDraftChars("👍")).toBe(1);
+    expect(countDraftChars("a👍b")).toBe(3);
+  });
+});
+
+describe("countDraftWords", () => {
+  it("returns 0 for empty / whitespace-only", () => {
+    expect(countDraftWords("")).toBe(0);
+    expect(countDraftWords("   ")).toBe(0);
+    expect(countDraftWords("\n\t")).toBe(0);
+  });
+
+  it("splits on whitespace runs", () => {
+    expect(countDraftWords("hello")).toBe(1);
+    expect(countDraftWords("hello world")).toBe(2);
+    expect(countDraftWords("  one   two\tthree\nfour  ")).toBe(4);
+  });
+
+  it("treats CJK without spaces as a single token", () => {
+    expect(countDraftWords("你好世界")).toBe(1);
+    expect(countDraftWords("你好 世界")).toBe(2);
+  });
+});
+
+describe("computeDraftStats", () => {
+  it("marks empty / whitespace-only as empty with zero counts", () => {
+    expect(computeDraftStats("")).toEqual({
+      chars: 0,
+      words: 0,
+      empty: true,
+    });
+    expect(computeDraftStats("  \n ")).toEqual({
+      chars: 0,
+      words: 0,
+      empty: true,
+    });
+  });
+
+  it("returns chars and words for non-empty drafts", () => {
+    expect(computeDraftStats("hi there")).toEqual({
+      chars: 8,
+      words: 2,
+      empty: false,
+    });
+    expect(computeDraftStats("hello")).toEqual({
+      chars: 5,
+      words: 1,
+      empty: false,
+    });
+  });
+
+  it("preserves internal whitespace in char count", () => {
+    const stats = computeDraftStats("a  b");
+    expect(stats.empty).toBe(false);
+    expect(stats.chars).toBe(4);
+    expect(stats.words).toBe(2);
+  });
+});
+
+describe("composer draft stats preference", () => {
+  it("defaults to true", () => {
+    expect(DEFAULT_SHOW_COMPOSER_DRAFT_STATS).toBe(true);
+    expect(parseComposerDraftStatsPref(null)).toBe(true);
+    expect(parseComposerDraftStatsPref("")).toBe(true);
+    expect(parseComposerDraftStatsPref("maybe")).toBe(true);
+    expect(loadComposerDraftStatsPref(memoryStorage())).toBe(true);
+  });
+
+  it("parses true/false variants", () => {
+    expect(parseComposerDraftStatsPref("1")).toBe(true);
+    expect(parseComposerDraftStatsPref("true")).toBe(true);
+    expect(parseComposerDraftStatsPref(true)).toBe(true);
+    expect(parseComposerDraftStatsPref("0")).toBe(false);
+    expect(parseComposerDraftStatsPref("false")).toBe(false);
+    expect(parseComposerDraftStatsPref(false)).toBe(false);
+  });
+
+  it("round-trips preference", () => {
+    const s = memoryStorage();
+    saveComposerDraftStatsPref(false, s);
+    expect(s.data[COMPOSER_DRAFT_STATS_KEY]).toBe("0");
+    expect(loadComposerDraftStatsPref(s)).toBe(false);
+    saveComposerDraftStatsPref(true, s);
+    expect(s.data[COMPOSER_DRAFT_STATS_KEY]).toBe("1");
+    expect(loadComposerDraftStatsPref(s)).toBe(true);
+  });
+});

--- a/src/lib/draftStats.ts
+++ b/src/lib/draftStats.ts
@@ -1,0 +1,109 @@
+/**
+ * Composer draft character / word stats (pure helpers) and optional UI toggle.
+ * Pref is localStorage-only — does not touch Host AppSettings.
+ * Default: show stats when the draft is non-empty.
+ */
+
+/** Storage key for the optional composer draft stats toggle. */
+export const COMPOSER_DRAFT_STATS_KEY = "grok.composerDraftStats";
+
+/** Fired on `window` after a same-tab preference save (storage events are cross-tab only). */
+export const COMPOSER_DRAFT_STATS_CHANGED_EVENT = "grok:composerDraftStats";
+
+/** Show muted char/word count by default when the draft is non-empty. */
+export const DEFAULT_SHOW_COMPOSER_DRAFT_STATS = true;
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface DraftStatsStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): DraftStatsStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+// ── Pure stats ──────────────────────────────────────────────────────────────
+
+export type DraftStats = {
+  /** Unicode code-point length (emoji-safe). */
+  chars: number;
+  /** Whitespace-separated token count; 0 when empty / whitespace-only. */
+  words: number;
+  /** True when text has no non-whitespace content. */
+  empty: boolean;
+};
+
+/** Character count using Unicode code points (not UTF-16 code units). */
+export function countDraftChars(text: string): number {
+  if (!text) return 0;
+  return [...text].length;
+}
+
+/**
+ * Word count: trim, then split on whitespace runs.
+ * Empty / whitespace-only → 0. Does not special-case CJK (whole run = 1 word).
+ */
+export function countDraftWords(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+/**
+ * Full draft stats for UI. Whitespace-only drafts are treated as empty
+ * (no counter shown).
+ */
+export function computeDraftStats(text: string): DraftStats {
+  if (!text || text.trim().length === 0) {
+    return { chars: 0, words: 0, empty: true };
+  }
+  return {
+    chars: countDraftChars(text),
+    words: countDraftWords(text),
+    empty: false,
+  };
+}
+
+// ── Preference ──────────────────────────────────────────────────────────────
+
+/** Parse stored value; invalid / empty → default true. */
+export function parseComposerDraftStatsPref(raw: unknown): boolean {
+  if (raw === "0" || raw === "false" || raw === false) return false;
+  if (raw === "1" || raw === "true" || raw === true) return true;
+  return DEFAULT_SHOW_COMPOSER_DRAFT_STATS;
+}
+
+export function loadComposerDraftStatsPref(
+  storage: DraftStatsStorage = defaultStorage(),
+): boolean {
+  try {
+    return parseComposerDraftStatsPref(
+      storage.getItem(COMPOSER_DRAFT_STATS_KEY),
+    );
+  } catch {
+    /* private mode */
+    return DEFAULT_SHOW_COMPOSER_DRAFT_STATS;
+  }
+}
+
+export function saveComposerDraftStatsPref(
+  show: boolean,
+  storage: DraftStatsStorage = defaultStorage(),
+): void {
+  try {
+    storage.setItem(COMPOSER_DRAFT_STATS_KEY, show ? "1" : "0");
+  } catch {
+    /* private mode / quota */
+  }
+  if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(COMPOSER_DRAFT_STATS_CHANGED_EVENT, { detail: show }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -262,6 +262,7 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     ],
   },
   {
+<<<<<<< ours
     id: "general.composerSpellcheck",
     section: "general",
     tab: "composer",
@@ -269,15 +270,34 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     labelKey: "settings.composerSpellcheck",
     descKeys: [
       "settings.composerSpellcheckDesc",
+=======
+    id: "general.composerDraftStats",
+    section: "general",
+    tab: "composer",
+    anchorId: "settings-anchor-composerDraftStats",
+    labelKey: "settings.composerDraftStats",
+    descKeys: [
+      "settings.composerDraftStatsDesc",
+>>>>>>> theirs
       "settings.section.composer",
     ],
     keywords: [
       "composer",
+<<<<<<< ours
       "spellcheck",
       "spell check",
       "spelling",
       "typo",
       "autocorrect",
+=======
+      "draft",
+      "stats",
+      "character",
+      "char count",
+      "word count",
+      "words",
+      "length",
+>>>>>>> theirs
     ],
   },
   // ── general / permissions ──

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9178,6 +9178,20 @@ button.composer__context-item {
   min-width: 8px;
 }
 
+/* Muted draft char/word count (Settings → Composer; non-empty only). */
+.composer__draft-stats {
+  font-size: 11px;
+  line-height: 1;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding: 0 6px;
+  user-select: none;
+  pointer-events: none;
+}
+
 .icon-btn {
   box-sizing: border-box;
   width: 32px;


### PR DESCRIPTION
## Summary

- Show a muted **character + word count** next to the composer when the draft is non-empty
- Pure `draftStats` helpers + unit tests (Unicode-safe char count; whitespace word split)
- Optional Settings → General → Composer toggle (localStorage; **on by default**)
- i18n (en / zh / zh-TW) and settings catalog search entry
- CHANGELOG Unreleased note

## Test plan

- [ ] Type in the composer → muted `N words · M chars` appears; clear draft → counter hides
- [ ] Settings → General → Composer → turn off “Draft character count” → counter gone; turn on → returns
- [ ] Preference survives reload / same-tab settings change via event
- [ ] `pnpm test -- src/lib/draftStats.test.ts src/lib/settingsCatalog.test.ts src/i18n/messages.test.ts`