### PR TITLE
feat(worktree): align new worktree sessions with CLI layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See `docs/llm-wiki/release.md`.
 - **Resume with code restore** — open an existing chat on a clean sibling git worktree at HEAD (session menu + command palette; dirty tree refused; same safety as Fork → restore code)
 - **Export** Markdown copy + **HTML export** · **bulk archive by age** · **date groups** · **project color**
 - **Sidebar j/k** navigation (when list focused)
+- **CLI-aligned worktrees**: create under `~/.grok/worktrees/<repo>/<name>` by default (matches `grok --worktree`); optional sibling layout; start-ref validation; sidebar **CLI** vs **WT** badge
 
 #### Appearance / app shell
 - **Theme schedule** (System + clock) · **follow system language**
@@ -41,7 +42,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 新增（按域）**
 
 - **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片、结构化 JSON 回复面板、上下文用量/费用粗估
-- **会话/侧栏**：复制 vs 分叉、恢复并还原代码（干净 worktree）、便签、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航
+- **会话/侧栏**：复制 vs 分叉、恢复并还原代码（干净 worktree）、便签、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标
 
 **中文 · 修复**

--- a/docs/llm-wiki/git-worktrees.md
+++ b/docs/llm-wiki/git-worktrees.md
@@ -1,6 +1,7 @@
 # Git worktrees
 
-Community request: [issue #42](https://github.com/RongleCat/grok-app/issues/42).
+Community request: [issue #42](https://github.com/RongleCat/grok-app/issues/42).  
+CLI alignment: Grok Build **0.2.114+** `--worktree` / `--worktree-ref` and `~/.grok/worktrees/`.
 
 ## Behavior
 
@@ -16,8 +17,11 @@ git worktree list --porcelain
 - **UI:** branch chip is hidden until host confirms `available: true` (non-git → no branch chip). Project menu no longer embeds worktrees.
 - **Create / remove / GC** live in the branch menu (not the project menu).
 - **Remove:** per-row trash on **non-main** linked worktrees → in-app confirm → host `git_worktree_remove` (force retry if dirty). Never removes main. Removing the active cwd switches to main. Use **GC** for stale admin records of folders already gone.
-- **Session badge:** worktree-bound chats show a compact **WT** chip in the sidebar. Meta is written when **New worktree & chat** creates the session (`worktreePath` / `worktreeBranch` / `isWorktreeSession` on `SessionMeta`). Fallback: if the session’s project path matches a **non-main** entry from `git worktree list`, badge without meta.
-- **Session menu (WT only):** Reveal worktree · Copy path · Remove worktree (same in-app confirm / force path as the branch menu). Apply/merge onto main is out of scope.
+- **Session badge:** worktree-bound chats show a compact chip in the sidebar:
+  - **`CLI`** — path under `~/.grok/worktrees/` (Grok Build CLI home layout)
+  - **`WT`** — sibling / other linked worktree
+  Meta is written when **New worktree & chat** creates the session (`worktreePath` / `worktreeBranch` / `isWorktreeSession` on `SessionMeta`). Fallback: if the session’s project path matches a **non-main** entry from `git worktree list`, badge without meta.
+- **Session menu (WT/CLI only):** Reveal worktree · Copy path · Remove worktree (same in-app confirm / force path as the branch menu). Apply/merge onto main is out of scope.
 
 ### Create worktree
 
@@ -26,11 +30,21 @@ From the branch / worktree menu:
 - **New worktree…** — create + bind current session/cwd to the new path.
 - **New worktree & chat…** — create, then open a **new session** whose project path is the worktree (agent cwd) and persist worktree meta on that session.
 
-1. User enters a **name** (required) and optional **start point** (branch / tag / commit).
+1. User enters a **name** (required), chooses **location** (default CLI home; optional sibling), and optional **start point** (branch / tag / commit — same idea as CLI `--worktree-ref` / `--ref`).
 2. Host runs `git worktree add -b <name> <path> [<start_point>]` with argv (no shell).
 3. On success: refresh the list, `project_add` with trust inherited from the source project when possible, then either bind the open session (and tag it) or `session_create` + `session_set_worktree` and open that session.
 
-**Path layout (sibling of main worktree):**
+**Path layout (default — CLI-aligned):**
+
+```text
+{GROK_HOME}/worktrees/<main_basename>/<name>
+```
+
+Example: main `/Users/me/Code/oss-grok-app` + name `feat` → `~/.grok/worktrees/oss-grok-app/feat`.
+
+This matches Grok Build 0.2.x (`grok --worktree=feat`, `grok worktree list` paths under `~/.grok/worktrees/<repo>/…`). `GROK_HOME` for placement is always the shared CLI home (`~/.grok`), not App independent agent-home — worktrees are filesystem layout shared with the terminal CLI.
+
+**Optional sibling layout:**
 
 ```text
 <main_parent>/<main_basename>-<name>
@@ -40,10 +54,12 @@ Example: main `/Users/me/repo` + name `feat` → `/Users/me/repo-feat`.
 
 | Choice | Why |
 |--------|-----|
-| **Sibling** `../<repo>-<name>` (preferred) | Matches common `git worktree add ../repo-feat` practice; checkouts sit next to the primary clone; same pattern as porcelain list samples. |
-| In-repo `.worktrees/<name>` | Avoided for create — keeps build/tooling ignore noise out of the main tree and matches sibling-first docs. |
+| **CLI home** `~/.grok/worktrees/<repo>/<name>` (**default**) | Aligns with Grok Build `--worktree` / subagent worktrees; keeps checkouts out of the project parent; same path family as `grok worktree list`. |
+| **Sibling** `../<repo>-<name>` | Classic `git worktree add ../repo-feat` practice when you want the tree next to the primary clone. |
+| In-repo `.worktrees/<name>` | Avoided for create — keeps build/tooling ignore noise out of the main tree. |
 
-Name rules: letters, digits, `.` `_` `-` only; max 64; no path separators; must not start with `-` (so it cannot look like a git flag).
+Name rules: letters, digits, `.` `_` `-` only; max 64; no path separators; must not start with `-` (so it cannot look like a git flag).  
+Start-point rules: optional; max 256; no NUL/newlines; must not start with `-`.
 
 Errors are shown when the folder is not a git repository, `git` is missing, the path already exists, or `git worktree add` fails (message surfaced in the dialog).
 
@@ -65,15 +81,16 @@ Menu action **Clean stale worktrees…** → GlassModal dry-run preview (`git wo
 - Full branch browser / remote fetch / same-directory `git checkout`
 - In-place checkout of an arbitrary local branch without a worktree
 - Apply / merge worktree branch back onto main from the session menu (open folder + remove only)
+- Registering App-created trees into the CLI `worktrees.db` index (git porcelain list is enough for switch/remove)
 
 ## Implementation
 
-- Host: `git_worktrees_list`, `git_worktree_add`, `git_worktree_remove`, `git_worktree_gc`, `session_set_worktree` (`src-tauri/src/commands.rs`) — argv only, no shell
+- Host: `git_worktrees_list` (includes `cliGrokHome`), `git_worktree_add` (`layout`: `cli` \| `sibling`), `git_worktree_remove`, `git_worktree_gc`, `session_set_worktree` (`src-tauri/src/commands.rs`) — argv only, no shell
 - Store: optional `SessionMeta.worktree_path` / `worktree_branch` / `is_worktree_session` (serde defaults; skip empty)
-- Pure path / name helpers: `sanitize_worktree_name`, `build_worktree_sibling_path` (+ unit tests)
-- Frontend pure helpers: `src/lib/gitWorktree.ts` — list/parse + `resolveSessionWorktreeBadge` / tooltip (+ unit tests)
+- Pure path / name helpers: `sanitize_worktree_name`, `sanitize_worktree_ref`, `build_worktree_cli_path`, `build_worktree_sibling_path`, `build_worktree_path_for_layout` (+ unit tests)
+- Frontend pure helpers: `src/lib/gitWorktree.ts` — list/parse + path builders + `resolveSessionWorktreeBadge` / tooltip / layout detect (+ unit tests)
 - UI:
   - Project: `ComposerProjectMenu` (folder only)
   - Branch / worktree: `ComposerWorktreeMenu` (context bar chip; per-row remove)
-  - Sidebar **WT** badge + session context menu manage actions
-  - Create + remove confirm + GC dialogs in `App.tsx`
+  - Sidebar **CLI** / **WT** badge + session context menu manage actions
+  - Create (layout radios + ref validation) + remove confirm + GC dialogs in `App.tsx`

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4896,6 +4896,9 @@ pub struct GitWorktreesResult {
     pub available: bool,
     pub worktrees: Vec<GitWorktreeEntry>,
     pub reason: Option<String>,
+    /// Absolute `~/.grok` used for CLI-aligned worktree placement / detection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cli_grok_home: Option<String>,
 }
 
 /// Parse `git worktree list --porcelain` (pure; unit-tested).
@@ -4975,12 +4978,17 @@ pub fn parse_worktree_porcelain(raw: &str) -> Vec<GitWorktreeEntry> {
 /// List linked git worktrees for a project folder. Soft-fails without git / non-repo.
 #[tauri::command]
 pub async fn git_worktrees_list(project_path: String) -> Result<GitWorktreesResult, String> {
+    let cli_home = shared_cli_grok_home()
+        .to_string_lossy()
+        .replace('\\', "/");
+    let cli_grok_home = Some(normalize_fs_path(&cli_home));
     let project = normalize_fs_path(&project_path);
     if project.is_empty() {
         return Ok(GitWorktreesResult {
             available: false,
             worktrees: vec![],
             reason: Some("empty path".into()),
+            cli_grok_home,
         });
     }
     let proj = std::path::PathBuf::from(&project);
@@ -4989,6 +4997,7 @@ pub async fn git_worktrees_list(project_path: String) -> Result<GitWorktreesResu
             available: false,
             worktrees: vec![],
             reason: Some("project not a directory".into()),
+            cli_grok_home,
         });
     }
     if let Err(reason) = git_probe_work_tree(&project) {
@@ -4996,6 +5005,7 @@ pub async fn git_worktrees_list(project_path: String) -> Result<GitWorktreesResu
             available: false,
             worktrees: vec![],
             reason: Some(reason),
+            cli_grok_home,
         });
     }
 
