### PR TITLE
feat(doctor): platform capability matrix honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Doctor platform capability matrix**: Doctor modal shows a **Platform matrix** table with honest macOS / Windows / Linux notes for CLI path probe, sandbox kernel (Seatbelt / Landlock / Windows soft-fail), window chrome (Overlay vs frameless vs decorated), app auto-update channel, and media loopback delivery — pure `doctorPlatformMatrix` helpers + tests; never invents probe results; en/zh/zh-TW. Complements the Windows day-use checklist without duplicating it.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20594,6 +20594,7 @@ export default function App() {
         open={showDoctor}
         onClose={() => setShowDoctor(false)}
         locale={locale}
+        sandboxProfile={sandboxProfile}
         onConfirm={({ title, message, confirmLabel, danger, onConfirm }) => {
           setAppDialog({
             kind: "confirm",

--- a/src/components/DoctorModal.tsx
+++ b/src/components/DoctorModal.tsx
@@ -47,6 +47,13 @@ import {
   type DoctorFindingRow,
   type DoctorFindingSourceFilter,
 } from "@/lib/doctorFindings";
+import {
+  buildDoctorPlatformMatrix,
+  doctorPlatformCellStatusKey,
+  doctorPlatformCellTone,
+} from "@/lib/doctorPlatformMatrix";
+import { detectAppPlatform } from "@/lib/appPlatform";
+import { useUpdaterContext } from "@/hooks/UpdaterProvider";
 import { CliUpdateRow } from "@/components/CliUpdateRow";
 import { redact } from "@/lib/redact";
 
@@ -83,6 +90,11 @@ export type DoctorModalProps = {
   onResetDone?: () => void;
   /** Open Reliability / Observability center (busy · stalls · errors). */
   onOpenReliability?: () => void;
+  /**
+   * Effective sandbox profile for platform-matrix honesty
+   * (global or project-resolved). Optional — omit → treat as off / default.
+   */
+  sandboxProfile?: string | null;
 };
 
 const CHECK_TITLE_KEYS: Record<string, MessageKey> = {
@@ -180,8 +192,11 @@ export function DoctorModal({
   onConfirm,
   onResetDone,
   onOpenReliability,
+  sandboxProfile = "off",
 }: DoctorModalProps) {
   const t = useMemo(() => createT(locale), [locale]);
+  // Product tree wraps Doctor in UpdaterProvider (App shell).
+  const { channelInfo } = useUpdaterContext();
   const [report, setReport] = useState<DoctorReport | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -699,6 +714,26 @@ export function DoctorModal({
     };
   }, [report]);
 
+  /**
+   * Platform capability matrix — pure honesty from known inputs only.
+   * Never invents CLI found / update channel / media probe results.
+   */
+  const platformMatrix = useMemo(() => {
+    const cliFound =
+      cliResolved != null
+        ? cliResolved.found
+        : report?.checks?.find((c) => c.id === "cli")
+          ? report.checks.find((c) => c.id === "cli")!.level !== "fail"
+          : null;
+    return buildDoctorPlatformMatrix({
+      platform: detectAppPlatform(),
+      cliFound,
+      sandboxProfile,
+      updateChannel: channelInfo?.channel ?? null,
+      // Omit live media probe — design honesty only (no invented uptime).
+    });
+  }, [channelInfo?.channel, cliResolved, report, sandboxProfile]);
+
   const copyCliPath = useCallback(
     async (path: string) => {
       try {
@@ -849,6 +884,65 @@ export function DoctorModal({
                 </div>
               </dl>
             </div>
+          )}
+
+          {!loading && (
+            <section
+              className="doctor-platform-matrix"
+              aria-label={t("doctor.platformMatrix.title")}
+              data-testid="doctor-platform-matrix"
+            >
+              <div className="doctor-platform-matrix__head">
+                <h3 className="doctor-platform-matrix__title">
+                  {t("doctor.platformMatrix.title")}
+                </h3>
+                <p className="doctor-platform-matrix__hint">
+                  {t("doctor.platformMatrix.hint")}
+                </p>
+              </div>
+              <div className="doctor-platform-matrix__table-wrap">
+                <table className="doctor-platform-matrix__table">
+                  <thead>
+                    <tr>
+                      <th scope="col">
+                        {t("doctor.platformMatrix.col.capability")}
+                      </th>
+                      <th scope="col">
+                        {t("doctor.platformMatrix.col.status")}
+                      </th>
+                      <th scope="col">
+                        {t("doctor.platformMatrix.col.detail")}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {platformMatrix.rows.map((row) => {
+                      const tone = doctorPlatformCellTone(row.status);
+                      return (
+                        <tr
+                          key={row.rowId}
+                          className={`doctor-platform-matrix__row doctor-platform-matrix__row--${tone}`}
+                          data-row-id={row.rowId}
+                          data-status={row.status}
+                        >
+                          <th scope="row">{t(row.labelKey)}</th>
+                          <td>
+                            <span
+                              className={`doctor-platform-matrix__badge doctor-platform-matrix__badge--${tone}`}
+                            >
+                              {t(doctorPlatformCellStatusKey(row.status))}
+                            </span>
+                          </td>
+                          <td className="doctor-platform-matrix__detail">
+                            {t(row.messageKey)}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </section>
           )}
 
           {!loading && allFindings.length === 0 && (

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -3475,6 +3475,70 @@ const en = {
   "doctor.finding.destructive": "destructive",
   "doctor.finding.noDetail": "No additional detail.",
 
+  // Platform capability matrix (mac / Windows / Linux honesty)
+  "doctor.platformMatrix.title": "Platform matrix",
+  "doctor.platformMatrix.hint":
+    "Honest macOS / Windows / Linux capability notes for this install — path probe, sandbox kernel, window chrome, update path, media loopback. Complements the Windows day-use checklist without inventing probe results.",
+  "doctor.platformMatrix.col.capability": "Capability",
+  "doctor.platformMatrix.col.status": "Status",
+  "doctor.platformMatrix.col.detail": "Detail",
+  "doctor.platformMatrix.row.platform": "Platform",
+  "doctor.platformMatrix.row.cliPathProbe": "CLI path probe",
+  "doctor.platformMatrix.row.sandboxEnforcement": "Sandbox kernel",
+  "doctor.platformMatrix.row.windowChrome": "Window chrome",
+  "doctor.platformMatrix.row.autoUpdate": "App auto-update",
+  "doctor.platformMatrix.row.mediaLoopback": "Media loopback",
+  "doctor.platformMatrix.status.pass": "Pass",
+  "doctor.platformMatrix.status.warn": "Warn",
+  "doctor.platformMatrix.status.na": "N/A",
+  "doctor.platformMatrix.status.unknown": "Unknown",
+  "doctor.platformMatrix.msg.platform.mac": "macOS (detected).",
+  "doctor.platformMatrix.msg.platform.win": "Windows (detected).",
+  "doctor.platformMatrix.msg.platform.linux": "Linux (detected).",
+  "doctor.platformMatrix.msg.platform.unknown":
+    "Platform not recognized — capability notes may be incomplete.",
+  "doctor.platformMatrix.msg.cli.found": "Grok Build CLI binary resolved by path probe.",
+  "doctor.platformMatrix.msg.cli.missing":
+    "CLI path probe did not find a Grok Build binary — install or set path in Settings → Runtime.",
+  "doctor.platformMatrix.msg.cli.unknown":
+    "CLI path probe result not available yet (re-run Doctor).",
+  "doctor.platformMatrix.msg.sandbox.off":
+    "Sandbox isolation is off — no kernel enforcement requested.",
+  "doctor.platformMatrix.msg.sandbox.macSeatbelt":
+    "macOS Seatbelt: CLI OS sandbox enforcement is documented when isolation is on.",
+  "doctor.platformMatrix.msg.sandbox.linuxLandlock":
+    "Linux Landlock: CLI OS sandbox enforcement is documented when isolation is on.",
+  "doctor.platformMatrix.msg.sandbox.winSoftFail":
+    "Windows: CLI may accept the sandbox profile but soft-fails without kernel enforcement — not a hard security boundary.",
+  "doctor.platformMatrix.msg.sandbox.platformSoft":
+    "This platform soft-fails OS sandbox enforcement (CLI may continue without isolation).",
+  "doctor.platformMatrix.msg.sandbox.unknown":
+    "Sandbox kernel support unknown on this platform.",
+  "doctor.platformMatrix.msg.chrome.macOverlay":
+    "macOS Overlay title bar + traffic lights (tauri.macos.conf).",
+  "doctor.platformMatrix.msg.chrome.winFrameless":
+    "Windows frameless custom chrome (min / max / close) — tauri.windows.conf.",
+  "doctor.platformMatrix.msg.chrome.linuxDecorated":
+    "Linux uses standard window decorations (base tauri.conf).",
+  "doctor.platformMatrix.msg.chrome.unknown":
+    "Window chrome layout not classified for this platform.",
+  "doctor.platformMatrix.msg.update.silent":
+    "Signed release path: silent in-app auto-update is available.",
+  "doctor.platformMatrix.msg.update.manual":
+    "Manual / GitHub update path (local, unsigned, or plugin off) — open Releases; no silent install claimed.",
+  "doctor.platformMatrix.msg.update.unsupported":
+    "This package type cannot silent-auto-update (e.g. Linux .deb/.rpm) — use manual download.",
+  "doctor.platformMatrix.msg.update.hostOnly":
+    "Not running in the desktop app host — auto-update N/A.",
+  "doctor.platformMatrix.msg.update.unknown":
+    "Update channel not reported yet — do not assume silent install.",
+  "doctor.platformMatrix.msg.media.loopback":
+    "Local media uses loopback HTTP (127.0.0.1) with path-scope allowlist — not raw media:// in product paths.",
+  "doctor.platformMatrix.msg.media.unavailable":
+    "Media loopback endpoint unavailable — previews may soft-fail until the host media server is up.",
+  "doctor.platformMatrix.msg.media.unknown":
+    "Media loopback capability not classified for this platform.",
+
   // Reliability / Observability center (long-task signals)
   "reliability.title": "Reliability",
   "reliability.close": "Close reliability center",
@@ -9474,6 +9538,70 @@ const zh: Record<MessageKey, string> = {
   "doctor.finding.fixId": "修复 id",
   "doctor.finding.destructive": "破坏性",
   "doctor.finding.noDetail": "无更多详情。",
+
+  // Platform capability matrix (mac / Windows / Linux honesty)
+  "doctor.platformMatrix.title": "平台能力矩阵",
+  "doctor.platformMatrix.hint":
+    "如实展示本安装在 macOS / Windows / Linux 上的能力说明：路径探测、沙箱内核、窗口装饰、更新路径、媒体环回。补充 Windows 日用清单，不编造探测结果。",
+  "doctor.platformMatrix.col.capability": "能力",
+  "doctor.platformMatrix.col.status": "状态",
+  "doctor.platformMatrix.col.detail": "说明",
+  "doctor.platformMatrix.row.platform": "平台",
+  "doctor.platformMatrix.row.cliPathProbe": "CLI 路径探测",
+  "doctor.platformMatrix.row.sandboxEnforcement": "沙箱内核",
+  "doctor.platformMatrix.row.windowChrome": "窗口装饰",
+  "doctor.platformMatrix.row.autoUpdate": "应用自动更新",
+  "doctor.platformMatrix.row.mediaLoopback": "媒体环回",
+  "doctor.platformMatrix.status.pass": "通过",
+  "doctor.platformMatrix.status.warn": "警告",
+  "doctor.platformMatrix.status.na": "不适用",
+  "doctor.platformMatrix.status.unknown": "未知",
+  "doctor.platformMatrix.msg.platform.mac": "macOS（已检测）。",
+  "doctor.platformMatrix.msg.platform.win": "Windows（已检测）。",
+  "doctor.platformMatrix.msg.platform.linux": "Linux（已检测）。",
+  "doctor.platformMatrix.msg.platform.unknown":
+    "未能识别平台 — 能力说明可能不完整。",
+  "doctor.platformMatrix.msg.cli.found": "路径探测已解析到 Grok Build CLI 二进制。",
+  "doctor.platformMatrix.msg.cli.missing":
+    "路径探测未找到 Grok Build 二进制 — 请安装或在 设置 → 运行环境 中指定路径。",
+  "doctor.platformMatrix.msg.cli.unknown":
+    "CLI 路径探测结果尚不可用（请重新运行 Doctor）。",
+  "doctor.platformMatrix.msg.sandbox.off":
+    "沙箱隔离已关闭 — 未请求内核强制。",
+  "doctor.platformMatrix.msg.sandbox.macSeatbelt":
+    "macOS Seatbelt：开启隔离时 CLI 文档支持 OS 沙箱强制。",
+  "doctor.platformMatrix.msg.sandbox.linuxLandlock":
+    "Linux Landlock：开启隔离时 CLI 文档支持 OS 沙箱强制。",
+  "doctor.platformMatrix.msg.sandbox.winSoftFail":
+    "Windows：CLI 可能接受沙箱配置但 soft-fail、无内核强制 — 请勿当作硬安全边界。",
+  "doctor.platformMatrix.msg.sandbox.platformSoft":
+    "此平台 OS 沙箱强制 soft-fail（CLI 可能在无隔离情况下继续运行）。",
+  "doctor.platformMatrix.msg.sandbox.unknown":
+    "此平台的沙箱内核支持未知。",
+  "doctor.platformMatrix.msg.chrome.macOverlay":
+    "macOS Overlay 标题栏 + 交通灯（tauri.macos.conf）。",
+  "doctor.platformMatrix.msg.chrome.winFrameless":
+    "Windows 无边框自绘窗控（最小化 / 最大化 / 关闭）— tauri.windows.conf。",
+  "doctor.platformMatrix.msg.chrome.linuxDecorated":
+    "Linux 使用标准窗口装饰（基础 tauri.conf）。",
+  "doctor.platformMatrix.msg.chrome.unknown":
+    "此平台的窗口装饰布局未分类。",
+  "doctor.platformMatrix.msg.update.silent":
+    "已签名发行路径：支持应用内静默自动更新。",
+  "doctor.platformMatrix.msg.update.manual":
+    "手动 / GitHub 更新路径（本地、未签名或插件关闭）— 打开 Releases；不宣称静默安装。",
+  "doctor.platformMatrix.msg.update.unsupported":
+    "此安装包类型不支持静默自动更新（例如 Linux .deb/.rpm）— 请手动下载。",
+  "doctor.platformMatrix.msg.update.hostOnly":
+    "未在桌面应用宿主中运行 — 自动更新不适用。",
+  "doctor.platformMatrix.msg.update.unknown":
+    "更新通道尚未报告 — 请勿假定静默安装。",
+  "doctor.platformMatrix.msg.media.loopback":
+    "本地媒体走环回 HTTP（127.0.0.1）并经 path-scope 白名单 — 产品路径不用 raw media://。",
+  "doctor.platformMatrix.msg.media.unavailable":
+    "媒体环回端点不可用 — 宿主媒体服务就绪前预览可能 soft-fail。",
+  "doctor.platformMatrix.msg.media.unknown":
+    "此平台的媒体环回能力未分类。",
 
   "reliability.title": "可靠性",
   "reliability.close": "关闭可靠性中心",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -3294,6 +3294,70 @@ export const zhTW: Record<MessageKey, string> = {
   "doctor.finding.destructive": "破壞性",
   "doctor.finding.noDetail": "無更多詳情。",
 
+  // Platform capability matrix (mac / Windows / Linux honesty)
+  "doctor.platformMatrix.title": "平台能力矩陣",
+  "doctor.platformMatrix.hint":
+    "如實展示本安裝在 macOS / Windows / Linux 上的能力說明：路徑探測、沙箱核心、視窗裝飾、更新路徑、媒體迴路。補充 Windows 日用清單，不編造探測結果。",
+  "doctor.platformMatrix.col.capability": "能力",
+  "doctor.platformMatrix.col.status": "狀態",
+  "doctor.platformMatrix.col.detail": "說明",
+  "doctor.platformMatrix.row.platform": "平台",
+  "doctor.platformMatrix.row.cliPathProbe": "CLI 路徑探測",
+  "doctor.platformMatrix.row.sandboxEnforcement": "沙箱核心",
+  "doctor.platformMatrix.row.windowChrome": "視窗裝飾",
+  "doctor.platformMatrix.row.autoUpdate": "應用自動更新",
+  "doctor.platformMatrix.row.mediaLoopback": "媒體迴路",
+  "doctor.platformMatrix.status.pass": "通過",
+  "doctor.platformMatrix.status.warn": "警告",
+  "doctor.platformMatrix.status.na": "不適用",
+  "doctor.platformMatrix.status.unknown": "未知",
+  "doctor.platformMatrix.msg.platform.mac": "macOS（已偵測）。",
+  "doctor.platformMatrix.msg.platform.win": "Windows（已偵測）。",
+  "doctor.platformMatrix.msg.platform.linux": "Linux（已偵測）。",
+  "doctor.platformMatrix.msg.platform.unknown":
+    "未能辨識平台 — 能力說明可能不完整。",
+  "doctor.platformMatrix.msg.cli.found": "路徑探測已解析到 Grok Build CLI 二進位。",
+  "doctor.platformMatrix.msg.cli.missing":
+    "路徑探測未找到 Grok Build 二進位 — 請安裝或在 設定 → 執行環境 中指定路徑。",
+  "doctor.platformMatrix.msg.cli.unknown":
+    "CLI 路徑探測結果尚不可用（請重新執行 Doctor）。",
+  "doctor.platformMatrix.msg.sandbox.off":
+    "沙箱隔離已關閉 — 未請求核心強制。",
+  "doctor.platformMatrix.msg.sandbox.macSeatbelt":
+    "macOS Seatbelt：開啟隔離時 CLI 文件支援 OS 沙箱強制。",
+  "doctor.platformMatrix.msg.sandbox.linuxLandlock":
+    "Linux Landlock：開啟隔離時 CLI 文件支援 OS 沙箱強制。",
+  "doctor.platformMatrix.msg.sandbox.winSoftFail":
+    "Windows：CLI 可能接受沙箱設定但 soft-fail、無核心強制 — 請勿當作硬性安全邊界。",
+  "doctor.platformMatrix.msg.sandbox.platformSoft":
+    "此平台 OS 沙箱強制 soft-fail（CLI 可能在無隔離情況下繼續執行）。",
+  "doctor.platformMatrix.msg.sandbox.unknown":
+    "此平台的沙箱核心支援未知。",
+  "doctor.platformMatrix.msg.chrome.macOverlay":
+    "macOS Overlay 標題列 + 交通燈（tauri.macos.conf）。",
+  "doctor.platformMatrix.msg.chrome.winFrameless":
+    "Windows 無邊框自繪窗控（最小化 / 最大化 / 關閉）— tauri.windows.conf。",
+  "doctor.platformMatrix.msg.chrome.linuxDecorated":
+    "Linux 使用標準視窗裝飾（基礎 tauri.conf）。",
+  "doctor.platformMatrix.msg.chrome.unknown":
+    "此平台的視窗裝飾佈局未分類。",
+  "doctor.platformMatrix.msg.update.silent":
+    "已簽名發行路徑：支援應用內靜默自動更新。",
+  "doctor.platformMatrix.msg.update.manual":
+    "手動 / GitHub 更新路徑（本機、未簽名或外掛關閉）— 開啟 Releases；不宣稱靜默安裝。",
+  "doctor.platformMatrix.msg.update.unsupported":
+    "此安裝包類型不支援靜默自動更新（例如 Linux .deb/.rpm）— 請手動下載。",
+  "doctor.platformMatrix.msg.update.hostOnly":
+    "未在桌面應用宿主中執行 — 自動更新不適用。",
+  "doctor.platformMatrix.msg.update.unknown":
+    "更新通道尚未回報 — 請勿假定靜默安裝。",
+  "doctor.platformMatrix.msg.media.loopback":
+    "本機媒體走迴路 HTTP（127.0.0.1）並經 path-scope 白名單 — 產品路徑不用 raw media://。",
+  "doctor.platformMatrix.msg.media.unavailable":
+    "媒體迴路端點不可用 — 宿主媒體服務就緒前預覽可能 soft-fail。",
+  "doctor.platformMatrix.msg.media.unknown":
+    "此平台的媒體迴路能力未分類。",
+
   "reliability.title": "可靠性",
   "reliability.close": "關閉可靠性中心",
   "reliability.lead":

--- a/src/lib/doctorPlatformMatrix.test.ts
+++ b/src/lib/doctorPlatformMatrix.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import {
+  DOCTOR_PLATFORM_MATRIX_ROW_IDS,
+  buildDoctorPlatformMatrix,
+  countDoctorPlatformMatrix,
+  doctorPlatformCellStatusKey,
+  doctorPlatformCellTone,
+  normalizeDoctorPlatform,
+  normalizeDoctorUpdateChannel,
+} from "./doctorPlatformMatrix";
+
+describe("normalizeDoctorPlatform", () => {
+  it("maps mac aliases", () => {
+    expect(normalizeDoctorPlatform("mac")).toBe("mac");
+    expect(normalizeDoctorPlatform("macOS")).toBe("mac");
+    expect(normalizeDoctorPlatform("darwin")).toBe("mac");
+  });
+
+  it("maps win / linux aliases", () => {
+    expect(normalizeDoctorPlatform("win")).toBe("win");
+    expect(normalizeDoctorPlatform("Windows")).toBe("win");
+    expect(normalizeDoctorPlatform("linux")).toBe("linux");
+  });
+
+  it("unknown / empty → other", () => {
+    expect(normalizeDoctorPlatform(null)).toBe("other");
+    expect(normalizeDoctorPlatform("")).toBe("other");
+    expect(normalizeDoctorPlatform("freebsd")).toBe("other");
+  });
+});
+
+describe("normalizeDoctorUpdateChannel", () => {
+  it("normalizes silent / auto", () => {
+    expect(normalizeDoctorUpdateChannel("silent")).toBe("silent");
+    expect(normalizeDoctorUpdateChannel("auto")).toBe("silent");
+  });
+
+  it("normalizes manual tokens", () => {
+    expect(normalizeDoctorUpdateChannel("github_manual")).toBe("github_manual");
+    expect(normalizeDoctorUpdateChannel("manual_github")).toBe("github_manual");
+    expect(normalizeDoctorUpdateChannel("manual")).toBe("github_manual");
+  });
+
+  it("does not invent from unknown strings", () => {
+    expect(normalizeDoctorUpdateChannel(null)).toBe("unknown");
+    expect(normalizeDoctorUpdateChannel("nightly")).toBe("unknown");
+    expect(normalizeDoctorUpdateChannel("")).toBe("unknown");
+  });
+});
+
+describe("buildDoctorPlatformMatrix", () => {
+  it("returns all six rows in stable order", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "mac",
+      cliFound: true,
+      sandboxProfile: "workspace",
+      updateChannel: "silent",
+    });
+    expect(m.rows.map((r) => r.rowId)).toEqual([
+      ...DOCTOR_PLATFORM_MATRIX_ROW_IDS,
+    ]);
+    expect(m.platform).toBe("mac");
+  });
+
+  it("mac: seatbelt pass, overlay chrome, silent update", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "mac",
+      cliFound: true,
+      sandboxProfile: "strict",
+      updateChannel: "silent",
+    });
+    const byId = Object.fromEntries(m.rows.map((r) => [r.rowId, r]));
+    expect(byId.platform?.status).toBe("pass");
+    expect(byId.cli_path_probe?.status).toBe("pass");
+    expect(byId.sandbox_enforcement).toMatchObject({
+      status: "pass",
+      messageKey: "doctor.platformMatrix.msg.sandbox.macSeatbelt",
+    });
+    expect(byId.window_chrome).toMatchObject({
+      status: "pass",
+      messageKey: "doctor.platformMatrix.msg.chrome.macOverlay",
+    });
+    expect(byId.auto_update?.status).toBe("pass");
+    expect(byId.media_loopback?.status).toBe("pass");
+  });
+
+  it("windows: sandbox soft-fail warn when isolation requested", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "win",
+      cliFound: true,
+      sandboxProfile: "workspace",
+      updateChannel: "silent",
+    });
+    const sandbox = m.rows.find((r) => r.rowId === "sandbox_enforcement");
+    expect(sandbox).toMatchObject({
+      status: "warn",
+      messageKey: "doctor.platformMatrix.msg.sandbox.winSoftFail",
+    });
+    const chrome = m.rows.find((r) => r.rowId === "window_chrome");
+    expect(chrome).toMatchObject({
+      status: "pass",
+      messageKey: "doctor.platformMatrix.msg.chrome.winFrameless",
+    });
+  });
+
+  it("linux: landlock note when isolation requested", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "linux",
+      cliFound: true,
+      sandboxProfile: "read-only",
+      updateChannel: "github_manual",
+    });
+    const sandbox = m.rows.find((r) => r.rowId === "sandbox_enforcement");
+    expect(sandbox).toMatchObject({
+      status: "pass",
+      messageKey: "doctor.platformMatrix.msg.sandbox.linuxLandlock",
+    });
+    const chrome = m.rows.find((r) => r.rowId === "window_chrome");
+    expect(chrome?.messageKey).toBe(
+      "doctor.platformMatrix.msg.chrome.linuxDecorated",
+    );
+    const update = m.rows.find((r) => r.rowId === "auto_update");
+    expect(update).toMatchObject({
+      status: "warn",
+      messageKey: "doctor.platformMatrix.msg.update.manual",
+    });
+  });
+
+  it("sandbox off → na (not requested)", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "win",
+      sandboxProfile: "off",
+    });
+    const sandbox = m.rows.find((r) => r.rowId === "sandbox_enforcement");
+    expect(sandbox).toMatchObject({
+      status: "na",
+      messageKey: "doctor.platformMatrix.msg.sandbox.off",
+    });
+  });
+
+  it("does not invent CLI found / update channel", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "mac",
+      // cliFound / updateChannel omitted
+    });
+    const cli = m.rows.find((r) => r.rowId === "cli_path_probe");
+    expect(cli?.status).toBe("unknown");
+    const update = m.rows.find((r) => r.rowId === "auto_update");
+    expect(update?.status).toBe("unknown");
+  });
+
+  it("cli missing → warn", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "linux",
+      cliFound: false,
+    });
+    expect(
+      m.rows.find((r) => r.rowId === "cli_path_probe")?.status,
+    ).toBe("warn");
+  });
+
+  it("mediaLoopback false → warn without inventing pass", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "mac",
+      mediaLoopback: false,
+    });
+    expect(
+      m.rows.find((r) => r.rowId === "media_loopback"),
+    ).toMatchObject({
+      status: "warn",
+      messageKey: "doctor.platformMatrix.msg.media.unavailable",
+    });
+  });
+
+  it("update unsupported / host_only honesty", () => {
+    const unsupported = buildDoctorPlatformMatrix({
+      platform: "linux",
+      updateChannel: "unsupported",
+    });
+    expect(
+      unsupported.rows.find((r) => r.rowId === "auto_update"),
+    ).toMatchObject({
+      status: "warn",
+      messageKey: "doctor.platformMatrix.msg.update.unsupported",
+    });
+
+    const hostOnly = buildDoctorPlatformMatrix({
+      platform: "mac",
+      updateChannel: "host_only",
+    });
+    expect(
+      hostOnly.rows.find((r) => r.rowId === "auto_update"),
+    ).toMatchObject({
+      status: "na",
+      messageKey: "doctor.platformMatrix.msg.update.hostOnly",
+    });
+  });
+
+  it("other platform → unknown platform / chrome / media design", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "freebsd",
+      cliFound: true,
+      sandboxProfile: "workspace",
+    });
+    expect(m.platform).toBe("other");
+    expect(m.rows.find((r) => r.rowId === "platform")?.status).toBe("unknown");
+    expect(m.rows.find((r) => r.rowId === "window_chrome")?.status).toBe(
+      "unknown",
+    );
+    expect(m.rows.find((r) => r.rowId === "sandbox_enforcement")?.status).toBe(
+      "unknown",
+    );
+    expect(m.rows.find((r) => r.rowId === "media_loopback")?.status).toBe(
+      "unknown",
+    );
+  });
+});
+
+describe("countDoctorPlatformMatrix / status helpers", () => {
+  it("counts statuses", () => {
+    const m = buildDoctorPlatformMatrix({
+      platform: "win",
+      cliFound: false,
+      sandboxProfile: "workspace",
+      updateChannel: "github_manual",
+    });
+    const c = countDoctorPlatformMatrix(m);
+    expect(c.total).toBe(6);
+    expect(c.warn).toBeGreaterThanOrEqual(2); // cli + sandbox + maybe update
+    expect(c.pass + c.warn + c.na + c.unknown).toBe(6);
+  });
+
+  it("maps status keys and tones", () => {
+    expect(doctorPlatformCellStatusKey("pass")).toBe(
+      "doctor.platformMatrix.status.pass",
+    );
+    expect(doctorPlatformCellStatusKey("na")).toBe(
+      "doctor.platformMatrix.status.na",
+    );
+    expect(doctorPlatformCellTone("pass")).toBe("ok");
+    expect(doctorPlatformCellTone("warn")).toBe("warn");
+    expect(doctorPlatformCellTone("na")).toBe("na");
+    expect(doctorPlatformCellTone("unknown")).toBe("unknown");
+  });
+
+  it("empty matrix counts zero", () => {
+    expect(countDoctorPlatformMatrix(null)).toEqual({
+      pass: 0,
+      warn: 0,
+      na: 0,
+      unknown: 0,
+      total: 0,
+    });
+  });
+});

