### PR TITLE
feat(dashboard): peek rows and dispatch new agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Agent dashboard peek + dispatch**: permission-first row sort (needs you → busy → connecting → error → idle); row chevron expands a read-only peek card (status, tool, path, model) without focusing the chat; **Open chat** inside peek focuses; top **Dispatch new agent** form (trusted project + prompt) opens a new chat, fills the composer, and soft-sends. Pure helpers `buildDashboardPeekModel` / `planDashboardDispatch` / `sanitizeDispatchPrompt` / `groupDashboardRowsByStatus` + tests; en/zh/zh-TW; no `window.confirm`.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,7 @@ import { resolveTrayBusyBadgeCount } from "@/lib/trayNotifyPro";
 import {
   collectAgentDashboardRows,
   countBusyDashboardRows,
+  planDashboardDispatch,
 } from "@/lib/agentDashboard";
 import {
   BATCH_AGENTS_HEADLESS_TIMEOUT_MS,
@@ -21320,6 +21321,12 @@ export default function App() {
         open={agentDashboardOpen}
         locale={locale}
         rows={agentDashboardRows}
+        projects={projects.map((p) => ({
+          id: p.id,
+          name: p.name,
+          path: p.path,
+          trusted: p.trusted,
+        }))}
         onClose={() => setAgentDashboardOpen(false)}
         onSelectSession={(id) => {
           const row = sessions.find((s) => s.id === id);
@@ -21339,6 +21346,53 @@ export default function App() {
         onOpenBatchAgents={() => {
           setAgentDashboardOpen(false);
           openBatchAgents();
+        }}
+        onDispatchAgent={({ projectId, prompt }) => {
+          const plan = planDashboardDispatch({
+            projectId,
+            prompt,
+            projects: projects.map((p) => ({
+              id: p.id,
+              name: p.name,
+              path: p.path,
+              trusted: p.trusted,
+            })),
+          });
+          if (!plan.ok) {
+            const key =
+              plan.reason === "empty_prompt"
+                ? "dashboard.dispatch.emptyPrompt"
+                : plan.reason === "untrusted"
+                  ? "dashboard.dispatch.untrusted"
+                  : plan.reason === "no_trusted_project"
+                    ? "dashboard.dispatch.noTrusted"
+                    : "dashboard.dispatch.noProject";
+            showToast(tr(key), 2800);
+            return;
+          }
+          const proj = projects.find((p) => p.id === plan.project.id) ?? null;
+          if (!proj || !proj.trusted) {
+            showToast(tr("dashboard.dispatch.untrusted"), 2800);
+            return;
+          }
+          // New chat on project with prompt filled; soft-send after paint.
+          void (async () => {
+            await newChat(proj, {
+              seedDraft: plan.prompt,
+              switchToChat: true,
+            });
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                void sendRef.current?.();
+              });
+            });
+            showToast(
+              tr("dashboard.dispatch.started", {
+                name: proj.name || proj.path || proj.id,
+              }),
+              2200,
+            );
+          })();
         }}
       />
       <BatchAgentsModal

--- a/src/components/AgentDashboardModal.tsx
+++ b/src/components/AgentDashboardModal.tsx
@@ -10,15 +10,20 @@ import { GlassModal } from "@/components/GlassModal";
 import { xEvidenceStats, type XEvidenceStats } from "@/lib/api";
 import {
   AGENT_DASHBOARD_STATUS_FILTERS,
+  buildDashboardPeekModel,
   countBusyDashboardRows,
   countDashboardRowsByStatus,
   filterAgentDashboardRows,
   filterStoppableAmongSelection,
+  planDashboardDispatch,
   stoppableDashboardRows,
   stoppableSelectedSessionIds,
+  trustedDashboardDispatchProjects,
   type AgentDashboardRow,
   type AgentDashboardStatus,
   type AgentDashboardStatusFilter,
+  type DashboardDispatchProject,
+  type DashboardPeekModel,
 } from "@/lib/agentDashboard";
 import { formatRelativeTime } from "@/lib/accountUi";
 import { pruneSelectedIds, toggleIdInSet } from "@/lib/sessionSelect";
@@ -77,19 +82,109 @@ function statusBadgeClass(status: AgentDashboardStatus): string {
   }
 }
 
