### PR TITLE
feat(mcp): OAuth recovery wizard with refresh and soft-fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+#### MCP
+- **OAuth recovery wizard**: multi-step GlassModal from MCP status modal and Extensions MCP rows — detect OAuth need → show server + reason → open sanitized auth URL (or honest TUI `/mcps` → `i` fallback when no headless `grok mcp oauth`) → “I’ve authorized” re-runs doctor → success / classified soft-fail (`no_url` · `no_cli_helper` · `open_url_failed` · `doctor_failed` · `still_needs_auth`). Pure step-machine helpers + vitest; secrets never logged; no `window.confirm`; en/zh/zh-TW
 #### Runtime / workflows
 - **Sandbox profile pro** (Settings → General → Permissions): polish OS sandbox presets (`off` / `workspace` / `read-only` / `strict` / `devbox`) with pure `sandboxProfile` helpers (spawn args/env, project resolve, danger confirm keys), **honest soft-fail** when CLI is missing/too old for `--sandbox` (flag omitted) or when the platform has no kernel enforcement (Windows honesty; Linux-only child-network note on macOS), Settings banners + recommended-workspace tip; Host soft-gates spawn flags on known-old CLI; i18n en/zh/zh-TW; `settingsCatalog`; tests
 - **Grok Build workflows** (Settings → Runtime → Tools): opt-in `workflowsEnabled` AppSettings toggle writes top-level `workflows_enabled` into independent agent-home `config.toml` (shared mode never rewrites `~/.grok`); honest copy that workflows run via CLI / Rhai (`workflow` tool, `/workflow`, `/workflows`) — **no in-app runner/editor**; read-only soft-fail discovery of `~/.grok/workflows` + project `.grok/workflows` names; command palette **Open workflows docs** / jump to settings; pure helpers + tests; `settingsCatalog` + en/zh/zh-TW
@@ -225,6 +227,7 @@ See `docs/llm-wiki/release.md`.
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**项目检查深度**（分区芯片、钩子/技能名清单、展开列表、分节复制 JSON/路径）
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**MCP doctor** 诊断结果列表（`mcp_doctor` + 扁平 findings；斜杠 MCP 弹窗可运行/筛选；与 inspect 刷新共存）
 - **扩展/市场**：**MCP OAuth GUI**（诊断标记需 OAuth / 凭证过期时显示「授权…」/「重试 OAuth」；打开脱敏后的授权 URL；无 URL 时 GlassModal 指引 TUI `/mcps` → `i`；无头 CLI 无 `mcp oauth`；不写客户端密钥日志）
