### PR TITLE
feat(automations): inbox review queue for schedule runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Automations Inbox** (review queue): Scheduled tasks page turns observed run history into an Inbox — outcome chips + search, unread mark-read / mark-all, open linked session (or project) when known, soft **Run now** only if the task still exists, clear via GlassModal (no `window.confirm`). Process-bound honesty banner: never invents offline runs after Quit. Pure `automationsInbox` helpers + tests; optional `sessionId` / `projectId` on run records; en/zh/zh-TW.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/docs/llm-wiki/automations.md
+++ b/docs/llm-wiki/automations.md
@@ -51,7 +51,7 @@
 - **写入时机**：Host 事件 `automation://ran` / `automation://error`（进程存活期间观察到的触发）；以及 UI「立即执行」返回 ok / error / skipped。
 - **字段**：`id` · `scheduleId` · `name` · `at` · `outcome`（`ok|error|skipped`）· 脱敏 `error` · `source`（`host|run_now|unknown`）。
 - **诚实**：完全退出后**不会**虚构离线触发；空列表是 soft-fail 空态，不是「后台什么都没发生过」的宣称。
-- **UI**：`AutomationsPage` 历史面板 + outcome 筛选 chips + GlassModal 清空（禁止 `window.confirm`）。
+- **UI**：`AutomationsPage` **Inbox** 审阅队列（outcome chips + 搜索 + 未读 / 打开会话 / 软 Run now）+ GlassModal 清空（禁止 `window.confirm`）。纯 helpers：`automationsInbox.ts`。
 
 ### 托盘与「退出后」诚实模型（AUTO-RUNNER + AUTO-HEADLESS-LITE + A2 one-shot）
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6443,6 +6443,7 @@ export default function App() {
           outcome: "skipped",
           source: "run_now",
           error: "busy",
+          projectId: auto.projectId,
         });
         return false;
       }
@@ -6453,6 +6454,7 @@ export default function App() {
           outcome: "skipped",
           source: "run_now",
           error: "session_busy",
+          projectId: auto.projectId,
         });
         return false;
       }
@@ -6471,6 +6473,7 @@ export default function App() {
             outcome: "error",
             source: "run_now",
             error: detail,
+            projectId: auto.projectId,
           });
           return false;
         }
@@ -6483,6 +6486,7 @@ export default function App() {
             outcome: "error",
             source: "run_now",
             error: detail,
+            projectId: auto.projectId,
           });
           return false;
         }
@@ -6584,6 +6588,7 @@ export default function App() {
             outcome: "error",
             source: "run_now",
             error: detail,
+            projectId: auto.projectId,
           });
           // Drop empty shell sessions so sidebar does not show SuperGrok ghosts.
           if (createdSessionId && api.isTauri()) {
@@ -6664,6 +6669,8 @@ export default function App() {
             outcome: "error",
             source: "run_now",
             error: errText,
+            sessionId: sessionId,
+            projectId: auto.projectId,
           });
           return false;
         }
@@ -6686,6 +6693,8 @@ export default function App() {
           outcome: "ok",
           source: "run_now",
           at: lastRunAt,
+          sessionId: sessionId,
+          projectId: auto.projectId,
         });
         setToast(tr("automations.runningToast", { title: auto.title }));
         window.setTimeout(() => setToast(null), 3200);
@@ -6698,6 +6707,7 @@ export default function App() {
           outcome: "error",
           source: "run_now",
           error: e,
+          projectId: auto.projectId,
         });
         return false;
       } finally {
@@ -6736,6 +6746,7 @@ export default function App() {
           name: title,
           outcome: "ok",
           source: "host",
+          sessionId: p?.sessionId ?? null,
         });
         setToast(tr("automations.runningToast", { title }));
         window.setTimeout(() => setToast(null), 3200);
@@ -18569,6 +18580,57 @@ export default function App() {
                 window.setTimeout(() => setToast(null), 4200);
               }}
               onRunNow={(auto) => void runAutomation(auto)}
