### PR TITLE
feat(automations): schedule run history with honest outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+#### Automations / schedules
+- **Schedule run history**: Scheduled tasks page shows a local ring buffer (max ~50) of **observed** fires — host `automation://ran` / `automation://error` while the process is alive, plus client **Run now** outcomes (`ok` / `error` / `skipped`). Redacted error text; outcome filter chips; clear via **GlassModal** (no `window.confirm`). Honest copy: process-bound only — never invents offline runs after Quit; empty history is a soft-fail empty state. Pure `automationRunHistory` helpers + tests; i18n en/zh/zh-TW.
+
 #### Runtime / workflows
 - **Sandbox profile pro** (Settings → General → Permissions): polish OS sandbox presets (`off` / `workspace` / `read-only` / `strict` / `devbox`) with pure `sandboxProfile` helpers (spawn args/env, project resolve, danger confirm keys), **honest soft-fail** when CLI is missing/too old for `--sandbox` (flag omitted) or when the platform has no kernel enforcement (Windows honesty; Linux-only child-network note on macOS), Settings banners + recommended-workspace tip; Host soft-gates spawn flags on known-old CLI; i18n en/zh/zh-TW; `settingsCatalog`; tests
 - **Grok Build workflows** (Settings → Runtime → Tools): opt-in `workflowsEnabled` AppSettings toggle writes top-level `workflows_enabled` into independent agent-home `config.toml` (shared mode never rewrites `~/.grok`); honest copy that workflows run via CLI / Rhai (`workflow` tool, `/workflow`, `/workflows`) — **no in-app runner/editor**; read-only soft-fail discovery of `~/.grok/workflows` + project `.grok/workflows` names; command palette **Open workflows docs** / jump to settings; pure helpers + tests; `settingsCatalog` + en/zh/zh-TW

--- a/docs/llm-wiki/automations.md
+++ b/docs/llm-wiki/automations.md
@@ -42,8 +42,16 @@
 2. 任一会话 mid-turn（streaming / permission / connecting / open tools）时不抢跑；空闲后下一 tick 补跑。
 3. 触发：Host `session_create(scheduled)` → `connect` → `send_message`；成功 `mark_run`；`once` 后 `enabled=false`。
 4. **connect 失败**：删除空壳 session；发 `automation://error`。
-5. UI 监听 `automation://ran` / `automation://error` 做 toast；**不再**用 WebView `setInterval` 双触发。
-6. 手动「立即执行」仍走前端 `runAutomation`。
+5. UI 监听 `automation://ran` / `automation://error` 做 toast，并写入**本地运行历史** ring；**不再**用 WebView `setInterval` 双触发。
+6. 手动「立即执行」仍走前端 `runAutomation`（同样记录 ok / error / skipped）。
+
+### 运行历史（observable，非假 daemon 日志）
+
+- **SoT**：前端 `localStorage` ring（`grok.automationRunHistory`，max ~50），纯 helpers：`src/lib/automationRunHistory.ts`。
+- **写入时机**：Host 事件 `automation://ran` / `automation://error`（进程存活期间观察到的触发）；以及 UI「立即执行」返回 ok / error / skipped。
+- **字段**：`id` · `scheduleId` · `name` · `at` · `outcome`（`ok|error|skipped`）· 脱敏 `error` · `source`（`host|run_now|unknown`）。
+- **诚实**：完全退出后**不会**虚构离线触发；空列表是 soft-fail 空态，不是「后台什么都没发生过」的宣称。
+- **UI**：`AutomationsPage` 历史面板 + outcome 筛选 chips + GlassModal 清空（禁止 `window.confirm`）。
 
 ### 托盘与「退出后」诚实模型（AUTO-RUNNER + AUTO-HEADLESS-LITE）
 
@@ -97,5 +105,6 @@
 - [x] `automation_runner_status` + 已安排页背景面板（诚实文案；无假 daemon 宣称）
 - [x] 可选 macOS LaunchAgent **助手**（app data 生成；登录/崩溃拉起完整 App；非 headless）
 - [x] **AUTO-HEADLESS-LITE**：诚实矩阵（托盘 vs 退出 vs LaunchAgent）+ runner 状态面（last tick / paused reason）+ LaunchAgent 安装失败 GlassModal soft-fail；纯 helpers + 单测
+- [x] **运行历史**：本地 ring（max ~50）观察 host 触发 + Run now；outcome 筛选 / GlassModal 清空；不发明退出后后台 fire；纯 helpers + 单测
 - [ ] 与 CLI scheduler 双向同步（可选 P2）
 - [ ] 无 UI 进程的真正 headless runner（可选 P2；当前明确不做假宣称）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -851,6 +851,7 @@ import {
   type Automation,
 } from "@/lib/automations";
 import { automationsBackgroundStatus } from "@/lib/automationsBackgroundStatus";
