### PR TITLE
feat(settings): Privacy center for Grok Build 0.2.117 privacy config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ### Added
 
 #### Runtime / connection
+- **Privacy center** (Settings → Runtime → Privacy): honest Grok Build **0.2.117** privacy-related `config.toml` keys from the active `GROK_HOME` — `[features] telemetry`, `[telemetry] trace_upload` / `mixpanel_enabled`, `[harness] disable_codebase_upload` / `disable_workspace_teleport`. Missing keys stay unset (never invent “off”). Independent agent-home: allowlisted write + soft-respawn; shared mode: read-only probe of `~/.grok`. Coding-data / retention / training is **not** a config key — UI links to CLI `/privacy` only (no fake App toggle). Pure helpers + tests; `settingsCatalog` + en/zh/zh-TW
 - **SDK Connect wizard** (Settings → Runtime → Connection): start local `agent serve`, show masked secret + ws URL, TCP health probe, copy curl / websocat / `grok --remote` examples for external clients, and optional paste remote serve URL + probe. Secrets never logged; full token only via one-time clipboard after start.
 
 #### Composer & chat

--- a/docs/llm-wiki/settings-ia.md
+++ b/docs/llm-wiki/settings-ia.md
@@ -25,7 +25,7 @@ Agent / 贡献者维护设置 UI 时**必读**。目标：层次清晰、可搜�
 | appearance | `theme`（主题：浅深色 / 皮肤 / 背景）· `interface`（界面：聊天展示） |
 | account | `official` · `providers` |
 | extensions | `plugins` · `skills` · `mcp` · `hooks` · `market` |
-| runtime | `cli` · `connection` · `pool` · `tools` |
+| runtime | `cli` · `connection` · `network` · `pool` · `tools` · `privacy` |
 | remote_im（远程控制） | `im`（IM 通信）· `mirror`（手机镜像） |
 | 其余 | 无 tab（单页） |
 
@@ -37,6 +37,7 @@ Agent / 贡献者维护设置 UI 时**必读**。目标：层次清晰、可搜�
 #/settings/general                  → general/composer
 #/settings/extensions/mcp           → 扩展 · MCP
 #/settings/runtime/tools            → CLI · 诊断
+#/settings/runtime/privacy          → CLI · 隐私中心
 #/settings/account/providers        → 自定义提供商
 #/settings/remote_im                → 远程控制 · IM 通信
 #/settings/remote_im/mirror         → 远程控制 · 手机镜像
@@ -60,7 +61,7 @@ Agent / 贡献者维护设置 UI 时**必读**。目标：层次清晰、可搜�
 |----|------|------|
 | 管理 Skills/MCP/Plugins/Hooks/Market | **扩展** | 可写开关、安装、移除 |
 | 只读 project inspect 摘要 | **运行时 · 诊断** | 保留；文案链到扩展 |
-| CLI 路径 / ACP / 进程池 / Doctor / Managed setup | **运行时** | 不进扩展 |
+| CLI 路径 / ACP / 进程池 / Doctor / Managed setup / Privacy center | **运行时** | 不进扩展 |
 
 ## 新增设置 — 强制清单
 

