### PR TITLE
fix(css): repair unclosed rewind-confirm selectors in app.css

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -15659,8 +15659,6 @@ div.composer__input:empty::before {
   border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
 }
 
-.rewind-confirm__hint,
-.fork-confirm__hint {
 /* Session trace export history (paths only — never file contents) */
 .trace-history-modal__desc {
   margin: 0 0 12px;
@@ -15747,7 +15745,6 @@ div.composer__input:empty::before {
   }
 }
 
-.rewind-confirm__hint {
 .ext-skill-editor {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What
Main `src/styles/app.css` had two unclosed rules:

```css
.rewind-confirm__hint,
.fork-confirm__hint {
/* then unrelated .trace-history-* rules */

.rewind-confirm__hint {
.ext-skill-editor {
```

That made brace delta +2 and failed Vite/Tailwind with `Missing closing } at .rewind-confirm__hint`.

## Fix
Drop the stray openers. Real `.rewind-confirm__hint` / `.fork-confirm__hint` styles a few lines below are unchanged.

## Why
Wave-3 frontend CI was red on every PR that still carried this file shape from main.

## Test plan
- [x] brace count balanced
- [ ] `pnpm build:ui` on CI