### PR TITLE
feat(permissions): optional auto-deny timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Permission auto-deny timeout** (Settings → General → Permissions): optional Off / 30s / 1m / 2m / 5m; when the bar is open and the timer fires, uses the same deny path as Escape / Deny; subtle countdown on the bar (`localStorage` `grok.permissionTimeoutSec`, default off)
 - **Stop all** busy sessions from the Tasks panel (confirm, then cancel every streaming / awaiting-permission / connecting session; toast with success count)
 - **Quiet hours** for desktop notifications (Settings → General → App): optional local start/end window that suppresses system notifies overnight or any range; in-app toasts unchanged
 - **Clear composer draft**: small clear control on the input row when text or attachments are present; long drafts (>200 characters) confirm first
@@ -36,6 +37,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增**
 
+- **权限超时自动拒绝**（设置 → 通用 → 权限）：可选关闭 / 30 秒 / 1 分 / 2 分 / 5 分；超时走与 Escape / 拒绝相同路径；权限条上轻量倒计时（`localStorage` `grok.permissionTimeoutSec`，默认关）
 - 任务面板「全部停止」忙碌会话（确认后批量取消； toast 成功数）
 - 桌面通知免打扰时段（设置 → 通用 → 应用；本地起止时间）
 - 输入框清空草稿（有内容时显示；超过 200 字需确认）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,12 @@ import {
   NOTIFY_SOUND_CHANGE_EVENT,
   saveNotifySoundPref,
 } from "@/lib/notifySound";
