### PR TITLE
feat(settings): CLI update channels (stable/alpha) + version pin (0.2.117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ### Added
 
 #### Runtime / connection
+- **CLI update channels** (CLI ≥ **0.2.117**): Settings → Runtime → CLI and About show current version + channel (`stable` / `alpha` / unknown from `grok update --check --json` only — never invented). Switch via `grok update --alpha|--stable`, optional version pin (`--version <V>`) with in-app confirm; soft-fail on older CLIs / unknown channels. Host `cli_update_install` accepts optional channel/version/force; pure helpers + tests.
 - **SDK Connect wizard** (Settings → Runtime → Connection): start local `agent serve`, show masked secret + ws URL, TCP health probe, copy curl / websocat / `grok --remote` examples for external clients, and optional paste remote serve URL + probe. Secrets never logged; full token only via one-time clipboard after start.
 
 #### Composer & chat

--- a/src-tauri/src/cli_update.rs
+++ b/src-tauri/src/cli_update.rs
@@ -6,6 +6,11 @@
 //! or `grok update` fails, we fall back to [`crate::cli_install::install_cli_latest`]
 //! (multi-mirror + checksum trust chain + progress events) — safer for first-time
 //! installs and when self-update is broken.
+//!
+//! ## Channels (CLI ≥ 0.2.117)
+//! `grok update --check --json` may report `channel` (`stable` / `alpha`).
+//! Switch with `grok update --alpha` / `--stable`; pin with `--version <V>`.
+//! App never invents channels — unknown/missing values surface as unknown.
 
 use std::path::Path;
 use std::process::Command;
@@ -22,6 +27,125 @@ use crate::process_util;
 const CHECK_TIMEOUT: Duration = Duration::from_secs(45);
 const UPDATE_TIMEOUT: Duration = Duration::from_secs(600);
 
+/// Known Grok Build CLI release channels from `grok update --check --json`.
+/// Do **not** invent extra channels — only map what the CLI documents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliReleaseChannel {
+    Stable,
+    Alpha,
+    /// Missing, empty, or unrecognized — UI shows unknown; no switch flag.
+    Unknown,
+}
+
+impl CliReleaseChannel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Stable => "stable",
+            Self::Alpha => "alpha",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// CLI flag for channel switch (`--stable` / `--alpha`), if any.
+    pub fn switch_flag(self) -> Option<&'static str> {
+        match self {
+            Self::Stable => Some("--stable"),
+            Self::Alpha => Some("--alpha"),
+            Self::Unknown => None,
+        }
+    }
+}
+
+/// Parse a channel string from CLI JSON or user input.
+/// Only `stable` / `alpha` (case-insensitive) are recognized — never invent.
+pub fn parse_cli_channel(raw: Option<&str>) -> CliReleaseChannel {
+    let Some(s) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
+        return CliReleaseChannel::Unknown;
+    };
+    match s.to_ascii_lowercase().as_str() {
+        "stable" => CliReleaseChannel::Stable,
+        "alpha" => CliReleaseChannel::Alpha,
+        _ => CliReleaseChannel::Unknown,
+    }
+}
+
+/// Options for `grok update` install / channel switch / version pin.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CliUpdateInstallOpts {
+    /// Switch release channel (`stable` / `alpha`). Mutually exclusive with pin.
+    pub channel: Option<String>,
+    /// Install a specific version (`--version`). Mutually exclusive with channel.
+    pub version: Option<String>,
+    /// Pass `--force-reinstall` when true.
+    pub force: bool,
+}
+
+/// Validate version pin text for `--version` (semver-ish; no flags/path tricks).
+pub fn is_valid_cli_version_pin(raw: &str) -> bool {
+    let t = raw.trim();
+    if t.is_empty() || t.len() > 64 {
+        return false;
+    }
+    // Reject anything that looks like a CLI flag or path.
+    if t.starts_with('-') || t.contains('/') || t.contains('\\') || t.contains(' ') {
+        return false;
+    }
+    // Require at least one digit and only version-ish chars.
+    let mut has_digit = false;
+    for c in t.chars() {
+        if c.is_ascii_digit() {
+            has_digit = true;
+            continue;
+        }
+        if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '+' || c == '_' {
+            continue;
+        }
+        return false;
+    }
+    has_digit
+}
+
+/// Build argv after the binary for `grok update …` (without the program name).
+/// Pure helper — soft-fails with Err when opts are invalid or invent a channel.
+pub fn build_update_args(opts: &CliUpdateInstallOpts) -> Result<Vec<String>, String> {
+    let channel_raw = opts
+        .channel
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let version_raw = opts
+        .version
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    if channel_raw.is_some() && version_raw.is_some() {
+        return Err("channel switch and version pin are mutually exclusive".into());
+    }
+
+    let mut args: Vec<String> = vec!["update".into()];
+
+    if let Some(ch) = channel_raw {
+        let parsed = parse_cli_channel(Some(ch));
+        let flag = parsed.switch_flag().ok_or_else(|| {
+            format!("unknown CLI channel `{ch}` — only stable and alpha are supported")
+        })?;
+        args.push(flag.into());
+    } else if let Some(ver) = version_raw {
+        if !is_valid_cli_version_pin(ver) {
+            return Err(format!("invalid CLI version pin: {ver}"));
+        }
+        args.push("--version".into());
+        args.push(ver.to_string());
+    }
+
+    if opts.force {
+        args.push("--force-reinstall".into());
+    }
+
+    Ok(args)
+}
+
 /// Parsed `grok update --check --json` payload (camelCase).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -29,6 +153,7 @@ pub struct CliUpdateCheck {
     pub current_version: String,
     pub latest_version: String,
     pub update_available: bool,
+    /// Raw channel from CLI JSON when present (`stable` / `alpha`); never invented.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub channel: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -86,7 +211,13 @@ fn parse_update_check_value(v: &Value) -> Result<CliUpdateCheck, String> {
         .ok_or_else(|| "missing latestVersion".to_string())?;
     let update_available = bool_field(v, &["updateAvailable", "update_available"])
         .unwrap_or_else(|| versions_differ(&current, &latest));
-    let channel = string_field(v, &["channel"]);
+    // Keep only recognized channel labels from CLI JSON — never invent.
+    let channel = string_field(v, &["channel"]).and_then(|c| {
+        match parse_cli_channel(Some(&c)) {
+            CliReleaseChannel::Unknown => None,
+            known => Some(known.as_str().to_string()),
+        }
+    });
     let installer = string_field(v, &["installer"]);
     let auto_update = bool_field(v, &["autoUpdate", "auto_update"]);
     let error = string_field(v, &["error"]).filter(|s| !s.is_empty());
@@ -169,47 +300,83 @@ fn strip_grok_prefix(v: &str) -> String {
     t.to_string()
 }
 
