### PR TITLE
feat(reliability): support bundle export honesty and manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Support bundle export honesty** (Reliability center): pure `supportBundlePro` helpers plan redacted sections (`doctor` / `settings` / `meta` / optional `stall-timeline` / `logs` / `README`), never claim secrets or invent logs; classified soft-fail (`host_only` · `cancel` · `io` · `empty` · `other`); GlassModal confirm with section checklist + text manifest preview before export; stall JSON only when signals exist. en/zh/zh-TW + tests.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/components/ReliabilityCenterModal.tsx
+++ b/src/components/ReliabilityCenterModal.tsx
@@ -58,6 +58,15 @@ import {
   type ReliabilityStallSignal,
   type StallHistoryEntry,
 } from "@/lib/reliabilityCenter";
+import {
+  canSupportBundleExport,
+  formatSupportBundleManifest,
+  planSupportBundleExport,
+  resolveSupportBundleEmptyState,
+  resolveSupportBundleSoftFail,
+  resolveSupportBundleStallJson,
+  type SupportBundleExportPlan,
+} from "@/lib/supportBundlePro";
 
 export type ReliabilityCenterModalProps = {
   open: boolean;
@@ -406,6 +415,7 @@ export function ReliabilityCenterModal({
   const [historyQuery, setHistoryQuery] = useState("");
   const [historyKind, setHistoryKind] = useState<StallKindFilter>("all");
   const [confirmClearHistory, setConfirmClearHistory] = useState(false);
+  const [confirmSupportZip, setConfirmSupportZip] = useState(false);
 
   const [auditEntries, setAuditEntries] = useState<AuditLedgerEntry[]>([]);
   const [auditQuery, setAuditQuery] = useState("");
@@ -440,6 +450,7 @@ export function ReliabilityCenterModal({
     setHistoryQuery("");
     setHistoryKind("all");
     setConfirmClearHistory(false);
+    setConfirmSupportZip(false);
     setStallHistory(loadStallHistory());
     setAuditQuery("");
     setAuditEvent("all");
@@ -566,22 +577,80 @@ export function ReliabilityCenterModal({
     }
   }, [goalOrchView.events, t]);
 
-  const onSupportZip = useCallback(async () => {
+  /** Honest support-zip plan (never invents stall/logs/secrets). */
+  const supportPlan: SupportBundleExportPlan = useMemo(() => {
+    const hasStall = view.stalls.signals.length > 0;
+    return planSupportBundleExport({
+      // Host always collects a Doctor report when UI passes null.
+      hasDoctor: true,
+      hasStallTimeline: hasStall,
+      // Audit ledger is a separate export — mark omitted when rows exist.
+      hasAudit: auditEntries.length > 0,
+      isHost: api.isTauri(),
+    });
+  }, [view.stalls.signals.length, auditEntries.length]);
+
+  const supportManifestText = useMemo(
+    () => formatSupportBundleManifest(supportPlan),
+    [supportPlan],
+  );
+
+  const supportEmpty = useMemo(
+    () =>
+      resolveSupportBundleEmptyState({
+        isHost: api.isTauri(),
+        hasDoctor: supportPlan.hasDoctor,
+        hasStallTimeline: supportPlan.hasStallTimeline,
+        hasAudit: supportPlan.auditOmitted,
+      }),
+    [supportPlan],
+  );
+
+  const onSupportZipRequest = useCallback(() => {
+    setStatusMsg(null);
+    setErrorMsg(null);
+    if (supportEmpty) {
+      setErrorMsg(
+        `${t(supportEmpty.titleKey as MessageKey)}. ${t(supportEmpty.hintKey as MessageKey)}`,
+      );
+      return;
+    }
+    if (
+      !canSupportBundleExport({
+        isHost: api.isTauri(),
+        busy: !!busy,
+      })
+    ) {
+      return;
+    }
+    setConfirmSupportZip(true);
+  }, [supportEmpty, t, busy]);
+
+  const doSupportZip = useCallback(async () => {
+    setConfirmSupportZip(false);
     setBusy("zip");
     setStatusMsg(null);
     setErrorMsg(null);
     try {
-      // Structured stall timeline only (titles/kinds/seconds) — host redacts secrets.
+      // Structured stall timeline only when signals exist — never invent rows.
       const timeline = buildStallTimelineSnapshot(view.stalls.signals);
-      const stallJson = serializeStallTimelineSnapshot(timeline);
+      const stallJson = resolveSupportBundleStallJson({
+        hasStallTimeline: supportPlan.hasStallTimeline,
+        stallJson: serializeStallTimelineSnapshot(timeline),
+        signalCount: timeline.count,
+      });
+      // Host builds Doctor when null; UI does not invent a doctor payload.
       const res = await api.exportSupportBundle(null, stallJson);
       setStatusMsg(`${t("doctor.supportZipDone")}: ${res.path}`);
     } catch (e) {
-      setErrorMsg(`${t("doctor.supportZipFail")}: ${String(e)}`);
+      const soft = resolveSupportBundleSoftFail(e);
+      if (soft.silent) return;
+      const base = t(soft.messageKey as MessageKey);
+      setErrorMsg(soft.detail ? `${base}: ${soft.detail}` : base);
     } finally {
       setBusy(null);
     }
-  }, [t, view.stalls.signals]);
+  }, [t, view.stalls.signals, supportPlan.hasStallTimeline]);
 
   const onExportStallHistory = useCallback(() => {
     setBusy("stall-export");
@@ -1308,9 +1377,10 @@ export function ReliabilityCenterModal({
           <button
             type="button"
             className="btn btn--ghost btn--sm"
-            disabled={!!busy}
-            onClick={() => void onSupportZip()}
+            disabled={!!busy || !canSupportBundleExport({ isHost: api.isTauri() })}
+            onClick={onSupportZipRequest}
             title={t("reliability.supportZipHint")}
+            data-testid="reliab-support-zip"
           >
             {busy === "zip" ? "…" : t("doctor.supportZip")}
           </button>
@@ -1364,6 +1434,115 @@ export function ReliabilityCenterModal({
             count: clearHistoryPlan.count,
           })}
         </p>
+      </GlassModal>
+      <GlassModal
+        open={confirmSupportZip}
+        onClose={() => setConfirmSupportZip(false)}
+        title={t("reliability.supportZip.confirmTitle")}
+        size="md"
+        closeLabel={t("common.cancel")}
+        titleId="reliab-support-zip-confirm-title"
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn--ghost"
+              onClick={() => setConfirmSupportZip(false)}
+            >
+              {t("common.cancel")}
+            </button>
+            <button
+              type="button"
+              className="btn btn--solid"
+              onClick={() => void doSupportZip()}
+              disabled={!!busy}
+              data-testid="reliab-support-zip-confirm"
+            >
+              {t("reliability.supportZip.confirmAction")}
+            </button>
+          </>
+        }
+      >
+        <div
+          className="app-dialog__msg"
+          style={{ margin: 0, padding: "12px 16px" }}
+          data-testid="reliab-support-zip-checklist"
+        >
+          <p style={{ margin: "0 0 8px" }}>
+            {t("reliability.supportZip.confirmMessage")}
+          </p>
+          <p
+            className="reliab-card__sub reliab-card__sub--muted"
+            style={{ margin: "0 0 10px" }}
+          >
+            {t("reliability.supportZip.secretsNever")}
+          </p>
+          <p style={{ margin: "0 0 6px", fontWeight: 600 }}>
+            {t("reliability.supportZip.checklistTitle")}
+          </p>
+          <ul
+            className="reliab-support-checklist"
+            style={{
+              margin: "0 0 10px",
+              padding: "0 0 0 1.1em",
+              listStyle: "disc",
+            }}
+          >
+            {supportPlan.sections.map((s) => (
+              <li
+                key={s.id}
+                data-section={s.id}
+                data-included={s.included ? "1" : "0"}
+                style={{
+                  marginBottom: 4,
+                  opacity: s.included ? 1 : 0.55,
+                }}
+              >
+                <span aria-hidden>{s.included ? "✓ " : "– "}</span>
+                {t(s.labelKey as MessageKey)}
+                {s.included && s.redacted
+                  ? ` · ${t("reliability.supportZip.redacted")}`
+                  : null}
+                {!s.included
+                  ? ` · ${t("reliability.supportZip.sectionOmitted")}`
+                  : s.availability === "when_available"
+                    ? ` · ${t("reliability.supportZip.whenAvailable")}`
+                    : null}
+              </li>
+            ))}
+          </ul>
+          {supportPlan.auditOmitted ? (
+            <p
+              className="reliab-card__sub reliab-card__sub--muted"
+              style={{ margin: "0 0 8px" }}
+            >
+              {t("reliability.supportZip.auditNotIncluded")}
+            </p>
+          ) : null}
+          <details style={{ marginTop: 4 }}>
+            <summary style={{ cursor: "pointer" }}>
+              {t("reliability.supportZip.manifestPreview")}
+            </summary>
+            <pre
+              className="reliab-support-manifest"
+              style={{
+                margin: "8px 0 0",
+                padding: 8,
+                fontSize: 11,
+                lineHeight: 1.4,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                maxHeight: 160,
+                overflow: "auto",
+                borderRadius: 6,
+                background: "var(--surface-2, rgba(0,0,0,0.06))",
+              }}
+              data-testid="reliab-support-manifest"
+            >
+              {supportManifestText}
+            </pre>
+          </details>
+        </div>
       </GlassModal>
       {clearAuditPortal}
     </div>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -3521,6 +3521,45 @@ const en = {
     "Aggregate busy chats, stall signals, recent error cards, and the tool audit ledger; export support zip.",
   "reliability.supportZipHint":
     "Redacted Doctor report, recent logs, and stall timeline snapshot (no secrets).",
+  "reliability.supportZip.confirmTitle": "Export support zip?",
+  "reliability.supportZip.confirmMessage":
+    "Review the redacted checklist below. The zip never includes secrets, auth tokens, or API keys.",
+  "reliability.supportZip.confirmAction": "Export support zip",
+  "reliability.supportZip.checklistTitle": "Included sections (redacted)",
+  "reliability.supportZip.secretsNever":
+    "Secrets are never included (no secrets.json, account auth, or raw API keys).",
+  "reliability.supportZip.redacted": "redacted",
+  "reliability.supportZip.whenAvailable": "if present on host",
+  "reliability.supportZip.sectionOmitted": "not included this export",
+  "reliability.supportZip.auditNotIncluded":
+    "Tool audit ledger is not in this zip — use Audit export instead.",
+  "reliability.supportZip.manifestPreview": "Text manifest preview",
+  "reliability.supportZip.section.doctor": "Doctor report (doctor.json)",
+  "reliability.supportZip.section.doctorHint":
+    "Health checks; host builds a fresh report when none is passed (paths only, no keys).",
+  "reliability.supportZip.section.settings": "App settings (settings.json)",
+  "reliability.supportZip.section.settingsHint":
+    "Included only when settings exist on this device; secrets scrubbed.",
+  "reliability.supportZip.section.meta": "App / OS meta (meta.json)",
+  "reliability.supportZip.section.metaHint":
+    "Version, OS/arch, session and project counts — no paths with secrets.",
+  "reliability.supportZip.section.stall": "Stall timeline (stall-timeline.json)",
+  "reliability.supportZip.section.stallHint":
+    "Structured stall signals from Reliability center only when present.",
+  "reliability.supportZip.section.logs": "Recent logs (logs/)",
+  "reliability.supportZip.section.logsHint":
+    "Recent log files if present on host; size-capped and redacted — never invented.",
+  "reliability.supportZip.section.readme": "README.txt",
+  "reliability.supportZip.section.readmeHint":
+    "Plain inventory of zip contents for the recipient.",
+  "reliability.supportZip.emptyHostOnly": "Support zip needs the desktop app",
+  "reliability.supportZip.emptyHostOnlyHint":
+    "Export runs on the Tauri host only — open Grok App on desktop to build a redacted support zip.",
+  "reliability.supportZip.failHostOnly":
+    "Support zip needs the desktop app (not available in browser)",
+  "reliability.supportZip.failCancel": "Support zip cancelled",
+  "reliability.supportZip.failIo": "Could not write support zip (disk or permission)",
+  "reliability.supportZip.failEmpty": "Nothing honest to put in the support zip",
   "reliability.goal.title": "Goal orchestration",
   "reliability.goal.count": "{count}",
   "reliability.goal.lead":
@@ -9520,6 +9559,43 @@ const zh: Record<MessageKey, string> = {
     "汇总忙碌会话、卡顿信号、最近错误卡片与工具审计账本；可导出支持包。",
   "reliability.supportZipHint":
     "脱敏后的 Doctor 报告、近期日志与卡顿时间线快照（不含密钥）。",
+  "reliability.supportZip.confirmTitle": "导出支持包？",
+  "reliability.supportZip.confirmMessage":
+    "请先核对下方脱敏清单。支持包绝不会包含密钥、登录凭据或 API Key。",
+  "reliability.supportZip.confirmAction": "导出支持包",
+  "reliability.supportZip.checklistTitle": "将包含的部分（已脱敏）",
+  "reliability.supportZip.secretsNever":
+    "绝不会包含密钥（无 secrets.json、账户登录或原始 API Key）。",
+  "reliability.supportZip.redacted": "已脱敏",
+  "reliability.supportZip.whenAvailable": "主机上存在时才写入",
+  "reliability.supportZip.sectionOmitted": "本次不包含",
+  "reliability.supportZip.auditNotIncluded":
+    "工具审计账本不在此压缩包内 — 请改用「审计」导出。",
+  "reliability.supportZip.manifestPreview": "文本清单预览",
+  "reliability.supportZip.section.doctor": "Doctor 报告（doctor.json）",
+  "reliability.supportZip.section.doctorHint":
+    "健康检查；界面未传入时由主机重新生成（仅路径，无密钥）。",
+  "reliability.supportZip.section.settings": "应用设置（settings.json）",
+  "reliability.supportZip.section.settingsHint":
+    "仅当本机存在设置文件时写入；密钥已脱敏。",
+  "reliability.supportZip.section.meta": "应用 / 系统元数据（meta.json）",
+  "reliability.supportZip.section.metaHint":
+    "版本、系统架构、会话与项目数量 — 不含含密钥路径。",
+  "reliability.supportZip.section.stall": "卡顿时间线（stall-timeline.json）",
+  "reliability.supportZip.section.stallHint":
+    "仅在有可靠性中心卡顿信号时写入结构化快照。",
+  "reliability.supportZip.section.logs": "近期日志（logs/）",
+  "reliability.supportZip.section.logsHint":
+    "主机上存在时才写入近期日志；限大小并脱敏 — 绝不虚构日志。",
+  "reliability.supportZip.section.readme": "README.txt",
+  "reliability.supportZip.section.readmeHint": "给接收方的压缩包内容说明。",
+  "reliability.supportZip.emptyHostOnly": "支持包需要桌面应用",
+  "reliability.supportZip.emptyHostOnlyHint":
+    "导出仅在 Tauri 主机上运行 — 请在桌面版 Grok App 中生成脱敏支持包。",
+  "reliability.supportZip.failHostOnly": "支持包需要桌面应用（浏览器中不可用）",
+  "reliability.supportZip.failCancel": "已取消导出支持包",
+  "reliability.supportZip.failIo": "无法写入支持包（磁盘或权限）",
+  "reliability.supportZip.failEmpty": "当前没有可诚实写入支持包的内容",
   "reliability.goal.title": "目标编排",
   "reliability.goal.count": "{count}",
   "reliability.goal.lead":

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -3368,6 +3368,43 @@ export const zhTW: Record<MessageKey, string> = {
   "reliability.goal.phase.unknown": "目標",
   "reliability.supportZipHint":
     "去敏後的 Doctor 報告、近期日誌與停滯時間軸快照（不含金鑰）。",
+  "reliability.supportZip.confirmTitle": "匯出支援包？",
+  "reliability.supportZip.confirmMessage":
+    "請先核對下方去敏清單。支援包絕不會包含金鑰、登入憑證或 API Key。",
+  "reliability.supportZip.confirmAction": "匯出支援包",
+  "reliability.supportZip.checklistTitle": "將包含的部分（已去敏）",
+  "reliability.supportZip.secretsNever":
+    "絕不會包含金鑰（無 secrets.json、帳戶登入或原始 API Key）。",
+  "reliability.supportZip.redacted": "已去敏",
+  "reliability.supportZip.whenAvailable": "主機上存在時才寫入",
+  "reliability.supportZip.sectionOmitted": "本次不包含",
+  "reliability.supportZip.auditNotIncluded":
+    "工具稽核帳本不在此壓縮檔內 — 請改用「稽核」匯出。",
+  "reliability.supportZip.manifestPreview": "文字清單預覽",
+  "reliability.supportZip.section.doctor": "Doctor 報告（doctor.json）",
+  "reliability.supportZip.section.doctorHint":
+    "健康檢查；介面未傳入時由主機重新產生（僅路徑，無金鑰）。",
+  "reliability.supportZip.section.settings": "應用程式設定（settings.json）",
+  "reliability.supportZip.section.settingsHint":
+    "僅當本機存在設定檔時寫入；金鑰已去敏。",
+  "reliability.supportZip.section.meta": "應用程式 / 系統中繼資料（meta.json）",
+  "reliability.supportZip.section.metaHint":
+    "版本、系統架構、工作階段與專案數量 — 不含含金鑰路徑。",
+  "reliability.supportZip.section.stall": "停滯時間軸（stall-timeline.json）",
+  "reliability.supportZip.section.stallHint":
+    "僅在有可靠性中心停滯訊號時寫入結構化快照。",
+  "reliability.supportZip.section.logs": "近期日誌（logs/）",
+  "reliability.supportZip.section.logsHint":
+    "主機上存在時才寫入近期日誌；限大小並去敏 — 絕不虛構日誌。",
+  "reliability.supportZip.section.readme": "README.txt",
+  "reliability.supportZip.section.readmeHint": "給接收方的壓縮檔內容說明。",
+  "reliability.supportZip.emptyHostOnly": "支援包需要桌面應用程式",
+  "reliability.supportZip.emptyHostOnlyHint":
+    "匯出僅在 Tauri 主機上執行 — 請在桌面版 Grok App 中產生去敏支援包。",
+  "reliability.supportZip.failHostOnly": "支援包需要桌面應用程式（瀏覽器中不可用）",
+  "reliability.supportZip.failCancel": "已取消匯出支援包",
+  "reliability.supportZip.failIo": "無法寫入支援包（磁碟或權限）",
+  "reliability.supportZip.failEmpty": "目前沒有可誠實寫入支援包的內容",
 
   "reliability.audit.title": "工具稽核帳本",
   "reliability.audit.count": "{count}",

--- a/src/lib/supportBundlePro.test.ts
+++ b/src/lib/supportBundlePro.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUPPORT_BUNDLE_SECTION_ORDER,
+  canSupportBundleExport,
+  classifySupportBundleError,
+  formatSupportBundleManifest,
+  planSupportBundleExport,
+  resolveSupportBundleEmptyState,
+  resolveSupportBundleSoftFail,
+  resolveSupportBundleStallJson,
+  supportBundleErrorMessageKey,
+  supportBundleSectionHintKey,
+  supportBundleSectionLabelKey,
+  supportBundleSoftFailSilent,
+} from "./supportBundlePro";
+
+describe("planSupportBundleExport", () => {
+  it("always includes doctor, settings, meta, logs, readme; never secrets", () => {
+    const plan = planSupportBundleExport({
+      hasDoctor: false,
+      hasStallTimeline: false,
+    });
+    expect(plan.secretsIncluded).toBe(false);
+    expect(plan.auditIncluded).toBe(false);
+    expect(plan.includedIds).toContain("doctor");
+    expect(plan.includedIds).toContain("settings");
+    expect(plan.includedIds).toContain("meta");
+    expect(plan.includedIds).toContain("logs");
+    expect(plan.includedIds).toContain("readme");
+    expect(plan.includedIds).not.toContain("stall_timeline");
+    expect(plan.hasStallTimeline).toBe(false);
+    expect(plan.hasDoctor).toBe(false);
+    expect(plan.canExport).toBe(true);
+  });
+
+  it("includes stall timeline only when hasStallTimeline", () => {
+    const off = planSupportBundleExport({
+      hasDoctor: true,
+      hasStallTimeline: false,
+    });
+    const on = planSupportBundleExport({
+      hasDoctor: true,
+      hasStallTimeline: true,
+    });
+    expect(off.sections.find((s) => s.id === "stall_timeline")?.included).toBe(
+      false,
+    );
+    expect(on.sections.find((s) => s.id === "stall_timeline")?.included).toBe(
+      true,
+    );
+    expect(on.includedIds).toContain("stall_timeline");
+    expect(on.hasStallTimeline).toBe(true);
+  });
+
+  it("never claims audit in the zip; marks auditOmitted when hasAudit", () => {
+    const plan = planSupportBundleExport({
+      hasDoctor: true,
+      hasStallTimeline: false,
+      hasAudit: true,
+    });
+    expect(plan.auditIncluded).toBe(false);
+    expect(plan.auditOmitted).toBe(true);
+    expect(plan.sections.some((s) => (s.id as string) === "audit")).toBe(false);
+  });
+
+  it("canExport false when isHost is false", () => {
+    const plan = planSupportBundleExport({
+      hasDoctor: true,
+      hasStallTimeline: true,
+      isHost: false,
+    });
+    expect(plan.canExport).toBe(false);
+  });
+
+  it("marks settings/logs as when_available (never invent files)", () => {
+    const plan = planSupportBundleExport({
+      hasDoctor: true,
+      hasStallTimeline: false,
+    });
+    expect(plan.sections.find((s) => s.id === "settings")?.availability).toBe(
+      "when_available",
+    );
+    expect(plan.sections.find((s) => s.id === "logs")?.availability).toBe(
+      "when_available",
+    );
+    expect(plan.sections.find((s) => s.id === "doctor")?.redacted).toBe(true);
+    expect(plan.sections.find((s) => s.id === "logs")?.redacted).toBe(true);
+  });
+
+  it("uses stable section order", () => {
+    const plan = planSupportBundleExport({
+      hasDoctor: true,
+      hasStallTimeline: true,
+    });
+    expect(plan.sections.map((s) => s.id)).toEqual([
+      ...SUPPORT_BUNDLE_SECTION_ORDER,
+    ]);
+  });
+});
+
+describe("resolveSupportBundleEmptyState", () => {
+  it("returns host_only when not on desktop host", () => {
+    const empty = resolveSupportBundleEmptyState({ isHost: false });
+    expect(empty?.kind).toBe("host_only");
+    expect(empty?.titleKey).toBe("reliability.supportZip.emptyHostOnly");
+    expect(empty?.hintKey).toBe("reliability.supportZip.emptyHostOnlyHint");
+  });
+
+  it("returns null on host (base zip always possible)", () => {
+    expect(
+      resolveSupportBundleEmptyState({
+        isHost: true,
+        hasDoctor: false,
+        hasStallTimeline: false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("formatSupportBundleManifest", () => {
+  it("lists included sections and never claims secrets", () => {
+    const plan = planSupportBundleExport({
+      hasDoctor: true,
+      hasStallTimeline: true,
+      hasAudit: true,
+    });
+    const text = formatSupportBundleManifest(plan);
+    expect(text).toContain("# Support bundle preview (redacted)");
+    expect(text).toContain("Secrets are never included");
+    expect(text).toContain("[x] doctor.json");
+    expect(text).toContain("[x] stall-timeline.json");
+    expect(text).toContain("if present on host");
+    expect(text).toContain("Never included: secrets.json");
+    expect(text).toContain("Tool audit ledger is not in this zip");
+    expect(text.toLowerCase()).not.toContain("secrets.json is included");
+    expect(text).not.toMatch(/logs\/[a-z0-9_-]+\.log/i);
+  });
+
+  it("marks omitted stall honestly", () => {
+    const plan = planSupportBundleExport({
+      hasDoctor: false,
+      hasStallTimeline: false,
+    });
+    const text = formatSupportBundleManifest(plan.sections);
+    expect(text).toContain("[ ] stall-timeline.json");
+    expect(text).toContain("not included this export");
+  });
+
+  it("handles empty input without inventing sections", () => {
+    const text = formatSupportBundleManifest(null);
+    expect(text).toContain("(no sections planned)");
+    expect(text).toContain("Secrets are never included");
+  });
+});
+
+describe("classifySupportBundleError", () => {
+  it("classifies host_only", () => {
+    expect(classifySupportBundleError("Tauri required: export_support_bundle")).toBe(
+      "host_only",
+    );
+    expect(classifySupportBundleError("need tauri")).toBe("host_only");
+    expect(classifySupportBundleError({ code: "host_only" })).toBe("host_only");
+    expect(classifySupportBundleError("desktop only")).toBe("host_only");
+  });
+
+  it("classifies cancel", () => {
+    expect(classifySupportBundleError("user cancelled")).toBe("cancel");
+    expect(classifySupportBundleError("User canceled")).toBe("cancel");
+    expect(classifySupportBundleError({ code: "cancelled" })).toBe("cancel");
+    expect(classifySupportBundleError("dismissed")).toBe("cancel");
+  });
+
+  it("classifies io", () => {
+    expect(classifySupportBundleError("create zip: permission denied")).toBe(
+      "io",
+    );
+    expect(classifySupportBundleError("copy archive: disk full")).toBe("io");
+    expect(classifySupportBundleError({ code: "enospc" })).toBe("io");
+    expect(classifySupportBundleError("finish zip: i/o error")).toBe("io");
+  });
+
+  it("classifies empty", () => {
+    expect(classifySupportBundleError("empty")).toBe("empty");
+    expect(classifySupportBundleError("nothing to export")).toBe("empty");
+    expect(classifySupportBundleError({ code: "empty" })).toBe("empty");
+  });
+
+  it("falls back to other", () => {
+    expect(classifySupportBundleError("something weird")).toBe("other");
+    expect(classifySupportBundleError(null)).toBe("other");
+    expect(classifySupportBundleError("")).toBe("other");
+  });
+});
+
+describe("soft-fail helpers", () => {
+  it("maps kinds to i18n keys", () => {
+    expect(supportBundleErrorMessageKey("host_only")).toBe(
+      "reliability.supportZip.failHostOnly",
+    );
+    expect(supportBundleErrorMessageKey("cancel")).toBe(
+      "reliability.supportZip.failCancel",
+    );
+    expect(supportBundleErrorMessageKey("io")).toBe(
+      "reliability.supportZip.failIo",
+    );
+    expect(supportBundleErrorMessageKey("empty")).toBe(
+      "reliability.supportZip.failEmpty",
+    );
+    expect(supportBundleErrorMessageKey("other")).toBe("doctor.supportZipFail");
+  });
+
+  it("cancel is silent; others are not", () => {
+    expect(supportBundleSoftFailSilent("cancel")).toBe(true);
+    expect(supportBundleSoftFailSilent("io")).toBe(false);
+    expect(supportBundleSoftFailSilent("host_only")).toBe(false);
+  });
+
+  it("resolveSupportBundleSoftFail returns detail only for other", () => {
+    const cancel = resolveSupportBundleSoftFail("user cancelled");
+    expect(cancel.kind).toBe("cancel");
+    expect(cancel.silent).toBe(true);
+    expect(cancel.detail).toBe("");
+
+    const other = resolveSupportBundleSoftFail(new Error("boom detail"));
+    expect(other.kind).toBe("other");
+    expect(other.silent).toBe(false);
+    expect(other.detail).toContain("boom detail");
+    expect(other.messageKey).toBe("doctor.supportZipFail");
+  });
+});
+
+describe("section label keys", () => {
+  it("returns stable i18n keys for every section id", () => {
+    for (const id of SUPPORT_BUNDLE_SECTION_ORDER) {
+      expect(supportBundleSectionLabelKey(id)).toMatch(
+        /^reliability\.supportZip\.section\./,
+      );
+      expect(supportBundleSectionHintKey(id)).toMatch(
+        /^reliability\.supportZip\.section\./,
+      );
+    }
+  });
+});
+
+describe("canSupportBundleExport / resolveSupportBundleStallJson", () => {
+  it("requires host and not busy", () => {
+    expect(canSupportBundleExport({ isHost: true })).toBe(true);
+    expect(canSupportBundleExport({ isHost: false })).toBe(false);
+    expect(canSupportBundleExport({ isHost: true, busy: true })).toBe(false);
+  });
+
+  it("only returns stall JSON when planned and non-empty", () => {
+    expect(
+      resolveSupportBundleStallJson({
+        hasStallTimeline: false,
+        stallJson: '{"count":1}',
+      }),
+    ).toBeNull();
+    expect(
+      resolveSupportBundleStallJson({
+        hasStallTimeline: true,
+        stallJson: "   ",
+      }),
+    ).toBeNull();
+    expect(
+      resolveSupportBundleStallJson({
+        hasStallTimeline: true,
+        stallJson: '{"count":0}',
+        signalCount: 0,
+      }),
+    ).toBeNull();
+    expect(
+      resolveSupportBundleStallJson({
+        hasStallTimeline: true,
+        stallJson: '{"count":2}',
+        signalCount: 2,
+      }),
+    ).toBe('{"count":2}');
+  });
+});

--- a/src/lib/supportBundlePro.ts
+++ b/src/lib/supportBundlePro.ts
@@ -1,0 +1,552 @@
+/**
+ * SUPPORT-BUNDLE-PRO — pure helpers for Reliability / Doctor support zip honesty.
+ *
+ * Plans which redacted sections will be included, classifies export soft-fails,
+ * formats a user-facing manifest checklist, and resolves empty/host-only states.
+ *
+ * Honesty rules:
+ * - Never claim secrets (secrets.json, auth tokens, API keys) are included
+ * - Never invent logs — logs/settings are "when available on host"
+ * - Stall timeline only when the caller has real signals to pass
+ * - Tool audit ledger is a separate export — never claimed inside the zip
+ *
+ * Host write path (`export_support_bundle` / `write_support_bundle`):
+ * doctor.json, settings.json?, meta.json, stall-timeline.json?, logs/*?, README.txt
+ *
+ * No DOM / Tauri side effects. Callers own dialogs and toasts.
+ */
+
+/** Stable zip section ids (known host paths only). */
+export type SupportBundleSectionId =
+  | "doctor"
+  | "settings"
+  | "meta"
+  | "stall_timeline"
+  | "logs"
+  | "readme";
+
+/**
+ * How the section lands in the zip:
+ * - `always` — host always writes it
+ * - `when_available` — host includes only if present on disk (settings/logs)
+ * - `when_provided` — only when the UI passes structured input (stall timeline)
+ */
+export type SupportBundleSectionAvailability =
+  | "always"
+  | "when_available"
+  | "when_provided";
+
+/** One planned zip section for checklist / manifest honesty. */
+export type SupportBundleSectionPlan = {
+  id: SupportBundleSectionId;
+  /** Whether this section is expected in the zip for this plan. */
+  included: boolean;
+  availability: SupportBundleSectionAvailability;
+  /** True when contents are scrubbed / redacted before packaging. */
+  redacted: boolean;
+  /** Zip entry path (known basename only). */
+  zipPath: string;
+  /** i18n label key (`reliability.supportZip.section.*`). */
+  labelKey: string;
+  /** i18n hint key. */
+  hintKey: string;
+};
+
+/** Result of {@link planSupportBundleExport}. */
+export type SupportBundleExportPlan = {
+  sections: SupportBundleSectionPlan[];
+  /** Ids with `included: true` (order matches {@link sections}). */
+  includedIds: SupportBundleSectionId[];
+  /** Always false — secrets are never packaged. */
+  secretsIncluded: false;
+  /**
+   * Always false — audit ledger is a separate Reliability export.
+   * See {@link auditOmitted}.
+   */
+  auditIncluded: false;
+  /** True when caller had audit data but it is not in this zip. */
+  auditOmitted: boolean;
+  hasDoctor: boolean;
+  hasStallTimeline: boolean;
+  /**
+   * Desktop host can run `export_support_bundle`.
+   * False in browser / non-host environments.
+   */
+  canExport: boolean;
+};
+
+/** Soft-fail kinds for support zip export toasts. */
+export type SupportBundleErrorKind =
+  | "host_only"
+  | "cancel"
+  | "io"
+  | "empty"
+  | "other";
+
+/** Empty-state kinds when export cannot start honestly. */
+export type SupportBundleEmptyKind = "host_only";
+
+export type SupportBundleEmptyState = {
+  kind: SupportBundleEmptyKind;
+  titleKey: string;
+  hintKey: string;
+};
+
+/** Ordered section catalog (stable for checklist UI). */
+export const SUPPORT_BUNDLE_SECTION_ORDER: readonly SupportBundleSectionId[] = [
+  "doctor",
+  "settings",
+  "meta",
+  "stall_timeline",
+  "logs",
+  "readme",
+] as const;
+
+const SECTION_META: Record<
+  SupportBundleSectionId,
+  {
+    zipPath: string;
+    availability: SupportBundleSectionAvailability;
+    redacted: boolean;
+    labelKey: string;
+    hintKey: string;
+  }
+> = {
+  doctor: {
+    zipPath: "doctor.json",
+    availability: "always",
+    redacted: true,
+    labelKey: "reliability.supportZip.section.doctor",
+    hintKey: "reliability.supportZip.section.doctorHint",
+  },
+  settings: {
+    zipPath: "settings.json",
+    availability: "when_available",
+    redacted: true,
+    labelKey: "reliability.supportZip.section.settings",
+    hintKey: "reliability.supportZip.section.settingsHint",
+  },
+  meta: {
+    zipPath: "meta.json",
+    availability: "always",
+    redacted: false,
+    labelKey: "reliability.supportZip.section.meta",
+    hintKey: "reliability.supportZip.section.metaHint",
+  },
+  stall_timeline: {
+    zipPath: "stall-timeline.json",
+    availability: "when_provided",
+    redacted: true,
+    labelKey: "reliability.supportZip.section.stall",
+    hintKey: "reliability.supportZip.section.stallHint",
+  },
+  logs: {
+    zipPath: "logs/",
+    availability: "when_available",
+    redacted: true,
+    labelKey: "reliability.supportZip.section.logs",
+    hintKey: "reliability.supportZip.section.logsHint",
+  },
+  readme: {
+    zipPath: "README.txt",
+    availability: "always",
+    redacted: false,
+    labelKey: "reliability.supportZip.section.readme",
+    hintKey: "reliability.supportZip.section.readmeHint",
+  },
+};
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as { code?: unknown; message?: unknown; reason?: unknown };
+    const parts = [o.code, o.message, o.reason]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+function errCode(err: unknown): string {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const c = (err as { code?: unknown }).code;
+    if (typeof c === "string") return c.trim().toLowerCase();
+  }
+  return "";
+}
+
+function sectionPlan(
+  id: SupportBundleSectionId,
+  included: boolean,
+): SupportBundleSectionPlan {
+  const m = SECTION_META[id];
+  return {
+    id,
+    included,
+    availability: m.availability,
+    redacted: m.redacted,
+    zipPath: m.zipPath,
+    labelKey: m.labelKey,
+    hintKey: m.hintKey,
+  };
+}
+
+/**
+ * Plan which redacted sections the support zip will contain.
+ *
+ * - Doctor is always included (host generates a fresh report when the UI
+ *   does not pass one; `hasDoctor` only records whether the UI already has
+ *   a report payload).
+ * - Stall timeline is included only when `hasStallTimeline` is true.
+ * - Settings and logs are listed as included-when-available — never invented.
+ * - Secrets are never claimed. Audit ledger is never claimed in this zip.
+ */
+export function planSupportBundleExport(input: {
+  hasDoctor: boolean;
+  hasStallTimeline: boolean;
+  hasAudit?: boolean;
+  /** Desktop host present. Default `true` (content plan only). */
+  isHost?: boolean;
+}): SupportBundleExportPlan {
+  const hasDoctor = !!input.hasDoctor;
+  const hasStallTimeline = !!input.hasStallTimeline;
+  const hasAudit = !!input.hasAudit;
+  const isHost = input.isHost !== false;
+
+  const sections: SupportBundleSectionPlan[] = [
+    // Doctor always lands in the zip (host builds when UI passes null).
+    sectionPlan("doctor", true),
+    sectionPlan("settings", true),
+    sectionPlan("meta", true),
+    sectionPlan("stall_timeline", hasStallTimeline),
+    // Logs: planned as when-available — never invent that log files exist.
+    sectionPlan("logs", true),
+    sectionPlan("readme", true),
+  ];
+
+  const includedIds = sections
+    .filter((s) => s.included)
+    .map((s) => s.id);
+
+  return {
+    sections,
+    includedIds,
+    secretsIncluded: false,
+    auditIncluded: false,
+    auditOmitted: hasAudit,
+    hasDoctor,
+    hasStallTimeline,
+    canExport: isHost && includedIds.length > 0,
+  };
+}
+
+/**
+ * Resolve pre-export empty / blocked state.
+ * Browser (no host) → host_only. Host can always build a base zip → null.
+ */
+export function resolveSupportBundleEmptyState(input: {
+  isHost: boolean;
+  hasDoctor?: boolean;
+  hasStallTimeline?: boolean;
+  hasAudit?: boolean;
+}): SupportBundleEmptyState | null {
+  if (!input.isHost) {
+    return {
+      kind: "host_only",
+      titleKey: "reliability.supportZip.emptyHostOnly",
+      hintKey: "reliability.supportZip.emptyHostOnlyHint",
+    };
+  }
+  // Host always produces doctor + meta + readme — never invent an empty zip.
+  return null;
+}
+
+/**
+ * Redacted plain-text manifest for user preview before export.
+ * English technical labels (same spirit as host README.txt); no secrets;
+ * never lists invented log filenames.
+ */
+export function formatSupportBundleManifest(
+  sections:
+    | readonly SupportBundleSectionPlan[]
+    | SupportBundleExportPlan
+    | null
+    | undefined,
+  opts?: {
+    /** Append audit-not-included honesty note. */
+    auditOmitted?: boolean;
+  },
+): string {
+  const list: readonly SupportBundleSectionPlan[] = !sections
+    ? []
+    : Array.isArray(sections)
+      ? sections
+      : (sections as SupportBundleExportPlan).sections ?? [];
+
+  const auditOmitted =
+    opts?.auditOmitted === true ||
+    (!Array.isArray(sections) &&
+      sections != null &&
+      (sections as SupportBundleExportPlan).auditOmitted === true);
+
+  const lines: string[] = [
+    "# Support bundle preview (redacted)",
+    "Secrets are never included (no secrets.json, auth tokens, or API keys).",
+    "",
+  ];
+
+  if (list.length === 0) {
+    lines.push("(no sections planned)");
+  } else {
+    for (const s of list) {
+      const mark = s.included ? "x" : " ";
+      const red = s.redacted ? "; redacted" : "";
+      let avail = "";
+      if (s.included) {
+        if (s.availability === "when_available") {
+          avail = "; if present on host";
+        } else if (s.availability === "when_provided") {
+          avail = "; from Reliability snapshot";
+        }
+      } else {
+        avail = "; not included this export";
+      }
+      lines.push(`- [${mark}] ${s.zipPath}${red}${avail}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("Never included: secrets.json, account auth, raw API keys.");
+
+  if (auditOmitted) {
+    lines.push(
+      "Tool audit ledger is not in this zip — use Reliability → Audit export.",
+    );
+  }
+
+  return lines.join("\n").trim();
+}
+
+/**
+ * Classify a thrown value / host error into a stable soft-fail kind.
+ * Prefer explicit `code` over free-form text.
+ */
+export function classifySupportBundleError(
+  err: unknown,
+): SupportBundleErrorKind {
+  if (err == null || err === "") return "other";
+
+  const code = errCode(err);
+  if (
+    code === "host_only" ||
+    code === "host-only" ||
+    code === "need_tauri" ||
+    code === "need-tauri" ||
+    code === "desktop_only" ||
+    code === "desktop-only"
+  ) {
+    return "host_only";
+  }
+  if (
+    code === "cancelled" ||
+    code === "canceled" ||
+    code === "cancel" ||
+    code === "user_cancelled" ||
+    code === "user_canceled"
+  ) {
+    return "cancel";
+  }
+  if (code === "empty" || code === "empty_bundle" || code === "nothing") {
+    return "empty";
+  }
+  if (
+    code === "io" ||
+    code === "io_error" ||
+    code === "write_failed" ||
+    code === "write-failed" ||
+    code === "save_failed" ||
+    code === "save-failed" ||
+    code === "enospc" ||
+    code === "eacces" ||
+    code === "eperm"
+  ) {
+    return "io";
+  }
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  if (
+    s.includes("tauri required") ||
+    s.includes("need tauri") ||
+    s.includes("desktop only") ||
+    s.includes("host only") ||
+    s.includes("host_only") ||
+    s.includes("not available in browser") ||
+    s.includes("requires desktop")
+  ) {
+    return "host_only";
+  }
+
+  if (
+    /\bcancel(l?ed)?\b/.test(s) ||
+    s.includes("user cancelled") ||
+    s.includes("user canceled") ||
+    s.includes("dismissed")
+  ) {
+    return "cancel";
+  }
+
+  const msgOnly =
+    err instanceof Error ? (err.message || "").trim().toLowerCase() : "";
+  if (
+    msgOnly === "empty" ||
+    s.trim() === "empty" ||
+    s.trim() === "error: empty" ||
+    s.includes("nothing to export") ||
+    s.includes("empty bundle") ||
+    s.includes("no content to export")
+  ) {
+    return "empty";
+  }
+
+  if (
+    s.includes("create zip") ||
+    s.includes("write doctor") ||
+    s.includes("write log") ||
+    s.includes("write meta") ||
+    s.includes("copy archive") ||
+    s.includes("disk full") ||
+    s.includes("enospc") ||
+    s.includes("eacces") ||
+    s.includes("permission denied") ||
+    s.includes("no space") ||
+    s.includes("i/o error") ||
+    s.includes("io error") ||
+    s.includes("failed to write") ||
+    s.includes("failed to create") ||
+    s.includes("finish zip")
+  ) {
+    return "io";
+  }
+
+  return "other";
+}
+
+/** i18n key for a classified soft-fail (never invent success). */
+export function supportBundleErrorMessageKey(
+  kind: SupportBundleErrorKind,
+): string {
+  switch (kind) {
+    case "host_only":
+      return "reliability.supportZip.failHostOnly";
+    case "cancel":
+      return "reliability.supportZip.failCancel";
+    case "io":
+      return "reliability.supportZip.failIo";
+    case "empty":
+      return "reliability.supportZip.failEmpty";
+    case "other":
+    default:
+      return "doctor.supportZipFail";
+  }
+}
+
+/** Cancelled native dialogs should not toast as a failure. */
+export function supportBundleSoftFailSilent(
+  kind: SupportBundleErrorKind,
+): boolean {
+  return kind === "cancel";
+}
+
+/**
+ * Resolve user-facing soft-fail copy from a thrown value.
+ * Returns message key + whether to stay silent (cancel).
+ */
+export function resolveSupportBundleSoftFail(err: unknown): {
+  kind: SupportBundleErrorKind;
+  messageKey: string;
+  silent: boolean;
+  /** Short technical detail for debug suffix (empty when not useful). */
+  detail: string;
+} {
+  const kind = classifySupportBundleError(err);
+  const messageKey = supportBundleErrorMessageKey(kind);
+  const silent = supportBundleSoftFailSilent(kind);
+  const raw = errText(err).trim();
+  let detail = "";
+  if (
+    kind === "other" &&
+    raw &&
+    !/^error:\s*$/i.test(raw) &&
+    raw.length < 200
+  ) {
+    detail = raw.replace(/^Error:\s*/i, "").trim();
+  }
+  return { kind, messageKey, silent, detail };
+}
+
+/** i18n label key for a section id. */
+export function supportBundleSectionLabelKey(
+  id: SupportBundleSectionId,
+): string {
+  return SECTION_META[id]?.labelKey ?? "reliability.supportZip.section.meta";
+}
+
+/** i18n hint key for a section id. */
+export function supportBundleSectionHintKey(
+  id: SupportBundleSectionId,
+): string {
+  return SECTION_META[id]?.hintKey ?? "reliability.supportZip.section.metaHint";
+}
+
+/**
+ * Whether the support zip action may run.
+ * Host required; busy alone does not invent content.
+ */
+export function canSupportBundleExport(input: {
+  isHost: boolean;
+  busy?: boolean;
+}): boolean {
+  if (!input.isHost) return false;
+  if (input.busy) return false;
+  return true;
+}
+
+/**
+ * Only pass stall JSON to the host when the plan includes that section
+ * and the snapshot has at least one signal. Empty snapshots → null
+ * (never invent a timeline).
+ */
+export function resolveSupportBundleStallJson(input: {
+  hasStallTimeline: boolean;
+  /** Serialized snapshot; empty/whitespace → null. */
+  stallJson?: string | null;
+  /** Optional signal count; 0 → null even if string present. */
+  signalCount?: number | null;
+}): string | null {
+  if (!input.hasStallTimeline) return null;
+  if (
+    typeof input.signalCount === "number" &&
+    Number.isFinite(input.signalCount) &&
+    input.signalCount <= 0
+  ) {
+    return null;
+  }
+  const raw = typeof input.stallJson === "string" ? input.stallJson.trim() : "";
+  return raw || null;
+}


### PR DESCRIPTION
## Summary
- Pure `supportBundlePro` helpers: plan redacted sections, classify soft-fails (`host_only` · `cancel` · `io` · `empty` · `other`), empty-state, text manifest preview
- Reliability center: GlassModal confirm with section checklist + redacted manifest before export; classified soft-fail toasts; stall JSON only when signals exist
- Never claims secrets included; never invents logs; audit ledger remains a separate export
- i18n en/zh/zh-TW + CHANGELOG + tests

## Test plan
- [x] `pnpm test -- src/lib/supportBundlePro.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Desktop: Reliability → Support zip → confirm checklist shows honest sections
- [ ] With stall signals: stall-timeline marked included; without: omitted
- [ ] Browser path soft-fails host_only (if exercised)
- [ ] Cancel native save is silent (no error toast)