+import {
+  loadPermissionTimeoutSec,
+  PERMISSION_TIMEOUT_CHANGE_EVENT,
+  permissionTimeoutRemainingSec,
+  savePermissionTimeoutSec,
+} from "@/lib/permissionTimeout";
 import { WallpaperMediaLayer } from "@/components/WallpaperMediaLayer";
 import {
   ASIDE_WIDTH_MIN,
@@ -1166,6 +1172,11 @@ export default function App() {
   const [activeAccountId, setActiveAccountId] = useState<string | null>(null);
   const [perm, setPerm] = useState<PermissionPayload | null>(null);
   const permBarRef = useRef<HTMLDivElement | null>(null);
+  /** Seconds until auto-deny (null when off / no active timer). */
+  const [permCountdownSec, setPermCountdownSec] = useState<number | null>(null);
+  const [permissionTimeoutSec, setPermissionTimeoutSec] = useState(() =>
+    loadPermissionTimeoutSec(localStorage),
+  );
   const [askUser, setAskUser] = useState<AskUserPayload | null>(null);
   /**
    * Unanswered gates per session (`sessionId` → payload).
@@ -2315,6 +2326,21 @@ export default function App() {
     window.addEventListener(NOTIFY_SOUND_CHANGE_EVENT, onChange);
     return () =>
       window.removeEventListener(NOTIFY_SOUND_CHANGE_EVENT, onChange);
+  }, []);
+
+  // Permission auto-deny timeout (localStorage; Settings dispatches change event).
+  useEffect(() => {
+    const onChange = (ev: Event) => {
+      const detail = (ev as CustomEvent<unknown>).detail;
+      if (typeof detail === "number" && Number.isFinite(detail)) {
+        setPermissionTimeoutSec(detail);
+        return;
+      }
+      setPermissionTimeoutSec(loadPermissionTimeoutSec(localStorage));
+    };
+    window.addEventListener(PERMISSION_TIMEOUT_CHANGE_EVENT, onChange);
+    return () =>
+      window.removeEventListener(PERMISSION_TIMEOUT_CHANGE_EVENT, onChange);
   }, []);
 
   // Phone layout flag: mirror client + ≤820px only (desktop ≥821px unchanged).
@@ -8825,6 +8851,55 @@ export default function App() {
     wasStreamingRef.current = streaming;
   }, [session.state, messages, tr]);
 
+  /** Same path as Deny button / Escape / optional auto-deny timeout. */
+  const resolvePermission = useCallback(
+    (
+      p: PermissionPayload,
+      decision: "allow_once" | "allow_session" | "deny",
+      optionId: string,
+    ) => {
+      void api
+        .sessionResolvePermission({
+          rpcId: p.rpcId,
+          decision,
+          optionId,
+          scopeKey: p.scopeKey,
+          // Background turns raise permissions on their own ACP child.
+          sessionId: p.sessionId,
+        })
+        .then(() => {
+          clearPendingGates(p.sessionId);
+          setPerm(null);
+        })
+        .catch((e) => {
+          const code =
+            e && typeof e === "object" && "code" in e
+              ? String((e as { code?: string }).code)
+              : "";
+          showToast(
+            code === "UNSUPPORTED"
+              ? tr("mirror.unsupported")
+              : String(e),
+            4000,
+          );
+        });
+    },
+    [clearPendingGates, showToast, tr],
+  );
+
+  const denyActivePermission = useCallback(
+    (p: PermissionPayload) => {
+      const deny = mapPermissionButtons(p.options, {
+        allowOnce: tr("perm.allowOnce"),
+        allowSession: tr("perm.allowSession"),
+        deny: tr("perm.deny"),
+      }).find((b) => b.decision === "deny");
+      if (!deny) return;
+      resolvePermission(p, deny.decision, deny.optionId);
+    },
+    [resolvePermission, tr],
+  );
+
   // T15: permission bar — focus primary action, Tab trap, Escape → deny.
   useEffect(() => {
     if (!perm) return;
@@ -8835,26 +8910,7 @@ export default function App() {
       if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
-        const deny = mapPermissionButtons(perm.options, {
-          allowOnce: tr("perm.allowOnce"),
-          allowSession: tr("perm.allowSession"),
-          deny: tr("perm.deny"),
-        }).find((b) => b.decision === "deny");
-        if (deny) {
-          void api
-            .sessionResolvePermission({
-              rpcId: perm.rpcId,
-              decision: deny.decision,
-              optionId: deny.optionId,
-              scopeKey: perm.scopeKey,
-              // Background turns raise permissions on their own ACP child.
-              sessionId: perm.sessionId,
-            })
-            .then(() => {
-              clearPendingGates(perm.sessionId);
-              setPerm(null);
-            });
-        }
+        denyActivePermission(perm);
         return;
       }
       trapTabKey(e, permBarRef.current);
@@ -8864,7 +8920,36 @@ export default function App() {
       window.clearTimeout(t);
       document.removeEventListener("keydown", onKey, true);
     };
-  }, [perm, tr]);
+  }, [perm, denyActivePermission]);
+
+  // Optional auto-deny after N seconds (Settings → Permissions; 0 = off).
+  useEffect(() => {
+    if (!perm || permissionTimeoutSec <= 0) {
+      setPermCountdownSec(null);
+      return;
+    }
+    const startedAt = Date.now();
+    setPermCountdownSec(
+      permissionTimeoutRemainingSec(startedAt, permissionTimeoutSec, startedAt),
+    );
+    const tick = window.setInterval(() => {
+      setPermCountdownSec(
+        permissionTimeoutRemainingSec(
+          startedAt,
+          permissionTimeoutSec,
+          Date.now(),
+        ),
+      );
+    }, 250);
+    const t = window.setTimeout(() => {
+      denyActivePermission(perm);
+    }, permissionTimeoutSec * 1000);
+    return () => {
+      window.clearTimeout(t);
+      window.clearInterval(tick);
+      setPermCountdownSec(null);
+    };
+  }, [perm, permissionTimeoutSec, denyActivePermission]);
 
   /** T04 deck buttons: reconnect / Doctor / Settings sections / dismiss. */
   const runErrorBannerAction = useCallback(
@@ -10323,6 +10408,11 @@ export default function App() {
           onNotifySound={(v) => {
             saveNotifySoundPref(v, localStorage);
             setNotifySound(v);
+          }}
+          permissionTimeoutSec={permissionTimeoutSec}
+          onPermissionTimeoutSec={(v) => {
+            savePermissionTimeoutSec(v, localStorage);
+            setPermissionTimeoutSec(v);
           }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
@@ -11894,6 +11984,13 @@ export default function App() {
                   <span className="perm-bar__tool">
                     {perm.title || perm.toolName}
                   </span>
+                  {permCountdownSec != null && permCountdownSec > 0 ? (
+                    <span className="perm-bar__countdown" aria-live="polite">
+                      {tr("perm.autoDenyCountdown", {
+                        seconds: String(permCountdownSec),
+                      })}
+                    </span>
+                  ) : null}
                 </div>
                 <p className="perm-bar__summary" id="perm-bar-summary">
                   {formatPermissionSummary({
@@ -11930,30 +12027,7 @@ export default function App() {
                             : tr("perm.hintDeny")
                       }
                       onClick={() =>
-                        void api
-                          .sessionResolvePermission({
-                            rpcId: perm.rpcId,
-                            decision: btn.decision,
-                            optionId: btn.optionId,
-                            scopeKey: perm.scopeKey,
-                            sessionId: perm.sessionId,
-                          })
-                          .then(() => {
-                            clearPendingGates(perm.sessionId);
-                            setPerm(null);
-                          })
-                          .catch((e) => {
-                            const code =
-                              e && typeof e === "object" && "code" in e
-                                ? String((e as { code?: string }).code)
-                                : "";
-                            showToast(
-                              code === "UNSUPPORTED"
-                                ? tr("mirror.unsupported")
-                                : String(e),
-                              4000,
-                            );
-                          })
+                        resolvePermission(perm, btn.decision, btn.optionId)
                       }
                     >
                       {btn.label}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -301,6 +301,12 @@ export interface SettingsPageProps {
   /** Play a short beep with desktop notifications (localStorage; default off). */
   notifySound?: boolean;
   onNotifySound?: (v: boolean) => void;
+  /**
+   * Auto-deny permission bar after N seconds (localStorage; 0 = off).
+   * Presets: 0 / 30 / 60 / 120 / 300.
+   */
+  permissionTimeoutSec?: number;
+  onPermissionTimeoutSec?: (v: number) => void;
   planEnabled?: boolean;
   onPlanEnabled?: (v: boolean) => void;
   subagentsEnabled?: boolean;
@@ -811,6 +817,8 @@ export function SettingsPage({
   onNotifyOnPermission,
   notifySound = false,
   onNotifySound,
+  permissionTimeoutSec = 0,
+  onPermissionTimeoutSec,
   cliInfo,
   onDoctor,
   versionFooter,
@@ -1786,6 +1794,63 @@ export function SettingsPage({
                         label: t("settings.sandbox.devbox"),
                       },
                     ]}
+                  />
+                </div>
+              ) : null}
+              {onPermissionTimeoutSec ? (
+                <div
+                  className={
+                    "settings-row settings-row--stack" +
+                    rowHighlight("settings-anchor-permissionTimeout")
+                  }
+                  id="settings-anchor-permissionTimeout"
+                >
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.permissionTimeout")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.permissionTimeoutDesc")}
+                    </div>
+                  </div>
+                  <Select
+                    value={String(permissionTimeoutSec ?? 0)}
+                    onChange={(v) => onPermissionTimeoutSec(Number(v))}
+                    options={(() => {
+                      const presets = [
+                        {
+                          value: "0",
+                          label: t("settings.permissionTimeout.off"),
+                        },
+                        {
+                          value: "30",
+                          label: t("settings.permissionTimeout.30"),
+                        },
+                        {
+                          value: "60",
+                          label: t("settings.permissionTimeout.60"),
+                        },
+                        {
+                          value: "120",
+                          label: t("settings.permissionTimeout.120"),
+                        },
+                        {
+                          value: "300",
+                          label: t("settings.permissionTimeout.300"),
+                        },
+                      ];
+                      const cur = Math.max(0, Math.round(permissionTimeoutSec ?? 0));
+                      if (
+                        cur > 0 &&
+                        !presets.some((o) => o.value === String(cur))
+                      ) {
+                        return [
+                          ...presets,
+                          { value: String(cur), label: `${cur}s` },
+                        ];
+                      }
+                      return presets;
+                    })()}
                   />
                 </div>
               ) : null}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -849,6 +849,14 @@ const en = {
   "settings.permissionDeep": "Default permission",
   "settings.permissionDeepDesc":
     "Applied to new turns and remembered at the scope chosen above. YOLO auto-approves tools.",
+  "settings.permissionTimeout": "Auto-deny after",
+  "settings.permissionTimeoutDesc":
+    "If you don't respond, automatically deny the permission request after this time. Off by default.",
+  "settings.permissionTimeout.off": "Off",
+  "settings.permissionTimeout.30": "30 seconds",
+  "settings.permissionTimeout.60": "1 minute",
+  "settings.permissionTimeout.120": "2 minutes",
+  "settings.permissionTimeout.300": "5 minutes",
   "settings.sandboxProfile": "Sandbox profile",
   "settings.sandboxProfileDesc":
     "OS-level filesystem/network isolation for the agent process (Landlock/Seatbelt). Applied when a new agent starts — reconnect the session after changing.",
@@ -1833,6 +1841,7 @@ const en = {
   "perm.hintOnce": "Run this once; ask again next time.",
   "perm.hintSession": "Allow similar actions for the rest of this chat.",
   "perm.hintDeny": "Block this action and tell the agent.",
+  "perm.autoDenyCountdown": "Auto-deny in {seconds}s",
 
   // Agent ask_user_question
   "askUser.title": "Agent question",
@@ -3113,6 +3122,14 @@ const zh: Record<MessageKey, string> = {
   "settings.permissionDeep": "默认权限",
   "settings.permissionDeepDesc":
     "对新一轮对话生效，并按上方选择的范围记忆。YOLO 会自动批准工具调用。",
+  "settings.permissionTimeout": "超时自动拒绝",
+  "settings.permissionTimeoutDesc":
+    "若在时限内未响应权限请求，将自动拒绝。默认关闭。",
+  "settings.permissionTimeout.off": "关闭",
+  "settings.permissionTimeout.30": "30 秒",
+  "settings.permissionTimeout.60": "1 分钟",
+  "settings.permissionTimeout.120": "2 分钟",
+  "settings.permissionTimeout.300": "5 分钟",
   "settings.sandboxProfile": "沙箱配置",
   "settings.sandboxProfileDesc":
     "对 Agent 进程施加操作系统级文件系统/网络隔离（Linux Landlock / macOS Seatbelt）。在新启动 Agent 时生效——更改后请重连会话。",
@@ -4071,6 +4088,7 @@ const zh: Record<MessageKey, string> = {
   "perm.hintOnce": "仅执行这一次，下次仍会询问。",
   "perm.hintSession": "本会话内同类操作不再询问。",
   "perm.hintDeny": "阻止本次操作并告知 Agent。",
+  "perm.autoDenyCountdown": "{seconds} 秒后自动拒绝",
 
   "askUser.title": "Agent 提问",
   "askUser.submit": "提交",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -814,6 +814,14 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.permissionDeep": "預設權限",
   "settings.permissionDeepDesc":
     "對新一輪對話生效，並依上方選擇的範圍記憶。YOLO 會自動核准工具呼叫。",
+  "settings.permissionTimeout": "逾時自動拒絕",
+  "settings.permissionTimeoutDesc":
+    "若在時限內未回應權限請求，將自動拒絕。預設關閉。",
+  "settings.permissionTimeout.off": "關閉",
+  "settings.permissionTimeout.30": "30 秒",
+  "settings.permissionTimeout.60": "1 分鐘",
+  "settings.permissionTimeout.120": "2 分鐘",
+  "settings.permissionTimeout.300": "5 分鐘",
   "settings.sandboxProfile": "沙箱設定檔",
   "settings.sandboxProfileDesc":
     "對 Agent 行程施加作業系統級檔案系統/網路隔離（Linux Landlock / macOS Seatbelt）。在新啟動 Agent 時生效——變更後請重新連線工作階段。",
@@ -1772,6 +1780,7 @@ export const zhTW: Record<MessageKey, string> = {
   "perm.hintOnce": "僅執行這一次，下次仍會詢問。",
   "perm.hintSession": "本對話內同類操作不再詢問。",
   "perm.hintDeny": "阻止本次操作並告知 Agent。",
+  "perm.autoDenyCountdown": "{seconds} 秒後自動拒絕",
 
   "askUser.title": "Agent 提問",
   "askUser.submit": "提交",

--- a/src/lib/permissionTimeout.test.ts
+++ b/src/lib/permissionTimeout.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PERMISSION_TIMEOUT_SEC,
+  PERMISSION_TIMEOUT_MAX_SEC,
+  PERMISSION_TIMEOUT_PRESETS,
+  PERMISSION_TIMEOUT_STORAGE_KEY,
+  loadPermissionTimeoutSec,
+  parsePermissionTimeoutSec,
+  permissionTimeoutRemainingSec,
+  savePermissionTimeoutSec,
+  type PermissionTimeoutStorage,
+} from "./permissionTimeout";
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+): PermissionTimeoutStorage & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    getItem(key) {
+      return key in data ? data[key]! : null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+  };
+}
+
+describe("parsePermissionTimeoutSec", () => {
+  it("defaults to off (0)", () => {
+    expect(DEFAULT_PERMISSION_TIMEOUT_SEC).toBe(0);
+    expect(parsePermissionTimeoutSec(null)).toBe(0);
+    expect(parsePermissionTimeoutSec(undefined)).toBe(0);
+    expect(parsePermissionTimeoutSec("")).toBe(0);
+    expect(parsePermissionTimeoutSec("nope")).toBe(0);
+    expect(parsePermissionTimeoutSec(-1)).toBe(0);
+    expect(parsePermissionTimeoutSec(true)).toBe(0);
+  });
+
+  it("accepts presets and free numbers", () => {
+    for (const p of PERMISSION_TIMEOUT_PRESETS) {
+      expect(parsePermissionTimeoutSec(p)).toBe(p);
+      expect(parsePermissionTimeoutSec(String(p))).toBe(p);
+    }
+    expect(parsePermissionTimeoutSec(45)).toBe(45);
+    expect(parsePermissionTimeoutSec(" 90 ")).toBe(90);
+    expect(parsePermissionTimeoutSec(30.4)).toBe(30);
+    expect(parsePermissionTimeoutSec(30.6)).toBe(31);
+  });
+
+  it("clamps to max", () => {
+    expect(parsePermissionTimeoutSec(PERMISSION_TIMEOUT_MAX_SEC + 1)).toBe(
+      PERMISSION_TIMEOUT_MAX_SEC,
+    );
+  });
+});
+
+describe("load / save", () => {
+  it("persists and reloads after simulated relaunch", () => {
+    const storage = memoryStorage();
+    expect(loadPermissionTimeoutSec(storage)).toBe(0);
+    savePermissionTimeoutSec(60, storage);
+    expect(storage.data[PERMISSION_TIMEOUT_STORAGE_KEY]).toBe("60");
+    expect(loadPermissionTimeoutSec(storage)).toBe(60);
+    savePermissionTimeoutSec(0, storage);
+    expect(loadPermissionTimeoutSec(storage)).toBe(0);
+  });
+
+  it("loads free number from storage", () => {
+    const storage = memoryStorage({
+      [PERMISSION_TIMEOUT_STORAGE_KEY]: "45",
+    });
+    expect(loadPermissionTimeoutSec(storage)).toBe(45);
+  });
+});
+
+describe("permissionTimeoutRemainingSec", () => {
+  it("returns 0 when timeout is off or invalid", () => {
+    expect(permissionTimeoutRemainingSec(1000, 0, 1000)).toBe(0);
+    expect(permissionTimeoutRemainingSec(1000, -5, 1000)).toBe(0);
+    expect(permissionTimeoutRemainingSec(NaN, 30, 1000)).toBe(0);
+    expect(permissionTimeoutRemainingSec(1000, 30, NaN)).toBe(0);
+  });
+
+  it("returns full timeout at start (ceil)", () => {
+    const start = 1_000_000;
+    expect(permissionTimeoutRemainingSec(start, 30, start)).toBe(30);
+    expect(permissionTimeoutRemainingSec(start, 30, start + 1)).toBe(30);
+  });
+
+  it("counts down and floors at 0", () => {
+    const start = 1_000_000;
+    expect(permissionTimeoutRemainingSec(start, 30, start + 1000)).toBe(29);
+    expect(permissionTimeoutRemainingSec(start, 30, start + 29_000)).toBe(1);
+    expect(permissionTimeoutRemainingSec(start, 30, start + 30_000)).toBe(0);
+    expect(permissionTimeoutRemainingSec(start, 30, start + 60_000)).toBe(0);
+  });
+});

--- a/src/lib/permissionTimeout.ts
+++ b/src/lib/permissionTimeout.ts
@@ -1,0 +1,101 @@
+/**
+ * Optional auto-deny timeout for the permission bar.
+ * localStorage-only — does not touch Host AppSettings.
+ *
+ * 0 = off (default). Positive seconds until the same deny path as Escape / Deny.
+ * Settings offers presets; storage accepts any non-negative integer.
+ */
+
+export const PERMISSION_TIMEOUT_STORAGE_KEY = "grok.permissionTimeoutSec";
+
+/** Fired on `window` after a successful save (detail = seconds). */
+export const PERMISSION_TIMEOUT_CHANGE_EVENT = "grok-permission-timeout-change";
+
+export const DEFAULT_PERMISSION_TIMEOUT_SEC = 0;
+
+/** Preset values shown in Settings select (seconds). */
+export const PERMISSION_TIMEOUT_PRESETS = [0, 30, 60, 120, 300] as const;
+
+/** Soft upper bound when parsing free-form values (1 hour). */
+export const PERMISSION_TIMEOUT_MAX_SEC = 3600;
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface PermissionTimeoutStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): PermissionTimeoutStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+/**
+ * Parse stored / form value to a non-negative integer seconds.
+ * Invalid / empty → 0 (off). Free numbers allowed (clamped to max).
+ */
+export function parsePermissionTimeoutSec(raw: unknown): number {
+  if (raw == null || raw === "") return DEFAULT_PERMISSION_TIMEOUT_SEC;
+  if (typeof raw === "boolean") return DEFAULT_PERMISSION_TIMEOUT_SEC;
+  const n =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string"
+        ? Number(raw.trim())
+        : NaN;
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_PERMISSION_TIMEOUT_SEC;
+  return Math.min(PERMISSION_TIMEOUT_MAX_SEC, Math.round(n));
+}
+
+export function loadPermissionTimeoutSec(
+  storage: PermissionTimeoutStorage = defaultStorage(),
+): number {
+  try {
+    return parsePermissionTimeoutSec(
+      storage.getItem(PERMISSION_TIMEOUT_STORAGE_KEY),
+    );
+  } catch {
+    /* private mode */
+    return DEFAULT_PERMISSION_TIMEOUT_SEC;
+  }
+}
+
+export function savePermissionTimeoutSec(
+  seconds: number,
+  storage: PermissionTimeoutStorage = defaultStorage(),
+): void {
+  const next = parsePermissionTimeoutSec(seconds);
+  try {
+    storage.setItem(PERMISSION_TIMEOUT_STORAGE_KEY, String(next));
+  } catch {
+    /* private mode / quota */
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.dispatchEvent === "function"
+  ) {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(PERMISSION_TIMEOUT_CHANGE_EVENT, { detail: next }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * Pure helper: whole seconds remaining until auto-deny.
+ * Returns 0 when timeout is off, already expired, or inputs are invalid.
+ * Uses ceil so the UI shows `timeoutSec` until the first second elapses.
+ */
+export function permissionTimeoutRemainingSec(
+  startedAtMs: number,
+  timeoutSec: number,
+  nowMs: number = Date.now(),
+): number {
+  if (!(timeoutSec > 0) || !Number.isFinite(timeoutSec)) return 0;
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(nowMs)) return 0;
+  const left = Math.ceil(timeoutSec - (nowMs - startedAtMs) / 1000);
+  return Math.max(0, left);
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -336,6 +336,26 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     labelKey: "settings.section.permissions",
     keywords: ["rules", "permission rules"],
   },
+  {
+    id: "general.permissionTimeout",
+    section: "general",
+    tab: "permissions",
+    anchorId: "settings-anchor-permissionTimeout",
+    labelKey: "settings.permissionTimeout",
+    descKeys: [
+      "settings.permissionTimeoutDesc",
+      "settings.permissionTimeout.off",
+      "settings.section.permissions",
+    ],
+    keywords: [
+      "auto-deny",
+      "timeout",
+      "permission timeout",
+      "auto deny",
+      "自动拒绝",
+      "超时",
+    ],
+  },
   // ── general / agent ──
   {
     id: "general.maxAgentTurns",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7290,6 +7290,16 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
   white-space: nowrap;
 }
 
+.perm-bar__countdown {
+  flex-shrink: 0;
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
 .perm-bar__preview {
   margin: 0;
   padding: 8px 10px;


### PR DESCRIPTION
## Summary

Optional **auto-deny** for the permission bar after a configurable timeout.

- **Pref**: `localStorage` `grok.permissionTimeoutSec` — `0` = off (default); presets **30 / 60 / 120 / 300** (storage also accepts free non-negative integers)
- **Behavior**: when `perm` becomes non-null and timeout > 0, start a timer; on fire, call the **same deny path** as Escape / Deny button; clear timer when perm is cleared
- **Settings**: General → Permissions → **Auto-deny after** (Off / 30s / 1m / 2m / 5m)
- **UI**: subtle countdown text on the permission bar while the timer is active
- **i18n** (en / zh / zh-TW), **settingsCatalog**, **CHANGELOG**
- Pure helper `permissionTimeoutRemainingSec` + unit tests

No new host API — reuses `sessionResolvePermission` via a shared `resolvePermission` / `denyActivePermission` path.

## Test plan

- [x] `pnpm test -- src/lib/permissionTimeout.test.ts src/i18n/messages.test.ts src/lib/settingsCatalog.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: set Auto-deny to 30s → trigger a permission → confirm countdown and auto-deny
- [ ] Manual: Escape / Deny still work and cancel the timer
- [ ] Manual: Off (default) leaves the bar open indefinitely