### PR TITLE
feat(settings): reopen last section and tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Remember last Settings section + tab**: generic open (⌘/Ctrl+,, gear, slash `/settings`, tray Settings…) restores the last place via `localStorage` `grok.settingsLastRoute`; explicit deep links and section jumps are unchanged
 - **Copy last assistant reply** shortcut: ⌘/Ctrl+Shift+C (same action as slash `/copy`; listed in shortcuts catalog)
 - **Collapse all activity** in the current chat: top-bar control and session menu item collapse expanded tool phases and finished thinking blocks (streaming thoughts stay open)
 - **Sidebar session relative time** (Settings → Appearance → Interface; on by default): muted “2 hours ago” meta on session rows from `updatedAt`, refreshed about once a minute (`localStorage` `grok.sidebarShowRelativeTime`)
@@ -40,6 +41,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增**
 
+- **记住上次设置分区与页签**：通用入口（⌘/Ctrl+,、齿轮、斜杠 `/settings`、托盘设置）恢复上次位置（`localStorage` `grok.settingsLastRoute`）；显式深链与指定分区跳转不变
 - 复制上一条助手回复快捷键：⌘/Ctrl+Shift+C（与 `/copy` 相同；快捷键列表已收录）
 - 当前对话「收起全部活动」：顶栏按钮与会话菜单可收起已展开的工具阶段与已完成思考（流式思考保持展开）
 - 侧栏会话相对更新时间（设置 → 外观 → 界面；默认开；约每分钟刷新）

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -265,10 +265,8 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
         }
         "more_settings" => {
             show_main_window(app);
-            let _ = app.emit(
-                "tray://open-settings",
-                serde_json::json!({ "section": "general" }),
-            );
+            // No section → frontend restores last settings route (or general).
+            let _ = app.emit("tray://open-settings", serde_json::json!({}));
         }
         "more_doctor" => {
             show_main_window(app);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -486,12 +486,16 @@ import {
   type SettingsSectionId,
 } from "@/components/SettingsPage";
 import {
-  SETTINGS_SECTION_IDS,
   buildSettingsHash,
+  isSettingsSectionId,
   parseSettingsHash,
-  resolveTab,
   type SettingsTabId,
 } from "@/lib/settingsCatalog";
+import {
+  loadSettingsLastRoute,
+  resolveOpenSettingsLocation,
+  saveSettingsLastRoute,
+} from "@/lib/settingsLastRoute";
 import {
   accountDisplayName,
   accountInitials,
@@ -3536,20 +3540,32 @@ export default function App() {
     );
   }, []);
 
