### PR TITLE
feat(settings): filter keyboard shortcuts list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Keyboard shortcuts filter** (Settings → Keyboard): search the shortcut list by action label, id, or key chord (⌘/Ctrl tokens)
 - **Copy last assistant reply** shortcut: ⌘/Ctrl+Shift+C (same action as slash `/copy`; listed in shortcuts catalog)
 - **Collapse all activity** in the current chat: top-bar control and session menu item collapse expanded tool phases and finished thinking blocks (streaming thoughts stay open)
 - **Sidebar session relative time** (Settings → Appearance → Interface; on by default): muted “2 hours ago” meta on session rows from `updatedAt`, refreshed about once a minute (`localStorage` `grok.sidebarShowRelativeTime`)
@@ -40,6 +41,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增**
 
+- 键盘快捷键筛选（设置 → 键盘）：按操作名称、id 或按键组合过滤列表
 - 复制上一条助手回复快捷键：⌘/Ctrl+Shift+C（与 `/copy` 相同；快捷键列表已收录）
 - 当前对话「收起全部活动」：顶栏按钮与会话菜单可收起已展开的工具阶段与已完成思考（流式思考保持展开）
 - 侧栏会话相对更新时间（设置 → 外观 → 界面；默认开；约每分钟刷新）

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -37,6 +37,7 @@ import {
 import { Tip } from "@/components/ui/tooltip";
 import {
   detectShortcutPlatform,
+  filterShortcutGroups,
   shortcutsByGroup,
   type ShortcutGroup,
 } from "@/lib/shortcuts";
@@ -4141,8 +4142,16 @@ function ShortcutsSettingsPanel({
   t: (key: MessageKey, vars?: Vars) => string;
   onOpenHelp?: () => void;
 }) {
+  const [filterQuery, setFilterQuery] = useState("");
   const platform = useMemo(() => detectShortcutPlatform(), []);
   const groups = useMemo(() => shortcutsByGroup(), []);
+  const filteredGroups = useMemo(
+    () =>
+      filterShortcutGroups(filterQuery, groups, (key) =>
+        t(key as MessageKey),
+      ),
+    [filterQuery, groups, t],
+  );
 
   const groupLabel = (g: ShortcutGroup) =>
     t(`settings.shortcuts.group.${g}` as MessageKey);
@@ -4167,49 +4176,67 @@ function ShortcutsSettingsPanel({
           </button>
         ) : null}
       </div>
-      {groups.map(({ group, rows }) => (
-        <div key={group} className="settings-shortcuts-group">
-          <div className="settings-shortcuts-group__title">{groupLabel(group)}</div>
-          <table className="settings-shortcuts-table">
-            <thead>
-              <tr>
-                <th scope="col">{t("settings.shortcuts.colAction")}</th>
-                <th
-                  scope="col"
-                  className={
-                    platform === "mac" ? "is-platform-active" : undefined
-                  }
-                >
-                  {t("settings.shortcuts.colMac")}
-                </th>
-                <th
-                  scope="col"
-                  className={
-                    platform === "win" || platform === "other"
-                      ? "is-platform-active"
-                      : undefined
-                  }
-                >
-                  {t("settings.shortcuts.colWin")}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => (
-                <tr key={row.id}>
-                  <td>{t(row.labelKey as MessageKey)}</td>
-                  <td>
-                    <kbd className="settings-shortcuts-kbd">{row.mac}</kbd>
-                  </td>
-                  <td>
-                    <kbd className="settings-shortcuts-kbd">{row.win}</kbd>
-                  </td>
+      <div className="settings-shortcuts-filter">
+        <IconSearch size={14} />
+        <input
+          type="search"
+          value={filterQuery}
+          onChange={(e) => setFilterQuery(e.target.value)}
+          placeholder={t("settings.shortcuts.filterPlaceholder")}
+          aria-label={t("settings.shortcuts.filterPlaceholder")}
+        />
+      </div>
+      {filteredGroups.length === 0 ? (
+        <p className="settings-shortcuts-empty" role="status">
+          {t("settings.shortcuts.filterEmpty")}
+        </p>
+      ) : (
+        filteredGroups.map(({ group, rows }) => (
+          <div key={group} className="settings-shortcuts-group">
+            <div className="settings-shortcuts-group__title">
+              {groupLabel(group)}
+            </div>
+            <table className="settings-shortcuts-table">
+              <thead>
+                <tr>
+                  <th scope="col">{t("settings.shortcuts.colAction")}</th>
+                  <th
+                    scope="col"
+                    className={
+                      platform === "mac" ? "is-platform-active" : undefined
+                    }
+                  >
+                    {t("settings.shortcuts.colMac")}
+                  </th>
+                  <th
+                    scope="col"
+                    className={
+                      platform === "win" || platform === "other"
+                        ? "is-platform-active"
+                        : undefined
+                    }
+                  >
+                    {t("settings.shortcuts.colWin")}
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ))}
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.id}>
+                    <td>{t(row.labelKey as MessageKey)}</td>
+                    <td>
+                      <kbd className="settings-shortcuts-kbd">{row.mac}</kbd>
+                    </td>
+                    <td>
+                      <kbd className="settings-shortcuts-kbd">{row.win}</kbd>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))
+      )}
       <p className="settings-shortcuts-note">{t("settings.shortcuts.note")}</p>
     </div>
   );

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -728,6 +728,8 @@ const en = {
   "settings.shortcuts.note":
     "Default send is Enter; switch to ⌘/Ctrl+Enter in Settings → Composer. Some chords may be taken by the OS (e.g. input sources).",
   "settings.shortcuts.openHelp": "Open shortcuts help",
+  "settings.shortcuts.filterPlaceholder": "Filter shortcuts…",
+  "settings.shortcuts.filterEmpty": "No shortcuts match this filter.",
   "settings.archived.desc":
     "Chats you archived are listed by project. Select multiple to restore or delete.",
   "settings.archived.empty": "No archived chats.",
@@ -3010,6 +3012,8 @@ const zh: Record<MessageKey, string> = {
   "settings.shortcuts.note":
     "默认 Enter 发送；可在 设置 → 对话偏好 改为 ⌘/Ctrl+Enter。部分组合键可能被系统占用（如输入法切换）。",
   "settings.shortcuts.openHelp": "打开快捷键帮助",
+  "settings.shortcuts.filterPlaceholder": "筛选快捷键…",
+  "settings.shortcuts.filterEmpty": "没有符合筛选条件的快捷键。",
   "settings.archived.desc":
     "已归档的会话按项目分组。可多选后批量还原或删除。",
   "settings.archived.empty": "暂无已归档会话。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -695,6 +695,8 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.shortcuts.note":
     "預設 Enter 傳送；可在 設定 → 對話偏好 改為 ⌘/Ctrl+Enter。部分組合鍵可能被系統占用（如輸入法切換）。",
   "settings.shortcuts.openHelp": "開啟快捷鍵說明",
+  "settings.shortcuts.filterPlaceholder": "篩選快捷鍵…",
+  "settings.shortcuts.filterEmpty": "沒有符合篩選條件的快捷鍵。",
   "settings.archived.desc":
     "已封存的對話依專案分組。可多選後批次還原或刪除。",
   "settings.archived.empty": "尚無已封存對話。",

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,9 +1,30 @@
 import { describe, expect, it } from "vitest";
 import {
   SHORTCUTS,
+  filterShortcutGroups,
+  filterShortcutRows,
   shortcutsByGroup,
   shortcutsForPlatform,
 } from "./shortcuts";
+
+/** Minimal t() for filter tests — returns the key suffix as a stand-in label. */
+function tStub(key: string): string {
+  // Real labels are looked up via i18n; tests use predictable English-ish strings.
+  const labels: Record<string, string> = {
+    "shortcuts.search": "Search chats / projects",
+    "shortcuts.findInChat": "Find in conversation",
+    "shortcuts.newChat": "New chat",
+    "shortcuts.send": "Send message",
+    "shortcuts.stop": "Stop generation",
+    "shortcuts.copyLastReply": "Copy last reply",
+    "shortcuts.settings": "Open settings",
+    "shortcuts.help": "Show shortcuts",
+    "shortcuts.doctor": "Open doctor",
+    "shortcuts.liveVoice": "Live voice",
+    "shortcuts.voice": "Voice dictation",
+  };
+  return labels[key] ?? key;
+}
 
 describe("shortcuts catalog", () => {
   it("has stable unique ids", () => {
@@ -75,5 +96,79 @@ describe("shortcuts catalog", () => {
     expect(row!.group).toBe("workbench");
     expect(row!.mac).toBe("⌘ ⇧ C");
     expect(row!.win).toBe("Ctrl Shift C");
+  });
+});
+
+describe("filterShortcutRows", () => {
+  it("returns all rows for empty or whitespace query", () => {
+    expect(filterShortcutRows("", SHORTCUTS, tStub)).toEqual(SHORTCUTS);
+    expect(filterShortcutRows("   \t  ", SHORTCUTS, tStub)).toEqual(SHORTCUTS);
+  });
+
+  it("matches id case-insensitively", () => {
+    const hits = filterShortcutRows("findinchat", SHORTCUTS, tStub);
+    expect(hits.map((r) => r.id)).toEqual(["findInChat"]);
+  });
+
+  it("matches localized label case-insensitively", () => {
+    const hits = filterShortcutRows("settings", SHORTCUTS, tStub);
+    expect(hits.some((r) => r.id === "settings")).toBe(true);
+    const doctor = filterShortcutRows("DOCTOR", SHORTCUTS, tStub);
+    expect(doctor.map((r) => r.id)).toEqual(["doctor"]);
+  });
+
+  it("matches mac/win key strings and expanded tokens (cmd, shift, enter)", () => {
+    const byCmdK = filterShortcutRows("⌘ k", SHORTCUTS, tStub);
+    expect(byCmdK.some((r) => r.id === "search")).toBe(true);
+
+    const byCmd = filterShortcutRows("cmd", SHORTCUTS, tStub);
+    expect(byCmd.length).toBeGreaterThan(0);
+    expect(byCmd.every((r) => r.mac.includes("⌘") || /cmd|ctrl/i.test(r.win))).toBe(
+      true,
+    );
+
+    const byCtrlF = filterShortcutRows("ctrl f", SHORTCUTS, tStub);
+    expect(byCtrlF.some((r) => r.id === "findInChat")).toBe(true);
+
+    const byEnter = filterShortcutRows("enter", SHORTCUTS, tStub);
+    expect(byEnter.some((r) => r.id === "send")).toBe(true);
+
+    const byShift = filterShortcutRows("shift", SHORTCUTS, tStub);
+    expect(byShift.some((r) => r.id === "copyLastReply")).toBe(true);
+    expect(byShift.some((r) => r.id === "doctor")).toBe(true);
+  });
+
+  it("returns empty array when nothing matches", () => {
+    expect(filterShortcutRows("no-such-shortcut-xyz", SHORTCUTS, tStub)).toEqual(
+      [],
+    );
+  });
+
+  it("preserves input order of matches", () => {
+    const hits = filterShortcutRows("ctrl", SHORTCUTS, tStub);
+    const ids = hits.map((r) => r.id);
+    const expected = SHORTCUTS.filter((r) =>
+      filterShortcutRows("ctrl", [r], tStub).length,
+    ).map((r) => r.id);
+    expect(ids).toEqual(expected);
+  });
+
+  it("handles empty row list", () => {
+    expect(filterShortcutRows("search", [], tStub)).toEqual([]);
+    expect(filterShortcutRows("", [], tStub)).toEqual([]);
+  });
+});
+
+describe("filterShortcutGroups", () => {
+  it("drops groups with no matching rows and keeps order", () => {
+    const groups = shortcutsByGroup();
+    const filtered = filterShortcutGroups("doctor", groups, tStub);
+    expect(filtered.map((g) => g.group)).toEqual(["diagnostics"]);
+    expect(filtered[0]!.rows.map((r) => r.id)).toEqual(["doctor"]);
+  });
+
+  it("returns all groups for empty query", () => {
+    const groups = shortcutsByGroup();
+    expect(filterShortcutGroups("", groups, tStub)).toEqual(groups);
   });
 });

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -140,3 +140,62 @@ export function shortcutsByGroup(): Array<{
     rows: SHORTCUTS.filter((s) => s.group === group),
   })).filter((g) => g.rows.length > 0);
 }
+
+/**
+ * Append Latin aliases for display glyphs (cmd for ⌘, shift for ⇧, …).
+ * Original key strings stay intact so queries like "⌘ k" still match.
+ */
+function keySearchExtra(keys: string): string {
+  const parts: string[] = [];
+  if (keys.includes("⌘")) parts.push("cmd", "command", "meta");
+  if (keys.includes("⇧")) parts.push("shift");
+  if (keys.includes("↵")) parts.push("enter", "return");
+  if (keys.includes("⌥")) parts.push("option", "alt");
+  if (keys.includes("⌃")) parts.push("control", "ctrl");
+  return parts.join(" ");
+}
+
+/**
+ * Filter shortcut rows by free-text query.
+ * Case-insensitive match on id, localized label (via `t`), and mac/win key strings
+ * (including expanded tokens like "cmd" for ⌘). Empty/whitespace query → all rows.
+ */
+export function filterShortcutRows(
+  query: string,
+  rows: ShortcutRow[],
+  t: (key: string) => string,
+): ShortcutRow[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return rows;
+  return rows.filter((row) => {
+    const label = t(row.labelKey).toLowerCase();
+    const haystack = [
+      row.id,
+      label,
+      row.mac,
+      row.win,
+      keySearchExtra(row.mac),
+      keySearchExtra(row.win),
+    ]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
+/**
+ * Apply {@link filterShortcutRows} per group and drop empty groups.
+ * Preserves {@link SHORTCUT_GROUP_ORDER}.
+ */
+export function filterShortcutGroups(
+  query: string,
+  groups: Array<{ group: ShortcutGroup; rows: ShortcutRow[] }>,
+  t: (key: string) => string,
+): Array<{ group: ShortcutGroup; rows: ShortcutRow[] }> {
+  return groups
+    .map(({ group, rows }) => ({
+      group,
+      rows: filterShortcutRows(query, rows, t),
+    }))
+    .filter((g) => g.rows.length > 0);
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4125,6 +4125,43 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
 }
 
 /* Settings → Keyboard (read-only shortcut catalog) */
+.settings-shortcuts-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  margin: 0 16px 8px;
+  padding: 0 10px;
+  border-radius: 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-tertiary);
+}
+
+.settings-shortcuts-filter input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.settings-shortcuts-filter input[type="search"]::-webkit-search-decoration,
+.settings-shortcuts-filter input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+
+.settings-shortcuts-empty {
+  margin: 0;
+  padding: 20px 16px 24px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
 .settings-shortcuts-group {
   padding: 8px 16px 14px;
   border-bottom: 1px solid var(--border-subtle);


### PR DESCRIPTION
## Summary
- Add pure `filterShortcutRows` / `filterShortcutGroups` helpers that match by action label (via `t`), id, and mac/win key chords (including cmd/shift/enter aliases for ⌘/⇧/↵)
- Settings → Keyboard: search input above the table, filter groups, empty state when nothing matches
- Keep active platform column highlight; no remapping / no App keydown changes
- i18n: `settings.shortcuts.filterPlaceholder` / `filterEmpty` (en / zh / zh-TW)
- Unit tests + CHANGELOG Unreleased

## Test plan
- [ ] `pnpm test -- src/lib/shortcuts.test.ts src/i18n/messages.test.ts`
- [ ] Open Settings → Keyboard, confirm all groups/rows still list
- [ ] Type `search`, `cmd`, `ctrl f`, `enter`, `doctor` — rows filter as expected; empty groups hide
- [ ] Nonsense query shows empty state string
- [ ] Active platform column still highlighted (macOS vs Windows/Linux)
- [ ] Switch locale en/zh/zh-TW and confirm filter placeholder + empty copy