### PR TITLE
feat(session): bulk-archive chats older than N days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Archive older than…** (sidebar Projects actions + Settings → Archived): bulk-archive unpinned chats last updated more than 7 / 30 / 90 days ago; in-app confirm with count; existing `session_set_archived` API
 - **Send queue reorder**: Up/Down on each queued follow-up before auto-flush
 - **Chat reading width** (Settings → Appearance): narrow / medium (default) / wide / full (`grok.chatWidth`)
 - **Phone mirror write guard**: confirm when enabling write; persistent warning banner; audit log (no secrets)
@@ -33,6 +34,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增**
 
+- **按时间归档**（侧栏项目区操作 + 设置 → 已归档）：批量归档超过 7 / 30 / 90 天未更新的非置顶会话；应用内确认数量；沿用现有归档 API
 - 发送队列上下排序；对话阅读宽度；镜像写权限确认与警告；整段对话复制为 Markdown
 - 可单独关闭实时语音快捷键；任务面板子代理树；计划历史归档；侧栏日期分组
 - 程序坞/托盘忙碌角标；按会话静音桌面通知

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -211,6 +211,10 @@ import {
 } from "@/lib/sandboxProfile";
 import { shouldRestoreLastSession } from "@/lib/sessionRestore";
 import {
+  ARCHIVE_AGE_DAY_OPTIONS,
+  filterSessionsOlderThanDays,
+} from "@/lib/sessionArchiveAge";
+import {
   collapsedIdsFromExpandMap,
   expandMapFromCollapsedIds,
   sameCollapsedIdSet,
@@ -820,6 +824,7 @@ type ContextMenuState =
   | { kind: "project-policy"; id: string; x: number; y: number }
   | { kind: "project-sandbox"; id: string; x: number; y: number }
   | { kind: "session"; id: string; x: number; y: number }
+  | { kind: "archive-older"; x: number; y: number }
   | null;
 
 /** In-app dialogs — window.prompt/confirm are unreliable in Tauri WebView. */
@@ -5819,6 +5824,75 @@ export default function App() {
     } catch (e) {
       setLocalError(String(e));
     }
+  };
+
+  /**
+   * Bulk-archive chats whose last update is older than `days`.
+   * Skips pinned + already-archived; confirms count via in-app dialog.
+   */
+  const confirmArchiveOlderThan = (days: number) => {
+    setCtxMenu(null);
+    const rows = filterSessionsOlderThanDays(sessions, days);
+    if (!rows.length) {
+      setToast(tr("sidebar.archiveOlderNone", { days: String(days) }));
+      window.setTimeout(() => setToast(null), 3200);
+      return;
+    }
+    const n = rows.length;
+    setAppDialog({
+      kind: "confirm",
+      title: tr("sidebar.archiveOlderTitle"),
+      message: tr("sidebar.archiveOlderConfirm", {
+        n: String(n),
+        days: String(days),
+      }),
+      confirmLabel: tr("sidebar.archiveSelected", { n: String(n) }),
+      onConfirm: async () => {
+        try {
+          if (!api.isTauri()) {
+            setLocalError(tr("error.needTauri"));
+            return;
+          }
+          const openId =
+            session.sessionId ?? viewingSessionIdRef.current ?? null;
+          const wasViewing =
+            !!openId && rows.some((s) => s.id === openId);
+          const viewingRow = wasViewing
+            ? rows.find((s) => s.id === openId) ?? null
+            : null;
+
+          const results = await Promise.allSettled(
+            rows.map((s) => api.sessionSetArchived(s.id, true)),
+          );
+          const ok = results.filter((r) => r.status === "fulfilled").length;
+          const firstFail = results.find(
+            (r): r is PromiseRejectedResult => r.status === "rejected",
+          );
+
+          await refreshSessions();
+
+          if (wasViewing && viewingRow) {
+            const proj = viewingRow.projectId
+              ? projects.find((p) => p.id === viewingRow.projectId) ?? null
+              : null;
+            if (proj) await newChat(proj, { switchToChat: true });
+            else await newChat(null, { switchToChat: true });
+          }
+
+          if (ok > 0) {
+            setToast(tr("sidebar.archivedToast", { n: String(ok) }));
+            window.setTimeout(() => setToast(null), 3200);
+          }
+          if (firstFail) {
+            setLocalError(String(firstFail.reason));
+          } else {
+            setLocalError(null);
+          }
+        } catch (e) {
+          setLocalError(String(e));
+        }
+      },
+    });
   };
 
   /**
@@ -11287,6 +11361,9 @@ export default function App() {
       "settings.archived.deselectAll",
       "settings.archived.selectedCount",
       "settings.archived.totalCount",
+      "settings.archived.archiveOlder",
+      "settings.archived.archiveOlderDesc",
+      "settings.archived.archiveOlderDays",
       "session.untitled",
       "settings.section.permissions",
       "settings.section.composer",
@@ -11937,6 +12014,9 @@ export default function App() {
               .filter((s): s is SessionRow => !!s);
             deleteSessionsConfirm(rows);
           }}
+          onArchiveOlderThan={(days) => {
+            confirmArchiveOlderThan(days);
+          }}
           projectPath={effectiveProjectPath}
           onSkillsPrefsChanged={() =>
             setSkillsReloadToken((n) => n + 1)
@@ -12115,19 +12195,38 @@ export default function App() {
                     </button>
                   </Tip>
                 ) : selectableSessionCount > 0 ? (
-                  <Tip label={tr("sidebar.select")}>
-                    <button
-                      type="button"
-                      className="tree-l1__action"
-                      aria-label={tr("sidebar.select")}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        enterSessionSelectMode();
-                      }}
-                    >
-                      <IconListCheck size={15} />
-                    </button>
-                  </Tip>
+                  <>
+                    <Tip label={tr("sidebar.select")}>
+                      <button
+                        type="button"
+                        className="tree-l1__action"
+                        aria-label={tr("sidebar.select")}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          enterSessionSelectMode();
+                        }}
+                      >
+                        <IconListCheck size={15} />
+                      </button>
+                    </Tip>
+                    <Tip label={tr("sidebar.archiveOlder")}>
+                      <button
+                        type="button"
+                        className="tree-l1__action"
+                        aria-label={tr("sidebar.archiveOlder")}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setCtxMenu({
+                            kind: "archive-older",
+                            x: e.clientX,
+                            y: e.clientY,
+                          });
+                        }}
+                      >
+                        <IconArchive size={15} />
+                      </button>
+                    </Tip>
+                  </>
                 ) : null}
                 {projects.length > 0 && !sessionSelectMode ? (
                   <Tip label={tr("sidebar.collapseAllProjects")}>
@@ -16303,7 +16402,16 @@ export default function App() {
       {/* Floating context menu (project / session) — unified ContextMenu */}
       {(() => {
         let items: ContextMenuItem[] = [];
-        if (ctxMenu?.kind === "project") {
+        if (ctxMenu?.kind === "archive-older") {
+          items = ARCHIVE_AGE_DAY_OPTIONS.map((days) => ({
+            id: `archive-older-${days}`,
+            label: tr("sidebar.archiveOlderDays", { days: String(days) }),
+            icon: <IconArchive size={16} />,
+            onClick: () => {
+              confirmArchiveOlderThan(days);
+            },
+          }));
+        } else if (ctxMenu?.kind === "project") {
           const proj = projects.find((p) => p.id === ctxMenu.id);
           if (proj) {
             items = [

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -40,6 +40,7 @@ import {
   countUnlinkedCliSessions,
   filterCliSessions,
 } from "@/lib/cliSessionsFilter";
+import { ARCHIVE_AGE_DAY_OPTIONS } from "@/lib/sessionArchiveAge";
 import {
   SHORTCUTS,
   detectShortcutPlatform,
@@ -429,6 +430,8 @@ export interface SettingsPageProps {
   onRestoreArchivedSessions?: (ids: string[]) => void;
   /** Delete one or more archived sessions after confirm (ids). */
   onDeleteArchivedSessions?: (ids: string[]) => void;
+  /** Bulk-archive active chats older than N days (confirm lives in App). */
+  onArchiveOlderThan?: (days: number) => void;
   /** Active project path for Skills/MCP inspect cwd. */
   projectPath?: string | null;
   /** After skill enable toggle — refresh slash palette in App. */
@@ -919,6 +922,7 @@ export function SettingsPage({
   archivedGroups = [],
   onRestoreArchivedSessions,
   onDeleteArchivedSessions,
+  onArchiveOlderThan,
   projectPath = null,
   onSkillsPrefsChanged,
   onOpenShortcutsHelp,
@@ -3689,6 +3693,41 @@ export function SettingsPage({
             <p className="settings-page__lead">
               {t("settings.archived.desc")}
             </p>
+            {onArchiveOlderThan ? (
+              <div
+                className="settings-card settings-archived-age"
+                id="settings-anchor-archive-older"
+              >
+                <div className="settings-row settings-row--stack">
+                  <div className="settings-row__meta">
+                    <div className="settings-row__label">
+                      {t("settings.archived.archiveOlder")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.archived.archiveOlderDesc")}
+                    </div>
+                  </div>
+                  <div
+                    className="settings-archived-age__actions"
+                    role="group"
+                    aria-label={t("settings.archived.archiveOlder")}
+                  >
+                    {ARCHIVE_AGE_DAY_OPTIONS.map((days) => (
+                      <button
+                        key={days}
+                        type="button"
+                        className="btn btn--ghost btn--sm"
+                        onClick={() => onArchiveOlderThan(days)}
+                      >
+                        {t("settings.archived.archiveOlderDays", {
+                          days: String(days),
+                        })}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ) : null}
             {archivedTotal === 0 ? (
               <div className="settings-card">
                 <div className="settings-archived-empty">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -58,6 +58,13 @@ const en = {
   "sidebar.archivedToast": "Archived {n} chats",
   "sidebar.restoredToast": "Restored {n} chats",
   "sidebar.deletedToast": "Deleted {n} chats",
+  "sidebar.archiveOlder": "Archive older than…",
+  "sidebar.archiveOlderDays": "Older than {days} days",
+  "sidebar.archiveOlderTitle": "Archive older chats",
+  "sidebar.archiveOlderConfirm":
+    "Archive {n} chats not updated in the last {days} days? Pinned chats are kept. You can restore them later from Settings → Archived.",
+  "sidebar.archiveOlderNone":
+    "No unpinned chats older than {days} days.",
   "user.menu": "Account menu",
   "user.theme": "Theme",
   "user.themeLight": "Switch to light",
@@ -853,6 +860,10 @@ const en = {
   "settings.archived.deselectAll": "Deselect all",
   "settings.archived.selectedCount": "{n} selected",
   "settings.archived.totalCount": "{n} archived",
+  "settings.archived.archiveOlder": "Archive older than…",
+  "settings.archived.archiveOlderDesc":
+    "Bulk-archive active chats whose last update is older than the threshold. Pinned chats are skipped.",
+  "settings.archived.archiveOlderDays": "{days} days",
   "settings.section.permissions": "Permissions",
   "settings.section.composer": "Composer prefs",
   "settings.section.voice": "Voice",
@@ -2754,6 +2765,12 @@ const zh: Record<MessageKey, string> = {
   "sidebar.archivedToast": "已归档 {n} 个会话",
   "sidebar.restoredToast": "已恢复 {n} 个会话",
   "sidebar.deletedToast": "已永久删除 {n} 个会话",
+  "sidebar.archiveOlder": "归档超过…天的会话",
+  "sidebar.archiveOlderDays": "超过 {days} 天",
+  "sidebar.archiveOlderTitle": "按时间归档",
+  "sidebar.archiveOlderConfirm":
+    "将归档 {n} 个超过 {days} 天未更新的会话？置顶会话会保留。之后可在「设置 → 已归档会话」中还原。",
+  "sidebar.archiveOlderNone": "没有超过 {days} 天且未置顶的会话。",
   "user.menu": "个人中心",
   "user.theme": "主题",
   "user.themeLight": "切换到浅色",
@@ -3518,6 +3535,10 @@ const zh: Record<MessageKey, string> = {
   "settings.archived.deselectAll": "取消全选",
   "settings.archived.selectedCount": "已选 {n} 项",
   "settings.archived.totalCount": "共 {n} 条",
+  "settings.archived.archiveOlder": "归档超过…天的会话",
+  "settings.archived.archiveOlderDesc":
+    "批量归档最后更新时间超过阈值的活跃会话。置顶会话会跳过。",
+  "settings.archived.archiveOlderDays": "{days} 天",
   "settings.section.permissions": "权限",
   "settings.section.composer": "对话偏好",
   "settings.section.voice": "语音",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -50,6 +50,12 @@ export const zhTW: Record<MessageKey, string> = {
   "sidebar.archivedToast": "已封存 {n} 個對話",
   "sidebar.restoredToast": "已還原 {n} 個對話",
   "sidebar.deletedToast": "已永久刪除 {n} 個對話",
+  "sidebar.archiveOlder": "封存超過…天的對話",
+  "sidebar.archiveOlderDays": "超過 {days} 天",
+  "sidebar.archiveOlderTitle": "依時間封存",
+  "sidebar.archiveOlderConfirm":
+    "將封存 {n} 個超過 {days} 天未更新的對話？已置頂對話會保留。之後可在「設定 → 已封存對話」中還原。",
+  "sidebar.archiveOlderNone": "沒有超過 {days} 天且未置頂的對話。",
   "user.menu": "個人中心",
   "user.theme": "主題",
   "user.themeLight": "切換為淺色",
@@ -814,6 +820,10 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.archived.deselectAll": "取消全選",
   "settings.archived.selectedCount": "已選 {n} 項",
   "settings.archived.totalCount": "共 {n} 條",
+  "settings.archived.archiveOlder": "封存超過…天的對話",
+  "settings.archived.archiveOlderDesc":
+    "批次封存最後更新時間超過閾值的活躍對話。已置頂對話會略過。",
+  "settings.archived.archiveOlderDays": "{days} 天",
   "settings.section.permissions": "權限",
   "settings.section.composer": "對話偏好",
   "settings.section.voice": "語音",

--- a/src/lib/sessionArchiveAge.test.ts
+++ b/src/lib/sessionArchiveAge.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  ARCHIVE_AGE_DAY_OPTIONS,
+  daysToMs,
+  filterSessionsOlderThanDays,
+  isSessionOlderThanDays,
+} from "./sessionArchiveAge";
+
+const NOW = new Date("2026-07-30T12:00:00.000Z").getTime();
+
+function isoDaysAgo(days: number): string {
+  return new Date(NOW - daysToMs(days)).toISOString();
+}
+
+describe("ARCHIVE_AGE_DAY_OPTIONS", () => {
+  it("offers 7 / 30 / 90 day thresholds", () => {
+    expect([...ARCHIVE_AGE_DAY_OPTIONS]).toEqual([7, 30, 90]);
+  });
+});
+
+describe("daysToMs", () => {
+  it("converts whole days to milliseconds", () => {
+    expect(daysToMs(1)).toBe(86_400_000);
+    expect(daysToMs(7)).toBe(7 * 86_400_000);
+  });
+});
+
+describe("isSessionOlderThanDays", () => {
+  it("is true when updatedAt is strictly older than the threshold", () => {
+    expect(isSessionOlderThanDays(isoDaysAgo(8), 7, NOW)).toBe(true);
+    expect(isSessionOlderThanDays(isoDaysAgo(7), 7, NOW)).toBe(false);
+    expect(isSessionOlderThanDays(isoDaysAgo(6), 7, NOW)).toBe(false);
+  });
+
+  it("rejects invalid, empty, or non-positive inputs", () => {
+    expect(isSessionOlderThanDays("", 7, NOW)).toBe(false);
+    expect(isSessionOlderThanDays(null, 7, NOW)).toBe(false);
+    expect(isSessionOlderThanDays("not-a-date", 7, NOW)).toBe(false);
+    expect(isSessionOlderThanDays(isoDaysAgo(30), 0, NOW)).toBe(false);
+    expect(isSessionOlderThanDays(isoDaysAgo(30), -1, NOW)).toBe(false);
+  });
+});
+
+describe("filterSessionsOlderThanDays", () => {
+  const rows = [
+    { id: "fresh", updatedAt: isoDaysAgo(1), archived: false, pinned: false },
+    { id: "old7", updatedAt: isoDaysAgo(8), archived: false, pinned: false },
+    { id: "old30", updatedAt: isoDaysAgo(31), archived: false, pinned: false },
+    { id: "old90", updatedAt: isoDaysAgo(100), archived: false, pinned: false },
+    {
+      id: "pinned-old",
+      updatedAt: isoDaysAgo(100),
+      archived: false,
+      pinned: true,
+    },
+    {
+      id: "archived-old",
+      updatedAt: isoDaysAgo(100),
+      archived: true,
+      pinned: false,
+    },
+    {
+      id: "bad-date",
+      updatedAt: "nope",
+      archived: false,
+      pinned: false,
+    },
+  ];
+
+  it("keeps only non-archived, non-pinned sessions older than N days", () => {
+    expect(filterSessionsOlderThanDays(rows, 7, NOW).map((s) => s.id)).toEqual([
+      "old7",
+      "old30",
+      "old90",
+    ]);
+    expect(filterSessionsOlderThanDays(rows, 30, NOW).map((s) => s.id)).toEqual(
+      ["old30", "old90"],
+    );
+    expect(filterSessionsOlderThanDays(rows, 90, NOW).map((s) => s.id)).toEqual(
+      ["old90"],
+    );
+  });
+
+  it("skips pinned and already-archived rows", () => {
+    const hits = filterSessionsOlderThanDays(rows, 7, NOW);
+    expect(hits.some((s) => s.id === "pinned-old")).toBe(false);
+    expect(hits.some((s) => s.id === "archived-old")).toBe(false);
+  });
+
+  it("returns empty for non-positive days or empty input", () => {
+    expect(filterSessionsOlderThanDays(rows, 0, NOW)).toEqual([]);
+    expect(filterSessionsOlderThanDays([], 7, NOW)).toEqual([]);
+  });
+
+  it("preserves input order", () => {
+    const shuffled = [rows[3], rows[1], rows[2]];
+    expect(
+      filterSessionsOlderThanDays(shuffled, 7, NOW).map((s) => s.id),
+    ).toEqual(["old90", "old7", "old30"]);
+  });
+});

--- a/src/lib/sessionArchiveAge.ts
+++ b/src/lib/sessionArchiveAge.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure helpers for bulk-archive-by-age (sidebar / Settings).
+ * Filters only — host archive is still `session_set_archived`.
+ */
+
+/** Supported thresholds in the “Archive older than…” picker. */
+export const ARCHIVE_AGE_DAY_OPTIONS = [7, 30, 90] as const;
+
+export type ArchiveAgeDays = (typeof ARCHIVE_AGE_DAY_OPTIONS)[number];
+
+export type ArchiveAgeSessionLike = {
+  id: string;
+  updatedAt: string;
+  archived?: boolean;
+  pinned?: boolean;
+};
+
+/** Milliseconds for `days` full days (UTC-safe wall-clock delta). */
+export function daysToMs(days: number): number {
+  return days * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * True when `updatedAt` is strictly older than `days` before `now`.
+ * Invalid / empty timestamps never match (safe: do not archive unknowns).
+ */
+export function isSessionOlderThanDays(
+  updatedAt: string | undefined | null,
+  days: number,
+  now: Date | number = Date.now(),
+): boolean {
+  if (!updatedAt || !Number.isFinite(days) || days <= 0) return false;
+  const t = new Date(updatedAt).getTime();
+  if (!Number.isFinite(t)) return false;
+  const nowMs = typeof now === "number" ? now : now.getTime();
+  if (!Number.isFinite(nowMs)) return false;
+  return t < nowMs - daysToMs(days);
+}
+
+/**
+ * Sessions eligible for bulk archive-by-age:
+ * - not already archived
+ * - not pinned
+ * - `updatedAt` strictly older than `days` before `now`
+ *
+ * Preserves input order.
+ */
+export function filterSessionsOlderThanDays<T extends ArchiveAgeSessionLike>(
+  sessions: readonly T[],
+  days: number,
+  now: Date | number = Date.now(),
+): T[] {
+  if (!Number.isFinite(days) || days <= 0) return [];
+  return sessions.filter(
+    (s) =>
+      !s.archived &&
+      !s.pinned &&
+      isSessionOlderThanDays(s.updatedAt, days, now),
+  );
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -1171,6 +1171,24 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     ],
     keywords: ["archive", "archived chats"],
   },
+  {
+    id: "archived.archiveOlder",
+    section: "archived",
+    anchorId: "settings-anchor-archive-older",
+    labelKey: "settings.archived.archiveOlder",
+    descKeys: ["settings.archived.archiveOlderDesc"],
+    keywords: [
+      "archive older",
+      "bulk archive",
+      "old chats",
+      "7 days",
+      "30 days",
+      "90 days",
+      "归档超过",
+      "按时间归档",
+      "封存超過",
+    ],
+  },
   // ── extensions ──
   {
     id: "ext.plugins",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3958,6 +3958,18 @@ html[data-sidebar-density="compact"] .session-row__meta {
   color: var(--text-tertiary);
 }
 
+.settings-archived-age {
+  margin: 0 0 14px;
+}
+
+.settings-archived-age__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+}
+
 .settings-archived-toolbar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Pure `filterSessionsOlderThanDays` helper (skip pinned + already archived; thresholds 7 / 30 / 90 days)
- Sidebar Projects toolbar: **Archive older than…** menu → in-app confirm with count → bulk `session_set_archived`
- Settings → Archived: same thresholds for discoverability
- i18n (en / zh / zh-TW), settings catalog search entry, unit tests, CHANGELOG

## Test plan

- [x] `vitest` for `sessionArchiveAge`, i18n keys, settings catalog
- [x] `tsc -b`
- [ ] Manual: sidebar archive icon when sessions exist → pick 7/30/90 → confirm count → chats leave sidebar (pinned kept)
- [ ] Manual: Settings → Archived age buttons open the same confirm flow
- [ ] Manual: empty match shows toast “No unpinned chats older than N days”