### PR TITLE
feat(session): deep link to message node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Message node deep links**: open a session and scroll to a message via `#/session/<id>/m/<messageId>` (or `?m=` / `?message=` / `?messageId=`). Reuses MessageNodeRail + virtualizer locate path; soft toast when the message is missing. Message action **Copy link** copies the app-relative hash. Multi-window secondary `#/session/<id>` still works (parser extended). Pure `messageNodeDeepLink` helpers + tests; en/zh/zh-TW.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,7 @@ import {
   shouldDeferWarmConnectForForeignBusy,
   shouldSkipWarmConnect,
 } from "@/lib/multiWindow";
+import { parseMessageDeepLink } from "@/lib/messageNodeDeepLink";
 import {
   applyChatWidth,
   loadChatWidth,
@@ -1470,6 +1471,22 @@ export default function App() {
     secondaryFocusSessionId,
   );
   secondaryFocusSessionIdRef.current = secondaryFocusSessionId;
+  /**
+   * Pending message-node deep link (`#/session/<id>/m/<mid>`).
+   * Cleared after ConversationThread scrolls (or soft-misses).
+   */
+  const [pendingLocateMessageId, setPendingLocateMessageId] = useState<
+    string | null
+  >(() => {
+    if (typeof window === "undefined") return null;
+    return parseMessageDeepLink(window.location.hash)?.messageId ?? null;
+  });
+  /** Session id the pending locate belongs to (avoid scrolling the wrong chat). */
+  const pendingLocateSessionIdRef = useRef<string | null>(
+    typeof window !== "undefined"
+      ? (parseMessageDeepLink(window.location.hash)?.sessionId ?? null)
+      : null,
+  );
   /** False until desktop window label is resolved (or non-desktop path). */
   const [windowRoleReady, setWindowRoleReady] = useState(
     () => !api.isDesktopHost(),
@@ -5444,6 +5461,7 @@ export default function App() {
   );
 
   // Hash route: #/settings[/section[/tab]][?pr=N] | #/automations | #/workbench
+  // | #/session/<id>[/m/<messageId>]
   // Explicit #/settings/{section}… deep links always win; bare #/settings uses last.
   useEffect(() => {
     const syncFromHash = () => {
@@ -5487,6 +5505,33 @@ export default function App() {
       } else if (raw === "" || raw === "workbench" || raw === "home") {
         setAppView("workbench");
         setMainPane("chat");
+      } else {
+        // Session / message-node deep link (multi-window + in-app jump).
+        const msgLink = parseMessageDeepLink(fullHash);
+        const sessionOnly = parseSessionDeepLinkHash(fullHash);
+        if (msgLink || sessionOnly) {
+          setAppView("workbench");
+          setMainPane("chat");
+          const focusId = msgLink?.sessionId ?? sessionOnly;
+          if (focusId) {
+            setSecondaryFocusSessionId(focusId);
+            secondaryFocusSessionIdRef.current = focusId;
+          }
+          if (msgLink) {
+            pendingLocateSessionIdRef.current = msgLink.sessionId;
+            setPendingLocateMessageId(msgLink.messageId);
+          } else {
+            pendingLocateSessionIdRef.current = null;
+            setPendingLocateMessageId(null);
+          }
+          // Open the session when the list is ready (same path as boot restore).
+          if (focusId && sessionsRef.current.length > 0) {
+            const row = sessionsRef.current.find((s) => s.id === focusId);
+            if (row) {
+              void openSessionRef.current(row);
+            }
+          }
+        }
       }
     };
     syncFromHash();
@@ -9871,6 +9916,22 @@ export default function App() {
       setToast((cur) => (cur === msg ? null : cur));
     }, ms);
   }, []);
+
+  /** Clear pending message deep link after locate (soft-toast when missing). */
+  const onLocateMessageDeepLink = useCallback(
+    (result: {
+      ok: boolean;
+      messageId: string;
+      reason?: "missing" | "empty_id";
+    }) => {
+      setPendingLocateMessageId(null);
+      pendingLocateSessionIdRef.current = null;
+      if (!result.ok) {
+        showToast(tr("message.deepLinkMissing"), 3600);
+      }
+    },
+    [showToast, tr],
+  );
 
   /** Open GlassModal to edit per-session sticky note (local only; never sent to agent). */
   const openSessionNote = useCallback(
@@ -19076,6 +19137,16 @@ export default function App() {
                 : session.state
             }
             sessionKey={session.sessionId ?? `draft-${session.title ?? "new"}`}
+            sessionId={session.sessionId}
+            locateMessageId={
+              pendingLocateMessageId &&
+              session.sessionId &&
+              (!pendingLocateSessionIdRef.current ||
+                session.sessionId === pendingLocateSessionIdRef.current)
+                ? pendingLocateMessageId
+                : null
+            }
+            onLocateMessage={onLocateMessageDeepLink}
             projectPath={effectiveProjectPath}
             suppressEmptyCopy={welcomeSession}
             canEditLastUser={canEditLastUser}

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -32,8 +32,13 @@ import {
   adjacentNode,
   buildSessionMessageNodes,
   estimateStartScrollTop,
+  nodeById,
   type SessionMessageNode,
 } from "@/lib/sessionMessageNodes";
+import {
+  formatMessageDeepLink,
+  planScrollToMessage,
+} from "@/lib/messageNodeDeepLink";
 import { MessageNodeRail } from "./MessageNodeRail";
 import { isEndOfTurnMarker } from "@/lib/endOfTurn";
 import type { Attachment } from "@/lib/attachments";
@@ -56,6 +61,7 @@ import {
   IconClock,
   IconExportMd,
   IconFork,
+  IconLink,
   IconRename,
   IconRewind,
   IconTarget,
@@ -446,6 +452,25 @@ export interface ConversationThreadProps {
   findHitMessageIds?: ReadonlySet<string>;
   /** Active match target for scroll / current mark. */
   findActive?: { messageId: string; occurrence: number } | null;
+  /**
+   * Stored session id for copy-link deep hashes (`#/session/<id>/m/<mid>`).
+   * Draft / new-chat leaves this null — copy link is hidden.
+   */
+  sessionId?: string | null;
+  /**
+   * External locate request (message deep link). Scrolls once when the
+   * journal contains `messageId` (reuses rail virtualizer path).
+   */
+  locateMessageId?: string | null;
+  /**
+   * Fired once per locate attempt after messages are available
+   * (success or soft-missing). Parent shows toast / clears pending.
+   */
+  onLocateMessage?: (result: {
+    ok: boolean;
+    messageId: string;
+    reason?: "missing" | "empty_id";
+  }) => void;
   /** Open session Changes panel (turn activity file strip). */
   onOpenSessionChanges?: () => void;
   /** Open a modified path from turn activity. */
@@ -534,6 +559,9 @@ export function ConversationThread({
   findQuery = "",
   findHitMessageIds,
   findActive = null,
+  sessionId = null,
+  locateMessageId = null,
+  onLocateMessage,
   onOpenSessionChanges: _onOpenSessionChanges,
   onOpenModifiedPath: _onOpenModifiedPath,
   showTimestamps = true,
@@ -804,6 +832,63 @@ export function ConversationThread({
     const t = window.requestAnimationFrame(() => applyScrollToNodeDom(node, 0));
     return () => window.cancelAnimationFrame(t);
   }, [locateTargetId, messageNodes, applyScrollToNodeDom]);
+
+  /**
+   * Deep-link locate: when parent sets `locateMessageId`, scroll once the
+   * journal has rows (reuse rail virtualizer path). Soft-missing reports up.
+   */
+  const deepLocateConsumedRef = useRef<string | null>(null);
+  useEffect(() => {
+    const mid = (locateMessageId ?? "").trim();
+    if (!mid) {
+      deepLocateConsumedRef.current = null;
+      return;
+    }
+    // Wait until the session journal is present (open-in-flight → empty).
+    if (messages.length === 0) return;
+    if (deepLocateConsumedRef.current === mid) return;
+
+    const plan = planScrollToMessage({
+      messageId: mid,
+      nodes: messageNodes,
+      messages,
+    });
+    deepLocateConsumedRef.current = mid;
+
+    if (!plan.ok) {
+      onLocateMessage?.({
+        ok: false,
+        messageId: mid,
+        reason: plan.reason,
+      });
+      return;
+    }
+
+    const fromNode = plan.nodeId ? nodeById(messageNodes, plan.nodeId) : null;
+    const roleRaw = messages[plan.messageIndex]?.role;
+    const role: SessionMessageNode["role"] =
+      roleRaw === "user" ? "user" : "assistant";
+    const node: SessionMessageNode =
+      fromNode ??
+      ({
+        id: mid,
+        messageIndex: plan.messageIndex,
+        nodeIndex: -1,
+        role,
+        preview: "",
+        status: "done",
+        promptIndex: null,
+      } satisfies SessionMessageNode);
+
+    scrollToMessageNode(node);
+    onLocateMessage?.({ ok: true, messageId: mid });
+  }, [
+    locateMessageId,
+    messages,
+    messageNodes,
+    onLocateMessage,
+    scrollToMessageNode,
+  ]);
 
   const onNodePrev = useCallback(() => {
     const cur = railCursorRef.current ?? activeNodeId;
@@ -1343,6 +1428,23 @@ export function ConversationThread({
                             copiedLabel={tr("message.copied")}
                           />
                         ) : null}
+                        {sessionId
+                          ? (() => {
+                              const link = formatMessageDeepLink(
+                                sessionId,
+                                m.id,
+                              );
+                              if (!link) return null;
+                              return (
+                                <MessageCopyButton
+                                  text={link}
+                                  copyLabel={tr("message.copyLink")}
+                                  copiedLabel={tr("message.linkCopied")}
+                                  idleIcon={<IconLink size={15} />}
+                                />
+                              );
+                            })()
+                          : null}
                         {isLastUser ? (
                           <MessageActionButton
                             label={tr("message.edit")}
@@ -1705,6 +1807,12 @@ export function ConversationThread({
                   const showRegen =
                     !!onRegenerateAssistant && regenerableAssistantId === m.id;
                   if (!showCopy && !showRegen) return null;
+                  const deepLink =
+                    sessionId != null
+                      ? formatMessageDeepLink(sessionId, m.id)
+                      : "";
+                  const showCopyLink = !!deepLink;
+                  if (!showCopy && !showRegen && !showCopyLink) return null;
                   return (
                     <>
                       {showCopy ? (
@@ -1731,6 +1839,14 @@ export function ConversationThread({
                             <IconExportMd size={15} />
                           </MessageActionButton>
                         </>
+                      ) : null}
+                      {showCopyLink ? (
+                        <MessageCopyButton
+                          text={deepLink}
+                          copyLabel={tr("message.copyLink")}
+                          copiedLabel={tr("message.linkCopied")}
+                          idleIcon={<IconLink size={15} />}
+                        />
                       ) : null}
                       {showRegen ? (
                         <MessageRegenerateButton

--- a/src/components/lobe-chat/MessageAction.tsx
+++ b/src/components/lobe-chat/MessageAction.tsx
@@ -62,10 +62,13 @@ export function MessageCopyButton({
   text,
   copyLabel,
   copiedLabel = "OK",
+  /** Optional idle icon (default copy glyph). Use for “copy link”. */
+  idleIcon,
 }: {
   text: string;
   copyLabel: string;
   copiedLabel?: string;
+  idleIcon?: ReactNode;
 }) {
   const [copied, setCopied] = useState(false);
   const timer = useRef<number | null>(null);
@@ -88,7 +91,11 @@ export function MessageCopyButton({
       onClick={() => void onCopy()}
       className={copied ? "is-copied" : undefined}
     >
-      {copied ? <IconCheck size={15} /> : <IconCopy size={15} />}
+      {copied ? (
+        <IconCheck size={15} />
+      ) : (
+        (idleIcon ?? <IconCopy size={15} />)
+      )}
     </MessageActionButton>
   );
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -402,6 +402,9 @@ const en = {
   "message.nodes.user": "You",
   "message.nodes.assistant": "Grok",
   "message.nodes.count": "{current} / {total}",
+  "message.copyLink": "Copy link",
+  "message.linkCopied": "Link copied",
+  "message.deepLinkMissing": "Message not found in this conversation",
 
   // Main
   "main.rightPane": "Files pane",
@@ -6508,6 +6511,9 @@ const zh: Record<MessageKey, string> = {
   "message.nodes.user": "你",
   "message.nodes.assistant": "Grok",
   "message.nodes.count": "{current} / {total}",
+  "message.copyLink": "复制链接",
+  "message.linkCopied": "链接已复制",
+  "message.deepLinkMissing": "此对话中未找到该消息",
 
   "main.rightPane": "文件栏",
   "main.leftPane": "侧栏",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -363,6 +363,9 @@ export const zhTW: Record<MessageKey, string> = {
   "message.nodes.user": "你",
   "message.nodes.assistant": "Grok",
   "message.nodes.count": "{current} / {total}",
+  "message.copyLink": "複製連結",
+  "message.linkCopied": "連結已複製",
+  "message.deepLinkMissing": "此對話中找不到該訊息",
 
   "main.rightPane": "檔案欄",
   "main.leftPane": "側邊欄",

--- a/src/lib/messageNodeDeepLink.test.ts
+++ b/src/lib/messageNodeDeepLink.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "./session";
+import { buildSessionMessageNodes } from "./sessionMessageNodes";
+import {
+  formatMessageDeepLink,
+  isValidMessageId,
+  messageDeepLinkPathOnly,
+  parseMessageDeepLink,
+  parseMessageDeepLinkQuery,
+  planScrollToMessage,
+} from "./messageNodeDeepLink";
+
+const SID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const MID = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+
+function msg(
+  partial: Partial<ChatMessage> & Pick<ChatMessage, "id" | "role">,
+): ChatMessage {
+  return {
+    content: partial.content ?? "hi",
+    ...partial,
+  };
+}
+
+describe("isValidMessageId", () => {
+  it("accepts UUID and host-style slugs", () => {
+    expect(isValidMessageId(MID)).toBe(true);
+    expect(isValidMessageId("a-1710000000000")).toBe(true);
+    expect(isValidMessageId("u-pending-1")).toBe(true);
+    expect(isValidMessageId("tool-call.abc")).toBe(true);
+  });
+
+  it("rejects empty, path junk, and overlong", () => {
+    expect(isValidMessageId("")).toBe(false);
+    expect(isValidMessageId("   ")).toBe(false);
+    expect(isValidMessageId(null)).toBe(false);
+    expect(isValidMessageId("a/b")).toBe(false);
+    expect(isValidMessageId("a?b")).toBe(false);
+    expect(isValidMessageId("a b")).toBe(false);
+    expect(isValidMessageId("x".repeat(300))).toBe(false);
+  });
+});
+
+describe("messageDeepLinkPathOnly / parseMessageDeepLinkQuery", () => {
+  it("strips hash, slash, query", () => {
+    expect(messageDeepLinkPathOnly(`#/session/${SID}/m/${MID}?x=1`)).toBe(
+      `session/${SID}/m/${MID}`,
+    );
+    expect(messageDeepLinkPathOnly(`session/${SID}/`)).toBe(`session/${SID}`);
+  });
+
+  it("parses query aliases", () => {
+    expect(parseMessageDeepLinkQuery(`#/session/${SID}?m=${MID}`)).toEqual({
+      m: MID,
+    });
+    expect(
+      parseMessageDeepLinkQuery(`#/session/${SID}?messageId=${MID}&x=1`),
+    ).toEqual({ messageId: MID, x: "1" });
+  });
+});
+
+describe("formatMessageDeepLink / parseMessageDeepLink", () => {
+  it("round-trips preferred path form", () => {
+    const link = formatMessageDeepLink(SID, MID);
+    expect(link).toBe(`#/session/${SID}/m/${MID}`);
+    expect(parseMessageDeepLink(link)).toEqual({
+      sessionId: SID,
+      messageId: MID,
+    });
+  });
+
+  it("parses without leading # or /", () => {
+    expect(parseMessageDeepLink(`session/${SID}/m/${MID}`)).toEqual({
+      sessionId: SID,
+      messageId: MID,
+    });
+    expect(parseMessageDeepLink(`/session/${SID}/m/${MID}`)).toEqual({
+      sessionId: SID,
+      messageId: MID,
+    });
+  });
+
+  it("parses query form m / message / messageId", () => {
+    expect(parseMessageDeepLink(`#/session/${SID}?m=${MID}`)).toEqual({
+      sessionId: SID,
+      messageId: MID,
+    });
+    expect(
+      parseMessageDeepLink(`#/session/${SID}?message=${MID}`),
+    ).toEqual({ sessionId: SID, messageId: MID });
+    expect(
+      parseMessageDeepLink(`#/session/${SID}?messageId=${MID}`),
+    ).toEqual({ sessionId: SID, messageId: MID });
+  });
+
+  it("returns null without message id (session-only still multi-window)", () => {
+    expect(parseMessageDeepLink(`#/session/${SID}`)).toBeNull();
+    expect(parseMessageDeepLink(`#/session/${SID}?x=1`)).toBeNull();
+    expect(parseMessageDeepLink("#/settings/general")).toBeNull();
+    expect(parseMessageDeepLink("")).toBeNull();
+  });
+
+  it("rejects invalid session or message segments", () => {
+    expect(formatMessageDeepLink("bad id", MID)).toBe("");
+    expect(formatMessageDeepLink(SID, "bad/id")).toBe("");
+    expect(parseMessageDeepLink(`#/session/bad id/m/${MID}`)).toBeNull();
+    expect(parseMessageDeepLink(`#/session/${SID}/m/bad/id`)).toBeNull();
+    expect(parseMessageDeepLink(`#/session/${SID}/m/`)).toBeNull();
+    // Extra path after message id
+    expect(
+      parseMessageDeepLink(`#/session/${SID}/m/${MID}/extra`),
+    ).toBeNull();
+  });
+
+  it("trims and accepts local slug ids", () => {
+    const link = formatMessageDeepLink(`  ${SID}  `, "a-123");
+    expect(link).toBe(`#/session/${SID}/m/a-123`);
+    expect(parseMessageDeepLink(link)?.messageId).toBe("a-123");
+  });
+});
+
+describe("planScrollToMessage", () => {
+  const messages: ChatMessage[] = [
+    msg({ id: "u1", role: "user", content: "hello" }),
+    msg({ id: "a1", role: "assistant", content: "world" }),
+    msg({
+      id: "t1",
+      role: "tool",
+      content: "tool_step|x",
+      marker: "tool_step",
+    }),
+  ];
+  const nodes = buildSessionMessageNodes(messages);
+
+  it("finds node candidates with nodeId", () => {
+    expect(planScrollToMessage({ messageId: "u1", nodes, messages })).toEqual({
+      ok: true,
+      messageIndex: 0,
+      nodeId: "u1",
+    });
+    expect(planScrollToMessage({ messageId: "a1", nodes, messages })).toEqual({
+      ok: true,
+      messageIndex: 1,
+      nodeId: "a1",
+    });
+  });
+
+  it("falls back to messages[] when not a node (soft nodeId null)", () => {
+    expect(planScrollToMessage({ messageId: "t1", nodes, messages })).toEqual({
+      ok: true,
+      messageIndex: 2,
+      nodeId: null,
+    });
+  });
+
+  it("soft-misses when id absent", () => {
+    expect(
+      planScrollToMessage({ messageId: "nope", nodes, messages }),
+    ).toEqual({ ok: false, reason: "missing" });
+  });
+
+  it("soft-fails empty id", () => {
+    expect(planScrollToMessage({ messageId: "", nodes, messages })).toEqual({
+      ok: false,
+      reason: "empty_id",
+    });
+    expect(planScrollToMessage({ messageId: null, nodes, messages })).toEqual({
+      ok: false,
+      reason: "empty_id",
+    });
+  });
+});

--- a/src/lib/messageNodeDeepLink.ts
+++ b/src/lib/messageNodeDeepLink.ts
@@ -1,0 +1,210 @@
+/**
+ * Message-node deep links: open a session and scroll to a message bubble.
+ *
+ * Preferred hash: `#/session/<sessionId>/m/<messageId>`
+ * Query form:     `#/session/<sessionId>?m=<messageId>`
+ *                 (aliases: `message`, `messageId`)
+ *
+ * Pure only — no DOM / navigation side effects.
+ * Reuses multi-window session id sanitization so `#/session/<id>` stays compatible.
+ */
+
+import { sanitizeSessionIdForLabel } from "./multiWindow";
+import type { SessionMessageNode } from "./sessionMessageNodes";
+import type { ChatMessage } from "./session";
+
+/** Path prefix shared with multi-window session deep links. */
+export const MESSAGE_DEEP_LINK_SESSION_PREFIX = "session/";
+
+/** Path segment between session id and message id (`…/m/<messageId>`). */
+export const MESSAGE_DEEP_LINK_MSG_SEGMENT = "m";
+
+export type MessageDeepLink = {
+  sessionId: string;
+  messageId: string;
+};
+
+/** Soft max length for message ids (UUID + host-generated slugs). */
+const MESSAGE_ID_MAX = 256;
+
+/**
+ * Soft validation for a message id suitable for a deep-link path segment.
+ * Accepts UUID / host ids / local `a-…` / `u-…` style; rejects path junk.
+ */
+export function isValidMessageId(id: string | null | undefined): boolean {
+  if (id == null) return false;
+  const raw = String(id).trim();
+  if (!raw) return false;
+  if (raw.length > MESSAGE_ID_MAX) return false;
+  // No path / query / hash / whitespace — keep path segments unambiguous.
+  if (/[/?#\s]/.test(raw)) return false;
+  // Soft: printable ASCII-ish identifiers (UUID, slug, host mid).
+  if (!/^[A-Za-z0-9_.:@+-]+$/.test(raw)) return false;
+  return true;
+}
+
+/**
+ * Path portion of a location hash without leading `#` / `#/` and without query.
+ * `"#/session/abc/m/mid?x=1"` → `"session/abc/m/mid"`.
+ */
+export function messageDeepLinkPathOnly(
+  raw: string | null | undefined,
+): string {
+  let s = (raw ?? "").trim();
+  if (s.startsWith("#")) s = s.slice(1);
+  if (s.startsWith("/")) s = s.slice(1);
+  const qi = s.indexOf("?");
+  if (qi >= 0) s = s.slice(0, qi);
+  return s.replace(/\/+$/, "");
+}
+
+/**
+ * Parse `?a=1&b=2` from a hash or path. Values are decodeURIComponent'd.
+ * Malformed pairs are skipped (never throws).
+ */
+export function parseMessageDeepLinkQuery(
+  raw: string | null | undefined,
+): Record<string, string> {
+  const s = (raw ?? "").replace(/^#/, "");
+  const qi = s.indexOf("?");
+  if (qi < 0) return {};
+  let query = s.slice(qi + 1);
+  const hashFrag = query.indexOf("#");
+  if (hashFrag >= 0) query = query.slice(0, hashFrag);
+  const out: Record<string, string> = {};
+  if (!query) return out;
+  for (const part of query.split("&")) {
+    if (!part) continue;
+    const eq = part.indexOf("=");
+    let k = eq >= 0 ? part.slice(0, eq) : part;
+    let v = eq >= 0 ? part.slice(eq + 1) : "";
+    try {
+      k = decodeURIComponent(k.replace(/\+/g, " ")).trim();
+      v = decodeURIComponent(v.replace(/\+/g, " ")).trim();
+    } catch {
+      continue;
+    }
+    if (k) out[k] = v;
+  }
+  return out;
+}
+
+function sanitizeMessageIdSegment(
+  raw: string | null | undefined,
+): string | null {
+  if (raw == null) return null;
+  let s = String(raw).trim();
+  if (!s) return null;
+  try {
+    s = decodeURIComponent(s);
+  } catch {
+    /* keep raw */
+  }
+  s = s.trim();
+  return isValidMessageId(s) ? s : null;
+}
+
+/**
+ * Build app-relative hash for a message node.
+ * Prefers `#/session/<sessionId>/m/<messageId>`.
+ * Returns empty string when either id is invalid.
+ */
+export function formatMessageDeepLink(
+  sessionId: string | null | undefined,
+  messageId: string | null | undefined,
+): string {
+  const sid = sanitizeSessionIdForLabel(sessionId);
+  const mid = sanitizeMessageIdSegment(messageId);
+  if (!sid || !mid) return "";
+  // encodeURIComponent is a no-op for UUID / simple slugs; safe for edge ids.
+  return `#/${MESSAGE_DEEP_LINK_SESSION_PREFIX}${sid}/${MESSAGE_DEEP_LINK_MSG_SEGMENT}/${encodeURIComponent(mid)}`;
+}
+
+/**
+ * Parse `#/session/<id>/m/<mid>` or `#/session/<id>?m=<mid>` (and aliases).
+ * Accepts with or without leading `#` / `/`. Returns null when incomplete.
+ */
+export function parseMessageDeepLink(
+  hashOrPath: string | null | undefined,
+): MessageDeepLink | null {
+  if (hashOrPath == null) return null;
+  const path = messageDeepLinkPathOnly(hashOrPath);
+  if (!path.startsWith(MESSAGE_DEEP_LINK_SESSION_PREFIX)) return null;
+
+  const rest = path.slice(MESSAGE_DEEP_LINK_SESSION_PREFIX.length);
+  const segments = rest.split("/").filter(Boolean);
+  // Need at least the session id segment.
+  if (segments.length < 1) return null;
+
+  const sessionId = sanitizeSessionIdForLabel(segments[0] ?? "");
+  if (!sessionId) return null;
+
+  // Path form: session/<id>/m/<messageId>
+  if (
+    segments.length >= 3 &&
+    (segments[1] ?? "").toLowerCase() === MESSAGE_DEEP_LINK_MSG_SEGMENT
+  ) {
+    const messageId = sanitizeMessageIdSegment(segments[2]);
+    if (!messageId) return null;
+    // Reject extra path noise after message id (keep link shape strict).
+    if (segments.length > 3) return null;
+    return { sessionId, messageId };
+  }
+
+  // Query form: session/<id>?m=… (or message / messageId)
+  // Only when path is exactly session/<id> (no extra path segments).
+  if (segments.length !== 1) return null;
+  const q = parseMessageDeepLinkQuery(hashOrPath);
+  const rawMid = q.m ?? q.message ?? q.messageId ?? "";
+  const messageId = sanitizeMessageIdSegment(rawMid);
+  if (!messageId) return null;
+  return { sessionId, messageId };
+}
+
+export type PlanScrollToMessageResult =
+  | {
+      ok: true;
+      messageIndex: number;
+      /** Node id when the row is a message-node candidate; else null. */
+      nodeId: string | null;
+    }
+  | {
+      ok: false;
+      reason: "missing" | "empty_id";
+    };
+
+/**
+ * Plan a virtualizer / rail scroll to `messageId`.
+ * Prefers session message nodes; falls back to any messages[] row by id.
+ * Soft-missing when the id is absent after the journal is available.
+ */
+export function planScrollToMessage(opts: {
+  messageId: string | null | undefined;
+  nodes: readonly SessionMessageNode[];
+  messages: readonly ChatMessage[];
+}): PlanScrollToMessageResult {
+  const mid = (opts.messageId ?? "").trim();
+  if (!mid || !isValidMessageId(mid)) {
+    return { ok: false, reason: "empty_id" };
+  }
+
+  const fromNode = opts.nodes.find((n) => n.id === mid);
+  if (fromNode) {
+    return {
+      ok: true,
+      messageIndex: fromNode.messageIndex,
+      nodeId: fromNode.id,
+    };
+  }
+
+  const msgIdx = opts.messages.findIndex((m) => m.id === mid);
+  if (msgIdx >= 0) {
+    return {
+      ok: true,
+      messageIndex: msgIdx,
+      nodeId: null,
+    };
+  }
+
+  return { ok: false, reason: "missing" };
+}


### PR DESCRIPTION
## Summary
- Add pure `messageNodeDeepLink` helpers: parse/format `#/session/<id>/m/<messageId>` (also `?m=` / `?message=` / `?messageId=`), soft `isValidMessageId`, and `planScrollToMessage` for the virtualizer/rail.
- On boot / hash change, open the session and scroll to the message via existing MessageNodeRail locate path; soft toast when the message is missing.
- Message bubble **Copy link** copies the app-relative hash; multi-window `#/session/<id>` remains compatible.
- i18n en/zh/zh-TW + CHANGELOG.

## Test plan
- [x] `pnpm test -- src/lib/messageNodeDeepLink.test.ts src/lib/sessionMessageNodes.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: open `#/session/<id>/m/<mid>` → session opens and bubble is highlighted/scrolled
- [ ] Manual: Copy link on a bubble → paste hash → jumps to same message
- [ ] Manual: unknown message id → soft toast, no crash
- [ ] Manual: secondary window with message deep link still focuses the session