### PR TITLE
feat(reliability): error deck pro with more classified recoveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+#### Composer & chat / reliability
+- **Error deck pro**: classified recoveries for workspace untrusted, missing project path/selection, tool permission denied, MCP auth required, and OAuth expired (mapped from real App/host free-form strings — no dead codes). Banner primary/secondary actions: trust project, relocate/add project, open permissions, open MCP modal / Extensions. Pure `errorDeck` helpers + tests; `presentErrorBanner` uses classification for local UX errors; en/zh/zh-TW
+
 #### Runtime / workflows
 - **Sandbox profile pro** (Settings → General → Permissions): polish OS sandbox presets (`off` / `workspace` / `read-only` / `strict` / `devbox`) with pure `sandboxProfile` helpers (spawn args/env, project resolve, danger confirm keys), **honest soft-fail** when CLI is missing/too old for `--sandbox` (flag omitted) or when the platform has no kernel enforcement (Windows honesty; Linux-only child-network note on macOS), Settings banners + recommended-workspace tip; Host soft-gates spawn flags on known-old CLI; i18n en/zh/zh-TW; `settingsCatalog`; tests
 - **Grok Build workflows** (Settings → Runtime → Tools): opt-in `workflowsEnabled` AppSettings toggle writes top-level `workflows_enabled` into independent agent-home `config.toml` (shared mode never rewrites `~/.grok`); honest copy that workflows run via CLI / Rhai (`workflow` tool, `/workflow`, `/workflows`) — **no in-app runner/editor**; read-only soft-fail discovery of `~/.grok/workflows` + project `.grok/workflows` names; command palette **Open workflows docs** / jump to settings; pure helpers + tests; `settingsCatalog` + en/zh/zh-TW

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13468,7 +13468,7 @@ export default function App() {
     };
   }, [perm, permissionTimeoutSec, denyActivePermission]);
 
