### PR TITLE
feat(sidebar): j/k to move between chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ See `docs/llm-wiki/release.md`.
 - **Per-session mute** desktop notifications · **session plugin dirs**
 - **Bulk archive older than 7/30/90 days** · **date groups** · **project color accent**
 - **Copy conversation as Markdown**
+- **j / k** next/previous chat when focus is in the sidebar session list (Enter opens the focused row; never steals keys from inputs)
 
 #### Tasks / system
 - **Tasks tree** (nest under spawn_subagent) · **Stop all skip-confirm** option
@@ -40,7 +41,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 新增（按域）**
 
 - **输入与对话**：队列编辑/排序、跨会话提示历史、阅读宽度与字号、工具默认折叠、重新生成可选模型、变更芯片
-- **会话与侧栏**：复制会话（vs 分叉+worktree）、便签、静音、插件目录、按天归档、日期分组、项目颜色、复制 Markdown
+- **会话与侧栏**：复制会话（vs 分叉+worktree）、便签、静音、插件目录、按天归档、日期分组、项目颜色、复制 Markdown、侧栏 j/k 切换会话
 - **任务与系统**：子代理树、Stop all 可跳过确认、计划历史、忙碌角标、镜像写权限等
 
 **中文 · 修复**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -333,6 +333,7 @@ import {
   matchGlobalShortcut,
   shortcutsForPlatform,
 } from "@/lib/shortcuts";
+import { nextSessionId } from "@/lib/sidebarSessionNav";
 import {
   isShortcutRecordingActive,
   loadShortcutRemaps,
@@ -1418,7 +1419,13 @@ export default function App() {
     cancelVoice: () => {},
     startLiveVoice: () => {},
     stopGeneration: () => {},
+    /** Open a sidebar session by id (j/k nav + tray). */
+    openSessionById: (_id: string) => {},
   });
