### PR TITLE
feat(sidebar): unread dot when background chat finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ See `docs/llm-wiki/release.md`.
 - **Fork** optional worktree restore (existing)
 - **Session sticky notes** (client-only, never sent to agent)
 - **Per-session mute** desktop notifications · **session plugin dirs**
+- **Unread dot** on sidebar when a background chat finishes a turn (localStorage; independent of mute; clears on open)
 - **Bulk archive older than 7/30/90 days** · **date groups** · **project color accent**
 - **Copy conversation as Markdown**
 
@@ -40,7 +41,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 新增（按域）**
 
 - **输入与对话**：队列编辑/排序、跨会话提示历史、阅读宽度与字号、工具默认折叠、重新生成可选模型、变更芯片
-- **会话与侧栏**：复制会话（vs 分叉+worktree）、便签、静音、插件目录、按天归档、日期分组、项目颜色、复制 Markdown
+- **会话与侧栏**：复制会话（vs 分叉+worktree）、便签、静音、插件目录、后台回合完成未读圆点、按天归档、日期分组、项目颜色、复制 Markdown
 - **任务与系统**：子代理树、Stop all 可跳过确认、计划历史、忙碌角标、镜像写权限等
 
 **中文 · 修复**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -359,6 +359,14 @@ import {
   toggle as toggleSessionMute,
 } from "@/lib/sessionMute";
 import {
+  clearUnread as clearSessionUnread,
+  isTurnDoneReadyTransition,
+  loadUnreadSessionIds,
+  markUnread as markSessionUnread,
+  SESSION_UNREAD_CHANGE_EVENT,
+  shouldMarkUnreadOnTurnDone,
+} from "@/lib/sessionUnread";
+import {
   SESSION_NOTE_MAX_LENGTH,
   SESSION_NOTES_CHANGE_EVENT,
   clearNote as clearSessionNote,
@@ -943,6 +951,19 @@ export default function App() {
     const onChange = () => setMutedSessionIds(loadMutedSessionIds());
     window.addEventListener(SESSION_MUTE_CHANGE_EVENT, onChange);
     return () => window.removeEventListener(SESSION_MUTE_CHANGE_EVENT, onChange);
+  }, []);
+  /**
+   * Sessions that finished a turn while not viewed (localStorage Set).
+   * Independent of mute — muted chats still show the sidebar unread dot.
+   */
+  const [unreadSessionIds, setUnreadSessionIds] = useState<Set<string>>(
+    () => loadUnreadSessionIds(),
+  );
+  useEffect(() => {
+    const onChange = () => setUnreadSessionIds(loadUnreadSessionIds());
+    window.addEventListener(SESSION_UNREAD_CHANGE_EVENT, onChange);
+    return () =>
+      window.removeEventListener(SESSION_UNREAD_CHANGE_EVENT, onChange);
   }, []);
   /** Per-session sticky notes (localStorage map; never sent to agent). */
   const [sessionNotesMap, setSessionNotesMap] = useState<
@@ -3062,6 +3083,9 @@ export default function App() {
             if (cancelled) return;
             // Host focus slot (the process under the live cursor). Multi-session
             // busy demotions also emit session://runtime so liveMap stays honest.
+            const prevLiveState = s.sessionId
+              ? liveMapRef.current[s.sessionId]?.state
+              : undefined;
             setLiveHost(s);
             liveHostRef.current = s;
             setLiveMap((prev) =>
@@ -3071,6 +3095,19 @@ export default function App() {
                 streamingMessageId: s.streamingMessageId,
               }),
             );
