### PR TITLE
feat(appearance): relative message timestamps option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ### Added
 
 - Desktop notification when the agent asks a question (`session://ask_user`), gated by the existing “Notify on permission” setting
+<<<<<<< ours
 - **Shortcuts catalog**: list **Find in conversation** (⌘/Ctrl+F) and **voice dictation** (Ctrl+Space; not Cmd)
 - **Composer spellcheck** (Settings → General → Composer): optional browser spellcheck on the main chat input (off by default)
 - **Session JSON export**: download chat as import-friendly JSON (`{ title, sessionId, exportedAt, messages: [{role,content}] }`) from the session menu; round-trips with existing transcript import
@@ -40,6 +41,9 @@ See `docs/llm-wiki/release.md`.
 **中文 · 变更**
 
 - 默认发送键展示为 Enter；说明可在设置 → 对话偏好改用 ⌘/Ctrl+Enter
+=======
+- **Relative message timestamps** (Settings → Appearance → Interface): absolute weekday+clock or relative (“2 minutes ago”); relative labels refresh about once a minute
+>>>>>>> theirs
 
 ## [0.2.1] - 2026-07-29
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,16 @@ import {
   MESSAGE_TIMESTAMPS_CHANGE_EVENT,
   saveMessageTimestampsPref,
 } from "@/lib/messageTimestampsPref";
+<<<<<<< ours
 import { loadConfirmExternalLinksPref } from "@/lib/externalLinkPref";
