### PR TITLE
feat(settings): subagent worktree snapshot (CLI 0.2.117 config)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ See `docs/llm-wiki/release.md`.
 
 #### Runtime / connection
 - **SDK Connect wizard** (Settings → Runtime → Connection): start local `agent serve`, show masked secret + ws URL, TCP health probe, copy curl / websocat / `grok --remote` examples for external clients, and optional paste remote serve URL + probe. Secrets never logged; full token only via one-time clipboard after start.
+- **Subagent worktree snapshot** (Settings → General → Agent; CLI **0.2.117+** config `subagent_worktree_snapshot_enabled`): opt-in toggle so nested subagents can snapshot / rehydrate isolated worktrees. Independent mode writes the top-level agent-home key; spawn sets `GROK_SUBAGENT_WORKTREE_SNAPSHOT` (soft-fail when CLI is known older). Soft-respawn on change. Tasks panel shows a short note when enabled.
 
 #### Composer & chat
 - **Live Voice delegate status** (VOX-DELEG): overlay shows listening / thinking / speaking from host `voice://` events, **Stop**, honest empty transcript (no fake STT), delegated session chips, and optional **Send transcript to active session** when a chat is open

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -711,6 +711,7 @@ impl AcpClient {
             crate::agents_catalog::normalize_agent_profile_path(&settings.agent_profile_path);
         let agents_json_args = agents_json_spawn_flags(&settings.agents_json);
         let subagents_enabled = settings.subagents_enabled;
+        let subagent_wt_snap = settings.subagent_worktree_snapshot_enabled;
         let memory_enabled = settings.experimental_memory;
         let use_leader = settings.use_leader;
         let plan_enabled = settings.plan_enabled;
@@ -719,6 +720,8 @@ impl AcpClient {
         let allowed_tools = settings.allowed_tools.clone();
         let spawn_policy = opts.permission_policy.as_deref().unwrap_or("ask");
         let spawn_product_mode = opts.product_mode.as_deref();
+        // Soft-fail older CLIs for GROK_SUBAGENT_WORKTREE_SNAPSHOT env.
+        let cli_ver = crate::cli_probe::read_version_of(&cli_path);
 
         if session_data_mode != "shared" {
             let _ = crate::agent_subagents::sync_subagents_to_agent_profile(
@@ -728,6 +731,10 @@ impl AcpClient {
             let _ = crate::agent_memory::sync_memory_to_agent_profile(
                 session_data_mode,
                 memory_enabled,
+            );
+            let _ = crate::agent_subagent_wt_snap::sync_subagent_wt_snap_to_agent_profile(
+                session_data_mode,
+                subagent_wt_snap,
             );
         }
 
@@ -794,6 +801,12 @@ impl AcpClient {
         }
         crate::agent_subagents::apply_subagents_to_command(&mut cmd, subagents_enabled);
         crate::agent_memory::apply_memory_to_command(&mut cmd, memory_enabled);
+        // Config-only surface (CLI 0.2.117+): env + independent agent-home key.
+        crate::agent_subagent_wt_snap::apply_subagent_wt_snap_to_command(
+            &mut cmd,
+            subagent_wt_snap,
+            cli_ver.as_deref(),
+        );
         cmd.arg("agent");
         cmd.arg(leader_spawn_flag(use_leader));
         // Agent option: `--agent-profile <PATH>` (before `stdio`). Path only —

--- a/src-tauri/src/agent_subagent_wt_snap.rs
+++ b/src-tauri/src/agent_subagent_wt_snap.rs
@@ -1,0 +1,195 @@
+//! Subagent worktree snapshot (CLI 0.2.117+) — config + env sync.
+//!
+//! Config key (top-level, agent-home independent mode):
+//! - `subagent_worktree_snapshot_enabled` (bool)
+//!
+//! Env: `GROK_SUBAGENT_WORKTREE_SNAPSHOT=0|1`
+//!
+//! No dedicated CLI flag. Shared mode never rewrites `~/.grok/config.toml`.
+//! Soft-fail older CLIs: omit env when version is known &lt; 0.2.117.
+
+use std::fs;
+
+use crate::paths::{agent_config_toml, ensure_app_dirs};
+
+/// First CLI that accepts the config / env surface.
+pub const SUBAGENT_WT_SNAP_MIN_CLI: (u64, u64, u64) = (0, 2, 117);
+
+pub const CONFIG_KEY: &str = "subagent_worktree_snapshot_enabled";
+pub const ENV_KEY: &str = "GROK_SUBAGENT_WORKTREE_SNAPSHOT";
+
+/// Normalize enable toggle (App default off).
+pub fn normalize_enabled(raw: bool) -> bool {
+    raw
+}
+
+/// Env value for the agent process.
+pub fn spawn_env_value(enabled: bool) -> &'static str {
+    if enabled {
+        "1"
+    } else {
+        "0"
+    }
+}
+
+/// `Some(true)` when CLI ≥ 0.2.117; `Some(false)` when older; `None` unparseable.
+pub fn cli_supports_subagent_wt_snap(raw_version: &str) -> Option<bool> {
+    let token = crate::cli_probe::extract_version_token(raw_version)?;
+    let parsed = crate::app_update::parse_semver(&token)?;
+    Some(parsed >= SUBAGENT_WT_SNAP_MIN_CLI)
+}
+
+/// Soft-fail: whether to apply the env override for this CLI version.
+///
+/// - Known ≥ 0.2.117 → apply
+/// - Known older → omit
+/// - Unknown / missing → apply (forward-compatible; env is ignored if unused)
+pub fn should_apply_env(raw_cli_version: Option<&str>) -> bool {
+    match raw_cli_version {
+        Some(v) => cli_supports_subagent_wt_snap(v) != Some(false),
+        None => true,
+    }
+}
+
+/// Upsert a bare top-level `key = value` assignment (not inside a `[table]`).
+pub fn set_top_level_assignment(text: &str, key: &str, value: &str) -> String {
+    let line_val = format!("{key} = {value}");
+    let mut lines: Vec<String> = text.lines().map(|s| s.to_string()).collect();
+    let mut in_table = false;
+    let mut first_table_idx: Option<usize> = None;
+
+    for i in 0..lines.len() {
+        let trimmed = lines[i].trim().to_string();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            if first_table_idx.is_none() {
+                first_table_idx = Some(i);
+            }
+            in_table = true;
+            continue;
+        }
+        if in_table {
+            continue;
+        }
+        // Root-level assignment.
+        let key_part = trimmed.split('=').next().map(str::trim).unwrap_or("");
+        if key_part == key {
+            lines[i] = line_val;
+            return lines.join("\n")
+                + if text.ends_with('\n') || text.is_empty() {
+                    "\n"
+                } else {
+                    ""
+                };
+        }
+    }
+
+    // Insert before the first table, or append at end.
+    if let Some(idx) = first_table_idx {
+        lines.insert(idx, line_val);
+        return lines.join("\n") + "\n";
+    }
+
+    let base = text.trim_end();
+    if base.is_empty() {
+        format!("{line_val}\n")
+    } else {
+        format!("{base}\n{line_val}\n")
+    }
+}
+
+/// Upsert `subagent_worktree_snapshot_enabled` into a TOML-ish text blob.
+pub fn set_subagent_wt_snap_in_toml(text: &str, enabled: bool) -> String {
+    set_top_level_assignment(text, CONFIG_KEY, &enabled.to_string())
+}
+
+/// Write the config key into App agent-home (independent GROK_HOME only).
+pub fn sync_subagent_wt_snap_to_agent_profile(
+    session_data_mode: &str,
+    enabled: bool,
+) -> Result<(), String> {
+    if session_data_mode == "shared" {
+        // Never rewrite the user's personal ~/.grok/config.toml from the App.
+        return Ok(());
+    }
+    let _ = ensure_app_dirs();
+    let path = agent_config_toml();
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    let next = set_subagent_wt_snap_in_toml(&existing, enabled);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    fs::write(&path, next).map_err(|e| e.to_string())?;
+    tracing::info!(
+        "agent_subagent_wt_snap: synced {}={} → {}",
+        CONFIG_KEY,
+        enabled,
+        path.display()
+    );
+    Ok(())
+}
+
+/// Apply env on a tokio Command (soft-gated by CLI version when provided).
+pub fn apply_subagent_wt_snap_to_command(
+    cmd: &mut tokio::process::Command,
+    enabled: bool,
+    raw_cli_version: Option<&str>,
+) {
+    if !should_apply_env(raw_cli_version) {
+        return;
+    }
+    cmd.env(ENV_KEY, spawn_env_value(enabled));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_and_env() {
+        assert!(!normalize_enabled(false));
+        assert!(normalize_enabled(true));
+        assert_eq!(spawn_env_value(true), "1");
+        assert_eq!(spawn_env_value(false), "0");
+    }
+
+    #[test]
+    fn version_gate() {
+        assert_eq!(
+            cli_supports_subagent_wt_snap("0.2.117"),
+            Some(true)
+        );
+        assert_eq!(
+            cli_supports_subagent_wt_snap("grok 0.2.117 (f1c06093089f)"),
+            Some(true)
+        );
+        assert_eq!(cli_supports_subagent_wt_snap("0.2.116"), Some(false));
+        assert_eq!(cli_supports_subagent_wt_snap("0.2.100"), Some(false));
+        assert_eq!(cli_supports_subagent_wt_snap("nope"), None);
+        assert!(should_apply_env(Some("0.2.117")));
+        assert!(!should_apply_env(Some("0.2.112")));
+        assert!(should_apply_env(None));
+        assert!(should_apply_env(Some("garbage")));
+    }
+
+    #[test]
+    fn upserts_top_level_key() {
+        let t = set_subagent_wt_snap_in_toml("", true);
+        assert!(t.contains("subagent_worktree_snapshot_enabled = true"));
+
+        let existing = "[ui]\nyolo = false\n\n[subagents]\nenabled = true\n";
+        let next = set_subagent_wt_snap_in_toml(existing, false);
+        assert!(next.contains("subagent_worktree_snapshot_enabled = false"));
+        let ui_pos = next.find("[ui]").unwrap();
+        let key_pos = next.find("subagent_worktree_snapshot_enabled").unwrap();
+        assert!(key_pos < ui_pos);
+        assert!(next.contains("[subagents]"));
+        assert!(next.contains("yolo = false"));
+
+        let again = set_subagent_wt_snap_in_toml(&next, true);
+        assert!(again.contains("subagent_worktree_snapshot_enabled = true"));
+        assert_eq!(
+            again.matches("subagent_worktree_snapshot_enabled").count(),
+            1
+        );
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1118,6 +1118,8 @@ pub async fn settings_set(
     let plan_enabled_flip = prev.plan_enabled != settings.plan_enabled;
     let use_leader_changed = prev.use_leader != settings.use_leader;
     let subagents_flip = prev.subagents_enabled != settings.subagents_enabled;
+    let subagent_wt_snap_flip = prev.subagent_worktree_snapshot_enabled
+        != settings.subagent_worktree_snapshot_enabled;
     let preferred_agent_flip =
         prev.preferred_agent.trim() != settings.preferred_agent.trim();
     let agent_profile_flip = prev.agent_profile_path.trim() != settings.agent_profile_path.trim();
@@ -1217,6 +1219,15 @@ pub async fn settings_set(
             settings.subagents_enabled,
         ) {
             tracing::warn!("settings_set sync subagents profile: {e}");
+        }
+        need_soft_respawn = true;
+    }
+    if subagent_wt_snap_flip {
+        if let Err(e) = crate::agent_subagent_wt_snap::sync_subagent_wt_snap_to_agent_profile(
+            &settings.session_data_mode,
+            settings.subagent_worktree_snapshot_enabled,
+        ) {
+            tracing::warn!("settings_set sync subagent_wt_snap profile: {e}");
         }
         need_soft_respawn = true;
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod agent_prefs;
 mod app_update;
 mod updater;
 mod agent_subagents;
+mod agent_subagent_wt_snap;
 mod extensions;
 mod hooks;
 mod supergrok_quota;

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -285,6 +285,12 @@ pub struct AppSettings {
     /// and independent mode writes `[subagents] enabled = false`.
     #[serde(default = "default_true")]
     pub subagents_enabled: bool,
+    /// Enable CLI subagent worktree snapshot (CLI **0.2.117+** config
+    /// `subagent_worktree_snapshot_enabled` + env `GROK_SUBAGENT_WORKTREE_SNAPSHOT`).
+    /// Default **false** (opt-in). Independent mode writes the top-level agent-home
+    /// key; spawn sets env (soft-fail when CLI is known older). Soft-respawns.
+    #[serde(default)]
+    pub subagent_worktree_snapshot_enabled: bool,
     /// Preferred Grok Build agent definition for new agent processes
     /// (`explore` / `plan` / `general-purpose` / custom name under `~/.grok/agents`).
     /// Empty / `default` / `none` → omit top-level `--agent` (CLI default).
@@ -445,6 +451,7 @@ impl Default for AppSettings {
             startup_new_chat_default_migrated: true,
             plan_enabled: default_plan_enabled(),
             subagents_enabled: true,
+            subagent_worktree_snapshot_enabled: false,
             preferred_agent: String::new(),
             agent_profile_path: String::new(),
             agents_json: String::new(),
@@ -2215,6 +2222,7 @@ mod tests {
         assert!(s.allowed_tools.is_empty());
         assert!(s.plan_enabled);
         assert!(s.subagents_enabled);
+        assert!(!s.subagent_worktree_snapshot_enabled);
         assert_eq!(s.preferred_agent, "");
         assert_eq!(s.agent_profile_path, "");
         assert_eq!(s.agents_json, "");
@@ -2365,6 +2373,13 @@ mod tests {
     fn subagents_enabled_defaults_true_when_missing_from_json() {
         let s: AppSettings = serde_json::from_str(legacy_settings_json()).expect("deserialize");
         assert!(s.subagents_enabled);
+    }
+
+    #[test]
+    fn subagent_worktree_snapshot_defaults_false_when_missing_from_json() {
+        let s: AppSettings = serde_json::from_str(legacy_settings_json()).expect("deserialize");
+        assert!(!s.subagent_worktree_snapshot_enabled);
+        assert!(!AppSettings::default().subagent_worktree_snapshot_enabled);
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2146,6 +2146,8 @@ export default function App() {
   const voiceDictationAutoSendRef = useRef(false);
   const sendRef = useRef<(() => Promise<void>) | null>(null);
   const [subagentsEnabled, setSubagentsEnabled] = useState(true);
+  const [subagentWorktreeSnapshotEnabled, setSubagentWorktreeSnapshotEnabled] =
+    useState(false);
   const [planEnabled, setPlanEnabled] = useState(true);
   const [disableWebSearch, setDisableWebSearch] = useState(false);
   const [disallowedTools, setDisallowedTools] = useState<string[]>([]);
@@ -2975,6 +2977,9 @@ export default function App() {
           : null,
       );
       setSubagentsEnabled(settings.subagentsEnabled !== false);
+      setSubagentWorktreeSnapshotEnabled(
+        !!settings.subagentWorktreeSnapshotEnabled,
+      );
       setPlanEnabled(settings.planEnabled !== false);
       setDisableWebSearch(!!settings.disableWebSearch);
       setDisallowedTools(
@@ -14571,6 +14576,13 @@ export default function App() {
               api.settingsSet({ ...s, subagentsEnabled: v }),
             );
           }}
+          subagentWorktreeSnapshotEnabled={subagentWorktreeSnapshotEnabled}
+          onSubagentWorktreeSnapshotEnabled={(v) => {
+            setSubagentWorktreeSnapshotEnabled(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, subagentWorktreeSnapshotEnabled: v }),
+            );
+          }}
           planEnabled={planEnabled}
           onPlanEnabled={(v) => {
             setPlanEnabled(v);
@@ -16485,6 +16497,9 @@ export default function App() {
               messages={messages}
               t={(k, vars) => tr(k, vars)}
               onClose={() => setTasksPanelOpen(false)}
+              subagentWorktreeSnapshotEnabled={
+                subagentWorktreeSnapshotEnabled
+              }
               activitySessions={collectActivitySessions({
                 liveMap,
                 sessions,

--- a/src/components/AgentTasksPanel.tsx
+++ b/src/components/AgentTasksPanel.tsx
@@ -69,6 +69,11 @@ export type AgentTasksPanelProps = {
   onOpenCwd?: (cwd: string) => void;
   /** Current chat project path — used to mark cwd as already active. */
   activeCwd?: string | null;
+  /**
+   * When true, CLI subagent worktree snapshot mode is on
+   * (`subagent_worktree_snapshot_enabled`, CLI 0.2.117+). Shows a short note.
+   */
+  subagentWorktreeSnapshotEnabled?: boolean;
 };
 
 async function revealOrCopyCwd(cwd: string): Promise<"revealed" | "copied"> {
@@ -501,6 +506,7 @@ export function AgentTasksPanel({
   onOpenDashboard,
   onOpenCwd,
   activeCwd = null,
+  subagentWorktreeSnapshotEnabled = false,
 }: AgentTasksPanelProps) {
   const [query, setQuery] = useState("");
   const tasks = useMemo(() => {
@@ -590,6 +596,12 @@ export function AgentTasksPanel({
           ) : null}
         </div>
       </header>
+
+      {subagentWorktreeSnapshotEnabled ? (
+        <p className="agent-tasks__snap-note" role="note">
+          {t("tasks.subagentWtSnapNote")}
+        </p>
+      ) : null}
 
       <div className="agent-tasks__search">
         <input

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -509,6 +509,9 @@ export interface SettingsPageProps {
   onPlanEnabled?: (v: boolean) => void;
   subagentsEnabled?: boolean;
   onSubagentsEnabled?: (v: boolean) => void;
+  /** CLI subagent worktree snapshot (config 0.2.117+). */
+  subagentWorktreeSnapshotEnabled?: boolean;
+  onSubagentWorktreeSnapshotEnabled?: (v: boolean) => void;
   useLeader?: boolean;
   onUseLeader?: (v: boolean) => void;
   /** Live voice speaker id (xAI realtime), e.g. eve. */
@@ -1105,6 +1108,8 @@ export function SettingsPage({
   onExperimentalMemory,
   subagentsEnabled = true,
   onSubagentsEnabled,
+  subagentWorktreeSnapshotEnabled = false,
+  onSubagentWorktreeSnapshotEnabled,
   planEnabled = true,
   onPlanEnabled,
   disableWebSearch = false,
@@ -2711,6 +2716,33 @@ export function SettingsPage({
                     checked={!!subagentsEnabled}
                     onChange={() => onSubagentsEnabled(!subagentsEnabled)}
                     ariaLabel={t("settings.subagentsEnabled")}
+                  />
+                </div>
+              ) : null}
+              {onSubagentWorktreeSnapshotEnabled ? (
+                <div
+                  className={
+                    "settings-row" +
+                    rowHighlight("settings-anchor-subagentWtSnap")
+                  }
+                  id="settings-anchor-subagentWtSnap"
+                >
+                  <div className="settings-row__text">
+                    <div className="settings-row__label">
+                      {t("settings.subagentWorktreeSnapshot")}
+                    </div>
+                    <div className="settings-row__desc">
+                      {t("settings.subagentWorktreeSnapshotDesc")}
+                    </div>
+                  </div>
+                  <UiCheck
+                    checked={!!subagentWorktreeSnapshotEnabled}
+                    onChange={() =>
+                      onSubagentWorktreeSnapshotEnabled(
+                        !subagentWorktreeSnapshotEnabled,
+                      )
+                    }
+                    ariaLabel={t("settings.subagentWorktreeSnapshot")}
                   />
                 </div>
               ) : null}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -591,6 +591,8 @@ const en = {
   "tasks.collapseChildren": "Collapse nested tools",
   "tasks.parent": "Parent",
   "tasks.searchPlaceholder": "Filter tasks…",
+  "tasks.subagentWtSnapNote":
+    "Subagent worktree snapshot is on (CLI 0.2.117+). Nested agents may use isolated worktree snapshots.",
   "tasks.openDashboard": "Agent dashboard",
   "dashboard.title": "Agent dashboard",
   "dashboard.hint":
@@ -1372,6 +1374,9 @@ const en = {
     "settings.section.agent": "Agent",
   "settings.subagentsEnabled": "Allow subagents",
   "settings.subagentsEnabledDesc": "When off, spawn with --no-subagents so nested Agent / task tools cannot start child sessions. Soft-respawns after change.",
+  "settings.subagentWorktreeSnapshot": "Subagent worktree snapshot",
+  "settings.subagentWorktreeSnapshotDesc":
+    "When on, Grok Build may snapshot / rehydrate isolated worktrees for nested subagents (CLI 0.2.117+ config subagent_worktree_snapshot_enabled + GROK_SUBAGENT_WORKTREE_SNAPSHOT). Default off. Independent mode writes agent-home config.toml. Soft-respawns after change; older CLIs soft-fail (env omitted).",
   "settings.planEnabled": "Allow plan mode",
   "settings.planEnabledDesc": "When off, spawn with --no-plan so the agent cannot enter plan mode. Soft-respawns after change.",
   "settings.useLeader": "Share agent backend (leader)",
@@ -4297,6 +4302,8 @@ const zh: Record<MessageKey, string> = {
   "tasks.collapseChildren": "收起子工具",
   "tasks.parent": "父级",
   "tasks.searchPlaceholder": "筛选任务…",
+  "tasks.subagentWtSnapNote":
+    "子代理 worktree 快照已开启（CLI 0.2.117+）。嵌套 Agent 可能使用隔离 worktree 快照。",
   "tasks.openDashboard": "Agent 仪表盘",
   "dashboard.title": "Agent 仪表盘",
   "dashboard.hint":
@@ -5049,6 +5056,9 @@ const zh: Record<MessageKey, string> = {
     "settings.section.agent": "Agent",
   "settings.subagentsEnabled": "允许子代理",
   "settings.subagentsEnabledDesc": "关闭时启动加上 --no-subagents，无法拉起嵌套 Agent / 任务。更改后 soft-respawn。",
+  "settings.subagentWorktreeSnapshot": "子代理 worktree 快照",
+  "settings.subagentWorktreeSnapshotDesc":
+    "开启后，Grok Build 可为嵌套子代理快照 / 还原隔离 worktree（CLI 0.2.117+ 配置 subagent_worktree_snapshot_enabled 与 GROK_SUBAGENT_WORKTREE_SNAPSHOT）。默认关闭。独立模式写入 agent-home config.toml。更改后 soft-respawn；旧版 CLI soft-fail（省略 env）。",
   "settings.planEnabled": "允许计划模式",
   "settings.planEnabledDesc": "关闭时启动加上 --no-plan，Agent 无法进入计划模式。更改后 soft-respawn。",
   "settings.useLeader": "共享 Agent 后端（leader）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -557,6 +557,8 @@ export const zhTW: Record<MessageKey, string> = {
   "tasks.collapseChildren": "收合子工具",
   "tasks.parent": "父級",
   "tasks.searchPlaceholder": "篩選任務…",
+  "tasks.subagentWtSnapNote":
+    "子代理 worktree 快照已開啟（CLI 0.2.117+）。巢狀 Agent 可能使用隔離 worktree 快照。",
   "tasks.openDashboard": "Agent 儀表板",
   "dashboard.title": "Agent 儀表板",
   "dashboard.hint":
@@ -1309,6 +1311,9 @@ export const zhTW: Record<MessageKey, string> = {
     "settings.section.agent": "Agent",
   "settings.subagentsEnabled": "允許子代理",
   "settings.subagentsEnabledDesc": "關閉時啟動加上 --no-subagents，無法拉起巢狀 Agent / 任務。變更後 soft-respawn。",
+  "settings.subagentWorktreeSnapshot": "子代理 worktree 快照",
+  "settings.subagentWorktreeSnapshotDesc":
+    "開啟後，Grok Build 可為巢狀子代理快照 / 還原隔離 worktree（CLI 0.2.117+ 設定 subagent_worktree_snapshot_enabled 與 GROK_SUBAGENT_WORKTREE_SNAPSHOT）。預設關閉。獨立模式寫入 agent-home config.toml。變更後 soft-respawn；舊版 CLI soft-fail（省略 env）。",
   "settings.planEnabled": "允許計畫模式",
   "settings.planEnabledDesc": "關閉時啟動加上 --no-plan，Agent 無法進入計畫模式。變更後 soft-respawn。",
   "settings.useLeader": "共用 Agent 後端（leader）",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1311,6 +1311,12 @@ export interface AppSettings {
   allowedTools?: string[];
   planEnabled?: boolean;
   subagentsEnabled?: boolean;
+  /**
+   * Enable CLI subagent worktree snapshot (CLI 0.2.117+).
+   * Default false. Writes agent-home `subagent_worktree_snapshot_enabled` in
+   * independent mode; spawn sets `GROK_SUBAGENT_WORKTREE_SNAPSHOT`. Soft-respawns.
+   */
+  subagentWorktreeSnapshotEnabled?: boolean;
   useLeader?: boolean;
   /** Reopen last active chat once after launch (default false → draft new chat). */
   reopenLastSession?: boolean;

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -587,6 +587,27 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     keywords: ["subagents", "sub-agent"],
   },
   {
+    id: "general.subagentWorktreeSnapshot",
+    section: "general",
+    tab: "agent",
+    anchorId: "settings-anchor-subagentWtSnap",
+    labelKey: "settings.subagentWorktreeSnapshot",
+    descKeys: [
+      "settings.subagentWorktreeSnapshotDesc",
+      "tasks.subagentWtSnapNote",
+    ],
+    keywords: [
+      "subagent worktree snapshot",
+      "subagent_worktree_snapshot_enabled",
+      "GROK_SUBAGENT_WORKTREE_SNAPSHOT",
+      "worktree snapshot",
+      "subagent snapshot",
+      "子代理 worktree 快照",
+      "子代理工作樹快照",
+      "快照",
+    ],
+  },
+  {
     id: "general.configTomlEdit",
     section: "general",
     tab: "agent",

--- a/src/lib/subagentWorktreeSnapshot.test.ts
+++ b/src/lib/subagentWorktreeSnapshot.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUBAGENT_WORKTREE_SNAPSHOT_CONFIG_KEY,
+  SUBAGENT_WORKTREE_SNAPSHOT_ENV,
+  cliSupportsSubagentWorktreeSnapshot,
+  normalizeSubagentWorktreeSnapshotEnabled,
+  subagentWorktreeSnapshotEqual,
+  subagentWorktreeSnapshotSpawnEnv,
+  subagentWorktreeSnapshotSpawnEnvSoft,
+} from "./subagentWorktreeSnapshot";
+
+describe("normalizeSubagentWorktreeSnapshotEnabled", () => {
+  it("defaults to false", () => {
+    expect(normalizeSubagentWorktreeSnapshotEnabled(null)).toBe(false);
+    expect(normalizeSubagentWorktreeSnapshotEnabled(undefined)).toBe(false);
+    expect(normalizeSubagentWorktreeSnapshotEnabled(false)).toBe(false);
+  });
+
+  it("is true only for true", () => {
+    expect(normalizeSubagentWorktreeSnapshotEnabled(true)).toBe(true);
+  });
+});
+
+describe("subagentWorktreeSnapshotSpawnEnv", () => {
+  it("always sets GROK_SUBAGENT_WORKTREE_SNAPSHOT", () => {
+    expect(subagentWorktreeSnapshotSpawnEnv(true)).toEqual({
+      [SUBAGENT_WORKTREE_SNAPSHOT_ENV]: "1",
+    });
+    expect(subagentWorktreeSnapshotSpawnEnv(false)).toEqual({
+      [SUBAGENT_WORKTREE_SNAPSHOT_ENV]: "0",
+    });
+    expect(subagentWorktreeSnapshotSpawnEnv(null)).toEqual({
+      [SUBAGENT_WORKTREE_SNAPSHOT_ENV]: "0",
+    });
+  });
+});
+
+describe("cliSupportsSubagentWorktreeSnapshot", () => {
+  it("parses version tokens", () => {
+    expect(cliSupportsSubagentWorktreeSnapshot("0.2.117")).toBe(true);
+    expect(cliSupportsSubagentWorktreeSnapshot("grok 0.2.117 (abc)")).toBe(
+      true,
+    );
+    expect(cliSupportsSubagentWorktreeSnapshot("0.2.118")).toBe(true);
+    expect(cliSupportsSubagentWorktreeSnapshot("0.3.0")).toBe(true);
+    expect(cliSupportsSubagentWorktreeSnapshot("0.2.116")).toBe(false);
+    expect(cliSupportsSubagentWorktreeSnapshot("0.2.100")).toBe(false);
+    expect(cliSupportsSubagentWorktreeSnapshot("0.1.99")).toBe(false);
+  });
+
+  it("returns null for unknown", () => {
+    expect(cliSupportsSubagentWorktreeSnapshot(null)).toBe(null);
+    expect(cliSupportsSubagentWorktreeSnapshot(undefined)).toBe(null);
+    expect(cliSupportsSubagentWorktreeSnapshot("")).toBe(null);
+    expect(cliSupportsSubagentWorktreeSnapshot("nope")).toBe(null);
+  });
+});
+
+describe("subagentWorktreeSnapshotSpawnEnvSoft", () => {
+  it("omits env on known-old CLI", () => {
+    expect(
+      subagentWorktreeSnapshotSpawnEnvSoft(true, "0.2.112"),
+    ).toEqual({});
+    expect(
+      subagentWorktreeSnapshotSpawnEnvSoft(false, "grok 0.2.100"),
+    ).toEqual({});
+  });
+
+  it("emits on new or unknown CLI", () => {
+    expect(subagentWorktreeSnapshotSpawnEnvSoft(true, "0.2.117")).toEqual({
+      [SUBAGENT_WORKTREE_SNAPSHOT_ENV]: "1",
+    });
+    expect(subagentWorktreeSnapshotSpawnEnvSoft(true, null)).toEqual({
+      [SUBAGENT_WORKTREE_SNAPSHOT_ENV]: "1",
+    });
+    expect(subagentWorktreeSnapshotSpawnEnvSoft(false, "garbage")).toEqual({
+      [SUBAGENT_WORKTREE_SNAPSHOT_ENV]: "0",
+    });
+  });
+});
+
+describe("subagentWorktreeSnapshotEqual", () => {
+  it("compares after normalize", () => {
+    expect(subagentWorktreeSnapshotEqual(null, false)).toBe(true);
+    expect(subagentWorktreeSnapshotEqual(true, true)).toBe(true);
+    expect(subagentWorktreeSnapshotEqual(true, false)).toBe(false);
+  });
+});
+
+describe("config key constant", () => {
+  it("matches CLI 0.2.117 surface", () => {
+    expect(SUBAGENT_WORKTREE_SNAPSHOT_CONFIG_KEY).toBe(
+      "subagent_worktree_snapshot_enabled",
+    );
+  });
+});

--- a/src/lib/subagentWorktreeSnapshot.ts
+++ b/src/lib/subagentWorktreeSnapshot.ts
@@ -1,0 +1,97 @@
+/**
+ * Subagent worktree snapshot (CLI 0.2.117+ config) — pure normalize helpers.
+ *
+ * When enabled, Grok Build can snapshot / rehydrate isolated worktrees for
+ * nested subagents (`subagent_worktree_snapshot_enabled` in agent-home
+ * config.toml; env `GROK_SUBAGENT_WORKTREE_SNAPSHOT`). No dedicated CLI flag.
+ *
+ * App default: **off** (opt-in). Independent mode writes the top-level config
+ * key; spawn always sets the env so shared mode cannot re-enable via leftover
+ * config. Soft-respawn after change so the next agent process reloads.
+ */
+
+/** Top-level config.toml key (CLI 0.2.117+). */
+export const SUBAGENT_WORKTREE_SNAPSHOT_CONFIG_KEY =
+  "subagent_worktree_snapshot_enabled";
+
+/** Process env that mirrors the config key. */
+export const SUBAGENT_WORKTREE_SNAPSHOT_ENV = "GROK_SUBAGENT_WORKTREE_SNAPSHOT";
+
+/** First CLI that understands the config / env surface. */
+export const SUBAGENT_WORKTREE_SNAPSHOT_MIN_CLI = "0.2.117";
+
+/**
+ * Normalize the enable toggle.
+ * null / undefined → false (App + CLI-aligned opt-in default).
+ */
+export function normalizeSubagentWorktreeSnapshotEnabled(
+  raw: boolean | null | undefined,
+): boolean {
+  return raw === true;
+}
+
+/**
+ * Env overrides applied to the agent process.
+ * Always set so shared-mode ~/.grok config cannot silently re-enable.
+ */
+export function subagentWorktreeSnapshotSpawnEnv(
+  enabled: boolean | null | undefined,
+): Record<typeof SUBAGENT_WORKTREE_SNAPSHOT_ENV, string> {
+  return {
+    [SUBAGENT_WORKTREE_SNAPSHOT_ENV]: normalizeSubagentWorktreeSnapshotEnabled(
+      enabled,
+    )
+      ? "1"
+      : "0",
+  };
+}
+
+/**
+ * Soft-gate: whether to emit the env override given a raw CLI version string.
+ * - Known ≥ 0.2.117 → true
+ * - Known older → false (omit; older builds ignore the env but avoid noise)
+ * - Unknown / unparseable → true when enabled is default-safe (we still emit
+ *   for off=0 / on=1; host may choose to always emit)
+ *
+ * Pure parse of `x.y.z` tokens only (no host IO).
+ */
+export function cliSupportsSubagentWorktreeSnapshot(
+  rawVersion: string | null | undefined,
+): boolean | null {
+  if (rawVersion == null) return null;
+  const m = String(rawVersion).match(/(\d+)\.(\d+)(?:\.(\d+))?/);
+  if (!m) return null;
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  const patch = Number(m[3] ?? "0");
+  if (![major, minor, patch].every((n) => Number.isFinite(n))) return null;
+  if (major > 0) return true;
+  if (major < 0) return false;
+  if (minor > 2) return true;
+  if (minor < 2) return false;
+  return patch >= 117;
+}
+
+/**
+ * Env map for spawn with soft-fail on known-old CLI.
+ * Empty object when CLI is known older (omit override); otherwise full map.
+ */
+export function subagentWorktreeSnapshotSpawnEnvSoft(
+  enabled: boolean | null | undefined,
+  rawCliVersion: string | null | undefined,
+): Record<string, string> {
+  const support = cliSupportsSubagentWorktreeSnapshot(rawCliVersion);
+  if (support === false) return {};
+  return subagentWorktreeSnapshotSpawnEnv(enabled);
+}
+
+/** True when two raw toggles normalize equal. */
+export function subagentWorktreeSnapshotEqual(
+  a: boolean | null | undefined,
+  b: boolean | null | undefined,
+): boolean {
+  return (
+    normalizeSubagentWorktreeSnapshotEnabled(a) ===
+    normalizeSubagentWorktreeSnapshotEnabled(b)
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -22314,6 +22314,15 @@ html[data-theme="light"] .rim-sidebar {
   display: flex;
   gap: 4px;
 }
+.agent-tasks__snap-note {
+  margin: 0 14px 8px;
+  padding: 6px 8px;
+  font-size: 11px;
+  line-height: 1.4;
+  opacity: 0.78;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--fg, #e8e8e8) 6%, transparent);
+}
 .agent-tasks__search {
   padding: 4px 12px 8px;
 }


### PR DESCRIPTION
## Summary

Wire Grok Build **0.2.117** config key `subagent_worktree_snapshot_enabled` into the App so nested subagents can use isolated worktree snapshot / rehydrate.

- **Settings → General → Agent**: opt-in toggle (default **off**)
- **Independent mode**: writes top-level `subagent_worktree_snapshot_enabled` into agent-home `config.toml` (never rewrites shared `~/.grok`)
- **Spawn**: sets `GROK_SUBAGENT_WORKTREE_SNAPSHOT=0|1`; soft-fail omits env when CLI is known older than 0.2.117
- **Soft-respawn** on change so the next agent process reloads config
- **Tasks panel**: short note when snapshot mode is on
- Pure TS/Rust helpers + unit tests; en / zh / zh-TW i18n; `settingsCatalog`; CHANGELOG

No dedicated CLI flag — config + env only (CLI binary surface).

## Test plan

- [x] `pnpm test -- src/lib/subagentWorktreeSnapshot.test.ts` (9 pass)
- [x] `cargo test --lib agent_subagent_wt_snap` (3 pass)
- [x] `pnpm typecheck`
- [ ] Desktop: Settings → Agent → enable Subagent worktree snapshot → soft-respawn toast
- [ ] Independent mode: agent-home `config.toml` contains `subagent_worktree_snapshot_enabled = true`
- [ ] Tasks panel shows snapshot note when enabled
- [ ] Shared mode: no rewrite of `~/.grok/config.toml`; env still applied on spawn