+  /** Ordered visible session ids for sidebar j/k (visual tree order). */
+  const sidebarNavIdsRef = useRef<string[]>([]);
+  /** Active / viewing session id for j/k relative moves. */
+  const sidebarNavCurrentIdRef = useRef<string | null>(null);
   /** Live Esc→stop gate (overlays / menus / busy) for the capture-phase handler. */
   const escapeStopLiveRef = useRef({
     streamingOrBusy: false,
@@ -1509,6 +1516,36 @@ export default function App() {
         tag === "input" ||
         tag === "textarea" ||
         !!target?.isContentEditable;
+      // Sidebar j/k: next/prev chat when focus is inside the open sidebar list.
+      // Never steals from inputs/textareas/contenteditable or when modifiers held.
+      if (
+        !typing &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.shiftKey
+      ) {
+        const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+        if (key === "j" || key === "k") {
+          const sidebar = querySidebarEl();
+          if (sidebar && target && sidebar.contains(target)) {
+            const dir = key === "j" ? "next" : "prev";
+            const nextId = nextSessionId(
+              sidebarNavIdsRef.current,
+              sidebarNavCurrentIdRef.current,
+              dir,
+            );
+            if (nextId) {
+              e.preventDefault();
+              e.stopPropagation();
+              if (nextId !== sidebarNavCurrentIdRef.current) {
+                shortcutHandlersRef.current.openSessionById(nextId);
+              }
+            }
+            return;
+          }
+        }
+      }
       // Catalog mod chords — defaults + user remaps (keep Esc / Ctrl+Space special-cased above).
       const matched = matchGlobalShortcut(
         {
@@ -4983,6 +5020,40 @@ export default function App() {
       (!s.projectId || !projects.some((p) => p.id === s.projectId)) &&
       !s.archived,
   );
+
+  /**
+   * Visual order of sessions in the open sidebar (expanded projects + orphans).
+   * Used by j/k navigation via {@link nextSessionId}.
+   */
+  const sidebarNavSessionIds = useMemo(() => {
+    const ids: string[] = [];
+    const now = new Date();
+    const projectIdSet = new Set(projects.map((p) => p.id));
+    if (projectsOpen) {
+      for (const proj of projects) {
+        if (expandedProjects[proj.id] === false) continue;
+        const projSessions = sessions.filter(
+          (s) => s.projectId === proj.id && !s.archived,
+        );
+        for (const group of groupSessionsByDate(projSessions, now)) {
+          for (const s of group.sessions) ids.push(s.id);
+        }
+      }
+    }
+    if (historyOpen) {
+      const orphans = sessions.filter(
+        (s) =>
+          (!s.projectId || !projectIdSet.has(s.projectId)) && !s.archived,
+      );
+      for (const group of groupSessionsByDate(orphans, now)) {
+        for (const s of group.sessions) ids.push(s.id);
+      }
+    }
+    return ids;
+  }, [projectsOpen, projects, expandedProjects, sessions, historyOpen]);
+  sidebarNavIdsRef.current = sidebarNavSessionIds;
+  sidebarNavCurrentIdRef.current =
+    session.sessionId ?? viewingSessionIdRef.current ?? null;
 
   /** Active (non-archived) session ids visible in the sidebar tree. */
   const selectableSessionIds = useMemo(() => {
@@ -10375,6 +10446,34 @@ export default function App() {
     openSettings: (_section?: SettingsSectionId) => {},
     openDoctor: () => {},
   });
+  const openSessionByIdHandler = (id: string) => {
+    void (async () => {
+      let row = sessions.find((s) => s.id === id) ?? null;
+      if (!row) {
+        try {
+          const list = await api.sessionsList();
+          const hit = list.find((s) => s.id === id);
+          if (hit) {
+            row = mapSessionListRow(hit);
+            setSessions(list.map((s) => mapSessionListRow(s)));
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+      if (!row) return;
+      const proj = projects.find((p) => p.id === row!.projectId) ?? null;
+      await openSession(row, proj);
+      // Keep keyboard focus on the active sidebar row so j/k can continue.
+      requestAnimationFrame(() => {
+        const sidebar = querySidebarEl();
+        const active = sidebar?.querySelector(
+          ".tree-l3--active",
+        ) as HTMLElement | null;
+        active?.focus?.({ preventScroll: true });
+      });
+    })();
+  };
   shortcutHandlersRef.current = {
     newChat: () => {
       void newChat();
@@ -10423,44 +10522,13 @@ export default function App() {
     stopGeneration: () => {
       void stop();
     },
+    openSessionById: openSessionByIdHandler,
   };
   trayHandlersRef.current = {
     newChat: () => {
       void newChat();
     },
-    openSessionById: (id: string) => {
-      void (async () => {
-        let row = sessions.find((s) => s.id === id) ?? null;
-        if (!row) {
-          try {
-            const list = await api.sessionsList();
-            const hit = list.find((s) => s.id === id);
-            if (hit) {
-              row = normalizeSessionRow(hit);
-              setSessions(
-                list.map((s) => normalizeSessionRow(s)),
-              );
-              row = mapSessionListRow(hit);
-              row = {
-                id: hit.id,
-                title: hit.title,
-                projectId: hit.projectId,
-                updatedAt: hit.updatedAt,
-                archived: !!hit.archived,
-                scheduled: !!hit.scheduled,
-              };
-              setSessions(list.map((s) => mapSessionListRow(s)));
-            }
-          } catch {
-            /* ignore */
-          }
-        }
-        if (!row) return;
-        const proj =
-          projects.find((p) => p.id === row!.projectId) ?? null;
-        await openSession(row, proj);
-      })();
-    },
+    openSessionById: openSessionByIdHandler,
     openSettings: (section?: SettingsSectionId) => {
       navigateSettings(section);
     },

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1831,6 +1831,8 @@ const en = {
   "shortcuts.copyLastReply": "Copy last assistant reply",
   "shortcuts.settings": "Settings",
   "shortcuts.toggleSidebar": "Toggle sidebar",
+  "shortcuts.sidebarSessionNav":
+    "Next / previous chat in sidebar (focus in list)",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "Start Live Voice",
   "shortcuts.off": "Off",
@@ -4528,6 +4530,7 @@ const zh: Record<MessageKey, string> = {
   "shortcuts.copyLastReply": "复制上一条助手回复",
   "shortcuts.settings": "设置",
   "shortcuts.toggleSidebar": "切换侧栏",
+  "shortcuts.sidebarSessionNav": "侧栏上下切换会话（焦点在列表内）",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "开始实时语音",
   "shortcuts.off": "关闭",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1763,6 +1763,7 @@ export const zhTW: Record<MessageKey, string> = {
   "shortcuts.copyLastReply": "複製上一條助手回覆",
   "shortcuts.settings": "設定",
   "shortcuts.toggleSidebar": "切換側欄",
+  "shortcuts.sidebarSessionNav": "側欄上下切換對話（焦點在列表內）",
   "shortcuts.doctor": "Doctor",
   "shortcuts.liveVoice": "開始即時語音",
   "shortcuts.off": "關閉",

--- a/src/lib/shortcutRemap.ts
+++ b/src/lib/shortcutRemap.ts
@@ -39,6 +39,8 @@ export const DEFAULT_SHORTCUT_CHORDS: Record<ShortcutId, ChordString> = {
   stop: "escape",
   copyLastReply: "mod+shift+c",
   toggleSidebar: "mod+b",
+  // Display-only (j/k pair); App handles when focus is in the sidebar list.
+  sidebarSessionNav: "j",
   settings: "mod+,",
   help: "mod+/",
   doctor: "mod+shift+d",

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -34,6 +34,7 @@ const tStub = (key: string) => {
     "shortcuts.stop": "Stop",
     "shortcuts.copyLastReply": "Copy last reply",
     "shortcuts.toggleSidebar": "Toggle sidebar",
+    "shortcuts.sidebarSessionNav": "Next / previous chat in sidebar",
     "shortcuts.settings": "Settings",
     "shortcuts.help": "Keyboard shortcuts",
     "shortcuts.doctor": "Doctor",
@@ -70,6 +71,19 @@ describe("shortcuts catalog", () => {
     expect(side).toBeDefined();
     expect(side!.labelKey).toBe("shortcuts.toggleSidebar");
     expect(side!.group).toBe("navigation");
+  });
+
+  it("lists sidebar j/k session navigation (display-only)", () => {
+    const row = SHORTCUTS.find((s) => s.id === "sidebarSessionNav");
+    expect(row).toBeDefined();
+    expect(row!.labelKey).toBe("shortcuts.sidebarSessionNav");
+    expect(row!.group).toBe("navigation");
+    expect(row!.mac.toLowerCase()).toMatch(/j/);
+    expect(row!.mac.toLowerCase()).toMatch(/k/);
+    expect(row!.win.toLowerCase()).toMatch(/j/);
+    expect(
+      (GLOBAL_MOD_SHORTCUT_IDS as readonly string[]).includes("sidebarSessionNav"),
+    ).toBe(false);
   });
 
   it("lists default send as plain Enter", () => {
@@ -236,8 +250,13 @@ describe("matchGlobalShortcut", () => {
     ).toBeNull();
   });
 
-  it("does not claim send / stop / dictation (special-cased elsewhere)", () => {
-    const special = new Set(["send", "stop", "dictation"]);
+  it("does not claim send / stop / dictation / sidebar j/k (special-cased elsewhere)", () => {
+    const special = new Set([
+      "send",
+      "stop",
+      "dictation",
+      "sidebarSessionNav",
+    ]);
     for (const id of SHORTCUT_IDS) {
       if (special.has(id)) {
         expect(

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -29,6 +29,7 @@ export type ShortcutId =
   | "stop"
   | "copyLastReply"
   | "toggleSidebar"
+  | "sidebarSessionNav"
   | "settings"
   | "help"
   | "doctor"
@@ -48,8 +49,8 @@ export type ShortcutRow = {
 
 /**
  * Stable catalog id order — same as SHORTCUTS.
- * Includes display-only rows (send, stop, dictation) that are not matched by
- * {@link matchGlobalShortcut}.
+ * Includes display-only rows (send, stop, dictation, sidebarSessionNav) that
+ * are not matched by {@link matchGlobalShortcut}.
  */
 export const SHORTCUT_IDS: readonly ShortcutId[] = [
   "search",
@@ -59,6 +60,7 @@ export const SHORTCUT_IDS: readonly ShortcutId[] = [
   "stop",
   "copyLastReply",
   "toggleSidebar",
+  "sidebarSessionNav",
   "settings",
   "help",
   "doctor",
@@ -124,6 +126,15 @@ export const SHORTCUTS: ShortcutRow[] = [
     win: "Ctrl B",
   },
   {
+    // Sidebar-local j/k (not global mod). App handles when focus is in the
+    // session list / sidebar; never steals from inputs. Display-only here.
+    id: "sidebarSessionNav",
+    labelKey: "shortcuts.sidebarSessionNav",
+    group: "navigation",
+    mac: "J / K",
+    win: "J / K",
+  },
+  {
     id: "settings",
     labelKey: "shortcuts.settings",
     group: "navigation",
@@ -165,7 +176,8 @@ export const SHORTCUTS: ShortcutRow[] = [
  * Catalog ids handled by {@link matchGlobalShortcut} (mod-based App capture handler).
  * Not included: `send` (composer-local), `stop` (Esc special-cased in App for order
  * vs voice cancel / overlays), `dictation` (Ctrl+Space via `isVoiceToggleKey` —
- * must not use meta, and runs before the mod branch).
+ * must not use meta, and runs before the mod branch), `sidebarSessionNav` (plain
+ * j/k when focus is in the sidebar session list).
  */
 export const GLOBAL_MOD_SHORTCUT_IDS = [
   "search",

--- a/src/lib/sidebarSessionNav.test.ts
+++ b/src/lib/sidebarSessionNav.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { nextSessionId } from "./sidebarSessionNav";
+
+const LIST = ["a", "b", "c"] as const;
+
+describe("nextSessionId", () => {
+  it("returns null for an empty list", () => {
+    expect(nextSessionId([], "a", "next")).toBeNull();
+    expect(nextSessionId([], null, "prev")).toBeNull();
+  });
+
+  it("moves next / prev within the list", () => {
+    expect(nextSessionId(LIST, "a", "next")).toBe("b");
+    expect(nextSessionId(LIST, "b", "next")).toBe("c");
+    expect(nextSessionId(LIST, "c", "prev")).toBe("b");
+    expect(nextSessionId(LIST, "b", "prev")).toBe("a");
+  });
+
+  it("clamps at the ends", () => {
+    expect(nextSessionId(LIST, "c", "next")).toBe("c");
+    expect(nextSessionId(LIST, "a", "prev")).toBe("a");
+  });
+
+  it("picks first on next / last on prev when current is missing", () => {
+    expect(nextSessionId(LIST, null, "next")).toBe("a");
+    expect(nextSessionId(LIST, undefined, "next")).toBe("a");
+    expect(nextSessionId(LIST, "", "next")).toBe("a");
+    expect(nextSessionId(LIST, "gone", "next")).toBe("a");
+    expect(nextSessionId(LIST, null, "prev")).toBe("c");
+    expect(nextSessionId(LIST, "gone", "prev")).toBe("c");
+  });
+
+  it("handles a single-item list", () => {
+    expect(nextSessionId(["only"], "only", "next")).toBe("only");
+    expect(nextSessionId(["only"], "only", "prev")).toBe("only");
+    expect(nextSessionId(["only"], null, "next")).toBe("only");
+    expect(nextSessionId(["only"], null, "prev")).toBe("only");
+  });
+});

--- a/src/lib/sidebarSessionNav.ts
+++ b/src/lib/sidebarSessionNav.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure helpers for j/k keyboard navigation across the sidebar session list.
+ *
+ * App builds an ordered id list that matches visual order (expanded projects
+ * → date groups → orphans) and uses {@link nextSessionId} for the target.
+ * Keys are only handled when focus is inside the sidebar and not in an
+ * input / textarea / contenteditable (see App capture-phase keydown).
+ */
+
+export type SessionNavDir = "next" | "prev";
+
+/**
+ * Resolve the next/previous session id in an ordered list.
+ *
+ * - Empty list → `null`
+ * - `current` missing / not in list → first (`next`) or last (`prev`)
+ * - At ends → clamp (stay on first/last); caller may no-op if unchanged
+ */
+export function nextSessionId(
+  list: readonly string[],
+  current: string | null | undefined,
+  dir: SessionNavDir,
+): string | null {
+  if (list.length === 0) return null;
+  const idx =
+    current == null || current === "" ? -1 : list.indexOf(current);
+  if (dir === "next") {
+    if (idx < 0) return list[0] ?? null;
+    if (idx >= list.length - 1) return list[list.length - 1] ?? null;
+    return list[idx + 1] ?? null;
+  }
+  // prev
+  if (idx < 0) return list[list.length - 1] ?? null;
+  if (idx <= 0) return list[0] ?? null;
+  return list[idx - 1] ?? null;
+}


### PR DESCRIPTION
## Summary
- **j / k** navigate next/previous chat when focus is inside the open sidebar session list (visual order: expanded projects → date groups → orphans)
- Pure `nextSessionId(list, current, dir)` + unit tests; clamps at ends
- Does **not** steal keys from inputs / textareas / contenteditable, or when modifiers are held
- Enter still opens the focused session row (existing a11y behavior)
- Shortcuts catalog / help entry + i18n (en / zh / zh-TW) + CHANGELOG

## Test plan
- [ ] Focus a session row in the sidebar; press **j** → opens next chat; **k** → previous
- [ ] At first/last session, j/k clamps (no wrap)
- [ ] Focus composer / any input and type **j** / **k** → inserts text, no session switch
- [ ] ⌘/Ctrl+K search and other mod shortcuts still work
- [ ] Settings → Keyboard / shortcuts help lists “Next / previous chat in sidebar”
- [ ] `pnpm test src/lib/sidebarSessionNav.test.ts src/lib/shortcuts.test.ts`