### PR TITLE
feat(reliability): stall timeline in support bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ See `docs/llm-wiki/release.md`.
 
 #### Tasks / system
 - Tasks tree · Stop-all skip-confirm · Plan history · Mirror write guard · Reliability / Leader / Memory / MCP / CLI notice (prior)
+- **Reliability support zip**: export from Reliability center includes a redacted **stall timeline** snapshot (`stall-timeline.json` — structured stall kinds/seconds/session ids only; Host redacts secrets; never `secrets.json`)
 - **Mirror write audit log** (Settings → Remote → Phone mirror): localStorage ring (~50) of write enable/disable, link regenerate, host start/stop — no tokens/URLs stored; collapsible list + in-app clear confirm
 - **Subagent worktree (cwd) badge**: when `spawn_subagent` / Agent / subagent tool_step data includes a cwd or worktree path (labeled fields, JSON, or absolute path), Tasks panel shows a compact **WT** / truncated-path badge and can reveal or copy the path — UI-only over existing tool_step data; nested tree unchanged
 - **Plan depth**: request-changes optional revision note (in-app modal → `session_resolve_plan` feedback); plan history search/filter by title·preview + decision chips, clear-all (in-app confirm), open chat when session still present
@@ -67,7 +68,7 @@ See `docs/llm-wiki/release.md`.
 - **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、会话规则（`--rules`）、会话最大轮次（`--max-turns` 覆盖；空/0 继承全局）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标、快捷键冲突面板（录制警告 + 重置冲突项）
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
-- **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选
+- **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选；**可靠性支持包**含脱敏卡顿时间线快照
 - **计划**：**请求修改** 可选修订说明；计划历史搜索/决策筛选、清空确认、会话仍在时可打开
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要
 - **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）

