### PR TITLE
feat(doctor): safe batch apply for CLI doctor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ See `docs/llm-wiki/release.md`.
 
 #### Permissions / CLI
 - **CLI `--permission-mode` alignment**: pure App policy / YOLO / plan-mode map (`default` · `acceptEdits` · `auto` · `dontAsk` · `bypassPermissions` · `plan`); spawn pins top-level `--permission-mode` (+ agent `--always-approve` for YOLO); Settings shows CLI label + advanced mode selector; product **Auto** policy
+- **Doctor fix depth**: plan banner (“N automatic fixes available (M need confirm)”), **Apply safe fixes** for non-destructive CLI remediations (sequential host `cli_doctor_fix`, then re-run doctor); destructive fixes stay per-row with in-app confirm; clearer fix-id + host errors
 
 ### Fixed
 
@@ -54,7 +55,7 @@ See `docs/llm-wiki/release.md`.
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 在设置 → 运行时 → 连接启停（掩码密钥 + 启动时复制连接 URL）
-- **权限/CLI**：对齐 `--permission-mode` 映射与 spawn；设置页展示 CLI 标签与高级选择；新增 **Auto** 策略
+- **权限/CLI**：对齐 `--permission-mode` 映射与 spawn；设置页展示 CLI 标签与高级选择；新增 **Auto** 策略；Doctor 修复深度（安全批量修复横幅 / 破坏性逐条确认）
 
 **中文 · 修复**
 

--- a/src/components/DoctorModal.tsx
+++ b/src/components/DoctorModal.tsx
@@ -20,7 +20,9 @@ import {
   extractFixIds,
   formatFactValue,
   hasAnySafeFact,
+  listSafeAutoFixes,
   parseCliDoctorEnvelope,
+  summarizeFixPlan,
   type CliDoctorCheck,
   type CliDoctorSafeFacts,
   type CliDoctorView,
@@ -254,6 +256,42 @@ export function DoctorModal({
     return extractFixIds(report.cliDoctor);
   }, [report]);
 
+  const fixPlan = useMemo(
+    () => summarizeFixPlan(cliDoctor),
+    [cliDoctor],
+  );
+
+  const safeAutoFixes = useMemo(
+    () => listSafeAutoFixes(cliDoctor),
+    [cliDoctor],
+  );
+
+  /** Host/stdout/stderr detail for a failed fix (no fix id prefix). */
+  const fixHostDetail = useCallback(
+    (res: api.CliDoctorFixResult | null, caught?: unknown) => {
+      if (caught != null) return redact(String(caught)).slice(0, 320);
+      return redact(
+        (
+          res?.error ||
+          res?.stderr ||
+          res?.stdout ||
+          t("doctor.cliDoctorFixFail")
+        ).trim(),
+      ).slice(0, 320);
+    },
+    [t],
+  );
+
+  const formatFixHostError = useCallback(
+    (fixId: string, res: api.CliDoctorFixResult | null, caught?: unknown) => {
+      return t("doctor.cliDoctorFixFailWithId", {
+        id: fixId,
+        error: fixHostDetail(res, caught),
+      });
+    },
+    [fixHostDetail, t],
+  );
+
   const applyFix = useCallback(
     async (fixId: string) => {
       setBusy("fix");
@@ -276,25 +314,97 @@ export function DoctorModal({
               : t("doctor.cliDoctorFixDone", { id: fixId }),
           );
         } else {
-          const detail = redact(
-            (
-              res.error ||
-              res.stderr ||
-              res.stdout ||
-              t("doctor.cliDoctorFixFail")
-            ).trim(),
-          ).slice(0, 320);
-          setError(`${t("doctor.cliDoctorFixFail")}: ${detail}`);
+          setError(formatFixHostError(fixId, res));
         }
       } catch (e) {
-        setError(`${t("doctor.cliDoctorFixFail")}: ${String(e)}`);
+        setError(formatFixHostError(fixId, null, e));
       } finally {
         setBusy(null);
         setFixingId(null);
       }
     },
-    [run, t],
+    [formatFixHostError, run, t],
   );
