### PR TITLE
feat(session): archive-by-age pro with preview and confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 
+#### Sessions & project rules
+- **Session archive-by-age pro**: bulk archive older than 7 / 30 / 90 days with **live preview counts** on sidebar menu + Settings → Archived chips, **GlassModal confirm** (sample titles + “…and N more”, no `window.confirm`), and **empty honesty** (no chats · all archived · all pinned · all recent). Pure `sessionArchiveAge` plan/preview helpers + tests; en/zh/zh-TW.
+
 #### Runtime / workflows
 - **Sandbox profile pro** (Settings → General → Permissions): polish OS sandbox presets (`off` / `workspace` / `read-only` / `strict` / `devbox`) with pure `sandboxProfile` helpers (spawn args/env, project resolve, danger confirm keys), **honest soft-fail** when CLI is missing/too old for `--sandbox` (flag omitted) or when the platform has no kernel enforcement (Windows honesty; Linux-only child-network note on macOS), Settings banners + recommended-workspace tip; Host soft-gates spawn flags on known-old CLI; i18n en/zh/zh-TW; `settingsCatalog`; tests
 - **Grok Build workflows** (Settings → Runtime → Tools): opt-in `workflowsEnabled` AppSettings toggle writes top-level `workflows_enabled` into independent agent-home `config.toml` (shared mode never rewrites `~/.grok`); honest copy that workflows run via CLI / Rhai (`workflow` tool, `/workflow`, `/workflows`) — **no in-app runner/editor**; read-only soft-fail discovery of `~/.grok/workflows` + project `.grok/workflows` names; command palette **Open workflows docs** / jump to settings; pure helpers + tests; `settingsCatalog` + en/zh/zh-TW

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -302,8 +302,10 @@ import {
 } from "@/lib/sandboxProfile";
 import { shouldRestoreLastSession } from "@/lib/sessionRestore";
 import {
-  ARCHIVE_AGE_DAY_OPTIONS,
-  filterSessionsOlderThanDays,
+  archiveAgeEmptyMessageKey,
+  listArchiveAgeOptionPreviews,
+  planArchiveOlderThan,
+  type ArchiveAgePlan,
 } from "@/lib/sessionArchiveAge";
 import {
   collapsedIdsFromExpandMap,
@@ -1475,6 +1477,13 @@ export default function App() {
   );
   /** Clear recent prompts — App-level GlassModal (avoids floating-menu dismiss). */
   const [promptHistoryClearOpen, setPromptHistoryClearOpen] = useState(false);
+  /**
+   * Archive-by-age pro confirm (GlassModal with preview count + title samples).
+   * Null when closed. Built via pure `planArchiveOlderThan`.
+   */
+  const [archiveAgeConfirm, setArchiveAgeConfirm] =
+    useState<ArchiveAgePlan<SessionRow> | null>(null);
+  const [archiveAgeBusy, setArchiveAgeBusy] = useState(false);
   const promptHistoryPanelRef = useRef<HTMLDivElement>(null);
   const promptHistoryOpenRef = useRef(false);
   promptHistoryOpenRef.current = promptHistoryOpen;
@@ -7411,71 +7420,80 @@ export default function App() {
 
   /**
    * Bulk-archive chats whose last update is older than `days`.
-   * Skips pinned + already-archived; confirms count via in-app dialog.
+   * Skips pinned + already-archived. Preview count + GlassModal confirm
+   * (never window.confirm). Empty → classified honesty toast.
    */
   const confirmArchiveOlderThan = (days: number) => {
     setCtxMenu(null);
-    const rows = filterSessionsOlderThanDays(sessions, days);
-    if (!rows.length) {
-      setToast(tr("sidebar.archiveOlderNone", { days: String(days) }));
-      window.setTimeout(() => setToast(null), 3200);
+    const plan = planArchiveOlderThan(sessions, days);
+    if (!plan.confirmNeeded || plan.count === 0) {
+      const kind = plan.emptyKind ?? "all_recent";
+      const key = archiveAgeEmptyMessageKey(kind);
+      setToast(
+        tr(key as MessageKey, {
+          days: String(days),
+          n: "0",
+        }),
+      );
+      window.setTimeout(() => setToast(null), 3600);
       return;
     }
-    const n = rows.length;
-    setAppDialog({
-      kind: "confirm",
-      title: tr("sidebar.archiveOlderTitle"),
-      message: tr("sidebar.archiveOlderConfirm", {
-        n: String(n),
-        days: String(days),
-      }),
-      confirmLabel: tr("sidebar.archiveSelected", { n: String(n) }),
-      onConfirm: async () => {
-        try {
-          if (!api.isTauri()) {
-            setLocalError(tr("error.needTauri"));
-            return;
-          }
-          const openId =
-            session.sessionId ?? viewingSessionIdRef.current ?? null;
-          const wasViewing =
-            !!openId && rows.some((s) => s.id === openId);
-          const viewingRow = wasViewing
-            ? rows.find((s) => s.id === openId) ?? null
-            : null;
+    setArchiveAgeConfirm(plan);
+  };
 
-          const results = await Promise.allSettled(
-            rows.map((s) => api.sessionSetArchived(s.id, true)),
-          );
-          const ok = results.filter((r) => r.status === "fulfilled").length;
-          const firstFail = results.find(
-            (r): r is PromiseRejectedResult => r.status === "rejected",
-          );
+  /** Apply a planned archive-by-age batch (GlassModal confirm). */
+  const runArchiveAgePlan = async (plan: ArchiveAgePlan<SessionRow>) => {
+    const rows = plan.sessions;
+    if (!rows.length) {
+      setArchiveAgeConfirm(null);
+      return;
+    }
+    setArchiveAgeBusy(true);
+    try {
+      if (!api.isTauri()) {
+        setLocalError(tr("error.needTauri"));
+        return;
+      }
+      const openId =
+        session.sessionId ?? viewingSessionIdRef.current ?? null;
+      const wasViewing = !!openId && rows.some((s) => s.id === openId);
+      const viewingRow = wasViewing
+        ? rows.find((s) => s.id === openId) ?? null
+        : null;
 
-          await refreshSessions();
+      const results = await Promise.allSettled(
+        rows.map((s) => api.sessionSetArchived(s.id, true)),
+      );
+      const ok = results.filter((r) => r.status === "fulfilled").length;
+      const firstFail = results.find(
+        (r): r is PromiseRejectedResult => r.status === "rejected",
+      );
 
-          if (wasViewing && viewingRow) {
-            const proj = viewingRow.projectId
-              ? projects.find((p) => p.id === viewingRow.projectId) ?? null
-              : null;
-            if (proj) await newChat(proj, { switchToChat: true });
-            else await newChat(null, { switchToChat: true });
-          }
+      await refreshSessions();
 
-          if (ok > 0) {
-            setToast(tr("sidebar.archivedToast", { n: String(ok) }));
-            window.setTimeout(() => setToast(null), 3200);
-          }
-          if (firstFail) {
-            setLocalError(String(firstFail.reason));
-          } else {
-            setLocalError(null);
-          }
-        } catch (e) {
-          setLocalError(String(e));
-        }
-      },
-    });
+      if (wasViewing && viewingRow) {
+        const proj = viewingRow.projectId
+          ? projects.find((p) => p.id === viewingRow.projectId) ?? null
+          : null;
+        if (proj) await newChat(proj, { switchToChat: true });
+        else await newChat(null, { switchToChat: true });
+      }
+
+      if (ok > 0) {
+        setToast(tr("sidebar.archivedToast", { n: String(ok) }));
+        window.setTimeout(() => setToast(null), 3200);
+      }
+      if (firstFail) {
+        setLocalError(String(firstFail.reason));
+      } else {
+        setLocalError(null);
+      }
+      setArchiveAgeConfirm(null);
+    } catch (e) {
+      setLocalError(String(e));
+    } finally {
+      setArchiveAgeBusy(false);
+    }
   };
 
   /**
@@ -16161,6 +16179,7 @@ export default function App() {
           onArchiveOlderThan={(days) => {
             confirmArchiveOlderThan(days);
           }}
+          archiveAgeSessions={sessions}
           projectPath={effectiveProjectPath}
           onSkillsPrefsChanged={() =>
             setSkillsReloadToken((n) => n + 1)
@@ -19699,6 +19718,81 @@ export default function App() {
         </p>
       </GlassModal>
       <GlassModal
+        open={!!archiveAgeConfirm}
+        onClose={() => {
+          if (archiveAgeBusy) return;
+          setArchiveAgeConfirm(null);
+        }}
+        title={tr("sidebar.archiveOlderTitle")}
+        size="sm"
+        closeLabel={tr("common.close")}
+        closeOnOverlay={!archiveAgeBusy}
+        showClose={!archiveAgeBusy}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              disabled={archiveAgeBusy}
+              onClick={() => setArchiveAgeConfirm(null)}
+            >
+              {tr("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={archiveAgeBusy || !archiveAgeConfirm?.count}
+              data-testid="archive-age-confirm"
+              onClick={() => {
+                if (!archiveAgeConfirm) return;
+                void runArchiveAgePlan(archiveAgeConfirm);
+              }}
+            >
+              {tr("sidebar.archiveOlderConfirmAction", {
+                n: String(archiveAgeConfirm?.count ?? 0),
+              })}
+            </button>
+          </>
+        }
+      >
+        {archiveAgeConfirm ? (
+          <div className="archive-age-modal">
+            <p className="archive-age-modal__msg">
+              {tr("sidebar.archiveOlderConfirm", {
+                n: String(archiveAgeConfirm.count),
+                days: String(archiveAgeConfirm.days),
+              })}
+            </p>
+            {archiveAgeConfirm.previewTitles.length > 0 ? (
+              <div className="archive-age-modal__preview">
+                <div className="archive-age-modal__preview-label">
+                  {tr("sidebar.archiveOlderPreviewLabel")}
+                </div>
+                <ul className="archive-age-modal__list">
+                  {archiveAgeConfirm.previewTitles.map((title, i) => {
+                    const row = archiveAgeConfirm.sessions[i];
+                    const key = row?.id ?? `preview-${i}`;
+                    return (
+                      <li key={key} className="archive-age-modal__item">
+                        {title || tr("session.untitled")}
+                      </li>
+                    );
+                  })}
+                </ul>
+                {archiveAgeConfirm.previewMore > 0 ? (
+                  <div className="archive-age-modal__more">
+                    {tr("sidebar.archiveOlderPreviewMore", {
+                      n: String(archiveAgeConfirm.previewMore),
+                    })}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </GlassModal>
+      <GlassModal
         open={worktreeCreateOpen}
         onClose={() => {
           if (worktreeCreateBusy) return;
@@ -22399,10 +22493,19 @@ export default function App() {
       {(() => {
         let items: ContextMenuItem[] = [];
         if (ctxMenu?.kind === "archive-older") {
-          items = ARCHIVE_AGE_DAY_OPTIONS.map((days) => ({
+          const agePreviews = listArchiveAgeOptionPreviews(sessions);
+          items = agePreviews.map(({ days, count }) => ({
             id: `archive-older-${days}`,
-            label: tr("sidebar.archiveOlderDays", { days: String(days) }),
+            label:
+              count > 0
+                ? tr("sidebar.archiveOlderDaysCount", {
+                    days: String(days),
+                    n: String(count),
+                  })
+                : tr("sidebar.archiveOlderDays", { days: String(days) }),
             icon: <IconArchive size={16} />,
+            // Keep rows clickable when empty so empty-honesty toast can fire.
+            disabled: false,
             onClick: () => {
               confirmArchiveOlderThan(days);
             },

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -42,7 +42,11 @@ import {
   countUnlinkedCliSessions,
   filterCliSessions,
 } from "@/lib/cliSessionsFilter";
-import { ARCHIVE_AGE_DAY_OPTIONS } from "@/lib/sessionArchiveAge";
+import {
+  listArchiveAgeOptionPreviews,
+  hasAnyArchiveAgeMatches,
+  type ArchiveAgeSessionLike,
+} from "@/lib/sessionArchiveAge";
 import { CostRollupPanel } from "@/components/CostRollupPanel";
 import { StreamingMessagesJsonPanel } from "@/components/StreamingMessagesJsonPanel";
 import { StreamingAcpNdjsonPanel } from "@/components/StreamingAcpNdjsonPanel";
@@ -685,6 +689,11 @@ export interface SettingsPageProps {
   onDeleteArchivedSessions?: (ids: string[]) => void;
   /** Bulk-archive active chats older than N days (confirm lives in App). */
   onArchiveOlderThan?: (days: number) => void;
+  /**
+   * Live session rows for archive-by-age preview counts (Settings → Archived).
+   * Filter / empty honesty are pure helpers; confirm GlassModal lives in App.
+   */
+  archiveAgeSessions?: readonly ArchiveAgeSessionLike[];
   /** Active project path for Skills/MCP inspect cwd. */
   projectPath?: string | null;
   /** After skill enable toggle — refresh slash palette in App. */
@@ -1314,6 +1323,7 @@ export function SettingsPage({
   onRestoreArchivedSessions,
   onDeleteArchivedSessions,
   onArchiveOlderThan,
+  archiveAgeSessions = [],
   projectPath = null,
   onSkillsPrefsChanged,
   onOpenShortcutsHelp,
@@ -1864,6 +1874,24 @@ export function SettingsPage({
   );
 
   const archivedTotal = archivedAllIds.length;
+
+  /** Live preview counts for archive-by-age day chips (pure helpers). */
+  const archiveAgePreviews = useMemo(
+    () => listArchiveAgeOptionPreviews(archiveAgeSessions),
+    [archiveAgeSessions],
+  );
+  const archiveAgeAnyMatch = useMemo(
+    () => hasAnyArchiveAgeMatches(archiveAgeSessions),
+    [archiveAgeSessions],
+  );
+  const archiveAgeMaxMatch = useMemo(
+    () =>
+      archiveAgePreviews.reduce(
+        (max, p) => (p.count > max ? p.count : max),
+        0,
+      ),
+    [archiveAgePreviews],
+  );
 
   // Drop stale selection when list changes (restore/delete/refresh).
   useEffect(() => {
@@ -5752,18 +5780,44 @@ export function SettingsPage({
                     role="group"
                     aria-label={t("settings.archived.archiveOlder")}
                   >
-                    {ARCHIVE_AGE_DAY_OPTIONS.map((days) => (
+                    {archiveAgePreviews.map(({ days, count }) => (
                       <button
                         key={days}
                         type="button"
-                        className="btn btn--ghost btn--sm"
+                        className={
+                          "btn btn--ghost btn--sm" +
+                          (count === 0
+                            ? " settings-archived-age__btn--empty"
+                            : "")
+                        }
                         onClick={() => onArchiveOlderThan(days)}
+                        data-count={count}
                       >
-                        {t("settings.archived.archiveOlderDays", {
-                          days: String(days),
-                        })}
+                        {count > 0
+                          ? t("settings.archived.archiveOlderDaysCount", {
+                              days: String(days),
+                              n: String(count),
+                            })
+                          : t("settings.archived.archiveOlderDays", {
+                              days: String(days),
+                            })}
                       </button>
                     ))}
+                  </div>
+                  <div
+                    className={
+                      "settings-archived-age__hint" +
+                      (archiveAgeAnyMatch
+                        ? ""
+                        : " settings-archived-age__hint--empty")
+                    }
+                    role="status"
+                  >
+                    {archiveAgeAnyMatch
+                      ? t("settings.archived.archiveOlderMatchHint", {
+                          n: String(archiveAgeMaxMatch),
+                        })
+                      : t("settings.archived.archiveOlderNoneHint")}
                   </div>
                 </div>
               </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -60,11 +60,23 @@ const en = {
   "sidebar.deletedToast": "Deleted {n} chats",
   "sidebar.archiveOlder": "Archive older than…",
   "sidebar.archiveOlderDays": "Older than {days} days",
+  "sidebar.archiveOlderDaysCount": "Older than {days} days ({n})",
   "sidebar.archiveOlderTitle": "Archive older chats",
   "sidebar.archiveOlderConfirm":
     "Archive {n} chats not updated in the last {days} days? Pinned chats are kept. You can restore them later from Settings → Archived.",
   "sidebar.archiveOlderNone":
     "No unpinned chats older than {days} days.",
+  "sidebar.archiveOlderEmpty.no_sessions":
+    "No chats yet — nothing to archive by age.",
+  "sidebar.archiveOlderEmpty.none_active":
+    "Every chat is already archived. Nothing left to archive by age.",
+  "sidebar.archiveOlderEmpty.all_pinned":
+    "Older chats are pinned (or every active chat is pinned). Unpin to include them.",
+  "sidebar.archiveOlderEmpty.all_recent":
+    "No unpinned chats older than {days} days — all active chats are still recent.",
+  "sidebar.archiveOlderPreviewLabel": "Will archive:",
+  "sidebar.archiveOlderPreviewMore": "…and {n} more",
+  "sidebar.archiveOlderConfirmAction": "Archive {n}",
   "user.menu": "Account menu",
   "user.theme": "Theme",
   "user.themeLight": "Switch to light",
@@ -1313,8 +1325,13 @@ const en = {
   "settings.archived.totalCount": "{n} archived",
   "settings.archived.archiveOlder": "Archive older than…",
   "settings.archived.archiveOlderDesc":
-    "Bulk-archive active chats whose last update is older than the threshold. Pinned chats are skipped.",
+    "Bulk-archive active chats whose last update is older than the threshold. Pinned chats are skipped. Counts update from the live session list.",
   "settings.archived.archiveOlderDays": "{days} days",
+  "settings.archived.archiveOlderDaysCount": "{days} days ({n})",
+  "settings.archived.archiveOlderMatchHint":
+    "{n} chats match · pinned kept · restore from this page",
+  "settings.archived.archiveOlderNoneHint":
+    "No unpinned chats older than these thresholds right now.",
   "settings.section.permissions": "Permissions",
   "settings.section.composer": "Composer prefs",
   "settings.section.voice": "Voice",
@@ -5214,10 +5231,21 @@ const zh: Record<MessageKey, string> = {
   "sidebar.deletedToast": "已永久删除 {n} 个会话",
   "sidebar.archiveOlder": "归档超过…天的会话",
   "sidebar.archiveOlderDays": "超过 {days} 天",
+  "sidebar.archiveOlderDaysCount": "超过 {days} 天（{n}）",
   "sidebar.archiveOlderTitle": "按时间归档",
   "sidebar.archiveOlderConfirm":
     "将归档 {n} 个超过 {days} 天未更新的会话？置顶会话会保留。之后可在「设置 → 已归档会话」中还原。",
   "sidebar.archiveOlderNone": "没有超过 {days} 天且未置顶的会话。",
+  "sidebar.archiveOlderEmpty.no_sessions": "还没有会话，无法按时间归档。",
+  "sidebar.archiveOlderEmpty.none_active":
+    "所有会话都已归档，没有可再按时间归档的会话。",
+  "sidebar.archiveOlderEmpty.all_pinned":
+    "较旧的会话已置顶（或当前活跃会话全部置顶）。取消置顶后才会被纳入。",
+  "sidebar.archiveOlderEmpty.all_recent":
+    "没有超过 {days} 天且未置顶的会话——当前活跃会话都还比较新。",
+  "sidebar.archiveOlderPreviewLabel": "将归档：",
+  "sidebar.archiveOlderPreviewMore": "…还有 {n} 个",
+  "sidebar.archiveOlderConfirmAction": "归档 {n} 个",
   "user.menu": "个人中心",
   "user.theme": "主题",
   "user.themeLight": "切换到浅色",
@@ -6411,8 +6439,13 @@ const zh: Record<MessageKey, string> = {
   "settings.archived.totalCount": "共 {n} 条",
   "settings.archived.archiveOlder": "归档超过…天的会话",
   "settings.archived.archiveOlderDesc":
-    "批量归档最后更新时间超过阈值的活跃会话。置顶会话会跳过。",
+    "批量归档最后更新时间超过阈值的活跃会话。置顶会话会跳过。数量来自当前会话列表实时预览。",
   "settings.archived.archiveOlderDays": "{days} 天",
+  "settings.archived.archiveOlderDaysCount": "{days} 天（{n}）",
+  "settings.archived.archiveOlderMatchHint":
+    "{n} 个会话符合条件 · 置顶保留 · 可在本页还原",
+  "settings.archived.archiveOlderNoneHint":
+    "当前没有超过这些阈值且未置顶的会话。",
   "settings.section.permissions": "权限",
   "settings.section.composer": "对话偏好",
   "settings.section.voice": "语音",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -52,10 +52,21 @@ export const zhTW: Record<MessageKey, string> = {
   "sidebar.deletedToast": "已永久刪除 {n} 個對話",
   "sidebar.archiveOlder": "封存超過…天的對話",
   "sidebar.archiveOlderDays": "超過 {days} 天",
+  "sidebar.archiveOlderDaysCount": "超過 {days} 天（{n}）",
   "sidebar.archiveOlderTitle": "依時間封存",
   "sidebar.archiveOlderConfirm":
     "將封存 {n} 個超過 {days} 天未更新的對話？已置頂對話會保留。之後可在「設定 → 已封存對話」中還原。",
   "sidebar.archiveOlderNone": "沒有超過 {days} 天且未置頂的對話。",
+  "sidebar.archiveOlderEmpty.no_sessions": "還沒有對話，無法依時間封存。",
+  "sidebar.archiveOlderEmpty.none_active":
+    "所有對話都已封存，沒有可再依時間封存的對話。",
+  "sidebar.archiveOlderEmpty.all_pinned":
+    "較舊的對話已置頂（或目前活躍對話全部置頂）。取消置頂後才會被納入。",
+  "sidebar.archiveOlderEmpty.all_recent":
+    "沒有超過 {days} 天且未置頂的對話——目前活躍對話都還比較新。",
+  "sidebar.archiveOlderPreviewLabel": "將封存：",
+  "sidebar.archiveOlderPreviewMore": "…還有 {n} 個",
+  "sidebar.archiveOlderConfirmAction": "封存 {n} 個",
   "user.menu": "個人中心",
   "user.theme": "主題",
   "user.themeLight": "切換為淺色",
@@ -1249,8 +1260,13 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.archived.totalCount": "共 {n} 條",
   "settings.archived.archiveOlder": "封存超過…天的對話",
   "settings.archived.archiveOlderDesc":
-    "批次封存最後更新時間超過閾值的活躍對話。已置頂對話會略過。",
+    "批次封存最後更新時間超過閾值的活躍對話。已置頂對話會略過。數量來自目前對話列表即時預覽。",
   "settings.archived.archiveOlderDays": "{days} 天",
+  "settings.archived.archiveOlderDaysCount": "{days} 天（{n}）",
+  "settings.archived.archiveOlderMatchHint":
+    "{n} 個對話符合條件 · 置頂保留 · 可在本頁還原",
+  "settings.archived.archiveOlderNoneHint":
+    "目前沒有超過這些閾值且未置頂的對話。",
   "settings.section.permissions": "權限",
   "settings.section.composer": "對話偏好",
   "settings.section.voice": "語音",

--- a/src/lib/sessionArchiveAge.test.ts
+++ b/src/lib/sessionArchiveAge.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
   ARCHIVE_AGE_DAY_OPTIONS,
+  ARCHIVE_AGE_PREVIEW_LIMIT,
+  archiveAgeEmptyMessageKey,
+  archiveAgePreviewTitles,
+  countSessionsOlderThanDays,
   daysToMs,
   filterSessionsOlderThanDays,
+  hasAnyArchiveAgeMatches,
   isSessionOlderThanDays,
+  listArchiveAgeOptionPreviews,
+  planArchiveOlderThan,
+  resolveArchiveAgeEmpty,
 } from "./sessionArchiveAge";
 
 const NOW = new Date("2026-07-30T12:00:00.000Z").getTime();
@@ -97,5 +105,205 @@ describe("filterSessionsOlderThanDays", () => {
     expect(
       filterSessionsOlderThanDays(shuffled, 7, NOW).map((s) => s.id),
     ).toEqual(["old90", "old7", "old30"]);
+  });
+});
+
+describe("countSessionsOlderThanDays", () => {
+  it("matches filter length", () => {
+    const rows = [
+      { id: "a", updatedAt: isoDaysAgo(10), archived: false, pinned: false },
+      { id: "b", updatedAt: isoDaysAgo(1), archived: false, pinned: false },
+    ];
+    expect(countSessionsOlderThanDays(rows, 7, NOW)).toBe(1);
+    expect(countSessionsOlderThanDays([], 7, NOW)).toBe(0);
+  });
+});
+
+describe("resolveArchiveAgeEmpty / empty honesty", () => {
+  it("returns no_sessions for empty catalog", () => {
+    expect(resolveArchiveAgeEmpty([], 7, NOW)).toBe("no_sessions");
+  });
+
+  it("returns null when matches exist", () => {
+    const rows = [
+      { id: "old", updatedAt: isoDaysAgo(10), archived: false, pinned: false },
+    ];
+    expect(resolveArchiveAgeEmpty(rows, 7, NOW)).toBe(null);
+  });
+
+  it("returns none_active when every row is archived", () => {
+    const rows = [
+      { id: "a", updatedAt: isoDaysAgo(100), archived: true, pinned: false },
+      { id: "b", updatedAt: isoDaysAgo(1), archived: true, pinned: false },
+    ];
+    expect(resolveArchiveAgeEmpty(rows, 7, NOW)).toBe("none_active");
+  });
+
+  it("returns all_pinned when older actives are all pinned", () => {
+    const rows = [
+      { id: "p", updatedAt: isoDaysAgo(40), archived: false, pinned: true },
+      { id: "fresh", updatedAt: isoDaysAgo(1), archived: false, pinned: false },
+    ];
+    expect(resolveArchiveAgeEmpty(rows, 30, NOW)).toBe("all_pinned");
+  });
+
+  it("returns all_pinned when every active is pinned (none older unpinned)", () => {
+    const rows = [
+      { id: "p1", updatedAt: isoDaysAgo(1), archived: false, pinned: true },
+      { id: "p2", updatedAt: isoDaysAgo(100), archived: false, pinned: true },
+    ];
+    expect(resolveArchiveAgeEmpty(rows, 7, NOW)).toBe("all_pinned");
+  });
+
+  it("returns all_recent when unpinned actives exist but are within threshold", () => {
+    const rows = [
+      { id: "a", updatedAt: isoDaysAgo(3), archived: false, pinned: false },
+      { id: "b", updatedAt: isoDaysAgo(1), archived: false, pinned: false },
+    ];
+    expect(resolveArchiveAgeEmpty(rows, 7, NOW)).toBe("all_recent");
+  });
+
+  it("maps empty kinds to message keys", () => {
+    expect(archiveAgeEmptyMessageKey("no_sessions")).toBe(
+      "sidebar.archiveOlderEmpty.no_sessions",
+    );
+    expect(archiveAgeEmptyMessageKey("none_active")).toBe(
+      "sidebar.archiveOlderEmpty.none_active",
+    );
+    expect(archiveAgeEmptyMessageKey("all_pinned")).toBe(
+      "sidebar.archiveOlderEmpty.all_pinned",
+    );
+    expect(archiveAgeEmptyMessageKey("all_recent")).toBe(
+      "sidebar.archiveOlderEmpty.all_recent",
+    );
+  });
+});
+
+describe("archiveAgePreviewTitles", () => {
+  it("trims titles and reports more beyond limit", () => {
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      id: `id-${i}`,
+      title: `  Chat ${i}  `,
+    }));
+    const { titles, more } = archiveAgePreviewTitles(rows, 3);
+    expect(titles).toEqual(["Chat 0", "Chat 1", "Chat 2"]);
+    expect(more).toBe(7);
+  });
+
+  it("keeps empty titles as empty strings (UI falls back to untitled)", () => {
+    const { titles, more } = archiveAgePreviewTitles(
+      [
+        { id: "a", title: "  " },
+        { id: "b", title: null },
+        { id: "c", title: "Hi" },
+      ],
+      8,
+    );
+    expect(titles).toEqual(["", "", "Hi"]);
+    expect(more).toBe(0);
+  });
+
+  it("defaults to ARCHIVE_AGE_PREVIEW_LIMIT", () => {
+    const rows = Array.from({ length: ARCHIVE_AGE_PREVIEW_LIMIT + 2 }, (_, i) => ({
+      id: `id-${i}`,
+      title: `T${i}`,
+    }));
+    const { titles, more } = archiveAgePreviewTitles(rows);
+    expect(titles).toHaveLength(ARCHIVE_AGE_PREVIEW_LIMIT);
+    expect(more).toBe(2);
+  });
+});
+
+describe("planArchiveOlderThan", () => {
+  const rows = [
+    {
+      id: "old",
+      title: "Old chat",
+      updatedAt: isoDaysAgo(40),
+      archived: false,
+      pinned: false,
+    },
+    {
+      id: "fresh",
+      title: "Fresh",
+      updatedAt: isoDaysAgo(1),
+      archived: false,
+      pinned: false,
+    },
+    {
+      id: "pin",
+      title: "Pinned old",
+      updatedAt: isoDaysAgo(40),
+      archived: false,
+      pinned: true,
+    },
+  ];
+
+  it("plans confirm when matches exist", () => {
+    const plan = planArchiveOlderThan(rows, 30, NOW);
+    expect(plan.confirmNeeded).toBe(true);
+    expect(plan.count).toBe(1);
+    expect(plan.sessions.map((s) => s.id)).toEqual(["old"]);
+    expect(plan.emptyKind).toBe(null);
+    expect(plan.previewTitles).toEqual(["Old chat"]);
+    expect(plan.previewMore).toBe(0);
+    expect(plan.logMeta).toEqual({
+      days: 30,
+      count: 1,
+      ids: ["old"],
+    });
+  });
+
+  it("does not confirm when empty; sets honest emptyKind", () => {
+    const onlyFresh = [
+      {
+        id: "f",
+        title: "F",
+        updatedAt: isoDaysAgo(1),
+        archived: false,
+        pinned: false,
+      },
+    ];
+    const plan = planArchiveOlderThan(onlyFresh, 7, NOW);
+    expect(plan.confirmNeeded).toBe(false);
+    expect(plan.count).toBe(0);
+    expect(plan.emptyKind).toBe("all_recent");
+    expect(plan.logMeta).toBe(null);
+    expect(plan.previewTitles).toEqual([]);
+  });
+
+  it("never invents logMeta ids for empty plan", () => {
+    const plan = planArchiveOlderThan([], 7, NOW);
+    expect(plan.emptyKind).toBe("no_sessions");
+    expect(plan.logMeta).toBe(null);
+  });
+});
+
+describe("listArchiveAgeOptionPreviews / hasAnyArchiveAgeMatches", () => {
+  it("lists counts for 7 / 30 / 90", () => {
+    const rows = [
+      { id: "a", updatedAt: isoDaysAgo(10), archived: false, pinned: false },
+      { id: "b", updatedAt: isoDaysAgo(40), archived: false, pinned: false },
+      { id: "c", updatedAt: isoDaysAgo(100), archived: false, pinned: false },
+    ];
+    const previews = listArchiveAgeOptionPreviews(rows, NOW);
+    expect(previews.map((p) => p.days)).toEqual([7, 30, 90]);
+    expect(previews.map((p) => p.count)).toEqual([3, 2, 1]);
+    expect(previews.every((p) => p.emptyKind === null)).toBe(true);
+    expect(hasAnyArchiveAgeMatches(rows, NOW)).toBe(true);
+  });
+
+  it("sets emptyKind per threshold when zero matches", () => {
+    const rows = [
+      { id: "f", updatedAt: isoDaysAgo(1), archived: false, pinned: false },
+    ];
+    const previews = listArchiveAgeOptionPreviews(rows, NOW);
+    expect(previews.every((p) => p.count === 0)).toBe(true);
+    expect(previews.every((p) => p.emptyKind === "all_recent")).toBe(true);
+    expect(hasAnyArchiveAgeMatches(rows, NOW)).toBe(false);
+  });
+
+  it("returns false for empty catalog", () => {
+    expect(hasAnyArchiveAgeMatches([], NOW)).toBe(false);
   });
 });

--- a/src/lib/sessionArchiveAge.ts
+++ b/src/lib/sessionArchiveAge.ts
@@ -1,6 +1,7 @@
 /**
  * Pure helpers for bulk-archive-by-age (sidebar / Settings).
- * Filters only — host archive is still `session_set_archived`.
+ * Filters + preview plan + empty honesty only — host archive is still
+ * `session_set_archived`. No DOM / Tauri side effects.
  */
 
 /** Supported thresholds in the “Archive older than…” picker. */
@@ -8,12 +9,34 @@ export const ARCHIVE_AGE_DAY_OPTIONS = [7, 30, 90] as const;
 
 export type ArchiveAgeDays = (typeof ARCHIVE_AGE_DAY_OPTIONS)[number];
 
+/** Max titles shown in the GlassModal preview list. */
+export const ARCHIVE_AGE_PREVIEW_LIMIT = 8;
+
 export type ArchiveAgeSessionLike = {
   id: string;
   updatedAt: string;
   archived?: boolean;
   pinned?: boolean;
+  /** Optional title for confirm-modal preview (never required for filter). */
+  title?: string | null;
 };
+
+/**
+ * Honest empty reasons when no session is eligible for archive-by-age.
+ * `null` means matches exist (caller should confirm).
+ */
+export type ArchiveAgeEmptyKind =
+  | "no_sessions"
+  | "none_active"
+  | "all_pinned"
+  | "all_recent";
+
+/** i18n keys for {@link ArchiveAgeEmptyKind}. */
+export type ArchiveAgeEmptyMessageKey =
+  | "sidebar.archiveOlderEmpty.no_sessions"
+  | "sidebar.archiveOlderEmpty.none_active"
+  | "sidebar.archiveOlderEmpty.all_pinned"
+  | "sidebar.archiveOlderEmpty.all_recent";
 
 /** Milliseconds for `days` full days (UTC-safe wall-clock delta). */
 export function daysToMs(days: number): number {
@@ -56,5 +79,193 @@ export function filterSessionsOlderThanDays<T extends ArchiveAgeSessionLike>(
       !s.archived &&
       !s.pinned &&
       isSessionOlderThanDays(s.updatedAt, days, now),
+  );
+}
+
+/** Count of sessions eligible for archive-by-age (pure). */
+export function countSessionsOlderThanDays(
+  sessions: readonly ArchiveAgeSessionLike[],
+  days: number,
+  now: Date | number = Date.now(),
+): number {
+  return filterSessionsOlderThanDays(sessions, days, now).length;
+}
+
+/**
+ * Resolve why nothing is eligible for archive-by-age.
+ * Returns `null` when at least one session matches.
+ *
+ * Priority when empty:
+ * 1. no_sessions — catalog empty
+ * 2. none_active — every row is already archived
+ * 3. all_pinned — age-matching active rows exist but all are pinned
+ *    (or no unpinned active rows at all)
+ * 4. all_recent — active unpinned rows exist, but none older than threshold
+ */
+export function resolveArchiveAgeEmpty(
+  sessions: readonly ArchiveAgeSessionLike[],
+  days: number,
+  now: Date | number = Date.now(),
+): ArchiveAgeEmptyKind | null {
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    return "no_sessions";
+  }
+  if (countSessionsOlderThanDays(sessions, days, now) > 0) {
+    return null;
+  }
+  if (!Number.isFinite(days) || days <= 0) {
+    return "all_recent";
+  }
+
+  const active = sessions.filter((s) => !s.archived);
+  if (active.length === 0) return "none_active";
+
+  const olderActive = active.filter((s) =>
+    isSessionOlderThanDays(s.updatedAt, days, now),
+  );
+  if (olderActive.length > 0) {
+    // Eligible filter already excluded pinned → every older active is pinned.
+    return "all_pinned";
+  }
+
+  const activeUnpinned = active.filter((s) => !s.pinned);
+  if (activeUnpinned.length === 0) return "all_pinned";
+  return "all_recent";
+}
+
+/** Map empty kind → MessageKey for toast / modal honesty. */
+export function archiveAgeEmptyMessageKey(
+  kind: ArchiveAgeEmptyKind,
+): ArchiveAgeEmptyMessageKey {
+  switch (kind) {
+    case "no_sessions":
+      return "sidebar.archiveOlderEmpty.no_sessions";
+    case "none_active":
+      return "sidebar.archiveOlderEmpty.none_active";
+    case "all_pinned":
+      return "sidebar.archiveOlderEmpty.all_pinned";
+    case "all_recent":
+    default:
+      return "sidebar.archiveOlderEmpty.all_recent";
+  }
+}
+
+/**
+ * One-line titles for GlassModal preview.
+ * Empty / whitespace titles become "" so the UI can fall back to untitled.
+ * Preserves input order; never invents session names.
+ */
+export function archiveAgePreviewTitles(
+  sessions: readonly Pick<ArchiveAgeSessionLike, "id" | "title">[],
+  limit: number = ARCHIVE_AGE_PREVIEW_LIMIT,
+): { titles: string[]; more: number } {
+  const max =
+    Number.isFinite(limit) && limit > 0
+      ? Math.floor(limit)
+      : ARCHIVE_AGE_PREVIEW_LIMIT;
+  const list = Array.isArray(sessions) ? sessions : [];
+  const slice = list.slice(0, max);
+  const titles = slice.map((s) => {
+    const t = typeof s.title === "string" ? s.title.trim() : "";
+    return t;
+  });
+  return {
+    titles,
+    more: Math.max(0, list.length - titles.length),
+  };
+}
+
+/**
+ * Pure plan for archive-by-age confirm.
+ * Caller owns GlassModal + `session_set_archived`.
+ */
+export type ArchiveAgePlan<T extends ArchiveAgeSessionLike = ArchiveAgeSessionLike> =
+  {
+    days: number;
+    sessions: T[];
+    count: number;
+    /** True when UI should open GlassModal before archiving. */
+    confirmNeeded: boolean;
+    /** Set when count is 0 — honest empty reason. */
+    emptyKind: ArchiveAgeEmptyKind | null;
+    /** Sample titles for confirm body (may include ""). */
+    previewTitles: string[];
+    /** Sessions beyond the preview list. */
+    previewMore: number;
+    /** Safe meta for logs — ids + count only, never titles. */
+    logMeta: { days: number; count: number; ids: string[] } | null;
+  };
+
+/**
+ * Build an archive-by-age plan for `days`.
+ * Does not mutate storage or call the host.
+ */
+export function planArchiveOlderThan<T extends ArchiveAgeSessionLike>(
+  sessions: readonly T[],
+  days: number,
+  now: Date | number = Date.now(),
+  previewLimit: number = ARCHIVE_AGE_PREVIEW_LIMIT,
+): ArchiveAgePlan<T> {
+  const safeDays = Number.isFinite(days) ? days : 0;
+  const matched = filterSessionsOlderThanDays(sessions, safeDays, now);
+  const count = matched.length;
+  const emptyKind =
+    count > 0 ? null : resolveArchiveAgeEmpty(sessions, safeDays, now);
+  const preview = archiveAgePreviewTitles(matched, previewLimit);
+  return {
+    days: safeDays,
+    sessions: matched,
+    count,
+    confirmNeeded: count > 0,
+    emptyKind,
+    previewTitles: preview.titles,
+    previewMore: preview.more,
+    logMeta:
+      count > 0
+        ? {
+            days: safeDays,
+            count,
+            ids: matched.map((s) => s.id),
+          }
+        : null,
+  };
+}
+
+/** Live count chip for one day option (sidebar menu / Settings buttons). */
+export type ArchiveAgeOptionPreview = {
+  days: ArchiveAgeDays;
+  count: number;
+  emptyKind: ArchiveAgeEmptyKind | null;
+};
+
+/**
+ * Preview counts for every supported day threshold.
+ * Used to badge “Older than N days (k)” before the user confirms.
+ */
+export function listArchiveAgeOptionPreviews(
+  sessions: readonly ArchiveAgeSessionLike[],
+  now: Date | number = Date.now(),
+): ArchiveAgeOptionPreview[] {
+  return ARCHIVE_AGE_DAY_OPTIONS.map((days) => {
+    const count = countSessionsOlderThanDays(sessions, days, now);
+    return {
+      days,
+      count,
+      emptyKind:
+        count > 0 ? null : resolveArchiveAgeEmpty(sessions, days, now),
+    };
+  });
+}
+
+/**
+ * True when at least one day option has eligible sessions.
+ * Useful for empty-honesty banners on the Settings card.
+ */
+export function hasAnyArchiveAgeMatches(
+  sessions: readonly ArchiveAgeSessionLike[],
+  now: Date | number = Date.now(),
+): boolean {
+  return ARCHIVE_AGE_DAY_OPTIONS.some(
+    (days) => countSessionsOlderThanDays(sessions, days, now) > 0,
   );
 }

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -2058,10 +2058,16 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     section: "archived",
     anchorId: "settings-anchor-archive-older",
     labelKey: "settings.archived.archiveOlder",
-    descKeys: ["settings.archived.archiveOlderDesc"],
+    descKeys: [
+      "settings.archived.archiveOlderDesc",
+      "settings.archived.archiveOlderMatchHint",
+      "settings.archived.archiveOlderNoneHint",
+    ],
     keywords: [
       "archive older",
       "bulk archive",
+      "archive by age",
+      "preview count",
       "old chats",
       "7 days",
       "30 days",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4423,6 +4423,80 @@ html[data-sidebar-density="compact"] .session-row__meta {
   margin-top: 10px;
 }
 
+.settings-archived-age__btn--empty {
+  opacity: 0.72;
+}
+
+.settings-archived-age__hint {
+  margin-top: 10px;
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--text-tertiary);
+}
+
+.settings-archived-age__hint--empty {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+/* Archive-by-age pro confirm (GlassModal body) */
+.archive-age-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.archive-age-modal__msg {
+  margin: 0;
+  white-space: pre-wrap;
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.archive-age-modal__preview {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated, var(--bg-card));
+}
+
+.archive-age-modal__preview-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}
+
+.archive-age-modal__list {
+  margin: 0;
+  padding: 0 0 0 1.1em;
+  list-style: disc;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 180px;
+  overflow: auto;
+}
+
+.archive-age-modal__item {
+  font-size: 13px;
+  line-height: 1.35;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.archive-age-modal__more {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
 .settings-archived-toolbar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Deepens **bulk archive-by-age** (7 / 30 / 90 days) for sidebar + Settings → Archived:

- **Live preview counts** on day chips / context-menu rows before confirm
- **GlassModal confirm** with sample session titles + “…and N more” (no `window.confirm`)
- **Empty honesty** when nothing matches: no chats · all archived · all pinned · all recent
- Pure `sessionArchiveAge` plan/preview helpers + unit tests
- i18n en / zh / zh-TW; CHANGELOG; `settingsCatalog` keywords

## Test plan

- [ ] Sidebar → archive-older menu shows counts like “Older than 30 days (n)”
- [ ] Choosing a day with matches opens GlassModal with preview list; Cancel / Archive work
- [ ] Choosing a day with 0 matches shows classified toast (not a blank confirm)
- [ ] Settings → Archived chips mirror live counts + match/empty hint
- [ ] Pinned sessions never appear in the eligible set
- [ ] `pnpm test -- src/lib/sessionArchiveAge.test.ts src/i18n/messages.test.ts`