### PR TITLE
feat(session): copy full conversation as Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Copy conversation as Markdown** (session menu + command palette): one-click clipboard copy of the full chat; skips pure tool_step noise by default (export dialog still offers tools/thoughts options)
 - **Per-session mute** for desktop notifications (context menu Mute / Unmute; sidebar muted icon; in-app toasts still show)
 - **Desktop notification click** opens the session that fired turn-done / permission / ask_user
 - **Send queue Edit** for follow-up items (GlassModal; empty text blocked unless attachments remain)
@@ -35,6 +36,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增**
 
+- 一键复制整段对话为 Markdown（会话菜单 / 命令面板；默认跳过 tool_step 噪音）
 - 按会话静音桌面通知（菜单 Mute/Unmute；侧栏静音图标；应用内 Toast 仍显示）
 - 通知点击跳转会话；发送队列可编辑；上下文 System/Tools/History；Compact 增强
 - Worktree 会话徽章与管理；Fork 可选恢复代码；沙箱项目覆盖

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -633,6 +633,8 @@ function paletteActionIcon(id: string) {
       return <IconKeyboard size={size} />;
     case "product-tutorial":
       return <IconHelp size={size} />;
+    case "copy-conversation-md":
+      return <IconCopy size={size} />;
     case "settings-appearance":
       return <IconAppearance size={size} />;
     case "settings-account":
@@ -9747,6 +9749,20 @@ export default function App() {
       case "product-tutorial":
         setShowProductTutorial(true);
         break;
+      case "copy-conversation-md":
+        void copyConversationMarkdown(
+          session.sessionId
+            ? {
+                id: session.sessionId,
+                title: session.title || tr("session.untitled"),
+                projectId:
+                  sessions.find((s) => s.id === session.sessionId)?.projectId ??
+                  activeProject?.id ??
+                  null,
+              }
+            : undefined,
+        );
+        break;
       case "settings-general":
         navigateSettings("general");
         break;
@@ -10402,6 +10418,60 @@ export default function App() {
       exportMdTarget,
       exportMdIncludeThoughts,
       exportMdIncludeTools,
+      buildSessionMarkdown,
+      showToast,
+      tr,
+    ],
+  );
+
+  /**
+   * One-click copy of the full conversation as Markdown.
+   * Skips pure tool_step noise by default (unlike the export dialog).
+   */
+  const copyConversationMarkdown = useCallback(
+    async (sessionMeta?: {
+      id: string;
+      title: string;
+      projectId?: string | null;
+    }) => {
+      const id = sessionMeta?.id ?? session.sessionId;
+      if (!id) {
+        showToast(tr("session.copyMdFail"));
+        return;
+      }
+      try {
+        const { md } = await buildSessionMarkdown(
+          {
+            id,
+            title:
+              sessionMeta?.title ||
+              sessions.find((s) => s.id === id)?.title ||
+              session.title ||
+              tr("session.untitled"),
+            projectId:
+              sessionMeta?.projectId ??
+              sessions.find((s) => s.id === id)?.projectId ??
+              null,
+          },
+          {
+            includeThoughts: true,
+            includeToolSummary: false,
+          },
+        );
+        if (!md.trim()) {
+          showToast(tr("session.copyMdEmpty"));
+          return;
+        }
+        await navigator.clipboard.writeText(md);
+        showToast(tr("session.copyMdDone"));
+      } catch (e) {
+        showToast(`${tr("session.copyMdFail")}: ${String(e)}`);
+      }
+    },
+    [
+      session.sessionId,
+      session.title,
+      sessions,
       buildSessionMarkdown,
       showToast,
       tr,
@@ -16174,6 +16244,18 @@ export default function App() {
               },
               ...wtItems,
               // Export group — not at top of menu (after edit/rename-style actions)
+              {
+                id: "copy-md",
+                label: tr("session.copyMd"),
+                icon: <IconCopy size={16} />,
+                onClick: () => {
+                  void copyConversationMarkdown({
+                    id: s.id,
+                    title: s.title,
+                    projectId: s.projectId,
+                  });
+                },
+              },
               {
                 id: "export-md",
                 label: tr("session.exportMd"),

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1790,6 +1790,10 @@ const en = {
   "slash.tutorialDesc": "Open the optional in-app product tour",
 
   // Session export
+  "session.copyMd": "Copy conversation as Markdown",
+  "session.copyMdDone": "Conversation copied as Markdown",
+  "session.copyMdFail": "Could not copy conversation",
+  "session.copyMdEmpty": "Nothing to copy in this conversation",
   "session.exportMd": "Export chat as Markdown",
   "session.exportMdTitle": "Export Markdown",
   "session.exportMdHint":
@@ -4383,6 +4387,10 @@ const zh: Record<MessageKey, string> = {
   "slash.tutorial": "产品导览",
   "slash.tutorialDesc": "打开可选的应用内产品导览",
 
+  "session.copyMd": "复制对话为 Markdown",
+  "session.copyMdDone": "已复制对话为 Markdown",
+  "session.copyMdFail": "无法复制对话",
+  "session.copyMdEmpty": "此对话没有可复制的内容",
   "session.exportMd": "导出会话为 Markdown",
   "session.exportMdTitle": "导出 Markdown",
   "session.exportMdHint": "选择要包含的内容，然后下载 .md 文件或复制到剪贴板。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1724,6 +1724,10 @@ export const zhTW: Record<MessageKey, string> = {
   "slash.tutorial": "產品導覽",
   "slash.tutorialDesc": "開啟可選的應用內產品導覽",
 
+  "session.copyMd": "複製對話為 Markdown",
+  "session.copyMdDone": "已複製對話為 Markdown",
+  "session.copyMdFail": "無法複製對話",
+  "session.copyMdEmpty": "此對話沒有可複製的內容",
   "session.exportMd": "匯出對話為 Markdown",
   "session.exportMdTitle": "匯出 Markdown",
   "session.exportMdHint": "選擇要包含的內容，然後下載 .md 檔或複製到剪貼簿。",

--- a/src/lib/paletteActions.test.ts
+++ b/src/lib/paletteActions.test.ts
@@ -21,6 +21,7 @@ describe("defaultPaletteActions", () => {
       "reliability",
       "shortcuts-help",
       "product-tutorial",
+      "copy-conversation-md",
       "settings-general",
       "settings-appearance",
       "settings-account",

--- a/src/lib/paletteActions.ts
+++ b/src/lib/paletteActions.ts
@@ -126,6 +126,22 @@ export function defaultPaletteActions(): PaletteActionDef[] {
       group: "help",
     },
     {
+      id: "copy-conversation-md",
+      labelKey: "session.copyMd",
+      keywords: [
+        "copy",
+        "conversation",
+        "markdown",
+        "md",
+        "clipboard",
+        "export text",
+        "copy chat",
+        "copy session",
+        "copy thread",
+      ],
+      group: "session",
+    },
+    {
       id: "settings-general",
       labelKey: "settings.nav.general",
       keywords: ["settings", "general", "preferences", "prefs", "composer"],

--- a/src/lib/sessionExport.test.ts
+++ b/src/lib/sessionExport.test.ts
@@ -1,11 +1,101 @@
 import { describe, expect, it } from "vitest";
 import {
   formatToolSummaryLine,
+  messagesToMarkdown,
   sessionExportFilename,
   sessionExportJsonFilename,
   sessionToJson,
   sessionToMarkdown,
 } from "./sessionExport";
+
+describe("messagesToMarkdown", () => {
+  it("renders user and assistant sections without a document header", () => {
+    const md = messagesToMarkdown([
+      { role: "user", content: "Add reset data" },
+      {
+        role: "assistant",
+        content: "Done.",
+        thought: "Need double confirm.",
+      },
+    ]);
+    // No session document title (# Title) — only ## role headings.
+    expect(md).not.toMatch(/^# /m);
+    expect(md).toContain("## User");
+    expect(md).toContain("Add reset data");
+    expect(md).toContain("## Assistant");
+    expect(md).toContain("<summary>Thinking</summary>");
+    expect(md).toContain("Need double confirm.");
+    expect(md).toContain("Done.");
+  });
+
+  it("skips tool_step noise by default", () => {
+    const md = messagesToMarkdown([
+      {
+        role: "tool",
+        content: "tool_step|bash|completed|ran tests",
+        marker: "tool_step",
+      },
+      { role: "assistant", content: "All green." },
+    ]);
+    expect(md).not.toContain("## Tool");
+    expect(md).not.toContain("bash");
+    expect(md).toContain("All green.");
+  });
+
+  it("includes tool summaries when opted in", () => {
+    const md = messagesToMarkdown(
+      [
+        {
+          role: "tool",
+          content: "tool_step|bash|completed|ran tests",
+          marker: "tool_step",
+        },
+        { role: "assistant", content: "All green." },
+      ],
+      { includeToolSummary: true },
+    );
+    expect(md).toContain("## Tool");
+    expect(md).toContain("- bash (completed)");
+    expect(md).toContain("All green.");
+  });
+
+  it("omits thoughts when includeThoughts is false", () => {
+    const md = messagesToMarkdown(
+      [
+        {
+          role: "assistant",
+          content: "Body only.",
+          thought: "secret plan",
+        },
+      ],
+      { includeThoughts: false },
+    );
+    expect(md).not.toContain("secret plan");
+    expect(md).not.toContain("<summary>Thinking</summary>");
+    expect(md).toContain("Body only.");
+  });
+
+  it("skips empty shells and returns empty string for no content", () => {
+    expect(messagesToMarkdown([])).toBe("");
+    expect(
+      messagesToMarkdown([
+        { role: "tool", content: "" },
+        { role: "assistant", content: "   " },
+      ]),
+    ).toBe("");
+  });
+
+  it("includes createdAt when present", () => {
+    const md = messagesToMarkdown([
+      {
+        role: "user",
+        content: "hi",
+        createdAt: "2026-07-24T00:00:00.000Z",
+      },
+    ]);
+    expect(md).toContain("*2026-07-24T00:00:00.000Z*");
+  });
+});
 
 describe("sessionToMarkdown", () => {
   it("builds a title, meta block, and role sections", () => {

--- a/src/lib/sessionExport.ts
+++ b/src/lib/sessionExport.ts
@@ -74,31 +74,34 @@ function isToolish(m: ExportableMessage): boolean {
   return c.startsWith("tool_step|") || c.startsWith("tool_step");
 }
 
+export type MessagesToMarkdownOptions = {
+  /**
+   * Include assistant thinking in collapsed `<details>` (default true).
+   */
+  includeThoughts?: boolean;
+  /**
+   * Include tool_step / tool rows as short summary lines.
+   * Default **false** — skip pure tool-step noise for clipboard / paste.
+   * Full session export opts in via {@link sessionToMarkdown}.
+   */
+  includeToolSummary?: boolean;
+};
+
 /**
- * Render a session as GitHub-flavored markdown.
- * Skips empty shells; optional thinking + tool summaries.
+ * Pure message list → GitHub-flavored markdown (no title / meta header).
+ * Skips empty shells. Defaults: thoughts on, tool_step noise off.
  */
-export function sessionToMarkdown(input: SessionExportInput): string {
-  const opts = input.options ?? {};
-  const includeThoughts = opts.includeThoughts !== false;
-  const includeToolSummary = opts.includeToolSummary !== false;
+export function messagesToMarkdown(
+  messages: ExportableMessage[],
+  opts?: MessagesToMarkdownOptions,
+): string {
+  const includeThoughts = opts?.includeThoughts !== false;
+  // Opt-in: clipboard copy should not dump every tool_step by default.
+  const includeToolSummary = opts?.includeToolSummary === true;
 
   const lines: string[] = [];
-  const title = (input.title || "Untitled").trim() || "Untitled";
-  lines.push(`# ${title}`);
-  lines.push("");
 
-  const meta: string[] = [];
-  if (input.projectName) meta.push(`Project: ${input.projectName}`);
-  if (input.projectPath) meta.push(`Path: ${input.projectPath}`);
-  if (input.sessionId) meta.push(`Session: ${input.sessionId}`);
-  meta.push(`Exported: ${input.exportedAt || new Date().toISOString()}`);
-  lines.push(meta.map((m) => `- ${m}`).join("\n"));
-  lines.push("");
-  lines.push("---");
-  lines.push("");
-
-  for (const m of input.messages) {
+  for (const m of messages) {
     const body = (m.content || "").trim();
     const thought = (m.thought || "").trim();
 
@@ -136,6 +139,44 @@ export function sessionToMarkdown(input: SessionExportInput): string {
       lines.push(body);
       lines.push("");
     }
+  }
+
+  return lines.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/**
+ * Render a session as GitHub-flavored markdown.
+ * Skips empty shells; optional thinking + tool summaries.
+ * Export defaults keep tool summaries on (unlike {@link messagesToMarkdown}).
+ */
+export function sessionToMarkdown(input: SessionExportInput): string {
+  const opts = input.options ?? {};
+  const includeThoughts = opts.includeThoughts !== false;
+  // Session file export historically includes tools unless explicitly off.
+  const includeToolSummary = opts.includeToolSummary !== false;
+
+  const lines: string[] = [];
+  const title = (input.title || "Untitled").trim() || "Untitled";
+  lines.push(`# ${title}`);
+  lines.push("");
+
+  const meta: string[] = [];
+  if (input.projectName) meta.push(`Project: ${input.projectName}`);
+  if (input.projectPath) meta.push(`Path: ${input.projectPath}`);
+  if (input.sessionId) meta.push(`Session: ${input.sessionId}`);
+  meta.push(`Exported: ${input.exportedAt || new Date().toISOString()}`);
+  lines.push(meta.map((m) => `- ${m}`).join("\n"));
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  const body = messagesToMarkdown(input.messages, {
+    includeThoughts,
+    includeToolSummary,
+  });
+  if (body) {
+    lines.push(body);
+    lines.push("");
   }
 
   return lines.join("\n").replace(/\n{3,}/g, "\n\n").trim() + "\n";

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -15659,8 +15659,6 @@ div.composer__input:empty::before {
   border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
 }
 
-.rewind-confirm__hint,
-.fork-confirm__hint {
 /* Session trace export history (paths only — never file contents) */
 .trace-history-modal__desc {
   margin: 0 0 12px;
@@ -15747,7 +15745,6 @@ div.composer__input:empty::before {
   }
 }
 
-.rewind-confirm__hint {
 .ext-skill-editor {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Add pure `messagesToMarkdown(messages, opts?)` helper (reuse export MD patterns; tool_step noise off by default)
- Session context menu + command palette: **Copy conversation as Markdown**
- Clipboard write with success/fail/empty toasts; export dialog still offers tools/thoughts options
- i18n (en / zh / zh-TW) + CHANGELOG

## Test plan
- [x] `pnpm test -- src/lib/sessionExport.test.ts src/lib/paletteActions.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manually: session menu → Copy conversation as Markdown → paste MD without tool_step spam
- [ ] Command palette search “copy markdown” runs the same action on the active chat