### PR TITLE
feat(shortcuts): single registry for catalog and key matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ See `docs/llm-wiki/release.md`.
 ### Changed
 
 - **Shortcuts catalog**: default **Send** shows plain Enter (not ⌘/Ctrl+Enter); note points to Settings → Composer for mod-enter
+- **Shortcut registry**: App global mod chords (`⌘/Ctrl+K`, `F`, `N`, `,`, `/`, `⇧D`, `⇧C`, `⇧V`) match via `matchGlobalShortcut` in the same module as the help/Settings catalog (Esc-stop and Ctrl+Space dictation stay special-cased)
 
 **中文 · 新增**
 
@@ -64,6 +65,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 变更**
 
 - 默认发送键展示为 Enter；说明可在设置 → 对话偏好改用 ⌘/Ctrl+Enter
+- 快捷键注册表：全局 mod 组合键与帮助/设置目录同模块匹配（Esc 停止、Ctrl+Space 语音仍在 App 特殊处理）
 
 ## [0.2.1] - 2026-07-29
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -265,7 +265,10 @@ import {
   type ChatFindMatch,
 } from "@/lib/chatFind";
 import { connPillForState } from "@/lib/connStatus";
-import { shortcutsForPlatform } from "@/lib/shortcuts";
+import {
+  matchGlobalShortcut,
+  shortcutsForPlatform,
+} from "@/lib/shortcuts";
 import {
   ensureNotifyPermission,
   shouldShowDesktopNotify,
@@ -1129,63 +1132,57 @@ export default function App() {
         }
       }
       // Ctrl+Space toggles voice (not Cmd+Space — Spotlight on macOS).
+      // Stays outside matchGlobalShortcut (ctrl-only; order before mod branch).
       if (isVoiceToggleKey(e)) {
         e.preventDefault();
         e.stopPropagation();
         shortcutHandlersRef.current.toggleVoice();
         return;
       }
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
+      // Mod-based catalog actions — single registry in lib/shortcuts.ts.
+      // Esc-stop stays special-cased above (order vs voice cancel / overlays).
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
       const typing =
         tag === "input" ||
         tag === "textarea" ||
         !!target?.isContentEditable;
-      const key = e.key.toLowerCase();
-      // In-chat find — open even while typing in the composer.
-      if (key === "f" && !e.shiftKey) {
-        e.preventDefault();
-        shortcutHandlersRef.current.openChatFind();
-        return;
-      }
-      if (key === "k") {
-        e.preventDefault();
-        setShowSearch(true);
-        return;
-      }
-      if (key === "/") {
-        e.preventDefault();
-        setShowShortcuts((v) => !v);
-        return;
-      }
-      if (key === "," && !typing) {
-        e.preventDefault();
-        shortcutHandlersRef.current.openSettings();
-        return;
-      }
-      if (key === "n" && !typing) {
-        e.preventDefault();
-        shortcutHandlersRef.current.newChat();
-        return;
-      }
-      if (key === "d" && e.shiftKey) {
-        e.preventDefault();
-        setShowDoctor(true);
-        return;
-      }
-      // Copy last assistant reply: Cmd/Ctrl+Shift+C (always; not plain Cmd+C).
-      if (key === "c" && e.shiftKey) {
-        e.preventDefault();
-        shortcutHandlersRef.current.copyLastReply();
-        return;
-      }
-      // Live Voice: Cmd/Ctrl+Shift+V (works while typing in composer).
-      if (key === "v" && e.shiftKey) {
-        e.preventDefault();
-        shortcutHandlersRef.current.startLiveVoice();
-        return;
+      const matched = matchGlobalShortcut({
+        key: e.key.toLowerCase(),
+        mod: e.metaKey || e.ctrlKey,
+        shift: e.shiftKey,
+        alt: e.altKey,
+        typing,
+      });
+      if (!matched) return;
+      e.preventDefault();
+      switch (matched) {
+        case "findInChat":
+          shortcutHandlersRef.current.openChatFind();
+          return;
+        case "search":
+          setShowSearch(true);
+          return;
+        case "help":
+          setShowShortcuts((v) => !v);
+          return;
+        case "settings":
+          shortcutHandlersRef.current.openSettings();
+          return;
+        case "newChat":
+          shortcutHandlersRef.current.newChat();
+          return;
+        case "doctor":
+          setShowDoctor(true);
+          return;
+        case "copyLastReply":
+          shortcutHandlersRef.current.copyLastReply();
+          return;
+        case "liveVoice":
+          shortcutHandlersRef.current.startLiveVoice();
+          return;
+        default:
+          return;
       }
     };
     document.addEventListener("keydown", onKey, true);

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,14 +1,35 @@
 import { describe, expect, it } from "vitest";
 import {
+  GLOBAL_MOD_SHORTCUT_IDS,
+  matchGlobalShortcut,
+  SHORTCUT_IDS,
   SHORTCUTS,
   shortcutsByGroup,
   shortcutsForPlatform,
+  type GlobalModShortcutId,
+  type ShortcutChordContext,
 } from "./shortcuts";
