### PR TITLE
feat(session): multi-window live lite — send/stop from secondary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ See `docs/llm-wiki/release.md`.
 #### Sessions & sidebar
 - **Continue last agent for this project** (CLI `grok -c/--continue`): project menu + command palette finds the newest agent session under active `GROK_HOME` for the project path, then opens the linked App chat or imports history; soft-fails with a toast when none exist
 - **Duplicate chat** (vs **Fork…** + optional worktree) · **session notes** · **mute** · **unread dot**
-- **Open session in new window** — session menu opens a second Tauri webview with `#/session/<id>` deep link; secondary is **view-only** (no warm-connect / send) so it cannot steal the Host live slot; re-open focuses the existing window; close secondary for real (main still tray/confirm)
+- **Open session in new window** — session menu opens a second Tauri webview with `#/session/<id>` deep link; re-open focuses the existing window; close secondary for real (main still tray/confirm)
+- **Multi-window live (lite)**: secondary session windows can **send / stop** via the shared Host (session-targeted); still skip *passive* warm-connect on open so browsing does not demote main’s agent; honest secondary tip + **Focus main window**; pure `canLiveParticipate` / `shouldSkipWarmConnect` policy + tests
 - **Resume with code restore** — open an existing chat on a clean sibling git worktree at HEAD (session menu + command palette; dirty tree refused; same safety as Fork → restore code)
 - **CLI `--fork-session` on Fork / Resume**: optional checkbox (when a linked agent session exists) creates a **new** agent session id with parent context via ACP `session/fork` (Grok `_x.ai/session/fork` fallback) instead of reusing via `session/load`; one-shot `SessionMeta.forkAgentSession`; source agent session left unchanged
 - **Session rules** (per-chat `grok --rules`; session menu → GlassModal; soft-respawn on change)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -660,6 +660,9 @@ pub fn app_force_quit(app: tauri::AppHandle) {
     app.exit(0);
 }
 
+/// Primary workbench window label (matches tauri.conf.json + frontend multiWindow).
+const MAIN_WINDOW_LABEL: &str = "main";
+
 /// Secondary session window label prefix (`session-<uuid>`). Matches frontend `multiWindow.ts`.
 const SESSION_WINDOW_LABEL_PREFIX: &str = "session-";
 
@@ -685,9 +688,10 @@ fn session_window_label(session_id: &str) -> Option<String> {
 
 /// Open (or focus) a secondary webview window for a chat (`#/session/<id>`).
 ///
-/// Secondary windows are view-focused: the frontend skips warm-connect / send so
-/// they never steal the Host live slot from the main window. Re-opening the same
-/// session focuses the existing window instead of spawning a third copy.
+/// Secondary windows are live-capable (send/stop via shared Host). The frontend
+/// still skips *passive* warm-connect on open so browsing does not demote main’s
+/// agent until the user acts. Re-opening the same session focuses the existing
+/// window instead of spawning a third copy.
 #[tauri::command]
 pub fn open_session_window(
     app: tauri::AppHandle,
@@ -715,7 +719,7 @@ pub fn open_session_window(
         return Ok(());
     }
 
-    // Deep link: frontend parses `#/session/<id>` on boot (view-only mode).
+    // Deep link: frontend parses `#/session/<id>` on boot (secondary live mode).
     let url = format!("index.html#/session/{sid}");
     WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url.into()))
         .title(win_title)
