### PR TITLE
feat(voice): command center chips and end-session honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Live Voice command center**: delegated session chips with title/status (click focuses session), dedicated tool + permission status region, footer honesty for Keep coding sessions on/off and end-session plan (keep vs cancel delegates). Pure `voiceCommandCenter` helpers + tests; empty transcript honesty (no invented STT); en/zh/zh-TW. No `window.confirm`.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21215,6 +21215,11 @@ export default function App() {
         voiceId={voiceId}
         keepAgentsOnEnd={voiceKeepAgentsOnEnd}
         hasActiveSession={Boolean(session.sessionId)}
+        sessions={sessions.map((s) => ({
+          id: s.id,
+          title: s.title || tr("session.untitled"),
+          status: liveMap[s.id]?.state ?? "idle",
+        }))}
         onClose={() => setLiveVoiceOpen(false)}
         onSendTranscriptAsPrompt={
           session.sessionId
@@ -21231,7 +21236,7 @@ export default function App() {
               }
             : undefined
         }
-        onOpenSession={(id) => {
+        onFocusSession={(id) => {
           setLiveVoiceOpen(false);
           void (async () => {
             await refreshSessions();

--- a/src/components/VoiceOverlay.tsx
+++ b/src/components/VoiceOverlay.tsx
@@ -1,5 +1,6 @@
 /**
- * Live Voice overlay — full-duplex session UI + delegated agent chips.
+ * Live Voice overlay — command center: full-duplex UI + delegated session
+ * chips, tool/permission status, keep-agents honesty.
  *
  * Status (listening / thinking / speaking / Build tool+permission path)
  * comes from host voice:// events + real session://permission for
@@ -21,6 +22,18 @@ import {
   type VoiceSessionState,
 } from "@/lib/api";
 import { playPcm16Base64, startPcmCapture } from "@/lib/voiceAudio";
+import {
+  buildVoiceSessionChips,
+  formatVoiceToolStatus,
+  hasRunningVoiceDelegates,
+  mergeVoiceSessionsForChips,
+  normalizeVoiceChipStatus,
+  planVoiceEnd,
+  resolveKeepAgentsBanner,
+  resolveVoiceCenterEmptyState,
+  voiceCenterEmptyMessageKey,
+  type VoiceSessionChipInput,
+} from "@/lib/voiceCommandCenter";
 import {
   canSendTranscriptAsPrompt,
   classifyLiveVoiceError,
@@ -64,7 +77,16 @@ export type VoiceOverlayProps = {
   keepAgentsOnEnd?: boolean;
   /** When true, the workbench has an active chat that can accept a prompt. */
   hasActiveSession?: boolean;
+  /**
+   * Sidebar / live session rows for chip titles + status.
+   * Overlay merges with host delegatedSessionIds (never invents STT).
+   */
+  sessions?: readonly VoiceSessionChipInput[] | null;
+  /** Soft auth gate for empty-state honesty (CLI / account). Default true. */
+  hasVoiceAuth?: boolean;
   onClose: () => void;
+  /** Focus a coding session (chip click). Alias of onOpenSession. */
+  onFocusSession?: (sessionId: string) => void;
   onOpenSession?: (sessionId: string) => void;
   /**
    * Optional: send formatted host transcript as a user prompt on the active
@@ -117,10 +139,14 @@ export function VoiceOverlay({
   voiceId,
   keepAgentsOnEnd = true,
   hasActiveSession = false,
+  sessions: sessionSummaries = null,
+  hasVoiceAuth = true,
   onClose,
+  onFocusSession,
   onOpenSession,
   onSendTranscriptAsPrompt,
 }: VoiceOverlayProps) {
+  const focusSession = onFocusSession ?? onOpenSession;
   const tt = useCallback(
     (key: MessageKey, vars?: Record<string, string | number>) => t(locale, key, vars),
     [locale],
@@ -543,6 +569,14 @@ export function VoiceOverlay({
   });
   const statusLabel = tt(phaseMessageKey(phase));
   const toolStatusKey = toolLoopStatusMessageKey(toolLoop);
+  const formattedTool = useMemo(
+    () =>
+      formatVoiceToolStatus({
+        name: toolLoop.name,
+        status: toolLoop.status,
+      }),
+    [toolLoop.name, toolLoop.status],
+  );
   const softMicLabel = softMicWarning
     ? tt(liveVoiceErrorMessageKey(softMicWarning) as MessageKey)
     : null;
@@ -553,6 +587,49 @@ export function VoiceOverlay({
         deny: tt("perm.deny"),
       })
     : [];
+
+  const sessionChips = useMemo(() => {
+    const merged = mergeVoiceSessionsForChips({
+      delegatedIds: state?.delegatedSessionIds ?? [],
+      // Only pass busy/permission rows as non-delegated candidates;
+      // idle sidebar chats stay out of the command-center strip.
+      sessions: (sessionSummaries ?? []).filter((s) => {
+        const st = normalizeVoiceChipStatus(s.status);
+        return st === "running" || st === "permission" || Boolean(s.isDelegated);
+      }),
+    });
+    // Prefer host-delegated chips; fall back to active Build sessions only.
+    const delegatedOnly = buildVoiceSessionChips(merged, {
+      preferDelegatedOnly: true,
+    });
+    if (delegatedOnly.length > 0) return delegatedOnly;
+    return buildVoiceSessionChips(merged, { preferDelegatedOnly: false }).filter(
+      (c) => c.status === "running" || c.status === "permission",
+    );
+  }, [state?.delegatedSessionIds, sessionSummaries]);
+
+  const keepBanner = useMemo(
+    () => resolveKeepAgentsBanner(keepAgentsOnEnd),
+    [keepAgentsOnEnd],
+  );
+  const endPlan = useMemo(
+    () =>
+      planVoiceEnd({
+        keepAgents: keepAgentsOnEnd,
+        hasRunningDelegates: hasRunningVoiceDelegates(sessionChips),
+      }),
+    [keepAgentsOnEnd, sessionChips],
+  );
+
+  const hasMic = !softMicWarning || !isSoftMicFailure(softMicWarning);
+  const centerEmptyKind = resolveVoiceCenterEmptyState({
+    hasMic,
+    hasAuth: hasVoiceAuth,
+    hasDelegates: hasDelegatedSessions(state) || sessionChips.length > 0,
+    transcriptEmpty:
+      emptyKind === "none" || emptyKind === "system_only",
+  });
+  const centerEmptyKey = voiceCenterEmptyMessageKey(centerEmptyKind);
 
   const handleSendTranscript = async () => {
     if (!showSend || !onSendTranscriptAsPrompt || !transcriptPrompt.trim()) {
@@ -599,38 +676,58 @@ export function VoiceOverlay({
                 aria-hidden
               />
               {statusLabel}
-              {toolStatusKey &&
-              (toolBusy ||
-                toolLoop.status === "completed" ||
-                toolLoop.status === "ok" ||
-                toolLoop.status === "soft_fail" ||
-                toolLoop.status === "error") ? (
-                <span
-                  className={cn(
-                    "voice-overlay__tool-chip",
-                    `is-${toolLoop.status === "running" ? "tool_running" : toolLoop.status === "ok" ? "completed" : toolLoop.status}`,
-                  )}
-                >
-                  {tt(toolStatusKey, {
-                    name: toolLoop.name ?? "tool",
-                    reason: toolLoop.reason ?? "",
-                    title:
-                      toolLoop.permissionTitle ??
-                      toolLoop.name ??
-                      "",
-                  })}
-                </span>
-              ) : null}
             </div>
           </div>
           <button
             type="button"
             className="voice-overlay__end"
+            title={tt(endPlan.noteMessageKey as MessageKey)}
             onClick={() => void handleEnd()}
           >
             {tt("voice.stop")}
           </button>
         </header>
+
+        {/* Tool + permission status region (host events only). */}
+        <div
+          className="voice-overlay__tool-status"
+          role="status"
+          data-tool-status={formattedTool.status}
+          data-tool-name={formattedTool.name ?? undefined}
+          data-permission-pending={permPending ? "true" : undefined}
+        >
+          {toolStatusKey &&
+          (toolBusy ||
+            toolLoop.status === "completed" ||
+            toolLoop.status === "ok" ||
+            toolLoop.status === "soft_fail" ||
+            toolLoop.status === "error" ||
+            permPending) ? (
+            <span
+              className={cn(
+                "voice-overlay__tool-chip",
+                `is-${
+                  toolLoop.status === "running"
+                    ? "tool_running"
+                    : toolLoop.status === "ok"
+                      ? "completed"
+                      : toolLoop.status
+                }`,
+              )}
+            >
+              {tt(toolStatusKey, {
+                name: toolLoop.name ?? "tool",
+                reason: toolLoop.reason ?? "",
+                title:
+                  toolLoop.permissionTitle ?? toolLoop.name ?? "",
+              })}
+            </span>
+          ) : (
+            <span className="voice-overlay__tool-idle">
+              {tt("voice.center.toolIdle")}
+            </span>
+          )}
+        </div>
 
         {error ? <div className="voice-overlay__error">{error}</div> : null}
         {!error && softMicLabel ? (
@@ -691,6 +788,54 @@ export function VoiceOverlay({
           </div>
         ) : null}
 
+        {/* Session chips strip — delegated / active Build sessions. */}
+        <section
+          className="voice-overlay__chips-strip"
+          aria-label={tt("voice.delegated")}
+        >
+          <div className="voice-overlay__delegated-title">
+            {tt("voice.delegated")}
+          </div>
+          {sessionChips.length === 0 ? (
+            <div className="voice-overlay__muted">{tt("voice.noDelegated")}</div>
+          ) : (
+            <ul className="voice-overlay__chips">
+              {sessionChips.map((chip) => (
+                <li key={chip.id}>
+                  <button
+                    type="button"
+                    className={cn(
+                      "voice-overlay__chip",
+                      `is-${chip.tone}`,
+                      chip.isDelegated && "is-delegated",
+                    )}
+                    data-session-id={chip.id}
+                    data-status={chip.status}
+                    title={chip.id}
+                    onClick={() => focusSession?.(chip.id)}
+                  >
+                    <span
+                      className={cn(
+                        "voice-overlay__chip-dot",
+                        `is-${chip.tone}`,
+                      )}
+                      aria-hidden
+                    />
+                    <span className="voice-overlay__chip-label">
+                      {chip.label}
+                    </span>
+                    {chip.isDelegated ? (
+                      <span className="voice-overlay__chip-tag">
+                        {tt("voice.center.chipDelegated")}
+                      </span>
+                    ) : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
         <div className="voice-overlay__wave" aria-hidden>
           <span
             className={cn(
@@ -725,12 +870,13 @@ export function VoiceOverlay({
         </div>
 
         <div className="voice-overlay__transcript">
-          {emptyKind === "none" ? (
-            <div className="voice-overlay__muted">{tt("voice.transcriptEmpty")}</div>
-          ) : null}
-          {emptyKind === "system_only" ? (
+          {emptyKind === "none" || emptyKind === "system_only" ? (
             <div className="voice-overlay__muted">
-              {tt("voice.transcriptSystemOnly")}
+              {centerEmptyKey
+                ? tt(centerEmptyKey as MessageKey)
+                : emptyKind === "system_only"
+                  ? tt("voice.transcriptSystemOnly")
+                  : tt("voice.transcriptEmpty")}
             </div>
           ) : null}
           {lines.map((l) => (
@@ -770,25 +916,6 @@ export function VoiceOverlay({
               </div>
             )
           ) : null}
-        </div>
-
-        <section className="voice-overlay__delegated">
-          <div className="voice-overlay__delegated-title">
-            {tt("voice.delegated")}
-          </div>
-          {!hasDelegatedSessions(state) ? (
-            <div className="voice-overlay__muted">{tt("voice.noDelegated")}</div>
-          ) : (
-            <ul className="voice-overlay__chips">
-              {(state?.delegatedSessionIds ?? []).map((id) => (
-                <li key={id}>
-                  <button type="button" onClick={() => onOpenSession?.(id)}>
-                    {tt("voice.openSession")} · {id.slice(0, 8)}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
           {state?.mock ? (
             <button
               type="button"
@@ -798,7 +925,23 @@ export function VoiceOverlay({
               {tt("voice.demoDelegate")}
             </button>
           ) : null}
-        </section>
+        </div>
+
+        {/* Footer honesty: keep coding sessions pref + end-session note. */}
+        <footer className="voice-overlay__footer">
+          <div
+            className={cn(
+              "voice-overlay__keep-banner",
+              keepBanner.keep ? "is-keep" : "is-cancel",
+            )}
+            data-keep-agents={keepBanner.keep ? "true" : "false"}
+          >
+            {tt(keepBanner.messageKey as MessageKey)}
+          </div>
+          <div className="voice-overlay__end-note">
+            {tt(endPlan.noteMessageKey as MessageKey)}
+          </div>
+        </footer>
       </div>
     </div>
   );

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -5510,6 +5510,26 @@ const en = {
   "voice.sendTranscriptNeedSpeech":
     "Need user or assistant speech from the host before sending.",
   "voice.transcriptSent": "Transcript sent to the active session",
+  "voice.center.toolIdle": "No Build tool running",
+  "voice.center.chipDelegated": "Voice",
+  "voice.center.keepAgentsOn":
+    "Keep coding sessions: on — ending Live Voice leaves delegated agents running.",
+  "voice.center.keepAgentsOff":
+    "Keep coding sessions: off — ending Live Voice may stop sessions started from voice.",
+  "voice.center.endNote.keepAgents":
+    "Stop ends voice and cancels in-flight host tools. Coding sessions stay.",
+  "voice.center.endNote.keepRunning":
+    "Stop ends voice. Running delegated coding sessions stay open.",
+  "voice.center.endNote.cancelDelegates":
+    "Stop ends voice, cancels in-flight tools, and stops delegated coding sessions.",
+  "voice.center.endNote.stopOnly":
+    "Stop ends voice and cancels in-flight host tools.",
+  "voice.center.empty.noAuth":
+    "Live Voice needs Grok auth (CLI login or official API key). No speech transcript yet.",
+  "voice.center.empty.noMic":
+    "Microphone unavailable. Transcript stays empty until the host sends text — nothing is invented.",
+  "voice.center.empty.transcriptWithDelegates":
+    "No speech transcript yet (host only). Delegated coding sessions are listed above.",
   "settings.preferredAgent.default": "Default (CLI)",
   "settings.preferredAgent.source.bundled": "Bundled",
   "settings.preferredAgent.source.builtin": "Built-in",
@@ -11435,6 +11455,26 @@ const zh: Record<MessageKey, string> = {
   "voice.sendTranscriptNeedSpeech":
     "需要主机提供的用户或助手发言后才能发送。",
   "voice.transcriptSent": "转写已发送到当前会话",
+  "voice.center.toolIdle": "当前没有 Build 工具在运行",
+  "voice.center.chipDelegated": "语音",
+  "voice.center.keepAgentsOn":
+    "结束后保留编码会话：开 — 结束实时语音不会停止已委派的 Agent。",
+  "voice.center.keepAgentsOff":
+    "结束后保留编码会话：关 — 结束实时语音可能会停止由语音拉起的会话。",
+  "voice.center.endNote.keepAgents":
+    "停止会结束语音并取消进行中的主机工具；编码会话会保留。",
+  "voice.center.endNote.keepRunning":
+    "停止会结束语音；正在运行的委派编码会话会继续保留。",
+  "voice.center.endNote.cancelDelegates":
+    "停止会结束语音、取消进行中的工具，并停止委派的编码会话。",
+  "voice.center.endNote.stopOnly":
+    "停止会结束语音并取消进行中的主机工具。",
+  "voice.center.empty.noAuth":
+    "实时语音需要 Grok 鉴权（CLI 登录或官方 API key）。尚无语音转写。",
+  "voice.center.empty.noMic":
+    "麦克风不可用。在主机推送文本之前转写保持为空 — 不会伪造 STT。",
+  "voice.center.empty.transcriptWithDelegates":
+    "尚无语音转写（仅主机推送）。上方已列出委派的编码会话。",
   "settings.preferredAgent.default": "default",
   "settings.preferredAgent.source.bundled": "bundled",
   "settings.preferredAgent.source.builtin": "Built-in",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -5291,6 +5291,26 @@ export const zhTW: Record<MessageKey, string> = {
   "voice.sendTranscriptNeedSpeech":
     "需要主機提供的使用者或助手發言後才能傳送。",
   "voice.transcriptSent": "轉寫已傳送到目前工作階段",
+  "voice.center.toolIdle": "目前沒有 Build 工具在執行",
+  "voice.center.chipDelegated": "語音",
+  "voice.center.keepAgentsOn":
+    "結束後保留編碼工作階段：開 — 結束即時語音不會停止已委派的 Agent。",
+  "voice.center.keepAgentsOff":
+    "結束後保留編碼工作階段：關 — 結束即時語音可能會停止由語音拉起的工作階段。",
+  "voice.center.endNote.keepAgents":
+    "停止會結束語音並取消進行中的主機工具；編碼工作階段會保留。",
+  "voice.center.endNote.keepRunning":
+    "停止會結束語音；正在執行的委派編碼工作階段會繼續保留。",
+  "voice.center.endNote.cancelDelegates":
+    "停止會結束語音、取消進行中的工具，並停止委派的編碼工作階段。",
+  "voice.center.endNote.stopOnly":
+    "停止會結束語音並取消進行中的主機工具。",
+  "voice.center.empty.noAuth":
+    "即時語音需要 Grok 驗證（CLI 登入或官方 API key）。尚無語音轉寫。",
+  "voice.center.empty.noMic":
+    "麥克風不可用。在主機推送文字之前轉寫保持為空 — 不會偽造 STT。",
+  "voice.center.empty.transcriptWithDelegates":
+    "尚無語音轉寫（僅主機推送）。上方已列出委派的編碼工作階段。",
   "settings.preferredAgent.default": "Default (CLI)",
   "settings.preferredAgent.source.bundled": "Bundled",
   "settings.preferredAgent.source.builtin": "Built-in",

--- a/src/lib/voiceCommandCenter.test.ts
+++ b/src/lib/voiceCommandCenter.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVoiceSessionChips,
+  formatVoiceSessionChipLabel,
+  formatVoiceToolStatus,
+  hasRunningVoiceDelegates,
+  mergeVoiceSessionsForChips,
+  normalizeVoiceChipStatus,
+  planVoiceEnd,
+  resolveKeepAgentsBanner,
+  resolveVoiceCenterEmptyState,
+  voiceCenterEmptyMessageKey,
+} from "./voiceCommandCenter";
+
+describe("buildVoiceSessionChips", () => {
+  it("builds chips from real titles and statuses; never invents ids", () => {
+    const chips = buildVoiceSessionChips([
+      { id: "abc12345xyz", title: "Fix tests", status: "streaming", isDelegated: true },
+      { id: "other", title: "Chat", status: "idle", isDelegated: false },
+    ]);
+    expect(chips).toHaveLength(1); // prefer delegated only when any delegated
+    expect(chips[0].label).toBe("Fix tests");
+    expect(chips[0].status).toBe("running");
+    expect(chips[0].isDelegated).toBe(true);
+    expect(chips[0].tone).toBe("running");
+  });
+
+  it("falls back to short id when title missing", () => {
+    const chips = buildVoiceSessionChips(
+      [{ id: "abcdefghij", title: "", status: "ready", isDelegated: true }],
+      { preferDelegatedOnly: false },
+    );
+    expect(chips[0].label).toBe("abcdefgh");
+  });
+
+  it("includes non-delegated when none are delegated", () => {
+    const chips = buildVoiceSessionChips([
+      { id: "a", title: "One", status: "idle" },
+      { id: "b", title: "Two", status: "streaming" },
+    ]);
+    expect(chips).toHaveLength(2);
+    // running first
+    expect(chips[0].id).toBe("b");
+    expect(chips[0].status).toBe("running");
+  });
+
+  it("drops empty ids", () => {
+    expect(
+      buildVoiceSessionChips([
+        { id: "  ", title: "x" },
+        { id: "ok", title: "Y", isDelegated: true },
+      ]),
+    ).toHaveLength(1);
+  });
+
+  it("sorts permission ahead of running among delegated", () => {
+    const chips = buildVoiceSessionChips([
+      {
+        id: "1",
+        title: "A",
+        status: "streaming",
+        isDelegated: true,
+      },
+      {
+        id: "2",
+        title: "B",
+        status: "awaiting_permission",
+        isDelegated: true,
+      },
+    ]);
+    expect(chips.map((c) => c.id)).toEqual(["2", "1"]);
+    expect(chips[0].status).toBe("permission");
+  });
+});
+
+describe("normalizeVoiceChipStatus / formatVoiceSessionChipLabel", () => {
+  it("maps known tokens; unknown stays unknown", () => {
+    expect(normalizeVoiceChipStatus("STREAMING")).toBe("running");
+    expect(normalizeVoiceChipStatus("awaiting_permission")).toBe("permission");
+    expect(normalizeVoiceChipStatus("completed")).toBe("done");
+    expect(normalizeVoiceChipStatus("failed")).toBe("error");
+    expect(normalizeVoiceChipStatus("weird_token")).toBe("unknown");
+    expect(normalizeVoiceChipStatus("")).toBe("unknown");
+  });
+
+  it("truncates long titles honestly", () => {
+    const long = "x".repeat(40);
+    expect(formatVoiceSessionChipLabel("id1", long).endsWith("…")).toBe(true);
+    expect(formatVoiceSessionChipLabel("id1", long).length).toBeLessThanOrEqual(
+      28,
+    );
+  });
+});
+
+describe("mergeVoiceSessionsForChips", () => {
+  it("marks host delegated ids and fills missing titles as null", () => {
+    const rows = mergeVoiceSessionsForChips({
+      delegatedIds: ["d1", "d2"],
+      sessions: [
+        { id: "d1", title: "Voice task", status: "streaming" },
+        { id: "side", title: "Other", status: "idle" },
+      ],
+    });
+    const d1 = rows.find((r) => r.id === "d1");
+    const d2 = rows.find((r) => r.id === "d2");
+    const side = rows.find((r) => r.id === "side");
+    expect(d1?.isDelegated).toBe(true);
+    expect(d1?.title).toBe("Voice task");
+    expect(d2?.isDelegated).toBe(true);
+    expect(d2?.title).toBeNull();
+    expect(side?.isDelegated).toBe(false);
+  });
+});
+
+describe("resolveVoiceCenterEmptyState", () => {
+  it("prioritizes no_auth then no_mic when transcript empty", () => {
+    expect(
+      resolveVoiceCenterEmptyState({
+        hasMic: false,
+        hasAuth: false,
+        hasDelegates: false,
+        transcriptEmpty: true,
+      }),
+    ).toBe("no_auth");
+    expect(
+      resolveVoiceCenterEmptyState({
+        hasMic: false,
+        hasAuth: true,
+        hasDelegates: false,
+        transcriptEmpty: true,
+      }),
+    ).toBe("no_mic");
+  });
+
+  it("returns null when transcript has real content (even if mic soft-fails)", () => {
+    expect(
+      resolveVoiceCenterEmptyState({
+        hasMic: true,
+        hasAuth: true,
+        hasDelegates: true,
+        transcriptEmpty: false,
+      }),
+    ).toBeNull();
+    expect(
+      resolveVoiceCenterEmptyState({
+        hasMic: false,
+        hasAuth: true,
+        hasDelegates: false,
+        transcriptEmpty: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("distinguishes empty transcript with/without delegates", () => {
+    expect(
+      resolveVoiceCenterEmptyState({
+        hasMic: true,
+        hasAuth: true,
+        hasDelegates: false,
+        transcriptEmpty: true,
+      }),
+    ).toBe("transcript_empty");
+    expect(
+      resolveVoiceCenterEmptyState({
+        hasMic: true,
+        hasAuth: true,
+        hasDelegates: true,
+        transcriptEmpty: true,
+      }),
+    ).toBe("transcript_empty_with_delegates");
+  });
+
+  it("maps kinds to i18n keys without inventing STT", () => {
+    expect(voiceCenterEmptyMessageKey("transcript_empty")).toBe(
+      "voice.transcriptEmpty",
+    );
+    expect(voiceCenterEmptyMessageKey("no_auth")).toBe(
+      "voice.center.empty.noAuth",
+    );
+    expect(voiceCenterEmptyMessageKey(null)).toBeNull();
+  });
+});
+
+describe("formatVoiceToolStatus", () => {
+  it("formats running tool with real name only", () => {
+    const f = formatVoiceToolStatus({
+      name: "create_agent_session",
+      status: "tool_running",
+    });
+    expect(f.status).toBe("tool_running");
+    expect(f.name).toBe("create_agent_session");
+    expect(f.busy).toBe(true);
+    expect(f.messageKey).toBe("voice.toolRunning");
+    expect(f.label).toContain("create_agent_session");
+  });
+
+  it("never invents a tool when name absent", () => {
+    const f = formatVoiceToolStatus({ status: "tool_running" });
+    expect(f.name).toBeNull();
+    // status alone with no name still surfaces when raw present
+    expect(f.messageKey).toBe("voice.toolRunning");
+  });
+
+  it("returns idle empty for blank input", () => {
+    expect(formatVoiceToolStatus(null)).toEqual({
+      status: "idle",
+      name: null,
+      label: "",
+      messageKey: null,
+      busy: false,
+    });
+    expect(formatVoiceToolStatus({ name: "", status: "" }).status).toBe("idle");
+  });
+
+  it("maps permission and soft-fail tokens", () => {
+    expect(
+      formatVoiceToolStatus({ name: "bash", status: "permission_pending" })
+        .status,
+    ).toBe("permission_pending");
+    expect(
+      formatVoiceToolStatus({ name: "bash", status: "cancelled" }).status,
+    ).toBe("soft_fail");
+  });
+});
+
+describe("resolveKeepAgentsBanner", () => {
+  it("defaults to keep on undefined/true", () => {
+    expect(resolveKeepAgentsBanner(true).keep).toBe(true);
+    expect(resolveKeepAgentsBanner(undefined).keep).toBe(true);
+    expect(resolveKeepAgentsBanner(undefined).messageKey).toBe(
+      "voice.center.keepAgentsOn",
+    );
+    expect(resolveKeepAgentsBanner(false).keep).toBe(false);
+    expect(resolveKeepAgentsBanner(false).messageKey).toBe(
+      "voice.center.keepAgentsOff",
+    );
+  });
+});
+
+describe("planVoiceEnd", () => {
+  it("keeps delegates when keepAgents is on", () => {
+    const plan = planVoiceEnd({
+      keepAgents: true,
+      hasRunningDelegates: true,
+    });
+    expect(plan.willCancelDelegates).toBe(false);
+    expect(plan.actions).toContain("keep_delegates");
+    expect(plan.actions).not.toContain("cancel_delegates");
+    expect(plan.noteMessageKey).toBe("voice.center.endNote.keepRunning");
+  });
+
+  it("cancels delegates only when pref off and running observed", () => {
+    const plan = planVoiceEnd({
+      keepAgents: false,
+      hasRunningDelegates: true,
+    });
+    expect(plan.willCancelDelegates).toBe(true);
+    expect(plan.actions).toContain("cancel_delegates");
+    expect(plan.noteMessageKey).toBe("voice.center.endNote.cancelDelegates");
+  });
+
+  it("does not claim cancel when no running delegates", () => {
+    const plan = planVoiceEnd({
+      keepAgents: false,
+      hasRunningDelegates: false,
+    });
+    expect(plan.willCancelDelegates).toBe(false);
+    expect(plan.noteMessageKey).toBe("voice.center.endNote.stopOnly");
+  });
+
+  it("always stops voice and cancels in-flight tools", () => {
+    const plan = planVoiceEnd({
+      keepAgents: true,
+      hasRunningDelegates: false,
+    });
+    expect(plan.actions[0]).toBe("stop_voice");
+    expect(plan.actions).toContain("cancel_in_flight_tools");
+  });
+});
+
+describe("hasRunningVoiceDelegates", () => {
+  it("only counts delegated running/permission chips", () => {
+    expect(
+      hasRunningVoiceDelegates([
+        {
+          id: "1",
+          label: "A",
+          status: "running",
+          isDelegated: false,
+          tone: "running",
+        },
+      ]),
+    ).toBe(false);
+    expect(
+      hasRunningVoiceDelegates([
+        {
+          id: "1",
+          label: "A",
+          status: "running",
+          isDelegated: true,
+          tone: "running",
+        },
+      ]),
+    ).toBe(true);
+    expect(hasRunningVoiceDelegates([])).toBe(false);
+  });
+});

--- a/src/lib/voiceCommandCenter.ts
+++ b/src/lib/voiceCommandCenter.ts
@@ -1,0 +1,482 @@
+/**
+ * Live Voice command center — pure helpers for session chips, empty-state
+ * honesty, tool/permission status labels, keep-agents banner, and end plan.
+ *
+ * No invented STT / tool results. UI maps returned kinds to i18n keys.
+ */
+
+// ── Session chips ────────────────────────────────────────────────────────────
+
+/** Input row for a chip (from App session list + live status). */
+export type VoiceSessionChipInput = {
+  id: string;
+  title?: string | null;
+  /** Host/UI status token (streaming · idle · ready · awaiting_permission · …). */
+  status?: string | null;
+  /** True when started from Live Voice host tools. */
+  isDelegated?: boolean;
+};
+
+/** Normalized chip for the overlay strip. */
+export type VoiceSessionChip = {
+  id: string;
+  /** Display label — real title or short id fallback (never invents speech). */
+  label: string;
+  /** Normalized status token for CSS / a11y. */
+  status: VoiceChipStatus;
+  isDelegated: boolean;
+  /** Visual tone bucket. */
+  tone: VoiceChipTone;
+};
+
+export type VoiceChipStatus =
+  | "running"
+  | "permission"
+  | "idle"
+  | "done"
+  | "error"
+  | "unknown";
+
+export type VoiceChipTone =
+  | "running"
+  | "permission"
+  | "idle"
+  | "done"
+  | "error"
+  | "unknown";
+
+const SHORT_ID_LEN = 8;
+const MAX_LABEL_LEN = 28;
+
+/**
+ * Normalize a free-form session status into a chip status.
+ * Unknown tokens stay `unknown` — never invents "running".
+ */
+export function normalizeVoiceChipStatus(
+  raw: string | null | undefined,
+): VoiceChipStatus {
+  const s = (raw ?? "").trim().toLowerCase();
+  if (!s) return "unknown";
+  if (
+    s === "streaming" ||
+    s === "running" ||
+    s === "busy" ||
+    s === "connecting" ||
+    s === "thinking" ||
+    s === "tool_running" ||
+    s === "in_progress"
+  ) {
+    return "running";
+  }
+  if (
+    s === "awaiting_permission" ||
+    s === "permission_pending" ||
+    s === "permission"
+  ) {
+    return "permission";
+  }
+  if (
+    s === "idle" ||
+    s === "ready" ||
+    s === "active" ||
+    s === "listening" ||
+    s === "disconnected"
+  ) {
+    return "idle";
+  }
+  if (
+    s === "done" ||
+    s === "completed" ||
+    s === "complete" ||
+    s === "finished" ||
+    s === "ended"
+  ) {
+    return "done";
+  }
+  if (
+    s === "error" ||
+    s === "failed" ||
+    s === "failure" ||
+    s === "crashed"
+  ) {
+    return "error";
+  }
+  return "unknown";
+}
+
+/** Map chip status → tone (1:1 for CSS). */
+export function voiceChipTone(status: VoiceChipStatus): VoiceChipTone {
+  return status;
+}
+
+/**
+ * Build a display label from a real title or short id.
+ * Never invents STT / fake session names.
+ */
+export function formatVoiceSessionChipLabel(
+  id: string,
+  title?: string | null,
+): string {
+  const t = (title ?? "").trim();
+  if (t) {
+    if (t.length <= MAX_LABEL_LEN) return t;
+    return `${t.slice(0, MAX_LABEL_LEN - 1)}…`;
+  }
+  const sid = (id ?? "").trim();
+  if (!sid) return "session";
+  return sid.length <= SHORT_ID_LEN ? sid : sid.slice(0, SHORT_ID_LEN);
+}
+
+/**
+ * Build ordered session chips for the command-center strip.
+ * - Prefers delegated sessions first, then other active/running rows.
+ * - Drops empty ids; never invents sessions.
+ * - When `preferDelegatedOnly` is true (default when any isDelegated), only
+ *   delegated rows are shown (product: voice-started coding sessions).
+ */
+export function buildVoiceSessionChips(
+  sessions: readonly VoiceSessionChipInput[] | null | undefined,
+  opts?: { preferDelegatedOnly?: boolean },
+): VoiceSessionChip[] {
+  if (!sessions?.length) return [];
+
+  const cleaned = sessions
+    .map((s) => {
+      const id = (s.id ?? "").trim();
+      if (!id) return null;
+      const status = normalizeVoiceChipStatus(s.status);
+      return {
+        id,
+        label: formatVoiceSessionChipLabel(id, s.title),
+        status,
+        isDelegated: Boolean(s.isDelegated),
+        tone: voiceChipTone(status),
+      } satisfies VoiceSessionChip;
+    })
+    .filter((c): c is VoiceSessionChip => c !== null);
+
+  if (!cleaned.length) return [];
+
+  const hasAnyDelegated = cleaned.some((c) => c.isDelegated);
+  const preferDelegatedOnly = opts?.preferDelegatedOnly ?? hasAnyDelegated;
+
+  let list = cleaned;
+  if (preferDelegatedOnly && hasAnyDelegated) {
+    list = cleaned.filter((c) => c.isDelegated);
+  }
+
+  // Delegated first, then running/permission, stable by input order.
+  return list.slice().sort((a, b) => {
+    if (a.isDelegated !== b.isDelegated) return a.isDelegated ? -1 : 1;
+    const rank = (s: VoiceChipStatus) =>
+      s === "permission" ? 0 : s === "running" ? 1 : s === "error" ? 2 : 3;
+    const d = rank(a.status) - rank(b.status);
+    if (d !== 0) return d;
+    return 0;
+  });
+}
+
+/**
+ * Merge host delegated ids with sidebar session summaries for chips.
+ * Host ids without a title stay as short-id labels (honest).
+ */
+export function mergeVoiceSessionsForChips(opts: {
+  delegatedIds?: readonly string[] | null;
+  sessions?: readonly VoiceSessionChipInput[] | null;
+}): VoiceSessionChipInput[] {
+  const delegated = new Set(
+    (opts.delegatedIds ?? []).map((id) => id.trim()).filter(Boolean),
+  );
+  const byId = new Map<string, VoiceSessionChipInput>();
+
+  for (const s of opts.sessions ?? []) {
+    const id = (s.id ?? "").trim();
+    if (!id) continue;
+    byId.set(id, {
+      id,
+      title: s.title,
+      status: s.status,
+      isDelegated: s.isDelegated || delegated.has(id),
+    });
+  }
+
+  for (const id of delegated) {
+    if (byId.has(id)) {
+      const prev = byId.get(id)!;
+      byId.set(id, { ...prev, isDelegated: true });
+    } else {
+      byId.set(id, { id, title: null, status: "unknown", isDelegated: true });
+    }
+  }
+
+  return Array.from(byId.values());
+}
+
+// ── Empty-state honesty ──────────────────────────────────────────────────────
+
+/**
+ * Why the command center shows empty / soft-fail chrome.
+ * Priority: auth → mic → transcript empty (with/without delegates) → null (has content).
+ * Never invents STT text for the empty pane.
+ */
+export type VoiceCenterEmptyKind =
+  | "no_auth"
+  | "no_mic"
+  | "transcript_empty"
+  | "transcript_empty_with_delegates"
+  | "ready_no_speech"
+  | null;
+
+/**
+ * Resolve empty-state honesty kind for the Live Voice command center.
+ * When `transcriptEmpty` is false, returns null (real host text is showing).
+ * Soft mic/auth banners still surface separately in the overlay.
+ */
+export function resolveVoiceCenterEmptyState(opts: {
+  hasMic: boolean;
+  hasAuth: boolean;
+  hasDelegates: boolean;
+  transcriptEmpty: boolean;
+}): VoiceCenterEmptyKind {
+  // Real conversational content → no empty chrome.
+  if (!opts.transcriptEmpty) return null;
+  // Auth / mic honesty only when there is nothing to read yet.
+  if (!opts.hasAuth) return "no_auth";
+  if (!opts.hasMic) return "no_mic";
+  if (opts.hasDelegates) return "transcript_empty_with_delegates";
+  // Soft mic/auth ok, nothing spoken yet — honest waiting copy.
+  return "transcript_empty";
+}
+
+/** i18n MessageKey fragment for empty kinds (null when no empty chrome). */
+export function voiceCenterEmptyMessageKey(
+  kind: VoiceCenterEmptyKind,
+): string | null {
+  switch (kind) {
+    case "no_auth":
+      return "voice.center.empty.noAuth";
+    case "no_mic":
+      return "voice.center.empty.noMic";
+    case "transcript_empty":
+      return "voice.transcriptEmpty";
+    case "transcript_empty_with_delegates":
+      return "voice.center.empty.transcriptWithDelegates";
+    case "ready_no_speech":
+      return "voice.transcriptEmpty";
+    default:
+      return null;
+  }
+}
+
+// ── Tool status ──────────────────────────────────────────────────────────────
+
+export type VoiceToolStatusInput = {
+  name?: string | null;
+  status?: string | null;
+};
+
+export type FormattedVoiceToolStatus = {
+  /** Canonical status token (tool_running · permission_pending · …). */
+  status: string;
+  /** Real tool name or null when absent (never invents). */
+  name: string | null;
+  /** Compact status line without inventing names. */
+  label: string;
+  /** i18n key for status chrome (null when idle / absent). */
+  messageKey: string | null;
+  busy: boolean;
+};
+
+/**
+ * Format a Build tool status for the command-center status region.
+ * Name comes only from host events — empty name → no invented tool.
+ */
+export function formatVoiceToolStatus(
+  tool: VoiceToolStatusInput | null | undefined,
+): FormattedVoiceToolStatus {
+  const name = (tool?.name ?? "").trim() || null;
+  const raw = (tool?.status ?? "").trim().toLowerCase();
+
+  let status = "idle";
+  if (
+    raw === "running" ||
+    raw === "tool_running" ||
+    raw === "in_progress"
+  ) {
+    status = "tool_running";
+  } else if (
+    raw === "permission_pending" ||
+    raw === "permission" ||
+    raw === "awaiting_permission"
+  ) {
+    status = "permission_pending";
+  } else if (
+    raw === "ok" ||
+    raw === "completed" ||
+    raw === "success" ||
+    raw === "done"
+  ) {
+    status = "completed";
+  } else if (
+    raw === "soft_fail" ||
+    raw === "softfail" ||
+    raw === "cancelled" ||
+    raw === "canceled"
+  ) {
+    status = "soft_fail";
+  } else if (raw === "error" || raw === "failed" || raw === "failure") {
+    status = "error";
+  } else if (raw && raw !== "idle") {
+    status = raw;
+  } else if (name && !raw) {
+    // Name-only without status: treat as in-flight (host start event).
+    status = "tool_running";
+  }
+
+  if (!name && (status === "idle" || !raw)) {
+    return {
+      status: "idle",
+      name: null,
+      label: "",
+      messageKey: null,
+      busy: false,
+    };
+  }
+
+  const busy =
+    status === "tool_running" || status === "permission_pending";
+
+  let messageKey: string | null = null;
+  switch (status) {
+    case "tool_running":
+      messageKey = "voice.toolRunning";
+      break;
+    case "permission_pending":
+      messageKey = "voice.permissionPending";
+      break;
+    case "completed":
+      messageKey = "voice.toolRan";
+      break;
+    case "soft_fail":
+      messageKey = "voice.toolSoftFail";
+      break;
+    case "error":
+      messageKey = "voice.toolFailed";
+      break;
+    default:
+      messageKey = name ? "voice.toolRunning" : null;
+  }
+
+  const displayName = name ?? "tool";
+  const label =
+    status === "permission_pending"
+      ? `permission · ${displayName}`
+      : `${status} · ${displayName}`;
+
+  return {
+    status,
+    name,
+    label,
+    messageKey,
+    busy,
+  };
+}
+
+// ── Keep-agents banner ───────────────────────────────────────────────────────
+
+export type KeepAgentsBanner = {
+  /** Pref is on — ending voice keeps coding sessions. */
+  keep: boolean;
+  /** i18n key for footer honesty line. */
+  messageKey: string;
+};
+
+/**
+ * Footer honesty for “Keep coding sessions after Live Voice” setting.
+ */
+export function resolveKeepAgentsBanner(
+  keepAgentsOnEnd: boolean | null | undefined,
+): KeepAgentsBanner {
+  // Product default: keep (undefined/true).
+  const keep = keepAgentsOnEnd !== false;
+  return {
+    keep,
+    messageKey: keep
+      ? "voice.center.keepAgentsOn"
+      : "voice.center.keepAgentsOff",
+  };
+}
+
+// ── End-session plan ─────────────────────────────────────────────────────────
+
+export type VoiceEndAction =
+  | "stop_voice"
+  | "cancel_in_flight_tools"
+  | "keep_delegates"
+  | "cancel_delegates";
+
+export type VoiceEndPlan = {
+  /** Ordered host/UI actions (for copy and host flags). */
+  actions: VoiceEndAction[];
+  /** Whether delegated agents will be cancelled. */
+  willCancelDelegates: boolean;
+  /** Whether any running delegates were observed. */
+  hasRunningDelegates: boolean;
+  /** i18n key for end-button / confirm note (no window.confirm — overlay copy). */
+  noteMessageKey: string;
+};
+
+/**
+ * Plan what ending Live Voice will do (honesty for footer / end control).
+ * Does not invent running delegates — caller passes observed flag.
+ */
+export function planVoiceEnd(opts: {
+  keepAgents: boolean | null | undefined;
+  hasRunningDelegates: boolean;
+}): VoiceEndPlan {
+  const keep = opts.keepAgents !== false;
+  const hasRunning = Boolean(opts.hasRunningDelegates);
+  const willCancelDelegates = !keep && hasRunning;
+
+  const actions: VoiceEndAction[] = [
+    "stop_voice",
+    "cancel_in_flight_tools",
+  ];
+  if (keep) {
+    actions.push("keep_delegates");
+  } else if (hasRunning) {
+    actions.push("cancel_delegates");
+  } else {
+    actions.push("keep_delegates");
+  }
+
+  let noteMessageKey: string;
+  if (willCancelDelegates) {
+    noteMessageKey = "voice.center.endNote.cancelDelegates";
+  } else if (hasRunning && keep) {
+    noteMessageKey = "voice.center.endNote.keepRunning";
+  } else if (keep) {
+    noteMessageKey = "voice.center.endNote.keepAgents";
+  } else {
+    noteMessageKey = "voice.center.endNote.stopOnly";
+  }
+
+  return {
+    actions,
+    willCancelDelegates,
+    hasRunningDelegates: hasRunning,
+    noteMessageKey,
+  };
+}
+
+/** True when any chip is running or waiting on permission. */
+export function hasRunningVoiceDelegates(
+  chips: readonly VoiceSessionChip[] | null | undefined,
+): boolean {
+  if (!chips?.length) return false;
+  return chips.some(
+    (c) =>
+      c.isDelegated &&
+      (c.status === "running" || c.status === "permission"),
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -24356,7 +24356,94 @@ div.composer__input:empty::before {
   cursor: pointer;
 }
 .voice-overlay__demo {
-  margin-top: 0.5rem;
+  margin-top: 0;
+}
+/* Command center — tool status + chips + keep-agents footer */
+.voice-overlay__tool-status {
+  display: flex;
+  align-items: center;
+  min-height: 1.35rem;
+  font-size: 0.78rem;
+}
+.voice-overlay__tool-idle {
+  opacity: 0.45;
+  font-size: 0.75rem;
+}
+.voice-overlay__chips-strip {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 0.55rem;
+}
+.voice-overlay__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: 100%;
+}
+.voice-overlay__chip-dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.28);
+  flex: 0 0 auto;
+}
+.voice-overlay__chip-dot.is-running {
+  background: #38bdf8;
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.22);
+}
+.voice-overlay__chip-dot.is-permission {
+  background: #fbbf24;
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.22);
+}
+.voice-overlay__chip-dot.is-done {
+  background: #34d399;
+}
+.voice-overlay__chip-dot.is-error {
+  background: #fb7185;
+}
+.voice-overlay__chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 10rem;
+}
+.voice-overlay__chip-tag {
+  font-size: 0.65rem;
+  opacity: 0.7;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+.voice-overlay__chip.is-delegated {
+  border-color: rgba(52, 211, 153, 0.28);
+  background: rgba(52, 211, 153, 0.08);
+}
+.voice-overlay__chip.is-running {
+  border-color: rgba(56, 189, 248, 0.35);
+}
+.voice-overlay__chip.is-permission {
+  border-color: rgba(251, 191, 36, 0.4);
+}
+.voice-overlay__footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.voice-overlay__keep-banner {
+  font-size: 0.75rem;
+  line-height: 1.35;
+  opacity: 0.85;
+}
+.voice-overlay__keep-banner.is-keep {
+  color: #6ee7b7;
+}
+.voice-overlay__keep-banner.is-cancel {
+  color: #fcd34d;
+}
+.voice-overlay__end-note {
+  font-size: 0.7rem;
+  line-height: 1.35;
+  opacity: 0.5;
 }
 
 /* ── Remote control · IM (card-internal dual pane; page chrome is standard) ─ */


### PR DESCRIPTION
## Summary
- Pure `voiceCommandCenter` helpers: session chips, empty-state honesty, tool status formatting, keep-agents banner, end-session plan (no invented STT).
- Live Voice overlay productized as a command center: delegated/active session chip strip (click → focus session), tool + permission status region, footer honesty for Keep coding sessions on/off + end note.
- App thin wiring: pass session list + live status; `onFocusSession` focuses sidebar session.
- i18n en/zh/zh-TW + CHANGELOG Unreleased.

## Test plan
- [x] `pnpm test -- src/lib/voiceCommandCenter.test.ts src/lib/voiceOverlay.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Open Live Voice: empty transcript shows honest “no STT invented” copy
- [ ] Start a sample / delegated coding task: chip appears with title/status; click focuses session
- [ ] Toggle Keep coding sessions setting: footer banner reflects on/off; Stop title matches end plan
- [ ] Permission pending for delegated session: allow/deny in-overlay (no `window.confirm`)