### PR TITLE
feat(reliability): cross-session tool/permission audit ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+#### Runtime / diagnostics
+- **Tool audit ledger** (Reliability center + Settings → Runtime → Tools): append-only JSONL under `{app_data}/audit/tool_ledger.jsonl` records permission decisions (user + auto allow/deny) and tool start/end with redacted summaries, session id, project path, and outcome. Soft size rotate; soft-fail I/O; never logs secrets. View / filter / clear (in-app confirm) / export redacted JSONL. Pure `auditLedger` helpers + host/unit tests; `settingsCatalog` keywords; en/zh/zh-TW.
+
 #### Agent / memory
 - **Memory embedding (CLI 0.2.117)** (Settings → Agent): host reads allowlisted `[memory.*]` keys from active GROK_HOME `config.toml` (`embedding.model` / `dimensions`, `search.*`, `search.mmr`, `search.temporal_decay`, `dream.*`, `watcher`, `initial_injection`) with soft-fail when missing; independent agent-home can write safe keys + soft-respawn (shared mode read-only). Memory browser shows honest **App keyword** vs **CLI hybrid/keyword** status and links to the panel. App `memory_search` stays path-scoped keyword scan — never invents embeddings client-side.
 

--- a/src-tauri/src/audit_ledger.rs
+++ b/src-tauri/src/audit_ledger.rs
@@ -1,0 +1,656 @@
+//! Cross-session tool / permission audit ledger.
+//!
+//! Append-only JSONL under `{app_data}/audit/tool_ledger.jsonl`. Soft-fail on
+//! all I/O. Never stores secrets/API keys (summary is redacted + length-capped).
+//! Soft-rotates when the file grows past a size budget.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use parking_lot::Mutex as ParkingMutex;
+use serde::{Deserialize, Serialize};
+
+/// Soft cap for the on-disk JSONL (bytes). Past this we rewrite keeping the tail.
+pub const MAX_LEDGER_BYTES: u64 = 2 * 1024 * 1024;
+/// When rotating, keep roughly this many trailing lines.
+pub const ROTATE_KEEP_LINES: usize = 4_000;
+/// Default / max rows returned by list.
+pub const DEFAULT_LIST_LIMIT: usize = 200;
+pub const MAX_LIST_LIMIT: usize = 1_000;
+/// Redacted free-form summary budget.
+pub const MAX_SUMMARY_CHARS: usize = 240;
+/// Cap tool_name / permission strings.
+pub const MAX_FIELD_CHARS: usize = 120;
+
+/// Event kinds written to the ledger.
+pub const EVENT_PERMISSION: &str = "permission";
+pub const EVENT_TOOL_START: &str = "tool_start";
+pub const EVENT_TOOL_END: &str = "tool_end";
+
+/// Outcome for terminal tool rows.
+pub const OUTCOME_OK: &str = "ok";
+pub const OUTCOME_ERR: &str = "err";
+
+static WRITE_LOCK: ParkingMutex<()> = ParkingMutex::new(());
+
+/// Pending UI permission context so `resolve_permission` can log tool_name.
+#[derive(Debug, Clone)]
+struct PendingPermission {
+    tool_name: String,
+    summary: String,
+}
+
+static PENDING_PERMS: Mutex<std::collections::HashMap<(String, u64), PendingPermission>> =
+    Mutex::new(std::collections::HashMap::new());
+
+/// One append-only ledger row (camelCase for the UI).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditLedgerEntry {
+    /// ISO-8601 UTC timestamp.
+    pub ts: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
+    #[serde(default)]
+    pub tool_name: String,
+    /// `permission` | `tool_start` | `tool_end`
+    pub event: String,
+    /// User/auto permission decision when `event == permission`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission: Option<String>,
+    /// `ok` | `err` when `event == tool_end`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+    /// Short redacted human summary (title / path / shell head).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+/// Directory `{app_data}/audit`.
+pub fn audit_dir() -> PathBuf {
+    let dir = crate::paths::app_data_root().join("audit");
+    let _ = fs::create_dir_all(&dir);
+    dir
+}
+
+/// Path `{app_data}/audit/tool_ledger.jsonl`.
+pub fn ledger_path() -> PathBuf {
+    audit_dir().join("tool_ledger.jsonl")
+}
+
+/// Normalize limit into a safe range.
+pub fn normalize_list_limit(raw: Option<u32>) -> usize {
+    match raw {
+        None => DEFAULT_LIST_LIMIT,
+        Some(n) => (n as usize).clamp(1, MAX_LIST_LIMIT),
+    }
+}
+
+/// Cap + scrub a free-form field. Soft-fail friendly (never panics).
+pub fn sanitize_field(raw: &str, max: usize) -> String {
+    let redacted = crate::store::redact_text(raw);
+    let cleaned: String = redacted
+        .chars()
+        .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let max = max.max(1);
+    if trimmed.chars().count() <= max {
+        return trimmed.to_string();
+    }
+    trimmed.chars().take(max).collect()
+}
+
+/// Map a terminal tool status string to ok/err (None when not terminal).
+pub fn outcome_from_tool_status(status: &str) -> Option<&'static str> {
+    let s = if status.is_empty() {
+        "in_progress"
+    } else {
+        status
+    };
+    let lower = s.to_ascii_lowercase();
+    match lower.as_str() {
+        "completed" | "complete" => Some(OUTCOME_OK),
+        "failed" | "error" | "cancelled" | "canceled" | "rejected" => Some(OUTCOME_ERR),
+        _ => None,
+    }
+}
+
+/// Build a sanitized entry (does not write).
+pub fn build_entry(
+    session_id: Option<&str>,
+    project_path: Option<&str>,
+    tool_name: &str,
+    event: &str,
+    permission: Option<&str>,
+    outcome: Option<&str>,
+    summary: Option<&str>,
+) -> AuditLedgerEntry {
+    let tool = sanitize_field(tool_name, MAX_FIELD_CHARS);
+    let tool = if tool.is_empty() {
+        "unknown".into()
+    } else {
+        tool
+    };
+    let event = match event {
+        EVENT_PERMISSION | EVENT_TOOL_START | EVENT_TOOL_END => event.to_string(),
+        other => sanitize_field(other, MAX_FIELD_CHARS),
+    };
+    let permission = permission
+        .map(|p| sanitize_field(p, MAX_FIELD_CHARS))
+        .filter(|s| !s.is_empty());
+    let outcome = outcome
+        .map(|o| sanitize_field(o, MAX_FIELD_CHARS))
+        .filter(|s| !s.is_empty());
+    let summary = summary
+        .map(|s| sanitize_field(s, MAX_SUMMARY_CHARS))
+        .filter(|s| !s.is_empty());
+    let session_id = session_id
+        .map(|s| sanitize_field(s, MAX_FIELD_CHARS))
+        .filter(|s| !s.is_empty());
+    let project_path = project_path
+        .map(|s| sanitize_field(s, 512))
+        .filter(|s| !s.is_empty());
+
+    AuditLedgerEntry {
+        ts: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        session_id,
+        project_path,
+        tool_name: tool,
+        event,
+        permission,
+        outcome,
+        summary,
+    }
+}
+
+/// Remember a pending UI permission so resolve can attribute tool_name.
+pub fn remember_permission(
+    session_id: &str,
+    rpc_id: u64,
+    tool_name: &str,
+    summary: Option<&str>,
+) {
+    let sid = session_id.trim();
+    if sid.is_empty() {
+        return;
+    }
+    let tool = sanitize_field(tool_name, MAX_FIELD_CHARS);
+    let sum = summary
+        .map(|s| sanitize_field(s, MAX_SUMMARY_CHARS))
+        .unwrap_or_default();
+    if let Ok(mut map) = PENDING_PERMS.lock() {
+        // Soft cap pending map so a stuck agent cannot grow unbounded.
+        if map.len() > 512 {
+            map.clear();
+        }
+        map.insert(
+            (sid.to_string(), rpc_id),
+            PendingPermission {
+                tool_name: if tool.is_empty() {
+                    "unknown".into()
+                } else {
+                    tool
+                },
+                summary: sum,
+            },
+        );
+    }
+}
+
+/// Take (and remove) a remembered permission context.
+fn take_permission(session_id: &str, rpc_id: u64) -> Option<PendingPermission> {
+    let Ok(mut map) = PENDING_PERMS.lock() else {
+        return None;
+    };
+    map.remove(&(session_id.to_string(), rpc_id))
+}
+
+/// Soft-fail append of one entry. Never panics; I/O errors are logged.
+pub fn append_entry(entry: &AuditLedgerEntry) {
+    let _guard = WRITE_LOCK.lock();
+    if let Err(e) = append_entry_locked(entry) {
+        tracing::warn!(target: "grok_app::audit_ledger", "append failed: {e}");
+    }
+}
+
+fn append_entry_locked(entry: &AuditLedgerEntry) -> Result<(), String> {
+    let path = ledger_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
+    }
+    let line = serde_json::to_string(entry).map_err(|e| format!("serialize: {e}"))?;
+    // Reject accidental secrets that slipped past sanitize (defense in depth).
+    let line = crate::store::redact_text(&line);
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| format!("open: {e}"))?;
+    file.write_all(line.as_bytes())
+        .map_err(|e| format!("write: {e}"))?;
+    file.write_all(b"\n").map_err(|e| format!("write nl: {e}"))?;
+    file.flush().map_err(|e| format!("flush: {e}"))?;
+
+    maybe_rotate_locked(&path)?;
+    Ok(())
+}
+
+/// Soft rotate: if file exceeds budget, keep the last ROTATE_KEEP_LINES lines.
+fn maybe_rotate_locked(path: &std::path::Path) -> Result<(), String> {
+    let meta = match fs::metadata(path) {
+        Ok(m) => m,
+        Err(_) => return Ok(()),
+    };
+    if meta.len() <= MAX_LEDGER_BYTES {
+        return Ok(());
+    }
+    let file = File::open(path).map_err(|e| format!("rotate open: {e}"))?;
+    let reader = BufReader::new(file);
+    let mut lines: Vec<String> = reader
+        .lines()
+        .filter_map(|r| r.ok())
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+    if lines.len() <= ROTATE_KEEP_LINES / 2 {
+        // File is huge with few lines (giant rows) — drop oldest half.
+        let keep = lines.len() / 2;
+        if keep == 0 {
+            let _ = fs::write(path, b"");
+            return Ok(());
+        }
+        lines = lines.split_off(lines.len() - keep);
+    } else {
+        let start = lines.len().saturating_sub(ROTATE_KEEP_LINES);
+        lines = lines.split_off(start);
+    }
+    let tmp = path.with_extension("jsonl.tmp");
+    {
+        let mut out = File::create(&tmp).map_err(|e| format!("rotate create: {e}"))?;
+        for l in &lines {
+            out.write_all(l.as_bytes())
+                .map_err(|e| format!("rotate write: {e}"))?;
+            out.write_all(b"\n")
+                .map_err(|e| format!("rotate write nl: {e}"))?;
+        }
+        out.flush().map_err(|e| format!("rotate flush: {e}"))?;
+    }
+    fs::rename(&tmp, path).map_err(|e| format!("rotate rename: {e}"))?;
+    tracing::info!(
+        target: "grok_app::audit_ledger",
+        kept = lines.len(),
+        "rotated tool ledger (size budget)"
+    );
+    Ok(())
+}
+
+/// Record a permission decision (user or auto). Soft-fail.
+pub fn record_permission(
+    session_id: Option<&str>,
+    project_path: Option<&str>,
+    tool_name: &str,
+    decision: &str,
+    summary: Option<&str>,
+) {
+    let entry = build_entry(
+        session_id,
+        project_path,
+        tool_name,
+        EVENT_PERMISSION,
+        Some(decision),
+        None,
+        summary,
+    );
+    append_entry(&entry);
+}
+
+/// Record permission using remembered UI context for `rpc_id` when available.
+pub fn record_permission_resolve(
+    session_id: Option<&str>,
+    project_path: Option<&str>,
+    rpc_id: u64,
+    decision: &str,
+) {
+    let pending = session_id.and_then(|sid| take_permission(sid, rpc_id));
+    let (tool_name, summary) = match pending {
+        Some(p) => (
+            p.tool_name,
+            if p.summary.is_empty() {
+                None
+            } else {
+                Some(p.summary)
+            },
+        ),
+        None => ("unknown".into(), None),
+    };
+    record_permission(
+        session_id,
+        project_path,
+        &tool_name,
+        decision,
+        summary.as_deref(),
+    );
+}
+
+/// Record tool start (non-terminal status, first open). Soft-fail.
+pub fn record_tool_start(
+    session_id: Option<&str>,
+    project_path: Option<&str>,
+    tool_name: &str,
+    summary: Option<&str>,
+) {
+    let entry = build_entry(
+        session_id,
+        project_path,
+        tool_name,
+        EVENT_TOOL_START,
+        None,
+        None,
+        summary,
+    );
+    append_entry(&entry);
+}
+
+/// Record tool end with ok/err outcome. Soft-fail.
+pub fn record_tool_end(
+    session_id: Option<&str>,
+    project_path: Option<&str>,
+    tool_name: &str,
+    outcome: &str,
+    summary: Option<&str>,
+) {
+    let entry = build_entry(
+        session_id,
+        project_path,
+        tool_name,
+        EVENT_TOOL_END,
+        None,
+        Some(outcome),
+        summary,
+    );
+    append_entry(&entry);
+}
+
+/// Parse one JSONL line into an entry (pure; used by list + tests).
+pub fn parse_entry_line(line: &str) -> Option<AuditLedgerEntry> {
+    let t = line.trim();
+    if t.is_empty() {
+        return None;
+    }
+    let v: serde_json::Value = serde_json::from_str(t).ok()?;
+    parse_entry_value(&v)
+}
+
+/// Normalize a JSON object into a safe entry (drops junk / secrets-ish fields).
+pub fn parse_entry_value(v: &serde_json::Value) -> Option<AuditLedgerEntry> {
+    let o = v.as_object()?;
+    let event = o
+        .get("event")
+        .and_then(|x| x.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+    // Only known events
+    if !matches!(
+        event.as_str(),
+        EVENT_PERMISSION | EVENT_TOOL_START | EVENT_TOOL_END
+    ) {
+        return None;
+    }
+    let tool_name = o
+        .get("toolName")
+        .or_else(|| o.get("tool_name"))
+        .and_then(|x| x.as_str())
+        .map(|s| sanitize_field(s, MAX_FIELD_CHARS))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into());
+    let ts = o
+        .get("ts")
+        .and_then(|x| x.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
+    let session_id = o
+        .get("sessionId")
+        .or_else(|| o.get("session_id"))
+        .and_then(|x| x.as_str())
+        .map(|s| sanitize_field(s, MAX_FIELD_CHARS))
+        .filter(|s| !s.is_empty());
+    let project_path = o
+        .get("projectPath")
+        .or_else(|| o.get("project_path"))
+        .and_then(|x| x.as_str())
+        .map(|s| sanitize_field(s, 512))
+        .filter(|s| !s.is_empty());
+    let permission = o
+        .get("permission")
+        .and_then(|x| x.as_str())
+        .map(|s| sanitize_field(s, MAX_FIELD_CHARS))
+        .filter(|s| !s.is_empty());
+    let outcome = o
+        .get("outcome")
+        .and_then(|x| x.as_str())
+        .map(|s| sanitize_field(s, MAX_FIELD_CHARS))
+        .filter(|s| !s.is_empty());
+    let summary = o
+        .get("summary")
+        .and_then(|x| x.as_str())
+        .map(|s| sanitize_field(s, MAX_SUMMARY_CHARS))
+        .filter(|s| !s.is_empty());
+
+    Some(AuditLedgerEntry {
+        ts,
+        session_id,
+        project_path,
+        tool_name,
+        event,
+        permission,
+        outcome,
+        summary,
+    })
+}
+
+/// Read recent entries (newest first). Soft-fail → empty vec.
+pub fn list_recent(limit: Option<u32>) -> Vec<AuditLedgerEntry> {
+    let lim = normalize_list_limit(limit);
+    let _guard = WRITE_LOCK.lock();
+    match list_recent_locked(lim) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(target: "grok_app::audit_ledger", "list failed: {e}");
+            Vec::new()
+        }
+    }
+}
+
+fn list_recent_locked(limit: usize) -> Result<Vec<AuditLedgerEntry>, String> {
+    let path = ledger_path();
+    if !path.is_file() {
+        return Ok(Vec::new());
+    }
+    let file = File::open(&path).map_err(|e| format!("open: {e}"))?;
+    let reader = BufReader::new(file);
+    let mut entries: Vec<AuditLedgerEntry> = Vec::new();
+    for line in reader.lines() {
+        let Ok(line) = line else { continue };
+        if let Some(e) = parse_entry_line(&line) {
+            entries.push(e);
+        }
+    }
+    // Newest first
+    entries.reverse();
+    if entries.len() > limit {
+        entries.truncate(limit);
+    }
+    Ok(entries)
+}
+
+/// Clear the ledger file. Soft-fail → Err string for UI toast.
+pub fn clear_ledger() -> Result<(), String> {
+    let _guard = WRITE_LOCK.lock();
+    let path = ledger_path();
+    if path.is_file() {
+        fs::write(&path, b"").map_err(|e| format!("clear: {e}"))?;
+    }
+    if let Ok(mut map) = PENDING_PERMS.lock() {
+        map.clear();
+    }
+    Ok(())
+}
+
+/// Export redacted JSONL text (newest first optional — keeps file order chronological).
+/// Soft-fail → empty string.
+pub fn export_redacted_jsonl() -> String {
+    let _guard = WRITE_LOCK.lock();
+    let path = ledger_path();
+    if !path.is_file() {
+        return String::new();
+    }
+    match fs::read_to_string(&path) {
+        Ok(raw) => {
+            // Re-parse each line so free-form junk / secrets cannot leave.
+            let mut out = String::new();
+            for line in raw.lines() {
+                if let Some(e) = parse_entry_line(line) {
+                    if let Ok(s) = serde_json::to_string(&e) {
+                        out.push_str(&crate::store::redact_text(&s));
+                        out.push('\n');
+                    }
+                }
+            }
+            out
+        }
+        Err(e) => {
+            tracing::warn!(target: "grok_app::audit_ledger", "export read failed: {e}");
+            String::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::APP_HOME_ENV_LOCK;
+    use std::sync::Mutex;
+
+    fn with_temp_home<F: FnOnce(PathBuf)>(f: F) {
+        let _env = APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Serialize tests that touch the ledger path.
+        static TEST_LOCK: Mutex<()> = Mutex::new(());
+        let _t = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let dir = std::env::temp_dir().join(format!(
+            "grok-audit-test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("GROK_APP_HOME", &dir);
+        f(dir.clone());
+        let _ = fs::remove_dir_all(&dir);
+        std::env::remove_var("GROK_APP_HOME");
+    }
+
+    #[test]
+    fn sanitize_redacts_and_caps() {
+        let s = sanitize_field(
+            &format!("path /tmp/x sk-abcdefghijklmnopqrstuvwxyz012345 {}", "y".repeat(300)),
+            MAX_SUMMARY_CHARS,
+        );
+        assert!(!s.contains("sk-abcdefghijklmnopqrstuvwxyz012345"));
+        assert!(s.chars().count() <= MAX_SUMMARY_CHARS);
+    }
+
+    #[test]
+    fn outcome_maps_terminal_statuses() {
+        assert_eq!(outcome_from_tool_status("completed"), Some(OUTCOME_OK));
+        assert_eq!(outcome_from_tool_status("failed"), Some(OUTCOME_ERR));
+        assert_eq!(outcome_from_tool_status("error"), Some(OUTCOME_ERR));
+        assert_eq!(outcome_from_tool_status("in_progress"), None);
+        assert_eq!(outcome_from_tool_status(""), None);
+    }
+
+    #[test]
+    fn parse_entry_line_accepts_camel_case() {
+        let line = r#"{"ts":"2026-01-01T00:00:00.000Z","sessionId":"s1","toolName":"bash","event":"tool_end","outcome":"ok","summary":"ls"}"#;
+        let e = parse_entry_line(line).expect("parse");
+        assert_eq!(e.session_id.as_deref(), Some("s1"));
+        assert_eq!(e.tool_name, "bash");
+        assert_eq!(e.event, EVENT_TOOL_END);
+        assert_eq!(e.outcome.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn parse_rejects_unknown_event() {
+        let line = r#"{"ts":"t","toolName":"x","event":"hack"}"#;
+        assert!(parse_entry_line(line).is_none());
+    }
+
+    #[test]
+    fn append_list_clear_roundtrip() {
+        with_temp_home(|_home| {
+            record_permission(
+                Some("sess-a"),
+                Some("/proj"),
+                "read_file",
+                "allow_once",
+                Some("src/main.rs"),
+            );
+            record_tool_start(Some("sess-a"), Some("/proj"), "bash", Some("echo hi"));
+            record_tool_end(
+                Some("sess-a"),
+                Some("/proj"),
+                "bash",
+                OUTCOME_OK,
+                Some("echo hi"),
+            );
+
+            let listed = list_recent(Some(10));
+            assert_eq!(listed.len(), 3);
+            // Newest first
+            assert_eq!(listed[0].event, EVENT_TOOL_END);
+            assert_eq!(listed[1].event, EVENT_TOOL_START);
+            assert_eq!(listed[2].event, EVENT_PERMISSION);
+            assert_eq!(listed[2].permission.as_deref(), Some("allow_once"));
+
+            let export = export_redacted_jsonl();
+            assert!(export.lines().count() >= 3);
+
+            clear_ledger().unwrap();
+            assert!(list_recent(None).is_empty());
+            assert!(export_redacted_jsonl().is_empty());
+        });
+    }
+
+    #[test]
+    fn remember_and_resolve_permission_context() {
+        with_temp_home(|_home| {
+            remember_permission("sid", 42, "write_file", Some("notes.md"));
+            record_permission_resolve(Some("sid"), Some("/p"), 42, "deny");
+            let listed = list_recent(Some(5));
+            assert_eq!(listed.len(), 1);
+            assert_eq!(listed[0].tool_name, "write_file");
+            assert_eq!(listed[0].permission.as_deref(), Some("deny"));
+            assert_eq!(listed[0].summary.as_deref(), Some("notes.md"));
+        });
+    }
+
+    #[test]
+    fn normalize_limit_clamps() {
+        assert_eq!(normalize_list_limit(None), DEFAULT_LIST_LIMIT);
+        assert_eq!(normalize_list_limit(Some(0)), 1);
+        assert_eq!(normalize_list_limit(Some(50)), 50);
+        assert_eq!(
+            normalize_list_limit(Some(99_999)),
+            MAX_LIST_LIMIT
+        );
+    }
+}

--- a/src-tauri/src/audit_ledger.rs
+++ b/src-tauri/src/audit_ledger.rs
@@ -7,7 +7,7 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 use parking_lot::Mutex as ParkingMutex;
 use serde::{Deserialize, Serialize};
@@ -42,8 +42,8 @@ struct PendingPermission {
     summary: String,
 }
 
-static PENDING_PERMS: Mutex<std::collections::HashMap<(String, u64), PendingPermission>> =
-    Mutex::new(std::collections::HashMap::new());
+static PENDING_PERMS: LazyLock<Mutex<std::collections::HashMap<(String, u64), PendingPermission>>> =
+    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
 
 /// One append-only ledger row (camelCase for the UI).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9902,3 +9902,57 @@ pub async fn streaming_messages_json_probe(
     .map_err(|e| format!("streaming_messages_json_probe: {e}"))
 }
 
+// ─── Tool / permission audit ledger ─────────────────────────────────────────
+
+/// Recent cross-session tool/permission audit rows (newest first). Soft-fail → [].
+#[tauri::command]
+pub async fn audit_ledger_list(
+    limit: Option<u32>,
+) -> Result<Vec<crate::audit_ledger::AuditLedgerEntry>, String> {
+    Ok(tauri::async_runtime::spawn_blocking(move || {
+        crate::audit_ledger::list_recent(limit)
+    })
+    .await
+    .map_err(|e| format!("audit_ledger_list: {e}"))?)
+}
+
+/// Clear the on-disk audit ledger (`{app_data}/audit/tool_ledger.jsonl`).
+#[tauri::command]
+pub async fn audit_ledger_clear() -> Result<serde_json::Value, String> {
+    tauri::async_runtime::spawn_blocking(|| crate::audit_ledger::clear_ledger())
+        .await
+        .map_err(|e| format!("audit_ledger_clear: {e}"))??;
+    Ok(serde_json::json!({ "ok": true }))
+}
+
+/// Export redacted JSONL via native save dialog.
+#[tauri::command]
+pub async fn audit_ledger_export() -> Result<serde_json::Value, String> {
+    let text = tauri::async_runtime::spawn_blocking(crate::audit_ledger::export_redacted_jsonl)
+        .await
+        .map_err(|e| format!("audit_ledger_export: {e}"))?;
+    if text.trim().is_empty() {
+        return Err("audit ledger is empty".into());
+    }
+    let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
+    let name = format!("grok-app-audit-ledger-{stamp}.jsonl");
+    let tmp_dir = std::env::temp_dir();
+    let tmp = tmp_dir.join(&name);
+    tauri::async_runtime::spawn_blocking({
+        let tmp = tmp.clone();
+        let text = text.clone();
+        move || std::fs::write(&tmp, text).map_err(|e| format!("write temp: {e}"))
+    })
+    .await
+    .map_err(|e| format!("audit_ledger_export: {e}"))??;
+
+    save_and_reveal_file(
+        tmp,
+        "Export audit ledger",
+        &name,
+        "JSONL",
+        &["jsonl", "json", "txt"],
+    )
+    .await
+}
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ mod process_util;
 mod process_limits;
 mod proxy;
 mod journal_throttle;
+mod audit_ledger;
 mod logging;
 mod stream_emit;
 mod stream_stall;
@@ -400,6 +401,9 @@ pub fn run() {
             commands::agents_recycle_all,
             commands::cli_doctor_fix,
             commands::export_support_bundle,
+            commands::audit_ledger_list,
+            commands::audit_ledger_clear,
+            commands::audit_ledger_export,
             commands::export_session_bundle,
             commands::session_cli_export,
             commands::export_bytes_save,

--- a/src-tauri/src/session_manager.rs
+++ b/src-tauri/src/session_manager.rs
@@ -56,7 +56,8 @@ use crate::stream_stall::{
     stall_tier_from_evidence, stream_stall_message, StallTier,
 };
 use crate::turn_complete::{
-    note_tool_open_status, release_tool_from_open, should_defer_prompt_complete,
+    is_terminal_tool_status, note_tool_open_status, release_tool_from_open,
+    should_defer_prompt_complete,
 };
 
 /// Outcome of one stall-watchdog pass on a single live/background session.
@@ -731,7 +732,8 @@ impl SessionManager {
     }
 
     /// Apply tool_call status to open/terminal sets (live + background paths).
-    fn note_tool_status_on_session(s: &mut LiveSession, tool_call_id: &str, status: &str) {
+    /// Returns true when open-set membership changed (insert or remove).
+    fn note_tool_status_on_session(s: &mut LiveSession, tool_call_id: &str, status: &str) -> bool {
         note_tool_open_status(
             &mut s.open_tool_ids,
             &mut s.terminal_tool_ids,
@@ -739,7 +741,44 @@ impl SessionManager {
             tool_call_id,
             status,
             Instant::now(),
-        );
+        )
+    }
+
+    /// Soft-fail audit row for a tool_call start/end (never panics).
+    fn audit_tool_call(
+        session_id: &str,
+        project_path: Option<&str>,
+        tool_name: &str,
+        status: &str,
+        summary: Option<&str>,
+        open_changed: bool,
+        already_terminal: bool,
+    ) {
+        if tool_name.is_empty() && summary.is_none() {
+            // Still record with "unknown" when we have a real lifecycle edge.
+        }
+        let name = if tool_name.is_empty() { "tool" } else { tool_name };
+        if is_terminal_tool_status(status) {
+            if already_terminal {
+                return;
+            }
+            let outcome = crate::audit_ledger::outcome_from_tool_status(status)
+                .unwrap_or(crate::audit_ledger::OUTCOME_ERR);
+            crate::audit_ledger::record_tool_end(
+                Some(session_id),
+                project_path,
+                name,
+                outcome,
+                summary,
+            );
+        } else if open_changed {
+            crate::audit_ledger::record_tool_start(
+                Some(session_id),
+                project_path,
+                name,
+                summary,
+            );
+        }
     }
 
     /// Release open-tool accounting for background tasks (no journal write).
@@ -3419,7 +3458,6 @@ impl SessionManager {
                         return;
                     }
                 };
-                let _ = project_path; // reserved for future UI badge
                 if auto {
                     let acp = self.inner.lock().as_ref().and_then(|s| s.acp.clone());
                     if let Some(acp) = acp {
@@ -3438,6 +3476,13 @@ impl SessionManager {
                                 PermissionOutcome::Selected { option_id },
                             )
                             .await;
+                        crate::audit_ledger::record_permission(
+                            Some(&session_id),
+                            project_path.as_deref(),
+                            &tool_name,
+                            "auto_allow",
+                            Some(&title),
+                        );
                         let empty = {
                             let mut guard = self.inner.lock();
                             if let Some(s) = guard.as_mut() {
@@ -3465,6 +3510,13 @@ impl SessionManager {
                                 PermissionOutcome::Selected { option_id },
                             )
                             .await;
+                        crate::audit_ledger::record_permission(
+                            Some(&session_id),
+                            project_path.as_deref(),
+                            &tool_name,
+                            "auto_deny",
+                            Some(&title),
+                        );
                         let empty = {
                             let mut guard = self.inner.lock();
                             if let Some(s) = guard.as_mut() {
@@ -3479,6 +3531,12 @@ impl SessionManager {
                         Self::emit_empty_run_if_any(app, empty);
                     }
                 } else {
+                    crate::audit_ledger::remember_permission(
+                        &session_id,
+                        rpc_id,
+                        &tool_name,
+                        Some(&title),
+                    );
                     let req = UiPermissionRequest {
                         rpc_id,
                         session_id,
@@ -3574,20 +3632,30 @@ impl SessionManager {
                     }
                 }
 
-                let (app_sid, empty_run) = {
+                let (app_sid, project_path, empty_run, open_changed, already_terminal) = {
                     let mut guard = self.inner.lock();
                     if let Some(s) = guard.as_mut() {
                         // Tool events count as progress so long tools never false-stall (I06).
                         Self::touch_stream_progress_locked(s);
-                        if !tool_call_id.is_empty() {
-                            Self::note_tool_status_on_session(s, &tool_call_id, &status);
-                        }
+                        let already_terminal = !tool_call_id.is_empty()
+                            && s.terminal_tool_ids.contains(&tool_call_id);
+                        let open_changed = if !tool_call_id.is_empty() {
+                            Self::note_tool_status_on_session(s, &tool_call_id, &status)
+                        } else {
+                            false
+                        };
                         s.tools_this_turn = s.tools_this_turn.saturating_add(1);
                         // Tools settled → apply deferred prompt_complete if any (#52).
                         let empty = Self::try_finish_deferred_prompt_complete(s).flatten();
-                        (s.app_session_id.clone(), empty)
+                        (
+                            s.app_session_id.clone(),
+                            s.project_path.clone(),
+                            empty,
+                            open_changed,
+                            already_terminal,
+                        )
                     } else {
-                        (String::new(), None)
+                        (String::new(), None, None, false, false)
                     }
                 };
                 Self::emit_empty_run_if_any(app, empty_run);
@@ -3604,6 +3672,30 @@ impl SessionManager {
                 } else {
                     String::new()
                 };
+                // Cross-session tool audit (soft-fail; redacted summary).
+                if !app_sid.is_empty() {
+                    let audit_name = if !kind.is_empty() {
+                        kind.as_str()
+                    } else if !title.is_empty() {
+                        title.as_str()
+                    } else {
+                        "tool"
+                    };
+                    let audit_summary = if !live_title.is_empty() {
+                        Some(live_title.as_str())
+                    } else {
+                        detail.as_deref().or(path_out.as_deref())
+                    };
+                    Self::audit_tool_call(
+                        &app_sid,
+                        project_path.as_deref(),
+                        audit_name,
+                        &status,
+                        audit_summary,
+                        open_changed,
+                        already_terminal,
+                    );
+                }
                 let _ = app.emit(
                     "session://tool",
                     serde_json::json!({
@@ -4268,7 +4360,6 @@ impl SessionManager {
                         return;
                     }
                 };
-                let _ = project_path;
                 if auto {
                     if let Some(acp) = acp {
                         let option_id = pick_option_id(&options, "allow_once")
@@ -4280,6 +4371,13 @@ impl SessionManager {
                                 PermissionOutcome::Selected { option_id },
                             )
                             .await;
+                        crate::audit_ledger::record_permission(
+                            Some(&session_id),
+                            project_path.as_deref(),
+                            &tool_name,
+                            "auto_allow",
+                            Some(&title),
+                        );
                         let mut bg = self.background.lock();
                         if let Some(s) = bg.get_mut(app_session_id) {
                             if s.fsm.state() == SessionState::AwaitingPermission {
@@ -4298,6 +4396,13 @@ impl SessionManager {
                                 PermissionOutcome::Selected { option_id },
                             )
                             .await;
+                        crate::audit_ledger::record_permission(
+                            Some(&session_id),
+                            project_path.as_deref(),
+                            &tool_name,
+                            "auto_deny",
+                            Some(&title),
+                        );
                         let mut bg = self.background.lock();
                         if let Some(s) = bg.get_mut(app_session_id) {
                             if s.fsm.state() == SessionState::AwaitingPermission {
@@ -4306,6 +4411,12 @@ impl SessionManager {
                         }
                     }
                 } else {
+                    crate::audit_ledger::remember_permission(
+                        &session_id,
+                        rpc_id,
+                        &tool_name,
+                        Some(&title),
+                    );
                     let req = UiPermissionRequest {
                         rpc_id,
                         session_id: session_id.clone(),
@@ -4342,7 +4453,7 @@ impl SessionManager {
                 status,
                 raw: _,
             } => {
-                let (app_sid, live_title, st, finished) = {
+                let (app_sid, project_path, live_title, st, finished, open_changed, already_terminal) = {
                     let mut bg = self.background.lock();
                     if let Some(s) = bg.get_mut(app_session_id) {
                         // Defensive: background turns never load-replay, but if
@@ -4355,9 +4466,13 @@ impl SessionManager {
                             return;
                         }
                         Self::touch_stream_progress_locked(s);
-                        if !tool_call_id.is_empty() {
-                            Self::note_tool_status_on_session(s, &tool_call_id, &status);
-                        }
+                        let already_terminal = !tool_call_id.is_empty()
+                            && s.terminal_tool_ids.contains(&tool_call_id);
+                        let open_changed = if !tool_call_id.is_empty() {
+                            Self::note_tool_status_on_session(s, &tool_call_id, &status)
+                        } else {
+                            false
+                        };
                         s.tools_this_turn = s.tools_this_turn.saturating_add(1);
                         let finished =
                             matches!(Self::try_finish_deferred_prompt_complete(s), Some(_));
@@ -4403,11 +4518,36 @@ impl SessionManager {
                                 );
                             }
                         }
-                        (s.app_session_id.clone(), live_title, st, finished)
+                        (
+                            s.app_session_id.clone(),
+                            s.project_path.clone(),
+                            live_title,
+                            st,
+                            finished,
+                            open_changed,
+                            already_terminal,
+                        )
                     } else {
                         return;
                     }
                 };
+                // Cross-session tool audit (background turn).
+                {
+                    let audit_name = if !kind.is_empty() {
+                        kind.as_str()
+                    } else {
+                        live_title.as_str()
+                    };
+                    Self::audit_tool_call(
+                        &app_sid,
+                        project_path.as_deref(),
+                        audit_name,
+                        &status,
+                        Some(live_title.as_str()),
+                        open_changed,
+                        already_terminal,
+                    );
+                }
                 let _ = app.emit(
                     "session://tool",
                     serde_json::json!({
@@ -5616,7 +5756,7 @@ impl SessionManager {
         session_id: Option<String>,
     ) -> Result<SessionSnapshot, String> {
         let target = self.resolve_target_session(session_id)?;
-        let (acp, empty_run) = self
+        let (acp, empty_run, project_path) = self
             .with_session_mut(&target, |s| {
                 Self::touch_activity_locked(s);
                 // "allow_session" decision caches scope_key for H05 (works under Ask chip too)
@@ -5630,7 +5770,7 @@ impl SessionManager {
                 }
                 // Permission cleared — may finish a deferred prompt_complete (#52).
                 let empty = Self::try_finish_deferred_prompt_complete(s).flatten();
-                (s.acp.clone(), empty)
+                (s.acp.clone(), empty, s.project_path.clone())
             })
             .ok_or("no session")?;
 
@@ -5647,6 +5787,13 @@ impl SessionManager {
             };
             acp.respond_permission(rpc_id, outcome).await?;
         }
+        // Cross-session permission audit (user decision). Soft-fail.
+        crate::audit_ledger::record_permission_resolve(
+            Some(&target),
+            project_path.as_deref(),
+            rpc_id,
+            &decision,
+        );
         self.emit_for_session(&app, &target);
         Self::emit_empty_run_if_any(&app, empty_run);
         Ok(self.snapshot())

--- a/src/components/ReliabilityCenterModal.tsx
+++ b/src/components/ReliabilityCenterModal.tsx
@@ -1,8 +1,9 @@
 /**
  * Reliability / Observability center — aggregate long-task signals:
  * busy sessions, stall / end-of-turn stalls, recent error-deck cards,
- * plus a persisted stall timeline (localStorage ring).
- * Actions: export support bundle, open Doctor, clear stall history.
+ * a persisted stall timeline (localStorage ring), and the cross-session
+ * tool/permission audit ledger (host JSONL).
+ * Actions: export support bundle, open Doctor, clear stall/audit, export audit.
  * No secrets from logs.
  */
 
@@ -16,6 +17,13 @@ import {
 } from "@/components/icons";
 import { createT, type Locale, type MessageKey } from "@/i18n";
 import * as api from "@/lib/api";
+import {
+  auditLedgerEventKey,
+  filterAuditLedger,
+  parseAuditLedgerList,
+  type AuditLedgerEntry,
+  type AuditLedgerEvent,
+} from "@/lib/auditLedger";
 import {
   buildStallTimelineSnapshot,
   clearStallHistory,
@@ -206,6 +214,62 @@ function ErrorRow({
   );
 }
 
+type AuditEventFilter = "all" | AuditLedgerEvent;
+
+function auditDotClass(event: AuditLedgerEvent): string {
+  if (event === "permission") return " reliab-card__dot--warn";
+  if (event === "tool_end") return " reliab-card__dot--busy";
+  return "";
+}
+
+function AuditRow({
+  entry,
+  t,
+  locale,
+}: {
+  entry: AuditLedgerEntry;
+  t: ReturnType<typeof createT>;
+  locale: Locale;
+}) {
+  const when = formatWhen(Date.parse(entry.ts) || 0, locale);
+  const meta = [
+    entry.permission,
+    entry.outcome,
+    when,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  return (
+    <li className="reliab-card__row" data-testid="reliab-audit-row">
+      <div className="reliab-card__row-main">
+        <span
+          className={"reliab-card__dot" + auditDotClass(entry.event)}
+          aria-hidden
+        />
+        <span className="reliab-card__name" title={entry.toolName}>
+          {entry.toolName}
+        </span>
+        <span className="reliab-card__meta">{t(auditLedgerEventKey(entry.event))}</span>
+      </div>
+      {entry.summary ? (
+        <div className="reliab-card__sub" title={entry.summary}>
+          {entry.summary}
+        </div>
+      ) : null}
+      <div className="reliab-card__sub reliab-card__sub--muted">
+        {[
+          entry.sessionId
+            ? entry.sessionId.slice(0, 8)
+            : t("reliability.audit.unknownSession"),
+          meta,
+        ]
+          .filter(Boolean)
+          .join(" · ")}
+      </div>
+    </li>
+  );
+}
+
 export function ReliabilityCenterModal({
   open,
   onClose,
@@ -215,7 +279,9 @@ export function ReliabilityCenterModal({
   onSelectSession,
 }: ReliabilityCenterModalProps) {
   const t = useMemo(() => createT(locale), [locale]);
-  const [busy, setBusy] = useState<"zip" | null>(null);
+  const [busy, setBusy] = useState<"zip" | "audit-export" | "audit-clear" | null>(
+    null,
+  );
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
@@ -226,6 +292,25 @@ export function ReliabilityCenterModal({
   const [historyKind, setHistoryKind] = useState<StallKindFilter>("all");
   const [confirmClearHistory, setConfirmClearHistory] = useState(false);
 
+  const [auditEntries, setAuditEntries] = useState<AuditLedgerEntry[]>([]);
+  const [auditQuery, setAuditQuery] = useState("");
+  const [auditEvent, setAuditEvent] = useState<AuditEventFilter>("all");
+  const [confirmClearAudit, setConfirmClearAudit] = useState(false);
+  const [auditLoading, setAuditLoading] = useState(false);
+
+  const loadAudit = useCallback(async () => {
+    setAuditLoading(true);
+    try {
+      const raw = await api.auditLedgerList(200);
+      setAuditEntries(parseAuditLedgerList(raw, 200));
+    } catch {
+      setErrorMsg(t("reliability.audit.loadFail"));
+      setAuditEntries([]);
+    } finally {
+      setAuditLoading(false);
+    }
+  }, [t]);
+
   useEffect(() => {
     if (!open) return;
     setStatusMsg(null);
@@ -235,7 +320,11 @@ export function ReliabilityCenterModal({
     setHistoryKind("all");
     setConfirmClearHistory(false);
     setStallHistory(loadStallHistory());
-  }, [open]);
+    setAuditQuery("");
+    setAuditEvent("all");
+    setConfirmClearAudit(false);
+    void loadAudit();
+  }, [open, loadAudit]);
 
   useEffect(() => {
     if (!open) return;
@@ -260,12 +349,16 @@ export function ReliabilityCenterModal({
           setConfirmClearHistory(false);
           return;
         }
+        if (confirmClearAudit) {
+          setConfirmClearAudit(false);
+          return;
+        }
         onClose();
       }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose, confirmClearHistory]);
+  }, [open, onClose, confirmClearHistory, confirmClearAudit]);
 
   const filteredHistory = useMemo(
     () =>
@@ -274,6 +367,15 @@ export function ReliabilityCenterModal({
         kind: historyKind,
       }),
     [stallHistory, historyQuery, historyKind],
+  );
+
+  const filteredAudit = useMemo(
+    () =>
+      filterAuditLedger(auditEntries, {
+        query: auditQuery,
+        event: auditEvent,
+      }),
+    [auditEntries, auditQuery, auditEvent],
   );
 
   const onSupportZip = useCallback(async () => {
@@ -299,6 +401,40 @@ export function ReliabilityCenterModal({
     setConfirmClearHistory(false);
   }, []);
 
+  const doClearAudit = useCallback(async () => {
+    setBusy("audit-clear");
+    setStatusMsg(null);
+    setErrorMsg(null);
+    try {
+      await api.auditLedgerClear();
+      setAuditEntries([]);
+      setConfirmClearAudit(false);
+      setStatusMsg(t("reliability.audit.clearDone"));
+    } catch (e) {
+      setErrorMsg(`${t("reliability.audit.clearFail")}: ${String(e)}`);
+    } finally {
+      setBusy(null);
+    }
+  }, [t]);
+
+  const onExportAudit = useCallback(async () => {
+    setBusy("audit-export");
+    setStatusMsg(null);
+    setErrorMsg(null);
+    try {
+      const res = await api.auditLedgerExport();
+      setStatusMsg(
+        t("reliability.audit.exportDone", {
+          path: res.path ?? "",
+        }),
+      );
+    } catch (e) {
+      setErrorMsg(`${t("reliability.audit.exportFail")}: ${String(e)}`);
+    } finally {
+      setBusy(null);
+    }
+  }, [t]);
+
   const openDoctor = () => {
     onClose();
     onOpenDoctor();
@@ -312,6 +448,22 @@ export function ReliabilityCenterModal({
     { id: "hard_end", label: t("reliability.stall.kind.hardEnd") },
     { id: "terminal", label: t("reliability.stall.kind.terminal") },
     { id: "end_of_turn", label: t("reliability.stall.kind.endOfTurn") },
+  ];
+
+  const auditChips: { id: AuditEventFilter; label: string }[] = [
+    { id: "all", label: t("reliability.audit.filterAll") },
+    {
+      id: "permission",
+      label: t("reliability.audit.event.permission"),
+    },
+    {
+      id: "tool_start",
+      label: t("reliability.audit.event.toolStart"),
+    },
+    {
+      id: "tool_end",
+      label: t("reliability.audit.event.toolEnd"),
+    },
   ];
 
   const clearConfirmPortal =
@@ -374,6 +526,65 @@ export function ReliabilityCenterModal({
       document.body,
     );
 
+  const clearAuditPortal =
+    confirmClearAudit &&
+    typeof document !== "undefined" &&
+    createPortal(
+      <div
+        className="overlay app-dialog-overlay"
+        role="presentation"
+        onMouseDown={(e) => {
+          if (e.target === e.currentTarget) setConfirmClearAudit(false);
+        }}
+      >
+        <div
+          className="modal app-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="reliab-audit-clear-title"
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <header className="modal-head">
+            <h2 id="reliab-audit-clear-title" className="modal-title">
+              {t("reliability.audit.clearConfirmTitle")}
+            </h2>
+            <button
+              type="button"
+              className="icon-btn modal-close"
+              onClick={() => setConfirmClearAudit(false)}
+              aria-label={t("common.cancel")}
+            >
+              <IconClose size={16} />
+            </button>
+          </header>
+          <div className="app-dialog__form">
+            <p className="app-dialog__msg">
+              {t("reliability.audit.clearConfirmMessage")}
+            </p>
+            <div className="app-dialog__actions modal-actions">
+              <button
+                type="button"
+                className="btn btn--ghost"
+                onClick={() => setConfirmClearAudit(false)}
+              >
+                {t("common.cancel")}
+              </button>
+              <button
+                type="button"
+                className="btn btn--danger"
+                disabled={busy === "audit-clear"}
+                onClick={() => void doClearAudit()}
+                data-testid="reliab-audit-clear-confirm"
+              >
+                {t("reliability.audit.clearConfirmAction")}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>,
+      document.body,
+    );
+
   return (
     <div
       className="overlay doctor-modal-overlay reliab-modal-overlay"
@@ -420,7 +631,9 @@ export function ReliabilityCenterModal({
         )}
 
         <div className="doctor-modal__body reliab-modal__body">
-          {view.empty && stallHistory.length === 0 ? (
+          {view.empty &&
+          stallHistory.length === 0 &&
+          auditEntries.length === 0 ? (
             <div className="reliab-empty" role="status">
               <IconAlertTriangle size={20} className="reliab-empty__icon" />
               <p className="reliab-empty__title">{t("reliability.empty.title")}</p>
@@ -576,6 +789,114 @@ export function ReliabilityCenterModal({
               <p className="reliab-card__empty">{t("reliability.errors.empty")}</p>
             )}
           </section>
+
+          <section
+            className="reliab-card"
+            aria-labelledby="reliab-audit-title"
+            data-testid="reliab-audit-section"
+          >
+            <header className="reliab-card__head">
+              <h3 id="reliab-audit-title" className="reliab-card__title">
+                {t("reliability.audit.title")}
+              </h3>
+              <span className="reliab-card__count">
+                {t("reliability.audit.count", {
+                  count: auditEntries.length,
+                })}
+              </span>
+            </header>
+            <p className="reliab-card__empty" style={{ marginBottom: 8 }}>
+              {t("reliability.audit.lead")}
+            </p>
+
+            <div className="reliab-timeline__toolbar">
+              <label className="reliab-timeline__search">
+                <span className="sr-only">
+                  {t("reliability.audit.searchPlaceholder")}
+                </span>
+                <input
+                  type="search"
+                  className="reliab-timeline__search-input"
+                  value={auditQuery}
+                  onChange={(e) => setAuditQuery(e.target.value)}
+                  placeholder={t("reliability.audit.searchPlaceholder")}
+                  autoComplete="off"
+                  data-testid="reliab-audit-search"
+                />
+              </label>
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                disabled={!!busy || auditLoading}
+                onClick={() => void loadAudit()}
+                data-testid="reliab-audit-refresh"
+              >
+                {auditLoading ? "…" : t("reliability.audit.refresh")}
+              </button>
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                disabled={!!busy || auditEntries.length === 0}
+                onClick={() => void onExportAudit()}
+                data-testid="reliab-audit-export"
+              >
+                {busy === "audit-export" ? "…" : t("reliability.audit.export")}
+              </button>
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                disabled={!!busy || auditEntries.length === 0}
+                onClick={() => setConfirmClearAudit(true)}
+                data-testid="reliab-audit-clear"
+              >
+                {t("reliability.audit.clear")}
+              </button>
+            </div>
+
+            <div
+              className="reliab-timeline__chips settings-seg"
+              role="tablist"
+              aria-label={t("reliability.audit.filterAria")}
+            >
+              {auditChips.map((c) => (
+                <button
+                  key={c.id}
+                  type="button"
+                  role="tab"
+                  className={
+                    "settings-seg__btn reliab-timeline__chip" +
+                    (auditEvent === c.id ? " is-on" : "")
+                  }
+                  aria-selected={auditEvent === c.id}
+                  data-testid={`reliab-audit-filter-${c.id}`}
+                  onClick={() => setAuditEvent(c.id)}
+                >
+                  {c.label}
+                </button>
+              ))}
+            </div>
+
+            {auditEntries.length === 0 ? (
+              <p className="reliab-card__empty">
+                {t("reliability.audit.empty")}
+              </p>
+            ) : filteredAudit.length === 0 ? (
+              <p className="reliab-card__empty">
+                {t("reliability.audit.emptyFilter")}
+              </p>
+            ) : (
+              <ul className="reliab-card__list">
+                {filteredAudit.map((e, i) => (
+                  <AuditRow
+                    key={`${e.ts}-${e.event}-${e.toolName}-${i}`}
+                    entry={e}
+                    t={t}
+                    locale={locale}
+                  />
+                ))}
+              </ul>
+            )}
+          </section>
         </div>
 
         <footer className="doctor-modal__foot reliab-modal__foot">
@@ -607,6 +928,7 @@ export function ReliabilityCenterModal({
         </footer>
       </div>
       {clearConfirmPortal}
+      {clearAuditPortal}
     </div>
   );
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2597,9 +2597,38 @@ const en = {
   "reliability.openDoctor": "Open Doctor",
   "reliability.openFromSettings": "Open reliability center",
   "reliability.settingsDesc":
-    "Aggregate busy chats, stall signals, and recent error cards; export support zip.",
+    "Aggregate busy chats, stall signals, recent error cards, and the tool audit ledger; export support zip.",
   "reliability.supportZipHint":
     "Redacted Doctor report, recent logs, and stall timeline snapshot (no secrets).",
+
+  // Cross-session tool / permission audit ledger
+  "reliability.audit.title": "Tool audit ledger",
+  "reliability.audit.count": "{count}",
+  "reliability.audit.empty": "No audit entries yet.",
+  "reliability.audit.emptyFilter": "No entries match this filter.",
+  "reliability.audit.lead":
+    "Cross-session permission decisions and tool start/end (redacted). Stored under app data as append-only JSONL.",
+  "reliability.audit.searchPlaceholder": "Search tool, summary, session…",
+  "reliability.audit.filterAria": "Filter audit ledger by event",
+  "reliability.audit.filterAll": "All",
+  "reliability.audit.event.permission": "Permission",
+  "reliability.audit.event.toolStart": "Tool start",
+  "reliability.audit.event.toolEnd": "Tool end",
+  "reliability.audit.refresh": "Refresh",
+  "reliability.audit.clear": "Clear ledger",
+  "reliability.audit.clearConfirmTitle": "Clear tool audit ledger?",
+  "reliability.audit.clearConfirmMessage":
+    "This permanently deletes the on-disk audit JSONL on this device. You cannot undo this.",
+  "reliability.audit.clearConfirmAction": "Clear ledger",
+  "reliability.audit.export": "Export redacted…",
+  "reliability.audit.exportDone": "Exported: {path}",
+  "reliability.audit.exportFail": "Export failed",
+  "reliability.audit.clearDone": "Audit ledger cleared",
+  "reliability.audit.clearFail": "Could not clear ledger",
+  "reliability.audit.loadFail": "Could not load audit ledger",
+  "reliability.audit.unknownSession": "No session",
+  "reliability.audit.outcome.ok": "ok",
+  "reliability.audit.outcome.err": "err",
 
   // Cost rollup (Settings → Runtime → Tools) — known tokens only, never invoice-grade
   "costRollup.title": "Cost rollup",
@@ -6630,9 +6659,37 @@ const zh: Record<MessageKey, string> = {
   "reliability.openDoctor": "打开 Doctor",
   "reliability.openFromSettings": "打开可靠性中心",
   "reliability.settingsDesc":
-    "汇总忙碌会话、卡顿信号与最近错误卡片；可导出支持包。",
+    "汇总忙碌会话、卡顿信号、最近错误卡片与工具审计账本；可导出支持包。",
   "reliability.supportZipHint":
     "脱敏后的 Doctor 报告、近期日志与卡顿时间线快照（不含密钥）。",
+
+  "reliability.audit.title": "工具审计账本",
+  "reliability.audit.count": "{count}",
+  "reliability.audit.empty": "尚无审计记录。",
+  "reliability.audit.emptyFilter": "没有符合筛选条件的记录。",
+  "reliability.audit.lead":
+    "跨会话的权限决策与工具起止（已脱敏）。以追加式 JSONL 保存在应用数据目录。",
+  "reliability.audit.searchPlaceholder": "搜索工具、摘要、会话…",
+  "reliability.audit.filterAria": "按事件类型筛选审计账本",
+  "reliability.audit.filterAll": "全部",
+  "reliability.audit.event.permission": "权限",
+  "reliability.audit.event.toolStart": "工具开始",
+  "reliability.audit.event.toolEnd": "工具结束",
+  "reliability.audit.refresh": "刷新",
+  "reliability.audit.clear": "清空账本",
+  "reliability.audit.clearConfirmTitle": "清空工具审计账本？",
+  "reliability.audit.clearConfirmMessage":
+    "将永久删除本机磁盘上的审计 JSONL，无法撤销。",
+  "reliability.audit.clearConfirmAction": "清空账本",
+  "reliability.audit.export": "导出脱敏…",
+  "reliability.audit.exportDone": "已导出：{path}",
+  "reliability.audit.exportFail": "导出失败",
+  "reliability.audit.clearDone": "审计账本已清空",
+  "reliability.audit.clearFail": "无法清空账本",
+  "reliability.audit.loadFail": "无法加载审计账本",
+  "reliability.audit.unknownSession": "无会话",
+  "reliability.audit.outcome.ok": "成功",
+  "reliability.audit.outcome.err": "失败",
 
   "costRollup.title": "费用汇总",
   "costRollup.settingsDesc":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2460,7 +2460,37 @@ export const zhTW: Record<MessageKey, string> = {
   "reliability.openDoctor": "開啟 Doctor",
   "reliability.openFromSettings": "開啟可靠性中心",
   "reliability.settingsDesc":
-    "彙總忙碌工作階段、停滯訊號與最近錯誤卡片；可匯出支援包。",
+    "彙總忙碌工作階段、停滯訊號、最近錯誤卡片與工具稽核帳本；可匯出支援包。",
+  "reliability.supportZipHint":
+    "去敏後的 Doctor 報告、近期日誌與停滯時間軸快照（不含金鑰）。",
+
+  "reliability.audit.title": "工具稽核帳本",
+  "reliability.audit.count": "{count}",
+  "reliability.audit.empty": "尚無稽核紀錄。",
+  "reliability.audit.emptyFilter": "沒有符合篩選條件的紀錄。",
+  "reliability.audit.lead":
+    "跨工作階段的權限決策與工具起迄（已去敏）。以附加式 JSONL 保存在應用程式資料目錄。",
+  "reliability.audit.searchPlaceholder": "搜尋工具、摘要、工作階段…",
+  "reliability.audit.filterAria": "依事件類型篩選稽核帳本",
+  "reliability.audit.filterAll": "全部",
+  "reliability.audit.event.permission": "權限",
+  "reliability.audit.event.toolStart": "工具開始",
+  "reliability.audit.event.toolEnd": "工具結束",
+  "reliability.audit.refresh": "重新整理",
+  "reliability.audit.clear": "清空帳本",
+  "reliability.audit.clearConfirmTitle": "清空工具稽核帳本？",
+  "reliability.audit.clearConfirmMessage":
+    "將永久刪除此裝置上的稽核 JSONL，無法復原。",
+  "reliability.audit.clearConfirmAction": "清空帳本",
+  "reliability.audit.export": "匯出去敏…",
+  "reliability.audit.exportDone": "已匯出：{path}",
+  "reliability.audit.exportFail": "匯出失敗",
+  "reliability.audit.clearDone": "稽核帳本已清空",
+  "reliability.audit.clearFail": "無法清空帳本",
+  "reliability.audit.loadFail": "無法載入稽核帳本",
+  "reliability.audit.unknownSession": "無工作階段",
+  "reliability.audit.outcome.ok": "成功",
+  "reliability.audit.outcome.err": "失敗",
 
   "costRollup.title": "費用彙總",
   "costRollup.settingsDesc":
@@ -2566,8 +2596,6 @@ export const zhTW: Record<MessageKey, string> = {
   "streamAcpNdjson.softGateNote":
     "僅當 CLI ≥ {min} 時探測才會加上 --output-format streaming-json；舊版本會省略該旗標。",
 
-  "reliability.supportZipHint":
-    "脫敏後的 Doctor 報告、近期日誌與停滯時間線快照（不含金鑰）。",
   "doctor.advanced": "進階",
   "doctor.cliDoctor": "Grok Build CLI doctor",
   "doctor.cliDoctorHint": "來自 `grok doctor --json`（終端機、剪貼簿、色彩）。",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1944,6 +1944,40 @@ export async function exportSupportBundle(
   });
 }
 
+/** One host audit ledger row (camelCase). */
+export type AuditLedgerHostEntry = {
+  ts: string;
+  sessionId?: string | null;
+  projectPath?: string | null;
+  toolName: string;
+  event: string;
+  permission?: string | null;
+  outcome?: string | null;
+  summary?: string | null;
+};
+
+/** Recent cross-session tool/permission audit rows (newest first). Soft-fail → []. */
+export async function auditLedgerList(limit?: number | null) {
+  if (!isTauri()) return [] as AuditLedgerHostEntry[];
+  try {
+    return await invoke<AuditLedgerHostEntry[]>("audit_ledger_list", {
+      limit: limit ?? null,
+    });
+  } catch {
+    return [];
+  }
+}
+
+/** Clear on-disk audit ledger. */
+export async function auditLedgerClear() {
+  return invoke<{ ok: boolean }>("audit_ledger_clear");
+}
+
+/** Export redacted JSONL via native save dialog. */
+export async function auditLedgerExport() {
+  return invoke<SupportBundleResult>("audit_ledger_export");
+}
+
 /**
  * Full session diagnostic zip for bug reports: messages, meta, settings,
  * CLI probe, agent trail (events/history/terminal logs), optional runtime snapshot.

--- a/src/lib/auditLedger.test.ts
+++ b/src/lib/auditLedger.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  auditLedgerEventKey,
+  auditLedgerTsMs,
+  filterAuditLedger,
+  formatAuditLedgerRow,
+  normalizeAuditLedgerLimit,
+  parseAuditLedgerEntry,
+  parseAuditLedgerList,
+  serializeAuditLedgerJsonl,
+  AUDIT_LEDGER_DEFAULT_LIMIT,
+  AUDIT_LEDGER_MAX_LIMIT,
+  AUDIT_LEDGER_SUMMARY_MAX,
+  type AuditLedgerEntry,
+} from "./auditLedger";
+
+const sample: AuditLedgerEntry = {
+  ts: "2026-07-31T12:00:00.000Z",
+  sessionId: "sess-1",
+  projectPath: "/tmp/proj",
+  toolName: "bash",
+  event: "tool_end",
+  outcome: "ok",
+  summary: "echo hi",
+};
+
+describe("normalizeAuditLedgerLimit", () => {
+  it("defaults and clamps", () => {
+    expect(normalizeAuditLedgerLimit(undefined)).toBe(AUDIT_LEDGER_DEFAULT_LIMIT);
+    expect(normalizeAuditLedgerLimit(0)).toBe(1);
+    expect(normalizeAuditLedgerLimit(50)).toBe(50);
+    expect(normalizeAuditLedgerLimit(99_999)).toBe(AUDIT_LEDGER_MAX_LIMIT);
+  });
+});
+
+describe("parseAuditLedgerEntry", () => {
+  it("accepts camelCase host rows", () => {
+    const e = parseAuditLedgerEntry({
+      ts: "2026-01-01T00:00:00.000Z",
+      sessionId: "s1",
+      toolName: "read_file",
+      event: "permission",
+      permission: "allow_once",
+      summary: "src/main.rs",
+    });
+    expect(e).toEqual({
+      ts: "2026-01-01T00:00:00.000Z",
+      sessionId: "s1",
+      toolName: "read_file",
+      event: "permission",
+      permission: "allow_once",
+      summary: "src/main.rs",
+    });
+  });
+
+  it("accepts snake_case aliases", () => {
+    const e = parseAuditLedgerEntry({
+      ts: "t",
+      session_id: "s",
+      tool_name: "write",
+      event: "tool_start",
+      project_path: "/p",
+    });
+    expect(e?.sessionId).toBe("s");
+    expect(e?.toolName).toBe("write");
+    expect(e?.projectPath).toBe("/p");
+  });
+
+  it("rejects unknown events and empty junk", () => {
+    expect(parseAuditLedgerEntry(null)).toBeNull();
+    expect(parseAuditLedgerEntry({ event: "hack", toolName: "x" })).toBeNull();
+    expect(parseAuditLedgerEntry({ toolName: "x" })).toBeNull();
+  });
+
+  it("caps summary length", () => {
+    const long = "x".repeat(AUDIT_LEDGER_SUMMARY_MAX + 80);
+    const e = parseAuditLedgerEntry({
+      ts: "t",
+      toolName: "bash",
+      event: "tool_end",
+      outcome: "ok",
+      summary: long,
+    });
+    expect(e?.summary?.length).toBe(AUDIT_LEDGER_SUMMARY_MAX);
+  });
+});
+
+describe("parseAuditLedgerList", () => {
+  it("parses array newest-first order preserved", () => {
+    const list = parseAuditLedgerList([
+      { ...sample, ts: "2026-07-31T13:00:00.000Z", toolName: "a" },
+      { ...sample, ts: "2026-07-31T12:00:00.000Z", toolName: "b" },
+    ]);
+    expect(list.map((e) => e.toolName)).toEqual(["a", "b"]);
+  });
+
+  it("parses JSONL oldest-first into newest-first", () => {
+    const jsonl = [
+      JSON.stringify({ ...sample, toolName: "old", ts: "2026-01-01T00:00:00.000Z" }),
+      JSON.stringify({ ...sample, toolName: "new", ts: "2026-01-02T00:00:00.000Z" }),
+    ].join("\n");
+    const list = parseAuditLedgerList(jsonl);
+    expect(list.map((e) => e.toolName)).toEqual(["new", "old"]);
+  });
+
+  it("tolerates corrupt lines", () => {
+    const jsonl = 'not-json\n{"ts":"t","toolName":"ok","event":"tool_start"}\n';
+    const list = parseAuditLedgerList(jsonl);
+    expect(list).toHaveLength(1);
+    expect(list[0]?.toolName).toBe("ok");
+  });
+});
+
+describe("filterAuditLedger", () => {
+  const rows: AuditLedgerEntry[] = [
+    sample,
+    {
+      ts: "2026-07-31T11:00:00.000Z",
+      toolName: "read_file",
+      event: "permission",
+      permission: "deny",
+      sessionId: "sess-2",
+      summary: "secrets.env",
+    },
+    {
+      ts: "2026-07-31T10:00:00.000Z",
+      toolName: "bash",
+      event: "tool_start",
+      sessionId: "sess-1",
+    },
+  ];
+
+  it("filters by event", () => {
+    expect(filterAuditLedger(rows, { event: "permission" })).toHaveLength(1);
+    expect(filterAuditLedger(rows, { event: "all" })).toHaveLength(3);
+  });
+
+  it("filters by query substring", () => {
+    expect(filterAuditLedger(rows, { query: "deny" })).toHaveLength(1);
+    expect(filterAuditLedger(rows, { query: "bash" })).toHaveLength(2);
+    expect(filterAuditLedger(rows, { query: "nope" })).toHaveLength(0);
+  });
+
+  it("filters by sessionId exact", () => {
+    expect(filterAuditLedger(rows, { sessionId: "sess-1" })).toHaveLength(2);
+  });
+});
+
+describe("format + serialize + keys", () => {
+  it("formats a readable row", () => {
+    expect(formatAuditLedgerRow(sample)).toContain("bash");
+    expect(formatAuditLedgerRow(sample)).toContain("ok");
+  });
+
+  it("serializes chronological JSONL", () => {
+    const a = { ...sample, ts: "2026-01-02T00:00:00.000Z", toolName: "new" };
+    const b = { ...sample, ts: "2026-01-01T00:00:00.000Z", toolName: "old" };
+    const out = serializeAuditLedgerJsonl([a, b]);
+    const lines = out.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).toolName).toBe("old");
+    expect(JSON.parse(lines[1]!).toolName).toBe("new");
+  });
+
+  it("maps event keys", () => {
+    expect(auditLedgerEventKey("permission")).toBe(
+      "reliability.audit.event.permission",
+    );
+    expect(auditLedgerEventKey("tool_start")).toBe(
+      "reliability.audit.event.toolStart",
+    );
+    expect(auditLedgerEventKey("tool_end")).toBe(
+      "reliability.audit.event.toolEnd",
+    );
+  });
+
+  it("parses ts to ms", () => {
+    expect(auditLedgerTsMs(sample)).toBeGreaterThan(0);
+    expect(auditLedgerTsMs({ ...sample, ts: "not-a-date" })).toBe(0);
+  });
+});

--- a/src/lib/auditLedger.ts
+++ b/src/lib/auditLedger.ts
@@ -1,0 +1,264 @@
+/**
+ * Cross-session tool / permission audit ledger — pure types + parse/filter.
+ *
+ * Host persists append-only JSONL under `{app_data}/audit/tool_ledger.jsonl`.
+ * This module normalizes host payloads for Reliability UI (no secrets).
+ */
+
+export type AuditLedgerEvent = "permission" | "tool_start" | "tool_end";
+
+export type AuditLedgerOutcome = "ok" | "err";
+
+export type AuditLedgerEntry = {
+  /** ISO-8601 timestamp from host. */
+  ts: string;
+  sessionId?: string | null;
+  projectPath?: string | null;
+  toolName: string;
+  event: AuditLedgerEvent;
+  /** Permission decision when event === "permission". */
+  permission?: string | null;
+  /** Tool outcome when event === "tool_end". */
+  outcome?: AuditLedgerOutcome | string | null;
+  /** Redacted short summary. */
+  summary?: string | null;
+};
+
+export const AUDIT_LEDGER_EVENTS = [
+  "permission",
+  "tool_start",
+  "tool_end",
+] as const satisfies readonly AuditLedgerEvent[];
+
+export const AUDIT_LEDGER_DEFAULT_LIMIT = 200;
+export const AUDIT_LEDGER_MAX_LIMIT = 1000;
+/** Cap free-form summary in UI filters / export preview. */
+export const AUDIT_LEDGER_SUMMARY_MAX = 240;
+export const AUDIT_LEDGER_FIELD_MAX = 120;
+
+const EVENT_SET = new Set<string>(AUDIT_LEDGER_EVENTS);
+
+/** Soft clamp for list limits (mirrors host). */
+export function normalizeAuditLedgerLimit(
+  raw: number | null | undefined,
+  fallback = AUDIT_LEDGER_DEFAULT_LIMIT,
+): number {
+  if (raw == null || !Number.isFinite(raw)) return fallback;
+  const n = Math.floor(raw);
+  if (n < 1) return 1;
+  if (n > AUDIT_LEDGER_MAX_LIMIT) return AUDIT_LEDGER_MAX_LIMIT;
+  return n;
+}
+
+function scrubField(raw: unknown, max: number): string {
+  if (typeof raw !== "string") return "";
+  // Drop C0 controls except tab/newline; trim.
+  let s = raw.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, "").trim();
+  if (!s) return "";
+  if (s.length > max) s = s.slice(0, max);
+  return s;
+}
+
+/**
+ * Normalize one raw host/object row into an AuditLedgerEntry, or null if invalid.
+ * Only known events; drops free-form junk that could carry secrets.
+ */
+export function parseAuditLedgerEntry(raw: unknown): AuditLedgerEntry | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+
+  const eventRaw =
+    typeof o.event === "string"
+      ? o.event.trim()
+      : typeof (o as { event_type?: unknown }).event_type === "string"
+        ? String((o as { event_type: string }).event_type).trim()
+        : "";
+  if (!EVENT_SET.has(eventRaw)) return null;
+  const event = eventRaw as AuditLedgerEvent;
+
+  const toolName =
+    scrubField(o.toolName ?? o.tool_name, AUDIT_LEDGER_FIELD_MAX) || "unknown";
+
+  const tsRaw =
+    typeof o.ts === "string"
+      ? o.ts.trim()
+      : typeof o.timestamp === "string"
+        ? o.timestamp.trim()
+        : "";
+  const ts = tsRaw || new Date(0).toISOString();
+
+  const sessionId =
+    scrubField(o.sessionId ?? o.session_id, AUDIT_LEDGER_FIELD_MAX) || null;
+  const projectPath =
+    scrubField(o.projectPath ?? o.project_path, 512) || null;
+  const permission =
+    scrubField(o.permission, AUDIT_LEDGER_FIELD_MAX) || null;
+  const outcomeRaw = scrubField(o.outcome, AUDIT_LEDGER_FIELD_MAX) || null;
+  const summary =
+    scrubField(o.summary, AUDIT_LEDGER_SUMMARY_MAX) || null;
+
+  return {
+    ts,
+    toolName,
+    event,
+    ...(sessionId ? { sessionId } : {}),
+    ...(projectPath ? { projectPath } : {}),
+    ...(permission ? { permission } : {}),
+    ...(outcomeRaw ? { outcome: outcomeRaw } : {}),
+    ...(summary ? { summary } : {}),
+  };
+}
+
+/** Parse a JSON array or JSONL string into newest-first entries (capped). */
+export function parseAuditLedgerList(
+  raw: unknown,
+  max = AUDIT_LEDGER_DEFAULT_LIMIT,
+): AuditLedgerEntry[] {
+  const lim = normalizeAuditLedgerLimit(max);
+  let list: unknown[] = [];
+
+  if (typeof raw === "string") {
+    const t = raw.trim();
+    if (!t) return [];
+    // Prefer JSON array; fall back to JSONL.
+    if (t.startsWith("[")) {
+      try {
+        const parsed = JSON.parse(t) as unknown;
+        if (Array.isArray(parsed)) list = parsed;
+      } catch {
+        return [];
+      }
+    } else {
+      list = t.split(/\r?\n/).filter((l) => l.trim());
+      // JSONL is chronological; reverse to newest-first after parse.
+      const out: AuditLedgerEntry[] = [];
+      for (let i = list.length - 1; i >= 0; i--) {
+        const line = list[i];
+        if (typeof line !== "string") continue;
+        try {
+          const e = parseAuditLedgerEntry(JSON.parse(line));
+          if (e) {
+            out.push(e);
+            if (out.length >= lim) break;
+          }
+        } catch {
+          /* skip bad line */
+        }
+      }
+      return out;
+    }
+  } else if (Array.isArray(raw)) {
+    list = raw;
+  } else {
+    return [];
+  }
+
+  const out: AuditLedgerEntry[] = [];
+  for (const item of list) {
+    const e =
+      typeof item === "string"
+        ? (() => {
+            try {
+              return parseAuditLedgerEntry(JSON.parse(item));
+            } catch {
+              return null;
+            }
+          })()
+        : parseAuditLedgerEntry(item);
+    if (!e) continue;
+    out.push(e);
+    if (out.length >= lim) break;
+  }
+  return out;
+}
+
+export type AuditLedgerFilter = {
+  query?: string;
+  event?: AuditLedgerEvent | "all";
+  sessionId?: string | null;
+  toolName?: string | null;
+};
+
+/**
+ * Filter entries (already newest-first). Case-insensitive substring match on
+ * toolName, summary, permission, sessionId, projectPath.
+ */
+export function filterAuditLedger(
+  entries: readonly AuditLedgerEntry[],
+  filter: AuditLedgerFilter = {},
+): AuditLedgerEntry[] {
+  const event = filter.event && filter.event !== "all" ? filter.event : null;
+  const q = (filter.query ?? "").trim().toLowerCase();
+  const sid = (filter.sessionId ?? "").trim().toLowerCase();
+  const tool = (filter.toolName ?? "").trim().toLowerCase();
+
+  return entries.filter((e) => {
+    if (event && e.event !== event) return false;
+    if (sid && (e.sessionId ?? "").toLowerCase() !== sid) return false;
+    if (tool && !e.toolName.toLowerCase().includes(tool)) return false;
+    if (!q) return true;
+    const hay = [
+      e.toolName,
+      e.summary ?? "",
+      e.permission ?? "",
+      e.outcome ?? "",
+      e.sessionId ?? "",
+      e.projectPath ?? "",
+      e.event,
+    ]
+      .join(" ")
+      .toLowerCase();
+    return hay.includes(q);
+  });
+}
+
+/** Stable sort key: epoch ms from ts (0 on parse fail). */
+export function auditLedgerTsMs(entry: AuditLedgerEntry): number {
+  const t = Date.parse(entry.ts);
+  return Number.isFinite(t) ? t : 0;
+}
+
+/** One-line preview for list rows (no secrets — summary already redacted). */
+export function formatAuditLedgerRow(entry: AuditLedgerEntry): string {
+  const parts: string[] = [entry.event, entry.toolName];
+  if (entry.permission) parts.push(entry.permission);
+  if (entry.outcome) parts.push(entry.outcome);
+  if (entry.summary) parts.push(entry.summary);
+  return parts.join(" · ");
+}
+
+/** Serialize entries as redacted JSONL (chronological: oldest first). */
+export function serializeAuditLedgerJsonl(
+  entries: readonly AuditLedgerEntry[],
+): string {
+  // UI lists newest first; export chronological.
+  const chrono = [...entries].sort(
+    (a, b) => auditLedgerTsMs(a) - auditLedgerTsMs(b),
+  );
+  const lines: string[] = [];
+  for (const e of chrono) {
+    const clean = parseAuditLedgerEntry(e);
+    if (!clean) continue;
+    lines.push(JSON.stringify(clean));
+  }
+  return lines.length ? lines.join("\n") + "\n" : "";
+}
+
+/** i18n key suffix for event type (`reliability.audit.event.*`). */
+export function auditLedgerEventKey(
+  event: AuditLedgerEvent,
+):
+  | "reliability.audit.event.permission"
+  | "reliability.audit.event.toolStart"
+  | "reliability.audit.event.toolEnd" {
+  switch (event) {
+    case "permission":
+      return "reliability.audit.event.permission";
+    case "tool_start":
+      return "reliability.audit.event.toolStart";
+    case "tool_end":
+      return "reliability.audit.event.toolEnd";
+    default:
+      return "reliability.audit.event.toolEnd";
+  }
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -2386,6 +2386,8 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     descKeys: [
       "reliability.settingsDesc",
       "reliability.openFromSettings",
+      "reliability.audit.title",
+      "reliability.audit.lead",
     ],
     keywords: [
       "reliability",
@@ -2394,6 +2396,14 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "stall",
       "error deck",
       "support zip",
+      "audit",
+      "ledger",
+      "tool audit",
+      "permission log",
+      "审计",
+      "帳本",
+      "账本",
+      "稽核",
     ],
   },
   {


### PR DESCRIPTION
Append-only redacted audit log under app data. View/clear/export via GlassModal. i18n + settingsCatalog + CHANGELOG.