-  /** T04 deck buttons: reconnect / Doctor / Settings sections / dismiss. */
+  /** T04 deck buttons: reconnect / Doctor / Settings sections / project / MCP / dismiss. */
   const runErrorBannerAction = useCallback(
     (action: NonNullable<ErrorBannerView["primary"]>) => {
       setErrorDetailOpen(false);
@@ -13505,6 +13505,30 @@ export default function App() {
           // login+key surface; extensions holds MCP. Prefer account for keys.
           navigateSettings("account");
           break;
+        case "open_permissions":
+          setLocalError(null);
+          navigateSettings("general", "permissions");
+          break;
+        case "open_extensions":
+          setLocalError(null);
+          navigateSettings("extensions");
+          break;
+        case "open_mcp":
+          setLocalError(null);
+          void openMcpModal();
+          break;
+        case "trust_project":
+          setLocalError(null);
+          void trustProject(activeProject);
+          break;
+        case "relocate_project":
+          setLocalError(null);
+          if (activeProject) void relocateProject(activeProject);
+          break;
+        case "add_project":
+          setLocalError(null);
+          void addProject(false);
+          break;
         case "dismiss":
         case "keep_waiting":
           // keep_waiting is for the stream-stall banner (clears prompt only).
@@ -13518,7 +13542,17 @@ export default function App() {
           break;
       }
     },
-    [ensureConnected, navigateSettings, openDoctor, stop],
+    [
+      activeProject,
+      addProject,
+      ensureConnected,
+      navigateSettings,
+      openDoctor,
+      openMcpModal,
+      relocateProject,
+      stop,
+      trustProject,
+    ],
   );
 
   const refreshAccount = useCallback(

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -364,6 +364,12 @@ const en = {
   "error.action.upgradeCli": "Upgrade CLI",
   "error.action.openNetwork": "Network settings",
   "error.action.dismiss": "Dismiss",
+  "error.action.trustProject": "Trust project",
+  "error.action.relocateProject": "Relocate folder",
+  "error.action.addProject": "Add project",
+  "error.action.openPermissions": "Permissions",
+  "error.action.openMcp": "Open MCP",
+  "error.action.openExtensions": "Extensions",
   "error.deck.cli.problem": "Grok Build CLI not found",
   "error.deck.cli.cause":
     "The desktop app needs the local CLI binary. Install it, or point Settings at an existing path.",
@@ -397,6 +403,21 @@ const en = {
   "error.deck.stall.problem": "Stream looks quiet",
   "error.deck.stall.cause":
     "No tokens or tool progress for about {seconds}s. Keep waiting or end this turn.",
+  "error.deck.untrusted.problem": "Project is not trusted",
+  "error.deck.untrusted.cause":
+    "Trust the folder so the agent may read and write there (Ask remains the default).",
+  "error.deck.projectMissing.problem": "Project folder unavailable",
+  "error.deck.projectMissing.cause":
+    "The path is missing, moved, or no project is selected. Relocate the folder or add a project.",
+  "error.deck.permission.problem": "Permission denied",
+  "error.deck.permission.cause":
+    "A tool or file access was rejected. Adjust permission policy or allow the next prompt.",
+  "error.deck.mcpAuth.problem": "MCP authentication required",
+  "error.deck.mcpAuth.cause":
+    "An MCP server needs OAuth or re-authorization. Open MCP doctor and complete the provider sign-in.",
+  "error.deck.oauthExpired.problem": "OAuth credentials expired",
+  "error.deck.oauthExpired.cause":
+    "Token or grant is no longer valid. Refresh MCP OAuth or re-login under Account.",
   "error.deck.generic.problem": "Something went wrong",
   "error.deck.generic.cause":
     "Check Doctor for CLI/auth status, then retry the last action.",
@@ -5448,6 +5469,12 @@ const zh: Record<MessageKey, string> = {
   "error.action.upgradeCli": "升级 CLI",
   "error.action.openNetwork": "网络设置",
   "error.action.dismiss": "关闭",
+  "error.action.trustProject": "信任项目",
+  "error.action.relocateProject": "重新定位",
+  "error.action.addProject": "添加项目",
+  "error.action.openPermissions": "权限设置",
+  "error.action.openMcp": "打开 MCP",
+  "error.action.openExtensions": "扩展",
   "error.deck.cli.problem": "未找到 Grok Build CLI",
   "error.deck.cli.cause":
     "桌面端需要本机 CLI 可执行文件。请安装，或在设置中指定已有路径。",
@@ -5481,6 +5508,21 @@ const zh: Record<MessageKey, string> = {
   "error.deck.stall.problem": "输出暂时停住了",
   "error.deck.stall.cause":
     "约 {seconds} 秒没有新的内容或工具进度。可继续等待或结束本轮。",
+  "error.deck.untrusted.problem": "项目尚未信任",
+  "error.deck.untrusted.cause":
+    "信任该文件夹后 Agent 才可读写（默认仍为 Ask 审批）。",
+  "error.deck.projectMissing.problem": "项目文件夹不可用",
+  "error.deck.projectMissing.cause":
+    "路径丢失、已移动，或尚未选择项目。请重新定位文件夹，或添加项目。",
+  "error.deck.permission.problem": "权限被拒绝",
+  "error.deck.permission.cause":
+    "工具或文件访问被拒绝。可调整权限策略，或在下次提示时允许。",
+  "error.deck.mcpAuth.problem": "需要 MCP 鉴权",
+  "error.deck.mcpAuth.cause":
+    "某 MCP 服务需要 OAuth 或重新授权。请打开 MCP Doctor 完成登录。",
+  "error.deck.oauthExpired.problem": "OAuth 凭证已过期",
+  "error.deck.oauthExpired.cause":
+    "令牌或授权已失效。请刷新 MCP OAuth，或在账号设置中重新登录。",
   "error.deck.generic.problem": "出了点问题",
   "error.deck.generic.cause": "可在 Doctor 查看 CLI/鉴权状态，然后重试上一步操作。",
   "main.startTitle": "开始对话",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -330,6 +330,12 @@ export const zhTW: Record<MessageKey, string> = {
   "error.action.upgradeCli": "升級 CLI",
   "error.action.openNetwork": "網路設定",
   "error.action.dismiss": "關閉",
+  "error.action.trustProject": "信任專案",
+  "error.action.relocateProject": "重新定位",
+  "error.action.addProject": "新增專案",
+  "error.action.openPermissions": "權限設定",
+  "error.action.openMcp": "開啟 MCP",
+  "error.action.openExtensions": "擴充功能",
   "error.deck.cli.problem": "找不到 Grok Build CLI",
   "error.deck.cli.cause":
     "桌面端需要本機 CLI 可執行檔。請安裝，或在設定中指定既有路徑。",
@@ -363,6 +369,21 @@ export const zhTW: Record<MessageKey, string> = {
     "約 {seconds} 秒沒有新的內容或工具進度。可取消本輪或繼續等待。",
   "error.deck.disconnect.cause":
     "傳輸通道在回合中關閉。請重新連線後再傳送。",
+  "error.deck.untrusted.problem": "專案尚未信任",
+  "error.deck.untrusted.cause":
+    "信任該資料夾後 Agent 才可讀寫（預設仍為 Ask 審批）。",
+  "error.deck.projectMissing.problem": "專案資料夾不可用",
+  "error.deck.projectMissing.cause":
+    "路徑遺失、已移動，或尚未選擇專案。請重新定位資料夾，或新增專案。",
+  "error.deck.permission.problem": "權限被拒絕",
+  "error.deck.permission.cause":
+    "工具或檔案存取被拒絕。可調整權限策略，或在下次提示時允許。",
+  "error.deck.mcpAuth.problem": "需要 MCP 驗證",
+  "error.deck.mcpAuth.cause":
+    "某 MCP 服務需要 OAuth 或重新授權。請開啟 MCP Doctor 完成登入。",
+  "error.deck.oauthExpired.problem": "OAuth 憑證已過期",
+  "error.deck.oauthExpired.cause":
+    "權杖或授權已失效。請重新整理 MCP OAuth，或在帳號設定中重新登入。",
   "error.deck.generic.problem": "出了點問題",
   "error.deck.generic.cause": "可在 Doctor 查看 CLI/驗證狀態，然後重試上一步操作。",
   "main.startTitle": "開始對話",

--- a/src/lib/errorDeck.test.ts
+++ b/src/lib/errorDeck.test.ts
@@ -58,12 +58,35 @@ describe("buildErrorDeck", () => {
   it("STREAM_STALL uses keep_waiting / cancel_turn (not dual dismiss)", () => {
     const stall = buildErrorDeck("STREAM_STALL", "en");
     expect(stall.code).toBe("STREAM_STALL");
-    expect(stall.problem.toLowerCase()).toMatch(/stuck|stream/);
+    expect(stall.problem.toLowerCase()).toMatch(/stuck|stream|quiet/);
     expect(stall.primary.id).toBe("keep_waiting");
     expect(stall.secondary?.id).toBe("cancel_turn");
     expect(stall.primary.label.toLowerCase()).toMatch(/wait/);
     // Copy changed from "Cancel" to "End turn"; assert intent, not wording.
     expect(stall.secondary?.label.toLowerCase()).toMatch(/cancel|end/);
+  });
+
+  it("new recovery decks expose primary/secondary actions", () => {
+    const untrusted = buildErrorDeck("WORKSPACE_UNTRUSTED", "en");
+    expect(untrusted.primary.id).toBe("trust_project");
+    expect(untrusted.secondary?.id).toBe("dismiss");
+    expect(untrusted.problem.toLowerCase()).toMatch(/trust/);
+
+    const missing = buildErrorDeck("PROJECT_MISSING", "en");
+    expect(missing.primary.id).toBe("relocate_project");
+    expect(missing.secondary?.id).toBe("add_project");
+
+    const perm = buildErrorDeck("PERMISSION_DENIED", "en");
+    expect(perm.primary.id).toBe("open_permissions");
+    expect(perm.problem.toLowerCase()).toMatch(/permission|denied|access/);
+
+    const mcp = buildErrorDeck("MCP_AUTH_FAILED", "en");
+    expect(mcp.primary.id).toBe("open_mcp");
+    expect(mcp.secondary?.id).toBe("open_extensions");
+
+    const oauth = buildErrorDeck("OAUTH_EXPIRED", "en");
+    expect(oauth.primary.id).toBe("open_mcp");
+    expect(oauth.secondary?.id).toBe("open_account");
   });
 
   it("classifies free-form messages into product classes", () => {
@@ -77,6 +100,57 @@ describe("buildErrorDeck", () => {
     expect(classifyErrorMessage("agent process exited")).toBe("AGENT_CRASHED");
   });
 
+  it("classifies App project-gate and MCP/permission strings", () => {
+    expect(classifyErrorMessage('Trust project "Demo" first.')).toBe(
+      "WORKSPACE_UNTRUSTED",
+    );
+    expect(classifyErrorMessage("请先信任项目「演示」。")).toBe(
+      "WORKSPACE_UNTRUSTED",
+    );
+    expect(classifyErrorMessage("請先信任專案「演示」。")).toBe(
+      "WORKSPACE_UNTRUSTED",
+    );
+    expect(
+      classifyErrorMessage(
+        'Folder for "Demo" is missing or not a directory. Relocate it to continue.',
+      ),
+    ).toBe("PROJECT_MISSING");
+    expect(classifyErrorMessage("Select a project first.")).toBe(
+      "PROJECT_MISSING",
+    );
+    expect(classifyErrorMessage("请先选择一个项目。")).toBe("PROJECT_MISSING");
+    expect(classifyErrorMessage("「演示」的文件夹已丢失或不是目录。")).toBe(
+      "PROJECT_MISSING",
+    );
+    expect(
+      classifyErrorMessage("「演示」的資料夾已遺失或不是目錄。請重新定位後繼續。"),
+    ).toBe("PROJECT_MISSING");
+    expect(classifyErrorMessage("permission denied writing file")).toBe(
+      "PERMISSION_DENIED",
+    );
+    expect(classifyErrorMessage("permission_denied")).toBe("PERMISSION_DENIED");
+    expect(classifyErrorMessage("EACCES: operation not permitted")).toBe(
+      "PERMISSION_DENIED",
+    );
+    expect(
+      classifyErrorMessage("MCP oauth authorization required for server"),
+    ).toBe("MCP_AUTH_FAILED");
+    expect(
+      classifyErrorMessage("invalid_token — MCP access token expired"),
+    ).toBe("OAUTH_EXPIRED");
+    expect(classifyErrorMessage("oauth failed during MCP handshake")).toBe(
+      "MCP_AUTH_FAILED",
+    );
+  });
+
+  it("deckCodeFromAgent accepts new App-side codes", () => {
+    expect(deckCodeFromAgent("WORKSPACE_UNTRUSTED")).toBe("WORKSPACE_UNTRUSTED");
+    expect(deckCodeFromAgent("PROJECT_MISSING")).toBe("PROJECT_MISSING");
+    expect(deckCodeFromAgent("PERMISSION_DENIED")).toBe("PERMISSION_DENIED");
+    expect(deckCodeFromAgent("MCP_AUTH_FAILED")).toBe("MCP_AUTH_FAILED");
+    expect(deckCodeFromAgent("OAUTH_EXPIRED")).toBe("OAUTH_EXPIRED");
+  });
+
   it("resolveErrorDeckCode prefers host code then message", () => {
     expect(resolveErrorDeckCode("AUTH_FAILED", "something else")).toBe(
       "AUTH_FAILED",
@@ -84,5 +158,11 @@ describe("buildErrorDeck", () => {
     expect(resolveErrorDeckCode(null, "command not found: grok")).toBe(
       "CLI_NOT_FOUND",
     );
+    expect(
+      resolveErrorDeckCode(null, 'Trust project "x" first.'),
+    ).toBe("WORKSPACE_UNTRUSTED");
+    expect(
+      resolveErrorDeckCode("GENERIC", "MCP oauth authorization required"),
+    ).toBe("MCP_AUTH_FAILED");
   });
 });

--- a/src/lib/errorDeck.ts
+++ b/src/lib/errorDeck.ts
@@ -1,6 +1,6 @@
 /**
- * T04 error deck — structured copy for the four product error classes
- * (plus a few host-side codes): problem / cause / primary / secondary.
+ * T04 error deck — structured copy for product error classes
+ * (host AgentErrorCode + App/local recoveries): problem / cause / primary / secondary.
  *
  * Labels come from i18n; action ids are stable for App handlers.
  */
@@ -22,9 +22,24 @@ export type ErrorDeckActionId =
   /** Stream-stall banner: clear the stall prompt and keep the turn running. */
   | "keep_waiting"
   /** Stream-stall banner: cancel the in-flight turn. */
-  | "cancel_turn";
+  | "cancel_turn"
+  /** Trust the active project (WORKSPACE_UNTRUSTED). */
+  | "trust_project"
+  /** Relocate a missing project folder (PROJECT_MISSING path). */
+  | "relocate_project"
+  /** Open the add-project picker (PROJECT_MISSING / no selection). */
+  | "add_project"
+  /** Settings → General → Permissions. */
+  | "open_permissions"
+  /** Open the MCP status / doctor modal. */
+  | "open_mcp"
+  /** Settings → Extensions (MCP list). */
+  | "open_extensions";
 
-/** Host / product error classes (aligned with AgentErrorCode + specials). */
+/**
+ * Host / product error classes (aligned with AgentErrorCode + App-side specials
+ * that surface as free-form localError or turn text).
+ */
 export type ErrorDeckCode =
   | "CLI_NOT_FOUND"
   | "AUTH_FAILED"
@@ -37,6 +52,16 @@ export type ErrorDeckCode =
   | "TURN_TIMEOUT"
   | "AGENT_DISCONNECTED"
   | "STREAM_STALL"
+  /** Active project is not trusted yet (App setLocalError trustFirst). */
+  | "WORKSPACE_UNTRUSTED"
+  /** Project folder missing / not selected (pathMissing, selectFirst). */
+  | "PROJECT_MISSING"
+  /** Tool / OS / user denied a permission (not account 401). */
+  | "PERMISSION_DENIED"
+  /** MCP server needs OAuth / auth handshake. */
+  | "MCP_AUTH_FAILED"
+  /** MCP or provider OAuth token expired / invalid_grant. */
+  | "OAUTH_EXPIRED"
   | "GENERIC";
 
 export type ErrorDeckAction = {
@@ -154,6 +179,46 @@ const DECK: Record<ErrorDeckCode, DeckSpec> = {
     secondaryId: "cancel_turn",
     secondaryLabel: "agent.streamStallCancel",
   },
+  WORKSPACE_UNTRUSTED: {
+    problem: "error.deck.untrusted.problem",
+    cause: "error.deck.untrusted.cause",
+    primaryId: "trust_project",
+    primaryLabel: "error.action.trustProject",
+    secondaryId: "dismiss",
+    secondaryLabel: "error.action.dismiss",
+  },
+  PROJECT_MISSING: {
+    problem: "error.deck.projectMissing.problem",
+    cause: "error.deck.projectMissing.cause",
+    primaryId: "relocate_project",
+    primaryLabel: "error.action.relocateProject",
+    secondaryId: "add_project",
+    secondaryLabel: "error.action.addProject",
+  },
+  PERMISSION_DENIED: {
+    problem: "error.deck.permission.problem",
+    cause: "error.deck.permission.cause",
+    primaryId: "open_permissions",
+    primaryLabel: "error.action.openPermissions",
+    secondaryId: "dismiss",
+    secondaryLabel: "error.action.dismiss",
+  },
+  MCP_AUTH_FAILED: {
+    problem: "error.deck.mcpAuth.problem",
+    cause: "error.deck.mcpAuth.cause",
+    primaryId: "open_mcp",
+    primaryLabel: "error.action.openMcp",
+    secondaryId: "open_extensions",
+    secondaryLabel: "error.action.openExtensions",
+  },
+  OAUTH_EXPIRED: {
+    problem: "error.deck.oauthExpired.problem",
+    cause: "error.deck.oauthExpired.cause",
+    primaryId: "open_mcp",
+    primaryLabel: "error.action.openMcp",
+    secondaryId: "open_account",
+    secondaryLabel: "error.action.openAccount",
+  },
   GENERIC: {
     problem: "error.deck.generic.problem",
     cause: "error.deck.generic.cause",
@@ -182,6 +247,7 @@ export function buildErrorDeck(
   };
 }
 
+/** Codes the host may emit as stable SCREAMING_SNAKE (or App may prefix). */
 const AGENT_DECK_CODES: ErrorDeckCode[] = [
   "CLI_NOT_FOUND",
   "AUTH_FAILED",
@@ -191,6 +257,12 @@ const AGENT_DECK_CODES: ErrorDeckCode[] = [
   "CONNECT_FAILED",
   "PROCESS_LIMIT",
   "CLI_TOO_OLD",
+  "WORKSPACE_UNTRUSTED",
+  "PROJECT_MISSING",
+  "PERMISSION_DENIED",
+  "MCP_AUTH_FAILED",
+  "OAUTH_EXPIRED",
+  "STREAM_STALL",
 ];
 
 /** Map a classified agent code (or special timeout/disconnect) to a deck code. */
@@ -208,11 +280,107 @@ export function deckCodeFromAgent(
 
 /**
  * Map free-form error text to a deck code when the host did not emit a stable code.
- * Keeps the four product classes (CLI / auth / network / crash) from collapsing to GENERIC.
+ * Order: App project gates → MCP OAuth → tool permission → classic four classes.
  */
 export function classifyErrorMessage(raw: string | null | undefined): ErrorDeckCode {
   const s = (raw ?? "").toLowerCase();
   if (!s.trim()) return "GENERIC";
+
+  // ── App project gates (setLocalError from trust / path / select) ──
+  if (
+    s.includes("workspace_untrusted") ||
+    s.includes("trust project") ||
+    s.includes("project not trusted") ||
+    s.includes("untrusted project") ||
+    s.includes("workspace untrusted") ||
+    s.includes("请先信任") ||
+    s.includes("請先信任")
+  ) {
+    return "WORKSPACE_UNTRUSTED";
+  }
+  if (
+    s.includes("project_missing") ||
+    s.includes("path missing") ||
+    s.includes("folder missing") ||
+    s.includes("is missing or not a directory") ||
+    (s.includes("folder for") && s.includes("missing")) ||
+    s.includes("select a project") ||
+    s.includes("add and select a project") ||
+    s.includes("no project") ||
+    s.includes("project missing") ||
+    s.includes("请先选择") ||
+    s.includes("請先選擇") ||
+    s.includes("文件夹已丢失") ||
+    s.includes("資料夾已遺失") ||
+    s.includes("資料夾遺失") ||
+    s.includes("不是目录") ||
+    s.includes("不是目錄") ||
+    s.includes("重新定位")
+  ) {
+    return "PROJECT_MISSING";
+  }
+
+  // ── MCP / OAuth (more specific than generic AUTH_FAILED) ──
+  const mcpish =
+    s.includes("mcp") ||
+    s.includes("oauth") ||
+    s.includes("resource_metadata") ||
+    s.includes("protected-resource") ||
+    s.includes("protected_resource") ||
+    s.includes("www-authenticate") ||
+    s.includes("authorization required") ||
+    s.includes("auth required");
+  const expiredish =
+    s.includes("expired") ||
+    s.includes("invalid_token") ||
+    s.includes("invalid_grant") ||
+    s.includes("token expir") ||
+    (s.includes("credential") && s.includes("expir")) ||
+    s.includes("refresh_token");
+  if (mcpish && expiredish) {
+    return "OAUTH_EXPIRED";
+  }
+  if (
+    s.includes("oauth_expired") ||
+    (expiredish &&
+      (s.includes("oauth") || s.includes("mcp") || s.includes("access_token")))
+  ) {
+    return "OAUTH_EXPIRED";
+  }
+  if (
+    s.includes("mcp_auth_failed") ||
+    s.includes("mcp auth") ||
+    s.includes("oauth failed") ||
+    s.includes("oauth error") ||
+    s.includes("authorization failed") ||
+    s.includes("authorization required") ||
+    s.includes("auth required") ||
+    s.includes("resource_metadata") ||
+    (s.includes("mcp") &&
+      (s.includes("auth") || s.includes("oauth") || s.includes("unauthorized")))
+  ) {
+    return "MCP_AUTH_FAILED";
+  }
+
+  // ── Tool / FS permission (not account 401) ──
+  if (
+    s.includes("permission_denied") ||
+    s.includes("permission denied") ||
+    s.includes("eacces") ||
+    s.includes("operation not permitted") ||
+    s.includes("user rejected") ||
+    s.includes("user denied") ||
+    s.includes("tool denied") ||
+    s.includes("tool call denied") ||
+    s.includes("rejected by user") ||
+    s.includes("权限被拒绝") ||
+    s.includes("權限被拒絕") ||
+    s.includes("无权访问") ||
+    s.includes("無權存取")
+  ) {
+    return "PERMISSION_DENIED";
+  }
+
   if (
     s.includes("cli_not_found") ||
     s.includes("command not found") ||

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1013,7 +1013,36 @@ describe("session projection", () => {
     const short = presentErrorBanner(null, "Select a project first", "en");
     expect(short?.summary).toBe("Select a project first");
     expect(short?.detail).toBeNull();
-    expect(short?.primary?.id).toBe("dismiss");
+    expect(short?.code).toBe("PROJECT_MISSING");
+    expect(short?.primary?.id).toBe("relocate_project");
+    expect(short?.secondary?.id).toBe("add_project");
+  });
+
+  it("presentErrorBanner decks trust / permission / MCP recoveries", () => {
+    const trust = presentErrorBanner(
+      null,
+      'Trust project "Demo" first.',
+      "en",
+    );
+    expect(trust?.code).toBe("WORKSPACE_UNTRUSTED");
+    expect(trust?.primary?.id).toBe("trust_project");
+    expect(trust?.summary).toContain("Demo");
+
+    const perm = presentErrorBanner(
+      null,
+      "permission denied writing file",
+      "en",
+    );
+    expect(perm?.code).toBe("PERMISSION_DENIED");
+    expect(perm?.primary?.id).toBe("open_permissions");
+
+    const mcp = presentErrorBanner(
+      null,
+      "MCP oauth authorization required",
+      "en",
+    );
+    expect(mcp?.code).toBe("MCP_AUTH_FAILED");
+    expect(mcp?.primary?.id).toBe("open_mcp");
   });
 
   it("presentErrorBanner decks the four product classes", () => {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1972,6 +1972,15 @@ export function errorCopy(code: AgentErrorCode, locale: Locale = "en"): string {
   return `${card.problem} ${card.cause}`.trim();
 }
 
+/** Friendly bubble body from any deck code (including App-only recoveries). */
+function errorCopyFromDeck(
+  code: Parameters<typeof buildErrorDeck>[0],
+  locale: Locale = "en",
+): string {
+  const card = buildErrorDeck(code, locale);
+  return `${card.problem} ${card.cause}`.trim();
+}
+
 /** Turn took too long (Host session/prompt timeout) — more specific than generic network. */
 export function turnTimeoutCopy(locale: Locale = "en"): string {
   const card = buildErrorDeck("TURN_TIMEOUT", locale);
@@ -2064,8 +2073,31 @@ export function formatTurnErrorBody(
   }
 
   // Infer codes from common agent/host phrases when payload lacks a code.
+  // Prefer resolveErrorDeckCode for App/MCP/permission recoveries; map only
+  // host AgentErrorCode values into the typed bubble path below.
   if (!code) {
+    const deckish = resolveErrorDeckCode(null, lower);
     if (
+      deckish === "CONNECT_FAILED" ||
+      deckish === "QUOTA_EXCEEDED" ||
+      deckish === "AUTH_FAILED" ||
+      deckish === "CLI_NOT_FOUND" ||
+      deckish === "NETWORK_PROVIDER" ||
+      deckish === "AGENT_CRASHED" ||
+      deckish === "PROCESS_LIMIT" ||
+      deckish === "CLI_TOO_OLD"
+    ) {
+      code = deckish;
+    } else if (
+      deckish === "PERMISSION_DENIED" ||
+      deckish === "MCP_AUTH_FAILED" ||
+      deckish === "OAUTH_EXPIRED" ||
+      deckish === "WORKSPACE_UNTRUSTED" ||
+      deckish === "PROJECT_MISSING"
+    ) {
+      // Deck-only codes: friendly bubble from the card (not AgentErrorCode).
+      return errorCopyFromDeck(deckish, locale);
+    } else if (
       /could not connect the agent|edit aborted|no active session|acp client missing|connect failed/i.test(
         lower,
       )
@@ -2201,7 +2233,28 @@ export function presentErrorBanner(
     return bannerFromDeck(deck, null, null);
   }
 
-  // Local UX strings (e.g. "select a project") — show as-is, soft dismiss.
+  // Classify free-form localError (trust / path / permission / MCP …).
+  // Keep the original short UX string as summary when present so project names
+  // from i18n stay visible; deck supplies cause + recovery actions.
+  const classified = resolveErrorDeckCode(null, cleaned);
+  if (classified !== "GENERIC") {
+    const deck = buildErrorDeck(classified, locale);
+    const short =
+      cleaned.length > 200 ? `${cleaned.slice(0, 200)}…` : cleaned;
+    return {
+      code: classified,
+      summary: short,
+      cause: deck.cause,
+      detail: null,
+      reconnectHint:
+        deck.primary.id === "reconnect" || deck.secondary?.id === "reconnect",
+      primary: deck.primary,
+      secondary: deck.secondary,
+      deck,
+    };
+  }
+
+  // Unknown local UX strings — show as-is, soft dismiss.
   const deck = buildErrorDeck("GENERIC", locale);
   return {
     code: null,


### PR DESCRIPTION
## Summary
- Expand the classified error deck with **mappable** recoveries from real App/host paths: `WORKSPACE_UNTRUSTED`, `PROJECT_MISSING`, `PERMISSION_DENIED`, `MCP_AUTH_FAILED`, `OAUTH_EXPIRED` (no dead codes / no YOLO_BLOCKED — host does not emit a distinct banner error for remote YOLO force-ask).
- Pure helpers: `classifyErrorMessage` / `resolveErrorDeckCode` / `deckCodeFromAgent` map free-form strings (trust first, path missing, MCP OAuth, permission denied, …) → deck codes; Vitest coverage.
- `presentErrorBanner` classifies free-form `localError` and keeps the original short UX summary (project names) while attaching deck cause + primary/secondary actions.
- App `runErrorBannerAction` wires new actions: `trust_project`, `relocate_project`, `add_project`, `open_permissions`, `open_mcp`, `open_extensions` (reuses existing Settings / MCP modal patterns; no `window.confirm`).
- i18n en / zh / zh-TW + CHANGELOG Unreleased.

## Test plan
- [x] `pnpm test -- src/lib/errorDeck.test.ts src/lib/session.test.ts src/i18n/messages.test.ts`
- [ ] Manual: untrusted project → banner Trust project
- [ ] Manual: missing folder → Relocate / Add project
- [ ] Manual: MCP oauth text in localError → Open MCP
- [ ] Manual: permission denied string → Permissions settings