### PR TITLE
feat(resources): agents rail for subagent task tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+#### Composer & chat / Sessions
+- **Agents rail** (Resources side mode): first-class **Agents** tab in the right resource pane shows the current session’s subagent/tool task tree (reuses `AgentTasksPanel` + `sessionTasks` — no invented metrics). Running-count badge; honest empty states (no tasks · filter empty · idle hint); bind cwd / WT badge same as floating Tasks panel. Pure `agentsRail` helpers + tests; en/zh/zh-TW.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -249,6 +249,7 @@ import { ReliabilityCenterModal } from "@/components/ReliabilityCenterModal";
 import {
   collectActivitySessions,
   countBusyLiveMapSessions,
+  isActiveSessionSnapshot,
   stoppableActivitySessions,
 } from "@/lib/agentActivity";
 import {
@@ -20413,6 +20414,50 @@ export default function App() {
                 sessionChangesById[session.sessionId || ""] ?? []
               }
               sessionMessages={messages}
+              activeCwd={activeProject?.path ?? null}
+              subagentWorktreeSnapshotEnabled={
+                subagentWorktreeSnapshotEnabled
+              }
+              sessionBusy={
+                !!session.sessionId &&
+                isActiveSessionSnapshot(liveMap[session.sessionId])
+              }
+              onOpenAgentsCwd={async (cwd): Promise<TasksBindCwdResult> => {
+                const path = (cwd || "").trim();
+                if (!path) {
+                  return { ok: false, kind: "empty_path" };
+                }
+                if (!api.isTauri()) {
+                  return { ok: false, kind: "host_only" };
+                }
+                if (
+                  activeProject?.path &&
+                  pathsEqual(path, activeProject.path)
+                ) {
+                  return { ok: false, kind: "already_active" };
+                }
+                const wt = worktreeEntryForPath(path, gitWorktrees);
+                if (!wt) {
+                  return { ok: false, kind: "not_worktree" };
+                }
+                try {
+                  await switchToWorktree(wt);
+                  const liveId =
+                    viewingSessionIdRef.current || session.sessionId || null;
+                  if (liveId) {
+                    await markSessionWorktree(liveId, wt.path, wt.branch);
+                  }
+                  return { ok: true };
+                } catch (e) {
+                  const view = classifyTasksBindCwdError(e);
+                  showToast(tr(view.titleKey as MessageKey), 4000);
+                  return {
+                    ok: false,
+                    kind: view.kind,
+                    detail: view.detail || undefined,
+                  };
+                }
+              }}
               plan={plan}
               planFocusKey={planFocusKey}
               planChrome={{

--- a/src/components/AgentTasksPanel.tsx
+++ b/src/components/AgentTasksPanel.tsx
@@ -52,6 +52,7 @@ import {
   type TasksBindCwdResult,
   type TasksPanelStatusFilter,
 } from "@/lib/tasksPanelPro";
+import { resolveAgentsRailEmptyState } from "@/lib/agentsRail";
 import {
   IconChevronDown,
   IconChevronRight,
@@ -63,6 +64,8 @@ import {
 } from "@/components/icons";
 
 type TFn = (key: MessageKey, vars?: Record<string, string | number>) => string;
+
+export type AgentTasksPanelVariant = "default" | "rail";
 
 export type AgentTasksPanelProps = {
   messages: ChatMessage[];
@@ -97,6 +100,16 @@ export type AgentTasksPanelProps = {
    * (`subagent_worktree_snapshot_enabled`, CLI 0.2.117+). Shows a short note.
    */
   subagentWorktreeSnapshotEnabled?: boolean;
+  /**
+   * `rail` = compact embed for Resources → Agents (no close chrome;
+   * session-local empty honesty via agentsRail helpers).
+   */
+  variant?: AgentTasksPanelVariant;
+  /**
+   * Whether the current session is streaming / busy (rail empty idle_hint).
+   * Ignored for the default floating panel.
+   */
+  sessionBusy?: boolean;
 };
 
 async function revealOrCopyCwd(cwd: string): Promise<"revealed" | "copied"> {
@@ -578,7 +591,10 @@ export function AgentTasksPanel({
   onOpenCwd,
   activeCwd = null,
   subagentWorktreeSnapshotEnabled = false,
+  variant = "default",
+  sessionBusy = false,
 }: AgentTasksPanelProps) {
+  const isRail = variant === "rail";
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] =
     useState<TasksPanelStatusFilter>("all");
@@ -628,30 +644,45 @@ export function AgentTasksPanel({
     () => tree.filter((n) => !taskTreeHasRunning(n)),
     [tree],
   );
+  // Rail is session-local: hide cross-session activity rows.
   const otherSessions = useMemo(
-    () => activitySessions.filter((r) => !r.isCurrent),
-    [activitySessions],
+    () =>
+      isRail ? [] : activitySessions.filter((r) => !r.isCurrent),
+    [activitySessions, isRail],
   );
   const stoppableSessions = useMemo(
-    () => stoppableActivitySessions(activitySessions),
-    [activitySessions],
+    () => (isRail ? [] : stoppableActivitySessions(activitySessions)),
+    [activitySessions, isRail],
   );
   const totalBusy = running + otherSessions.length;
   const showStopAll =
-    !!onStopAllSessions && stoppableSessions.length > 0;
+    !isRail && !!onStopAllSessions && stoppableSessions.length > 0;
   const hasTaskRows = activeTree.length > 0 || recentTree.length > 0;
   const showTreeChrome = taskTreeHasNesting(tree);
 
-  const emptyState = useMemo(
-    () =>
-      resolveTasksPanelEmptyState({
-        totalTasks: tasks.length,
-        filteredTasks: filteredFlat.length,
-        otherSessions: otherSessions.length,
-        hasFilters,
-      }),
-    [tasks.length, filteredFlat.length, otherSessions.length, hasFilters],
-  );
+  const emptyState = useMemo(() => {
+    if (isRail) {
+      return resolveAgentsRailEmptyState({
+        hasTasks: hasTaskRows || filteredFlat.length > 0,
+        filterActive: hasFilters,
+        sessionBusy,
+      });
+    }
+    return resolveTasksPanelEmptyState({
+      totalTasks: tasks.length,
+      filteredTasks: filteredFlat.length,
+      otherSessions: otherSessions.length,
+      hasFilters,
+    });
+  }, [
+    isRail,
+    hasTaskRows,
+    filteredFlat.length,
+    hasFilters,
+    sessionBusy,
+    tasks.length,
+    otherSessions.length,
+  ]);
 
   const snapshotNoteKey = tasksPanelSnapshotBannerKey(
     subagentWorktreeSnapshotEnabled,
@@ -670,12 +701,18 @@ export function AgentTasksPanel({
     !hasTaskRows &&
     otherSessions.length > 0;
 
+  const titleLabel = isRail ? t("resources.agents") : t("tasks.title");
+
   return (
-    <section className="agent-tasks" aria-label={t("tasks.title")}>
+    <section
+      className={"agent-tasks" + (isRail ? " agent-tasks--rail" : "")}
+      aria-label={titleLabel}
+      data-variant={variant}
+    >
       <header className="agent-tasks__head">
         <div className="agent-tasks__title-row">
           <IconList size={15} />
-          <h2 className="agent-tasks__title">{t("tasks.title")}</h2>
+          <h2 className="agent-tasks__title">{titleLabel}</h2>
           {totalBusy > 0 ? (
             <span className="agent-tasks__badge">
               {t("tasks.runningCount", { n: totalBusy })}
@@ -683,7 +720,7 @@ export function AgentTasksPanel({
           ) : null}
         </div>
         <div className="agent-tasks__head-actions">
-          {onOpenDashboard ? (
+          {!isRail && onOpenDashboard ? (
             <button
               type="button"
               className="btn btn--ghost btn--sm"
@@ -703,7 +740,7 @@ export function AgentTasksPanel({
               {t("tasks.activity.stopAll")}
             </button>
           ) : null}
-          {onClose ? (
+          {!isRail && onClose ? (
             <button
               type="button"
               className="chrome-btn"

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -40,6 +40,7 @@ import {
   IconFileDiff,
   IconFolder,
   IconFiles,
+  IconList,
   IconListTree,
   IconPlan,
   IconRefresh,
@@ -48,12 +49,23 @@ import {
   IconUpload,
 } from "@/components/icons";
 import { PlanReviewPanel } from "@/components/PlanReviewPanel";
+import { AgentTasksPanel } from "@/components/AgentTasksPanel";
 import type { PlanReviewState } from "@/lib/planBody";
+import type { ChatMessage } from "@/lib/session";
 import {
   resolvePlanResourceEmptyState,
   shouldAutoLeavePlanSideMode,
   shouldShowPlanChromeButton,
 } from "@/lib/planModePro";
+import {
+  AGENTS_RAIL_SIDE_MODE,
+  countAgentsRailRunning,
+  shouldShowAgentsRailBadge,
+} from "@/lib/agentsRail";
+import {
+  collectSessionTasks,
+} from "@/lib/sessionTasks";
+import type { TasksBindCwdResult } from "@/lib/tasksPanelPro";
 import { OfficeDocumentPreview } from "@/components/OfficeDocumentPreview";
 import { CodePreview } from "@/components/CodePreview";
 import { isOfficeKind } from "@/lib/filePreviewSrc";
@@ -163,11 +175,23 @@ export interface ResourceViewerProps {
    */
   sessionChanges?: SessionFileChange[];
   /**
-   * Active session messages (optional; used by some side-pane helpers).
-   * Accepted for forward-compat with App; not required for core file/plan UI.
+   * Active session messages — drives Resources → Agents task tree.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sessionMessages?: any[];
+  sessionMessages?: ChatMessage[];
+  /**
+   * Bind chat cwd from a subagent worktree path (Agents rail / Tasks panel).
+   */
+  onOpenAgentsCwd?: (
+    cwd: string,
+  ) => void | TasksBindCwdResult | Promise<void | TasksBindCwdResult>;
+  /** Current chat project path — marks active cwd on Agents rail rows. */
+  activeCwd?: string | null;
+  /**
+   * CLI subagent worktree snapshot mode (`subagent_worktree_snapshot_enabled`).
+   */
+  subagentWorktreeSnapshotEnabled?: boolean;
+  /** Current session is streaming / connecting / awaiting permission. */
+  sessionBusy?: boolean;
   /**
    * Live plan snapshot for Plan review mode (exit_plan_mode / progress).
    */
@@ -206,7 +230,7 @@ export interface ResourceViewerProps {
   onAsideLayoutHint?: (hint: AsideLayoutHint) => void;
 }
 
-type SideMode = "files" | "changes" | "plan";
+type SideMode = "files" | "changes" | "plan" | typeof AGENTS_RAIL_SIDE_MODE;
 
 type DiffLayout = "unified" | "split";
 
@@ -339,6 +363,11 @@ export function ResourceViewer({
   onOpenRequestConsumed,
   paneActive = true,
   sessionChanges = [],
+  sessionMessages = [],
+  onOpenAgentsCwd,
+  activeCwd = null,
+  subagentWorktreeSnapshotEnabled = false,
+  sessionBusy = false,
   plan = null,
   planFocusKey = null,
   planChrome = null,
@@ -365,6 +394,14 @@ export function ResourceViewer({
   const lastPlanFocusKey = useRef<number | null>(null);
   /** User opened Plan via open-in-resources / planFocus — keep empty states. */
   const [userPinnedPlanSide, setUserPinnedPlanSide] = useState(false);
+
+  const agentsRailRunningCount = useMemo(
+    () => countAgentsRailRunning(collectSessionTasks(sessionMessages)),
+    [sessionMessages],
+  );
+  const showAgentsRailBadge = shouldShowAgentsRailBadge(
+    agentsRailRunningCount,
+  );
 
   const planResourceEmpty = useMemo(
     () =>
@@ -3515,6 +3552,35 @@ export function ResourceViewer({
           ) : null}
           <Tip
             label={
+              treeVisible && sideMode === AGENTS_RAIL_SIDE_MODE
+                ? tr("resources.agentsHide")
+                : tr("resources.agentsShow")
+            }
+          >
+            <button
+              type="button"
+              className={
+                "chrome-btn main__pane-toggle rp-chrome__agents-btn" +
+                (treeVisible && sideMode === AGENTS_RAIL_SIDE_MODE
+                  ? " is-on"
+                  : "")
+              }
+              onClick={() => showSidePanel(AGENTS_RAIL_SIDE_MODE)}
+              aria-label={tr("resources.agents")}
+              data-testid="resources-agents-chrome-btn"
+            >
+              <IconList size={16} />
+              {showAgentsRailBadge ? (
+                <span className="rp-chrome__badge" aria-hidden>
+                  {agentsRailRunningCount > 99
+                    ? "99+"
+                    : agentsRailRunningCount}
+                </span>
+              ) : null}
+            </button>
+          </Tip>
+          <Tip
+            label={
               treeVisible && sideMode === "files"
                 ? tr("resources.collapseTree")
                 : tr("resources.expandTree")
@@ -3788,6 +3854,26 @@ export function ResourceViewer({
                     ) : null}
                   </button>
                 ) : null}
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={sideMode === AGENTS_RAIL_SIDE_MODE}
+                  className={
+                    "rp-side-modes__btn" +
+                    (sideMode === AGENTS_RAIL_SIDE_MODE ? " is-active" : "")
+                  }
+                  onClick={() => setSideMode(AGENTS_RAIL_SIDE_MODE)}
+                  data-testid="resources-agents-tab"
+                >
+                  {tr("resources.agents")}
+                  {showAgentsRailBadge ? (
+                    <span className="rp-side-modes__count">
+                      {agentsRailRunningCount > 99
+                        ? "99+"
+                        : agentsRailRunningCount}
+                    </span>
+                  ) : null}
+                </button>
                 {plan?.visible ? (
                   <button
                     type="button"
@@ -3803,6 +3889,25 @@ export function ResourceViewer({
                   </button>
                 ) : null}
               </div>
+              {sideMode === AGENTS_RAIL_SIDE_MODE ? (
+                <div
+                  className="rp-agents-rail"
+                  data-testid="resources-agents-rail"
+                >
+                  <AgentTasksPanel
+                    variant="rail"
+                    messages={sessionMessages}
+                    t={(k, vars) => tr(k, vars)}
+                    onOpenCwd={onOpenAgentsCwd}
+                    activeCwd={activeCwd}
+                    subagentWorktreeSnapshotEnabled={
+                      subagentWorktreeSnapshotEnabled
+                    }
+                    sessionBusy={sessionBusy}
+                  />
+                </div>
+              ) : (
+                <>
               <div className="rp-tree-search">
                 <IconSearch size={14} />
                 <input
@@ -4278,6 +4383,8 @@ export function ResourceViewer({
                   renderTree(root, 0)
                 )}
               </OverlayScroll>
+                </>
+              )}
             </div>
           </>
         )}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -524,6 +524,17 @@ const en = {
     "Pick a file from the tree on the right to preview it here.",
   "resources.plan": "Plan",
   "resources.planEmpty": "No plan is waiting for review in this session.",
+  "resources.agents": "Agents",
+  "resources.agentsShow": "Show agents rail",
+  "resources.agentsHide": "Hide agents rail",
+  "agentsRail.noTasks": "No agent tasks in this turn",
+  "agentsRail.busyHint":
+    "The session is working — tool steps and nested subagents will appear here as they start.",
+  "agentsRail.idleHint":
+    "When this chat runs tools or spawns subagents, their task tree shows here without opening the floating Tasks panel.",
+  "agentsRail.filterEmpty": "No tasks match these filters",
+  "agentsRail.filterEmptyHint":
+    "Clear the search or pick another status to see more tasks.",
   "resources.copyPathShort": "Path",
   "resources.tabClose": "Close tab",
   "resources.tabCloseOthers": "Close other tabs",
@@ -6627,6 +6638,16 @@ const zh: Record<MessageKey, string> = {
   "resources.emptyPreviewHint": "从右侧文件树选择文件进行预览。",
   "resources.plan": "计划",
   "resources.planEmpty": "当前会话没有待审阅的计划。",
+  "resources.agents": "Agents",
+  "resources.agentsShow": "显示 Agents 侧栏",
+  "resources.agentsHide": "隐藏 Agents 侧栏",
+  "agentsRail.noTasks": "本轮暂无 Agent 任务",
+  "agentsRail.busyHint":
+    "会话正在工作 — 工具步骤与嵌套子代理会在启动后出现在这里。",
+  "agentsRail.idleHint":
+    "当本对话运行工具或拉起子代理时，任务树会显示在这里，无需打开浮动任务面板。",
+  "agentsRail.filterEmpty": "没有符合筛选条件的任务",
+  "agentsRail.filterEmptyHint": "清除搜索或换一个状态筛选以查看更多任务。",
   "resources.copyPathShort": "路径",
   "resources.tabClose": "关闭标签",
   "resources.tabCloseOthers": "关闭其他标签",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -482,6 +482,16 @@ export const zhTW: Record<MessageKey, string> = {
   "resources.emptyPreviewHint": "從右側檔案樹選擇檔案進行預覽。",
   "resources.plan": "計劃",
   "resources.planEmpty": "目前對話沒有待審閱的計劃。",
+  "resources.agents": "Agents",
+  "resources.agentsShow": "顯示 Agents 側欄",
+  "resources.agentsHide": "隱藏 Agents 側欄",
+  "agentsRail.noTasks": "本輪尚無 Agent 任務",
+  "agentsRail.busyHint":
+    "對話正在工作 — 工具步驟與巢狀子代理會在啟動後出現在這裡。",
+  "agentsRail.idleHint":
+    "當本對話執行工具或啟動子代理時，任務樹會顯示在這裡，無需開啟浮動任務面板。",
+  "agentsRail.filterEmpty": "沒有符合篩選條件的任務",
+  "agentsRail.filterEmptyHint": "清除搜尋或換一個狀態篩選以查看更多任務。",
   "resources.copyPathShort": "路徑",
   "resources.tabClose": "關閉分頁",
   "resources.tabCloseOthers": "關閉其他分頁",

--- a/src/lib/agentsRail.test.ts
+++ b/src/lib/agentsRail.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import type { AgentTask, TaskTreeNode } from "./sessionTasks";
+import {
+  AGENTS_RAIL_SIDE_MODE,
+  countAgentsRailRunning,
+  resolveAgentsRailEmptyState,
+  shouldShowAgentsRailBadge,
+} from "./agentsRail";
+
+function task(
+  partial: Partial<AgentTask> & Pick<AgentTask, "id" | "status">,
+): AgentTask {
+  return {
+    name: partial.name ?? partial.id,
+    kind: partial.kind ?? "tool",
+    longRunning: partial.longRunning ?? false,
+    ...partial,
+  };
+}
+
+describe("AGENTS_RAIL_SIDE_MODE", () => {
+  it("exports agents side mode id", () => {
+    expect(AGENTS_RAIL_SIDE_MODE).toBe("agents");
+  });
+});
+
+describe("resolveAgentsRailEmptyState", () => {
+  it("returns null when tasks are visible", () => {
+    expect(
+      resolveAgentsRailEmptyState({
+        hasTasks: true,
+        filterActive: false,
+        sessionBusy: false,
+      }),
+    ).toBeNull();
+    expect(
+      resolveAgentsRailEmptyState({
+        hasTasks: true,
+        filterActive: true,
+        sessionBusy: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns filter_empty when filters hid all rows", () => {
+    expect(
+      resolveAgentsRailEmptyState({
+        hasTasks: false,
+        filterActive: true,
+        sessionBusy: false,
+      }),
+    ).toEqual({
+      kind: "filter_empty",
+      titleKey: "agentsRail.filterEmpty",
+      hintKey: "agentsRail.filterEmptyHint",
+      showClearFilters: true,
+    });
+  });
+
+  it("returns no_tasks when session is busy but no tool rows", () => {
+    expect(
+      resolveAgentsRailEmptyState({
+        hasTasks: false,
+        filterActive: false,
+        sessionBusy: true,
+      }),
+    ).toEqual({
+      kind: "no_tasks",
+      titleKey: "agentsRail.noTasks",
+      hintKey: "agentsRail.busyHint",
+      showClearFilters: false,
+    });
+  });
+
+  it("returns idle_hint when session is idle with no tasks", () => {
+    expect(
+      resolveAgentsRailEmptyState({
+        hasTasks: false,
+        filterActive: false,
+        sessionBusy: false,
+      }),
+    ).toEqual({
+      kind: "idle_hint",
+      titleKey: "agentsRail.noTasks",
+      hintKey: "agentsRail.idleHint",
+      showClearFilters: false,
+    });
+  });
+
+  it("prefers filter_empty over busy/idle when filters active", () => {
+    expect(
+      resolveAgentsRailEmptyState({
+        hasTasks: false,
+        filterActive: true,
+        sessionBusy: true,
+      })?.kind,
+    ).toBe("filter_empty");
+  });
+});
+
+describe("countAgentsRailRunning", () => {
+  it("counts flat running tasks", () => {
+    const tasks = [
+      task({ id: "a", status: "running" }),
+      task({ id: "b", status: "completed" }),
+      task({ id: "c", status: "running" }),
+    ];
+    expect(countAgentsRailRunning(tasks)).toBe(2);
+  });
+
+  it("counts nested tree nodes", () => {
+    const tree: TaskTreeNode[] = [
+      {
+        task: task({ id: "spawn", status: "running", longRunning: true }),
+        children: [
+          {
+            task: task({ id: "child1", status: "running" }),
+            children: [],
+          },
+          {
+            task: task({ id: "child2", status: "completed" }),
+            children: [],
+          },
+        ],
+      },
+      {
+        task: task({ id: "done", status: "failed" }),
+        children: [],
+      },
+    ];
+    expect(countAgentsRailRunning(tree)).toBe(2);
+  });
+
+  it("returns 0 for empty / null", () => {
+    expect(countAgentsRailRunning([])).toBe(0);
+    expect(countAgentsRailRunning(null)).toBe(0);
+    expect(countAgentsRailRunning(undefined)).toBe(0);
+  });
+});
+
+describe("shouldShowAgentsRailBadge", () => {
+  it("is true only when runningCount > 0", () => {
+    expect(shouldShowAgentsRailBadge(0)).toBe(false);
+    expect(shouldShowAgentsRailBadge(-1)).toBe(false);
+    expect(shouldShowAgentsRailBadge(NaN)).toBe(false);
+    expect(shouldShowAgentsRailBadge(1)).toBe(true);
+    expect(shouldShowAgentsRailBadge(3)).toBe(true);
+  });
+});

--- a/src/lib/agentsRail.ts
+++ b/src/lib/agentsRail.ts
@@ -1,0 +1,112 @@
+/**
+ * Agents rail — pure helpers for Resources → Agents side mode.
+ *
+ * Reuses session task collection (no invented metrics). Empty-state kinds
+ * distinguish no tasks vs filter empty vs idle session hint.
+ */
+
+import {
+  countRunningTasks,
+  type AgentTask,
+  type TaskTreeNode,
+} from "@/lib/sessionTasks";
+
+/** Side-mode id for the Agents rail in ResourceViewer. */
+export const AGENTS_RAIL_SIDE_MODE = "agents" as const;
+
+export type AgentsRailSideMode = typeof AGENTS_RAIL_SIDE_MODE;
+
+/** Empty-state kinds when the rail has nothing to list. */
+export type AgentsRailEmptyKind = "no_tasks" | "filter_empty" | "idle_hint";
+
+export type AgentsRailEmptyPresentation = {
+  kind: AgentsRailEmptyKind;
+  /** Primary title i18n key. */
+  titleKey: string;
+  /** Optional hint i18n key. */
+  hintKey: string | null;
+  /** Offer clear-filters CTA (filter_empty only). */
+  showClearFilters: boolean;
+};
+
+export type AgentsRailEmptyInput = {
+  /** True when any task rows would render (post-filter). */
+  hasTasks: boolean;
+  /** Status chip or free-text filter is narrowing the list. */
+  filterActive: boolean;
+  /** Current session is streaming / connecting / awaiting permission. */
+  sessionBusy: boolean;
+};
+
+/**
+ * Resolve empty-state presentation for Resources → Agents.
+ * Returns `null` when task rows should render.
+ *
+ * Priority:
+ * 1. hasTasks → null
+ * 2. filterActive → filter_empty
+ * 3. sessionBusy → no_tasks (busy but no tool rows yet)
+ * 4. else → idle_hint (session idle)
+ */
+export function resolveAgentsRailEmptyState(
+  opts: AgentsRailEmptyInput,
+): AgentsRailEmptyPresentation | null {
+  if (opts.hasTasks) return null;
+
+  if (opts.filterActive) {
+    return {
+      kind: "filter_empty",
+      titleKey: "agentsRail.filterEmpty",
+      hintKey: "agentsRail.filterEmptyHint",
+      showClearFilters: true,
+    };
+  }
+
+  if (opts.sessionBusy) {
+    return {
+      kind: "no_tasks",
+      titleKey: "agentsRail.noTasks",
+      hintKey: "agentsRail.busyHint",
+      showClearFilters: false,
+    };
+  }
+
+  return {
+    kind: "idle_hint",
+    titleKey: "agentsRail.noTasks",
+    hintKey: "agentsRail.idleHint",
+    showClearFilters: false,
+  };
+}
+
+/**
+ * Count running tasks for the Agents rail badge.
+ * Accepts a flat task list or a task tree forest (roots + nested).
+ * Thin wrapper over {@link countRunningTasks} — never invents work.
+ */
+export function countAgentsRailRunning(
+  nodesOrTasks:
+    | readonly Pick<AgentTask, "status">[]
+    | readonly TaskTreeNode[]
+    | null
+    | undefined,
+): number {
+  if (!nodesOrTasks || nodesOrTasks.length === 0) return 0;
+  const first = nodesOrTasks[0] as { task?: AgentTask; status?: string };
+  if (first && typeof first === "object" && "task" in first && first.task) {
+    const flat: Pick<AgentTask, "status">[] = [];
+    const walk = (node: TaskTreeNode) => {
+      flat.push(node.task);
+      for (const c of node.children) walk(c);
+    };
+    for (const n of nodesOrTasks as readonly TaskTreeNode[]) walk(n);
+    return countRunningTasks(flat as AgentTask[]);
+  }
+  return countRunningTasks(nodesOrTasks as AgentTask[]);
+}
+
+/** True when the Agents tab / chrome should show a running badge. */
+export function shouldShowAgentsRailBadge(runningCount: number): boolean {
+  const n = Number(runningCount);
+  return Number.isFinite(n) && n > 0;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16015,8 +16015,45 @@ textarea::-webkit-scrollbar-thumb:active,
 }
 
 .rp-chrome__changes-btn,
-.rp-chrome__tasks-btn {
+.rp-chrome__tasks-btn,
+.rp-chrome__agents-btn {
   position: relative;
+}
+
+/* Resources → Agents rail (embedded session task tree) */
+.rp-agents-rail {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.rp-agents-rail .agent-tasks--rail {
+  border-bottom: none;
+  background: transparent;
+  max-height: none;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+}
+
+.rp-agents-rail .agent-tasks__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.rp-agents-rail .agent-tasks__head {
+  padding: 6px 10px 2px;
+}
+
+.rp-agents-rail .agent-tasks__filters {
+  padding: 0 8px 6px;
+}
+
+.rp-agents-rail .agent-tasks__empty {
+  padding: 16px 12px;
 }
 
 /* Agent tasks panel (L05) — derived from live tool_step / session://tool */


### PR DESCRIPTION
## Summary
- Add Resources → **Agents** side mode with the current session's tool/subagent task tree in the right pane (no need to open the floating Tasks modal).
- Reuse `AgentTasksPanel` via `variant="rail"` + existing `sessionTasks` / filters / WT bind-cwd — pure `agentsRail` helpers for empty honesty (`no_tasks` · `filter_empty` · `idle_hint`) and running badge.
- Wire App: `sessionMessages`, `sessionBusy`, `activeCwd`, `onOpenAgentsCwd`, snapshot flag; en/zh/zh-TW + minimal `.rp-agents-rail` CSS; CHANGELOG.

## Test plan
- [x] `pnpm test -- src/lib/agentsRail.test.ts src/lib/sessionTasks.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Open Resources tree → **Agents** tab; idle session shows honest empty hint
- [ ] Run a turn with tools / nested subagent; tree + running badge update live
- [ ] Status chips / search filter empty + Clear filters
- [ ] WT badge bind cwd soft-fail matches floating Tasks panel
- [ ] Chrome Agents button toggles the rail; floating Tasks panel still works