+  /**
+   * Open Settings at section/tab.
+   * - Omit `section` (generic open: ⌘,, gear, slash /settings, tray Settings…)
+   *   → restore last route when valid, else general.
+   * - Explicit section always wins (palette, deep link, account, errors).
+   * - Persists the resolved route to localStorage for the next generic open.
+   */
   const navigateSettings = useCallback(
-    (section: SettingsSectionId = "general", tab?: string | null) => {
-      const nextTab = resolveTab(section, tab);
-      setSettingsSection(section);
-      setSettingsTab(nextTab);
+    (section?: SettingsSectionId | null, tab?: string | null) => {
+      const loc = resolveOpenSettingsLocation({
+        section: section ?? undefined,
+        tab,
+        last: section == null ? loadSettingsLastRoute() : null,
+      });
+      setSettingsSection(loc.section);
+      setSettingsTab(loc.tab);
       setAppView("settings");
       setShowUserMenu(false);
+      saveSettingsLastRoute(loc);
       if (typeof window !== "undefined") {
         // Phone: generic settings open lands on the section index (SettingsPage
         // starts at phonePane=index). Specific sections still set the hash so a
         // later drill-in / deep-link matches the intended section.
         const hash = buildSettingsHash({
-          section,
-          tab: nextTab,
+          section: loc.section,
+          tab: loc.tab,
         });
         // Avoid no-op hash writes (some webviews skip hashchange; state still set above).
         if (window.location.hash !== hash) {
@@ -3561,17 +3577,33 @@ export default function App() {
   );
 
   // Hash route: #/settings[/section[/tab]] | #/automations | #/workbench
+  // Explicit #/settings/{section}… deep links always win; bare #/settings uses last.
   useEffect(() => {
     const syncFromHash = () => {
       const raw = (window.location.hash || "").replace(/^#\/?/, "");
       if (raw.startsWith("settings")) {
-        const loc = parseSettingsHash(raw);
-        if (loc) {
-          setSettingsSection(loc.section);
-          setSettingsTab(loc.tab ?? null);
+        const parts = raw.split("/").filter(Boolean);
+        // parts[0] === "settings"; parts[1] may be section
+        const sectionPart = parts[1];
+        const hasExplicitSection = isSettingsSectionId(sectionPart);
+        if (hasExplicitSection) {
+          const loc = parseSettingsHash(raw);
+          if (loc) {
+            setSettingsSection(loc.section);
+            setSettingsTab(loc.tab ?? null);
+            saveSettingsLastRoute(loc);
+          }
         } else {
-          setSettingsSection("general");
-          setSettingsTab(resolveTab("general"));
+          // Bare #/settings or unknown first segment → last route if valid.
+          const last = loadSettingsLastRoute();
+          const loc = resolveOpenSettingsLocation({ last });
+          setSettingsSection(loc.section);
+          setSettingsTab(loc.tab);
+          saveSettingsLastRoute(loc);
+          const hash = buildSettingsHash(loc);
+          if (window.location.hash !== hash) {
+            window.location.hash = hash;
+          }
         }
         setAppView("settings");
       } else if (raw === "automations" || raw.startsWith("automations")) {
@@ -7713,7 +7745,7 @@ export default function App() {
             setLiveVoiceOpen(true);
             return;
           case "settings":
-            navigateSettings("general");
+            navigateSettings();
             return;
           case "export":
             void exportActiveSessionMd();
@@ -8744,14 +8776,15 @@ export default function App() {
   const trayHandlersRef = useRef({
     newChat: () => {},
     openSessionById: (_id: string) => {},
-    openSettings: (_section: SettingsSectionId = "general") => {},
+    /** Omit section to restore last settings route. */
+    openSettings: (_section?: SettingsSectionId) => {},
     openDoctor: () => {},
   });
   shortcutHandlersRef.current = {
     newChat: () => {
       void newChat();
     },
-    openSettings: (section: SettingsSectionId = "general") => {
+    openSettings: (section?: SettingsSectionId) => {
       navigateSettings(section);
     },
     openChatFind: () => {
@@ -8824,7 +8857,7 @@ export default function App() {
         await openSession(row, proj);
       })();
     },
-    openSettings: (section: SettingsSectionId = "general") => {
+    openSettings: (section?: SettingsSectionId) => {
       navigateSettings(section);
     },
     openDoctor: () => {
@@ -8854,12 +8887,16 @@ export default function App() {
         );
         unsubs.push(
           await listen<{ section?: string }>("tray://open-settings", (ev) => {
-            const raw = (ev.payload?.section || "general") as string;
-            const section = (SETTINGS_SECTION_IDS as readonly string[]).includes(
-              raw,
-            )
-              ? (raw as SettingsSectionId)
-              : "general";
+            // No section (tray "Settings…") → restore last. Explicit section
+            // (e.g. Account) always wins; invalid ids fall back to general.
+            const raw = ev.payload?.section;
+            if (raw == null || raw === "") {
+              trayHandlersRef.current.openSettings();
+              return;
+            }
+            const section = isSettingsSectionId(raw)
+              ? raw
+              : ("general" as SettingsSectionId);
             trayHandlersRef.current.openSettings(section);
           }),
         );
@@ -11275,7 +11312,7 @@ export default function App() {
               customProvider: tr("prov.customProvider"),
               resetsAt: tr("account.resetsAt"),
             }}
-            onSettings={() => navigateSettings("general")}
+            onSettings={() => navigateSettings()}
             onAccountSettings={() => navigateSettings("account")}
             onToggleTheme={toggleThemeBtn}
             onLogin={() => void runAccountLogin("oauth")}

--- a/src/lib/settingsLastRoute.test.ts
+++ b/src/lib/settingsLastRoute.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  SETTINGS_LAST_ROUTE_STORAGE_KEY,
+  loadSettingsLastRoute,
+  parseSettingsLastRoute,
+  resolveOpenSettingsLocation,
+  saveSettingsLastRoute,
+  type SettingsLastRouteStorage,
+} from "./settingsLastRoute";
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+): SettingsLastRouteStorage & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    getItem(key) {
+      return key in data ? data[key]! : null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+  };
+}
+
+describe("settingsLastRoute", () => {
+  it("parse rejects empty / invalid / unknown section", () => {
+    expect(parseSettingsLastRoute(null)).toBeNull();
+    expect(parseSettingsLastRoute("")).toBeNull();
+    expect(parseSettingsLastRoute("not-json")).toBeNull();
+    expect(parseSettingsLastRoute("{}")).toBeNull();
+    expect(parseSettingsLastRoute({ section: "nope" })).toBeNull();
+    expect(parseSettingsLastRoute({ section: 1 })).toBeNull();
+  });
+
+  it("parse accepts valid section and resolves tab", () => {
+    expect(
+      parseSettingsLastRoute({ section: "runtime", tab: "tools" }),
+    ).toEqual({ section: "runtime", tab: "tools" });
+    expect(parseSettingsLastRoute({ section: "about" })).toEqual({
+      section: "about",
+      tab: null,
+    });
+    // unknown tab → default for section
+    expect(
+      parseSettingsLastRoute({ section: "extensions", tab: "not-a-tab" }),
+    ).toEqual({ section: "extensions", tab: "plugins" });
+    expect(
+      parseSettingsLastRoute(
+        JSON.stringify({ section: "appearance", tab: "interface" }),
+      ),
+    ).toEqual({ section: "appearance", tab: "interface" });
+  });
+
+  it("load / save round-trip and ignores bad section on save", () => {
+    const storage = memoryStorage();
+    expect(loadSettingsLastRoute(storage)).toBeNull();
+
+    saveSettingsLastRoute({ section: "remote_im", tab: "mirror" }, storage);
+    expect(storage.data[SETTINGS_LAST_ROUTE_STORAGE_KEY]).toBe(
+      JSON.stringify({ section: "remote_im", tab: "mirror" }),
+    );
+    expect(loadSettingsLastRoute(storage)).toEqual({
+      section: "remote_im",
+      tab: "mirror",
+    });
+
+    saveSettingsLastRoute({ section: "shortcuts" }, storage);
+    expect(loadSettingsLastRoute(storage)).toEqual({
+      section: "shortcuts",
+      tab: null,
+    });
+
+    // Invalid section must not clobber storage (type-guard is runtime for safety).
+    saveSettingsLastRoute(
+      { section: "bogus" as "general", tab: "composer" },
+      storage,
+    );
+    expect(loadSettingsLastRoute(storage)).toEqual({
+      section: "shortcuts",
+      tab: null,
+    });
+  });
+
+  it("resolveOpenSettingsLocation: explicit wins over last", () => {
+    const last = { section: "runtime" as const, tab: "tools" as const };
+    expect(
+      resolveOpenSettingsLocation({
+        section: "account",
+        tab: "providers",
+        last,
+      }),
+    ).toEqual({ section: "account", tab: "providers" });
+    expect(
+      resolveOpenSettingsLocation({ section: "about", last }),
+    ).toEqual({ section: "about", tab: null });
+  });
+
+  it("resolveOpenSettingsLocation: no section uses last when valid", () => {
+    expect(
+      resolveOpenSettingsLocation({
+        last: { section: "extensions", tab: "mcp" },
+      }),
+    ).toEqual({ section: "extensions", tab: "mcp" });
+    expect(
+      resolveOpenSettingsLocation({
+        last: { section: "extensions", tab: "nope" as "mcp" },
+      }),
+    ).toEqual({ section: "extensions", tab: "plugins" });
+  });
+
+  it("resolveOpenSettingsLocation: falls back to general", () => {
+    expect(resolveOpenSettingsLocation({})).toEqual({
+      section: "general",
+      tab: "composer",
+    });
+    expect(resolveOpenSettingsLocation({ last: null })).toEqual({
+      section: "general",
+      tab: "composer",
+    });
+    expect(
+      resolveOpenSettingsLocation({ section: "not-a-section", last: null }),
+    ).toEqual({ section: "general", tab: "composer" });
+  });
+
+  it("isSettingsSectionId gate: only known sections restore", () => {
+    // parse already nulls unknown sections — resolve never sees them as last.
+    const bad = parseSettingsLastRoute({ section: "legacy_foo", tab: "x" });
+    expect(bad).toBeNull();
+    expect(resolveOpenSettingsLocation({ last: bad })).toEqual({
+      section: "general",
+      tab: "composer",
+    });
+  });
+});

--- a/src/lib/settingsLastRoute.ts
+++ b/src/lib/settingsLastRoute.ts
@@ -1,0 +1,125 @@
+/**
+ * Remember last Settings section + tab so generic "open Settings"
+ * (⌘,, gear, slash /settings, tray Settings…) restores that place.
+ *
+ * localStorage-only — no Rust AppSettings.
+ * Explicit deep links (`#/settings/{section}[/{tab}]`) always win.
+ */
+
+import {
+  isSettingsSectionId,
+  resolveTab,
+  type SettingsSectionId,
+  type SettingsTabId,
+} from "./settingsCatalog";
+
+export const SETTINGS_LAST_ROUTE_STORAGE_KEY = "grok.settingsLastRoute";
+
+export type SettingsLastRoute = {
+  section: SettingsSectionId;
+  tab: SettingsTabId | null;
+};
+
+export interface SettingsLastRouteStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+const noopStorage: SettingsLastRouteStorage = {
+  getItem: () => null,
+  setItem: () => {},
+};
+
+function defaultStorage(): SettingsLastRouteStorage {
+  return typeof localStorage !== "undefined" ? localStorage : noopStorage;
+}
+
+/**
+ * Parse stored JSON. Invalid / unknown section → null.
+ * Unknown tab falls back via resolveTab (default tab or null).
+ */
+export function parseSettingsLastRoute(raw: unknown): SettingsLastRoute | null {
+  if (raw == null || raw === "") return null;
+  let obj: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const section = (obj as { section?: unknown }).section;
+  if (typeof section !== "string" || !isSettingsSectionId(section)) {
+    return null;
+  }
+  const tabRaw = (obj as { tab?: unknown }).tab;
+  const tab =
+    typeof tabRaw === "string" || tabRaw === null || tabRaw === undefined
+      ? resolveTab(section, tabRaw as string | null | undefined)
+      : resolveTab(section, null);
+  return { section, tab };
+}
+
+export function loadSettingsLastRoute(
+  storage: SettingsLastRouteStorage = defaultStorage(),
+): SettingsLastRoute | null {
+  try {
+    return parseSettingsLastRoute(
+      storage.getItem(SETTINGS_LAST_ROUTE_STORAGE_KEY),
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a validated route. Unknown section is ignored (no write).
+ * Tab is always resolved so storage stays canonical.
+ */
+export function saveSettingsLastRoute(
+  route: { section: SettingsSectionId; tab?: SettingsTabId | string | null },
+  storage: SettingsLastRouteStorage = defaultStorage(),
+): void {
+  if (!isSettingsSectionId(route.section)) return;
+  const tab = resolveTab(route.section, route.tab);
+  const payload: SettingsLastRoute = { section: route.section, tab };
+  try {
+    storage.setItem(SETTINGS_LAST_ROUTE_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+/**
+ * Resolve where to open Settings.
+ *
+ * - Explicit `section` (deep link / palette / account) always wins.
+ * - Otherwise use last route when section id is valid.
+ * - Else general + default tab.
+ */
+export function resolveOpenSettingsLocation(opts: {
+  /** Explicit target; omit / null / undefined → try last. */
+  section?: SettingsSectionId | string | null;
+  tab?: string | null;
+  last?: SettingsLastRoute | null;
+}): SettingsLastRoute {
+  const explicit = opts.section;
+  if (typeof explicit === "string" && isSettingsSectionId(explicit)) {
+    return {
+      section: explicit,
+      tab: resolveTab(explicit, opts.tab),
+    };
+  }
+  const last = opts.last ?? null;
+  if (last && isSettingsSectionId(last.section)) {
+    return {
+      section: last.section,
+      tab: resolveTab(last.section, last.tab ?? opts.tab),
+    };
+  }
+  return {
+    section: "general",
+    tab: resolveTab("general", opts.tab),
+  };
+}


### PR DESCRIPTION
## Summary

- Remember last Settings **section + tab** in `localStorage` (`grok.settingsLastRoute`)
- Generic open paths restore that place: ⌘/Ctrl+,, gear menu, slash `/settings`, tray **Settings…**
- Explicit deep links (`#/settings/{section}[/{tab}]`) and targeted jumps (palette, account, errors) are unchanged
- Pure helpers + unit tests in `src/lib/settingsLastRoute.ts`; wired in `App.tsx` (no `shortcuts.ts` changes)

## Test plan

- [ ] Open Settings → Runtime → Tools, leave Settings, press ⌘/, — lands on Runtime / Tools
- [ ] Gear → Settings restores last section/tab
- [ ] Slash `/settings` restores last; `/extensions` still opens Extensions
- [ ] Command palette “Appearance” still opens Appearance (not last)
- [ ] Visit `#/settings/account/providers` — lands on Account / Providers (deep link wins)
- [ ] Bare `#/settings` with a stored last route restores it
- [ ] `pnpm exec vitest run src/lib/settingsLastRoute.test.ts`