### PR TITLE
feat(session): continue-cwd pro soft-fail and empty honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ See `docs/llm-wiki/release.md`.
 
 #### Sessions & sidebar
 - **Continue last agent for this project** (CLI `grok -c/--continue`): project menu + command palette finds the newest agent session under active `GROK_HOME` for the project path, then opens the linked App chat or imports history; soft-fails with a toast when none exist
+- **Continue last agent (cwd) pro**: classified soft-fail toasts (no session · no CLI · untrusted · host-only · import failed) with empty honesty when none exist; pure `continueCwd` preflight/classify helpers + tests; en/zh/zh-TW
 - **Duplicate chat** (vs **Fork…** + optional worktree) · **session notes** · **mute** · **unread dot**
 - **Open session in new window** — session menu opens a second Tauri webview with `#/session/<id>` deep link; re-open focuses the existing window; close secondary for real (main still tray/confirm)
 - **Multi-window live (lite)**: secondary session windows can **send / stop** via the shared Host (session-targeted); still skip *passive* warm-connect on open so browsing does not demote main’s agent; honest secondary tip + **Focus main window**; pure `canLiveParticipate` / `shouldSkipWarmConnect` policy + tests

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -434,7 +434,15 @@ import {
   filterPaletteActions,
   type PaletteActionDef,
 } from "@/lib/paletteActions";
