### PR TITLE
feat(agent): allowlist built-in tools via --tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ See `docs/llm-wiki/release.md`.
 - **Subagent worktree (cwd) badge**: when `spawn_subagent` / Agent / subagent tool_step data includes a cwd or worktree path (labeled fields, JSON, or absolute path), Tasks panel shows a compact **WT** / truncated-path badge and can reveal or copy the path — UI-only over existing tool_step data; nested tree unchanged
 - **Plan depth**: request-changes optional revision note (in-app modal → `session_resolve_plan` feedback); plan history search/filter by title·preview + decision chips, clear-all (in-app confirm), open chat when session still present
 - **Disallowed built-in tools** (Settings → General → Agent): chips + freeform list → `AppSettings.disallowedTools` / CLI `--disallowed-tools a,b`; coexists with Disable web search; soft-respawn on change
+- **Allowed built-in tools** (Settings → General → Agent): chips + freeform list → `AppSettings.allowedTools` / CLI `--tools a,b`; empty = all tools (CLI default); when set restricts to listed tools; coexists with denylist (both-set UI hint); soft-respawn on change
 - **Agent profile path** (Settings → General → Agent): optional file for `grok agent --agent-profile`; soft-respawns on change
 - **Agent serve** start/stop from Settings → Runtime → Connection (`grok agent serve --bind/--secret`; default `127.0.0.1:2419`; masked secret + one-time connection URL copy)
 - **Agent dashboard filters**: status chips with per-status counts (all / busy / permission / connecting / idle / error), free-text session search, project id/name/path filter, empty-filter state + clear; **Stop all busy** still targets every stoppable session globally (not only the filtered list)
@@ -66,7 +67,7 @@ See `docs/llm-wiki/release.md`.
 - **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片、会话变更审阅（+/− · 并排 diff · j/k）、结构化 JSON 回复面板（校验/复制/导出）、上下文用量/费用粗估
 - **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、会话规则（`--rules`）、会话最大轮次（`--max-turns` 覆盖；空/0 继承全局）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标、快捷键冲突面板（录制警告 + 重置冲突项）
-- **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
+- **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；**允许的工具**（`--tools` allowlist；空=全部；与 denylist 并存提示；soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选
 - **计划**：**请求修改** 可选修订说明；计划历史搜索/决策筛选、清空确认、会话仍在时可打开
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要

--- a/docs/llm-wiki/catalog.md
+++ b/docs/llm-wiki/catalog.md
@@ -50,16 +50,23 @@ Spawn：`--reasoning-effort <id>`。无模型级默认时 App 默认 **`medium`*
 2. 中途切换：优先 `set_mode`；失败则 soft-respawn。  
 3. 按 `composerPrefsScope` 记忆。
 
-## 禁用内置工具（disallowed tools）
+## 内置工具 allowlist / denylist
 
 | App 设置 | Spawn | 说明 |
 |----------|-------|------|
 | `disableWebSearch` | top-level `--disable-web-search` | 移除 `web_search` / `web_fetch` |
-| `disallowedTools: string[]` | top-level `--disallowed-tools a,b` | 逗号分隔 tool id denylist |
+| `allowedTools: string[]` | top-level `--tools a,b` | 逗号分隔 tool id **allowlist**；空 = 省略（CLI 默认全部） |
+| `disallowedTools: string[]` | top-level `--disallowed-tools a,b` | 逗号分隔 tool id **denylist** |
 
-两者**并存**：网页开关不写入 `disallowedTools` 数组，但 UI 把 web 工具视为已覆盖；纯 helper `effectiveDisallowedTools` 可合并展示。常见芯片：`web_search` · `web_fetch` · `run_terminal_command`（caution）· `search_replace` · `write` · `Agent` · `spawn_subagent`；另支持 freeform 逗号列表。
+**并存规则：**
 
