### PR TITLE
feat(skills): scaffold new SKILL.md from Extensions → Skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ See `docs/llm-wiki/release.md`.
 - **Install failure recovery**: last install error stays on that plugin row with **Retry**; cleared on success
 - Installed **Details** shows structured marketplace/provides summary when available (plus CLI `plugin details` body)
 - **Delete CLI sessions from disk** (Settings → Agent / CLI sessions): per-row delete + delete all unlinked; path-scoped under active `GROK_HOME/sessions`; linked App chats stay
+- **New skill scaffold** (Settings → Extensions → Skills): modal name/description + user (path-scoped GROK_HOME `/skills`) or project scope; host creates folder + default `SKILL.md` (no overwrite); refresh list and open existing SKILL.md editor
 
 ### Fixed
 
@@ -69,7 +70,7 @@ See `docs/llm-wiki/release.md`.
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选
 - **计划**：**请求修改** 可选修订说明；计划历史搜索/决策筛选、清空确认、会话仍在时可打开
-- **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要
+- **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**新建技能脚手架**（名称/描述/用户或项目作用域 → 默认 SKILL.md + 打开编辑器）
 - **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）
 
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2390,6 +2390,31 @@ pub async fn skill_roots(project_path: Option<String>) -> Result<Vec<String>, St
     Ok(crate::skill_edit::skill_roots_list(project_path.as_deref()))
 }
 