+              locale={locale}
+              onOpenSession={(sessionId, projectId) => {
+                const id = (sessionId || "").trim();
+                if (!id) return;
+                void (async () => {
+                  let found =
+                    sessionsRef.current.find((s) => s.id === id) ?? null;
+                  if (!found) {
+                    try {
+                      const list = await api.sessionsList();
+                      const hit = list.find((s) => s.id === id);
+                      if (hit) {
+                        found = mapSessionListRow(hit);
+                        setSessions(list.map((s) => mapSessionListRow(s)));
+                      }
+                    } catch {
+                      /* soft-fail */
+                    }
+                  }
+                  if (!found) {
+                    setToast(tr("automations.inbox.sessionMissing"));
+                    window.setTimeout(() => setToast(null), 2800);
+                    return;
+                  }
+                  const pid = projectId ?? found.projectId;
+                  const proj =
+                    (pid
+                      ? projects.find((p) => p.id === pid) ?? null
+                      : null) ??
+                    (found.projectId
+                      ? projects.find((p) => p.id === found!.projectId) ?? null
+                      : null);
+                  setMainPane("chat");
+                  setAppView("workbench");
+                  await openSessionRef.current(found, proj);
+                })();
+              }}
+              onOpenProject={(projectId) => {
+                const id = (projectId || "").trim();
+                if (!id) return;
+                const proj = projects.find((p) => p.id === id) ?? null;
+                if (!proj) {
+                  setToast(tr("automations.inbox.projectMissing"));
+                  window.setTimeout(() => setToast(null), 2800);
+                  return;
+                }
+                setMainPane("chat");
+                setAppView("workbench");
+                setActiveProject(proj);
+                setExpandedProjects((e) => ({ ...e, [proj.id]: true }));
+              }}
             />
           ) : (
           <>

--- a/src/components/AutomationsPage.tsx
+++ b/src/components/AutomationsPage.tsx
@@ -23,12 +23,24 @@ import {
 import {
   AUTOMATION_RUN_HISTORY_CHANGE_EVENT,
   clearAutomationRunHistory,
-  countAutomationRunOutcomes,
-  filterAutomationRunHistory,
   loadAutomationRunHistory,
   type AutomationRunOutcomeFilter,
   type AutomationRunRecord,
 } from "@/lib/automationRunHistory";
+import {
+  buildAutomationsInbox,
+  clearInboxSeenIds,
+  countInboxByOutcome,
+  filterInbox,
+  loadInboxSeenIds,
+  markAllInboxRead,
+  markInboxItemRead,
+  planOpenInboxItem,
+  planRetryAutomation,
+  resolveInboxEmptyState,
+  type AutomationsInboxItem,
+} from "@/lib/automationsInbox";
+import { formatRelativeTime } from "@/lib/accountUi";
 import { Select } from "@/components/Select";
 import { GlassModal } from "@/components/GlassModal";
 import {
@@ -65,6 +77,15 @@ export interface AutomationsPageProps {
   models?: ModelOption[];
   onAiCreate: () => void;
   onRunNow?: (auto: Automation) => void;
+  /**
+   * Open a session linked from an Inbox row (when sessionId was observed).
+   * Soft — App resolves live session; may toast if missing.
+   */
+  onOpenSession?: (sessionId: string, projectId?: string | null) => void;
+  /** Focus a project when Inbox row has project but no session. */
+  onOpenProject?: (projectId: string) => void;
+  /** Locale for relative timestamps in Inbox (default: en). */
+  locale?: string;
   /** AppSettings.launchAtLogin — honest background status banner. */
   openAtLogin?: boolean;
   /** Deep-link to Settings → general/app → Launch at login. */
@@ -110,6 +131,9 @@ export function AutomationsPage({
   models,
   onAiCreate,
   onRunNow,
+  onOpenSession,
+  onOpenProject,
+  locale = "en",
   openAtLogin = false,
   onOpenLaunchAtLogin,
   closeToTray = true,
@@ -144,8 +168,13 @@ export function AutomationsPage({
   const [runHistory, setRunHistory] = useState<AutomationRunRecord[]>(() =>
     loadAutomationRunHistory(),
   );
-  const [runHistoryFilter, setRunHistoryFilter] =
+  /** Inbox filters (outcome chips + search) over the same observed ring. */
+  const [inboxOutcome, setInboxOutcome] =
     useState<AutomationRunOutcomeFilter>("all");
+  const [inboxQuery, setInboxQuery] = useState("");
+  const [inboxSeen, setInboxSeen] = useState<Set<string>>(() =>
+    loadInboxSeenIds(),
+  );
   const [clearHistoryOpen, setClearHistoryOpen] = useState(false);
   const createBtnRef = useRef<HTMLButtonElement>(null);
   const createMenuRef = useRef<HTMLDivElement>(null);
@@ -215,20 +244,90 @@ export function AutomationsPage({
     [list],
   );
 
-  const filteredRunHistory = useMemo(
-    () => filterAutomationRunHistory(runHistory, runHistoryFilter),
-    [runHistory, runHistoryFilter],
+  const inboxItems = useMemo(
+    () =>
+      buildAutomationsInbox(runHistory, {
+        seenIds: inboxSeen,
+        tasks: list.map((a) => ({
+          id: a.id,
+          projectId: a.projectId,
+          title: a.title,
+        })),
+      }),
+    [runHistory, inboxSeen, list],
   );
 
-  const runHistoryCounts = useMemo(
-    () => countAutomationRunOutcomes(runHistory),
-    [runHistory],
+  const filteredInbox = useMemo(
+    () =>
+      filterInbox(inboxItems, {
+        outcome: inboxOutcome,
+        query: inboxQuery,
+      }),
+    [inboxItems, inboxOutcome, inboxQuery],
+  );
+
+  const inboxCounts = useMemo(
+    () => countInboxByOutcome(inboxItems),
+    [inboxItems],
+  );
+
+  const inboxEmpty = useMemo(
+    () =>
+      resolveInboxEmptyState({
+        totalCount: inboxItems.length,
+        filteredCount: filteredInbox.length,
+        outcomeFilter: inboxOutcome,
+        query: inboxQuery,
+      }),
+    [inboxItems.length, filteredInbox.length, inboxOutcome, inboxQuery],
+  );
+
+  const unreadCount = useMemo(
+    () => inboxItems.filter((i) => i.unread).length,
+    [inboxItems],
   );
 
   const confirmClearHistory = () => {
     setRunHistory(clearAutomationRunHistory());
+    setInboxSeen(clearInboxSeenIds());
     setClearHistoryOpen(false);
   };
+
+  const onMarkInboxRead = useCallback((item: AutomationsInboxItem) => {
+    setInboxSeen(markInboxItemRead(item.id));
+  }, []);
+
+  const onMarkAllInboxRead = useCallback(() => {
+    setInboxSeen(markAllInboxRead(inboxItems.map((i) => i.id)));
+  }, [inboxItems]);
+
+  const onOpenInboxItem = useCallback(
+    (item: AutomationsInboxItem) => {
+      const plan = planOpenInboxItem(item);
+      if (plan.kind === "session") {
+        onOpenSession?.(plan.sessionId, plan.projectId ?? item.projectId);
+        onMarkInboxRead(item);
+        return;
+      }
+      if (plan.kind === "project") {
+        onOpenProject?.(plan.projectId);
+        onMarkInboxRead(item);
+      }
+    },
+    [onOpenSession, onOpenProject, onMarkInboxRead],
+  );
+
+  const onRetryInboxItem = useCallback(
+    (item: AutomationsInboxItem) => {
+      const plan = planRetryAutomation(item);
+      if (!plan.canRetry || !onRunNow) return;
+      const auto = list.find((a) => a.id === plan.taskId);
+      if (!auto) return;
+      onMarkInboxRead(item);
+      onRunNow(auto);
+    },
+    [list, onRunNow, onMarkInboxRead],
+  );
 
   const banner = useMemo(
     () =>
@@ -837,77 +936,111 @@ export function AutomationsPage({
         </div>
       </div>
 
-      {/* Observed fires only — empty is soft-fail, never invents offline runs */}
+      {/* Inbox: observed fires only — empty is soft-fail, never invents offline runs */}
       <div
-        className="auto-page__history"
+        className="auto-page__history auto-page__inbox"
         role="region"
-        aria-label={t("automations.history.section")}
+        aria-label={t("automations.inbox.section")}
       >
         <div className="auto-page__history-head">
           <div className="auto-page__history-titles">
             <div className="auto-page__history-title">
-              {t("automations.history.section")}
+              {t("automations.inbox.section")}
+              {unreadCount > 0 ? (
+                <span className="auto-page__inbox-unread" aria-label={t("automations.inbox.unreadCount", { n: unreadCount })}>
+                  {unreadCount}
+                </span>
+              ) : null}
             </div>
             <p className="auto-page__history-desc">
-              {t("automations.history.honesty")}
+              {t("automations.inbox.desc")}
             </p>
           </div>
-          {runHistory.length > 0 ? (
-            <button
-              type="button"
-              className="auto-page__bg-banner-link"
-              onClick={() => setClearHistoryOpen(true)}
-            >
-              {t("automations.history.clear")}
-            </button>
-          ) : null}
+          <div className="auto-page__inbox-head-actions">
+            {unreadCount > 0 ? (
+              <button
+                type="button"
+                className="auto-page__bg-banner-link"
+                onClick={onMarkAllInboxRead}
+              >
+                {t("automations.inbox.markAllRead")}
+              </button>
+            ) : null}
+            {runHistory.length > 0 ? (
+              <button
+                type="button"
+                className="auto-page__bg-banner-link"
+                onClick={() => setClearHistoryOpen(true)}
+              >
+                {t("automations.inbox.clear")}
+              </button>
+            ) : null}
+          </div>
         </div>
+
         <div
-          className="auto-page__history-filters"
-          role="tablist"
-          aria-label={t("automations.history.filterAria")}
+          className="auto-page__inbox-banner"
+          role="note"
         >
-          {(
-            [
-              ["all", "automations.history.filter.all"],
-              ["ok", "automations.history.filter.ok"],
-              ["error", "automations.history.filter.error"],
-              ["skipped", "automations.history.filter.skipped"],
-            ] as const
-          ).map(([id, key]) => (
-            <button
-              key={id}
-              type="button"
-              role="tab"
-              aria-selected={runHistoryFilter === id}
-              className={
-                "auto-page__filter" +
-                (runHistoryFilter === id ? " is-active" : "")
-              }
-              onClick={() => setRunHistoryFilter(id)}
-            >
-              {t(key)}
-              <span className="auto-page__history-count" aria-hidden>
-                {runHistoryCounts[id]}
-              </span>
-            </button>
-          ))}
+          {t("automations.inbox.processBound")}
         </div>
-        {filteredRunHistory.length === 0 ? (
+
+        <div className="auto-page__inbox-toolbar">
+          <div className="auto-page__search auto-page__inbox-search">
+            <IconSearch size={14} />
+            <input
+              type="search"
+              value={inboxQuery}
+              onChange={(e) => setInboxQuery(e.target.value)}
+              placeholder={t("automations.inbox.search")}
+              aria-label={t("automations.inbox.search")}
+            />
+          </div>
+          <div
+            className="auto-page__history-filters"
+            role="tablist"
+            aria-label={t("automations.inbox.filterAria")}
+          >
+            {(
+              [
+                ["all", "automations.history.filter.all"],
+                ["ok", "automations.history.filter.ok"],
+                ["error", "automations.history.filter.error"],
+                ["skipped", "automations.history.filter.skipped"],
+              ] as const
+            ).map(([id, key]) => (
+              <button
+                key={id}
+                type="button"
+                role="tab"
+                aria-selected={inboxOutcome === id}
+                className={
+                  "auto-page__filter" +
+                  (inboxOutcome === id ? " is-active" : "")
+                }
+                onClick={() => setInboxOutcome(id)}
+              >
+                {t(key)}
+                <span className="auto-page__history-count" aria-hidden>
+                  {inboxCounts[id]}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {inboxEmpty ? (
           <div className="auto-page__history-empty" role="status">
-            {runHistory.length === 0
-              ? t("automations.history.empty")
-              : t("automations.history.emptyFiltered")}
+            {inboxEmpty === "filter"
+              ? t("automations.inbox.emptyFiltered")
+              : inboxEmpty === "process_bound_hint"
+                ? t("automations.inbox.emptyProcessBound")
+                : t("automations.inbox.empty")}
           </div>
         ) : (
-          <ul className="auto-page__history-list">
-            {filteredRunHistory.map((row) => {
-              let when = row.at;
-              try {
-                when = new Date(row.at).toLocaleString();
-              } catch {
-                /* keep raw */
-              }
+          <ul className="auto-page__history-list auto-page__inbox-list">
+            {filteredInbox.map((row) => {
+              const when = formatRelativeTime(row.at, locale);
               const outcomeKey =
                 row.outcome === "ok"
                   ? "automations.history.outcome.ok"
@@ -920,16 +1053,19 @@ export function AutomationsPage({
                   : row.source === "run_now"
                     ? "automations.history.source.runNow"
                     : "automations.history.source.unknown";
+              const openPlan = planOpenInboxItem(row);
+              const retryPlan = planRetryAutomation(row);
               return (
                 <li
                   key={row.id}
                   className={
-                    "auto-page__history-row" +
+                    "auto-page__history-row auto-page__inbox-row" +
                     (row.outcome === "error"
                       ? " auto-page__history-row--error"
                       : row.outcome === "skipped"
                         ? " auto-page__history-row--skipped"
-                        : "")
+                        : "") +
+                    (row.unread ? " auto-page__inbox-row--unread" : "")
                   }
                 >
                   <span
@@ -941,17 +1077,62 @@ export function AutomationsPage({
                     {t(outcomeKey)}
                   </span>
                   <div className="auto-page__history-main">
-                    <span className="auto-page__history-name">{row.name}</span>
+                    <span className="auto-page__history-name">
+                      {row.unread ? (
+                        <span
+                          className="auto-page__inbox-dot"
+                          aria-hidden
+                        />
+                      ) : null}
+                      {row.title}
+                    </span>
                     <span className="auto-page__history-meta">
-                      {when}
+                      <time dateTime={row.at} title={row.at}>
+                        {when}
+                      </time>
                       {" · "}
                       {t(sourceKey)}
                     </span>
                     {row.outcome === "error" && row.error ? (
-                      <span className="auto-page__history-error" title={row.error}>
+                      <span
+                        className="auto-page__history-error"
+                        title={row.error}
+                      >
                         {row.error}
                       </span>
                     ) : null}
+                    <div className="auto-page__inbox-actions">
+                      {openPlan.kind !== "none" &&
+                      (onOpenSession || onOpenProject) ? (
+                        <button
+                          type="button"
+                          className="auto-page__inbox-action"
+                          onClick={() => onOpenInboxItem(row)}
+                        >
+                          {openPlan.kind === "session"
+                            ? t("automations.inbox.openSession")
+                            : t("automations.inbox.openProject")}
+                        </button>
+                      ) : null}
+                      {retryPlan.canRetry && onRunNow ? (
+                        <button
+                          type="button"
+                          className="auto-page__inbox-action"
+                          onClick={() => onRetryInboxItem(row)}
+                        >
+                          {t("automations.inbox.runNow")}
+                        </button>
+                      ) : null}
+                      {row.unread ? (
+                        <button
+                          type="button"
+                          className="auto-page__inbox-action"
+                          onClick={() => onMarkInboxRead(row)}
+                        >
+                          {t("automations.inbox.markRead")}
+                        </button>
+                      ) : null}
+                    </div>
                   </div>
                 </li>
               );
@@ -1179,7 +1360,7 @@ export function AutomationsPage({
       <GlassModal
         open={clearHistoryOpen}
         onClose={() => setClearHistoryOpen(false)}
-        title={t("automations.history.clearTitle")}
+        title={t("automations.inbox.clearTitle")}
         size="sm"
         closeLabel={t("common.close")}
         footer={
@@ -1196,14 +1377,14 @@ export function AutomationsPage({
               className="btn btn--danger"
               onClick={confirmClearHistory}
             >
-              {t("automations.history.clearConfirm")}
+              {t("automations.inbox.clearConfirm")}
             </button>
           </>
         }
       >
-        <p className="app-dialog__msg">{t("automations.history.clearBody")}</p>
+        <p className="app-dialog__msg">{t("automations.inbox.clearBody")}</p>
         <p className="app-dialog__msg app-dialog__msg--muted">
-          {t("automations.history.honesty")}
+          {t("automations.inbox.processBound")}
         </p>
       </GlassModal>
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -5072,6 +5072,32 @@ const en = {
   "automations.history.clearBody":
     "Removes the local observed run list on this device. This cannot be undone. Schedules themselves are unchanged.",
   "automations.history.clearConfirm": "Clear",
+  "automations.inbox.section": "Inbox",
+  "automations.inbox.desc":
+    "Review queue for schedule runs observed in this process. Open the linked session when known, retry when the task still exists, or mark items read.",
+  "automations.inbox.processBound":
+    "Runs are recorded only while Grok App is open or in the tray. Full Quit does not invent offline runs — empty Inbox after relaunch is normal until something fires.",
+  "automations.inbox.search": "Search inbox",
+  "automations.inbox.filterAria": "Filter inbox by outcome",
+  "automations.inbox.empty": "No inbox items.",
+  "automations.inbox.emptyFiltered": "No runs match this filter or search.",
+  "automations.inbox.emptyProcessBound":
+    "No observed runs yet. History fills when a schedule fires in this process or you use Run now — never after Quit offline.",
+  "automations.inbox.openSession": "Open session",
+  "automations.inbox.openProject": "Open project",
+  "automations.inbox.runNow": "Run now",
+  "automations.inbox.markRead": "Mark read",
+  "automations.inbox.markAllRead": "Mark all read",
+  "automations.inbox.clear": "Clear inbox",
+  "automations.inbox.clearTitle": "Clear inbox history?",
+  "automations.inbox.clearBody":
+    "Removes the local observed run list and read markers on this device. This cannot be undone. Schedules themselves are unchanged.",
+  "automations.inbox.clearConfirm": "Clear",
+  "automations.inbox.unreadCount": "{n} unread",
+  "automations.inbox.sessionMissing":
+    "That session is no longer available. It may have been deleted after the run.",
+  "automations.inbox.projectMissing":
+    "That project is no longer available.",
   "automations.oneshot.title": "One-shot schedule fire",
   "automations.oneshot.desc":
     "Tray residency keeps continuous ticks while the process is alive. After full Quit, invoke {flag} (helper script {script} under app data) to fire at most one due task without opening the full UI, then exit.",
@@ -11007,6 +11033,31 @@ const zh: Record<MessageKey, string> = {
   "automations.history.clearBody":
     "将删除本机已观察到的运行列表，且无法撤销。已安排任务本身不受影响。",
   "automations.history.clearConfirm": "清空",
+  "automations.inbox.section": "收件箱",
+  "automations.inbox.desc":
+    "本进程内观察到的调度运行审阅队列。可在已知时打开关联会话、在任务仍存在时重试，或标记已读。",
+  "automations.inbox.processBound":
+    "仅在 Grok 应用打开或收起到托盘期间记录运行。完全退出后不会虚构离线运行——重新打开后若尚未触发，收件箱为空是正常的。",
+  "automations.inbox.search": "搜索收件箱",
+  "automations.inbox.filterAria": "按结果筛选收件箱",
+  "automations.inbox.empty": "暂无收件箱条目。",
+  "automations.inbox.emptyFiltered": "没有匹配该筛选或搜索的运行。",
+  "automations.inbox.emptyProcessBound":
+    "暂无观察到的运行。当本进程内调度触发或你使用「立即运行」时会写入——完全退出后的离线触发不会出现。",
+  "automations.inbox.openSession": "打开会话",
+  "automations.inbox.openProject": "打开项目",
+  "automations.inbox.runNow": "立即运行",
+  "automations.inbox.markRead": "标为已读",
+  "automations.inbox.markAllRead": "全部标为已读",
+  "automations.inbox.clear": "清空收件箱",
+  "automations.inbox.clearTitle": "清空收件箱历史？",
+  "automations.inbox.clearBody":
+    "将删除本机已观察到的运行列表与已读标记，且无法撤销。已安排任务本身不受影响。",
+  "automations.inbox.clearConfirm": "清空",
+  "automations.inbox.unreadCount": "{n} 条未读",
+  "automations.inbox.sessionMissing":
+    "该会话已不存在，可能在运行后被删除。",
+  "automations.inbox.projectMissing": "该项目已不存在。",
   "automations.oneshot.title": "一次性触发已安排任务",
   "automations.oneshot.desc":
     "托盘驻留可在进程存活期间持续检查。完全退出后，可用 {flag}（应用数据目录中的助手脚本 {script}）最多触发一个到期任务（无需完整交互界面），然后退出。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -4863,6 +4863,31 @@ export const zhTW: Record<MessageKey, string> = {
   "automations.history.clearBody":
     "將刪除本機已觀察到的執行列表，且無法復原。已排程任務本身不受影響。",
   "automations.history.clearConfirm": "清除",
+  "automations.inbox.section": "收件匣",
+  "automations.inbox.desc":
+    "本行程內觀察到的排程執行審閱佇列。可在已知時開啟關聯對話、在任務仍存在時重試，或標記已讀。",
+  "automations.inbox.processBound":
+    "僅在 Grok 應用開啟或收起到系統匣期間記錄執行。完全結束後不會虛構離線執行——重新開啟後若尚未觸發，收件匣為空是正常的。",
+  "automations.inbox.search": "搜尋收件匣",
+  "automations.inbox.filterAria": "依結果篩選收件匣",
+  "automations.inbox.empty": "暫無收件匣項目。",
+  "automations.inbox.emptyFiltered": "沒有符合此篩選或搜尋的執行。",
+  "automations.inbox.emptyProcessBound":
+    "尚無觀察到的執行。當本行程內排程觸發或你使用「立即執行」時會寫入——完全結束後的離線觸發不會出現。",
+  "automations.inbox.openSession": "開啟對話",
+  "automations.inbox.openProject": "開啟專案",
+  "automations.inbox.runNow": "立即執行",
+  "automations.inbox.markRead": "標為已讀",
+  "automations.inbox.markAllRead": "全部標為已讀",
+  "automations.inbox.clear": "清除收件匣",
+  "automations.inbox.clearTitle": "清除收件匣歷史？",
+  "automations.inbox.clearBody":
+    "將刪除本機已觀察到的執行列表與已讀標記，且無法復原。已排程任務本身不受影響。",
+  "automations.inbox.clearConfirm": "清除",
+  "automations.inbox.unreadCount": "{n} 則未讀",
+  "automations.inbox.sessionMissing":
+    "該對話已不存在，可能在執行後被刪除。",
+  "automations.inbox.projectMissing": "該專案已不存在。",
   "automations.oneshot.title": "一次性觸發已排程任務",
   "automations.oneshot.desc":
     "系統匣駐留可在行程存活期間持續檢查。完全結束後，可用 {flag}（應用資料目錄中的助手腳本 {script}）最多觸發一個到期任務（無需完整互動介面），然後退出。",

--- a/src/lib/automationRunHistory.test.ts
+++ b/src/lib/automationRunHistory.test.ts
@@ -71,6 +71,16 @@ describe("parseAutomationRunRecord", () => {
     expect(e?.source).toBe("unknown");
     expect(e?.error).toBeUndefined();
   });
+
+  it("keeps optional sessionId / projectId when present", () => {
+    const e = parseAutomationRunRecord({
+      ...base,
+      sessionId: "sess-1",
+      project_id: "proj-9",
+    });
+    expect(e?.sessionId).toBe("sess-1");
+    expect(e?.projectId).toBe("proj-9");
+  });
 });
 
 describe("redactAutomationRunError", () => {

--- a/src/lib/automationRunHistory.ts
+++ b/src/lib/automationRunHistory.ts
@@ -30,6 +30,13 @@ export type AutomationRunRecord = {
   error?: string | null;
   /** How this row was observed. */
   source: AutomationRunSource;
+  /**
+   * Session created for this fire when known (host runner / Run now).
+   * Soft optional — never invented after Quit.
+   */
+  sessionId?: string | null;
+  /** Project the schedule was bound to when known. */
+  projectId?: string | null;
 };
 
 export type AutomationRunOutcomeFilter = "all" | AutomationRunOutcome;
@@ -136,6 +143,15 @@ export function parseAutomationRunRecord(raw: unknown): AutomationRunRecord | nu
   const error =
     outcome === "error" ? redactAutomationRunError(o.error ?? o.detail) : null;
 
+  const sessionId = scrub(
+    o.sessionId ?? o.session_id,
+    AUTOMATION_RUN_ID_MAX,
+  );
+  const projectId = scrub(
+    o.projectId ?? o.project_id,
+    AUTOMATION_RUN_ID_MAX,
+  );
+
   return {
     id,
     scheduleId,
@@ -144,6 +160,8 @@ export function parseAutomationRunRecord(raw: unknown): AutomationRunRecord | nu
     outcome,
     source,
     ...(error ? { error } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(projectId ? { projectId } : {}),
   };
 }
 
@@ -244,11 +262,15 @@ export function recordAutomationRun(
     error?: unknown;
     source?: AutomationRunSource;
     id?: string;
+    sessionId?: string | null;
+    projectId?: string | null;
   },
   storage: AutomationRunHistoryStorage = defaultStorage(),
   max = AUTOMATION_RUN_HISTORY_MAX,
 ): AutomationRunRecord[] {
   const name = (input.name ?? input.title ?? "").toString();
+  const sessionId = scrub(input.sessionId, AUTOMATION_RUN_ID_MAX);
+  const projectId = scrub(input.projectId, AUTOMATION_RUN_ID_MAX);
   const entry: AutomationRunRecord = {
     id: input.id || newAutomationRunId(),
     scheduleId: (input.scheduleId ?? "").toString(),
@@ -259,6 +281,8 @@ export function recordAutomationRun(
     ...(input.outcome === "error"
       ? { error: redactAutomationRunError(input.error) }
       : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(projectId ? { projectId } : {}),
   };
   const next = pushAutomationRun(
     loadAutomationRunHistory(storage, max),

--- a/src/lib/automationsInbox.test.ts
+++ b/src/lib/automationsInbox.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import type { AutomationRunRecord } from "./automationRunHistory";
+import {
+  buildAutomationsInbox,
+  clearInboxSeenIds,
+  countInboxByOutcome,
+  filterInbox,
+  isInboxItemUnread,
+  loadInboxSeenIds,
+  markAllInboxRead,
+  markInboxItemRead,
+  parseInboxSeenIds,
+  planOpenInboxItem,
+  planRetryAutomation,
+  resolveInboxEmptyState,
+  type AutomationsInboxStorage,
+} from "./automationsInbox";
+
+function memStorage(seed?: string): AutomationsInboxStorage {
+  let val: string | null = seed ?? null;
+  return {
+    getItem: () => val,
+    setItem: (_k, v) => {
+      val = v;
+    },
+  };
+}
+
+const base: AutomationRunRecord = {
+  id: "ar-1",
+  scheduleId: "sched-1",
+  name: "Morning digest",
+  at: "2026-07-31T12:00:00.000Z",
+  outcome: "ok",
+  source: "host",
+};
+
+describe("buildAutomationsInbox", () => {
+  it("maps history to display fields and never invents rows", () => {
+    expect(buildAutomationsInbox([])).toEqual([]);
+    expect(buildAutomationsInbox(undefined as unknown as [])).toEqual([]);
+
+    const items = buildAutomationsInbox([
+      {
+        ...base,
+        sessionId: "sess-9",
+        projectId: "proj-1",
+        error: "should-drop-on-ok",
+      } as AutomationRunRecord & { sessionId: string; projectId: string },
+      {
+        id: "ar-2",
+        scheduleId: "sched-2",
+        name: "Fail job",
+        at: "2026-07-31T11:00:00.000Z",
+        outcome: "error",
+        source: "run_now",
+        error: "connect failed",
+      },
+    ]);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      id: "ar-1",
+      title: "Morning digest",
+      outcome: "ok",
+      sessionId: "sess-9",
+      projectId: "proj-1",
+      error: null,
+      unread: true,
+      taskExists: false,
+    });
+    expect(items[1]).toMatchObject({
+      id: "ar-2",
+      error: "connect failed",
+      unread: true,
+    });
+  });
+
+  it("joins taskExists / projectId from live tasks and respects seen set", () => {
+    const items = buildAutomationsInbox([base], {
+      seenIds: ["ar-1"],
+      tasks: [{ id: "sched-1", projectId: "p-live", title: "Live" }],
+    });
+    expect(items[0].unread).toBe(false);
+    expect(items[0].taskExists).toBe(true);
+    expect(items[0].projectId).toBe("p-live");
+  });
+
+  it("trackUnread false forces unread=false", () => {
+    const items = buildAutomationsInbox([base], { trackUnread: false });
+    expect(items[0].unread).toBe(false);
+  });
+});
+
+describe("filterInbox / countInboxByOutcome", () => {
+  const items = buildAutomationsInbox([
+    base,
+    {
+      id: "ar-2",
+      scheduleId: "s2",
+      name: "Nightly",
+      at: "t",
+      outcome: "error",
+      source: "host",
+      error: "boom secret",
+    },
+    {
+      id: "ar-3",
+      scheduleId: "s3",
+      name: "Busy",
+      at: "t",
+      outcome: "skipped",
+      source: "run_now",
+    },
+  ]);
+
+  it("filters by outcome and query", () => {
+    expect(filterInbox(items, { outcome: "error" })).toHaveLength(1);
+    expect(filterInbox(items, { query: "night" })[0].id).toBe("ar-2");
+    expect(filterInbox(items, { query: "boom" })).toHaveLength(1);
+    expect(filterInbox(items, { outcome: "ok", query: "night" })).toHaveLength(
+      0,
+    );
+    expect(filterInbox(items, { outcome: "all", query: "  " })).toHaveLength(3);
+  });
+
+  it("counts outcomes", () => {
+    expect(countInboxByOutcome(items)).toEqual({
+      all: 3,
+      ok: 1,
+      error: 1,
+      skipped: 1,
+    });
+  });
+});
+
+describe("resolveInboxEmptyState", () => {
+  it("process_bound_hint when nothing observed", () => {
+    expect(
+      resolveInboxEmptyState({ totalCount: 0, filteredCount: 0 }),
+    ).toBe("process_bound_hint");
+  });
+
+  it("filter when chips/query hide all rows", () => {
+    expect(
+      resolveInboxEmptyState({
+        totalCount: 3,
+        filteredCount: 0,
+        outcomeFilter: "error",
+      }),
+    ).toBe("filter");
+    expect(
+      resolveInboxEmptyState({
+        totalCount: 3,
+        filteredCount: 0,
+        query: "zzz",
+      }),
+    ).toBe("filter");
+  });
+
+  it("null when filtered list has rows", () => {
+    expect(
+      resolveInboxEmptyState({ totalCount: 2, filteredCount: 1 }),
+    ).toBeNull();
+  });
+
+  it("empty fallback when total>0 but no active filter", () => {
+    expect(
+      resolveInboxEmptyState({
+        totalCount: 2,
+        filteredCount: 0,
+        outcomeFilter: "all",
+        query: "",
+      }),
+    ).toBe("empty");
+  });
+});
+
+describe("planOpenInboxItem / planRetryAutomation", () => {
+  it("prefers session, then project, else none", () => {
+    expect(
+      planOpenInboxItem({ sessionId: "s1", projectId: "p1" }),
+    ).toEqual({ kind: "session", sessionId: "s1", projectId: "p1" });
+    expect(planOpenInboxItem({ sessionId: "s1", projectId: null })).toEqual({
+      kind: "session",
+      sessionId: "s1",
+    });
+    expect(planOpenInboxItem({ sessionId: null, projectId: "p1" })).toEqual({
+      kind: "project",
+      projectId: "p1",
+    });
+    expect(planOpenInboxItem({ sessionId: null, projectId: null })).toEqual({
+      kind: "none",
+    });
+    expect(planOpenInboxItem(null)).toEqual({ kind: "none" });
+  });
+
+  it("retry only when taskId present and task still exists", () => {
+    expect(
+      planRetryAutomation({ scheduleId: "sched-1", taskExists: true }),
+    ).toEqual({ canRetry: true, taskId: "sched-1" });
+    expect(
+      planRetryAutomation({ scheduleId: "sched-1", taskExists: false }),
+    ).toEqual({ canRetry: false, reason: "task_missing" });
+    expect(
+      planRetryAutomation({ scheduleId: "", taskExists: true }),
+    ).toEqual({ canRetry: false, reason: "no_task_id" });
+    expect(planRetryAutomation(null)).toEqual({
+      canRetry: false,
+      reason: "no_task_id",
+    });
+  });
+});
+
+describe("seen / mark-read helpers", () => {
+  it("loads, marks one, marks all, clears", () => {
+    const storage = memStorage();
+    expect(loadInboxSeenIds(storage).size).toBe(0);
+    expect(isInboxItemUnread("ar-1", new Set())).toBe(true);
+
+    let seen = markInboxItemRead("ar-1", storage);
+    expect(seen.has("ar-1")).toBe(true);
+    expect(isInboxItemUnread("ar-1", seen)).toBe(false);
+
+    seen = markAllInboxRead(["ar-1", "ar-2", "  "], storage);
+    expect(seen.has("ar-2")).toBe(true);
+    expect(loadInboxSeenIds(storage).size).toBe(2);
+
+    clearInboxSeenIds(storage);
+    expect(loadInboxSeenIds(storage).size).toBe(0);
+  });
+
+  it("soft-fails corrupt seen storage", () => {
+    expect(parseInboxSeenIds("{not json")).toEqual(new Set());
+    expect(parseInboxSeenIds(null)).toEqual(new Set());
+    expect(parseInboxSeenIds(["a", 1, "b"])).toEqual(new Set(["a", "b"]));
+  });
+});

--- a/src/lib/automationsInbox.ts
+++ b/src/lib/automationsInbox.ts
@@ -1,0 +1,380 @@
+/**
+ * Automations Inbox — review queue over observed schedule run history.
+ *
+ * Pure helpers only. Built on `automationRunHistory` (process-bound ring).
+ * Never invents offline runs; empty is a soft-fail honesty state.
+ */
+
+import {
+  parseAutomationRunHistory,
+  type AutomationRunOutcome,
+  type AutomationRunOutcomeFilter,
+  type AutomationRunRecord,
+  type AutomationRunSource,
+} from "./automationRunHistory";
+
+/** localStorage key for ids the user has marked read in the Inbox. */
+export const AUTOMATIONS_INBOX_SEEN_STORAGE_KEY = "grok.automationsInboxSeen";
+
+/** Cap seen-id set growth (ring history is already ~50). */
+export const AUTOMATIONS_INBOX_SEEN_MAX = 200;
+
+export type AutomationsInboxItem = {
+  id: string;
+  /** Schedule / task id when known (may be empty). */
+  scheduleId: string;
+  /** Display title (name at fire time). */
+  title: string;
+  /** ISO-8601 timestamp. */
+  at: string;
+  outcome: AutomationRunOutcome;
+  source: AutomationRunSource;
+  /** Redacted error snippet when outcome === "error". */
+  error: string | null;
+  sessionId: string | null;
+  projectId: string | null;
+  /** True when id is not in the optional seen set. */
+  unread: boolean;
+  /**
+   * Soft: schedule still present in the current tasks list.
+   * Used only for Retry / Run now CTA — never invents a missing task.
+   */
+  taskExists: boolean;
+};
+
+export type AutomationsInboxTaskRef = {
+  id: string;
+  projectId?: string | null;
+  title?: string | null;
+};
+
+export type BuildAutomationsInboxOpts = {
+  /** Ids already marked read. Missing / empty → all unread when trackUnread. */
+  seenIds?: Iterable<string> | ReadonlySet<string> | null;
+  /**
+   * Current scheduled tasks (for taskExists + projectId fallback).
+   * Soft join only — never invents history rows.
+   */
+  tasks?: ReadonlyArray<AutomationsInboxTaskRef> | null;
+  /**
+   * When false, every item has unread=false (no mark-read UX).
+   * Default true.
+   */
+  trackUnread?: boolean;
+};
+
+export type FilterInboxOpts = {
+  outcome?: AutomationRunOutcomeFilter;
+  query?: string | null;
+};
+
+export type AutomationsInboxEmptyState =
+  | "empty"
+  | "filter"
+  | "process_bound_hint";
+
+export type PlanOpenInboxItem =
+  | { kind: "session"; sessionId: string; projectId?: string }
+  | { kind: "project"; projectId: string }
+  | { kind: "none" };
+
+export type PlanRetryAutomation =
+  | { canRetry: true; taskId: string }
+  | { canRetry: false; reason: "no_task_id" | "task_missing" };
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface AutomationsInboxStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): AutomationsInboxStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return { getItem: () => null, setItem: () => {} };
+}
+
+function scrubId(raw: unknown, max = 120): string {
+  if (typeof raw !== "string") return "";
+  return raw.replace(/[\u0000-\u001f]/g, "").trim().slice(0, max);
+}
+
+function toSeenSet(
+  seenIds?: Iterable<string> | ReadonlySet<string> | null,
+): Set<string> {
+  if (!seenIds) return new Set();
+  if (seenIds instanceof Set) {
+    const out = new Set<string>();
+    for (const id of seenIds) {
+      const s = scrubId(id);
+      if (s) out.add(s);
+    }
+    return out;
+  }
+  const out = new Set<string>();
+  for (const id of seenIds) {
+    const s = scrubId(id);
+    if (s) out.add(s);
+  }
+  return out;
+}
+
+function tasksById(
+  tasks?: ReadonlyArray<AutomationsInboxTaskRef> | null,
+): Map<string, AutomationsInboxTaskRef> {
+  const map = new Map<string, AutomationsInboxTaskRef>();
+  if (!tasks) return map;
+  for (const t of tasks) {
+    const id = scrubId(t?.id);
+    if (!id) continue;
+    map.set(id, t);
+  }
+  return map;
+}
+
+/**
+ * Build Inbox rows from observed run history (newest first).
+ * Soft-fails corrupt history to []. Never invents offline fires.
+ */
+export function buildAutomationsInbox(
+  history: readonly AutomationRunRecord[] | unknown,
+  opts: BuildAutomationsInboxOpts = {},
+): AutomationsInboxItem[] {
+  const cleaned = parseAutomationRunHistory(history);
+  const seen = toSeenSet(opts.seenIds);
+  const trackUnread = opts.trackUnread !== false;
+  const taskMap = tasksById(opts.tasks);
+
+  return cleaned.map((row) => {
+    const scheduleId = scrubId(row.scheduleId);
+    const task = scheduleId ? taskMap.get(scheduleId) : undefined;
+    const sessionId = scrubId(row.sessionId);
+    const fromRow = scrubId(row.projectId);
+    const fromTask = scrubId(task?.projectId ?? "");
+    const projectId = fromRow || fromTask || "";
+
+    return {
+      id: row.id,
+      scheduleId,
+      title: row.name || scheduleId || "automation",
+      at: row.at,
+      outcome: row.outcome,
+      source: row.source,
+      error: row.error ?? null,
+      sessionId: sessionId || null,
+      projectId: projectId || null,
+      unread: trackUnread ? !seen.has(row.id) : false,
+      taskExists: !!task,
+    };
+  });
+}
+
+/**
+ * Filter Inbox items by outcome chip and free-text query (title / error / id).
+ */
+export function filterInbox(
+  items: readonly AutomationsInboxItem[],
+  opts: FilterInboxOpts = {},
+): AutomationsInboxItem[] {
+  const outcome = opts.outcome ?? "all";
+  const q = (opts.query ?? "").trim().toLowerCase();
+
+  return items.filter((item) => {
+    if (outcome !== "all" && item.outcome !== outcome) return false;
+    if (!q) return true;
+    const hay = [
+      item.title,
+      item.error ?? "",
+      item.scheduleId,
+      item.id,
+      item.sessionId ?? "",
+      item.projectId ?? "",
+      item.outcome,
+      item.source,
+    ]
+      .join(" ")
+      .toLowerCase();
+    return hay.includes(q);
+  });
+}
+
+/** Counts per outcome for chip labels (from unfiltered Inbox items). */
+export function countInboxByOutcome(
+  items: readonly AutomationsInboxItem[],
+): Record<AutomationRunOutcomeFilter, number> {
+  const counts: Record<AutomationRunOutcomeFilter, number> = {
+    all: items.length,
+    ok: 0,
+    error: 0,
+    skipped: 0,
+  };
+  for (const e of items) {
+    counts[e.outcome] += 1;
+  }
+  return counts;
+}
+
+/**
+ * Empty-state kind for the Inbox list.
+ * - process_bound_hint: no observed runs (honest empty; process-bound)
+ * - filter: history exists but chips/query match nothing
+ * - empty: soft fallback
+ * Returns null when the filtered list is non-empty.
+ */
+export function resolveInboxEmptyState(input: {
+  totalCount: number;
+  filteredCount: number;
+  outcomeFilter?: AutomationRunOutcomeFilter;
+  query?: string | null;
+}): AutomationsInboxEmptyState | null {
+  const total =
+    typeof input.totalCount === "number" && Number.isFinite(input.totalCount)
+      ? Math.max(0, Math.floor(input.totalCount))
+      : 0;
+  const filtered =
+    typeof input.filteredCount === "number" &&
+    Number.isFinite(input.filteredCount)
+      ? Math.max(0, Math.floor(input.filteredCount))
+      : 0;
+
+  if (filtered > 0) return null;
+  if (total === 0) return "process_bound_hint";
+
+  const q = (input.query ?? "").trim();
+  const f = input.outcomeFilter ?? "all";
+  if (q || f !== "all") return "filter";
+  return "empty";
+}
+
+/**
+ * Plan navigation for an Inbox row.
+ * Prefers linked session when known; else project; else none.
+ * Soft — never invents ids.
+ */
+export function planOpenInboxItem(
+  item: Pick<AutomationsInboxItem, "sessionId" | "projectId"> | null | undefined,
+): PlanOpenInboxItem {
+  if (!item) return { kind: "none" };
+  const sessionId = scrubId(item.sessionId);
+  const projectId = scrubId(item.projectId);
+  if (sessionId) {
+    return projectId
+      ? { kind: "session", sessionId, projectId }
+      : { kind: "session", sessionId };
+  }
+  if (projectId) return { kind: "project", projectId };
+  return { kind: "none" };
+}
+
+/**
+ * Soft retry plan: only when scheduleId is present **and** the task still exists.
+ * UI must call existing run-now with the live task — never invent a payload.
+ */
+export function planRetryAutomation(
+  item:
+    | Pick<AutomationsInboxItem, "scheduleId" | "taskExists">
+    | null
+    | undefined,
+): PlanRetryAutomation {
+  if (!item) return { canRetry: false, reason: "no_task_id" };
+  const taskId = scrubId(item.scheduleId);
+  if (!taskId) return { canRetry: false, reason: "no_task_id" };
+  if (!item.taskExists) return { canRetry: false, reason: "task_missing" };
+  return { canRetry: true, taskId };
+}
+
+/** Parse stored JSON array of seen run ids. Soft-fails to empty Set. */
+export function parseInboxSeenIds(raw: unknown): Set<string> {
+  if (raw == null || raw === "") return new Set();
+  let value: unknown = raw;
+  if (typeof raw === "string") {
+    const t = raw.trim();
+    if (!t) return new Set();
+    try {
+      value = JSON.parse(t);
+    } catch {
+      return new Set();
+    }
+  }
+  if (!Array.isArray(value)) return new Set();
+  const out = new Set<string>();
+  for (const item of value) {
+    const id = scrubId(item);
+    if (id) out.add(id);
+    if (out.size >= AUTOMATIONS_INBOX_SEEN_MAX) break;
+  }
+  return out;
+}
+
+export function loadInboxSeenIds(
+  storage: AutomationsInboxStorage = defaultStorage(),
+): Set<string> {
+  try {
+    return parseInboxSeenIds(
+      storage.getItem(AUTOMATIONS_INBOX_SEEN_STORAGE_KEY),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveInboxSeenIds(
+  ids: Iterable<string>,
+  storage: AutomationsInboxStorage = defaultStorage(),
+): Set<string> {
+  const unique = new Set<string>();
+  for (const item of ids) {
+    const id = scrubId(item);
+    if (id) unique.add(id);
+    if (unique.size >= AUTOMATIONS_INBOX_SEEN_MAX) break;
+  }
+  // Keep a stable newest-ish order: insertion order of the Set as given.
+  const list = Array.from(unique).slice(-AUTOMATIONS_INBOX_SEEN_MAX);
+  try {
+    storage.setItem(AUTOMATIONS_INBOX_SEEN_STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    /* private mode / quota */
+  }
+  return new Set(list);
+}
+
+/** Mark one Inbox row read. Returns updated seen set. */
+export function markInboxItemRead(
+  id: string | null | undefined,
+  storage: AutomationsInboxStorage = defaultStorage(),
+): Set<string> {
+  const sid = scrubId(id);
+  if (!sid) return loadInboxSeenIds(storage);
+  const next = loadInboxSeenIds(storage);
+  next.add(sid);
+  return saveInboxSeenIds(next, storage);
+}
+
+/** Mark every provided id read (mark-all). Returns updated seen set. */
+export function markAllInboxRead(
+  itemIds: Iterable<string>,
+  storage: AutomationsInboxStorage = defaultStorage(),
+): Set<string> {
+  const next = loadInboxSeenIds(storage);
+  for (const raw of itemIds) {
+    const id = scrubId(raw);
+    if (id) next.add(id);
+  }
+  return saveInboxSeenIds(next, storage);
+}
+
+/** Whether a run id is still unread given a seen set. */
+export function isInboxItemUnread(
+  id: string | null | undefined,
+  seenIds: Iterable<string> | ReadonlySet<string> | null | undefined,
+): boolean {
+  const sid = scrubId(id);
+  if (!sid) return false;
+  return !toSeenSet(seenIds).has(sid);
+}
+
+/** Wipe seen markers (e.g. after clear history). Soft no-op on failure. */
+export function clearInboxSeenIds(
+  storage: AutomationsInboxStorage = defaultStorage(),
+): Set<string> {
+  return saveInboxSeenIds([], storage);
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17902,6 +17902,108 @@ textarea::-webkit-scrollbar-thumb:active,
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
 }
 
+/* Automations Inbox (review queue over observed run history) */
+.auto-page__inbox-head-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.auto-page__inbox-unread {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 6px;
+  min-width: 1.25rem;
+  height: 1.15rem;
+  padding: 0 5px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  background: color-mix(in srgb, var(--accent, #5b8def) 22%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent, #5b8def) 35%, transparent);
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.auto-page__inbox-banner {
+  padding: 7px 9px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--accent, #5b8def) 22%, transparent);
+  background: color-mix(in srgb, var(--accent, #5b8def) 8%, transparent);
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.auto-page__inbox-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.auto-page__inbox-search {
+  max-width: 100%;
+}
+
+.auto-page__inbox-search input {
+  font-size: 12.5px;
+}
+
+.auto-page__inbox-row--unread {
+  border-color: color-mix(in srgb, var(--accent, #5b8def) 28%, transparent);
+  background: color-mix(in srgb, var(--accent, #5b8def) 6%, transparent);
+}
+
+.auto-page__inbox-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: var(--accent, #5b8def);
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.auto-page__inbox-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  margin-top: 4px;
+}
+
+.auto-page__inbox-action {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 550;
+  line-height: 1.4;
+  color: var(--accent, #5b8def);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.auto-page__inbox-action:hover {
+  text-decoration: underline;
+}
+
+.auto-page__inbox-action:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent, #5b8def) 55%, transparent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
 .app-dialog__msg--muted {
   opacity: 0.88;
   font-size: 12.5px;


### PR DESCRIPTION
## Summary
- Pure `automationsInbox` helpers: build / filter / outcome counts / empty states / open plan / soft retry / mark-read (localStorage seen ids)
- Automations page **Inbox** over observed run history: chips, search, unread, open session/project when known, Run now if task still exists, clear via GlassModal
- Optional `sessionId` / `projectId` on run records (host + Run now); process-bound honesty banner — never invents offline runs

## Test plan
- [x] `pnpm test -- src/lib/automationsInbox.test.ts src/lib/automationRunHistory.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: open Scheduled → Inbox empty state shows process-bound copy
- [ ] Manual: Run now → row appears; Mark read / Mark all; Open session when linked; Run now CTA only if task still listed
- [ ] Manual: Clear inbox → GlassModal (no `window.confirm`); history wiped, unread markers cleared