-更改后 soft-respawn（`settings_spawn`）。源码：`src/lib/disallowedTools.ts`、Host `AppSettings.disallowed_tools`、`acp_client::disallowed_tools_spawn_flags`。
+- 两者皆空 + 未关网页搜索 → CLI 默认（全部工具）。
+- `allowedTools` 非空 → 仅允许列出的工具；`disallowedTools` 若也非空仍会从该集合中移除。
+- 网页开关不写入 `disallowedTools` 数组，但 UI 把 web 工具视为已覆盖；纯 helper `effectiveDisallowedTools` 可合并展示。
+
+常见芯片：`web_search` · `web_fetch` · `run_terminal_command`（caution）· `search_replace` · `write` · `Agent` · `spawn_subagent`；另支持 freeform 逗号列表。
+
+更改后 soft-respawn（`settings_spawn`）。源码：`src/lib/allowedTools.ts`、`src/lib/disallowedTools.ts`、Host `AppSettings.allowed_tools` / `disallowed_tools`、`acp_client::allowed_tools_spawn_flags` / `disallowed_tools_spawn_flags`。
 
 ## 权限（含 YOLO）与 CLI `--permission-mode`
 

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -469,6 +469,25 @@ pub fn disallowed_tools_equal(a: &[String], b: &[String]) -> bool {
     aa == bb
 }
 
