### PR TITLE
feat(plan): plan mode pro — empty states and open-in-resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See `docs/llm-wiki/release.md`.
 - **Streaming ACP NDJSON diagnostics** (Settings → Runtime → Tools; CLI **0.2.117+**): pure parser for headless `--output-format streaming-json` as agent-native ACP session-update NDJSON (not `streaming-messages-json`); import/paste or soft-gated headless probe; event type counts + copy summary
 
 #### Composer & chat
+- **Plan mode pro** (PLAN-MODE-PRO): Resources → Plan contextual empty states (plan mode waiting · settings disabled · user-closed cycle · idle + history CTA); sticky bar **Open in resources** also works in plan mode before a draft arrives; pin policy keeps empty Plan panel reachable after open-in-resources (no bounce to Files). Pure `planModePro` helpers + tests; en/zh/zh-TW
 - **Live Voice delegate status** (VOX-DELEG): overlay shows listening / thinking / speaking from host `voice://` events, **Stop**, honest empty transcript (no fake STT), delegated session chips, and optional **Send transcript to active session** when a chat is open
 - **Send queue** edit / reorder · **composer min height** · **cross-session recent prompts**
 - **Chat width** · **chat / code font** · **tool auto-collapse** · **transcript filter** (hide tool steps)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -424,7 +424,13 @@ import {
 } from "@/lib/shareCardSkins";
 import { loadExportLogoPref } from "@/lib/exportLogoPref";
 import { recordTraceExport } from "@/lib/traceHistory";
