### PR TITLE
feat(context): compact dialog presets + before/after estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ See `docs/llm-wiki/release.md`.
 - **Session change review**: per-file +/−, unified / side-by-side diff, open in Resources, j/k in Changes list; chip always opens Changes tab (works without git)
 - **Structured JSON replies**: when a session JSON Schema is active, finished assistant turns show a Structured panel — parse + light required-field validation, honest “not valid JSON” on failure, copy / export, and a Structured badge
 - **Context usage / cost estimates**: chip menu shows input/output/total when known; optional crude USD estimate from a static rates table (never invoice-grade); Settings → Appearance → **Show usage estimates** (on by default, with disclaimer)
+- **Compact dialog presets** (light / standard / aggressive): note templates for `/compact` (CLI has no intensity flag yet); optional keep-note + chips; before → after estimate when tokens known; last compact range when available
 
 #### Sessions & sidebar
 - **Duplicate chat** (vs **Fork…** + optional worktree) · **session notes** · **mute** · **unread dot**
@@ -63,7 +64,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 新增（按域）**
 
-- **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片、会话变更审阅（+/− · 并排 diff · j/k）、结构化 JSON 回复面板（校验/复制/导出）、上下文用量/费用粗估
+- **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片、会话变更审阅（+/− · 并排 diff · j/k）、结构化 JSON 回复面板（校验/复制/导出）、上下文用量/费用粗估、压缩对话框强度预设（轻/标/激 · 备注模板 · 前后估值）
 - **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、会话规则（`--rules`）、会话最大轮次（`--max-turns` 覆盖；空/0 继承全局）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标、快捷键冲突面板（录制警告 + 重置冲突项）
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,10 +191,17 @@ import { StreamCoalescer } from "@/lib/streamCoalesce";
 import { UiErrorBoundary } from "@/components/UiErrorBoundary";
 import {
   buildCompactSlashCommand,
+  COMPACT_PRESET_IDS,
+  DEFAULT_COMPACT_PRESET,
+  estimateCompactAfterTokens,
+  formatCompactBeforeAfterRange,
+  formatTokenCount,
   INITIAL_CONTEXT_USAGE,
   mergeCompactTokensBefore,
   reduceContextUsage,
+  resolveCompactNoteBody,
   resolveContextUsageDisplay,
+  type CompactPresetId,
   type ContextUsageState,
 } from "@/lib/contextUsage";
 import { ContextUsageChip } from "@/components/ContextUsageChip";
