### PR TITLE
feat(chat): regenerate last reply with optional model pick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+- **Regenerate with model pick**: one-click still uses the current model; chevron / right-click / long-press opens a menu (Same model + catalog) and switches session model before resend when different
 - **Send queue reorder**: Up/Down on each queued follow-up before auto-flush
 - **Chat reading width** (Settings → Appearance): narrow / medium (default) / wide / full (`grok.chatWidth`)
 - **Phone mirror write guard**: confirm when enabling write; persistent warning banner; audit log (no secrets)
@@ -33,6 +34,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增**
 
+- **重新生成可选模型**：单击仍用当前模型；箭头 / 右键 / 长按打开菜单（当前模型 + 目录），选不同模型时先切换会话模型再重发
 - 发送队列上下排序；对话阅读宽度；镜像写权限确认与警告；整段对话复制为 Markdown
 - 可单独关闭实时语音快捷键；任务面板子代理树；计划历史归档；侧栏日期分组
 - 程序坞/托盘忙碌角标；按会话静音桌面通知

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10826,7 +10826,12 @@ export default function App() {
       msg: ChatMessage,
       storedDisplay: string,
       att: Attachment[],
-      opts?: { onlyLastToastKey?: "message.editOnlyLast" | "message.regenerateOnlyLast"; busyToastKey?: "message.editBusy" | "message.regenerateBusy" },
+      opts?: {
+        onlyLastToastKey?: "message.editOnlyLast" | "message.regenerateOnlyLast";
+        busyToastKey?: "message.editBusy" | "message.regenerateBusy";
+        /** When set and different from current, apply before resend. */
+        modelId?: string;
+      },
     ) => {
       if (msg.role !== "user" || msg.id !== lastUserMessageId) {
         showToast(tr(opts?.onlyLastToastKey ?? "message.editOnlyLast"));
@@ -10855,6 +10860,16 @@ export default function App() {
       let sendTargetId = session.sessionId;
       let cacheKey = sendTargetId ?? "__draft__";
       const nowIso = new Date().toISOString();
+      const nextModelId = opts?.modelId?.trim() || "";
+      const switchModel =
+        !!nextModelId &&
+        nextModelId !== modelId &&
+        isValidModelId(nextModelId, availableModels);
+
+      // Optimistic UI + prefs: live agent model is applied after connect.
+      if (switchModel) {
+        setModelId(nextModelId);
+      }
 
       setEditSubmitting(true);
 
@@ -10955,6 +10970,28 @@ export default function App() {
           }
         }
 
+        if (switchModel && api.isTauri()) {
+          try {
+            await api.sessionSetModel(nextModelId, {
+              sessionId,
+              projectId: activeProject?.id ?? null,
+            });
+          } catch (e) {
+            console.warn("session set model before resend failed", e);
+            // Soft-fail: UI model already switched; resend may still use prior agent model.
+          }
+        } else if (switchModel) {
+          void api
+            .composerPrefsSet({
+              projectId: activeProject?.id ?? null,
+              sessionId,
+              modelId: nextModelId,
+            })
+            .catch(() => {
+              /* ignore */
+            });
+        }
+
         await api.sessionSend(agentText, storedDisplay, sessionId);
         // Mirror-allowlisted (`session.autoTitle`) — safe for phone clients.
         if (shouldAutoTitle && api.hasHost()) {
@@ -10988,6 +11025,9 @@ export default function App() {
       goalMode,
       session.title,
       session.sessionId,
+      modelId,
+      availableModels,
+      activeProject?.id,
       // ensureConnected / patchSessionMessages / applySessionTitle via closure
     ],
   );
@@ -11008,9 +11048,10 @@ export default function App() {
   /**
    * Regenerate last assistant reply: resend the last user turn unchanged
    * (same content + attachments) via the edit-resend pipeline.
+   * Optional `modelId` switches session model for this turn when it differs.
    */
   const regenerateLastAssistant = useCallback(
-    async (message: ChatMessage) => {
+    async (message: ChatMessage, opts?: { modelId?: string }) => {
       if (message.role !== "assistant") return;
       if (!canEditLastUser || editSubmitting) {
         showToast(tr("message.regenerateBusy"));
@@ -11030,9 +11071,12 @@ export default function App() {
         name: a.name,
         isDir: a.isDir,
       }));
+      const pick = opts?.modelId?.trim();
       await resendLastUserTurn(userMsg, userMsg.content, att, {
         onlyLastToastKey: "message.regenerateOnlyLast",
         busyToastKey: "message.regenerateBusy",
+        modelId:
+          pick && isValidModelId(pick, availableModels) ? pick : undefined,
       });
     },
     [
@@ -11043,6 +11087,7 @@ export default function App() {
       resendLastUserTurn,
       showToast,
       tr,
+      availableModels,
     ],
   );
 
@@ -13677,9 +13722,11 @@ export default function App() {
               )
             }
             canRegenerate={canEditLastUser && !editSubmitting}
-            onRegenerateAssistant={(msg) => {
-              void regenerateLastAssistant(msg);
+            onRegenerateAssistant={(msg, opts) => {
+              void regenerateLastAssistant(msg, opts);
             }}
+            regenerateModels={availableModels}
+            regenerateModelId={modelId}
             canRewindSession={canRewindSession && !!session.sessionId}
             onRewindToUserMessage={onRewindToUserMessage}
             onForkFromUserMessage={onForkFromUserMessage}

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -55,7 +55,6 @@ import {
   IconClock,
   IconExportMd,
   IconFork,
-  IconRefresh,
   IconRename,
   IconRewind,
   IconTarget,
@@ -63,6 +62,7 @@ import {
 import { formatMessageTime, formatRelativeTime } from "@/lib/accountUi";
 import type { MessageTimeFormat } from "@/lib/messageTimeFormatPref";
 import { formatTokenCount } from "@/lib/contextUsage";
+import type { ModelOption } from "@/lib/grokCatalog";
 import { useStickToBottom } from "@/hooks/useStickToBottom";
 import { useChatMessageVirtualizer } from "@/hooks/useChatMessageVirtualizer";
 import { estimateChatRowHeight } from "@/lib/chatVirtualList";
@@ -70,6 +70,7 @@ import { StructuredJsonPanel } from "./StructuredJsonPanel";
 import {
   MessageActionButton,
   MessageCopyButton,
+  MessageRegenerateButton,
 } from "./MessageAction";
 import { ChatItem } from "./ChatItem";
 import { MarkdownChat } from "./MarkdownChat";
@@ -392,9 +393,17 @@ export interface ConversationThreadProps {
   /**
    * Regenerate last assistant reply (resend last user turn unchanged).
    * Gated like edit-last-user: idle session, last completed assistant only.
+   * Optional `modelId` switches session model before resend when it differs.
    */
   canRegenerate?: boolean;
-  onRegenerateAssistant?: (message: ChatMessage) => void;
+  onRegenerateAssistant?: (
+    message: ChatMessage,
+    opts?: { modelId?: string },
+  ) => void;
+  /** Live model catalog for regenerate-with-model menu (optional). */
+  regenerateModels?: ModelOption[];
+  /** Current composer/session model id (highlight + same-model baseline). */
+  regenerateModelId?: string;
   /** Idle session — allow rewind / fork from user bubbles. */
   canRewindSession?: boolean;
   onRewindToUserMessage?: (message: ChatMessage) => void;
@@ -469,6 +478,8 @@ export function ConversationThread({
   onRemoveEditAttachment,
   canRegenerate = false,
   onRegenerateAssistant,
+  regenerateModels = [],
+  regenerateModelId = "",
   canRewindSession = false,
   onRewindToUserMessage,
   onForkFromUserMessage,
@@ -1321,16 +1332,22 @@ export function ConversationThread({
                     </span>
                     {canRegenError ? (
                       <span className="lobe-chat-error__actions">
-                        <MessageActionButton
+                        <MessageRegenerateButton
                           label={tr("message.regenerate")}
+                          sameModelLabel={tr("message.regenerateSameModel")}
+                          pickModelLabel={tr("message.regeneratePickModel")}
                           disabled={!canRegenerate}
-                          onClick={() => {
+                          models={regenerateModels}
+                          currentModelId={regenerateModelId}
+                          iconSize={14}
+                          onRegenerate={(modelId) => {
                             if (!canRegenerate) return;
-                            onRegenerateAssistant?.(m);
+                            onRegenerateAssistant?.(
+                              m,
+                              modelId ? { modelId } : undefined,
+                            );
                           }}
-                        >
-                          <IconRefresh size={14} />
-                        </MessageActionButton>
+                        />
                       </span>
                     ) : null}
                   </div>
@@ -1564,16 +1581,21 @@ export function ConversationThread({
                         </>
                       ) : null}
                       {showRegen ? (
-                        <MessageActionButton
+                        <MessageRegenerateButton
                           label={tr("message.regenerate")}
+                          sameModelLabel={tr("message.regenerateSameModel")}
+                          pickModelLabel={tr("message.regeneratePickModel")}
                           disabled={!canRegenerate}
-                          onClick={() => {
+                          models={regenerateModels}
+                          currentModelId={regenerateModelId}
+                          onRegenerate={(modelId) => {
                             if (!canRegenerate) return;
-                            onRegenerateAssistant?.(m);
+                            onRegenerateAssistant?.(
+                              m,
+                              modelId ? { modelId } : undefined,
+                            );
                           }}
-                        >
-                          <IconRefresh size={15} />
-                        </MessageActionButton>
+                        />
                       ) : null}
                     </>
                   );

--- a/src/components/lobe-chat/MessageAction.tsx
+++ b/src/components/lobe-chat/MessageAction.tsx
@@ -1,9 +1,27 @@
 /**
  * Compact chat hover action — Codex tip + optional copy→check feedback.
+ * MessageRegenerateButton: one-click same-model regenerate + optional model menu.
  */
 
-import { useCallback, useRef, useState, type ReactNode } from "react";
-import { IconCheck, IconCopy } from "@/components/icons";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+import {
+  IconCheck,
+  IconChevronDown,
+  IconCopy,
+  IconRefresh,
+} from "@/components/icons";
+import {
+  ContextMenu,
+  type ContextMenuItem,
+} from "@/components/ContextMenu";
 import { Tip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
@@ -14,6 +32,7 @@ export function MessageActionButton({
   disabled,
   children,
   className,
+  onContextMenu,
 }: {
   label: string;
   ariaLabel?: string;
@@ -21,6 +40,7 @@ export function MessageActionButton({
   disabled?: boolean;
   children: ReactNode;
   className?: string;
+  onContextMenu?: (e: ReactMouseEvent) => void;
 }) {
   return (
     <Tip label={label} disabled={disabled || !label}>
@@ -30,6 +50,7 @@ export function MessageActionButton({
         aria-label={ariaLabel ?? label}
         disabled={disabled}
         onClick={onClick}
+        onContextMenu={onContextMenu}
       >
         {children}
       </button>
@@ -69,5 +90,186 @@ export function MessageCopyButton({
     >
       {copied ? <IconCheck size={15} /> : <IconCopy size={15} />}
     </MessageActionButton>
+  );
+}
+
+export type RegenModelOption = {
+  id: string;
+  label: string;
+};
+
+/**
+ * One-click regenerate (same model) + optional model pick via chevron / right-click.
+ * Picking the current model is treated as “same model”.
+ */
+export function MessageRegenerateButton({
+  label,
+  sameModelLabel,
+  pickModelLabel,
+  disabled,
+  models,
+  currentModelId,
+  onRegenerate,
+  iconSize = 15,
+}: {
+  /** Primary action tip (one-click regenerate). */
+  label: string;
+  /** Menu row for keeping the current model. */
+  sameModelLabel: string;
+  /** Chevron / secondary tip explaining model pick. */
+  pickModelLabel: string;
+  disabled?: boolean;
+  models: RegenModelOption[];
+  currentModelId: string;
+  /** `modelId` omitted / same as current → keep session model. */
+  onRegenerate: (modelId?: string) => void;
+  iconSize?: number;
+}) {
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const longPressTimer = useRef<number | null>(null);
+  /** When long-press opens the menu, suppress the synthetic click that follows. */
+  const suppressClickRef = useRef(false);
+
+  const clearLongPress = useCallback(() => {
+    if (longPressTimer.current != null) {
+      window.clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearLongPress(), [clearLongPress]);
+
+  const openMenuAt = useCallback(
+    (x: number, y: number) => {
+      if (disabled) return;
+      setMenu({ x, y });
+    },
+    [disabled],
+  );
+
+  const openMenuFromTrigger = useCallback(() => {
+    if (disabled) return;
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (rect) {
+      openMenuAt(rect.left, rect.bottom + 4);
+    } else {
+      openMenuAt(8, 8);
+    }
+  }, [disabled, openMenuAt]);
+
+  const runSame = useCallback(() => {
+    if (disabled) return;
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      return;
+    }
+    onRegenerate(undefined);
+  }, [disabled, onRegenerate]);
+
+  const runWithModel = useCallback(
+    (id: string | undefined) => {
+      if (disabled) return;
+      const next = id?.trim();
+      if (!next || next === currentModelId) {
+        onRegenerate(undefined);
+        return;
+      }
+      onRegenerate(next);
+    },
+    [currentModelId, disabled, onRegenerate],
+  );
+
+  const onPrimaryContextMenu = useCallback(
+    (e: ReactMouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (disabled) return;
+      openMenuAt(e.clientX, e.clientY);
+    },
+    [disabled, openMenuAt],
+  );
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent) => {
+      if (disabled || e.button !== 0) return;
+      // Touch / pen long-press opens model menu (desktop click stays one-shot).
+      if (e.pointerType === "mouse") return;
+      clearLongPress();
+      longPressTimer.current = window.setTimeout(() => {
+        longPressTimer.current = null;
+        suppressClickRef.current = true;
+        openMenuAt(e.clientX, e.clientY);
+      }, 480);
+    },
+    [clearLongPress, disabled, openMenuAt],
+  );
+
+  const onPointerUp = useCallback(() => {
+    clearLongPress();
+  }, [clearLongPress]);
+
+  const showModelMenu = models.length > 0;
+  const items: ContextMenuItem[] = [
+    {
+      id: "same",
+      label: sameModelLabel,
+      icon: <IconCheck size={14} />,
+      onClick: () => runWithModel(undefined),
+    },
+    ...models.map((m) => ({
+      id: m.id,
+      label: m.label || m.id,
+      icon:
+        m.id === currentModelId ? (
+          <IconCheck size={14} />
+        ) : (
+          <span style={{ width: 14, display: "inline-block" }} />
+        ),
+      onClick: () => runWithModel(m.id),
+    })),
+  ];
+
+  return (
+    <span
+      ref={rootRef}
+      className="lobe-chat-regen"
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      onPointerLeave={onPointerUp}
+    >
+      <MessageActionButton
+        label={label}
+        disabled={disabled}
+        onClick={runSame}
+        onContextMenu={showModelMenu ? onPrimaryContextMenu : undefined}
+      >
+        <IconRefresh size={iconSize} />
+      </MessageActionButton>
+      {showModelMenu ? (
+        <MessageActionButton
+          label={pickModelLabel}
+          ariaLabel={pickModelLabel}
+          disabled={disabled}
+          className="lobe-chat-regen__chevron"
+          onClick={openMenuFromTrigger}
+          onContextMenu={onPrimaryContextMenu}
+        >
+          <IconChevronDown size={12} />
+        </MessageActionButton>
+      ) : null}
+      {showModelMenu ? (
+        <ContextMenu
+          open={!!menu}
+          x={menu?.x ?? 0}
+          y={menu?.y ?? 0}
+          items={items}
+          onClose={() => setMenu(null)}
+          estimatedWidth={220}
+          estimatedHeight={Math.min(360, 48 + models.length * 34)}
+        />
+      ) : null}
+    </span>
   );
 }

--- a/src/components/lobe-chat/lobe-chat.css
+++ b/src/components/lobe-chat/lobe-chat.css
@@ -356,6 +356,21 @@ html[data-msg-actions="always"] .lobe-chat-item__actions {
   color: var(--success, #3ecf8e);
 }
 
+/* Regenerate: primary refresh + optional model chevron (split control). */
+.lobe-chat-regen {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  vertical-align: middle;
+}
+.lobe-chat-regen .lobe-chat-action {
+  border-radius: 8px;
+}
+.lobe-chat-regen__chevron {
+  width: 20px;
+  margin-inline-start: -2px;
+}
+
 /* ── Markdown body ── */
 .chat-md,
 .lobe-chat-md {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2260,6 +2260,8 @@ const en = {
     "Wait for the current turn to finish before regenerating",
   "message.regenerateOnlyLast":
     "Only the latest assistant reply can be regenerated",
+  "message.regenerateSameModel": "Same model",
+  "message.regeneratePickModel": "Regenerate with model…",
   "composer.editing": "Editing message",
   "composer.editingCancel": "Cancel edit",
   "chat.thinking": "Thinking…",
@@ -4884,6 +4886,8 @@ const zh: Record<MessageKey, string> = {
   "message.regenerate": "重新生成",
   "message.regenerateBusy": "请等待当前回合结束后再重新生成",
   "message.regenerateOnlyLast": "只能重新生成最后一条助手回复",
+  "message.regenerateSameModel": "使用当前模型",
+  "message.regeneratePickModel": "选择模型重新生成…",
   "composer.editing": "正在编辑消息",
   "composer.editingCancel": "取消编辑",
   "chat.thinking": "思考中…",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2180,6 +2180,8 @@ export const zhTW: Record<MessageKey, string> = {
   "message.regenerate": "重新生成",
   "message.regenerateBusy": "請等待目前回合結束後再重新生成",
   "message.regenerateOnlyLast": "只能重新生成最後一則助手回覆",
+  "message.regenerateSameModel": "使用目前模型",
+  "message.regeneratePickModel": "選擇模型重新生成…",
   "composer.editing": "正在編輯訊息",
   "composer.editingCancel": "取消編輯",
   "chat.thinking": "思考中…",


### PR DESCRIPTION
## Summary

- Keep **one-click regenerate** on the last assistant reply (same model, idle-only, existing resend path).
- Add an optional **model pick** submenu (chevron / right-click / long-press): **Same model** + catalog; choosing a different model updates UI + `sessionSetModel` after connect, then regenerates.
- i18n (en / zh / zh-TW) and CHANGELOG.

## Test plan

- [ ] Idle chat: click regenerate → same model, last user turn resends (thinking + new reply).
- [ ] Open model menu via chevron; pick **Same model** → same behavior as one-click.
- [ ] Pick a different catalog model → composer model updates and regenerated turn uses it.
- [ ] Busy / streaming: regenerate disabled; busy toast if forced.
- [ ] Only last assistant (and turn error when regenerable) shows the control.
- [ ] Locale switch shows translated menu labels.