### PR TITLE
feat(plugins): marketplace pro install recovery and empty honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+#### Extensions / plugins
+- **Plugin marketplace pro** (PLUGIN-MARKET-PRO): classified install/list/validate errors (CLI missing · too old · network · offline · timeout · not found · already installed · …) with kind chips + actionable hints; **row-stuck install errors** keep **Retry** (or Open Runtime / update CLI when soft-fail); honest catalog empty states (loading · CLI gap · offline · no sources · empty catalog · empty filter/query) with Clear filters / Retry / Refresh CTAs; soft-fail when CLI is missing/too old (warn, no hard crash). Pure `pluginMarketPro` helpers + tests; en/zh/zh-TW; CLI remains source of truth (no second App store).
+
 #### Runtime / workflows
 - **Sandbox profile pro** (Settings → General → Permissions): polish OS sandbox presets (`off` / `workspace` / `read-only` / `strict` / `devbox`) with pure `sandboxProfile` helpers (spawn args/env, project resolve, danger confirm keys), **honest soft-fail** when CLI is missing/too old for `--sandbox` (flag omitted) or when the platform has no kernel enforcement (Windows honesty; Linux-only child-network note on macOS), Settings banners + recommended-workspace tip; Host soft-gates spawn flags on known-old CLI; i18n en/zh/zh-TW; `settingsCatalog`; tests
 - **Grok Build workflows** (Settings → Runtime → Tools): opt-in `workflowsEnabled` AppSettings toggle writes top-level `workflows_enabled` into independent agent-home `config.toml` (shared mode never rewrites `~/.grok`); honest copy that workflows run via CLI / Rhai (`workflow` tool, `/workflow`, `/workflows`) — **no in-app runner/editor**; read-only soft-fail discovery of `~/.grok/workflows` + project `.grok/workflows` names; command palette **Open workflows docs** / jump to settings; pure helpers + tests; `settingsCatalog` + en/zh/zh-TW

--- a/docs/llm-wiki/plugins-marketplace.md
+++ b/docs/llm-wiki/plugins-marketplace.md
@@ -22,8 +22,9 @@ Skills / MCP enable toggles remain App-side (`extensions.json` + ACP inject). **
 1. **Default filter** is **xAI Official** (about a dozen curated plugins). Other sources (e.g. Claude official) are available under “All sources” or per-source chips.
 2. **Cache**: first load runs CLI; re-entering Marketplace within ~6h uses in-memory cache. “Refresh catalog” forces a reload. Install/add/remove sources invalidate or patch the cache.
 3. **Detail panel**: clicking a catalog row opens a GlassModal detail (name, description, marketplace, version, skill/hooks/agents/MCP badges, install source). **Install** / **Reinstall** from the detail or row still use GlassModal confirm (no `window.confirm`). On success the plugin is **trusted and enabled**, then the agent soft-respawns so skills/MCP appear on the next turn.
-4. **Install failure recovery**: errors stick to that plugin row (and detail) with **Retry**; cleared on success. Do not only show a global banner.
+4. **Install failure recovery**: errors stick to that plugin row (and detail) with **Retry**; cleared on success. Do not only show a global banner. Errors are **classified** (`cli_missing` / `cli_too_old` / `network` / …) via pure `pluginMarketPro` helpers — kind chip + hint + retry plan (open Runtime / update CLI / retry install). Soft-fail capability gaps use warn tone, not a hard crash banner.
 5. **Empty Plugins tab** links to Marketplace (“Browse official plugins”). Installed **Details** may show structured provides/marketplace summary when the CLI list includes it, plus `plugin details` text.
+6. **Catalog empty honesty**: loading · CLI missing · CLI too old · offline/network · load error · no sources · empty catalog · empty filter · empty query — each with a distinct title/hint and CTA (Retry / Refresh / Clear filters / Open Runtime). Never invent catalog rows when the CLI fails.
 
 ## Component counts
 