+import { recordAutomationRun } from "@/lib/automationRunHistory";
 import {
   extractAutomationPayload,
   looksLikeScheduleIntent,
@@ -6311,8 +6312,25 @@ export default function App() {
       auto: Automation,
       opts?: { fromScheduler?: boolean },
     ): Promise<boolean> => {
-      if (automationRunLock.current) return false;
+      if (automationRunLock.current) {
+        // Soft skip — do not invent a fire; only note busy contention.
+        recordAutomationRun({
+          scheduleId: auto.id,
+          name: auto.title,
+          outcome: "skipped",
+          source: "run_now",
+          error: "busy",
+        });
+        return false;
+      }
       if (opts?.fromScheduler && (session.state === "streaming" || connecting)) {
+        recordAutomationRun({
+          scheduleId: auto.id,
+          name: auto.title,
+          outcome: "skipped",
+          source: "run_now",
+          error: "session_busy",
+        });
         return false;
       }
       automationRunLock.current = true;
@@ -6322,11 +6340,27 @@ export default function App() {
           ? projects.find((p) => p.id === auto.projectId) ?? null
           : null;
         if (proj && !proj.trusted) {
-          setLocalError(tr("project.trustFirst", { name: proj.name }));
+          const detail = tr("project.trustFirst", { name: proj.name });
+          setLocalError(detail);
+          recordAutomationRun({
+            scheduleId: auto.id,
+            name: auto.title,
+            outcome: "error",
+            source: "run_now",
+            error: detail,
+          });
           return false;
         }
         if (proj && isProjectPathMissing(proj.pathOk)) {
-          setLocalError(tr("project.pathMissing", { name: proj.name }));
+          const detail = tr("project.pathMissing", { name: proj.name });
+          setLocalError(detail);
+          recordAutomationRun({
+            scheduleId: auto.id,
+            name: auto.title,
+            outcome: "error",
+            source: "run_now",
+            error: detail,
+          });
           return false;
         }
         setMainPane("chat");
@@ -6421,6 +6455,13 @@ export default function App() {
           setLocalError(
             tr("automations.connectFailed", { detail }),
           );
+          recordAutomationRun({
+            scheduleId: auto.id,
+            name: auto.title,
+            outcome: "error",
+            source: "run_now",
+            error: detail,
+          });
           // Drop empty shell sessions so sidebar does not show SuperGrok ghosts.
           if (createdSessionId && api.isTauri()) {
             try {
@@ -6494,6 +6535,13 @@ export default function App() {
               ? { ...prev, state: "ready" }
               : prev,
           );
+          recordAutomationRun({
+            scheduleId: auto.id,
+            name: auto.title,
+            outcome: "error",
+            source: "run_now",
+            error: errText,
+          });
           return false;
         }
 
@@ -6509,11 +6557,25 @@ export default function App() {
         if (auto.frequency === "once") {
           await api.automationSetEnabled(auto.id, false);
         }
+        recordAutomationRun({
+          scheduleId: auto.id,
+          name: auto.title,
+          outcome: "ok",
+          source: "run_now",
+          at: lastRunAt,
+        });
         setToast(tr("automations.runningToast", { title: auto.title }));
         window.setTimeout(() => setToast(null), 3200);
         return true;
       } catch (e) {
         setLocalError(String(e));
+        recordAutomationRun({
+          scheduleId: auto.id,
+          name: auto.title,
+          outcome: "error",
+          source: "run_now",
+          error: e,
+        });
         return false;
       } finally {
         automationRunLock.current = false;
@@ -6538,29 +6600,45 @@ export default function App() {
       }
     };
     void track(
-      api.listen<{ title?: string; sessionId?: string }>(
-        "automation://ran",
-        (p) => {
-          if (cancelled) return;
-          const title = (p?.title || "").trim() || "automation";
-          setToast(tr("automations.runningToast", { title }));
-          window.setTimeout(() => setToast(null), 3200);
-          void refreshSessions();
-        },
-      ),
+      api.listen<{
+        title?: string;
+        sessionId?: string;
+        automationId?: string;
+      }>("automation://ran", (p) => {
+        if (cancelled) return;
+        const title = (p?.title || "").trim() || "automation";
+        // Observe host fire while process is alive — never invent offline runs.
+        recordAutomationRun({
+          scheduleId: p?.automationId ?? "",
+          name: title,
+          outcome: "ok",
+          source: "host",
+        });
+        setToast(tr("automations.runningToast", { title }));
+        window.setTimeout(() => setToast(null), 3200);
+        void refreshSessions();
+      }),
     );
     void track(
-      api.listen<{ title?: string; error?: string }>(
-        "automation://error",
-        (p) => {
-          if (cancelled) return;
-          const title = (p?.title || "").trim() || "automation";
-          const err = (p?.error || "").trim() || "failed";
-          setLocalError(
-            tr("automations.hostRunFailed", { title, detail: err }),
-          );
-        },
-      ),
+      api.listen<{
+        title?: string;
+        error?: string;
+        automationId?: string;
+      }>("automation://error", (p) => {
+        if (cancelled) return;
+        const title = (p?.title || "").trim() || "automation";
+        const err = (p?.error || "").trim() || "failed";
+        recordAutomationRun({
+          scheduleId: p?.automationId ?? "",
+          name: title,
+          outcome: "error",
+          source: "host",
+          error: err,
+        });
+        setLocalError(
+          tr("automations.hostRunFailed", { title, detail: err }),
+        );
+      }),
     );
     return () => {
       cancelled = true;

--- a/src/components/AutomationsPage.tsx
+++ b/src/components/AutomationsPage.tsx
@@ -19,6 +19,15 @@ import {
   launchAgentSoftFail,
   type LaunchAgentSoftFail,
 } from "@/lib/automationsHeadlessHonesty";
+import {
+  AUTOMATION_RUN_HISTORY_CHANGE_EVENT,
+  clearAutomationRunHistory,
+  countAutomationRunOutcomes,
+  filterAutomationRunHistory,
+  loadAutomationRunHistory,
+  type AutomationRunOutcomeFilter,
+  type AutomationRunRecord,
+} from "@/lib/automationRunHistory";
 import { Select } from "@/components/Select";
 import { GlassModal } from "@/components/GlassModal";
 import {
@@ -130,6 +139,13 @@ export function AutomationsPage({
   /** Soft-fail modal when LaunchAgent install/remove/reveal fails (no fake daemon). */
   const [launchAgentFail, setLaunchAgentFail] =
     useState<LaunchAgentSoftFail | null>(null);
+  /** Observed schedule run history (local ring; process-bound honesty). */
+  const [runHistory, setRunHistory] = useState<AutomationRunRecord[]>(() =>
+    loadAutomationRunHistory(),
+  );
+  const [runHistoryFilter, setRunHistoryFilter] =
+    useState<AutomationRunOutcomeFilter>("all");
+  const [clearHistoryOpen, setClearHistoryOpen] = useState(false);
   const createBtnRef = useRef<HTMLButtonElement>(null);
   const createMenuRef = useRef<HTMLDivElement>(null);
   const deleteConfirmBtnRef = useRef<HTMLButtonElement>(null);
@@ -176,10 +192,42 @@ export function AutomationsPage({
     return () => window.clearInterval(id);
   }, [refreshRunner]);
 
+  // Live ring buffer updates from host fires + Run now (App records).
+  useEffect(() => {
+    const onChange = (ev: Event) => {
+      const detail = (ev as CustomEvent<AutomationRunRecord[]>).detail;
+      if (Array.isArray(detail)) {
+        setRunHistory(detail);
+      } else {
+        setRunHistory(loadAutomationRunHistory());
+      }
+    };
+    window.addEventListener(AUTOMATION_RUN_HISTORY_CHANGE_EVENT, onChange);
+    // Soft reload on mount in case another surface wrote while we were away.
+    setRunHistory(loadAutomationRunHistory());
+    return () =>
+      window.removeEventListener(AUTOMATION_RUN_HISTORY_CHANGE_EVENT, onChange);
+  }, []);
+
   const enabledCount = useMemo(
     () => list.filter((a) => a.enabled).length,
     [list],
   );
+
+  const filteredRunHistory = useMemo(
+    () => filterAutomationRunHistory(runHistory, runHistoryFilter),
+    [runHistory, runHistoryFilter],
+  );
+
+  const runHistoryCounts = useMemo(
+    () => countAutomationRunOutcomes(runHistory),
+    [runHistory],
+  );
+
+  const confirmClearHistory = () => {
+    setRunHistory(clearAutomationRunHistory());
+    setClearHistoryOpen(false);
+  };
 
   const banner = useMemo(
     () =>
@@ -757,6 +805,129 @@ export function AutomationsPage({
         </div>
       </div>
 
+      {/* Observed fires only — empty is soft-fail, never invents offline runs */}
+      <div
+        className="auto-page__history"
+        role="region"
+        aria-label={t("automations.history.section")}
+      >
+        <div className="auto-page__history-head">
+          <div className="auto-page__history-titles">
+            <div className="auto-page__history-title">
+              {t("automations.history.section")}
+            </div>
+            <p className="auto-page__history-desc">
+              {t("automations.history.honesty")}
+            </p>
+          </div>
+          {runHistory.length > 0 ? (
+            <button
+              type="button"
+              className="auto-page__bg-banner-link"
+              onClick={() => setClearHistoryOpen(true)}
+            >
+              {t("automations.history.clear")}
+            </button>
+          ) : null}
+        </div>
+        <div
+          className="auto-page__history-filters"
+          role="tablist"
+          aria-label={t("automations.history.filterAria")}
+        >
+          {(
+            [
+              ["all", "automations.history.filter.all"],
+              ["ok", "automations.history.filter.ok"],
+              ["error", "automations.history.filter.error"],
+              ["skipped", "automations.history.filter.skipped"],
+            ] as const
+          ).map(([id, key]) => (
+            <button
+              key={id}
+              type="button"
+              role="tab"
+              aria-selected={runHistoryFilter === id}
+              className={
+                "auto-page__filter" +
+                (runHistoryFilter === id ? " is-active" : "")
+              }
+              onClick={() => setRunHistoryFilter(id)}
+            >
+              {t(key)}
+              <span className="auto-page__history-count" aria-hidden>
+                {runHistoryCounts[id]}
+              </span>
+            </button>
+          ))}
+        </div>
+        {filteredRunHistory.length === 0 ? (
+          <div className="auto-page__history-empty" role="status">
+            {runHistory.length === 0
+              ? t("automations.history.empty")
+              : t("automations.history.emptyFiltered")}
+          </div>
+        ) : (
+          <ul className="auto-page__history-list">
+            {filteredRunHistory.map((row) => {
+              let when = row.at;
+              try {
+                when = new Date(row.at).toLocaleString();
+              } catch {
+                /* keep raw */
+              }
+              const outcomeKey =
+                row.outcome === "ok"
+                  ? "automations.history.outcome.ok"
+                  : row.outcome === "error"
+                    ? "automations.history.outcome.error"
+                    : "automations.history.outcome.skipped";
+              const sourceKey =
+                row.source === "host"
+                  ? "automations.history.source.host"
+                  : row.source === "run_now"
+                    ? "automations.history.source.runNow"
+                    : "automations.history.source.unknown";
+              return (
+                <li
+                  key={row.id}
+                  className={
+                    "auto-page__history-row" +
+                    (row.outcome === "error"
+                      ? " auto-page__history-row--error"
+                      : row.outcome === "skipped"
+                        ? " auto-page__history-row--skipped"
+                        : "")
+                  }
+                >
+                  <span
+                    className={
+                      "auto-page__history-outcome" +
+                      ` auto-page__history-outcome--${row.outcome}`
+                    }
+                  >
+                    {t(outcomeKey)}
+                  </span>
+                  <div className="auto-page__history-main">
+                    <span className="auto-page__history-name">{row.name}</span>
+                    <span className="auto-page__history-meta">
+                      {when}
+                      {" · "}
+                      {t(sourceKey)}
+                    </span>
+                    {row.outcome === "error" && row.error ? (
+                      <span className="auto-page__history-error" title={row.error}>
+                        {row.error}
+                      </span>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
       <div className="auto-page__toolbar">
         <div className="auto-page__search">
           <IconSearch size={15} />
@@ -971,6 +1142,37 @@ export function AutomationsPage({
             ) : null}
           </>
         ) : null}
+      </GlassModal>
+
+      <GlassModal
+        open={clearHistoryOpen}
+        onClose={() => setClearHistoryOpen(false)}
+        title={t("automations.history.clearTitle")}
+        size="sm"
+        closeLabel={t("common.close")}
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => setClearHistoryOpen(false)}
+            >
+              {t("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--danger"
+              onClick={confirmClearHistory}
+            >
+              {t("automations.history.clearConfirm")}
+            </button>
+          </>
+        }
+      >
+        <p className="app-dialog__msg">{t("automations.history.clearBody")}</p>
+        <p className="app-dialog__msg app-dialog__msg--muted">
+          {t("automations.history.honesty")}
+        </p>
       </GlassModal>
 
       {deleteTarget &&

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -4310,6 +4310,28 @@ const en = {
     "Could not open the helper files folder. Generate/enable the helper once, or check app data permissions.",
   "automations.launchAgent.failHonesty":
     "This helper is not a background schedule daemon. Even when installed, tasks tick only inside the full Grok App process (window or tray). A normal Quit still pauses schedules.",
+  "automations.history.section": "Run history",
+  "automations.history.honesty":
+    "Only fires observed while this app process is alive (host runner or Run now). Full Quit does not invent offline runs — empty history is normal after relaunch if nothing has fired yet.",
+  "automations.history.empty":
+    "No observed runs yet. History fills when a schedule fires in this process or you use Run now.",
+  "automations.history.emptyFiltered": "No runs match this filter.",
+  "automations.history.filterAria": "Filter run history by outcome",
+  "automations.history.filter.all": "All",
+  "automations.history.filter.ok": "Ok",
+  "automations.history.filter.error": "Error",
+  "automations.history.filter.skipped": "Skipped",
+  "automations.history.outcome.ok": "Ok",
+  "automations.history.outcome.error": "Error",
+  "automations.history.outcome.skipped": "Skipped",
+  "automations.history.source.host": "Host runner",
+  "automations.history.source.runNow": "Run now",
+  "automations.history.source.unknown": "Unknown",
+  "automations.history.clear": "Clear history",
+  "automations.history.clearTitle": "Clear run history?",
+  "automations.history.clearBody":
+    "Removes the local observed run list on this device. This cannot be undone. Schedules themselves are unchanged.",
+  "automations.history.clearConfirm": "Clear",
   "automations.aiComposerHint":
     "Describe what to run and how often — Grok will schedule it for you when ready.",
   "automations.createdToast": "Scheduled: {title}",
@@ -9259,6 +9281,28 @@ const zh: Record<MessageKey, string> = {
     "无法打开助手文件目录。可先生成/启用一次助手，或检查应用数据目录权限。",
   "automations.launchAgent.failHonesty":
     "此助手不是后台调度守护进程。即便安装成功，任务仍只在完整 Grok 应用进程内（窗口或托盘）触发。正常退出仍会暂停调度。",
+  "automations.history.section": "运行历史",
+  "automations.history.honesty":
+    "仅记录本应用进程存活期间观察到的触发（Host 调度器或「立即运行」）。完全退出后不会虚构离线运行——重新打开后若尚未触发，列表为空是正常的。",
+  "automations.history.empty":
+    "暂无观察到的运行。当本进程内调度触发或你使用「立即运行」时会写入历史。",
+  "automations.history.emptyFiltered": "没有匹配该筛选的运行记录。",
+  "automations.history.filterAria": "按结果筛选运行历史",
+  "automations.history.filter.all": "全部",
+  "automations.history.filter.ok": "成功",
+  "automations.history.filter.error": "失败",
+  "automations.history.filter.skipped": "跳过",
+  "automations.history.outcome.ok": "成功",
+  "automations.history.outcome.error": "失败",
+  "automations.history.outcome.skipped": "跳过",
+  "automations.history.source.host": "Host 调度",
+  "automations.history.source.runNow": "立即运行",
+  "automations.history.source.unknown": "未知",
+  "automations.history.clear": "清空历史",
+  "automations.history.clearTitle": "清空运行历史？",
+  "automations.history.clearBody":
+    "将删除本机已观察到的运行列表，且无法撤销。已安排任务本身不受影响。",
+  "automations.history.clearConfirm": "清空",
   "automations.aiComposerHint":
     "用自然语言描述要做什么、多久一次——准备好后 Grok 会自动创建已安排任务。",
   "automations.createdToast": "已安排：{title}",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -4142,6 +4142,28 @@ export const zhTW: Record<MessageKey, string> = {
     "無法開啟助手檔案目錄。可先產生/啟用一次助手，或檢查應用資料目錄權限。",
   "automations.launchAgent.failHonesty":
     "此助手不是背景排程守護行程。即便安裝成功，任務仍只在完整 Grok 應用行程內（視窗或系統匣）觸發。正常結束仍會暫停排程。",
+  "automations.history.section": "執行歷史",
+  "automations.history.honesty":
+    "僅記錄本應用行程存活期間觀察到的觸發（Host 排程器或「立即執行」）。完全結束後不會虛構離線執行——重新開啟後若尚未觸發，列表為空是正常的。",
+  "automations.history.empty":
+    "尚無觀察到的執行。當本行程內排程觸發或你使用「立即執行」時會寫入歷史。",
+  "automations.history.emptyFiltered": "沒有符合此篩選的執行紀錄。",
+  "automations.history.filterAria": "依結果篩選執行歷史",
+  "automations.history.filter.all": "全部",
+  "automations.history.filter.ok": "成功",
+  "automations.history.filter.error": "失敗",
+  "automations.history.filter.skipped": "略過",
+  "automations.history.outcome.ok": "成功",
+  "automations.history.outcome.error": "失敗",
+  "automations.history.outcome.skipped": "略過",
+  "automations.history.source.host": "Host 排程",
+  "automations.history.source.runNow": "立即執行",
+  "automations.history.source.unknown": "未知",
+  "automations.history.clear": "清除歷史",
+  "automations.history.clearTitle": "清除執行歷史？",
+  "automations.history.clearBody":
+    "將刪除本機已觀察到的執行列表，且無法復原。已排程任務本身不受影響。",
+  "automations.history.clearConfirm": "清除",
   "automations.aiComposerHint":
     "用自然語言描述要做什麼、多久一次——準備好後 Grok 會自動建立已排程任務。",
   "automations.createdToast": "已排程：{title}",

--- a/src/lib/automationRunHistory.test.ts
+++ b/src/lib/automationRunHistory.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTOMATION_RUN_HISTORY_MAX,
+  clearAutomationRunHistory,
+  countAutomationRunOutcomes,
+  filterAutomationRunHistory,
+  loadAutomationRunHistory,
+  parseAutomationRunHistory,
+  parseAutomationRunRecord,
+  pushAutomationRun,
+  recordAutomationRun,
+  redactAutomationRunError,
+  type AutomationRunHistoryStorage,
+  type AutomationRunRecord,
+} from "./automationRunHistory";
+
+function memStorage(seed?: string): AutomationRunHistoryStorage {
+  let val: string | null = seed ?? null;
+  return {
+    getItem: () => val,
+    setItem: (_k, v) => {
+      val = v;
+    },
+  };
+}
+
+const base: AutomationRunRecord = {
+  id: "ar-1",
+  scheduleId: "sched-1",
+  name: "Morning digest",
+  at: "2026-07-31T12:00:00.000Z",
+  outcome: "ok",
+  source: "host",
+};
+
+describe("parseAutomationRunRecord", () => {
+  it("accepts valid records and aliases", () => {
+    const e = parseAutomationRunRecord({
+      id: "x",
+      automationId: "a1",
+      title: "T",
+      at: "2026-01-01T00:00:00.000Z",
+      outcome: "error",
+      error: "boom",
+      source: "run_now",
+    });
+    expect(e).toMatchObject({
+      id: "x",
+      scheduleId: "a1",
+      name: "T",
+      outcome: "error",
+      source: "run_now",
+      error: "boom",
+    });
+  });
+
+  it("rejects unknown outcomes", () => {
+    expect(parseAutomationRunRecord({ ...base, outcome: "pending" })).toBeNull();
+    expect(parseAutomationRunRecord(null)).toBeNull();
+    expect(parseAutomationRunRecord("nope")).toBeNull();
+  });
+
+  it("defaults source and strips error on non-error outcomes", () => {
+    const e = parseAutomationRunRecord({
+      scheduleId: "s",
+      name: "N",
+      at: "t",
+      outcome: "ok",
+      error: "should-drop",
+    });
+    expect(e?.source).toBe("unknown");
+    expect(e?.error).toBeUndefined();
+  });
+});
+
+describe("redactAutomationRunError", () => {
+  it("redacts api keys and clamps", () => {
+    const long = `fail sk-abcdefghijklmnop ${"x".repeat(400)}`;
+    const r = redactAutomationRunError(long);
+    expect(r).toBeTruthy();
+    expect(r).not.toMatch(/sk-abcdefghijklmnop/);
+    expect(r!.length).toBeLessThanOrEqual(280);
+  });
+
+  it("returns null for empty", () => {
+    expect(redactAutomationRunError("   ")).toBeNull();
+    expect(redactAutomationRunError(null)).toBeNull();
+  });
+});
+
+describe("parseAutomationRunHistory / push", () => {
+  it("soft-fails corrupt storage to empty", () => {
+    expect(parseAutomationRunHistory("{not json")).toEqual([]);
+    expect(parseAutomationRunHistory(undefined)).toEqual([]);
+  });
+
+  it("caps at max and keeps newest first", () => {
+    const many = Array.from({ length: 60 }, (_, i) => ({
+      ...base,
+      id: `ar-${i}`,
+      at: `2026-07-31T12:${String(i).padStart(2, "0")}:00.000Z`,
+    }));
+    const list = parseAutomationRunHistory(many, 50);
+    expect(list).toHaveLength(50);
+    expect(list[0].id).toBe("ar-0");
+  });
+
+  it("push prepends and dedupes by id", () => {
+    const a = pushAutomationRun([], base);
+    const b = pushAutomationRun(a, { ...base, name: "Updated" });
+    expect(b).toHaveLength(1);
+    expect(b[0].name).toBe("Updated");
+    const c = pushAutomationRun(b, { ...base, id: "ar-2", name: "Two" });
+    expect(c.map((e) => e.id)).toEqual(["ar-2", "ar-1"]);
+  });
+});
+
+describe("record / load / clear / filter", () => {
+  it("records ok, error, skipped and filters by outcome chips", () => {
+    const storage = memStorage();
+    recordAutomationRun(
+      {
+        scheduleId: "s1",
+        name: "A",
+        outcome: "ok",
+        source: "host",
+        at: "2026-07-31T10:00:00.000Z",
+      },
+      storage,
+    );
+    recordAutomationRun(
+      {
+        scheduleId: "s2",
+        title: "B",
+        outcome: "error",
+        error: "connect failed: sk-SECRETKEY1234567890",
+        source: "run_now",
+        at: "2026-07-31T11:00:00.000Z",
+      },
+      storage,
+    );
+    recordAutomationRun(
+      {
+        scheduleId: "s1",
+        name: "A",
+        outcome: "skipped",
+        source: "run_now",
+        at: "2026-07-31T12:00:00.000Z",
+      },
+      storage,
+    );
+
+    const all = loadAutomationRunHistory(storage);
+    expect(all).toHaveLength(3);
+    expect(all[0].outcome).toBe("skipped");
+    expect(all[1].outcome).toBe("error");
+    expect(all[1].error).not.toMatch(/sk-SECRETKEY/);
+
+    expect(filterAutomationRunHistory(all, "error")).toHaveLength(1);
+    expect(filterAutomationRunHistory(all, "ok")).toHaveLength(1);
+    expect(filterAutomationRunHistory(all, "all")).toHaveLength(3);
+
+    const counts = countAutomationRunOutcomes(all);
+    expect(counts).toEqual({ all: 3, ok: 1, error: 1, skipped: 1 });
+
+    clearAutomationRunHistory(storage);
+    expect(loadAutomationRunHistory(storage)).toEqual([]);
+  });
+
+  it("never invents entries from empty storage", () => {
+    expect(loadAutomationRunHistory(memStorage())).toEqual([]);
+  });
+
+  it("respects max ring size on record", () => {
+    const storage = memStorage();
+    for (let i = 0; i < AUTOMATION_RUN_HISTORY_MAX + 5; i++) {
+      recordAutomationRun(
+        {
+          scheduleId: `s${i}`,
+          name: `N${i}`,
+          outcome: "ok",
+          source: "host",
+          at: new Date(1_700_000_000_000 + i * 1000).toISOString(),
+        },
+        storage,
+      );
+    }
+    expect(loadAutomationRunHistory(storage)).toHaveLength(
+      AUTOMATION_RUN_HISTORY_MAX,
+    );
+  });
+});

--- a/src/lib/automationRunHistory.ts
+++ b/src/lib/automationRunHistory.ts
@@ -1,0 +1,330 @@
+/**
+ * Automation / schedule run history — local observable ring buffer.
+ *
+ * Records fires the UI actually observes: host `automation://ran` /
+ * `automation://error` while the process is alive, and client "Run now"
+ * outcomes. Newest first, max ~50, localStorage only.
+ *
+ * **Honest model:** process-bound. This never invents background fires after
+ * Quit. Empty history is a soft-fail empty state, not a claim that nothing
+ * was due offline.
+ */
+
+import { redact } from "./redact";
+
+export type AutomationRunOutcome = "ok" | "error" | "skipped";
+
+export type AutomationRunSource = "host" | "run_now" | "unknown";
+
+export type AutomationRunRecord = {
+  /** Stable id for list keys / remove. */
+  id: string;
+  /** Automation schedule id (may be empty for edge payloads). */
+  scheduleId: string;
+  /** Display name at fire time. */
+  name: string;
+  /** ISO-8601 timestamp. */
+  at: string;
+  outcome: AutomationRunOutcome;
+  /** Redacted short error when outcome === "error". */
+  error?: string | null;
+  /** How this row was observed. */
+  source: AutomationRunSource;
+};
+
+export type AutomationRunOutcomeFilter = "all" | AutomationRunOutcome;
+
+export const AUTOMATION_RUN_HISTORY_STORAGE_KEY = "grok.automationRunHistory";
+export const AUTOMATION_RUN_HISTORY_MAX = 50;
+/** Cap redacted error text in storage / UI. */
+export const AUTOMATION_RUN_ERROR_MAX = 280;
+export const AUTOMATION_RUN_NAME_MAX = 160;
+export const AUTOMATION_RUN_ID_MAX = 80;
+
+/** Fired on `window` after load/save/clear (detail = entries). */
+export const AUTOMATION_RUN_HISTORY_CHANGE_EVENT =
+  "grok-automation-run-history-change";
+
+const OUTCOMES = new Set<string>(["ok", "error", "skipped"]);
+const SOURCES = new Set<string>(["host", "run_now", "unknown"]);
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface AutomationRunHistoryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): AutomationRunHistoryStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+function scrub(raw: unknown, max: number): string {
+  if (typeof raw !== "string") return "";
+  let s = raw.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, "").trim();
+  if (!s) return "";
+  if (s.length > max) s = s.slice(0, max);
+  return s;
+}
+
+/**
+ * Redact secrets and clamp error text for storage / list display.
+ * Empty after scrub → null (no invented message).
+ */
+export function redactAutomationRunError(raw: unknown): string | null {
+  let text = "";
+  if (raw instanceof Error) text = raw.message;
+  else if (typeof raw === "string") text = raw;
+  else if (raw != null) text = String(raw);
+  text = scrub(text, AUTOMATION_RUN_ERROR_MAX * 2);
+  if (!text) return null;
+  try {
+    text = redact(text);
+  } catch {
+    /* keep scrubbed */
+  }
+  text = text.replace(/\s+/g, " ").trim();
+  if (!text) return null;
+  if (text.length > AUTOMATION_RUN_ERROR_MAX) {
+    text = `${text.slice(0, AUTOMATION_RUN_ERROR_MAX - 1)}…`;
+  }
+  return text;
+}
+
+/** New id for a run record (crypto when available). */
+export function newAutomationRunId(now = Date.now()): string {
+  try {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return `ar-${crypto.randomUUID()}`;
+    }
+  } catch {
+    /* fall through */
+  }
+  const rand = Math.floor(Math.random() * 1e9).toString(36);
+  return `ar-${now.toString(36)}-${rand}`;
+}
+
+/**
+ * Normalize one raw object into an AutomationRunRecord, or null if invalid.
+ */
+export function parseAutomationRunRecord(raw: unknown): AutomationRunRecord | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+
+  const outcomeRaw = scrub(o.outcome, 32).toLowerCase();
+  if (!OUTCOMES.has(outcomeRaw)) return null;
+  const outcome = outcomeRaw as AutomationRunOutcome;
+
+  const scheduleId = scrub(
+    o.scheduleId ?? o.automationId ?? o.schedule_id ?? o.automation_id,
+    AUTOMATION_RUN_ID_MAX,
+  );
+  const name =
+    scrub(o.name ?? o.title, AUTOMATION_RUN_NAME_MAX) ||
+    (scheduleId ? scheduleId : "automation");
+
+  const id = scrub(o.id, AUTOMATION_RUN_ID_MAX) || newAutomationRunId();
+
+  const atRaw = scrub(o.at ?? o.ts ?? o.timestamp, 64);
+  const at = atRaw || new Date(0).toISOString();
+
+  const sourceRaw = scrub(o.source, 32).toLowerCase();
+  const source: AutomationRunSource = SOURCES.has(sourceRaw)
+    ? (sourceRaw as AutomationRunSource)
+    : "unknown";
+
+  const error =
+    outcome === "error" ? redactAutomationRunError(o.error ?? o.detail) : null;
+
+  return {
+    id,
+    scheduleId,
+    name,
+    at,
+    outcome,
+    source,
+    ...(error ? { error } : {}),
+  };
+}
+
+/**
+ * Parse stored JSON into a clean, newest-first list (capped).
+ * Soft-fails corrupt / partial data to [].
+ */
+export function parseAutomationRunHistory(
+  raw: unknown,
+  max = AUTOMATION_RUN_HISTORY_MAX,
+): AutomationRunRecord[] {
+  const lim =
+    typeof max === "number" && Number.isFinite(max) && max > 0
+      ? Math.min(500, Math.floor(max))
+      : AUTOMATION_RUN_HISTORY_MAX;
+
+  let list: unknown[] = [];
+  if (typeof raw === "string") {
+    const t = raw.trim();
+    if (!t) return [];
+    try {
+      const parsed = JSON.parse(t) as unknown;
+      if (Array.isArray(parsed)) list = parsed;
+      else return [];
+    } catch {
+      return [];
+    }
+  } else if (Array.isArray(raw)) {
+    list = raw;
+  } else {
+    return [];
+  }
+
+  const out: AutomationRunRecord[] = [];
+  for (const item of list) {
+    const e = parseAutomationRunRecord(item);
+    if (!e) continue;
+    out.push(e);
+    if (out.length >= lim) break;
+  }
+  return out;
+}
+
+/**
+ * Pure ring-buffer push: newest first, max length. Does not touch storage.
+ */
+export function pushAutomationRun(
+  existing: readonly AutomationRunRecord[],
+  entry: AutomationRunRecord | Record<string, unknown>,
+  max = AUTOMATION_RUN_HISTORY_MAX,
+): AutomationRunRecord[] {
+  const next = parseAutomationRunRecord(entry);
+  if (!next) return parseAutomationRunHistory(existing, max);
+  const cleaned = parseAutomationRunHistory(existing, max);
+  // Dedupe identical id if re-appended.
+  const without = cleaned.filter((e) => e.id !== next.id);
+  return parseAutomationRunHistory([next, ...without], max);
+}
+
+export function loadAutomationRunHistory(
+  storage: AutomationRunHistoryStorage = defaultStorage(),
+  max = AUTOMATION_RUN_HISTORY_MAX,
+): AutomationRunRecord[] {
+  try {
+    return parseAutomationRunHistory(
+      storage.getItem(AUTOMATION_RUN_HISTORY_STORAGE_KEY),
+      max,
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function saveAutomationRunHistory(
+  entries: readonly AutomationRunRecord[],
+  storage: AutomationRunHistoryStorage = defaultStorage(),
+  max = AUTOMATION_RUN_HISTORY_MAX,
+): void {
+  const clean = parseAutomationRunHistory(entries, max);
+  try {
+    storage.setItem(AUTOMATION_RUN_HISTORY_STORAGE_KEY, JSON.stringify(clean));
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+/**
+ * Record an observed fire: load → push → save → notify.
+ * Returns the updated list. Invalid input is a soft no-op (returns current).
+ */
+export function recordAutomationRun(
+  input: {
+    scheduleId?: string | null;
+    name?: string | null;
+    title?: string | null;
+    at?: string;
+    outcome: AutomationRunOutcome;
+    error?: unknown;
+    source?: AutomationRunSource;
+    id?: string;
+  },
+  storage: AutomationRunHistoryStorage = defaultStorage(),
+  max = AUTOMATION_RUN_HISTORY_MAX,
+): AutomationRunRecord[] {
+  const name = (input.name ?? input.title ?? "").toString();
+  const entry: AutomationRunRecord = {
+    id: input.id || newAutomationRunId(),
+    scheduleId: (input.scheduleId ?? "").toString(),
+    name: name || "automation",
+    at: input.at || new Date().toISOString(),
+    outcome: input.outcome,
+    source: input.source ?? "unknown",
+    ...(input.outcome === "error"
+      ? { error: redactAutomationRunError(input.error) }
+      : {}),
+  };
+  const next = pushAutomationRun(
+    loadAutomationRunHistory(storage, max),
+    entry,
+    max,
+  );
+  saveAutomationRunHistory(next, storage, max);
+  notifyAutomationRunHistoryChange(next);
+  return next;
+}
+
+/**
+ * Filter history by outcome chip. "all" returns cleaned list as-is.
+ */
+export function filterAutomationRunHistory(
+  history: readonly AutomationRunRecord[],
+  filter: AutomationRunOutcomeFilter = "all",
+): AutomationRunRecord[] {
+  const cleaned = parseAutomationRunHistory(history);
+  if (filter === "all") return cleaned;
+  return cleaned.filter((e) => e.outcome === filter);
+}
+
+/** Counts per outcome for chip labels. */
+export function countAutomationRunOutcomes(
+  history: readonly AutomationRunRecord[],
+): Record<AutomationRunOutcomeFilter, number> {
+  const cleaned = parseAutomationRunHistory(history);
+  const counts: Record<AutomationRunOutcomeFilter, number> = {
+    all: cleaned.length,
+    ok: 0,
+    error: 0,
+    skipped: 0,
+  };
+  for (const e of cleaned) {
+    counts[e.outcome] += 1;
+  }
+  return counts;
+}
+
+/**
+ * Wipe the local ring (empty list + notify). Soft no-op on storage failure.
+ */
+export function clearAutomationRunHistory(
+  storage: AutomationRunHistoryStorage = defaultStorage(),
+): AutomationRunRecord[] {
+  saveAutomationRunHistory([], storage);
+  notifyAutomationRunHistoryChange([]);
+  return [];
+}
+
+function notifyAutomationRunHistoryChange(
+  next: readonly AutomationRunRecord[],
+): void {
+  if (
+    typeof window !== "undefined" &&
+    typeof window.dispatchEvent === "function"
+  ) {
+    try {
+      window.dispatchEvent(
+        new CustomEvent(AUTOMATION_RUN_HISTORY_CHANGE_EVENT, {
+          detail: next,
+        }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16738,6 +16738,156 @@ textarea::-webkit-scrollbar-thumb:active,
   color: var(--text-secondary);
 }
 
+/* Schedule run history (local ring; process-bound observations only) */
+.auto-page__history {
+  flex-shrink: 0;
+  margin: 0 24px 8px;
+  padding: 10px 12px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.18));
+  background: var(--bg-elevated, rgba(127, 127, 127, 0.04));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.auto-page__history-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.auto-page__history-titles {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.auto-page__history-title {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.auto-page__history-desc {
+  margin: 3px 0 0;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+}
+
+.auto-page__history-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.auto-page__history-count {
+  margin-left: 4px;
+  opacity: 0.72;
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+}
+
+.auto-page__history-empty {
+  padding: 10px 4px 2px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+}
+
+.auto-page__history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 14rem;
+  overflow: auto;
+}
+
+.auto-page__history-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 7px 8px;
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.12));
+  background: var(--bg-elevated, rgba(127, 127, 127, 0.05));
+  min-width: 0;
+}
+
+.auto-page__history-row--error {
+  border-color: color-mix(in srgb, var(--danger, #e5484d) 28%, transparent);
+}
+
+.auto-page__history-row--skipped {
+  opacity: 0.88;
+}
+
+.auto-page__history-outcome {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.2));
+  color: var(--text-secondary);
+}
+
+.auto-page__history-outcome--ok {
+  border-color: color-mix(in srgb, var(--success, #30a46c) 35%, transparent);
+  background: color-mix(in srgb, var(--success, #30a46c) 12%, transparent);
+  color: var(--text-primary);
+}
+
+.auto-page__history-outcome--error {
+  border-color: color-mix(in srgb, var(--danger, #e5484d) 35%, transparent);
+  background: color-mix(in srgb, var(--danger, #e5484d) 12%, transparent);
+  color: var(--text-primary);
+}
+
+.auto-page__history-outcome--skipped {
+  background: var(--bg-sunken, rgba(127, 127, 127, 0.08));
+}
+
+.auto-page__history-main {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.auto-page__history-name {
+  font-size: 12.5px;
+  font-weight: 550;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.auto-page__history-meta {
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--text-tertiary);
+}
+
+.auto-page__history-error {
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
 .app-dialog__msg--muted {
   opacity: 0.88;
   font-size: 12.5px;


### PR DESCRIPTION
## Summary

- Local **schedule run history** ring (max ~50) of fires the UI actually observes while the app process is alive
- Records host `automation://ran` / `automation://error` and client **Run now** outcomes (`ok` | `error` | `skipped`) with redacted errors
- Automations page panel: outcome filter chips, honest process-bound copy, clear via **GlassModal** (no `window.confirm`)
- Pure `automationRunHistory` helpers + tests; i18n en/zh/zh-TW; CHANGELOG + wiki

## Honesty

Process-bound only — does **not** invent background fires after full Quit. Empty history is a soft-fail empty state after relaunch, not a claim that nothing was due offline.

## Test plan

- [x] `vitest run src/lib/automationRunHistory.test.ts src/i18n/messages.test.ts`
- [ ] Open Scheduled tasks → history empty state + honesty line
- [ ] Run now → ok row appears (source Run now)
- [ ] Force connect/send failure → error chip + redacted detail
- [ ] Double-click Run now while busy → skipped
- [ ] Outcome filter chips + clear via GlassModal
- [ ] Host schedule fire (if possible) → Host runner source row