-/// Install latest CLI: prefer `grok update`, else App install trust-chain.
-pub async fn install_cli_update(app: tauri::AppHandle) -> Result<CliInstallResult, String> {
+/// Install / switch CLI: prefer `grok update` (with optional channel/version),
+/// else App install trust-chain for plain latest only.
+///
+/// Channel switch and version pin never fall back to the App trust-chain
+/// (which always pulls stable latest). Soft-fail with Err instead.
+pub async fn install_cli_update(
+    app: tauri::AppHandle,
+    opts: CliUpdateInstallOpts,
+) -> Result<CliInstallResult, String> {
     let settings = crate::store::load_settings();
     let manual = settings.manual_cli_path.clone();
     let probe = cli_probe::probe_cli(manual.as_deref());
 
+    let args = build_update_args(&opts)?;
+    let specialized = opts.channel.is_some() || opts.version.is_some();
+    let args_label = args.join(" ");
+
     if probe.found {
         if let Some(path) = probe.path.clone() {
-            info!("cli_update_install: running `{path} update`");
+            info!("cli_update_install: running `{path} {args_label}`");
+            let args_owned = args.clone();
             match tauri::async_runtime::spawn_blocking({
                 let path = path.clone();
-                move || run_cli_with_timeout(Path::new(&path), &["update"], UPDATE_TIMEOUT)
+                move || {
+                    let arg_refs: Vec<&str> = args_owned.iter().map(|s| s.as_str()).collect();
+                    run_cli_with_timeout(Path::new(&path), &arg_refs, UPDATE_TIMEOUT)
+                }
             })
             .await
             {
                 Ok(Ok(stdout)) => {
                     // Re-probe after update.
                     let after = cli_probe::probe_cli(manual.as_deref());
-                    let version = after.version.or_else(|| extract_version_hint(&stdout));
+                    let version = after
+                        .version
+                        .map(|v| strip_grok_prefix(&v))
+                        .or_else(|| extract_version_hint(&stdout));
+                    let message = if let Some(ch) = opts.channel.as_deref() {
+                        format!("Switched CLI channel via `grok update --{ch}`")
+                    } else if let Some(ver) = opts.version.as_deref() {
+                        format!("Installed CLI {ver} via `grok update --version`")
+                    } else {
+                        "Updated via `grok update`".into()
+                    };
                     return Ok(CliInstallResult {
                         ok: true,
                         path: after.path.or(Some(path)),
                         version,
                         mirror_used: Some("grok-update".into()),
-                        message: "Updated via `grok update`".into(),
+                        message,
                         sha256: None,
                         checksum_verified: None,
                     });
                 }
                 Ok(Err(e)) => {
+                    if specialized {
+                        // Soft-fail: do not pull stable latest when user asked for channel/version.
+                        return Err(format!("grok {args_label} failed: {e}"));
+                    }
                     warn!(
                         "cli_update_install: grok update failed ({e}); falling back to install_cli_latest"
                     );
                 }
                 Err(e) => {
+                    if specialized {
+                        return Err(format!("grok {args_label} join error: {e}"));
+                    }
                     warn!(
                         "cli_update_install: join error ({e}); falling back to install_cli_latest"
                     );
                 }
             }
         }
+    } else if specialized {
+        return Err(
+            "Grok Build CLI not found — install or set the path under Runtime".into(),
+        );
     }
 
     info!("cli_update_install: using cli_install trust-chain");
@@ -360,6 +527,130 @@ mod tests {
     #[test]
     fn extract_json_object_from_mixed() {
         let s = "info: start\n{\"a\":1}\n";
-        assert_eq!(extract_json_object(s), Some(r#"{"a":1}"#));
+        assert_eq!(extract_json_object(s), Some("{\"a\":1}"));
+    }
+
+    #[test]
+    fn parse_cli_channel_known_and_unknown() {
+        assert_eq!(parse_cli_channel(Some("stable")), CliReleaseChannel::Stable);
+        assert_eq!(parse_cli_channel(Some("ALPHA")), CliReleaseChannel::Alpha);
+        assert_eq!(parse_cli_channel(Some("  alpha  ")), CliReleaseChannel::Alpha);
+        assert_eq!(parse_cli_channel(None), CliReleaseChannel::Unknown);
+        assert_eq!(parse_cli_channel(Some("")), CliReleaseChannel::Unknown);
+        assert_eq!(parse_cli_channel(Some("beta")), CliReleaseChannel::Unknown);
+        assert_eq!(parse_cli_channel(Some("nightly")), CliReleaseChannel::Unknown);
+    }
+
+    #[test]
+    fn parse_drops_unknown_channel_field() {
+        let raw = r#"{"currentVersion":"0.2.117","latestVersion":"0.2.117","updateAvailable":false,"channel":"nightly"}"#;
+        let d = parse_update_check_json(raw).unwrap();
+        assert!(d.channel.is_none());
+    }
+
+    #[test]
+    fn parse_normalizes_alpha_channel() {
+        let raw = r#"{"currentVersion":"0.2.117","latestVersion":"0.2.118-alpha.1","updateAvailable":true,"channel":"Alpha"}"#;
+        let d = parse_update_check_json(raw).unwrap();
+        assert_eq!(d.channel.as_deref(), Some("alpha"));
+    }
+
+    #[test]
+    fn build_update_args_plain_and_force() {
+        assert_eq!(
+            build_update_args(&CliUpdateInstallOpts::default()).unwrap(),
+            vec!["update"]
+        );
+        assert_eq!(
+            build_update_args(&CliUpdateInstallOpts {
+                force: true,
+                ..Default::default()
+            })
+            .unwrap(),
+            vec!["update", "--force-reinstall"]
+        );
+    }
+
+    #[test]
+    fn build_update_args_channel_switch() {
+        assert_eq!(
+            build_update_args(&CliUpdateInstallOpts {
+                channel: Some("alpha".into()),
+                ..Default::default()
+            })
+            .unwrap(),
+            vec!["update", "--alpha"]
+        );
+        assert_eq!(
+            build_update_args(&CliUpdateInstallOpts {
+                channel: Some("STABLE".into()),
+                force: true,
+                ..Default::default()
+            })
+            .unwrap(),
+            vec!["update", "--stable", "--force-reinstall"]
+        );
+        assert!(build_update_args(&CliUpdateInstallOpts {
+            channel: Some("beta".into()),
+            ..Default::default()
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn build_update_args_version_pin() {
+        assert_eq!(
+            build_update_args(&CliUpdateInstallOpts {
+                version: Some("0.2.117".into()),
+                ..Default::default()
+            })
+            .unwrap(),
+            vec!["update", "--version", "0.2.117"]
+        );
+        assert_eq!(
+            build_update_args(&CliUpdateInstallOpts {
+                version: Some("0.1.151-alpha.2".into()),
+                force: true,
+                ..Default::default()
+            })
+            .unwrap(),
+            vec![
+                "update",
+                "--version",
+                "0.1.151-alpha.2",
+                "--force-reinstall"
+            ]
+        );
+        assert!(build_update_args(&CliUpdateInstallOpts {
+            version: Some("--help".into()),
+            ..Default::default()
+        })
+        .is_err());
+        assert!(build_update_args(&CliUpdateInstallOpts {
+            version: Some("../etc/passwd".into()),
+            ..Default::default()
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn build_update_args_rejects_channel_and_version() {
+        assert!(build_update_args(&CliUpdateInstallOpts {
+            channel: Some("alpha".into()),
+            version: Some("0.2.117".into()),
+            ..Default::default()
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn is_valid_cli_version_pin_samples() {
+        assert!(is_valid_cli_version_pin("0.2.117"));
+        assert!(is_valid_cli_version_pin("0.1.151-alpha.2"));
+        assert!(!is_valid_cli_version_pin(""));
+        assert!(!is_valid_cli_version_pin("  "));
+        assert!(!is_valid_cli_version_pin("-alpha"));
+        assert!(!is_valid_cli_version_pin("a b"));
+        assert!(!is_valid_cli_version_pin("no-digits"));
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7058,14 +7058,26 @@ pub async fn cli_update_check() -> Result<crate::cli_update::CliUpdateCheck, Str
     .map_err(|e| e.to_string())?
 }
 
-// from PR #63
+// from PR #63 / channel UX (CLI ≥ 0.2.117)
 
-/// Install CLI update: prefer `grok update`, fall back to install trust-chain.
+/// Install CLI update / switch channel / pin version.
+///
+/// Optional `channel` (`stable`|`alpha`), `version` pin, and `force` reinstall.
+/// Channel switch and version pin are mutually exclusive; unknown channels error
+/// (never invented). Plain update still falls back to App install trust-chain.
 #[tauri::command]
 pub async fn cli_update_install(
     app: tauri::AppHandle,
+    channel: Option<String>,
+    version: Option<String>,
+    force: Option<bool>,
 ) -> Result<crate::cli_install::CliInstallResult, String> {
-    crate::cli_update::install_cli_update(app).await
+    let opts = crate::cli_update::CliUpdateInstallOpts {
+        channel,
+        version,
+        force: force.unwrap_or(false),
+    };
+    crate::cli_update::install_cli_update(app, opts).await
 }
 
 /// Recycle every warm agent process so the next send spawns fresh binaries.

--- a/src/components/CliUpdateRow.tsx
+++ b/src/components/CliUpdateRow.tsx
@@ -1,32 +1,70 @@
 /**
  * Check / install Grok Build CLI updates (`grok update --check --json`).
- * Used in Settings → Runtime and Doctor → Advanced.
+ * Channel switch (`--alpha` / `--stable`) and version pin (`--version`) for CLI ≥ 0.2.117.
+ * Used in Settings → Runtime / About and Doctor → Advanced.
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { MessageKey } from "@/i18n";
 import * as api from "@/lib/api";
+import {
+  canSwitchCliChannel,
+  cliChannelLabelKey,
+  formatCliUpdateStatus,
+  isValidCliVersionPin,
+  normalizeCliChannel,
+  type CliSwitchableChannel,
+} from "@/lib/cliUpdateChannel";
+import { GlassModal } from "@/components/GlassModal";
+
+type BusyKind =
+  | "check"
+  | "install"
+  | "switch-stable"
+  | "switch-alpha"
+  | "pin"
+  | null;
+
+type ConfirmAction =
+  | { kind: "switch"; channel: CliSwitchableChannel }
+  | { kind: "pin"; version: string };
 
 export function CliUpdateRow({
   t,
   cliFound,
   onAfterInstall,
   compact,
+  /** Auto-run check once when CLI is available (About / Runtime). */
+  autoCheck = false,
 }: {
   t: (key: MessageKey, vars?: Record<string, string | number>) => string;
   cliFound?: boolean;
   onAfterInstall?: () => void;
   /** Tighter layout for Doctor advanced section. */
   compact?: boolean;
+  autoCheck?: boolean;
 }) {
-  const [busy, setBusy] = useState<"check" | "install" | null>(null);
+  const [busy, setBusy] = useState<BusyKind>(null);
   const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<any | null>(null);
+  const [result, setResult] = useState<api.CliUpdateCheck | null>(null);
   const [installMsg, setInstallMsg] = useState<string | null>(null);
   const [needsRestart, setNeedsRestart] = useState(false);
   const [restarting, setRestarting] = useState(false);
+  const [pinInput, setPinInput] = useState("");
+  const [confirm, setConfirm] = useState<ConfirmAction | null>(null);
 
-  const check = async () => {
+  const status = result
+    ? formatCliUpdateStatus({
+        currentVersion: result.currentVersion ?? result.current,
+        latestVersion: result.latestVersion ?? result.latest,
+        channel: result.channel,
+        updateAvailable: result.updateAvailable,
+      })
+    : null;
+
+  const channel = status?.channel ?? "unknown";
+
+  const check = useCallback(async () => {
     if (!api.isTauri()) {
       setError("not in Tauri");
       return;
@@ -39,7 +77,6 @@ export function CliUpdateRow({
     setBusy("check");
     setError(null);
     setInstallMsg(null);
-    setResult(null);
     try {
       const r = await api.cliUpdateCheck();
       setResult(r);
@@ -51,29 +88,62 @@ export function CliUpdateRow({
     } finally {
       setBusy(null);
     }
-  };
+  }, [cliFound, t]);
 
-  const install = async () => {
+  useEffect(() => {
+    if (!autoCheck || compact) return;
+    if (cliFound === false) return;
+    void check();
+    // mount / cliFound / autoCheck only
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional one-shot refresh
+  }, [autoCheck, compact, cliFound]);
+
+  const runInstall = async (
+    opts?: api.CliUpdateInstallOpts | null,
+    busyKind: BusyKind = "install",
+  ) => {
     if (!api.isTauri()) {
       setError("not in Tauri");
       return;
     }
-    setBusy("install");
+    setBusy(busyKind);
     setError(null);
     setInstallMsg(null);
+    setConfirm(null);
     try {
-      const r = await api.cliUpdateInstall();
-      if (!r.ok) {
-        setError(r.message || "update failed");
+      const r = await api.cliUpdateInstall(opts ?? null);
+      if (r.ok === false) {
+        setError(r.message || r.error || "update failed");
         return;
       }
-      setInstallMsg(
-        t("settings.cliUpdateDone", {
-          version: r.version || result?.latestVersion || "—",
-        }),
-      );
+      const version =
+        r.version ||
+        opts?.version ||
+        result?.latestVersion ||
+        result?.latest ||
+        "—";
+      if (opts?.channel) {
+        const ch = normalizeCliChannel(opts.channel);
+        setInstallMsg(
+          t("settings.cliChannel.switched", {
+            channel: t(cliChannelLabelKey(ch)),
+            version: String(version),
+          }),
+        );
+      } else if (opts?.version) {
+        setInstallMsg(
+          t("settings.cliChannel.pinned", {
+            version: String(opts.version),
+          }),
+        );
+      } else {
+        setInstallMsg(
+          t("settings.cliUpdateDone", {
+            version: String(version),
+          }),
+        );
+      }
       setNeedsRestart(true);
-      // Refresh check status after install.
       try {
         const next = await api.cliUpdateCheck();
         setResult(next);
@@ -81,8 +151,11 @@ export function CliUpdateRow({
         if (result) {
           setResult({
             ...result,
-            currentVersion: r.version || result.latestVersion,
+            currentVersion: String(version),
             updateAvailable: false,
+            channel: opts?.channel
+              ? normalizeCliChannel(opts.channel)
+              : result.channel,
           });
         }
       }
@@ -106,6 +179,43 @@ export function CliUpdateRow({
     }
   };
 
+  const requestSwitch = (target: CliSwitchableChannel) => {
+    if (!canSwitchCliChannel(channel, target)) return;
+    setConfirm({ kind: "switch", channel: target });
+  };
+
+  const requestPin = () => {
+    const v = pinInput.trim();
+    if (!isValidCliVersionPin(v)) {
+      setError(t("settings.cliChannel.invalidVersion"));
+      return;
+    }
+    setError(null);
+    setConfirm({ kind: "pin", version: v });
+  };
+
+  const confirmTitle =
+    confirm?.kind === "switch"
+      ? t("settings.cliChannel.switchConfirmTitle", {
+          channel: t(cliChannelLabelKey(confirm.channel)),
+        })
+      : confirm?.kind === "pin"
+        ? t("settings.cliChannel.pinConfirmTitle", {
+            version: confirm.version,
+          })
+        : t("settings.cliUpdate");
+
+  const confirmBody =
+    confirm?.kind === "switch"
+      ? t("settings.cliChannel.switchConfirmMsg", {
+          channel: t(cliChannelLabelKey(confirm.channel)),
+        })
+      : confirm?.kind === "pin"
+        ? t("settings.cliChannel.pinConfirmMsg", {
+            version: confirm.version,
+          })
+        : "";
+
   return (
     <div
       className={
@@ -119,6 +229,30 @@ export function CliUpdateRow({
         <div className="settings-row__desc">{t("settings.cliUpdateDesc")}</div>
       </div>
       <div className="settings-cli-update">
+        {status ? (
+          <div className="settings-cli-update__meta" role="status">
+            <span className="settings-cli-update__meta-item">
+              {t("settings.cliChannel.versionLabel", {
+                version: status.current,
+              })}
+            </span>
+            <span
+              className={
+                "settings-cli-update__channel" +
+                (channel === "alpha"
+                  ? " is-alpha"
+                  : channel === "stable"
+                    ? " is-stable"
+                    : " is-unknown")
+              }
+            >
+              {t("settings.cliChannel.label", {
+                channel: t(cliChannelLabelKey(channel)),
+              })}
+            </span>
+          </div>
+        ) : null}
+
         <div className="settings-cli-update__actions">
           <button
             type="button"
@@ -135,7 +269,7 @@ export function CliUpdateRow({
               type="button"
               className="btn btn--ghost"
               disabled={busy !== null}
-              onClick={() => void install()}
+              onClick={() => void runInstall(null, "install")}
             >
               {busy === "install"
                 ? t("settings.cliUpdateInstalling")
@@ -143,9 +277,87 @@ export function CliUpdateRow({
             </button>
           ) : null}
         </div>
+
+        {!compact ? (
+          <>
+            <div className="settings-cli-update__channel-actions">
+              <span className="settings-cli-update__channel-hint">
+                {t("settings.cliChannel.switchHint")}
+              </span>
+              <div className="settings-cli-update__actions">
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  disabled={
+                    busy !== null || !canSwitchCliChannel(channel, "alpha")
+                  }
+                  onClick={() => requestSwitch("alpha")}
+                  title={t("settings.cliChannel.switchToAlpha")}
+                >
+                  {busy === "switch-alpha"
+                    ? t("settings.cliUpdateInstalling")
+                    : t("settings.cliChannel.switchToAlpha")}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  disabled={
+                    busy !== null || !canSwitchCliChannel(channel, "stable")
+                  }
+                  onClick={() => requestSwitch("stable")}
+                  title={t("settings.cliChannel.switchToStable")}
+                >
+                  {busy === "switch-stable"
+                    ? t("settings.cliUpdateInstalling")
+                    : t("settings.cliChannel.switchToStable")}
+                </button>
+              </div>
+            </div>
+
+            <div className="settings-cli-update__pin">
+              <label className="settings-cli-update__pin-label" htmlFor="cli-version-pin">
+                {t("settings.cliChannel.pinLabel")}
+              </label>
+              <div className="settings-cli-update__pin-row">
+                <input
+                  id="cli-version-pin"
+                  className="settings-input settings-cli-update__pin-input"
+                  value={pinInput}
+                  placeholder={t("settings.cliChannel.pinPlaceholder")}
+                  disabled={busy !== null}
+                  onChange={(e) => setPinInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      requestPin();
+                    }
+                  }}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  disabled={
+                    busy !== null || !isValidCliVersionPin(pinInput)
+                  }
+                  onClick={() => requestPin()}
+                >
+                  {busy === "pin"
+                    ? t("settings.cliUpdateInstalling")
+                    : t("settings.cliChannel.pinAction")}
+                </button>
+              </div>
+              <div className="settings-cli-update__pin-hint">
+                {t("settings.cliChannel.pinHint")}
+              </div>
+            </div>
+          </>
+        ) : null}
+
         {error ? (
           <div className="settings-cli-update__err" role="alert">
-            {result?.updateAvailable
+            {result?.updateAvailable || busy === "install"
               ? t("settings.cliUpdateInstallFailed", { error })
               : t("settings.cliUpdateFailed", { error })}
           </div>
@@ -182,16 +394,65 @@ export function CliUpdateRow({
           >
             {result.updateAvailable
               ? t("settings.cliUpdateAvailable", {
-                  latest: result.latestVersion,
-                  current: result.currentVersion,
+                  latest: status?.latest ?? "—",
+                  current: status?.current ?? "—",
                 })
               : t("settings.cliUpdateLatest", {
-                  version: result.currentVersion,
+                  version: status?.current ?? "—",
                 })}
-            {result.channel ? ` · ${result.channel}` : ""}
           </div>
         ) : null}
       </div>
+
+      <GlassModal
+        open={!!confirm}
+        onClose={() => {
+          if (busy === null) setConfirm(null);
+        }}
+        title={confirmTitle}
+        size="sm"
+        closeLabel={t("common.close")}
+        closeOnOverlay={busy === null}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={busy !== null}
+              onClick={() => setConfirm(null)}
+            >
+              {t("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={busy !== null}
+              onClick={() => {
+                if (!confirm) return;
+                if (confirm.kind === "switch") {
+                  void runInstall(
+                    { channel: confirm.channel },
+                    confirm.channel === "alpha"
+                      ? "switch-alpha"
+                      : "switch-stable",
+                  );
+                } else {
+                  void runInstall(
+                    { version: confirm.version },
+                    "pin",
+                  );
+                }
+              }}
+            >
+              {t("settings.cliChannel.confirmAction")}
+            </button>
+          </>
+        }
+      >
+        <p className="settings-row__desc" style={{ margin: 0 }}>
+          {confirmBody}
+        </p>
+      </GlassModal>
     </div>
   );
 }

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -212,6 +212,7 @@ import { RemoteImLayout } from "@/components/RemoteImLayout";
 import { MirrorConnectPanel } from "@/components/MirrorConnectPanel";
 import { LeaderServePanel } from "@/components/LeaderServePanel";
 import { SdkConnectWizard } from "@/components/SdkConnectWizard";
+import { CliUpdateRow } from "@/components/CliUpdateRow";
 import {
   createT,
   resolveLocale,
@@ -5387,6 +5388,19 @@ export function SettingsPage({
                     />
                   </div>
                 ) : null}
+                <div
+                  className={
+                    "settings-row settings-row--stack" +
+                    rowHighlight("settings-anchor-cliUpdate")
+                  }
+                  id="settings-anchor-cliUpdate"
+                >
+                  <CliUpdateRow
+                    t={t}
+                    cliFound={cliInfo.found}
+                    autoCheck
+                  />
+                </div>
               </div>
             )}
             {activeTab === "connection" && (
@@ -5818,6 +5832,15 @@ export function SettingsPage({
                 </div>
               </div>
               <AboutUpdateRow t={t} />
+              <div
+                className={
+                  "settings-row settings-row--stack" +
+                  rowHighlight("settings-anchor-aboutCli")
+                }
+                id="settings-anchor-aboutCli"
+              >
+                <CliUpdateRow t={t} cliFound={cliInfo.found} autoCheck />
+              </div>
             </div>
             {onOpenProductTutorial ? (
               <div

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1233,7 +1233,7 @@ const en = {
   "settings.cliNotFound": "(not found)",
   "settings.cliUpdate": "CLI updates",
   "settings.cliUpdateDesc":
-    "Check the Grok Build CLI channel for a newer binary (same as `grok update --check`).",
+    "Check for CLI updates (`grok update --check --json`), switch stable/alpha channels (CLI 0.2.117+), or pin a version.",
   "settings.cliUpdateCheck": "Check for CLI updates",
   "settings.cliUpdateChecking": "Checking…",
   "settings.cliUpdateLatest": "CLI is up to date ({version}).",
@@ -1253,6 +1253,32 @@ const en = {
   "settings.cliUpdateFailed": "Could not check: {error}",
   "settings.cliUpdateInstallFailed": "Update failed: {error}",
   "settings.cliUpdateNeedCli": "Install or locate the CLI first.",
+  "settings.cliChannel.label": "Channel: {channel}",
+  "settings.cliChannel.stable": "stable",
+  "settings.cliChannel.alpha": "alpha",
+  "settings.cliChannel.unknown": "unknown",
+  "settings.cliChannel.versionLabel": "CLI {version}",
+  "settings.cliChannel.switchHint":
+    "Switch release channel (CLI 0.2.117+: `grok update --alpha|--stable`). Never invents channels.",
+  "settings.cliChannel.switchToAlpha": "Switch to alpha",
+  "settings.cliChannel.switchToStable": "Switch to stable",
+  "settings.cliChannel.switchConfirmTitle": "Switch CLI to {channel}?",
+  "settings.cliChannel.switchConfirmMsg":
+    "Runs `grok update --{channel}` and may download a different binary. Restart sessions afterward so they use the new CLI.",
+  "settings.cliChannel.switched":
+    "CLI channel is now {channel} ({version}).",
+  "settings.cliChannel.pinLabel": "Install specific version",
+  "settings.cliChannel.pinPlaceholder": "e.g. 0.2.117",
+  "settings.cliChannel.pinHint":
+    "Pins with `grok update --version <V>` (optional alpha tags like 0.1.151-alpha.2).",
+  "settings.cliChannel.pinAction": "Install version",
+  "settings.cliChannel.pinConfirmTitle": "Install CLI {version}?",
+  "settings.cliChannel.pinConfirmMsg":
+    "Runs `grok update --version {version}`. Soft-fails if the CLI rejects the pin; no invented versions.",
+  "settings.cliChannel.pinned": "CLI pinned to {version}.",
+  "settings.cliChannel.invalidVersion":
+    "Enter a valid version (e.g. 0.2.117), not a flag or path.",
+  "settings.cliChannel.confirmAction": "Continue",
   "settings.acpServer": "ACP server (API mode)",
   "settings.acpServerDesc":
     "Connect to a remote ACP agent over TCP (host:port) instead of spawning the local CLI — e.g. an agent in WSL, a container, or another host. Leave empty for local spawn.",
@@ -2204,7 +2230,8 @@ const en = {
   "doctor.check.logs": "Logs",
   "doctor.rawToggle": "Show raw report",
   "doctor.cliUpdate": "CLI updates",
-  "doctor.cliUpdateHint": "Same check as Settings → Runtime (`grok update --check`).",
+  "doctor.cliUpdateHint":
+    "Same check as Settings → Runtime / About (`grok update --check`; channel switch in Settings).",
   "doctor.supportZip": "Support zip",
   "doctor.supportZipHint": "Redacted Doctor report + recent logs (no secrets).",
   "doctor.supportZipDone": "Support zip saved",
@@ -4913,7 +4940,7 @@ const zh: Record<MessageKey, string> = {
   "settings.cliNotFound": "（未找到）",
   "settings.cliUpdate": "CLI 更新",
   "settings.cliUpdateDesc":
-    "检查 Grok Build CLI 通道是否有新版本（等同 `grok update --check`）。",
+    "检查 CLI 更新（`grok update --check --json`），切换 stable/alpha 通道（CLI 0.2.117+），或固定版本。",
   "settings.cliUpdateCheck": "检查 CLI 更新",
   "settings.cliUpdateChecking": "检查中…",
   "settings.cliUpdateLatest": "CLI 已是最新（{version}）。",
@@ -4932,6 +4959,32 @@ const zh: Record<MessageKey, string> = {
   "settings.cliUpdateFailed": "检查失败：{error}",
   "settings.cliUpdateInstallFailed": "更新失败：{error}",
   "settings.cliUpdateNeedCli": "请先安装或指定 CLI 路径。",
+  "settings.cliChannel.label": "通道：{channel}",
+  "settings.cliChannel.stable": "stable",
+  "settings.cliChannel.alpha": "alpha",
+  "settings.cliChannel.unknown": "未知",
+  "settings.cliChannel.versionLabel": "CLI {version}",
+  "settings.cliChannel.switchHint":
+    "切换发布通道（CLI 0.2.117+：`grok update --alpha|--stable`）。不会虚构通道。",
+  "settings.cliChannel.switchToAlpha": "切换到 alpha",
+  "settings.cliChannel.switchToStable": "切换到 stable",
+  "settings.cliChannel.switchConfirmTitle": "将 CLI 切换到 {channel}？",
+  "settings.cliChannel.switchConfirmMsg":
+    "将执行 `grok update --{channel}`，可能下载另一二进制。完成后请重启会话以使用新 CLI。",
+  "settings.cliChannel.switched":
+    "CLI 通道已为 {channel}（{version}）。",
+  "settings.cliChannel.pinLabel": "安装指定版本",
+  "settings.cliChannel.pinPlaceholder": "例如 0.2.117",
+  "settings.cliChannel.pinHint":
+    "使用 `grok update --version <V>` 固定版本（可含 alpha 标签，如 0.1.151-alpha.2）。",
+  "settings.cliChannel.pinAction": "安装该版本",
+  "settings.cliChannel.pinConfirmTitle": "安装 CLI {version}？",
+  "settings.cliChannel.pinConfirmMsg":
+    "将执行 `grok update --version {version}`。CLI 拒绝时软失败；不会虚构版本。",
+  "settings.cliChannel.pinned": "CLI 已固定为 {version}。",
+  "settings.cliChannel.invalidVersion":
+    "请输入有效版本（如 0.2.117），不要填标志或路径。",
+  "settings.cliChannel.confirmAction": "继续",
   "settings.acpServer": "ACP 服务器（API 模式）",
   "settings.acpServerDesc":
     "通过 TCP（host:port）连接远程 ACP Agent，替代启动本地 CLI —— 例如运行在 WSL、容器或另一台主机上的 Agent。留空则使用本地启动。",
@@ -5863,7 +5916,8 @@ const zh: Record<MessageKey, string> = {
   "doctor.check.logs": "日志",
   "doctor.rawToggle": "显示原始报告",
   "doctor.cliUpdate": "CLI 更新",
-  "doctor.cliUpdateHint": "与设置 → 运行环境相同（`grok update --check`）。",
+  "doctor.cliUpdateHint":
+    "与设置 → 运行环境 / 关于相同（`grok update --check`；通道切换在设置中）。",
   "doctor.supportZip": "支持包",
   "doctor.supportZipHint": "脱敏后的 Doctor 报告与近期日志（不含密钥）。",
   "doctor.supportZipDone": "支持包已保存",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1171,7 +1171,7 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.cliNotFound": "（未找到）",
   "settings.cliUpdate": "CLI 更新",
   "settings.cliUpdateDesc":
-    "檢查 Grok Build CLI 通道是否有新版本（等同 `grok update --check`）。",
+    "檢查 CLI 更新（`grok update --check --json`），切換 stable/alpha 通道（CLI 0.2.117+），或固定版本。",
   "settings.cliUpdateCheck": "檢查 CLI 更新",
   "settings.cliUpdateChecking": "檢查中…",
   "settings.cliUpdateLatest": "CLI 已是最新（{version}）。",
@@ -1190,6 +1190,32 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.cliUpdateFailed": "檢查失敗：{error}",
   "settings.cliUpdateInstallFailed": "更新失敗：{error}",
   "settings.cliUpdateNeedCli": "請先安裝或指定 CLI 路徑。",
+  "settings.cliChannel.label": "通道：{channel}",
+  "settings.cliChannel.stable": "stable",
+  "settings.cliChannel.alpha": "alpha",
+  "settings.cliChannel.unknown": "未知",
+  "settings.cliChannel.versionLabel": "CLI {version}",
+  "settings.cliChannel.switchHint":
+    "切換發布通道（CLI 0.2.117+：`grok update --alpha|--stable`）。不會虛構通道。",
+  "settings.cliChannel.switchToAlpha": "切換到 alpha",
+  "settings.cliChannel.switchToStable": "切換到 stable",
+  "settings.cliChannel.switchConfirmTitle": "將 CLI 切換到 {channel}？",
+  "settings.cliChannel.switchConfirmMsg":
+    "將執行 `grok update --{channel}`，可能下載另一二進位。完成後請重新啟動對話以使用新 CLI。",
+  "settings.cliChannel.switched":
+    "CLI 通道已為 {channel}（{version}）。",
+  "settings.cliChannel.pinLabel": "安裝指定版本",
+  "settings.cliChannel.pinPlaceholder": "例如 0.2.117",
+  "settings.cliChannel.pinHint":
+    "使用 `grok update --version <V>` 固定版本（可含 alpha 標籤，如 0.1.151-alpha.2）。",
+  "settings.cliChannel.pinAction": "安裝該版本",
+  "settings.cliChannel.pinConfirmTitle": "安裝 CLI {version}？",
+  "settings.cliChannel.pinConfirmMsg":
+    "將執行 `grok update --version {version}`。CLI 拒絕時軟失敗；不會虛構版本。",
+  "settings.cliChannel.pinned": "CLI 已固定為 {version}。",
+  "settings.cliChannel.invalidVersion":
+    "請輸入有效版本（如 0.2.117），不要填旗標或路徑。",
+  "settings.cliChannel.confirmAction": "繼續",
   "settings.acpServer": "ACP 伺服器（API 模式）",
   "settings.acpServerDesc":
     "透過 TCP（host:port）連線遠端 ACP Agent，取代啟動本機 CLI —— 例如執行在 WSL、容器或另一台主機上的 Agent。留空則使用本機啟動。",
@@ -2121,7 +2147,8 @@ export const zhTW: Record<MessageKey, string> = {
   "doctor.check.logs": "日誌",
   "doctor.rawToggle": "顯示原始報告",
   "doctor.cliUpdate": "CLI 更新",
-  "doctor.cliUpdateHint": "與設定 → 執行環境相同（`grok update --check`）。",
+  "doctor.cliUpdateHint":
+    "與設定 → 執行環境 / 關於相同（`grok update --check`；通道切換在設定中）。",
   "doctor.supportZip": "支援包",
   "doctor.supportZipHint": "脫敏後的 Doctor 報告與近期日誌（不含金鑰）。",
   "doctor.supportZipDone": "支援包已儲存",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3377,25 +3377,45 @@ export async function voiceTranscribe(opts: {
 }
 
 export type CliUpdateCheck = {
-  ok: boolean;
+  ok?: boolean;
   current?: string | null;
   latest?: string | null;
   currentVersion?: string | null;
   latestVersion?: string | null;
   version?: string | null;
+  /** Raw channel from CLI when known (`stable` / `alpha`); omit/null = unknown. */
   channel?: string | null;
   updateAvailable?: boolean;
   message?: string | null;
   error?: string | null;
+  cliPath?: string | null;
   [key: string]: unknown;
+};
+
+export type CliUpdateInstallOpts = {
+  /** Switch to `stable` or `alpha` (`grok update --stable|--alpha`). */
+  channel?: string | null;
+  /** Pin a specific version (`grok update --version <V>`). */
+  version?: string | null;
+  /** Pass `--force-reinstall`. */
+  force?: boolean | null;
 };
 
 export async function cliUpdateCheck() {
   return invoke<CliUpdateCheck>("cli_update_check");
 }
 
-export async function cliUpdateInstall() {
-  return invoke<CliUpdateCheck>("cli_update_install");
+/**
+ * Install / switch / pin CLI via host `cli_update_install`.
+ * Plain call = current-channel update (App trust-chain fallback).
+ * Channel/version soft-fail without inventing channels.
+ */
+export async function cliUpdateInstall(opts?: CliUpdateInstallOpts | null) {
+  return invoke<CliUpdateCheck>("cli_update_install", {
+    channel: opts?.channel ?? null,
+    version: opts?.version ?? null,
+    force: opts?.force ?? null,
+  });
 }
 
 /** Recycle all warm agent processes (e.g. after CLI upgrade). */

--- a/src/lib/cliUpdateChannel.test.ts
+++ b/src/lib/cliUpdateChannel.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  canSwitchCliChannel,
+  cliChannelLabelKey,
+  formatCliUpdateStatus,
+  isValidCliVersionPin,
+  normalizeCliChannel,
+} from "./cliUpdateChannel";
+
+describe("normalizeCliChannel", () => {
+  it("recognizes stable and alpha only", () => {
+    expect(normalizeCliChannel("stable")).toBe("stable");
+    expect(normalizeCliChannel("ALPHA")).toBe("alpha");
+    expect(normalizeCliChannel("  alpha  ")).toBe("alpha");
+  });
+
+  it("never invents unknown channels", () => {
+    expect(normalizeCliChannel(null)).toBe("unknown");
+    expect(normalizeCliChannel(undefined)).toBe("unknown");
+    expect(normalizeCliChannel("")).toBe("unknown");
+    expect(normalizeCliChannel("beta")).toBe("unknown");
+    expect(normalizeCliChannel("nightly")).toBe("unknown");
+  });
+});
+
+describe("canSwitchCliChannel", () => {
+  it("allows switch when current differs or unknown", () => {
+    expect(canSwitchCliChannel("stable", "alpha")).toBe(true);
+    expect(canSwitchCliChannel("alpha", "stable")).toBe(true);
+    expect(canSwitchCliChannel("unknown", "stable")).toBe(true);
+    expect(canSwitchCliChannel(null, "alpha")).toBe(true);
+  });
+
+  it("blocks switch when already on target", () => {
+    expect(canSwitchCliChannel("stable", "stable")).toBe(false);
+    expect(canSwitchCliChannel("alpha", "alpha")).toBe(false);
+  });
+});
+
+describe("isValidCliVersionPin", () => {
+  it("accepts semver-ish pins", () => {
+    expect(isValidCliVersionPin("0.2.117")).toBe(true);
+    expect(isValidCliVersionPin("0.1.151-alpha.2")).toBe(true);
+  });
+
+  it("rejects empty, flags, paths, and non-version text", () => {
+    expect(isValidCliVersionPin("")).toBe(false);
+    expect(isValidCliVersionPin("  ")).toBe(false);
+    expect(isValidCliVersionPin("--help")).toBe(false);
+    expect(isValidCliVersionPin("../etc/passwd")).toBe(false);
+    expect(isValidCliVersionPin("a b")).toBe(false);
+    expect(isValidCliVersionPin("no-digits")).toBe(false);
+  });
+});
+
+describe("cliChannelLabelKey", () => {
+  it("maps to i18n keys without inventing", () => {
+    expect(cliChannelLabelKey("stable")).toBe("settings.cliChannel.stable");
+    expect(cliChannelLabelKey("alpha")).toBe("settings.cliChannel.alpha");
+    expect(cliChannelLabelKey("nightly")).toBe("settings.cliChannel.unknown");
+  });
+});
+
+describe("formatCliUpdateStatus", () => {
+  it("summarizes check payload", () => {
+    expect(
+      formatCliUpdateStatus({
+        currentVersion: "0.2.117",
+        latestVersion: "0.2.118",
+        channel: "stable",
+        updateAvailable: true,
+      }),
+    ).toEqual({
+      current: "0.2.117",
+      latest: "0.2.118",
+      channel: "stable",
+      updateAvailable: true,
+    });
+  });
+
+  it("defaults missing channel to unknown", () => {
+    expect(
+      formatCliUpdateStatus({
+        currentVersion: "0.2.100",
+      }).channel,
+    ).toBe("unknown");
+  });
+});

--- a/src/lib/cliUpdateChannel.ts
+++ b/src/lib/cliUpdateChannel.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure helpers for Grok Build CLI release channels (CLI ≥ 0.2.117).
+ *
+ * `grok update --check --json` may report `channel: "stable" | "alpha"`.
+ * Switch via `grok update --alpha|--stable`; pin via `--version <V>`.
+ * Never invent channels — unknown/missing → "unknown".
+ */
+
+export type CliReleaseChannel = "stable" | "alpha" | "unknown";
+
+/** Switch targets the CLI actually supports as flags. */
+export type CliSwitchableChannel = "stable" | "alpha";
+
+/**
+ * Normalize a raw channel string from CLI JSON or UI.
+ * Only `stable` / `alpha` (case-insensitive) are recognized.
+ */
+export function normalizeCliChannel(
+  raw: string | null | undefined,
+): CliReleaseChannel {
+  const t = String(raw ?? "")
+    .trim()
+    .toLowerCase();
+  if (t === "stable") return "stable";
+  if (t === "alpha") return "alpha";
+  return "unknown";
+}
+
+/** Whether `target` is a different, switchable channel from `current`. */
+export function canSwitchCliChannel(
+  current: CliReleaseChannel | string | null | undefined,
+  target: CliSwitchableChannel,
+): boolean {
+  const cur = normalizeCliChannel(
+    typeof current === "string" || current == null ? current : String(current),
+  );
+  return cur !== target;
+}
+
+/**
+ * Validate a version pin for `grok update --version`.
+ * Semver-ish only; rejects flags, paths, and empty input.
+ */
+export function isValidCliVersionPin(raw: string | null | undefined): boolean {
+  const t = String(raw ?? "").trim();
+  if (!t || t.length > 64) return false;
+  if (t.startsWith("-") || t.includes("/") || t.includes("\\") || /\s/.test(t)) {
+    return false;
+  }
+  let hasDigit = false;
+  for (const c of t) {
+    if (c >= "0" && c <= "9") {
+      hasDigit = true;
+      continue;
+    }
+    if (
+      (c >= "a" && c <= "z") ||
+      (c >= "A" && c <= "Z") ||
+      c === "." ||
+      c === "-" ||
+      c === "+" ||
+      c === "_"
+    ) {
+      continue;
+    }
+    return false;
+  }
+  return hasDigit;
+}
+
+/** Display label key suffix for a channel (`stable` / `alpha` / `unknown`). */
+export function cliChannelLabelKey(
+  channel: CliReleaseChannel | string | null | undefined,
+): "settings.cliChannel.stable" | "settings.cliChannel.alpha" | "settings.cliChannel.unknown" {
+  const c = normalizeCliChannel(
+    typeof channel === "string" || channel == null ? channel : String(channel),
+  );
+  if (c === "stable") return "settings.cliChannel.stable";
+  if (c === "alpha") return "settings.cliChannel.alpha";
+  return "settings.cliChannel.unknown";
+}
+
+/**
+ * Summarize version + channel for status chips.
+ * Never invents a channel label when JSON omitted it.
+ */
+export function formatCliUpdateStatus(input: {
+  currentVersion?: string | null;
+  latestVersion?: string | null;
+  channel?: string | null;
+  updateAvailable?: boolean;
+}): {
+  current: string;
+  latest: string;
+  channel: CliReleaseChannel;
+  updateAvailable: boolean;
+} {
+  const current = String(input.currentVersion ?? "").trim() || "—";
+  const latest = String(input.latestVersion ?? "").trim() || current;
+  const channel = normalizeCliChannel(input.channel);
+  const updateAvailable = Boolean(input.updateAvailable);
+  return { current, latest, channel, updateAvailable };
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -1783,6 +1783,27 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     keywords: ["checksum", "sha256", "unverified", "cli install", "trust"],
   },
   {
+    id: "runtime.cliUpdate",
+    section: "runtime",
+    tab: "cli",
+    anchorId: "settings-anchor-cliUpdate",
+    labelKey: "settings.cliUpdate",
+    descKeys: [
+      "settings.cliUpdateDesc",
+      "settings.cliChannel.switchHint",
+      "settings.cliChannel.pinHint",
+    ],
+    keywords: [
+      "cli update",
+      "grok update",
+      "channel",
+      "alpha",
+      "stable",
+      "version pin",
+      "0.2.117",
+    ],
+  },
+  {
     id: "runtime.acp",
     section: "runtime",
     tab: "connection",
@@ -2148,6 +2169,25 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     anchorId: "settings-anchor-about",
     labelKey: "settings.aboutApp",
     keywords: ["about", "version", "update"],
+  },
+  {
+    id: "about.cli",
+    section: "about",
+    anchorId: "settings-anchor-aboutCli",
+    labelKey: "settings.cliUpdate",
+    descKeys: [
+      "settings.cliUpdateDesc",
+      "settings.cliChannel.switchHint",
+      "settings.cliChannel.pinLabel",
+    ],
+    keywords: [
+      "cli",
+      "grok update",
+      "channel",
+      "alpha",
+      "stable",
+      "cli version",
+    ],
   },
   {
     id: "about.tutorial",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5201,7 +5201,7 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   font-family: var(--font-mono);
 }
 
-/* CLI update check (Settings → Runtime + Doctor) */
+/* CLI update check (Settings → Runtime / About + Doctor) */
 .settings-cli-update {
   display: flex;
   flex-direction: column;
@@ -5215,6 +5215,86 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
+}
+
+.settings-cli-update__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 10px;
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.settings-cli-update__meta-item {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.settings-cli-update__channel {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 500;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated, var(--bg-secondary));
+  color: var(--text-secondary);
+}
+
+.settings-cli-update__channel.is-stable {
+  color: var(--text-primary);
+}
+
+.settings-cli-update__channel.is-alpha {
+  color: var(--warning, #c90);
+  border-color: color-mix(in srgb, var(--warning, #c90) 35%, var(--border-subtle));
+}
+
+.settings-cli-update__channel.is-unknown {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.settings-cli-update__channel-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-cli-update__channel-hint,
+.settings-cli-update__pin-hint {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  line-height: 1.4;
+}
+
+.settings-cli-update__pin {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-cli-update__pin-label {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+}
+
+.settings-cli-update__pin-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-cli-update__pin-input {
+  flex: 1 1 10rem;
+  min-width: 0;
+  max-width: 16rem;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
 }
 
 .settings-cli-update__status {


### PR DESCRIPTION
## Summary

Wire **Grok Build CLI 0.2.117** update channels into the App:

- **Host** (`cli_update`): parse `channel` from `grok update --check --json` (only `stable` / `alpha` — **never invents**); pure `build_update_args` / `parse_cli_channel` / version-pin validation; `cli_update_install` accepts optional `channel` | `version` | `force` (`--alpha` / `--stable` / `--version` / `--force-reinstall`). Channel/version soft-fail without App trust-chain fallback (which is stable-latest only).
- **UI**: Settings → **Runtime → CLI** and **About** show current version + channel chip; **Switch to alpha / stable** + optional version pin with **in-app confirm** (`GlassModal`). Doctor keeps compact check/install only.
- **Pure helpers/tests**: `src/lib/cliUpdateChannel.ts` + vitest; Rust unit tests on arg builders and JSON channel handling.
- **i18n** en / zh / zh-TW; **settings catalog** deep links; **CHANGELOG**.

## CLI surface (0.2.117)

```
grok update --check --json
grok update --alpha | --stable
grok update --version <V>
grok update --force-reinstall
```

## Test plan

- [x] `cargo test --lib cli_update` (15 passed)
- [x] `vitest` `cliUpdateChannel` + `messages` (27 passed)
- [ ] Manual: Settings → Runtime → CLI / About — check shows version + channel
- [ ] Switch alpha ↔ stable (confirm dialog); soft-fail if CLI too old
- [ ] Pin a known version (e.g. current); invalid input rejected in UI
- [ ] Plain “Update CLI” still works when update available