### PR TITLE
feat(shortcuts): tag scopes global vs chat-focus in Keyboard settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ See `docs/llm-wiki/release.md`.
 - **Theme schedule** (System + clock) · **follow system language**
 - **Confirm quit while busy** (in-app dialog; optional skip) · **dock/tray busy badge**
 - **Shortcut conflicts** (Settings → Keyboard): panel lists chords shared by multiple actions; capture warns in-app before save; optional **Reset conflicting to default** (pure `findChordConflicts` + tests)
+- **Shortcut scopes** (Settings → Keyboard): each catalog row is tagged **Global** vs **Chat**; optional **Allow same chord across scopes** ignores cross-scope conflicts in capture/panel only (stored remaps + App matching unchanged)
 
 #### Tasks / system
 - Tasks tree · Stop-all skip-confirm · Plan history · Mirror write guard · Reliability / Leader / Memory / MCP / CLI notice (prior)
@@ -65,7 +66,7 @@ See `docs/llm-wiki/release.md`.
 
 - **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片、会话变更审阅（+/− · 并排 diff · j/k）、结构化 JSON 回复面板（校验/复制/导出）、上下文用量/费用粗估
 - **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、会话规则（`--rules`）、会话最大轮次（`--max-turns` 覆盖；空/0 继承全局）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
