### PR TITLE
feat(remote): add Docker mirror fallback and Telegram context controls

### DIFF
--- a/docs/llm-wiki/remote-im.md
+++ b/docs/llm-wiki/remote-im.md
@@ -7,6 +7,15 @@
 > **产品：** Grok App 设置 → **远程控制** 内可视化配置；本机 Bridge × **仅 Grok Build（ACP）**  
 > **IA：** 设置一级导航展示名为「远程控制」（section id 仍为 `remote_im`）；页内 tab：`im`（IM 通信，本文）· `mirror`（手机镜像，见 PR #95 / `MirrorConnectPanel`）  
 > **原则：** **零 CLI 主路径** — 绑定、扫码、启停、ACL、Doctor 全部 GUI；禁止要求用户手写 TOML
+
+### 手机镜像公网隧道
+
+- 启动手机镜像时优先使用宿主机 `PATH` 中的 `cloudflared`。
+- 若宿主机未安装 `cloudflared`，自动检测 Docker daemon，并通过官方 `cloudflare/cloudflared:latest` 镜像创建 Quick Tunnel；无需挂载 Cloudflare 凭证。
+- macOS / Windows 容器通过 `host.docker.internal:<动态端口>` 访问仅监听本机的镜像主机；Linux 使用 host network，继续保持回环地址。
+- App 负责容器命名、日志就绪检测和停止清理；“停止主机”或正常退出时会强制移除本次容器，异常终止产生的同前缀残留会在下次启动隧道前清理。
+- 可用 `GROK_MIRROR_CLOUDFLARED_IMAGE` 覆盖镜像；`GROK_MIRROR_NO_TUNNEL=1` 仍用于仅本机测试。
+
 ---
 
 ## 目录
@@ -178,7 +187,7 @@
 
 | 能力 | 首版 | GUI 位置 |
 |------|------|----------|
-| `/p` `/r` `/new` `/status` `/help` `/stop` `/whoami` `/account` `/quota` `/switch` | ✅ | 总览说明 + 帮助文案；账号列表含剩余额度 |
+| `/p` `/r` `/new` `/status` `/context` `/compact` `/help` `/stop` `/whoami` `/account` `/quota` `/switch` | ✅ | 总览说明 + 帮助文案；上下文用量与压缩；账号列表含剩余额度 |
 | `/model` `/mode` 远程改模型 | 二期 | 总览高级 |
 | `/shell` `/cron` | 默认关 | 总览高级 + admin_from |
 
@@ -195,6 +204,8 @@
 | `/r <序号>` | 绑定会话 → **mode=resume** |
 | `/new` | 清 session 绑定，保持项目，mode=new |
 | `/status` | 项目、cwd、mode、session、chatKey |
+| `/context` | 当前会话上下文用量；优先 agent 上报值，否则明确标记为 `~` 估算值 |
+| `/compact [备注]` | 在当前 agent session 执行上下文压缩；结果与压缩标记同步回 App 会话 |
 | `/account` `/accounts` `/quota` | 列出已保存 Grok 账号 + SuperGrok 剩余额度（`★` 为当前） |
 | `/account <序号\|标签>` `/switch <n>` | 切换活动账号（写 `~/.grok/auth.json` + agent-home，软断桌面 ACP） |
 | `/stop` | 中断 turn |
@@ -390,6 +401,8 @@ Bridge **启动**与 **测试连接成功** 时自动调用 `setMyCommands`，�
 | `/r` · `/resume` | 列/恢复会话 |
 | `/new` | 新会话（保持项目） |
 | `/status` | 状态快照 |
+| `/context` | 当前会话上下文用量 |
+| `/compact [备注]` | 压缩当前会话上下文 |
 | `/account` · `/accounts` · `/quota` · `/switch` | 账号列表与额度 / 切换账号 |
 | `/whoami` | 发送者 id |
 | `/stop` | 中断当前 turn |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-app",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-app",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-collapsible": "^1.1.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grok-app",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Desktop workbench for Grok Build CLI (English-first)",
   "author": "RongleCat",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "grok-app"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "arboard",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grok-app"
-version = "0.2.2"
+version = "0.2.3"
 description = "Grok — desktop workbench for Grok Build CLI"
 authors = ["RongleCat"]
 edition = "2021"

