### PR TITLE
feat(composer): send intent honesty for steer and queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+#### Composer & chat
+- **Send-intent honesty** (steer / queue / concurrent): pure `resolveSendIntent` classifies what Send will do — enqueue follow-up on same-session busy, foreign concurrent when another chat is live, blocked on permission/empty — without changing enqueue rules. Composer shows a pre-send banner + optional **Open as new chat** CTA; queue strip labels stay consistent (follow-up vs hold vs steer hint). en/zh/zh-TW + tests.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -713,6 +713,12 @@ import {
   type QueuedSend,
 } from "@/lib/sendQueue";
 import {
+  planOpenAsNewSessionInstead,
+  resolveSendControlLabelKey,
+  resolveSendIntent,
+  resolveSendQueueStripIntentLabel,
+} from "@/lib/sendIntent";
+import {
   useSendQueue,
   type ExecuteSendFromQueue,
 } from "@/hooks/useSendQueue";
@@ -10655,6 +10661,43 @@ export default function App() {
       ? liveHost.state === "streaming"
       : session.state === "streaming");
 
+  /** Pure send-intent honesty (enqueue vs foreign concurrent vs blocked). */
+  const composerHasBody =
+    !isDraftEmpty(parseStoredContent(draft)) || attachments.length > 0;
+  const sendIntent = useMemo(
+    () =>
+      resolveSendIntent({
+        viewedState: session.state,
+        connecting,
+        liveSessionId: liveHost.sessionId,
+        liveState: liveHost.state,
+        viewedSessionId: session.sessionId,
+        hasBody: composerHasBody,
+        queueLength: sendQueue.activeQueue.length,
+      }),
+    [
+      session.state,
+      session.sessionId,
+      connecting,
+      liveHost.sessionId,
+      liveHost.state,
+      composerHasBody,
+      sendQueue.activeQueue.length,
+    ],
+  );
+  const openAsNewChatPlan = useMemo(
+    () =>
+      planOpenAsNewSessionInstead({
+        kind: sendIntent.kind,
+        queueLength: sendQueue.activeQueue.length,
+      }),
+    [sendIntent.kind, sendQueue.activeQueue.length],
+  );
+  const sendControlLabelKey = useMemo(
+    () => resolveSendControlLabelKey(sendIntent.kind),
+    [sendIntent.kind],
+  );
+
   const closeQueueEdit = useCallback(() => {
     setQueueEditItemId(null);
     setQueueEditText("");
@@ -10683,6 +10726,16 @@ export default function App() {
         flushHold: sendQueue.flushHold,
       }),
     [sendQueue.activeQueue, sendQueue.flushHold],
+  );
+
+  const sendQueueStripIntentLabel = useMemo(
+    () =>
+      resolveSendQueueStripIntentLabel({
+        visible: sendQueueStrip.visible,
+        showHold: sendQueueStrip.showHold,
+        canSteer: canGuideQueuedMessage,
+      }),
+    [sendQueueStrip.visible, sendQueueStrip.showHold, canGuideQueuedMessage],
   );
 
   const sendQueueClearPlan = useMemo(
@@ -19405,6 +19458,39 @@ export default function App() {
                 (dragZone === "main" ? " composer--drop-ready" : "")
               }
             >
+              {sendIntent.bannerKey && composerHasBody ? (
+                <div
+                  className={
+                    "composer__intent" +
+                    (sendIntent.kind === "foreign_concurrent"
+                      ? " composer__intent--foreign"
+                      : "") +
+                    (sendIntent.kind === "blocked_permission"
+                      ? " composer__intent--blocked"
+                      : "") +
+                    (sendIntent.kind === "enqueue"
+                      ? " composer__intent--enqueue"
+                      : "")
+                  }
+                  role="status"
+                  data-testid="composer-send-intent"
+                  data-intent={sendIntent.kind}
+                >
+                  <span className="composer__intent-text">
+                    {tr(sendIntent.bannerKey)}
+                  </span>
+                  {openAsNewChatPlan.show ? (
+                    <button
+                      type="button"
+                      className="composer__intent-cta"
+                      data-testid="composer-intent-open-new"
+                      onClick={() => void newChat(activeProject)}
+                    >
+                      {tr(openAsNewChatPlan.ctaKey)}
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
               {sendQueueStrip.visible && (
                 <div
                   className="composer__queue"
@@ -19418,6 +19504,12 @@ export default function App() {
                       {tr("composer.queueCount", {
                         n: String(sendQueueStrip.count),
                       })}
+                      {sendQueueStripIntentLabel ? (
+                        <span className="composer__queue-intent-label">
+                          {" · "}
+                          {tr(sendQueueStripIntentLabel.labelKey)}
+                        </span>
+                      ) : null}
                     </span>
                     <button
                       type="button"
@@ -20313,15 +20405,24 @@ export default function App() {
                     {sendQueue.canShowQueueButton(
                       session.state,
                       connecting,
-                      !isDraftEmpty(parseStoredContent(draft)) ||
-                        attachments.length > 0,
+                      composerHasBody,
                     ) && (
-                      <Tip label={tr("composer.queue")}>
+                      <Tip
+                        label={
+                          sendIntent.kind === "enqueue"
+                            ? tr(sendControlLabelKey)
+                            : tr("composer.queue")
+                        }
+                      >
                         <button
                           type="button"
                           className="icon-btn icon-btn--primary"
                           onClick={() => void send()}
-                          aria-label={tr("composer.queue")}
+                          aria-label={
+                            sendIntent.kind === "enqueue"
+                              ? tr(sendControlLabelKey)
+                              : tr("composer.queue")
+                          }
                         >
                           <IconQueue size={16} />
                         </button>
@@ -20339,19 +20440,18 @@ export default function App() {
                     </Tip>
                   </>
                 ) : (
-                  <Tip label={tr("composer.send")}>
+                  <Tip label={tr(sendControlLabelKey)}>
                     <button
                       type="button"
                       className="icon-btn icon-btn--primary"
                       disabled={
                         (!effectiveCanSend &&
                           !shouldEnqueueSend(session.state, connecting)) ||
-                        (isDraftEmpty(parseStoredContent(draft)) &&
-                          attachments.length === 0) ||
+                        !composerHasBody ||
                         session.state === "awaiting_permission"
                       }
                       onClick={() => void send()}
-                      aria-label={tr("composer.send")}
+                      aria-label={tr(sendControlLabelKey)}
                     >
                       <IconSend size={16} />
                     </button>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1072,6 +1072,21 @@ const en = {
   "composer.queueEditEmpty": "Message cannot be empty",
   "composer.queueEmptyPreview": "(attachment)",
   "composer.queueFilesCount": "{n} files",
+  // Send-intent honesty (steer vs queue vs concurrent — pure classification)
+  "composer.intent.enqueue":
+    "Send queues a follow-up for after this turn (this chat). Use Steer on a queued item to interject mid-turn.",
+  "composer.intent.enqueueShort": "Queue follow-up",
+  "composer.intent.steer":
+    "Steer injects mid-turn guidance into the live task (not a queued follow-up).",
+  "composer.intent.foreignConcurrent":
+    "Send starts concurrent work here — another chat is still running. Open a new chat to keep drafts separate.",
+  "composer.intent.foreignShort": "Send (concurrent)",
+  "composer.intent.blockedPermission": "Resolve the permission prompt first",
+  "composer.intent.openAsNewChat": "Open as new chat",
+  "composer.intent.stripEnqueue": "Follow-ups — send after this turn",
+  "composer.intent.stripHold": "Auto-send paused",
+  "composer.intent.stripSteerHint":
+    "Follow-ups after this turn · Steer injects mid-turn",
   "composer.stop": "Stop",
   "composer.noProject": "General",
   "composer.noProjectWriteHint":
@@ -7148,6 +7163,20 @@ const zh: Record<MessageKey, string> = {
   "composer.queueEditEmpty": "消息不能为空",
   "composer.queueEmptyPreview": "（附件）",
   "composer.queueFilesCount": "{n} 个文件",
+  // Send-intent honesty (steer vs queue vs concurrent — pure classification)
+  "composer.intent.enqueue":
+    "发送会将跟进排入本会话队列，本轮结束后自动发送。要对进行中的任务插话，请对队列项使用「引导」。",
+  "composer.intent.enqueueShort": "排队跟进",
+  "composer.intent.steer":
+    "「引导」会向当前进行中的任务插入中途指示（不是排队跟进）。",
+  "composer.intent.foreignConcurrent":
+    "发送会在此开始并发工作 — 另一会话仍在运行。可用新对话分开草稿。",
+  "composer.intent.foreignShort": "发送（并发）",
+  "composer.intent.blockedPermission": "请先处理权限请求",
+  "composer.intent.openAsNewChat": "作为新对话打开",
+  "composer.intent.stripEnqueue": "跟进 — 本轮结束后发送",
+  "composer.intent.stripHold": "自动发送已暂停",
+  "composer.intent.stripSteerHint": "本轮结束后发送跟进 · 引导可中途插话",
   "composer.stop": "停止",
   "composer.noProject": "通用",
   "composer.noProjectWriteHint":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1044,6 +1044,20 @@ export const zhTW: Record<MessageKey, string> = {
   "composer.queueEditEmpty": "訊息不能為空",
   "composer.queueEmptyPreview": "（附件）",
   "composer.queueFilesCount": "{n} 個檔案",
+  // Send-intent honesty (steer vs queue vs concurrent — pure classification)
+  "composer.intent.enqueue":
+    "傳送會將後續排入此對話佇列，本輪結束後自動傳送。若要對進行中的任務插話，請對佇列項目使用「引導」。",
+  "composer.intent.enqueueShort": "排隊後續",
+  "composer.intent.steer":
+    "「引導」會向目前進行中的任務插入中途指示（不是排隊後續）。",
+  "composer.intent.foreignConcurrent":
+    "傳送會在此開始並行工作 — 另一對話仍在執行。可用新對話分開草稿。",
+  "composer.intent.foreignShort": "傳送（並行）",
+  "composer.intent.blockedPermission": "請先處理權限請求",
+  "composer.intent.openAsNewChat": "以新對話開啟",
+  "composer.intent.stripEnqueue": "後續 — 本輪結束後傳送",
+  "composer.intent.stripHold": "自動傳送已暫停",
+  "composer.intent.stripSteerHint": "本輪結束後傳送後續 · 引導可中途插話",
   "composer.stop": "停止",
   "composer.noProject": "通用",
   "composer.noProjectWriteHint":

--- a/src/lib/sendIntent.test.ts
+++ b/src/lib/sendIntent.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "vitest";
+import { isForeignLiveBusy, shouldEnqueueSend } from "./sendQueue";
+import type { SessionState } from "./session";
+import {
+  planOpenAsNewSessionInstead,
+  resolveSendControlLabelKey,
+  resolveSendIntent,
+  resolveSendIntentBanner,
+  resolveSendQueueStripIntentLabel,
+  SEND_INTENT_CROWDED_AT,
+  type SendIntentKind,
+} from "./sendIntent";
+
+const IDLE: SessionState[] = ["idle", "ready", "disconnected"];
+
+describe("resolveSendIntent", () => {
+  const base = {
+    connecting: false,
+    liveSessionId: null as string | null,
+    liveState: null as SessionState | null,
+    viewedSessionId: "s1" as string | null,
+    hasBody: true,
+    queueLength: 0,
+  };
+
+  it("blocked_empty when no body", () => {
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "ready",
+      hasBody: false,
+    });
+    expect(r).toEqual({
+      kind: "blocked_empty",
+      enqueue: false,
+      suggestOpenNewChat: false,
+    });
+    expect(resolveSendIntentBanner(r.kind)).toBeNull();
+  });
+
+  it("blocked_permission when awaiting_permission (never enqueues)", () => {
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "awaiting_permission",
+      hasBody: true,
+    });
+    expect(r.kind).toBe("blocked_permission");
+    expect(r.enqueue).toBe(false);
+    expect(r.bannerKey).toBe("composer.intent.blockedPermission");
+    expect(shouldEnqueueSend("awaiting_permission", false)).toBe(false);
+    expect(shouldEnqueueSend("awaiting_permission", true)).toBe(false);
+  });
+
+  it("enqueue when same-session streaming/connecting (Send path, not steer)", () => {
+    for (const state of ["streaming", "connecting"] as SessionState[]) {
+      const r = resolveSendIntent({
+        ...base,
+        viewedState: state,
+        liveSessionId: "s1",
+        liveState: state,
+        hasBody: true,
+      });
+      expect(r.kind, state).toBe("enqueue");
+      expect(r.enqueue, state).toBe(true);
+      expect(r.bannerKey, state).toBe("composer.intent.enqueue");
+      expect(shouldEnqueueSend(state, false)).toBe(true);
+    }
+  });
+
+  it("parity: enqueue flag matches shouldEnqueueSend × hasBody matrix", () => {
+    const states: SessionState[] = [
+      "idle",
+      "ready",
+      "disconnected",
+      "connecting",
+      "streaming",
+      "awaiting_permission",
+    ];
+    for (const state of states) {
+      for (const connecting of [false, true]) {
+        for (const hasBody of [false, true]) {
+          const r = resolveSendIntent({
+            ...base,
+            viewedState: state,
+            connecting,
+            hasBody,
+            // Same-session live so foreign does not interfere.
+            liveSessionId: "s1",
+            liveState: state,
+            viewedSessionId: "s1",
+          });
+          const expectEnqueue =
+            hasBody && shouldEnqueueSend(state, connecting);
+          expect(r.enqueue, `${state}/conn=${connecting}/body=${hasBody}`).toBe(
+            expectEnqueue,
+          );
+          if (expectEnqueue) {
+            expect(r.kind).toBe("enqueue");
+          }
+        }
+      }
+    }
+  });
+
+  it("ignores process-global connecting for idle/ready viewed chat", () => {
+    for (const state of IDLE) {
+      const r = resolveSendIntent({
+        ...base,
+        viewedState: state,
+        connecting: true,
+        liveSessionId: null,
+        liveState: null,
+        hasBody: true,
+      });
+      expect(r.enqueue, state).toBe(false);
+      expect(r.kind, state).not.toBe("enqueue");
+      expect(shouldEnqueueSend(state, true)).toBe(false);
+    }
+  });
+
+  it("foreign_concurrent when host busy on another session (not enqueue)", () => {
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "ready",
+      liveSessionId: "other",
+      liveState: "streaming",
+      viewedSessionId: "s1",
+      hasBody: true,
+    });
+    expect(r.kind).toBe("foreign_concurrent");
+    expect(r.enqueue).toBe(false);
+    expect(r.bannerKey).toBe("composer.intent.foreignConcurrent");
+    expect(r.suggestOpenNewChat).toBe(true);
+    expect(isForeignLiveBusy("other", "streaming", "s1")).toBe(true);
+    expect(shouldEnqueueSend("ready", false)).toBe(false);
+  });
+
+  it("foreign_concurrent on draft (null viewed) while any live is busy", () => {
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "idle",
+      liveSessionId: "live-a",
+      liveState: "streaming",
+      viewedSessionId: null,
+      hasBody: true,
+    });
+    expect(r.kind).toBe("foreign_concurrent");
+    expect(r.enqueue).toBe(false);
+    expect(isForeignLiveBusy("live-a", "streaming", null)).toBe(true);
+  });
+
+  it("same-session busy wins over foreign (enqueue, not foreign_concurrent)", () => {
+    // Viewed chat is streaming — Send always enqueues; foreign is irrelevant.
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "streaming",
+      liveSessionId: "s1",
+      liveState: "streaming",
+      viewedSessionId: "s1",
+      hasBody: true,
+    });
+    expect(r.kind).toBe("enqueue");
+    expect(r.enqueue).toBe(true);
+  });
+
+  it("send_now when ready and no foreign busy", () => {
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "ready",
+      liveSessionId: "s1",
+      liveState: "ready",
+      hasBody: true,
+    });
+    expect(r).toEqual({
+      kind: "send_now",
+      enqueue: false,
+      suggestOpenNewChat: false,
+    });
+  });
+
+  it("action steer → kind steer when viewed session is streaming", () => {
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "streaming",
+      liveSessionId: "s1",
+      liveState: "streaming",
+      hasBody: true,
+      action: "steer",
+    });
+    expect(r.kind).toBe("steer");
+    expect(r.enqueue).toBe(false);
+    expect(r.bannerKey).toBe("composer.intent.steer");
+  });
+
+  it("action steer without streaming falls through (enqueue if connecting)", () => {
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "connecting",
+      liveSessionId: "s1",
+      liveState: "connecting",
+      hasBody: true,
+      action: "steer",
+    });
+    // Guide unavailable during connecting-only; Send would enqueue.
+    expect(r.kind).toBe("enqueue");
+    expect(r.enqueue).toBe(true);
+  });
+
+  it("action steer with empty body is blocked_empty", () => {
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "streaming",
+      hasBody: false,
+      action: "steer",
+    });
+    expect(r.kind).toBe("blocked_empty");
+  });
+
+  it("suggestOpenNewChat when enqueue queue is crowded", () => {
+    const r = resolveSendIntent({
+      ...base,
+      viewedState: "streaming",
+      liveSessionId: "s1",
+      liveState: "streaming",
+      hasBody: true,
+      queueLength: SEND_INTENT_CROWDED_AT,
+    });
+    expect(r.kind).toBe("enqueue");
+    expect(r.suggestOpenNewChat).toBe(true);
+
+    const notCrowded = resolveSendIntent({
+      ...base,
+      viewedState: "streaming",
+      liveSessionId: "s1",
+      liveState: "streaming",
+      hasBody: true,
+      queueLength: SEND_INTENT_CROWDED_AT - 1,
+    });
+    expect(notCrowded.suggestOpenNewChat).toBe(false);
+  });
+});
+
+describe("resolveSendIntentBanner", () => {
+  const cases: Array<[SendIntentKind, string | null]> = [
+    ["send_now", null],
+    ["blocked_empty", null],
+    ["enqueue", "composer.intent.enqueue"],
+    ["steer", "composer.intent.steer"],
+    ["foreign_concurrent", "composer.intent.foreignConcurrent"],
+    ["blocked_permission", "composer.intent.blockedPermission"],
+  ];
+  for (const [kind, key] of cases) {
+    it(`${kind} → ${key}`, () => {
+      expect(resolveSendIntentBanner(kind)).toBe(key);
+    });
+  }
+});
+
+describe("planOpenAsNewSessionInstead", () => {
+  it("shows for foreign_concurrent", () => {
+    const p = planOpenAsNewSessionInstead({ kind: "foreign_concurrent" });
+    expect(p.show).toBe(true);
+    expect(p.ctaKey).toBe("composer.intent.openAsNewChat");
+    expect(p.reasonKey).toBe("composer.intent.foreignConcurrent");
+  });
+
+  it("shows for crowded enqueue only", () => {
+    expect(
+      planOpenAsNewSessionInstead({
+        kind: "enqueue",
+        queueLength: SEND_INTENT_CROWDED_AT - 1,
+      }).show,
+    ).toBe(false);
+    expect(
+      planOpenAsNewSessionInstead({
+        kind: "enqueue",
+        queueLength: SEND_INTENT_CROWDED_AT,
+      }).show,
+    ).toBe(true);
+  });
+
+  it("hidden for send_now / steer / blocked", () => {
+    for (const kind of [
+      "send_now",
+      "steer",
+      "blocked_empty",
+      "blocked_permission",
+    ] as SendIntentKind[]) {
+      expect(planOpenAsNewSessionInstead({ kind, queueLength: 99 }).show).toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe("resolveSendQueueStripIntentLabel", () => {
+  it("null when strip not visible", () => {
+    expect(
+      resolveSendQueueStripIntentLabel({ visible: false, showHold: false }),
+    ).toBeNull();
+  });
+
+  it("hold / steer hint / enqueue labels", () => {
+    expect(
+      resolveSendQueueStripIntentLabel({ visible: true, showHold: true }),
+    ).toEqual({ labelKey: "composer.intent.stripHold" });
+    expect(
+      resolveSendQueueStripIntentLabel({
+        visible: true,
+        showHold: false,
+        canSteer: true,
+      }),
+    ).toEqual({ labelKey: "composer.intent.stripSteerHint" });
+    expect(
+      resolveSendQueueStripIntentLabel({
+        visible: true,
+        showHold: false,
+        canSteer: false,
+      }),
+    ).toEqual({ labelKey: "composer.intent.stripEnqueue" });
+  });
+});
+
+describe("resolveSendControlLabelKey", () => {
+  it("maps kinds to control labels", () => {
+    expect(resolveSendControlLabelKey("enqueue")).toBe(
+      "composer.intent.enqueueShort",
+    );
+    expect(resolveSendControlLabelKey("foreign_concurrent")).toBe(
+      "composer.intent.foreignShort",
+    );
+    expect(resolveSendControlLabelKey("send_now")).toBe("composer.send");
+    expect(resolveSendControlLabelKey("blocked_empty")).toBe("composer.send");
+    expect(resolveSendControlLabelKey("steer")).toBe("composer.send");
+    expect(resolveSendControlLabelKey("blocked_permission")).toBe(
+      "composer.intent.blockedPermission",
+    );
+  });
+});

--- a/src/lib/sendIntent.ts
+++ b/src/lib/sendIntent.ts
@@ -1,0 +1,308 @@
+/**
+ * Send-intent honesty — pure classification for composer Send / Steer / queue.
+ *
+ * Product reality (App.tsx `send` / queue Guide) — **do not diverge**:
+ * - Empty body → no-op (`blocked_empty`).
+ * - `awaiting_permission` → blocked toast; **never** enqueue.
+ * - Same-session FSM busy (`streaming` / `connecting`) → **enqueue** follow-up
+ *   for after this turn (not mid-turn interject).
+ * - Steer / interject is a **separate** path (`sessionInterject` via queue-row
+ *   Guide) while the agent is generating — classify with `action: "steer"`.
+ * - Host live busy on another session / draft → **foreign concurrent** demote+
+ *   spawn (`executeSend`); never park into a fake local queue.
+ * - Process-global `connecting` is ignored for enqueue gating (parity with
+ *   {@link shouldEnqueueSend}).
+ *
+ * This module is honesty UX only — enqueue semantics stay in `sendQueue.ts`.
+ */
+
+import {
+  isForeignLiveBusy,
+  shouldEnqueueSend,
+  SEND_QUEUE_MAX,
+} from "@/lib/sendQueue";
+import type { SessionState } from "@/lib/session";
+
+/** What the next Send (or Steer) action means for the user. */
+export type SendIntentKind =
+  | "send_now"
+  | "steer"
+  | "enqueue"
+  | "foreign_concurrent"
+  | "blocked_permission"
+  | "blocked_empty";
+
+/** i18n keys returned by intent helpers (translate in UI). */
+export type SendIntentBannerKey =
+  | "composer.intent.enqueue"
+  | "composer.intent.steer"
+  | "composer.intent.foreignConcurrent"
+  | "composer.intent.blockedPermission";
+
+export type SendIntentCtaKey = "composer.intent.openAsNewChat";
+
+export type SendIntentStripLabelKey =
+  | "composer.intent.stripEnqueue"
+  | "composer.intent.stripHold"
+  | "composer.intent.stripSteerHint";
+
+export type ResolveSendIntentOpts = {
+  viewedState: SessionState;
+  /**
+   * Process-global connect flag. Kept for call-site parity with
+   * {@link shouldEnqueueSend}; ignored for enqueue gating.
+   */
+  connecting: boolean;
+  liveSessionId: string | null | undefined;
+  liveState: SessionState | null | undefined;
+  viewedSessionId: string | null | undefined;
+  /** True when composer has text and/or attachments. */
+  hasBody: boolean;
+  /** Current viewed-session queue length (for crowded CTA). */
+  queueLength: number;
+  /**
+   * Default `"send"` classifies the Send / Queue button path.
+   * Pass `"steer"` for the queue-row Guide / interject action.
+   */
+  action?: "send" | "steer";
+};
+
+export type SendIntent = {
+  kind: SendIntentKind;
+  /**
+   * True iff the Send path would call `enqueue` (has body + same-session busy,
+   * never permission, never foreign-only).
+   */
+  enqueue: boolean;
+  /** Pre-send honesty chip; omit when no banner is useful. */
+  bannerKey?: SendIntentBannerKey;
+  /**
+   * True when showing “Open as new chat” is useful (foreign concurrent, or
+   * enqueue with a crowded queue). Callers still pass their own `onOpenNewChat`.
+   */
+  suggestOpenNewChat: boolean;
+};
+
+/** Default queue length at which enqueue suggests opening a new chat. */
+export const SEND_INTENT_CROWDED_AT = 5;
+
+/**
+ * Map a classified kind to its honesty banner i18n key (or null when silent).
+ */
+export function resolveSendIntentBanner(
+  kind: SendIntentKind,
+): SendIntentBannerKey | null {
+  switch (kind) {
+    case "enqueue":
+      return "composer.intent.enqueue";
+    case "steer":
+      return "composer.intent.steer";
+    case "foreign_concurrent":
+      return "composer.intent.foreignConcurrent";
+    case "blocked_permission":
+      return "composer.intent.blockedPermission";
+    case "send_now":
+    case "blocked_empty":
+      return null;
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Classify what Send (or Steer) will do for the current composer surface.
+ * Mirrors {@link shouldEnqueueSend} + permission + foreign busy; does not
+ * change enqueue rules.
+ */
+export function resolveSendIntent(opts: ResolveSendIntentOpts): SendIntent {
+  const action = opts.action ?? "send";
+  const queueLength = normalizeCount(opts.queueLength);
+
+  if (!opts.hasBody) {
+    return {
+      kind: "blocked_empty",
+      enqueue: false,
+      suggestOpenNewChat: false,
+    };
+  }
+
+  if (opts.viewedState === "awaiting_permission") {
+    return {
+      kind: "blocked_permission",
+      enqueue: false,
+      bannerKey: "composer.intent.blockedPermission",
+      suggestOpenNewChat: false,
+    };
+  }
+
+  // Queue-row Guide / mid-turn interject — never enqueues.
+  if (action === "steer") {
+    if (canClassifySteer(opts)) {
+      return {
+        kind: "steer",
+        enqueue: false,
+        bannerKey: "composer.intent.steer",
+        suggestOpenNewChat: false,
+      };
+    }
+    // Guide unavailable: fall through to Send classification so the surface
+    // still explains enqueue vs send_now honestly.
+  }
+
+  // Same-session busy → enqueue follow-up (App `send` path).
+  // Connecting global flag ignored — parity with shouldEnqueueSend.
+  if (shouldEnqueueSend(opts.viewedState, opts.connecting)) {
+    const suggestOpenNewChat = queueLength >= SEND_INTENT_CROWDED_AT;
+    return {
+      kind: "enqueue",
+      enqueue: true,
+      bannerKey: "composer.intent.enqueue",
+      suggestOpenNewChat,
+    };
+  }
+
+  // Host mid-turn elsewhere → concurrent demote+spawn, not local queue.
+  if (
+    isForeignLiveBusy(
+      opts.liveSessionId,
+      opts.liveState,
+      opts.viewedSessionId,
+    )
+  ) {
+    return {
+      kind: "foreign_concurrent",
+      enqueue: false,
+      bannerKey: "composer.intent.foreignConcurrent",
+      suggestOpenNewChat: true,
+    };
+  }
+
+  return {
+    kind: "send_now",
+    enqueue: false,
+    suggestOpenNewChat: false,
+  };
+}
+
+/**
+ * Whether the Guide / steer path is available (same product gate as App
+ * `canGuideQueuedMessage`: viewed chat streaming with a real session id).
+ * Live host may lag after demote — viewed FSM streaming is enough.
+ */
+function canClassifySteer(opts: ResolveSendIntentOpts): boolean {
+  if (!opts.viewedSessionId) return false;
+  if (opts.viewedState !== "streaming") return false;
+  // Process-global connect does not block guide in App (only !connecting is
+  // checked there for UI busy); keep steer honest while this chat streams.
+  return true;
+}
+
+function normalizeCount(raw: unknown): number {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.floor(n));
+}
+
+/**
+ * Optional CTA plan: open a separate draft instead of queueing more / stacking
+ * concurrent work on the current surface.
+ */
+export type OpenAsNewSessionPlan = {
+  show: boolean;
+  ctaKey: SendIntentCtaKey;
+  /** Why the CTA is shown (i18n); null when hidden. */
+  reasonKey: SendIntentBannerKey | null;
+};
+
+export function planOpenAsNewSessionInstead(opts: {
+  kind: SendIntentKind;
+  queueLength?: number;
+  /** Override crowded threshold (default {@link SEND_INTENT_CROWDED_AT}). */
+  crowdedAt?: number;
+}): OpenAsNewSessionPlan {
+  const crowdedAt =
+    typeof opts.crowdedAt === "number" && Number.isFinite(opts.crowdedAt)
+      ? Math.max(1, Math.floor(opts.crowdedAt))
+      : SEND_INTENT_CROWDED_AT;
+  const queueLength = normalizeCount(opts.queueLength);
+  const crowded = queueLength >= crowdedAt;
+
+  if (opts.kind === "foreign_concurrent") {
+    return {
+      show: true,
+      ctaKey: "composer.intent.openAsNewChat",
+      reasonKey: "composer.intent.foreignConcurrent",
+    };
+  }
+  if (opts.kind === "enqueue" && crowded) {
+    return {
+      show: true,
+      ctaKey: "composer.intent.openAsNewChat",
+      reasonKey: "composer.intent.enqueue",
+    };
+  }
+  return {
+    show: false,
+    ctaKey: "composer.intent.openAsNewChat",
+    reasonKey: null,
+  };
+}
+
+/**
+ * Queue-strip label keys so strip chrome stays consistent with send intent.
+ * Empty / hidden strip → null (caller keeps strip hidden).
+ */
+export function resolveSendQueueStripIntentLabel(opts: {
+  visible: boolean;
+  showHold: boolean;
+  /** True when mid-turn Guide is available on this chat. */
+  canSteer?: boolean;
+}): { labelKey: SendIntentStripLabelKey } | null {
+  if (!opts.visible) return null;
+  if (opts.showHold) {
+    return { labelKey: "composer.intent.stripHold" };
+  }
+  if (opts.canSteer) {
+    return { labelKey: "composer.intent.stripSteerHint" };
+  }
+  return { labelKey: "composer.intent.stripEnqueue" };
+}
+
+/**
+ * Short label for the primary Send/Queue control (tooltip / aria).
+ * Falls back to classic keys when intent is silent.
+ */
+export type SendControlLabelKey =
+  | "composer.send"
+  | "composer.queue"
+  | "composer.intent.enqueueShort"
+  | "composer.intent.foreignShort"
+  | "composer.intent.blockedPermission";
+
+export function resolveSendControlLabelKey(
+  kind: SendIntentKind,
+): SendControlLabelKey {
+  switch (kind) {
+    case "enqueue":
+      return "composer.intent.enqueueShort";
+    case "foreign_concurrent":
+      return "composer.intent.foreignShort";
+    case "blocked_permission":
+      return "composer.intent.blockedPermission";
+    case "steer":
+      // Steer is not the primary Send control; keep classic send label.
+      return "composer.send";
+    case "send_now":
+    case "blocked_empty":
+      return "composer.send";
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Expose max for tests that assert crowded CTA vs SEND_QUEUE_MAX. */
+export const SEND_INTENT_QUEUE_MAX = SEND_QUEUE_MAX;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9881,6 +9881,57 @@ button.composer__context-item {
   background: var(--bg-hover);
 }
 
+.composer__intent {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0 4px 6px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.composer__intent--enqueue {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+.composer__intent--foreign {
+  background: color-mix(in srgb, var(--warning, #d97706) 12%, transparent);
+  border-color: color-mix(in srgb, var(--warning, #d97706) 30%, transparent);
+}
+
+.composer__intent--blocked {
+  background: color-mix(in srgb, var(--danger, #dc2626) 10%, transparent);
+  border-color: color-mix(in srgb, var(--danger, #dc2626) 28%, transparent);
+}
+
+.composer__intent-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.composer__intent-cta {
+  flex: 0 0 auto;
+  border: none;
+  background: transparent;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--accent);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.composer__intent-cta:hover {
+  background: var(--bg-hover);
+}
+
 .composer__queue {
   display: flex;
   flex-direction: column;
@@ -9902,6 +9953,11 @@ button.composer__context-item {
   flex: 1;
   min-width: 0;
   font-weight: 500;
+}
+
+.composer__queue-intent-label {
+  font-weight: 400;
+  opacity: 0.85;
 }
 
 .composer__queue-clear {


### PR DESCRIPTION
## Summary
- Pure `src/lib/sendIntent.ts` classifies what **Send** will do: `send_now` · `enqueue` (same-session busy follow-up) · `foreign_concurrent` · `blocked_permission` · `blocked_empty`, plus `steer` for the queue-row Guide path — **no change** to enqueue semantics (`shouldEnqueueSend` / `isForeignLiveBusy` parity tests).
- Composer pre-send banner when about to queue / run concurrent / blocked on permission; optional **Open as new chat** CTA when foreign concurrent or queue is crowded.
- Queue strip intent labels (follow-up / hold / steer hint) + Send/Queue control label honesty.
- i18n en / zh / zh-TW; CHANGELOG Unreleased.

## Product notes
- Mid-turn **Send** still **enqueues** a follow-up (does not interject).
- **Steer** remains the separate queue-row Guide → `sessionInterject` path.
- Host busy on another session → concurrent demote+spawn (not a fake local queue).

## Test plan
- [x] `pnpm test -- src/lib/sendIntent.test.ts src/lib/sendQueue.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: same-session streaming → banner “queue follow-up”; queue strip label; Guide still steers
- [ ] Manual: other session streaming while viewing ready/draft → foreign concurrent banner + Open as new chat
- [ ] Manual: awaiting_permission → blocked banner; Send disabled