--- a/src-tauri/src/agent_privacy.rs
+++ b/src-tauri/src/agent_privacy.rs
@@ -1,0 +1,537 @@
+//! Privacy center — allowlisted read/write of Grok Build 0.2.117 privacy keys
+//! in the active `GROK_HOME` `config.toml`.
+//!
+//! ## Allowlist (soft-fail when missing)
+//! - `[features] telemetry` — product-analytics master switch
+//! - `[telemetry] trace_upload` — session trace upload
+//! - `[telemetry] mixpanel_enabled` — Mixpanel product analytics
+//! - `[harness] disable_codebase_upload` — refuse codebase/index upload
+//! - `[harness] disable_workspace_teleport` — related harness upload flag
+//!
+//! ## Honesty
+//! - Missing keys stay `None` (never invent CLI defaults as “off”).
+//! - Writes are path-scoped to independent agent-home only (never `~/.grok`).
+//! - Shared mode is read-only against the live `~/.grok/config.toml`.
+//! - Coding-data / training opt-in is **not** a config.toml key — UI must
+//!   point users at CLI `/privacy` instead of a fake App toggle.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::agent_config_edit::{
+    is_agent_home_config_path, parse_toml_bool, require_agent_home_config_path, set_table_key,
+};
+use crate::agent_config_view::{config_toml_path, normalize_mode};
+use crate::paths::{agent_config_toml, agent_home_dir, ensure_app_dirs, resolve_agent_grok_home};
+use crate::store;
+
+/// Hard cap on bytes read before parse / redaction.
+pub const MAX_PRIVACY_CONFIG_BYTES: u64 = 256 * 1024;
+
+/// Snapshot of privacy-related allowlisted keys for Settings UI.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivacyConfigSnapshot {
+    /// Absolute path of the config.toml being shown (active mode).
+    pub path: String,
+    /// Absolute GROK_HOME root for this mode.
+    pub grok_home: String,
+    /// `independent` | `shared`
+    pub mode: String,
+    /// True only when mode is independent (edits apply to App agent-home).
+    pub writable: bool,
+    pub file_exists: bool,
+    /// `[features].telemetry` when present.
+    pub telemetry: Option<bool>,
+    /// `[telemetry].trace_upload` when present.
+    pub trace_upload: Option<bool>,
+    /// `[telemetry].mixpanel_enabled` when present.
+    pub mixpanel_enabled: Option<bool>,
+    /// `[harness].disable_codebase_upload` when present.
+    pub disable_codebase_upload: Option<bool>,
+    /// `[harness].disable_workspace_teleport` when present.
+    pub disable_workspace_teleport: Option<bool>,
+    /// Redacted preview of allowlisted privacy sections only.
+    pub redacted_preview: String,
+    /// CLI slash command for coding-data / retention / training (not config.toml).
+    pub cli_privacy_command: String,
+}
+
+/// Partial patch for allowlisted privacy keys. `None` = leave unchanged.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivacyConfigPatch {
+    pub telemetry: Option<bool>,
+    pub trace_upload: Option<bool>,
+    pub mixpanel_enabled: Option<bool>,
+    pub disable_codebase_upload: Option<bool>,
+    pub disable_workspace_teleport: Option<bool>,
+}
+
+impl PrivacyConfigPatch {
+    pub fn is_empty(&self) -> bool {
+        self.telemetry.is_none()
+            && self.trace_upload.is_none()
+            && self.mixpanel_enabled.is_none()
+            && self.disable_codebase_upload.is_none()
+            && self.disable_workspace_teleport.is_none()
+    }
+}
+
+/// Parsed allowlisted privacy flags (all optional — soft-fail missing).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PrivacyFlags {
+    pub telemetry: Option<bool>,
+    pub trace_upload: Option<bool>,
+    pub mixpanel_enabled: Option<bool>,
+    pub disable_codebase_upload: Option<bool>,
+    pub disable_workspace_teleport: Option<bool>,
+}
+
+/// Extract allowlisted privacy keys from full config text (pure).
+pub fn parse_privacy_flags(text: &str) -> PrivacyFlags {
+    let mut flags = PrivacyFlags::default();
+    let mut table = String::new();
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            table = trimmed
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .to_string();
+            continue;
+        }
+        let Some(eq) = trimmed.find('=') else {
+            continue;
+        };
+        let key = trimmed[..eq].trim();
+        let val = trimmed[eq + 1..].trim();
+        let Some(b) = parse_toml_bool(val) else {
+            continue;
+        };
+        match (table.as_str(), key) {
+            ("features", "telemetry") => flags.telemetry = Some(b),
+            ("telemetry", "trace_upload") => flags.trace_upload = Some(b),
+            ("telemetry", "mixpanel_enabled") => flags.mixpanel_enabled = Some(b),
+            ("harness", "disable_codebase_upload") => flags.disable_codebase_upload = Some(b),
+            ("harness", "disable_workspace_teleport") => {
+                flags.disable_workspace_teleport = Some(b)
+            }
+            _ => {}
+        }
+    }
+
+    flags
+}
+
+/// Apply an allowlisted privacy patch onto TOML text (pure). Never rewrites secrets.
+pub fn apply_privacy_patch(text: &str, patch: &PrivacyConfigPatch) -> String {
+    let mut next = text.to_string();
+    if let Some(v) = patch.telemetry {
+        next = set_table_key(
+            &next,
+            "features",
+            "telemetry",
+            if v { "true" } else { "false" },
+            false,
+        );
+    }
+    if let Some(v) = patch.trace_upload {
+        next = set_table_key(
+            &next,
+            "telemetry",
+            "trace_upload",
+            if v { "true" } else { "false" },
+            false,
+        );
+    }
+    if let Some(v) = patch.mixpanel_enabled {
+        next = set_table_key(
+            &next,
+            "telemetry",
+            "mixpanel_enabled",
+            if v { "true" } else { "false" },
+            false,
+        );
+    }
+    if let Some(v) = patch.disable_codebase_upload {
+        next = set_table_key(
+            &next,
+            "harness",
+            "disable_codebase_upload",
+            if v { "true" } else { "false" },
+            false,
+        );
+    }
+    if let Some(v) = patch.disable_workspace_teleport {
+        next = set_table_key(
+            &next,
+            "harness",
+            "disable_workspace_teleport",
+            if v { "true" } else { "false" },
+            false,
+        );
+    }
+    next
+}
+
+/// Extract only privacy-related tables for preview (document order).
+pub fn extract_privacy_sections(text: &str) -> String {
+    let mut out = String::new();
+    let mut keep = false;
+    let mut any = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let name = trimmed.trim_start_matches('[').trim_end_matches(']');
+            // Keep whole tables that host privacy keys (not nested model secrets).
+            keep = matches!(name, "features" | "telemetry" | "harness");
+            if keep {
+                if any {
+                    out.push('\n');
+                }
+                any = true;
+                out.push_str(trimmed);
+                out.push('\n');
+            }
+            continue;
+        }
+        if keep {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Format-preserving secret redaction for privacy preview text.
+pub fn redact_privacy_preview(input: &str) -> String {
+    // Reuse config-edit redaction (api_key / token spans).
+    crate::agent_config_edit::redact_config_text(input)
+}
+
+fn read_config_text(path: &Path) -> (String, bool) {
+    if !path.is_file() {
+        return (String::new(), false);
+    }
+    let meta_len = fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    let truncated = meta_len > MAX_PRIVACY_CONFIG_BYTES;
+    match fs::read(path) {
+        Ok(bytes) => {
+            let slice = if bytes.len() as u64 > MAX_PRIVACY_CONFIG_BYTES {
+                &bytes[..MAX_PRIVACY_CONFIG_BYTES as usize]
+            } else {
+                &bytes
+            };
+            let mut s = String::from_utf8_lossy(slice).into_owned();
+            if truncated {
+                s.push_str("\n# … [truncated] …\n");
+            }
+            (s, true)
+        }
+        Err(_) => (String::new(), false),
+    }
+}
+
+fn snapshot_from_raw(
+    path: &Path,
+    home: &Path,
+    mode: &str,
+    raw: &str,
+    exists: bool,
+) -> PrivacyConfigSnapshot {
+    let flags = parse_privacy_flags(raw);
+    let preview = redact_privacy_preview(&extract_privacy_sections(raw));
+    PrivacyConfigSnapshot {
+        path: path.to_string_lossy().to_string(),
+        grok_home: home.to_string_lossy().to_string(),
+        mode: mode.to_string(),
+        writable: mode == "independent",
+        file_exists: exists,
+        telemetry: flags.telemetry,
+        trace_upload: flags.trace_upload,
+        mixpanel_enabled: flags.mixpanel_enabled,
+        disable_codebase_upload: flags.disable_codebase_upload,
+        disable_workspace_teleport: flags.disable_workspace_teleport,
+        redacted_preview: preview,
+        cli_privacy_command: "/privacy".into(),
+    }
+}
+
+/// Load privacy snapshot for the active session data mode (redact-on-read).
+///
+/// Soft-fails: missing file / missing keys → empty / `None` fields, never error.
+pub fn load_privacy_config() -> Result<PrivacyConfigSnapshot, String> {
+    let settings = store::load_settings();
+    let mode = normalize_mode(&settings.session_data_mode);
+    if mode == "independent" {
+        let _ = ensure_app_dirs();
+    }
+    let path = config_toml_path(mode);
+    let home = resolve_agent_grok_home(mode);
+    let (raw, exists) = read_config_text(&path);
+    Ok(snapshot_from_raw(&path, &home, mode, &raw, exists))
+}
+
+/// Apply allowlisted privacy patch to agent-home config.toml. Shared mode refused.
+pub fn save_privacy_config(patch: &PrivacyConfigPatch) -> Result<PrivacyConfigSnapshot, String> {
+    let settings = store::load_settings();
+    let mode = normalize_mode(&settings.session_data_mode);
+    if mode != "independent" {
+        return Err(
+            "shared session mode: agent-home config.toml is not the live GROK_HOME; switch to independent to edit privacy keys"
+                .into(),
+        );
+    }
+
+    if patch.is_empty() {
+        return load_privacy_config();
+    }
+
+    let _ = ensure_app_dirs();
+    let path = agent_config_toml();
+    require_agent_home_config_path(&path)?;
+    if !is_agent_home_config_path(&path) {
+        return Err(format!(
+            "path not allowed: only agent-home config.toml may be edited ({})",
+            path.display()
+        ));
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create agent-home: {e}"))?;
+    }
+
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    if existing.contains("[REDACTED]") {
+        tracing::warn!(
+            "agent_privacy: on-disk config contains [REDACTED]; writing patch carefully"
+        );
+    }
+    let next = apply_privacy_patch(&existing, patch);
+    fs::write(&path, &next).map_err(|e| format!("write config: {e}"))?;
+
+    tracing::info!(
+        path = %path.display(),
+        telemetry = ?patch.telemetry,
+        trace_upload = ?patch.trace_upload,
+        mixpanel = ?patch.mixpanel_enabled,
+        disable_codebase_upload = ?patch.disable_codebase_upload,
+        disable_workspace_teleport = ?patch.disable_workspace_teleport,
+        "agent_privacy: saved allowlisted privacy keys"
+    );
+
+    // Re-load from agent-home (independent path).
+    let home = agent_home_dir();
+    let (raw, exists) = read_config_text(&path);
+    Ok(snapshot_from_raw(&path, &home, "independent", &raw, exists))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_app_home(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let p = std::env::temp_dir().join(format!(
+            "grok-privacy-{}-{}-{}",
+            label,
+            std::process::id(),
+            nanos
+        ));
+        let _ = fs::remove_dir_all(&p);
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn parse_missing_keys_are_none() {
+        let flags = parse_privacy_flags("[ui]\nyolo = true\n");
+        assert_eq!(flags, PrivacyFlags::default());
+    }
+
+    #[test]
+    fn parse_allowlisted_privacy_keys() {
+        let text = r#"
+[features]
+telemetry = false
+codebase_indexing = true
+
+[telemetry]
+trace_upload = false
+mixpanel_enabled = false
+events_url = "https://example.com"
+
+[harness]
+disable_codebase_upload = true
+disable_workspace_teleport = true
+
+[model.x]
+api_key = "sk-abcdefghijklmnopqrstuvwxyz0123"
+"#;
+        let flags = parse_privacy_flags(text);
+        assert_eq!(flags.telemetry, Some(false));
+        assert_eq!(flags.trace_upload, Some(false));
+        assert_eq!(flags.mixpanel_enabled, Some(false));
+        assert_eq!(flags.disable_codebase_upload, Some(true));
+        assert_eq!(flags.disable_workspace_teleport, Some(true));
+    }
+
+    #[test]
+    fn apply_patch_preserves_other_sections_and_secrets() {
+        let existing = r#"
+[models]
+default = "grok"
+
+[features]
+telemetry = true
+
+[model.relay]
+api_key = "sk-abcdefghijklmnopqrstuvwxyz0123"
+base_url = "https://example.com/v1"
+"#;
+        let next = apply_privacy_patch(
+            existing,
+            &PrivacyConfigPatch {
+                telemetry: Some(false),
+                trace_upload: Some(false),
+                mixpanel_enabled: Some(false),
+                disable_codebase_upload: Some(true),
+                disable_workspace_teleport: Some(true),
+            },
+        );
+        assert!(next.contains("[models]"), "{next}");
+        assert!(next.contains("default = \"grok\""), "{next}");
+        assert!(next.contains("telemetry = false"), "{next}");
+        assert!(next.contains("[telemetry]"), "{next}");
+        assert!(next.contains("trace_upload = false"), "{next}");
+        assert!(next.contains("mixpanel_enabled = false"), "{next}");
+        assert!(next.contains("[harness]"), "{next}");
+        assert!(next.contains("disable_codebase_upload = true"), "{next}");
+        assert!(
+            next.contains("disable_workspace_teleport = true"),
+            "{next}"
+        );
+        assert!(
+            next.contains("sk-abcdefghijklmnopqrstuvwxyz0123"),
+            "{next}"
+        );
+        assert!(next.contains("base_url"), "{next}");
+        // One telemetry assignment under [features].
+        assert_eq!(
+            next.lines()
+                .filter(|l| l.trim().starts_with("telemetry ="))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn extract_privacy_sections_drops_secrets_tables() {
+        let text = r#"
+[features]
+telemetry = false
+
+[model.x]
+api_key = "sk-abcdefghijklmnopqrstuvwxyz0123"
+
+[harness]
+disable_codebase_upload = true
+
+[telemetry]
+trace_upload = false
+"#;
+        let preview = extract_privacy_sections(text);
+        assert!(preview.contains("[features]"));
+        assert!(preview.contains("[harness]"));
+        assert!(preview.contains("[telemetry]"));
+        assert!(!preview.contains("[model.x]"));
+        assert!(!preview.contains("sk-"));
+    }
+
+    #[test]
+    fn load_and_save_roundtrip_independent() {
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let tmp = temp_app_home("roundtrip");
+        let prev = std::env::var("GROK_APP_HOME").ok();
+        std::env::set_var("GROK_APP_HOME", &tmp);
+
+        let _ = ensure_app_dirs();
+        let mut s = store::load_settings();
+        s.session_data_mode = "independent".into();
+        store::save_settings(&s).unwrap();
+
+        let snap = load_privacy_config().unwrap();
+        assert!(snap.writable);
+        assert!(snap.path.contains("agent-home"));
+        assert_eq!(snap.cli_privacy_command, "/privacy");
+        // Soft-fail: no keys yet.
+        assert_eq!(snap.telemetry, None);
+        assert_eq!(snap.disable_codebase_upload, None);
+
+        let saved = save_privacy_config(&PrivacyConfigPatch {
+            telemetry: Some(false),
+            trace_upload: Some(false),
+            mixpanel_enabled: Some(false),
+            disable_codebase_upload: Some(true),
+            disable_workspace_teleport: Some(true),
+        })
+        .unwrap();
+        assert_eq!(saved.telemetry, Some(false));
+        assert_eq!(saved.trace_upload, Some(false));
+        assert_eq!(saved.mixpanel_enabled, Some(false));
+        assert_eq!(saved.disable_codebase_upload, Some(true));
+        assert_eq!(saved.disable_workspace_teleport, Some(true));
+        assert!(saved.file_exists);
+
+        let disk = fs::read_to_string(agent_config_toml()).unwrap();
+        assert!(disk.contains("[features]"));
+        assert!(disk.contains("telemetry = false"));
+        assert!(disk.contains("[telemetry]"));
+        assert!(disk.contains("trace_upload = false"));
+        assert!(disk.contains("[harness]"));
+        assert!(disk.contains("disable_codebase_upload = true"));
+        assert!(!disk.contains("[REDACTED]"));
+
+        match prev {
+            Some(v) => std::env::set_var("GROK_APP_HOME", v),
+            None => std::env::remove_var("GROK_APP_HOME"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn save_refuses_shared_mode() {
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let tmp = temp_app_home("shared");
+        let prev = std::env::var("GROK_APP_HOME").ok();
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = ensure_app_dirs();
+        let mut s = store::load_settings();
+        s.session_data_mode = "shared".into();
+        store::save_settings(&s).unwrap();
+
+        let err = save_privacy_config(&PrivacyConfigPatch {
+            telemetry: Some(false),
+            ..Default::default()
+        })
+        .unwrap_err();
+        assert!(err.contains("shared"), "{err}");
+
+        match prev {
+            Some(v) => std::env::set_var("GROK_APP_HOME", v),
+            None => std::env::remove_var("GROK_APP_HOME"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8672,6 +8672,45 @@ pub async fn agent_config_edit_set(
     Ok(result)
 }
 
+/// Read allowlisted privacy keys from active GROK_HOME config.toml (redacted).
+/// Soft-fails missing keys as null; never invents defaults.
+#[tauri::command]
+pub async fn privacy_config_get(
+) -> Result<crate::agent_privacy::PrivacyConfigSnapshot, String> {
+    tauri::async_runtime::spawn_blocking(crate::agent_privacy::load_privacy_config)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Write allowlisted privacy keys into agent-home config.toml only (independent mode).
+/// Soft-respawns so the next turn reloads the agent profile.
+#[tauri::command]
+pub async fn privacy_config_set(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    telemetry: Option<bool>,
+    trace_upload: Option<bool>,
+    mixpanel_enabled: Option<bool>,
+    disable_codebase_upload: Option<bool>,
+    disable_workspace_teleport: Option<bool>,
+) -> Result<crate::agent_privacy::PrivacyConfigSnapshot, String> {
+    let patch = crate::agent_privacy::PrivacyConfigPatch {
+        telemetry,
+        trace_upload,
+        mixpanel_enabled,
+        disable_codebase_upload,
+        disable_workspace_teleport,
+    };
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        crate::agent_privacy::save_privacy_config(&patch)
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    mgr.soft_respawn_with_reason(&app, "privacy_config").await;
+    Ok(result)
+}
+
 // marketplace
 // ── Plugin marketplace (`grok plugin marketplace …` + available list) ───────
 //

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod account_profiles;
 mod acp_client;
 mod agent_config_view;
 mod agent_config_edit;
+mod agent_privacy;
 mod agent_memory;
 mod agents_catalog;
 mod agent_prefs;
@@ -371,6 +372,8 @@ pub fn run() {
             commands::permission_rules_set,
             commands::agent_config_edit_get,
             commands::agent_config_edit_set,
+            commands::privacy_config_get,
+            commands::privacy_config_set,
             commands::session_set_model,
             commands::session_rewind_drop_last_user,
             commands::session_rewind_points,

--- a/src/components/PrivacyCenterPanel.tsx
+++ b/src/components/PrivacyCenterPanel.tsx
@@ -1,0 +1,449 @@
+/**
+ * Settings → Runtime → Privacy: honest Grok Build 0.2.117 privacy keys.
+ * Independent agent-home: allowlisted read/write. Shared mode: read-only probe.
+ * Coding-data / training is CLI `/privacy` only — never a fake App toggle.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import * as api from "@/lib/api";
+import type { PrivacyConfigSnapshot } from "@/lib/api";
+import { createT, type Locale, type MessageKey } from "@/i18n";
+import {
+  buildPrivacyPatch,
+  CLI_PRIVACY_COMMAND,
+  hasPrivacyChanges,
+  privacyKeyPresence,
+  privacyToggleChecked,
+  togglePrivacyTri,
+  valuesFromPrivacySnapshot,
+  type PrivacyTri,
+  type PrivacyValues,
+} from "@/lib/privacyConfig";
+import { IconRefresh } from "@/components/icons";
+
+function Toggle({
+  checked,
+  disabled,
+  onChange,
+  ariaLabel,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onChange: () => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      className={"ui-check" + (checked ? " is-on" : "")}
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        if (!disabled) onChange();
+      }}
+    >
+      <span className="ui-check__box" aria-hidden>
+        {checked ? (
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path
+              d="M2.5 6.2L4.8 8.5L9.5 3.5"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : null}
+      </span>
+    </button>
+  );
+}
+
+function PresenceBadge({
+  value,
+  t,
+}: {
+  value: PrivacyTri;
+  t: (k: MessageKey, vars?: Record<string, string | number>) => string;
+}) {
+  const p = privacyKeyPresence(value);
+  if (p === "unset") {
+    return (
+      <span className="ext-badge ext-badge--muted">
+        {t("settings.privacy.presence.unset")}
+      </span>
+    );
+  }
+  if (p === "set_on") {
+    return (
+      <span className="ext-badge">{t("settings.privacy.presence.on")}</span>
+    );
+  }
+  return (
+    <span className="ext-badge ext-badge--muted">
+      {t("settings.privacy.presence.off")}
+    </span>
+  );
+}
+
+type RowKey = keyof PrivacyValues;
+
+function PrivacyRow({
+  id,
+  labelKey,
+  descKey,
+  configKey,
+  value,
+  disabled,
+  onToggle,
+  t,
+}: {
+  id: string;
+  labelKey: MessageKey;
+  descKey: MessageKey;
+  configKey: string;
+  value: PrivacyTri;
+  disabled: boolean;
+  onToggle: () => void;
+  t: (k: MessageKey, vars?: Record<string, string | number>) => string;
+}) {
+  return (
+    <div className="settings-row" id={id}>
+      <div className="settings-row__text">
+        <div className="settings-row__label">
+          {t(labelKey)}{" "}
+          <PresenceBadge value={value} t={t} />
+        </div>
+        <div className="settings-row__desc">{t(descKey)}</div>
+        <div className="settings-row__hint" title={configKey}>
+          {configKey}
+        </div>
+      </div>
+      <Toggle
+        checked={privacyToggleChecked(value)}
+        disabled={disabled}
+        onChange={onToggle}
+        ariaLabel={t(labelKey)}
+      />
+    </div>
+  );
+}
+
+export function PrivacyCenterPanel({
+  locale,
+  onSaved,
+  onError,
+}: {
+  locale: Locale;
+  onSaved?: () => void;
+  onError?: (message: string) => void;
+}) {
+  const tr = useMemo(() => createT(locale), [locale]);
+  const t = useCallback(
+    (k: MessageKey, vars?: Record<string, string | number>) => tr(k, vars),
+    [tr],
+  );
+
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [snap, setSnap] = useState<PrivacyConfigSnapshot | null>(null);
+  const [baseline, setBaseline] = useState<PrivacyValues>(
+    valuesFromPrivacySnapshot({}),
+  );
+  const [draft, setDraft] = useState<PrivacyValues>(
+    valuesFromPrivacySnapshot({}),
+  );
+  const [copied, setCopied] = useState(false);
+
+  const applySnap = useCallback((s: PrivacyConfigSnapshot) => {
+    setSnap(s);
+    const vals = valuesFromPrivacySnapshot({
+      telemetry: s.telemetry,
+      traceUpload: s.traceUpload,
+      mixpanelEnabled: s.mixpanelEnabled,
+      disableCodebaseUpload: s.disableCodebaseUpload,
+      disableWorkspaceTeleport: s.disableWorkspaceTeleport,
+    });
+    setBaseline(vals);
+    setDraft(vals);
+  }, []);
+
+  const load = useCallback(async () => {
+    if (!api.isTauri()) {
+      setSnap(null);
+      setError(t("settings.privacy.needTauri"));
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.privacyConfigGet();
+      applySnap(res);
+    } catch (e) {
+      setSnap(null);
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      onError?.(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [applySnap, onError, t]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const patch = useMemo(
+    () => buildPrivacyPatch(draft, baseline),
+    [draft, baseline],
+  );
+  const dirty = hasPrivacyChanges(patch);
+  const writable = !!snap?.writable;
+  const disabled = !writable || busy || loading;
+
+  const setKey = (key: RowKey) => {
+    setDraft((d) => ({ ...d, [key]: togglePrivacyTri(d[key]) }));
+  };
+
+  const save = async () => {
+    if (!dirty || !writable || !api.isTauri()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await api.privacyConfigSet({
+        telemetry: patch.telemetry ?? null,
+        traceUpload: patch.traceUpload ?? null,
+        mixpanelEnabled: patch.mixpanelEnabled ?? null,
+        disableCodebaseUpload: patch.disableCodebaseUpload ?? null,
+        disableWorkspaceTeleport: patch.disableWorkspaceTeleport ?? null,
+      });
+      applySnap(res);
+      onSaved?.();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      onError?.(msg);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reset = () => setDraft(baseline);
+
+  const copyPrivacyCmd = async () => {
+    const cmd = snap?.cliPrivacyCommand || CLI_PRIVACY_COMMAND;
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // ignore — clipboard may be blocked
+    }
+  };
+
+  return (
+    <div
+      className="settings-row settings-row--stack settings-privacy"
+      id="settings-anchor-privacy"
+    >
+      <div className="settings-row__text">
+        <div className="settings-row__label">{t("settings.privacy")}</div>
+        <div className="settings-row__desc">{t("settings.privacyDesc")}</div>
+        {snap?.path ? (
+          <div className="settings-row__hint" title={snap.path}>
+            {t("settings.privacy.path", { path: snap.path })}
+          </div>
+        ) : null}
+      </div>
+
+      {loading && !snap ? (
+        <p className="ext-field-hint">{t("settings.privacy.loading")}</p>
+      ) : null}
+
+      {error ? (
+        <div className="ext-alert ext-alert--error" role="alert">
+          <div className="ext-alert__title">{t("settings.privacy.error")}</div>
+          <p className="ext-alert__body">{error}</p>
+        </div>
+      ) : null}
+
+      {snap && !writable ? (
+        <div className="ext-alert ext-alert--warn" role="status">
+          <p className="ext-alert__body" style={{ margin: 0 }}>
+            {t("settings.privacy.sharedWarning")}
+          </p>
+        </div>
+      ) : null}
+
+      {snap ? (
+        <>
+          <div className="settings-config-edit__badges">
+            <span className="ext-badge ext-badge--muted">
+              {snap.mode === "shared"
+                ? t("settings.privacy.mode.shared")
+                : t("settings.privacy.mode.independent")}
+            </span>
+            {!snap.fileExists ? (
+              <span className="ext-badge">
+                {t("settings.privacy.missing")}
+              </span>
+            ) : null}
+            {writable ? (
+              <span className="ext-badge">
+                {t("settings.privacy.writable")}
+              </span>
+            ) : (
+              <span className="ext-badge">
+                {t("settings.privacy.readOnly")}
+              </span>
+            )}
+          </div>
+
+          <div className="settings-config-edit__fields">
+            <PrivacyRow
+              id="settings-anchor-privacy-telemetry"
+              labelKey="settings.privacy.telemetry"
+              descKey="settings.privacy.telemetryDesc"
+              configKey="[features] telemetry · GROK_TELEMETRY_ENABLED"
+              value={draft.telemetry}
+              disabled={disabled}
+              onToggle={() => setKey("telemetry")}
+              t={t}
+            />
+            <PrivacyRow
+              id="settings-anchor-privacy-traceUpload"
+              labelKey="settings.privacy.traceUpload"
+              descKey="settings.privacy.traceUploadDesc"
+              configKey="[telemetry] trace_upload · GROK_TELEMETRY_TRACE_UPLOAD"
+              value={draft.traceUpload}
+              disabled={disabled}
+              onToggle={() => setKey("traceUpload")}
+              t={t}
+            />
+            <PrivacyRow
+              id="settings-anchor-privacy-mixpanel"
+              labelKey="settings.privacy.mixpanel"
+              descKey="settings.privacy.mixpanelDesc"
+              configKey="[telemetry] mixpanel_enabled · GROK_TELEMETRY_MIXPANEL_ENABLED"
+              value={draft.mixpanelEnabled}
+              disabled={disabled}
+              onToggle={() => setKey("mixpanelEnabled")}
+              t={t}
+            />
+            <PrivacyRow
+              id="settings-anchor-privacy-codebaseUpload"
+              labelKey="settings.privacy.disableCodebaseUpload"
+              descKey="settings.privacy.disableCodebaseUploadDesc"
+              configKey="[harness] disable_codebase_upload"
+              value={draft.disableCodebaseUpload}
+              disabled={disabled}
+              onToggle={() => setKey("disableCodebaseUpload")}
+              t={t}
+            />
+            <PrivacyRow
+              id="settings-anchor-privacy-workspaceTeleport"
+              labelKey="settings.privacy.disableWorkspaceTeleport"
+              descKey="settings.privacy.disableWorkspaceTeleportDesc"
+              configKey="[harness] disable_workspace_teleport"
+              value={draft.disableWorkspaceTeleport}
+              disabled={disabled}
+              onToggle={() => setKey("disableWorkspaceTeleport")}
+              t={t}
+            />
+          </div>
+
+          <div
+            className="settings-row settings-row--stack"
+            id="settings-anchor-privacy-codingData"
+            style={{ marginTop: 12 }}
+          >
+            <div className="settings-row__text">
+              <div className="settings-row__label">
+                {t("settings.privacy.codingData")}
+              </div>
+              <div className="settings-row__desc">
+                {t("settings.privacy.codingDataDesc")}
+              </div>
+              <div className="settings-row__hint">
+                {t("settings.privacy.codingDataHint", {
+                  cmd: snap.cliPrivacyCommand || CLI_PRIVACY_COMMAND,
+                })}
+              </div>
+            </div>
+            <div
+              className="settings-row__actions"
+              style={{ display: "flex", gap: 8, flexWrap: "wrap" }}
+            >
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                onClick={() => void copyPrivacyCmd()}
+              >
+                {copied
+                  ? t("settings.privacy.codingDataCopied")
+                  : t("settings.privacy.codingDataCopy", {
+                      cmd: snap.cliPrivacyCommand || CLI_PRIVACY_COMMAND,
+                    })}
+              </button>
+            </div>
+          </div>
+
+          {snap.redactedPreview?.trim() ? (
+            <div className="settings-config-edit__preview">
+              <div className="settings-row__label">
+                {t("settings.privacy.preview")}
+              </div>
+              <p className="ext-field-hint" style={{ marginTop: 4 }}>
+                {t("settings.privacy.redactNote")}
+              </p>
+              <pre className="settings-config-edit__pre" tabIndex={0}>
+                {snap.redactedPreview}
+              </pre>
+            </div>
+          ) : (
+            <p className="ext-field-hint">{t("settings.privacy.previewEmpty")}</p>
+          )}
+
+          <div
+            className="settings-row__actions"
+            style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 8 }}
+          >
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              disabled={busy || loading}
+              onClick={() => void load()}
+            >
+              <IconRefresh size={14} />
+              <span>{t("settings.privacy.refresh")}</span>
+            </button>
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              disabled={!dirty || busy || loading}
+              onClick={reset}
+            >
+              {t("settings.privacy.reset")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--primary btn--sm"
+              disabled={!dirty || !writable || busy || loading}
+              onClick={() => void save()}
+            >
+              {busy
+                ? t("settings.privacy.saving")
+                : t("settings.privacy.save")}
+            </button>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -203,6 +203,7 @@ import { ExtensionsPanel } from "@/components/ExtensionsPanel";
 import { ProjectInspectPanel } from "@/components/ProjectInspectPanel";
 import { PermissionRulesPanel } from "@/components/PermissionRulesPanel";
 import { AgentConfigEditPanel } from "@/components/AgentConfigEditPanel";
+import { PrivacyCenterPanel } from "@/components/PrivacyCenterPanel";
 import { ManagedSetupPanel } from "@/components/ManagedSetupPanel";
 import { TraceHistoryList } from "@/components/TraceHistoryList";
 import { GlassModal } from "@/components/GlassModal";
@@ -5789,6 +5790,22 @@ export function SettingsPage({
                   />
                 </div>
               </>
+            )}
+            {activeTab === "privacy" && (
+              <div
+                className={
+                  "settings-card" + rowHighlight("settings-anchor-privacy")
+                }
+                id="settings-anchor-privacy-card"
+              >
+                <PrivacyCenterPanel
+                  locale={resolveLocale(locale)}
+                  onError={(msg) => showSettingsToast(msg, 4000)}
+                  onSaved={() =>
+                    showSettingsToast(t("settings.privacy.saved"), 2200)
+                  }
+                />
+              </div>
             )}
           </>
         )}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1040,8 +1040,58 @@ const en = {
   "settings.netProbeFailed": "unreachable",
   "settings.tab.pool": "Process pool",
   "settings.tab.tools": "Diagnostics",
+  "settings.tab.privacy": "Privacy",
   "settings.tab.remoteIm": "IM messaging",
   "settings.tab.phoneMirror": "Phone mirror",
+  "settings.privacy": "Privacy center",
+  "settings.privacyDesc":
+    "Honest view of Grok Build privacy-related keys in the active GROK_HOME config.toml (0.2.117+). Missing keys stay unset — this App never invents “off”. Writes apply only in independent agent-home mode.",
+  "settings.privacy.path": "Config: {path}",
+  "settings.privacy.loading": "Loading privacy config…",
+  "settings.privacy.error": "Could not load or update privacy config",
+  "settings.privacy.saved": "Privacy config saved (agent soft-respawned)",
+  "settings.privacy.sharedWarning":
+    "Shared mode shows ~/.grok/config.toml (read-only probe). Switch session data mode to independent to write allowlisted privacy keys into App agent-home.",
+  "settings.privacy.mode.independent": "Independent (agent-home)",
+  "settings.privacy.mode.shared": "Shared (~/.grok)",
+  "settings.privacy.missing": "File not found yet",
+  "settings.privacy.writable": "Editable",
+  "settings.privacy.readOnly": "Read-only",
+  "settings.privacy.presence.unset": "unset",
+  "settings.privacy.presence.on": "on",
+  "settings.privacy.presence.off": "off",
+  "settings.privacy.telemetry": "Product telemetry",
+  "settings.privacy.telemetryDesc":
+    "[features] telemetry — product-analytics master switch (GROK_TELEMETRY_ENABLED). Separate from coding-data sharing.",
+  "settings.privacy.traceUpload": "Session trace upload",
+  "settings.privacy.traceUploadDesc":
+    "[telemetry] trace_upload — upload session traces (GROK_TELEMETRY_TRACE_UPLOAD). When unset, CLI follows the telemetry toggle.",
+  "settings.privacy.mixpanel": "Mixpanel analytics",
+  "settings.privacy.mixpanelDesc":
+    "[telemetry] mixpanel_enabled — Mixpanel product analytics (GROK_TELEMETRY_MIXPANEL_ENABLED).",
+  "settings.privacy.disableCodebaseUpload": "Disable codebase upload",
+  "settings.privacy.disableCodebaseUploadDesc":
+    "[harness] disable_codebase_upload — when on, refuses codebase/index upload from the agent harness.",
+  "settings.privacy.disableWorkspaceTeleport": "Disable workspace teleport",
+  "settings.privacy.disableWorkspaceTeleportDesc":
+    "[harness] disable_workspace_teleport — related harness flag that blocks workspace teleport upload paths.",
+  "settings.privacy.codingData": "Coding data, retention, and training",
+  "settings.privacy.codingDataDesc":
+    "Not a config.toml key. Opt in or out in the Grok Build CLI Settings row opened by /privacy. Team accounts may show ZDR or Admin Managed. This App does not change that choice.",
+  "settings.privacy.codingDataHint":
+    "In a Grok Build TUI session, run {cmd}. Does not change telemetry or trace_upload.",
+  "settings.privacy.codingDataCopy": "Copy {cmd}",
+  "settings.privacy.codingDataCopied": "Copied",
+  "settings.privacy.preview": "Privacy sections (redacted)",
+  "settings.privacy.previewEmpty":
+    "No [features] / [telemetry] / [harness] privacy keys found yet in this config.",
+  "settings.privacy.redactNote":
+    "Secrets in these sections are redacted. Only allowlisted keys are written on save.",
+  "settings.privacy.refresh": "Refresh",
+  "settings.privacy.reset": "Reset",
+  "settings.privacy.save": "Save privacy keys",
+  "settings.privacy.saving": "Saving…",
+  "settings.privacy.needTauri": "Privacy center requires the desktop app.",
   "settings.searchResults": "Matching settings",
   "settings.searchOpen": "Open",
   "settings.inspect.manageInExtensions": "Manage in Extensions",
@@ -4727,6 +4777,56 @@ const zh: Record<MessageKey, string> = {
   "settings.netProbeFailed": "不可达",
   "settings.tab.pool": "进程池",
   "settings.tab.tools": "诊断",
+  "settings.tab.privacy": "隐私",
+  "settings.privacy": "隐私中心",
+  "settings.privacyDesc":
+    "如实展示当前 GROK_HOME config.toml 中与隐私相关的 Grok Build 键（0.2.117+）。缺失键保持「未设置」——本应用不会虚构为「关闭」。仅在独立 agent-home 模式下可写。",
+  "settings.privacy.path": "配置：{path}",
+  "settings.privacy.loading": "正在加载隐私配置…",
+  "settings.privacy.error": "无法加载或更新隐私配置",
+  "settings.privacy.saved": "隐私配置已保存（agent 已 soft-respawn）",
+  "settings.privacy.sharedWarning":
+    "共享模式显示 ~/.grok/config.toml（只读探测）。切换到独立会话数据模式后，才能将白名单隐私键写入 App agent-home。",
+  "settings.privacy.mode.independent": "独立（agent-home）",
+  "settings.privacy.mode.shared": "共享（~/.grok）",
+  "settings.privacy.missing": "文件尚不存在",
+  "settings.privacy.writable": "可编辑",
+  "settings.privacy.readOnly": "只读",
+  "settings.privacy.presence.unset": "未设置",
+  "settings.privacy.presence.on": "开",
+  "settings.privacy.presence.off": "关",
+  "settings.privacy.telemetry": "产品遥测",
+  "settings.privacy.telemetryDesc":
+    "[features] telemetry — 产品分析总开关（GROK_TELEMETRY_ENABLED）。与编码数据分享无关。",
+  "settings.privacy.traceUpload": "会话 trace 上传",
+  "settings.privacy.traceUploadDesc":
+    "[telemetry] trace_upload — 上传会话 trace（GROK_TELEMETRY_TRACE_UPLOAD）。未设置时 CLI 跟随 telemetry 开关。",
+  "settings.privacy.mixpanel": "Mixpanel 分析",
+  "settings.privacy.mixpanelDesc":
+    "[telemetry] mixpanel_enabled — Mixpanel 产品分析（GROK_TELEMETRY_MIXPANEL_ENABLED）。",
+  "settings.privacy.disableCodebaseUpload": "禁用代码库上传",
+  "settings.privacy.disableCodebaseUploadDesc":
+    "[harness] disable_codebase_upload — 开启后拒绝 agent harness 上传代码库/索引。",
+  "settings.privacy.disableWorkspaceTeleport": "禁用工作区 teleport",
+  "settings.privacy.disableWorkspaceTeleportDesc":
+    "[harness] disable_workspace_teleport — 相关 harness 标志，阻止工作区 teleport 上传路径。",
+  "settings.privacy.codingData": "编码数据、保留与训练",
+  "settings.privacy.codingDataDesc":
+    "不是 config.toml 键。请在 Grok Build CLI 中通过 /privacy 打开的设置行选择加入或退出。团队账户可能显示 ZDR 或 Admin Managed。本应用不会改写该选择。",
+  "settings.privacy.codingDataHint":
+    "在 Grok Build TUI 会话中运行 {cmd}。不会改动 telemetry 或 trace_upload。",
+  "settings.privacy.codingDataCopy": "复制 {cmd}",
+  "settings.privacy.codingDataCopied": "已复制",
+  "settings.privacy.preview": "隐私相关分区（已脱敏）",
+  "settings.privacy.previewEmpty":
+    "此配置中尚未找到 [features] / [telemetry] / [harness] 隐私键。",
+  "settings.privacy.redactNote":
+    "这些分区中的密钥会脱敏。保存时仅写入白名单键。",
+  "settings.privacy.refresh": "刷新",
+  "settings.privacy.reset": "重置",
+  "settings.privacy.save": "保存隐私键",
+  "settings.privacy.saving": "保存中…",
+  "settings.privacy.needTauri": "隐私中心需要桌面应用。",
   "settings.tab.remoteIm": "IM 通信",
   "settings.tab.phoneMirror": "手机镜像",
   "settings.searchResults": "匹配的设置",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -985,6 +985,56 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.netProbeFailed": "無法連上",
   "settings.tab.pool": "程序池",
   "settings.tab.tools": "診斷",
+  "settings.tab.privacy": "隱私",
+  "settings.privacy": "隱私中心",
+  "settings.privacyDesc":
+    "如實展示目前 GROK_HOME config.toml 中與隱私相關的 Grok Build 鍵（0.2.117+）。缺失鍵保持「未設定」——本應用不會虛構為「關閉」。僅在獨立 agent-home 模式下可寫。",
+  "settings.privacy.path": "設定：{path}",
+  "settings.privacy.loading": "正在載入隱私設定…",
+  "settings.privacy.error": "無法載入或更新隱私設定",
+  "settings.privacy.saved": "隱私設定已儲存（agent 已 soft-respawn）",
+  "settings.privacy.sharedWarning":
+    "共用模式顯示 ~/.grok/config.toml（唯讀探測）。切換到獨立工作階段資料模式後，才能將白名單隱私鍵寫入 App agent-home。",
+  "settings.privacy.mode.independent": "獨立（agent-home）",
+  "settings.privacy.mode.shared": "共用（~/.grok）",
+  "settings.privacy.missing": "檔案尚不存在",
+  "settings.privacy.writable": "可編輯",
+  "settings.privacy.readOnly": "唯讀",
+  "settings.privacy.presence.unset": "未設定",
+  "settings.privacy.presence.on": "開",
+  "settings.privacy.presence.off": "關",
+  "settings.privacy.telemetry": "產品遙測",
+  "settings.privacy.telemetryDesc":
+    "[features] telemetry — 產品分析總開關（GROK_TELEMETRY_ENABLED）。與編碼資料分享無關。",
+  "settings.privacy.traceUpload": "工作階段 trace 上傳",
+  "settings.privacy.traceUploadDesc":
+    "[telemetry] trace_upload — 上傳工作階段 trace（GROK_TELEMETRY_TRACE_UPLOAD）。未設定時 CLI 跟隨 telemetry 開關。",
+  "settings.privacy.mixpanel": "Mixpanel 分析",
+  "settings.privacy.mixpanelDesc":
+    "[telemetry] mixpanel_enabled — Mixpanel 產品分析（GROK_TELEMETRY_MIXPANEL_ENABLED）。",
+  "settings.privacy.disableCodebaseUpload": "停用程式碼庫上傳",
+  "settings.privacy.disableCodebaseUploadDesc":
+    "[harness] disable_codebase_upload — 開啟後拒絕 agent harness 上傳程式碼庫/索引。",
+  "settings.privacy.disableWorkspaceTeleport": "停用工作區 teleport",
+  "settings.privacy.disableWorkspaceTeleportDesc":
+    "[harness] disable_workspace_teleport — 相關 harness 標誌，阻止工作區 teleport 上傳路徑。",
+  "settings.privacy.codingData": "編碼資料、保留與訓練",
+  "settings.privacy.codingDataDesc":
+    "不是 config.toml 鍵。請在 Grok Build CLI 中透過 /privacy 開啟的設定列選擇加入或退出。團隊帳戶可能顯示 ZDR 或 Admin Managed。本應用不會改寫該選擇。",
+  "settings.privacy.codingDataHint":
+    "在 Grok Build TUI 工作階段中執行 {cmd}。不會改動 telemetry 或 trace_upload。",
+  "settings.privacy.codingDataCopy": "複製 {cmd}",
+  "settings.privacy.codingDataCopied": "已複製",
+  "settings.privacy.preview": "隱私相關分區（已去敏）",
+  "settings.privacy.previewEmpty":
+    "此設定中尚未找到 [features] / [telemetry] / [harness] 隱私鍵。",
+  "settings.privacy.redactNote":
+    "這些分區中的金鑰會去敏。儲存時僅寫入白名單鍵。",
+  "settings.privacy.refresh": "重新整理",
+  "settings.privacy.reset": "重設",
+  "settings.privacy.save": "儲存隱私鍵",
+  "settings.privacy.saving": "儲存中…",
+  "settings.privacy.needTauri": "隱私中心需要桌面應用程式。",
   "settings.tab.remoteIm": "IM 通訊",
   "settings.tab.phoneMirror": "手機鏡像",
   "settings.searchResults": "相符的設定",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3294,6 +3294,51 @@ export async function agentConfigEditSet(
   });
 }
 
+/**
+ * Privacy center — allowlisted Grok Build 0.2.117 privacy keys from active
+ * GROK_HOME config.toml. Missing keys are null (soft-fail). Writes only in
+ * independent agent-home mode.
+ */
+export type PrivacyConfigSnapshot = {
+  path: string;
+  grokHome: string;
+  mode: string;
+  writable: boolean;
+  fileExists: boolean;
+  telemetry?: boolean | null;
+  traceUpload?: boolean | null;
+  mixpanelEnabled?: boolean | null;
+  disableCodebaseUpload?: boolean | null;
+  disableWorkspaceTeleport?: boolean | null;
+  redactedPreview: string;
+  cliPrivacyCommand: string;
+};
+
+export type PrivacyConfigPatch = {
+  telemetry?: boolean | null;
+  traceUpload?: boolean | null;
+  mixpanelEnabled?: boolean | null;
+  disableCodebaseUpload?: boolean | null;
+  disableWorkspaceTeleport?: boolean | null;
+};
+
+export async function privacyConfigGet(): Promise<PrivacyConfigSnapshot> {
+  return invoke<PrivacyConfigSnapshot>("privacy_config_get");
+}
+
+export async function privacyConfigSet(
+  patch: PrivacyConfigPatch,
+): Promise<PrivacyConfigSnapshot> {
+  // Tauri maps camelCase invoke keys → snake_case command args.
+  return invoke<PrivacyConfigSnapshot>("privacy_config_set", {
+    telemetry: patch.telemetry ?? null,
+    traceUpload: patch.traceUpload ?? null,
+    mixpanelEnabled: patch.mixpanelEnabled ?? null,
+    disableCodebaseUpload: patch.disableCodebaseUpload ?? null,
+    disableWorkspaceTeleport: patch.disableWorkspaceTeleport ?? null,
+  });
+}
+
 export interface VoiceSessionState {
   active: boolean;
   mode?: string;

--- a/src/lib/privacyConfig.test.ts
+++ b/src/lib/privacyConfig.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPrivacyPatch,
+  CLI_PRIVACY_COMMAND,
+  hasPrivacyChanges,
+  isPrivacyWritable,
+  privacyKeyPresence,
+  privacyToggleChecked,
+  togglePrivacyTri,
+  valuesFromPrivacySnapshot,
+  type PrivacyValues,
+} from "./privacyConfig";
+
+const base: PrivacyValues = {
+  telemetry: false,
+  traceUpload: false,
+  mixpanelEnabled: false,
+  disableCodebaseUpload: true,
+  disableWorkspaceTeleport: true,
+};
+
+describe("valuesFromPrivacySnapshot", () => {
+  it("maps missing keys to null (soft-fail, never invents defaults)", () => {
+    expect(valuesFromPrivacySnapshot({})).toEqual({
+      telemetry: null,
+      traceUpload: null,
+      mixpanelEnabled: null,
+      disableCodebaseUpload: null,
+      disableWorkspaceTeleport: null,
+    });
+    expect(valuesFromPrivacySnapshot(null)).toEqual({
+      telemetry: null,
+      traceUpload: null,
+      mixpanelEnabled: null,
+      disableCodebaseUpload: null,
+      disableWorkspaceTeleport: null,
+    });
+  });
+
+  it("maps present bools", () => {
+    expect(
+      valuesFromPrivacySnapshot({
+        telemetry: false,
+        traceUpload: true,
+        mixpanelEnabled: false,
+        disableCodebaseUpload: true,
+        disableWorkspaceTeleport: false,
+      }),
+    ).toEqual({
+      telemetry: false,
+      traceUpload: true,
+      mixpanelEnabled: false,
+      disableCodebaseUpload: true,
+      disableWorkspaceTeleport: false,
+    });
+  });
+});
+
+describe("buildPrivacyPatch", () => {
+  it("emits only changed concrete fields", () => {
+    const draft: PrivacyValues = {
+      ...base,
+      telemetry: true,
+      disableCodebaseUpload: false,
+    };
+    const patch = buildPrivacyPatch(draft, base);
+    expect(patch).toEqual({
+      telemetry: true,
+      disableCodebaseUpload: false,
+    });
+    expect(hasPrivacyChanges(patch)).toBe(true);
+    expect(hasPrivacyChanges(buildPrivacyPatch(base, base))).toBe(false);
+  });
+
+  it("does not emit null→null or null-only draft fields", () => {
+    const baseline: PrivacyValues = {
+      telemetry: null,
+      traceUpload: null,
+      mixpanelEnabled: null,
+      disableCodebaseUpload: null,
+      disableWorkspaceTeleport: null,
+    };
+    // Still unset — no write.
+    expect(buildPrivacyPatch(baseline, baseline)).toEqual({});
+    // User toggled telemetry on from unset.
+    const draft = { ...baseline, telemetry: true as const };
+    expect(buildPrivacyPatch(draft, baseline)).toEqual({ telemetry: true });
+  });
+});
+
+describe("togglePrivacyTri / presence", () => {
+  it("cycles unset → true → false → true", () => {
+    expect(togglePrivacyTri(null)).toBe(true);
+    expect(togglePrivacyTri(true)).toBe(false);
+    expect(togglePrivacyTri(false)).toBe(true);
+  });
+
+  it("presence and checked honesty", () => {
+    expect(privacyKeyPresence(null)).toBe("unset");
+    expect(privacyKeyPresence(true)).toBe("set_on");
+    expect(privacyKeyPresence(false)).toBe("set_off");
+    expect(privacyToggleChecked(null)).toBe(false);
+    expect(privacyToggleChecked(true)).toBe(true);
+    expect(privacyToggleChecked(false)).toBe(false);
+  });
+});
+
+describe("isPrivacyWritable", () => {
+  it("requires writable flag", () => {
+    expect(isPrivacyWritable(undefined)).toBe(false);
+    expect(isPrivacyWritable({ writable: false })).toBe(false);
+    expect(isPrivacyWritable({ writable: true })).toBe(true);
+  });
+});
+
+describe("CLI_PRIVACY_COMMAND", () => {
+  it("is the coding-data slash command (not a config key)", () => {
+    expect(CLI_PRIVACY_COMMAND).toBe("/privacy");
+  });
+});

--- a/src/lib/privacyConfig.ts
+++ b/src/lib/privacyConfig.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure helpers for Privacy center (Grok Build 0.2.117 config.toml keys).
+ * Host enforces path-scope + write gate; this validates UI drafts + patches.
+ *
+ * Allowlist:
+ * - [features] telemetry
+ * - [telemetry] trace_upload / mixpanel_enabled
+ * - [harness] disable_codebase_upload / disable_workspace_teleport
+ *
+ * Missing keys stay null — never invent CLI defaults as “off”.
+ * Coding-data / training opt-in is CLI `/privacy` only (not config.toml).
+ */
+
+export type PrivacyTri = boolean | null;
+
+export type PrivacyValues = {
+  /** [features] telemetry — null when unset in config. */
+  telemetry: PrivacyTri;
+  /** [telemetry] trace_upload */
+  traceUpload: PrivacyTri;
+  /** [telemetry] mixpanel_enabled */
+  mixpanelEnabled: PrivacyTri;
+  /** [harness] disable_codebase_upload */
+  disableCodebaseUpload: PrivacyTri;
+  /** [harness] disable_workspace_teleport */
+  disableWorkspaceTeleport: PrivacyTri;
+};
+
+export type PrivacyPatch = {
+  telemetry?: boolean | null;
+  traceUpload?: boolean | null;
+  mixpanelEnabled?: boolean | null;
+  disableCodebaseUpload?: boolean | null;
+  disableWorkspaceTeleport?: boolean | null;
+};
+
+export type PrivacySnapshotLike = {
+  telemetry?: boolean | null;
+  traceUpload?: boolean | null;
+  mixpanelEnabled?: boolean | null;
+  disableCodebaseUpload?: boolean | null;
+  disableWorkspaceTeleport?: boolean | null;
+  writable?: boolean;
+  mode?: string;
+  fileExists?: boolean;
+  path?: string;
+  cliPrivacyCommand?: string;
+};
+
+/** CLI slash command for coding-data / retention / training (not a config key). */
+export const CLI_PRIVACY_COMMAND = "/privacy";
+
+/** Keys this App can write (independent agent-home only). */
+export const PRIVACY_WRITABLE_KEYS = [
+  "telemetry",
+  "traceUpload",
+  "mixpanelEnabled",
+  "disableCodebaseUpload",
+  "disableWorkspaceTeleport",
+] as const;
+
+export type PrivacyWritableKey = (typeof PRIVACY_WRITABLE_KEYS)[number];
+
+function tri(v: boolean | null | undefined): PrivacyTri {
+  if (v === true) return true;
+  if (v === false) return false;
+  return null;
+}
+
+/** Map host snapshot → UI draft (null = unset / missing). */
+export function valuesFromPrivacySnapshot(
+  snap: PrivacySnapshotLike | null | undefined,
+): PrivacyValues {
+  return {
+    telemetry: tri(snap?.telemetry),
+    traceUpload: tri(snap?.traceUpload),
+    mixpanelEnabled: tri(snap?.mixpanelEnabled),
+    disableCodebaseUpload: tri(snap?.disableCodebaseUpload),
+    disableWorkspaceTeleport: tri(snap?.disableWorkspaceTeleport),
+  };
+}
+
+/** Build a host patch from draft vs baseline (only changed fields with concrete bools). */
+export function buildPrivacyPatch(
+  draft: PrivacyValues,
+  baseline: PrivacyValues,
+): PrivacyPatch {
+  const patch: PrivacyPatch = {};
+  if (draft.telemetry !== baseline.telemetry && draft.telemetry !== null) {
+    patch.telemetry = draft.telemetry;
+  }
+  if (draft.traceUpload !== baseline.traceUpload && draft.traceUpload !== null) {
+    patch.traceUpload = draft.traceUpload;
+  }
+  if (
+    draft.mixpanelEnabled !== baseline.mixpanelEnabled &&
+    draft.mixpanelEnabled !== null
+  ) {
+    patch.mixpanelEnabled = draft.mixpanelEnabled;
+  }
+  if (
+    draft.disableCodebaseUpload !== baseline.disableCodebaseUpload &&
+    draft.disableCodebaseUpload !== null
+  ) {
+    patch.disableCodebaseUpload = draft.disableCodebaseUpload;
+  }
+  if (
+    draft.disableWorkspaceTeleport !== baseline.disableWorkspaceTeleport &&
+    draft.disableWorkspaceTeleport !== null
+  ) {
+    patch.disableWorkspaceTeleport = draft.disableWorkspaceTeleport;
+  }
+  return patch;
+}
+
+export function hasPrivacyChanges(patch: PrivacyPatch): boolean {
+  return (
+    patch.telemetry != null ||
+    patch.traceUpload != null ||
+    patch.mixpanelEnabled != null ||
+    patch.disableCodebaseUpload != null ||
+    patch.disableWorkspaceTeleport != null
+  );
+}
+
+/**
+ * Toggle a tri-state bool for UI:
+ * - null → true (first write enables / sets the “on” side of the label)
+ * - true → false
+ * - false → true
+ *
+ * For `disable_*` keys the “on” side of the label is “disabled = true”.
+ */
+export function togglePrivacyTri(current: PrivacyTri): boolean {
+  if (current === null) return true;
+  return !current;
+}
+
+/** Honest status label id for a tri-state value. */
+export function privacyKeyPresence(
+  value: PrivacyTri,
+): "set_on" | "set_off" | "unset" {
+  if (value === true) return "set_on";
+  if (value === false) return "set_off";
+  return "unset";
+}
+
+/**
+ * Effective toggle checked state for UI.
+ * Unset keys render as unchecked with an explicit “unset” badge (not claimed off).
+ */
+export function privacyToggleChecked(value: PrivacyTri): boolean {
+  return value === true;
+}
+
+/** Whether writes are allowed for this snapshot (independent mode only). */
+export function isPrivacyWritable(
+  snap: PrivacySnapshotLike | null | undefined,
+): boolean {
+  return !!snap?.writable;
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -62,6 +62,7 @@ export type SettingsTabId =
   | "network"
   | "pool"
   | "tools"
+  | "privacy"
   // remote control (section id stays remote_im)
   | "im"
   | "mirror";
@@ -184,6 +185,7 @@ export const SETTINGS_NAV: readonly SettingsNavDef[] = [
       { id: "network", labelKey: "settings.tab.network" },
       { id: "pool", labelKey: "settings.tab.pool" },
       { id: "tools", labelKey: "settings.tab.tools" },
+      { id: "privacy", labelKey: "settings.tab.privacy" },
     ],
   },
   {
@@ -1764,6 +1766,97 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     keywords: ["marketplace", "market", "install plugin"],
   },
   // ── runtime ──
+  {
+    id: "runtime.privacy",
+    section: "runtime",
+    tab: "privacy",
+    anchorId: "settings-anchor-privacy",
+    labelKey: "settings.privacy",
+    descKeys: [
+      "settings.privacyDesc",
+      "settings.privacy.telemetry",
+      "settings.privacy.telemetryDesc",
+      "settings.privacy.traceUpload",
+      "settings.privacy.traceUploadDesc",
+      "settings.privacy.mixpanel",
+      "settings.privacy.disableCodebaseUpload",
+      "settings.privacy.disableCodebaseUploadDesc",
+      "settings.privacy.disableWorkspaceTeleport",
+      "settings.privacy.codingData",
+      "settings.privacy.codingDataDesc",
+      "settings.privacy.sharedWarning",
+    ],
+    keywords: [
+      "privacy",
+      "telemetry",
+      "trace upload",
+      "codebase upload",
+      "disable_codebase_upload",
+      "trace_upload",
+      "mixpanel",
+      "GROK_TELEMETRY",
+      "/privacy",
+      "coding data",
+      "training",
+      "retention",
+      "隐私",
+      "遙測",
+      "遥测",
+      "隐私中心",
+      "隱私",
+    ],
+  },
+  {
+    id: "runtime.privacy.telemetry",
+    section: "runtime",
+    tab: "privacy",
+    anchorId: "settings-anchor-privacy-telemetry",
+    labelKey: "settings.privacy.telemetry",
+    descKeys: ["settings.privacy.telemetryDesc"],
+    keywords: ["telemetry", "features telemetry", "product analytics"],
+  },
+  {
+    id: "runtime.privacy.traceUpload",
+    section: "runtime",
+    tab: "privacy",
+    anchorId: "settings-anchor-privacy-traceUpload",
+    labelKey: "settings.privacy.traceUpload",
+    descKeys: ["settings.privacy.traceUploadDesc"],
+    keywords: ["trace_upload", "session trace", "trace upload"],
+  },
+  {
+    id: "runtime.privacy.codebaseUpload",
+    section: "runtime",
+    tab: "privacy",
+    anchorId: "settings-anchor-privacy-codebaseUpload",
+    labelKey: "settings.privacy.disableCodebaseUpload",
+    descKeys: ["settings.privacy.disableCodebaseUploadDesc"],
+    keywords: [
+      "disable_codebase_upload",
+      "codebase upload",
+      "upload codebase",
+      "index upload",
+    ],
+  },
+  {
+    id: "runtime.privacy.codingData",
+    section: "runtime",
+    tab: "privacy",
+    anchorId: "settings-anchor-privacy-codingData",
+    labelKey: "settings.privacy.codingData",
+    descKeys: [
+      "settings.privacy.codingDataDesc",
+      "settings.privacy.codingDataHint",
+    ],
+    keywords: [
+      "/privacy",
+      "coding data",
+      "training",
+      "retention",
+      "ZDR",
+      "opt out",
+    ],
+  },
   {
     id: "runtime.cliPath",
     section: "runtime",


### PR DESCRIPTION
## Summary

Align Grok App Settings with **Grok Build 0.2.117** privacy-related `config.toml` surface after public concern about uploads. Settings → **Runtime → Privacy** is an honest Privacy center — not a stub.

### Host
- Read allowlisted keys from the **active** `GROK_HOME` `config.toml` (independent agent-home or shared `~/.grok`):
  - `[features] telemetry` (`GROK_TELEMETRY_ENABLED`)
  - `[telemetry] trace_upload` (`GROK_TELEMETRY_TRACE_UPLOAD`)
  - `[telemetry] mixpanel_enabled` (`GROK_TELEMETRY_MIXPANEL_ENABLED`)
  - `[harness] disable_codebase_upload`
  - `[harness] disable_workspace_teleport`
- Soft-fail: missing keys stay `null` / “unset” — never invent CLI defaults as “off”
- Writes path-scoped to **independent agent-home only**; shared mode is a read-only probe with a clear warning
- Soft-respawn after save so the agent reloads profile
- Redacted preview of `[features]` / `[telemetry]` / `[harness]` only

### UI
- New Runtime tab **Privacy** with toggles + presence badges (on / off / unset)
- **Coding data, retention, and training** is **not** a config key — copy CLI `/privacy` only (no fake App toggle)
- `settingsCatalog` entries + search keywords; en / zh / zh-TW

### Tests
- Pure TS helpers (`privacyConfig.test.ts`)
- Rust unit tests (`agent_privacy`: parse, patch, path-scope, independent roundtrip, shared refuse)

## Test plan
- [ ] Settings → Runtime → Privacy loads under independent mode; missing keys show **unset**
- [ ] Toggle + Save writes only allowlisted keys into `~/.grok-app/agent-home/config.toml`; other sections/secrets untouched
- [ ] Shared session data mode: read-only of `~/.grok/config.toml`; Save disabled + warning
- [ ] Coding-data row copies `/privacy`; does not claim App can change training opt-in
- [ ] Search “telemetry” / “privacy” / “codebase upload” jumps to Privacy anchors
- [ ] `vitest` privacyConfig + settingsCatalog + messages; `cargo test --lib agent_privacy`