### PR TITLE
feat(shortcuts): conflict visualization in Settings → Keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ See `docs/llm-wiki/release.md`.
 #### Appearance / app shell
 - **Theme schedule** (System + clock) · **follow system language**
 - **Confirm quit while busy** (in-app dialog; optional skip) · **dock/tray busy badge**
+- **Shortcut conflicts** (Settings → Keyboard): panel lists chords shared by multiple actions; capture warns in-app before save; optional **Reset conflicting to default** (pure `findChordConflicts` + tests)
 
 #### Tasks / system
 - Tasks tree · Stop-all skip-confirm · Plan history · Mirror write guard · Reliability / Leader / Memory / MCP / CLI notice (prior)
@@ -51,7 +52,7 @@ See `docs/llm-wiki/release.md`.
 
 - **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片、会话变更审阅（+/− · 并排 diff · j/k）、结构化 JSON 回复面板（校验/复制/导出）、上下文用量/费用粗估
 - **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、会话规则（`--rules`）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
-- **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标
+- **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标、快捷键冲突面板（录制警告 + 重置冲突项）
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 在设置 → 运行时 → 连接启停（掩码密钥 + 启动时复制连接 URL）
 - **权限/CLI**：对齐 `--permission-mode` 映射与 spawn；设置页展示 CLI 标签与高级选择；新增 **Auto** 策略

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -64,9 +64,12 @@ import {
   chordFromKeyboardEvent,
   clearAllShortcutRemaps,
   findChordConflict,
+  findChordConflicts,
+  formatChordDisplay,
   hasAnyShortcutRemaps,
   isRemappableShortcutId,
   loadShortcutRemaps,
+  resetConflictingShortcutRemaps,
   setShortcutRecordingActive,
   setShortcutRemap,
   type ShortcutRemapMap,
@@ -5361,6 +5364,23 @@ function ShortcutsSettingsPanel({
     [filterQuery, groups, t],
   );
 
+  const conflictGroups = useMemo(
+    () => findChordConflicts(remaps),
+    [remaps],
+  );
+  const conflictIdSet = useMemo(() => {
+    const s = new Set<ShortcutId>();
+    for (const g of conflictGroups) {
+      for (const id of g.ids) s.add(id);
+    }
+    return s;
+  }, [conflictGroups]);
+
+  const shortcutLabel = (id: ShortcutId): string => {
+    const row = SHORTCUTS.find((s) => s.id === id);
+    return row ? t(row.labelKey as MessageKey) : id;
+  };
+
   const groupLabel = (g: ShortcutGroup) =>
     t(`settings.shortcuts.group.${g}` as MessageKey);
 
@@ -5381,6 +5401,12 @@ function ShortcutsSettingsPanel({
 
   const resetAll = () => {
     setRemaps(clearAllShortcutRemaps());
+    setRecordingId(null);
+    setRecordError(null);
+  };
+
+  const resetConflicting = () => {
+    setRemaps(resetConflictingShortcutRemaps(remaps));
     setRecordingId(null);
     setRecordError(null);
   };
@@ -5426,6 +5452,47 @@ function ShortcutsSettingsPanel({
           disabled={!!recordingId}
         />
       </div>
+      {conflictGroups.length > 0 ? (
+        <div
+          className="settings-shortcuts-conflicts"
+          role="region"
+          aria-label={t("settings.shortcuts.conflictsTitle")}
+        >
+          <div className="settings-shortcuts-conflicts__header">
+            <div className="settings-shortcuts-conflicts__text">
+              <div className="settings-shortcuts-conflicts__title">
+                {t("settings.shortcuts.conflictsTitle")}
+              </div>
+              <div className="settings-shortcuts-conflicts__desc">
+                {t("settings.shortcuts.conflictsDesc")}
+              </div>
+            </div>
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              disabled={!!recordingId}
+              onClick={() => resetConflicting()}
+            >
+              {t("settings.shortcuts.conflictsReset")}
+            </button>
+          </div>
+          <ul className="settings-shortcuts-conflicts__list">
+            {conflictGroups.map((group) => (
+              <li key={group.chord} className="settings-shortcuts-conflicts__item">
+                <kbd className="settings-shortcuts-kbd">
+                  {formatChordDisplay(
+                    group.chord,
+                    platform === "mac" ? "mac" : "win",
+                  )}
+                </kbd>
+                <span className="settings-shortcuts-conflicts__actions">
+                  {group.ids.map((id) => shortcutLabel(id)).join(" · ")}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
       {recordError ? (
         <p className="settings-shortcuts-error" role="alert">
           {recordError}
@@ -5477,16 +5544,18 @@ function ShortcutsSettingsPanel({
                   const remappable = isRemappableShortcutId(row.id);
                   const isCustom = remappable && !!remaps[row.id];
                   const isRecording = recordingId === row.id;
+                  const isConflict = conflictIdSet.has(row.id);
+                  const rowClass = [
+                    isRecording ? "settings-shortcuts-row--recording" : "",
+                    isCustom ? "settings-shortcuts-row--custom" : "",
+                    isConflict ? "settings-shortcuts-row--conflict" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ");
                   return (
                     <tr
                       key={row.id}
-                      className={
-                        isRecording
-                          ? "settings-shortcuts-row--recording"
-                          : isCustom
-                            ? "settings-shortcuts-row--custom"
-                            : undefined
-                      }
+                      className={rowClass || undefined}
                     >
                       <td>
                         {t(row.labelKey as MessageKey)}
@@ -5500,7 +5569,8 @@ function ShortcutsSettingsPanel({
                         <kbd
                           className={
                             "settings-shortcuts-kbd" +
-                            (isRecording ? " is-recording" : "")
+                            (isRecording ? " is-recording" : "") +
+                            (isConflict && !isRecording ? " is-conflict" : "")
                           }
                         >
                           {isRecording
@@ -5514,7 +5584,8 @@ function ShortcutsSettingsPanel({
                         <kbd
                           className={
                             "settings-shortcuts-kbd" +
-                            (isRecording ? " is-recording" : "")
+                            (isRecording ? " is-recording" : "") +
+                            (isConflict && !isRecording ? " is-conflict" : "")
                           }
                         >
                           {isRecording

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -953,7 +953,11 @@ const en = {
   "settings.shortcuts.pressKeys": "Press keys…",
   "settings.shortcuts.recordingHint":
     "Press a new shortcut (include ⌘/Ctrl). Escape cancels.",
-  "settings.shortcuts.conflict": "That chord is already used by “{action}”.",
+  "settings.shortcuts.conflict": "That chord is already used by “{action}”. Choose another chord or cancel.",
+  "settings.shortcuts.conflictsTitle": "Conflicts",
+  "settings.shortcuts.conflictsDesc":
+    "These chords are bound to more than one action. Only one binding can win at runtime — reset or re-record the extras.",
+  "settings.shortcuts.conflictsReset": "Reset conflicting to default",
   "settings.shortcuts.customBadge": "Custom binding",
   "settings.shortcuts.fixed": "Fixed",
   "settings.shortcuts.fixedSend": "Composer pref",
@@ -3845,7 +3849,11 @@ const zh: Record<MessageKey, string> = {
   "settings.shortcuts.pressKeys": "请按键…",
   "settings.shortcuts.recordingHint":
     "按下新的快捷键（需包含 ⌘/Ctrl）。Esc 取消录制。",
-  "settings.shortcuts.conflict": "该组合键已被「{action}」占用。",
+  "settings.shortcuts.conflict": "该组合键已被「{action}」占用。请换一组键，或取消录制。",
+  "settings.shortcuts.conflictsTitle": "冲突",
+  "settings.shortcuts.conflictsDesc":
+    "以下组合键绑定了多个操作。运行时只会生效其中一个——请重置或重新录制多余的绑定。",
+  "settings.shortcuts.conflictsReset": "将冲突项重置为默认",
   "settings.shortcuts.customBadge": "自定义绑定",
   "settings.shortcuts.fixed": "固定",
   "settings.shortcuts.fixedSend": "对话偏好",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -904,7 +904,11 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.shortcuts.pressKeys": "請按鍵…",
   "settings.shortcuts.recordingHint":
     "按下新的快捷鍵（需包含 ⌘/Ctrl）。Esc 取消錄製。",
-  "settings.shortcuts.conflict": "該組合鍵已被「{action}」占用。",
+  "settings.shortcuts.conflict": "該組合鍵已被「{action}」占用。請換一組鍵，或取消錄製。",
+  "settings.shortcuts.conflictsTitle": "衝突",
+  "settings.shortcuts.conflictsDesc":
+    "以下組合鍵綁定了多個操作。執行時只會生效其中一個——請重設或重新錄製多餘的綁定。",
+  "settings.shortcuts.conflictsReset": "將衝突項重設為預設",
   "settings.shortcuts.customBadge": "自訂綁定",
   "settings.shortcuts.fixed": "固定",
   "settings.shortcuts.fixedSend": "對話偏好",

--- a/src/lib/shortcutRemap.test.ts
+++ b/src/lib/shortcutRemap.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import {
+  CHORD_CONFLICT_IGNORE_IDS,
   DEFAULT_SHORTCUT_CHORDS,
   REMAPPABLE_SHORTCUT_IDS,
   SHORTCUT_REMAP_STORAGE_KEY,
@@ -9,10 +10,12 @@ import {
   clearAllShortcutRemaps,
   effectiveShortcutChord,
   findChordConflict,
+  findChordConflicts,
   formatChordDisplay,
   loadShortcutRemaps,
   normalizeChordString,
   parseChord,
+  resetConflictingShortcutRemaps,
   saveShortcutRemaps,
   serializeChord,
   setShortcutRemap,
@@ -231,6 +234,122 @@ describe("findChordConflict", () => {
     const effective = buildEffectiveChordMap({ search: "mod+p" });
     expect(findChordConflict("search", "mod+p", effective)).toBeNull();
     expect(findChordConflict("help", "mod+p", effective)).toBe("search");
+  });
+
+  it("skips display-only conflict-ignore ids", () => {
+    const effective = buildEffectiveChordMap();
+    // send default is enter — ignored even if present in the map
+    expect(findChordConflict("stop", "enter", effective)).toBeNull();
+  });
+});
+
+describe("findChordConflicts", () => {
+  it("returns empty when all defaults are unique", () => {
+    expect(findChordConflicts({})).toEqual([]);
+    expect(findChordConflicts(null)).toEqual([]);
+  });
+
+  it("groups ids that share a normalized chord after remaps", () => {
+    // newChat remapped onto search's default mod+k
+    const groups = findChordConflicts({ newChat: "mod+k" });
+    expect(groups).toEqual([
+      { chord: "mod+k", ids: ["newChat", "search"] },
+    ]);
+  });
+
+  it("detects two remaps colliding on a free chord", () => {
+    const groups = findChordConflicts({
+      search: "mod+p",
+      help: "mod+p",
+    });
+    expect(groups).toEqual([{ chord: "mod+p", ids: ["help", "search"] }]);
+  });
+
+  it("normalizes aliases before comparing", () => {
+    const groups = findChordConflicts({
+      search: "Cmd+P",
+      settings: "mod+p",
+    });
+    expect(groups).toEqual([
+      { chord: "mod+p", ids: ["search", "settings"] },
+    ]);
+  });
+
+  it("reports three-way collisions", () => {
+    const groups = findChordConflicts({
+      newChat: "mod+k",
+      help: "mod+k",
+    });
+    expect(groups).toEqual([
+      { chord: "mod+k", ids: ["help", "newChat", "search"] },
+    ]);
+  });
+
+  it("excludes display-only ignore ids (send / sidebarSessionNav)", () => {
+    expect(CHORD_CONFLICT_IGNORE_IDS.has("send")).toBe(true);
+    expect(CHORD_CONFLICT_IGNORE_IDS.has("sidebarSessionNav")).toBe(true);
+    // Even if a remap used bare "j", sidebarSessionNav must not join a group.
+    // (Recording UI cannot bind bare j; this guards the pure helper.)
+    const groups = findChordConflicts({
+      // force a map that would collide with sidebarSessionNav's default "j"
+      // if it were included — use a custom defaults override instead:
+    });
+    expect(groups).toEqual([]);
+    // Custom defaults: pretend search default is "j" alongside sidebarSessionNav
+    const withDefaults = findChordConflicts(
+      {},
+      { ...DEFAULT_SHORTCUT_CHORDS, search: "j" },
+    );
+    // sidebarSessionNav ignored → search alone on "j" → no conflict group
+    expect(withDefaults.some((g) => g.chord === "j")).toBe(false);
+  });
+
+  it("accepts an explicit defaults map", () => {
+    const groups = findChordConflicts(
+      { search: "mod+x" },
+      {
+        search: "mod+a",
+        help: "mod+x",
+      },
+    );
+    expect(groups).toEqual([{ chord: "mod+x", ids: ["help", "search"] }]);
+  });
+});
+
+describe("resetConflictingShortcutRemaps", () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = memoryStorage();
+  });
+
+  it("clears remaps that participate in conflicts and leaves others", () => {
+    setShortcutRemap("search", "mod+p", storage);
+    setShortcutRemap("help", "mod+p", storage);
+    setShortcutRemap("doctor", "mod+shift+x", storage);
+
+    const next = resetConflictingShortcutRemaps(
+      loadShortcutRemaps(storage),
+      storage,
+    );
+    expect(next).toEqual({ doctor: "mod+shift+x" });
+    expect(findChordConflicts(next)).toEqual([]);
+  });
+
+  it("resets a remap that steals another action's default chord", () => {
+    setShortcutRemap("newChat", "mod+k", storage);
+    const next = resetConflictingShortcutRemaps(undefined, storage);
+    expect(next).toEqual({});
+    expect(findChordConflicts(next)).toEqual([]);
+  });
+
+  it("is a no-op when there are no conflicts", () => {
+    setShortcutRemap("search", "mod+p", storage);
+    const next = resetConflictingShortcutRemaps(
+      loadShortcutRemaps(storage),
+      storage,
+    );
+    expect(next).toEqual({ search: "mod+p" });
   });
 });
 

--- a/src/lib/shortcutRemap.ts
+++ b/src/lib/shortcutRemap.ts
@@ -349,8 +349,90 @@ export function buildEffectiveChordMap(
 }
 
 /**
+ * Catalog ids excluded from multi-id conflict grouping / capture collision checks.
+ *
+ * These are display-only (or composer-owned) rows that do not share the global
+ * remappable capture handler, so an overlapping “chord” is not a real runtime
+ * collision in the App mod-key path:
+ * - `sidebarSessionNav` — j/k when the sidebar list is focused (not a single global chord)
+ * - `send` — Composer Enter / mod-enter preference (not remappable here)
+ */
+export const CHORD_CONFLICT_IGNORE_IDS: ReadonlySet<ShortcutId> = new Set([
+  "sidebarSessionNav",
+  "send",
+]);
+
+/** One normalized chord shared by two or more catalog ids. */
+export type ChordConflictGroup = {
+  /** Canonical chord string (e.g. `"mod+k"`). */
+  chord: ChordString;
+  /** Ids currently bound to {@link chord}, sorted for stable UI / tests. */
+  ids: ShortcutId[];
+};
+
+/**
+ * Group shortcut ids that share the same normalized effective chord.
+ *
+ * @param remaps user remaps (partial); defaults fill the rest
+ * @param defaults catalog defaults (defaults to {@link DEFAULT_SHORTCUT_CHORDS})
+ * @returns conflict groups (length ≥ 2 ids each), sorted by chord; empty when none
+ */
+export function findChordConflicts(
+  remaps?: ShortcutRemapMap | null,
+  defaults: Readonly<Partial<Record<ShortcutId, ChordString>>> = DEFAULT_SHORTCUT_CHORDS,
+): ChordConflictGroup[] {
+  const effective: Partial<Record<ShortcutId, ChordString>> = {};
+
+  for (const id of Object.keys(defaults) as ShortcutId[]) {
+    if (CHORD_CONFLICT_IGNORE_IDS.has(id)) continue;
+    const custom = remaps?.[id];
+    if (custom) {
+      const n = normalizeChordString(custom);
+      if (n) {
+        effective[id] = n;
+        continue;
+      }
+    }
+    const d = defaults[id];
+    if (!d) continue;
+    const n = normalizeChordString(d);
+    if (n) effective[id] = n;
+  }
+
+  // Include remaps for known ids even if omitted from a custom `defaults` map.
+  if (remaps) {
+    for (const id of Object.keys(remaps) as ShortcutId[]) {
+      if (CHORD_CONFLICT_IGNORE_IDS.has(id)) continue;
+      if (effective[id]) continue;
+      if (!KNOWN_IDS.has(id)) continue;
+      const n = remaps[id] ? normalizeChordString(remaps[id]!) : null;
+      if (n) effective[id] = n;
+    }
+  }
+
+  const byChord = new Map<ChordString, ShortcutId[]>();
+  for (const id of Object.keys(effective) as ShortcutId[]) {
+    const chord = effective[id]!;
+    const list = byChord.get(chord);
+    if (list) list.push(id);
+    else byChord.set(chord, [id]);
+  }
+
+  const groups: ChordConflictGroup[] = [];
+  for (const [chord, ids] of byChord) {
+    if (ids.length < 2) continue;
+    ids.sort((a, b) => a.localeCompare(b));
+    groups.push({ chord, ids });
+  }
+  groups.sort((a, b) => a.chord.localeCompare(b.chord));
+  return groups;
+}
+
+/**
  * If `candidateChord` is already used by another shortcut id in `effectiveMap`,
  * return that id; otherwise null.
+ *
+ * Skips {@link CHORD_CONFLICT_IGNORE_IDS} (display-only / composer-owned rows).
  */
 export function findChordConflict(
   candidateId: ShortcutId,
@@ -361,11 +443,43 @@ export function findChordConflict(
   if (!norm) return null;
   for (const id of Object.keys(effectiveMap) as ShortcutId[]) {
     if (id === candidateId) continue;
+    if (CHORD_CONFLICT_IGNORE_IDS.has(id)) continue;
     const other = effectiveMap[id];
     if (!other) continue;
     if (normalizeChordString(other) === norm) return id;
   }
   return null;
+}
+
+/**
+ * Drop custom remaps that participate in a chord conflict (restores those ids
+ * to catalog defaults). Non-remappable / default-only rows are left as-is.
+ * Returns the saved map after write.
+ */
+export function resetConflictingShortcutRemaps(
+  remaps?: ShortcutRemapMap | null,
+  storage: Storage = localStorage,
+): ShortcutRemapMap {
+  const map: ShortcutRemapMap = {
+    ...(remaps ?? loadShortcutRemaps(storage)),
+  };
+  const groups = findChordConflicts(map);
+  if (groups.length === 0) {
+    return loadShortcutRemaps(storage);
+  }
+  let changed = false;
+  for (const group of groups) {
+    for (const id of group.ids) {
+      if (!isRemappableShortcutId(id)) continue;
+      if (map[id] === undefined) continue;
+      delete map[id];
+      changed = true;
+    }
+  }
+  if (changed) {
+    saveShortcutRemaps(map, storage);
+  }
+  return loadShortcutRemaps(storage);
 }
 
 export function loadShortcutRemaps(

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4334,6 +4334,68 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   color: var(--text-primary);
 }
 
+/* Chord conflict visualization (Settings → Keyboard) */
+.settings-shortcuts-conflicts {
+  margin: 0 16px 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--danger, #e55) 35%, var(--border-subtle));
+  background: color-mix(in srgb, var(--danger, #e55) 10%, transparent);
+}
+
+.settings-shortcuts-conflicts__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px 12px;
+}
+
+.settings-shortcuts-conflicts__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.settings-shortcuts-conflicts__desc {
+  margin-top: 2px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.settings-shortcuts-conflicts__list {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-shortcuts-conflicts__item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 10px;
+  font-size: 12.5px;
+  color: var(--text-primary);
+}
+
+.settings-shortcuts-conflicts__actions {
+  color: var(--text-secondary);
+  line-height: 1.35;
+}
+
+.settings-shortcuts-row--conflict td {
+  background: color-mix(in srgb, var(--danger, #e55) 7%, transparent);
+}
+
+.settings-shortcuts-kbd.is-conflict {
+  border-color: color-mix(in srgb, var(--danger, #e55) 45%, var(--border-subtle));
+  color: var(--text-primary);
+}
+
 .settings-shortcuts-group {
   padding: 8px 16px 14px;
   border-bottom: 1px solid var(--border-subtle);


### PR DESCRIPTION
## Summary

- **Pure helpers** (`src/lib/shortcutRemap.ts`): `findChordConflicts(remaps, defaults)` groups shortcut ids that share a normalized chord; `resetConflictingShortcutRemaps` clears remaps that participate in conflicts. Display-only `send` / `sidebarSessionNav` are ignored (`CHORD_CONFLICT_IGNORE_IDS`) and documented. Existing load/save remap path is unchanged.
- **Settings → Keyboard UI**: when conflicts exist, a **Conflicts** panel lists each chord + conflicting action labels; rows in conflict are highlighted. Capture still blocks save and shows an in-app warning (no `window.alert`). Optional **Reset conflicting to default**.
- **i18n** en + zh + zh-TW · **CHANGELOG** Unreleased · unit tests for conflicts/reset.

## Test plan

- [x] `pnpm exec vitest run src/lib/shortcutRemap.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: Settings → Keyboard → Record two actions to the same chord (e.g. via corrupt storage or reset after forced map) and confirm Conflicts panel + reset
- [ ] Manual: while recording, press an already-used chord → in-app error, binding not saved