--- a/src/lib/doctorPlatformMatrix.ts
+++ b/src/lib/doctorPlatformMatrix.ts
@@ -1,0 +1,443 @@
+/**
+ * Doctor platform capability matrix — pure honesty helpers.
+ *
+ * Surfaces macOS / Windows / Linux differences for:
+ * path probe, sandbox kernel enforcement, window chrome, auto-update path,
+ * and media loopback delivery. Complements Windows day-use checklist without
+ * duplicating install/smoke steps.
+ *
+ * Never invents probe results: unknown inputs → `unknown` cells.
+ * Status vocabulary: pass | warn | na | unknown.
+ */
+
+import type { MessageKey } from "@/i18n";
+import type { AppPlatform } from "@/lib/appPlatform";
+import {
+  platformEnforcesOsSandbox,
+  sandboxIsolationActive,
+} from "@/lib/sandboxProfile";
+
+/** Stable matrix row ids (column 0 / capability). */
+export const DOCTOR_PLATFORM_MATRIX_ROW_IDS = [
+  "platform",
+  "cli_path_probe",
+  "sandbox_enforcement",
+  "window_chrome",
+  "auto_update",
+  "media_loopback",
+] as const;
+
+export type DoctorPlatformMatrixRowId =
+  (typeof DOCTOR_PLATFORM_MATRIX_ROW_IDS)[number];
+
+/** Cell status — no invented fail; use warn for soft-fail honesty. */
+export type DoctorPlatformCellStatus = "pass" | "warn" | "na" | "unknown";
+
+/**
+ * Product update channel tokens accepted from Host / useUpdater.
+ * Aligns with updater_status + app-update honesty (when present).
+ */
+export type DoctorUpdateChannel =
+  | "silent"
+  | "auto"
+  | "github_manual"
+  | "manual_github"
+  | "manual"
+  | "unsupported"
+  | "host_only"
+  | "unknown";
+
+export type DoctorPlatformMatrixCell = {
+  rowId: DoctorPlatformMatrixRowId;
+  status: DoctorPlatformCellStatus;
+  /** i18n key for the capability label (row name). */
+  labelKey: MessageKey;
+  /** i18n key for the detail / honesty message. */
+  messageKey: MessageKey;
+};
+
+export type DoctorPlatformMatrix = {
+  /** Normalized platform id used for all cells. */
+  platform: AppPlatform;
+  rows: DoctorPlatformMatrixCell[];
+};
+
+export type BuildDoctorPlatformMatrixInput = {
+  /** App platform token (`mac` | `win` | `linux` | `other` / aliases). */
+  platform?: string | null;
+  /** Whether the Grok Build CLI path probe found a binary. */
+  cliFound?: boolean | null;
+  /** Effective sandbox profile (global or project-resolved). */
+  sandboxProfile?: unknown;
+  /**
+   * App auto-update channel honesty (`silent` / `github_manual` / …).
+   * Omit or `unknown` → do not invent silent install.
+   */
+  updateChannel?: string | null;
+  /**
+   * Optional live media loopback probe. Omit → platform-design honesty only
+   * (do not invent that the server is up).
+   */
+  mediaLoopback?: boolean | null;
+};
+
+const ROW_LABEL_KEYS: Record<DoctorPlatformMatrixRowId, MessageKey> = {
+  platform: "doctor.platformMatrix.row.platform",
+  cli_path_probe: "doctor.platformMatrix.row.cliPathProbe",
+  sandbox_enforcement: "doctor.platformMatrix.row.sandboxEnforcement",
+  window_chrome: "doctor.platformMatrix.row.windowChrome",
+  auto_update: "doctor.platformMatrix.row.autoUpdate",
+  media_loopback: "doctor.platformMatrix.row.mediaLoopback",
+};
+
+/**
+ * Normalize platform tokens to AppPlatform.
+ * Accepts `mac` / `macos` / `darwin`, `win` / `windows`, `linux`, etc.
+ */
+export function normalizeDoctorPlatform(
+  platform: string | null | undefined,
+): AppPlatform {
+  if (platform == null) return "other";
+  const p = String(platform).trim().toLowerCase();
+  if (!p) return "other";
+  if (
+    p === "mac" ||
+    p === "macos" ||
+    p === "darwin" ||
+    p === "osx" ||
+    p === "apple"
+  ) {
+    return "mac";
+  }
+  if (p === "win" || p === "windows" || p === "win32" || p === "win64") {
+    return "win";
+  }
+  if (p === "linux" || p === "gnu/linux") {
+    return "linux";
+  }
+  return "other";
+}
+
+/** Normalize host / hook update channel strings without inventing. */
+export function normalizeDoctorUpdateChannel(
+  raw: string | null | undefined,
+): DoctorUpdateChannel {
+  const t = String(raw ?? "")
+    .trim()
+    .toLowerCase();
+  if (!t) return "unknown";
+  if (t === "silent" || t === "auto") return "silent";
+  if (t === "github_manual" || t === "manual_github" || t === "manual") {
+    return "github_manual";
+  }
+  if (t === "unsupported") return "unsupported";
+  if (t === "host_only" || t === "web") return "host_only";
+  if (t === "unknown") return "unknown";
+  return "unknown";
+}
+
+function cell(
+  rowId: DoctorPlatformMatrixRowId,
+  status: DoctorPlatformCellStatus,
+  messageKey: MessageKey,
+): DoctorPlatformMatrixCell {
+  return {
+    rowId,
+    status,
+    labelKey: ROW_LABEL_KEYS[rowId],
+    messageKey,
+  };
+}
+
+function platformRow(platform: AppPlatform): DoctorPlatformMatrixCell {
+  switch (platform) {
+    case "mac":
+      return cell("platform", "pass", "doctor.platformMatrix.msg.platform.mac");
+    case "win":
+      return cell("platform", "pass", "doctor.platformMatrix.msg.platform.win");
+    case "linux":
+      return cell(
+        "platform",
+        "pass",
+        "doctor.platformMatrix.msg.platform.linux",
+      );
+    case "other":
+    default:
+      return cell(
+        "platform",
+        "unknown",
+        "doctor.platformMatrix.msg.platform.unknown",
+      );
+  }
+}
+
+function cliPathProbeRow(
+  cliFound: boolean | null | undefined,
+): DoctorPlatformMatrixCell {
+  if (cliFound === true) {
+    return cell(
+      "cli_path_probe",
+      "pass",
+      "doctor.platformMatrix.msg.cli.found",
+    );
+  }
+  if (cliFound === false) {
+    return cell(
+      "cli_path_probe",
+      "warn",
+      "doctor.platformMatrix.msg.cli.missing",
+    );
+  }
+  return cell(
+    "cli_path_probe",
+    "unknown",
+    "doctor.platformMatrix.msg.cli.unknown",
+  );
+}
+
+/**
+ * Sandbox kernel honesty from CLI docs:
+ * - mac: Seatbelt enforcement when isolation requested
+ * - linux: Landlock enforcement when isolation requested
+ * - win / other: soft-fail (flag may be accepted, no kernel enforcement)
+ * - off / not requested: N/A
+ */
+function sandboxEnforcementRow(
+  platform: AppPlatform,
+  sandboxProfile: unknown,
+): DoctorPlatformMatrixCell {
+  if (!sandboxIsolationActive(sandboxProfile)) {
+    return cell(
+      "sandbox_enforcement",
+      "na",
+      "doctor.platformMatrix.msg.sandbox.off",
+    );
+  }
+
+  if (platform === "other") {
+    return cell(
+      "sandbox_enforcement",
+      "unknown",
+      "doctor.platformMatrix.msg.sandbox.unknown",
+    );
+  }
+
+  if (platform === "mac") {
+    return cell(
+      "sandbox_enforcement",
+      "pass",
+      "doctor.platformMatrix.msg.sandbox.macSeatbelt",
+    );
+  }
+  if (platform === "linux") {
+    return cell(
+      "sandbox_enforcement",
+      "pass",
+      "doctor.platformMatrix.msg.sandbox.linuxLandlock",
+    );
+  }
+  // Windows (and any non-enforcing known platform)
+  if (!platformEnforcesOsSandbox(platform)) {
+    return cell(
+      "sandbox_enforcement",
+      "warn",
+      "doctor.platformMatrix.msg.sandbox.winSoftFail",
+    );
+  }
+  return cell(
+    "sandbox_enforcement",
+    "warn",
+    "doctor.platformMatrix.msg.sandbox.platformSoft",
+  );
+}
+
+/**
+ * Window chrome from packaging configs:
+ * - mac: Overlay title bar + traffic lights
+ * - win: frameless custom chrome
+ * - linux: standard decorations (base tauri.conf)
+ */
+function windowChromeRow(platform: AppPlatform): DoctorPlatformMatrixCell {
+  switch (platform) {
+    case "mac":
+      return cell(
+        "window_chrome",
+        "pass",
+        "doctor.platformMatrix.msg.chrome.macOverlay",
+      );
+    case "win":
+      return cell(
+        "window_chrome",
+        "pass",
+        "doctor.platformMatrix.msg.chrome.winFrameless",
+      );
+    case "linux":
+      return cell(
+        "window_chrome",
+        "pass",
+        "doctor.platformMatrix.msg.chrome.linuxDecorated",
+      );
+    case "other":
+    default:
+      return cell(
+        "window_chrome",
+        "unknown",
+        "doctor.platformMatrix.msg.chrome.unknown",
+      );
+  }
+}
+
+/**
+ * Auto-update path honesty — echoes Host channel, never invents silent install.
+ */
+function autoUpdateRow(
+  channelRaw: string | null | undefined,
+): DoctorPlatformMatrixCell {
+  const channel = normalizeDoctorUpdateChannel(channelRaw);
+  switch (channel) {
+    case "silent":
+    case "auto":
+      return cell(
+        "auto_update",
+        "pass",
+        "doctor.platformMatrix.msg.update.silent",
+      );
+    case "github_manual":
+    case "manual_github":
+    case "manual":
+      return cell(
+        "auto_update",
+        "warn",
+        "doctor.platformMatrix.msg.update.manual",
+      );
+    case "unsupported":
+      return cell(
+        "auto_update",
+        "warn",
+        "doctor.platformMatrix.msg.update.unsupported",
+      );
+    case "host_only":
+      return cell(
+        "auto_update",
+        "na",
+        "doctor.platformMatrix.msg.update.hostOnly",
+      );
+    case "unknown":
+    default:
+      return cell(
+        "auto_update",
+        "unknown",
+        "doctor.platformMatrix.msg.update.unknown",
+      );
+  }
+}
+
+/**
+ * Media delivery: loopback HTTP is the product path on all desktop OSes.
+ * Optional live probe: true → pass, false → warn; omit → design honesty (pass
+ * on known desktop, unknown on other) without inventing server uptime.
+ */
+function mediaLoopbackRow(
+  platform: AppPlatform,
+  mediaLoopback: boolean | null | undefined,
+): DoctorPlatformMatrixCell {
+  if (mediaLoopback === true) {
+    return cell(
+      "media_loopback",
+      "pass",
+      "doctor.platformMatrix.msg.media.loopback",
+    );
+  }
+  if (mediaLoopback === false) {
+    return cell(
+      "media_loopback",
+      "warn",
+      "doctor.platformMatrix.msg.media.unavailable",
+    );
+  }
+  // No live probe — platform design honesty only.
+  if (platform === "mac" || platform === "win" || platform === "linux") {
+    return cell(
+      "media_loopback",
+      "pass",
+      "doctor.platformMatrix.msg.media.loopback",
+    );
+  }
+  return cell(
+    "media_loopback",
+    "unknown",
+    "doctor.platformMatrix.msg.media.unknown",
+  );
+}
+
+/**
+ * Build the Doctor platform capability matrix from known inputs only.
+ * Pure — no I/O, no invented probe results.
+ */
+export function buildDoctorPlatformMatrix(
+  input: BuildDoctorPlatformMatrixInput,
+): DoctorPlatformMatrix {
+  const platform = normalizeDoctorPlatform(input.platform);
+  const rows: DoctorPlatformMatrixCell[] = [
+    platformRow(platform),
+    cliPathProbeRow(input.cliFound),
+    sandboxEnforcementRow(platform, input.sandboxProfile),
+    windowChromeRow(platform),
+    autoUpdateRow(input.updateChannel),
+    mediaLoopbackRow(platform, input.mediaLoopback),
+  ];
+  return { platform, rows };
+}
+
+/** i18n key for a cell status badge. */
+export function doctorPlatformCellStatusKey(
+  status: DoctorPlatformCellStatus,
+): MessageKey {
+  switch (status) {
+    case "pass":
+      return "doctor.platformMatrix.status.pass";
+    case "warn":
+      return "doctor.platformMatrix.status.warn";
+    case "na":
+      return "doctor.platformMatrix.status.na";
+    case "unknown":
+      return "doctor.platformMatrix.status.unknown";
+  }
+}
+
+/**
+ * Map matrix status → Doctor check level class (ok / warn / muted).
+ * `na` and `unknown` use distinct modifiers for UI honesty.
+ */
+export function doctorPlatformCellTone(
+  status: DoctorPlatformCellStatus,
+): "ok" | "warn" | "na" | "unknown" {
+  if (status === "pass") return "ok";
+  if (status === "warn") return "warn";
+  if (status === "na") return "na";
+  return "unknown";
+}
+
+/** Count cells by status (for summary chips). */
+export function countDoctorPlatformMatrix(
+  matrix: DoctorPlatformMatrix | null | undefined,
+): {
+  pass: number;
+  warn: number;
+  na: number;
+  unknown: number;
+  total: number;
+} {
+  const rows = matrix?.rows ?? [];
+  let pass = 0;
+  let warn = 0;
+  let na = 0;
+  let unknown = 0;
+  for (const r of rows) {
+    if (r.status === "pass") pass += 1;
+    else if (r.status === "warn") warn += 1;
+    else if (r.status === "na") na += 1;
+    else unknown += 1;
+  }
+  return { pass, warn, na, unknown, total: rows.length };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11843,6 +11843,87 @@ html[data-composer-min-rows="8"] .composer__input {
   font-size: 11px;
 }
 
+.doctor-platform-matrix {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated, var(--bg-main));
+}
+.doctor-platform-matrix__head {
+  margin-bottom: 8px;
+}
+.doctor-platform-matrix__title {
+  margin: 0 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+}
+.doctor-platform-matrix__hint {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.45;
+  opacity: 0.72;
+}
+.doctor-platform-matrix__table-wrap {
+  overflow-x: auto;
+}
+.doctor-platform-matrix__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.doctor-platform-matrix__table th,
+.doctor-platform-matrix__table td {
+  text-align: left;
+  vertical-align: top;
+  padding: 6px 8px;
+  border-top: 1px solid var(--border-subtle);
+}
+.doctor-platform-matrix__table thead th {
+  border-top: none;
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.7;
+  white-space: nowrap;
+}
+.doctor-platform-matrix__table tbody th {
+  font-weight: 500;
+  white-space: nowrap;
+  width: 1%;
+}
+.doctor-platform-matrix__detail {
+  line-height: 1.4;
+  opacity: 0.9;
+}
+.doctor-platform-matrix__badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: var(--radius-full, 999px);
+  white-space: nowrap;
+}
+.doctor-platform-matrix__badge--ok {
+  color: var(--success);
+  background: var(--success-muted);
+}
+.doctor-platform-matrix__badge--warn {
+  color: var(--warning);
+  background: var(--warning-muted);
+}
+.doctor-platform-matrix__badge--na {
+  color: var(--fg-muted, inherit);
+  background: var(--bg-main);
+  border: 1px solid var(--border-subtle);
+  opacity: 0.85;
+}
+.doctor-platform-matrix__badge--unknown {
+  color: var(--fg-muted, inherit);
+  background: var(--bg-main);
+  border: 1px dashed var(--border-subtle);
+  opacity: 0.9;
+}
+
 .doctor-checks {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary

- Add pure `src/lib/doctorPlatformMatrix.ts` + tests: platform capability rows for `platform`, `cli_path_probe`, `sandbox_enforcement`, `window_chrome`, `auto_update`, `media_loopback` with `pass | warn | na | unknown` cells and i18n message keys.
- Wire a **Platform matrix** table into Doctor modal (honest macOS Seatbelt / Linux Landlock / Windows sandbox soft-fail; Overlay vs frameless vs decorated chrome; update channel honesty; media loopback design). Complements Windows day-use checklist without duplicating install smoke steps.
- i18n en/zh/zh-TW + CHANGELOG. Never invents probe results.

## Test plan

- [x] `pnpm test -- src/lib/doctorPlatformMatrix.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: open Doctor on mac/win/linux (or UA-spoof) and confirm matrix labels match platform; Windows + sandbox on shows soft-fail warn; sandbox off shows N/A.