### PR TITLE
feat(session): resume chat with optional code restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 
 #### Sessions & sidebar
 - **Duplicate chat** (vs **Fork…** + optional worktree) · **session notes** · **mute** · **unread dot**
+- **Resume with code restore** — open an existing chat on a clean sibling git worktree at HEAD (session menu + command palette; dirty tree refused; same safety as Fork → restore code)
 - **Export** Markdown copy + **HTML export** · **bulk archive by age** · **date groups** · **project color**
 - **Sidebar j/k** navigation (when list focused)
 
@@ -38,7 +39,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 新增（按域）**
 
 - **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片
-- **会话/侧栏**：复制 vs 分叉、便签、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航
+- **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标
 
 **中文 · 修复**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -546,6 +546,11 @@ import {
   buildForkWorktreeName,
   canRestoreCodeOnFork,
 } from "@/lib/sessionFork";
+import {
+  buildResumeWorktreeName,
+  canOfferResumeWithCodeRestore,
+  canRestoreCodeOnResume,
+} from "@/lib/sessionResumeRestore";
 import { isProjectPathMissing } from "@/lib/projectPath";
 import {
   PROJECT_COLOR_TOKENS,
@@ -1250,6 +1255,10 @@ export default function App() {
   } | null>(null);
   const [forkRestoreCode, setForkRestoreCode] = useState(false);
   const [forkBusy, setForkBusy] = useState(false);
+  /** Resume existing chat on a clean worktree (restore-code). */
+  const [resumeRestoreConfirm, setResumeRestoreConfirm] =
+    useState<SessionRow | null>(null);
+  const [resumeRestoreBusy, setResumeRestoreBusy] = useState(false);
   /** Last user message open in inline edit (not main composer). */
   const [editingUserMessageId, setEditingUserMessageId] = useState<
     string | null
@@ -9097,6 +9106,164 @@ export default function App() {
   );
 
   /**
+   * Resume an existing session on a clean sibling worktree at current HEAD.
+   * Reuses the fork restore-code dirty gate; does not clone the journal.
+   */
+  const runResumeWithCodeRestore = useCallback(
+    async (source: SessionRow) => {
+      if (!api.isTauri()) {
+        showToast(tr("error.needTauri"));
+        return;
+      }
+      const isOpenSource =
+        session.sessionId === source.id ||
+        viewingSessionIdRef.current === source.id;
+      if (
+        busyIds.has(source.id) ||
+        (isOpenSource && !canRewindSession)
+      ) {
+        showToast(tr("session.resumeRestoreBusy"), 3500);
+        return;
+      }
+      setResumeRestoreBusy(true);
+      try {
+        const sourceProjectId = normalizeProjectId(source.projectId);
+        const sourceProject = sourceProjectId
+          ? projects.find((p) => p.id === sourceProjectId) ?? null
+          : null;
+        const projectPath = sourceProject?.path?.trim() || "";
+        if (!projectPath) {
+          showToast(tr("session.resumeRestoreNoProject"), 4500);
+          return;
+        }
+
+        let status: api.GitStatusResult;
+        try {
+          status = await api.gitStatus(projectPath);
+        } catch (e) {
+          showToast(
+            tr("session.resumeRestoreUnavailable") + ": " + String(e),
+            4500,
+          );
+          return;
+        }
+        const gate = canRestoreCodeOnResume(projectPath, status);
+        if (!gate.ok) {
+          if (gate.reason === "dirty") {
+            showToast(tr("session.resumeRestoreDirty"), 5200);
+          } else if (gate.reason === "no_project") {
+            showToast(tr("session.resumeRestoreNoProject"), 4500);
+          } else {
+            showToast(tr("session.resumeRestoreUnavailable"), 4500);
+          }
+          return;
+        }
+
+        let created: api.GitWorktreeAddResult | null = null;
+        let lastErr: unknown = null;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          const name = buildResumeWorktreeName(source.id, {
+            attempt,
+            now: Date.now() + attempt,
+          });
+          try {
+            created = await api.gitWorktreeAdd(projectPath, name, null);
+            break;
+          } catch (e) {
+            lastErr = e;
+            const msg = String(e).toLowerCase();
+            if (
+              !msg.includes("already exists") &&
+              !msg.includes("already registered") &&
+              !msg.includes("already checked out")
+            ) {
+              break;
+            }
+          }
+        }
+        if (!created) {
+          showToast(
+            tr("session.resumeRestoreCreateFailed") +
+              (lastErr ? ": " + String(lastErr) : ""),
+            5200,
+          );
+          return;
+        }
+
+        const trust = !!sourceProject?.trusted;
+        const existing = projects.find((p) =>
+          pathsEqual(p.path, created!.path),
+        );
+        let bindProject: Project | null = existing ?? null;
+        if (!bindProject) {
+          const added = (await api.projectAdd(created.path, trust)) as Project;
+          const list = mapProjectsList(
+            (await api.projectsList()) as Project[],
+          );
+          setProjects(list);
+          bindProject =
+            list.find((p) => p.id === added.id) ??
+            list.find((p) => pathsEqual(p.path, created!.path)) ??
+            normalizeProject(added);
+        }
+
+        try {
+          await api.sessionSetProject(source.id, bindProject.id);
+        } catch (e) {
+          showToast(
+            tr("session.resumeRestoreBindFailed") + ": " + String(e),
+            4500,
+          );
+          return;
+        }
+
+        const branch =
+          created.branch?.trim() ||
+          created.name ||
+          tr("composer.worktreeDetached");
+        try {
+          await api.sessionSetWorktree(source.id, {
+            worktreePath: created.path,
+            worktreeBranch: branch,
+          });
+        } catch {
+          /* soft-fail badge meta */
+        }
+
+        setResumeRestoreConfirm(null);
+        await refreshSessions();
+        await refreshGitWorktrees();
+        const row = normalizeSessionRow({
+          ...source,
+          projectId: bindProject.id,
+          worktreePath: created.path,
+          worktreeBranch: branch,
+          isWorktreeSession: true,
+          updatedAt: new Date().toISOString(),
+        });
+        setExpandedProjects((e) => ({ ...e, [bindProject!.id]: true }));
+        await openSession(row, bindProject);
+        showToast(tr("session.resumeRestoreOk"), 2800);
+      } catch (e) {
+        showToast(
+          tr("session.resumeRestoreFailed") + ": " + String(e),
+          4500,
+        );
+      } finally {
+        setResumeRestoreBusy(false);
+      }
+    },
+    // openSession / refreshSessions / busyIds / canRewindSession via closure
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [projects, showToast, tr, session.sessionId],
+  );
+
+  const confirmResumeWithCodeRestore = useCallback((source: SessionRow) => {
+    setCtxMenu(null);
+    setResumeRestoreConfirm(source);
+  }, []);
+
+  /**
    * Duplicate a session: full journal clone via sessionFork (no cut, no restore-code).
    * Idle-only so we don't snapshot a mid-turn journal.
    */
