### PR TITLE
feat(mirror): confirm and warn when phone write is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
-- **Per-session mute** for desktop notifications (context menu Mute / Unmute; sidebar muted icon; in-app toasts still show)
+- **Phone mirror write guard**: enabling “Allow phone to send” requires an in-app confirm dialog; persistent warning banner while write is on; audit log line when write access is toggled (no secrets)
 - **Desktop notification click** opens the session that fired turn-done / permission / ask_user
 - **Send queue Edit** for follow-up items (GlassModal; empty text blocked unless attachments remain)
 - **Context usage chip**: System / Tools / History breakdown (estimate or agent-known buckets)
@@ -35,7 +35,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增**
 
-- 按会话静音桌面通知（菜单 Mute/Unmute；侧栏静音图标；应用内 Toast 仍显示）
+- 手机镜像写权限确认与持续警告横幅；切换时写审计日志（无密钥）
 - 通知点击跳转会话；发送队列可编辑；上下文 System/Tools/History；Compact 增强
 - Worktree 会话徽章与管理；Fork 可选恢复代码；沙箱项目覆盖
 - MCP 状态灯；Memory 浏览器；产品教程；Agent 总览；Trace 历史；快捷键重映射

--- a/docs/features/remote-security.md
+++ b/docs/features/remote-security.md
@@ -1,5 +1,6 @@
 # Remote control security
 
-- Phone mirror defaults to **read-only**; enable “Allow phone to send” for writes.
+- Phone mirror defaults to **read-only**; enable “Allow phone to send” for writes (in-app confirm + persistent warning banner while write is on).
+- Toggling write access writes an audit line to `app.log` (no tokens/URLs).
 - **Regenerate link** rotates the token and disconnects old QR sessions.
 - IM allow-from and LINE signature checks ship in 0.1.9+.

