### PR TITLE
feat(agent): disallow selected built-in tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ See `docs/llm-wiki/release.md`.
 
 #### Tasks / system
 - Tasks tree · Stop-all skip-confirm · Plan history · Mirror write guard · Reliability / Leader / Memory / MCP / CLI notice (prior)
+- **Disallowed built-in tools** (Settings → General → Agent): chips + freeform list → `AppSettings.disallowedTools` / CLI `--disallowed-tools a,b`; coexists with Disable web search; soft-respawn on change
 
 ### Fixed
 
@@ -43,6 +44,7 @@ See `docs/llm-wiki/release.md`.
 - **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片、结构化 JSON 回复面板、上下文用量/费用粗估
 - **会话/侧栏**：复制 vs 分叉、恢复并还原代码（干净 worktree）、便签、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标
+- **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）
 
 **中文 · 修复**
 

--- a/docs/llm-wiki/catalog.md
+++ b/docs/llm-wiki/catalog.md
@@ -50,6 +50,17 @@ Spawn：`--reasoning-effort <id>`。无模型级默认时 App 默认 **`medium`*
 2. 中途切换：优先 `set_mode`；失败则 soft-respawn。  
 3. 按 `composerPrefsScope` 记忆。
 
+## 禁用内置工具（disallowed tools）
+
+| App 设置 | Spawn | 说明 |
+|----------|-------|------|
+| `disableWebSearch` | top-level `--disable-web-search` | 移除 `web_search` / `web_fetch` |
+| `disallowedTools: string[]` | top-level `--disallowed-tools a,b` | 逗号分隔 tool id denylist |
+
+两者**并存**：网页开关不写入 `disallowedTools` 数组，但 UI 把 web 工具视为已覆盖；纯 helper `effectiveDisallowedTools` 可合并展示。常见芯片：`web_search` · `web_fetch` · `run_terminal_command`（caution）· `search_replace` · `write` · `Agent` · `spawn_subagent`；另支持 freeform 逗号列表。
+
+更改后 soft-respawn（`settings_spawn`）。源码：`src/lib/disallowedTools.ts`、Host `AppSettings.disallowed_tools`、`acp_client::disallowed_tools_spawn_flags`。
+
 ## 权限（含 YOLO）
 
 | App ID | Agent 配置 `[ui] permission_mode` | Claude `defaultMode` | Spawn |

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -362,6 +362,52 @@ pub fn disable_web_search_spawn_flags(disable: bool) -> Vec<&'static str> {
     }
 }
 
