### PR TITLE
feat(shortcuts): show send key from composer preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Changed
 
+- **Shortcuts catalog / help**: **Send** row reflects the Composer send-key preference (Enter vs ⌘/Ctrl+Enter) and updates live when the pref changes
 - **Shortcuts catalog**: default **Send** shows plain Enter (not ⌘/Ctrl+Enter); note points to Settings → Composer for mod-enter
 
 **中文 · 新增**
@@ -63,6 +64,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 变更**
 
+- 快捷键列表 / 帮助：发送键随对话偏好（Enter 或 ⌘/Ctrl+Enter）实时更新
 - 默认发送键展示为 Enter；说明可在设置 → 对话偏好改用 ⌘/Ctrl+Enter
 
 ## [0.2.1] - 2026-07-29

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13380,6 +13380,7 @@ export default function App() {
         <ul className="shortcuts-list">
           {shortcutsForPlatform(
             platform === "mac" ? "mac" : platform === "win" ? "win" : "other",
+            composerSendKeyPref,
           ).map((row) => (
             <li key={row.id} className="shortcuts-list__row">
               <span className="shortcuts-list__label">

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -93,6 +93,7 @@ import {
   PERMISSION_POLICIES,
 } from "@/lib/grokCatalog";
 import {
+  COMPOSER_SEND_KEY_CHANGED_EVENT,
   loadComposerSendKeyPref,
   saveComposerSendKeyPref,
   type ComposerSendKeyPref,
@@ -4142,7 +4143,23 @@ function ShortcutsSettingsPanel({
   onOpenHelp?: () => void;
 }) {
   const platform = useMemo(() => detectShortcutPlatform(), []);
-  const groups = useMemo(() => shortcutsByGroup(), []);
+  /** Live send chord from Composer pref (same-tab + storage). */
+  const [sendPref, setSendPref] = useState<ComposerSendKeyPref>(() =>
+    loadComposerSendKeyPref(),
+  );
+  useEffect(() => {
+    const reload = () => setSendPref(loadComposerSendKeyPref());
+    window.addEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, reload);
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === "grok.composerSendKey" || e.key === null) reload();
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, reload);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+  const groups = useMemo(() => shortcutsByGroup(sendPref), [sendPref]);
 
   const groupLabel = (g: ShortcutGroup) =>
     t(`settings.shortcuts.group.${g}` as MessageKey);

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it } from "vitest";
 import {
   SHORTCUTS,
+  sendShortcutDisplay,
   shortcutsByGroup,
   shortcutsForPlatform,
 } from "./shortcuts";
+
+describe("sendShortcutDisplay", () => {
+  it("defaults to plain Enter", () => {
+    expect(sendShortcutDisplay()).toEqual({ mac: "↵", win: "Enter" });
+    expect(sendShortcutDisplay("enter")).toEqual({ mac: "↵", win: "Enter" });
+  });
+
+  it("shows mod-enter chords", () => {
+    expect(sendShortcutDisplay("mod-enter")).toEqual({
+      mac: "⌘ ↵",
+      win: "Ctrl Enter",
+    });
+  });
+});
 
 describe("shortcuts catalog", () => {
   it("has stable unique ids", () => {
@@ -21,8 +36,8 @@ describe("shortcuts catalog", () => {
   });
 
   it("picks platform-specific keys", () => {
-    const mac = shortcutsForPlatform("mac");
-    const win = shortcutsForPlatform("win");
+    const mac = shortcutsForPlatform("mac", "enter");
+    const win = shortcutsForPlatform("win", "enter");
     const searchMac = mac.find((s) => s.id === "search");
     const searchWin = win.find((s) => s.id === "search");
     expect(searchMac?.keys).toContain("⌘");
@@ -30,7 +45,7 @@ describe("shortcuts catalog", () => {
   });
 
   it("groups for settings panel cover every shortcut once", () => {
-    const grouped = shortcutsByGroup();
+    const grouped = shortcutsByGroup("enter");
     const flat = grouped.flatMap((g) => g.rows.map((r) => r.id));
     expect(flat.sort()).toEqual([...SHORTCUTS.map((s) => s.id)].sort());
   });
@@ -55,6 +70,40 @@ describe("shortcuts catalog", () => {
     expect(row!.win.toLowerCase()).toBe("enter");
     expect(row!.mac).not.toMatch(/⌘/);
     expect(row!.win.toLowerCase()).not.toMatch(/ctrl/);
+  });
+
+  it("patches send keys from composer preference in platform list", () => {
+    const enterMac = shortcutsForPlatform("mac", "enter").find(
+      (s) => s.id === "send",
+    );
+    const enterWin = shortcutsForPlatform("win", "enter").find(
+      (s) => s.id === "send",
+    );
+    expect(enterMac?.keys).toBe("↵");
+    expect(enterWin?.keys).toBe("Enter");
+
+    const modMac = shortcutsForPlatform("mac", "mod-enter").find(
+      (s) => s.id === "send",
+    );
+    const modWin = shortcutsForPlatform("win", "mod-enter").find(
+      (s) => s.id === "send",
+    );
+    expect(modMac?.keys).toBe("⌘ ↵");
+    expect(modWin?.keys).toBe("Ctrl Enter");
+  });
+
+  it("patches send keys from composer preference in settings groups", () => {
+    const enterSend = shortcutsByGroup("enter")
+      .flatMap((g) => g.rows)
+      .find((r) => r.id === "send");
+    expect(enterSend?.mac).toBe("↵");
+    expect(enterSend?.win).toBe("Enter");
+
+    const modSend = shortcutsByGroup("mod-enter")
+      .flatMap((g) => g.rows)
+      .find((r) => r.id === "send");
+    expect(modSend?.mac).toBe("⌘ ↵");
+    expect(modSend?.win).toBe("Ctrl Enter");
   });
 
   it("lists Ctrl+Space dictation on both platforms (not Cmd)", () => {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,5 +1,10 @@
 /** Keyboard shortcut catalog — help panel + Settings → Keyboard. */
 
+import {
+  loadComposerSendKeyPref,
+  type ComposerSendKeyPref,
+} from "@/lib/composerSendKey";
+
 export type ShortcutGroup = "workbench" | "navigation" | "diagnostics" | "input";
 
 export type ShortcutRow = {
@@ -17,6 +22,9 @@ export type ShortcutRow = {
  * Shipped shortcuts that already work in the app.
  * Keep this list honest — only document real bindings.
  * Single source for the help modal and Settings → Keyboard.
+ *
+ * The `send` row stores the product default (plain Enter). Live display
+ * patches via {@link sendShortcutDisplay} / optional send pref args.
  */
 export const SHORTCUTS: ShortcutRow[] = [
   {
@@ -108,15 +116,55 @@ export const SHORTCUT_GROUP_ORDER: ShortcutGroup[] = [
   "input",
 ];
 
+/**
+ * Display chords for the Send shortcut based on Composer send-key preference.
+ * - `enter`: mac `↵`, win `Enter`
+ * - `mod-enter`: mac `⌘ ↵`, win `Ctrl Enter`
+ */
+export function sendShortcutDisplay(
+  pref: ComposerSendKeyPref = "enter",
+): { mac: string; win: string } {
+  if (pref === "mod-enter") {
+    return { mac: "⌘ ↵", win: "Ctrl Enter" };
+  }
+  return { mac: "↵", win: "Enter" };
+}
+
+function resolveSendPref(pref?: ComposerSendKeyPref): ComposerSendKeyPref {
+  if (pref !== undefined) return pref;
+  if (typeof localStorage !== "undefined") {
+    try {
+      return loadComposerSendKeyPref();
+    } catch {
+      /* private mode / non-browser */
+    }
+  }
+  return "enter";
+}
+
+function withSendPref(
+  row: ShortcutRow,
+  pref: ComposerSendKeyPref,
+): ShortcutRow {
+  if (row.id !== "send") return row;
+  const keys = sendShortcutDisplay(pref);
+  return { ...row, mac: keys.mac, win: keys.win };
+}
+
 export function shortcutsForPlatform(
   platform: "mac" | "win" | "other",
+  sendPref?: ComposerSendKeyPref,
 ): Array<{ id: string; labelKey: string; keys: string; group: ShortcutGroup }> {
-  return SHORTCUTS.map((s) => ({
-    id: s.id,
-    labelKey: s.labelKey,
-    group: s.group,
-    keys: platform === "mac" ? s.mac : s.win,
-  }));
+  const pref = resolveSendPref(sendPref);
+  return SHORTCUTS.map((s) => {
+    const row = withSendPref(s, pref);
+    return {
+      id: row.id,
+      labelKey: row.labelKey,
+      group: row.group,
+      keys: platform === "mac" ? row.mac : row.win,
+    };
+  });
 }
 
 /** Detect host OS for highlighting the active column in Settings. */
@@ -131,12 +179,17 @@ export function detectShortcutPlatform(): "mac" | "win" | "other" {
   return "other";
 }
 
-export function shortcutsByGroup(): Array<{
+export function shortcutsByGroup(
+  sendPref?: ComposerSendKeyPref,
+): Array<{
   group: ShortcutGroup;
   rows: ShortcutRow[];
 }> {
+  const pref = resolveSendPref(sendPref);
   return SHORTCUT_GROUP_ORDER.map((group) => ({
     group,
-    rows: SHORTCUTS.filter((s) => s.group === group),
+    rows: SHORTCUTS.filter((s) => s.group === group).map((s) =>
+      withSendPref(s, pref),
+    ),
   })).filter((g) => g.rows.length > 0);
 }


### PR DESCRIPTION
## Summary
- Keyboard catalog / help modal show the **actual** send chord from the Composer send-key preference (`enter` vs `mod-enter`)
- Pure helper `sendShortcutDisplay` + optional pref on `shortcutsForPlatform` / `shortcutsByGroup` (defaults from localStorage in browser)
- Settings → Keyboard send row updates live on `grok:composerSendKey` (and `storage`)
- Tests for display helper and pref patching

## Test plan
- [ ] Settings → Composer: switch between Enter and ⌘/Ctrl+Enter
- [ ] Settings → Keyboard: Send row updates without reload
- [ ] Shortcuts help modal (⌘/): Send keys match preference
- [ ] `pnpm test -- src/lib/shortcuts.test.ts`