### PR TITLE
feat(session): task board by status columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+#### Sessions & sidebar
+- **Session task board**: cross-session board view of local sessions by status columns (needs you · running · error · idle · done/archived). Pure `sessionTaskBoard` helpers from sessions + liveMap only — no invented CI/cloud state; include-archived chip, title/project search, honest empty / filter-empty states. Open from Agent dashboard **Board view**, command palette `open-task-board`, or App state. en/zh/zh-TW + tests.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -244,6 +244,7 @@ import {
 } from "@/lib/planSession";
 import { AgentTasksPanel } from "@/components/AgentTasksPanel";
 import { AgentDashboardModal } from "@/components/AgentDashboardModal";
+import { SessionTaskBoardModal } from "@/components/SessionTaskBoardModal";
 import { BatchAgentsModal } from "@/components/BatchAgentsModal";
 import { ReliabilityCenterModal } from "@/components/ReliabilityCenterModal";
 import {
@@ -265,6 +266,7 @@ import {
   collectAgentDashboardRows,
   countBusyDashboardRows,
 } from "@/lib/agentDashboard";
+import { buildTaskBoard } from "@/lib/sessionTaskBoard";
 import {
   BATCH_AGENTS_HEADLESS_TIMEOUT_MS,
   buildBatchPromptBody,
@@ -1005,6 +1007,8 @@ function paletteActionIcon(id: string) {
       return <IconList size={size} />;
     case "open-agent-dashboard":
       return <IconActivity size={size} />;
+    case "open-task-board":
+      return <IconList size={size} />;
     case "open-batch-agents":
       return <IconList size={size} />;
     case "doctor":
@@ -2533,6 +2537,9 @@ export default function App() {
   const didRestoreLastRef = useRef(false);
   const [tasksPanelOpen, setTasksPanelOpen] = useState(false);
   const [agentDashboardOpen, setAgentDashboardOpen] = useState(false);
+  const [taskBoardOpen, setTaskBoardOpen] = useState(false);
+  const [taskBoardIncludeArchived, setTaskBoardIncludeArchived] =
+    useState(false);
   const [batchAgentsOpen, setBatchAgentsOpen] = useState(false);
   const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
   /** null = unknown/loading; true = git work tree; false = not a git repo. */
@@ -8146,6 +8153,33 @@ export default function App() {
     [agentDashboardRows],
   );
 
+  const taskBoard = useMemo(
+    () =>
+      buildTaskBoard({
+        sessions,
+        projects: projects.map((p) => ({
+          id: p.id,
+          name: p.name,
+          path: p.path,
+        })),
+        liveMap,
+        currentSessionId: session.sessionId,
+        includeArchived: taskBoardIncludeArchived,
+        untitledLabel: tr("session.untitled"),
+        generalWorkspacePath,
+        unboundProjectLabel: tr("sidebar.otherSessions"),
+      }),
+    [
+      sessions,
+      projects,
+      liveMap,
+      session.sessionId,
+      taskBoardIncludeArchived,
+      tr,
+      generalWorkspacePath,
+    ],
+  );
+
   const connPill = useMemo(
     () => connPillForState(session.state, connecting),
     [session.state, connecting],
@@ -13588,6 +13622,16 @@ export default function App() {
           window.location.hash = "#/workbench";
         }
         break;
+      case "open-task-board":
+        setAppView("workbench");
+        setTaskBoardOpen(true);
+        if (
+          typeof window !== "undefined" &&
+          window.location.hash.includes("settings")
+        ) {
+          window.location.hash = "#/workbench";
+        }
+        break;
       case "open-batch-agents":
         openBatchAgents();
         break;
@@ -16346,7 +16390,8 @@ export default function App() {
         worktreeGcOpen ||
         shipOpen ||
         projectRulesTarget ||
-        agentDashboardOpen,
+        agentDashboardOpen ||
+        taskBoardOpen,
     ),
     permOpen: !!perm,
     askUserOpen: !!askUser,
@@ -21339,6 +21384,24 @@ export default function App() {
         onOpenBatchAgents={() => {
           setAgentDashboardOpen(false);
           openBatchAgents();
+        }}
+        onOpenTaskBoard={() => {
+          setAgentDashboardOpen(false);
+          setTaskBoardOpen(true);
+        }}
+      />
+      <SessionTaskBoardModal
+        open={taskBoardOpen}
+        locale={locale}
+        board={taskBoard}
+        includeArchived={taskBoardIncludeArchived}
+        onIncludeArchivedChange={setTaskBoardIncludeArchived}
+        onClose={() => setTaskBoardOpen(false)}
+        onSelectSession={(id) => {
+          const row = sessions.find((s) => s.id === id);
+          if (!row) return;
+          const proj = projects.find((p) => p.id === row.projectId) || null;
+          void openSession(row, proj);
         }}
       />
       <BatchAgentsModal

--- a/src/components/AgentDashboardModal.tsx
+++ b/src/components/AgentDashboardModal.tsx
@@ -214,6 +214,8 @@ export type AgentDashboardModalProps = {
   onStopSessions?: (sessionIds: string[]) => void;
   /** Open multi-project batch agents dispatch. */
   onOpenBatchAgents?: () => void;
+  /** Open session task board (status columns). */
+  onOpenTaskBoard?: () => void;
 };
 
 export function AgentDashboardModal({
@@ -225,6 +227,7 @@ export function AgentDashboardModal({
   onStopAllBusy,
   onStopSessions,
   onOpenBatchAgents,
+  onOpenTaskBoard,
 }: AgentDashboardModalProps) {
   const tr = useMemo(() => createT(locale), [locale]);
   const [query, setQuery] = useState("");
@@ -349,6 +352,16 @@ export function AgentDashboardModal({
       footer={
         <div className="agent-dash-modal__footer">
           <div className="agent-dash-modal__footer-actions">
+            {onOpenTaskBoard ? (
+              <button
+                type="button"
+                className="btn btn--ghost"
+                onClick={onOpenTaskBoard}
+                title={tr("dashboard.openBoardTitle")}
+              >
+                {tr("dashboard.openBoard")}
+              </button>
+            ) : null}
             {onOpenBatchAgents ? (
               <button
                 type="button"

--- a/src/components/SessionTaskBoardModal.tsx
+++ b/src/components/SessionTaskBoardModal.tsx
@@ -1,0 +1,343 @@
+/**
+ * Cross-session task board — sessions by status columns.
+ * Pure local meta (sessions + liveMap); no invented CI/cloud state.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import type { Locale, MessageKey } from "@/i18n";
+import { createT } from "@/i18n";
+import { GlassModal } from "@/components/GlassModal";
+import { formatRelativeTime } from "@/lib/accountUi";
+import type { AgentDashboardStatus } from "@/lib/agentDashboard";
+import {
+  countTaskBoardColumns,
+  filterTaskBoard,
+  resolveTaskBoardEmptyState,
+  TASK_BOARD_COLUMN_ORDER,
+  type TaskBoard,
+  type TaskBoardCard,
+  type TaskBoardColumn,
+} from "@/lib/sessionTaskBoard";
+
+type TFn = (key: MessageKey, vars?: Record<string, string | number>) => string;
+
+function columnLabel(col: TaskBoardColumn, t: TFn): string {
+  switch (col) {
+    case "needs_you":
+      return t("taskBoard.column.needsYou");
+    case "running":
+      return t("taskBoard.column.running");
+    case "idle":
+      return t("taskBoard.column.idle");
+    case "done":
+      return t("taskBoard.column.done");
+    case "error":
+      return t("taskBoard.column.error");
+  }
+}
+
+function statusLabel(status: AgentDashboardStatus, t: TFn): string {
+  switch (status) {
+    case "busy":
+      return t("dashboard.status.busy");
+    case "permission":
+      return t("dashboard.status.permission");
+    case "connecting":
+      return t("dashboard.status.connecting");
+    case "error":
+      return t("dashboard.status.error");
+    default:
+      return t("dashboard.status.idle");
+  }
+}
+
+function columnToneClass(col: TaskBoardColumn): string {
+  switch (col) {
+    case "needs_you":
+      return "task-board__col--needs";
+    case "running":
+      return "task-board__col--running";
+    case "error":
+      return "task-board__col--error";
+    case "done":
+      return "task-board__col--done";
+    default:
+      return "task-board__col--idle";
+  }
+}
+
+function TaskBoardCardView({
+  card,
+  t,
+  locale,
+  onSelect,
+}: {
+  card: TaskBoardCard;
+  t: TFn;
+  locale: Locale;
+  onSelect?: (sessionId: string) => void;
+}) {
+  const metaParts: string[] = [];
+  if (card.projectName) metaParts.push(card.projectName);
+  else if (card.projectPath) metaParts.push(card.projectPath);
+
+  const activity =
+    card.lastActivityAt > 0
+      ? formatRelativeTime(new Date(card.lastActivityAt).toISOString(), locale)
+      : null;
+  const toolTitle = card.liveToolTitle?.trim() || null;
+
+  return (
+    <li
+      className={
+        "task-board__card" +
+        (card.isCurrent ? " is-current" : "") +
+        (card.column === "needs_you" ? " is-needs" : "") +
+        (card.column === "running" ? " is-running" : "") +
+        (card.column === "error" ? " is-error" : "")
+      }
+    >
+      <button
+        type="button"
+        className="task-board__card-btn"
+        onClick={() => onSelect?.(card.sessionId)}
+        title={t("dashboard.openSession")}
+      >
+        <span className="task-board__card-title" title={card.title}>
+          {card.title}
+        </span>
+        {card.isCurrent ? (
+          <span className="task-board__card-current">
+            {t("dashboard.current")}
+          </span>
+        ) : null}
+        {toolTitle ? (
+          <span className="task-board__card-tool" title={toolTitle}>
+            <span className="task-board__card-tool-label">
+              {t("dashboard.toolLabel")}
+            </span>
+            <span className="task-board__card-tool-name">{toolTitle}</span>
+          </span>
+        ) : null}
+        {metaParts.length > 0 ? (
+          <span className="task-board__card-meta" title={metaParts.join(" · ")}>
+            {metaParts.join(" · ")}
+          </span>
+        ) : null}
+        {activity ? (
+          <span className="task-board__card-activity">
+            {t("dashboard.lastActivity", { time: activity })}
+          </span>
+        ) : null}
+        {card.column === "done" || card.status !== "idle" ? (
+          <span className="task-board__card-status">
+            {card.column === "done"
+              ? t("taskBoard.column.done")
+              : statusLabel(card.status, t)}
+          </span>
+        ) : null}
+      </button>
+    </li>
+  );
+}
+
+export type SessionTaskBoardModalProps = {
+  open: boolean;
+  locale: Locale;
+  board: TaskBoard;
+  onClose: () => void;
+  onSelectSession?: (sessionId: string) => void;
+  /** Controlled include-archived chip (parent owns state when provided). */
+  includeArchived?: boolean;
+  onIncludeArchivedChange?: (include: boolean) => void;
+};
+
+export function SessionTaskBoardModal({
+  open,
+  locale,
+  board,
+  onClose,
+  onSelectSession,
+  includeArchived: includeArchivedProp,
+  onIncludeArchivedChange,
+}: SessionTaskBoardModalProps) {
+  const tr = useMemo(() => createT(locale), [locale]);
+  const [query, setQuery] = useState("");
+  const [projectQuery, setProjectQuery] = useState("");
+  const [localIncludeArchived, setLocalIncludeArchived] = useState(false);
+
+  const includeArchived = includeArchivedProp ?? localIncludeArchived;
+  const setIncludeArchived = (v: boolean) => {
+    if (onIncludeArchivedChange) onIncludeArchivedChange(v);
+    else setLocalIncludeArchived(v);
+  };
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setProjectQuery("");
+    }
+  }, [open]);
+
+  const totalCounts = useMemo(() => countTaskBoardColumns(board), [board]);
+
+  const filtered = useMemo(
+    () => filterTaskBoard(board, { query, projectQuery }),
+    [board, query, projectQuery],
+  );
+  const filteredCounts = useMemo(
+    () => countTaskBoardColumns(filtered),
+    [filtered],
+  );
+
+  const emptyKind = useMemo(
+    () =>
+      resolveTaskBoardEmptyState({
+        totalSessions: totalCounts.total,
+        filteredCount: filteredCounts.total,
+      }),
+    [totalCounts.total, filteredCounts.total],
+  );
+
+  const hasActiveFilters =
+    query.trim().length > 0 || projectQuery.trim().length > 0;
+
+  const tFn: TFn = (k, vars) => tr(k, vars);
+
+  return (
+    <GlassModal
+      open={open}
+      onClose={onClose}
+      title={tr("taskBoard.title")}
+      titleId="session-task-board-title"
+      closeLabel={tr("common.close")}
+      size="lg"
+      className="task-board-modal"
+      wrapBody
+      bodyClassName="task-board-modal__body"
+      footer={
+        <div className="task-board-modal__footer">
+          <span className="task-board-modal__footer-meta">
+            {tr("taskBoard.totalCount", { n: filteredCounts.total })}
+          </span>
+          <button type="button" className="btn btn--solid" onClick={onClose}>
+            {tr("common.close")}
+          </button>
+        </div>
+      }
+    >
+      <p className="task-board__hint">{tr("taskBoard.hint")}</p>
+      <div className="task-board__toolbar">
+        <input
+          type="search"
+          className="settings-input task-board__search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={tr("taskBoard.searchPlaceholder")}
+          autoComplete="off"
+          spellCheck={false}
+          aria-label={tr("taskBoard.searchPlaceholder")}
+        />
+        <input
+          type="search"
+          className="settings-input task-board__search task-board__search--project"
+          value={projectQuery}
+          onChange={(e) => setProjectQuery(e.target.value)}
+          placeholder={tr("taskBoard.projectSearchPlaceholder")}
+          autoComplete="off"
+          spellCheck={false}
+          aria-label={tr("taskBoard.projectSearchPlaceholder")}
+        />
+        <button
+          type="button"
+          role="switch"
+          aria-checked={includeArchived}
+          className={
+            "task-board__chip" + (includeArchived ? " is-active" : "")
+          }
+          onClick={() => setIncludeArchived(!includeArchived)}
+          title={tr("taskBoard.includeArchivedTitle")}
+        >
+          {tr("taskBoard.includeArchived")}
+        </button>
+      </div>
+
+      {emptyKind === "empty" ? (
+        <div className="task-board__empty">
+          <p className="task-board__empty-title">{tr("taskBoard.empty")}</p>
+          <p className="task-board__empty-hint">{tr("taskBoard.emptyHint")}</p>
+        </div>
+      ) : emptyKind === "filter_empty" ? (
+        <div className="task-board__empty">
+          <p className="task-board__empty-title">
+            {tr("taskBoard.filterEmpty")}
+          </p>
+          <p className="task-board__empty-hint">
+            {tr("taskBoard.filterEmptyHint")}
+          </p>
+          {hasActiveFilters ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm task-board__clear-filters"
+              onClick={() => {
+                setQuery("");
+                setProjectQuery("");
+              }}
+            >
+              {tr("taskBoard.clearFilters")}
+            </button>
+          ) : null}
+        </div>
+      ) : (
+        <div
+          className="task-board__columns"
+          role="list"
+          aria-label={tr("taskBoard.columnsLabel")}
+        >
+          {TASK_BOARD_COLUMN_ORDER.map((col) => {
+            const cards = filtered[col];
+            // Hide empty done column when archived not included and empty.
+            if (col === "done" && cards.length === 0 && !includeArchived) {
+              return null;
+            }
+            return (
+              <section
+                key={col}
+                className={"task-board__col " + columnToneClass(col)}
+                role="listitem"
+                aria-label={columnLabel(col, tFn)}
+              >
+                <header className="task-board__col-head">
+                  <span className="task-board__col-title">
+                    {columnLabel(col, tFn)}
+                  </span>
+                  <span className="task-board__col-count">{cards.length}</span>
+                </header>
+                {cards.length === 0 ? (
+                  <p className="task-board__col-empty">
+                    {tr("taskBoard.columnEmpty")}
+                  </p>
+                ) : (
+                  <ul className="task-board__cards" role="list">
+                    {cards.map((card) => (
+                      <TaskBoardCardView
+                        key={card.sessionId}
+                        card={card}
+                        t={tFn}
+                        locale={locale}
+                        onSelect={(id) => {
+                          onSelectSession?.(id);
+                          onClose();
+                        }}
+                      />
+                    ))}
+                  </ul>
+                )}
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </GlassModal>
+  );
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -865,6 +865,34 @@ const en = {
   "dashboard.batchAgents": "Batch agents…",
   "dashboard.batchAgentsTitle":
     "Dispatch the same prompt to multiple projects (sessions or headless)",
+  "dashboard.openBoard": "Board view",
+  "dashboard.openBoardTitle":
+    "Open sessions as a status board (needs you / running / idle / done)",
+
+  "taskBoard.title": "Session task board",
+  "taskBoard.hint":
+    "Sessions grouped by local status from the app and live agent state — not CI or cloud. Click a card to open that chat.",
+  "taskBoard.open": "Session task board",
+  "taskBoard.searchPlaceholder": "Filter sessions…",
+  "taskBoard.projectSearchPlaceholder": "Filter by project…",
+  "taskBoard.includeArchived": "Include archived",
+  "taskBoard.includeArchivedTitle":
+    "Show archived idle sessions in the Done column",
+  "taskBoard.columnsLabel": "Session status columns",
+  "taskBoard.column.needsYou": "Needs you",
+  "taskBoard.column.running": "Running",
+  "taskBoard.column.idle": "Idle",
+  "taskBoard.column.done": "Done",
+  "taskBoard.column.error": "Error",
+  "taskBoard.columnEmpty": "No sessions",
+  "taskBoard.empty": "No sessions to show",
+  "taskBoard.emptyHint":
+    "Start a chat or wait for an agent turn — sessions appear here by status.",
+  "taskBoard.filterEmpty": "No sessions match these filters",
+  "taskBoard.filterEmptyHint":
+    "Clear the search or include archived to see more sessions.",
+  "taskBoard.clearFilters": "Clear filters",
+  "taskBoard.totalCount": "{n} sessions",
 
   "batchAgents.title": "Batch agents",
   "batchAgents.hint":
@@ -6956,6 +6984,32 @@ const zh: Record<MessageKey, string> = {
   "dashboard.batchAgents": "批量 Agent…",
   "dashboard.batchAgentsTitle":
     "将同一提示词派发到多个项目（会话或无头摘要）",
+  "dashboard.openBoard": "看板视图",
+  "dashboard.openBoardTitle":
+    "按状态分列查看会话（需你处理 / 运行中 / 空闲 / 完成）",
+
+  "taskBoard.title": "会话任务看板",
+  "taskBoard.hint":
+    "按应用内会话与本地 live 状态分列 — 非 CI/云端。点击卡片打开该对话。",
+  "taskBoard.open": "会话任务看板",
+  "taskBoard.searchPlaceholder": "筛选会话…",
+  "taskBoard.projectSearchPlaceholder": "按项目筛选…",
+  "taskBoard.includeArchived": "含已归档",
+  "taskBoard.includeArchivedTitle": "在「完成」列显示已归档的空闲会话",
+  "taskBoard.columnsLabel": "会话状态列",
+  "taskBoard.column.needsYou": "需你处理",
+  "taskBoard.column.running": "运行中",
+  "taskBoard.column.idle": "空闲",
+  "taskBoard.column.done": "完成",
+  "taskBoard.column.error": "异常",
+  "taskBoard.columnEmpty": "暂无会话",
+  "taskBoard.empty": "暂无会话",
+  "taskBoard.emptyHint":
+    "开始对话或等待 Agent 回合 — 会话会按状态出现在这里。",
+  "taskBoard.filterEmpty": "没有符合筛选条件的会话",
+  "taskBoard.filterEmptyHint": "清空搜索或勾选「含已归档」以查看更多会话。",
+  "taskBoard.clearFilters": "清除筛选",
+  "taskBoard.totalCount": "{n} 个会话",
 
   "batchAgents.title": "批量 Agent",
   "batchAgents.hint":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -812,6 +812,32 @@ export const zhTW: Record<MessageKey, string> = {
   "dashboard.batchAgents": "批量 Agent…",
   "dashboard.batchAgentsTitle":
     "將同一提示詞派發到多個專案（工作階段或無頭摘要）",
+  "dashboard.openBoard": "看板檢視",
+  "dashboard.openBoardTitle":
+    "依狀態分欄檢視工作階段（需你處理 / 執行中 / 閒置 / 完成）",
+
+  "taskBoard.title": "工作階段任務看板",
+  "taskBoard.hint":
+    "依應用程式內工作階段與本地 live 狀態分欄 — 非 CI/雲端。點擊卡片開啟該對話。",
+  "taskBoard.open": "工作階段任務看板",
+  "taskBoard.searchPlaceholder": "篩選工作階段…",
+  "taskBoard.projectSearchPlaceholder": "依專案篩選…",
+  "taskBoard.includeArchived": "含已封存",
+  "taskBoard.includeArchivedTitle": "在「完成」欄顯示已封存的閒置工作階段",
+  "taskBoard.columnsLabel": "工作階段狀態欄",
+  "taskBoard.column.needsYou": "需你處理",
+  "taskBoard.column.running": "執行中",
+  "taskBoard.column.idle": "閒置",
+  "taskBoard.column.done": "完成",
+  "taskBoard.column.error": "異常",
+  "taskBoard.columnEmpty": "尚無工作階段",
+  "taskBoard.empty": "尚無工作階段",
+  "taskBoard.emptyHint":
+    "開始對話或等待 Agent 回合 — 工作階段會依狀態出現在這裡。",
+  "taskBoard.filterEmpty": "沒有符合篩選條件的工作階段",
+  "taskBoard.filterEmptyHint": "清空搜尋或勾選「含已封存」以查看更多工作階段。",
+  "taskBoard.clearFilters": "清除篩選",
+  "taskBoard.totalCount": "{n} 個工作階段",
 
   "batchAgents.title": "批量 Agent",
   "batchAgents.hint":

--- a/src/lib/paletteActions.test.ts
+++ b/src/lib/paletteActions.test.ts
@@ -16,6 +16,7 @@ describe("defaultPaletteActions", () => {
       "open-automations",
       "open-tasks",
       "open-agent-dashboard",
+      "open-task-board",
       "open-batch-agents",
       "doctor",
       "traces",

--- a/src/lib/paletteActions.ts
+++ b/src/lib/paletteActions.ts
@@ -72,6 +72,25 @@ export function defaultPaletteActions(): PaletteActionDef[] {
       group: "navigate",
     },
     {
+      id: "open-task-board",
+      labelKey: "taskBoard.open",
+      keywords: [
+        "task board",
+        "session board",
+        "kanban",
+        "columns",
+        "needs you",
+        "running",
+        "idle",
+        "done",
+        "board view",
+        "status board",
+        "看板",
+        "任务板",
+      ],
+      group: "navigate",
+    },
+    {
       id: "open-batch-agents",
       labelKey: "batchAgents.open",
       keywords: [

--- a/src/lib/sessionTaskBoard.test.ts
+++ b/src/lib/sessionTaskBoard.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTaskBoard,
+  countTaskBoardColumns,
+  filterTaskBoard,
+  flattenTaskBoard,
+  mapDashboardStatusToBoardColumn,
+  resolveTaskBoardEmptyState,
+  TASK_BOARD_COLUMN_ORDER,
+  type TaskBoard,
+  type TaskBoardCard,
+} from "./sessionTaskBoard";
+import { emptyLiveSnapshot, type SessionLiveMap } from "./sessionLiveStore";
+
+describe("mapDashboardStatusToBoardColumn", () => {
+  it("maps permission → needs_you, busy/connecting → running", () => {
+    expect(mapDashboardStatusToBoardColumn("permission")).toBe("needs_you");
+    expect(mapDashboardStatusToBoardColumn("busy")).toBe("running");
+    expect(mapDashboardStatusToBoardColumn("connecting")).toBe("running");
+  });
+
+  it("maps idle → idle, error → error", () => {
+    expect(mapDashboardStatusToBoardColumn("idle")).toBe("idle");
+    expect(mapDashboardStatusToBoardColumn("error")).toBe("error");
+  });
+
+  it("maps archived idle → done", () => {
+    expect(mapDashboardStatusToBoardColumn("idle", true)).toBe("done");
+    // Archived does not reclassify non-idle statuses.
+    expect(mapDashboardStatusToBoardColumn("busy", true)).toBe("running");
+    expect(mapDashboardStatusToBoardColumn("permission", true)).toBe(
+      "needs_you",
+    );
+    expect(mapDashboardStatusToBoardColumn("error", true)).toBe("error");
+  });
+});
+
+describe("buildTaskBoard", () => {
+  it("groups sessions into status columns from liveMap + meta", () => {
+    const liveMap: SessionLiveMap = {
+      a: {
+        ...emptyLiveSnapshot("a", 100),
+        state: "streaming",
+        liveToolTitle: "bash",
+        updatedAt: 5000,
+      },
+      b: {
+        ...emptyLiveSnapshot("b", 50),
+        state: "awaiting_permission",
+        awaitingPermission: true,
+        updatedAt: 4000,
+      },
+      c: { ...emptyLiveSnapshot("c", 10), state: "ready", updatedAt: 10 },
+      d: {
+        ...emptyLiveSnapshot("d", 1),
+        state: "disconnected",
+        updatedAt: 1,
+      },
+    };
+    const board = buildTaskBoard({
+      sessions: [
+        {
+          id: "a",
+          title: "Fix CI",
+          projectId: "p1",
+          updatedAt: "2026-07-30T10:00:00.000Z",
+        },
+        {
+          id: "b",
+          title: "Review PR",
+          projectId: "p1",
+          updatedAt: "2026-07-30T09:00:00.000Z",
+        },
+        {
+          id: "c",
+          title: "Idle chat",
+          projectId: null,
+          updatedAt: "2026-07-29T12:00:00.000Z",
+        },
+        {
+          id: "d",
+          title: "Dropped",
+          projectId: "p2",
+          updatedAt: "2026-07-28T12:00:00.000Z",
+        },
+      ],
+      projects: [
+        { id: "p1", name: "grok-app", path: "/Users/me/Code/grok-app" },
+        { id: "p2", name: "other", path: "/tmp/other" },
+      ],
+      liveMap,
+      currentSessionId: "a",
+      untitledLabel: "Untitled",
+      unboundProjectLabel: "Other chats",
+    });
+
+    expect(board.running.map((c) => c.sessionId)).toEqual(["a"]);
+    expect(board.needs_you.map((c) => c.sessionId)).toEqual(["b"]);
+    expect(board.idle.map((c) => c.sessionId)).toEqual(["c"]);
+    expect(board.error.map((c) => c.sessionId)).toEqual(["d"]);
+    expect(board.done).toEqual([]);
+
+    const a = board.running[0]!;
+    expect(a.isCurrent).toBe(true);
+    expect(a.liveToolTitle).toBe("bash");
+    expect(a.projectName).toBe("grok-app");
+    expect(a.projectPath).toBe("/Users/me/Code/grok-app");
+    expect(a.status).toBe("busy");
+    expect(a.column).toBe("running");
+
+    const c = board.idle[0]!;
+    expect(c.projectName).toBe("Other chats");
+    expect(c.status).toBe("idle");
+  });
+
+  it("puts archived idle into done only when includeArchived", () => {
+    const sessions = [
+      {
+        id: "arch",
+        title: "Old archive",
+        archived: true,
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      },
+      {
+        id: "live",
+        title: "Live",
+        updatedAt: "2026-07-30T00:00:00.000Z",
+      },
+    ];
+    const without = buildTaskBoard({
+      sessions,
+      projects: [],
+      liveMap: {},
+      includeArchived: false,
+    });
+    expect(flattenTaskBoard(without).map((c) => c.sessionId)).toEqual([
+      "live",
+    ]);
+    expect(without.done).toEqual([]);
+
+    const withArch = buildTaskBoard({
+      sessions,
+      projects: [],
+      liveMap: {},
+      includeArchived: true,
+    });
+    expect(withArch.done.map((c) => c.sessionId)).toEqual(["arch"]);
+    expect(withArch.done[0]!.column).toBe("done");
+    expect(withArch.done[0]!.archived).toBe(true);
+    expect(withArch.idle.map((c) => c.sessionId)).toEqual(["live"]);
+  });
+
+  it("keeps archived busy sessions in running even without includeArchived", () => {
+    const liveMap: SessionLiveMap = {
+      archBusy: {
+        ...emptyLiveSnapshot("archBusy", 20),
+        state: "streaming",
+        updatedAt: 20,
+      },
+    };
+    const board = buildTaskBoard({
+      sessions: [
+        {
+          id: "archBusy",
+          title: "Still running archive",
+          archived: true,
+          updatedAt: "2026-07-30T00:00:00.000Z",
+        },
+      ],
+      projects: [],
+      liveMap,
+      includeArchived: false,
+    });
+    expect(board.running.map((c) => c.sessionId)).toEqual(["archBusy"]);
+    expect(board.done).toEqual([]);
+  });
+
+  it("includes live-busy sessions missing from the sidebar list", () => {
+    const liveMap: SessionLiveMap = {
+      ghost: {
+        ...emptyLiveSnapshot("ghost", 99),
+        state: "connecting",
+        updatedAt: 99,
+      },
+    };
+    const board = buildTaskBoard({
+      sessions: [],
+      projects: [],
+      liveMap,
+      untitledLabel: "Untitled",
+    });
+    expect(board.running).toHaveLength(1);
+    expect(board.running[0]!.sessionId).toBe("ghost");
+    expect(board.running[0]!.title).toBe("Untitled");
+    expect(board.running[0]!.status).toBe("connecting");
+  });
+
+  it("sorts within column by current then lastActivityAt desc", () => {
+    const liveMap: SessionLiveMap = {
+      older: {
+        ...emptyLiveSnapshot("older", 1),
+        state: "streaming",
+        updatedAt: 100,
+      },
+      newer: {
+        ...emptyLiveSnapshot("newer", 2),
+        state: "streaming",
+        updatedAt: 200,
+      },
+      current: {
+        ...emptyLiveSnapshot("current", 3),
+        state: "streaming",
+        updatedAt: 50,
+      },
+    };
+    const board = buildTaskBoard({
+      sessions: [
+        { id: "older", title: "Older", updatedAt: "2026-07-01T00:00:00.000Z" },
+        { id: "newer", title: "Newer", updatedAt: "2026-07-02T00:00:00.000Z" },
+        {
+          id: "current",
+          title: "Current",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+        },
+      ],
+      projects: [],
+      liveMap,
+      currentSessionId: "current",
+    });
+    // Current first even with lower live updatedAt; then newer before older.
+    expect(board.running.map((c) => c.sessionId)).toEqual([
+      "current",
+      "newer",
+      "older",
+    ]);
+  });
+});
+
+describe("countTaskBoardColumns", () => {
+  it("returns per-column and total counts", () => {
+    const board: TaskBoard = {
+      needs_you: [{ sessionId: "b" } as TaskBoardCard],
+      running: [
+        { sessionId: "a" } as TaskBoardCard,
+        { sessionId: "c" } as TaskBoardCard,
+      ],
+      idle: [],
+      done: [{ sessionId: "d" } as TaskBoardCard],
+      error: [{ sessionId: "e" } as TaskBoardCard],
+    };
+    expect(countTaskBoardColumns(board)).toEqual({
+      needs_you: 1,
+      running: 2,
+      idle: 0,
+      done: 1,
+      error: 1,
+      total: 5,
+    });
+    expect(countTaskBoardColumns(emptyBoardLike())).toEqual({
+      needs_you: 0,
+      running: 0,
+      idle: 0,
+      done: 0,
+      error: 0,
+      total: 0,
+    });
+  });
+
+  it("lists every column in TASK_BOARD_COLUMN_ORDER", () => {
+    expect([...TASK_BOARD_COLUMN_ORDER]).toEqual([
+      "needs_you",
+      "running",
+      "error",
+      "idle",
+      "done",
+    ]);
+  });
+});
+
+function emptyBoardLike(): TaskBoard {
+  return {
+    needs_you: [],
+    running: [],
+    idle: [],
+    done: [],
+    error: [],
+  };
+}
+
+describe("filterTaskBoard", () => {
+  const sample = buildTaskBoard({
+    sessions: [
+      {
+        id: "a",
+        title: "Fix CI",
+        projectId: "p1",
+        updatedAt: "2026-07-30T10:00:00.000Z",
+      },
+      {
+        id: "b",
+        title: "Notes",
+        projectId: null,
+        updatedAt: "2026-07-29T12:00:00.000Z",
+      },
+      {
+        id: "c",
+        title: "Auth gate",
+        projectId: "p2",
+        updatedAt: "2026-07-28T12:00:00.000Z",
+      },
+    ],
+    projects: [
+      { id: "p1", name: "grok-app", path: "/code/grok-app" },
+      { id: "p2", name: "api-server", path: "/code/api-server" },
+    ],
+    liveMap: {
+      a: {
+        ...emptyLiveSnapshot("a", 1),
+        state: "streaming",
+        liveToolTitle: "bash",
+        updatedAt: 10,
+      },
+      c: {
+        ...emptyLiveSnapshot("c", 1),
+        state: "awaiting_permission",
+        awaitingPermission: true,
+        updatedAt: 8,
+      },
+    },
+  });
+
+  it("filters by title free-text across columns", () => {
+    const filtered = filterTaskBoard(sample, { query: "ci" });
+    expect(flattenTaskBoard(filtered).map((c) => c.sessionId)).toEqual(["a"]);
+    expect(filtered.running.map((c) => c.sessionId)).toEqual(["a"]);
+    expect(filtered.needs_you).toEqual([]);
+  });
+
+  it("filters by project name / path substring", () => {
+    const byName = filterTaskBoard(sample, { projectQuery: "API" });
+    expect(flattenTaskBoard(byName).map((c) => c.sessionId)).toEqual(["c"]);
+    const byPath = filterTaskBoard(sample, { projectQuery: "/code/grok" });
+    expect(flattenTaskBoard(byPath).map((c) => c.sessionId)).toEqual(["a"]);
+  });
+
+  it("combines query + projectQuery with AND", () => {
+    expect(
+      flattenTaskBoard(
+        filterTaskBoard(sample, { query: "auth", projectQuery: "api" }),
+      ).map((c) => c.sessionId),
+    ).toEqual(["c"]);
+    expect(
+      flattenTaskBoard(
+        filterTaskBoard(sample, { query: "ci", projectQuery: "api" }),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("empty filter returns the same board", () => {
+    expect(filterTaskBoard(sample, {})).toBe(sample);
+    expect(filterTaskBoard(sample, { query: "  " })).toBe(sample);
+  });
+});
+
+describe("resolveTaskBoardEmptyState", () => {
+  it("returns empty when no sessions", () => {
+    expect(
+      resolveTaskBoardEmptyState({ totalSessions: 0, filteredCount: 0 }),
+    ).toBe("empty");
+  });
+
+  it("returns filter_empty when catalog has rows but filter removes all", () => {
+    expect(
+      resolveTaskBoardEmptyState({ totalSessions: 3, filteredCount: 0 }),
+    ).toBe("filter_empty");
+  });
+
+  it("returns null when there are visible cards", () => {
+    expect(
+      resolveTaskBoardEmptyState({ totalSessions: 3, filteredCount: 2 }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/sessionTaskBoard.ts
+++ b/src/lib/sessionTaskBoard.ts
@@ -1,0 +1,284 @@
+/**
+ * Cross-session task board — pure column model over sessions + liveMap.
+ *
+ * Status columns (local meta only; no invented CI/cloud state):
+ *   needs_you · running · idle · done · error
+ *
+ * Reuses dashboard status mapping from agentDashboard; groups into a board.
+ */
+
+import {
+  isStoppableDashboardStatus,
+  mapDashboardStatus,
+  type AgentDashboardProjectInput,
+  type AgentDashboardSessionInput,
+  type AgentDashboardStatus,
+} from "./agentDashboard";
+import type { SessionLiveMap } from "./sessionLiveStore";
+
+/** Board columns for the session task board. */
+export type TaskBoardColumn =
+  | "needs_you"
+  | "running"
+  | "idle"
+  | "done"
+  | "error";
+
+/** Stable left-to-right column order for UI. */
+export const TASK_BOARD_COLUMN_ORDER: readonly TaskBoardColumn[] = [
+  "needs_you",
+  "running",
+  "error",
+  "idle",
+  "done",
+] as const;
+
+export interface TaskBoardCard {
+  sessionId: string;
+  title: string;
+  projectName: string | null;
+  projectPath: string | null;
+  /** Original dashboard-coarse status (busy / permission / …). */
+  status: AgentDashboardStatus;
+  column: TaskBoardColumn;
+  liveToolTitle: string | null;
+  isCurrent: boolean;
+  lastActivityAt: number;
+  /** True when the session is archived (done column when idle). */
+  archived: boolean;
+}
+
+export type TaskBoard = Record<TaskBoardColumn, TaskBoardCard[]>;
+
+export type TaskBoardColumnCounts = Record<TaskBoardColumn, number> & {
+  total: number;
+};
+
+export type TaskBoardEmptyState = "empty" | "filter_empty";
+
+export interface TaskBoardFilter {
+  /** Free-text over title, project name/path, tool, sessionId. */
+  query?: string;
+  /** Project id / name / path substring. */
+  projectQuery?: string;
+}
+
+/**
+ * Map a dashboard status to a board column.
+ * Archived idle sessions land in `done` (completed / archived).
+ */
+export function mapDashboardStatusToBoardColumn(
+  status: AgentDashboardStatus,
+  archived = false,
+): TaskBoardColumn {
+  if (status === "permission") return "needs_you";
+  if (status === "busy" || status === "connecting") return "running";
+  if (status === "error") return "error";
+  // idle
+  if (archived) return "done";
+  return "idle";
+}
+
+function emptyBoard(): TaskBoard {
+  return {
+    needs_you: [],
+    running: [],
+    idle: [],
+    done: [],
+    error: [],
+  };
+}
+
+function parseUpdatedMs(iso: string | null | undefined): number {
+  if (!iso) return 0;
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? t : 0;
+}
+
+/**
+ * Build a task board from sessions + liveMap + projects.
+ *
+ * - Host liveMap is authoritative for busy / permission / connecting / error.
+ * - Archived idle sessions appear only when `includeArchived` is true (done).
+ * - Live busy / error sessions always appear even if missing from the list.
+ * - No invented metrics; sort within each column by lastActivityAt desc
+ *   (current session first on ties of activity when both current flags differ).
+ */
+export function buildTaskBoard(opts: {
+  sessions: AgentDashboardSessionInput[];
+  liveMap: SessionLiveMap;
+  projects: AgentDashboardProjectInput[];
+  currentSessionId?: string | null;
+  includeArchived?: boolean;
+  untitledLabel?: string;
+  generalWorkspacePath?: string | null;
+  unboundProjectLabel?: string | null;
+}): TaskBoard {
+  const untitled = opts.untitledLabel || "Untitled";
+  const includeArchived = opts.includeArchived === true;
+  const current = opts.currentSessionId || null;
+  const projectById = new Map(
+    opts.projects.map((p) => [p.id, p] as const),
+  );
+  const sessionById = new Map(opts.sessions.map((s) => [s.id, s] as const));
+
+  const ids = new Set<string>();
+  for (const s of opts.sessions) {
+    if (!s.archived || includeArchived) {
+      ids.add(s.id);
+    } else {
+      // Still surface archived when live-busy / error (ops honesty).
+      const status = mapDashboardStatus(opts.liveMap[s.id]);
+      if (isStoppableDashboardStatus(status) || status === "error") {
+        ids.add(s.id);
+      }
+    }
+  }
+  for (const [id, snap] of Object.entries(opts.liveMap)) {
+    const status = mapDashboardStatus(snap);
+    if (isStoppableDashboardStatus(status) || status === "error") {
+      ids.add(id);
+    }
+  }
+
+  const board = emptyBoard();
+  for (const sessionId of ids) {
+    const meta = sessionById.get(sessionId);
+    const snap = opts.liveMap[sessionId];
+    const status = mapDashboardStatus(snap);
+    const archived = !!meta?.archived;
+
+    // Drop archived idle when not including archived (done would be empty).
+    if (archived && status === "idle" && !includeArchived) {
+      continue;
+    }
+
+    const column = mapDashboardStatusToBoardColumn(status, archived);
+    const projectId = meta?.projectId ?? null;
+    const project = projectId ? projectById.get(projectId) : undefined;
+    const sessionUpdatedMs = parseUpdatedMs(meta?.updatedAt);
+    const liveUpdatedMs = snap?.updatedAt ?? 0;
+    const lastActivityAt = Math.max(sessionUpdatedMs, liveUpdatedMs);
+    const title = (meta?.title || "").trim() || untitled;
+    const projectPath =
+      project?.path?.trim() ||
+      (projectId ? null : opts.generalWorkspacePath?.trim() || null);
+    const projectName =
+      project?.name?.trim() ||
+      (projectId
+        ? null
+        : opts.unboundProjectLabel?.trim() || null);
+
+    board[column].push({
+      sessionId,
+      title,
+      projectName,
+      projectPath,
+      status,
+      column,
+      liveToolTitle: snap?.liveToolTitle ?? null,
+      isCurrent: current != null && sessionId === current,
+      lastActivityAt,
+      archived,
+    });
+  }
+
+  // Sort each column: current first, then newest activity. No invented ranks.
+  for (const col of TASK_BOARD_COLUMN_ORDER) {
+    board[col].sort((a, b) => {
+      if (a.isCurrent !== b.isCurrent) return a.isCurrent ? -1 : 1;
+      return b.lastActivityAt - a.lastActivityAt;
+    });
+  }
+
+  return board;
+}
+
+/** Per-column counts plus total cards. */
+export function countTaskBoardColumns(board: TaskBoard): TaskBoardColumnCounts {
+  const counts: TaskBoardColumnCounts = {
+    needs_you: board.needs_you.length,
+    running: board.running.length,
+    idle: board.idle.length,
+    done: board.done.length,
+    error: board.error.length,
+    total: 0,
+  };
+  counts.total =
+    counts.needs_you +
+    counts.running +
+    counts.idle +
+    counts.done +
+    counts.error;
+  return counts;
+}
+
+/** Flatten board cards in column order. */
+export function flattenTaskBoard(board: TaskBoard): TaskBoardCard[] {
+  const out: TaskBoardCard[] = [];
+  for (const col of TASK_BOARD_COLUMN_ORDER) {
+    out.push(...board[col]);
+  }
+  return out;
+}
+
+function cardMatchesQuery(card: TaskBoardCard, q: string): boolean {
+  if (!q) return true;
+  const hay = [
+    card.title,
+    card.projectName || "",
+    card.projectPath || "",
+    card.liveToolTitle || "",
+    card.status,
+    card.column,
+    card.sessionId,
+  ]
+    .join("\n")
+    .toLowerCase();
+  return hay.includes(q);
+}
+
+function cardMatchesProject(card: TaskBoardCard, projectQuery: string): boolean {
+  const q = projectQuery.trim().toLowerCase();
+  if (!q) return true;
+  const hay = [card.projectName || "", card.projectPath || ""]
+    .join("\n")
+    .toLowerCase();
+  return hay.includes(q);
+}
+
+/**
+ * Filter board cards by free-text and/or project substring (AND).
+ * Column structure is preserved; empty columns stay empty arrays.
+ */
+export function filterTaskBoard(
+  board: TaskBoard,
+  filter: TaskBoardFilter = {},
+): TaskBoard {
+  const q = (filter.query ?? "").trim().toLowerCase();
+  const pq = filter.projectQuery ?? "";
+  if (!q && !pq.trim()) return board;
+
+  const out = emptyBoard();
+  for (const col of TASK_BOARD_COLUMN_ORDER) {
+    out[col] = board[col].filter(
+      (c) => cardMatchesQuery(c, q) && cardMatchesProject(c, pq),
+    );
+  }
+  return out;
+}
+
+/**
+ * Honest empty-state kind for the board UI.
+ * - `empty` — no sessions in the catalog at all
+ * - `filter_empty` — catalog has sessions but filters removed all cards
+ * - `null` — board has visible cards
+ */
+export function resolveTaskBoardEmptyState(opts: {
+  totalSessions: number;
+  filteredCount: number;
+}): TaskBoardEmptyState | null {
+  if (opts.totalSessions <= 0) return "empty";
+  if (opts.filteredCount <= 0) return "filter_empty";
+  return null;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -25978,6 +25978,250 @@ html[data-theme="light"] .rim-sidebar {
   line-height: 1.45;
 }
 
+/* ── Session task board (status columns) ────────────────────────────── */
+.task-board-modal {
+  width: min(1100px, 96vw);
+  max-height: min(86vh, 780px);
+}
+.task-board-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  max-height: min(68vh, 640px);
+}
+.task-board-modal__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+.task-board-modal__footer-meta {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+.task-board__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  line-height: 1.45;
+  flex-shrink: 0;
+}
+.task-board__toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.task-board__search {
+  flex: 1;
+  min-width: 120px;
+}
+.task-board__search--project {
+  flex: 0.9;
+}
+.task-board__chip {
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.3;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.task-board__chip:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.task-board__chip.is-active {
+  border-color: color-mix(in srgb, var(--accent, #6b8cff) 30%, transparent);
+  background: color-mix(in srgb, var(--accent, #6b8cff) 14%, transparent);
+  color: var(--text-primary);
+  font-weight: 560;
+}
+.task-board__columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+  align-items: stretch;
+}
+.task-board__col {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.18));
+  background: var(--bg-hover, rgba(127, 127, 127, 0.05));
+  overflow: hidden;
+}
+.task-board__col--needs {
+  border-color: color-mix(in srgb, var(--warning, #d4a017) 32%, transparent);
+}
+.task-board__col--running {
+  border-color: color-mix(in srgb, var(--accent, #5b8def) 28%, transparent);
+}
+.task-board__col--error {
+  border-color: color-mix(in srgb, var(--danger, #e35d5d) 28%, transparent);
+}
+.task-board__col--done {
+  opacity: 0.92;
+}
+.task-board__col-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.14));
+  flex-shrink: 0;
+}
+.task-board__col-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.task-board__col-count {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+  min-width: 1.2em;
+  text-align: right;
+}
+.task-board__col-empty {
+  margin: 0;
+  padding: 12px 10px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  line-height: 1.4;
+}
+.task-board__cards {
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  overflow: auto;
+  min-height: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.task-board__card {
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: var(--bg-elevated, var(--bg-primary, #fff));
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--border-subtle, #888) 40%, transparent);
+}
+.task-board__card.is-current {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent, #5b8def) 40%, transparent);
+}
+.task-board__card.is-needs {
+  border-color: color-mix(in srgb, var(--warning, #d4a017) 30%, transparent);
+}
+.task-board__card.is-running {
+  border-color: color-mix(in srgb, var(--accent, #5b8def) 24%, transparent);
+}
+.task-board__card.is-error {
+  border-color: color-mix(in srgb, var(--danger, #e35d5d) 26%, transparent);
+}
+.task-board__card-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 3px;
+  width: 100%;
+  margin: 0;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 10px;
+}
+.task-board__card-btn:hover {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.08));
+}
+.task-board__card-btn:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent, #5b8def) 55%, transparent);
+  outline-offset: 1px;
+}
+.task-board__card-title {
+  font-size: 12.5px;
+  font-weight: 560;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.task-board__card-current {
+  font-size: 10.5px;
+  color: var(--accent, #5b8def);
+  font-weight: 560;
+}
+.task-board__card-tool {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  min-width: 0;
+}
+.task-board__card-tool-label {
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+.task-board__card-tool-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.task-board__card-meta,
+.task-board__card-activity {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.task-board__card-status {
+  font-size: 10.5px;
+  color: var(--text-secondary);
+  opacity: 0.85;
+}
+.task-board__empty {
+  padding: 16px 4px 8px;
+}
+.task-board__empty-title {
+  margin: 0 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+}
+.task-board__empty-hint {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.7;
+  line-height: 1.45;
+}
+.task-board__clear-filters {
+  margin-top: 10px;
+}
+
 /* ── Batch agents (multi-project dispatch) ──────────────────────────── */
 .batch-agents-modal {
   width: min(640px, 100%);


### PR DESCRIPTION
## Summary
- Pure `sessionTaskBoard` helpers: map dashboard status → board columns (`needs_you` / `running` / `idle` / `done` / `error`), build/filter/count board from **sessions + liveMap + projects** only (no invented CI/cloud metrics).
- `SessionTaskBoardModal` with 4–5 status columns, searchable title/project, include-archived chip, honest empty / filter-empty states; cards open the session.
- Wire from Agent dashboard **Board view**, command palette `open-task-board`, and App open/close + `openSession`.
- i18n en / zh / zh-TW + CHANGELOG; minimal CSS.

## Test plan
- [x] `pnpm test -- src/lib/sessionTaskBoard.test.ts src/lib/agentDashboard.test.ts src/i18n/messages.test.ts src/lib/paletteActions.test.ts`
- [x] `pnpm typecheck`
- [ ] Open Agent dashboard → **Board view** → columns populate from live sessions
- [ ] Permission session appears under **Needs you**; busy/connecting under **Running**
- [ ] Toggle **Include archived** → archived idle moves to **Done**
- [ ] Search / project filter → filter-empty honesty + Clear filters
- [ ] Click card → focuses that session and closes board
- [ ] Command palette → “Session task board” / `open-task-board`