-- **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标、快捷键冲突面板（录制警告 + 重置冲突项）
+- **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标、快捷键冲突面板（录制警告 + 重置冲突项）、快捷键范围（全局/对话列 + 可选跨范围共用组合键）
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选
 - **计划**：**请求修改** 可选修订说明；计划历史搜索/决策筛选、清空确认、会话仍在时可打开

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -53,11 +53,15 @@ import {
   SHORTCUTS,
   detectShortcutPlatform,
   filterShortcutGroups,
+  shortcutScope,
   shortcutsByGroup,
   type ShortcutGroup,
   type ShortcutId,
+  type ShortcutScope,
 } from "@/lib/shortcuts";
 import {
+  SHORTCUT_IGNORE_CROSS_SCOPE_CHANGED_EVENT,
+  SHORTCUT_IGNORE_CROSS_SCOPE_STORAGE_KEY,
   SHORTCUT_REMAP_CHANGED_EVENT,
   SHORTCUT_REMAP_STORAGE_KEY,
   buildEffectiveChordMap,
@@ -68,10 +72,13 @@ import {
   formatChordDisplay,
   hasAnyShortcutRemaps,
   isRemappableShortcutId,
+  loadIgnoreCrossScopeConflicts,
   loadShortcutRemaps,
   resetConflictingShortcutRemaps,
+  saveIgnoreCrossScopeConflicts,
   setShortcutRecordingActive,
   setShortcutRemap,
+  type ChordConflictOpts,
   type ShortcutRemapMap,
 } from "@/lib/shortcutRemap";
 import type { Theme, ThemePreference } from "@/lib/theme";
@@ -5312,17 +5319,34 @@ function ShortcutsSettingsPanel({
   const [voiceHotkeyEnabled, setVoiceHotkeyEnabled] = useState(() =>
     loadVoiceHotkeyEnabled(),
   );
+  const [ignoreCrossScope, setIgnoreCrossScope] = useState(() =>
+    loadIgnoreCrossScopeConflicts(),
+  );
   const [recordingId, setRecordingId] = useState<ShortcutId | null>(null);
   const [recordError, setRecordError] = useState<string | null>(null);
+
+  const conflictOpts = useMemo<ChordConflictOpts>(
+    () => ({
+      ignoreCrossScope,
+      scopeOf: shortcutScope,
+    }),
+    [ignoreCrossScope],
+  );
 
   useEffect(() => {
     const reloadSend = () => setSendPref(loadComposerSendKeyPref());
     const reloadRemaps = () => setRemaps(loadShortcutRemaps());
     const reloadVoiceHotkey = () =>
       setVoiceHotkeyEnabled(loadVoiceHotkeyEnabled());
+    const reloadIgnoreCross = () =>
+      setIgnoreCrossScope(loadIgnoreCrossScopeConflicts());
     window.addEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, reloadSend);
     window.addEventListener(SHORTCUT_REMAP_CHANGED_EVENT, reloadRemaps);
     window.addEventListener(VOICE_HOTKEY_CHANGED_EVENT, reloadVoiceHotkey);
+    window.addEventListener(
+      SHORTCUT_IGNORE_CROSS_SCOPE_CHANGED_EVENT,
+      reloadIgnoreCross,
+    );
     const onStorage = (e: StorageEvent) => {
       if (e.key === "grok.composerSendKey" || e.key === null) reloadSend();
       if (e.key === SHORTCUT_REMAP_STORAGE_KEY || e.key === null) {
@@ -5331,12 +5355,22 @@ function ShortcutsSettingsPanel({
       if (e.key === VOICE_HOTKEY_STORAGE_KEY || e.key === null) {
         reloadVoiceHotkey();
       }
+      if (
+        e.key === SHORTCUT_IGNORE_CROSS_SCOPE_STORAGE_KEY ||
+        e.key === null
+      ) {
+        reloadIgnoreCross();
+      }
     };
     window.addEventListener("storage", onStorage);
     return () => {
       window.removeEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, reloadSend);
       window.removeEventListener(SHORTCUT_REMAP_CHANGED_EVENT, reloadRemaps);
       window.removeEventListener(VOICE_HOTKEY_CHANGED_EVENT, reloadVoiceHotkey);
+      window.removeEventListener(
+        SHORTCUT_IGNORE_CROSS_SCOPE_CHANGED_EVENT,
+        reloadIgnoreCross,
+      );
       window.removeEventListener("storage", onStorage);
     };
   }, []);
@@ -5362,7 +5396,12 @@ function ShortcutsSettingsPanel({
       const chord = chordFromKeyboardEvent(e);
       if (!chord) return;
       const effective = buildEffectiveChordMap(remaps);
-      const conflict = findChordConflict(recordingId, chord, effective);
+      const conflict = findChordConflict(
+        recordingId,
+        chord,
+        effective,
+        conflictOpts,
+      );
       if (conflict) {
         const conflictRow = SHORTCUTS.find((s) => s.id === conflict);
         const action = conflictRow
@@ -5385,7 +5424,7 @@ function ShortcutsSettingsPanel({
       window.removeEventListener("keydown", onKey, true);
       setShortcutRecordingActive(false);
     };
-  }, [recordingId, remaps, t]);
+  }, [recordingId, remaps, t, conflictOpts]);
 
   const groups = useMemo(
     () => shortcutsByGroup(sendPref, remaps, voiceHotkeyEnabled),
@@ -5400,8 +5439,8 @@ function ShortcutsSettingsPanel({
   );
 
   const conflictGroups = useMemo(
-    () => findChordConflicts(remaps),
-    [remaps],
+    () => findChordConflicts(remaps, undefined, conflictOpts),
+    [remaps, conflictOpts],
   );
   const conflictIdSet = useMemo(() => {
     const s = new Set<ShortcutId>();
@@ -5415,6 +5454,11 @@ function ShortcutsSettingsPanel({
     const row = SHORTCUTS.find((s) => s.id === id);
     return row ? t(row.labelKey as MessageKey) : id;
   };
+
+  const scopeLabel = (scope: ShortcutScope) =>
+    scope === "chat-focus"
+      ? t("settings.shortcuts.scope.chatFocus")
+      : t("settings.shortcuts.scope.global");
 
   const groupLabel = (g: ShortcutGroup) =>
     t(`settings.shortcuts.group.${g}` as MessageKey);
@@ -5441,7 +5485,7 @@ function ShortcutsSettingsPanel({
   };
 
   const resetConflicting = () => {
-    setRemaps(resetConflictingShortcutRemaps(remaps));
+    setRemaps(resetConflictingShortcutRemaps(remaps, localStorage, conflictOpts));
     setRecordingId(null);
     setRecordError(null);
   };
@@ -5475,6 +5519,25 @@ function ShortcutsSettingsPanel({
             {t("settings.shortcuts.resetAll")}
           </button>
         </div>
+      </div>
+      <div className="settings-row settings-shortcuts-scope-pref">
+        <div className="settings-row__text">
+          <div className="settings-row__label">
+            {t("settings.shortcuts.ignoreCrossScope")}
+          </div>
+          <div className="settings-row__desc">
+            {t("settings.shortcuts.ignoreCrossScopeDesc")}
+          </div>
+        </div>
+        <UiCheck
+          checked={ignoreCrossScope}
+          onChange={() => {
+            const next = !ignoreCrossScope;
+            setIgnoreCrossScope(next);
+            saveIgnoreCrossScopeConflicts(next);
+          }}
+          ariaLabel={t("settings.shortcuts.ignoreCrossScope")}
+        />
       </div>
       <div className="settings-shortcuts-filter">
         <IconSearch size={14} />
@@ -5513,7 +5576,10 @@ function ShortcutsSettingsPanel({
           </div>
           <ul className="settings-shortcuts-conflicts__list">
             {conflictGroups.map((group) => (
-              <li key={group.chord} className="settings-shortcuts-conflicts__item">
+              <li
+                key={`${group.chord}:${group.ids.join(",")}`}
+                className="settings-shortcuts-conflicts__item"
+              >
                 <kbd className="settings-shortcuts-kbd">
                   {formatChordDisplay(
                     group.chord,
@@ -5551,6 +5617,7 @@ function ShortcutsSettingsPanel({
               <thead>
                 <tr>
                   <th scope="col">{t("settings.shortcuts.colAction")}</th>
+                  <th scope="col">{t("settings.shortcuts.colScope")}</th>
                   <th
                     scope="col"
                     className={
@@ -5599,6 +5666,23 @@ function ShortcutsSettingsPanel({
                             ·
                           </span>
                         ) : null}
+                      </td>
+                      <td>
+                        <span
+                          className={
+                            "settings-shortcuts-scope" +
+                            (row.scope === "chat-focus"
+                              ? " settings-shortcuts-scope--chat"
+                              : " settings-shortcuts-scope--global")
+                          }
+                          title={
+                            row.scope === "chat-focus"
+                              ? t("settings.shortcuts.scope.chatFocusHint")
+                              : t("settings.shortcuts.scope.globalHint")
+                          }
+                        >
+                          {scopeLabel(row.scope)}
+                        </span>
                       </td>
                       <td>
                         <kbd

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -977,15 +977,25 @@ const en = {
   "settings.shortcuts.desc":
     "Click Record and press a chord to remap global actions. Reset restores the default; Reset all clears every custom binding.",
   "settings.shortcuts.colAction": "Action",
+  "settings.shortcuts.colScope": "Scope",
   "settings.shortcuts.colMac": "macOS",
   "settings.shortcuts.colWin": "Windows / Linux",
   "settings.shortcuts.colEdit": "Edit",
+  "settings.shortcuts.scope.global": "Global",
+  "settings.shortcuts.scope.chatFocus": "Chat",
+  "settings.shortcuts.scope.globalHint":
+    "App-wide shell action (palette, settings, sidebar, diagnostics, …).",
+  "settings.shortcuts.scope.chatFocusHint":
+    "Conversation surface (find in chat, copy last reply, send, stop).",
+  "settings.shortcuts.ignoreCrossScope": "Allow same chord across scopes",
+  "settings.shortcuts.ignoreCrossScopeDesc":
+    "When on, a Global action and a Chat action may share a chord without counting as a conflict in this list. Same-scope collisions still warn. Does not change how App matches keys at runtime.",
   "settings.shortcuts.group.workbench": "Workbench",
   "settings.shortcuts.group.navigation": "Navigation",
   "settings.shortcuts.group.diagnostics": "Diagnostics",
   "settings.shortcuts.group.input": "Input",
   "settings.shortcuts.note":
-    "Default send is Enter; switch to ⌘/Ctrl+Enter in Settings → Composer. Esc, Ctrl+Space dictation, and Send are fixed. Some chords may be taken by the OS (e.g. input sources).",
+    "Default send is Enter; switch to ⌘/Ctrl+Enter in Settings → Composer. Esc, Ctrl+Space dictation, and Send are fixed. Scope marks Global vs Chat actions; optional cross-scope sharing only affects conflict checks. Some chords may be taken by the OS (e.g. input sources).",
   "settings.shortcuts.openHelp": "Open shortcuts help",
   "settings.shortcuts.filterPlaceholder": "Filter shortcuts…",
   "settings.shortcuts.filterEmpty": "No shortcuts match this filter.",
@@ -3979,15 +3989,25 @@ const zh: Record<MessageKey, string> = {
   "settings.shortcuts.desc":
     "点击「录制」后按下组合键即可改绑全局操作。「重置」恢复默认；「全部重置」清除所有自定义。",
   "settings.shortcuts.colAction": "操作",
+  "settings.shortcuts.colScope": "范围",
   "settings.shortcuts.colMac": "macOS",
   "settings.shortcuts.colWin": "Windows / Linux",
   "settings.shortcuts.colEdit": "编辑",
+  "settings.shortcuts.scope.global": "全局",
+  "settings.shortcuts.scope.chatFocus": "对话",
+  "settings.shortcuts.scope.globalHint":
+    "应用级壳操作（命令面板、设置、侧栏、诊断等）。",
+  "settings.shortcuts.scope.chatFocusHint":
+    "对话界面操作（会话内查找、复制上一条回复、发送、停止）。",
+  "settings.shortcuts.ignoreCrossScope": "允许跨范围共用组合键",
+  "settings.shortcuts.ignoreCrossScopeDesc":
+    "开启后，全局操作与对话操作共用同一组合键时，本列表不视为冲突；同范围内的冲突仍会提示。不会改变应用运行时如何匹配按键。",
   "settings.shortcuts.group.workbench": "工作台",
   "settings.shortcuts.group.navigation": "导航",
   "settings.shortcuts.group.diagnostics": "诊断",
   "settings.shortcuts.group.input": "输入",
   "settings.shortcuts.note":
-    "默认 Enter 发送；可在 设置 → 对话偏好 改为 ⌘/Ctrl+Enter。Esc、Ctrl+Space 语音输入与发送键为固定绑定。部分组合键可能被系统占用（如输入法切换）。",
+    "默认 Enter 发送；可在 设置 → 对话偏好 改为 ⌘/Ctrl+Enter。Esc、Ctrl+Space 语音输入与发送键为固定绑定。范围区分全局与对话；可选跨范围共用仅影响冲突检查。部分组合键可能被系统占用（如输入法切换）。",
   "settings.shortcuts.openHelp": "打开快捷键帮助",
   "settings.shortcuts.filterPlaceholder": "筛选快捷键…",
   "settings.shortcuts.filterEmpty": "没有符合筛选条件的快捷键。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -924,15 +924,25 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.shortcuts.desc":
     "點「錄製」後按下組合鍵即可改綁全域操作。「重設」恢復預設；「全部重設」清除所有自訂。",
   "settings.shortcuts.colAction": "操作",
+  "settings.shortcuts.colScope": "範圍",
   "settings.shortcuts.colMac": "macOS",
   "settings.shortcuts.colWin": "Windows / Linux",
   "settings.shortcuts.colEdit": "編輯",
+  "settings.shortcuts.scope.global": "全域",
+  "settings.shortcuts.scope.chatFocus": "對話",
+  "settings.shortcuts.scope.globalHint":
+    "應用層殼操作（命令面板、設定、側欄、診斷等）。",
+  "settings.shortcuts.scope.chatFocusHint":
+    "對話介面操作（對話內尋找、複製上一則回覆、傳送、停止）。",
+  "settings.shortcuts.ignoreCrossScope": "允許跨範圍共用組合鍵",
+  "settings.shortcuts.ignoreCrossScopeDesc":
+    "開啟後，全域操作與對話操作共用同一組合鍵時，本列表不視為衝突；同範圍內的衝突仍會提示。不會改變應用執行時如何比對按鍵。",
   "settings.shortcuts.group.workbench": "工作台",
   "settings.shortcuts.group.navigation": "導覽",
   "settings.shortcuts.group.diagnostics": "診斷",
   "settings.shortcuts.group.input": "輸入",
   "settings.shortcuts.note":
-    "預設 Enter 傳送；可在 設定 → 對話偏好 改為 ⌘/Ctrl+Enter。Esc、Ctrl+Space 語音輸入與傳送鍵為固定綁定。部分組合鍵可能被系統占用（如輸入法切換）。",
+    "預設 Enter 傳送；可在 設定 → 對話偏好 改為 ⌘/Ctrl+Enter。Esc、Ctrl+Space 語音輸入與傳送鍵為固定綁定。範圍區分全域與對話；可選跨範圍共用僅影響衝突檢查。部分組合鍵可能被系統占用（如輸入法切換）。",
   "settings.shortcuts.openHelp": "開啟快捷鍵說明",
   "settings.shortcuts.filterPlaceholder": "篩選快捷鍵…",
   "settings.shortcuts.filterEmpty": "沒有符合篩選條件的快捷鍵。",

--- a/src/lib/shortcutRemap.test.ts
+++ b/src/lib/shortcutRemap.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, beforeEach } from "vitest";
+import { shortcutScope } from "./shortcuts";
 import {
   CHORD_CONFLICT_IGNORE_IDS,
+  DEFAULT_IGNORE_CROSS_SCOPE_CONFLICTS,
   DEFAULT_SHORTCUT_CHORDS,
   REMAPPABLE_SHORTCUT_IDS,
+  SHORTCUT_IGNORE_CROSS_SCOPE_STORAGE_KEY,
   SHORTCUT_REMAP_STORAGE_KEY,
   buildEffectiveChordMap,
   chordFromKeyboardEvent,
@@ -12,10 +15,13 @@ import {
   findChordConflict,
   findChordConflicts,
   formatChordDisplay,
+  loadIgnoreCrossScopeConflicts,
   loadShortcutRemaps,
   normalizeChordString,
   parseChord,
+  parseIgnoreCrossScopeConflicts,
   resetConflictingShortcutRemaps,
+  saveIgnoreCrossScopeConflicts,
   saveShortcutRemaps,
   serializeChord,
   setShortcutRemap,
@@ -313,6 +319,87 @@ describe("findChordConflicts", () => {
       },
     );
     expect(groups).toEqual([{ chord: "mod+x", ids: ["help", "search"] }]);
+  });
+
+  it("optionally ignores cross-scope collisions (global vs chat-focus)", () => {
+    // findInChat is chat-focus; search is global — same chord.
+    const remaps = { findInChat: "mod+k" as const };
+    // Default: still a conflict.
+    expect(findChordConflicts(remaps)).toEqual([
+      { chord: "mod+k", ids: ["findInChat", "search"] },
+    ]);
+    // With ignore + scopeOf: no same-scope multi-id group.
+    expect(
+      findChordConflicts(remaps, DEFAULT_SHORTCUT_CHORDS, {
+        ignoreCrossScope: true,
+        scopeOf: shortcutScope,
+      }),
+    ).toEqual([]);
+    // Same-scope still conflicts (search + help are both global).
+    expect(
+      findChordConflicts(
+        { help: "mod+k" },
+        DEFAULT_SHORTCUT_CHORDS,
+        { ignoreCrossScope: true, scopeOf: shortcutScope },
+      ),
+    ).toEqual([{ chord: "mod+k", ids: ["help", "search"] }]);
+  });
+
+  it("findChordConflict honors ignoreCrossScope with scopeOf", () => {
+    const effective = buildEffectiveChordMap({ findInChat: "mod+k" });
+    // Without opts: findInChat conflicts with search's default.
+    expect(findChordConflict("search", "mod+k", effective)).toBe("findInChat");
+    // With ignore: search (global) may keep mod+k while findInChat also has it.
+    expect(
+      findChordConflict("search", "mod+k", effective, {
+        ignoreCrossScope: true,
+        scopeOf: shortcutScope,
+      }),
+    ).toBeNull();
+    // Same-scope still blocked.
+    expect(
+      findChordConflict("help", "mod+k", effective, {
+        ignoreCrossScope: true,
+        scopeOf: shortcutScope,
+      }),
+    ).toBe("search");
+  });
+
+  it("ignoreCrossScope without scopeOf is a no-op", () => {
+    const groups = findChordConflicts(
+      { findInChat: "mod+k" },
+      DEFAULT_SHORTCUT_CHORDS,
+      { ignoreCrossScope: true },
+    );
+    expect(groups).toEqual([
+      { chord: "mod+k", ids: ["findInChat", "search"] },
+    ]);
+  });
+});
+
+describe("ignore cross-scope conflicts pref", () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = memoryStorage();
+  });
+
+  it("defaults to false and round-trips", () => {
+    expect(DEFAULT_IGNORE_CROSS_SCOPE_CONFLICTS).toBe(false);
+    expect(loadIgnoreCrossScopeConflicts(storage)).toBe(false);
+    saveIgnoreCrossScopeConflicts(true, storage);
+    expect(storage.getItem(SHORTCUT_IGNORE_CROSS_SCOPE_STORAGE_KEY)).toBe("1");
+    expect(loadIgnoreCrossScopeConflicts(storage)).toBe(true);
+    saveIgnoreCrossScopeConflicts(false, storage);
+    expect(loadIgnoreCrossScopeConflicts(storage)).toBe(false);
+  });
+
+  it("parses known tokens and falls back on junk", () => {
+    expect(parseIgnoreCrossScopeConflicts("1")).toBe(true);
+    expect(parseIgnoreCrossScopeConflicts("true")).toBe(true);
+    expect(parseIgnoreCrossScopeConflicts("0")).toBe(false);
+    expect(parseIgnoreCrossScopeConflicts("nope")).toBe(false);
+    expect(parseIgnoreCrossScopeConflicts(null)).toBe(false);
   });
 });
 

--- a/src/lib/shortcutRemap.ts
+++ b/src/lib/shortcutRemap.ts
@@ -7,14 +7,43 @@
  *
  * Pure parse / conflict helpers live here; Settings + App load via
  * {@link loadShortcutRemaps} / {@link effectiveShortcutChord}.
+ *
+ * Scopes (`global` vs `chat-focus`) live on the shortcuts catalog. Optional
+ * ignore-cross-scope pref only affects conflict UI / capture checks — it does
+ * not change App key matching or stored remap maps.
  */
 
-import type { ShortcutId } from "@/lib/shortcuts";
+import type { ShortcutId, ShortcutScope } from "@/lib/shortcuts";
 
 export const SHORTCUT_REMAP_STORAGE_KEY = "grok.shortcutRemap";
 
 /** Fired on `window` after a same-tab remap save (storage events are cross-tab only). */
 export const SHORTCUT_REMAP_CHANGED_EVENT = "grok:shortcutRemap";
+
+/**
+ * When true, chords shared only across different scopes (global vs chat-focus)
+ * are not treated as conflicts in Settings capture / conflict panel.
+ * Default false preserves historical same-chord-is-conflict behavior.
+ */
+export const SHORTCUT_IGNORE_CROSS_SCOPE_STORAGE_KEY =
+  "grok.shortcutIgnoreCrossScopeConflicts";
+
+/** Fired on `window` after a same-tab ignore-cross-scope pref save. */
+export const SHORTCUT_IGNORE_CROSS_SCOPE_CHANGED_EVENT =
+  "grok:shortcutIgnoreCrossScopeConflicts";
+
+export const DEFAULT_IGNORE_CROSS_SCOPE_CONFLICTS = false;
+
+/** Options for chord conflict detection (scope-aware when requested). */
+export type ChordConflictOpts = {
+  /**
+   * When true and {@link scopeOf} is provided, only ids that share the same
+   * scope can form a conflict. Cross-scope shared chords are allowed.
+   */
+  ignoreCrossScope?: boolean;
+  /** Resolve catalog scope for an id (usually {@link shortcutScope} from shortcuts). */
+  scopeOf?: (id: ShortcutId) => ShortcutScope;
+};
 
 /** Unified chord string, tokens joined by `+` (order: mod|ctrl, alt, shift, key). */
 export type ChordString = string;
@@ -373,13 +402,19 @@ export type ChordConflictGroup = {
 /**
  * Group shortcut ids that share the same normalized effective chord.
  *
+ * When {@link ChordConflictOpts.ignoreCrossScope} is true and `scopeOf` is set,
+ * ids on a shared chord are split by scope: only same-scope multi-id sets are
+ * reported. Cross-scope sharing is allowed (optional Settings preference).
+ *
  * @param remaps user remaps (partial); defaults fill the rest
  * @param defaults catalog defaults (defaults to {@link DEFAULT_SHORTCUT_CHORDS})
+ * @param opts optional scope-aware filtering
  * @returns conflict groups (length ≥ 2 ids each), sorted by chord; empty when none
  */
 export function findChordConflicts(
   remaps?: ShortcutRemapMap | null,
   defaults: Readonly<Partial<Record<ShortcutId, ChordString>>> = DEFAULT_SHORTCUT_CHORDS,
+  opts?: ChordConflictOpts,
 ): ChordConflictGroup[] {
   const effective: Partial<Record<ShortcutId, ChordString>> = {};
 
@@ -418,13 +453,37 @@ export function findChordConflicts(
     else byChord.set(chord, [id]);
   }
 
+  const ignoreCross =
+    opts?.ignoreCrossScope === true && typeof opts.scopeOf === "function";
+  const scopeOf = opts?.scopeOf;
+
   const groups: ChordConflictGroup[] = [];
   for (const [chord, ids] of byChord) {
     if (ids.length < 2) continue;
+    if (ignoreCross && scopeOf) {
+      // Partition by scope; emit a group only when ≥2 ids share one scope.
+      const byScope = new Map<ShortcutScope, ShortcutId[]>();
+      for (const id of ids) {
+        const scope = scopeOf(id);
+        const list = byScope.get(scope);
+        if (list) list.push(id);
+        else byScope.set(scope, [id]);
+      }
+      for (const scoped of byScope.values()) {
+        if (scoped.length < 2) continue;
+        scoped.sort((a, b) => a.localeCompare(b));
+        groups.push({ chord, ids: scoped });
+      }
+      continue;
+    }
     ids.sort((a, b) => a.localeCompare(b));
     groups.push({ chord, ids });
   }
-  groups.sort((a, b) => a.chord.localeCompare(b.chord));
+  groups.sort((a, b) => {
+    const c = a.chord.localeCompare(b.chord);
+    if (c !== 0) return c;
+    return a.ids.join(",").localeCompare(b.ids.join(","));
+  });
   return groups;
 }
 
@@ -433,17 +492,24 @@ export function findChordConflicts(
  * return that id; otherwise null.
  *
  * Skips {@link CHORD_CONFLICT_IGNORE_IDS} (display-only / composer-owned rows).
+ * With {@link ChordConflictOpts.ignoreCrossScope}, skips other ids whose scope
+ * differs from the candidate's (requires `scopeOf`).
  */
 export function findChordConflict(
   candidateId: ShortcutId,
   candidateChord: ChordString,
   effectiveMap: Readonly<Partial<Record<ShortcutId, ChordString>>>,
+  opts?: ChordConflictOpts,
 ): ShortcutId | null {
   const norm = normalizeChordString(candidateChord);
   if (!norm) return null;
+  const ignoreCross =
+    opts?.ignoreCrossScope === true && typeof opts.scopeOf === "function";
+  const candidateScope = ignoreCross ? opts!.scopeOf!(candidateId) : null;
   for (const id of Object.keys(effectiveMap) as ShortcutId[]) {
     if (id === candidateId) continue;
     if (CHORD_CONFLICT_IGNORE_IDS.has(id)) continue;
+    if (ignoreCross && opts!.scopeOf!(id) !== candidateScope) continue;
     const other = effectiveMap[id];
     if (!other) continue;
     if (normalizeChordString(other) === norm) return id;
@@ -455,15 +521,19 @@ export function findChordConflict(
  * Drop custom remaps that participate in a chord conflict (restores those ids
  * to catalog defaults). Non-remappable / default-only rows are left as-is.
  * Returns the saved map after write.
+ *
+ * Pass the same {@link ChordConflictOpts} used by the Settings conflict panel
+ * so reset matches what the user sees (including ignore-cross-scope).
  */
 export function resetConflictingShortcutRemaps(
   remaps?: ShortcutRemapMap | null,
   storage: Storage = localStorage,
+  opts?: ChordConflictOpts,
 ): ShortcutRemapMap {
   const map: ShortcutRemapMap = {
     ...(remaps ?? loadShortcutRemaps(storage)),
   };
-  const groups = findChordConflicts(map);
+  const groups = findChordConflicts(map, DEFAULT_SHORTCUT_CHORDS, opts);
   if (groups.length === 0) {
     return loadShortcutRemaps(storage);
   }
@@ -480,6 +550,65 @@ export function resetConflictingShortcutRemaps(
     saveShortcutRemaps(map, storage);
   }
   return loadShortcutRemaps(storage);
+}
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface ShortcutPrefStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+function defaultPrefStorage(): ShortcutPrefStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+/** Parse stored ignore-cross-scope flag; invalid / empty → default false. */
+export function parseIgnoreCrossScopeConflicts(raw: unknown): boolean {
+  if (raw === "1" || raw === "true" || raw === true) return true;
+  if (raw === "0" || raw === "false" || raw === false) return false;
+  return DEFAULT_IGNORE_CROSS_SCOPE_CONFLICTS;
+}
+
+export function loadIgnoreCrossScopeConflicts(
+  storage: ShortcutPrefStorage = defaultPrefStorage(),
+): boolean {
+  try {
+    return parseIgnoreCrossScopeConflicts(
+      storage.getItem(SHORTCUT_IGNORE_CROSS_SCOPE_STORAGE_KEY),
+    );
+  } catch {
+    return DEFAULT_IGNORE_CROSS_SCOPE_CONFLICTS;
+  }
+}
+
+export function saveIgnoreCrossScopeConflicts(
+  enabled: boolean,
+  storage: ShortcutPrefStorage = defaultPrefStorage(),
+): void {
+  try {
+    storage.setItem(
+      SHORTCUT_IGNORE_CROSS_SCOPE_STORAGE_KEY,
+      enabled ? "1" : "0",
+    );
+  } catch {
+    /* private mode / quota */
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.dispatchEvent === "function"
+  ) {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(SHORTCUT_IGNORE_CROSS_SCOPE_CHANGED_EVENT, {
+          detail: enabled,
+        }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 export function loadShortcutRemaps(

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -7,6 +7,7 @@ import {
   sendShortcutDisplay,
   SHORTCUT_IDS,
   SHORTCUTS,
+  shortcutScope,
   shortcutsByGroup,
   shortcutsForPlatform,
   type GlobalModShortcutId,
@@ -54,13 +55,26 @@ describe("shortcuts catalog", () => {
     expect([...SHORTCUT_IDS]).toEqual(SHORTCUTS.map((s) => s.id));
   });
 
-  it("every row has mac and win bindings and a group", () => {
+  it("every row has mac and win bindings, a group, and a scope", () => {
     for (const s of SHORTCUTS) {
       expect(s.mac.trim().length).toBeGreaterThan(0);
       expect(s.win.trim().length).toBeGreaterThan(0);
       expect(s.labelKey.startsWith("shortcuts.")).toBe(true);
       expect(s.group).toBeTruthy();
+      expect(s.scope === "global" || s.scope === "chat-focus").toBe(true);
+      expect(shortcutScope(s.id)).toBe(s.scope);
     }
+  });
+
+  it("tags chat-surface actions as chat-focus and shell actions as global", () => {
+    expect(shortcutScope("findInChat")).toBe("chat-focus");
+    expect(shortcutScope("copyLastReply")).toBe("chat-focus");
+    expect(shortcutScope("send")).toBe("chat-focus");
+    expect(shortcutScope("stop")).toBe("chat-focus");
+    expect(shortcutScope("search")).toBe("global");
+    expect(shortcutScope("settings")).toBe("global");
+    expect(shortcutScope("toggleSidebar")).toBe("global");
+    expect(shortcutScope("doctor")).toBe("global");
   });
 
   it("lists find-in-chat and toggle sidebar", () => {
@@ -327,6 +341,14 @@ describe("filterShortcutRows", () => {
     expect(hits.some((r) => r.id === "findInChat")).toBe(true);
     const doctor = filterShortcutRows("DOCTOR", SHORTCUTS, tStub);
     expect(doctor.some((r) => r.id === "doctor")).toBe(true);
+  });
+
+  it("matches scope tokens", () => {
+    const chat = filterShortcutRows("chat-focus", SHORTCUTS, tStub);
+    expect(chat.some((r) => r.id === "findInChat")).toBe(true);
+    expect(chat.every((r) => r.scope === "chat-focus")).toBe(true);
+    const globalHits = filterShortcutRows("global", SHORTCUTS, tStub);
+    expect(globalHits.some((r) => r.id === "search")).toBe(true);
   });
 
   it("matches key chord text", () => {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -21,6 +21,16 @@ import {
 
 export type ShortcutGroup = "workbench" | "navigation" | "diagnostics" | "input";
 
+/**
+ * When a remappable chord may fire:
+ * - `global` — app shell / workbench (palette, settings, sidebar, doctor, …)
+ * - `chat-focus` — conversation surface (find-in-chat, copy last reply, send, stop)
+ *
+ * Used for Settings scope column and optional cross-scope conflict ignoring.
+ * Does not change App capture matching by itself.
+ */
+export type ShortcutScope = "global" | "chat-focus";
+
 export type ShortcutId =
   | "search"
   | "findInChat"
@@ -41,6 +51,8 @@ export type ShortcutRow = {
   /** i18n message key for the action label */
   labelKey: string;
   group: ShortcutGroup;
+  /** Where the action applies (Settings column + conflict scope). */
+  scope: ShortcutScope;
   /** Display keys for mac (⌘ is replaced at render time if needed) */
   mac: string;
   /** Display keys for win/linux */
@@ -79,6 +91,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "search",
     labelKey: "shortcuts.search",
     group: "workbench",
+    scope: "global",
     mac: "⌘ K",
     win: "Ctrl K",
   },
@@ -86,6 +99,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "findInChat",
     labelKey: "shortcuts.findInChat",
     group: "workbench",
+    scope: "chat-focus",
     mac: "⌘ F",
     win: "Ctrl F",
   },
@@ -93,6 +107,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "newChat",
     labelKey: "shortcuts.newChat",
     group: "workbench",
+    scope: "global",
     mac: "⌘ N",
     win: "Ctrl N",
   },
@@ -100,6 +115,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "send",
     labelKey: "shortcuts.send",
     group: "workbench",
+    scope: "chat-focus",
     // Product default: plain Enter (mod-enter only when Settings → Composer pref is set).
     mac: "↵",
     win: "Enter",
@@ -108,6 +124,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "stop",
     labelKey: "shortcuts.stop",
     group: "workbench",
+    scope: "chat-focus",
     mac: "Esc",
     win: "Esc",
   },
@@ -115,6 +132,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "copyLastReply",
     labelKey: "shortcuts.copyLastReply",
     group: "workbench",
+    scope: "chat-focus",
     mac: "⌘ ⇧ C",
     win: "Ctrl Shift C",
   },
@@ -122,6 +140,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "toggleSidebar",
     labelKey: "shortcuts.toggleSidebar",
     group: "navigation",
+    scope: "global",
     mac: "⌘ B",
     win: "Ctrl B",
   },
@@ -131,6 +150,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "sidebarSessionNav",
     labelKey: "shortcuts.sidebarSessionNav",
     group: "navigation",
+    scope: "global",
     mac: "J / K",
     win: "J / K",
   },
@@ -138,6 +158,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "settings",
     labelKey: "shortcuts.settings",
     group: "navigation",
+    scope: "global",
     mac: "⌘ ,",
     win: "Ctrl ,",
   },
@@ -145,6 +166,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "help",
     labelKey: "shortcuts.help",
     group: "navigation",
+    scope: "global",
     mac: "⌘ /",
     win: "Ctrl /",
   },
@@ -152,6 +174,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "doctor",
     labelKey: "shortcuts.doctor",
     group: "diagnostics",
+    scope: "global",
     mac: "⌘ ⇧ D",
     win: "Ctrl Shift D",
   },
@@ -159,6 +182,7 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "liveVoice",
     labelKey: "shortcuts.liveVoice",
     group: "input",
+    scope: "global",
     mac: "⌘ ⇧ V",
     win: "Ctrl Shift V",
   },
@@ -167,10 +191,17 @@ export const SHORTCUTS: ShortcutRow[] = [
     id: "dictation",
     labelKey: "shortcuts.voice",
     group: "input",
+    scope: "global",
     mac: "Ctrl Space",
     win: "Ctrl Space",
   },
 ];
+
+/** Resolve catalog scope for an id (defaults to `global` for unknown ids). */
+export function shortcutScope(id: ShortcutId): ShortcutScope {
+  const row = SHORTCUTS.find((s) => s.id === id);
+  return row?.scope ?? "global";
+}
 
 /**
  * Catalog ids handled by {@link matchGlobalShortcut} (mod-based App capture handler).
@@ -458,6 +489,8 @@ export function filterShortcutRows(
     const haystack = [
       row.id,
       label,
+      row.scope,
+      row.scope === "chat-focus" ? "chat focus" : "global",
       row.mac,
       row.win,
       keySearchExtra(row.mac),

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4278,6 +4278,32 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   gap: 6px;
 }
 
+.settings-shortcuts-scope-pref {
+  margin: 0 0 4px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.settings-shortcuts-scope {
+  display: inline-block;
+  font-size: 11.5px;
+  font-weight: 500;
+  line-height: 1.3;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.settings-shortcuts-scope--global {
+  background: color-mix(in srgb, var(--accent, #6b8afd) 10%, transparent);
+}
+
+.settings-shortcuts-scope--chat {
+  background: color-mix(in srgb, var(--text-tertiary) 12%, transparent);
+}
+
 .settings-shortcuts-filter {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- **Catalog scopes** (`src/lib/shortcuts.ts`): every shortcut row is tagged `global` (shell: palette, settings, sidebar, doctor, …) or `chat-focus` (conversation: find-in-chat, copy last reply, send, stop). `shortcutScope(id)` helper; filter matches scope tokens.
- **Conflict helpers** (`src/lib/shortcutRemap.ts`): optional `ChordConflictOpts` (`ignoreCrossScope` + `scopeOf`) on `findChordConflict` / `findChordConflicts` / `resetConflictingShortcutRemaps`. Cross-scope shared chords are allowed only when the pref is on **and** `scopeOf` is provided; same-scope collisions still warn. Pref load/save (`grok.shortcutIgnoreCrossScopeConflicts`, default **off**) does not touch stored remaps or App key matching.
- **Settings → Keyboard**: **Scope** column (Global / Chat pills); toggle **Allow same chord across scopes**; capture + Conflicts panel honor the pref. Existing remap load/save path unchanged.
- **i18n** en + zh + zh-TW · **CHANGELOG** Unreleased · unit tests for scopes, cross-scope ignore, and pref.

## Test plan

- [x] `vitest run src/lib/shortcuts.test.ts src/lib/shortcutRemap.test.ts src/i18n/messages.test.ts` (83 passed)
- [x] `tsc -b` / typecheck
- [ ] Manual: Settings → Keyboard → Scope column shows Global vs Chat
- [ ] Manual: remap find-in-chat onto search’s chord → Conflicts panel lists both; enable **Allow same chord across scopes** → conflict clears; same-scope collision still warns
- [ ] Manual: existing remaps still load and fire unchanged with pref off (default)