### PR TITLE
feat(update): auto vs manual update path honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **App auto-update path honesty** (Settings → About): pure `appUpdateHonesty` maps signed in-app updater vs GitHub manual download vs unsupported package types vs host-only; progress states (checking / downloading / installing) with honest notes that agents, voice, Remote IM, and mirror stop only after successful install prepare; classified soft-fail errors (network · signature · plugin missing · not ready · host-only); manual path keeps Open release page + Download installer when asset URL known; no invented versions. en/zh/zh-TW + tests.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/docs/desktop-auto-update.md
+++ b/docs/desktop-auto-update.md
@@ -31,6 +31,7 @@ Unsigned / local builds keep the previous GitHub “open release page” path.
 | Platform support | `is_auto_update_supported` — Linux requires AppImage (`APPIMAGE` env) |
 | Pre-relaunch teardown | `prepare_for_app_update` — **only after** successful `install()`, never before |
 | Frontend state machine | `src/hooks/useUpdater.ts` + `UpdaterProvider` (single path: plugin or GitHub) |
+| Path honesty (copy / channel) | `src/lib/appUpdateHonesty.ts` — signed auto vs GitHub manual vs unsupported vs host-only; soft-fail error classes; agents stop only after install prepare |
 | UI | Settings → About (`AboutUpdateRow`) |
 | Capabilities | `updater:allow-*`, `process:allow-restart` |
 

--- a/docs/features/app-update-flow.md
+++ b/docs/features/app-update-flow.md
@@ -4,13 +4,13 @@ Settings → About → Check for updates.
 
 ## Behaviour
 
-1. Query GitHub Releases for the latest tag.
-2. Compare semver to the running app.
-3. When newer: offer **Download installer** (platform asset) and **Open release page**.
-
-Unsigned community builds do not silent-install; the handoff is download + user install.
+1. Signed release (plugin on + platform supports): check → download → install → `prepare_for_app_update` → relaunch.
+2. Unsigned / local / plugin off: query GitHub Releases, then **Open release page** and optional **Download installer**.
+3. Package types that cannot auto-update (e.g. Linux non-AppImage): manual path with honest unsupported channel copy.
+4. Status copy and channel honesty: pure `src/lib/appUpdateHonesty.ts` (never invents versions; agents stop only after successful install prepare).
 
 ## Verify
 
 1. Check update against a known newer release — download URL points at the matching asset when present.
 2. When already latest — status says up to date.
+3. Local / unsigned build shows GitHub download channel, not silent in-app.

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -275,6 +275,19 @@ import {
 } from "@/i18n";
 import { useUpdaterContext } from "@/hooks/UpdaterProvider";
 import {
+  isAutoUpdatePath,
+  isUpdateActionBusy,
+  mapUpdateStatusCopy,
+  resolveManualUpdateUrls,
+  resolveUpdateChannelHonestyPreferHost,
+  shouldShowInstallButton,
+  shouldShowInstallProgress,
+  shouldShowManualDownloadCtas,
+  updateChannelLabelKey,
+  updateStatusToneClass,
+  type AppUpdateStatusLike,
+} from "@/lib/appUpdateHonesty";
+import {
   loadCodeLineNumbersPref,
   saveCodeLineNumbersPref,
 } from "@/lib/codeLineNumbersPref";