+
+  /**
+   * Run all non-destructive fixIds sequentially via the host path,
+   * then re-run doctor once. Stops on first failure.
+   */
+  const applySafeFixes = useCallback(async () => {
+    const safe = listSafeAutoFixes(cliDoctor);
+    if (safe.length === 0) return;
+
+    setBusy("fix");
+    setError(null);
+    setStatusMsg(null);
+
+    const applied: string[] = [];
+    let failedId: string | null = null;
+    let failedMsg: string | null = null;
+    let lastFixId: string | null = null;
+
+    try {
+      for (let i = 0; i < safe.length; i += 1) {
+        const fixId = safe[i].fixId;
+        if (!fixId) continue;
+        lastFixId = fixId;
+        setFixingId(fixId);
+        setStatusMsg(
+          t("doctor.cliDoctorFixBatchProgress", {
+            current: i + 1,
+            total: safe.length,
+            id: fixId,
+          }),
+        );
+        try {
+          const res = await api.cliDoctorFix(fixId);
+          if (res.ok) {
+            applied.push(fixId);
+          } else {
+            failedId = fixId;
+            failedMsg = fixHostDetail(res);
+            break;
+          }
+        } catch (e) {
+          failedId = fixId;
+          failedMsg = fixHostDetail(null, e);
+          break;
+        }
+      }
+
+      // Refresh findings after the batch (success or partial).
+      await run();
+
+      if (failedId && failedMsg) {
+        setError(
+          applied.length > 0
+            ? t("doctor.cliDoctorFixBatchPartial", {
+                ok: applied.length,
+                id: failedId,
+                error: failedMsg,
+              })
+            : t("doctor.cliDoctorFixFailWithId", {
+                id: failedId,
+                error: failedMsg,
+              }),
+        );
+      } else {
+        setStatusMsg(
+          t("doctor.cliDoctorFixBatchDone", { count: applied.length }),
+        );
+      }
+    } catch (e) {
+      setError(
+        t("doctor.cliDoctorFixFailWithId", {
+          id: lastFixId || "batch",
+          error: redact(String(e)).slice(0, 320),
+        }),
+      );
+    } finally {
+      setBusy(null);
+      setFixingId(null);
+    }
+  }, [cliDoctor, fixHostDetail, run, t]);
 
   const onApplyFix = useCallback(
     (handle: { fixId: string; message?: string; destructive?: boolean }) => {
@@ -553,6 +663,36 @@ export function DoctorModal({
                         cliDoctor.error ? `: ${cliDoctor.error}` : ""
                       }`}
                 </p>
+              )}
+
+              {cliDoctor.available && fixPlan.total > 0 && (
+                <div
+                  className="doctor-cli-fix-plan"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <p className="doctor-cli-fix-plan__banner">
+                    {t("doctor.cliDoctorFixPlanBanner", {
+                      total: fixPlan.total,
+                      confirm: fixPlan.needsConfirm,
+                    })}
+                  </p>
+                  {fixPlan.safe > 0 ? (
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm"
+                      disabled={!!busy || loading}
+                      onClick={() => void applySafeFixes()}
+                      title={t("doctor.cliDoctorApplySafeFixesHint")}
+                    >
+                      {busy === "fix" &&
+                      fixingId &&
+                      safeAutoFixes.some((c) => c.fixId === fixingId)
+                        ? "…"
+                        : t("doctor.cliDoctorApplySafeFixes")}
+                    </button>
+                  ) : null}
+                </div>
               )}
 
               {cliDoctor.available && cliDoctor.checks.length > 0 && (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1939,6 +1939,18 @@ const en = {
   "doctor.cliDoctorFixDone": "Applied fix “{id}”. Doctor re-ran.",
   "doctor.cliDoctorFixDoneDetail": "Applied fix “{id}”. {detail}",
   "doctor.cliDoctorFixFail": "Could not apply CLI doctor fix",
+  "doctor.cliDoctorFixFailWithId": "Could not apply fix “{id}”: {error}",
+  "doctor.cliDoctorFixPlanBanner":
+    "{total} automatic fixes available ({confirm} need confirm)",
+  "doctor.cliDoctorApplySafeFixes": "Apply safe fixes",
+  "doctor.cliDoctorApplySafeFixesHint":
+    "Run non-destructive doctor fixes sequentially, then re-run doctor",
+  "doctor.cliDoctorFixBatchProgress":
+    "Applying fix {current}/{total}: {id}…",
+  "doctor.cliDoctorFixBatchDone":
+    "Applied {count} safe fix(es). Doctor re-ran.",
+  "doctor.cliDoctorFixBatchPartial":
+    "Applied {ok} safe fix(es); stopped on “{id}”: {error}",
   "doctor.openReliability": "Reliability center",
   "doctor.openReliabilityHint":
     "Busy sessions, stall signals, and recent error cards.",
@@ -4808,6 +4820,18 @@ const zh: Record<MessageKey, string> = {
   "doctor.cliDoctorFixDone": "已应用修复「{id}」。Doctor 已重新运行。",
   "doctor.cliDoctorFixDoneDetail": "已应用修复「{id}」。{detail}",
   "doctor.cliDoctorFixFail": "无法应用 CLI doctor 修复",
+  "doctor.cliDoctorFixFailWithId": "无法应用修复「{id}」：{error}",
+  "doctor.cliDoctorFixPlanBanner":
+    "有 {total} 项自动修复可用（{confirm} 项需确认）",
+  "doctor.cliDoctorApplySafeFixes": "应用安全修复",
+  "doctor.cliDoctorApplySafeFixesHint":
+    "依次运行非破坏性 doctor 修复，然后重新运行 doctor",
+  "doctor.cliDoctorFixBatchProgress":
+    "正在应用修复 {current}/{total}：{id}…",
+  "doctor.cliDoctorFixBatchDone":
+    "已应用 {count} 项安全修复。Doctor 已重新运行。",
+  "doctor.cliDoctorFixBatchPartial":
+    "已应用 {ok} 项安全修复；在「{id}」处停止：{error}",
   "doctor.openReliability": "可靠性中心",
   "doctor.openReliabilityHint": "忙碌会话、卡顿信号与最近错误卡片。",
 

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1896,6 +1896,18 @@ export const zhTW: Record<MessageKey, string> = {
   "doctor.cliDoctorFixDone": "已套用修復「{id}」。Doctor 已重新執行。",
   "doctor.cliDoctorFixDoneDetail": "已套用修復「{id}」。{detail}",
   "doctor.cliDoctorFixFail": "無法套用 CLI doctor 修復",
+  "doctor.cliDoctorFixFailWithId": "無法套用修復「{id}」：{error}",
+  "doctor.cliDoctorFixPlanBanner":
+    "有 {total} 項自動修復可用（{confirm} 項需確認）",
+  "doctor.cliDoctorApplySafeFixes": "套用安全修復",
+  "doctor.cliDoctorApplySafeFixesHint":
+    "依序執行非破壞性 doctor 修復，然後重新執行 doctor",
+  "doctor.cliDoctorFixBatchProgress":
+    "正在套用修復 {current}/{total}：{id}…",
+  "doctor.cliDoctorFixBatchDone":
+    "已套用 {count} 項安全修復。Doctor 已重新執行。",
+  "doctor.cliDoctorFixBatchPartial":
+    "已套用 {ok} 項安全修復；在「{id}」處停止：{error}",
 
   "conn.idle": "閒置",
   "conn.connecting": "連線中",

--- a/src/lib/cliDoctor.test.ts
+++ b/src/lib/cliDoctor.test.ts
@@ -8,9 +8,12 @@ import {
   hasAnySafeFact,
   isDestructiveDoctorFix,
   isValidDoctorFixId,
+  listFixableChecks,
+  listSafeAutoFixes,
   parseCliDoctorEnvelope,
   parseCliDoctorReport,
   parseFinding,
+  summarizeFixPlan,
 } from "./cliDoctor";
 
 /** Minimal fixture shaped like `grok doctor --json` (schemaVersion 1). */
@@ -315,5 +318,119 @@ describe("formatFactValue", () => {
     expect(formatFactValue("ssh", true)).toBe("yes");
     expect(formatFactValue("ssh", false)).toBe("no");
     expect(formatFactValue("terminal", "iterm2")).toBe("iterm2");
+  });
+});
+
+describe("listFixableChecks / listSafeAutoFixes / summarizeFixPlan", () => {
+  function viewWithChecks(
+    checks: Array<{
+      id: string;
+      fixId?: string | null;
+      level?: "ok" | "warn" | "fail";
+      title?: string;
+    }>,
+  ) {
+    return parseCliDoctorEnvelope({
+      available: true,
+      report: {
+        schemaVersion: "1",
+        findings: checks.map((c) => ({
+          id: c.id,
+          disposition:
+            c.level === "fail"
+              ? "issue"
+              : c.level === "ok"
+                ? "ok"
+                : "recommendation",
+          message: c.title ?? c.id,
+          automaticRemediation: c.fixId ?? null,
+        })),
+      },
+    });
+  }
+
+  it("lists checks that carry a valid fixId", () => {
+    const view = viewWithChecks([
+      { id: "a", fixId: "noop" },
+      { id: "b", fixId: null },
+      { id: "c", fixId: "ssh-wrap" },
+      { id: "d", fixId: "--bad" },
+    ]);
+    const fixable = listFixableChecks(view);
+    expect(fixable.map((c) => c.fixId)).toEqual(["noop", "ssh-wrap"]);
+  });
+
+  it("dedupes the same fixId across checks", () => {
+    const view = viewWithChecks([
+      { id: "a", fixId: "noop" },
+      { id: "b", fixId: "NOOP" },
+    ]);
+    expect(listFixableChecks(view)).toHaveLength(1);
+  });
+
+  it("returns only non-destructive fixes for safe auto-apply", () => {
+    const view = viewWithChecks([
+      { id: "a", fixId: "noop" },
+      { id: "b", fixId: "ssh-wrap" },
+      { id: "c", fixId: "info" },
+      { id: "d", fixId: "tmux-clipboard" },
+    ]);
+    const safe = listSafeAutoFixes(view);
+    expect(safe.map((c) => c.fixId).sort()).toEqual(["info", "noop"]);
+    for (const c of safe) {
+      expect(isDestructiveDoctorFix(c.fixId!)).toBe(false);
+    }
+  });
+
+  it("summarizeFixPlan counts total / safe / needsConfirm", () => {
+    const view = viewWithChecks([
+      { id: "a", fixId: "noop" },
+      { id: "b", fixId: "ssh-wrap" },
+      { id: "c", fixId: "info" },
+      { id: "d" },
+    ]);
+    expect(summarizeFixPlan(view)).toEqual({
+      total: 3,
+      safe: 2,
+      needsConfirm: 1,
+    });
+  });
+
+  it("returns empty plan when doctor unavailable or has no fixes", () => {
+    expect(listFixableChecks(null)).toEqual([]);
+    expect(listSafeAutoFixes(undefined)).toEqual([]);
+    expect(summarizeFixPlan(null)).toEqual({
+      total: 0,
+      safe: 0,
+      needsConfirm: 0,
+    });
+
+    const unavailable = parseCliDoctorEnvelope({
+      available: false,
+      error: "missing",
+      report: null,
+    });
+    expect(summarizeFixPlan(unavailable)).toEqual({
+      total: 0,
+      safe: 0,
+      needsConfirm: 0,
+    });
+
+    const clean = parseCliDoctorEnvelope({
+      available: true,
+      report: { schemaVersion: "1", findings: [] },
+    });
+    expect(listFixableChecks(clean)).toEqual([]);
+    expect(summarizeFixPlan(clean).total).toBe(0);
+  });
+
+  it("works on fixture view (ssh-wrap is destructive only)", () => {
+    const view = parseCliDoctorEnvelope(FIXTURE);
+    const plan = summarizeFixPlan(view);
+    expect(plan.total).toBe(1);
+    expect(plan.safe).toBe(0);
+    expect(plan.needsConfirm).toBe(1);
+    expect(listSafeAutoFixes(view)).toEqual([]);
+    expect(listFixableChecks(view)[0]?.fixId).toBe("ssh-wrap");
   });
 });

--- a/src/lib/cliDoctor.ts
+++ b/src/lib/cliDoctor.ts
@@ -515,3 +515,62 @@ export function formatFactValue(key: keyof CliDoctorSafeFacts, value: unknown): 
   if (value == null || value === "") return "—";
   return String(value);
 }
+
+/** Counts for the Doctor fix-plan banner / Apply safe fixes button. */
+export type DoctorFixPlanSummary = {
+  /** Checks (or unique fix handles) with a valid fixId. */
+  total: number;
+  /** Non-destructive fixes that can auto-apply without confirm. */
+  safe: number;
+  /** Destructive fixes that need per-row confirm. */
+  needsConfirm: number;
+};
+
+/**
+ * Checks that expose a valid automatic fix handle.
+ * Dedupes by fixId (case-insensitive), keeping first occurrence order.
+ */
+export function listFixableChecks(
+  view: CliDoctorView | null | undefined,
+): CliDoctorCheck[] {
+  if (!view?.available) return [];
+  const seen = new Set<string>();
+  const out: CliDoctorCheck[] = [];
+  for (const c of view.checks) {
+    const fixId = c.fixId?.trim();
+    if (!fixId || !isValidDoctorFixId(fixId)) continue;
+    const key = fixId.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(c);
+  }
+  return out;
+}
+
+/**
+ * Fixable checks whose fixId is non-destructive (`!isDestructiveDoctorFix`).
+ * Safe for sequential “Apply safe fixes” without confirm dialogs.
+ */
+export function listSafeAutoFixes(
+  view: CliDoctorView | null | undefined,
+): CliDoctorCheck[] {
+  return listFixableChecks(view).filter(
+    (c) => c.fixId != null && !isDestructiveDoctorFix(c.fixId),
+  );
+}
+
+/** Summarize fixable / safe / needs-confirm counts for the Doctor banner. */
+export function summarizeFixPlan(
+  view: CliDoctorView | null | undefined,
+): DoctorFixPlanSummary {
+  const fixable = listFixableChecks(view);
+  let safe = 0;
+  for (const c of fixable) {
+    if (c.fixId != null && !isDestructiveDoctorFix(c.fixId)) safe += 1;
+  }
+  return {
+    total: fixable.length,
+    safe,
+    needsConfirm: fixable.length - safe,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10614,6 +10614,26 @@ html[data-composer-min-rows="8"] .composer__input {
   word-break: break-word;
 }
 
+.doctor-cli-fix-plan {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated, var(--bg-main));
+}
+
+.doctor-cli-fix-plan__banner {
+  margin: 0;
+  flex: 1 1 12rem;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
 .doctor-cli-section {
   margin-top: 16px;
   padding-top: 12px;


### PR DESCRIPTION
## Summary

- Pure helpers on `CliDoctorView`: `listFixableChecks`, `listSafeAutoFixes`, `summarizeFixPlan` (+ unit tests)
- Doctor modal banner: **N automatic fixes available (M need confirm)**
- **Apply safe fixes** runs non-destructive `fixId`s sequentially via host `cli_doctor_fix`, then re-runs doctor once; stops on first failure with fix id + host error
- Destructive remediations stay per-row **Apply fix** with existing in-app confirm (no `window.confirm`)
- i18n en / zh / zh-TW; CHANGELOG Unreleased

## Implementation notes

- Does **not** invent new CLI fix IDs — only drives existing `cli_doctor_fix`
- Safe set is `!isDestructiveDoctorFix(fixId)` (today mostly `noop` / `none` / `info`; shell/config writers remain confirm-gated)

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run src/lib/cliDoctor.test.ts src/i18n/messages.test.ts`
- [ ] Open Doctor with CLI findings that have automatic remediations
- [ ] Banner counts match findings; destructive rows still prompt confirm
- [ ] When a non-destructive fix exists, **Apply safe fixes** applies it and refreshes doctor
- [ ] Failure path shows fix id + host error