### PR TITLE
feat(x-evidence): X Evidence Rail MVP + wallpaper/MCP parser bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ See `docs/llm-wiki/release.md`.
 
 - **Long chat virtualizer (PERF-A11Y-PACK / perf)**: history browse no longer expands the continuous window to the tail just because idle force-mount lists the last user/assistant (that mounted hundreds of rows mid-scroll). Force expand is nearby-only while escaped; pin still expands for blank-pin defense. Adaptive viewport-scaled overscan, binary-search range find, rAF-coalesced scroll recompute, and cached cumulative offsets keep long transcripts snappy. Pure helpers + tests in `chatVirtualList`.
 - **Custom provider save stuck on “Saving…” / requires restart** (#376): `providers_upsert` / activate / remove / set-default run file I/O on a blocking pool and recycle warm agents (`provider_route`) so the next message reloads `config.toml` + auth without a full app restart. Settings save uses a wall-clock timeout, always clears busy in `finally`, shows success / soft-fail apply toasts (en/zh/zh-TW), and no longer parks live agents via `sessionDisconnect` (which kept stale OIDC in memory). Pure `providerSave` helpers + tests.
+- **MCP config.toml parser**: an unclosed multi-line `args = [` no longer silently swallows the next `[mcp_servers.*]` table (whole server used to disappear); array end detection is now string-literal-aware, so `]` inside a quoted arg (e.g. `"some]thing"`) no longer truncates the array
+- **Wallpaper gallery**: `is_gallery_media_url` now accepts all download-allowlisted hosts (`abs.twimg.com`, `filesystem.site`) — legit Imagine/CDN images were silently filtered out before display
+- **Wallpaper URL normalize**: legacy twimg `:thumb/:small/:medium/:large` suffixes are normalized to `:orig` again (the replacement branch was unreachable dead code after `Url::parse` succeeded)
 
 ### Added
 
@@ -172,10 +175,11 @@ See `docs/llm-wiki/release.md`.
 - **Hooks try-run**: Settings → Extensions → Hooks can **real-run** a script under `~/.grok/hooks` or project `.grok/hooks` only (host `hooks_try_run`, optional JSON stdin, timeout, redacted stdout/stderr); paths outside hooks dirs are refused; `ok` only on exit 0
 - **Hooks validate pro**: try-run / stdin **Validate** show classified outcomes (path refused, timeout, non-zero exit, invalid JSON, …) with actionable hints in a **GlassModal** result (no `window.confirm`); pure `hooksValidate` helpers + tests; en/zh/zh-TW
 
-### Fixed
-
-- CLI install missing SHA-256 (#227) · app.css rewind/fork selectors (#259)
-- **Multi-turn chat scroll jank (#280)**: free-scroll node-rail highlight no longer `setState`s the transcript parent each frame; virtual-list `measureRef` callbacks are stable per index (stops ResizeObserver thrash); idle force-mount uses transcript indices only; rail `scrollIntoView` is instant
+#### X Evidence Rail (MVP)
+- **X 证据轨** backend (`x_evidence.rs`, design: `docs/features/x-search.md`): `x_evidence_search` searches X via headless Grok CLI and persists every post as a local **evidence row** (sqlite `{app_data}/x-evidence/evidence.db`) with a stable `evidence_id`; posts without a canonical `x.com/…/status/…` URL are stored but flagged `verified=false` — hallucinated links never pass as evidence
+- **Local evidence bus**: `x_evidence_list` (filter by session tag / query / author) + `x_evidence_get` (by ids) so later agent turns re-read evidence without re-searching or losing citations
+- **Quote pack**: `x_quote_pack` renders evidence ids into a paste-ready markdown pack saved under `{app_data}/x-evidence/packs/*.md` (unverified items clearly marked); write-to-X path intentionally absent
+- Frontend API wrappers in `src/lib/api.ts` (`xEvidenceSearch` / `xEvidenceList` / `xEvidenceGet` / `xQuotePack`)
 
 **中文 · 新增（按域）**
 
@@ -236,11 +240,15 @@ See `docs/llm-wiki/release.md`.
 - **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）；**权限规则试算**（输入工具调用预览 allow/deny/ask，不写配置）
 - **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）；**记忆正文搜索**（`GROK_HOME/memory` 路径限定 + 上限；脱敏摘录；打开/显示）
 - **权限/CLI**：`--permission-mode` 映射与 spawn；设置页 CLI 标签与高级选择；**Auto** 策略；Doctor 安全批量修复；**删除磁盘 CLI 会话**（单条/全部未关联；限定 `GROK_HOME/sessions`）；**ACP 服务器健康检查**（解析/TCP 探测/状态芯片/blur 校验；地址变更 soft-respawn）
+- **X 证据轨（MVP）**：`x_evidence_search` 经 headless Grok CLI 搜 X 并逐条落库为本地证据行（sqlite，稳定 `evidence_id`，无合法 status 链接标 `verified=false`）；`x_evidence_list` / `x_evidence_get` 本地证据总线跨回合复用；`x_quote_pack` 生成可粘贴 markdown 引用包（设计文档 `docs/features/x-search.md`；不含发帖写路径）
 
 
 **中文 · 修复**
 
 - CLI SHA-256（#227）；CSS（#259）；多轮对话滚动卡顿（#280）
+- **MCP config.toml 解析**：多行 `args = [` 漏闭合不再吞掉下一个 `[mcp_servers.*]` 表头（整个 server 曾被静默丢弃）；数组结尾判定改为字符串感知，引号内的 `]` 不再截断参数
+- **壁纸画廊**：`is_gallery_media_url` 补齐下载白名单主机（`abs.twimg.com`、`filesystem.site`），合法 Imagine/CDN 图不再被静默过滤
+- **壁纸 URL 归一**：twimg 老式 `:thumb/:small/:medium/:large` 后缀恢复归一为 `:orig`（原替换分支在 `Url::parse` 成功后不可达）
 
 
 ## [0.2.2] - 2026-07-30

--- a/docs/features/x-search.md
+++ b/docs/features/x-search.md
@@ -1,0 +1,305 @@
+# 设计选择：**只服务 Agent 党**，但做出一个别人抄不像的特色
+
+不选「也服务运营党」。运营党要的是排期、多号矩阵、自动互动——那是 Buffer / 社媒中台赛道，和 GrokGo 的本地网关基因打架，一做就平庸。
+
+---
+
+## 与众不同的产品特色（一句话）
+
+> **GrokGo 不帮你「玩 X」，只帮 Agent「用 X 当可验证证据」——搜得到、存得住、引得出、回得像人、默认不代发。**
+
+市面常见两极：
+
+| 类型 | 做什么 | 缺什么 |
+|------|--------|--------|
+| 通用 AI / OpenRouter | 聊天里「好像搜过」 | 无稳定 tool、无引用链、无本地证据 |
+| 社媒运营工具 | 发帖排期、矩阵 | 进不了 Codex/CC 的 tool loop |
+| 裸 `x_search` | 搜一次吐一段字 | 下一轮 Agent 失忆、乱编、乱降级 web_search |
+
+**GrokGo 卡的是第三极：Agent 工作流里的「X 证据层（Evidence Layer）」。**
+
+产品记忆点可以叫：
+
+### **X Evidence Rail（X 证据轨）**
+
+一条强制轨：
+
+```text
+搜 → 结构化落证 →（可选）本地再分析 → 凡结论必带 x.com 引用
+                                      → 回复只出草稿 + 原帖锚点
+```
+
+Agent 被 agents-guide **禁止**用 web_search / 瞎编帖子 URL 顶替；人始终在环上点发送。
+
+这和「又多一个 MCP search」完全不是一个品类。
+
+---
+
+## 设计原则（决定工具长什么样）
+
+1. **证据优先于内容**：返回值永远能指向 `https://x.com/i/status/...`，没有 URL 的结果降级为 `unverified`。  
+2. **本地是系统真相**：落库在 `~/.grok-go/x-evidence/`（或 sqlite），CDN/上游 raw 可丢，证据 ID 不丢。  
+3. **写路径默认关闭**：任何「发到 X」的能力不进默认 MCP 目录；草稿可以。  
+4. **少工具、强合约**：6 个以内主工具，参数稳，agents-guide 写死何时用哪个。  
+5. **为 tool loop 设计，不为仪表盘设计**：输出 JSON + 短 markdown，给模型吃，不给运营看报表。
+
+---
+
+## MCP 工具清单（Agent 党 · Evidence Rail）
+
+> 命名统一 `x_*`；是否落库以「能否被下一轮 Agent 复用」为准。
+
+### 0. 总览
+
+| 工具 | 作用 | 落库 | 默认启用 |
+|------|------|:----:|:--------:|
+| `x_search` | 实时搜 X，写入证据 | ✅ | ✅ |
+| `x_get` | 按 url/id 取单帖（补全/校验） | ✅ | ✅ |
+| `x_evidence_list` | 列本机证据（按 query/session/tag） | 只读库 | ✅ |
+| `x_evidence_get` | 取单条/一批证据全文 | 只读库 | ✅ |
+| `x_analyze` | 只基于已落库证据做分析 | 可选写「分析快照」 | ✅ |
+| `x_draft_reply` | 基于证据生成回复草稿 | ✅ 草稿 | ✅ |
+| `x_quote_pack` | 把证据打成可粘贴引用包 | 可选 | ✅ |
+| `x_publish_reply` | 真发送（若有一天） | 审计日志 | ❌ 默认关 |
+
+下面是详细合约。
+
+---
+
+### 1. `x_search` — 搜并落证（主入口）
+
+**用途**：唯一「从 X 拉新信息」的入口。
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|:----:|------|
+| `query` | string | ✅ | 关键词 / `from:user` / 话题（透传上游能力，不假装支持官方全语法） |
+| `limit` | number | | 默认 10，上限 25（防上下文炸） |
+| `freshness` | enum | | `any` \| `day` \| `week`（能映射就映射，不能就进 prompt 约束） |
+| `session_tag` | string | | 默认当前 agent session id；用于证据分桶 |
+| `dedupe` | bool | | 默认 true：同 status id 不重复占库 |
+
+**返回（强制 envelope）**
+
+**落库**：✅ 每条 → evidence row（见下节 schema）  
+**特色**：搜完不是「一段散文」，是 **可 ID 引用的证据集**。Agent 下一轮必须说 `evidence_ids`，不能只复述模糊记忆。
+
+---
+
+### 2. `x_get` — 单帖校验 / 补全
+
+**用途**：用户丢链接、或分析前要「钉死原文」。
+
+| 参数 | 必填 | 说明 |
+|------|:----:|------|
+| `url` 或 `status_id` | ✅ 二选一 | |
+| `session_tag` | | 写入同一证据桶 |
+
+**落库**：✅ upsert  
+**特色**：专门打「幻觉帖」——没有稳定 url 的不配进 `x_analyze` / `x_draft_reply`。
+
+---
+
+### 3. `x_evidence_list` / `x_evidence_get` — 本地证据总线
+
+这是 **和「只有 search 的产品」真正拉开差距** 的两刀。
+
+**`x_evidence_list`**
+
+| 参数 | 说明 |
+|------|------|
+| `session_tag` / `query_contains` / `author` / `since` / `until` / `limit` | 过滤 |
+| `ids_only` | 默认 false；true 时只返回 id 列表省 token |
+
+**`x_evidence_get`**
+
+| 参数 | 说明 |
+|------|------|
+| `evidence_ids` | string[]，必填 |
+| `include_raw` | 默认 false（raw 大、易污染上下文） |
+
+**落库**：只读  
+**特色**：Agent 长任务可以：
+
+```text
+回合1: x_search → 落下 20 条
+回合5: x_evidence_list → 还在
+回合6: x_analyze(evidence_ids=…) → 不重新搜、不丢引用
+```
+
+没有这两工具，`x_search` 永远是一次性烟花。
+
+---
+
+### 4. `x_analyze` — 只吃证据，不吃空气
+
+| 参数 | 必填 | 说明 |
+|------|:----:|------|
+| `evidence_ids` | ✅ | **禁止空数组**；禁止「全库瞎扫」除非显式 `scope=session` |
+| `lens` | | `consensus` \| `dispute` \| `timeline` \| `claims` \| `risk` \| `custom` |
+| `question` | | `lens=custom` 时必填 |
+| `max_items` | | 默认 30，超出要 Agent 先 list 再筛 |
+
+**规则（写进 tool description + agents-guide）**
+
+- 只能基于给定 evidence；缺证据就说缺，**禁止补搜幻想**  
+- 输出每个 claim 必须带 `evidence_ids` / `urls`  
+- 找不到支撑的观点标 `confidence: low` 或直接省略  
+
+**落库**：可选写 `analysis_snapshot`（id + 结论 markdown + 引用 ids），便于「把上次分析接着做」。  
+**特色**：分析工具绑定证据 ID，把 GrokGo 从「搜索插件」变成 **可审计推理轨**。
+
+---
+
+### 5. `x_draft_reply` — 人在环的回复（运营党最想要的那部分，用 Agent 方式给）
+
+| 参数 | 必填 | 说明 |
+|------|:----:|------|
+| `evidence_id` 或 `url` | ✅ | 回哪条 |
+| `goal` | ✅ | 澄清 / 反驳 / 共鸣 / 引流 / 客服… |
+| `persona` | | 简短人设，默认空 |
+| `tone` | | `neutral` \| `sharp` \| `warm` \| `professional` |
+| `variants` | | 默认 3，上限 5 |
+| `must_cite` | | 默认 true：草稿里保留原帖要点，不歪曲 |
+
+**返回**
+
+**落库**：✅ 草稿 + 关联 evidence_id（可 `/` 复查）  
+**不落**：发送状态（因为根本不发）  
+**特色**：满足「回复需求」里 **80% 真实价值**（想好怎么回），砍掉 **90% 封号风险**（自动发）。
+
+---
+
+### 6. `x_quote_pack` — 小而锋利的「可交付物」
+
+Agent 党经常要的不是分析本身，而是 **能贴进 PRD / 日报 / 投资 memo 的引用块**。
+
+| 参数 | 说明 |
+|------|------|
+| `evidence_ids` | 必填 |
+| `format` | `markdown` \| `json` \| `footnote` |
+| `title` | 可选 |
+
+**输出示例（markdown）**
+
+```markdown
+## X 证据包 · 2026-07-30
+1. @foo (链接) — 「原文摘录…」
+2. @bar (链接) — 「…」
+```
+
+**落库**：可选把 pack 存成 `~/.grok-go/x-evidence/packs/*.md`（和媒体 artifacts 哲学一致：本地绝对路径可打开）  
+**特色**：一键从「搜过」变成「可交付」，这是运营后台也不如 Agent 顺手的点。
+
+---
+
+### 7. `x_publish_reply` — 明确不作为主特色
+
+| 参数 | 说明 |
+|------|------|
+| — | 仅当用户显式绑定 X、打开 experimental write、二次确认 |
+
+**默认**：不出现在 `tools/list`  
+**若做**：独立 scope、审计日志、速率限制——**永不作为卖点首页**。
+
+特色靠 Evidence Rail，不靠自动刷回复。
+
+---
+
+## 本地数据（系统真相）
+
+路径建议：`~/.grok-go/x-evidence.db` + 可选 `packs/`。
+
+**evidence 表（核心字段）**
+
+| 字段 | 含义 |
+|------|------|
+| `evidence_id` | 稳定主键 |
+| `status_id` / `url` | 外部锚点 |
+| `author` / `text` / `created_at` | 内容 |
+| `metrics_json` | 互动（有则存） |
+| `query` / `session_tag` | 来源上下文 |
+| `source` | `x_search` \| `x_get` \| `import` |
+| `verified` | 是否有合法 x.com status url |
+| `raw_ref` | 可选，大 raw 外置文件 |
+| `fetched_at` | 抓取时间 |
+
+**drafts / analysis_snapshots**：外键挂 `evidence_id`，形成：
+
+```text
+search ──► evidence ──► analyze
+                │
+                └──► draft_reply ──► (human sends on X)
+                └──► quote_pack
+```
+
+这就是产品图，不是工具堆。
+
+---
+
+## agents-guide 硬规则（特色靠纪律，不靠口号）
+
+```text
+1. 需要 X 近况 → 只用 grok-go::x_search / x_get
+2. 禁止 web_search / 浏览器 / 第三方 twitter API 顶替（除非 MCP /health 失败并声明）
+3. 任何关于「某帖说了什么」的断言 → 必须带 url 或 evidence_id
+4. 多轮任务先 x_evidence_list，再决定是否重新 search
+5. x_analyze 不得在 evidence_ids 为空时调用
+6. 回复需求 → x_draft_reply；禁止声称「已发送」
+7. 图片仍走 Codex 原生；视频走既有 MCP；X 证据链独立
+```
+
+**纪律本身就是护城河**：客户端换了，guide + tool 合约还在。
+
+---
+
+## 为什么这套设计「与众不同」
+
+| 维度 | 普通做法 | GrokGo Evidence Rail |
+|------|----------|----------------------|
+| 搜索 | 返回一段模型摘要 | 返回 **evidence_id + 强制 citation** |
+| 记忆 | 靠上下文窗口 | **本机证据库跨回合** |
+| 分析 | 自由发挥 | **只准吃已落证 ID** |
+| 回复 | 自动发或纯文案 | **草稿 + 原帖锚点 + 风险标签** |
+| 交付 | 聊完就没了 | **`x_quote_pack` 本地 markdown 产物** |
+| 身份 | 纠结绑不绑 x.com | **先不绑也能完成 Agent 主路径**；绑 X 只为 write experimental |
+| 竞品 | 像 NewAPI 或社媒工具 | **像「给 Agent 用的 X 证据总线」** |
+
+一句话对外：
+
+> **Codex / Claude Code 里，唯一把 X 搜索变成「可引用、可复查、可分析、可起草回复」闭环的本地轨。**
+
+---
+
+## 刻意不做的（保证特色不被稀释）
+
+- 多账号 X 矩阵、定时发帖、点赞转发刷量  
+- 漂亮运营看板（热力可以极简，不做完整 BI）  
+- 全站爬虫、粉丝画像 CRM  
+- 自动回复 bot  
+- 用绑定 x.com 才能搜索（搜索继续走 Grok/xAI 能力）
+
+---
+
+## 落地优先级（仍然突出特色）
+
+| 阶段 | 工具 | 特色是否成形 |
+|------|------|----------------|
+| **MVP** | `x_search` envelope 强化 + 落库 + `x_evidence_list/get` | ⭐ 证据轨成型 |
+| **+1** | `x_analyze`（强制 ids）+ agents-guide 纪律 | ⭐⭐ 可审计分析 |
+| **+2** | `x_draft_reply` + `x_quote_pack` | ⭐⭐⭐ 搜-证-析-稿-交付 闭环 |
+| **以后** | `x_get` 补强、可选 X OAuth 只读、`x_publish_*` 默认关 | 不改变主叙事 |
+
+MVP 其实 **不必先做回复**；只要「搜完有 ID、下轮还在、结论必须带链接」，特色已经立住。回复是锦上添花，不是灵魂。
+
+---
+
+## 产品叙事（你对外怎么讲）
+
+- **不是**：「我们加了 X 搜索 MCP」  
+- **而是**：「我们给 Agent 铺了一条 **X 证据轨**——它在本地记住帖子，逼模型引用，帮你起草回复，但绝不替你社死。」
+
+若你只做一件视觉化的事：Overview 加一块 **Evidence** 小计数（今日新证 / 本周引用包），比再做一页运营图表更符合这个定位。
+
+---
+
+如果你下一步要进实现，我建议直接从 **`x_search` 返回强制 `evidence_ids` + sqlite 落库 + `x_evidence_list/get`** 开刀——这三个上线，产品特色就从 README 变成用户可感知的行为。需要的话我可以按你们现有 `mcp_tools_catalog` / `extract_x_search_result` 结构拆一版具体改动点。

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10930,6 +10930,13 @@ pub async fn x_evidence_get(
 }
 
 #[tauri::command]
+pub async fn x_evidence_stats() -> Result<crate::x_evidence::EvidenceStats, String> {
+    tauri::async_runtime::spawn_blocking(crate::x_evidence::evidence_stats)
+        .await
+        .map_err(|e| format!("x_evidence_stats: {e}"))?
+}
+
+#[tauri::command]
 pub async fn x_quote_pack(
     ids: Vec<String>,
     title: Option<String>,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10891,3 +10891,53 @@ pub async fn batch_agents_headless(
     .map_err(|e| format!("batch_agents_headless: {e}"))
 }
 
+// ── X Evidence Rail (search → local evidence store → quote pack) ────────────
+// Design: docs/features/x-search.md — every X search result becomes a local
+// evidence row with a stable id; later turns list / re-read / quote without
+// re-searching. Write path (publishing to X) intentionally absent.
+
+#[tauri::command]
+pub async fn x_evidence_search(
+    query: String,
+    limit: Option<u32>,
+    session_tag: Option<String>,
+) -> Result<crate::x_evidence::XSearchEnvelope, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::x_evidence::x_search(&query, limit, session_tag.as_deref())
+    })
+    .await
+    .map_err(|e| format!("x_evidence_search: {e}"))
+}
+
+#[tauri::command]
+pub async fn x_evidence_list(
+    filter: Option<crate::x_evidence::EvidenceFilter>,
+) -> Result<Vec<crate::x_evidence::EvidenceItem>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::x_evidence::evidence_list(&filter.unwrap_or_default())
+    })
+    .await
+    .map_err(|e| format!("x_evidence_list: {e}"))?
+}
+
+#[tauri::command]
+pub async fn x_evidence_get(
+    ids: Vec<String>,
+) -> Result<Vec<crate::x_evidence::EvidenceItem>, String> {
+    tauri::async_runtime::spawn_blocking(move || crate::x_evidence::evidence_get(&ids))
+        .await
+        .map_err(|e| format!("x_evidence_get: {e}"))?
+}
+
+#[tauri::command]
+pub async fn x_quote_pack(
+    ids: Vec<String>,
+    title: Option<String>,
+) -> Result<crate::x_evidence::QuotePack, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::x_evidence::quote_pack(&ids, title.as_deref())
+    })
+    .await
+    .map_err(|e| format!("x_quote_pack: {e}"))?
+}
+

