### PR TITLE
feat(skills): edit pro — validate + classified GlassModal feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ See `docs/llm-wiki/release.md`.
 - **Hooks Try / override**: validate sample stdin JSON (object only, ~32 KB cap), record synthetic dry-run activity (does **not** execute shell hooks); activity outcome filter chips (all/ok/fail/skip) + clear activity (in-app confirm)
 - **MCP status modal depth**: search filter, status chips (all / ok / warn / error / unknown) from inspect `compatibilityStatus`/`transport`, count summary, refresh while open, copy name/target — host list only (no fake servers)
 - **New skill scaffold** (Settings → Extensions → Skills): modal name/description + user (path-scoped GROK_HOME `/skills`) or project scope; host creates folder + default `SKILL.md` (no overwrite); refresh list and open existing SKILL.md editor
+- **Skill edit pro** (Settings → Extensions → Skills): **Validate** + save preflight for `SKILL.md` frontmatter (name/description/body), classified load/save/create errors with actionable hints in a **GlassModal** (no `window.confirm`); pure `skillEditFeedback` helpers + tests; en/zh/zh-TW
 - **Agents tab + scaffold**: Settings → Extensions → **Agents** lists user / project / bundled definition files; **New agent** modal (name + user/project scope) writes a SKILL-like `{name}.md` under active `GROK_HOME/agents` or project `.grok/agents` (no overwrite unless confirmed); open/reveal after create; preferred agent still chosen later in Settings → Agent
 - **Project inspect depth** (Settings → Runtime): secret-safe hooks rows + skill name lists from `grok inspect --json`; section chips (plugins / skills / MCP / hooks / agents / rules / config / models / permissions); expand long lists; per-section copy JSON / copy path / reveal; pure filter helpers + tests
 - **MCP doctor findings** (slash MCP modal + Extensions): host `mcp_doctor(name?)` runs `grok mcp doctor --json` with timeout and redacted errors; pure helpers flatten checks/issues into `{ id, level, title, detail, server? }` rows (no invented servers); **Run MCP doctor** shows findings with server filter + search; inspect refresh coexists with doctor results
@@ -164,6 +165,7 @@ See `docs/llm-wiki/release.md`.
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**Hooks 试跑/覆盖**（校验 stdin JSON、合成 dry-run 活动、结果筛选与清空确认；不执行 shell hook）
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**MCP 状态弹层**（搜索/状态芯片/计数/刷新/复制名称与目标）
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**新建技能脚手架**（名称/描述/用户或项目作用域 → 默认 SKILL.md + 打开编辑器）
+- **扩展/市场**：**技能编辑 pro**（校验 + 保存前检查 SKILL.md 前置元数据；加载/保存/创建错误分类与可操作提示的 GlassModal；无 `window.confirm`）
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**Agents** 页列出定义文件并支持 **新建 Agent** 脚手架（用户/项目作用域、`Name.md` 模板、覆盖确认、打开/显示）
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**插件校验**（`plugin validate`：已安装行 + 本地路径安装前；行内结果面板；旧 CLI 软失败）
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**项目检查深度**（分区芯片、钩子/技能名清单、展开列表、分节复制 JSON/路径）

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -62,6 +62,17 @@ import {
 } from "@/lib/skillEditPath";
 import { sanitizeSkillFolderName } from "@/lib/skillScaffold";
 import {
+  buildSkillHostErrorPresentation,
+  buildSkillSaveOkPresentation,
+  buildSkillSavePreflightError,
+  buildSkillValidatePresentation,
+  skillEditBadgeTone,
+  skillEditHint,
+  skillEditKindLabel,
+  type SkillEditKind,
+  type SkillEditPresentation,
+} from "@/lib/skillEditFeedback";
+import {
   isFsWriteConflict,
   isResourceDraftDirty,
 } from "@/lib/resourceEdit";