--- a/src-tauri/src/mirror/mod.rs
+++ b/src-tauri/src/mirror/mod.rs
@@ -135,7 +135,7 @@ struct Runtime {
     public_url: Option<String>,
     error: Option<String>,
     shutdown_tx: Option<oneshot::Sender<()>>,
-    /// cloudflared child (process group); killed on stop.
+    /// cloudflared adapter handle (host process or Docker container); stopped on teardown.
     tunnel: Option<tunnel::TunnelHandle>,
     #[allow(dead_code)] // kept for future media/static re-resolve
     dist_dir: PathBuf,
@@ -438,7 +438,7 @@ impl MirrorHost {
         Ok(self.status())
     }
 
-    /// Full teardown; invalidates token immediately; kills tunnel process group.
+    /// Full teardown; invalidates token immediately; stops the active tunnel adapter.
     pub async fn stop(&self) -> Result<MirrorStatus, String> {
         self.stop_inner();
         // Brief yield so server task can observe shutdown.
@@ -461,8 +461,8 @@ impl MirrorHost {
             (tx, tun)
         };
         if let Some(t) = tunnel {
-            t.kill_group();
-            tracing::info!("mirror tunnel process group killed");
+            t.stop();
+            tracing::info!("mirror tunnel adapter stopped");
         }
         if let Some(tx) = shutdown {
             let _ = tx.send(());

--- a/src-tauri/src/mirror/tunnel.rs
+++ b/src-tauri/src/mirror/tunnel.rs
@@ -1,11 +1,13 @@
 //! cloudflared quick tunnel lifecycle (DESIGN §9).
 //!
-//! Spawn in a **process group**, parse public URL from logs, wait for
-//! `Registered tunnel connection` before declaring ready. Stop kills the
-//! whole group so no orphans hold ports (REQUIREMENT known pitfall).
+//! Select a host-binary or Docker adapter, parse the public URL from logs,
+//! and wait for `Registered tunnel connection` before declaring ready.
+//! Stop tears down the process group and any managed container so no orphan
+//! tunnel keeps the mirror reachable (REQUIREMENT known pitfall).
 
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
@@ -19,12 +21,113 @@ use std::os::windows::process::CommandExt;
 
 /// How long to wait for URL + registered connection.
 const TUNNEL_READY_TIMEOUT: Duration = Duration::from_secs(90);
+/// First Docker run can pull the official image before cloudflared starts.
+const DOCKER_TUNNEL_READY_TIMEOUT: Duration = Duration::from_secs(180);
+const DOCKER_DAEMON_TIMEOUT: Duration = Duration::from_secs(8);
+const DEFAULT_CLOUDFLARED_IMAGE: &str = "cloudflare/cloudflared:latest";
+const DOCKER_CONTAINER_PREFIX: &str = "grok-mirror-cloudflared-";
+const DOCKER_MIRROR_LABEL: &str = "com.grokapp.mirror=1";
+
+/// Internal adapter seam: host binary remains the preferred path; Docker is
+/// selected only when cloudflared is absent from the desktop app's PATH.
+#[derive(Debug, Clone)]
+enum TunnelAdapter {
+    HostBinary {
+        bin: PathBuf,
+    },
+    Docker {
+        bin: PathBuf,
+        image: String,
+        container_name: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct DockerCleanup {
+    bin: PathBuf,
+    container_name: String,
+}
+
+struct TunnelCommandSpec {
+    program: PathBuf,
+    args: Vec<String>,
+    adapter_name: &'static str,
+    ready_timeout: Duration,
+    docker_cleanup: Option<DockerCleanup>,
+}
+
+impl TunnelAdapter {
+    fn command_spec(&self, local_port: u16) -> TunnelCommandSpec {
+        match self {
+            Self::HostBinary { bin } => TunnelCommandSpec {
+                program: bin.clone(),
+                args: vec![
+                    "tunnel".into(),
+                    "--url".into(),
+                    format!("http://127.0.0.1:{local_port}"),
+                    "--no-autoupdate".into(),
+                ],
+                adapter_name: "host_binary",
+                ready_timeout: TUNNEL_READY_TIMEOUT,
+                docker_cleanup: None,
+            },
+            Self::Docker {
+                bin,
+                image,
+                container_name,
+            } => {
+                let mut args = vec![
+                    "run".into(),
+                    "--rm".into(),
+                    "--name".into(),
+                    container_name.clone(),
+                    "--label".into(),
+                    DOCKER_MIRROR_LABEL.into(),
+                ];
+                #[cfg(target_os = "linux")]
+                args.extend(["--network".into(), "host".into()]);
+                args.extend([
+                    image.clone(),
+                    "tunnel".into(),
+                    "--url".into(),
+                    docker_tunnel_origin(local_port),
+                    "--no-autoupdate".into(),
+                ]);
+                TunnelCommandSpec {
+                    program: bin.clone(),
+                    args,
+                    adapter_name: "docker",
+                    ready_timeout: DOCKER_TUNNEL_READY_TIMEOUT,
+                    docker_cleanup: Some(DockerCleanup {
+                        bin: bin.clone(),
+                        container_name: container_name.clone(),
+                    }),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn docker_tunnel_origin(local_port: u16) -> String {
+    // Host networking preserves the loopback-only security posture on Linux.
+    format!("http://127.0.0.1:{local_port}")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn docker_tunnel_origin(local_port: u16) -> String {
+    // Docker Desktop exposes the macOS/Windows host through this stable name;
+    // container-local 127.0.0.1 would point at cloudflared itself.
+    format!("http://host.docker.internal:{local_port}")
+}
 
 /// Live tunnel process (own process group on Unix).
 pub struct TunnelHandle {
     child: Child,
     /// Process group / leader pid for group kill (Unix).
     pgid: Option<i32>,
+    adapter_name: &'static str,
+    docker_cleanup: Option<DockerCleanup>,
     pub public_url: String,
 }
 
@@ -37,19 +140,29 @@ impl TunnelHandle {
     pub fn poll_exited(&mut self) -> bool {
         match self.child.try_wait() {
             Ok(Some(status)) => {
-                tracing::warn!(?status, "mirror cloudflared process exited");
+                // status() holds the mirror runtime mutex while polling; never
+                // block that path on a Docker daemon round-trip.
+                cleanup_docker_container_in_background(self.docker_cleanup.clone());
+                tracing::warn!(
+                    ?status,
+                    adapter = self.adapter_name,
+                    "mirror cloudflared process exited"
+                );
                 true
             }
             Ok(None) => false,
             Err(e) => {
+                cleanup_docker_container_in_background(self.docker_cleanup.clone());
                 tracing::warn!(error = %e, "mirror cloudflared try_wait failed");
                 true
             }
         }
     }
 
-    /// Kill the tunnel process group (no orphans).
-    pub fn kill_group(mut self) {
+    /// Stop the selected adapter and remove Docker containers before reaping
+    /// the attached client process. This keeps stop/quit free of tunnel orphans.
+    pub fn stop(mut self) {
+        cleanup_docker_container(self.docker_cleanup.take());
         kill_process_group(self.child.id(), self.pgid.take());
         // Best-effort reaping so we don't leave zombies.
         let _ = self.child.start_kill();
@@ -65,22 +178,16 @@ pub struct TunnelStart {
     pub public_url: String,
 }
 
-/// Spawn `cloudflared tunnel --url http://127.0.0.1:<port>`.
+/// Spawn a quick tunnel through the host cloudflared binary, or through the
+/// official Docker image when the host binary is not available.
 ///
 /// Returns only after logs show a public URL **and**
 /// `Registered tunnel connection` (or errors out).
 pub async fn start_quick_tunnel(local_port: u16) -> Result<TunnelStart, String> {
-    let bin = which::which("cloudflared").map_err(|_| {
-        "cloudflared not found on PATH — install cloudflared or set GROK_MIRROR_NO_TUNNEL=1"
-            .to_string()
-    })?;
-
-    let url_arg = format!("http://127.0.0.1:{local_port}");
-    let mut cmd = Command::new(&bin);
-    cmd.arg("tunnel")
-        .arg("--url")
-        .arg(&url_arg)
-        .arg("--no-autoupdate")
+    let adapter = select_tunnel_adapter(local_port).await?;
+    let spec = adapter.command_spec(local_port);
+    let mut cmd = Command::new(&spec.program);
+    cmd.args(&spec.args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -106,20 +213,29 @@ pub async fn start_quick_tunnel(local_port: u16) -> Result<TunnelStart, String> 
         cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
     }
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("failed to spawn cloudflared: {e}"))?;
+    let mut child = cmd.spawn().map_err(|e| {
+        format!(
+            "failed to spawn {} cloudflared adapter: {e}",
+            spec.adapter_name
+        )
+    })?;
     let pid = child.id();
     let pgid = pid.map(|p| p as i32);
 
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "cloudflared stdout missing".to_string())?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| "cloudflared stderr missing".to_string())?;
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
+            return Err("cloudflared stdout missing".into());
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
+            return Err("cloudflared stderr missing".into());
+        }
+    };
 
     let (tx, rx) = oneshot::channel::<Result<(String, bool), String>>();
     tauri::async_runtime::spawn(async move {
@@ -127,49 +243,241 @@ pub async fn start_quick_tunnel(local_port: u16) -> Result<TunnelStart, String> 
         let _ = tx.send(result);
     });
 
-    let ready = timeout(TUNNEL_READY_TIMEOUT, rx).await;
+    let ready = timeout(spec.ready_timeout, rx).await;
     let (public_url, registered) = match ready {
         Ok(Ok(Ok(pair))) => pair,
         Ok(Ok(Err(e))) => {
-            kill_process_group(pid, pgid);
-            let _ = child.start_kill();
+            terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
             return Err(e);
         }
         Ok(Err(_)) => {
-            kill_process_group(pid, pgid);
-            let _ = child.start_kill();
+            terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
             return Err("cloudflared log pump closed without ready signal".into());
         }
         Err(_) => {
-            kill_process_group(pid, pgid);
-            let _ = child.start_kill();
+            terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
             return Err(format!(
                 "cloudflared did not become ready within {}s",
-                TUNNEL_READY_TIMEOUT.as_secs()
+                spec.ready_timeout.as_secs()
             ));
         }
     };
 
     if !registered {
-        kill_process_group(pid, pgid);
-        let _ = child.start_kill();
-        return Err(
-            "cloudflared printed URL but never 'Registered tunnel connection'".into(),
-        );
+        terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
+        return Err("cloudflared printed URL but never 'Registered tunnel connection'".into());
     }
 
     let public_url = public_url.trim_end_matches('/').to_string();
 
-    tracing::info!(%public_url, ?pid, "mirror cloudflared tunnel registered");
+    tracing::info!(%public_url, ?pid, adapter = spec.adapter_name, "mirror cloudflared tunnel registered");
 
     Ok(TunnelStart {
         handle: TunnelHandle {
             child,
             pgid,
+            adapter_name: spec.adapter_name,
+            docker_cleanup: spec.docker_cleanup,
             public_url: public_url.clone(),
         },
         public_url,
     })
+}
+
+async fn select_tunnel_adapter(local_port: u16) -> Result<TunnelAdapter, String> {
+    if let Ok(bin) = which::which("cloudflared") {
+        return Ok(TunnelAdapter::HostBinary { bin });
+    }
+
+    let docker = find_docker_binary().ok_or_else(|| {
+        "cloudflared not found on PATH and Docker CLI is unavailable — install cloudflared, or install/start Docker Desktop, or set GROK_MIRROR_NO_TUNNEL=1"
+            .to_string()
+    })?;
+    ensure_docker_daemon(&docker).await?;
+    cleanup_stale_docker_containers(&docker).await?;
+
+    let image = std::env::var("GROK_MIRROR_CLOUDFLARED_IMAGE")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_CLOUDFLARED_IMAGE.to_string());
+
+    Ok(TunnelAdapter::Docker {
+        bin: docker,
+        image,
+        container_name: docker_container_name(local_port),
+    })
+}
+
+fn find_docker_binary() -> Option<PathBuf> {
+    if let Ok(bin) = which::which("docker") {
+        return Some(bin);
+    }
+
+    #[cfg(target_os = "windows")]
+    if let Some(program_files) = std::env::var_os("ProgramFiles") {
+        let candidate = PathBuf::from(program_files)
+            .join("Docker")
+            .join("Docker")
+            .join("resources")
+            .join("bin")
+            .join("docker.exe");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    // Finder/LaunchServices apps often inherit a minimal PATH. Check official
+    // Docker Desktop and common package-manager locations before declaring the
+    // Docker adapter unavailable.
+    #[cfg(target_os = "macos")]
+    const CANDIDATES: &[&str] = &[
+        "/Applications/Docker.app/Contents/Resources/bin/docker",
+        "/opt/homebrew/bin/docker",
+        "/usr/local/bin/docker",
+        "/usr/bin/docker",
+    ];
+    #[cfg(target_os = "linux")]
+    const CANDIDATES: &[&str] = &["/usr/bin/docker", "/usr/local/bin/docker"];
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    const CANDIDATES: &[&str] = &[];
+
+    CANDIDATES
+        .iter()
+        .map(PathBuf::from)
+        .find(|path| path.is_file())
+}
+
+async fn ensure_docker_daemon(docker: &Path) -> Result<(), String> {
+    let mut probe = Command::new(docker);
+    probe
+        .arg("info")
+        .arg("--format")
+        .arg("{{.ServerVersion}}")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+
+    match timeout(DOCKER_DAEMON_TIMEOUT, probe.status()).await {
+        Ok(Ok(status)) if status.success() => Ok(()),
+        Ok(_) => Err(
+            "cloudflared not found on PATH and Docker daemon is unavailable — start Docker Desktop and retry, or set GROK_MIRROR_NO_TUNNEL=1"
+                .into(),
+        ),
+        Err(_) => Err(
+            "cloudflared not found on PATH and Docker daemon check timed out — start Docker Desktop and retry, or set GROK_MIRROR_NO_TUNNEL=1"
+                .into(),
+        ),
+    }
+}
+
+async fn cleanup_stale_docker_containers(docker: &Path) -> Result<(), String> {
+    // A force-killed desktop process cannot run its normal stop hook. Since
+    // Grok is single-instance, any container with our private name prefix is
+    // stale when a new mirror adapter is being selected.
+    let mut list = Command::new(docker);
+    list.args([
+        "ps",
+        "--all",
+        "--quiet",
+        "--filter",
+        &format!("name={DOCKER_CONTAINER_PREFIX}"),
+    ])
+    .stdin(Stdio::null())
+    .stderr(Stdio::null())
+    .kill_on_drop(true);
+    let output = match timeout(DOCKER_DAEMON_TIMEOUT, list.output()).await {
+        Ok(Ok(output)) if output.status.success() => output,
+        _ => {
+            return Err(
+                "cloudflared not found on PATH and stale Docker mirror cleanup could not be checked — restart Docker Desktop and retry"
+                    .into(),
+            )
+        }
+    };
+
+    let ids: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|id| !id.is_empty() && id.len() <= 64 && id.chars().all(|c| c.is_ascii_hexdigit()))
+        .take(32)
+        .map(str::to_string)
+        .collect();
+    if ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut remove = Command::new(docker);
+    remove
+        .args(["rm", "--force"])
+        .args(&ids)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    match timeout(DOCKER_DAEMON_TIMEOUT, remove.status()).await {
+        Ok(Ok(status)) if status.success() => {
+            tracing::info!(count = ids.len(), "mirror stale Docker tunnels removed");
+            Ok(())
+        }
+        _ => Err(
+            "cloudflared not found on PATH and stale Docker mirror containers could not be removed — restart Docker Desktop and retry"
+                .into(),
+        ),
+    }
+}
+
+fn docker_container_name(local_port: u16) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!(
+        "{DOCKER_CONTAINER_PREFIX}{}-{local_port}-{nonce}",
+        std::process::id()
+    )
+}
+
+fn terminate_failed_tunnel(
+    child: &mut Child,
+    pid: Option<u32>,
+    pgid: Option<i32>,
+    docker_cleanup: Option<DockerCleanup>,
+) {
+    cleanup_docker_container(docker_cleanup);
+    kill_process_group(pid, pgid);
+    let _ = child.start_kill();
+}
+
+fn cleanup_docker_container(cleanup: Option<DockerCleanup>) {
+    let Some(cleanup) = cleanup else {
+        return;
+    };
+    let status = std::process::Command::new(&cleanup.bin)
+        .args(["rm", "--force", &cleanup.container_name])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    match status {
+        Ok(status) if status.success() => {
+            tracing::info!(container = %cleanup.container_name, "mirror Docker tunnel removed");
+        }
+        Ok(status) => {
+            tracing::debug!(?status, container = %cleanup.container_name, "mirror Docker tunnel already absent or could not be removed");
+        }
+        Err(error) => {
+            tracing::warn!(%error, container = %cleanup.container_name, "mirror Docker tunnel cleanup failed");
+        }
+    }
+}
+
+fn cleanup_docker_container_in_background(cleanup: Option<DockerCleanup>) {
+    if cleanup.is_none() {
+        return;
+    }
+    std::thread::spawn(move || cleanup_docker_container(cleanup));
 }
 
 /// Read stdout+stderr until we have URL and Registered, or process dies.
@@ -326,5 +634,57 @@ mod tests {
     #[test]
     fn no_url_returns_none() {
         assert!(extract_trycloudflare_url("Registered tunnel connection").is_none());
+    }
+
+    #[test]
+    fn host_adapter_keeps_loopback_origin() {
+        let adapter = TunnelAdapter::HostBinary {
+            bin: PathBuf::from("/usr/local/bin/cloudflared"),
+        };
+        let spec = adapter.command_spec(52770);
+        assert_eq!(spec.adapter_name, "host_binary");
+        assert_eq!(spec.program, PathBuf::from("/usr/local/bin/cloudflared"));
+        assert!(spec.args.iter().any(|arg| arg == "http://127.0.0.1:52770"));
+        assert!(spec.docker_cleanup.is_none());
+    }
+
+    #[test]
+    fn docker_adapter_uses_official_image_and_managed_container() {
+        let adapter = TunnelAdapter::Docker {
+            bin: PathBuf::from("/usr/local/bin/docker"),
+            image: DEFAULT_CLOUDFLARED_IMAGE.into(),
+            container_name: "grok-mirror-test".into(),
+        };
+        let spec = adapter.command_spec(52770);
+        assert_eq!(spec.adapter_name, "docker");
+        assert!(spec.args.iter().any(|arg| arg == DEFAULT_CLOUDFLARED_IMAGE));
+        assert!(spec
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--name" && pair[1] == "grok-mirror-test"));
+        assert!(spec
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--label" && pair[1] == DOCKER_MIRROR_LABEL));
+        assert_eq!(
+            spec.docker_cleanup
+                .as_ref()
+                .map(|cleanup| cleanup.container_name.as_str()),
+            Some("grok-mirror-test")
+        );
+
+        #[cfg(target_os = "linux")]
+        {
+            assert!(spec
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--network" && pair[1] == "host"));
+            assert!(spec.args.iter().any(|arg| arg == "http://127.0.0.1:52770"));
+        }
+        #[cfg(not(target_os = "linux"))]
+        assert!(spec
+            .args
+            .iter()
+            .any(|arg| arg == "http://host.docker.internal:52770"));
     }
 }

--- a/src-tauri/src/remote_im/app_sessions.rs
+++ b/src-tauri/src/remote_im/app_sessions.rs
@@ -1,5 +1,6 @@
 //! Load App sessions_index for Remote IM /r + sync IM turns into App journal.
 
+use super::context::ContextCompactSnapshot;
 use super::control_plane::{AppSessionEntry, PendingMode, ScopeBinding};
 use crate::store::{self, ChatMessageStored, SessionMeta};
 use chrono::Utc;
@@ -25,6 +26,78 @@ fn emit_index_changed(session_id: &str) {
             serde_json::json!({ "sessionId": session_id, "source": "remote_im" }),
         );
     }
+}
+
+/// Persist a Remote IM compaction marker in the same App journal used by ACP.
+/// This keeps the desktop context indicator aligned with Telegram commands.
+pub fn sync_compact_to_app(
+    binding: &ScopeBinding,
+    compact: &ContextCompactSnapshot,
+) -> Option<String> {
+    let agent_id = binding
+        .agent_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty());
+    let session_id = find_app_session_id(&binding.local_session_id, agent_id)?;
+    let mut parts = vec![if compact.trigger == "manual" {
+        "manual".to_string()
+    } else {
+        "auto".to_string()
+    }];
+    match (compact.tokens_before, compact.tokens_after) {
+        (Some(before), Some(after)) => parts.push(format!("tokens:{before}->{after}")),
+        (Some(before), None) => parts.push(format!("tokens_before:{before}")),
+        (None, Some(after)) => parts.push(format!("tokens_after:{after}")),
+        (None, None) => {}
+    }
+    if let Some(note) = compact.note.as_deref().map(str::trim).filter(|n| !n.is_empty()) {
+        parts.push(format!("note:{note}"));
+    }
+    let mut content = format!("context_compact|{}", parts.join("|"));
+    if let Some(summary) = compact
+        .summary_preview
+        .as_deref()
+        .map(str::trim)
+        .filter(|summary| !summary.is_empty())
+    {
+        content.push('\n');
+        content.push_str(summary);
+    }
+    let message_id = uuid::Uuid::new_v4().to_string();
+    if let Err(error) = store::append_message(
+        &session_id,
+        ChatMessageStored {
+            id: message_id.clone(),
+            role: "tool".into(),
+            content: content.clone(),
+            thought: None,
+            created_at: Utc::now(),
+            is_error: false,
+            attachments: None,
+            marker: Some("context_compact".into()),
+        },
+    ) {
+        tracing::warn!(%error, session = %session_id, "remote_im: append compact marker failed");
+        return None;
+    }
+    if let Some(app) = APP_HANDLE.get() {
+        let _ = app.emit(
+            "session://context_compact",
+            serde_json::json!({
+                "sessionId": session_id,
+                "messageId": message_id,
+                "trigger": compact.trigger,
+                "tokensBefore": compact.tokens_before,
+                "tokensAfter": compact.tokens_after,
+                "summaryPreview": compact.summary_preview,
+                "note": compact.note,
+                "content": content,
+            }),
+        );
+    }
+    emit_index_changed(&session_id);
+    Some(message_id)
 }
 
 pub fn sessions_for_project(project_id: Option<&str>) -> Vec<AppSessionEntry> {

--- a/src-tauri/src/remote_im/channels/telegram.rs
+++ b/src-tauri/src/remote_im/channels/telegram.rs
@@ -7,6 +7,9 @@ use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 
+/// Telegram accepts two-letter ISO 639-1 language codes for command menus.
+const COMMAND_LANGUAGE_CODES_ZH: &[&str] = &["zh"];
+
 pub async fn run(
     inst: ChannelInstance,
     tx: mpsc::Sender<IncomingMessage>,
@@ -50,7 +53,10 @@ pub async fn run(
         let res = match res {
             Ok(r) => r,
             Err(e) => {
-                tracing::warn!(instance = %inst.id, "telegram poll error: {e}");
+                // reqwest errors include the request URL by default; Telegram
+                // embeds the bot token in that URL, so always strip it first.
+                let safe_error = e.without_url();
+                tracing::warn!(instance = %inst.id, "telegram poll error: {safe_error}");
                 tokio::time::sleep(Duration::from_secs(3)).await;
                 continue;
             }
@@ -286,10 +292,9 @@ pub async fn register_native_commands(
 
     // Default language (fallback for all clients)
     post_set_my_commands(client, &base, &en_cmds, None).await?;
-    // Simplified Chinese clients
-    post_set_my_commands(client, &base, &zh_cmds, Some("zh-hans")).await?;
-    // Also zh as broader Chinese tag used by some clients
-    let _ = post_set_my_commands(client, &base, &zh_cmds, Some("zh")).await;
+    for language_code in COMMAND_LANGUAGE_CODES_ZH {
+        post_set_my_commands(client, &base, &zh_cmds, Some(language_code)).await?;
+    }
 
     Ok(())
 }
@@ -309,7 +314,7 @@ async fn post_set_my_commands(
         .json(&body)
         .send()
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| e.without_url().to_string())?;
     if !res.status().is_success() {
         let status = res.status();
         let text = res.text().await.unwrap_or_default();
@@ -394,7 +399,7 @@ async fn post_bot_api(
         .json(body)
         .send()
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| e.without_url().to_string())?;
     let status = res.status();
     let value: Value = res.json().await.map_err(|e| e.to_string())?;
     if !status.is_success() || value.get("ok").and_then(|x| x.as_bool()) != Some(true) {
@@ -505,6 +510,14 @@ pub async fn edit_card(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn command_menu_language_codes_are_telegram_compatible() {
+        assert_eq!(COMMAND_LANGUAGE_CODES_ZH, &["zh"]);
+        assert!(COMMAND_LANGUAGE_CODES_ZH.iter().all(|code| {
+            code.len() == 2 && code.bytes().all(|byte| byte.is_ascii_lowercase())
+        }));
+    }
 
     #[test]
     fn normalizes_bot_command_with_entity() {

--- a/src-tauri/src/remote_im/context.rs
+++ b/src-tauri/src/remote_im/context.rs
@@ -1,0 +1,392 @@
+//! Context usage/compaction data shared by Remote IM commands and headless turns.
+
+use crate::store::ChatMessageStored;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextUsageSnapshot {
+    pub total_tokens: Option<u64>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub system_tokens: Option<u64>,
+    pub tools_tokens: Option<u64>,
+    pub history_tokens: Option<u64>,
+    /// Agent event kind, for example `usage`, `turn_usage`, or `compact`.
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextCompactSnapshot {
+    pub trigger: String,
+    pub tokens_before: Option<u64>,
+    pub tokens_after: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary_preview: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ContextSignals {
+    pub usage: Option<ContextUsageSnapshot>,
+    pub compact: Option<ContextCompactSnapshot>,
+}
+
+fn token_u64(obj: &Value, keys: &[&str]) -> Option<u64> {
+    keys.iter().find_map(|key| {
+        obj.get(*key).and_then(|value| {
+            value
+                .as_u64()
+                .or_else(|| value.as_i64().map(|n| n.max(0) as u64))
+                .or_else(|| value.as_f64().map(|n| n.max(0.0) as u64))
+        })
+    })
+}
+
+fn event_kind(value: &Value) -> String {
+    ["sessionUpdate", "session_update", "type", "event", "kind"]
+        .iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .unwrap_or("")
+        .to_ascii_lowercase()
+}
+
+fn parse_usage(kind: &str, update: &Value) -> Option<ContextUsageSnapshot> {
+    let root = update
+        .get("usage")
+        .or_else(|| update.get("tokenUsage"))
+        .or_else(|| update.get("token_usage"))
+        .or_else(|| update.get("tokens"))
+        .filter(|value| value.is_object())
+        .unwrap_or(update);
+    let input_tokens = token_u64(
+        root,
+        &[
+            "inputTokens",
+            "input_tokens",
+            "promptTokens",
+            "prompt_tokens",
+            "input",
+        ],
+    );
+    let output_tokens = token_u64(
+        root,
+        &[
+            "outputTokens",
+            "output_tokens",
+            "completionTokens",
+            "completion_tokens",
+            "output",
+        ],
+    );
+    let total_tokens = token_u64(
+        root,
+        &[
+            "totalTokens",
+            "total_tokens",
+            "contextTokens",
+            "context_tokens",
+            "usedTokens",
+            "used_tokens",
+            "tokens",
+            "total",
+        ],
+    )
+    .or_else(|| match (input_tokens, output_tokens) {
+        (Some(input), Some(output)) => Some(input.saturating_add(output)),
+        _ => None,
+    });
+    let system_tokens = token_u64(root, &["systemTokens", "system_tokens", "system"]);
+    let tools_tokens = token_u64(
+        root,
+        &[
+            "toolsTokens",
+            "tools_tokens",
+            "toolTokens",
+            "tool_tokens",
+            "tools",
+        ],
+    );
+    let history_tokens = token_u64(
+        root,
+        &[
+            "historyTokens",
+            "history_tokens",
+            "messagesTokens",
+            "messages_tokens",
+            "history",
+        ],
+    );
+    if total_tokens.is_none()
+        && input_tokens.is_none()
+        && output_tokens.is_none()
+        && system_tokens.is_none()
+        && tools_tokens.is_none()
+        && history_tokens.is_none()
+    {
+        return None;
+    }
+    // Compact-only before/after counters are not a regular usage report.
+    if kind.contains("compact")
+        && total_tokens.is_none()
+        && (update.get("tokens_before").is_some()
+            || update.get("tokensBefore").is_some()
+            || update.get("tokens_after").is_some()
+            || update.get("tokensAfter").is_some())
+    {
+        return None;
+    }
+    Some(ContextUsageSnapshot {
+        total_tokens,
+        input_tokens,
+        output_tokens,
+        system_tokens,
+        tools_tokens,
+        history_tokens,
+        source: if kind.is_empty() { "usage" } else { kind }.to_string(),
+    })
+}
+
+fn parse_compact(kind: &str, update: &Value) -> Option<ContextCompactSnapshot> {
+    let tokens_before = token_u64(update, &["tokens_before", "tokensBefore"]);
+    let tokens_after = token_u64(update, &["tokens_after", "tokensAfter"]);
+    let title = update.get("title").and_then(Value::as_str).unwrap_or("");
+    let title_lower = title.to_ascii_lowercase();
+    let is_compact = kind.contains("compact")
+        || tokens_before.is_some()
+        || tokens_after.is_some()
+        || title_lower.contains("compact");
+    if !is_compact {
+        return None;
+    }
+    let trigger_raw = update
+        .get("trigger")
+        .or_else(|| update.get("trigger_type"))
+        .or_else(|| update.get("triggerType"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let trigger = if trigger_raw.eq_ignore_ascii_case("manual")
+        || kind.contains("manual")
+        || (title_lower.contains("compact") && !title_lower.contains("auto"))
+    {
+        "manual"
+    } else if trigger_raw.eq_ignore_ascii_case("auto") || kind.contains("auto") {
+        "auto"
+    } else if trigger_raw.is_empty() {
+        "auto"
+    } else {
+        trigger_raw
+    };
+    let summary_preview = update
+        .get("summary_preview")
+        .or_else(|| update.get("summaryPreview"))
+        .or_else(|| update.get("summary"))
+        .and_then(Value::as_str)
+        .map(|text| text.chars().take(500).collect());
+    let note = update
+        .get("note")
+        .or_else(|| update.get("message"))
+        .or_else(|| update.get("reason"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| (!title.is_empty()).then(|| title.to_string()));
+    Some(ContextCompactSnapshot {
+        trigger: trigger.to_string(),
+        tokens_before,
+        tokens_after,
+        summary_preview,
+        note,
+    })
+}
+
+fn visit_signals(value: &Value, signals: &mut ContextSignals) {
+    let Value::Object(map) = value else {
+        return;
+    };
+    let kind = event_kind(value);
+    if let Some(usage) = parse_usage(&kind, value) {
+        signals.usage = Some(usage);
+    }
+    if let Some(compact) = parse_compact(&kind, value) {
+        signals.compact = Some(compact);
+    }
+    // Headless stream envelopes differ between CLI versions. Recursing through
+    // JSON objects keeps Remote IM compatible with both flat and ACP-like payloads.
+    for child in map.values() {
+        if child.is_object() {
+            visit_signals(child, signals);
+        } else if let Value::Array(items) = child {
+            for item in items.iter().filter(|item| item.is_object()) {
+                visit_signals(item, signals);
+            }
+        }
+    }
+}
+
+pub fn extract_context_signals(value: &Value) -> ContextSignals {
+    let mut signals = ContextSignals::default();
+    visit_signals(value, &mut signals);
+    signals
+}
+
+pub fn estimate_visible_tokens(messages: &[ChatMessageStored]) -> u64 {
+    let chars: usize = messages
+        .iter()
+        .filter(|message| {
+            message.role != "tool"
+                && !matches!(
+                    message.marker.as_deref(),
+                    Some("context_compact" | "turn_cancelled" | "turn_end" | "tool_step")
+                )
+        })
+        .map(|message| {
+            message.content.chars().count()
+                + message
+                    .thought
+                    .as_deref()
+                    .map(|thought| thought.chars().count())
+                    .unwrap_or(0)
+        })
+        .sum();
+    chars.div_ceil(4) as u64
+}
+
+fn parse_compact_marker(message: &ChatMessageStored) -> Option<ContextCompactSnapshot> {
+    if message.marker.as_deref() != Some("context_compact")
+        && !message.content.starts_with("context_compact|")
+    {
+        return None;
+    }
+    let (head, summary) = message
+        .content
+        .split_once('\n')
+        .map(|(head, summary)| (head, Some(summary.trim().to_string())))
+        .unwrap_or((message.content.as_str(), None));
+    let mut trigger = "auto".to_string();
+    let mut tokens_before = None;
+    let mut tokens_after = None;
+    let mut note = None;
+    for part in head.split('|').skip(1) {
+        if part == "manual" || part == "auto" {
+            trigger = part.to_string();
+        } else if let Some(tokens) = part.strip_prefix("tokens:") {
+            if let Some((before, after)) = tokens.split_once("->") {
+                tokens_before = before.parse().ok();
+                tokens_after = after.parse().ok();
+            }
+        } else if let Some(before) = part.strip_prefix("tokens_before:") {
+            tokens_before = before.parse().ok();
+        } else if let Some(after) = part.strip_prefix("tokens_after:") {
+            tokens_after = after.parse().ok();
+        } else if let Some(value) = part.strip_prefix("note:") {
+            note = Some(value.to_string());
+        }
+    }
+    Some(ContextCompactSnapshot {
+        trigger,
+        tokens_before,
+        tokens_after,
+        summary_preview: summary.filter(|summary| !summary.is_empty()),
+        note,
+    })
+}
+
+pub fn latest_compact_from_messages(
+    messages: &[ChatMessageStored],
+) -> Option<(usize, ContextCompactSnapshot)> {
+    messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(index, message)| parse_compact_marker(message).map(|compact| (index, compact)))
+}
+
+pub fn format_tokens(tokens: u64) -> String {
+    let raw = tokens.to_string();
+    let mut out = String::with_capacity(raw.len() + raw.len() / 3);
+    for (index, ch) in raw.chars().enumerate() {
+        if index > 0 && (raw.len() - index) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_nested_usage_and_compaction() {
+        let signals = extract_context_signals(&json!({
+            "type": "session_update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "compaction_completed",
+                    "trigger": "manual",
+                    "tokensBefore": 12000,
+                    "tokensAfter": 3200,
+                    "usage": { "inputTokens": 3000, "outputTokens": 200, "totalTokens": 3200 }
+                }
+            }
+        }));
+        assert_eq!(
+            signals.usage.as_ref().and_then(|u| u.total_tokens),
+            Some(3200)
+        );
+        assert_eq!(
+            signals.compact.as_ref().and_then(|c| c.tokens_before),
+            Some(12000)
+        );
+        assert_eq!(
+            signals.compact.as_ref().map(|c| c.trigger.as_str()),
+            Some("manual")
+        );
+    }
+
+    #[test]
+    fn estimates_only_visible_conversation_text() {
+        let message = |role: &str, content: &str, marker: Option<&str>| ChatMessageStored {
+            id: uuid::Uuid::new_v4().to_string(),
+            role: role.into(),
+            content: content.into(),
+            thought: None,
+            created_at: Utc::now(),
+            is_error: false,
+            attachments: None,
+            marker: marker.map(str::to_string),
+        };
+        let messages = vec![
+            message("user", "12345678", None),
+            message("assistant", "1234", None),
+            message("tool", "ignored", Some("context_compact")),
+        ];
+        assert_eq!(estimate_visible_tokens(&messages), 3);
+        assert_eq!(format_tokens(1234567), "1,234,567");
+    }
+
+    #[test]
+    fn hydrates_latest_compact_marker() {
+        let message = ChatMessageStored {
+            id: "compact-1".into(),
+            role: "tool".into(),
+            content: "context_compact|manual|tokens:12000->3200|note:keep decisions".into(),
+            thought: None,
+            created_at: Utc::now(),
+            is_error: false,
+            attachments: None,
+            marker: Some("context_compact".into()),
+        };
+        let (_, compact) = latest_compact_from_messages(&[message]).expect("compact marker");
+        assert_eq!(compact.trigger, "manual");
+        assert_eq!(compact.tokens_before, Some(12000));
+        assert_eq!(compact.tokens_after, Some(3200));
+        assert_eq!(compact.note.as_deref(), Some("keep decisions"));
+    }
+}

--- a/src-tauri/src/remote_im/control_plane.rs
+++ b/src-tauri/src/remote_im/control_plane.rs
@@ -1,6 +1,7 @@
 //! Pure control-plane transitions for Remote IM (/p /r / bind / resume).
 //! Network-free and unit-tested against production functions.
 
+use super::context::{ContextCompactSnapshot, ContextUsageSnapshot};
 use super::types::TrustedProject;
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +28,12 @@ pub struct ScopeBinding {
     pub agent_session_id: Option<String>,
     pub pending_mode: PendingMode,
     pub turn_count: u32,
+    /// Last agent-reported context usage. Older persisted bindings omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_usage: Option<ContextUsageSnapshot>,
+    /// Last manual/automatic compaction observed for this agent session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_compact: Option<ContextCompactSnapshot>,
 }
 
 impl ScopeBinding {
@@ -38,6 +45,8 @@ impl ScopeBinding {
             agent_session_id: None,
             pending_mode: PendingMode::New,
             turn_count: 0,
+            context_usage: None,
+            last_compact: None,
         }
     }
 }
@@ -72,6 +81,8 @@ pub fn binding_after_project_select(_prev: &ScopeBinding, project: &TrustedProje
         agent_session_id: None,
         pending_mode: PendingMode::New,
         turn_count: 0,
+        context_usage: None,
+        last_compact: None,
     }
 }
 
@@ -87,6 +98,10 @@ pub fn binding_after_session_resume(
     next.agent_session_id = Some(effective_agent_session_id(session));
     next.pending_mode = PendingMode::Resume;
     next.local_session_id = session.id.clone();
+    // Usage belongs to the previously bound agent session. `/context` can
+    // hydrate compact markers or estimate the newly selected App journal.
+    next.context_usage = None;
+    next.last_compact = None;
     next
 }
 
@@ -934,6 +949,8 @@ mod tests {
             agent_session_id: None,
             pending_mode: PendingMode::New,
             turn_count: 0,
+            context_usage: None,
+            last_compact: None,
         };
         let s = sess("app-sess-1", "p1", "Prior chat", Some("grok-agent-99"));
         let next = binding_after_session_resume(&b, &s);
@@ -1197,6 +1214,8 @@ mod tests {
             agent_session_id: None,
             pending_mode: PendingMode::New,
             turn_count: 0,
+            context_usage: None,
+            last_compact: None,
         };
         let s = sess("app1", "p1", "Chat", Some("agent-xyz"));
         let b1 = binding_after_session_resume(&b0, &s);
@@ -1219,5 +1238,20 @@ mod tests {
         // CLI path for turn 2
         let args = grok_turn_cli_args("follow up", Some("agent-xyz"), false);
         assert!(args.contains(&"--resume".into()));
+    }
+
+    #[test]
+    fn old_scope_binding_json_defaults_context_fields() {
+        let binding: ScopeBinding = serde_json::from_value(serde_json::json!({
+            "projectId": "p1",
+            "workDir": "/tmp/project",
+            "localSessionId": "local-1",
+            "agentSessionId": "agent-1",
+            "pendingMode": "continue",
+            "turnCount": 2
+        }))
+        .expect("old persisted binding should still deserialize");
+        assert!(binding.context_usage.is_none());
+        assert!(binding.last_compact.is_none());
     }
 }

--- a/src-tauri/src/remote_im/engine.rs
+++ b/src-tauri/src/remote_im/engine.rs
@@ -6,6 +6,10 @@ use super::control_plane::{
     format_project_menu, format_session_menu, list_sessions_for_project, parse_card_action,
     resolve_turn_intent, AppSessionEntry, CardAction, PendingMode, ScopeBinding, TurnIntent,
 };
+use super::context::{
+    estimate_visible_tokens, format_tokens, latest_compact_from_messages, ContextCompactSnapshot,
+    ContextUsageSnapshot,
+};
 use super::grok_agent;
 use super::outbound::{self, OutboundRouter};
 use super::projects::{self, load_trusted_projects};
@@ -855,6 +859,13 @@ impl Engine {
                 );
                 let _ = self.reply_msg(msg, &text).await;
             }
+            BuiltinCommand::Context => {
+                self.handle_context(scope, msg, default_wd).await;
+            }
+            BuiltinCommand::Compact { note } => {
+                self.handle_compact(note.as_deref(), scope, msg, default_wd)
+                    .await;
+            }
             BuiltinCommand::Stop => {
                 self.aborts.lock().insert(scope.to_string(), true);
                 let t = if self.lang == "en" {
@@ -884,6 +895,118 @@ impl Engine {
                 let _ = self.reply_msg(msg, &t).await;
             }
         }
+    }
+
+    async fn handle_context(&self, scope: &str, msg: &IncomingMessage, default_wd: &str) {
+        let binding = self.store.get_or_create(scope, default_wd);
+        let messages = crate::store::load_messages(&binding.local_session_id);
+        let text = format_context_report(&binding, &messages, &self.lang);
+        let _ = self.reply_msg(msg, &text).await;
+    }
+
+    async fn handle_compact(
+        &self,
+        note: Option<&str>,
+        scope: &str,
+        msg: &IncomingMessage,
+        default_wd: &str,
+    ) {
+        let binding = self.store.get_or_create(scope, default_wd);
+        let Some(agent_session_id) = binding
+            .agent_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+        else {
+            let text = if self.lang == "en" {
+                "No active agent session. Send a message or use /r first."
+            } else {
+                "当前没有可压缩的 agent 会话。请先发送一条消息，或使用 /r 恢复会话。"
+            };
+            let _ = self.reply_msg(msg, text).await;
+            return;
+        };
+        let compact_prompt = match note.map(str::trim).filter(|note| !note.is_empty()) {
+            Some(note) => format!("/compact {note}"),
+            None => "/compact".to_string(),
+        };
+        let working = if self.lang == "en" {
+            "Compacting current session…"
+        } else {
+            "正在压缩当前会话…"
+        };
+        let _ = self.reply_msg(msg, working).await;
+
+        let before = binding
+            .context_usage
+            .as_ref()
+            .and_then(|usage| usage.total_tokens)
+            .or_else(|| binding.last_compact.as_ref().and_then(|item| item.tokens_after));
+        let result = grok_agent::run_turn(
+            &PathBuf::from(&binding.work_dir),
+            &compact_prompt,
+            Some(&agent_session_id),
+            self.allow_remote_yolo,
+            None,
+        )
+        .await;
+        if let Some(error) = result.error.as_deref() {
+            let text = agent_error_user_message(&self.lang, classify_rim_error(error), error);
+            let _ = self.reply_msg(msg, &text).await;
+            return;
+        }
+
+        let event_confirmed = result.compact.is_some();
+        let mut compact = result.compact.unwrap_or_else(|| ContextCompactSnapshot {
+            trigger: "manual".into(),
+            tokens_before: before,
+            tokens_after: result.usage.as_ref().and_then(|usage| usage.total_tokens),
+            summary_preview: None,
+            note: note.map(str::trim).filter(|note| !note.is_empty()).map(str::to_string),
+        });
+        if compact.tokens_before.is_none() {
+            compact.tokens_before = before;
+        }
+        if compact.tokens_after.is_none() {
+            compact.tokens_after = result.usage.as_ref().and_then(|usage| usage.total_tokens);
+        }
+        if compact.note.is_none() {
+            compact.note = note.map(str::trim).filter(|note| !note.is_empty()).map(str::to_string);
+        }
+
+        let mut next = binding_after_agent_turn(
+            &binding,
+            result.session_id.as_deref().or(Some(agent_session_id.as_str())),
+        );
+        next.last_compact = Some(compact.clone());
+        next.context_usage = result.usage.or_else(|| {
+            compact.tokens_after.map(|tokens| ContextUsageSnapshot {
+                total_tokens: Some(tokens),
+                input_tokens: None,
+                output_tokens: None,
+                system_tokens: None,
+                tools_tokens: None,
+                history_tokens: None,
+                source: "compact".into(),
+            })
+        });
+        self.store.set(scope, next.clone());
+        app_sessions::sync_compact_to_app(&next, &compact);
+
+        let span = format_compact_span(compact.tokens_before, compact.tokens_after);
+        let text = if self.lang == "en" {
+            if event_confirmed {
+                format!("Compaction completed.{span}\nUse /context to inspect the current size.")
+            } else {
+                format!("/compact was sent.{span}\nThis CLI did not emit a compaction event; use /context to inspect the latest available size.")
+            }
+        } else if event_confirmed {
+            format!("会话压缩完成。{span}\n可发送 /context 查看当前大小。")
+        } else {
+            format!("已发送 /compact。{span}\n当前 CLI 未返回压缩事件，可发送 /context 查看最新可用大小。")
+        };
+        let _ = self.reply_msg(msg, &text).await;
     }
 
     async fn handle_project(
@@ -1123,6 +1246,9 @@ impl Engine {
         )
         .await;
 
+        let usage = result.usage.clone();
+        let compact = result.compact.clone();
+
         let mut next = binding_after_agent_turn(
             &binding,
             result.session_id.as_deref().or(resume_id.as_deref()),
@@ -1135,6 +1261,27 @@ impl Engine {
         }
         if next.pending_mode == PendingMode::New {
             next.pending_mode = PendingMode::Continue;
+        }
+        // Do not carry a previous turn's count forward as if it were current.
+        // `/context` can still estimate growth from the last compact baseline.
+        next.context_usage = usage;
+        if let Some(compact) = compact.as_ref() {
+            next.last_compact = Some(compact.clone());
+            // A compact event invalidates stale pre-compact usage. Keep a known
+            // post-compact base only when the agent actually reported one.
+            if compact.tokens_after.is_some() && next.context_usage.is_none() {
+                next.context_usage = compact.tokens_after.map(|tokens| ContextUsageSnapshot {
+                    total_tokens: Some(tokens),
+                    input_tokens: None,
+                    output_tokens: None,
+                    system_tokens: None,
+                    tools_tokens: None,
+                    history_tokens: None,
+                    source: "compact".into(),
+                });
+            } else if compact.tokens_after.is_none() {
+                next.context_usage = None;
+            }
         }
 
         let had_error = result.error.is_some();
@@ -1170,6 +1317,9 @@ impl Engine {
             is_error,
             &msg.channel,
         );
+        if let Some(compact) = compact.as_ref() {
+            app_sessions::sync_compact_to_app(&next, compact);
+        }
         self.store.set(scope, next);
 
         for chunk in chunk_text(&text, 3500) {
@@ -1402,6 +1552,150 @@ Add more accounts in Grok App → Settings → Account to enable `/account n` sw
         out.push("回复序号切换 · `0` 取消 · 或 `/account <序号>`".into());
     }
     out.join("\n")
+}
+
+fn format_compact_span(before: Option<u64>, after: Option<u64>) -> String {
+    match (before, after) {
+        (Some(before), Some(after)) => format!(
+            "\n- context: {} → {} tokens",
+            format_tokens(before),
+            format_tokens(after)
+        ),
+        (Some(before), None) => format!("\n- before: {} tokens", format_tokens(before)),
+        (None, Some(after)) => format!("\n- after: {} tokens", format_tokens(after)),
+        (None, None) => String::new(),
+    }
+}
+
+fn format_context_report(
+    binding: &ScopeBinding,
+    messages: &[crate::store::ChatMessageStored],
+    lang: &str,
+) -> String {
+    let journal_compact = latest_compact_from_messages(messages);
+    let last_compact = binding
+        .last_compact
+        .clone()
+        .or_else(|| journal_compact.as_ref().map(|(_, compact)| compact.clone()));
+    let mut lines = if lang == "en" {
+        vec!["**Current session context**".to_string()]
+    } else {
+        vec!["**当前会话上下文**".to_string()]
+    };
+    if binding.agent_session_id.is_none() && messages.is_empty() {
+        lines.push(if lang == "en" {
+            "- size: unavailable (no active agent session)".into()
+        } else {
+            "- 大小：暂无（当前没有 agent 会话）".into()
+        });
+    } else if let Some(usage) = binding.context_usage.as_ref() {
+        if let Some(total) = usage.total_tokens {
+            lines.push(if lang == "en" {
+                format!("- used: **{} tokens** (agent-reported)", format_tokens(total))
+            } else {
+                format!("- 已用：**{} tokens**（agent 上报）", format_tokens(total))
+            });
+        } else {
+            lines.push(if lang == "en" {
+                "- used: total unavailable (partial agent report)".into()
+            } else {
+                "- 已用：总量暂无（agent 仅上报了部分指标）".into()
+            });
+        }
+        if usage.input_tokens.is_some() || usage.output_tokens.is_some() {
+            lines.push(format!(
+                "- input / output: {} / {}",
+                usage.input_tokens.map(format_tokens).unwrap_or_else(|| "-".into()),
+                usage.output_tokens.map(format_tokens).unwrap_or_else(|| "-".into())
+            ));
+        }
+    } else if last_compact
+        .as_ref()
+        .is_some_and(|compact| compact.tokens_after.is_none())
+    {
+        lines.push(if lang == "en" {
+            "- used: unavailable — the last compact event did not report token counts".into()
+        } else {
+            "- 已用：暂无——最近一次压缩事件没有上报 token 数".into()
+        });
+    } else if let Some((marker_index, compact)) = journal_compact
+        .as_ref()
+        .filter(|(_, compact)| compact.tokens_after.is_some())
+    {
+        let base = compact.tokens_after.unwrap_or(0);
+        let delta = estimate_visible_tokens(&messages[marker_index + 1..]);
+        let estimate = base.saturating_add(delta);
+        lines.push(if lang == "en" {
+            format!(
+                "- used: **~{} tokens** (reported post-compact base + visible-message estimate)",
+                format_tokens(estimate)
+            )
+        } else {
+            format!(
+                "- 已用：**~{} tokens**（压缩后上报基线 + 后续可见消息估算）",
+                format_tokens(estimate)
+            )
+        });
+    } else if let Some(after) = last_compact
+        .as_ref()
+        .and_then(|compact| compact.tokens_after)
+    {
+        lines.push(if lang == "en" {
+            format!(
+                "- last known: **{} tokens** after compact (current growth unavailable)",
+                format_tokens(after)
+            )
+        } else {
+            format!(
+                "- 最近已知：压缩后 **{} tokens**（当前增量暂无）",
+                format_tokens(after)
+            )
+        });
+    } else if messages.is_empty() {
+        lines.push(if lang == "en" {
+            "- used: unavailable (send a message, then retry)".into()
+        } else {
+            "- 已用：暂无（发送一条消息后再试）".into()
+        });
+    } else {
+        let estimate = estimate_visible_tokens(messages);
+        lines.push(if lang == "en" {
+            format!(
+                "- used: **~{} tokens** (visible-message estimate, not model tokenizer output)",
+                format_tokens(estimate)
+            )
+        } else {
+            format!(
+                "- 已用：**~{} tokens**（按可见消息估算，并非模型 tokenizer 精确值）",
+                format_tokens(estimate)
+            )
+        });
+    }
+
+    if let Some(compact) = last_compact.as_ref() {
+        let span = match (compact.tokens_before, compact.tokens_after) {
+            (Some(before), Some(after)) => {
+                format!("{} → {} tokens", format_tokens(before), format_tokens(after))
+            }
+            (Some(before), None) => format!("before {} tokens", format_tokens(before)),
+            (None, Some(after)) => format!("after {} tokens", format_tokens(after)),
+            (None, None) => if lang == "en" {
+                "counts unavailable"
+            } else {
+                "未上报数值"
+            }
+            .into(),
+        };
+        lines.push(if lang == "en" {
+            format!("- last compact: {} ({span})", compact.trigger)
+        } else {
+            format!("- 最近压缩：{}（{span}）", compact.trigger)
+        });
+    }
+    if let Some(session_id) = binding.agent_session_id.as_deref() {
+        lines.push(format!("- agent session: `{session_id}`"));
+    }
+    lines.join("\n")
 }
 
 /// After Remote IM switches auth.json, soft-drop desktop ACP + notify UI.

--- a/src-tauri/src/remote_im/grok_agent.rs
+++ b/src-tauri/src/remote_im/grok_agent.rs
@@ -5,10 +5,16 @@ use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
+use super::context::{
+    extract_context_signals, ContextCompactSnapshot, ContextUsageSnapshot,
+};
+
 pub struct GrokTurnResult {
     pub text: String,
     pub session_id: Option<String>,
     pub error: Option<String>,
+    pub usage: Option<ContextUsageSnapshot>,
+    pub compact: Option<ContextCompactSnapshot>,
 }
 
 pub fn resolve_grok_binary() -> PathBuf {
@@ -123,6 +129,8 @@ pub async fn run_turn(
                 text: String::new(),
                 session_id: None,
                 error: Some(format!("spawn grok failed: {e}")),
+                usage: None,
+                compact: None,
             };
         }
     };
@@ -132,6 +140,8 @@ pub async fn run_turn(
     let mut acc = String::new();
     let mut out_sid: Option<String> = None;
     let mut err_msg: Option<String> = None;
+    let mut context_usage: Option<ContextUsageSnapshot> = None;
+    let mut context_compact: Option<ContextCompactSnapshot> = None;
 
     // Drain stderr concurrently so the child cannot block on a full pipe.
     let stderr_task = tokio::spawn(async move {
@@ -155,6 +165,13 @@ pub async fn run_turn(
                 continue;
             }
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+                let signals = extract_context_signals(&v);
+                if signals.usage.is_some() {
+                    context_usage = signals.usage;
+                }
+                if signals.compact.is_some() {
+                    context_compact = signals.compact;
+                }
                 if let Some(sid) = v
                     .get("session_id")
                     .or_else(|| v.get("sessionId"))
@@ -255,6 +272,8 @@ pub async fn run_turn(
 
     // If streaming-json path yields nothing useful, retry simple -p but KEEP resume.
     if acc.trim().is_empty()
+        && context_usage.is_none()
+        && context_compact.is_none()
         && err_msg
             .as_ref()
             .map(|e| e.contains("exit") || e.contains("spawn"))
@@ -268,6 +287,12 @@ pub async fn run_turn(
                 .filter(|s| !s.is_empty())
                 .or(out_sid);
         }
+        if simple.usage.is_none() {
+            simple.usage = context_usage;
+        }
+        if simple.compact.is_none() {
+            simple.compact = context_compact;
+        }
         return simple;
     }
 
@@ -279,6 +304,8 @@ pub async fn run_turn(
                 .filter(|s| !s.is_empty())
         }),
         error: err_msg,
+        usage: context_usage,
+        compact: context_compact,
     }
 }
 
@@ -331,6 +358,8 @@ async fn run_turn_simple(
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty()),
                 error: err,
+                usage: None,
+                compact: None,
             }
         }
         Err(e) => GrokTurnResult {
@@ -339,6 +368,8 @@ async fn run_turn_simple(
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty()),
             error: Some(e.to_string()),
+            usage: None,
+            compact: None,
         },
     }
 }

--- a/src-tauri/src/remote_im/mod.rs
+++ b/src-tauri/src/remote_im/mod.rs
@@ -4,6 +4,7 @@ mod app_sessions;
 mod bridge;
 mod channels;
 mod config;
+mod context;
 mod control_plane;
 mod engine;
 mod feishu_reg;

--- a/src-tauri/src/remote_im/slash.rs
+++ b/src-tauri/src/remote_im/slash.rs
@@ -7,6 +7,10 @@ pub enum BuiltinCommand {
     New,
     Whoami,
     Status,
+    /// Compact the currently bound agent session; optional text guides the summary.
+    Compact { note: Option<String> },
+    /// Show current/last-reported context usage for the bound session.
+    Context,
     Stop,
     /// List saved Grok accounts + quota; optional query picks/switches by number or label.
     Account { query: Option<String> },
@@ -66,6 +70,16 @@ pub fn native_bot_commands() -> &'static [NativeBotCommand] {
             command: "status",
             description_en: "Binding & runtime snapshot",
             description_zh: "绑定与运行状态",
+        },
+        NativeBotCommand {
+            command: "context",
+            description_en: "Show current context usage",
+            description_zh: "查看当前会话上下文用量",
+        },
+        NativeBotCommand {
+            command: "compact",
+            description_en: "Compact the current session",
+            description_zh: "压缩当前会话上下文",
         },
         NativeBotCommand {
             command: "whoami",
@@ -136,6 +150,8 @@ pub fn parse_slash(text: &str) -> Option<BuiltinCommand> {
         "new" | "reset" => BuiltinCommand::New,
         "whoami" | "id" => BuiltinCommand::Whoami,
         "status" => BuiltinCommand::Status,
+        "context" | "ctx" => BuiltinCommand::Context,
+        "compact" => BuiltinCommand::Compact { note: query },
         "stop" | "cancel" => BuiltinCommand::Stop,
         // Multi-account: list quota + switch (Telegram native menu + aliases).
         "account" | "accounts" | "quota" | "usage" | "switch" => {
@@ -165,6 +181,8 @@ pub fn help_text(lang: &str) -> String {
             "- `/account <n|label>` · `/switch <n>` — switch Grok account",
             "- `/whoami` — show your sender id",
             "- `/status` — snapshot",
+            "- `/context` — current context usage (agent-reported or clearly marked estimate)",
+            "- `/compact [note]` — compact the current session context",
             "- `/stop` — cancel in-flight turn",
             "- `0` — cancel number-pick mode",
         ]
@@ -184,6 +202,8 @@ pub fn help_text(lang: &str) -> String {
             "- `/account <序号|标签>` · `/switch <序号>` — 切换 Grok 账号",
             "- `/whoami` — 查看发送者 id",
             "- `/status` — 状态快照",
+            "- `/context` — 当前会话上下文用量（上报值或明确标注的估算值）",
+            "- `/compact [备注]` — 压缩当前会话上下文",
             "- `/stop` — 中断当前任务",
             "- `0` — 取消序号选择",
         ]
@@ -212,6 +232,18 @@ mod tests {
             Some(BuiltinCommand::Resume { query: None })
         );
         assert!(matches!(parse_slash("hi"), None));
+    }
+
+    #[test]
+    fn parses_context_and_compact() {
+        assert_eq!(parse_slash("/context"), Some(BuiltinCommand::Context));
+        assert_eq!(parse_slash("/ctx"), Some(BuiltinCommand::Context));
+        assert_eq!(
+            parse_slash("/compact keep decisions"),
+            Some(BuiltinCommand::Compact {
+                note: Some("keep decisions".into())
+            })
+        );
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Grok",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.grokapp.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:ui",

--- a/src/components/RemoteImOverview.tsx
+++ b/src/components/RemoteImOverview.tsx
@@ -456,6 +456,12 @@ export function RemoteImOverview({
               <code>/status</code> — {t("settings.remoteIm.cmd.status")}
             </li>
             <li>
+              <code>/context</code> — {t("settings.remoteIm.cmd.context")}
+            </li>
+            <li>
+              <code>/compact [note]</code> — {t("settings.remoteIm.cmd.compact")}
+            </li>
+            <li>
               <code>/account</code> · <code>/quota</code> —{" "}
               {t("settings.remoteIm.cmd.account")}
             </li>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -4336,7 +4336,7 @@ const en = {
   "mirror.warningToken":
     "Anyone with this link can control the agent on this machine. Stop the host when finished.",
   "mirror.missingCloudflared":
-    "cloudflared not found. Install it and ensure it is on PATH, or use local-only mode for tests.",
+    "No local cloudflared binary was found and Docker is unavailable. Install cloudflared, or start Docker Desktop and retry; local-only mode remains available for tests.",
   "mirror.errorGeneric": "Something went wrong",
   "mirror.qrAlt": "QR code for phone mirror URL",
   "mirror.linkLabel": "Public URL",
@@ -4345,7 +4345,7 @@ const en = {
     "Tunnel failed, but the local host is still running. Phones on the public internet cannot reach this link — only loopback/LAN debug works until the tunnel is fixed.",
   "mirror.softTunnelDeadBanner":
     "The public tunnel exited, but the local host is still running. Connected phones may drop; restart the host after cloudflared is healthy.",
-  "mirror.err.cloudflaredMissing": "cloudflared missing",
+  "mirror.err.cloudflaredMissing": "Tunnel runtime unavailable",
   "mirror.err.tunnelTimeout": "Tunnel timeout",
   "mirror.err.tunnelSpawn": "Tunnel start failed",
   "mirror.err.tunnelNotRegistered": "Tunnel not registered",
@@ -4360,7 +4360,7 @@ const en = {
   "mirror.err.clientsFull": "Client limit",
   "mirror.err.other": "Error",
   "mirror.hint.cloudflaredMissing":
-    "Install cloudflared on PATH, or set GROK_MIRROR_NO_TUNNEL=1 for local-only tests.",
+    "Install cloudflared on PATH, or start Docker Desktop; alternatively set GROK_MIRROR_NO_TUNNEL=1 for local-only tests.",
   "mirror.hint.tunnelTimeout":
     "cloudflared did not become ready in time. Check network / firewall, then restart the host.",
   "mirror.hint.tunnelSpawn":
@@ -4943,7 +4943,7 @@ const en = {
   "settings.remoteIm.dingtalk.guide.step4": "Copy Client ID (AppKey) + Client Secret here, set allow-from, then Save & connect.",
   "settings.remoteIm.dingtalk.guide.softFail": "Test connection only checks that Client ID and Client Secret are present — it does not prove the Stream gateway WebSocket is online.",
   "settings.remoteIm.telegram.tokenHelp":
-    "Token from @BotFather. Stored masked and never logged. Connecting also registers /start /help /p /r /new /status /account /quota /switch /whoami /stop in Telegram’s native / menu.",
+    "Token from @BotFather. Stored masked and never logged. Connecting also registers /start /help /p /r /new /status /context /compact /account /quota /switch /whoami /stop in Telegram’s native / menu.",
   "settings.remoteIm.telegram.tokenPlaceholder": "123456789:AAH…",
   "settings.remoteIm.telegram.proxyHelp": "Optional HTTP or SOCKS5 proxy for Telegram API (getUpdates / send). Leave empty to use the app proxy or direct.",
   "settings.remoteIm.telegram.proxyPlaceholder": "socks5://127.0.0.1:1080",
@@ -5026,6 +5026,8 @@ const en = {
   "settings.remoteIm.cmd.resume": "List / resume an App history session",
   "settings.remoteIm.cmd.new": "New session, keep project",
   "settings.remoteIm.cmd.status": "Show binding status",
+  "settings.remoteIm.cmd.context": "Show current session context usage",
+  "settings.remoteIm.cmd.compact": "Compact the current agent session context",
   "settings.remoteIm.cmd.help": "Welcome & command help",
   "settings.remoteIm.cmd.whoami": "Show your sender id",
   "settings.remoteIm.cmd.stop": "Cancel the current turn",
@@ -9259,7 +9261,7 @@ const zh: Record<MessageKey, string> = {
   "mirror.warningToken":
     "持有此链接的人可以控制本机上的 Agent。用完后请停止主机。",
   "mirror.missingCloudflared":
-    "未找到 cloudflared。请安装并确保在 PATH 中，或在测试时使用仅本机模式。",
+    "未找到本机 cloudflared，且 Docker 当前不可用。请安装 cloudflared，或启动 Docker Desktop 后重试；测试时也可使用仅本机模式。",
   "mirror.errorGeneric": "出了点问题",
   "mirror.qrAlt": "手机镜像地址的二维码",
   "mirror.linkLabel": "公开地址",
@@ -9268,7 +9270,7 @@ const zh: Record<MessageKey, string> = {
     "隧道启动失败，但本机主机仍在运行。公网手机无法访问此链接——修复隧道前仅本机/局域网调试可用。",
   "mirror.softTunnelDeadBanner":
     "公网隧道进程已退出，但本机主机仍在运行。已连接手机可能掉线；cloudflared 恢复后请重启主机。",
-  "mirror.err.cloudflaredMissing": "缺少 cloudflared",
+  "mirror.err.cloudflaredMissing": "隧道运行环境不可用",
   "mirror.err.tunnelTimeout": "隧道超时",
   "mirror.err.tunnelSpawn": "隧道启动失败",
   "mirror.err.tunnelNotRegistered": "隧道未注册",
@@ -9283,7 +9285,7 @@ const zh: Record<MessageKey, string> = {
   "mirror.err.clientsFull": "连接数已满",
   "mirror.err.other": "错误",
   "mirror.hint.cloudflaredMissing":
-    "请安装 cloudflared 并加入 PATH，或设置 GROK_MIRROR_NO_TUNNEL=1 做仅本机测试。",
+    "请安装 cloudflared 并加入 PATH，或启动 Docker Desktop；也可设置 GROK_MIRROR_NO_TUNNEL=1 做仅本机测试。",
   "mirror.hint.tunnelTimeout":
     "cloudflared 未在时限内就绪。请检查网络/防火墙后重启主机。",
   "mirror.hint.tunnelSpawn":
@@ -9855,7 +9857,7 @@ const zh: Record<MessageKey, string> = {
   "settings.remoteIm.dingtalk.guide.step4": "将 Client ID（AppKey）与 Client Secret 粘贴到此处，设置允许用户，再点「保存并连接」。",
   "settings.remoteIm.dingtalk.guide.softFail": "「测试连接」仅校验 Client ID 与 Client Secret 是否齐全，不代表 Stream 网关 WebSocket 已在线。",
   "settings.remoteIm.telegram.tokenHelp":
-    "从 @BotFather 获取。默认遮罩存储且不写入日志；连接时还会自动注册 /start /help /p /r /new /status /account /quota /switch /whoami /stop 到 Telegram 原生 / 菜单。",
+    "从 @BotFather 获取。默认遮罩存储且不写入日志；连接时还会自动注册 /start /help /p /r /new /status /context /compact /account /quota /switch /whoami /stop 到 Telegram 原生 / 菜单。",
   "settings.remoteIm.telegram.tokenPlaceholder": "123456789:AAH…",
   "settings.remoteIm.telegram.proxyHelp": "可选 HTTP/SOCKS5 代理，用于 Telegram API（getUpdates / 发送）。留空则使用应用代理或直连。",
   "settings.remoteIm.telegram.proxyPlaceholder": "socks5://127.0.0.1:1080",
@@ -9938,6 +9940,8 @@ const zh: Record<MessageKey, string> = {
   "settings.remoteIm.cmd.resume": "列出 / 恢复 App 历史会话",
   "settings.remoteIm.cmd.new": "新会话，保持项目",
   "settings.remoteIm.cmd.status": "查看绑定状态",
+  "settings.remoteIm.cmd.context": "查看当前会话上下文用量",
+  "settings.remoteIm.cmd.compact": "压缩当前 agent 会话上下文",
   "settings.remoteIm.cmd.help": "欢迎与命令帮助",
   "settings.remoteIm.cmd.whoami": "查看发送者 id",
   "settings.remoteIm.cmd.stop": "中断当前任务",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -4167,7 +4167,7 @@ export const zhTW: Record<MessageKey, string> = {
   "mirror.warningToken":
     "持有此連結的人可以控制本機上的 Agent。用完後請停止主機。",
   "mirror.missingCloudflared":
-    "找不到 cloudflared。請安裝並確保在 PATH 中，或在測試時使用僅本機模式。",
+    "找不到本機 cloudflared，且 Docker 目前不可用。請安裝 cloudflared，或啟動 Docker Desktop 後重試；測試時也可使用僅本機模式。",
   "mirror.errorGeneric": "出了點問題",
   "mirror.qrAlt": "手機鏡像網址的 QR 碼",
   "mirror.linkLabel": "公開網址",
@@ -4176,7 +4176,7 @@ export const zhTW: Record<MessageKey, string> = {
     "通道啟動失敗，但本機主機仍在執行。公網手機無法存取此連結——修復通道前僅本機/區域網路除錯可用。",
   "mirror.softTunnelDeadBanner":
     "公網通道行程已結束，但本機主機仍在執行。已連線手機可能掉線；cloudflared 恢復後請重新啟動主機。",
-  "mirror.err.cloudflaredMissing": "缺少 cloudflared",
+  "mirror.err.cloudflaredMissing": "通道執行環境不可用",
   "mirror.err.tunnelTimeout": "通道逾時",
   "mirror.err.tunnelSpawn": "通道啟動失敗",
   "mirror.err.tunnelNotRegistered": "通道未註冊",
@@ -4191,7 +4191,7 @@ export const zhTW: Record<MessageKey, string> = {
   "mirror.err.clientsFull": "連線數已滿",
   "mirror.err.other": "錯誤",
   "mirror.hint.cloudflaredMissing":
-    "請安裝 cloudflared 並加入 PATH，或設定 GROK_MIRROR_NO_TUNNEL=1 做僅本機測試。",
+    "請安裝 cloudflared 並加入 PATH，或啟動 Docker Desktop；也可設定 GROK_MIRROR_NO_TUNNEL=1 做僅本機測試。",
   "mirror.hint.tunnelTimeout":
     "cloudflared 未在時限內就緒。請檢查網路/防火牆後重新啟動主機。",
   "mirror.hint.tunnelSpawn":
@@ -4763,7 +4763,7 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.remoteIm.dingtalk.guide.step4": "將 Client ID（AppKey）與 Client Secret 貼到此處，設定允許使用者，再點「儲存並連線」。",
   "settings.remoteIm.dingtalk.guide.softFail": "「測試連線」僅校驗 Client ID 與 Client Secret 是否齊全，不代表 Stream 閘道 WebSocket 已在線。",
   "settings.remoteIm.telegram.tokenHelp":
-    "從 @BotFather 取得。預設遮罩儲存且不寫入日誌；連線時還會自動註冊 /start /help /p /r /new /status /account /quota /switch /whoami /stop 到 Telegram 原生 / 選單。",
+    "從 @BotFather 取得。預設遮罩儲存且不寫入日誌；連線時還會自動註冊 /start /help /p /r /new /status /context /compact /account /quota /switch /whoami /stop 到 Telegram 原生 / 選單。",
   "settings.remoteIm.telegram.tokenPlaceholder": "123456789:AAH…",
   "settings.remoteIm.telegram.proxyHelp": "可選 HTTP/SOCKS5 代理，用於 Telegram API（getUpdates / 傳送）。留空則使用應用代理或直連。",
   "settings.remoteIm.telegram.proxyPlaceholder": "socks5://127.0.0.1:1080",
@@ -4846,6 +4846,8 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.remoteIm.cmd.resume": "列出 / 恢復 App 歷史會話",
   "settings.remoteIm.cmd.new": "新會話，保持專案",
   "settings.remoteIm.cmd.status": "查看綁定狀態",
+  "settings.remoteIm.cmd.context": "查看目前會話上下文用量",
+  "settings.remoteIm.cmd.compact": "壓縮目前 agent 會話上下文",
   "settings.remoteIm.cmd.help": "歡迎與命令說明",
   "settings.remoteIm.cmd.whoami": "查看發送者 id",
   "settings.remoteIm.cmd.stop": "中斷目前任務",

--- a/src/lib/mirrorStatus.test.ts
+++ b/src/lib/mirrorStatus.test.ts
@@ -44,6 +44,11 @@ describe("classifyMirrorError", () => {
       ),
     ).toBe("cloudflared_missing");
     expect(
+      classifyMirrorError(
+        "cloudflared not found on PATH and Docker daemon is unavailable — start Docker Desktop",
+      ),
+    ).toBe("cloudflared_missing");
+    expect(
       classifyMirrorError("cloudflared did not become ready within 90s"),
     ).toBe("tunnel_timeout");
     expect(classifyMirrorError("failed to spawn cloudflared: ENOENT")).toBe(

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -2821,6 +2821,8 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "connect device",
       "qr",
       "cloudflared",
+      "docker",
+      "docker desktop",
       "max clients",
       "rotate token",
       "write allowlist",


### PR DESCRIPTION
## Summary

- add a Docker-backed `cloudflared` adapter for phone mirror tunnels when no host binary is available
- add Telegram `/context` and `/compact [note]` commands with persisted usage/compaction state and App journal synchronization
- fix Telegram native command registration for Chinese clients and redact token-bearing Bot API URLs from transport errors
- bump the desktop test build version to `0.2.3`

## Why

Phone mirroring previously failed whenever `cloudflared` was absent from the GUI process PATH, even if Docker Desktop was available. Remote IM also had no native way to compact a session or inspect its context usage, and its headless stream parser discarded usage/compaction signals.

Telegram command registration additionally used the unsupported `zh-hans` Bot API language code, which caused `setMyCommands` to fail before the Chinese menu was installed. Reqwest transport errors could include the token-bearing request URL in logs.

## Details

- prefer the host `cloudflared` binary, then fall back to `cloudflare/cloudflared:latest`
- use `host.docker.internal` on macOS/Windows and host networking on Linux
- label, name, stop, and clean stale managed tunnel containers
- parse nested headless usage and compaction events without inventing missing token counts
- clearly distinguish agent-reported context values from visible-message estimates
- preserve backward compatibility for existing `scope-bindings.json`
- register `/context` and `/compact` in Telegram default and `zh` command menus
- synchronize compact markers into the desktop session journal

## Validation

- `cargo test mirror:: --lib` — 18 passed
- `cargo test remote_im:: --lib` — 74 passed
- `pnpm typecheck`
- `pnpm exec vitest run src/lib/mirrorStatus.test.ts` — 24 passed
- `pnpm build:mac-arm`
- installed and launched the ARM64 `0.2.3` app locally
- verified Docker Quick Tunnel startup and managed-container cleanup
- verified Telegram default and `zh` `getMyCommands` results include `context` and `compact`
- verified the final app bundle and DMG-contained app with ad-hoc codesign checks
