### PR TITLE
feat(settings): Ask User Question auto-dismiss timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@ See `docs/llm-wiki/release.md`.
 - **Collapse all activity** in the current chat (top-bar + session menu; streaming thoughts stay open)
 - **Sidebar session relative time** (on by default; about once a minute)
 - **Permission auto-deny timeout** (Settings → General → Permissions): Off / 30s / 1m / 2m / 5m with countdown on the bar
+- **Ask User Question timeout** (Settings → General → Permissions): Off / 30s / 1m / 2m / 5m with countdown on the questionnaire modal; auto-dismisses (cancel) when the timer ends. **App-enforced** (localStorage); aligns with Grok Build CLI **0.2.117** `[toolset.ask_user_question]` `timeout_enabled` / `timeout_secs` conceptually — does not rewrite `~/.grok/config.toml`
 
 ### Changed
 
@@ -206,7 +207,7 @@ See `docs/llm-wiki/release.md`.
 - 侧栏多选：选择改为清单图标；项目行操作仅 hover 显示；支持二次确认后永久删除
 - 禅模式、记住上次设置页、始终显示回到底部、窗口置顶
 - 快捷键筛选；⌘/Ctrl+B 切换侧栏；⌘/Ctrl+Shift+C 复制上一条助手回复
-- 收起全部活动；侧栏相对时间；权限超时自动拒绝
+- 收起全部活动；侧栏相对时间；权限超时自动拒绝；Agent 提问超时自动忽略
 
 **中文 · 变更**
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,11 @@ import {
   permissionTimeoutRemainingSec,
   savePermissionTimeoutSec,
 } from "@/lib/permissionTimeout";