@@ -10713,6 +10880,48 @@ export default function App() {
             : undefined,
         );
         break;
+      case "resume-with-code-restore": {
+        const sid = session.sessionId || viewingSessionIdRef.current;
+        if (!sid) {
+          showToast(tr("session.resumeRestoreNoProject"), 3500);
+          break;
+        }
+        const row =
+          sessions.find((s) => s.id === sid) ??
+          (sid
+            ? normalizeSessionRow({
+                id: sid,
+                title: session.title || tr("session.untitled"),
+                projectId: activeProject?.id ?? null,
+                updatedAt: new Date().toISOString(),
+              })
+            : null);
+        if (!row) {
+          showToast(tr("session.resumeRestoreNoProject"), 3500);
+          break;
+        }
+        const proj = row.projectId
+          ? projects.find((p) => p.id === row.projectId) ?? activeProject
+          : activeProject;
+        if (
+          !canOfferResumeWithCodeRestore(proj?.path, {
+            gitAvailable: gitWorktreesAvailable,
+          })
+        ) {
+          showToast(
+            proj?.path
+              ? tr("session.resumeRestoreUnavailable")
+              : tr("session.resumeRestoreNoProject"),
+            3500,
+          );
+          break;
+        }
+        confirmResumeWithCodeRestore({
+          ...row,
+          projectId: row.projectId ?? proj?.id ?? null,
+        });
+        break;
+      }
       case "settings-general":
         navigateSettings("general");
         break;
