### PR TITLE
feat(settings): delete on-disk CLI sessions under GROK_HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ See `docs/llm-wiki/release.md`.
 
 #### Permissions / CLI
 - **CLI `--permission-mode` alignment**: pure App policy / YOLO / plan-mode map (`default` · `acceptEdits` · `auto` · `dontAsk` · `bypassPermissions` · `plan`); spawn pins top-level `--permission-mode` (+ agent `--always-approve` for YOLO); Settings shows CLI label + advanced mode selector; product **Auto** policy
+- **Delete CLI sessions from disk** (Settings → Agent / CLI sessions): per-row delete + delete all unlinked; path-scoped under active `GROK_HOME/sessions`; linked App chats stay
 
 ### Fixed
 
@@ -54,7 +55,7 @@ See `docs/llm-wiki/release.md`.
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 在设置 → 运行时 → 连接启停（掩码密钥 + 启动时复制连接 URL）
-- **权限/CLI**：对齐 `--permission-mode` 映射与 spawn；设置页展示 CLI 标签与高级选择；新增 **Auto** 策略
+- **权限/CLI**：对齐 `--permission-mode` 映射与 spawn；设置页展示 CLI 标签与高级选择；新增 **Auto** 策略；**删除磁盘 CLI 会话**（单条 / 全部未关联；限定 `GROK_HOME/sessions`；应用内已关联聊天保留）
 
 **中文 · 修复**
 

--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -538,6 +538,132 @@ pub fn import_all_cli_sessions(
     Ok(imported)
 }
 
