### PR TITLE
feat(resources): multi-file tabs in resource viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Resource multi-file tabs**: open several files in the Resources workbench with a tab strip (dedupe by path, max 12 with LRU drop), dirty marker for unsaved text edits, switch without losing drafts, and GlassModal discard confirm on close — pure `resourceTabs` helpers + tests; en/zh/zh-TW.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -106,6 +106,15 @@ import {
   isResourceTextEditable,
 } from "@/lib/resourceEdit";
 import {
+  closeResourceTab,
+  openResourceTab,
+  resolveResourceTabsEmptyState,
+  resourceTabPathsEqual,
+  setActiveTab,
+  type OpenResourceTabResult,
+  type ResourceTab,
+} from "@/lib/resourceTabs";
+import {
   asideSurfaceFromPreviewKind,
   type AsideLayoutHint,
   type AsideSurface,
@@ -275,6 +284,50 @@ interface FileTab {
   /** true = textarea editor; false = preview (markdown default). */
   editMode?: boolean;
   saving?: boolean;
+}
+
+/** Slim strip model for pure open/close/LRU helpers. */
+function fileTabToResourceTab(t: FileTab): ResourceTab {
+  const path =
+    t.tabKind === "url"
+      ? t.url || t.relativePath
+      : t.absolutePath || t.relativePath;
+  return {
+    id: t.id,
+    path,
+    name: t.name,
+    kind: t.preview?.kind,
+    dirty: isResourceDraftDirty(t.draftText, t.baselineText),
+  };
+}
+
+/** Match a file tab by absolute or relative path (normalized). */
+function fileTabMatchesPath(t: FileTab, path: string): boolean {
+  if (t.tabKind === "url") {
+    return resourceTabPathsEqual(t.url || t.relativePath, path);
+  }
+  if (t.absolutePath && resourceTabPathsEqual(t.absolutePath, path)) return true;
+  if (t.relativePath && resourceTabPathsEqual(t.relativePath, path)) return true;
+  return false;
+}
+
+/**
+ * Apply pure open result onto rich FileTab list (order + LRU drops + optional create).
+ */
+function mergeFileTabsFromOpen(
+  prev: FileTab[],
+  open: OpenResourceTabResult,
+  created?: FileTab,
+): FileTab[] {
+  const byId = new Map(prev.map((t) => [t.id, t]));
+  if (created) byId.set(created.id, created);
+  for (const id of open.droppedIds) byId.delete(id);
+  const out: FileTab[] = [];
+  for (const r of open.tabs) {
+    const f = byId.get(r.id);
+    if (f) out.push(f);
+  }
+  return out;
 }
 
 function formatSize(n: number): string {
@@ -449,6 +502,14 @@ export function ResourceViewer({
   });
 
   const activeTab = tabs.find((t) => t.id === activeId) ?? null;
+  const filesTabsEmpty = useMemo(
+    () =>
+      resolveResourceTabsEmptyState({
+        tabCount: tabs.length,
+        sideMode,
+      }),
+    [tabs.length, sideMode],
+  );
   const changeCount = sessionChanges.length;
   const workspaceCount = workspaceFiles.length;
   const totalChangeBadge = changeCount + workspaceCount;
@@ -2125,18 +2186,28 @@ export function ResourceViewer({
       return;
     }
     const existing = tabs.find(
-      (t) => t.tabKind !== "url" && t.relativePath === relativePath,
+      (t) => t.tabKind !== "url" && fileTabMatchesPath(t, relativePath),
     );
-    if (existing) {
-      setTabs((prev) => {
-        const hit = prev.find((t) => t.id === existing.id);
-        if (!hit) return prev;
-        return [hit, ...prev.filter((t) => t.id !== existing.id)];
-      });
-      setActiveId(existing.id);
+    const keyPath = existing
+      ? fileTabToResourceTab(existing).path
+      : relativePath;
+    const open = openResourceTab(
+      tabs.map(fileTabToResourceTab),
+      keyPath,
+      existing
+        ? {
+            id: existing.id,
+            name: existing.name,
+            kind: existing.preview?.kind,
+          }
+        : { name: baseName(relativePath) },
+    );
+    if (!open.created) {
+      setTabs((prev) => mergeFileTabsFromOpen(prev, open));
+      setActiveId(open.activeId);
       return;
     }
-    const id = `tab_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+    const id = open.activeId;
     const tab: FileTab = {
       id,
       relativePath,
@@ -2148,8 +2219,7 @@ export function ResourceViewer({
       loading: true,
       tabKind: "file",
     };
-    // Newest tab on the left
-    setTabs((prev) => [tab, ...prev]);
+    setTabs((prev) => mergeFileTabsFromOpen(prev, open, tab));
     setActiveId(id);
     try {
       const r = await api.fsReadFile(projectPath, relativePath);
@@ -2184,21 +2254,27 @@ export function ResourceViewer({
       const norm = absolutePath.trim();
       if (!norm) return;
       const existing = tabs.find(
-        (t) =>
-          t.tabKind !== "url" &&
-          (t.absolutePath === norm || t.relativePath === norm),
+        (t) => t.tabKind !== "url" && fileTabMatchesPath(t, norm),
       );
-      if (existing) {
-        // Move existing to front + activate (Chrome-like focus)
-        setTabs((prev) => {
-          const hit = prev.find((t) => t.id === existing.id);
-          if (!hit) return prev;
-          return [hit, ...prev.filter((t) => t.id !== existing.id)];
-        });
-        setActiveId(existing.id);
+      const keyPath = existing ? fileTabToResourceTab(existing).path : norm;
+      const open = openResourceTab(
+        tabs.map(fileTabToResourceTab),
+        keyPath,
+        existing
+          ? {
+              id: existing.id,
+              name: title || existing.name,
+              kind: existing.preview?.kind,
+            }
+          : { name: title || baseName(norm) },
+      );
+      if (!open.created) {
+        // Move existing to front + activate (Chrome-like focus / MRU)
+        setTabs((prev) => mergeFileTabsFromOpen(prev, open));
+        setActiveId(open.activeId);
         return;
       }
-      const id = `tab_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+      const id = open.activeId;
       const tab: FileTab = {
         id,
         relativePath: norm,
@@ -2210,7 +2286,7 @@ export function ResourceViewer({
         loading: true,
         tabKind: "file",
       };
-      setTabs((prev) => [tab, ...prev]);
+      setTabs((prev) => mergeFileTabsFromOpen(prev, open, tab));
       setActiveId(id);
       try {
         const r = await api.fsOpenPath(norm, projectPath);
@@ -2255,18 +2331,29 @@ export function ResourceViewer({
     (url: string, title?: string) => {
       const u = url.trim();
       if (!u) return;
-      const existing = tabs.find((t) => t.tabKind === "url" && t.url === u);
-      if (existing) {
-        setActiveId(existing.id);
-        return;
-      }
-      const id = `tab_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+      const existing = tabs.find(
+        (t) => t.tabKind === "url" && fileTabMatchesPath(t, u),
+      );
       let name = title || u;
       try {
         name = title || new URL(u).hostname || u;
       } catch {
         /* keep */
       }
+      const keyPath = existing ? fileTabToResourceTab(existing).path : u;
+      const open = openResourceTab(
+        tabs.map(fileTabToResourceTab),
+        keyPath,
+        existing
+          ? { id: existing.id, name: title || existing.name, kind: "url" }
+          : { name, kind: "url" },
+      );
+      if (!open.created) {
+        setTabs((prev) => mergeFileTabsFromOpen(prev, open));
+        setActiveId(open.activeId);
+        return;
+      }
+      const id = open.activeId;
       const tab: FileTab = {
         id,
         relativePath: u,
@@ -2279,7 +2366,7 @@ export function ResourceViewer({
         url: u,
         tabKind: "url",
       };
-      setTabs((prev) => [tab, ...prev]);
+      setTabs((prev) => mergeFileTabsFromOpen(prev, open, tab));
       setActiveId(id);
     },
     [tabs],
@@ -2433,19 +2520,20 @@ export function ResourceViewer({
     (id: string) => {
       let remaining = -1;
       setTabs((prev) => {
-        const idx = prev.findIndex((t) => t.id === id);
-        if (idx < 0) {
-          remaining = prev.length;
-          return prev;
-        }
-        const next = prev.filter((t) => t.id !== id);
-        remaining = next.length;
-        if (activeId === id) {
-          // Prefer neighbor on the left (newer), else right
-          const neighbor = next[Math.max(0, idx - 1)] ?? next[0] ?? null;
-          setActiveId(neighbor?.id ?? null);
-        }
-        return next;
+        const closed = closeResourceTab(
+          prev.map(fileTabToResourceTab),
+          activeId,
+          id,
+        );
+        remaining = closed.tabs.length;
+        setActiveId(closed.activeId);
+        if (closed.tabs.length === prev.length) return prev;
+        const keep = new Set(closed.tabs.map((t) => t.id));
+        // Preserve pure-helper order (same relative order minus closed).
+        const byId = new Map(prev.map((t) => [t.id, t]));
+        return closed.tabs
+          .map((r) => byId.get(r.id))
+          .filter((t): t is FileTab => !!t && keep.has(t.id));
       });
       if (remaining === 0) closePaneIfNoTabs(0);
     },
@@ -3349,9 +3437,11 @@ export function ResourceViewer({
       <div className="rp-chrome">
         <div className="rp-tabs" role="tablist" aria-label={tr("resources.files")}>
           <div className="rp-tabs__scroll">
-            {tabs.length === 0 ? (
+            {filesTabsEmpty ? (
               <div className="rp-tabs__placeholder">
-                <span className="rp-tabs__hint">{tr("resources.emptyPreview")}</span>
+                <span className="rp-tabs__hint">
+                  {tr(filesTabsEmpty.titleKey)}
+                </span>
               </div>
             ) : (
               tabs.map((t) => {
@@ -3373,9 +3463,18 @@ export function ResourceViewer({
                       className={
                         "rp-tab" +
                         (active ? " is-active" : " is-inactive") +
-                        (t.tabKind === "url" ? " rp-tab--url" : "")
+                        (t.tabKind === "url" ? " rp-tab--url" : "") +
+                        (isResourceDraftDirty(t.draftText, t.baselineText)
+                          ? " is-dirty"
+                          : "")
                       }
-                      onClick={() => setActiveId(t.id)}
+                      onClick={() => {
+                        const next = setActiveTab(
+                          tabs.map(fileTabToResourceTab),
+                          t.id,
+                        );
+                        setActiveId(next.activeId);
+                      }}
                       onContextMenu={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
@@ -3675,7 +3774,9 @@ export function ResourceViewer({
                   ? tr("changes.empty")
                   : sideMode === "changes"
                     ? tr("changes.pickTitle")
-                    : tr("resources.emptyPreview")}
+                    : tr(
+                        filesTabsEmpty?.titleKey ?? "resources.emptyPreview",
+                      )}
               </div>
               <div className="rp__empty-desc">
                 {sideMode === "changes" &&
@@ -3684,7 +3785,10 @@ export function ResourceViewer({
                   ? tr("changes.emptyHint")
                   : sideMode === "changes"
                     ? tr("changes.pickHint")
-                    : tr("resources.emptyPreviewHint")}
+                    : tr(
+                        filesTabsEmpty?.hintKey ??
+                          "resources.emptyPreviewHint",
+                      )}
               </div>
               {sideMode === "changes" &&
               (changeCount > 0 || workspaceCount > 0) ? (

--- a/src/lib/resourceTabs.test.ts
+++ b/src/lib/resourceTabs.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  RESOURCE_TABS_MAX,
+  closeResourceTab,
+  markTabDirty,
+  normalizeResourceTabPath,
+  openResourceTab,
+  resolveResourceTabsEmptyState,
+  resourceTabPathsEqual,
+  setActiveTab,
+  type ResourceTab,
+} from "./resourceTabs";
+
+function tab(
+  partial: Partial<ResourceTab> & Pick<ResourceTab, "id" | "path">,
+): ResourceTab {
+  return {
+    name: partial.name ?? partial.path.split("/").pop() ?? partial.path,
+    dirty: partial.dirty ?? false,
+    kind: partial.kind,
+    id: partial.id,
+    path: partial.path,
+  };
+}
+
+describe("normalizeResourceTabPath / resourceTabPathsEqual", () => {
+  it("normalizes file separators and trailing slashes", () => {
+    expect(normalizeResourceTabPath("src\\\\lib\\\\a.ts")).toBe("src/lib/a.ts");
+    expect(normalizeResourceTabPath("/tmp/foo/")).toBe("/tmp/foo");
+    expect(normalizeResourceTabPath("  /a/b  ")).toBe("/a/b");
+  });
+
+  it("preserves URL scheme double-slash", () => {
+    expect(normalizeResourceTabPath("https://example.com/x")).toBe(
+      "https://example.com/x",
+    );
+    expect(normalizeResourceTabPath("http://localhost:3000/")).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("equates paths only after normalize", () => {
+    expect(resourceTabPathsEqual("a/b", "a\\\\b")).toBe(true);
+    expect(resourceTabPathsEqual("a/b", "a/c")).toBe(false);
+    expect(resourceTabPathsEqual("", "a")).toBe(false);
+  });
+});
+
+describe("openResourceTab", () => {
+  it("creates a tab and activates it", () => {
+    const r = openResourceTab([], "src/App.tsx", { name: "App.tsx", kind: "code" });
+    expect(r.created).toBe(true);
+    expect(r.droppedIds).toEqual([]);
+    expect(r.tabs).toHaveLength(1);
+    expect(r.activeId).toBe(r.tabs[0]!.id);
+    expect(r.tabs[0]!.path).toBe("src/App.tsx");
+    expect(r.tabs[0]!.name).toBe("App.tsx");
+    expect(r.tabs[0]!.kind).toBe("code");
+    expect(r.tabs[0]!.dirty).toBe(false);
+  });
+
+  it("dedupes by path and moves existing to front (MRU)", () => {
+    const a = tab({ id: "1", path: "a.ts" });
+    const b = tab({ id: "2", path: "b.ts" });
+    const r = openResourceTab([a, b], "b.ts");
+    expect(r.created).toBe(false);
+    expect(r.activeId).toBe("2");
+    expect(r.tabs.map((t) => t.id)).toEqual(["2", "1"]);
+  });
+
+  it("dedupes by normalized path", () => {
+    const a = tab({ id: "1", path: "src/x.ts" });
+    const r = openResourceTab([a], "src\\\\x.ts", { name: "x.ts" });
+    expect(r.created).toBe(false);
+    expect(r.activeId).toBe("1");
+    expect(r.tabs).toHaveLength(1);
+  });
+
+  it("dedupes by meta.id when path keys differ", () => {
+    const a = tab({ id: "keep", path: "/abs/foo.ts" });
+    const r = openResourceTab([a], "foo.ts", { id: "keep", name: "foo.ts" });
+    expect(r.created).toBe(false);
+    expect(r.activeId).toBe("keep");
+    expect(r.tabs[0]!.path).toBe("foo.ts");
+  });
+
+  it("drops LRU tabs when over max", () => {
+    const tabs: ResourceTab[] = [];
+    for (let i = 0; i < RESOURCE_TABS_MAX; i++) {
+      tabs.push(tab({ id: `t${i}`, path: `f${i}.ts` }));
+    }
+    // MRU front … LRU end: t0 is MRU, t11 is LRU when filled by sequential open.
+    // Build MRU order explicitly: index 0 = newest.
+    const filled = Array.from({ length: RESOURCE_TABS_MAX }, (_, i) =>
+      tab({ id: `id${i}`, path: `p${i}.ts` }),
+    );
+    const r = openResourceTab(filled, "new.ts", { name: "new.ts" }, RESOURCE_TABS_MAX);
+    expect(r.created).toBe(true);
+    expect(r.tabs).toHaveLength(RESOURCE_TABS_MAX);
+    expect(r.tabs[0]!.path).toBe("new.ts");
+    // Last (LRU) of previous list should be dropped.
+    expect(r.droppedIds).toEqual([`id${RESOURCE_TABS_MAX - 1}`]);
+    expect(r.tabs.some((t) => t.id === `id${RESOURCE_TABS_MAX - 1}`)).toBe(
+      false,
+    );
+  });
+
+  it("respects a custom max of 1", () => {
+    const a = tab({ id: "a", path: "a.ts" });
+    const r = openResourceTab([a], "b.ts", undefined, 1);
+    expect(r.tabs).toHaveLength(1);
+    expect(r.tabs[0]!.path).toBe("b.ts");
+    expect(r.droppedIds).toEqual(["a"]);
+  });
+
+  it("no-ops empty path without inventing a tab", () => {
+    const a = tab({ id: "a", path: "a.ts" });
+    const r = openResourceTab([a], "   ");
+    expect(r.created).toBe(false);
+    expect(r.tabs).toEqual([a]);
+  });
+});
+
+describe("closeResourceTab", () => {
+  it("closes non-active and keeps active", () => {
+    const tabs = [
+      tab({ id: "a", path: "a.ts" }),
+      tab({ id: "b", path: "b.ts" }),
+    ];
+    const r = closeResourceTab(tabs, "a", "b");
+    expect(r.tabs.map((t) => t.id)).toEqual(["a"]);
+    expect(r.activeId).toBe("a");
+  });
+
+  it("closes active and prefers left (newer) neighbor", () => {
+    const tabs = [
+      tab({ id: "a", path: "a.ts" }),
+      tab({ id: "b", path: "b.ts" }),
+      tab({ id: "c", path: "c.ts" }),
+    ];
+    const r = closeResourceTab(tabs, "b", "b");
+    expect(r.tabs.map((t) => t.id)).toEqual(["a", "c"]);
+    expect(r.activeId).toBe("a");
+  });
+
+  it("closes sole tab → empty", () => {
+    const r = closeResourceTab([tab({ id: "a", path: "a.ts" })], "a", "a");
+    expect(r.tabs).toEqual([]);
+    expect(r.activeId).toBeNull();
+  });
+
+  it("unknown id is a no-op", () => {
+    const tabs = [tab({ id: "a", path: "a.ts" })];
+    const r = closeResourceTab(tabs, "a", "missing");
+    expect(r.tabs).toEqual(tabs);
+    expect(r.activeId).toBe("a");
+  });
+});
+
+describe("setActiveTab", () => {
+  it("activates an existing id", () => {
+    const tabs = [
+      tab({ id: "a", path: "a.ts" }),
+      tab({ id: "b", path: "b.ts" }),
+    ];
+    expect(setActiveTab(tabs, "b")).toEqual({ tabs, activeId: "b" });
+  });
+
+  it("ignores unknown id without wiping tabs", () => {
+    const tabs = [tab({ id: "a", path: "a.ts" })];
+    const r = setActiveTab(tabs, "nope");
+    expect(r.tabs).toEqual(tabs);
+    expect(r.activeId).toBe("a");
+  });
+});
+
+describe("markTabDirty", () => {
+  it("sets and clears dirty on the target only", () => {
+    const tabs = [
+      tab({ id: "a", path: "a.ts", dirty: false }),
+      tab({ id: "b", path: "b.ts", dirty: false }),
+    ];
+    const dirty = markTabDirty(tabs, "a", true);
+    expect(dirty[0]!.dirty).toBe(true);
+    expect(dirty[1]!.dirty).toBe(false);
+    const clean = markTabDirty(dirty, "a", false);
+    expect(clean[0]!.dirty).toBe(false);
+  });
+});
+
+describe("resolveResourceTabsEmptyState", () => {
+  it("returns presentation when no tabs", () => {
+    const p = resolveResourceTabsEmptyState({ tabCount: 0 });
+    expect(p).toEqual({
+      kind: "no_tabs",
+      titleKey: "resources.emptyPreview",
+      hintKey: "resources.emptyPreviewHint",
+    });
+  });
+
+  it("returns null when tabs are open", () => {
+    expect(resolveResourceTabsEmptyState({ tabCount: 1 })).toBeNull();
+    expect(resolveResourceTabsEmptyState({ tabCount: 3, sideMode: "files" })).toBeNull();
+  });
+});

--- a/src/lib/resourceTabs.ts
+++ b/src/lib/resourceTabs.ts
@@ -1,0 +1,232 @@
+/**
+ * Resource workbench multi-file tabs — pure open / close / activate / dirty helpers.
+ *
+ * ResourceViewer keeps rich preview/edit state on each tab; this module owns
+ * the strip model: path identity, MRU order, max cap + LRU drop, empty state.
+ * No DOM / Tauri / i18n side effects.
+ */
+
+import { normalizePath, pathBaseName } from "@/lib/sessionChanges";
+
+/** Soft cap on open resource tabs (LRU drop when exceeded). */
+export const RESOURCE_TABS_MAX = 12;
+
+export type ResourceTab = {
+  id: string;
+  /** Normalized path or URL used for dedupe. */
+  path: string;
+  name: string;
+  kind?: string;
+  dirty?: boolean;
+};
+
+export type ResourceTabsState = {
+  tabs: ResourceTab[];
+  activeId: string | null;
+};
+
+export type OpenResourceTabMeta = {
+  name?: string;
+  kind?: string;
+  /** Reuse an id when focusing an already-open rich tab. */
+  id?: string;
+  dirty?: boolean;
+};
+
+export type OpenResourceTabResult = ResourceTabsState & {
+  /** Focused / opened tab id (always set when path is non-empty). */
+  activeId: string;
+  /** True when a new tab row was created. */
+  created: boolean;
+  /** Tab ids dropped by LRU when over max. */
+  droppedIds: string[];
+};
+
+export type ResourceTabsEmptyKind = "no_tabs";
+
+export type ResourceTabsEmptyTitleKey = "resources.emptyPreview";
+export type ResourceTabsEmptyHintKey = "resources.emptyPreviewHint";
+
+export type ResourceTabsEmptyPresentation = {
+  kind: ResourceTabsEmptyKind;
+  titleKey: ResourceTabsEmptyTitleKey;
+  hintKey: ResourceTabsEmptyHintKey;
+};
+
+/**
+ * Normalize a tab path key for equality.
+ * File paths use {@link normalizePath}; URL schemes keep `://` intact.
+ */
+export function normalizeResourceTabPath(path: string): string {
+  const raw = (path || "").trim();
+  if (!raw) return "";
+  // http(s)://, file://, media://, etc. — do not collapse scheme slashes.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw)) {
+    return raw.replace(/\/+$/, "");
+  }
+  return normalizePath(raw);
+}
+
+/** True when two path keys refer to the same tab after normalize. */
+export function resourceTabPathsEqual(a: string, b: string): boolean {
+  const na = normalizeResourceTabPath(a);
+  const nb = normalizeResourceTabPath(b);
+  if (!na || !nb) return false;
+  return na === nb;
+}
+
+function newTabId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") {
+    return `tab_${c.randomUUID()}`;
+  }
+  return `tab_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function clampMax(max: number | undefined): number {
+  if (max == null || !Number.isFinite(max)) return RESOURCE_TABS_MAX;
+  return Math.max(1, Math.floor(max));
+}
+
+/**
+ * Open or focus a path. Dedupes by normalized path (or explicit meta.id),
+ * moves the hit to the front (MRU), and drops LRU entries from the end
+ * when over `max` (default {@link RESOURCE_TABS_MAX}).
+ */
+export function openResourceTab(
+  tabs: ResourceTab[],
+  path: string,
+  meta?: OpenResourceTabMeta,
+  max: number = RESOURCE_TABS_MAX,
+): OpenResourceTabResult {
+  const list = Array.isArray(tabs) ? tabs : [];
+  const norm = normalizeResourceTabPath(path);
+  const cap = clampMax(max);
+
+  // Prefer explicit id, then path match.
+  let existingIdx = -1;
+  if (meta?.id) {
+    existingIdx = list.findIndex((t) => t.id === meta.id);
+  }
+  if (existingIdx < 0 && norm) {
+    existingIdx = list.findIndex(
+      (t) => normalizeResourceTabPath(t.path) === norm,
+    );
+  }
+
+  if (existingIdx >= 0) {
+    const hit = list[existingIdx]!;
+    const updated: ResourceTab = {
+      ...hit,
+      path: norm || hit.path,
+      name: meta?.name ?? hit.name,
+      kind: meta?.kind ?? hit.kind,
+      dirty: meta?.dirty ?? hit.dirty,
+    };
+    const rest = list.filter((_, i) => i !== existingIdx);
+    return {
+      tabs: [updated, ...rest],
+      activeId: updated.id,
+      created: false,
+      droppedIds: [],
+    };
+  }
+
+  // Empty path → no-op (keep strip unchanged).
+  if (!norm) {
+    return {
+      tabs: list,
+      activeId: list[0]?.id ?? "",
+      created: false,
+      droppedIds: [],
+    };
+  }
+
+  const id = meta?.id || newTabId();
+  const tab: ResourceTab = {
+    id,
+    path: norm,
+    name: (meta?.name || pathBaseName(norm) || norm).trim() || norm,
+    kind: meta?.kind,
+    dirty: meta?.dirty ?? false,
+  };
+  let next = [tab, ...list];
+  const droppedIds: string[] = [];
+  while (next.length > cap) {
+    const drop = next[next.length - 1]!;
+    if (drop.id === id) {
+      // Cap of 1 with only the new tab — keep it.
+      break;
+    }
+    droppedIds.push(drop.id);
+    next = next.slice(0, -1);
+  }
+  return {
+    tabs: next,
+    activeId: id,
+    created: true,
+    droppedIds,
+  };
+}
+
+/**
+ * Close a tab by id. When closing the active tab, prefer the left neighbor
+ * (newer / MRU side), else the right, else null.
+ */
+export function closeResourceTab(
+  tabs: ResourceTab[],
+  activeId: string | null,
+  id: string,
+): ResourceTabsState {
+  const list = Array.isArray(tabs) ? tabs : [];
+  const idx = list.findIndex((t) => t.id === id);
+  if (idx < 0) {
+    return { tabs: list, activeId };
+  }
+  const next = list.filter((t) => t.id !== id);
+  if (activeId !== id) {
+    return { tabs: next, activeId };
+  }
+  const neighbor = next[Math.max(0, idx - 1)] ?? next[0] ?? null;
+  return { tabs: next, activeId: neighbor?.id ?? null };
+}
+
+/** Activate a tab by id (no reorder). Unknown id leaves state unchanged. */
+export function setActiveTab(
+  tabs: ResourceTab[],
+  id: string,
+): ResourceTabsState {
+  const list = Array.isArray(tabs) ? tabs : [];
+  if (!list.some((t) => t.id === id)) {
+    return { tabs: list, activeId: list.find((t) => t.id)?.id ?? null };
+  }
+  return { tabs: list, activeId: id };
+}
+
+/** Set or clear the dirty flag on a tab (strip model only). */
+export function markTabDirty(
+  tabs: ResourceTab[],
+  id: string,
+  dirty: boolean,
+): ResourceTab[] {
+  const list = Array.isArray(tabs) ? tabs : [];
+  return list.map((t) => (t.id === id ? { ...t, dirty: !!dirty } : t));
+}
+
+/**
+ * Empty-state for the files tab strip / preview when nothing is open.
+ * Returns null when at least one tab is present.
+ */
+export function resolveResourceTabsEmptyState(input: {
+  tabCount: number;
+  /** Side mode is informational; empty files strip applies whenever count is 0. */
+  sideMode?: string;
+}): ResourceTabsEmptyPresentation | null {
+  const n = Number(input.tabCount);
+  if (Number.isFinite(n) && n > 0) return null;
+  return {
+    kind: "no_tabs",
+    titleKey: "resources.emptyPreview",
+    hintKey: "resources.emptyPreviewHint",
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -15727,6 +15727,12 @@ textarea::-webkit-scrollbar-thumb:active,
   line-height: 1;
 }
 
+/* Unsaved draft on inactive/active strip tabs (multi-file workbench). */
+.rp-tab.is-dirty .rp-tab__name,
+.rp-tab.is-dirty .rp-tab__dirty {
+  color: var(--warning, #f0993d);
+}
+
 .chrome-btn--save.is-dirty {
   color: var(--text-primary);
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Pure `resourceTabs` helpers: open (dedupe by path, max 12 LRU), close, setActive, markDirty, empty-state resolve + path normalize (URLs keep `://`)
- ResourceViewer files mode uses those helpers for open/close/activate; tab strip dirty marker; switch keeps draft buffers; dirty close uses existing GlassModal discard (no `window.confirm`)
- Minimal CSS for dirty strip tabs; CHANGELOG; vitest coverage

## Test plan
- [x] `pnpm test -- src/lib/resourceTabs.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manually: open multiple files from tree → tabs strip; switch without losing edit; close dirty → discard modal; >12 opens drops LRU