+- **扩展/市场**：**MCP OAuth 恢复向导**（状态弹窗 + Extensions 多步 GlassModal：检测 → 服务器/原因 → 脱敏 URL 或 TUI 回退 →「我已授权」重跑 doctor → 成功/分类 soft-fail；纯 step-machine + 测试；无 `window.confirm`；en/zh/zh-TW）
 - **扩展/市场**：目录插件详情面板（描述/版本/组件徽章 + 安装/重装）；安装失败行内重试；已安装 provides 结构化摘要；**Hooks 试跑**（仅 hooks 目录内脚本、可选 JSON stdin、超时、脱敏输出；目录外拒绝；仅 exit 0 成功）
 - **权限/CLI**：**`--no-ask-user`**（设置 → 通用 → Agent；**CLI ≥ 0.2.117**）：顶层 flag 禁用 ask_user 问卷；可选会话覆盖（`null` 继承全局）；soft-respawn；纯 resolve/spawn 助手与测试
 - **权限/CLI**：**包含部分流式事件**（CLI 0.2.117+：`--include-partial-messages`；仅 `streaming-messages-json`；设置 → 运行时 → 进程池；远程 IM 升级 format；旧 CLI soft-fail）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9506,10 +9506,16 @@ export default function App() {
    * (must already exist in CLI config — host does not invent servers).
    */
   const runMcpDoctor = useCallback(
-    async (name?: string | null) => {
+    async (
+      name?: string | null,
+    ): Promise<{
+      report: api.McpDoctorReport | null;
+      error: string | null;
+    }> => {
       if (!api.isTauri()) {
-        setMcpDoctorError(tr("ext.needTauri"));
-        return;
+        const error = tr("ext.needTauri");
+        setMcpDoctorError(error);
+        return { report: null, error };
       }
       const focus = name?.trim() || null;
       setMcpDoctorFocus(focus);
@@ -9518,9 +9524,12 @@ export default function App() {
       try {
         const report = await api.mcpDoctor(focus);
         setMcpDoctorReport(report);
+        return { report, error: null };
       } catch (e) {
+        const error = String(e);
         setMcpDoctorReport(null);
-        setMcpDoctorError(String(e));
+        setMcpDoctorError(error);
+        return { report: null, error };
       } finally {
         setMcpDoctorLoading(false);
       }
@@ -20072,6 +20081,7 @@ export default function App() {
         doctorLoading={mcpDoctorLoading}
         doctorFocus={mcpDoctorFocus}
         onRunDoctor={(name) => void runMcpDoctor(name)}
+        onRefreshDoctor={(name) => runMcpDoctor(name)}
       />
       {rewindTimeline && (
         <div

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -67,9 +67,9 @@ import {
 import {
   classifyMcpOauthFromStatus,
   mcpOauthActionLabelKey,
-  planMcpOauthOpen,
-  redactMcpOauthText,
+  type McpOauthAction,
 } from "@/lib/mcpOauth";
+import { McpOauthWizard } from "@/components/McpOauthWizard";
 import {
   isSkillEditable,
   resolveSkillMdPath,
@@ -279,9 +279,9 @@ export function ExtensionsPanel({
   const [doctorStatusIndex, setDoctorStatusIndex] = useState<McpStatusIndex>(
     () => new Map(),
   );
-  /** In-app “How to refresh” guidance for auth-expired / auth-required. */
-  const [authHelpTarget, setAuthHelpTarget] = useState<{
-    name: string;
+  /** OAuth recovery wizard target (Authorize / Retry / How to refresh). */
+  const [oauthWizardTarget, setOauthWizardTarget] = useState<{
+    action: McpOauthAction;
     status: McpServerStatus;
   } | null>(null);
 
@@ -1170,8 +1170,12 @@ export function ExtensionsPanel({
   };
 
   const runDoctor = useCallback(
-    async (focusName?: string | null) => {
-      if (!api.isTauri()) return;
+    async (
+      focusName?: string | null,
+    ): Promise<{ report: unknown; error: string | null }> => {
+      if (!api.isTauri()) {
+        return { report: null, error: tr("ext.needTauri") };
+      }
       setDoctorOpen(true);
       setDoctorLoading(true);
       setDoctorError(null);
@@ -1188,12 +1192,38 @@ export function ExtensionsPanel({
           for (const [k, v] of next) merged.set(k, v);
           return merged;
         });
+        return { report, error: null };
       } catch (e) {
+        const error = String(e);
         setDoctorReport(null);
-        setDoctorError(String(e));
+        setDoctorError(error);
+        return { report: null, error };
       } finally {
         setDoctorLoading(false);
       }
+    },
+    [tr],
+  );
+
+  const openOauthWizard = useCallback(
+    (action: McpOauthAction | null, status: McpServerStatus) => {
+      if (action) {
+        setOauthWizardTarget({ action, status });
+        return;
+      }
+      // No OAuth classifier hit — still open wizard with a synthetic action
+      // so the user gets TUI / re-add instructions (soft-fail path).
+      const isRetry = status.tone === "auth_expired";
+      setOauthWizardTarget({
+        action: {
+          kind: isRetry ? "retry" : "authorize",
+          authUrls: [],
+          preferredUrl: null,
+          server: status.name,
+          isRetry,
+        },
+        status,
+      });
     },
     [],
   );
@@ -1992,20 +2022,7 @@ export function ExtensionsPanel({
                       <button
                         type="button"
                         className="btn btn--ghost btn--sm"
-                        onClick={() => {
-                          const plan = planMcpOauthOpen(oauthAction);
-                          if (plan?.mode === "open_url") {
-                            void api
-                              .openExternalUrl(plan.url)
-                              .catch((e) => {
-                                console.error(
-                                  "[mcp] open auth url failed",
-                                  redactMcpOauthText(String(e)),
-                                );
-                              });
-                          }
-                          setAuthHelpTarget({ name: s.name, status: st });
-                        }}
+                        onClick={() => openOauthWizard(oauthAction, st)}
                       >
                         {tr(
                           (oauthAction
@@ -2587,23 +2604,7 @@ export function ExtensionsPanel({
                           <button
                             type="button"
                             className="btn btn--ghost btn--sm"
-                            onClick={() => {
-                              const plan = planMcpOauthOpen(oauthAction);
-                              if (plan?.mode === "open_url") {
-                                void api
-                                  .openExternalUrl(plan.url)
-                                  .catch((e) => {
-                                    console.error(
-                                      "[mcp] open auth url failed",
-                                      redactMcpOauthText(String(e)),
-                                    );
-                                  });
-                              }
-                              setAuthHelpTarget({
-                                name: s.name,
-                                status: st,
-                              });
-                            }}
+                            onClick={() => openOauthWizard(oauthAction, st)}
                           >
                             {tr(
                               (oauthAction
@@ -2656,60 +2657,41 @@ export function ExtensionsPanel({
         )}
       </GlassModal>
 
-      <GlassModal
-        open={!!authHelpTarget}
-        onClose={() => setAuthHelpTarget(null)}
-        title={tr("ext.mcp.auth.refreshTitle", {
-          name: authHelpTarget?.name ?? "",
-        })}
-        size="md"
-        closeLabel={tr("common.close")}
-        wrapBody
-        footer={
-          <>
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={doctorLoading || cliMissing}
-              onClick={() => {
-                const name = authHelpTarget?.name;
-                setAuthHelpTarget(null);
-                if (name) void runDoctor(name);
-              }}
-            >
-              <IconDoctor size={14} />
-              <span>{tr("ext.mcp.doctorRerun")}</span>
-            </button>
-            <button
-              type="button"
-              className="btn btn--solid"
-              onClick={() => setAuthHelpTarget(null)}
-            >
-              {tr("common.close")}
-            </button>
-          </>
-        }
-      >
-        <p className="app-dialog__msg">
-          {authHelpTarget?.status.tone === "auth_expired"
-            ? tr("ext.mcp.auth.refreshLeadExpired")
-            : tr("ext.mcp.auth.refreshLeadRequired")}
-        </p>
-        {authHelpTarget?.status.reason ? (
-          <p className="ext-mcp-status-reason">
-            {redactMcpText(authHelpTarget.status.reason)}
-          </p>
-        ) : null}
-        <ol className="ext-mcp-auth-steps">
-          <li>{tr("mcpModal.oauth.stepTui")}</li>
-          <li>{tr("mcpModal.oauth.stepBrowser")}</li>
-          <li>{tr("ext.mcp.auth.stepReauth")}</li>
-          <li>{tr("ext.mcp.auth.stepReadd")}</li>
-          <li>{tr("ext.mcp.auth.stepRemoteUrl")}</li>
-          <li>{tr("ext.mcp.auth.stepDoctor")}</li>
-        </ol>
-        <p className="ext-field-hint">{tr("mcpModal.oauth.noCliHelper")}</p>
-      </GlassModal>
+      <McpOauthWizard
+        open={!!oauthWizardTarget}
+        locale={locale}
+        action={oauthWizardTarget?.action ?? null}
+        statusReason={oauthWizardTarget?.status.reason ?? null}
+        onClose={() => setOauthWizardTarget(null)}
+        onRefreshDoctor={async (serverName) => {
+          // Keep doctor modal closed when refreshing from wizard; still update index.
+          if (!api.isTauri()) {
+            return { report: null, error: tr("ext.needTauri") };
+          }
+          setDoctorLoading(true);
+          setDoctorError(null);
+          setDoctorFocus(serverName?.trim() || null);
+          try {
+            const report = await api.mcpDoctor(serverName?.trim() || null);
+            setDoctorReport(report);
+            setDoctorLastAt(Date.now());
+            const next = indexDoctorServerStatuses(report);
+            setDoctorStatusIndex((prev) => {
+              if (!serverName?.trim()) return next;
+              const merged = new Map(prev);
+              for (const [k, v] of next) merged.set(k, v);
+              return merged;
+            });
+            return { report, error: null };
+          } catch (e) {
+            const error = String(e);
+            setDoctorError(error);
+            return { report: null, error };
+          } finally {
+            setDoctorLoading(false);
+          }
+        }}
+      />
 
       <GlassModal
         open={skillNewOpen}

--- a/src/components/McpOauthWizard.tsx
+++ b/src/components/McpOauthWizard.tsx
@@ -1,0 +1,582 @@
+/**
+ * MCP OAuth recovery wizard (GlassModal steps).
+ *
+ * intro → auth URL / TUI instructions → “I’ve authorized” → doctor refresh
+ * → success / classified soft-fail.
+ *
+ * No window.confirm. No headless CLI oauth — honest TUI fallback copy.
+ * Secrets never logged; URLs sanitized via mcpOauth helpers.
+ */
+
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import type { Locale, MessageKey } from "@/i18n";
+import { createT } from "@/i18n";
+import { GlassModal } from "@/components/GlassModal";
+import {
+  IconDoctor,
+  IconExternalLink,
+  IconRefresh,
+} from "@/components/icons";
+import * as api from "@/lib/api";
+import {
+  redactMcpOauthText,
+  type McpOauthAction,
+} from "@/lib/mcpOauth";
+import {
+  createMcpOauthWizardState,
+  emptyMcpOauthWizardState,
+  evaluateMcpOauthDoctorRefresh,
+  mcpOauthWizardCanConfirmAuthorized,
+  mcpOauthWizardHasOpenableUrl,
+  mcpOauthWizardSoftFailLabelKey,
+  mcpOauthWizardStepIndex,
+  mcpOauthWizardStepLabelKey,
+  mcpOauthWizardTitleKey,
+  MCP_OAUTH_WIZARD_PROGRESS_TOTAL,
+  reduceMcpOauthWizard,
+  sanitizeMcpOauthWizardLog,
+  type McpOauthWizardState,
+} from "@/lib/mcpOauthWizard";
+import type { McpDoctorReportLike } from "@/lib/mcpStatus";
+
+export type McpOauthWizardDoctorRefreshResult = {
+  report?: McpDoctorReportLike | null;
+  error?: string | null;
+};
+
+export type McpOauthWizardProps = {
+  open: boolean;
+  locale: Locale;
+  /** Classified OAuth action; required when open. */
+  action: McpOauthAction | null;
+  /** Optional redacted reason from doctor status / finding. */
+  statusReason?: string | null;
+  onClose: () => void;
+  /**
+   * Soft-fail open browser URL (defaults to host `openExternalUrl`).
+   * Callers only receive sanitized http(s).
+   */
+  onOpenExternalUrl?: (url: string) => void | Promise<void>;
+  /**
+   * Re-run doctor after the user confirms authorization.
+   * Should update parent doctor state and return the latest report.
+   */
+  onRefreshDoctor?: (
+    serverName: string | null,
+  ) => Promise<McpOauthWizardDoctorRefreshResult>;
+};
+
+function softFailBadgeClass(
+  soft: McpOauthWizardState["softFail"],
+  step: McpOauthWizardState["step"],
+): string {
+  if (step === "success" || soft === "none") return "ext-badge--ok";
+  if (soft === "doctor_failed") return "ext-badge--fail";
+  // Soft guidance / still needs auth — warn, not hard crash.
+  return "ext-badge--warn";
+}
+
+export function McpOauthWizard({
+  open,
+  locale,
+  action,
+  statusReason,
+  onClose,
+  onOpenExternalUrl,
+  onRefreshDoctor,
+}: McpOauthWizardProps) {
+  const tr = useMemo(() => createT(locale), [locale]);
+  const [state, dispatch] = useReducer(
+    reduceMcpOauthWizard,
+    undefined,
+    emptyMcpOauthWizardState,
+  );
+  const [busy, setBusy] = useState(false);
+
+  // Seed when opened / target changes; reset when closed.
+  useEffect(() => {
+    if (!open || !action) {
+      if (!open) {
+        dispatch({ type: "reset" });
+        setBusy(false);
+      }
+      return;
+    }
+    const next = createMcpOauthWizardState({
+      action,
+      reason: statusReason ?? null,
+    });
+    dispatch({
+      type: "init",
+      input: {
+        action,
+        reason: statusReason ?? null,
+      },
+    });
+    setBusy(false);
+    // Safe snapshot only — no secrets / raw tokens.
+    try {
+      console.info(
+        "[mcp-oauth-wizard] open",
+        sanitizeMcpOauthWizardLog(next),
+      );
+    } catch {
+      /* ignore log failures */
+    }
+  }, [
+    open,
+    action?.server,
+    action?.kind,
+    action?.preferredUrl,
+    action?.isRetry,
+    statusReason,
+  ]);
+
+  const openExternal = useCallback(
+    async (url: string) => {
+      if (onOpenExternalUrl) {
+        await onOpenExternalUrl(url);
+        return;
+      }
+      if (!api.isTauri()) {
+        window.open(url, "_blank", "noopener,noreferrer");
+        return;
+      }
+      await api.openExternalUrl(url);
+    },
+    [onOpenExternalUrl],
+  );
+
+  const handleOpenUrl = useCallback(async () => {
+    const url = state.authUrl;
+    if (!url) return;
+    setBusy(true);
+    try {
+      await openExternal(url);
+      dispatch({ type: "open_url_ok" });
+    } catch (e) {
+      dispatch({
+        type: "open_url_error",
+        error: redactMcpOauthText(String(e)).slice(0, 240),
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [openExternal, state.authUrl]);
+
+  const runDoctorRefresh = useCallback(async () => {
+    const server = state.server;
+    dispatch({ type: "doctor_start" });
+    setBusy(true);
+    try {
+      let result: McpOauthWizardDoctorRefreshResult;
+      if (onRefreshDoctor) {
+        result = await onRefreshDoctor(server);
+      } else if (api.isTauri()) {
+        try {
+          const report = await api.mcpDoctor(server);
+          result = { report, error: null };
+        } catch (e) {
+          result = {
+            report: null,
+            error: redactMcpOauthText(String(e)).slice(0, 240),
+          };
+        }
+      } else {
+        result = {
+          report: null,
+          error: tr("ext.needTauri"),
+        };
+      }
+
+      const evaluated = evaluateMcpOauthDoctorRefresh({
+        report: result.report,
+        serverName: server,
+        doctorError: result.error,
+      });
+      dispatch({
+        type: "doctor_result",
+        stillNeedsAuth: evaluated.stillNeedsAuth,
+        reason: evaluated.reason,
+        doctorError:
+          evaluated.softFail === "doctor_failed"
+            ? evaluated.reason ?? result.error
+            : null,
+      });
+      try {
+        console.info(
+          "[mcp-oauth-wizard] doctor_result",
+          sanitizeMcpOauthWizardLog({
+            ...state,
+            step: evaluated.ok ? "success" : "fail",
+            softFail: evaluated.softFail,
+            softFailNonBlocking:
+              evaluated.softFail !== "none" &&
+              evaluated.softFail !== "doctor_failed",
+            reason: evaluated.reason,
+            errorMessage: evaluated.reason,
+            refreshAttempts: state.refreshAttempts + 1,
+          }),
+        );
+      } catch {
+        /* ignore */
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [onRefreshDoctor, state, tr]);
+
+  const handleIAuthorized = useCallback(() => {
+    if (!mcpOauthWizardCanConfirmAuthorized(state)) return;
+    void runDoctorRefresh();
+  }, [runDoctorRefresh, state]);
+
+  const handleClose = useCallback(() => {
+    if (busy && state.step === "refreshing") return;
+    dispatch({ type: "reset" });
+    onClose();
+  }, [busy, onClose, state.step]);
+
+  const serverName =
+    state.server || tr("mcpModal.oauth.unknownServer");
+  const stepIdx = mcpOauthWizardStepIndex(state.step);
+  const progressLabel = tr("mcpOauth.wizard.progress", {
+    n: Math.min(stepIdx + 1, MCP_OAUTH_WIZARD_PROGRESS_TOTAL),
+    total: MCP_OAUTH_WIZARD_PROGRESS_TOTAL,
+  });
+  const hasUrl = mcpOauthWizardHasOpenableUrl(state);
+  const showSoftChip =
+    state.softFail !== "none" ||
+    state.step === "success" ||
+    state.step === "fail";
+
+  const footer = (
+    <>
+      {state.step === "intro" ? (
+        <>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={handleClose}
+          >
+            {tr("common.cancel")}
+          </button>
+          <button
+            type="button"
+            className="btn btn--solid"
+            onClick={() => dispatch({ type: "continue" })}
+          >
+            {tr("mcpOauth.wizard.next")}
+          </button>
+        </>
+      ) : null}
+
+      {state.step === "auth" ? (
+        <>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            disabled={busy}
+            onClick={() => dispatch({ type: "back" })}
+          >
+            {tr("mcpOauth.wizard.back")}
+          </button>
+          {hasUrl ? (
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={busy}
+              onClick={() => void handleOpenUrl()}
+            >
+              <IconExternalLink size={14} />
+              <span>
+                {busy
+                  ? tr("mcpOauth.wizard.openingUrl")
+                  : tr("mcpModal.oauth.openUrl")}
+              </span>
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="btn btn--solid"
+            disabled={busy}
+            onClick={() => dispatch({ type: "continue" })}
+          >
+            {tr("mcpOauth.wizard.next")}
+          </button>
+        </>
+      ) : null}
+
+      {state.step === "waiting" ? (
+        <>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            disabled={busy}
+            onClick={() => dispatch({ type: "back" })}
+          >
+            {tr("mcpOauth.wizard.back")}
+          </button>
+          {hasUrl ? (
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={busy}
+              onClick={() => void handleOpenUrl()}
+            >
+              <IconExternalLink size={14} />
+              <span>{tr("mcpModal.oauth.openUrl")}</span>
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="btn btn--solid"
+            disabled={busy}
+            onClick={handleIAuthorized}
+          >
+            <IconDoctor size={14} />
+            <span>{tr("mcpOauth.wizard.iAuthorized")}</span>
+          </button>
+        </>
+      ) : null}
+
+      {state.step === "refreshing" ? (
+        <button type="button" className="btn btn--solid" disabled>
+          <IconRefresh size={14} />
+          <span>{tr("mcpOauth.wizard.refreshing")}</span>
+        </button>
+      ) : null}
+
+      {state.step === "success" ? (
+        <button
+          type="button"
+          className="btn btn--solid"
+          onClick={handleClose}
+        >
+          {tr("common.close")}
+        </button>
+      ) : null}
+
+      {state.step === "fail" ? (
+        <>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            disabled={busy}
+            onClick={() => dispatch({ type: "retry_auth" })}
+          >
+            {tr("mcpOauth.wizard.retryAuth")}
+          </button>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            disabled={busy}
+            onClick={() => {
+              dispatch({ type: "retry_refresh" });
+            }}
+          >
+            {tr("mcpOauth.wizard.retryRefresh")}
+          </button>
+          <button
+            type="button"
+            className="btn btn--solid"
+            disabled={busy}
+            onClick={() => void runDoctorRefresh()}
+          >
+            <IconDoctor size={14} />
+            <span>{tr("mcpOauth.wizard.iAuthorized")}</span>
+          </button>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={handleClose}
+          >
+            {tr("common.close")}
+          </button>
+        </>
+      ) : null}
+    </>
+  );
+
+  return (
+    <GlassModal
+      open={open && !!action}
+      onClose={handleClose}
+      title={tr(mcpOauthWizardTitleKey(state) as MessageKey, {
+        name: serverName,
+      })}
+      size="md"
+      closeLabel={tr("common.close")}
+      wrapBody
+      className="mcp-oauth-wizard"
+      bodyClassName="mcp-oauth-wizard__body"
+      closeOnOverlay={!busy || state.step !== "refreshing"}
+      showClose={!busy || state.step !== "refreshing"}
+      footer={footer}
+    >
+      <div className="mcp-oauth-wizard__progress" role="status">
+        <span className="mcp-oauth-wizard__progress-label">
+          {progressLabel}
+        </span>
+        <span className="mcp-oauth-wizard__progress-step">
+          {tr(mcpOauthWizardStepLabelKey(state.step) as MessageKey)}
+        </span>
+        <div
+          className="mcp-oauth-wizard__dots"
+          aria-hidden
+        >
+          {Array.from({ length: MCP_OAUTH_WIZARD_PROGRESS_TOTAL }, (_, i) => (
+            <span
+              key={i}
+              className={
+                "mcp-oauth-wizard__dot" +
+                (i <= stepIdx ? " is-active" : "") +
+                (i === stepIdx ? " is-current" : "") +
+                (state.step === "success" && i === stepIdx
+                  ? " is-ok"
+                  : "") +
+                (state.step === "fail" && i === stepIdx ? " is-fail" : "")
+              }
+            />
+          ))}
+        </div>
+      </div>
+
+      {showSoftChip && state.softFail !== "none" ? (
+        <p className="mcp-oauth-wizard__chip-row">
+          <span
+            className={
+              "ext-badge " + softFailBadgeClass(state.softFail, state.step)
+            }
+          >
+            {tr(mcpOauthWizardSoftFailLabelKey(state.softFail) as MessageKey)}
+          </span>
+          {state.softFailNonBlocking ? (
+            <span className="mcp-oauth-wizard__soft-hint">
+              {tr("mcpOauth.wizard.softHint")}
+            </span>
+          ) : null}
+        </p>
+      ) : null}
+
+      {state.step === "intro" ? (
+        <div className="mcp-oauth-wizard__panel">
+          <p className="app-dialog__msg">
+            {state.isRetry
+              ? tr("mcpModal.oauth.retryLead")
+              : tr("mcpModal.oauth.authorizeLead")}
+          </p>
+          <dl className="mcp-oauth-wizard__meta">
+            <div>
+              <dt>{tr("mcpOauth.wizard.serverLabel")}</dt>
+              <dd title={serverName}>{serverName}</dd>
+            </div>
+            {state.reason ? (
+              <div>
+                <dt>{tr("mcpOauth.wizard.reasonLabel")}</dt>
+                <dd>{state.reason}</dd>
+              </div>
+            ) : null}
+          </dl>
+          <p className="ext-field-hint">{tr("mcpModal.oauth.noCliHelper")}</p>
+        </div>
+      ) : null}
+
+      {state.step === "auth" ? (
+        <div className="mcp-oauth-wizard__panel">
+          <p className="app-dialog__msg">
+            {hasUrl
+              ? tr("mcpOauth.wizard.authLeadUrl")
+              : tr("mcpOauth.wizard.authLeadTui")}
+          </p>
+          {hasUrl && state.authUrl ? (
+            <p
+              className="mcp-modal__oauth-url"
+              title={state.authUrl}
+            >
+              <span className="mcp-modal__oauth-url-label">
+                {tr("mcpModal.oauth.urlLabel")}
+              </span>{" "}
+              <code className="mcp-modal__oauth-url-value">
+                {state.authUrl}
+              </code>
+            </p>
+          ) : null}
+          {state.errorMessage ? (
+            <p className="modal-status modal-status--error">
+              {state.errorMessage}
+            </p>
+          ) : null}
+          {state.urlOpened ? (
+            <p className="modal-status" role="status">
+              {tr("mcpOauth.wizard.urlOpened")}
+            </p>
+          ) : null}
+          <ol className="ext-mcp-auth-steps">
+            <li>{tr("mcpModal.oauth.stepTui")}</li>
+            <li>{tr("mcpModal.oauth.stepBrowser")}</li>
+            {!hasUrl ? (
+              <li>{tr("ext.mcp.auth.stepReauth")}</li>
+            ) : null}
+          </ol>
+          <p className="ext-field-hint">{tr("mcpModal.oauth.noCliHelper")}</p>
+        </div>
+      ) : null}
+
+      {state.step === "waiting" ? (
+        <div className="mcp-oauth-wizard__panel">
+          <p className="app-dialog__msg">
+            {tr("mcpOauth.wizard.waitingLead")}
+          </p>
+          <ol className="ext-mcp-auth-steps">
+            <li>{tr("mcpModal.oauth.stepDoctor")}</li>
+            <li>{tr("ext.mcp.auth.stepDoctor")}</li>
+          </ol>
+          <p className="ext-field-hint">
+            {tr("mcpOauth.wizard.waitingHint")}
+          </p>
+        </div>
+      ) : null}
+
+      {state.step === "refreshing" ? (
+        <div className="mcp-oauth-wizard__panel">
+          <p className="modal-status" role="status">
+            {tr("mcpOauth.wizard.refreshingDetail", { name: serverName })}
+          </p>
+        </div>
+      ) : null}
+
+      {state.step === "success" ? (
+        <div className="mcp-oauth-wizard__panel">
+          <p className="app-dialog__msg mcp-oauth-wizard__success">
+            {tr("mcpOauth.wizard.successLead", { name: serverName })}
+          </p>
+          {state.reason ? (
+            <p className="ext-mcp-status-reason">{state.reason}</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {state.step === "fail" ? (
+        <div className="mcp-oauth-wizard__panel">
+          <p className="app-dialog__msg">
+            {state.softFail === "doctor_failed"
+              ? tr("mcpOauth.wizard.failDoctor")
+              : tr("mcpOauth.wizard.failStillAuth", { name: serverName })}
+          </p>
+          {state.errorMessage || state.reason ? (
+            <p className="ext-mcp-status-reason">
+              {state.errorMessage || state.reason}
+            </p>
+          ) : null}
+          <ol className="ext-mcp-auth-steps">
+            <li>{tr("mcpModal.oauth.stepTui")}</li>
+            <li>{tr("ext.mcp.auth.stepReadd")}</li>
+            <li>{tr("mcpModal.oauth.stepDoctor")}</li>
+          </ol>
+          <p className="ext-field-hint">{tr("mcpModal.oauth.noCliHelper")}</p>
+        </div>
+      ) : null}
+    </GlassModal>
+  );
+}

--- a/src/components/McpStatusModal.tsx
+++ b/src/components/McpStatusModal.tsx
@@ -14,10 +14,9 @@ import {
   classifyMcpOauthFinding,
   classifyMcpOauthFromStatus,
   mcpOauthActionLabelKey,
-  planMcpOauthOpen,
-  redactMcpOauthText,
   type McpOauthAction,
 } from "@/lib/mcpOauth";
+import { McpOauthWizard } from "@/components/McpOauthWizard";
 import {
   classifyMcpRowHealth,
   countMcpDoctorFindings,
@@ -52,9 +51,11 @@ export type McpServerRow = {
 
 type TFn = (key: MessageKey, vars?: Record<string, string | number>) => string;
 
-type OauthHelpTarget = {
+type OauthWizardTarget = {
   action: McpOauthAction;
   status?: McpServerStatus | null;
+  /** Extra redacted reason (e.g. finding detail). */
+  reason?: string | null;
 };
 
 function healthFilterLabel(filter: McpRowStatusFilter, t: TFn): string {
@@ -163,6 +164,7 @@ export function McpStatusModal({
   doctorFocus,
   onRunDoctor,
   onOpenExternalUrl,
+  onRefreshDoctor,
 }: {
   open: boolean;
   locale: Locale;
@@ -187,14 +189,25 @@ export function McpStatusModal({
    * Never pass secrets — callers only receive sanitized http(s).
    */
   onOpenExternalUrl?: (url: string) => void | Promise<void>;
+  /**
+   * Optional doctor runner that returns the report so the OAuth wizard can
+   * evaluate success/soft-fail after “I’ve authorized”.
+   */
+  onRefreshDoctor?: (
+    name?: string | null,
+  ) => Promise<{
+    report?: McpDoctorReportLike | null;
+    error?: string | null;
+  }>;
 }) {
   const tr = useMemo(() => createT(locale), [locale]);
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<McpRowStatusFilter>("all");
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
-  const [oauthHelp, setOauthHelp] = useState<OauthHelpTarget | null>(null);
+  const [oauthWizard, setOauthWizard] = useState<OauthWizardTarget | null>(
+    null,
+  );
   const [oauthBusy, setOauthBusy] = useState(false);
-  const [oauthOpenError, setOauthOpenError] = useState<string | null>(null);
 
   const statusCounts = useMemo(() => countMcpRowsByHealth(servers), [servers]);
   const filtered = useMemo(
@@ -273,30 +286,46 @@ export function McpStatusModal({
   );
 
   const handleOauth = useCallback(
-    async (action: McpOauthAction, status?: McpServerStatus | null) => {
-      setOauthOpenError(null);
-      const plan = planMcpOauthOpen(action);
-      if (!plan) return;
-
-      if (plan.mode === "open_url") {
-        setOauthBusy(true);
-        try {
-          await openExternal(plan.url);
-          // Still show brief instructions so the user re-runs doctor after auth.
-          setOauthHelp({ action, status: status ?? null });
-        } catch (e) {
-          setOauthOpenError(redactMcpOauthText(String(e)).slice(0, 240));
-          setOauthHelp({ action, status: status ?? null });
-        } finally {
-          setOauthBusy(false);
-        }
-        return;
-      }
-
-      // No URL / no CLI helper — instructions only (GlassModal, never confirm()).
-      setOauthHelp({ action, status: status ?? null });
+    (
+      action: McpOauthAction,
+      status?: McpServerStatus | null,
+      reason?: string | null,
+    ) => {
+      // Open multi-step OAuth recovery wizard (never window.confirm).
+      setOauthWizard({
+        action,
+        status: status ?? null,
+        reason: reason ?? status?.reason ?? null,
+      });
     },
-    [openExternal],
+    [],
+  );
+
+  const refreshDoctorForWizard = useCallback(
+    async (serverName: string | null) => {
+      if (onRefreshDoctor) {
+        return onRefreshDoctor(serverName);
+      }
+      // Fallback: run host doctor and also notify parent (fire-and-forget).
+      setOauthBusy(true);
+      try {
+        if (!api.isTauri()) {
+          return { report: null, error: tr("ext.needTauri") };
+        }
+        try {
+          const report = await api.mcpDoctor(serverName);
+          onRunDoctor?.(serverName);
+          return { report, error: null };
+        } catch (e) {
+          const msg = String(e);
+          onRunDoctor?.(serverName);
+          return { report: null, error: msg };
+        }
+      } finally {
+        setOauthBusy(false);
+      }
+    },
+    [onRefreshDoctor, onRunDoctor, tr],
   );
 
   const copyField = useCallback(
@@ -316,11 +345,6 @@ export function McpStatusModal({
     },
     [],
   );
-
-  const oauthHelpName =
-    oauthHelp?.action.server ||
-    oauthHelp?.status?.name ||
-    tr("mcpModal.oauth.unknownServer");
 
   return (
     <>
@@ -725,7 +749,11 @@ export function McpStatusModal({
                               action.server,
                             )
                           : null;
-                        void handleOauth(action, st);
+                        handleOauth(
+                          action,
+                          st,
+                          st?.reason ?? null,
+                        );
                       }}
                       oauthBusy={oauthBusy}
                     />
@@ -744,105 +772,17 @@ export function McpStatusModal({
       ) : null}
     </GlassModal>
 
-    <GlassModal
-      open={!!oauthHelp}
-      onClose={() => {
-        setOauthHelp(null);
-        setOauthOpenError(null);
-      }}
-      title={tr(
-        oauthHelp?.action.isRetry
-          ? "mcpModal.oauth.retryTitle"
-          : "mcpModal.oauth.authorizeTitle",
-        { name: oauthHelpName },
-      )}
-      size="md"
-      closeLabel={tr("common.close")}
-      wrapBody
-      footer={
-        <>
-          {oauthHelp?.action.preferredUrl ? (
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={oauthBusy}
-              onClick={() => {
-                const url = oauthHelp.action.preferredUrl;
-                if (!url) return;
-                setOauthBusy(true);
-                void openExternal(url)
-                  .catch((e) => {
-                    setOauthOpenError(
-                      redactMcpOauthText(String(e)).slice(0, 240),
-                    );
-                  })
-                  .finally(() => setOauthBusy(false));
-              }}
-            >
-              <IconExternalLink size={14} />
-              <span>{tr("mcpModal.oauth.openUrl")}</span>
-            </button>
-          ) : null}
-          {canDoctor && oauthHelp?.action.server ? (
-            <button
-              type="button"
-              className="btn btn--ghost"
-              disabled={!!doctorLoading}
-              onClick={() => {
-                const name = oauthHelp.action.server;
-                setOauthHelp(null);
-                setOauthOpenError(null);
-                if (name) onRunDoctor?.(name);
-              }}
-            >
-              <IconDoctor size={14} />
-              <span>{tr("mcpModal.doctor.rerun")}</span>
-            </button>
-          ) : null}
-          <button
-            type="button"
-            className="btn btn--solid"
-            onClick={() => {
-              setOauthHelp(null);
-              setOauthOpenError(null);
-            }}
-          >
-            {tr("common.close")}
-          </button>
-        </>
+    <McpOauthWizard
+      open={!!oauthWizard}
+      locale={locale}
+      action={oauthWizard?.action ?? null}
+      statusReason={
+        oauthWizard?.reason ?? oauthWizard?.status?.reason ?? null
       }
-    >
-      <p className="app-dialog__msg">
-        {oauthHelp?.action.isRetry
-          ? tr("mcpModal.oauth.retryLead")
-          : tr("mcpModal.oauth.authorizeLead")}
-      </p>
-      {oauthHelp?.status?.reason ? (
-        <p className="ext-mcp-status-reason">
-          {redactMcpText(oauthHelp.status.reason)}
-        </p>
-      ) : null}
-      {oauthOpenError ? (
-        <p className="modal-status modal-status--error">{oauthOpenError}</p>
-      ) : null}
-      {oauthHelp?.action.preferredUrl ? (
-        <p className="mcp-modal__oauth-url" title={oauthHelp.action.preferredUrl}>
-          <span className="mcp-modal__oauth-url-label">
-            {tr("mcpModal.oauth.urlLabel")}
-          </span>{" "}
-          <code className="mcp-modal__oauth-url-value">
-            {oauthHelp.action.preferredUrl}
-          </code>
-        </p>
-      ) : null}
-      <ol className="ext-mcp-auth-steps">
-        <li>{tr("mcpModal.oauth.stepTui")}</li>
-        <li>{tr("mcpModal.oauth.stepBrowser")}</li>
-        <li>{tr("mcpModal.oauth.stepDoctor")}</li>
-        <li>{tr("ext.mcp.auth.stepReadd")}</li>
-      </ol>
-      <p className="ext-field-hint">{tr("mcpModal.oauth.noCliHelper")}</p>
-    </GlassModal>
+      onClose={() => setOauthWizard(null)}
+      onOpenExternalUrl={openExternal}
+      onRefreshDoctor={refreshDoctorForWizard}
+    />
     </>
   );
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -3607,6 +3607,48 @@ const en = {
     "There is no headless `grok mcp oauth` command — authorization is interactive (TUI) or via a doctor-provided browser URL. The app never stores client secrets in logs.",
   "mcpModal.oauth.unknownServer": "server",
 
+  // MCP OAuth recovery wizard
+  "mcpOauth.wizard.progress": "Step {n} of {total}",
+  "mcpOauth.wizard.next": "Continue",
+  "mcpOauth.wizard.back": "Back",
+  "mcpOauth.wizard.iAuthorized": "I’ve authorized — refresh doctor",
+  "mcpOauth.wizard.refreshing": "Refreshing doctor…",
+  "mcpOauth.wizard.refreshingDetail":
+    "Re-running MCP doctor for {name}. This does not invent success — wait for the report.",
+  "mcpOauth.wizard.openingUrl": "Opening…",
+  "mcpOauth.wizard.urlOpened": "Auth URL opened in your browser. Finish sign-in there, then continue.",
+  "mcpOauth.wizard.retryAuth": "Retry auth steps",
+  "mcpOauth.wizard.retryRefresh": "Back to confirm",
+  "mcpOauth.wizard.serverLabel": "Server",
+  "mcpOauth.wizard.reasonLabel": "Reason",
+  "mcpOauth.wizard.authLeadUrl":
+    "Open the sanitized auth URL below (query secrets stripped), complete the provider consent screen, then continue.",
+  "mcpOauth.wizard.authLeadTui":
+    "No doctor-provided browser URL for this server. Use the Grok Build TUI interactive OAuth flow, then continue.",
+  "mcpOauth.wizard.waitingLead":
+    "When the provider sign-in finishes and tokens are saved, confirm below to re-run MCP doctor.",
+  "mcpOauth.wizard.waitingHint":
+    "Doctor is the only honesty check — the app does not assume OAuth succeeded without a fresh report.",
+  "mcpOauth.wizard.successLead":
+    "Doctor no longer reports OAuth required for {name}. You can close this wizard.",
+  "mcpOauth.wizard.failDoctor":
+    "Could not refresh doctor. Fix the host/CLI issue below, then try again — this is a soft-fail, not a forced success.",
+  "mcpOauth.wizard.failStillAuth":
+    "Doctor still reports OAuth / auth issues for {name}. Complete the provider flow (or TUI), then refresh again.",
+  "mcpOauth.wizard.softHint": "Soft-fail — guidance only; not a hard crash.",
+  "mcpOauth.wizard.step.intro": "Server & reason",
+  "mcpOauth.wizard.step.auth": "Authorize",
+  "mcpOauth.wizard.step.waiting": "Confirm",
+  "mcpOauth.wizard.step.refreshing": "Doctor refresh",
+  "mcpOauth.wizard.step.success": "Success",
+  "mcpOauth.wizard.step.fail": "Needs attention",
+  "mcpOauth.wizard.soft.none": "OK",
+  "mcpOauth.wizard.soft.noUrl": "No auth URL",
+  "mcpOauth.wizard.soft.noCliHelper": "No headless OAuth CLI",
+  "mcpOauth.wizard.soft.openUrlFailed": "Could not open URL",
+  "mcpOauth.wizard.soft.doctorFailed": "Doctor refresh failed",
+  "mcpOauth.wizard.soft.stillNeedsAuth": "Still needs OAuth",
+
   // Settings → Extensions (Plugins + Skills + MCP)
   "ext.lead":
     "Manage plugins, skills, and MCP for this machine. Plugins are user-global; skills/MCP respect the active project when set.",
@@ -8590,6 +8632,48 @@ const zh: Record<MessageKey, string> = {
   "mcpModal.oauth.noCliHelper":
     "没有无头的 `grok mcp oauth` 命令 — 授权需交互（TUI）或通过诊断提供的浏览器 URL。应用不会将客户端密钥写入日志。",
   "mcpModal.oauth.unknownServer": "服务器",
+
+  // MCP OAuth recovery wizard
+  "mcpOauth.wizard.progress": "第 {n} / {total} 步",
+  "mcpOauth.wizard.next": "继续",
+  "mcpOauth.wizard.back": "上一步",
+  "mcpOauth.wizard.iAuthorized": "我已授权 — 刷新诊断",
+  "mcpOauth.wizard.refreshing": "正在刷新诊断…",
+  "mcpOauth.wizard.refreshingDetail":
+    "正在对 {name} 重新运行 MCP 诊断。不会假装成功 — 请等待报告。",
+  "mcpOauth.wizard.openingUrl": "正在打开…",
+  "mcpOauth.wizard.urlOpened": "已在浏览器打开授权 URL。请完成登录，然后继续。",
+  "mcpOauth.wizard.retryAuth": "重试授权步骤",
+  "mcpOauth.wizard.retryRefresh": "返回确认",
+  "mcpOauth.wizard.serverLabel": "服务器",
+  "mcpOauth.wizard.reasonLabel": "原因",
+  "mcpOauth.wizard.authLeadUrl":
+    "打开下方已消毒的授权 URL（查询串中的密钥已剥离），完成提供方同意页，然后继续。",
+  "mcpOauth.wizard.authLeadTui":
+    "诊断未提供该服务器的浏览器授权 URL。请使用 Grok Build TUI 交互式 OAuth，然后继续。",
+  "mcpOauth.wizard.waitingLead":
+    "提供方登录完成且令牌已保存后，点下方确认以重新运行 MCP 诊断。",
+  "mcpOauth.wizard.waitingHint":
+    "诊断是唯一的诚实校验 — 应用不会在没有新报告时假定 OAuth 已成功。",
+  "mcpOauth.wizard.successLead":
+    "诊断不再报告 {name} 需要 OAuth。可以关闭此向导。",
+  "mcpOauth.wizard.failDoctor":
+    "无法刷新诊断。请根据下方信息修复 Host/CLI 问题后重试 — 这是 soft-fail，不会强行标为成功。",
+  "mcpOauth.wizard.failStillAuth":
+    "诊断仍报告 {name} 存在 OAuth / 认证问题。请完成提供方流程（或 TUI）后再次刷新。",
+  "mcpOauth.wizard.softHint": "Soft-fail — 仅作指引，不是硬崩溃。",
+  "mcpOauth.wizard.step.intro": "服务器与原因",
+  "mcpOauth.wizard.step.auth": "授权",
+  "mcpOauth.wizard.step.waiting": "确认",
+  "mcpOauth.wizard.step.refreshing": "刷新诊断",
+  "mcpOauth.wizard.step.success": "成功",
+  "mcpOauth.wizard.step.fail": "需处理",
+  "mcpOauth.wizard.soft.none": "正常",
+  "mcpOauth.wizard.soft.noUrl": "无授权 URL",
+  "mcpOauth.wizard.soft.noCliHelper": "无无头 OAuth CLI",
+  "mcpOauth.wizard.soft.openUrlFailed": "无法打开 URL",
+  "mcpOauth.wizard.soft.doctorFailed": "诊断刷新失败",
+  "mcpOauth.wizard.soft.stillNeedsAuth": "仍需 OAuth",
 
   // Settings → Extensions (Plugins + Skills + MCP)
   "ext.lead":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -3474,6 +3474,48 @@ export const zhTW: Record<MessageKey, string> = {
     "沒有無頭的 `grok mcp oauth` 命令 — 授權需互動（TUI）或透過診斷提供的瀏覽器 URL。應用不會將用戶端密鑰寫入日誌。",
   "mcpModal.oauth.unknownServer": "伺服器",
 
+  // MCP OAuth recovery wizard
+  "mcpOauth.wizard.progress": "第 {n} / {total} 步",
+  "mcpOauth.wizard.next": "繼續",
+  "mcpOauth.wizard.back": "上一步",
+  "mcpOauth.wizard.iAuthorized": "我已授權 — 重新整理診斷",
+  "mcpOauth.wizard.refreshing": "正在重新整理診斷…",
+  "mcpOauth.wizard.refreshingDetail":
+    "正在對 {name} 重新執行 MCP 診斷。不會假裝成功 — 請等待報告。",
+  "mcpOauth.wizard.openingUrl": "正在開啟…",
+  "mcpOauth.wizard.urlOpened": "已在瀏覽器開啟授權 URL。請完成登入，然後繼續。",
+  "mcpOauth.wizard.retryAuth": "重試授權步驟",
+  "mcpOauth.wizard.retryRefresh": "返回確認",
+  "mcpOauth.wizard.serverLabel": "伺服器",
+  "mcpOauth.wizard.reasonLabel": "原因",
+  "mcpOauth.wizard.authLeadUrl":
+    "開啟下方已消毒的授權 URL（查詢字串中的密鑰已剝離），完成提供方同意頁，然後繼續。",
+  "mcpOauth.wizard.authLeadTui":
+    "診斷未提供該伺服器的瀏覽器授權 URL。請使用 Grok Build TUI 互動式 OAuth，然後繼續。",
+  "mcpOauth.wizard.waitingLead":
+    "提供方登入完成且權杖已儲存後，點下方確認以重新執行 MCP 診斷。",
+  "mcpOauth.wizard.waitingHint":
+    "診斷是唯一的誠實校驗 — 應用不會在沒有新報告時假定 OAuth 已成功。",
+  "mcpOauth.wizard.successLead":
+    "診斷不再報告 {name} 需要 OAuth。可以關閉此精靈。",
+  "mcpOauth.wizard.failDoctor":
+    "無法重新整理診斷。請依下方資訊修復 Host/CLI 問題後重試 — 這是 soft-fail，不會強行標為成功。",
+  "mcpOauth.wizard.failStillAuth":
+    "診斷仍報告 {name} 存在 OAuth / 認證問題。請完成提供方流程（或 TUI）後再次重新整理。",
+  "mcpOauth.wizard.softHint": "Soft-fail — 僅作指引，不是硬崩潰。",
+  "mcpOauth.wizard.step.intro": "伺服器與原因",
+  "mcpOauth.wizard.step.auth": "授權",
+  "mcpOauth.wizard.step.waiting": "確認",
+  "mcpOauth.wizard.step.refreshing": "重新整理診斷",
+  "mcpOauth.wizard.step.success": "成功",
+  "mcpOauth.wizard.step.fail": "需處理",
+  "mcpOauth.wizard.soft.none": "正常",
+  "mcpOauth.wizard.soft.noUrl": "無授權 URL",
+  "mcpOauth.wizard.soft.noCliHelper": "無無頭 OAuth CLI",
+  "mcpOauth.wizard.soft.openUrlFailed": "無法開啟 URL",
+  "mcpOauth.wizard.soft.doctorFailed": "診斷重新整理失敗",
+  "mcpOauth.wizard.soft.stillNeedsAuth": "仍需 OAuth",
+
   // Settings → Extensions (Plugins + Skills + MCP)
   "ext.lead":
     "管理本機外掛、技能與 MCP。外掛為使用者全域；有目前專案時技能/MCP 以該目錄為範圍。",

--- a/src/lib/mcpOauthWizard.test.ts
+++ b/src/lib/mcpOauthWizard.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyMcpOauthSource,
+} from "./mcpOauth";
+import {
+  createMcpOauthWizardState,
+  emptyMcpOauthWizardState,
+  evaluateMcpOauthDoctorRefresh,
+  isMcpOauthWizardSoftFailNonBlocking,
+  mcpOauthWizardCanConfirmAuthorized,
+  mcpOauthWizardCanContinue,
+  mcpOauthWizardHasOpenableUrl,
+  mcpOauthWizardSoftFailLabelKey,
+  mcpOauthWizardStepIndex,
+  mcpOauthWizardStepLabelKey,
+  mcpOauthWizardTitleKey,
+  reduceMcpOauthWizard,
+  sanitizeMcpOauthWizardLog,
+  type McpOauthWizardState,
+} from "./mcpOauthWizard";
+import type { McpDoctorReportLike } from "./mcpStatus";
+
+function authorizeAction(detail: string, server = "cloudflare-api") {
+  const action = classifyMcpOauthSource({
+    detail,
+    server,
+    tone: "auth_required",
+  });
+  if (!action) throw new Error("expected oauth action");
+  return action;
+}
+
+function retryAction(detail: string, server = "github") {
+  const action = classifyMcpOauthSource({
+    detail,
+    server,
+    tone: "auth_expired",
+  });
+  if (!action) throw new Error("expected oauth action");
+  return action;
+}
+
+describe("createMcpOauthWizardState", () => {
+  it("starts on intro with sanitized auth URL when present", () => {
+    const action = authorizeAction(
+      "OAuth authorization required — open https://login.example.com/oauth/authorize?client_id=app&access_token=SECRETOK",
+    );
+    const state = createMcpOauthWizardState({
+      action,
+      reason: "Bearer SECRETOK1234567890 needed",
+    });
+    expect(state.step).toBe("intro");
+    expect(state.server).toBe("cloudflare-api");
+    expect(state.kind).toBe("authorize");
+    expect(state.isRetry).toBe(false);
+    expect(state.authUrl).toBeTruthy();
+    expect(state.authUrl).not.toContain("SECRETOK");
+    expect(state.authUrl).not.toContain("access_token");
+    expect(state.reason).not.toContain("SECRETOK1234567890");
+    expect(state.openPlan?.mode).toBe("open_url");
+    expect(state.softFail).toBe("none");
+    expect(mcpOauthWizardHasOpenableUrl(state)).toBe(true);
+  });
+
+  it("marks no_cli_helper soft-fail when no URL (honest TUI path)", () => {
+    const action = authorizeAction("OAuth authorization required");
+    const state = createMcpOauthWizardState({ action });
+    expect(state.authUrl).toBeNull();
+    expect(state.openPlan?.mode).toBe("instructions");
+    expect(state.softFail).toBe("no_cli_helper");
+    expect(state.softFailNonBlocking).toBe(true);
+    expect(mcpOauthWizardHasOpenableUrl(state)).toBe(false);
+  });
+
+  it("uses retry title for expired credentials", () => {
+    const action = retryAction("OAuth token expired");
+    const state = createMcpOauthWizardState({ action });
+    expect(state.isRetry).toBe(true);
+    expect(mcpOauthWizardTitleKey(state)).toBe("mcpModal.oauth.retryTitle");
+  });
+});
+
+describe("reduceMcpOauthWizard step machine", () => {
+  function seeded(): McpOauthWizardState {
+    return createMcpOauthWizardState({
+      action: authorizeAction(
+        "authorize at https://auth.example.com/oauth/authorize?client_id=x",
+      ),
+      reason: "auth required",
+    });
+  }
+
+  it("intro → auth → waiting → refreshing → success", () => {
+    let s = seeded();
+    expect(mcpOauthWizardStepIndex(s.step)).toBe(0);
+    expect(mcpOauthWizardCanContinue(s)).toBe(true);
+
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    expect(s.step).toBe("auth");
+    expect(mcpOauthWizardStepIndex(s.step)).toBe(1);
+
+    s = reduceMcpOauthWizard(s, { type: "open_url_ok" });
+    expect(s.urlOpened).toBe(true);
+
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    expect(s.step).toBe("waiting");
+    expect(mcpOauthWizardCanConfirmAuthorized(s)).toBe(true);
+
+    s = reduceMcpOauthWizard(s, { type: "doctor_start" });
+    expect(s.step).toBe("refreshing");
+    expect(s.refreshAttempts).toBe(1);
+
+    s = reduceMcpOauthWizard(s, {
+      type: "doctor_result",
+      stillNeedsAuth: false,
+    });
+    expect(s.step).toBe("success");
+    expect(s.softFail).toBe("none");
+  });
+
+  it("open_url_error is soft-fail non-blocking on auth", () => {
+    let s = seeded();
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    s = reduceMcpOauthWizard(s, {
+      type: "open_url_error",
+      error: "spawn failed access_token=leakme",
+    });
+    expect(s.softFail).toBe("open_url_failed");
+    expect(s.softFailNonBlocking).toBe(true);
+    expect(s.errorMessage).toBeTruthy();
+    expect(s.errorMessage).not.toContain("leakme");
+    // Can still proceed to waiting.
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    expect(s.step).toBe("waiting");
+  });
+
+  it("doctor still needs auth → fail with still_needs_auth", () => {
+    let s = seeded();
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    s = reduceMcpOauthWizard(s, { type: "doctor_start" });
+    s = reduceMcpOauthWizard(s, {
+      type: "doctor_result",
+      stillNeedsAuth: true,
+      reason: "OAuth authorization required",
+    });
+    expect(s.step).toBe("fail");
+    expect(s.softFail).toBe("still_needs_auth");
+    expect(isMcpOauthWizardSoftFailNonBlocking(s.softFail)).toBe(true);
+  });
+
+  it("doctor host error → fail with doctor_failed", () => {
+    let s = seeded();
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    s = reduceMcpOauthWizard(s, { type: "doctor_start" });
+    s = reduceMcpOauthWizard(s, {
+      type: "doctor_result",
+      stillNeedsAuth: true,
+      doctorError: "CLI not found",
+    });
+    expect(s.step).toBe("fail");
+    expect(s.softFail).toBe("doctor_failed");
+  });
+
+  it("retry_auth and retry_refresh from fail", () => {
+    let s = seeded();
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    s = reduceMcpOauthWizard(s, { type: "doctor_start" });
+    s = reduceMcpOauthWizard(s, {
+      type: "doctor_result",
+      stillNeedsAuth: true,
+    });
+    s = reduceMcpOauthWizard(s, { type: "retry_auth" });
+    expect(s.step).toBe("auth");
+
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    s = reduceMcpOauthWizard(s, { type: "doctor_start" });
+    s = reduceMcpOauthWizard(s, {
+      type: "doctor_result",
+      stillNeedsAuth: true,
+    });
+    s = reduceMcpOauthWizard(s, { type: "retry_refresh" });
+    expect(s.step).toBe("waiting");
+  });
+
+  it("back navigates intro ← auth ← waiting", () => {
+    let s = seeded();
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    s = reduceMcpOauthWizard(s, { type: "continue" });
+    expect(s.step).toBe("waiting");
+    s = reduceMcpOauthWizard(s, { type: "back" });
+    expect(s.step).toBe("auth");
+    s = reduceMcpOauthWizard(s, { type: "back" });
+    expect(s.step).toBe("intro");
+  });
+
+  it("reset clears to empty", () => {
+    let s = seeded();
+    s = reduceMcpOauthWizard(s, { type: "reset" });
+    expect(s).toEqual(emptyMcpOauthWizardState());
+  });
+
+  it("ignores invalid transitions", () => {
+    const s = seeded();
+    expect(reduceMcpOauthWizard(s, { type: "doctor_start" })).toEqual(s);
+    expect(
+      reduceMcpOauthWizard(s, {
+        type: "doctor_result",
+        stillNeedsAuth: false,
+      }),
+    ).toEqual(s);
+  });
+});
+
+describe("evaluateMcpOauthDoctorRefresh", () => {
+  it("doctor_failed when error or missing report", () => {
+    expect(
+      evaluateMcpOauthDoctorRefresh({ doctorError: "timeout" }).softFail,
+    ).toBe("doctor_failed");
+    expect(evaluateMcpOauthDoctorRefresh({ report: null }).softFail).toBe(
+      "doctor_failed",
+    );
+  });
+
+  it("still_needs_auth when server status remains OAuth", () => {
+    const report: McpDoctorReportLike = {
+      ok: false,
+      servers: [
+        {
+          name: "github",
+          healthy: false,
+          status: "OAuth token expired",
+          issues: ["invalid_token — access token expired"],
+        },
+      ],
+    };
+    const r = evaluateMcpOauthDoctorRefresh({
+      report,
+      serverName: "github",
+    });
+    expect(r.stillNeedsAuth).toBe(true);
+    expect(r.softFail).toBe("still_needs_auth");
+    expect(r.ok).toBe(false);
+  });
+
+  it("success when server healthy after re-auth", () => {
+    const report: McpDoctorReportLike = {
+      ok: true,
+      servers: [
+        {
+          name: "github",
+          healthy: true,
+          status: "ok",
+        },
+      ],
+    };
+    const r = evaluateMcpOauthDoctorRefresh({
+      report,
+      serverName: "github",
+    });
+    expect(r.stillNeedsAuth).toBe(false);
+    expect(r.ok).toBe(true);
+    expect(r.softFail).toBe("none");
+  });
+
+  it("detects OAuth from findings when no server status map entry", () => {
+    const report: McpDoctorReportLike = {
+      ok: false,
+      issues: [
+        {
+          server: "lin",
+          message:
+            'AuthRequired (resource_metadata="https://auth.example.com/.well-known/oauth-protected-resource")',
+          level: "fail",
+        },
+      ],
+    };
+    const r = evaluateMcpOauthDoctorRefresh({
+      report,
+      serverName: "lin",
+    });
+    expect(r.stillNeedsAuth).toBe(true);
+    expect(r.softFail).toBe("still_needs_auth");
+  });
+});
+
+describe("labels / log sanitize", () => {
+  it("maps soft-fail and step keys", () => {
+    expect(mcpOauthWizardSoftFailLabelKey("no_cli_helper")).toBe(
+      "mcpOauth.wizard.soft.noCliHelper",
+    );
+    expect(mcpOauthWizardStepLabelKey("refreshing")).toBe(
+      "mcpOauth.wizard.step.refreshing",
+    );
+  });
+
+  it("sanitizeMcpOauthWizardLog never includes secrets or full query tokens", () => {
+    const action = authorizeAction(
+      "https://login.example.com/oauth/authorize?client_id=app&state=xyz",
+    );
+    const state = createMcpOauthWizardState({
+      action,
+      reason: "Bearer supersecrettokenvalue99",
+    });
+    const withErr = reduceMcpOauthWizard(
+      reduceMcpOauthWizard(state, { type: "continue" }),
+      {
+        type: "open_url_error",
+        error: "failed access_token=ABCSECRET123 client_secret=xyz",
+      },
+    );
+    const log = sanitizeMcpOauthWizardLog(withErr);
+    const blob = JSON.stringify(log);
+    expect(blob).not.toContain("supersecrettokenvalue99");
+    expect(blob).not.toContain("ABCSECRET123");
+    expect(blob).not.toContain("client_secret");
+    expect(log.hasAuthUrl).toBe(true);
+    expect(log.authHost).toBe("login.example.com");
+    expect(log.step).toBe("auth");
+    expect(log.softFail).toBe("open_url_failed");
+  });
+});

--- a/src/lib/mcpOauthWizard.ts
+++ b/src/lib/mcpOauthWizard.ts
@@ -1,0 +1,610 @@
+/**
+ * MCP OAuth recovery wizard — pure step machine.
+ *
+ * Flow:
+ *   intro → auth → waiting → refreshing → success | fail
+ *
+ * Soft-fails (never invents success):
+ * - no doctor-provided URL → TUI / instructions path (`no_url` / `no_cli_helper`)
+ * - open URL fails → stay on auth with `open_url_failed`
+ * - doctor still reports auth needed → fail with `still_needs_auth`
+ * - doctor host error → fail with `doctor_failed`
+ *
+ * Never logs secrets; URLs are pre-sanitized via mcpOauth helpers.
+ * CLI probe (0.2.117): no headless `grok mcp oauth` — TUI `/mcps` → `i`.
+ */
+
+import {
+  classifyMcpOauthFinding,
+  classifyMcpOauthFromStatus,
+  planMcpOauthOpen,
+  redactMcpOauthText,
+  sanitizeMcpAuthUrl,
+  type McpOauthAction,
+  type McpOauthActionKind,
+  type McpOauthOpenPlan,
+} from "@/lib/mcpOauth";
+import {
+  indexDoctorServerStatuses,
+  lookupServerStatus,
+  normalizeMcpDoctorFindings,
+  type McpDoctorReportLike,
+} from "@/lib/mcpStatus";
+
+/** Ordered wizard steps (UI progress). */
+export type McpOauthWizardStep =
+  | "intro"
+  | "auth"
+  | "waiting"
+  | "refreshing"
+  | "success"
+  | "fail";
+
+/** Classified soft-fail kinds for fail / auth guidance chips. */
+export type McpOauthWizardSoftFailKind =
+  | "none"
+  | "no_url"
+  | "no_cli_helper"
+  | "open_url_failed"
+  | "doctor_failed"
+  | "still_needs_auth";
+
+export type McpOauthWizardState = {
+  step: McpOauthWizardStep;
+  server: string | null;
+  kind: McpOauthActionKind;
+  isRetry: boolean;
+  /** Sanitized preferred auth URL (or null). */
+  authUrl: string | null;
+  /** Open plan for the auth step. */
+  openPlan: McpOauthOpenPlan | null;
+  /** Redacted doctor reason (one line). */
+  reason: string | null;
+  softFail: McpOauthWizardSoftFailKind;
+  /**
+   * Soft-fail is guidance / partial progress — UI should not treat as a hard
+   * crash (e.g. no URL → TUI path; open failed but user can retry).
+   */
+  softFailNonBlocking: boolean;
+  /** Redacted error / diagnostic for display (never secrets). */
+  errorMessage: string | null;
+  /** User successfully opened the browser URL this session. */
+  urlOpened: boolean;
+  /** Doctor refresh attempts after “I’ve authorized”. */
+  refreshAttempts: number;
+};
+
+export type McpOauthWizardInitInput = {
+  action: McpOauthAction;
+  /** Optional status reason / finding detail (will be redacted). */
+  reason?: string | null;
+  preferUrl?: string | null;
+};
+
+export type McpOauthWizardEvent =
+  | { type: "init"; input: McpOauthWizardInitInput }
+  | { type: "continue" }
+  | { type: "open_url_ok" }
+  | { type: "open_url_error"; error: string }
+  | { type: "i_authorized" }
+  | { type: "doctor_start" }
+  | {
+      type: "doctor_result";
+      stillNeedsAuth: boolean;
+      reason?: string | null;
+      doctorError?: string | null;
+    }
+  | { type: "retry_auth" }
+  | { type: "retry_refresh" }
+  | { type: "back" }
+  | { type: "reset" };
+
+/** Ordered steps for progress UI (terminal success/fail share slot 5). */
+export const MCP_OAUTH_WIZARD_STEP_ORDER: readonly McpOauthWizardStep[] = [
+  "intro",
+  "auth",
+  "waiting",
+  "refreshing",
+  "success",
+  "fail",
+] as const;
+
+/** Soft-fail kinds that are non-blocking guidance. */
+const NON_BLOCKING_SOFT: ReadonlySet<McpOauthWizardSoftFailKind> = new Set([
+  "no_url",
+  "no_cli_helper",
+  "open_url_failed",
+  "still_needs_auth",
+]);
+
+export function isMcpOauthWizardSoftFailNonBlocking(
+  kind: McpOauthWizardSoftFailKind,
+): boolean {
+  return NON_BLOCKING_SOFT.has(kind);
+}
+
+/** Progress index 0..3 for active path; success/fail → 4. */
+export function mcpOauthWizardStepIndex(step: McpOauthWizardStep): number {
+  switch (step) {
+    case "intro":
+      return 0;
+    case "auth":
+      return 1;
+    case "waiting":
+      return 2;
+    case "refreshing":
+      return 3;
+    case "success":
+    case "fail":
+      return 4;
+    default:
+      return 0;
+  }
+}
+
+/** Human-facing step count for progress (“Step 2 of 5”). */
+export const MCP_OAUTH_WIZARD_PROGRESS_TOTAL = 5;
+
+function softFromPlan(
+  plan: McpOauthOpenPlan | null,
+): McpOauthWizardSoftFailKind {
+  if (!plan) return "no_cli_helper";
+  if (plan.mode === "open_url") return "none";
+  if (plan.reason === "no_url") return "no_url";
+  return "no_cli_helper";
+}
+
+function redactLine(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const t = redactMcpOauthText(String(raw)).trim();
+  if (!t) return null;
+  return t.slice(0, 280);
+}
+
+/** Build initial wizard state from a classified OAuth action. */
+export function createMcpOauthWizardState(
+  input: McpOauthWizardInitInput,
+): McpOauthWizardState {
+  const { action } = input;
+  const prefer = sanitizeMcpAuthUrl(input.preferUrl ?? null);
+  const plan = planMcpOauthOpen(action, { preferUrl: prefer });
+  const authUrl =
+    plan?.mode === "open_url"
+      ? plan.url
+      : prefer ?? action.preferredUrl ?? null;
+  const soft = softFromPlan(plan);
+  return {
+    step: "intro",
+    server: action.server?.trim() || null,
+    kind: action.kind,
+    isRetry: action.isRetry || action.kind === "retry",
+    authUrl,
+    openPlan: plan,
+    reason: redactLine(input.reason),
+    softFail: soft,
+    softFailNonBlocking: isMcpOauthWizardSoftFailNonBlocking(soft),
+    errorMessage: null,
+    urlOpened: false,
+    refreshAttempts: 0,
+  };
+}
+
+/** Idle / closed placeholder (not open). */
+export function emptyMcpOauthWizardState(): McpOauthWizardState {
+  return {
+    step: "intro",
+    server: null,
+    kind: "authorize",
+    isRetry: false,
+    authUrl: null,
+    openPlan: null,
+    reason: null,
+    softFail: "none",
+    softFailNonBlocking: false,
+    errorMessage: null,
+    urlOpened: false,
+    refreshAttempts: 0,
+  };
+}
+
+function withSoft(
+  state: McpOauthWizardState,
+  soft: McpOauthWizardSoftFailKind,
+  errorMessage?: string | null,
+): Pick<
+  McpOauthWizardState,
+  "softFail" | "softFailNonBlocking" | "errorMessage"
+> {
+  return {
+    softFail: soft,
+    softFailNonBlocking: isMcpOauthWizardSoftFailNonBlocking(soft),
+    errorMessage:
+      errorMessage === undefined
+        ? state.errorMessage
+        : redactLine(errorMessage),
+  };
+}
+
+/**
+ * Pure reducer for the OAuth recovery wizard.
+ * Unknown transitions leave state unchanged.
+ */
+export function reduceMcpOauthWizard(
+  state: McpOauthWizardState,
+  event: McpOauthWizardEvent,
+): McpOauthWizardState {
+  switch (event.type) {
+    case "init":
+      return createMcpOauthWizardState(event.input);
+
+    case "reset":
+      return emptyMcpOauthWizardState();
+
+    case "continue": {
+      if (state.step === "intro") {
+        return { ...state, step: "auth" };
+      }
+      if (state.step === "auth") {
+        // Auth → waiting (user proceeds without / after opening URL).
+        return { ...state, step: "waiting", errorMessage: null };
+      }
+      return state;
+    }
+
+    case "open_url_ok": {
+      if (state.step !== "auth" && state.step !== "waiting") return state;
+      return {
+        ...state,
+        urlOpened: true,
+        ...withSoft(state, state.authUrl ? "none" : state.softFail, null),
+      };
+    }
+
+    case "open_url_error": {
+      if (state.step !== "auth" && state.step !== "waiting") return state;
+      return {
+        ...state,
+        ...withSoft(state, "open_url_failed", event.error),
+      };
+    }
+
+    case "i_authorized": {
+      if (state.step !== "waiting" && state.step !== "auth") return state;
+      // Jump to waiting first if still on auth, then parent fires doctor_start.
+      return {
+        ...state,
+        step: "waiting",
+        errorMessage: null,
+      };
+    }
+
+    case "doctor_start": {
+      if (
+        state.step !== "waiting" &&
+        state.step !== "fail" &&
+        state.step !== "auth"
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        step: "refreshing",
+        refreshAttempts: state.refreshAttempts + 1,
+        ...withSoft(state, "none", null),
+      };
+    }
+
+    case "doctor_result": {
+      if (state.step !== "refreshing" && state.step !== "waiting") {
+        return state;
+      }
+      const doctorErr = event.doctorError?.trim();
+      if (doctorErr) {
+        return {
+          ...state,
+          step: "fail",
+          reason: redactLine(event.reason) ?? state.reason,
+          ...withSoft(state, "doctor_failed", doctorErr),
+        };
+      }
+      if (event.stillNeedsAuth) {
+        return {
+          ...state,
+          step: "fail",
+          reason: redactLine(event.reason) ?? state.reason,
+          ...withSoft(
+            state,
+            "still_needs_auth",
+            event.reason ?? "OAuth still required after refresh",
+          ),
+        };
+      }
+      return {
+        ...state,
+        step: "success",
+        reason: redactLine(event.reason) ?? state.reason,
+        ...withSoft(state, "none", null),
+      };
+    }
+
+    case "retry_auth": {
+      if (state.step !== "fail" && state.step !== "success") return state;
+      return {
+        ...state,
+        step: "auth",
+        errorMessage: null,
+        softFail: softFromPlan(state.openPlan),
+        softFailNonBlocking: isMcpOauthWizardSoftFailNonBlocking(
+          softFromPlan(state.openPlan),
+        ),
+      };
+    }
+
+    case "retry_refresh": {
+      if (state.step !== "fail") return state;
+      return {
+        ...state,
+        step: "waiting",
+        ...withSoft(state, "none", null),
+      };
+    }
+
+    case "back": {
+      if (state.step === "auth") {
+        return { ...state, step: "intro", errorMessage: null };
+      }
+      if (state.step === "waiting") {
+        return { ...state, step: "auth", errorMessage: null };
+      }
+      if (state.step === "fail") {
+        return {
+          ...state,
+          step: "waiting",
+          ...withSoft(state, "none", null),
+        };
+      }
+      return state;
+    }
+
+    default:
+      return state;
+  }
+}
+
+/**
+ * Evaluate a doctor report after the user claims authorization completed.
+ * Pure — never invents healthy when report is missing.
+ */
+export function evaluateMcpOauthDoctorRefresh(opts: {
+  report?: McpDoctorReportLike | null;
+  serverName?: string | null;
+  doctorError?: string | null;
+}): {
+  stillNeedsAuth: boolean;
+  reason: string | null;
+  softFail: McpOauthWizardSoftFailKind;
+  ok: boolean;
+} {
+  const err = opts.doctorError?.trim();
+  if (err) {
+    return {
+      stillNeedsAuth: true,
+      reason: redactLine(err),
+      softFail: "doctor_failed",
+      ok: false,
+    };
+  }
+  const report = opts.report ?? null;
+  if (!report) {
+    return {
+      stillNeedsAuth: true,
+      reason: "Doctor report missing",
+      softFail: "doctor_failed",
+      ok: false,
+    };
+  }
+
+  const server = opts.serverName?.trim() || null;
+  const index = indexDoctorServerStatuses(report);
+  const status = server ? lookupServerStatus(index, server) : null;
+
+  if (status) {
+    const action = classifyMcpOauthFromStatus(status);
+    if (action) {
+      return {
+        stillNeedsAuth: true,
+        reason: redactLine(status.reason),
+        softFail: "still_needs_auth",
+        ok: false,
+      };
+    }
+    // Status present and not OAuth — success when healthy/ok/warn, else still fail soft.
+    if (status.tone === "error") {
+      // Non-auth error after re-auth: still not a full OAuth success, but OAuth path done.
+      // Treat as success for OAuth recovery (auth cleared) only when needsAuthRefresh is false.
+      if (!status.needsAuthRefresh) {
+        return {
+          stillNeedsAuth: false,
+          reason: redactLine(status.reason),
+          softFail: "none",
+          ok: true,
+        };
+      }
+    }
+    return {
+      stillNeedsAuth: false,
+      reason: redactLine(status.reason),
+      softFail: "none",
+      ok: true,
+    };
+  }
+
+  // No per-server status — scan findings for this server (or any OAuth if unnamed).
+  const findings = normalizeMcpDoctorFindings(report, {
+    server,
+    includeUnscoped: !server,
+  });
+  for (const row of findings) {
+    if (row.level === "ok") continue;
+    const action = classifyMcpOauthFinding(row);
+    if (action) {
+      return {
+        stillNeedsAuth: true,
+        reason: redactLine(row.detail || row.title),
+        softFail: "still_needs_auth",
+        ok: false,
+      };
+    }
+  }
+
+  // If doctor ok flag is true, treat as success.
+  if (report.ok === true) {
+    return {
+      stillNeedsAuth: false,
+      reason: null,
+      softFail: "none",
+      ok: true,
+    };
+  }
+
+  // Report present, no OAuth findings for this server → OAuth path cleared.
+  return {
+    stillNeedsAuth: false,
+    reason: null,
+    softFail: "none",
+    ok: true,
+  };
+}
+
+/** Whether primary continue is available on this step. */
+export function mcpOauthWizardCanContinue(
+  state: McpOauthWizardState,
+): boolean {
+  return state.step === "intro" || state.step === "auth";
+}
+
+/** Whether “I’ve authorized” is available. */
+export function mcpOauthWizardCanConfirmAuthorized(
+  state: McpOauthWizardState,
+): boolean {
+  return state.step === "waiting" || state.step === "auth";
+}
+
+/** Whether Open auth URL should be shown. */
+export function mcpOauthWizardHasOpenableUrl(
+  state: McpOauthWizardState,
+): boolean {
+  return Boolean(state.authUrl && state.openPlan?.mode === "open_url");
+}
+
+/** i18n key for the modal title. */
+export function mcpOauthWizardTitleKey(
+  state: McpOauthWizardState,
+):
+  | "mcpModal.oauth.authorizeTitle"
+  | "mcpModal.oauth.retryTitle" {
+  return state.isRetry
+    ? "mcpModal.oauth.retryTitle"
+    : "mcpModal.oauth.authorizeTitle";
+}
+
+/** i18n key for soft-fail / result chip. */
+export function mcpOauthWizardSoftFailLabelKey(
+  kind: McpOauthWizardSoftFailKind,
+):
+  | "mcpOauth.wizard.soft.none"
+  | "mcpOauth.wizard.soft.noUrl"
+  | "mcpOauth.wizard.soft.noCliHelper"
+  | "mcpOauth.wizard.soft.openUrlFailed"
+  | "mcpOauth.wizard.soft.doctorFailed"
+  | "mcpOauth.wizard.soft.stillNeedsAuth" {
+  switch (kind) {
+    case "no_url":
+      return "mcpOauth.wizard.soft.noUrl";
+    case "no_cli_helper":
+      return "mcpOauth.wizard.soft.noCliHelper";
+    case "open_url_failed":
+      return "mcpOauth.wizard.soft.openUrlFailed";
+    case "doctor_failed":
+      return "mcpOauth.wizard.soft.doctorFailed";
+    case "still_needs_auth":
+      return "mcpOauth.wizard.soft.stillNeedsAuth";
+    default:
+      return "mcpOauth.wizard.soft.none";
+  }
+}
+
+/** i18n key for step label in progress chrome. */
+export function mcpOauthWizardStepLabelKey(
+  step: McpOauthWizardStep,
+):
+  | "mcpOauth.wizard.step.intro"
+  | "mcpOauth.wizard.step.auth"
+  | "mcpOauth.wizard.step.waiting"
+  | "mcpOauth.wizard.step.refreshing"
+  | "mcpOauth.wizard.step.success"
+  | "mcpOauth.wizard.step.fail" {
+  switch (step) {
+    case "intro":
+      return "mcpOauth.wizard.step.intro";
+    case "auth":
+      return "mcpOauth.wizard.step.auth";
+    case "waiting":
+      return "mcpOauth.wizard.step.waiting";
+    case "refreshing":
+      return "mcpOauth.wizard.step.refreshing";
+    case "success":
+      return "mcpOauth.wizard.step.success";
+    case "fail":
+      return "mcpOauth.wizard.step.fail";
+  }
+}
+
+/**
+ * Extra scrub for log fields: drop secret-bearing key names entirely so logs
+ * never retain `access_token=` / `client_secret=` labels next to redactions.
+ */
+function scrubSecretKeyNames(text: string): string {
+  return text
+    .replace(
+      /\b(access_token|refresh_token|id_token|client_secret|api[_-]?key|authorization|bearer)\s*[=:]\s*(\S+)/gi,
+      "[REDACTED_CRED]",
+    )
+    .replace(/\b(access_token|refresh_token|id_token|client_secret)\b/gi, "[CRED]");
+}
+
+/**
+ * Safe snapshot for logs / diagnostics — never includes raw secrets or
+ * unsanitized URLs with tokens.
+ */
+export function sanitizeMcpOauthWizardLog(
+  state: McpOauthWizardState,
+): Record<string, string | number | boolean | null> {
+  const url = state.authUrl ? sanitizeMcpAuthUrl(state.authUrl) : null;
+  const err = state.errorMessage
+    ? scrubSecretKeyNames(redactMcpOauthText(state.errorMessage)).slice(0, 160)
+    : null;
+  return {
+    step: state.step,
+    server: state.server,
+    kind: state.kind,
+    isRetry: state.isRetry,
+    hasAuthUrl: Boolean(url),
+    // Host only — path only, no query (defensive).
+    authHost: url
+      ? (() => {
+          try {
+            return new URL(url).host;
+          } catch {
+            return null;
+          }
+        })()
+      : null,
+    softFail: state.softFail,
+    softFailNonBlocking: state.softFailNonBlocking,
+    urlOpened: state.urlOpened,
+    refreshAttempts: state.refreshAttempts,
+    // Redacted error only; never echo raw event payloads or secret key names.
+    errorMessage: err,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -18184,6 +18184,95 @@ div.composer__input:empty::before {
   color: var(--text-primary);
 }
 
+/* MCP OAuth recovery wizard */
+.mcp-oauth-wizard__body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.mcp-oauth-wizard__progress {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.mcp-oauth-wizard__progress-label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.mcp-oauth-wizard__progress-step {
+  color: var(--text-tertiary);
+}
+.mcp-oauth-wizard__dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+}
+.mcp-oauth-wizard__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--border-subtle, rgba(128, 128, 128, 0.28));
+}
+.mcp-oauth-wizard__dot.is-active {
+  background: color-mix(in srgb, var(--accent, #6b8afd) 55%, transparent);
+}
+.mcp-oauth-wizard__dot.is-current {
+  background: var(--accent, #6b8afd);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent, #6b8afd) 28%, transparent);
+}
+.mcp-oauth-wizard__dot.is-ok {
+  background: var(--ok, #3d9a6a);
+}
+.mcp-oauth-wizard__dot.is-fail {
+  background: var(--warn, #c9a227);
+}
+.mcp-oauth-wizard__chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 12px;
+}
+.mcp-oauth-wizard__soft-hint {
+  color: var(--text-tertiary);
+}
+.mcp-oauth-wizard__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.mcp-oauth-wizard__meta {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+}
+.mcp-oauth-wizard__meta > div {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: 8px;
+  align-items: start;
+}
+.mcp-oauth-wizard__meta dt {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-weight: 500;
+}
+.mcp-oauth-wizard__meta dd {
+  margin: 0;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+.mcp-oauth-wizard__success {
+  color: var(--text-primary);
+}
+
 /* Rewind timeline picker */
 .rewind-modal {
   width: min(var(--modal-width-md, 480px), 100%);


### PR DESCRIPTION
## Summary
- Multi-step **MCP OAuth recovery wizard** (GlassModal): detect OAuth need → show server + reason → open sanitized auth URL (or honest TUI `/mcps` → `i` when no headless `grok mcp oauth`) → **I’ve authorized** re-runs doctor → success / classified soft-fail.
- Pure step-machine helpers (`mcpOauthWizard`) + vitest: states, URL sanitize, log scrub (no secrets / secret key names).
- Wired from **McpStatusModal** (Authorize / Retry) and **Extensions** MCP rows (including doctor modal auth actions).
- Soft-fail kinds: `no_url` · `no_cli_helper` · `open_url_failed` · `doctor_failed` · `still_needs_auth` (never invents success).
- i18n en / zh / zh-TW; CHANGELOG; no `window.confirm`.

## Test plan
- [ ] Unit: `pnpm exec vitest run src/lib/mcpOauthWizard.test.ts src/lib/mcpOauth.test.ts src/i18n/messages.test.ts`
- [ ] Typecheck: `pnpm exec tsc -b`
- [ ] MCP status modal: Authorize / Retry opens wizard; progress steps work; cancel closes without confirm()
- [ ] With doctor-provided auth URL: Open URL uses sanitized https; secrets stripped from query
- [ ] Without URL: TUI instructions + no-CLI-helper soft chip
- [ ] “I’ve authorized” re-runs doctor; success when auth clears; fail chip when still needed / doctor error
- [ ] Extensions → MCP auth row opens the same wizard and updates doctor status index after refresh