### PR TITLE
feat(plan): editable plan draft before approve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Editable plan canvas** (Resources → Plan): when a plan is awaiting review, **Edit plan** opens a local markdown draft; dirty drafts disable **Approve** (hint: request changes with your edits first); **Request changes with draft** sends feedback with clear revised-plan markers; discard dirty edit uses GlassModal (no `window.confirm`). Pure `planEditCanvas` helpers + tests; en/zh/zh-TW.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20422,7 +20422,15 @@ export default function App() {
                 hasHistory: planHistoryNonEmpty,
               }}
               onApprovePlan={() => void approvePlan()}
-              onRequestPlanChanges={() => openRequestPlanChanges()}
+              onRequestPlanChanges={(note) => {
+                // Draft-from-edit canvas includes revised-plan markers — send
+                // immediately. Empty / omitted opens the optional note modal.
+                if (typeof note === "string" && note.trim().length > 0) {
+                  void requestPlanChanges(note);
+                  return;
+                }
+                openRequestPlanChanges();
+              }}
               onDismissPlan={() => void dismissPlan()}
               onOpenPlanHistory={() => setShowPlanHistory(true)}
               onShip={openShipFlow}

--- a/src/components/PlanReviewPanel.tsx
+++ b/src/components/PlanReviewPanel.tsx
@@ -4,9 +4,13 @@
  * - **Awaiting review** (`rpcId`): expand by default — Markdown + approve/revise.
  * - **In progress** (entries, no gate): collapsed by default — top progress only;
  *   click header / expand control to show steps + detail body.
+ * - **Edit canvas**: when the exit_plan_mode gate is open, users can edit plan
+ *   markdown locally; dirty drafts disable Approve and send via request-changes
+ *   with clear revised-plan markers (see `planEditCanvas`).
  */
 
 import { useEffect, useMemo, useState } from "react";
+import { GlassModal } from "@/components/GlassModal";
 import { MarkdownBody } from "@/components/MarkdownBody";
 import { OverlayScroll } from "@/components/OverlayScroll";
 import { IconChevronDown, IconChevronRight, IconPlan } from "@/components/icons";
@@ -16,6 +20,13 @@ import {
   planIsAwaitingReview,
   type PlanReviewState,
 } from "@/lib/planBody";
