### PR TITLE
feat(dashboard): Agent Dashboard status & project filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ See `docs/llm-wiki/release.md`.
 - **Disallowed built-in tools** (Settings → General → Agent): chips + freeform list → `AppSettings.disallowedTools` / CLI `--disallowed-tools a,b`; coexists with Disable web search; soft-respawn on change
 - **Agent profile path** (Settings → General → Agent): optional file for `grok agent --agent-profile`; soft-respawns on change
 - **Agent serve** start/stop from Settings → Runtime → Connection (`grok agent serve --bind/--secret`; default `127.0.0.1:2419`; masked secret + one-time connection URL copy)
+- **Agent dashboard filters**: status chips with per-status counts (all / busy / permission / connecting / idle / error), free-text session search, project id/name/path filter, empty-filter state + clear; **Stop all busy** still targets every stoppable session globally (not only the filtered list)
 
 #### Permissions / CLI
 - **CLI `--permission-mode` alignment**: pure App policy / YOLO / plan-mode map (`default` · `acceptEdits` · `auto` · `dontAsk` · `bypassPermissions` · `plan`); spawn pins top-level `--permission-mode` (+ agent `--always-approve` for YOLO); Settings shows CLI label + advanced mode selector; product **Auto** policy
@@ -54,6 +55,7 @@ See `docs/llm-wiki/release.md`.
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 在设置 → 运行时 → 连接启停（掩码密钥 + 启动时复制连接 URL）
+- **Agent 仪表盘筛选**：状态芯片（计数）、会话搜索、项目筛选、无匹配空态；「全部停止忙碌」仍针对全局可停止会话（非仅筛选结果）
 - **权限/CLI**：对齐 `--permission-mode` 映射与 spawn；设置页展示 CLI 标签与高级选择；新增 **Auto** 策略
 
 **中文 · 修复**

--- a/src/components/AgentDashboardModal.tsx
+++ b/src/components/AgentDashboardModal.tsx
@@ -8,11 +8,14 @@ import type { Locale, MessageKey } from "@/i18n";
 import { createT } from "@/i18n";
 import { GlassModal } from "@/components/GlassModal";
 import {
+  AGENT_DASHBOARD_STATUS_FILTERS,
   countBusyDashboardRows,
+  countDashboardRowsByStatus,
   filterAgentDashboardRows,
   stoppableDashboardRows,
   type AgentDashboardRow,
   type AgentDashboardStatus,
+  type AgentDashboardStatusFilter,
 } from "@/lib/agentDashboard";
 import { formatRelativeTime } from "@/lib/accountUi";
 
@@ -31,6 +34,14 @@ function statusLabel(status: AgentDashboardStatus, t: TFn): string {
     default:
       return t("dashboard.status.idle");
   }
