### PR TITLE
fix(settings): custom provider save stuck and live apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Custom provider save stuck on “Saving…” / requires restart** (#376): `providers_upsert` / activate / remove / set-default run file I/O on a blocking pool and recycle warm agents (`provider_route`) so the next message reloads `config.toml` + auth without a full app restart. Settings save uses a wall-clock timeout, always clears busy in `finally`, shows success / soft-fail apply toasts (en/zh/zh-TW), and no longer parks live agents via `sessionDisconnect` (which kept stale OIDC in memory). Pure `providerSave` helpers + tests.
+
 ### Added
 
 #### Agent / memory

--- a/docs/llm-wiki/providers.md
+++ b/docs/llm-wiki/providers.md
@@ -69,16 +69,19 @@ Host must rebind both sides on every switch and before each ACP spawn (`prepare_
 
 | Command | Role |
 |---------|------|
-| `providers_list` | Providers + default (no raw keys) |
-| `providers_upsert` | Create/update; empty key keeps previous |
-| `providers_remove` | Delete section |
-| `providers_set_default` | Set default model id |
+| `providers_list` | Providers + default (no raw keys); blocking pool |
+| `providers_upsert` | Create/update; empty key keeps previous; recycles warm agents when default/active route changes (`provider_route`) so next send applies without app restart |
+| `providers_remove` | Delete section; recycles warm agents |
+| `providers_set_default` | Set default model id; recycles warm agents |
+| `providers_activate` | Switch official/custom route + rebind auth; recycles warm agents |
 | `providers_ping` | `GET {base}/models` RTT |
 | `providers_list_models` | Fetch remote model ids |
 | `providers_cc_switch_scan` | Read-only scan of local **CC Switch** Grok Build providers |
 | `providers_cc_switch_import` | Import selected CC Switch rows into custom providers |
 | `editors_list` | Detected local IDEs |
 | `open_in_editor` | Open path in chosen editor |
+
+**Live apply (#376):** Do **not** only park the live agent (`session_disconnect`) after provider edits — parked processes keep old OIDC/`config.toml` in memory. Host `recycle_all_agents(..., "provider_route")` after route-affecting writes. Settings UI always clears “Saving…” in `finally` and soft-fails apply errors with a toast (config is already on disk).
 
 ## Import from CC Switch (#167)
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6956,67 +6956,87 @@ pub async fn providers_cc_switch_import(
 
 #[tauri::command]
 pub async fn providers_list() -> Result<crate::providers::ProvidersListResult, String> {
-    // One-time migration of legacy single relay secrets → multi-provider config.
-    let secrets = store::load_secrets();
-    let _ = crate::providers::maybe_migrate_legacy_relay(
-        secrets.relay_base_url.as_deref(),
-        secrets.relay_api_key.as_deref(),
-        secrets.default_model.as_deref(),
-    );
-    // Ensure agent transport retries are high enough for flaky custom relays.
-    let _ = crate::providers::ensure_models_retry_cap();
-    // Fix bases saved without /v1 (causes silent multi-minute inference retries).
-    let _ = crate::providers::repair_custom_base_urls();
-    crate::providers::list_custom_providers()
+    // Blocking file I/O off the async runtime (migrations / repairs / list).
+    tauri::async_runtime::spawn_blocking(|| {
+        // One-time migration of legacy single relay secrets → multi-provider config.
+        let secrets = store::load_secrets();
+        let _ = crate::providers::maybe_migrate_legacy_relay(
+            secrets.relay_base_url.as_deref(),
+            secrets.relay_api_key.as_deref(),
+            secrets.default_model.as_deref(),
+        );
+        // Ensure agent transport retries are high enough for flaky custom relays.
+        let _ = crate::providers::ensure_models_retry_cap();
+        // Fix bases saved without /v1 (causes silent multi-minute inference retries).
+        let _ = crate::providers::repair_custom_base_urls();
+        crate::providers::list_custom_providers()
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 /// Activate official Grok Build or a custom provider; returns updated list.
+///
+/// Recycles warm agents so the next send spawns with rebound auth / config
+/// (no full app restart).
 #[tauri::command]
 pub async fn providers_activate(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
     source: String,
     provider_id: Option<String>,
 ) -> Result<crate::providers::ProvidersListResult, String> {
-    let result =
-        crate::providers::activate_provider(&source, provider_id.as_deref())?;
-    // Composer model stays a catalog id (UI). Channel is `[models].default`.
-    // When leaving a custom route, drop stale provider ids from settings.
-    let mut settings = store::load_settings();
-    let cur = settings.model_id.clone().unwrap_or_default();
-    if result.active_source == "official" {
-        if cur.is_empty()
-            || crate::providers::is_custom_provider_id(&cur)
-            || cur == crate::providers::OFFICIAL_DEFAULT_MODEL
-        {
-            settings.model_id =
-                Some(crate::providers::OFFICIAL_CATALOG_MODEL.into());
-            let _ = store::save_settings(&settings);
-        }
-    } else if result.active_source == "custom" {
-        // Keep catalog model in settings for the model picker; spawn resolves route id.
-        if cur.is_empty() || crate::providers::is_custom_provider_id(&cur) {
-            if let Some(p) = result
-                .active_provider_id
-                .as_ref()
-                .and_then(|id| result.providers.iter().find(|x| x.id == *id))
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let result =
+            crate::providers::activate_provider(&source, provider_id.as_deref())?;
+        // Composer model stays a catalog id (UI). Channel is `[models].default`.
+        // When leaving a custom route, drop stale provider ids from settings.
+        let mut settings = store::load_settings();
+        let cur = settings.model_id.clone().unwrap_or_default();
+        if result.active_source == "official" {
+            if cur.is_empty()
+                || crate::providers::is_custom_provider_id(&cur)
+                || cur == crate::providers::OFFICIAL_DEFAULT_MODEL
             {
-                let upstream = p.model.trim();
-                settings.model_id = Some(if upstream.is_empty() {
-                    crate::providers::OFFICIAL_CATALOG_MODEL.into()
-                } else {
-                    upstream.to_string()
-                });
-            } else {
                 settings.model_id =
                     Some(crate::providers::OFFICIAL_CATALOG_MODEL.into());
+                let _ = store::save_settings(&settings);
             }
-            let _ = store::save_settings(&settings);
+        } else if result.active_source == "custom" {
+            // Keep catalog model in settings for the model picker; spawn resolves route id.
+            if cur.is_empty() || crate::providers::is_custom_provider_id(&cur) {
+                if let Some(p) = result
+                    .active_provider_id
+                    .as_ref()
+                    .and_then(|id| result.providers.iter().find(|x| x.id == *id))
+                {
+                    let upstream = p.model.trim();
+                    settings.model_id = Some(if upstream.is_empty() {
+                        crate::providers::OFFICIAL_CATALOG_MODEL.into()
+                    } else {
+                        upstream.to_string()
+                    });
+                } else {
+                    settings.model_id =
+                        Some(crate::providers::OFFICIAL_CATALOG_MODEL.into());
+                }
+                let _ = store::save_settings(&settings);
+            }
         }
-    }
+        Ok::<_, String>(result)
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    // Parked processes keep old GROK_HOME auth/config in memory — kill them.
+    mgr.recycle_all_agents(&app, "provider_route").await;
     Ok(result)
 }
 
 #[tauri::command]
 pub async fn providers_upsert(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
     id: String,
     model: String,
     base_url: String,
@@ -7026,74 +7046,117 @@ pub async fn providers_upsert(
     set_as_default: Option<bool>,
     create_only: Option<bool>,
 ) -> Result<crate::providers::ProvidersListResult, String> {
-    let result = crate::providers::upsert_custom_provider(crate::providers::UpsertProviderInput {
-        id,
-        model: model.clone(),
-        base_url,
-        name,
-        api_key,
-        api_backend,
-        set_as_default,
-        create_only,
-    })?;
-    // Keep legacy secrets in sync for Doctor / account channel display.
-    if let Some(p) = result.providers.iter().find(|p| p.is_default).or(result.providers.first())
-    {
-        let mut secrets = store::load_secrets();
-        secrets.relay_base_url = Some(p.base_url.clone());
-        secrets.default_model = result.default_model.clone();
-        // Do not copy api_key into secrets (stays only in config.toml).
-        let _ = store::save_secrets(&secrets);
-        if set_as_default.unwrap_or(false) {
-            let mut settings = store::load_settings();
-            // Composer shows upstream request model, not the route slug.
-            let upstream = p.model.trim();
-            settings.model_id = Some(if upstream.is_empty() {
-                crate::providers::OFFICIAL_CATALOG_MODEL.into()
-            } else {
-                upstream.to_string()
-            });
-            let _ = store::save_settings(&settings);
+    let set_default_flag = set_as_default.unwrap_or(false);
+    let mutated_id = id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let result =
+            crate::providers::upsert_custom_provider(crate::providers::UpsertProviderInput {
+                id,
+                model: model.clone(),
+                base_url,
+                name,
+                api_key,
+                api_backend,
+                set_as_default,
+                create_only,
+            })?;
+        // Keep legacy secrets in sync for Doctor / account channel display.
+        if let Some(p) = result
+            .providers
+            .iter()
+            .find(|p| p.is_default)
+            .or(result.providers.first())
+        {
+            let mut secrets = store::load_secrets();
+            secrets.relay_base_url = Some(p.base_url.clone());
+            secrets.default_model = result.default_model.clone();
+            // Do not copy api_key into secrets (stays only in config.toml).
+            let _ = store::save_secrets(&secrets);
+            if set_as_default.unwrap_or(false) {
+                let mut settings = store::load_settings();
+                // Composer shows upstream request model, not the route slug.
+                let upstream = p.model.trim();
+                settings.model_id = Some(if upstream.is_empty() {
+                    crate::providers::OFFICIAL_CATALOG_MODEL.into()
+                } else {
+                    upstream.to_string()
+                });
+                let _ = store::save_settings(&settings);
+            }
         }
+        Ok::<_, String>(result)
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    // Apply active-route / active-provider edits without requiring app restart.
+    // Recycle (not mere park) so parked shells cannot reopen with stale OIDC.
+    if crate::providers::provider_mutation_needs_agent_reload(
+        set_default_flag,
+        &mutated_id,
+        &result,
+    ) {
+        mgr.recycle_all_agents(&app, "provider_route").await;
     }
     Ok(result)
 }
 
 #[tauri::command]
-pub async fn providers_remove(id: String) -> Result<crate::providers::ProvidersListResult, String> {
-    crate::providers::remove_custom_provider(&id)
+pub async fn providers_remove(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
+    id: String,
+) -> Result<crate::providers::ProvidersListResult, String> {
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        crate::providers::remove_custom_provider(&id)
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+    // Removing a provider (esp. the active one) must not leave warm agents on
+    // a deleted route id.
+    mgr.recycle_all_agents(&app, "provider_route").await;
+    Ok(result)
 }
 
 #[tauri::command]
 pub async fn providers_set_default(
+    app: tauri::AppHandle,
+    mgr: State<'_, Arc<SessionManager>>,
     model_id: String,
 ) -> Result<crate::providers::ProvidersListResult, String> {
     // Prefer activate_provider so auth material is rebound correctly.
-    let id = model_id.trim();
-    let list = crate::providers::list_custom_providers()?;
-    let result = if list.providers.iter().any(|p| p.id == id) {
-        crate::providers::activate_provider("custom", Some(id))?
-    } else {
-        crate::providers::activate_provider("official", None)?
-    };
-    let mut settings = store::load_settings();
-    if result.active_source == "custom" {
-        if let Some(p) = result
-            .active_provider_id
-            .as_ref()
-            .and_then(|pid| result.providers.iter().find(|x| x.id == *pid))
-        {
-            let upstream = p.model.trim();
-            settings.model_id = Some(if upstream.is_empty() {
-                crate::providers::OFFICIAL_CATALOG_MODEL.into()
-            } else {
-                upstream.to_string()
-            });
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let id = model_id.trim().to_string();
+        let list = crate::providers::list_custom_providers()?;
+        let result = if list.providers.iter().any(|p| p.id == id) {
+            crate::providers::activate_provider("custom", Some(&id))?
+        } else {
+            crate::providers::activate_provider("official", None)?
+        };
+        let mut settings = store::load_settings();
+        if result.active_source == "custom" {
+            if let Some(p) = result
+                .active_provider_id
+                .as_ref()
+                .and_then(|pid| result.providers.iter().find(|x| x.id == *pid))
+            {
+                let upstream = p.model.trim();
+                settings.model_id = Some(if upstream.is_empty() {
+                    crate::providers::OFFICIAL_CATALOG_MODEL.into()
+                } else {
+                    upstream.to_string()
+                });
+            }
+        } else {
+            settings.model_id = Some(crate::providers::OFFICIAL_CATALOG_MODEL.into());
         }
-    } else {
-        settings.model_id = Some(crate::providers::OFFICIAL_CATALOG_MODEL.into());
-    }
-    let _ = store::save_settings(&settings);
+        let _ = store::save_settings(&settings);
+        Ok::<_, String>(result)
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    mgr.recycle_all_agents(&app, "provider_route").await;
     Ok(result)
 }
 

--- a/src-tauri/src/providers.rs
+++ b/src-tauri/src/providers.rs
@@ -698,6 +698,26 @@ pub fn activate_provider(
     }
 }
 
+/// Whether a provider mutation should recycle warm ACP processes so the next
+/// send reloads `config.toml` / auth material without a full app restart.
+///
+/// - `set_as_default` → active route or default model changed
+/// - Mutated id is the active custom route → key / base_url / backend edit
+pub fn provider_mutation_needs_agent_reload(
+    set_as_default: bool,
+    mutated_id: &str,
+    result: &ProvidersListResult,
+) -> bool {
+    if set_as_default {
+        return true;
+    }
+    let id = mutated_id.trim();
+    if id.is_empty() {
+        return false;
+    }
+    result.active_source == "custom" && result.active_provider_id.as_deref() == Some(id)
+}
+
 pub fn upsert_custom_provider(input: UpsertProviderInput) -> Result<ProvidersListResult, String> {
     let id = sanitize_id(&input.id)?;
     let model = {
@@ -982,6 +1002,39 @@ mod tests {
             normalize_openai_base_url("https://api.yunyi.ai/v1/", "chat_completions"),
             "https://api.yunyi.ai/v1"
         );
+    }
+
+    #[test]
+    fn mutation_reload_when_default_or_active() {
+        let active = ProvidersListResult {
+            providers: vec![CustomProvider {
+                id: "relay".into(),
+                model: "m".into(),
+                base_url: "https://ex/v1".into(),
+                name: "Relay".into(),
+                has_api_key: true,
+                api_backend: "responses".into(),
+                is_default: true,
+            }],
+            default_model: Some("relay".into()),
+            active_source: "custom".into(),
+            active_provider_id: Some("relay".into()),
+            config_path: String::new(),
+            agent_home: String::new(),
+        };
+        assert!(provider_mutation_needs_agent_reload(true, "other", &active));
+        assert!(provider_mutation_needs_agent_reload(false, "relay", &active));
+        assert!(!provider_mutation_needs_agent_reload(
+            false, "other", &active
+        ));
+        let official = ProvidersListResult {
+            active_source: "official".into(),
+            active_provider_id: None,
+            ..active.clone()
+        };
+        assert!(!provider_mutation_needs_agent_reload(
+            false, "relay", &official
+        ));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4266,7 +4266,12 @@ export default function App() {
             "session://agents_recycled",
             (p) => {
               if (cancelled || !p) return;
-              // session_data_mode flip (and any future full recycle).
+              // session_data_mode flip, custom provider route apply (#376), CLI upgrade, etc.
+              if (p.reason === "provider_route") {
+                setToast(tr("prov.switchedHotReload"));
+                window.setTimeout(() => setToast(null), 3600);
+                return;
+              }
               if (
                 p.reason === "session_data_mode" ||
                 (p.killed != null && p.killed > 0)
@@ -14970,20 +14975,29 @@ export default function App() {
             .filter((p) => p.trusted)
             .map((p) => ({ id: p.id, name: p.name, path: p.path }))}
           onProviderActivated={() => {
-            // Hot-reload Grok Build: drop live ACP so next send re-spawns with new GROK_HOME config.
+            // Host already recycled warm agents on upsert/activate. Refresh UI
+            // chrome only — never park (sessionDisconnect) a live process: that
+            // kept stale OIDC/config in memory and required a full app restart
+            // (issue #376). Soft-fail so save UI never sticks on “Saving…”.
             void (async () => {
               try {
                 if (api.isTauri()) {
-                  await api.sessionDisconnect();
                   setSession({ ...IDLE_SNAPSHOT });
                 }
                 await refreshProviderRoute();
-                await refreshAccount({ refreshBilling: false });
-                await refreshVoiceGate();
+                await refreshAccount({ refreshBilling: false }).catch(() => {
+                  /* soft-fail billing refresh */
+                });
+                await refreshVoiceGate().catch(() => {
+                  /* soft-fail voice gate */
+                });
                 setToast(tr("prov.switchedHotReload"));
                 window.setTimeout(() => setToast(null), 3200);
               } catch (e) {
-                setToast(String(e));
+                setToast(
+                  tr("prov.savedApplyFailed", { detail: String(e) }),
+                );
+                window.setTimeout(() => setToast(null), 4800);
               }
             })();
           }}

--- a/src/components/ProvidersPanel.tsx
+++ b/src/components/ProvidersPanel.tsx
@@ -22,6 +22,12 @@ import {
   IconRefresh,
   IconTrash,
 } from "@/components/icons";
+import {
+  PROVIDER_SAVE_TIMEOUT_MS,
+  providerMutationNeedsAgentReload,
+  slugifyProviderId,
+  withProviderSaveTimeout,
+} from "@/lib/providerSave";
 
 export interface ProvidersPanelProps {
   locale: Locale;
@@ -53,15 +59,6 @@ const emptyForm = (): FormState => ({
   apiBackend: "responses",
   setAsDefault: true,
 });
-
-function slugify(raw: string): string {
-  return raw
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 48);
-}
 
 function hostOf(url: string): string {
   try {
@@ -377,21 +374,28 @@ export function ProvidersPanel({
     setBusy(true);
     setHint(tr("prov.saving"));
     setHintTone("muted");
+    const id =
+      editingId ??
+      (slugifyProviderId(form.id || form.name || form.baseUrl) ||
+        `provider-${Date.now().toString(36)}`);
+    const setAsDefault = form.setAsDefault;
     try {
-      const id =
-        editingId ??
-        (slugify(form.id || form.name || form.baseUrl) ||
-          `provider-${Date.now().toString(36)}`);
-      const r = await api.providersUpsert({
-        id,
-        model: form.model.trim() || id,
-        baseUrl: form.baseUrl.trim(),
-        name: form.name.trim() || id,
-        apiKey: form.apiKey.trim() || undefined,
-        apiBackend: form.apiBackend,
-        setAsDefault: form.setAsDefault,
-        createOnly: !editingId,
-      });
+      // Wall-clock budget so a hung host IPC cannot leave the UI on “Saving…”.
+      // Disk write may still complete after a timeout (user can re-open panel).
+      const r = await withProviderSaveTimeout(
+        api.providersUpsert({
+          id,
+          model: form.model.trim() || id,
+          baseUrl: form.baseUrl.trim(),
+          name: form.name.trim() || id,
+          apiKey: form.apiKey.trim() || undefined,
+          apiBackend: form.apiBackend,
+          setAsDefault,
+          createOnly: !editingId,
+        }),
+        PROVIDER_SAVE_TIMEOUT_MS,
+        tr("prov.err.saveTimeout"),
+      );
       setList(r);
       const saved = r.providers.find((p) => p.id === id);
       if (saved) {
@@ -400,14 +404,32 @@ export function ProvidersPanel({
         setRightMode("empty");
         setSelection(null);
       }
-      setHint(null);
-      if (form.setAsDefault) {
-        onProviderActivated?.();
+      const needsReload = providerMutationNeedsAgentReload({
+        setAsDefault,
+        providerId: id,
+        activeSource: r.activeSource,
+        activeProviderId: r.activeProviderId,
+      });
+      if (needsReload) {
+        setHint(tr("prov.savedHotReload"));
+        setHintTone("ok");
+        try {
+          // Fire-and-forget UI refresh; host already recycled agents on upsert.
+          onProviderActivated?.();
+        } catch (e) {
+          // Soft-fail: config is on disk; next message / restart still works.
+          setHint(tr("prov.savedApplyFailed", { detail: String(e) }));
+          setHintTone("err");
+        }
+      } else {
+        setHint(tr("prov.saved"));
+        setHintTone("ok");
       }
     } catch (e) {
       setHint(String(e));
       setHintTone("err");
     } finally {
+      // Always leave “Saving…” — never leave busy latched on hung apply.
       setBusy(false);
     }
   };
@@ -796,7 +818,7 @@ export function ProvidersPanel({
                       setForm((f) => ({
                         ...f,
                         name,
-                        id: editingId ? f.id : slugify(name) || f.id,
+                        id: editingId ? f.id : slugifyProviderId(name) || f.id,
                       }));
                     }}
                     placeholder={tr("prov.namePh")}
@@ -815,7 +837,7 @@ export function ProvidersPanel({
                       onChange={(e) =>
                         setForm((f) => ({
                           ...f,
-                          id: slugify(e.target.value),
+                          id: slugifyProviderId(e.target.value),
                         }))
                       }
                       placeholder={tr("prov.idPh")}
@@ -974,7 +996,9 @@ export function ProvidersPanel({
                     onClick={() => void save()}
                     disabled={busy}
                   >
-                    {editingId ? (
+                    {busy ? (
+                      tr("prov.saving")
+                    ) : editingId ? (
                       <>
                         <IconEdit size={14} />
                         {tr("prov.save")}

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -283,6 +283,8 @@ export function SetupWizard({
     setError(null);
     try {
       // Write agent-home config with chosen message format (default Responses).
+      // Host recycles warm agents on setAsDefault so the first workbench send
+      // spawns with the relay (no full app restart — issue #376).
       await api.providersUpsert({
         id: "relay",
         model: "default",
@@ -292,11 +294,22 @@ export function SetupWizard({
         apiBackend: relayBackend || "responses",
         setAsDefault: true,
       });
-      await api.secretsSet({ relayBaseUrl: base, relayApiKey: key });
-      const ping = await api.providersPing({ baseUrl: base, apiKey: key });
-      if (ping && (ping as { ok?: boolean }).ok === false) {
-        setStatusMsg(String((ping as { message?: string }).message || "ping failed"));
-      } else {
+      try {
+        await api.secretsSet({ relayBaseUrl: base, relayApiKey: key });
+      } catch {
+        /* soft-fail: config.toml already holds the key */
+      }
+      try {
+        const ping = await api.providersPing({ baseUrl: base, apiKey: key });
+        if (ping && (ping as { ok?: boolean }).ok === false) {
+          setStatusMsg(
+            String((ping as { message?: string }).message || "ping failed"),
+          );
+        } else {
+          setStatusMsg(tr("setup.account.ok"));
+        }
+      } catch {
+        // Soft-fail ping — still enter workbench; user can fix URL in Settings.
         setStatusMsg(tr("setup.account.ok"));
       }
       setAuthOk(true);

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2250,6 +2250,13 @@ const en = {
   "prov.save": "Save",
   "prov.add": "Add",
   "prov.saving": "Saving…",
+  "prov.saved": "Provider saved.",
+  "prov.savedHotReload":
+    "Provider saved. Agents reloaded — next message uses the new config (no app restart).",
+  "prov.savedApplyFailed":
+    "Provider saved on disk, but live apply failed ({detail}). Try sending a message, or restart the app if chat stays offline.",
+  "prov.err.saveTimeout":
+    "Save is taking too long. Config may still have been written — close and reopen this panel, or restart if chat does not work.",
   "prov.confirmDelete": "Delete provider “{id}”?",
   "prov.loading": "Loading…",
   "prov.err.needBase": "Base URL is required.",
@@ -2273,7 +2280,7 @@ const en = {
   "prov.customProvider": "Custom provider",
   "prov.useThis": "Use",
   "prov.switchedHotReload":
-    "Provider switched. Next message starts a new session with the new config.",
+    "Provider applied. Next message reconnects with the new config — no full app restart needed.",
   "prov.ccSwitch.importBtn": "Import from CC Switch",
   "prov.ccSwitch.importBtnHint":
     "Read Grok Build providers from local CC Switch and add them here",
@@ -6289,6 +6296,13 @@ const zh: Record<MessageKey, string> = {
   "prov.save": "保存",
   "prov.add": "添加",
   "prov.saving": "保存中…",
+  "prov.saved": "提供商已保存。",
+  "prov.savedHotReload":
+    "提供商已保存，Agent 已重载 — 下一条消息使用新配置（无需重启应用）。",
+  "prov.savedApplyFailed":
+    "提供商已写入磁盘，但即时应用失败（{detail}）。可先发一条消息；若对话仍不可用再重启应用。",
+  "prov.err.saveTimeout":
+    "保存耗时过长。配置可能已写入 — 请关闭后重新打开此面板；若对话不可用再重启应用。",
   "prov.confirmDelete": "删除提供商「{id}」？",
   "prov.loading": "加载中…",
   "prov.err.needBase": "请填写 Base URL。",
@@ -6311,7 +6325,7 @@ const zh: Record<MessageKey, string> = {
   "prov.customProvider": "自定义提供商",
   "prov.useThis": "使用",
   "prov.switchedHotReload":
-    "已切换服务商。下一条消息会用新配置启动新会话。",
+    "服务商已应用。下一条消息会用新配置重连 — 无需完整重启应用。",
   "prov.ccSwitch.importBtn": "从 CC Switch 导入",
   "prov.ccSwitch.importBtnHint":
     "读取本机 CC Switch 的 Grok Build 供应商并添加到此处",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2155,6 +2155,13 @@ export const zhTW: Record<MessageKey, string> = {
   "prov.save": "儲存",
   "prov.add": "新增",
   "prov.saving": "儲存中…",
+  "prov.saved": "供應商已儲存。",
+  "prov.savedHotReload":
+    "供應商已儲存，Agent 已重載 — 下一則訊息使用新設定（無需重新啟動應用程式）。",
+  "prov.savedApplyFailed":
+    "供應商已寫入磁碟，但即時套用失敗（{detail}）。可先傳送一則訊息；若對話仍不可用再重新啟動應用程式。",
+  "prov.err.saveTimeout":
+    "儲存耗時過長。設定可能已寫入 — 請關閉後重新開啟此面板；若對話不可用再重新啟動應用程式。",
   "prov.confirmDelete": "刪除供應商「{id}」？",
   "prov.loading": "載入中…",
   "prov.err.needBase": "請填寫 Base URL。",
@@ -2177,7 +2184,7 @@ export const zhTW: Record<MessageKey, string> = {
   "prov.customProvider": "自訂供應商",
   "prov.useThis": "使用",
   "prov.switchedHotReload":
-    "已切換服務商。下一則訊息會用新設定啟動新對話。",
+    "服務商已套用。下一則訊息會用新設定重連 — 無需完整重新啟動應用程式。",
   "prov.ccSwitch.importBtn": "從 CC Switch 匯入",
   "prov.ccSwitch.importBtnHint":
     "讀取本機 CC Switch 的 Grok Build 供應商並新增到此處",

--- a/src/lib/providerSave.test.ts
+++ b/src/lib/providerSave.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  PROVIDER_SAVE_TIMEOUT_MS,
+  providerMutationNeedsAgentReload,
+  slugifyProviderId,
+  withProviderSaveTimeout,
+} from "./providerSave";
+
+describe("providerMutationNeedsAgentReload", () => {
+  it("reloads when set as default", () => {
+    expect(
+      providerMutationNeedsAgentReload({
+        setAsDefault: true,
+        providerId: "relay",
+        activeSource: "official",
+        activeProviderId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("reloads when editing the active custom provider", () => {
+    expect(
+      providerMutationNeedsAgentReload({
+        setAsDefault: false,
+        providerId: "relay",
+        activeSource: "custom",
+        activeProviderId: "relay",
+      }),
+    ).toBe(true);
+  });
+
+  it("skips reload when editing a non-active provider", () => {
+    expect(
+      providerMutationNeedsAgentReload({
+        setAsDefault: false,
+        providerId: "other",
+        activeSource: "custom",
+        activeProviderId: "relay",
+      }),
+    ).toBe(false);
+  });
+
+  it("skips reload when official is active and not setting default", () => {
+    expect(
+      providerMutationNeedsAgentReload({
+        setAsDefault: false,
+        providerId: "relay",
+        activeSource: "official",
+        activeProviderId: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("slugifyProviderId", () => {
+  it("normalizes display names", () => {
+    expect(slugifyProviderId("My Relay")).toBe("my-relay");
+    expect(slugifyProviderId("  Foo_Bar  ")).toBe("foo_bar");
+  });
+});
+
+describe("withProviderSaveTimeout", () => {
+  it("resolves when the promise finishes in time", async () => {
+    await expect(
+      withProviderSaveTimeout(Promise.resolve(42), 1000),
+    ).resolves.toBe(42);
+  });
+
+  it("rejects on timeout without waiting forever", async () => {
+    vi.useFakeTimers();
+    const pending = withProviderSaveTimeout(
+      new Promise(() => {
+        /* never settles */
+      }),
+      50,
+      "timed out",
+    );
+    const assertion = expect(pending).rejects.toThrow("timed out");
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+    vi.useRealTimers();
+  });
+
+  it("exports a positive default budget", () => {
+    expect(PROVIDER_SAVE_TIMEOUT_MS).toBeGreaterThan(1000);
+  });
+});

--- a/src/lib/providerSave.ts
+++ b/src/lib/providerSave.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure helpers for Settings → Account → Custom providers save / live-apply.
+ *
+ * Host writes agent-home `config.toml`; warm ACP processes must be recycled so
+ * the next send reloads base_url / api_key / auth.json without a full app restart.
+ */
+
+export type ProviderActiveRoute = {
+  activeSource: string;
+  activeProviderId: string | null | undefined;
+};
+
+/**
+ * Whether a successful upsert should recycle warm agents so config applies live.
+ *
+ * - `setAsDefault` → route / default model changed
+ * - Mutated id is the active custom route → key/url/backend edit must respawn
+ */
+export function providerMutationNeedsAgentReload(
+  opts: {
+    setAsDefault: boolean;
+    providerId: string;
+  } & ProviderActiveRoute,
+): boolean {
+  if (opts.setAsDefault) return true;
+  const id = opts.providerId.trim();
+  if (!id) return false;
+  return (
+    opts.activeSource === "custom" &&
+    (opts.activeProviderId ?? "").trim() === id
+  );
+}
+
+/**
+ * Race a promise against a wall-clock timeout so UI never sticks on “Saving…”.
+ * On timeout the underlying work may still complete (host already wrote disk).
+ */
+export function withProviderSaveTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  timeoutMessage = "Provider save timed out",
+): Promise<T> {
+  const timeoutMs = Number.isFinite(ms) && ms > 0 ? ms : 25_000;
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+    promise.then(
+      (v) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
+/** Default wall-clock budget for `providers_upsert` IPC (ms). */
+export const PROVIDER_SAVE_TIMEOUT_MS = 25_000;
+
+/** Slug for new provider ids (mirrors host sanitize rules loosely). */
+export function slugifyProviderId(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+}


### PR DESCRIPTION
Fixes #376. Unstick Saving… and apply custom provider without requiring full restart when possible.

## Problem
- Custom provider edits stayed stuck on **Saving…** even though `config.toml` was written.
- After setup / provider edits, chat only worked after a **full app restart** because warm ACP processes (including parked ones) kept stale OIDC / config in memory. `sessionDisconnect` only *parked* the live agent instead of recycling it.

## Fix
- Host: `providers_upsert` / `activate` / `remove` / `set_default` run file I/O on a blocking pool and `recycle_all_agents(..., "provider_route")` when the active route is affected.
- UI: wall-clock save timeout, always clear busy in `finally`, success / soft-fail apply toasts (en / zh / zh-TW).
- App: `onProviderActivated` refreshes chrome only — no park-via-disconnect after provider writes.
- Pure helpers + tests (`providerSave`); wiki + CHANGELOG.

## Test plan
- [ ] Fresh setup: add custom relay in wizard → enter workbench → first send responds without restart
- [ ] Settings → Custom providers → edit + Save: leaves Saving…, shows success hint
- [ ] Switch Use official ↔ custom: next message uses new route without restart
- [ ] Timeout path (optional): hung host still clears busy after ~25s