### PR TITLE
feat(settings): CLI sessions search via grok sessions search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ See `docs/llm-wiki/release.md`.
 #### Permissions / CLI
 - **CLI `--permission-mode` alignment**: pure App policy / YOLO / plan-mode map (`default` · `acceptEdits` · `auto` · `dontAsk` · `bypassPermissions` · `plan`); spawn pins top-level `--permission-mode` (+ agent `--always-approve` for YOLO); Settings shows CLI label + advanced mode selector; product **Auto** policy
 - **Doctor fix depth**: plan banner (“N automatic fixes available (M need confirm)”), **Apply safe fixes** for non-destructive CLI remediations (sequential host `cli_doctor_fix`, then re-run doctor); destructive fixes stay per-row with in-app confirm; clearer fix-id + host errors
+- **CLI sessions search** (Settings → Agent / CLI sessions): host `cli_sessions_search` runs `grok sessions search` (tries `--json`, else text parse of summaries + first prompts); enriches with local dir / linked state for import·open·delete; falls back to disk filter including first user prompt when CLI is unavailable
 
 #### Extensions / marketplace
 - **Marketplace plugin detail**: clicking a catalog plugin opens a real detail panel (name, description, marketplace, version, skill/hooks/agents/MCP badges) with Install / Reinstall — not a stub
@@ -70,7 +71,7 @@ See `docs/llm-wiki/release.md`.
 - **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选
 - **计划**：**请求修改** 可选修订说明；计划历史搜索/决策筛选、清空确认、会话仍在时可打开
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要
-- **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）
+- **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）；**CLI 会话搜索**（`grok sessions search` 摘要+首条提示，失败则本地磁盘含首条提示筛选）
 
 
 **中文 · 修复**

--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -32,6 +32,34 @@ pub struct CliSessionSummary {
     pub app_session_id: Option<String>,
     /// GROK_HOME used for discovery (path clarity independent vs shared).
     pub source_home: String,
+    /// First user prompt when known (search / enriched list only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_prompt: Option<String>,
+}
+
+/// Search hit from `grok sessions search` or local first-prompt fallback.
+/// Compatible with list rows for import / open / delete in the UI.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliSessionSearchHit {
+    pub agent_session_id: String,
+    pub title: String,
+    pub cwd: Option<String>,
+    pub updated_at: String,
+    /// May be empty for remote-only hits not present under local GROK_HOME.
+    pub dir: String,
+    pub num_messages: u32,
+    pub already_linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_session_id: Option<String>,
+    pub source_home: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_prompt: Option<String>,
+    /// CLI status token when known (`local` / `remote`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// `"cli"` when from `grok sessions search`, `"local"` for disk fallback.
+    pub source: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -125,6 +153,7 @@ pub fn list_cli_sessions(session_data_mode: &str) -> Result<Vec<CliSessionSummar
                 dir: dir.display().to_string(),
                 num_messages: n,
                 source_home: source_home.clone(),
+                first_prompt: None,
             });
         }
     }
@@ -135,6 +164,574 @@ pub fn list_cli_sessions(session_data_mode: &str) -> Result<Vec<CliSessionSummar
         out.truncate(200);
     }
     Ok(out)