+/// Scaffold a new skill directory + SKILL.md under user (path-scoped GROK_HOME)
+/// or project skills root. Does not overwrite an existing SKILL.md.
+#[tauri::command]
+pub async fn skill_create(
+    name: String,
+    description: Option<String>,
+    project_path: Option<String>,
+    scope: Option<String>,
+) -> Result<crate::skill_edit::SkillCreateResult, String> {
+    let name = name.clone();
+    let description = description.unwrap_or_default();
+    let project_path = project_path.clone();
+    let scope = scope.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::skill_edit::skill_create(
+            &name,
+            &description,
+            project_path.as_deref(),
+            scope.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 /// List MCP servers from `grok inspect --json`.
 /// Always returns Ok; on CLI missing / timeout, `servers` is empty and `error` is set.
 /// Each server includes `enabled` from App Extensions prefs (default true).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -338,6 +338,7 @@ pub fn run() {
             commands::skill_read,
             commands::skill_write,
             commands::skill_roots,
+            commands::skill_create,
             commands::agents_list,
             commands::inspect_mcp,
             commands::project_inspect,

--- a/src-tauri/src/skill_edit.rs
+++ b/src-tauri/src/skill_edit.rs
@@ -1,4 +1,5 @@
 //! In-app SKILL.md editor — path allowlist + read/write under known skills roots.
+//! Also scaffolds new skills (`skill_create`) under path-scoped GROK_HOME or project.
 //!
 //! Writable roots (mirrors `src/lib/skillEditPath.ts`):
 //! - `{user_home}/.grok/skills`
@@ -13,10 +14,13 @@ use std::time::UNIX_EPOCH;
 
 use serde::Serialize;
 
-use crate::paths::agent_home_dir;
+use crate::paths::{agent_home_dir, resolve_agent_grok_home};
 use crate::process_util::user_home;
 
 const MAX_SKILL_BYTES: u64 = 2 * 1024 * 1024; // 2 MiB
+const SKILL_NAME_MIN: usize = 2;
+const SKILL_NAME_MAX: usize = 64;
+const SKILL_DESCRIPTION_MAX: usize = 2000;
 
 /// Result of reading a SKILL.md for the editor.
 #[derive(Debug, Clone, Serialize)]
@@ -37,6 +41,263 @@ pub struct SkillWriteResult {
     pub path: String,
     pub size: u64,
     pub mtime_ms: u64,
+}
+
+/// Result of scaffolding a new skill directory + SKILL.md.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillCreateResult {
+    /// Absolute path to SKILL.md.
+    pub path: String,
+    /// Sanitized skill folder name.
+    pub name: String,
+    /// Skills root directory used.
+    pub root: String,
+    /// True when this call wrote a new SKILL.md.
+    pub created: bool,
+    /// True when SKILL.md already existed (not overwritten).
+    pub already_existed: bool,
+}
+
+/// Pure: sanitize / validate a skill folder name (mirrors `src/lib/skillScaffold.ts`).
+///
+/// Lowercase a-z, digits, hyphens; spaces/underscores → hyphens; 2–64 chars;
+/// must start/end alnum; rejects `bundled`.
+pub fn sanitize_skill_folder_name(raw: &str) -> Result<String, String> {
+    let mut s = raw.trim().to_ascii_lowercase();
+    if s.is_empty() {
+        return Err("skill name is required".into());
+    }
+    // Normalize separators.
+    s = s
+        .chars()
+        .map(|c| match c {
+            ' ' | '_' => '-',
+            other => other,
+        })
+        .collect();
+    // Keep only a-z0-9-
+    s = s
+        .chars()
+        .filter(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '-')
+        .collect();
+    // Collapse repeated hyphens + trim edge hyphens.
+    while s.contains("--") {
+        s = s.replace("--", "-");
+    }
+    s = s.trim_matches('-').to_string();
+
+    if s.len() < SKILL_NAME_MIN {
+        return Err(format!(
+            "skill name too short (min {SKILL_NAME_MIN} characters after sanitize)"
+        ));
+    }
+    if s.len() > SKILL_NAME_MAX {
+        return Err(format!(
+            "skill name too long (max {SKILL_NAME_MAX} characters)"
+        ));
+    }
+    let bytes = s.as_bytes();
+    let first = bytes[0];
+    let last = bytes[bytes.len() - 1];
+    let alnum = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit();
+    if !alnum(first) || !alnum(last) {
+        return Err("skill name must start and end with a letter or digit".into());
+    }
+    if s.eq_ignore_ascii_case("bundled") {
+        return Err("skill name is reserved".into());
+    }
+    Ok(s)
+}
+
+fn normalize_skill_description(raw: &str) -> String {
+    let mut d = raw.replace("\r\n", "\n").trim().to_string();
+    if d.is_empty() {
+        return String::new();
+    }
+    // Collapse trailing spaces before newlines, then 3+ blank lines → 2.
+    let mut cleaned = String::with_capacity(d.len());
+    for line in d.lines() {
+        if !cleaned.is_empty() {
+            cleaned.push('\n');
+        }
+        cleaned.push_str(line.trim_end());
+    }
+    d = cleaned;
+    while d.contains("\n\n\n") {
+        d = d.replace("\n\n\n", "\n\n");
+    }
+    if d.len() > SKILL_DESCRIPTION_MAX {
+        d.truncate(SKILL_DESCRIPTION_MAX);
+        d = d.trim_end().to_string();
+    }
+    d
+}
+
+fn skill_description_for_frontmatter(description: &str) -> String {
+    let d = normalize_skill_description(description);
+    if d.is_empty() {
+        return "Describe what this skill does and when to use it (include trigger phrases)."
+            .into();
+    }
+    d.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .replace('"', "\\\"")
+}
+
+fn title_case_skill_name(name: &str) -> String {
+    name.split('-')
+        .filter(|w| !w.is_empty())
+        .map(|w| {
+            let mut c = w.chars();
+            match c.next() {
+                None => String::new(),
+                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Pure: default SKILL.md frontmatter + body template (mirrors TS `defaultSkillMdContent`).
+pub fn default_skill_md_content(name: &str, description: &str) -> String {
+    let safe_name = sanitize_skill_folder_name(name)
+        .unwrap_or_else(|_| name.trim().to_ascii_lowercase());
+    let desc_line = skill_description_for_frontmatter(description);
+    let body_desc = {
+        let n = normalize_skill_description(description);
+        if n.is_empty() {
+            "Describe the workflow this skill should automate.".into()
+        } else {
+            n
+        }
+    };
+    let title = title_case_skill_name(&safe_name);
+    let title = if title.is_empty() {
+        safe_name.clone()
+    } else {
+        title
+    };
+
+    format!(
+        "---\n\
+name: {safe_name}\n\
+description: {desc_line}\n\
+---\n\
+\n\
+# {title}\n\
+\n\
+{body_desc}\n\
+\n\
+## Steps\n\
+\n\
+1. Clarify the goal with the user if anything is ambiguous.\n\
+2. Perform the task following the instructions above.\n\
+3. Summarize what you did and any follow-ups.\n\
+"
+    )
+}
+
+/// Resolve the skills root for create: path-scoped GROK_HOME (user) or project.
+///
+/// - `scope` `"project"` → `{project}/.grok/skills` (requires non-empty project_path)
+/// - otherwise `"user"` (default) → `{resolve_agent_grok_home}/skills`
+pub fn resolve_skill_create_root(
+    project_path: Option<&str>,
+    scope: Option<&str>,
+) -> Result<PathBuf, String> {
+    let scope = scope.unwrap_or("user").trim().to_ascii_lowercase();
+    match scope.as_str() {
+        "project" => {
+            let raw = project_path
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| "project scope requires an active project path".to_string())?;
+            if path_has_traversal(Path::new(raw)) {
+                return Err("invalid project path".into());
+            }
+            Ok(PathBuf::from(raw).join(".grok").join("skills"))
+        }
+        "user" | "global" | "" => {
+            let settings = crate::store::load_settings();
+            let grok_home = resolve_agent_grok_home(&settings.session_data_mode);
+            Ok(grok_home.join("skills"))
+        }
+        other => Err(format!(
+            "invalid skill scope '{other}' (expected user or project)"
+        )),
+    }
+}
+
+/// Create `{root}/{name}/` and write SKILL.md when missing (does not overwrite).
+pub fn skill_create(
+    name: &str,
+    description: &str,
+    project_path: Option<&str>,
+    scope: Option<&str>,
+) -> Result<SkillCreateResult, String> {
+    let safe_name = sanitize_skill_folder_name(name)?;
+    let root = resolve_skill_create_root(project_path, scope)?;
+    let roots = build_skill_edit_roots(project_path);
+    // Ensure the chosen root is allowlisted (project root may not be in list if path empty —
+    // resolve_skill_create_root already validates project).
+    let root_ok = roots.iter().any(|r| paths_equal_loose(r, &root));
+    if !root_ok {
+        // Project create: project may be newly under roots only when project_path is set —
+        // rebuild already includes it. If still not ok, reject.
+        tracing::warn!(
+            root = %root.display(),
+            "skill_create: root not in allowlisted skills roots"
+        );
+        return Err("path not allowed: outside known skills roots".into());
+    }
+
+    let skill_dir = root.join(&safe_name);
+    if path_has_traversal(&skill_dir) {
+        return Err("path not allowed: traversal".into());
+    }
+    let skill_md = skill_dir.join("SKILL.md");
+    let allowed = require_skill_md_allowed(&skill_md, &roots)?;
+
+    if allowed.is_file() {
+        return Ok(SkillCreateResult {
+            path: allowed.to_string_lossy().to_string(),
+            name: safe_name,
+            root: root.to_string_lossy().to_string(),
+            created: false,
+            already_existed: true,
+        });
+    }
+
+    fs::create_dir_all(&skill_dir).map_err(|e| format!("create skill directory: {e}"))?;
+
+    let content = default_skill_md_content(&safe_name, description);
+    let bytes = content.as_bytes();
+    if bytes.len() as u64 > MAX_SKILL_BYTES {
+        return Err(format!(
+            "template too large (max {MAX_SKILL_BYTES} bytes)"
+        ));
+    }
+
+    // Atomic-ish write: temp then rename.
+    let tmp = skill_dir.join(format!(
+        ".SKILL.md.grok-skill-create-{}",
+        std::process::id()
+    ));
+    fs::write(&tmp, bytes).map_err(|e| format!("write temp SKILL.md: {e}"))?;
+    fs::rename(&tmp, &allowed).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        format!("create SKILL.md: {e}")
+    })?;
+
+    Ok(SkillCreateResult {
+        path: allowed.to_string_lossy().to_string(),
+        name: safe_name,
+        root: root.to_string_lossy().to_string(),
+        created: true,
+        already_existed: false,
+    })
 }
 
 fn file_mtime_ms(path: &Path) -> u64 {
@@ -384,5 +645,73 @@ mod tests {
         assert_eq!(fs::read_to_string(&allowed).unwrap(), new_body);
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sanitize_skill_name_rules() {
+        assert_eq!(sanitize_skill_folder_name("deploy-k8s").unwrap(), "deploy-k8s");
+        assert_eq!(sanitize_skill_folder_name("  My Skill  ").unwrap(), "my-skill");
+        assert_eq!(sanitize_skill_folder_name("foo_bar").unwrap(), "foo-bar");
+        assert!(sanitize_skill_folder_name("x").is_err());
+        assert!(sanitize_skill_folder_name("").is_err());
+        assert!(sanitize_skill_folder_name("bundled").is_err());
+        assert!(sanitize_skill_folder_name(&"a".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn default_template_has_frontmatter() {
+        let md = default_skill_md_content("code-review", "Review PRs carefully.");
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("name: code-review"));
+        assert!(md.contains("description: Review PRs carefully."));
+        assert!(md.contains("# Code Review"));
+        assert!(md.contains("## Steps"));
+    }
+
+    #[test]
+    fn skill_create_project_scope_idempotent() {
+        let proj = std::env::temp_dir().join(format!(
+            "grok-skill-create-proj-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&proj);
+        fs::create_dir_all(&proj).unwrap();
+        let proj_s = proj.to_string_lossy().to_string();
+
+        let r1 = skill_create(
+            "Hello World",
+            "Says hello when asked.",
+            Some(&proj_s),
+            Some("project"),
+        )
+        .unwrap();
+        assert!(r1.created);
+        assert!(!r1.already_existed);
+        assert_eq!(r1.name, "hello-world");
+        assert!(Path::new(&r1.path).is_file());
+        let body = fs::read_to_string(&r1.path).unwrap();
+        assert!(body.contains("name: hello-world"));
+        assert!(body.contains("Says hello when asked."));
+
+        let r2 = skill_create(
+            "hello-world",
+            "ignored on second create",
+            Some(&proj_s),
+            Some("project"),
+        )
+        .unwrap();
+        assert!(!r2.created);
+        assert!(r2.already_existed);
+        // macOS may canonicalize /var → /private/var on the second call (file exists).
+        assert!(
+            paths_equal_loose(Path::new(&r2.path), Path::new(&r1.path))
+                || Path::new(&r2.path).ends_with("hello-world/SKILL.md")
+        );
+        // Must not overwrite.
+        let body2 = fs::read_to_string(&r2.path).unwrap();
+        assert!(body2.contains("Says hello when asked."));
+        assert!(!body2.contains("ignored on second create"));
+
+        let _ = fs::remove_dir_all(&proj);
     }
 }

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -53,6 +53,7 @@ import {
   isSkillEditable,
   resolveSkillMdPath,
 } from "@/lib/skillEditPath";
+import { sanitizeSkillFolderName } from "@/lib/skillScaffold";
 import {
   isFsWriteConflict,
   isResourceDraftDirty,
@@ -143,6 +144,12 @@ export function ExtensionsPanel({
   const [skillDiscardOpen, setSkillDiscardOpen] = useState(false);
   const [skillConflictOpen, setSkillConflictOpen] = useState(false);
   const skillEditorSeq = useRef(0);
+  /** New skill scaffold modal (Extensions → Skills). */
+  const [skillNewOpen, setSkillNewOpen] = useState(false);
+  const [skillNewName, setSkillNewName] = useState("");
+  const [skillNewDesc, setSkillNewDesc] = useState("");
+  const [skillNewScope, setSkillNewScope] = useState<"user" | "project">("user");
+  const [skillNewError, setSkillNewError] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
   const [addName, setAddName] = useState("");
   const [addCommand, setAddCommand] = useState("");
@@ -351,12 +358,13 @@ export function ExtensionsPanel({
   }, [closeSkillEditor, skillEditor?.saving, skillEditorDirty]);
 
   const openSkillEditor = useCallback(
-    async (skill: api.SkillDto) => {
+    async (skill: api.SkillDto, opts?: { force?: boolean }) => {
       if (!api.isTauri()) {
         setPathHint(tr("ext.needTauri"));
         return;
       }
-      if (!isSkillEditable(skill, skillRoots)) return;
+      // `force` skips client allowlist (e.g. right after create, roots state may lag).
+      if (!opts?.force && !isSkillEditable(skill, skillRoots)) return;
       const mdPath = resolveSkillMdPath(skill.path) ?? skill.path?.trim() ?? "";
       if (!mdPath) return;
       const seq = ++skillEditorSeq.current;
@@ -471,6 +479,77 @@ export function ExtensionsPanel({
     },
     [onSkillsPrefsChanged, projectPath, refresh, skillEditor, tr],
   );
+
+  const skillNewSanitized = useMemo(
+    () => sanitizeSkillFolderName(skillNewName),
+    [skillNewName],
+  );
+
+  const openSkillNew = useCallback(() => {
+    setSkillNewName("");
+    setSkillNewDesc("");
+    setSkillNewScope("user");
+    setSkillNewError(null);
+    setSkillNewOpen(true);
+  }, []);
+
+  const submitSkillNew = useCallback(async () => {
+    if (!api.isTauri() || actionBusy) return;
+    const safe = sanitizeSkillFolderName(skillNewName);
+    if (!safe) {
+      setSkillNewError(tr("ext.skills.newNameInvalid"));
+      return;
+    }
+    const scope: "user" | "project" =
+      skillNewScope === "project" && projectPath?.trim()
+        ? "project"
+        : "user";
+    if (skillNewScope === "project" && !projectPath?.trim()) {
+      setSkillNewError(tr("ext.skills.newScopeProjectNeed"));
+      return;
+    }
+    setActionBusy("skill:create");
+    setSkillNewError(null);
+    setActionError(null);
+    try {
+      const res = await api.skillCreate({
+        name: safe,
+        description: skillNewDesc,
+        projectPath,
+        scope,
+      });
+      setSkillNewOpen(false);
+      setSkillNewName("");
+      setSkillNewDesc("");
+      await refresh();
+      onSkillsPrefsChanged?.();
+      // Reuse existing SKILL.md editor open flow.
+      const dto: api.SkillDto = {
+        name: res.name,
+        description: skillNewDesc.trim(),
+        source: scope === "project" ? "project" : "user",
+        path: res.path,
+        userInvocable: true,
+        enabled: true,
+      };
+      // Roots React state may lag one frame after refresh — force open by path.
+      void openSkillEditor(dto, { force: true });
+    } catch (e) {
+      setSkillNewError(String(e) || tr("ext.skills.newError"));
+    } finally {
+      setActionBusy(null);
+    }
+  }, [
+    actionBusy,
+    onSkillsPrefsChanged,
+    openSkillEditor,
+    projectPath,
+    refresh,
+    skillNewDesc,
+    skillNewName,
+    skillNewScope,
+    tr,
+  ]);
 
   const runPluginAction = async (
     key: string,
@@ -1075,16 +1154,27 @@ export function ExtensionsPanel({
         {!loading ? (
           <span className="ext-count">{skills.length}</span>
         ) : null}
-        {!loading && skills.length > 0 && skillsOffCount > 0 ? (
+        <span className="ext-h2-actions">
           <button
             type="button"
             className="btn btn--ghost ext-bulk-btn"
-            disabled={!!busyKey}
-            onClick={() => void enableAllSkills()}
+            disabled={!!actionBusy || !!busyKey || !api.isTauri() || !!skillEditor}
+            onClick={openSkillNew}
           >
-            {tr("ext.enableAll")}
+            <IconPlus size={14} />
+            <span>{tr("ext.skills.new")}</span>
           </button>
-        ) : null}
+          {!loading && skills.length > 0 && skillsOffCount > 0 ? (
+            <button
+              type="button"
+              className="btn btn--ghost ext-bulk-btn"
+              disabled={!!busyKey}
+              onClick={() => void enableAllSkills()}
+            >
+              {tr("ext.enableAll")}
+            </button>
+          ) : null}
+        </span>
       </h2>
       <div className="settings-card ext-card">
         {loading && (
@@ -1842,6 +1932,121 @@ export function ExtensionsPanel({
           <li>{tr("ext.mcp.auth.stepDoctor")}</li>
         </ol>
         <p className="ext-field-hint">{tr("ext.mcp.auth.noAutoRefresh")}</p>
+      </GlassModal>
+
+      <GlassModal
+        open={skillNewOpen}
+        onClose={() => {
+          if (actionBusy !== "skill:create") setSkillNewOpen(false);
+        }}
+        title={tr("ext.skills.newTitle")}
+        size="md"
+        closeLabel={tr("common.close")}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={actionBusy === "skill:create"}
+              onClick={() => setSkillNewOpen(false)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={
+                actionBusy === "skill:create" || !skillNewSanitized
+              }
+              onClick={() => void submitSkillNew()}
+            >
+              {actionBusy === "skill:create"
+                ? tr("ext.skills.newWorking")
+                : tr("ext.skills.newSubmit")}
+            </button>
+          </>
+        }
+      >
+        <form
+          className="app-dialog__form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void submitSkillNew();
+          }}
+        >
+          <label className="field">
+            <span>{tr("ext.skills.newName")}</span>
+            <input
+              className="app-dialog__input"
+              value={skillNewName}
+              onChange={(e) => {
+                setSkillNewName(e.target.value);
+                setSkillNewError(null);
+              }}
+              placeholder={tr("ext.skills.newNamePlaceholder")}
+              autoComplete="off"
+              spellCheck={false}
+              disabled={actionBusy === "skill:create"}
+              autoFocus
+            />
+            <span className="ext-field-hint">
+              {skillNewSanitized
+                ? tr("ext.skills.newNameHintOk", { name: skillNewSanitized })
+                : tr("ext.skills.newNameHint")}
+            </span>
+          </label>
+          <label className="field">
+            <span>{tr("ext.skills.newDescription")}</span>
+            <textarea
+              className="app-dialog__input ext-env-textarea"
+              value={skillNewDesc}
+              onChange={(e) => {
+                setSkillNewDesc(e.target.value);
+                setSkillNewError(null);
+              }}
+              placeholder={tr("ext.skills.newDescriptionPlaceholder")}
+              rows={3}
+              spellCheck
+              disabled={actionBusy === "skill:create"}
+            />
+            <span className="ext-field-hint">
+              {tr("ext.skills.newDescriptionHint")}
+            </span>
+          </label>
+          <fieldset className="field" disabled={actionBusy === "skill:create"}>
+            <legend>{tr("ext.skills.newScope")}</legend>
+            <label className="ext-radio-row">
+              <input
+                type="radio"
+                name="skill-new-scope"
+                checked={skillNewScope === "user"}
+                onChange={() => setSkillNewScope("user")}
+              />
+              <span>{tr("ext.skills.newScopeUser")}</span>
+            </label>
+            <label className="ext-radio-row">
+              <input
+                type="radio"
+                name="skill-new-scope"
+                checked={skillNewScope === "project"}
+                onChange={() => setSkillNewScope("project")}
+                disabled={!projectPath?.trim()}
+              />
+              <span>
+                {projectPath?.trim()
+                  ? tr("ext.skills.newScopeProject")
+                  : tr("ext.skills.newScopeProjectDisabled")}
+              </span>
+            </label>
+            <span className="ext-field-hint">{tr("ext.skills.newScopeHint")}</span>
+          </fieldset>
+          {skillNewError ? (
+            <p className="ext-alert" role="alert">
+              <span className="ext-alert__body">{skillNewError}</span>
+            </p>
+          ) : null}
+        </form>
       </GlassModal>
 
       <GlassModal

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2400,6 +2400,30 @@ const en = {
     "This SKILL.md was modified outside the app. Reload the file or overwrite with your draft.",
   "ext.skills.editConflictReload": "Reload",
   "ext.skills.editConflictOverwrite": "Overwrite",
+  "ext.skills.new": "New skill",
+  "ext.skills.newTitle": "New skill",
+  "ext.skills.newSubmit": "Create",
+  "ext.skills.newWorking": "Creating…",
+  "ext.skills.newName": "Name",
+  "ext.skills.newNamePlaceholder": "e.g. deploy-k8s",
+  "ext.skills.newNameHint":
+    "Lowercase letters, digits, and hyphens; 2–64 characters (slash command /name).",
+  "ext.skills.newNameHintOk": "Will create as /{name}",
+  "ext.skills.newNameInvalid":
+    "Enter a valid skill name (a-z, 0-9, hyphens; 2–64 chars).",
+  "ext.skills.newDescription": "Description",
+  "ext.skills.newDescriptionPlaceholder":
+    "What it does and when to use it (trigger phrases help auto-invoke)…",
+  "ext.skills.newDescriptionHint":
+    "Written into SKILL.md frontmatter. You can edit the full body after create.",
+  "ext.skills.newScope": "Location",
+  "ext.skills.newScopeUser": "User (path-scoped GROK_HOME /skills)",
+  "ext.skills.newScopeProject": "Project (.grok/skills in active project)",
+  "ext.skills.newScopeProjectDisabled": "Project (open a project first)",
+  "ext.skills.newScopeProjectNeed": "Open a project to create a project skill.",
+  "ext.skills.newScopeHint":
+    "User skills follow the active agent home (independent GROK_HOME or ~/.grok). Project skills ship with the repo.",
+  "ext.skills.newError": "Could not create skill",
   "ext.mcp.title": "MCP servers",
   "ext.mcp.loading": "Loading MCP servers…",
   "ext.mcp.empty": "No MCP servers discovered",
@@ -5364,6 +5388,30 @@ const zh: Record<MessageKey, string> = {
     "此 SKILL.md 已在应用外被修改。可重新加载文件，或用当前草稿覆盖。",
   "ext.skills.editConflictReload": "重新加载",
   "ext.skills.editConflictOverwrite": "覆盖",
+  "ext.skills.new": "新建技能",
+  "ext.skills.newTitle": "新建技能",
+  "ext.skills.newSubmit": "创建",
+  "ext.skills.newWorking": "正在创建…",
+  "ext.skills.newName": "名称",
+  "ext.skills.newNamePlaceholder": "例如 deploy-k8s",
+  "ext.skills.newNameHint":
+    "小写字母、数字与连字符；2–64 个字符（斜杠命令 /name）。",
+  "ext.skills.newNameHintOk": "将创建为 /{name}",
+  "ext.skills.newNameInvalid":
+    "请输入有效技能名（a-z、0-9、连字符；2–64 字符）。",
+  "ext.skills.newDescription": "描述",
+  "ext.skills.newDescriptionPlaceholder":
+    "做什么、何时使用（触发短语有助于自动调用）…",
+  "ext.skills.newDescriptionHint":
+    "写入 SKILL.md 前置元数据。创建后可继续编辑正文。",
+  "ext.skills.newScope": "位置",
+  "ext.skills.newScopeUser": "用户（路径作用域 GROK_HOME /skills）",
+  "ext.skills.newScopeProject": "项目（当前项目 .grok/skills）",
+  "ext.skills.newScopeProjectDisabled": "项目（请先打开项目）",
+  "ext.skills.newScopeProjectNeed": "请先打开项目以创建项目技能。",
+  "ext.skills.newScopeHint":
+    "用户技能跟随当前 agent home（独立 GROK_HOME 或 ~/.grok）。项目技能随仓库共享。",
+  "ext.skills.newError": "无法创建技能",
   "ext.mcp.title": "MCP 服务器",
   "ext.mcp.loading": "正在加载 MCP…",
   "ext.mcp.empty": "未发现 MCP 服务器",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2309,6 +2309,30 @@ export const zhTW: Record<MessageKey, string> = {
     "此 SKILL.md 已在應用外被修改。可重新載入檔案，或用目前草稿覆寫。",
   "ext.skills.editConflictReload": "重新載入",
   "ext.skills.editConflictOverwrite": "覆寫",
+  "ext.skills.new": "新增技能",
+  "ext.skills.newTitle": "新增技能",
+  "ext.skills.newSubmit": "建立",
+  "ext.skills.newWorking": "正在建立…",
+  "ext.skills.newName": "名稱",
+  "ext.skills.newNamePlaceholder": "例如 deploy-k8s",
+  "ext.skills.newNameHint":
+    "小寫字母、數字與連字號；2–64 個字元（斜線指令 /name）。",
+  "ext.skills.newNameHintOk": "將建立為 /{name}",
+  "ext.skills.newNameInvalid":
+    "請輸入有效技能名（a-z、0-9、連字號；2–64 字元）。",
+  "ext.skills.newDescription": "描述",
+  "ext.skills.newDescriptionPlaceholder":
+    "做什麼、何時使用（觸發片語有助於自動呼叫）…",
+  "ext.skills.newDescriptionHint":
+    "寫入 SKILL.md 前置中繼資料。建立後可繼續編輯正文。",
+  "ext.skills.newScope": "位置",
+  "ext.skills.newScopeUser": "使用者（路徑作用域 GROK_HOME /skills）",
+  "ext.skills.newScopeProject": "專案（目前專案 .grok/skills）",
+  "ext.skills.newScopeProjectDisabled": "專案（請先開啟專案）",
+  "ext.skills.newScopeProjectNeed": "請先開啟專案以建立專案技能。",
+  "ext.skills.newScopeHint":
+    "使用者技能跟隨目前 agent home（獨立 GROK_HOME 或 ~/.grok）。專案技能隨倉庫共用。",
+  "ext.skills.newError": "無法建立技能",
   "ext.mcp.title": "MCP 伺服器",
   "ext.mcp.loading": "正在載入 MCP…",
   "ext.mcp.empty": "未發現 MCP 伺服器",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1435,6 +1435,15 @@ export interface SkillWriteResult {
   mtimeMs: number;
 }
 
+/** Result of Host `skill_create` (scaffold folder + SKILL.md). */
+export interface SkillCreateResult {
+  path: string;
+  name: string;
+  root: string;
+  created: boolean;
+  alreadyExisted: boolean;
+}
+
 export interface InspectMcpResult {
   servers: McpDto[];
   error?: string;
@@ -1578,6 +1587,25 @@ export async function skillWrite(
     content,
     expectedMtimeMs: expectedMtimeMs ?? null,
     projectPath: projectPath ?? null,
+  });
+}
+
+/**
+ * Scaffold a new skill (`{root}/{name}/SKILL.md`).
+ * @param scope `"user"` (path-scoped GROK_HOME skills) or `"project"` (requires projectPath).
+ * Does not overwrite an existing SKILL.md.
+ */
+export async function skillCreate(opts: {
+  name: string;
+  description?: string | null;
+  projectPath?: string | null;
+  scope?: "user" | "project" | null;
+}) {
+  return invoke<SkillCreateResult>("skill_create", {
+    name: opts.name,
+    description: opts.description ?? null,
+    projectPath: opts.projectPath ?? null,
+    scope: opts.scope ?? "user",
   });
 }
 

--- a/src/lib/skillScaffold.test.ts
+++ b/src/lib/skillScaffold.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  SKILL_DESCRIPTION_MAX,
+  SKILL_NAME_MAX,
+  SKILL_NAME_MIN,
+  defaultSkillMdContent,
+  normalizeSkillDescription,
+  sanitizeSkillFolderName,
+  skillDescriptionForFrontmatter,
+} from "./skillScaffold";
+
+describe("sanitizeSkillFolderName", () => {
+  it("accepts simple lowercase names", () => {
+    expect(sanitizeSkillFolderName("deploy")).toBe("deploy");
+    expect(sanitizeSkillFolderName("deploy-k8s")).toBe("deploy-k8s");
+    expect(sanitizeSkillFolderName("a1")).toBe("a1");
+  });
+
+  it("normalizes case, spaces, and underscores", () => {
+    expect(sanitizeSkillFolderName("  Deploy K8s  ")).toBe("deploy-k8s");
+    expect(sanitizeSkillFolderName("my_skill_name")).toBe("my-skill-name");
+    expect(sanitizeSkillFolderName("Foo__Bar")).toBe("foo-bar");
+  });
+
+  it("strips invalid characters and collapses hyphens", () => {
+    expect(sanitizeSkillFolderName("hello@world!")).toBe("helloworld");
+    expect(sanitizeSkillFolderName("a--b---c")).toBe("a-b-c");
+    expect(sanitizeSkillFolderName("-trim-me-")).toBe("trim-me");
+  });
+
+  it("rejects empty, too short, too long, and reserved", () => {
+    expect(sanitizeSkillFolderName("")).toBeNull();
+    expect(sanitizeSkillFolderName("   ")).toBeNull();
+    expect(sanitizeSkillFolderName("x")).toBeNull(); // min 2
+    expect(sanitizeSkillFolderName("a".repeat(SKILL_NAME_MAX + 1))).toBeNull();
+    expect(sanitizeSkillFolderName("bundled")).toBeNull();
+    expect(sanitizeSkillFolderName("Bundled")).toBeNull();
+    expect(sanitizeSkillFolderName(null)).toBeNull();
+    expect(sanitizeSkillFolderName(undefined)).toBeNull();
+  });
+
+  it("accepts boundary lengths", () => {
+    expect(sanitizeSkillFolderName("ab")).toBe("ab");
+    expect(sanitizeSkillFolderName("a".repeat(SKILL_NAME_MAX))).toBe(
+      "a".repeat(SKILL_NAME_MAX),
+    );
+    expect(SKILL_NAME_MIN).toBe(2);
+  });
+});
+
+describe("normalizeSkillDescription", () => {
+  it("trims and caps length", () => {
+    expect(normalizeSkillDescription("  hello  ")).toBe("hello");
+    const long = "x".repeat(SKILL_DESCRIPTION_MAX + 50);
+    expect(normalizeSkillDescription(long).length).toBe(SKILL_DESCRIPTION_MAX);
+  });
+
+  it("collapses excessive blank lines", () => {
+    expect(normalizeSkillDescription("a\n\n\n\nb")).toBe("a\n\nb");
+  });
+});
+
+describe("skillDescriptionForFrontmatter", () => {
+  it("provides a default when empty", () => {
+    expect(skillDescriptionForFrontmatter("")).toMatch(/Describe what this skill/);
+  });
+
+  it("flattens newlines and escapes quotes", () => {
+    expect(skillDescriptionForFrontmatter("line1\nline2")).toBe("line1 line2");
+    expect(skillDescriptionForFrontmatter('say "hi"')).toBe('say \\"hi\\"');
+  });
+});
+
+describe("defaultSkillMdContent", () => {
+  it("emits frontmatter name + description and body steps", () => {
+    const md = defaultSkillMdContent("code-review", "Review PRs carefully.");
+    expect(md.startsWith("---\n")).toBe(true);
+    expect(md).toContain("name: code-review");
+    expect(md).toContain("description: Review PRs carefully.");
+    expect(md).toContain("# Code Review");
+    expect(md).toContain("Review PRs carefully.");
+    expect(md).toContain("## Steps");
+  });
+
+  it("sanitizes name in frontmatter", () => {
+    const md = defaultSkillMdContent("My Skill", "does things");
+    expect(md).toContain("name: my-skill");
+    expect(md).toContain("# My Skill");
+  });
+
+  it("uses placeholder body when description omitted", () => {
+    const md = defaultSkillMdContent("help-me");
+    expect(md).toContain("name: help-me");
+    expect(md).toMatch(/Describe the workflow|Describe what this skill/);
+  });
+});

--- a/src/lib/skillScaffold.ts
+++ b/src/lib/skillScaffold.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure helpers for scaffolding a new user skill (folder + SKILL.md).
+ *
+ * Host `skill_create` enforces the same name rules and template; this module
+ * is the shared client-side validator + unit-tested template.
+ */
+
+export const SKILL_NAME_MIN = 2;
+export const SKILL_NAME_MAX = 64;
+
+/** Max description length accepted for a scaffolded SKILL.md. */
+export const SKILL_DESCRIPTION_MAX = 2000;
+
+/**
+ * Sanitize and validate a skill folder / slash-command name.
+ *
+ * Rules (aligned with Grok `/create-skill`):
+ * - lowercase a-z, digits 0-9, hyphens only
+ * - spaces / underscores normalized to hyphens
+ * - must start and end with alphanumeric
+ * - length 2–64 after sanitization
+ * - reserved names (e.g. `bundled`) rejected
+ *
+ * Returns the cleaned name, or `null` when invalid / empty.
+ */
+export function sanitizeSkillFolderName(raw: string | null | undefined): string | null {
+  let s = (raw ?? "").trim().toLowerCase();
+  if (!s) return null;
+
+  // Normalize common separators, then drop other junk.
+  s = s.replace(/[\s_]+/g, "-");
+  s = s.replace(/[^a-z0-9-]/g, "");
+  s = s.replace(/-+/g, "-");
+  s = s.replace(/^-+|-+$/g, "");
+
+  if (s.length < SKILL_NAME_MIN || s.length > SKILL_NAME_MAX) return null;
+  // Single alnum is already rejected by min length; still require alnum ends.
+  if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(s)) return null;
+  if (s === "bundled") return null;
+  return s;
+}
+
+/**
+ * Normalize optional description for frontmatter / body.
+ * Trims, collapses internal runs of whitespace/newlines lightly, caps length.
+ */
+export function normalizeSkillDescription(
+  raw: string | null | undefined,
+): string {
+  let d = (raw ?? "").replace(/\r\n/g, "\n").trim();
+  if (!d) return "";
+  // Collapse excessive blank lines for the body copy; frontmatter uses one line.
+  d = d.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n");
+  if (d.length > SKILL_DESCRIPTION_MAX) {
+    d = d.slice(0, SKILL_DESCRIPTION_MAX).trimEnd();
+  }
+  return d;
+}
+
+/** One-line description suitable for YAML frontmatter (no bare newlines). */
+export function skillDescriptionForFrontmatter(description: string): string {
+  const d = normalizeSkillDescription(description);
+  if (!d) {
+    return "Describe what this skill does and when to use it (include trigger phrases).";
+  }
+  // Single line for simple frontmatter; escape double quotes.
+  return d.replace(/\s*\n+\s*/g, " ").replace(/"/g, '\\"');
+}
+
+/**
+ * Default SKILL.md content: YAML frontmatter (`name`, `description`) + body stub.
+ * Pure — no I/O.
+ */
+export function defaultSkillMdContent(
+  name: string,
+  description?: string | null,
+): string {
+  const safeName = sanitizeSkillFolderName(name) ?? name.trim().toLowerCase();
+  const descLine = skillDescriptionForFrontmatter(description ?? "");
+  const bodyDesc =
+    normalizeSkillDescription(description) ||
+    "Describe the workflow this skill should automate.";
+
+  const title = safeName
+    .split("-")
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+
+  return [
+    "---",
+    `name: ${safeName}`,
+    `description: ${descLine}`,
+    "---",
+    "",
+    `# ${title || safeName}`,
+    "",
+    bodyDesc,
+    "",
+    "## Steps",
+    "",
+    "1. Clarify the goal with the user if anything is ambiguous.",
+    "2. Perform the task following the instructions above.",
+    "3. Summarize what you did and any follow-ups.",
+    "",
+  ].join("\n");
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17450,6 +17450,26 @@ div.composer__input:empty::before {
   color: #e05a5a;
 }
 
+.ext-radio-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.ext-radio-row input[type="radio"] {
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.ext-radio-row:has(input:disabled) {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 /* Settings → Agent: workspace memory browser */
 .settings-memory-browser {
   gap: 10px;


### PR DESCRIPTION
## Summary

- **Pure helpers (+ tests):** `sanitizeSkillFolderName` / `defaultSkillMdContent` in `src/lib/skillScaffold.ts` (and mirrored in `skill_edit.rs`) — folder name rules match Grok `/create-skill` (a-z, 0-9, hyphens; 2–64; reserved `bundled` rejected).
- **Host `skill_create`:** creates `{root}/{name}/SKILL.md` under path-scoped GROK_HOME (`resolve_agent_grok_home` → `/skills`) or project `.grok/skills`; allowlisted via existing skill roots; **never overwrites** an existing SKILL.md.
- **UI:** Settings → Extensions → Skills → **New skill** modal (name, description, user/project scope) → create → refresh list + open existing SKILL.md editor.
- **i18n** en / zh / zh-TW + **CHANGELOG**.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test src/lib/skillScaffold.test.ts src/i18n/messages.test.ts`
- [x] `cargo test skill_edit` (sanitize, template, project-scope create idempotent)
- [ ] Manual: Extensions → Skills → New skill → user scope → editor opens with template
- [ ] Manual: create same name again → no overwrite; editor still opens
- [ ] Manual: project scope with active project → writes under `<project>/.grok/skills/`