--- a/src-tauri/src/extensions.rs
+++ b/src-tauri/src/extensions.rs
@@ -317,20 +317,29 @@ pub fn parse_mcp_servers_from_toml(text: &str) -> Vec<McpServerDef> {
 
     for line in text.lines() {
         let trimmed = line.trim();
-        if let Some(ref mut buf) = args_buf {
-            buf.push(' ');
-            buf.push_str(trimmed);
-            if trimmed.contains(']') {
-                let joined = args_buf.take().unwrap_or_default();
-                if let Some(name) = current.as_ref() {
-                    if let Some(def) = by_name.get_mut(name) {
-                        if let Some(arr) = parse_toml_string_array(&joined) {
-                            def.args = Some(arr);
+        if args_buf.is_some() {
+            // A table header while accumulating means the previous multi-line
+            // args never closed — drop the malformed buffer and let the header
+            // logic below process this line, instead of silently eating it
+            // (which used to lose whole servers).
+            if trimmed.starts_with('[') && trimmed.ends_with(']') && !trimmed.contains('"') && !trimmed.contains('\'') {
+                args_buf = None;
+            } else {
+                let buf = args_buf.as_mut().expect("checked is_some");
+                buf.push(' ');
+                buf.push_str(trimmed);
+                if toml_array_closed(buf) {
+                    let joined = args_buf.take().unwrap_or_default();
+                    if let Some(name) = current.as_ref() {
+                        if let Some(def) = by_name.get_mut(name) {
+                            if let Some(arr) = parse_toml_string_array(&joined) {
+                                def.args = Some(arr);
+                            }
                         }
                     }
                 }
+                continue;
             }
-            continue;
         }
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
@@ -408,7 +417,7 @@ pub fn parse_mcp_servers_from_toml(text: &str) -> Vec<McpServerDef> {
                 def.enabled = parse_toml_bool(val_raw);
             }
             "args" => {
-                if val_raw.contains('[') && !val_raw.contains(']') {
+                if val_raw.contains('[') && !toml_array_closed(val_raw) {
                     args_buf = Some(val_raw.to_string());
                 } else if let Some(arr) = parse_toml_string_array(val_raw) {
                     def.args = Some(arr);
@@ -466,20 +475,49 @@ fn parse_toml_bool(raw: &str) -> Option<bool> {
     }
 }
 
+/// Whether an `args = [ …` buffer (single line or multi-line-joined) already
+/// contains its closing `]` **outside** any string literal. A `]` inside a
+/// quoted element (e.g. `"some]thing"`) must not terminate the array.
+fn toml_array_closed(buf: &str) -> bool {
+    let Some(start) = buf.find('[') else {
+        return false;
+    };
+    let mut in_str: Option<char> = None;
+    let mut escape = false;
+    for ch in buf[start + 1..].chars() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if let Some(q) = in_str {
+            if ch == '\\' {
+                escape = true;
+            } else if ch == q {
+                in_str = None;
+            }
+            continue;
+        }
+        match ch {
+            '"' | '\'' => in_str = Some(ch),
+            ']' => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
 /// Parse a single-line or multi-line-joined TOML string array: `["a", "b"]`.
+/// Stops at the first `]` outside a string literal so quoted elements may
+/// contain `]` without truncating the array.
 fn parse_toml_string_array(raw: &str) -> Option<Vec<String>> {
     let s = raw.trim();
     let start = s.find('[')?;
-    let end = s.rfind(']')?;
-    if end <= start {
-        return None;
-    }
-    let inner = &s[start + 1..end];
     let mut out = Vec::new();
     let mut cur = String::new();
     let mut in_str: Option<char> = None;
     let mut escape = false;
-    for ch in inner.chars() {
+    let mut closed = false;
+    for ch in s[start + 1..].chars() {
         if escape {
             cur.push(ch);
             escape = false;
@@ -501,9 +539,15 @@ fn parse_toml_string_array(raw: &str) -> Option<Vec<String>> {
         }
         match ch {
             '"' | '\'' => in_str = Some(ch),
-            ',' | ' ' | '\t' | '\n' | '\r' => {}
+            ']' => {
+                closed = true;
+                break;
+            }
             _ => {}
         }
+    }
+    if !closed {
+        return None;
     }
     Some(out)
 }
@@ -1653,6 +1697,48 @@ enabled = true
         assert_eq!(a.len(), 2);
         assert!(a.iter().any(|v| v["name"] == "chrome-devtools"));
         assert!(a.iter().any(|v| v["name"] == "cloudflare-api" && v["type"] == "http"));
+    }
+
+    #[test]
+    fn parse_mcp_servers_from_toml_recovers_from_unclosed_args() {
+        // alpha 的多行 args 漏了 `]` — beta 表头不能被当成 args 续行吞掉。
+        let raw = r#"
+[mcp_servers.alpha]
+command = "npx"
+args = [
+    "-y",
+    "alpha-mcp"
+
+[mcp_servers.beta]
+command = "node"
+args = ["server.js"]
+
+[mcp_servers.gamma]
+command = "python"
+args = ["-m", "gamma"]
+"#;
+        let defs = parse_mcp_servers_from_toml(raw);
+        let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta", "gamma"], "{defs:?}");
+        let beta = defs.iter().find(|d| d.name == "beta").unwrap();
+        assert_eq!(
+            beta.args.as_ref().map(|a| a.as_slice()),
+            Some(["server.js".to_string()].as_slice())
+        );
+        // alpha 的坏 buffer 被丢弃，不能吃到 beta 的 args。
+        let alpha = defs.iter().find(|d| d.name == "alpha").unwrap();
+        assert_ne!(
+            alpha.args.as_ref().map(|a| a.as_slice()),
+            Some(["server.js".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn parse_toml_string_array_bracket_inside_string() {
+        let arr = parse_toml_string_array(r#"["-y", "some]thing", "last"]"#).unwrap();
+        assert_eq!(arr, vec!["-y", "some]thing", "last"]);
+        // 未闭合数组（字符串外无 `]`）→ None，而不是截断。
+        assert!(parse_toml_string_array(r#"["-y", "open"#).is_none());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,6 +87,7 @@ mod remote_im;
 mod wallpaper_source;
 mod streaming_messages_json;
 mod batch_agents;
+mod x_evidence;
 mod leader;
 mod serve;
 
@@ -572,6 +573,10 @@ pub fn run() {
             commands::wallpaper_library_list,
             commands::streaming_messages_json_probe,
             commands::batch_agents_headless,
+            commands::x_evidence_search,
+            commands::x_evidence_list,
+            commands::x_evidence_get,
+            commands::x_quote_pack,
         ])
         .build(tauri::generate_context!())
         .expect("error while building Grok App")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -576,6 +576,7 @@ pub fn run() {
             commands::x_evidence_search,
             commands::x_evidence_list,
             commands::x_evidence_get,
+            commands::x_evidence_stats,
             commands::x_quote_pack,
         ])
         .build(tauri::generate_context!())

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -103,6 +103,14 @@ pub fn normalize_media_url(url: &str) -> String {
     }
     // pbs.twimg.com/media/XXX?format=jpg&name=small → name=orig
     if trimmed.contains("pbs.twimg.com/media/") {
+        // Legacy `:small` / `:large` suffix — must be handled before
+        // Url::parse, which accepts the suffix as part of the path and
+        // would return the URL unchanged.
+        for suffix in [":thumb", ":small", ":medium", ":large"] {
+            if let Some(base) = trimmed.strip_suffix(suffix) {
+                return format!("{base}:orig");
+            }
+        }
         if let Ok(mut u) = url::Url::parse(trimmed) {
             let mut pairs: Vec<(String, String)> = u
                 .query_pairs()
@@ -123,17 +131,6 @@ pub fn normalize_media_url(url: &str) -> String {
                 u.query_pairs_mut().append_pair(&k, &v);
             }
             return u.to_string();
-        }
-        // Legacy :small / :large suffix
-        for suffix in [":thumb", ":small", ":medium", ":large"] {
-            if let Some(base) = trimmed.strip_suffix(suffix) {
-                return format!("{base}:orig");
-            }
-        }
-        if !trimmed.contains(':') || trimmed.matches(':').count() == 1 {
-            // scheme only — leave as-is
-        } else if !trimmed.ends_with(":orig") {
-            return format!("{trimmed}:orig");
         }
     }
     trimmed.to_string()
@@ -184,13 +181,16 @@ pub fn is_gallery_media_url(url: &str) -> bool {
     {
         return false;
     }
-    // Prefer photo media CDN paths
+    // Prefer photo media CDN paths. Keep in sync with is_allowed_media_url —
+    // a host allowed for download must not be silently dropped from the gallery.
     lower.contains("pbs.twimg.com/media/")
         || lower.contains("video.twimg.com/")
         || lower.contains("ton.twimg.com/")
+        || lower.contains("abs.twimg.com/")
         || lower.contains(".x.ai/")
         || lower.contains("cdn.grok.com")
         || lower.contains("assets.grok.com")
+        || lower.contains("filesystem.site/")
 }
 
 fn mime_from_ext(ext: &str) -> &'static str {
@@ -248,7 +248,7 @@ fn kind_from_mime(mime: &str) -> &'static str {
 
 // ── Auth / CLI ──────────────────────────────────────────────────────────────
 
-fn require_cli_ready() -> Result<String, String> {
+pub(crate) fn require_cli_ready() -> Result<String, String> {
     let settings = store::load_settings();
     let probe = cli_probe::probe_cli(settings.manual_cli_path.as_deref());
     if !probe.found {
@@ -493,7 +493,7 @@ fn extract_json_object(raw: &str) -> Option<serde_json::Value> {
     parse_grok_wallpaper_payload(raw)
 }
 
-fn run_grok_headless(
+pub(crate) fn run_grok_headless(
     cli_path: &str,
     prompt: &str,
     schema: &str,
@@ -1342,6 +1342,25 @@ mod tests {
             "https://pbs.twimg.com/media/HOUbJsYaEAAaEQ6.jpg?format=jpg&name=small",
         );
         assert!(u.contains("name=orig"), "{u}");
+    }
+
+    #[test]
+    fn normalize_twimg_legacy_colon_suffix() {
+        assert_eq!(
+            normalize_media_url("https://pbs.twimg.com/media/abc.jpg:small"),
+            "https://pbs.twimg.com/media/abc.jpg:orig"
+        );
+        assert_eq!(
+            normalize_media_url("https://pbs.twimg.com/media/abc.jpg:large"),
+            "https://pbs.twimg.com/media/abc.jpg:orig"
+        );
+    }
+
+    #[test]
+    fn gallery_accepts_all_allowlisted_hosts() {
+        // 下载白名单里的主机不能被画廊判定静默丢弃。
+        assert!(is_gallery_media_url("https://filesystem.site/cdn/xyz.png"));
+        assert!(is_gallery_media_url("https://abs.twimg.com/media/foo.jpg"));
     }
 
     #[test]

--- a/src-tauri/src/x_evidence.rs
+++ b/src-tauri/src/x_evidence.rs
@@ -13,7 +13,7 @@
 //! Write path (publishing to X) is intentionally absent.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use rusqlite::{params, Connection};
@@ -83,6 +83,15 @@ pub struct EvidenceFilter {
     pub author: Option<String>,
     #[serde(default)]
     pub limit: Option<u32>,
+}
+
+/// Small dashboard counters: today's new evidence / this week's quote packs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EvidenceStats {
+    pub total: i64,
+    pub today_new: i64,
+    pub week_packs: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -408,6 +417,61 @@ fn items_to_evidence(
     out
 }
 
+// ── Stats (dashboard Evidence block) ─────────────────────────────────────────
+
+fn count_recent_packs(dir: &Path, days: u64) -> i64 {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return 0;
+    };
+    let cutoff = std::time::SystemTime::now()
+        .checked_sub(Duration::from_secs(days * 24 * 3600));
+    let Some(cutoff) = cutoff else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter(|e| {
+            e.path().extension().and_then(|s| s.to_str()) == Some("md")
+                && e.metadata()
+                    .and_then(|m| m.modified())
+                    .map(|t| t >= cutoff)
+                    .unwrap_or(false)
+        })
+        .count() as i64
+}
+
+fn stats_from(conn: &Connection, today_start_ms: i64, packs: &Path) -> Result<EvidenceStats, String> {
+    let total: i64 = conn
+        .query_row("SELECT COUNT(*) FROM evidence", [], |r| r.get(0))
+        .map_err(|e| format!("x-evidence stats: {e}"))?;
+    let today_new: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM evidence WHERE fetched_at >= ?1",
+            params![today_start_ms],
+            |r| r.get(0),
+        )
+        .map_err(|e| format!("x-evidence stats: {e}"))?;
+    Ok(EvidenceStats {
+        total,
+        today_new,
+        week_packs: count_recent_packs(packs, 7),
+    })
+}
+
+/// Counters for the dashboard: total evidence / new since local midnight /
+/// quote packs written in the last 7 days.
+pub fn evidence_stats() -> Result<EvidenceStats, String> {
+    let conn = open_db()?;
+    let now = chrono::Local::now();
+    let today_start_ms = now
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .and_then(|naive| naive.and_local_timezone(chrono::Local).single())
+        .map(|dt| dt.timestamp_millis())
+        .unwrap_or_else(|| now.timestamp_millis() - 86_400_000);
+    stats_from(&conn, today_start_ms, &packs_dir())
+}
+
 // ── Public API ───────────────────────────────────────────────────────────────
 
 fn build_x_evidence_prompt(query: &str, limit: u32) -> String {
@@ -685,6 +749,23 @@ mod tests {
         let items = items_to_evidence(&v, "q", None, "x_search");
         assert_eq!(items.len(), 2);
         assert!(items.iter().all(|i| !i.verified));
+    }
+
+    #[test]
+    fn stats_counts_today_and_total() {
+        let conn = mem_db();
+        let mut old = sample(Some("https://x.com/xai/status/1111111111111"), "old");
+        old.fetched_at_ms = 100;
+        upsert_evidence(&conn, &old).unwrap();
+        let mut fresh = sample(Some("https://x.com/xai/status/2222222222222"), "fresh");
+        fresh.fetched_at_ms = 5_000;
+        upsert_evidence(&conn, &fresh).unwrap();
+
+        let tmp = std::env::temp_dir().join("grok-app-x-evidence-test-empty-packs");
+        let stats = stats_from(&conn, 1_000, &tmp).unwrap();
+        assert_eq!(stats.total, 2);
+        assert_eq!(stats.today_new, 1);
+        assert_eq!(stats.week_packs, 0);
     }
 
     #[test]

--- a/src-tauri/src/x_evidence.rs
+++ b/src-tauri/src/x_evidence.rs
@@ -1,0 +1,700 @@
+//! X Evidence Rail — search X via headless Grok CLI and persist every post as
+//! a local *evidence row* (sqlite), so later agent turns can list / re-read /
+//! quote it without re-searching or hallucinating URLs.
+//!
+//! Design: `docs/features/x-search.md`. MVP surface:
+//! - [`x_search`] — the only entry that pulls new posts; each result is upserted
+//!   as evidence with a stable `evidence_id`. No canonical `x.com/...status/...`
+//!   URL → stored but flagged `verified = false`.
+//! - [`evidence_list`] / [`evidence_get`] — the local evidence bus.
+//! - [`quote_pack`] — turn evidence ids into a paste-ready markdown pack under
+//!   `{app_data}/x-evidence/packs/`.
+//!
+//! Write path (publishing to X) is intentionally absent.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+use crate::paths;
+use crate::wallpaper_source::{require_cli_ready, run_grok_headless};
+
+/// Headless X evidence search budget.
+const X_EVIDENCE_TIMEOUT: Duration = Duration::from_secs(150);
+/// Hard cap on posts per search (context-blowup guard, per design doc).
+const MAX_LIMIT: u32 = 25;
+const DEFAULT_LIMIT: u32 = 10;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EvidenceItem {
+    pub evidence_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub likes: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_tag: Option<String>,
+    /// `x_search` | `x_get` | `import`
+    pub source: String,
+    /// Has a canonical `x.com/<user>/status/<id>` anchor.
+    pub verified: bool,
+    pub fetched_at_ms: i64,
+}
+
+/// Envelope returned by [`x_search`] — evidence ids first, prose never.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct XSearchEnvelope {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    pub query: String,
+    pub evidence: Vec<EvidenceItem>,
+    pub new_count: usize,
+    pub unverified_count: usize,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EvidenceFilter {
+    #[serde(default)]
+    pub session_tag: Option<String>,
+    #[serde(default)]
+    pub query_contains: Option<String>,
+    #[serde(default)]
+    pub author: Option<String>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuotePack {
+    pub markdown: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub count: usize,
+}
+
+// ── Storage ──────────────────────────────────────────────────────────────────
+
+fn x_evidence_root() -> PathBuf {
+    paths::app_data_root().join("x-evidence")
+}
+
+fn db_path() -> PathBuf {
+    x_evidence_root().join("evidence.db")
+}
+
+fn packs_dir() -> PathBuf {
+    x_evidence_root().join("packs")
+}
+
+fn open_db() -> Result<Connection, String> {
+    let root = x_evidence_root();
+    fs::create_dir_all(&root).map_err(|e| format!("x-evidence dir: {e}"))?;
+    let conn = Connection::open(db_path()).map_err(|e| format!("x-evidence db: {e}"))?;
+    init_schema(&conn)?;
+    Ok(conn)
+}
+
+fn init_schema(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS evidence (
+            evidence_id  TEXT PRIMARY KEY,
+            status_id    TEXT,
+            url          TEXT,
+            author       TEXT,
+            text         TEXT,
+            created_at   TEXT,
+            likes        INTEGER,
+            query        TEXT,
+            session_tag  TEXT,
+            source       TEXT NOT NULL,
+            verified     INTEGER NOT NULL DEFAULT 0,
+            fetched_at   INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_evidence_session ON evidence(session_tag);
+        CREATE INDEX IF NOT EXISTS idx_evidence_status ON evidence(status_id);",
+    )
+    .map_err(|e| format!("x-evidence schema: {e}"))
+}
+
+/// Insert or refresh one evidence row. Returns `true` when it was new.
+fn upsert_evidence(conn: &Connection, it: &EvidenceItem) -> Result<bool, String> {
+    let inserted = conn
+        .execute(
+            "INSERT OR IGNORE INTO evidence
+             (evidence_id, status_id, url, author, text, created_at, likes,
+              query, session_tag, source, verified, fetched_at)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
+            params![
+                it.evidence_id,
+                it.status_id,
+                it.url,
+                it.author,
+                it.text,
+                it.created_at,
+                it.likes,
+                it.query,
+                it.session_tag,
+                it.source,
+                it.verified as i64,
+                it.fetched_at_ms,
+            ],
+        )
+        .map_err(|e| format!("x-evidence insert: {e}"))?;
+    if inserted == 0 {
+        // Same evidence seen again — refresh volatile fields, keep first-seen anchor.
+        conn.execute(
+            "UPDATE evidence SET likes = COALESCE(?2, likes), fetched_at = ?3
+             WHERE evidence_id = ?1",
+            params![it.evidence_id, it.likes, it.fetched_at_ms],
+        )
+        .map_err(|e| format!("x-evidence refresh: {e}"))?;
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+fn row_to_item(row: &rusqlite::Row<'_>) -> rusqlite::Result<EvidenceItem> {
+    Ok(EvidenceItem {
+        evidence_id: row.get(0)?,
+        status_id: row.get(1)?,
+        url: row.get(2)?,
+        author: row.get(3)?,
+        text: row.get(4)?,
+        created_at: row.get(5)?,
+        likes: row.get(6)?,
+        query: row.get(7)?,
+        session_tag: row.get(8)?,
+        source: row.get(9)?,
+        verified: row.get::<_, i64>(10)? != 0,
+        fetched_at_ms: row.get(11)?,
+    })
+}
+
+const SELECT_COLS: &str = "evidence_id, status_id, url, author, text, created_at, likes, \
+                           query, session_tag, source, verified, fetched_at";
+
+fn list_evidence(conn: &Connection, filter: &EvidenceFilter) -> Result<Vec<EvidenceItem>, String> {
+    let mut sql = format!("SELECT {SELECT_COLS} FROM evidence WHERE 1=1");
+    let mut args: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    if let Some(tag) = filter.session_tag.as_deref().filter(|s| !s.trim().is_empty()) {
+        sql.push_str(" AND session_tag = ?");
+        args.push(Box::new(tag.trim().to_string()));
+    }
+    if let Some(q) = filter.query_contains.as_deref().filter(|s| !s.trim().is_empty()) {
+        sql.push_str(" AND query LIKE ?");
+        args.push(Box::new(format!("%{}%", q.trim())));
+    }
+    if let Some(a) = filter.author.as_deref().filter(|s| !s.trim().is_empty()) {
+        sql.push_str(" AND author = ?");
+        args.push(Box::new(a.trim().trim_start_matches('@').to_string()));
+    }
+    let limit = filter.limit.unwrap_or(100).clamp(1, 500);
+    sql.push_str(&format!(" ORDER BY fetched_at DESC LIMIT {limit}"));
+
+    let mut stmt = conn.prepare(&sql).map_err(|e| format!("x-evidence list: {e}"))?;
+    let params_ref: Vec<&dyn rusqlite::ToSql> = args.iter().map(|b| b.as_ref()).collect();
+    let rows = stmt
+        .query_map(params_ref.as_slice(), row_to_item)
+        .map_err(|e| format!("x-evidence list: {e}"))?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| format!("x-evidence list: {e}"))
+}
+
+fn get_evidence(conn: &Connection, ids: &[String]) -> Result<Vec<EvidenceItem>, String> {
+    let mut out = Vec::with_capacity(ids.len());
+    let mut stmt = conn
+        .prepare(&format!("SELECT {SELECT_COLS} FROM evidence WHERE evidence_id = ?1"))
+        .map_err(|e| format!("x-evidence get: {e}"))?;
+    for id in ids {
+        let id = id.trim();
+        if id.is_empty() {
+            continue;
+        }
+        if let Some(item) = stmt
+            .query_row(params![id], row_to_item)
+            .map(Some)
+            .or_else(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                other => Err(format!("x-evidence get: {other}")),
+            })?
+        {
+            out.push(item);
+        }
+    }
+    Ok(out)
+}
+
+// ── URL / id helpers ─────────────────────────────────────────────────────────
+
+/// Extract the numeric status id from an `x.com` / `twitter.com` status URL.
+pub fn extract_status_id(url: &str) -> Option<String> {
+    let u = url.trim();
+    let lower = u.to_ascii_lowercase();
+    if !(lower.contains("x.com/") || lower.contains("twitter.com/")) {
+        return None;
+    }
+    let idx = lower.find("/status/")?;
+    let rest = &u[idx + "/status/".len()..];
+    let id: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    // Real snowflake ids are long; short digit runs are noise, not anchors.
+    if id.len() >= 8 {
+        Some(id)
+    } else {
+        None
+    }
+}
+
+fn evidence_id_for(status_id: Option<&str>, url: Option<&str>, fallback: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let key = status_id
+        .map(|s| format!("status:{s}"))
+        .or_else(|| url.map(|u| format!("url:{}", u.trim())))
+        .unwrap_or_else(|| format!("text:{fallback}"));
+    let mut h = Sha256::new();
+    h.update(key.as_bytes());
+    let d = h.finalize();
+    let hex: String = d.iter().take(6).map(|b| format!("{b:02x}")).collect();
+    format!("ev-{hex}")
+}
+
+// ── Model output parsing ─────────────────────────────────────────────────────
+
+/// First balanced `{…}` JSON object in free-form text (string-literal aware).
+fn first_json_object(s: &str) -> Option<serde_json::Value> {
+    let start = s.find('{')?;
+    let mut depth = 0i32;
+    let mut in_str = false;
+    let mut esc = false;
+    for (i, c) in s[start..].char_indices() {
+        if esc {
+            esc = false;
+            continue;
+        }
+        if in_str {
+            match c {
+                '\\' => esc = true,
+                '"' => in_str = false,
+                _ => {}
+            }
+            continue;
+        }
+        match c {
+            '"' => in_str = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let end = start + i + c.len_utf8();
+                    return serde_json::from_str(&s[start..end]).ok();
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn has_items_array(v: &serde_json::Value) -> bool {
+    v.get("items").map(|i| i.is_array()).unwrap_or(false)
+}
+
+/// Unwrap headless `grok -p --output-format json` envelopes down to the
+/// `{ "items": [...] }` object (direct, `structuredOutput`, or nested `text`).
+fn extract_items_value(raw: &str) -> Option<serde_json::Value> {
+    let env = first_json_object(raw.trim())?;
+    if has_items_array(&env) {
+        return Some(env);
+    }
+    if let Some(so) = env.get("structuredOutput") {
+        if has_items_array(so) {
+            return Some(so.clone());
+        }
+    }
+    if let Some(text) = env.get("text").and_then(|t| t.as_str()) {
+        if let Some(v) = first_json_object(text) {
+            if has_items_array(&v) {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+fn items_to_evidence(
+    value: &serde_json::Value,
+    query: &str,
+    session_tag: Option<&str>,
+    source: &str,
+) -> Vec<EvidenceItem> {
+    let arr = value
+        .get("items")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let fetched = now_ms();
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for raw in arr {
+        let url = raw
+            .get("url")
+            .or_else(|| raw.get("postUrl"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let text = raw
+            .get("text")
+            .and_then(|v| v.as_str())
+            .map(|s| s.chars().take(600).collect::<String>())
+            .filter(|s| !s.trim().is_empty());
+        if url.is_none() && text.is_none() {
+            continue;
+        }
+        let status_id = url.as_deref().and_then(extract_status_id);
+        let fallback = text.clone().unwrap_or_default();
+        let evidence_id = evidence_id_for(status_id.as_deref(), url.as_deref(), &fallback);
+        if !seen.insert(evidence_id.clone()) {
+            continue;
+        }
+        out.push(EvidenceItem {
+            evidence_id,
+            verified: status_id.is_some(),
+            status_id,
+            url,
+            author: raw
+                .get("username")
+                .or_else(|| raw.get("author"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim().trim_start_matches('@').to_string())
+                .filter(|s| !s.is_empty()),
+            text,
+            created_at: raw
+                .get("createdAt")
+                .or_else(|| raw.get("created_at"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            likes: raw.get("likes").and_then(|v| v.as_i64()),
+            query: Some(query.to_string()),
+            session_tag: session_tag.map(|s| s.to_string()),
+            source: source.to_string(),
+            fetched_at_ms: fetched,
+        });
+    }
+    out
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+fn build_x_evidence_prompt(query: &str, limit: u32) -> String {
+    format!(
+        r#"You collect X (Twitter) posts as VERIFIABLE EVIDENCE for an agent workflow.
+
+User query (raw): {query}
+
+Rules:
+1. Use X search tools only. Collect up to {limit} distinct, relevant posts (prefer higher engagement).
+2. `url` MUST be the real canonical status link `https://x.com/<user>/status/<id>` exactly as found — NEVER fabricate or guess an id. Skip posts whose link you cannot confirm.
+3. `text` = the post's own text (trim to ~500 chars, keep meaning). `username` without @. `createdAt` ISO date if known. `likes` if known.
+4. Return exactly ONE JSON object matching the schema (items array). No prose, no markdown fences, no placeholder posts.
+"#
+    )
+}
+
+const X_EVIDENCE_SCHEMA: &str = r#"{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": { "type": "string" },
+          "username": { "type": "string" },
+          "text": { "type": "string" },
+          "createdAt": { "type": "string" },
+          "likes": { "type": "number" }
+        },
+        "required": ["url"]
+      }
+    }
+  },
+  "required": ["items"]
+}"#;
+
+fn err_envelope(query: &str, code: &str, message: Option<String>) -> XSearchEnvelope {
+    XSearchEnvelope {
+        ok: false,
+        error_code: Some(code.into()),
+        message,
+        query: query.to_string(),
+        evidence: vec![],
+        new_count: 0,
+        unverified_count: 0,
+    }
+}
+
+/// Search X and persist every post as evidence. Sync (headless CLI); call from
+/// `spawn_blocking`.
+pub fn x_search(query: &str, limit: Option<u32>, session_tag: Option<&str>) -> XSearchEnvelope {
+    let q = query.trim();
+    if q.is_empty() {
+        return err_envelope(q, "empty", Some("empty query".into()));
+    }
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let cli = match require_cli_ready() {
+        Ok(p) => p,
+        Err(code) => return err_envelope(q, &code, None),
+    };
+    let prompt = build_x_evidence_prompt(q, limit);
+    let stdout = match run_grok_headless(&cli, &prompt, X_EVIDENCE_SCHEMA, 14, X_EVIDENCE_TIMEOUT, None) {
+        Ok(s) => s,
+        Err(code) => return err_envelope(q, &code, None),
+    };
+    let Some(value) = extract_items_value(&stdout) else {
+        return err_envelope(q, "search_failed", Some("could not parse evidence JSON".into()));
+    };
+    let mut items = items_to_evidence(&value, q, session_tag, "x_search");
+    items.truncate(limit as usize);
+    if items.is_empty() {
+        return err_envelope(q, "empty", Some("no posts found".into()));
+    }
+
+    let conn = match open_db() {
+        Ok(c) => c,
+        Err(e) => return err_envelope(q, "store_failed", Some(e)),
+    };
+    let mut new_count = 0usize;
+    for it in &items {
+        match upsert_evidence(&conn, it) {
+            Ok(true) => new_count += 1,
+            Ok(false) => {}
+            Err(e) => return err_envelope(q, "store_failed", Some(e)),
+        }
+    }
+    let unverified_count = items.iter().filter(|i| !i.verified).count();
+    XSearchEnvelope {
+        ok: true,
+        error_code: None,
+        message: None,
+        query: q.to_string(),
+        evidence: items,
+        new_count,
+        unverified_count,
+    }
+}
+
+/// List local evidence (read-only bus).
+pub fn evidence_list(filter: &EvidenceFilter) -> Result<Vec<EvidenceItem>, String> {
+    let conn = open_db()?;
+    list_evidence(&conn, filter)
+}
+
+/// Fetch evidence rows by id (missing ids are silently skipped).
+pub fn evidence_get(ids: &[String]) -> Result<Vec<EvidenceItem>, String> {
+    let conn = open_db()?;
+    get_evidence(&conn, ids)
+}
+
+/// Render evidence ids into a paste-ready markdown quote pack and save it under
+/// `{app_data}/x-evidence/packs/`.
+pub fn quote_pack(ids: &[String], title: Option<&str>) -> Result<QuotePack, String> {
+    let items = evidence_get(ids)?;
+    if items.is_empty() {
+        return Err("no evidence found for given ids".into());
+    }
+    let date = chrono::Local::now().format("%Y-%m-%d").to_string();
+    let markdown = build_pack_markdown(&items, title, &date);
+
+    let dir = packs_dir();
+    fs::create_dir_all(&dir).map_err(|e| format!("packs dir: {e}"))?;
+    let name = format!("pack-{}.md", chrono::Local::now().format("%Y%m%d-%H%M%S"));
+    let path = dir.join(&name);
+    fs::write(&path, &markdown).map_err(|e| format!("write pack: {e}"))?;
+
+    Ok(QuotePack {
+        markdown,
+        path: Some(path.display().to_string()),
+        count: items.len(),
+    })
+}
+
+fn build_pack_markdown(items: &[EvidenceItem], title: Option<&str>, date: &str) -> String {
+    let title = title
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("X 证据包");
+    let mut md = format!("## {title} · {date}\n\n");
+    for (i, it) in items.iter().enumerate() {
+        let author = it.author.as_deref().unwrap_or("unknown");
+        let excerpt: String = it
+            .text
+            .as_deref()
+            .unwrap_or("")
+            .chars()
+            .take(160)
+            .collect();
+        let anchor = match it.url.as_deref() {
+            Some(u) if it.verified => format!("[链接]({u})"),
+            Some(u) => format!("[链接·未验证]({u})"),
+            None => "无链接·unverified".to_string(),
+        };
+        md.push_str(&format!(
+            "{}. @{author} ({anchor}) — 「{excerpt}」 `{}`\n",
+            i + 1,
+            it.evidence_id
+        ));
+    }
+    md
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mem_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn
+    }
+
+    fn sample(url: Option<&str>, text: &str) -> EvidenceItem {
+        let status_id = url.and_then(extract_status_id);
+        EvidenceItem {
+            evidence_id: evidence_id_for(status_id.as_deref(), url, text),
+            verified: status_id.is_some(),
+            status_id,
+            url: url.map(|s| s.to_string()),
+            author: Some("xai".into()),
+            text: Some(text.into()),
+            created_at: None,
+            likes: Some(5),
+            query: Some("grok".into()),
+            session_tag: Some("s1".into()),
+            source: "x_search".into(),
+            fetched_at_ms: 1,
+        }
+    }
+
+    #[test]
+    fn status_id_extraction() {
+        assert_eq!(
+            extract_status_id("https://x.com/xai/status/1234567890123"),
+            Some("1234567890123".into())
+        );
+        assert_eq!(
+            extract_status_id("https://twitter.com/a/status/99887766?s=20"),
+            Some("99887766".into())
+        );
+        // 幻觉/短 id、非 status 页面一律拒绝。
+        assert_eq!(extract_status_id("https://x.com/xai/status/123"), None);
+        assert_eq!(extract_status_id("https://x.com/xai"), None);
+        assert_eq!(extract_status_id("https://example.com/status/1234567890"), None);
+    }
+
+    #[test]
+    fn upsert_dedupes_by_status_id() {
+        let conn = mem_db();
+        let a = sample(Some("https://x.com/xai/status/1234567890123"), "hello");
+        assert!(upsert_evidence(&conn, &a).unwrap());
+        // Same status id again → refresh, not a new row.
+        let mut b = sample(Some("https://x.com/xai/status/1234567890123"), "hello again");
+        b.likes = Some(42);
+        assert!(!upsert_evidence(&conn, &b).unwrap());
+        let rows = list_evidence(&conn, &EvidenceFilter::default()).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].likes, Some(42));
+        assert!(rows[0].verified);
+    }
+
+    #[test]
+    fn list_filters_and_get_roundtrip() {
+        let conn = mem_db();
+        let a = sample(Some("https://x.com/xai/status/1111111111111"), "one");
+        let mut b = sample(Some("https://x.com/other/status/2222222222222"), "two");
+        b.author = Some("other".into());
+        b.session_tag = Some("s2".into());
+        upsert_evidence(&conn, &a).unwrap();
+        upsert_evidence(&conn, &b).unwrap();
+
+        let by_tag = list_evidence(
+            &conn,
+            &EvidenceFilter {
+                session_tag: Some("s2".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(by_tag.len(), 1);
+        assert_eq!(by_tag[0].author.as_deref(), Some("other"));
+
+        let got = get_evidence(&conn, &[a.evidence_id.clone(), "ev-missing".into()]).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].evidence_id, a.evidence_id);
+    }
+
+    #[test]
+    fn parse_headless_envelope_nested_text() {
+        let raw = r#"{
+  "text": "{\"items\":[{\"url\":\"https://x.com/xai/status/1234567890123\",\"username\":\"xai\",\"text\":\"Grok ships\",\"likes\":10}]}",
+  "stopReason": "EndTurn",
+  "structuredOutput": null
+}"#;
+        let v = extract_items_value(raw).expect("items");
+        let items = items_to_evidence(&v, "grok", Some("s1"), "x_search");
+        assert_eq!(items.len(), 1);
+        assert!(items[0].verified);
+        assert_eq!(items[0].status_id.as_deref(), Some("1234567890123"));
+        assert_eq!(items[0].author.as_deref(), Some("xai"));
+    }
+
+    #[test]
+    fn unverified_when_no_canonical_url() {
+        let v = serde_json::json!({
+            "items": [
+                { "url": "https://example.com/blog", "text": "not a status" },
+                { "text": "no url at all" }
+            ]
+        });
+        let items = items_to_evidence(&v, "q", None, "x_search");
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().all(|i| !i.verified));
+    }
+
+    #[test]
+    fn quote_pack_markdown_marks_unverified() {
+        let a = sample(Some("https://x.com/xai/status/1234567890123"), "verified post");
+        let b = sample(None, "unverified note");
+        let md = build_pack_markdown(&[a.clone(), b], Some("测试包"), "2026-07-31");
+        assert!(md.starts_with("## 测试包 · 2026-07-31"));
+        assert!(md.contains("[链接](https://x.com/xai/status/1234567890123)"));
+        assert!(md.contains("unverified"));
+        assert!(md.contains(&a.evidence_id));
+    }
+}

--- a/src/components/AgentDashboardModal.tsx
+++ b/src/components/AgentDashboardModal.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import type { Locale, MessageKey } from "@/i18n";
 import { createT } from "@/i18n";
 import { GlassModal } from "@/components/GlassModal";
+import { xEvidenceStats, type XEvidenceStats } from "@/lib/api";
 import {
   AGENT_DASHBOARD_STATUS_FILTERS,
   countBusyDashboardRows,
@@ -231,7 +232,23 @@ export function AgentDashboardModal({
   const [statusFilter, setStatusFilter] =
     useState<AgentDashboardStatusFilter>("all");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
-
+  // X Evidence Rail counters (today's new evidence / this week's quote packs).
+  // Absent backend (mock mode) or empty store → hide the block silently.
+  const [evidence, setEvidence] = useState<XEvidenceStats | null>(null);
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    xEvidenceStats()
+      .then((s) => {
+        if (!cancelled) setEvidence(s);
+      })
+      .catch(() => {
+        if (!cancelled) setEvidence(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
   const filtered = useMemo(
     () =>
       filterAgentDashboardRows(rows, {
@@ -372,6 +389,25 @@ export function AgentDashboardModal({
       }
     >
       <p className="agent-dash__hint">{tr("dashboard.hint")}</p>
+      {evidence && evidence.total > 0 ? (
+        <div
+          className="agent-dash__evidence"
+          title={tr("dashboard.evidence.hint")}
+        >
+          <span className="agent-dash__evidence-title">
+            {tr("dashboard.evidence.title")}
+          </span>
+          <span className="agent-dash__evidence-stat">
+            {tr("dashboard.evidence.todayNew", { n: evidence.todayNew })}
+          </span>
+          <span className="agent-dash__evidence-stat">
+            {tr("dashboard.evidence.weekPacks", { n: evidence.weekPacks })}
+          </span>
+          <span className="agent-dash__evidence-stat agent-dash__evidence-stat--dim">
+            {tr("dashboard.evidence.total", { n: evidence.total })}
+          </span>
+        </div>
+      ) : null}
       <div
         className="agent-dash__chips"
         role="tablist"

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -690,6 +690,12 @@ const en = {
   "dashboard.tool": "Tool: {name}",
   "dashboard.toolLabel": "Tool",
   "dashboard.open": "Agent dashboard",
+  "dashboard.evidence.title": "X Evidence",
+  "dashboard.evidence.hint":
+    "X Evidence Rail — local evidence rows saved by x_evidence_search (docs/features/x-search.md)",
+  "dashboard.evidence.todayNew": "{n} new today",
+  "dashboard.evidence.weekPacks": "{n} quote packs this week",
+  "dashboard.evidence.total": "{n} total",
   "dashboard.batchAgents": "Batch agents…",
   "dashboard.batchAgentsTitle":
     "Dispatch the same prompt to multiple projects (sessions or headless)",
@@ -5766,6 +5772,12 @@ const zh: Record<MessageKey, string> = {
   "dashboard.tool": "工具：{name}",
   "dashboard.toolLabel": "工具",
   "dashboard.open": "Agent 仪表盘",
+  "dashboard.evidence.title": "X 证据",
+  "dashboard.evidence.hint":
+    "X 证据轨 — x_evidence_search 落库的本地证据（docs/features/x-search.md）",
+  "dashboard.evidence.todayNew": "今日新证 {n}",
+  "dashboard.evidence.weekPacks": "本周引用包 {n}",
+  "dashboard.evidence.total": "共 {n} 条",
   "dashboard.batchAgents": "批量 Agent…",
   "dashboard.batchAgentsTitle":
     "将同一提示词派发到多个项目（会话或无头摘要）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -648,6 +648,12 @@ export const zhTW: Record<MessageKey, string> = {
   "dashboard.tool": "工具：{name}",
   "dashboard.toolLabel": "工具",
   "dashboard.open": "Agent 儀表板",
+  "dashboard.evidence.title": "X 證據",
+  "dashboard.evidence.hint":
+    "X 證據軌 — x_evidence_search 落庫的本地證據（docs/features/x-search.md）",
+  "dashboard.evidence.todayNew": "今日新證 {n}",
+  "dashboard.evidence.weekPacks": "本週引用包 {n}",
+  "dashboard.evidence.total": "共 {n} 條",
   "dashboard.batchAgents": "批量 Agent…",
   "dashboard.batchAgentsTitle":
     "將同一提示詞派發到多個專案（工作階段或無頭摘要）",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4422,3 +4422,76 @@ export async function wallpaperLibraryList(
     limit: limit ?? null,
   });
 }
+
+// ── X Evidence Rail (search → local evidence store → quote pack) ────────────
+// Design: docs/features/x-search.md — every X search result becomes a local
+// evidence row with a stable id; later turns list / re-read / quote it.
+
+export interface XEvidenceItem {
+  evidenceId: string;
+  statusId?: string;
+  url?: string;
+  author?: string;
+  text?: string;
+  createdAt?: string;
+  likes?: number;
+  query?: string;
+  sessionTag?: string;
+  source: string;
+  verified: boolean;
+  fetchedAtMs: number;
+}
+
+export interface XSearchEnvelope {
+  ok: boolean;
+  errorCode?: string;
+  message?: string;
+  query: string;
+  evidence: XEvidenceItem[];
+  newCount: number;
+  unverifiedCount: number;
+}
+
+export interface XEvidenceFilter {
+  sessionTag?: string;
+  queryContains?: string;
+  author?: string;
+  limit?: number;
+}
+
+export interface XQuotePack {
+  markdown: string;
+  path?: string;
+  count: number;
+}
+
+export async function xEvidenceSearch(
+  query: string,
+  limit?: number,
+  sessionTag?: string,
+): Promise<XSearchEnvelope> {
+  return invoke<XSearchEnvelope>("x_evidence_search", {
+    query,
+    limit: limit ?? null,
+    sessionTag: sessionTag ?? null,
+  });
+}
+
+export async function xEvidenceList(
+  filter?: XEvidenceFilter,
+): Promise<XEvidenceItem[]> {
+  return invoke<XEvidenceItem[]>("x_evidence_list", {
+    filter: filter ?? null,
+  });
+}
+
+export async function xEvidenceGet(ids: string[]): Promise<XEvidenceItem[]> {
+  return invoke<XEvidenceItem[]>("x_evidence_get", { ids });
+}
+
+export async function xQuotePack(
+  ids: string[],
+  title?: string,
+): Promise<XQuotePack> {
+  return invoke<XQuotePack>("x_quote_pack", { ids, title: title ?? null });
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4495,3 +4495,13 @@ export async function xQuotePack(
 ): Promise<XQuotePack> {
   return invoke<XQuotePack>("x_quote_pack", { ids, title: title ?? null });
 }
+
+export interface XEvidenceStats {
+  total: number;
+  todayNew: number;
+  weekPacks: number;
+}
+
+export async function xEvidenceStats(): Promise<XEvidenceStats> {
+  return invoke<XEvidenceStats>("x_evidence_stats");
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -24061,6 +24061,29 @@ html[data-theme="light"] .rim-sidebar {
 .agent-dash__chip.is-active .agent-dash__chip-count {
   opacity: 0.9;
 }
+.agent-dash__evidence {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  flex-shrink: 0;
+  padding: 6px 10px;
+  border-radius: 8px;
+  font-size: 11px;
+  background: var(--bg-hover, rgba(127, 127, 127, 0.06));
+  border: 1px solid color-mix(in srgb, var(--accent, #5b8def) 18%, transparent);
+}
+.agent-dash__evidence-title {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.agent-dash__evidence-stat {
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.agent-dash__evidence-stat--dim {
+  color: var(--text-tertiary);
+}
 .agent-dash__toolbar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Adds the **X Evidence Rail** MVP (design: `docs/features/x-search.md`) so X search results become local, citable evidence rows — plus three small reliability fixes found while shipping.

### X Evidence Rail
- `x_evidence_search` via headless Grok CLI persists every post as a local evidence row (`sqlite` under `{app_data}/x-evidence/evidence.db`) with a stable `evidence_id`
- Posts without a canonical `x.com/…/status/…` URL are stored with `verified=false` (hallucinated links never pass as evidence)
- `x_evidence_list` / `x_evidence_get` local evidence bus for cross-turn reuse
- `x_quote_pack` renders ids into paste-ready markdown under `{app_data}/x-evidence/packs/` (unverified items marked; write-to-X intentionally absent)
- `x_evidence_stats` + Agent Dashboard strip (today new / week packs / total; hidden when empty or backend unavailable)
- Frontend wrappers in `src/lib/api.ts`; i18n en / zh / zh-TW

### Bug fixes
- **MCP config.toml parser**: unclosed multi-line `args = [` no longer swallows the next `[mcp_servers.*]` table; array end detection is string-literal aware
- **Wallpaper gallery**: `is_gallery_media_url` accepts all allowlisted hosts (`abs.twimg.com`, `filesystem.site`)
- **Wallpaper URL normalize**: legacy twimg `:thumb/:small/:medium/:large` suffix rewrite runs before `Url::parse` (was dead code)

## Test plan

- [x] `cargo test --lib x_evidence` — 7/7 (search/list/get, dedupe, unverified, quote pack, stats)
- [x] `cargo test --lib extensions` — 15/15 (incl. unclosed `args` + `]` inside quoted string)
- [x] `cargo test --lib wallpaper_source` — 10/10 (gallery hosts + colon suffix normalize)
- [x] `npx tsc --noEmit`
- [ ] Optional manual: DevTools `invoke("x_evidence_search", …)` → `x_evidence_list` / `x_evidence_stats` / `x_quote_pack`; open Agent dashboard for the Evidence strip

## Notes

- Branch is rebased onto latest `RongleCat/grok-app` `main` (not the fork-only integrate line).
- Dead-code `warning: function … is never used` noise in `cargo build` is pre-existing across the lib (helpers used from commands/tests); it is not introduced by this PR and does not fail the build.