--- a/docs/features/diagnostics-center.md
+++ b/docs/features/diagnostics-center.md
@@ -14,7 +14,7 @@ Pure assembly: `src/lib/reliabilityCenter.ts` (`buildReliabilityCenter` / `assem
 | Stall signals | Active soft stall, liveMap `terminalReason: stall`, in-memory hard_end ring |
 | Recent errors | Current error-deck banner + in-memory ring of prior cards |
 
-Actions reuse Host APIs: `exportSupportBundle`, open Doctor. Does **not** scrape secrets from logs into the UI. Empty states are explicit when no signals are present.
+Actions reuse Host APIs: `exportSupportBundle`, open Doctor. Export from Reliability center also attaches a redacted **stall timeline** snapshot (`stall-timeline.json`: structured kinds/seconds/session ids only; Host runs `redact_text`). Does **not** scrape secrets from logs into the UI. Empty states are explicit when no signals are present.
 
 ## Host file logs
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1814,11 +1814,14 @@ fn truncate_cli_err(s: &str, max: usize) -> String {
     format!("{head}…")
 }
 
-/// Write a redacted support zip (Doctor JSON + logs) and return its path.
+/// Write a redacted support zip (Doctor JSON + logs + optional stall timeline) and return its path.
 /// Optionally opens a save dialog so the user can pick the destination.
+///
+/// `stall_timeline_json` is optional Reliability-center snapshot JSON (structured only).
 #[tauri::command]
 pub async fn export_support_bundle(
     doctor_json: Option<String>,
+    stall_timeline_json: Option<String>,
 ) -> Result<serde_json::Value, String> {
     let doctor = if let Some(j) = doctor_json.filter(|s| !s.trim().is_empty()) {
         j
@@ -1828,9 +1831,13 @@ pub async fn export_support_bundle(
         serde_json::to_string_pretty(&report).map_err(|e| e.to_string())?
     };
 
+    let stall = stall_timeline_json
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.to_string());
+
     // Zip + native save dialog must not block the async runtime (macOS rfd hangs).
     let tmp = tauri::async_runtime::spawn_blocking(move || {
-        crate::support_bundle::write_support_bundle(&doctor)
+        crate::support_bundle::write_support_bundle(&doctor, stall.as_deref())
     })
     .await
     .map_err(|e| e.to_string())??;

--- a/src-tauri/src/support_bundle.rs
+++ b/src-tauri/src/support_bundle.rs
@@ -17,8 +17,17 @@ use crate::store;
 const MAX_LOG_FILES: usize = 12;
 const MAX_LOG_BYTES_EACH: u64 = 512 * 1024;
 
+/// Max bytes accepted for an optional stall-timeline snapshot from the UI.
+const MAX_STALL_TIMELINE_BYTES: usize = 256 * 1024;
+
 /// Build a support zip under the system temp dir (caller may move/reveal it).
-pub fn write_support_bundle(doctor_json: &str) -> Result<PathBuf, String> {
+///
+/// `stall_timeline_json` is an optional Reliability-center stall timeline snapshot
+/// (structured signals only). Always redacted; never required.
+pub fn write_support_bundle(
+    doctor_json: &str,
+    stall_timeline_json: Option<&str>,
+) -> Result<PathBuf, String> {
     let root = paths::app_data_root();
     let stamp = Utc::now().format("%Y%m%d-%H%M%S");
     let out = std::env::temp_dir().join(format!("grok-app-support-{stamp}.zip"));
@@ -52,12 +61,30 @@ pub fn write_support_bundle(doctor_json: &str) -> Result<PathBuf, String> {
         "dataRootExists": root.is_dir(),
         "sessionCount": store::load_sessions_index().len(),
         "projectCount": store::load_projects().len(),
+        "hasStallTimeline": stall_timeline_json
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false),
     });
     let meta_s = serde_json::to_string_pretty(&meta).map_err(|e| e.to_string())?;
     zip.start_file("meta.json", opts)
         .map_err(|e| format!("zip meta: {e}"))?;
     zip.write_all(meta_s.as_bytes())
         .map_err(|e| format!("write meta: {e}"))?;
+
+    // 3b) Optional Reliability-center stall timeline (redacted structured snapshot)
+    if let Some(raw) = stall_timeline_json.map(str::trim).filter(|s| !s.is_empty()) {
+        let capped = if raw.len() > MAX_STALL_TIMELINE_BYTES {
+            // Prefer keeping a truncated valid-ish prefix over dropping entirely.
+            &raw[..MAX_STALL_TIMELINE_BYTES]
+        } else {
+            raw
+        };
+        let scrubbed = store::redact_text(capped);
+        zip.start_file("stall-timeline.json", opts)
+            .map_err(|e| format!("zip stall-timeline: {e}"))?;
+        zip.write_all(scrubbed.as_bytes())
+            .map_err(|e| format!("write stall-timeline: {e}"))?;
+    }
 
     // 4) Recent log files (capped + redacted)
     let log_dir = root.join("logs");
@@ -102,6 +129,7 @@ Contents:\n\
 - doctor.json — health checks (paths only, no keys)\n\
 - settings.json — app settings with secrets redacted\n\
 - meta.json — app/OS versions and counts\n\
+- stall-timeline.json — optional Reliability-center stall snapshot (redacted)\n\
 - logs/ — recent log files (redacted, size-capped)\n\
 \n\
 This archive never includes secrets.json or account auth snapshots.\n\
@@ -724,13 +752,77 @@ mod tests {
         fs::write(tmp.join("secrets.json"), r#"{"officialApiKey":"sk-secret"}"#).unwrap();
 
         std::env::set_var("GROK_APP_HOME", &tmp);
-        let zip_path = write_support_bundle(r#"{"summary":{"ok":1}}"#).expect("bundle");
+        let zip_path = write_support_bundle(r#"{"summary":{"ok":1}}"#, None).expect("bundle");
         assert!(zip_path.is_file());
         let bytes = fs::read(&zip_path).unwrap();
         // secrets.json must not appear as a zip entry name / content
         let as_str = String::from_utf8_lossy(&bytes);
         assert!(!as_str.contains("secrets.json"));
         assert!(!as_str.contains("sk-secret"));
+        assert!(!as_str.contains("stall-timeline.json"));
+        let _ = fs::remove_file(&zip_path);
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn support_bundle_includes_redacted_stall_timeline() {
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-app-bundle-stall-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+        fs::write(tmp.join("settings.json"), r#"{"locale":"en"}"#).unwrap();
+        // Present so redact_text can scrub known key material if it leaks into the snapshot.
+        fs::write(
+            tmp.join("secrets.json"),
+            r#"{"officialApiKey":"sk-stall-secret-key-value"}"#,
+        )
+        .unwrap();
+
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let timeline = r#"{
+  "kind": "stall_timeline",
+  "source": "reliability_center",
+  "count": 1,
+  "signals": [{
+    "id": "evt:hard_end:s1:1",
+    "sessionId": "s1",
+    "title": "Long run",
+    "kind": "hard_end",
+    "stallSeconds": 90,
+    "tier": "hard",
+    "reason": "stall sk-stall-secret-key-value",
+    "at": 1
+  }]
+}"#;
+        let zip_path =
+            write_support_bundle(r#"{"summary":{"ok":1}}"#, Some(timeline)).expect("bundle");
+        assert!(zip_path.is_file());
+        let bytes = fs::read(&zip_path).unwrap();
+        let as_str = String::from_utf8_lossy(&bytes);
+        // Entry name lives in the central directory (uncompressed).
+        assert!(as_str.contains("stall-timeline.json"));
+        assert!(!as_str.contains("secrets.json"));
+
+        // Deflated payload: open the archive and read the entry.
+        let file = fs::File::open(&zip_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).expect("open zip");
+        let mut entry = archive
+            .by_name("stall-timeline.json")
+            .expect("stall-timeline entry");
+        let mut body = String::new();
+        entry.read_to_string(&mut body).expect("read timeline");
+        assert!(body.contains("stall_timeline") || body.contains("hard_end"));
+        assert!(body.contains("Long run"));
+        assert!(
+            !body.contains("sk-stall-secret-key-value"),
+            "secret must be redacted from stall timeline: {body}"
+        );
+        assert!(body.contains("[REDACTED]") || !body.contains("sk-stall"));
+
         let _ = fs::remove_file(&zip_path);
         std::env::remove_var("GROK_APP_HOME");
         let _ = fs::remove_dir_all(&tmp);

--- a/src/components/ReliabilityCenterModal.tsx
+++ b/src/components/ReliabilityCenterModal.tsx
@@ -13,11 +13,13 @@ import {
 } from "@/components/icons";
 import { createT, type Locale, type MessageKey } from "@/i18n";
 import * as api from "@/lib/api";
-import type {
-  ReliabilityBusySession,
-  ReliabilityCenterView,
-  ReliabilityErrorEntry,
-  ReliabilityStallSignal,
+import {
+  buildStallTimelineSnapshot,
+  serializeStallTimelineSnapshot,
+  type ReliabilityBusySession,
+  type ReliabilityCenterView,
+  type ReliabilityErrorEntry,
+  type ReliabilityStallSignal,
 } from "@/lib/reliabilityCenter";
 
 export type ReliabilityCenterModalProps = {
@@ -220,14 +222,17 @@ export function ReliabilityCenterModal({
     setStatusMsg(null);
     setErrorMsg(null);
     try {
-      const res = await api.exportSupportBundle(null);
+      // Structured stall timeline only (titles/kinds/seconds) — host redacts secrets.
+      const timeline = buildStallTimelineSnapshot(view.stalls.signals);
+      const stallJson = serializeStallTimelineSnapshot(timeline);
+      const res = await api.exportSupportBundle(null, stallJson);
       setStatusMsg(`${t("doctor.supportZipDone")}: ${res.path}`);
     } catch (e) {
       setErrorMsg(`${t("doctor.supportZipFail")}: ${String(e)}`);
     } finally {
       setBusy(null);
     }
-  }, [t]);
+  }, [t, view.stalls.signals]);
 
   const openDoctor = () => {
     onClose();
@@ -362,7 +367,7 @@ export function ReliabilityCenterModal({
             className="btn btn--ghost btn--sm"
             disabled={!!busy}
             onClick={() => void onSupportZip()}
-            title={t("doctor.supportZipHint")}
+            title={t("reliability.supportZipHint")}
           >
             {busy === "zip" ? "…" : t("doctor.supportZip")}
           </button>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2041,6 +2041,8 @@ const en = {
   "reliability.openFromSettings": "Open reliability center",
   "reliability.settingsDesc":
     "Aggregate busy chats, stall signals, and recent error cards; export support zip.",
+  "reliability.supportZipHint":
+    "Redacted Doctor report, recent logs, and stall timeline snapshot (no secrets).",
 
   // Connection status pill
   "conn.idle": "Idle",
@@ -5017,6 +5019,8 @@ const zh: Record<MessageKey, string> = {
   "reliability.openFromSettings": "打开可靠性中心",
   "reliability.settingsDesc":
     "汇总忙碌会话、卡顿信号与最近错误卡片；可导出支持包。",
+  "reliability.supportZipHint":
+    "脱敏后的 Doctor 报告、近期日志与卡顿时间线快照（不含密钥）。",
 
   "conn.idle": "空闲",
   "conn.connecting": "连接中",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1926,6 +1926,8 @@ export const zhTW: Record<MessageKey, string> = {
   "reliability.openFromSettings": "開啟可靠性中心",
   "reliability.settingsDesc":
     "彙總忙碌工作階段、停滯訊號與最近錯誤卡片；可匯出支援包。",
+  "reliability.supportZipHint":
+    "脫敏後的 Doctor 報告、近期日誌與停滯時間線快照（不含金鑰）。",
   "doctor.advanced": "進階",
   "doctor.cliDoctor": "Grok Build CLI doctor",
   "doctor.cliDoctorHint": "來自 `grok doctor --json`（終端機、剪貼簿、色彩）。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1499,10 +1499,20 @@ export interface SupportBundleResult {
   sizeBytes?: number;
 }
 
-/** Build a redacted support zip (Doctor + logs) and save via native dialog. */
-export async function exportSupportBundle(doctorJson?: string | null) {
+/**
+ * Build a redacted support zip (Doctor + logs + optional stall timeline)
+ * and save via native dialog.
+ *
+ * `stallTimelineJson` is optional Reliability-center snapshot JSON
+ * (structured stall signals only; host redacts secrets).
+ */
+export async function exportSupportBundle(
+  doctorJson?: string | null,
+  stallTimelineJson?: string | null,
+) {
   return invoke<SupportBundleResult>("export_support_bundle", {
     doctorJson: doctorJson ?? null,
+    stallTimelineJson: stallTimelineJson ?? null,
   });
 }
 

--- a/src/lib/reliabilityCenter.test.ts
+++ b/src/lib/reliabilityCenter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   assembleReliabilityCenter,
   buildReliabilityCenter,
+  buildStallTimelineSnapshot,
   collectLiveStallSignals,
   collectReliabilityBusySessions,
   mergeErrorEntries,
@@ -9,6 +10,8 @@ import {
   prependReliabilityRing,
   reliabilityErrorFromDeck,
   reliabilityStallFromEvent,
+  serializeStallTimelineSnapshot,
+  STALL_TIMELINE_FIELD_MAX,
   type ReliabilityErrorEntry,
   type ReliabilityStallSignal,
 } from "./reliabilityCenter";
@@ -279,5 +282,113 @@ describe("buildReliabilityCenter", () => {
       sessions: [{ id: "x", title: "Idle" }],
     });
     expect(view.empty).toBe(true);
+  });
+});
+
+describe("buildStallTimelineSnapshot", () => {
+  it("builds a redacted support-bundle snapshot from stall signals", () => {
+    const signals: ReliabilityStallSignal[] = [
+      reliabilityStallFromEvent({
+        kind: "hard_end",
+        sessionId: "s1",
+        title: "Long run",
+        stallSeconds: 120,
+        tier: "hard",
+        reason: "stall",
+        at: 1000,
+      }),
+      {
+        id: "active:s2:45",
+        sessionId: "s2",
+        title: "Soft quiet",
+        kind: "active",
+        stallSeconds: 45,
+        tier: "soft",
+        reason: "stall",
+        at: 2000,
+      },
+    ];
+    const snap = buildStallTimelineSnapshot(signals, {
+      generatedAt: "2026-07-30T12:00:00.000Z",
+    });
+    expect(snap.kind).toBe("stall_timeline");
+    expect(snap.source).toBe("reliability_center");
+    expect(snap.generatedAt).toBe("2026-07-30T12:00:00.000Z");
+    expect(snap.count).toBe(2);
+    expect(snap.signals).toHaveLength(2);
+    expect(snap.signals[0]).toMatchObject({
+      sessionId: "s1",
+      title: "Long run",
+      kind: "hard_end",
+      stallSeconds: 120,
+      tier: "hard",
+      reason: "stall",
+      at: 1000,
+    });
+    // Only known keys — no accidental secret-bearing fields.
+    for (const row of snap.signals) {
+      expect(Object.keys(row).sort()).toEqual(
+        [
+          "at",
+          "id",
+          "kind",
+          "reason",
+          "sessionId",
+          "stallSeconds",
+          "tier",
+          "title",
+        ].sort(),
+      );
+    }
+    const json = serializeStallTimelineSnapshot(snap);
+    expect(json).toContain('"kind": "stall_timeline"');
+    expect(json).not.toContain("sk-");
+  });
+
+  it("caps title length and drops invalid kinds / duplicate ids", () => {
+    const long = "t".repeat(STALL_TIMELINE_FIELD_MAX + 40);
+    const signals = [
+      reliabilityStallFromEvent({
+        kind: "terminal",
+        sessionId: "a",
+        title: long,
+        at: 1,
+      }),
+      reliabilityStallFromEvent({
+        kind: "terminal",
+        sessionId: "a",
+        title: "dup-id-will-lose",
+        at: 1,
+      }),
+      {
+        id: "bad",
+        sessionId: null,
+        title: null,
+        kind: "not_a_kind" as ReliabilityStallSignal["kind"],
+        stallSeconds: null,
+        tier: null,
+        reason: null,
+        at: 2,
+      },
+    ];
+    // Force same id on second row
+    signals[1] = { ...signals[1]!, id: signals[0]!.id };
+    const snap = buildStallTimelineSnapshot(signals, { max: 10 });
+    expect(snap.count).toBe(1);
+    expect(snap.signals[0]!.title!.length).toBe(STALL_TIMELINE_FIELD_MAX);
+  });
+
+  it("honors max and empty input", () => {
+    expect(buildStallTimelineSnapshot([], { max: 5 }).count).toBe(0);
+    const many = Array.from({ length: 8 }, (_, i) =>
+      reliabilityStallFromEvent({
+        kind: "hard_end",
+        sessionId: `s${i}`,
+        at: i + 1,
+      }),
+    );
+    expect(buildStallTimelineSnapshot(many, { max: 3 }).signals).toHaveLength(
+      3,
+    );
   });
 });

--- a/src/lib/reliabilityCenter.ts
+++ b/src/lib/reliabilityCenter.ts
@@ -415,3 +415,125 @@ export function buildReliabilityCenter(opts: {
     maxErrors: opts.maxErrors,
   });
 }
+
+/** Cap for support-bundle stall timeline rows (UI view is smaller; allow a bit more headroom). */
+export const STALL_TIMELINE_SNAPSHOT_MAX = 40;
+/** Cap title/reason fields so the zip never carries multi-kb blobs. */
+export const STALL_TIMELINE_FIELD_MAX = 200;
+
+/** One row in the support-bundle stall timeline (known fields only). */
+export type StallTimelineSnapshotSignal = {
+  id: string;
+  sessionId: string | null;
+  title: string | null;
+  kind: ReliabilityStallKind;
+  stallSeconds: number | null;
+  tier: string | null;
+  reason: string | null;
+  at: number;
+};
+
+/**
+ * Redacted stall timeline for support zip export.
+ * Never includes secrets, log bodies, or free-form diagnostic dumps —
+ * only structured stall fields already shown in Reliability center.
+ */
+export type StallTimelineSnapshot = {
+  kind: "stall_timeline";
+  generatedAt: string;
+  source: "reliability_center";
+  count: number;
+  signals: StallTimelineSnapshotSignal[];
+};
+
+const STALL_TIMELINE_KINDS = new Set<ReliabilityStallKind>([
+  "active",
+  "hard_end",
+  "terminal",
+  "end_of_turn",
+]);
+
+function capStallField(raw: unknown, max: number = STALL_TIMELINE_FIELD_MAX): string | null {
+  if (typeof raw !== "string") return null;
+  const t = raw.replace(/\u0000/g, "").trim();
+  if (!t) return null;
+  return t.slice(0, Math.max(0, max));
+}
+
+/**
+ * Build a support-bundle-ready stall timeline from Reliability center signals.
+ * Drops unknown kinds / empty ids; caps title/reason/tier; never invents data.
+ */
+export function buildStallTimelineSnapshot(
+  signals: readonly ReliabilityStallSignal[],
+  opts?: {
+    nowMs?: number;
+    max?: number;
+    generatedAt?: string;
+  },
+): StallTimelineSnapshot {
+  const max = Math.max(
+    0,
+    Math.floor(opts?.max ?? STALL_TIMELINE_SNAPSHOT_MAX),
+  );
+  const generatedAt =
+    opts?.generatedAt ??
+    new Date(opts?.nowMs ?? Date.now()).toISOString();
+
+  const out: StallTimelineSnapshotSignal[] = [];
+  const seen = new Set<string>();
+  for (const s of signals) {
+    if (!s || typeof s !== "object") continue;
+    const kind = s.kind;
+    if (!STALL_TIMELINE_KINDS.has(kind)) continue;
+    const id = typeof s.id === "string" ? s.id.trim() : "";
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+
+    const sidRaw = s.sessionId;
+    const sessionId =
+      typeof sidRaw === "string"
+        ? sidRaw.trim() || null
+        : sidRaw == null
+          ? null
+          : null;
+
+    let stallSeconds: number | null = null;
+    if (typeof s.stallSeconds === "number" && Number.isFinite(s.stallSeconds)) {
+      const n = Math.round(s.stallSeconds);
+      if (n > 0) stallSeconds = n;
+    }
+
+    const at =
+      typeof s.at === "number" && Number.isFinite(s.at) && s.at >= 0
+        ? Math.floor(s.at)
+        : 0;
+
+    out.push({
+      id: id.slice(0, STALL_TIMELINE_FIELD_MAX),
+      sessionId,
+      title: capStallField(s.title),
+      kind,
+      stallSeconds,
+      tier: capStallField(s.tier, 64),
+      reason: capStallField(s.reason, 120) ?? "stall",
+      at,
+    });
+    if (out.length >= max) break;
+  }
+
+  return {
+    kind: "stall_timeline",
+    generatedAt,
+    source: "reliability_center",
+    count: out.length,
+    signals: out,
+  };
+}
+
+/** JSON string for Host `export_support_bundle` (pretty, known fields only). */
+export function serializeStallTimelineSnapshot(
+  snapshot: StallTimelineSnapshot,
+): string {
+  return JSON.stringify(snapshot, null, 2);
+}


### PR DESCRIPTION
## Summary
- Reliability center **Support zip** export attaches a redacted **stall timeline** snapshot (`stall-timeline.json`).
- Snapshot is structured only: stall kind, seconds, session id, capped title/reason/tier — never secrets, logs, or free-form dumps.
- Host `write_support_bundle` accepts optional timeline JSON, runs `redact_text`, size-caps the payload; Doctor export still works without a timeline.

## API
- `buildStallTimelineSnapshot` / `serializeStallTimelineSnapshot` in `src/lib/reliabilityCenter.ts`
- `exportSupportBundle(doctorJson?, stallTimelineJson?)` → Host `export_support_bundle`
- Zip entry: `stall-timeline.json` (+ `meta.hasStallTimeline`)

## Test plan
- [x] `pnpm test -- src/lib/reliabilityCenter.test.ts src/i18n/messages.test.ts` (34 passed)
- [x] `tsc --noEmit`
- [x] `cargo test --lib support_bundle` (4 passed, including redacted timeline entry)
- [ ] Manually: open Reliability center with stall signals → Support zip → archive contains `stall-timeline.json` without keys
- [ ] Doctor Advanced → Support zip still succeeds without timeline entry