+/// Reject empty / traversal-looking agent session ids before any path join.
+pub fn validate_agent_session_id(agent_session_id: &str) -> Result<&str, String> {
+    let id = agent_session_id.trim();
+    if id.is_empty() {
+        return Err("empty agent_session_id".into());
+    }
+    if id.contains('\0') {
+        return Err("invalid agent_session_id".into());
+    }
+    // Single path segment only — no separators or relative components.
+    if id.contains('/') || id.contains('\\') || id == "." || id == ".." || id.contains("..") {
+        return Err("invalid agent_session_id".into());
+    }
+    Ok(id)
+}
+
+/// True when `path` is exactly `{sessions_root}/{cwd_enc}/{agent_id}` (2 levels).
+fn is_strict_cli_session_dir(path: &Path, sessions_root: &Path, agent_id: &str) -> bool {
+    let name = match path.file_name().and_then(|s| s.to_str()) {
+        Some(n) if n == agent_id => n,
+        _ => return false,
+    };
+    let Ok(rel) = path.strip_prefix(sessions_root) else {
+        return false;
+    };
+    let mut depth = 0usize;
+    for c in rel.components() {
+        match c {
+            std::path::Component::Normal(os) => {
+                // First segment is percent-encoded cwd; second must be agent id.
+                if depth == 1 {
+                    if os.to_str() != Some(name) {
+                        return false;
+                    }
+                }
+                depth += 1;
+                if depth > 2 {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    depth == 2
+}
+
+/// Resolve a deletable CLI session directory under `sessions_root`.
+///
+/// When `dir` is provided it is preferred (from list), but must still canonicalize
+/// under `{sessions_root}/{cwd}/{agent_session_id}`. Path traversal and id mismatch
+/// are rejected. Does not touch App journals.
+pub fn resolve_deletable_cli_session_dir(
+    agent_session_id: &str,
+    dir: Option<&str>,
+    sessions_root: &Path,
+) -> Result<PathBuf, String> {
+    let agent_id = validate_agent_session_id(agent_session_id)?;
+
+    let sessions_canon = sessions_root.canonicalize().map_err(|e| {
+        format!("sessions root not available: {e}")
+    })?;
+
+    let candidate = if let Some(d) = dir.map(str::trim).filter(|s| !s.is_empty()) {
+        if d.contains('\0') {
+            return Err("invalid session dir".into());
+        }
+        PathBuf::from(d)
+    } else {
+        // Scan sessions_root/{cwd_enc}/{agent_id}/
+        let Ok(cwd_dirs) = fs::read_dir(&sessions_canon) else {
+            return Err(format!("CLI session dir not found for {agent_id}"));
+        };
+        let mut found: Option<PathBuf> = None;
+        for ent in cwd_dirs.flatten() {
+            let cwd_path = ent.path();
+            if !cwd_path.is_dir() {
+                continue;
+            }
+            let hit = cwd_path.join(agent_id);
+            if hit.is_dir() {
+                if found.is_some() {
+                    return Err(format!(
+                        "ambiguous CLI session dir for {agent_id}; pass dir from list"
+                    ));
+                }
+                found = Some(hit);
+            }
+        }
+        found.ok_or_else(|| format!("CLI session dir not found for {agent_id}"))?
+    };
+
+    let target = candidate
+        .canonicalize()
+        .map_err(|e| format!("session dir not found: {e}"))?;
+
+    if !target.is_dir() {
+        return Err(format!("not a directory: {}", target.display()));
+    }
+    if !is_strict_cli_session_dir(&target, &sessions_canon, agent_id) {
+        return Err("path not allowed: outside GROK_HOME/sessions or id mismatch".into());
+    }
+    Ok(target)
+}
+
+/// Delete one CLI session directory under the active GROK_HOME only.
+///
+/// Removes the on-disk tree (`summary.json`, `chat_history.jsonl`, …).
+/// Does **not** delete or unlink App chats — linked sidebar rows stay.
+pub fn delete_cli_session(
+    agent_session_id: &str,
+    dir: Option<&str>,
+    session_data_mode: &str,
+) -> Result<(), String> {
+    let home = resolve_agent_grok_home(session_data_mode);
+    let sessions = home.join("sessions");
+    let target = resolve_deletable_cli_session_dir(agent_session_id, dir, &sessions)?;
+    fs::remove_dir_all(&target).map_err(|e| format!("delete failed: {e}"))?;
+    tracing::info!(
+        target: "session",
+        agent = %agent_session_id,
+        dir = %target.display(),
+        "deleted on-disk CLI session under GROK_HOME"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -627,5 +753,102 @@ mod tests {
             journal_covers_assistant(&full, "基于已有调研，产出矩阵。"),
             CoverKind::Covered
         );
+    }
+
+    #[test]
+    fn validate_agent_session_id_rejects_traversal() {
+        assert!(validate_agent_session_id("").is_err());
+        assert!(validate_agent_session_id("   ").is_err());
+        assert!(validate_agent_session_id("../etc").is_err());
+        assert!(validate_agent_session_id("a/b").is_err());
+        assert!(validate_agent_session_id("a\\b").is_err());
+        assert!(validate_agent_session_id("..").is_err());
+        assert!(validate_agent_session_id("sess-ok-123").is_ok());
+    }
+
+    fn make_fake_cli_session(home: &Path, agent_id: &str) -> PathBuf {
+        let cwd_enc = percent_encode_path_component("/Users/me/proj");
+        let dir = home.join("sessions").join(cwd_enc).join(agent_id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("summary.json"), r#"{"generated_title":"t"}"#).unwrap();
+        fs::write(dir.join("chat_history.jsonl"), "").unwrap();
+        dir
+    }
+
+    #[test]
+    fn resolve_delete_accepts_strict_session_dir() {
+        let home = std::env::temp_dir().join(format!("cli-del-ok-{}", Uuid::new_v4()));
+        let agent_id = "agent-sess-aaaa";
+        let dir = make_fake_cli_session(&home, agent_id);
+        let sessions = home.join("sessions");
+        let resolved =
+            resolve_deletable_cli_session_dir(agent_id, Some(dir.to_str().unwrap()), &sessions)
+                .unwrap();
+        assert_eq!(resolved, dir.canonicalize().unwrap());
+        // Discover by id alone
+        let by_id = resolve_deletable_cli_session_dir(agent_id, None, &sessions).unwrap();
+        assert_eq!(by_id, dir.canonicalize().unwrap());
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn resolve_delete_rejects_outside_sessions_and_id_mismatch() {
+        let home = std::env::temp_dir().join(format!("cli-del-bad-{}", Uuid::new_v4()));
+        let agent_id = "agent-sess-bbbb";
+        let _dir = make_fake_cli_session(&home, agent_id);
+        let sessions = home.join("sessions");
+
+        // Outside sessions root
+        let outside = home.join("other").join(agent_id);
+        fs::create_dir_all(&outside).unwrap();
+        assert!(
+            resolve_deletable_cli_session_dir(agent_id, Some(outside.to_str().unwrap()), &sessions)
+                .is_err()
+        );
+
+        // Id does not match directory name
+        let wrong_name = sessions
+            .join(percent_encode_path_component("/Users/me/proj"))
+            .join("not-the-agent");
+        fs::create_dir_all(&wrong_name).unwrap();
+        assert!(resolve_deletable_cli_session_dir(
+            agent_id,
+            Some(wrong_name.to_str().unwrap()),
+            &sessions
+        )
+        .is_err());
+
+        // sessions root itself
+        assert!(
+            resolve_deletable_cli_session_dir(agent_id, Some(sessions.to_str().unwrap()), &sessions)
+                .is_err()
+        );
+
+        // cwd folder (only one level under sessions)
+        let cwd_only = sessions.join(percent_encode_path_component("/Users/me/proj"));
+        assert!(resolve_deletable_cli_session_dir(
+            agent_id,
+            Some(cwd_only.to_str().unwrap()),
+            &sessions
+        )
+        .is_err());
+
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn delete_cli_session_removes_tree() {
+        let home = std::env::temp_dir().join(format!("cli-del-rm-{}", Uuid::new_v4()));
+        let agent_id = "agent-sess-cccc";
+        let dir = make_fake_cli_session(&home, agent_id);
+        let sessions = home.join("sessions");
+        let target =
+            resolve_deletable_cli_session_dir(agent_id, Some(dir.to_str().unwrap()), &sessions)
+                .unwrap();
+        fs::remove_dir_all(&target).unwrap();
+        assert!(!dir.exists());
+        // sibling under home must remain
+        assert!(sessions.is_dir() || !home.join("sessions").exists() || home.exists());
+        let _ = fs::remove_dir_all(&home);
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -517,6 +517,26 @@ pub async fn cli_sessions_import_all(limit: Option<u32>) -> Result<Vec<SessionMe
     crate::cli_sessions::import_all_cli_sessions(&mode, lim)
 }
 
+/// Delete one on-disk CLI session under active GROK_HOME (path-scoped).
+/// App-linked chats are left intact.
+#[tauri::command]
+pub async fn cli_sessions_delete(
+    agent_session_id: String,
+    dir: Option<String>,
+) -> Result<(), String> {
+    let mode = store::load_settings().session_data_mode;
+    // Blocking disk IO off the async runtime.
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::cli_sessions::delete_cli_session(
+            &agent_session_id,
+            dir.as_deref(),
+            &mode,
+        )
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 #[tauri::command]
 pub async fn session_create(
     project_id: Option<String>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -286,6 +286,7 @@ pub fn run() {
             commands::cli_sessions_list,
             commands::cli_session_import,
             commands::cli_sessions_import_all,
+            commands::cli_sessions_delete,
             commands::session_create,
             commands::session_delete,
             commands::session_rename,

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -5569,7 +5569,7 @@ function ShortcutsSettingsPanel({
   );
 }
 
-/** List / import / open Grok Build CLI sessions from active GROK_HOME. */
+/** List / import / open / delete Grok Build CLI sessions from active GROK_HOME. */
 function CliSessionsPanel({
   t,
   sessionDataMode,
@@ -5588,6 +5588,11 @@ function CliSessionsPanel({
   const [status, setStatus] = useState<string | null>(null);
   const [filterQuery, setFilterQuery] = useState("");
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<
+    | null
+    | { kind: "one"; row: api.CliSessionSummary }
+    | { kind: "unlinked"; count: number }
+  >(null);
   const isIndependent = sessionDataMode !== "shared";
 
   const refresh = useCallback(async () => {
@@ -5613,7 +5618,7 @@ function CliSessionsPanel({
     () => filterCliSessions(rows, filterQuery),
     [rows, filterQuery],
   );
-  /** Bulk import always targets the full list (not the filter). */
+  /** Bulk import / delete unlinked always targets the full list (not the filter). */
   const pending = countUnlinkedCliSessions(rows);
   const sourceHome =
     rows.find((r) => r.sourceHome)?.sourceHome ??
@@ -5680,6 +5685,60 @@ function CliSessionsPanel({
     }
   };
 
+  const runDeleteOne = async (row: api.CliSessionSummary) => {
+    setBusyId(row.agentSessionId);
+    setError(null);
+    setStatus(null);
+    try {
+      await api.cliSessionDelete(row.agentSessionId, { dir: row.dir });
+      setDeleteConfirm(null);
+      setStatus(t("settings.cliSessionsDeleted", { title: row.title }));
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const runDeleteUnlinked = async () => {
+    const targets = rows.filter((r) => !r.alreadyLinked);
+    if (targets.length === 0) {
+      setDeleteConfirm(null);
+      return;
+    }
+    setBusyId("__delete_unlinked__");
+    setError(null);
+    setStatus(null);
+    let deleted = 0;
+    const errors: string[] = [];
+    try {
+      for (const row of targets) {
+        try {
+          await api.cliSessionDelete(row.agentSessionId, { dir: row.dir });
+          deleted += 1;
+        } catch (e) {
+          errors.push(`${row.agentSessionId}: ${String(e)}`);
+        }
+      }
+      setDeleteConfirm(null);
+      setStatus(
+        t("settings.cliSessionsDeletedN", { n: String(deleted) }),
+      );
+      if (errors.length > 0) {
+        setError(errors.slice(0, 3).join("; "));
+      }
+      await refresh();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const deleteBusy =
+    busyId === "__delete_unlinked__" ||
+    (deleteConfirm?.kind === "one" &&
+      busyId === deleteConfirm.row.agentSessionId);
+
   return (
     <div
       className="settings-row settings-row--stack"
@@ -5716,6 +5775,20 @@ function CliSessionsPanel({
             {busyId === "__all__"
               ? t("settings.cliSessionsImporting")
               : t("settings.cliSessionsImportAll", { n: String(pending) })}
+          </button>
+          <button
+            type="button"
+            className="btn btn--ghost btn--danger"
+            disabled={loading || !!busyId || pending === 0}
+            onClick={() =>
+              setDeleteConfirm({ kind: "unlinked", count: pending })
+            }
+          >
+            {busyId === "__delete_unlinked__"
+              ? t("settings.cliSessionsDeleting")
+              : t("settings.cliSessionsDeleteUnlinked", {
+                  n: String(pending),
+                })}
           </button>
         </div>
         {rows.length > 0 ? (
@@ -5836,6 +5909,25 @@ function CliSessionsPanel({
                           : t("settings.cliSessionsImportOpen")}
                       </button>
                     )}
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm btn--danger"
+                      disabled={!!busyId}
+                      title={t("settings.cliSessionsDeleteConfirmMsg", {
+                        title: r.title,
+                      })}
+                      aria-label={t("settings.cliSessionsDelete")}
+                      onClick={() =>
+                        setDeleteConfirm({ kind: "one", row: r })
+                      }
+                    >
+                      <IconTrash size={13} />
+                      <span>
+                        {busy
+                          ? t("settings.cliSessionsDeleting")
+                          : t("settings.cliSessionsDelete")}
+                      </span>
+                    </button>
                   </div>
                 </li>
               );
@@ -5843,6 +5935,60 @@ function CliSessionsPanel({
           </ul>
         )}
       </div>
+
+      <GlassModal
+        open={!!deleteConfirm}
+        onClose={() => {
+          if (!deleteBusy) setDeleteConfirm(null);
+        }}
+        title={
+          deleteConfirm?.kind === "unlinked"
+            ? t("settings.cliSessionsDeleteUnlinkedConfirmTitle")
+            : t("settings.cliSessionsDeleteConfirmTitle")
+        }
+        size="sm"
+        closeLabel={t("common.close")}
+        closeOnOverlay={!deleteBusy}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={deleteBusy}
+              onClick={() => setDeleteConfirm(null)}
+            >
+              {t("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--danger"
+              disabled={deleteBusy || !deleteConfirm}
+              onClick={() => {
+                if (!deleteConfirm) return;
+                if (deleteConfirm.kind === "unlinked") {
+                  void runDeleteUnlinked();
+                } else {
+                  void runDeleteOne(deleteConfirm.row);
+                }
+              }}
+            >
+              {deleteBusy
+                ? t("settings.cliSessionsDeleting")
+                : t("settings.cliSessionsDelete")}
+            </button>
+          </>
+        }
+      >
+        <p className="settings-row__desc" style={{ margin: 0 }}>
+          {deleteConfirm?.kind === "unlinked"
+            ? t("settings.cliSessionsDeleteUnlinkedConfirmMsg", {
+                n: String(deleteConfirm.count),
+              })
+            : t("settings.cliSessionsDeleteConfirmMsg", {
+                title: deleteConfirm?.row.title ?? "",
+              })}
+        </p>
+      </GlassModal>
     </div>
   );
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1019,6 +1019,18 @@ const en = {
   "settings.cliSessionsSource": "Scanning {path}",
   "settings.cliSessionsIndependentNote":
     "Independent mode uses the app agent-home (~/.grok-app/agent-home), which may differ from terminal CLI sessions under ~/.grok. Import still copies chat history into the app; agent resume may not find the same on-disk session unless you switch to shared mode.",
+  "settings.cliSessionsDelete": "Delete",
+  "settings.cliSessionsDeleting": "Deleting…",
+  "settings.cliSessionsDeleted": "Deleted “{title}” from disk",
+  "settings.cliSessionsDeletedN": "Deleted {n} on-disk session(s)",
+  "settings.cliSessionsDeleteConfirmTitle": "Delete CLI session from disk?",
+  "settings.cliSessionsDeleteConfirmMsg":
+    "Deletes the on-disk CLI session under GROK_HOME (“{title}”). Linked App chats stay. This cannot be undone.",
+  "settings.cliSessionsDeleteUnlinked": "Delete all unlinked ({n})",
+  "settings.cliSessionsDeleteUnlinkedConfirmTitle":
+    "Delete all unlinked CLI sessions?",
+  "settings.cliSessionsDeleteUnlinkedConfirmMsg":
+    "Deletes {n} unlinked on-disk CLI session(s) under GROK_HOME. Linked App chats stay. This cannot be undone.",
   "settings.storeApiKeysInKeychain": "Store API keys in system keychain",
   "settings.storeApiKeysInKeychainDesc":
     "Off by default: keys stay in the app data folder (mode 0600). Turn on to use the OS keychain — the system may ask once. Official login still uses Grok Build auth.",
@@ -3909,6 +3921,17 @@ const zh: Record<MessageKey, string> = {
   "settings.cliSessionsSource": "扫描路径 {path}",
   "settings.cliSessionsIndependentNote":
     "独立模式使用应用 agent-home（~/.grok-app/agent-home），可能与终端 CLI 的 ~/.grok 会话不一致。仍可导入聊天记录到应用；若需与终端同一 on-disk 会话继续，请切换到共享模式。",
+  "settings.cliSessionsDelete": "删除",
+  "settings.cliSessionsDeleting": "删除中…",
+  "settings.cliSessionsDeleted": "已从磁盘删除「{title}」",
+  "settings.cliSessionsDeletedN": "已删除 {n} 个磁盘会话",
+  "settings.cliSessionsDeleteConfirmTitle": "从磁盘删除 CLI 会话？",
+  "settings.cliSessionsDeleteConfirmMsg":
+    "将删除 GROK_HOME 下的 on-disk CLI 会话「{title}」。已关联的应用内聊天会保留。此操作不可撤销。",
+  "settings.cliSessionsDeleteUnlinked": "删除全部未关联（{n}）",
+  "settings.cliSessionsDeleteUnlinkedConfirmTitle": "删除全部未关联 CLI 会话？",
+  "settings.cliSessionsDeleteUnlinkedConfirmMsg":
+    "将删除 GROK_HOME 下 {n} 个未关联的 on-disk CLI 会话。已关联的应用内聊天会保留。此操作不可撤销。",
   "settings.storeApiKeysInKeychain": "用系统钥匙串保存 API Key",
   "settings.storeApiKeysInKeychainDesc":
     "默认关闭：密钥写在应用数据目录（0600）。开启后写入系统钥匙串，系统可能要求一次授权。官方登录仍走 Grok Build 鉴权，不受此项影响。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -968,6 +968,17 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.cliSessionsSource": "掃描路徑 {path}",
   "settings.cliSessionsIndependentNote":
     "獨立模式使用應用程式 agent-home（~/.grok-app/agent-home），可能與終端機 CLI 的 ~/.grok 工作階段不一致。仍可匯入聊天紀錄到應用程式；若需與終端機同一 on-disk 工作階段繼續，請切換到共用模式。",
+  "settings.cliSessionsDelete": "刪除",
+  "settings.cliSessionsDeleting": "刪除中…",
+  "settings.cliSessionsDeleted": "已從磁碟刪除「{title}」",
+  "settings.cliSessionsDeletedN": "已刪除 {n} 個磁碟工作階段",
+  "settings.cliSessionsDeleteConfirmTitle": "從磁碟刪除 CLI 工作階段？",
+  "settings.cliSessionsDeleteConfirmMsg":
+    "將刪除 GROK_HOME 下的 on-disk CLI 工作階段「{title}」。已關聯的應用程式內聊天會保留。此操作無法復原。",
+  "settings.cliSessionsDeleteUnlinked": "刪除全部未關聯（{n}）",
+  "settings.cliSessionsDeleteUnlinkedConfirmTitle": "刪除全部未關聯 CLI 工作階段？",
+  "settings.cliSessionsDeleteUnlinkedConfirmMsg":
+    "將刪除 GROK_HOME 下 {n} 個未關聯的 on-disk CLI 工作階段。已關聯的應用程式內聊天會保留。此操作無法復原。",
   "settings.storeApiKeysInKeychain": "以系統鑰匙圈儲存 API Key",
   "settings.storeApiKeysInKeychainDesc":
     "預設關閉：金鑰寫在應用資料目錄（0600）。開啟後寫入系統鑰匙圈，系統可能要求一次授權。官方登入仍走 Grok Build 驗證，不受此項影響。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -964,6 +964,20 @@ export async function cliSessionsImportAll(limit?: number) {
   >("cli_sessions_import_all", { limit: limit ?? 50 });
 }
 
+/**
+ * Delete one on-disk CLI session under active GROK_HOME.
+ * Prefer passing `dir` from list. Does not delete App chats.
+ */
+export async function cliSessionDelete(
+  agentSessionId: string,
+  opts?: { dir?: string | null },
+) {
+  return invoke<void>("cli_sessions_delete", {
+    agentSessionId,
+    dir: opts?.dir ?? null,
+  });
+}
+
 export async function sessionCreate(
   projectId?: string,
   title?: string,

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -616,14 +616,18 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "settings.cliSessionsDesc",
       "settings.cliSessionsIndependentNote",
       "settings.cliSessionsImportOpen",
+      "settings.cliSessionsDelete",
+      "settings.cliSessionsDeleteUnlinked",
     ],
     keywords: [
       "cli sessions",
       "import session",
       "agent session id",
       "resume",
+      "delete session",
       "CLI 会话",
       "导入会话",
+      "删除会话",
     ],
   },
   {


### PR DESCRIPTION
## Summary

Adds safe delete for Grok Build CLI sessions listed in **Settings → Agent / CLI sessions**.

- **Host:** `cli_sessions_delete(agent_session_id, dir?)` removes one session directory under the active `GROK_HOME/sessions/{cwd}/{id}/` only (path-scoped; rejects traversal and id mismatch). Linked App chats are not deleted.
- **UI:** Per-row **Delete** for all listed sessions, plus **Delete all unlinked**. Confirms via in-app `GlassModal` (no `window.confirm`). Refreshes the list after delete.
- **API:** `api.cliSessionDelete` in `src/lib/api.ts`.
- **i18n:** en / zh / zh-TW; settings catalog keywords updated.
- **Tests:** Rust path-safety + resolve/delete unit tests under `cli_sessions`.

## Test plan

- [x] `cargo test --lib cli_sessions` (path safety + delete tree)
- [x] `pnpm typecheck`
- [x] `vitest` for `cliSessionsFilter` + i18n catalog keys
- [ ] Manual: open Settings → CLI sessions, delete an unlinked session; confirm disk dir gone and list refreshes
- [ ] Manual: delete a linked session; App chat remains; disk CLI copy removed
- [ ] Manual: Delete all unlinked with confirm; only unlinked rows removed from disk