+=======
+import {
+  loadMessageTimeFormatPref,
+  MESSAGE_TIME_FORMAT_CHANGE_EVENT,
+  saveMessageTimeFormatPref,
+  type MessageTimeFormat,
+} from "@/lib/messageTimeFormatPref";
+>>>>>>> theirs
 import { WallpaperMediaLayer } from "@/components/WallpaperMediaLayer";
 import {
   ASIDE_WIDTH_MIN,
@@ -622,6 +631,9 @@ export default function App() {
   );
   const [showMessageTimestamps, setShowMessageTimestamps] = useState(() =>
     loadMessageTimestampsPref(localStorage),
+  );
+  const [messageTimeFormat, setMessageTimeFormat] = useState<MessageTimeFormat>(
+    () => loadMessageTimeFormatPref(localStorage),
   );
   const [layout, setLayout] = useState(() => {
     // Platform UA is available at first paint; reserve window-control inset on Win.
@@ -2235,6 +2247,21 @@ export default function App() {
     window.addEventListener(MESSAGE_TIMESTAMPS_CHANGE_EVENT, onChange);
     return () =>
       window.removeEventListener(MESSAGE_TIMESTAMPS_CHANGE_EVENT, onChange);
+  }, []);
+
+  // Message time format absolute/relative (localStorage; Settings change event).
+  useEffect(() => {
+    const onChange = (ev: Event) => {
+      const detail = (ev as CustomEvent<unknown>).detail;
+      if (detail === "absolute" || detail === "relative") {
+        setMessageTimeFormat(detail);
+        return;
+      }
+      setMessageTimeFormat(loadMessageTimeFormatPref(localStorage));
+    };
+    window.addEventListener(MESSAGE_TIME_FORMAT_CHANGE_EVENT, onChange);
+    return () =>
+      window.removeEventListener(MESSAGE_TIME_FORMAT_CHANGE_EVENT, onChange);
   }, []);
 
   // Phone layout flag: mirror client + ≤820px only (desktop ≥821px unchanged).
@@ -9862,6 +9889,11 @@ export default function App() {
             saveMessageTimestampsPref(v, localStorage);
             setShowMessageTimestamps(v);
           }}
+          messageTimeFormat={messageTimeFormat}
+          onMessageTimeFormat={(v) => {
+            saveMessageTimeFormatPref(v, localStorage);
+            setMessageTimeFormat(v);
+          }}
           skin={skin}
           onSkin={applySkinChoice}
           wallpaperUrl={wallpaperUrl}
@@ -11651,6 +11683,7 @@ export default function App() {
             findHitMessageIds={showChatFind ? chatFindHitIds : undefined}
             findActive={showChatFind ? chatFindActive : null}
             showTimestamps={showMessageTimestamps}
+            messageTimeFormat={messageTimeFormat}
           />
           </UiErrorBoundary>
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -132,6 +132,10 @@ import {
   type MessageActionsVisibility,
 } from "@/lib/messageActionsPref";
 import {
+  MESSAGE_TIME_FORMATS,
+  type MessageTimeFormat,
+} from "@/lib/messageTimeFormatPref";
+import {
   SETTINGS_NAV,
   buildSettingsHash,
   defaultTabFor,
@@ -189,6 +193,9 @@ export interface SettingsPageProps {
   /** Show message timestamps in chat action rows (localStorage). */
   showMessageTimestamps?: boolean;
   onShowMessageTimestamps?: (v: boolean) => void;
+  /** Absolute vs relative message time labels (localStorage). */
+  messageTimeFormat?: MessageTimeFormat;
+  onMessageTimeFormat?: (v: MessageTimeFormat) => void;
   /** Color skin pack on top of light/dark (optional for older callers). */
   skin?: ThemeSkinId;
   onSkin?: (v: ThemeSkinId) => void;
@@ -702,6 +709,8 @@ export function SettingsPage({
   onTheme,
   showMessageTimestamps = true,
   onShowMessageTimestamps,
+  messageTimeFormat = "absolute",
+  onMessageTimeFormat,
   skin = "default",
   onSkin,
   wallpaperUrl = null,
@@ -2837,6 +2846,84 @@ export function SettingsPage({
                         }
                         ariaLabel={t("settings.messageTimestamps")}
                       />
+                    </div>
+                  </div>
+                ) : null}
+                {onMessageTimeFormat ? (
+                  <div
+                    className={
+                      "settings-card" +
+                      rowHighlight("settings-anchor-messageTimeFormat")
+                    }
+                    id="settings-anchor-messageTimeFormat"
+                  >
+                    <div className="settings-row">
+                      <div className="settings-row__text">
+                        <SettingsLabelWithTip
+                          label={t("settings.messageTimeFormat")}
+                          tip={t("settings.messageTimeFormatDesc")}
+                        />
+                      </div>
+                      <div
+                        className="settings-seg"
+                        role="radiogroup"
+                        aria-label={t("settings.messageTimeFormat")}
+                      >
+                        {MESSAGE_TIME_FORMATS.map((mode) => (
+                          <button
+                            key={mode}
+                            type="button"
+                            role="radio"
+                            aria-checked={messageTimeFormat === mode}
+                            className={
+                              "settings-seg__btn" +
+                              (messageTimeFormat === mode ? " is-on" : "")
+                            }
+                            onClick={() => onMessageTimeFormat(mode)}
+                          >
+                            {t(`settings.messageTimeFormat.${mode}`)}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+                {onMessageTimeFormat ? (
+                  <div
+                    className={
+                      "settings-card" +
+                      rowHighlight("settings-anchor-messageTimeFormat")
+                    }
+                    id="settings-anchor-messageTimeFormat"
+                  >
+                    <div className="settings-row">
+                      <div className="settings-row__text">
+                        <SettingsLabelWithTip
+                          label={t("settings.messageTimeFormat")}
+                          tip={t("settings.messageTimeFormatDesc")}
+                        />
+                      </div>
+                      <div
+                        className="settings-seg"
+                        role="radiogroup"
+                        aria-label={t("settings.messageTimeFormat")}
+                      >
+                        {MESSAGE_TIME_FORMATS.map((mode) => (
+                          <button
+                            key={mode}
+                            type="button"
+                            role="radio"
+                            aria-checked={messageTimeFormat === mode}
+                            className={
+                              "settings-seg__btn" +
+                              (messageTimeFormat === mode ? " is-on" : "")
+                            }
+                            onClick={() => onMessageTimeFormat(mode)}
+                          >
+                            {t(`settings.messageTimeFormat.${mode}`)}
+                          </button>
+                        ))}
+                      </div>
                     </div>
                   </div>
                 ) : null}

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -60,7 +60,8 @@ import {
   IconRewind,
   IconTarget,
 } from "@/components/icons";
-import { formatMessageTime } from "@/lib/accountUi";
+import { formatMessageTime, formatRelativeTime } from "@/lib/accountUi";
+import type { MessageTimeFormat } from "@/lib/messageTimeFormatPref";
 import { formatTokenCount } from "@/lib/contextUsage";
 import { useStickToBottom } from "@/hooks/useStickToBottom";
 import { useChatMessageVirtualizer } from "@/hooks/useChatMessageVirtualizer";
@@ -427,6 +428,11 @@ export interface ConversationThreadProps {
    * Default true.
    */
   showTimestamps?: boolean;
+  /**
+   * Absolute (weekday + clock) vs relative (“2 minutes ago”).
+   * Relative mode re-renders on a 60s tick so labels stay fresh.
+   */
+  messageTimeFormat?: MessageTimeFormat;
 }
 
 export function ConversationThread({
@@ -460,10 +466,23 @@ export function ConversationThread({
   onOpenSessionChanges: _onOpenSessionChanges,
   onOpenModifiedPath: _onOpenModifiedPath,
   showTimestamps = true,
+  messageTimeFormat = "absolute",
 }: ConversationThreadProps) {
   const tr = useMemo(() => createT(locale), [locale]);
   void _onOpenSessionChanges;
   void _onOpenModifiedPath;
+
+  /** Re-render relative labels roughly once a minute. */
+  const [relativeTick, setRelativeTick] = useState(0);
+  useEffect(() => {
+    if (!showTimestamps || messageTimeFormat !== "relative") return;
+    const id = window.setInterval(() => {
+      setRelativeTick((n) => n + 1);
+    }, 60_000);
+    return () => window.clearInterval(id);
+  }, [showTimestamps, messageTimeFormat]);
+  // Keep tick in the render graph so interval updates recompute labels.
+  void relativeTick;
 
   /**
    * Force stick-to-bottom when a new user turn starts **and** when the turn
@@ -1041,9 +1060,12 @@ export function ConversationThread({
               const isInterjection = m.marker === "interjection";
               const isLastUser = !isInterjection && lastUserMessageId === m.id;
               const isEditing = editingUserMessageId === m.id;
-              const timeLabel = showTimestamps
-                ? formatMessageTime(m.createdAt, locale)
-                : null;
+              const timeLabel =
+                showTimestamps && m.createdAt
+                  ? messageTimeFormat === "relative"
+                    ? formatRelativeTime(m.createdAt, locale)
+                    : formatMessageTime(m.createdAt, locale)
+                  : null;
               const isFindHit = !!findHitMessageIds?.has(m.id);
               const isFindCurrent = findActive?.messageId === m.id;
               const isNodeFocus = focusMessageId === m.id;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -921,6 +921,11 @@ const en = {
   "settings.messageTimestamps": "Show message timestamps",
   "settings.messageTimestampsDesc":
     "Show the send time next to message actions. Turn off for a cleaner transcript.",
+  "settings.messageTimeFormat": "Timestamp format",
+  "settings.messageTimeFormatDesc":
+    "Absolute shows weekday and clock time; relative shows “2 minutes ago” and refreshes about once a minute.",
+  "settings.messageTimeFormat.absolute": "Absolute",
+  "settings.messageTimeFormat.relative": "Relative",
   "settings.skin": "Color skin",
   "settings.skinDesc": "Accent and surface palette (works with light/dark)",
   "settings.skin.default": "Default",
@@ -3147,6 +3152,11 @@ const zh: Record<MessageKey, string> = {
   "settings.messageTimestamps": "显示消息时间戳",
   "settings.messageTimestampsDesc":
     "在消息操作区显示发送时间。关闭后对话更简洁。",
+  "settings.messageTimeFormat": "时间戳格式",
+  "settings.messageTimeFormatDesc":
+    "绝对时间显示星期与时钟；相对时间如「2 分钟前」，约每分钟刷新。",
+  "settings.messageTimeFormat.absolute": "绝对时间",
+  "settings.messageTimeFormat.relative": "相对时间",
   "settings.skin": "配色皮肤",
   "settings.skinDesc": "强调色与表面色板（可与浅/深色叠加）",
   "settings.skin.default": "默认",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -885,6 +885,11 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.messageTimestamps": "顯示訊息時間戳",
   "settings.messageTimestampsDesc":
     "在訊息操作區顯示傳送時間。關閉後對話更簡潔。",
+  "settings.messageTimeFormat": "時間戳格式",
+  "settings.messageTimeFormatDesc":
+    "絕對時間顯示星期與時鐘；相對時間如「2 分鐘前」，約每分鐘重新整理。",
+  "settings.messageTimeFormat.absolute": "絕對時間",
+  "settings.messageTimeFormat.relative": "相對時間",
   "settings.skin": "配色皮膚",
   "settings.skinDesc": "強調色與表面色板（可與淺/深色疊加）",
   "settings.skin.default": "預設",

--- a/src/lib/accountUi.test.ts
+++ b/src/lib/accountUi.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach } from "vitest";
 import {
   formatMessageTime,
   formatQuotaResetTime,
+  formatRelativeTime,
   loadCachedSuperGrokBrand,
   localDateKeyFromIso,
   resolveWelcomeBrandKind,
@@ -145,6 +146,44 @@ describe("formatMessageTime", () => {
     expect(zh.length).toBeGreaterThan(4);
     expect(en.length).toBeGreaterThan(4);
     expect(formatMessageTime(null, "zh")).toBe("");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("returns em dash for empty/invalid", () => {
+    expect(formatRelativeTime(null, "en")).toBe("—");
+    expect(formatRelativeTime(undefined, "zh")).toBe("—");
+    expect(formatRelativeTime("not-a-date", "en")).toBe("—");
+  });
+
+  it("formats recent times with relative units", () => {
+    const now = Date.now();
+    const twoMinAgo = new Date(now - 2 * 60 * 1000).toISOString();
+    const en = formatRelativeTime(twoMinAgo, "en");
+    const zh = formatRelativeTime(twoMinAgo, "zh");
+    expect(en.length).toBeGreaterThan(1);
+    expect(zh.length).toBeGreaterThan(1);
+    // English uses minute/minutes or "2 minutes ago" / "2 min. ago" depending on engine
+    expect(/minute|min/i.test(en) || /\d/.test(en)).toBe(true);
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("returns em dash for empty/invalid", () => {
+    expect(formatRelativeTime(null, "en")).toBe("—");
+    expect(formatRelativeTime(undefined, "zh")).toBe("—");
+    expect(formatRelativeTime("not-a-date", "en")).toBe("—");
+  });
+
+  it("formats recent times with relative units", () => {
+    const now = Date.now();
+    const twoMinAgo = new Date(now - 2 * 60 * 1000).toISOString();
+    const en = formatRelativeTime(twoMinAgo, "en");
+    const zh = formatRelativeTime(twoMinAgo, "zh");
+    expect(en.length).toBeGreaterThan(1);
+    expect(zh.length).toBeGreaterThan(1);
+    // English uses minute/minutes or "2 minutes ago" / "2 min. ago" depending on engine
+    expect(/minute|min/i.test(en) || /\d/.test(en)).toBe(true);
   });
 });
 

--- a/src/lib/messageTimeFormatPref.test.ts
+++ b/src/lib/messageTimeFormatPref.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MESSAGE_TIME_FORMAT,
+  MESSAGE_TIME_FORMAT_STORAGE_KEY,
+  isMessageTimeFormat,
+  loadMessageTimeFormatPref,
+  parseMessageTimeFormat,
+  saveMessageTimeFormatPref,
+  type MessageTimeFormatStorage,
+} from "./messageTimeFormatPref";
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+): MessageTimeFormatStorage & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    getItem(key) {
+      return key in data ? data[key]! : null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+  };
+}
+
+describe("messageTimeFormatPref", () => {
+  it("defaults to absolute", () => {
+    expect(DEFAULT_MESSAGE_TIME_FORMAT).toBe("absolute");
+    expect(parseMessageTimeFormat(null)).toBe("absolute");
+    expect(parseMessageTimeFormat("")).toBe("absolute");
+    expect(parseMessageTimeFormat("maybe")).toBe("absolute");
+    expect(loadMessageTimeFormatPref(memoryStorage())).toBe("absolute");
+  });
+
+  it("parses absolute/relative", () => {
+    expect(isMessageTimeFormat("absolute")).toBe(true);
+    expect(isMessageTimeFormat("relative")).toBe(true);
+    expect(isMessageTimeFormat("iso")).toBe(false);
+    expect(parseMessageTimeFormat("absolute")).toBe("absolute");
+    expect(parseMessageTimeFormat("relative")).toBe("relative");
+  });
+
+  it("round-trips preference", () => {
+    const s = memoryStorage();
+    saveMessageTimeFormatPref("relative", s);
+    expect(s.data[MESSAGE_TIME_FORMAT_STORAGE_KEY]).toBe("relative");
+    expect(loadMessageTimeFormatPref(s)).toBe("relative");
+    saveMessageTimeFormatPref("absolute", s);
+    expect(s.data[MESSAGE_TIME_FORMAT_STORAGE_KEY]).toBe("absolute");
+    expect(loadMessageTimeFormatPref(s)).toBe("absolute");
+  });
+});

--- a/src/lib/messageTimeFormatPref.ts
+++ b/src/lib/messageTimeFormatPref.ts
@@ -1,0 +1,76 @@
+/**
+ * Message timestamp display format (Appearance → Interface).
+ * localStorage-only — does not touch Host AppSettings.
+ *
+ * - `absolute` (default): compact weekday + clock (`formatMessageTime`)
+ * - `relative`: “2 minutes ago” style (`formatRelativeTime`); chat refreshes ~60s
+ */
+
+export type MessageTimeFormat = "absolute" | "relative";
+
+export const MESSAGE_TIME_FORMAT_STORAGE_KEY = "grok.messageTimeFormat";
+
+/** Fired on `window` after a successful save (detail = format). */
+export const MESSAGE_TIME_FORMAT_CHANGE_EVENT =
+  "grok-message-time-format-change";
+
+export const DEFAULT_MESSAGE_TIME_FORMAT: MessageTimeFormat = "absolute";
+
+export const MESSAGE_TIME_FORMATS: readonly MessageTimeFormat[] = [
+  "absolute",
+  "relative",
+] as const;
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface MessageTimeFormatStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): MessageTimeFormatStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+export function isMessageTimeFormat(value: unknown): value is MessageTimeFormat {
+  return value === "absolute" || value === "relative";
+}
+
+/** Parse stored value; invalid / empty → default absolute. */
+export function parseMessageTimeFormat(raw: unknown): MessageTimeFormat {
+  if (typeof raw === "string" && isMessageTimeFormat(raw)) return raw;
+  return DEFAULT_MESSAGE_TIME_FORMAT;
+}
+
+export function loadMessageTimeFormatPref(
+  storage: MessageTimeFormatStorage = defaultStorage(),
+): MessageTimeFormat {
+  try {
+    return parseMessageTimeFormat(
+      storage.getItem(MESSAGE_TIME_FORMAT_STORAGE_KEY),
+    );
+  } catch {
+    /* private mode */
+    return DEFAULT_MESSAGE_TIME_FORMAT;
+  }
+}
+
+export function saveMessageTimeFormatPref(
+  format: MessageTimeFormat,
+  storage: MessageTimeFormatStorage = defaultStorage(),
+): void {
+  try {
+    storage.setItem(MESSAGE_TIME_FORMAT_STORAGE_KEY, format);
+  } catch {
+    /* private mode / quota */
+  }
+  if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(MESSAGE_TIME_FORMAT_CHANGE_EVENT, { detail: format }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/lib/settingsCatalog.test.ts
+++ b/src/lib/settingsCatalog.test.ts
@@ -102,6 +102,7 @@ describe("settingsCatalog", () => {
     expect(appearance).toContain("settings.chatDensity");
     expect(appearance).toContain("settings.messageActions");
     expect(appearance).toContain("settings.messageTimestamps");
+    expect(appearance).toContain("settings.messageTimeFormat");
     const rim = keywordKeysForSection("remote_im");
     expect(rim).toContain("settings.nav.remoteIm");
     expect(rim).toContain("settings.tab.remoteIm");
@@ -183,6 +184,14 @@ describe("settingsCatalog", () => {
         : searchSettingsEntries("timestamp", tZh, tEn);
     expect(
       timestampsHits.some((h) => h.entry.id === "appearance.messageTimestamps"),
+    ).toBe(true);
+    const relativeTime = searchSettingsEntries("relative time", tZh, tEn);
+    expect(
+      relativeTime.some((h) => h.entry.id === "appearance.messageTimeFormat"),
+    ).toBe(true);
+    const relativeZh = searchSettingsEntries("相对时间", tZh, tEn);
+    expect(
+      relativeZh.some((h) => h.entry.id === "appearance.messageTimeFormat"),
     ).toBe(true);
     const cli = searchSettingsEntries("CLI", tZh, tEn);
     expect(cli.some((h) => h.entry.section === "runtime")).toBe(true);

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -710,6 +710,29 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "時間戳",
     ],
   },
+  {
+    id: "appearance.messageTimeFormat",
+    section: "appearance",
+    tab: "interface",
+    anchorId: "settings-anchor-messageTimeFormat",
+    labelKey: "settings.messageTimeFormat",
+    descKeys: [
+      "settings.messageTimeFormatDesc",
+      "settings.messageTimeFormat.absolute",
+      "settings.messageTimeFormat.relative",
+    ],
+    keywords: [
+      "relative time",
+      "absolute time",
+      "time format",
+      "minutes ago",
+      "相对时间",
+      "绝对时间",
+      "相對時間",
+      "絕對時間",
+      "多久前",
+    ],
+  },
   // ── account ──
   {
     id: "account.official",


### PR DESCRIPTION
## What
Message timestamps can be **absolute** (weekday + clock, existing `formatMessageTime`) or **relative** (“2 minutes ago”, `formatRelativeTime`). Preference is localStorage-only under Appearance → Interface, next to the show-timestamps toggle. Relative labels re-render about every 60 seconds.

## Why
Absolute weekday+time is dense for recent turns; relative times make recency easier to scan without leaving the chat.

## Notes
- Pref: `grok.messageTimeFormat` (`absolute` | `relative`, default absolute)
- Settings search catalog entry `appearance.messageTimeFormat`
- i18n en / zh / zh-TW for format labels and tip
- CHANGELOG Unreleased entry