### PR TITLE
feat(plugins): validate manifests via grok plugin validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ See `docs/llm-wiki/release.md`.
 - **Marketplace plugin detail**: clicking a catalog plugin opens a real detail panel (name, description, marketplace, version, skill/hooks/agents/MCP badges) with Install / Reinstall — not a stub
 - **Install failure recovery**: last install error stays on that plugin row with **Retry**; cleared on success
 - Installed **Details** shows structured marketplace/provides summary when available (plus CLI `plugin details` body)
+- **Plugin validate** (`grok plugin validate`): **Validate** on installed plugin rows and on a local path before advanced install; multi-line CLI messages stay in an in-panel result (not only toast); soft-fail when the CLI is too old
 - **Delete CLI sessions from disk** (Settings → Agent / CLI sessions): per-row delete + delete all unlinked; path-scoped under active `GROK_HOME/sessions`; linked App chats stay
 
 ### Fixed
@@ -69,7 +70,7 @@ See `docs/llm-wiki/release.md`.
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选
 - **计划**：**请求修改** 可选修订说明；计划历史搜索/决策筛选、清空确认、会话仍在时可打开
-- **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要
+- **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**插件校验**（`plugin validate`：已安装行 + 本地路径安装前；行内结果面板；旧 CLI 软失败）
 - **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）
 
 

--- a/docs/llm-wiki/plugins-marketplace.md
+++ b/docs/llm-wiki/plugins-marketplace.md
@@ -9,9 +9,10 @@ Install and manage Grok Build plugins from Settings → Extensions without dropp
 | List installed | Extensions → Plugins | `grok plugin list --json` + inspect enrich |
 | Enable / disable | Same | CLI + `~/.grok/config.toml` |
 | Details / uninstall / update | Same | CLI; GlassModal confirms uninstall |
+| **Validate** | Installed row **Validate**, or advanced install **Validate** on a local path | `grok plugin validate [path]`; multi-line messages in-row (not only toast); soft-fail if CLI too old |
 | Browse catalog | Extensions → Marketplace | `plugin list --json --available` (cached) |
 | Install from catalog | Marketplace row → confirm | `plugin install --trust` then `plugin enable` + soft-respawn |
-| Manual install | Plugins → “Install from path or git…” | Same install path (path / git / `owner/repo`) |
+| Manual install | Plugins → “Install from path or git…” | Same install path (path / git / `owner/repo`); optional pre-install validate for local folders |
 | Marketplace sources | Marketplace → sources details | add / remove / refresh git sources |
 
 Skills / MCP enable toggles remain App-side (`extensions.json` + ACP inject). **Plugins follow CLI/config as source of truth** — do not invent a second store under `~/.grok-app`.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3665,6 +3665,221 @@ pub async fn plugin_update(
     }))
 }
 
