### PR TITLE
feat(git): PR review prompts for CI fails and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **PR review workbench** (Settings → Runtime → Tools → Pull requests): when CI overall fails, **Fix with Grok** builds a composer draft from observed failed checks; each comment/review row gets **Ask Grok** for a comment-address draft. Inserts into the workbench composer + soft toast (never auto-sends; no invented `gh` data). Pure `prReviewWorkbench` helpers + tests; en/zh/zh-TW.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16457,6 +16457,14 @@ export default function App() {
           phoneLayout={phoneLayout}
           focusAnchorId={settingsFocusAnchor}
           prHubHighlightPr={prHubHighlightPr}
+          onPrReviewDraftToChat={(prompt) => {
+            const text = (prompt ?? "").trim();
+            if (!text) return;
+            setDraft(text);
+            navigateWorkbench();
+            requestComposerFocus();
+            showToast(tr("prHub.draftInsertedToast"), 2800);
+          }}
           onFocusAnchorConsumed={() => setSettingsFocusAnchor(null)}
           labels={settingsLabels}
           locale={locale}

--- a/src/components/GitPrHubPanel.tsx
+++ b/src/components/GitPrHubPanel.tsx
@@ -17,6 +17,7 @@ import {
   classifyPrHubReason,
   formatChecksSummaryLine,
   normalizeMergeable,
+  summarizeChecks,
   type GitPrCheckEntry,
   type GitPrCommentEntry,
   type GitPrHubEntry,
@@ -26,6 +27,12 @@ import {
   isHighlightedPr,
   sanitizePrNumber,
 } from "@/lib/prHubDeepLink";
+import {
+  buildFixCiPrompt,
+  buildPrCommentPrompt,
+  canSuggestFixCi,
+  listFailedChecks,
+} from "@/lib/prReviewWorkbench";
 import {
   IconChevronDown,
   IconChevronRight,
@@ -44,6 +51,12 @@ export interface GitPrHubPanelProps {
    * Soft-no-op when the number is missing from the current list.
    */
   highlightPrNumber?: number | null;
+  /**
+   * Insert a Fix-CI / comment prompt into the workbench composer.
+   * When omitted, "Fix with Grok" / "Ask Grok" action buttons stay hidden
+   * (honest: no silent no-op).
+   */
+  onDraftToChat?: (prompt: string) => void;
 }
 
 function ChecksBadge({
@@ -224,12 +237,15 @@ function CommentsDetail({
   error,
   conversationUrl,
   tr,
+  onAskGrok,
 }: {
   comments: GitPrCommentEntry[] | null;
   loading: boolean;
   error: string | null;
   conversationUrl?: string | null;
   tr: (key: MessageKey, vars?: Record<string, string | number>) => string;
+  /** Per-row Ask Grok; omit to hide action buttons. */
+  onAskGrok?: (comment: GitPrCommentEntry) => void;
 }) {
   if (loading) {
     return (
@@ -259,6 +275,8 @@ function CommentsDetail({
           const stateLabel =
             c.kind === "review" ? reviewStateLabel(c.state, tr) : null;
           const openTarget = c.url || conversationUrl || null;
+          const canAsk =
+            typeof onAskGrok === "function" && Boolean(c.body?.trim());
           return (
             <li key={c.id} className="pr-hub__comment-row">
               <div className="pr-hub__comment-head">
@@ -274,17 +292,30 @@ function CommentsDetail({
                     {tr("prHub.comments.comment")}
                   </span>
                 )}
-                {openTarget ? (
-                  <button
-                    type="button"
-                    className="btn btn--ghost btn--sm pr-hub__comment-link"
-                    onClick={() => void openUrl(openTarget)}
-                    title={openTarget}
-                    aria-label={tr("prHub.comments.open")}
-                  >
-                    <IconExternalLink size={12} />
-                  </button>
-                ) : null}
+                <span className="pr-hub__comment-actions">
+                  {canAsk ? (
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm pr-hub__ask-grok"
+                      onClick={() => onAskGrok?.(c)}
+                      title={tr("prHub.comments.askGrokTitle")}
+                      aria-label={tr("prHub.comments.askGrok")}
+                    >
+                      {tr("prHub.comments.askGrok")}
+                    </button>
+                  ) : null}
+                  {openTarget ? (
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm pr-hub__comment-link"
+                      onClick={() => void openUrl(openTarget)}
+                      title={openTarget}
+                      aria-label={tr("prHub.comments.open")}
+                    >
+                      <IconExternalLink size={12} />
+                    </button>
+                  ) : null}
+                </span>
               </div>
               <p className="pr-hub__comment-excerpt" title={c.body || undefined}>
                 {c.excerpt || tr("prHub.comments.emptyBody")}
@@ -312,10 +343,12 @@ export function GitPrHubPanel({
   projectPath = null,
   hideHeader = false,
   highlightPrNumber = null,
+  onDraftToChat,
 }: GitPrHubPanelProps) {
   const tr = useMemo(() => createT(locale), [locale]);
   const cwd = projectPath?.trim() || null;
   const highlightN = sanitizePrNumber(highlightPrNumber);
+  const canDraft = typeof onDraftToChat === "function";
 
   const [prs, setPrs] = useState<GitPrHubEntry[]>([]);
   const [loading, setLoading] = useState(false);
@@ -505,6 +538,50 @@ export function GitPrHubPanel({
     });
   };
 
+  const draftFixCi = useCallback(
+    (pr: GitPrHubEntry) => {
+      if (!canDraft || !onDraftToChat) return;
+      const loaded = checksByPr[pr.number];
+      const failed = listFailedChecks(loaded ?? []);
+      const prompt = buildFixCiPrompt({
+        prNumber: pr.number,
+        title: pr.title || "",
+        url: pr.url || null,
+        headRef: pr.headRefName ?? null,
+        baseRef: pr.baseRefName ?? null,
+        failedChecks: failed.map((c) => ({
+          name: c.name,
+          state: c.state || c.bucket,
+          description: c.description ?? null,
+        })),
+        bodyExcerpt: pr.body ?? null,
+      });
+      if (!prompt.trim()) return;
+      onDraftToChat(prompt);
+    },
+    [canDraft, onDraftToChat, checksByPr],
+  );
+
+  const draftComment = useCallback(
+    (pr: GitPrHubEntry, comment: GitPrCommentEntry) => {
+      if (!canDraft || !onDraftToChat) return;
+      const prompt = buildPrCommentPrompt({
+        prNumber: pr.number,
+        title: pr.title || "",
+        comment: {
+          author: comment.author || "",
+          body: comment.body || "",
+          kind: comment.kind,
+          state: comment.state ?? null,
+          url: comment.url ?? null,
+        },
+      });
+      if (!prompt.trim()) return;
+      onDraftToChat(prompt);
+    },
+    [canDraft, onDraftToChat],
+  );
+
   const reasonKind = classifyPrHubReason(reason);
   const softMessage = (() => {
     if (!cwd) {
@@ -566,6 +643,13 @@ export function GitPrHubPanel({
           const conversationUrl =
             conversationUrlByPr[pr.number] || pr.url || null;
           const highlighted = isHighlightedPr(pr.number, highlightN);
+          const loadedChecks = checksByPr[pr.number];
+          const effectiveSummary: PrChecksSummary | null | undefined =
+            loadedChecks != null && loadedChecks.length > 0
+              ? summarizeChecks(loadedChecks)
+              : pr.checks;
+          const showFixCi =
+            canDraft && canSuggestFixCi(effectiveSummary);
           return (
             <li
               key={pr.number}
@@ -642,6 +726,18 @@ export function GitPrHubPanel({
                       <h4 className="pr-hub__section-title">
                         {tr("prHub.checks.title")}
                       </h4>
+                      {showFixCi ? (
+                        <button
+                          type="button"
+                          className="btn btn--ghost btn--sm pr-hub__fix-ci"
+                          onClick={() => draftFixCi(pr)}
+                          title={tr("prHub.checks.fixCiTitle")}
+                          aria-label={tr("prHub.checks.fixCi")}
+                          data-testid={`pr-hub-fix-ci-${pr.number}`}
+                        >
+                          {tr("prHub.checks.fixCi")}
+                        </button>
+                      ) : null}
                     </div>
                     <ChecksDetail
                       checks={checksByPr[pr.number] ?? null}
@@ -674,6 +770,11 @@ export function GitPrHubPanel({
                       error={commentsError[pr.number] ?? null}
                       conversationUrl={conversationUrl}
                       tr={tr}
+                      onAskGrok={
+                        canDraft
+                          ? (c) => draftComment(pr, c)
+                          : undefined
+                      }
                     />
                   </section>
                 </div>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -763,6 +763,11 @@ export interface SettingsPageProps {
   focusAnchorId?: string | null;
   /** Optional PR number to highlight in Git PR hub (`?pr=` / ship success). */
   prHubHighlightPr?: number | null;
+  /**
+   * Insert a PR review prompt (Fix CI / comment → Grok) into the workbench
+   * composer. When omitted, GitPrHubPanel hides those action buttons.
+   */
+  onPrReviewDraftToChat?: (prompt: string) => void;
   /** Called once after focusAnchorId is applied (parent can clear). */
   onFocusAnchorConsumed?: () => void;
   /** After skill enable toggle — refresh slash palette in App. */
@@ -1444,6 +1449,7 @@ export function SettingsPage({
   onOpenProjectFileInResources,
   focusAnchorId = null,
   prHubHighlightPr = null,
+  onPrReviewDraftToChat,
   onFocusAnchorConsumed,
   onSkillsPrefsChanged,
   onOpenShortcutsHelp,
@@ -7308,6 +7314,7 @@ export function SettingsPage({
                       projectPath={projectPath}
                       hideHeader
                       highlightPrNumber={prHubHighlightPr}
+                      onDraftToChat={onPrReviewDraftToChat}
                     />
                   </div>
                 </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -6133,6 +6133,9 @@ const en = {
   "prHub.checks.none": "No checks",
   "prHub.checks.loading": "Loading checks…",
   "prHub.checks.failed": "Could not load checks",
+  "prHub.checks.fixCi": "Fix with Grok",
+  "prHub.checks.fixCiTitle":
+    "Insert a draft into the composer asking Grok to fix failing CI (does not auto-send)",
   "prHub.comments.title": "Recent comments",
   "prHub.comments.loading": "Loading comments…",
   "prHub.comments.failed": "Could not load comments",
@@ -6142,6 +6145,10 @@ const en = {
   "prHub.comments.open": "Open comment",
   "prHub.comments.unknownAuthor": "Unknown",
   "prHub.comments.emptyBody": "(no body)",
+  "prHub.comments.askGrok": "Ask Grok",
+  "prHub.comments.askGrokTitle":
+    "Insert a draft into the composer about this comment (does not auto-send)",
+  "prHub.draftInsertedToast": "Draft inserted into composer",
   "prHub.review.approved": "Approved",
   "prHub.review.changesRequested": "Changes requested",
   "prHub.review.commented": "Commented",
@@ -12054,6 +12061,9 @@ const zh: Record<MessageKey, string> = {
   "prHub.checks.none": "无检查",
   "prHub.checks.loading": "正在加载检查…",
   "prHub.checks.failed": "无法加载检查",
+  "prHub.checks.fixCi": "用 Grok 修复",
+  "prHub.checks.fixCiTitle":
+    "将修复 CI 的草稿插入输入框（不会自动发送）",
   "prHub.comments.title": "近期评论",
   "prHub.comments.loading": "正在加载评论…",
   "prHub.comments.failed": "无法加载评论",
@@ -12063,6 +12073,10 @@ const zh: Record<MessageKey, string> = {
   "prHub.comments.open": "打开评论",
   "prHub.comments.unknownAuthor": "未知",
   "prHub.comments.emptyBody": "（无正文）",
+  "prHub.comments.askGrok": "问 Grok",
+  "prHub.comments.askGrokTitle":
+    "将关于此评论的草稿插入输入框（不会自动发送）",
+  "prHub.draftInsertedToast": "草稿已插入输入框",
   "prHub.review.approved": "已批准",
   "prHub.review.changesRequested": "请求修改",
   "prHub.review.commented": "已评论",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -5910,6 +5910,9 @@ export const zhTW: Record<MessageKey, string> = {
   "prHub.checks.none": "無檢查",
   "prHub.checks.loading": "正在載入檢查…",
   "prHub.checks.failed": "無法載入檢查",
+  "prHub.checks.fixCi": "用 Grok 修復",
+  "prHub.checks.fixCiTitle":
+    "將修復 CI 的草稿插入輸入框（不會自動傳送）",
   "prHub.comments.title": "近期留言",
   "prHub.comments.loading": "正在載入留言…",
   "prHub.comments.failed": "無法載入留言",
@@ -5919,6 +5922,10 @@ export const zhTW: Record<MessageKey, string> = {
   "prHub.comments.open": "開啟留言",
   "prHub.comments.unknownAuthor": "未知",
   "prHub.comments.emptyBody": "（無正文）",
+  "prHub.comments.askGrok": "問 Grok",
+  "prHub.comments.askGrokTitle":
+    "將關於此留言的草稿插入輸入框（不會自動傳送）",
+  "prHub.draftInsertedToast": "草稿已插入輸入框",
   "prHub.review.approved": "已核准",
   "prHub.review.changesRequested": "請求修改",
   "prHub.review.commented": "已留言",

--- a/src/lib/prReviewWorkbench.test.ts
+++ b/src/lib/prReviewWorkbench.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+import type { GitPrCheckEntry, PrChecksSummary } from "./gitPrHub";
+import {
+  FIX_CI_CHECKS_CAP,
+  PR_COMMENT_BODY_CAP,
+  buildFixCiPrompt,
+  buildPrCommentPrompt,
+  canSuggestFixCi,
+  classifyPrReviewActionError,
+  listFailedChecks,
+} from "./prReviewWorkbench";
+
+function summary(
+  partial: Partial<PrChecksSummary> & Pick<PrChecksSummary, "overall">,
+): PrChecksSummary {
+  return {
+    pass: 0,
+    fail: 0,
+    pending: 0,
+    skipping: 0,
+    cancel: 0,
+    total: 0,
+    ...partial,
+  };
+}
+
+function check(
+  partial: Partial<GitPrCheckEntry> & Pick<GitPrCheckEntry, "name" | "bucket">,
+): GitPrCheckEntry {
+  return {
+    state: partial.state ?? partial.bucket,
+    ...partial,
+  };
+}
+
+describe("canSuggestFixCi", () => {
+  it("false for null / empty / pass / pending", () => {
+    expect(canSuggestFixCi(null)).toBe(false);
+    expect(canSuggestFixCi(undefined)).toBe(false);
+    expect(
+      canSuggestFixCi(
+        summary({ overall: "none", total: 0 }),
+      ),
+    ).toBe(false);
+    expect(
+      canSuggestFixCi(
+        summary({ overall: "pass", pass: 3, total: 3 }),
+      ),
+    ).toBe(false);
+    expect(
+      canSuggestFixCi(
+        summary({ overall: "pending", pass: 1, pending: 2, total: 3 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("true when overall fail", () => {
+    expect(
+      canSuggestFixCi(
+        summary({ overall: "fail", pass: 2, fail: 1, total: 3 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("true when mixed with fail>0", () => {
+    expect(
+      canSuggestFixCi(
+        summary({ overall: "mixed", fail: 1, cancel: 1, total: 2 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("true when fail count > 0 even if overall mis-set", () => {
+    expect(
+      canSuggestFixCi(
+        summary({ overall: "pass", fail: 2, pass: 1, total: 3 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("false for mixed without fails", () => {
+    expect(
+      canSuggestFixCi(
+        summary({ overall: "mixed", cancel: 2, total: 2, fail: 0 }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("listFailedChecks", () => {
+  it("returns only fail-bucket rows in order", () => {
+    const checks = [
+      check({ name: "frontend", bucket: "pass", state: "SUCCESS" }),
+      check({ name: "Rust Windows", bucket: "fail", state: "FAILURE" }),
+      check({ name: "lint", bucket: "fail", state: "FAILURE" }),
+      check({ name: "Rust Linux", bucket: "pending", state: "PENDING" }),
+    ];
+    const failed = listFailedChecks(checks);
+    expect(failed.map((c) => c.name)).toEqual(["Rust Windows", "lint"]);
+  });
+
+  it("empty for null / empty", () => {
+    expect(listFailedChecks(null)).toEqual([]);
+    expect(listFailedChecks([])).toEqual([]);
+    expect(listFailedChecks(undefined)).toEqual([]);
+  });
+
+  it("infers fail from state when bucket empty", () => {
+    const failed = listFailedChecks([
+      check({ name: "x", bucket: "", state: "FAILURE" }),
+      check({ name: "y", bucket: "", state: "SUCCESS" }),
+    ]);
+    expect(failed.map((c) => c.name)).toEqual(["x"]);
+  });
+});
+
+describe("buildFixCiPrompt", () => {
+  it("builds structured prompt with failed checks only", () => {
+    const p = buildFixCiPrompt({
+      prNumber: 359,
+      title: "feat(settings): CLI partial messages",
+      url: "https://github.com/RongleCat/grok-app/pull/359",
+      headRef: "feat/partial-stream",
+      baseRef: "main",
+      failedChecks: [
+        {
+          name: "Rust Windows",
+          state: "FAILURE",
+          description: "test target/debug failed",
+        },
+        { name: "frontend", state: "FAILURE" },
+      ],
+      bodyExcerpt: "## Summary\nPartial stream polish",
+    });
+    expect(p).toContain("#359");
+    expect(p).toContain("feat(settings): CLI partial messages");
+    expect(p).toContain("Rust Windows");
+    expect(p).toContain("frontend");
+    expect(p).toContain("feat/partial-stream → main");
+    expect(p).toContain("Partial stream polish");
+    expect(p).toContain("Do not invent CI results");
+    // Does not invent checks not supplied
+    expect(p).not.toContain("Rust Linux");
+  });
+
+  it("returns empty for invalid pr number", () => {
+    expect(
+      buildFixCiPrompt({
+        prNumber: 0,
+        title: "x",
+        failedChecks: [{ name: "a", state: "FAILURE" }],
+      }),
+    ).toBe("");
+    expect(
+      buildFixCiPrompt({
+        prNumber: -1,
+        title: "x",
+        failedChecks: [],
+      }),
+    ).toBe("");
+  });
+
+  it("honest when no failed check rows provided", () => {
+    const p = buildFixCiPrompt({
+      prNumber: 1,
+      title: "t",
+      failedChecks: [],
+    });
+    expect(p).toContain("#1");
+    expect(p).toMatch(/No individual failed-check/i);
+    expect(p).not.toMatch(/Invented check/i);
+  });
+
+  it("caps failed checks list", () => {
+    const many = Array.from({ length: FIX_CI_CHECKS_CAP + 5 }, (_, i) => ({
+      name: `check-${i}`,
+      state: "FAILURE",
+    }));
+    const p = buildFixCiPrompt({
+      prNumber: 2,
+      title: "many fails",
+      failedChecks: many,
+    });
+    expect(p).toContain("check-0");
+    expect(p).toContain(`check-${FIX_CI_CHECKS_CAP - 1}`);
+    expect(p).not.toContain(`check-${FIX_CI_CHECKS_CAP}`);
+    expect(p).toMatch(/more failed check/i);
+  });
+
+  it("redacts secrets in descriptions and body", () => {
+    const p = buildFixCiPrompt({
+      prNumber: 9,
+      title: "sec",
+      failedChecks: [
+        {
+          name: "deploy",
+          state: "FAILURE",
+          description: "token sk-abcdefghijklmnopqrstuvwxyz leaked",
+        },
+      ],
+      bodyExcerpt: "Bearer abcdefghijklmnopqr",
+    });
+    expect(p).toContain("[REDACTED]");
+    expect(p).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+  });
+});
+
+describe("buildPrCommentPrompt", () => {
+  it("builds prompt from comment fields", () => {
+    const p = buildPrCommentPrompt({
+      prNumber: 344,
+      title: "feat: ask timeout",
+      comment: {
+        author: "alice",
+        body: "Please also cover zh-TW.",
+        kind: "comment",
+        url: "https://github.com/RongleCat/grok-app/pull/344#issuecomment-2",
+      },
+    });
+    expect(p).toContain("#344");
+    expect(p).toContain("feat: ask timeout");
+    expect(p).toContain("alice");
+    expect(p).toContain("Please also cover zh-TW.");
+    expect(p).toContain("issuecomment-2");
+    expect(p).toContain("Do not invent review history");
+  });
+
+  it("includes review state when kind is review", () => {
+    const p = buildPrCommentPrompt({
+      prNumber: 10,
+      title: "t",
+      comment: {
+        author: "bob",
+        body: "Needs tests",
+        kind: "review",
+        state: "CHANGES_REQUESTED",
+      },
+    });
+    expect(p).toContain("review");
+    expect(p).toContain("CHANGES_REQUESTED");
+    expect(p).toContain("Needs tests");
+  });
+
+  it("returns empty for invalid pr or empty body", () => {
+    expect(
+      buildPrCommentPrompt({
+        prNumber: 0,
+        title: "t",
+        comment: { author: "a", body: "hi" },
+      }),
+    ).toBe("");
+    expect(
+      buildPrCommentPrompt({
+        prNumber: 3,
+        title: "t",
+        comment: { author: "a", body: "   " },
+      }),
+    ).toBe("");
+  });
+
+  it("caps long comment body and redacts secrets", () => {
+    const long = "x".repeat(PR_COMMENT_BODY_CAP + 100);
+    const p = buildPrCommentPrompt({
+      prNumber: 5,
+      title: "t",
+      comment: {
+        author: "eve",
+        body: `token sk-abcdefghijklmnopqrstuvwxyz\n${long}`,
+      },
+    });
+    expect(p.length).toBeLessThan(PR_COMMENT_BODY_CAP + 800);
+    expect(p).toContain("[REDACTED]");
+    expect(p).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+    expect(p).toMatch(/…$/m); // truncated
+  });
+});
+
+describe("classifyPrReviewActionError", () => {
+  it("classifies soft kinds", () => {
+    expect(classifyPrReviewActionError(null)).toBeNull();
+    expect(classifyPrReviewActionError("")).toBeNull();
+    expect(classifyPrReviewActionError("empty_prompt")).toBe("empty_prompt");
+    expect(classifyPrReviewActionError("empty comment body")).toBe(
+      "empty_comment",
+    );
+    expect(classifyPrReviewActionError("invalid pr number")).toBe("empty_pr");
+    expect(classifyPrReviewActionError("no failed checks")).toBe(
+      "no_failed_checks",
+    );
+    expect(classifyPrReviewActionError("boom")).toBe("other");
+  });
+});

--- a/src/lib/prReviewWorkbench.ts
+++ b/src/lib/prReviewWorkbench.ts
@@ -1,0 +1,287 @@
+/**
+ * PR Review workbench — pure prompt builders for CI fails and PR comments → Grok.
+ *
+ * Never invents check/comment data; only formats caller-supplied fields.
+ * Soft-fails empty inputs with empty / classified strings (no network).
+ */
+
+import type { GitPrCheckEntry, PrChecksSummary } from "./gitPrHub";
+import { redact } from "./redact";
+
+/** Cap failed-check rows included in a Fix-CI prompt. */
+export const FIX_CI_CHECKS_CAP = 25;
+/** Cap characters per check description / state line. */
+export const FIX_CI_DESC_CAP = 400;
+/** Cap PR body excerpt in Fix-CI prompt. */
+export const FIX_CI_BODY_EXCERPT_CAP = 2_000;
+/** Cap comment body in comment → Grok prompt. */
+export const PR_COMMENT_BODY_CAP = 4_000;
+/** Soft cap on total prompt length (extra safety after field caps). */
+export const PR_REVIEW_PROMPT_TOTAL_CAP = 12_000;
+/** Cap title / ref / author display fields. */
+export const PR_REVIEW_FIELD_CAP = 200;
+
+export type PrReviewActionErrorKind =
+  | "empty_prompt"
+  | "empty_pr"
+  | "empty_comment"
+  | "no_failed_checks"
+  | "other"
+  | null;
+
+function clampText(
+  raw: string | null | undefined,
+  max: number,
+): string {
+  const s = String(raw ?? "")
+    .replace(/\r\n/g, "\n")
+    .trim();
+  if (!s) return "";
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(1, max - 1)).trimEnd() + "…";
+}
+
+function clampField(raw: string | null | undefined): string {
+  return clampText(raw, PR_REVIEW_FIELD_CAP);
+}
+
+/** Redact secrets then clamp. Never invents content. */
+function safeClip(
+  raw: string | null | undefined,
+  max: number,
+): string {
+  return clampText(redact(String(raw ?? "")), max);
+}
+
+/**
+ * True when the checks rollup indicates CI failure worth a "Fix with Grok" action.
+ * - overall `fail`, or
+ * - overall `mixed` with fail &gt; 0, or
+ * - raw fail count &gt; 0 (belt if overall was mis-set)
+ */
+export function canSuggestFixCi(
+  summary: PrChecksSummary | null | undefined,
+): boolean {
+  if (!summary) return false;
+  if (summary.fail > 0) return true;
+  if (summary.overall === "fail") return true;
+  if (summary.overall === "mixed" && summary.fail > 0) return true;
+  return false;
+}
+
+/**
+ * Filter to failed check rows only (bucket === "fail").
+ * Preserves order; does not invent names or rewrite states.
+ */
+export function listFailedChecks(
+  checks: GitPrCheckEntry[] | null | undefined,
+): GitPrCheckEntry[] {
+  if (!checks || checks.length === 0) return [];
+  return checks.filter((c) => {
+    const bucket = (c.bucket || "").trim().toLowerCase();
+    if (bucket === "fail") return true;
+    // Fallback when bucket missing but state looks failed.
+    if (!bucket) {
+      const state = (c.state || "").trim().toUpperCase();
+      return (
+        state === "FAILURE" ||
+        state === "FAILED" ||
+        state === "ERROR" ||
+        state === "TIMED_OUT" ||
+        state === "ACTION_REQUIRED" ||
+        state === "STARTUP_FAILURE"
+      );
+    }
+    return false;
+  });
+}
+
+export type FixCiPromptOpts = {
+  prNumber: number;
+  title: string;
+  url?: string | null;
+  headRef?: string | null;
+  baseRef?: string | null;
+  failedChecks: {
+    name: string;
+    state: string;
+    description?: string | null;
+  }[];
+  bodyExcerpt?: string | null;
+};
+
+/**
+ * Build a composer draft asking Grok to fix failing CI for a PR.
+ * Only includes checks the caller supplied — never invents CI data.
+ * Empty / invalid PR number → empty string.
+ */
+export function buildFixCiPrompt(opts: FixCiPromptOpts): string {
+  const n = Math.trunc(Number(opts.prNumber));
+  if (!Number.isFinite(n) || n <= 0) return "";
+
+  const title = clampField(opts.title) || "(no title)";
+  const url = clampText(opts.url, 500);
+  const headRef = clampField(opts.headRef);
+  const baseRef = clampField(opts.baseRef);
+  const bodyExcerpt = safeClip(opts.bodyExcerpt, FIX_CI_BODY_EXCERPT_CAP);
+
+  const lines: string[] = [];
+  lines.push(
+    `Please help fix the failing CI checks on pull request #${n}: ${title}`,
+  );
+  lines.push("");
+  lines.push("## PR context");
+  lines.push(`- Number: #${n}`);
+  lines.push(`- Title: ${title}`);
+  if (url) lines.push(`- URL: ${url}`);
+  if (headRef || baseRef) {
+    const branch =
+      headRef && baseRef
+        ? `${headRef} → ${baseRef}`
+        : headRef || baseRef;
+    lines.push(`- Branch: ${branch}`);
+  }
+
+  lines.push("");
+  lines.push("## Failed checks");
+  const checks = Array.isArray(opts.failedChecks) ? opts.failedChecks : [];
+  const limited = checks.slice(0, FIX_CI_CHECKS_CAP);
+  if (limited.length === 0) {
+    lines.push(
+      "(No individual failed-check rows were provided. Investigate recent CI failures for this PR using the project workspace and `gh pr checks` if available — do not invent check names.)",
+    );
+  } else {
+    for (const c of limited) {
+      const name = clampField(c.name) || "(unnamed check)";
+      const state = clampField(c.state) || "fail";
+      const desc = safeClip(c.description, FIX_CI_DESC_CAP);
+      if (desc) {
+        lines.push(`- **${name}** — ${state}: ${desc}`);
+      } else {
+        lines.push(`- **${name}** — ${state}`);
+      }
+    }
+    if (checks.length > FIX_CI_CHECKS_CAP) {
+      lines.push(
+        `…and ${checks.length - FIX_CI_CHECKS_CAP} more failed check(s) omitted.`,
+      );
+    }
+  }
+
+  if (bodyExcerpt) {
+    lines.push("");
+    lines.push("## PR body (excerpt)");
+    lines.push(bodyExcerpt);
+  }
+
+  lines.push("");
+  lines.push("## Task");
+  lines.push(
+    "Diagnose the failures from the project workspace (read logs / failing tests / related files).",
+  );
+  lines.push(
+    "Propose and apply minimal fixes so CI can pass. Explain what you changed and how to re-run checks. Do not invent CI results you have not observed.",
+  );
+
+  return clampText(lines.join("\n"), PR_REVIEW_PROMPT_TOTAL_CAP);
+}
+
+export type PrCommentPromptOpts = {
+  prNumber: number;
+  title: string;
+  comment: {
+    author: string;
+    body: string;
+    kind?: string;
+    state?: string | null;
+    url?: string | null;
+  };
+};
+
+/**
+ * Build a composer draft asking Grok to address a PR review comment.
+ * Empty PR number or empty comment body → empty string.
+ */
+export function buildPrCommentPrompt(opts: PrCommentPromptOpts): string {
+  const n = Math.trunc(Number(opts.prNumber));
+  if (!Number.isFinite(n) || n <= 0) return "";
+
+  const title = clampField(opts.title) || "(no title)";
+  const author = clampField(opts.comment?.author) || "unknown";
+  const body = safeClip(opts.comment?.body, PR_COMMENT_BODY_CAP);
+  if (!body) return "";
+
+  const kindRaw = (opts.comment?.kind ?? "comment").trim().toLowerCase();
+  const kind =
+    kindRaw === "review" ? "review" : kindRaw === "comment" ? "comment" : kindRaw || "comment";
+  const state = clampField(opts.comment?.state);
+  const commentUrl = clampText(opts.comment?.url, 500);
+
+  const lines: string[] = [];
+  lines.push(
+    `Please help address this ${kind} on pull request #${n}: ${title}`,
+  );
+  lines.push("");
+  lines.push("## PR context");
+  lines.push(`- Number: #${n}`);
+  lines.push(`- Title: ${title}`);
+  lines.push("");
+  lines.push("## Comment");
+  lines.push(`- Author: ${author}`);
+  lines.push(`- Kind: ${kind}`);
+  if (state) lines.push(`- Review state: ${state}`);
+  if (commentUrl) lines.push(`- URL: ${commentUrl}`);
+  lines.push("");
+  lines.push("### Body");
+  lines.push(body);
+  lines.push("");
+  lines.push("## Task");
+  lines.push(
+    "Understand the feedback, inspect the relevant code in the project workspace, and implement or propose concrete changes that address it.",
+  );
+  lines.push(
+    "If the comment is a question, answer it from the codebase. If it requests changes, make minimal focused edits. Do not invent review history beyond what is shown above.",
+  );
+
+  return clampText(lines.join("\n"), PR_REVIEW_PROMPT_TOTAL_CAP);
+}
+
+/**
+ * Soft classification for draft / action failures (UI mapping only).
+ */
+export function classifyPrReviewActionError(
+  reason: string | null | undefined,
+): PrReviewActionErrorKind {
+  const r = (reason ?? "").trim().toLowerCase();
+  if (!r) return null;
+  if (
+    r === "empty_prompt" ||
+    r.includes("empty prompt") ||
+    r.includes("empty draft")
+  ) {
+    return "empty_prompt";
+  }
+  if (
+    r === "empty_pr" ||
+    r.includes("invalid pr") ||
+    r.includes("empty pr") ||
+    r.includes("missing pr")
+  ) {
+    return "empty_pr";
+  }
+  if (
+    r === "empty_comment" ||
+    r.includes("empty comment") ||
+    r.includes("no comment body")
+  ) {
+    return "empty_comment";
+  }
+  if (
+    r === "no_failed_checks" ||
+    r.includes("no failed") ||
+    r.includes("no check")
+  ) {
+    return "no_failed_checks";
+  }
+  return "other";
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -26846,6 +26846,21 @@ html[data-theme="light"] .rim-sidebar {
   min-width: 0;
 }
 
+.pr-hub__fix-ci,
+.pr-hub__ask-grok {
+  flex-shrink: 0;
+  white-space: nowrap;
+  font-size: 11px;
+}
+
+.pr-hub__comment-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
 .pr-hub__section-title {
   margin: 0;
   font-size: 11px;


### PR DESCRIPTION
## Summary
- Pure `prReviewWorkbench` helpers: `canSuggestFixCi`, `listFailedChecks`, `buildFixCiPrompt`, `buildPrCommentPrompt`, soft `classifyPrReviewActionError` (caps + redact; never invent CI data).
- **GitPrHubPanel**: **Fix with Grok** when checks overall fail; **Ask Grok** per comment/review row. Actions hidden when `onDraftToChat` is omitted (honest).
- **App → Settings**: wire `onPrReviewDraftToChat` to fill composer, navigate workbench, focus chat, soft toast *Draft inserted into composer* (no auto-send).
- i18n en/zh/zh-TW + CHANGELOG.

## Verify
```
pnpm test -- src/lib/prReviewWorkbench.test.ts src/lib/gitPrHub.test.ts src/i18n/messages.test.ts
pnpm typecheck
```

## Test plan
- [ ] Settings → Runtime → Tools → open a PR with failing CI → **Fix with Grok** inserts draft and toast
- [ ] Expand comments → **Ask Grok** inserts comment prompt (no auto-send)
- [ ] Without wiring (panel alone) action buttons stay hidden
- [ ] Pass-only CI does not show Fix with Grok