+import {
+  buildRequestChangesNoteFromDraft,
+  planDraftIsDirty,
+  planEditEmptyState,
+  sanitizePlanDraft,
+  validatePlanDraft,
+} from "@/lib/planEditCanvas";
 import {
   planHasExpandableContent,
   planPanelInnerEmptyLabelKey,
@@ -44,6 +55,27 @@ export type PlanReviewPanelLabels = {
   /** Collapse control when expanded. */
   collapseDetails: string;
   current: string;
+  /** Enter local plan draft edit mode. */
+  edit: string;
+  /** Leave edit mode (clean). */
+  cancelEdit: string;
+  /** Primary when draft is dirty — send revised plan via request-changes. */
+  requestWithDraft: string;
+  /** Hint when Approve is disabled because the draft is dirty. */
+  approveDirtyHint: string;
+  /** Textarea aria / placeholder. */
+  draftPlaceholder: string;
+  draftAria: string;
+  /** Discard dirty draft confirm modal. */
+  discardTitle: string;
+  discardMessage: string;
+  discardConfirm: string;
+  discardCancel: string;
+  /** Soft-fail when draft is empty / too long. */
+  draftEmpty: string;
+  draftTooLong: string;
+  /** Close dialog button label. */
+  close: string;
 };
 
 export type PlanReviewPanelProps = {
@@ -55,6 +87,7 @@ export type PlanReviewPanelProps = {
   /**
    * Request plan revisions. Optional `note` is free-form feedback for the agent.
    * Callers may open a note modal first, then invoke with the string (empty ok).
+   * When the edit canvas sends a dirty draft, `note` includes revised-plan markers.
    */
   onRequestChanges?: (note?: string) => void;
   onDismiss?: () => void;
@@ -77,6 +110,7 @@ export function PlanReviewPanel({
   const fraction = formatPlanFraction(progress);
   const canAct = planActionsEnabled(plan);
   const awaitingReview = planIsAwaitingReview(plan);
+  const editAvail = planEditEmptyState({ canAct, hasBody });
 
   const model = useMemo(
     () =>
@@ -101,6 +135,12 @@ export function PlanReviewPanel({
     return "";
   }, [hasBody, plan.body, plan.entries, awaitingReview, entries.length]);
 
+  /** Baseline for dirty checks — prefer full body; fall back to display md. */
+  const originalBody = useMemo(() => {
+    if (plan.body) return sanitizePlanDraft(plan.body);
+    return sanitizePlanDraft(detailMarkdown);
+  }, [plan.body, detailMarkdown]);
+
   const statusLabel =
     model.headlineKey === "planBar.progress"
       ? labels.progress
@@ -115,11 +155,20 @@ export function PlanReviewPanel({
   // Review gate → expanded; pure progress → collapsed until user opens.
   const defaultExpanded = awaitingReview || (hasBody && entries.length === 0);
   const [expanded, setExpanded] = useState(defaultExpanded);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(originalBody);
+  const [discardOpen, setDiscardOpen] = useState(false);
 
-  // When plan identity / gate flips, reset expand policy.
+  const dirty = planDraftIsDirty(originalBody, draft);
+  const draftValidation = validatePlanDraft(draft);
+
+  // When plan identity / gate flips, reset expand policy and leave edit mode.
   useEffect(() => {
     setExpanded(defaultExpanded);
-  }, [defaultExpanded, plan.rpcId, plan.title]);
+    setEditing(false);
+    setDraft(originalBody);
+    setDiscardOpen(false);
+  }, [defaultExpanded, plan.rpcId, plan.title, originalBody]);
 
   // 详情 / planFocusKey: force expand so steps+detail are visible.
   useEffect(() => {
@@ -129,7 +178,8 @@ export function PlanReviewPanel({
 
   const hasExpandableContent =
     planHasExpandableContent({ body: detailMarkdown || plan.body, entries }) ||
-    !!planDisplayMarkdown(plan.body, plan.entries);
+    !!planDisplayMarkdown(plan.body, plan.entries) ||
+    editing;
 
   const innerEmptyKind = resolvePlanPanelInnerEmpty({
     waiting: plan.waiting && !canAct,
@@ -147,14 +197,60 @@ export function PlanReviewPanel({
     setExpanded((v) => !v);
   };
 
+  const enterEdit = () => {
+    setDraft(originalBody);
+    setEditing(true);
+    setExpanded(true);
+  };
+
+  const leaveEditClean = () => {
+    setEditing(false);
+    setDraft(originalBody);
+    setDiscardOpen(false);
+  };
+
+  const requestCancelEdit = () => {
+    if (dirty) {
+      setDiscardOpen(true);
+      return;
+    }
+    leaveEditClean();
+  };
+
+  const submitDraftChanges = () => {
+    if (!onRequestChanges) return;
+    if (!dirty) {
+      onRequestChanges();
+      return;
+    }
+    if (!draftValidation.ok) return;
+    const note = buildRequestChangesNoteFromDraft({
+      originalBody,
+      draft,
+    });
+    onRequestChanges(note);
+    leaveEditClean();
+  };
+
+  const approveDisabled = dirty;
+  const draftErrorLabel =
+    editing && dirty && !draftValidation.ok
+      ? draftValidation.reason === "too_long"
+        ? labels.draftTooLong
+        : labels.draftEmpty
+      : null;
+
   return (
     <div
       className={
         "plan-review" +
-        (expanded ? " plan-review--expanded" : " plan-review--collapsed")
+        (expanded ? " plan-review--expanded" : " plan-review--collapsed") +
+        (editing ? " plan-review--editing" : "")
       }
       data-testid="plan-review-panel"
       data-plan-card
+      data-plan-editing={editing ? "true" : undefined}
+      data-plan-dirty={dirty ? "true" : undefined}
     >
       <header className="plan-review__header">
         <button
@@ -211,7 +307,7 @@ export function PlanReviewPanel({
         ) : null}
 
         <div className="plan-review__actions">
-          {hasExpandableContent ? (
+          {hasExpandableContent && !editing ? (
             <button
               type="button"
               className="btn btn--ghost btn--sm"
@@ -220,20 +316,55 @@ export function PlanReviewPanel({
               {expanded ? labels.collapseDetails : labels.expandDetails}
             </button>
           ) : null}
+          {editAvail.canEdit && !editing ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={enterEdit}
+              data-testid="plan-review-edit"
+            >
+              {labels.edit}
+            </button>
+          ) : null}
+          {editing ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={requestCancelEdit}
+              data-testid="plan-review-cancel-edit"
+            >
+              {labels.cancelEdit}
+            </button>
+          ) : null}
           {canAct && onApprove ? (
             <button
               type="button"
               className="btn btn--solid btn--sm"
               onClick={onApprove}
+              disabled={approveDisabled}
+              title={approveDisabled ? labels.approveDirtyHint : undefined}
+              data-testid="plan-review-approve"
             >
               {labels.approve}
             </button>
           ) : null}
-          {canAct && onRequestChanges ? (
+          {canAct && onRequestChanges && editing && dirty ? (
+            <button
+              type="button"
+              className="btn btn--solid btn--sm"
+              onClick={submitDraftChanges}
+              disabled={!draftValidation.ok}
+              data-testid="plan-review-request-with-draft"
+            >
+              {labels.requestWithDraft}
+            </button>
+          ) : null}
+          {canAct && onRequestChanges && !(editing && dirty) ? (
             <button
               type="button"
               className="btn btn--ghost btn--sm"
               onClick={() => onRequestChanges()}
+              data-testid="plan-review-request-changes"
             >
               {labels.changes}
             </button>
@@ -248,12 +379,30 @@ export function PlanReviewPanel({
             </button>
           ) : null}
         </div>
+        {approveDisabled && canAct ? (
+          <p
+            className="plan-review__dirty-hint"
+            role="status"
+            data-testid="plan-review-dirty-hint"
+          >
+            {labels.approveDirtyHint}
+          </p>
+        ) : null}
+        {draftErrorLabel ? (
+          <p
+            className="plan-review__draft-error"
+            role="alert"
+            data-testid="plan-review-draft-error"
+          >
+            {draftErrorLabel}
+          </p>
+        ) : null}
       </header>
 
       {expanded ? (
         <OverlayScroll className="plan-review__scroll">
           <div className="plan-review__body">
-            {entries.length > 0 ? (
+            {entries.length > 0 && !editing ? (
               <section className="plan-review__steps">
                 <h3 className="plan-review__steps-title">{labels.steps}</h3>
                 <ol className="plan-review__steps-list">
@@ -280,7 +429,19 @@ export function PlanReviewPanel({
               </section>
             ) : null}
 
-            {detailMarkdown ? (
+            {editing ? (
+              <div className="plan-review__editor">
+                <textarea
+                  className="plan-review__textarea"
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  placeholder={labels.draftPlaceholder}
+                  aria-label={labels.draftAria}
+                  spellCheck={false}
+                  data-testid="plan-review-draft"
+                />
+              </div>
+            ) : detailMarkdown ? (
               <div
                 className={
                   "plan-review__md" +
@@ -305,6 +466,36 @@ export function PlanReviewPanel({
           </div>
         </OverlayScroll>
       ) : null}
+
+      <GlassModal
+        open={discardOpen}
+        onClose={() => setDiscardOpen(false)}
+        title={labels.discardTitle}
+        size="sm"
+        closeLabel={labels.close}
+        wrapBody
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => setDiscardOpen(false)}
+            >
+              {labels.discardCancel}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              onClick={leaveEditClean}
+              data-testid="plan-review-discard-confirm"
+            >
+              {labels.discardConfirm}
+            </button>
+          </>
+        }
+      >
+        <p className="plan-review__discard-msg">{labels.discardMessage}</p>
+      </GlassModal>
     </div>
   );
 }

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -3623,6 +3623,19 @@ export function ResourceViewer({
                 expandDetails: tr("plan.expandDetails"),
                 collapseDetails: tr("plan.collapseDetails"),
                 current: tr("planBar.current"),
+                edit: tr("plan.edit"),
+                cancelEdit: tr("plan.cancelEdit"),
+                requestWithDraft: tr("plan.requestWithDraft"),
+                approveDirtyHint: tr("plan.approveDirtyHint"),
+                draftPlaceholder: tr("plan.draftPlaceholder"),
+                draftAria: tr("plan.draftAria"),
+                discardTitle: tr("plan.discardTitle"),
+                discardMessage: tr("plan.discardMessage"),
+                discardConfirm: tr("plan.discardConfirm"),
+                discardCancel: tr("common.cancel"),
+                draftEmpty: tr("plan.draftEmpty"),
+                draftTooLong: tr("plan.draftTooLong"),
+                close: tr("common.close"),
               }}
               onApprove={onApprovePlan}
               onRequestChanges={onRequestPlanChanges}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1306,6 +1306,20 @@ const en = {
     "Optional note for the agent. Leave empty to ask for a general revision.",
   "plan.reviseNotePlaceholder": "What should change? (optional)",
   "plan.reviseNoteSubmit": "Send revision request",
+  /** Editable plan canvas (Resources → Plan before approve) */
+  "plan.edit": "Edit plan",
+  "plan.cancelEdit": "Cancel edit",
+  "plan.requestWithDraft": "Request changes with draft",
+  "plan.approveDirtyHint":
+    "You have unsaved plan edits. Request changes with your draft first, or discard them to approve the agent's plan.",
+  "plan.draftPlaceholder": "Edit the plan markdown…",
+  "plan.draftAria": "Plan draft markdown",
+  "plan.discardTitle": "Discard plan edits?",
+  "plan.discardMessage":
+    "Your local edits will be lost. The agent’s original plan stays until you request changes or approve.",
+  "plan.discardConfirm": "Discard edits",
+  "plan.draftEmpty": "Plan draft cannot be empty.",
+  "plan.draftTooLong": "Plan draft is too long (max about 200k characters).",
   "plan.phaseLabel": "Thinking {n}",
   "plan.steps": "Steps",
   "plan.openInResources": "Open in resources",
@@ -7375,6 +7389,20 @@ const zh: Record<MessageKey, string> = {
   "plan.reviseNoteDesc": "可填写给 Agent 的说明；留空则请求一般性修订。",
   "plan.reviseNotePlaceholder": "希望改什么？（可选）",
   "plan.reviseNoteSubmit": "发送修改请求",
+  /** Editable plan canvas (Resources → Plan before approve) */
+  "plan.edit": "编辑计划",
+  "plan.cancelEdit": "取消编辑",
+  "plan.requestWithDraft": "用草稿请求修改",
+  "plan.approveDirtyHint":
+    "你有未提交的计划修改。请先用草稿请求修改，或丢弃后再批准 Agent 的原计划。",
+  "plan.draftPlaceholder": "编辑计划 Markdown…",
+  "plan.draftAria": "计划草稿 Markdown",
+  "plan.discardTitle": "丢弃计划修改？",
+  "plan.discardMessage":
+    "本地修改将丢失。在请求修改或批准之前，仍以 Agent 原计划为准。",
+  "plan.discardConfirm": "丢弃修改",
+  "plan.draftEmpty": "计划草稿不能为空。",
+  "plan.draftTooLong": "计划草稿过长（上限约 20 万字符）。",
   "plan.phaseLabel": "思考 {n}",
   "plan.steps": "步骤",
   "plan.openInResources": "在资源中打开",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1230,6 +1230,20 @@ export const zhTW: Record<MessageKey, string> = {
   "plan.reviseNoteDesc": "可填寫給 Agent 的說明；留空則請求一般性修訂。",
   "plan.reviseNotePlaceholder": "希望改什麼？（可選）",
   "plan.reviseNoteSubmit": "傳送修改請求",
+  /** Editable plan canvas (Resources → Plan before approve) */
+  "plan.edit": "編輯計劃",
+  "plan.cancelEdit": "取消編輯",
+  "plan.requestWithDraft": "用草稿請求修改",
+  "plan.approveDirtyHint":
+    "你有未提交的計劃修改。請先用草稿請求修改，或丟棄後再核准 Agent 的原計劃。",
+  "plan.draftPlaceholder": "編輯計劃 Markdown…",
+  "plan.draftAria": "計劃草稿 Markdown",
+  "plan.discardTitle": "丟棄計劃修改？",
+  "plan.discardMessage":
+    "本機修改將遺失。在請求修改或核准之前，仍以 Agent 原計劃為準。",
+  "plan.discardConfirm": "丟棄修改",
+  "plan.draftEmpty": "計劃草稿不能為空。",
+  "plan.draftTooLong": "計劃草稿過長（上限約 20 萬字元）。",
   "plan.phaseLabel": "思考 {n}",
   "plan.steps": "步驟",
   "plan.openInResources": "在資源中開啟",

--- a/src/lib/planEditCanvas.test.ts
+++ b/src/lib/planEditCanvas.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  PLAN_DRAFT_MAX_CHARS,
+  PLAN_REVISED_MARKER_END,
+  PLAN_REVISED_MARKER_START,
+  buildRequestChangesNoteFromDraft,
+  planDraftIsDirty,
+  planEditEmptyState,
+  sanitizePlanDraft,
+  validatePlanDraft,
+} from "./planEditCanvas";
+
+describe("sanitizePlanDraft", () => {
+  it("returns empty for non-strings", () => {
+    expect(sanitizePlanDraft(null)).toBe("");
+    expect(sanitizePlanDraft(undefined)).toBe("");
+  });
+
+  it("strips NULs", () => {
+    expect(sanitizePlanDraft("a\0b\0c")).toBe("abc");
+  });
+
+  it("normalizes CRLF and bare CR to LF", () => {
+    expect(sanitizePlanDraft("a\r\nb\rc")).toBe("a\nb\nc");
+  });
+
+  it("preserves interior whitespace and trailing newlines", () => {
+    expect(sanitizePlanDraft("  hello  \n")).toBe("  hello  \n");
+  });
+
+  it("caps length", () => {
+    const long = "x".repeat(PLAN_DRAFT_MAX_CHARS + 50);
+    expect(sanitizePlanDraft(long).length).toBe(PLAN_DRAFT_MAX_CHARS);
+    expect(sanitizePlanDraft("abcdef", 3)).toBe("abc");
+  });
+});
+
+describe("planDraftIsDirty", () => {
+  it("false when equal after sanitize", () => {
+    expect(planDraftIsDirty("# Plan\n", "# Plan\n")).toBe(false);
+    expect(planDraftIsDirty("a\r\nb", "a\nb")).toBe(false);
+    expect(planDraftIsDirty("a\0b", "ab")).toBe(false);
+  });
+
+  it("true when content differs", () => {
+    expect(planDraftIsDirty("# A", "# B")).toBe(true);
+    expect(planDraftIsDirty("", "x")).toBe(true);
+    expect(planDraftIsDirty("x", "")).toBe(true);
+  });
+});
+
+describe("validatePlanDraft", () => {
+  it("rejects empty / whitespace", () => {
+    expect(validatePlanDraft("")).toEqual({ ok: false, reason: "empty" });
+    expect(validatePlanDraft("  \n\t  ")).toEqual({
+      ok: false,
+      reason: "empty",
+    });
+    expect(validatePlanDraft(null)).toEqual({ ok: false, reason: "empty" });
+  });
+
+  it("rejects too long", () => {
+    const long = "y".repeat(PLAN_DRAFT_MAX_CHARS + 1);
+    expect(validatePlanDraft(long)).toEqual({
+      ok: false,
+      reason: "too_long",
+    });
+  });
+
+  it("accepts normal markdown", () => {
+    expect(validatePlanDraft("# Hello\n\n- step")).toEqual({ ok: true });
+  });
+});
+
+describe("planEditEmptyState", () => {
+  it("not actionable without gate", () => {
+    expect(planEditEmptyState({ canAct: false, hasBody: true })).toEqual({
+      canEdit: false,
+      kind: "not_actionable",
+    });
+  });
+
+  it("allows edit with empty body (paste full plan)", () => {
+    expect(planEditEmptyState({ canAct: true, hasBody: false })).toEqual({
+      canEdit: true,
+      kind: "no_body",
+    });
+  });
+
+  it("ready when gate open and body present", () => {
+    expect(planEditEmptyState({ canAct: true, hasBody: true })).toEqual({
+      canEdit: true,
+      kind: "ready",
+    });
+  });
+});
+
+describe("buildRequestChangesNoteFromDraft", () => {
+  it("returns only user note when draft is not dirty", () => {
+    expect(
+      buildRequestChangesNoteFromDraft({
+        originalBody: "# Plan",
+        draft: "# Plan",
+        userNote: "  tweak steps  ",
+      }),
+    ).toBe("tweak steps");
+    expect(
+      buildRequestChangesNoteFromDraft({
+        originalBody: "# Plan",
+        draft: "# Plan",
+      }),
+    ).toBe("");
+  });
+
+  it("includes revised plan markers when dirty", () => {
+    const note = buildRequestChangesNoteFromDraft({
+      originalBody: "# Old",
+      draft: "# New plan\n\n1. Do it",
+    });
+    expect(note).toContain(PLAN_REVISED_MARKER_START);
+    expect(note).toContain(PLAN_REVISED_MARKER_END);
+    expect(note).toContain("# New plan\n\n1. Do it");
+    expect(note).toMatch(/user edited the plan/i);
+  });
+
+  it("prepends user note before revised plan", () => {
+    const note = buildRequestChangesNoteFromDraft({
+      originalBody: "a",
+      draft: "b",
+      userNote: "Prefer tests first",
+    });
+    expect(note.startsWith("Prefer tests first")).toBe(true);
+    expect(note.indexOf("Prefer tests first")).toBeLessThan(
+      note.indexOf(PLAN_REVISED_MARKER_START),
+    );
+    expect(note).toContain("b");
+  });
+
+  it("sanitizes draft body in the note", () => {
+    const note = buildRequestChangesNoteFromDraft({
+      originalBody: "a",
+      draft: "line1\r\nline2\0x",
+    });
+    expect(note).toContain("line1\nline2x");
+    expect(note).not.toContain("\0");
+    expect(note).not.toContain("\r");
+  });
+});

--- a/src/lib/planEditCanvas.ts
+++ b/src/lib/planEditCanvas.ts
@@ -1,0 +1,124 @@
+/**
+ * Plan edit canvas — pure helpers for editable plan drafts before approve.
+ *
+ * Drafts stay local until the user sends them via request-changes.
+ * No DOM / Tauri / i18n side effects.
+ */
+
+/** Soft cap on plan draft markdown (~200 KiB of characters). */
+export const PLAN_DRAFT_MAX_CHARS = 200_000;
+
+/** Clear markers wrapping a user-revised plan in agent feedback. */
+export const PLAN_REVISED_MARKER_START = "--- revised plan (user edit) ---";
+export const PLAN_REVISED_MARKER_END = "--- end revised plan ---";
+
+/**
+ * Strip NULs, normalize newlines to `\n`, and cap length.
+ * Does not trim — trailing newlines are meaningful for dirty checks.
+ */
+export function sanitizePlanDraft(
+  raw: string | null | undefined,
+  maxLen: number = PLAN_DRAFT_MAX_CHARS,
+): string {
+  if (typeof raw !== "string") return "";
+  let s = raw.replace(/\0/g, "");
+  s = s.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const cap = maxLen > 0 ? maxLen : 0;
+  if (cap <= 0) return "";
+  if (s.length > cap) return s.slice(0, cap);
+  return s;
+}
+
+/**
+ * True when the draft differs from the original after sanitize.
+ * Both sides are sanitized so CR/LF and NULs cannot false-positive.
+ */
+export function planDraftIsDirty(
+  original: string | null | undefined,
+  draft: string | null | undefined,
+): boolean {
+  return sanitizePlanDraft(original) !== sanitizePlanDraft(draft);
+}
+
+export type PlanDraftValidation =
+  | { ok: true }
+  | { ok: false; reason: "empty" | "too_long" };
+
+/**
+ * Validate a plan draft before sending as request-changes feedback.
+ * Empty / whitespace-only → `empty`. Pre-cap length over max → `too_long`.
+ */
+export function validatePlanDraft(
+  draft: string | null | undefined,
+  maxLen: number = PLAN_DRAFT_MAX_CHARS,
+): PlanDraftValidation {
+  if (typeof draft !== "string") {
+    return { ok: false, reason: "empty" };
+  }
+  // Length check after NUL strip + newline normalize, before cap.
+  const cleaned = draft.replace(/\0/g, "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (!cleaned.trim()) {
+    return { ok: false, reason: "empty" };
+  }
+  const cap = maxLen > 0 ? maxLen : 0;
+  if (cleaned.length > cap) {
+    return { ok: false, reason: "too_long" };
+  }
+  return { ok: true };
+}
+
+export type PlanEditEmptyKind = "not_actionable" | "no_body" | "ready";
+
+/**
+ * Honesty helper: when can the plan body be edited in the review canvas?
+ * Edit is offered when the exit_plan_mode gate is open (`canAct`).
+ * `no_body` still allows edit (user may paste a full revised plan).
+ */
+export function planEditEmptyState(input: {
+  canAct: boolean;
+  hasBody: boolean;
+}): { canEdit: boolean; kind: PlanEditEmptyKind } {
+  if (!input.canAct) {
+    return { canEdit: false, kind: "not_actionable" };
+  }
+  if (!input.hasBody) {
+    return { canEdit: true, kind: "no_body" };
+  }
+  return { canEdit: true, kind: "ready" };
+}
+
+/**
+ * Build the feedback string for request-changes.
+ *
+ * - When the draft is dirty: include clear markers + revised markdown;
+ *   optional `userNote` is prepended.
+ * - When not dirty: return trimmed `userNote` only (may be empty).
+ */
+export function buildRequestChangesNoteFromDraft(opts: {
+  originalBody: string;
+  draft: string;
+  userNote?: string;
+}): string {
+  const userNote =
+    typeof opts.userNote === "string" ? opts.userNote.trim() : "";
+  const dirty = planDraftIsDirty(opts.originalBody, opts.draft);
+
+  if (!dirty) {
+    return userNote;
+  }
+
+  const revised = sanitizePlanDraft(opts.draft);
+  const blocks: string[] = [];
+  if (userNote) {
+    blocks.push(userNote);
+    blocks.push("");
+  }
+  blocks.push(
+    "The user edited the plan in the review panel. Treat the following as the proposed revised plan:",
+  );
+  blocks.push("");
+  blocks.push(PLAN_REVISED_MARKER_START);
+  blocks.push(revised);
+  blocks.push(PLAN_REVISED_MARKER_END);
+  return blocks.join("\n");
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8645,6 +8645,18 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
   flex-wrap: wrap;
   gap: 8px;
 }
+.plan-review__dirty-hint,
+.plan-review__draft-error {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.plan-review__dirty-hint {
+  color: var(--text-secondary);
+}
+.plan-review__draft-error {
+  color: var(--danger, #e5484d);
+}
 .plan-review__scroll {
   flex: 1;
   min-height: 0;
@@ -8652,6 +8664,47 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
 .plan-review__body {
   padding: 16px 18px 28px;
   max-width: 720px;
+}
+.plan-review--editing .plan-review__body {
+  max-width: none;
+  display: flex;
+  flex-direction: column;
+  min-height: min(60vh, 520px);
+}
+.plan-review__editor {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 240px;
+}
+.plan-review__textarea {
+  flex: 1;
+  width: 100%;
+  min-height: 240px;
+  resize: vertical;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: var(--bg-elevated, var(--bg-main));
+  color: var(--text-primary);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12.5px;
+  line-height: 1.5;
+  tab-size: 2;
+}
+.plan-review__textarea:focus,
+.plan-review__textarea:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-subtle));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+.plan-review__discard-msg {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-secondary);
 }
 .plan-review__md {
   font-size: 13.5px;


### PR DESCRIPTION
## Summary
- **Editable plan canvas** in Resources → Plan: when a plan is awaiting review (`exit_plan_mode` gate), users can **Edit plan** and revise the markdown draft locally.
- Dirty drafts **disable Approve** with an honesty hint; primary action becomes **Request changes with draft**, which sends agent feedback with clear `--- revised plan (user edit) ---` markers.
- Discard dirty edit uses **GlassModal** (never `window.confirm`).
- Pure helpers in `src/lib/planEditCanvas.ts` (`sanitizePlanDraft`, `planDraftIsDirty`, `validatePlanDraft`, `buildRequestChangesNoteFromDraft`, `planEditEmptyState`) + vitest.
- App passes non-empty notes from the canvas through to `requestPlanChanges` (skips empty note modal).
- i18n en / zh / zh-TW + minimal CSS + CHANGELOG.

## Test plan
- [x] `pnpm test -- src/lib/planEditCanvas.test.ts src/lib/planBody.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: open Resources → Plan while awaiting review → Edit → change markdown → Approve disabled + hint → Request changes with draft
- [ ] Manual: Cancel edit with dirty draft → GlassModal discard confirm
- [ ] Manual: Edit without changes → Cancel edit leaves cleanly; Request changes still opens note modal