-import { clearPlanHistory, recordPlanHistory } from "@/lib/planHistory";
+import {
+  clearPlanHistory,
+  loadPlanHistory,
+  recordPlanHistory,
+  PLAN_HISTORY_CHANGE_EVENT,
+  PLAN_HISTORY_STORAGE_KEY,
+} from "@/lib/planHistory";
 import type { PlanHistoryEntry } from "@/lib/planHistory";
 import { planDisplayMarkdown } from "@/lib/planBody";
 import {
@@ -1975,8 +1981,28 @@ export default function App() {
   const [showPlanHistory, setShowPlanHistory] = useState(false);
   const [planHistoryPreview, setPlanHistoryPreview] =
     useState<PlanHistoryEntry | null>(null);
+  /** Non-empty archive — drives Plan empty-state history CTA. */
+  const [planHistoryNonEmpty, setPlanHistoryNonEmpty] = useState(
+    () => loadPlanHistory().length > 0,
+  );
   /** Request-changes note modal (optional free-form feedback). */
   const [planReviseOpen, setPlanReviseOpen] = useState(false);
+
+  // Keep plan-history empty CTA honest after archive / clear.
+  useEffect(() => {
+    const refresh = () => setPlanHistoryNonEmpty(loadPlanHistory().length > 0);
+    refresh();
+    const onChange = () => refresh();
+    window.addEventListener(PLAN_HISTORY_CHANGE_EVENT, onChange);
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === null || e.key === PLAN_HISTORY_STORAGE_KEY) refresh();
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(PLAN_HISTORY_CHANGE_EVENT, onChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
   const [planReviseNote, setPlanReviseNote] = useState("");
   /**
    * Dedupe plan-complete history rows per session+toolCall cycle
@@ -18179,6 +18205,12 @@ export default function App() {
               sessionMessages={messages}
               plan={plan}
               planFocusKey={planFocusKey}
+              planChrome={{
+                composerMode: mode,
+                planEnabled,
+                userClosed: plan.userClosed,
+                hasHistory: planHistoryNonEmpty,
+              }}
               onApprovePlan={() => void approvePlan()}
               onRequestPlanChanges={() => openRequestPlanChanges()}
               onDismissPlan={() => void dismissPlan()}

--- a/src/components/PlanReviewPanel.tsx
+++ b/src/components/PlanReviewPanel.tsx
@@ -17,6 +17,11 @@ import {
   type PlanReviewState,
 } from "@/lib/planBody";
 import {
+  planHasExpandableContent,
+  planPanelInnerEmptyLabelKey,
+  resolvePlanPanelInnerEmpty,
+} from "@/lib/planModePro";
+import {
   computePlanProgress,
   formatPlanFraction,
   parsePlanEntries,
@@ -123,7 +128,19 @@ export function PlanReviewPanel({
   }, [forceExpandKey]);
 
   const hasExpandableContent =
-    entries.length > 0 || !!detailMarkdown || !!planDisplayMarkdown(plan.body, plan.entries);
+    planHasExpandableContent({ body: detailMarkdown || plan.body, entries }) ||
+    !!planDisplayMarkdown(plan.body, plan.entries);
+
+  const innerEmptyKind = resolvePlanPanelInnerEmpty({
+    waiting: plan.waiting && !canAct,
+    hasExpandableContent,
+  });
+  const innerEmptyLabel =
+    innerEmptyKind != null
+      ? planPanelInnerEmptyLabelKey(innerEmptyKind) === "plan.waiting"
+        ? labels.waiting
+        : labels.empty
+      : null;
 
   const toggleExpand = () => {
     if (!hasExpandableContent) return;
@@ -272,8 +289,18 @@ export function PlanReviewPanel({
               >
                 <MarkdownBody>{detailMarkdown}</MarkdownBody>
               </div>
-            ) : !entries.length ? (
-              <p className="plan-review__empty">{labels.empty}</p>
+            ) : !entries.length && innerEmptyLabel ? (
+              <p
+                className={
+                  "plan-review__empty" +
+                  (innerEmptyKind === "waiting"
+                    ? " plan-review__empty--waiting"
+                    : "")
+                }
+                data-empty-kind={innerEmptyKind ?? undefined}
+              >
+                {innerEmptyLabel}
+              </p>
             ) : null}
           </div>
         </OverlayScroll>

--- a/src/components/PlanStatusBar.tsx
+++ b/src/components/PlanStatusBar.tsx
@@ -8,6 +8,7 @@ import {
   shouldShowPlanBar,
   type PlanBarModel,
 } from "@/lib/planStatus";
+import { shouldOfferOpenInResourcesFromModel } from "@/lib/planModePro";
 
 export type PlanStatusBarLabels = {
   goal: string;
@@ -153,11 +154,14 @@ export function PlanStatusBar({
       ) : null}
 
       <div className="plan-bar__actions">
-        {planVisible && onOpenDetails ? (
+        {shouldOfferOpenInResourcesFromModel(model, planVisible) &&
+        onOpenDetails ? (
           <button
             type="button"
             className="btn btn--ghost btn--sm plan-bar__btn"
             onClick={onOpenDetails}
+            data-testid="plan-bar-open-resources"
+            title={labels.expand}
           >
             {labels.expand}
           </button>

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -43,6 +43,11 @@ import {
 } from "@/components/icons";
 import { PlanReviewPanel } from "@/components/PlanReviewPanel";
 import type { PlanReviewState } from "@/lib/planBody";
+import {
+  resolvePlanResourceEmptyState,
+  shouldAutoLeavePlanSideMode,
+  shouldShowPlanChromeButton,
+} from "@/lib/planModePro";
 import { OfficeDocumentPreview } from "@/components/OfficeDocumentPreview";
 import { CodePreview } from "@/components/CodePreview";
 import { isOfficeKind } from "@/lib/filePreviewSrc";
@@ -154,6 +159,20 @@ export interface ResourceViewerProps {
   plan?: PlanReviewState | null;
   /** Increment / change to force switch into Plan mode (详情 / auto-open). */
   planFocusKey?: number | null;
+  /**
+   * PLAN-MODE-PRO empty-state context (composer mode, settings, hard-dismiss).
+   * When omitted, empty panel falls back to the generic planEmpty copy.
+   */
+  planChrome?: {
+    /** Composer access mode (`plan` | `agent` | …). */
+    composerMode?: string;
+    /** Settings: allow plan mode (false → spawn --no-plan). Default true. */
+    planEnabled?: boolean;
+    /** User hard-dismissed this plan cycle. */
+    userClosed?: boolean;
+    /** Local plan history archive is non-empty. */
+    hasHistory?: boolean;
+  } | null;
   onApprovePlan?: () => void;
   /** Optional revision note when requesting changes (empty allowed). */
   onRequestPlanChanges?: (note?: string) => void;
@@ -302,6 +321,7 @@ export function ResourceViewer({
   sessionChanges = [],
   plan = null,
   planFocusKey = null,
+  planChrome = null,
   onApprovePlan,
   onRequestPlanChanges,
   onDismissPlan,
@@ -322,6 +342,26 @@ export function ResourceViewer({
   const [treeVisible, setTreeVisible] = useState(false);
   const [sideMode, setSideMode] = useState<SideMode>("files");
   const lastPlanFocusKey = useRef<number | null>(null);
+  /** User opened Plan via open-in-resources / planFocus — keep empty states. */
+  const [userPinnedPlanSide, setUserPinnedPlanSide] = useState(false);
+
+  const planResourceEmpty = useMemo(
+    () =>
+      resolvePlanResourceEmptyState({
+        planVisible: !!plan?.visible,
+        planEnabled: planChrome?.planEnabled !== false,
+        userClosed: !!planChrome?.userClosed,
+        composerMode: planChrome?.composerMode ?? "agent",
+        hasHistory: !!planChrome?.hasHistory,
+      }),
+    [
+      plan?.visible,
+      planChrome?.planEnabled,
+      planChrome?.userClosed,
+      planChrome?.composerMode,
+      planChrome?.hasHistory,
+    ],
+  );
   const [treeWidth, setTreeWidth] = useState(loadTreeWidth);
   const [resizingTree, setResizingTree] = useState(false);
   const splitRef = useRef<HTMLDivElement>(null);
@@ -1262,8 +1302,11 @@ export function ResourceViewer({
     if (mode === "plan") {
       setSideMode("plan");
       setTreeVisible(false);
+      setUserPinnedPlanSide(true);
       return;
     }
+    // Leaving Plan unpins empty-state hold.
+    setUserPinnedPlanSide(false);
     if (treeVisible && sideMode === mode) {
       setTreeVisible(false);
       return;
@@ -1272,21 +1315,29 @@ export function ResourceViewer({
     setTreeVisible(true);
   };
 
-  // External “open plan in resources” (详情 / auto-open on review).
+  // External “open plan in resources” (详情 / auto-open on review / plan mode).
   useEffect(() => {
     if (planFocusKey == null) return;
     if (lastPlanFocusKey.current === planFocusKey) return;
     lastPlanFocusKey.current = planFocusKey;
     setSideMode("plan");
     setTreeVisible(false);
+    setUserPinnedPlanSide(true);
   }, [planFocusKey]);
 
-  // Plan hard-dismissed / approved / cancelled while viewing plan → files.
+  // Plan hard-dismissed while viewing plan → files only when not user-pinned
+  // (open-in-resources keeps the empty state reachable).
   useEffect(() => {
-    if (sideMode === "plan" && (!plan || !plan.visible)) {
+    if (
+      shouldAutoLeavePlanSideMode({
+        sideModeIsPlan: sideMode === "plan",
+        planVisible: !!plan?.visible,
+        userPinnedPlanSide,
+      })
+    ) {
       setSideMode("files");
     }
-  }, [plan, sideMode]);
+  }, [plan, sideMode, userPinnedPlanSide]);
 
   // Drag-resize preview | file-tree split
   useEffect(() => {
@@ -2864,7 +2915,12 @@ export function ResourceViewer({
               }}
             />
           ) : null}
-          {plan?.visible ? (
+          {shouldShowPlanChromeButton({
+            planVisible: !!plan?.visible,
+            composerMode: planChrome?.composerMode ?? "agent",
+            userClosed: !!planChrome?.userClosed,
+            userPinnedPlanSide,
+          }) ? (
             <Tip label={tr("resources.plan")}>
               <button
                 type="button"
@@ -2874,6 +2930,7 @@ export function ResourceViewer({
                 }
                 onClick={() => showSidePanel("plan")}
                 aria-label={tr("resources.plan")}
+                data-testid="resources-plan-chrome-btn"
               >
                 <IconPlan size={16} />
               </button>
@@ -3003,15 +3060,28 @@ export function ResourceViewer({
               onDismiss={onDismissPlan}
             />
           ) : sideMode === "plan" ? (
-            <div className="rp__empty-state">
-              <div className="rp__empty-title">{tr("resources.plan")}</div>
-              <div className="rp__empty-desc">{tr("resources.planEmpty")}</div>
-              {onOpenPlanHistory ? (
+            <div
+              className={
+                "rp__empty-state plan-resource-empty plan-resource-empty--" +
+                (planResourceEmpty?.kind ?? "idle")
+              }
+              data-testid="plan-resource-empty"
+              data-empty-kind={planResourceEmpty?.kind ?? "idle"}
+              role="status"
+            >
+              <div className="rp__empty-title plan-resource-empty__title">
+                {tr(planResourceEmpty?.titleKey ?? "resources.plan")}
+              </div>
+              <div className="rp__empty-desc plan-resource-empty__hint">
+                {tr(planResourceEmpty?.hintKey ?? "resources.planEmpty")}
+              </div>
+              {(planResourceEmpty?.showHistoryCta ?? false) &&
+              onOpenPlanHistory ? (
                 <button
                   type="button"
-                  className="btn btn--ghost btn--sm"
-                  style={{ marginTop: 12 }}
+                  className="btn btn--ghost btn--sm plan-resource-empty__cta"
                   onClick={onOpenPlanHistory}
+                  data-testid="plan-resource-empty-history"
                 >
                   {tr("plan.history")}
                 </button>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -977,6 +977,17 @@ const en = {
   "plan.ready": "Plan ready for review",
   "plan.context": "Context",
   "plan.empty": "(empty plan)",
+  /** PLAN-MODE-PRO — Resources → Plan empty states */
+  "plan.emptyDisabledTitle": "Plan mode is off",
+  "plan.emptyDisabledHint":
+    "Allow plan mode in Settings → Agent so the agent can draft plans. You can still browse archived plans from history.",
+  "plan.emptyClosedTitle": "Plan closed for this chat",
+  "plan.emptyClosedHint":
+    "You dismissed the plan for this cycle. It stays hidden until the agent starts a new plan task (or a new exit_plan_mode gate).",
+  "plan.emptyPlanModeHint":
+    "Plan mode is on. Send a message and the agent will draft a plan here — approve or request changes when it is ready.",
+  "plan.emptyIdleHint":
+    "No live plan in this chat. Turn on Plan mode from Access, or open Plan history for archived reviews.",
   "plan.approve": "Approve & build",
   "plan.changes": "Request changes",
   "plan.dismiss": "Dismiss",
@@ -5059,6 +5070,17 @@ const zh: Record<MessageKey, string> = {
   "plan.ready": "计划待审阅",
   "plan.context": "上下文",
   "plan.empty": "（空 plan）",
+  /** PLAN-MODE-PRO — Resources → Plan 空状态 */
+  "plan.emptyDisabledTitle": "计划模式已关闭",
+  "plan.emptyDisabledHint":
+    "请在 设置 → Agent 中开启「允许计划模式」，Agent 才能起草计划。仍可从历史查看已归档的计划。",
+  "plan.emptyClosedTitle": "本会话计划已关闭",
+  "plan.emptyClosedHint":
+    "你已关闭本轮计划。在 Agent 再次发起计划任务（或新的 exit_plan_mode 审阅）之前不会再显示。",
+  "plan.emptyPlanModeHint":
+    "已开启计划模式。发送消息后 Agent 会在此起草计划，就绪后可批准或请求修改。",
+  "plan.emptyIdleHint":
+    "当前会话没有进行中的计划。可在 Access 中打开计划模式，或从计划历史查看已归档审阅。",
   "plan.approve": "批准并构建",
   "plan.changes": "请求修改",
   "plan.dismiss": "关闭",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -925,6 +925,17 @@ export const zhTW: Record<MessageKey, string> = {
   "plan.ready": "計劃待審閱",
   "plan.context": "上下文",
   "plan.empty": "（空 plan）",
+  /** PLAN-MODE-PRO — Resources → Plan 空狀態 */
+  "plan.emptyDisabledTitle": "計劃模式已關閉",
+  "plan.emptyDisabledHint":
+    "請在 設定 → Agent 中開啟「允許計劃模式」，Agent 才能起草計劃。仍可從歷史查看已封存的計劃。",
+  "plan.emptyClosedTitle": "本對話計劃已關閉",
+  "plan.emptyClosedHint":
+    "你已關閉本輪計劃。在 Agent 再次發起計劃任務（或新的 exit_plan_mode 審閱）之前不會再顯示。",
+  "plan.emptyPlanModeHint":
+    "已開啟計劃模式。傳送訊息後 Agent 會在此起草計劃，就緒後可核准或請求修改。",
+  "plan.emptyIdleHint":
+    "目前對話沒有進行中的計劃。可在 Access 中開啟計劃模式，或從計劃歷史查看已封存審閱。",
   "plan.approve": "核准並建置",
   "plan.changes": "請求修改",
   "plan.dismiss": "關閉",

--- a/src/lib/planModePro.test.ts
+++ b/src/lib/planModePro.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+import {
+  planHasExpandableContent,
+  planPanelInnerEmptyLabelKey,
+  resolvePlanPanelInnerEmpty,
+  resolvePlanResourceEmptyState,
+  shouldAutoLeavePlanSideMode,
+  shouldOfferOpenInResources,
+  shouldOfferOpenInResourcesFromModel,
+  shouldShowPlanChromeButton,
+} from "./planModePro";
+
+describe("resolvePlanResourceEmptyState", () => {
+  const base = {
+    planVisible: false,
+    planEnabled: true,
+    userClosed: false,
+    composerMode: "agent",
+    hasHistory: false,
+  };
+
+  it("returns null when a live plan is visible", () => {
+    expect(
+      resolvePlanResourceEmptyState({ ...base, planVisible: true }),
+    ).toBeNull();
+  });
+
+  it("surfaces disabled settings before other kinds", () => {
+    const p = resolvePlanResourceEmptyState({
+      ...base,
+      planEnabled: false,
+      composerMode: "plan",
+      userClosed: true,
+    });
+    expect(p?.kind).toBe("disabled");
+    expect(p?.titleKey).toBe("plan.emptyDisabledTitle");
+    expect(p?.hintKey).toBe("plan.emptyDisabledHint");
+    expect(p?.showHistoryCta).toBe(false);
+  });
+
+  it("shows history CTA when disabled but archive exists", () => {
+    const p = resolvePlanResourceEmptyState({
+      ...base,
+      planEnabled: false,
+      hasHistory: true,
+    });
+    expect(p?.kind).toBe("disabled");
+    expect(p?.showHistoryCta).toBe(true);
+  });
+
+  it("shows user_closed after hard dismiss", () => {
+    const p = resolvePlanResourceEmptyState({
+      ...base,
+      userClosed: true,
+      hasHistory: true,
+    });
+    expect(p?.kind).toBe("user_closed");
+    expect(p?.titleKey).toBe("plan.emptyClosedTitle");
+    expect(p?.hintKey).toBe("plan.emptyClosedHint");
+    expect(p?.showHistoryCta).toBe(true);
+  });
+
+  it("shows plan_mode waiting while composer is in plan", () => {
+    const p = resolvePlanResourceEmptyState({
+      ...base,
+      composerMode: "plan",
+    });
+    expect(p?.kind).toBe("plan_mode");
+    expect(p?.titleKey).toBe("plan.waiting");
+    expect(p?.hintKey).toBe("plan.emptyPlanModeHint");
+  });
+
+  it("is case-insensitive for composer plan mode", () => {
+    const p = resolvePlanResourceEmptyState({
+      ...base,
+      composerMode: "Plan",
+    });
+    expect(p?.kind).toBe("plan_mode");
+  });
+
+  it("idle without history uses generic resources.planEmpty", () => {
+    const p = resolvePlanResourceEmptyState(base);
+    expect(p?.kind).toBe("idle");
+    expect(p?.titleKey).toBe("resources.plan");
+    expect(p?.hintKey).toBe("resources.planEmpty");
+    expect(p?.showHistoryCta).toBe(false);
+  });
+
+  it("idle with history offers archive CTA + idle hint", () => {
+    const p = resolvePlanResourceEmptyState({ ...base, hasHistory: true });
+    expect(p?.kind).toBe("idle");
+    expect(p?.hintKey).toBe("plan.emptyIdleHint");
+    expect(p?.showHistoryCta).toBe(true);
+  });
+});
+
+describe("shouldOfferOpenInResources", () => {
+  it("offers for review always", () => {
+    expect(
+      shouldOfferOpenInResources({ barKind: "plan_review", planVisible: true }),
+    ).toBe(true);
+    expect(
+      shouldOfferOpenInResources({
+        barKind: "plan_review",
+        planVisible: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("offers progress only when planVisible", () => {
+    expect(
+      shouldOfferOpenInResources({
+        barKind: "plan_progress",
+        planVisible: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldOfferOpenInResources({
+        barKind: "plan_progress",
+        planVisible: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("offers plan_mode so empty/waiting is reachable", () => {
+    expect(
+      shouldOfferOpenInResources({ barKind: "plan_mode", planVisible: false }),
+    ).toBe(true);
+  });
+
+  it("never offers for goal / hidden", () => {
+    expect(
+      shouldOfferOpenInResources({ barKind: "goal", planVisible: false }),
+    ).toBe(false);
+    expect(
+      shouldOfferOpenInResources({ barKind: "hidden", planVisible: false }),
+    ).toBe(false);
+  });
+
+  it("reads kind from bar model", () => {
+    expect(
+      shouldOfferOpenInResourcesFromModel(
+        { kind: "plan_mode" },
+        false,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("shouldAutoLeavePlanSideMode", () => {
+  it("leaves when plan gone and not pinned", () => {
+    expect(
+      shouldAutoLeavePlanSideMode({
+        sideModeIsPlan: true,
+        planVisible: false,
+        userPinnedPlanSide: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays when user pinned open-in-resources", () => {
+    expect(
+      shouldAutoLeavePlanSideMode({
+        sideModeIsPlan: true,
+        planVisible: false,
+        userPinnedPlanSide: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("stays while plan is visible", () => {
+    expect(
+      shouldAutoLeavePlanSideMode({
+        sideModeIsPlan: true,
+        planVisible: true,
+        userPinnedPlanSide: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("no-op when not on plan side", () => {
+    expect(
+      shouldAutoLeavePlanSideMode({
+        sideModeIsPlan: false,
+        planVisible: false,
+        userPinnedPlanSide: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldShowPlanChromeButton", () => {
+  it("shows for live plan", () => {
+    expect(
+      shouldShowPlanChromeButton({
+        planVisible: true,
+        composerMode: "agent",
+        userClosed: false,
+        userPinnedPlanSide: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("shows in plan mode and when closed / pinned", () => {
+    expect(
+      shouldShowPlanChromeButton({
+        planVisible: false,
+        composerMode: "plan",
+        userClosed: false,
+        userPinnedPlanSide: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowPlanChromeButton({
+        planVisible: false,
+        composerMode: "agent",
+        userClosed: true,
+        userPinnedPlanSide: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowPlanChromeButton({
+        planVisible: false,
+        composerMode: "agent",
+        userClosed: false,
+        userPinnedPlanSide: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides when idle agent with no pin", () => {
+    expect(
+      shouldShowPlanChromeButton({
+        planVisible: false,
+        composerMode: "agent",
+        userClosed: false,
+        userPinnedPlanSide: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("planHasExpandableContent / inner empty", () => {
+  it("detects body or entries", () => {
+    expect(planHasExpandableContent({ body: "  ", entries: [] })).toBe(false);
+    expect(planHasExpandableContent({ body: "# x", entries: [] })).toBe(true);
+    expect(
+      planHasExpandableContent({
+        body: "",
+        entries: [{ content: "a", status: "pending" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("inner empty distinguishes waiting vs blank", () => {
+    expect(
+      resolvePlanPanelInnerEmpty({
+        waiting: true,
+        hasExpandableContent: false,
+      }),
+    ).toBe("waiting");
+    expect(
+      resolvePlanPanelInnerEmpty({
+        waiting: false,
+        hasExpandableContent: false,
+      }),
+    ).toBe("blank");
+    expect(
+      resolvePlanPanelInnerEmpty({
+        waiting: true,
+        hasExpandableContent: true,
+      }),
+    ).toBeNull();
+    expect(planPanelInnerEmptyLabelKey("waiting")).toBe("plan.waiting");
+    expect(planPanelInnerEmptyLabelKey("blank")).toBe("plan.empty");
+  });
+});

--- a/src/lib/planModePro.ts
+++ b/src/lib/planModePro.ts
@@ -1,0 +1,196 @@
+/**
+ * PLAN-MODE-PRO — pure helpers for plan mode / plan panel UX.
+ *
+ * Contextual empty states for Resources → Plan, open-in-resources
+ * affordances on the sticky bar, and side-mode pin policy so empty
+ * states are actually reachable (not bounced back to Files).
+ *
+ * No DOM / Tauri / i18n side effects — callers pass `tr(key)`.
+ */
+
+import type { PlanBarKind, PlanBarModel } from "@/lib/planStatus";
+
+/** Empty-state kinds when Resources is on Plan but there is no live plan card. */
+export type PlanResourceEmptyKind =
+  | "disabled"
+  | "plan_mode"
+  | "user_closed"
+  | "idle";
+
+export type PlanResourceEmptyTitleKey =
+  | "resources.plan"
+  | "plan.waiting"
+  | "plan.emptyDisabledTitle"
+  | "plan.emptyClosedTitle";
+
+export type PlanResourceEmptyHintKey =
+  | "resources.planEmpty"
+  | "plan.emptyPlanModeHint"
+  | "plan.emptyDisabledHint"
+  | "plan.emptyClosedHint"
+  | "plan.emptyIdleHint";
+
+export type PlanResourceEmptyPresentation = {
+  kind: PlanResourceEmptyKind;
+  titleKey: PlanResourceEmptyTitleKey;
+  hintKey: PlanResourceEmptyHintKey;
+  /** Offer "Plan history" CTA when archive may help. */
+  showHistoryCta: boolean;
+};
+
+export type PlanResourceEmptyInput = {
+  /** Live plan chrome is showing (body / entries / gate). */
+  planVisible: boolean;
+  /** Settings: allow plan mode (spawn without --no-plan). */
+  planEnabled: boolean;
+  /** User hard-dismissed this plan cycle. */
+  userClosed: boolean;
+  /** Composer access mode (`plan` | `agent` | …). */
+  composerMode: string;
+  /** Local archive has at least one entry. */
+  hasHistory: boolean;
+};
+
+/**
+ * Resolve empty-state presentation for Resources → Plan.
+ * Returns `null` when the live PlanReviewPanel should render.
+ */
+export function resolvePlanResourceEmptyState(
+  input: PlanResourceEmptyInput,
+): PlanResourceEmptyPresentation | null {
+  if (input.planVisible) return null;
+
+  const hasHistory = !!input.hasHistory;
+
+  if (!input.planEnabled) {
+    return {
+      kind: "disabled",
+      titleKey: "plan.emptyDisabledTitle",
+      hintKey: "plan.emptyDisabledHint",
+      showHistoryCta: hasHistory,
+    };
+  }
+
+  if (input.userClosed) {
+    return {
+      kind: "user_closed",
+      titleKey: "plan.emptyClosedTitle",
+      hintKey: "plan.emptyClosedHint",
+      showHistoryCta: true,
+    };
+  }
+
+  if ((input.composerMode ?? "").trim().toLowerCase() === "plan") {
+    return {
+      kind: "plan_mode",
+      titleKey: "plan.waiting",
+      hintKey: "plan.emptyPlanModeHint",
+      showHistoryCta: hasHistory,
+    };
+  }
+
+  return {
+    kind: "idle",
+    titleKey: "resources.plan",
+    hintKey: hasHistory ? "plan.emptyIdleHint" : "resources.planEmpty",
+    showHistoryCta: hasHistory,
+  };
+}
+
+/**
+ * Sticky bar should offer 「在资源中打开」 for plan chrome kinds.
+ * Goal strip is unrelated; hidden never shows a bar.
+ */
+export function shouldOfferOpenInResources(input: {
+  barKind: PlanBarKind;
+  planVisible: boolean;
+}): boolean {
+  switch (input.barKind) {
+    case "plan_review":
+      return true;
+    case "plan_progress":
+      return !!input.planVisible;
+    case "plan_mode":
+      // Open Resources → Plan empty/waiting even before the agent drafts.
+      return true;
+    case "goal":
+    case "hidden":
+    default:
+      return false;
+  }
+}
+
+/**
+ * Convenience over a resolved bar model.
+ */
+export function shouldOfferOpenInResourcesFromModel(
+  model: Pick<PlanBarModel, "kind">,
+  planVisible: boolean,
+): boolean {
+  return shouldOfferOpenInResources({ barKind: model.kind, planVisible });
+}
+
+/**
+ * When plan becomes non-visible, leave Plan side only if the user did not
+ * pin it via open-in-resources / planFocusKey.
+ */
+export function shouldAutoLeavePlanSideMode(input: {
+  sideModeIsPlan: boolean;
+  planVisible: boolean;
+  userPinnedPlanSide: boolean;
+}): boolean {
+  if (!input.sideModeIsPlan) return false;
+  if (input.planVisible) return false;
+  if (input.userPinnedPlanSide) return false;
+  return true;
+}
+
+/**
+ * Whether the Resources chrome Plan toggle should appear.
+ * Visible plan, plan mode, hard-closed cycle, or user pin.
+ */
+export function shouldShowPlanChromeButton(input: {
+  planVisible: boolean;
+  composerMode: string;
+  userClosed: boolean;
+  userPinnedPlanSide: boolean;
+}): boolean {
+  if (input.planVisible) return true;
+  if (input.userPinnedPlanSide) return true;
+  if (input.userClosed) return true;
+  if ((input.composerMode ?? "").trim().toLowerCase() === "plan") return true;
+  return false;
+}
+
+/**
+ * Whether PlanReviewPanel has expandable body/steps (not a blank waiting card).
+ */
+export function planHasExpandableContent(input: {
+  body?: string | null;
+  entries?: unknown[] | null;
+}): boolean {
+  if ((input.body ?? "").trim()) return true;
+  if (Array.isArray(input.entries) && input.entries.length > 0) return true;
+  return false;
+}
+
+/**
+ * Empty copy inside an expanded PlanReviewPanel when body+entries are blank.
+ * Distinct from the Resources-level empty state (no live plan at all).
+ */
+export type PlanPanelInnerEmptyKind = "waiting" | "blank";
+
+export function resolvePlanPanelInnerEmpty(input: {
+  waiting: boolean;
+  hasExpandableContent: boolean;
+}): PlanPanelInnerEmptyKind | null {
+  if (input.hasExpandableContent) return null;
+  return input.waiting ? "waiting" : "blank";
+}
+
+/** Stable i18n key for PlanReviewPanel inner empty. */
+export function planPanelInnerEmptyLabelKey(
+  kind: PlanPanelInnerEmptyKind,
+): "plan.waiting" | "plan.empty" {
+  return kind === "waiting" ? "plan.waiting" : "plan.empty";
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8210,6 +8210,42 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
   color: var(--text-tertiary);
   font-size: 13px;
 }
+.plan-review__empty--waiting {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* PLAN-MODE-PRO — Resources → Plan contextual empty */
+.plan-resource-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 28px 24px;
+  max-width: 28rem;
+}
+.plan-resource-empty__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.plan-resource-empty__hint {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+.plan-resource-empty__cta {
+  margin-top: 8px;
+}
+.plan-resource-empty--plan_mode .plan-resource-empty__title {
+  color: var(--accent);
+}
+.plan-resource-empty--disabled .plan-resource-empty__hint {
+  color: var(--text-tertiary);
+}
+.plan-resource-empty--user_closed .plan-resource-empty__hint {
+  color: var(--text-tertiary);
+}
 .plan-review__steps {
   margin-top: 20px;
   padding-top: 16px;


### PR DESCRIPTION
## Summary

Plan mode / plan panel polish (**PLAN-MODE-PRO**):

- **Contextual empty states** for Resources → Plan: settings disabled · plan mode waiting · user-closed cycle · idle (with history CTA when archive exists)
- **Open in resources** from the sticky plan bar also works in **plan mode** before the agent drafts (opens Resources → Plan empty/waiting instead of bouncing to Files)
- **Pin policy**: user-opened Plan side stays on Plan empty after hard-dismiss / pre-draft; switching to Files/Changes unpins
- Chrome Plan toggle appears in plan mode / after close / when pinned (not only when a live plan is visible)
- Plan review panel distinguishes waiting vs blank inner empty
- Pure `src/lib/planModePro.ts` helpers + tests; i18n en/zh/zh-TW; Unreleased CHANGELOG

## Test plan

- [ ] `npm test -- --run src/lib/planModePro.test.ts src/i18n/messages.test.ts`
- [ ] Access → Plan mode → sticky bar shows **Open in resources** → Resources Plan empty says waiting / plan-mode hint
- [ ] Approve/dismiss flow: hard-dismiss while Plan pinned keeps **closed** empty + history CTA (no bounce to Files)
- [ ] Settings → Agent: turn off plan mode → Resources Plan empty shows disabled copy
- [ ] Live review gate still auto-opens Resources Plan with approve/request-changes
- [ ] Locale switch en/zh/zh-TW covers new empty strings