+// ── plugin validate (`grok plugin validate [path]`) ─────────────────────────
+
+/// Split stdout + stderr into non-empty lines (stderr first, de-duped).
+pub fn parse_plugin_validate_messages(stdout: &str, stderr: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for part in [stderr, stdout] {
+        for line in part.lines() {
+            let t = line.trim();
+            if t.is_empty() || seen.contains(t) {
+                continue;
+            }
+            seen.insert(t.to_string());
+            out.push(t.to_string());
+        }
+    }
+    out
+}
+
+/// Old CLI rejects `plugin validate` as an unknown subcommand (clap-style).
+pub fn looks_like_unsupported_plugin_validate(stderr: &str, stdout: &str) -> bool {
+    let s = format!("{stderr}\n{stdout}").to_ascii_lowercase();
+    if s.trim().is_empty() {
+        return false;
+    }
+    if s.contains("unrecognized subcommand")
+        || s.contains("unknown subcommand")
+        || s.contains("unexpected subcommand")
+        || s.contains("invalid subcommand")
+    {
+        return true;
+    }
+    if s.contains("validate")
+        && (s.contains("unexpected argument")
+            || s.contains("unrecognized")
+            || s.contains("unknown command")
+            || s.contains("unknown argument"))
+    {
+        return true;
+    }
+    false
+}
+
+/// True when `s` looks like a filesystem path (not a bare plugin name / owner/repo).
+pub fn looks_like_plugin_validate_path(s: &str) -> bool {
+    let s = s.trim();
+    if s.is_empty() {
+        return false;
+    }
+    if s.starts_with("git@") || s.contains("://") {
+        return false;
+    }
+    if s.starts_with('/')
+        || s.starts_with('~')
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.starts_with(".\\")
+        || s.starts_with("..\\")
+    {
+        return true;
+    }
+    // Windows drive: C:\… or D:/…
+    let bytes = s.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+    {
+        return true;
+    }
+    // Relative path segments with separators
+    s.contains('/') || s.contains('\\')
+}
+
+/// Normalize optional path/name; empty → None (CLI defaults to `.`).
+pub fn normalize_plugin_validate_target(path_or_name: Option<&str>) -> Option<String> {
+    path_or_name
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Resolve bare plugin name to installed path via `plugin list --json` (best-effort).
+fn resolve_installed_plugin_path(name: &str) -> Option<String> {
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    let (stdout, _stderr, ok) =
+        run_grok_cli_args(&["plugin", "list", "--json"], PLUGIN_CMD_TIMEOUT_SECS).ok()?;
+    if !ok || stdout.is_empty() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_str(&stdout).ok()?;
+    let arr = value.as_array()?;
+    // Prefer exact name match with a path; if several, first with path.
+    let mut fallback: Option<String> = None;
+    for item in arr {
+        let n = item
+            .get("name")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .trim();
+        if n != name {
+            continue;
+        }
+        let path = item
+            .get("path")
+            .and_then(|x| x.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        if let Some(p) = path {
+            return Some(p);
+        }
+        if fallback.is_none() {
+            fallback = Some(name.to_string());
+        }
+    }
+    fallback
+}
+
+/// Resolve validate target: path as-is; bare name → installed path when known.
+pub fn resolve_plugin_validate_path(path_or_name: Option<&str>) -> Option<String> {
+    let raw = normalize_plugin_validate_target(path_or_name)?;
+    if looks_like_plugin_validate_path(&raw) {
+        return Some(raw);
+    }
+    // Bare name (or name@market) — strip @marketplace for list match
+    let name = raw.split_once('@').map(|(l, _)| l).unwrap_or(&raw).trim();
+    if name.is_empty() {
+        return Some(raw);
+    }
+    resolve_installed_plugin_path(name).or(Some(if name == raw {
+        raw
+    } else {
+        name.to_string()
+    }))
+}
+
+/// Validate a plugin manifest via `grok plugin validate [path]`.
+///
+/// - `path_or_name`: local path, installed plugin name, or omit (CLI default `.`)
+/// - Always returns an envelope `{ ok, messages[] }` (never hard-fails on CLI-too-old)
+/// - Soft-fail: older CLIs without `plugin validate` → `ok: false`, `reason: "cli_too_old"`
+#[tauri::command]
+pub async fn plugin_validate(
+    path_or_name: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let path_or_name_owned = path_or_name.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let resolved = resolve_plugin_validate_path(path_or_name_owned.as_deref());
+        let run = match resolved.as_deref() {
+            Some(p) => run_grok_cli_args(
+                &["plugin", "validate", p],
+                PLUGIN_CMD_TIMEOUT_SECS,
+            ),
+            None => run_grok_cli_args(&["plugin", "validate"], PLUGIN_CMD_TIMEOUT_SECS),
+        };
+        (resolved, run)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let (resolved, run) = result;
+    match run {
+        Err(e) => {
+            // CLI missing / spawn failure — surface as envelope so UI can show in-panel.
+            let msg = e;
+            let reason = if msg.to_ascii_lowercase().contains("not found") {
+                Some("cli_missing")
+            } else {
+                None
+            };
+            Ok(serde_json::json!({
+                "ok": false,
+                "messages": [msg],
+                "path": resolved,
+                "reason": reason,
+            }))
+        }
+        Ok((stdout, stderr, exit_ok)) => {
+            if looks_like_unsupported_plugin_validate(&stderr, &stdout) {
+                return Ok(serde_json::json!({
+                    "ok": false,
+                    "messages": [
+                        format!(
+                            "This Grok CLI does not support `plugin validate`; version {} or newer is required. Run `grok update`, then fully restart the app.",
+                            crate::cli_probe::min_cli_version_str()
+                        )
+                    ],
+                    "path": resolved,
+                    "reason": "cli_too_old",
+                }));
+            }
+            let messages = parse_plugin_validate_messages(&stdout, &stderr);
+            let messages = if messages.is_empty() {
+                if exit_ok {
+                    vec!["Plugin manifest is valid.".to_string()]
+                } else {
+                    vec!["Plugin validation failed.".to_string()]
+                }
+            } else {
+                messages
+            };
+            Ok(serde_json::json!({
+                "ok": exit_ok,
+                "messages": messages,
+                "path": resolved,
+                "reason": serde_json::Value::Null,
+            }))
+        }
+    }
+}
+
 #[cfg(test)]
 mod plugin_config_tests {
     use super::*;
@@ -3834,6 +4049,64 @@ disabled = ["yes"]
         assert_eq!(normalize_plugin_update_name(Some("")), None);
         assert_eq!(normalize_plugin_update_name(Some("   ")), None);
         assert_eq!(normalize_plugin_update_name(None), None);
+    }
+
+    #[test]
+    fn parse_validate_messages_stderr_first_dedupe() {
+        let msgs = parse_plugin_validate_messages(
+            "Plugin manifest is valid.\n  name: demo\n",
+            "  name: demo\n",
+        );
+        assert_eq!(
+            msgs,
+            vec![
+                "name: demo".to_string(),
+                "Plugin manifest is valid.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn looks_like_unsupported_validate_clap() {
+        assert!(looks_like_unsupported_plugin_validate(
+            "error: unrecognized subcommand 'validate'\n\nUsage: grok plugin …",
+            ""
+        ));
+        assert!(looks_like_unsupported_plugin_validate(
+            "error: unexpected argument 'validate' found",
+            ""
+        ));
+        assert!(!looks_like_unsupported_plugin_validate(
+            "Error: Not a directory: /nope",
+            ""
+        ));
+        assert!(!looks_like_unsupported_plugin_validate(
+            "Error: Failed to load manifest: missing field `name`",
+            ""
+        ));
+    }
+
+    #[test]
+    fn looks_like_validate_path_variants() {
+        assert!(looks_like_plugin_validate_path("/tmp/my-plugin"));
+        assert!(looks_like_plugin_validate_path("~/code/plugin"));
+        assert!(looks_like_plugin_validate_path("./plugin"));
+        assert!(looks_like_plugin_validate_path("C:\\Users\\a\\plugin"));
+        assert!(looks_like_plugin_validate_path("owner/repo")); // has slash → path-ish for CLI
+        assert!(!looks_like_plugin_validate_path("chrome-devtools-mcp"));
+        assert!(!looks_like_plugin_validate_path("https://github.com/a/b.git"));
+        assert!(!looks_like_plugin_validate_path("git@github.com:a/b.git"));
+    }
+
+    #[test]
+    fn normalize_validate_target_empty() {
+        assert_eq!(normalize_plugin_validate_target(None), None);
+        assert_eq!(normalize_plugin_validate_target(Some("")), None);
+        assert_eq!(normalize_plugin_validate_target(Some("  ")), None);
+        assert_eq!(
+            normalize_plugin_validate_target(Some("  /tmp/p  ")).as_deref(),
+            Some("/tmp/p")
+        );
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -356,6 +356,7 @@ pub fn run() {
             commands::plugin_details,
             commands::plugin_install,
             commands::plugin_update,
+            commands::plugin_validate,
             commands::hooks_list,
             commands::hooks_reveal,
             commands::hooks_open_dir,

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -40,6 +40,13 @@ import {
   type PluginFilter,
 } from "@/lib/extensionsUi";
 import {
+  formatPluginValidateMessages,
+  isLocalPluginPath,
+  isPluginValidateCliTooOld,
+  pluginValidateTarget,
+  type PluginValidateResult,
+} from "@/lib/pluginValidate";
+import {
   indexDoctorServerStatuses,
   lookupServerStatus,
   mcpAuthGuidanceKey,
@@ -138,6 +145,13 @@ export function ExtensionsPanel({
   /** Grok Build Plugins tab filter: all | enabled | disabled */
   const [pluginFilter, setPluginFilter] = useState<PluginFilter>("all");
   const [installSource, setInstallSource] = useState("");
+  /** Per-row `plugin validate` result (keyed by pluginRowKey). Shown in-panel. */
+  const [validateByKey, setValidateByKey] = useState<
+    Record<string, PluginValidateResult>
+  >({});
+  /** Pre-install validate for advanced path/git install field. */
+  const [installValidate, setInstallValidate] =
+    useState<PluginValidateResult | null>(null);
   /** In-app SKILL.md light editor (Settings → Extensions → Skills). */
   const [skillEditor, setSkillEditor] = useState<SkillEditorState | null>(null);
   const [skillDiscardOpen, setSkillDiscardOpen] = useState(false);
@@ -540,6 +554,98 @@ export function ExtensionsPanel({
     });
   };
 
+  const applyValidateResult = (
+    res: api.PluginValidateResult,
+  ): PluginValidateResult => ({
+    ok: !!res.ok,
+    messages: Array.isArray(res.messages)
+      ? res.messages.filter((m): m is string => typeof m === "string")
+      : [],
+    path: res.path ?? null,
+    reason: res.reason ?? null,
+  });
+
+  /** Validate an installed plugin (path preferred) — result stays on the row. */
+  const validatePlugin = (p: api.PluginDto) => {
+    if (!api.isTauri() || actionBusy || cliMissing) return;
+    const key = pluginRowKey(p);
+    const target = pluginValidateTarget(p);
+    setActionBusy(`validate:${key}`);
+    setActionError(null);
+    setActionErrorSource(null);
+    void (async () => {
+      try {
+        const res = applyValidateResult(await api.pluginValidate(target));
+        setValidateByKey((prev) => ({ ...prev, [key]: res }));
+        // Soft-fail (CLI too old) also surfaces in the top action panel for visibility.
+        if (!res.ok && isPluginValidateCliTooOld(res)) {
+          setActionError(
+            formatPluginValidateMessages(
+              res.messages,
+              tr("ext.plugins.validateCliTooOld"),
+            ),
+          );
+          setActionErrorSource("plugin");
+        }
+      } catch (e) {
+        const msg = String(e);
+        setValidateByKey((prev) => ({
+          ...prev,
+          [key]: { ok: false, messages: [msg] },
+        }));
+        setActionError(msg);
+        setActionErrorSource("plugin");
+      } finally {
+        setActionBusy(null);
+      }
+    })();
+  };
+
+  /** Pre-install validate for a local path in the advanced install field. */
+  const validateInstallSource = () => {
+    if (!api.isTauri() || actionBusy || cliMissing) return;
+    const source = normalizePluginInstallSource(installSource);
+    if (!source) {
+      setInstallValidate({
+        ok: false,
+        messages: [tr("ext.plugins.installEmpty")],
+      });
+      return;
+    }
+    if (!isLocalPluginPath(source)) {
+      setInstallValidate({
+        ok: false,
+        messages: [tr("ext.plugins.validatePathOnly")],
+      });
+      return;
+    }
+    setActionBusy("validate:install");
+    setActionError(null);
+    setActionErrorSource(null);
+    void (async () => {
+      try {
+        const res = applyValidateResult(await api.pluginValidate(source));
+        setInstallValidate(res);
+        if (!res.ok && isPluginValidateCliTooOld(res)) {
+          setActionError(
+            formatPluginValidateMessages(
+              res.messages,
+              tr("ext.plugins.validateCliTooOld"),
+            ),
+          );
+          setActionErrorSource("plugin");
+        }
+      } catch (e) {
+        const msg = String(e);
+        setInstallValidate({ ok: false, messages: [msg] });
+        setActionError(msg);
+        setActionErrorSource("plugin");
+      } finally {
+        setActionBusy(null);
+      }
+    })();
+  };
+
   const showDetails = async (p: api.PluginDto) => {
     setDetailsTitle(p.name);
     setDetailsBody("");
@@ -919,10 +1025,12 @@ export function ExtensionsPanel({
               const key = pluginRowKey(p);
               const rowBusy = actionBusy === key;
               const updating = actionBusy === `update:${key}`;
-              const busy = rowBusy || updating;
+              const validating = actionBusy === `validate:${key}`;
+              const busy = rowBusy || updating || validating;
               const tone = pluginStatusTone(p.status, p.enabled);
               const meta = pluginMetaLine(p);
               const provides = pluginProvidesLine(p);
+              const vResult = validateByKey[key] ?? null;
               return (
                 <li
                   key={key}
@@ -994,6 +1102,16 @@ export function ExtensionsPanel({
                     <button
                       type="button"
                       className="btn btn--ghost btn--sm"
+                      disabled={busy || !!actionBusy || cliMissing}
+                      onClick={() => validatePlugin(p)}
+                    >
+                      {validating
+                        ? tr("ext.plugins.validating")
+                        : tr("ext.plugins.validate")}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm"
                       disabled={busy || !!actionBusy}
                       onClick={() => void showDetails(p)}
                     >
@@ -1009,6 +1127,43 @@ export function ExtensionsPanel({
                       <span>{tr("ext.plugins.uninstall")}</span>
                     </button>
                   </div>
+                  {vResult ? (
+                    <div
+                      className={
+                        "ext-item__validate" +
+                        (vResult.ok
+                          ? " ext-item__validate--ok"
+                          : " ext-item__validate--err")
+                      }
+                      role={vResult.ok ? "status" : "alert"}
+                    >
+                      <div className="ext-item__validate-title">
+                        {vResult.ok
+                          ? tr("ext.plugins.validateOk")
+                          : isPluginValidateCliTooOld(vResult)
+                            ? tr("ext.plugins.validateCliTooOld")
+                            : tr("ext.plugins.validateFailed")}
+                      </div>
+                      {vResult.messages.length > 0 ? (
+                        <pre className="ext-item__validate-body">
+                          {formatPluginValidateMessages(vResult.messages)}
+                        </pre>
+                      ) : null}
+                      <button
+                        type="button"
+                        className="btn btn--ghost btn--sm"
+                        onClick={() =>
+                          setValidateByKey((prev) => {
+                            const next = { ...prev };
+                            delete next[key];
+                            return next;
+                          })
+                        }
+                      >
+                        {tr("common.close")}
+                      </button>
+                    </div>
+                  ) : null}
                 </li>
               );
             })}
@@ -1036,7 +1191,10 @@ export function ExtensionsPanel({
                   disabled={!!actionBusy || cliMissing}
                   autoComplete="off"
                   spellCheck={false}
-                  onChange={(e) => setInstallSource(e.target.value)}
+                  onChange={(e) => {
+                    setInstallSource(e.target.value);
+                    if (installValidate) setInstallValidate(null);
+                  }}
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
                       e.preventDefault();
@@ -1044,6 +1202,21 @@ export function ExtensionsPanel({
                     }
                   }}
                 />
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  disabled={
+                    !!actionBusy ||
+                    cliMissing ||
+                    !normalizePluginInstallSource(installSource)
+                  }
+                  title={tr("ext.plugins.validateHint")}
+                  onClick={() => validateInstallSource()}
+                >
+                  {actionBusy === "validate:install"
+                    ? tr("ext.plugins.validating")
+                    : tr("ext.plugins.validate")}
+                </button>
                 <button
                   type="button"
                   className="btn btn--solid btn--sm"
@@ -1059,6 +1232,40 @@ export function ExtensionsPanel({
                     : tr("ext.plugins.install")}
                 </button>
               </div>
+              <p className="ext-plugin-install__hint">
+                {tr("ext.plugins.installHint")}
+              </p>
+              {installValidate ? (
+                <div
+                  className={
+                    "ext-item__validate" +
+                    (installValidate.ok
+                      ? " ext-item__validate--ok"
+                      : " ext-item__validate--err")
+                  }
+                  role={installValidate.ok ? "status" : "alert"}
+                >
+                  <div className="ext-item__validate-title">
+                    {installValidate.ok
+                      ? tr("ext.plugins.validateOk")
+                      : isPluginValidateCliTooOld(installValidate)
+                        ? tr("ext.plugins.validateCliTooOld")
+                        : tr("ext.plugins.validateFailed")}
+                  </div>
+                  {installValidate.messages.length > 0 ? (
+                    <pre className="ext-item__validate-body">
+                      {formatPluginValidateMessages(installValidate.messages)}
+                    </pre>
+                  ) : null}
+                  <button
+                    type="button"
+                    className="btn btn--ghost btn--sm"
+                    onClick={() => setInstallValidate(null)}
+                  >
+                    {tr("common.close")}
+                  </button>
+                </div>
+              ) : null}
             </div>
           </details>
         ) : null}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2376,6 +2376,16 @@ const en = {
   "ext.plugins.update": "Update",
   "ext.plugins.updateAll": "Update all",
   "ext.plugins.updating": "Updating…",
+  "ext.plugins.validate": "Validate",
+  "ext.plugins.validating": "Validating…",
+  "ext.plugins.validateOk": "Manifest is valid",
+  "ext.plugins.validateFailed": "Validation failed",
+  "ext.plugins.validateCliTooOld":
+    "This Grok CLI does not support plugin validate — update the CLI and restart the app.",
+  "ext.plugins.validatePathOnly":
+    "Validate before install works on a local folder path (not git URL or owner/repo).",
+  "ext.plugins.validateHint":
+    "Run `grok plugin validate` on a local path before install",
   "ext.skills.title": "Skills",
   "ext.skills.loading": "Loading skills…",
   "ext.skills.empty": "No skills discovered",
@@ -5341,6 +5351,15 @@ const zh: Record<MessageKey, string> = {
   "ext.plugins.update": "更新",
   "ext.plugins.updateAll": "全部更新",
   "ext.plugins.updating": "正在更新…",
+  "ext.plugins.validate": "校验",
+  "ext.plugins.validating": "正在校验…",
+  "ext.plugins.validateOk": "清单有效",
+  "ext.plugins.validateFailed": "校验失败",
+  "ext.plugins.validateCliTooOld":
+    "当前 Grok CLI 不支持 plugin validate — 请更新 CLI 并完全重启应用。",
+  "ext.plugins.validatePathOnly":
+    "安装前校验仅支持本地文件夹路径（不支持 git URL 或 owner/repo）。",
+  "ext.plugins.validateHint": "对本地路径运行 `grok plugin validate` 后再安装",
   "ext.skills.title": "技能",
   "ext.skills.loading": "正在加载技能…",
   "ext.skills.empty": "未发现技能",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2286,6 +2286,15 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.plugins.update": "更新",
   "ext.plugins.updateAll": "全部更新",
   "ext.plugins.updating": "正在更新…",
+  "ext.plugins.validate": "驗證",
+  "ext.plugins.validating": "正在驗證…",
+  "ext.plugins.validateOk": "清單有效",
+  "ext.plugins.validateFailed": "驗證失敗",
+  "ext.plugins.validateCliTooOld":
+    "目前 Grok CLI 不支援 plugin validate — 請更新 CLI 並完全重新啟動應用程式。",
+  "ext.plugins.validatePathOnly":
+    "安裝前驗證僅支援本機資料夾路徑（不支援 git URL 或 owner/repo）。",
+  "ext.plugins.validateHint": "對本機路徑執行 `grok plugin validate` 後再安裝",
   "ext.skills.title": "技能",
   "ext.skills.loading": "正在載入技能…",
   "ext.skills.empty": "未發現技能",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1696,6 +1696,27 @@ export async function pluginUpdate(name?: string | null) {
   });
 }
 
+/** Result of `grok plugin validate` (host always returns envelope; soft-fail when CLI too old). */
+export interface PluginValidateResult {
+  ok: boolean;
+  messages: string[];
+  path?: string | null;
+  /** e.g. `cli_too_old` when the probed CLI lacks `plugin validate`. */
+  reason?: string | null;
+}
+
+/**
+ * Validate a plugin manifest via `grok plugin validate [path|name]`.
+ * Pass an installed plugin path/name, or a local path before install.
+ * Soft-fails (ok:false + reason) when CLI is too old — does not throw for that case.
+ */
+export async function pluginValidate(pathOrName?: string | null) {
+  const raw = (pathOrName ?? "").trim();
+  return invoke<PluginValidateResult>("plugin_validate", {
+    pathOrName: raw ? raw : null,
+  });
+}
+
 // ── Official Grok Build account ─────────────────────────────────────────────
 
 export interface AccountProfile {

--- a/src/lib/pluginValidate.test.ts
+++ b/src/lib/pluginValidate.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatPluginValidateMessages,
+  isLocalPluginPath,
+  isPluginValidateCliTooOld,
+  looksLikeUnsupportedPluginValidate,
+  parsePluginValidateMessages,
+  parsePluginValidateOutput,
+  pluginValidateTarget,
+} from "./pluginValidate";
+
+describe("parsePluginValidateMessages", () => {
+  it("splits non-empty lines; stderr before stdout; dedupes", () => {
+    expect(
+      parsePluginValidateMessages(
+        "Plugin manifest is valid.\n  name: demo\n",
+        "  name: demo\n",
+      ),
+    ).toEqual(["name: demo", "Plugin manifest is valid."]);
+  });
+
+  it("handles empty / null", () => {
+    expect(parsePluginValidateMessages("", "")).toEqual([]);
+    expect(parsePluginValidateMessages(null, undefined)).toEqual([]);
+  });
+});
+
+describe("parsePluginValidateOutput", () => {
+  it("ok follows exit status even when messages look soft", () => {
+    const noManifest =
+      "No plugin.json found. Grok discovers skills, agents, and hooks automatically from standard directories. A manifest is only needed for custom paths or metadata.";
+    expect(parsePluginValidateOutput(noManifest, "", true)).toEqual({
+      ok: true,
+      messages: [noManifest],
+    });
+  });
+
+  it("failed parse is not ok", () => {
+    const err =
+      "Error: Failed to load manifest: failed to parse /tmp/bad/plugin.json: missing field `name`";
+    const r = parsePluginValidateOutput("", err, false);
+    expect(r.ok).toBe(false);
+    expect(r.messages[0]).toContain("missing field `name`");
+  });
+});
+
+describe("looksLikeUnsupportedPluginValidate", () => {
+  it("detects clap unrecognized subcommand", () => {
+    expect(
+      looksLikeUnsupportedPluginValidate(
+        "error: unrecognized subcommand 'validate'\n\nUsage: grok plugin [OPTIONS] <COMMAND>",
+        "",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects unexpected argument validate", () => {
+    expect(
+      looksLikeUnsupportedPluginValidate(
+        "error: unexpected argument 'validate' found",
+        "",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores normal validate failures", () => {
+    expect(
+      looksLikeUnsupportedPluginValidate(
+        "Error: Not a directory: /nope",
+        "",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeUnsupportedPluginValidate(
+        "Error: Failed to load manifest: missing field `name`",
+        "",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isPluginValidateCliTooOld", () => {
+  it("uses reason field", () => {
+    expect(
+      isPluginValidateCliTooOld({
+        reason: "cli_too_old",
+        messages: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to message text", () => {
+    expect(
+      isPluginValidateCliTooOld({
+        reason: null,
+        messages: [
+          "This Grok CLI does not support `plugin validate`. Update the CLI and restart the app.",
+        ],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("formatPluginValidateMessages", () => {
+  it("joins lines and uses fallback", () => {
+    expect(formatPluginValidateMessages(["a", "b"])).toBe("a\nb");
+    expect(formatPluginValidateMessages([], "none")).toBe("none");
+  });
+});
+
+describe("isLocalPluginPath", () => {
+  it("accepts filesystem paths", () => {
+    expect(isLocalPluginPath("/tmp/my-plugin")).toBe(true);
+    expect(isLocalPluginPath("~/code/plugin")).toBe(true);
+    expect(isLocalPluginPath("./plugin")).toBe(true);
+    expect(isLocalPluginPath("../plugin")).toBe(true);
+    expect(isLocalPluginPath("C:\\Users\\a\\plugin")).toBe(true);
+    expect(isLocalPluginPath("D:/plugins/x")).toBe(true);
+  });
+
+  it("rejects git / marketplace / bare names", () => {
+    expect(isLocalPluginPath("owner/repo")).toBe(false);
+    expect(isLocalPluginPath("vercel@xAI Official")).toBe(false);
+    expect(isLocalPluginPath("https://github.com/a/b.git")).toBe(false);
+    expect(isLocalPluginPath("git@github.com:a/b.git")).toBe(false);
+    expect(isLocalPluginPath("chrome-devtools-mcp")).toBe(false);
+    expect(isLocalPluginPath("")).toBe(false);
+  });
+});
+
+describe("pluginValidateTarget", () => {
+  it("prefers path over name", () => {
+    expect(
+      pluginValidateTarget({
+        name: "demo",
+        path: "/p/demo",
+      }),
+    ).toBe("/p/demo");
+    expect(pluginValidateTarget({ name: "demo", path: null })).toBe("demo");
+  });
+});

--- a/src/lib/pluginValidate.ts
+++ b/src/lib/pluginValidate.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure helpers for `grok plugin validate` output / targets.
+ * Host runs the CLI; UI parses and displays messages in-panel.
+ */
+
+export type PluginValidateReason = "cli_too_old" | "cli_missing" | string;
+
+/** Envelope from host `plugin_validate` (and pure parse helpers). */
+export interface PluginValidateResult {
+  ok: boolean;
+  messages: string[];
+  /** Resolved path that was validated (when known). */
+  path?: string | null;
+  /** Soft-fail machine reason (e.g. `cli_too_old` when CLI lacks the subcommand). */
+  reason?: PluginValidateReason | null;
+}
+
+/**
+ * Split stdout + stderr into non-empty message lines (stderr first).
+ * Pure — used by tests and optional client-side re-parse.
+ */
+export function parsePluginValidateMessages(
+  stdout: string | null | undefined,
+  stderr: string | null | undefined,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const part of [stderr ?? "", stdout ?? ""]) {
+    for (const line of part.split(/\r?\n/)) {
+      const t = line.trim();
+      if (!t || seen.has(t)) continue;
+      seen.add(t);
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a validate result from raw CLI streams + exit status.
+ * Exit code is authoritative for `ok` (informational "no plugin.json" is still ok).
+ */
+export function parsePluginValidateOutput(
+  stdout: string | null | undefined,
+  stderr: string | null | undefined,
+  exitOk: boolean,
+): Pick<PluginValidateResult, "ok" | "messages"> {
+  const messages = parsePluginValidateMessages(stdout, stderr);
+  return { ok: exitOk, messages };
+}
+
+/**
+ * Heuristic: old CLI rejects `plugin validate` as an unknown subcommand.
+ * Matches clap-style errors from older grok builds.
+ */
+export function looksLikeUnsupportedPluginValidate(
+  stderr: string | null | undefined,
+  stdout: string | null | undefined = "",
+): boolean {
+  const s = `${stderr ?? ""}\n${stdout ?? ""}`.toLowerCase();
+  if (!s.trim()) return false;
+  if (
+    s.includes("unrecognized subcommand") ||
+    s.includes("unknown subcommand") ||
+    s.includes("unexpected subcommand") ||
+    s.includes("invalid subcommand")
+  ) {
+    return true;
+  }
+  // `error: unexpected argument 'validate'` / similar
+  if (
+    s.includes("validate") &&
+    (s.includes("unexpected argument") ||
+      s.includes("unrecognized") ||
+      s.includes("unknown command") ||
+      s.includes("unknown argument"))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function isPluginValidateCliTooOld(
+  result: Pick<PluginValidateResult, "reason" | "messages"> | null | undefined,
+): boolean {
+  if (!result) return false;
+  if (result.reason === "cli_too_old") return true;
+  const joined = (result.messages ?? []).join("\n").toLowerCase();
+  return (
+    joined.includes("does not support") && joined.includes("plugin validate")
+  );
+}
+
+/** Join messages for compact display (panel body / title attribute). */
+export function formatPluginValidateMessages(
+  messages: string[] | null | undefined,
+  fallback = "",
+): string {
+  const lines = (messages ?? []).map((m) => m.trim()).filter(Boolean);
+  if (lines.length === 0) return fallback;
+  return lines.join("\n");
+}
+
+/**
+ * True when install source looks like a local filesystem path
+ * (Validate pre-install only makes sense for paths, not git / owner/repo).
+ */
+export function isLocalPluginPath(raw: string | null | undefined): boolean {
+  const s = (raw ?? "").trim();
+  if (!s) return false;
+  if (s.startsWith("git@") || s.includes("://")) return false;
+  // Absolute / home / relative / Windows drive
+  if (
+    s.startsWith("/") ||
+    s.startsWith("~") ||
+    s.startsWith("./") ||
+    s.startsWith("../") ||
+    s.startsWith(".\\") ||
+    s.startsWith("..\\")
+  ) {
+    return true;
+  }
+  if (s.length >= 3) {
+    const c0 = s.charCodeAt(0);
+    const isLetter =
+      (c0 >= 65 && c0 <= 90) || (c0 >= 97 && c0 <= 122);
+    if (isLetter && s[1] === ":" && (s[2] === "\\" || s[2] === "/")) {
+      return true;
+    }
+  }
+  // Bare name or owner/repo → not a local path for pre-install validate
+  return false;
+}
+
+/**
+ * Prefer installed plugin path for validate; fall back to name.
+ * Host also resolves bare names to install paths when possible.
+ */
+export function pluginValidateTarget(plugin: {
+  path?: string | null;
+  name: string;
+}): string {
+  const path = (plugin.path ?? "").trim();
+  if (path) return path;
+  return plugin.name.trim();
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17751,6 +17751,47 @@ div.composer__input:empty::before {
   word-break: break-word;
 }
 
+/* plugin validate result panel (installed row + advanced install) */
+.ext-item__validate {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  min-width: 0;
+}
+
+.ext-item__validate--err {
+  background: color-mix(in srgb, #e05a5a 10%, transparent);
+  border: 1px solid color-mix(in srgb, #e05a5a 28%, transparent);
+}
+
+.ext-item__validate--ok {
+  background: color-mix(in srgb, #6bcf8e 10%, transparent);
+  border: 1px solid color-mix(in srgb, #6bcf8e 28%, transparent);
+}
+
+.ext-item__validate-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ext-item__validate-body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 160px;
+  overflow: auto;
+}
+
 .ext-market-detail {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Host **`plugin_validate(pathOrName?)`** wraps `grok plugin validate`, resolves installed names to paths, returns `{ ok, messages[], path?, reason? }`
- **Extensions → Plugins**: **Validate** on each installed row; **Validate** on a local path in advanced install before install
- Multi-line CLI messages shown **in-panel** under the row / install field (not only toast)
- Soft-fail when CLI is too old / missing subcommand (`reason: cli_too_old`)
- Pure parse helpers + unit tests (TS + Rust); i18n en/zh/zh-TW; CHANGELOG + wiki

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/pluginValidate.test.ts src/i18n/messages.test.ts`
- [x] `cargo test --lib plugin_config_tests`
- [ ] Manual: Settings → Extensions → Plugins → Validate on an installed plugin (green panel + CLI lines)
- [ ] Manual: Advanced install with `/path/to/plugin` → Validate (failure shows red panel with parse errors)
- [ ] Manual: Old CLI / simulated unsupported subcommand → soft-fail message, UI does not throw