### PR TITLE
feat(worktree): parallel task creates worktree and opens chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+#### Composer & chat
+- **Parallel task (worktree)**: one flow to create a linked git worktree and open a new chat there (palette `parallel-worktree-task` + worktree menu). Optional first prompt fills the composer; optional “send after open” (default off, trusted only). Pure `worktreeParallel` helpers + tests; en/zh/zh-TW
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -459,6 +459,13 @@ import {
   type ContinueCwdSoftFailKind,
 } from "@/lib/continueCwd";
 import {
+  buildParallelTaskComposerText,
+  evaluateParallelTaskPreflight,
+  parallelTaskPreflightMessageKey,
+  planParallelTask,
+  suggestParallelWorktreeName,
+} from "@/lib/worktreeParallel";
+import {
   sessionExportMimeType,
   sessionToHtml,
   sessionToJson,
@@ -757,7 +764,6 @@ import {
   normalizeWorktreeLayout,
   pathsEqual,
   resolveSessionWorktreeBadge,
-  sanitizeWorktreeName,
   sanitizeWorktreeRef,
   sessionWorktreeTooltip,
   worktreeEntryForPath,
@@ -1022,6 +1028,8 @@ function paletteActionIcon(id: string) {
       return <IconCopy size={size} />;
     case "continue-cwd":
       return <IconHistory size={size} />;
+    case "parallel-worktree-task":
+      return <IconSquarePen size={size} />;
     case "resume-with-code-restore":
       return <IconRewind size={size} />;
     case "settings-appearance":
@@ -2556,6 +2564,11 @@ export default function App() {
   );
   /** When true, after create bind cwd and open a draft chat on that path. */
   const [worktreeCreateStartChat, setWorktreeCreateStartChat] = useState(false);
+  /** Optional first composer prompt for parallel-task / new-chat create. */
+  const [worktreeCreateFirstPrompt, setWorktreeCreateFirstPrompt] =
+    useState("");
+  /** When true + trusted, send first prompt once after open (default off). */
+  const [worktreeCreateAutoSend, setWorktreeCreateAutoSend] = useState(false);
   /** Absolute `~/.grok` from host list (CLI path preview + badge detection). */
   const [cliGrokHome, setCliGrokHome] = useState<string | null>(null);
   /** CLI-tracked worktrees from `grok worktree list` (soft-fail). */
@@ -13050,15 +13063,25 @@ export default function App() {
     [activeProject?.path, executeWorktreeRemove, tr],
   );
 
-  const openWorktreeCreate = useCallback((opts?: { startNewChat?: boolean }) => {
-    setWorktreeCreateName("");
-    setWorktreeCreateRef("");
-    setWorktreeCreateLayout("cli");
-    setWorktreeCreateError(null);
-    setWorktreeCreateBusy(false);
-    setWorktreeCreateStartChat(!!opts?.startNewChat);
-    setWorktreeCreateOpen(true);
-  }, []);
+  const openWorktreeCreate = useCallback(
+    (opts?: {
+      startNewChat?: boolean;
+      suggestedName?: string;
+      firstPrompt?: string;
+      autoSend?: boolean;
+    }) => {
+      setWorktreeCreateName((opts?.suggestedName ?? "").trim());
+      setWorktreeCreateRef("");
+      setWorktreeCreateLayout("cli");
+      setWorktreeCreateError(null);
+      setWorktreeCreateBusy(false);
+      setWorktreeCreateStartChat(!!opts?.startNewChat);
+      setWorktreeCreateFirstPrompt(opts?.firstPrompt ?? "");
+      setWorktreeCreateAutoSend(!!opts?.autoSend);
+      setWorktreeCreateOpen(true);
+    },
+    [],
+  );
 
   const worktreeCreatePreviewPath = (() => {
     try {
@@ -13137,6 +13160,7 @@ export default function App() {
    * Create worktree → refresh list → add as project (trust inherited) →
    * either bind current session or start a draft chat on that path.
    * Worktree+chat creates a real session immediately so meta can be persisted.
+   * Optional first prompt fills the composer; auto-send is best-effort when trusted.
    */
   const submitWorktreeCreate = useCallback(async () => {
     if (!api.isTauri() || !activeProject?.path) return;
@@ -13145,13 +13169,18 @@ export default function App() {
       setWorktreeCreateError(tr("composer.worktreeNameRequired"));
       return;
     }
-    let safeName: string;
+    let plan: ReturnType<typeof planParallelTask>;
     try {
-      safeName = sanitizeWorktreeName(rawName);
+      plan = planParallelTask({
+        name: rawName,
+        firstPrompt: worktreeCreateFirstPrompt,
+        autoSend: worktreeCreateAutoSend,
+      });
     } catch {
       setWorktreeCreateError(tr("composer.worktreeNameInvalid"));
       return;
     }
+    const safeName = plan.name;
     let start: string | null;
     try {
       start = sanitizeWorktreeRef(worktreeCreateRef);
@@ -13203,9 +13232,11 @@ export default function App() {
 
       if (startChat) {
         // Materialize session now so worktree meta survives before first send.
+        const sessionTitle =
+          plan.sessionTitle?.trim() || tr("session.new");
         const meta = (await api.sessionCreate(
           target.id,
-          tr("session.new"),
+          sessionTitle,
         )) as SessionRow & { id: string; title?: string };
         await markSessionWorktree(meta.id, path, branch);
         const row = normalizeSessionRow({
@@ -13217,6 +13248,26 @@ export default function App() {
         });
         setExpandedProjects((e) => ({ ...e, [target!.id]: true }));
         await openSession(row, target);
+        // openSession clears the composer — seed optional first prompt after.
+        if (plan.firstPrompt) {
+          const seed = buildParallelTaskComposerText(plan.firstPrompt, {
+            branch,
+            path,
+          });
+          if (seed) {
+            suppressProjectDraftPersistRef.current = true;
+            setDraft(seed);
+            requestAnimationFrame(() => {
+              suppressProjectDraftPersistRef.current = false;
+            });
+            // Best-effort auto-send (same pattern as voice dictation).
+            if (plan.autoSend) {
+              window.setTimeout(() => {
+                void sendRef.current?.();
+              }, 0);
+            }
+          }
+        }
         showToast(
           tr("composer.worktreeCreatedChat", {
             name: created.name,
@@ -13257,6 +13308,8 @@ export default function App() {
     session.sessionId,
     showToast,
     tr,
+    worktreeCreateAutoSend,
+    worktreeCreateFirstPrompt,
     worktreeCreateLayout,
     worktreeCreateName,
     worktreeCreateRef,
@@ -13674,6 +13727,32 @@ export default function App() {
           break;
         }
         void continueLastAgentForProject(proj);
+        break;
+      }
+      case "parallel-worktree-task": {
+        const pre = evaluateParallelTaskPreflight({
+          isTauri: api.isTauri(),
+          projectPath: activeProject?.path,
+          trusted: activeProject?.trusted,
+          gitAvailable: gitWorktreesAvailable,
+        });
+        if (!pre.ok) {
+          showToast(
+            tr(parallelTaskPreflightMessageKey(pre.reason) as MessageKey),
+            3500,
+          );
+          break;
+        }
+        const existingNames = gitWorktrees
+          .map((w) => (w.branch || worktreeLabel(w) || "").trim())
+          .filter(Boolean);
+        const suggested = suggestParallelWorktreeName({
+          existingNames,
+        });
+        openWorktreeCreate({
+          startNewChat: true,
+          suggestedName: suggested,
+        });
         break;
       }
       case "settings-general":
@@ -20861,6 +20940,45 @@ export default function App() {
               disabled={worktreeCreateBusy}
               spellCheck={false}
             />
+          </label>
+          <label className="wt-create__field">
+            <span className="wt-create__label">
+              {tr("composer.worktreeFirstPrompt")}
+            </span>
+            <textarea
+              className="settings-input wt-create__prompt"
+              value={worktreeCreateFirstPrompt}
+              onChange={(e) => {
+                setWorktreeCreateFirstPrompt(e.target.value);
+              }}
+              placeholder={tr("composer.worktreeFirstPromptPlaceholder")}
+              rows={3}
+              disabled={worktreeCreateBusy}
+              spellCheck
+            />
+            <span className="wt-create__field-hint">
+              {tr("composer.worktreeFirstPromptHint")}
+            </span>
+          </label>
+          <label className="wt-create__check">
+            <input
+              type="checkbox"
+              checked={worktreeCreateAutoSend}
+              onChange={(e) => {
+                setWorktreeCreateAutoSend(e.target.checked);
+              }}
+              disabled={
+                worktreeCreateBusy || !worktreeCreateFirstPrompt.trim()
+              }
+            />
+            <span>
+              <span className="wt-create__check-label">
+                {tr("composer.worktreeAutoSend")}
+              </span>
+              <span className="wt-create__field-hint">
+                {tr("composer.worktreeAutoSendHint")}
+              </span>
+            </span>
           </label>
           {worktreeCreatePreviewPath ? (
             <p className="wt-create__preview">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1089,13 +1089,13 @@ const en = {
   "composer.worktreeTip": "Switch git worktree / branch",
   "composer.worktreeSwitched": "Using worktree {name} ({branch})",
   "composer.worktreeNew": "New worktree",
-  "composer.worktreeNewChat": "New worktree & chat",
+  "composer.worktreeNewChat": "Parallel task (worktree)",
   "composer.worktreeNewTitle": "New git worktree",
-  "composer.worktreeNewChatTitle": "New worktree & chat",
+  "composer.worktreeNewChatTitle": "Parallel task (worktree)",
   "composer.worktreeNewHint":
     "Creates a linked git worktree (default: CLI layout under ~/.grok/worktrees) and checks out a new branch. Same idea as grok --worktree=name.",
   "composer.worktreeNewChatHint":
-    "Creates a linked worktree, then starts a new chat with that folder as the project cwd (session meta bound for the CLI/WT badge).",
+    "Creates a linked worktree, then starts a new chat with that folder as the project cwd (session meta bound for the CLI/WT badge). Parallel work without touching the main checkout.",
   "composer.worktreeName": "Name",
   "composer.worktreeNamePlaceholder": "feat-login",
   "composer.worktreeLayout": "Location",
@@ -1108,6 +1108,14 @@ const en = {
   "composer.worktreeRefInvalid":
     "Start point must not start with '-' or contain line breaks",
   "composer.worktreePathPreview": "Path: {path}",
+  "composer.worktreeFirstPrompt": "First prompt (optional)",
+  "composer.worktreeFirstPromptHint":
+    "Used when opening a new chat — filled into the composer after create.",
+  "composer.worktreeFirstPromptPlaceholder":
+    "What should the agent work on in this worktree?",
+  "composer.worktreeAutoSend": "Send after open",
+  "composer.worktreeAutoSendHint":
+    "When checked, send the first prompt once the new chat opens (trusted projects only). Default off.",
   "composer.worktreeCreate": "Create",
   "composer.worktreeCreateChat": "Create & open chat",
   "composer.worktreeCreating": "Creating…",
@@ -1117,6 +1125,14 @@ const en = {
   "composer.worktreeNameRequired": "Enter a worktree name",
   "composer.worktreeNameInvalid":
     "Use letters, digits, '.', '_' or '-' (no spaces or slashes)",
+  "composer.parallelTask": "Parallel task (worktree)",
+  "composer.parallelTaskHostOnly":
+    "Parallel task needs the desktop app window.",
+  "composer.parallelTaskNoProject": "Select a project first.",
+  "composer.parallelTaskUntrusted":
+    "Trust this project before starting a parallel worktree task.",
+  "composer.parallelTaskNotGit":
+    "This folder is not a git repository (or git is unavailable).",
   "composer.clearProject": "General workspace",
   "composer.projectUntrusted": "Not trusted yet",
   "composer.projectBound": "Session bound to “{name}”",
@@ -7165,13 +7181,13 @@ const zh: Record<MessageKey, string> = {
   "composer.worktreeTip": "切换 Git worktree / 分支",
   "composer.worktreeSwitched": "已切换到 worktree {name}（{branch}）",
   "composer.worktreeNew": "新建 worktree",
-  "composer.worktreeNewChat": "新建 worktree 并开聊",
+  "composer.worktreeNewChat": "并行任务（worktree）",
   "composer.worktreeNewTitle": "新建 Git worktree",
-  "composer.worktreeNewChatTitle": "新建 worktree 并开聊",
+  "composer.worktreeNewChatTitle": "并行任务（worktree）",
   "composer.worktreeNewHint":
     "创建关联 git worktree（默认 CLI 布局 ~/.grok/worktrees），并检出新分支。对齐 grok --worktree=name。",
   "composer.worktreeNewChatHint":
-    "创建关联 worktree，并以该目录为项目 cwd 开启新对话（写入会话 meta，侧栏显示 CLI/WT 标记）。",
+    "创建关联 worktree，并以该目录为项目 cwd 开启新对话（写入会话 meta，侧栏显示 CLI/WT 标记）。主检出不受影响，适合并行工作。",
   "composer.worktreeName": "名称",
   "composer.worktreeNamePlaceholder": "feat-login",
   "composer.worktreeLayout": "位置",
@@ -7184,6 +7200,14 @@ const zh: Record<MessageKey, string> = {
   "composer.worktreeRefInvalid":
     "起始点不能以 '-' 开头，也不能包含换行",
   "composer.worktreePathPreview": "路径：{path}",
+  "composer.worktreeFirstPrompt": "首条提示（可选）",
+  "composer.worktreeFirstPromptHint":
+    "开启新对话时使用 — 创建后填入输入框。",
+  "composer.worktreeFirstPromptPlaceholder":
+    "希望 Agent 在这个 worktree 里做什么？",
+  "composer.worktreeAutoSend": "打开后发送",
+  "composer.worktreeAutoSendHint":
+    "勾选后，新对话打开时自动发送首条提示（仅已信任项目）。默认关闭。",
   "composer.worktreeCreate": "创建",
   "composer.worktreeCreateChat": "创建并开聊",
   "composer.worktreeCreating": "正在创建…",
@@ -7193,6 +7217,13 @@ const zh: Record<MessageKey, string> = {
   "composer.worktreeNameRequired": "请输入 worktree 名称",
   "composer.worktreeNameInvalid":
     "仅允许字母、数字、'.'、'_'、'-'（不能含空格或斜杠）",
+  "composer.parallelTask": "并行任务（worktree）",
+  "composer.parallelTaskHostOnly": "并行任务需要在桌面应用窗口中操作。",
+  "composer.parallelTaskNoProject": "请先选择一个项目。",
+  "composer.parallelTaskUntrusted":
+    "请先信任该项目，再启动并行 worktree 任务。",
+  "composer.parallelTaskNotGit":
+    "当前文件夹不是 git 仓库（或 git 不可用）。",
   "composer.clearProject": "通用工作区",
   "composer.projectUntrusted": "尚未信任",
   "composer.projectBound": "会话已绑定到「{name}」",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -897,13 +897,13 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.worktreeTip": "切換 Git worktree / 分支",
   "composer.worktreeSwitched": "已切換到 worktree {name}（{branch}）",
   "composer.worktreeNew": "新建 worktree",
-  "composer.worktreeNewChat": "新建 worktree 並開聊",
+  "composer.worktreeNewChat": "並行任務（worktree）",
   "composer.worktreeNewTitle": "新建 Git worktree",
-  "composer.worktreeNewChatTitle": "新建 worktree 並開聊",
+  "composer.worktreeNewChatTitle": "並行任務（worktree）",
   "composer.worktreeNewHint":
     "建立關聯 git worktree（預設 CLI 佈局 ~/.grok/worktrees），並檢出新分支。對齊 grok --worktree=name。",
   "composer.worktreeNewChatHint":
-    "建立關聯 worktree，並以該目錄為專案 cwd 開啟新對話（寫入對話 meta，側欄顯示 CLI/WT 標記）。",
+    "建立關聯 worktree，並以該目錄為專案 cwd 開啟新對話（寫入對話 meta，側欄顯示 CLI/WT 標記）。主檢出不受影響，適合並行工作。",
   "composer.worktreeName": "名稱",
   "composer.worktreeNamePlaceholder": "feat-login",
   "composer.worktreeLayout": "位置",
@@ -916,6 +916,14 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.worktreeRefInvalid":
     "起始點不能以 '-' 開頭，也不能包含換行",
   "composer.worktreePathPreview": "路徑：{path}",
+  "composer.worktreeFirstPrompt": "首條提示（可選）",
+  "composer.worktreeFirstPromptHint":
+    "開啟新對話時使用 — 建立後填入輸入框。",
+  "composer.worktreeFirstPromptPlaceholder":
+    "希望 Agent 在這個 worktree 裡做什麼？",
+  "composer.worktreeAutoSend": "開啟後傳送",
+  "composer.worktreeAutoSendHint":
+    "勾選後，新對話開啟時自動傳送首條提示（僅已信任專案）。預設關閉。",
   "composer.worktreeCreate": "建立",
   "composer.worktreeCreateChat": "建立並開聊",
   "composer.worktreeCreating": "正在建立…",
@@ -925,6 +933,13 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.worktreeNameRequired": "請輸入 worktree 名稱",
   "composer.worktreeNameInvalid":
     "僅允許字母、數字、'.'、'_'、'-'（不能含空格或斜線）",
+  "composer.parallelTask": "並行任務（worktree）",
+  "composer.parallelTaskHostOnly": "並行任務需要在桌面應用視窗中操作。",
+  "composer.parallelTaskNoProject": "請先選擇一個專案。",
+  "composer.parallelTaskUntrusted":
+    "請先信任該專案，再啟動並行 worktree 任務。",
+  "composer.parallelTaskNotGit":
+    "目前資料夾不是 git 倉庫（或 git 不可用）。",
   "composer.addFiles": "上傳檔案",
   "composer.planMode": "計劃模式",
   "composer.planModeHint": "開啟計劃模式",

--- a/src/lib/paletteActions.test.ts
+++ b/src/lib/paletteActions.test.ts
@@ -25,6 +25,7 @@ describe("defaultPaletteActions", () => {
       "copy-conversation-md",
       "resume-with-code-restore",
       "continue-cwd",
+      "parallel-worktree-task",
       "settings-general",
       "settings-appearance",
       "settings-account",
@@ -98,6 +99,12 @@ describe("filterPaletteActions", () => {
     expect(
       filterPaletteActions("--continue", catalog).map((h) => h.id),
     ).toContain("continue-cwd");
+
+    const parallel = filterPaletteActions("parallel task", catalog);
+    expect(parallel.map((h) => h.id)).toContain("parallel-worktree-task");
+    expect(
+      filterPaletteActions("git worktree", catalog).map((h) => h.id),
+    ).toContain("parallel-worktree-task");
   });
 
   it("matches translated label when t is provided", () => {

--- a/src/lib/paletteActions.ts
+++ b/src/lib/paletteActions.ts
@@ -195,6 +195,23 @@ export function defaultPaletteActions(): PaletteActionDef[] {
       group: "session",
     },
     {
+      id: "parallel-worktree-task",
+      labelKey: "composer.parallelTask",
+      keywords: [
+        "parallel",
+        "parallel task",
+        "worktree",
+        "new worktree",
+        "worktree chat",
+        "isolate",
+        "branch task",
+        "git worktree",
+        "side task",
+        "parallel chat",
+      ],
+      group: "create",
+    },
+    {
       id: "settings-general",
       labelKey: "settings.nav.general",
       keywords: ["settings", "general", "preferences", "prefs", "composer"],

--- a/src/lib/worktreeParallel.test.ts
+++ b/src/lib/worktreeParallel.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildParallelTaskComposerText,
+  evaluateParallelTaskPreflight,
+  PARALLEL_TASK_PROMPT_MAX,
+  parallelTaskPreflightMessageKey,
+  planParallelTask,
+  slugifyParallelTaskName,
+  suggestParallelWorktreeName,
+} from "./worktreeParallel";
+
+describe("slugifyParallelTaskName", () => {
+  it("lowercases and replaces unsafe chars", () => {
+    expect(slugifyParallelTaskName("  Fix Login Flow  ")).toBe("fix-login-flow");
+    expect(slugifyParallelTaskName("Feat: Foo/Bar!")).toBe("feat-foo-bar");
+  });
+
+  it("uses only the first line", () => {
+    expect(slugifyParallelTaskName("hello world\nsecond line")).toBe(
+      "hello-world",
+    );
+  });
+
+  it("returns empty for blank / junk", () => {
+    expect(slugifyParallelTaskName("")).toBe("");
+    expect(slugifyParallelTaskName("   ")).toBe("");
+    expect(slugifyParallelTaskName("!!!")).toBe("");
+    expect(slugifyParallelTaskName(null)).toBe("");
+    expect(slugifyParallelTaskName(undefined)).toBe("");
+  });
+
+  it("caps length", () => {
+    const long = "a".repeat(80);
+    expect(slugifyParallelTaskName(long).length).toBeLessThanOrEqual(40);
+  });
+});
+
+describe("suggestParallelWorktreeName", () => {
+  const fixed = new Date("2026-04-01T12:00:00.000Z");
+
+  it("slugifies title when free", () => {
+    expect(
+      suggestParallelWorktreeName({
+        title: "Parallel UI polish",
+        existingNames: [],
+        now: fixed,
+      }),
+    ).toBe("parallel-ui-polish");
+  });
+
+  it("falls back to task-<time> without title", () => {
+    const name = suggestParallelWorktreeName({
+      title: null,
+      existingNames: [],
+      now: fixed,
+    });
+    expect(name.startsWith("task-")).toBe(true);
+    expect(name).toMatch(/^task-[a-z0-9]+$/);
+  });
+
+  it("appends -2/-3 on collision", () => {
+    expect(
+      suggestParallelWorktreeName({
+        title: "feat-x",
+        existingNames: ["feat-x", "feat-x-2"],
+        now: fixed,
+      }),
+    ).toBe("feat-x-3");
+  });
+
+  it("is case-insensitive against existing", () => {
+    expect(
+      suggestParallelWorktreeName({
+        title: "Feat-X",
+        existingNames: ["FEAT-X"],
+        now: fixed,
+      }),
+    ).toBe("feat-x-2");
+  });
+});
+
+describe("evaluateParallelTaskPreflight", () => {
+  const okBase = {
+    isTauri: true,
+    projectPath: "/Users/me/proj",
+    trusted: true,
+    gitAvailable: true as boolean | null,
+  };
+
+  it("ok when host + project + trusted + git", () => {
+    expect(evaluateParallelTaskPreflight(okBase)).toEqual({ ok: true });
+  });
+
+  it("host_only when not Tauri", () => {
+    expect(
+      evaluateParallelTaskPreflight({ ...okBase, isTauri: false }),
+    ).toEqual({ ok: false, reason: "host_only" });
+  });
+
+  it("no_project when path empty", () => {
+    expect(
+      evaluateParallelTaskPreflight({ ...okBase, projectPath: "  " }),
+    ).toEqual({ ok: false, reason: "no_project" });
+    expect(
+      evaluateParallelTaskPreflight({ ...okBase, projectPath: null }),
+    ).toEqual({ ok: false, reason: "no_project" });
+  });
+
+  it("untrusted when trusted === false", () => {
+    expect(
+      evaluateParallelTaskPreflight({ ...okBase, trusted: false }),
+    ).toEqual({ ok: false, reason: "untrusted" });
+  });
+
+  it("not_git when gitAvailable === false", () => {
+    expect(
+      evaluateParallelTaskPreflight({ ...okBase, gitAvailable: false }),
+    ).toEqual({ ok: false, reason: "not_git" });
+  });
+
+  it("allows unknown git (null) so host can still open create", () => {
+    expect(
+      evaluateParallelTaskPreflight({ ...okBase, gitAvailable: null }),
+    ).toEqual({ ok: true });
+  });
+
+  it("maps reasons to message keys", () => {
+    expect(parallelTaskPreflightMessageKey("host_only")).toBe(
+      "composer.parallelTaskHostOnly",
+    );
+    expect(parallelTaskPreflightMessageKey("no_project")).toBe(
+      "composer.parallelTaskNoProject",
+    );
+    expect(parallelTaskPreflightMessageKey("untrusted")).toBe(
+      "composer.parallelTaskUntrusted",
+    );
+    expect(parallelTaskPreflightMessageKey("not_git")).toBe(
+      "composer.parallelTaskNotGit",
+    );
+  });
+});
+
+describe("planParallelTask", () => {
+  it("sanitizes name and nulls empty prompt", () => {
+    const p = planParallelTask({ name: "  feat-login  ", firstPrompt: "  " });
+    expect(p.name).toBe("feat-login");
+    expect(p.firstPrompt).toBeNull();
+    expect(p.autoSend).toBe(false);
+    expect(p.sessionTitle).toBe("feat-login");
+  });
+
+  it("keeps prompt and caps length", () => {
+    const long = "x".repeat(PARALLEL_TASK_PROMPT_MAX + 50);
+    const p = planParallelTask({
+      name: "task-abc",
+      firstPrompt: long,
+      autoSend: true,
+    });
+    expect(p.firstPrompt?.length).toBe(PARALLEL_TASK_PROMPT_MAX);
+    expect(p.autoSend).toBe(true);
+  });
+
+  it("autoSend requires a non-empty prompt", () => {
+    expect(
+      planParallelTask({ name: "feat-a", firstPrompt: "", autoSend: true })
+        .autoSend,
+    ).toBe(false);
+  });
+
+  it("session title prefers prompt first line for generic task-* names", () => {
+    const p = planParallelTask({
+      name: "task-k1m2n3",
+      firstPrompt: "Ship the parallel worktree flow\nmore detail",
+    });
+    expect(p.sessionTitle).toBe("Ship the parallel worktree flow");
+  });
+
+  it("session title keeps explicit name", () => {
+    const p = planParallelTask({
+      name: "feat-parallel",
+      firstPrompt: "Do the thing",
+    });
+    expect(p.sessionTitle).toBe("feat-parallel");
+  });
+
+  it("throws on illegal name", () => {
+    expect(() => planParallelTask({ name: "has space" })).toThrow();
+    expect(() => planParallelTask({ name: "" })).toThrow();
+  });
+});
+
+describe("buildParallelTaskComposerText", () => {
+  it("returns body alone without meta", () => {
+    expect(buildParallelTaskComposerText("Hello")).toBe("Hello");
+    expect(buildParallelTaskComposerText("  Hi  ", {})).toBe("Hi");
+  });
+
+  it("prefixes honest branch/path when present", () => {
+    expect(
+      buildParallelTaskComposerText("Do work", {
+        branch: "feat-x",
+        path: "/tmp/wt-feat-x",
+      }),
+    ).toBe(
+      "[parallel task · branch: feat-x · cwd: /tmp/wt-feat-x]\n\nDo work",
+    );
+  });
+
+  it("omits missing bits (never invents)", () => {
+    expect(
+      buildParallelTaskComposerText("Only branch", { branch: "main" }),
+    ).toBe("[parallel task · branch: main]\n\nOnly branch");
+    expect(
+      buildParallelTaskComposerText("Only path", {
+        path: "/repo",
+        branch: "  ",
+      }),
+    ).toBe("[parallel task · cwd: /repo]\n\nOnly path");
+  });
+
+  it("empty prompt → empty string", () => {
+    expect(buildParallelTaskComposerText("  ")).toBe("");
+    expect(buildParallelTaskComposerText("", { branch: "x" })).toBe("");
+  });
+});

--- a/src/lib/worktreeParallel.ts
+++ b/src/lib/worktreeParallel.ts
@@ -1,0 +1,192 @@
+/**
+ * Pure helpers for “parallel task” = create a git worktree + open a new chat.
+ * I/O-free for unit tests; host (App) owns gitWorktreeAdd / sessionCreate / draft.
+ */
+
+import { sanitizeWorktreeName } from "@/lib/gitWorktree";
+
+/** Soft cap for optional first prompt stored on create (composer still owns send). */
+export const PARALLEL_TASK_PROMPT_MAX = 8_000;
+
+/** Max length for slug fragments before uniqueness suffix. */
+const SLUG_MAX = 40;
+
+/**
+ * Safe branch/worktree name fragment from an optional task title or prompt.
+ * Empty / junk → empty string (caller adds `task` + time fallback).
+ */
+export function slugifyParallelTaskName(raw: string | null | undefined): string {
+  const s = (raw ?? "")
+    .trim()
+    .toLowerCase()
+    // First line only (prompt titles often multi-line)
+    .split(/\r?\n/, 1)[0]
+    .trim()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-")
+    .slice(0, SLUG_MAX)
+    .replace(/-+$/g, "");
+  // Must not start with '-' after edge truncation
+  if (!s || s === "." || s === "..") return "";
+  if (s.startsWith("-")) return s.replace(/^-+/, "") || "";
+  return s;
+}
+
+function timeSuffix(now: Date): string {
+  return Math.abs(now.getTime()).toString(36).slice(-6);
+}
+
+function normalizeExistingNames(names: readonly string[] | undefined): Set<string> {
+  const set = new Set<string>();
+  for (const n of names ?? []) {
+    const t = (n ?? "").trim().toLowerCase();
+    if (t) set.add(t);
+  }
+  return set;
+}
+
+/**
+ * Suggest a unique worktree/branch name for a parallel task.
+ * Prefers slug from title; falls back to `task-<time>`; appends `-2`, `-3`, …
+ * when colliding with `existingNames`.
+ */
+export function suggestParallelWorktreeName(opts: {
+  title?: string | null;
+  existingNames?: string[];
+  now?: Date;
+}): string {
+  const now = opts.now ?? new Date();
+  const existing = normalizeExistingNames(opts.existingNames);
+  const baseSlug = slugifyParallelTaskName(opts.title);
+  const base = baseSlug || `task-${timeSuffix(now)}`;
+
+  let candidate = base;
+  let n = 2;
+  while (existing.has(candidate.toLowerCase()) || candidate.length > 64) {
+    const suffix = `-${n}`;
+    const head = base.slice(0, Math.max(1, 64 - suffix.length)).replace(/-+$/, "");
+    candidate = `${head || "task"}${suffix}`;
+    n += 1;
+    if (n > 999) {
+      candidate = `task-${timeSuffix(now)}-${n}`;
+      break;
+    }
+  }
+  // Final hard-safe pass via sanitize (throws only on empty / illegal).
+  try {
+    return sanitizeWorktreeName(candidate);
+  } catch {
+    return sanitizeWorktreeName(`task-${timeSuffix(now)}`);
+  }
+}
+
+export type ParallelTaskPreflightReason =
+  | "host_only"
+  | "no_project"
+  | "untrusted"
+  | "not_git";
+
+export type ParallelTaskPreflight =
+  | { ok: true }
+  | { ok: false; reason: ParallelTaskPreflightReason };
+
+/**
+ * Gate for palette / menu “Parallel task (worktree)”.
+ * Honest soft-fail reasons only — never invents a project or git status.
+ */
+export function evaluateParallelTaskPreflight(opts: {
+  isTauri: boolean;
+  projectPath?: string | null;
+  trusted?: boolean;
+  gitAvailable?: boolean | null;
+}): ParallelTaskPreflight {
+  if (!opts.isTauri) return { ok: false, reason: "host_only" };
+  const path = (opts.projectPath ?? "").trim();
+  if (!path) return { ok: false, reason: "no_project" };
+  if (opts.trusted === false) return { ok: false, reason: "untrusted" };
+  if (opts.gitAvailable === false) return { ok: false, reason: "not_git" };
+  return { ok: true };
+}
+
+/** i18n message key for a preflight soft-fail (host maps via tr). */
+export function parallelTaskPreflightMessageKey(
+  reason: ParallelTaskPreflightReason,
+): string {
+  switch (reason) {
+    case "host_only":
+      return "composer.parallelTaskHostOnly";
+    case "no_project":
+      return "composer.parallelTaskNoProject";
+    case "untrusted":
+      return "composer.parallelTaskUntrusted";
+    case "not_git":
+      return "composer.parallelTaskNotGit";
+    default:
+      return "composer.parallelTaskNoProject";
+  }
+}
+
+export type ParallelTaskPlan = {
+  name: string;
+  firstPrompt: string | null;
+  autoSend: boolean;
+  sessionTitle: string;
+};
+
+function firstLine(text: string): string {
+  return text.split(/\r?\n/, 1)[0]?.trim() || "";
+}
+
+/**
+ * Sanitize create options for a parallel task.
+ * - name via {@link sanitizeWorktreeName} (throws on illegal)
+ * - prompt trimmed, capped to {@link PARALLEL_TASK_PROMPT_MAX}, empty → null
+ * - sessionTitle from name, or first line of prompt when name is a generic task-*
+ */
+export function planParallelTask(opts: {
+  name: string;
+  firstPrompt?: string | null;
+  autoSend?: boolean;
+}): ParallelTaskPlan {
+  const name = sanitizeWorktreeName(opts.name);
+  let prompt = (opts.firstPrompt ?? "").trim();
+  if (prompt.length > PARALLEL_TASK_PROMPT_MAX) {
+    prompt = prompt.slice(0, PARALLEL_TASK_PROMPT_MAX);
+  }
+  const firstPrompt = prompt.length > 0 ? prompt : null;
+  const autoSend = !!opts.autoSend && !!firstPrompt;
+
+  let sessionTitle = name;
+  if (firstPrompt) {
+    const line = firstLine(firstPrompt);
+    if (line && /^task-[a-z0-9]+$/i.test(name)) {
+      // Generic auto-name: prefer a short title from the prompt
+      sessionTitle = line.length > 48 ? `${line.slice(0, 47)}…` : line;
+    }
+  }
+
+  return { name, firstPrompt, autoSend, sessionTitle };
+}
+
+/**
+ * Composer draft for the new parallel-task chat.
+ * Optional short honest context prefix (branch / path when known) then the user prompt.
+ * Never invents paths or branches.
+ */
+export function buildParallelTaskComposerText(
+  firstPrompt: string,
+  meta: { branch?: string | null; path?: string | null } = {},
+): string {
+  const body = firstPrompt.trim();
+  if (!body) return "";
+
+  const bits: string[] = [];
+  const branch = (meta.branch ?? "").trim();
+  const path = (meta.path ?? "").trim();
+  if (branch) bits.push(`branch: ${branch}`);
+  if (path) bits.push(`cwd: ${path}`);
+
+  if (bits.length === 0) return body;
+  return `[parallel task · ${bits.join(" · ")}]\n\n${body}`;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3393,6 +3393,45 @@ html[data-sidebar-density="compact"] .session-row__meta {
   color: var(--danger, #e35d6a);
 }
 
+.wt-create__prompt {
+  resize: vertical;
+  min-height: 4.5em;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.wt-create__field-hint {
+  font-size: 11.5px;
+  line-height: 1.35;
+  color: var(--text-tertiary);
+}
+
+.wt-create__check {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.wt-create__check input {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.wt-create__check-label {
+  display: block;
+  font-weight: 500;
+}
+
+.wt-create__check .wt-create__field-hint {
+  display: block;
+  margin-top: 2px;
+}
+
 .cpm__worktree-remove {
   flex-shrink: 0;
   display: inline-flex;


### PR DESCRIPTION
## Summary
- One flow to create a linked git worktree and open a new chat there (command palette `parallel-worktree-task` + Composer worktree menu “Parallel task (worktree)”).
- Optional **First prompt** textarea always visible in the worktree create dialog; fills the composer after open. Optional **Send after open** checkbox (default off; best-effort auto-send when trusted).
- Pure helpers in `src/lib/worktreeParallel.ts` (slugify / unique name / preflight / plan / composer text) + vitest; en/zh/zh-TW i18n; CHANGELOG under Unreleased.

## Test plan
- [x] `pnpm test -- src/lib/worktreeParallel.test.ts src/lib/paletteActions.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: palette → “Parallel task” with a trusted git project → create worktree, confirm new chat + optional first prompt in composer
- [ ] Manual: worktree menu → Parallel task (worktree) without auto-send; with auto-send checked on trusted project
- [ ] Manual: preflight soft-fails (no project / untrusted / not git / non-desktop) show honest toasts