+
+function chord(
+  partial: Partial<ShortcutChordContext> & Pick<ShortcutChordContext, "key">,
+): ShortcutChordContext {
+  return {
+    mod: true,
+    shift: false,
+    alt: false,
+    typing: false,
+    ...partial,
+  };
+}
 
 describe("shortcuts catalog", () => {
   it("has stable unique ids", () => {
     const ids = SHORTCUTS.map((s) => s.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("SHORTCUT_IDS matches catalog rows in order", () => {
+    expect([...SHORTCUT_IDS]).toEqual(SHORTCUTS.map((s) => s.id));
   });
 
   it("every row has mac and win bindings and a group", () => {
@@ -75,5 +96,102 @@ describe("shortcuts catalog", () => {
     expect(row!.group).toBe("workbench");
     expect(row!.mac).toBe("⌘ ⇧ C");
     expect(row!.win).toBe("Ctrl Shift C");
+  });
+});
+
+describe("matchGlobalShortcut", () => {
+  /** Canonical chords that App handles via the mod matcher. */
+  const cases: Array<{
+    id: GlobalModShortcutId;
+    key: string;
+    shift?: boolean;
+    typing?: boolean;
+  }> = [
+    { id: "search", key: "k" },
+    { id: "findInChat", key: "f" },
+    { id: "newChat", key: "n", typing: false },
+    { id: "settings", key: ",", typing: false },
+    { id: "help", key: "/" },
+    { id: "doctor", key: "d", shift: true },
+    { id: "liveVoice", key: "v", shift: true },
+    { id: "copyLastReply", key: "c", shift: true },
+  ];
+
+  it("covers every GLOBAL_MOD_SHORTCUT_IDS entry", () => {
+    const covered = new Set(cases.map((c) => c.id));
+    for (const id of GLOBAL_MOD_SHORTCUT_IDS) {
+      expect(covered.has(id)).toBe(true);
+    }
+    expect(covered.size).toBe(GLOBAL_MOD_SHORTCUT_IDS.length);
+  });
+
+  it("matches each global mod catalog action", () => {
+    for (const c of cases) {
+      expect(
+        matchGlobalShortcut(
+          chord({
+            key: c.key,
+            shift: c.shift ?? false,
+            typing: c.typing ?? false,
+          }),
+        ),
+      ).toBe(c.id);
+    }
+  });
+
+  it("findInChat / search / help work while typing", () => {
+    expect(matchGlobalShortcut(chord({ key: "f", typing: true }))).toBe(
+      "findInChat",
+    );
+    expect(matchGlobalShortcut(chord({ key: "k", typing: true }))).toBe(
+      "search",
+    );
+    expect(matchGlobalShortcut(chord({ key: "/", typing: true }))).toBe("help");
+    expect(
+      matchGlobalShortcut(chord({ key: "d", shift: true, typing: true })),
+    ).toBe("doctor");
+    expect(
+      matchGlobalShortcut(chord({ key: "c", shift: true, typing: true })),
+    ).toBe("copyLastReply");
+    expect(
+      matchGlobalShortcut(chord({ key: "v", shift: true, typing: true })),
+    ).toBe("liveVoice");
+  });
+
+  it("skips newChat and settings while typing", () => {
+    expect(matchGlobalShortcut(chord({ key: "n", typing: true }))).toBeNull();
+    expect(matchGlobalShortcut(chord({ key: ",", typing: true }))).toBeNull();
+  });
+
+  it("does not match without mod", () => {
+    expect(matchGlobalShortcut(chord({ key: "k", mod: false }))).toBeNull();
+    expect(
+      matchGlobalShortcut(chord({ key: "d", mod: false, shift: true })),
+    ).toBeNull();
+  });
+
+  it("does not match plain keys or unrelated chords", () => {
+    expect(matchGlobalShortcut(chord({ key: "a" }))).toBeNull();
+    expect(matchGlobalShortcut(chord({ key: "f", shift: true }))).toBeNull(); // not find
+    expect(matchGlobalShortcut(chord({ key: "c" }))).toBeNull(); // needs shift
+    expect(matchGlobalShortcut(chord({ key: "v" }))).toBeNull();
+    expect(matchGlobalShortcut(chord({ key: "d" }))).toBeNull();
+    expect(matchGlobalShortcut(chord({ key: "escape" }))).toBeNull();
+    expect(matchGlobalShortcut(chord({ key: " ", mod: false }))).toBeNull();
+  });
+
+  it("does not match with alt held", () => {
+    expect(matchGlobalShortcut(chord({ key: "k", alt: true }))).toBeNull();
+  });
+
+  it("does not claim send / stop / dictation (special-cased elsewhere)", () => {
+    const special = new Set(["send", "stop", "dictation"]);
+    for (const id of SHORTCUT_IDS) {
+      if (special.has(id)) {
+        expect(
+          (GLOBAL_MOD_SHORTCUT_IDS as readonly string[]).includes(id),
+        ).toBe(false);
+      }
+    }
   });
 });

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,9 +1,22 @@
-/** Keyboard shortcut catalog — help panel + Settings → Keyboard. */
+/** Keyboard shortcut catalog + global chord matchers (help, Settings, App keydown). */
 
 export type ShortcutGroup = "workbench" | "navigation" | "diagnostics" | "input";
 
+export type ShortcutId =
+  | "search"
+  | "findInChat"
+  | "newChat"
+  | "send"
+  | "stop"
+  | "copyLastReply"
+  | "settings"
+  | "help"
+  | "doctor"
+  | "liveVoice"
+  | "dictation";
+
 export type ShortcutRow = {
-  id: string;
+  id: ShortcutId;
   /** i18n message key for the action label */
   labelKey: string;
   group: ShortcutGroup;
@@ -12,6 +25,25 @@ export type ShortcutRow = {
   /** Display keys for win/linux */
   win: string;
 };
+
+/**
+ * Stable catalog id order — same as SHORTCUTS.
+ * Includes display-only rows (send, stop, dictation) that are not matched by
+ * {@link matchGlobalShortcut}.
+ */
+export const SHORTCUT_IDS: readonly ShortcutId[] = [
+  "search",
+  "findInChat",
+  "newChat",
+  "send",
+  "stop",
+  "copyLastReply",
+  "settings",
+  "help",
+  "doctor",
+  "liveVoice",
+  "dictation",
+] as const;
 
 /**
  * Shipped shortcuts that already work in the app.
@@ -100,6 +132,73 @@ export const SHORTCUTS: ShortcutRow[] = [
   },
 ];
 
+/**
+ * Catalog ids handled by {@link matchGlobalShortcut} (mod-based App capture handler).
+ * Not included: `send` (composer-local), `stop` (Esc special-cased in App for order
+ * vs voice cancel / overlays), `dictation` (Ctrl+Space via `isVoiceToggleKey` —
+ * must not use meta, and runs before the mod branch).
+ */
+export const GLOBAL_MOD_SHORTCUT_IDS = [
+  "search",
+  "findInChat",
+  "newChat",
+  "settings",
+  "help",
+  "doctor",
+  "liveVoice",
+  "copyLastReply",
+] as const satisfies readonly ShortcutId[];
+
+export type GlobalModShortcutId = (typeof GLOBAL_MOD_SHORTCUT_IDS)[number];
+
+/** Normalized chord state for pure global matching (no DOM). */
+export type ShortcutChordContext = {
+  /** Lowercased `KeyboardEvent.key` (e.g. "k", ",", "/") */
+  key: string;
+  /** metaKey || ctrlKey */
+  mod: boolean;
+  shift: boolean;
+  alt: boolean;
+  /** True when focus is input / textarea / contenteditable */
+  typing: boolean;
+};
+
+/**
+ * Match mod-based global shortcuts that App handles in the capture-phase keydown.
+ *
+ * Esc-stop and Ctrl+Space dictation stay special-cased in App (handler order /
+ * non-mod-or-ctrl-only semantics). See comment on {@link GLOBAL_MOD_SHORTCUT_IDS}.
+ *
+ * Behavior preserved from the previous inline App handler:
+ * - findInChat works while typing
+ * - newChat / settings skip when typing
+ * - search / help / doctor / copyLastReply / liveVoice work while typing
+ */
+export function matchGlobalShortcut(
+  ctx: ShortcutChordContext,
+): GlobalModShortcutId | null {
+  if (!ctx.mod) return null;
+  // Alt chords are left to the OS / browser (not used by catalog mod actions).
+  if (ctx.alt) return null;
+
+  const key = ctx.key;
+  const shift = ctx.shift;
+  const typing = ctx.typing;
+
+  // findInChat: mod+f without shift (even while typing).
+  if (key === "f" && !shift) return "findInChat";
+  // search / help: same as prior App handler (no shift gate).
+  if (key === "k") return "search";
+  if (key === "/") return "help";
+  if (key === "," && !typing) return "settings";
+  if (key === "n" && !typing) return "newChat";
+  if (key === "d" && shift) return "doctor";
+  if (key === "c" && shift) return "copyLastReply";
+  if (key === "v" && shift) return "liveVoice";
+
+  return null;
+}
+
 /** Group order for Settings → Keyboard (and optional help grouping). */
 export const SHORTCUT_GROUP_ORDER: ShortcutGroup[] = [
   "workbench",
@@ -110,7 +209,7 @@ export const SHORTCUT_GROUP_ORDER: ShortcutGroup[] = [
 
 export function shortcutsForPlatform(
   platform: "mac" | "win" | "other",
-): Array<{ id: string; labelKey: string; keys: string; group: ShortcutGroup }> {
+): Array<{ id: ShortcutId; labelKey: string; keys: string; group: ShortcutGroup }> {
   return SHORTCUTS.map((s) => ({
     id: s.id,
     labelKey: s.labelKey,


### PR DESCRIPTION
## Summary
- Centralize display catalog and App global mod-chord matching in `src/lib/shortcuts.ts` (`matchGlobalShortcut`, `GLOBAL_MOD_SHORTCUT_IDS`, `SHORTCUT_IDS`).
- App capture-phase keydown switches on matcher ids; Esc-stop and Ctrl+Space dictation stay special-cased (handler order).
- Unit tests cover every global-mod catalog id and reject plain-key false positives.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/shortcuts.test.ts`