### PR TITLE
perf(chat): long-session virtualizer window bounds + overscan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Long chat virtualizer (PERF-A11Y-PACK / perf)**: history browse no longer expands the continuous window to the tail just because idle force-mount lists the last user/assistant (that mounted hundreds of rows mid-scroll). Force expand is nearby-only while escaped; pin still expands for blank-pin defense. Adaptive viewport-scaled overscan, binary-search range find, rAF-coalesced scroll recompute, and cached cumulative offsets keep long transcripts snappy. Pure helpers + tests in `chatVirtualList`.
+
 ### Added
 
 #### Agent / memory

--- a/docs/llm-wiki/session-continuity.md
+++ b/docs/llm-wiki/session-continuity.md
@@ -146,15 +146,21 @@ Frontend also coalesces stream tokens (~48ms) before React `setState`.
 
 ### 4f. Main chat virtualization (scroll-safe)
 
-When the transcript has **≥36** messages, the main chat uses a **variable-height**
+When the transcript has **≥48** messages, the main chat uses a **variable-height**
 virtual window (`chatVirtualList` + `useChatMessageVirtualizer`):
 
 - Spacers preserve total `scrollHeight` so `useStickToBottom` pin / escape / re-pin
   and “Back to bottom” keep working.
-- **Pinned** (following stream): always mount the tail; overscan builds upward.
+- **Pinned** (following stream): always mount the tail; adaptive overscan builds
+  upward (viewport-scaled, clamped).
 - **Escaped** (user scrolled up): window by `scrollTop`; height remeasure of rows
   above the viewport adjusts `scrollTop` so content does not jump.
