### PR TITLE
feat(plan): keep a local history of reviewed plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Plan history archive**: when a plan is approved, abandoned, or completes, store a redacted body preview in a local ring (max 30); session menu / Resources open a read-only list + preview
 - **Per-session mute** for desktop notifications (context menu Mute / Unmute; sidebar muted icon; in-app toasts still show)
 - **Desktop notification click** opens the session that fired turn-done / permission / ask_user
 - **Send queue Edit** for follow-up items (GlassModal; empty text blocked unless attachments remain)
@@ -35,6 +36,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增**
 
+- 计划历史归档（批准/放弃/完成后本地预览，最多 30 条；会话菜单 / 资源面板只读查看）
 - 按会话静音桌面通知（菜单 Mute/Unmute；侧栏静音图标；应用内 Toast 仍显示）
 - 通知点击跳转会话；发送队列可编辑；上下文 System/Tools/History；Compact 增强
 - Worktree 会话徽章与管理；Fork 可选恢复代码；沙箱项目覆盖

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -282,6 +282,8 @@ import {
 import { AskUserModal } from "@/components/AskUserModal";
 import { DoctorModal } from "@/components/DoctorModal";
 import { TraceHistoryList } from "@/components/TraceHistoryList";
+import { PlanHistoryList } from "@/components/PlanHistoryList";
+import { MarkdownBody } from "@/components/MarkdownBody";
 import { VoiceOverlay } from "@/components/VoiceOverlay";
 import {
   filterSessionSearch,
@@ -300,6 +302,13 @@ import {
   sessionToMarkdown,
 } from "@/lib/sessionExport";
 import { recordTraceExport } from "@/lib/traceHistory";
+import { recordPlanHistory } from "@/lib/planHistory";
+import type { PlanHistoryEntry } from "@/lib/planHistory";
+import { planDisplayMarkdown } from "@/lib/planBody";
+import {
+  computePlanProgress,
+  parsePlanEntries,
+} from "@/lib/planStatus";
 import {
   findChatMatches,
   stepChatFindIndex,
@@ -524,6 +533,7 @@ import {
   IconShield,
   IconCheck,
   IconList,
+  IconPlan,
   IconActivity,
   IconFileText,
   IconSettings,
@@ -1075,6 +1085,8 @@ export default function App() {
   const [editSubmitting, setEditSubmitting] = useState(false);
   const [projects, setProjects] = useState<Project[]>([]);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const sessionsRef = useRef(sessions);
+  sessionsRef.current = sessions;
   const [activeProject, setActiveProject] = useState<Project | null>(null);
   /**
    * On-disk default cwd for unbound chats (`workspaces/general`).
@@ -1480,6 +1492,15 @@ export default function App() {
   const [setupCliSeed, setSetupCliSeed] = useState<SetupCliInfo | null>(null);
   const [showDoctor, setShowDoctor] = useState(false);
   const [showTraces, setShowTraces] = useState(false);
+  /** Local plan review archive (approved / abandoned / completed). */
+  const [showPlanHistory, setShowPlanHistory] = useState(false);
+  const [planHistoryPreview, setPlanHistoryPreview] =
+    useState<PlanHistoryEntry | null>(null);
+  /**
+   * Dedupe plan-complete history rows per session+toolCall cycle
+   * (session://plan can emit multiple “all done” updates).
+   */
+  const planCompletedRecordedRef = useRef(new Set<string>());
   /** Reliability / Observability center (busy · stalls · error deck). */
   const [showReliability, setShowReliability] = useState(false);
   /** In-session ring of recent stall events (soft/hard); no secrets. */
@@ -3743,6 +3764,54 @@ export default function App() {
               viewingSessionIdRef.current ||
               null;
 
+            const planJustCompleted = (
+              prev: PlanState,
+              next: PlanState,
+              sid: string | null,
+            ) => {
+              if (!sid) return;
+              const prevProg = computePlanProgress(
+                parsePlanEntries(prev.entries),
+              );
+              const nextProg = computePlanProgress(
+                parsePlanEntries(next.entries),
+              );
+              const wasDone =
+                prevProg.total > 0 &&
+                prevProg.completed + prevProg.cancelled >= prevProg.total &&
+                prevProg.inProgress === 0 &&
+                prevProg.pending === 0;
+              const nowDone =
+                nextProg.total > 0 &&
+                nextProg.completed + nextProg.cancelled >= nextProg.total &&
+                nextProg.inProgress === 0 &&
+                nextProg.pending === 0;
+              if (!nowDone || wasDone) return;
+              const cycleKey = `${sid}|${next.toolCallId ?? "notool"}`;
+              if (planCompletedRecordedRef.current.has(cycleKey)) return;
+              planCompletedRecordedRef.current.add(cycleKey);
+              // Bound the dedupe set.
+              if (planCompletedRecordedRef.current.size > 80) {
+                const first = planCompletedRecordedRef.current.values().next()
+                  .value;
+                if (first != null) planCompletedRecordedRef.current.delete(first);
+              }
+              const bodyMd = planDisplayMarkdown(next.body, next.entries);
+              if (!bodyMd.trim()) return;
+              const row = sessionsRef.current.find((s) => s.id === sid);
+              const sessionTitle = row?.title?.trim() || undefined;
+              try {
+                recordPlanHistory({
+                  sessionId: sid,
+                  decision: "completed",
+                  title: sessionTitle,
+                  bodyPreview: bodyMd,
+                });
+              } catch {
+                /* private mode */
+              }
+            };
+
             // Background session: keep plan cache warm without stealing the bar.
             if (
               p.sessionId &&
@@ -3758,6 +3827,7 @@ export default function App() {
                 composerMode,
               );
               planBySessionRef.current.set(p.sessionId, next);
+              planJustCompleted(prev, next, p.sessionId);
               return;
             }
 
@@ -3786,6 +3856,7 @@ export default function App() {
               }
               if (targetSid) {
                 planBySessionRef.current.set(targetSid, next);
+                planJustCompleted(prev, next, targetSid);
               }
               return next;
             });
@@ -7831,14 +7902,52 @@ export default function App() {
     setPlan(next);
   }, []);
 
+  /** Archive a plan decision to localStorage (preview only; no secrets). */
+  const archivePlanDecision = useCallback(
+    (
+      decision: "approved" | "abandoned" | "completed",
+      snapshot: Pick<PlanState, "body" | "entries" | "title">,
+      sessionId: string | null | undefined,
+    ) => {
+      const sid = (sessionId || "").trim();
+      if (!sid) return;
+      const bodyMd = planDisplayMarkdown(snapshot.body, snapshot.entries);
+      if (!bodyMd.trim() && decision !== "abandoned" && decision !== "approved") {
+        // Completing with no body/steps is not useful to archive.
+        return;
+      }
+      const row = sessionsRef.current.find((s) => s.id === sid);
+      const sessionTitle = row?.title?.trim() || undefined;
+      const planTitle =
+        snapshot.title?.trim() &&
+        snapshot.title.trim() !== trRef.current("plan.ready")
+          ? snapshot.title.trim()
+          : undefined;
+      try {
+        recordPlanHistory({
+          sessionId: sid,
+          decision,
+          title: sessionTitle || planTitle,
+          bodyPreview: bodyMd,
+        });
+      } catch {
+        /* private mode / quota */
+      }
+    },
+    [],
+  );
+
   const approvePlan = useCallback(async () => {
     try {
+      const snap = planRef.current;
+      const sid = viewingSessionIdRef.current;
       await api.sessionResolvePlan({
         decision: "approved",
         rpcId: plan.rpcId,
         // Plan chrome is per-viewed-session; the gate may sit on a demoted turn.
-        sessionId: viewingSessionIdRef.current,
+        sessionId: sid,
       });
+      archivePlanDecision("approved", snap, sid);
       writePlanForViewing({
         ...planRef.current,
         visible: false,
@@ -7850,7 +7959,7 @@ export default function App() {
     } catch (e) {
       showToast(String(e), 4500);
     }
-  }, [plan.rpcId, showToast, tr, writePlanForViewing]);
+  }, [archivePlanDecision, plan.rpcId, showToast, tr, writePlanForViewing]);
 
   const requestPlanChanges = useCallback(async () => {
     try {
@@ -7893,16 +8002,25 @@ export default function App() {
       onConfirm: async () => {
         const latest = planRef.current;
         const abandonedRpcId = latest.rpcId ?? null;
+        const sid = viewingSessionIdRef.current;
         if (abandonedRpcId != null) {
           try {
             await api.sessionResolvePlan({
               decision: "abandoned",
               rpcId: abandonedRpcId,
-              sessionId: viewingSessionIdRef.current,
+              sessionId: sid,
             });
           } catch {
             /* clear UI anyway */
           }
+        }
+        // Archive when user abandons review or dismisses an in-flight plan.
+        if (
+          latest.body.trim() ||
+          latest.entries.length > 0 ||
+          abandonedRpcId != null
+        ) {
+          archivePlanDecision("abandoned", latest, sid);
         }
         writePlanForViewing(
           closedSessionPlan(
@@ -7924,7 +8042,7 @@ export default function App() {
         }
       },
     });
-  }, [tr, writePlanForViewing]);
+  }, [archivePlanDecision, tr, writePlanForViewing]);
 
   /** Open resource pane Plan review (replaces scroll-to-card “详情”). */
   const openPlanInResource = useCallback(() => {
@@ -11194,6 +11312,8 @@ export default function App() {
         showSearch ||
         showDoctor ||
         showTraces ||
+        showPlanHistory ||
+        planHistoryPreview ||
         showShortcuts ||
         showProductTutorial ||
         showStatusModal ||
@@ -14412,6 +14532,7 @@ export default function App() {
               onApprovePlan={() => void approvePlan()}
               onRequestPlanChanges={() => void requestPlanChanges()}
               onDismissPlan={() => void dismissPlan()}
+              onOpenPlanHistory={() => setShowPlanHistory(true)}
               onAsideLayoutHint={applyAsideLayoutHint}
               onClose={() => {
                 // Manual close — do not treat as plan-owned pane on later dismiss.
@@ -15202,6 +15323,98 @@ export default function App() {
           onCopied={() => showToast(tr("session.tracesCopied"), 2000)}
           onError={(msg) => showToast(msg, 4000)}
         />
+      </GlassModal>
+
+      <GlassModal
+        open={showPlanHistory}
+        onClose={() => setShowPlanHistory(false)}
+        title={tr("plan.historyTitle")}
+        size="md"
+        closeLabel={tr("common.close")}
+        wrapBody
+        className="plan-history-modal"
+        footer={
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={() => setShowPlanHistory(false)}
+          >
+            {tr("common.close")}
+          </button>
+        }
+      >
+        <p className="plan-history-modal__desc">{tr("plan.historyDesc")}</p>
+        <PlanHistoryList
+          labels={{
+            empty: tr("plan.historyEmpty"),
+            open: tr("plan.historyOpen"),
+            decisionApproved: tr("plan.historyDecisionApproved"),
+            decisionAbandoned: tr("plan.historyDecisionAbandoned"),
+            decisionCompleted: tr("plan.historyDecisionCompleted"),
+            listAria: tr("plan.historyTitle"),
+          }}
+          onOpen={(entry) => setPlanHistoryPreview(entry)}
+        />
+      </GlassModal>
+
+      <GlassModal
+        open={!!planHistoryPreview}
+        onClose={() => setPlanHistoryPreview(null)}
+        title={tr("plan.historyPreviewTitle")}
+        size="md"
+        closeLabel={tr("common.close")}
+        wrapBody
+        className="plan-history-preview-modal"
+        footer={
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={() => setPlanHistoryPreview(null)}
+          >
+            {tr("common.close")}
+          </button>
+        }
+      >
+        {planHistoryPreview ? (
+          <div className="plan-history-preview">
+            <div className="plan-history-preview__meta">
+              <span>
+                {planHistoryPreview.decision === "approved"
+                  ? tr("plan.historyDecisionApproved")
+                  : planHistoryPreview.decision === "abandoned"
+                    ? tr("plan.historyDecisionAbandoned")
+                    : tr("plan.historyDecisionCompleted")}
+              </span>
+              {planHistoryPreview.title ? (
+                <span title={planHistoryPreview.title}>
+                  {planHistoryPreview.title}
+                </span>
+              ) : null}
+              {planHistoryPreview.at ? (
+                <span>
+                  {(() => {
+                    const d = Date.parse(planHistoryPreview.at);
+                    if (!Number.isFinite(d)) return planHistoryPreview.at;
+                    try {
+                      return new Date(d).toLocaleString();
+                    } catch {
+                      return planHistoryPreview.at;
+                    }
+                  })()}
+                </span>
+              ) : null}
+            </div>
+            {planHistoryPreview.bodyPreview.trim() ? (
+              <MarkdownBody locale={locale}>
+                {planHistoryPreview.bodyPreview}
+              </MarkdownBody>
+            ) : (
+              <div className="plan-history-preview__empty">
+                {tr("plan.historyPreviewEmpty")}
+              </div>
+            )}
+          </div>
+        ) : null}
       </GlassModal>
 
       <GlassModal
@@ -16212,6 +16425,14 @@ export default function App() {
                 icon: <IconFolder size={16} />,
                 onClick: () => {
                   setShowTraces(true);
+                },
+              },
+              {
+                id: "plan-history",
+                label: tr("plan.history"),
+                icon: <IconPlan size={16} />,
+                onClick: () => {
+                  setShowPlanHistory(true);
                 },
               },
               {

--- a/src/components/PlanHistoryList.tsx
+++ b/src/components/PlanHistoryList.tsx
@@ -1,0 +1,148 @@
+/**
+ * Local archive of reviewed plans — body previews only (redacted, capped).
+ * Used from the session menu / Plan history modal.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  PLAN_HISTORY_CHANGE_EVENT,
+  PLAN_HISTORY_STORAGE_KEY,
+  loadPlanHistory,
+  planHistoryEntryKey,
+  planHistoryLabel,
+  planHistoryListSnippet,
+  type PlanHistoryDecision,
+  type PlanHistoryEntry,
+} from "@/lib/planHistory";
+
+export type PlanHistoryListLabels = {
+  empty: string;
+  open: string;
+  decisionApproved: string;
+  decisionAbandoned: string;
+  decisionCompleted: string;
+  /** Optional list aria */
+  listAria?: string;
+};
+
+export type PlanHistoryListProps = {
+  labels: PlanHistoryListLabels;
+  onOpen?: (entry: PlanHistoryEntry) => void;
+  className?: string;
+  compact?: boolean;
+};
+
+function formatAt(iso: string): string {
+  const d = Date.parse(iso);
+  if (!Number.isFinite(d)) return iso || "";
+  try {
+    return new Date(d).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function decisionLabel(
+  decision: PlanHistoryDecision,
+  labels: PlanHistoryListLabels,
+): string {
+  if (decision === "approved") return labels.decisionApproved;
+  if (decision === "abandoned") return labels.decisionAbandoned;
+  return labels.decisionCompleted;
+}
+
+export function PlanHistoryList({
+  labels,
+  onOpen,
+  className = "",
+  compact = false,
+}: PlanHistoryListProps) {
+  const [entries, setEntries] = useState<PlanHistoryEntry[]>(() =>
+    loadPlanHistory(),
+  );
+
+  useEffect(() => {
+    const refresh = () => setEntries(loadPlanHistory());
+    refresh();
+    const onChange = () => refresh();
+    window.addEventListener(PLAN_HISTORY_CHANGE_EVENT, onChange);
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === null || e.key === PLAN_HISTORY_STORAGE_KEY) refresh();
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(PLAN_HISTORY_CHANGE_EVENT, onChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  if (entries.length === 0) {
+    return (
+      <div
+        className={"plan-history-empty" + (className ? ` ${className}` : "")}
+        role="status"
+      >
+        {labels.empty}
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      className={
+        "plan-history-list" +
+        (compact ? " plan-history-list--compact" : "") +
+        (className ? ` ${className}` : "")
+      }
+      aria-label={labels.listAria}
+    >
+      {entries.map((e) => {
+        const label = planHistoryLabel(e);
+        const snippet = planHistoryListSnippet(e);
+        const decision = decisionLabel(e.decision, labels);
+        return (
+          <li key={planHistoryEntryKey(e)} className="plan-history-row">
+            <button
+              type="button"
+              className="plan-history-row__btn"
+              onClick={() => onOpen?.(e)}
+              title={labels.open}
+            >
+              <div className="plan-history-row__text">
+                <div className="plan-history-row__title" title={label}>
+                  {label}
+                </div>
+                <div className="plan-history-row__meta">
+                  <span
+                    className={
+                      "plan-history-row__decision plan-history-row__decision--" +
+                      e.decision
+                    }
+                  >
+                    {decision}
+                  </span>
+                  {e.at ? (
+                    <span className="plan-history-row__when">
+                      {formatAt(e.at)}
+                    </span>
+                  ) : null}
+                </div>
+                {snippet ? (
+                  <div className="plan-history-row__snippet" title={snippet}>
+                    {snippet}
+                  </div>
+                ) : null}
+              </div>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -25,6 +25,7 @@ import { ImageUi } from "@/components/ImageUi";
 import {
   IconChevronDown,
   IconChevronRight,
+  IconClock,
   IconClose,
   IconCopy,
   IconEdit,
@@ -140,6 +141,8 @@ export interface ResourceViewerProps {
   onApprovePlan?: () => void;
   onRequestPlanChanges?: () => void;
   onDismissPlan?: () => void;
+  /** Open local plan review history archive (session menu / Resources). */
+  onOpenPlanHistory?: () => void;
   /**
    * Content-aware right-pane layout hint (preview kind, tree open, tabs).
    * App soft-grows aside width so chrome icons never collide with window controls.
@@ -262,6 +265,7 @@ export function ResourceViewer({
   onApprovePlan,
   onRequestPlanChanges,
   onDismissPlan,
+  onOpenPlanHistory,
   onAsideLayoutHint,
 }: ResourceViewerProps) {
   const tr = useMemo(() => createT(locale), [locale]);
@@ -2004,6 +2008,18 @@ export function ResourceViewer({
               </button>
             </Tip>
           ) : null}
+          {onOpenPlanHistory ? (
+            <Tip label={tr("plan.history")}>
+              <button
+                type="button"
+                className="chrome-btn main__pane-toggle"
+                onClick={onOpenPlanHistory}
+                aria-label={tr("plan.history")}
+              >
+                <IconClock size={16} />
+              </button>
+            </Tip>
+          ) : null}
           {workspaceAvailable ? (
             <Tip
               label={
@@ -2119,6 +2135,16 @@ export function ResourceViewer({
             <div className="rp__empty-state">
               <div className="rp__empty-title">{tr("resources.plan")}</div>
               <div className="rp__empty-desc">{tr("resources.planEmpty")}</div>
+              {onOpenPlanHistory ? (
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  style={{ marginTop: 12 }}
+                  onClick={onOpenPlanHistory}
+                >
+                  {tr("plan.history")}
+                </button>
+              ) : null}
             </div>
           ) : sideMode === "changes" && diffView ? (
             diffView.loading ? (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -727,6 +727,18 @@ const en = {
   "plan.openInResources": "Open in resources",
   "plan.expandDetails": "Show steps & details",
   "plan.collapseDetails": "Hide steps & details",
+  "plan.history": "Plan history",
+  "plan.historyTitle": "Plan history",
+  "plan.historyDesc":
+    "Local archive of plans you approved, abandoned, or that finished. Previews only — no secrets. Up to 30 recent entries.",
+  "plan.historyEmpty":
+    "No reviewed plans yet. Approve, dismiss, or finish a plan in a chat to archive it here.",
+  "plan.historyOpen": "Open preview",
+  "plan.historyPreviewTitle": "Plan preview",
+  "plan.historyPreviewEmpty": "(no plan body stored)",
+  "plan.historyDecisionApproved": "Approved",
+  "plan.historyDecisionAbandoned": "Abandoned",
+  "plan.historyDecisionCompleted": "Completed",
 
   // Sticky plan/goal bar
   "planBar.aria": "Plan and goal status",
@@ -3349,6 +3361,18 @@ const zh: Record<MessageKey, string> = {
   "plan.openInResources": "在资源中打开",
   "plan.expandDetails": "展开步骤与详情",
   "plan.collapseDetails": "收起步骤与详情",
+  "plan.history": "计划历史",
+  "plan.historyTitle": "计划历史",
+  "plan.historyDesc":
+    "本地保存你批准、放弃或已完成的计划预览（已脱敏、最多 30 条），不含密钥。",
+  "plan.historyEmpty":
+    "还没有归档的计划。在对话中批准、关闭或完成计划后会出现在这里。",
+  "plan.historyOpen": "打开预览",
+  "plan.historyPreviewTitle": "计划预览",
+  "plan.historyPreviewEmpty": "（未保存计划正文）",
+  "plan.historyDecisionApproved": "已批准",
+  "plan.historyDecisionAbandoned": "已放弃",
+  "plan.historyDecisionCompleted": "已完成",
 
   // Sticky plan/goal bar
   "planBar.aria": "计划与目标状态",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -690,6 +690,18 @@ export const zhTW: Record<MessageKey, string> = {
   "plan.openInResources": "在資源中開啟",
   "plan.expandDetails": "展開步驟與詳情",
   "plan.collapseDetails": "收起步驟與詳情",
+  "plan.history": "計劃歷史",
+  "plan.historyTitle": "計劃歷史",
+  "plan.historyDesc":
+    "本機保存你核准、放棄或已完成的計劃預覽（已脫敏、最多 30 筆），不含金鑰。",
+  "plan.historyEmpty":
+    "還沒有封存的計劃。在對話中核准、關閉或完成計劃後會出現在這裡。",
+  "plan.historyOpen": "開啟預覽",
+  "plan.historyPreviewTitle": "計劃預覽",
+  "plan.historyPreviewEmpty": "（未儲存計劃正文）",
+  "plan.historyDecisionApproved": "已核准",
+  "plan.historyDecisionAbandoned": "已放棄",
+  "plan.historyDecisionCompleted": "已完成",
 
   // Sticky plan/goal bar
   "planBar.aria": "計劃與目標狀態",

--- a/src/lib/planHistory.test.ts
+++ b/src/lib/planHistory.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+import {
+  PLAN_HISTORY_BODY_PREVIEW_MAX,
+  PLAN_HISTORY_MAX,
+  loadPlanHistory,
+  parsePlanHistory,
+  parsePlanHistoryEntry,
+  planHistoryBodyPreview,
+  planHistoryEntryKey,
+  planHistoryLabel,
+  planHistoryListSnippet,
+  pushPlanHistory,
+  recordPlanHistory,
+  savePlanHistory,
+  type PlanHistoryEntry,
+  type PlanHistoryStorage,
+} from "./planHistory";
+
+function memStorage(seed?: Record<string, string>): PlanHistoryStorage {
+  const map = new Map<string, string>(Object.entries(seed ?? {}));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+  };
+}
+
+const sample = (
+  n: number,
+  overrides?: Partial<PlanHistoryEntry>,
+): PlanHistoryEntry => ({
+  sessionId: `sess-${n}`,
+  bodyPreview: `## Plan ${n}\n\nDo the thing.`,
+  decision: "approved",
+  at: new Date(1_700_000_000_000 + n * 1000).toISOString(),
+  title: `Chat ${n}`,
+  ...overrides,
+});
+
+describe("planHistoryBodyPreview", () => {
+  it("trims, redacts secrets, and caps length", () => {
+    expect(planHistoryBodyPreview("  hello  ")).toBe("hello");
+    expect(planHistoryBodyPreview("key sk-abcdefghijklmnop tail")).toContain(
+      "[REDACTED]",
+    );
+    expect(planHistoryBodyPreview("key sk-abcdefghijklmnop tail")).not.toContain(
+      "sk-abcdefghijklmnop",
+    );
+    const long = "x".repeat(PLAN_HISTORY_BODY_PREVIEW_MAX + 50);
+    const preview = planHistoryBodyPreview(long);
+    expect(preview.length).toBeLessThanOrEqual(PLAN_HISTORY_BODY_PREVIEW_MAX);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  it("returns empty for blank input", () => {
+    expect(planHistoryBodyPreview("")).toBe("");
+    expect(planHistoryBodyPreview("   ")).toBe("");
+    expect(planHistoryBodyPreview(null)).toBe("");
+  });
+});
+
+describe("parsePlanHistoryEntry", () => {
+  it("accepts valid entries and drops unknown fields", () => {
+    expect(
+      parsePlanHistoryEntry({
+        sessionId: "  abc  ",
+        title: "  Hello  ",
+        bodyPreview: "  steps  ",
+        decision: "approved",
+        at: "2026-01-01T00:00:00.000Z",
+        secret: "should-drop",
+        apiKey: "sk-xyz",
+      }),
+    ).toEqual({
+      sessionId: "abc",
+      title: "Hello",
+      bodyPreview: "steps",
+      decision: "approved",
+      at: "2026-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("rejects missing sessionId or invalid decision", () => {
+    expect(
+      parsePlanHistoryEntry({
+        decision: "approved",
+        bodyPreview: "x",
+        at: "t",
+      }),
+    ).toBeNull();
+    expect(
+      parsePlanHistoryEntry({
+        sessionId: "s",
+        decision: "nope",
+        bodyPreview: "x",
+      }),
+    ).toBeNull();
+    expect(parsePlanHistoryEntry(null)).toBeNull();
+    expect(parsePlanHistoryEntry("nope")).toBeNull();
+  });
+
+  it("accepts abandoned and completed decisions", () => {
+    expect(
+      parsePlanHistoryEntry({
+        sessionId: "s",
+        decision: "abandoned",
+        bodyPreview: "a",
+      })?.decision,
+    ).toBe("abandoned");
+    expect(
+      parsePlanHistoryEntry({
+        sessionId: "s",
+        decision: "COMPLETED",
+        bodyPreview: "a",
+      })?.decision,
+    ).toBe("completed");
+  });
+
+  it("caps title and redacts body preview", () => {
+    const long = "t".repeat(500);
+    const e = parsePlanHistoryEntry({
+      sessionId: "s",
+      decision: "approved",
+      title: long,
+      bodyPreview: "token sk-abcdefghijklmnop here",
+    });
+    expect(e?.title?.length).toBe(200);
+    expect(e?.bodyPreview).toContain("[REDACTED]");
+  });
+});
+
+describe("parsePlanHistory", () => {
+  it("parses JSON string and array, newest-first order preserved", () => {
+    const a = sample(1);
+    const b = sample(2);
+    expect(parsePlanHistory(JSON.stringify([a, b]))).toEqual([a, b]);
+    expect(parsePlanHistory([a, b])).toEqual([a, b]);
+  });
+
+  it("returns empty on corrupt input", () => {
+    expect(parsePlanHistory("{not json")).toEqual([]);
+    expect(parsePlanHistory(42)).toEqual([]);
+    expect(parsePlanHistory(undefined)).toEqual([]);
+  });
+
+  it("caps at max", () => {
+    const many = Array.from({ length: 40 }, (_, i) => sample(i));
+    expect(parsePlanHistory(many, 5)).toHaveLength(5);
+    expect(parsePlanHistory(many).length).toBeLessThanOrEqual(PLAN_HISTORY_MAX);
+  });
+});
+
+describe("pushPlanHistory (ring buffer)", () => {
+  it("prepends newest and trims to max 30", () => {
+    const existing = Array.from({ length: 3 }, (_, i) => sample(i));
+    const next = pushPlanHistory(existing, sample(99), 3);
+    expect(next).toHaveLength(3);
+    expect(next[0]!.sessionId).toBe("sess-99");
+    expect(next.map((e) => e.sessionId)).toEqual([
+      "sess-99",
+      "sess-0",
+      "sess-1",
+    ]);
+  });
+
+  it("keeps multiple rows for same session (no path-style dedupe)", () => {
+    const a = sample(1, { decision: "approved" });
+    const b = sample(1, {
+      decision: "completed",
+      at: "2026-02-01T00:00:00.000Z",
+    });
+    const next = pushPlanHistory([a], b, 20);
+    expect(next).toHaveLength(2);
+    expect(next[0]!.decision).toBe("completed");
+    expect(next[1]!.decision).toBe("approved");
+  });
+
+  it("ignores invalid entry", () => {
+    const existing = [sample(1)];
+    expect(
+      pushPlanHistory(existing, {
+        sessionId: "",
+        bodyPreview: "",
+        decision: "approved",
+        at: "",
+      }),
+    ).toEqual(existing);
+  });
+
+  it("enforces default max of 30", () => {
+    let list: PlanHistoryEntry[] = [];
+    for (let i = 0; i < 35; i++) {
+      list = pushPlanHistory(list, sample(i));
+    }
+    expect(list).toHaveLength(PLAN_HISTORY_MAX);
+    expect(list[0]!.sessionId).toBe("sess-34");
+    expect(list[list.length - 1]!.sessionId).toBe("sess-5");
+  });
+});
+
+describe("load / save / recordPlanHistory", () => {
+  it("round-trips via storage", () => {
+    const storage = memStorage();
+    const entries = [sample(1), sample(2)];
+    savePlanHistory(entries, storage);
+    expect(loadPlanHistory(storage)).toEqual(entries);
+  });
+
+  it("recordPlanHistory prepends and persists", () => {
+    const storage = memStorage();
+    savePlanHistory([sample(1)], storage);
+    const next = recordPlanHistory(
+      {
+        sessionId: "sess-new",
+        decision: "abandoned",
+        title: "New chat",
+        body: "# Steps\n\n1. Go",
+      },
+      storage,
+    );
+    expect(next[0]).toMatchObject({
+      sessionId: "sess-new",
+      decision: "abandoned",
+      title: "New chat",
+      bodyPreview: "# Steps\n\n1. Go",
+    });
+    expect(next).toHaveLength(2);
+    expect(loadPlanHistory(storage)[0]!.decision).toBe("abandoned");
+  });
+
+  it("recordPlanHistory prefers bodyPreview over body", () => {
+    const storage = memStorage();
+    const next = recordPlanHistory(
+      {
+        sessionId: "s",
+        decision: "completed",
+        body: "ignored",
+        bodyPreview: "from entries",
+      },
+      storage,
+    );
+    expect(next[0]!.bodyPreview).toBe("from entries");
+  });
+
+  it("load returns empty when storage throws or missing", () => {
+    expect(loadPlanHistory(memStorage())).toEqual([]);
+    const bad: PlanHistoryStorage = {
+      getItem: () => {
+        throw new Error("quota");
+      },
+      setItem: () => {},
+    };
+    expect(loadPlanHistory(bad)).toEqual([]);
+  });
+
+  it("record ignores empty sessionId", () => {
+    const storage = memStorage();
+    const next = recordPlanHistory(
+      { sessionId: "  ", decision: "approved", body: "x" },
+      storage,
+    );
+    expect(next).toEqual([]);
+  });
+});
+
+describe("display helpers", () => {
+  it("planHistoryLabel prefers title then short id", () => {
+    expect(
+      planHistoryLabel({
+        sessionId: "abcdefghijklmnop",
+        bodyPreview: "",
+        decision: "approved",
+        at: "",
+        title: "My plan",
+      }),
+    ).toBe("My plan");
+    expect(
+      planHistoryLabel({
+        sessionId: "abcdefghijklmnop",
+        bodyPreview: "",
+        decision: "approved",
+        at: "",
+      }),
+    ).toBe("abcdefgh…");
+    expect(
+      planHistoryLabel({
+        sessionId: "short",
+        bodyPreview: "",
+        decision: "approved",
+        at: "",
+      }),
+    ).toBe("short");
+  });
+
+  it("planHistoryListSnippet collapses whitespace", () => {
+    expect(
+      planHistoryListSnippet({
+        sessionId: "s",
+        decision: "approved",
+        at: "",
+        bodyPreview: "line1\n\nline2",
+      }),
+    ).toBe("line1 line2");
+  });
+
+  it("planHistoryEntryKey is stable", () => {
+    const e = sample(1);
+    expect(planHistoryEntryKey(e)).toBe(
+      `${e.sessionId}|${e.decision}|${e.at}`,
+    );
+  });
+});

--- a/src/lib/planHistory.ts
+++ b/src/lib/planHistory.ts
@@ -1,0 +1,270 @@
+/**
+ * Local archive of reviewed plans (localStorage ring buffer).
+ *
+ * Records a short, redacted body preview when a plan is approved, abandoned,
+ * or completes — never full secrets or unbounded payloads.
+ * Entries: { sessionId, title?, bodyPreview, decision, at }, max 30, newest first.
+ */
+
+import { redact } from "@/lib/redact";
+
+export type PlanHistoryDecision = "approved" | "abandoned" | "completed";
+
+export type PlanHistoryEntry = {
+  sessionId: string;
+  title?: string;
+  /** Truncated, redacted plan body for read-only preview. */
+  bodyPreview: string;
+  decision: PlanHistoryDecision;
+  /** ISO-8601 timestamp. */
+  at: string;
+};
+
+export const PLAN_HISTORY_STORAGE_KEY = "grok.planHistory";
+export const PLAN_HISTORY_MAX = 30;
+/** Cap stored preview size (characters) — keeps localStorage lean. */
+export const PLAN_HISTORY_BODY_PREVIEW_MAX = 2000;
+/** Cap stored title length. */
+export const PLAN_HISTORY_TITLE_MAX = 200;
+
+/** Fired on `window` after a successful record (detail = entries). */
+export const PLAN_HISTORY_CHANGE_EVENT = "grok-plan-history-change";
+
+const DECISIONS = new Set<PlanHistoryDecision>([
+  "approved",
+  "abandoned",
+  "completed",
+]);
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface PlanHistoryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): PlanHistoryStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+/**
+ * Build a safe body preview: strip NULs, redact common secret patterns, cap length.
+ * Keeps newlines so Markdown preview remains readable.
+ */
+export function planHistoryBodyPreview(
+  text: string | null | undefined,
+  max = PLAN_HISTORY_BODY_PREVIEW_MAX,
+): string {
+  const raw = typeof text === "string" ? text : "";
+  const cleaned = raw.replace(/\u0000/g, "").trim();
+  if (!cleaned) return "";
+  let redacted: string;
+  try {
+    redacted = redact(cleaned);
+  } catch {
+    redacted = cleaned;
+  }
+  if (redacted.length <= max) return redacted;
+  return `${redacted.slice(0, Math.max(1, max - 1))}…`;
+}
+
+/** Normalize optional title (trim, cap, omit empty). */
+export function planHistoryTitle(
+  title: string | null | undefined,
+): string | undefined {
+  if (typeof title !== "string") return undefined;
+  const t = title.trim();
+  if (!t) return undefined;
+  return t.slice(0, PLAN_HISTORY_TITLE_MAX);
+}
+
+/**
+ * Normalize one raw object into a PlanHistoryEntry, or null if invalid.
+ * Only known fields; drops unknown keys that could carry secrets.
+ */
+export function parsePlanHistoryEntry(raw: unknown): PlanHistoryEntry | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const sessionId =
+    typeof o.sessionId === "string" ? o.sessionId.trim() : "";
+  if (!sessionId) return null;
+
+  const decisionRaw =
+    typeof o.decision === "string" ? o.decision.trim().toLowerCase() : "";
+  if (!DECISIONS.has(decisionRaw as PlanHistoryDecision)) return null;
+  const decision = decisionRaw as PlanHistoryDecision;
+
+  const at =
+    typeof o.at === "string" && o.at.trim()
+      ? o.at.trim()
+      : new Date(0).toISOString();
+
+  const bodyPreview = planHistoryBodyPreview(
+    typeof o.bodyPreview === "string" ? o.bodyPreview : "",
+  );
+
+  const title = planHistoryTitle(
+    typeof o.title === "string" ? o.title : undefined,
+  );
+
+  return {
+    sessionId,
+    bodyPreview,
+    decision,
+    at,
+    ...(title ? { title } : {}),
+  };
+}
+
+/**
+ * Parse stored JSON into a clean, newest-first list (capped).
+ * Tolerates corrupt / partial data.
+ */
+export function parsePlanHistory(
+  raw: unknown,
+  max = PLAN_HISTORY_MAX,
+): PlanHistoryEntry[] {
+  let list: unknown[] = [];
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (Array.isArray(parsed)) list = parsed;
+    } catch {
+      return [];
+    }
+  } else if (Array.isArray(raw)) {
+    list = raw;
+  } else {
+    return [];
+  }
+
+  const out: PlanHistoryEntry[] = [];
+  for (const item of list) {
+    const e = parsePlanHistoryEntry(item);
+    if (!e) continue;
+    out.push(e);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+/**
+ * Pure ring-buffer push: newest first, max length.
+ * Does not touch storage. Each decision is a distinct row (no path-style dedupe).
+ */
+export function pushPlanHistory(
+  existing: readonly PlanHistoryEntry[],
+  entry: PlanHistoryEntry,
+  max = PLAN_HISTORY_MAX,
+): PlanHistoryEntry[] {
+  const next = parsePlanHistoryEntry(entry);
+  if (!next) return parsePlanHistory(existing, max);
+  return parsePlanHistory([next, ...existing], max);
+}
+
+export function loadPlanHistory(
+  storage: PlanHistoryStorage = defaultStorage(),
+  max = PLAN_HISTORY_MAX,
+): PlanHistoryEntry[] {
+  try {
+    return parsePlanHistory(
+      storage.getItem(PLAN_HISTORY_STORAGE_KEY),
+      max,
+    );
+  } catch {
+    /* private mode */
+    return [];
+  }
+}
+
+export function savePlanHistory(
+  entries: readonly PlanHistoryEntry[],
+  storage: PlanHistoryStorage = defaultStorage(),
+  max = PLAN_HISTORY_MAX,
+): void {
+  const clean = parsePlanHistory(entries, max);
+  try {
+    storage.setItem(PLAN_HISTORY_STORAGE_KEY, JSON.stringify(clean));
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+/**
+ * Record a plan decision: load → push → save → notify.
+ * Returns the updated list.
+ */
+export function recordPlanHistory(
+  input: {
+    sessionId: string;
+    decision: PlanHistoryDecision;
+    title?: string | null;
+    body?: string | null;
+    /** Prefer pre-built preview when body was assembled from entries. */
+    bodyPreview?: string | null;
+    at?: string;
+  },
+  storage: PlanHistoryStorage = defaultStorage(),
+  max = PLAN_HISTORY_MAX,
+): PlanHistoryEntry[] {
+  const sessionId =
+    typeof input.sessionId === "string" ? input.sessionId.trim() : "";
+  if (!sessionId) return loadPlanHistory(storage, max);
+  if (!DECISIONS.has(input.decision)) return loadPlanHistory(storage, max);
+
+  const previewSource =
+    typeof input.bodyPreview === "string" && input.bodyPreview.trim()
+      ? input.bodyPreview
+      : (input.body ?? "");
+
+  const entry: PlanHistoryEntry = {
+    sessionId,
+    decision: input.decision,
+    bodyPreview: planHistoryBodyPreview(previewSource),
+    at: input.at || new Date().toISOString(),
+    ...(planHistoryTitle(input.title ?? undefined)
+      ? { title: planHistoryTitle(input.title ?? undefined) }
+      : {}),
+  };
+
+  const next = pushPlanHistory(loadPlanHistory(storage, max), entry, max);
+  savePlanHistory(next, storage, max);
+  if (
+    typeof window !== "undefined" &&
+    typeof window.dispatchEvent === "function"
+  ) {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(PLAN_HISTORY_CHANGE_EVENT, { detail: next }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+  return next;
+}
+
+/** Short label for list rows: title, else session id prefix. */
+export function planHistoryLabel(entry: PlanHistoryEntry): string {
+  const t = (entry.title || "").trim();
+  if (t) return t;
+  const id = entry.sessionId.trim();
+  if (id.length <= 12) return id;
+  return id.slice(0, 8) + "…";
+}
+
+/** One-line list preview of body (collapsed whitespace). */
+export function planHistoryListSnippet(
+  entry: PlanHistoryEntry,
+  maxLen = 100,
+): string {
+  const flat = (entry.bodyPreview || "").replace(/\s+/g, " ").trim();
+  if (!flat) return "";
+  if (flat.length <= maxLen) return flat;
+  return `${flat.slice(0, Math.max(1, maxLen - 1))}…`;
+}
+
+/** Stable list key (session + decision + time). */
+export function planHistoryEntryKey(entry: PlanHistoryEntry): string {
+  return `${entry.sessionId}|${entry.decision}|${entry.at}`;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -15659,8 +15659,6 @@ div.composer__input:empty::before {
   border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
 }
 
-.rewind-confirm__hint,
-.fork-confirm__hint {
 /* Session trace export history (paths only — never file contents) */
 .trace-history-modal__desc {
   margin: 0 0 12px;
@@ -15747,7 +15745,6 @@ div.composer__input:empty::before {
   }
 }
 
-.rewind-confirm__hint {
 .ext-skill-editor {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Archive plans when they are **approved**, **abandoned** (dismiss), or **complete** into a localStorage ring (max 30)
- Pure `planHistory.ts` + unit tests: redacted body preview only (no secrets), newest-first
- UI: session menu **Plan history** + Resources plan empty/chrome entry; list + read-only Markdown preview modal
- i18n (en / zh / zh-TW) and CHANGELOG

## Test plan
- [ ] Approve a plan → appears in Plan history with “Approved”
- [ ] Dismiss a plan with content → “Abandoned”
- [ ] Let plan steps all finish → “Completed” once per cycle
- [ ] Open preview modal (read-only Markdown); empty state when none
- [ ] Ring caps at 30; reopening app still shows history
- [ ] `pnpm exec vitest run src/lib/planHistory.test.ts src/i18n/messages.test.ts`