### PR TITLE
feat(notify): focus session when notification is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Desktop notification click opens the session** that fired turn-done / permission / ask_user (falls back to focusing the app when the session is unknown)
+
 ## [0.2.2] - 2026-07-30
 
 > **Highlight:** In-app auto-update works for signed builds; calmer sidebar multi-select; PATH / busy / media reliability.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,6 +286,7 @@ import {
 } from "@/lib/shortcuts";
 import {
   ensureNotifyPermission,
+  setDesktopNotifySessionFocusHandler,
   shouldShowDesktopNotify,
   showDesktopNotification,
 } from "@/lib/desktopNotify";
@@ -2696,10 +2697,12 @@ export default function App() {
                     notifyPrefsRef.current,
                   )
                 ) {
+                  const turnSid = s.sessionId || null;
                   showDesktopNotification({
                     title: trRef.current("notify.turnDoneTitle"),
                     body: trRef.current("notify.turnDoneBody"),
-                    tag: `turn-${s.sessionId || "x"}`,
+                    tag: `turn-done-${turnSid || "x"}`,
+                    sessionId: turnSid,
                   });
                 }
               } else if (
@@ -3325,8 +3328,9 @@ export default function App() {
                 showDesktopNotification({
                   title: trRef.current("notify.permissionTitle"),
                   body: trRef.current("session.backgroundPermission"),
-                  tag: `perm-bg-${p.rpcId}`,
+                  tag: `perm-bg-${p.sessionId || p.rpcId}`,
                   force: true,
+                  sessionId: p.sessionId ?? null,
                 });
               }
               return;
@@ -3338,8 +3342,9 @@ export default function App() {
               showDesktopNotification({
                 title: trRef.current("notify.permissionTitle"),
                 body: trRef.current("notify.permissionBody"),
-                tag: `perm-${p.rpcId}`,
+                tag: `perm-${p.sessionId || p.rpcId}`,
                 force: true,
+                sessionId: p.sessionId ?? null,
               });
             }
           }),
@@ -3366,8 +3371,9 @@ export default function App() {
                 showDesktopNotification({
                   title: trRef.current("notify.askUserTitle"),
                   body: trRef.current("notify.askUserBody"),
-                  tag: `ask-bg-${p.rpcId}`,
+                  tag: `ask-bg-${p.sessionId || p.rpcId}`,
                   force: true,
+                  sessionId: p.sessionId ?? null,
                 });
               }
               return;
@@ -3380,8 +3386,9 @@ export default function App() {
               showDesktopNotification({
                 title: trRef.current("notify.askUserTitle"),
                 body: trRef.current("notify.askUserBody"),
-                tag: `ask-${p.rpcId}`,
+                tag: `ask-${p.sessionId || p.rpcId}`,
                 force: true,
+                sessionId: p.sessionId ?? null,
               });
             }
           }),
@@ -9034,6 +9041,16 @@ export default function App() {
       void openDoctor();
     },
   };