@@ -5014,6 +5024,7 @@ pub async fn git_worktrees_list(project_path: String) -> Result<GitWorktreesResu
             } else {
                 err.chars().take(200).collect()
             }),
+            cli_grok_home,
         });
     }
 
@@ -5023,6 +5034,7 @@ pub async fn git_worktrees_list(project_path: String) -> Result<GitWorktreesResu
         available: true,
         worktrees,
         reason: None,
+        cli_grok_home,
     })
 }
 
@@ -5715,13 +5727,73 @@ pub fn build_worktree_gc_args(
 
 // from PR #64
 
+/// Path placement for new linked worktrees (`cli` default, or `sibling`).
+pub fn normalize_worktree_layout(raw: Option<&str>) -> &'static str {
+    match raw.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) if s.eq_ignore_ascii_case("sibling") => "sibling",
+        _ => "cli",
+    }
+}
+
+/// Shared CLI GROK_HOME (`~/.grok`) used for worktree placement.
+/// Matches Grok Build 0.2.x `~/.grok/worktrees/<repo>/…` regardless of
+/// App independent agent-home (git worktrees are filesystem layout, not session store).
+pub fn shared_cli_grok_home() -> std::path::PathBuf {
+    crate::process_util::user_home().join(".grok")
+}
+
+/// CLI worktrees root: `{GROK_HOME}/worktrees`.
+pub fn cli_worktrees_home(grok_home: &std::path::Path) -> std::path::PathBuf {
+    grok_home.join("worktrees")
+}
+
+/// Repo folder slug for CLI layout (main worktree basename).
+pub fn worktree_repo_slug(main_worktree_path: &str) -> Result<String, String> {
+    let main = normalize_fs_path(main_worktree_path);
+    if main.is_empty() {
+        return Err("empty main worktree path".into());
+    }
+    let main_pb = std::path::PathBuf::from(&main);
+    main_pb
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .ok_or_else(|| "cannot derive repo folder name".to_string())
+}
+
+/// CLI-aligned path: `{GROK_HOME}/worktrees/<main_basename>/<name>`.
+///
+/// Example: grok_home `~/.grok`, main `/Users/me/Code/oss-grok-app`, name `feat`
+/// → `~/.grok/worktrees/oss-grok-app/feat`.
+///
+/// Matches Grok Build 0.2.x (`grok --worktree=…`, `grok worktree list`).
+pub fn build_worktree_cli_path(
+    main_worktree_path: &str,
+    name: &str,
+    grok_home: &std::path::Path,
+) -> Result<String, String> {
+    let main = normalize_fs_path(main_worktree_path);
+    if main.is_empty() {
+        return Err("empty main worktree path".into());
+    }
+    let safe = sanitize_worktree_name(name)?;
+    let slug = worktree_repo_slug(&main)?;
+    let path = cli_worktrees_home(grok_home).join(slug).join(safe);
+    let s = path.to_string_lossy().replace('\\', "/");
+    let s = normalize_fs_path(&s);
+    if s == main || s.is_empty() {
+        return Err("resolved worktree path is invalid".into());
+    }
+    Ok(s)
+}
+
 /// Build sibling worktree path: `<parent>/<main_basename>-<name>`.
 ///
 /// Example: main `/Users/me/repo` + name `feat` → `/Users/me/repo-feat`.
 ///
-/// Choice (documented in `docs/llm-wiki/git-worktrees.md`): sibling of the
-/// **main** worktree root, not `.worktrees/<name>` inside the repo. Matches
-/// common `git worktree add ../repo-feat` layout and existing list samples.
+/// Optional alternative to CLI home layout — matches common
+/// `git worktree add ../repo-feat` practice.
 pub fn build_worktree_sibling_path(main_worktree_path: &str, name: &str) -> Result<String, String> {
     let main = normalize_fs_path(main_worktree_path);
     if main.is_empty() {
@@ -5745,6 +5817,18 @@ pub fn build_worktree_sibling_path(main_worktree_path: &str, name: &str) -> Resu
         return Err("resolved worktree path is invalid".into());
     }
     Ok(s)
+}
+
+/// Resolve create path for layout (`cli` default, or `sibling`).
+pub fn build_worktree_path_for_layout(
+    layout: Option<&str>,
+    main_worktree_path: &str,
+    name: &str,
+) -> Result<String, String> {
+    match normalize_worktree_layout(layout) {
+        "sibling" => build_worktree_sibling_path(main_worktree_path, name),
+        _ => build_worktree_cli_path(main_worktree_path, name, &shared_cli_grok_home()),
+    }
 }
 
 // from PR #88
