### PR TITLE
feat(tasks): agent tasks panel pro filters and empty honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+#### Composer & chat
+- **Agent Tasks panel pro**: running / done / all status chips with counts, honest empty states (no tasks · filter empty + clear), snapshot-mode banner key when `subagentWorktreeSnapshotEnabled`, soft-fail stop / bind-cwd classification (no raw `Error:` dumps, no `window.confirm`); pure `tasksPanelPro` helpers + tests; en/zh/zh-TW
 #### Runtime / workflows
 - **Sandbox profile pro** (Settings → General → Permissions): polish OS sandbox presets (`off` / `workspace` / `read-only` / `strict` / `devbox`) with pure `sandboxProfile` helpers (spawn args/env, project resolve, danger confirm keys), **honest soft-fail** when CLI is missing/too old for `--sandbox` (flag omitted) or when the platform has no kernel enforcement (Windows honesty; Linux-only child-network note on macOS), Settings banners + recommended-workspace tip; Host soft-gates spawn flags on known-old CLI; i18n en/zh/zh-TW; `settingsCatalog`; tests
 - **Grok Build workflows** (Settings → Runtime → Tools): opt-in `workflowsEnabled` AppSettings toggle writes top-level `workflows_enabled` into independent agent-home `config.toml` (shared mode never rewrites `~/.grok`); honest copy that workflows run via CLI / Rhai (`workflow` tool, `/workflow`, `/workflows`) — **no in-app runner/editor**; read-only soft-fail discovery of `~/.grok/workflows` + project `.grok/workflows` names; command palette **Open workflows docs** / jump to settings; pure helpers + tests; `settingsCatalog` + en/zh/zh-TW

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -250,6 +250,11 @@ import {
   stoppableActivitySessions,
 } from "@/lib/agentActivity";
 import {
+  classifyTasksBindCwdError,
+  classifyTasksStopError,
+  type TasksBindCwdResult,
+} from "@/lib/tasksPanelPro";
+import {
   loadTrayBusyBadgePref,
   saveTrayBusyBadgePref,
 } from "@/lib/trayBusyBadgePref";
@@ -17798,32 +17803,55 @@ export default function App() {
                   projects.find((p) => p.id === row.projectId) || null;
                 void openSession(row, proj);
               }}