+function PeekCard({
+  peek,
+  t,
+  locale,
+  onOpen,
+}: {
+  peek: DashboardPeekModel;
+  t: TFn;
+  locale: Locale;
+  onOpen?: () => void;
+}) {
+  const activity =
+    peek.lastActivityAt > 0
+      ? formatRelativeTime(new Date(peek.lastActivityAt).toISOString(), locale)
+      : null;
+
+  return (
+    <div className="agent-dash__peek" role="region" aria-label={t("dashboard.peek.label")}>
+      <div className="agent-dash__peek-grid">
+        <div className="agent-dash__peek-row">
+          <span className="agent-dash__peek-k">{t("dashboard.peek.status")}</span>
+          <span className="agent-dash__peek-v">
+            <span
+              className={
+                "agent-dash__status-badge " + statusBadgeClass(peek.status)
+              }
+            >
+              {statusLabel(peek.status, t)}
+            </span>
+          </span>
+        </div>
+        <div className="agent-dash__peek-row">
+          <span className="agent-dash__peek-k">{t("dashboard.peek.tool")}</span>
+          <span className="agent-dash__peek-v" title={peek.toolTitle || undefined}>
+            {peek.toolTitle || t("dashboard.peek.noTool")}
+          </span>
+        </div>
+        {peek.projectName || peek.projectPath ? (
+          <div className="agent-dash__peek-row">
+            <span className="agent-dash__peek-k">
+              {t("dashboard.peek.project")}
+            </span>
+            <span
+              className="agent-dash__peek-v"
+              title={peek.projectPath || peek.projectName || undefined}
+            >
+              {peek.projectName || peek.projectPath}
+              {peek.projectName && peek.projectPath ? (
+                <span className="agent-dash__peek-path">{peek.projectPath}</span>
+              ) : null}
+            </span>
+          </div>
+        ) : null}
+        {peek.modelId ? (
+          <div className="agent-dash__peek-row">
+            <span className="agent-dash__peek-k">{t("dashboard.peek.model")}</span>
+            <span className="agent-dash__peek-v">
+              {peek.modelId}
+              {peek.effort ? ` · ${peek.effort}` : ""}
+            </span>
+          </div>
+        ) : null}
+        {activity ? (
+          <div className="agent-dash__peek-row">
+            <span className="agent-dash__peek-k">
+              {t("dashboard.peek.activity")}
+            </span>
+            <span className="agent-dash__peek-v">{activity}</span>
+          </div>
+        ) : null}
+      </div>
+      {peek.canOpen && onOpen ? (
+        <div className="agent-dash__peek-actions">
+          <button
+            type="button"
+            className="btn btn--solid btn--sm"
+            onClick={onOpen}
+          >
+            {t("dashboard.peek.openChat")}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function DashboardRow({
   row,
   t,
   locale,
   selected,
+  expanded,
   onToggleSelect,
+  onTogglePeek,
   onSelect,
 }: {
   row: AgentDashboardRow;
   t: TFn;
   locale: Locale;
   selected: boolean;
+  expanded: boolean;
   onToggleSelect: (sessionId: string) => void;
+  onTogglePeek: (sessionId: string) => void;
   onSelect?: (sessionId: string) => void;
 }) {
   const metaParts: string[] = [];
@@ -105,6 +200,7 @@ function DashboardRow({
 
   const cwd = row.projectPath || null;
   const toolTitle = row.liveToolTitle?.trim() || null;
+  const peek = expanded ? buildDashboardPeekModel(row) : null;
 
   return (
     <li
@@ -113,6 +209,7 @@ function DashboardRow({
         (row.isCurrent ? " is-current" : "") +
         (row.stoppable ? " is-busy" : "") +
         (selected ? " is-selected" : "") +
+        (expanded ? " is-expanded" : "") +
         (row.status === "permission" ? " is-permission" : "")
       }
     >
@@ -191,7 +288,44 @@ function DashboardRow({
             ) : null}
           </span>
         </button>
+        <button
+          type="button"
+          className={
+            "agent-dash__peek-toggle" + (expanded ? " is-open" : "")
+          }
+          aria-expanded={expanded}
+          aria-label={
+            expanded
+              ? t("dashboard.peek.collapse", { title: row.title })
+              : t("dashboard.peek.expand", { title: row.title })
+          }
+          title={
+            expanded
+              ? t("dashboard.peek.collapse", { title: row.title })
+              : t("dashboard.peek.expand", { title: row.title })
+          }
+          onClick={(e) => {
+            e.stopPropagation();
+            onTogglePeek(row.sessionId);
+          }}
+        >
+          <span className="agent-dash__peek-chevron" aria-hidden>
+            {expanded ? "▾" : "▸"}
+          </span>
+        </button>
       </div>
+      {peek ? (
+        <PeekCard
+          peek={peek}
+          t={t}
+          locale={locale}
+          onOpen={
+            peek.canOpen
+              ? () => onSelect?.(row.sessionId)
+              : undefined
+          }
+        />
+      ) : null}
     </li>
   );
 }
@@ -200,6 +334,8 @@ export type AgentDashboardModalProps = {
   open: boolean;
   locale: Locale;
   rows: AgentDashboardRow[];
+  /** Trusted-project catalog for single dispatch (optional). */
+  projects?: readonly DashboardDispatchProject[];
   onClose: () => void;
   onSelectSession?: (sessionId: string) => void;
   /**
@@ -214,17 +350,24 @@ export type AgentDashboardModalProps = {
   onStopSessions?: (sessionIds: string[]) => void;
   /** Open multi-project batch agents dispatch. */
   onOpenBatchAgents?: () => void;
+  /**
+   * Single-project dispatch: App creates/opens a chat and fills the composer.
+   * Soft-fail toasts live in App.
+   */
+  onDispatchAgent?: (opts: { projectId: string; prompt: string }) => void;
 };
 
 export function AgentDashboardModal({
   open,
   locale,
   rows,
+  projects = [],
   onClose,
   onSelectSession,
   onStopAllBusy,
   onStopSessions,
   onOpenBatchAgents,
+  onDispatchAgent,
 }: AgentDashboardModalProps) {
   const tr = useMemo(() => createT(locale), [locale]);
   const [query, setQuery] = useState("");
@@ -232,6 +375,10 @@ export function AgentDashboardModal({
   const [statusFilter, setStatusFilter] =
     useState<AgentDashboardStatusFilter>("all");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [peekedId, setPeekedId] = useState<string | null>(null);
+  const [dispatchProjectId, setDispatchProjectId] = useState("");
+  const [dispatchPrompt, setDispatchPrompt] = useState("");
+  const [dispatchHint, setDispatchHint] = useState<MessageKey | null>(null);
   // X Evidence Rail counters (today's new evidence / this week's quote packs).
   // Absent backend (mock mode) or empty store → hide the block silently.
   const [evidence, setEvidence] = useState<XEvidenceStats | null>(null);
@@ -249,6 +396,21 @@ export function AgentDashboardModal({
       cancelled = true;
     };
   }, [open]);
+
+  const trustedProjects = useMemo(
+    () => trustedDashboardDispatchProjects(projects),
+    [projects],
+  );
+
+  // Default dispatch project to first trusted when catalog changes / opens.
+  useEffect(() => {
+    if (!open) return;
+    setDispatchProjectId((prev) => {
+      if (prev && trustedProjects.some((p) => p.id === prev)) return prev;
+      return trustedProjects[0]?.id ?? "";
+    });
+  }, [open, trustedProjects]);
+
   const filtered = useMemo(
     () =>
       filterAgentDashboardRows(rows, {
@@ -273,11 +435,17 @@ export function AgentDashboardModal({
   useEffect(() => {
     const live = new Set(rows.map((r) => r.sessionId));
     setSelectedIds((prev) => pruneSelectedIds(prev, live));
+    setPeekedId((prev) => (prev && live.has(prev) ? prev : null));
   }, [rows]);
 
-  // Clear multi-select when the modal closes so the next open is fresh.
+  // Clear multi-select / peek / dispatch draft when the modal closes.
   useEffect(() => {
-    if (!open) setSelectedIds(new Set());
+    if (!open) {
+      setSelectedIds(new Set());
+      setPeekedId(null);
+      setDispatchPrompt("");
+      setDispatchHint(null);
+    }
   }, [open]);
 
   const selectedStoppable = useMemo(
@@ -312,6 +480,10 @@ export function AgentDashboardModal({
     setSelectedIds((prev) => toggleIdInSet(prev, sessionId));
   };
 
+  const togglePeek = (sessionId: string) => {
+    setPeekedId((prev) => (prev === sessionId ? null : sessionId));
+  };
+
   const toggleSelectAllVisible = () => {
     setSelectedIds((prev) => {
       if (allVisibleSelected) {
@@ -334,6 +506,32 @@ export function AgentDashboardModal({
     // Clear selection after dispatch so the footer doesn't stale-count.
     setSelectedIds(new Set());
   };
+
+  const handleDispatch = () => {
+    if (!onDispatchAgent) return;
+    const plan = planDashboardDispatch({
+      projectId: dispatchProjectId,
+      prompt: dispatchPrompt,
+      projects,
+    });
+    if (!plan.ok) {
+      const key: MessageKey =
+        plan.reason === "empty_prompt"
+          ? "dashboard.dispatch.emptyPrompt"
+          : plan.reason === "untrusted"
+            ? "dashboard.dispatch.untrusted"
+            : plan.reason === "no_trusted_project"
+              ? "dashboard.dispatch.noTrusted"
+              : "dashboard.dispatch.noProject";
+      setDispatchHint(key);
+      return;
+    }
+    setDispatchHint(null);
+    onDispatchAgent({ projectId: plan.project.id, prompt: plan.prompt });
+    setDispatchPrompt("");
+  };
+
+  const showDispatch = !!onDispatchAgent;
 
   return (
     <GlassModal
@@ -389,6 +587,72 @@ export function AgentDashboardModal({
       }
     >
       <p className="agent-dash__hint">{tr("dashboard.hint")}</p>
+      {showDispatch ? (
+        <div className="agent-dash__dispatch" aria-label={tr("dashboard.dispatch.title")}>
+          <div className="agent-dash__dispatch-head">
+            <span className="agent-dash__dispatch-title">
+              {tr("dashboard.dispatch.title")}
+            </span>
+          </div>
+          {trustedProjects.length === 0 ? (
+            <p className="agent-dash__dispatch-empty">
+              {tr("dashboard.dispatch.noTrusted")}
+            </p>
+          ) : (
+            <>
+              <div className="agent-dash__dispatch-row">
+                <label className="agent-dash__dispatch-label" htmlFor="agent-dash-dispatch-project">
+                  {tr("dashboard.dispatch.projectLabel")}
+                </label>
+                <select
+                  id="agent-dash-dispatch-project"
+                  className="settings-input agent-dash__dispatch-select"
+                  value={dispatchProjectId}
+                  onChange={(e) => {
+                    setDispatchProjectId(e.target.value);
+                    setDispatchHint(null);
+                  }}
+                  aria-label={tr("dashboard.dispatch.projectLabel")}
+                >
+                  {trustedProjects.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name || p.path || p.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <textarea
+                className="settings-input agent-dash__dispatch-prompt"
+                value={dispatchPrompt}
+                onChange={(e) => {
+                  setDispatchPrompt(e.target.value);
+                  setDispatchHint(null);
+                }}
+                placeholder={tr("dashboard.dispatch.promptPlaceholder")}
+                rows={2}
+                spellCheck={false}
+                aria-label={tr("dashboard.dispatch.promptPlaceholder")}
+              />
+              <div className="agent-dash__dispatch-actions">
+                <button
+                  type="button"
+                  className="btn btn--solid btn--sm"
+                  onClick={handleDispatch}
+                  disabled={!dispatchPrompt.trim()}
+                  title={tr("dashboard.dispatch.buttonTitle")}
+                >
+                  {tr("dashboard.dispatch.button")}
+                </button>
+                {dispatchHint ? (
+                  <span className="agent-dash__dispatch-hint" role="status">
+                    {tr(dispatchHint)}
+                  </span>
+                ) : null}
+              </div>
+            </>
+          )}
+        </div>
+      ) : null}
       {evidence && evidence.total > 0 ? (
         <div
           className="agent-dash__evidence"
@@ -539,7 +803,9 @@ export function AgentDashboardModal({
                 t={(k, vars) => tr(k, vars)}
                 locale={locale}
                 selected={selectedIds.has(row.sessionId)}
+                expanded={peekedId === row.sessionId}
                 onToggleSelect={toggleRow}
+                onTogglePeek={togglePeek}
                 onSelect={(id) => {
                   onSelectSession?.(id);
                   onClose();

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -865,6 +865,29 @@ const en = {
   "dashboard.batchAgents": "Batch agents…",
   "dashboard.batchAgentsTitle":
     "Dispatch the same prompt to multiple projects (sessions or headless)",
+  "dashboard.peek.label": "Session details",
+  "dashboard.peek.expand": "Show details for {title}",
+  "dashboard.peek.collapse": "Hide details for {title}",
+  "dashboard.peek.status": "Status",
+  "dashboard.peek.tool": "Tool",
+  "dashboard.peek.noTool": "No active tool",
+  "dashboard.peek.project": "Project",
+  "dashboard.peek.model": "Model",
+  "dashboard.peek.activity": "Updated",
+  "dashboard.peek.openChat": "Open chat",
+  "dashboard.dispatch.title": "Dispatch new agent",
+  "dashboard.dispatch.projectLabel": "Trusted project",
+  "dashboard.dispatch.promptPlaceholder": "Prompt for a new session…",
+  "dashboard.dispatch.button": "Dispatch",
+  "dashboard.dispatch.buttonTitle":
+    "Open a new chat on the selected project, fill the prompt, and send",
+  "dashboard.dispatch.noTrusted":
+    "No trusted projects yet. Trust a project in the sidebar to dispatch.",
+  "dashboard.dispatch.emptyPrompt": "Enter a prompt to dispatch.",
+  "dashboard.dispatch.noProject": "Pick a trusted project first.",
+  "dashboard.dispatch.untrusted":
+    "That project is not trusted. Trust it before dispatching.",
+  "dashboard.dispatch.started": "Dispatched to {name}",
 
   "batchAgents.title": "Batch agents",
   "batchAgents.hint":
@@ -6956,6 +6979,28 @@ const zh: Record<MessageKey, string> = {
   "dashboard.batchAgents": "批量 Agent…",
   "dashboard.batchAgentsTitle":
     "将同一提示词派发到多个项目（会话或无头摘要）",
+  "dashboard.peek.label": "会话详情",
+  "dashboard.peek.expand": "展开 {title} 的详情",
+  "dashboard.peek.collapse": "收起 {title} 的详情",
+  "dashboard.peek.status": "状态",
+  "dashboard.peek.tool": "工具",
+  "dashboard.peek.noTool": "无运行中的工具",
+  "dashboard.peek.project": "项目",
+  "dashboard.peek.model": "模型",
+  "dashboard.peek.activity": "更新",
+  "dashboard.peek.openChat": "打开对话",
+  "dashboard.dispatch.title": "派发新 Agent",
+  "dashboard.dispatch.projectLabel": "已信任项目",
+  "dashboard.dispatch.promptPlaceholder": "新会话的提示词…",
+  "dashboard.dispatch.button": "派发",
+  "dashboard.dispatch.buttonTitle":
+    "在所选项目新建对话、填入提示词并发送",
+  "dashboard.dispatch.noTrusted":
+    "还没有已信任项目。请先在侧栏信任一个项目后再派发。",
+  "dashboard.dispatch.emptyPrompt": "请输入要派发的提示词。",
+  "dashboard.dispatch.noProject": "请先选择一个已信任项目。",
+  "dashboard.dispatch.untrusted": "该项目尚未信任。请先信任后再派发。",
+  "dashboard.dispatch.started": "已派发到 {name}",
 
   "batchAgents.title": "批量 Agent",
   "batchAgents.hint":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -812,6 +812,28 @@ export const zhTW: Record<MessageKey, string> = {
   "dashboard.batchAgents": "批量 Agent…",
   "dashboard.batchAgentsTitle":
     "將同一提示詞派發到多個專案（工作階段或無頭摘要）",
+  "dashboard.peek.label": "工作階段詳情",
+  "dashboard.peek.expand": "展開 {title} 的詳情",
+  "dashboard.peek.collapse": "收起 {title} 的詳情",
+  "dashboard.peek.status": "狀態",
+  "dashboard.peek.tool": "工具",
+  "dashboard.peek.noTool": "無執行中的工具",
+  "dashboard.peek.project": "專案",
+  "dashboard.peek.model": "模型",
+  "dashboard.peek.activity": "更新",
+  "dashboard.peek.openChat": "開啟對話",
+  "dashboard.dispatch.title": "派發新 Agent",
+  "dashboard.dispatch.projectLabel": "已信任專案",
+  "dashboard.dispatch.promptPlaceholder": "新工作階段的提示詞…",
+  "dashboard.dispatch.button": "派發",
+  "dashboard.dispatch.buttonTitle":
+    "在所選專案新建對話、填入提示詞並送出",
+  "dashboard.dispatch.noTrusted":
+    "尚無已信任專案。請先在側欄信任一個專案後再派發。",
+  "dashboard.dispatch.emptyPrompt": "請輸入要派發的提示詞。",
+  "dashboard.dispatch.noProject": "請先選擇一個已信任專案。",
+  "dashboard.dispatch.untrusted": "該專案尚未信任。請先信任後再派發。",
+  "dashboard.dispatch.started": "已派發到 {name}",
 
   "batchAgents.title": "批量 Agent",
   "batchAgents.hint":

--- a/src/lib/agentDashboard.test.ts
+++ b/src/lib/agentDashboard.test.ts
@@ -1,17 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
   AGENT_DASHBOARD_STATUS_FILTERS,
+  buildDashboardPeekModel,
   collectAgentDashboardRows,
   countBusyDashboardRows,
   countDashboardRowsByStatus,
   dashboardStatusFromSessionState,
+  dashboardStatusSortRank,
   filterAgentDashboardRows,
   filterStoppableAmongSelection,
+  groupDashboardRowsByStatus,
   isStoppableDashboardStatus,
   mapDashboardStatus,
   matchAgentDashboardProject,
+  planDashboardDispatch,
+  sanitizeDispatchPrompt,
   stoppableDashboardRows,
   stoppableSelectedSessionIds,
+  trustedDashboardDispatchProjects,
   type AgentDashboardRow,
 } from "./agentDashboard";
 import { emptyLiveSnapshot, type SessionLiveMap } from "./sessionLiveStore";
@@ -126,19 +132,20 @@ describe("collectAgentDashboardRows", () => {
       unboundProjectLabel: "Other chats",
     });
 
-    // Busy first (a, b), then idle by last activity (c newer than d).
-    expect(rows.map((r) => r.sessionId)).toEqual(["a", "b", "c", "d"]);
-    expect(rows[0]!.isCurrent).toBe(true);
-    expect(rows[0]!.status).toBe("busy");
-    expect(rows[0]!.liveToolTitle).toBe("bash");
-    expect(rows[0]!.modelId).toBe("grok-4");
-    expect(rows[0]!.effort).toBe("high");
-    expect(rows[0]!.projectName).toBe("grok-app");
-    expect(rows[0]!.projectPath).toBe("/Users/me/Code/grok-app");
+    // Permission (needs you) before busy; then idle by last activity (c newer than d).
+    expect(rows.map((r) => r.sessionId)).toEqual(["b", "a", "c", "d"]);
+    expect(rows[0]!.status).toBe("permission");
     expect(rows[0]!.stoppable).toBe(true);
 
-    expect(rows[1]!.status).toBe("permission");
-    expect(rows[1]!.stoppable).toBe(true);
+    const busyA = rows.find((r) => r.sessionId === "a")!;
+    expect(busyA.isCurrent).toBe(true);
+    expect(busyA.status).toBe("busy");
+    expect(busyA.liveToolTitle).toBe("bash");
+    expect(busyA.modelId).toBe("grok-4");
+    expect(busyA.effort).toBe("high");
+    expect(busyA.projectName).toBe("grok-app");
+    expect(busyA.projectPath).toBe("/Users/me/Code/grok-app");
+    expect(busyA.stoppable).toBe(true);
 
     const idleC = rows.find((r) => r.sessionId === "c")!;
     expect(idleC.status).toBe("idle");
@@ -150,9 +157,46 @@ describe("collectAgentDashboardRows", () => {
 
     expect(countBusyDashboardRows(rows)).toBe(2);
     expect(stoppableDashboardRows(rows).map((r) => r.sessionId)).toEqual([
-      "a",
       "b",
+      "a",
     ]);
+  });
+
+  it("ranks permission above busy above connecting", () => {
+    const liveMap: SessionLiveMap = {
+      perm: {
+        ...emptyLiveSnapshot("perm", 1),
+        state: "awaiting_permission",
+        awaitingPermission: true,
+        updatedAt: 10,
+      },
+      busy: {
+        ...emptyLiveSnapshot("busy", 2),
+        state: "streaming",
+        updatedAt: 99,
+      },
+      conn: {
+        ...emptyLiveSnapshot("conn", 3),
+        state: "connecting",
+        updatedAt: 50,
+      },
+    };
+    const rows = collectAgentDashboardRows({
+      sessions: [
+        { id: "busy", title: "Busy", updatedAt: "2026-07-30T12:00:00.000Z" },
+        { id: "perm", title: "Perm", updatedAt: "2026-07-30T11:00:00.000Z" },
+        { id: "conn", title: "Conn", updatedAt: "2026-07-30T10:00:00.000Z" },
+      ],
+      projects: [],
+      liveMap,
+    });
+    expect(rows.map((r) => r.sessionId)).toEqual(["perm", "busy", "conn"]);
+    expect(dashboardStatusSortRank("permission")).toBeLessThan(
+      dashboardStatusSortRank("busy"),
+    );
+    expect(dashboardStatusSortRank("busy")).toBeLessThan(
+      dashboardStatusSortRank("connecting"),
+    );
   });
 
   it("includes live-busy sessions missing from the sidebar list", () => {
@@ -607,3 +651,203 @@ describe("filterStoppableAmongSelection", () => {
     ).toEqual(["busy-1", "perm-1"]);
   });
 });
+
+describe("groupDashboardRowsByStatus", () => {
+  it("groups in permission → busy → connecting → error → idle order", () => {
+    const rows: AgentDashboardRow[] = [
+      {
+        sessionId: "i",
+        title: "Idle",
+        projectId: null,
+        projectName: null,
+        projectPath: null,
+        modelId: null,
+        effort: null,
+        status: "idle",
+        liveToolTitle: null,
+        isCurrent: false,
+        lastActivityAt: 1,
+        updatedAtIso: null,
+        stoppable: false,
+      },
+      {
+        sessionId: "b",
+        title: "Busy",
+        projectId: null,
+        projectName: null,
+        projectPath: null,
+        modelId: null,
+        effort: null,
+        status: "busy",
+        liveToolTitle: "bash",
+        isCurrent: false,
+        lastActivityAt: 2,
+        updatedAtIso: null,
+        stoppable: true,
+      },
+      {
+        sessionId: "p",
+        title: "Perm",
+        projectId: null,
+        projectName: null,
+        projectPath: null,
+        modelId: null,
+        effort: null,
+        status: "permission",
+        liveToolTitle: null,
+        isCurrent: false,
+        lastActivityAt: 3,
+        updatedAtIso: null,
+        stoppable: true,
+      },
+      {
+        sessionId: "e",
+        title: "Err",
+        projectId: null,
+        projectName: null,
+        projectPath: null,
+        modelId: null,
+        effort: null,
+        status: "error",
+        liveToolTitle: null,
+        isCurrent: false,
+        lastActivityAt: 0,
+        updatedAtIso: null,
+        stoppable: false,
+      },
+    ];
+    const groups = groupDashboardRowsByStatus(rows);
+    expect(groups.map((g) => g.status)).toEqual([
+      "permission",
+      "busy",
+      "error",
+      "idle",
+    ]);
+    expect(groups[0]!.rows.map((r) => r.sessionId)).toEqual(["p"]);
+    expect(groups[1]!.rows.map((r) => r.sessionId)).toEqual(["b"]);
+  });
+});
+
+describe("buildDashboardPeekModel", () => {
+  it("projects row fields into a read-only peek card", () => {
+    const row: AgentDashboardRow = {
+      sessionId: "s1",
+      title: "Fix CI",
+      projectId: "p1",
+      projectName: "grok-app",
+      projectPath: "/code/grok-app",
+      modelId: "grok-4",
+      effort: "high",
+      status: "busy",
+      liveToolTitle: "  bash  ",
+      isCurrent: true,
+      lastActivityAt: 123,
+      updatedAtIso: null,
+      stoppable: true,
+    };
+    expect(buildDashboardPeekModel(row)).toEqual({
+      title: "Fix CI",
+      status: "busy",
+      toolTitle: "bash",
+      projectPath: "/code/grok-app",
+      projectName: "grok-app",
+      modelId: "grok-4",
+      effort: "high",
+      lastActivityAt: 123,
+      canOpen: true,
+      canStop: true,
+    });
+  });
+});
+
+describe("sanitizeDispatchPrompt", () => {
+  it("trims, clamps, and never invents content", () => {
+    expect(sanitizeDispatchPrompt("  hello  ")).toBe("hello");
+    expect(sanitizeDispatchPrompt("   ")).toBe("");
+    expect(sanitizeDispatchPrompt(null)).toBe("");
+    expect(sanitizeDispatchPrompt(undefined)).toBe("");
+    const long = "x".repeat(9000);
+    expect(sanitizeDispatchPrompt(long)).toHaveLength(8000);
+    expect(sanitizeDispatchPrompt("abcdef", 3)).toBe("abc");
+  });
+});
+
+describe("planDashboardDispatch", () => {
+  const projects = [
+    {
+      id: "p1",
+      name: "trusted",
+      path: "/code/t",
+      trusted: true,
+    },
+    {
+      id: "p2",
+      name: "untrusted",
+      path: "/code/u",
+      trusted: false,
+    },
+  ];
+
+  it("returns ok plan with sanitized prompt + project", () => {
+    const plan = planDashboardDispatch({
+      projectId: "p1",
+      prompt: "  do the thing  ",
+      projects,
+    });
+    expect(plan).toEqual({
+      ok: true,
+      prompt: "do the thing",
+      project: {
+        id: "p1",
+        name: "trusted",
+        path: "/code/t",
+        trusted: true,
+      },
+    });
+  });
+
+  it("soft-fails empty prompt / missing / untrusted / no trusted catalog", () => {
+    expect(
+      planDashboardDispatch({
+        projectId: "p1",
+        prompt: "   ",
+        projects,
+      }),
+    ).toEqual({ ok: false, reason: "empty_prompt" });
+    expect(
+      planDashboardDispatch({
+        projectId: null,
+        prompt: "hi",
+        projects,
+      }),
+    ).toEqual({ ok: false, reason: "no_project" });
+    expect(
+      planDashboardDispatch({
+        projectId: "missing",
+        prompt: "hi",
+        projects,
+      }),
+    ).toEqual({ ok: false, reason: "no_project" });
+    expect(
+      planDashboardDispatch({
+        projectId: "p2",
+        prompt: "hi",
+        projects,
+      }),
+    ).toEqual({ ok: false, reason: "untrusted" });
+    expect(
+      planDashboardDispatch({
+        projectId: null,
+        prompt: "hi",
+        projects: [{ id: "x", name: "x", path: "/x", trusted: false }],
+      }),
+    ).toEqual({ ok: false, reason: "no_trusted_project" });
+  });
+
+  it("lists trusted projects for the select", () => {
+    expect(trustedDashboardDispatchProjects(projects).map((p) => p.id)).toEqual(
+      ["p1"],
+    );
+  });
+});
+

--- a/src/lib/agentDashboard.ts
+++ b/src/lib/agentDashboard.ts
@@ -91,6 +91,25 @@ export function isStoppableDashboardStatus(
   );
 }
 
+/**
+ * Sort rank for dashboard rows: permission (needs you) first, then busy,
+ * connecting, error, idle. Lower = higher priority.
+ */
+export function dashboardStatusSortRank(status: AgentDashboardStatus): number {
+  switch (status) {
+    case "permission":
+      return 0;
+    case "busy":
+      return 1;
+    case "connecting":
+      return 2;
+    case "error":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
 function parseUpdatedMs(iso: string | null | undefined): number {
   if (!iso) return 0;
   const t = Date.parse(iso);
@@ -187,15 +206,11 @@ export function collectAgentDashboardRows(opts: {
     });
   }
 
-  // Sort: stoppable/busy first (newest), then error, then idle by activity.
-  const rank = (s: AgentDashboardStatus): number => {
-    if (s === "busy" || s === "permission" || s === "connecting") return 0;
-    if (s === "error") return 1;
-    return 2;
-  };
+  // Sort: permission (needs you) → busy → connecting → error → idle; then
+  // current session, then newest activity.
   rows.sort((a, b) => {
-    const ra = rank(a.status);
-    const rb = rank(b.status);
+    const ra = dashboardStatusSortRank(a.status);
+    const rb = dashboardStatusSortRank(b.status);
     if (ra !== rb) return ra - rb;
     if (a.isCurrent !== b.isCurrent) return a.isCurrent ? -1 : 1;
     return b.lastActivityAt - a.lastActivityAt;
@@ -212,6 +227,170 @@ export function collectAgentDashboardRows(opts: {
     out.push(row);
   }
   return out;
+}
+
+/** Status order used by {@link groupDashboardRowsByStatus}. */
+export const AGENT_DASHBOARD_STATUS_GROUP_ORDER: readonly AgentDashboardStatus[] =
+  ["permission", "busy", "connecting", "error", "idle"] as const;
+
+export type DashboardStatusGroup = {
+  status: AgentDashboardStatus;
+  rows: AgentDashboardRow[];
+};
+
+/**
+ * Group rows into status sections (permission → busy → … → idle).
+ * Empty statuses are omitted. Within each group, input order is preserved.
+ */
+export function groupDashboardRowsByStatus(
+  rows: readonly AgentDashboardRow[],
+): DashboardStatusGroup[] {
+  const buckets = new Map<AgentDashboardStatus, AgentDashboardRow[]>();
+  for (const status of AGENT_DASHBOARD_STATUS_GROUP_ORDER) {
+    buckets.set(status, []);
+  }
+  for (const row of rows) {
+    const list = buckets.get(row.status);
+    if (list) list.push(row);
+  }
+  const out: DashboardStatusGroup[] = [];
+  for (const status of AGENT_DASHBOARD_STATUS_GROUP_ORDER) {
+    const groupRows = buckets.get(status) ?? [];
+    if (groupRows.length > 0) out.push({ status, rows: groupRows });
+  }
+  return out;
+}
+
+/** Read-only peek card model for a dashboard row (no I/O). */
+export type DashboardPeekModel = {
+  title: string;
+  status: AgentDashboardStatus;
+  toolTitle: string | null;
+  projectPath: string | null;
+  projectName: string | null;
+  modelId: string | null;
+  effort: string | null;
+  lastActivityAt: number;
+  /** Always true when the row is listed (session can be focused). */
+  canOpen: boolean;
+  canStop: boolean;
+};
+
+/** Build a peek model from a collected row. */
+export function buildDashboardPeekModel(
+  row: AgentDashboardRow,
+): DashboardPeekModel {
+  return {
+    title: row.title,
+    status: row.status,
+    toolTitle: row.liveToolTitle?.trim() || null,
+    projectPath: row.projectPath,
+    projectName: row.projectName,
+    modelId: row.modelId,
+    effort: row.effort,
+    lastActivityAt: row.lastActivityAt,
+    canOpen: !!row.sessionId,
+    canStop: row.stoppable,
+  };
+}
+
+/** Default max length for a dashboard dispatch prompt. */
+export const DASHBOARD_DISPATCH_PROMPT_MAX = 8000;
+
+/**
+ * Trim + clamp a dispatch prompt. Empty / whitespace-only → "".
+ * Does not invent content.
+ */
+export function sanitizeDispatchPrompt(
+  raw: string | null | undefined,
+  max: number = DASHBOARD_DISPATCH_PROMPT_MAX,
+): string {
+  const s = String(raw ?? "").trim();
+  if (!s) return "";
+  const cap = Number.isFinite(max) && max > 0 ? Math.floor(max) : DASHBOARD_DISPATCH_PROMPT_MAX;
+  return s.length <= cap ? s : s.slice(0, cap);
+}
+
+export type DashboardDispatchProject = {
+  id: string;
+  name: string;
+  path: string;
+  /** Trusted projects only may receive agent work. Default true when omitted. */
+  trusted?: boolean;
+};
+
+export type DashboardDispatchFailReason =
+  | "no_project"
+  | "untrusted"
+  | "empty_prompt"
+  | "no_trusted_project";
+
+export type DashboardDispatchPlan =
+  | {
+      ok: true;
+      prompt: string;
+      project: DashboardDispatchProject;
+    }
+  | {
+      ok: false;
+      reason: DashboardDispatchFailReason;
+    };
+
+/**
+ * Plan a single-project dashboard dispatch (no I/O).
+ *
+ * Soft-fails:
+ * - `empty_prompt` — sanitized prompt is empty
+ * - `no_trusted_project` — catalog has no trusted targets (and no projectId)
+ * - `no_project` — missing / unknown projectId
+ * - `untrusted` — project found but not trusted
+ */
+export function planDashboardDispatch(opts: {
+  projectId?: string | null;
+  prompt: string;
+  projects: readonly DashboardDispatchProject[];
+}): DashboardDispatchPlan {
+  const prompt = sanitizeDispatchPrompt(opts.prompt);
+  if (!prompt) return { ok: false, reason: "empty_prompt" };
+
+  const projects = opts.projects ?? [];
+  const trustedProjects = projects.filter((p) => {
+    const id = String(p?.id ?? "").trim();
+    return !!id && p.trusted !== false;
+  });
+
+  const projectId = String(opts.projectId ?? "").trim();
+  if (!projectId) {
+    if (trustedProjects.length === 0) {
+      return { ok: false, reason: "no_trusted_project" };
+    }
+    return { ok: false, reason: "no_project" };
+  }
+
+  const project = projects.find((p) => String(p.id ?? "").trim() === projectId);
+  if (!project) return { ok: false, reason: "no_project" };
+  if (project.trusted === false) return { ok: false, reason: "untrusted" };
+
+  return {
+    ok: true,
+    prompt,
+    project: {
+      id: project.id,
+      name: project.name,
+      path: project.path,
+      trusted: true,
+    },
+  };
+}
+
+/** Trusted-only project list for the dispatch select. */
+export function trustedDashboardDispatchProjects(
+  projects: readonly DashboardDispatchProject[],
+): DashboardDispatchProject[] {
+  return projects.filter((p) => {
+    const id = String(p?.id ?? "").trim();
+    return !!id && p.trusted !== false;
+  });
 }
 
 /** Rows that accept Stop / Stop all. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -25758,10 +25758,146 @@ html[data-theme="light"] .rim-sidebar {
 }
 .agent-dash__row-inner {
   display: grid;
-  grid-template-columns: 28px minmax(0, 1fr);
+  grid-template-columns: 28px minmax(0, 1fr) 28px;
   gap: 2px;
   align-items: start;
   padding: 4px 4px 4px 8px;
+}
+.agent-dash__peek-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 6px 4px;
+  border: 0;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  border-radius: 8px;
+  font: inherit;
+  line-height: 1;
+  min-height: 32px;
+}
+.agent-dash__peek-toggle:hover {
+  background: var(--hover-bg, rgba(127, 127, 127, 0.1));
+  color: var(--text-primary);
+}
+.agent-dash__peek-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent, #5b8def) 55%, transparent);
+  outline-offset: 1px;
+}
+.agent-dash__peek-toggle.is-open {
+  color: var(--text-primary);
+}
+.agent-dash__peek-chevron {
+  font-size: 12px;
+  line-height: 1;
+}
+.agent-dash__row.is-expanded {
+  border-color: color-mix(in srgb, var(--accent, #5b8def) 24%, transparent);
+}
+.agent-dash__peek {
+  margin: 0 8px 8px 36px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--bg-elevated, rgba(0, 0, 0, 0.12));
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.2));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.agent-dash__peek-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.agent-dash__peek-row {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.agent-dash__peek-k {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+.agent-dash__peek-v {
+  color: var(--text-secondary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+}
+.agent-dash__peek-path {
+  display: block;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.agent-dash__peek-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+.agent-dash__dispatch {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex-shrink: 0;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.22));
+  background: var(--bg-hover, rgba(127, 127, 127, 0.05));
+}
+.agent-dash__dispatch-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.agent-dash__dispatch-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.agent-dash__dispatch-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  line-height: 1.4;
+}
+.agent-dash__dispatch-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.agent-dash__dispatch-label {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+.agent-dash__dispatch-select {
+  width: 100%;
+}
+.agent-dash__dispatch-prompt {
+  width: 100%;
+  min-height: 52px;
+  resize: vertical;
+  font: inherit;
+  line-height: 1.4;
+}
+.agent-dash__dispatch-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.agent-dash__dispatch-hint {
+  font-size: 11px;
+  color: var(--warning, #d4a017);
+  line-height: 1.35;
 }
 .agent-dash__check {
   display: inline-flex;


### PR DESCRIPTION
## Summary

- **Permission-first sort**: dashboard rows rank `permission` (needs you) → `busy` → `connecting` → `error` → `idle` (pure `dashboardStatusSortRank` + `groupDashboardRowsByStatus`)
- **Peek**: row chevron expands a read-only peek card (status, tool, path, model, activity) without calling `onSelectSession`; **Open chat** inside peek focuses the session
- **Dispatch**: top form with trusted-project select + prompt textarea + **Dispatch** → pure `planDashboardDispatch` / `sanitizeDispatchPrompt`; App opens `newChat` on the project, fills composer, soft-sends; soft-fail toasts for empty prompt / untrusted / no project / no trusted catalog
- i18n en/zh/zh-TW + CHANGELOG; no `window.confirm`

## Test plan

- [x] `pnpm test -- src/lib/agentDashboard.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Open Agent dashboard with mixed busy / permission / idle rows — permission rows float above busy
- [ ] Expand chevron on a row → peek shows status/tool/path/model; row click still focuses; peek **Open chat** focuses + closes
- [ ] Dispatch with no trusted projects → honest empty state
- [ ] Dispatch empty prompt → inline soft-fail; valid trusted project + prompt → new chat opens with prompt and sends
- [ ] Untrusted project path soft-fails without inventing a session