### PR TITLE
feat(voice): Build tool-loop status + soft-fail mic/CLI (VOX-BUILD-LOOP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See `docs/llm-wiki/release.md`.
 - **Streaming ACP NDJSON diagnostics** (Settings → Runtime → Tools; CLI **0.2.117+**): pure parser for headless `--output-format streaming-json` as agent-native ACP session-update NDJSON (not `streaming-messages-json`); import/paste or soft-gated headless probe; event type counts + copy summary
 
 #### Composer & chat
+- **Live Voice → Build tool loop** (VOX-BUILD-LOOP): host emits tool **running → ok / soft_fail / error** on `voice://tool` with `activeTool` on state; overlay shows Build tool chip + system lines; **mic missing/denied soft-fails** (warn, keep session for playback/tools); **CLI missing soft-fails** tool results (`ok: false, reason: cli_missing`) so voice stays open; classified errors (`voice.err.*`) en/zh/zh-TW; pure helpers + tests
 - **Live Voice delegate status** (VOX-DELEG): overlay shows listening / thinking / speaking from host `voice://` events, **Stop**, honest empty transcript (no fake STT), delegated session chips, and optional **Send transcript to active session** when a chat is open
 - **Send queue** edit / reorder · **composer min height** · **cross-session recent prompts**
 - **Chat width** · **chat / code font** · **tool auto-collapse** · **transcript filter** (hide tool steps)

--- a/src-tauri/src/voice_host.rs
+++ b/src-tauri/src/voice_host.rs
@@ -37,6 +37,8 @@ pub struct VoiceSessionState {
     pub speaking: bool,
     /// Model / host-tool turn in progress (not listening, not speaking).
     pub thinking: bool,
+    /// In-flight Build tool name when a host tool is running (honest loop status).
+    pub active_tool: Option<String>,
     pub error: Option<String>,
     pub delegated_session_ids: Vec<String>,
 }
@@ -53,6 +55,7 @@ impl Default for VoiceSessionState {
             listening: false,
             speaking: false,
             thinking: false,
+            active_tool: None,
             error: None,
             delegated_session_ids: vec![],
         }
@@ -132,6 +135,7 @@ impl VoiceHost {
                 listening: true,
                 speaking: false,
                 thinking: false,
+                active_tool: None,
                 error: None,
                 delegated_session_ids: vec![],
             };
@@ -209,6 +213,7 @@ impl VoiceHost {
             g.state.listening = false;
             g.state.speaking = false;
             g.state.thinking = false;
+            g.state.active_tool = None;
             g.state.mode = "idle".into();
             g.stop.clone()
         };
@@ -269,9 +274,26 @@ fn set_thinking(host: &VoiceHost, app: &AppHandle, thinking: bool) {
         st.speaking = false;
     } else if st.active && !st.speaking {
         st.listening = true;
+        st.active_tool = None;
     }
     host.inner.lock().state = st;
     host.emit_state(app);
+}
+
+fn set_active_tool(host: &VoiceHost, app: &AppHandle, tool: Option<&str>) {
+    let mut st = host.snapshot();
+    st.active_tool = tool.map(|s| s.to_string());
+    if tool.is_some() {
+        st.thinking = true;
+        st.listening = false;
+        st.speaking = false;
+    }
+    host.inner.lock().state = st;
+    host.emit_state(app);
+}
+
+fn emit_tool_event(app: &AppHandle, payload: Value) {
+    let _ = app.emit("voice://tool", payload);
 }
 
 async fn execute_tool(
@@ -283,9 +305,104 @@ async fn execute_tool(
     args_json: &str,
 ) -> Result<Value, String> {
     set_thinking(host, app, true);
+    set_active_tool(host, app, Some(name));
+    emit_tool_event(
+        app,
+        json!({
+            "name": name,
+            "status": "running",
+            "args": args_json,
+        }),
+    );
+
     let result = execute_tool_inner(app, mgr, host, snap, name, args_json).await;
+
+    set_active_tool(host, app, None);
     set_thinking(host, app, false);
-    result
+
+    match result {
+        Ok(out) => {
+            let soft = voice_tools::soft_fail_reason(&out);
+            let status = if soft.is_some() { "soft_fail" } else { "ok" };
+            let mut payload = json!({
+                "name": name,
+                "status": status,
+                "args": args_json,
+                "result": out,
+            });
+            if let Some(reason) = soft {
+                payload
+                    .as_object_mut()
+                    .map(|o| o.insert("reason".into(), json!(reason)));
+            }
+            if let Some(sid) = out
+                .get("session_id")
+                .or_else(|| out.get("sessionId"))
+                .and_then(|x| x.as_str())
+            {
+                payload
+                    .as_object_mut()
+                    .map(|o| o.insert("sessionId".into(), json!(sid)));
+            }
+            emit_tool_event(app, payload);
+            let _ = app.emit(
+                "voice://tool_result",
+                json!({
+                    "name": name,
+                    "status": status,
+                    "result": out,
+                }),
+            );
+            Ok(out)
+        }
+        Err(e) => {
+            let class = voice_tools::classify_tool_error(&e);
+            // Soft-fail CLI missing (and similar): return structured result so
+            // the voice model can narrate honestly without killing the session.
+            if voice_tools::is_soft_tool_error(class) {
+                let out = voice_tools::soft_fail_result(class, &e);
+                emit_tool_event(
+                    app,
+                    json!({
+                        "name": name,
+                        "status": "soft_fail",
+                        "reason": class,
+                        "errorClass": class,
+                        "message": e,
+                        "result": out,
+                    }),
+                );
+                let _ = app.emit(
+                    "voice://tool_result",
+                    json!({
+                        "name": name,
+                        "status": "soft_fail",
+                        "reason": class,
+                        "result": out,
+                    }),
+                );
+                return Ok(out);
+            }
+            emit_tool_event(
+                app,
+                json!({
+                    "name": name,
+                    "status": "error",
+                    "reason": class,
+                    "errorClass": class,
+                    "message": e,
+                }),
+            );
+            let _ = app.emit(
+                "voice://error",
+                json!({
+                    "message": format!("tool {name}: {e}"),
+                    "errorClass": class,
+                }),
+            );
+            Err(e)
+        }
+    }
 }
 
 async fn execute_tool_inner(
@@ -298,10 +415,6 @@ async fn execute_tool_inner(
 ) -> Result<Value, String> {
     if VoiceHost::is_mock_env() {
         let out = voice_tools::mock_execute_tool(name, args_json)?;
-        let _ = app.emit(
-            "voice://tool",
-            json!({ "name": name, "args": args_json, "result": out }),
-        );
         if let Some(sid) = out.get("session_id").and_then(|x| x.as_str()) {
             host.push_delegated(sid);
             host.emit_state(app);
@@ -434,10 +547,6 @@ async fn execute_tool_inner(
         }
     };
 
-    let _ = app.emit(
-        "voice://tool",
-        json!({ "name": name, "args": args_json, "result": out }),
-    );
     Ok(out)
 }
 
@@ -653,25 +762,11 @@ async fn handle_server_event(
                 .unwrap_or("{}");
             if voice_tools::VoiceToolName::parse(name).is_some() {
                 let snap = host.snapshot();
-                match execute_tool(app, mgr, host, &snap, name, args).await {
-                    Ok(result) => {
-                        // Best-effort tool result injection for the model.
-                        let _ = app.emit(
-                            "voice://tool_result",
-                            json!({
-                                "callId": call_id,
-                                "name": name,
-                                "result": result
-                            }),
-                        );
-                    }
-                    Err(e) => {
-                        let _ = app.emit(
-                            "voice://error",
-                            json!({ "message": format!("tool {name}: {e}") }),
-                        );
-                    }
-                }
+                // execute_tool emits running → ok/soft_fail/error + tool_result.
+                // Soft-fail (e.g. CLI missing) returns Ok(structured) so the
+                // model can speak honestly without ending the voice session.
+                let _ = execute_tool(app, mgr, host, &snap, name, args).await;
+                let _ = call_id; // reserved for future realtime function_call_output
             }
         }
         "error" => {
@@ -680,7 +775,11 @@ async fn handle_server_event(
                 .or_else(|| v.get("message"))
                 .and_then(|x| x.as_str())
                 .unwrap_or("voice error");
-            let _ = app.emit("voice://error", json!({ "message": msg }));
+            let class = voice_tools::classify_tool_error(msg);
+            let _ = app.emit(
+                "voice://error",
+                json!({ "message": msg, "errorClass": class }),
+            );
         }
         _ => {}
     }
@@ -770,5 +869,6 @@ mod tests {
     fn default_inactive() {
         let h = VoiceHost::new();
         assert!(!h.snapshot().active);
+        assert!(h.snapshot().active_tool.is_none());
     }
 }

--- a/src-tauri/src/voice_tools.rs
+++ b/src-tauri/src/voice_tools.rs
@@ -207,6 +207,96 @@ pub fn parse_list_sessions_args(raw: &str) -> Result<ListSessionsArgs, String> {
     Ok(ListSessionsArgs { limit })
 }
 
+/// Stable error class tokens for voice → Build tool failures (UI / model).
+pub fn classify_tool_error(raw: &str) -> &'static str {
+    let s = raw.to_lowercase();
+    if s.contains("cli not found")
+        || s.contains("cli_missing")
+        || s.contains("grok build not found")
+        || s.contains("grok build cli not found")
+        || s.contains("install grok build")
+        || s.contains("install or set the cli path")
+        || s.contains("install or set cli path")
+    {
+        return "cli_missing";
+    }
+    if s.contains("permission")
+        || s.contains("denied")
+        || s.contains("notallowed")
+        || s.contains("mic_denied")
+    {
+        return "mic_denied";
+    }
+    if s.contains("no microphone")
+        || s.contains("mic_missing")
+        || s.contains("no device")
+        || s.contains("device not found")
+    {
+        return "mic_missing";
+    }
+    if s.contains("timeout") || s.contains("timed out") || s.contains("deadline") {
+        return "timeout";
+    }
+    if s.contains("network")
+        || s.contains("connection")
+        || s.contains("websocket")
+        || s.contains("econn")
+        || s.contains("dns")
+    {
+        return "network";
+    }
+    if s.contains("401")
+        || s.contains("403")
+        || s.contains("unauthor")
+        || s.contains("credential")
+        || s.contains("no xai")
+        || s.contains("bearer")
+        || s.contains("auth")
+    {
+        return "auth";
+    }
+    if s.contains("not available") || s.contains("not_available") {
+        return "not_available";
+    }
+    if s.contains("unknown tool") || s.contains("tool ") {
+        return "tool_failed";
+    }
+    "unknown"
+}
+
+/// Soft-fail classes: return structured tool result instead of killing the loop.
+pub fn is_soft_tool_error(class: &str) -> bool {
+    matches!(class, "cli_missing")
+}
+
+/// Honest soft-fail payload for the voice model (never invent success).
+pub fn soft_fail_result(reason: &str, message: &str) -> Value {
+    json!({
+        "ok": false,
+        "reason": reason,
+        "message": message,
+    })
+}
+
+/// Read soft-fail reason from a tool result object (`ok: false` only).
+pub fn soft_fail_reason(result: &Value) -> Option<String> {
+    if result.get("ok").and_then(|x| x.as_bool()) == Some(false) {
+        let reason = result
+            .get("reason")
+            .and_then(|x| x.as_str())
+            .unwrap_or("unknown")
+            .trim()
+            .to_string();
+        Some(if reason.is_empty() {
+            "unknown".into()
+        } else {
+            reason
+        })
+    } else {
+        None
+    }
+}
+
 /// Mock tool executor for tests / GROK_APP_VOICE=mock without a live agent.
 pub fn mock_execute_tool(name: &str, args_json: &str) -> Result<Value, String> {
     let tool = VoiceToolName::parse(name).ok_or_else(|| format!("unknown tool: {name}"))?;
@@ -286,5 +376,31 @@ mod tests {
         let s = live_voice_instructions(Some("/tmp/app"), Some("app"));
         assert!(s.contains("app"));
         assert!(s.contains("create_agent_session"));
+    }
+
+    #[test]
+    fn classifies_cli_missing_as_soft() {
+        assert_eq!(
+            classify_tool_error("Grok Build CLI not found. Install Grok Build or set path in Settings."),
+            "cli_missing"
+        );
+        assert!(is_soft_tool_error("cli_missing"));
+        assert!(!is_soft_tool_error("auth"));
+        let out = soft_fail_result("cli_missing", "missing");
+        assert_eq!(out["ok"], false);
+        assert_eq!(soft_fail_reason(&out).as_deref(), Some("cli_missing"));
+        assert_eq!(soft_fail_reason(&json!({ "session_id": "x" })), None);
+    }
+
+    #[test]
+    fn classifies_auth_and_network() {
+        assert_eq!(
+            classify_tool_error("No xAI credentials found"),
+            "auth"
+        );
+        assert_eq!(
+            classify_tool_error("voice websocket connect failed"),
+            "network"
+        );
     }
 }

--- a/src/components/VoiceOverlay.tsx
+++ b/src/components/VoiceOverlay.tsx
@@ -1,10 +1,11 @@
 /**
  * Live Voice overlay — full-duplex session UI + delegated agent chips.
  *
- * Status (listening / thinking / speaking) comes from host voice:// events
- * only. Transcript text is never invented (no fake STT). Optional “send
- * transcript to active session as prompt” appears only when the host/app
- * provides a send callback and conversational host text exists.
+ * Status (listening / thinking / speaking / Build tool loop) comes from
+ * host voice:// events only. Transcript text is never invented (no fake STT).
+ * Mic / CLI missing soft-fails with clear copy; host tools surface running →
+ * ok / soft_fail / error. Optional “send transcript to active session”
+ * only when host/app provides a send callback and conversational text exists.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
@@ -19,14 +20,23 @@ import {
 import { playPcm16Base64, startPcmCapture } from "@/lib/voiceAudio";
 import {
   canSendTranscriptAsPrompt,
+  classifyLiveVoiceError,
   deriveVoiceDelegatePhase,
   formatTranscriptAsPrompt,
   hasDelegatedSessions,
+  initialToolLoopState,
+  isSoftMicFailure,
+  isToolLoopBusy,
+  liveVoiceErrorMessageKey,
   mergeTranscriptLine,
   nextAwaitingResponse,
-  toolEventName,
+  parseToolLoopEvent,
+  reduceToolLoopState,
+  toolLoopStatusMessageKey,
   transcriptEmptyKind,
   type VoiceDelegatePhase,
+  type VoiceLiveErrorClass,
+  type VoiceToolLoopState,
   type VoiceTranscriptLine,
 } from "@/lib/voiceOverlay";
 import type { Locale, MessageKey } from "@/i18n";
@@ -72,6 +82,21 @@ function phaseMessageKey(phase: VoiceDelegatePhase): MessageKey {
   }
 }
 
+/** Humanize a classified Live Voice error (i18n). Falls back to generic. */
+function formatLiveError(
+  tt: (key: MessageKey, vars?: Record<string, string | number>) => string,
+  raw: string | null | undefined,
+  errorClass?: string | null,
+): string {
+  const cls = classifyLiveVoiceError(raw, errorClass);
+  const key = liveVoiceErrorMessageKey(cls) as MessageKey;
+  const localized = tt(key);
+  // If catalog missing for some reason, still surface something honest.
+  if (localized && localized !== key) return localized;
+  if (raw?.trim()) return tt("voice.error", { message: raw.trim() });
+  return tt("voice.err.unknown");
+}
+
 export function VoiceOverlay({
   locale,
   open,
@@ -91,10 +116,17 @@ export function VoiceOverlay({
   );
   const [state, setState] = useState<VoiceSessionState | null>(null);
   const [lines, setLines] = useState<VoiceTranscriptLine[]>([]);
+  /** Fatal UI/host error (forces error phase). */
   const [error, setError] = useState<string | null>(null);
+  /** Soft mic warning — host may still be active (playback / tools). */
+  const [softMicWarning, setSoftMicWarning] =
+    useState<VoiceLiveErrorClass | null>(null);
   const [busy, setBusy] = useState(false);
   const [awaitingResponse, setAwaitingResponse] = useState(false);
   const [sendingPrompt, setSendingPrompt] = useState(false);
+  const [toolLoop, setToolLoop] = useState<VoiceToolLoopState>(
+    initialToolLoopState,
+  );
   const stopCapture = useRef<(() => void) | null>(null);
   const started = useRef(false);
 
@@ -108,20 +140,60 @@ export function VoiceOverlay({
     [],
   );
 
+  const applyToolEvent = useCallback(
+    (payload: {
+      name?: string | null;
+      status?: string | null;
+      reason?: string | null;
+      message?: string | null;
+      sessionId?: string | null;
+      session_id?: string | null;
+      result?: unknown;
+      errorClass?: string | null;
+    }) => {
+      const parsed = parseToolLoopEvent(payload);
+      if (!parsed) return;
+      setToolLoop((prev) => reduceToolLoopState(prev, parsed));
+      const key = toolLoopStatusMessageKey(parsed);
+      if (key && parsed.name) {
+        const vars: Record<string, string | number> = { name: parsed.name };
+        if (parsed.reason) vars.reason = parsed.reason;
+        appendLine("system", tt(key, vars), true);
+      }
+      if (
+        parsed.name === "create_agent_session" ||
+        parsed.name === "prompt_agent"
+      ) {
+        window.dispatchEvent(
+          new CustomEvent("grok-app:voice-session-changed"),
+        );
+      }
+      // Refresh delegated chips after host tool updates.
+      void voiceState()
+        .then(setState)
+        .catch(() => {});
+    },
+    [appendLine, tt],
+  );
+
   useEffect(() => {
     if (!open) {
       started.current = false;
       stopCapture.current?.();
       stopCapture.current = null;
       setAwaitingResponse(false);
+      setToolLoop(initialToolLoopState());
+      setSoftMicWarning(null);
       return;
     }
     if (started.current) return;
     started.current = true;
     setBusy(true);
     setError(null);
+    setSoftMicWarning(null);
     setLines([]);
     setAwaitingResponse(false);
+    setToolLoop(initialToolLoopState());
 
     let unsubs: Array<() => void> = [];
 
@@ -141,20 +213,41 @@ export function VoiceOverlay({
           true,
         );
 
-        // Mic → host (skip in pure mock if getUserMedia fails)
+        // Mic → host. Soft-fail when missing/denied: session stays up for
+        // playback + Build tools; only warn (do not hard-kill the overlay).
         try {
           const cap = await startPcmCapture((b64) => {
             void voicePushPcm(b64).catch(() => {});
           });
           stopCapture.current = cap.stop;
-        } catch {
-          setError(tt("voice.micDenied"));
+        } catch (micErr) {
+          const cls = classifyLiveVoiceError(String(micErr));
+          if (isSoftMicFailure(cls)) {
+            setSoftMicWarning(cls);
+            appendLine("system", tt(liveVoiceErrorMessageKey(cls) as MessageKey), true);
+          } else {
+            setError(formatLiveError(tt, String(micErr)));
+          }
         }
 
         const u1 = await listen<VoiceSessionState>("voice://state", (e) => {
           setState(e.payload);
           if (e.payload.speaking) {
             setAwaitingResponse(false);
+          }
+          // Host activeTool mirrors tool-loop busy when present.
+          const active = e.payload.activeTool?.trim();
+          if (active) {
+            setToolLoop((prev) =>
+              prev.status === "running" && prev.name === active
+                ? prev
+                : {
+                    status: "running",
+                    name: active,
+                    reason: null,
+                    sessionId: prev.sessionId,
+                  },
+            );
           }
         });
         unsubs.push(u1);
@@ -178,42 +271,42 @@ export function VoiceOverlay({
         });
         unsubs.push(u3);
 
-        const u4 = await listen<{ message?: string }>("voice://error", (e) => {
-          setError(
-            tt("voice.error", { message: e.payload.message ?? "unknown" }),
+        const u4 = await listen<{
+          message?: string;
+          errorClass?: string;
+        }>("voice://error", (e) => {
+          const cls = classifyLiveVoiceError(
+            e.payload.message,
+            e.payload.errorClass,
           );
+          if (isSoftMicFailure(cls)) {
+            setSoftMicWarning(cls);
+            appendLine(
+              "system",
+              tt(liveVoiceErrorMessageKey(cls) as MessageKey),
+              true,
+            );
+            return;
+          }
+          setError(formatLiveError(tt, e.payload.message, e.payload.errorClass));
         });
         unsubs.push(u4);
 
-        const u5 = await listen<{ name?: string }>("voice://tool", (e) => {
-          const name = toolEventName(e.payload);
-          if (name) {
-            appendLine(
-              "system",
-              tt("voice.toolRan", { name }),
-              true,
-            );
-          }
-          if (name === "create_agent_session" || name === "prompt_agent") {
-            window.dispatchEvent(
-              new CustomEvent("grok-app:voice-session-changed"),
-            );
-          }
-          // Refresh delegated chips after host tool completes.
-          void voiceState()
-            .then(setState)
-            .catch(() => {});
+        const u5 = await listen<Record<string, unknown>>("voice://tool", (e) => {
+          applyToolEvent(e.payload as Parameters<typeof applyToolEvent>[0]);
         });
         unsubs.push(u5);
 
         const u6 = await listen("voice://tool_result", () => {
+          // Lifecycle lines come from voice://tool (running/ok/soft_fail/error).
+          // tool_result only refreshes delegated chips — avoid double-append.
           void voiceState()
             .then(setState)
             .catch(() => {});
         });
         unsubs.push(u6);
       } catch (e) {
-        setError(String(e));
+        setError(formatLiveError(tt, String(e)));
       } finally {
         setBusy(false);
       }
@@ -236,6 +329,7 @@ export function VoiceOverlay({
     voiceId,
     keepAgentsOnEnd,
     appendLine,
+    applyToolEvent,
     tt,
   ]);
 
@@ -264,7 +358,7 @@ export function VoiceOverlay({
       const st = await voiceState();
       setState(st);
     } catch (e) {
-      setError(String(e));
+      setError(formatLiveError(tt, String(e)));
     }
   };
 
@@ -279,13 +373,20 @@ export function VoiceOverlay({
     transcriptText: transcriptPrompt,
   });
   const emptyKind = transcriptEmptyKind(lines);
+  const toolBusy = isToolLoopBusy(toolLoop);
   const phase = deriveVoiceDelegatePhase({
     connecting: busy,
     uiError: error,
+    softMicWarning,
     state,
+    toolBusy,
     awaitingResponse,
   });
   const statusLabel = tt(phaseMessageKey(phase));
+  const toolStatusKey = toolLoopStatusMessageKey(toolLoop);
+  const softMicLabel = softMicWarning
+    ? tt(liveVoiceErrorMessageKey(softMicWarning) as MessageKey)
+    : null;
 
   const handleSendTranscript = async () => {
     if (!showSend || !onSendTranscriptAsPrompt || !transcriptPrompt.trim()) {
@@ -295,7 +396,7 @@ export function VoiceOverlay({
     try {
       await onSendTranscriptAsPrompt(transcriptPrompt);
     } catch (e) {
-      setError(String(e));
+      setError(formatLiveError(tt, String(e)));
     } finally {
       setSendingPrompt(false);
     }
@@ -319,6 +420,8 @@ export function VoiceOverlay({
                 `voice-overlay__status--${phase}`,
               )}
               data-phase={phase}
+              data-tool-status={toolLoop.status}
+              data-tool-name={toolLoop.name ?? undefined}
             >
               <span
                 className={cn(
@@ -328,6 +431,14 @@ export function VoiceOverlay({
                 aria-hidden
               />
               {statusLabel}
+              {toolStatusKey && toolLoop.name && toolBusy ? (
+                <span className="voice-overlay__tool-chip">
+                  {tt(toolStatusKey, {
+                    name: toolLoop.name,
+                    reason: toolLoop.reason ?? "",
+                  })}
+                </span>
+              ) : null}
             </div>
           </div>
           <button
@@ -340,6 +451,11 @@ export function VoiceOverlay({
         </header>
 
         {error ? <div className="voice-overlay__error">{error}</div> : null}
+        {!error && softMicLabel ? (
+          <div className="voice-overlay__warn" role="status">
+            {softMicLabel}
+          </div>
+        ) : null}
 
         <div className="voice-overlay__wave" aria-hidden>
           <span

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -3851,7 +3851,26 @@ const en = {
   "voice.ready": "Voice ready",
   "voice.micDenied": "Microphone permission denied",
   "voice.error": "Voice error: {message}",
-  "voice.toolRan": "Tool finished: {name}",
+  "voice.toolRunning": "Build tool running: {name}\u2026",
+  "voice.toolRan": "Build tool finished: {name}",
+  "voice.toolSoftFail":
+    "Build tool soft-failed ({name}): {reason}. Voice stays open — fix CLI/mic and retry.",
+  "voice.toolFailed": "Build tool failed: {name}",
+  "voice.err.mic_denied":
+    "Microphone permission denied. Live Voice can still play audio and run Build tools without capture.",
+  "voice.err.mic_missing":
+    "No microphone found. Live Voice can still play audio and run Build tools without capture.",
+  "voice.err.cli_missing":
+    "Grok Build CLI not found. Install Grok Build or set the path under Settings \u2192 Runtime.",
+  "voice.err.auth":
+    "Voice auth failed. Sign in with Grok CLI (`grok login`) or add an official API key under Account.",
+  "voice.err.network":
+    "Could not reach the voice service. Check network and try again.",
+  "voice.err.timeout": "Voice request timed out. Try again.",
+  "voice.err.tool_failed": "A Build tool call failed. See the tool status line.",
+  "voice.err.not_available":
+    "Live Voice is not available with the current auth or provider setup.",
+  "voice.err.unknown": "Live Voice failed for an unknown reason.",
   "voice.connecting": "Connecting\u2026",
   "voice.speaking": "Speaking\u2026",
   "voice.thinking": "Thinking\u2026",
@@ -7848,7 +7867,24 @@ const zh: Record<MessageKey, string> = {
   "voice.ready": "语音已就绪",
   "voice.micDenied": "麦克风权限被拒绝",
   "voice.error": "语音错误：{message}",
-  "voice.toolRan": "工具已完成：{name}",
+  "voice.toolRunning": "Build 工具运行中：{name}…",
+  "voice.toolRan": "Build 工具已完成：{name}",
+  "voice.toolSoftFail":
+    "Build 工具软失败（{name}）：{reason}。语音会话保持开启 — 请修复 CLI/麦克风后重试。",
+  "voice.toolFailed": "Build 工具失败：{name}",
+  "voice.err.mic_denied":
+    "麦克风权限被拒绝。实时语音仍可播放音频并运行 Build 工具（无采集）。",
+  "voice.err.mic_missing":
+    "未检测到麦克风。实时语音仍可播放音频并运行 Build 工具（无采集）。",
+  "voice.err.cli_missing":
+    "未找到 Grok Build CLI。请安装 Grok Build，或在 设置 → 运行时 中配置路径。",
+  "voice.err.auth":
+    "语音鉴权失败。请用 Grok CLI 登录（`grok login`），或在账户中添加官方 API key。",
+  "voice.err.network": "无法连接语音服务，请检查网络后重试。",
+  "voice.err.timeout": "语音请求超时，请重试。",
+  "voice.err.tool_failed": "Build 工具调用失败，请查看工具状态行。",
+  "voice.err.not_available": "当前鉴权或供应商配置下不可用实时语音。",
+  "voice.err.unknown": "实时语音因未知原因失败。",
   "voice.connecting": "连接中…",
   "voice.speaking": "正在说话…",
   "voice.thinking": "思考中…",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -3715,7 +3715,24 @@ export const zhTW: Record<MessageKey, string> = {
   "voice.ready": "語音已就緒",
   "voice.micDenied": "麥克風權限被拒絕",
   "voice.error": "語音錯誤：{message}",
-  "voice.toolRan": "工具已完成：{name}",
+  "voice.toolRunning": "Build 工具執行中：{name}…",
+  "voice.toolRan": "Build 工具已完成：{name}",
+  "voice.toolSoftFail":
+    "Build 工具軟失敗（{name}）：{reason}。語音工作階段保持開啟 — 請修復 CLI/麥克風後重試。",
+  "voice.toolFailed": "Build 工具失敗：{name}",
+  "voice.err.mic_denied":
+    "麥克風權限被拒絕。即時語音仍可播放音訊並執行 Build 工具（無擷取）。",
+  "voice.err.mic_missing":
+    "未偵測到麥克風。即時語音仍可播放音訊並執行 Build 工具（無擷取）。",
+  "voice.err.cli_missing":
+    "未找到 Grok Build CLI。請安裝 Grok Build，或在 設定 → 執行階段 中設定路徑。",
+  "voice.err.auth":
+    "語音驗證失敗。請用 Grok CLI 登入（`grok login`），或在帳戶中新增官方 API key。",
+  "voice.err.network": "無法連線語音服務，請檢查網路後重試。",
+  "voice.err.timeout": "語音請求逾時，請重試。",
+  "voice.err.tool_failed": "Build 工具呼叫失敗，請查看工具狀態列。",
+  "voice.err.not_available": "目前驗證或供應商設定下無法使用即時語音。",
+  "voice.err.unknown": "即時語音因未知原因失敗。",
   "voice.connecting": "連線中…",
   "voice.speaking": "正在說話…",
   "voice.thinking": "思考中…",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3708,6 +3708,8 @@ export interface VoiceSessionState {
   speaking?: boolean;
   /** Host: model / tool turn in progress (from voice://state). */
   thinking?: boolean;
+  /** Host: in-flight Build tool name while voice → agent loop runs. */
+  activeTool?: string | null;
 }
 
 export async function voiceState(): Promise<VoiceSessionState> {
@@ -3738,11 +3740,19 @@ export async function voicePushPcm(pcmBase64: string): Promise<void> {
   return invoke<void>("voice_push_pcm", { pcmBase64 });
 }
 
+/**
+ * Invoke a Live Voice host tool (mock / debug / demo delegate).
+ * Host expects `argsJson` string; objects are serialized.
+ */
 export async function voiceInvokeTool(
   name: string,
-  args?: any,
+  args?: string | Record<string, unknown> | null,
 ): Promise<unknown> {
-  return invoke<unknown>("voice_invoke_tool", { name, args: args ?? {} });
+  const argsJson =
+    typeof args === "string"
+      ? args
+      : JSON.stringify(args ?? {});
+  return invoke<unknown>("voice_invoke_tool", { name, argsJson });
 }
 
 

--- a/src/lib/voiceOverlay.test.ts
+++ b/src/lib/voiceOverlay.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
   canSendTranscriptAsPrompt,
+  classifyLiveVoiceError,
   deriveVoiceDelegatePhase,
   formatTranscriptAsPrompt,
   hasDelegatedSessions,
+  initialToolLoopState,
   isConversationalRole,
+  isFatalLiveVoiceError,
+  isSoftMicFailure,
+  isToolLoopBusy,
+  liveVoiceErrorMessageKey,
   mergeTranscriptLine,
   nextAwaitingResponse,
+  parseToolLoopEvent,
+  reduceToolLoopState,
+  softFailReasonFromToolResult,
   toolEventName,
+  toolLoopStatusMessageKey,
   transcriptEmptyKind,
   type VoiceTranscriptLine,
 } from "./voiceOverlay";
@@ -28,16 +38,38 @@ describe("deriveVoiceDelegatePhase", () => {
     ).toBe("ended");
   });
 
-  it("surfaces error from ui or host", () => {
+  it("surfaces fatal error from ui or host", () => {
     expect(
       deriveVoiceDelegatePhase({
-        uiError: "mic denied",
+        uiError: "auth failed",
         state: { active: true, listening: true },
       }),
     ).toBe("error");
     expect(
       deriveVoiceDelegatePhase({
         state: { active: true, error: "ws down", listening: true },
+      }),
+    ).toBe("error");
+  });
+
+  it("soft-fails mic: keeps listening while host is active", () => {
+    expect(
+      deriveVoiceDelegatePhase({
+        softMicWarning: "mic_denied",
+        state: { active: true, listening: true },
+      }),
+    ).toBe("listening");
+    expect(
+      deriveVoiceDelegatePhase({
+        softMicWarning: "mic_missing",
+        state: { active: true, thinking: true },
+      }),
+    ).toBe("thinking");
+    // No host yet → still show error so the user sees the mic issue.
+    expect(
+      deriveVoiceDelegatePhase({
+        softMicWarning: "mic_denied",
+        state: { active: false },
       }),
     ).toBe("error");
   });
@@ -86,6 +118,11 @@ describe("deriveVoiceDelegatePhase", () => {
     ).toBe("thinking");
     expect(
       deriveVoiceDelegatePhase({
+        state: { active: true, activeTool: "create_agent_session", listening: true },
+      }),
+    ).toBe("thinking");
+    expect(
+      deriveVoiceDelegatePhase({
         awaitingResponse: true,
         state: { active: true, listening: true },
       }),
@@ -103,6 +140,127 @@ describe("deriveVoiceDelegatePhase", () => {
         state: { active: true, listening: false, speaking: false },
       }),
     ).toBe("thinking");
+  });
+});
+
+describe("classifyLiveVoiceError / soft mic", () => {
+  it("classifies cli_missing and auth", () => {
+    expect(classifyLiveVoiceError("Grok Build CLI not found")).toBe(
+      "cli_missing",
+    );
+    expect(classifyLiveVoiceError(null, "cli_missing")).toBe("cli_missing");
+    expect(classifyLiveVoiceError("No xAI credentials found")).toBe("auth");
+    expect(classifyLiveVoiceError("websocket connect failed")).toBe("network");
+    expect(classifyLiveVoiceError("tool create_agent_session: boom")).toBe(
+      "tool_failed",
+    );
+  });
+
+  it("treats mic as soft, others as fatal", () => {
+    expect(isSoftMicFailure("mic_denied")).toBe(true);
+    expect(isSoftMicFailure("mic_missing")).toBe(true);
+    expect(isSoftMicFailure("cli_missing")).toBe(false);
+    expect(isFatalLiveVoiceError("mic_denied")).toBe(false);
+    expect(isFatalLiveVoiceError("cli_missing")).toBe(true);
+    expect(isFatalLiveVoiceError("auth")).toBe(true);
+  });
+
+  it("maps to i18n keys", () => {
+    expect(liveVoiceErrorMessageKey("cli_missing")).toBe(
+      "voice.err.cli_missing",
+    );
+    expect(liveVoiceErrorMessageKey("mic_denied")).toBe("voice.err.mic_denied");
+  });
+});
+
+describe("voice → Build tool loop", () => {
+  it("parses running / ok / soft_fail / error events", () => {
+    expect(
+      parseToolLoopEvent({ name: "create_agent_session", status: "running" }),
+    ).toEqual({
+      status: "running",
+      name: "create_agent_session",
+      reason: null,
+      sessionId: null,
+    });
+    expect(
+      parseToolLoopEvent({
+        name: "prompt_agent",
+        status: "ok",
+        result: { session_id: "abc", state: "streaming" },
+      }),
+    ).toEqual({
+      status: "ok",
+      name: "prompt_agent",
+      reason: null,
+      sessionId: "abc",
+    });
+    expect(
+      parseToolLoopEvent({
+        name: "create_agent_session",
+        status: "soft_fail",
+        reason: "cli_missing",
+        result: { ok: false, reason: "cli_missing" },
+      })?.status,
+    ).toBe("soft_fail");
+    expect(
+      parseToolLoopEvent({
+        name: "cancel_agent",
+        status: "error",
+        message: "unknown tool",
+        errorClass: "tool_failed",
+      })?.reason,
+    ).toBe("tool_failed");
+  });
+
+  it("never invents a tool name", () => {
+    expect(parseToolLoopEvent({ status: "running" })).toBeNull();
+    expect(parseToolLoopEvent(null)).toBeNull();
+  });
+
+  it("treats legacy finish-with-result as ok (or soft_fail)", () => {
+    expect(
+      parseToolLoopEvent({
+        name: "list_sessions",
+        result: { sessions: [] },
+      })?.status,
+    ).toBe("ok");
+    expect(
+      parseToolLoopEvent({
+        name: "create_agent_session",
+        result: { ok: false, reason: "cli_missing" },
+      }),
+    ).toMatchObject({ status: "soft_fail", reason: "cli_missing" });
+  });
+
+  it("reduces busy state and status keys", () => {
+    let loop = initialToolLoopState();
+    expect(isToolLoopBusy(loop)).toBe(false);
+    loop = reduceToolLoopState(
+      loop,
+      parseToolLoopEvent({ name: "prompt_agent", status: "running" }),
+    );
+    expect(isToolLoopBusy(loop)).toBe(true);
+    expect(toolLoopStatusMessageKey(loop)).toBe("voice.toolRunning");
+    loop = reduceToolLoopState(
+      loop,
+      parseToolLoopEvent({
+        name: "prompt_agent",
+        status: "ok",
+        result: { session_id: "s1" },
+      }),
+    );
+    expect(isToolLoopBusy(loop)).toBe(false);
+    expect(toolLoopStatusMessageKey(loop)).toBe("voice.toolRan");
+    expect(toolLoopStatusMessageKey(initialToolLoopState())).toBeNull();
+  });
+
+  it("reads soft-fail reason only when ok:false", () => {
+    expect(softFailReasonFromToolResult({ ok: false, reason: "cli_missing" })).toBe(
+      "cli_missing",
+    );
+    expect(softFailReasonFromToolResult({ session_id: "x" })).toBeNull();
+    expect(softFailReasonFromToolResult(null)).toBeNull();
   });
 });
 

--- a/src/lib/voiceOverlay.ts
+++ b/src/lib/voiceOverlay.ts
@@ -1,9 +1,10 @@
 /**
  * Pure helpers for Live Voice overlay — delegate phase, transcript merge,
- * and optional “send transcript as prompt” gating.
+ * Build tool-loop status (VOX-BUILD-LOOP), and optional “send transcript
+ * as prompt” gating.
  *
  * Sources: host `voice://state` / transcript / tool events only.
- * Never invent STT partials or fake speech text.
+ * Never invent STT partials, fake tool results, or speech text.
  */
 
 /** High-level UI phase for the Live Voice overlay status line. */
@@ -16,6 +17,40 @@ export type VoiceDelegatePhase =
   | "error"
   | "ended";
 
+/**
+ * Stable error classes for Live Voice + Build tool loop (i18n keys).
+ * Mic failures are soft when the host session is otherwise alive.
+ */
+export type VoiceLiveErrorClass =
+  | "mic_denied"
+  | "mic_missing"
+  | "cli_missing"
+  | "auth"
+  | "network"
+  | "timeout"
+  | "tool_failed"
+  | "not_available"
+  | "unknown";
+
+/** Host Build tool lifecycle for voice → agent delegation. */
+export type VoiceToolLoopStatus =
+  | "idle"
+  | "running"
+  | "ok"
+  | "soft_fail"
+  | "error";
+
+/** Client-side tool-loop snapshot (from host events only). */
+export type VoiceToolLoopState = {
+  status: VoiceToolLoopStatus;
+  /** Tool name when known; null when idle / absent. */
+  name: string | null;
+  /** Soft-fail / error reason token when present (e.g. cli_missing). */
+  reason: string | null;
+  /** Delegated session id from tool result when present. */
+  sessionId: string | null;
+};
+
 /** Subset of host VoiceSessionState used for phase derivation. */
 export type VoiceHostStateLike = {
   active?: boolean | null;
@@ -25,6 +60,8 @@ export type VoiceHostStateLike = {
   speaking?: boolean | null;
   thinking?: boolean | null;
   error?: string | null;
+  /** Host-reported in-flight tool name (optional). */
+  activeTool?: string | null;
   delegatedSessionIds?: string[] | null;
   mock?: boolean | null;
 };
@@ -42,13 +79,21 @@ export type DeriveVoiceDelegatePhaseInput = {
   connecting?: boolean;
   /** Overlay closed after stop. */
   ended?: boolean;
-  /** Local UI error (mic denied, start failure). */
+  /**
+   * Fatal UI/host error text. Soft mic warnings should not be passed here
+   * when the host session is still active (use softMicWarning instead).
+   */
   uiError?: string | null;
+  /**
+   * Soft mic failure class (denied / missing). Does not force error phase
+   * while the host session remains active — voice can still play / tools run.
+   */
+  softMicWarning?: VoiceLiveErrorClass | null;
   /** Host snapshot from voice_state / voice://state. */
   state?: VoiceHostStateLike | null;
   /**
    * True while a host tool is in-flight (from events). Prefer host
-   * `thinking` when present; this is a client-side supplement.
+   * `thinking` / `activeTool` when present; this is a client-side supplement.
    */
   toolBusy?: boolean;
   /**
@@ -58,9 +103,271 @@ export type DeriveVoiceDelegatePhaseInput = {
   awaitingResponse?: boolean;
 };
 
+const KNOWN_LIVE_ERRORS: readonly VoiceLiveErrorClass[] = [
+  "mic_denied",
+  "mic_missing",
+  "cli_missing",
+  "auth",
+  "network",
+  "timeout",
+  "tool_failed",
+  "not_available",
+  "unknown",
+] as const;
+
+function isLiveErrorClass(s: string): s is VoiceLiveErrorClass {
+  return (KNOWN_LIVE_ERRORS as readonly string[]).includes(s);
+}
+
+/**
+ * Map host/UI failure text (or stable errorClass token) to a Live Voice class.
+ * Never invents success — unknown stays unknown.
+ */
+export function classifyLiveVoiceError(
+  raw: string | null | undefined,
+  errorClass?: string | null,
+): VoiceLiveErrorClass {
+  const token = (errorClass ?? "").trim().toLowerCase();
+  if (token && isLiveErrorClass(token)) return token;
+
+  const s = (raw ?? "").trim().toLowerCase();
+  if (!s) return "unknown";
+  if (isLiveErrorClass(s)) return s;
+
+  if (
+    s.includes("cli not found") ||
+    s.includes("cli_missing") ||
+    s.includes("grok build not found") ||
+    s.includes("grok build cli not found") ||
+    s.includes("install grok build")
+  ) {
+    return "cli_missing";
+  }
+  if (
+    s.includes("not_available") ||
+    s.includes("not available") ||
+    s.includes("no speech auth")
+  ) {
+    return "not_available";
+  }
+  if (
+    s.includes("permission") ||
+    s.includes("denied") ||
+    s.includes("notallowed") ||
+    s.includes("mic_denied")
+  ) {
+    return "mic_denied";
+  }
+  if (
+    s.includes("notfound") ||
+    s.includes("no device") ||
+    s.includes("no microphone") ||
+    s.includes("mic_missing") ||
+    s.includes("device not found")
+  ) {
+    return "mic_missing";
+  }
+  if (
+    s.includes("timeout") ||
+    s.includes("timed out") ||
+    s.includes("deadline")
+  ) {
+    return "timeout";
+  }
+  if (
+    s.includes("network") ||
+    s.includes("fetch") ||
+    s.includes("connection") ||
+    s.includes("websocket") ||
+    s.includes("ws ") ||
+    s.includes("dns") ||
+    s.includes("econn")
+  ) {
+    return "network";
+  }
+  if (
+    s.includes("401") ||
+    s.includes("403") ||
+    s.includes("unauthor") ||
+    s.includes("auth") ||
+    s.includes("bearer") ||
+    s.includes("credential")
+  ) {
+    return "auth";
+  }
+  if (s.includes("tool ") || s.includes("tool_failed") || s.includes("unknown tool")) {
+    return "tool_failed";
+  }
+  return "unknown";
+}
+
+/** Mic denied / missing — soft when host is otherwise alive. */
+export function isSoftMicFailure(cls: VoiceLiveErrorClass | null | undefined): boolean {
+  return cls === "mic_denied" || cls === "mic_missing";
+}
+
+/**
+ * Whether a Live Voice error should force the overlay error phase.
+ * Soft mic failures do not, so playback / tool loop can continue.
+ */
+export function isFatalLiveVoiceError(
+  cls: VoiceLiveErrorClass | null | undefined,
+): boolean {
+  if (!cls) return false;
+  if (isSoftMicFailure(cls)) return false;
+  return true;
+}
+
+/** i18n MessageKey fragment for a classified Live Voice error. */
+export function liveVoiceErrorMessageKey(
+  cls: VoiceLiveErrorClass,
+): `voice.err.${VoiceLiveErrorClass}` {
+  return `voice.err.${cls}`;
+}
+
+export function initialToolLoopState(): VoiceToolLoopState {
+  return { status: "idle", name: null, reason: null, sessionId: null };
+}
+
+/**
+ * Normalize a host `voice://tool` payload. Returns null when name is absent
+ * (never invents a tool). Status defaults: result present → ok, else running
+ * when status omitted for backward compatibility with finish-only events.
+ */
+export function parseToolLoopEvent(payload: {
+  name?: string | null;
+  status?: string | null;
+  reason?: string | null;
+  message?: string | null;
+  sessionId?: string | null;
+  session_id?: string | null;
+  result?: unknown;
+  errorClass?: string | null;
+} | null | undefined): VoiceToolLoopState | null {
+  const name = toolEventName(payload);
+  if (!name) return null;
+
+  const statusRaw = (payload?.status ?? "").trim().toLowerCase();
+  let status: VoiceToolLoopStatus;
+  if (
+    statusRaw === "running" ||
+    statusRaw === "ok" ||
+    statusRaw === "soft_fail" ||
+    statusRaw === "error" ||
+    statusRaw === "idle"
+  ) {
+    status = statusRaw;
+  } else if (payload?.result !== undefined && payload?.result !== null) {
+    // Legacy finish event with result but no status.
+    const soft = softFailReasonFromToolResult(payload.result);
+    status = soft ? "soft_fail" : "ok";
+  } else if (statusRaw === "failed" || statusRaw === "err") {
+    status = "error";
+  } else {
+    // Name-only without status: treat as in-flight (start event).
+    status = "running";
+  }
+
+  let reason =
+    (payload?.reason ?? "").trim() ||
+    softFailReasonFromToolResult(payload?.result) ||
+    null;
+  if (!reason && status === "error") {
+    const cls = classifyLiveVoiceError(
+      payload?.message,
+      payload?.errorClass,
+    );
+    reason = cls === "unknown" ? null : cls;
+  }
+
+  const sessionId =
+    (payload?.sessionId ?? payload?.session_id ?? "").trim() ||
+    sessionIdFromToolResult(payload?.result) ||
+    null;
+
+  return {
+    status,
+    name,
+    reason,
+    sessionId,
+  };
+}
+
+/** Reduce tool-loop state from a parsed event (host order only). */
+export function reduceToolLoopState(
+  prev: VoiceToolLoopState,
+  next: VoiceToolLoopState | null,
+): VoiceToolLoopState {
+  if (!next) return prev;
+  if (next.status === "idle") return initialToolLoopState();
+  return {
+    status: next.status,
+    name: next.name ?? prev.name,
+    reason: next.reason,
+    sessionId: next.sessionId ?? prev.sessionId,
+  };
+}
+
+/** True while a Build tool is in-flight. */
+export function isToolLoopBusy(loop: VoiceToolLoopState | null | undefined): boolean {
+  return loop?.status === "running";
+}
+
+/**
+ * Extract soft-fail reason from a host tool result object.
+ * Only trusts explicit `ok: false` + `reason` — never invents failures.
+ */
+export function softFailReasonFromToolResult(
+  result: unknown,
+): string | null {
+  if (!result || typeof result !== "object") return null;
+  const r = result as Record<string, unknown>;
+  if (r.ok === false) {
+    const reason = typeof r.reason === "string" ? r.reason.trim() : "";
+    return reason || "unknown";
+  }
+  return null;
+}
+
+function sessionIdFromToolResult(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null;
+  const r = result as Record<string, unknown>;
+  const sid = r.session_id ?? r.sessionId;
+  if (typeof sid === "string" && sid.trim()) return sid.trim();
+  return null;
+}
+
+/**
+ * i18n key for the tool-loop status line. Null when idle (no chrome).
+ * Callers interpolate `{name}` / `{reason}` as needed.
+ */
+export function toolLoopStatusMessageKey(
+  loop: VoiceToolLoopState | null | undefined,
+):
+  | "voice.toolRunning"
+  | "voice.toolRan"
+  | "voice.toolSoftFail"
+  | "voice.toolFailed"
+  | null {
+  if (!loop || loop.status === "idle" || !loop.name) return null;
+  switch (loop.status) {
+    case "running":
+      return "voice.toolRunning";
+    case "ok":
+      return "voice.toolRan";
+    case "soft_fail":
+      return "voice.toolSoftFail";
+    case "error":
+      return "voice.toolFailed";
+    default:
+      return null;
+  }
+}
+
 /**
  * Derive overlay status: speaking > thinking > listening > connecting/idle.
  * Prefers explicit host `phase` / `thinking` when present.
+ * Soft mic warnings do not force error while the host session is active.
  */
 export function deriveVoiceDelegatePhase(
   input: DeriveVoiceDelegatePhaseInput,
@@ -73,7 +380,13 @@ export function deriveVoiceDelegatePhase(
   if (hostErr || uiErr) return "error";
 
   const st = input.state;
-  if (!st?.active) return "idle";
+  if (!st?.active) {
+    // Soft mic only and no host yet → still surface error so the user sees it.
+    if (input.softMicWarning && isSoftMicFailure(input.softMicWarning)) {
+      return "error";
+    }
+    return "idle";
+  }
 
   const phaseRaw = (st.phase ?? "").trim().toLowerCase();
   if (
@@ -88,7 +401,8 @@ export function deriveVoiceDelegatePhase(
   }
 
   if (st.speaking) return "speaking";
-  if (st.thinking || input.toolBusy || input.awaitingResponse) {
+  const hostToolBusy = Boolean(st.activeTool?.trim());
+  if (st.thinking || input.toolBusy || hostToolBusy || input.awaitingResponse) {
     return "thinking";
   }
   if (st.listening) return "listening";

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21485,6 +21485,21 @@ div.composer__input:empty::before {
   font-weight: 600;
   cursor: pointer;
 }
+.voice-overlay__tool-chip {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.85;
+  font-weight: 500;
+}
+.voice-overlay__warn {
+  margin: 0.5rem 1rem 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  background: color-mix(in srgb, #f59e0b 18%, transparent);
+  color: #fde68a;
+  font-size: 0.8125rem;
+  line-height: 1.35;
+}
 .voice-overlay__error {
   font-size: 0.8rem;
   color: #fda4af;


### PR DESCRIPTION
## Summary

Honesty improvements for **voice-driven Grok Build** (VOX-BUILD-LOOP), building on VOX-DELEG:

- **Tool loop status**: host emits `voice://tool` with `status: running | ok | soft_fail | error` and sets `activeTool` on `voice://state`; overlay shows a Build tool chip + system transcript lines (never invents tool results)
- **Clearer errors**: classified Live Voice / Build errors (`voice.err.*` — mic, CLI, auth, network, timeout, tool_failed, …) in en / zh / zh-TW
- **Soft-fail mic**: missing or denied mic warns but **keeps the session** for playback and Build tools (does not force fatal error phase while host is active)
- **Soft-fail CLI missing**: tool execution returns `{ ok: false, reason: "cli_missing", message }` instead of killing the voice session; model can narrate honestly
- Pure helpers + tests (`voiceOverlay.ts`); Rust classifiers in `voice_tools.rs`; fixed `voiceInvokeTool` to pass `argsJson`

## Anchors

- `src-tauri/src/voice_host.rs` — tool lifecycle emit, `active_tool`, soft-fail path
- `src-tauri/src/voice_tools.rs` — `classify_tool_error` / soft-fail helpers + tests
- `src/lib/voiceOverlay.ts` (+ tests) — phase, tool-loop state, error classes
- `src/components/VoiceOverlay.tsx` — chip, warn banner, classified copy
- `src/lib/api.ts` — `activeTool`, `voiceInvokeTool` argsJson
- i18n en/zh/zh-TW · CHANGELOG Unreleased

## DoD

- [x] `pnpm typecheck`
- [x] vitest: `voiceOverlay.test.ts`, `messages.test.ts` (44 passed)
- [x] `cargo test --lib voice_` (14 passed)
- [x] commit + push + PR

## Test plan

- [ ] Start Live Voice with project open → connecting → listening
- [ ] Deny mic → **warn** banner (soft), status stays listening when host active; no hard kill
- [ ] Mock mode (`GROK_APP_VOICE=mock`) → demo delegate → **tool running** chip → finished + delegated chip
- [ ] Without Grok Build CLI → create_agent_session soft-fails (`cli_missing`); voice stays open; clear system line
- [ ] Auth/network failure on start → classified `voice.err.*` copy (not raw dump only)
- [ ] **Stop** ends overlay; agents kept per settings