+}
+
+function statusFilterLabel(
+  filter: AgentDashboardStatusFilter,
+  t: TFn,
+): string {
+  if (filter === "all") return t("dashboard.filter.all");
+  return statusLabel(filter, t);
 }
 
 function statusDotClass(status: AgentDashboardStatus): string {
@@ -135,7 +146,10 @@ export type AgentDashboardModalProps = {
   rows: AgentDashboardRow[];
   onClose: () => void;
   onSelectSession?: (sessionId: string) => void;
-  /** Reuse App stop-all (confirm lives in App). */
+  /**
+   * Reuse App stop-all (confirm lives in App).
+   * Stops **all** busy sessions globally — not only the currently filtered list.
+   */
   onStopAllBusy?: () => void;
 };
 
@@ -149,13 +163,31 @@ export function AgentDashboardModal({
 }: AgentDashboardModalProps) {
   const tr = useMemo(() => createT(locale), [locale]);
   const [query, setQuery] = useState("");
+  const [projectQuery, setProjectQuery] = useState("");
+  const [statusFilter, setStatusFilter] =
+    useState<AgentDashboardStatusFilter>("all");
+
   const filtered = useMemo(
-    () => filterAgentDashboardRows(rows, query),
-    [rows, query],
+    () =>
+      filterAgentDashboardRows(rows, {
+        query,
+        projectQuery,
+        status: statusFilter,
+      }),
+    [rows, query, projectQuery, statusFilter],
   );
+  const statusCounts = useMemo(() => countDashboardRowsByStatus(rows), [rows]);
   const busyCount = useMemo(() => countBusyDashboardRows(rows), [rows]);
+  // Stop-all targets every stoppable row in the dashboard, not only the filter.
   const stoppable = useMemo(() => stoppableDashboardRows(rows), [rows]);
   const showStopAll = !!onStopAllBusy && stoppable.length > 0;
+
+  const hasActiveFilters =
+    statusFilter !== "all" ||
+    query.trim().length > 0 ||
+    projectQuery.trim().length > 0;
+  const isEmptyCatalog = rows.length === 0;
+  const isEmptyFilter = !isEmptyCatalog && filtered.length === 0;
 
   return (
     <GlassModal
@@ -175,6 +207,7 @@ export function AgentDashboardModal({
               type="button"
               className="btn btn--ghost"
               onClick={onStopAllBusy}
+              title={tr("dashboard.stopAllTitle")}
             >
               {tr("dashboard.stopAll")}
             </button>
@@ -186,6 +219,32 @@ export function AgentDashboardModal({
       }
     >
       <p className="agent-dash__hint">{tr("dashboard.hint")}</p>
+      <div
+        className="agent-dash__chips"
+        role="tablist"
+        aria-label={tr("dashboard.filter.statusLabel")}
+      >
+        {AGENT_DASHBOARD_STATUS_FILTERS.map((id) => {
+          const n = statusCounts[id];
+          // Hide zero-count status chips except "all" and the active selection.
+          if (id !== "all" && n === 0 && statusFilter !== id) return null;
+          return (
+            <button
+              key={id}
+              type="button"
+              role="tab"
+              aria-selected={statusFilter === id}
+              className={
+                "agent-dash__chip" + (statusFilter === id ? " is-active" : "")
+              }
+              onClick={() => setStatusFilter(id)}
+            >
+              <span>{statusFilterLabel(id, (k, vars) => tr(k, vars))}</span>
+              <span className="agent-dash__chip-count">{n}</span>
+            </button>
+          );
+        })}
+      </div>
       <div className="agent-dash__toolbar">
         <input
           type="search"
@@ -197,16 +256,48 @@ export function AgentDashboardModal({
           spellCheck={false}
           aria-label={tr("dashboard.searchPlaceholder")}
         />
+        <input
+          type="search"
+          className="settings-input agent-dash__search agent-dash__search--project"
+          value={projectQuery}
+          onChange={(e) => setProjectQuery(e.target.value)}
+          placeholder={tr("dashboard.projectSearchPlaceholder")}
+          autoComplete="off"
+          spellCheck={false}
+          aria-label={tr("dashboard.projectSearchPlaceholder")}
+        />
         {busyCount > 0 ? (
           <span className="agent-dash__badge">
             {tr("dashboard.busyCount", { n: busyCount })}
           </span>
         ) : null}
       </div>
-      {filtered.length === 0 ? (
+      {isEmptyCatalog ? (
         <div className="agent-dash__empty">
           <p className="agent-dash__empty-title">{tr("dashboard.empty")}</p>
           <p className="agent-dash__empty-hint">{tr("dashboard.emptyHint")}</p>
+        </div>
+      ) : isEmptyFilter ? (
+        <div className="agent-dash__empty">
+          <p className="agent-dash__empty-title">
+            {tr("dashboard.filterEmpty")}
+          </p>
+          <p className="agent-dash__empty-hint">
+            {tr("dashboard.filterEmptyHint")}
+          </p>
+          {hasActiveFilters ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm agent-dash__clear-filters"
+              onClick={() => {
+                setQuery("");
+                setProjectQuery("");
+                setStatusFilter("all");
+              }}
+            >
+              {tr("dashboard.clearFilters")}
+            </button>
+          ) : null}
         </div>
       ) : (
         <ul className="agent-dash__list" role="list">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -537,11 +537,20 @@ const en = {
   "dashboard.hint":
     "Active and recent sessions across the app. Open a row to focus that chat. Distinct from Tasks (tools for the current turn).",
   "dashboard.searchPlaceholder": "Filter sessions…",
+  "dashboard.projectSearchPlaceholder": "Filter by project…",
+  "dashboard.filter.statusLabel": "Filter by status",
+  "dashboard.filter.all": "All",
   "dashboard.empty": "No sessions to show",
   "dashboard.emptyHint":
     "Start a chat or wait for an agent turn — busy and recent sessions appear here.",
+  "dashboard.filterEmpty": "No sessions match these filters",
+  "dashboard.filterEmptyHint":
+    "Clear the search or pick another status to see more sessions.",
+  "dashboard.clearFilters": "Clear filters",
   "dashboard.busyCount": "{n} busy",
   "dashboard.stopAll": "Stop all busy",
+  "dashboard.stopAllTitle":
+    "Stop every busy session in the app (not only the filtered list)",
   "dashboard.openSession": "Open session",
   "dashboard.current": "(this chat)",
   "dashboard.status.busy": "Busy",
@@ -3446,11 +3455,18 @@ const zh: Record<MessageKey, string> = {
   "dashboard.hint":
     "应用内活跃与最近会话。点击一行可聚焦该对话。与「任务」面板（当前回合工具）不同。",
   "dashboard.searchPlaceholder": "筛选会话…",
+  "dashboard.projectSearchPlaceholder": "按项目筛选…",
+  "dashboard.filter.statusLabel": "按状态筛选",
+  "dashboard.filter.all": "全部",
   "dashboard.empty": "暂无会话",
   "dashboard.emptyHint":
     "开始对话或等待 Agent 回合 — 忙碌与最近会话会出现在这里。",
+  "dashboard.filterEmpty": "没有符合筛选条件的会话",
+  "dashboard.filterEmptyHint": "清空搜索或换一个状态以查看更多会话。",
+  "dashboard.clearFilters": "清除筛选",
   "dashboard.busyCount": "{n} 个忙碌",
   "dashboard.stopAll": "全部停止忙碌",
+  "dashboard.stopAllTitle": "停止应用内全部忙碌会话（不仅限于当前筛选结果）",
   "dashboard.openSession": "打开会话",
   "dashboard.current": "（当前）",
   "dashboard.status.busy": "忙碌",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -505,11 +505,18 @@ export const zhTW: Record<MessageKey, string> = {
   "dashboard.hint":
     "應用程式內活躍與最近工作階段。點一列可聚焦該對話。與「任務」面板（目前回合工具）不同。",
   "dashboard.searchPlaceholder": "篩選工作階段…",
+  "dashboard.projectSearchPlaceholder": "依專案篩選…",
+  "dashboard.filter.statusLabel": "依狀態篩選",
+  "dashboard.filter.all": "全部",
   "dashboard.empty": "尚無工作階段",
   "dashboard.emptyHint":
     "開始對話或等待 Agent 回合 — 忙碌與最近工作階段會出現在這裡。",
+  "dashboard.filterEmpty": "沒有符合篩選條件的工作階段",
+  "dashboard.filterEmptyHint": "清空搜尋或換一個狀態以查看更多工作階段。",
+  "dashboard.clearFilters": "清除篩選",
   "dashboard.busyCount": "{n} 個忙碌",
   "dashboard.stopAll": "全部停止忙碌",
+  "dashboard.stopAllTitle": "停止應用程式內全部忙碌工作階段（不僅限於目前篩選結果）",
   "dashboard.openSession": "開啟工作階段",
   "dashboard.current": "（目前）",
   "dashboard.status.busy": "忙碌",

--- a/src/lib/agentDashboard.test.ts
+++ b/src/lib/agentDashboard.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  AGENT_DASHBOARD_STATUS_FILTERS,
   collectAgentDashboardRows,
   countBusyDashboardRows,
+  countDashboardRowsByStatus,
   dashboardStatusFromSessionState,
   filterAgentDashboardRows,
   isStoppableDashboardStatus,
   mapDashboardStatus,
+  matchAgentDashboardProject,
   stoppableDashboardRows,
   type AgentDashboardRow,
 } from "./agentDashboard";
@@ -261,18 +264,246 @@ describe("filterAgentDashboardRows", () => {
       updatedAtIso: null,
       stoppable: false,
     },
+    {
+      sessionId: "c",
+      title: "Auth gate",
+      projectId: "p2",
+      projectName: "api-server",
+      projectPath: "/code/api-server",
+      modelId: "grok-4",
+      effort: "high",
+      status: "permission",
+      liveToolTitle: null,
+      isCurrent: false,
+      lastActivityAt: 8,
+      updatedAtIso: null,
+      stoppable: true,
+    },
+    {
+      sessionId: "d",
+      title: "Spin up",
+      projectId: "p1",
+      projectName: "grok-app",
+      projectPath: "/code/grok-app",
+      modelId: null,
+      effort: null,
+      status: "connecting",
+      liveToolTitle: null,
+      isCurrent: false,
+      lastActivityAt: 7,
+      updatedAtIso: null,
+      stoppable: true,
+    },
+    {
+      sessionId: "e",
+      title: "Dropped",
+      projectId: "p2",
+      projectName: "api-server",
+      projectPath: "/code/api-server",
+      modelId: "grok-3",
+      effort: null,
+      status: "error",
+      liveToolTitle: null,
+      isCurrent: false,
+      lastActivityAt: 1,
+      updatedAtIso: null,
+      stoppable: false,
+    },
   ];
 
-  it("filters by title / project / model", () => {
+  it("filters by title / project / model (string form)", () => {
     expect(filterAgentDashboardRows(sample, "ci").map((r) => r.sessionId)).toEqual(
       ["a"],
     );
     expect(
       filterAgentDashboardRows(sample, "grok-3").map((r) => r.sessionId),
-    ).toEqual(["b"]);
+    ).toEqual(["b", "e"]);
     expect(
       filterAgentDashboardRows(sample, "grok-app").map((r) => r.sessionId),
+    ).toEqual(["a", "d"]);
+    expect(filterAgentDashboardRows(sample, "  ")).toHaveLength(5);
+  });
+
+  it("filters by status chip", () => {
+    expect(
+      filterAgentDashboardRows(sample, { status: "all" }).map((r) => r.sessionId),
+    ).toEqual(["a", "b", "c", "d", "e"]);
+    expect(
+      filterAgentDashboardRows(sample, { status: "busy" }).map((r) => r.sessionId),
     ).toEqual(["a"]);
-    expect(filterAgentDashboardRows(sample, "  ")).toHaveLength(2);
+    expect(
+      filterAgentDashboardRows(sample, { status: "permission" }).map(
+        (r) => r.sessionId,
+      ),
+    ).toEqual(["c"]);
+    expect(
+      filterAgentDashboardRows(sample, { status: "idle" }).map((r) => r.sessionId),
+    ).toEqual(["b"]);
+    expect(
+      filterAgentDashboardRows(sample, { status: "error" }).map((r) => r.sessionId),
+    ).toEqual(["e"]);
+  });
+
+  it("filters by project id / name / path substring", () => {
+    expect(
+      filterAgentDashboardRows(sample, { projectQuery: "p1" }).map(
+        (r) => r.sessionId,
+      ),
+    ).toEqual(["a", "d"]);
+    expect(
+      filterAgentDashboardRows(sample, { projectQuery: "API" }).map(
+        (r) => r.sessionId,
+      ),
+    ).toEqual(["c", "e"]);
+    expect(
+      filterAgentDashboardRows(sample, { projectQuery: "/code/grok" }).map(
+        (r) => r.sessionId,
+      ),
+    ).toEqual(["a", "d"]);
+    expect(
+      filterAgentDashboardRows(sample, { projectQuery: "   " }),
+    ).toHaveLength(5);
+  });
+
+  it("combines status + project + free-text with AND", () => {
+    expect(
+      filterAgentDashboardRows(sample, {
+        status: "busy",
+        projectQuery: "p1",
+        query: "ci",
+      }).map((r) => r.sessionId),
+    ).toEqual(["a"]);
+    expect(
+      filterAgentDashboardRows(sample, {
+        status: "busy",
+        projectQuery: "api",
+      }),
+    ).toHaveLength(0);
+    expect(
+      filterAgentDashboardRows(sample, {
+        status: "permission",
+        query: "auth",
+      }).map((r) => r.sessionId),
+    ).toEqual(["c"]);
+  });
+});
+
+describe("countDashboardRowsByStatus", () => {
+  it("returns total and per-status counts", () => {
+    const rows: AgentDashboardRow[] = [
+      {
+        sessionId: "a",
+        title: "A",
+        projectId: null,
+        projectName: null,
+        projectPath: null,
+        modelId: null,
+        effort: null,
+        status: "busy",
+        liveToolTitle: null,
+        isCurrent: false,
+        lastActivityAt: 1,
+        updatedAtIso: null,
+        stoppable: true,
+      },
+      {
+        sessionId: "b",
+        title: "B",
+        projectId: null,
+        projectName: null,
+        projectPath: null,
+        modelId: null,
+        effort: null,
+        status: "busy",
+        liveToolTitle: null,
+        isCurrent: false,
+        lastActivityAt: 1,
+        updatedAtIso: null,
+        stoppable: true,
+      },
+      {
+        sessionId: "c",
+        title: "C",
+        projectId: null,
+        projectName: null,
+        projectPath: null,
+        modelId: null,
+        effort: null,
+        status: "idle",
+        liveToolTitle: null,
+        isCurrent: false,
+        lastActivityAt: 1,
+        updatedAtIso: null,
+        stoppable: false,
+      },
+      {
+        sessionId: "d",
+        title: "D",
+        projectId: null,
+        projectName: null,
+        projectPath: null,
+        modelId: null,
+        effort: null,
+        status: "error",
+        liveToolTitle: null,
+        isCurrent: false,
+        lastActivityAt: 1,
+        updatedAtIso: null,
+        stoppable: false,
+      },
+    ];
+    expect(countDashboardRowsByStatus(rows)).toEqual({
+      all: 4,
+      busy: 2,
+      permission: 0,
+      connecting: 0,
+      idle: 1,
+      error: 1,
+    });
+    expect(countDashboardRowsByStatus([])).toEqual({
+      all: 0,
+      busy: 0,
+      permission: 0,
+      connecting: 0,
+      idle: 0,
+      error: 0,
+    });
+  });
+
+  it("lists every chip status in AGENT_DASHBOARD_STATUS_FILTERS", () => {
+    expect([...AGENT_DASHBOARD_STATUS_FILTERS]).toEqual([
+      "all",
+      "busy",
+      "permission",
+      "connecting",
+      "idle",
+      "error",
+    ]);
+  });
+});
+
+describe("matchAgentDashboardProject", () => {
+  const row: AgentDashboardRow = {
+    sessionId: "a",
+    title: "Fix",
+    projectId: "proj-42",
+    projectName: "grok-app",
+    projectPath: "/Users/me/Code/grok-app",
+    modelId: null,
+    effort: null,
+    status: "idle",
+    liveToolTitle: null,
+    isCurrent: false,
+    lastActivityAt: 0,
+    updatedAtIso: null,
+    stoppable: false,
+  };
+
+  it("matches id, name, or path substring", () => {
+    expect(matchAgentDashboardProject(row, "")).toBe(true);
+    expect(matchAgentDashboardProject(row, "proj-42")).toBe(true);
+    expect(matchAgentDashboardProject(row, "GROK")).toBe(true);
+    expect(matchAgentDashboardProject(row, "/users/me")).toBe(true);
+    expect(matchAgentDashboardProject(row, "missing")).toBe(false);
   });
 });

--- a/src/lib/agentDashboard.ts
+++ b/src/lib/agentDashboard.ts
@@ -226,18 +226,102 @@ export function countBusyDashboardRows(rows: AgentDashboardRow[]): number {
   return rows.filter((r) => isStoppableDashboardStatus(r.status)).length;
 }
 
-/** Filter rows by free-text query (title, project, model, path, status). */
+/**
+ * Status chip filter values (single-select).
+ * `"all"` shows every row; other values match {@link AgentDashboardStatus}.
+ */
+export type AgentDashboardStatusFilter = "all" | AgentDashboardStatus;
+
+/** Ordered chip list for the dashboard status filter bar. */
+export const AGENT_DASHBOARD_STATUS_FILTERS: readonly AgentDashboardStatusFilter[] =
+  ["all", "busy", "permission", "connecting", "idle", "error"] as const;
+
+/** Per-status counts plus total (`all`). Used for chip badges. */
+export type AgentDashboardStatusCounts = Record<
+  AgentDashboardStatusFilter,
+  number
+>;
+
+/** Count rows per status (and total under `all`). */
+export function countDashboardRowsByStatus(
+  rows: AgentDashboardRow[],
+): AgentDashboardStatusCounts {
+  const counts: AgentDashboardStatusCounts = {
+    all: rows.length,
+    busy: 0,
+    permission: 0,
+    connecting: 0,
+    idle: 0,
+    error: 0,
+  };
+  for (const r of rows) {
+    counts[r.status] += 1;
+  }
+  return counts;
+}
+
+/**
+ * Match a row against a project id / name / path substring (case-insensitive).
+ * Empty query matches everything.
+ */
+export function matchAgentDashboardProject(
+  row: AgentDashboardRow,
+  projectQuery: string,
+): boolean {
+  const q = projectQuery.trim().toLowerCase();
+  if (!q) return true;
+  const hay = [row.projectId || "", row.projectName || "", row.projectPath || ""]
+    .join("\n")
+    .toLowerCase();
+  return hay.includes(q);
+}
+
+/** Combined dashboard list filters (status chips + text + project). */
+export interface AgentDashboardFilter {
+  /** Free-text over title, project, model, path, status, tool, sessionId. */
+  query?: string;
+  /** Status chip; default `"all"`. */
+  status?: AgentDashboardStatusFilter;
+  /** Project id / name / path substring. */
+  projectQuery?: string;
+}
+
+function normalizeDashboardFilter(
+  queryOrFilter: string | AgentDashboardFilter | undefined,
+): AgentDashboardFilter {
+  if (queryOrFilter == null) return {};
+  if (typeof queryOrFilter === "string") return { query: queryOrFilter };
+  return queryOrFilter;
+}
+
+/**
+ * Filter rows by free-text query, status chip, and/or project substring.
+ *
+ * Accepts a plain string (legacy free-text only) or a structured
+ * {@link AgentDashboardFilter}. Filters combine with AND.
+ */
 export function filterAgentDashboardRows(
   rows: AgentDashboardRow[],
-  query: string,
+  queryOrFilter: string | AgentDashboardFilter = "",
 ): AgentDashboardRow[] {
-  const q = query.trim().toLowerCase();
-  if (!q) return rows;
-  return rows.filter((r) => {
+  const filter = normalizeDashboardFilter(queryOrFilter);
+  const status = filter.status ?? "all";
+  let out = rows;
+  if (status !== "all") {
+    out = out.filter((r) => r.status === status);
+  }
+  if (filter.projectQuery?.trim()) {
+    const pq = filter.projectQuery;
+    out = out.filter((r) => matchAgentDashboardProject(r, pq));
+  }
+  const q = (filter.query ?? "").trim().toLowerCase();
+  if (!q) return out;
+  return out.filter((r) => {
     const hay = [
       r.title,
       r.projectName || "",
       r.projectPath || "",
+      r.projectId || "",
       r.modelId || "",
       r.effort || "",
       r.status,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -19580,20 +19580,66 @@ html[data-theme="light"] .rim-sidebar {
   line-height: 1.45;
   flex-shrink: 0;
 }
+.agent-dash__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.agent-dash__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.3;
+  cursor: pointer;
+}
+.agent-dash__chip:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.agent-dash__chip.is-active {
+  border-color: color-mix(in srgb, var(--accent, #6b8cff) 30%, transparent);
+  background: color-mix(in srgb, var(--accent, #6b8cff) 14%, transparent);
+  color: var(--text-primary);
+  font-weight: 560;
+}
+.agent-dash__chip-count {
+  font-size: 11px;
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+.agent-dash__chip.is-active .agent-dash__chip-count {
+  opacity: 0.9;
+}
 .agent-dash__toolbar {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   flex-shrink: 0;
 }
 .agent-dash__search {
   flex: 1;
-  min-width: 0;
+  min-width: 120px;
+}
+.agent-dash__search--project {
+  flex: 0.9;
 }
 .agent-dash__badge {
   font-size: 11px;
   opacity: 0.8;
   white-space: nowrap;
+}
+.agent-dash__clear-filters {
+  margin-top: 10px;
 }
 .agent-dash__list {
   list-style: none;


### PR DESCRIPTION
## Summary

DASH-PARITY: richer **Agent Dashboard** filters for multi-session ops.

- **Status filter chips** with per-status counts: All · Busy · Permission · Connecting · Idle · Error (zero-count chips hidden unless selected)
- **Session free-text search** (title / model / path / tool / id)
- **Project filter** by id / name / path substring
- **Empty filter state** + clear filters when nothing matches
- **Stop all busy** stays **global** (every stoppable session), not limited to the filtered list — tooltip documents this

## Files

- `src/lib/agentDashboard.ts` — pure helpers: `countDashboardRowsByStatus`, `matchAgentDashboardProject`, structured `filterAgentDashboardRows`
- `src/lib/agentDashboard.test.ts` — unit coverage
- `src/components/AgentDashboardModal.tsx` — chips + dual search + empty states
- `src/styles/app.css` — chip toolbar styles
- i18n `en` / `zh` / `zh-TW`
- `CHANGELOG.md` Unreleased

## Behavior notes

| Action | Scope |
|--------|--------|
| Status chips / search / project filter | Filter the visible list only |
| Open session | Unchanged (select + close modal) |
| **Stop all busy** | All stoppable rows in the dashboard (`busy` / `permission` / `connecting`), **not** only filtered |

## Test plan

- [x] `pnpm test -- src/lib/agentDashboard.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: open Agent dashboard with mixed statuses → chips show counts; filter by busy; project search; empty state + clear; Stop all busy stops every busy session while a filter is active