### PR TITLE
feat(remote-im): retire WPS xiezuo and agentspace channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ See `docs/llm-wiki/release.md`.
 - **Long chat virtualizer (PERF-A11Y-PACK / perf)**: history browse no longer expands the continuous window to the tail just because idle force-mount lists the last user/assistant (that mounted hundreds of rows mid-scroll). Force expand is nearby-only while escaped; pin still expands for blank-pin defense. Adaptive viewport-scaled overscan, binary-search range find, rAF-coalesced scroll recompute, and cached cumulative offsets keep long transcripts snappy. Pure helpers + tests in `chatVirtualList`.
 - **Custom provider save stuck on “Saving…” / requires restart** (#376): `providers_upsert` / activate / remove / set-default run file I/O on a blocking pool and recycle warm agents (`provider_route`) so the next message reloads `config.toml` + auth without a full app restart. Settings save uses a wall-clock timeout, always clears busy in `finally`, shows success / soft-fail apply toasts (en/zh/zh-TW), and no longer parks live agents via `sessionDisconnect` (which kept stale OIDC in memory). Pure `providerSave` helpers + tests.
 
+### Changed
+
+- **Remote IM: retire WPS channels** — `wps-xiezuo` (WPS Collaboration) and `wps-agentspace` (WPS Agentspace) are soft-retired: hidden from the default channel sidebar / new-bind picker (`REQUIRED_CHANNEL_IDS` + `filterActiveChannels`), schema `retired`/`unsupported` flags, soft-retired banner for existing saved instances (delete credentials only; no setup guide pack), pure `isRetiredChannel` / `filterActiveChannels` helpers + tests; en/zh/zh-TW. Host catalog keeps ids for legacy dispatch only.
+
 ### Added
 
 #### Runtime / workflows

--- a/src-tauri/src/remote_im/catalog_ac4_tests.rs
+++ b/src-tauri/src/remote_im/catalog_ac4_tests.rs
@@ -73,14 +73,13 @@ mod tests {
 
     #[test]
     fn catalog_matches_required_sidebar_ids() {
-        // Align with frontend REQUIRED_CHANNEL_IDS core set
+        // Align with frontend REQUIRED_CHANNEL_IDS (active picker; WPS retired)
         let required = [
             "feishu",
             "lark",
             "dingtalk",
             "wecom",
             "weixin",
-            "wps-xiezuo",
             "weibo",
             "qq",
             "qqbot",
@@ -89,7 +88,6 @@ mod tests {
             "discord",
             "matrix",
             "line",
-            "wps-agentspace",
         ];
         for id in required {
             assert!(
@@ -98,5 +96,8 @@ mod tests {
             );
             let _ = channels::protocol_for(id);
         }
+        // Soft-retired WPS ids remain in Host catalog for legacy instance dispatch
+        assert!(CATALOG_CHANNELS.contains(&"wps-xiezuo"));
+        assert!(CATALOG_CHANNELS.contains(&"wps-agentspace"));
     }
 }

--- a/src/components/RemoteImChannelPanel.tsx
+++ b/src/components/RemoteImChannelPanel.tsx
@@ -21,6 +21,7 @@ import {
   credentialsRefFor,
   defaultAcl,
   getChannelSchema,
+  isRetiredChannel,
   isSecretControl,
   parseIdSecretPair,
   primaryBindFields,
@@ -177,7 +178,7 @@ export function RemoteImChannelPanel({
       keepSecretsVisible?: boolean;
     }): Promise<boolean> => {
       const sch = getChannelSchema(channelId);
-      if (!sch?.implemented) return false;
+      if (!sch || isRetiredChannel(sch) || !sch.implemented) return false;
 
       setFormError(null);
       const nextValues = { ...values, ...override?.values };
@@ -395,6 +396,85 @@ export function RemoteImChannelPanel({
     return (
       <div className="rim-panel__empty">
         {t("settings.remoteIm.unknownChannel")}
+      </div>
+    );
+  }
+
+  // Soft-retired (WPS xiezuo / agentspace): honest banner, no setup pack, allow cleanup
+  if (isRetiredChannel(schema) || schema.retired || schema.unsupported) {
+    const hasLegacy =
+      instance.hasCredentials ||
+      instances.some((i) => i.channel === channelId);
+    return (
+      <div
+        className="rim-retired"
+        data-channel={channelId}
+        data-retired="1"
+      >
+        <header className="rim-panel__header">
+          <div>
+            <h2 className="rim-panel__title">{t(schema.nameKey)}</h2>
+            <p className="rim-panel__lead">{t(schema.connectionKey)}</p>
+          </div>
+          <RimBadge>{t("settings.remoteIm.retired")}</RimBadge>
+        </header>
+        <div
+          className="rim-callout rim-callout--warn"
+          role="status"
+          data-rim-retired-banner="1"
+        >
+          <div className="rim-callout__title">
+            {t("settings.remoteIm.retiredTitle")}
+          </div>
+          <p className="rim-callout__body" style={{ margin: "0.35rem 0 0" }}>
+            {t("settings.remoteIm.retiredBody")}
+          </p>
+          <p className="settings-row__hint" style={{ margin: "0.35rem 0 0" }}>
+            {t("settings.remoteIm.retiredHint")}
+          </p>
+        </div>
+        {hasLegacy ? (
+          <div className="settings-card">
+            <div className="settings-row settings-row--stack">
+              <div className="settings-row__label">
+                {t("settings.remoteIm.instance")}
+              </div>
+              <div className="settings-row__desc">
+                {name || instance.name || instance.id}
+                {instance.hasCredentials
+                  ? ` · ${t("settings.remoteIm.retired.hasCredentials")}`
+                  : ""}
+              </div>
+            </div>
+            <div className="settings-row settings-row--stack">
+              <div className="settings-row__label">
+                {t("settings.remoteIm.danger")}
+              </div>
+              <div className="settings-row__desc">
+                {t("settings.remoteIm.danger.desc")}
+              </div>
+              <button
+                type="button"
+                className="btn btn--danger btn--sm"
+                disabled={!!busy}
+                onClick={() => onRequestDelete(instance.id)}
+              >
+                {t("settings.remoteIm.danger.delete")}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="settings-card rim-disabled-form" aria-disabled>
+            <p className="settings-page__lead" style={{ margin: 0 }}>
+              {t("settings.remoteIm.retiredNoInstance")}
+            </p>
+            <div className="settings-row">
+              <button type="button" className="btn btn--primary" disabled>
+                {t("settings.remoteIm.saveConnect")}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/RemoteImLayout.tsx
+++ b/src/components/RemoteImLayout.tsx
@@ -23,8 +23,10 @@ import {
   createDefaultInstance,
   deleteChannelInstance,
   deriveStatus,
+  filterActiveChannels,
   instancesForChannel,
   isRemoteChannelId,
+  isRetiredChannel,
   loadChannelInstances,
   loadBridgeConfig,
   recordRimBridgeEvent,
@@ -219,6 +221,8 @@ export function RemoteImLayout({
 
   const onSaveInstance = useCallback(
     async (inst: ChannelInstance) => {
+      // Soft-retired channels: no new bind / save-connect
+      if (isRetiredChannel(inst.channel)) return;
       setBusy("save");
       try {
         let saved = { ...inst };
@@ -347,7 +351,11 @@ export function RemoteImLayout({
         </button>
 
         {groups.map((g) => {
-          const channels = CHANNEL_SCHEMAS.filter((c) => c.group === g.key);
+          // Hide soft-retired WPS channels by default; re-show when legacy instances exist.
+          const channels = filterActiveChannels(
+            CHANNEL_SCHEMAS.filter((c) => c.group === g.key),
+            { includeRetiredWithInstances: true, instances },
+          );
           if (channels.length === 0) return null;
           return (
             <div key={g.key} className="rim-sidebar__group">
@@ -494,6 +502,8 @@ export function RemoteImLayout({
               })
             }
             onAddInstance={() => {
+              // Soft-retired channels: no new binds / instances
+              if (isRetiredChannel(selection.channelId)) return;
               const n = instancesForChannel(instances, selection.channelId)
                 .length;
               const inst = createDefaultInstance(

--- a/src/components/remoteIm/rimUi.guard.test.ts
+++ b/src/components/remoteIm/rimUi.guard.test.ts
@@ -65,6 +65,22 @@ describe("Remote IM UI chrome guard", () => {
     expect(src).not.toMatch(/window\.prompt/);
   });
 
+  it("ChannelPanel soft-retires WPS without setup guide packs", () => {
+    const src = readFileSync(join(ROOT, "RemoteImChannelPanel.tsx"), "utf8");
+    expect(src).toContain("data-rim-retired-banner");
+    expect(src).toContain("isRetiredChannel");
+    expect(src).not.toMatch(/data-wps-guide/);
+    expect(src).not.toMatch(/wps\.guide/);
+    expect(src).not.toMatch(/window\.confirm/);
+  });
+
+  it("Layout hides retired channels from default sidebar filter", () => {
+    const src = readFileSync(join(ROOT, "RemoteImLayout.tsx"), "utf8");
+    expect(src).toContain("filterActiveChannels");
+    expect(src).toContain("includeRetiredWithInstances");
+    expect(src).toContain("isRetiredChannel");
+  });
+
   it("Overview has local event timeline without window.confirm", () => {
     const src = readFileSync(join(ROOT, "RemoteImOverview.tsx"), "utf8");
     expect(src).toContain("loadRimEventTimeline");

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -4783,6 +4783,15 @@ const en = {
   "settings.remoteIm.comingSoon": "Coming soon",
   "settings.remoteIm.comingSoonBody": "This channel is listed for planning. Binding is not enabled yet.",
   "settings.remoteIm.comingSoonHint": "Credential submit is disabled until the channel ships.",
+  "settings.remoteIm.retired": "Retired",
+  "settings.remoteIm.retiredTitle": "This channel is no longer supported",
+  "settings.remoteIm.retiredBody":
+    "WPS Collaboration and WPS Agentspace have been retired. New binds and setup guides are not available.",
+  "settings.remoteIm.retiredHint":
+    "Existing saved credentials stay on disk until you delete them. The Bridge will not treat this channel as an active picker option.",
+  "settings.remoteIm.retired.hasCredentials": "credentials saved",
+  "settings.remoteIm.retiredNoInstance":
+    "No saved instance for this retired channel. It is hidden from the default channel list.",
   "settings.remoteIm.unknownChannel": "Unknown channel",
   "settings.remoteIm.bind": "Credentials",
   "settings.remoteIm.bind.scan": "Scan to create",
@@ -9764,6 +9773,15 @@ const zh: Record<MessageKey, string> = {
   "settings.remoteIm.comingSoon": "即将支持",
   "settings.remoteIm.comingSoonBody": "该渠道已列入规划，绑定尚未开放。",
   "settings.remoteIm.comingSoonHint": "在渠道正式上线前无法提交凭证。",
+  "settings.remoteIm.retired": "已下线",
+  "settings.remoteIm.retiredTitle": "该渠道已不再支持",
+  "settings.remoteIm.retiredBody":
+    "WPS 协作与 WPS 数字员工已下线。不可新建绑定，也不再提供配置引导。",
+  "settings.remoteIm.retiredHint":
+    "已保存的凭证会保留在本地，直到你主动删除。默认侧栏与新建绑定列表不再展示该渠道。",
+  "settings.remoteIm.retired.hasCredentials": "已保存凭证",
+  "settings.remoteIm.retiredNoInstance":
+    "此已下线渠道没有本地实例。默认渠道列表中已隐藏。",
   "settings.remoteIm.unknownChannel": "未知渠道",
   "settings.remoteIm.bind": "绑定凭证",
   "settings.remoteIm.bind.scan": "扫码创建",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -4603,6 +4603,15 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.remoteIm.comingSoon": "即將支援",
   "settings.remoteIm.comingSoonBody": "此渠道已列入規劃，綁定尚未開放。",
   "settings.remoteIm.comingSoonHint": "在渠道正式上線前無法提交憑證。",
+  "settings.remoteIm.retired": "已下線",
+  "settings.remoteIm.retiredTitle": "此渠道已不再支援",
+  "settings.remoteIm.retiredBody":
+    "WPS 協作與 WPS 數字員工已下線。不可新建綁定，也不再提供設定引導。",
+  "settings.remoteIm.retiredHint":
+    "已儲存的憑證會保留在本機，直到你主動刪除。預設側欄與新建綁定列表不再顯示此渠道。",
+  "settings.remoteIm.retired.hasCredentials": "已儲存憑證",
+  "settings.remoteIm.retiredNoInstance":
+    "此已下線渠道沒有本機實例。預設渠道列表中已隱藏。",
   "settings.remoteIm.unknownChannel": "未知渠道",
   "settings.remoteIm.bind": "綁定憑證",
   "settings.remoteIm.bind.scan": "掃碼建立",

--- a/src/lib/remoteIm/channelSchemas.test.ts
+++ b/src/lib/remoteIm/channelSchemas.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   CHANNEL_SCHEMAS,
   REQUIRED_CHANNEL_IDS,
+  RETIRED_CHANNEL_IDS,
+  filterActiveChannels,
   getChannelSchema,
+  isRetiredChannel,
   parseIdSecretPair,
   showsPublicUrlCallout,
   validateBindFields,
@@ -15,6 +18,47 @@ describe("remoteIm channelSchemas", () => {
     for (const id of REQUIRED_CHANNEL_IDS) {
       expect(ids.has(id), `missing channel ${id}`).toBe(true);
     }
+  });
+
+  it("excludes retired WPS channels from REQUIRED_CHANNEL_IDS", () => {
+    for (const id of RETIRED_CHANNEL_IDS) {
+      expect(REQUIRED_CHANNEL_IDS).not.toContain(id);
+    }
+    expect(isRetiredChannel("wps-xiezuo")).toBe(true);
+    expect(isRetiredChannel("wps-agentspace")).toBe(true);
+    expect(isRetiredChannel("feishu")).toBe(false);
+    expect(isRetiredChannel(getChannelSchema("wps-xiezuo"))).toBe(true);
+    expect(isRetiredChannel(null)).toBe(false);
+  });
+
+  it("marks WPS schemas retired/unsupported and not bindable", () => {
+    for (const id of RETIRED_CHANNEL_IDS) {
+      const s = getChannelSchema(id)!;
+      expect(s.retired).toBe(true);
+      expect(s.unsupported).toBe(true);
+      expect(s.implemented).toBe(false);
+      expect(validateBindFields(s, { app_id: "x", app_secret: "y" }).ok).toBe(
+        false,
+      );
+      expect(validateBindFields(s, { app_id: "x", app_secret: "y" }).missing).toContain(
+        "_retired",
+      );
+    }
+  });
+
+  it("filterActiveChannels hides retired unless legacy instances exist", () => {
+    const active = filterActiveChannels();
+    expect(active.some((c) => c.id === "wps-xiezuo")).toBe(false);
+    expect(active.some((c) => c.id === "wps-agentspace")).toBe(false);
+    expect(active.some((c) => c.id === "feishu")).toBe(true);
+    expect(active.every((c) => !isRetiredChannel(c))).toBe(true);
+
+    const withLegacy = filterActiveChannels(CHANNEL_SCHEMAS, {
+      includeRetiredWithInstances: true,
+      instances: [{ channel: "wps-xiezuo" }],
+    });
+    expect(withLegacy.some((c) => c.id === "wps-xiezuo")).toBe(true);
+    expect(withLegacy.some((c) => c.id === "wps-agentspace")).toBe(false);
   });
 
   it("orders domestic then overseas then other groups", () => {

--- a/src/lib/remoteIm/channelSchemas.ts
+++ b/src/lib/remoteIm/channelSchemas.ts
@@ -701,8 +701,18 @@ const LINE_FIELDS: ChannelSchema["fields"] = [
 ];
 
 /**
+ * Soft-retired channel ids (product decision: WPS xiezuo + agentspace).
+ * Kept in CHANNEL_SCHEMAS for legacy instance resolve; hidden by default.
+ */
+export const RETIRED_CHANNEL_IDS: readonly RemoteChannelId[] = [
+  "wps-xiezuo",
+  "wps-agentspace",
+] as const;
+
+/**
  * Full sidebar catalog order (spec §2.2).
  * `implemented` gates credential submit; false → comingSoon panel.
+ * `retired` / `unsupported` hide from default picker; soft banner for legacy.
  */
 export const CHANNEL_SCHEMAS: ChannelSchema[] = [
   {
@@ -764,9 +774,11 @@ export const CHANNEL_SCHEMAS: ChannelSchema[] = [
   {
     id: "wps-xiezuo",
     group: "domestic",
-    implemented: true,
+    implemented: false,
+    retired: true,
+    unsupported: true,
     scanSupport: false,
-    pasteSupport: true,
+    pasteSupport: false,
     connectionKey: "settings.remoteIm.conn.websocket",
     nameKey: "settings.remoteIm.channel.wpsXiezuo",
     fields: WPS_XIEZUO_FIELDS,
@@ -855,23 +867,27 @@ export const CHANNEL_SCHEMAS: ChannelSchema[] = [
   {
     id: "wps-agentspace",
     group: "other",
-    implemented: true,
+    implemented: false,
+    retired: true,
+    unsupported: true,
     scanSupport: false,
-    pasteSupport: true,
+    pasteSupport: false,
     connectionKey: "settings.remoteIm.conn.websocket",
     nameKey: "settings.remoteIm.channel.wpsAgentspace",
     fields: WPS_AGENTSPACE_FIELDS,
   },
 ];
 
-/** Required channel ids for Phase 0 sidebar completeness checks */
+/**
+ * Required channel ids for default sidebar completeness checks.
+ * Soft-retired WPS channels are intentionally excluded.
+ */
 export const REQUIRED_CHANNEL_IDS: RemoteChannelId[] = [
   "feishu",
   "lark",
   "dingtalk",
   "wecom",
   "weixin",
-  "wps-xiezuo",
   "weibo",
   "qq",
   "qqbot",
@@ -880,13 +896,57 @@ export const REQUIRED_CHANNEL_IDS: RemoteChannelId[] = [
   "discord",
   "matrix",
   "line",
-  "wps-agentspace",
 ];
 
 export function getChannelSchema(
   id: RemoteChannelId | string,
 ): ChannelSchema | undefined {
   return CHANNEL_SCHEMAS.find((c) => c.id === id);
+}
+
+/**
+ * Whether a channel is soft-retired / unsupported (hidden from default picker).
+ * Accepts id string or schema object.
+ */
+export function isRetiredChannel(
+  channel: RemoteChannelId | string | ChannelSchema | null | undefined,
+): boolean {
+  if (channel == null) return false;
+  if (typeof channel === "object") {
+    return !!(channel.retired || channel.unsupported);
+  }
+  if ((RETIRED_CHANNEL_IDS as readonly string[]).includes(channel)) {
+    return true;
+  }
+  const schema = getChannelSchema(channel);
+  return !!(schema?.retired || schema?.unsupported);
+}
+
+export type FilterActiveChannelsOpts = {
+  /**
+   * When true, keep retired schemas that still have a saved instance
+   * (so users can open the soft-retired banner + delete credentials).
+   */
+  includeRetiredWithInstances?: boolean;
+  /** Instance list used when includeRetiredWithInstances is set */
+  instances?: Array<{ channel: string }>;
+};
+
+/**
+ * Default sidebar / new-bind picker: active (non-retired) channels only.
+ * Optionally re-includes retired channels that still have saved instances.
+ */
+export function filterActiveChannels(
+  channels: readonly ChannelSchema[] = CHANNEL_SCHEMAS,
+  opts?: FilterActiveChannelsOpts,
+): ChannelSchema[] {
+  const includeLegacy = !!opts?.includeRetiredWithInstances;
+  const instances = opts?.instances ?? [];
+  return channels.filter((schema) => {
+    if (!isRetiredChannel(schema)) return true;
+    if (!includeLegacy) return false;
+    return instances.some((i) => i.channel === schema.id);
+  });
 }
 
 export function channelsByGroup(
@@ -976,6 +1036,9 @@ export function validateBindFields(
     savedValues?: Record<string, unknown>;
   },
 ): { ok: boolean; missing: string[] } {
+  if (isRetiredChannel(schema)) {
+    return { ok: false, missing: ["_retired"] };
+  }
   if (!schema.implemented) {
     return { ok: false, missing: ["_not_implemented"] };
   }

--- a/src/lib/remoteIm/types.ts
+++ b/src/lib/remoteIm/types.ts
@@ -157,6 +157,14 @@ export type ChannelSchema = {
   group: ChannelGroup;
   /** GUI bind + save available (not comingSoon) */
   implemented: boolean;
+  /**
+   * Soft-retired / unsupported channel.
+   * Hidden from default sidebar + new-bind picker; existing instances
+   * keep a soft-retired banner (no crash, no setup guide pack).
+   */
+  retired?: boolean;
+  /** Alias of product language; prefer `retired` in code. */
+  unsupported?: boolean;
   scanSupport: boolean;
   pasteSupport: boolean;
   /** Needs public webhook URL callout */


### PR DESCRIPTION
## Summary

Soft-retire **WPS Collaboration** (`wps-xiezuo`) and **WPS Agentspace** (`wps-agentspace`) per product decision (user cancelled WPS 协作 work; no setup packs).

- Schema `retired` / `unsupported` flags; removed from `REQUIRED_CHANNEL_IDS`
- Default sidebar / new-bind picker via pure `filterActiveChannels` + `isRetiredChannel`
- Legacy saved instances: soft-retired banner + delete credentials only (no crash, no setup guide)
- Host catalog keeps ids for legacy connector dispatch only
- i18n en / zh / zh-TW · CHANGELOG · no `window.confirm`

## Test plan

- [x] `vitest` `channelSchemas.test.ts` (retired helpers + REQUIRED list)
- [x] `vitest` `rimUi.guard.test.ts` (no WPS guide pack, sidebar filter wiring)
- [x] `vitest` `messages.test.ts` (key parity)
- [ ] Manual: Settings → 远程控制 → IM — WPS rows absent from default sidebar
- [ ] Manual: with a leftover WPS instance in storage, row reappears with retired banner; delete works via in-app modal