### PR TITLE
feat(session): CLI --fork-session on Fork / Resume (new agent id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ See `docs/llm-wiki/release.md`.
 #### Sessions & sidebar
 - **Duplicate chat** (vs **Fork…** + optional worktree) · **session notes** · **mute** · **unread dot**
 - **Resume with code restore** — open an existing chat on a clean sibling git worktree at HEAD (session menu + command palette; dirty tree refused; same safety as Fork → restore code)
+- **CLI `--fork-session` on Fork / Resume**: optional checkbox (when a linked agent session exists) creates a **new** agent session id with parent context via ACP `session/fork` (Grok `_x.ai/session/fork` fallback) instead of reusing via `session/load`; one-shot `SessionMeta.forkAgentSession`; source agent session left unchanged
 - **Session rules** (per-chat `grok --rules`; session menu → GlassModal; soft-respawn on change)
 - **Session max agent turns** (per-chat `grok --max-turns` override; session menu → number input; 0/empty inherits global Settings 1–200; soft-respawn on change)
 - **Export** Markdown copy + **HTML export** · **bulk archive by age** · **date groups** · **project color**
@@ -64,7 +65,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 新增（按域）**
 
 - **输入/对话**：队列、高度、提示历史、宽度字号、工具折叠/过滤、重生选模型、字数、变更芯片、工作区 dirty 芯片、会话变更审阅（+/− · 并排 diff · j/k）、结构化 JSON 回复面板（校验/复制/导出）、上下文用量/费用粗估
-- **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、便签、会话规则（`--rules`）、会话最大轮次（`--max-turns` 覆盖；空/0 继承全局）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
+- **会话/侧栏**：复制 vs 分叉、恢复对话并还原代码（干净 worktree）、分叉/恢复可选 CLI `--fork-session`（新 agent session id，ACP `session/fork`）、便签、会话规则（`--rules`）、会话最大轮次（`--max-turns` 覆盖；空/0 继承全局）、静音、未读点、HTML 导出、按天归档、日期分组、项目色、j/k 导航、CLI 对齐 worktree（默认 `~/.grok/worktrees`、侧栏 CLI/WT 标记）
 - **外观/壳**：主题定时、跟随系统语言、忙碌退出确认、托盘角标、快捷键冲突面板（录制警告 + 重置冲突项）
 - **Agent**：禁用内置工具（芯片 + 自由列表 → `--disallowed-tools`；与禁用网页搜索并存；更改 soft-respawn）；可选 profile 路径（`--agent-profile`）
 - **系统**：**Agent serve** 启停（设置 → 运行时 → 连接）；**手机镜像写入审计**（本地 ring、无密钥/URL）；**Trace 历史管理**（搜索/移除/清空确认/可选大小）；任务面板子代理 **WT/cwd** 标记；**Agent 仪表盘** 状态/搜索/项目筛选

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -259,6 +259,41 @@ pub struct SpawnOptions {
     /// Per-session max turns override → top-level `grok --max-turns N`.
     /// When set (after normalize), wins over `AppSettings.max_agent_turns`.
     pub max_agent_turns: Option<u32>,
+    /// CLI `--fork-session` semantics: on open, fork the resume agent session
+    /// into a **new** agent id (ACP `session/fork`) instead of `session/load`.
+    /// Host sets this from `SessionMeta.fork_agent_session` for one-shot connect.
+    pub fork_session: bool,
+}
+
+/// Pure helper: top-level CLI args for `--fork-session`.
+///
+/// `["--fork-session"]` when enabled; empty otherwise. The TUI requires this
+/// with `--resume`/`--continue`. Host `agent stdio` uses ACP `session/fork`
+/// instead of bare CLI flags (CLI errors without resume).
+pub fn fork_session_spawn_flags(enabled: bool) -> Vec<&'static str> {
+    if enabled {
+        vec!["--fork-session"]
+    } else {
+        vec![]
+    }
+}
+
+/// Extract the forked agent session id from an ACP fork response.
+///
+/// Accepts standard `sessionId` or Grok extension `newSessionId`. Rejects empty
+/// and equal-to-source ids (fork must allocate a **new** id).
+pub fn parse_fork_session_id(result: &serde_json::Value, source_session_id: &str) -> Option<String> {
+    let raw = result
+        .get("sessionId")
+        .and_then(|v| v.as_str())
+        .or_else(|| result.get("newSessionId").and_then(|v| v.as_str()))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    // Fork semantics require a distinct id; reuse would mutate the source.
+    if raw == source_session_id.trim() {
+        return None;
+    }
+    Some(raw.to_string())
 }
 
 /// Pure helper: top-level CLI args for session extra rules (before `agent`).