@@ -8539,6 +8552,7 @@ function AboutUpdateRow({
   t: (key: MessageKey, vars?: Record<string, string | number>) => string;
 }) {
   // Single authority: useUpdater (plugin path or GitHub fallback).
+  // Status / channel copy via appUpdateHonesty — never invent versions.
   const {
     status,
     channelInfo,
@@ -8557,64 +8571,67 @@ function AboutUpdateRow({
     }
   };
 
+  const statusLike = status as AppUpdateStatusLike;
+  const copy = mapUpdateStatusCopy(statusLike);
+  const channel = resolveUpdateChannelHonestyPreferHost({
+    hostChannel: channelInfo.channel,
+    pluginEnabled: channelInfo.pluginEnabled,
+    autoUpdateSupported:
+      channelInfo.platformSupported && channelInfo.pluginEnabled,
+    isDesktopHost: true,
+    status: statusLike,
+  });
+  const channelLabelKey = updateChannelLabelKey(channel);
+
   const statusText = (() => {
-    switch (status.state) {
-      case "checking":
-        return t("settings.autoUpdateChecking");
-      case "up-to-date":
-        return status.version
-          ? t("settings.checkUpdateLatest", { version: status.version })
-          : t("settings.autoUpdateUpToDate");
-      case "available":
-        return t("settings.autoUpdateAvailable", { version: status.version });
-      case "downloading":
-        return t("settings.autoUpdateDownloading");
-      case "ready":
-        return t("settings.autoUpdateReady");
-      case "installing":
-        return t("settings.autoUpdateInstalling");
-      case "manual-required":
-        return t("settings.autoUpdateManualRequired", {
-          version: status.version,
-        });
-      case "error":
-        return null;
-      default:
-        return null;
+    if (!copy.titleKey || status.state === "idle" || status.state === "error") {
+      return null;
     }
+    if (copy.version) {
+      return t(copy.titleKey, { version: copy.version });
+    }
+    return t(copy.titleKey);
   })();
 
-  const busy =
-    status.state === "checking" ||
-    status.state === "downloading" ||
-    status.state === "installing";
+  const bodyText = (() => {
+    if (!copy.bodyKey) return null;
+    // Error body is shown under the alert line separately.
+    if (status.state === "error") return null;
+    // Agents note only on auto path; manual path uses manual body.
+    if (
+      copy.bodyKey === "settings.autoUpdateBody.agentsNote" &&
+      !isAutoUpdatePath(channel)
+    ) {
+      return null;
+    }
+    return t(copy.bodyKey);
+  })();
 
+  const busy = isUpdateActionBusy(statusLike);
+  const showInstallProgress = shouldShowInstallProgress(statusLike);
   // Only show install when download finished (ready), never on available.
-  const showInstall = status.state === "ready";
-  const showInstalling = status.state === "installing";
-  const showOpenRelease = status.state === "manual-required";
-  const releaseUrl =
-    status.state === "manual-required" ? status.releaseUrl : githubReleasesUrl;
-  const downloadUrl =
-    status.state === "manual-required" ? status.downloadUrl : null;
-  const assetNames =
-    status.state === "manual-required" ? status.assetNames : undefined;
-  const highlight =
-    status.state === "available" ||
-    status.state === "ready" ||
-    status.state === "downloading" ||
-    status.state === "manual-required";
+  const showInstall = shouldShowInstallButton(statusLike);
+  const showOpenRelease = shouldShowManualDownloadCtas(statusLike);
+  const manualUrls = showOpenRelease
+    ? resolveManualUpdateUrls(statusLike, githubReleasesUrl)
+    : null;
+  const releaseUrl = manualUrls?.releaseUrl ?? githubReleasesUrl;
+  const downloadUrl = manualUrls?.downloadUrl ?? null;
+  const assetNames = manualUrls?.assetNames;
+  const toneClass = updateStatusToneClass(copy.severity);
 
   return (
     <div className="settings-row settings-row--stack">
       <div className="settings-row__text">
         <div className="settings-row__label">{t("settings.checkUpdate")}</div>
         <div className="settings-row__desc">{t("settings.checkUpdateDesc")}</div>
-        <div className="settings-row__hint" data-updater-channel={channelInfo.channel}>
-          {channelInfo.channel === "silent"
-            ? t("settings.autoUpdateChannelSilent")
-            : t("settings.autoUpdateChannelManual")}
-          {channelInfo.endpoint
+        <div
+          className="settings-row__hint"
+          data-updater-channel={channel}
+          data-updater-host-channel={channelInfo.channel}
+        >
+          {t(channelLabelKey)}
+          {channelInfo.endpoint && isAutoUpdatePath(channel)
             ? ` · ${channelInfo.endpoint.replace(/^https:\/\//, "")}`
             : ""}
         </div>
@@ -8631,7 +8648,7 @@ function AboutUpdateRow({
               ? t("settings.checkUpdateChecking")
               : t("settings.checkUpdate")}
           </button>
-          {showInstalling ? (
+          {showInstallProgress && status.state === "installing" ? (
             <button type="button" className="btn btn--solid" disabled>
               {t("settings.autoUpdateInstalling")}
             </button>
@@ -8667,16 +8684,38 @@ function AboutUpdateRow({
         {statusText ? (
           <div
             className={
-              "settings-about-update__status" + (highlight ? " is-available" : "")
+              "settings-about-update__status" +
+              (toneClass ? ` ${toneClass}` : "")
             }
             role="status"
+            data-update-state={status.state}
+            data-update-severity={copy.severity}
           >
             {statusText}
           </div>
         ) : null}
+        {bodyText ? (
+          <div
+            className="settings-about-update__body"
+            data-update-body={copy.bodyKey ?? undefined}
+          >
+            {bodyText}
+          </div>
+        ) : null}
         {status.state === "error" ? (
-          <div className="settings-about-update__err" role="alert">
-            {t("settings.autoUpdateError", { error: status.message })}
+          <div
+            className="settings-about-update__err"
+            role="alert"
+            data-update-error-kind={copy.errorKind ?? "other"}
+          >
+            {t("settings.autoUpdateError", {
+              error: copy.errorMessage ?? status.message,
+            })}
+            {copy.bodyKey ? (
+              <div className="settings-about-update__err-hint">
+                {t(copy.bodyKey)}
+              </div>
+            ) : null}
           </div>
         ) : null}
         {openError ? (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2971,7 +2971,7 @@ const en = {
   "settings.aboutApp": "About Grok App",
   "settings.checkUpdate": "Check for updates",
   "settings.checkUpdateDesc":
-    "Signed release builds can download and install updates in-app. Local or unsigned builds open the GitHub release page instead.",
+    "Signed release builds can download and install updates in-app. Local or unsigned builds open the GitHub release page instead. Agents, voice, Remote IM, and mirror keep running until install succeeds.",
   "settings.checkUpdateChecking": "Checking…",
   "settings.checkUpdateLatest": "You are on the latest version ({version}).",
   "settings.checkUpdateAvailable":
@@ -2979,6 +2979,7 @@ const en = {
   "settings.checkUpdateOpen": "Open release page",
   "settings.checkUpdateDownload": "Download installer",
   "settings.checkUpdateFailed": "Could not check: {error}",
+  "settings.autoUpdateIdle": "Check when you want — no update status yet.",
   "settings.autoUpdateChecking": "Checking for updates…",
   "settings.autoUpdateUpToDate": "You are on the latest version.",
   "settings.autoUpdateAvailable": "Version {version} is available.",
@@ -2989,10 +2990,38 @@ const en = {
   "settings.autoUpdateManualRequired":
     "Version {version} is available. This install type cannot auto-update — download from the release page.",
   "settings.autoUpdateError": "Update failed: {error}",
+  "settings.autoUpdateBody.checking":
+    "Contacting the signed updater endpoint or GitHub Releases…",
+  "settings.autoUpdateBody.downloading":
+    "Downloading a signed package. Agents keep running until install succeeds.",
+  "settings.autoUpdateBody.installing":
+    "Staging the update. Agents, voice, Remote IM, and mirror stop only after a successful install prepare.",
+  "settings.autoUpdateBody.ready":
+    "Install and restart when ready. A failed install will not stop agents.",
+  "settings.autoUpdateBody.manual":
+    "Open the release page or download the installer for this platform. In-app silent install is not available on this build.",
+  "settings.autoUpdateBody.agentsNote":
+    "Agents, voice, Remote IM, and mirror keep running; they stop only after a successful install prepare.",
+  "settings.autoUpdateError.network":
+    "Could not reach the update server. Check your network or proxy, then try again.",
+  "settings.autoUpdateError.signature":
+    "The update package failed signature verification. Use a signed release build or download from GitHub Releases.",
+  "settings.autoUpdateError.pluginMissing":
+    "In-app updater is not available in this build (unsigned or local). Use Check for updates to open GitHub Releases.",
+  "settings.autoUpdateError.notReady":
+    "The update is not ready to install yet. Wait for download to finish, then try Install and restart.",
+  "settings.autoUpdateError.hostOnly":
+    "App updates are only available in the desktop app, not in a browser preview.",
+  "settings.autoUpdateError.other":
+    "Update failed. You can still open the GitHub release page and install manually.",
   "settings.autoUpdateChannelSilent":
     "Update channel: in-app (signed release)",
   "settings.autoUpdateChannelManual":
     "Update channel: GitHub download (unsigned / local build)",
+  "settings.autoUpdateChannelUnsupported":
+    "Update channel: manual install (this package type cannot auto-update)",
+  "settings.autoUpdateChannelHostOnly":
+    "Update channel: desktop app only (not available here)",
   "settings.close": "Close",
   "settings.sharedConfirm":
     "Switch to shared ~/.grok? Data will not merge silently. Confirm?",
@@ -8984,7 +9013,7 @@ const zh: Record<MessageKey, string> = {
   "settings.aboutApp": "关于 Grok App",
   "settings.checkUpdate": "检查更新",
   "settings.checkUpdateDesc":
-    "已签名的正式版可在应用内下载并安装更新。本地或未签名构建会改为打开 GitHub 发布页。",
+    "已签名的正式版可在应用内下载并安装更新。本地或未签名构建会改为打开 GitHub 发布页。智能体、语音、远程 IM 与镜像在安装成功前会继续运行。",
   "settings.checkUpdateChecking": "检查中…",
   "settings.checkUpdateLatest": "已是最新版本（{version}）。",
   "settings.checkUpdateAvailable":
@@ -8992,6 +9021,7 @@ const zh: Record<MessageKey, string> = {
   "settings.checkUpdateOpen": "打开发布页",
   "settings.checkUpdateDownload": "下载安装包",
   "settings.checkUpdateFailed": "检查失败：{error}",
+  "settings.autoUpdateIdle": "需要时再检查 — 尚无更新状态。",
   "settings.autoUpdateChecking": "正在检查更新…",
   "settings.autoUpdateUpToDate": "已是最新版本。",
   "settings.autoUpdateAvailable": "有新版本 {version}。",
@@ -9002,9 +9032,37 @@ const zh: Record<MessageKey, string> = {
   "settings.autoUpdateManualRequired":
     "有新版本 {version}。当前安装方式不支持应用内更新 — 请到发布页下载。",
   "settings.autoUpdateError": "更新失败：{error}",
+  "settings.autoUpdateBody.checking":
+    "正在连接已签名更新端点或 GitHub Releases…",
+  "settings.autoUpdateBody.downloading":
+    "正在下载已签名安装包。安装成功前智能体继续运行。",
+  "settings.autoUpdateBody.installing":
+    "正在暂存更新。智能体、语音、远程 IM 与镜像仅在安装准备成功后才会停止。",
+  "settings.autoUpdateBody.ready":
+    "准备好后可安装并重启。安装失败不会停止智能体。",
+  "settings.autoUpdateBody.manual":
+    "请打开发布页或下载本平台安装包。此构建不支持应用内静默安装。",
+  "settings.autoUpdateBody.agentsNote":
+    "智能体、语音、远程 IM 与镜像继续运行；仅在安装准备成功后才会停止。",
+  "settings.autoUpdateError.network":
+    "无法连接更新服务器。请检查网络或代理后重试。",
+  "settings.autoUpdateError.signature":
+    "更新包签名校验失败。请使用已签名正式版，或从 GitHub Releases 下载。",
+  "settings.autoUpdateError.pluginMissing":
+    "此构建未启用应用内更新（未签名或本地版）。请点「检查更新」打开 GitHub Releases。",
+  "settings.autoUpdateError.notReady":
+    "更新尚未就绪。请等待下载完成后再点「安装并重启」。",
+  "settings.autoUpdateError.hostOnly":
+    "应用更新仅在桌面端可用，浏览器预览中不可用。",
+  "settings.autoUpdateError.other":
+    "更新失败。你仍可打开发布页并手动安装。",
   "settings.autoUpdateChannelSilent": "更新通道：应用内（已签名正式版）",
   "settings.autoUpdateChannelManual":
     "更新通道：GitHub 下载（未签名 / 本地构建）",
+  "settings.autoUpdateChannelUnsupported":
+    "更新通道：手动安装（此安装包类型不支持自动更新）",
+  "settings.autoUpdateChannelHostOnly":
+    "更新通道：仅桌面端（此处不可用）",
   "settings.close": "关闭",
   "settings.sharedConfirm":
     "切换到共享 ~/.grok？数据不会静默合并，请确认。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2839,7 +2839,7 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.aboutApp": "關於 Grok App",
   "settings.checkUpdate": "檢查更新",
   "settings.checkUpdateDesc":
-    "已簽名的正式版可在應用程式內下載並安裝更新。本機或未簽名建置會改為開啟 GitHub 發佈頁。",
+    "已簽名的正式版可在應用程式內下載並安裝更新。本機或未簽名建置會改為開啟 GitHub 發佈頁。智慧體、語音、遠端 IM 與鏡像在安裝成功前會繼續執行。",
   "settings.checkUpdateChecking": "檢查中…",
   "settings.checkUpdateLatest": "已是最新版本（{version}）。",
   "settings.checkUpdateAvailable":
@@ -2847,6 +2847,7 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.checkUpdateOpen": "開啟發佈頁",
   "settings.checkUpdateDownload": "下載安裝包",
   "settings.checkUpdateFailed": "檢查失敗：{error}",
+  "settings.autoUpdateIdle": "需要時再檢查 — 尚無更新狀態。",
   "settings.autoUpdateChecking": "正在檢查更新…",
   "settings.autoUpdateUpToDate": "已是最新版本。",
   "settings.autoUpdateAvailable": "有新版本 {version}。",
@@ -2857,9 +2858,37 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.autoUpdateManualRequired":
     "有新版本 {version}。目前安裝方式不支援應用程式內更新 — 請到發佈頁下載。",
   "settings.autoUpdateError": "更新失敗：{error}",
+  "settings.autoUpdateBody.checking":
+    "正在連線已簽名更新端點或 GitHub Releases…",
+  "settings.autoUpdateBody.downloading":
+    "正在下載已簽名安裝包。安裝成功前智慧體繼續執行。",
+  "settings.autoUpdateBody.installing":
+    "正在暫存更新。智慧體、語音、遠端 IM 與鏡像僅在安裝準備成功後才會停止。",
+  "settings.autoUpdateBody.ready":
+    "準備好後可安裝並重新啟動。安裝失敗不會停止智慧體。",
+  "settings.autoUpdateBody.manual":
+    "請開啟發佈頁或下載本平台安裝包。此建置不支援應用程式內靜默安裝。",
+  "settings.autoUpdateBody.agentsNote":
+    "智慧體、語音、遠端 IM 與鏡像繼續執行；僅在安裝準備成功後才會停止。",
+  "settings.autoUpdateError.network":
+    "無法連線更新伺服器。請檢查網路或代理後重試。",
+  "settings.autoUpdateError.signature":
+    "更新包簽名校驗失敗。請使用已簽名正式版，或從 GitHub Releases 下載。",
+  "settings.autoUpdateError.pluginMissing":
+    "此建置未啟用應用程式內更新（未簽名或本機版）。請點「檢查更新」開啟 GitHub Releases。",
+  "settings.autoUpdateError.notReady":
+    "更新尚未就緒。請等待下載完成後再點「安裝並重新啟動」。",
+  "settings.autoUpdateError.hostOnly":
+    "應用更新僅在桌面端可用，瀏覽器預覽中不可用。",
+  "settings.autoUpdateError.other":
+    "更新失敗。你仍可開啟發佈頁並手動安裝。",
   "settings.autoUpdateChannelSilent": "更新通道：應用內（已簽名正式版）",
   "settings.autoUpdateChannelManual":
     "更新通道：GitHub 下載（未簽名 / 本地建置）",
+  "settings.autoUpdateChannelUnsupported":
+    "更新通道：手動安裝（此安裝包類型不支援自動更新）",
+  "settings.autoUpdateChannelHostOnly":
+    "更新通道：僅桌面端（此處不可用）",
   "settings.close": "關閉",
   "settings.sharedConfirm":
     "切換到共用 ~/.grok？資料不會靜默合併，請確認。",

--- a/src/lib/appUpdateHonesty.test.ts
+++ b/src/lib/appUpdateHonesty.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it } from "vitest";
+import {
+  channelFromHostString,
+  classifyUpdateError,
+  formatUpdateProgressLine,
+  isAutoUpdatePath,
+  isUpdateActionBusy,
+  mapUpdateStatusCopy,
+  resolveManualUpdateUrls,
+  resolveUpdateChannelHonesty,
+  resolveUpdateChannelHonestyPreferHost,
+  shouldShowInstallButton,
+  shouldShowInstallProgress,
+  shouldShowManualDownloadCtas,
+  updateChannelLabelKey,
+  updateErrorBodyKey,
+  updateStatusToneClass,
+  type AppUpdateStatusLike,
+} from "./appUpdateHonesty";
+
+describe("resolveUpdateChannelHonesty", () => {
+  it("returns host_only when not desktop", () => {
+    expect(
+      resolveUpdateChannelHonesty({
+        pluginEnabled: true,
+        autoUpdateSupported: true,
+        isDesktopHost: false,
+      }),
+    ).toBe("host_only");
+  });
+
+  it("returns manual_github when plugin is off", () => {
+    expect(
+      resolveUpdateChannelHonesty({
+        pluginEnabled: false,
+        autoUpdateSupported: false,
+        isDesktopHost: true,
+      }),
+    ).toBe("manual_github");
+  });
+
+  it("returns unsupported when plugin on but platform cannot auto-update", () => {
+    expect(
+      resolveUpdateChannelHonesty({
+        pluginEnabled: true,
+        autoUpdateSupported: false,
+        isDesktopHost: true,
+      }),
+    ).toBe("unsupported");
+  });
+
+  it("returns auto when plugin + platform support silent path", () => {
+    expect(
+      resolveUpdateChannelHonesty({
+        pluginEnabled: true,
+        autoUpdateSupported: true,
+        isDesktopHost: true,
+      }),
+    ).toBe("auto");
+  });
+
+  it("manual-required + platform gate → unsupported", () => {
+    expect(
+      resolveUpdateChannelHonesty({
+        pluginEnabled: true,
+        autoUpdateSupported: false,
+        isDesktopHost: true,
+        status: {
+          state: "manual-required",
+          version: "0.2.4",
+          releaseUrl: "https://example.com/r",
+        },
+      }),
+    ).toBe("unsupported");
+  });
+
+  it("manual-required without platform gate → manual_github", () => {
+    expect(
+      resolveUpdateChannelHonesty({
+        pluginEnabled: false,
+        autoUpdateSupported: false,
+        isDesktopHost: true,
+        status: {
+          state: "manual-required",
+          version: "0.2.4",
+          releaseUrl: "https://example.com/r",
+        },
+      }),
+    ).toBe("manual_github");
+  });
+});
+
+describe("updateChannelLabelKey / isAutoUpdatePath", () => {
+  it("maps channels to i18n keys", () => {
+    expect(updateChannelLabelKey("auto")).toBe(
+      "settings.autoUpdateChannelSilent",
+    );
+    expect(updateChannelLabelKey("manual_github")).toBe(
+      "settings.autoUpdateChannelManual",
+    );
+    expect(updateChannelLabelKey("unsupported")).toBe(
+      "settings.autoUpdateChannelUnsupported",
+    );
+    expect(updateChannelLabelKey("host_only")).toBe(
+      "settings.autoUpdateChannelHostOnly",
+    );
+  });
+
+  it("only auto is silent-install path", () => {
+    expect(isAutoUpdatePath("auto")).toBe(true);
+    expect(isAutoUpdatePath("manual_github")).toBe(false);
+    expect(isAutoUpdatePath("unsupported")).toBe(false);
+    expect(isAutoUpdatePath("host_only")).toBe(false);
+  });
+});
+
+describe("mapUpdateStatusCopy", () => {
+  it("maps idle with no invented version", () => {
+    const c = mapUpdateStatusCopy({ state: "idle" });
+    expect(c.titleKey).toBe("settings.autoUpdateIdle");
+    expect(c.version).toBeNull();
+    expect(c.severity).toBe("none");
+  });
+
+  it("maps checking / progress states with body notes", () => {
+    expect(mapUpdateStatusCopy({ state: "checking" }).bodyKey).toBe(
+      "settings.autoUpdateBody.checking",
+    );
+    expect(
+      mapUpdateStatusCopy({ state: "downloading", version: "1.2.3" }),
+    ).toMatchObject({
+      titleKey: "settings.autoUpdateDownloading",
+      bodyKey: "settings.autoUpdateBody.downloading",
+      version: "1.2.3",
+      severity: "info",
+    });
+    expect(
+      mapUpdateStatusCopy({ state: "installing", version: "1.2.3" }).bodyKey,
+    ).toBe("settings.autoUpdateBody.installing");
+  });
+
+  it("never invents version on up-to-date without one", () => {
+    const bare = mapUpdateStatusCopy({ state: "up-to-date" });
+    expect(bare.titleKey).toBe("settings.autoUpdateUpToDate");
+    expect(bare.version).toBeNull();
+
+    const withV = mapUpdateStatusCopy({
+      state: "up-to-date",
+      version: "0.2.3",
+    });
+    expect(withV.titleKey).toBe("settings.checkUpdateLatest");
+    expect(withV.version).toBe("0.2.3");
+  });
+
+  it("manual-required keeps version and manual body", () => {
+    const c = mapUpdateStatusCopy({
+      state: "manual-required",
+      version: "0.3.0",
+      releaseUrl: "https://github.com/x/y/releases/latest",
+    });
+    expect(c.titleKey).toBe("settings.autoUpdateManualRequired");
+    expect(c.bodyKey).toBe("settings.autoUpdateBody.manual");
+    expect(c.version).toBe("0.3.0");
+    expect(c.severity).toBe("warn");
+  });
+
+  it("available notes agents stop only after install prepare", () => {
+    const c = mapUpdateStatusCopy({ state: "available", version: "1.0.0" });
+    expect(c.bodyKey).toBe("settings.autoUpdateBody.agentsNote");
+  });
+
+  it("ready uses warn severity for install CTA", () => {
+    const c = mapUpdateStatusCopy({ state: "ready", version: "1.0.1" });
+    expect(c.titleKey).toBe("settings.autoUpdateReady");
+    expect(c.bodyKey).toBe("settings.autoUpdateBody.ready");
+    expect(c.severity).toBe("warn");
+  });
+
+  it("classifies error soft-fails into body keys", () => {
+    const net = mapUpdateStatusCopy({
+      state: "error",
+      message: "network timeout while fetching",
+    });
+    expect(net.severity).toBe("error");
+    expect(net.errorKind).toBe("network");
+    expect(net.bodyKey).toBe("settings.autoUpdateError.network");
+    expect(net.version).toBeNull();
+  });
+});
+
+describe("formatUpdateProgressLine", () => {
+  it("returns null for idle", () => {
+    expect(formatUpdateProgressLine({ state: "idle" })).toBeNull();
+  });
+
+  it("returns title key without inventing version", () => {
+    expect(formatUpdateProgressLine({ state: "checking" })).toEqual({
+      titleKey: "settings.autoUpdateChecking",
+      version: null,
+      severity: "info",
+    });
+    expect(
+      formatUpdateProgressLine({ state: "available", version: "9.9.9" }),
+    ).toEqual({
+      titleKey: "settings.autoUpdateAvailable",
+      version: "9.9.9",
+      severity: "info",
+    });
+  });
+});
+
+describe("shouldShowInstallProgress / busy / CTAs", () => {
+  it("shows progress only for downloading and installing", () => {
+    expect(shouldShowInstallProgress({ state: "downloading" })).toBe(true);
+    expect(shouldShowInstallProgress({ state: "installing" })).toBe(true);
+    expect(shouldShowInstallProgress({ state: "available" })).toBe(false);
+    expect(shouldShowInstallProgress({ state: "ready" })).toBe(false);
+    expect(shouldShowInstallProgress({ state: "checking" })).toBe(false);
+    expect(shouldShowInstallProgress(null)).toBe(false);
+  });
+
+  it("marks check/install busy for checking + progress", () => {
+    expect(isUpdateActionBusy({ state: "checking" })).toBe(true);
+    expect(isUpdateActionBusy({ state: "downloading" })).toBe(true);
+    expect(isUpdateActionBusy({ state: "installing" })).toBe(true);
+    expect(isUpdateActionBusy({ state: "ready" })).toBe(false);
+  });
+
+  it("install button only when ready; manual CTAs only when manual-required", () => {
+    expect(shouldShowInstallButton({ state: "ready" })).toBe(true);
+    expect(shouldShowInstallButton({ state: "available" })).toBe(false);
+    expect(shouldShowManualDownloadCtas({ state: "manual-required" })).toBe(
+      true,
+    );
+    expect(shouldShowManualDownloadCtas({ state: "available" })).toBe(false);
+  });
+});
+
+describe("classifyUpdateError", () => {
+  it("classifies network soft-fails", () => {
+    expect(classifyUpdateError("Network request failed")).toBe("network");
+    expect(classifyUpdateError("connection timed out")).toBe("network");
+    expect(classifyUpdateError("failed to fetch latest.json")).toBe("network");
+  });
+
+  it("classifies signature soft-fails", () => {
+    expect(classifyUpdateError("signature verification failed")).toBe(
+      "signature",
+    );
+    expect(classifyUpdateError("minisign: invalid pubkey")).toBe("signature");
+  });
+
+  it("classifies plugin_missing soft-fails", () => {
+    expect(classifyUpdateError("plugin updater not found")).toBe(
+      "plugin_missing",
+    );
+    expect(classifyUpdateError('command "check" not found')).toBe(
+      "plugin_missing",
+    );
+  });
+
+  it("classifies not_ready and host_only", () => {
+    expect(classifyUpdateError("Update is not ready to install yet")).toBe(
+      "not_ready",
+    );
+    expect(
+      classifyUpdateError("Updates are only available in the desktop app"),
+    ).toBe("host_only");
+  });
+
+  it("falls back to other for unknown / empty", () => {
+    expect(classifyUpdateError("")).toBe("other");
+    expect(classifyUpdateError(null)).toBe("other");
+    expect(classifyUpdateError("weird boom")).toBe("other");
+  });
+
+  it("maps kinds to body keys", () => {
+    expect(updateErrorBodyKey("network")).toBe(
+      "settings.autoUpdateError.network",
+    );
+    expect(updateErrorBodyKey("signature")).toBe(
+      "settings.autoUpdateError.signature",
+    );
+    expect(updateErrorBodyKey("plugin_missing")).toBe(
+      "settings.autoUpdateError.pluginMissing",
+    );
+  });
+});
+
+describe("resolveManualUpdateUrls", () => {
+  it("prefers status URLs and never invents download", () => {
+    const r = resolveManualUpdateUrls(
+      {
+        state: "manual-required",
+        version: "1.0.0",
+        releaseUrl: "https://github.com/RongleCat/grok-app/releases/tag/v1.0.0",
+        downloadUrl: "https://github.com/x/y/releases/download/v1/a.dmg",
+        assetNames: ["a.dmg", ""],
+      },
+      "https://github.com/RongleCat/grok-app/releases/latest",
+    );
+    expect(r.releaseUrl).toContain("tag/v1.0.0");
+    expect(r.downloadUrl).toContain("a.dmg");
+    expect(r.assetNames).toEqual(["a.dmg"]);
+  });
+
+  it("falls back to provided releases URL when status has none", () => {
+    const r = resolveManualUpdateUrls(
+      { state: "manual-required", version: "1.0.0" },
+      "https://github.com/RongleCat/grok-app/releases/latest",
+    );
+    expect(r.releaseUrl).toBe(
+      "https://github.com/RongleCat/grok-app/releases/latest",
+    );
+    expect(r.downloadUrl).toBeNull();
+  });
+});
+
+describe("channelFromHostString / prefer host", () => {
+  it("parses known host channel strings only", () => {
+    expect(channelFromHostString("silent")).toBe("auto");
+    expect(channelFromHostString("github_manual")).toBe("manual_github");
+    expect(channelFromHostString("unsupported")).toBe("unsupported");
+    expect(channelFromHostString("nightly")).toBeNull();
+    expect(channelFromHostString("")).toBeNull();
+  });
+
+  it("prefer host silent, but live manual-required wins", () => {
+    expect(
+      resolveUpdateChannelHonestyPreferHost({
+        hostChannel: "silent",
+        pluginEnabled: true,
+        autoUpdateSupported: true,
+        isDesktopHost: true,
+      }),
+    ).toBe("auto");
+
+    expect(
+      resolveUpdateChannelHonestyPreferHost({
+        hostChannel: "silent",
+        pluginEnabled: true,
+        autoUpdateSupported: false,
+        isDesktopHost: true,
+        status: {
+          state: "manual-required",
+          version: "0.2.4",
+          releaseUrl: "https://example.com",
+        },
+      }),
+    ).toBe("unsupported");
+  });
+});
+
+describe("updateStatusToneClass", () => {
+  it("maps severity to CSS modifiers", () => {
+    expect(updateStatusToneClass("error")).toBe("is-error");
+    expect(updateStatusToneClass("warn")).toBe("is-available");
+    expect(updateStatusToneClass("info")).toBe("is-available");
+    expect(updateStatusToneClass("success")).toBe("");
+    expect(updateStatusToneClass("none")).toBe("");
+  });
+});
+
+describe("status machine exhaustiveness smoke", () => {
+  const states: AppUpdateStatusLike[] = [
+    { state: "idle" },
+    { state: "checking" },
+    { state: "up-to-date" },
+    { state: "up-to-date", version: "1.0.0" },
+    { state: "available", version: "1.0.1" },
+    { state: "downloading", version: "1.0.1" },
+    { state: "installing", version: "1.0.1" },
+    { state: "ready", version: "1.0.1" },
+    {
+      state: "manual-required",
+      version: "1.0.1",
+      releaseUrl: "https://example.com",
+    },
+    { state: "error", message: "boom" },
+  ];
+
+  it("maps every known state without throwing", () => {
+    for (const s of states) {
+      const copy = mapUpdateStatusCopy(s);
+      expect(copy.severity).toBeTruthy();
+      if (s.state !== "error" && s.state !== "idle" && s.state !== "checking") {
+        // version fields only when provided
+        if (s.version) expect(copy.version).toBe(s.version);
+      }
+    }
+  });
+});

--- a/src/lib/appUpdateHonesty.ts
+++ b/src/lib/appUpdateHonesty.ts
@@ -1,0 +1,545 @@
+/**
+ * App auto-update path honesty (Top30 #26).
+ *
+ * Pure helpers that map the signed in-app updater vs GitHub manual download
+ * fallback into product status copy — no invented versions, no I/O.
+ *
+ * Channel truth:
+ * - **auto** — signed release + plugin + platform supports silent install
+ * - **manual_github** — unsigned / local / plugin off → open release page
+ * - **unsupported** — plugin present but this install type cannot auto-update
+ *   (e.g. Linux .deb/.rpm; Linux AppImage is supported)
+ * - **host_only** — not running in the desktop app host
+ *
+ * P0: agents / voice / IM / mirror stop only after successful `install()`
+ * prepare — never claim they stop earlier.
+ */
+
+/** Mirrors `UpdateStatus` from `useUpdater` without importing the hook. */
+export type AppUpdateStatusState =
+  | "idle"
+  | "checking"
+  | "up-to-date"
+  | "available"
+  | "downloading"
+  | "installing"
+  | "ready"
+  | "error"
+  | "manual-required";
+
+export type AppUpdateStatusLike = {
+  state: AppUpdateStatusState;
+  /** Only when known from check/download — never invent. */
+  version?: string;
+  message?: string;
+  releaseUrl?: string;
+  downloadUrl?: string | null;
+  assetNames?: string[];
+};
+
+/** Product update path for About / Settings banners. */
+export type UpdateChannelHonesty =
+  | "auto"
+  | "manual_github"
+  | "unsupported"
+  | "host_only";
+
+export type UpdateHonestySeverity =
+  | "none"
+  | "info"
+  | "success"
+  | "warn"
+  | "error";
+
+/** Soft-fail classes for update errors (string match on host messages). */
+export type UpdateErrorKind =
+  | "network"
+  | "signature"
+  | "plugin_missing"
+  | "not_ready"
+  | "host_only"
+  | "other";
+
+/** i18n title keys for status banners (en/zh/zh-TW under same id). */
+export type UpdateStatusTitleKey =
+  | "settings.autoUpdateChecking"
+  | "settings.autoUpdateUpToDate"
+  | "settings.checkUpdateLatest"
+  | "settings.autoUpdateAvailable"
+  | "settings.autoUpdateDownloading"
+  | "settings.autoUpdateReady"
+  | "settings.autoUpdateInstalling"
+  | "settings.autoUpdateManualRequired"
+  | "settings.autoUpdateError"
+  | "settings.autoUpdateIdle";
+
+/** Optional body / note under the title. */
+export type UpdateStatusBodyKey =
+  | "settings.autoUpdateBody.checking"
+  | "settings.autoUpdateBody.downloading"
+  | "settings.autoUpdateBody.installing"
+  | "settings.autoUpdateBody.ready"
+  | "settings.autoUpdateBody.manual"
+  | "settings.autoUpdateBody.agentsNote"
+  | "settings.autoUpdateError.network"
+  | "settings.autoUpdateError.signature"
+  | "settings.autoUpdateError.pluginMissing"
+  | "settings.autoUpdateError.notReady"
+  | "settings.autoUpdateError.hostOnly"
+  | "settings.autoUpdateError.other";
+
+export type UpdateChannelLabelKey =
+  | "settings.autoUpdateChannelSilent"
+  | "settings.autoUpdateChannelManual"
+  | "settings.autoUpdateChannelUnsupported"
+  | "settings.autoUpdateChannelHostOnly";
+
+export type UpdateStatusCopy = {
+  titleKey: UpdateStatusTitleKey | null;
+  bodyKey: UpdateStatusBodyKey | null;
+  severity: UpdateHonestySeverity;
+  /**
+   * Version string from status when present — never invented.
+   * Callers interpolate `{version}` only when this is set.
+   */
+  version: string | null;
+  /** For error state: classified soft-fail kind. */
+  errorKind: UpdateErrorKind | null;
+  /** Raw error message when state is error (for fallback interpolate). */
+  errorMessage: string | null;
+};
+
+export type ResolveUpdateChannelInput = {
+  pluginEnabled: boolean;
+  autoUpdateSupported: boolean;
+  /** When false / omitted for non-desktop, channel is host_only. */
+  isDesktopHost?: boolean;
+  /**
+   * Optional live status. `manual-required` forces manual_github / unsupported
+   * honesty even if channel flags look auto-capable.
+   */
+  status?: AppUpdateStatusLike | null;
+};
+
+/**
+ * Resolve product update channel honesty from host capability flags.
+ *
+ * Priority: not desktop → host_only; plugin off → manual_github;
+ * plugin on + not platform-supported → unsupported; else auto.
+ * Live `manual-required` never claims auto.
+ */
+export function resolveUpdateChannelHonesty(
+  input: ResolveUpdateChannelInput,
+): UpdateChannelHonesty {
+  if (input.isDesktopHost === false) {
+    return "host_only";
+  }
+
+  const state = input.status?.state;
+  if (state === "manual-required") {
+    // Plugin may still be on (e.g. Linux non-AppImage) — prefer unsupported
+    // when the platform gate failed; otherwise GitHub manual.
+    if (input.pluginEnabled && !input.autoUpdateSupported) {
+      return "unsupported";
+    }
+    return "manual_github";
+  }
+
+  if (!input.pluginEnabled) {
+    return "manual_github";
+  }
+  if (!input.autoUpdateSupported) {
+    return "unsupported";
+  }
+  return "auto";
+}
+
+/** Channel label i18n key for the About hint line. */
+export function updateChannelLabelKey(
+  channel: UpdateChannelHonesty,
+): UpdateChannelLabelKey {
+  switch (channel) {
+    case "auto":
+      return "settings.autoUpdateChannelSilent";
+    case "manual_github":
+      return "settings.autoUpdateChannelManual";
+    case "unsupported":
+      return "settings.autoUpdateChannelUnsupported";
+    case "host_only":
+      return "settings.autoUpdateChannelHostOnly";
+  }
+}
+
+/**
+ * Map a status machine state to title/body keys + severity.
+ * Never invents a version — only echoes `status.version` when present.
+ */
+export function mapUpdateStatusCopy(
+  status: AppUpdateStatusLike,
+): UpdateStatusCopy {
+  const version =
+    typeof status.version === "string" && status.version.trim()
+      ? status.version.trim()
+      : null;
+
+  switch (status.state) {
+    case "idle":
+      return {
+        titleKey: "settings.autoUpdateIdle",
+        bodyKey: null,
+        severity: "none",
+        version: null,
+        errorKind: null,
+        errorMessage: null,
+      };
+    case "checking":
+      return {
+        titleKey: "settings.autoUpdateChecking",
+        bodyKey: "settings.autoUpdateBody.checking",
+        severity: "info",
+        version: null,
+        errorKind: null,
+        errorMessage: null,
+      };
+    case "up-to-date":
+      return {
+        titleKey: version
+          ? "settings.checkUpdateLatest"
+          : "settings.autoUpdateUpToDate",
+        bodyKey: null,
+        severity: "success",
+        version,
+        errorKind: null,
+        errorMessage: null,
+      };
+    case "available":
+      return {
+        titleKey: "settings.autoUpdateAvailable",
+        bodyKey: "settings.autoUpdateBody.agentsNote",
+        severity: "info",
+        version,
+        errorKind: null,
+        errorMessage: null,
+      };
+    case "downloading":
+      return {
+        titleKey: "settings.autoUpdateDownloading",
+        bodyKey: "settings.autoUpdateBody.downloading",
+        severity: "info",
+        version,
+        errorKind: null,
+        errorMessage: null,
+      };
+    case "ready":
+      return {
+        titleKey: "settings.autoUpdateReady",
+        bodyKey: "settings.autoUpdateBody.ready",
+        severity: "warn",
+        version,
+        errorKind: null,
+        errorMessage: null,
+      };
+    case "installing":
+      return {
+        titleKey: "settings.autoUpdateInstalling",
+        bodyKey: "settings.autoUpdateBody.installing",
+        severity: "info",
+        version,
+        errorKind: null,
+        errorMessage: null,
+      };
+    case "manual-required":
+      return {
+        titleKey: "settings.autoUpdateManualRequired",
+        bodyKey: "settings.autoUpdateBody.manual",
+        severity: "warn",
+        version,
+        errorKind: null,
+        errorMessage: null,
+      };
+    case "error": {
+      const errorMessage =
+        typeof status.message === "string" && status.message.trim()
+          ? status.message.trim()
+          : null;
+      const errorKind = classifyUpdateError(errorMessage);
+      return {
+        titleKey: "settings.autoUpdateError",
+        bodyKey: updateErrorBodyKey(errorKind),
+        severity: "error",
+        version: null,
+        errorKind,
+        errorMessage,
+      };
+    }
+    default:
+      return {
+        titleKey: null,
+        bodyKey: null,
+        severity: "none",
+        version: null,
+        errorKind: null,
+        errorMessage: null,
+      };
+  }
+}
+
+/**
+ * One-line progress label for the status strip.
+ * Returns null when idle / nothing to show; never invents versions.
+ */
+export function formatUpdateProgressLine(
+  status: AppUpdateStatusLike,
+): {
+  titleKey: UpdateStatusTitleKey;
+  version: string | null;
+  severity: UpdateHonestySeverity;
+} | null {
+  const copy = mapUpdateStatusCopy(status);
+  if (!copy.titleKey || status.state === "idle") return null;
+  if (status.state === "error") {
+    return {
+      titleKey: copy.titleKey,
+      version: null,
+      severity: copy.severity,
+    };
+  }
+  return {
+    titleKey: copy.titleKey,
+    version: copy.version,
+    severity: copy.severity,
+  };
+}
+
+/**
+ * True while download or install is in flight (busy progress chrome).
+ * `available` is not install progress (auto-download may start next).
+ */
+export function shouldShowInstallProgress(
+  status: AppUpdateStatusLike | { state: string } | null | undefined,
+): boolean {
+  const state = status?.state;
+  return state === "downloading" || state === "installing";
+}
+
+/** Whether check / install buttons should be disabled (in-flight). */
+export function isUpdateActionBusy(
+  status: AppUpdateStatusLike | { state: string } | null | undefined,
+): boolean {
+  const state = status?.state;
+  return (
+    state === "checking" ||
+    state === "downloading" ||
+    state === "installing"
+  );
+}
+
+/** Whether the Install-and-restart CTA should show (download finished). */
+export function shouldShowInstallButton(
+  status: AppUpdateStatusLike | { state: string } | null | undefined,
+): boolean {
+  return status?.state === "ready";
+}
+
+/** Manual GitHub path CTAs (open release / download asset). */
+export function shouldShowManualDownloadCtas(
+  status: AppUpdateStatusLike | { state: string } | null | undefined,
+): boolean {
+  return status?.state === "manual-required";
+}
+
+/**
+ * Classify soft-fail update errors from host / plugin message text.
+ * Prefer structured paths in the hook when available; this is last-resort.
+ */
+export function classifyUpdateError(
+  message: string | null | undefined,
+): UpdateErrorKind {
+  const m = String(message ?? "")
+    .trim()
+    .toLowerCase();
+  if (!m) return "other";
+
+  if (
+    m.includes("only available in the desktop") ||
+    m.includes("desktop app") ||
+    m.includes("not a desktop")
+  ) {
+    return "host_only";
+  }
+
+  if (
+    m.includes("plugin updater not found") ||
+    m.includes("plugin not found") ||
+    m.includes("command updater") ||
+    m.includes('command "check" not found') ||
+    m.includes("not initialized") ||
+    m.includes("updater unavailable")
+  ) {
+    return "plugin_missing";
+  }
+
+  if (
+    m.includes("signature") ||
+    m.includes("minisign") ||
+    m.includes("invalid pubkey") ||
+    m.includes("public key") ||
+    m.includes("verification failed") ||
+    m.includes("checksum")
+  ) {
+    return "signature";
+  }
+
+  if (
+    m.includes("not ready to install") ||
+    m.includes("update is not ready")
+  ) {
+    return "not_ready";
+  }
+
+  if (
+    m.includes("network") ||
+    m.includes("timeout") ||
+    m.includes("timed out") ||
+    m.includes("connection") ||
+    m.includes("connect") ||
+    m.includes("dns") ||
+    m.includes("econn") ||
+    m.includes("enotfound") ||
+    m.includes("fetch failed") ||
+    m.includes("failed to fetch") ||
+    m.includes("http 4") ||
+    m.includes("http 5") ||
+    m.includes("status code") ||
+    m.includes("offline")
+  ) {
+    return "network";
+  }
+
+  return "other";
+}
+
+/** Body key for a classified update error. */
+export function updateErrorBodyKey(
+  kind: UpdateErrorKind,
+): UpdateStatusBodyKey {
+  switch (kind) {
+    case "network":
+      return "settings.autoUpdateError.network";
+    case "signature":
+      return "settings.autoUpdateError.signature";
+    case "plugin_missing":
+      return "settings.autoUpdateError.pluginMissing";
+    case "not_ready":
+      return "settings.autoUpdateError.notReady";
+    case "host_only":
+      return "settings.autoUpdateError.hostOnly";
+    case "other":
+      return "settings.autoUpdateError.other";
+  }
+}
+
+/**
+ * Resolve release / asset URLs for manual CTAs without inventing versions.
+ * Prefers status fields; falls back to a known GitHub releases URL only.
+ */
+export function resolveManualUpdateUrls(
+  status: AppUpdateStatusLike,
+  fallbackReleaseUrl: string,
+): {
+  releaseUrl: string;
+  downloadUrl: string | null;
+  assetNames: string[];
+} {
+  const releaseUrl =
+    typeof status.releaseUrl === "string" && status.releaseUrl.trim()
+      ? status.releaseUrl.trim()
+      : fallbackReleaseUrl;
+  const downloadUrl =
+    typeof status.downloadUrl === "string" && status.downloadUrl.trim()
+      ? status.downloadUrl.trim()
+      : null;
+  const assetNames = Array.isArray(status.assetNames)
+    ? status.assetNames.filter(
+        (n): n is string => typeof n === "string" && n.trim().length > 0,
+      )
+    : [];
+  return { releaseUrl, downloadUrl, assetNames };
+}
+
+/**
+ * Map host `updater_status.channel` string to honesty without inventing.
+ * Unknown → null (caller keeps capability-based resolve).
+ */
+export function channelFromHostString(
+  raw: string | null | undefined,
+): UpdateChannelHonesty | null {
+  const t = String(raw ?? "")
+    .trim()
+    .toLowerCase();
+  if (t === "silent" || t === "auto") return "auto";
+  if (t === "github_manual" || t === "manual" || t === "manual_github") {
+    return "manual_github";
+  }
+  if (t === "unsupported") return "unsupported";
+  if (t === "host_only" || t === "web") return "host_only";
+  return null;
+}
+
+/**
+ * Prefer host channel when known; else capability resolve.
+ * Live `manual-required` still forces non-auto honesty.
+ */
+export function resolveUpdateChannelHonestyPreferHost(input: {
+  hostChannel?: string | null;
+  pluginEnabled: boolean;
+  autoUpdateSupported: boolean;
+  isDesktopHost?: boolean;
+  status?: AppUpdateStatusLike | null;
+}): UpdateChannelHonesty {
+  const fromStatus = resolveUpdateChannelHonesty({
+    pluginEnabled: input.pluginEnabled,
+    autoUpdateSupported: input.autoUpdateSupported,
+    isDesktopHost: input.isDesktopHost,
+    status: input.status,
+  });
+
+  // Live manual path wins over a stale "silent" host report.
+  if (
+    input.status?.state === "manual-required" ||
+    fromStatus === "host_only"
+  ) {
+    return fromStatus;
+  }
+
+  const fromHost = channelFromHostString(input.hostChannel);
+  if (fromHost) return fromHost;
+  return fromStatus;
+}
+
+/** CSS modifier for About status strip (`is-available` / `is-error` / …). */
+export function updateStatusToneClass(
+  severity: UpdateHonestySeverity,
+): string {
+  switch (severity) {
+    case "error":
+      return "is-error";
+    case "warn":
+      return "is-available";
+    case "info":
+      return "is-available";
+    case "success":
+      return "";
+    case "none":
+    default:
+      return "";
+  }
+}
+
+/**
+ * Whether the auto path may download/install (for honest notes).
+ * Manual / unsupported / host-only never claim silent install.
+ */
+export function isAutoUpdatePath(channel: UpdateChannelHonesty): boolean {
+  return channel === "auto";
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7232,9 +7232,27 @@ button.settings-wallpaper__preview:hover:not(:disabled) {
   font-weight: 500;
 }
 
+.settings-about-update__status.is-error {
+  color: var(--danger, #d33);
+  font-weight: 500;
+}
+
+.settings-about-update__body {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  line-height: 1.45;
+}
+
 .settings-about-update__err {
   font-size: 12.5px;
   color: var(--danger, #d33);
+  line-height: 1.45;
+}
+
+.settings-about-update__err-hint {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
   line-height: 1.45;
 }
 


### PR DESCRIPTION
## Summary

Productizes **App auto-update path honesty** (Top30 #26) for Settings → About:

- Pure `src/lib/appUpdateHonesty.ts` maps updater states → i18n title/body + severity
- `resolveUpdateChannelHonesty` → `auto` | `manual_github` | `unsupported` | `host_only`
- Progress copy for checking / downloading / installing; **agents / voice / Remote IM / mirror stop only after successful install prepare** (already P0 in `useUpdater`)
- Soft-fail error classes: network · signature · plugin_missing · not_ready · host_only · other
- Manual path: clear **Open release page** + **Download installer** when asset URL is known
- Never invents versions

## Test plan

- [x] `pnpm test -- src/lib/appUpdateHonesty.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Local/unsigned build: About shows GitHub download channel; Check opens manual CTAs
- [ ] Signed release: silent channel, progress notes, install still after ready only
- [ ] Install failure path still leaves agents running (unchanged P0)