### PR TITLE
feat(setup): SETUP-GATE-PRO honesty + classified errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+#### Setup / first-run
+- **Setup gate pro** (SETUP-GATE-PRO): pure `setupGatePro` helpers + tests for boot decision (CLI hard-required, account optional), classified install/probe/account errors with recovery hints, ready-step checklist honesty (never soft-ok CLI; never invent auth-connected on skip); SetupWizard + App boot wire-up; i18n en/zh/zh-TW
+
 #### Agent / memory
 - **Memory embedding (CLI 0.2.117)** (Settings → Agent): host reads allowlisted `[memory.*]` keys from active GROK_HOME `config.toml` (`embedding.model` / `dimensions`, `search.*`, `search.mmr`, `search.temporal_decay`, `dream.*`, `watcher`, `initial_injection`) with soft-fail when missing; independent agent-home can write safe keys + soft-respawn (shared mode read-only). Memory browser shows honest **App keyword** vs **CLI hybrid/keyword** status and links to the panel. App `memory_search` stays path-scoped keyword scan — never invents embeddings client-side.
 

--- a/docs/llm-wiki/setup.md
+++ b/docs/llm-wiki/setup.md
@@ -58,6 +58,20 @@ Persists `setupWizardCompleted: true`. If account skipped: `authSetupDeferred: t
 - Styles: `src/styles/setup-wizard.css` (overflow hidden, no scrollbars)
 - i18n: `setup.*` keys in `src/i18n/messages.ts`
 
+## Honesty (SETUP-GATE-PRO)
+
+Pure helpers: `src/lib/setupGatePro.ts` (+ tests).
+
+| Rule | Behavior |
+|------|----------|
+| Hard CLI | `canEnterHome` / boot `resolveSetupGateBoot` never mark **ready** without `cliFound` |
+| Soft account | Account step is always skippable; `buildAuthDeferredFlags` never sets deferred when auth is ok |
+| Errors | Install/probe/account failures classified (`checksum_missing`, `mirror`, `network`, …) with stable `setup.error.*` titles + recovery hints |
+| Ready checklist | Never soft-ok CLI; auth row is soft when skipped |
+| Legacy migrate | Older `onboardingDone` / `setupSkipped` + CLI → write `setupWizardCompleted` once |
+
+Checksum: missing sidecar may offer **Install without checksum**; **mismatch never** offers unverified force.
+
 ## CLI probe (mac + Windows)
 
 `cli_probe::probe_cli` must work when the app is launched from Dock / Explorer (sparse PATH):

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -611,6 +611,12 @@ import { sortSessionsForSidebar } from "@/lib/sidebarDateGroups";
 import { GrokLogo } from "@/components/GrokLogo";
 import { SetupWizard, type SetupCliInfo } from "@/components/SetupWizard";
 import {
+  buildAuthDeferredFlags,
+  formatCliTooOldDetail,
+  isCliVersionUnsupported,
+  resolveSetupGateBoot,
+} from "@/lib/setupGatePro";
+import {
   ComposerEditor,
   getComposerCaretOffset,
 } from "@/components/ComposerEditor";
@@ -2952,11 +2958,12 @@ export default function App() {
           );
         }
       }
-      if (cli.versionSupported === false) {
+      if (isCliVersionUnsupported(cli.versionSupported)) {
         setLocalError(
-          `CLI_TOO_OLD: grok CLI ${cli.version ?? "?"} < required ${
-            cli.minVersion ?? ""
-          }`.trim(),
+          formatCliTooOldDetail({
+            version: cli.version,
+            minVersion: cli.minVersion,
+          }),
         );
       }
       setSessionDataMode(settings.sessionDataMode || "independent");
@@ -3130,28 +3137,33 @@ export default function App() {
       };
       setSetupCliSeed(cliSeed);
 
+      // SETUP-GATE-PRO: pure decision — CLI hard-required; account never blocks.
       const wizardCompleted = !!settings.setupWizardCompleted;
       const legacyDone =
         !!settings.onboardingDone || !!settings.setupSkipped;
-
-      if (cli.found && !wizardCompleted && legacyDone) {
-        // Migrate older installs that already finished the account modal.
+      const gate = resolveSetupGateBoot({
+        cliFound: !!cli.found,
+        wizardCompleted,
+        legacyDone,
+        isMirror: isMirrorClient(),
+      });
+      if (gate.shouldMigrateLegacy) {
+        // Older installs that finished the account modal before setupWizardCompleted.
+        const flags = buildAuthDeferredFlags({
+          authDeferred: !!settings.setupSkipped,
+          authOk,
+        });
         try {
           await api.settingsSet({
             ...settings,
             setupWizardCompleted: true,
-            authSetupDeferred: !!settings.setupSkipped && !authOk,
+            authSetupDeferred: flags.authSetupDeferred,
           });
         } catch {
           /* ignore */
         }
-        setAppGate("ready");
-      } else if (!cli.found || !wizardCompleted) {
-        // No CLI → always wizard. First launch with CLI → account step.
-        setAppGate("setup");
-      } else {
-        setAppGate("ready");
       }
+      setAppGate(gate.phase);
 
       // One-shot: corrupt store JSON was renamed aside on load (shared-mode safety).
       void api

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -1,6 +1,9 @@
 /**
  * Full-screen first-run gate: install Grok Build (required) → account (skippable) → enter home.
  * No page scrollbars; content is centered and compact.
+ *
+ * Honesty (SETUP-GATE-PRO): CLI is hard-required; account is soft/skippable.
+ * Errors are classified via pure `setupGatePro` helpers — never invent success.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -9,6 +12,19 @@ import { Select } from "@/components/Select";
 import { Spinner } from "@/components/ui/spinner";
 import * as api from "@/lib/api";
 import type { createT } from "@/i18n";
+import type { MessageKey } from "@/i18n";
+import {
+  buildAuthDeferredFlags,
+  buildReadyChecklist,
+  canAdvancePastRuntime,
+  canEnterHome,
+  clampInstallPercent,
+  mirrorHostFromUrl,
+  resolveInitialWizardStep,
+  resolveSetupGateError,
+  type SetupGateErrorView,
+  type SetupWizardStep,
+} from "@/lib/setupGatePro";
 
 type Tr = ReturnType<typeof createT>;
 
@@ -20,7 +36,7 @@ export type SetupCliInfo = {
   cliAuthPresent: boolean;
 };
 
-type Step = "runtime" | "account" | "ready";
+type Step = SetupWizardStep;
 type AccountPanel = "menu" | "key" | "relay";
 
 type Props = {
@@ -32,15 +48,6 @@ type Props = {
   onAccountLoginOauth: () => Promise<boolean>;
 };
 
-function mirrorHost(url: string | null | undefined): string {
-  if (!url) return "";
-  try {
-    return new URL(url).host;
-  } catch {
-    return url.replace(/^https?:\/\//, "").split("/")[0] || url;
-  }
-}
-
 export function SetupWizard({
   tr,
   platform,
@@ -49,12 +56,14 @@ export function SetupWizard({
   onComplete,
   onAccountLoginOauth,
 }: Props) {
-  const [step, setStep] = useState<Step>(initialCli.found ? "account" : "runtime");
+  const [step, setStep] = useState<Step>(() =>
+    resolveInitialWizardStep(initialCli.found),
+  );
   const [cli, setCli] = useState<SetupCliInfo>(initialCli);
   const [probing, setProbing] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [progress, setProgress] = useState<api.CliInstallProgress | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [errorView, setErrorView] = useState<SetupGateErrorView | null>(null);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [installCmds, setInstallCmds] = useState<api.CliInstallCommands | null>(
     null,
@@ -71,6 +80,20 @@ export function SetupWizard({
   const [relayKey, setRelayKey] = useState("");
   /** Default: OpenAI Responses — preferred for modern gateways. */
   const [relayBackend, setRelayBackend] = useState("responses");
+
+  const reportError = useCallback((err: unknown) => {
+    const view = resolveSetupGateError(err);
+    if (view.silent) {
+      setErrorView(null);
+      return view;
+    }
+    setErrorView(view);
+    return view;
+  }, []);
+
+  const clearError = useCallback(() => {
+    setErrorView(null);
+  }, []);
 
   const protocolOptions = useMemo(
     () => [
@@ -114,7 +137,7 @@ export function SetupWizard({
 
   const recheck = useCallback(async (manualPath?: string | null) => {
     setProbing(true);
-    setError(null);
+    clearError();
     try {
       const r = await api.probeCli(manualPath || undefined);
       const next: SetupCliInfo = {
@@ -131,12 +154,12 @@ export function SetupWizard({
       }
       return next;
     } catch (e) {
-      setError(String(e));
+      reportError(e);
       return null;
     } finally {
       setProbing(false);
     }
-  }, []);
+  }, [clearError, reportError]);
 
   // Soft auto-detect once when opening runtime step without CLI
   useEffect(() => {
@@ -148,7 +171,7 @@ export function SetupWizard({
     async (opts?: { allowUnverified?: boolean }) => {
       if (installing) return;
       setInstalling(true);
-      setError(null);
+      clearError();
       setProgress({
         phase: "resolving",
         message: tr("setup.detecting"),
@@ -159,18 +182,18 @@ export function SetupWizard({
           opts?.allowUnverified ? { allowUnverified: true } : undefined,
         );
         if (!res.ok) {
-          setError(res.message || tr("setup.error"));
+          reportError(res.message || tr("setup.error"));
           return;
         }
         const next = await recheck(res.path);
-        if (next?.found) {
+        if (next?.found && canAdvancePastRuntime(next.found)) {
           setStep("account");
         } else {
-          setError(tr("setup.cli.missing"));
+          reportError({ code: "cli_missing", message: tr("setup.cli.missing") });
         }
       } catch (e) {
-        const msg = String(e);
-        setError(msg);
+        const view = reportError(e);
+        const msg = view.detail || tr(view.titleKey as MessageKey);
         setProgress((p) =>
           p
             ? { ...p, phase: "error", message: msg }
@@ -180,20 +203,13 @@ export function SetupWizard({
         setInstalling(false);
       }
     },
-    [installing, recheck, tr],
+    [clearError, installing, recheck, reportError, tr],
   );
 
-  const checksumMissing = useMemo(
-    () =>
-      !!error &&
-      /No published SHA-256|checksum required|GROK_CLI_REQUIRE_CHECKSUM|未发布 SHA-256|未發佈 SHA-256/i.test(
-        error,
-      ),
-    [error],
-  );
+  const checksumMissing = !!errorView?.offerUnverifiedInstall;
 
   const pickBinary = useCallback(async () => {
-    setError(null);
+    clearError();
     try {
       const path = await api.pickCliBinary();
       if (!path) return;
@@ -201,15 +217,15 @@ export function SetupWizard({
         api.settingsSet({ ...s, manualCliPath: path }),
       );
       const next = await recheck(path);
-      if (next?.found) {
+      if (next?.found && canAdvancePastRuntime(next.found)) {
         setStep("account");
       } else {
-        setError(tr("setup.cli.missing"));
+        reportError({ code: "cli_missing", message: tr("setup.cli.missing") });
       }
     } catch (e) {
-      setError(String(e));
+      reportError(e);
     }
-  }, [recheck, tr]);
+  }, [clearError, recheck, reportError, tr]);
 
   const copyCmd = useCallback(async () => {
     const cmd = installCmds?.primary;
@@ -219,25 +235,30 @@ export function SetupWizard({
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1800);
     } catch {
-      setError(tr("setup.error"));
+      reportError(tr("setup.error"));
     }
-  }, [installCmds, tr]);
+  }, [installCmds, reportError, tr]);
 
   const openDocs = useCallback(() => {
     const url = installCmds?.docsUrl || "https://docs.x.ai/build/overview";
-    void api.openExternalUrl(url).catch((e) => setError(String(e)));
-  }, [installCmds]);
+    void api.openExternalUrl(url).catch((e) => reportError(e));
+  }, [installCmds, reportError]);
 
   const finishWizard = useCallback(
     async (opts: { authDeferred: boolean; authOk: boolean }) => {
+      if (!canEnterHome(cli.found)) return;
+      const flags = buildAuthDeferredFlags({
+        authDeferred: opts.authDeferred,
+        authOk: opts.authOk,
+      });
       try {
         const s = await api.settingsGet();
         await api.settingsSet({
           ...s,
           setupWizardCompleted: true,
-          authSetupDeferred: opts.authDeferred && !opts.authOk,
+          authSetupDeferred: flags.authSetupDeferred,
           onboardingDone: true,
-          setupSkipped: opts.authDeferred && !opts.authOk,
+          setupSkipped: flags.setupSkipped,
         });
       } catch {
         /* still enter if probe ok */
@@ -248,11 +269,12 @@ export function SetupWizard({
   );
 
   const goAccountContinue = useCallback(() => {
-    if (!cli.found) return;
+    if (!canAdvancePastRuntime(cli.found)) return;
     setStep("ready");
   }, [cli.found]);
 
   const skipAccount = useCallback(() => {
+    // Soft gate: account is optional — never blocks home after CLI is ready.
     setAuthDeferred(true);
     setStep("ready");
   }, []);
@@ -261,7 +283,7 @@ export function SetupWizard({
     const key = officialKey.trim();
     if (!key) return;
     setAccountBusy(true);
-    setError(null);
+    clearError();
     try {
       await api.secretsSet({ officialApiKey: key });
       setAuthOk(true);
@@ -269,18 +291,18 @@ export function SetupWizard({
       setAccountPanel("menu");
       setStep("ready");
     } catch (e) {
-      setError(String(e));
+      reportError(e);
     } finally {
       setAccountBusy(false);
     }
-  }, [officialKey, tr]);
+  }, [clearError, officialKey, reportError, tr]);
 
   const saveRelay = useCallback(async () => {
     const base = relayBase.trim();
     const key = relayKey.trim();
     if (!base || !key) return;
     setAccountBusy(true);
-    setError(null);
+    clearError();
     try {
       // Write agent-home config with chosen message format (default Responses).
       await api.providersUpsert({
@@ -303,15 +325,15 @@ export function SetupWizard({
       setAccountPanel("menu");
       setStep("ready");
     } catch (e) {
-      setError(String(e));
+      reportError(e);
     } finally {
       setAccountBusy(false);
     }
-  }, [relayBase, relayKey, relayBackend, tr]);
+  }, [clearError, relayBase, relayKey, relayBackend, reportError, tr]);
 
   const runOauth = useCallback(async () => {
     setAccountBusy(true);
-    setError(null);
+    clearError();
     try {
       const ok = await onAccountLoginOauth();
       if (ok) {
@@ -325,15 +347,15 @@ export function SetupWizard({
         setStep("ready");
       }
     } catch (e) {
-      setError(String(e));
+      reportError(e);
     } finally {
       setAccountBusy(false);
     }
-  }, [cli.path, onAccountLoginOauth, recheck, tr]);
+  }, [clearError, cli.path, onAccountLoginOauth, recheck, reportError, tr]);
 
   const importCli = useCallback(async () => {
     setAccountBusy(true);
-    setError(null);
+    clearError();
     try {
       const r = await api.importGrokCli();
       if ((r as { ok?: boolean }).ok) {
@@ -344,26 +366,26 @@ export function SetupWizard({
         setStatusMsg(JSON.stringify((r as { messages?: string[] }).messages || r));
       }
     } catch (e) {
-      setError(String(e));
+      reportError(e);
     } finally {
       setAccountBusy(false);
     }
-  }, [tr]);
+  }, [clearError, reportError, tr]);
 
   const importGo = useCallback(async () => {
     setAccountBusy(true);
-    setError(null);
+    clearError();
     try {
       await api.importGrokGo();
       setAuthOk(true);
       setStatusMsg(tr("setup.account.ok"));
       setStep("ready");
     } catch (e) {
-      setError(String(e));
+      reportError(e);
     } finally {
       setAccountBusy(false);
     }
-  }, [tr]);
+  }, [clearError, reportError, tr]);
 
   /** Abort the running login (OAuth/device) and unlock the UI immediately.
    *  The backend kills the `grok login` child; the pending handler's `finally`
@@ -377,11 +399,21 @@ export function SetupWizard({
     setAccountBusy(false);
   }, []);
 
-  const percent = useMemo(() => {
-    const p = progress?.percent;
-    if (p == null || Number.isNaN(p)) return installing ? 8 : 0;
-    return Math.max(0, Math.min(100, Math.round(p)));
-  }, [progress, installing]);
+  const percent = useMemo(
+    () => clampInstallPercent(progress?.percent, installing),
+    [progress, installing],
+  );
+
+  const readyChecklist = useMemo(
+    () =>
+      buildReadyChecklist({
+        cliFound: cli.found,
+        cliVersion: cli.version,
+        authOk,
+        authDeferred,
+      }),
+    [cli.found, cli.version, authOk, authDeferred],
+  );
 
   const stepIndex = step === "runtime" ? 0 : step === "account" ? 1 : 2;
 
@@ -475,7 +507,7 @@ export function SetupWizard({
                   {progress?.mirror && (
                     <div className="setup-progress__mirror">
                       {tr("setup.mirror", {
-                        host: mirrorHost(progress.mirror),
+                        host: mirrorHostFromUrl(progress.mirror),
                       })}
                     </div>
                   )}
@@ -746,27 +778,34 @@ export function SetupWizard({
             <>
               <div className="setup-card__head">
                 <h2>{tr("setup.ready.title")}</h2>
+                {readyChecklist.authDeferred && (
+                  <p className="setup-ready-soft">
+                    {tr("setup.ready.authSoftNote")}
+                  </p>
+                )}
               </div>
               <ul className="setup-checklist">
-                <li className="is-ok">
-                  <span className="setup-check" />
-                  {tr("setup.ready.cliOk")}
-                  {cli.version ? (
-                    <span className="setup-check-meta">{cli.version}</span>
-                  ) : null}
-                </li>
-                <li className={authOk ? "is-ok" : "is-soft"}>
-                  <span className="setup-check" />
-                  {authOk
-                    ? tr("setup.ready.authOk")
-                    : tr("setup.ready.authSkip")}
-                </li>
+                {readyChecklist.rows.map((row) => (
+                  <li
+                    key={row.id}
+                    className={
+                      row.ok ? "is-ok" : row.soft ? "is-soft" : "is-fail"
+                    }
+                    data-setup-check={row.id}
+                  >
+                    <span className="setup-check" />
+                    {tr(row.labelKey as MessageKey)}
+                    {row.meta ? (
+                      <span className="setup-check-meta">{row.meta}</span>
+                    ) : null}
+                  </li>
+                ))}
               </ul>
               <div className="setup-actions">
                 <button
                   type="button"
                   className="btn btn--primary setup-btn-primary"
-                  disabled={!cli.found}
+                  disabled={!readyChecklist.canEnter}
                   onClick={() =>
                     void finishWizard({
                       authDeferred: authDeferred || !authOk,
@@ -780,23 +819,25 @@ export function SetupWizard({
             </>
           )}
 
-          {error && (
-            <div className="setup-error" role="alert">
-              <strong>{tr("setup.error")}</strong>
-              <span>{error}</span>
-              {checksumMissing && (
+          {errorView && !errorView.silent && (
+            <div
+              className={
+                "setup-error" +
+                (errorView.tone === "warn" ? " setup-error--warn" : "")
+              }
+              role="alert"
+              data-setup-error-kind={errorView.kind}
+            >
+              <strong>{tr(errorView.titleKey as MessageKey)}</strong>
+              {errorView.detail ? <span>{errorView.detail}</span> : null}
+              {errorView.hintKey ? (
                 <span className="setup-error__hint">
-                  {tr("setup.checksumMissingHint")}
+                  {tr(errorView.hintKey as MessageKey)}
                 </span>
-              )}
-              {/network|timeout|mirror|download|HTTP|failed/i.test(error) && (
-                <span className="setup-error__hint">
-                  {tr("setup.networkHint")}
-                </span>
-              )}
+              ) : null}
             </div>
           )}
-          {statusMsg && !error && (
+          {statusMsg && !(errorView && !errorView.silent) && (
             <div className="setup-status" role="status">
               {statusMsg}
             </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2469,8 +2469,37 @@ const en = {
   "setup.ready.cliOk": "Grok Build",
   "setup.ready.authOk": "Account connected",
   "setup.ready.authSkip": "Account later",
+  "setup.ready.authSoftNote":
+    "Account is optional — you can sign in later in Settings. Chat needs a provider or CLI login.",
   "setup.ready.enter": "Enter Grok",
   "setup.error": "Something went wrong",
+  "setup.error.cliMissing": "Grok Build not found",
+  "setup.error.cliTooOld": "Grok Build is too old",
+  "setup.error.cliTooOldHint":
+    "Update Grok Build (install latest from this screen or the official command), then recheck.",
+  "setup.error.checksumMissing": "Install checksum not published",
+  "setup.error.checksumMismatch": "Install checksum mismatch",
+  "setup.error.checksumMismatchHint":
+    "The download did not match the published hash. Retry, switch mirror, or pick a local binary — do not force unverified if mismatch is reported.",
+  "setup.error.network": "Network error during install",
+  "setup.error.mirror": "All install mirrors failed",
+  "setup.error.download": "Download failed",
+  "setup.error.unsupportedPlatform": "This platform cannot auto-install",
+  "setup.error.unsupportedPlatformHint":
+    "Use the official install command or choose a local Grok Build binary.",
+  "setup.error.binaryInvalid": "Downloaded binary is not runnable",
+  "setup.error.binaryInvalidHint":
+    "Retry the install, or pick a known-good local binary via Choose local binary.",
+  "setup.error.permission": "Permission denied",
+  "setup.error.permissionHint":
+    "Check folder permissions for ~/.grok, or install via the shell command.",
+  "setup.error.probeFailed": "Could not probe Grok Build",
+  "setup.error.probeFailedHint":
+    "Recheck after install, or set a manual binary path.",
+  "setup.error.account": "Account setup failed",
+  "setup.error.accountHint":
+    "You can skip and configure login or a provider later in Settings.",
+  "setup.error.cancelled": "Cancelled",
   "setup.networkHint": "Network error — try another mirror or the manual command.",
 
   "doctor.title": "Doctor",
@@ -6504,8 +6533,35 @@ const zh: Record<MessageKey, string> = {
   "setup.ready.cliOk": "Grok Build",
   "setup.ready.authOk": "账户已连接",
   "setup.ready.authSkip": "账户稍后配置",
+  "setup.ready.authSoftNote":
+    "账户为可选项 — 稍后可在设置中登录。对话仍需服务商或 CLI 登录。",
   "setup.ready.enter": "进入 Grok",
   "setup.error": "出错了",
+  "setup.error.cliMissing": "未找到 Grok Build",
+  "setup.error.cliTooOld": "Grok Build 版本过旧",
+  "setup.error.cliTooOldHint":
+    "请通过本页安装最新版，或使用官方命令升级后重新检测。",
+  "setup.error.checksumMissing": "安装包未发布校验和",
+  "setup.error.checksumMismatch": "安装包校验和不匹配",
+  "setup.error.checksumMismatchHint":
+    "下载内容与发布哈希不一致。请重试、换镜像或选择本地二进制 — 校验失败时请勿强制跳过校验。",
+  "setup.error.network": "安装时网络异常",
+  "setup.error.mirror": "所有安装镜像均失败",
+  "setup.error.download": "下载失败",
+  "setup.error.unsupportedPlatform": "当前平台无法自动安装",
+  "setup.error.unsupportedPlatformHint":
+    "请使用官方安装命令，或选择本机已有的 Grok Build 二进制。",
+  "setup.error.binaryInvalid": "下载的二进制无法运行",
+  "setup.error.binaryInvalidHint":
+    "请重试安装，或通过「选择本地二进制」指定可用文件。",
+  "setup.error.permission": "权限不足",
+  "setup.error.permissionHint":
+    "请检查 ~/.grok 目录权限，或改用 shell 安装命令。",
+  "setup.error.probeFailed": "无法探测 Grok Build",
+  "setup.error.probeFailedHint": "安装后重新检测，或设置手动二进制路径。",
+  "setup.error.account": "账户设置失败",
+  "setup.error.accountHint": "可暂时跳过，稍后在设置中登录或配置服务商。",
+  "setup.error.cancelled": "已取消",
   "setup.networkHint": "网络异常 — 可换镜像或使用手动命令。",
 
   "doctor.title": "Doctor",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2370,8 +2370,35 @@ export const zhTW: Record<MessageKey, string> = {
   "setup.ready.cliOk": "Grok Build",
   "setup.ready.authOk": "帳戶已連線",
   "setup.ready.authSkip": "帳戶稍後設定",
+  "setup.ready.authSoftNote":
+    "帳戶為可選 — 稍後可在設定中登入。對話仍需服務商或 CLI 登入。",
   "setup.ready.enter": "進入 Grok",
   "setup.error": "出錯了",
+  "setup.error.cliMissing": "未找到 Grok Build",
+  "setup.error.cliTooOld": "Grok Build 版本過舊",
+  "setup.error.cliTooOldHint":
+    "請透過本頁安裝最新版，或使用官方指令升級後重新偵測。",
+  "setup.error.checksumMissing": "安裝包未發佈校驗和",
+  "setup.error.checksumMismatch": "安裝包校驗和不匹配",
+  "setup.error.checksumMismatchHint":
+    "下載內容與發佈雜湊不一致。請重試、換鏡像或選擇本機二進位檔 — 校驗失敗時請勿強制略過校驗。",
+  "setup.error.network": "安裝時網路異常",
+  "setup.error.mirror": "所有安裝鏡像均失敗",
+  "setup.error.download": "下載失敗",
+  "setup.error.unsupportedPlatform": "目前平台無法自動安裝",
+  "setup.error.unsupportedPlatformHint":
+    "請使用官方安裝指令，或選擇本機已有的 Grok Build 二進位檔。",
+  "setup.error.binaryInvalid": "下載的二進位檔無法執行",
+  "setup.error.binaryInvalidHint":
+    "請重試安裝，或透過「選擇本機二進位檔」指定可用檔案。",
+  "setup.error.permission": "權限不足",
+  "setup.error.permissionHint":
+    "請檢查 ~/.grok 目錄權限，或改用 shell 安裝指令。",
+  "setup.error.probeFailed": "無法偵測 Grok Build",
+  "setup.error.probeFailedHint": "安裝後重新偵測，或設定手動二進位路徑。",
+  "setup.error.account": "帳戶設定失敗",
+  "setup.error.accountHint": "可暫時跳過，稍後在設定中登入或設定服務商。",
+  "setup.error.cancelled": "已取消",
   "setup.networkHint": "網路異常 — 可換鏡像或使用手動指令。",
 
   "doctor.title": "Doctor",

--- a/src/lib/setupGatePro.test.ts
+++ b/src/lib/setupGatePro.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAuthDeferredFlags,
+  buildReadyChecklist,
+  canAdvancePastRuntime,
+  canEnterHome,
+  classifySetupGateError,
+  clampInstallPercent,
+  formatCliTooOldDetail,
+  isAccountStepOptional,
+  isCliVersionUnsupported,
+  mirrorHostFromUrl,
+  resolveInitialWizardStep,
+  resolveSetupGateBoot,
+  resolveSetupGateError,
+  setupGateErrorHintKey,
+  setupGateErrorTitleKey,
+  setupGateOfferUnverifiedInstall,
+} from "./setupGatePro";
+
+describe("classifySetupGateError", () => {
+  it("classifies checksum missing (strict mode / CN copy)", () => {
+    expect(
+      classifySetupGateError(
+        "No published SHA-256 for artifact; set GROK_CLI_REQUIRE_CHECKSUM=0",
+      ),
+    ).toBe("checksum_missing");
+    expect(classifySetupGateError("checksum required")).toBe(
+      "checksum_missing",
+    );
+    expect(classifySetupGateError("官方镜像未发布 SHA-256")).toBe(
+      "checksum_missing",
+    );
+  });
+
+  it("classifies checksum mismatch", () => {
+    expect(
+      classifySetupGateError("checksum mismatch: expected abc got def"),
+    ).toBe("checksum_mismatch");
+  });
+
+  it("classifies network / mirror / download", () => {
+    expect(classifySetupGateError("All mirrors failed. Last error: timeout")).toBe(
+      "mirror",
+    );
+    expect(
+      classifySetupGateError(
+        "Could not resolve Grok Build version from any mirror.",
+      ),
+    ).toBe("mirror");
+    expect(classifySetupGateError("download https://x: HTTP 403")).toBe(
+      "download",
+    );
+    expect(classifySetupGateError("connection timed out")).toBe("network");
+    expect(classifySetupGateError(new Error("ENOTFOUND api.example"))).toBe(
+      "network",
+    );
+  });
+
+  it("classifies platform / binary / permission / missing", () => {
+    expect(
+      classifySetupGateError("Unsupported OS for Grok Build auto-install"),
+    ).toBe("unsupported_platform");
+    expect(
+      classifySetupGateError("downloaded binary --version failed: signal"),
+    ).toBe("binary_invalid");
+    expect(classifySetupGateError("Permission denied")).toBe("permission");
+    expect(classifySetupGateError("Grok Build not found")).toBe("cli_missing");
+  });
+
+  it("classifies too-old CLI and account / cancel", () => {
+    expect(
+      classifySetupGateError("CLI_TOO_OLD: grok CLI 0.2.100 < required 0.2.112"),
+    ).toBe("cli_too_old");
+    expect(classifySetupGateError("login cancelled by user")).toBe("cancelled");
+    expect(classifySetupGateError("OAuth device flow failed")).toBe("account");
+  });
+
+  it("uses explicit code when present", () => {
+    expect(classifySetupGateError({ code: "checksum_missing" })).toBe(
+      "checksum_missing",
+    );
+    expect(classifySetupGateError({ code: "cancelled", message: "x" })).toBe(
+      "cancelled",
+    );
+  });
+
+  it("falls back to other", () => {
+    expect(classifySetupGateError("weird host boom")).toBe("other");
+    expect(classifySetupGateError(null)).toBe("other");
+  });
+});
+
+describe("setupGateError keys / offer unverified", () => {
+  it("maps kinds to i18n title keys", () => {
+    expect(setupGateErrorTitleKey("checksum_missing")).toBe(
+      "setup.error.checksumMissing",
+    );
+    expect(setupGateErrorTitleKey("network")).toBe("setup.error.network");
+    expect(setupGateErrorTitleKey("other")).toBe("setup.error");
+  });
+
+  it("offers unverified install only for checksum_missing", () => {
+    expect(setupGateOfferUnverifiedInstall("checksum_missing")).toBe(true);
+    expect(setupGateOfferUnverifiedInstall("checksum_mismatch")).toBe(false);
+    expect(setupGateOfferUnverifiedInstall("network")).toBe(false);
+  });
+
+  it("hints network recovery for mirror/download", () => {
+    expect(setupGateErrorHintKey("mirror")).toBe("setup.networkHint");
+    expect(setupGateErrorHintKey("download")).toBe("setup.networkHint");
+    expect(setupGateErrorHintKey("cancelled")).toBeNull();
+  });
+
+  it("resolveSetupGateError packages view", () => {
+    const v = resolveSetupGateError(
+      "No published SHA-256 for artifact; GROK_CLI_REQUIRE_CHECKSUM",
+    );
+    expect(v.kind).toBe("checksum_missing");
+    expect(v.offerUnverifiedInstall).toBe(true);
+    expect(v.titleKey).toBe("setup.error.checksumMissing");
+    expect(v.hintKey).toBe("setup.checksumMissingHint");
+    expect(v.silent).toBe(false);
+    expect(v.detail.length).toBeGreaterThan(0);
+  });
+
+  it("marks cancelled silent", () => {
+    const v = resolveSetupGateError("User cancelled");
+    expect(v.kind).toBe("cancelled");
+    expect(v.silent).toBe(true);
+  });
+});
+
+describe("resolveSetupGateBoot", () => {
+  it("mirror always ready (no install surface)", () => {
+    expect(
+      resolveSetupGateBoot({
+        cliFound: false,
+        wizardCompleted: false,
+        legacyDone: false,
+        isMirror: true,
+      }),
+    ).toEqual({
+      phase: "ready",
+      shouldMigrateLegacy: false,
+      reason: "mirror",
+    });
+  });
+
+  it("missing CLI always setup — never invent ready", () => {
+    expect(
+      resolveSetupGateBoot({
+        cliFound: false,
+        wizardCompleted: true,
+        legacyDone: true,
+      }),
+    ).toMatchObject({ phase: "setup", reason: "cli_missing" });
+  });
+
+  it("CLI + incomplete wizard → setup", () => {
+    expect(
+      resolveSetupGateBoot({
+        cliFound: true,
+        wizardCompleted: false,
+        legacyDone: false,
+      }),
+    ).toEqual({
+      phase: "setup",
+      shouldMigrateLegacy: false,
+      reason: "wizard_pending",
+    });
+  });
+
+  it("CLI + legacy done migrates and enters ready", () => {
+    expect(
+      resolveSetupGateBoot({
+        cliFound: true,
+        wizardCompleted: false,
+        legacyDone: true,
+      }),
+    ).toEqual({
+      phase: "ready",
+      shouldMigrateLegacy: true,
+      reason: "legacy_migrate",
+    });
+  });
+
+  it("CLI + wizard completed → ready", () => {
+    expect(
+      resolveSetupGateBoot({
+        cliFound: true,
+        wizardCompleted: true,
+        legacyDone: false,
+      }),
+    ).toEqual({
+      phase: "ready",
+      shouldMigrateLegacy: false,
+      reason: "wizard_done",
+    });
+  });
+});
+
+describe("wizard step + enter home honesty", () => {
+  it("initial step depends only on CLI found", () => {
+    expect(resolveInitialWizardStep(false)).toBe("runtime");
+    expect(resolveInitialWizardStep(true)).toBe("account");
+  });
+
+  it("canEnterHome is hard CLI gate only", () => {
+    expect(canEnterHome(false)).toBe(false);
+    expect(canEnterHome(true)).toBe(true);
+  });
+
+  it("cannot advance past runtime without CLI", () => {
+    expect(canAdvancePastRuntime(false)).toBe(false);
+    expect(canAdvancePastRuntime(true)).toBe(true);
+  });
+
+  it("account step is always optional", () => {
+    expect(isAccountStepOptional()).toBe(true);
+  });
+});
+
+describe("buildAuthDeferredFlags", () => {
+  it("never defers when auth is ok", () => {
+    expect(buildAuthDeferredFlags({ authDeferred: true, authOk: true })).toEqual(
+      {
+        authSetupDeferred: false,
+        setupSkipped: false,
+      },
+    );
+  });
+
+  it("defers only when skipped and not connected", () => {
+    expect(
+      buildAuthDeferredFlags({ authDeferred: true, authOk: false }),
+    ).toEqual({
+      authSetupDeferred: true,
+      setupSkipped: true,
+    });
+    expect(
+      buildAuthDeferredFlags({ authDeferred: false, authOk: false }),
+    ).toEqual({
+      authSetupDeferred: false,
+      setupSkipped: false,
+    });
+  });
+});
+
+describe("buildReadyChecklist", () => {
+  it("blocks enter when CLI missing — never soft-ok CLI", () => {
+    const c = buildReadyChecklist({
+      cliFound: false,
+      authOk: true,
+    });
+    expect(c.canEnter).toBe(false);
+    expect(c.rows[0]).toMatchObject({
+      id: "cli",
+      ok: false,
+      soft: false,
+      labelKey: "setup.cli.missing",
+    });
+    // Auth may still show ok if secrets present; does not grant entry.
+    expect(c.rows[1].ok).toBe(true);
+  });
+
+  it("honest auth skip vs connected", () => {
+    const skipped = buildReadyChecklist({
+      cliFound: true,
+      cliVersion: "0.2.117",
+      authOk: false,
+      authDeferred: true,
+    });
+    expect(skipped.canEnter).toBe(true);
+    expect(skipped.authDeferred).toBe(true);
+    expect(skipped.rows[0].meta).toBe("0.2.117");
+    expect(skipped.rows[1].labelKey).toBe("setup.ready.authSkip");
+
+    const ok = buildReadyChecklist({
+      cliFound: true,
+      authOk: true,
+      authDeferred: true,
+    });
+    expect(ok.authDeferred).toBe(false);
+    expect(ok.rows[1].labelKey).toBe("setup.ready.authOk");
+  });
+});
+
+describe("mirrorHostFromUrl + clampInstallPercent", () => {
+  it("extracts host from valid URLs", () => {
+    expect(
+      mirrorHostFromUrl(
+        "https://storage.googleapis.com/grok-build-public-artifacts/cli",
+      ),
+    ).toBe("storage.googleapis.com");
+    expect(mirrorHostFromUrl("https://x.ai/cli")).toBe("x.ai");
+  });
+
+  it("falls back for non-URL strings", () => {
+    expect(mirrorHostFromUrl("not a url")).toBe("not a url");
+    expect(mirrorHostFromUrl(null)).toBe("");
+  });
+
+  it("clamps percent honestly", () => {
+    expect(clampInstallPercent(null, true)).toBe(8);
+    expect(clampInstallPercent(null, false)).toBe(0);
+    expect(clampInstallPercent(150, false)).toBe(100);
+    expect(clampInstallPercent(-3, false)).toBe(0);
+    expect(clampInstallPercent(42.6, true)).toBe(43);
+  });
+});
+
+describe("cli version unsupported", () => {
+  it("only false means unsupported (null is unknown — not blocked)", () => {
+    expect(isCliVersionUnsupported(false)).toBe(true);
+    expect(isCliVersionUnsupported(true)).toBe(false);
+    expect(isCliVersionUnsupported(null)).toBe(false);
+    expect(isCliVersionUnsupported(undefined)).toBe(false);
+  });
+
+  it("formats CLI_TOO_OLD detail without inventing min", () => {
+    expect(
+      formatCliTooOldDetail({ version: "0.2.100", minVersion: "0.2.112" }),
+    ).toBe("CLI_TOO_OLD: grok CLI 0.2.100 < required 0.2.112");
+    expect(formatCliTooOldDetail({ version: null })).toContain("?");
+  });
+});

--- a/src/lib/setupGatePro.ts
+++ b/src/lib/setupGatePro.ts
@@ -1,0 +1,645 @@
+/**
+ * SETUP-GATE-PRO — pure helpers for the full-screen first-run setup gate.
+ *
+ * Honesty rules (see docs/llm-wiki/setup.md):
+ * - CLI is a **hard** gate: never enter home without a found binary.
+ * - Account / auth is **soft**: skippable; never invent "connected" from skip.
+ * - Gate phase (loading → setup → ready) is derived from settings + probe only —
+ *   never invent wizardCompleted when CLI is missing.
+ * - Install / probe failures are classified into stable kinds with actionable
+ *   i18n keys; raw host strings stay as detail, not as the only signal.
+ *
+ * No DOM / Tauri side effects.
+ */
+
+/** Wizard steps inside SetupWizard. */
+export type SetupWizardStep = "runtime" | "account" | "ready";
+
+/**
+ * App-level gate after boot probe.
+ * `loading` is host-owned; pure helpers resolve setup vs ready only.
+ */
+export type SetupAppGatePhase = "setup" | "ready";
+
+/** Stable failure modes for install / probe / account actions. */
+export type SetupGateErrorKind =
+  | "cli_missing"
+  | "cli_too_old"
+  | "checksum_missing"
+  | "checksum_mismatch"
+  | "network"
+  | "mirror"
+  | "download"
+  | "unsupported_platform"
+  | "binary_invalid"
+  | "permission"
+  | "probe_failed"
+  | "account"
+  | "cancelled"
+  | "other";
+
+/** Visual tone for error / status chrome. */
+export type SetupGateTone = "ok" | "warn" | "err" | "muted" | "info";
+
+/** Inputs for the boot-time app gate decision. */
+export type SetupGateBootInput = {
+  /** Probe says a runnable grok binary was found. */
+  cliFound: boolean;
+  /** Settings: setupWizardCompleted. */
+  wizardCompleted: boolean;
+  /**
+   * Legacy: onboardingDone || setupSkipped (pre-wizard installs).
+   * When CLI is present and wizard flag is missing, migrate + enter ready.
+   */
+  legacyDone: boolean;
+  /**
+   * Phone mirror / secondary client — never hard-blocks on setup wizard.
+   * When true, always ready (mirror has no install surface).
+   */
+  isMirror?: boolean;
+};
+
+export type SetupGateBootDecision = {
+  phase: SetupAppGatePhase;
+  /** True when older installs should be written as setupWizardCompleted. */
+  shouldMigrateLegacy: boolean;
+  /**
+   * Stable machine reason for tests / diagnostics (English tokens).
+   * Never a user-facing string.
+   */
+  reason:
+    | "mirror"
+    | "cli_missing"
+    | "wizard_pending"
+    | "legacy_migrate"
+    | "wizard_done";
+};
+
+/** Ready-step checklist row (CLI hard / auth soft). */
+export type SetupReadyCheckRow = {
+  id: "cli" | "auth";
+  /** true = hard ok, false = soft skip / missing (auth only). */
+  ok: boolean;
+  /** Soft row is allowed incomplete (auth). CLI is never soft-ok when missing. */
+  soft: boolean;
+  /** i18n key for the row label. */
+  labelKey: string;
+  /** Optional version / path meta (already safe; never secrets). */
+  meta: string | null;
+};
+
+export type SetupReadyChecklist = {
+  rows: SetupReadyCheckRow[];
+  /** Hard gate: both must pass for CLI; auth may be soft. */
+  canEnter: boolean;
+  /** True when auth was skipped or not connected. */
+  authDeferred: boolean;
+};
+
+/** Resolved install/account error presentation. */
+export type SetupGateErrorView = {
+  kind: SetupGateErrorKind;
+  tone: SetupGateTone;
+  /** Primary title i18n key. */
+  titleKey: string;
+  /** Optional secondary hint key (actionable recovery). */
+  hintKey: string | null;
+  /** Show "Install without checksum" primary when true. */
+  offerUnverifiedInstall: boolean;
+  /** Raw host/detail string (caller may display under the title). */
+  detail: string;
+  /** Cancelled OAuth / user dismiss — do not treat as hard failure toast. */
+  silent: boolean;
+};
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as {
+      code?: unknown;
+      message?: unknown;
+      reason?: unknown;
+      error?: unknown;
+    };
+    const parts = [o.code, o.message, o.reason, o.error]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+/**
+ * Classify install / probe / account failures into a stable kind.
+ * Prefer explicit codes and known host phrases over free-form text.
+ */
+export function classifySetupGateError(err: unknown): SetupGateErrorKind {
+  if (err == null || err === "") return "other";
+
+  const codeRaw =
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    typeof (err as { code?: unknown }).code === "string"
+      ? String((err as { code: string }).code).trim().toLowerCase()
+      : "";
+
+  if (codeRaw === "cli_missing" || codeRaw === "cli-missing") return "cli_missing";
+  if (codeRaw === "cli_too_old" || codeRaw === "cli-too-old") return "cli_too_old";
+  if (codeRaw === "checksum_missing" || codeRaw === "checksum-missing") {
+    return "checksum_missing";
+  }
+  if (codeRaw === "checksum_mismatch" || codeRaw === "checksum-mismatch") {
+    return "checksum_mismatch";
+  }
+  if (codeRaw === "cancelled" || codeRaw === "cancel") return "cancelled";
+  if (codeRaw === "network" || codeRaw === "timeout") return "network";
+  if (codeRaw === "permission" || codeRaw === "eacces") return "permission";
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  // User cancelled OAuth / device login / file picker.
+  if (
+    /\bcancel(led)?\b/.test(s) ||
+    s.includes("user cancelled") ||
+    s.includes("user canceled") ||
+    s.includes("login cancelled") ||
+    s.includes("login canceled")
+  ) {
+    return "cancelled";
+  }
+
+  // Checksum — missing sidecar (strict mode) vs mismatch.
+  if (
+    s.includes("no published sha-256") ||
+    s.includes("no published sha256") ||
+    s.includes("checksum required") ||
+    s.includes("grok_cli_require_checksum") ||
+    s.includes("未发布 sha-256") ||
+    s.includes("未發佈 sha-256") ||
+    s.includes("未发布 sha256")
+  ) {
+    return "checksum_missing";
+  }
+  if (
+    s.includes("checksum mismatch") ||
+    s.includes("sha-256 mismatch") ||
+    s.includes("sha256 mismatch") ||
+    s.includes("digest mismatch") ||
+    (s.includes("checksum") && s.includes("mismatch"))
+  ) {
+    return "checksum_mismatch";
+  }
+
+  // Too-old CLI (App boot also surfaces CLI_TOO_OLD).
+  if (
+    s.includes("cli_too_old") ||
+    s.includes("cli too old") ||
+    (s.includes("required") && s.includes("<") && s.includes("cli")) ||
+    /grok cli .+ < required/.test(s)
+  ) {
+    return "cli_too_old";
+  }
+
+  // Unsupported OS / arch from host install.
+  if (
+    s.includes("unsupported os") ||
+    s.includes("unsupported cpu") ||
+    s.includes("unsupported architecture") ||
+    s.includes("unsupported platform")
+  ) {
+    return "unsupported_platform";
+  }
+
+  // Binary found but invalid after download / pick.
+  if (
+    s.includes("downloaded binary --version failed") ||
+    s.includes("not a file") ||
+    s.includes("failed to run downloaded binary") ||
+    s.includes("download produced empty") ||
+    s.includes("download size mismatch") ||
+    s.includes("binary invalid") ||
+    s.includes("exec format")
+  ) {
+    return "binary_invalid";
+  }
+
+  // Permission / sandbox.
+  if (
+    s.includes("permission denied") ||
+    s.includes("operation not permitted") ||
+    s.includes("eacces") ||
+    s.includes("eperm") ||
+    s.includes("access is denied")
+  ) {
+    return "permission";
+  }
+
+  // Explicit not found.
+  if (
+    s.includes("grok build not found") ||
+    s.includes("cli not found") ||
+    s.includes("grok build cli not found") ||
+    s.includes("no such file") ||
+    s.includes("command not found")
+  ) {
+    return "cli_missing";
+  }
+
+  // All mirrors / mirror host failures.
+  if (
+    s.includes("all mirrors failed") ||
+    s.includes("could not resolve grok build version from any mirror") ||
+    (s.includes("mirror") && (s.includes("fail") || s.includes("error")))
+  ) {
+    return "mirror";
+  }
+
+  // Download / HTTP / network / timeout.
+  if (
+    s.includes("download url not on allowlist") ||
+    s.includes("version url not on allowlist") ||
+    /http\s*[1-5]\d{2}/.test(s) ||
+    s.includes("download ")
+  ) {
+    // Prefer network when connectivity-shaped.
+    if (
+      s.includes("timeout") ||
+      s.includes("timed out") ||
+      s.includes("network") ||
+      s.includes("connection") ||
+      s.includes("dns") ||
+      s.includes("econn") ||
+      s.includes("enotfound") ||
+      s.includes("offline")
+    ) {
+      return "network";
+    }
+    return "download";
+  }
+  if (
+    s.includes("timeout") ||
+    s.includes("timed out") ||
+    s.includes("network") ||
+    s.includes("connection refused") ||
+    s.includes("connection reset") ||
+    s.includes("name or service not known") ||
+    s.includes("could not resolve host") ||
+    s.includes("econnreset") ||
+    s.includes("enotfound") ||
+    s.includes("offline")
+  ) {
+    return "network";
+  }
+
+  // Account / OAuth / key save soft failures.
+  if (
+    s.includes("oauth") ||
+    s.includes("login failed") ||
+    s.includes("auth failed") ||
+    s.includes("unauthorized") ||
+    s.includes("invalid api key") ||
+    s.includes("invalid key") ||
+    s.includes("relay") && s.includes("fail")
+  ) {
+    return "account";
+  }
+
+  // Probe-shaped generic failures.
+  if (
+    s.includes("probe") ||
+    s.includes("failed to run") ||
+    s.includes("spawn")
+  ) {
+    return "probe_failed";
+  }
+
+  return "other";
+}
+
+/** i18n title key for a classified setup-gate error. */
+export function setupGateErrorTitleKey(kind: SetupGateErrorKind): string {
+  switch (kind) {
+    case "cli_missing":
+      return "setup.error.cliMissing";
+    case "cli_too_old":
+      return "setup.error.cliTooOld";
+    case "checksum_missing":
+      return "setup.error.checksumMissing";
+    case "checksum_mismatch":
+      return "setup.error.checksumMismatch";
+    case "network":
+      return "setup.error.network";
+    case "mirror":
+      return "setup.error.mirror";
+    case "download":
+      return "setup.error.download";
+    case "unsupported_platform":
+      return "setup.error.unsupportedPlatform";
+    case "binary_invalid":
+      return "setup.error.binaryInvalid";
+    case "permission":
+      return "setup.error.permission";
+    case "probe_failed":
+      return "setup.error.probeFailed";
+    case "account":
+      return "setup.error.account";
+    case "cancelled":
+      return "setup.error.cancelled";
+    case "other":
+    default:
+      return "setup.error";
+  }
+}
+
+/**
+ * Optional recovery hint key. Null when the title alone is enough
+ * (or when silent cancel).
+ */
+export function setupGateErrorHintKey(
+  kind: SetupGateErrorKind,
+): string | null {
+  switch (kind) {
+    case "checksum_missing":
+      return "setup.checksumMissingHint";
+    case "checksum_mismatch":
+      return "setup.error.checksumMismatchHint";
+    case "network":
+    case "mirror":
+    case "download":
+      return "setup.networkHint";
+    case "cli_missing":
+      return "setup.manualHint";
+    case "cli_too_old":
+      return "setup.error.cliTooOldHint";
+    case "unsupported_platform":
+      return "setup.error.unsupportedPlatformHint";
+    case "binary_invalid":
+      return "setup.error.binaryInvalidHint";
+    case "permission":
+      return "setup.error.permissionHint";
+    case "account":
+      return "setup.error.accountHint";
+    case "probe_failed":
+      return "setup.error.probeFailedHint";
+    case "cancelled":
+      return null;
+    case "other":
+    default:
+      return "setup.networkHint";
+  }
+}
+
+/** True when the UI should offer "Install without checksum". */
+export function setupGateOfferUnverifiedInstall(
+  kind: SetupGateErrorKind,
+): boolean {
+  return kind === "checksum_missing";
+}
+
+export function setupGateErrorSilent(kind: SetupGateErrorKind): boolean {
+  return kind === "cancelled";
+}
+
+export function setupGateErrorTone(kind: SetupGateErrorKind): SetupGateTone {
+  if (kind === "cancelled") return "muted";
+  if (kind === "checksum_missing" || kind === "cli_too_old") return "warn";
+  if (kind === "account") return "warn";
+  return "err";
+}
+
+/**
+ * Resolve presentation for a thrown / host error.
+ * Never invents success; cancelled stays silent for callers that toast.
+ */
+export function resolveSetupGateError(err: unknown): SetupGateErrorView {
+  const kind = classifySetupGateError(err);
+  const raw = errText(err).trim();
+  let detail = "";
+  if (raw && raw.length < 280) {
+    // Strip redundant "Error:" prefix; keep host message for support.
+    detail = raw.replace(/^Error:\s*/i, "").trim();
+  }
+  // When the title already names the kind, avoid repeating a near-empty detail.
+  if (
+    kind !== "other" &&
+    detail &&
+    detail.length < 8 &&
+    !/[/:\\]/.test(detail)
+  ) {
+    detail = "";
+  }
+  return {
+    kind,
+    tone: setupGateErrorTone(kind),
+    titleKey: setupGateErrorTitleKey(kind),
+    hintKey: setupGateErrorHintKey(kind),
+    offerUnverifiedInstall: setupGateOfferUnverifiedInstall(kind),
+    detail,
+    silent: setupGateErrorSilent(kind),
+  };
+}
+
+/**
+ * Boot-time gate: CLI hard-required, account never blocks home.
+ *
+ * Decision table:
+ * | CLI | wizardCompleted | legacyDone | result |
+ * |-----|-----------------|------------|--------|
+ * | mirror client | * | * | ready |
+ * | no  | * | * | setup |
+ * | yes | no | yes | ready + migrate |
+ * | yes | no | no | setup |
+ * | yes | yes | * | ready |
+ */
+export function resolveSetupGateBoot(
+  input: SetupGateBootInput,
+): SetupGateBootDecision {
+  if (input.isMirror) {
+    return {
+      phase: "ready",
+      shouldMigrateLegacy: false,
+      reason: "mirror",
+    };
+  }
+  if (!input.cliFound) {
+    return {
+      phase: "setup",
+      shouldMigrateLegacy: false,
+      reason: "cli_missing",
+    };
+  }
+  if (!input.wizardCompleted && input.legacyDone) {
+    return {
+      phase: "ready",
+      shouldMigrateLegacy: true,
+      reason: "legacy_migrate",
+    };
+  }
+  if (!input.wizardCompleted) {
+    return {
+      phase: "setup",
+      shouldMigrateLegacy: false,
+      reason: "wizard_pending",
+    };
+  }
+  return {
+    phase: "ready",
+    shouldMigrateLegacy: false,
+    reason: "wizard_done",
+  };
+}
+
+/** Initial wizard step: no CLI → runtime; CLI present → account (skippable). */
+export function resolveInitialWizardStep(cliFound: boolean): SetupWizardStep {
+  return cliFound ? "account" : "runtime";
+}
+
+/**
+ * Hard enter-home gate. Account state never grants entry without CLI.
+ * Documented honesty: returns false when `cliFound` is falsey.
+ */
+export function canEnterHome(cliFound: boolean): boolean {
+  return !!cliFound;
+}
+
+/**
+ * Settings flags after finish. Never marks auth deferred when auth is ok.
+ * `authDeferred` only sticks when the user skipped **and** is not connected.
+ */
+export function buildAuthDeferredFlags(opts: {
+  authDeferred: boolean;
+  authOk: boolean;
+}): { authSetupDeferred: boolean; setupSkipped: boolean } {
+  const deferred = !!opts.authDeferred && !opts.authOk;
+  return {
+    authSetupDeferred: deferred,
+    setupSkipped: deferred,
+  };
+}
+
+/**
+ * Ready-step checklist. Never claims CLI ok without found; auth is soft.
+ */
+export function buildReadyChecklist(opts: {
+  cliFound: boolean;
+  cliVersion?: string | null;
+  authOk: boolean;
+  /**
+   * User chose skip (or left without connecting). Ignored when authOk —
+   * never claim deferred while connected.
+   */
+  authDeferred?: boolean;
+}): SetupReadyChecklist {
+  const cliFound = !!opts.cliFound;
+  const authOk = !!opts.authOk;
+  // Soft gate honesty: not connected ⇒ deferred for checklist copy.
+  // Explicit authDeferred=false still shows "later" when !authOk (user continued).
+  const authDeferred = !authOk;
+
+  const version =
+    typeof opts.cliVersion === "string" && opts.cliVersion.trim()
+      ? opts.cliVersion.trim()
+      : null;
+
+  const rows: SetupReadyCheckRow[] = [
+    {
+      id: "cli",
+      ok: cliFound,
+      soft: false,
+      labelKey: cliFound ? "setup.ready.cliOk" : "setup.cli.missing",
+      meta: cliFound ? version : null,
+    },
+    {
+      id: "auth",
+      ok: authOk,
+      soft: true,
+      labelKey: authOk ? "setup.ready.authOk" : "setup.ready.authSkip",
+      meta: null,
+    },
+  ];
+
+  return {
+    rows,
+    canEnter: canEnterHome(cliFound),
+    authDeferred,
+  };
+}
+
+/** Extract hostname from a mirror URL for progress chrome. */
+export function mirrorHostFromUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  try {
+    return new URL(url).host;
+  } catch {
+    return url.replace(/^https?:\/\//, "").split("/")[0] || url;
+  }
+}
+
+/**
+ * Clamp install progress percent for the bar.
+ * When installing with no percent, show a soft 8% so the bar is not empty
+ * (honest "started", not "done").
+ */
+export function clampInstallPercent(
+  percent: number | null | undefined,
+  installing: boolean,
+): number {
+  if (percent == null || Number.isNaN(Number(percent))) {
+    return installing ? 8 : 0;
+  }
+  return Math.max(0, Math.min(100, Math.round(Number(percent))));
+}
+
+/**
+ * Whether a CLI probe with `versionSupported === false` should surface
+ * as a soft warning (still found — not a hard install block).
+ */
+export function isCliVersionUnsupported(
+  versionSupported: boolean | null | undefined,
+): boolean {
+  return versionSupported === false;
+}
+
+/**
+ * Build the short CLI_TOO_OLD style detail used at boot (no secrets).
+ */
+export function formatCliTooOldDetail(opts: {
+  version?: string | null;
+  minVersion?: string | null;
+}): string {
+  const v = (opts.version ?? "?").trim() || "?";
+  const min = (opts.minVersion ?? "").trim();
+  if (min) return `CLI_TOO_OLD: grok CLI ${v} < required ${min}`;
+  return `CLI_TOO_OLD: grok CLI ${v}`;
+}
+
+/**
+ * Auth is always optional for the gate. Pure constant for callers / tests
+ * so UI never hard-blocks on missing account.
+ */
+export function isAccountStepOptional(): true {
+  return true;
+}
+
+/**
+ * Whether the runtime step may advance to account.
+ * Only when CLI is found — never advance on skip.
+ */
+export function canAdvancePastRuntime(cliFound: boolean): boolean {
+  return !!cliFound;
+}

--- a/src/styles/setup-wizard.css
+++ b/src/styles/setup-wizard.css
@@ -462,11 +462,27 @@
   border-style: dashed;
 }
 
+.setup-checklist li.is-fail {
+  color: var(--danger);
+}
+
+.setup-checklist li.is-fail .setup-check {
+  border-color: var(--danger);
+  background: var(--danger-muted);
+}
+
 .setup-check-meta {
   margin-left: auto;
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-tertiary);
+}
+
+.setup-ready-soft {
+  margin: 6px 0 0 !important;
+  font-size: var(--text-xs) !important;
+  color: var(--text-tertiary) !important;
+  line-height: 1.4 !important;
 }
 
 .setup-error {
@@ -481,8 +497,14 @@
   color: var(--danger);
   line-height: 1.4;
   /* Clip long errors without introducing a page scrollbar */
-  max-height: 72px;
+  max-height: 96px;
   overflow: hidden;
+}
+
+.setup-error--warn {
+  background: var(--warning-muted, var(--accent-muted));
+  border-color: rgba(210, 160, 60, 0.35);
+  color: var(--warning, var(--text-primary));
 }
 
 .setup-error strong {


### PR DESCRIPTION
## Summary

Polishes the first-run **setup gate** (CLI hard-required, account optional) with honest boot decisions and classified install/probe/account errors.

- **Pure helpers** `src/lib/setupGatePro.ts` (+ tests):
  - `resolveSetupGateBoot` — never invents ready without CLI; legacy migrate when `onboardingDone`/`setupSkipped`
  - `classifySetupGateError` / `resolveSetupGateError` — stable kinds (`checksum_missing`, `mirror`, `network`, `cli_too_old`, …) with i18n title + recovery hint
  - `buildReadyChecklist` / `buildAuthDeferredFlags` — never soft-ok CLI; never claim auth deferred when connected
  - Unverified install offered **only** for missing checksum (not mismatch)
- **SetupWizard**: classified error chrome, ready-step soft auth note, hard enter gate via helpers
- **App boot**: uses pure gate decision + `formatCliTooOldDetail`
- i18n en/zh/zh-TW · `docs/llm-wiki/setup.md` honesty table · Unreleased CHANGELOG

## Test plan

- [x] `vitest run src/lib/setupGatePro.test.ts src/i18n/messages.test.ts` (48 tests)
- [ ] First launch without CLI → runtime step only; cannot enter home
- [ ] CLI present, wizard incomplete → account step; Skip → ready with soft auth row
- [ ] Install failure (network/mirror) shows classified title + recovery hint
- [ ] Strict checksum-missing path offers “Install without checksum”; mismatch does not
- [ ] Legacy settings (`onboardingDone` + CLI) migrate to `setupWizardCompleted` and enter home