@@ -5892,7 +5976,11 @@ fn extract_agent_description_from_content(content: &str) -> Option<String> {
 
 // from PR #64
 
-/// Create a linked git worktree under a sibling path, then return its path.
+/// Create a linked git worktree, then return its path.
+///
+/// Default layout (`cli` / omitted): `{GROK_HOME}/worktrees/<repo>/<name>`
+/// aligned with Grok Build 0.2.x (`grok --worktree=…`).
+/// Optional `layout = "sibling"`: `<parent>/<main_basename>-<name>`.
 ///
 /// Args are passed to `git` as an argv array (no shell) to avoid injection.
 /// - Without `start_point`: `git worktree add -b <name> <path>` (branch from HEAD).
@@ -5902,6 +5990,7 @@ pub async fn git_worktree_add(
     project_path: String,
     name: String,
     start_point: Option<String>,
+    layout: Option<String>,
 ) -> Result<GitWorktreeAddResult, String> {
     let project = normalize_fs_path(&project_path);
     if project.is_empty() {
@@ -5915,8 +6004,9 @@ pub async fn git_worktree_add(
 
     let safe_name = sanitize_worktree_name(&name)?;
     let start = sanitize_worktree_ref(start_point.as_deref())?;
+    let layout_kind = normalize_worktree_layout(layout.as_deref());
 
-    // Resolve main worktree path (first porcelain entry) for sibling placement.
+    // Resolve main worktree path (first porcelain entry) for path placement.
     let list_out = crate::process_util::command("git")
         .args(["-C", &project, "worktree", "list", "--porcelain"])
         .output()
@@ -5936,7 +6026,7 @@ pub async fn git_worktree_add(
         .filter(|p| !p.is_empty())
         .ok_or_else(|| "could not resolve main worktree path".to_string())?;
 
-    let target = build_worktree_sibling_path(&main_path, &safe_name)?;
+    let target = build_worktree_path_for_layout(Some(layout_kind), &main_path, &safe_name)?;
     let target_pb = std::path::PathBuf::from(&target);
     if target_pb.exists() {
         return Err(format!("path already exists: {target}"));
@@ -5947,6 +6037,13 @@ pub async fn git_worktree_add(
         p.eq_ignore_ascii_case(&target) || p == target
     }) {
         return Err(format!("worktree already registered: {target}"));
+    }
+
+    // CLI layout nests under ~/.grok/worktrees/<repo>/ — ensure parents exist.
+    if let Some(parent) = target_pb.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            format!("could not create worktree parent {}: {e}", parent.display())
+        })?;
     }
 
     // Safe argv — never go through a shell.
@@ -6769,6 +6866,51 @@ pub fn sanitize_worktree_ref(raw: Option<&str>) -> Result<Option<String>, String
         return Err("branch / ref must not start with '-'".into());
     }
     Ok(Some(s.to_string()))
+}
+
+#[cfg(test)]
+mod worktree_path_tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn layout_defaults_to_cli() {
+        assert_eq!(normalize_worktree_layout(None), "cli");
+        assert_eq!(normalize_worktree_layout(Some("")), "cli");
+        assert_eq!(normalize_worktree_layout(Some("CLI")), "cli");
+        assert_eq!(normalize_worktree_layout(Some("sibling")), "sibling");
+    }
+
+    #[test]
+    fn sibling_path_next_to_main() {
+        assert_eq!(
+            build_worktree_sibling_path("/Users/me/repo", "feat").unwrap(),
+            "/Users/me/repo-feat"
+        );
+    }
+
+    #[test]
+    fn cli_path_under_grok_worktrees() {
+        let home = Path::new("/Users/me/.grok");
+        assert_eq!(
+            build_worktree_cli_path("/Users/me/Code/oss-grok-app", "feat", home).unwrap(),
+            "/Users/me/.grok/worktrees/oss-grok-app/feat"
+        );
+        assert_eq!(
+            worktree_repo_slug("/Users/me/Code/oss-grok-app").unwrap(),
+            "oss-grok-app"
+        );
+    }
+
+    #[test]
+    fn sanitize_ref_rejects_flags() {
+        assert!(sanitize_worktree_ref(Some("-b")).is_err());
+        assert_eq!(
+            sanitize_worktree_ref(Some("  origin/main  ")).unwrap().as_deref(),
+            Some("origin/main")
+        );
+        assert_eq!(sanitize_worktree_ref(None).unwrap(), None);
+    }
 }
 
 // from PR #77

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -536,16 +536,19 @@ import {
 import { ComposerProjectMenu } from "@/components/ComposerProjectMenu";
 import { ComposerWorktreeMenu } from "@/components/ComposerWorktreeMenu";
 import {
-  buildWorktreeSiblingPath,
+  buildWorktreePath,
   canRemoveWorktree,
   mainWorktreePath,
+  normalizeWorktreeLayout,
   pathsEqual,
   resolveSessionWorktreeBadge,
   sanitizeWorktreeName,
+  sanitizeWorktreeRef,
   sessionWorktreeTooltip,
   worktreeLabel,
   worktreeRemoveErrorSuggestsForce,
   type SessionWorktreeBadge,
+  type WorktreeLayout,
 } from "@/lib/gitWorktree";
 import {
   buildForkWorktreeName,
@@ -1979,16 +1982,21 @@ export default function App() {
   const [gitWorktreesReason, setGitWorktreesReason] = useState<string | null>(
     null,
   );
-  /** New worktree dialog (name + optional start-point). */
+  /** New worktree dialog (name + optional start-point + layout). */
   const [worktreeCreateOpen, setWorktreeCreateOpen] = useState(false);
   const [worktreeCreateName, setWorktreeCreateName] = useState("");
   const [worktreeCreateRef, setWorktreeCreateRef] = useState("");
+  /** Default CLI-aligned (`~/.grok/worktrees`); optional sibling. */
+  const [worktreeCreateLayout, setWorktreeCreateLayout] =
+    useState<WorktreeLayout>("cli");
   const [worktreeCreateBusy, setWorktreeCreateBusy] = useState(false);
   const [worktreeCreateError, setWorktreeCreateError] = useState<string | null>(
     null,
   );
   /** When true, after create bind cwd and open a draft chat on that path. */
   const [worktreeCreateStartChat, setWorktreeCreateStartChat] = useState(false);
+  /** Absolute `~/.grok` from host list (CLI path preview + badge detection). */
+  const [cliGrokHome, setCliGrokHome] = useState<string | null>(null);
   /** Clean stale worktrees (git worktree prune) dialog. */
   const [worktreeGcOpen, setWorktreeGcOpen] = useState(false);
   const [worktreeGcForce, setWorktreeGcForce] = useState(false);
@@ -10207,6 +10215,7 @@ export default function App() {
       setGitWorktrees([]);
       setGitWorktreesAvailable(null);
       setGitWorktreesReason(null);
+      setCliGrokHome(null);
       setGitWorktreesLoading(false);
       return;
     }
@@ -10223,6 +10232,8 @@ export default function App() {
     try {
       const res = await api.gitWorktreesList(path);
       if (reqId !== gitWorktreesReqRef.current) return;
+      const home = (res.cliGrokHome || "").trim() || null;
+      if (home) setCliGrokHome(home);
       if (!res.available) {
         setGitWorktrees([]);
         setGitWorktreesAvailable(false);
@@ -10595,6 +10606,7 @@ export default function App() {
   const openWorktreeCreate = useCallback((opts?: { startNewChat?: boolean }) => {
     setWorktreeCreateName("");
     setWorktreeCreateRef("");
+    setWorktreeCreateLayout("cli");
     setWorktreeCreateError(null);
     setWorktreeCreateBusy(false);
     setWorktreeCreateStartChat(!!opts?.startNewChat);
@@ -10605,7 +10617,22 @@ export default function App() {
     try {
       const main = mainWorktreePath(gitWorktrees) || activeProject?.path || "";
       if (!main || !worktreeCreateName.trim()) return null;
-      return buildWorktreeSiblingPath(main, worktreeCreateName.trim());
+      const layout = normalizeWorktreeLayout(worktreeCreateLayout);
+      if (layout === "cli" && !cliGrokHome) {
+        // Host has not reported home yet — show tilde form for CLI layout.
+        return buildWorktreePath(
+          "cli",
+          main,
+          worktreeCreateName.trim(),
+          "~/.grok",
+        );
+      }
+      return buildWorktreePath(
+        layout,
+        main,
+        worktreeCreateName.trim(),
+        cliGrokHome,
+      );
     } catch {
       return null;
     }
@@ -10639,7 +10666,7 @@ export default function App() {
     [],
   );
 
-  /** Resolve WT badge for a session row (meta first, git list fallback). */
+  /** Resolve WT/CLI badge for a session row (meta first, git list fallback). */
   const sessionWorktreeBadgeFor = useCallback(
     (s: SessionRow): SessionWorktreeBadge | null => {
       const proj = s.projectId
@@ -10653,9 +10680,10 @@ export default function App() {
         },
         proj?.path ?? s.worktreePath,
         gitWorktrees,
+        { grokHome: cliGrokHome },
       );
     },
-    [gitWorktrees, projects],
+    [cliGrokHome, gitWorktrees, projects],
   );
 
   /**
@@ -10677,14 +10705,22 @@ export default function App() {
       setWorktreeCreateError(tr("composer.worktreeNameInvalid"));
       return;
     }
+    let start: string | null;
+    try {
+      start = sanitizeWorktreeRef(worktreeCreateRef);
+    } catch {
+      setWorktreeCreateError(tr("composer.worktreeRefInvalid"));
+      return;
+    }
+    const layout = normalizeWorktreeLayout(worktreeCreateLayout);
     setWorktreeCreateBusy(true);
     setWorktreeCreateError(null);
     try {
-      const start = worktreeCreateRef.trim() || null;
       const created = await api.gitWorktreeAdd(
         activeProject.path,
         safeName,
         start,
+        layout,
       );
       setWorktreeCreateOpen(false);
       await refreshGitWorktrees();
@@ -10774,6 +10810,7 @@ export default function App() {
     session.sessionId,
     showToast,
     tr,
+    worktreeCreateLayout,
     worktreeCreateName,
     worktreeCreateRef,
     worktreeCreateStartChat,
@@ -13684,22 +13721,40 @@ export default function App() {
                                                 detachedLabel: tr(
                                                   "composer.worktreeDetached",
                                                 ),
+                                                cliLayoutLabel: tr(
+                                                  "session.worktreeLayoutCli",
+                                                ),
+                                                siblingLayoutLabel: tr(
+                                                  "session.worktreeLayoutSibling",
+                                                ),
+                                                otherLayoutLabel: tr(
+                                                  "session.worktreeBadge",
+                                                ),
                                               },
                                             );
+                                            const ariaKey =
+                                              wtBadge.layoutKind === "cli"
+                                                ? "session.worktreeBadgeCliAria"
+                                                : "session.worktreeBadgeAria";
                                             return (
                                               <span
-                                                className="tree-l3__wt"
+                                                className={
+                                                  "tree-l3__wt" +
+                                                  (wtBadge.layoutKind === "cli"
+                                                    ? " tree-l3__wt--cli"
+                                                    : wtBadge.layoutKind ===
+                                                        "sibling"
+                                                      ? " tree-l3__wt--sibling"
+                                                      : "")
+                                                }
                                                 title={tip}
-                                                aria-label={tr(
-                                                  "session.worktreeBadgeAria",
-                                                  {
-                                                    branch:
-                                                      wtBadge.branch ||
-                                                      tr(
-                                                        "composer.worktreeDetached",
-                                                      ),
-                                                  },
-                                                )}
+                                                aria-label={tr(ariaKey, {
+                                                  branch:
+                                                    wtBadge.branch ||
+                                                    tr(
+                                                      "composer.worktreeDetached",
+                                                    ),
+                                                })}
                                               >
                                                 {wtBadge.label}
                                               </span>
@@ -13961,19 +14016,36 @@ export default function App() {
                                     detachedLabel: tr(
                                       "composer.worktreeDetached",
                                     ),
+                                    cliLayoutLabel: tr(
+                                      "session.worktreeLayoutCli",
+                                    ),
+                                    siblingLayoutLabel: tr(
+                                      "session.worktreeLayoutSibling",
+                                    ),
+                                    otherLayoutLabel: tr(
+                                      "session.worktreeBadge",
+                                    ),
                                   });
+                                  const ariaKey =
+                                    wtBadge.layoutKind === "cli"
+                                      ? "session.worktreeBadgeCliAria"
+                                      : "session.worktreeBadgeAria";
                                   return (
                                     <span
-                                      className="tree-l3__wt"
+                                      className={
+                                        "tree-l3__wt" +
+                                        (wtBadge.layoutKind === "cli"
+                                          ? " tree-l3__wt--cli"
+                                          : wtBadge.layoutKind === "sibling"
+                                            ? " tree-l3__wt--sibling"
+                                            : "")
+                                      }
                                       title={tip}
-                                      aria-label={tr(
-                                        "session.worktreeBadgeAria",
-                                        {
-                                          branch:
-                                            wtBadge.branch ||
-                                            tr("composer.worktreeDetached"),
-                                        },
-                                      )}
+                                      aria-label={tr(ariaKey, {
+                                        branch:
+                                          wtBadge.branch ||
+                                          tr("composer.worktreeDetached"),
+                                      })}
                                     >
                                       {wtBadge.label}
                                     </span>
@@ -16449,6 +16521,37 @@ export default function App() {
               spellCheck={false}
             />
           </label>
+          <fieldset className="wt-create__field wt-create__layout" disabled={worktreeCreateBusy}>
+            <legend className="wt-create__label">
+              {tr("composer.worktreeLayout")}
+            </legend>
+            <label className="wt-create__radio">
+              <input
+                type="radio"
+                name="worktree-layout"
+                value="cli"
+                checked={worktreeCreateLayout === "cli"}
+                onChange={() => {
+                  setWorktreeCreateLayout("cli");
+                  setWorktreeCreateError(null);
+                }}
+              />
+              <span>{tr("composer.worktreeLayoutCli")}</span>
+            </label>
+            <label className="wt-create__radio">
+              <input
+                type="radio"
+                name="worktree-layout"
+                value="sibling"
+                checked={worktreeCreateLayout === "sibling"}
+                onChange={() => {
+                  setWorktreeCreateLayout("sibling");
+                  setWorktreeCreateError(null);
+                }}
+              />
+              <span>{tr("composer.worktreeLayoutSibling")}</span>
+            </label>
+          </fieldset>
           <label className="wt-create__field">
             <span className="wt-create__label">
               {tr("composer.worktreeRef")}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -137,6 +137,9 @@ const en = {
   "session.noteChars": "{n}/{max}",
   "session.worktreeBadge": "Worktree",
   "session.worktreeBadgeAria": "Worktree session · {branch}",
+  "session.worktreeBadgeCliAria": "CLI worktree session · {branch}",
+  "session.worktreeLayoutCli": "CLI worktrees home (~/.grok/worktrees)",
+  "session.worktreeLayoutSibling": "Sibling of main checkout",
   "session.worktreeReveal": "Reveal worktree",
   "session.worktreeCopyPath": "Copy worktree path",
   "session.worktreePathCopied": "Worktree path copied",
@@ -663,13 +666,20 @@ const en = {
   "composer.worktreeNewTitle": "New git worktree",
   "composer.worktreeNewChatTitle": "New worktree & chat",
   "composer.worktreeNewHint":
-    "Creates a sibling folder next to the main worktree and checks out a new branch.",
+    "Creates a linked git worktree (default: CLI layout under ~/.grok/worktrees) and checks out a new branch. Same idea as grok --worktree=name.",
   "composer.worktreeNewChatHint":
-    "Creates a sibling worktree, then starts a new chat with that folder as the project.",
+    "Creates a linked worktree, then starts a new chat with that folder as the project cwd (session meta bound for the CLI/WT badge).",
   "composer.worktreeName": "Name",
   "composer.worktreeNamePlaceholder": "feat-login",
+  "composer.worktreeLayout": "Location",
+  "composer.worktreeLayoutCli":
+    "CLI home — ~/.grok/worktrees/<repo>/<name> (matches grok --worktree)",
+  "composer.worktreeLayoutSibling":
+    "Sibling — next to main checkout (<repo>-<name>)",
   "composer.worktreeRef": "Start point (optional)",
   "composer.worktreeRefPlaceholder": "main, origin/main, or commit",
+  "composer.worktreeRefInvalid":
+    "Start point must not start with '-' or contain line breaks",
   "composer.worktreePathPreview": "Path: {path}",
   "composer.worktreeCreate": "Create",
   "composer.worktreeCreateChat": "Create & open chat",
@@ -2973,6 +2983,9 @@ const zh: Record<MessageKey, string> = {
   "session.noteChars": "{n}/{max}",
   "session.worktreeBadge": "Worktree",
   "session.worktreeBadgeAria": "Worktree 会话 · {branch}",
+  "session.worktreeBadgeCliAria": "CLI worktree 会话 · {branch}",
+  "session.worktreeLayoutCli": "CLI worktrees 目录（~/.grok/worktrees）",
+  "session.worktreeLayoutSibling": "主检出旁的同级 worktree",
   "session.worktreeReveal": "在文件管理器中显示 worktree",
   "session.worktreeCopyPath": "复制 worktree 路径",
   "session.worktreePathCopied": "已复制 worktree 路径",
@@ -3469,13 +3482,20 @@ const zh: Record<MessageKey, string> = {
   "composer.worktreeNewTitle": "新建 Git worktree",
   "composer.worktreeNewChatTitle": "新建 worktree 并开聊",
   "composer.worktreeNewHint":
-    "在主 worktree 旁创建同级目录，并检出一条新分支。",
+    "创建关联 git worktree（默认 CLI 布局 ~/.grok/worktrees），并检出新分支。对齐 grok --worktree=name。",
   "composer.worktreeNewChatHint":
-    "创建同级 worktree，并以该目录为项目开始新对话。",
+    "创建关联 worktree，并以该目录为项目 cwd 开启新对话（写入会话 meta，侧栏显示 CLI/WT 标记）。",
   "composer.worktreeName": "名称",
   "composer.worktreeNamePlaceholder": "feat-login",
+  "composer.worktreeLayout": "位置",
+  "composer.worktreeLayoutCli":
+    "CLI 目录 — ~/.grok/worktrees/<repo>/<name>（对齐 grok --worktree）",
+  "composer.worktreeLayoutSibling":
+    "同级目录 — 主检出旁（<repo>-<name>）",
   "composer.worktreeRef": "起始点（可选）",
   "composer.worktreeRefPlaceholder": "main、origin/main 或 commit",
+  "composer.worktreeRefInvalid":
+    "起始点不能以 '-' 开头，也不能包含换行",
   "composer.worktreePathPreview": "路径：{path}",
   "composer.worktreeCreate": "创建",
   "composer.worktreeCreateChat": "创建并开聊",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -126,6 +126,9 @@ export const zhTW: Record<MessageKey, string> = {
   "session.noteChars": "{n}/{max}",
   "session.worktreeBadge": "Worktree",
   "session.worktreeBadgeAria": "Worktree 對話 · {branch}",
+  "session.worktreeBadgeCliAria": "CLI worktree 對話 · {branch}",
+  "session.worktreeLayoutCli": "CLI worktrees 目錄（~/.grok/worktrees）",
+  "session.worktreeLayoutSibling": "主檢出旁的同級 worktree",
   "session.worktreeReveal": "在檔案管理員中顯示 worktree",
   "session.worktreeCopyPath": "複製 worktree 路徑",
   "session.worktreePathCopied": "已複製 worktree 路徑",
@@ -529,13 +532,20 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.worktreeNewTitle": "新建 Git worktree",
   "composer.worktreeNewChatTitle": "新建 worktree 並開聊",
   "composer.worktreeNewHint":
-    "在主 worktree 旁建立同級目錄，並檢出一條新分支。",
+    "建立關聯 git worktree（預設 CLI 佈局 ~/.grok/worktrees），並檢出新分支。對齊 grok --worktree=name。",
   "composer.worktreeNewChatHint":
-    "建立同級 worktree，並以該目錄為專案開始新對話。",
+    "建立關聯 worktree，並以該目錄為專案 cwd 開啟新對話（寫入對話 meta，側欄顯示 CLI/WT 標記）。",
   "composer.worktreeName": "名稱",
   "composer.worktreeNamePlaceholder": "feat-login",
+  "composer.worktreeLayout": "位置",
+  "composer.worktreeLayoutCli":
+    "CLI 目錄 — ~/.grok/worktrees/<repo>/<name>（對齊 grok --worktree）",
+  "composer.worktreeLayoutSibling":
+    "同級目錄 — 主檢出旁（<repo>-<name>）",
   "composer.worktreeRef": "起始點（可選）",
   "composer.worktreeRefPlaceholder": "main、origin/main 或 commit",
+  "composer.worktreeRefInvalid":
+    "起始點不能以 '-' 開頭，也不能包含換行",
   "composer.worktreePathPreview": "路徑：{path}",
   "composer.worktreeCreate": "建立",
   "composer.worktreeCreateChat": "建立並開聊",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -457,6 +457,8 @@ export interface GitWorktreesResult {
   available: boolean;
   worktrees: GitWorktreeEntry[];
   reason?: string | null;
+  /** Absolute `~/.grok` for CLI-aligned worktree placement / badge detection. */
+  cliGrokHome?: string | null;
 }
 
 /** List worktrees for a project folder. Soft-fails when git/repo missing. */
@@ -474,18 +476,23 @@ export interface GitWorktreeAddResult {
 
 /**
  * Create a linked worktree for a project folder.
- * Path: `<parent>/<main_basename>-<name>` (see docs/llm-wiki/git-worktrees.md).
+ *
+ * Default layout `cli`: `~/.grok/worktrees/<repo>/<name>` (Grok Build 0.2.x).
+ * Optional `sibling`: `<parent>/<main_basename>-<name>`.
+ * See docs/llm-wiki/git-worktrees.md.
  * Throws when not a git repo / git missing / path exists / invalid name.
  */
 export async function gitWorktreeAdd(
   projectPath: string,
   name: string,
   startPoint?: string | null,
+  layout?: "cli" | "sibling" | null,
 ) {
   return invoke<GitWorktreeAddResult>("git_worktree_add", {
     projectPath,
     name,
     startPoint: startPoint?.trim() || null,
+    layout: layout === "sibling" ? "sibling" : "cli",
   });
 }
 

--- a/src/lib/gitWorktree.test.ts
+++ b/src/lib/gitWorktree.test.ts
@@ -1,23 +1,33 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildWorktreeCliPath,
   buildWorktreeGcArgs,
+  buildWorktreePath,
   buildWorktreeSiblingPath,
   canRemoveWorktree,
+  cliWorktreesHome,
   countWorktreePruneLines,
+  detectWorktreeLayoutKind,
   findWorktreeAt,
+  grokHomeFromUserHome,
   isLinkedWorktreeEntry,
+  isSiblingWorktreePath,
+  isUnderCliWorktreesHome,
   mainWorktreePath,
+  normalizeWorktreeLayout,
   normalizeWorktreePath,
   parseWorktreePorcelain,
   pathsEqual,
   resolveSessionWorktreeBadge,
   sanitizeWorktreeGcMaxAge,
   sanitizeWorktreeName,
+  sanitizeWorktreeRef,
   sessionWorktreeBadgeLabel,
   sessionWorktreeTooltip,
   siblingWorktrees,
   worktreeLabel,
   worktreeRemoveErrorSuggestsForce,
+  worktreeRepoSlug,
 } from "./gitWorktree";
 
 const SAMPLE = `worktree /Users/me/repo
@@ -91,6 +101,23 @@ describe("worktree path builder", () => {
     expect(() => sanitizeWorktreeName("has space")).toThrow();
   });
 
+  it("sanitizes optional start refs", () => {
+    expect(sanitizeWorktreeRef("  main  ")).toBe("main");
+    expect(sanitizeWorktreeRef("origin/main")).toBe("origin/main");
+    expect(sanitizeWorktreeRef("")).toBeNull();
+    expect(sanitizeWorktreeRef(null)).toBeNull();
+    expect(() => sanitizeWorktreeRef("-b")).toThrow(/start/);
+    expect(() => sanitizeWorktreeRef("a\nb")).toThrow(/invalid/);
+  });
+
+  it("normalizes layout ids (default cli)", () => {
+    expect(normalizeWorktreeLayout(undefined)).toBe("cli");
+    expect(normalizeWorktreeLayout("")).toBe("cli");
+    expect(normalizeWorktreeLayout("CLI")).toBe("cli");
+    expect(normalizeWorktreeLayout("sibling")).toBe("sibling");
+    expect(normalizeWorktreeLayout("other")).toBe("cli");
+  });
+
   it("builds sibling path next to main worktree", () => {
     expect(buildWorktreeSiblingPath("/Users/me/repo", "feat")).toBe(
       "/Users/me/repo-feat",
@@ -104,6 +131,71 @@ describe("worktree path builder", () => {
     // Path preview uses main even when active cwd is a linked worktree.
     const main = mainWorktreePath(parseWorktreePorcelain(SAMPLE))!;
     expect(buildWorktreeSiblingPath(main, "new")).toBe("/Users/me/repo-new");
+  });
+
+  it("builds CLI home path under ~/.grok/worktrees/<repo>/<name>", () => {
+    expect(grokHomeFromUserHome("/Users/me")).toBe("/Users/me/.grok");
+    expect(cliWorktreesHome("/Users/me/.grok")).toBe(
+      "/Users/me/.grok/worktrees",
+    );
+    expect(cliWorktreesHome("/Users/me", { fromUserHome: true })).toBe(
+      "/Users/me/.grok/worktrees",
+    );
+    expect(worktreeRepoSlug("/Users/me/Code/oss-grok-app")).toBe(
+      "oss-grok-app",
+    );
+    expect(
+      buildWorktreeCliPath(
+        "/Users/me/Code/oss-grok-app",
+        "feat",
+        "/Users/me/.grok",
+      ),
+    ).toBe("/Users/me/.grok/worktrees/oss-grok-app/feat");
+    expect(
+      buildWorktreePath(
+        "cli",
+        "/Users/me/repo",
+        "hot-fix",
+        "/Users/me/.grok",
+      ),
+    ).toBe("/Users/me/.grok/worktrees/repo/hot-fix");
+    expect(buildWorktreePath("sibling", "/Users/me/repo", "feat")).toBe(
+      "/Users/me/repo-feat",
+    );
+  });
+
+  it("detects CLI home vs sibling paths", () => {
+    expect(
+      isUnderCliWorktreesHome(
+        "/Users/me/.grok/worktrees/oss-grok-app/feat",
+        "/Users/me/.grok",
+      ),
+    ).toBe(true);
+    expect(
+      isUnderCliWorktreesHome("/Users/me/.grok/worktrees/oss-grok-app/feat"),
+    ).toBe(true);
+    expect(isUnderCliWorktreesHome("/Users/me/repo-feat")).toBe(false);
+    expect(isSiblingWorktreePath("/Users/me/repo-feat", "/Users/me/repo")).toBe(
+      true,
+    );
+    expect(
+      isSiblingWorktreePath(
+        "/Users/me/.grok/worktrees/repo/feat",
+        "/Users/me/repo",
+      ),
+    ).toBe(false);
+    expect(
+      detectWorktreeLayoutKind(
+        "/Users/me/.grok/worktrees/repo/feat",
+        "/Users/me/repo",
+      ),
+    ).toBe("cli");
+    expect(
+      detectWorktreeLayoutKind("/Users/me/repo-feat", "/Users/me/repo"),
+    ).toBe("sibling");
+    expect(detectWorktreeLayoutKind("/tmp/other-wt", "/Users/me/repo")).toBe(
+      "other",
+    );
   });
 });
 
@@ -119,8 +211,11 @@ describe("canRemoveWorktree", () => {
 });
 
 describe("session worktree badge helpers", () => {
-  it("labels compact badge as WT", () => {
+  it("labels CLI home as CLI and sibling as WT", () => {
     expect(sessionWorktreeBadgeLabel()).toBe("WT");
+    expect(sessionWorktreeBadgeLabel("sibling")).toBe("WT");
+    expect(sessionWorktreeBadgeLabel("other")).toBe("WT");
+    expect(sessionWorktreeBadgeLabel("cli")).toBe("CLI");
   });
 
   it("detects linked (non-main) worktree entries", () => {
@@ -142,10 +237,27 @@ describe("session worktree badge helpers", () => {
     );
     expect(badge).not.toBeNull();
     expect(badge!.label).toBe("WT");
+    expect(badge!.layoutKind).toBe("other");
     expect(badge!.path).toBe("/Users/me/repo-feat");
     expect(badge!.branch).toBe("feat/x");
     expect(badge!.fromMeta).toBe(true);
     expect(badge!.fromGitList).toBe(false);
+  });
+
+  it("badges CLI-home meta with CLI label", () => {
+    const badge = resolveSessionWorktreeBadge(
+      {
+        isWorktreeSession: true,
+        worktreePath: "/Users/me/.grok/worktrees/repo/feat",
+        worktreeBranch: "feat",
+      },
+      "/Users/me/.grok/worktrees/repo/feat",
+      [],
+      { grokHome: "/Users/me/.grok" },
+    );
+    expect(badge).not.toBeNull();
+    expect(badge!.label).toBe("CLI");
+    expect(badge!.layoutKind).toBe("cli");
   });
 
   it("falls back to git list when project path is a linked worktree", () => {
@@ -157,6 +269,7 @@ describe("session worktree badge helpers", () => {
     );
     expect(badge).not.toBeNull();
     expect(badge!.label).toBe("WT");
+    expect(badge!.layoutKind).toBe("sibling");
     expect(pathsEqual(badge!.path, "/Users/me/repo-feat")).toBe(true);
     expect(badge!.branch).toBe("feat/x");
     expect(badge!.fromMeta).toBe(false);
@@ -172,16 +285,27 @@ describe("session worktree badge helpers", () => {
     expect(resolveSessionWorktreeBadge(null, null, list)).toBeNull();
   });
 
-  it("builds tooltip with branch and path", () => {
+  it("builds tooltip with layout, branch and path", () => {
     expect(
-      sessionWorktreeTooltip({ path: "/Users/me/repo-feat", branch: "feat/x" }),
-    ).toBe("feat/x\n/Users/me/repo-feat");
+      sessionWorktreeTooltip({
+        path: "/Users/me/repo-feat",
+        branch: "feat/x",
+        layoutKind: "sibling",
+      }),
+    ).toBe("Sibling worktree\nfeat/x\n/Users/me/repo-feat");
     expect(
       sessionWorktreeTooltip(
-        { path: "/Users/me/repo-feat", branch: null },
-        { detachedLabel: "detached" },
+        {
+          path: "/Users/me/.grok/worktrees/repo/feat",
+          branch: null,
+          layoutKind: "cli",
+        },
+        {
+          detachedLabel: "detached",
+          cliLayoutLabel: "CLI home",
+        },
       ),
-    ).toBe("detached\n/Users/me/repo-feat");
+    ).toBe("CLI home\ndetached\n/Users/me/.grok/worktrees/repo/feat");
   });
 });
 

--- a/src/lib/gitWorktree.ts
+++ b/src/lib/gitWorktree.ts
@@ -24,6 +24,8 @@ export type GitWorktreesResult = {
   available: boolean;
   worktrees: GitWorktreeEntry[];
   reason?: string | null;
+  /** Absolute `~/.grok` for CLI-aligned worktree placement / badge detection. */
+  cliGrokHome?: string | null;
 };
 
 /** Normalize path for comparison (slash direction, no trailing slash). */
@@ -227,13 +229,134 @@ export function sanitizeWorktreeName(raw: string | null | undefined): string {
 }
 
 /**
+ * Path placement strategy for new linked worktrees.
+ *
+ * - `cli` (default): Grok Build CLI layout
+ *   `{GROK_HOME}/worktrees/<repo-basename>/<name>`
+ *   (CLI 0.2.x uses `~/.grok/worktrees/<repo>/…` for `--worktree` / subagents).
+ * - `sibling`: classic git UX next to the main checkout
+ *   `<parent>/<main_basename>-<name>`
+ */
+export type WorktreeLayout = "cli" | "sibling";
+
+/** Normalize layout id; unknown / empty → `cli` (CLI-aligned default). */
+export function normalizeWorktreeLayout(
+  raw: string | null | undefined,
+): WorktreeLayout {
+  const s = (raw ?? "").trim().toLowerCase();
+  if (s === "sibling") return "sibling";
+  return "cli";
+}
+
+/**
+ * Optional commit-ish / branch start-point for `git worktree add`.
+ * Mirrors host `sanitize_worktree_ref` (single argv element; no flags).
+ * Empty → `null` (use HEAD).
+ */
+export function sanitizeWorktreeRef(
+  raw: string | null | undefined,
+): string | null {
+  const s = (raw ?? "").trim();
+  if (!s) return null;
+  if (s.length > 256) {
+    throw new Error("branch / ref too long");
+  }
+  if (s.includes("\0") || s.includes("\n") || s.includes("\r")) {
+    throw new Error("invalid branch / ref");
+  }
+  if (s.startsWith("-")) {
+    throw new Error("branch / ref must not start with '-'");
+  }
+  return s;
+}
+
+/** Last non-empty path segment (repo folder / worktree slug). */
+export function worktreeRepoSlug(
+  mainWorktreePath: string | null | undefined,
+): string {
+  const main = normalizeWorktreePath(mainWorktreePath);
+  if (!main) {
+    throw new Error("empty main worktree path");
+  }
+  const base = main.split("/").filter(Boolean).pop();
+  if (!base) {
+    throw new Error("cannot derive repo folder name");
+  }
+  return base;
+}
+
+/**
+ * Shared CLI home root from a user home directory.
+ * Example: `/Users/me` → `/Users/me/.grok`.
+ */
+export function grokHomeFromUserHome(
+  userHome: string | null | undefined,
+): string {
+  const home = normalizeWorktreePath(userHome);
+  if (!home) {
+    throw new Error("empty user home");
+  }
+  return normalizeWorktreePath(`${home}/.grok`);
+}
+
+/**
+ * CLI worktrees root: `{GROK_HOME}/worktrees`.
+ * Accepts either a full GROK_HOME or a user home (when `opts.fromUserHome`).
+ */
+export function cliWorktreesHome(
+  grokOrUserHome: string | null | undefined,
+  opts?: { fromUserHome?: boolean },
+): string {
+  const root = opts?.fromUserHome
+    ? grokHomeFromUserHome(grokOrUserHome)
+    : normalizeWorktreePath(grokOrUserHome);
+  if (!root) {
+    throw new Error("empty grok home");
+  }
+  return normalizeWorktreePath(`${root}/worktrees`);
+}
+
+/**
+ * CLI-aligned path layout (host + UI preview):
+ *   `{GROK_HOME}/worktrees/<main_basename>/<name>`
+ *
+ * Example: grokHome `/Users/me/.grok`, main `/Users/me/Code/oss-grok-app`,
+ * name `feat` → `/Users/me/.grok/worktrees/oss-grok-app/feat`.
+ *
+ * Matches Grok Build 0.2.x (`grok --worktree=…`, `grok worktree list`).
+ */
+export function buildWorktreeCliPath(
+  mainWorktreePath: string | null | undefined,
+  name: string | null | undefined,
+  grokHome: string | null | undefined,
+): string {
+  const main = normalizeWorktreePath(mainWorktreePath);
+  if (!main) {
+    throw new Error("empty main worktree path");
+  }
+  const safe = sanitizeWorktreeName(name);
+  const slug = worktreeRepoSlug(main);
+  const home = normalizeWorktreePath(grokHome);
+  if (!home) {
+    throw new Error("empty grok home");
+  }
+  const out = normalizeWorktreePath(
+    `${cliWorktreesHome(home)}/${slug}/${safe}`,
+  );
+  if (!out || pathsEqual(out, main)) {
+    throw new Error("resolved worktree path is invalid");
+  }
+  return out;
+}
+
+/**
  * Sibling path layout (host + UI preview):
  *   `<parent>/<main_basename>-<name>`
  *
  * Example: main `/Users/me/repo` + `feat` → `/Users/me/repo-feat`.
  *
- * Prefer sibling of the **main** worktree over in-repo `.worktrees/<name>`
- * so linked checkouts sit next to the primary clone (common git worktree UX).
+ * Optional alternative to CLI home layout — keeps checkouts next to the
+ * primary clone (common bare `git worktree add ../repo-feat` practice).
  */
 export function buildWorktreeSiblingPath(
   mainWorktreePath: string | null | undefined,
@@ -270,6 +393,94 @@ export function buildWorktreeSiblingPath(
     throw new Error("resolved worktree path is invalid");
   }
   return out;
+}
+
+/**
+ * Resolve create path for the chosen layout.
+ * `grokHome` is required for `cli` (absolute `~/.grok` or override).
+ */
+export function buildWorktreePath(
+  layout: WorktreeLayout | string | null | undefined,
+  mainWorktreePath: string | null | undefined,
+  name: string | null | undefined,
+  grokHome?: string | null,
+): string {
+  const kind = normalizeWorktreeLayout(layout);
+  if (kind === "sibling") {
+    return buildWorktreeSiblingPath(mainWorktreePath, name);
+  }
+  return buildWorktreeCliPath(mainWorktreePath, name, grokHome);
+}
+
+/**
+ * True when `path` sits under a CLI worktrees home.
+ *
+ * With `grokHome`: strict prefix under `{grokHome}/worktrees/`.
+ * Without: heuristic match on `/.grok/worktrees/` (or Windows `\`).
+ */
+export function isUnderCliWorktreesHome(
+  path: string | null | undefined,
+  grokHome?: string | null,
+): boolean {
+  const p = normalizeWorktreePath(path);
+  if (!p) return false;
+  const home = normalizeWorktreePath(grokHome);
+  if (home) {
+    const root = cliWorktreesHome(home);
+    if (pathsEqual(p, root)) return true;
+    const prefix = root.endsWith("/") ? root : `${root}/`;
+    // Case-fold for Windows drive paths.
+    const pCmp = /^[a-zA-Z]:\//.test(p) ? p.toLowerCase() : p;
+    const prefixCmp = /^[a-zA-Z]:\//.test(prefix) ? prefix.toLowerCase() : prefix;
+    return pCmp.startsWith(prefixCmp);
+  }
+  // Heuristic: …/.grok/worktrees/… (POSIX or Windows separators already normalized).
+  return /(?:^|\/)\.grok\/worktrees(?:\/|$)/i.test(p);
+}
+
+/**
+ * True when `path` looks like a sibling of `main` built as
+ * `<parent>/<main_basename>-<name>` (not under CLI home).
+ */
+export function isSiblingWorktreePath(
+  path: string | null | undefined,
+  mainWorktreePath: string | null | undefined,
+): boolean {
+  const p = normalizeWorktreePath(path);
+  const main = normalizeWorktreePath(mainWorktreePath);
+  if (!p || !main || pathsEqual(p, main)) return false;
+  if (isUnderCliWorktreesHome(p)) return false;
+  let slug: string;
+  try {
+    slug = worktreeRepoSlug(main);
+  } catch {
+    return false;
+  }
+  const base = p.split("/").filter(Boolean).pop() || "";
+  if (!base.startsWith(`${slug}-`)) return false;
+  const parentMain = main.includes("/")
+    ? main.slice(0, main.lastIndexOf("/")) || "/"
+    : "";
+  const parentPath = p.includes("/")
+    ? p.slice(0, p.lastIndexOf("/")) || "/"
+    : "";
+  return pathsEqual(parentMain, parentPath);
+}
+
+/**
+ * Classify a worktree path for sidebar / tooltips.
+ * Prefer CLI home detection; then sibling-of-main; else `other`.
+ */
+export function detectWorktreeLayoutKind(
+  path: string | null | undefined,
+  mainWorktreePath?: string | null,
+  grokHome?: string | null,
+): "cli" | "sibling" | "other" {
+  if (isUnderCliWorktreesHome(path, grokHome)) return "cli";
+  if (mainWorktreePath && isSiblingWorktreePath(path, mainWorktreePath)) {
+    return "sibling";
+  }
+  return "other";
 }
 
 /** Main worktree path from a porcelain list (first entry), if any. */
@@ -321,7 +532,10 @@ export type SessionWorktreeMeta = {
 
 /** Compact sidebar badge + path/branch for tooltip and manage actions. */
 export type SessionWorktreeBadge = {
-  /** Always `"WT"` for the compact sidebar chip. */
+  /**
+   * Compact chip text: `"CLI"` under `~/.grok/worktrees`, else `"WT"`
+   * (sibling / other linked worktrees).
+   */
   label: string;
   /** Absolute worktree path when known. */
   path: string;
@@ -331,6 +545,8 @@ export type SessionWorktreeBadge = {
   fromMeta: boolean;
   /** True when path matched a non-main entry in the porcelain list. */
   fromGitList: boolean;
+  /** Path placement: CLI home vs sibling-of-main vs other. */
+  layoutKind: "cli" | "sibling" | "other";
 };
 
 /** Linked (non-main) worktrees only — main checkout is not a "WT session". */
@@ -350,6 +566,7 @@ export function resolveSessionWorktreeBadge(
   meta: SessionWorktreeMeta | null | undefined,
   projectPath: string | null | undefined,
   worktrees: GitWorktreeEntry[] | null | undefined,
+  opts?: { grokHome?: string | null },
 ): SessionWorktreeBadge | null {
   const metaPath = normalizeWorktreePath(meta?.worktreePath);
   const fromMeta = !!(meta?.isWorktreeSession || metaPath);
@@ -375,30 +592,55 @@ export function resolveSessionWorktreeBadge(
     atProject?.branch?.trim() ||
     null;
 
+  const mainPath = mainWorktreePath(list);
+  const layoutKind = detectWorktreeLayoutKind(
+    path,
+    mainPath,
+    opts?.grokHome,
+  );
+
   return {
-    label: sessionWorktreeBadgeLabel(),
+    label: sessionWorktreeBadgeLabel(layoutKind),
     path,
     branch: branch || null,
     fromMeta,
     fromGitList,
+    layoutKind,
   };
 }
 
-/** Compact badge text for the session list. */
-export function sessionWorktreeBadgeLabel(): string {
-  return "WT";
+/**
+ * Compact badge text for the session list.
+ * CLI home worktrees → `CLI`; sibling / other linked → `WT`.
+ */
+export function sessionWorktreeBadgeLabel(
+  layoutKind?: "cli" | "sibling" | "other" | null,
+): string {
+  return layoutKind === "cli" ? "CLI" : "WT";
 }
 
 /**
- * Tooltip / aria body: branch + path on two lines when both exist.
+ * Tooltip / aria body: layout + branch + path when available.
  */
 export function sessionWorktreeTooltip(
-  badge: Pick<SessionWorktreeBadge, "path" | "branch">,
-  opts?: { detachedLabel?: string },
+  badge: Pick<SessionWorktreeBadge, "path" | "branch" | "layoutKind">,
+  opts?: {
+    detachedLabel?: string;
+    cliLayoutLabel?: string;
+    siblingLayoutLabel?: string;
+    otherLayoutLabel?: string;
+  },
 ): string {
   const detached = (opts?.detachedLabel || "detached").trim() || "detached";
   const branch = (badge.branch || "").trim() || detached;
   const path = normalizeWorktreePath(badge.path);
-  if (path) return `${branch}\n${path}`;
-  return branch;
+  const layoutLabel =
+    badge.layoutKind === "cli"
+      ? (opts?.cliLayoutLabel || "CLI worktrees home").trim()
+      : badge.layoutKind === "sibling"
+        ? (opts?.siblingLayoutLabel || "Sibling worktree").trim()
+        : (opts?.otherLayoutLabel || "Worktree").trim();
+  const lines = [layoutLabel, branch];
+  if (path) lines.push(path);
+  return lines.join("\n");
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -941,6 +941,13 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   opacity: 0.95;
 }
 
+/* CLI home (`~/.grok/worktrees`) — slightly accented so it is distinct from sibling WT. */
+.tree-l3__wt--cli {
+  color: var(--accent, var(--text-secondary));
+  background: color-mix(in srgb, var(--accent, var(--text-tertiary)) 16%, transparent);
+  border-color: color-mix(in srgb, var(--accent, var(--text-tertiary)) 32%, transparent);
+}
+
 .tree-l3__name {
   min-width: 0;
   overflow: hidden;
@@ -3031,6 +3038,34 @@ html[data-sidebar-density="compact"] .session-row__meta {
   font-size: 12.5px;
   font-weight: 500;
   color: var(--text-secondary);
+}
+
+.wt-create__layout {
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+.wt-create__layout .wt-create__label {
+  padding: 0;
+  margin: 0 0 2px;
+}
+
+.wt-create__radio {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.wt-create__radio input {
+  margin-top: 2px;
+  flex-shrink: 0;
 }
 
 .wt-create__preview {


### PR DESCRIPTION
## What

- New worktrees default to the Grok Build CLI layout: `~/.grok/worktrees/<repo>/<name>` (same path family as `grok --worktree` / `grok worktree list`).
- Optional **sibling** layout kept as a radio in the create dialog (`<repo>-<name>` next to the main checkout).
- Start-point field validates like the host (`sanitize_worktree_ref`): no leading `-`, no line breaks.
- **New worktree & chat** still binds session meta (`worktreePath` / branch) and opens the chat with the worktree as project cwd.
- Sidebar badge: **CLI** under `~/.grok/worktrees`, **WT** for sibling/other; tooltip shows layout + branch + path.
- Pure helpers + unit tests in `gitWorktree.ts`; host path builders + tests; i18n en/zh/zh-TW; docs + CHANGELOG.

## Why

App create used only sibling paths, so new worktree sessions did not match Grok Build 0.2.114 CLI placement. Aligning defaults (with an opt-out sibling option) keeps terminal CLI and App worktrees in one place and makes layout obvious in the session list.

## Test

- `pnpm typecheck`
- `pnpm test` (incl. `gitWorktree.test.ts`, i18n catalog)
- `cargo test worktree_path_tests`
- Manual: create worktree (CLI default) → path under `~/.grok/worktrees/<repo>/…`; create with sibling → path next to main; new worktree & chat → session has CLI/WT badge and agent cwd is the worktree; invalid start ref rejected in dialog.