+
+  // Desktop notification click → open the session that fired the notify.
+  useEffect(() => {
+    setDesktopNotifySessionFocusHandler((sessionId) => {
+      trayHandlersRef.current.openSessionById(sessionId);
+    });
+    return () => {
+      setDesktopNotifySessionFocusHandler(null);
+    };
+  }, []);
 
   // System tray / menu-bar (Codex-style): Recent · More · Usage · New Chat · Open · Quit
   useEffect(() => {

--- a/src/lib/desktopNotify.test.ts
+++ b/src/lib/desktopNotify.test.ts
@@ -3,6 +3,7 @@ import {
   ensureNotifyPermission,
   focusAppFromNotification,
   notificationSupport,
+  setDesktopNotifySessionFocusHandler,
   shouldShowDesktopNotify,
   showDesktopNotification,
 } from "./desktopNotify";
@@ -15,6 +16,7 @@ import {
 const originalNotification = globalThis.Notification;
 
 afterEach(() => {
+  setDesktopNotifySessionFocusHandler(null);
   if (originalNotification) {
     globalThis.Notification = originalNotification;
   } else {
@@ -118,6 +120,150 @@ describe("desktopNotify", () => {
       instances[0]!.onclick?.call({} as Notification, {} as Event);
       expect(focus).toHaveBeenCalled();
       expect(instances[0]!.close).toHaveBeenCalled();
+    } finally {
+      if (prevWindow === undefined) {
+        // @ts-expect-error cleanup stub
+        delete globalThis.window;
+      } else {
+        Object.defineProperty(globalThis, "window", {
+          value: prevWindow,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
+
+  it("onclick invokes session focus handler with sessionId after app focus", () => {
+    const { instances } = mockNotification("granted");
+    const focus = vi.fn();
+    const onSession = vi.fn();
+    const prevWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { focus },
+      configurable: true,
+      writable: true,
+    });
+    setDesktopNotifySessionFocusHandler(onSession);
+    try {
+      expect(
+        showDesktopNotification({
+          title: "done",
+          force: true,
+          tag: "turn-done-sess-1",
+          sessionId: "sess-1",
+        }),
+      ).toBe(true);
+      instances[0]!.onclick?.call({} as Notification, {} as Event);
+      expect(focus).toHaveBeenCalled();
+      expect(onSession).toHaveBeenCalledWith("sess-1");
+      expect(instances[0]!.close).toHaveBeenCalled();
+    } finally {
+      if (prevWindow === undefined) {
+        // @ts-expect-error cleanup stub
+        delete globalThis.window;
+      } else {
+        Object.defineProperty(globalThis, "window", {
+          value: prevWindow,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
+
+  it("onclick focuses app without throwing when sessionId set but no handler", () => {
+    const { instances } = mockNotification("granted");
+    const focus = vi.fn();
+    const prevWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { focus },
+      configurable: true,
+      writable: true,
+    });
+    setDesktopNotifySessionFocusHandler(null);
+    try {
+      expect(
+        showDesktopNotification({
+          title: "done",
+          force: true,
+          sessionId: "sess-2",
+        }),
+      ).toBe(true);
+      expect(() =>
+        instances[0]!.onclick?.call({} as Notification, {} as Event),
+      ).not.toThrow();
+      expect(focus).toHaveBeenCalled();
+    } finally {
+      if (prevWindow === undefined) {
+        // @ts-expect-error cleanup stub
+        delete globalThis.window;
+      } else {
+        Object.defineProperty(globalThis, "window", {
+          value: prevWindow,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
+
+  it("onclick does not call session handler when sessionId is missing", () => {
+    const { instances } = mockNotification("granted");
+    const focus = vi.fn();
+    const onSession = vi.fn();
+    const prevWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { focus },
+      configurable: true,
+      writable: true,
+    });
+    setDesktopNotifySessionFocusHandler(onSession);
+    try {
+      expect(
+        showDesktopNotification({ title: "x", force: true }),
+      ).toBe(true);
+      instances[0]!.onclick?.call({} as Notification, {} as Event);
+      expect(focus).toHaveBeenCalled();
+      expect(onSession).not.toHaveBeenCalled();
+    } finally {
+      if (prevWindow === undefined) {
+        // @ts-expect-error cleanup stub
+        delete globalThis.window;
+      } else {
+        Object.defineProperty(globalThis, "window", {
+          value: prevWindow,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
+
+  it("swallows session handler errors so focus still works", () => {
+    const { instances } = mockNotification("granted");
+    const focus = vi.fn();
+    const prevWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: { focus },
+      configurable: true,
+      writable: true,
+    });
+    setDesktopNotifySessionFocusHandler(() => {
+      throw new Error("open failed");
+    });
+    try {
+      expect(
+        showDesktopNotification({
+          title: "x",
+          force: true,
+          sessionId: "sess-err",
+        }),
+      ).toBe(true);
+      expect(() =>
+        instances[0]!.onclick?.call({} as Notification, {} as Event),
+      ).not.toThrow();
+      expect(focus).toHaveBeenCalled();
     } finally {
       if (prevWindow === undefined) {
         // @ts-expect-error cleanup stub

--- a/src/lib/desktopNotify.ts
+++ b/src/lib/desktopNotify.ts
@@ -14,11 +14,32 @@ export type DesktopNotifyOptions = {
   force?: boolean;
   tag?: string;
   /**
+   * Session that fired this notification (turn_done / permission / ask_user).
+   * On click, after focusing the app, the registered session focus handler is
+   * invoked when this is a non-empty string. Missing id still focuses the app.
+   */
+  sessionId?: string | null;
+  /**
    * Play the optional notify beep after a successful show.
    * `undefined` → use localStorage `grok.notifySound` pref (default off).
    */
   sound?: boolean;
 };
+
+/** Focus a session when the user clicks a desktop notification. */
+export type DesktopNotifySessionFocusHandler = (sessionId: string) => void;
+
+let sessionFocusHandler: DesktopNotifySessionFocusHandler | null = null;
+
+/**
+ * Register (or clear) the App-level handler used when a notification with
+ * `sessionId` is clicked. Module-level so App can wire without circular imports.
+ */
+export function setDesktopNotifySessionFocusHandler(
+  handler: DesktopNotifySessionFocusHandler | null,
+): void {
+  sessionFocusHandler = handler;
+}
 
 export type NotifyPermission = "granted" | "denied" | "default" | "unsupported";
 
@@ -114,7 +135,8 @@ export function focusAppFromNotification(): void {
 /**
  * Show a system notification when permission is granted.
  * Returns true only when a Notification object was constructed.
- * Click focuses the app window when possible.
+ * Click focuses the app window when possible, then deep-links to
+ * `sessionId` via the registered session focus handler (if any).
  * Suppressed entirely during quiet hours (localStorage pref).
  */
 export function showDesktopNotification(opts: DesktopNotifyOptions): boolean {
@@ -127,6 +149,10 @@ export function showDesktopNotification(opts: DesktopNotifyOptions): boolean {
   const N = notificationCtor();
   if (!N) return false;
   try {
+    const focusSessionId =
+      typeof opts.sessionId === "string" && opts.sessionId.trim()
+        ? opts.sessionId.trim()
+        : null;
     const n = new N(opts.title, {
       body: opts.body,
       tag: opts.tag,
@@ -142,6 +168,13 @@ export function showDesktopNotification(opts: DesktopNotifyOptions): boolean {
             /* ignore */
           }
           focusAppFromNotification();
+          if (focusSessionId && sessionFocusHandler) {
+            try {
+              sessionFocusHandler(focusSessionId);
+            } catch {
+              /* fail closed — window already focused */
+            }
+          }
         };
       }
     } catch {


### PR DESCRIPTION
## Summary
- Desktop notifications for **turn_done**, **permission**, and **ask_user** now deep-link to the session that fired them when clicked.
- `desktopNotify` exposes `setDesktopNotifySessionFocusHandler` so App registers a session switcher without circular imports; missing session still focuses the app (fail-closed).
- Notification tags include session id for coalescing (`turn-done-${sessionId}`, etc.) without extra secrets.

## Changes
- **`src/lib/desktopNotify.ts`**: optional `sessionId` on options; module-level focus handler; onclick → `focusAppFromNotification()` then handler.
- **`src/App.tsx`**: register handler → `openSessionById`; pass `sessionId` at all turn/perm/ask notify call sites; unregister on unmount.
- **`src/lib/desktopNotify.test.ts`**: onclick invokes focus + session handler; no throw without handler; blank sessionId skips handler; handler errors swallowed.
- **CHANGELOG** Unreleased Added bullet.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/lib/desktopNotify.test.ts` (20 passed)
- [ ] Manual: background chat finishes / asks permission → click notification → app focuses and opens that session
- [ ] Manual: notification without known session still focuses app only