+import {
+  ASK_USER_TIMEOUT_CHANGE_EVENT,
+  loadAskUserTimeoutSec,
+  saveAskUserTimeoutSec,
+} from "@/lib/askUserTimeout";
 import { WallpaperMediaLayer } from "@/components/WallpaperMediaLayer";
 import {
   ASIDE_WIDTH_MIN,
@@ -1994,6 +1999,9 @@ export default function App() {
   const [permissionTimeoutSec, setPermissionTimeoutSec] = useState(() =>
     loadPermissionTimeoutSec(localStorage),
   );
+  const [askUserTimeoutSec, setAskUserTimeoutSec] = useState(() =>
+    loadAskUserTimeoutSec(localStorage),
+  );
   const [askUser, setAskUser] = useState<AskUserPayload | null>(null);
   /**
    * Unanswered gates per session (`sessionId` → payload).
@@ -3425,6 +3433,21 @@ export default function App() {
     window.addEventListener(PERMISSION_TIMEOUT_CHANGE_EVENT, onChange);
     return () =>
       window.removeEventListener(PERMISSION_TIMEOUT_CHANGE_EVENT, onChange);
+  }, []);
+
+  // Ask User Question auto-cancel timeout (localStorage; Settings dispatches change).
+  useEffect(() => {
+    const onChange = (ev: Event) => {
+      const detail = (ev as CustomEvent<unknown>).detail;
+      if (typeof detail === "number" && Number.isFinite(detail)) {
+        setAskUserTimeoutSec(detail);
+        return;
+      }
+      setAskUserTimeoutSec(loadAskUserTimeoutSec(localStorage));
+    };
+    window.addEventListener(ASK_USER_TIMEOUT_CHANGE_EVENT, onChange);
+    return () =>
+      window.removeEventListener(ASK_USER_TIMEOUT_CHANGE_EVENT, onChange);
   }, []);
 
   // Phone layout flag: mirror client + ≤820px only (desktop ≥821px unchanged).
@@ -14676,6 +14699,11 @@ export default function App() {
             savePermissionTimeoutSec(v, localStorage);
             setPermissionTimeoutSec(v);
           }}
+          askUserTimeoutSec={askUserTimeoutSec}
+          onAskUserTimeoutSec={(v) => {
+            saveAskUserTimeoutSec(v, localStorage);
+            setAskUserTimeoutSec(v);
+          }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
           onOpenReliability={() => openReliability()}
@@ -18457,6 +18485,7 @@ export default function App() {
       />
       <AskUserModal
         payload={askUser}
+        timeoutSec={askUserTimeoutSec}
         labels={{
           title: tr("askUser.title"),
           submit: tr("askUser.submit"),
@@ -18465,6 +18494,7 @@ export default function App() {
           freeTextHint: tr("askUser.freeTextHint"),
           multiHint: tr("askUser.multiHint"),
           close: tr("common.close"),
+          autoCancelCountdown: tr("askUser.autoCancelCountdown"),
         }}
         onSubmit={async (answers) => {
           if (!askUser) return;

--- a/src/components/AskUserModal.tsx
+++ b/src/components/AskUserModal.tsx
@@ -3,9 +3,10 @@
  * GlassModal shell — no window.confirm / prompt / alert.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { GlassModal } from "@/components/GlassModal";
 import type { AskUserPayload, AskUserQuestionItem } from "@/lib/session";
+import { askUserTimeoutRemainingSec } from "@/lib/askUserTimeout";
 
 export type AskUserLabels = {
   title: string;
@@ -15,6 +16,8 @@ export type AskUserLabels = {
   freeTextHint: string;
   multiHint: string;
   close: string;
+  /** e.g. "Auto-dismiss in {seconds}s" — `{seconds}` replaced. */
+  autoCancelCountdown?: string;
 };
 
 type Props = {
@@ -22,13 +25,28 @@ type Props = {
   labels: AskUserLabels;
   onSubmit: (answers: Record<string, string>) => void | Promise<void>;
   onCancel: () => void | Promise<void>;
+  /**
+   * App-enforced auto-cancel after N seconds (0 / missing = off).
+   * Same cancel path as Dismiss; independent of CLI toolset timeout.
+   */
+  timeoutSec?: number;
 };
 
 function questionKey(q: AskUserQuestionItem, index: number): string {
   return q.question?.trim() || q.id || String(index);
 }
 
-export function AskUserModal({ payload, labels, onSubmit, onCancel }: Props) {
+function formatCountdown(template: string, seconds: number): string {
+  return template.replace(/\{seconds\}/g, String(seconds));
+}
+
+export function AskUserModal({
+  payload,
+  labels,
+  onSubmit,
+  onCancel,
+  timeoutSec = 0,
+}: Props) {
   const questions = payload?.questions ?? [];
   const open = Boolean(payload && questions.length > 0);
 
@@ -37,6 +55,13 @@ export function AskUserModal({ payload, labels, onSubmit, onCancel }: Props) {
   // Per-question free-text override / free-text-only answer.
   const [freeText, setFreeText] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
+  const [countdownSec, setCountdownSec] = useState<number | null>(null);
+  const timedOutRef = useRef(false);
+  const busyRef = useRef(false);
+  busyRef.current = busy;
+  // Stable cancel handle so parent re-renders do not reset the countdown.
+  const onCancelRef = useRef(onCancel);
+  onCancelRef.current = onCancel;
 
   // Reset when a new questionnaire arrives.
   useEffect(() => {
@@ -44,12 +69,41 @@ export function AskUserModal({ payload, labels, onSubmit, onCancel }: Props) {
       setSelected({});
       setFreeText({});
       setBusy(false);
+      setCountdownSec(null);
+      timedOutRef.current = false;
       return;
     }
     setSelected({});
     setFreeText({});
     setBusy(false);
+    timedOutRef.current = false;
   }, [payload?.rpcId]);
+
+  // Optional auto-cancel after N seconds (Settings → Permissions; 0 = off).
+  useEffect(() => {
+    if (!open || !payload || !(timeoutSec > 0)) {
+      setCountdownSec(null);
+      return;
+    }
+    const startedAt = Date.now();
+    timedOutRef.current = false;
+    setCountdownSec(askUserTimeoutRemainingSec(startedAt, timeoutSec, startedAt));
+    const tick = window.setInterval(() => {
+      setCountdownSec(
+        askUserTimeoutRemainingSec(startedAt, timeoutSec, Date.now()),
+      );
+    }, 250);
+    const t = window.setTimeout(() => {
+      if (timedOutRef.current || busyRef.current) return;
+      timedOutRef.current = true;
+      void onCancelRef.current();
+    }, timeoutSec * 1000);
+    return () => {
+      window.clearTimeout(t);
+      window.clearInterval(tick);
+      setCountdownSec(null);
+    };
+  }, [open, payload?.rpcId, timeoutSec]);
 
   const canSubmit = useMemo(() => {
     if (!questions.length) return false;
@@ -130,6 +184,13 @@ export function AskUserModal({ payload, labels, onSubmit, onCancel }: Props) {
     !questions[0]?.multiSelect &&
     (questions[0]?.options?.length ?? 0) > 0;
 
+  const countdownLabel =
+    countdownSec != null &&
+    countdownSec > 0 &&
+    labels.autoCancelCountdown
+      ? formatCountdown(labels.autoCancelCountdown, countdownSec)
+      : null;
+
   return (
     <GlassModal
       open={open}
@@ -141,6 +202,11 @@ export function AskUserModal({ payload, labels, onSubmit, onCancel }: Props) {
       wrapBody
       footer={
         <>
+          {countdownLabel ? (
+            <span className="ask-user__countdown" aria-live="polite">
+              {countdownLabel}
+            </span>
+          ) : null}
           <button
             type="button"
             className="btn btn--ghost"

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -505,6 +505,12 @@ export interface SettingsPageProps {
    */
   permissionTimeoutSec?: number;
   onPermissionTimeoutSec?: (v: number) => void;
+  /**
+   * Auto-cancel Ask User Question modal after N seconds (localStorage; 0 = off).
+   * App-enforced; presets: 0 / 30 / 60 / 120 / 300.
+   */
+  askUserTimeoutSec?: number;
+  onAskUserTimeoutSec?: (v: number) => void;
   planEnabled?: boolean;
   onPlanEnabled?: (v: boolean) => void;
   subagentsEnabled?: boolean;
@@ -1141,6 +1147,8 @@ export function SettingsPage({
   onNotifySound,
   permissionTimeoutSec = 0,
   onPermissionTimeoutSec,
+  askUserTimeoutSec = 0,
+  onAskUserTimeoutSec,
   cliInfo,
   onDoctor,
   onOpenReliability,
@@ -2407,6 +2415,63 @@ export function SettingsPage({
                         },
                       ];
                       const cur = Math.max(0, Math.round(permissionTimeoutSec ?? 0));
+                      if (
+                        cur > 0 &&
+                        !presets.some((o) => o.value === String(cur))
+                      ) {
+                        return [
+                          ...presets,
+                          { value: String(cur), label: `${cur}s` },
+                        ];
+                      }
+                      return presets;
+                    })()}
+                  />
+                </div>
+              ) : null}
+              {onAskUserTimeoutSec ? (
+                <div
+                  className={
+                    "settings-row settings-row--stack" +
+                    rowHighlight("settings-anchor-askUserTimeout")
+                  }
+                  id="settings-anchor-askUserTimeout"
+                >
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.askUserTimeout")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.askUserTimeoutDesc")}
+                    </div>
+                  </div>
+                  <Select
+                    value={String(askUserTimeoutSec ?? 0)}
+                    onChange={(v) => onAskUserTimeoutSec(Number(v))}
+                    options={(() => {
+                      const presets = [
+                        {
+                          value: "0",
+                          label: t("settings.askUserTimeout.off"),
+                        },
+                        {
+                          value: "30",
+                          label: t("settings.askUserTimeout.30"),
+                        },
+                        {
+                          value: "60",
+                          label: t("settings.askUserTimeout.60"),
+                        },
+                        {
+                          value: "120",
+                          label: t("settings.askUserTimeout.120"),
+                        },
+                        {
+                          value: "300",
+                          label: t("settings.askUserTimeout.300"),
+                        },
+                      ];
+                      const cur = Math.max(0, Math.round(askUserTimeoutSec ?? 0));
                       if (
                         cur > 0 &&
                         !presets.some((o) => o.value === String(cur))

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1326,6 +1326,14 @@ const en = {
   "settings.permissionTimeout.60": "1 minute",
   "settings.permissionTimeout.120": "2 minutes",
   "settings.permissionTimeout.300": "5 minutes",
+  "settings.askUserTimeout": "Ask-question timeout",
+  "settings.askUserTimeoutDesc":
+    "If you don't answer an agent questionnaire, auto-dismiss (cancel) after this time. App-enforced; off by default. Aligns with CLI 0.2.117 [toolset.ask_user_question] (independent of the CLI's longer default budget).",
+  "settings.askUserTimeout.off": "Off",
+  "settings.askUserTimeout.30": "30 seconds",
+  "settings.askUserTimeout.60": "1 minute",
+  "settings.askUserTimeout.120": "2 minutes",
+  "settings.askUserTimeout.300": "5 minutes",
   "settings.sandboxProfile": "Sandbox profile",
   "settings.sandboxProfileDesc":
     "OS-level filesystem/network isolation for the agent process (Landlock/Seatbelt). Applied when a new agent starts — reconnect the session after changing. Projects can override this from the project menu.",
@@ -3060,6 +3068,7 @@ const en = {
   "askUser.otherPlaceholder": "Type your answer…",
   "askUser.freeTextHint": "Or type a custom answer",
   "askUser.multiHint": "Select one or more options",
+  "askUser.autoCancelCountdown": "Auto-dismiss in {seconds}s",
 
   "message.interjectionTag": "Steer",
   "message.copy": "Copy",
@@ -5004,6 +5013,14 @@ const zh: Record<MessageKey, string> = {
   "settings.permissionTimeout.60": "1 分钟",
   "settings.permissionTimeout.120": "2 分钟",
   "settings.permissionTimeout.300": "5 分钟",
+  "settings.askUserTimeout": "提问超时",
+  "settings.askUserTimeoutDesc":
+    "若在时限内未回答 Agent 问卷，将自动忽略（取消）。由应用强制执行，默认关闭。与 CLI 0.2.117 [toolset.ask_user_question] 概念对齐（独立于 CLI 更长的默认超时）。",
+  "settings.askUserTimeout.off": "关闭",
+  "settings.askUserTimeout.30": "30 秒",
+  "settings.askUserTimeout.60": "1 分钟",
+  "settings.askUserTimeout.120": "2 分钟",
+  "settings.askUserTimeout.300": "5 分钟",
   "settings.sandboxProfile": "沙箱配置",
   "settings.sandboxProfileDesc":
     "对 Agent 进程施加操作系统级文件系统/网络隔离（Linux Landlock / macOS Seatbelt）。在新启动 Agent 时生效——更改后请重连会话。可在项目菜单中为单个项目覆盖。",
@@ -6695,6 +6712,7 @@ const zh: Record<MessageKey, string> = {
   "askUser.otherPlaceholder": "输入你的回答…",
   "askUser.freeTextHint": "或输入自定义回答",
   "askUser.multiHint": "可多选",
+  "askUser.autoCancelCountdown": "{seconds} 秒后自动忽略",
 
   "message.interjectionTag": "引导",
   "message.copy": "复制",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1262,6 +1262,14 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.permissionTimeout.60": "1 分鐘",
   "settings.permissionTimeout.120": "2 分鐘",
   "settings.permissionTimeout.300": "5 分鐘",
+  "settings.askUserTimeout": "提問逾時",
+  "settings.askUserTimeoutDesc":
+    "若在時限內未回答 Agent 問卷，將自動略過（取消）。由應用強制執行，預設關閉。與 CLI 0.2.117 [toolset.ask_user_question] 概念對齊（獨立於 CLI 更長的預設逾時）。",
+  "settings.askUserTimeout.off": "關閉",
+  "settings.askUserTimeout.30": "30 秒",
+  "settings.askUserTimeout.60": "1 分鐘",
+  "settings.askUserTimeout.120": "2 分鐘",
+  "settings.askUserTimeout.300": "5 分鐘",
   "settings.sandboxProfile": "沙箱設定檔",
   "settings.sandboxProfileDesc":
     "對 Agent 行程施加作業系統級檔案系統/網路隔離（Linux Landlock / macOS Seatbelt）。在新啟動 Agent 時生效——變更後請重新連線工作階段。可在專案選單中為單一專案覆寫。",
@@ -2954,6 +2962,7 @@ export const zhTW: Record<MessageKey, string> = {
   "askUser.otherPlaceholder": "輸入你的回答…",
   "askUser.freeTextHint": "或輸入自訂回答",
   "askUser.multiHint": "可多選",
+  "askUser.autoCancelCountdown": "{seconds} 秒後自動略過",
 
   "message.interjectionTag": "引導",
   "message.copy": "複製",

--- a/src/lib/askUserTimeout.test.ts
+++ b/src/lib/askUserTimeout.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  ASK_USER_TIMEOUT_MAX_SEC,
+  ASK_USER_TIMEOUT_PRESETS,
+  ASK_USER_TIMEOUT_STORAGE_KEY,
+  DEFAULT_ASK_USER_TIMEOUT_SEC,
+  askUserTimeoutRemainingSec,
+  loadAskUserTimeoutSec,
+  parseAskUserTimeoutSec,
+  saveAskUserTimeoutSec,
+  type AskUserTimeoutStorage,
+} from "./askUserTimeout";
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+): AskUserTimeoutStorage & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    getItem(key) {
+      return key in data ? data[key]! : null;
+    },
+    setItem(key, value) {
+      data[key] = value;
+    },
+  };
+}
+
+describe("parseAskUserTimeoutSec", () => {
+  it("defaults to off (0)", () => {
+    expect(DEFAULT_ASK_USER_TIMEOUT_SEC).toBe(0);
+    expect(parseAskUserTimeoutSec(null)).toBe(0);
+    expect(parseAskUserTimeoutSec(undefined)).toBe(0);
+    expect(parseAskUserTimeoutSec("")).toBe(0);
+    expect(parseAskUserTimeoutSec("nope")).toBe(0);
+    expect(parseAskUserTimeoutSec(-1)).toBe(0);
+    expect(parseAskUserTimeoutSec(true)).toBe(0);
+  });
+
+  it("accepts presets and free numbers", () => {
+    for (const p of ASK_USER_TIMEOUT_PRESETS) {
+      expect(parseAskUserTimeoutSec(p)).toBe(p);
+      expect(parseAskUserTimeoutSec(String(p))).toBe(p);
+    }
+    expect(parseAskUserTimeoutSec(45)).toBe(45);
+    expect(parseAskUserTimeoutSec(" 90 ")).toBe(90);
+    expect(parseAskUserTimeoutSec(30.4)).toBe(30);
+    expect(parseAskUserTimeoutSec(30.6)).toBe(31);
+  });
+
+  it("clamps to max", () => {
+    expect(parseAskUserTimeoutSec(ASK_USER_TIMEOUT_MAX_SEC + 1)).toBe(
+      ASK_USER_TIMEOUT_MAX_SEC,
+    );
+  });
+});
+
+describe("load / save", () => {
+  it("persists and reloads after simulated relaunch", () => {
+    const storage = memoryStorage();
+    expect(loadAskUserTimeoutSec(storage)).toBe(0);
+    saveAskUserTimeoutSec(60, storage);
+    expect(storage.data[ASK_USER_TIMEOUT_STORAGE_KEY]).toBe("60");
+    expect(loadAskUserTimeoutSec(storage)).toBe(60);
+    saveAskUserTimeoutSec(0, storage);
+    expect(loadAskUserTimeoutSec(storage)).toBe(0);
+  });
+
+  it("loads free number from storage", () => {
+    const storage = memoryStorage({
+      [ASK_USER_TIMEOUT_STORAGE_KEY]: "45",
+    });
+    expect(loadAskUserTimeoutSec(storage)).toBe(45);
+  });
+});
+
+describe("askUserTimeoutRemainingSec", () => {
+  it("returns 0 when timeout is off or invalid", () => {
+    expect(askUserTimeoutRemainingSec(1000, 0, 1000)).toBe(0);
+    expect(askUserTimeoutRemainingSec(1000, -5, 1000)).toBe(0);
+    expect(askUserTimeoutRemainingSec(NaN, 30, 1000)).toBe(0);
+    expect(askUserTimeoutRemainingSec(1000, 30, NaN)).toBe(0);
+  });
+
+  it("returns full timeout at start (ceil)", () => {
+    const start = 1_000_000;
+    expect(askUserTimeoutRemainingSec(start, 30, start)).toBe(30);
+    expect(askUserTimeoutRemainingSec(start, 30, start + 1)).toBe(30);
+  });
+
+  it("counts down and floors at 0", () => {
+    const start = 1_000_000;
+    expect(askUserTimeoutRemainingSec(start, 30, start + 1000)).toBe(29);
+    expect(askUserTimeoutRemainingSec(start, 30, start + 29_000)).toBe(1);
+    expect(askUserTimeoutRemainingSec(start, 30, start + 30_000)).toBe(0);
+    expect(askUserTimeoutRemainingSec(start, 30, start + 60_000)).toBe(0);
+  });
+});

--- a/src/lib/askUserTimeout.ts
+++ b/src/lib/askUserTimeout.ts
@@ -1,0 +1,105 @@
+/**
+ * Optional auto-cancel timeout for the Ask User Question modal.
+ * localStorage-only — App-enforced (does not rewrite Host AppSettings).
+ *
+ * Aligns conceptually with Grok Build CLI 0.2.117
+ * `[toolset.ask_user_question] timeout_enabled / timeout_secs`
+ * (and env `GROK_ASK_USER_QUESTION_TIMEOUT_*`). The App timer is independent
+ * and typically much shorter (presets up to 5m); CLI still has its own
+ * default budget (~30m) when enabled.
+ *
+ * 0 = off (default). Positive seconds until the same cancel path as Dismiss.
+ * Settings offers presets; storage accepts any non-negative integer.
+ */
+
+export const ASK_USER_TIMEOUT_STORAGE_KEY = "grok.askUserTimeoutSec";
+
+/** Fired on `window` after a successful save (detail = seconds). */
+export const ASK_USER_TIMEOUT_CHANGE_EVENT = "grok-ask-user-timeout-change";
+
+export const DEFAULT_ASK_USER_TIMEOUT_SEC = 0;
+
+/** Preset values shown in Settings select (seconds). */
+export const ASK_USER_TIMEOUT_PRESETS = [0, 30, 60, 120, 300] as const;
+
+/** Soft upper bound when parsing free-form values (1 hour). */
+export const ASK_USER_TIMEOUT_MAX_SEC = 3600;
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface AskUserTimeoutStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): AskUserTimeoutStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+/**
+ * Parse stored / form value to a non-negative integer seconds.
+ * Invalid / empty → 0 (off). Free numbers allowed (clamped to max).
+ */
+export function parseAskUserTimeoutSec(raw: unknown): number {
+  if (raw == null || raw === "") return DEFAULT_ASK_USER_TIMEOUT_SEC;
+  if (typeof raw === "boolean") return DEFAULT_ASK_USER_TIMEOUT_SEC;
+  const n =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string"
+        ? Number(raw.trim())
+        : NaN;
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_ASK_USER_TIMEOUT_SEC;
+  return Math.min(ASK_USER_TIMEOUT_MAX_SEC, Math.round(n));
+}
+
+export function loadAskUserTimeoutSec(
+  storage: AskUserTimeoutStorage = defaultStorage(),
+): number {
+  try {
+    return parseAskUserTimeoutSec(storage.getItem(ASK_USER_TIMEOUT_STORAGE_KEY));
+  } catch {
+    /* private mode */
+    return DEFAULT_ASK_USER_TIMEOUT_SEC;
+  }
+}
+
+export function saveAskUserTimeoutSec(
+  seconds: number,
+  storage: AskUserTimeoutStorage = defaultStorage(),
+): void {
+  const next = parseAskUserTimeoutSec(seconds);
+  try {
+    storage.setItem(ASK_USER_TIMEOUT_STORAGE_KEY, String(next));
+  } catch {
+    /* private mode / quota */
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.dispatchEvent === "function"
+  ) {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(ASK_USER_TIMEOUT_CHANGE_EVENT, { detail: next }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * Pure helper: whole seconds remaining until auto-cancel.
+ * Returns 0 when timeout is off, already expired, or inputs are invalid.
+ * Uses ceil so the UI shows `timeoutSec` until the first second elapses.
+ */
+export function askUserTimeoutRemainingSec(
+  startedAtMs: number,
+  timeoutSec: number,
+  nowMs: number = Date.now(),
+): number {
+  if (!(timeoutSec > 0) || !Number.isFinite(timeoutSec)) return 0;
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(nowMs)) return 0;
+  const left = Math.ceil(timeoutSec - (nowMs - startedAtMs) / 1000);
+  return Math.max(0, left);
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -451,6 +451,32 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "超时",
     ],
   },
+  {
+    id: "general.askUserTimeout",
+    section: "general",
+    tab: "permissions",
+    anchorId: "settings-anchor-askUserTimeout",
+    labelKey: "settings.askUserTimeout",
+    descKeys: [
+      "settings.askUserTimeoutDesc",
+      "settings.askUserTimeout.off",
+      "settings.section.permissions",
+      "askUser.title",
+    ],
+    keywords: [
+      "ask user",
+      "ask question",
+      "questionnaire",
+      "timeout",
+      "auto-dismiss",
+      "auto cancel",
+      "ask_user_question",
+      "提问超时",
+      "问卷",
+      "自动忽略",
+      "超时",
+    ],
+  },
   // ── general / agent ──
   {
     id: "general.maxAgentTurns",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8414,6 +8414,16 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
   gap: 16px;
 }
 
+.ask-user__countdown {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-right: auto;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  line-height: 1.3;
+}
+
 .ask-user__q {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Adds an **App-enforced** timeout for the `_x.ai/ask_user_question` questionnaire modal, parallel to the existing permission auto-deny timeout.

**Settings → General → Permissions → Ask-question timeout**: Off / 30s / 1m / 2m / 5m (free non-negative seconds also accepted in storage, clamped to 1h).

When enabled, `AskUserModal` shows a countdown and auto-dismisses via the same cancel path as **Dismiss** (`session_resolve_ask_user` → cancelled).

### CLI 0.2.117 alignment

Grok Build CLI **0.2.117** exposes:

```toml
[toolset.ask_user_question]
timeout_enabled = true
timeout_secs = 1800
```

(and env `GROK_ASK_USER_QUESTION_TIMEOUT_ENABLED` / `GROK_ASK_USER_QUESTION_TIMEOUT_SECS` / managed keys `ask_user_question_timeout_*`).

This PR is **App-enforced** (localStorage `grok.askUserTimeoutSec`) — it does **not** rewrite `~/.grok/config.toml` or agent-home. App presets (≤5m) are intentionally shorter UX budgets than the CLI default (~30m). Optional config mirror can land later if product wants dual-write for independent `GROK_HOME`.

## Changes

- `src/lib/askUserTimeout.ts` + pure helper tests
- Settings UI + `settingsCatalog` search entry
- `AskUserModal` countdown + auto-cancel (stable cancel ref so parent re-renders do not reset the timer)
- i18n: en / zh / zh-TW
- CHANGELOG Unreleased note

## Test plan

- [x] `pnpm test -- src/lib/askUserTimeout.test.ts src/lib/settingsCatalog.test.ts src/i18n/messages.test.ts`
- [ ] Settings → Permissions: set Ask-question timeout to 30s; trigger agent questionnaire; confirm countdown + auto-dismiss cancels the gate
- [ ] Off: questionnaire stays open until Submit / Dismiss
- [ ] Quick-pick single-select still answers immediately before timeout