### PR TITLE
feat(settings): sandbox profile wizard on project trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Sandbox profile wizard on project trust**: after trusting a project (when the global profile is still Off), optional GlassModal guide recommends **Workspace** for daily use, lets pick off / workspace / read-only / strict / devbox (danger note on off/devbox), and applies via Settings. Settings → sandbox row shows “Recommended for daily use” + **Open sandbox guide**. Windows / old-CLI honesty banners (soft-fail). Soft localStorage dismiss. Pure `sandboxWizard` helpers + tests; en/zh/zh-TW; no `window.confirm`.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -307,12 +307,20 @@ import {
 import * as api from "@/lib/api";
 import {
   SANDBOX_PROFILES,
+  cliSupportsSandbox,
   isDangerousSandboxProfile,
   normalizeSandboxProfile,
   sandboxDangerConfirmKey,
   sandboxProfileLabelKey,
   type SandboxProfileId,
 } from "@/lib/sandboxProfile";
+import { SandboxWizard } from "@/components/SandboxWizard";
+import {
+  loadSandboxWizardDismissed,
+  markSandboxWizardDismissed,
+  shouldOfferSandboxWizard,
+  type SandboxWizardMode,
+} from "@/lib/sandboxWizard";
 import { shouldRestoreLastSession } from "@/lib/sessionRestore";
 import {
   archiveAgeEmptyMessageKey,
@@ -2299,6 +2307,10 @@ export default function App() {
   /** Optional product tour (not first-run account setup). */
   const [showProductTutorial, setShowProductTutorial] = useState(false);
   const productTutorialAutoOfferedRef = useRef(false);
+  /** Sandbox profile wizard after trust / Settings guide. */
+  const [sandboxWizardOpen, setSandboxWizardOpen] = useState(false);
+  const [sandboxWizardMode, setSandboxWizardMode] =
+    useState<SandboxWizardMode>("trust");
   // Soft one-time product tour after setup gate — never blocks setup wizard.
   useEffect(() => {
     if (appGate !== "ready") return;
@@ -7142,6 +7154,31 @@ export default function App() {
 
     commit();
   };
+
+  /** Soft offer sandbox guide after a successful project trust. */
+  const maybeOfferSandboxWizardAfterTrust = useCallback(() => {
+    try {
+      if (
+        !shouldOfferSandboxWizard({
+          justTrusted: true,
+          currentProfile: sandboxProfile,
+          dismissed: loadSandboxWizardDismissed(),
+        })
+      ) {
+        return;
+      }
+      setSandboxWizardMode("trust");
+      // After trust confirm dialog closes — open wizard next tick.
+      window.setTimeout(() => setSandboxWizardOpen(true), 0);
+    } catch {
+      /* ignore */
+    }
+  }, [sandboxProfile]);
+
+  const openSandboxWizardGuide = useCallback(() => {
+    setSandboxWizardMode("info");
+    setSandboxWizardOpen(true);
+  }, []);
 
   /** Remove project from app list only (disk folder + chats kept). */
   const removeProjectFromApp = (proj: Project) => {
@@ -12618,6 +12655,7 @@ export default function App() {
             try {
               const trusted = (await api.projectTrust(p.id)) as Project;
               await apply(trusted);
+              maybeOfferSandboxWizardAfterTrust();
             } catch (e) {
               setLocalError(String(e));
             }
@@ -12627,7 +12665,7 @@ export default function App() {
       }
       await apply(p);
     },
-    [bindSessionProject, showToast, tr],
+    [bindSessionProject, maybeOfferSandboxWizardAfterTrust, showToast, tr],
   );
 
   /** Open gc dialog and run dry-run preview. */
@@ -13310,6 +13348,7 @@ export default function App() {
       setActiveProject(p);
       setProjects(mapProjectsList((await api.projectsList()) as Project[]));
       setLocalError(null);
+      maybeOfferSandboxWizardAfterTrust();
       // CLI connects on first send only.
     } catch (e) {
       setLocalError(String(e));
@@ -16725,6 +16764,7 @@ export default function App() {
           onSandboxProfile={(v) => {
             applyGlobalSandboxProfile(v);
           }}
+          onOpenSandboxWizard={openSandboxWizardGuide}
           preferredAgent={preferredAgent}
           onPreferredAgent={(v) => {
             setPreferredAgent(v);
@@ -21200,6 +21240,32 @@ export default function App() {
         onDone={() => {
           markProductTutorialDone();
           setShowProductTutorial(false);
+        }}
+      />
+      <SandboxWizard
+        open={sandboxWizardOpen}
+        locale={locale}
+        mode={sandboxWizardMode}
+        platform={platform}
+        cliSupportsSandbox={cliSupportsSandbox(cliInfo.version)}
+        onClose={() => {
+          if (sandboxWizardMode === "trust") {
+            // Soft dismiss for this session only unless checkbox used via skip/apply.
+          }
+          setSandboxWizardOpen(false);
+        }}
+        onSkip={({ dontOfferAgain }) => {
+          if (sandboxWizardMode === "trust" && dontOfferAgain) {
+            markSandboxWizardDismissed();
+          }
+          setSandboxWizardOpen(false);
+        }}
+        onApply={(profile, { dontOfferAgain }) => {
+          if (dontOfferAgain) {
+            markSandboxWizardDismissed();
+          }
+          setSandboxWizardOpen(false);
+          applyGlobalSandboxProfile(profile);
         }}
       />
       <VoiceOverlay

--- a/src/components/SandboxWizard.tsx
+++ b/src/components/SandboxWizard.tsx
@@ -1,0 +1,326 @@
+/**
+ * Sandbox profile guide (GlassModal).
+ *
+ * Modes:
+ * - trust: optional offer after project trust (recommend workspace)
+ * - info: Settings “Open sandbox guide” replay
+ *
+ * Steps: intro → pick profile → confirm. No window.confirm.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { GlassModal } from "@/components/GlassModal";
+import {
+  createT,
+  resolveLocale,
+  type Locale,
+} from "@/i18n";
+import {
+  SANDBOX_MIN_CLI,
+  type SandboxProfileId,
+} from "@/lib/sandboxProfile";
+import {
+  advanceSandboxWizardStep,
+  createSandboxWizardAnswers,
+  planSandboxWizardStep,
+  recommendSandboxForTrust,
+  resolveSandboxWizardBanner,
+  retreatSandboxWizardStep,
+  sandboxWizardProfileChoices,
+  sandboxWizardProfileHelpKey,
+  sandboxWizardProfileLabelKey,
+  sandboxWizardStepLabelKey,
+  sandboxWizardTitleKey,
+  type SandboxWizardMode,
+  type SandboxWizardStep,
+} from "@/lib/sandboxWizard";
+
+export type SandboxWizardProps = {
+  open: boolean;
+  locale: Locale | string | undefined;
+  mode: SandboxWizardMode;
+  platform?: string | null;
+  /** Pre-resolved CLI support for --sandbox (null = unknown). */
+  cliSupportsSandbox?: boolean | null;
+  onClose: () => void;
+  /**
+   * Skip / “not now”. Host may soft-persist dismiss for trust mode.
+   * `dontOfferAgain` when the checkbox was ticked.
+   */
+  onSkip: (opts: { dontOfferAgain: boolean }) => void;
+  /** Apply selected profile to settings (host runs danger confirm if needed). */
+  onApply: (
+    profile: SandboxProfileId,
+    opts: { dontOfferAgain: boolean },
+  ) => void;
+};
+
+export function SandboxWizard({
+  open,
+  locale,
+  mode,
+  platform = null,
+  cliSupportsSandbox = null,
+  onClose,
+  onSkip,
+  onApply,
+}: SandboxWizardProps) {
+  const tr = useMemo(() => createT(resolveLocale(locale)), [locale]);
+  const [step, setStep] = useState<SandboxWizardStep>("intro");
+  const [profile, setProfile] = useState<SandboxProfileId | null>(
+    RECOMMENDED_SEED,
+  );
+  const [dontOfferAgain, setDontOfferAgain] = useState(false);
+
+  const recommendation = useMemo(
+    () =>
+      recommendSandboxForTrust({
+        platform,
+        cliSupportsSandbox,
+      }),
+    [platform, cliSupportsSandbox],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const seeded = createSandboxWizardAnswers({
+      platform,
+      cliSupportsSandbox,
+    });
+    setStep("intro");
+    setProfile(seeded.profile);
+    setDontOfferAgain(false);
+  }, [open, platform, cliSupportsSandbox]);
+
+  const answers = useMemo(
+    () => ({ profile, dontOfferAgain }),
+    [profile, dontOfferAgain],
+  );
+  const plan = useMemo(
+    () => planSandboxWizardStep(step, answers),
+    [step, answers],
+  );
+
+  const bannerKey = useMemo(
+    () =>
+      resolveSandboxWizardBanner({
+        platform,
+        cliSupportsSandbox,
+        profile: profile ?? recommendation.profile,
+      }),
+    [platform, cliSupportsSandbox, profile, recommendation.profile],
+  );
+
+  const handleContinue = () => {
+    if (!plan.canContinue) return;
+    const next = advanceSandboxWizardStep(step, answers);
+    if (next === "done") {
+      if (profile) {
+        onApply(profile, { dontOfferAgain });
+      }
+      return;
+    }
+    setStep(next);
+  };
+
+  const handleBack = () => {
+    setStep(retreatSandboxWizardStep(step));
+  };
+
+  const handleSkip = () => {
+    onSkip({ dontOfferAgain });
+  };
+
+  const footer = (
+    <>
+      <button
+        type="button"
+        className="btn btn--ghost sandbox-wizard__skip"
+        onClick={handleSkip}
+      >
+        {mode === "info" ? tr("common.close") : tr("sandboxWizard.skip")}
+      </button>
+      {plan.canBack ? (
+        <button type="button" className="btn btn--ghost" onClick={handleBack}>
+          {tr("sandboxWizard.back")}
+        </button>
+      ) : null}
+      <button
+        type="button"
+        className="btn btn--solid"
+        disabled={!plan.canContinue}
+        onClick={handleContinue}
+      >
+        {plan.isLast
+          ? tr("sandboxWizard.apply")
+          : tr("sandboxWizard.next")}
+      </button>
+    </>
+  );
+
+  return (
+    <GlassModal
+      open={open}
+      onClose={onClose}
+      title={tr(sandboxWizardTitleKey(mode))}
+      size="md"
+      closeLabel={tr("common.close")}
+      className="sandbox-wizard"
+      wrapBody
+      bodyClassName="sandbox-wizard__body-wrap"
+      footer={footer}
+    >
+      <p className="sandbox-wizard__progress" aria-live="polite">
+        {tr("sandboxWizard.progress", {
+          n: String(plan.progress),
+          total: String(plan.total),
+          step: tr(sandboxWizardStepLabelKey(step)),
+        })}
+      </p>
+
+      <div
+        className="sandbox-wizard__dots"
+        role="presentation"
+        aria-hidden
+      >
+        {(["intro", "pick", "confirm"] as const).map((id, i) => (
+          <span
+            key={id}
+            className={
+              "sandbox-wizard__dot" +
+              (i === plan.index ? " is-active" : "") +
+              (i < plan.index ? " is-done" : "")
+            }
+          />
+        ))}
+      </div>
+
+      {step === "intro" ? (
+        <div className="sandbox-wizard__panel">
+          <p className="sandbox-wizard__lead">
+            {mode === "trust"
+              ? tr("sandboxWizard.intro.trust")
+              : tr("sandboxWizard.intro.info")}
+          </p>
+          <p className="sandbox-wizard__recommend">
+            {tr(recommendation.reasonKey)}
+          </p>
+          {bannerKey ? (
+            <p
+              className="sandbox-wizard__banner settings-row__hint is-danger"
+              role="status"
+            >
+              {tr(bannerKey, { min: SANDBOX_MIN_CLI })}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {step === "pick" ? (
+        <div className="sandbox-wizard__panel">
+          <p className="sandbox-wizard__lead">
+            {tr("sandboxWizard.pick.lead")}
+          </p>
+          <div
+            className="sandbox-wizard__choices"
+            role="radiogroup"
+            aria-label={tr("sandboxWizard.step.pick")}
+          >
+            {sandboxWizardProfileChoices().map((id) => {
+              const selected = profile === id;
+              const recommended = id === recommendation.profile;
+              return (
+                <label
+                  key={id}
+                  className={
+                    "sandbox-wizard__choice" +
+                    (selected ? " is-selected" : "") +
+                    (recommended ? " is-recommended" : "")
+                  }
+                >
+                  <input
+                    type="radio"
+                    name="sandbox-wizard-profile"
+                    value={id}
+                    checked={selected}
+                    onChange={() => setProfile(id)}
+                  />
+                  <span className="sandbox-wizard__choice-main">
+                    <span className="sandbox-wizard__choice-label">
+                      {tr(sandboxWizardProfileLabelKey(id))}
+                      {recommended ? (
+                        <span className="sandbox-wizard__badge">
+                          {tr("sandboxWizard.recommendedBadge")}
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="sandbox-wizard__choice-help">
+                      {tr(sandboxWizardProfileHelpKey(id))}
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+          {bannerKey && profile && profile !== "off" ? (
+            <p
+              className="sandbox-wizard__banner settings-row__hint is-danger"
+              role="status"
+            >
+              {tr(bannerKey, { min: SANDBOX_MIN_CLI })}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {step === "confirm" ? (
+        <div className="sandbox-wizard__panel">
+          <p className="sandbox-wizard__lead">
+            {tr("sandboxWizard.confirm.lead", {
+              profile: profile
+                ? tr(sandboxWizardProfileLabelKey(profile))
+                : "—",
+            })}
+          </p>
+          {profile ? (
+            <p className="sandbox-wizard__confirm-help">
+              {tr(sandboxWizardProfileHelpKey(profile))}
+            </p>
+          ) : null}
+          {plan.dangerKey ? (
+            <p
+              className="sandbox-wizard__banner settings-row__hint is-danger"
+              role="status"
+            >
+              {tr(plan.dangerKey)}
+            </p>
+          ) : null}
+          {bannerKey && profile && profile !== "off" ? (
+            <p
+              className="sandbox-wizard__banner settings-row__hint is-danger"
+              role="status"
+            >
+              {tr(bannerKey, { min: SANDBOX_MIN_CLI })}
+            </p>
+          ) : null}
+          <p className="sandbox-wizard__hint">
+            {tr("sandboxWizard.confirm.respawnHint")}
+          </p>
+        </div>
+      ) : null}
+
+      {mode === "trust" ? (
+        <label className="sandbox-wizard__dont-offer">
+          <input
+            type="checkbox"
+            checked={dontOfferAgain}
+            onChange={(e) => setDontOfferAgain(e.target.checked)}
+          />
+          <span>{tr("sandboxWizard.dontOfferAgain")}</span>
+        </label>
+      ) : null}
+    </GlassModal>
+  );
+}
+
+const RECOMMENDED_SEED: SandboxProfileId = "workspace";

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -74,7 +74,6 @@ import {
 } from "@/lib/allowedTools";
 import { detectAppPlatform } from "@/lib/appPlatform";
 import {
-  RECOMMENDED_SANDBOX_PROFILE,
   SANDBOX_MIN_CLI,
   childNetworkRestrictApplies,
   sandboxIsolationActive,
@@ -691,6 +690,8 @@ export interface SettingsPageProps {
   /** OS sandbox for agent spawn: off | workspace | read-only | strict | devbox. */
   sandboxProfile?: string;
   onSandboxProfile?: (v: string) => void;
+  /** Open sandbox profile guide wizard (GlassModal). */
+  onOpenSandboxWizard?: () => void;
   cliInfo: {
     found: boolean;
     path: string | null;
@@ -1329,6 +1330,7 @@ export function SettingsPage({
   onStoreApiKeysInKeychain,
   sandboxProfile = "off",
   onSandboxProfile,
+  onOpenSandboxWizard,
   maxAgentTurns = 0,
   onMaxAgentTurns,
   backgroundWaitPolicy = "wait",
@@ -2763,10 +2765,20 @@ export function SettingsPage({
                   <div className="settings-row__desc" style={{ marginTop: 8 }}>
                     {t(sandboxProfileHelpKey(sandboxProfile || "off"))}
                   </div>
-                  {sandboxProfile === RECOMMENDED_SANDBOX_PROFILE ||
-                  (sandboxProfile || "off") === "off" ? (
-                    <div className="settings-row__hint" style={{ marginTop: 6 }}>
-                      {t("settings.sandbox.recommendedNote")}
+                  <div className="settings-row__hint" style={{ marginTop: 6 }}>
+                    {t("settings.sandbox.recommendedDaily")}
+                    {" — "}
+                    {t("settings.sandbox.recommendedNote")}
+                  </div>
+                  {onOpenSandboxWizard ? (
+                    <div style={{ marginTop: 8 }}>
+                      <button
+                        type="button"
+                        className="btn btn--ghost btn--sm"
+                        onClick={onOpenSandboxWizard}
+                      >
+                        {t("settings.sandbox.openGuide")}
+                      </button>
                     </div>
                   ) : null}
                   {(() => {

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2201,6 +2201,36 @@ const en = {
     "Child-process network blocking for this profile is enforced on Linux only; on macOS it is a no-op (in-process tools still have network).",
   "settings.sandbox.recommendedNote":
     "Tip: Workspace is the recommended everyday profile.",
+  "settings.sandbox.openGuide": "Open sandbox guide",
+  "settings.sandbox.recommendedDaily": "Recommended for daily use",
+  // Sandbox profile wizard (trust offer + Settings guide)
+  "sandboxWizard.title.trust": "Choose a sandbox profile",
+  "sandboxWizard.title.info": "Sandbox profile guide",
+  "sandboxWizard.progress": "Step {n} of {total} · {step}",
+  "sandboxWizard.step.intro": "Why sandbox",
+  "sandboxWizard.step.pick": "Pick a profile",
+  "sandboxWizard.step.confirm": "Confirm",
+  "sandboxWizard.next": "Continue",
+  "sandboxWizard.back": "Back",
+  "sandboxWizard.skip": "Not now",
+  "sandboxWizard.apply": "Apply profile",
+  "sandboxWizard.intro.trust":
+    "You trusted this project. Optionally set an OS-level sandbox for agent processes so writes stay scoped to the workspace (and temp).",
+  "sandboxWizard.intro.info":
+    "OS sandbox profiles limit what the agent process can write. Pick a profile that matches how you use this machine.",
+  "sandboxWizard.reason.workspace":
+    "Recommended for daily coding: Workspace — read anywhere; write limited to the session working directory, ~/.grok/, and system temp. Network allowed.",
+  "sandboxWizard.honesty.platform":
+    "On this platform, kernel OS sandbox enforcement is not documented (macOS Seatbelt / Linux Landlock only). The CLI may accept the profile but soft-fail without enforcement — not a hard security boundary.",
+  "sandboxWizard.honesty.cliUnsupported":
+    "This CLI is too old for --sandbox (needs ≥ {min}). The profile can be saved, but the flag is omitted (soft-fail) until you upgrade Grok Build.",
+  "sandboxWizard.pick.lead":
+    "Select a sandbox profile. Workspace is recommended for everyday use.",
+  "sandboxWizard.recommendedBadge": "Recommended",
+  "sandboxWizard.confirm.lead": "Apply “{profile}” as the app sandbox profile?",
+  "sandboxWizard.confirm.respawnHint":
+    "Takes effect when a new agent starts — reconnect the session after changing. Projects can still override this from the project menu.",
+  "sandboxWizard.dontOfferAgain": "Don’t offer this after trusting projects",
   "settings.disableWebSearch": "Disable web search & fetch",
   "settings.disableWebSearchDesc":
     "Spawn agents with --disable-web-search so web_search and web_fetch tools are unavailable. Live agents soft-respawn when this changes.",
@@ -8231,6 +8261,36 @@ const zh: Record<MessageKey, string> = {
     "此配置的子进程网络拦截仅在 Linux 生效；macOS 为 no-op（进程内工具仍可联网）。",
   "settings.sandbox.recommendedNote":
     "提示：日常使用推荐「工作区」配置。",
+  "settings.sandbox.openGuide": "打开沙箱指南",
+  "settings.sandbox.recommendedDaily": "日常使用推荐",
+  // Sandbox profile wizard (trust offer + Settings guide)
+  "sandboxWizard.title.trust": "选择沙箱配置",
+  "sandboxWizard.title.info": "沙箱配置指南",
+  "sandboxWizard.progress": "第 {n} / {total} 步 · {step}",
+  "sandboxWizard.step.intro": "为何使用沙箱",
+  "sandboxWizard.step.pick": "选择配置",
+  "sandboxWizard.step.confirm": "确认",
+  "sandboxWizard.next": "继续",
+  "sandboxWizard.back": "上一步",
+  "sandboxWizard.skip": "暂不设置",
+  "sandboxWizard.apply": "应用配置",
+  "sandboxWizard.intro.trust":
+    "你已信任此项目。可选为 Agent 进程设置操作系统级沙箱，使写入范围限制在工作区（及临时目录）。",
+  "sandboxWizard.intro.info":
+    "OS 沙箱配置限制 Agent 进程的写入能力。请按你对本机的使用方式选择配置。",
+  "sandboxWizard.reason.workspace":
+    "日常编程推荐：工作区 — 可读任意路径；写入限制为会话工作目录、~/.grok/ 与系统临时目录。网络允许。",
+  "sandboxWizard.honesty.platform":
+    "当前平台未文档化内核级 OS 沙箱强制（仅 macOS Seatbelt / Linux Landlock）。CLI 可能接受配置但 soft-fail 且无强制执行 — 请勿当作硬安全边界。",
+  "sandboxWizard.honesty.cliUnsupported":
+    "当前 CLI 过旧，不支持 --sandbox（需要 ≥ {min}）。配置可保存，但会 soft-fail（省略 flag）直至升级 Grok Build。",
+  "sandboxWizard.pick.lead":
+    "选择沙箱配置。日常使用推荐「工作区」。",
+  "sandboxWizard.recommendedBadge": "推荐",
+  "sandboxWizard.confirm.lead": "将「{profile}」应用为应用级沙箱配置？",
+  "sandboxWizard.confirm.respawnHint":
+    "在新启动 Agent 时生效——更改后请重连会话。仍可在项目菜单中为单个项目覆盖。",
+  "sandboxWizard.dontOfferAgain": "信任项目后不再提示",
   "settings.disableWebSearch": "禁用网页搜索与抓取",
   "settings.disableWebSearchDesc":
     "启动 Agent 时加上 --disable-web-search，移除 web_search / web_fetch 工具。更改后会 soft-respawn 已连接的 Agent。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2077,6 +2077,36 @@ export const zhTW: Record<MessageKey, string> = {
     "此設定檔的子行程網路攔截僅在 Linux 生效；macOS 為 no-op（行程內工具仍可連網）。",
   "settings.sandbox.recommendedNote":
     "提示：日常使用推薦「工作區」設定檔。",
+  "settings.sandbox.openGuide": "開啟沙箱指南",
+  "settings.sandbox.recommendedDaily": "日常使用推薦",
+  // Sandbox profile wizard (trust offer + Settings guide)
+  "sandboxWizard.title.trust": "選擇沙箱設定檔",
+  "sandboxWizard.title.info": "沙箱設定檔指南",
+  "sandboxWizard.progress": "第 {n} / {total} 步 · {step}",
+  "sandboxWizard.step.intro": "為何使用沙箱",
+  "sandboxWizard.step.pick": "選擇設定檔",
+  "sandboxWizard.step.confirm": "確認",
+  "sandboxWizard.next": "繼續",
+  "sandboxWizard.back": "上一步",
+  "sandboxWizard.skip": "暫不設定",
+  "sandboxWizard.apply": "套用設定檔",
+  "sandboxWizard.intro.trust":
+    "你已信任此專案。可選為 Agent 行程設定作業系統級沙箱，使寫入範圍限制在工作區（及暫存目錄）。",
+  "sandboxWizard.intro.info":
+    "OS 沙箱設定檔限制 Agent 行程的寫入能力。請依你對本機的使用方式選擇設定檔。",
+  "sandboxWizard.reason.workspace":
+    "日常程式設計推薦：工作區 — 可讀任意路徑；寫入限制為工作階段工作目錄、~/.grok/ 與系統暫存目錄。網路允許。",
+  "sandboxWizard.honesty.platform":
+    "目前平台未文件化核心級 OS 沙箱強制（僅 macOS Seatbelt / Linux Landlock）。CLI 可能接受設定但 soft-fail 且無強制執行 — 請勿當作硬性安全邊界。",
+  "sandboxWizard.honesty.cliUnsupported":
+    "目前 CLI 過舊，不支援 --sandbox（需要 ≥ {min}）。設定可儲存，但會 soft-fail（省略 flag）直至升級 Grok Build。",
+  "sandboxWizard.pick.lead":
+    "選擇沙箱設定檔。日常使用推薦「工作區」。",
+  "sandboxWizard.recommendedBadge": "推薦",
+  "sandboxWizard.confirm.lead": "將「{profile}」套用為應用程式級沙箱設定檔？",
+  "sandboxWizard.confirm.respawnHint":
+    "在新啟動 Agent 時生效——變更後請重新連線工作階段。仍可在專案選單中為單一專案覆寫。",
+  "sandboxWizard.dontOfferAgain": "信任專案後不再提示",
   "settings.disableWebSearch": "停用網頁搜尋與抓取",
   "settings.disableWebSearchDesc":
     "啟動 Agent 時加上 --disable-web-search，移除 web_search / web_fetch 工具。變更後會 soft-respawn 已連線的 Agent。",

--- a/src/lib/sandboxWizard.test.ts
+++ b/src/lib/sandboxWizard.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SANDBOX_PROFILE,
+  RECOMMENDED_SANDBOX_PROFILE,
+  SANDBOX_PROFILES,
+} from "./sandboxProfile";
+import {
+  SANDBOX_WIZARD_DISMISS_KEY,
+  SANDBOX_WIZARD_STEP_TOTAL,
+  advanceSandboxWizardStep,
+  clearSandboxWizardDismissed,
+  createSandboxWizardAnswers,
+  loadSandboxWizardDismissed,
+  markSandboxWizardDismissed,
+  parseSandboxWizardDismissed,
+  planSandboxWizardStep,
+  recommendSandboxForTrust,
+  resolveSandboxWizardBanner,
+  retreatSandboxWizardStep,
+  sandboxWizardProfileChoices,
+  sandboxWizardStepLabelKey,
+  sandboxWizardTitleKey,
+  shouldOfferSandboxWizard,
+  type SandboxWizardStorage,
+} from "./sandboxWizard";
+
+function memoryStorage(seed: Record<string, string> = {}): SandboxWizardStorage {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+    removeItem: (k) => {
+      map.delete(k);
+    },
+  };
+}
+
+describe("recommendSandboxForTrust", () => {
+  it("recommends workspace for everyday use on mac/linux", () => {
+    for (const platform of ["mac", "macos", "darwin", "linux"]) {
+      const r = recommendSandboxForTrust({
+        platform,
+        cliSupportsSandbox: true,
+      });
+      expect(r.profile).toBe(RECOMMENDED_SANDBOX_PROFILE);
+      expect(r.profile).toBe("workspace");
+      expect(r.reasonKey).toBe("sandboxWizard.reason.workspace");
+      expect(r.honestyKey).toBeNull();
+    }
+  });
+
+  it("still recommends workspace on Windows with platform honesty", () => {
+    const r = recommendSandboxForTrust({
+      platform: "win",
+      cliSupportsSandbox: true,
+    });
+    expect(r.profile).toBe("workspace");
+    expect(r.honestyKey).toBe("sandboxWizard.honesty.platform");
+  });
+
+  it("flags old CLI soft-fail honesty", () => {
+    const r = recommendSandboxForTrust({
+      platform: "mac",
+      cliSupportsSandbox: false,
+    });
+    expect(r.profile).toBe("workspace");
+    expect(r.honestyKey).toBe("sandboxWizard.honesty.cliUnsupported");
+  });
+
+  it("prefers CLI honesty over platform when both apply", () => {
+    const r = recommendSandboxForTrust({
+      platform: "win",
+      cliSupportsSandbox: false,
+    });
+    expect(r.honestyKey).toBe("sandboxWizard.honesty.cliUnsupported");
+  });
+
+  it("unknown CLI support + known enforcing platform → no honesty", () => {
+    const r = recommendSandboxForTrust({
+      platform: "mac",
+      cliSupportsSandbox: null,
+    });
+    expect(r.honestyKey).toBeNull();
+  });
+});
+
+describe("planSandboxWizardStep", () => {
+  it("intro can continue to pick without a profile", () => {
+    const plan = planSandboxWizardStep("intro", { profile: null });
+    expect(plan.step).toBe("intro");
+    expect(plan.index).toBe(0);
+    expect(plan.progress).toBe(1);
+    expect(plan.total).toBe(SANDBOX_WIZARD_STEP_TOTAL);
+    expect(plan.canContinue).toBe(true);
+    expect(plan.canBack).toBe(false);
+    expect(plan.nextStep).toBe("pick");
+    expect(plan.prevStep).toBeNull();
+    expect(plan.isLast).toBe(false);
+    expect(plan.recommendedProfile).toBe("workspace");
+  });
+
+  it("pick requires a selected profile", () => {
+    const blocked = planSandboxWizardStep("pick", { profile: null });
+    expect(blocked.canContinue).toBe(false);
+    expect(blocked.nextStep).toBe("confirm");
+    expect(blocked.canBack).toBe(true);
+    expect(blocked.prevStep).toBe("intro");
+
+    const ok = planSandboxWizardStep("pick", { profile: "workspace" });
+    expect(ok.canContinue).toBe(true);
+    expect(ok.selectedProfile).toBe("workspace");
+  });
+
+  it("confirm is last and surfaces danger keys for off/devbox", () => {
+    const off = planSandboxWizardStep("confirm", { profile: "off" });
+    expect(off.isLast).toBe(true);
+    expect(off.nextStep).toBe("done");
+    expect(off.dangerKey).toBe("settings.sandbox.dangerConfirmOff");
+    expect(off.canContinue).toBe(true);
+
+    const devbox = planSandboxWizardStep("confirm", { profile: "devbox" });
+    expect(devbox.dangerKey).toBe("settings.sandbox.dangerConfirmDevbox");
+
+    const safe = planSandboxWizardStep("confirm", { profile: "workspace" });
+    expect(safe.dangerKey).toBeNull();
+  });
+});
+
+describe("advance / retreat", () => {
+  it("advances intro → pick → confirm → done", () => {
+    expect(advanceSandboxWizardStep("intro", { profile: null })).toBe("pick");
+    expect(
+      advanceSandboxWizardStep("pick", { profile: "strict" }),
+    ).toBe("confirm");
+    expect(
+      advanceSandboxWizardStep("confirm", { profile: "strict" }),
+    ).toBe("done");
+  });
+
+  it("stays on pick when no profile selected", () => {
+    expect(advanceSandboxWizardStep("pick", { profile: null })).toBe("pick");
+  });
+
+  it("retreats confirm → pick → intro", () => {
+    expect(retreatSandboxWizardStep("confirm")).toBe("pick");
+    expect(retreatSandboxWizardStep("pick")).toBe("intro");
+    expect(retreatSandboxWizardStep("intro")).toBe("intro");
+  });
+});
+
+describe("shouldOfferSandboxWizard", () => {
+  it("offers after trust when profile is still off and not dismissed", () => {
+    expect(
+      shouldOfferSandboxWizard({
+        justTrusted: true,
+        currentProfile: "off",
+        dismissed: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldOfferSandboxWizard({
+        justTrusted: true,
+        currentProfile: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("skips when not just trusted, dismissed, or already isolating", () => {
+    expect(
+      shouldOfferSandboxWizard({
+        justTrusted: false,
+        currentProfile: "off",
+      }),
+    ).toBe(false);
+    expect(
+      shouldOfferSandboxWizard({
+        justTrusted: true,
+        currentProfile: "off",
+        dismissed: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldOfferSandboxWizard({
+        justTrusted: true,
+        currentProfile: "workspace",
+      }),
+    ).toBe(false);
+    expect(
+      shouldOfferSandboxWizard({
+        justTrusted: true,
+        currentProfile: "strict",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveSandboxWizardBanner", () => {
+  it("returns null for off profile", () => {
+    expect(
+      resolveSandboxWizardBanner({
+        platform: "win",
+        cliSupportsSandbox: false,
+        profile: "off",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns platform honesty on Windows when isolating", () => {
+    expect(
+      resolveSandboxWizardBanner({
+        platform: "win",
+        cliSupportsSandbox: true,
+        profile: "workspace",
+      }),
+    ).toBe("sandboxWizard.honesty.platform");
+  });
+
+  it("returns CLI honesty when unsupported", () => {
+    expect(
+      resolveSandboxWizardBanner({
+        platform: "mac",
+        cliSupportsSandbox: false,
+        profile: "workspace",
+      }),
+    ).toBe("sandboxWizard.honesty.cliUnsupported");
+  });
+
+  it("returns null when isolation likely applies", () => {
+    expect(
+      resolveSandboxWizardBanner({
+        platform: "mac",
+        cliSupportsSandbox: true,
+        profile: "workspace",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("dismiss storage", () => {
+  it("parses JSON + legacy truthy flags", () => {
+    expect(parseSandboxWizardDismissed(null)).toBe(false);
+    expect(parseSandboxWizardDismissed("")).toBe(false);
+    expect(parseSandboxWizardDismissed("1")).toBe(true);
+    expect(parseSandboxWizardDismissed("true")).toBe(true);
+    expect(
+      parseSandboxWizardDismissed(
+        JSON.stringify({ version: 1, dismissed: true }),
+      ),
+    ).toBe(true);
+    expect(
+      parseSandboxWizardDismissed(
+        JSON.stringify({ version: 1, dismissed: false }),
+      ),
+    ).toBe(false);
+    expect(parseSandboxWizardDismissed("{")).toBe(false);
+  });
+
+  it("load / mark / clear via storage surface", () => {
+    const storage = memoryStorage();
+    expect(loadSandboxWizardDismissed(storage)).toBe(false);
+    markSandboxWizardDismissed(storage);
+    expect(loadSandboxWizardDismissed(storage)).toBe(true);
+    expect(storage.getItem(SANDBOX_WIZARD_DISMISS_KEY)).toContain(
+      '"dismissed":true',
+    );
+    clearSandboxWizardDismissed(storage);
+    expect(loadSandboxWizardDismissed(storage)).toBe(false);
+  });
+});
+
+describe("createSandboxWizardAnswers / choices / keys", () => {
+  it("seeds recommended workspace", () => {
+    const a = createSandboxWizardAnswers({ platform: "mac" });
+    expect(a.profile).toBe(RECOMMENDED_SANDBOX_PROFILE);
+    expect(a.dontOfferAgain).toBe(false);
+  });
+
+  it("lists all sandbox profiles", () => {
+    expect(sandboxWizardProfileChoices()).toEqual([...SANDBOX_PROFILES]);
+  });
+
+  it("maps title and step label keys", () => {
+    expect(sandboxWizardTitleKey("trust")).toBe("sandboxWizard.title.trust");
+    expect(sandboxWizardTitleKey("info")).toBe("sandboxWizard.title.info");
+    expect(sandboxWizardStepLabelKey("intro")).toBe("sandboxWizard.step.intro");
+    expect(sandboxWizardStepLabelKey("pick")).toBe("sandboxWizard.step.pick");
+    expect(sandboxWizardStepLabelKey("confirm")).toBe(
+      "sandboxWizard.step.confirm",
+    );
+  });
+
+  it("default profile constant stays off (wizard still recommends workspace)", () => {
+    expect(DEFAULT_SANDBOX_PROFILE).toBe("off");
+    expect(RECOMMENDED_SANDBOX_PROFILE).toBe("workspace");
+  });
+});

--- a/src/lib/sandboxWizard.ts
+++ b/src/lib/sandboxWizard.ts
@@ -1,0 +1,392 @@
+/**
+ * Sandbox profile trust wizard — pure helpers.
+ *
+ * Flow (trust / info guide):
+ *   intro → pick profile → confirm
+ *
+ * Recommends {@link RECOMMENDED_SANDBOX_PROFILE} (`workspace`) for everyday use.
+ * Honesty banners for Windows (kernel soft-fail) and older CLI (flag omitted).
+ * Never uses `window.confirm` — UI hosts a GlassModal.
+ */
+
+import type { MessageKey } from "@/i18n";
+import {
+  DEFAULT_SANDBOX_PROFILE,
+  RECOMMENDED_SANDBOX_PROFILE,
+  SANDBOX_PROFILES,
+  isDangerousSandboxProfile,
+  normalizeSandboxProfile,
+  platformEnforcesOsSandbox,
+  sandboxDangerConfirmKey,
+  sandboxIsolationActive,
+  sandboxProfileHelpKey,
+  sandboxProfileLabelKey,
+  type SandboxProfileId,
+} from "@/lib/sandboxProfile";
+
+/** Ordered wizard steps. */
+export type SandboxWizardStep = "intro" | "pick" | "confirm";
+
+export const SANDBOX_WIZARD_STEPS: readonly SandboxWizardStep[] = [
+  "intro",
+  "pick",
+  "confirm",
+] as const;
+
+export const SANDBOX_WIZARD_STEP_TOTAL = SANDBOX_WIZARD_STEPS.length;
+
+/** Host mode: post-trust offer vs Settings “Open sandbox guide”. */
+export type SandboxWizardMode = "trust" | "info";
+
+/** Soft localStorage key for “don’t offer after trust”. */
+export const SANDBOX_WIZARD_DISMISS_KEY = "grok.sandboxWizard.dismissed.v1";
+
+export const SANDBOX_WIZARD_DISMISS_VERSION = 1;
+
+/** Minimal storage surface so unit tests need no jsdom. */
+export interface SandboxWizardStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+function defaultStorage(): SandboxWizardStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+}
+
+export type SandboxWizardDismissStored = {
+  version: number;
+  dismissed: boolean;
+};
+
+/** User answers while stepping through the wizard. */
+export type SandboxWizardAnswers = {
+  /** Selected profile (null until pick step). */
+  profile: SandboxProfileId | null;
+  /** Soft “don’t offer again after trust”. */
+  dontOfferAgain?: boolean;
+};
+
+export type SandboxWizardRecommendResult = {
+  profile: SandboxProfileId;
+  /** Why this profile is recommended. */
+  reasonKey: MessageKey;
+  /**
+   * Optional honesty banner (Windows soft-fail / old CLI).
+   * `null` when no extra caution is needed.
+   */
+  honestyKey: MessageKey | null;
+};
+
+export type SandboxWizardStepPlan = {
+  step: SandboxWizardStep;
+  /** 0-based index into {@link SANDBOX_WIZARD_STEPS}. */
+  index: number;
+  total: number;
+  /** Human progress 1..total. */
+  progress: number;
+  canBack: boolean;
+  /** True when continue advances past confirm (apply). */
+  isLast: boolean;
+  /** Continue enabled (pick requires a profile). */
+  canContinue: boolean;
+  nextStep: SandboxWizardStep | "done";
+  prevStep: SandboxWizardStep | null;
+  selectedProfile: SandboxProfileId | null;
+  recommendedProfile: SandboxProfileId;
+  /** Danger note when selected profile is off/devbox. */
+  dangerKey: MessageKey | null;
+};
+
+/**
+ * Recommend a sandbox profile when trusting a project.
+ * Always prefers {@link RECOMMENDED_SANDBOX_PROFILE}; honesty keys when
+ * platform/CLI cannot enforce isolation.
+ */
+export function recommendSandboxForTrust(opts: {
+  platform?: string | null;
+  /** Pre-resolved `cliSupportsSandbox(version)` result. */
+  cliSupportsSandbox?: boolean | null;
+} = {}): SandboxWizardRecommendResult {
+  const profile = RECOMMENDED_SANDBOX_PROFILE;
+  const reasonKey: MessageKey = "sandboxWizard.reason.workspace";
+
+  if (opts.cliSupportsSandbox === false) {
+    return {
+      profile,
+      reasonKey,
+      honestyKey: "sandboxWizard.honesty.cliUnsupported",
+    };
+  }
+
+  if (
+    opts.platform != null &&
+    !platformEnforcesOsSandbox(opts.platform)
+  ) {
+    return {
+      profile,
+      reasonKey,
+      honestyKey: "sandboxWizard.honesty.platform",
+    };
+  }
+
+  return { profile, reasonKey, honestyKey: null };
+}
+
+/**
+ * Simple step machine plan for intro → pick → confirm.
+ * Pure: does not mutate answers.
+ */
+export function planSandboxWizardStep(
+  step: SandboxWizardStep,
+  answers: SandboxWizardAnswers,
+): SandboxWizardStepPlan {
+  const selectedProfile =
+    answers.profile != null
+      ? normalizeSandboxProfile(answers.profile)
+      : null;
+
+  const recommendedProfile = RECOMMENDED_SANDBOX_PROFILE;
+  const dangerKey =
+    selectedProfile && isDangerousSandboxProfile(selectedProfile)
+      ? sandboxDangerConfirmKey(selectedProfile)
+      : null;
+
+  if (step === "intro") {
+    return {
+      step: "intro",
+      index: 0,
+      total: SANDBOX_WIZARD_STEP_TOTAL,
+      progress: 1,
+      canBack: false,
+      isLast: false,
+      canContinue: true,
+      nextStep: "pick",
+      prevStep: null,
+      selectedProfile,
+      recommendedProfile,
+      dangerKey: null,
+    };
+  }
+
+  if (step === "pick") {
+    return {
+      step: "pick",
+      index: 1,
+      total: SANDBOX_WIZARD_STEP_TOTAL,
+      progress: 2,
+      canBack: true,
+      isLast: false,
+      canContinue: selectedProfile != null,
+      nextStep: "confirm",
+      prevStep: "intro",
+      selectedProfile,
+      recommendedProfile,
+      dangerKey,
+    };
+  }
+
+  // confirm
+  return {
+    step: "confirm",
+    index: 2,
+    total: SANDBOX_WIZARD_STEP_TOTAL,
+    progress: 3,
+    canBack: true,
+    isLast: true,
+    canContinue: selectedProfile != null,
+    nextStep: "done",
+    prevStep: "pick",
+    selectedProfile,
+    recommendedProfile,
+    dangerKey,
+  };
+}
+
+/**
+ * Advance one step (or stay if continue blocked).
+ * Pure transition helper for hosts that don't want to re-derive next.
+ */
+export function advanceSandboxWizardStep(
+  step: SandboxWizardStep,
+  answers: SandboxWizardAnswers,
+): SandboxWizardStep | "done" {
+  const plan = planSandboxWizardStep(step, answers);
+  if (!plan.canContinue) return step;
+  return plan.nextStep;
+}
+
+/** Step back, or stay on intro. */
+export function retreatSandboxWizardStep(
+  step: SandboxWizardStep,
+): SandboxWizardStep {
+  const plan = planSandboxWizardStep(step, { profile: null });
+  return plan.prevStep ?? step;
+}
+
+/**
+ * Whether to open the wizard after a successful project trust.
+ * - Requires `justTrusted`
+ * - Soft-skips when user dismissed previously
+ * - Offers when global profile is still unrestricted (`off` / invalid)
+ */
+export function shouldOfferSandboxWizard(opts: {
+  justTrusted: boolean;
+  currentProfile: string;
+  dismissed?: boolean;
+}): boolean {
+  if (!opts.justTrusted) return false;
+  if (opts.dismissed) return false;
+  const id =
+    normalizeSandboxProfile(opts.currentProfile) ?? DEFAULT_SANDBOX_PROFILE;
+  // Already isolating → no need to nag after trust.
+  return id === "off" || !sandboxIsolationActive(id);
+}
+
+/**
+ * Honesty banner for the wizard body (Windows / old CLI soft-fail).
+ * Independent of soft-fail Settings banners; returns wizard-scoped keys.
+ * `null` when no banner is needed.
+ */
+export function resolveSandboxWizardBanner(opts: {
+  platform?: string | null;
+  cliSupportsSandbox?: boolean | null;
+  /** Optional selected / recommended profile (off → no banner). */
+  profile?: unknown;
+}): MessageKey | null {
+  if (opts.profile != null && !sandboxIsolationActive(opts.profile)) {
+    return null;
+  }
+
+  if (opts.cliSupportsSandbox === false) {
+    return "sandboxWizard.honesty.cliUnsupported";
+  }
+
+  if (
+    opts.platform != null &&
+    !platformEnforcesOsSandbox(opts.platform)
+  ) {
+    return "sandboxWizard.honesty.platform";
+  }
+
+  return null;
+}
+
+/** Profiles shown in the pick step (stable order from catalog). */
+export function sandboxWizardProfileChoices(): readonly SandboxProfileId[] {
+  return SANDBOX_PROFILES;
+}
+
+/** Label key for a pick-row profile. */
+export function sandboxWizardProfileLabelKey(
+  profile: SandboxProfileId,
+): MessageKey {
+  return sandboxProfileLabelKey(profile);
+}
+
+/** Help key for a pick-row profile. */
+export function sandboxWizardProfileHelpKey(
+  profile: SandboxProfileId,
+): MessageKey {
+  return sandboxProfileHelpKey(profile);
+}
+
+/** i18n title key for the wizard mode. */
+export function sandboxWizardTitleKey(mode: SandboxWizardMode): MessageKey {
+  return mode === "info"
+    ? "sandboxWizard.title.info"
+    : "sandboxWizard.title.trust";
+}
+
+/** i18n step label key. */
+export function sandboxWizardStepLabelKey(step: SandboxWizardStep): MessageKey {
+  switch (step) {
+    case "intro":
+      return "sandboxWizard.step.intro";
+    case "pick":
+      return "sandboxWizard.step.pick";
+    case "confirm":
+      return "sandboxWizard.step.confirm";
+  }
+}
+
+/** Seed answers with recommended profile pre-selected. */
+export function createSandboxWizardAnswers(opts?: {
+  platform?: string | null;
+  cliSupportsSandbox?: boolean | null;
+  /** Override initial selection (default = recommended). */
+  profile?: SandboxProfileId | null;
+}): SandboxWizardAnswers {
+  const rec = recommendSandboxForTrust({
+    platform: opts?.platform,
+    cliSupportsSandbox: opts?.cliSupportsSandbox,
+  });
+  return {
+    profile:
+      opts?.profile !== undefined
+        ? opts.profile
+        : rec.profile,
+    dontOfferAgain: false,
+  };
+}
+
+/** Parse dismiss flag from storage raw value. */
+export function parseSandboxWizardDismissed(raw: unknown): boolean {
+  if (raw == null || raw === "") return false;
+  if (raw === "1" || raw === "true" || raw === true) return true;
+  if (typeof raw !== "string") return false;
+  try {
+    const parsed = JSON.parse(raw) as Partial<SandboxWizardDismissStored>;
+    if (parsed && typeof parsed === "object" && parsed.dismissed === true) {
+      return true;
+    }
+  } catch {
+    /* not JSON */
+  }
+  return false;
+}
+
+export function loadSandboxWizardDismissed(
+  storage: SandboxWizardStorage = defaultStorage(),
+): boolean {
+  try {
+    return parseSandboxWizardDismissed(
+      storage.getItem(SANDBOX_WIZARD_DISMISS_KEY),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function markSandboxWizardDismissed(
+  storage: SandboxWizardStorage = defaultStorage(),
+): void {
+  const payload: SandboxWizardDismissStored = {
+    version: SANDBOX_WIZARD_DISMISS_VERSION,
+    dismissed: true,
+  };
+  try {
+    storage.setItem(SANDBOX_WIZARD_DISMISS_KEY, JSON.stringify(payload));
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+export function clearSandboxWizardDismissed(
+  storage: SandboxWizardStorage = defaultStorage(),
+): void {
+  try {
+    if (typeof storage.removeItem === "function") {
+      storage.removeItem(SANDBOX_WIZARD_DISMISS_KEY);
+    } else {
+      storage.setItem(SANDBOX_WIZARD_DISMISS_KEY, "");
+    }
+  } catch {
+    /* private mode */
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12530,6 +12530,168 @@ html[data-composer-min-rows="8"] .composer__input {
   white-space: pre-wrap;
 }
 
+/* Sandbox profile wizard (GlassModal) */
+.sandbox-wizard .modal-actions {
+  justify-content: flex-end;
+}
+
+.sandbox-wizard__skip {
+  margin-right: auto;
+}
+
+.sandbox-wizard__body-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 12px);
+  min-width: 0;
+}
+
+.sandbox-wizard__progress {
+  margin: 0;
+  font-size: var(--text-xs, 12px);
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.sandbox-wizard__dots {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.sandbox-wizard__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-tertiary) 55%, transparent);
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.sandbox-wizard__dot.is-done {
+  background: color-mix(in srgb, var(--accent, #6b8afd) 55%, var(--text-tertiary));
+}
+
+.sandbox-wizard__dot.is-active {
+  background: var(--accent, #6b8afd);
+  transform: scale(1.2);
+}
+
+.sandbox-wizard__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.sandbox-wizard__lead,
+.sandbox-wizard__recommend,
+.sandbox-wizard__confirm-help,
+.sandbox-wizard__hint {
+  margin: 0;
+  font-size: var(--text-sm, 13px);
+  line-height: 1.55;
+  color: var(--text-primary);
+}
+
+.sandbox-wizard__recommend {
+  color: var(--text-secondary);
+}
+
+.sandbox-wizard__hint {
+  color: var(--text-secondary);
+  font-size: var(--text-xs, 12px);
+}
+
+.sandbox-wizard__banner {
+  margin: 0;
+}
+
+.sandbox-wizard__choices {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: min(42vh, 320px);
+  overflow: auto;
+  min-width: 0;
+}
+
+.sandbox-wizard__choice {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  border-radius: var(--radius-md, 10px);
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.28));
+  background: color-mix(in srgb, var(--bg-elevated, var(--bg-main)) 88%, transparent);
+  cursor: pointer;
+}
+
+.sandbox-wizard__choice.is-selected {
+  border-color: color-mix(in srgb, var(--accent, #6b8afd) 65%, var(--border-subtle));
+  background: color-mix(in srgb, var(--accent, #6b8afd) 10%, transparent);
+}
+
+.sandbox-wizard__choice.is-recommended:not(.is-selected) {
+  border-color: color-mix(in srgb, var(--accent, #6b8afd) 35%, var(--border-subtle));
+}
+
+.sandbox-wizard__choice input {
+  margin-top: 3px;
+  flex-shrink: 0;
+}
+
+.sandbox-wizard__choice-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.sandbox-wizard__choice-label {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-sm, 13px);
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.sandbox-wizard__choice-help {
+  font-size: var(--text-xs, 12px);
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.sandbox-wizard__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent, #6b8afd);
+  background: color-mix(in srgb, var(--accent, #6b8afd) 16%, transparent);
+}
+
+.sandbox-wizard__dont-offer {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 2px 0 0;
+  font-size: var(--text-xs, 12px);
+  color: var(--text-secondary);
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.sandbox-wizard__dont-offer input {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
 .perm-bar__hint {
   margin: 0 0 8px;
   font-size: 11px;


### PR DESCRIPTION
## Summary
- Pure `sandboxWizard` step machine: recommend **workspace**, intro → pick → confirm, offer-gate after trust, Windows/old-CLI honesty banners, soft localStorage dismiss
- GlassModal wizard after project trust (when global profile is still Off) and from Settings → **Open sandbox guide**
- Settings tip “Recommended for daily use”; applies via existing global `sandboxProfile` setter (danger confirm for off/devbox)
- en / zh / zh-TW + CHANGELOG; no `window.confirm`

## Test plan
- [x] `pnpm test -- src/lib/sandboxWizard.test.ts src/lib/sandboxProfile.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Trust a new project with sandbox Off → wizard opens, recommend workspace, apply
- [ ] Skip with “don’t offer again” → no re-offer on next trust
- [ ] Settings → Open sandbox guide (info mode)
- [ ] Windows / old CLI honesty banner copy