### PR TITLE
feat(session): per-session system prompt override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See `docs/llm-wiki/release.md`.
 - **Duplicate chat** (vs **Fork…** + optional worktree) · **session notes** · **mute** · **unread dot**
 - **Resume with code restore** — open an existing chat on a clean sibling git worktree at HEAD (session menu + command palette; dirty tree refused; same safety as Fork → restore code)
 - **Session rules** (per-chat `grok --rules`; session menu → GlassModal; soft-respawn on change)
+- **Session system prompt override** (per-chat `grok --system-prompt-override` / `--system-prompt`; session menu → GlassModal textarea; Clear; soft-respawn on change; never logs full prompt body)
 - **Session max agent turns** (per-chat `grok --max-turns` override; session menu → number input; 0/empty inherits global Settings 1–200; soft-respawn on change)
 - **Export** Markdown copy + **HTML export** · **bulk archive by age** · **date groups** · **project color**
 - **Sidebar j/k** navigation (when list focused)
@@ -64,7 +65,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 新增（按域）**
 
 - **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片、会话变更审阅（+/− · 并排 diff · j/k）、结构化 JSON 回复面板（校验/复制/导出）、上下文用量/费用粗估
-- **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、会话规则（`--rules`）、会话最大轮次（`--max-turns` 覆盖；空/0 继承全局）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
+- **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、会话规则（`--rules`）、系统提示词覆盖（`--system-prompt-override`）、会话最大轮次（`--max-turns` 覆盖；空/0 继承全局）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标、快捷键冲突面板（录制警告 + 重置冲突项）
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -259,6 +259,10 @@ pub struct SpawnOptions {
     /// Per-session max turns override → top-level `grok --max-turns N`.
     /// When set (after normalize), wins over `AppSettings.max_agent_turns`.
     pub max_agent_turns: Option<u32>,
+    /// Per-session system prompt override → top-level
+    /// `grok --system-prompt-override <TEXT>` (before `agent`).
+    /// Never log the full value (may contain secrets / PII).
+    pub system_prompt_override: Option<String>,
 }
 
 /// Pure helper: top-level CLI args for session extra rules (before `agent`).
@@ -268,6 +272,20 @@ pub fn extra_rules_spawn_flags(rules: Option<&str>) -> Vec<String> {
     let normalized = crate::store::sanitize_extra_rules(rules.map(|s| s.to_string()));
     match normalized {
         Some(text) => vec!["--rules".into(), text],
+        None => Vec::new(),
+    }
+}
+
+/// Pure helper: top-level CLI args for system prompt override (before `agent`).
+///
+/// `["--system-prompt-override", text]` — empty when none.
+/// Trims, strips NUL, drops empty, clamps length. Prefer the long flag name
+/// (CLI also accepts `--system-prompt`).
+pub fn system_prompt_override_spawn_flags(prompt: Option<&str>) -> Vec<String> {
+    let normalized =
+        crate::store::sanitize_system_prompt_override(prompt.map(|s| s.to_string()));
+    match normalized {
+        Some(text) => vec!["--system-prompt-override".into(), text],
         None => Vec::new(),
     }
 }
