### PR TITLE
feat(batch): templates and results export for multi-project dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Batch agents pro**: prompt template chips (code review · fix tests · summarize) with i18n titles/bodies; eligibility strip for selected projects (ready vs not eligible); results matrix **Copy summary** + **Download .txt** via pure `batchAgentsPro` (`applyBatchTemplate`, `exportBatchResultsSummary`, `planBatchExport` soft-fail empty, `classifyBatchResultRow` for ok-without-detail / partial honesty). en/zh/zh-TW + tests. No `window.confirm`.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/components/BatchAgentsModal.tsx
+++ b/src/components/BatchAgentsModal.tsx
@@ -1,6 +1,7 @@
 /**
  * Multi-project batch agent dispatch.
  * Select projects + shared prompt → open/queue sessions or headless soft-fail summary.
+ * Templates + results matrix export (copy / download .txt).
  */
 
 import { useEffect, useMemo, useState } from "react";
@@ -12,7 +13,6 @@ import {
   buildBatchDispatchPlan,
   canDispatchBatch,
   filterBatchProjects,
-  formatBatchSummaryText,
   pruneBatchProjectSelection,
   toggleBatchProjectSelection,
   type BatchDispatchItemResult,
@@ -20,6 +20,15 @@ import {
   type BatchDispatchSummary,
   type BatchProjectInput,
 } from "@/lib/batchAgents";
+import {
+  applyBatchTemplate,
+  classifyBatchResultRow,
+  DEFAULT_BATCH_TEMPLATES,
+  planBatchExport,
+  summarizeBatchEligibility,
+  type BatchExportLabels,
+  type BatchTemplateId,
+} from "@/lib/batchAgentsPro";
 
 type TFn = (key: MessageKey, vars?: Record<string, string | number>) => string;
 
@@ -57,6 +66,22 @@ function statusLabel(status: BatchDispatchItemResult["status"], t: TFn): string 
   }
 }
 