--- a/src/components/ExtensionsBuildExtras.tsx
+++ b/src/components/ExtensionsBuildExtras.tsx
@@ -44,7 +44,6 @@ import {
   availablePluginDetailModel,
   availablePluginMetaLine,
   availablePluginRowKey,
-  clearPluginRowError,
   enrichAvailableFromComponents,
   filterAvailableByMarketplace,
   filterAvailablePlugins,
@@ -55,7 +54,6 @@ import {
   marketplaceSourceLabel,
   normalizeMarketplaceAddSource,
   pickDefaultMarketplaceFilter,
-  setPluginRowError,
   sortAvailablePluginsByName,
   sortMarketplaceSourcesByName,
   XAI_OFFICIAL_MARKETPLACE,
@@ -64,6 +62,19 @@ import {
   type MarketplaceSourceLike,
   type PluginComponentBadgeKind,
 } from "@/lib/pluginMarketplace";
+import {
+  buildPluginMarketErrorView,
+  clearPluginMarketRowError,
+  formatPluginMarketRowErrorMessage,
+  planPluginMarketEmptyRetry,
+  planPluginMarketRetry,
+  pluginMarketErrorHintKey,
+  pluginMarketErrorTitleKey,
+  pluginMarketLoadIsSoftFail,
+  resolvePluginCatalogEmptyState,
+  setPluginMarketRowError,
+  type PluginMarketRowError,
+} from "@/lib/pluginMarketPro";
 
 export type ExtensionsBuildExtrasProps = {
   locale: Locale;
@@ -73,6 +84,8 @@ export type ExtensionsBuildExtrasProps = {
   mode?: "hooks" | "market" | "agents" | "all";
   /** After plugin install — parent can refresh plugins list. */
   onPluginsChanged?: () => void;
+  /** Navigate to Settings → Runtime when CLI is missing / too old. */
+  onOpenRuntime?: () => void;
   /**
    * Installed plugin names (and optional marketplace) so catalog rows can
    * offer Reinstall and match “already installed” state.
@@ -142,6 +155,7 @@ export function ExtensionsBuildExtras({
   cliFound = true,
   mode = "all",
   onPluginsChanged,
+  onOpenRuntime,
   installedPlugins = [],
 }: ExtensionsBuildExtrasProps) {
   const tr = useMemo(() => createT(locale), [locale]);
@@ -198,9 +212,9 @@ export function ExtensionsBuildExtras({
   const [installTarget, setInstallTarget] =
     useState<AvailablePluginLike | null>(null);
   /** Per-plugin last install/update error (row + detail Retry). */
-  const [installErrors, setInstallErrors] = useState<Record<string, string>>(
-    {},
-  );
+  const [installErrors, setInstallErrors] = useState<
+    Record<string, PluginMarketRowError>
+  >({});
 
   const installedNameSet = useMemo(() => {
     const set = new Set<string>();
@@ -396,10 +410,13 @@ export function ExtensionsBuildExtras({
   }, [newAgentName, newAgentScope, runScaffold]);
 
   const loadMarket = useCallback(async (force = false) => {
-    if (!api.isTauri()) {
+    // Soft-fail: no CLI / non-desktop — never hard-crash the marketplace tab.
+    if (!api.isTauri() || cliMissing) {
       setSources([]);
       setAvailable([]);
       setMarketLoading(false);
+      setMarketError(null);
+      setFromCache(false);
       return;
     }
     setMarketLoading(true);
@@ -430,6 +447,7 @@ export function ExtensionsBuildExtras({
       setSources(result.sources);
       setAvailable(result.available);
       setFromCache(result.fromCache);
+      // Soft-fail capability gaps are presented via empty-state, not only a banner.
       if (result.error) setMarketError(result.error);
 
       // Keep official default when that source exists; otherwise stay on filter chip.
@@ -449,7 +467,7 @@ export function ExtensionsBuildExtras({
     } finally {
       setMarketLoading(false);
     }
-  }, []);
+  }, [cliMissing]);
 
   useEffect(() => {
     if (showHooks) void loadHooks();
@@ -495,6 +513,62 @@ export function ExtensionsBuildExtras({
   );
 
   const hasMore = filteredAvailable.length > visibleAvailable.length;
+
+  /** Honest catalog empty / soft-fail presentation (null when rows visible). */
+  const catalogEmpty = useMemo(
+    () =>
+      resolvePluginCatalogEmptyState({
+        loading: marketLoading,
+        cliFound,
+        error: marketError,
+        sourceCount: sources.length,
+        availableCount: available.length,
+        visibleCount: visibleAvailable.length,
+        marketFilter,
+        query: availQuery,
+      }),
+    [
+      marketLoading,
+      cliFound,
+      marketError,
+      sources.length,
+      available.length,
+      visibleAvailable.length,
+      marketFilter,
+      availQuery,
+    ],
+  );
+
+  /** Classified load error for optional banner (suppress when empty-state owns it). */
+  const marketLoadView = useMemo(() => {
+    if (!marketError?.trim()) return null;
+    return buildPluginMarketErrorView(marketError, "list");
+  }, [marketError]);
+
+  /**
+   * Show a top banner only when:
+   * - empty-state does not already own the same soft/hard story, or
+   * - we have visible rows but a soft residual error (e.g. partial cache).
+   */
+  const showMarketErrorBanner = useMemo(() => {
+    if (!marketLoadView) return false;
+    if (catalogEmpty) {
+      // Empty-state already explains cli/offline/error — skip duplicate hard banner
+      // unless the empty kind is filter/query (load succeeded).
+      if (
+        catalogEmpty.kind === "empty_filter" ||
+        catalogEmpty.kind === "empty_query" ||
+        catalogEmpty.kind === "empty_catalog" ||
+        catalogEmpty.kind === "no_sources" ||
+        catalogEmpty.kind === "loading"
+      ) {
+        // Residual load error with an otherwise empty-but-ok catalog shape.
+        return !catalogEmpty.softFail && !!marketError;
+      }
+      return false;
+    }
+    return true;
+  }, [marketLoadView, catalogEmpty, marketError]);
 
   useEffect(() => {
     setPageLimit(PAGE_SIZE);
@@ -606,19 +680,24 @@ export function ExtensionsBuildExtras({
       target.marketplace,
     );
     setMarketBusy(`inst:${rowKey}`);
+    // Install failures stick to the row — do not escalate soft CLI gaps to a hard global banner.
     setMarketError(null);
     try {
       const res = await api.pluginInstall(source);
       if (res && typeof res === "object" && "ok" in res && res.ok === false) {
         const err =
-          (res as { error?: string; message?: string }).error?.trim() ||
+          (res as { error?: string; message?: string; reason?: string })
+            .error?.trim() ||
           (res as { message?: string }).message?.trim() ||
+          (res as { reason?: string }).reason?.trim() ||
           tr("ext.market.error");
-        setInstallErrors((prev) => setPluginRowError(prev, rowKey, err));
+        setInstallErrors((prev) =>
+          setPluginMarketRowError(prev, rowKey, err, "install"),
+        );
         if (opts?.closeConfirm !== false) setInstallTarget(null);
         return;
       }
-      setInstallErrors((prev) => clearPluginRowError(prev, rowKey));
+      setInstallErrors((prev) => clearPluginMarketRowError(prev, rowKey));
       removeAvailablePluginFromCache(target.name, target.marketplace);
       setAvailable((prev) =>
         prev.filter(
@@ -633,11 +712,60 @@ export function ExtensionsBuildExtras({
       setDetailPlugin(null);
       onPluginsChanged?.();
     } catch (e) {
-      const err = String(e);
-      setInstallErrors((prev) => setPluginRowError(prev, rowKey, err));
+      setInstallErrors((prev) =>
+        setPluginMarketRowError(prev, rowKey, e, "install"),
+      );
       if (opts?.closeConfirm !== false) setInstallTarget(null);
     } finally {
       setMarketBusy(null);
+    }
+  };
+
+  const clearCatalogFilters = () => {
+    setAvailQuery("");
+    setMarketFilter("__all__");
+  };
+
+  const runEmptyRetry = (action: ReturnType<typeof planPluginMarketEmptyRetry>["action"]) => {
+    if (action === "retry_load" || action === "refresh_catalog") {
+      void loadMarket(true);
+      return;
+    }
+    if (action === "clear_filter") {
+      clearCatalogFilters();
+      return;
+    }
+    if (action === "open_runtime" || action === "update_cli") {
+      onOpenRuntime?.();
+    }
+  };
+
+  const rowErrorLabel = (row: PluginMarketRowError): string => {
+    const title = tr(pluginMarketErrorTitleKey(row.kind) as MessageKey);
+    return formatPluginMarketRowErrorMessage(row, {
+      title,
+      includeDetail: row.kind === "other" || row.kind === "host_error",
+    });
+  };
+
+  const rowRetryLabel = (row: PluginMarketRowError): string => {
+    const plan = planPluginMarketRetry(row.kind, "install");
+    if (plan.action === "open_runtime") return tr("ext.error.openRuntime");
+    if (plan.action === "update_cli") return tr("ext.market.openRuntimeCli");
+    if (plan.action === "retry_install" && row.kind === "already_installed") {
+      return tr("ext.market.reinstall");
+    }
+    return tr("ext.market.retry");
+  };
+
+  const runRowRetry = (target: AvailablePluginLike, row: PluginMarketRowError) => {
+    const plan = planPluginMarketRetry(row.kind, "install");
+    if (plan.action === "open_runtime" || plan.action === "update_cli") {
+      onOpenRuntime?.();
+      return;
+    }
+    if (plan.canRetry) {
+      void retryInstall(target);
     }
   };
 
@@ -1156,10 +1284,44 @@ export function ExtensionsBuildExtras({
             </button>
           </h2>
           <div className="settings-card ext-card">
-            {marketError ? (
-              <div className="ext-alert ext-alert--error" role="alert">
-                <div className="ext-alert__title">{tr("ext.market.error")}</div>
-                <p className="ext-alert__body">{marketError}</p>
+            {showMarketErrorBanner && marketLoadView ? (
+              <div
+                className={
+                  "ext-alert" +
+                  (marketLoadView.softFail ||
+                  pluginMarketLoadIsSoftFail(marketError)
+                    ? " ext-alert--warn"
+                    : " ext-alert--error")
+                }
+                role={marketLoadView.softFail ? "status" : "alert"}
+              >
+                <div className="ext-alert__title">
+                  {tr(pluginMarketErrorTitleKey(marketLoadView.kind) as MessageKey)}
+                </div>
+                <p className="ext-alert__body">
+                  {tr(pluginMarketErrorHintKey(marketLoadView.kind) as MessageKey)}
+                </p>
+                {marketLoadView.detail ? (
+                  <p className="ext-alert__detail">{marketLoadView.detail}</p>
+                ) : null}
+                {marketLoadView.softFail && onOpenRuntime ? (
+                  <button
+                    type="button"
+                    className="btn btn--solid ext-alert__cta"
+                    onClick={onOpenRuntime}
+                  >
+                    {tr("ext.error.openRuntime")}
+                  </button>
+                ) : !marketLoadView.softFail ? (
+                  <button
+                    type="button"
+                    className="btn btn--ghost ext-alert__cta"
+                    disabled={marketLoading || !!marketBusy}
+                    onClick={() => void loadMarket(true)}
+                  >
+                    {tr("ext.market.retry")}
+                  </button>
+                ) : null}
               </div>
             ) : null}
 
@@ -1190,7 +1352,7 @@ export function ExtensionsBuildExtras({
                 className="settings-input ext-market-browse__search"
                 value={availQuery}
                 placeholder={tr("ext.market.searchPlaceholder")}
-                disabled={marketLoading}
+                disabled={marketLoading || cliMissing}
                 autoComplete="off"
                 spellCheck={false}
                 onChange={(e) => setAvailQuery(e.target.value)}
@@ -1200,10 +1362,43 @@ export function ExtensionsBuildExtras({
               ) : null}
             </div>
 
-            {marketLoading ? (
-              <p className="ext-empty">{tr("ext.market.availableLoading")}</p>
-            ) : visibleAvailable.length === 0 ? (
-              <p className="ext-empty">{tr("ext.market.availableEmpty")}</p>
+            {catalogEmpty ? (
+              <div className="ext-empty-cta">
+                <p className="ext-empty-cta__text">
+                  {tr(catalogEmpty.titleKey as MessageKey)}
+                </p>
+                {catalogEmpty.hintKey ? (
+                  <p className="ext-field-hint">
+                    {tr(catalogEmpty.hintKey as MessageKey)}
+                  </p>
+                ) : null}
+                {(() => {
+                  const plan = planPluginMarketEmptyRetry(catalogEmpty);
+                  if (plan.action === "none") return null;
+                  const label =
+                    plan.action === "open_runtime" || plan.action === "update_cli"
+                      ? tr("ext.error.openRuntime")
+                      : plan.action === "clear_filter"
+                        ? tr("ext.market.clearFilters")
+                        : plan.action === "refresh_catalog"
+                          ? tr("ext.market.refreshCatalog")
+                          : tr("ext.market.retry");
+                  const disabled =
+                    plan.action === "open_runtime" || plan.action === "update_cli"
+                      ? !onOpenRuntime
+                      : marketLoading || !!marketBusy;
+                  return (
+                    <button
+                      type="button"
+                      className="btn btn--solid btn--sm"
+                      disabled={disabled}
+                      onClick={() => runEmptyRetry(plan.action)}
+                    >
+                      {label}
+                    </button>
+                  );
+                })()}
+              </div>
             ) : (
               <ul className="ext-list ext-market-browse__list">
                 {visibleAvailable.map((p) => {
@@ -1273,19 +1468,50 @@ export function ExtensionsBuildExtras({
                       </button>
                       {rowError ? (
                         <div
-                          className="ext-item__row-error"
-                          role="alert"
+                          className={
+                            "ext-item__row-error" +
+                            (rowError.softFail ? " ext-item__row-error--soft" : "")
+                          }
+                          role={rowError.softFail ? "status" : "alert"}
                         >
-                          <p className="ext-item__row-error-text">{rowError}</p>
+                          <span
+                            className={
+                              "ext-badge " +
+                              (rowError.softFail
+                                ? "ext-badge--muted"
+                                : "ext-badge--fail")
+                            }
+                          >
+                            {tr(
+                              pluginMarketErrorTitleKey(
+                                rowError.kind,
+                              ) as MessageKey,
+                            )}
+                          </span>
+                          <p className="ext-item__row-error-text">
+                            {rowErrorLabel(rowError)}
+                          </p>
+                          <p className="ext-field-hint">
+                            {tr(
+                              pluginMarketErrorHintKey(
+                                rowError.kind,
+                              ) as MessageKey,
+                            )}
+                          </p>
                           <button
                             type="button"
                             className="btn btn--ghost btn--sm"
-                            disabled={!!marketBusy || cliMissing}
-                            onClick={() => void retryInstall(p)}
+                            disabled={
+                              !!marketBusy ||
+                              (cliMissing &&
+                                planPluginMarketRetry(rowError.kind, "install")
+                                  .action === "retry_install")
+                            }
+                            onClick={() => runRowRetry(p, rowError)}
                           >
                             {busy
                               ? tr("ext.market.installing")
-                              : tr("ext.market.retry")}
+                              : rowRetryLabel(rowError)}
                           </button>
                         </div>
                       ) : null}
@@ -1578,23 +1804,67 @@ export function ExtensionsBuildExtras({
                 {detailPlugin &&
                 installErrors[availablePluginRowKey(detailPlugin)] ? (
                   <div
-                    className="ext-item__row-error ext-item__row-error--detail"
-                    role="alert"
+                    className={
+                      "ext-item__row-error ext-item__row-error--detail" +
+                      (installErrors[availablePluginRowKey(detailPlugin)]
+                        .softFail
+                        ? " ext-item__row-error--soft"
+                        : "")
+                    }
+                    role={
+                      installErrors[availablePluginRowKey(detailPlugin)]
+                        .softFail
+                        ? "status"
+                        : "alert"
+                    }
                   >
+                    <span
+                      className={
+                        "ext-badge " +
+                        (installErrors[availablePluginRowKey(detailPlugin)]
+                          .softFail
+                          ? "ext-badge--muted"
+                          : "ext-badge--fail")
+                      }
+                    >
+                      {tr(
+                        pluginMarketErrorTitleKey(
+                          installErrors[availablePluginRowKey(detailPlugin)]
+                            .kind,
+                        ) as MessageKey,
+                      )}
+                    </span>
                     <p className="ext-item__row-error-text">
-                      {installErrors[availablePluginRowKey(detailPlugin)]}
+                      {rowErrorLabel(
+                        installErrors[availablePluginRowKey(detailPlugin)],
+                      )}
+                    </p>
+                    <p className="ext-field-hint">
+                      {tr(
+                        pluginMarketErrorHintKey(
+                          installErrors[availablePluginRowKey(detailPlugin)]
+                            .kind,
+                        ) as MessageKey,
+                      )}
                     </p>
                     <button
                       type="button"
                       className="btn btn--ghost btn--sm"
-                      disabled={!!marketBusy || cliMissing}
-                      onClick={() => void retryInstall(detailPlugin)}
+                      disabled={!!marketBusy}
+                      onClick={() =>
+                        runRowRetry(
+                          detailPlugin,
+                          installErrors[availablePluginRowKey(detailPlugin)],
+                        )
+                      }
                     >
                       {marketBusy ===
                         `inst:${availablePluginRowKey(detailPlugin)}` ||
                       marketBusy === `inst:${detailPlugin.name}`
                         ? tr("ext.market.installing")
-                        : tr("ext.market.retry")}
+                        : rowRetryLabel(
+                            installErrors[availablePluginRowKey(detailPlugin)],
+                          )}
                     </button>
                   </div>
                 ) : null}

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -2090,6 +2090,7 @@ export function ExtensionsPanel({
             name: p.name,
             marketplace: p.marketplace,
           }))}
+          onOpenRuntime={onOpenRuntime}
           onPluginsChanged={() => {
             void refresh();
           }}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -4068,6 +4068,65 @@ const en = {
   "ext.market.badge.mcp": "MCP",
   "ext.market.searchPlaceholder": "Search plugins…",
   "ext.market.error": "Marketplace action failed",
+  "ext.market.clearFilters": "Clear filters",
+  "ext.market.openRuntimeCli": "Open Runtime",
+  "ext.market.emptyCli": "Marketplace needs the Grok CLI",
+  "ext.market.emptyCliHint":
+    "Install or path the Grok CLI in Settings → Runtime, then refresh the catalog.",
+  "ext.market.emptyCliTooOld": "CLI too old for marketplace catalog",
+  "ext.market.emptyCliTooOldHint":
+    "Update Grok CLI (`grok update`) and fully restart the app, then refresh.",
+  "ext.market.emptyOffline": "Could not reach marketplace catalogs",
+  "ext.market.emptyOfflineHint":
+    "Check your network connection, then retry loading the catalog.",
+  "ext.market.emptyError": "Could not load marketplace catalog",
+  "ext.market.emptyNoSourcesHint":
+    "Add a git marketplace source below (xAI Official is recommended).",
+  "ext.market.emptyCatalog": "No available plugins in configured sources",
+  "ext.market.emptyCatalogHint":
+    "Refresh sources or switch filters. Installed plugins stay under the Plugins tab.",
+  "ext.market.emptyFilterHint":
+    "No plugins from this marketplace source. Try All sources or another chip.",
+  "ext.market.emptyQueryHint":
+    "No plugins match this search. Clear the query or try another keyword.",
+  "ext.market.err.cliMissing": "CLI missing",
+  "ext.market.err.cliTooOld": "CLI too old",
+  "ext.market.err.network": "Network error",
+  "ext.market.err.offline": "Offline",
+  "ext.market.err.timeout": "Timed out",
+  "ext.market.err.notFound": "Not found",
+  "ext.market.err.alreadyInstalled": "Already installed",
+  "ext.market.err.permission": "Permission denied",
+  "ext.market.err.auth": "Auth required",
+  "ext.market.err.invalidSource": "Invalid source",
+  "ext.market.err.parse": "Parse error",
+  "ext.market.err.hostOnly": "Desktop host required",
+  "ext.market.err.hostError": "Host error",
+  "ext.market.err.other": "Error",
+  "ext.market.err.hint.cliMissing":
+    "Install or path the Grok CLI in Settings → Runtime, then retry.",
+  "ext.market.err.hint.cliTooOld":
+    "Update Grok CLI (`grok update`) and fully restart the app, then retry.",
+  "ext.market.err.hint.network":
+    "Check your connection and refresh the catalog.",
+  "ext.market.err.hint.offline":
+    "You appear offline — reconnect and refresh the catalog.",
+  "ext.market.err.hint.timeout": "The CLI timed out — retry or refresh sources.",
+  "ext.market.err.hint.notFound":
+    "Plugin or marketplace source was not found — check the name.",
+  "ext.market.err.hint.alreadyInstalled":
+    "Plugin is already installed — use Reinstall to force.",
+  "ext.market.err.hint.permission":
+    "Permission denied — check filesystem or agent trust.",
+  "ext.market.err.hint.auth": "Sign in or fix credentials, then retry.",
+  "ext.market.err.hint.invalidSource":
+    "Use a marketplace name, git URL, owner/repo, or local path.",
+  "ext.market.err.hint.parse":
+    "Catalog JSON could not be parsed — refresh or update the CLI.",
+  "ext.market.err.hint.hostOnly":
+    "Open the desktop app (Tauri) to manage plugins.",
+  "ext.market.err.hint.hostError": "Host invoke failed — see detail.",
+  "ext.market.err.hint.other": "Unexpected result — see detail and retry.",
 
   // Extensions → Agents (definition files under ~/.grok/agents + project)
   "ext.agents.title": "Agents",
@@ -9031,6 +9090,57 @@ const zh: Record<MessageKey, string> = {
   "ext.market.badge.mcp": "MCP",
   "ext.market.searchPlaceholder": "搜索插件…",
   "ext.market.error": "市场操作失败",
+  "ext.market.clearFilters": "清除筛选",
+  "ext.market.openRuntimeCli": "打开运行时",
+  "ext.market.emptyCli": "市场需要 Grok CLI",
+  "ext.market.emptyCliHint":
+    "请在 设置 → 运行时 安装或指定 Grok CLI 路径，然后刷新目录。",
+  "ext.market.emptyCliTooOld": "CLI 过旧，无法加载市场目录",
+  "ext.market.emptyCliTooOldHint":
+    "请更新 Grok CLI（`grok update`）并完全重启应用后刷新。",
+  "ext.market.emptyOffline": "无法访问市场目录",
+  "ext.market.emptyOfflineHint": "请检查网络连接后重试加载目录。",
+  "ext.market.emptyError": "无法加载市场目录",
+  "ext.market.emptyNoSourcesHint":
+    "请在下方添加 git 市场源（推荐 xAI Official）。",
+  "ext.market.emptyCatalog": "已配置源中暂无可用插件",
+  "ext.market.emptyCatalogHint":
+    "可刷新源或切换筛选。已安装插件仍在「插件」标签中。",
+  "ext.market.emptyFilterHint":
+    "该市场源没有插件。可尝试「全部来源」或其他筛选。",
+  "ext.market.emptyQueryHint": "没有匹配此搜索的插件。可清除搜索词或换关键词。",
+  "ext.market.err.cliMissing": "找不到 CLI",
+  "ext.market.err.cliTooOld": "CLI 过旧",
+  "ext.market.err.network": "网络错误",
+  "ext.market.err.offline": "离线",
+  "ext.market.err.timeout": "超时",
+  "ext.market.err.notFound": "未找到",
+  "ext.market.err.alreadyInstalled": "已安装",
+  "ext.market.err.permission": "权限不足",
+  "ext.market.err.auth": "需要登录",
+  "ext.market.err.invalidSource": "源无效",
+  "ext.market.err.parse": "解析错误",
+  "ext.market.err.hostOnly": "需要桌面 Host",
+  "ext.market.err.hostError": "Host 错误",
+  "ext.market.err.other": "错误",
+  "ext.market.err.hint.cliMissing":
+    "请在 设置 → 运行时 安装或指定 Grok CLI 后重试。",
+  "ext.market.err.hint.cliTooOld":
+    "请更新 Grok CLI（`grok update`）并完全重启应用后重试。",
+  "ext.market.err.hint.network": "请检查网络并刷新目录。",
+  "ext.market.err.hint.offline": "当前似乎离线 — 恢复网络后刷新目录。",
+  "ext.market.err.hint.timeout": "CLI 超时 — 可重试或刷新源。",
+  "ext.market.err.hint.notFound": "未找到插件或市场源 — 请检查名称。",
+  "ext.market.err.hint.alreadyInstalled":
+    "插件已安装 — 可用「重新安装」强制刷新。",
+  "ext.market.err.hint.permission": "权限不足 — 请检查文件系统或 Agent 信任。",
+  "ext.market.err.hint.auth": "请登录或修复凭据后重试。",
+  "ext.market.err.hint.invalidSource":
+    "请使用市场名称、git URL、owner/repo 或本地路径。",
+  "ext.market.err.hint.parse": "目录 JSON 无法解析 — 请刷新或更新 CLI。",
+  "ext.market.err.hint.hostOnly": "请在桌面应用（Tauri）中管理插件。",
+  "ext.market.err.hint.hostError": "Host 调用失败 — 见详情。",
+  "ext.market.err.hint.other": "意外结果 — 见详情后重试。",
 
   "ext.agents.title": "Agents",
   "ext.agents.desc":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -3914,6 +3914,57 @@ export const zhTW: Record<MessageKey, string> = {
   "ext.market.badge.mcp": "MCP",
   "ext.market.searchPlaceholder": "搜尋外掛…",
   "ext.market.error": "市集操作失敗",
+  "ext.market.clearFilters": "清除篩選",
+  "ext.market.openRuntimeCli": "開啟執行階段",
+  "ext.market.emptyCli": "市集需要 Grok CLI",
+  "ext.market.emptyCliHint":
+    "請在 設定 → 執行階段 安裝或指定 Grok CLI 路徑，然後重新整理目錄。",
+  "ext.market.emptyCliTooOld": "CLI 過舊，無法載入市集目錄",
+  "ext.market.emptyCliTooOldHint":
+    "請更新 Grok CLI（`grok update`）並完全重新啟動應用程式後再重新整理。",
+  "ext.market.emptyOffline": "無法連線市集目錄",
+  "ext.market.emptyOfflineHint": "請檢查網路連線後重試載入目錄。",
+  "ext.market.emptyError": "無法載入市集目錄",
+  "ext.market.emptyNoSourcesHint":
+    "請在下方新增 git 市集來源（建議 xAI Official）。",
+  "ext.market.emptyCatalog": "已設定來源中暫無可用外掛",
+  "ext.market.emptyCatalogHint":
+    "可重新整理來源或切換篩選。已安裝外掛仍在「外掛」分頁。",
+  "ext.market.emptyFilterHint":
+    "此市集來源沒有外掛。可試試「全部來源」或其他篩選。",
+  "ext.market.emptyQueryHint": "沒有符合此搜尋的外掛。可清除搜尋詞或換關鍵字。",
+  "ext.market.err.cliMissing": "找不到 CLI",
+  "ext.market.err.cliTooOld": "CLI 過舊",
+  "ext.market.err.network": "網路錯誤",
+  "ext.market.err.offline": "離線",
+  "ext.market.err.timeout": "逾時",
+  "ext.market.err.notFound": "找不到",
+  "ext.market.err.alreadyInstalled": "已安裝",
+  "ext.market.err.permission": "權限不足",
+  "ext.market.err.auth": "需要登入",
+  "ext.market.err.invalidSource": "來源無效",
+  "ext.market.err.parse": "解析錯誤",
+  "ext.market.err.hostOnly": "需要桌面 Host",
+  "ext.market.err.hostError": "Host 錯誤",
+  "ext.market.err.other": "錯誤",
+  "ext.market.err.hint.cliMissing":
+    "請在 設定 → 執行階段 安裝或指定 Grok CLI 後重試。",
+  "ext.market.err.hint.cliTooOld":
+    "請更新 Grok CLI（`grok update`）並完全重新啟動應用程式後重試。",
+  "ext.market.err.hint.network": "請檢查網路並重新整理目錄。",
+  "ext.market.err.hint.offline": "目前似乎離線 — 恢復網路後重新整理目錄。",
+  "ext.market.err.hint.timeout": "CLI 逾時 — 可重試或重新整理來源。",
+  "ext.market.err.hint.notFound": "找不到外掛或市集來源 — 請檢查名稱。",
+  "ext.market.err.hint.alreadyInstalled":
+    "外掛已安裝 — 可用「重新安裝」強制更新。",
+  "ext.market.err.hint.permission": "權限不足 — 請檢查檔案系統或 Agent 信任。",
+  "ext.market.err.hint.auth": "請登入或修復憑證後重試。",
+  "ext.market.err.hint.invalidSource":
+    "請使用市集名稱、git URL、owner/repo 或本機路徑。",
+  "ext.market.err.hint.parse": "目錄 JSON 無法解析 — 請重新整理或更新 CLI。",
+  "ext.market.err.hint.hostOnly": "請在桌面應用程式（Tauri）中管理外掛。",
+  "ext.market.err.hint.hostError": "Host 呼叫失敗 — 見詳情。",
+  "ext.market.err.hint.other": "意外結果 — 見詳情後重試。",
 
   "ext.agents.title": "Agents",
   "ext.agents.desc":

--- a/src/lib/pluginMarketPro.test.ts
+++ b/src/lib/pluginMarketPro.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPluginMarketErrorView,
+  classifyPluginMarketError,
+  clearPluginMarketRowError,
+  formatPluginMarketRowErrorMessage,
+  planPluginMarketEmptyRetry,
+  planPluginMarketRetry,
+  pluginMarketErrorHintKey,
+  pluginMarketErrorTitleKey,
+  pluginMarketIsSoftFailKind,
+  pluginMarketLoadIsSoftFail,
+  resolvePluginCatalogEmptyState,
+  setPluginMarketRowError,
+} from "./pluginMarketPro";
+
+describe("classifyPluginMarketError", () => {
+  it("classifies CLI missing / too old", () => {
+    expect(classifyPluginMarketError("CLI not found")).toBe("cli_missing");
+    expect(classifyPluginMarketError("Grok Build CLI not found")).toBe(
+      "cli_missing",
+    );
+    expect(
+      classifyPluginMarketError({ reason: "cli_missing", message: "x" }),
+    ).toBe("cli_missing");
+    expect(
+      classifyPluginMarketError(
+        "This Grok CLI does not support `plugin list --available`",
+      ),
+    ).toBe("cli_too_old");
+    expect(
+      classifyPluginMarketError(
+        "error: unrecognized subcommand 'marketplace'",
+      ),
+    ).toBe("cli_too_old");
+    expect(
+      classifyPluginMarketError("unexpected argument '--trust' found"),
+    ).toBe("cli_too_old");
+    expect(classifyPluginMarketError({ code: "cli_too_old" })).toBe(
+      "cli_too_old",
+    );
+  });
+
+  it("classifies network / offline / timeout", () => {
+    expect(classifyPluginMarketError("connection refused")).toBe("network");
+    expect(classifyPluginMarketError(new Error("ENOTFOUND github.com"))).toBe(
+      "network",
+    );
+    expect(classifyPluginMarketError("You appear offline")).toBe("offline");
+    expect(classifyPluginMarketError("operation timed out")).toBe("timeout");
+  });
+
+  it("classifies install-specific failures", () => {
+    expect(classifyPluginMarketError("plugin already installed")).toBe(
+      "already_installed",
+    );
+    expect(classifyPluginMarketError("plugin source required")).toBe(
+      "invalid_source",
+    );
+    expect(classifyPluginMarketError("unknown plugin: nope")).toBe("not_found");
+    expect(classifyPluginMarketError("Permission denied writing config")).toBe(
+      "permission",
+    );
+    expect(classifyPluginMarketError("401 Unauthorized")).toBe("auth");
+  });
+
+  it("classifies parse / host-only / host error", () => {
+    expect(
+      classifyPluginMarketError(
+        "Failed to parse available plugins JSON: Unexpected token",
+      ),
+    ).toBe("parse");
+    expect(classifyPluginMarketError("Need Tauri for marketplace")).toBe(
+      "host_only",
+    );
+    expect(classifyPluginMarketError("ipc invoke failed")).toBe("host_error");
+  });
+
+  it("falls back to other", () => {
+    expect(classifyPluginMarketError("weird host boom")).toBe("other");
+    expect(classifyPluginMarketError(null)).toBe("other");
+    expect(classifyPluginMarketError("")).toBe("other");
+  });
+});
+
+describe("buildPluginMarketErrorView / soft-fail", () => {
+  it("marks cli gaps as soft-fail", () => {
+    const v = buildPluginMarketErrorView("CLI not found", "list");
+    expect(v.kind).toBe("cli_missing");
+    expect(v.softFail).toBe(true);
+    expect(v.title).toMatch(/cli/i);
+    expect(v.hint.length).toBeGreaterThan(0);
+    expect(pluginMarketIsSoftFailKind("cli_too_old")).toBe(true);
+    expect(pluginMarketIsSoftFailKind("network")).toBe(false);
+    expect(pluginMarketLoadIsSoftFail("CLI not found")).toBe(true);
+    expect(pluginMarketLoadIsSoftFail("connection refused")).toBe(false);
+  });
+
+  it("maps i18n keys for each kind", () => {
+    expect(pluginMarketErrorTitleKey("cli_missing")).toBe(
+      "ext.market.err.cliMissing",
+    );
+    expect(pluginMarketErrorHintKey("network")).toBe(
+      "ext.market.err.hint.network",
+    );
+    expect(pluginMarketErrorTitleKey("other")).toBe("ext.market.err.other");
+  });
+});
+
+describe("resolvePluginCatalogEmptyState", () => {
+  const base = {
+    loading: false,
+    cliFound: true,
+    error: null as unknown,
+    sourceCount: 2,
+    availableCount: 10,
+    visibleCount: 0,
+    marketFilter: "xAI Official",
+    query: "",
+  };
+
+  it("returns null when rows are visible", () => {
+    expect(
+      resolvePluginCatalogEmptyState({ ...base, visibleCount: 3 }),
+    ).toBeNull();
+  });
+
+  it("loading state", () => {
+    const e = resolvePluginCatalogEmptyState({
+      ...base,
+      loading: true,
+      sourceCount: 0,
+      availableCount: 0,
+      visibleCount: 0,
+    });
+    expect(e?.kind).toBe("loading");
+    expect(e?.softFail).toBe(true);
+  });
+
+  it("cli missing soft-fail", () => {
+    const e = resolvePluginCatalogEmptyState({
+      ...base,
+      cliFound: false,
+      availableCount: 0,
+      sourceCount: 0,
+    });
+    expect(e?.kind).toBe("cli_missing");
+    expect(e?.softFail).toBe(true);
+    expect(e?.retryAction).toBe("open_runtime");
+  });
+
+  it("cli too old from list error", () => {
+    const e = resolvePluginCatalogEmptyState({
+      ...base,
+      availableCount: 0,
+      error: "unrecognized subcommand 'marketplace'",
+    });
+    expect(e?.kind).toBe("cli_too_old");
+    expect(e?.softFail).toBe(true);
+    expect(e?.retryAction).toBe("update_cli");
+  });
+
+  it("offline / network load error", () => {
+    const e = resolvePluginCatalogEmptyState({
+      ...base,
+      availableCount: 0,
+      error: "network is unreachable",
+    });
+    expect(e?.kind).toBe("offline");
+    expect(e?.retryAction).toBe("retry_load");
+  });
+
+  it("no sources honesty", () => {
+    const e = resolvePluginCatalogEmptyState({
+      ...base,
+      sourceCount: 0,
+      availableCount: 0,
+      marketFilter: "__all__",
+    });
+    expect(e?.kind).toBe("no_sources");
+    expect(e?.titleKey).toBe("ext.market.empty");
+  });
+
+  it("empty catalog with sources", () => {
+    const e = resolvePluginCatalogEmptyState({
+      ...base,
+      sourceCount: 1,
+      availableCount: 0,
+      marketFilter: "__all__",
+    });
+    expect(e?.kind).toBe("empty_catalog");
+    expect(e?.retryAction).toBe("refresh_catalog");
+  });
+
+  it("empty filter vs empty query honesty", () => {
+    const filterEmpty = resolvePluginCatalogEmptyState({
+      ...base,
+      marketFilter: "xAI Official",
+      query: "",
+    });
+    expect(filterEmpty?.kind).toBe("empty_filter");
+    expect(filterEmpty?.showClearFilters).toBe(true);
+    expect(filterEmpty?.hintKey).toBe("ext.market.emptyFilterHint");
+
+    const queryEmpty = resolvePluginCatalogEmptyState({
+      ...base,
+      marketFilter: "__all__",
+      query: "zzzz-nope",
+    });
+    expect(queryEmpty?.kind).toBe("empty_query");
+    expect(queryEmpty?.showClearFilters).toBe(true);
+    expect(queryEmpty?.hintKey).toBe("ext.market.emptyQueryHint");
+  });
+
+  it("hard load error with empty catalog", () => {
+    const e = resolvePluginCatalogEmptyState({
+      ...base,
+      availableCount: 0,
+      error: "Failed to parse available plugins JSON: boom",
+    });
+    expect(e?.kind).toBe("error");
+    expect(e?.retryAction).toBe("retry_load");
+  });
+});
+
+describe("planPluginMarketRetry", () => {
+  it("maps capability gaps to runtime / CLI update", () => {
+    expect(planPluginMarketRetry("cli_missing").action).toBe("open_runtime");
+    expect(planPluginMarketRetry("cli_missing").canRetry).toBe(false);
+    expect(planPluginMarketRetry("cli_too_old").action).toBe("update_cli");
+    expect(planPluginMarketRetry("host_only").action).toBe("none");
+  });
+
+  it("retries install for transient / generic install failures", () => {
+    expect(planPluginMarketRetry("network", "install")).toEqual(
+      expect.objectContaining({
+        action: "retry_install",
+        canRetry: true,
+      }),
+    );
+    expect(planPluginMarketRetry("other", "install").action).toBe(
+      "retry_install",
+    );
+    expect(planPluginMarketRetry("already_installed").label).toMatch(
+      /reinstall/i,
+    );
+  });
+
+  it("retries load for list failures", () => {
+    expect(planPluginMarketRetry("timeout", "list").action).toBe("retry_load");
+    expect(planPluginMarketRetry("parse", "list").action).toBe(
+      "refresh_catalog",
+    );
+  });
+
+  it("plans from empty presentation", () => {
+    expect(
+      planPluginMarketEmptyRetry({
+        kind: "empty_filter",
+        retryAction: "clear_filter",
+        softFail: true,
+      }).action,
+    ).toBe("clear_filter");
+    expect(
+      planPluginMarketEmptyRetry({
+        kind: "offline",
+        retryAction: "retry_load",
+        softFail: false,
+      }).canRetry,
+    ).toBe(true);
+  });
+});
+
+describe("setPluginMarketRowError / clear", () => {
+  it("sets classified row errors immutably", () => {
+    const empty: Record<string, never> = {};
+    const withErr = setPluginMarketRowError(
+      empty,
+      "xAI Official:vercel",
+      "connection refused",
+      "install",
+    );
+    expect(withErr["xAI Official:vercel"]).toMatchObject({
+      kind: "network",
+      softFail: false,
+    });
+    expect(withErr["xAI Official:vercel"].message).toMatch(/connection/i);
+    expect(empty).toEqual({});
+
+    // Same error → same object
+    expect(
+      setPluginMarketRowError(
+        withErr,
+        "xAI Official:vercel",
+        "connection refused",
+      ),
+    ).toBe(withErr);
+
+    const cleared = clearPluginMarketRowError(withErr, "xAI Official:vercel");
+    expect(cleared).toEqual({});
+    expect(clearPluginMarketRowError(cleared, "missing")).toBe(cleared);
+    expect(setPluginMarketRowError(empty, "", "x")).toBe(empty);
+  });
+
+  it("formats row message with optional detail", () => {
+    const row = {
+      kind: "network" as const,
+      message: "connection refused",
+      softFail: false,
+    };
+    expect(formatPluginMarketRowErrorMessage(row)).toMatch(/network/i);
+    expect(
+      formatPluginMarketRowErrorMessage(row, {
+        title: "Network error",
+        includeDetail: true,
+      }),
+    ).toContain("connection refused");
+  });
+});

--- a/src/lib/pluginMarketPro.ts
+++ b/src/lib/pluginMarketPro.ts
@@ -1,0 +1,874 @@
+/**
+ * PLUGIN-MARKET-PRO — pure helpers for marketplace install recovery and
+ * catalog empty-state honesty (Settings → Extensions → Marketplace).
+ *
+ * CLI (`grok plugin …`) is the source of truth — never invent a second store.
+ * Soft-fail when CLI is missing / too old (warn, no hard crash banner).
+ * No DOM / Tauri side effects.
+ */
+
+/** Which marketplace operation produced the error. */
+export type PluginMarketOp =
+  | "install"
+  | "list"
+  | "validate"
+  | "sources"
+  | "update";
+
+/** Stable failure kinds for install / list / validate / sources. */
+export type PluginMarketErrorKind =
+  | "cli_missing"
+  | "cli_too_old"
+  | "network"
+  | "offline"
+  | "timeout"
+  | "not_found"
+  | "already_installed"
+  | "permission"
+  | "auth"
+  | "invalid_source"
+  | "parse"
+  | "host_only"
+  | "host_error"
+  | "other";
+
+/** Contextual empty states for the catalog browse list. */
+export type PluginCatalogEmptyKind =
+  | "loading"
+  | "cli_missing"
+  | "cli_too_old"
+  | "offline"
+  | "error"
+  | "no_sources"
+  | "empty_catalog"
+  | "empty_filter"
+  | "empty_query";
+
+/** Primary recovery action for Retry / empty CTAs. */
+export type PluginMarketRetryAction =
+  | "retry_install"
+  | "retry_load"
+  | "refresh_catalog"
+  | "open_runtime"
+  | "update_cli"
+  | "clear_filter"
+  | "none";
+
+export type PluginMarketErrorView = {
+  kind: PluginMarketErrorKind;
+  /** Soft-fail: capability gap — warn, do not escalate to hard action banner. */
+  softFail: boolean;
+  /** Short English fallback title (UI prefers i18n). */
+  title: string;
+  /** Actionable English fallback hint (UI prefers i18n). */
+  hint: string;
+  /** Trimmed host detail (may be empty). */
+  detail: string;
+  op: PluginMarketOp;
+};
+
+export type PluginCatalogEmptyPresentation = {
+  kind: PluginCatalogEmptyKind;
+  /** Soft-fail empty (cli missing / too old) vs hard error empty. */
+  softFail: boolean;
+  /** i18n title key under ext.market.* */
+  titleKey: string;
+  /** Optional i18n hint key. */
+  hintKey: string | null;
+  /** Suggested primary CTA. */
+  retryAction: PluginMarketRetryAction;
+  /** Offer clear-filter / clear-search when filter or query is active. */
+  showClearFilters: boolean;
+};
+
+export type PluginMarketRetryPlan = {
+  action: PluginMarketRetryAction;
+  softFail: boolean;
+  /** Whether Retry button should re-run the failed op. */
+  canRetry: boolean;
+  /** English fallback label for the primary CTA. */
+  label: string;
+};
+
+export type PluginMarketRowError = {
+  kind: PluginMarketErrorKind;
+  message: string;
+  softFail: boolean;
+};
+
+// ── Error text helpers ──────────────────────────────────────────────────────
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as {
+      code?: unknown;
+      message?: unknown;
+      reason?: unknown;
+      error?: unknown;
+    };
+    const parts = [o.code, o.message, o.reason, o.error]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+function errCode(err: unknown): string {
+  if (typeof err === "object" && err !== null) {
+    const o = err as { code?: unknown; reason?: unknown };
+    if (typeof o.code === "string" && o.code.trim()) {
+      return o.code.trim().toLowerCase().replace(/-/g, "_");
+    }
+    if (typeof o.reason === "string" && o.reason.trim()) {
+      return o.reason.trim().toLowerCase().replace(/-/g, "_");
+    }
+  }
+  return "";
+}
+
+/** English fallback titles for classified kinds. */
+export const PLUGIN_MARKET_ERROR_TITLE_FALLBACK: Record<
+  PluginMarketErrorKind,
+  string
+> = {
+  cli_missing: "CLI missing",
+  cli_too_old: "CLI too old",
+  network: "Network error",
+  offline: "Offline",
+  timeout: "Timed out",
+  not_found: "Not found",
+  already_installed: "Already installed",
+  permission: "Permission denied",
+  auth: "Auth required",
+  invalid_source: "Invalid source",
+  parse: "Parse error",
+  host_only: "Desktop host required",
+  host_error: "Host error",
+  other: "Error",
+};
+
+/** Actionable English hints for classified kinds. */
+export const PLUGIN_MARKET_ERROR_HINT_FALLBACK: Record<
+  PluginMarketErrorKind,
+  string
+> = {
+  cli_missing: "Install or path the Grok CLI in Settings → Runtime, then retry.",
+  cli_too_old:
+    "Update Grok CLI (`grok update`) and fully restart the app, then retry.",
+  network: "Check your connection and refresh the catalog.",
+  offline: "You appear offline — reconnect and refresh the catalog.",
+  timeout: "The CLI timed out — retry or refresh sources.",
+  not_found: "Plugin or marketplace source was not found — check the name.",
+  already_installed: "Plugin is already installed — use Reinstall to force.",
+  permission: "Permission denied — check filesystem or agent trust.",
+  auth: "Sign in or fix credentials, then retry.",
+  invalid_source: "Use a marketplace name, git URL, owner/repo, or local path.",
+  parse: "Catalog JSON could not be parsed — refresh or update the CLI.",
+  host_only: "Open the desktop app (Tauri) to manage plugins.",
+  host_error: "Host invoke failed — see detail.",
+  other: "Unexpected result — see detail and retry.",
+};
+
+/** i18n title keys for market error kinds (`ext.market.err.*`). */
+export function pluginMarketErrorTitleKey(kind: PluginMarketErrorKind): string {
+  switch (kind) {
+    case "cli_missing":
+      return "ext.market.err.cliMissing";
+    case "cli_too_old":
+      return "ext.market.err.cliTooOld";
+    case "network":
+      return "ext.market.err.network";
+    case "offline":
+      return "ext.market.err.offline";
+    case "timeout":
+      return "ext.market.err.timeout";
+    case "not_found":
+      return "ext.market.err.notFound";
+    case "already_installed":
+      return "ext.market.err.alreadyInstalled";
+    case "permission":
+      return "ext.market.err.permission";
+    case "auth":
+      return "ext.market.err.auth";
+    case "invalid_source":
+      return "ext.market.err.invalidSource";
+    case "parse":
+      return "ext.market.err.parse";
+    case "host_only":
+      return "ext.market.err.hostOnly";
+    case "host_error":
+      return "ext.market.err.hostError";
+    case "other":
+    default:
+      return "ext.market.err.other";
+  }
+}
+
+/** i18n hint keys for market error kinds. */
+export function pluginMarketErrorHintKey(kind: PluginMarketErrorKind): string {
+  switch (kind) {
+    case "cli_missing":
+      return "ext.market.err.hint.cliMissing";
+    case "cli_too_old":
+      return "ext.market.err.hint.cliTooOld";
+    case "network":
+      return "ext.market.err.hint.network";
+    case "offline":
+      return "ext.market.err.hint.offline";
+    case "timeout":
+      return "ext.market.err.hint.timeout";
+    case "not_found":
+      return "ext.market.err.hint.notFound";
+    case "already_installed":
+      return "ext.market.err.hint.alreadyInstalled";
+    case "permission":
+      return "ext.market.err.hint.permission";
+    case "auth":
+      return "ext.market.err.hint.auth";
+    case "invalid_source":
+      return "ext.market.err.hint.invalidSource";
+    case "parse":
+      return "ext.market.err.hint.parse";
+    case "host_only":
+      return "ext.market.err.hint.hostOnly";
+    case "host_error":
+      return "ext.market.err.hint.hostError";
+    case "other":
+    default:
+      return "ext.market.err.hint.other";
+  }
+}
+
+/**
+ * Soft-fail kinds: capability / environment gaps.
+ * UI should warn (not hard red global crash) and still show catalog chrome.
+ */
+export function pluginMarketIsSoftFailKind(kind: PluginMarketErrorKind): boolean {
+  return (
+    kind === "cli_missing" ||
+    kind === "cli_too_old" ||
+    kind === "host_only"
+  );
+}
+
+/**
+ * Classify install / list / validate / sources failures into a stable kind.
+ * Prefer explicit `code` / `reason`, then known host / CLI phrases.
+ * Never invents success.
+ */
+export function classifyPluginMarketError(
+  err: unknown,
+  _op: PluginMarketOp = "install",
+): PluginMarketErrorKind {
+  // `_op` reserved for future op-specific heuristics; keep signature stable.
+  void _op;
+  if (err == null || err === "") return "other";
+
+  const code = errCode(err);
+  if (code === "cli_missing" || code === "cli_not_found") return "cli_missing";
+  if (code === "cli_too_old" || code === "unsupported") return "cli_too_old";
+  if (code === "network" || code === "econnrefused" || code === "enotfound") {
+    return "network";
+  }
+  if (code === "offline") return "offline";
+  if (code === "timeout" || code === "timed_out") return "timeout";
+  if (code === "not_found" || code === "enoent") return "not_found";
+  if (code === "already_installed" || code === "exists") {
+    return "already_installed";
+  }
+  if (code === "permission" || code === "eacces" || code === "eperm") {
+    return "permission";
+  }
+  if (code === "auth" || code === "unauthorized" || code === "auth_failed") {
+    return "auth";
+  }
+  if (code === "invalid_source" || code === "invalid") return "invalid_source";
+  if (code === "parse" || code === "parse_error") return "parse";
+  if (code === "host_only" || code === "need_tauri") return "host_only";
+  if (code === "host_error") return "host_error";
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  // CLI missing
+  if (
+    s.includes("cli not found") ||
+    s.includes("cli_not_found") ||
+    s.includes("grok build not found") ||
+    s.includes("grok build cli not found") ||
+    s.includes("command not found") ||
+    (s.includes("no such file") && s.includes("grok")) ||
+    (s.includes("not found") && s.includes("cli"))
+  ) {
+    return "cli_missing";
+  }
+
+  // CLI too old / unknown subcommand (marketplace / available / install flags)
+  if (
+    s.includes("cli_too_old") ||
+    s.includes("cli too old") ||
+    (s.includes("does not support") &&
+      (s.includes("plugin") ||
+        s.includes("marketplace") ||
+        s.includes("available") ||
+        s.includes("validate"))) ||
+    s.includes("unrecognized subcommand") ||
+    s.includes("unknown subcommand") ||
+    s.includes("unexpected subcommand") ||
+    (s.includes("unexpected argument") &&
+      (s.includes("available") ||
+        s.includes("marketplace") ||
+        s.includes("validate") ||
+        s.includes("--trust")))
+  ) {
+    return "cli_too_old";
+  }
+
+  // Host-only (browser / non-Tauri)
+  if (
+    s.includes("need tauri") ||
+    s.includes("not a tauri") ||
+    s.includes("desktop only") ||
+    s.includes("host only") ||
+    s.includes("requires the desktop") ||
+    s.includes("not available in browser")
+  ) {
+    return "host_only";
+  }
+
+  // Offline / network
+  if (
+    s.includes("offline") ||
+    s.includes("network is unreachable") ||
+    s.includes("no internet") ||
+    s.includes("not connected to the internet")
+  ) {
+    return "offline";
+  }
+  if (
+    s.includes("timed out") ||
+    s.includes("timeout") ||
+    s.includes("deadline exceeded")
+  ) {
+    return "timeout";
+  }
+  if (
+    s.includes("econnrefused") ||
+    s.includes("enotfound") ||
+    s.includes("econnreset") ||
+    s.includes("network") ||
+    s.includes("dns") ||
+    s.includes("could not resolve") ||
+    s.includes("failed to fetch") ||
+    s.includes("connection refused") ||
+    s.includes("connection reset") ||
+    s.includes("ssl") ||
+    s.includes("tls") ||
+    s.includes("proxy") ||
+    s.includes("http 5") ||
+    s.includes("http 4") ||
+    s.includes("status code")
+  ) {
+    return "network";
+  }
+
+  // Already installed
+  if (
+    s.includes("already installed") ||
+    s.includes("already exists") ||
+    (s.includes("exists") && s.includes("install"))
+  ) {
+    return "already_installed";
+  }
+
+  // Invalid source / empty
+  if (
+    s.includes("plugin source required") ||
+    s.includes("marketplace source required") ||
+    s.includes("invalid source") ||
+    s.includes("source required") ||
+    s.includes("empty source")
+  ) {
+    return "invalid_source";
+  }
+
+  // Auth
+  if (
+    s.includes("unauthorized") ||
+    s.includes("authentication") ||
+    s.includes("not logged in") ||
+    s.includes("login required") ||
+    s.includes("401") ||
+    s.includes("403") ||
+    (s.includes("permission denied") && s.includes("auth"))
+  ) {
+    return "auth";
+  }
+
+  // Permission (filesystem)
+  if (
+    s.includes("permission denied") ||
+    s.includes("access denied") ||
+    s.includes("eacces") ||
+    s.includes("operation not permitted")
+  ) {
+    return "permission";
+  }
+
+  // Parse / JSON
+  if (
+    s.includes("failed to parse") ||
+    s.includes("parse error") ||
+    s.includes("invalid json") ||
+    s.includes("not an array") ||
+    s.includes("json")
+  ) {
+    return "parse";
+  }
+
+  // Not found
+  if (
+    s.includes("not found") ||
+    s.includes("does not exist") ||
+    s.includes("no such") ||
+    s.includes("unknown plugin") ||
+    s.includes("unknown marketplace")
+  ) {
+    return "not_found";
+  }
+
+  // Host invoke failures
+  if (
+    s.includes("invoke") ||
+    s.includes("ipc") ||
+    s.includes("tauri") && s.includes("error")
+  ) {
+    return "host_error";
+  }
+
+  return "other";
+}
+
+/**
+ * Build a presentation envelope for a thrown / host error.
+ * `ok` is never implied — callers already know the action failed.
+ */
+export function buildPluginMarketErrorView(
+  err: unknown,
+  op: PluginMarketOp = "install",
+): PluginMarketErrorView {
+  const kind = classifyPluginMarketError(err, op);
+  const detail = errText(err).trim();
+  return {
+    kind,
+    softFail: pluginMarketIsSoftFailKind(kind),
+    title: PLUGIN_MARKET_ERROR_TITLE_FALLBACK[kind],
+    hint: PLUGIN_MARKET_ERROR_HINT_FALLBACK[kind],
+    detail,
+    op,
+  };
+}
+
+// ── Catalog empty state ─────────────────────────────────────────────────────
+
+export type PluginCatalogEmptyInput = {
+  loading: boolean;
+  /** Probe: CLI binary found (false → soft empty). */
+  cliFound?: boolean | null;
+  /**
+   * Load / list error string or object (classified).
+   * Soft-fail kinds suppress hard red banners.
+   */
+  error?: unknown;
+  /** Configured marketplace source count. */
+  sourceCount: number;
+  /** Available plugins before filter/query (catalog size). */
+  availableCount: number;
+  /** Rows after marketplace chip + search query. */
+  visibleCount: number;
+  /** Active marketplace filter id (`__all__` or source name). */
+  marketFilter?: string | null;
+  /** Search query. */
+  query?: string | null;
+};
+
+/**
+ * Resolve empty-state presentation for marketplace catalog browse.
+ * Returns `null` when there are visible rows (no empty UI).
+ *
+ * Priority: loading → cli missing → classified load error → no sources →
+ * empty catalog → empty filter/query.
+ */
+export function resolvePluginCatalogEmptyState(
+  input: PluginCatalogEmptyInput,
+): PluginCatalogEmptyPresentation | null {
+  if (input.loading && input.availableCount === 0 && input.sourceCount === 0) {
+    return {
+      kind: "loading",
+      softFail: true,
+      titleKey: "ext.market.availableLoading",
+      hintKey: null,
+      retryAction: "none",
+      showClearFilters: false,
+    };
+  }
+
+  if (input.cliFound === false) {
+    return {
+      kind: "cli_missing",
+      softFail: true,
+      titleKey: "ext.market.emptyCli",
+      hintKey: "ext.market.emptyCliHint",
+      retryAction: "open_runtime",
+      showClearFilters: false,
+    };
+  }
+
+  if (input.error != null && String(input.error).trim()) {
+    const kind = classifyPluginMarketError(input.error, "list");
+    if (kind === "cli_missing") {
+      return {
+        kind: "cli_missing",
+        softFail: true,
+        titleKey: "ext.market.emptyCli",
+        hintKey: "ext.market.emptyCliHint",
+        retryAction: "open_runtime",
+        showClearFilters: false,
+      };
+    }
+    if (kind === "cli_too_old") {
+      return {
+        kind: "cli_too_old",
+        softFail: true,
+        titleKey: "ext.market.emptyCliTooOld",
+        hintKey: "ext.market.emptyCliTooOldHint",
+        retryAction: "update_cli",
+        showClearFilters: false,
+      };
+    }
+    if (kind === "offline" || kind === "network") {
+      return {
+        kind: "offline",
+        softFail: false,
+        titleKey: "ext.market.emptyOffline",
+        hintKey: "ext.market.emptyOfflineHint",
+        retryAction: "retry_load",
+        showClearFilters: false,
+      };
+    }
+    if (kind === "timeout") {
+      return {
+        kind: "error",
+        softFail: false,
+        titleKey: "ext.market.emptyError",
+        hintKey: "ext.market.err.hint.timeout",
+        retryAction: "retry_load",
+        showClearFilters: false,
+      };
+    }
+    // Parse / host / other load failures — still show catalog chrome + retry.
+    if (input.availableCount === 0) {
+      return {
+        kind: "error",
+        softFail: pluginMarketIsSoftFailKind(kind),
+        titleKey: "ext.market.emptyError",
+        hintKey: pluginMarketErrorHintKey(kind),
+        retryAction: "retry_load",
+        showClearFilters: false,
+      };
+    }
+  }
+
+  if (input.visibleCount > 0) return null;
+
+  // No sources configured
+  if (input.sourceCount === 0) {
+    return {
+      kind: "no_sources",
+      softFail: true,
+      titleKey: "ext.market.empty",
+      hintKey: "ext.market.emptyNoSourcesHint",
+      retryAction: "none",
+      showClearFilters: false,
+    };
+  }
+
+  // Sources exist but catalog has zero available plugins
+  if (input.availableCount === 0) {
+    return {
+      kind: "empty_catalog",
+      softFail: true,
+      titleKey: "ext.market.emptyCatalog",
+      hintKey: "ext.market.emptyCatalogHint",
+      retryAction: "refresh_catalog",
+      showClearFilters: false,
+    };
+  }
+
+  // Filter / query emptied the list
+  const q = (input.query ?? "").trim();
+  const filter = (input.marketFilter ?? "").trim();
+  const filterActive = !!filter && filter !== "__all__";
+
+  if (q) {
+    return {
+      kind: "empty_query",
+      softFail: true,
+      titleKey: "ext.market.availableEmpty",
+      hintKey: "ext.market.emptyQueryHint",
+      retryAction: "clear_filter",
+      showClearFilters: true,
+    };
+  }
+
+  if (filterActive) {
+    return {
+      kind: "empty_filter",
+      softFail: true,
+      titleKey: "ext.market.availableEmpty",
+      hintKey: "ext.market.emptyFilterHint",
+      retryAction: "clear_filter",
+      showClearFilters: true,
+    };
+  }
+
+  // Defensive fallback
+  return {
+    kind: "empty_catalog",
+    softFail: true,
+    titleKey: "ext.market.emptyCatalog",
+    hintKey: "ext.market.emptyCatalogHint",
+    retryAction: "refresh_catalog",
+    showClearFilters: false,
+  };
+}
+
+// ── Retry plan ──────────────────────────────────────────────────────────────
+
+/**
+ * Plan recovery for a classified error (install row Retry, catalog Retry, etc.).
+ */
+export function planPluginMarketRetry(
+  kind: PluginMarketErrorKind,
+  op: PluginMarketOp = "install",
+): PluginMarketRetryPlan {
+  const softFail = pluginMarketIsSoftFailKind(kind);
+
+  if (kind === "cli_missing") {
+    return {
+      action: "open_runtime",
+      softFail: true,
+      canRetry: false,
+      label: "Open Runtime",
+    };
+  }
+  if (kind === "cli_too_old") {
+    return {
+      action: "update_cli",
+      softFail: true,
+      canRetry: false,
+      label: "Update CLI",
+    };
+  }
+  if (kind === "host_only") {
+    return {
+      action: "none",
+      softFail: true,
+      canRetry: false,
+      label: "",
+    };
+  }
+  if (kind === "offline" || kind === "network" || kind === "timeout") {
+    if (op === "install" || op === "update") {
+      return {
+        action: "retry_install",
+        softFail: false,
+        canRetry: true,
+        label: "Retry",
+      };
+    }
+    return {
+      action: "retry_load",
+      softFail: false,
+      canRetry: true,
+      label: "Retry",
+    };
+  }
+  if (kind === "already_installed") {
+    return {
+      action: "retry_install",
+      softFail: false,
+      canRetry: true,
+      label: "Reinstall",
+    };
+  }
+  if (kind === "parse" && (op === "list" || op === "sources")) {
+    return {
+      action: "refresh_catalog",
+      softFail: false,
+      canRetry: true,
+      label: "Refresh catalog",
+    };
+  }
+  if (op === "list" || op === "sources") {
+    return {
+      action: "retry_load",
+      softFail,
+      canRetry: true,
+      label: "Retry",
+    };
+  }
+  // install / update / validate default
+  return {
+    action: "retry_install",
+    softFail,
+    canRetry: true,
+    label: "Retry",
+  };
+}
+
+/**
+ * Plan from a retry action suggested by empty-state presentation.
+ */
+export function planPluginMarketEmptyRetry(
+  empty: Pick<PluginCatalogEmptyPresentation, "kind" | "retryAction" | "softFail">,
+): PluginMarketRetryPlan {
+  switch (empty.retryAction) {
+    case "open_runtime":
+      return {
+        action: "open_runtime",
+        softFail: true,
+        canRetry: false,
+        label: "Open Runtime",
+      };
+    case "update_cli":
+      return {
+        action: "update_cli",
+        softFail: true,
+        canRetry: false,
+        label: "Update CLI",
+      };
+    case "retry_load":
+      return {
+        action: "retry_load",
+        softFail: empty.softFail,
+        canRetry: true,
+        label: "Retry",
+      };
+    case "refresh_catalog":
+      return {
+        action: "refresh_catalog",
+        softFail: empty.softFail,
+        canRetry: true,
+        label: "Refresh catalog",
+      };
+    case "clear_filter":
+      return {
+        action: "clear_filter",
+        softFail: true,
+        canRetry: false,
+        label: "Clear filters",
+      };
+    case "retry_install":
+      return {
+        action: "retry_install",
+        softFail: empty.softFail,
+        canRetry: true,
+        label: "Retry",
+      };
+    case "none":
+    default:
+      return {
+        action: "none",
+        softFail: empty.softFail,
+        canRetry: false,
+        label: "",
+      };
+  }
+}
+
+// ── Structured row errors (install recovery) ────────────────────────────────
+
+/**
+ * Set a classified per-row install error (immutable).
+ * Empty key / empty message → no-op.
+ */
+export function setPluginMarketRowError(
+  errors: Record<string, PluginMarketRowError>,
+  rowKey: string,
+  err: unknown,
+  op: PluginMarketOp = "install",
+): Record<string, PluginMarketRowError> {
+  const key = (rowKey ?? "").trim();
+  if (!key) return errors;
+  const view = buildPluginMarketErrorView(err, op);
+  const message = view.detail || view.title;
+  if (!message.trim()) return errors;
+  const next: PluginMarketRowError = {
+    kind: view.kind,
+    message,
+    softFail: view.softFail,
+  };
+  const prev = errors[key];
+  if (
+    prev &&
+    prev.kind === next.kind &&
+    prev.message === next.message &&
+    prev.softFail === next.softFail
+  ) {
+    return errors;
+  }
+  return { ...errors, [key]: next };
+}
+
+/** Clear a per-row install error (immutable). */
+export function clearPluginMarketRowError(
+  errors: Record<string, PluginMarketRowError>,
+  rowKey: string,
+): Record<string, PluginMarketRowError> {
+  const key = (rowKey ?? "").trim();
+  if (!key || !(key in errors)) return errors;
+  const next = { ...errors };
+  delete next[key];
+  return next;
+}
+
+/**
+ * Whether a catalog-level load error should use the soft (warn) banner
+ * instead of a hard red action-error alert.
+ */
+export function pluginMarketLoadIsSoftFail(error: unknown): boolean {
+  if (error == null || !String(error).trim()) return false;
+  return pluginMarketIsSoftFailKind(classifyPluginMarketError(error, "list"));
+}
+
+/**
+ * Prefer classified title + optional detail for row error text.
+ * UI may still show raw detail under the kind chip.
+ */
+export function formatPluginMarketRowErrorMessage(
+  row: PluginMarketRowError,
+  opts?: { title?: string; includeDetail?: boolean },
+): string {
+  const title = (opts?.title ?? PLUGIN_MARKET_ERROR_TITLE_FALLBACK[row.kind]).trim();
+  const detail = (row.message ?? "").trim();
+  if (!opts?.includeDetail || !detail || detail === title) return title || detail;
+  // Avoid duplicating long CLI dumps when title already covers it.
+  if (detail.toLowerCase().includes(title.toLowerCase())) return detail;
+  return `${title}: ${detail}`;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -20657,6 +20657,12 @@ div.composer__input:empty::before {
   border: 1px solid color-mix(in srgb, #e05a5a 28%, transparent);
 }
 
+/* Soft-fail install/list gaps (CLI missing / too old) — warn, not hard red. */
+.ext-item__row-error--soft {
+  background: color-mix(in srgb, var(--warn, #c9a227) 12%, transparent);
+  border-color: color-mix(in srgb, var(--warn, #c9a227) 32%, transparent);
+}
+
 .ext-item__row-error--detail {
   margin: 8px 0;
 }


### PR DESCRIPTION
## Summary
- **PLUGIN-MARKET-PRO** pure helpers (`pluginMarketPro`): classify install/list/validate-adjacent errors; catalog empty states (loading / CLI missing / CLI too old / offline / error / no sources / empty catalog / empty filter / empty query); retry plans (retry install · retry load · refresh · open Runtime · clear filters).
- Marketplace UI: row-stuck install errors with **kind chip + hint + Retry** (soft-fail warn for CLI gaps); honest empty catalog CTAs; soft-fail when CLI missing/too old (no hard crash banner); empty Plugins → browse marketplace unchanged.
- CLI remains source of truth — no second App plugin store.
- i18n en / zh / zh-TW · CHANGELOG · GlassModal confirms only (no `window.confirm`).

## Test plan
- [x] `vitest run src/lib/pluginMarketPro.test.ts src/lib/pluginMarketplace.test.ts`
- [ ] Settings → Extensions → Marketplace: with CLI missing → soft empty + Open Runtime
- [ ] Force install failure → row error sticks + Retry; success clears
- [ ] Official filter with no matches / search with no matches → Clear filters
- [ ] Install confirm still GlassModal