@@ -679,6 +697,12 @@ impl AcpClient {
         // Top-level `grok --rules <RULES>` (before `agent`) — session-only
         // system-prompt append; not accepted under `grok agent` / `stdio`.
         for a in extra_rules_spawn_flags(opts.extra_rules.as_deref()) {
+            cmd.arg(a);
+        }
+        // Top-level `grok --system-prompt-override <PROMPT>` (before `agent`) —
+        // session-only full system prompt replacement (alias: --system-prompt).
+        // Do not log the prompt body (may contain secrets / PII).
+        for a in system_prompt_override_spawn_flags(opts.system_prompt_override.as_deref()) {
             cmd.arg(a);
         }
         for f in disable_web_search_spawn_flags(disable_web) {
@@ -3532,6 +3556,43 @@ mod extra_rules_spawn_tests {
         assert_eq!(
             args,
             vec!["--rules".to_string(), "Always write tests".to_string()]
+        );
+    }
+}
+
+#[cfg(test)]
+mod system_prompt_override_spawn_tests {
+    use super::*;
+
+    #[test]
+    fn empty_yields_no_flags() {
+        assert!(system_prompt_override_spawn_flags(None).is_empty());
+        assert!(system_prompt_override_spawn_flags(Some("")).is_empty());
+        assert!(system_prompt_override_spawn_flags(Some("   \n")).is_empty());
+        assert!(system_prompt_override_spawn_flags(Some("\0\0")).is_empty());
+    }
+
+    #[test]
+    fn builds_top_level_override_pair() {
+        let args = system_prompt_override_spawn_flags(Some("  You are helpful  "));
+        assert_eq!(
+            args,
+            vec![
+                "--system-prompt-override".to_string(),
+                "You are helpful".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn strips_nul_before_spawn() {
+        let args = system_prompt_override_spawn_flags(Some("a\0b\0c"));
+        assert_eq!(
+            args,
+            vec![
+                "--system-prompt-override".to_string(),
+                "abc".to_string()
+            ]
         );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -687,6 +687,26 @@ pub async fn session_set_max_agent_turns(
     Ok(meta)
 }
 
+/// Set or clear per-session system prompt override
+/// (`grok --system-prompt-override` at next spawn).
+/// Empty / whitespace clears. Soft-respawns the live agent for this chat.
+/// Never logs the prompt body (may contain secrets / PII).
+#[tauri::command]
+pub async fn session_set_system_prompt_override(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    id: String,
+    system_prompt_override: Option<String>,
+) -> Result<SessionMeta, String> {
+    let meta = store::set_session_system_prompt_override(&id, system_prompt_override)?;
+    let snap = mgr.snapshot();
+    if snap.session_id.as_deref() == Some(meta.id.as_str()) {
+        mgr.soft_respawn_with_reason(&app, "session_system_prompt_override")
+            .await;
+    }
+    Ok(meta)
+}
+
 #[tauri::command]
 pub async fn session_messages(
     id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -298,6 +298,7 @@ pub fn run() {
             commands::session_set_plugin_dirs,
             commands::session_set_extra_rules,
             commands::session_set_max_agent_turns,
+            commands::session_set_system_prompt_override,
             commands::session_set_scheduled,
             commands::session_messages,
             commands::session_media_root,

--- a/src-tauri/src/remote_im/app_sessions.rs
+++ b/src-tauri/src/remote_im/app_sessions.rs
@@ -213,6 +213,7 @@ mod tests {
             plugin_dirs: Vec::new(),
             extra_rules: None,
             max_agent_turns: None,
+            system_prompt_override: None,
         }
     }
 

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -2793,6 +2793,11 @@ impl SessionManager {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty()),
             max_agent_turns: meta.max_agent_turns,
+            system_prompt_override: meta
+                .system_prompt_override
+                .as_ref()
+                .map(|s| s.to_string())
+                .and_then(|s| crate::store::sanitize_system_prompt_override(Some(s))),
         };
 
         let (client, mut events) = match AcpClient::spawn_with_options(cli_path, cwd, spawn_opts)
@@ -5825,6 +5830,7 @@ mod connect_preserve_tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                system_prompt_override: None,
             },
             fsm,
             backend: "grok_agent_stdio".into(),
@@ -6010,6 +6016,7 @@ mod session_routing_tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                system_prompt_override: None,
             },
             fsm,
             backend: "mock_acp".into(),
@@ -6176,6 +6183,7 @@ mod session_routing_tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                system_prompt_override: None,
             },
             fsm,
             backend: "mock_acp".into(),
@@ -6279,6 +6287,7 @@ mod session_routing_tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                system_prompt_override: None,
             },
             fsm,
             backend: "mock_acp".into(),

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -166,6 +166,12 @@ pub struct SessionMeta {
     /// `None` / 0 → inherit global `AppSettings.max_agent_turns`. Soft-respawn on change.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_agent_turns: Option<u32>,
+    /// Optional per-session system prompt override via top-level
+    /// `grok --system-prompt-override` (alias `--system-prompt`).
+    /// Empty / unset → no flag. Soft-respawn reloads on change.
+    /// Never log the full value (may contain secrets / PII).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_prompt_override: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1020,6 +1026,7 @@ pub fn create_session(
         plugin_dirs: Vec::new(),
         extra_rules: None,
         max_agent_turns: None,
+        system_prompt_override: None,
     };
     let mut list = load_sessions_index();
     list.insert(0, meta.clone());
@@ -1218,6 +1225,9 @@ pub fn set_session_plugin_dirs(
 /// Soft cap aligned with the frontend helper (~32 KiB).
 const EXTRA_RULES_MAX_CHARS: usize = 32 * 1024;
 
+/// Soft cap for system prompt override (~32 KiB), aligned with the frontend helper.
+const SYSTEM_PROMPT_OVERRIDE_MAX_CHARS: usize = 32 * 1024;
+
 /// Trim + clamp session extra rules. Empty after trim → `None` (clear).
 pub fn sanitize_extra_rules(raw: Option<String>) -> Option<String> {
     match raw {
@@ -1228,6 +1238,26 @@ pub fn sanitize_extra_rules(raw: Option<String>) -> Option<String> {
                 None
             } else if t.len() > EXTRA_RULES_MAX_CHARS {
                 Some(t.chars().take(EXTRA_RULES_MAX_CHARS).collect())
+            } else {
+                Some(t.to_string())
+            }
+        }
+    }
+}
+
+/// Trim, strip NUL bytes, and clamp session system prompt override.
+/// Empty after sanitize → `None` (clear). Never log the returned value.
+pub fn sanitize_system_prompt_override(raw: Option<String>) -> Option<String> {
+    match raw {
+        None => None,
+        Some(s) => {
+            // Strip NULs so the value cannot break argv / TOML / log lines.
+            let cleaned: String = s.chars().filter(|c| *c != '\0').collect();
+            let t = cleaned.trim();
+            if t.is_empty() {
+                None
+            } else if t.chars().count() > SYSTEM_PROMPT_OVERRIDE_MAX_CHARS {
+                Some(t.chars().take(SYSTEM_PROMPT_OVERRIDE_MAX_CHARS).collect())
             } else {
                 Some(t.to_string())
             }
@@ -1269,6 +1299,26 @@ pub fn set_session_max_agent_turns(
         .find(|s| s.id == id)
         .ok_or_else(|| "session not found".to_string())?;
     s.max_agent_turns = normalized;
+    s.updated_at = Utc::now();
+    let clone = s.clone();
+    save_sessions_index(&list)?;
+    Ok(clone)
+}
+
+/// Set or clear per-session system prompt override
+/// (`grok --system-prompt-override` on next spawn).
+/// Pass `None` or empty/whitespace to clear. Soft-respawn is handled by the command.
+pub fn set_session_system_prompt_override(
+    id: &str,
+    system_prompt_override: Option<String>,
+) -> Result<SessionMeta, String> {
+    let normalized = sanitize_system_prompt_override(system_prompt_override);
+    let mut list = load_sessions_index();
+    let s = list
+        .iter_mut()
+        .find(|s| s.id == id)
+        .ok_or_else(|| "session not found".to_string())?;
+    s.system_prompt_override = normalized;
     s.updated_at = Utc::now();
     let clone = s.clone();
     save_sessions_index(&list)?;
@@ -1424,6 +1474,7 @@ pub fn fork_session(
     meta.plugin_dirs = source.plugin_dirs.clone();
     meta.extra_rules = source.extra_rules.clone();
     meta.max_agent_turns = source.max_agent_turns;
+    meta.system_prompt_override = source.system_prompt_override.clone();
     meta.updated_at = Utc::now();
     update_session_meta(&meta)?;
 
@@ -2256,6 +2307,7 @@ mod tests {
             plugin_dirs: Vec::new(),
             extra_rules: None,
             max_agent_turns: None,
+            system_prompt_override: None,
         }
     }
 
@@ -2299,6 +2351,29 @@ mod tests {
             crate::acp_client::normalize_max_agent_turns(Some(999)),
             Some(200)
         );
+    }
+
+    #[test]
+    fn session_system_prompt_override_default_none_and_sanitize() {
+        let raw = r#"{"id":"s1","projectId":null,"title":"t","agentSessionId":null,"createdAt":"2020-01-01T00:00:00Z","updatedAt":"2020-01-01T00:00:00Z"}"#;
+        let m: SessionMeta =
+            serde_json::from_str(raw).expect("legacy session without systemPromptOverride");
+        assert!(m.system_prompt_override.is_none());
+        assert_eq!(sanitize_system_prompt_override(None), None);
+        assert_eq!(sanitize_system_prompt_override(Some("  ".into())), None);
+        assert_eq!(
+            sanitize_system_prompt_override(Some("  You are helpful  ".into())).as_deref(),
+            Some("You are helpful")
+        );
+        // Strip NUL bytes.
+        assert_eq!(
+            sanitize_system_prompt_override(Some("a\0b\0c".into())).as_deref(),
+            Some("abc")
+        );
+        assert_eq!(sanitize_system_prompt_override(Some("\0\0".into())), None);
+        let long = "x".repeat(SYSTEM_PROMPT_OVERRIDE_MAX_CHARS + 10);
+        let capped = sanitize_system_prompt_override(Some(long)).expect("capped");
+        assert_eq!(capped.chars().count(), SYSTEM_PROMPT_OVERRIDE_MAX_CHARS);
     }
 
     #[test]
@@ -2441,6 +2516,7 @@ mod tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                system_prompt_override: None,
             },
         );
         write_json(&sessions_index_file(), &sessions).expect("seed sessions");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -459,6 +459,10 @@ import {
   normalizeMaxAgentTurns,
 } from "@/lib/sessionMaxAgentTurns";
 import {
+  SESSION_SYSTEM_PROMPT_MAX_CHARS,
+  sanitizeSystemPromptOverride,
+} from "@/lib/sessionSystemPrompt";
+import {
   collectUserPromptHistory,
   filterPromptHistory,
   shouldHandlePromptHistoryKey,
@@ -652,6 +656,7 @@ import {
   IconCheck,
   IconList,
   IconListNumbers,
+  IconRobot,
   IconPlan,
   IconActivity,
   IconFileDiff,
@@ -870,6 +875,8 @@ interface SessionRow {
   extraRules?: string | null;
   /** Per-session max agent turns (`--max-turns`); null = inherit global. */
   maxAgentTurns?: number | null;
+  /** Per-session system prompt override (`--system-prompt-override`). */
+  systemPromptOverride?: string | null;
 }
 
 /** Normalize sessions_list / create rows into sidebar SessionRow shape. */
@@ -911,6 +918,7 @@ function mapSessionListRow(
     pluginDirs?: string[] | null;
     extraRules?: string | null;
     maxAgentTurns?: number | null;
+    systemPromptOverride?: string | null;
   },
 ): SessionRow {
   const schema =
@@ -926,6 +934,9 @@ function mapSessionListRow(
   const maxAgentTurns = normalizeMaxAgentTurns(
     typeof x.maxAgentTurns === "number" ? x.maxAgentTurns : null,
   );
+  const systemPromptOverride = sanitizeSystemPromptOverride(
+    typeof x.systemPromptOverride === "string" ? x.systemPromptOverride : null,
+  );
   return {
     ...normalizeSessionRow(x),
     modelId: x.modelId ?? null,
@@ -934,6 +945,7 @@ function mapSessionListRow(
     pluginDirs,
     extraRules: extraRules || null,
     maxAgentTurns,
+    systemPromptOverride: systemPromptOverride || null,
   };
 }
 
@@ -1088,6 +1100,12 @@ export default function App() {
   } | null>(null);
   /** Draft as string so empty input means inherit global. */
   const [sessionMaxTurnsDraft, setSessionMaxTurnsDraft] = useState("");
+  /** Per-session system prompt override editor (`--system-prompt-override`). */
+  const [sessionSysPromptTarget, setSessionSysPromptTarget] = useState<{
+    id: string;
+    title: string;
+  } | null>(null);
+  const [sessionSysPromptDraft, setSessionSysPromptDraft] = useState("");
   const [notifySound, setNotifySound] = useState(() =>
     loadNotifySoundPref(localStorage),
   );
@@ -6474,6 +6492,85 @@ export default function App() {
       setSessionMaxTurnsDraft("");
       closeSessionMaxTurnsModal();
       setToast(tr("session.maxTurnsCleared"));
+      window.setTimeout(() => setToast(null), 3200);
+    } catch (e) {
+      setLocalError(String(e));
+    }
+  };
+
+  /** Open GlassModal to edit per-session system prompt override. */
+  const openSessionSysPrompt = (s: SessionRow) => {
+    setCtxMenu(null);
+    setSessionSysPromptDraft(
+      typeof s.systemPromptOverride === "string" ? s.systemPromptOverride : "",
+    );
+    setSessionSysPromptTarget({
+      id: s.id,
+      title: s.title || tr("session.untitled"),
+    });
+  };
+
+  const closeSessionSysPromptModal = () => {
+    setSessionSysPromptTarget(null);
+    setSessionSysPromptDraft("");
+  };
+
+  const saveSessionSysPromptModal = async () => {
+    const target = sessionSysPromptTarget;
+    if (!target) return;
+    const next = sanitizeSystemPromptOverride(sessionSysPromptDraft);
+    try {
+      if (!api.isTauri()) {
+        setLocalError(tr("error.needTauri"));
+        return;
+      }
+      const saved = await api.sessionSetSystemPromptOverride(
+        target.id,
+        next || null,
+      );
+      const stored =
+        typeof saved.systemPromptOverride === "string" &&
+        saved.systemPromptOverride.trim()
+          ? saved.systemPromptOverride
+          : next || null;
+      setSessions((list) =>
+        list.map((row) =>
+          row.id === target.id
+            ? { ...row, systemPromptOverride: stored }
+            : row,
+        ),
+      );
+      closeSessionSysPromptModal();
+      setToast(
+        stored
+          ? tr("session.sysPromptSaved")
+          : tr("session.sysPromptCleared"),
+      );
+      window.setTimeout(() => setToast(null), 3200);
+    } catch (e) {
+      setLocalError(String(e));
+    }
+  };
+
+  const clearSessionSysPromptModal = async () => {
+    const target = sessionSysPromptTarget;
+    if (!target) return;
+    try {
+      if (!api.isTauri()) {
+        setLocalError(tr("error.needTauri"));
+        return;
+      }
+      await api.sessionSetSystemPromptOverride(target.id, null);
+      setSessions((list) =>
+        list.map((row) =>
+          row.id === target.id
+            ? { ...row, systemPromptOverride: null }
+            : row,
+        ),
+      );
+      setSessionSysPromptDraft("");
+      closeSessionSysPromptModal();
+      setToast(tr("session.sysPromptCleared"));
       window.setTimeout(() => setToast(null), 3200);
     } catch (e) {
       setLocalError(String(e));
@@ -17973,6 +18070,86 @@ export default function App() {
       </GlassModal>
 
       <GlassModal
+        open={!!sessionSysPromptTarget}
+        onClose={closeSessionSysPromptModal}
+        title={tr("session.sysPromptTitle")}
+        size="md"
+        closeLabel={tr("common.close")}
+        wrapBody
+        className="session-sys-prompt-modal"
+        footer={
+          <div className="session-sys-prompt-modal__actions">
+            {sessionSysPromptTarget &&
+            (sessionSysPromptDraft.trim() ||
+              sessions.some(
+                (row) =>
+                  row.id === sessionSysPromptTarget.id &&
+                  !!sanitizeSystemPromptOverride(row.systemPromptOverride),
+              )) ? (
+              <button
+                type="button"
+                className="btn btn--ghost"
+                onClick={() => {
+                  void clearSessionSysPromptModal();
+                }}
+              >
+                {tr("session.sysPromptClear")}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={closeSessionSysPromptModal}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--primary"
+              onClick={() => {
+                void saveSessionSysPromptModal();
+              }}
+            >
+              {tr("common.save")}
+            </button>
+          </div>
+        }
+      >
+        <p className="session-sys-prompt-modal__hint">
+          {tr("session.sysPromptHint", {
+            n: String(SESSION_SYSTEM_PROMPT_MAX_CHARS),
+          })}
+        </p>
+        {sessionSysPromptTarget ? (
+          <p
+            className="session-sys-prompt-modal__session"
+            title={sessionSysPromptTarget.title}
+          >
+            {sessionSysPromptTarget.title}
+          </p>
+        ) : null}
+        <textarea
+          className="session-sys-prompt-modal__textarea"
+          value={sessionSysPromptDraft}
+          onChange={(e) =>
+            setSessionSysPromptDraft(
+              e.target.value.slice(0, SESSION_SYSTEM_PROMPT_MAX_CHARS),
+            )
+          }
+          placeholder={tr("session.sysPromptPlaceholder")}
+          maxLength={SESSION_SYSTEM_PROMPT_MAX_CHARS}
+          spellCheck={false}
+          aria-label={tr("session.sysPromptTitle")}
+        />
+        <p className="session-sys-prompt-modal__count" aria-live="polite">
+          {tr("session.sysPromptChars", {
+            n: String(sessionSysPromptDraft.length),
+            max: String(SESSION_SYSTEM_PROMPT_MAX_CHARS),
+          })}
+        </p>
+      </GlassModal>
+
+      <GlassModal
         open={!!exportMdTarget}
         onClose={() => {
           if (exportMdBusy) return;
@@ -18851,6 +19028,14 @@ export default function App() {
                 label: tr("session.rules"),
                 icon: <IconList size={16} />,
                 onClick: () => openSessionRules(s),
+              },
+              {
+                id: "session-sys-prompt",
+                label: sanitizeSystemPromptOverride(s.systemPromptOverride)
+                  ? tr("session.sysPromptActive")
+                  : tr("session.sysPrompt"),
+                icon: <IconRobot size={16} />,
+                onClick: () => openSessionSysPrompt(s),
               },
               {
                 id: "session-max-turns",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -156,6 +156,18 @@ const en = {
   "session.maxTurnsSaved":
     "Session max turns saved — agent will reload on next turn",
   "session.maxTurnsCleared": "Session max turns cleared — using global setting",
+  "session.sysPrompt": "System prompt override…",
+  "session.sysPromptActive": "System prompt override… (set)",
+  "session.sysPromptTitle": "System prompt override",
+  "session.sysPromptPlaceholder":
+    "Full system prompt for this chat only (replaces the default)",
+  "session.sysPromptHint":
+    "Passed as grok --system-prompt-override for this chat only. Replaces the default system prompt (not append). Max {n} characters. Live agent soft-respawns on save; empty clears.",
+  "session.sysPromptClear": "Clear",
+  "session.sysPromptSaved":
+    "System prompt override saved — agent will reload on next turn",
+  "session.sysPromptCleared": "System prompt override cleared",
+  "session.sysPromptChars": "{n}/{max}",
   "session.worktreeBadge": "Worktree",
   "session.worktreeBadgeAria": "Worktree session · {branch}",
   "session.worktreeBadgeCliAria": "CLI worktree session · {branch}",
@@ -3198,6 +3210,18 @@ const zh: Record<MessageKey, string> = {
   "session.maxTurnsClear": "使用全局",
   "session.maxTurnsSaved": "会话最大轮次已保存 — 下一回合将重新加载 Agent",
   "session.maxTurnsCleared": "已清除会话最大轮次 — 使用全局设置",
+  "session.sysPrompt": "系统提示词覆盖…",
+  "session.sysPromptActive": "系统提示词覆盖…（已设置）",
+  "session.sysPromptTitle": "系统提示词覆盖",
+  "session.sysPromptPlaceholder":
+    "仅本会话的完整系统提示词（替换默认，非追加）",
+  "session.sysPromptHint":
+    "仅本会话以 grok --system-prompt-override 传入。替换默认系统提示词（不是追加）。最多 {n} 个字符。保存后 live Agent 会 soft-respawn；清空即清除。",
+  "session.sysPromptClear": "清除",
+  "session.sysPromptSaved":
+    "系统提示词覆盖已保存 — 下一回合将重新加载 Agent",
+  "session.sysPromptCleared": "已清除系统提示词覆盖",
+  "session.sysPromptChars": "{n}/{max}",
   "session.worktreeBadge": "Worktree",
   "session.worktreeBadgeAria": "Worktree 会话 · {branch}",
   "session.worktreeBadgeCliAria": "CLI worktree 会话 · {branch}",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -143,6 +143,18 @@ export const zhTW: Record<MessageKey, string> = {
   "session.maxTurnsClear": "使用全域",
   "session.maxTurnsSaved": "工作階段最大輪次已儲存 — 下一回合將重新載入 Agent",
   "session.maxTurnsCleared": "已清除工作階段最大輪次 — 使用全域設定",
+  "session.sysPrompt": "系統提示詞覆蓋…",
+  "session.sysPromptActive": "系統提示詞覆蓋…（已設定）",
+  "session.sysPromptTitle": "系統提示詞覆蓋",
+  "session.sysPromptPlaceholder":
+    "僅本對話的完整系統提示詞（取代預設，非附加）",
+  "session.sysPromptHint":
+    "僅本對話以 grok --system-prompt-override 傳入。取代預設系統提示詞（不是附加）。最多 {n} 個字元。儲存後 live Agent 會 soft-respawn；清空即清除。",
+  "session.sysPromptClear": "清除",
+  "session.sysPromptSaved":
+    "系統提示詞覆蓋已儲存 — 下一回合將重新載入 Agent",
+  "session.sysPromptCleared": "已清除系統提示詞覆蓋",
+  "session.sysPromptChars": "{n}/{max}",
   "session.worktreeBadge": "Worktree",
   "session.worktreeBadgeAria": "Worktree 對話 · {branch}",
   "session.worktreeBadgeCliAria": "CLI worktree 對話 · {branch}",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -862,6 +862,8 @@ export async function sessionsList() {
       extraRules?: string | null;
       /** Per-session max agent turns (`--max-turns`); null/omit = inherit global */
       maxAgentTurns?: number | null;
+      /** Per-session system prompt override (`--system-prompt-override`); empty/omit = none */
+      systemPromptOverride?: string | null;
     }>
   >("sessions_list");
 }
@@ -900,6 +902,27 @@ export async function sessionSetMaxAgentTurns(
   }>("session_set_max_agent_turns", {
     id,
     maxAgentTurns: n,
+  });
+}
+
+/**
+ * Set or clear per-session system prompt override (`grok --system-prompt-override`).
+ * Empty clears. Soft-respawns live agent. Do not log the prompt body.
+ */
+export async function sessionSetSystemPromptOverride(
+  id: string,
+  systemPromptOverride: string | null,
+) {
+  return invoke<{
+    id: string;
+    title: string;
+    systemPromptOverride?: string | null;
+  }>("session_set_system_prompt_override", {
+    id,
+    systemPromptOverride:
+      systemPromptOverride && systemPromptOverride.trim()
+        ? systemPromptOverride
+        : null,
   });
 }
 

--- a/src/lib/sessionSystemPrompt.test.ts
+++ b/src/lib/sessionSystemPrompt.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  SESSION_SYSTEM_PROMPT_MAX_CHARS,
+  hasSystemPromptOverride,
+  sanitizeSystemPromptOverride,
+  systemPromptOverrideLogMeta,
+  systemPromptOverrideSpawnArgs,
+} from "./sessionSystemPrompt";
+
+describe("sanitizeSystemPromptOverride", () => {
+  it("returns empty for nullish / whitespace", () => {
+    expect(sanitizeSystemPromptOverride(null)).toBe("");
+    expect(sanitizeSystemPromptOverride(undefined)).toBe("");
+    expect(sanitizeSystemPromptOverride("")).toBe("");
+    expect(sanitizeSystemPromptOverride("   \n\t  ")).toBe("");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeSystemPromptOverride("  You are a bot  ")).toBe(
+      "You are a bot",
+    );
+    expect(sanitizeSystemPromptOverride("\nline a\nline b\n")).toBe(
+      "line a\nline b",
+    );
+  });
+
+  it("strips NUL bytes", () => {
+    expect(sanitizeSystemPromptOverride("a\0b\0c")).toBe("abc");
+    expect(sanitizeSystemPromptOverride("\0\0  hi  \0")).toBe("hi");
+    expect(sanitizeSystemPromptOverride("\0\0")).toBe("");
+  });
+
+  it("clamps to max length after trim + NUL strip", () => {
+    const long = "x".repeat(100);
+    expect(sanitizeSystemPromptOverride(long, 10)).toBe("x".repeat(10));
+    expect(sanitizeSystemPromptOverride("  " + "y".repeat(50) + "  ", 5)).toBe(
+      "y".repeat(5),
+    );
+    // NUL does not count toward retained content after strip.
+    expect(sanitizeSystemPromptOverride("a\0b\0c\0d", 3)).toBe("abc");
+  });
+
+  it("uses the default 32 KiB soft cap", () => {
+    const ok = "a".repeat(SESSION_SYSTEM_PROMPT_MAX_CHARS);
+    expect(sanitizeSystemPromptOverride(ok).length).toBe(
+      SESSION_SYSTEM_PROMPT_MAX_CHARS,
+    );
+    const over = "b".repeat(SESSION_SYSTEM_PROMPT_MAX_CHARS + 20);
+    expect(sanitizeSystemPromptOverride(over).length).toBe(
+      SESSION_SYSTEM_PROMPT_MAX_CHARS,
+    );
+  });
+});
+
+describe("systemPromptOverrideSpawnArgs", () => {
+  it("builds top-level --system-prompt-override pair", () => {
+    expect(systemPromptOverrideSpawnArgs("You are helpful")).toEqual([
+      "--system-prompt-override",
+      "You are helpful",
+    ]);
+  });
+
+  it("omits the flag when empty after sanitize", () => {
+    expect(systemPromptOverrideSpawnArgs("")).toEqual([]);
+    expect(systemPromptOverrideSpawnArgs(null)).toEqual([]);
+    expect(systemPromptOverrideSpawnArgs("   ")).toEqual([]);
+    expect(systemPromptOverrideSpawnArgs("\0")).toEqual([]);
+  });
+
+  it("does not place override under agent/stdio flags", () => {
+    const args = systemPromptOverrideSpawnArgs("be concise");
+    expect(args[0]).toBe("--system-prompt-override");
+    expect(args).not.toContain("agent");
+    expect(args).not.toContain("stdio");
+    expect(args).not.toContain("--system-prompt");
+  });
+});
+
+describe("hasSystemPromptOverride", () => {
+  it("is true only for non-empty sanitized text", () => {
+    expect(hasSystemPromptOverride("hi")).toBe(true);
+    expect(hasSystemPromptOverride("  ")).toBe(false);
+    expect(hasSystemPromptOverride(null)).toBe(false);
+    expect(hasSystemPromptOverride("\0")).toBe(false);
+  });
+});
+
+describe("systemPromptOverrideLogMeta", () => {
+  it("never returns the prompt body — only char count", () => {
+    const secret = "sk-super-secret-api-key-value";
+    const meta = systemPromptOverrideLogMeta(secret);
+    expect(meta).toEqual({ chars: secret.length });
+    expect(JSON.stringify(meta)).not.toContain("sk-");
+    expect(JSON.stringify(meta)).not.toContain("secret");
+    expect(systemPromptOverrideLogMeta("  ")).toBe(null);
+    expect(systemPromptOverrideLogMeta(null)).toBe(null);
+  });
+});

--- a/src/lib/sessionSystemPrompt.ts
+++ b/src/lib/sessionSystemPrompt.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-session system prompt override — pure sanitize + spawn-arg helpers.
+ *
+ * CLI: top-level `grok --system-prompt-override <PROMPT> agent … stdio`
+ * (alias `--system-prompt`; same placement class as `--rules` / `--json-schema`).
+ * Replaces the agent's default system prompt for this process only.
+ */
+
+/** Soft cap so spawn argv / session index stay bounded (~32 KiB). */
+export const SESSION_SYSTEM_PROMPT_MAX_CHARS = 32 * 1024;
+
+/**
+ * Trim, strip NUL bytes, and clamp session system prompt override text.
+ * Empty / whitespace-only → `""` (caller treats as clear).
+ */
+export function sanitizeSystemPromptOverride(
+  raw: string | null | undefined,
+  maxLen: number = SESSION_SYSTEM_PROMPT_MAX_CHARS,
+): string {
+  if (typeof raw !== "string") return "";
+  // Strip NULs so the value cannot break argv / TOML / log lines.
+  const cleaned = raw.replace(/\0/g, "");
+  const t = cleaned.trim();
+  if (!t) return "";
+  const cap = maxLen > 0 ? maxLen : 0;
+  if (cap <= 0) return "";
+  if (t.length <= cap) return t;
+  return t.slice(0, cap);
+}
+
+/**
+ * Top-level CLI args for system prompt override (before `agent`):
+ * `["--system-prompt-override", text]`. Empty when none.
+ *
+ * Prefer the long flag name (canonical); CLI also accepts `--system-prompt`.
+ */
+export function systemPromptOverrideSpawnArgs(
+  prompt: string | null | undefined,
+): string[] {
+  const s = sanitizeSystemPromptOverride(prompt);
+  if (!s) return [];
+  return ["--system-prompt-override", s];
+}
+
+/** True when stored override text is present after sanitize. */
+export function hasSystemPromptOverride(
+  raw: string | null | undefined,
+): boolean {
+  return sanitizeSystemPromptOverride(raw).length > 0;
+}
+
+/**
+ * Safe log label — never emit the full prompt (may contain secrets / PII).
+ * Returns `null` when empty, otherwise `{ chars: N }`.
+ */
+export function systemPromptOverrideLogMeta(
+  raw: string | null | undefined,
+): { chars: number } | null {
+  const s = sanitizeSystemPromptOverride(raw);
+  if (!s) return null;
+  return { chars: s.length };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16095,6 +16095,53 @@ div.composer__input:empty::before {
   margin-top: 4px;
 }
 
+/* Per-session system prompt override (`--system-prompt-override`) */
+.session-sys-prompt-modal__hint {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+.session-sys-prompt-modal__session {
+  margin: 0 0 10px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.session-sys-prompt-modal__textarea {
+  width: 100%;
+  min-height: 180px;
+  resize: vertical;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  line-height: 1.5;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+  background: var(--bg-elevated, rgba(0, 0, 0, 0.2));
+  color: var(--text-primary);
+  box-sizing: border-box;
+}
+.session-sys-prompt-modal__textarea:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+.session-sys-prompt-modal__count {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  text-align: right;
+}
+.session-sys-prompt-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
 /* Status modal */
 .status-modal__dl {
   margin: 0;


### PR DESCRIPTION
## Summary

Per-session **system prompt override** via CLI top-level `grok --system-prompt-override <PROMPT>` (alias `--system-prompt`).

- **SessionMeta** `system_prompt_override` / camelCase `systemPromptOverride`
- **Sanitize**: trim, strip NUL, cap at 32 KiB (`sanitize_system_prompt_override` / TS `sanitizeSystemPromptOverride`)
- **Host** `session_set_system_prompt_override` + **soft-respawn** when the open chat changes (same pattern as extra rules / max agent turns)
- **Spawn** injects top-level `--system-prompt-override` before `agent` when non-empty
- **UI**: session context menu → GlassModal textarea + Clear (no `window.confirm`)
- **Safety**: never logs the full prompt body; log meta is char-count only
- **i18n** en / zh / zh-TW · **CHANGELOG** Unreleased

## Test plan

- [x] `tsc -b` typecheck
- [x] `vitest run src/lib/sessionSystemPrompt.test.ts src/i18n/messages.test.ts`
- [x] `cargo test --lib system_prompt_override` (sanitize + spawn flags)
- [ ] Manual: session menu → System prompt override → save → next turn soft-respawns with override
- [ ] Manual: Clear removes flag; empty whitespace treated as clear
- [ ] Manual: fork inherits override