@@ -159,6 +170,10 @@ export function ExtensionsPanel({
   const [skillEditor, setSkillEditor] = useState<SkillEditorState | null>(null);
   const [skillDiscardOpen, setSkillDiscardOpen] = useState(false);
   const [skillConflictOpen, setSkillConflictOpen] = useState(false);
+  /** Classified validate / load / save feedback (GlassModal — no window.confirm). */
+  const [skillFeedback, setSkillFeedback] =
+    useState<SkillEditPresentation | null>(null);
+  const [skillFeedbackOpen, setSkillFeedbackOpen] = useState(false);
   const skillEditorSeq = useRef(0);
   /** New skill scaffold modal (Extensions → Skills). */
   const [skillNewOpen, setSkillNewOpen] = useState(false);
@@ -357,11 +372,73 @@ export function ExtensionsPanel({
     skillEditor?.baselineText,
   );
 
+  const skillKindLabels = useMemo((): Partial<Record<SkillEditKind, string>> => {
+    return {
+      ok: tr("ext.skills.feedback.kind.ok"),
+      empty: tr("ext.skills.feedback.kind.empty"),
+      too_large: tr("ext.skills.feedback.kind.tooLarge"),
+      missing_frontmatter: tr("ext.skills.feedback.kind.missingFrontmatter"),
+      unclosed_frontmatter: tr("ext.skills.feedback.kind.unclosedFrontmatter"),
+      invalid_frontmatter: tr("ext.skills.feedback.kind.invalidFrontmatter"),
+      missing_name: tr("ext.skills.feedback.kind.missingName"),
+      invalid_name: tr("ext.skills.feedback.kind.invalidName"),
+      name_mismatch: tr("ext.skills.feedback.kind.nameMismatch"),
+      missing_description: tr("ext.skills.feedback.kind.missingDescription"),
+      empty_body: tr("ext.skills.feedback.kind.emptyBody"),
+      conflict: tr("ext.skills.feedback.kind.conflict"),
+      path_denied: tr("ext.skills.feedback.kind.pathDenied"),
+      path_outside: tr("ext.skills.feedback.kind.pathOutside"),
+      bundled_readonly: tr("ext.skills.feedback.kind.bundledReadonly"),
+      not_found: tr("ext.skills.feedback.kind.notFound"),
+      not_a_file: tr("ext.skills.feedback.kind.notAFile"),
+      already_exists: tr("ext.skills.feedback.kind.alreadyExists"),
+      host_only: tr("ext.skills.feedback.kind.hostOnly"),
+      host_error: tr("ext.skills.feedback.kind.hostError"),
+      other: tr("ext.skills.feedback.kind.other"),
+    };
+  }, [tr]);
+
+  const skillKindHints = useMemo((): Partial<Record<SkillEditKind, string>> => {
+    return {
+      ok: tr("ext.skills.feedback.hint.ok"),
+      empty: tr("ext.skills.feedback.hint.empty"),
+      too_large: tr("ext.skills.feedback.hint.tooLarge"),
+      missing_frontmatter: tr("ext.skills.feedback.hint.missingFrontmatter"),
+      unclosed_frontmatter: tr("ext.skills.feedback.hint.unclosedFrontmatter"),
+      invalid_frontmatter: tr("ext.skills.feedback.hint.invalidFrontmatter"),
+      missing_name: tr("ext.skills.feedback.hint.missingName"),
+      invalid_name: tr("ext.skills.feedback.hint.invalidName"),
+      name_mismatch: tr("ext.skills.feedback.hint.nameMismatch"),
+      missing_description: tr("ext.skills.feedback.hint.missingDescription"),
+      empty_body: tr("ext.skills.feedback.hint.emptyBody"),
+      conflict: tr("ext.skills.feedback.hint.conflict"),
+      path_denied: tr("ext.skills.feedback.hint.pathDenied"),
+      path_outside: tr("ext.skills.feedback.hint.pathOutside"),
+      bundled_readonly: tr("ext.skills.feedback.hint.bundledReadonly"),
+      not_found: tr("ext.skills.feedback.hint.notFound"),
+      not_a_file: tr("ext.skills.feedback.hint.notAFile"),
+      already_exists: tr("ext.skills.feedback.hint.alreadyExists"),
+      host_only: tr("ext.skills.feedback.hint.hostOnly"),
+      host_error: tr("ext.skills.feedback.hint.hostError"),
+      other: tr("ext.skills.feedback.hint.other"),
+    };
+  }, [tr]);
+
+  const openSkillFeedback = useCallback(
+    (presentation: SkillEditPresentation) => {
+      setSkillFeedback(presentation);
+      setSkillFeedbackOpen(true);
+    },
+    [],
+  );
+
   const closeSkillEditor = useCallback(() => {
     skillEditorSeq.current += 1;
     setSkillEditor(null);
     setSkillDiscardOpen(false);
     setSkillConflictOpen(false);
+    setSkillFeedbackOpen(false);
+    setSkillFeedback(null);
   }, []);
 
   const requestCloseSkillEditor = useCallback(() => {
@@ -376,6 +453,15 @@ export function ExtensionsPanel({
   const openSkillEditor = useCallback(
     async (skill: api.SkillDto, opts?: { force?: boolean }) => {
       if (!api.isTauri()) {
+        const presentation = buildSkillHostErrorPresentation(
+          tr("ext.needTauri"),
+          "load",
+          {
+            labels: skillKindLabels,
+            fallbackTitle: tr("ext.skills.editLoadError"),
+          },
+        );
+        openSkillFeedback(presentation);
         setPathHint(tr("ext.needTauri"));
         return;
       }
@@ -386,6 +472,8 @@ export function ExtensionsPanel({
       const seq = ++skillEditorSeq.current;
       setSkillDiscardOpen(false);
       setSkillConflictOpen(false);
+      setSkillFeedbackOpen(false);
+      setSkillFeedback(null);
       setSkillEditor({
         skill,
         path: mdPath,
@@ -416,6 +504,11 @@ export function ExtensionsPanel({
         });
       } catch (e) {
         if (seq !== skillEditorSeq.current) return;
+        const presentation = buildSkillHostErrorPresentation(e, "load", {
+          path: mdPath,
+          labels: skillKindLabels,
+          fallbackTitle: tr("ext.skills.editLoadError"),
+        });
         setSkillEditor({
           skill,
           path: mdPath,
@@ -424,29 +517,72 @@ export function ExtensionsPanel({
           mtimeMs: null,
           loading: false,
           saving: false,
-          error: String(e) || tr("ext.skills.editLoadError"),
+          error: presentation.summary || tr("ext.skills.editLoadError"),
           savedHint: null,
         });
+        openSkillFeedback(presentation);
       }
     },
-    [projectPath, skillRoots, tr],
+    [openSkillFeedback, projectPath, skillKindLabels, skillRoots, tr],
   );
+
+  const validateSkillEditor = useCallback(() => {
+    if (!skillEditor || skillEditor.loading) return;
+    const presentation = buildSkillValidatePresentation(skillEditor.draftText, {
+      expectedName: skillEditor.skill.name,
+      path: skillEditor.path,
+      labels: skillKindLabels,
+      titles: {
+        ok: tr("ext.skills.feedback.validateOk"),
+        fail: tr("ext.skills.feedback.validateFail"),
+      },
+    });
+    setSkillEditor((s) =>
+      s
+        ? {
+            ...s,
+            error: presentation.blocking ? presentation.summary : null,
+            savedHint: presentation.blocking
+              ? null
+              : presentation.summary || tr("ext.skills.feedback.validateOk"),
+          }
+        : s,
+    );
+    openSkillFeedback(presentation);
+  }, [openSkillFeedback, skillEditor, skillKindLabels, tr]);
 
   const saveSkillEditor = useCallback(
     async (opts?: { force?: boolean }) => {
       if (!skillEditor || skillEditor.loading || skillEditor.saving) return;
-      if (!api.isTauri()) {
-        setSkillEditor((s) =>
-          s ? { ...s, error: tr("ext.needTauri") } : s,
-        );
-        return;
-      }
       if (
         !isResourceDraftDirty(skillEditor.draftText, skillEditor.baselineText) &&
         !opts?.force
       ) {
         return;
       }
+
+      // Client-side SKILL.md validate before host write (force overwrite still validates).
+      const preflight = buildSkillSavePreflightError(skillEditor.draftText, {
+        isTauri: api.isTauri(),
+        expectedName: skillEditor.skill.name,
+        path: skillEditor.path,
+        labels: skillKindLabels,
+        hostOnlyTitle: tr("ext.needTauri"),
+      });
+      if (preflight) {
+        setSkillEditor((s) =>
+          s
+            ? {
+                ...s,
+                error: preflight.summary,
+                savedHint: null,
+              }
+            : s,
+        );
+        openSkillFeedback(preflight);
+        return;
+      }
+
       setSkillEditor((s) =>
         s ? { ...s, saving: true, error: null, savedHint: null } : s,
       );
@@ -459,6 +595,13 @@ export function ExtensionsPanel({
           projectPath,
         );
         const saved = skillEditor.draftText;
+        const okPresentation = buildSkillSaveOkPresentation({
+          path: w.path || skillEditor.path,
+          name: skillEditor.skill.name,
+          sizeBytes: w.size,
+          labels: skillKindLabels,
+          title: tr("ext.skills.editSaved"),
+        });
         setSkillEditor((s) =>
           s
             ? {
@@ -473,6 +616,7 @@ export function ExtensionsPanel({
               }
             : s,
         );
+        setSkillFeedback(okPresentation);
         // Reload Extensions list + composer skills picker.
         await refresh();
         onSkillsPrefsChanged?.();
@@ -482,18 +626,32 @@ export function ExtensionsPanel({
           setSkillConflictOpen(true);
           return;
         }
+        const presentation = buildSkillHostErrorPresentation(e, "save", {
+          path: skillEditor.path,
+          labels: skillKindLabels,
+          fallbackTitle: tr("ext.skills.editSaveError"),
+        });
         setSkillEditor((s) =>
           s
             ? {
                 ...s,
                 saving: false,
-                error: String(e) || tr("ext.skills.editSaveError"),
+                error: presentation.summary || tr("ext.skills.editSaveError"),
               }
             : s,
         );
+        openSkillFeedback(presentation);
       }
     },
-    [onSkillsPrefsChanged, projectPath, refresh, skillEditor, tr],
+    [
+      onSkillsPrefsChanged,
+      openSkillFeedback,
+      projectPath,
+      refresh,
+      skillEditor,
+      skillKindLabels,
+      tr,
+    ],
   );
 
   const skillNewSanitized = useMemo(
@@ -551,7 +709,12 @@ export function ExtensionsPanel({
       // Roots React state may lag one frame after refresh — force open by path.
       void openSkillEditor(dto, { force: true });
     } catch (e) {
-      setSkillNewError(String(e) || tr("ext.skills.newError"));
+      const presentation = buildSkillHostErrorPresentation(e, "create", {
+        labels: skillKindLabels,
+        fallbackTitle: tr("ext.skills.newError"),
+      });
+      setSkillNewError(presentation.summary || tr("ext.skills.newError"));
+      openSkillFeedback(presentation);
     } finally {
       setActionBusy(null);
     }
@@ -559,8 +722,10 @@ export function ExtensionsPanel({
     actionBusy,
     onSkillsPrefsChanged,
     openSkillEditor,
+    openSkillFeedback,
     projectPath,
     refresh,
+    skillKindLabels,
     skillNewDesc,
     skillNewName,
     skillNewScope,
@@ -2291,6 +2456,16 @@ export function ExtensionsPanel({
             </button>
             <button
               type="button"
+              className="btn btn--ghost"
+              disabled={
+                !skillEditor || skillEditor.loading || skillEditor.saving
+              }
+              onClick={validateSkillEditor}
+            >
+              {tr("ext.skills.editValidate")}
+            </button>
+            <button
+              type="button"
               className="btn btn--solid"
               disabled={
                 !skillEditor ||
@@ -2353,14 +2528,170 @@ export function ExtensionsPanel({
             {skillEditor.error && skillEditor.baselineText ? (
               <p className="ext-skill-editor__error" role="alert">
                 {skillEditor.error}
+                {skillFeedback ? (
+                  <>
+                    {" "}
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm ext-skill-editor__details-btn"
+                      onClick={() => setSkillFeedbackOpen(true)}
+                    >
+                      {tr("ext.skills.feedback.viewDetails")}
+                    </button>
+                  </>
+                ) : null}
               </p>
             ) : null}
             {skillEditor.savedHint ? (
-              <p className="ext-skill-editor__saved" role="status">
+              <p
+                className={
+                  "ext-skill-editor__saved" +
+                  (skillFeedback && !skillFeedback.blocking
+                    ? skillFeedback.severity === "warn"
+                      ? " ext-skill-editor__status--warn"
+                      : skillFeedback.severity === "ok"
+                        ? " ext-skill-editor__status--ok"
+                        : ""
+                    : " ext-skill-editor__status--ok")
+                }
+                role="status"
+              >
                 {skillEditor.savedHint}
+                {skillFeedback && !skillFeedback.blocking ? (
+                  <>
+                    {" "}
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm ext-skill-editor__details-btn"
+                      onClick={() => setSkillFeedbackOpen(true)}
+                    >
+                      {tr("ext.skills.feedback.viewDetails")}
+                    </button>
+                  </>
+                ) : null}
               </p>
             ) : null}
           </>
+        ) : null}
+      </GlassModal>
+
+      <GlassModal
+        open={skillFeedbackOpen && !!skillFeedback}
+        onClose={() => setSkillFeedbackOpen(false)}
+        title={
+          skillFeedback?.phase === "validate"
+            ? tr("ext.skills.feedback.resultValidateTitle")
+            : skillFeedback?.phase === "load"
+              ? tr("ext.skills.feedback.resultLoadTitle")
+              : skillFeedback?.phase === "create"
+                ? tr("ext.skills.feedback.resultCreateTitle")
+                : tr("ext.skills.feedback.resultSaveTitle")
+        }
+        size="md"
+        closeLabel={tr("common.close")}
+        wrapBody
+        bodyClassName="ext-skill-feedback"
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--solid"
+              onClick={() => setSkillFeedbackOpen(false)}
+            >
+              {tr("common.close")}
+            </button>
+          </>
+        }
+      >
+        {skillFeedback ? (
+          <div className="ext-skill-feedback__body">
+            <div className="ext-skill-feedback__meta">
+              <span
+                className={
+                  "ext-badge ext-badge--" +
+                  skillEditBadgeTone(skillFeedback.severity)
+                }
+              >
+                {skillEditKindLabel(skillFeedback.kind, skillKindLabels)}
+              </span>
+              {skillFeedback.name ? (
+                <span className="ext-badge ext-badge--muted">
+                  /{skillFeedback.name}
+                </span>
+              ) : null}
+              {skillFeedback.sizeBytes != null ? (
+                <span className="ext-badge ext-badge--muted">
+                  {tr("ext.skills.feedback.sizeBytes", {
+                    n: String(skillFeedback.sizeBytes),
+                  })}
+                </span>
+              ) : null}
+            </div>
+            <p
+              className={
+                "ext-skill-feedback__summary" +
+                (skillFeedback.severity === "ok"
+                  ? " ext-skill-feedback__summary--ok"
+                  : skillFeedback.severity === "err"
+                    ? " ext-skill-feedback__summary--err"
+                    : skillFeedback.severity === "warn"
+                      ? " ext-skill-feedback__summary--warn"
+                      : "")
+              }
+            >
+              {skillFeedback.summary}
+            </p>
+            {skillEditHint(skillFeedback.kind, skillKindHints) ? (
+              <p className="ext-skill-feedback__hint">
+                {skillEditHint(skillFeedback.kind, skillKindHints)}
+              </p>
+            ) : null}
+            {skillFeedback.detail &&
+            skillFeedback.detail !== skillFeedback.summary ? (
+              <p className="ext-skill-feedback__detail">
+                {skillFeedback.detail}
+              </p>
+            ) : null}
+            {skillFeedback.issues.length > 1 ? (
+              <ul className="ext-skill-feedback__issues">
+                {skillFeedback.issues.map((issue, idx) => (
+                  <li key={`${issue.kind}-${idx}`}>
+                    <span
+                      className={
+                        "ext-badge ext-badge--" +
+                        skillEditBadgeTone(issue.severity)
+                      }
+                    >
+                      {skillEditKindLabel(issue.kind, skillKindLabels)}
+                    </span>
+                    {issue.detail ? (
+                      <span className="ext-skill-feedback__issue-detail">
+                        {issue.detail}
+                      </span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {skillFeedback.reason ? (
+              <p className="ext-skill-feedback__reason">
+                <span className="ext-skill-feedback__label">
+                  {tr("ext.skills.feedback.reason")}
+                </span>
+                <code>{skillFeedback.reason}</code>
+              </p>
+            ) : null}
+            {skillFeedback.path ? (
+              <p className="ext-skill-feedback__path" title={skillFeedback.path}>
+                <span className="ext-skill-feedback__label">
+                  {tr("ext.skills.feedback.path")}
+                </span>
+                <code>
+                  {shortPathLabel(skillFeedback.path, 64) || skillFeedback.path}
+                </code>
+              </p>
+            ) : null}
+          </div>
         ) : null}
       </GlassModal>
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -3177,6 +3177,77 @@ const en = {
     "This SKILL.md was modified outside the app. Reload the file or overwrite with your draft.",
   "ext.skills.editConflictReload": "Reload",
   "ext.skills.editConflictOverwrite": "Overwrite",
+  "ext.skills.editValidate": "Validate",
+  "ext.skills.feedback.validateOk": "SKILL.md looks valid",
+  "ext.skills.feedback.validateFail": "SKILL.md has problems",
+  "ext.skills.feedback.viewDetails": "Details",
+  "ext.skills.feedback.resultValidateTitle": "Skill validation",
+  "ext.skills.feedback.resultLoadTitle": "Could not open skill",
+  "ext.skills.feedback.resultSaveTitle": "Save result",
+  "ext.skills.feedback.resultCreateTitle": "Create skill",
+  "ext.skills.feedback.reason": "Reason",
+  "ext.skills.feedback.path": "Path",
+  "ext.skills.feedback.sizeBytes": "{n} bytes",
+  "ext.skills.feedback.kind.ok": "OK",
+  "ext.skills.feedback.kind.empty": "Empty file",
+  "ext.skills.feedback.kind.tooLarge": "Too large",
+  "ext.skills.feedback.kind.missingFrontmatter": "Missing frontmatter",
+  "ext.skills.feedback.kind.unclosedFrontmatter": "Unclosed frontmatter",
+  "ext.skills.feedback.kind.invalidFrontmatter": "Invalid frontmatter",
+  "ext.skills.feedback.kind.missingName": "Missing name",
+  "ext.skills.feedback.kind.invalidName": "Invalid name",
+  "ext.skills.feedback.kind.nameMismatch": "Name mismatch",
+  "ext.skills.feedback.kind.missingDescription": "Missing description",
+  "ext.skills.feedback.kind.emptyBody": "Empty body",
+  "ext.skills.feedback.kind.conflict": "File conflict",
+  "ext.skills.feedback.kind.pathDenied": "Path denied",
+  "ext.skills.feedback.kind.pathOutside": "Outside skills roots",
+  "ext.skills.feedback.kind.bundledReadonly": "Bundled (read-only)",
+  "ext.skills.feedback.kind.notFound": "Not found",
+  "ext.skills.feedback.kind.notAFile": "Not a file",
+  "ext.skills.feedback.kind.alreadyExists": "Already exists",
+  "ext.skills.feedback.kind.hostOnly": "Desktop host required",
+  "ext.skills.feedback.kind.hostError": "Host error",
+  "ext.skills.feedback.kind.other": "Error",
+  "ext.skills.feedback.hint.ok":
+    "Frontmatter looks valid. You can save when ready.",
+  "ext.skills.feedback.hint.empty":
+    "Paste or write a SKILL.md with YAML frontmatter and body.",
+  "ext.skills.feedback.hint.tooLarge":
+    "Keep SKILL.md under 2 MiB for in-app edit.",
+  "ext.skills.feedback.hint.missingFrontmatter":
+    "Start the file with --- then name: / description: fields, then closing ---.",
+  "ext.skills.feedback.hint.unclosedFrontmatter":
+    "Add a closing --- line after the frontmatter fields.",
+  "ext.skills.feedback.hint.invalidFrontmatter":
+    "Use simple one-line key: value pairs in the frontmatter (no nested YAML).",
+  "ext.skills.feedback.hint.missingName":
+    "Add a name: field in the frontmatter (slash-command style).",
+  "ext.skills.feedback.hint.invalidName":
+    "Name must be lowercase a-z, digits, hyphens; 2–64 chars; start/end alnum.",
+  "ext.skills.feedback.hint.nameMismatch":
+    "Frontmatter name differs from the skill folder — save still works, but CLI may prefer the folder name.",
+  "ext.skills.feedback.hint.missingDescription":
+    "Add a description: with what the skill does and trigger phrases.",
+  "ext.skills.feedback.hint.emptyBody":
+    "Add markdown steps under the frontmatter so the agent has instructions.",
+  "ext.skills.feedback.hint.conflict":
+    "Reload from disk or overwrite with your draft.",
+  "ext.skills.feedback.hint.pathDenied":
+    "Only SKILL.md under user/agent-home/project skills roots can be edited.",
+  "ext.skills.feedback.hint.pathOutside":
+    "This path is outside known skills roots — open a user or project skill.",
+  "ext.skills.feedback.hint.bundledReadonly":
+    "Bundled/vendor skills are read-only. Copy into user skills to edit.",
+  "ext.skills.feedback.hint.notFound":
+    "File missing — refresh the skills list or recreate the skill.",
+  "ext.skills.feedback.hint.notAFile": "Target is not a SKILL.md file.",
+  "ext.skills.feedback.hint.alreadyExists":
+    "A skill with this name already exists — open it or pick another name.",
+  "ext.skills.feedback.hint.hostOnly":
+    "Open the desktop app (Tauri) to read or save skills.",
+  "ext.skills.feedback.hint.hostError": "Host invoke failed — see detail.",
+  "ext.skills.feedback.hint.other": "Unexpected outcome — see detail.",
   "ext.skills.new": "New skill",
   "ext.skills.newTitle": "New skill",
   "ext.skills.newSubmit": "Create",
@@ -7191,6 +7262,72 @@ const zh: Record<MessageKey, string> = {
     "此 SKILL.md 已在应用外被修改。可重新加载文件，或用当前草稿覆盖。",
   "ext.skills.editConflictReload": "重新加载",
   "ext.skills.editConflictOverwrite": "覆盖",
+  "ext.skills.editValidate": "校验",
+  "ext.skills.feedback.validateOk": "SKILL.md 看起来有效",
+  "ext.skills.feedback.validateFail": "SKILL.md 存在问题",
+  "ext.skills.feedback.viewDetails": "详情",
+  "ext.skills.feedback.resultValidateTitle": "技能校验",
+  "ext.skills.feedback.resultLoadTitle": "无法打开技能",
+  "ext.skills.feedback.resultSaveTitle": "保存结果",
+  "ext.skills.feedback.resultCreateTitle": "创建技能",
+  "ext.skills.feedback.reason": "原因",
+  "ext.skills.feedback.path": "路径",
+  "ext.skills.feedback.sizeBytes": "{n} 字节",
+  "ext.skills.feedback.kind.ok": "正常",
+  "ext.skills.feedback.kind.empty": "文件为空",
+  "ext.skills.feedback.kind.tooLarge": "文件过大",
+  "ext.skills.feedback.kind.missingFrontmatter": "缺少前置元数据",
+  "ext.skills.feedback.kind.unclosedFrontmatter": "前置元数据未闭合",
+  "ext.skills.feedback.kind.invalidFrontmatter": "前置元数据无效",
+  "ext.skills.feedback.kind.missingName": "缺少 name",
+  "ext.skills.feedback.kind.invalidName": "name 无效",
+  "ext.skills.feedback.kind.nameMismatch": "名称不一致",
+  "ext.skills.feedback.kind.missingDescription": "缺少 description",
+  "ext.skills.feedback.kind.emptyBody": "正文为空",
+  "ext.skills.feedback.kind.conflict": "文件冲突",
+  "ext.skills.feedback.kind.pathDenied": "路径被拒绝",
+  "ext.skills.feedback.kind.pathOutside": "不在技能根目录内",
+  "ext.skills.feedback.kind.bundledReadonly": "内置（只读）",
+  "ext.skills.feedback.kind.notFound": "未找到",
+  "ext.skills.feedback.kind.notAFile": "不是文件",
+  "ext.skills.feedback.kind.alreadyExists": "已存在",
+  "ext.skills.feedback.kind.hostOnly": "需要桌面宿主",
+  "ext.skills.feedback.kind.hostError": "宿主错误",
+  "ext.skills.feedback.kind.other": "错误",
+  "ext.skills.feedback.hint.ok": "前置元数据看起来有效。准备好后即可保存。",
+  "ext.skills.feedback.hint.empty":
+    "请粘贴或编写带 YAML 前置元数据与正文的 SKILL.md。",
+  "ext.skills.feedback.hint.tooLarge": "应用内编辑要求 SKILL.md 不超过 2 MiB。",
+  "ext.skills.feedback.hint.missingFrontmatter":
+    "文件以 --- 开头，写入 name: / description:，再以 --- 结束前置块。",
+  "ext.skills.feedback.hint.unclosedFrontmatter":
+    "在前置字段后添加一行闭合的 ---。",
+  "ext.skills.feedback.hint.invalidFrontmatter":
+    "前置元数据请使用简单的单行 key: value（不支持嵌套 YAML）。",
+  "ext.skills.feedback.hint.missingName":
+    "在前置元数据中添加 name:（斜杠命令风格）。",
+  "ext.skills.feedback.hint.invalidName":
+    "名称须为小写 a-z、数字、连字符；2–64 字符；以字母或数字开头结尾。",
+  "ext.skills.feedback.hint.nameMismatch":
+    "前置 name 与技能文件夹不一致 — 仍可保存，但 CLI 可能优先使用文件夹名。",
+  "ext.skills.feedback.hint.missingDescription":
+    "添加 description: 说明用途与触发短语。",
+  "ext.skills.feedback.hint.emptyBody":
+    "在前置元数据下补充 Markdown 步骤，便于代理执行。",
+  "ext.skills.feedback.hint.conflict": "可从磁盘重新加载，或用当前草稿覆盖。",
+  "ext.skills.feedback.hint.pathDenied":
+    "仅可编辑用户 / agent-home / 项目技能根目录下的 SKILL.md。",
+  "ext.skills.feedback.hint.pathOutside":
+    "路径不在已知技能根目录内 — 请打开用户或项目技能。",
+  "ext.skills.feedback.hint.bundledReadonly":
+    "内置/供应商技能为只读。请复制到用户技能目录后再编辑。",
+  "ext.skills.feedback.hint.notFound": "文件不存在 — 刷新列表或重新创建技能。",
+  "ext.skills.feedback.hint.notAFile": "目标不是 SKILL.md 文件。",
+  "ext.skills.feedback.hint.alreadyExists":
+    "同名技能已存在 — 请打开它或换一个名称。",
+  "ext.skills.feedback.hint.hostOnly": "请在桌面应用（Tauri）中读写技能。",
+  "ext.skills.feedback.hint.hostError": "宿主调用失败 — 见详情。",
+  "ext.skills.feedback.hint.other": "意外结果 — 见详情。",
   "ext.skills.new": "新建技能",
   "ext.skills.newTitle": "新建技能",
   "ext.skills.newSubmit": "创建",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -3058,6 +3058,72 @@ export const zhTW: Record<MessageKey, string> = {
     "此 SKILL.md 已在應用外被修改。可重新載入檔案，或用目前草稿覆寫。",
   "ext.skills.editConflictReload": "重新載入",
   "ext.skills.editConflictOverwrite": "覆寫",
+  "ext.skills.editValidate": "驗證",
+  "ext.skills.feedback.validateOk": "SKILL.md 看起來有效",
+  "ext.skills.feedback.validateFail": "SKILL.md 存在問題",
+  "ext.skills.feedback.viewDetails": "詳情",
+  "ext.skills.feedback.resultValidateTitle": "技能驗證",
+  "ext.skills.feedback.resultLoadTitle": "無法開啟技能",
+  "ext.skills.feedback.resultSaveTitle": "儲存結果",
+  "ext.skills.feedback.resultCreateTitle": "建立技能",
+  "ext.skills.feedback.reason": "原因",
+  "ext.skills.feedback.path": "路徑",
+  "ext.skills.feedback.sizeBytes": "{n} 位元組",
+  "ext.skills.feedback.kind.ok": "正常",
+  "ext.skills.feedback.kind.empty": "檔案為空",
+  "ext.skills.feedback.kind.tooLarge": "檔案過大",
+  "ext.skills.feedback.kind.missingFrontmatter": "缺少前置中繼資料",
+  "ext.skills.feedback.kind.unclosedFrontmatter": "前置中繼資料未閉合",
+  "ext.skills.feedback.kind.invalidFrontmatter": "前置中繼資料無效",
+  "ext.skills.feedback.kind.missingName": "缺少 name",
+  "ext.skills.feedback.kind.invalidName": "name 無效",
+  "ext.skills.feedback.kind.nameMismatch": "名稱不一致",
+  "ext.skills.feedback.kind.missingDescription": "缺少 description",
+  "ext.skills.feedback.kind.emptyBody": "正文為空",
+  "ext.skills.feedback.kind.conflict": "檔案衝突",
+  "ext.skills.feedback.kind.pathDenied": "路徑被拒絕",
+  "ext.skills.feedback.kind.pathOutside": "不在技能根目錄內",
+  "ext.skills.feedback.kind.bundledReadonly": "內建（唯讀）",
+  "ext.skills.feedback.kind.notFound": "找不到",
+  "ext.skills.feedback.kind.notAFile": "不是檔案",
+  "ext.skills.feedback.kind.alreadyExists": "已存在",
+  "ext.skills.feedback.kind.hostOnly": "需要桌面主機",
+  "ext.skills.feedback.kind.hostError": "主機錯誤",
+  "ext.skills.feedback.kind.other": "錯誤",
+  "ext.skills.feedback.hint.ok": "前置中繼資料看起來有效。準備好後即可儲存。",
+  "ext.skills.feedback.hint.empty":
+    "請貼上或撰寫含 YAML 前置中繼資料與正文的 SKILL.md。",
+  "ext.skills.feedback.hint.tooLarge": "應用內編輯要求 SKILL.md 不超過 2 MiB。",
+  "ext.skills.feedback.hint.missingFrontmatter":
+    "檔案以 --- 開頭，寫入 name: / description:，再以 --- 結束前置區塊。",
+  "ext.skills.feedback.hint.unclosedFrontmatter":
+    "在前置欄位後加入一行閉合的 ---。",
+  "ext.skills.feedback.hint.invalidFrontmatter":
+    "前置中繼資料請使用簡單的單行 key: value（不支援巢狀 YAML）。",
+  "ext.skills.feedback.hint.missingName":
+    "在前置中繼資料中加入 name:（斜線指令風格）。",
+  "ext.skills.feedback.hint.invalidName":
+    "名稱須為小寫 a-z、數字、連字號；2–64 字元；以字母或數字開頭結尾。",
+  "ext.skills.feedback.hint.nameMismatch":
+    "前置 name 與技能資料夾不一致 — 仍可儲存，但 CLI 可能優先使用資料夾名。",
+  "ext.skills.feedback.hint.missingDescription":
+    "加入 description: 說明用途與觸發片語。",
+  "ext.skills.feedback.hint.emptyBody":
+    "在前置中繼資料下補充 Markdown 步驟，便於代理執行。",
+  "ext.skills.feedback.hint.conflict": "可從磁碟重新載入，或用目前草稿覆寫。",
+  "ext.skills.feedback.hint.pathDenied":
+    "僅可編輯使用者 / agent-home / 專案技能根目錄下的 SKILL.md。",
+  "ext.skills.feedback.hint.pathOutside":
+    "路徑不在已知技能根目錄內 — 請開啟使用者或專案技能。",
+  "ext.skills.feedback.hint.bundledReadonly":
+    "內建/供應商技能為唯讀。請複製到使用者技能目錄後再編輯。",
+  "ext.skills.feedback.hint.notFound": "檔案不存在 — 重新整理列表或重新建立技能。",
+  "ext.skills.feedback.hint.notAFile": "目標不是 SKILL.md 檔案。",
+  "ext.skills.feedback.hint.alreadyExists":
+    "同名技能已存在 — 請開啟它或換一個名稱。",
+  "ext.skills.feedback.hint.hostOnly": "請在桌面應用（Tauri）中讀寫技能。",
+  "ext.skills.feedback.hint.hostError": "主機呼叫失敗 — 見詳情。",
+  "ext.skills.feedback.hint.other": "意外結果 — 見詳情。",
   "ext.skills.new": "新增技能",
   "ext.skills.newTitle": "新增技能",
   "ext.skills.newSubmit": "建立",

--- a/src/lib/skillEditFeedback.test.ts
+++ b/src/lib/skillEditFeedback.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import { defaultSkillMdContent } from "./skillScaffold";
+import {
+  MAX_SKILL_EDIT_BYTES,
+  buildSkillHostErrorPresentation,
+  buildSkillSaveOkPresentation,
+  buildSkillSavePreflightError,
+  buildSkillValidatePresentation,
+  classifySkillHostError,
+  parseSkillMdFrontmatter,
+  skillEditBadgeTone,
+  skillEditHint,
+  skillEditKindBlocksSave,
+  skillEditKindLabel,
+  skillEditSeverity,
+  skillMdByteLength,
+  validateSkillMdContent,
+} from "./skillEditFeedback";
+
+describe("skillMdByteLength", () => {
+  it("counts ASCII and multi-byte", () => {
+    expect(skillMdByteLength("abc")).toBe(3);
+    expect(skillMdByteLength("你")).toBe(3);
+    expect(skillMdByteLength("")).toBe(0);
+  });
+});
+
+describe("parseSkillMdFrontmatter", () => {
+  it("parses scaffold template", () => {
+    const md = defaultSkillMdContent("deploy-k8s", "Deploy to k8s.");
+    const p = parseSkillMdFrontmatter(md);
+    expect(p.ok).toBe(true);
+    if (!p.ok) return;
+    expect(p.frontmatter.name).toBe("deploy-k8s");
+    expect(p.frontmatter.description).toContain("Deploy");
+    expect(p.frontmatter.body).toContain("# Deploy K8s");
+  });
+
+  it("rejects empty / missing / unclosed frontmatter", () => {
+    const empty = parseSkillMdFrontmatter("");
+    expect(empty.ok).toBe(false);
+    if (!empty.ok) expect(empty.kind).toBe("empty");
+
+    const missing = parseSkillMdFrontmatter("# just body\n");
+    expect(missing.ok).toBe(false);
+    if (!missing.ok) expect(missing.kind).toBe("missing_frontmatter");
+
+    const unclosed = parseSkillMdFrontmatter("---\nname: x\n");
+    expect(unclosed.ok).toBe(false);
+    if (!unclosed.ok) expect(unclosed.kind).toBe("unclosed_frontmatter");
+  });
+
+  it("rejects invalid frontmatter lines", () => {
+    const bad = parseSkillMdFrontmatter("---\nnot a kv line\n---\n");
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.kind).toBe("invalid_frontmatter");
+  });
+
+  it("strips quotes and allows description", () => {
+    const md = `---
+name: "hello-world"
+description: 'Say "hi"'
+---
+
+Body here.
+`;
+    const p = parseSkillMdFrontmatter(md);
+    expect(p.ok).toBe(true);
+    if (!p.ok) return;
+    expect(p.frontmatter.name).toBe("hello-world");
+    expect(p.frontmatter.description).toContain("hi");
+    expect(p.frontmatter.body.trim()).toBe("Body here.");
+  });
+});
+
+describe("validateSkillMdContent", () => {
+  it("accepts valid scaffold", () => {
+    const md = defaultSkillMdContent("code-review", "Review PRs.");
+    const v = validateSkillMdContent(md, { expectedName: "code-review" });
+    expect(v.ok).toBe(true);
+    expect(v.blocking).toBe(false);
+    expect(v.kind).toBe("ok");
+    expect(v.name).toBe("code-review");
+  });
+
+  it("blocks empty and missing name", () => {
+    expect(validateSkillMdContent("").blocking).toBe(true);
+    expect(validateSkillMdContent("").kind).toBe("empty");
+
+    const noName = `---
+description: something useful
+---
+
+# Title
+`;
+    const v = validateSkillMdContent(noName);
+    expect(v.blocking).toBe(true);
+    expect(v.kind).toBe("missing_name");
+  });
+
+  it("blocks invalid name", () => {
+    const md = `---
+name: BAD_NAME!!
+description: x
+---
+
+body
+`;
+    const v = validateSkillMdContent(md);
+    expect(v.blocking).toBe(true);
+    expect(v.kind).toBe("invalid_name");
+  });
+
+  it("warns on name mismatch without blocking", () => {
+    const md = defaultSkillMdContent("alpha", "Alpha skill.");
+    const v = validateSkillMdContent(md, { expectedName: "beta" });
+    expect(v.ok).toBe(true);
+    expect(v.blocking).toBe(false);
+    expect(v.issues.some((i) => i.kind === "name_mismatch")).toBe(true);
+    expect(v.kind).toBe("name_mismatch");
+  });
+
+  it("warns on missing description / empty body", () => {
+    const md = `---
+name: bare-skill
+---
+`;
+    const v = validateSkillMdContent(md);
+    expect(v.ok).toBe(true);
+    expect(v.blocking).toBe(false);
+    expect(v.issues.some((i) => i.kind === "missing_description")).toBe(true);
+    expect(v.issues.some((i) => i.kind === "empty_body")).toBe(true);
+  });
+
+  it("blocks oversized content", () => {
+    const big = "x".repeat(MAX_SKILL_EDIT_BYTES + 1);
+    const v = validateSkillMdContent(big, { maxBytes: MAX_SKILL_EDIT_BYTES });
+    expect(v.blocking).toBe(true);
+    expect(v.kind).toBe("too_large");
+  });
+});
+
+describe("classifySkillHostError", () => {
+  it("maps known host messages", () => {
+    expect(classifySkillHostError("CONFLICT: file changed on disk")).toBe(
+      "conflict",
+    );
+    expect(
+      classifySkillHostError("path not allowed: outside known skills roots"),
+    ).toBe("path_outside");
+    expect(classifySkillHostError("path not allowed: traversal")).toBe(
+      "path_denied",
+    );
+    expect(classifySkillHostError("path not allowed: bundled skills")).toBe(
+      "bundled_readonly",
+    );
+    expect(
+      classifySkillHostError("file too large to edit in-app (max 2097152 bytes)"),
+    ).toBe("too_large");
+    expect(classifySkillHostError("not a file: /tmp/x")).toBe("not_a_file");
+    expect(classifySkillHostError("path not found: No such file")).toBe(
+      "not_found",
+    );
+    expect(
+      classifySkillHostError("skill already exists", "create"),
+    ).toBe("already_exists");
+    expect(classifySkillHostError("Try-run requires the desktop host")).toBe(
+      "host_only",
+    );
+    expect(classifySkillHostError("skill name is reserved")).toBe(
+      "invalid_name",
+    );
+    expect(classifySkillHostError("boom")).toBe("host_error");
+  });
+});
+
+describe("skillEditSeverity / blocks / badge", () => {
+  it("maps severity and block rules", () => {
+    expect(skillEditSeverity("ok")).toBe("ok");
+    expect(skillEditSeverity("name_mismatch")).toBe("warn");
+    expect(skillEditSeverity("empty_body")).toBe("info");
+    expect(skillEditSeverity("invalid_name")).toBe("err");
+    expect(skillEditKindBlocksSave("ok")).toBe(false);
+    expect(skillEditKindBlocksSave("name_mismatch")).toBe(false);
+    expect(skillEditKindBlocksSave("missing_name")).toBe(true);
+    expect(skillEditBadgeTone("ok")).toBe("ok");
+    expect(skillEditBadgeTone("err")).toBe("fail");
+    expect(skillEditBadgeTone("warn")).toBe("muted");
+  });
+
+  it("has fallback labels and hints", () => {
+    expect(skillEditKindLabel("conflict")).toMatch(/conflict/i);
+    expect(skillEditHint("missing_frontmatter").length).toBeGreaterThan(10);
+  });
+});
+
+describe("buildSkillValidatePresentation / host / preflight", () => {
+  it("builds ok presentation", () => {
+    const md = defaultSkillMdContent("ok-skill", "Does things.");
+    const p = buildSkillValidatePresentation(md, {
+      expectedName: "ok-skill",
+      path: "/tmp/skills/ok-skill/SKILL.md",
+    });
+    expect(p.ok).toBe(true);
+    expect(p.blocking).toBe(false);
+    expect(p.phase).toBe("validate");
+    expect(p.path).toContain("SKILL.md");
+    expect(p.name).toBe("ok-skill");
+  });
+
+  it("builds blocking presentation for bad content", () => {
+    const p = buildSkillValidatePresentation("# no fm\n");
+    expect(p.ok).toBe(false);
+    expect(p.blocking).toBe(true);
+    expect(p.kind).toBe("missing_frontmatter");
+  });
+
+  it("builds host error presentation", () => {
+    const p = buildSkillHostErrorPresentation(
+      new Error("CONFLICT: mtime"),
+      "save",
+      { path: "/x/SKILL.md" },
+    );
+    expect(p.kind).toBe("conflict");
+    expect(p.phase).toBe("save");
+    expect(p.blocking).toBe(true);
+    expect(p.path).toBe("/x/SKILL.md");
+  });
+
+  it("preflight blocks host-only and invalid content", () => {
+    expect(
+      buildSkillSavePreflightError("x", { isTauri: false })?.kind,
+    ).toBe("host_only");
+    const bad = buildSkillSavePreflightError("# no", { isTauri: true });
+    expect(bad?.blocking).toBe(true);
+    expect(bad?.phase).toBe("save");
+
+    const good = buildSkillSavePreflightError(
+      defaultSkillMdContent("fine", "desc"),
+      { isTauri: true, expectedName: "fine" },
+    );
+    expect(good).toBeNull();
+  });
+
+  it("builds save ok presentation", () => {
+    const p = buildSkillSaveOkPresentation({
+      path: "/a/SKILL.md",
+      name: "a",
+      sizeBytes: 12,
+      title: "Saved",
+    });
+    expect(p.ok).toBe(true);
+    expect(p.phase).toBe("save");
+    expect(p.title).toBe("Saved");
+  });
+});

--- a/src/lib/skillEditFeedback.ts
+++ b/src/lib/skillEditFeedback.ts
@@ -1,0 +1,721 @@
+/**
+ * SKILL-EDIT-PRO — pure helpers for Extensions → Skills edit / validate / save UX.
+ *
+ * Classifies SKILL.md content checks and host read/write/create errors into stable
+ * machine kinds for i18n labels, severity chips, and GlassModal presentation.
+ * Never invents success — only maps honest parse / host signals.
+ */
+
+import {
+  sanitizeSkillFolderName,
+  SKILL_DESCRIPTION_MAX,
+} from "./skillScaffold";
+
+/** Matches host `skill_edit` MAX_SKILL_BYTES (2 MiB). */
+export const MAX_SKILL_EDIT_BYTES = 2 * 1024 * 1024;
+
+/** Stable outcome kinds for validate / load / save / create. */
+export type SkillEditKind =
+  | "ok"
+  | "empty"
+  | "too_large"
+  | "missing_frontmatter"
+  | "unclosed_frontmatter"
+  | "invalid_frontmatter"
+  | "missing_name"
+  | "invalid_name"
+  | "name_mismatch"
+  | "missing_description"
+  | "empty_body"
+  | "conflict"
+  | "path_denied"
+  | "path_outside"
+  | "bundled_readonly"
+  | "not_found"
+  | "not_a_file"
+  | "already_exists"
+  | "host_only"
+  | "host_error"
+  | "other";
+
+export type SkillEditSeverity = "ok" | "warn" | "err" | "info";
+
+export type SkillEditPhase = "validate" | "load" | "save" | "create";
+
+/** One issue in a content validation pass. */
+export type SkillEditIssue = {
+  kind: SkillEditKind;
+  severity: SkillEditSeverity;
+  /** Optional detail (e.g. parse note, expected vs actual name). */
+  detail?: string;
+};
+
+/** Parsed SKILL.md frontmatter + body (simple YAML `key: value` lines). */
+export type SkillFrontmatter = {
+  name: string | null;
+  description: string | null;
+  /** All simple key/value pairs from the frontmatter block. */
+  raw: Record<string, string>;
+  body: string;
+};
+
+export type SkillEditPresentation = {
+  kind: SkillEditKind;
+  severity: SkillEditSeverity;
+  phase: SkillEditPhase;
+  /** Short headline (kind label or phase-specific title). */
+  title: string;
+  /** One-line summary for status / modal. */
+  summary: string;
+  /** Optional longer detail (host message, mismatch note, …). */
+  detail: string;
+  /** Machine reason / kind when useful to show as code. */
+  reason: string | null;
+  path: string | null;
+  name: string | null;
+  description: string | null;
+  sizeBytes: number | null;
+  issues: SkillEditIssue[];
+  /** True when no blocking errors (warns/info allowed). */
+  ok: boolean;
+  /** True when save/create must not proceed. */
+  blocking: boolean;
+};
+
+export type ValidateSkillMdOptions = {
+  /** Folder / row skill name — mismatch is warn only. */
+  expectedName?: string | null;
+  /** Max UTF-8 byte size (defaults to {@link MAX_SKILL_EDIT_BYTES}). */
+  maxBytes?: number;
+};
+
+export type ValidateSkillMdResult = {
+  ok: boolean;
+  blocking: boolean;
+  kind: SkillEditKind;
+  severity: SkillEditSeverity;
+  issues: SkillEditIssue[];
+  name: string | null;
+  description: string | null;
+  body: string;
+  sizeBytes: number;
+  frontmatter: SkillFrontmatter | null;
+};
+
+/** UTF-8 byte length (TextEncoder when available). */
+export function skillMdByteLength(text: string | null | undefined): number {
+  const s = text ?? "";
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(s).length;
+  }
+  // Fallback: approximate for environments without TextEncoder.
+  let n = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c <= 0x7f) n += 1;
+    else if (c <= 0x7ff) n += 2;
+    else if (c >= 0xd800 && c <= 0xdbff) {
+      n += 4;
+      i++;
+    } else n += 3;
+  }
+  return n;
+}
+
+/**
+ * Strip BOM + normalize newlines; trim only outer leading blank lines for open check.
+ */
+export function normalizeSkillMdSource(
+  content: string | null | undefined,
+): string {
+  let s = (content ?? "").replace(/^\uFEFF/, "");
+  s = s.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  return s;
+}
+
+/**
+ * Parse SKILL.md YAML frontmatter (`---` … `---`) with simple `key: value` lines.
+ * Pure — does not validate name rules.
+ */
+export function parseSkillMdFrontmatter(
+  content: string | null | undefined,
+):
+  | { ok: true; frontmatter: SkillFrontmatter }
+  | { ok: false; kind: SkillEditKind; detail?: string } {
+  const src = normalizeSkillMdSource(content);
+  if (!src.trim()) {
+    return { ok: false, kind: "empty" };
+  }
+
+  // Leading blank lines allowed before opening fence.
+  const openMatch = src.match(/^(?:\s*\n)*---[ \t]*\n/);
+  if (!openMatch) {
+    return {
+      ok: false,
+      kind: "missing_frontmatter",
+      detail: "SKILL.md must start with a YAML frontmatter block (---).",
+    };
+  }
+  const afterOpen = src.slice(openMatch[0].length);
+  const closeIdx = afterOpen.search(/^[ \t]*---[ \t]*$/m);
+  if (closeIdx < 0) {
+    return {
+      ok: false,
+      kind: "unclosed_frontmatter",
+      detail: "Closing --- for frontmatter not found.",
+    };
+  }
+  const fmBlock = afterOpen.slice(0, closeIdx);
+  // Skip the closing --- line itself.
+  const afterClose = afterOpen.slice(closeIdx);
+  const closeLineEnd = afterClose.indexOf("\n");
+  const body =
+    closeLineEnd < 0 ? "" : afterClose.slice(closeLineEnd + 1).replace(/^\n/, "");
+
+  const raw: Record<string, string> = {};
+  for (const line of fmBlock.split("\n")) {
+    const t = line.trimEnd();
+    if (!t.trim() || t.trimStart().startsWith("#")) continue;
+    // Multline / nested YAML not supported — reject folded markers as invalid.
+    if (/^[ \t]/.test(line) && line.trim()) {
+      return {
+        ok: false,
+        kind: "invalid_frontmatter",
+        detail: "Nested or multi-line YAML is not supported in the app editor.",
+      };
+    }
+    const m = t.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+    if (!m) {
+      // Allow pure blank already skipped; otherwise invalid.
+      if (t.trim()) {
+        return {
+          ok: false,
+          kind: "invalid_frontmatter",
+          detail: `Unrecognized frontmatter line: ${t.trim().slice(0, 80)}`,
+        };
+      }
+      continue;
+    }
+    const key = m[1].toLowerCase();
+    let val = m[2].trim();
+    // Strip matching single/double quotes.
+    if (
+      (val.startsWith('"') && val.endsWith('"') && val.length >= 2) ||
+      (val.startsWith("'") && val.endsWith("'") && val.length >= 2)
+    ) {
+      val = val.slice(1, -1);
+    }
+    // Unescape common \" in double-quoted values (scaffold uses this).
+    if (m[2].trim().startsWith('"')) {
+      val = val.replace(/\\"/g, '"');
+    }
+    raw[key] = val;
+  }
+
+  const nameRaw = raw.name?.trim() || null;
+  const descriptionRaw = raw.description?.trim() || null;
+
+  return {
+    ok: true,
+    frontmatter: {
+      name: nameRaw,
+      description: descriptionRaw,
+      raw,
+      body,
+    },
+  };
+}
+
+/**
+ * Severity for a classified kind.
+ * Name mismatch / missing description / empty body are soft (warn/info).
+ */
+export function skillEditSeverity(kind: SkillEditKind): SkillEditSeverity {
+  switch (kind) {
+    case "ok":
+      return "ok";
+    case "name_mismatch":
+    case "missing_description":
+      return "warn";
+    case "empty_body":
+      return "info";
+    case "host_only":
+    case "path_denied":
+    case "path_outside":
+    case "bundled_readonly":
+    case "already_exists":
+      return "warn";
+    default:
+      return "err";
+  }
+}
+
+/** True when this kind must block save / create. */
+export function skillEditKindBlocksSave(kind: SkillEditKind): boolean {
+  switch (kind) {
+    case "ok":
+    case "name_mismatch":
+    case "missing_description":
+    case "empty_body":
+      return false;
+    default:
+      // Host / path kinds also block; content hard errors block.
+      return true;
+  }
+}
+
+/**
+ * Validate SKILL.md draft content for the editor.
+ * Blocking issues prevent save; warnings still return ok:false only when blocking.
+ * `ok` is true when there are zero blocking issues (warns allowed).
+ */
+export function validateSkillMdContent(
+  content: string | null | undefined,
+  opts?: ValidateSkillMdOptions,
+): ValidateSkillMdResult {
+  const maxBytes = opts?.maxBytes ?? MAX_SKILL_EDIT_BYTES;
+  const sizeBytes = skillMdByteLength(content);
+  const issues: SkillEditIssue[] = [];
+
+  if (!(content ?? "").trim()) {
+    const kind: SkillEditKind = "empty";
+    issues.push({ kind, severity: skillEditSeverity(kind) });
+    return finishValidate(issues, null, sizeBytes);
+  }
+
+  if (sizeBytes > maxBytes) {
+    const kind: SkillEditKind = "too_large";
+    issues.push({
+      kind,
+      severity: skillEditSeverity(kind),
+      detail: `${sizeBytes} > ${maxBytes}`,
+    });
+    return finishValidate(issues, null, sizeBytes);
+  }
+
+  const parsed = parseSkillMdFrontmatter(content);
+  if (!parsed.ok) {
+    issues.push({
+      kind: parsed.kind,
+      severity: skillEditSeverity(parsed.kind),
+      detail: parsed.detail,
+    });
+    return finishValidate(issues, null, sizeBytes);
+  }
+
+  const fm = parsed.frontmatter;
+  if (!fm.name) {
+    const kind: SkillEditKind = "missing_name";
+    issues.push({ kind, severity: skillEditSeverity(kind) });
+  } else {
+    const safe = sanitizeSkillFolderName(fm.name);
+    if (!safe || safe !== fm.name.trim().toLowerCase()) {
+      // Name present but fails folder rules (or has uppercase that sanitize fixes).
+      const kind: SkillEditKind = "invalid_name";
+      issues.push({
+        kind,
+        severity: skillEditSeverity(kind),
+        detail: fm.name,
+      });
+    } else {
+      const expected = (opts?.expectedName ?? "").trim();
+      if (expected) {
+        const expectedSafe =
+          sanitizeSkillFolderName(expected) ?? expected.toLowerCase();
+        if (safe !== expectedSafe) {
+          const kind: SkillEditKind = "name_mismatch";
+          issues.push({
+            kind,
+            severity: skillEditSeverity(kind),
+            detail: `frontmatter=${safe}, folder=${expectedSafe}`,
+          });
+        }
+      }
+    }
+  }
+
+  if (!fm.description) {
+    const kind: SkillEditKind = "missing_description";
+    issues.push({ kind, severity: skillEditSeverity(kind) });
+  } else if (fm.description.length > SKILL_DESCRIPTION_MAX) {
+    // Host scaffold caps description; soft warn only (edit still allowed).
+    issues.push({
+      kind: "missing_description",
+      severity: "warn",
+      detail: `description longer than ${SKILL_DESCRIPTION_MAX} characters (scaffold limit)`,
+    });
+  }
+
+  if (!fm.body.trim()) {
+    const kind: SkillEditKind = "empty_body";
+    issues.push({ kind, severity: skillEditSeverity(kind) });
+  }
+
+  return finishValidate(issues, fm, sizeBytes);
+}
+
+function finishValidate(
+  issues: SkillEditIssue[],
+  fm: SkillFrontmatter | null,
+  sizeBytes: number,
+): ValidateSkillMdResult {
+  const blockingIssues = issues.filter((i) => skillEditKindBlocksSave(i.kind));
+  const blocking = blockingIssues.length > 0;
+  const primary =
+    blockingIssues[0] ??
+    issues.find((i) => i.severity === "warn") ??
+    issues.find((i) => i.severity === "info") ??
+    null;
+  const kind: SkillEditKind = primary?.kind ?? "ok";
+  return {
+    ok: !blocking,
+    blocking,
+    kind,
+    severity: skillEditSeverity(kind),
+    issues,
+    name: fm?.name ?? null,
+    description: fm?.description ?? null,
+    body: fm?.body ?? "",
+    sizeBytes,
+    frontmatter: fm,
+  };
+}
+
+/**
+ * Classify a thrown host / invoke error for skill read/write/create.
+ */
+export function classifySkillHostError(
+  err: unknown,
+  phase: SkillEditPhase = "save",
+): SkillEditKind {
+  const raw =
+    err instanceof Error
+      ? err.message
+      : typeof err === "string"
+        ? err
+        : String(err ?? "");
+  const m = raw.toLowerCase();
+  if (!m.trim()) return "host_error";
+
+  if (
+    m.includes("not a tauri") ||
+    m.includes("not available") ||
+    m.includes("requires the desktop") ||
+    m.includes("host only")
+  ) {
+    return "host_only";
+  }
+
+  if (m.includes("conflict:")) return "conflict";
+
+  if (m.includes("bundled")) return "bundled_readonly";
+
+  if (
+    m.includes("outside known skills") ||
+    m.includes("outside skills root") ||
+    (m.includes("outside") && m.includes("skill"))
+  ) {
+    return "path_outside";
+  }
+
+  if (
+    m.includes("path not allowed") ||
+    m.includes("traversal") ||
+    m.includes("only skill.md")
+  ) {
+    return "path_denied";
+  }
+
+  if (m.includes("too large")) return "too_large";
+
+  if (
+    m.includes("not a file") ||
+    m.includes("is a directory") ||
+    m.includes("not_a_file")
+  ) {
+    return "not_a_file";
+  }
+
+  if (
+    m.includes("not found") ||
+    m.includes("enoent") ||
+    m.includes("no such file")
+  ) {
+    return "not_found";
+  }
+
+  if (
+    phase === "create" &&
+    (m.includes("already exist") ||
+      m.includes("already_exist") ||
+      m.includes("file exists") ||
+      m.includes("eexist"))
+  ) {
+    return "already_exists";
+  }
+
+  if (
+    m.includes("skill name") ||
+    m.includes("name is required") ||
+    m.includes("name too") ||
+    m.includes("name is reserved")
+  ) {
+    return "invalid_name";
+  }
+
+  return "host_error";
+}
+
+/** English fallback labels (UI should prefer i18n). */
+export const SKILL_EDIT_KIND_FALLBACK: Record<SkillEditKind, string> = {
+  ok: "OK",
+  empty: "Empty file",
+  too_large: "Too large",
+  missing_frontmatter: "Missing frontmatter",
+  unclosed_frontmatter: "Unclosed frontmatter",
+  invalid_frontmatter: "Invalid frontmatter",
+  missing_name: "Missing name",
+  invalid_name: "Invalid name",
+  name_mismatch: "Name mismatch",
+  missing_description: "Missing description",
+  empty_body: "Empty body",
+  conflict: "File conflict",
+  path_denied: "Path denied",
+  path_outside: "Outside skills roots",
+  bundled_readonly: "Bundled (read-only)",
+  not_found: "Not found",
+  not_a_file: "Not a file",
+  already_exists: "Already exists",
+  host_only: "Desktop host required",
+  host_error: "Host error",
+  other: "Error",
+};
+
+/** Actionable English hints (UI should prefer i18n). */
+export const SKILL_EDIT_HINT_FALLBACK: Partial<Record<SkillEditKind, string>> = {
+  ok: "Frontmatter looks valid. You can save when ready.",
+  empty: "Paste or write a SKILL.md with YAML frontmatter and body.",
+  too_large: "Keep SKILL.md under 2 MiB for in-app edit.",
+  missing_frontmatter:
+    "Start the file with --- then name: / description: fields, then closing ---.",
+  unclosed_frontmatter: "Add a closing --- line after the frontmatter fields.",
+  invalid_frontmatter:
+    "Use simple one-line key: value pairs in the frontmatter (no nested YAML).",
+  missing_name: "Add a name: field in the frontmatter (slash-command style).",
+  invalid_name:
+    "Name must be lowercase a-z, digits, hyphens; 2–64 chars; start/end alnum.",
+  name_mismatch:
+    "Frontmatter name differs from the skill folder — save still works, but CLI may prefer the folder name.",
+  missing_description:
+    "Add a description: with what the skill does and trigger phrases.",
+  empty_body: "Add markdown steps under the frontmatter so the agent has instructions.",
+  conflict: "Reload from disk or overwrite with your draft.",
+  path_denied: "Only SKILL.md under user/agent-home/project skills roots can be edited.",
+  path_outside: "This path is outside known skills roots — open a user or project skill.",
+  bundled_readonly: "Bundled/vendor skills are read-only. Copy into user skills to edit.",
+  not_found: "File missing — refresh the skills list or recreate the skill.",
+  not_a_file: "Target is not a SKILL.md file.",
+  already_exists: "A skill with this name already exists — open it or pick another name.",
+  host_only: "Open the desktop app (Tauri) to read or save skills.",
+  host_error: "Host invoke failed — see detail.",
+  other: "Unexpected outcome — see detail.",
+};
+
+export type SkillEditKindLabels = Partial<Record<SkillEditKind, string>>;
+
+export function skillEditKindLabel(
+  kind: SkillEditKind,
+  labels?: SkillEditKindLabels,
+): string {
+  return labels?.[kind] ?? SKILL_EDIT_KIND_FALLBACK[kind] ?? kind;
+}
+
+export function skillEditHint(
+  kind: SkillEditKind,
+  hints?: Partial<Record<SkillEditKind, string>>,
+): string {
+  return hints?.[kind] ?? SKILL_EDIT_HINT_FALLBACK[kind] ?? "";
+}
+
+/** Badge class suffix helper (`ok` | `fail` | `muted`). */
+export function skillEditBadgeTone(
+  severity: SkillEditSeverity,
+): "ok" | "fail" | "muted" {
+  if (severity === "ok") return "ok";
+  if (severity === "err") return "fail";
+  return "muted";
+}
+
+function errMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return String(err ?? "");
+}
+
+/**
+ * Build GlassModal presentation from a content validation result.
+ */
+export function buildSkillValidatePresentation(
+  content: string | null | undefined,
+  opts?: ValidateSkillMdOptions & {
+    path?: string | null;
+    labels?: SkillEditKindLabels;
+    titles?: { ok?: string; fail?: string };
+  },
+): SkillEditPresentation {
+  const check = validateSkillMdContent(content, opts);
+  const kindLabel = skillEditKindLabel(check.kind, opts?.labels);
+  const title = check.ok
+    ? (opts?.titles?.ok ?? kindLabel)
+    : (opts?.titles?.fail ?? kindLabel);
+
+  let summary = title;
+  if (check.ok && check.issues.length > 0) {
+    // Soft warnings — summarize first issue.
+    const soft = check.issues[0];
+    const softLabel = skillEditKindLabel(soft.kind, opts?.labels);
+    summary = softLabel;
+  } else if (check.ok) {
+    summary = title;
+  } else {
+    summary = title;
+  }
+
+  const detailParts = check.issues
+    .filter((i) => i.kind !== check.kind || i.detail)
+    .map((i) => {
+      const lab = skillEditKindLabel(i.kind, opts?.labels);
+      return i.detail ? `${lab}: ${i.detail}` : lab;
+    });
+  const detail =
+    check.issues.find((i) => i.kind === check.kind)?.detail ??
+    (detailParts.length ? detailParts.join(" · ") : "");
+
+  return {
+    kind: check.kind,
+    severity: check.severity,
+    phase: "validate",
+    title,
+    summary,
+    detail: detail || "",
+    reason: check.kind === "ok" ? null : check.kind,
+    path: opts?.path ?? null,
+    name: check.name,
+    description: check.description,
+    sizeBytes: check.sizeBytes,
+    issues: check.issues,
+    ok: check.ok,
+    blocking: check.blocking,
+  };
+}
+
+/**
+ * Build presentation for a host error (load / save / create).
+ */
+export function buildSkillHostErrorPresentation(
+  err: unknown,
+  phase: SkillEditPhase,
+  opts?: {
+    path?: string | null;
+    labels?: SkillEditKindLabels;
+    fallbackTitle?: string;
+  },
+): SkillEditPresentation {
+  const kind = classifySkillHostError(err, phase);
+  const severity = skillEditSeverity(kind);
+  const kindLabel = skillEditKindLabel(kind, opts?.labels);
+  const raw = errMessage(err);
+  const detail = raw.slice(0, 400);
+  return {
+    kind,
+    severity,
+    phase,
+    title: opts?.fallbackTitle ?? kindLabel,
+    summary: detail || kindLabel,
+    detail,
+    reason: kind,
+    path: opts?.path ?? null,
+    name: null,
+    description: null,
+    sizeBytes: null,
+    issues: [{ kind, severity, detail: raw }],
+    ok: false,
+    blocking: true,
+  };
+}
+
+/**
+ * Build success presentation after a save.
+ */
+export function buildSkillSaveOkPresentation(opts?: {
+  path?: string | null;
+  name?: string | null;
+  sizeBytes?: number | null;
+  labels?: SkillEditKindLabels;
+  title?: string;
+}): SkillEditPresentation {
+  const kind: SkillEditKind = "ok";
+  const title = opts?.title ?? skillEditKindLabel(kind, opts?.labels);
+  return {
+    kind,
+    severity: "ok",
+    phase: "save",
+    title,
+    summary: title,
+    detail: "",
+    reason: null,
+    path: opts?.path ?? null,
+    name: opts?.name ?? null,
+    description: null,
+    sizeBytes: opts?.sizeBytes ?? null,
+    issues: [],
+    ok: true,
+    blocking: false,
+  };
+}
+
+/**
+ * Preflight before host save: content validation + desktop host check.
+ * Returns a presentation when the client should block the host call.
+ */
+export function buildSkillSavePreflightError(
+  content: string | null | undefined,
+  opts?: {
+    isTauri?: boolean;
+    expectedName?: string | null;
+    path?: string | null;
+    labels?: SkillEditKindLabels;
+    hostOnlyTitle?: string;
+  },
+): SkillEditPresentation | null {
+  if (opts?.isTauri === false) {
+    const kind: SkillEditKind = "host_only";
+    const title =
+      opts.hostOnlyTitle ?? skillEditKindLabel(kind, opts.labels);
+    return {
+      kind,
+      severity: skillEditSeverity(kind),
+      phase: "save",
+      title,
+      summary: title,
+      detail: "",
+      reason: "host_only",
+      path: opts.path ?? null,
+      name: null,
+      description: null,
+      sizeBytes: skillMdByteLength(content),
+      issues: [{ kind, severity: skillEditSeverity(kind) }],
+      ok: false,
+      blocking: true,
+    };
+  }
+  const presentation = buildSkillValidatePresentation(content, {
+    expectedName: opts?.expectedName,
+    path: opts?.path,
+    labels: opts?.labels,
+  });
+  if (presentation.blocking) {
+    return { ...presentation, phase: "save" };
+  }
+  return null;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -18127,6 +18127,10 @@ div.composer__input:empty::before {
   font-size: 12.5px;
   color: #e05a5a;
   line-height: 1.4;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
 }
 
 .ext-skill-editor__saved {
@@ -18134,6 +18138,122 @@ div.composer__input:empty::before {
   font-size: 12.5px;
   color: var(--text-secondary);
   line-height: 1.4;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.ext-skill-editor__status--ok {
+  color: var(--ok, var(--text-secondary));
+}
+
+.ext-skill-editor__status--warn {
+  color: color-mix(in srgb, #e0b44a 85%, var(--text-secondary));
+}
+
+.ext-skill-editor__details-btn {
+  padding: 0 6px;
+  min-height: 0;
+  font-size: 12px;
+}
+
+.ext-skill-feedback {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ext-skill-feedback__body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ext-skill-feedback__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.ext-skill-feedback__summary {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.ext-skill-feedback__summary--ok {
+  color: var(--ok, var(--text-primary));
+}
+
+.ext-skill-feedback__summary--err {
+  color: var(--danger, #e05a5a);
+}
+
+.ext-skill-feedback__summary--warn {
+  color: color-mix(in srgb, #e0b44a 90%, var(--text-primary));
+}
+
+.ext-skill-feedback__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.ext-skill-feedback__detail {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.ext-skill-feedback__issues {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ext-skill-feedback__issues li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.ext-skill-feedback__issue-detail {
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.ext-skill-feedback__reason,
+.ext-skill-feedback__path {
+  margin: 0;
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.ext-skill-feedback__label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.ext-skill-feedback__reason code,
+.ext-skill-feedback__path code {
+  font-size: 11.5px;
+  word-break: break-all;
+  color: var(--text-primary);
 }
 
 .rewind-confirm__hint,


### PR DESCRIPTION
## Summary

- **SKILL-EDIT-PRO**: polish Settings → Extensions → Skills edit / validate / save feedback
- Pure `skillEditFeedback` helpers + unit tests (frontmatter parse, content validate, host error classification, GlassModal presentation)
- **Validate** button + save preflight for `SKILL.md` (blocking: empty / missing or invalid frontmatter / invalid name; soft warns: name mismatch, missing description, empty body)
- Load / save / create failures open an in-app **GlassModal** with kind chip, actionable hint, reason, and path (no `window.confirm`)
- i18n en / zh / zh-TW + Unreleased CHANGELOG

## Test plan

- [x] `pnpm test -- src/lib/skillEditFeedback.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: Extensions → Skills → Edit → Validate good scaffold → OK modal
- [ ] Manual: remove frontmatter `name` → Validate / Save blocked with GlassModal
- [ ] Manual: dirty close still uses discard GlassModal (not `window.confirm`)
- [ ] Manual: save conflict still offers Reload / Overwrite GlassModal