### PR TITLE
feat(i18n): follow system language option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ See `docs/llm-wiki/release.md`.
 - **Tasks tree** (nest under spawn_subagent) · **Stop all skip-confirm** option
 - **Plan history** archive · **Dock/tray busy badge**
 - **Phone mirror write guard** · **CLI launch update notice** · Reliability / Leader / Memory / MCP / etc. (prior integrate)
+- **Language: follow system** (Settings → General): option **System** maps OS / browser language to `en` / `zh` / `zh-TW`; persists as `"system"` and live-updates on `languagechange`
 
 ### Fixed
 
@@ -41,7 +42,7 @@ See `docs/llm-wiki/release.md`.
 
 - **输入与对话**：队列编辑/排序、跨会话提示历史、阅读宽度与字号、工具默认折叠、重新生成可选模型、变更芯片
 - **会话与侧栏**：复制会话（vs 分叉+worktree）、便签、静音、插件目录、按天归档、日期分组、项目颜色、复制 Markdown
-- **任务与系统**：子代理树、Stop all 可跳过确认、计划历史、忙碌角标、镜像写权限等
+- **任务与系统**：子代理树、Stop all 可跳过确认、计划历史、忙碌角标、镜像写权限等；**语言跟随系统**（`system` → en/zh/zh-TW）
 
 **中文 · 修复**
 

--- a/docs/llm-wiki/i18n.md
+++ b/docs/llm-wiki/i18n.md
@@ -10,9 +10,9 @@
 |------|------|
 | `src/i18n/messages.ts` | Catalog: **`en` is the key authority**; `zh` must cover every key |
 | `src/i18n/zh-tw.ts` | Traditional Chinese (Taiwan) catalog |
-| `src/i18n/index.ts` | `t` / `createT` / `resolveLocale` / types |
+| `src/i18n/index.ts` | `t` / `createT` / `resolveLocale` / `resolveLocaleFromSystem` / types |
 | Components | Reference keys only — never hard-code `"Settings"` / `"设置"` |
-| `src-tauri/src/tray_i18n.rs` | Native tray strings (keep in sync with `tray.*` keys; reads `settings.locale`) |
+| `src-tauri/src/tray_i18n.rs` | Native tray strings (keep in sync with `tray.*` keys; reads `settings.locale`; `"system"` → OS lang) |
 
 ## Adding or changing copy
 
@@ -29,10 +29,17 @@
 
 | Layer | Default |
 |-------|---------|
-| `AppSettings.locale` | `"en"` |
+| `AppSettings.locale` | `"en"` (explicit; users may choose `"system"`) |
 | `resolveLocale(undefined)` | `"en"` |
+| `resolveLocale("system")` | maps `navigator.language` / OS → `en` \| `zh` \| `zh-TW` |
 | Tray unknown locale | English |
-| Settings language dropdown | English listed first |
+| Settings language dropdown | **System** first, then English / 简体 / 繁體 |
+
+## Follow system
+
+- Preference value stored in `settings.locale` is the string `"system"` (not the resolved catalog id).
+- Frontend: `resolveLocaleFromSystem(langTag)` (pure) + `languagechange` while preference is system.
+- Tray: `Locale::from_lang_tag` / `from_system` via `LANG` / `LC_*` when preference is `"system"`.
 
 ## Translation quality
 