@@ -12401,6 +12610,7 @@ export default function App() {
         exportMdTarget ||
         rewindConfirm ||
         forkConfirm ||
+        resumeRestoreConfirm ||
         worktreeCreateOpen ||
         projectRulesTarget ||
         agentDashboardOpen,
@@ -16711,6 +16921,55 @@ export default function App() {
       </GlassModal>
 
       <GlassModal
+        open={!!resumeRestoreConfirm}
+        onClose={() => {
+          if (resumeRestoreBusy) return;
+          setResumeRestoreConfirm(null);
+        }}
+        title={tr("session.resumeRestoreTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        closeOnOverlay={!resumeRestoreBusy}
+        showClose={!resumeRestoreBusy}
+        wrapBody
+        className="fork-confirm-modal"
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={resumeRestoreBusy}
+              onClick={() => setResumeRestoreConfirm(null)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn"
+              disabled={resumeRestoreBusy || !resumeRestoreConfirm}
+              onClick={() => {
+                if (!resumeRestoreConfirm) return;
+                void runResumeWithCodeRestore(resumeRestoreConfirm);
+              }}
+            >
+              {resumeRestoreBusy
+                ? tr("session.resumeRestoreWorking")
+                : tr("session.resumeRestore")}
+            </button>
+          </>
+        }
+      >
+        <div className="fork-confirm">
+          <p className="fork-confirm__msg">
+            {tr("session.resumeRestoreConfirm")}
+          </p>
+          <p className="fork-confirm__hint">
+            {tr("session.resumeRestoreHint")}
+          </p>
+        </div>
+      </GlassModal>
+
+      <GlassModal
         open={showTraces}
         onClose={() => setShowTraces(false)}
         title={tr("session.tracesTitle")}
@@ -17913,6 +18172,38 @@ export default function App() {
                   void runDuplicateSession(s);
                 },
               },
+              ...(() => {
+                const proj = s.projectId
+                  ? projects.find((p) => p.id === s.projectId) ?? null
+                  : null;
+                const path = proj?.path?.trim() || "";
+                const gitKnown =
+                  activeProject &&
+                  path &&
+                  pathsEqual(activeProject.path, path)
+                    ? gitWorktreesAvailable
+                    : null;
+                if (
+                  !canOfferResumeWithCodeRestore(path, {
+                    gitAvailable: gitKnown,
+                  })
+                ) {
+                  return [];
+                }
+                return [
+                  {
+                    id: "resume-restore",
+                    label: tr("session.resumeRestore"),
+                    icon: <IconGitBranch size={16} />,
+                    disabled:
+                      resumeRestoreBusy ||
+                      forkBusy ||
+                      busyIds.has(s.id) ||
+                      (isOpen && !canRewindSession),
+                    onClick: () => confirmResumeWithCodeRestore(s),
+                  } satisfies ContextMenuItem,
+                ];
+              })(),
               {
                 id: "session-plugin-add",
                 label:

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -185,6 +185,27 @@ const en = {
   "session.forkRestoreFailed": "Could not create a worktree for restore",
   "session.forkRestoreBindFailed":
     "Forked the chat, but could not bind it to the new worktree",
+  "session.resumeRestore": "Resume with code restore…",
+  "session.resumeRestoreTitle": "Resume with code restore",
+  "session.resumeRestoreConfirm":
+    "Open this chat on a clean linked git worktree at the project’s current HEAD (isolates agent edits from your main checkout). The conversation stays the same; only the working directory changes. Refuses if the tree has uncommitted changes.",
+  "session.resumeRestoreHint":
+    "Creates a sibling worktree (branch resume-…) and rebinds this session there. Same dirty-tree safety as Fork → restore code. Off until you confirm.",
+  "session.resumeRestoreWorking": "Resuming…",
+  "session.resumeRestoreOk": "Resumed · opened chat on a clean worktree",
+  "session.resumeRestoreFailed": "Could not resume with code restore",
+  "session.resumeRestoreDirty":
+    "Working tree has uncommitted changes. Commit or stash first, then try again.",
+  "session.resumeRestoreNoProject":
+    "Code restore needs a project folder bound to this chat.",
+  "session.resumeRestoreUnavailable":
+    "Code restore needs a git repository for this project.",
+  "session.resumeRestoreCreateFailed":
+    "Could not create a worktree for resume restore",
+  "session.resumeRestoreBindFailed":
+    "Could not bind this chat to the new worktree",
+  "session.resumeRestoreBusy":
+    "Wait for the current turn to finish before resuming with code restore",
   "session.duplicate": "Duplicate chat",
   "session.duplicateTitleOf": "Copy of {name}",
   "session.duplicateWorking": "Duplicating…",
@@ -2977,6 +2998,22 @@ const zh: Record<MessageKey, string> = {
   "session.forkRestoreUnavailable": "恢复代码需要该项目是 git 仓库。",
   "session.forkRestoreFailed": "无法为恢复创建 worktree",
   "session.forkRestoreBindFailed": "会话已分叉，但未能绑定到新 worktree",
+  "session.resumeRestore": "恢复对话并还原代码…",
+  "session.resumeRestoreTitle": "恢复对话并还原代码",
+  "session.resumeRestoreConfirm":
+    "在项目当前 HEAD 创建干净的关联 git worktree，并在该目录打开本会话（代理改动与主检出隔离）。对话内容不变，仅工作目录切换。工作区有未提交改动时会拒绝。",
+  "session.resumeRestoreHint":
+    "创建同级 worktree（分支 resume-…）并将本会话绑定到该目录。脏树安全规则与「分叉 → 恢复代码」相同。确认后才会执行。",
+  "session.resumeRestoreWorking": "正在恢复…",
+  "session.resumeRestoreOk": "已恢复 · 已在干净 worktree 中打开会话",
+  "session.resumeRestoreFailed": "无法以代码还原方式恢复会话",
+  "session.resumeRestoreDirty":
+    "工作区有未提交改动。请先提交或暂存后再试。",
+  "session.resumeRestoreNoProject": "代码还原需要该会话已绑定项目文件夹。",
+  "session.resumeRestoreUnavailable": "代码还原需要该项目是 git 仓库。",
+  "session.resumeRestoreCreateFailed": "无法为恢复创建 worktree",
+  "session.resumeRestoreBindFailed": "未能将本会话绑定到新 worktree",
+  "session.resumeRestoreBusy": "请等待当前回合结束后再使用「恢复并还原代码」",
   "session.duplicate": "复制会话",
   "session.duplicateTitleOf": "副本：{name}",
   "session.duplicateWorking": "正在复制…",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -167,6 +167,22 @@ export const zhTW: Record<MessageKey, string> = {
   "session.forkRestoreUnavailable": "還原程式碼需要此專案是 git 儲存庫。",
   "session.forkRestoreFailed": "無法為還原建立 worktree",
   "session.forkRestoreBindFailed": "對話已分叉，但未能繫結到新 worktree",
+  "session.resumeRestore": "恢復對話並還原程式碼…",
+  "session.resumeRestoreTitle": "恢復對話並還原程式碼",
+  "session.resumeRestoreConfirm":
+    "在專案目前 HEAD 建立乾淨的關聯 git worktree，並在該目錄開啟本對話（代理改動與主檢出隔離）。對話內容不變，僅工作目錄切換。工作區有未提交變更時會拒絕。",
+  "session.resumeRestoreHint":
+    "建立同級 worktree（分支 resume-…）並將本對話繫結到該目錄。髒樹安全規則與「分叉 → 還原程式碼」相同。確認後才會執行。",
+  "session.resumeRestoreWorking": "正在恢復…",
+  "session.resumeRestoreOk": "已恢復 · 已在乾淨 worktree 中開啟對話",
+  "session.resumeRestoreFailed": "無法以程式碼還原方式恢復對話",
+  "session.resumeRestoreDirty":
+    "工作區有未提交變更。請先提交或暫存後再試。",
+  "session.resumeRestoreNoProject": "還原程式碼需要此對話已繫結專案資料夾。",
+  "session.resumeRestoreUnavailable": "還原程式碼需要此專案是 git 儲存庫。",
+  "session.resumeRestoreCreateFailed": "無法為恢復建立 worktree",
+  "session.resumeRestoreBindFailed": "未能將本對話繫結到新 worktree",
+  "session.resumeRestoreBusy": "請等待目前回合結束後再使用「恢復並還原程式碼」",
   "session.duplicate": "複製對話",
   "session.duplicateTitleOf": "副本：{name}",
   "session.duplicateWorking": "正在複製…",

--- a/src/lib/paletteActions.test.ts
+++ b/src/lib/paletteActions.test.ts
@@ -22,6 +22,7 @@ describe("defaultPaletteActions", () => {
       "shortcuts-help",
       "product-tutorial",
       "copy-conversation-md",
+      "resume-with-code-restore",
       "settings-general",
       "settings-appearance",
       "settings-account",

--- a/src/lib/paletteActions.ts
+++ b/src/lib/paletteActions.ts
@@ -142,6 +142,22 @@ export function defaultPaletteActions(): PaletteActionDef[] {
       group: "session",
     },
     {
+      id: "resume-with-code-restore",
+      labelKey: "session.resumeRestore",
+      keywords: [
+        "resume",
+        "continue",
+        "restore",
+        "restore code",
+        "code restore",
+        "worktree",
+        "clean worktree",
+        "isolate",
+        "git restore",
+      ],
+      group: "session",
+    },
+    {
       id: "settings-general",
       labelKey: "settings.nav.general",
       keywords: ["settings", "general", "preferences", "prefs", "composer"],

--- a/src/lib/sessionResumeRestore.test.ts
+++ b/src/lib/sessionResumeRestore.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildResumeWorktreeName,
+  canOfferResumeWithCodeRestore,
+  canRestoreCodeOnResume,
+  isGitWorkingTreeDirty,
+  shouldCaptureBaselineCommit,
+} from "./sessionResumeRestore";
+
+describe("isGitWorkingTreeDirty (resume path)", () => {
+  it("is false when unavailable or empty", () => {
+    expect(isGitWorkingTreeDirty(null)).toBe(false);
+    expect(isGitWorkingTreeDirty(undefined)).toBe(false);
+    expect(
+      isGitWorkingTreeDirty({ available: false, files: [{ path: "a" }] }),
+    ).toBe(false);
+    expect(isGitWorkingTreeDirty({ available: true, files: [] })).toBe(false);
+  });
+
+  it("is true when available and any files listed", () => {
+    expect(
+      isGitWorkingTreeDirty({
+        available: true,
+        files: [{ path: "src/a.ts" }],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("canRestoreCodeOnResume", () => {
+  it("requires a project path", () => {
+    expect(canRestoreCodeOnResume("", { available: true, files: [] })).toEqual({
+      ok: false,
+      reason: "no_project",
+    });
+    expect(
+      canRestoreCodeOnResume(null, { available: true, files: [] }),
+    ).toEqual({ ok: false, reason: "no_project" });
+  });
+
+  it("requires available git status", () => {
+    expect(
+      canRestoreCodeOnResume("/repo", {
+        available: false,
+        reason: "not a repo",
+      }),
+    ).toEqual({ ok: false, reason: "unavailable" });
+    expect(canRestoreCodeOnResume("/repo", null)).toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+  });
+
+  it("refuses dirty trees (never destroy uncommitted work)", () => {
+    expect(
+      canRestoreCodeOnResume("/repo", {
+        available: true,
+        files: [{ path: "x" }],
+      }),
+    ).toEqual({ ok: false, reason: "dirty" });
+  });
+
+  it("allows clean git project", () => {
+    expect(
+      canRestoreCodeOnResume("/repo", { available: true, files: [] }),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe("canOfferResumeWithCodeRestore", () => {
+  it("needs a project path", () => {
+    expect(canOfferResumeWithCodeRestore(null)).toBe(false);
+    expect(canOfferResumeWithCodeRestore("")).toBe(false);
+    expect(canOfferResumeWithCodeRestore("   ")).toBe(false);
+  });
+
+  it("offers when path present and git unknown or available", () => {
+    expect(canOfferResumeWithCodeRestore("/repo")).toBe(true);
+    expect(
+      canOfferResumeWithCodeRestore("/repo", { gitAvailable: true }),
+    ).toBe(true);
+    expect(
+      canOfferResumeWithCodeRestore("/repo", { gitAvailable: null }),
+    ).toBe(true);
+  });
+
+  it("hides when known non-git", () => {
+    expect(
+      canOfferResumeWithCodeRestore("/repo", { gitAvailable: false }),
+    ).toBe(false);
+  });
+});
+
+describe("buildResumeWorktreeName", () => {
+  it("builds a stable sanitize-safe name", () => {
+    const name = buildResumeWorktreeName("a1b2c3d4-eeee-ffff", {
+      now: 1_700_000_000_000,
+      attempt: 0,
+    });
+    expect(name).toMatch(/^resume-a1b2c3d4-[a-z0-9]+$/);
+    expect(name.length).toBeLessThanOrEqual(64);
+    expect(name.startsWith("-")).toBe(false);
+  });
+
+  it("includes attempt suffix when retrying", () => {
+    const name = buildResumeWorktreeName("session-id", {
+      now: 42,
+      attempt: 2,
+    });
+    expect(name).toContain("-2");
+    expect(name.startsWith("resume-")).toBe(true);
+  });
+
+  it("falls back when session id is empty", () => {
+    const name = buildResumeWorktreeName("", { now: 99, attempt: 0 });
+    expect(name.startsWith("resume-chat-")).toBe(true);
+  });
+});
+
+describe("shouldCaptureBaselineCommit", () => {
+  it("captures when clean, available, and no stored baseline", () => {
+    expect(
+      shouldCaptureBaselineCommit({
+        storedCommit: null,
+        gitAvailable: true,
+        status: { available: true, files: [] },
+      }),
+    ).toEqual({ capture: true });
+  });
+
+  it("skips when a baseline is already stored", () => {
+    expect(
+      shouldCaptureBaselineCommit({
+        storedCommit: "abc123",
+        gitAvailable: true,
+        status: { available: true, files: [] },
+      }),
+    ).toEqual({ capture: false, reason: "has_stored" });
+  });
+
+  it("skips when dirty or git unavailable", () => {
+    expect(
+      shouldCaptureBaselineCommit({
+        status: { available: true, files: [{ path: "a" }] },
+      }),
+    ).toEqual({ capture: false, reason: "unsafe" });
+    expect(
+      shouldCaptureBaselineCommit({
+        gitAvailable: false,
+        status: { available: true, files: [] },
+      }),
+    ).toEqual({ capture: false, reason: "unsafe" });
+    expect(
+      shouldCaptureBaselineCommit({
+        status: { available: false },
+      }),
+    ).toEqual({ capture: false, reason: "unsafe" });
+  });
+});

--- a/src/lib/sessionResumeRestore.ts
+++ b/src/lib/sessionResumeRestore.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure helpers for “Resume with code restore” (open existing session on a
+ * clean git worktree). Reuses the fork dirty-gate so uncommitted work is never
+ * force-checked out. Host/UI create the worktree + rebind project; helpers
+ * stay I/O-free.
+ *
+ * CLI analogy: `--resume` / `--continue` + optional `--restore-code` — agent
+ * session continuity stays on the App journal / agentSessionId; restore-code
+ * is the workspace isolation path (sibling worktree at HEAD).
+ */
+
+import { sanitizeWorktreeName } from "@/lib/gitWorktree";
+import {
+  canRestoreCodeOnFork,
+  isGitWorkingTreeDirty,
+  sanitizeForkNameFragment,
+  type ForkGitStatusSnapshot,
+  type ForkRestoreCodeGate,
+} from "@/lib/sessionFork";
+
+export type { ForkGitStatusSnapshot as ResumeGitStatusSnapshot };
+export type ResumeCodeRestoreGate = ForkRestoreCodeGate;
+
+/** Re-export dirty check used by both fork and resume restore-code paths. */
+export { isGitWorkingTreeDirty };
+
+/**
+ * Gate for restore-code on resume (same rules as fork):
+ * - no_project: chat has no bound folder
+ * - unavailable: not a git work tree / git missing
+ * - dirty: uncommitted changes — never force checkout / destroy work
+ */
+export function canRestoreCodeOnResume(
+  projectPath: string | null | undefined,
+  status: ForkGitStatusSnapshot | null | undefined,
+): ResumeCodeRestoreGate {
+  return canRestoreCodeOnFork(projectPath, status);
+}
+
+/**
+ * Whether the session menu / palette should offer “Resume with code restore…”.
+ * Needs a bound project path. When `gitAvailable === false`, hide (known
+ * non-git). When unknown, show optimistically and gate at run time.
+ */
+export function canOfferResumeWithCodeRestore(
+  projectPath: string | null | undefined,
+  opts?: { gitAvailable?: boolean | null },
+): boolean {
+  const path = (projectPath ?? "").trim();
+  if (!path) return false;
+  if (opts?.gitAvailable === false) return false;
+  return true;
+}
+
+/**
+ * Unique-ish worktree / branch name for a resume restore:
+ *   `resume-<sessionFrag>-<base36time>[-<attempt>]`
+ *
+ * Safe for `git worktree add -b` via {@link sanitizeWorktreeName}.
+ */
+export function buildResumeWorktreeName(
+  sourceSessionId: string | null | undefined,
+  opts?: { attempt?: number; now?: number },
+): string {
+  const frag = sanitizeForkNameFragment(sourceSessionId, 8);
+  const now = opts?.now ?? Date.now();
+  const attempt = Math.max(0, opts?.attempt ?? 0);
+  const time = Math.abs(now).toString(36);
+  let candidate =
+    attempt > 0
+      ? `resume-${frag}-${time}-${attempt}`
+      : `resume-${frag}-${time}`;
+  if (candidate.length > 64) {
+    candidate = candidate.slice(0, 64).replace(/-+$/, "") || `resume-${time}`;
+  }
+  if (candidate.startsWith("-")) {
+    candidate = `resume${candidate}`;
+  }
+  return sanitizeWorktreeName(candidate);
+}
+
+/**
+ * Whether it is safe to record HEAD as a baseline commit at restore time.
+ * MVP: capture only when git is available, tree is clean, and no prior
+ * baseline is stored. Pure decision — caller reads/writes storage.
+ */
+export function shouldCaptureBaselineCommit(input: {
+  storedCommit?: string | null;
+  gitAvailable?: boolean | null;
+  status?: ForkGitStatusSnapshot | null;
+}): { capture: true } | { capture: false; reason: "has_stored" | "unsafe" } {
+  const stored = (input.storedCommit ?? "").trim();
+  if (stored) return { capture: false, reason: "has_stored" };
+  if (input.gitAvailable === false) return { capture: false, reason: "unsafe" };
+  if (!input.status?.available) return { capture: false, reason: "unsafe" };
+  if (isGitWorkingTreeDirty(input.status)) {
+    return { capture: false, reason: "unsafe" };
+  }
+  return { capture: true };
+}


### PR DESCRIPTION
## Summary

- **Resume with code restore…** in the session context menu (when the chat is bound to a project / git-capable path) and the command palette
- Reuses the fork restore-code dirty gate: dirty working tree → refuse with toast; clean → create a sibling worktree at current HEAD (`resume-<id>-…`), `project_add`, rebind the **existing** session via `session_set_project` + worktree meta, open it
- Does **not** clone the journal (unlike Fork); agent continuity stays on the same App session / `agentSessionId` (`--resume` / `--continue` semantics)
- Pure helpers + unit tests (`sessionResumeRestore.ts`); i18n en / zh / zh-TW; CHANGELOG

## How it works

1. User picks **Resume with code restore…** (sidebar menu or palette).
2. GlassModal confirm explains isolation on a clean worktree at HEAD.
3. On confirm: `git_status` → dirty / no project / non-git → toast and stay put; clean → `git_worktree_add` → bind this session to the new path → open chat.
4. Never force-checkouts the live working tree.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (1585 passed), including `sessionResumeRestore.test.ts` + i18n + palette catalog
- [ ] Manual: non-git / no project session → menu item hidden or toast
- [ ] Manual: dirty tree → refuse toast
- [ ] Manual: clean git project → sibling worktree + same chat rebound and opened