@@ -741,11 +776,12 @@ impl AcpClient {
             cmd.env(k, v);
         }
         tracing::info!(
-            "acp: spawn home={} mode={} sandbox={:?} max_turns={:?} leader={} subagents={} memory={} agent_profile={:?}",
+            "acp: spawn home={} mode={} sandbox={:?} max_turns={:?} fork_session={} leader={} subagents={} memory={} agent_profile={:?}",
             grok_home.display(),
             session_data_mode,
             sandbox.as_ref().map(|s| s.profile.as_str()),
             max_turns.as_ref().map(|m| m.turns),
+            opts.fork_session,
             use_leader,
             subagents_enabled,
             memory_enabled,
@@ -1616,11 +1652,14 @@ impl AcpClient {
 
     /// Initialize + auth, then open a session.
     /// Prefer `session/load` when `resume_session_id` is set (Grok persists agent
-    /// sessions under GROK_HOME). Fall back to `session/new`.
+    /// sessions under GROK_HOME). When `fork_session` is true, use ACP
+    /// `session/fork` (CLI `--fork-session` semantics) for a **new** agent id
+    /// with the source context. Fall back to `session/new`.
     /// Returns `(session_id, resumed)`.
     pub async fn initialize_and_open_session(
         &self,
         resume_session_id: Option<&str>,
+        fork_session: bool,
     ) -> Result<(String, bool), AgentError> {
         // Do not advertise client fs methods we do not implement — avoids agent
         // hanging on fs/readTextFile while we never reply.
@@ -1634,11 +1673,12 @@ impl AcpClient {
             .map_err(|e| self.map_handshake_err("initialize", e))?;
 
         info!(
-            "acp initialized agentVersion={:?} loadSession={:?}",
+            "acp initialized agentVersion={:?} loadSession={:?} forkSession={}",
             init.pointer("/_meta/agentVersion")
                 .or_else(|| init.pointer("/agentVersion")),
             init.pointer("/agentCapabilities/loadSession")
-                .or_else(|| init.pointer("/capabilities/loadSession"))
+                .or_else(|| init.pointer("/capabilities/loadSession")),
+            fork_session
         );
 
         // Best-effort cached auth — short timeout so a hung auth cannot burn 120s.
@@ -1654,7 +1694,7 @@ impl AcpClient {
             Err(e) => warn!("acp authenticate soft-fail (continuing): {e}"),
         }
 
-        self.open_session(resume_session_id).await
+        self.open_session(resume_session_id, fork_session).await
     }
 
     /// Open or resume an ACP session on an already-initialized agent process.
@@ -1664,9 +1704,15 @@ impl AcpClient {
     ///
     /// Injects **enabled** MCP servers (App Extensions prefs + `grok mcp list`)
     /// into `mcpServers` so independent GROK_HOME and shared mode both see tools.
+    ///
+    /// When `fork_session` is true and `resume_session_id` is set, tries
+    /// `session/fork` (standard ACP) then `_x.ai/session/fork` (Grok extension)
+    /// before falling back to `session/new` — never `session/load` (would reuse
+    /// the source id and violate `--fork-session` semantics).
     pub async fn open_session(
         &self,
         resume_session_id: Option<&str>,
+        fork_session: bool,
     ) -> Result<(String, bool), AgentError> {
         let cwd = self.cwd.to_string_lossy().to_string();
         if !self.cwd.is_dir() {
@@ -1686,44 +1732,66 @@ impl AcpClient {
         let mcp_count = mcp_servers.as_array().map(|a| a.len()).unwrap_or(0);
         info!("acp session open injecting mcpServers count={mcp_count}");
 
-        // Prefer resuming the previous agent session for full native context.
-        // Note: session/load replays history as ACP notifications; Host must
-        // gate stream/tool side effects on `prompt_in_flight` (see session_manager).
         if let Some(rid) = resume_session_id.map(str::trim).filter(|s| !s.is_empty()) {
-            info!("acp session/load begin sessionId={rid} cwd={cwd}");
-            match self
-                .request_timeout(
-                    "session/load",
-                    json!({
-                        "sessionId": rid,
-                        "cwd": cwd,
-                        "mcpServers": mcp_servers.clone()
-                    }),
-                    HANDSHAKE_TIMEOUT_SECS,
-                )
-                .await
-            {
-                Ok(result) => {
-                    let sid = result
-                        .get("sessionId")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or(rid)
-                        .to_string();
-                    info!("acp session/load ok sessionId={sid}");
+            // CLI `--fork-session`: new agent session id with parent context.
+            if fork_session {
+                if let Some((sid, model_id)) = self
+                    .try_fork_session(rid, &cwd, &mcp_servers)
+                    .await
+                {
                     *self.agent_session_id.lock() = Some(sid.clone());
-                    let model_id = result
-                        .pointer("/models/currentModelId")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string());
                     let _ = self.event_tx.send(AcpEvent::State {
                         backend: "grok_agent_stdio".into(),
                         agent_session_id: Some(sid.clone()),
                         model_id,
                     });
+                    // Full parent context was forked — treat like a successful resume
+                    // for bootstrap purposes (no journal rewrite needed).
                     return Ok((sid, true));
                 }
-                Err(e) => {
-                    warn!("acp session/load fail ({e}); falling back to session/new");
+                warn!(
+                    "acp session/fork failed for source={rid}; falling back to session/new (will not reuse source id)"
+                );
+                // Fall through to session/new — do not session/load (would mutate source).
+            } else {
+                // Prefer resuming the previous agent session for full native context.
+                // Note: session/load replays history as ACP notifications; Host must
+                // gate stream/tool side effects on `prompt_in_flight` (see session_manager).
+                info!("acp session/load begin sessionId={rid} cwd={cwd}");
+                match self
+                    .request_timeout(
+                        "session/load",
+                        json!({
+                            "sessionId": rid,
+                            "cwd": cwd,
+                            "mcpServers": mcp_servers.clone()
+                        }),
+                        HANDSHAKE_TIMEOUT_SECS,
+                    )
+                    .await
+                {
+                    Ok(result) => {
+                        let sid = result
+                            .get("sessionId")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(rid)
+                            .to_string();
+                        info!("acp session/load ok sessionId={sid}");
+                        *self.agent_session_id.lock() = Some(sid.clone());
+                        let model_id = result
+                            .pointer("/models/currentModelId")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                        let _ = self.event_tx.send(AcpEvent::State {
+                            backend: "grok_agent_stdio".into(),
+                            agent_session_id: Some(sid.clone()),
+                            model_id,
+                        });
+                        return Ok((sid, true));
+                    }
+                    Err(e) => {
+                        warn!("acp session/load fail ({e}); falling back to session/new");
+                    }
                 }
             }
         }
@@ -1769,9 +1837,81 @@ impl AcpClient {
         Ok((sid, false))
     }
 
+    /// Try standard ACP `session/fork`, then Grok `_x.ai/session/fork`.
+    /// Returns `(new_session_id, model_id)` on success.
+    async fn try_fork_session(
+        &self,
+        source_session_id: &str,
+        cwd: &str,
+        mcp_servers: &serde_json::Value,
+    ) -> Option<(String, Option<String>)> {
+        info!(
+            "acp session/fork begin sourceSessionId={source_session_id} cwd={cwd}"
+        );
+        // Standard ACP ForkSessionRequest: sessionId + cwd + mcpServers.
+        match self
+            .request_timeout(
+                "session/fork",
+                json!({
+                    "sessionId": source_session_id,
+                    "cwd": cwd,
+                    "mcpServers": mcp_servers.clone()
+                }),
+                HANDSHAKE_TIMEOUT_SECS,
+            )
+            .await
+        {
+            Ok(result) => {
+                if let Some(sid) = parse_fork_session_id(&result, source_session_id) {
+                    info!("acp session/fork ok newSessionId={sid}");
+                    let model_id = result
+                        .pointer("/models/currentModelId")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    return Some((sid, model_id));
+                }
+                warn!("acp session/fork response missing sessionId");
+            }
+            Err(e) => {
+                warn!("acp session/fork fail ({e}); trying _x.ai/session/fork");
+            }
+        }
+
+        // Grok Build extension (vscode / older agents): sourceSessionId + sourceCwd + newCwd.
+        match self
+            .request_timeout(
+                "_x.ai/session/fork",
+                json!({
+                    "sourceSessionId": source_session_id,
+                    "sourceCwd": cwd,
+                    "newCwd": cwd,
+                }),
+                HANDSHAKE_TIMEOUT_SECS,
+            )
+            .await
+        {
+            Ok(result) => {
+                if let Some(sid) = parse_fork_session_id(&result, source_session_id) {
+                    info!("acp _x.ai/session/fork ok newSessionId={sid}");
+                    let model_id = result
+                        .pointer("/models/currentModelId")
+                        .and_then(|v| v.as_str())
+                        .or_else(|| result.get("newModelId").and_then(|v| v.as_str()))
+                        .map(|s| s.to_string());
+                    return Some((sid, model_id));
+                }
+                warn!("acp _x.ai/session/fork response missing sessionId");
+            }
+            Err(e) => {
+                warn!("acp _x.ai/session/fork fail ({e})");
+            }
+        }
+        None
+    }
+
     /// Back-compat: always create a new session.
     pub async fn initialize_and_new_session(&self) -> Result<String, AgentError> {
-        self.initialize_and_open_session(None)
+        self.initialize_and_open_session(None, false)
             .await
             .map(|(sid, _)| sid)
     }
@@ -3405,6 +3545,34 @@ mod disallowed_tools_spawn_tests {
             &["B".into(), "A".into()]
         ));
         assert!(!disallowed_tools_equal(&["a".into()], &["a".into(), "b".into()]));
+    }
+}
+
+#[cfg(test)]
+mod fork_session_spawn_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn spawn_flags_toggle() {
+        assert!(fork_session_spawn_flags(false).is_empty());
+        assert_eq!(fork_session_spawn_flags(true), vec!["--fork-session"]);
+    }
+
+    #[test]
+    fn parse_fork_id_standard_and_extension() {
+        assert_eq!(
+            parse_fork_session_id(&json!({ "sessionId": "child-1" }), "parent"),
+            Some("child-1".into())
+        );
+        assert_eq!(
+            parse_fork_session_id(&json!({ "newSessionId": "child-2" }), "parent"),
+            Some("child-2".into())
+        );
+        // Reject empty / same-as-source (would not be a real fork).
+        assert!(parse_fork_session_id(&json!({ "sessionId": "parent" }), "parent").is_none());
+        assert!(parse_fork_session_id(&json!({ "sessionId": "  " }), "parent").is_none());
+        assert!(parse_fork_session_id(&json!({}), "parent").is_none());
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -119,13 +119,41 @@ pub async fn session_rewind_execute(
 }
 
 /// Fork a session into a new chat (same project, messages up to optional cut).
+///
+/// When `fork_agent_session` is true and the source has an agent id, the new
+/// chat carries that id with a one-shot fork flag so the next connect uses
+/// CLI `--fork-session` semantics (ACP `session/fork` → new agent id).
 #[tauri::command]
 pub fn session_fork(
     source_id: String,
     through_user_prompt_index: Option<u32>,
     title: Option<String>,
+    fork_agent_session: Option<bool>,
 ) -> Result<store::SessionMeta, String> {
-    store::fork_session(&source_id, through_user_prompt_index, title)
+    store::fork_session(
+        &source_id,
+        through_user_prompt_index,
+        title,
+        fork_agent_session.unwrap_or(false),
+    )
+}
+
+/// Set the one-shot CLI `--fork-session` flag (new agent id on next connect).
+/// Soft-respawns the live agent for this chat when the flag is armed so the
+/// next connect can fork instead of reusing the warm process.
+#[tauri::command]
+pub async fn session_set_fork_agent_session(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    id: String,
+    fork_agent_session: bool,
+) -> Result<store::SessionMeta, String> {
+    let meta = store::set_session_fork_agent_session(&id, fork_agent_session)?;
+    let snap = mgr.snapshot();
+    if fork_agent_session && snap.session_id.as_deref() == Some(meta.id.as_str()) {
+        mgr.soft_respawn_with_reason(&app, "session_fork_agent").await;
+    }
+    Ok(meta)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -298,6 +298,7 @@ pub fn run() {
             commands::session_set_plugin_dirs,
             commands::session_set_extra_rules,
             commands::session_set_max_agent_turns,
+            commands::session_set_fork_agent_session,
             commands::session_set_scheduled,
             commands::session_messages,
             commands::session_media_root,

--- a/src-tauri/src/remote_im/app_sessions.rs
+++ b/src-tauri/src/remote_im/app_sessions.rs
@@ -213,6 +213,7 @@ mod tests {
             plugin_dirs: Vec::new(),
             extra_rules: None,
             max_agent_turns: None,
+            fork_agent_session: false,
         }
     }
 

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -2494,11 +2494,70 @@ impl SessionManager {
         let policy = PermissionPolicy::parse(&prefs.permission_policy);
         let agent_model = crate::providers::agent_spawn_model_id(&prefs.model_id);
 
+        // Pending CLI --fork-session: must cold-spawn so open can call session/fork.
+        // Never no-op / unpark a warm process that still holds the source agent id.
+        let pending_fork = meta.fork_agent_session
+            && meta
+                .agent_session_id
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|s| !s.is_empty());
+        if pending_fork {
+            // Drop live/bg/parked shells for this App session so cold spawn can fork.
+            let acp_to_kill = {
+                let mut guard = self.inner.lock();
+                if let Some(s) = guard.as_mut() {
+                    if s.app_session_id == meta.id {
+                        if Self::live_session_is_busy(s) {
+                            tracing::warn!(
+                                "connect fork pending but live mid-turn; deferring fork sid={}",
+                                meta.id
+                            );
+                            return Ok(self.snapshot());
+                        }
+                        let acp = s.acp.take();
+                        s.needs_history_bootstrap = false;
+                        s.fsm.soft_disconnect();
+                        s.process_id = String::new();
+                        acp
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            };
+            let bg_acp = self
+                .background
+                .lock()
+                .remove(&meta.id)
+                .and_then(|mut bg| bg.acp.take());
+            let parked_acp = self
+                .parked
+                .lock()
+                .remove(&meta.id)
+                .map(|p| p.acp);
+            if let Some(acp) = acp_to_kill {
+                acp.kill().await;
+            }
+            if let Some(acp) = bg_acp {
+                acp.kill().await;
+            }
+            if let Some(acp) = parked_acp {
+                acp.kill().await;
+            }
+            tracing::info!(
+                target: "session",
+                session = %meta.id,
+                "connect pending fork_agent_session — forced cold spawn"
+            );
+        }
+
         // Already live on this App session with a healthy agent → no-op.
         // Includes mid-turn (streaming / open tools): never respawn or cancel.
         // Never no-op on Disconnected/Idle — leftover busy flags after fail_with
         // must not block reconnect (see `should_preserve_live_process`).
-        {
+        if !pending_fork {
             let mut guard = self.inner.lock();
             if let Some(s) = guard.as_mut() {
                 if s.app_session_id == meta.id
@@ -2525,7 +2584,7 @@ impl SessionManager {
         }
 
         // Target already streaming in background → promote to focus.
-        if self.background.lock().contains_key(&meta.id) {
+        if !pending_fork && self.background.lock().contains_key(&meta.id) {
             if let Err(e) = self.try_park_live_emit(&app) {
                 Self::emit_process_limit(&app, Some(&meta.id), max_concurrent);
                 return Err(format!("{}: {}", e.code.as_str(), e.message));
@@ -2540,7 +2599,7 @@ impl SessionManager {
         }
 
         // Target already parked (warm multi-session) → unpark.
-        if self.parked.lock().contains_key(&meta.id) {
+        if !pending_fork && self.parked.lock().contains_key(&meta.id) {
             // Park current live if needed (busy → demote to background / park).
             if let Err(e) = self.try_park_live_emit(&app) {
                 Self::emit_process_limit(&app, Some(&meta.id), max_concurrent);
@@ -2775,6 +2834,12 @@ impl SessionManager {
             &settings.sandbox_profile,
             project_sandbox.as_deref(),
         );
+        // One-shot CLI --fork-session: only when meta asks and we have a source id.
+        let fork_agent = meta.fork_agent_session
+            && resume_agent_sid
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|s| !s.is_empty());
         let spawn_opts = crate::acp_client::SpawnOptions {
             model_id: Some(agent_model.clone()),
             effort: Some(prefs.effort.clone()),
@@ -2793,6 +2858,7 @@ impl SessionManager {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty()),
             max_agent_turns: meta.max_agent_turns,
+            fork_session: fork_agent,
         };
 
         let (client, mut events) = match AcpClient::spawn_with_options(cli_path, cwd, spawn_opts)
@@ -2802,6 +2868,7 @@ impl SessionManager {
                     target: "session",
                     session = %meta.id,
                     process = %process_id,
+                    fork_session = fork_agent,
                     "connect spawn_ok"
                 );
                 v
@@ -2842,11 +2909,17 @@ impl SessionManager {
             target: "session",
             session = %meta.id,
             resume_agent = ?resume_agent_sid,
+            fork_session = fork_agent,
             "connect session_open_begin"
         );
         let open_result = client
-            .initialize_and_open_session(resume_agent_sid.as_deref())
+            .initialize_and_open_session(resume_agent_sid.as_deref(), fork_agent)
             .await;
+
+        // One-shot flag: clear whether fork succeeded or fell through to new/load.
+        if meta.fork_agent_session {
+            let _ = store::clear_session_fork_agent_session(&meta.id);
+        }
 
         match open_result {
             Ok((agent_sid, resumed)) => {
@@ -2857,14 +2930,15 @@ impl SessionManager {
                 if let Err(e) = client.set_mode(&prefs.mode).await {
                     tracing::warn!("acp set_mode after session open soft-fail: {e}");
                 }
-                // Native resume = full agent context. Fresh session + existing UI
-                // journal → bootstrap history into the next prompt.
+                // Native resume / successful fork = full agent context. Fresh
+                // session + existing UI journal → bootstrap history into the next prompt.
                 let need_bootstrap = !resumed && journal_has_history;
                 if resumed {
                     tracing::info!(
                         target: "session",
                         session = %meta.id,
                         agent = %agent_sid,
+                        forked = fork_agent,
                         "connect session_open_ok resumed=true (full context)"
                     );
                 } else if need_bootstrap {
@@ -2889,6 +2963,7 @@ impl SessionManager {
                         s.acp = Some(client);
                         s.process_id = process_id;
                         s.meta.agent_session_id = Some(agent_sid);
+                        s.meta.fork_agent_session = false;
                         s.meta.model_id = Some(prefs.model_id.clone());
                         s.meta.mode = Some(prefs.mode.clone());
                         s.meta.effort = Some(prefs.effort.clone());
@@ -5825,6 +5900,7 @@ mod connect_preserve_tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                fork_agent_session: false,
             },
             fsm,
             backend: "grok_agent_stdio".into(),
@@ -6010,6 +6086,7 @@ mod session_routing_tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                fork_agent_session: false,
             },
             fsm,
             backend: "mock_acp".into(),
@@ -6176,6 +6253,7 @@ mod session_routing_tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                fork_agent_session: false,
             },
             fsm,
             backend: "mock_acp".into(),
@@ -6279,6 +6357,7 @@ mod session_routing_tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                fork_agent_session: false,
             },
             fsm,
             backend: "mock_acp".into(),

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -166,6 +166,12 @@ pub struct SessionMeta {
     /// `None` / 0 → inherit global `AppSettings.max_agent_turns`. Soft-respawn on change.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_agent_turns: Option<u32>,
+    /// One-shot CLI `--fork-session` semantics: on next connect, fork the agent
+    /// session (ACP `session/fork`) so the chat gets a **new** agent session id
+    /// with the source’s context instead of reusing via `session/load`.
+    /// Requires `agent_session_id` as the source; cleared after connect attempt.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub fork_agent_session: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1020,6 +1026,7 @@ pub fn create_session(
         plugin_dirs: Vec::new(),
         extra_rules: None,
         max_agent_turns: None,
+        fork_agent_session: false,
     };
     let mut list = load_sessions_index();
     list.insert(0, meta.clone());
@@ -1379,12 +1386,20 @@ pub fn truncate_through_user_prompt(
     Ok(messages[..end].to_vec())
 }
 
-/// Fork a session: new journal + meta, same project, no agent session id.
+/// Fork a session: new journal + meta, same project.
+///
+/// By default the fork has **no** `agent_session_id` (next connect → `session/new`
+/// + journal bootstrap). When `fork_agent_session` is true and the source has an
+/// agent id, the fork carries that id with `fork_agent_session=true` so the next
+/// connect uses CLI `--fork-session` semantics (ACP `session/fork` → new agent id,
+/// full parent context, source agent session left untouched).
+///
 /// `through_user_prompt_index`: when set, copy only through that user turn (inclusive).
 pub fn fork_session(
     source_id: &str,
     through_user_prompt_index: Option<u32>,
     title: Option<String>,
+    fork_agent_session: bool,
 ) -> Result<SessionMeta, String> {
     let list = load_sessions_index();
     let source = list
@@ -1424,6 +1439,19 @@ pub fn fork_session(
     meta.plugin_dirs = source.plugin_dirs.clone();
     meta.extra_rules = source.extra_rules.clone();
     meta.max_agent_turns = source.max_agent_turns;
+    // CLI --fork-session: resume parent agent context under a new agent id.
+    let source_agent = source
+        .agent_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    if fork_agent_session {
+        if let Some(aid) = source_agent {
+            meta.agent_session_id = Some(aid);
+            meta.fork_agent_session = true;
+        }
+    }
     meta.updated_at = Utc::now();
     update_session_meta(&meta)?;
 
@@ -1439,6 +1467,36 @@ pub fn fork_session(
         .collect();
     save_messages(&meta.id, &forked)?;
     Ok(meta)
+}
+
+/// Set or clear the one-shot CLI `--fork-session` flag on a session.
+///
+/// When `true`, next connect forks `agent_session_id` into a new agent id.
+/// Requires a non-empty `agent_session_id` to enable; otherwise stores `false`.
+pub fn set_session_fork_agent_session(
+    id: &str,
+    fork_agent_session: bool,
+) -> Result<SessionMeta, String> {
+    let mut list = load_sessions_index();
+    let s = list
+        .iter_mut()
+        .find(|s| s.id == id)
+        .ok_or_else(|| "session not found".to_string())?;
+    let has_agent = s
+        .agent_session_id
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|a| !a.is_empty());
+    s.fork_agent_session = fork_agent_session && has_agent;
+    s.updated_at = Utc::now();
+    let clone = s.clone();
+    save_sessions_index(&list)?;
+    Ok(clone)
+}
+
+/// Clear the one-shot fork flag after a connect attempt (success or fallthrough).
+pub fn clear_session_fork_agent_session(id: &str) -> Result<SessionMeta, String> {
+    set_session_fork_agent_session(id, false)
 }
 
 // ─── Automations (scheduled tasks shell) ───────────────────────────────────
@@ -2256,6 +2314,7 @@ mod tests {
             plugin_dirs: Vec::new(),
             extra_rules: None,
             max_agent_turns: None,
+            fork_agent_session: false,
         }
     }
 
@@ -2441,6 +2500,7 @@ mod tests {
                 plugin_dirs: Vec::new(),
                 extra_rules: None,
                 max_agent_turns: None,
+                fork_agent_session: false,
             },
         );
         write_json(&sessions_index_file(), &sessions).expect("seed sessions");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -560,7 +560,9 @@ import {
 } from "@/lib/gitWorktree";
 import {
   buildForkWorktreeName,
+  canOfferForkAgentSession,
   canRestoreCodeOnFork,
+  resolveForkAgentSession,
 } from "@/lib/sessionFork";
 import {
   buildResumeWorktreeName,
@@ -870,6 +872,8 @@ interface SessionRow {
   extraRules?: string | null;
   /** Per-session max agent turns (`--max-turns`); null = inherit global. */
   maxAgentTurns?: number | null;
+  /** Linked Grok agent session id (for CLI `--fork-session` / session/load). */
+  agentSessionId?: string | null;
 }
 
 /** Normalize sessions_list / create rows into sidebar SessionRow shape. */
@@ -879,11 +883,13 @@ function normalizeSessionRow(
     title?: string;
     projectId?: string | null;
     updatedAt?: string;
+    agentSessionId?: string | null;
   },
 ): SessionRow {
   const worktreePath = (x.worktreePath || "").trim() || null;
   const worktreeBranch = (x.worktreeBranch || "").trim() || null;
   const isWorktreeSession = !!(x.isWorktreeSession || worktreePath);
+  const agentSessionId = (x.agentSessionId || "").trim() || null;
   return {
     id: x.id,
     title: x.title || "",
@@ -895,6 +901,7 @@ function normalizeSessionRow(
     worktreePath,
     worktreeBranch,
     isWorktreeSession,
+    agentSessionId,
   };
 }
 
@@ -911,6 +918,7 @@ function mapSessionListRow(
     pluginDirs?: string[] | null;
     extraRules?: string | null;
     maxAgentTurns?: number | null;
+    agentSessionId?: string | null;
   },
 ): SessionRow {
   const schema =
@@ -1295,16 +1303,19 @@ export default function App() {
     preview?: string;
   } | null>(null);
   const [rewindRestoreFiles, setRewindRestoreFiles] = useState(false);
-  /** Fork chat confirm + optional restore-code (default off). */
+  /** Fork chat confirm + optional restore-code / CLI --fork-session (default off). */
   const [forkConfirm, setForkConfirm] = useState<{
     source: SessionRow;
     throughUserPromptIndex?: number | null;
   } | null>(null);
   const [forkRestoreCode, setForkRestoreCode] = useState(false);
+  /** CLI `--fork-session`: new agent session id with parent context. */
+  const [forkCliSession, setForkCliSession] = useState(false);
   const [forkBusy, setForkBusy] = useState(false);
   /** Resume existing chat on a clean worktree (restore-code). */
   const [resumeRestoreConfirm, setResumeRestoreConfirm] =
     useState<SessionRow | null>(null);
+  const [resumeForkCliSession, setResumeForkCliSession] = useState(false);
   const [resumeRestoreBusy, setResumeRestoreBusy] = useState(false);
   /** Last user message open in inline edit (not main composer). */
   const [editingUserMessageId, setEditingUserMessageId] = useState<
@@ -9206,6 +9217,7 @@ export default function App() {
    * Fork a session (full history or through a user-prompt index) and open it.
    * Optional restore-code: when clean git work tree, create a sibling worktree
    * at HEAD and bind the forked session to that path (never force on dirty).
+   * Optional CLI `--fork-session`: new agent session id with parent context.
    */
   const runForkSession = useCallback(
     async (
@@ -9213,6 +9225,7 @@ export default function App() {
       opts?: {
         throughUserPromptIndex?: number | null;
         restoreCode?: boolean;
+        forkCliSession?: boolean;
       },
     ) => {
       if (!api.isTauri()) {
@@ -9220,6 +9233,10 @@ export default function App() {
         return;
       }
       const restoreCode = !!opts?.restoreCode;
+      const forkResolved = resolveForkAgentSession({
+        wantFork: !!opts?.forkCliSession,
+        agentSessionId: source.agentSessionId,
+      });
       setForkBusy(true);
       try {
         const sourceProjectId = normalizeProjectId(source.projectId);
@@ -9323,6 +9340,7 @@ export default function App() {
         const meta = await api.sessionFork(source.id, {
           throughUserPromptIndex: opts?.throughUserPromptIndex ?? null,
           title,
+          forkAgentSession: forkResolved.fork,
         });
 
         // Rebind fork to the worktree project when restore-code succeeded.
@@ -9348,6 +9366,7 @@ export default function App() {
 
         setForkConfirm(null);
         setForkRestoreCode(false);
+        setForkCliSession(false);
         await refreshSessions();
         const row = normalizeSessionRow({
           ...source,
@@ -9361,6 +9380,9 @@ export default function App() {
           archived: meta.archived,
           pinned: !!(meta as SessionRow).pinned,
           scheduled: meta.scheduled,
+          agentSessionId:
+            (meta as SessionRow).agentSessionId ??
+            (forkResolved.fork ? forkResolved.sourceAgentId : null),
         });
         const proj =
           (projectId
@@ -9380,8 +9402,12 @@ export default function App() {
         await openSession(row, openProj);
         showToast(
           restoredWorktree
-            ? tr("session.forkOkRestore")
-            : tr("session.forkOk"),
+            ? forkResolved.fork
+              ? tr("session.forkOkRestoreCli")
+              : tr("session.forkOkRestore")
+            : forkResolved.fork
+              ? tr("session.forkOkCli")
+              : tr("session.forkOk"),
           2800,
         );
       } catch (e) {
@@ -9399,20 +9425,31 @@ export default function App() {
     (source: SessionRow, throughUserPromptIndex?: number | null) => {
       setCtxMenu(null);
       setForkRestoreCode(false);
+      // Prefer live snapshot agent id when forking the open chat.
+      const agentId =
+        source.agentSessionId ||
+        (session.sessionId === source.id ? session.agentSessionId : null);
+      const enriched = { ...source, agentSessionId: agentId ?? null };
+      // Default on when the source has an agent session to fork (full context).
+      setForkCliSession(canOfferForkAgentSession(enriched.agentSessionId));
       setForkConfirm({
-        source,
+        source: enriched,
         throughUserPromptIndex: throughUserPromptIndex ?? null,
       });
     },
-    [],
+    [session.sessionId, session.agentSessionId],
   );
 
   /**
    * Resume an existing session on a clean sibling worktree at current HEAD.
    * Reuses the fork restore-code dirty gate; does not clone the journal.
+   * Optional CLI `--fork-session`: new agent session id (source agent left intact).
    */
   const runResumeWithCodeRestore = useCallback(
-    async (source: SessionRow) => {
+    async (
+      source: SessionRow,
+      opts?: { forkCliSession?: boolean },
+    ) => {
       if (!api.isTauri()) {
         showToast(tr("error.needTauri"));
         return;
@@ -9427,6 +9464,10 @@ export default function App() {
         showToast(tr("session.resumeRestoreBusy"), 3500);
         return;
       }
+      const forkResolved = resolveForkAgentSession({
+        wantFork: !!opts?.forkCliSession,
+        agentSessionId: source.agentSessionId,
+      });
       setResumeRestoreBusy(true);
       try {
         const sourceProjectId = normalizeProjectId(source.projectId);
@@ -9532,7 +9573,20 @@ export default function App() {
           /* soft-fail badge meta */
         }
 
+        if (forkResolved.fork) {
+          try {
+            await api.sessionSetForkAgentSession(source.id, true);
+          } catch (e) {
+            showToast(
+              tr("session.forkCliFailed") + ": " + String(e),
+              4500,
+            );
+            // Worktree rebind still succeeded — continue without agent fork.
+          }
+        }
+
         setResumeRestoreConfirm(null);
+        setResumeForkCliSession(false);
         await refreshSessions();
         await refreshGitWorktrees();
         const row = normalizeSessionRow({
@@ -9545,7 +9599,12 @@ export default function App() {
         });
         setExpandedProjects((e) => ({ ...e, [bindProject!.id]: true }));
         await openSession(row, bindProject);
-        showToast(tr("session.resumeRestoreOk"), 2800);
+        showToast(
+          forkResolved.fork
+            ? tr("session.resumeRestoreOkCli")
+            : tr("session.resumeRestoreOk"),
+          2800,
+        );
       } catch (e) {
         showToast(
           tr("session.resumeRestoreFailed") + ": " + String(e),
@@ -9560,10 +9619,21 @@ export default function App() {
     [projects, showToast, tr, session.sessionId],
   );
 
-  const confirmResumeWithCodeRestore = useCallback((source: SessionRow) => {
-    setCtxMenu(null);
-    setResumeRestoreConfirm(source);
-  }, []);
+  const confirmResumeWithCodeRestore = useCallback(
+    (source: SessionRow) => {
+      setCtxMenu(null);
+      const agentId =
+        source.agentSessionId ||
+        (session.sessionId === source.id ? session.agentSessionId : null);
+      // Default off (reuse agent id); user can opt into CLI --fork-session.
+      setResumeForkCliSession(false);
+      setResumeRestoreConfirm({
+        ...source,
+        agentSessionId: agentId ?? null,
+      });
+    },
+    [session.sessionId, session.agentSessionId],
+  );
 
   /**
    * Duplicate a session: full journal clone via sessionFork (no cut, no restore-code).
@@ -17306,6 +17376,7 @@ export default function App() {
           if (forkBusy) return;
           setForkConfirm(null);
           setForkRestoreCode(false);
+          setForkCliSession(false);
         }}
         title={tr("session.forkTitle")}
         size="sm"
@@ -17323,6 +17394,7 @@ export default function App() {
               onClick={() => {
                 setForkConfirm(null);
                 setForkRestoreCode(false);
+                setForkCliSession(false);
               }}
             >
               {tr("common.cancel")}
@@ -17337,6 +17409,7 @@ export default function App() {
                   throughUserPromptIndex:
                     forkConfirm.throughUserPromptIndex ?? null,
                   restoreCode: forkRestoreCode,
+                  forkCliSession,
                 });
               }}
             >
@@ -17364,6 +17437,22 @@ export default function App() {
           <p className="fork-confirm__hint">
             {tr("session.forkRestoreCodeHint")}
           </p>
+          {canOfferForkAgentSession(forkConfirm?.source.agentSessionId) ? (
+            <>
+              <label className="fork-confirm__restore">
+                <input
+                  type="checkbox"
+                  checked={forkCliSession}
+                  disabled={forkBusy}
+                  onChange={(e) => setForkCliSession(e.target.checked)}
+                />
+                <span>{tr("session.forkCliSession")}</span>
+              </label>
+              <p className="fork-confirm__hint">
+                {tr("session.forkCliSessionHint")}
+              </p>
+            </>
+          ) : null}
         </div>
       </GlassModal>
 
@@ -17372,6 +17461,7 @@ export default function App() {
         onClose={() => {
           if (resumeRestoreBusy) return;
           setResumeRestoreConfirm(null);
+          setResumeForkCliSession(false);
         }}
         title={tr("session.resumeRestoreTitle")}
         size="sm"
@@ -17386,7 +17476,10 @@ export default function App() {
               type="button"
               className="btn btn--ghost"
               disabled={resumeRestoreBusy}
-              onClick={() => setResumeRestoreConfirm(null)}
+              onClick={() => {
+                setResumeRestoreConfirm(null);
+                setResumeForkCliSession(false);
+              }}
             >
               {tr("common.cancel")}
             </button>
@@ -17396,7 +17489,9 @@ export default function App() {
               disabled={resumeRestoreBusy || !resumeRestoreConfirm}
               onClick={() => {
                 if (!resumeRestoreConfirm) return;
-                void runResumeWithCodeRestore(resumeRestoreConfirm);
+                void runResumeWithCodeRestore(resumeRestoreConfirm, {
+                  forkCliSession: resumeForkCliSession,
+                });
               }}
             >
               {resumeRestoreBusy
@@ -17413,6 +17508,26 @@ export default function App() {
           <p className="fork-confirm__hint">
             {tr("session.resumeRestoreHint")}
           </p>
+          {canOfferForkAgentSession(
+            resumeRestoreConfirm?.agentSessionId,
+          ) ? (
+            <>
+              <label className="fork-confirm__restore">
+                <input
+                  type="checkbox"
+                  checked={resumeForkCliSession}
+                  disabled={resumeRestoreBusy}
+                  onChange={(e) =>
+                    setResumeForkCliSession(e.target.checked)
+                  }
+                />
+                <span>{tr("session.forkCliSession")}</span>
+              </label>
+              <p className="fork-confirm__hint">
+                {tr("session.resumeForkCliSessionHint")}
+              </p>
+            </>
+          ) : null}
         </div>
       </GlassModal>
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -209,6 +209,18 @@ const en = {
   "session.forkRestoreFailed": "Could not create a worktree for restore",
   "session.forkRestoreBindFailed":
     "Forked the chat, but could not bind it to the new worktree",
+  "session.forkCliSession":
+    "Fork CLI agent session (new agent id — grok --fork-session)",
+  "session.forkCliSessionHint":
+    "Creates a new agent session id with the parent’s full context (ACP session/fork). The original agent session stays unchanged. Off when no agent session is linked yet.",
+  "session.resumeForkCliSessionHint":
+    "On this worktree, allocate a new agent session id instead of reusing the original (CLI --fork-session). Leave unchecked to continue the same agent session.",
+  "session.forkOkCli": "Forked · new agent session · opened new chat",
+  "session.forkOkRestoreCli":
+    "Forked · new agent session · opened on a clean worktree",
+  "session.resumeRestoreOkCli":
+    "Resumed · new agent session · opened on a clean worktree",
+  "session.forkCliFailed": "Could not arm CLI agent session fork",
   "session.resumeRestore": "Resume with code restore…",
   "session.resumeRestoreTitle": "Resume with code restore",
   "session.resumeRestoreConfirm":
@@ -3246,6 +3258,17 @@ const zh: Record<MessageKey, string> = {
   "session.forkRestoreUnavailable": "恢复代码需要该项目是 git 仓库。",
   "session.forkRestoreFailed": "无法为恢复创建 worktree",
   "session.forkRestoreBindFailed": "会话已分叉，但未能绑定到新 worktree",
+  "session.forkCliSession":
+    "分叉 CLI Agent 会话（新 agent id — grok --fork-session）",
+  "session.forkCliSessionHint":
+    "用父会话完整上下文创建新的 agent session id（ACP session/fork）。原 agent 会话保持不变。尚未关联 agent 会话时不可用。",
+  "session.resumeForkCliSessionHint":
+    "在本 worktree 上分配新的 agent session id，而不是复用原会话（CLI --fork-session）。不勾选则继续同一 agent 会话。",
+  "session.forkOkCli": "已分叉 · 新 agent 会话 · 已打开新会话",
+  "session.forkOkRestoreCli": "已分叉 · 新 agent 会话 · 已在干净 worktree 中打开",
+  "session.resumeRestoreOkCli":
+    "已恢复 · 新 agent 会话 · 已在干净 worktree 中打开",
+  "session.forkCliFailed": "无法启用 CLI Agent 会话分叉",
   "session.resumeRestore": "恢复对话并还原代码…",
   "session.resumeRestoreTitle": "恢复对话并还原代码",
   "session.resumeRestoreConfirm":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -189,6 +189,18 @@ export const zhTW: Record<MessageKey, string> = {
   "session.forkRestoreUnavailable": "還原程式碼需要此專案是 git 儲存庫。",
   "session.forkRestoreFailed": "無法為還原建立 worktree",
   "session.forkRestoreBindFailed": "對話已分叉，但未能繫結到新 worktree",
+  "session.forkCliSession":
+    "分叉 CLI Agent 工作階段（新 agent id — grok --fork-session）",
+  "session.forkCliSessionHint":
+    "以父工作階段完整內容建立新的 agent session id（ACP session/fork）。原 agent 工作階段保持不變。尚未關聯 agent 工作階段時不可用。",
+  "session.resumeForkCliSessionHint":
+    "在此 worktree 上分配新的 agent session id，而不是沿用原工作階段（CLI --fork-session）。不勾選則繼續同一 agent 工作階段。",
+  "session.forkOkCli": "已分叉 · 新 agent 工作階段 · 已開啟新對話",
+  "session.forkOkRestoreCli":
+    "已分叉 · 新 agent 工作階段 · 已在乾淨 worktree 中開啟",
+  "session.resumeRestoreOkCli":
+    "已恢復 · 新 agent 工作階段 · 已在乾淨 worktree 中開啟",
+  "session.forkCliFailed": "無法啟用 CLI Agent 工作階段分叉",
   "session.resumeRestore": "恢復對話並還原程式碼…",
   "session.resumeRestoreTitle": "恢復對話並還原程式碼",
   "session.resumeRestoreConfirm":

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -189,6 +189,8 @@ export async function sessionFork(
   opts?: {
     throughUserPromptIndex?: number | null;
     title?: string | null;
+    /** CLI `--fork-session`: new agent id with parent context on next connect. */
+    forkAgentSession?: boolean | null;
   },
 ) {
   return invoke<{
@@ -199,10 +201,31 @@ export async function sessionFork(
     modelId: string | null;
     archived?: boolean;
     scheduled?: boolean;
+    agentSessionId?: string | null;
+    forkAgentSession?: boolean;
   }>("session_fork", {
     sourceId,
     throughUserPromptIndex: opts?.throughUserPromptIndex ?? null,
     title: opts?.title ?? null,
+    forkAgentSession: opts?.forkAgentSession ?? false,
+  });
+}
+
+/**
+ * Arm or clear the one-shot CLI `--fork-session` flag on a session.
+ * Soft-respawns the live agent when arming so the next connect can fork.
+ */
+export async function sessionSetForkAgentSession(
+  id: string,
+  forkAgentSession: boolean,
+) {
+  return invoke<{
+    id: string;
+    agentSessionId?: string | null;
+    forkAgentSession?: boolean;
+  }>("session_set_fork_agent_session", {
+    id,
+    forkAgentSession,
   });
 }
 

--- a/src/lib/sessionFork.test.ts
+++ b/src/lib/sessionFork.test.ts
@@ -1,10 +1,49 @@
 import { describe, expect, it } from "vitest";
 import {
   buildForkWorktreeName,
+  canOfferForkAgentSession,
   canRestoreCodeOnFork,
+  FORK_SESSION_CLI_FLAG,
+  forkSessionSpawnArgs,
   isGitWorkingTreeDirty,
+  resolveForkAgentSession,
   sanitizeForkNameFragment,
 } from "./sessionFork";
+
+describe("forkSessionSpawnArgs / CLI --fork-session", () => {
+  it("emits the top-level flag only when enabled", () => {
+    expect(forkSessionSpawnArgs(false)).toEqual([]);
+    expect(forkSessionSpawnArgs(true)).toEqual([FORK_SESSION_CLI_FLAG]);
+    expect(FORK_SESSION_CLI_FLAG).toBe("--fork-session");
+  });
+});
+
+describe("canOfferForkAgentSession", () => {
+  it("requires a non-empty agent session id", () => {
+    expect(canOfferForkAgentSession(null)).toBe(false);
+    expect(canOfferForkAgentSession(undefined)).toBe(false);
+    expect(canOfferForkAgentSession("")).toBe(false);
+    expect(canOfferForkAgentSession("   ")).toBe(false);
+    expect(canOfferForkAgentSession("abc-123")).toBe(true);
+  });
+});
+
+describe("resolveForkAgentSession", () => {
+  it("forks only when requested and source id present", () => {
+    expect(
+      resolveForkAgentSession({ wantFork: true, agentSessionId: "sid-1" }),
+    ).toEqual({ fork: true, sourceAgentId: "sid-1" });
+    expect(
+      resolveForkAgentSession({ wantFork: false, agentSessionId: "sid-1" }),
+    ).toEqual({ fork: false, sourceAgentId: "sid-1" });
+    expect(
+      resolveForkAgentSession({ wantFork: true, agentSessionId: "" }),
+    ).toEqual({ fork: false, sourceAgentId: null });
+    expect(
+      resolveForkAgentSession({ wantFork: true, agentSessionId: "  " }),
+    ).toEqual({ fork: false, sourceAgentId: null });
+  });
+});
 
 describe("isGitWorkingTreeDirty", () => {
   it("is false when unavailable or empty", () => {

--- a/src/lib/sessionFork.ts
+++ b/src/lib/sessionFork.ts
@@ -1,6 +1,12 @@
 /**
- * Pure helpers for chat fork + optional restore-code (git worktree bind).
- * Host `session_fork` stays journal-only; worktree + project bind run in UI.
+ * Pure helpers for chat fork + optional restore-code (git worktree bind)
+ * and CLI `--fork-session` (new agent session id on resume) semantics.
+ *
+ * Host `session_fork` clones the App journal; worktree + project bind run in UI.
+ * When the user opts into CLI fork, Host sets `forkAgentSession` and on next
+ * connect uses ACP `session/fork` (CLI `--fork-session` semantics) so the
+ * child agent session gets a **new** id with the parent’s context, leaving
+ * the source agent session unchanged.
  */
 
 import { sanitizeWorktreeName } from "@/lib/gitWorktree";
@@ -11,6 +17,45 @@ export type ForkGitStatusSnapshot = {
   files?: readonly unknown[] | null;
   reason?: string | null;
 };
+
+/**
+ * CLI top-level flag: `grok --fork-session` (requires `--resume` / `--continue`
+ * in the TUI). Host ACP path implements the same semantics via `session/fork`.
+ */
+export const FORK_SESSION_CLI_FLAG = "--fork-session";
+
+/**
+ * Top-level CLI args for fork-session: `["--fork-session"]` or `[]`.
+ * Host spawn for `agent stdio` does **not** pass this alone (CLI requires
+ * `--resume`/`--continue`); use for docs / parity tests. Runtime uses ACP.
+ */
+export function forkSessionSpawnArgs(enabled: boolean): string[] {
+  return enabled ? [FORK_SESSION_CLI_FLAG] : [];
+}
+
+/**
+ * Whether the UI should offer “fork CLI agent session” (new agent id).
+ * Needs a non-empty source agent session id to fork from.
+ */
+export function canOfferForkAgentSession(
+  agentSessionId: string | null | undefined,
+): boolean {
+  return (agentSessionId ?? "").trim().length > 0;
+}
+
+/**
+ * Resolve whether connect should fork the agent session.
+ * `wantFork` is the UI checkbox; `agentSessionId` is the source to fork.
+ */
+export function resolveForkAgentSession(input: {
+  wantFork?: boolean | null;
+  agentSessionId?: string | null;
+}): { fork: boolean; sourceAgentId: string | null } {
+  const source = (input.agentSessionId ?? "").trim();
+  if (!source) return { fork: false, sourceAgentId: null };
+  if (!input.wantFork) return { fork: false, sourceAgentId: source };
+  return { fork: true, sourceAgentId: source };
+}
 
 /**
  * True when porcelain lists any changed / untracked paths.
@@ -86,3 +131,4 @@ export function buildForkWorktreeName(
   }
   return sanitizeWorktreeName(candidate);
 }
+

--- a/src/lib/sessionResumeRestore.ts
+++ b/src/lib/sessionResumeRestore.ts
@@ -11,8 +11,10 @@
 
 import { sanitizeWorktreeName } from "@/lib/gitWorktree";
 import {
+  canOfferForkAgentSession,
   canRestoreCodeOnFork,
   isGitWorkingTreeDirty,
+  resolveForkAgentSession,
   sanitizeForkNameFragment,
   type ForkGitStatusSnapshot,
   type ForkRestoreCodeGate,
@@ -23,6 +25,9 @@ export type ResumeCodeRestoreGate = ForkRestoreCodeGate;
 
 /** Re-export dirty check used by both fork and resume restore-code paths. */
 export { isGitWorkingTreeDirty };
+
+/** Re-export CLI `--fork-session` offer gate for resume-with-code UI. */
+export { canOfferForkAgentSession, resolveForkAgentSession };
 
 /**
  * Gate for restore-code on resume (same rules as fork):


### PR DESCRIPTION
## Summary

Optional **CLI `--fork-session` semantics** when forking or resuming a chat: allocate a **new** agent session id with the parent’s full context instead of reusing via `session/load`.

- **UI**: checkbox on Fork… and Resume with code restore (shown when a linked agent session exists). Fork defaults **on** when an agent id is available; resume defaults **off**.
- **Host**: one-shot `SessionMeta.forkAgentSession`; connect cold-spawns and calls ACP `session/fork` (fallback `_x.ai/session/fork`), never `session/load` when forking so the source agent session stays untouched.
- **Helpers**: `sessionFork.ts` (`forkSessionSpawnArgs`, `canOfferForkAgentSession`, `resolveForkAgentSession`) + tests; pure Rust `fork_session_spawn_flags` / `parse_fork_session_id`.
- **i18n** en / zh / zh-TW · **CHANGELOG** Unreleased.

## Test plan

- [x] `pnpm test -- src/lib/sessionFork.test.ts src/i18n/messages.test.ts src/lib/sessionResumeRestore.test.ts`
- [x] `pnpm typecheck`
- [x] `cargo test --lib fork_session`
- [ ] Manual: Fork a chat that has an agent session → checkbox on → new chat gets new agent id after connect; original chat still resumes old id
- [ ] Manual: Resume with code restore + fork CLI session → worktree rebind + new agent id
- [ ] Manual: Fork without agent session → checkbox hidden; journal-only fork still works