### PR TITLE
feat(changes): batch accept and reject session diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+#### Composer & chat
+- **Diff accept batch** (Changes panel): **Accept all remaining** / **Reject all remaining** for session files (skips merge conflicts and already-decided paths; untracked wipe still needs in-app GlassModal confirm — never `window.confirm`); file-scoped **accept/reject all remaining hunks** when a multi-hunk diff is open; sequential host writes with busy/progress honesty and soft-fail partial summary toast; pure `planBatchAccept` / `planBatchReject` / `planBatchRemainingHunks` helpers + tests; en/zh/zh-TW
+
 #### Runtime / workflows
 - **Sandbox profile pro** (Settings → General → Permissions): polish OS sandbox presets (`off` / `workspace` / `read-only` / `strict` / `devbox`) with pure `sandboxProfile` helpers (spawn args/env, project resolve, danger confirm keys), **honest soft-fail** when CLI is missing/too old for `--sandbox` (flag omitted) or when the platform has no kernel enforcement (Windows honesty; Linux-only child-network note on macOS), Settings banners + recommended-workspace tip; Host soft-gates spawn flags on known-old CLI; i18n en/zh/zh-TW; `settingsCatalog`; tests
 - **Grok Build workflows** (Settings → Runtime → Tools): opt-in `workflowsEnabled` AppSettings toggle writes top-level `workflows_enabled` into independent agent-home `config.toml` (shared mode never rewrites `~/.grok`); honest copy that workflows run via CLI / Rhai (`workflow` tool, `/workflow`, `/workflows`) — **no in-app runner/editor**; read-only soft-fail discovery of `~/.grok/workflows` + project `.grok/workflows` names; command palette **Open workflows docs** / jump to settings; pure helpers + tests; `settingsCatalog` + en/zh/zh-TW

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -69,12 +69,21 @@ import {
 } from "@/lib/sessionChanges";
 import {
   applySelectedHunks,
+  batchSummaryVars,
   needsUntrackedWipeConfirm,
   parseUnifiedDiff,
+  planBatchAccept,
+  planBatchReject,
+  planBatchRemainingHunks,
   planFileAccept,
   planFileReject,
   planFileRestore,
   rejectSelectedHunks,
+  remainingHunkIndices,
+  summarizeBatchResults,
+  type BatchDiffPlan,
+  type BatchDiffResultItem,
+  type BatchFileInput,
   type UnifiedHunk,
 } from "@/lib/diffAccept";
 import {
@@ -396,6 +405,14 @@ export function ResourceViewer({
   const [pathCopyFlash, setPathCopyFlash] = useState(false);
   /** Accept / reject / restore in flight. */
   const [diffActionBusy, setDiffActionBusy] = useState(false);
+  /** Batch accept/reject progress (null when idle). */
+  const [batchProgress, setBatchProgress] = useState<{
+    action: "accept" | "reject";
+    current: number;
+    total: number;
+  } | null>(null);
+  /** Soft success / partial summary (dismissible; not a hard error). */
+  const [batchStatus, setBatchStatus] = useState<string | null>(null);
   /** Per-path decision badge after accept/reject. */
   const [diffDecisionByPath, setDiffDecisionByPath] = useState<
     Record<string, "accepted" | "rejected">
@@ -410,6 +427,13 @@ export function ResourceViewer({
     name: string;
     untracked: boolean;
   } | null>(null);
+  /** In-app confirm for batch reject (session / remaining hunks). */
+  const [batchRejectConfirm, setBatchRejectConfirm] = useState<{
+    plan: BatchDiffPlan;
+    untracked: boolean;
+  } | null>(null);
+  /** In-app confirm for file-scoped reject-all-remaining hunks. */
+  const [batchHunkRejectConfirm, setBatchHunkRejectConfirm] = useState(false);
   /** Open-with target for the location button (finder / editor id). */
   const [openWithTarget, setOpenWithTarget] = useState(() => {
     try {
@@ -1303,6 +1327,455 @@ export function ResourceViewer({
       tr,
     ],
   );
+
+  /** Build BatchFileInput list for session (or single-file) remaining. */
+  const buildSessionBatchInputs = useCallback((): BatchFileInput[] => {
+    return sessionChanges.map((c) => {
+      const key = normalizePath(c.path);
+      return {
+        path: c.path,
+        name: c.name,
+        kind: kindForPath(c.path),
+        after: typeof c.after === "string" ? c.after : null,
+        before: typeof c.before === "string" ? c.before : null,
+        decision: key ? (diffDecisionByPath[key] ?? null) : null,
+        fileExists: true,
+      };
+    });
+  }, [sessionChanges, kindForPath, diffDecisionByPath]);
+
+  /** Host write for one accept plan entry (no busy flag). */
+  const hostAcceptOne = useCallback(
+    async (
+      path: string,
+      after: string | null | undefined,
+    ): Promise<BatchDiffResultItem> => {
+      const name = pathBaseName(path);
+      try {
+        const plan = planFileAccept({ after });
+        if (plan.mode === "write_after") {
+          const res = await api.applyFilePatch(projectPath!, path, plan.content);
+          if (!res.ok) {
+            return {
+              path,
+              name,
+              status: "soft_fail",
+              reason: res.reason || "write failed",
+            };
+          }
+          rememberRestorable(path, plan.content);
+        } else if (plan.mode === "unavailable") {
+          return { path, name, status: "skipped", reason: plan.reason };
+        }
+        markDecision(path, "accepted");
+        return { path, name, status: "ok" };
+      } catch (e) {
+        return { path, name, status: "error", reason: String(e) };
+      }
+    },
+    [projectPath, rememberRestorable, markDecision],
+  );
+
+  /** Host reject for one file (confirmed when wipe already approved). */
+  const hostRejectOne = useCallback(
+    async (
+      path: string,
+      opts: {
+        confirmed: boolean;
+        kind?: string | null;
+        before?: string | null;
+        after?: string | null;
+      },
+    ): Promise<BatchDiffResultItem> => {
+      const name = pathBaseName(path);
+      try {
+        if (typeof opts.after === "string") {
+          rememberRestorable(path, opts.after);
+        }
+        const plan = planFileReject({
+          hasGitRepo: workspaceAvailable,
+          kind: opts.kind,
+          before: opts.before,
+          fileExists: true,
+        });
+        if (plan.mode === "git") {
+          if (plan.confirmUntracked && !opts.confirmed) {
+            return {
+              path,
+              name,
+              status: "skipped",
+              reason: "needs untracked confirm",
+            };
+          }
+          const res = await api.gitCheckoutFile(
+            projectPath!,
+            path,
+            plan.confirmUntracked && opts.confirmed,
+          );
+          if (res.needsUntrackedConfirm) {
+            return {
+              path,
+              name,
+              status: "skipped",
+              reason: "needs untracked confirm",
+            };
+          }
+          if (!res.ok) {
+            const reason = (res.reason || "").toLowerCase();
+            const softGit =
+              reason.includes("not a git") ||
+              reason.includes("git not available") ||
+              reason.includes("not available");
+            if (softGit && typeof opts.before === "string") {
+              const w = await api.applyFilePatch(
+                projectPath!,
+                path,
+                opts.before,
+              );
+              if (!w.ok) {
+                return {
+                  path,
+                  name,
+                  status: "soft_fail",
+                  reason: w.reason || res.reason || "reject failed",
+                };
+              }
+            } else {
+              return {
+                path,
+                name,
+                status: "soft_fail",
+                reason: res.reason || "reject failed",
+              };
+            }
+          }
+        } else if (plan.mode === "write_before") {
+          const res = await api.applyFilePatch(
+            projectPath!,
+            path,
+            plan.content,
+          );
+          if (!res.ok) {
+            return {
+              path,
+              name,
+              status: "soft_fail",
+              reason: res.reason || "write failed",
+            };
+          }
+        } else if (plan.mode === "delete") {
+          if (!opts.confirmed) {
+            return {
+              path,
+              name,
+              status: "skipped",
+              reason: "needs untracked confirm",
+            };
+          }
+          const res = await api.deleteProjectFile(projectPath!, path, true);
+          if (!res.ok) {
+            return {
+              path,
+              name,
+              status: "soft_fail",
+              reason: res.reason || "delete failed",
+            };
+          }
+        } else {
+          return { path, name, status: "skipped", reason: plan.reason };
+        }
+        markDecision(path, "rejected");
+        return { path, name, status: "ok" };
+      } catch (e) {
+        return { path, name, status: "error", reason: String(e) };
+      }
+    },
+    [projectPath, workspaceAvailable, rememberRestorable, markDecision],
+  );
+
+  const publishBatchSummary = useCallback(
+    (action: "accept" | "reject", items: BatchDiffResultItem[]) => {
+      const summary = summarizeBatchResults(action, items);
+      const vars = batchSummaryVars(summary);
+      if (summary.error + summary.softFail > 0) {
+        setError(
+          tr(
+            action === "accept"
+              ? "changes.batchAcceptSummary"
+              : "changes.batchRejectSummary",
+            vars,
+          ),
+        );
+        setBatchStatus(null);
+      } else {
+        setError(null);
+        setBatchStatus(
+          tr(
+            action === "accept"
+              ? "changes.batchAcceptSummary"
+              : "changes.batchRejectSummary",
+            vars,
+          ),
+        );
+      }
+    },
+    [tr],
+  );
+
+  const executeBatchAccept = useCallback(
+    async (plan: BatchDiffPlan) => {
+      if (!projectPath || !api.isTauri() || !plan.canRun) return;
+      setDiffActionBusy(true);
+      setBatchStatus(null);
+      setError(null);
+      const results: BatchDiffResultItem[] = plan.skipped.map((e) => ({
+        path: e.path,
+        name: e.name,
+        status: "skipped" as const,
+        reason:
+          e.outcome.kind === "skip"
+            ? e.outcome.reason
+            : undefined,
+      }));
+      const total = plan.run.length;
+      let current = 0;
+      setBatchProgress({ action: "accept", current: 0, total });
+      try {
+        for (const entry of plan.run) {
+          current += 1;
+          setBatchProgress({ action: "accept", current, total });
+          const after =
+            entry.outcome.kind === "run" &&
+            entry.outcome.run.action === "accept" &&
+            entry.outcome.run.plan.mode === "write_after"
+              ? entry.outcome.run.plan.content
+              : sessionChanges.find(
+                  (c) => normalizePath(c.path) === normalizePath(entry.path),
+                )?.after ?? null;
+          const r = await hostAcceptOne(entry.path, after);
+          results.push(r);
+        }
+        publishBatchSummary("accept", results);
+        void refreshWorkspaceStatus();
+      } finally {
+        setBatchProgress(null);
+        setDiffActionBusy(false);
+      }
+    },
+    [
+      projectPath,
+      hostAcceptOne,
+      publishBatchSummary,
+      refreshWorkspaceStatus,
+      sessionChanges,
+    ],
+  );
+
+  const executeBatchReject = useCallback(
+    async (plan: BatchDiffPlan, confirmed: boolean) => {
+      if (!projectPath || !api.isTauri() || !plan.canRun) return;
+      setBatchRejectConfirm(null);
+      setDiffActionBusy(true);
+      setBatchStatus(null);
+      setError(null);
+      const results: BatchDiffResultItem[] = plan.skipped.map((e) => ({
+        path: e.path,
+        name: e.name,
+        status: "skipped" as const,
+        reason:
+          e.outcome.kind === "skip" ? e.outcome.reason : undefined,
+      }));
+      const total = plan.run.length;
+      let current = 0;
+      setBatchProgress({ action: "reject", current: 0, total });
+      try {
+        for (const entry of plan.run) {
+          current += 1;
+          setBatchProgress({ action: "reject", current, total });
+          const sc = sessionChanges.find(
+            (c) => normalizePath(c.path) === normalizePath(entry.path),
+          );
+          const needsWipe =
+            entry.outcome.kind === "run" &&
+            entry.outcome.run.action === "reject" &&
+            entry.outcome.run.needsUntrackedConfirm;
+          const r = await hostRejectOne(entry.path, {
+            confirmed: confirmed || !needsWipe,
+            kind: entry.kind,
+            before: typeof sc?.before === "string" ? sc.before : null,
+            after: typeof sc?.after === "string" ? sc.after : null,
+          });
+          results.push(r);
+        }
+        publishBatchSummary("reject", results);
+        void refreshWorkspaceStatus();
+      } finally {
+        setBatchProgress(null);
+        setDiffActionBusy(false);
+      }
+    },
+    [
+      projectPath,
+      hostRejectOne,
+      publishBatchSummary,
+      refreshWorkspaceStatus,
+      sessionChanges,
+    ],
+  );
+
+  const requestBatchAcceptSession = useCallback(() => {
+    if (!projectPath || !api.isTauri() || diffActionBusy) return;
+    const plan = planBatchAccept(buildSessionBatchInputs(), {
+      scope: "session",
+    });
+    if (!plan.canRun) {
+      setBatchStatus(tr("changes.batchNothingRemaining"));
+      return;
+    }
+    void executeBatchAccept(plan);
+  }, [
+    projectPath,
+    diffActionBusy,
+    buildSessionBatchInputs,
+    executeBatchAccept,
+    tr,
+  ]);
+
+  const requestBatchRejectSession = useCallback(() => {
+    if (!projectPath || !api.isTauri() || diffActionBusy) return;
+    const plan = planBatchReject(buildSessionBatchInputs(), {
+      hasGitRepo: workspaceAvailable,
+      scope: "session",
+    });
+    if (!plan.canRun) {
+      setBatchStatus(tr("changes.batchNothingRemaining"));
+      return;
+    }
+    // Always confirm batch reject; stronger copy when untracked wipes included.
+    setBatchRejectConfirm({
+      plan,
+      untracked: plan.untrackedConfirmCount > 0,
+    });
+  }, [
+    projectPath,
+    diffActionBusy,
+    buildSessionBatchInputs,
+    workspaceAvailable,
+    tr,
+  ]);
+
+  const remainingHunkCount = useMemo(
+    () => remainingHunkIndices(diffHunks.length, []).length,
+    [diffHunks.length],
+  );
+
+  const runBatchRemainingHunks = useCallback(
+    async (action: "accept" | "reject") => {
+      if (!projectPath || !api.isTauri() || !diffView || diffActionBusy) return;
+      const plan = planBatchRemainingHunks({
+        action,
+        hunks: diffHunks,
+        before:
+          typeof diffView.beforeText === "string" ? diffView.beforeText : null,
+        after:
+          typeof diffView.afterText === "string" ? diffView.afterText : null,
+      });
+      if (!plan.ok) {
+        setError(
+          tr("changes.actionUnavailable", {
+            reason: plan.detail || plan.reason,
+          }),
+        );
+        return;
+      }
+      setDiffActionBusy(true);
+      setBatchStatus(null);
+      setError(null);
+      setBatchProgress({
+        action,
+        current: 0,
+        total: plan.indices.length,
+      });
+      try {
+        if (action === "reject") {
+          rememberRestorable(diffView.path, diffView.afterText);
+        }
+        const res = await api.applyFilePatch(
+          projectPath,
+          diffView.path,
+          plan.content,
+        );
+        setBatchProgress({
+          action,
+          current: plan.indices.length,
+          total: plan.indices.length,
+        });
+        if (!res.ok) {
+          setError(
+            tr("changes.actionFailed", {
+              reason: res.reason || "hunk batch write failed",
+            }),
+          );
+          return;
+        }
+        if (action === "accept") {
+          rememberRestorable(diffView.path, plan.content);
+          markDecision(diffView.path, "accepted");
+        } else {
+          markDecision(diffView.path, "rejected");
+        }
+        setDiffView((prev) => {
+          if (!prev) return prev;
+          const before =
+            typeof prev.beforeText === "string" ? prev.beforeText : null;
+          const rel =
+            pathRelativeToProject(prev.path, projectPath) || prev.name;
+          return {
+            ...prev,
+            afterText: plan.content,
+            unified:
+              before != null
+                ? buildUnifiedDiff(rel, before, plan.content)
+                : prev.unified,
+          };
+        });
+        setBatchStatus(
+          tr(
+            action === "accept"
+              ? "changes.batchHunksAcceptDone"
+              : "changes.batchHunksRejectDone",
+            { n: String(plan.indices.length) },
+          ),
+        );
+        void refreshWorkspaceStatus();
+      } catch (e) {
+        setError(tr("changes.actionFailed", { reason: String(e) }));
+      } finally {
+        setBatchProgress(null);
+        setDiffActionBusy(false);
+        setBatchHunkRejectConfirm(false);
+      }
+    },
+    [
+      projectPath,
+      diffView,
+      diffHunks,
+      diffActionBusy,
+      rememberRestorable,
+      markDecision,
+      refreshWorkspaceStatus,
+      tr,
+    ],
+  );
+
+  const requestBatchAcceptHunks = useCallback(() => {
+    void runBatchRemainingHunks("accept");
+  }, [runBatchRemainingHunks]);
+
+  const requestBatchRejectHunks = useCallback(() => {
+    if (!diffView || remainingHunkCount === 0 || diffActionBusy) return;
+    setBatchHunkRejectConfirm(true);
+  }, [diffView, remainingHunkCount, diffActionBusy]);
 
   const showSidePanel = (mode: SideMode) => {
     // Plan mode uses full-width review (no side tree).
@@ -2293,6 +2766,36 @@ export function ResourceViewer({
             aria-label={tr("changes.hunks")}
           >
             <span className="rp-diff-hunks__label">{tr("changes.hunks")}</span>
+            {remainingHunkCount > 1 ? (
+              <div className="rp-diff-hunks__batch" role="group">
+                <Tip label={tr("changes.acceptAllHunksTip")}>
+                  <button
+                    type="button"
+                    className="chrome-btn rp-diff-action rp-diff-action--accept rp-changes-batch-btn"
+                    disabled={!tauriReady || diffActionBusy}
+                    data-testid="changes-accept-all-hunks"
+                    onClick={() => requestBatchAcceptHunks()}
+                    aria-label={tr("changes.acceptAllHunks")}
+                  >
+                    <IconCheck size={12} />
+                    <span>{tr("changes.acceptAllRemainingShort")}</span>
+                  </button>
+                </Tip>
+                <Tip label={tr("changes.rejectAllHunksTip")}>
+                  <button
+                    type="button"
+                    className="chrome-btn rp-diff-action rp-diff-action--reject rp-changes-batch-btn"
+                    disabled={!tauriReady || diffActionBusy}
+                    data-testid="changes-reject-all-hunks"
+                    onClick={() => requestBatchRejectHunks()}
+                    aria-label={tr("changes.rejectAllHunks")}
+                  >
+                    <IconClose size={12} />
+                    <span>{tr("changes.rejectAllRemainingShort")}</span>
+                  </button>
+                </Tip>
+              </div>
+            ) : null}
             {diffHunks.map((h, idx) => (
               <div key={`${h.header}-${idx}`} className="rp-diff-hunks__row">
                 <span className="rp-diff-hunks__name" title={h.header}>
@@ -2774,6 +3277,9 @@ export function ResourceViewer({
     runRestoreFile,
     runAcceptHunk,
     runRejectHunk,
+    remainingHunkCount,
+    requestBatchAcceptHunks,
+    requestBatchRejectHunks,
   ]);
 
   // No project and no open tabs → empty; allow absolute/url tabs without a project.
@@ -3027,6 +3533,36 @@ export function ResourceViewer({
           </Tip>
         </div>
       )}
+      {batchProgress ? (
+        <div
+          className="rp__status"
+          role="status"
+          aria-live="polite"
+          data-testid="changes-batch-progress"
+        >
+          {tr("changes.batchProgress", {
+            action:
+              batchProgress.action === "accept"
+                ? tr("changes.accept")
+                : tr("changes.reject"),
+            current: String(batchProgress.current),
+            total: String(batchProgress.total),
+          })}
+        </div>
+      ) : batchStatus && !error ? (
+        <div className="rp__status" role="status" data-testid="changes-batch-status">
+          {batchStatus}
+          <Tip label={tr("common.dismiss")}>
+            <button
+              type="button"
+              className="chrome-btn"
+              onClick={() => setBatchStatus(null)}
+            >
+              <IconClose size={12} />
+            </button>
+          </Tip>
+        </div>
+      ) : null}
       {activeTab?.error && (
         <div className="rp__error" role="alert">
           {activeTab.error}
@@ -3293,7 +3829,50 @@ export function ResourceViewer({
                             {changeCount}
                           </span>
                         ) : null}
+                        {changeCount > 0 ? (
+                          <div
+                            className="rp-changes-section__batch"
+                            role="group"
+                            aria-label={tr("changes.batchGroup")}
+                          >
+                            <Tip label={tr("changes.acceptAllRemainingTip")}>
+                              <button
+                                type="button"
+                                className="chrome-btn rp-diff-action rp-diff-action--accept rp-changes-batch-btn"
+                                disabled={
+                                  !projectPath ||
+                                  !api.isTauri() ||
+                                  diffActionBusy
+                                }
+                                data-testid="changes-accept-all"
+                                onClick={() => requestBatchAcceptSession()}
+                                aria-label={tr("changes.acceptAllRemaining")}
+                              >
+                                <IconCheck size={12} />
+                                <span>{tr("changes.acceptAllRemainingShort")}</span>
+                              </button>
+                            </Tip>
+                            <Tip label={tr("changes.rejectAllRemainingTip")}>
+                              <button
+                                type="button"
+                                className="chrome-btn rp-diff-action rp-diff-action--reject rp-changes-batch-btn"
+                                disabled={
+                                  !projectPath ||
+                                  !api.isTauri() ||
+                                  diffActionBusy
+                                }
+                                data-testid="changes-reject-all"
+                                onClick={() => requestBatchRejectSession()}
+                                aria-label={tr("changes.rejectAllRemaining")}
+                              >
+                                <IconClose size={12} />
+                                <span>{tr("changes.rejectAllRemainingShort")}</span>
+                              </button>
+                            </Tip>
+                          </div>
+                        ) : null}
                       </div>
+
                       {filteredChanges.length === 0 ? (
                         <div className="rp-changes-section__empty">
                           {query.trim()
@@ -3838,6 +4417,93 @@ export function ResourceViewer({
                 name: rejectConfirm.name,
               })
             : tr("changes.rejectConfirmBody")}
+        </p>
+      </GlassModal>
+
+      <GlassModal
+        open={!!batchRejectConfirm}
+        onClose={() => setBatchRejectConfirm(null)}
+        title={
+          batchRejectConfirm?.untracked
+            ? tr("changes.batchRejectConfirmUntrackedTitle")
+            : tr("changes.batchRejectConfirmTitle")
+        }
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => setBatchRejectConfirm(null)}
+              disabled={diffActionBusy}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid btn--danger"
+              data-testid="changes-batch-reject-confirm"
+              disabled={diffActionBusy}
+              onClick={() => {
+                const p = batchRejectConfirm?.plan;
+                if (p) void executeBatchReject(p, true);
+              }}
+            >
+              {diffActionBusy
+                ? tr("changes.actionBusy")
+                : tr("changes.rejectAllRemaining")}
+            </button>
+          </>
+        }
+      >
+        <p className="rp-modal-copy">
+          {batchRejectConfirm?.untracked
+            ? tr("changes.batchRejectConfirmUntrackedBody", {
+                n: String(batchRejectConfirm.plan.runCount),
+                u: String(batchRejectConfirm.plan.untrackedConfirmCount),
+              })
+            : tr("changes.batchRejectConfirmBody", {
+                n: String(batchRejectConfirm?.plan.runCount ?? 0),
+              })}
+        </p>
+      </GlassModal>
+
+      <GlassModal
+        open={batchHunkRejectConfirm}
+        onClose={() => setBatchHunkRejectConfirm(false)}
+        title={tr("changes.batchHunksRejectConfirmTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => setBatchHunkRejectConfirm(false)}
+              disabled={diffActionBusy}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid btn--danger"
+              data-testid="changes-batch-hunks-reject-confirm"
+              disabled={diffActionBusy}
+              onClick={() => void runBatchRemainingHunks("reject")}
+            >
+              {diffActionBusy
+                ? tr("changes.actionBusy")
+                : tr("changes.rejectAllHunks")}
+            </button>
+          </>
+        }
+      >
+        <p className="rp-modal-copy">
+          {tr("changes.batchHunksRejectConfirmBody", {
+            n: String(remainingHunkCount),
+            name: diffView?.name ?? "",
+          })}
         </p>
       </GlassModal>
     </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -549,6 +549,36 @@ const en = {
   "changes.needProject": "Select a project to accept or reject changes",
   "changes.hunks": "Hunks",
   "changes.hunkLabel": "Hunk {n}",
+  "changes.batchGroup": "Batch actions",
+  "changes.acceptAllRemaining": "Accept all remaining",
+  "changes.acceptAllRemainingShort": "Accept all",
+  "changes.acceptAllRemainingTip":
+    "Accept every remaining session file (skips conflicts and already accepted)",
+  "changes.rejectAllRemaining": "Reject all remaining",
+  "changes.rejectAllRemainingShort": "Reject all",
+  "changes.rejectAllRemainingTip":
+    "Reject every remaining session file (skips conflicts; confirms untracked deletes)",
+  "changes.acceptAllHunks": "Accept all remaining hunks",
+  "changes.acceptAllHunksTip": "Apply every remaining hunk in this file",
+  "changes.rejectAllHunks": "Reject all remaining hunks",
+  "changes.rejectAllHunksTip": "Undo every remaining hunk in this file",
+  "changes.batchNothingRemaining": "No remaining changes to process",
+  "changes.batchProgress": "{action}… {current}/{total}",
+  "changes.batchAcceptSummary":
+    "Accept batch: {ok} ok · {fail} failed · {skipped} skipped (of {total})",
+  "changes.batchRejectSummary":
+    "Reject batch: {ok} ok · {fail} failed · {skipped} skipped (of {total})",
+  "changes.batchRejectConfirmTitle": "Reject all remaining changes?",
+  "changes.batchRejectConfirmBody":
+    "This restores {n} file(s) to HEAD (or before snapshot). You can Restore afterward if snapshots are kept.",
+  "changes.batchRejectConfirmUntrackedTitle": "Reject remaining (includes untracked)?",
+  "changes.batchRejectConfirmUntrackedBody":
+    "This rejects {n} file(s), including {u} untracked/added that will be deleted from disk. Restore only works when a snapshot was kept.",
+  "changes.batchHunksRejectConfirmTitle": "Reject all remaining hunks?",
+  "changes.batchHunksRejectConfirmBody":
+    "Undo {n} hunk(s) in “{name}”. This writes the file without those hunks.",
+  "changes.batchHunksAcceptDone": "Accepted {n} hunk(s)",
+  "changes.batchHunksRejectDone": "Rejected {n} hunk(s)",
 
   // Project rules (AGENTS.md / CLAUDE.md / .grok rules) — project menu modal
   "rules.title": "Rules",
@@ -5629,6 +5659,36 @@ const zh: Record<MessageKey, string> = {
   "changes.needProject": "请先选择项目以接受或拒绝变更",
   "changes.hunks": "变更块",
   "changes.hunkLabel": "第 {n} 块",
+  "changes.batchGroup": "批量操作",
+  "changes.acceptAllRemaining": "接受全部剩余",
+  "changes.acceptAllRemainingShort": "全部接受",
+  "changes.acceptAllRemainingTip":
+    "接受会话中所有剩余文件（跳过冲突与已接受）",
+  "changes.rejectAllRemaining": "拒绝全部剩余",
+  "changes.rejectAllRemainingShort": "全部拒绝",
+  "changes.rejectAllRemainingTip":
+    "拒绝会话中所有剩余文件（跳过冲突；删除未跟踪前需确认）",
+  "changes.acceptAllHunks": "接受全部剩余块",
+  "changes.acceptAllHunksTip": "将此文件中全部剩余 hunk 应用到磁盘",
+  "changes.rejectAllHunks": "拒绝全部剩余块",
+  "changes.rejectAllHunksTip": "撤销此文件中全部剩余 hunk",
+  "changes.batchNothingRemaining": "没有可处理的剩余变更",
+  "changes.batchProgress": "{action}… {current}/{total}",
+  "changes.batchAcceptSummary":
+    "批量接受：{ok} 成功 · {fail} 失败 · {skipped} 跳过（共 {total}）",
+  "changes.batchRejectSummary":
+    "批量拒绝：{ok} 成功 · {fail} 失败 · {skipped} 跳过（共 {total}）",
+  "changes.batchRejectConfirmTitle": "拒绝全部剩余变更？",
+  "changes.batchRejectConfirmBody":
+    "将把 {n} 个文件恢复为 HEAD（或修改前快照）。若仍保留快照，之后可点「还原」。",
+  "changes.batchRejectConfirmUntrackedTitle": "拒绝剩余（含未跟踪文件）？",
+  "changes.batchRejectConfirmUntrackedBody":
+    "将拒绝 {n} 个文件，其中 {u} 个未跟踪/新增文件会从磁盘删除。仅当仍有快照时可「还原」。",
+  "changes.batchHunksRejectConfirmTitle": "拒绝全部剩余块？",
+  "changes.batchHunksRejectConfirmBody":
+    "撤销「{name}」中的 {n} 个 hunk，将写入不含这些块的内容。",
+  "changes.batchHunksAcceptDone": "已接受 {n} 个块",
+  "changes.batchHunksRejectDone": "已拒绝 {n} 个块",
 
   "rules.title": "规则",
   "rules.modalTitleNamed": "项目规则 · {name}",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -511,6 +511,36 @@ export const zhTW: Record<MessageKey, string> = {
   "changes.needProject": "請先選擇專案以接受或拒絕變更",
   "changes.hunks": "變更區塊",
   "changes.hunkLabel": "第 {n} 塊",
+  "changes.batchGroup": "批量操作",
+  "changes.acceptAllRemaining": "接受全部剩餘",
+  "changes.acceptAllRemainingShort": "全部接受",
+  "changes.acceptAllRemainingTip":
+    "接受工作階段中所有剩餘檔案（略過衝突與已接受）",
+  "changes.rejectAllRemaining": "拒絕全部剩餘",
+  "changes.rejectAllRemainingShort": "全部拒絕",
+  "changes.rejectAllRemainingTip":
+    "拒絕工作階段中所有剩餘檔案（略過衝突；刪除未追蹤前需確認）",
+  "changes.acceptAllHunks": "接受全部剩餘區塊",
+  "changes.acceptAllHunksTip": "將此檔案中全部剩餘 hunk 套用到磁碟",
+  "changes.rejectAllHunks": "拒絕全部剩餘區塊",
+  "changes.rejectAllHunksTip": "撤銷此檔案中全部剩餘 hunk",
+  "changes.batchNothingRemaining": "沒有可處理的剩餘變更",
+  "changes.batchProgress": "{action}… {current}/{total}",
+  "changes.batchAcceptSummary":
+    "批量接受：{ok} 成功 · {fail} 失敗 · {skipped} 略過（共 {total}）",
+  "changes.batchRejectSummary":
+    "批量拒絕：{ok} 成功 · {fail} 失敗 · {skipped} 略過（共 {total}）",
+  "changes.batchRejectConfirmTitle": "拒絕全部剩餘變更？",
+  "changes.batchRejectConfirmBody":
+    "會將 {n} 個檔案還原為 HEAD（或修改前快照）。若仍保留快照，之後可按「還原」。",
+  "changes.batchRejectConfirmUntrackedTitle": "拒絕剩餘（含未追蹤檔案）？",
+  "changes.batchRejectConfirmUntrackedBody":
+    "將拒絕 {n} 個檔案，其中 {u} 個未追蹤/新增檔案會從磁碟刪除。僅當仍有快照時可「還原」。",
+  "changes.batchHunksRejectConfirmTitle": "拒絕全部剩餘區塊？",
+  "changes.batchHunksRejectConfirmBody":
+    "撤銷「{name}」中的 {n} 個 hunk，將寫入不含這些區塊的內容。",
+  "changes.batchHunksAcceptDone": "已接受 {n} 個區塊",
+  "changes.batchHunksRejectDone": "已拒絕 {n} 個區塊",
 
   "rules.title": "規則",
   "rules.modalTitleNamed": "專案規則 · {name}",

--- a/src/lib/diffAccept.test.ts
+++ b/src/lib/diffAccept.test.ts
@@ -3,18 +3,28 @@ import {
   applyHunks,
   applySelectedHunks,
   applyUnifiedPatch,
+  batchSummaryVars,
   canAcceptWithContent,
   canRejectWithBefore,
   canRestoreAfter,
+  isAlreadyDecided,
+  isConflictKind,
   needsUntrackedWipeConfirm,
   parseUnifiedDiff,
+  planBatchAccept,
+  planBatchFileAccept,
+  planBatchFileReject,
+  planBatchReject,
+  planBatchRemainingHunks,
   planFileAccept,
   planFileReject,
   planFileRestore,
   preferGitCheckoutReject,
   rejectSelectedHunks,
+  remainingHunkIndices,
   reverseHunks,
   splitPatchLines,
+  summarizeBatchResults,
 } from "./diffAccept";
 
 const SAMPLE_DIFF = `--- a/hello.txt
@@ -224,5 +234,179 @@ describe("safety / plans", () => {
     expect(planFileAccept({})).toEqual({ mode: "keep_current" });
     expect(planFileRestore({ after: "x" }).mode).toBe("write_after");
     expect(planFileRestore({}).mode).toBe("unavailable");
+  });
+});
+
+describe("batch plan", () => {
+  it("isConflictKind / isAlreadyDecided", () => {
+    expect(isConflictKind("conflict")).toBe(true);
+    expect(isConflictKind("Conflict")).toBe(true);
+    expect(isConflictKind("modified")).toBe(false);
+    expect(isAlreadyDecided("accepted", "accept")).toBe(true);
+    expect(isAlreadyDecided("accepted", "reject")).toBe(false);
+    expect(isAlreadyDecided("rejected", "reject")).toBe(true);
+    expect(isAlreadyDecided(null, "accept")).toBe(false);
+  });
+
+  it("planBatchFileAccept skips conflict and already decided", () => {
+    expect(
+      planBatchFileAccept({ path: "a.ts", kind: "conflict" }).outcome.kind,
+    ).toBe("skip");
+    expect(
+      planBatchFileAccept({
+        path: "a.ts",
+        decision: "accepted",
+        after: "x",
+      }).outcome.kind,
+    ).toBe("skip");
+    const ok = planBatchFileAccept({ path: "a.ts", after: "new" });
+    expect(ok.outcome.kind).toBe("run");
+    if (ok.outcome.kind === "run") {
+      expect(ok.outcome.run.action).toBe("accept");
+      expect(ok.outcome.run.plan.mode).toBe("write_after");
+    }
+  });
+
+  it("planBatchFileAccept keep_current without after still runs", () => {
+    const p = planBatchFileAccept({ path: "a.ts", kind: "modified" });
+    expect(p.outcome.kind).toBe("run");
+    if (p.outcome.kind === "run") {
+      expect(p.outcome.run.plan.mode).toBe("keep_current");
+    }
+  });
+
+  it("planBatchFileReject flags untracked wipe confirm", () => {
+    const p = planBatchFileReject(
+      { path: "new.ts", kind: "untracked", name: "new.ts" },
+      { hasGitRepo: true },
+    );
+    expect(p.outcome.kind).toBe("run");
+    if (p.outcome.kind === "run" && p.outcome.run.action === "reject") {
+      expect(p.outcome.run.needsUntrackedConfirm).toBe(true);
+    }
+  });
+
+  it("planBatchFileReject skips conflict", () => {
+    const p = planBatchFileReject(
+      { path: "c.ts", kind: "conflict" },
+      { hasGitRepo: true },
+    );
+    expect(p.outcome).toMatchObject({ kind: "skip", reason: "conflict" });
+  });
+
+  it("planBatchAccept aggregates session remaining", () => {
+    const plan = planBatchAccept(
+      [
+        { path: "ok.ts", after: "a", kind: "modified" },
+        { path: "done.ts", after: "b", decision: "accepted" },
+        { path: "bad.ts", kind: "conflict" },
+        { path: "", name: "empty" },
+      ],
+      { scope: "session" },
+    );
+    expect(plan.canRun).toBe(true);
+    expect(plan.runCount).toBe(1);
+    expect(plan.skipCount).toBe(3);
+    expect(plan.run[0]!.path).toBe("ok.ts");
+  });
+
+  it("planBatchReject separates untracked confirm", () => {
+    const plan = planBatchReject(
+      [
+        { path: "m.ts", kind: "modified", before: "old" },
+        { path: "u.ts", kind: "untracked" },
+        { path: "c.ts", kind: "conflict" },
+      ],
+      { hasGitRepo: true, scope: "session" },
+    );
+    expect(plan.runCount).toBe(2);
+    expect(plan.untrackedConfirmCount).toBe(1);
+    expect(plan.needsUntrackedConfirm[0]!.path).toBe("u.ts");
+    expect(plan.skipped).toHaveLength(1);
+  });
+
+  it("remainingHunkIndices excludes resolved", () => {
+    expect(remainingHunkIndices(3, [])).toEqual([0, 1, 2]);
+    expect(remainingHunkIndices(3, [1])).toEqual([0, 2]);
+    expect(remainingHunkIndices(3, [0, 1, 2])).toEqual([]);
+    expect(remainingHunkIndices(0)).toEqual([]);
+  });
+
+  it("planBatchRemainingHunks accept applies selected", () => {
+    const original = "a\nb\nc\nd\n";
+    const diff = `--- a/f
++++ b/f
+@@ -1,2 +1,2 @@
+-a
++A
+ b
+@@ -3,2 +3,2 @@
+-c
++C
+ d
+`;
+    const hunks = parseUnifiedDiff(diff).hunks;
+    const all = applyHunks(original, hunks);
+    expect(all.ok).toBe(true);
+    if (!all.ok) return;
+    const plan = planBatchRemainingHunks({
+      action: "accept",
+      hunks,
+      before: original,
+      resolvedIndices: [0], // only second remaining
+    });
+    expect(plan.ok).toBe(true);
+    if (plan.ok) {
+      expect(plan.indices).toEqual([1]);
+      expect(plan.content).toBe("a\nb\nC\nd\n");
+    }
+    const rej = planBatchRemainingHunks({
+      action: "reject",
+      hunks,
+      after: all.content,
+      resolvedIndices: [],
+    });
+    expect(rej.ok).toBe(true);
+    if (rej.ok) expect(rej.content).toBe(original);
+  });
+
+  it("planBatchRemainingHunks no remaining / missing snapshot", () => {
+    expect(
+      planBatchRemainingHunks({
+        action: "accept",
+        hunks: parseUnifiedDiff(SAMPLE_DIFF).hunks,
+        resolvedIndices: [0],
+        before: "x",
+      }).ok,
+    ).toBe(false);
+    expect(
+      planBatchRemainingHunks({
+        action: "accept",
+        hunks: parseUnifiedDiff(SAMPLE_DIFF).hunks,
+        before: null,
+      }),
+    ).toMatchObject({ ok: false, reason: "unavailable" });
+  });
+
+  it("summarizeBatchResults + batchSummaryVars", () => {
+    const s = summarizeBatchResults("accept", [
+      { path: "a", name: "a", status: "ok" },
+      { path: "b", name: "b", status: "soft_fail", reason: "write" },
+      { path: "c", name: "c", status: "skipped", reason: "conflict" },
+      { path: "d", name: "d", status: "error" },
+    ]);
+    expect(s).toMatchObject({
+      ok: 1,
+      softFail: 1,
+      skipped: 1,
+      error: 1,
+      total: 4,
+    });
+    expect(batchSummaryVars(s)).toEqual({
+      ok: "1",
+      fail: "2",
+      skipped: "1",
+      total: "4",
+    });
   });
 });

--- a/src/lib/diffAccept.ts
+++ b/src/lib/diffAccept.ts
@@ -424,3 +424,344 @@ export function planFileRestore(opts: {
   }
   return { mode: "unavailable", reason: "no after snapshot to restore" };
 }
+
+// ─── Batch accept / reject (session or file scope) ─────────────────────────
+
+export type BatchDiffAction = "accept" | "reject";
+export type BatchDiffScope = "session" | "file" | "hunks";
+
+export type BatchFileSkipReason =
+  | "already_decided"
+  | "conflict"
+  | "unavailable"
+  | "empty_path"
+  | "no_remaining";
+
+/** One file considered by a batch plan (pure; no I/O). */
+export type BatchFileInput = {
+  path: string;
+  name?: string;
+  kind?: string | null;
+  after?: string | null;
+  before?: string | null;
+  /** Prior accept/reject badge for this path in the Changes UI. */
+  decision?: "accepted" | "rejected" | null;
+  /** Disk presence; false → skip untracked wipe. Default assumed true. */
+  fileExists?: boolean;
+};
+
+export type BatchFileRunAction =
+  | { action: "accept"; plan: AcceptPlan }
+  | { action: "reject"; plan: RejectPlan; needsUntrackedConfirm: boolean };
+
+export type BatchFilePlanEntry = {
+  path: string;
+  name: string;
+  kind: string | null;
+  outcome:
+    | { kind: "run"; run: BatchFileRunAction }
+    | { kind: "skip"; reason: BatchFileSkipReason; detail?: string };
+};
+
+export type BatchDiffPlan = {
+  action: BatchDiffAction;
+  scope: BatchDiffScope;
+  entries: BatchFilePlanEntry[];
+  /** Files the host should process (includes those needing untracked confirm). */
+  run: BatchFilePlanEntry[];
+  skipped: BatchFilePlanEntry[];
+  /** Subset of `run` that still need wipe confirm before delete/checkout. */
+  needsUntrackedConfirm: BatchFilePlanEntry[];
+  runCount: number;
+  skipCount: number;
+  untrackedConfirmCount: number;
+  canRun: boolean;
+};
+
+export type BatchResultStatus = "ok" | "soft_fail" | "skipped" | "error";
+
+export type BatchDiffResultItem = {
+  path: string;
+  name: string;
+  status: BatchResultStatus;
+  reason?: string;
+};
+
+export type BatchDiffSummary = {
+  action: BatchDiffAction;
+  ok: number;
+  softFail: number;
+  skipped: number;
+  error: number;
+  total: number;
+  items: BatchDiffResultItem[];
+};
+
+/** True when kind is a merge conflict — batch skips these (soft). */
+export function isConflictKind(kind?: string | null): boolean {
+  return (kind || "").toLowerCase().trim() === "conflict";
+}
+
+/** Skip when the UI already recorded the same decision for this path. */
+export function isAlreadyDecided(
+  decision: "accepted" | "rejected" | null | undefined,
+  action: BatchDiffAction,
+): boolean {
+  if (!decision) return false;
+  return (
+    (action === "accept" && decision === "accepted") ||
+    (action === "reject" && decision === "rejected")
+  );
+}
+
+function entryName(item: BatchFileInput): string {
+  const n = (item.name || "").trim();
+  if (n) return n;
+  const p = (item.path || "").replace(/\\/g, "/");
+  const parts = p.split("/").filter(Boolean);
+  return parts[parts.length - 1] || p || "?";
+}
+
+/**
+ * Indices of hunks not yet resolved (for file-scoped “accept/reject all remaining”).
+ * When `resolvedIndices` is empty, every hunk is remaining.
+ */
+export function remainingHunkIndices(
+  totalHunks: number,
+  resolvedIndices: readonly number[] = [],
+): number[] {
+  const n = Math.max(0, Math.floor(totalHunks));
+  if (n === 0) return [];
+  const done = new Set(
+    resolvedIndices.filter((i) => Number.isInteger(i) && i >= 0 && i < n),
+  );
+  const out: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (!done.has(i)) out.push(i);
+  }
+  return out;
+}
+
+function skipEntry(
+  item: BatchFileInput,
+  reason: BatchFileSkipReason,
+  detail?: string,
+): BatchFilePlanEntry {
+  return {
+    path: item.path || "",
+    name: entryName(item),
+    kind: item.kind ?? null,
+    outcome: { kind: "skip", reason, detail },
+  };
+}
+
+/** Plan one file for batch accept (skip conflict / already accepted). */
+export function planBatchFileAccept(item: BatchFileInput): BatchFilePlanEntry {
+  const path = (item.path || "").trim();
+  if (!path) return skipEntry(item, "empty_path");
+  if (isConflictKind(item.kind)) {
+    return skipEntry(item, "conflict", "merge conflict");
+  }
+  if (isAlreadyDecided(item.decision, "accept")) {
+    return skipEntry(item, "already_decided");
+  }
+  const plan = planFileAccept({ after: item.after });
+  if (plan.mode === "unavailable") {
+    return skipEntry(item, "unavailable", plan.reason);
+  }
+  return {
+    path,
+    name: entryName(item),
+    kind: item.kind ?? null,
+    outcome: {
+      kind: "run",
+      run: { action: "accept", plan },
+    },
+  };
+}
+
+/** Plan one file for batch reject (skip conflict / already rejected; flag wipe). */
+export function planBatchFileReject(
+  item: BatchFileInput,
+  opts?: { hasGitRepo?: boolean },
+): BatchFilePlanEntry {
+  const path = (item.path || "").trim();
+  if (!path) return skipEntry(item, "empty_path");
+  if (isConflictKind(item.kind)) {
+    return skipEntry(item, "conflict", "merge conflict");
+  }
+  if (isAlreadyDecided(item.decision, "reject")) {
+    return skipEntry(item, "already_decided");
+  }
+  const plan = planFileReject({
+    hasGitRepo: !!opts?.hasGitRepo,
+    kind: item.kind,
+    before: item.before,
+    fileExists: item.fileExists,
+  });
+  if (plan.mode === "unavailable") {
+    return skipEntry(item, "unavailable", plan.reason);
+  }
+  const needsUntrackedConfirm =
+    (plan.mode === "git" && plan.confirmUntracked) ||
+    (plan.mode === "delete" && plan.confirmUntracked) ||
+    needsUntrackedWipeConfirm(item.kind);
+  return {
+    path,
+    name: entryName(item),
+    kind: item.kind ?? null,
+    outcome: {
+      kind: "run",
+      run: { action: "reject", plan, needsUntrackedConfirm },
+    },
+  };
+}
+
+function assembleBatchPlan(
+  action: BatchDiffAction,
+  scope: BatchDiffScope,
+  entries: BatchFilePlanEntry[],
+): BatchDiffPlan {
+  const run = entries.filter((e) => e.outcome.kind === "run");
+  const skipped = entries.filter((e) => e.outcome.kind === "skip");
+  const needsUntrackedConfirm = run.filter(
+    (e) =>
+      e.outcome.kind === "run" &&
+      e.outcome.run.action === "reject" &&
+      e.outcome.run.needsUntrackedConfirm,
+  );
+  return {
+    action,
+    scope,
+    entries,
+    run,
+    skipped,
+    needsUntrackedConfirm,
+    runCount: run.length,
+    skipCount: skipped.length,
+    untrackedConfirmCount: needsUntrackedConfirm.length,
+    canRun: run.length > 0,
+  };
+}
+
+/** Build a session- or file-scoped batch accept plan. */
+export function planBatchAccept(
+  files: readonly BatchFileInput[],
+  opts?: { scope?: BatchDiffScope },
+): BatchDiffPlan {
+  const entries = files.map((f) => planBatchFileAccept(f));
+  return assembleBatchPlan("accept", opts?.scope ?? "session", entries);
+}
+
+/** Build a session- or file-scoped batch reject plan. */
+export function planBatchReject(
+  files: readonly BatchFileInput[],
+  opts?: { hasGitRepo?: boolean; scope?: BatchDiffScope },
+): BatchDiffPlan {
+  const entries = files.map((f) =>
+    planBatchFileReject(f, { hasGitRepo: opts?.hasGitRepo }),
+  );
+  return assembleBatchPlan("reject", opts?.scope ?? "session", entries);
+}
+
+/**
+ * File-scoped remaining-hunks plan. When no indices remain, returns canRun false.
+ * Accept = apply selected hunks onto before; reject = reverse them from after.
+ */
+export type BatchHunksPlan =
+  | {
+      ok: true;
+      action: BatchDiffAction;
+      indices: number[];
+      /** Content to write when apply succeeds. */
+      content: string;
+    }
+  | {
+      ok: false;
+      reason: BatchFileSkipReason | "apply_failed";
+      detail?: string;
+    };
+
+export function planBatchRemainingHunks(opts: {
+  action: BatchDiffAction;
+  hunks: readonly UnifiedHunk[];
+  /** Already resolved hunk indices (empty → all remaining). */
+  resolvedIndices?: readonly number[];
+  before?: string | null;
+  after?: string | null;
+}): BatchHunksPlan {
+  const indices = remainingHunkIndices(
+    opts.hunks.length,
+    opts.resolvedIndices ?? [],
+  );
+  if (indices.length === 0) {
+    return { ok: false, reason: "no_remaining" };
+  }
+  if (opts.action === "accept") {
+    if (typeof opts.before !== "string") {
+      return {
+        ok: false,
+        reason: "unavailable",
+        detail: "hunk accept needs before snapshot",
+      };
+    }
+    const r = applySelectedHunks(opts.before, opts.hunks, indices);
+    if (!r.ok) {
+      return { ok: false, reason: "apply_failed", detail: r.error };
+    }
+    return { ok: true, action: "accept", indices, content: r.content };
+  }
+  if (typeof opts.after !== "string") {
+    return {
+      ok: false,
+      reason: "unavailable",
+      detail: "hunk reject needs after snapshot",
+    };
+  }
+  const r = rejectSelectedHunks(opts.after, opts.hunks, indices);
+  if (!r.ok) {
+    return { ok: false, reason: "apply_failed", detail: r.error };
+  }
+  return { ok: true, action: "reject", indices, content: r.content };
+}
+
+/** Aggregate host results into a soft-fail summary. */
+export function summarizeBatchResults(
+  action: BatchDiffAction,
+  items: readonly BatchDiffResultItem[],
+): BatchDiffSummary {
+  let ok = 0;
+  let softFail = 0;
+  let skipped = 0;
+  let error = 0;
+  for (const it of items) {
+    if (it.status === "ok") ok++;
+    else if (it.status === "soft_fail") softFail++;
+    else if (it.status === "skipped") skipped++;
+    else error++;
+  }
+  return {
+    action,
+    ok,
+    softFail,
+    skipped,
+    error,
+    total: items.length,
+    items: items.slice(),
+  };
+}
+
+/** Vars for i18n summary strings: ok / fail / skipped / total. */
+export function batchSummaryVars(summary: BatchDiffSummary): {
+  ok: string;
+  fail: string;
+  skipped: string;
+  total: string;
+} {
+  return {
+    ok: String(summary.ok),
+    fail: String(summary.softFail + summary.error),
+    skipped: String(summary.skipped),
+    total: String(summary.total),
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -14140,6 +14140,18 @@ textarea::-webkit-scrollbar-thumb:active,
   border-bottom: 1px solid var(--border-subtle);
 }
 
+.rp__status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--accent, #6c8cff) 10%, transparent);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
 /* ── Single chrome: tabs + open/tree/close (no second title row) ───────────
    Strict lock to --titlebar-height so the bottom border lines up with .main__top
    (padding vertical 0; height includes border via border-box — same as main). */
@@ -15252,6 +15264,42 @@ textarea::-webkit-scrollbar-thumb:active,
   gap: 6px;
   padding: 4px 10px 6px;
   min-height: 22px;
+  flex-wrap: wrap;
+}
+
+.rp-changes-section__batch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.rp-changes-batch-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 2px 6px !important;
+  min-height: 22px;
+  white-space: nowrap;
+}
+
+.rp-changes-batch-btn span {
+  line-height: 1;
+}
+
+.rp-changes-batch-progress {
+  padding: 2px 12px 6px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.rp-diff-hunks__batch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 4px;
 }
 
 .rp-changes-section__title {


### PR DESCRIPTION
## Summary
- Pure batch plan helpers (`planBatchAccept` / `planBatchReject` / `planBatchRemainingHunks`) list eligible session files/hunks, skip merge conflicts and already-decided paths, and flag untracked wipe for confirm
- Changes panel **Accept all remaining** / **Reject all remaining** (session) plus multi-hunk file toolbar **accept/reject all remaining hunks**
- Reuses host `apply_file_patch` / `git_checkout_file` / `delete_project_file`; sequential busy + progress honesty; soft-fail partial summary (no `window.confirm` — GlassModal only)
- i18n en / zh / zh-TW + CHANGELOG; unit tests for batch planning

## Test plan
- [ ] `npx vitest run src/lib/diffAccept.test.ts`
- [ ] Open Changes with several session files → Accept all remaining marks decisions, skips already accepted
- [ ] Reject all remaining shows GlassModal; with untracked files uses stronger copy and only deletes after confirm
- [ ] Open multi-hunk file → Accept/Reject all remaining hunks writes once and updates preview
- [ ] Conflict-kind workspace paths are skipped (summary counts)
- [ ] Buttons disabled while batch progress shows `n/total`