-              onStopSession={(id) => {
-                void (async () => {
-                  try {
-                    await api.sessionStop(id);
-                    setLiveMap((lm) =>
-                      settleStoppedSessionInLiveMap(lm, id),
-                    );
-                  } catch (e) {
-                    showToast(String(e), 4000);
-                  }
-                })();
+              onStopSession={async (id) => {
+                try {
+                  await api.sessionStop(id);
+                  setLiveMap((lm) => settleStoppedSessionInLiveMap(lm, id));
+                } catch (e) {
+                  const view = classifyTasksStopError(e);
+                  showToast(tr(view.titleKey as MessageKey), 4000);
+                  // Re-throw so the panel can also show an inline soft-fail hint.
+                  throw e;
+                }
               }}
               onStopAllSessions={stopAllBusySessions}
               onOpenDashboard={() => setAgentDashboardOpen(true)}
               activeCwd={activeProject?.path ?? null}
-              onOpenCwd={(cwd) => {
-                const wt = worktreeEntryForPath(cwd, gitWorktrees);
-                if (!wt) return;
-                void (async () => {
+              onOpenCwd={async (cwd): Promise<TasksBindCwdResult> => {
+                const path = (cwd || "").trim();
+                if (!path) {
+                  return { ok: false, kind: "empty_path" };
+                }
+                if (!api.isTauri()) {
+                  return { ok: false, kind: "host_only" };
+                }
+                if (
+                  activeProject?.path &&
+                  pathsEqual(path, activeProject.path)
+                ) {
+                  return { ok: false, kind: "already_active" };
+                }
+                const wt = worktreeEntryForPath(path, gitWorktrees);
+                if (!wt) {
+                  return { ok: false, kind: "not_worktree" };
+                }
+                try {
                   await switchToWorktree(wt);
                   const liveId =
                     viewingSessionIdRef.current || session.sessionId || null;
                   if (liveId) {
                     await markSessionWorktree(liveId, wt.path, wt.branch);
                   }
-                })();
+                  return { ok: true };
+                } catch (e) {
+                  const view = classifyTasksBindCwdError(e);
+                  showToast(tr(view.titleKey as MessageKey), 4000);
+                  return {
+                    ok: false,
+                    kind: view.kind,
+                    detail: view.detail || undefined,
+                  };
+                }
               }}
             />
           ) : null}

--- a/src/components/AgentTasksPanel.tsx
+++ b/src/components/AgentTasksPanel.tsx
@@ -8,6 +8,9 @@
  * linkage (explicit or inferred) is available.
  * Subagent cwd / worktree paths surface as a compact WT badge when present
  * in tool_step data — open as chat cwd, reveal, or copy (UI-only).
+ *
+ * Pro: running / done / all chips, honest empty (no tasks · filter empty),
+ * snapshot-mode banner, soft-fail stop / bind-cwd classification.
  */
 
 import { useCallback, useMemo, useState, type MouseEvent } from "react";
@@ -19,8 +22,6 @@ import {
   buildTaskTree,
   collectSessionTasks,
   countRunningTasks,
-  filterSessionTasks,
-  filterTaskTree,
   formatTaskCwdLabel,
   taskStatusMessageKey,
   taskTreeHasNesting,
@@ -36,6 +37,21 @@ import {
   stoppableActivitySessions,
   type ActivitySessionRow,
 } from "@/lib/agentActivity";
+import {
+  TASKS_PANEL_STATUS_FILTERS,
+  classifyTasksBindCwdError,
+  classifyTasksStopError,
+  countTasksByStatusFilter,
+  filterTaskTreePanel,
+  filterTasksPanelList,
+  normalizeTasksBindCwdResult,
+  resolveTasksPanelEmptyState,
+  tasksPanelHasActiveFilters,
+  tasksPanelSnapshotBannerKey,
+  tasksPanelStatusFilterLabelKey,
+  type TasksBindCwdResult,
+  type TasksPanelStatusFilter,
+} from "@/lib/tasksPanelPro";
 import {
   IconChevronDown,
   IconChevronRight,
@@ -57,7 +73,11 @@ export type AgentTasksPanelProps = {
   /** Other sessions that are busy / waiting (from liveMap). */
   activitySessions?: ActivitySessionRow[];
   onSelectSession?: (sessionId: string) => void;
-  onStopSession?: (sessionId: string) => void;
+  /**
+   * Stop a busy session. May throw or return a rejected promise — panel
+   * classifies soft-fail and surfaces an inline hint (no window.confirm).
+   */
+  onStopSession?: (sessionId: string) => void | Promise<void>;
   /** Stop every stoppable busy session (confirm lives in App). */
   onStopAllSessions?: () => void;
   /** Open the cross-session Agent dashboard (distinct from this tools panel). */
@@ -65,8 +85,11 @@ export type AgentTasksPanelProps = {
   /**
    * Bind this chat to a subagent cwd / worktree path (agent project cwd).
    * Parent owns project_add / session bind / toast.
+   * May return {@link TasksBindCwdResult} for soft-fail honesty.
    */
-  onOpenCwd?: (cwd: string) => void;
+  onOpenCwd?: (
+    cwd: string,
+  ) => void | TasksBindCwdResult | Promise<void | TasksBindCwdResult>;
   /** Current chat project path — used to mark cwd as already active. */
   activeCwd?: string | null;
   /**
@@ -108,7 +131,7 @@ function TaskRow({
   onToggleChildren?: () => void;
   /** When false, omit tree toggle/spacer so flat lists match pre-tree layout. */
   showTreeChrome?: boolean;
-  onOpenCwd?: (cwd: string) => void;
+  onOpenCwd?: AgentTasksPanelProps["onOpenCwd"];
   activeCwd?: string | null;
 }) {
   const [open, setOpen] = useState(false);
@@ -164,11 +187,40 @@ function TaskRow({
       e.preventDefault();
       if (!task.cwd || !onOpenCwd) return;
       if (cwdIsActive) {
-        setCwdActionHint(t("tasks.cwdAlreadyActive"));
+        const view = classifyTasksBindCwdError(null, { alreadyActive: true });
+        setCwdActionHint(t(view.titleKey as MessageKey));
         return;
       }
-      onOpenCwd(task.cwd);
-      setCwdActionHint(t("tasks.cwdOpened"));
+      if (!task.cwd.trim()) {
+        const view = classifyTasksBindCwdError(null, { emptyPath: true });
+        setCwdActionHint(t(view.titleKey as MessageKey));
+        return;
+      }
+      void (async () => {
+        try {
+          const raw = await onOpenCwd(task.cwd!);
+          const result = normalizeTasksBindCwdResult(raw);
+          if (result.ok) {
+            setCwdActionHint(t("tasks.cwdOpened"));
+            return;
+          }
+          const view = classifyTasksBindCwdError(result.detail ?? result.kind, {
+            alreadyActive: result.kind === "already_active",
+            emptyPath: result.kind === "empty_path",
+          });
+          // Prefer classified kind from result when detail is just a token.
+          if (result.kind && result.kind !== "other") {
+            setCwdActionHint(
+              t(`tasks.cwdBindErr.${result.kind}` as MessageKey),
+            );
+            return;
+          }
+          setCwdActionHint(t(view.titleKey as MessageKey));
+        } catch (err) {
+          const view = classifyTasksBindCwdError(err);
+          setCwdActionHint(t(view.titleKey as MessageKey));
+        }
+      })();
     },
     [cwdIsActive, onOpenCwd, t, task.cwd],
   );
@@ -377,7 +429,7 @@ function TaskTreeItem({
   t: TFn;
   depth?: number;
   showTreeChrome?: boolean;
-  onOpenCwd?: (cwd: string) => void;
+  onOpenCwd?: AgentTasksPanelProps["onOpenCwd"];
   activeCwd?: string | null;
 }) {
   const hasChildren = node.children.length > 0;
@@ -430,12 +482,30 @@ function ActivityRow({
   t,
   onSelect,
   onStop,
+  stopHint,
 }: {
   row: ActivitySessionRow;
   t: TFn;
   onSelect?: (sessionId: string) => void;
-  onStop?: (sessionId: string) => void;
+  onStop?: (sessionId: string) => void | Promise<void>;
+  stopHint?: string | null;
 }) {
+  const [localHint, setLocalHint] = useState<string | null>(null);
+  const hint = localHint ?? stopHint ?? null;
+
+  const handleStop = useCallback(() => {
+    if (!onStop) return;
+    setLocalHint(null);
+    void (async () => {
+      try {
+        await onStop(row.sessionId);
+      } catch (err) {
+        const view = classifyTasksStopError(err);
+        setLocalHint(t(view.titleKey as MessageKey));
+      }
+    })();
+  }, [onStop, row.sessionId, t]);
+
   return (
     <li
       className={
@@ -485,12 +555,13 @@ function ActivityRow({
           <button
             type="button"
             className="btn btn--ghost btn--sm"
-            onClick={() => onStop(row.sessionId)}
+            onClick={handleStop}
           >
             {t("tasks.activity.stop")}
           </button>
         ) : null}
       </div>
+      {hint ? <p className="agent-tasks__hint agent-tasks__hint--soft">{hint}</p> : null}
     </li>
   );
 }
@@ -509,6 +580,9 @@ export function AgentTasksPanel({
   subagentWorktreeSnapshotEnabled = false,
 }: AgentTasksPanelProps) {
   const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] =
+    useState<TasksPanelStatusFilter>("all");
+
   const tasks = useMemo(() => {
     const act = buildTurnActivity(messages);
     const fromTurn = tasksFromTurnActivity(act);
@@ -518,16 +592,34 @@ export function AgentTasksPanel({
     );
     return [...extraRunning, ...fromTurn];
   }, [messages]);
-  const filtered = useMemo(
-    () => filterSessionTasks(tasks, query),
-    [tasks, query],
+
+  const statusCounts = useMemo(
+    () => countTasksByStatusFilter(tasks),
+    [tasks],
   );
+
+  const listFilter = useMemo(
+    () => ({ query, status: statusFilter }),
+    [query, statusFilter],
+  );
+
+  const hasFilters = tasksPanelHasActiveFilters(listFilter);
+
+  const filteredFlat = useMemo(
+    () => filterTasksPanelList(tasks, listFilter),
+    [tasks, listFilter],
+  );
+
   const tree = useMemo(() => {
     // Build from full list so parent linkage survives filter, then filter tree.
     const full = buildTaskTree(tasks);
-    return filterTaskTree(full, query);
-  }, [tasks, query]);
-  const running = useMemo(() => countRunningTasks(filtered), [filtered]);
+    return filterTaskTreePanel(full, listFilter);
+  }, [tasks, listFilter]);
+
+  const running = useMemo(
+    () => countRunningTasks(filteredFlat),
+    [filteredFlat],
+  );
   const activeTree = useMemo(
     () => tree.filter((n) => taskTreeHasRunning(n)),
     [tree],
@@ -549,6 +641,34 @@ export function AgentTasksPanel({
     !!onStopAllSessions && stoppableSessions.length > 0;
   const hasTaskRows = activeTree.length > 0 || recentTree.length > 0;
   const showTreeChrome = taskTreeHasNesting(tree);
+
+  const emptyState = useMemo(
+    () =>
+      resolveTasksPanelEmptyState({
+        totalTasks: tasks.length,
+        filteredTasks: filteredFlat.length,
+        otherSessions: otherSessions.length,
+        hasFilters,
+      }),
+    [tasks.length, filteredFlat.length, otherSessions.length, hasFilters],
+  );
+
+  const snapshotNoteKey = tasksPanelSnapshotBannerKey(
+    subagentWorktreeSnapshotEnabled,
+  );
+
+  const clearFilters = useCallback(() => {
+    setQuery("");
+    setStatusFilter("all");
+  }, []);
+
+  const showFullEmpty =
+    !!emptyState && otherSessions.length === 0 && !hasTaskRows;
+  const showFilterEmptyInBody =
+    !!emptyState &&
+    emptyState.kind === "filter_empty" &&
+    !hasTaskRows &&
+    otherSessions.length > 0;
 
   return (
     <section className="agent-tasks" aria-label={t("tasks.title")}>
@@ -597,28 +717,79 @@ export function AgentTasksPanel({
         </div>
       </header>
 
-      {subagentWorktreeSnapshotEnabled ? (
+      {snapshotNoteKey ? (
         <p className="agent-tasks__snap-note" role="note">
-          {t("tasks.subagentWtSnapNote")}
+          {t(snapshotNoteKey)}
         </p>
       ) : null}
 
-      <div className="agent-tasks__search">
-        <input
-          type="search"
-          className="settings-input agent-tasks__search-input"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder={t("tasks.searchPlaceholder")}
-          autoComplete="off"
-          spellCheck={false}
-        />
+      <div className="agent-tasks__filters">
+        <div
+          className="agent-tasks__chips"
+          role="toolbar"
+          aria-label={t("tasks.filter.statusLabel")}
+        >
+          {TASKS_PANEL_STATUS_FILTERS.map((id) => {
+            const n = statusCounts[id];
+            // Hide zero-count chips except "all" and the active selection.
+            if (id !== "all" && n === 0 && statusFilter !== id) return null;
+            return (
+              <button
+                key={id}
+                type="button"
+                className={
+                  "agent-tasks__chip" + (statusFilter === id ? " is-active" : "")
+                }
+                aria-pressed={statusFilter === id}
+                onClick={() => setStatusFilter(id)}
+              >
+                <span>
+                  {t(tasksPanelStatusFilterLabelKey(id) as MessageKey)}
+                </span>
+                <span className="agent-tasks__chip-count">{n}</span>
+              </button>
+            );
+          })}
+        </div>
+        <div className="agent-tasks__search">
+          <input
+            type="search"
+            className="settings-input agent-tasks__search-input"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t("tasks.searchPlaceholder")}
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </div>
       </div>
 
-      {!hasTaskRows && otherSessions.length === 0 ? (
-        <div className="agent-tasks__empty">
-          <p className="agent-tasks__empty-title">{t("tasks.empty")}</p>
-          <p className="agent-tasks__empty-hint">{t("tasks.emptyHint")}</p>
+      {showFullEmpty && emptyState ? (
+        <div
+          className={
+            "agent-tasks__empty" +
+            (emptyState.kind === "filter_empty"
+              ? " agent-tasks__empty--filter"
+              : "")
+          }
+        >
+          <p className="agent-tasks__empty-title">
+            {t(emptyState.titleKey as MessageKey)}
+          </p>
+          {emptyState.hintKey ? (
+            <p className="agent-tasks__empty-hint">
+              {t(emptyState.hintKey as MessageKey)}
+            </p>
+          ) : null}
+          {emptyState.showClearFilters ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={clearFilters}
+            >
+              {t("tasks.clearFilters")}
+            </button>
+          ) : null}
         </div>
       ) : (
         <div className="agent-tasks__body">
@@ -638,6 +809,27 @@ export function AgentTasksPanel({
                   />
                 ))}
               </ul>
+            </div>
+          ) : null}
+          {showFilterEmptyInBody && emptyState ? (
+            <div className="agent-tasks__empty agent-tasks__empty--filter">
+              <p className="agent-tasks__empty-title">
+                {t(emptyState.titleKey as MessageKey)}
+              </p>
+              {emptyState.hintKey ? (
+                <p className="agent-tasks__empty-hint">
+                  {t(emptyState.hintKey as MessageKey)}
+                </p>
+              ) : null}
+              {emptyState.showClearFilters ? (
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  onClick={clearFilters}
+                >
+                  {t("tasks.clearFilters")}
+                </button>
+              ) : null}
             </div>
           ) : null}
           {activeTree.length > 0 ? (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -648,9 +648,53 @@ const en = {
   "tasks.collapseChildren": "Collapse nested tools",
   "tasks.parent": "Parent",
   "tasks.searchPlaceholder": "Filter tasks…",
+  "tasks.filter.statusLabel": "Filter by status",
+  "tasks.filter.all": "All",
+  "tasks.filter.running": "Running",
+  "tasks.filter.done": "Done",
+  "tasks.filterEmpty": "No tasks match these filters",
+  "tasks.filterEmptyHint":
+    "Clear the search or pick another status to see more tasks.",
+  "tasks.clearFilters": "Clear filters",
   "tasks.subagentWtSnapNote":
     "Subagent worktree snapshot is on (CLI 0.2.117+). Nested agents may use isolated worktree snapshots.",
   "tasks.openDashboard": "Agent dashboard",
+  "tasks.activity.stopErr.host_only": "Stop needs the desktop app",
+  "tasks.activity.stopErr.host_onlyHint":
+    "Session stop is only available in the Tauri host — not in the browser preview.",
+  "tasks.activity.stopErr.not_found": "Session not found",
+  "tasks.activity.stopErr.not_foundHint":
+    "That session may already be closed. Refresh the list or open another chat.",
+  "tasks.activity.stopErr.already_stopped": "Already idle",
+  "tasks.activity.stopErr.already_stoppedHint":
+    "Nothing to stop — the session is not busy right now.",
+  "tasks.activity.stopErr.timeout": "Stop timed out",
+  "tasks.activity.stopErr.timeoutHint":
+    "The host did not confirm stop in time. Try again or disconnect the session.",
+  "tasks.activity.stopErr.permission": "Stop not allowed",
+  "tasks.activity.stopErr.permissionHint":
+    "The host denied stopping this session. Check permissions and try again.",
+  "tasks.activity.stopErr.other": "Could not stop session",
+  "tasks.activity.stopErr.otherHint":
+    "Stop failed. Try again, or open the session and stop the turn from the composer.",
+  "tasks.cwdBindErr.empty_path": "No folder path",
+  "tasks.cwdBindErr.empty_pathHint":
+    "This tool row has no worktree path to open as the chat folder.",
+  "tasks.cwdBindErr.already_active": "Already this chat’s folder",
+  "tasks.cwdBindErr.already_activeHint":
+    "The chat is already bound to this path.",
+  "tasks.cwdBindErr.host_only": "Switch folder needs the desktop app",
+  "tasks.cwdBindErr.host_onlyHint":
+    "Binding a chat folder requires the Tauri host.",
+  "tasks.cwdBindErr.not_worktree": "Not a usable worktree path",
+  "tasks.cwdBindErr.not_worktreeHint":
+    "The path is missing or not a project folder the app can open.",
+  "tasks.cwdBindErr.switch_failed": "Could not switch chat folder",
+  "tasks.cwdBindErr.switch_failedHint":
+    "Project bind failed. Check the path exists and try again.",
+  "tasks.cwdBindErr.other": "Could not use as chat folder",
+  "tasks.cwdBindErr.otherHint":
+    "Binding failed. Reveal the path or copy it and open the project manually.",
   "dashboard.title": "Agent dashboard",
   "dashboard.hint":
     "Active and recent sessions across the app. Open a row to focus that chat. Distinct from Tasks (tools for the current turn).",
@@ -5726,9 +5770,47 @@ const zh: Record<MessageKey, string> = {
   "tasks.collapseChildren": "收起子工具",
   "tasks.parent": "父级",
   "tasks.searchPlaceholder": "筛选任务…",
+  "tasks.filter.statusLabel": "按状态筛选",
+  "tasks.filter.all": "全部",
+  "tasks.filter.running": "进行中",
+  "tasks.filter.done": "已完成",
+  "tasks.filterEmpty": "没有符合筛选条件的任务",
+  "tasks.filterEmptyHint": "清空搜索或换一个状态以查看更多任务。",
+  "tasks.clearFilters": "清除筛选",
   "tasks.subagentWtSnapNote":
     "子代理 worktree 快照已开启（CLI 0.2.117+）。嵌套 Agent 可能使用隔离 worktree 快照。",
   "tasks.openDashboard": "Agent 仪表盘",
+  "tasks.activity.stopErr.host_only": "停止会话需要桌面端应用",
+  "tasks.activity.stopErr.host_onlyHint":
+    "会话停止仅在 Tauri 桌面端可用，浏览器预览中不可用。",
+  "tasks.activity.stopErr.not_found": "找不到该会话",
+  "tasks.activity.stopErr.not_foundHint":
+    "会话可能已关闭。请刷新列表或打开其他对话。",
+  "tasks.activity.stopErr.already_stopped": "已空闲",
+  "tasks.activity.stopErr.already_stoppedHint":
+    "无需停止 — 该会话当前不在忙碌状态。",
+  "tasks.activity.stopErr.timeout": "停止超时",
+  "tasks.activity.stopErr.timeoutHint":
+    "主机未在时限内确认停止。请重试或断开该会话。",
+  "tasks.activity.stopErr.permission": "无权停止",
+  "tasks.activity.stopErr.permissionHint":
+    "主机拒绝停止此会话。请检查权限后重试。",
+  "tasks.activity.stopErr.other": "无法停止会话",
+  "tasks.activity.stopErr.otherHint":
+    "停止失败。请重试，或打开该会话并从输入框停止本轮。",
+  "tasks.cwdBindErr.empty_path": "没有可用路径",
+  "tasks.cwdBindErr.empty_pathHint": "此工具行没有可绑定为对话目录的 worktree 路径。",
+  "tasks.cwdBindErr.already_active": "已是当前对话目录",
+  "tasks.cwdBindErr.already_activeHint": "对话已绑定到该路径。",
+  "tasks.cwdBindErr.host_only": "切换目录需要桌面端应用",
+  "tasks.cwdBindErr.host_onlyHint": "绑定对话目录需要 Tauri 桌面端。",
+  "tasks.cwdBindErr.not_worktree": "不是可用的 worktree 路径",
+  "tasks.cwdBindErr.not_worktreeHint": "路径缺失，或应用无法打开为项目目录。",
+  "tasks.cwdBindErr.switch_failed": "无法切换对话目录",
+  "tasks.cwdBindErr.switch_failedHint": "项目绑定失败。请确认路径存在后重试。",
+  "tasks.cwdBindErr.other": "无法用作对话目录",
+  "tasks.cwdBindErr.otherHint":
+    "绑定失败。可显示路径或复制后手动打开项目。",
   "dashboard.title": "Agent 仪表盘",
   "dashboard.hint":
     "应用内活跃与最近会话。点击一行可聚焦该对话。与「任务」面板（当前回合工具）不同。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -608,9 +608,48 @@ export const zhTW: Record<MessageKey, string> = {
   "tasks.collapseChildren": "收合子工具",
   "tasks.parent": "父級",
   "tasks.searchPlaceholder": "篩選任務…",
+  "tasks.filter.statusLabel": "依狀態篩選",
+  "tasks.filter.all": "全部",
+  "tasks.filter.running": "進行中",
+  "tasks.filter.done": "已完成",
+  "tasks.filterEmpty": "沒有符合篩選條件的任務",
+  "tasks.filterEmptyHint": "清空搜尋或換一個狀態以查看更多任務。",
+  "tasks.clearFilters": "清除篩選",
   "tasks.subagentWtSnapNote":
     "子代理 worktree 快照已開啟（CLI 0.2.117+）。巢狀 Agent 可能使用隔離 worktree 快照。",
   "tasks.openDashboard": "Agent 儀表板",
+  "tasks.activity.stopErr.host_only": "停止工作階段需要桌面端應用程式",
+  "tasks.activity.stopErr.host_onlyHint":
+    "工作階段停止僅在 Tauri 桌面端可用，瀏覽器預覽中不可用。",
+  "tasks.activity.stopErr.not_found": "找不到該工作階段",
+  "tasks.activity.stopErr.not_foundHint":
+    "工作階段可能已關閉。請重新整理列表或開啟其他對話。",
+  "tasks.activity.stopErr.already_stopped": "已閒置",
+  "tasks.activity.stopErr.already_stoppedHint":
+    "無需停止 — 該工作階段目前不在忙碌狀態。",
+  "tasks.activity.stopErr.timeout": "停止逾時",
+  "tasks.activity.stopErr.timeoutHint":
+    "主機未在時限內確認停止。請重試或中斷該工作階段。",
+  "tasks.activity.stopErr.permission": "無權停止",
+  "tasks.activity.stopErr.permissionHint":
+    "主機拒絕停止此工作階段。請檢查權限後重試。",
+  "tasks.activity.stopErr.other": "無法停止工作階段",
+  "tasks.activity.stopErr.otherHint":
+    "停止失敗。請重試，或開啟該工作階段並從輸入框停止本回合。",
+  "tasks.cwdBindErr.empty_path": "沒有可用路徑",
+  "tasks.cwdBindErr.empty_pathHint":
+    "此工具列沒有可綁定為對話目錄的 worktree 路徑。",
+  "tasks.cwdBindErr.already_active": "已是目前對話目錄",
+  "tasks.cwdBindErr.already_activeHint": "對話已綁定到該路徑。",
+  "tasks.cwdBindErr.host_only": "切換目錄需要桌面端應用程式",
+  "tasks.cwdBindErr.host_onlyHint": "綁定對話目錄需要 Tauri 桌面端。",
+  "tasks.cwdBindErr.not_worktree": "不是可用的 worktree 路徑",
+  "tasks.cwdBindErr.not_worktreeHint": "路徑缺失，或應用程式無法開啟為專案目錄。",
+  "tasks.cwdBindErr.switch_failed": "無法切換對話目錄",
+  "tasks.cwdBindErr.switch_failedHint": "專案綁定失敗。請確認路徑存在後重試。",
+  "tasks.cwdBindErr.other": "無法用作對話目錄",
+  "tasks.cwdBindErr.otherHint":
+    "綁定失敗。可顯示路徑或複製後手動開啟專案。",
   "dashboard.title": "Agent 儀表板",
   "dashboard.hint":
     "應用程式內活躍與最近工作階段。點一列可聚焦該對話。與「任務」面板（目前回合工具）不同。",

--- a/src/lib/tasksPanelPro.test.ts
+++ b/src/lib/tasksPanelPro.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+import type { AgentTask, TaskTreeNode } from "./sessionTasks";
+import {
+  TASKS_PANEL_SNAPSHOT_NOTE_KEY,
+  TASKS_PANEL_STATUS_FILTERS,
+  classifyTasksBindCwdError,
+  classifyTasksStopError,
+  countTaskTreeNodes,
+  countTasksByStatusFilter,
+  filterTaskTreeByStatus,
+  filterTaskTreePanel,
+  filterTasksByStatus,
+  filterTasksPanelList,
+  isTasksPanelDoneStatus,
+  normalizeTasksBindCwdResult,
+  resolveTasksPanelEmptyState,
+  taskMatchesStatusFilter,
+  taskTreeMatchesStatusFilter,
+  tasksPanelBucketForStatus,
+  tasksPanelHasActiveFilters,
+  tasksPanelSnapshotBannerKey,
+  tasksPanelStatusFilterLabelKey,
+} from "./tasksPanelPro";
+
+function task(
+  partial: Partial<AgentTask> & Pick<AgentTask, "id" | "status">,
+): AgentTask {
+  return {
+    name: partial.name ?? partial.id,
+    kind: partial.kind ?? "tool",
+    longRunning: partial.longRunning ?? false,
+    ...partial,
+  };
+}
+
+const TASKS: AgentTask[] = [
+  task({ id: "r1", status: "running", name: "spawn_subagent", kind: "spawn_subagent" }),
+  task({ id: "r2", status: "running", name: "bash build", kind: "bash", detail: "pnpm test" }),
+  task({ id: "d1", status: "completed", name: "read_file", kind: "read_file", path: "/a.ts" }),
+  task({ id: "d2", status: "failed", name: "write_file", kind: "write_file" }),
+  task({ id: "d3", status: "cancelled", name: "monitor", kind: "monitor" }),
+];
+
+describe("status chip buckets", () => {
+  it("maps running vs done", () => {
+    expect(isTasksPanelDoneStatus("running")).toBe(false);
+    expect(isTasksPanelDoneStatus("completed")).toBe(true);
+    expect(isTasksPanelDoneStatus("failed")).toBe(true);
+    expect(isTasksPanelDoneStatus("cancelled")).toBe(true);
+    expect(tasksPanelBucketForStatus("running")).toBe("running");
+    expect(tasksPanelBucketForStatus("failed")).toBe("done");
+  });
+
+  it("matches filter chips", () => {
+    expect(taskMatchesStatusFilter(TASKS[0]!, "all")).toBe(true);
+    expect(taskMatchesStatusFilter(TASKS[0]!, "running")).toBe(true);
+    expect(taskMatchesStatusFilter(TASKS[0]!, "done")).toBe(false);
+    expect(taskMatchesStatusFilter(TASKS[2]!, "done")).toBe(true);
+    expect(taskMatchesStatusFilter(null, "running")).toBe(false);
+  });
+
+  it("counts all / running / done", () => {
+    const counts = countTasksByStatusFilter(TASKS);
+    expect(counts).toEqual({ all: 5, running: 2, done: 3 });
+    expect(countTasksByStatusFilter([])).toEqual({
+      all: 0,
+      running: 0,
+      done: 0,
+    });
+    expect(TASKS_PANEL_STATUS_FILTERS).toEqual(["all", "running", "done"]);
+  });
+
+  it("filters by status chip", () => {
+    expect(filterTasksByStatus(TASKS, "running").map((t) => t.id)).toEqual([
+      "r1",
+      "r2",
+    ]);
+    expect(filterTasksByStatus(TASKS, "done").map((t) => t.id)).toEqual([
+      "d1",
+      "d2",
+      "d3",
+    ]);
+    expect(filterTasksByStatus(TASKS, "all")).toHaveLength(5);
+    expect(filterTasksByStatus(TASKS, null)).toHaveLength(5);
+  });
+
+  it("combines status + free-text query", () => {
+    expect(
+      filterTasksPanelList(TASKS, { status: "running", query: "pnpm" }).map(
+        (t) => t.id,
+      ),
+    ).toEqual(["r2"]);
+    expect(
+      filterTasksPanelList(TASKS, { status: "done", query: "read" }).map(
+        (t) => t.id,
+      ),
+    ).toEqual(["d1"]);
+    expect(
+      filterTasksPanelList(TASKS, { status: "running", query: "read" }),
+    ).toHaveLength(0);
+    expect(filterTasksPanelList(TASKS, "WRITE").map((t) => t.id)).toEqual([
+      "d2",
+    ]);
+    expect(filterTasksPanelList([], { status: "running" })).toEqual([]);
+  });
+
+  it("detects active filters", () => {
+    expect(tasksPanelHasActiveFilters(undefined)).toBe(false);
+    expect(tasksPanelHasActiveFilters({ status: "all", query: "" })).toBe(
+      false,
+    );
+    expect(tasksPanelHasActiveFilters({ status: "running" })).toBe(true);
+    expect(tasksPanelHasActiveFilters({ query: "bash" })).toBe(true);
+  });
+
+  it("maps chip labels to i18n keys", () => {
+    expect(tasksPanelStatusFilterLabelKey("all")).toBe("tasks.filter.all");
+    expect(tasksPanelStatusFilterLabelKey("running")).toBe(
+      "tasks.filter.running",
+    );
+    expect(tasksPanelStatusFilterLabelKey("done")).toBe("tasks.filter.done");
+  });
+});
+
+describe("task tree status filter", () => {
+  const forest: TaskTreeNode[] = [
+    {
+      task: task({
+        id: "spawn",
+        status: "running",
+        name: "spawn",
+        kind: "spawn_subagent",
+        longRunning: true,
+      }),
+      children: [
+        {
+          task: task({
+            id: "child-done",
+            status: "completed",
+            name: "child read",
+            parentId: "spawn",
+          }),
+          children: [],
+        },
+      ],
+    },
+    {
+      task: task({ id: "solo", status: "failed", name: "solo fail" }),
+      children: [],
+    },
+  ];
+
+  it("keeps ancestors when a child matches", () => {
+    const done = filterTaskTreeByStatus(forest, "done");
+    expect(done.map((n) => n.task.id)).toEqual(["spawn", "solo"]);
+    expect(done[0]!.children.map((c) => c.task.id)).toEqual(["child-done"]);
+    expect(taskTreeMatchesStatusFilter(forest[0]!, "done")).toBe(true);
+    expect(taskTreeMatchesStatusFilter(forest[0]!, "running")).toBe(true);
+  });
+
+  it("filters running-only tree", () => {
+    const running = filterTaskTreeByStatus(forest, "running");
+    expect(running.map((n) => n.task.id)).toEqual(["spawn"]);
+    // Child completed is dropped when status is running-only.
+    expect(running[0]!.children).toEqual([]);
+  });
+
+  it("combines tree status + query", () => {
+    const hit = filterTaskTreePanel(forest, {
+      status: "done",
+      query: "solo",
+    });
+    expect(hit.map((n) => n.task.id)).toEqual(["solo"]);
+    expect(countTaskTreeNodes(forest)).toBe(3);
+  });
+});
+
+describe("empty honesty", () => {
+  it("shows no_tasks when stream has nothing", () => {
+    expect(
+      resolveTasksPanelEmptyState({
+        totalTasks: 0,
+        filteredTasks: 0,
+      }),
+    ).toEqual({
+      kind: "no_tasks",
+      titleKey: "tasks.empty",
+      hintKey: "tasks.emptyHint",
+      showClearFilters: false,
+    });
+  });
+
+  it("shows filter_empty when chips/query hide all tasks", () => {
+    expect(
+      resolveTasksPanelEmptyState({
+        totalTasks: 4,
+        filteredTasks: 0,
+        hasFilters: true,
+      }),
+    ).toEqual({
+      kind: "filter_empty",
+      titleKey: "tasks.filterEmpty",
+      hintKey: "tasks.filterEmptyHint",
+      showClearFilters: true,
+    });
+  });
+
+  it("returns null when filtered rows exist", () => {
+    expect(
+      resolveTasksPanelEmptyState({
+        totalTasks: 4,
+        filteredTasks: 2,
+        hasFilters: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when only other busy sessions exist (no local tasks)", () => {
+    expect(
+      resolveTasksPanelEmptyState({
+        totalTasks: 0,
+        filteredTasks: 0,
+        otherSessions: 2,
+      }),
+    ).toBeNull();
+  });
+
+  it("filter_empty when chips hide tools even if other sessions exist", () => {
+    // UI may still render other sessions above the filter-empty block.
+    expect(
+      resolveTasksPanelEmptyState({
+        totalTasks: 3,
+        filteredTasks: 0,
+        otherSessions: 1,
+        hasFilters: true,
+      }),
+    ).toEqual({
+      kind: "filter_empty",
+      titleKey: "tasks.filterEmpty",
+      hintKey: "tasks.filterEmptyHint",
+      showClearFilters: true,
+    });
+  });
+});
+
+describe("snapshot banner key", () => {
+  it("returns note key only when enabled", () => {
+    expect(tasksPanelSnapshotBannerKey(true)).toBe(
+      TASKS_PANEL_SNAPSHOT_NOTE_KEY,
+    );
+    expect(tasksPanelSnapshotBannerKey(false)).toBeNull();
+    expect(tasksPanelSnapshotBannerKey(null)).toBeNull();
+    expect(tasksPanelSnapshotBannerKey(undefined)).toBeNull();
+    expect(TASKS_PANEL_SNAPSHOT_NOTE_KEY).toBe("tasks.subagentWtSnapNote");
+  });
+});
+
+describe("stop soft-fail", () => {
+  it("classifies host-only / not-found / already-stopped / timeout", () => {
+    expect(classifyTasksStopError("need_tauri: desktop app").kind).toBe(
+      "host_only",
+    );
+    expect(classifyTasksStopError("session not found").kind).toBe("not_found");
+    expect(classifyTasksStopError("already stopped").kind).toBe(
+      "already_stopped",
+    );
+    expect(classifyTasksStopError("operation timed out").kind).toBe("timeout");
+    expect(classifyTasksStopError("permission denied").kind).toBe("permission");
+    expect(classifyTasksStopError("boom").kind).toBe("other");
+  });
+
+  it("marks capability gaps as softFail", () => {
+    expect(classifyTasksStopError("need_tauri").softFail).toBe(true);
+    expect(classifyTasksStopError("unknown session").softFail).toBe(true);
+    expect(classifyTasksStopError("already idle").softFail).toBe(true);
+    expect(classifyTasksStopError("timeout").softFail).toBe(true);
+    expect(classifyTasksStopError("weird crash").softFail).toBe(false);
+    expect(classifyTasksStopError("permission denied").softFail).toBe(false);
+  });
+
+  it("emits i18n key paths", () => {
+    const v = classifyTasksStopError("timeout waiting");
+    expect(v.titleKey).toBe("tasks.activity.stopErr.timeout");
+    expect(v.hintKey).toBe("tasks.activity.stopErr.timeoutHint");
+  });
+});
+
+describe("bind-cwd soft-fail", () => {
+  it("handles already_active / empty_path opts", () => {
+    expect(
+      classifyTasksBindCwdError(null, { alreadyActive: true }).kind,
+    ).toBe("already_active");
+    expect(classifyTasksBindCwdError(null, { emptyPath: true }).kind).toBe(
+      "empty_path",
+    );
+    expect(
+      classifyTasksBindCwdError(null, { alreadyActive: true }).softFail,
+    ).toBe(true);
+  });
+
+  it("classifies host-only / not_worktree / switch_failed", () => {
+    expect(classifyTasksBindCwdError("need_tauri host").kind).toBe(
+      "host_only",
+    );
+    expect(classifyTasksBindCwdError("not a worktree path").kind).toBe(
+      "not_worktree",
+    );
+    expect(classifyTasksBindCwdError("project_add failed: EACCES").kind).toBe(
+      "switch_failed",
+    );
+    expect(classifyTasksBindCwdError("need_tauri").softFail).toBe(true);
+    expect(classifyTasksBindCwdError("switch failed").softFail).toBe(false);
+  });
+
+  it("normalizes void / result returns", () => {
+    expect(normalizeTasksBindCwdResult(undefined)).toEqual({ ok: true });
+    expect(normalizeTasksBindCwdResult(null)).toEqual({ ok: true });
+    expect(normalizeTasksBindCwdResult({ ok: true })).toEqual({ ok: true });
+    expect(
+      normalizeTasksBindCwdResult({
+        ok: false,
+        kind: "not_worktree",
+        detail: "x",
+      }),
+    ).toEqual({ ok: false, kind: "not_worktree", detail: "x" });
+  });
+});

--- a/src/lib/tasksPanelPro.ts
+++ b/src/lib/tasksPanelPro.ts
@@ -1,0 +1,536 @@
+/**
+ * TASKS-PANEL-PRO — pure helpers for the Agent Tasks side panel:
+ * running / done / all status chips, empty honesty (no tasks vs filter empty),
+ * snapshot-mode banner keys, and soft-fail classification for stop / bind-cwd.
+ *
+ * Builds on `sessionTasks` tree helpers. No DOM / Tauri side effects.
+ * Never invents tasks or kill capability over ACP.
+ */
+
+import {
+  filterSessionTasks,
+  filterTaskTree,
+  type AgentTask,
+  type AgentTaskStatus,
+  type TaskTreeNode,
+} from "@/lib/sessionTasks";
+
+// ── Status chips ─────────────────────────────────────────────────────────────
+
+/**
+ * First-class status chip buckets for the Tasks panel.
+ * `done` = terminal (completed | failed | cancelled).
+ */
+export type TasksPanelStatusFilter = "all" | "running" | "done";
+
+/** Ordered chip list (All · Running · Done). */
+export const TASKS_PANEL_STATUS_FILTERS: readonly TasksPanelStatusFilter[] = [
+  "all",
+  "running",
+  "done",
+] as const;
+
+/** Per-chip counts; `all` is total length. */
+export type TasksPanelStatusCounts = Record<TasksPanelStatusFilter, number>;
+
+/** True when status is terminal (not running). */
+export function isTasksPanelDoneStatus(
+  status: AgentTaskStatus | string | null | undefined,
+): boolean {
+  const s = String(status ?? "")
+    .toLowerCase()
+    .trim();
+  return s !== "" && s !== "running";
+}
+
+/** Map a task status into a chip bucket (`running` | `done`). */
+export function tasksPanelBucketForStatus(
+  status: AgentTaskStatus | string | null | undefined,
+): Exclude<TasksPanelStatusFilter, "all"> {
+  return isTasksPanelDoneStatus(status) ? "done" : "running";
+}
+
+/** Whether a task matches the status chip (`all` always matches). */
+export function taskMatchesStatusFilter(
+  task: Pick<AgentTask, "status"> | null | undefined,
+  filter: TasksPanelStatusFilter | null | undefined,
+): boolean {
+  if (!task) return false;
+  const f = filter ?? "all";
+  if (f === "all") return true;
+  return tasksPanelBucketForStatus(task.status) === f;
+}
+
+/** Count tasks per chip bucket. */
+export function countTasksByStatusFilter(
+  tasks: readonly Pick<AgentTask, "status">[],
+): TasksPanelStatusCounts {
+  const counts: TasksPanelStatusCounts = {
+    all: tasks.length,
+    running: 0,
+    done: 0,
+  };
+  for (const t of tasks) {
+    counts[tasksPanelBucketForStatus(t.status)] += 1;
+  }
+  return counts;
+}
+
+/** Filter flat task list by status chip only. */
+export function filterTasksByStatus<T extends Pick<AgentTask, "status">>(
+  tasks: readonly T[],
+  filter: TasksPanelStatusFilter | null | undefined,
+): T[] {
+  const f = filter ?? "all";
+  if (f === "all") return tasks as T[];
+  return tasks.filter((t) => taskMatchesStatusFilter(t, f));
+}
+
+/** Combined free-text + status chip filter for a flat list. */
+export interface TasksPanelListFilter {
+  query?: string | null;
+  status?: TasksPanelStatusFilter | null;
+}
+
+/**
+ * Filter tasks by status chip and free-text query (AND).
+ * Reuses {@link filterSessionTasks} for query; does not invent rows.
+ */
+export function filterTasksPanelList<T extends AgentTask>(
+  tasks: readonly T[],
+  filter: TasksPanelListFilter | string = {},
+): T[] {
+  const opts: TasksPanelListFilter =
+    typeof filter === "string" ? { query: filter } : filter ?? {};
+  let out = filterTasksByStatus(tasks, opts.status ?? "all") as T[];
+  const q = (opts.query ?? "").trim();
+  if (q) {
+    out = filterSessionTasks(out, q) as T[];
+  }
+  return out;
+}
+
+/**
+ * True when status chip or free-text narrows the list
+ * (used for filter-empty honesty and clear-filters CTA).
+ */
+export function tasksPanelHasActiveFilters(
+  filter: TasksPanelListFilter | null | undefined,
+): boolean {
+  if (!filter) return false;
+  const status = filter.status ?? "all";
+  const q = (filter.query ?? "").trim();
+  return status !== "all" || q.length > 0;
+}
+
+/**
+ * Whether a task tree node (or any descendant) matches the status chip.
+ * Used so parents of matching children stay visible when nested.
+ */
+export function taskTreeMatchesStatusFilter(
+  node: TaskTreeNode,
+  filter: TasksPanelStatusFilter | null | undefined,
+): boolean {
+  const f = filter ?? "all";
+  if (f === "all") return true;
+  if (taskMatchesStatusFilter(node.task, f)) return true;
+  return node.children.some((c) => taskTreeMatchesStatusFilter(c, f));
+}
+
+/**
+ * Filter a task forest by status chip; keeps ancestors of matches.
+ * Empty / `all` returns nodes unchanged (same references when possible).
+ */
+export function filterTaskTreeByStatus(
+  nodes: TaskTreeNode[],
+  filter: TasksPanelStatusFilter | null | undefined,
+): TaskTreeNode[] {
+  const f = filter ?? "all";
+  if (f === "all") return nodes;
+
+  const walk = (node: TaskTreeNode): TaskTreeNode | null => {
+    const kids = node.children
+      .map(walk)
+      .filter((n): n is TaskTreeNode => n != null);
+    if (taskMatchesStatusFilter(node.task, f) || kids.length > 0) {
+      return { task: node.task, children: kids };
+    }
+    return null;
+  };
+
+  return nodes.map(walk).filter((n): n is TaskTreeNode => n != null);
+}
+
+/**
+ * Filter a task forest by status chip + free-text query (AND).
+ * Query uses {@link filterTaskTree} (keeps ancestors of text matches).
+ */
+export function filterTaskTreePanel(
+  nodes: TaskTreeNode[],
+  filter: TasksPanelListFilter | string = {},
+): TaskTreeNode[] {
+  const opts: TasksPanelListFilter =
+    typeof filter === "string" ? { query: filter } : filter ?? {};
+  let out = filterTaskTreeByStatus(nodes, opts.status ?? "all");
+  const q = (opts.query ?? "").trim();
+  if (q) {
+    out = filterTaskTree(out, q);
+  }
+  return out;
+}
+
+/** Count root-level task ids in a forest (each root once). */
+export function countTaskTreeRoots(nodes: readonly TaskTreeNode[]): number {
+  return nodes.length;
+}
+
+/**
+ * Count all task nodes in a forest (roots + nested children).
+ * Used for chip counts when nested tools exist.
+ */
+export function countTaskTreeNodes(nodes: readonly TaskTreeNode[]): number {
+  let n = 0;
+  const walk = (node: TaskTreeNode) => {
+    n += 1;
+    for (const c of node.children) walk(c);
+  };
+  for (const root of nodes) walk(root);
+  return n;
+}
+
+// ── Empty honesty ────────────────────────────────────────────────────────────
+
+/** Contextual empty surfaces for the tasks list body. */
+export type TasksPanelEmptyKind = "no_tasks" | "filter_empty";
+
+export type TasksPanelEmptyPresentation = {
+  kind: TasksPanelEmptyKind;
+  /** Primary title i18n key under tasks.*. */
+  titleKey: string;
+  /** Optional hint i18n key. */
+  hintKey: string | null;
+  /** Offer clear-filters CTA. */
+  showClearFilters: boolean;
+};
+
+export type TasksPanelEmptyInput = {
+  /** Total tasks from session (pre status/query filter). */
+  totalTasks: number;
+  /** Visible tasks after filters (flat or root count — same honesty). */
+  filteredTasks: number;
+  /**
+   * Other busy sessions shown in the activity section.
+   * When > 0 and there are no local tasks, the panel still has content —
+   * returns `null` so the body can render other sessions without a full empty.
+   * Filter-empty still returns when local tasks exist but chips hid them all
+   * (caller may show other sessions + a filter-empty block together).
+   */
+  otherSessions?: number;
+  /** Status chip or free-text active. */
+  hasFilters?: boolean;
+};
+
+/**
+ * Resolve which empty surface to show for the local tasks list.
+ * Returns `null` when filtered task rows should render.
+ *
+ * Priority:
+ * 1. filtered tasks > 0 → null (render list)
+ * 2. total == 0 → no_tasks (unless otherSessions > 0 → null, body has content)
+ * 3. total > 0 + filters + filtered == 0 → filter_empty
+ *
+ * Never invents “running” work when the stream is idle.
+ */
+export function resolveTasksPanelEmptyState(
+  input: TasksPanelEmptyInput,
+): TasksPanelEmptyPresentation | null {
+  const total = Math.max(0, Number(input.totalTasks) || 0);
+  const filtered = Math.max(0, Number(input.filteredTasks) || 0);
+  const other = Math.max(0, Number(input.otherSessions) || 0);
+  const hasFilters = Boolean(input.hasFilters);
+
+  if (filtered > 0) return null;
+
+  if (total === 0) {
+    // Other busy sessions alone are enough content for the body.
+    if (other > 0) return null;
+    return {
+      kind: "no_tasks",
+      titleKey: "tasks.empty",
+      hintKey: "tasks.emptyHint",
+      showClearFilters: false,
+    };
+  }
+
+  if (hasFilters) {
+    return {
+      kind: "filter_empty",
+      titleKey: "tasks.filterEmpty",
+      hintKey: "tasks.filterEmptyHint",
+      showClearFilters: true,
+    };
+  }
+
+  // Total > 0 but filtered 0 without filters should not happen; soft fallback.
+  if (other > 0) return null;
+  return {
+    kind: "no_tasks",
+    titleKey: "tasks.empty",
+    hintKey: "tasks.emptyHint",
+    showClearFilters: false,
+  };
+}
+
+// ── Snapshot mode banner ─────────────────────────────────────────────────────
+
+/** i18n key for the subagent worktree snapshot note (when enabled). */
+export const TASKS_PANEL_SNAPSHOT_NOTE_KEY = "tasks.subagentWtSnapNote";
+
+/**
+ * Banner copy key when subagent worktree snapshot mode is on.
+ * Returns `null` when disabled / unset — UI omits the note.
+ */
+export function tasksPanelSnapshotBannerKey(
+  enabled: boolean | null | undefined,
+): typeof TASKS_PANEL_SNAPSHOT_NOTE_KEY | null {
+  return enabled === true ? TASKS_PANEL_SNAPSHOT_NOTE_KEY : null;
+}
+
+/** Label i18n key for a status chip. */
+export function tasksPanelStatusFilterLabelKey(
+  filter: TasksPanelStatusFilter,
+): string {
+  switch (filter) {
+    case "running":
+      return "tasks.filter.running";
+    case "done":
+      return "tasks.filter.done";
+    case "all":
+    default:
+      return "tasks.filter.all";
+  }
+}
+
+// ── Soft-fail: stop session ──────────────────────────────────────────────────
+
+/** Stable failure kinds for Tasks-panel session stop. */
+export type TasksStopErrorKind =
+  | "host_only"
+  | "not_found"
+  | "already_stopped"
+  | "timeout"
+  | "permission"
+  | "other";
+
+export type TasksStopErrorView = {
+  kind: TasksStopErrorKind;
+  /** Soft-fail: capability / already-idle — warn, do not escalate. */
+  softFail: boolean;
+  /** Short detail excerpt for UI (no secrets expected). */
+  detail: string;
+  /** i18n title key under tasks.activity.stopErr.*. */
+  titleKey: string;
+  /** i18n hint key under tasks.activity.stopErr.*. */
+  hintKey: string;
+};
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as {
+      code?: unknown;
+      message?: unknown;
+      reason?: unknown;
+      error?: unknown;
+    };
+    const parts = [o.code, o.message, o.reason, o.error]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+/**
+ * Classify a sessionStop / stop-all failure for soft-fail presentation.
+ * Soft-fail: host-only, already idle, missing session, timeout.
+ */
+export function classifyTasksStopError(err: unknown): TasksStopErrorView {
+  const raw = errText(err);
+  const detail = raw.trim().slice(0, 280);
+  const s = raw.toLowerCase();
+
+  let kind: TasksStopErrorKind = "other";
+
+  if (
+    /need[_\s-]?tauri|desktop\s+app|host[_\s-]?only|not\s+available\s+in\s+browser|webview\s+only/i.test(
+      s,
+    )
+  ) {
+    kind = "host_only";
+  } else if (
+    /not\s+found|unknown\s+session|no\s+such\s+session|session[_\s-]?missing|enoent/i.test(
+      s,
+    )
+  ) {
+    kind = "not_found";
+  } else if (
+    /already\s+(stopped|idle|settled)|not\s+(running|busy|active)|nothing\s+to\s+stop|idle/i.test(
+      s,
+    )
+  ) {
+    kind = "already_stopped";
+  } else if (/timed?\s*out|timeout/i.test(s)) {
+    kind = "timeout";
+  } else if (
+    /permission|eacces|eperm|denied|unauthorized|forbidden/i.test(s)
+  ) {
+    kind = "permission";
+  } else if (raw.trim()) {
+    kind = "other";
+  }
+
+  const softFail =
+    kind === "host_only" ||
+    kind === "not_found" ||
+    kind === "already_stopped" ||
+    kind === "timeout";
+
+  return {
+    kind,
+    softFail,
+    detail,
+    titleKey: `tasks.activity.stopErr.${kind}`,
+    hintKey: `tasks.activity.stopErr.${kind}Hint`,
+  };
+}
+
+// ── Soft-fail: bind cwd / open worktree ──────────────────────────────────────
+
+/** Stable failure kinds for “use as chat folder” bind. */
+export type TasksBindCwdErrorKind =
+  | "empty_path"
+  | "already_active"
+  | "host_only"
+  | "not_worktree"
+  | "switch_failed"
+  | "other";
+
+export type TasksBindCwdErrorView = {
+  kind: TasksBindCwdErrorKind;
+  softFail: boolean;
+  detail: string;
+  titleKey: string;
+  hintKey: string;
+};
+
+export type TasksBindCwdResult =
+  | { ok: true }
+  | { ok: false; kind: TasksBindCwdErrorKind; detail?: string };
+
+/**
+ * Classify a bind-cwd / open-as-chat-folder failure.
+ * Soft-fail: empty path, already active, host-only, not a worktree.
+ */
+export function classifyTasksBindCwdError(
+  err: unknown,
+  opts?: { alreadyActive?: boolean; emptyPath?: boolean },
+): TasksBindCwdErrorView {
+  if (opts?.emptyPath) {
+    return {
+      kind: "empty_path",
+      softFail: true,
+      detail: "",
+      titleKey: "tasks.cwdBindErr.empty_path",
+      hintKey: "tasks.cwdBindErr.empty_pathHint",
+    };
+  }
+  if (opts?.alreadyActive) {
+    return {
+      kind: "already_active",
+      softFail: true,
+      detail: "",
+      titleKey: "tasks.cwdBindErr.already_active",
+      hintKey: "tasks.cwdBindErr.already_activeHint",
+    };
+  }
+
+  const raw = errText(err);
+  const detail = raw.trim().slice(0, 280);
+  const s = raw.toLowerCase();
+
+  let kind: TasksBindCwdErrorKind = "other";
+
+  if (
+    /need[_\s-]?tauri|desktop\s+app|host[_\s-]?only|not\s+available\s+in\s+browser/i.test(
+      s,
+    )
+  ) {
+    kind = "host_only";
+  } else if (
+    /not\s+(a\s+)?worktree|no\s+worktree|unknown\s+worktree|invalid\s+path|not\s+a\s+(git\s+)?repo/i.test(
+      s,
+    )
+  ) {
+    kind = "not_worktree";
+  } else if (
+    /already\s+(active|bound|current)|same\s+(path|cwd|folder|project)/i.test(s)
+  ) {
+    kind = "already_active";
+  } else if (
+    /switch|bind|project[_\s-]?add|failed|error|eacces|enoent|permission/i.test(
+      s,
+    ) &&
+    raw.trim()
+  ) {
+    kind = "switch_failed";
+  } else if (raw.trim()) {
+    kind = "other";
+  }
+
+  const softFail =
+    kind === "already_active" ||
+    kind === "host_only" ||
+    kind === "not_worktree";
+
+  return {
+    kind,
+    softFail,
+    detail,
+    titleKey: `tasks.cwdBindErr.${kind}`,
+    hintKey: `tasks.cwdBindErr.${kind}Hint`,
+  };
+}
+
+/**
+ * Normalize an onOpenCwd callback return value into a bind result.
+ * `void` / `undefined` → success (legacy callers).
+ */
+export function normalizeTasksBindCwdResult(
+  value: void | TasksBindCwdResult | null | undefined,
+): TasksBindCwdResult {
+  if (value == null) return { ok: true };
+  if (typeof value === "object" && "ok" in value) {
+    return value.ok
+      ? { ok: true }
+      : {
+          ok: false,
+          kind: value.kind ?? "other",
+          detail: value.detail,
+        };
+  }
+  return { ok: true };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -23754,8 +23754,55 @@ html[data-theme="light"] .rim-sidebar {
   border-radius: 6px;
   background: color-mix(in srgb, var(--fg, #e8e8e8) 6%, transparent);
 }
+.agent-tasks__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 12px 8px;
+}
+.agent-tasks__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.agent-tasks__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.35));
+  background: transparent;
+  color: var(--text-secondary, inherit);
+  font: inherit;
+  font-size: 11px;
+  line-height: 1.3;
+  cursor: pointer;
+  max-width: 140px;
+  overflow: hidden;
+}
+.agent-tasks__chip:hover {
+  background: var(--hover-bg, rgba(127, 127, 127, 0.1));
+  color: var(--text-primary, inherit);
+}
+.agent-tasks__chip.is-active {
+  border-color: color-mix(in srgb, var(--accent, #5b8def) 30%, transparent);
+  background: color-mix(in srgb, var(--accent, #5b8def) 14%, transparent);
+  color: var(--text-primary, inherit);
+  font-weight: 560;
+}
+.agent-tasks__chip-count {
+  font-size: 10px;
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+.agent-tasks__chip.is-active .agent-tasks__chip-count {
+  opacity: 0.9;
+}
 .agent-tasks__search {
-  padding: 4px 12px 8px;
+  padding: 0;
 }
 .agent-tasks__search-input {
   width: 100%;
@@ -23962,9 +24009,18 @@ html[data-theme="light"] .rim-sidebar {
 }
 .agent-tasks__empty {
   padding: 12px 14px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+.agent-tasks__empty--filter {
+  margin: 4px 0 8px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--fg, #e8e8e8) 5%, transparent);
 }
 .agent-tasks__empty-title {
-  margin: 0 0 4px;
+  margin: 0;
   font-size: 13px;
   font-weight: 600;
 }
@@ -23987,6 +24043,10 @@ html[data-theme="light"] .rim-sidebar {
   font-size: 12px;
   opacity: 0.7;
   line-height: 1.45;
+}
+.agent-tasks__hint--soft {
+  padding: 0 10px 8px 28px;
+  opacity: 0.72;
 }
 
 /* —— Agent dashboard (cross-session status modal) —— */


### PR DESCRIPTION
## Summary
Deepens the **Agent Tasks** side panel (`AgentTasksPanel`) with pro-level filters, empty honesty, and soft-fail polish.

- **Status chips**: All / Running / Done with counts (hide zero-count chips except All and active)
- **Empty honesty**: no tasks vs filter empty (+ clear filters CTA); other busy sessions still render when present
- **Snapshot banner**: copy key when `subagentWorktreeSnapshotEnabled` (CLI 0.2.117+)
- **Soft-fail**: stop session + bind-cwd classification (no raw `Error:` dumps, no `window.confirm`)
- Pure helpers + tests in `src/lib/tasksPanelPro.ts`; i18n en / zh / zh-TW; CHANGELOG

## Test plan
- [x] `vitest run src/lib/tasksPanelPro.test.ts src/i18n/messages.test.ts` (40 passed)
- [ ] Open Tasks panel with running + completed tools → chips filter correctly
- [ ] Filter to empty → clear filters restores list
- [ ] Enable subagent worktree snapshot → note banner appears
- [ ] Stop busy other-session with failure → soft-fail toast/hint (not raw error)
- [ ] Bind cwd when already active → honest “already active” hint