-- Force-mounted: find match, active streaming assistant, last user, last 4 rows.
+- Force-mounted nearby only while escaped (find match, streaming assistant, last
+  user/assistant within a small index gap). Distant tail force **must not** expand
+  the continuous window across the whole list — that defeated virtualization on
+  long history browse. While pinned, force may still expand for blank-pin defense.
+- Scroll recomputes are rAF-coalesced; cumulative offsets are cached until a height
+  commit so flings stay O(log n) for range find, not O(n) every event.
 
 Consequences, all of them load-bearing:
 

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -921,9 +921,10 @@ export function ConversationThread({
     [messages, transcriptFilter],
   );
 
-  // Force-mount only what must stay in DOM. Do NOT always force the last N
-  // rows while reading history — that expanded every window to the tail and
-  // remounted huge answers (org charts) mid-scroll → bounce.
+  // Force-mount only what must stay in DOM. The virtualizer applies force
+  // freely while pinned (blank-pin defense) but only expands nearby while
+  // escaped — listing the last user/assistant here no longer mounts the
+  // whole tail mid-history (see CHAT_FORCE_EXPAND_MAX_GAP).
   const forceVirtualIndices = useMemo(() => {
     const out: number[] = [];
     const pushId = (id: string | null | undefined) => {
@@ -944,9 +945,9 @@ export function ConversationThread({
       const n = transcriptMessages.length;
       if (n > 0) out.push(n - 1);
     }
-    // Even when idle, pin-window must include the last user + last assistant
-    // (not only trailing tool_step zeros), or reopening a long tool-heavy
-    // thread can paint an empty viewport at the bottom.
+    // While pinned, last user + last assistant keep the pin window from
+    // landing only on trailing tool_step zeros. Escaped history browse
+    // ignores distant force (virtualizer max-gap) so long chats stay windowed.
     // Always resolve via pushId (transcript indices) — never push messages[]
     // offsets into the virtual list (idle path used to force wrong rows / thrash).
     if (!turnBusy && transcriptMessages.length > 0) {

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -11,6 +11,12 @@
  * - Per-row ResizeObserver so image/video decode updates height cache (callback
  *   refs alone only fire on mount).
  * - Debounced recompute so measure storms cannot oscillate the window.
+ *
+ * Long-session perf:
+ * - rAF-coalesce scroll recomputes (one window update per frame while flinging).
+ * - Cache cumulative offsets until a height commit or itemCount change.
+ * - Adaptive overscan via {@link resolveChatOverscanPx}.
+ * - Force-index expand capped while escaped (see chatVirtualList).
  */
 
 import {
@@ -23,11 +29,10 @@ import {
 } from "react";
 import {
   CHAT_DEFAULT_ROW_ESTIMATE_PX,
-  CHAT_PIN_OVERSCAN_PX,
-  CHAT_OVERSCAN_PX,
   CHAT_VIRTUALIZE_THRESHOLD,
   computeChatVirtualWindow,
   cumulativeOffsets,
+  resolveChatOverscanPx,
   scrollTopAfterHeightChange,
   shouldCommitRowHeight,
   type ChatVirtualWindow,
@@ -99,12 +104,26 @@ export function useChatMessageVirtualizer(
   const ignoreScrollAdjustRef = useRef(false);
   /** Per-index ResizeObserver so media decode updates height after mount. */
   const rowObserversRef = useRef<Map<number, ResizeObserver>>(new Map());
+  /** Coalesce scroll-driven recomputes to one per animation frame. */
+  const scrollRafRef = useRef<number | null>(null);
+  /**
+   * Bump when any committed height changes so the offset cache invalidates.
+   * Avoids O(n) cumulative rebuild on every scroll when heights are stable.
+   */
+  const heightsVersionRef = useRef(0);
+  const offsetsCacheRef = useRef<{
+    version: number;
+    count: number;
+    offsets: number[];
+  } | null>(null);
 
   const [win, setWin] = useState<ChatVirtualWindow>(() => full(itemCount));
 
   // Drop height cache on conversation change.
   useEffect(() => {
     heightsRef.current.clear();
+    heightsVersionRef.current = 0;
+    offsetsCacheRef.current = null;
     for (const ro of rowObserversRef.current.values()) ro.disconnect();
     rowObserversRef.current.clear();
     setWin(full(itemCount));
@@ -123,6 +142,21 @@ export function useChatMessageVirtualizer(
     if (est != null && Number.isFinite(est) && est >= 0) return est;
     return CHAT_DEFAULT_ROW_ESTIMATE_PX;
   }, []);
+
+  const getOffsets = useCallback(() => {
+    const version = heightsVersionRef.current;
+    const cached = offsetsCacheRef.current;
+    if (
+      cached &&
+      cached.version === version &&
+      cached.count === itemCount
+    ) {
+      return cached.offsets;
+    }
+    const offsets = cumulativeOffsets(itemCount, getHeight);
+    offsetsCacheRef.current = { version, count: itemCount, offsets };
+    return offsets;
+  }, [itemCount, getHeight]);
 
   const recomputeNow = useCallback(() => {
     if (!virtualized) {
@@ -143,14 +177,19 @@ export function useChatMessageVirtualizer(
       return;
     }
     const pin = !!isPinnedRef.current;
+    const offsets = getOffsets();
     const next = computeChatVirtualWindow({
       count: itemCount,
       getHeight,
       scrollTop: el.scrollTop,
       viewportHeight: el.clientHeight,
-      overscanPx: pin ? CHAT_PIN_OVERSCAN_PX : CHAT_OVERSCAN_PX,
+      overscanPx: resolveChatOverscanPx({
+        viewportHeight: el.clientHeight,
+        pinToBottom: pin,
+      }),
       pinToBottom: pin,
       forceIndices: forceRef.current,
+      offsets,
     });
     setWin((prev) => {
       if (
@@ -176,7 +215,7 @@ export function useChatMessageVirtualizer(
       }
       return next;
     });
-  }, [virtualized, itemCount, viewportRef, isPinnedRef, getHeight]);
+  }, [virtualized, itemCount, viewportRef, isPinnedRef, getHeight, getOffsets]);
 
   const recompute = useCallback(() => {
     // Coalesce measure storms (tall markdown + table reflow) into one window update.
@@ -191,7 +230,7 @@ export function useChatMessageVirtualizer(
     }, delay);
   }, [recomputeNow, isPinnedRef]);
 
-  // Scroll → recompute (immediate so window tracks the gesture).
+  // Scroll → recompute (rAF-coalesced so flings don't rebuild every event).
   useEffect(() => {
     if (!virtualized) {
       setWin(full(itemCount));
@@ -204,7 +243,12 @@ export function useChatMessageVirtualizer(
         ignoreScrollAdjustRef.current = false;
         return;
       }
-      recomputeNow();
+      // One window update per frame while the user is flinging through history.
+      if (scrollRafRef.current != null) return;
+      scrollRafRef.current = requestAnimationFrame(() => {
+        scrollRafRef.current = null;
+        recomputeNow();
+      });
     };
     el.addEventListener("scroll", onScroll, { passive: true });
     const ro = new ResizeObserver(() => recompute());
@@ -213,6 +257,10 @@ export function useChatMessageVirtualizer(
     return () => {
       el.removeEventListener("scroll", onScroll);
       ro.disconnect();
+      if (scrollRafRef.current != null) {
+        cancelAnimationFrame(scrollRafRef.current);
+        scrollRafRef.current = null;
+      }
       if (recomputeTimerRef.current != null) {
         clearTimeout(recomputeTimerRef.current);
         recomputeTimerRef.current = null;
@@ -247,10 +295,9 @@ export function useChatMessageVirtualizer(
       // not on first measure from estimate — large first deltas at the viewport
       // edge were a primary bounce source for diagram rows.
       if (viewport && prevH != null && !pin) {
-        const offsets = cumulativeOffsets(itemCount, (i) => {
-          if (i === index) return prevH;
-          return getHeight(i);
-        });
+        const offsets = getOffsets();
+        // Use prev height for this row when computing rowOffset (cache may
+        // still hold the old value until we write nextH below).
         const rowOffset = offsets[index] ?? 0;
         const delta = nextH - prevH;
         const adjusted = scrollTopAfterHeightChange({
@@ -267,6 +314,8 @@ export function useChatMessageVirtualizer(
       }
 
       heightsRef.current.set(key, nextH);
+      heightsVersionRef.current += 1;
+      offsetsCacheRef.current = null;
       recompute();
       // Stay glued to the true bottom after a height commit while pinned —
       // avoids one-frame empty play at the tail then snap-back flash.
@@ -282,7 +331,7 @@ export function useChatMessageVirtualizer(
         });
       }
     },
-    [virtualized, itemCount, getHeight, isPinnedRef, viewportRef, recompute],
+    [virtualized, getOffsets, isPinnedRef, viewportRef, recompute],
   );
 
   /**

--- a/src/lib/chatVirtualList.test.ts
+++ b/src/lib/chatVirtualList.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
+  CHAT_FORCE_EXPAND_MAX_GAP,
+  CHAT_OVERSCAN_MAX_PX,
+  CHAT_OVERSCAN_MIN_PX,
+  CHAT_PIN_OVERSCAN_MAX_PX,
+  CHAT_PIN_OVERSCAN_MIN_PX,
   CHAT_VIRTUALIZE_THRESHOLD,
+  applyForceIndices,
   computeChatVirtualWindow,
   cumulativeOffsets,
   estimateChatRowHeight,
+  findEndIndex,
+  findStartIndex,
+  resolveChatOverscanPx,
   scrollTopAfterHeightChange,
   shouldCommitRowHeight,
 } from "./chatVirtualList";
@@ -60,7 +69,8 @@ describe("computeChatVirtualWindow", () => {
     );
   });
 
-  it("forceIndices expands the window", () => {
+  it("nearby forceIndices expands the window when escaped", () => {
+    // Natural window ~ indices 30–34 with overscan 0.
     const w = computeChatVirtualWindow({
       count: 40,
       getHeight: fixed(100),
@@ -68,14 +78,151 @@ describe("computeChatVirtualWindow", () => {
       viewportHeight: 400,
       pinToBottom: false,
       overscanPx: 0,
-      forceIndices: [2],
+      forceIndices: [28],
     });
-    expect(w.start).toBeLessThanOrEqual(2);
-    expect(w.end).toBeGreaterThan(2);
+    expect(w.start).toBeLessThanOrEqual(28);
+    expect(w.end).toBeGreaterThan(28);
+  });
+
+  it("distant forceIndices do not mount the whole tail when escaped", () => {
+    // Reading mid-history must not expand end to the last row just because
+    // idle force includes last user/assistant (long-session jank).
+    const w = computeChatVirtualWindow({
+      count: 200,
+      getHeight: fixed(100),
+      scrollTop: 5000,
+      viewportHeight: 400,
+      pinToBottom: false,
+      overscanPx: 100,
+      forceIndices: [0, 199],
+    });
+    expect(w.start).toBeGreaterThan(10);
+    expect(w.end).toBeLessThan(100);
+    // Natural window stays local — far force is ignored while escaped.
+    expect(w.end - w.start).toBeLessThan(30);
+  });
+
+  it("pin forceIndices still expand to early rows (blank-pin defense)", () => {
+    const heights = [80, 2000, ...Array(64).fill(40)];
+    const w = computeChatVirtualWindow({
+      count: heights.length,
+      getHeight: (i) => heights[i] ?? 0,
+      scrollTop: 0,
+      viewportHeight: 600,
+      pinToBottom: true,
+      overscanPx: 400,
+      forceIndices: [0, 1],
+    });
+    expect(w.end).toBe(heights.length);
+    expect(w.start).toBe(0);
   });
 
   it("threshold constant is high enough to skip short chats", () => {
     expect(CHAT_VIRTUALIZE_THRESHOLD).toBeGreaterThanOrEqual(40);
+  });
+
+  it("accepts precomputed offsets (scroll-path cache)", () => {
+    const count = 80;
+    const offsets = cumulativeOffsets(count, fixed(50));
+    const w = computeChatVirtualWindow({
+      count,
+      getHeight: fixed(50),
+      scrollTop: 800,
+      viewportHeight: 300,
+      overscanPx: 50,
+      offsets,
+    });
+    expect(w.totalHeight).toBe(4000);
+    expect(w.paddingTop + (w.end - w.start) * 50 + w.paddingBottom).toBe(
+      w.totalHeight,
+    );
+  });
+
+  it("binary search matches linear scan on long lists", () => {
+    const count = 2000;
+    const getHeight = (i: number) => 40 + (i % 7) * 10;
+    const offsets = cumulativeOffsets(count, getHeight);
+    // Spot-check several y positions.
+    for (const y of [0, 1, 500, 12_345, 50_000, 999_999]) {
+      let linearStart = 0;
+      for (let i = 0; i < count; i++) {
+        const bottom = offsets[i + 1] ?? 0;
+        if (bottom > y) {
+          linearStart = i;
+          break;
+        }
+        linearStart = i;
+      }
+      let linearEnd = count;
+      for (let i = 0; i < count; i++) {
+        const top = offsets[i] ?? 0;
+        if (top >= y) {
+          linearEnd = i;
+          break;
+        }
+      }
+      expect(findStartIndex(offsets, y)).toBe(linearStart);
+      expect(findEndIndex(offsets, y)).toBe(linearEnd);
+    }
+  });
+});
+
+describe("resolveChatOverscanPx", () => {
+  it("honors explicit override", () => {
+    expect(
+      resolveChatOverscanPx({
+        viewportHeight: 800,
+        overscanPx: 123,
+      }),
+    ).toBe(123);
+  });
+
+  it("clamps browse overscan for tiny and huge viewports", () => {
+    const tiny = resolveChatOverscanPx({ viewportHeight: 200 });
+    const huge = resolveChatOverscanPx({ viewportHeight: 4000 });
+    expect(tiny).toBeGreaterThanOrEqual(CHAT_OVERSCAN_MIN_PX);
+    expect(huge).toBeLessThanOrEqual(CHAT_OVERSCAN_MAX_PX);
+    expect(huge).toBeGreaterThan(tiny);
+  });
+
+  it("pin overscan is larger than browse for the same viewport", () => {
+    const vh = 900;
+    const browse = resolveChatOverscanPx({ viewportHeight: vh });
+    const pin = resolveChatOverscanPx({
+      viewportHeight: vh,
+      pinToBottom: true,
+    });
+    expect(pin).toBeGreaterThan(browse);
+    expect(pin).toBeGreaterThanOrEqual(CHAT_PIN_OVERSCAN_MIN_PX);
+    expect(pin).toBeLessThanOrEqual(CHAT_PIN_OVERSCAN_MAX_PX);
+  });
+});
+
+describe("applyForceIndices", () => {
+  it("expands freely when pinned", () => {
+    const r = applyForceIndices({
+      start: 40,
+      end: 50,
+      count: 100,
+      pinToBottom: true,
+      forceIndices: [2, 99],
+    });
+    expect(r.start).toBe(2);
+    expect(r.end).toBe(100);
+  });
+
+  it("only expands within max gap when escaped", () => {
+    const r = applyForceIndices({
+      start: 40,
+      end: 50,
+      count: 100,
+      pinToBottom: false,
+      maxGap: CHAT_FORCE_EXPAND_MAX_GAP,
+      forceIndices: [40 - CHAT_FORCE_EXPAND_MAX_GAP, 90],
+    });
+    expect(r.start).toBe(40 - CHAT_FORCE_EXPAND_MAX_GAP);
+    // 90 is far past end — ignored.
+    expect(r.end).toBe(50);
   });
 });
 
@@ -211,5 +358,41 @@ describe("scrollTopAfterHeightChange", () => {
 describe("cumulativeOffsets", () => {
   it("builds prefix sums", () => {
     expect(cumulativeOffsets(3, (i) => (i + 1) * 10)).toEqual([0, 10, 30, 60]);
+  });
+});
+
+describe("long transcript window scale", () => {
+  it("keeps a bounded mount set on a 500-message history browse", () => {
+    const count = 500;
+    const w = computeChatVirtualWindow({
+      count,
+      getHeight: fixed(120),
+      scrollTop: 20_000,
+      viewportHeight: 800,
+      pinToBottom: false,
+      // Idle force of last user + last assistant — must not swallow the list.
+      forceIndices: [count - 2, count - 1],
+    });
+    const mounted = w.end - w.start;
+    // Viewport 800 + adaptive overscan (~1.1*800) ≈ a few thousand px / 120 ≈ ~30–50.
+    expect(mounted).toBeLessThan(80);
+    expect(w.end).toBeLessThan(count - 10);
+    expect(w.start).toBeGreaterThan(50);
+  });
+
+  it("pin still mounts the tail on a 500-message stream", () => {
+    const count = 500;
+    const w = computeChatVirtualWindow({
+      count,
+      getHeight: fixed(120),
+      scrollTop: 0,
+      viewportHeight: 800,
+      pinToBottom: true,
+      forceIndices: [count - 2, count - 1],
+    });
+    expect(w.end).toBe(count);
+    expect(w.paddingBottom).toBe(0);
+    // Not the whole list — only overscan above the tail.
+    expect(w.start).toBeGreaterThan(count - 80);
   });
 });

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -5,6 +5,12 @@
  * - When `pinToBottom`, always include the last row and build the window upward
  *   so streaming tail stays mounted.
  * - Spacers keep total scrollHeight stable so pin/escape math stays valid.
+ *
+ * Perf (long sessions):
+ * - Binary search over cumulative offsets (O(log n) range find).
+ * - Adaptive overscan scales with viewport (not fixed multi-screen mounts).
+ * - Force-indices expand only nearby when escaped — distant tail force must
+ *   not mount the entire remainder of a long chat (history-browse jank).
  */
 
 /** Only virtualize long threads — short chats keep full DOM (identical UX). */
@@ -16,11 +22,25 @@ export const CHAT_DEFAULT_ROW_ESTIMATE_PX = 120;
 /** Cap a single estimated row so one mega-answer cannot dominate scroll math. */
 export const CHAT_MAX_ROW_ESTIMATE_PX = 8000;
 
-/** Extra px above/below the viewport when browsing history. */
+/** Baseline extra px above/below the viewport when browsing history. */
 export const CHAT_OVERSCAN_PX = 1200;
 
-/** When pinned, pull in more history above the tail so pin feels continuous. */
+/** Baseline when pinned: more history above the tail so pin feels continuous. */
 export const CHAT_PIN_OVERSCAN_PX = 1600;
+
+/** Floor / ceiling for adaptive overscan (px). */
+export const CHAT_OVERSCAN_MIN_PX = 700;
+export const CHAT_OVERSCAN_MAX_PX = 1800;
+export const CHAT_PIN_OVERSCAN_MIN_PX = 1000;
+export const CHAT_PIN_OVERSCAN_MAX_PX = 2400;
+
+/**
+ * Max index gap when expanding the window for `forceIndices` while **escaped**.
+ * Beyond this, locate/find must scroll the target into the natural window first
+ * (ConversationThread already coarse-jumps `scrollTop`). Expanding across the
+ * whole list defeated virtualization on multi-hundred-message threads.
+ */
+export const CHAT_FORCE_EXPAND_MAX_GAP = 12;
 
 /**
  * Content-aware row estimate so tall assistant answers (diagrams, tables)
@@ -97,6 +117,134 @@ export function cumulativeOffsets(
 }
 
 /**
+ * Adaptive overscan in px.
+ * Scales with viewport so large monitors do not mount multi-screen markdown
+ * windows, while short viewports still get enough runway for fling.
+ */
+export function resolveChatOverscanPx(input: {
+  viewportHeight: number;
+  pinToBottom?: boolean;
+  /** Explicit override (tests / callers). */
+  overscanPx?: number;
+}): number {
+  if (input.overscanPx != null && Number.isFinite(input.overscanPx)) {
+    return Math.max(0, input.overscanPx);
+  }
+  const vh = Math.max(0, input.viewportHeight);
+  if (input.pinToBottom) {
+    // ~1.5 viewports above the tail + small baseline, clamped.
+    const raw = vh * 1.5 + 200;
+    return Math.round(
+      Math.min(
+        CHAT_PIN_OVERSCAN_MAX_PX,
+        Math.max(CHAT_PIN_OVERSCAN_MIN_PX, raw, CHAT_PIN_OVERSCAN_PX * 0.75),
+      ),
+    );
+  }
+  // History browse: ~1 viewport of runway.
+  const raw = vh * 1.1 + 100;
+  return Math.round(
+    Math.min(
+      CHAT_OVERSCAN_MAX_PX,
+      Math.max(CHAT_OVERSCAN_MIN_PX, raw, CHAT_OVERSCAN_PX * 0.6),
+    ),
+  );
+}
+
+/**
+ * First index whose bottom edge is past `y` (row intersects or sits below y).
+ * `offsets` length = count + 1. O(log n).
+ */
+export function findStartIndex(offsets: number[], y: number): number {
+  const count = offsets.length - 1;
+  if (count <= 0) return 0;
+  if (y <= 0) return 0;
+  // First i with offsets[i+1] > y.
+  let lo = 0;
+  let hi = count - 1;
+  let ans = count - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const bottom = offsets[mid + 1] ?? 0;
+    if (bottom > y) {
+      ans = mid;
+      hi = mid - 1;
+    } else {
+      lo = mid + 1;
+    }
+  }
+  return ans;
+}
+
+/**
+ * First index whose top is ≥ `y` (exclusive end candidate). O(log n).
+ */
+export function findEndIndex(offsets: number[], y: number): number {
+  const count = offsets.length - 1;
+  if (count <= 0) return 0;
+  // First i with offsets[i] >= y; if none, count.
+  let lo = 0;
+  let hi = count;
+  let ans = count;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (mid >= count) {
+      ans = count;
+      break;
+    }
+    const top = offsets[mid] ?? 0;
+    if (top >= y) {
+      ans = mid;
+      hi = mid - 1;
+    } else {
+      lo = mid + 1;
+    }
+  }
+  return Math.min(count, ans);
+}
+
+/**
+ * Expand [start, end) to include force indices.
+ * - When pinned: always expand (blank-pin defense for tool-heavy tails).
+ * - When escaped: only expand if within {@link CHAT_FORCE_EXPAND_MAX_GAP}
+ *   of the natural window so history browse does not mount the whole tail.
+ */
+export function applyForceIndices(input: {
+  start: number;
+  end: number;
+  count: number;
+  forceIndices?: readonly number[];
+  pinToBottom?: boolean;
+  maxGap?: number;
+}): { start: number; end: number } {
+  let { start, end } = input;
+  const count = input.count;
+  const pin = !!input.pinToBottom;
+  const maxGap = input.maxGap ?? CHAT_FORCE_EXPAND_MAX_GAP;
+  if (!input.forceIndices?.length || count <= 0) {
+    return { start, end };
+  }
+  for (const raw of input.forceIndices) {
+    const i = Math.floor(raw);
+    if (i < 0 || i >= count) continue;
+    if (pin) {
+      if (i < start) start = i;
+      if (i >= end) end = i + 1;
+      continue;
+    }
+    // Escaped: nearby expand only.
+    if (i < start) {
+      if (start - i <= maxGap) start = i;
+    }
+    if (i >= end) {
+      // Distance from last included index (end - 1) to i.
+      if (i - (end - 1) <= maxGap) end = i + 1;
+    }
+  }
+  return { start, end };
+}
+
+/**
  * Compute the visible index range + spacers for a variable-height list.
  */
 export function computeChatVirtualWindow(input: {
@@ -109,20 +257,29 @@ export function computeChatVirtualWindow(input: {
   pinToBottom?: boolean;
   /** Indices that must stay mounted (find hit, streaming assistant, …). */
   forceIndices?: readonly number[];
+  /**
+   * Optional precomputed cumulative offsets (length count+1).
+   * Callers that recompute on every scroll can cache these until heights change.
+   */
+  offsets?: readonly number[];
 }): ChatVirtualWindow {
   const count = Math.max(0, Math.floor(input.count));
   if (count === 0) {
     return { start: 0, end: 0, paddingTop: 0, paddingBottom: 0, totalHeight: 0 };
   }
 
-  const offsets = cumulativeOffsets(count, input.getHeight);
+  const offsets: number[] =
+    input.offsets && input.offsets.length === count + 1
+      ? (input.offsets as number[])
+      : cumulativeOffsets(count, input.getHeight);
   const totalHeight = offsets[count] ?? 0;
   const viewportHeight = Math.max(0, input.viewportHeight);
   const pin = !!input.pinToBottom;
-  const overscan = Math.max(
-    0,
-    input.overscanPx ?? (pin ? CHAT_PIN_OVERSCAN_PX : CHAT_OVERSCAN_PX),
-  );
+  const overscan = resolveChatOverscanPx({
+    viewportHeight,
+    pinToBottom: pin,
+    overscanPx: input.overscanPx,
+  });
 
   // When pinned, treat the viewport as parked on the absolute bottom so the
   // window always covers the streaming tail even if scrollTop lags one frame.
@@ -136,41 +293,21 @@ export function computeChatVirtualWindow(input: {
   const rangeTop = Math.max(0, viewTop - overscan);
   const rangeBottom = Math.min(totalHeight, viewBottom + overscan);
 
-  // First index whose bottom edge is past rangeTop.
-  let start = 0;
-  for (let i = 0; i < count; i++) {
-    const bottom = offsets[i + 1] ?? 0;
-    if (bottom > rangeTop) {
-      start = i;
-      break;
-    }
-    start = i;
-  }
-
-  // First index whose top is >= rangeBottom (exclusive end).
-  let end = count;
-  for (let i = start; i < count; i++) {
-    const top = offsets[i] ?? 0;
-    if (top >= rangeBottom) {
-      end = i;
-      break;
-    }
-  }
+  let start = findStartIndex(offsets, rangeTop);
+  let end = findEndIndex(offsets, rangeBottom);
   if (end <= start) end = Math.min(count, start + 1);
 
   if (pin) {
     end = count;
   }
 
-  // Force-include indices (find match, live assistant, last user, …).
-  if (input.forceIndices?.length) {
-    for (const raw of input.forceIndices) {
-      const i = Math.floor(raw);
-      if (i < 0 || i >= count) continue;
-      if (i < start) start = i;
-      if (i >= end) end = i + 1;
-    }
-  }
+  ({ start, end } = applyForceIndices({
+    start,
+    end,
+    count,
+    forceIndices: input.forceIndices,
+    pinToBottom: pin,
+  }));
 
   start = Math.max(0, Math.min(start, count - 1));
   end = Math.max(start + 1, Math.min(end, count));


### PR DESCRIPTION
## Summary

PERF-A11Y-PACK (**perf half**) for long chat sessions.

- **Force-mount gap limit while escaped**: idle force of last user/assistant no longer expands the continuous virtual window across the whole tail mid-history (main long-session jank). Pin still expands freely for blank-pin defense on tool-heavy tails.
- **Adaptive overscan**: viewport-scaled, clamped browse/pin overscan (`resolveChatOverscanPx`) instead of always mounting fixed multi-screen px.
- **Binary-search range find** over cumulative offsets (`findStartIndex` / `findEndIndex`).
- **rAF-coalesced scroll recompute** + **cached cumulative offsets** until height commit (flings stay cheap).
- Tests for force gap, adaptive overscan, binary search parity, 500-message bounded mount; CHANGELOG + `session-continuity` wiki.

## Test plan

- [x] `pnpm test -- src/lib/chatVirtualList.test.ts src/lib/stickToBottom.test.ts` (53 pass)
- [x] `pnpm exec tsc -b`
- [ ] Manual: open a 100+ message session, scroll history — DOM mount count stays near-viewport (DevTools), no full-tail remount
- [ ] Manual: pin/stream at bottom still follows; tool-heavy reopen does not blank the pin window
- [ ] Manual: message-node rail / find jump still lands on target