+}
+
+/// Clamp search limit (1–100). Default 40.
+pub fn clamp_search_limit(limit: Option<u32>) -> u32 {
+    limit.unwrap_or(40).clamp(1, 100)
+}
+
+/// Run `grok sessions search <query>` under the active GROK_HOME.
+///
+/// Prefers `--json` when the CLI accepts it; otherwise parses text output.
+/// On CLI failure / missing binary, falls back to local disk filter that also
+/// matches first user prompts from `chat_history.jsonl`.
+pub fn search_cli_sessions(
+    query: &str,
+    limit: Option<u32>,
+    session_data_mode: &str,
+    cli_path: Option<&Path>,
+) -> Result<Vec<CliSessionSearchHit>, String> {
+    let q = query.trim();
+    if q.is_empty() {
+        return Ok(Vec::new());
+    }
+    let lim = clamp_search_limit(limit);
+    let home = resolve_agent_grok_home(session_data_mode);
+    let source_home = home.display().to_string();
+
+    // Prefer real CLI when a binary is available.
+    if let Some(path) = cli_path.filter(|p| p.is_file()) {
+        match run_sessions_search_cli(path, &home, q, lim) {
+            Ok(hits) if !hits.is_empty() => {
+                return Ok(enrich_search_hits(hits, session_data_mode, &source_home, "cli"));
+            }
+            Ok(_empty) => {
+                // CLI succeeded with zero hits — still try local first-prompt
+                // match (CLI may only search remote index / different store).
+                let local = search_local_sessions(q, lim, session_data_mode)?;
+                if !local.is_empty() {
+                    return Ok(local);
+                }
+                return Ok(Vec::new());
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "session",
+                    error = %e,
+                    "grok sessions search failed; falling back to local filter"
+                );
+            }
+        }
+    }
+
+    search_local_sessions(q, lim, session_data_mode)
+}
+
+/// Pure text parser for `grok sessions search` human output.
+pub fn parse_sessions_search_text(raw: &str) -> Vec<RawSearchHit> {
+    let text = raw.replace("\r\n", "\n");
+    if text.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let mut hits: Vec<RawSearchHit> = Vec::new();
+    let mut current: Option<RawSearchHitBuilder> = None;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.to_ascii_lowercase().starts_with("total:") {
+            if let Some(b) = current.take() {
+                hits.push(b.finish());
+            }
+            break;
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.starts_with("warning:") || lower.starts_with("error:") {
+            continue;
+        }
+
+        let is_indented = line.starts_with("  ") || line.starts_with('\t');
+        if let Some(id) = extract_session_id_prefix(trimmed) {
+            if !is_indented {
+                if let Some(b) = current.take() {
+                    hits.push(b.finish());
+                }
+                let rest = trimmed[id.len()..].trim();
+                let (status, updated) = parse_status_and_date(rest);
+                current = Some(RawSearchHitBuilder {
+                    agent_session_id: id.to_string(),
+                    status,
+                    updated_label: updated,
+                    body: Vec::new(),
+                });
+                continue;
+            }
+        }
+
+        if let Some(ref mut b) = current {
+            if is_indented {
+                b.body.push(line.trim_start().to_string());
+            } else if !b.body.is_empty() && extract_session_id_prefix(trimmed).is_none() {
+                // Rare unindented continuation of first prompt.
+                b.body.push(trimmed.to_string());
+            }
+        }
+    }
+    if let Some(b) = current.take() {
+        hits.push(b.finish());
+    }
+    hits
+}
+
+/// Pure JSON parser for future `grok sessions search --json`.
+pub fn parse_sessions_search_json(raw: &str) -> Option<Vec<RawSearchHit>> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty()
+        || !(trimmed.starts_with('{') || trimmed.starts_with('['))
+    {
+        return None;
+    }
+    let value: Value = serde_json::from_str(trimmed).ok()?;
+    let rows: Vec<Value> = match value {
+        Value::Array(arr) => arr,
+        Value::Object(map) => {
+            for key in ["sessions", "results", "items", "data", "hits"] {
+                if let Some(Value::Array(arr)) = map.get(key) {
+                    return Some(json_rows_to_hits(arr.clone()));
+                }
+            }
+            // Single object
+            if json_pick_str(&Value::Object(map.clone()), &[
+                "agentSessionId",
+                "agent_session_id",
+                "sessionId",
+                "session_id",
+                "id",
+            ])
+            .is_some()
+            {
+                vec![Value::Object(map)]
+            } else {
+                return None;
+            }
+        }
+        _ => return None,
+    };
+    Some(json_rows_to_hits(rows))
+}
+
+fn json_rows_to_hits(rows: Vec<Value>) -> Vec<RawSearchHit> {
+    let mut out = Vec::new();
+    for row in rows {
+        let id = match json_pick_str(&row, &[
+            "agentSessionId",
+            "agent_session_id",
+            "sessionId",
+            "session_id",
+            "id",
+        ]) {
+            Some(id) => id,
+            None => continue,
+        };
+        let title = json_pick_str(&row, &[
+            "title",
+            "summary",
+            "generatedTitle",
+            "generated_title",
+            "sessionSummary",
+            "session_summary",
+        ])
+        .unwrap_or_else(|| format!("CLI {}", id.chars().take(8).collect::<String>()));
+        let first_prompt = json_pick_str(&row, &[
+            "firstPrompt",
+            "first_prompt",
+            "prompt",
+            "firstUserPrompt",
+            "first_user_prompt",
+        ]);
+        let status = json_pick_str(&row, &["status", "location", "source"]);
+        let updated_label = json_pick_str(&row, &[
+            "updatedLabel",
+            "updatedAt",
+            "updated_at",
+            "updated",
+            "lastActiveAt",
+            "last_active_at",
+        ]);
+        out.push(RawSearchHit {
+            agent_session_id: id,
+            title,
+            first_prompt,
+            status,
+            updated_label,
+        });
+    }
+    out
+}
+
+fn json_pick_str(v: &Value, keys: &[&str]) -> Option<String> {
+    let obj = v.as_object()?;
+    for k in keys {
+        if let Some(s) = obj.get(*k).and_then(|x| x.as_str()).map(str::trim) {
+            if !s.is_empty() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawSearchHit {
+    pub agent_session_id: String,
+    pub title: String,
+    pub first_prompt: Option<String>,
+    pub status: Option<String>,
+    pub updated_label: Option<String>,
+}
+
+struct RawSearchHitBuilder {
+    agent_session_id: String,
+    status: Option<String>,
+    updated_label: Option<String>,
+    body: Vec<String>,
+}
+
+impl RawSearchHitBuilder {
+    fn finish(self) -> RawSearchHit {
+        let body: Vec<String> = self
+            .body
+            .into_iter()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let title = body
+            .first()
+            .cloned()
+            .unwrap_or_else(|| {
+                format!(
+                    "CLI {}",
+                    self.agent_session_id.chars().take(8).collect::<String>()
+                )
+            });
+        let first_prompt = if body.len() > 1 {
+            Some(body[1..].join("\n"))
+        } else {
+            None
+        };
+        RawSearchHit {
+            agent_session_id: self.agent_session_id,
+            title,
+            first_prompt,
+            status: self.status,
+            updated_label: self.updated_label,
+        }
+    }
+}
+
+fn extract_session_id_prefix(s: &str) -> Option<&str> {
+    // UUID-shaped agent session ids (Grok uses UUID v7-ish).
+    let bytes = s.as_bytes();
+    if bytes.len() < 36 {
+        return None;
+    }
+    let cand = &s[..36];
+    let ok = cand.as_bytes().iter().enumerate().all(|(i, &c)| match i {
+        8 | 13 | 18 | 23 => c == b'-',
+        _ => c.is_ascii_hexdigit(),
+    });
+    if ok {
+        Some(cand)
+    } else {
+        None
+    }
+}
+
+fn parse_status_and_date(rest: &str) -> (Option<String>, Option<String>) {
+    let rest = rest.trim();
+    if rest.is_empty() {
+        return (None, None);
+    }
+    if rest.starts_with('(') {
+        if let Some(end) = rest.find(')') {
+            let status = rest[1..end].trim();
+            let after = rest[end + 1..].trim();
+            return (
+                if status.is_empty() {
+                    None
+                } else {
+                    Some(status.to_string())
+                },
+                if after.is_empty() {
+                    None
+                } else {
+                    Some(after.to_string())
+                },
+            );
+        }
+    }
+    (None, Some(rest.to_string()))
+}
+
+fn looks_like_unsupported_flag(stderr: &str) -> bool {
+    let s = stderr.to_ascii_lowercase();
+    s.contains("unexpected argument")
+        || s.contains("unrecognized option")
+        || s.contains("unknown flag")
+        || s.contains("unknown option")
+        || s.contains("invalid option")
+        || s.contains("unrecognized subcommand")
+        || s.contains("unexpected subcommand")
+}
+
+const SESSIONS_SEARCH_TIMEOUT_SECS: u64 = 25;
+
+fn run_sessions_search_cli(
+    cli_path: &Path,
+    grok_home: &Path,
+    query: &str,
+    limit: u32,
+) -> Result<Vec<RawSearchHit>, String> {
+    // Try --json first (future CLI); fall back to text on unsupported flag.
+    let json_attempt = run_grok_sessions_search(cli_path, grok_home, query, limit, true);
+    match json_attempt {
+        Ok((stdout, stderr, ok)) => {
+            if let Some(hits) = parse_sessions_search_json(&stdout) {
+                return Ok(hits);
+            }
+            // Some CLIs print JSON errors on stderr only.
+            if looks_like_unsupported_flag(&stderr) {
+                // retry without --json below
+            } else if !stdout.trim().is_empty() {
+                // Might still be text despite requesting json.
+                let hits = parse_sessions_search_text(&stdout);
+                if !hits.is_empty() || ok {
+                    return Ok(hits);
+                }
+            } else if looks_like_unsupported_flag(&stderr) {
+                // fall through
+            } else if !ok {
+                return Err(format!(
+                    "grok sessions search failed: {}",
+                    truncate_err(if stderr.is_empty() { &stdout } else { &stderr }, 240)
+                ));
+            }
+        }
+        Err(e) => {
+            // Spawn failure — do not retry.
+            return Err(e);
+        }
+    }
+
+    let (stdout, stderr, ok) =
+        run_grok_sessions_search(cli_path, grok_home, query, limit, false)?;
+    if !ok && stdout.trim().is_empty() {
+        return Err(format!(
+            "grok sessions search failed: {}",
+            truncate_err(if stderr.is_empty() { &stdout } else { &stderr }, 240)
+        ));
+    }
+    // Prefer JSON if it somehow worked without flag.
+    if let Some(hits) = parse_sessions_search_json(&stdout) {
+        return Ok(hits);
+    }
+    Ok(parse_sessions_search_text(&stdout))
+}
+
+fn run_grok_sessions_search(
+    cli_path: &Path,
+    grok_home: &Path,
+    query: &str,
+    limit: u32,
+    with_json: bool,
+) -> Result<(String, String, bool), String> {
+    let mut args: Vec<String> = vec![
+        "sessions".into(),
+        "search".into(),
+        query.into(),
+        "-n".into(),
+        limit.to_string(),
+    ];
+    if with_json {
+        args.push("--json".into());
+    }
+
+    let cli_path = cli_path.to_path_buf();
+    let grok_home = grok_home.to_path_buf();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut cmd = crate::process_util::command(&cli_path);
+        cmd.args(&args);
+        cmd.env("GROK_HOME", &grok_home);
+        if let Some(path_env) = crate::process_util::enriched_path_env() {
+            cmd.env("PATH", path_env);
+        }
+        let _ = tx.send(cmd.output());
+    });
+
+    match rx.recv_timeout(std::time::Duration::from_secs(SESSIONS_SEARCH_TIMEOUT_SECS)) {
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            Ok((stdout, stderr, output.status.success()))
+        }
+        Ok(Err(e)) => Err(format!("Failed to run grok sessions search: {e}")),
+        Err(_) => Err(format!(
+            "grok sessions search timed out after {SESSIONS_SEARCH_TIMEOUT_SECS}s"
+        )),
+    }
+}
+
+fn truncate_err(s: &str, max: usize) -> String {
+    let t = s.trim();
+    if t.chars().count() <= max {
+        return t.to_string();
+    }
+    let head: String = t.chars().take(max).collect();
+    format!("{head}…")
+}
+
+fn enrich_search_hits(
+    hits: Vec<RawSearchHit>,
+    session_data_mode: &str,
+    source_home: &str,
+    source: &str,
+) -> Vec<CliSessionSearchHit> {
+    let local = list_cli_sessions(session_data_mode).unwrap_or_default();
+    let by_id: std::collections::HashMap<String, CliSessionSummary> = local
+        .into_iter()
+        .map(|s| (s.agent_session_id.clone(), s))
+        .collect();
+
+    hits.into_iter()
+        .map(|h| {
+            if let Some(loc) = by_id.get(&h.agent_session_id) {
+                CliSessionSearchHit {
+                    agent_session_id: h.agent_session_id,
+                    title: if h.title.is_empty() {
+                        loc.title.clone()
+                    } else {
+                        h.title
+                    },
+                    cwd: loc.cwd.clone(),
+                    updated_at: if loc.updated_at.is_empty() {
+                        h.updated_label.unwrap_or_default()
+                    } else {
+                        loc.updated_at.clone()
+                    },
+                    dir: loc.dir.clone(),
+                    num_messages: loc.num_messages,
+                    already_linked: loc.already_linked,
+                    app_session_id: loc.app_session_id.clone(),
+                    source_home: loc.source_home.clone(),
+                    first_prompt: h.first_prompt.or_else(|| loc.first_prompt.clone()),
+                    status: h.status,
+                    source: source.to_string(),
+                }
+            } else {
+                CliSessionSearchHit {
+                    agent_session_id: h.agent_session_id,
+                    title: h.title,
+                    cwd: None,
+                    updated_at: h.updated_label.unwrap_or_default(),
+                    dir: String::new(),
+                    num_messages: 0,
+                    already_linked: false,
+                    app_session_id: None,
+                    source_home: source_home.to_string(),
+                    first_prompt: h.first_prompt,
+                    status: h.status,
+                    source: source.to_string(),
+                }
+            }
+        })
+        .collect()
+}
+
+/// Local disk search: title / id / cwd / first user prompt.
+fn search_local_sessions(
+    query: &str,
+    limit: u32,
+    session_data_mode: &str,
+) -> Result<Vec<CliSessionSearchHit>, String> {
+    let q = query.trim().to_ascii_lowercase();
+    if q.is_empty() {
+        return Ok(Vec::new());
+    }
+    let list = list_cli_sessions(session_data_mode)?;
+    let mut out = Vec::new();
+    for mut row in list {
+        // Lazy first-prompt only when title/id/cwd did not already match —
+        // but CLI search is meant to hit first prompts, so always load when
+        // cheap enough. Cap body read via first user message only.
+        let prompt = read_first_user_prompt(Path::new(&row.dir));
+        row.first_prompt = prompt.clone();
+
+        let hay_title = row.title.to_ascii_lowercase();
+        let hay_id = row.agent_session_id.to_ascii_lowercase();
+        let hay_cwd = row.cwd.as_deref().unwrap_or("").to_ascii_lowercase();
+        let hay_prompt = prompt.as_deref().unwrap_or("").to_ascii_lowercase();
+        if !(hay_title.contains(&q)
+            || hay_id.contains(&q)
+            || (!hay_cwd.is_empty() && hay_cwd.contains(&q))
+            || (!hay_prompt.is_empty() && hay_prompt.contains(&q)))
+        {
+            continue;
+        }
+        out.push(CliSessionSearchHit {
+            agent_session_id: row.agent_session_id,
+            title: row.title,
+            cwd: row.cwd,
+            updated_at: row.updated_at,
+            dir: row.dir,
+            num_messages: row.num_messages,
+            already_linked: row.already_linked,
+            app_session_id: row.app_session_id,
+            source_home: row.source_home,
+            first_prompt: prompt,
+            status: Some("local".into()),
+            source: "local".into(),
+        });
+        if out.len() >= limit as usize {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// First user message body from chat_history.jsonl (best-effort, capped).
+pub fn read_first_user_prompt(dir: &Path) -> Option<String> {
+    let history = dir.join("chat_history.jsonl");
+    if !history.is_file() {
+        return None;
+    }
+    let raw = fs::read_to_string(&history).ok()?;
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let typ = v
+            .get("type")
+            .or_else(|| v.get("role"))
+            .and_then(|x| x.as_str())
+            .unwrap_or("");
+        if typ != "user" {
+            continue;
+        }
+        let content = v.get("content").map(content_to_text).unwrap_or_default();
+        let content = content.trim().to_string();
+        if content.is_empty() {
+            continue;
+        }
+        let content = extract_user_query(&content).unwrap_or(content);
+        let content = content.trim();
+        if content.is_empty() {
+            continue;
+        }
+        // Cap length for UI / filter.
+        let capped: String = content.chars().take(500).collect();
+        return Some(capped);
+    }
+    None
 }
 
 fn read_summary_bits(
@@ -850,5 +1447,85 @@ mod tests {
         // sibling under home must remain
         assert!(sessions.is_dir() || !home.join("sessions").exists() || home.exists());
         let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn parse_sessions_search_text_basic() {
+        let raw = r#"019f3fc7-485c-7ef1-ba71-624d6c014657 (remote)  Jul 08, 11:42am
+  Test Message
+  test
+019f3fc7-fd3a-72b1-b0a7-5d0c3e0b02bc (local)  Jul 08, 11:42am
+  Test Session
+  测试 session
+
+Total: 2
+"#;
+        let hits = parse_sessions_search_text(raw);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(
+            hits[0].agent_session_id,
+            "019f3fc7-485c-7ef1-ba71-624d6c014657"
+        );
+        assert_eq!(hits[0].title, "Test Message");
+        assert_eq!(hits[0].first_prompt.as_deref(), Some("test"));
+        assert_eq!(hits[0].status.as_deref(), Some("remote"));
+        assert_eq!(hits[1].title, "Test Session");
+        assert_eq!(hits[1].status.as_deref(), Some("local"));
+    }
+
+    #[test]
+    fn parse_sessions_search_text_empty_and_warnings() {
+        assert!(parse_sessions_search_text("\nTotal: 0\n").is_empty());
+        let raw = r#"warning: remote session search timed out, showing local results only
+019ea630-1bd7-7f20-9ee4-78325ae16994 (local)  Jun 08,  6:17pm
+  GatePath Software Download
+
+Total: 1
+"#;
+        let hits = parse_sessions_search_text(raw);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "GatePath Software Download");
+        assert!(hits[0].first_prompt.is_none());
+    }
+
+    #[test]
+    fn parse_sessions_search_json_array() {
+        let raw = r#"[
+          {
+            "agentSessionId": "abc-1111-uuid-xxxx-yyyyyyyyyyyy",
+            "title": "Hello",
+            "firstPrompt": "hi there",
+            "status": "local"
+          }
+        ]"#;
+        let hits = parse_sessions_search_json(raw).expect("json");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Hello");
+        assert_eq!(hits[0].first_prompt.as_deref(), Some("hi there"));
+    }
+
+    #[test]
+    fn read_first_user_prompt_from_history() {
+        let dir = std::env::temp_dir().join(format!("cli-fp-{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("chat_history.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, r#"{{"type":"system","content":"sys"}}"#).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","content":[{{"type":"text","text":"<user_query>\nsearch me please\n</user_query>"}}]}}"#
+        )
+        .unwrap();
+        let p = read_first_user_prompt(&dir).unwrap();
+        assert_eq!(p, "search me please");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn clamp_search_limit_bounds() {
+        assert_eq!(clamp_search_limit(None), 40);
+        assert_eq!(clamp_search_limit(Some(0)), 1);
+        assert_eq!(clamp_search_limit(Some(200)), 100);
+        assert_eq!(clamp_search_limit(Some(25)), 25);
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -493,6 +493,29 @@ pub async fn cli_sessions_list() -> Result<Vec<crate::cli_sessions::CliSessionSu
     crate::cli_sessions::list_cli_sessions(&mode)
 }
 
+/// Search CLI sessions via `grok sessions search` (summaries + first prompts).
+/// Falls back to local disk filter (incl. first prompt) when CLI is unavailable.
+#[tauri::command]
+pub async fn cli_sessions_search(
+    query: String,
+    limit: Option<u32>,
+) -> Result<Vec<crate::cli_sessions::CliSessionSearchHit>, String> {
+    let settings = store::load_settings();
+    let mode = settings.session_data_mode.clone();
+    let probe = cli_probe::probe_cli(settings.manual_cli_path.as_deref());
+    let cli_path = probe.path.filter(|_| probe.found).map(std::path::PathBuf::from);
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::cli_sessions::search_cli_sessions(
+            &query,
+            limit,
+            &mode,
+            cli_path.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 /// Import one CLI session (chat_history.jsonl) into the App journal.
 #[tauri::command]
 pub async fn cli_session_import(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -284,6 +284,7 @@ pub fn run() {
             commands::sessions_list,
             commands::sessions_search,
             commands::cli_sessions_list,
+            commands::cli_sessions_search,
             commands::cli_session_import,
             commands::cli_sessions_import_all,
             commands::cli_sessions_delete,

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -5693,12 +5693,21 @@ function CliSessionsPanel({
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [filterQuery, setFilterQuery] = useState("");
+  /** Host CLI search results when query is non-empty; null = show local list/filter. */
+  const [searchHits, setSearchHits] = useState<api.CliSessionSearchHit[] | null>(
+    null,
+  );
+  const [searching, setSearching] = useState(false);
+  const [searchNote, setSearchNote] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<
     | null
     | { kind: "one"; row: api.CliSessionSummary }
     | { kind: "unlinked"; count: number }
   >(null);
+  const searchSeq = useRef(0);
+  /** Bumps after list refresh so active CLI search re-enriches linked state. */
+  const [listEpoch, setListEpoch] = useState(0);
   const isIndependent = sessionDataMode !== "shared";
 
   const refresh = useCallback(async () => {
@@ -5708,6 +5717,7 @@ function CliSessionsPanel({
     try {
       const list = await api.cliSessionsList();
       setRows(list);
+      setListEpoch((n) => n + 1);
     } catch (e) {
       setError(String(e));
       setRows([]);
@@ -5720,10 +5730,56 @@ function CliSessionsPanel({
     void refresh();
   }, [refresh, sessionDataMode]);
 
-  const filtered = useMemo(
-    () => filterCliSessions(rows, filterQuery),
-    [rows, filterQuery],
-  );
+  // When the search box is non-empty, call host `cli_sessions_search`
+  // (`grok sessions search` + local first-prompt fallback). Debounced.
+  useEffect(() => {
+    const q = filterQuery.trim();
+    if (!q) {
+      setSearchHits(null);
+      setSearching(false);
+      setSearchNote(null);
+      return;
+    }
+    if (!api.isTauri()) {
+      setSearchHits(null);
+      return;
+    }
+    const seq = ++searchSeq.current;
+    setSearching(true);
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const hits = await api.cliSessionsSearch(q, 40);
+          if (searchSeq.current !== seq) return;
+          setSearchHits(hits);
+          const viaCli = hits.some((h) => h.source === "cli");
+          setSearchNote(
+            viaCli
+              ? t("settings.cliSessionsSearchViaCli")
+              : t("settings.cliSessionsSearchViaLocal"),
+          );
+        } catch {
+          if (searchSeq.current !== seq) return;
+          // Host failed — fall back to client-side title/id/cwd/firstPrompt filter.
+          setSearchHits(null);
+          setSearchNote(t("settings.cliSessionsSearchFallback"));
+        } finally {
+          if (searchSeq.current === seq) setSearching(false);
+        }
+      })();
+    }, 280);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [filterQuery, sessionDataMode, listEpoch, t]);
+
+  const filtered = useMemo(() => {
+    const q = filterQuery.trim();
+    if (!q) return rows;
+    if (searchHits) return searchHits;
+    // Host still loading or failed → local filter (incl. firstPrompt when present).
+    return filterCliSessions(rows, q);
+  }, [rows, filterQuery, searchHits]);
   /** Bulk import / delete unlinked always targets the full list (not the filter). */
   const pending = countUnlinkedCliSessions(rows);
   const sourceHome =
@@ -5897,16 +5953,29 @@ function CliSessionsPanel({
                 })}
           </button>
         </div>
-        {rows.length > 0 ? (
-          <div className="settings-cli-sessions__filter">
-            <IconSearch size={14} />
-            <input
-              type="search"
-              value={filterQuery}
-              onChange={(e) => setFilterQuery(e.target.value)}
-              placeholder={t("settings.cliSessionsFilterPlaceholder")}
-              aria-label={t("settings.cliSessionsFilterPlaceholder")}
-            />
+        <div className="settings-cli-sessions__filter">
+          <IconSearch size={14} />
+          <input
+            type="search"
+            value={filterQuery}
+            onChange={(e) => {
+              setFilterQuery(e.target.value);
+              // Clear stale host error when the user edits the query.
+              if (error) setError(null);
+            }}
+            placeholder={t("settings.cliSessionsFilterPlaceholder")}
+            aria-label={t("settings.cliSessionsFilterPlaceholder")}
+          />
+        </div>
+        {searchNote && filterQuery.trim() ? (
+          <div className="settings-cli-sessions__search-note" role="status">
+            {searching
+              ? t("settings.cliSessionsSearching")
+              : searchNote}
+          </div>
+        ) : searching && filterQuery.trim() ? (
+          <div className="settings-cli-sessions__search-note" role="status">
+            {t("settings.cliSessionsSearching")}
           </div>
         ) : null}
         {error ? (
@@ -5919,17 +5988,23 @@ function CliSessionsPanel({
             {status}
           </div>
         ) : null}
-        {loading && rows.length === 0 ? (
+        {loading && rows.length === 0 && !filterQuery.trim() ? (
           <div className="settings-cli-sessions__empty">
             {t("settings.cliSessionsLoading")}
           </div>
-        ) : rows.length === 0 ? (
+        ) : rows.length === 0 && !filterQuery.trim() ? (
           <div className="settings-cli-sessions__empty">
             {t("settings.cliSessionsEmpty")}
           </div>
+        ) : searching && filtered.length === 0 ? (
+          <div className="settings-cli-sessions__empty">
+            {t("settings.cliSessionsSearching")}
+          </div>
         ) : filtered.length === 0 ? (
           <div className="settings-cli-sessions__empty">
-            {t("settings.cliSessionsFilterEmpty")}
+            {filterQuery.trim()
+              ? t("settings.cliSessionsSearchEmpty")
+              : t("settings.cliSessionsFilterEmpty")}
           </div>
         ) : (
           <ul className="settings-cli-sessions__list">
@@ -5939,6 +6014,11 @@ function CliSessionsPanel({
                 r.agentSessionId.length > 14
                   ? `${r.agentSessionId.slice(0, 8)}…${r.agentSessionId.slice(-4)}`
                   : r.agentSessionId;
+              const firstPrompt =
+                "firstPrompt" in r
+                  ? (r as { firstPrompt?: string | null }).firstPrompt
+                  : undefined;
+              const remoteOnly = !r.dir;
               return (
                 <li
                   key={r.agentSessionId}
@@ -5960,6 +6040,14 @@ function CliSessionsPanel({
                         </span>
                       ) : null}
                     </div>
+                    {firstPrompt ? (
+                      <div
+                        className="settings-cli-sessions__prompt"
+                        title={firstPrompt}
+                      >
+                        {firstPrompt}
+                      </div>
+                    ) : null}
                     <div className="settings-cli-sessions__sub">
                       {r.cwd ? `${r.cwd} · ` : ""}
                       {r.numMessages
@@ -6018,10 +6106,14 @@ function CliSessionsPanel({
                     <button
                       type="button"
                       className="btn btn--ghost btn--sm btn--danger"
-                      disabled={!!busyId}
-                      title={t("settings.cliSessionsDeleteConfirmMsg", {
-                        title: r.title,
-                      })}
+                      disabled={!!busyId || remoteOnly}
+                      title={
+                        remoteOnly
+                          ? t("settings.cliSessionsDeleteRemoteOnly")
+                          : t("settings.cliSessionsDeleteConfirmMsg", {
+                              title: r.title,
+                            })
+                      }
                       aria-label={t("settings.cliSessionsDelete")}
                       onClick={() =>
                         setDeleteConfirm({ kind: "one", row: r })

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1061,8 +1061,19 @@ const en = {
   "settings.cliSessionsAgentId": "id {id}",
   "settings.cliSessionsCopyId": "Copy id",
   "settings.cliSessionsCopied": "Copied",
-  "settings.cliSessionsFilterPlaceholder": "Filter by title or id…",
+  "settings.cliSessionsFilterPlaceholder":
+    "Search summaries and first prompts…",
   "settings.cliSessionsFilterEmpty": "No sessions match this filter.",
+  "settings.cliSessionsSearching": "Searching CLI sessions…",
+  "settings.cliSessionsSearchEmpty": "No CLI sessions match this search.",
+  "settings.cliSessionsSearchViaCli":
+    "Results from grok sessions search (summaries + first prompts)",
+  "settings.cliSessionsSearchViaLocal":
+    "Local disk search (title, id, cwd, first prompt)",
+  "settings.cliSessionsSearchFallback":
+    "CLI search unavailable — filtering the local list",
+  "settings.cliSessionsDeleteRemoteOnly":
+    "No on-disk folder under GROK_HOME for this hit (remote-only)",
   "settings.cliSessionsSource": "Scanning {path}",
   "settings.cliSessionsIndependentNote":
     "Independent mode uses the app agent-home (~/.grok-app/agent-home), which may differ from terminal CLI sessions under ~/.grok. Import still copies chat history into the app; agent resume may not find the same on-disk session unless you switch to shared mode.",
@@ -4061,8 +4072,17 @@ const zh: Record<MessageKey, string> = {
   "settings.cliSessionsAgentId": "id {id}",
   "settings.cliSessionsCopyId": "复制 id",
   "settings.cliSessionsCopied": "已复制",
-  "settings.cliSessionsFilterPlaceholder": "按标题或 id 筛选…",
+  "settings.cliSessionsFilterPlaceholder": "搜索摘要与首条提示…",
   "settings.cliSessionsFilterEmpty": "没有符合筛选条件的会话。",
+  "settings.cliSessionsSearching": "正在搜索 CLI 会话…",
+  "settings.cliSessionsSearchEmpty": "没有符合搜索条件的 CLI 会话。",
+  "settings.cliSessionsSearchViaCli":
+    "来自 grok sessions search（摘要 + 首条提示）",
+  "settings.cliSessionsSearchViaLocal":
+    "本地磁盘搜索（标题、id、路径、首条提示）",
+  "settings.cliSessionsSearchFallback": "CLI 搜索不可用 — 正在筛选本地列表",
+  "settings.cliSessionsDeleteRemoteOnly":
+    "此结果在 GROK_HOME 下没有本地目录（仅远程）",
   "settings.cliSessionsSource": "扫描路径 {path}",
   "settings.cliSessionsIndependentNote":
     "独立模式使用应用 agent-home（~/.grok-app/agent-home），可能与终端 CLI 的 ~/.grok 会话不一致。仍可导入聊天记录到应用；若需与终端同一 on-disk 会话继续，请切换到共享模式。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1006,8 +1006,17 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.cliSessionsAgentId": "id {id}",
   "settings.cliSessionsCopyId": "複製 id",
   "settings.cliSessionsCopied": "已複製",
-  "settings.cliSessionsFilterPlaceholder": "依標題或 id 篩選…",
+  "settings.cliSessionsFilterPlaceholder": "搜尋摘要與首則提示…",
   "settings.cliSessionsFilterEmpty": "沒有符合篩選條件的工作階段。",
+  "settings.cliSessionsSearching": "正在搜尋 CLI 工作階段…",
+  "settings.cliSessionsSearchEmpty": "沒有符合搜尋條件的 CLI 工作階段。",
+  "settings.cliSessionsSearchViaCli":
+    "來自 grok sessions search（摘要 + 首則提示）",
+  "settings.cliSessionsSearchViaLocal":
+    "本機磁碟搜尋（標題、id、路徑、首則提示）",
+  "settings.cliSessionsSearchFallback": "CLI 搜尋不可用 — 正在篩選本機列表",
+  "settings.cliSessionsDeleteRemoteOnly":
+    "此結果在 GROK_HOME 下沒有本機目錄（僅遠端）",
   "settings.cliSessionsSource": "掃描路徑 {path}",
   "settings.cliSessionsIndependentNote":
     "獨立模式使用應用程式 agent-home（~/.grok-app/agent-home），可能與終端機 CLI 的 ~/.grok 工作階段不一致。仍可匯入聊天紀錄到應用程式；若需與終端機同一 on-disk 工作階段繼續，請切換到共用模式。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -955,10 +955,31 @@ export type CliSessionSummary = {
   appSessionId?: string | null;
   /** GROK_HOME used for discovery (path clarity). */
   sourceHome?: string;
+  /** First user prompt when known (search / enriched). */
+  firstPrompt?: string | null;
+};
+
+/** Hit from `grok sessions search` (or local first-prompt fallback). */
+export type CliSessionSearchHit = CliSessionSummary & {
+  /** CLI status token: local | remote. */
+  status?: string | null;
+  /** `"cli"` from `grok sessions search`, `"local"` for disk fallback. */
+  source: "cli" | "local" | string;
 };
 
 export async function cliSessionsList() {
   return invoke<CliSessionSummary[]>("cli_sessions_list");
+}
+
+/**
+ * Search CLI sessions (summaries + first prompts) via host
+ * `grok sessions search`. Falls back to local disk filter when CLI fails.
+ */
+export async function cliSessionsSearch(query: string, limit?: number) {
+  return invoke<CliSessionSearchHit[]>("cli_sessions_search", {
+    query,
+    limit: limit ?? 40,
+  });
 }
 
 export async function cliSessionImport(

--- a/src/lib/cliSessionsFilter.test.ts
+++ b/src/lib/cliSessionsFilter.test.ts
@@ -22,6 +22,7 @@ const rows = [
     title: "CLI import polish",
     cwd: null,
     alreadyLinked: false,
+    firstPrompt: "please polish the import UX for sessions",
   },
 ];
 
@@ -47,6 +48,11 @@ describe("filterCliSessions", () => {
   it("matches cwd when present", () => {
     expect(filterCliSessions(rows, "grok-app")).toEqual([rows[1]]);
     expect(filterCliSessions(rows, "/users/me/code/app")).toEqual([rows[0]]);
+  });
+
+  it("matches first prompt when present", () => {
+    expect(filterCliSessions(rows, "polish the import")).toEqual([rows[2]]);
+    expect(filterCliSessions(rows, "IMPORT UX")).toEqual([rows[2]]);
   });
 
   it("returns empty array when nothing matches", () => {

--- a/src/lib/cliSessionsFilter.ts
+++ b/src/lib/cliSessionsFilter.ts
@@ -6,11 +6,13 @@ export type CliSessionFilterRow = {
   agentSessionId: string;
   title: string;
   cwd?: string | null;
+  /** First user prompt when known (local fallback / enriched list). */
+  firstPrompt?: string | null;
 };
 
 /**
  * Filter CLI session rows by free-text query.
- * Case-insensitive match on title, agent session id, and cwd.
+ * Case-insensitive match on title, agent session id, cwd, and first prompt.
  * Empty/whitespace query → all rows (preserves order).
  */
 export function filterCliSessions<T extends CliSessionFilterRow>(
@@ -24,6 +26,8 @@ export function filterCliSessions<T extends CliSessionFilterRow>(
     if (r.agentSessionId.toLowerCase().includes(q)) return true;
     const cwd = r.cwd?.toLowerCase() ?? "";
     if (cwd && cwd.includes(q)) return true;
+    const prompt = r.firstPrompt?.toLowerCase() ?? "";
+    if (prompt && prompt.includes(q)) return true;
     return false;
   });
 }

--- a/src/lib/cliSessionsSearch.test.ts
+++ b/src/lib/cliSessionsSearch.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampCliSessionsSearchLimit,
+  looksLikeCliSearchUnsupported,
+  mergeCliSearchHitsWithLocal,
+  parseCliSessionsSearchJson,
+  parseCliSessionsSearchOutput,
+  parseCliSessionsSearchText,
+} from "./cliSessionsSearch";
+
+const SAMPLE_TEXT = `019f3fc7-485c-7ef1-ba71-624d6c014657 (remote)  Jul 08, 11:42am
+  Test Message
+  test
+019f3fc7-fd3a-72b1-b0a7-5d0c3e0b02bc (remote)  Jul 08, 11:42am
+  Test Session
+  测试 session
+
+Total: 2
+`;
+
+const SAMPLE_LOCAL = `019fa76f-bed6-7293-b52d-2d4e647c0755 (local)  Jul 28,  3:01pm
+  Update Code to Latest Version
+  please update all packages
+
+Total: 1
+`;
+
+describe("parseCliSessionsSearchText", () => {
+  it("parses id, status, title, and first prompt", () => {
+    const hits = parseCliSessionsSearchText(SAMPLE_TEXT);
+    expect(hits).toHaveLength(2);
+    expect(hits[0]).toMatchObject({
+      agentSessionId: "019f3fc7-485c-7ef1-ba71-624d6c014657",
+      title: "Test Message",
+      firstPrompt: "test",
+      status: "remote",
+      updatedLabel: "Jul 08, 11:42am",
+    });
+    expect(hits[1].title).toBe("Test Session");
+    expect(hits[1].firstPrompt).toBe("测试 session");
+  });
+
+  it("parses local status hits", () => {
+    const hits = parseCliSessionsSearchText(SAMPLE_LOCAL);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].status).toBe("local");
+    expect(hits[0].firstPrompt).toBe("please update all packages");
+  });
+
+  it("returns empty for Total: 0 and blank input", () => {
+    expect(parseCliSessionsSearchText("\nTotal: 0\n")).toEqual([]);
+    expect(parseCliSessionsSearchText("")).toEqual([]);
+    expect(parseCliSessionsSearchText("   \n  ")).toEqual([]);
+  });
+
+  it("skips warning lines and tolerates missing first prompt", () => {
+    const raw = `warning: remote session search timed out, showing local results only
+019ea630-1bd7-7f20-9ee4-78325ae16994 (local)  Jun 08,  6:17pm
+  GatePath Software Download
+
+Total: 1
+`;
+    const hits = parseCliSessionsSearchText(raw);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].title).toBe("GatePath Software Download");
+    expect(hits[0].firstPrompt).toBeNull();
+  });
+
+  it("joins multi-line first prompts", () => {
+    const raw = `019f3fc7-485c-7ef1-ba71-624d6c014657 (remote)  Jul 08, 11:42am
+  Title Line
+  first line of prompt
+  second line of prompt
+
+Total: 1
+`;
+    const hits = parseCliSessionsSearchText(raw);
+    expect(hits[0].firstPrompt).toBe(
+      "first line of prompt\nsecond line of prompt",
+    );
+  });
+});
+
+describe("parseCliSessionsSearchJson", () => {
+  it("parses array of camelCase objects", () => {
+    const raw = JSON.stringify([
+      {
+        agentSessionId: "abc-1111",
+        title: "Hello",
+        firstPrompt: "hi there",
+        status: "local",
+      },
+    ]);
+    expect(parseCliSessionsSearchJson(raw)).toEqual([
+      {
+        agentSessionId: "abc-1111",
+        title: "Hello",
+        firstPrompt: "hi there",
+        status: "local",
+        updatedLabel: null,
+      },
+    ]);
+  });
+
+  it("parses { sessions: [...] } with snake_case keys", () => {
+    const raw = JSON.stringify({
+      sessions: [
+        {
+          session_id: "def-2222",
+          summary: "Refactor",
+          first_prompt: "please refactor",
+          updated_at: "2026-07-01",
+        },
+      ],
+    });
+    const hits = parseCliSessionsSearchJson(raw);
+    expect(hits).toHaveLength(1);
+    expect(hits![0]).toMatchObject({
+      agentSessionId: "def-2222",
+      title: "Refactor",
+      firstPrompt: "please refactor",
+      updatedLabel: "2026-07-01",
+    });
+  });
+
+  it("returns null for non-JSON or unrelated JSON", () => {
+    expect(parseCliSessionsSearchJson("not json")).toBeNull();
+    expect(parseCliSessionsSearchJson('{"foo":1}')).toBeNull();
+    expect(parseCliSessionsSearchJson("")).toBeNull();
+  });
+});
+
+describe("parseCliSessionsSearchOutput", () => {
+  it("prefers JSON when valid", () => {
+    const raw = JSON.stringify([
+      { id: "x-1", title: "From JSON", firstPrompt: "q" },
+    ]);
+    const hits = parseCliSessionsSearchOutput(raw);
+    expect(hits[0].title).toBe("From JSON");
+  });
+
+  it("falls back to text parse", () => {
+    const hits = parseCliSessionsSearchOutput(SAMPLE_TEXT);
+    expect(hits).toHaveLength(2);
+  });
+});
+
+describe("looksLikeCliSearchUnsupported", () => {
+  it("detects clap unexpected argument", () => {
+    expect(
+      looksLikeCliSearchUnsupported(
+        "error: unexpected argument '--json' found",
+      ),
+    ).toBe(true);
+    expect(looksLikeCliSearchUnsupported("")).toBe(false);
+    expect(looksLikeCliSearchUnsupported("auth failed")).toBe(false);
+  });
+});
+
+describe("clampCliSessionsSearchLimit", () => {
+  it("clamps to 1..100 with default 40", () => {
+    expect(clampCliSessionsSearchLimit(undefined)).toBe(40);
+    expect(clampCliSessionsSearchLimit(0)).toBe(1);
+    expect(clampCliSessionsSearchLimit(200)).toBe(100);
+    expect(clampCliSessionsSearchLimit(25.9)).toBe(25);
+  });
+});
+
+describe("mergeCliSearchHitsWithLocal", () => {
+  const local = [
+    {
+      agentSessionId: "019f3fc7-485c-7ef1-ba71-624d6c014657",
+      title: "Old title",
+      cwd: "/Users/me/app",
+      dir: "/tmp/sess",
+      numMessages: 3,
+      alreadyLinked: true,
+      appSessionId: "app-1",
+      sourceHome: "/.grok",
+      updatedAt: "2026-01-01",
+    },
+  ];
+
+  it("fills dir / linked from local list and keeps CLI title/prompt", () => {
+    const hits = parseCliSessionsSearchText(SAMPLE_TEXT);
+    const merged = mergeCliSearchHitsWithLocal(hits, local);
+    expect(merged).toHaveLength(2);
+    expect(merged[0].dir).toBe("/tmp/sess");
+    expect(merged[0].alreadyLinked).toBe(true);
+    expect(merged[0].title).toBe("Test Message");
+    expect(merged[0].firstPrompt).toBe("test");
+    // Second hit has no local row
+    expect(merged[1].dir).toBe("");
+    expect(merged[1].alreadyLinked).toBe(false);
+    expect(merged[1].title).toBe("Test Session");
+  });
+});

--- a/src/lib/cliSessionsSearch.ts
+++ b/src/lib/cliSessionsSearch.ts
@@ -1,0 +1,320 @@
+/**
+ * Pure helpers for `grok sessions search` output and CLI session search UI.
+ *
+ * CLI text shape (current grok sessions search):
+ *   <uuid> (local|remote)  <date>
+ *     <summary / title>
+ *     <first prompt…>
+ *   …
+ *   Total: N
+ *
+ * JSON (when CLI adds --json later) is also accepted.
+ */
+
+/** One hit from CLI search or local first-prompt fallback. */
+export type CliSessionSearchHit = {
+  agentSessionId: string;
+  /** Session summary / generated title. */
+  title: string;
+  /** First user prompt snippet when known. */
+  firstPrompt?: string | null;
+  /** CLI status token: local | remote | … */
+  status?: string | null;
+  /** Raw date / time label from CLI text, if present. */
+  updatedLabel?: string | null;
+};
+
+const SESSION_ID_RE =
+  /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i;
+
+/**
+ * Parse human-readable `grok sessions search` stdout into hits.
+ * Tolerant of warnings / blank lines / missing body lines.
+ */
+export function parseCliSessionsSearchText(raw: string): CliSessionSearchHit[] {
+  const text = (raw ?? "").replace(/\r\n/g, "\n");
+  if (!text.trim()) return [];
+
+  const hits: CliSessionSearchHit[] = [];
+  let current: {
+    agentSessionId: string;
+    status: string | null;
+    updatedLabel: string | null;
+    body: string[];
+  } | null = null;
+
+  const flush = () => {
+    if (!current) return;
+    const body = current.body.map((l) => l.trim()).filter(Boolean);
+    const title = body[0] || `CLI ${current.agentSessionId.slice(0, 8)}`;
+    const firstPrompt = body.length > 1 ? body.slice(1).join("\n") : null;
+    hits.push({
+      agentSessionId: current.agentSessionId,
+      title,
+      firstPrompt,
+      status: current.status,
+      updatedLabel: current.updatedLabel,
+    });
+    current = null;
+  };
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // Footer
+    if (/^total:\s*\d+/i.test(trimmed)) {
+      flush();
+      break;
+    }
+    // Skip common warning banners that appear on stdout/stderr mixed.
+    if (/^warning:/i.test(trimmed) || /^error:/i.test(trimmed)) {
+      continue;
+    }
+
+    const idMatch = SESSION_ID_RE.exec(trimmed);
+    // Header lines start at column 0 (no indent). Indented lines are body.
+    const isIndented = /^\s{2,}/.test(line);
+    if (idMatch && !isIndented) {
+      flush();
+      const id = idMatch[1];
+      const rest = trimmed.slice(idMatch[0].length).trim();
+      let status: string | null = null;
+      let updatedLabel: string | null = null;
+      const statusMatch = /^\(([^)]+)\)\s*(.*)$/.exec(rest);
+      if (statusMatch) {
+        status = statusMatch[1].trim() || null;
+        updatedLabel = statusMatch[2].trim() || null;
+      } else if (rest) {
+        updatedLabel = rest;
+      }
+      current = {
+        agentSessionId: id,
+        status,
+        updatedLabel,
+        body: [],
+      };
+      continue;
+    }
+
+    if (current && isIndented) {
+      // Strip leading indent only.
+      current.body.push(line.replace(/^\s{2,}/, ""));
+      continue;
+    }
+
+    // Continuation of first prompt without indent (rare wrap) — attach when we
+    // already have a title line so we do not swallow the next header.
+    if (current && current.body.length >= 1 && !SESSION_ID_RE.test(trimmed)) {
+      current.body.push(trimmed);
+    }
+  }
+  flush();
+  return hits;
+}
+
+/**
+ * Parse JSON `grok sessions search --json` when available.
+ * Accepts an array, `{ sessions|results|items: [...] }`, or a single object.
+ * Returns null when the blob is not JSON session-search data.
+ */
+export function parseCliSessionsSearchJson(
+  raw: string,
+): CliSessionSearchHit[] | null {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed || (!trimmed.startsWith("{") && !trimmed.startsWith("["))) {
+    return null;
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  const rows = normalizeJsonRows(data);
+  if (rows === null) return null;
+
+  const out: CliSessionSearchHit[] = [];
+  for (const row of rows) {
+    if (!row || typeof row !== "object") continue;
+    const o = row as Record<string, unknown>;
+    const id = pickString(o, [
+      "agentSessionId",
+      "agent_session_id",
+      "sessionId",
+      "session_id",
+      "id",
+    ]);
+    if (!id) continue;
+    const title =
+      pickString(o, [
+        "title",
+        "summary",
+        "generatedTitle",
+        "generated_title",
+        "sessionSummary",
+        "session_summary",
+      ]) || `CLI ${id.slice(0, 8)}`;
+    const firstPrompt = pickString(o, [
+      "firstPrompt",
+      "first_prompt",
+      "prompt",
+      "firstUserPrompt",
+      "first_user_prompt",
+    ]);
+    const status = pickString(o, ["status", "location", "source"]);
+    const updatedLabel = pickString(o, [
+      "updatedLabel",
+      "updatedAt",
+      "updated_at",
+      "updated",
+      "lastActiveAt",
+      "last_active_at",
+    ]);
+    out.push({
+      agentSessionId: id,
+      title,
+      firstPrompt,
+      status,
+      updatedLabel,
+    });
+  }
+  return out;
+}
+
+function normalizeJsonRows(data: unknown): unknown[] | null {
+  if (Array.isArray(data)) return data;
+  if (!data || typeof data !== "object") return null;
+  const o = data as Record<string, unknown>;
+  for (const key of ["sessions", "results", "items", "data", "hits"]) {
+    if (Array.isArray(o[key])) return o[key] as unknown[];
+  }
+  // Single session object
+  if (
+    pickString(o, [
+      "agentSessionId",
+      "agent_session_id",
+      "sessionId",
+      "session_id",
+      "id",
+    ])
+  ) {
+    return [o];
+  }
+  return null;
+}
+
+function pickString(
+  o: Record<string, unknown>,
+  keys: string[],
+): string | null {
+  for (const k of keys) {
+    const v = o[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return null;
+}
+
+/**
+ * Prefer JSON when stdout looks like JSON; otherwise parse text.
+ */
+export function parseCliSessionsSearchOutput(raw: string): CliSessionSearchHit[] {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    const json = parseCliSessionsSearchJson(trimmed);
+    if (json) return json;
+  }
+  return parseCliSessionsSearchText(trimmed);
+}
+
+/**
+ * Detect CLI clap errors that mean `--json` (or the whole search subcommand)
+ * is not supported — so the host can retry without the flag or fall back.
+ */
+export function looksLikeCliSearchUnsupported(stderr: string): boolean {
+  const s = (stderr ?? "").toLowerCase();
+  return (
+    s.includes("unexpected argument") ||
+    s.includes("unrecognized option") ||
+    s.includes("unknown flag") ||
+    s.includes("unknown option") ||
+    s.includes("invalid option") ||
+    s.includes("unrecognized subcommand") ||
+    s.includes("unexpected subcommand")
+  );
+}
+
+/**
+ * Clamp search limit for host / UI (1–100, default 40).
+ */
+export function clampCliSessionsSearchLimit(
+  limit: number | null | undefined,
+  fallback = 40,
+): number {
+  const n = typeof limit === "number" && Number.isFinite(limit) ? limit : fallback;
+  return Math.max(1, Math.min(100, Math.floor(n)));
+}
+
+/**
+ * Merge CLI search hits with local list rows so import/delete still have `dir`.
+ * Preserves CLI hit order. Local-only fields fill gaps.
+ */
+export function mergeCliSearchHitsWithLocal<
+  T extends {
+    agentSessionId: string;
+    title: string;
+    cwd?: string | null;
+    dir?: string;
+    numMessages?: number;
+    alreadyLinked?: boolean;
+    appSessionId?: string | null;
+    sourceHome?: string;
+    updatedAt?: string;
+  },
+>(
+  hits: CliSessionSearchHit[],
+  local: T[],
+): Array<
+  T & {
+    title: string;
+    firstPrompt?: string | null;
+    status?: string | null;
+    fromCliSearch: true;
+  }
+> {
+  const byId = new Map(local.map((r) => [r.agentSessionId, r]));
+  return hits.map((h) => {
+    const loc = byId.get(h.agentSessionId);
+    if (loc) {
+      return {
+        ...loc,
+        title: h.title || loc.title,
+        firstPrompt: h.firstPrompt ?? null,
+        status: h.status ?? null,
+        fromCliSearch: true as const,
+      };
+    }
+    // Synthetic row for remote-only / not-yet-listed hits.
+    const synthetic = {
+      agentSessionId: h.agentSessionId,
+      title: h.title,
+      cwd: null,
+      dir: "",
+      numMessages: 0,
+      alreadyLinked: false,
+      appSessionId: null,
+      sourceHome: "",
+      updatedAt: h.updatedLabel ?? "",
+      firstPrompt: h.firstPrompt ?? null,
+      status: h.status ?? null,
+      fromCliSearch: true as const,
+    } as unknown as T & {
+      title: string;
+      firstPrompt?: string | null;
+      status?: string | null;
+      fromCliSearch: true;
+    };
+    return synthetic;
+  });
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -618,6 +618,8 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "settings.cliSessionsImportOpen",
       "settings.cliSessionsDelete",
       "settings.cliSessionsDeleteUnlinked",
+      "settings.cliSessionsFilterPlaceholder",
+      "settings.cliSessionsSearchViaCli",
     ],
     keywords: [
       "cli sessions",
@@ -625,9 +627,13 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "agent session id",
       "resume",
       "delete session",
+      "search sessions",
+      "first prompt",
       "CLI 会话",
       "导入会话",
       "删除会话",
+      "搜索会话",
+      "首条提示",
     ],
   },
   {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6078,6 +6078,23 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
   -webkit-appearance: none;
 }
 
+.settings-cli-sessions__search-note {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  line-height: 1.35;
+}
+
+.settings-cli-sessions__prompt {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.35;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}
+
 .settings-cli-sessions__list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary

- **Host `cli_sessions_search(query, limit?)`**: runs `grok sessions search` under active `GROK_HOME` (tries `--json`, falls back to text parse of summaries + first prompts), enriches hits with local dir / linked / app session for import·open·delete
- **Local fallback** when CLI is missing or fails: disk filter on title, id, cwd, and first user prompt from `chat_history.jsonl`
- **Settings → CLI sessions**: search box always visible; non-empty query debounces to host search; shows first-prompt snippet; keeps existing import / open / delete
- Pure TS helpers + tests (`cliSessionsSearch`); Rust parsers + unit tests; i18n (en / zh / zh-TW); CHANGELOG

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test -- src/lib/cliSessionsSearch.test.ts src/lib/cliSessionsFilter.test.ts src/i18n/messages.test.ts`
- [x] `cargo test --lib cli_sessions::tests` (12 passed)
- [ ] Manual: Settings → Agent → CLI sessions — type a keyword that matches a first prompt; confirm CLI note + results
- [ ] Manual: with CLI unavailable / no binary — local fallback note and list filter still work
- [ ] Manual: import / open / delete still work on search hits that have a local dir