### PR TITLE
feat(trace): export local vs upload (localOnly + confirm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ See `docs/llm-wiki/release.md`.
 - **Agent serve** start/stop from Settings → Runtime → Connection (`grok agent serve --bind/--secret`; default `127.0.0.1:2419`; masked secret + one-time connection URL copy)
 - **Agent dashboard filters**: status chips with per-status counts (all / busy / permission / connecting / idle / error), free-text session search, project id/name/path filter, empty-filter state + clear; **Stop all busy** still targets every stoppable session globally (not only the filtered list)
 - **Trace history manage** (Traces modal + Settings → Runtime): search by title/path, remove row, clear all (in-app confirm), optional file size from host `stat` after export — still paths only, never loads archive contents
+- **Trace export + upload** (`grok trace`): session menu **Export local** (default, `--local`) vs **Export and upload…** with in-app confirm (network to xAI); host `session_trace_export` `localOnly` (default true); history may note `uploaded=true` when CLI reports remote info (paths only, no URLs/secrets); actionable failure toasts
 
 #### Permissions / CLI
 - **CLI `--permission-mode` alignment**: pure App policy / YOLO / plan-mode map (`default` · `acceptEdits` · `auto` · `dontAsk` · `bypassPermissions` · `plan`); spawn pins top-level `--permission-mode` (+ agent `--always-approve` for YOLO); Settings shows CLI label + advanced mode selector; product **Auto** policy
@@ -67,7 +68,7 @@ See `docs/llm-wiki/release.md`.
 - **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、会话规则（`--rules`）、会话最大轮次（`--max-turns` 覆盖；空/0 继承全局）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标、快捷键冲突面板（录制警告 + 重置冲突项）
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
-- **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选
+- **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；**Trace 本地导出 vs 导出并上传**（确认弹窗、`localOnly` 默认 true、历史上传标记、失败 toast）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选
 - **计划**：**请求修改** 可选修订说明；计划历史搜索/决策筛选、清空确认、会话仍在时可打开
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要
 - **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1874,18 +1874,26 @@ pub async fn export_session_bundle(
     .await
 }
 
-/// Export the Grok Build CLI session trace (`grok trace <agent_id> --local`).
-/// Resolves `agent_session_id` from live/parked runtime or session meta.
-/// Opens a save dialog for the `.tar.gz` and reveals the file.
+/// Export the Grok Build CLI session trace (`grok trace <agent_id>`).
+///
+/// - `local_only` (default **true** for safety): when true, pass `--local` so the
+///   CLI only writes a local archive. When false, omit `--local` so the CLI may
+///   also upload (network).
+/// - Resolves `agent_session_id` from live/parked runtime or session meta.
+/// - Opens a save dialog for the `.tar.gz` and reveals the file.
+/// - Returns `{ ok, path, sizeBytes?, uploaded?, localOnly }` — never secrets/URLs.
 #[tauri::command]
 pub async fn session_trace_export(
     session_id: String,
+    local_only: Option<bool>,
     mgr: State<'_, Arc<SessionManager>>,
 ) -> Result<serde_json::Value, String> {
     let sid = session_id.trim().to_string();
     if sid.is_empty() {
         return Err("session id is empty".into());
     }
+    // Default true: local-only is the safe path; upload requires explicit false.
+    let local_only = local_only.unwrap_or(true);
 
     // Prefer live/parked agent id (may be newer than the index), then meta.
     let live_agent = mgr.diagnostic_runtime_for(&sid).and_then(|rt| {
@@ -1897,17 +1905,53 @@ pub async fn session_trace_export(
     });
 
     tauri::async_runtime::spawn_blocking(move || {
-        session_trace_export_blocking(&sid, live_agent.as_deref())
+        session_trace_export_blocking(&sid, live_agent.as_deref(), local_only)
     })
     .await
     .map_err(|e| e.to_string())?
 }
 
 const TRACE_EXPORT_TIMEOUT_SECS: u64 = 90;
+/// Upload may need extra time for network transfer of large archives.
+const TRACE_EXPORT_UPLOAD_TIMEOUT_SECS: u64 = 180;
+
+/// Detect whether CLI JSON indicates a remote upload completed.
+/// Presence-only: never returns or stores remote URLs / tokens.
+fn trace_cli_reports_uploaded(cli_json: Option<&serde_json::Value>) -> bool {
+    let Some(v) = cli_json else {
+        return false;
+    };
+    if v.get("uploaded").and_then(|x| x.as_bool()) == Some(true) {
+        return true;
+    }
+    let status = v
+        .get("status")
+        .and_then(|s| s.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    if matches!(
+        status.as_str(),
+        "uploaded" | "upload_complete" | "upload-complete" | "ok_uploaded"
+    ) {
+        return true;
+    }
+    // Remote info keys — truthy non-empty string means upload path ran.
+    // Do not persist these values (may contain URLs).
+    for key in ["remote_url", "upload_url", "share_url", "object_path"] {
+        if let Some(s) = v.get(key).and_then(|x| x.as_str()) {
+            if !s.trim().is_empty() {
+                return true;
+            }
+        }
+    }
+    false
+}
 
 fn session_trace_export_blocking(
     session_id: &str,
     live_agent_session_id: Option<&str>,
+    local_only: bool,
 ) -> Result<serde_json::Value, String> {
     let meta = store::load_sessions_index()
         .into_iter()
@@ -1942,14 +1986,14 @@ fn session_trace_export_blocking(
     let tmp = std::env::temp_dir().join(format!("grok-trace-{short}-{stamp}.tar.gz"));
     let tmp_s = tmp.to_string_lossy().to_string();
 
-    let args = vec![
-        "trace".to_string(),
-        agent_sid.clone(),
-        "--local".to_string(),
-        "-o".to_string(),
-        tmp_s.clone(),
-        "--json".to_string(),
-    ];
+    // `grok trace <id>` uploads unless `--local`. Default App path keeps `--local`.
+    let mut args = vec!["trace".to_string(), agent_sid.clone()];
+    if local_only {
+        args.push("--local".to_string());
+    }
+    args.push("-o".to_string());
+    args.push(tmp_s.clone());
+    args.push("--json".to_string());
 
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
@@ -1963,15 +2007,18 @@ fn session_trace_export_blocking(
         let _ = tx.send(cmd.output());
     });
 
-    let output = match rx.recv_timeout(std::time::Duration::from_secs(TRACE_EXPORT_TIMEOUT_SECS)) {
+    let timeout_secs = if local_only {
+        TRACE_EXPORT_TIMEOUT_SECS
+    } else {
+        TRACE_EXPORT_UPLOAD_TIMEOUT_SECS
+    };
+    let output = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
         Ok(Ok(o)) => o,
         Ok(Err(e)) => {
             return Err(store::redact_text(&format!("Failed to run grok trace: {e}")));
         }
         Err(_) => {
-            return Err(format!(
-                "grok trace timed out after {TRACE_EXPORT_TIMEOUT_SECS}s"
-            ));
+            return Err(format!("grok trace timed out after {timeout_secs}s"));
         }
     };
 
@@ -1993,17 +2040,19 @@ fn session_trace_export_blocking(
             .collect());
     }
 
+    let cli_json = serde_json::from_str::<serde_json::Value>(&stdout).ok();
+    // Only claim uploaded when we intentionally allowed network upload.
+    let uploaded = !local_only && trace_cli_reports_uploaded(cli_json.as_ref());
+
     // Prefer the archive we asked for; fall back to JSON local_path from CLI.
     let archive = if tmp.is_file() {
         tmp
     } else {
-        let from_json = serde_json::from_str::<serde_json::Value>(&stdout)
-            .ok()
-            .and_then(|v| {
-                v.get("local_path")
-                    .and_then(|p| p.as_str())
-                    .map(|s| std::path::PathBuf::from(s))
-            });
+        let from_json = cli_json.as_ref().and_then(|v| {
+            v.get("local_path")
+                .and_then(|p| p.as_str())
+                .map(std::path::PathBuf::from)
+        });
         match from_json {
             Some(p) if p.is_file() => p,
             _ => {
@@ -2022,13 +2071,21 @@ fn session_trace_export_blocking(
 
     let suggested = format!("grok-trace-{short}.tar.gz");
     // Already on a blocking thread (session_trace_export spawns us).
-    save_and_reveal_file_blocking(
+    let mut result = save_and_reveal_file_blocking(
         archive,
         "Save session trace",
         &suggested,
         "Trace archive",
         &["tar.gz".into(), "gz".into(), "tgz".into()],
-    )
+    )?;
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert("localOnly".into(), serde_json::json!(local_only));
+        // Paths-only history may note uploaded=true; never attach remote URLs.
+        if uploaded {
+            obj.insert("uploaded".into(), serde_json::json!(true));
+        }
+    }
+    Ok(result)
 }
 
 /// Save dialog + reveal. Always runs rfd/copy on a blocking thread so async

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12183,26 +12183,42 @@ export default function App() {
     [session.sessionId, showToast, tr],
   );
 
-  /** Export Grok Build CLI session trace (`grok trace --local`). */
+  /**
+   * Export Grok Build CLI session trace.
+   * `localOnly` default true → `grok trace --local`. False omits `--local` (may upload).
+   */
   const exportSessionTrace = useCallback(
-    async (sessionId?: string | null) => {
+    async (
+      sessionId?: string | null,
+      opts?: { localOnly?: boolean },
+    ) => {
       const id = sessionId || session.sessionId;
+      const localOnly = opts?.localOnly !== false;
       if (!id) {
         showToast(tr("session.exportTraceFail"));
         return;
       }
       try {
-        const res = await api.sessionTraceExport(id);
+        const res = await api.sessionTraceExport(id, { localOnly });
         if (res?.ok && res.path) {
           const row = sessions.find((s) => s.id === id);
+          const uploaded = res.uploaded === true;
           recordTraceExport({
             sessionId: id,
             path: res.path,
             title: row?.title ?? null,
             sizeBytes:
               typeof res.sizeBytes === "number" ? res.sizeBytes : null,
+            uploaded: uploaded || null,
           });
-          showToast(tr("session.exportTraceDone"), 4200);
+          if (uploaded) {
+            showToast(tr("session.exportTraceUploaded"), 4200);
+          } else if (!localOnly) {
+            // Network allowed but CLI only wrote local (upload disabled / fallback).
+            showToast(tr("session.exportTraceDoneLocalFallback"), 5000);
+          } else {
+            showToast(tr("session.exportTraceDone"), 4200);
+          }
         } else {
           showToast(tr("session.exportTraceFail"));
         }
@@ -12210,12 +12226,46 @@ export default function App() {
         const msg = String(e);
         if (/no agent session/i.test(msg)) {
           showToast(tr("session.exportTraceNoAgent"), 5000);
+        } else if (/cli not found|grok build cli not found/i.test(msg)) {
+          showToast(`${tr("session.exportTraceFail")}: ${tr("session.exportTraceNoCli")}`, 5500);
+        } else if (/timed out/i.test(msg)) {
+          showToast(
+            `${tr("session.exportTraceFail")}: ${tr("session.exportTraceTimeout")}`,
+            5500,
+          );
+        } else if (!localOnly && /upload|network|telemetry|403|401|forbidden/i.test(msg)) {
+          showToast(
+            `${tr("session.exportTraceUploadFail")}: ${msg}`,
+            6000,
+          );
         } else {
-          showToast(`${tr("session.exportTraceFail")}: ${msg}`, 5000);
+          // Actionable: surface host/CLI reason (already redacted server-side).
+          showToast(`${tr("session.exportTraceFail")}: ${msg}`, 5500);
         }
       }
     },
     [session.sessionId, sessions, showToast, tr],
+  );
+
+  /** Confirm network upload before `grok trace` without `--local`. */
+  const confirmExportSessionTraceUpload = useCallback(
+    (sessionId?: string | null) => {
+      const id = sessionId || session.sessionId;
+      if (!id) {
+        showToast(tr("session.exportTraceFail"));
+        return;
+      }
+      setAppDialog({
+        kind: "confirm",
+        title: tr("session.exportTraceUploadTitle"),
+        message: tr("session.exportTraceUploadMessage"),
+        confirmLabel: tr("session.exportTraceUploadConfirm"),
+        onConfirm: () => {
+          void exportSessionTrace(id, { localOnly: false });
+        },
+      });
+    },
+    [exportSessionTrace, session.sessionId, showToast, tr],
   );
 
   const beginEditLastUser = useCallback(
@@ -17450,6 +17500,7 @@ export default function App() {
             cancel: tr("common.cancel"),
             searchPlaceholder: tr("session.tracesSearch"),
             listAria: tr("session.tracesTitle"),
+            uploadedBadge: tr("session.tracesUploadedBadge"),
           }}
           onCopied={() => showToast(tr("session.tracesCopied"), 2000)}
           onError={(msg) => showToast(msg, 4000)}
@@ -19025,11 +19076,19 @@ export default function App() {
                 },
               },
               {
-                id: "export-trace",
-                label: tr("session.exportTrace"),
+                id: "export-trace-local",
+                label: tr("session.exportTraceLocal"),
                 icon: <IconArchive size={16} />,
                 onClick: () => {
-                  void exportSessionTrace(s.id);
+                  void exportSessionTrace(s.id, { localOnly: true });
+                },
+              },
+              {
+                id: "export-trace-upload",
+                label: tr("session.exportTraceUpload"),
+                icon: <IconArchive size={16} />,
+                onClick: () => {
+                  confirmExportSessionTraceUpload(s.id);
                 },
               },
               {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -5070,6 +5070,7 @@ export function SettingsPage({
                         cancel: t("common.cancel"),
                         searchPlaceholder: t("session.tracesSearch"),
                         listAria: t("session.tracesTitle"),
+                        uploadedBadge: t("session.tracesUploadedBadge"),
                       }}
                       onCopied={() =>
                         showSettingsToast(t("session.tracesCopied"), 2000)

--- a/src/components/TraceHistoryList.tsx
+++ b/src/components/TraceHistoryList.tsx
@@ -37,6 +37,8 @@ export type TraceHistoryListLabels = {
   searchPlaceholder: string;
   /** Optional column/section aria */
   listAria?: string;
+  /** Optional badge when history notes uploaded=true (no URLs). */
+  uploadedBadge?: string;
 };
 
 export type TraceHistoryListProps = {
@@ -265,6 +267,14 @@ export function TraceHistoryList({
                     {sizeLabel ? (
                       <span className="trace-history-row__size">
                         {sizeLabel}
+                      </span>
+                    ) : null}
+                    {e.uploaded && labels.uploadedBadge ? (
+                      <span
+                        className="trace-history-row__uploaded"
+                        title={labels.uploadedBadge}
+                      >
+                        {labels.uploadedBadge}
                       </span>
                     ) : null}
                     {e.exportedAt ? (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2127,16 +2127,30 @@ const en = {
   "session.exportJson": "Export chat as JSON",
   "session.exportHtml": "Export chat as HTML",
   "session.exportTrace": "Export trace",
+  "session.exportTraceLocal": "Export local",
+  "session.exportTraceUpload": "Export and upload…",
+  "session.exportTraceUploadTitle": "Export and upload session trace?",
+  "session.exportTraceUploadMessage":
+    "This runs grok trace without --local so the CLI may upload the session archive over the network to xAI. Only continue if you intend to share this session’s trace for support or debugging.",
+  "session.exportTraceUploadConfirm": "Export and upload",
   "session.exportTraceDone": "Session trace saved",
+  "session.exportTraceUploaded": "Session trace saved and uploaded",
+  "session.exportTraceDoneLocalFallback":
+    "Session trace saved locally (upload was not reported by the CLI — check telemetry / network if you expected a remote upload).",
   "session.exportTraceFail": "Trace export failed",
+  "session.exportTraceUploadFail": "Trace upload failed",
   "session.exportTraceNoAgent":
     "No agent session linked yet. Start a conversation first, then export the trace.",
+  "session.exportTraceNoCli":
+    "Grok Build CLI not found. Install or set the CLI path in Settings, then retry.",
+  "session.exportTraceTimeout":
+    "Timed out waiting for grok trace. Try again, or use Export local for a faster archive-only path.",
   "session.traces": "Traces",
   "session.tracesTitle": "Recent traces",
   "session.tracesDesc":
     "Local history of session trace exports (paths only). Open the folder or copy the path — large archives are not loaded into the app.",
   "session.tracesEmpty":
-    "No traces exported yet. Use Export trace from a chat menu after a conversation has an agent session.",
+    "No traces exported yet. Use Export local or Export and upload from a chat menu after a conversation has an agent session.",
   "session.tracesReveal": "Reveal in folder",
   "session.tracesCopyPath": "Copy path",
   "session.tracesCopied": "Path copied",
@@ -2148,6 +2162,7 @@ const en = {
   "session.tracesClearConfirmAction": "Clear all",
   "session.tracesSearch": "Filter by title or path…",
   "session.tracesEmptyFilter": "No traces match this filter",
+  "session.tracesUploadedBadge": "Uploaded",
   "session.exportBundle": "Export diagnostic package…",
   "session.exportBundleDone": "Diagnostic package saved",
   "session.exportBundleFail": "Diagnostic export failed",
@@ -5097,16 +5112,30 @@ const zh: Record<MessageKey, string> = {
   "session.exportJson": "导出会话为 JSON",
   "session.exportHtml": "导出会话为 HTML",
   "session.exportTrace": "导出 trace",
+  "session.exportTraceLocal": "仅本地导出",
+  "session.exportTraceUpload": "导出并上传…",
+  "session.exportTraceUploadTitle": "导出并上传会话 trace？",
+  "session.exportTraceUploadMessage":
+    "将运行不带 --local 的 grok trace，CLI 可能通过网络将会话归档上传到 xAI。仅在你确实要分享该会话 trace 用于支持或调试时继续。",
+  "session.exportTraceUploadConfirm": "导出并上传",
   "session.exportTraceDone": "会话 trace 已保存",
+  "session.exportTraceUploaded": "会话 trace 已保存并上传",
+  "session.exportTraceDoneLocalFallback":
+    "会话 trace 已保存到本地（CLI 未报告上传成功 — 若期望远程上传，请检查 telemetry / 网络）。",
   "session.exportTraceFail": "trace 导出失败",
+  "session.exportTraceUploadFail": "trace 上传失败",
   "session.exportTraceNoAgent":
     "尚未关联 agent 会话。请先发起对话，再导出 trace。",
+  "session.exportTraceNoCli":
+    "未找到 Grok Build CLI。请先安装或在设置中配置 CLI 路径后再试。",
+  "session.exportTraceTimeout":
+    "等待 grok trace 超时。可重试，或改用「仅本地导出」以更快生成归档。",
   "session.traces": "Traces",
   "session.tracesTitle": "最近的 trace",
   "session.tracesDesc":
     "会话 trace 导出的本地历史（仅路径）。可在文件夹中显示或复制路径 — 大文件不会加载进应用。",
   "session.tracesEmpty":
-    "还没有导出过 trace。在有 agent 会话的对话菜单中选择「导出 trace」。",
+    "还没有导出过 trace。在有 agent 会话的对话菜单中选择「仅本地导出」或「导出并上传」。",
   "session.tracesReveal": "在文件夹中显示",
   "session.tracesCopyPath": "复制路径",
   "session.tracesCopied": "路径已复制",
@@ -5118,6 +5147,7 @@ const zh: Record<MessageKey, string> = {
   "session.tracesClearConfirmAction": "全部清除",
   "session.tracesSearch": "按标题或路径筛选…",
   "session.tracesEmptyFilter": "没有匹配的 trace",
+  "session.tracesUploadedBadge": "已上传",
   "session.exportBundle": "导出完整诊断包…",
   "session.exportBundleDone": "诊断包已保存",
   "session.exportBundleFail": "诊断包导出失败",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2042,16 +2042,30 @@ export const zhTW: Record<MessageKey, string> = {
   "session.exportJson": "匯出對話為 JSON",
   "session.exportHtml": "匯出對話為 HTML",
   "session.exportTrace": "匯出 trace",
+  "session.exportTraceLocal": "僅本機匯出",
+  "session.exportTraceUpload": "匯出並上傳…",
+  "session.exportTraceUploadTitle": "匯出並上傳對話 trace？",
+  "session.exportTraceUploadMessage":
+    "將執行不帶 --local 的 grok trace，CLI 可能透過網路將對話封存上傳至 xAI。僅在你確實要分享此對話 trace 以供支援或除錯時繼續。",
+  "session.exportTraceUploadConfirm": "匯出並上傳",
   "session.exportTraceDone": "對話 trace 已儲存",
+  "session.exportTraceUploaded": "對話 trace 已儲存並上傳",
+  "session.exportTraceDoneLocalFallback":
+    "對話 trace 已儲存至本機（CLI 未回報上傳成功 — 若預期遠端上傳，請檢查 telemetry / 網路）。",
   "session.exportTraceFail": "trace 匯出失敗",
+  "session.exportTraceUploadFail": "trace 上傳失敗",
   "session.exportTraceNoAgent":
     "尚未關聯 agent 對話。請先發起對話，再匯出 trace。",
+  "session.exportTraceNoCli":
+    "找不到 Grok Build CLI。請先安裝或在設定中設定 CLI 路徑後再試。",
+  "session.exportTraceTimeout":
+    "等待 grok trace 逾時。可重試，或改用「僅本機匯出」以更快產生封存。",
   "session.traces": "Traces",
   "session.tracesTitle": "最近的 trace",
   "session.tracesDesc":
     "對話 trace 匯出的本機歷史（僅路徑）。可在資料夾中顯示或複製路徑 — 大檔不會載入應用。",
   "session.tracesEmpty":
-    "還沒有匯出過 trace。在有 agent 對話的選單中選擇「匯出 trace」。",
+    "還沒有匯出過 trace。在有 agent 對話的選單中選擇「僅本機匯出」或「匯出並上傳」。",
   "session.tracesReveal": "在資料夾中顯示",
   "session.tracesCopyPath": "複製路徑",
   "session.tracesCopied": "路徑已複製",
@@ -2063,6 +2077,7 @@ export const zhTW: Record<MessageKey, string> = {
   "session.tracesClearConfirmAction": "全部清除",
   "session.tracesSearch": "依標題或路徑篩選…",
   "session.tracesEmptyFilter": "沒有相符的 trace",
+  "session.tracesUploadedBadge": "已上傳",
   "session.exportBundle": "匯出完整診斷包…",
   "session.exportBundleDone": "診斷包已儲存",
   "session.exportBundleFail": "診斷包匯出失敗",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1499,6 +1499,18 @@ export interface SupportBundleResult {
   sizeBytes?: number;
 }
 
+/**
+ * Result of `session_trace_export`.
+ * History may record `uploaded` when the CLI reported a remote upload —
+ * never secrets or remote URLs.
+ */
+export interface SessionTraceExportResult extends SupportBundleResult {
+  /** Host default is true (`grok trace --local`). */
+  localOnly?: boolean;
+  /** True only when export allowed network upload and CLI reported remote info. */
+  uploaded?: boolean;
+}
+
 /** Build a redacted support zip (Doctor + logs) and save via native dialog. */
 export async function exportSupportBundle(doctorJson?: string | null) {
   return invoke<SupportBundleResult>("export_support_bundle", {
@@ -1518,12 +1530,19 @@ export async function exportSessionBundle(sessionId: string) {
 }
 
 /**
- * Export Grok Build CLI session trace via `grok trace <agentSessionId> --local`.
+ * Export Grok Build CLI session trace via `grok trace <agentSessionId>`.
  * Requires a linked agent session id. Opens a native save dialog for the `.tar.gz`.
+ *
+ * @param localOnly default **true** (safe): pass `--local`. Set false to omit
+ *   `--local` so the CLI may upload over the network.
  */
-export async function sessionTraceExport(sessionId: string) {
-  return invoke<SupportBundleResult>("session_trace_export", {
+export async function sessionTraceExport(
+  sessionId: string,
+  opts?: { localOnly?: boolean },
+) {
+  return invoke<SessionTraceExportResult>("session_trace_export", {
     sessionId,
+    localOnly: opts?.localOnly ?? true,
   });
 }
 

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -1693,7 +1693,11 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     tab: "tools",
     anchorId: "settings-anchor-traces",
     labelKey: "session.tracesTitle",
-    descKeys: ["session.tracesDesc", "session.exportTrace"],
+    descKeys: [
+      "session.tracesDesc",
+      "session.exportTraceLocal",
+      "session.exportTraceUpload",
+    ],
     keywords: [
       "trace",
       "traces",

--- a/src/lib/traceHistory.test.ts
+++ b/src/lib/traceHistory.test.ts
@@ -6,9 +6,11 @@ import {
   filterTraceHistory,
   formatTraceHistorySize,
   loadTraceHistory,
+  parseTraceExportUploadedFlag,
   parseTraceHistory,
   parseTraceHistoryEntry,
   parseTraceHistorySizeBytes,
+  parseTraceHistoryUploaded,
   pushTraceHistory,
   recordTraceExport,
   removeTraceHistory,
@@ -88,6 +90,29 @@ describe("parseTraceHistoryEntry", () => {
         sizeBytes: Number.NaN,
       }),
     ).not.toHaveProperty("sizeBytes");
+  });
+
+  it("keeps uploaded=true only (paths still; no secrets)", () => {
+    expect(
+      parseTraceHistoryEntry({
+        sessionId: "s",
+        path: "/p",
+        uploaded: true,
+        remote_url: "https://evil.example/secret",
+      }),
+    ).toEqual({
+      sessionId: "s",
+      path: "/p",
+      exportedAt: new Date(0).toISOString(),
+      uploaded: true,
+    });
+    expect(
+      parseTraceHistoryEntry({
+        sessionId: "s",
+        path: "/p",
+        uploaded: false,
+      }),
+    ).not.toHaveProperty("uploaded");
   });
 
   it("rejects missing sessionId or path", () => {
@@ -275,6 +300,24 @@ describe("load / save / recordTraceExport", () => {
     expect(loadTraceHistory(storage)[0]!.path).toBe("/tmp/new.tar.gz");
   });
 
+  it("recordTraceExport can note uploaded=true without URLs", () => {
+    const storage = memStorage();
+    const next = recordTraceExport(
+      {
+        sessionId: "sess-up",
+        path: "/tmp/up.tar.gz",
+        uploaded: true,
+      },
+      storage,
+    );
+    expect(next[0]).toMatchObject({
+      sessionId: "sess-up",
+      path: "/tmp/up.tar.gz",
+      uploaded: true,
+    });
+    expect(JSON.stringify(next[0])).not.toMatch(/https?:\/\//);
+  });
+
   it("load returns empty when storage throws or missing", () => {
     expect(loadTraceHistory(memStorage())).toEqual([]);
     const bad: TraceHistoryStorage = {
@@ -330,5 +373,56 @@ describe("display helpers", () => {
     expect(parseTraceHistorySizeBytes(100)).toBe(100);
     expect(parseTraceHistorySizeBytes("99.7")).toBe(99);
     expect(parseTraceHistorySizeBytes(-3)).toBeUndefined();
+  });
+});
+
+describe("parseTraceExportUploadedFlag / parseTraceHistoryUploaded", () => {
+  it("parseTraceHistoryUploaded coerces common truthy forms", () => {
+    expect(parseTraceHistoryUploaded(true)).toBe(true);
+    expect(parseTraceHistoryUploaded(false)).toBe(false);
+    expect(parseTraceHistoryUploaded("true")).toBe(true);
+    expect(parseTraceHistoryUploaded("no")).toBe(false);
+    expect(parseTraceHistoryUploaded(undefined)).toBeUndefined();
+  });
+
+  it("detects host result uploaded flag", () => {
+    expect(
+      parseTraceExportUploadedFlag({
+        ok: true,
+        path: "/tmp/a.tar.gz",
+        uploaded: true,
+      }),
+    ).toBe(true);
+    expect(
+      parseTraceExportUploadedFlag({
+        ok: true,
+        path: "/tmp/a.tar.gz",
+        localOnly: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("detects CLI-style remote info without requiring secrets", () => {
+    expect(
+      parseTraceExportUploadedFlag({
+        session_id: "abc",
+        status: "exported",
+        local_path: "/tmp/x.tar.gz",
+      }),
+    ).toBe(false);
+    expect(
+      parseTraceExportUploadedFlag({
+        session_id: "abc",
+        status: "uploaded",
+        local_path: "/tmp/x.tar.gz",
+      }),
+    ).toBe(true);
+    expect(
+      parseTraceExportUploadedFlag({
+        local_path: "/tmp/x.tar.gz",
+        remote_url: "https://example.invalid/t",
+      }),
+    ).toBe(true);
+    expect(parseTraceExportUploadedFlag(null)).toBe(false);
   });
 });

--- a/src/lib/traceHistory.ts
+++ b/src/lib/traceHistory.ts
@@ -2,7 +2,8 @@
  * Recent session-trace export history (localStorage ring buffer).
  *
  * Stores **paths only** — never file contents (traces can be large).
- * Entries: { sessionId, title?, path, exportedAt, sizeBytes? }, max ~20, newest first.
+ * Entries: { sessionId, title?, path, exportedAt, sizeBytes?, uploaded? }, max ~20, newest first.
+ * Optional `uploaded=true` notes that the CLI reported a remote upload — never URLs/secrets.
  */
 
 export type TraceHistoryEntry = {
@@ -12,6 +13,11 @@ export type TraceHistoryEntry = {
   exportedAt: string;
   /** Optional file size in bytes (from host stat after export). Never load contents. */
   sizeBytes?: number;
+  /**
+   * True when export used network upload and CLI JSON indicated remote success.
+   * Omitted / false for local-only exports. Never stores remote URLs or tokens.
+   */
+  uploaded?: boolean;
 };
 
 export const TRACE_HISTORY_STORAGE_KEY = "grok.traceHistory";
@@ -74,6 +80,54 @@ export function parseTraceHistorySizeBytes(raw: unknown): number | undefined {
 }
 
 /**
+ * Coerce a host/CLI-style boolean for the optional `uploaded` history flag.
+ * Only true when clearly true — never invents upload from paths alone.
+ */
+export function parseTraceHistoryUploaded(raw: unknown): boolean | undefined {
+  if (raw === true || raw === 1) return true;
+  if (raw === false || raw === 0) return false;
+  if (typeof raw === "string") {
+    const s = raw.trim().toLowerCase();
+    if (s === "true" || s === "1" || s === "yes") return true;
+    if (s === "false" || s === "0" || s === "no") return false;
+  }
+  return undefined;
+}
+
+/**
+ * Pure: did host / CLI JSON report a successful remote upload?
+ * Accepts the `session_trace_export` result or a subset of CLI `--json` fields.
+ * Presence of remote *info* (not the URL values) may set uploaded — callers must
+ * not persist those URL strings into history.
+ */
+export function parseTraceExportUploadedFlag(raw: unknown): boolean {
+  if (!raw || typeof raw !== "object") return false;
+  const o = raw as Record<string, unknown>;
+
+  const direct = parseTraceHistoryUploaded(o.uploaded);
+  if (direct === true) return true;
+  if (direct === false) return false;
+
+  const status =
+    typeof o.status === "string" ? o.status.trim().toLowerCase() : "";
+  if (
+    status === "uploaded" ||
+    status === "upload_complete" ||
+    status === "upload-complete" ||
+    status === "ok_uploaded"
+  ) {
+    return true;
+  }
+
+  // Remote info keys: non-empty string means upload path reported success.
+  for (const key of ["remote_url", "upload_url", "share_url", "object_path"]) {
+    const v = o[key];
+    if (typeof v === "string" && v.trim()) return true;
+  }
+  return false;
+}
+
+/**
  * Human-readable size for list rows. Returns null when unknown.
  * Pure — no i18n (B/KB/MB/GB are universal unit abbreviations).
  */
@@ -122,12 +176,16 @@ export function parseTraceHistoryEntry(raw: unknown): TraceHistoryEntry | null {
     parseTraceHistorySizeBytes(o.sizeBytes) ??
     parseTraceHistorySizeBytes(o.size_bytes);
 
+  // Only persist true — omit false to keep history lean / local-default.
+  const uploaded = parseTraceHistoryUploaded(o.uploaded) === true;
+
   return {
     sessionId,
     path,
     exportedAt,
     ...(title ? { title } : {}),
     ...(sizeBytes != null ? { sizeBytes } : {}),
+    ...(uploaded ? { uploaded: true } : {}),
   };
 }
 
@@ -278,11 +336,17 @@ export function recordTraceExport(
     exportedAt?: string;
     /** Optional size from host `stat` after export — never file contents. */
     sizeBytes?: number | null;
+    /**
+     * Optional: CLI/host reported remote upload success.
+     * Paths-only history still; never store URLs or secrets here.
+     */
+    uploaded?: boolean | null;
   },
   storage: TraceHistoryStorage = defaultStorage(),
   max = TRACE_HISTORY_MAX,
 ): TraceHistoryEntry[] {
   const sizeBytes = parseTraceHistorySizeBytes(input.sizeBytes ?? undefined);
+  const uploaded = input.uploaded === true;
   const entry: TraceHistoryEntry = {
     sessionId: input.sessionId,
     path: input.path,
@@ -291,6 +355,7 @@ export function recordTraceExport(
       ? { title: String(input.title).trim().slice(0, 200) }
       : {}),
     ...(sizeBytes != null ? { sizeBytes } : {}),
+    ...(uploaded ? { uploaded: true } : {}),
   };
   const next = pushTraceHistory(loadTraceHistory(storage, max), entry, max);
   saveTraceHistory(next, storage, max);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16595,6 +16595,18 @@ div.composer__input:empty::before {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
+.trace-history-row__uploaded {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 999px;
+  white-space: nowrap;
+  color: var(--accent-fg, var(--text-primary));
+  background: color-mix(in srgb, var(--accent, #6b8cff) 22%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent, #6b8cff) 35%, transparent);
+}
 .trace-history-row__actions {
   display: flex;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

- **Host** `session_trace_export`: add `localOnly: bool` (default **true** for safety). When `false`, omit CLI `--local` so `grok trace` may upload over the network.
- **Session menu**: **Export local** (default) vs **Export and upload…** with in-app confirm (no `window.confirm`) explaining network upload to xAI.
- **History**: still paths only; optional `uploaded=true` when CLI JSON reports remote info (never URLs/secrets); badge in Traces list.
- **Toasts**: success paths for local / uploaded / local-fallback; actionable failures (no agent, missing CLI, timeout, upload errors).
- **i18n** (en / zh / zh-TW) + CHANGELOG + pure helper tests (`parseTraceExportUploadedFlag`, history `uploaded`).

## CLI alignment

`grok trace <id>` uploads unless `--local`. App previously always passed `--local`.

## Test plan

- [x] `pnpm typecheck` (tsc -b)
- [x] `pnpm test -- src/lib/traceHistory.test.ts src/i18n/messages.test.ts`
- [x] `cargo check` (src-tauri)
- [ ] Manual: Export local on a session with agent id → save dialog + history row (no Uploaded badge)
- [ ] Manual: Export and upload… → confirm dialog → cancel leaves no export
- [ ] Manual: Confirm upload → when CLI reports remote info, toast “saved and uploaded” + Uploaded badge
- [ ] Manual: Failures (no agent / missing CLI) show actionable toast text