### PR TITLE
feat(mcp): deepen status modal with filter, chips, refresh, copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ See `docs/llm-wiki/release.md`.
 - **Install failure recovery**: last install error stays on that plugin row with **Retry**; cleared on success
 - Installed **Details** shows structured marketplace/provides summary when available (plus CLI `plugin details` body)
 - **Delete CLI sessions from disk** (Settings → Agent / CLI sessions): per-row delete + delete all unlinked; path-scoped under active `GROK_HOME/sessions`; linked App chats stay
+- **MCP status modal depth**: search filter, status chips (all / ok / warn / error / unknown) from inspect `compatibilityStatus`/`transport`, count summary, refresh while open, copy name/target — host list only (no fake servers)
 
 ### Fixed
 
@@ -69,7 +70,7 @@ See `docs/llm-wiki/release.md`.
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选
 - **计划**：**请求修改** 可选修订说明；计划历史搜索/决策筛选、清空确认、会话仍在时可打开
-- **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要
+- **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**MCP 状态弹层**（搜索/状态芯片/计数/刷新/复制名称与目标）
 - **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）
 
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8350,12 +8350,12 @@ export default function App() {
     });
   }, [composerMenuEntries.length]);
 
-  const openMcpModal = useCallback(async () => {
-    setShowMcpModal(true);
+  const refreshMcpModal = useCallback(async () => {
     setMcpLoading(true);
     setMcpError(null);
     try {
       const res = await api.inspectMcp(activeProject?.path ?? null);
+      // Host list only — never invent placeholder servers.
       setMcpServers(res.servers ?? []);
       if (res.error) setMcpError(res.error);
     } catch (e) {
@@ -8365,6 +8365,11 @@ export default function App() {
       setMcpLoading(false);
     }
   }, [activeProject?.path]);
+
+  const openMcpModal = useCallback(async () => {
+    setShowMcpModal(true);
+    await refreshMcpModal();
+  }, [refreshMcpModal]);
 
   const showToast = useCallback((msg: string, ms = 3200) => {
     setToast(msg);
@@ -17148,6 +17153,7 @@ export default function App() {
         loading={mcpLoading}
         onClose={() => setShowMcpModal(false)}
         onManage={() => navigateSettings("extensions")}
+        onRefresh={() => void refreshMcpModal()}
       />
       {rewindTimeline && (
         <div

--- a/src/components/McpStatusModal.tsx
+++ b/src/components/McpStatusModal.tsx
@@ -1,8 +1,20 @@
-import { useMemo } from "react";
-import type { Locale } from "@/i18n";
+import { useCallback, useMemo, useState } from "react";
+import type { Locale, MessageKey } from "@/i18n";
 import { createT } from "@/i18n";
 import { GlassModal } from "@/components/GlassModal";
+import { IconCopy, IconRefresh } from "@/components/icons";
 import { mcpMetaLine } from "@/lib/extensionsUi";
+import {
+  classifyMcpRowHealth,
+  countMcpRowsByHealth,
+  filterMcpRows,
+  mcpRowCopyText,
+  mcpStatusBadgeMod,
+  mcpStatusLabelKey,
+  MCP_ROW_STATUS_FILTERS,
+  type McpRowHealth,
+  type McpRowStatusFilter,
+} from "@/lib/mcpStatus";
 
 export type McpServerRow = {
   name: string;
@@ -12,6 +24,27 @@ export type McpServerRow = {
   compatibilityStatus?: string | null;
 };
 
+type TFn = (key: MessageKey, vars?: Record<string, string | number>) => string;
+
+function healthFilterLabel(filter: McpRowStatusFilter, t: TFn): string {
+  if (filter === "all") return t("mcpModal.filter.all");
+  // Reuse Extensions status labels (ok / warn / error / unknown).
+  return t(mcpStatusLabelKey(filter) as MessageKey);
+}
+
+function healthDotClass(health: McpRowHealth): string {
+  switch (health) {
+    case "ok":
+      return "mcp-modal__dot--ok";
+    case "warn":
+      return "mcp-modal__dot--warn";
+    case "error":
+      return "mcp-modal__dot--error";
+    default:
+      return "mcp-modal__dot--unknown";
+  }
+}
+
 export function McpStatusModal({
   open,
   locale,
@@ -20,6 +53,7 @@ export function McpStatusModal({
   loading,
   onClose,
   onManage,
+  onRefresh,
 }: {
   open: boolean;
   locale: Locale;
@@ -29,8 +63,43 @@ export function McpStatusModal({
   onClose: () => void;
   /** Open Settings → Extensions for full Skills/MCP management. */
   onManage?: () => void;
+  /** Re-run inspect while the modal stays open. */
+  onRefresh?: () => void;
 }) {
   const tr = useMemo(() => createT(locale), [locale]);
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<McpRowStatusFilter>("all");
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const statusCounts = useMemo(() => countMcpRowsByHealth(servers), [servers]);
+  const filtered = useMemo(
+    () => filterMcpRows(servers, { query, status: statusFilter }),
+    [servers, query, statusFilter],
+  );
+
+  const hasActiveFilters =
+    statusFilter !== "all" || query.trim().length > 0;
+  const isEmptyCatalog = !loading && servers.length === 0 && !error;
+  const isEmptyFilter =
+    !loading && servers.length > 0 && filtered.length === 0;
+
+  const copyField = useCallback(
+    async (row: McpServerRow, field: "name" | "target") => {
+      const text = mcpRowCopyText(row, field);
+      if (!text) return;
+      try {
+        await navigator.clipboard.writeText(text);
+        const key = `${row.name}:${field}`;
+        setCopiedKey(key);
+        window.setTimeout(() => {
+          setCopiedKey((cur) => (cur === key ? null : cur));
+        }, 1600);
+      } catch {
+        // Clipboard may be denied; leave UI unchanged.
+      }
+    },
+    [],
+  );
 
   return (
     <GlassModal
@@ -41,6 +110,8 @@ export function McpStatusModal({
       closeLabel={tr("common.close")}
       size="md"
       className="mcp-modal"
+      wrapBody
+      bodyClassName="mcp-modal__body"
       footer={
         <div className="mcp-modal__footer">
           {onManage ? (
@@ -62,22 +133,178 @@ export function McpStatusModal({
       }
     >
       <p className="mcp-modal__hint">{tr("mcpModal.hint")}</p>
-      {loading && <p className="modal-status">{tr("mcpModal.loading")}</p>}
+
+      <div className="mcp-modal__toolbar">
+        <input
+          type="search"
+          className="settings-input mcp-modal__search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={tr("mcpModal.searchPlaceholder")}
+          autoComplete="off"
+          spellCheck={false}
+          aria-label={tr("mcpModal.searchPlaceholder")}
+          disabled={loading && servers.length === 0}
+        />
+        {onRefresh ? (
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm mcp-modal__refresh"
+            onClick={() => onRefresh()}
+            disabled={!!loading}
+            title={tr("mcpModal.refresh")}
+            aria-label={tr("mcpModal.refresh")}
+          >
+            <IconRefresh size={14} />
+            <span>{loading ? tr("mcpModal.refreshing") : tr("mcpModal.refresh")}</span>
+          </button>
+        ) : null}
+      </div>
+
+      {servers.length > 0 || hasActiveFilters ? (
+        <div
+          className="mcp-modal__chips"
+          role="tablist"
+          aria-label={tr("mcpModal.filter.statusLabel")}
+        >
+          {MCP_ROW_STATUS_FILTERS.map((id) => {
+            const n = statusCounts[id];
+            // Hide zero-count chips except "all" and the active selection.
+            if (id !== "all" && n === 0 && statusFilter !== id) return null;
+            return (
+              <button
+                key={id}
+                type="button"
+                role="tab"
+                aria-selected={statusFilter === id}
+                className={
+                  "mcp-modal__chip" + (statusFilter === id ? " is-active" : "")
+                }
+                onClick={() => setStatusFilter(id)}
+              >
+                <span>{healthFilterLabel(id, (k, vars) => tr(k, vars))}</span>
+                <span className="mcp-modal__chip-count">{n}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {!loading && servers.length > 0 ? (
+        <p className="mcp-modal__summary" role="status">
+          {hasActiveFilters
+            ? tr("mcpModal.summaryFiltered", {
+                shown: filtered.length,
+                total: servers.length,
+              })
+            : tr("mcpModal.summary", { n: servers.length })}
+        </p>
+      ) : null}
+
+      {loading && servers.length === 0 && (
+        <p className="modal-status">{tr("mcpModal.loading")}</p>
+      )}
       {error && (
         <p className="modal-status modal-status--error">{error}</p>
       )}
-      {!loading && servers.length === 0 && !error && (
+      {isEmptyCatalog && (
         <p className="modal-status">{tr("mcpModal.empty")}</p>
       )}
-      {servers.length > 0 ? (
-        <ul className="mcp-modal__list">
-          {servers.map((s) => {
+      {isEmptyFilter ? (
+        <div className="mcp-modal__empty-filter">
+          <p className="modal-status">{tr("mcpModal.filterEmpty")}</p>
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm"
+            onClick={() => {
+              setQuery("");
+              setStatusFilter("all");
+            }}
+          >
+            {tr("mcpModal.clearFilters")}
+          </button>
+        </div>
+      ) : null}
+
+      {filtered.length > 0 ? (
+        <ul className="mcp-modal__list" role="list">
+          {filtered.map((s) => {
             const meta = mcpMetaLine(s);
+            const health = classifyMcpRowHealth(s);
+            const badgeMod = mcpStatusBadgeMod(
+              health === "error"
+                ? "error"
+                : health === "warn"
+                  ? "warn"
+                  : health === "ok"
+                    ? "ok"
+                    : "unknown",
+            );
+            const nameCopied = copiedKey === `${s.name}:name`;
+            const targetCopied = copiedKey === `${s.name}:target`;
             return (
               <li key={s.name} className="mcp-modal__item">
-                <strong>{s.name}</strong>
-                {meta ? <span>{meta}</span> : null}
-                {s.target ? <em title={s.target}>{s.target}</em> : null}
+                <div className="mcp-modal__item-head">
+                  <span
+                    className={`mcp-modal__dot ${healthDotClass(health)}`}
+                    aria-hidden
+                  />
+                  <strong className="mcp-modal__name" title={s.name}>
+                    {s.name}
+                  </strong>
+                  <span
+                    className={"ext-badge ext-badge--" + badgeMod}
+                    title={s.compatibilityStatus ?? undefined}
+                  >
+                    {tr(mcpStatusLabelKey(
+                      health === "error"
+                        ? "error"
+                        : health === "warn"
+                          ? "warn"
+                          : health === "ok"
+                            ? "ok"
+                            : "unknown",
+                    ) as MessageKey)}
+                  </span>
+                  <span className="mcp-modal__item-actions">
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm mcp-modal__copy"
+                      onClick={() => void copyField(s, "name")}
+                      title={tr("mcpModal.copyName")}
+                      aria-label={tr("mcpModal.copyName")}
+                    >
+                      <IconCopy size={13} />
+                      <span>
+                        {nameCopied
+                          ? tr("mcpModal.copied")
+                          : tr("mcpModal.copyName")}
+                      </span>
+                    </button>
+                    {s.target ? (
+                      <button
+                        type="button"
+                        className="btn btn--ghost btn--sm mcp-modal__copy"
+                        onClick={() => void copyField(s, "target")}
+                        title={tr("mcpModal.copyTarget")}
+                        aria-label={tr("mcpModal.copyTarget")}
+                      >
+                        <IconCopy size={13} />
+                        <span>
+                          {targetCopied
+                            ? tr("mcpModal.copied")
+                            : tr("mcpModal.copyTarget")}
+                        </span>
+                      </button>
+                    ) : null}
+                  </span>
+                </div>
+                {meta ? <span className="mcp-modal__meta">{meta}</span> : null}
+                {s.target ? (
+                  <em className="mcp-modal__target" title={s.target}>
+                    {s.target}
+                  </em>
+                ) : null}
               </li>
             );
           })}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2322,6 +2322,18 @@ const en = {
   "mcpModal.loading": "Loading MCP servers…",
   "mcpModal.empty": "No MCP servers discovered",
   "mcpModal.manage": "Manage in Settings",
+  "mcpModal.searchPlaceholder": "Filter by name, target, transport…",
+  "mcpModal.filter.statusLabel": "Filter by status",
+  "mcpModal.filter.all": "All",
+  "mcpModal.refresh": "Refresh",
+  "mcpModal.refreshing": "Refreshing…",
+  "mcpModal.summary": "{n} servers",
+  "mcpModal.summaryFiltered": "{shown} of {total}",
+  "mcpModal.filterEmpty": "No servers match these filters",
+  "mcpModal.clearFilters": "Clear filters",
+  "mcpModal.copyName": "Copy name",
+  "mcpModal.copyTarget": "Copy target",
+  "mcpModal.copied": "Copied",
 
   // Settings → Extensions (Plugins + Skills + MCP)
   "ext.lead":
@@ -5288,6 +5300,18 @@ const zh: Record<MessageKey, string> = {
   "mcpModal.loading": "正在加载 MCP…",
   "mcpModal.empty": "未发现 MCP 服务器",
   "mcpModal.manage": "在设置中管理",
+  "mcpModal.searchPlaceholder": "按名称、目标、传输筛选…",
+  "mcpModal.filter.statusLabel": "按状态筛选",
+  "mcpModal.filter.all": "全部",
+  "mcpModal.refresh": "刷新",
+  "mcpModal.refreshing": "刷新中…",
+  "mcpModal.summary": "{n} 个服务器",
+  "mcpModal.summaryFiltered": "{shown} / {total}",
+  "mcpModal.filterEmpty": "没有符合筛选条件的服务器",
+  "mcpModal.clearFilters": "清除筛选",
+  "mcpModal.copyName": "复制名称",
+  "mcpModal.copyTarget": "复制目标",
+  "mcpModal.copied": "已复制",
 
   // Settings → Extensions (Plugins + Skills + MCP)
   "ext.lead":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2233,6 +2233,18 @@ export const zhTW: Record<MessageKey, string> = {
   "mcpModal.loading": "正在載入 MCP…",
   "mcpModal.empty": "未發現 MCP 伺服器",
   "mcpModal.manage": "在設定中管理",
+  "mcpModal.searchPlaceholder": "依名稱、目標、傳輸篩選…",
+  "mcpModal.filter.statusLabel": "依狀態篩選",
+  "mcpModal.filter.all": "全部",
+  "mcpModal.refresh": "重新整理",
+  "mcpModal.refreshing": "重新整理中…",
+  "mcpModal.summary": "{n} 個伺服器",
+  "mcpModal.summaryFiltered": "{shown} / {total}",
+  "mcpModal.filterEmpty": "沒有符合篩選條件的伺服器",
+  "mcpModal.clearFilters": "清除篩選",
+  "mcpModal.copyName": "複製名稱",
+  "mcpModal.copyTarget": "複製目標",
+  "mcpModal.copied": "已複製",
 
   // Settings → Extensions (Plugins + Skills + MCP)
   "ext.lead":

--- a/src/lib/mcpStatus.test.ts
+++ b/src/lib/mcpStatus.test.ts
@@ -1,16 +1,24 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyMcpRowHealth,
+  countMcpRowsByHealth,
   detectAuthToneFromText,
+  filterMcpRows,
   indexDoctorServerStatuses,
   inferMcpStatusTone,
   lookupServerStatus,
   mapIssuesToServers,
+  matchMcpRowQuery,
   mcpAuthGuidanceKey,
+  mcpRowCopyText,
+  mcpRowHealthFromTone,
   mcpStatusBadgeMod,
   mcpStatusLabelKey,
+  MCP_ROW_STATUS_FILTERS,
   redactMcpText,
   statusFromDoctorServer,
   type McpDoctorReportLike,
+  type McpRowLike,
 } from "./mcpStatus";
 
 /** Fixture shaped like host `mcp_doctor` / `grok mcp doctor --json`. */
@@ -262,5 +270,162 @@ describe("label / badge / guidance helpers", () => {
       "ext.mcp.auth.requiredHint",
     );
     expect(mcpAuthGuidanceKey("error")).toBeNull();
+  });
+});
+
+const INSPECT_ROWS: McpRowLike[] = [
+  {
+    name: "context7",
+    transport: "stdio",
+    target: "npx -y @context7/mcp",
+    compatibilityStatus: "ok",
+    vendor: "context7",
+  },
+  {
+    name: "github",
+    transport: "http",
+    target: "https://api.github.com/mcp",
+    compatibilityStatus: "warn",
+  },
+  {
+    name: "broken",
+    transport: "http",
+    target: "https://example.com/mcp",
+    compatibilityStatus: "error",
+  },
+  {
+    name: "mystery",
+    transport: "stdio",
+    target: "/usr/local/bin/mystery-mcp",
+  },
+];
+
+describe("classifyMcpRowHealth", () => {
+  it("maps known compatibilityStatus tokens", () => {
+    expect(classifyMcpRowHealth({ compatibilityStatus: "ok" })).toBe("ok");
+    expect(classifyMcpRowHealth({ compatibilityStatus: "compatible" })).toBe(
+      "ok",
+    );
+    expect(classifyMcpRowHealth({ compatibilityStatus: "WARN" })).toBe("warn");
+    expect(classifyMcpRowHealth({ compatibilityStatus: "degraded" })).toBe(
+      "warn",
+    );
+    expect(classifyMcpRowHealth({ compatibilityStatus: "error" })).toBe(
+      "error",
+    );
+    expect(classifyMcpRowHealth({ compatibilityStatus: "incompatible" })).toBe(
+      "error",
+    );
+  });
+
+  it("infers free-form compatibility text", () => {
+    expect(
+      classifyMcpRowHealth({
+        compatibilityStatus: "token expired for this server",
+      }),
+    ).toBe("error");
+    expect(
+      classifyMcpRowHealth({
+        compatibilityStatus: "slow handshake warning",
+      }),
+    ).toBe("warn");
+  });
+
+  it("does not invent ok from transport alone", () => {
+    expect(classifyMcpRowHealth({ transport: "stdio" })).toBe("unknown");
+    expect(classifyMcpRowHealth({ transport: "http", name: "x" })).toBe(
+      "unknown",
+    );
+    expect(classifyMcpRowHealth({})).toBe("unknown");
+    expect(classifyMcpRowHealth(null)).toBe("unknown");
+  });
+
+  it("uses transport text only when it carries health keywords", () => {
+    expect(
+      classifyMcpRowHealth({ transport: "failed to start stdio" }),
+    ).toBe("error");
+  });
+
+  it("collapses doctor tones for chip buckets", () => {
+    expect(mcpRowHealthFromTone("ok")).toBe("ok");
+    expect(mcpRowHealthFromTone("warn")).toBe("warn");
+    expect(mcpRowHealthFromTone("auth_expired")).toBe("error");
+    expect(mcpRowHealthFromTone("auth_required")).toBe("error");
+    expect(mcpRowHealthFromTone("unknown")).toBe("unknown");
+  });
+});
+
+describe("countMcpRowsByHealth / filterMcpRows", () => {
+  it("counts per health including all", () => {
+    const counts = countMcpRowsByHealth(INSPECT_ROWS);
+    expect(counts.all).toBe(4);
+    expect(counts.ok).toBe(1);
+    expect(counts.warn).toBe(1);
+    expect(counts.error).toBe(1);
+    expect(counts.unknown).toBe(1);
+    expect(MCP_ROW_STATUS_FILTERS).toEqual([
+      "all",
+      "ok",
+      "warn",
+      "error",
+      "unknown",
+    ]);
+  });
+
+  it("filters by status chip", () => {
+    expect(filterMcpRows(INSPECT_ROWS, { status: "ok" }).map((r) => r.name)).toEqual([
+      "context7",
+    ]);
+    expect(
+      filterMcpRows(INSPECT_ROWS, { status: "error" }).map((r) => r.name),
+    ).toEqual(["broken"]);
+    expect(filterMcpRows(INSPECT_ROWS, { status: "all" })).toHaveLength(4);
+  });
+
+  it("filters by free-text query across name/target/transport/status", () => {
+    expect(
+      filterMcpRows(INSPECT_ROWS, { query: "github" }).map((r) => r.name),
+    ).toEqual(["github"]);
+    expect(
+      filterMcpRows(INSPECT_ROWS, { query: "api.github" }).map((r) => r.name),
+    ).toEqual(["github"]);
+    expect(
+      filterMcpRows(INSPECT_ROWS, { query: "stdio" }).map((r) => r.name),
+    ).toEqual(["context7", "mystery"]);
+    expect(filterMcpRows(INSPECT_ROWS, "context7").map((r) => r.name)).toEqual([
+      "context7",
+    ]);
+  });
+
+  it("combines query and status with AND", () => {
+    expect(
+      filterMcpRows(INSPECT_ROWS, { query: "http", status: "error" }).map(
+        (r) => r.name,
+      ),
+    ).toEqual(["broken"]);
+    expect(
+      filterMcpRows(INSPECT_ROWS, { query: "http", status: "ok" }),
+    ).toHaveLength(0);
+  });
+
+  it("never invents rows for empty input", () => {
+    expect(filterMcpRows([], { status: "ok" })).toEqual([]);
+    expect(countMcpRowsByHealth([]).all).toBe(0);
+  });
+
+  it("matchMcpRowQuery treats empty as match-all", () => {
+    expect(matchMcpRowQuery(INSPECT_ROWS[0]!, "")).toBe(true);
+    expect(matchMcpRowQuery(INSPECT_ROWS[0]!, "nope")).toBe(false);
+  });
+});
+
+describe("mcpRowCopyText", () => {
+  it("prefers target for auto, with field overrides", () => {
+    const row = INSPECT_ROWS[0]!;
+    expect(mcpRowCopyText(row, "auto")).toBe("npx -y @context7/mcp");
+    expect(mcpRowCopyText(row, "name")).toBe("context7");
+    expect(mcpRowCopyText(row, "target")).toBe("npx -y @context7/mcp");
+    expect(mcpRowCopyText({ name: "solo" }, "auto")).toBe("solo");
+    expect(mcpRowCopyText(null)).toBe("");
   });
 });

--- a/src/lib/mcpStatus.ts
+++ b/src/lib/mcpStatus.ts
@@ -519,3 +519,201 @@ export function mcpAuthGuidanceKey(
   if (tone === "auth_required") return "ext.mcp.auth.requiredHint";
   return null;
 }
+
+// ---------------------------------------------------------------------------
+// Inspect-row health (McpStatusModal) — from compatibilityStatus / transport
+// Never invents servers; empty list stays empty. Auth-ish tones collapse to
+// "error" for the four-chip filter bar (all / ok / warn / error / unknown).
+// ---------------------------------------------------------------------------
+
+/** Coarse health for inspect MCP rows (chips in the status modal). */
+export type McpRowHealth = "ok" | "warn" | "error" | "unknown";
+
+/** Inspect-shaped server row (name + optional meta). */
+export type McpRowLike = {
+  name?: string | null;
+  transport?: string | null;
+  target?: string | null;
+  vendor?: string | null;
+  compatibilityStatus?: string | null;
+};
+
+/** Status chip filter values for the MCP modal. */
+export type McpRowStatusFilter = "all" | McpRowHealth;
+
+/** Ordered chip list: all · ok · warn · error · unknown. */
+export const MCP_ROW_STATUS_FILTERS: readonly McpRowStatusFilter[] = [
+  "all",
+  "ok",
+  "warn",
+  "error",
+  "unknown",
+] as const;
+
+const COMPAT_OK = new Set([
+  "ok",
+  "healthy",
+  "compatible",
+  "pass",
+  "passed",
+  "up",
+  "supported",
+  "ready",
+  "good",
+  "success",
+  "available",
+]);
+const COMPAT_WARN = new Set([
+  "warn",
+  "warning",
+  "degraded",
+  "partial",
+  "slow",
+  "limited",
+]);
+const COMPAT_ERROR = new Set([
+  "error",
+  "fail",
+  "failed",
+  "unhealthy",
+  "down",
+  "bad",
+  "incompatible",
+  "broken",
+  "unsupported",
+  "disabled",
+  "offline",
+  "unreachable",
+]);
+
+/** Collapse doctor/auth tones into the four modal chip buckets. */
+export function mcpRowHealthFromTone(tone: McpStatusTone): McpRowHealth {
+  switch (tone) {
+    case "ok":
+      return "ok";
+    case "warn":
+      return "warn";
+    case "error":
+    case "auth_expired":
+    case "auth_required":
+      return "error";
+    case "unknown":
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Classify one inspect MCP row for modal lamps / chips.
+ *
+ * Priority: `compatibilityStatus` tokens → free-text tone on status →
+ * free-text tone on `transport` → `unknown`. Presence of transport alone
+ * does **not** imply healthy (no invented ok).
+ */
+export function classifyMcpRowHealth(
+  row: McpRowLike | null | undefined,
+): McpRowHealth {
+  if (!row) return "unknown";
+  const status = (row.compatibilityStatus ?? "").trim();
+  if (status) {
+    const lower = status.toLowerCase();
+    if (COMPAT_OK.has(lower)) return "ok";
+    if (COMPAT_WARN.has(lower)) return "warn";
+    if (COMPAT_ERROR.has(lower)) return "error";
+    // Multi-word / free-form compatibility strings.
+    return mcpRowHealthFromTone(inferMcpStatusTone([status], null));
+  }
+  const transport = (row.transport ?? "").trim();
+  if (transport) {
+    const tone = inferMcpStatusTone([transport], null);
+    // Transport labels like "stdio" / "http" yield unknown — keep that.
+    // Only promote when transport string itself carries health keywords.
+    if (tone !== "unknown") return mcpRowHealthFromTone(tone);
+  }
+  return "unknown";
+}
+
+/** Per-health counts plus total under `all`. */
+export type McpRowHealthCounts = Record<McpRowStatusFilter, number>;
+
+/** Count rows per health tone (and total under `all`). */
+export function countMcpRowsByHealth(
+  rows: readonly McpRowLike[],
+): McpRowHealthCounts {
+  const counts: McpRowHealthCounts = {
+    all: rows.length,
+    ok: 0,
+    warn: 0,
+    error: 0,
+    unknown: 0,
+  };
+  for (const r of rows) {
+    counts[classifyMcpRowHealth(r)] += 1;
+  }
+  return counts;
+}
+
+/** Combined MCP modal list filters (status chip + free text). */
+export interface McpRowFilter {
+  /** Free-text over name, transport, target, vendor, status, health. */
+  query?: string;
+  /** Status chip; default `"all"`. */
+  status?: McpRowStatusFilter;
+}
+
+/**
+ * Match a row against a free-text query (case-insensitive substring).
+ * Empty query matches everything.
+ */
+export function matchMcpRowQuery(
+  row: McpRowLike,
+  query: string | null | undefined,
+): boolean {
+  const q = (query ?? "").trim().toLowerCase();
+  if (!q) return true;
+  const health = classifyMcpRowHealth(row);
+  const hay = [
+    row.name ?? "",
+    row.transport ?? "",
+    row.target ?? "",
+    row.vendor ?? "",
+    row.compatibilityStatus ?? "",
+    health,
+  ]
+    .join("\n")
+    .toLowerCase();
+  return hay.includes(q);
+}
+
+/**
+ * Filter inspect MCP rows by free-text query and/or status chip.
+ * Filters combine with AND. Does not invent rows.
+ */
+export function filterMcpRows<T extends McpRowLike>(
+  rows: readonly T[],
+  filter: McpRowFilter | string = {},
+): T[] {
+  const opts: McpRowFilter =
+    typeof filter === "string" ? { query: filter } : filter ?? {};
+  const status = opts.status ?? "all";
+  let out: T[] = rows as T[];
+  if (status !== "all") {
+    out = out.filter((r) => classifyMcpRowHealth(r) === status);
+  }
+  const q = (opts.query ?? "").trim();
+  if (!q) return out;
+  return out.filter((r) => matchMcpRowQuery(r, q));
+}
+
+/** Preferred clipboard text for a row: target when present, else name. */
+export function mcpRowCopyText(
+  row: McpRowLike | null | undefined,
+  field: "name" | "target" | "auto" = "auto",
+): string {
+  if (!row) return "";
+  const name = (row.name ?? "").trim();
+  const target = (row.target ?? "").trim();
+  if (field === "name") return name;
+  if (field === "target") return target;
+  return target || name;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16131,13 +16131,89 @@ div.composer__input:empty::before {
 }
 
 /* MCP status modal */
+.mcp-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  flex: 1;
+}
 .mcp-modal__hint {
   font-size: 12px;
   color: var(--text-tertiary);
   margin: 0;
   flex-shrink: 0;
+  line-height: 1.45;
 }
-
+.mcp-modal__toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.mcp-modal__search {
+  flex: 1;
+  min-width: 140px;
+}
+.mcp-modal__refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.mcp-modal__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.mcp-modal__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.3;
+  cursor: pointer;
+}
+.mcp-modal__chip:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.mcp-modal__chip.is-active {
+  border-color: color-mix(in srgb, var(--accent, #6b8cff) 30%, transparent);
+  background: color-mix(in srgb, var(--accent, #6b8cff) 14%, transparent);
+  color: var(--text-primary);
+  font-weight: 560;
+}
+.mcp-modal__chip-count {
+  font-size: 11px;
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+.mcp-modal__chip.is-active .mcp-modal__chip-count {
+  opacity: 0.9;
+}
+.mcp-modal__summary {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.mcp-modal__empty-filter {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
 .mcp-modal__list {
   list-style: none;
   margin: 0;
@@ -16150,35 +16226,86 @@ div.composer__input:empty::before {
   flex-direction: column;
   gap: 8px;
 }
-
 .mcp-modal__item {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
   padding: 8px 10px;
   border-radius: 8px;
   background: var(--bg-hover);
   font-size: 13px;
   border: 1px solid transparent;
 }
-
-.mcp-modal__item strong {
+.mcp-modal__item-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  min-width: 0;
+}
+.mcp-modal__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-tertiary);
+}
+.mcp-modal__dot--ok {
+  background: color-mix(in srgb, #3ecf8e 85%, transparent);
+}
+.mcp-modal__dot--warn {
+  background: color-mix(in srgb, #e6b84d 90%, transparent);
+}
+.mcp-modal__dot--error {
+  background: color-mix(in srgb, #e85d5d 90%, transparent);
+}
+.mcp-modal__dot--unknown {
+  background: var(--text-tertiary);
+  opacity: 0.55;
+}
+.mcp-modal__name {
   font-weight: 500;
   color: var(--text-primary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-
-.mcp-modal__item span {
+.mcp-modal__item-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.mcp-modal__copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  padding: 2px 6px;
+}
+.mcp-modal__meta {
   color: var(--text-secondary);
   font-size: 12px;
+  padding-left: 16px;
 }
-
-.mcp-modal__item em {
+.mcp-modal__target {
   font-style: normal;
   font-size: 11px;
   color: var(--text-tertiary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding-left: 16px;
+}
+/* legacy selectors kept for any external references */
+.mcp-modal__item strong {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+.mcp-modal__item em {
+  font-style: normal;
 }
 
 /* Rewind timeline picker */


### PR DESCRIPTION
## Summary
- **Pure helpers** (`mcpStatus.ts`): classify inspect MCP row health from `compatibilityStatus` / `transport`, filter by query + status chip, counts, copy text — with unit tests; never invents servers
- **McpStatusModal**: search filter, status chips (all / ok / warn / error / unknown), count summary, refresh while open, copy name/target, health lamp + badge
- **App**: `onRefresh` re-runs `inspectMcp` while modal stays open
- **i18n** en / zh / zh-TW + CHANGELOG

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test src/lib/mcpStatus.test.ts src/i18n/messages.test.ts`
- [ ] Open MCP modal via slash/palette — list is host inspect only (empty stays empty)
- [ ] Search narrows by name/target/transport; chips filter health; summary updates
- [ ] Refresh re-fetches; copy name/target writes clipboard