+/// Normalize tool ids for `--tools` allowlist: same rules as denylist.
+pub fn normalize_allowed_tools(tools: &[String]) -> Vec<String> {
+    normalize_disallowed_tools(tools)
+}
+
+/// Spawn argv for allowlist: `["--tools", "a,b"]` or empty (CLI default = all).
+pub fn allowed_tools_spawn_flags(tools: &[String]) -> Vec<String> {
+    let cleaned = normalize_allowed_tools(tools);
+    if cleaned.is_empty() {
+        return Vec::new();
+    }
+    vec!["--tools".into(), cleaned.join(",")]
+}
+
+/// Order-independent, case-insensitive equality for soft-respawn flip checks.
+pub fn allowed_tools_equal(a: &[String], b: &[String]) -> bool {
+    disallowed_tools_equal(a, b)
+}
+
 pub fn no_plan_spawn_flags(plan_enabled: bool) -> Vec<&'static str> {
     if plan_enabled {
         vec![]
@@ -636,6 +655,7 @@ impl AcpClient {
         let plan_enabled = settings.plan_enabled;
         let disable_web = settings.disable_web_search;
         let disallowed_tools = settings.disallowed_tools.clone();
+        let allowed_tools = settings.allowed_tools.clone();
         let spawn_policy = opts.permission_policy.as_deref().unwrap_or("ask");
         let spawn_product_mode = opts.product_mode.as_deref();
 
@@ -683,6 +703,9 @@ impl AcpClient {
         }
         for f in disable_web_search_spawn_flags(disable_web) {
             cmd.arg(f);
+        }
+        for a in allowed_tools_spawn_flags(&allowed_tools) {
+            cmd.arg(a);
         }
         for a in disallowed_tools_spawn_flags(&disallowed_tools) {
             cmd.arg(a);
@@ -3405,6 +3428,56 @@ mod disallowed_tools_spawn_tests {
             &["B".into(), "A".into()]
         ));
         assert!(!disallowed_tools_equal(&["a".into()], &["a".into(), "b".into()]));
+    }
+}
+
+#[cfg(test)]
+mod allowed_tools_spawn_tests {
+    use super::*;
+
+    #[test]
+    fn empty_yields_no_flags() {
+        assert!(allowed_tools_spawn_flags(&[]).is_empty());
+        assert!(allowed_tools_spawn_flags(&["".into(), "  ".into()]).is_empty());
+    }
+
+    #[test]
+    fn builds_comma_separated_flag() {
+        let args = allowed_tools_spawn_flags(&[
+            "  web_search  ".into(),
+            "write".into(),
+            "web_search".into(),
+        ]);
+        assert_eq!(
+            args,
+            vec!["--tools".to_string(), "web_search,write".to_string(),]
+        );
+    }
+
+    #[test]
+    fn splits_embedded_commas_and_dedupes_case_insensitively() {
+        let cleaned = normalize_allowed_tools(&[
+            "Web_Search,write".into(),
+            "WEB_SEARCH".into(),
+            "Agent".into(),
+        ]);
+        assert_eq!(
+            cleaned,
+            vec![
+                "Web_Search".to_string(),
+                "write".to_string(),
+                "Agent".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn equality_is_order_and_case_insensitive() {
+        assert!(allowed_tools_equal(
+            &["a".into(), "b".into()],
+            &["B".into(), "A".into()]
+        ));
+        assert!(!allowed_tools_equal(&["a".into()], &["a".into(), "b".into()]));
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -857,9 +857,11 @@ pub async fn settings_set(
 ) -> Result<AppSettings, String> {
     let prev = store::load_settings();
     let mut settings = settings;
-    // Normalize denylist so spawn / equality see a stable list.
+    // Normalize denylist / allowlist so spawn / equality see stable lists.
     settings.disallowed_tools =
         crate::acp_client::normalize_disallowed_tools(&settings.disallowed_tools);
+    settings.allowed_tools =
+        crate::acp_client::normalize_allowed_tools(&settings.allowed_tools);
     // Normalize optional agent profile path (trim / drop control chars).
     settings.agent_profile_path =
         crate::agents_catalog::normalize_agent_profile_path(&settings.agent_profile_path)
@@ -873,6 +875,10 @@ pub async fn settings_set(
     let disallowed_tools_flip = !crate::acp_client::disallowed_tools_equal(
         &prev.disallowed_tools,
         &settings.disallowed_tools,
+    );
+    let allowed_tools_flip = !crate::acp_client::allowed_tools_equal(
+        &prev.allowed_tools,
+        &settings.allowed_tools,
     );
     let plan_enabled_flip = prev.plan_enabled != settings.plan_enabled;
     let use_leader_changed = prev.use_leader != settings.use_leader;
@@ -938,6 +944,7 @@ pub async fn settings_set(
     }
     if web_search_flip
         || disallowed_tools_flip
+        || allowed_tools_flip
         || plan_enabled_flip
         || use_leader_changed
         || preferred_agent_flip

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -240,6 +240,13 @@ pub struct AppSettings {
     /// [`Self::disable_web_search`]; changing the list soft-respawns agents.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub disallowed_tools: Vec<String>,
+    /// Built-in tool ids to allow via top-level `grok --tools a,b`.
+    /// Default empty = omit flag (CLI default — all tools). When non-empty,
+    /// restricts the agent to the listed tools. Coexists with
+    /// [`Self::disallowed_tools`] (allowlist restricts; denylist still applies).
+    /// Changing the list soft-respawns agents.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_tools: Vec<String>,
     /// Reopen the last active chat once after launch (default **false** —
     /// start on a draft new-chat page; opt-in via Settings).
     #[serde(default = "default_reopen_last_session")]
@@ -402,6 +409,7 @@ impl Default for AppSettings {
             max_agent_turns: None,
             disable_web_search: false,
             disallowed_tools: Vec::new(),
+            allowed_tools: Vec::new(),
             reopen_last_session: default_reopen_last_session(),
             last_session_id: None,
             last_project_id: None,
@@ -2077,6 +2085,7 @@ mod tests {
         assert_eq!(s.max_agent_turns, None);
         assert!(!s.disable_web_search);
         assert!(s.disallowed_tools.is_empty());
+        assert!(s.allowed_tools.is_empty());
         assert!(s.plan_enabled);
         assert!(s.subagents_enabled);
         assert_eq!(s.preferred_agent, "");
@@ -2179,6 +2188,25 @@ mod tests {
         let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(
             back.disallowed_tools,
+            vec!["web_search".to_string(), "write".to_string()]
+        );
+    }
+
+    #[test]
+    fn allowed_tools_defaults_empty_when_missing_from_json() {
+        let s: AppSettings = serde_json::from_str(legacy_settings_json()).expect("deserialize");
+        assert!(s.allowed_tools.is_empty());
+    }
+
+    #[test]
+    fn allowed_tools_round_trips_camel_case() {
+        let mut s = AppSettings::default();
+        s.allowed_tools = vec!["web_search".into(), "write".into()];
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert!(json.contains("\"allowedTools\""));
+        let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            back.allowed_tools,
             vec!["web_search".to_string(), "write".to_string()]
         );
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1998,6 +1998,7 @@ export default function App() {
   const [planEnabled, setPlanEnabled] = useState(true);
   const [disableWebSearch, setDisableWebSearch] = useState(false);
   const [disallowedTools, setDisallowedTools] = useState<string[]>([]);
+  const [allowedTools, setAllowedTools] = useState<string[]>([]);
   const [useLeader, setUseLeader] = useState(false);
   /** Default off → launch on draft new-chat page. */
   const [reopenLastSession, setReopenLastSession] = useState(false);
@@ -2756,6 +2757,13 @@ export default function App() {
       setDisallowedTools(
         Array.isArray(settings.disallowedTools)
           ? settings.disallowedTools.filter(
+              (x): x is string => typeof x === "string",
+            )
+          : [],
+      );
+      setAllowedTools(
+        Array.isArray(settings.allowedTools)
+          ? settings.allowedTools.filter(
               (x): x is string => typeof x === "string",
             )
           : [],
@@ -13356,6 +13364,13 @@ export default function App() {
             setDisallowedTools(v);
             void api.settingsGet().then((s) =>
               api.settingsSet({ ...s, disallowedTools: v }),
+            );
+          }}
+          allowedTools={allowedTools}
+          onAllowedTools={(v) => {
+            setAllowedTools(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, allowedTools: v }),
             );
           }}
           useLeader={useLeader}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -50,6 +50,14 @@ import {
   toggleDisallowedTool,
 } from "@/lib/disallowedTools";
 import {
+  COMMON_ALLOWED_TOOLS,
+  bothToolListsSet,
+  isToolAllowed,
+  normalizeAllowedTools,
+  parseAllowedToolsInput,
+  toggleAllowedTool,
+} from "@/lib/allowedTools";
+import {
   SHORTCUTS,
   detectShortcutPlatform,
   filterShortcutGroups,
@@ -420,6 +428,9 @@ export interface SettingsPageProps {
   /** Built-in tool denylist (`--disallowed-tools`). */
   disallowedTools?: string[];
   onDisallowedTools?: (v: string[]) => void;
+  /** Built-in tool allowlist (`--tools`). Empty = CLI default (all tools). */
+  allowedTools?: string[];
+  onAllowedTools?: (v: string[]) => void;
   reopenLastSession?: boolean;
   onReopenLastSession?: (v: boolean) => void;
   closeToTray?: boolean;
@@ -961,6 +972,8 @@ export function SettingsPage({
   onDisableWebSearch,
   disallowedTools = [],
   onDisallowedTools,
+  allowedTools = [],
+  onAllowedTools,
   useLeader = false,
   onUseLeader,
   voiceId = "eve",
@@ -2460,6 +2473,112 @@ export function SettingsPage({
                   />
                 </div>
               ) : null}
+              {onAllowedTools ? (
+                <div
+                  className={
+                    "settings-row settings-row--stack" +
+                    rowHighlight("settings-anchor-allowedTools")
+                  }
+                  id="settings-anchor-allowedTools"
+                >
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.allowedTools")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.allowedToolsDesc")}
+                    </div>
+                    {bothToolListsSet(allowedTools, disallowedTools) ? (
+                      <div className="settings-row__hint">
+                        {t("settings.allowedTools.bothSet")}
+                      </div>
+                    ) : null}
+                  </div>
+                  <div
+                    className="settings-tool-deny__chips"
+                    role="group"
+                    aria-label={t("settings.allowedTools")}
+                  >
+                    {COMMON_ALLOWED_TOOLS.map((tool) => {
+                      const selected = isToolAllowed(allowedTools, tool.id);
+                      return (
+                        <button
+                          key={tool.id}
+                          type="button"
+                          className={
+                            "settings-tool-deny__chip" +
+                            (selected ? " is-on" : "") +
+                            (tool.caution ? " is-caution" : "")
+                          }
+                          aria-pressed={selected}
+                          title={
+                            tool.caution
+                              ? t("settings.allowedTools.caution")
+                              : tool.id
+                          }
+                          onClick={() => {
+                            onAllowedTools(
+                              toggleAllowedTool(allowedTools, tool.id),
+                            );
+                          }}
+                        >
+                          {tool.id}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <div className="settings-tool-deny__row">
+                    <input
+                      type="text"
+                      className="settings-input settings-tool-deny__input"
+                      placeholder={t("settings.allowedToolsPlaceholder")}
+                      defaultValue={normalizeAllowedTools(allowedTools)
+                        .filter(
+                          (id) =>
+                            !COMMON_ALLOWED_TOOLS.some(
+                              (c) => c.id.toLowerCase() === id.toLowerCase(),
+                            ),
+                        )
+                        .join(", ")}
+                      key={normalizeAllowedTools(allowedTools)
+                        .filter(
+                          (id) =>
+                            !COMMON_ALLOWED_TOOLS.some(
+                              (c) => c.id.toLowerCase() === id.toLowerCase(),
+                            ),
+                        )
+                        .join(",")}
+                      onBlur={(e) => {
+                        const custom = parseAllowedToolsInput(e.target.value);
+                        const keptCommon = normalizeAllowedTools(
+                          allowedTools,
+                        ).filter((id) =>
+                          COMMON_ALLOWED_TOOLS.some(
+                            (c) => c.id.toLowerCase() === id.toLowerCase(),
+                          ),
+                        );
+                        onAllowedTools(
+                          normalizeAllowedTools([...keptCommon, ...custom]),
+                        );
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          (e.target as HTMLInputElement).blur();
+                        }
+                      }}
+                    />
+                    {normalizeAllowedTools(allowedTools).length > 0 ? (
+                      <button
+                        type="button"
+                        className="btn btn--sm settings-tool-deny__clear"
+                        onClick={() => onAllowedTools([])}
+                      >
+                        {t("settings.allowedTools.clear")}
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
               {onDisallowedTools ? (
                 <div
                   className={
@@ -2478,6 +2597,11 @@ export function SettingsPage({
                     {disableWebSearch ? (
                       <div className="settings-row__hint">
                         {t("settings.disallowedTools.webCovered")}
+                      </div>
+                    ) : null}
+                    {bothToolListsSet(allowedTools, disallowedTools) ? (
+                      <div className="settings-row__hint">
+                        {t("settings.allowedTools.bothSet")}
                       </div>
                     ) : null}
                   </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1231,9 +1231,19 @@ const en = {
   "settings.disableWebSearch": "Disable web search & fetch",
   "settings.disableWebSearchDesc":
     "Spawn agents with --disable-web-search so web_search and web_fetch tools are unavailable. Live agents soft-respawn when this changes.",
+  "settings.allowedTools": "Allowed tools",
+  "settings.allowedToolsDesc":
+    "Restrict built-in tools via --tools (comma-separated). Empty = all tools (CLI default). When set, only listed tools are available. Coexists with Disallowed tools below (denylist still applies). Live agents soft-respawn when this changes.",
+  "settings.allowedToolsPlaceholder":
+    "Extra tool ids, comma-separated (e.g. bash,grep)",
+  "settings.allowedTools.caution":
+    "Caution: allowlisting only shell / coding tools may still be powerful",
+  "settings.allowedTools.clear": "Clear all (default: all tools)",
+  "settings.allowedTools.bothSet":
+    "Both allowlist and denylist are set: --tools restricts the set first; --disallowed-tools still removes listed tools from that set.",
   "settings.disallowedTools": "Disallowed tools",
   "settings.disallowedToolsDesc":
-    "Remove selected built-in tools via --disallowed-tools. Coexists with Disable web search. Live agents soft-respawn when this changes.",
+    "Remove selected built-in tools via --disallowed-tools. Coexists with Disable web search and Allowed tools above. Live agents soft-respawn when this changes.",
   "settings.disallowedToolsPlaceholder":
     "Extra tool ids, comma-separated (e.g. bash,grep)",
   "settings.disallowedTools.caution": "Caution: blocks shell / coding tools",
@@ -4227,9 +4237,19 @@ const zh: Record<MessageKey, string> = {
   "settings.disableWebSearch": "禁用网页搜索与抓取",
   "settings.disableWebSearchDesc":
     "启动 Agent 时加上 --disable-web-search，移除 web_search / web_fetch 工具。更改后会 soft-respawn 已连接的 Agent。",
+  "settings.allowedTools": "允许的工具",
+  "settings.allowedToolsDesc":
+    "通过 --tools（逗号分隔）限制可用内置工具。留空 = 全部工具（CLI 默认）。设置后仅列出的工具可用。可与下方「禁用内置工具」并存（denylist 仍生效）。更改后会 soft-respawn。",
+  "settings.allowedToolsPlaceholder":
+    "额外工具 id，逗号分隔（如 bash,grep）",
+  "settings.allowedTools.caution":
+    "注意：仅允许终端 / 编码类工具仍可能权限较大",
+  "settings.allowedTools.clear": "全部清除（默认：全部工具）",
+  "settings.allowedTools.bothSet":
+    "允许列表与禁用列表均已设置：--tools 先收窄范围，--disallowed-tools 仍会从中移除列出的工具。",
   "settings.disallowedTools": "禁用内置工具",
   "settings.disallowedToolsDesc":
-    "通过 --disallowed-tools 移除所选内置工具。可与上方「禁用网页搜索」并存。更改后会 soft-respawn。",
+    "通过 --disallowed-tools 移除所选内置工具。可与「禁用网页搜索」及上方「允许的工具」并存。更改后会 soft-respawn。",
   "settings.disallowedToolsPlaceholder":
     "额外工具 id，逗号分隔（如 bash,grep）",
   "settings.disallowedTools.caution": "注意：会屏蔽终端 / 编码类工具",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1172,9 +1172,19 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.disableWebSearch": "停用網頁搜尋與抓取",
   "settings.disableWebSearchDesc":
     "啟動 Agent 時加上 --disable-web-search，移除 web_search / web_fetch 工具。變更後會 soft-respawn 已連線的 Agent。",
+  "settings.allowedTools": "允許的工具",
+  "settings.allowedToolsDesc":
+    "透過 --tools（逗號分隔）限制可用內建工具。留空 = 全部工具（CLI 預設）。設定後僅列出的工具可用。可與下方「停用內建工具」並存（denylist 仍生效）。變更後會 soft-respawn。",
+  "settings.allowedToolsPlaceholder":
+    "額外工具 id，逗號分隔（如 bash,grep）",
+  "settings.allowedTools.caution":
+    "注意：僅允許終端機 / 編碼類工具仍可能權限較大",
+  "settings.allowedTools.clear": "全部清除（預設：全部工具）",
+  "settings.allowedTools.bothSet":
+    "允許清單與停用清單均已設定：--tools 先收窄範圍，--disallowed-tools 仍會從中移除列出的工具。",
   "settings.disallowedTools": "停用內建工具",
   "settings.disallowedToolsDesc":
-    "透過 --disallowed-tools 移除所選內建工具。可與上方「停用網頁搜尋」並存。變更後會 soft-respawn。",
+    "透過 --disallowed-tools 移除所選內建工具。可與「停用網頁搜尋」及上方「允許的工具」並存。變更後會 soft-respawn。",
   "settings.disallowedToolsPlaceholder":
     "額外工具 id，逗號分隔（如 bash,grep）",
   "settings.disallowedTools.caution": "注意：會封鎖終端機 / 編碼類工具",

--- a/src/lib/allowedTools.test.ts
+++ b/src/lib/allowedTools.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMMON_ALLOWED_TOOLS,
+  allowedToolsCliValue,
+  allowedToolsEqual,
+  allowedToolsSpawnArgs,
+  bothToolListsSet,
+  isToolAllowed,
+  normalizeAllowedTools,
+  parseAllowedToolsInput,
+  toggleAllowedTool,
+} from "./allowedTools";
+
+describe("normalizeAllowedTools", () => {
+  it("accepts arrays and comma-separated strings", () => {
+    expect(normalizeAllowedTools(["web_search", "  write  "])).toEqual([
+      "web_search",
+      "write",
+    ]);
+    expect(normalizeAllowedTools("web_search, write, Agent")).toEqual([
+      "web_search",
+      "write",
+      "Agent",
+    ]);
+  });
+
+  it("dedupes case-insensitively, keeping first spelling", () => {
+    expect(
+      normalizeAllowedTools(["Web_Search", "web_search", "WRITE", "write"]),
+    ).toEqual(["Web_Search", "WRITE"]);
+  });
+
+  it("splits embedded commas in array items", () => {
+    expect(normalizeAllowedTools(["a,b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns empty for nullish / garbage", () => {
+    expect(normalizeAllowedTools(null)).toEqual([]);
+    expect(normalizeAllowedTools(undefined)).toEqual([]);
+    expect(normalizeAllowedTools(true)).toEqual([]);
+    expect(normalizeAllowedTools("")).toEqual([]);
+    expect(normalizeAllowedTools([""])).toEqual([]);
+  });
+});
+
+describe("parseAllowedToolsInput", () => {
+  it("parses freeform input", () => {
+    expect(parseAllowedToolsInput("  web_search,run_terminal_command , ")).toEqual(
+      ["web_search", "run_terminal_command"],
+    );
+  });
+});
+
+describe("allowedToolsCliValue / spawnArgs", () => {
+  it("omits flag when empty", () => {
+    expect(allowedToolsCliValue([])).toBeNull();
+    expect(allowedToolsSpawnArgs([])).toEqual([]);
+  });
+
+  it("builds comma-separated CLI value and --tools flag", () => {
+    expect(allowedToolsCliValue(["web_search", "write"])).toBe(
+      "web_search,write",
+    );
+    expect(allowedToolsSpawnArgs(["web_search", "write"])).toEqual([
+      "--tools",
+      "web_search,write",
+    ]);
+  });
+});
+
+describe("toggle / membership", () => {
+  it("toggles tools case-insensitively", () => {
+    const a = toggleAllowedTool([], "web_search");
+    expect(a).toEqual(["web_search"]);
+    expect(isToolAllowed(a, "WEB_SEARCH")).toBe(true);
+    const b = toggleAllowedTool(a, "Web_Search");
+    expect(b).toEqual([]);
+  });
+
+  it("preserves existing spelling when removing via different case", () => {
+    expect(toggleAllowedTool(["Agent", "write"], "agent")).toEqual(["write"]);
+  });
+});
+
+describe("allowedToolsEqual", () => {
+  it("compares order- and case-insensitively", () => {
+    expect(allowedToolsEqual(["a", "b"], ["B", "A"])).toBe(true);
+    expect(allowedToolsEqual(["a"], ["a", "b"])).toBe(false);
+    expect(allowedToolsEqual(null, [])).toBe(true);
+  });
+});
+
+describe("bothToolListsSet", () => {
+  it("is true only when both lists are non-empty", () => {
+    expect(bothToolListsSet([], [])).toBe(false);
+    expect(bothToolListsSet(["write"], [])).toBe(false);
+    expect(bothToolListsSet([], ["write"])).toBe(false);
+    expect(bothToolListsSet(["write"], ["web_search"])).toBe(true);
+  });
+});
+
+describe("catalog constants", () => {
+  it("exposes common chips shared with denylist", () => {
+    expect(COMMON_ALLOWED_TOOLS.map((t) => t.id)).toContain(
+      "run_terminal_command",
+    );
+    expect(
+      COMMON_ALLOWED_TOOLS.find((t) => t.id === "run_terminal_command")
+        ?.caution,
+    ).toBe(true);
+  });
+});

--- a/src/lib/allowedTools.ts
+++ b/src/lib/allowedTools.ts
@@ -1,0 +1,120 @@
+/**
+ * Allowed built-in tools → CLI `--tools` (comma-separated allowlist).
+ *
+ * Empty / omitted = CLI default (all tools available). When non-empty, the
+ * agent is restricted to the listed tools. Coexists with `disallowedTools` /
+ * `disableWebSearch`: allowlist restricts the set; denylist and disable-web
+ * still apply when set.
+ */
+
+import {
+  COMMON_DISALLOWED_TOOLS,
+  normalizeToolId,
+  type CommonDisallowedTool,
+} from "./disallowedTools";
+
+/** Same chip catalog as the denylist UI (common built-in tool ids). */
+export const COMMON_ALLOWED_TOOLS: readonly CommonDisallowedTool[] =
+  COMMON_DISALLOWED_TOOLS;
+
+/**
+ * Normalize a list (or comma-separated string) of tool ids:
+ * trim, drop empties, dedupe case-insensitively (first spelling wins).
+ */
+export function normalizeAllowedTools(raw: unknown): string[] {
+  const parts: string[] = [];
+  if (raw == null) return parts;
+  if (typeof raw === "string") {
+    for (const piece of raw.split(",")) {
+      const n = normalizeToolId(piece);
+      if (n) parts.push(n);
+    }
+  } else if (Array.isArray(raw)) {
+    for (const item of raw) {
+      if (typeof item === "string" && item.includes(",")) {
+        for (const piece of item.split(",")) {
+          const n = normalizeToolId(piece);
+          if (n) parts.push(n);
+        }
+      } else {
+        const n = normalizeToolId(item);
+        if (n) parts.push(n);
+      }
+    }
+  } else {
+    return parts;
+  }
+
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const id of parts) {
+    const key = id.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(id);
+  }
+  return out;
+}
+
+/** Parse a freeform comma-separated input into a normalized list. */
+export function parseAllowedToolsInput(raw: string | null | undefined): string[] {
+  return normalizeAllowedTools(raw ?? "");
+}
+
+/** Comma-separated value for `--tools`, or null when empty (omit flag). */
+export function allowedToolsCliValue(tools: unknown): string | null {
+  const list = normalizeAllowedTools(tools);
+  return list.length ? list.join(",") : null;
+}
+
+/** Spawn argv fragments: `["--tools", "a,b"]` or `[]`. */
+export function allowedToolsSpawnArgs(tools: unknown): string[] {
+  const v = allowedToolsCliValue(tools);
+  return v ? ["--tools", v] : [];
+}
+
+/** Case-insensitive membership check. */
+export function isToolAllowed(tools: unknown, id: string): boolean {
+  const needle = normalizeToolId(id);
+  if (!needle) return false;
+  const key = needle.toLowerCase();
+  return normalizeAllowedTools(tools).some((t) => t.toLowerCase() === key);
+}
+
+/** Toggle a tool id in/out of the list (normalized result). */
+export function toggleAllowedTool(tools: unknown, id: string): string[] {
+  const list = normalizeAllowedTools(tools);
+  const needle = normalizeToolId(id);
+  if (!needle) return list;
+  const key = needle.toLowerCase();
+  if (list.some((t) => t.toLowerCase() === key)) {
+    return list.filter((t) => t.toLowerCase() !== key);
+  }
+  return [...list, needle];
+}
+
+/**
+ * Whether two allowlists are equivalent (order-independent, case-insensitive).
+ * Used for soft-respawn flip detection on the UI side.
+ */
+export function allowedToolsEqual(a: unknown, b: unknown): boolean {
+  const aa = normalizeAllowedTools(a)
+    .map((t) => t.toLowerCase())
+    .sort();
+  const bb = normalizeAllowedTools(b)
+    .map((t) => t.toLowerCase())
+    .sort();
+  if (aa.length !== bb.length) return false;
+  return aa.every((v, i) => v === bb[i]);
+}
+
+/**
+ * True when both allowlist and denylist are non-empty — UI may warn that
+ * allowlist restricts tools and denylist still applies.
+ */
+export function bothToolListsSet(allowed: unknown, disallowed: unknown): boolean {
+  return (
+    normalizeAllowedTools(allowed).length > 0 &&
+    normalizeAllowedTools(disallowed).length > 0
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1180,6 +1180,13 @@ export interface AppSettings {
    * Default empty. Coexists with `disableWebSearch`; changes soft-respawn.
    */
   disallowedTools?: string[];
+  /**
+   * Built-in tool ids allowlisted via CLI `--tools a,b`.
+   * Default empty = omit flag (CLI default all tools). When non-empty,
+   * restricts the agent to listed tools. Coexists with `disallowedTools`
+   * (allowlist restricts; denylist still applies). Changes soft-respawn.
+   */
+  allowedTools?: string[];
   planEnabled?: boolean;
   subagentsEnabled?: boolean;
   useLeader?: boolean;

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -547,6 +547,26 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     keywords: ["web search"],
   },
   {
+    id: "general.allowedTools",
+    section: "general",
+    tab: "agent",
+    anchorId: "settings-anchor-allowedTools",
+    labelKey: "settings.allowedTools",
+    descKeys: [
+      "settings.allowedToolsDesc",
+      "settings.allowedTools.bothSet",
+    ],
+    keywords: [
+      "allowed tools",
+      "allowlist",
+      "tools allow",
+      "--tools",
+      "web_search",
+      "run_terminal_command",
+      "tool allow",
+    ],
+  },
+  {
     id: "general.disallowedTools",
     section: "general",
     tab: "agent",
@@ -555,6 +575,7 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     descKeys: [
       "settings.disallowedToolsDesc",
       "settings.disallowedTools.webCovered",
+      "settings.allowedTools.bothSet",
     ],
     keywords: [
       "disallowed tools",


### PR DESCRIPTION
## Summary

- Add `AppSettings.allowedTools: string[]` → CLI top-level `--tools a,b` (empty = omit flag = CLI default all tools)
- Pure helpers + tests (`src/lib/allowedTools.ts`) mirroring denylist: normalize, chips, spawn args `["--tools", "a,b"]`
- Settings → General → Agent UI next to disallowed tools (chips + freeform); coexistence copy when both allow & deny are set
- Host spawn flags + soft-respawn on change (`settings_spawn`)
- i18n (en / zh / zh-TW), `settingsCatalog`, catalog wiki, CHANGELOG

### Coexistence

| State | Behavior |
|-------|----------|
| Both empty | CLI default (all tools) |
| Allowlist set | Restricts to listed tools via `--tools` |
| Both set | `--tools` restricts first; `--disallowed-tools` still removes listed tools from that set (UI hint) |

## Test plan

- [x] `pnpm typecheck`
- [x] `vitest` `allowedTools.test.ts` + i18n + settingsCatalog
- [x] `cargo test --lib allowed_tools_` (spawn + store round-trip)
- [ ] Manual: Settings → Agent → toggle allowlist chips → agent soft-respawns with `--tools …`
- [ ] Manual: clear allowlist → flag omitted; set both allow + deny → both-set hint shown