--- a/src-tauri/src/mirror/mod.rs
+++ b/src-tauri/src/mirror/mod.rs
@@ -197,9 +197,22 @@ impl MirrorHost {
 
     pub fn set_read_only(&self, read_only: bool) {
         let mut g = self.inner.lock();
+        let prev = g
+            .runtime
+            .as_ref()
+            .map(|r| r.read_only)
+            .unwrap_or(g.read_only);
         g.read_only = read_only;
         if let Some(r) = g.runtime.as_mut() {
             r.read_only = read_only;
+        }
+        // Audit line for support bundles / app.log — no tokens or URLs.
+        if prev != read_only {
+            tracing::info!(
+                read_only,
+                allow_write = !read_only,
+                "mirror: phone write access toggled"
+            );
         }
     }
 

--- a/src/components/MirrorConnectPanel.tsx
+++ b/src/components/MirrorConnectPanel.tsx
@@ -42,6 +42,19 @@ export type MirrorConnectLabels = {
   allowWrite: string;
   readOnlyOn: string;
   readOnlyHint: string;
+  /** Confirm dialog when enabling phone writes. */
+  writeConfirmTitle: string;
+  writeConfirmMessage: string;
+  writeConfirmOk: string;
+  /** Persistent banner while phone write is enabled. */
+  writeEnabledBanner: string;
+};
+
+export type MirrorConfirmRequest = {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => void;
 };
 
 export type MirrorConnectPanelProps = {
@@ -57,13 +70,11 @@ export type MirrorConnectPanelProps = {
   open?: boolean;
   onClose?: () => void;
   labels: MirrorConnectLabels;
-  /** In-app confirm for stop (no window.confirm). */
-  onConfirmStop: (opts: {
-    title: string;
-    message: string;
-    confirmLabel: string;
-    onConfirm: () => void;
-  }) => void;
+  /**
+   * In-app confirm for stop / enable-write (no window.confirm).
+   * Prefer GlassModal / setAppDialog from the parent.
+   */
+  onRequestConfirm: (opts: MirrorConfirmRequest) => void;
   showToast: (msg: string, ms?: number) => void;
   /**
    * Inline only: auto-start host when the panel becomes active (default true).
@@ -236,9 +247,13 @@ function MirrorConnectBody({
             </button>
             <button
               type="button"
-              className="btn btn--ghost"
+              className={
+                "btn btn--ghost" +
+                (status.readOnly ? "" : " mirror-connect__write-toggle--on")
+              }
               disabled={busy}
               onClick={onToggleReadOnly}
+              aria-pressed={!status.readOnly}
             >
               {status.readOnly ? labels.allowWrite : labels.readOnlyOn}
             </button>
@@ -247,6 +262,20 @@ function MirrorConnectBody({
       </div>
       {status.running && status.readOnly ? (
         <p className="mirror-connect__hint">{labels.readOnlyHint}</p>
+      ) : null}
+      {status.running && !status.readOnly ? (
+        <div
+          className="mirror-connect__write-banner"
+          role="status"
+          aria-live="polite"
+        >
+          <span className="mirror-connect__write-banner-chip" aria-hidden>
+            !
+          </span>
+          <span className="mirror-connect__write-banner-text">
+            {labels.writeEnabledBanner}
+          </span>
+        </div>
       ) : null}
     </>
   );
@@ -257,7 +286,7 @@ export function MirrorConnectPanel({
   open = true,
   onClose,
   labels,
-  onConfirmStop,
+  onRequestConfirm,
   showToast,
   autoStart = true,
 }: MirrorConnectPanelProps) {
@@ -350,15 +379,30 @@ export function MirrorConnectPanel({
     })();
   };
 
-  const handleToggleReadOnly = () => {
+  const applyReadOnly = (readOnly: boolean) => {
     void (async () => {
       try {
-        const st = await api.mirrorSetReadOnly(!status.readOnly);
+        const st = await api.mirrorSetReadOnly(readOnly);
         setStatus(st);
       } catch (e) {
         setErr(String(e));
       }
     })();
+  };
+
+  const handleToggleReadOnly = () => {
+    // Enabling write is a high-risk action — always confirm in-app (never window.confirm).
+    if (status.readOnly) {
+      onRequestConfirm({
+        title: labels.writeConfirmTitle,
+        message: labels.writeConfirmMessage,
+        confirmLabel: labels.writeConfirmOk,
+        onConfirm: () => applyReadOnly(false),
+      });
+      return;
+    }
+    // Reverting to read-only is safe; no confirm.
+    applyReadOnly(true);
   };
 
   const handleCopy = async () => {
@@ -385,7 +429,7 @@ export function MirrorConnectPanel({
   };
 
   const handleStop = () => {
-    onConfirmStop({
+    onRequestConfirm({
       title: labels.stopConfirmTitle,
       message: labels.stopConfirmMessage,
       confirmLabel: labels.stopConfirmOk,

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -931,8 +931,8 @@ export function SettingsPage({
   /** Bump to remount MemoryBrowserPanel after clear-all. */
   const [memoryBrowserEpoch, setMemoryBrowserEpoch] = useState(0);
   const [settingsToast, setSettingsToast] = useState<string | null>(null);
-  /** Phone-mirror stop confirm (settings → remote control → mirror tab). */
-  const [mirrorStopConfirm, setMirrorStopConfirm] = useState<{
+  /** Phone-mirror stop / enable-write confirm (settings → remote control → mirror). */
+  const [mirrorConfirm, setMirrorConfirm] = useState<{
     title: string;
     message: string;
     confirmLabel: string;
@@ -3822,8 +3822,12 @@ export function SettingsPage({
                       allowWrite: t("mirror.allowWrite"),
                       readOnlyOn: t("mirror.readOnlyOn"),
                       readOnlyHint: t("mirror.readOnlyHint"),
+                      writeConfirmTitle: t("mirror.writeConfirmTitle"),
+                      writeConfirmMessage: t("mirror.writeConfirmMessage"),
+                      writeConfirmOk: t("mirror.writeConfirmOk"),
+                      writeEnabledBanner: t("mirror.writeEnabledBanner"),
                     }}
-                    onConfirmStop={(opts) => setMirrorStopConfirm(opts)}
+                    onRequestConfirm={(opts) => setMirrorConfirm(opts)}
                     showToast={showSettingsToast}
                   />
                 ) : (
@@ -4366,9 +4370,9 @@ export function SettingsPage({
       </GlassModal>
 
       <GlassModal
-        open={!!mirrorStopConfirm}
-        onClose={() => setMirrorStopConfirm(null)}
-        title={mirrorStopConfirm?.title ?? t("mirror.stopConfirmTitle")}
+        open={!!mirrorConfirm}
+        onClose={() => setMirrorConfirm(null)}
+        title={mirrorConfirm?.title ?? t("mirror.stopConfirmTitle")}
         size="sm"
         closeLabel={t("common.close")}
         footer={
@@ -4376,7 +4380,7 @@ export function SettingsPage({
             <button
               type="button"
               className="btn btn--ghost"
-              onClick={() => setMirrorStopConfirm(null)}
+              onClick={() => setMirrorConfirm(null)}
             >
               {t("common.cancel")}
             </button>
@@ -4384,18 +4388,18 @@ export function SettingsPage({
               type="button"
               className="btn btn--danger"
               onClick={() => {
-                const action = mirrorStopConfirm?.onConfirm;
-                setMirrorStopConfirm(null);
+                const action = mirrorConfirm?.onConfirm;
+                setMirrorConfirm(null);
                 action?.();
               }}
             >
-              {mirrorStopConfirm?.confirmLabel ?? t("mirror.stopConfirmOk")}
+              {mirrorConfirm?.confirmLabel ?? t("mirror.stopConfirmOk")}
             </button>
           </>
         }
       >
         <p className="settings-row__desc" style={{ margin: 0 }}>
-          {mirrorStopConfirm?.message ?? t("mirror.stopConfirmMessage")}
+          {mirrorConfirm?.message ?? t("mirror.stopConfirmMessage")}
         </p>
       </GlassModal>
     </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2361,6 +2361,12 @@ const en = {
   "mirror.readOnlyOn": "Read-only (safe)",
   "mirror.readOnlyHint":
     "Read-only: the phone can view sessions but cannot send messages or approve tools until you allow writes.",
+  "mirror.writeConfirmTitle": "Allow phone to send?",
+  "mirror.writeConfirmMessage":
+    "The linked phone will be able to send messages, approve tools, and control the agent on this machine. Only enable this if you trust every person who can open the mirror link. You can switch back to read-only at any time.",
+  "mirror.writeConfirmOk": "Allow writes",
+  "mirror.writeEnabledBanner":
+    "Write enabled: phone can send messages and approve tools on this machine.",
   "mirror.chrome.connected": "Linked to host",
   "mirror.chrome.reconnecting": "Reconnecting…",
   "mirror.chrome.accountHost": "Host account",
@@ -4938,6 +4944,12 @@ const zh: Record<MessageKey, string> = {
   "mirror.readOnlyOn": "只读（安全）",
   "mirror.readOnlyHint":
     "只读模式：手机可查看会话，但不能发消息或批准工具，直到你允许写入。",
+  "mirror.writeConfirmTitle": "允许手机发送？",
+  "mirror.writeConfirmMessage":
+    "已连接的手机会发送消息、批准工具，并控制本机上的 Agent。仅在你信任所有能打开镜像链接的人时启用。可随时切回只读。",
+  "mirror.writeConfirmOk": "允许写入",
+  "mirror.writeEnabledBanner":
+    "已允许写入：手机可在本机发送消息并批准工具。",
   "mirror.chrome.connected": "已连接主机",
   "mirror.chrome.reconnecting": "重新连接中…",
   "mirror.chrome.accountHost": "主机账户",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2279,6 +2279,12 @@ export const zhTW: Record<MessageKey, string> = {
   "mirror.readOnlyOn": "唯讀（安全）",
   "mirror.readOnlyHint":
     "唯讀模式：手機可檢視會話，但不能傳送訊息或核准工具，直到你允許寫入。",
+  "mirror.writeConfirmTitle": "允許手機傳送？",
+  "mirror.writeConfirmMessage":
+    "已連線的手機會傳送訊息、核准工具，並控制本機上的 Agent。僅在你信任所有能開啟鏡像連結的人時啟用。可隨時切回唯讀。",
+  "mirror.writeConfirmOk": "允許寫入",
+  "mirror.writeEnabledBanner":
+    "已允許寫入：手機可在本機傳送訊息並核准工具。",
   "mirror.chrome.connected": "已連線主機",
   "mirror.chrome.reconnecting": "重新連線中…",
   "mirror.chrome.accountHost": "主機帳戶",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17034,6 +17034,46 @@ div.composer__input:empty::before {
   color: var(--text-tertiary);
 }
 
+/* Persistent warning while phone write (send / tool approve) is enabled */
+.mirror-connect__write-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
+  padding: 9px 11px;
+  border-radius: 10px;
+  background: rgba(220, 140, 40, 0.12);
+  border: 1px solid rgba(220, 140, 40, 0.35);
+  color: var(--text-primary);
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
+.mirror-connect__write-banner-chip {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  border-radius: 999px;
+  background: rgba(220, 140, 40, 0.28);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.mirror-connect__write-banner-text {
+  min-width: 0;
+  flex: 1;
+}
+
+.mirror-connect__write-toggle--on {
+  color: var(--danger, #e55);
+}
+
 .mirror-connect__footer {
   display: flex;
   gap: 8px;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -15659,8 +15659,6 @@ div.composer__input:empty::before {
   border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
 }
 
-.rewind-confirm__hint,
-.fork-confirm__hint {
 /* Session trace export history (paths only — never file contents) */
 .trace-history-modal__desc {
   margin: 0 0 12px;
@@ -15747,7 +15745,6 @@ div.composer__input:empty::before {
   }
 }
 
-.rewind-confirm__hint {
 .ext-skill-editor {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
Safer phone-mirror write enablement:

- Enabling **Allow phone to send** requires an in-app `GlassModal` confirm (never `window.confirm`) with clear risk copy
- While write is on, a persistent warning banner stays visible in the Mirror panel
- Host logs an audit line on toggle (`mirror: phone write access toggled`) with `read_only` / `allow_write` only — no tokens or URLs
- i18n for en / zh / zh-TW; CHANGELOG + remote-security note

## Test plan
- [ ] Settings → Remote control → Phone mirror: host running, default read-only
- [ ] Click **Allow phone to send** → GlassModal with risk copy; Cancel leaves read-only
- [ ] Confirm → write enabled, orange warning banner visible, toggle shows **Read-only (safe)**
- [ ] Click **Read-only (safe)** → reverts immediately without confirm; banner gone
- [ ] Stop host still uses the same in-app confirm dialog
- [ ] Locale en/zh/zh-TW strings render for confirm + banner
- [ ] `app.log` shows `mirror: phone write access toggled` with `allow_write=true/false` (no secrets)