--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -12,11 +12,55 @@ pub enum Locale {
 
 impl Locale {
     pub fn parse(raw: &str) -> Self {
-        match raw.trim().to_ascii_lowercase().as_str() {
+        let v = raw.trim().to_ascii_lowercase();
+        match v.as_str() {
+            "system" => Locale::from_system(),
             "en" | "en-us" | "en_us" | "en-gb" => Locale::En,
             "zh-tw" | "zh_tw" | "zh-hant" | "zh_hant" => Locale::ZhTw,
             "zh" | "zh-cn" | "zh_cn" | "zh-hans" | "zh_hans" => Locale::Zh,
             // Default product locale is en (matches AppSettings::default).
+            _ => Locale::En,
+        }
+    }
+
+    /// Best-effort map of OS language (LANG / LC_ALL / LC_MESSAGES) → catalog.
+    /// Mirrors frontend `resolveLocaleFromSystem` for tray copy when preference
+    /// is `"system"`.
+    pub fn from_system() -> Self {
+        let tag = std::env::var("LC_ALL")
+            .or_else(|_| std::env::var("LC_MESSAGES"))
+            .or_else(|_| std::env::var("LANG"))
+            .unwrap_or_default();
+        Self::from_lang_tag(&tag)
+    }
+
+    /// Map a BCP-47 / POSIX language tag to a tray locale (pure; testable).
+    pub fn from_lang_tag(raw: &str) -> Self {
+        let bare = raw
+            .trim()
+            .split('.')
+            .next()
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .replace('_', "-");
+        if bare.is_empty() {
+            return Locale::En;
+        }
+        let primary = bare.split('-').next().unwrap_or("");
+        if primary == "zh" {
+            let is_trad = bare.split('-').any(|p| {
+                p == "hant" || p == "tw" || p == "hk" || p == "mo"
+            });
+            return if is_trad { Locale::ZhTw } else { Locale::Zh };
+        }
+        if primary == "en" {
+            return Locale::En;
+        }
+        // Fall through to exact alias parse (without re-entering "system").
+        match bare.as_str() {
+            "zh-tw" | "zh-hant" => Locale::ZhTw,
+            "zh" | "zh-cn" | "zh-hans" => Locale::Zh,
+            "en" | "en-us" | "en-gb" => Locale::En,
             _ => Locale::En,
         }
     }
@@ -136,6 +180,18 @@ mod tests {
         assert_eq!(Locale::parse("zh-TW"), Locale::ZhTw);
         assert_eq!(Locale::parse("zh-Hant"), Locale::ZhTw);
         assert_eq!(strings(Locale::ZhTw).settings, "設定…");
+    }
+
+    #[test]
+    fn from_lang_tag_maps_system_tags() {
+        assert_eq!(Locale::from_lang_tag("en-US"), Locale::En);
+        assert_eq!(Locale::from_lang_tag("zh_CN.UTF-8"), Locale::Zh);
+        assert_eq!(Locale::from_lang_tag("zh-Hans-CN"), Locale::Zh);
+        assert_eq!(Locale::from_lang_tag("zh-TW"), Locale::ZhTw);
+        assert_eq!(Locale::from_lang_tag("zh-Hant-TW"), Locale::ZhTw);
+        assert_eq!(Locale::from_lang_tag("zh-HK"), Locale::ZhTw);
+        assert_eq!(Locale::from_lang_tag("fr_FR.UTF-8"), Locale::En);
+        assert_eq!(Locale::from_lang_tag(""), Locale::En);
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -271,7 +271,15 @@ import {
   mirrorWsConnected,
 } from "@/lib/mirrorTransport";
 
-import { createT, resolveLocale, type Locale } from "@/i18n";
+import {
+  createT,
+  parseLocalePreference,
+  resolveLocale,
+  resolveLocaleFromSystem,
+  resolveLocalePreference,
+  type Locale,
+  type LocalePreference,
+} from "@/i18n";
 import {
   DEFAULT_EFFORT,
   DEFAULT_MODEL_ID,
@@ -1692,7 +1700,11 @@ export default function App() {
    * Hard-dismiss sets `userClosed` so reopen stays empty until a new plan cycle.
    */
   const planBySessionRef = useRef(new Map<string, PlanState>());
-  const [locale, setLocale] = useState<Locale>("zh");
+  const [localePreference, setLocalePreference] =
+    useState<LocalePreference>("en");
+  const [locale, setLocale] = useState<Locale>(() =>
+    resolveLocalePreference("en"),
+  );
   const localeRef = useRef(locale);
   localeRef.current = locale;
   const tr = useMemo(() => createT(locale), [locale]);
@@ -2139,6 +2151,23 @@ export default function App() {
     };
   }, [themePreference]);
 
+  // Follow OS / browser UI language when preference is "system".
+  useEffect(() => {
+    if (localePreference !== "system") return;
+    const applySystem = () => {
+      const next = resolveLocaleFromSystem(
+        typeof navigator !== "undefined" ? navigator.language : null,
+      );
+      setLocale(next);
+    };
+    applySystem();
+    if (typeof window === "undefined" || !("addEventListener" in window)) {
+      return;
+    }
+    window.addEventListener("languagechange", applySystem);
+    return () => window.removeEventListener("languagechange", applySystem);
+  }, [localePreference]);
+
   useEffect(() => {
     applySkinToDocument(skin);
   }, [skin]);
@@ -2288,7 +2317,9 @@ export default function App() {
           .then((path) => setGeneralWorkspacePath(path || null))
           .catch(() => {});
         if (settings) {
-          setLocale(resolveLocale(settings.locale));
+          const pref = parseLocalePreference(settings.locale);
+          setLocalePreference(pref);
+          setLocale(resolveLocalePreference(pref));
           if (
             settings.composerPrefsScope &&
             isValidPrefsScope(settings.composerPrefsScope)
@@ -2354,7 +2385,11 @@ export default function App() {
         .then((path) => setGeneralWorkspacePath(path || null))
         .catch(() => {});
       void api.trayRefresh();
-      setLocale(resolveLocale(settings.locale));
+      {
+        const pref = parseLocalePreference(settings.locale);
+        setLocalePreference(pref);
+        setLocale(resolveLocalePreference(pref));
+      }
       const catalog: ModelOption[] =
         modelsRes?.models?.length
           ? modelsRes.models.map((m) => {
@@ -11746,6 +11781,7 @@ export default function App() {
       "settings.section.general",
       "settings.language",
       "settings.languageDesc",
+      "settings.languageSystem",
       "settings.sessionDataMode",
       "settings.sessionDataModeDesc",
       "settings.cliPath",
@@ -12019,11 +12055,15 @@ export default function App() {
           phoneLayout={phoneLayout}
           labels={settingsLabels}
           locale={locale}
+          localePreference={localePreference}
           onLocale={(v) => {
-            const next = resolveLocale(v);
+            const pref = parseLocalePreference(v);
+            setLocalePreference(pref);
+            const next = resolveLocalePreference(pref);
             setLocale(next);
             void api.settingsGet().then(async (s) => {
-              await api.settingsSet({ ...s, locale: next });
+              // Persist preference including "system" (not the resolved catalog id).
+              await api.settingsSet({ ...s, locale: pref });
               // settings_set also refreshes tray; call again so UI stays in sync if invoke fails mid-way.
               void api.trayRefresh();
             });

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -261,7 +261,13 @@ export interface SettingsPageProps {
    */
   phoneLayout?: boolean;
   labels: Record<string, string>;
+  /** Resolved catalog locale used for Settings copy (`en` | `zh` | `zh-TW`). */
   locale: string;
+  /**
+   * Durable language preference including `"system"`. When omitted, the Select
+   * falls back to `locale` (explicit lock).
+   */
+  localePreference?: string;
   onLocale: (v: string) => void;
   /** Resolved light/dark currently applied (for display-only consumers). */
   theme: Theme;
@@ -813,6 +819,7 @@ export function SettingsPage({
   phoneLayout = false,
   labels: _legacyLabels,
   locale,
+  localePreference: localePreferenceProp,
   onLocale,
   theme,
   themePreference: themePreferenceProp,
@@ -1116,11 +1123,14 @@ export function SettingsPage({
   } | null>(null);
   // Full catalog via createT — do not depend on App's partial `labels` whitelist
   // (missing keys used to render raw "settings.acpServer" etc.).
+  // `locale` is the resolved catalog locale (never "system").
   const tr = useMemo(() => createT(resolveLocale(locale)), [locale]);
   const t = useCallback(
     (k: string, vars?: Vars) => tr(k as MessageKey, vars),
     [tr],
   );
+  /** Language Select: durable preference including "system". */
+  const localePreference = localePreferenceProp ?? locale;
   /** Segment selection: prefer explicit preference; fall back to resolved theme. */
   const themePreference: ThemePreference =
     themePreferenceProp ?? theme;
@@ -2347,12 +2357,13 @@ export function SettingsPage({
                   </div>
                 </div>
                 <Select
-                  value={locale}
+                  value={localePreference}
                   onChange={onLocale}
                   options={[
+                    { value: "system", label: t("settings.languageSystem") },
+                    { value: "en", label: "English" },
                     { value: "zh", label: "简体中文" },
                     { value: "zh-TW", label: "繁體中文" },
-                    { value: "en", label: "English" },
                   ]}
                 />
               </div>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -13,6 +13,9 @@ import {
 export type { Locale, MessageKey };
 export { isLocale, messages };
 
+/** User preference: explicit catalog locale or follow OS / browser language. */
+export type LocalePreference = "system" | Locale;
+
 export type Vars = Record<string, string | number | undefined | null>;
 
 function interpolate(template: string, vars?: Vars): string {
@@ -42,21 +45,107 @@ export function createT(locale: Locale) {
  * case-insensitive parsing on the Rust side (see tray_i18n.rs `Locale::parse`).
  */
 function normalizeLocale(raw: string): Locale | null {
-  const v = raw.trim().toLowerCase();
-  if (v === "zh-tw" || v === "zh_tw" || v === "zh-hant" || v === "zh_hant") {
+  const v = raw.trim().toLowerCase().replace(/_/g, "-");
+  if (v === "zh-tw" || v === "zh-hant") {
     return "zh-TW";
   }
-  if (v === "zh" || v === "zh-cn" || v === "zh_cn" || v === "zh-hans") {
+  if (v === "zh" || v === "zh-cn" || v === "zh-hans") {
     return "zh";
   }
-  if (v === "en" || v === "en-us" || v === "en_us" || v === "en-gb") {
+  if (v === "en" || v === "en-us" || v === "en-gb") {
     return "en";
   }
   return null;
 }
 
+/**
+ * Map a BCP-47 / OS language tag (e.g. `navigator.language`) to a catalog
+ * {@link Locale}. Pure — no `navigator` access. Unknown or empty tags → `en`.
+ *
+ * Rules:
+ * - Chinese + Traditional script/region (`Hant`, `TW`, `HK`, `MO`) → `zh-TW`
+ * - Other Chinese (`zh`, `zh-CN`, `zh-Hans`, `zh-SG`, …) → `zh`
+ * - English (`en`, `en-US`, …) → `en`
+ * - Everything else → product default `en`
+ */
+export function resolveLocaleFromSystem(
+  langTag: string | null | undefined,
+): Locale {
+  if (langTag == null) return "en";
+  const v = String(langTag).trim().toLowerCase().replace(/_/g, "-");
+  if (!v) return "en";
+
+  // Strip encoding suffix from POSIX tags: "zh_CN.UTF-8" → already "_"→"-",
+  // still may have ".utf-8".
+  const bare = v.split(".")[0] ?? v;
+  const primary = bare.split("-")[0] ?? bare;
+
+  if (primary === "zh") {
+    // Script subtag or region for Traditional Chinese.
+    const parts = bare.split("-");
+    if (
+      parts.includes("hant") ||
+      parts.includes("tw") ||
+      parts.includes("hk") ||
+      parts.includes("mo")
+    ) {
+      return "zh-TW";
+    }
+    return "zh";
+  }
+
+  if (primary === "en") return "en";
+
+  return normalizeLocale(bare) ?? "en";
+}
+
+export function isLocalePreference(v: unknown): v is LocalePreference {
+  return v === "system" || (typeof v === "string" && isLocale(v));
+}
+
+/**
+ * Parse a durable settings value into a {@link LocalePreference}.
+ * Accepts `system`, canonical locales, and common aliases. Invalid → `en`.
+ */
+export function parseLocalePreference(
+  raw: string | null | undefined,
+): LocalePreference {
+  if (raw == null) return "en";
+  const trimmed = String(raw).trim();
+  if (!trimmed) return "en";
+  if (trimmed.toLowerCase() === "system") return "system";
+  if (isLocale(trimmed)) return trimmed;
+  return normalizeLocale(trimmed) ?? "en";
+}
+
+/**
+ * Resolve a user preference to a concrete catalog locale.
+ * When preference is `system`, maps `systemLangTag` (or `navigator.language`
+ * when available) via {@link resolveLocaleFromSystem}.
+ */
+export function resolveLocalePreference(
+  preference: LocalePreference,
+  systemLangTag?: string | null,
+): Locale {
+  if (preference !== "system") return preference;
+  const tag =
+    systemLangTag !== undefined
+      ? systemLangTag
+      : typeof navigator !== "undefined"
+        ? navigator.language
+        : null;
+  return resolveLocaleFromSystem(tag);
+}
+
+/**
+ * Resolve a stored settings locale string to a concrete catalog locale.
+ * `"system"` follows OS / browser language; explicit ids stay as-is.
+ */
 export function resolveLocale(raw: string | undefined | null): Locale {
   if (!raw) return "en";
+  if (raw.trim().toLowerCase() === "system") {
+    return resolveLocalePreference("system");
+  }
   if (isLocale(raw)) return raw;
   return normalizeLocale(raw) ?? "en";
 }

--- a/src/i18n/messages.test.ts
+++ b/src/i18n/messages.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   createT,
   messages,
+  parseLocalePreference,
   resolveLocale,
+  resolveLocaleFromSystem,
+  resolveLocalePreference,
   t,
   type MessageKey,
 } from "./index";
@@ -71,5 +74,74 @@ describe("resolveLocale", () => {
     expect(resolveLocale("")).toBe("en");
     expect(resolveLocale(undefined)).toBe("en");
     expect(resolveLocale(null)).toBe("en");
+  });
+});
+
+describe("resolveLocaleFromSystem", () => {
+  it("maps English tags to en", () => {
+    expect(resolveLocaleFromSystem("en")).toBe("en");
+    expect(resolveLocaleFromSystem("en-US")).toBe("en");
+    expect(resolveLocaleFromSystem("en_GB")).toBe("en");
+    expect(resolveLocaleFromSystem("en-AU")).toBe("en");
+  });
+
+  it("maps Simplified Chinese tags to zh", () => {
+    expect(resolveLocaleFromSystem("zh")).toBe("zh");
+    expect(resolveLocaleFromSystem("zh-CN")).toBe("zh");
+    expect(resolveLocaleFromSystem("zh_CN")).toBe("zh");
+    expect(resolveLocaleFromSystem("zh-Hans")).toBe("zh");
+    expect(resolveLocaleFromSystem("zh-Hans-CN")).toBe("zh");
+    expect(resolveLocaleFromSystem("zh-SG")).toBe("zh");
+    expect(resolveLocaleFromSystem("zh_CN.UTF-8")).toBe("zh");
+  });
+
+  it("maps Traditional Chinese tags to zh-TW", () => {
+    expect(resolveLocaleFromSystem("zh-TW")).toBe("zh-TW");
+    expect(resolveLocaleFromSystem("zh_TW")).toBe("zh-TW");
+    expect(resolveLocaleFromSystem("zh-Hant")).toBe("zh-TW");
+    expect(resolveLocaleFromSystem("zh-Hant-TW")).toBe("zh-TW");
+    expect(resolveLocaleFromSystem("zh-HK")).toBe("zh-TW");
+    expect(resolveLocaleFromSystem("zh-MO")).toBe("zh-TW");
+    expect(resolveLocaleFromSystem("zh_TW.UTF-8")).toBe("zh-TW");
+  });
+
+  it("falls back to en for unknown or empty tags", () => {
+    expect(resolveLocaleFromSystem("fr")).toBe("en");
+    expect(resolveLocaleFromSystem("ja-JP")).toBe("en");
+    expect(resolveLocaleFromSystem("")).toBe("en");
+    expect(resolveLocaleFromSystem("   ")).toBe("en");
+    expect(resolveLocaleFromSystem(undefined)).toBe("en");
+    expect(resolveLocaleFromSystem(null)).toBe("en");
+  });
+});
+
+describe("parseLocalePreference / resolveLocalePreference", () => {
+  it("keeps system and canonical locales", () => {
+    expect(parseLocalePreference("system")).toBe("system");
+    expect(parseLocalePreference("System")).toBe("system");
+    expect(parseLocalePreference("en")).toBe("en");
+    expect(parseLocalePreference("zh")).toBe("zh");
+    expect(parseLocalePreference("zh-TW")).toBe("zh-TW");
+  });
+
+  it("normalizes aliases and invalid values", () => {
+    expect(parseLocalePreference("zh-cn")).toBe("zh");
+    expect(parseLocalePreference("zh-hant")).toBe("zh-TW");
+    expect(parseLocalePreference("fr")).toBe("en");
+    expect(parseLocalePreference("")).toBe("en");
+    expect(parseLocalePreference(undefined)).toBe("en");
+  });
+
+  it("resolves system preference via an explicit lang tag", () => {
+    expect(resolveLocalePreference("system", "zh-CN")).toBe("zh");
+    expect(resolveLocalePreference("system", "zh-TW")).toBe("zh-TW");
+    expect(resolveLocalePreference("system", "en-US")).toBe("en");
+    expect(resolveLocalePreference("system", "de")).toBe("en");
+  });
+
+  it("returns explicit preferences unchanged", () => {
+    expect(resolveLocalePreference("zh", "en-US")).toBe("zh");
+    expect(resolveLocalePreference("en", "zh-CN")).toBe("en");
+    expect(resolveLocalePreference("zh-TW", "en")).toBe("zh-TW");
   });
 });

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -913,7 +913,8 @@ const en = {
   "settings.voiceKeepAgentsOnEndDesc":
     "If off, ending Live Voice may stop sessions started from voice.",
   "settings.language": "Language",
-  "settings.languageDesc": "App UI language",
+  "settings.languageDesc": "App UI language — follow the system, or lock a language",
+  "settings.languageSystem": "System",
   "store.quarantineNotice":
     "A damaged settings/sessions file was set aside ({path}). The app started with defaults for that file.",
   "settings.sessionDataMode": "Session data mode",
@@ -3635,7 +3636,8 @@ const zh: Record<MessageKey, string> = {
   "settings.voiceKeepAgentsOnEndDesc":
     "关闭后，结束实时语音可能会停止由语音发起的编码会话。",
   "settings.language": "语言",
-  "settings.languageDesc": "应用界面语言",
+  "settings.languageDesc": "应用界面语言 — 跟随系统，或固定一种语言",
+  "settings.languageSystem": "跟随系统",
   "store.quarantineNotice":
     "检测到损坏的配置/会话文件，已隔离备份（{path}）。该文件已按默认值启动。",
   "settings.sessionDataMode": "会话数据模式",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -870,7 +870,8 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.voiceKeepAgentsOnEndDesc":
     "關閉後，結束即時語音可能會停止由語音發起的編碼工作階段。",
   "settings.language": "語言",
-  "settings.languageDesc": "應用程式介面語言",
+  "settings.languageDesc": "應用程式介面語言 — 跟隨系統，或固定一種語言",
+  "settings.languageSystem": "跟隨系統",
   "store.quarantineNotice":
     "偵測到損壞的設定/工作階段檔，已隔離備份（{path}）。該檔已以預設值啟動。",
   "settings.sessionDataMode": "對話資料模式",

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -474,7 +474,15 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     anchorId: "settings-anchor-language",
     labelKey: "settings.language",
     descKeys: ["settings.languageDesc", "settings.section.general"],
-    keywords: ["language", "locale", "中文", "english"],
+    keywords: [
+      "language",
+      "locale",
+      "中文",
+      "english",
+      "system",
+      "跟随系统",
+      "跟隨系統",
+    ],
   },
   {
     id: "general.sessionDataMode",


### PR DESCRIPTION
## Summary
- Adds Settings → Language **System** preference that maps OS / browser language (`navigator.language`) to catalog locales `en` | `zh` | `zh-TW`
- Pure `resolveLocaleFromSystem(langTag)` + preference helpers with unit tests; persists durable value as `"system"`
- Live-updates via `languagechange` while preference is system; tray/native side maps `"system"` via `LANG` / `LC_*`

## Details
- **i18n**: `LocalePreference`, `parseLocalePreference`, `resolveLocalePreference`, `resolveLocaleFromSystem`
- **UI**: Settings language Select (System first); resolved locale still drives all `createT` copy
- **Catalog / labels**: `settings.languageSystem`, updated `settings.languageDesc`, search keywords
- **Tray**: `Locale::from_lang_tag` / `from_system` when settings.locale is `"system"`
- **Docs / CHANGELOG**: Unreleased + `docs/llm-wiki/i18n.md`

## Test plan
- [x] `pnpm exec vitest run src/i18n/messages.test.ts` (18 tests)
- [x] `cargo test --lib tray_i18n`
- [x] `pnpm exec tsc -b`
- [ ] Manual: set Language → System, confirm UI matches OS language; switch OS/browser language if possible and see UI update
- [ ] Manual: lock English/简体/繁體 and confirm preference sticks after restart