+/// Normalize tool ids for `--disallowed-tools`: trim, drop empty, dedupe
+/// case-insensitively (first spelling wins).
+pub fn normalize_disallowed_tools(tools: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for raw in tools {
+        for piece in raw.split(',') {
+            let t = piece.trim();
+            if t.is_empty() {
+                continue;
+            }
+            let key = t.to_ascii_lowercase();
+            if seen.contains(&key) {
+                continue;
+            }
+            seen.insert(key);
+            out.push(t.to_string());
+        }
+    }
+    out
+}
+
+/// Spawn argv for denylist: `["--disallowed-tools", "a,b"]` or empty.
+pub fn disallowed_tools_spawn_flags(tools: &[String]) -> Vec<String> {
+    let cleaned = normalize_disallowed_tools(tools);
+    if cleaned.is_empty() {
+        return Vec::new();
+    }
+    vec!["--disallowed-tools".into(), cleaned.join(",")]
+}
+
+/// Order-independent, case-insensitive equality for soft-respawn flip checks.
+pub fn disallowed_tools_equal(a: &[String], b: &[String]) -> bool {
+    let mut aa: Vec<String> = normalize_disallowed_tools(a)
+        .into_iter()
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
+    let mut bb: Vec<String> = normalize_disallowed_tools(b)
+        .into_iter()
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
+    aa.sort();
+    bb.sort();
+    aa == bb
+}
+
 pub fn no_plan_spawn_flags(plan_enabled: bool) -> Vec<&'static str> {
     if plan_enabled {
         vec![]
@@ -517,6 +563,7 @@ impl AcpClient {
         let use_leader = settings.use_leader;
         let plan_enabled = settings.plan_enabled;
         let disable_web = settings.disable_web_search;
+        let disallowed_tools = settings.disallowed_tools.clone();
 
         if session_data_mode != "shared" {
             let _ = crate::agent_subagents::sync_subagents_to_agent_profile(
@@ -553,6 +600,9 @@ impl AcpClient {
         }
         for f in disable_web_search_spawn_flags(disable_web) {
             cmd.arg(f);
+        }
+        for a in disallowed_tools_spawn_flags(&disallowed_tools) {
+            cmd.arg(a);
         }
         for f in no_plan_spawn_flags(plan_enabled) {
             cmd.arg(f);
@@ -3214,6 +3264,59 @@ mod prompt_wait_timeout_tests {
             prompt_wait_should_timeout(Some(last), started, now, idle(), absolute()),
             Some("absolute")
         );
+    }
+}
+
+#[cfg(test)]
+mod disallowed_tools_spawn_tests {
+    use super::*;
+
+    #[test]
+    fn empty_yields_no_flags() {
+        assert!(disallowed_tools_spawn_flags(&[]).is_empty());
+        assert!(disallowed_tools_spawn_flags(&["".into(), "  ".into()]).is_empty());
+    }
+
+    #[test]
+    fn builds_comma_separated_flag() {
+        let args = disallowed_tools_spawn_flags(&[
+            "  web_search  ".into(),
+            "write".into(),
+            "web_search".into(),
+        ]);
+        assert_eq!(
+            args,
+            vec![
+                "--disallowed-tools".to_string(),
+                "web_search,write".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn splits_embedded_commas_and_dedupes_case_insensitively() {
+        let cleaned = normalize_disallowed_tools(&[
+            "Web_Search,write".into(),
+            "WEB_SEARCH".into(),
+            "Agent".into(),
+        ]);
+        assert_eq!(
+            cleaned,
+            vec![
+                "Web_Search".to_string(),
+                "write".to_string(),
+                "Agent".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn equality_is_order_and_case_insensitive() {
+        assert!(disallowed_tools_equal(
+            &["a".into(), "b".into()],
+            &["B".into(), "A".into()]
+        ));
+        assert!(!disallowed_tools_equal(&["a".into()], &["a".into(), "b".into()]));
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -783,12 +783,20 @@ pub async fn settings_set(
     settings: AppSettings,
 ) -> Result<AppSettings, String> {
     let prev = store::load_settings();
+    let mut settings = settings;
+    // Normalize denylist so spawn / equality see a stable list.
+    settings.disallowed_tools =
+        crate::acp_client::normalize_disallowed_tools(&settings.disallowed_tools);
     let keychain_flip =
         prev.store_api_keys_in_keychain != settings.store_api_keys_in_keychain;
     let session_data_mode_changed =
         prev.session_data_mode != settings.session_data_mode;
     let memory_flip = prev.experimental_memory != settings.experimental_memory;
     let web_search_flip = prev.disable_web_search != settings.disable_web_search;
+    let disallowed_tools_flip = !crate::acp_client::disallowed_tools_equal(
+        &prev.disallowed_tools,
+        &settings.disallowed_tools,
+    );
     let plan_enabled_flip = prev.plan_enabled != settings.plan_enabled;
     let use_leader_changed = prev.use_leader != settings.use_leader;
     let subagents_flip = prev.subagents_enabled != settings.subagents_enabled;
@@ -851,6 +859,7 @@ pub async fn settings_set(
         need_soft_respawn = true;
     }
     if web_search_flip
+        || disallowed_tools_flip
         || plan_enabled_flip
         || use_leader_changed
         || preferred_agent_flip

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -227,6 +227,11 @@ pub struct AppSettings {
     /// `web_search` / `web_fetch` tools are removed. Default false (CLI default).
     #[serde(default)]
     pub disable_web_search: bool,
+    /// Built-in tool ids to deny via top-level `grok --disallowed-tools a,b`.
+    /// Default empty (CLI default — all tools available). Coexists with
+    /// [`Self::disable_web_search`]; changing the list soft-respawns agents.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disallowed_tools: Vec<String>,
     /// Reopen the last active chat once after launch (default **false** —
     /// start on a draft new-chat page; opt-in via Settings).
     #[serde(default = "default_reopen_last_session")]
@@ -383,6 +388,7 @@ impl Default for AppSettings {
             experimental_memory: false,
             max_agent_turns: None,
             disable_web_search: false,
+            disallowed_tools: Vec::new(),
             reopen_last_session: default_reopen_last_session(),
             last_session_id: None,
             last_project_id: None,
@@ -1992,6 +1998,7 @@ mod tests {
         assert!(!s.experimental_memory);
         assert_eq!(s.max_agent_turns, None);
         assert!(!s.disable_web_search);
+        assert!(s.disallowed_tools.is_empty());
         assert!(s.plan_enabled);
         assert!(s.subagents_enabled);
         assert_eq!(s.preferred_agent, "");
@@ -2070,6 +2077,25 @@ mod tests {
     fn disable_web_search_defaults_when_missing_from_json() {
         let s: AppSettings = serde_json::from_str(legacy_settings_json()).expect("deserialize");
         assert!(!s.disable_web_search);
+    }
+
+    #[test]
+    fn disallowed_tools_defaults_empty_when_missing_from_json() {
+        let s: AppSettings = serde_json::from_str(legacy_settings_json()).expect("deserialize");
+        assert!(s.disallowed_tools.is_empty());
+    }
+
+    #[test]
+    fn disallowed_tools_round_trips_camel_case() {
+        let mut s = AppSettings::default();
+        s.disallowed_tools = vec!["web_search".into(), "write".into()];
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert!(json.contains("\"disallowedTools\""));
+        let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            back.disallowed_tools,
+            vec!["web_search".to_string(), "write".to_string()]
+        );
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1953,6 +1953,7 @@ export default function App() {
   const [subagentsEnabled, setSubagentsEnabled] = useState(true);
   const [planEnabled, setPlanEnabled] = useState(true);
   const [disableWebSearch, setDisableWebSearch] = useState(false);
+  const [disallowedTools, setDisallowedTools] = useState<string[]>([]);
   const [useLeader, setUseLeader] = useState(false);
   /** Default off → launch on draft new-chat page. */
   const [reopenLastSession, setReopenLastSession] = useState(false);
@@ -2702,6 +2703,13 @@ export default function App() {
       setSubagentsEnabled(settings.subagentsEnabled !== false);
       setPlanEnabled(settings.planEnabled !== false);
       setDisableWebSearch(!!settings.disableWebSearch);
+      setDisallowedTools(
+        Array.isArray(settings.disallowedTools)
+          ? settings.disallowedTools.filter(
+              (x): x is string => typeof x === "string",
+            )
+          : [],
+      );
       setUseLeader(!!settings.useLeader);
       // Opt-in only (missing key / false → draft new chat on launch).
       setReopenLastSession(settings.reopenLastSession === true);
@@ -13023,6 +13031,13 @@ export default function App() {
             setDisableWebSearch(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, disableWebSearch: v }),
+            );
+          }}
+          disallowedTools={disallowedTools}
+          onDisallowedTools={(v) => {
+            setDisallowedTools(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, disallowedTools: v }),
             );
           }}
           useLeader={useLeader}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -42,6 +42,14 @@ import {
 } from "@/lib/cliSessionsFilter";
 import { ARCHIVE_AGE_DAY_OPTIONS } from "@/lib/sessionArchiveAge";
 import {
+  COMMON_DISALLOWED_TOOLS,
+  isToolDisallowed,
+  isWebSearchTool,
+  normalizeDisallowedTools,
+  parseDisallowedToolsInput,
+  toggleDisallowedTool,
+} from "@/lib/disallowedTools";
+import {
   SHORTCUTS,
   detectShortcutPlatform,
   filterShortcutGroups,
@@ -392,6 +400,9 @@ export interface SettingsPageProps {
   onExperimentalMemory?: (v: boolean) => void;
   disableWebSearch?: boolean;
   onDisableWebSearch?: (v: boolean) => void;
+  /** Built-in tool denylist (`--disallowed-tools`). */
+  disallowedTools?: string[];
+  onDisallowedTools?: (v: string[]) => void;
   reopenLastSession?: boolean;
   onReopenLastSession?: (v: boolean) => void;
   closeToTray?: boolean;
@@ -928,6 +939,8 @@ export function SettingsPage({
   onPlanEnabled,
   disableWebSearch = false,
   onDisableWebSearch,
+  disallowedTools = [],
+  onDisallowedTools,
   useLeader = false,
   onUseLeader,
   voiceId = "eve",
@@ -2300,6 +2313,120 @@ export function SettingsPage({
                     onChange={() => onDisableWebSearch(!disableWebSearch)}
                     ariaLabel={t("settings.disableWebSearch")}
                   />
+                </div>
+              ) : null}
+              {onDisallowedTools ? (
+                <div
+                  className={
+                    "settings-row settings-row--stack" +
+                    rowHighlight("settings-anchor-disallowedTools")
+                  }
+                  id="settings-anchor-disallowedTools"
+                >
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.disallowedTools")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.disallowedToolsDesc")}
+                    </div>
+                    {disableWebSearch ? (
+                      <div className="settings-row__hint">
+                        {t("settings.disallowedTools.webCovered")}
+                      </div>
+                    ) : null}
+                  </div>
+                  <div
+                    className="settings-tool-deny__chips"
+                    role="group"
+                    aria-label={t("settings.disallowedTools")}
+                  >
+                    {COMMON_DISALLOWED_TOOLS.map((tool) => {
+                      const selected =
+                        isToolDisallowed(disallowedTools, tool.id) ||
+                        (!!disableWebSearch && isWebSearchTool(tool.id));
+                      const coveredByWeb =
+                        !!disableWebSearch && isWebSearchTool(tool.id);
+                      return (
+                        <button
+                          key={tool.id}
+                          type="button"
+                          className={
+                            "settings-tool-deny__chip" +
+                            (selected ? " is-on" : "") +
+                            (tool.caution ? " is-caution" : "") +
+                            (coveredByWeb ? " is-covered" : "")
+                          }
+                          aria-pressed={selected}
+                          title={
+                            tool.caution
+                              ? t("settings.disallowedTools.caution")
+                              : coveredByWeb
+                                ? t("settings.disallowedTools.webCovered")
+                                : tool.id
+                          }
+                          onClick={() => {
+                            if (coveredByWeb) return;
+                            onDisallowedTools(
+                              toggleDisallowedTool(disallowedTools, tool.id),
+                            );
+                          }}
+                        >
+                          {tool.id}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <div className="settings-tool-deny__row">
+                    <input
+                      type="text"
+                      className="settings-input settings-tool-deny__input"
+                      placeholder={t("settings.disallowedToolsPlaceholder")}
+                      defaultValue={normalizeDisallowedTools(disallowedTools)
+                        .filter(
+                          (id) =>
+                            !COMMON_DISALLOWED_TOOLS.some(
+                              (c) => c.id.toLowerCase() === id.toLowerCase(),
+                            ),
+                        )
+                        .join(", ")}
+                      key={normalizeDisallowedTools(disallowedTools)
+                        .filter(
+                          (id) =>
+                            !COMMON_DISALLOWED_TOOLS.some(
+                              (c) => c.id.toLowerCase() === id.toLowerCase(),
+                            ),
+                        )
+                        .join(",")}
+                      onBlur={(e) => {
+                        const custom = parseDisallowedToolsInput(e.target.value);
+                        const keptCommon = normalizeDisallowedTools(
+                          disallowedTools,
+                        ).filter((id) =>
+                          COMMON_DISALLOWED_TOOLS.some(
+                            (c) => c.id.toLowerCase() === id.toLowerCase(),
+                          ),
+                        );
+                        onDisallowedTools(
+                          normalizeDisallowedTools([...keptCommon, ...custom]),
+                        );
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          (e.target as HTMLInputElement).blur();
+                        }
+                      }}
+                    />
+                    {normalizeDisallowedTools(disallowedTools).length > 0 ? (
+                      <button
+                        type="button"
+                        className="btn btn--sm settings-tool-deny__clear"
+                        onClick={() => onDisallowedTools([])}
+                      >
+                        {t("settings.disallowedTools.clear")}
+                      </button>
+                    ) : null}
+                  </div>
                 </div>
               ) : null}
               {onUseLeader ? (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1123,6 +1123,15 @@ const en = {
   "settings.disableWebSearch": "Disable web search & fetch",
   "settings.disableWebSearchDesc":
     "Spawn agents with --disable-web-search so web_search and web_fetch tools are unavailable. Live agents soft-respawn when this changes.",
+  "settings.disallowedTools": "Disallowed tools",
+  "settings.disallowedToolsDesc":
+    "Remove selected built-in tools via --disallowed-tools. Coexists with Disable web search. Live agents soft-respawn when this changes.",
+  "settings.disallowedToolsPlaceholder":
+    "Extra tool ids, comma-separated (e.g. bash,grep)",
+  "settings.disallowedTools.caution": "Caution: blocks shell / coding tools",
+  "settings.disallowedTools.clear": "Clear all",
+  "settings.disallowedTools.webCovered":
+    "web_search / web_fetch also blocked by Disable web search above",
     "settings.section.agent": "Agent",
   "settings.subagentsEnabled": "Allow subagents",
   "settings.subagentsEnabledDesc": "When off, spawn with --no-subagents so nested Agent / task tools cannot start child sessions. Soft-respawns after change.",
@@ -3917,6 +3926,15 @@ const zh: Record<MessageKey, string> = {
   "settings.disableWebSearch": "禁用网页搜索与抓取",
   "settings.disableWebSearchDesc":
     "启动 Agent 时加上 --disable-web-search，移除 web_search / web_fetch 工具。更改后会 soft-respawn 已连接的 Agent。",
+  "settings.disallowedTools": "禁用内置工具",
+  "settings.disallowedToolsDesc":
+    "通过 --disallowed-tools 移除所选内置工具。可与上方「禁用网页搜索」并存。更改后会 soft-respawn。",
+  "settings.disallowedToolsPlaceholder":
+    "额外工具 id，逗号分隔（如 bash,grep）",
+  "settings.disallowedTools.caution": "注意：会屏蔽终端 / 编码类工具",
+  "settings.disallowedTools.clear": "全部清除",
+  "settings.disallowedTools.webCovered":
+    "web_search / web_fetch 也受上方「禁用网页搜索」约束",
     "settings.section.agent": "Agent",
   "settings.subagentsEnabled": "允许子代理",
   "settings.subagentsEnabledDesc": "关闭时启动加上 --no-subagents，无法拉起嵌套 Agent / 任务。更改后 soft-respawn。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1070,6 +1070,15 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.disableWebSearch": "停用網頁搜尋與抓取",
   "settings.disableWebSearchDesc":
     "啟動 Agent 時加上 --disable-web-search，移除 web_search / web_fetch 工具。變更後會 soft-respawn 已連線的 Agent。",
+  "settings.disallowedTools": "停用內建工具",
+  "settings.disallowedToolsDesc":
+    "透過 --disallowed-tools 移除所選內建工具。可與上方「停用網頁搜尋」並存。變更後會 soft-respawn。",
+  "settings.disallowedToolsPlaceholder":
+    "額外工具 id，逗號分隔（如 bash,grep）",
+  "settings.disallowedTools.caution": "注意：會封鎖終端機 / 編碼類工具",
+  "settings.disallowedTools.clear": "全部清除",
+  "settings.disallowedTools.webCovered":
+    "web_search / web_fetch 也受上方「停用網頁搜尋」約束",
     "settings.section.agent": "Agent",
   "settings.subagentsEnabled": "允許子代理",
   "settings.subagentsEnabledDesc": "關閉時啟動加上 --no-subagents，無法拉起巢狀 Agent / 任務。變更後 soft-respawn。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1102,6 +1102,11 @@ export interface AppSettings {
   preferredAgent?: string;
   experimentalMemory?: boolean;
   disableWebSearch?: boolean;
+  /**
+   * Built-in tool ids denied via CLI `--disallowed-tools a,b`.
+   * Default empty. Coexists with `disableWebSearch`; changes soft-respawn.
+   */
+  disallowedTools?: string[];
   planEnabled?: boolean;
   subagentsEnabled?: boolean;
   useLeader?: boolean;

--- a/src/lib/disallowedTools.test.ts
+++ b/src/lib/disallowedTools.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMMON_DISALLOWED_TOOLS,
+  WEB_SEARCH_TOOLS,
+  disallowedToolsCliValue,
+  disallowedToolsEqual,
+  disallowedToolsSpawnArgs,
+  effectiveDisallowedTools,
+  isToolDisallowed,
+  isWebSearchTool,
+  normalizeDisallowedTools,
+  normalizeToolId,
+  parseDisallowedToolsInput,
+  toggleDisallowedTool,
+} from "./disallowedTools";
+
+describe("normalizeToolId", () => {
+  it("trims and rejects empty / non-string", () => {
+    expect(normalizeToolId("  web_search  ")).toBe("web_search");
+    expect(normalizeToolId("")).toBeNull();
+    expect(normalizeToolId("   ")).toBeNull();
+    expect(normalizeToolId(null)).toBeNull();
+    expect(normalizeToolId(undefined)).toBeNull();
+    expect(normalizeToolId(42)).toBeNull();
+  });
+});
+
+describe("normalizeDisallowedTools", () => {
+  it("accepts arrays and comma-separated strings", () => {
+    expect(normalizeDisallowedTools(["web_search", "  write  "])).toEqual([
+      "web_search",
+      "write",
+    ]);
+    expect(normalizeDisallowedTools("web_search, write, Agent")).toEqual([
+      "web_search",
+      "write",
+      "Agent",
+    ]);
+  });
+
+  it("dedupes case-insensitively, keeping first spelling", () => {
+    expect(
+      normalizeDisallowedTools(["Web_Search", "web_search", "WRITE", "write"]),
+    ).toEqual(["Web_Search", "WRITE"]);
+  });
+
+  it("splits embedded commas in array items", () => {
+    expect(normalizeDisallowedTools(["a,b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns empty for nullish / garbage", () => {
+    expect(normalizeDisallowedTools(null)).toEqual([]);
+    expect(normalizeDisallowedTools(undefined)).toEqual([]);
+    expect(normalizeDisallowedTools(true)).toEqual([]);
+    expect(normalizeDisallowedTools("")).toEqual([]);
+    expect(normalizeDisallowedTools([""])).toEqual([]);
+  });
+});
+
+describe("parseDisallowedToolsInput", () => {
+  it("parses freeform input", () => {
+    expect(parseDisallowedToolsInput("  web_search,run_terminal_command , ")).toEqual(
+      ["web_search", "run_terminal_command"],
+    );
+  });
+});
+
+describe("effectiveDisallowedTools + disableWebSearch coherence", () => {
+  it("leaves list alone when disableWebSearch is off", () => {
+    expect(effectiveDisallowedTools(["write"], false)).toEqual(["write"]);
+    expect(effectiveDisallowedTools([], false)).toEqual([]);
+  });
+
+  it("injects web tools when disableWebSearch is on", () => {
+    expect(effectiveDisallowedTools(["write"], true)).toEqual([
+      "write",
+      "web_search",
+      "web_fetch",
+    ]);
+    expect(effectiveDisallowedTools([], true)).toEqual([
+      "web_search",
+      "web_fetch",
+    ]);
+  });
+
+  it("does not duplicate web tools already present", () => {
+    expect(
+      effectiveDisallowedTools(["web_search", "web_fetch", "write"], true),
+    ).toEqual(["web_search", "web_fetch", "write"]);
+  });
+});
+
+describe("disallowedToolsCliValue / spawnArgs", () => {
+  it("omits flag when empty", () => {
+    expect(disallowedToolsCliValue([])).toBeNull();
+    expect(disallowedToolsSpawnArgs([])).toEqual([]);
+  });
+
+  it("builds comma-separated CLI value", () => {
+    expect(disallowedToolsCliValue(["web_search", "write"])).toBe(
+      "web_search,write",
+    );
+    expect(disallowedToolsSpawnArgs(["web_search", "write"])).toEqual([
+      "--disallowed-tools",
+      "web_search,write",
+    ]);
+  });
+
+  it("can merge disableWebSearch into spawn args", () => {
+    expect(disallowedToolsCliValue(["write"], true)).toBe(
+      "write,web_search,web_fetch",
+    );
+    expect(disallowedToolsSpawnArgs([], true)).toEqual([
+      "--disallowed-tools",
+      "web_search,web_fetch",
+    ]);
+  });
+});
+
+describe("toggle / membership", () => {
+  it("toggles tools case-insensitively", () => {
+    const a = toggleDisallowedTool([], "web_search");
+    expect(a).toEqual(["web_search"]);
+    expect(isToolDisallowed(a, "WEB_SEARCH")).toBe(true);
+    const b = toggleDisallowedTool(a, "Web_Search");
+    expect(b).toEqual([]);
+  });
+
+  it("preserves existing spelling when removing via different case", () => {
+    expect(toggleDisallowedTool(["Agent", "write"], "agent")).toEqual([
+      "write",
+    ]);
+  });
+});
+
+describe("disallowedToolsEqual", () => {
+  it("compares order- and case-insensitively", () => {
+    expect(disallowedToolsEqual(["a", "b"], ["B", "A"])).toBe(true);
+    expect(disallowedToolsEqual(["a"], ["a", "b"])).toBe(false);
+    expect(disallowedToolsEqual(null, [])).toBe(true);
+  });
+});
+
+describe("catalog constants", () => {
+  it("exposes common chips and web tools", () => {
+    expect(WEB_SEARCH_TOOLS).toEqual(["web_search", "web_fetch"]);
+    expect(COMMON_DISALLOWED_TOOLS.map((t) => t.id)).toContain(
+      "run_terminal_command",
+    );
+    expect(
+      COMMON_DISALLOWED_TOOLS.find((t) => t.id === "run_terminal_command")
+        ?.caution,
+    ).toBe(true);
+    expect(isWebSearchTool("web_fetch")).toBe(true);
+    expect(isWebSearchTool("write")).toBe(false);
+  });
+});

--- a/src/lib/disallowedTools.ts
+++ b/src/lib/disallowedTools.ts
@@ -1,0 +1,174 @@
+/**
+ * Disallowed built-in tools → CLI `--disallowed-tools` (comma-separated).
+ *
+ * Coherent with `settings.disableWebSearch`: when that toggle is on, the
+ * effective denylist always includes `web_search` / `web_fetch` (also mirrored
+ * by the dedicated `--disable-web-search` spawn flag).
+ */
+
+/** Tools blocked by the dedicated disable-web-search setting. */
+export const WEB_SEARCH_TOOLS = ["web_search", "web_fetch"] as const;
+
+export type WebSearchToolId = (typeof WEB_SEARCH_TOOLS)[number];
+
+export type CommonDisallowedTool = {
+  /** CLI tool id (passed to `--disallowed-tools`). */
+  id: string;
+  /**
+   * When true, UI may show a caution affordance (e.g. shell tools that break
+   * most coding workflows when denied).
+   */
+  caution?: boolean;
+};
+
+/**
+ * Common built-in tools offered as chips in Settings.
+ * `run_terminal_command` is marked caution — denying it is powerful but
+ * cripples normal agent work.
+ */
+export const COMMON_DISALLOWED_TOOLS: readonly CommonDisallowedTool[] = [
+  { id: "web_search" },
+  { id: "web_fetch" },
+  { id: "run_terminal_command", caution: true },
+  { id: "search_replace" },
+  { id: "write" },
+  { id: "Agent" },
+  { id: "spawn_subagent" },
+] as const;
+
+/** Trim a single tool id. Empty → null. */
+export function normalizeToolId(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") return null;
+  const t = raw.trim();
+  return t ? t : null;
+}
+
+/**
+ * Normalize a list (or comma-separated string) of tool ids:
+ * trim, drop empties, dedupe case-insensitively (first spelling wins).
+ */
+export function normalizeDisallowedTools(raw: unknown): string[] {
+  const parts: string[] = [];
+  if (raw == null) return parts;
+  if (typeof raw === "string") {
+    for (const piece of raw.split(",")) {
+      const n = normalizeToolId(piece);
+      if (n) parts.push(n);
+    }
+  } else if (Array.isArray(raw)) {
+    for (const item of raw) {
+      if (typeof item === "string" && item.includes(",")) {
+        for (const piece of item.split(",")) {
+          const n = normalizeToolId(piece);
+          if (n) parts.push(n);
+        }
+      } else {
+        const n = normalizeToolId(item);
+        if (n) parts.push(n);
+      }
+    }
+  } else {
+    return parts;
+  }
+
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const id of parts) {
+    const key = id.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(id);
+  }
+  return out;
+}
+
+/** Parse a freeform comma-separated input into a normalized list. */
+export function parseDisallowedToolsInput(raw: string | null | undefined): string[] {
+  return normalizeDisallowedTools(raw ?? "");
+}
+
+/**
+ * Effective denylist for UI / spawn coherence:
+ * when `disableWebSearch` is true, ensure web tools are present.
+ */
+export function effectiveDisallowedTools(
+  tools: unknown,
+  disableWebSearch?: boolean,
+): string[] {
+  const base = normalizeDisallowedTools(tools);
+  if (!disableWebSearch) return base;
+  const seen = new Set(base.map((t) => t.toLowerCase()));
+  const out = [...base];
+  for (const w of WEB_SEARCH_TOOLS) {
+    if (!seen.has(w)) {
+      out.push(w);
+      seen.add(w);
+    }
+  }
+  return out;
+}
+
+/** Comma-separated value for `--disallowed-tools`, or null when empty. */
+export function disallowedToolsCliValue(
+  tools: unknown,
+  disableWebSearch?: boolean,
+): string | null {
+  const list =
+    disableWebSearch === undefined
+      ? normalizeDisallowedTools(tools)
+      : effectiveDisallowedTools(tools, disableWebSearch);
+  return list.length ? list.join(",") : null;
+}
+
+/** Spawn argv fragments: `["--disallowed-tools", "a,b"]` or `[]`. */
+export function disallowedToolsSpawnArgs(
+  tools: unknown,
+  disableWebSearch?: boolean,
+): string[] {
+  const v = disallowedToolsCliValue(tools, disableWebSearch);
+  return v ? ["--disallowed-tools", v] : [];
+}
+
+/** Case-insensitive membership check. */
+export function isToolDisallowed(tools: unknown, id: string): boolean {
+  const needle = normalizeToolId(id);
+  if (!needle) return false;
+  const key = needle.toLowerCase();
+  return normalizeDisallowedTools(tools).some((t) => t.toLowerCase() === key);
+}
+
+/** Toggle a tool id in/out of the list (normalized result). */
+export function toggleDisallowedTool(tools: unknown, id: string): string[] {
+  const list = normalizeDisallowedTools(tools);
+  const needle = normalizeToolId(id);
+  if (!needle) return list;
+  const key = needle.toLowerCase();
+  if (list.some((t) => t.toLowerCase() === key)) {
+    return list.filter((t) => t.toLowerCase() !== key);
+  }
+  return [...list, needle];
+}
+
+/**
+ * Whether two denylists are equivalent (order-independent, case-insensitive).
+ * Used for soft-respawn flip detection on the UI side.
+ */
+export function disallowedToolsEqual(a: unknown, b: unknown): boolean {
+  const aa = normalizeDisallowedTools(a)
+    .map((t) => t.toLowerCase())
+    .sort();
+  const bb = normalizeDisallowedTools(b)
+    .map((t) => t.toLowerCase())
+    .sort();
+  if (aa.length !== bb.length) return false;
+  return aa.every((v, i) => v === bb[i]);
+}
+
+/** True when `id` is one of the web tools blocked by disableWebSearch. */
+export function isWebSearchTool(id: string): boolean {
+  const n = normalizeToolId(id);
+  if (!n) return false;
+  const key = n.toLowerCase();
+  return (WEB_SEARCH_TOOLS as readonly string[]).some((w) => w === key);
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -487,6 +487,25 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     keywords: ["web search"],
   },
   {
+    id: "general.disallowedTools",
+    section: "general",
+    tab: "agent",
+    anchorId: "settings-anchor-disallowedTools",
+    labelKey: "settings.disallowedTools",
+    descKeys: [
+      "settings.disallowedToolsDesc",
+      "settings.disallowedTools.webCovered",
+    ],
+    keywords: [
+      "disallowed tools",
+      "deny tools",
+      "web_search",
+      "web_fetch",
+      "run_terminal_command",
+      "tool deny",
+    ],
+  },
+  {
     id: "general.useLeader",
     section: "general",
     tab: "agent",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4942,6 +4942,65 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   font-variant-numeric: tabular-nums;
 }
 
+/* Settings → Agent: disallowed built-in tools chips */
+.settings-tool-deny__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.settings-tool-deny__chip {
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+}
+
+.settings-tool-deny__chip:hover {
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--text-secondary) 35%, var(--border-subtle));
+}
+
+.settings-tool-deny__chip.is-on {
+  background: color-mix(in srgb, var(--accent, #6b8afd) 16%, var(--bg-elevated));
+  color: var(--text-primary);
+  font-weight: 600;
+  border-color: color-mix(in srgb, var(--accent, #6b8afd) 40%, var(--border-subtle));
+}
+
+.settings-tool-deny__chip.is-caution.is-on {
+  background: color-mix(in srgb, var(--danger, #e55) 14%, var(--bg-elevated));
+  border-color: color-mix(in srgb, var(--danger, #e55) 40%, var(--border-subtle));
+}
+
+.settings-tool-deny__chip.is-covered {
+  opacity: 0.72;
+  cursor: default;
+}
+
+.settings-tool-deny__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.settings-tool-deny__input {
+  flex: 1;
+  min-width: 160px;
+}
+
+.settings-tool-deny__clear {
+  flex-shrink: 0;
+}
+
 .settings-seg {
   display: inline-flex;
   padding: 3px;


### PR DESCRIPTION
## Summary

- Settings → General → Agent: chips + freeform list for built-in tool denylist (`web_search`, `web_fetch`, `run_terminal_command` caution, `search_replace`, `write`, `Agent`, `spawn_subagent`, plus custom ids)
- Persist `AppSettings.disallowedTools: string[]`; spawn injects top-level `--disallowed-tools a,b`
- Keep existing `disableWebSearch` / `--disable-web-search`; UI shows web tools as covered when that toggle is on
- Soft-respawn on denylist change; pure helper + tests (`src/lib/disallowedTools.ts`); i18n (en/zh/zh-TW); settings catalog search; catalog.md + CHANGELOG

## Test plan

- [x] `pnpm exec vitest run src/lib/disallowedTools.test.ts src/lib/settingsCatalog.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [x] `cargo test --lib disallowed_tools` (+ default settings store test)
- [ ] Manual: Settings → Agent → toggle chips / freeform → confirm soft-respawn toast and next agent spawn carries `--disallowed-tools`
- [ ] Manual: Disable web search alone still works; with denylist both flags coexist