### PR TITLE
feat(setup): CLI checksum trust grades and risk chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **CLI supply-chain trust grades**: Setup + Settings → Runtime show explicit checksum risk chips (`verified` · `missing_sidecar` · `mismatch` · `unverified_allowed` · `unknown`) via pure `cliTrustSupplyChain` helpers. Missing sidecar is warn-grade honesty (official mirrors often omit sidecars); mismatch stays fail-closed and is never forceable. Clearer allow-unverified description; Doctor adds a `cli_checksum` finding when last install recorded `checksumVerified`. en/zh/zh-TW + tests.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/docs/llm-wiki/setup.md
+++ b/docs/llm-wiki/setup.md
@@ -36,6 +36,8 @@ Each mirror is tried multiple times before failing over.
 
 **Checksum trust:** download is HTTPS-allowlisted; streamed SHA-256 is always computed. If the mirror publishes a sidecar, **mismatch aborts**. Official mirrors currently omit sidecars (same as `install.sh` / `install.ps1`), so **missing checksum is allowed by default** and stored as `checksum_verified: false`. Strict fail-closed: `GROK_CLI_REQUIRE_CHECKSUM=1` (override with Settings → Runtime “Allow unverified CLI install” or `GROK_CLI_ALLOW_UNVERIFIED=1`).
 
+**Trust grades (UI):** pure `src/lib/cliTrustSupplyChain.ts` maps install outcomes to grades `verified` · `missing_sidecar` · `mismatch` · `unverified_allowed` · `unknown` — never invents sidecar presence. Setup shows a risk chip on missing sidecar / mismatch (hard-fail honesty; no force on mismatch). Settings → Runtime shows a trust chip for the last App-managed install; Doctor adds a `cli_checksum` finding when `lastCliChecksumVerified` is known.
+
 ### Step 2 — Account (skippable)
 
 OAuth, official key, relay, import CLI / grok-go. No `window.prompt`.
@@ -70,7 +72,7 @@ Pure helpers: `src/lib/setupGatePro.ts` (+ tests).
 | Ready checklist | Never soft-ok CLI; auth row is soft when skipped |
 | Legacy migrate | Older `onboardingDone` / `setupSkipped` + CLI → write `setupWizardCompleted` once |
 
-Checksum: missing sidecar may offer **Install without checksum**; **mismatch never** offers unverified force.
+Checksum: missing sidecar may offer **Install without checksum**; **mismatch never** offers unverified force. Grades + chips: `cliTrustSupplyChain` (`resolveChecksumTrustGrade` / `planInstallWithoutChecksum`).
 
 ## CLI probe (mac + Windows)
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1973,6 +1973,7 @@ pub async fn doctor_report() -> Result<serde_json::Value, String> {
             "path": probe.path,
             "version": probe.version,
             "source": probe.source,
+            "checksumVerified": settings.last_cli_checksum_verified,
         },
         "auth": {
             "cliAuthJson": auth_ok,
@@ -1999,22 +2000,29 @@ pub async fn doctor_report() -> Result<serde_json::Value, String> {
         }
     });
 
-    let mut checks: Vec<DoctorCheck> = Vec::with_capacity(5);
+    let mut checks: Vec<DoctorCheck> = Vec::with_capacity(6);
 
     // 1) CLI
+    let checksum_verified = settings.last_cli_checksum_verified;
     if probe.found {
         let ver = probe.version.as_deref().unwrap_or("unknown");
         let path = probe.path.as_deref().unwrap_or("—");
+        let checksum_note = match checksum_verified {
+            Some(true) => " · last install checksum verified",
+            Some(false) => " · last install missing checksum sidecar",
+            None => "",
+        };
         checks.push(doctor_check(
             "cli",
             "ok",
             "Grok Build CLI",
-            format!("Found {ver} ({}) at {path}", probe.source),
+            format!("Found {ver} ({}) at {path}{checksum_note}", probe.source),
             serde_json::json!({
                 "found": true,
                 "path": probe.path,
                 "version": probe.version,
                 "source": probe.source,
+                "checksumVerified": checksum_verified,
             }),
         ));
     } else {
@@ -2030,8 +2038,34 @@ pub async fn doctor_report() -> Result<serde_json::Value, String> {
                 "version": probe.version,
                 "source": probe.source,
                 "candidatesTried": probe.candidates_tried,
+                "checksumVerified": checksum_verified,
             }),
         ));