@@ -726,6 +730,20 @@ pub fn open_session_window(
         .center()
         .build()
         .map_err(|e| format!("open session window: {e}"))?;
+    Ok(())
+}
+
+/// Focus (show / unminimize) the primary workbench window from a secondary pane.
+#[tauri::command]
+pub fn focus_main_window(app: tauri::AppHandle) -> Result<(), String> {
+    use tauri::Manager;
+
+    let w = app
+        .get_webview_window(MAIN_WINDOW_LABEL)
+        .ok_or_else(|| "main window not found".to_string())?;
+    let _ = w.show();
+    let _ = w.unminimize();
+    let _ = w.set_focus();
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -344,6 +344,7 @@ pub fn run() {
             commands::cli_session_continue_cwd,
             commands::session_create,
             commands::open_session_window,
+            commands::focus_main_window,
             commands::session_delete,
             commands::session_rename,
             commands::session_set_archived,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,11 +101,12 @@ import {
   saveWindowAlwaysOnTopPref,
 } from "@/lib/windowAlwaysOnTop";
 import {
+  canLiveParticipate,
   canOpenSessionInNewWindow,
   isSessionWindowLabel,
   parseSessionDeepLinkHash,
   resolveSecondarySessionId,
-  shouldSkipAgentSpawn,
+  shouldSkipWarmConnect,
 } from "@/lib/multiWindow";
 import {
   applyChatWidth,
@@ -1258,11 +1259,12 @@ export default function App() {
   const [liveHost, setLiveHost] = useState<SessionSnapshot>(IDLE_SNAPSHOT);
   /**
    * Secondary session window (`session-*` label / `#/session/<id>` deep link).
-   * View-focused: loads journal + follows streams, but never warm-connects / sends
-   * so it cannot steal the Host live slot from the main window.
+   * Live-capable (MULTI-WIN-LITE): send / stop / ensureConnected use the shared
+   * process Host. Passive warm-connect on open is still skipped so browsing a
+   * second pane does not demote main’s agent until the user acts.
    */
   // True only for real `session-*` windows (set after label detect). Hash alone
-  // on main must not disable send.
+  // on main must not change layout / chrome.
   const [isSecondaryWindow, setIsSecondaryWindow] = useState(false);
   const isSecondaryWindowRef = useRef(false);
   isSecondaryWindowRef.current = isSecondaryWindow;
@@ -2689,7 +2691,7 @@ export default function App() {
 
   /**
    * Detect secondary session window early (label + deep-link hash).
-   * Sets view-only mode before warm-connect / last-session restore can run.
+   * Sets role before warm-connect / last-session restore can run.
    */
   useEffect(() => {
     if (!api.isDesktopHost()) {
@@ -2716,8 +2718,9 @@ export default function App() {
           hash: window.location.hash,
           windowLabel: label,
         });
-        // Label wins for view-only: only real session-* windows skip spawn.
-        // Hash alone on main should not disable send (e.g. manual hash edit).
+        // Label wins for secondary role: only real session-* windows skip
+        // passive warm-connect and collapse chrome. Hash alone on main must
+        // not change layout (e.g. manual hash edit).
         setIsSecondaryWindow(secondary);
         isSecondaryWindowRef.current = secondary;
         if (focusId) {
@@ -2746,7 +2749,7 @@ export default function App() {
   }, []);
 
   // Dock / tray busy-session badge from liveMap projection.
-  // Secondary windows must not overwrite the dock badge from a view-only pane.
+  // Secondary windows must not overwrite the dock badge (main owns chrome).
   useEffect(() => {
     if (isSecondaryWindow) return;
     if (!trayBusyBadge) {
@@ -3690,7 +3693,7 @@ export default function App() {
               snap.sessionId === secondaryFocusSessionIdRef.current
             ) {
               // Same chat is already live on Host — mirror state without
-              // warm-connect (view-only still follows streams by session id).
+              // passive warm-connect (secondary still follows streams by id).
               setSession((prev) => ({
                 ...snap,
                 state: reconcileSessionState(snap.state, prev.state),
@@ -5402,9 +5405,10 @@ export default function App() {
     // The next send on this chat will `ensureConnected` intentionally.
     // Skip when project folder is missing (D05) — user must relocate first.
     //
-    // Secondary (view-only) windows never warm-connect — Host live slot is shared
-    // process-wide; connecting from a second webview steals focus from main.
-    if (shouldSkipAgentSpawn(isSecondaryWindowRef.current)) {
+    // Secondary windows skip *passive* warm-connect — Host live slot is shared
+    // process-wide; auto-connect on open would demote main’s agent. Intentional
+    // send still runs ensureConnected (MULTI-WIN-LITE).
+    if (shouldSkipWarmConnect(isSecondaryWindowRef.current)) {
       return;
     }
     const foreignBusy =
@@ -5430,7 +5434,7 @@ export default function App() {
       void (async () => {
         if (viewingSessionIdRef.current !== warmId) return;
         if (sendInFlightRef.current || connectingRef.current) return;
-        if (shouldSkipAgentSpawn(isSecondaryWindowRef.current)) return;
+        if (shouldSkipWarmConnect(isSecondaryWindowRef.current)) return;
         try {
           const snap = await api.sessionConnect({
             projectPath:
@@ -5611,7 +5615,7 @@ export default function App() {
     isSecondaryWindow,
   ]);
 
-  /** Open (or focus) a chat in a secondary view-only webview window. */
+  /** Open (or focus) a chat in a secondary live-capable webview window. */
   const openSessionInNewWindow = useCallback(
     (s: SessionRow) => {
       if (
@@ -5943,11 +5947,12 @@ export default function App() {
       }),
     [session.state, stopLatch],
   );
+  // MULTI-WIN-LITE: secondary shares Host — send/stop allowed (session-targeted).
   const effectiveCanSend =
-    stopGate.sendable && !shouldSkipAgentSpawn(isSecondaryWindow);
-  // Secondary is view-only: stop belongs to the main window's live slot.
+    stopGate.sendable && canLiveParticipate(isSecondaryWindow);
   const effectiveCanStop =
-    !isSecondaryWindow && canStopWithStopLatch(session.state, stopLatch);
+    canLiveParticipate(isSecondaryWindow) &&
+    canStopWithStopLatch(session.state, stopLatch);
 
   const refreshSessions = async () => {
     try {
@@ -7487,8 +7492,8 @@ export default function App() {
       | boolean
       | { force?: boolean; sessionId?: string | null } = false,
   ): Promise<string | null> => {
-    // View-only secondary window: never connect / demote / spawn.
-    if (shouldSkipAgentSpawn(isSecondaryWindowRef.current)) {
+    // MULTI-WIN-LITE: secondary may connect when the user sends (shared Host).
+    if (!canLiveParticipate(isSecondaryWindowRef.current)) {
       return null;
     }
     const opts =
@@ -7773,9 +7778,9 @@ export default function App() {
     fromQueue?: boolean;
     targetSessionId?: string | null;
   }): Promise<boolean> => {
-    // Secondary windows are view-only — never spawn/send from here.
-    if (shouldSkipAgentSpawn(isSecondaryWindowRef.current)) {
-      setLocalError(tr("session.viewOnlyBanner"));
+    // MULTI-WIN-LITE: secondary may send via shared Host (session-targeted).
+    if (!canLiveParticipate(isSecondaryWindowRef.current)) {
+      setLocalError(tr("session.secondaryLiveBanner"));
       return false;
     }
     if (sendInFlightRef.current) return false;
@@ -8104,8 +8109,8 @@ export default function App() {
 
   /** Enqueue when agent is busy; otherwise send immediately. */
   const send = async () => {
-    if (shouldSkipAgentSpawn(isSecondaryWindowRef.current)) {
-      showToast(tr("session.viewOnlyBanner"), 4000);
+    if (!canLiveParticipate(isSecondaryWindowRef.current)) {
+      showToast(tr("session.secondaryLiveBanner"), 4000);
       return;
     }
     const segments = parseStoredContent(draft);
@@ -16546,18 +16551,40 @@ export default function App() {
             </div>
           )}
 
-          {/* Secondary multi-window: honest view-only (no spawn / send from this pane). */}
+          {/* Secondary multi-window: live-capable tip + focus main (MULTI-WIN-LITE). */}
           {isSecondaryWindow && mainPane === "chat" && (
             <div
               className="view-only-banner"
               role="status"
-              aria-label={tr("session.viewOnlyTitle")}
+              aria-label={tr("session.secondaryLiveTitle")}
             >
-              <div className="view-only-banner__title">
-                {tr("session.viewOnlyTitle")}
-              </div>
-              <div className="view-only-banner__body">
-                {tr("session.viewOnlyBanner")}
+              <div className="view-only-banner__row">
+                <div className="view-only-banner__copy">
+                  <div className="view-only-banner__title">
+                    {tr("session.secondaryLiveTitle")}
+                  </div>
+                  <div className="view-only-banner__body">
+                    {tr("session.secondaryLiveBanner")}
+                  </div>
+                </div>
+                {api.isDesktopHost() ? (
+                  <button
+                    type="button"
+                    className="btn btn--ghost view-only-banner__action"
+                    onClick={() => {
+                      void api.focusMainWindow().catch((e) => {
+                        showToast(
+                          tr("session.focusMainWindowFailed") +
+                            ": " +
+                            String(e),
+                          3200,
+                        );
+                      });
+                    }}
+                  >
+                    {tr("session.focusMainWindow")}
+                  </button>
+                ) : null}
               </div>
             </div>
           )}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -208,9 +208,11 @@ const en = {
   "session.openInNewWindowFailed": "Could not open session window",
   "session.openInNewWindowMissing":
     "That chat was not found — it may have been deleted.",
-  "session.viewOnlyTitle": "View only",
-  "session.viewOnlyBanner":
-    "This window is view-only. Agent spawn and send stay in the main window so sessions do not fight over the live slot.",
+  "session.secondaryLiveTitle": "Secondary window",
+  "session.secondaryLiveBanner":
+    "Send and stop work here. Connecting for this chat may move the live agent from the main window until that turn finishes.",
+  "session.focusMainWindow": "Focus main window",
+  "session.focusMainWindowFailed": "Could not focus main window",
   "session.collapseAllActivity": "Collapse all activity",
   "session.collapseAllActivityHint":
     "Collapse expanded tool phases and finished thinking blocks",
@@ -4326,9 +4328,11 @@ const zh: Record<MessageKey, string> = {
   "session.openInNewWindowOk": "已在新窗口打开",
   "session.openInNewWindowFailed": "无法打开会话窗口",
   "session.openInNewWindowMissing": "未找到该会话 — 可能已被删除。",
-  "session.viewOnlyTitle": "仅查看",
-  "session.viewOnlyBanner":
-    "此窗口为仅查看。Agent 启动与发送仍在主窗口，避免多窗口争抢 live 槽位。",
+  "session.secondaryLiveTitle": "副窗口",
+  "session.secondaryLiveBanner":
+    "可在此发送与停止。为此会话连接时，可能会把主窗口的 live Agent 移走，直到该回合结束。",
+  "session.focusMainWindow": "聚焦主窗口",
+  "session.focusMainWindowFailed": "无法聚焦主窗口",
   "session.collapseAllActivity": "收起全部活动",
   "session.collapseAllActivityHint": "收起已展开的工具阶段与已完成的思考块",
   "session.new": "新会话",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -191,9 +191,11 @@ export const zhTW: Record<MessageKey, string> = {
   "session.openInNewWindowOk": "已在新視窗開啟",
   "session.openInNewWindowFailed": "無法開啟對話視窗",
   "session.openInNewWindowMissing": "找不到該對話 — 可能已被刪除。",
-  "session.viewOnlyTitle": "僅檢視",
-  "session.viewOnlyBanner":
-    "此視窗為僅檢視。Agent 啟動與傳送仍在主視窗，避免多視窗爭搶 live 槽位。",
+  "session.secondaryLiveTitle": "副視窗",
+  "session.secondaryLiveBanner":
+    "可在此傳送與停止。為此對話連線時，可能會把主視窗的 live Agent 移走，直到該回合結束。",
+  "session.focusMainWindow": "聚焦主視窗",
+  "session.focusMainWindowFailed": "無法聚焦主視窗",
   "session.collapseAllActivity": "收合全部活動",
   "session.collapseAllActivityHint": "收合已展開的工具階段與已完成的思考塊",
   "session.new": "新對話",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2529,7 +2529,8 @@ export async function appForceQuit() {
 
 /**
  * Open (or focus) a secondary webview window for a chat (`#/session/<id>`).
- * Desktop Tauri only. Secondary windows are view-only (no agent spawn/send).
+ * Desktop Tauri only. Secondary is live-capable (send/stop via shared Host);
+ * passive warm-connect on open is still skipped in the frontend.
  */
 export async function openSessionWindow(
   sessionId: string,
@@ -2542,6 +2543,17 @@ export async function openSessionWindow(
     sessionId,
     title: title ?? null,
   });
+}
+
+/**
+ * Focus (and show/unminimize) the primary workbench window.
+ * Desktop Tauri only — used from secondary session windows (MULTI-WIN-LITE).
+ */
+export async function focusMainWindow(): Promise<void> {
+  if (!isDesktopHost()) {
+    throw new Error("focusMainWindow requires desktop Tauri");
+  }
+  await invoke<void>("focus_main_window");
 }
 
 // ── Custom providers (agent-home config.toml) ───────────────────────────────

--- a/src/lib/multiWindow.test.ts
+++ b/src/lib/multiWindow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   MAIN_WINDOW_LABEL,
   buildSessionDeepLinkHash,
+  canLiveParticipate,
   canOpenSessionInNewWindow,
   isMainWindowLabel,
   isSessionWindowLabel,
@@ -11,6 +12,7 @@ import {
   sanitizeSessionIdForLabel,
   sessionWindowLabel,
   shouldSkipAgentSpawn,
+  shouldSkipWarmConnect,
 } from "./multiWindow";
 
 const UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
@@ -97,8 +99,16 @@ describe("multiWindow", () => {
     ).toBe(false);
   });
 
-  it("skips agent spawn only in secondary windows", () => {
+  it("skips only passive warm-connect in secondary (MULTI-WIN-LITE)", () => {
+    expect(shouldSkipWarmConnect(true)).toBe(true);
+    expect(shouldSkipWarmConnect(false)).toBe(false);
+    // Deprecated alias tracks warm-connect, not send/stop.
     expect(shouldSkipAgentSpawn(true)).toBe(true);
     expect(shouldSkipAgentSpawn(false)).toBe(false);
+  });
+
+  it("allows live send/stop from main and secondary (shared Host)", () => {
+    expect(canLiveParticipate(false)).toBe(true);
+    expect(canLiveParticipate(true)).toBe(true);
   });
 });

--- a/src/lib/multiWindow.ts
+++ b/src/lib/multiWindow.ts
@@ -2,8 +2,11 @@
  * Multi-window session helpers (desktop Tauri).
  *
  * Minimal product: open a chat in a second webview window via deep link
- * `#/session/<id>`. Secondary windows are **view-focused** — they must not
- * warm-connect / spawn / send so they never fight the Host live slot.
+ * `#/session/<id>`. Secondary windows **participate live** — send / stop /
+ * ensureConnected go through the shared process Host (session-targeted).
+ *
+ * They still skip *passive* warm-connect on open/browse so merely popping a
+ * second pane does not demote the main window’s agent until the user acts.
  *
  * Window labels: `main` (primary) · `session-<uuid>` (secondary).
  */
@@ -119,9 +122,30 @@ export function canOpenSessionInNewWindow(opts: {
 }
 
 /**
- * Secondary windows must not spawn / warm-connect / send — Host has a single
- * live focus slot and concurrent connects steal it from the main window.
+ * Skip *passive* warm-connect when opening/browsing a session.
+ * Secondary windows stay passive until the user sends (then ensureConnected runs).
+ * Host has one live focus slot; auto-connect on open would demote main’s agent.
+ */
+export function shouldSkipWarmConnect(isSecondaryWindow: boolean): boolean {
+  return isSecondaryWindow;
+}
+
+/**
+ * Whether this window may send / stop / ensureConnected for its focused session.
+ * Secondary webviews share the process Host — live participation is allowed
+ * (session-targeted invoke). Policy locked here so UI gates stay honest.
+ */
+export function canLiveParticipate(isSecondaryWindow: boolean): boolean {
+  // Secondary is not view-only for send/stop. Argument kept for call-site clarity
+  // and future policy tweaks (e.g. mirror/browser).
+  void isSecondaryWindow;
+  return true;
+}
+
+/**
+ * @deprecated Prefer `shouldSkipWarmConnect` for browse and `canLiveParticipate`
+ * for send/stop. Kept as warm-connect alias so older call sites stay safe.
  */
 export function shouldSkipAgentSpawn(isSecondaryWindow: boolean): boolean {
-  return isSecondaryWindow;
+  return shouldSkipWarmConnect(isSecondaryWindow);
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8673,7 +8673,7 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
   gap: 10px 12px;
 }
 
-/* Secondary multi-window: honest view-only notice (not an error). */
+/* Secondary multi-window: live tip + focus main (not an error). */
 .view-only-banner {
   margin: 0 var(--space-5) var(--space-2);
   padding: var(--space-3) var(--space-4);
@@ -8685,6 +8685,19 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
   color: var(--text-primary);
 }
 
+.view-only-banner__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px 14px;
+}
+
+.view-only-banner__copy {
+  min-width: 0;
+  flex: 1 1 220px;
+}
+
 .view-only-banner__title {
   font-weight: 600;
   margin-bottom: 2px;
@@ -8693,6 +8706,11 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
 .view-only-banner__body {
   color: var(--text-secondary, var(--text-primary));
   opacity: 0.92;
+}
+
+.view-only-banner__action {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 /* Prefer warning palette even when combined with error-banner utility classes. */


### PR DESCRIPTION
## Summary

- **Secondary session windows can send / stop** via the shared process Host (session-targeted invoke). Previously view-only gates blocked participation.
- **Passive warm-connect on open still skipped** so merely opening a second pane does not demote the main window’s live agent until the user acts (`shouldSkipWarmConnect`).
- **Honest secondary tip** (no more “view only”) + **Focus main window** (`focus_main_window` command + API).
- Policy helpers: `canLiveParticipate` / `shouldSkipWarmConnect` (+ deprecated `shouldSkipAgentSpawn` alias) with unit tests; i18n en/zh/zh-TW; CHANGELOG.

## Multi-window policy (MULTI-WIN-LITE)

| Action | Secondary window |
|--------|------------------|
| Open / browse journal | ✅ |
| Follow streams | ✅ |
| Passive warm-connect on open | ❌ (avoids demoting main) |
| Send / stop / ensureConnected | ✅ (shared Host) |
| Focus main window | ✅ |

## Test plan

- [x] `npx vitest run src/lib/multiWindow.test.ts src/i18n/messages.test.ts`
- [x] `cargo check` (registers `focus_main_window`)
- [ ] Desktop: main → session menu → **Open session in new window**
- [ ] Secondary: composer Send works; Stop works while streaming
- [ ] Opening secondary alone does not steal live slot until send
- [ ] **Focus main window** button brings main to front
- [ ] Re-open same session focuses existing secondary (no third window)