### PR TITLE
feat(chat): collapse all tools and thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Collapse all activity** in the current chat: top-bar control and session menu item collapse expanded tool phases and finished thinking blocks (streaming thoughts stay open)
 - **Stop all** busy sessions from the Tasks panel (confirm, then cancel every streaming / awaiting-permission / connecting session; toast with success count)
 - **Quiet hours** for desktop notifications (Settings → General → App): optional local start/end window that suppresses system notifies overnight or any range; in-app toasts unchanged
 - **Clear composer draft**: small clear control on the input row when text or attachments are present; long drafts (>200 characters) confirm first
@@ -36,6 +37,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增**
 
+- 当前对话「收起全部活动」：顶栏按钮与会话菜单可收起已展开的工具阶段与已完成思考（流式思考保持展开）
 - 任务面板「全部停止」忙碌会话（确认后批量取消； toast 成功数）
 - 桌面通知免打扰时段（设置 → 通用 → 应用；本地起止时间）
 - 输入框清空草稿（有内容时显示；超过 200 字需确认）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -395,6 +395,7 @@ import {
   IconFolder,
   IconFolderPlus,
   IconArrowsVerticalCollapse,
+  IconArrowsMinimize,
   IconClock,
   IconClose,
   IconNewChat as IconSquarePen,
@@ -458,6 +459,7 @@ import {
   type SessionFileChange,
 } from "@/lib/sessionChanges";
 import { ConversationThread } from "@/components/lobe-chat";
+import { dispatchCollapseAllActivity } from "@/lib/collapseAllActivity";
 import {
   preferPermissionFocus,
   trapTabKey,
@@ -11396,6 +11398,19 @@ export default function App() {
                     />
                   )}
                   {mainPane === "chat" && session.sessionId ? (
+                    <Tip label={tr("session.collapseAllActivityHint")}>
+                      <button
+                        type="button"
+                        className="chrome-btn main__pane-toggle"
+                        onClick={() => dispatchCollapseAllActivity()}
+                        aria-label={tr("session.collapseAllActivity")}
+                        data-testid="collapse-all-activity"
+                      >
+                        <IconArrowsMinimize size={16} />
+                      </button>
+                    </Tip>
+                  ) : null}
+                  {mainPane === "chat" && session.sessionId ? (
                     <Tip
                       label={
                         tasksPanelOpen
@@ -14061,6 +14076,15 @@ export default function App() {
                 disabled: !isOpen || !canRewindSession,
                 onClick: () => {
                   void openRewindTimeline(s.id);
+                },
+              },
+              {
+                id: "collapse-all-activity",
+                label: tr("session.collapseAllActivity"),
+                icon: <IconArrowsMinimize size={16} />,
+                disabled: !isOpen,
+                onClick: () => {
+                  dispatchCollapseAllActivity();
                 },
               },
               // Export group — not at top of menu (after edit/rename-style actions)

--- a/src/components/lobe-chat/Thinking.tsx
+++ b/src/components/lobe-chat/Thinking.tsx
@@ -13,6 +13,7 @@ import { IconChevronDown } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { MarkdownChat } from "./MarkdownChat";
 import type { Locale } from "@/i18n";
+import { COLLAPSE_ALL_ACTIVITY_EVENT } from "@/lib/collapseAllActivity";
 import {
   loadThinkingExpandPref,
   saveThinkingExpandPref,
@@ -98,6 +99,19 @@ export function Thinking({
       window.removeEventListener("storage", onStorage);
     };
   }, [expandPref]);
+
+  // Collapse all activity: force closed finished blocks only (leave streaming open).
+  useEffect(() => {
+    const onCollapseAll = () => {
+      if (thinkingRef.current) return;
+      userToggled.current = true;
+      setOpen(false);
+    };
+    window.addEventListener(COLLAPSE_ALL_ACTIVITY_EVENT, onCollapseAll);
+    return () => {
+      window.removeEventListener(COLLAPSE_ALL_ACTIVITY_EVENT, onCollapseAll);
+    };
+  }, []);
 
   useEffect(() => {
     if (thinking) {

--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
+import { COLLAPSE_ALL_ACTIVITY_EVENT } from "@/lib/collapseAllActivity";
 import type { TimelinePhase } from "@/lib/timelinePhases";
 import { phaseTitleModel } from "@/lib/timelinePhases";
 import { IconChevronRight } from "@/components/icons";
@@ -71,6 +72,15 @@ export function TimelinePhaseBlock({
     }
   }, [shouldExpand, phase.id]);
 
+  // One-click collapse all tool phases in the current chat.
+  useEffect(() => {
+    const onCollapseAll = () => setOpen(false);
+    window.addEventListener(COLLAPSE_ALL_ACTIVITY_EVENT, onCollapseAll);
+    return () => {
+      window.removeEventListener(COLLAPSE_ALL_ACTIVITY_EVENT, onCollapseAll);
+    };
+  }, []);
+
   const toolDisplay = useMemo(() => {
     const segs: MessageSegment[] = phase.tools.map((t) => t);
     return buildTimelineDisplayItems(segs);
@@ -96,7 +106,9 @@ export function TimelinePhaseBlock({
         className="lobe-timeline-phase__trigger"
         aria-expanded={open}
         onClick={() => {
-          if (phase.live && phase.runningCount > 0) return;
+          // While tools are running, block click-to-collapse (auto-expand stays
+          // the default). Still allow expand if collapse-all forced us closed.
+          if (open && phase.live && phase.runningCount > 0) return;
           setOpen((v) => !v);
         }}
       >

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -107,6 +107,9 @@ const en = {
   "session.deleteManyConfirm":
     "Delete {n} chats permanently? This cannot be undone.",
   "session.menu": "Session menu",
+  "session.collapseAllActivity": "Collapse all activity",
+  "session.collapseAllActivityHint":
+    "Collapse expanded tool phases and finished thinking blocks",
   "session.new": "New chat",
   "session.newShort": "New",
   "session.placeholderTitle": "New chat",
@@ -2395,6 +2398,8 @@ const zh: Record<MessageKey, string> = {
   "session.deleteManyTitle": "删除会话",
   "session.deleteManyConfirm": "确定永久删除 {n} 个会话？此操作不可撤销。",
   "session.menu": "会话菜单",
+  "session.collapseAllActivity": "收起全部活动",
+  "session.collapseAllActivityHint": "收起已展开的工具阶段与已完成的思考块",
   "session.new": "新会话",
   "session.newShort": "新建",
   "session.placeholderTitle": "新会话",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -96,6 +96,8 @@ export const zhTW: Record<MessageKey, string> = {
   "session.deleteManyTitle": "刪除對話",
   "session.deleteManyConfirm": "確定永久刪除 {n} 個對話？此操作無法復原。",
   "session.menu": "對話選單",
+  "session.collapseAllActivity": "收合全部活動",
+  "session.collapseAllActivityHint": "收合已展開的工具階段與已完成的思考塊",
   "session.new": "新對話",
   "session.newShort": "新增",
   "session.placeholderTitle": "新對話",

--- a/src/lib/collapseAllActivity.ts
+++ b/src/lib/collapseAllActivity.ts
@@ -1,0 +1,17 @@
+/**
+ * One-click collapse of expanded tool phases / thinking blocks in chat.
+ * Dispatched on `window`; TimelinePhaseBlock + Thinking listen and force closed.
+ */
+
+/** Window event name — keep stable for any external listeners/tests. */
+export const COLLAPSE_ALL_ACTIVITY_EVENT = "grok:collapse-all-activity";
+
+/** Fire collapse-all for the current chat transcript. */
+export function dispatchCollapseAllActivity(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(new Event(COLLAPSE_ALL_ACTIVITY_EVENT));
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary
- One-click **Collapse all activity** for the current chat: collapses expanded tool phases (`TimelinePhaseBlock`) and finished thinking blocks (`Thinking`; streaming thoughts stay open).
- Window event `grok:collapse-all-activity` + `dispatchCollapseAllActivity()`.
- UI: minimize icon in the main chat top bar (next to Tasks) and a session overflow menu item.
- i18n en / zh / zh-TW + CHANGELOG.

## Test plan
- [ ] Open a chat with expanded tool phases and finished thinking blocks
- [ ] Click the top-bar collapse control → phases and finished thoughts collapse
- [ ] While a thought is streaming, collapse all → streaming block stays open
- [ ] Session ⋯ menu → Collapse all activity works for the open session
- [ ] After collapse-all on a live phase, click the phase header to re-expand
- [ ] Locale switch en/zh/zh-TW shows translated labels