+    }
+
+    // 1b) CLI install checksum trust (only when App recorded a last install).
+    // Never invents verified; mismatch never reaches install ok.
+    if let Some(verified) = checksum_verified {
+        if verified {
+            checks.push(doctor_check(
+                "cli_checksum",
+                "ok",
+                "CLI install checksum",
+                "Last App-managed CLI install matched a published SHA-256 sidecar."
+                    .into(),
+                serde_json::json!({ "checksumVerified": true }),
+            ));
+        } else {
+            checks.push(doctor_check(
+                "cli_checksum",
+                "warn",
+                "CLI install checksum",
+                "Last App-managed CLI install had no published SHA-256 sidecar \
+                 (HTTPS allowlist + binary probe only; not cryptographically verified)."
+                    .into(),
+                serde_json::json!({ "checksumVerified": false }),
+            ));
+        }
     }
 
     // 2) Auth — warn if no CLI auth, official key, or relay

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -43,6 +43,11 @@ import {
   filterCliSessions,
 } from "@/lib/cliSessionsFilter";
 import {
+  cliTrustChipClass,
+  gradeFromLastInstall,
+  resolveCliTrustBanner,
+} from "@/lib/cliTrustSupplyChain";
+import {
   listArchiveAgeOptionPreviews,
   hasAnyArchiveAgeMatches,
   type ArchiveAgeSessionLike,
@@ -6581,13 +6586,32 @@ export function SettingsPage({
                       {cliInfo.cliAuthPresent
                         ? ` · ${t("account.cliAuthOk")}`
                         : ` · ${t("account.cliAuthMissing")}`}
-                      {lastCliChecksumVerified === true
-                        ? ` · ${t("settings.cliChecksumVerified")}`
-                        : lastCliChecksumVerified === false
-                          ? ` · ${t("settings.cliChecksumUnverified")}`
-                          : ""}
                     </div>
                   )}
+                  {(() => {
+                    const grade = gradeFromLastInstall({
+                      lastCliChecksumVerified,
+                      allowUnverified: allowUnverifiedCliInstall,
+                    });
+                    if (grade === "unknown") return null;
+                    const banner = resolveCliTrustBanner(grade);
+                    return (
+                      <div
+                        className="settings-cli-trust"
+                        data-testid="settings-cli-trust-chip"
+                        data-trust-grade={grade}
+                      >
+                        <span className={cliTrustChipClass(banner.severity)}>
+                          {t(banner.titleKey as MessageKey)}
+                        </span>
+                        {banner.hintKey ? (
+                          <span className="settings-row__hint">
+                            {t(banner.hintKey as MessageKey)}
+                          </span>
+                        ) : null}
+                      </div>
+                    );
+                  })()}
                 </div>
                 {onAllowUnverifiedCliInstall ? (
                   <div

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -25,6 +25,13 @@ import {
   type SetupGateErrorView,
   type SetupWizardStep,
 } from "@/lib/setupGatePro";
+import {
+  cliTrustChipClass,
+  gradeFromSetupErrorKind,
+  resolveChecksumTrustGrade,
+  resolveCliTrustBanner,
+  type ChecksumTrustGrade,
+} from "@/lib/cliTrustSupplyChain";
 
 type Tr = ReturnType<typeof createT>;
 
@@ -64,6 +71,8 @@ export function SetupWizard({
   const [installing, setInstalling] = useState(false);
   const [progress, setProgress] = useState<api.CliInstallProgress | null>(null);
   const [errorView, setErrorView] = useState<SetupGateErrorView | null>(null);
+  /** Trust grade from last install attempt or classified checksum error. */
+  const [trustGrade, setTrustGrade] = useState<ChecksumTrustGrade | null>(null);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [installCmds, setInstallCmds] = useState<api.CliInstallCommands | null>(
     null,
@@ -88,6 +97,8 @@ export function SetupWizard({
       return view;
     }
     setErrorView(view);
+    const g = gradeFromSetupErrorKind(view.kind);
+    if (g) setTrustGrade(g);
     return view;
   }, []);
 
@@ -185,6 +196,16 @@ export function SetupWizard({
           reportError(res.message || tr("setup.error"));
           return;
         }
+        // Honest grade from Host — never invent verified when flag is false/absent.
+        setTrustGrade(
+          resolveChecksumTrustGrade({
+            verifiedFlag:
+              typeof res.checksumVerified === "boolean"
+                ? res.checksumVerified
+                : null,
+            allowUnverified: opts?.allowUnverified === true,
+          }),
+        );
         const next = await recheck(res.path);
         if (next?.found && canAdvancePastRuntime(next.found)) {
           setStep("account");
@@ -207,6 +228,15 @@ export function SetupWizard({
   );
 
   const checksumMissing = !!errorView?.offerUnverifiedInstall;
+  const trustBanner = useMemo(
+    () => (trustGrade ? resolveCliTrustBanner(trustGrade) : null),
+    [trustGrade],
+  );
+  /** Risk chip: missing sidecar (warn) or mismatch (hard fail honesty). */
+  const showTrustRiskChip =
+    trustGrade === "missing_sidecar" ||
+    trustGrade === "mismatch" ||
+    trustGrade === "unverified_allowed";
 
   const pickBinary = useCallback(async () => {
     clearError();
@@ -497,6 +527,33 @@ export function SetupWizard({
                   <p className="setup-mono">
                     {tr("setup.cli.path", { path: cli.path })}
                   </p>
+                )}
+                {showTrustRiskChip && trustBanner && (
+                  <div
+                    className="setup-trust-chip-row"
+                    data-testid="setup-cli-trust-chip"
+                    data-trust-grade={trustGrade ?? undefined}
+                  >
+                    <span
+                      className={cliTrustChipClass(trustBanner.severity)}
+                      title={
+                        trustBanner.hintKey
+                          ? tr(trustBanner.hintKey as MessageKey)
+                          : undefined
+                      }
+                    >
+                      {tr(trustBanner.titleKey as MessageKey)}
+                    </span>
+                    {trustGrade === "mismatch" ? (
+                      <span className="setup-trust-chip-row__hint">
+                        {tr("cliTrust.hint.mismatch" as MessageKey)}
+                      </span>
+                    ) : trustBanner.hintKey ? (
+                      <span className="setup-trust-chip-row__hint">
+                        {tr(trustBanner.hintKey as MessageKey)}
+                      </span>
+                    ) : null}
+                  </div>
                 )}
               </div>
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1948,9 +1948,23 @@ const en = {
   "settings.codebaseSearch.clear": "Clear",
   "settings.allowUnverifiedCli": "Allow unverified CLI install",
   "settings.allowUnverifiedCliDesc":
-    "Official mirrors often omit SHA-256 sidecars; missing checksums are allowed by default (HTTPS allowlist + binary probe). Turn this on to install even when GROK_CLI_REQUIRE_CHECKSUM=1. A mismatched checksum always fails.",
+    "Official mirrors often omit SHA-256 sidecars — missing checksum is a warn-grade risk (HTTPS allowlist + binary probe), allowed by default. Turn this on only to override GROK_CLI_REQUIRE_CHECKSUM=1. A mismatched published checksum always fails closed and is never forceable.",
   "settings.cliChecksumVerified": "last install checksum OK",
   "settings.cliChecksumUnverified": "last install unverified",
+  // CLI supply-chain trust grades (Setup risk chip + Settings Runtime)
+  "cliTrust.grade.verified": "Checksum verified",
+  "cliTrust.grade.missingSidecar": "No checksum sidecar",
+  "cliTrust.grade.mismatch": "Checksum mismatch",
+  "cliTrust.grade.unverifiedAllowed": "Unverified install allowed",
+  "cliTrust.grade.unknown": "Checksum status unknown",
+  "cliTrust.hint.missingSidecar":
+    "Official mirrors currently omit published SHA-256 sidecars. Install uses HTTPS allowlist + binary probe; not cryptographically verified.",
+  "cliTrust.hint.mismatch":
+    "Published checksum did not match the download. Install is refused — do not force unverified on mismatch.",
+  "cliTrust.hint.unverifiedAllowed":
+    "Install proceeded without a published sidecar (escape hatch or default missing-sidecar policy).",
+  "cliTrust.hint.unknown":
+    "No App-managed install checksum record yet. Manual or external installs are not graded.",
   "settings.cliPath": "CLI path",
   "settings.cliPathDesc": "Path to the Grok Build CLI binary",
   "settings.cliNotFound": "(not found)",
@@ -7982,9 +7996,22 @@ const zh: Record<MessageKey, string> = {
   "settings.codebaseSearch.clear": "清除",
   "settings.allowUnverifiedCli": "允许未校验的 CLI 安装",
   "settings.allowUnverifiedCliDesc":
-    "官方镜像通常不发布 SHA-256 校验文件；缺少校验时默认仍可安装（HTTPS 白名单 + 二进制探测）。开启此项可在设置了 GROK_CLI_REQUIRE_CHECKSUM=1 时仍允许安装。校验和不一致始终拒绝。",
+    "官方镜像通常不发布 SHA-256 校验文件——缺少校验为警告级风险（HTTPS 白名单 + 二进制探测），默认仍可安装。仅在设置了 GROK_CLI_REQUIRE_CHECKSUM=1 时需要开启此项以继续安装。已发布校验和不匹配时始终拒绝，且不可强制跳过。",
   "settings.cliChecksumVerified": "上次安装校验通过",
   "settings.cliChecksumUnverified": "上次安装未校验",
+  "cliTrust.grade.verified": "校验已通过",
+  "cliTrust.grade.missingSidecar": "无校验文件",
+  "cliTrust.grade.mismatch": "校验和不匹配",
+  "cliTrust.grade.unverifiedAllowed": "已允许未校验安装",
+  "cliTrust.grade.unknown": "校验状态未知",
+  "cliTrust.hint.missingSidecar":
+    "官方镜像当前未发布 SHA-256 校验文件。安装依赖 HTTPS 白名单 + 二进制探测，未经密码学校验。",
+  "cliTrust.hint.mismatch":
+    "已发布校验和与下载内容不一致，安装已拒绝——校验失败时不可强制跳过。",
+  "cliTrust.hint.unverifiedAllowed":
+    "在无已发布校验文件的情况下完成安装（逃生开关或默认「缺校验可装」策略）。",
+  "cliTrust.hint.unknown":
+    "尚无 App 托管安装的校验记录。手动或外部安装不评级。",
   "settings.cliPath": "CLI 路径",
   "settings.cliPathDesc": "Grok Build CLI 可执行文件路径",
   "settings.cliNotFound": "（未找到）",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1837,9 +1837,22 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.codebaseSearch.clear": "清除",
   "settings.allowUnverifiedCli": "允許未校驗的 CLI 安裝",
   "settings.allowUnverifiedCliDesc":
-    "官方鏡像通常不發佈 SHA-256 校驗檔；缺少校驗時預設仍可安裝（HTTPS 白名單 + 二進位探測）。開啟此項可在設定了 GROK_CLI_REQUIRE_CHECKSUM=1 時仍允許安裝。校驗和不一致一律拒絕。",
+    "官方鏡像通常不發佈 SHA-256 校驗檔——缺少校驗為警告級風險（HTTPS 白名單 + 二進位探測），預設仍可安裝。僅在設定了 GROK_CLI_REQUIRE_CHECKSUM=1 時需要開啟此項以繼續安裝。已發佈校驗和不匹配時一律拒絕，且不可強制略過。",
   "settings.cliChecksumVerified": "上次安裝校驗通過",
   "settings.cliChecksumUnverified": "上次安裝未校驗",
+  "cliTrust.grade.verified": "校驗已通過",
+  "cliTrust.grade.missingSidecar": "無校驗檔",
+  "cliTrust.grade.mismatch": "校驗和不匹配",
+  "cliTrust.grade.unverifiedAllowed": "已允許未校驗安裝",
+  "cliTrust.grade.unknown": "校驗狀態未知",
+  "cliTrust.hint.missingSidecar":
+    "官方鏡像目前未發佈 SHA-256 校驗檔。安裝依賴 HTTPS 白名單 + 二進位探測，未經密碼學校驗。",
+  "cliTrust.hint.mismatch":
+    "已發佈校驗和與下載內容不一致，安裝已拒絕——校驗失敗時不可強制略過。",
+  "cliTrust.hint.unverifiedAllowed":
+    "在無已發佈校驗檔的情況下完成安裝（逃生開關或預設「缺校驗可裝」策略）。",
+  "cliTrust.hint.unknown":
+    "尚無 App 託管安裝的校驗記錄。手動或外部安裝不評級。",
   "settings.cliPath": "CLI 路徑",
   "settings.cliPathDesc": "Grok Build CLI 可執行檔路徑",
   "settings.cliNotFound": "（未找到）",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -402,6 +402,13 @@ export interface CliInstallResult {
   version: string | null;
   mirrorUsed: string | null;
   message: string;
+  /** Streamed SHA-256 when Host computed it. */
+  sha256?: string | null;
+  /**
+   * `true` = published sidecar matched; `false` = installed without sidecar
+   * (HTTPS allowlist + binary probe). Mismatch never returns ok.
+   */
+  checksumVerified?: boolean | null;
 }
 
 export interface CliInstallCommands {

--- a/src/lib/cliTrustSupplyChain.test.ts
+++ b/src/lib/cliTrustSupplyChain.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCliTrustDoctorFinding,
+  cliTrustChipClass,
+  formatCliTrustSummary,
+  gradeFromLastInstall,
+  gradeFromSetupErrorKind,
+  planInstallWithoutChecksum,
+  resolveChecksumTrustGrade,
+  resolveCliTrustBanner,
+  type ChecksumTrustGrade,
+} from "./cliTrustSupplyChain";
+
+describe("resolveChecksumTrustGrade", () => {
+  it("never invents sidecar — empty opts → unknown", () => {
+    expect(resolveChecksumTrustGrade({})).toBe("unknown");
+    expect(resolveChecksumTrustGrade({ hasSidecar: null, match: null })).toBe(
+      "unknown",
+    );
+  });
+
+  it("mismatch always wins (fail-closed)", () => {
+    expect(
+      resolveChecksumTrustGrade({
+        match: false,
+        hasSidecar: true,
+        allowUnverified: true,
+        verifiedFlag: true,
+      }),
+    ).toBe("mismatch");
+  });
+
+  it("verified when match or verifiedFlag true", () => {
+    expect(
+      resolveChecksumTrustGrade({ hasSidecar: true, match: true }),
+    ).toBe("verified");
+    expect(resolveChecksumTrustGrade({ verifiedFlag: true })).toBe("verified");
+  });
+
+  it("missing_sidecar when sidecar absent and no escape hatch", () => {
+    expect(
+      resolveChecksumTrustGrade({ hasSidecar: false, allowUnverified: false }),
+    ).toBe("missing_sidecar");
+    expect(
+      resolveChecksumTrustGrade({
+        verifiedFlag: false,
+        allowUnverified: false,
+      }),
+    ).toBe("missing_sidecar");
+  });
+
+  it("unverified_allowed when missing sidecar + allowUnverified", () => {
+    expect(
+      resolveChecksumTrustGrade({
+        hasSidecar: false,
+        allowUnverified: true,
+      }),
+    ).toBe("unverified_allowed");
+    expect(
+      resolveChecksumTrustGrade({
+        verifiedFlag: false,
+        allowUnverified: true,
+      }),
+    ).toBe("unverified_allowed");
+  });
+
+  it("hasSidecar true without match stays unknown (no invent verified)", () => {
+    expect(resolveChecksumTrustGrade({ hasSidecar: true })).toBe("unknown");
+  });
+});
+
+describe("resolveCliTrustBanner", () => {
+  const grades: ChecksumTrustGrade[] = [
+    "verified",
+    "missing_sidecar",
+    "mismatch",
+    "unverified_allowed",
+    "unknown",
+  ];
+
+  it("maps every grade to titleKey + severity warn|error|ok", () => {
+    for (const g of grades) {
+      const b = resolveCliTrustBanner(g);
+      expect(b.titleKey.startsWith("cliTrust.")).toBe(true);
+      expect(["ok", "warn", "error"]).toContain(b.severity);
+    }
+  });
+
+  it("verified is ok; mismatch is error; missing is warn", () => {
+    expect(resolveCliTrustBanner("verified").severity).toBe("ok");
+    expect(resolveCliTrustBanner("mismatch").severity).toBe("error");
+    expect(resolveCliTrustBanner("missing_sidecar").severity).toBe("warn");
+    expect(resolveCliTrustBanner("unverified_allowed").severity).toBe("warn");
+  });
+
+  it("mismatch hint stresses fail-closed", () => {
+    const b = resolveCliTrustBanner("mismatch");
+    expect(b.hintKey).toBe("cliTrust.hint.mismatch");
+    expect(b.titleKey).toBe("cliTrust.grade.mismatch");
+  });
+});
+
+describe("planInstallWithoutChecksum", () => {
+  it("allows missing sidecar by default", () => {
+    expect(
+      planInstallWithoutChecksum({
+        requireChecksum: false,
+        allowUnverified: false,
+      }),
+    ).toBe("allow");
+  });
+
+  it("refuses when requireChecksum without allowUnverified", () => {
+    expect(
+      planInstallWithoutChecksum({
+        requireChecksum: true,
+        allowUnverified: false,
+      }),
+    ).toBe("refuse_need_flag");
+  });
+
+  it("allows strict mode when allowUnverified is set", () => {
+    expect(
+      planInstallWithoutChecksum({
+        requireChecksum: true,
+        allowUnverified: true,
+      }),
+    ).toBe("allow");
+  });
+
+  it("mismatch always refuse_mismatch (never forceable)", () => {
+    expect(
+      planInstallWithoutChecksum({
+        requireChecksum: false,
+        allowUnverified: true,
+        match: false,
+      }),
+    ).toBe("refuse_mismatch");
+  });
+});
+
+describe("formatCliTrustSummary", () => {
+  it("includes grade and redacts mirror to host", () => {
+    const s = formatCliTrustSummary({
+      grade: "missing_sidecar",
+      version: "0.2.3",
+      mirror: "https://user:secret@storage.googleapis.com/grok-build/path",
+    });
+    expect(s).toContain("CLI trust: missing_sidecar");
+    expect(s).toContain("version 0.2.3");
+    expect(s).toContain("mirror storage.googleapis.com");
+    expect(s).not.toContain("secret");
+    expect(s).not.toContain("user:");
+  });
+
+  it("omits empty version / mirror", () => {
+    expect(formatCliTrustSummary({ grade: "verified" })).toBe(
+      "CLI trust: verified",
+    );
+  });
+});
+
+describe("cliTrustChipClass / grade helpers", () => {
+  it("chip classes use ext-badge tokens", () => {
+    expect(cliTrustChipClass("ok")).toContain("ext-badge--ok");
+    expect(cliTrustChipClass("warn")).toContain("ext-badge--warn");
+    expect(cliTrustChipClass("error")).toContain("ext-badge--fail");
+  });
+
+  it("gradeFromSetupErrorKind only for checksum kinds", () => {
+    expect(gradeFromSetupErrorKind("checksum_missing")).toBe("missing_sidecar");
+    expect(gradeFromSetupErrorKind("checksum_mismatch")).toBe("mismatch");
+    expect(gradeFromSetupErrorKind("network")).toBeNull();
+    expect(gradeFromSetupErrorKind(null)).toBeNull();
+  });
+
+  it("gradeFromLastInstall maps settings flag", () => {
+    expect(
+      gradeFromLastInstall({ lastCliChecksumVerified: true }),
+    ).toBe("verified");
+    expect(
+      gradeFromLastInstall({
+        lastCliChecksumVerified: false,
+        allowUnverified: false,
+      }),
+    ).toBe("missing_sidecar");
+    expect(
+      gradeFromLastInstall({
+        lastCliChecksumVerified: false,
+        allowUnverified: true,
+      }),
+    ).toBe("unverified_allowed");
+    expect(gradeFromLastInstall({})).toBe("unknown");
+  });
+});
+
+describe("buildCliTrustDoctorFinding", () => {
+  it("skips unknown; returns honest levels for known grades", () => {
+    expect(buildCliTrustDoctorFinding("unknown")).toBeNull();
+    const ok = buildCliTrustDoctorFinding("verified");
+    expect(ok?.level).toBe("ok");
+    expect(ok?.id).toBe("cli_checksum_trust");
+    const fail = buildCliTrustDoctorFinding("mismatch");
+    expect(fail?.level).toBe("fail");
+    const warn = buildCliTrustDoctorFinding("missing_sidecar");
+    expect(warn?.level).toBe("warn");
+    expect(warn?.summary).toContain("missing_sidecar");
+  });
+});

--- a/src/lib/cliTrustSupplyChain.ts
+++ b/src/lib/cliTrustSupplyChain.ts
@@ -1,0 +1,252 @@
+/**
+ * CLI supply-chain trust grades — pure helpers for Setup + Settings Runtime.
+ *
+ * Honesty (see docs/llm-wiki/setup.md):
+ * - Never invent published sidecar presence (`hasSidecar` only when explicit).
+ * - Mismatch is always fail-closed (no force-unverified path).
+ * - Missing sidecar is allowed by default; strict mode needs allow-unverified.
+ * - Grades map to i18n keys + severity chips only — no DOM / Tauri side effects.
+ */
+
+/** Explicit trust grade for last install / live install attempt. */
+export type ChecksumTrustGrade =
+  | "verified"
+  | "missing_sidecar"
+  | "mismatch"
+  | "unverified_allowed"
+  | "unknown";
+
+/** Banner / chip severity (maps to ext-badge ok|warn|fail). */
+export type CliTrustBannerSeverity = "ok" | "warn" | "error";
+
+/** i18n keys + severity for Setup risk chip / Settings trust chip. */
+export type CliTrustBanner = {
+  titleKey: string;
+  hintKey: string | null;
+  severity: CliTrustBannerSeverity;
+};
+
+/** Inputs for grade resolution. All optional — never invent sidecar presence. */
+export type ResolveChecksumTrustGradeOpts = {
+  /**
+   * Explicit: published sidecar was found for this artifact.
+   * `true` / `false` only when host reported; omit/null = unknown.
+   */
+  hasSidecar?: boolean | null;
+  /**
+   * Explicit: stream digest matched published hash.
+   * `false` → always `mismatch` (fail-closed).
+   */
+  match?: boolean | null;
+  /** `GROK_CLI_REQUIRE_CHECKSUM=1` (or equivalent strict policy). */
+  requireChecksum?: boolean | null;
+  /**
+   * Settings `allowUnverifiedCliInstall` or install-time escape hatch.
+   * Does **not** override mismatch.
+   */
+  allowUnverified?: boolean | null;
+  /**
+   * Host settings `lastCliChecksumVerified`:
+   * `true` = last App install matched sidecar;
+   * `false` = installed without sidecar verify;
+   * null/undefined = no App-managed install record.
+   */
+  verifiedFlag?: boolean | null;
+};
+
+/**
+ * Resolve an honest checksum trust grade.
+ * Never invents sidecar presence; mismatch always wins over allow-unverified.
+ */
+export function resolveChecksumTrustGrade(
+  opts: ResolveChecksumTrustGradeOpts,
+): ChecksumTrustGrade {
+  // Explicit mismatch — fail-closed, never soft-graded.
+  if (opts.match === false) return "mismatch";
+
+  // Explicit match or last install recorded as verified.
+  if (opts.match === true || opts.verifiedFlag === true) return "verified";
+
+  // Known missing sidecar (explicit false) or last install unverified.
+  const missingSidecar =
+    opts.hasSidecar === false || opts.verifiedFlag === false;
+
+  if (missingSidecar) {
+    // Escape hatch engaged (or would allow under strict require).
+    if (opts.allowUnverified === true) return "unverified_allowed";
+    return "missing_sidecar";
+  }
+
+  // Sidecar known present but match not yet reported — do not invent verified.
+  if (opts.hasSidecar === true) return "unknown";
+
+  return "unknown";
+}
+
+/**
+ * Map grade → title/hint i18n keys + severity for chips and banners.
+ */
+export function resolveCliTrustBanner(grade: ChecksumTrustGrade): CliTrustBanner {
+  switch (grade) {
+    case "verified":
+      return {
+        titleKey: "cliTrust.grade.verified",
+        hintKey: null,
+        severity: "ok",
+      };
+    case "missing_sidecar":
+      return {
+        titleKey: "cliTrust.grade.missingSidecar",
+        hintKey: "cliTrust.hint.missingSidecar",
+        severity: "warn",
+      };
+    case "mismatch":
+      return {
+        titleKey: "cliTrust.grade.mismatch",
+        hintKey: "cliTrust.hint.mismatch",
+        severity: "error",
+      };
+    case "unverified_allowed":
+      return {
+        titleKey: "cliTrust.grade.unverifiedAllowed",
+        hintKey: "cliTrust.hint.unverifiedAllowed",
+        severity: "warn",
+      };
+    case "unknown":
+    default:
+      return {
+        titleKey: "cliTrust.grade.unknown",
+        hintKey: "cliTrust.hint.unknown",
+        severity: "warn",
+      };
+  }
+}
+
+/**
+ * Plan whether install may proceed when **no published checksum** is available.
+ *
+ * - `allow` — missing sidecar is OK (default) or escape hatch is set.
+ * - `refuse_need_flag` — strict require-checksum without allow-unverified.
+ * - `refuse_mismatch` — digest mismatch (fail-closed; never forceable).
+ *
+ * Callers pass `match: false` when the host already reported mismatch.
+ * This helper never invents a sidecar.
+ */
+export function planInstallWithoutChecksum(opts: {
+  requireChecksum: boolean;
+  allowUnverified: boolean;
+  /** Explicit mismatch → always refuse (fail-closed). */
+  match?: boolean | null;
+}): "allow" | "refuse_need_flag" | "refuse_mismatch" {
+  if (opts.match === false) return "refuse_mismatch";
+  if (opts.requireChecksum && !opts.allowUnverified) {
+    return "refuse_need_flag";
+  }
+  return "allow";
+}
+
+/**
+ * Redacted plain-text summary for logs / Doctor / support (no secrets).
+ * Mirror is reduced to host only; version is trimmed as-is.
+ */
+export function formatCliTrustSummary(opts: {
+  grade: ChecksumTrustGrade;
+  mirror?: string | null;
+  version?: string | null;
+}): string {
+  const parts: string[] = [`CLI trust: ${opts.grade}`];
+  const ver = typeof opts.version === "string" ? opts.version.trim() : "";
+  if (ver) parts.push(`version ${ver}`);
+  const host = safeMirrorHost(opts.mirror);
+  if (host) parts.push(`mirror ${host}`);
+  return parts.join(" · ");
+}
+
+/**
+ * CSS class for trust chips (reuses Extensions badge tokens).
+ */
+export function cliTrustChipClass(severity: CliTrustBannerSeverity): string {
+  switch (severity) {
+    case "ok":
+      return "ext-badge ext-badge--ok";
+    case "error":
+      return "ext-badge ext-badge--fail";
+    case "warn":
+    default:
+      return "ext-badge ext-badge--warn";
+  }
+}
+
+/**
+ * Map Setup gate error kind → trust grade when relevant.
+ * Returns null for unrelated errors (no invented grade).
+ */
+export function gradeFromSetupErrorKind(
+  kind: string | null | undefined,
+): ChecksumTrustGrade | null {
+  if (kind === "checksum_missing") return "missing_sidecar";
+  if (kind === "checksum_mismatch") return "mismatch";
+  return null;
+}
+
+/**
+ * Optional Doctor finding line from a known grade.
+ * Returns null for `unknown` (no invented finding).
+ */
+export function buildCliTrustDoctorFinding(grade: ChecksumTrustGrade): {
+  id: string;
+  level: "ok" | "warn" | "fail";
+  titleKey: string;
+  detailKey: string;
+  summary: string;
+} | null {
+  if (grade === "unknown") return null;
+  const banner = resolveCliTrustBanner(grade);
+  const level: "ok" | "warn" | "fail" =
+    banner.severity === "ok"
+      ? "ok"
+      : banner.severity === "error"
+        ? "fail"
+        : "warn";
+  return {
+    id: "cli_checksum_trust",
+    level,
+    titleKey: banner.titleKey,
+    detailKey: banner.hintKey ?? banner.titleKey,
+    summary: formatCliTrustSummary({ grade }),
+  };
+}
+
+/**
+ * Grade from host last-install flag (+ allow-unverified for escape hatch honesty).
+ * Convenience for Settings Runtime CLI chip.
+ */
+export function gradeFromLastInstall(opts: {
+  lastCliChecksumVerified?: boolean | null;
+  allowUnverified?: boolean | null;
+}): ChecksumTrustGrade {
+  return resolveChecksumTrustGrade({
+    verifiedFlag: opts.lastCliChecksumVerified,
+    allowUnverified: opts.allowUnverified,
+  });
+}
+
+/** Host-only mirror host for summary (strip path / credentials). */
+function safeMirrorHost(mirror: string | null | undefined): string {
+  if (mirror == null) return "";
+  const raw = String(mirror).trim();
+  if (!raw) return "";
+  try {
+    const withScheme = /:\/\//.test(raw) ? raw : `https://${raw}`;
+    const u = new URL(withScheme);
+    // Drop userinfo if somehow present.
+    return u.host || "";
+  } catch {
+    // Best-effort: strip scheme, path, and userinfo.
+    const noScheme = raw.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, "");
+    const noUser = noScheme.includes("@")
+      ? noScheme.slice(noScheme.lastIndexOf("@") + 1)
+      : noScheme;
+    return noUser.split("/")[0]?.split("?")[0]?.trim() || "";
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5568,6 +5568,21 @@ html[data-theme="light"] .ui-check.is-mixed .ui-check__box {
   font-family: var(--font-mono);
 }
 
+/* CLI checksum trust chip (Settings → Runtime) */
+.settings-cli-trust {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.settings-cli-trust .settings-row__hint {
+  flex: 1 1 12rem;
+  min-width: 0;
+  font-family: var(--font-sans, inherit);
+}
+
 /* CLI update check (Settings → Runtime / About + Doctor) */
 .settings-cli-update {
   display: flex;

--- a/src/styles/setup-wizard.css
+++ b/src/styles/setup-wizard.css
@@ -485,6 +485,23 @@
   line-height: 1.4 !important;
 }
 
+/* CLI checksum trust risk chip (missing sidecar / mismatch honesty) */
+.setup-trust-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.setup-trust-chip-row__hint {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  line-height: 1.4;
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
 .setup-error {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Top30 #24 — CLI supply-chain trust UX upgrade.

- **Pure** `src/lib/cliTrustSupplyChain.ts` (+ tests): grades `verified` · `missing_sidecar` · `mismatch` · `unverified_allowed` · `unknown`; `resolveChecksumTrustGrade` / `resolveCliTrustBanner` / `planInstallWithoutChecksum` / `formatCliTrustSummary`. Never invents sidecar presence; mismatch always fail-closed.
- **Setup** runtime step: risk chip + hint on missing sidecar / mismatch / unverified-allowed install.
- **Settings → Runtime CLI**: trust grade chip for last App-managed install; clearer allow-unverified description (warn-grade missing sidecar; mismatch never forceable).
- **Doctor**: optional `cli_checksum` finding when `lastCliChecksumVerified` is known; `checksumVerified` on cli check meta/raw.
- i18n en/zh/zh-TW; CHANGELOG; `docs/llm-wiki/setup.md` trust-grades paragraph.

## Test plan

- [x] `pnpm test -- src/lib/cliTrustSupplyChain.test.ts src/lib/setupGatePro.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: Setup install with missing sidecar shows warn chip; mismatch path shows error chip and no force-unverified
- [ ] Manual: Settings → Runtime shows trust chip after install; Doctor shows cli_checksum when last install recorded