+/** Prefer honesty kinds (ok_empty / partial) over raw status when present. */
+function resultStatusLabel(
+  item: BatchDispatchItemResult,
+  t: TFn,
+): string {
+  const row = classifyBatchResultRow(item);
+  switch (row.kind) {
+    case "ok_empty":
+      return t("batchAgents.status.okEmpty");
+    case "partial":
+      return t("batchAgents.status.partial");
+    default:
+      return statusLabel(item.status, t);
+  }
+}
+
 function statusClass(status: BatchDispatchItemResult["status"]): string {
   switch (status) {
     case "ok":
@@ -71,6 +96,26 @@ function statusClass(status: BatchDispatchItemResult["status"]): string {
       return "batch-agents__status--queued";
     default:
       return "batch-agents__status--pending";
+  }
+}
+
+function statusClassForItem(item: BatchDispatchItemResult): string {
+  const row = classifyBatchResultRow(item);
+  if (row.kind === "ok_empty") return "batch-agents__status--ok-empty";
+  if (row.kind === "partial") return "batch-agents__status--partial";
+  return statusClass(item.status);
+}
+
+function downloadText(filename: string, body: string) {
+  const blob = new Blob([body], { type: "text/plain;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+  } finally {
+    URL.revokeObjectURL(url);
   }
 }
 
@@ -92,6 +137,11 @@ export function BatchAgentsModal({
   );
   const [summary, setSummary] = useState<BatchDispatchSummary | null>(null);
   const [copyDone, setCopyDone] = useState(false);
+  const [downloadDone, setDownloadDone] = useState(false);
+  const [activeTemplateId, setActiveTemplateId] = useState<BatchTemplateId | null>(
+    null,
+  );
+  const [exportNote, setExportNote] = useState<string | null>(null);
 
   const liveIds = useMemo(
     () => new Set(projects.filter((p) => !p.system).map((p) => p.id)),
@@ -112,6 +162,9 @@ export function BatchAgentsModal({
       setResultItems(null);
       setSummary(null);
       setCopyDone(false);
+      setDownloadDone(false);
+      setActiveTemplateId(null);
+      setExportNote(null);
     }
   }, [open]);
 
@@ -129,6 +182,16 @@ export function BatchAgentsModal({
         selectedIds,
       }),
     [mode, prompt, projects, selectedIds],
+  );
+
+  const eligibility = useMemo(
+    () =>
+      summarizeBatchEligibility({
+        selectedCount: plan.selected.length,
+        eligibleCount: plan.eligible.length,
+        skipped: plan.skipped.map((s) => ({ reason: s.reason })),
+      }),
+    [plan],
   );
 
   const canGo = canDispatchBatch({
@@ -153,11 +216,28 @@ export function BatchAgentsModal({
   const allVisibleSelected =
     filtered.length > 0 && visibleSelectedCount === filtered.length;
 
+  const exportLabels = useMemo((): BatchExportLabels => {
+    return {
+      modeSessions: tr("batchAgents.mode.sessions"),
+      modeHeadless: tr("batchAgents.mode.headless"),
+      statusOk: tr("batchAgents.status.ok"),
+      statusOkEmpty: tr("batchAgents.status.okEmpty"),
+      statusPartial: tr("batchAgents.status.partial"),
+      statusSoftFail: tr("batchAgents.status.softFail"),
+      statusError: tr("batchAgents.status.error"),
+      statusSkipped: tr("batchAgents.status.skipped"),
+      statusQueued: tr("batchAgents.status.queued"),
+      statusPending: tr("batchAgents.status.pending"),
+      emptyExport: tr("batchAgents.exportEmpty"),
+    };
+  }, [tr]);
+
   const toggleRow = (id: string) => {
     if (running) return;
     setSelectedIds((prev) => toggleBatchProjectSelection(prev, id));
     setResultItems(null);
     setSummary(null);
+    setExportNote(null);
   };
 
   const toggleSelectAllVisible = () => {
@@ -174,6 +254,19 @@ export function BatchAgentsModal({
     });
     setResultItems(null);
     setSummary(null);
+    setExportNote(null);
+  };
+
+  const applyTemplate = (id: BatchTemplateId) => {
+    if (running) return;
+    const tpl = DEFAULT_BATCH_TEMPLATES.find((t) => t.id === id);
+    if (!tpl) return;
+    const body = tr(tpl.bodyKey as MessageKey);
+    setPrompt(applyBatchTemplate(body));
+    setActiveTemplateId(id);
+    setResultItems(null);
+    setSummary(null);
+    setExportNote(null);
   };
 
   const handleDispatch = async () => {
@@ -182,6 +275,8 @@ export function BatchAgentsModal({
     setResultItems(null);
     setSummary(null);
     setCopyDone(false);
+    setDownloadDone(false);
+    setExportNote(null);
     try {
       const sum = await onDispatch({
         mode: plan.mode,
@@ -229,23 +324,34 @@ export function BatchAgentsModal({
   };
 
   const handleCopySummary = async () => {
-    if (!summary) return;
-    const text = formatBatchSummaryText(summary, {
-      modeSessions: tr("batchAgents.mode.sessions"),
-      modeHeadless: tr("batchAgents.mode.headless"),
-      statusOk: tr("batchAgents.status.ok"),
-      statusSoftFail: tr("batchAgents.status.softFail"),
-      statusError: tr("batchAgents.status.error"),
-      statusSkipped: tr("batchAgents.status.skipped"),
-      statusQueued: tr("batchAgents.status.queued"),
-      statusPending: tr("batchAgents.status.pending"),
-    });
+    const planEx = planBatchExport(summary, exportLabels);
+    if (!planEx.ok) {
+      setExportNote(tr("batchAgents.exportEmpty"));
+      return;
+    }
     try {
-      await navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(planEx.text);
       setCopyDone(true);
+      setExportNote(null);
       window.setTimeout(() => setCopyDone(false), 2000);
     } catch {
-      /* soft-fail clipboard */
+      setExportNote(tr("batchAgents.exportFailed"));
+    }
+  };
+
+  const handleDownloadSummary = () => {
+    const planEx = planBatchExport(summary, exportLabels);
+    if (!planEx.ok) {
+      setExportNote(tr("batchAgents.exportEmpty"));
+      return;
+    }
+    try {
+      downloadText(planEx.filename, planEx.text);
+      setDownloadDone(true);
+      setExportNote(null);
+      window.setTimeout(() => setDownloadDone(false), 2000);
+    } catch {
+      setExportNote(tr("batchAgents.exportFailed"));
     }
   };
 
@@ -267,16 +373,28 @@ export function BatchAgentsModal({
         <div className="batch-agents-modal__footer">
           <div className="batch-agents-modal__footer-actions">
             {summary ? (
-              <button
-                type="button"
-                className="btn btn--ghost"
-                onClick={handleCopySummary}
-                disabled={running}
-              >
-                {copyDone
-                  ? tr("batchAgents.copied")
-                  : tr("batchAgents.copySummary")}
-              </button>
+              <>
+                <button
+                  type="button"
+                  className="btn btn--ghost"
+                  onClick={handleCopySummary}
+                  disabled={running}
+                >
+                  {copyDone
+                    ? tr("batchAgents.copied")
+                    : tr("batchAgents.copySummary")}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn--ghost"
+                  onClick={handleDownloadSummary}
+                  disabled={running}
+                >
+                  {downloadDone
+                    ? tr("batchAgents.downloaded")
+                    : tr("batchAgents.downloadSummary")}
+                </button>
+              </>
             ) : null}
           </div>
           <button
@@ -350,6 +468,34 @@ export function BatchAgentsModal({
           : tr("batchAgents.mode.sessionsHint")}
       </p>
 
+      <div className="batch-agents__templates">
+        <span className="batch-agents__templates-label" id="batch-agents-tpls">
+          {tr("batchAgents.templatesLabel")}
+        </span>
+        <div
+          className="batch-agents__chips"
+          role="group"
+          aria-labelledby="batch-agents-tpls"
+        >
+          {DEFAULT_BATCH_TEMPLATES.map((tpl) => {
+            const active = activeTemplateId === tpl.id;
+            return (
+              <button
+                key={tpl.id}
+                type="button"
+                className={
+                  "batch-agents__chip" + (active ? " is-active" : "")
+                }
+                onClick={() => applyTemplate(tpl.id)}
+                disabled={running}
+              >
+                {tr(tpl.titleKey as MessageKey)}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
       <label className="batch-agents__label" htmlFor="batch-agents-prompt">
         {tr("batchAgents.promptLabel")}
       </label>
@@ -359,6 +505,7 @@ export function BatchAgentsModal({
         value={prompt}
         onChange={(e) => {
           setPrompt(e.target.value);
+          setActiveTemplateId(null);
           setResultItems(null);
           setSummary(null);
         }}
@@ -387,6 +534,25 @@ export function BatchAgentsModal({
           })}
         </span>
       </div>
+
+      {plan.selected.length > 0 ? (
+        <p
+          className={
+            "batch-agents__eligibility" +
+            (eligibility.eligible === 0
+              ? " batch-agents__eligibility--none"
+              : "")
+          }
+        >
+          {eligibility.eligible === 0
+            ? tr("batchAgents.eligibilityNone")
+            : tr("batchAgents.eligibilitySummary", {
+                ready: eligibility.eligible,
+                skip: eligibility.skipped,
+                selected: eligibility.selected,
+              })}
+        </p>
+      ) : null}
 
       {filtered.length === 0 ? (
         <div className="batch-agents__empty">
@@ -469,6 +635,12 @@ export function BatchAgentsModal({
         </p>
       ) : null}
 
+      {exportNote ? (
+        <p className="batch-agents__export-note" role="status">
+          {exportNote}
+        </p>
+      ) : null}
+
       {resultItems && resultItems.length > 0 ? (
         <div className="batch-agents__results">
           <h3 className="batch-agents__results-title">
@@ -488,9 +660,9 @@ export function BatchAgentsModal({
             {resultItems.map((it) => (
               <li key={it.projectId} className="batch-agents__result-row">
                 <span
-                  className={`batch-agents__status ${statusClass(it.status)}`}
+                  className={`batch-agents__status ${statusClassForItem(it)}`}
                 >
-                  {statusLabel(it.status, (k, v) => tr(k, v))}
+                  {resultStatusLabel(it, (k, v) => tr(k, v))}
                 </span>
                 <span className="batch-agents__result-name">
                   {it.projectName}
@@ -503,6 +675,10 @@ export function BatchAgentsModal({
                 {it.summary ? (
                   <span className="batch-agents__result-summary" title={it.summary}>
                     {it.summary}
+                  </span>
+                ) : classifyBatchResultRow(it).kind === "ok_empty" ? (
+                  <span className="batch-agents__result-summary batch-agents__result-summary--empty">
+                    —
                   </span>
                 ) : null}
               </li>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -896,8 +896,27 @@ const en = {
   "batchAgents.resultsMeta":
     "ok {ok} · soft-fail {soft} · error {err} · skipped {skip}",
   "batchAgents.copySummary": "Copy summary",
+  "batchAgents.downloadSummary": "Download .txt",
   "batchAgents.copied": "Copied",
+  "batchAgents.downloaded": "Downloaded",
+  "batchAgents.exportEmpty": "No batch results to export yet.",
+  "batchAgents.exportFailed": "Could not export results.",
+  "batchAgents.templatesLabel": "Prompt templates",
+  "batchAgents.tpl.codeReview.title": "Code review",
+  "batchAgents.tpl.codeReview.body":
+    "Review recent changes in this repository. Call out risks, missing tests, and incomplete work with concrete file paths. Be honest about uncertainty — do not invent findings.",
+  "batchAgents.tpl.fixTests.title": "Fix tests",
+  "batchAgents.tpl.fixTests.body":
+    "Find failing or flaky tests in this repository, fix them with minimal changes, and report what still fails. Do not claim green if tests were not run.",
+  "batchAgents.tpl.summarize.title": "Summarize",
+  "batchAgents.tpl.summarize.body":
+    "Summarize what this repository does, its layout, and current risks or open TODOs. Prefer evidence from the tree over speculation.",
+  "batchAgents.eligibilitySummary":
+    "{ready} ready · {skip} not eligible of {selected} selected",
+  "batchAgents.eligibilityNone": "No eligible projects in the current selection.",
   "batchAgents.status.ok": "OK",
+  "batchAgents.status.okEmpty": "OK (no detail)",
+  "batchAgents.status.partial": "Partial",
   "batchAgents.status.softFail": "Soft-fail",
   "batchAgents.status.error": "Error",
   "batchAgents.status.skipped": "Skipped",
@@ -6985,8 +7004,27 @@ const zh: Record<MessageKey, string> = {
   "batchAgents.resultsMeta":
     "成功 {ok} · soft-fail {soft} · 错误 {err} · 跳过 {skip}",
   "batchAgents.copySummary": "复制摘要",
+  "batchAgents.downloadSummary": "下载 .txt",
   "batchAgents.copied": "已复制",
+  "batchAgents.downloaded": "已下载",
+  "batchAgents.exportEmpty": "暂无批量结果可导出。",
+  "batchAgents.exportFailed": "无法导出结果。",
+  "batchAgents.templatesLabel": "提示词模板",
+  "batchAgents.tpl.codeReview.title": "代码审查",
+  "batchAgents.tpl.codeReview.body":
+    "审查本仓库近期变更。指出风险、缺失测试与未完成工作，并给出具体文件路径。对不确定处保持诚实——不要编造发现。",
+  "batchAgents.tpl.fixTests.title": "修复测试",
+  "batchAgents.tpl.fixTests.body":
+    "找出本仓库失败或不稳定的测试，用最小改动修复，并汇报仍失败的项。若未实际跑测试，不要声称已通过。",
+  "batchAgents.tpl.summarize.title": "总结仓库",
+  "batchAgents.tpl.summarize.body":
+    "总结本仓库用途、目录结构与当前风险或未完成 TODO。优先依据树中证据，避免臆测。",
+  "batchAgents.eligibilitySummary":
+    "可运行 {ready} · 不合格 {skip}（已选 {selected}）",
+  "batchAgents.eligibilityNone": "当前选择中没有可运行的项目。",
   "batchAgents.status.ok": "成功",
+  "batchAgents.status.okEmpty": "成功（无详情）",
+  "batchAgents.status.partial": "部分",
   "batchAgents.status.softFail": "Soft-fail",
   "batchAgents.status.error": "错误",
   "batchAgents.status.skipped": "跳过",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -841,8 +841,27 @@ export const zhTW: Record<MessageKey, string> = {
   "batchAgents.resultsMeta":
     "成功 {ok} · soft-fail {soft} · 錯誤 {err} · 略過 {skip}",
   "batchAgents.copySummary": "複製摘要",
+  "batchAgents.downloadSummary": "下載 .txt",
   "batchAgents.copied": "已複製",
+  "batchAgents.downloaded": "已下載",
+  "batchAgents.exportEmpty": "尚無批量結果可匯出。",
+  "batchAgents.exportFailed": "無法匯出結果。",
+  "batchAgents.templatesLabel": "提示詞範本",
+  "batchAgents.tpl.codeReview.title": "程式碼審查",
+  "batchAgents.tpl.codeReview.body":
+    "審查本倉庫近期變更。指出風險、缺失測試與未完成工作，並給出具體檔案路徑。對不確定處保持誠實——不要編造發現。",
+  "batchAgents.tpl.fixTests.title": "修復測試",
+  "batchAgents.tpl.fixTests.body":
+    "找出本倉庫失敗或不穩定的測試，用最小改動修復，並回報仍失敗的項目。若未實際跑測試，不要聲稱已通過。",
+  "batchAgents.tpl.summarize.title": "總結倉庫",
+  "batchAgents.tpl.summarize.body":
+    "總結本倉庫用途、目錄結構與當前風險或未完成 TODO。優先依據樹中證據，避免臆測。",
+  "batchAgents.eligibilitySummary":
+    "可執行 {ready} · 不合格 {skip}（已選 {selected}）",
+  "batchAgents.eligibilityNone": "目前選擇中沒有可執行的專案。",
   "batchAgents.status.ok": "成功",
+  "batchAgents.status.okEmpty": "成功（無詳情）",
+  "batchAgents.status.partial": "部分",
   "batchAgents.status.softFail": "Soft-fail",
   "batchAgents.status.error": "錯誤",
   "batchAgents.status.skipped": "略過",

--- a/src/lib/batchAgentsPro.test.ts
+++ b/src/lib/batchAgentsPro.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import type { BatchDispatchItemResult } from "./batchAgents";
+import {
+  applyBatchTemplate,
+  classifyBatchResultRow,
+  DEFAULT_BATCH_TEMPLATES,
+  exportBatchResultsSummary,
+  getBatchTemplate,
+  isBatchTemplateId,
+  planBatchExport,
+  summarizeBatchEligibility,
+} from "./batchAgentsPro";
+
+const sampleItems: BatchDispatchItemResult[] = [
+  {
+    projectId: "a",
+    projectName: "Alpha",
+    projectPath: "/a",
+    status: "ok",
+    summary: "looks good",
+  },
+  {
+    projectId: "b",
+    projectName: "Beta",
+    projectPath: "/b",
+    status: "ok",
+    summary: null,
+  },
+  {
+    projectId: "c",
+    projectName: "Gamma",
+    projectPath: "/c",
+    status: "soft_fail",
+    reason: "timeout",
+    summary: "timed out",
+  },
+  {
+    projectId: "d",
+    projectName: "Delta",
+    projectPath: "/d",
+    status: "skipped",
+    reason: "untrusted",
+  },
+];
+
+describe("DEFAULT_BATCH_TEMPLATES", () => {
+  it("has three honest templates with i18n keys", () => {
+    expect(DEFAULT_BATCH_TEMPLATES).toHaveLength(3);
+    const ids = DEFAULT_BATCH_TEMPLATES.map((t) => t.id).sort();
+    expect(ids).toEqual(["code_review", "fix_tests", "summarize"].sort());
+    for (const t of DEFAULT_BATCH_TEMPLATES) {
+      expect(t.titleKey.startsWith("batchAgents.tpl.")).toBe(true);
+      expect(t.bodyKey.startsWith("batchAgents.tpl.")).toBe(true);
+      expect(t.titleKey.endsWith(".title")).toBe(true);
+      expect(t.bodyKey.endsWith(".body")).toBe(true);
+    }
+  });
+
+  it("isBatchTemplateId / getBatchTemplate gate unknowns", () => {
+    expect(isBatchTemplateId("code_review")).toBe(true);
+    expect(isBatchTemplateId("nope")).toBe(false);
+    expect(getBatchTemplate("fix_tests")?.id).toBe("fix_tests");
+    expect(getBatchTemplate("missing")).toBeNull();
+    expect(getBatchTemplate(null)).toBeNull();
+  });
+});
+
+describe("applyBatchTemplate", () => {
+  it("replaces {project} when name provided", () => {
+    expect(applyBatchTemplate("Review {project} risks", "Alpha")).toBe(
+      "Review Alpha risks",
+    );
+    expect(applyBatchTemplate("A {project} / {project}", "X")).toBe("A X / X");
+  });
+
+  it("leaves placeholder when no project name", () => {
+    expect(applyBatchTemplate("Review {project}", null)).toBe(
+      "Review {project}",
+    );
+    expect(applyBatchTemplate("  hello  ")).toBe("hello");
+    expect(applyBatchTemplate("   ")).toBe("");
+    expect(applyBatchTemplate(null)).toBe("");
+  });
+});
+
+describe("classifyBatchResultRow", () => {
+  it("marks ok without summary as ok_empty", () => {
+    const row = classifyBatchResultRow(sampleItems[1]);
+    expect(row.kind).toBe("ok_empty");
+    expect(row.terminal).toBe(true);
+    expect(row.note).toBe("no_detail");
+  });
+
+  it("keeps ok with detail", () => {
+    const row = classifyBatchResultRow(sampleItems[0]);
+    expect(row.kind).toBe("ok");
+    expect(row.hasDetail).toBe(true);
+  });
+
+  it("classifies soft_fail / skipped / empty", () => {
+    expect(classifyBatchResultRow(sampleItems[2]).kind).toBe("soft_fail");
+    expect(classifyBatchResultRow(sampleItems[3]).kind).toBe("skipped");
+    expect(classifyBatchResultRow(null).kind).toBe("pending");
+    expect(classifyBatchResultRow(null).note).toBe("empty_row");
+  });
+
+  it("flags partial soft_fail when reason says partial", () => {
+    const row = classifyBatchResultRow({
+      projectId: "p",
+      projectName: "P",
+      projectPath: "/p",
+      status: "soft_fail",
+      reason: "partial",
+      summary: "got some output",
+    });
+    expect(row.kind).toBe("partial");
+  });
+});
+
+describe("exportBatchResultsSummary / planBatchExport", () => {
+  it("builds a matrix with empty-detail honesty", () => {
+    const text = exportBatchResultsSummary(sampleItems, undefined, {
+      mode: "headless",
+      prompt: "review todos",
+    });
+    expect(text).toContain("Alpha");
+    expect(text).toContain("Beta");
+    expect(text).toContain("Results matrix");
+    expect(text).toMatch(/ok \(no detail\)|no detail/i);
+    expect(text).toContain("soft-fail");
+    expect(text).toContain("untrusted");
+  });
+
+  it("soft-fails empty export plans", () => {
+    expect(planBatchExport(null).ok).toBe(false);
+    const empty = planBatchExport([]);
+    expect(empty.ok).toBe(false);
+    if (!empty.ok) {
+      expect(empty.reason).toBe("empty");
+      expect(empty.filename).toBeNull();
+    }
+    expect(exportBatchResultsSummary(null)).toMatch(/no batch results/i);
+  });
+
+  it("plans a downloadable export with counts", () => {
+    const plan = planBatchExport(sampleItems, undefined, {
+      mode: "sessions",
+      prompt: "go",
+      now: new Date(2026, 6, 31, 14, 5),
+    });
+    expect(plan.ok).toBe(true);
+    if (plan.ok) {
+      expect(plan.rowCount).toBe(4);
+      expect(plan.okCount).toBe(2);
+      expect(plan.softFail).toBe(1);
+      expect(plan.skipped).toBe(1);
+      expect(plan.emptyDetail).toBe(1);
+      expect(plan.filename).toBe("batch-agents-20260731-1405.txt");
+      expect(plan.text.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("accepts a BatchDispatchSummary object", () => {
+    const plan = planBatchExport({
+      mode: "sessions",
+      promptPreview: "x",
+      total: 1,
+      ok: 1,
+      softFail: 0,
+      error: 0,
+      skipped: 0,
+      queued: 0,
+      items: [sampleItems[0]!],
+    });
+    expect(plan.ok).toBe(true);
+    if (plan.ok) expect(plan.rowCount).toBe(1);
+  });
+});
+
+describe("summarizeBatchEligibility", () => {
+  it("tallies skip reasons", () => {
+    const c = summarizeBatchEligibility({
+      selectedCount: 4,
+      eligibleCount: 2,
+      skipped: [
+        { reason: "untrusted" },
+        { reason: "untrusted" },
+        { reason: "path_missing" },
+      ],
+    });
+    expect(c.selected).toBe(4);
+    expect(c.eligible).toBe(2);
+    expect(c.skipped).toBe(3);
+    expect(c.byReason.untrusted).toBe(2);
+    expect(c.byReason.path_missing).toBe(1);
+  });
+});

--- a/src/lib/batchAgentsPro.ts
+++ b/src/lib/batchAgentsPro.ts
@@ -1,0 +1,458 @@
+/**
+ * Batch agents pro — templates, result-row honesty, export matrix.
+ *
+ * Pure helpers only. UI resolves i18n keys for template title/body;
+ * English catalog bodies are the source of truth for default wording.
+ */
+
+import {
+  formatBatchSummaryText,
+  summarizeBatchResults,
+  truncateBatchText,
+  type BatchDispatchItemResult,
+  type BatchDispatchMode,
+  type BatchDispatchSummary,
+  type BatchItemStatus,
+} from "./batchAgents";
+
+// ── Templates ──────────────────────────────────────────────────────────
+
+/** Built-in template ids (stable machine codes). */
+export type BatchTemplateId = "code_review" | "fix_tests" | "summarize";
+
+/**
+ * Prompt template: ids + i18n keys only (no hardcoded Chinese).
+ * UI looks up `titleKey` / `bodyKey` via `createT(locale)`.
+ */
+export type BatchPromptTemplate = {
+  id: BatchTemplateId;
+  /** Message key for chip title, e.g. `batchAgents.tpl.codeReview.title`. */
+  titleKey: string;
+  /** Message key for body (may include `{project}` placeholder). */
+  bodyKey: string;
+};
+
+/**
+ * Three short honest defaults: code review, fix tests, summarize.
+ * Titles/bodies live in i18n catalogs under `batchAgents.tpl.*`.
+ */
+export const DEFAULT_BATCH_TEMPLATES: readonly BatchPromptTemplate[] = [
+  {
+    id: "code_review",
+    titleKey: "batchAgents.tpl.codeReview.title",
+    bodyKey: "batchAgents.tpl.codeReview.body",
+  },
+  {
+    id: "fix_tests",
+    titleKey: "batchAgents.tpl.fixTests.title",
+    bodyKey: "batchAgents.tpl.fixTests.body",
+  },
+  {
+    id: "summarize",
+    titleKey: "batchAgents.tpl.summarize.title",
+    bodyKey: "batchAgents.tpl.summarize.body",
+  },
+] as const;
+
+export function isBatchTemplateId(
+  v: string | null | undefined,
+): v is BatchTemplateId {
+  return v === "code_review" || v === "fix_tests" || v === "summarize";
+}
+
+/** Look up a default template by id; unknown → null. */
+export function getBatchTemplate(
+  id: string | null | undefined,
+): BatchPromptTemplate | null {
+  if (!isBatchTemplateId(id)) return null;
+  return DEFAULT_BATCH_TEMPLATES.find((t) => t.id === id) ?? null;
+}
+
+/**
+ * Apply optional `{project}` substitution in a template body.
+ * - When `projectName` is non-empty: replace every `{project}` with the name.
+ * - When empty/omitted: leave `{project}` untouched (honest shared prompt).
+ * Trims the body; empty body → "".
+ */
+export function applyBatchTemplate(
+  templateBody: string | null | undefined,
+  projectName?: string | null,
+): string {
+  const body = String(templateBody ?? "").trim();
+  if (!body) return "";
+  const name = String(projectName ?? "").trim();
+  if (!name) return body;
+  return body.replaceAll("{project}", name);
+}
+
+// ── Result row honesty ─────────────────────────────────────────────────
+
+/**
+ * Row honesty kinds for the results matrix.
+ * Distinguishes empty detail vs partial output from raw status alone.
+ */
+export type BatchResultRowKind =
+  | "ok"
+  | "ok_empty"
+  | "partial"
+  | "soft_fail"
+  | "error"
+  | "skipped"
+  | "queued"
+  | "pending";
+
+export type BatchResultRowClass = {
+  kind: BatchResultRowKind;
+  status: BatchItemStatus;
+  /** True when summary/reason gives the user something to read. */
+  hasDetail: boolean;
+  /** True when status is terminal (not pending/queued). */
+  terminal: boolean;
+  /** Short machine-ish note for export (English; UI may re-label). */
+  note: string | null;
+};
+
+function hasNonEmptyText(v: string | null | undefined): boolean {
+  return String(v ?? "").trim().length > 0;
+}
+
+/**
+ * Classify one result row for matrix honesty.
+ * - `ok` with no summary → `ok_empty` (success claimed, no detail)
+ * - `soft_fail` / `error` with truncated/short summary → still soft_fail/error;
+ *   `partial` when status is ok-ish host soft path with incomplete text flag via reason
+ * - empty/missing item → pending-like empty honesty
+ */
+export function classifyBatchResultRow(
+  item: BatchDispatchItemResult | null | undefined,
+): BatchResultRowClass {
+  if (!item) {
+    return {
+      kind: "pending",
+      status: "pending",
+      hasDetail: false,
+      terminal: false,
+      note: "empty_row",
+    };
+  }
+  const status = item.status;
+  const hasSummary = hasNonEmptyText(item.summary);
+  const hasReason = hasNonEmptyText(item.reason);
+  const hasDetail = hasSummary || hasReason;
+
+  switch (status) {
+    case "ok": {
+      if (!hasSummary) {
+        return {
+          kind: "ok_empty",
+          status,
+          hasDetail: hasReason,
+          terminal: true,
+          note: hasReason ? String(item.reason).trim() : "no_detail",
+        };
+      }
+      return {
+        kind: "ok",
+        status,
+        hasDetail: true,
+        terminal: true,
+        note: null,
+      };
+    }
+    case "soft_fail": {
+      // Only mark partial when the host/reason explicitly says so —
+      // short summaries alone (e.g. "timed out") are still soft_fail.
+      const reason = String(item.reason ?? "");
+      const summary = String(item.summary ?? "");
+      const partial = /partial|incomplete|truncated/i.test(
+        `${reason} ${summary}`,
+      );
+      return {
+        kind: partial ? "partial" : "soft_fail",
+        status,
+        hasDetail,
+        terminal: true,
+        note: hasReason
+          ? reason.trim()
+          : hasSummary
+            ? null
+            : "soft_fail_empty",
+      };
+    }
+    case "error":
+      return {
+        kind: "error",
+        status,
+        hasDetail,
+        terminal: true,
+        note: hasReason
+          ? String(item.reason).trim()
+          : hasSummary
+            ? null
+            : "error_empty",
+      };
+    case "skipped":
+      return {
+        kind: "skipped",
+        status,
+        hasDetail: hasReason,
+        terminal: true,
+        note: hasReason ? String(item.reason).trim() : "skipped",
+      };
+    case "queued":
+      return {
+        kind: "queued",
+        status,
+        hasDetail: false,
+        terminal: false,
+        note: "queued",
+      };
+    default:
+      return {
+        kind: "pending",
+        status: "pending",
+        hasDetail: false,
+        terminal: false,
+        note: "pending",
+      };
+  }
+}
+
+// ── Export matrix ──────────────────────────────────────────────────────
+
+export type BatchExportLabels = {
+  modeSessions?: string;
+  modeHeadless?: string;
+  statusOk?: string;
+  statusOkEmpty?: string;
+  statusPartial?: string;
+  statusSoftFail?: string;
+  statusError?: string;
+  statusSkipped?: string;
+  statusQueued?: string;
+  statusPending?: string;
+  emptyExport?: string;
+  matrixHeader?: string;
+  colProject?: string;
+  colStatus?: string;
+  colReason?: string;
+  colDetail?: string;
+};
+
+export type BatchExportPlan =
+  | {
+      ok: true;
+      text: string;
+      filename: string;
+      rowCount: number;
+      /** Counts derived from items (honest; includes empty-detail oks). */
+      okCount: number;
+      softFail: number;
+      error: number;
+      skipped: number;
+      emptyDetail: number;
+    }
+  | {
+      ok: false;
+      reason: "empty";
+      text: string;
+      filename: null;
+      rowCount: 0;
+    };
+
+function defaultFilename(now = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  const hh = String(now.getHours()).padStart(2, "0");
+  const mm = String(now.getMinutes()).padStart(2, "0");
+  return `batch-agents-${y}${m}${d}-${hh}${mm}.txt`;
+}
+
+function asSummary(
+  results:
+    | BatchDispatchSummary
+    | readonly BatchDispatchItemResult[]
+    | null
+    | undefined,
+  fallback?: { mode?: BatchDispatchMode; prompt?: string },
+): BatchDispatchSummary | null {
+  if (results == null) return null;
+  if (Array.isArray(results)) {
+    if (results.length === 0) return null;
+    return summarizeBatchResults({
+      mode: fallback?.mode ?? "sessions",
+      prompt: fallback?.prompt ?? "",
+      items: results as BatchDispatchItemResult[],
+    });
+  }
+  const sum = results as BatchDispatchSummary;
+  if (!sum.items || sum.items.length === 0) return null;
+  return sum;
+}
+
+/**
+ * Plain-text results matrix for copy/download.
+ * Marks ok-without-detail and partial rows honestly; never invents outcomes.
+ */
+export function exportBatchResultsSummary(
+  results:
+    | BatchDispatchSummary
+    | readonly BatchDispatchItemResult[]
+    | null
+    | undefined,
+  labels?: BatchExportLabels,
+  opts?: { mode?: BatchDispatchMode; prompt?: string },
+): string {
+  const summary = asSummary(results, opts);
+  if (!summary) {
+    return labels?.emptyExport ?? "No batch results to export.";
+  }
+
+  const statusWord = (kind: BatchResultRowKind): string => {
+    switch (kind) {
+      case "ok":
+        return labels?.statusOk ?? "ok";
+      case "ok_empty":
+        return labels?.statusOkEmpty ?? labels?.statusOk ?? "ok (no detail)";
+      case "partial":
+        return labels?.statusPartial ?? "partial";
+      case "soft_fail":
+        return labels?.statusSoftFail ?? "soft-fail";
+      case "error":
+        return labels?.statusError ?? "error";
+      case "skipped":
+        return labels?.statusSkipped ?? "skipped";
+      case "queued":
+        return labels?.statusQueued ?? "queued";
+      default:
+        return labels?.statusPending ?? "pending";
+    }
+  };
+
+  // Reuse count header from base formatter, then append a clearer matrix.
+  const base = formatBatchSummaryText(summary, {
+    modeSessions: labels?.modeSessions,
+    modeHeadless: labels?.modeHeadless,
+    statusOk: labels?.statusOk,
+    statusSoftFail: labels?.statusSoftFail,
+    statusError: labels?.statusError,
+    statusSkipped: labels?.statusSkipped,
+    statusQueued: labels?.statusQueued,
+    statusPending: labels?.statusPending,
+  });
+
+  let emptyDetail = 0;
+  const colProject = labels?.colProject ?? "Project";
+  const colStatus = labels?.colStatus ?? "Status";
+  const colReason = labels?.colReason ?? "Reason";
+  const colDetail = labels?.colDetail ?? "Detail";
+  const matrixTitle = labels?.matrixHeader ?? "Results matrix";
+
+  const matrixLines: string[] = [
+    "",
+    matrixTitle,
+    `${colProject}\t${colStatus}\t${colReason}\t${colDetail}`,
+  ];
+
+  for (const it of summary.items) {
+    const row = classifyBatchResultRow(it);
+    if (row.kind === "ok_empty") emptyDetail += 1;
+    const name = it.projectName || it.projectId || "—";
+    const reason = (it.reason || row.note || "").trim() || "—";
+    const detail = truncateBatchText(it.summary, 160) || "—";
+    matrixLines.push(
+      `${name}\t${statusWord(row.kind)}\t${reason}\t${detail}`,
+    );
+  }
+
+  if (emptyDetail > 0) {
+    matrixLines.push("");
+    matrixLines.push(
+      `note: ${emptyDetail} row(s) marked ok without detail (empty summary)`,
+    );
+  }
+
+  return `${base}\n${matrixLines.join("\n")}`;
+}
+
+/**
+ * Plan a copy/download export. Soft-fails when there are no rows
+ * (never claims success with invented content).
+ */
+export function planBatchExport(
+  results:
+    | BatchDispatchSummary
+    | readonly BatchDispatchItemResult[]
+    | null
+    | undefined,
+  labels?: BatchExportLabels,
+  opts?: {
+    mode?: BatchDispatchMode;
+    prompt?: string;
+    now?: Date;
+    filename?: string;
+  },
+): BatchExportPlan {
+  const summary = asSummary(results, opts);
+  const emptyText = labels?.emptyExport ?? "No batch results to export.";
+  if (!summary) {
+    return {
+      ok: false,
+      reason: "empty",
+      text: emptyText,
+      filename: null,
+      rowCount: 0,
+    };
+  }
+
+  let emptyDetail = 0;
+  for (const it of summary.items) {
+    if (classifyBatchResultRow(it).kind === "ok_empty") emptyDetail += 1;
+  }
+
+  const text = exportBatchResultsSummary(summary, labels, opts);
+  return {
+    ok: true,
+    text,
+    filename: opts?.filename ?? defaultFilename(opts?.now),
+    rowCount: summary.items.length,
+    okCount: summary.ok,
+    softFail: summary.softFail,
+    error: summary.error,
+    skipped: summary.skipped,
+    emptyDetail,
+  };
+}
+
+// ── Eligibility matrix (selection clarity) ─────────────────────────────
+
+export type BatchEligibilityCounts = {
+  selected: number;
+  eligible: number;
+  skipped: number;
+  /** Skip reasons → count (stable order not required). */
+  byReason: Record<string, number>;
+};
+
+/**
+ * Summarize plan selection for the eligibility strip
+ * (ready vs skipped, with reason tallies).
+ */
+export function summarizeBatchEligibility(opts: {
+  selectedCount: number;
+  eligibleCount: number;
+  skipped: readonly { reason: string }[];
+}): BatchEligibilityCounts {
+  const byReason: Record<string, number> = {};
+  for (const s of opts.skipped) {
+    const r = String(s.reason || "skipped").trim() || "skipped";
+    byReason[r] = (byReason[r] ?? 0) + 1;
+  }
+  return {
+    selected: Math.max(0, opts.selectedCount | 0),
+    eligible: Math.max(0, opts.eligibleCount | 0),
+    skipped: opts.skipped.length,
+    byReason,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -26041,6 +26041,50 @@ html[data-theme="light"] .rim-sidebar {
   border-color: var(--accent);
   color: var(--text-primary);
 }
+.batch-agents__templates {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.batch-agents__templates-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.batch-agents__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.batch-agents__chip {
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  line-height: 1.3;
+  cursor: pointer;
+}
+.batch-agents__chip:hover:not(:disabled) {
+  border-color: var(--border-strong, var(--border-subtle));
+  color: var(--text-primary);
+  background: var(--hover-bg, rgba(127, 127, 127, 0.08));
+}
+.batch-agents__chip.is-active {
+  background: var(--accent-soft, color-mix(in srgb, var(--accent) 16%, transparent));
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+.batch-agents__chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 .batch-agents__label {
   font-size: 12px;
   font-weight: 600;
@@ -26052,6 +26096,23 @@ html[data-theme="light"] .rim-sidebar {
   min-height: 72px;
   resize: vertical;
   font: inherit;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+.batch-agents__eligibility {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+.batch-agents__eligibility--none {
+  color: var(--warning, #c9a227);
+}
+.batch-agents__export-note {
+  margin: 0;
+  font-size: 11px;
+  color: var(--warning, #c9a227);
   line-height: 1.4;
   flex-shrink: 0;
 }
@@ -26232,6 +26293,15 @@ html[data-theme="light"] .rim-sidebar {
   color: var(--success, #2f9e6b);
   border-color: color-mix(in srgb, var(--success, #2f9e6b) 40%, transparent);
 }
+.batch-agents__status--ok-empty {
+  color: var(--text-secondary);
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--success, #2f9e6b) 35%, transparent);
+}
+.batch-agents__status--partial {
+  color: var(--warning, #c9892e);
+  border-style: dashed;
+}
 .batch-agents__status--soft {
   color: var(--warning, #c9892e);
 }
@@ -26239,6 +26309,7 @@ html[data-theme="light"] .rim-sidebar {
   color: var(--danger, #d14);
 }
 .batch-agents__status--skip,
+.batch-agents__status--skipped,
 .batch-agents__status--pending {
   color: var(--text-tertiary);
 }
@@ -26263,6 +26334,10 @@ html[data-theme="light"] .rim-sidebar {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.batch-agents__result-summary--empty {
+  opacity: 0.55;
+  font-style: italic;
 }
 
 /* ── Cost rollup (Settings → Runtime → Tools) ───────────────────────── */


### PR DESCRIPTION
## Summary
- Pure `batchAgentsPro` helpers: default prompt templates (code review / fix tests / summarize), `{project}` apply, result-row honesty (`ok_empty` / partial), eligibility tallies, and soft-fail-empty results matrix export (copy/download `.txt`)
- `BatchAgentsModal`: template chips above the prompt, eligibility strip for selected projects, Copy summary + Download .txt, clearer ok-without-detail matrix rows
- i18n en / zh / zh-TW + CHANGELOG + minimal CSS

## Test plan
- [x] `pnpm test -- src/lib/batchAgents.test.ts src/lib/batchAgentsPro.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Open Batch agents → pick a template chip → confirm prompt fills
- [ ] Select mixed trusted/untrusted projects → eligibility strip shows ready vs not eligible
- [ ] Run a small batch → Copy summary / Download .txt produce matrix text; empty results soft-fail honestly