+            // Background turn finished while user is elsewhere → unread dot.
+            // Mute only suppresses desktop notify; unread still applies.
+            if (
+              s.sessionId &&
+              s.state === "ready" &&
+              isTurnDoneReadyTransition(prevLiveState, s.state) &&
+              shouldMarkUnreadOnTurnDone({
+                sessionId: s.sessionId,
+                viewingSessionId: viewingSessionIdRef.current,
+              })
+            ) {
+              markSessionUnread(s.sessionId);
+            }
             if (
               s.state !== "streaming" &&
               s.state !== "awaiting_permission" &&
@@ -3177,6 +3214,7 @@ export default function App() {
         await track(
           api.listen<SessionSnapshot>("session://runtime", (s) => {
             if (cancelled || !s.sessionId) return;
+            const prevLiveState = liveMapRef.current[s.sessionId]?.state;
             setLiveMap((prev) =>
               projectHostIntoLiveMap(prev, {
                 sessionId: s.sessionId,
@@ -3184,6 +3222,17 @@ export default function App() {
                 streamingMessageId: s.streamingMessageId,
               }),
             );
+            // Background turn finished (demoted agent) → unread; mute is separate.
+            if (
+              s.state === "ready" &&
+              isTurnDoneReadyTransition(prevLiveState, s.state) &&
+              shouldMarkUnreadOnTurnDone({
+                sessionId: s.sessionId,
+                viewingSessionId: viewingSessionIdRef.current,
+              })
+            ) {
+              markSessionUnread(s.sessionId);
+            }
             // If user is viewing this demoted session, keep workbench state in sync.
             if (s.sessionId === viewingSessionIdRef.current) {
               setSession((prev) => ({
@@ -3263,6 +3312,15 @@ export default function App() {
                 streamingMessageId: null,
               }),
             );
+            // Stream done for a non-viewed session → unread (mute still allows this).
+            if (
+              shouldMarkUnreadOnTurnDone({
+                sessionId: chunk.sessionId,
+                viewingSessionId: viewingSessionIdRef.current,
+              })
+            ) {
+              markSessionUnread(chunk.sessionId);
+            }
           }
           patchSessionMessages(chunk.sessionId, (prev) => {
             const next = applyStreamChunk(prev, chunk);
@@ -4363,6 +4421,8 @@ export default function App() {
     // Point viewing id immediately so late stream chunks land in the right cache.
     openingSessionIdRef.current = s.id;
     viewingSessionIdRef.current = s.id;
+    // Opening/viewing clears the sidebar unread dot for this chat.
+    clearSessionUnread(s.id);
     // Swap plan chrome to this session (or hide if none / not yet streamed).
     setPlan(
       planBySessionRef.current.get(s.id) ??
@@ -6225,6 +6285,13 @@ export default function App() {
     toggleSessionMute(sessionId);
     setMutedSessionIds(loadMutedSessionIds());
   }, []);
+
+  // Any path that binds the workbench to a session clears its unread marker.
+  useEffect(() => {
+    if (session.sessionId) {
+      clearSessionUnread(session.sessionId);
+    }
+  }, [session.sessionId]);
 
   const openProjectMenu = (e: ReactMouseEvent, proj: Project) => {
     e.preventDefault();
@@ -12809,6 +12876,7 @@ export default function App() {
                                     const working = busyIds.has(s.id);
                                     const checked =
                                       selectedSessionIds.has(s.id);
+                                    const unread = unreadSessionIds.has(s.id);
                                     return (
                                       <div
                                         className={
@@ -12820,6 +12888,7 @@ export default function App() {
                                             ? " tree-l3--archived"
                                             : "") +
                                           (working ? " tree-l3--working" : "") +
+                                          (unread ? " tree-l3--unread" : "") +
                                           (sessionSelectMode
                                             ? " tree-l3--select-mode"
                                             : "") +
@@ -12874,6 +12943,15 @@ export default function App() {
                                           </span>
                                         ) : null}
                                         <span className="tree-l3__title">
+                                          {unread ? (
+                                            <span
+                                              className="tree-l3__unread"
+                                              title={tr("session.unreadAria")}
+                                              aria-label={tr(
+                                                "session.unreadAria",
+                                              )}
+                                            />
+                                          ) : null}
                                           {s.pinned ? (
                                             <span
                                               className="tree-l3__kind"
@@ -13097,6 +13175,7 @@ export default function App() {
                         renderItem={(s) => {
                           const working = busyIds.has(s.id);
                           const checked = selectedSessionIds.has(s.id);
+                          const unread = unreadSessionIds.has(s.id);
                           return (
                             <div
                               className={
@@ -13105,6 +13184,7 @@ export default function App() {
                                   ? " tree-l3--active"
                                   : "") +
                                 (working ? " tree-l3--working" : "") +
+                                (unread ? " tree-l3--unread" : "") +
                                 (sessionSelectMode
                                   ? " tree-l3--select-mode"
                                   : "") +
@@ -13148,6 +13228,13 @@ export default function App() {
                                 </span>
                               ) : null}
                               <span className="tree-l3__title">
+                                {unread ? (
+                                  <span
+                                    className="tree-l3__unread"
+                                    title={tr("session.unreadAria")}
+                                    aria-label={tr("session.unreadAria")}
+                                  />
+                                ) : null}
                                 {s.pinned ? (
                                   <span
                                     className="tree-l3__kind"

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -123,6 +123,7 @@ const en = {
   "session.mute": "Mute notifications",
   "session.unmute": "Unmute notifications",
   "session.muted": "Notifications muted",
+  "session.unreadAria": "Unread — reply finished in background",
   "session.note": "Session note…",
   "session.noteTitle": "Session note",
   "session.notePlaceholder":
@@ -2878,6 +2879,7 @@ const zh: Record<MessageKey, string> = {
   "session.mute": "静音桌面通知",
   "session.unmute": "取消静音通知",
   "session.muted": "已静音桌面通知",
+  "session.unreadAria": "未读 — 后台回合已完成",
   "session.note": "会话备注…",
   "session.noteTitle": "会话备注",
   "session.notePlaceholder": "此对话的私人备注（不会发送给 Agent）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -113,6 +113,7 @@ export const zhTW: Record<MessageKey, string> = {
   "session.mute": "靜音桌面通知",
   "session.unmute": "取消靜音通知",
   "session.muted": "已靜音桌面通知",
+  "session.unreadAria": "未讀 — 背景回合已完成",
   "session.note": "對話備註…",
   "session.noteTitle": "對話備註",
   "session.notePlaceholder": "此對話的私人備註（不會傳送給 Agent）",

--- a/src/lib/sessionUnread.test.ts
+++ b/src/lib/sessionUnread.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SESSION_UNREAD_CHANGE_EVENT,
+  SESSION_UNREAD_STORAGE_KEY,
+  clearUnread,
+  isTurnDoneReadyTransition,
+  isUnread,
+  load,
+  loadUnreadSessionIds,
+  markUnread,
+  parseUnreadSessionIds,
+  save,
+  saveUnreadSessionIds,
+  shouldMarkUnreadOnTurnDone,
+  type SessionUnreadStorage,
+} from "./sessionUnread";
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+): SessionUnreadStorage & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    getItem(key) {
+      return key in data ? data[key]! : null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseUnreadSessionIds", () => {
+  it("returns empty set for empty / invalid input", () => {
+    expect(parseUnreadSessionIds(null).size).toBe(0);
+    expect(parseUnreadSessionIds(undefined).size).toBe(0);
+    expect(parseUnreadSessionIds("").size).toBe(0);
+    expect(parseUnreadSessionIds("not-json").size).toBe(0);
+    expect(parseUnreadSessionIds("{}").size).toBe(0);
+    expect(parseUnreadSessionIds(42).size).toBe(0);
+  });
+
+  it("parses JSON array of non-empty strings", () => {
+    const set = parseUnreadSessionIds(JSON.stringify(["a", "  b  ", "", "a"]));
+    expect(set.has("a")).toBe(true);
+    expect(set.has("b")).toBe(true);
+    expect(set.has("")).toBe(false);
+    expect(set.size).toBe(2);
+  });
+
+  it("accepts already-parsed arrays", () => {
+    expect(parseUnreadSessionIds(["x", 1, null, "y"]).has("x")).toBe(true);
+    expect(parseUnreadSessionIds(["x", 1, null, "y"]).has("y")).toBe(true);
+    expect(parseUnreadSessionIds(["x", 1, null, "y"]).size).toBe(2);
+  });
+});
+
+describe("load / save", () => {
+  it("load returns empty set when missing", () => {
+    const storage = memoryStorage();
+    expect(loadUnreadSessionIds(storage).size).toBe(0);
+    expect(load(storage).size).toBe(0);
+  });
+
+  it("round-trips ids and sorts on write", () => {
+    const storage = memoryStorage();
+    saveUnreadSessionIds(["z", "a", "z", "  m  "], storage);
+    expect(JSON.parse(storage.data[SESSION_UNREAD_STORAGE_KEY]!)).toEqual([
+      "a",
+      "m",
+      "z",
+    ]);
+    const loaded = loadUnreadSessionIds(storage);
+    expect(loaded.has("a")).toBe(true);
+    expect(loaded.has("m")).toBe(true);
+    expect(loaded.has("z")).toBe(true);
+    expect(loaded.size).toBe(3);
+    // alias
+    save(["only"], storage);
+    expect(Array.from(load(storage))).toEqual(["only"]);
+  });
+
+  it("load survives corrupt JSON", () => {
+    const storage = memoryStorage({
+      [SESSION_UNREAD_STORAGE_KEY]: "{broken",
+    });
+    expect(loadUnreadSessionIds(storage).size).toBe(0);
+  });
+
+  it("dispatches change event after save when window is available", () => {
+    const storage = memoryStorage();
+    const handler = vi.fn();
+    const prevWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        dispatchEvent: handler,
+      },
+      configurable: true,
+      writable: true,
+    });
+    try {
+      saveUnreadSessionIds(["s1"], storage);
+      expect(handler).toHaveBeenCalledTimes(1);
+      const ev = handler.mock.calls[0]![0] as CustomEvent;
+      expect(ev.type).toBe(SESSION_UNREAD_CHANGE_EVENT);
+      expect(ev.detail).toEqual(["s1"]);
+    } finally {
+      if (prevWindow === undefined) {
+        // @ts-expect-error cleanup
+        delete globalThis.window;
+      } else {
+        Object.defineProperty(globalThis, "window", {
+          value: prevWindow,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
+});
+
+describe("isUnread / markUnread / clearUnread", () => {
+  it("isUnread is false for empty / unknown ids", () => {
+    const storage = memoryStorage();
+    expect(isUnread(null, storage)).toBe(false);
+    expect(isUnread(undefined, storage)).toBe(false);
+    expect(isUnread("  ", storage)).toBe(false);
+    expect(isUnread("missing", storage)).toBe(false);
+  });
+
+  it("markUnread adds and is idempotent", () => {
+    const storage = memoryStorage();
+    expect(markUnread("sess-1", storage)).toBe(true);
+    expect(isUnread("sess-1", storage)).toBe(true);
+    expect(markUnread("sess-1", storage)).toBe(true);
+    expect(Array.from(loadUnreadSessionIds(storage))).toEqual(["sess-1"]);
+  });
+
+  it("markUnread ignores blank session ids", () => {
+    const storage = memoryStorage();
+    expect(markUnread("", storage)).toBe(false);
+    expect(markUnread("   ", storage)).toBe(false);
+    expect(loadUnreadSessionIds(storage).size).toBe(0);
+  });
+
+  it("clearUnread removes and is idempotent", () => {
+    const storage = memoryStorage();
+    markUnread("a", storage);
+    expect(clearUnread("a", storage)).toBe(true);
+    expect(isUnread("a", storage)).toBe(false);
+    expect(clearUnread("a", storage)).toBe(true);
+    expect(loadUnreadSessionIds(storage).size).toBe(0);
+  });
+
+  it("trims session ids on unread check", () => {
+    const storage = memoryStorage();
+    saveUnreadSessionIds(["sess-x"], storage);
+    expect(isUnread("  sess-x  ", storage)).toBe(true);
+  });
+});
+
+describe("shouldMarkUnreadOnTurnDone", () => {
+  it("marks only when finished session is not the viewed one", () => {
+    expect(
+      shouldMarkUnreadOnTurnDone({
+        sessionId: "bg",
+        viewingSessionId: "fg",
+      }),
+    ).toBe(true);
+    expect(
+      shouldMarkUnreadOnTurnDone({
+        sessionId: "fg",
+        viewingSessionId: "fg",
+      }),
+    ).toBe(false);
+    expect(
+      shouldMarkUnreadOnTurnDone({
+        sessionId: "bg",
+        viewingSessionId: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldMarkUnreadOnTurnDone({
+        sessionId: null,
+        viewingSessionId: "fg",
+      }),
+    ).toBe(false);
+  });
+
+  it("trims ids before compare", () => {
+    expect(
+      shouldMarkUnreadOnTurnDone({
+        sessionId: "  same  ",
+        viewingSessionId: "same",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isTurnDoneReadyTransition", () => {
+  it("requires ready after streaming or awaiting_permission", () => {
+    expect(isTurnDoneReadyTransition("streaming", "ready")).toBe(true);
+    expect(isTurnDoneReadyTransition("awaiting_permission", "ready")).toBe(
+      true,
+    );
+    expect(isTurnDoneReadyTransition("connecting", "ready")).toBe(false);
+    expect(isTurnDoneReadyTransition("idle", "ready")).toBe(false);
+    expect(isTurnDoneReadyTransition("ready", "ready")).toBe(false);
+    expect(isTurnDoneReadyTransition("streaming", "idle")).toBe(false);
+    expect(isTurnDoneReadyTransition(null, "ready")).toBe(false);
+  });
+});

--- a/src/lib/sessionUnread.ts
+++ b/src/lib/sessionUnread.ts
@@ -1,0 +1,173 @@
+/**
+ * Per-session unread indicator for background turns.
+ * localStorage-only Set of session ids that finished a turn while not viewed.
+ *
+ * Independent of desktop-notification mute (`sessionMute`): muted sessions still
+ * get an unread dot when a background turn completes.
+ */
+
+export const SESSION_UNREAD_STORAGE_KEY = "grok.sessionUnread";
+
+/** Fired on `window` after a successful save (detail = string[] of unread ids). */
+export const SESSION_UNREAD_CHANGE_EVENT = "grok-session-unread-change";
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface SessionUnreadStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): SessionUnreadStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+function normalizeId(sessionId: string | null | undefined): string | null {
+  if (typeof sessionId !== "string") return null;
+  const id = sessionId.trim();
+  return id ? id : null;
+}
+
+/**
+ * Parse stored JSON array of session ids into a Set.
+ * Invalid / empty → empty Set.
+ */
+export function parseUnreadSessionIds(raw: unknown): Set<string> {
+  if (raw == null || raw === "") return new Set();
+  let value: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      return new Set();
+    }
+  }
+  if (!Array.isArray(value)) return new Set();
+  const out = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const id = item.trim();
+    if (id) out.add(id);
+  }
+  return out;
+}
+
+/** Load unread session id Set from storage. */
+export function loadUnreadSessionIds(
+  storage: SessionUnreadStorage = defaultStorage(),
+): Set<string> {
+  try {
+    return parseUnreadSessionIds(storage.getItem(SESSION_UNREAD_STORAGE_KEY));
+  } catch {
+    /* private mode */
+    return new Set();
+  }
+}
+
+/** Persist unread session ids (sorted for stable JSON). */
+export function saveUnreadSessionIds(
+  ids: Iterable<string>,
+  storage: SessionUnreadStorage = defaultStorage(),
+): void {
+  const unique = new Set<string>();
+  for (const item of ids) {
+    const id = normalizeId(item);
+    if (id) unique.add(id);
+  }
+  const list = Array.from(unique).sort();
+  try {
+    storage.setItem(SESSION_UNREAD_STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    /* private mode / quota */
+    return;
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.dispatchEvent === "function"
+  ) {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(SESSION_UNREAD_CHANGE_EVENT, { detail: list }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Whether `sessionId` is currently marked unread. */
+export function isUnread(
+  sessionId: string | null | undefined,
+  storage: SessionUnreadStorage = defaultStorage(),
+): boolean {
+  const id = normalizeId(sessionId);
+  if (!id) return false;
+  return loadUnreadSessionIds(storage).has(id);
+}
+
+/**
+ * Mark a session unread. Returns `true` when the id is now in the set.
+ * Empty / missing id → `false`.
+ */
+export function markUnread(
+  sessionId: string | null | undefined,
+  storage: SessionUnreadStorage = defaultStorage(),
+): boolean {
+  const id = normalizeId(sessionId);
+  if (!id) return false;
+  const ids = loadUnreadSessionIds(storage);
+  if (!ids.has(id)) {
+    ids.add(id);
+    saveUnreadSessionIds(ids, storage);
+  }
+  return true;
+}
+
+/**
+ * Clear unread for a session (e.g. when the user opens/views it).
+ * Returns `true` when the id is not in the set afterward.
+ */
+export function clearUnread(
+  sessionId: string | null | undefined,
+  storage: SessionUnreadStorage = defaultStorage(),
+): boolean {
+  const id = normalizeId(sessionId);
+  if (!id) return true;
+  const ids = loadUnreadSessionIds(storage);
+  if (!ids.has(id)) return true;
+  ids.delete(id);
+  saveUnreadSessionIds(ids, storage);
+  return true;
+}
+
+/**
+ * Whether a completed turn should mark the session unread.
+ * Only background sessions (not currently viewed). Mute is intentionally ignored.
+ */
+export function shouldMarkUnreadOnTurnDone(opts: {
+  sessionId: string | null | undefined;
+  viewingSessionId: string | null | undefined;
+}): boolean {
+  const finished = normalizeId(opts.sessionId);
+  if (!finished) return false;
+  const viewing = normalizeId(opts.viewingSessionId);
+  return finished !== viewing;
+}
+
+/**
+ * True when Host/UI state moves from an in-progress turn into `ready`.
+ * Used to avoid marking unread on cold reconnect / idle→ready shells.
+ */
+export function isTurnDoneReadyTransition(
+  previousState: string | null | undefined,
+  nextState: string | null | undefined,
+): boolean {
+  if (nextState !== "ready") return false;
+  return (
+    previousState === "streaming" || previousState === "awaiting_permission"
+  );
+}
+
+/** Aliases matching DoD naming. */
+export const load = loadUnreadSessionIds;
+export const save = saveUnreadSessionIds;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -904,6 +904,23 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   opacity: 0.9;
 }
 
+/* Unread dot: background chat finished a turn while not viewed. */
+.tree-l3__unread {
+  width: 7px;
+  height: 7px;
+  min-width: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--accent, #6b9fff);
+  box-shadow: 0 0 0 1px
+    color-mix(in srgb, var(--accent, #6b9fff) 28%, transparent);
+}
+
+.tree-l3--unread .tree-l3__name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
 /* Compact worktree-bound session badge (sidebar). */
 .tree-l3__wt {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Mark a session **unread** in `localStorage` when it finishes a turn (`stream done` / `state → ready` after streaming) while the user is viewing another chat
- Opening/viewing a session clears its unread marker
- Sidebar row shows an accent **unread dot** + stronger title weight (aria via i18n)
- Independent of per-session mute (mute only suppresses desktop notify)

## Implementation
- Pure module: `src/lib/sessionUnread.ts` + unit tests
- Wired in `session://state`, `session://runtime`, and stream `done` handlers
- Clears on `openSession` and when `session.sessionId` binds

## Test plan
- [x] `pnpm exec vitest run src/lib/sessionUnread.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: start a turn in chat A, switch to B, wait for A to finish → unread dot on A; open A → dot clears
- [ ] Manual: mute A, background finish → still shows unread (no desktop notify)