@@ -1269,6 +1276,9 @@ export default function App() {
   const [showMcpModal, setShowMcpModal] = useState(false);
   const [showCompactModal, setShowCompactModal] = useState(false);
   const [compactNote, setCompactNote] = useState("");
+  /** light / standard / aggressive — seeds note templates (CLI has no intensity flag). */
+  const [compactPreset, setCompactPreset] =
+    useState<CompactPresetId>(DEFAULT_COMPACT_PRESET);
   const compactNoteRef = useRef<HTMLInputElement>(null);
   /**
    * UI estimate of tokens-before captured when the user confirms manual compact.
@@ -7106,13 +7116,27 @@ export default function App() {
   };
 
   /**
-   * `/compact [note]` — richer compact dialog (current usage + optional keep-note).
+   * `/compact [note]` — richer compact dialog:
+   * presets (light/standard/aggressive as note templates; CLI has no intensity flag),
+   * optional keep-note, current usage + honest after estimate when tokens known.
    * Empty note → `/compact`; non-empty → `/compact {note}`.
    * Never uses window.prompt (unreliable in Tauri WebView).
    */
   const openCompactWithNote = () => {
-    setCompactNote("");
+    setCompactPreset(DEFAULT_COMPACT_PRESET);
+    setCompactNote(tr("slash.compactPresetNote.standard"));
     setShowCompactModal(true);
+  };
+
+  const compactPresetNote = (id: CompactPresetId): string => {
+    if (id === "light") return tr("slash.compactPresetNote.light");
+    if (id === "aggressive") return tr("slash.compactPresetNote.aggressive");
+    return tr("slash.compactPresetNote.standard");
+  };
+
+  const selectCompactPreset = (id: CompactPresetId) => {
+    setCompactPreset(id);
+    setCompactNote(compactPresetNote(id));
   };
 
   const attachLabels = useMemo(
@@ -18048,6 +18072,7 @@ export default function App() {
           onClick={() => {
             setShowCompactModal(false);
             setCompactNote("");
+            setCompactPreset(DEFAULT_COMPACT_PRESET);
           }}
         >
           <form
@@ -18064,12 +18089,17 @@ export default function App() {
               ) {
                 return;
               }
-              const note = compactNote;
+              const note = resolveCompactNoteBody(
+                compactNote,
+                compactPresetNote(compactPreset),
+              );
               const uiBefore = contextUsageDisplay.tokens;
+              const preset = compactPreset;
               setShowCompactModal(false);
               setCompactNote("");
+              setCompactPreset(DEFAULT_COMPACT_PRESET);
               void (async () => {
-                const cmd = buildCompactSlashCommand(note);
+                const cmd = buildCompactSlashCommand(note, { preset });
                 try {
                   const sid = await ensureConnected();
                   if (!sid) return;
@@ -18099,6 +18129,7 @@ export default function App() {
                 onClick={() => {
                   setShowCompactModal(false);
                   setCompactNote("");
+                  setCompactPreset(DEFAULT_COMPACT_PRESET);
                 }}
                 aria-label={tr("common.close")}
               >
@@ -18108,29 +18139,131 @@ export default function App() {
             <p className="compact-modal__msg">
               {tr("slash.compactExplain")}
             </p>
+            <div
+              className="compact-modal__presets"
+              role="radiogroup"
+              aria-label={tr("slash.compactPresets")}
+            >
+              {COMPACT_PRESET_IDS.map((id) => {
+                const labelKey =
+                  id === "light"
+                    ? "slash.compactPreset.light"
+                    : id === "aggressive"
+                      ? "slash.compactPreset.aggressive"
+                      : "slash.compactPreset.standard";
+                const hintKey =
+                  id === "light"
+                    ? "slash.compactPresetHint.light"
+                    : id === "aggressive"
+                      ? "slash.compactPresetHint.aggressive"
+                      : "slash.compactPresetHint.standard";
+                const active = compactPreset === id;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    className={
+                      "compact-modal__preset" + (active ? " is-active" : "")
+                    }
+                    title={tr(hintKey)}
+                    onClick={() => selectCompactPreset(id)}
+                  >
+                    <span className="compact-modal__preset-label">
+                      {tr(labelKey)}
+                    </span>
+                    <span className="compact-modal__preset-hint">
+                      {tr(hintKey)}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="compact-modal__hint compact-modal__hint--presets">
+              {tr("slash.compactPresetCliNote")}
+            </p>
             <div className="compact-modal__usage" aria-live="polite">
-              <span className="compact-modal__usage-k">
-                {tr("slash.compactCurrent")}
-              </span>
-              <span className="compact-modal__usage-v">
-                <span className="compact-modal__usage-tokens">
-                  {contextUsageDisplay.tokens != null
-                    ? contextUsageDisplay.label
-                    : tr("slash.compactCurrentUnknown")}
+              <div className="compact-modal__usage-row">
+                <span className="compact-modal__usage-k">
+                  {tr("slash.compactBefore")}
                 </span>
-                {contextUsageDisplay.tokens != null ? (
-                  <span className="compact-modal__usage-src">
-                    {contextUsageDisplay.source === "known"
-                      ? tr("context.sourceKnown")
-                      : contextUsageDisplay.source === "estimated"
-                        ? tr("context.sourceEstimated")
-                        : tr("context.sourceUnknown")}
+                <span className="compact-modal__usage-v">
+                  <span className="compact-modal__usage-tokens">
+                    {contextUsageDisplay.tokens != null
+                      ? contextUsageDisplay.label
+                      : tr("slash.compactCurrentUnknown")}
                   </span>
-                ) : null}
-              </span>
+                  {contextUsageDisplay.tokens != null ? (
+                    <span className="compact-modal__usage-src">
+                      {contextUsageDisplay.source === "known"
+                        ? tr("context.sourceKnown")
+                        : contextUsageDisplay.source === "estimated"
+                          ? tr("context.sourceEstimated")
+                          : tr("context.sourceUnknown")}
+                    </span>
+                  ) : null}
+                </span>
+              </div>
+              {(() => {
+                const afterEst = estimateCompactAfterTokens(
+                  contextUsageDisplay.tokens,
+                  compactPreset,
+                );
+                if (afterEst == null) {
+                  return (
+                    <div className="compact-modal__usage-row">
+                      <span className="compact-modal__usage-k">
+                        {tr("slash.compactAfterEst")}
+                      </span>
+                      <span className="compact-modal__usage-v">
+                        <span className="compact-modal__usage-tokens">
+                          {tr("slash.compactAfterUnknown")}
+                        </span>
+                      </span>
+                    </div>
+                  );
+                }
+                return (
+                  <div className="compact-modal__usage-row">
+                    <span className="compact-modal__usage-k">
+                      {tr("slash.compactAfterEst")}
+                    </span>
+                    <span className="compact-modal__usage-v">
+                      <span className="compact-modal__usage-tokens">
+                        ~{formatTokenCount(afterEst, locale)}
+                      </span>
+                      <span className="compact-modal__usage-src">
+                        {tr("context.sourceEstimated")}
+                      </span>
+                    </span>
+                  </div>
+                );
+              })()}
+              {contextUsageDisplay.lastCompact &&
+              (contextUsageDisplay.lastCompact.tokensBefore != null ||
+                contextUsageDisplay.lastCompact.tokensAfter != null) ? (
+                <div className="compact-modal__usage-row compact-modal__usage-row--last">
+                  <span className="compact-modal__usage-k">
+                    {tr("context.lastCompact")}
+                  </span>
+                  <span className="compact-modal__usage-v">
+                    <span className="compact-modal__usage-tokens">
+                      {formatCompactBeforeAfterRange(
+                        contextUsageDisplay.lastCompact.tokensBefore,
+                        contextUsageDisplay.lastCompact.tokensAfter,
+                        {
+                          locale,
+                          template: tr("compact.tokensRange"),
+                        },
+                      ) ?? tr("context.lastCompactNone")}
+                    </span>
+                  </span>
+                </div>
+              ) : null}
             </div>
             <p className="compact-modal__hint">
-              {tr("slash.compactNoteHint")}
+              {tr("slash.compactEstimateHint")}
             </p>
             <label className="compact-modal__field-label" htmlFor="compact-note">
               {tr("slash.compactNote")}
@@ -18192,6 +18325,7 @@ export default function App() {
                 onClick={() => {
                   setShowCompactModal(false);
                   setCompactNote("");
+                  setCompactPreset(DEFAULT_COMPACT_PRESET);
                 }}
               >
                 {tr("slash.compactConfirmCancel")}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2198,6 +2198,26 @@ const en = {
   "slash.compactNoteChipErrors": "Recent errors",
   "slash.compactNoteChipFiles": "Open files & paths",
   "slash.compactNoteChipTodos": "Open TODOs",
+  "slash.compactPresets": "Compact intensity",
+  "slash.compactPreset.light": "Light",
+  "slash.compactPreset.standard": "Standard",
+  "slash.compactPreset.aggressive": "Aggressive",
+  "slash.compactPresetHint.light": "Keep more detail; compress tool dumps",
+  "slash.compactPresetHint.standard": "Balanced summary of the session",
+  "slash.compactPresetHint.aggressive": "Max free space; essentials only",
+  "slash.compactPresetNote.light":
+    "Light compact: keep detailed decisions, open files, recent errors, and open TODOs; only compress verbose tool dumps and repeated exploration.",
+  "slash.compactPresetNote.standard":
+    "Standard compact: keep key decisions, the current task, open files/paths, and open TODOs.",
+  "slash.compactPresetNote.aggressive":
+    "Aggressive compact: keep only the current goal and essential decisions/paths; drop intermediate exploration and tool noise.",
+  "slash.compactPresetCliNote":
+    "CLI has no intensity flag yet — presets send note templates with /compact.",
+  "slash.compactBefore": "Before",
+  "slash.compactAfterEst": "After (est.)",
+  "slash.compactAfterUnknown": "Unknown until usage is known",
+  "slash.compactEstimateHint":
+    "After estimate is a rough keep-ratio guess for the selected preset (~), not the model’s tokenizer. Host chat history is not rewritten.",
   "compact.bannerAuto": "Context auto-compacted",
   "compact.bannerManual": "Context compacted",
   "compact.tokensRange": "{before} → {after} tokens",
@@ -5165,6 +5185,26 @@ const zh: Record<MessageKey, string> = {
   "slash.compactNoteChipErrors": "最近错误",
   "slash.compactNoteChipFiles": "打开的文件与路径",
   "slash.compactNoteChipTodos": "未完成待办",
+  "slash.compactPresets": "压缩强度",
+  "slash.compactPreset.light": "轻度",
+  "slash.compactPreset.standard": "标准",
+  "slash.compactPreset.aggressive": "激进",
+  "slash.compactPresetHint.light": "保留更多细节；主要压缩工具输出",
+  "slash.compactPresetHint.standard": "均衡摘要当前会话",
+  "slash.compactPresetHint.aggressive": "尽量腾空间；只留要点",
+  "slash.compactPresetNote.light":
+    "轻度压缩：保留详细决策、打开的文件、最近错误与未完成待办；主要压缩冗长工具输出与重复探索。",
+  "slash.compactPresetNote.standard":
+    "标准压缩：保留关键决策、当前任务、打开的文件/路径与未完成待办。",
+  "slash.compactPresetNote.aggressive":
+    "激进压缩：只保留当前目标与必要决策/路径；丢弃中间探索与工具噪声。",
+  "slash.compactPresetCliNote":
+    "CLI 尚无强度参数 — 预设会以备注模板随 /compact 发给代理。",
+  "slash.compactBefore": "压缩前",
+  "slash.compactAfterEst": "压缩后（估）",
+  "slash.compactAfterUnknown": "用量未知时无法估算",
+  "slash.compactEstimateHint":
+    "压缩后估值为所选预设的粗略保留比例（~），非模型精确分词。应用内聊天记录不会被改写。",
   "compact.bannerAuto": "上下文已自动压缩",
   "compact.bannerManual": "上下文已压缩",
   "compact.tokensRange": "{before} → {after} tokens",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2110,6 +2110,26 @@ export const zhTW: Record<MessageKey, string> = {
   "slash.compactNoteChipErrors": "最近錯誤",
   "slash.compactNoteChipFiles": "開啟的檔案與路徑",
   "slash.compactNoteChipTodos": "未完成待辦",
+  "slash.compactPresets": "壓縮強度",
+  "slash.compactPreset.light": "輕度",
+  "slash.compactPreset.standard": "標準",
+  "slash.compactPreset.aggressive": "激進",
+  "slash.compactPresetHint.light": "保留更多細節；主要壓縮工具輸出",
+  "slash.compactPresetHint.standard": "均衡摘要目前對話",
+  "slash.compactPresetHint.aggressive": "盡量騰空間；只留要點",
+  "slash.compactPresetNote.light":
+    "輕度壓縮：保留詳細決策、開啟的檔案、最近錯誤與未完成待辦；主要壓縮冗長工具輸出與重複探索。",
+  "slash.compactPresetNote.standard":
+    "標準壓縮：保留關鍵決策、目前任務、開啟的檔案/路徑與未完成待辦。",
+  "slash.compactPresetNote.aggressive":
+    "激進壓縮：只保留目前目標與必要決策/路徑；丟棄中間探索與工具雜訊。",
+  "slash.compactPresetCliNote":
+    "CLI 尚無強度參數 — 預設會以備註模板隨 /compact 傳給代理。",
+  "slash.compactBefore": "壓縮前",
+  "slash.compactAfterEst": "壓縮後（估）",
+  "slash.compactAfterUnknown": "用量未知時無法估算",
+  "slash.compactEstimateHint":
+    "壓縮後估值為所選預設的粗略保留比例（~），非模型精確分詞。應用內聊天紀錄不會被改寫。",
   "compact.bannerAuto": "上下文已自動壓縮",
   "compact.bannerManual": "上下文已壓縮",
   "compact.tokensRange": "{before} → {after} tokens",

--- a/src/lib/contextUsage.test.ts
+++ b/src/lib/contextUsage.test.ts
@@ -1,18 +1,25 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCompactSlashCommand,
+  COMPACT_PRESET_CLI_INTENSITY,
+  COMPACT_PRESET_IDS,
+  DEFAULT_COMPACT_PRESET,
+  estimateCompactAfterTokens,
   estimateContextBreakdown,
   estimateTokensFromMessages,
   estimateTokensFromText,
+  formatCompactBeforeAfterRange,
   formatContextChipLabel,
   formatTokenCount,
   hydrateContextUsageFromMessages,
   INITIAL_CONTEXT_USAGE,
+  isCompactPresetId,
   isSystemLikeMessage,
   isToolActivityMessage,
   mergeCompactTokensBefore,
   mergeKnownBucketsIntoBreakdown,
   reduceContextUsage,
+  resolveCompactNoteBody,
   resolveContextUsageDisplay,
 } from "./contextUsage";
 
@@ -526,5 +533,76 @@ describe("buildCompactSlashCommand", () => {
     expect(buildCompactSlashCommand(" keep decisions ")).toBe(
       "/compact keep decisions",
     );
+  });
+
+  it("does not emit intensity flags while CLI support is off", () => {
+    expect(COMPACT_PRESET_CLI_INTENSITY).toBe(false);
+    expect(
+      buildCompactSlashCommand("keep auth", { preset: "aggressive" }),
+    ).toBe("/compact keep auth");
+    expect(buildCompactSlashCommand("", { preset: "light" })).toBe(
+      "/compact",
+    );
+  });
+});
+
+describe("compact presets", () => {
+  it("exposes light / standard / aggressive with standard default", () => {
+    expect(COMPACT_PRESET_IDS).toEqual(["light", "standard", "aggressive"]);
+    expect(DEFAULT_COMPACT_PRESET).toBe("standard");
+    expect(isCompactPresetId("light")).toBe(true);
+    expect(isCompactPresetId("standard")).toBe(true);
+    expect(isCompactPresetId("aggressive")).toBe(true);
+    expect(isCompactPresetId("heavy")).toBe(false);
+    expect(isCompactPresetId("")).toBe(false);
+  });
+
+  it("estimates after tokens with honest keep ratios (aggressive < standard < light)", () => {
+    expect(estimateCompactAfterTokens(null, "standard")).toBeNull();
+    expect(estimateCompactAfterTokens(0, "standard")).toBeNull();
+    expect(estimateCompactAfterTokens(-10, "light")).toBeNull();
+    const light = estimateCompactAfterTokens(100_000, "light")!;
+    const standard = estimateCompactAfterTokens(100_000, "standard")!;
+    const aggressive = estimateCompactAfterTokens(100_000, "aggressive")!;
+    expect(aggressive).toBeLessThan(standard);
+    expect(standard).toBeLessThan(light);
+    expect(light).toBe(55_000);
+    expect(standard).toBe(35_000);
+    expect(aggressive).toBe(15_000);
+    // Tiny contexts still yield at least 1 token estimate.
+    expect(estimateCompactAfterTokens(1, "aggressive")).toBe(1);
+  });
+
+  it("resolveCompactNoteBody prefers field text over preset template", () => {
+    expect(resolveCompactNoteBody("", "template keep")).toBe("template keep");
+    expect(resolveCompactNoteBody("  custom  ", "template keep")).toBe(
+      "custom",
+    );
+    expect(resolveCompactNoteBody("   ", "  ")).toBe("");
+    expect(resolveCompactNoteBody("", null)).toBe("");
+  });
+
+  it("formatCompactBeforeAfterRange fills template with ~ for estimates", () => {
+    expect(
+      formatCompactBeforeAfterRange(12_000, 4_000, {
+        beforeEstimated: true,
+        afterEstimated: true,
+        locale: "en",
+        template: "{before} → {after}",
+      }),
+    ).toBe("~1.2万 → ~4千");
+    expect(
+      formatCompactBeforeAfterRange(10_000, null, {
+        beforeEstimated: false,
+        afterEstimated: true,
+        locale: "zh",
+        template: "{before} → {after}",
+      }),
+    ).toBe("1万 → —");
+    expect(
+      formatCompactBeforeAfterRange(null, null, {
+        template: "{before} → {after}",
+      }),
+    ).toBeNull();
   });
 });

--- a/src/lib/contextUsage.ts
+++ b/src/lib/contextUsage.ts
@@ -638,8 +638,124 @@ export function mergeCompactTokensBefore(
   return finiteToken(uiTokensBefore);
 }
 
-/** Build `/compact` slash command; empty/whitespace note → bare `/compact`. */
-export function buildCompactSlashCommand(note: string): string {
+/**
+ * Compact intensity presets in the App dialog.
+ * Grok Build CLI only accepts `/compact [note]` today — no light/standard/
+ * aggressive flag — so presets seed **note templates** for the agent.
+ * When CLI gains intensity flags, flip {@link COMPACT_PRESET_CLI_INTENSITY}.
+ */
+export type CompactPresetId = "light" | "standard" | "aggressive";
+
+export const COMPACT_PRESET_IDS: readonly CompactPresetId[] = [
+  "light",
+  "standard",
+  "aggressive",
+] as const;
+
+export const DEFAULT_COMPACT_PRESET: CompactPresetId = "standard";
+
+/**
+ * When true, {@link buildCompactSlashCommand} would emit a CLI intensity flag.
+ * Kept false until Grok Build documents `/compact --intensity=…` (or similar).
+ */
+export const COMPACT_PRESET_CLI_INTENSITY = false;
+
+/**
+ * Rough keep-ratio for **honest** after-estimate in the dialog only.
+ * Not model-grade; labels always show `~` so users know it is a guess.
+ */
+export const COMPACT_PRESET_KEEP_RATIO: Record<CompactPresetId, number> = {
+  light: 0.55,
+  standard: 0.35,
+  aggressive: 0.15,
+};
+
+export function isCompactPresetId(value: unknown): value is CompactPresetId {
+  return (
+    value === "light" || value === "standard" || value === "aggressive"
+  );
+}
+
+/**
+ * Project tokens after a manual compact from current size + preset.
+ * Returns null when before is unknown/invalid (dialog shows unknown).
+ */
+export function estimateCompactAfterTokens(
+  beforeTokens: number | null | undefined,
+  preset: CompactPresetId = DEFAULT_COMPACT_PRESET,
+): number | null {
+  const before = finiteToken(beforeTokens);
+  if (before == null || before <= 0) return null;
+  const ratio = COMPACT_PRESET_KEEP_RATIO[preset] ?? COMPACT_PRESET_KEEP_RATIO.standard;
+  return Math.max(1, Math.floor(before * ratio));
+}
+
+/**
+ * Combine optional preset note template with free-form keep note.
+ * Custom text wins over the template when both are set and the custom field
+ * is not exactly the template (user edited). Prefer calling with the current
+ * field value; App seeds the field from the template on preset change.
+ */
+export function resolveCompactNoteBody(
+  fieldNote: string,
+  presetNoteTemplate: string | null | undefined,
+): string {
+  const field = fieldNote.trim();
+  if (field) return field;
+  const preset = (presetNoteTemplate ?? "").trim();
+  return preset;
+}
+
+/**
+ * Build `/compact` slash command; empty/whitespace note → bare `/compact`.
+ * When {@link COMPACT_PRESET_CLI_INTENSITY} is true and a preset is given,
+ * appends `intensity=<id>` so the agent/CLI can prefer a level; today that
+ * flag is off and the note alone carries light/standard/aggressive intent.
+ */
+export function buildCompactSlashCommand(
+  note: string,
+  opts?: { preset?: CompactPresetId | null },
+): string {
   const n = note.trim();
+  if (
+    COMPACT_PRESET_CLI_INTENSITY &&
+    opts?.preset &&
+    isCompactPresetId(opts.preset)
+  ) {
+    const flag = `intensity=${opts.preset}`;
+    return n ? `/compact ${flag} ${n}` : `/compact ${flag}`;
+  }
   return n ? `/compact ${n}` : "/compact";
+}
+
+/**
+ * Format before → after range for the compact dialog (and banners).
+ * Uses `~` on either side when that side is an estimate.
+ * Returns null when both sides are unknown.
+ */
+export function formatCompactBeforeAfterRange(
+  before: number | null | undefined,
+  after: number | null | undefined,
+  opts: {
+    beforeEstimated?: boolean;
+    afterEstimated?: boolean;
+    locale?: string;
+    template: string;
+  },
+): string | null {
+  const b = finiteToken(before);
+  const a = finiteToken(after);
+  if (b == null && a == null) return null;
+  const locale = opts.locale ?? "zh";
+  const fmt = (n: number, estimated: boolean) => {
+    const s = formatTokenCount(n, locale);
+    return estimated ? `~${s}` : s;
+  };
+  const beforeLabel =
+    b != null ? fmt(b, !!opts.beforeEstimated) : "—";
+  const afterLabel =
+    a != null ? fmt(a, !!opts.afterEstimated) : "—";
+  return opts.template
+    .replace("{before}", beforeLabel)
+    .replace("{after}", afterLabel);
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16698,7 +16698,7 @@ div.composer__input:empty::before {
 
 /* Compact confirm */
 .compact-modal {
-  width: min(var(--modal-width-sm, 420px), 100%);
+  width: min(var(--modal-width-md, 480px), 100%);
   gap: var(--modal-gap, 16px);
 }
 
@@ -16709,15 +16709,80 @@ div.composer__input:empty::before {
   line-height: 1.5;
 }
 
+.compact-modal__presets {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.compact-modal__preset {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  margin: 0;
+  padding: 10px 10px 9px;
+  border-radius: var(--menu-item-radius, 8px);
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+  min-width: 0;
+}
+
+.compact-modal__preset:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.compact-modal__preset.is-active {
+  border-color: color-mix(in srgb, var(--text-primary) 28%, var(--border-subtle));
+  background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+  color: var(--text-primary);
+}
+
+.compact-modal__preset-label {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.compact-modal__preset-hint {
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--text-tertiary, var(--text-secondary));
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.compact-modal__preset.is-active .compact-modal__preset-hint {
+  color: color-mix(in srgb, var(--text-primary) 72%, var(--text-secondary));
+}
+
 .compact-modal__usage {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
+  flex-direction: column;
+  gap: 8px;
   padding: 10px 12px;
   border-radius: var(--menu-item-radius, 8px);
   border: 1px solid var(--border-subtle);
   background: color-mix(in srgb, var(--bg-code) 55%, transparent);
+}
+
+.compact-modal__usage-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.compact-modal__usage-row--range .compact-modal__usage-tokens,
+.compact-modal__usage-row--last .compact-modal__usage-tokens {
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .compact-modal__usage-k {
@@ -16751,6 +16816,10 @@ div.composer__input:empty::before {
   font-size: 12px;
   line-height: 1.45;
   color: var(--text-tertiary, var(--text-secondary));
+}
+
+.compact-modal__hint--presets {
+  margin-top: -6px;
 }
 
 .compact-modal__field-label {


### PR DESCRIPTION
## Summary
- **Compact intensity presets** (light / standard / aggressive) in the `/compact` dialog
- CLI has **no intensity flag** today → presets seed **note templates** sent as `/compact {note}` (ready for a future CLI flag via `COMPACT_PRESET_CLI_INTENSITY`)
- Optional keep-note field (prefilled from preset; chips still replace/toggle)
- **Before** context tokens + **After (est.)** using honest keep-ratio (~55% / ~35% / ~15%) when usage is known
- Shows **last compact** before→after range when the agent previously reported it
- Pure helpers + unit tests; i18n en / zh / zh-TW; CHANGELOG

## Test plan
- [ ] Open Compact from context chip (idle session) — see Light / Standard / Aggressive cards
- [ ] Standard selected by default; note field prefilled with standard template
- [ ] Switching preset updates the note template and ~after estimate
- [ ] With known/estimated tokens, Before shows current label; After shows `~` estimate
- [ ] With unknown tokens, After shows unknown copy
- [ ] If last compact had token counts, dialog shows last range
- [ ] Empty note still sends `/compact`; custom note / chip sends `/compact {note}`
- [ ] Streaming/awaiting permission: Compact disabled + busy hint
- [ ] `pnpm typecheck` + `vitest run src/lib/contextUsage.test.ts src/i18n/messages.test.ts`