-import { canOfferContinueCwd } from "@/lib/continueCwd";
+import {
+  canOfferContinueCwd,
+  classifyContinueCwdEmptyResult,
+  continueCwdSoftFailMessageKey,
+  evaluateContinueCwd,
+  resolveContinueCwdEmptyHonesty,
+  resolveContinueCwdSoftFail,
+  type ContinueCwdSoftFailKind,
+} from "@/lib/continueCwd";
 import {
   sessionExportFilename,
   sessionExportFilenameFor,
@@ -7645,16 +7653,22 @@ export default function App() {
   /**
    * CLI `grok -c/--continue` for a project folder: find newest agent session
    * under active GROK_HOME for that path, import if needed, open App chat.
-   * Soft-fails with a toast when no agent session exists.
+   * Classified soft-fail (no session / no CLI / untrusted / host-only / import)
+   * with empty honesty when none exist — never invents a session id.
    */
   const continueLastAgentForProject = async (proj: Project) => {
     setCtxMenu(null);
-    if (!canOfferContinueCwd(proj.path)) {
-      showToast(tr("project.continueCwdNoProject"), 3500);
-      return;
-    }
-    if (!api.isTauri()) {
-      setLocalError(tr("error.needTauri"));
+    const toastContinueSoftFail = (kind: ContinueCwdSoftFailKind, detail = "") => {
+      const key = continueCwdSoftFailMessageKey(kind) as MessageKey;
+      const base = tr(key);
+      showToast(detail ? `${base}: ${detail}` : base, kind === "no_session" ? 4200 : 4500);
+    };
+    const gate = evaluateContinueCwd(
+      { path: proj.path, trusted: proj.trusted },
+      { isTauri: api.isTauri() },
+    );
+    if (!gate.ok) {
+      toastContinueSoftFail(gate.kind);
       return;
     }
     showToast(tr("project.continueCwdWorking"), 2000);
@@ -7662,20 +7676,23 @@ export default function App() {
       const meta = await api.cliSessionContinueCwd(proj.path, {
         projectId: proj.id,
       });
-      if (!meta?.id) {
-        showToast(tr("project.continueCwdNone"), 4200);
+      const emptyKind = classifyContinueCwdEmptyResult(meta);
+      if (emptyKind) {
+        const honesty = resolveContinueCwdEmptyHonesty();
+        showToast(tr(honesty.messageKey as MessageKey), 4200);
         return;
       }
+      const id = meta!.id;
       await refreshSessions();
       const list = (await api.sessionsList()) as SessionRow[];
       const row =
-        list.map((s) => normalizeSessionRow(s)).find((s) => s.id === meta.id) ??
+        list.map((s) => normalizeSessionRow(s)).find((s) => s.id === id) ??
         normalizeSessionRow({
-          id: meta.id,
-          title: meta.title || tr("session.untitled"),
-          projectId: meta.projectId ?? proj.id,
-          updatedAt: meta.updatedAt || new Date().toISOString(),
-          agentSessionId: meta.agentSessionId ?? null,
+          id,
+          title: meta!.title || tr("session.untitled"),
+          projectId: meta!.projectId ?? proj.id,
+          updatedAt: meta!.updatedAt || new Date().toISOString(),
+          agentSessionId: meta!.agentSessionId ?? null,
         });
       const openProj =
         (row.projectId && projects.find((p) => p.id === row.projectId)) || proj;
@@ -7683,12 +7700,13 @@ export default function App() {
       await openSession(row, openProj);
       showToast(
         tr("project.continueCwdOk", {
-          title: row.title || meta.title || tr("session.untitled"),
+          title: row.title || meta!.title || tr("session.untitled"),
         }),
         2800,
       );
     } catch (e) {
-      showToast(tr("project.continueCwdFailed") + ": " + String(e), 4500);
+      const soft = resolveContinueCwdSoftFail(e);
+      toastContinueSoftFail(soft.kind, soft.detail);
     }
   };
 
@@ -13124,7 +13142,12 @@ export default function App() {
       case "continue-cwd": {
         const proj = activeProject;
         if (!proj || !canOfferContinueCwd(proj.path)) {
-          showToast(tr("project.continueCwdNoProject"), 3500);
+          showToast(
+            tr(
+              continueCwdSoftFailMessageKey("no_project") as MessageKey,
+            ),
+            3500,
+          );
           break;
         }
         void continueLastAgentForProject(proj);

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -124,6 +124,14 @@ const en = {
   "project.continueCwdOk": "Continued “{title}”",
   "project.continueCwdFailed": "Could not continue last agent",
   "project.continueCwdNoProject": "Select a project first.",
+  "project.continueCwdNoCli":
+    "Grok Build CLI not found — install or set the CLI path, then try Continue again.",
+  "project.continueCwdUntrusted":
+    "Trust this project first, then continue the last agent session.",
+  "project.continueCwdHostOnly":
+    "Continue last agent requires the desktop app window.",
+  "project.continueCwdImportFailed":
+    "Found an agent session but could not import it into the app.",
 
   "session.pin": "Pin chat",
   "session.unpin": "Unpin chat",
@@ -5275,6 +5283,13 @@ const zh: Record<MessageKey, string> = {
   "project.continueCwdOk": "已继续「{title}」",
   "project.continueCwdFailed": "无法继续最近的 Agent",
   "project.continueCwdNoProject": "请先选择一个项目。",
+  "project.continueCwdNoCli":
+    "未找到 Grok Build CLI — 请先安装或设置 CLI 路径，再试「继续」。",
+  "project.continueCwdUntrusted":
+    "请先信任此项目，再继续最近的 Agent 会话。",
+  "project.continueCwdHostOnly": "继续最近的 Agent 需要在桌面应用窗口中操作。",
+  "project.continueCwdImportFailed":
+    "找到了 Agent 会话，但无法导入到应用中。",
 
   "session.pin": "置顶会话",
   "session.unpin": "取消置顶",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -113,6 +113,13 @@ export const zhTW: Record<MessageKey, string> = {
   "project.continueCwdOk": "已繼續「{title}」",
   "project.continueCwdFailed": "無法繼續最近的 Agent",
   "project.continueCwdNoProject": "請先選擇一個專案。",
+  "project.continueCwdNoCli":
+    "找不到 Grok Build CLI — 請先安裝或設定 CLI 路徑，再試「繼續」。",
+  "project.continueCwdUntrusted":
+    "請先信任此專案，再繼續最近的 Agent 工作階段。",
+  "project.continueCwdHostOnly": "繼續最近的 Agent 需要在桌面應用視窗中操作。",
+  "project.continueCwdImportFailed":
+    "找到了 Agent 工作階段，但無法匯入到應用中。",
 
   "session.pin": "置頂對話",
   "session.unpin": "取消置頂",

--- a/src/lib/continueCwd.test.ts
+++ b/src/lib/continueCwd.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
   canOfferContinueCwd,
+  classifyContinueCwdEmptyResult,
+  classifyContinueCwdError,
+  continueCwdSoftFailMessageKey,
   cwdPathsMatch,
+  evaluateContinueCwd,
   normalizeCwdPath,
   pickLatestCliSessionForCwd,
+  resolveContinueCwdEmptyHonesty,
+  resolveContinueCwdEmptyState,
+  resolveContinueCwdSoftFail,
 } from "./continueCwd";
 
 describe("normalizeCwdPath", () => {
@@ -88,5 +95,232 @@ describe("canOfferContinueCwd", () => {
     expect(canOfferContinueCwd("  ")).toBe(false);
     expect(canOfferContinueCwd(null)).toBe(false);
     expect(canOfferContinueCwd(undefined)).toBe(false);
+  });
+
+  it("still offers untrusted by default (soft-fail on run)", () => {
+    expect(
+      canOfferContinueCwd("/Users/me/proj", { trusted: false }),
+    ).toBe(true);
+  });
+
+  it("hides untrusted when hideWhenUntrusted", () => {
+    expect(
+      canOfferContinueCwd("/Users/me/proj", {
+        trusted: false,
+        hideWhenUntrusted: true,
+      }),
+    ).toBe(false);
+    expect(
+      canOfferContinueCwd("/Users/me/proj", {
+        trusted: true,
+        hideWhenUntrusted: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("evaluateContinueCwd", () => {
+  it("ok for trusted path on tauri", () => {
+    expect(
+      evaluateContinueCwd(
+        { path: "/Users/me/proj", trusted: true },
+        { isTauri: true },
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("soft-fails host_only when not tauri", () => {
+    expect(
+      evaluateContinueCwd(
+        { path: "/p", trusted: true },
+        { isTauri: false },
+      ),
+    ).toEqual({ ok: false, kind: "host_only" });
+  });
+
+  it("soft-fails no_project when path empty", () => {
+    expect(evaluateContinueCwd({ path: "  ", trusted: true })).toEqual({
+      ok: false,
+      kind: "no_project",
+    });
+    expect(evaluateContinueCwd(null)).toEqual({
+      ok: false,
+      kind: "no_project",
+    });
+  });
+
+  it("soft-fails untrusted", () => {
+    expect(
+      evaluateContinueCwd({ path: "/p", trusted: false }, { isTauri: true }),
+    ).toEqual({ ok: false, kind: "untrusted" });
+  });
+
+  it("soft-fails no_cli when probe known missing", () => {
+    expect(
+      evaluateContinueCwd(
+        { path: "/p", trusted: true },
+        { isTauri: true, cliFound: false },
+      ),
+    ).toEqual({ ok: false, kind: "no_cli" });
+  });
+
+  it("allows unknown cliFound", () => {
+    expect(
+      evaluateContinueCwd(
+        { path: "/p", trusted: true },
+        { isTauri: true, cliFound: null },
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("priority: host_only before no_project", () => {
+    expect(
+      evaluateContinueCwd({ path: "" }, { isTauri: false }),
+    ).toEqual({ ok: false, kind: "host_only" });
+  });
+});
+
+describe("classifyContinueCwdError", () => {
+  it("maps explicit codes", () => {
+    expect(classifyContinueCwdError({ code: "no_session" })).toBe("no_session");
+    expect(classifyContinueCwdError({ code: "cli_missing" })).toBe("no_cli");
+    expect(classifyContinueCwdError({ code: "CLI_NOT_FOUND" })).toBe("no_cli");
+    expect(classifyContinueCwdError({ code: "untrusted" })).toBe("untrusted");
+    expect(classifyContinueCwdError({ code: "need_tauri" })).toBe("host_only");
+    expect(classifyContinueCwdError({ code: "import_failed" })).toBe(
+      "import_failed",
+    );
+    expect(classifyContinueCwdError({ code: "path_not_allowed" })).toBe(
+      "import_failed",
+    );
+    expect(classifyContinueCwdError({ code: "no_project" })).toBe("no_project");
+  });
+
+  it("maps free-text patterns", () => {
+    expect(classifyContinueCwdError("Grok Build CLI not found")).toBe("no_cli");
+    expect(classifyContinueCwdError(new Error("CLI_NOT_FOUND: missing"))).toBe(
+      "no_cli",
+    );
+    expect(classifyContinueCwdError("project is not trusted")).toBe("untrusted");
+    expect(
+      classifyContinueCwdError("No agent session found for this project"),
+    ).toBe("no_session");
+    expect(
+      classifyContinueCwdError("path not allowed: outside GROK_HOME/sessions"),
+    ).toBe("import_failed");
+    expect(classifyContinueCwdError("CLI session dir not found for abc")).toBe(
+      "import_failed",
+    );
+    expect(classifyContinueCwdError("Select a project first")).toBe(
+      "no_project",
+    );
+    expect(classifyContinueCwdError("requires the Tauri window")).toBe(
+      "host_only",
+    );
+  });
+
+  it("falls back to other", () => {
+    expect(classifyContinueCwdError("weird boom")).toBe("other");
+    expect(classifyContinueCwdError(null)).toBe("other");
+    expect(classifyContinueCwdError("")).toBe("other");
+  });
+});
+
+describe("classifyContinueCwdEmptyResult", () => {
+  it("null / empty id → no_session; real id → null", () => {
+    expect(classifyContinueCwdEmptyResult(null)).toBe("no_session");
+    expect(classifyContinueCwdEmptyResult(undefined)).toBe("no_session");
+    expect(classifyContinueCwdEmptyResult({ id: "" })).toBe("no_session");
+    expect(classifyContinueCwdEmptyResult({ id: "  " })).toBe("no_session");
+    expect(classifyContinueCwdEmptyResult({ id: "sess-1" })).toBeNull();
+  });
+});
+
+describe("continueCwdSoftFailMessageKey / resolve", () => {
+  it("maps kinds to i18n keys", () => {
+    expect(continueCwdSoftFailMessageKey("no_project")).toBe(
+      "project.continueCwdNoProject",
+    );
+    expect(continueCwdSoftFailMessageKey("no_session")).toBe(
+      "project.continueCwdNone",
+    );
+    expect(continueCwdSoftFailMessageKey("no_cli")).toBe(
+      "project.continueCwdNoCli",
+    );
+    expect(continueCwdSoftFailMessageKey("untrusted")).toBe(
+      "project.continueCwdUntrusted",
+    );
+    expect(continueCwdSoftFailMessageKey("host_only")).toBe(
+      "project.continueCwdHostOnly",
+    );
+    expect(continueCwdSoftFailMessageKey("import_failed")).toBe(
+      "project.continueCwdImportFailed",
+    );
+    expect(continueCwdSoftFailMessageKey("other")).toBe(
+      "project.continueCwdFailed",
+    );
+  });
+
+  it("resolveContinueCwdSoftFail attaches detail only for other", () => {
+    const other = resolveContinueCwdSoftFail(new Error("disk full xyz"));
+    expect(other.kind).toBe("other");
+    expect(other.messageKey).toBe("project.continueCwdFailed");
+    expect(other.detail).toContain("disk full");
+
+    const cli = resolveContinueCwdSoftFail(new Error("CLI not found"));
+    expect(cli.kind).toBe("no_cli");
+    expect(cli.detail).toBe("");
+  });
+
+  it("empty honesty is always no_session", () => {
+    const e = resolveContinueCwdEmptyHonesty();
+    expect(e.kind).toBe("no_session");
+    expect(e.messageKey).toBe("project.continueCwdNone");
+  });
+});
+
+describe("resolveContinueCwdEmptyState", () => {
+  it("returns null when ready to attempt", () => {
+    expect(
+      resolveContinueCwdEmptyState({
+        projectPath: "/p",
+        trusted: true,
+        isTauri: true,
+        cliFound: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("surfaces classified empty / blocked states", () => {
+    expect(
+      resolveContinueCwdEmptyState({ projectPath: "", isTauri: true }),
+    ).toMatchObject({ kind: "no_project" });
+    expect(
+      resolveContinueCwdEmptyState({
+        projectPath: "/p",
+        trusted: false,
+        isTauri: true,
+      }),
+    ).toMatchObject({ kind: "untrusted" });
+    expect(
+      resolveContinueCwdEmptyState({
+        projectPath: "/p",
+        trusted: true,
+        cliFound: false,
+      }),
+    ).toMatchObject({ kind: "no_cli" });
+    expect(
+      resolveContinueCwdEmptyState({
+        projectPath: "/p",
+        trusted: true,
+        hostEmpty: true,
+      }),
+    ).toMatchObject({ kind: "no_session" });
+    expect(
+      resolveContinueCwdEmptyState({
+        projectPath: "/p",
+        isTauri: false,
+      }),
+    ).toMatchObject({ kind: "host_only" });
   });
 });

--- a/src/lib/continueCwd.ts
+++ b/src/lib/continueCwd.ts
@@ -3,6 +3,9 @@
  *
  * Host scans `{GROK_HOME}/sessions/{percent-encoded-cwd}/` and imports/opens the
  * newest agent session. These helpers stay I/O-free for unit tests and UI gates.
+ *
+ * Pro: classified soft-fail (no session · no CLI · untrusted · host-only ·
+ * import), empty honesty when none exist, and preflight gates for menu/palette.
  */
 
 /** Normalize a project / cwd path for equality (trim, unify slashes, drop trailing sep, lower). */
@@ -55,12 +58,374 @@ export function pickLatestCliSessionForCwd<T extends ContinueCwdSessionRow>(
   return best;
 }
 
+// ── Soft-fail classification (pro) ───────────────────────────────────────────
+
+/**
+ * Stable soft-fail kinds for continue-cwd toasts / gates.
+ * Never invents a session id; empty host result is {@link "no_session"}.
+ */
+export type ContinueCwdSoftFailKind =
+  | "no_project"
+  | "no_session"
+  | "no_cli"
+  | "untrusted"
+  | "host_only"
+  | "import_failed"
+  | "other";
+
+/** Empty / honesty states the UI may surface without inventing history. */
+export type ContinueCwdEmptyKind =
+  | "no_project"
+  | "no_session"
+  | "no_cli"
+  | "untrusted";
+
+export type ContinueCwdGate =
+  | { ok: true }
+  | { ok: false; kind: ContinueCwdSoftFailKind };
+
+export type ContinueCwdProjectLike = {
+  path?: string | null;
+  /** Trusted projects may run agents; untrusted soft-fails continue. */
+  trusted?: boolean | null;
+};
+
 /**
  * Whether the project menu / palette should offer “Continue last agent…”.
- * Needs a non-empty bound project path.
+ * Needs a non-empty bound project path. When `trusted === false`, still offer
+ * so the click path can show an honest untrusted soft-fail toast (unless
+ * `opts.hideWhenUntrusted`).
  */
 export function canOfferContinueCwd(
   projectPath: string | null | undefined,
+  opts?: {
+    trusted?: boolean | null;
+    /** When true, hide the action for untrusted projects. Default false. */
+    hideWhenUntrusted?: boolean;
+  },
 ): boolean {
-  return normalizeCwdPath(projectPath).length > 0;
+  if (!normalizeCwdPath(projectPath)) return false;
+  if (opts?.hideWhenUntrusted && opts.trusted === false) return false;
+  return true;
+}
+
+/**
+ * Preflight before Host `cli_session_continue_cwd`.
+ * Order: host_only → no_project → untrusted → no_cli → ok.
+ * Does **not** invent “no_session” (that is a host empty result).
+ */
+export function evaluateContinueCwd(
+  project: ContinueCwdProjectLike | null | undefined,
+  opts?: {
+    /** `api.isTauri()` — false → host_only. Default true (optimistic). */
+    isTauri?: boolean | null;
+    /**
+     * When known `false` (doctor / setup probe), soft-fail no_cli without
+     * calling Host. `null`/`undefined` = unknown → allow attempt.
+     */
+    cliFound?: boolean | null;
+  },
+): ContinueCwdGate {
+  if (opts?.isTauri === false) {
+    return { ok: false, kind: "host_only" };
+  }
+  const path = project?.path;
+  if (!normalizeCwdPath(path)) {
+    return { ok: false, kind: "no_project" };
+  }
+  if (project?.trusted === false) {
+    return { ok: false, kind: "untrusted" };
+  }
+  if (opts?.cliFound === false) {
+    return { ok: false, kind: "no_cli" };
+  }
+  return { ok: true };
+}
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as {
+      code?: unknown;
+      message?: unknown;
+      reason?: unknown;
+      status?: unknown;
+    };
+    const parts = [o.code, o.status, o.message, o.reason]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+function errCode(err: unknown): string {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const c = (err as { code?: unknown }).code;
+    if (typeof c === "string") return c.trim().toLowerCase();
+    if (typeof c === "number" && Number.isFinite(c)) return String(c);
+  }
+  return "";
+}
+
+/**
+ * Classify a thrown value / host error into a stable soft-fail kind.
+ * Prefer explicit `code` over free-form text. Never invents success.
+ */
+export function classifyContinueCwdError(
+  err: unknown,
+): ContinueCwdSoftFailKind {
+  if (err == null || err === "") return "other";
+
+  const code = errCode(err);
+  if (
+    code === "no_project" ||
+    code === "no-project" ||
+    code === "empty_path" ||
+    code === "empty-path"
+  ) {
+    return "no_project";
+  }
+  if (
+    code === "no_session" ||
+    code === "no-session" ||
+    code === "none" ||
+    code === "empty" ||
+    code === "not_found"
+  ) {
+    return "no_session";
+  }
+  if (
+    code === "no_cli" ||
+    code === "no-cli" ||
+    code === "cli_missing" ||
+    code === "cli-missing" ||
+    code === "cli_not_found" ||
+    code === "cli-not-found"
+  ) {
+    return "no_cli";
+  }
+  if (
+    code === "untrusted" ||
+    code === "not_trusted" ||
+    code === "not-trusted" ||
+    code === "trust_required"
+  ) {
+    return "untrusted";
+  }
+  if (
+    code === "host_only" ||
+    code === "host-only" ||
+    code === "need_tauri" ||
+    code === "need-tauri"
+  ) {
+    return "host_only";
+  }
+  if (
+    code === "import_failed" ||
+    code === "import-failed" ||
+    code === "import_error" ||
+    code === "path_not_allowed" ||
+    code === "path-not-allowed"
+  ) {
+    return "import_failed";
+  }
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  if (
+    s.includes("need tauri") ||
+    s.includes("requires the tauri") ||
+    s.includes("host only") ||
+    s.includes("not in tauri")
+  ) {
+    return "host_only";
+  }
+
+  if (
+    s.includes("cli_not_found") ||
+    s.includes("cli not found") ||
+    s.includes("cli_missing") ||
+    s.includes("cli missing") ||
+    s.includes("grok build not found") ||
+    s.includes("grok build cli not found") ||
+    s.includes("command not found") ||
+    (s.includes("enoent") && (s.includes("grok") || s.includes("cli")))
+  ) {
+    return "no_cli";
+  }
+
+  if (
+    s.includes("untrusted") ||
+    s.includes("not trusted") ||
+    s.includes("trust this project") ||
+    s.includes("project is not trusted")
+  ) {
+    return "untrusted";
+  }
+
+  if (
+    s.includes("no project") ||
+    s.includes("select a project") ||
+    s.includes("empty path") ||
+    s.includes("path is empty")
+  ) {
+    return "no_project";
+  }
+
+  if (
+    s.includes("no agent session") ||
+    s.includes("no session") ||
+    s.includes("session not found") ||
+    s.includes("none found") ||
+    s.includes("no cli session")
+  ) {
+    return "no_session";
+  }
+
+  if (
+    s.includes("import") ||
+    s.includes("path not allowed") ||
+    s.includes("outside grok_home") ||
+    s.includes("not a directory") ||
+    s.includes("cli session dir not found")
+  ) {
+    return "import_failed";
+  }
+
+  return "other";
+}
+
+/**
+ * Classify a successful Host call that returned null / empty id as empty honesty.
+ * Non-empty id → null (caller handles success).
+ */
+export function classifyContinueCwdEmptyResult(
+  meta: { id?: string | null } | null | undefined,
+): ContinueCwdSoftFailKind | null {
+  if (meta == null) return "no_session";
+  const id = typeof meta.id === "string" ? meta.id.trim() : "";
+  if (!id) return "no_session";
+  return null;
+}
+
+/** i18n message key for a classified soft-fail (never invent success). */
+export function continueCwdSoftFailMessageKey(
+  kind: ContinueCwdSoftFailKind,
+): string {
+  switch (kind) {
+    case "no_project":
+      return "project.continueCwdNoProject";
+    case "no_session":
+      return "project.continueCwdNone";
+    case "no_cli":
+      return "project.continueCwdNoCli";
+    case "untrusted":
+      return "project.continueCwdUntrusted";
+    case "host_only":
+      return "project.continueCwdHostOnly";
+    case "import_failed":
+      return "project.continueCwdImportFailed";
+    case "other":
+    default:
+      return "project.continueCwdFailed";
+  }
+}
+
+/**
+ * Resolve user-facing soft-fail copy from a thrown value.
+ * `detail` is a short technical suffix for `other` only (never secrets-heavy).
+ */
+export function resolveContinueCwdSoftFail(err: unknown): {
+  kind: ContinueCwdSoftFailKind;
+  messageKey: string;
+  /** Short technical detail for debug suffix (empty when not useful). */
+  detail: string;
+} {
+  const kind = classifyContinueCwdError(err);
+  const messageKey = continueCwdSoftFailMessageKey(kind);
+  const raw = errText(err).trim();
+  let detail = "";
+  if (
+    kind === "other" &&
+    raw &&
+    !/^error:\s*$/i.test(raw) &&
+    raw.length < 200
+  ) {
+    detail = raw.replace(/^Error:\s*/i, "").trim();
+  }
+  return { kind, messageKey, detail };
+}
+
+/**
+ * Empty honesty for null Host result (no agent session under cwd).
+ * Prefer this over a generic failure toast.
+ */
+export function resolveContinueCwdEmptyHonesty(): {
+  kind: "no_session";
+  messageKey: string;
+} {
+  return {
+    kind: "no_session",
+    messageKey: continueCwdSoftFailMessageKey("no_session"),
+  };
+}
+
+/**
+ * Resolve an empty / blocked state for menu hints or toasts without inventing
+ * a session. Returns null when the project is ready to attempt continue.
+ */
+export function resolveContinueCwdEmptyState(input: {
+  projectPath?: string | null;
+  trusted?: boolean | null;
+  isTauri?: boolean | null;
+  cliFound?: boolean | null;
+  /** Host already returned empty / null meta. */
+  hostEmpty?: boolean;
+}): { kind: ContinueCwdEmptyKind | "host_only"; messageKey: string } | null {
+  if (input.isTauri === false) {
+    return {
+      kind: "host_only",
+      messageKey: continueCwdSoftFailMessageKey("host_only"),
+    };
+  }
+  if (!normalizeCwdPath(input.projectPath)) {
+    return {
+      kind: "no_project",
+      messageKey: continueCwdSoftFailMessageKey("no_project"),
+    };
+  }
+  if (input.trusted === false) {
+    return {
+      kind: "untrusted",
+      messageKey: continueCwdSoftFailMessageKey("untrusted"),
+    };
+  }
+  if (input.cliFound === false) {
+    return {
+      kind: "no_cli",
+      messageKey: continueCwdSoftFailMessageKey("no_cli"),
+    };
+  }
+  if (input.hostEmpty) {
+    return {
+      kind: "no_session",
+      messageKey: continueCwdSoftFailMessageKey("no_session"),
+    };
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

Deepens **Continue last agent for this project** (CLI `grok -c/--continue`) with classified soft-fail and empty honesty.

- **Soft-fail kinds**: `no_session` · `no_cli` · `untrusted` · `host_only` · `import_failed` · `no_project` · `other`
- **Empty honesty**: host null / empty id → dedicated no-session toast (never invents a session id)
- **Preflight gate** (`evaluateContinueCwd`): host-only → no project → untrusted → no CLI before Host call
- **Wiring**: project context menu + command palette → `continueLastAgentForProject`
- **Pure helpers + tests**: `src/lib/continueCwd.ts` / `.test.ts` (26 unit tests)
- **i18n**: en / zh / zh-TW
- **CHANGELOG** under Sessions & sidebar

## Test plan

- [x] `vitest run src/lib/continueCwd.test.ts src/lib/paletteActions.test.ts` (39 passed)
- [ ] Project menu → Continue last agent on trusted project with prior CLI session → opens/import toast OK
- [ ] Same with no agent sessions under cwd → empty honesty toast (`project.continueCwdNone`)
- [ ] Untrusted project → soft-fail untrusted toast (no Host invent)
- [ ] Palette `continue last agent` / `--continue` without active project → no-project toast