### PR TITLE
feat(resources): open-in-editor soft-fail honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Open-in-editor / reveal soft-fail honesty**: classify Host `open_in_editor` / `path_reveal` / `path_open` failures into stable kinds (`no_editor` · `not_found` · `path_denied` · `host_only` · `cancelled` · `other`) so ResourceViewer, Open Location, and file chips show i18n toasts instead of raw `Error:` dumps; soft preflight `planOpenInEditor`; Settings → Open files with empty / preferred-missing honesty when no editors are detected. Pure `openEditorHonesty` helpers + tests; en/zh/zh-TW. No `window.confirm`.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -257,6 +257,10 @@ import {
   type TasksBindCwdResult,
 } from "@/lib/tasksPanelPro";
 import {
+  formatOpenEditorErrorMessage,
+  resolveOpenEditorError,
+} from "@/lib/openEditorHonesty";
+import {
   loadTrayBusyBadgePref,
   saveTrayBusyBadgePref,
 } from "@/lib/trayBusyBadgePref";
@@ -18339,7 +18343,13 @@ export default function App() {
                       path={activeProject.path}
                       target={defaultOpenTarget || "finder"}
                       onTargetChange={persistOpenTarget}
-                      onOpenError={(e) => setLocalError(e)}
+                      onOpenError={(e) => {
+                        const resolved = resolveOpenEditorError(e);
+                        if (resolved.silent) return;
+                        setLocalError(
+                          formatOpenEditorErrorMessage(resolved, tr),
+                        );
+                      }}
                       onCopied={() => {
                         setToast(tr("attach.copyPath") + " ✓");
                         window.setTimeout(() => setToast(null), 1600);

--- a/src/components/FilePathCard.tsx
+++ b/src/components/FilePathCard.tsx
@@ -15,6 +15,10 @@ import {
   normalizePathToken,
 } from "@/lib/pathRefs";
 import {
+  resolveOpenEditorError,
+  resolveRevealError,
+} from "@/lib/openEditorHonesty";
+import {
   IconClose,
   IconCopy,
   IconExternalLink,
@@ -45,6 +49,14 @@ export interface FilePathCardLabels {
   typeFile?: string;
   typeUrl?: string;
   typeDir?: string;
+  /** Soft-fail copy for open/reveal (classified honesty). */
+  errNotFound?: string;
+  errPathDenied?: string;
+  errHostOnly?: string;
+  errNoEditor?: string;
+  errCancelled?: string;
+  errOther?: string;
+  errRevealOther?: string;
 }
 
 export interface FilePathCardProps {
@@ -66,6 +78,8 @@ export interface FilePathCardProps {
     url?: string;
     title?: string;
   }) => void;
+  /** Optional toast / banner when open-external or reveal soft-fails. */
+  onOpenError?: (message: string) => void;
 }
 
 function kindLabel(path: string, kind: FilePathCardKind): string {
@@ -83,6 +97,36 @@ function relativeToken(path: string): string | null {
   return t;
 }
 
+function filePathCardErrLabel(
+  labels: FilePathCardLabels,
+  kind:
+    | "no_editor"
+    | "not_found"
+    | "path_denied"
+    | "host_only"
+    | "cancelled"
+    | "other",
+  forReveal = false,
+): string {
+  switch (kind) {
+    case "no_editor":
+      return labels.errNoEditor || "No code editor available";
+    case "not_found":
+      return labels.errNotFound || "File not found";
+    case "path_denied":
+      return labels.errPathDenied || "Path denied";
+    case "host_only":
+      return labels.errHostOnly || "Desktop app required";
+    case "cancelled":
+      return labels.errCancelled || "";
+    case "other":
+    default:
+      return forReveal
+        ? labels.errRevealOther || labels.errOther || "Could not reveal"
+        : labels.errOther || "Could not open";
+  }
+}
+
 export function FilePathCard({
   path,
   absolutePath,
@@ -91,6 +135,7 @@ export function FilePathCard({
   subtitle: _subtitle,
   labels,
   onOpenInPanel,
+  onOpenError,
 }: FilePathCardProps) {
   void _subtitle; // callers may pass; card no longer shows path/subtitle
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
@@ -228,18 +273,26 @@ export function FilePathCard({
       window.open(path, "_blank", "noopener,noreferrer");
       return;
     }
-    if (!api.isTauri()) return;
+    if (!api.isTauri()) {
+      onOpenError?.(filePathCardErrLabel(labels, "host_only"));
+      return;
+    }
     if (busy) return;
     setBusy(true);
     try {
       const abs = resolvedAbs || (await resolveAbsolute());
       if (!abs) {
-        console.error("[FilePathCard] openExternal: file not found", path);
+        setMissing(true);
+        onOpenError?.(filePathCardErrLabel(labels, "not_found"));
         return;
       }
       await api.pathOpen(abs);
     } catch (e) {
-      console.error("[FilePathCard] openExternal failed", e);
+      // path_open shares reveal-like Host phrases; open classifier is a superset.
+      const resolved = resolveOpenEditorError(e);
+      if (resolved.silent) return;
+      // Prefer classified label over raw Error dumps (never String(e)).
+      onOpenError?.(filePathCardErrLabel(labels, resolved.kind));
     } finally {
       setBusy(false);
     }
@@ -247,18 +300,24 @@ export function FilePathCard({
 
   const reveal = async () => {
     if (isUrl) return;
-    if (!api.isTauri()) return;
+    if (!api.isTauri()) {
+      onOpenError?.(filePathCardErrLabel(labels, "host_only"));
+      return;
+    }
     if (busy) return;
     setBusy(true);
     try {
       const abs = resolvedAbs || (await resolveAbsolute());
       if (!abs) {
-        console.error("[FilePathCard] reveal: file not found", path);
+        setMissing(true);
+        onOpenError?.(filePathCardErrLabel(labels, "not_found"));
         return;
       }
       await api.pathReveal(abs);
     } catch (e) {
-      console.error("[FilePathCard] reveal failed", e);
+      const resolved = resolveRevealError(e);
+      if (resolved.silent) return;
+      onOpenError?.(filePathCardErrLabel(labels, resolved.kind, true));
     } finally {
       setBusy(false);
     }

--- a/src/components/ResourceViewer.tsx
+++ b/src/components/ResourceViewer.tsx
@@ -13,13 +13,20 @@ import {
   type ReactNode,
 } from "react";
 import * as api from "@/lib/api";
-import { createT, type Locale } from "@/i18n";
+import { createT, type Locale, type MessageKey } from "@/i18n";
 import { resolvePreviewSrc } from "@/lib/filePreviewSrc";
 import {
   formatMediaLoadErrorMessage,
   mediaLoadErrorLabelMap,
   resolveMediaLoadError,
 } from "@/lib/mediaLoadPro";
+import {
+  formatOpenEditorErrorMessage,
+  formatRevealErrorMessage,
+  planOpenInEditor,
+  resolveOpenEditorError,
+  resolveRevealError,
+} from "@/lib/openEditorHonesty";
 import { HtmlBrowser } from "@/components/HtmlBrowser";
 import { EmbeddedBrowser } from "@/components/EmbeddedBrowser";
 import { MarkdownBody } from "@/components/MarkdownBody";
@@ -61,7 +68,6 @@ import { OpenLocationButton } from "@/components/OpenLocationButton";
 import { Tip } from "@/components/ui/tooltip";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import { GlassModal } from "@/components/GlassModal";
-import type { MessageKey } from "@/i18n";
 import {
   buildUnifiedDiff,
   changeListKey,
@@ -847,23 +853,46 @@ export function ResourceViewer({
     [projectPath],
   );
 
-  const openChangeInEditor = useCallback(async (path: string) => {
-    if (!path || !api.isTauri()) return;
-    try {
-      await api.openInEditor({ path });
-    } catch (e) {
-      setError(String(e));
-    }
-  }, []);
+  const openChangeInEditor = useCallback(
+    async (path: string) => {
+      const plan = planOpenInEditor({
+        path,
+        isTauri: api.isTauri(),
+      });
+      if (!plan.ok) {
+        if (plan.kind === "cancelled") return;
+        setError(tr(plan.messageKey as MessageKey));
+        return;
+      }
+      try {
+        await api.openInEditor({ path: plan.path });
+      } catch (e) {
+        const resolved = resolveOpenEditorError(e);
+        if (resolved.silent) return;
+        setError(formatOpenEditorErrorMessage(resolved, tr));
+      }
+    },
+    [tr],
+  );
 
-  const revealChangePath = useCallback(async (path: string) => {
-    if (!path || !api.isTauri()) return;
-    try {
-      await api.pathReveal(path);
-    } catch (e) {
-      setError(String(e));
-    }
-  }, []);
+  const revealChangePath = useCallback(
+    async (path: string) => {
+      if (!path) return;
+      if (!api.isTauri()) {
+        const resolved = resolveRevealError({ code: "host_only" });
+        setError(formatRevealErrorMessage(resolved, tr));
+        return;
+      }
+      try {
+        await api.pathReveal(path);
+      } catch (e) {
+        const resolved = resolveRevealError(e);
+        if (resolved.silent) return;
+        setError(formatRevealErrorMessage(resolved, tr));
+      }
+    },
+    [tr],
+  );
 
   const copyChangePath = useCallback(async (path: string) => {
     if (!path) return;
@@ -3441,7 +3470,13 @@ export function ResourceViewer({
                   /* ignore */
                 }
               }}
-              onOpenError={(e) => setError(e)}
+              onOpenError={(e) => {
+                // OpenLocationButton may reveal, system-open, or open-in-editor.
+                // Prefer open-editor classifier (superset); reveal-only phrases map fine.
+                const resolved = resolveOpenEditorError(e);
+                if (resolved.silent) return;
+                setError(formatOpenEditorErrorMessage(resolved, tr));
+              }}
               compact
               platform={detectAppPlatform()}
               labels={{

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -73,6 +73,7 @@ import {
   toggleAllowedTool,
 } from "@/lib/allowedTools";
 import { detectAppPlatform } from "@/lib/appPlatform";
+import { resolveOpenEditorEmptyState } from "@/lib/openEditorHonesty";
 import {
   RECOMMENDED_SANDBOX_PROFILE,
   SANDBOX_MIN_CLI,
@@ -4631,6 +4632,26 @@ export function SettingsPage({
                     <div className="settings-row__desc">
                       {t("settings.openTargetDesc")}
                     </div>
+                    {(() => {
+                      const available = editors.filter((e) => e.available);
+                      const empty = resolveOpenEditorEmptyState({
+                        editorsFound: available.length,
+                        preferred: defaultOpenTarget,
+                        availableIds: available.map((e) => e.id),
+                      });
+                      if (!empty.messageKey) return null;
+                      return (
+                        <div
+                          className={
+                            "settings-row__hint" +
+                            (empty.severity === "warn" ? " is-danger" : "")
+                          }
+                          role="status"
+                        >
+                          {t(empty.messageKey as MessageKey)}
+                        </div>
+                      );
+                    })()}
                   </div>
                   <Select
                     value={defaultOpenTarget}

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -169,6 +169,13 @@ export const MarkdownChat = memo(function MarkdownChat({
       typeFile: tr("attach.typeFile"),
       typeUrl: tr("attach.typeUrl"),
       typeDir: tr("attach.typeDir"),
+      errNotFound: tr("resources.openErr.notFound"),
+      errPathDenied: tr("resources.openErr.pathDenied"),
+      errHostOnly: tr("resources.openErr.hostOnly"),
+      errNoEditor: tr("resources.openErr.noEditor"),
+      errCancelled: tr("resources.openErr.cancelled"),
+      errOther: tr("resources.openErr.other"),
+      errRevealOther: tr("resources.revealErr.other"),
     }),
     [tr],
   );

--- a/src/components/ui/message-response.tsx
+++ b/src/components/ui/message-response.tsx
@@ -84,6 +84,13 @@ function MessageResponseImpl({
       typeFile: tr("attach.typeFile"),
       typeUrl: tr("attach.typeUrl"),
       typeDir: tr("attach.typeDir"),
+      errNotFound: tr("resources.openErr.notFound"),
+      errPathDenied: tr("resources.openErr.pathDenied"),
+      errHostOnly: tr("resources.openErr.hostOnly"),
+      errNoEditor: tr("resources.openErr.noEditor"),
+      errCancelled: tr("resources.openErr.cancelled"),
+      errOther: tr("resources.openErr.other"),
+      errRevealOther: tr("resources.revealErr.other"),
     }),
     [tr],
   );

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -518,6 +518,22 @@ const en = {
   "resources.openDefault": "Open with system default",
   "resources.revealFolder": "Reveal in file manager",
   "resources.noEditors": "No code editors detected on this machine",
+  "resources.openErr.noEditor":
+    "No code editor available. Install one or choose Finder/Explorer in Settings.",
+  "resources.openErr.notFound":
+    "File not found — it may have been moved or deleted.",
+  "resources.openErr.pathDenied":
+    "This path cannot be opened (permission or allowlist).",
+  "resources.openErr.hostOnly": "Open in editor needs the desktop app.",
+  "resources.openErr.cancelled": "Open cancelled.",
+  "resources.openErr.other": "Could not open in editor.",
+  "resources.revealErr.notFound":
+    "Path not found — nothing to reveal in the file manager.",
+  "resources.revealErr.pathDenied":
+    "This path cannot be revealed (permission or allowlist).",
+  "resources.revealErr.hostOnly": "Reveal needs the desktop app.",
+  "resources.revealErr.cancelled": "Reveal cancelled.",
+  "resources.revealErr.other": "Could not reveal in file manager.",
   "resources.needProject": "Add or select a project to browse files here.",
   "resources.emptyPreview": "No file open",
   "resources.emptyPreviewHint":
@@ -3010,6 +3026,10 @@ const en = {
   "settings.openTargetDesc":
     "Default app when opening a path from the resource pane",
   "settings.openFinder": "Finder / Explorer",
+  "settings.openTargetEmpty":
+    "No code editors detected — Finder/Explorer still works. Install VS Code, Cursor, or another editor to open files there.",
+  "settings.openTargetPreferredMissing":
+    "Preferred editor is not installed or not detected. Finder/Explorer will be used until you pick another.",
 
   "prov.emptyTitle": "No providers yet",
   "prov.detailEmpty": "Select a provider or add a new one.",
@@ -6622,6 +6642,18 @@ const zh: Record<MessageKey, string> = {
   "resources.openDefault": "用系统默认应用打开",
   "resources.revealFolder": "在文件管理器中显示",
   "resources.noEditors": "未检测到本机代码编辑器",
+  "resources.openErr.noEditor":
+    "没有可用的代码编辑器。请安装编辑器，或在设置中选择访达/资源管理器。",
+  "resources.openErr.notFound": "找不到该文件 — 可能已被移动或删除。",
+  "resources.openErr.pathDenied": "无法打开此路径（权限或白名单限制）。",
+  "resources.openErr.hostOnly": "在编辑器中打开需要桌面端应用。",
+  "resources.openErr.cancelled": "已取消打开。",
+  "resources.openErr.other": "无法在编辑器中打开。",
+  "resources.revealErr.notFound": "找不到该路径 — 无法在文件管理器中显示。",
+  "resources.revealErr.pathDenied": "无法显示此路径（权限或白名单限制）。",
+  "resources.revealErr.hostOnly": "在文件管理器中显示需要桌面端应用。",
+  "resources.revealErr.cancelled": "已取消显示。",
+  "resources.revealErr.other": "无法在文件管理器中显示。",
   "resources.needProject": "添加或选择项目后，即可在此浏览文件。",
   "resources.emptyPreview": "尚未打开文件",
   "resources.emptyPreviewHint": "从右侧文件树选择文件进行预览。",
@@ -9021,6 +9053,10 @@ const zh: Record<MessageKey, string> = {
   "settings.openTarget": "打开文件方式",
   "settings.openTargetDesc": "资源面板中打开路径时的默认应用",
   "settings.openFinder": "访达 / 资源管理器",
+  "settings.openTargetEmpty":
+    "未检测到代码编辑器 — 访达/资源管理器仍可用。安装 VS Code、Cursor 等编辑器后即可在此打开文件。",
+  "settings.openTargetPreferredMissing":
+    "首选编辑器未安装或未检测到。在重新选择之前将使用访达/资源管理器。",
 
   "prov.emptyTitle": "暂无提供商",
   "prov.detailEmpty": "选择左侧提供商，或添加新的。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -477,6 +477,18 @@ export const zhTW: Record<MessageKey, string> = {
   "resources.openDefault": "以系統預設應用程式開啟",
   "resources.revealFolder": "在檔案管理員中顯示",
   "resources.noEditors": "未偵測到本機程式碼編輯器",
+  "resources.openErr.noEditor":
+    "沒有可用的程式碼編輯器。請安裝編輯器，或在設定中選擇 Finder／檔案總管。",
+  "resources.openErr.notFound": "找不到該檔案 — 可能已被移動或刪除。",
+  "resources.openErr.pathDenied": "無法開啟此路徑（權限或白名單限制）。",
+  "resources.openErr.hostOnly": "在編輯器中開啟需要桌面端應用程式。",
+  "resources.openErr.cancelled": "已取消開啟。",
+  "resources.openErr.other": "無法在編輯器中開啟。",
+  "resources.revealErr.notFound": "找不到該路徑 — 無法在檔案管理員中顯示。",
+  "resources.revealErr.pathDenied": "無法顯示此路徑（權限或白名單限制）。",
+  "resources.revealErr.hostOnly": "在檔案管理員中顯示需要桌面端應用程式。",
+  "resources.revealErr.cancelled": "已取消顯示。",
+  "resources.revealErr.other": "無法在檔案管理員中顯示。",
   "resources.needProject": "新增或選擇專案後，即可在此瀏覽檔案。",
   "resources.emptyPreview": "尚未開啟檔案",
   "resources.emptyPreviewHint": "從右側檔案樹選擇檔案進行預覽。",
@@ -2876,6 +2888,10 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.openTarget": "開啟檔案方式",
   "settings.openTargetDesc": "資源面板中開啟路徑時的預設應用程式",
   "settings.openFinder": "Finder / 檔案總管",
+  "settings.openTargetEmpty":
+    "未偵測到程式碼編輯器 — Finder／檔案總管仍可用。安裝 VS Code、Cursor 等編輯器後即可在此開啟檔案。",
+  "settings.openTargetPreferredMissing":
+    "偏好的編輯器未安裝或未偵測到。在重新選擇之前將使用 Finder／檔案總管。",
 
   "prov.emptyTitle": "尚無供應商",
   "prov.detailEmpty": "選擇左側供應商，或新增一個。",

--- a/src/lib/openEditorHonesty.test.ts
+++ b/src/lib/openEditorHonesty.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyOpenEditorError,
+  classifyRevealError,
+  formatOpenEditorErrorMessage,
+  openEditorErrorMessageKey,
+  planOpenInEditor,
+  resolveOpenEditorEmptyState,
+  resolveOpenEditorError,
+  resolveRevealError,
+  revealErrorMessageKey,
+} from "./openEditorHonesty";
+
+describe("classifyOpenEditorError", () => {
+  it("maps explicit codes", () => {
+    expect(classifyOpenEditorError({ code: "no_editor" })).toBe("no_editor");
+    expect(classifyOpenEditorError({ code: "not_found" })).toBe("not_found");
+    expect(classifyOpenEditorError({ code: "path_denied" })).toBe(
+      "path_denied",
+    );
+    expect(classifyOpenEditorError({ code: "host_only" })).toBe("host_only");
+    expect(classifyOpenEditorError({ code: "cancelled" })).toBe("cancelled");
+    expect(classifyOpenEditorError({ code: "need_tauri" })).toBe("host_only");
+    expect(classifyOpenEditorError({ code: "path_not_allowed" })).toBe(
+      "path_denied",
+    );
+  });
+
+  it("maps Host path not found", () => {
+    expect(classifyOpenEditorError("path not found: /tmp/x.ts")).toBe(
+      "not_found",
+    );
+    expect(classifyOpenEditorError("empty path")).toBe("not_found");
+    expect(classifyOpenEditorError(new Error("ENOENT: no such file"))).toBe(
+      "not_found",
+    );
+  });
+
+  it("maps missing editor id / failed open editor", () => {
+    expect(classifyOpenEditorError("cursor not found")).toBe("no_editor");
+    expect(classifyOpenEditorError("code not found")).toBe("no_editor");
+    expect(
+      classifyOpenEditorError("failed to open editor `code`: spawn failed"),
+    ).toBe("no_editor");
+    expect(classifyOpenEditorError("no code editors detected")).toBe(
+      "no_editor",
+    );
+  });
+
+  it("maps path denied / permission", () => {
+    expect(classifyOpenEditorError("path not allowed: /secret")).toBe(
+      "path_denied",
+    );
+    expect(classifyOpenEditorError("EACCES: permission denied")).toBe(
+      "path_denied",
+    );
+    expect(classifyOpenEditorError("operation not permitted")).toBe(
+      "path_denied",
+    );
+  });
+
+  it("maps host-only and cancel", () => {
+    expect(classifyOpenEditorError("need tauri: desktop app")).toBe(
+      "host_only",
+    );
+    expect(classifyOpenEditorError("not available in browser")).toBe(
+      "host_only",
+    );
+    expect(classifyOpenEditorError("user cancelled")).toBe("cancelled");
+    expect(classifyOpenEditorError("Error: canceled")).toBe("cancelled");
+  });
+
+  it("falls back to other for unknown noise", () => {
+    expect(classifyOpenEditorError("weird boom")).toBe("other");
+    expect(classifyOpenEditorError(null)).toBe("other");
+    expect(classifyOpenEditorError("")).toBe("other");
+  });
+});
+
+describe("classifyRevealError", () => {
+  it("maps path not found and empty path", () => {
+    expect(classifyRevealError("path not found: /a")).toBe("not_found");
+    expect(classifyRevealError("empty path")).toBe("not_found");
+  });
+
+  it("maps path denied and host only", () => {
+    expect(classifyRevealError("path not allowed")).toBe("path_denied");
+    expect(classifyRevealError("need_tauri")).toBe("host_only");
+  });
+
+  it("maps cancel and other", () => {
+    expect(classifyRevealError("user canceled")).toBe("cancelled");
+    expect(classifyRevealError("spawn failed: xdg-open")).toBe("other");
+  });
+
+  it("does not invent no_editor for reveal", () => {
+    // Reveal surface has no no_editor kind — generic not_found / other.
+    expect(classifyRevealError("code not found")).toBe("not_found");
+  });
+});
+
+describe("message keys", () => {
+  it("maps every open kind to resources.openErr.*", () => {
+    expect(openEditorErrorMessageKey("no_editor")).toBe(
+      "resources.openErr.noEditor",
+    );
+    expect(openEditorErrorMessageKey("not_found")).toBe(
+      "resources.openErr.notFound",
+    );
+    expect(openEditorErrorMessageKey("path_denied")).toBe(
+      "resources.openErr.pathDenied",
+    );
+    expect(openEditorErrorMessageKey("host_only")).toBe(
+      "resources.openErr.hostOnly",
+    );
+    expect(openEditorErrorMessageKey("cancelled")).toBe(
+      "resources.openErr.cancelled",
+    );
+    expect(openEditorErrorMessageKey("other")).toBe("resources.openErr.other");
+  });
+
+  it("maps every reveal kind to resources.revealErr.*", () => {
+    expect(revealErrorMessageKey("not_found")).toBe(
+      "resources.revealErr.notFound",
+    );
+    expect(revealErrorMessageKey("path_denied")).toBe(
+      "resources.revealErr.pathDenied",
+    );
+    expect(revealErrorMessageKey("host_only")).toBe(
+      "resources.revealErr.hostOnly",
+    );
+    expect(revealErrorMessageKey("cancelled")).toBe(
+      "resources.revealErr.cancelled",
+    );
+    expect(revealErrorMessageKey("other")).toBe("resources.revealErr.other");
+  });
+});
+
+describe("resolveOpenEditorError / resolveRevealError", () => {
+  it("is silent for cancelled", () => {
+    const r = resolveOpenEditorError("user cancelled");
+    expect(r.kind).toBe("cancelled");
+    expect(r.silent).toBe(true);
+  });
+
+  it("keeps detail only for other", () => {
+    const known = resolveOpenEditorError("path not found: /x");
+    expect(known.kind).toBe("not_found");
+    expect(known.detail).toBe("");
+
+    const other = resolveOpenEditorError("spawn exploded xyz");
+    expect(other.kind).toBe("other");
+    expect(other.detail).toContain("spawn exploded");
+  });
+
+  it("formats with tr + optional detail", () => {
+    const tr = (k: string) =>
+      k === "resources.openErr.other" ? "Could not open" : k;
+    expect(
+      formatOpenEditorErrorMessage(
+        { messageKey: "resources.openErr.other", detail: "boom" },
+        tr,
+      ),
+    ).toBe("Could not open (boom)");
+    expect(
+      formatOpenEditorErrorMessage(
+        { messageKey: "resources.openErr.other", detail: "" },
+        tr,
+      ),
+    ).toBe("Could not open");
+  });
+
+  it("resolveRevealError mirrors kind keys", () => {
+    const r = resolveRevealError("path not found: /z");
+    expect(r.kind).toBe("not_found");
+    expect(r.messageKey).toBe("resources.revealErr.notFound");
+    expect(r.silent).toBe(false);
+  });
+});
+
+describe("resolveOpenEditorEmptyState", () => {
+  it("warns when no editors detected", () => {
+    const s = resolveOpenEditorEmptyState({ editorsFound: 0 });
+    expect(s.kind).toBe("no_editors");
+    expect(s.severity).toBe("warn");
+    expect(s.messageKey).toBe("settings.openTargetEmpty");
+  });
+
+  it("info when preferred editor missing from scan", () => {
+    const s = resolveOpenEditorEmptyState({
+      editorsFound: 2,
+      preferred: "cursor",
+      availableIds: ["code", "zed"],
+    });
+    expect(s.kind).toBe("preferred_missing");
+    expect(s.severity).toBe("info");
+    expect(s.messageKey).toBe("settings.openTargetPreferredMissing");
+  });
+
+  it("ok for finder / system preferred even with zero editors", () => {
+    // Zero editors still surfaces no_editors (Finder works but honesty first).
+    const zero = resolveOpenEditorEmptyState({
+      editorsFound: 0,
+      preferred: "finder",
+    });
+    expect(zero.kind).toBe("no_editors");
+
+    const ok = resolveOpenEditorEmptyState({
+      editorsFound: 1,
+      preferred: "finder",
+      availableIds: ["code"],
+    });
+    expect(ok.kind).toBe("ok");
+    expect(ok.messageKey).toBeNull();
+    expect(ok.severity).toBe("none");
+  });
+
+  it("ok when preferred is available", () => {
+    const s = resolveOpenEditorEmptyState({
+      editorsFound: 2,
+      preferred: "Code",
+      availableIds: ["code", "cursor"],
+    });
+    expect(s.kind).toBe("ok");
+  });
+});
+
+describe("planOpenInEditor", () => {
+  it("ok for absolute path on tauri", () => {
+    expect(
+      planOpenInEditor({ path: "/Users/me/a.ts", isTauri: true }),
+    ).toEqual({
+      ok: true,
+      path: "/Users/me/a.ts",
+      editorId: null,
+    });
+  });
+
+  it("soft-fails host_only when not tauri", () => {
+    const p = planOpenInEditor({ path: "/a", isTauri: false });
+    expect(p.ok).toBe(false);
+    if (!p.ok) {
+      expect(p.kind).toBe("host_only");
+      expect(p.messageKey).toBe("resources.openErr.hostOnly");
+    }
+  });
+
+  it("soft-fails not_found for empty path", () => {
+    const p = planOpenInEditor({ path: "  ", isTauri: true });
+    expect(p.ok).toBe(false);
+    if (!p.ok) expect(p.kind).toBe("not_found");
+  });
+
+  it("soft-fails no_editor when preferred editor requested but none found", () => {
+    const p = planOpenInEditor({
+      path: "/a.ts",
+      editorId: "cursor",
+      editorsFound: 0,
+      isTauri: true,
+    });
+    expect(p.ok).toBe(false);
+    if (!p.ok) expect(p.kind).toBe("no_editor");
+  });
+
+  it("allows finder/system even when editorsFound is 0", () => {
+    expect(
+      planOpenInEditor({
+        path: "/a",
+        editorId: "finder",
+        editorsFound: 0,
+      }).ok,
+    ).toBe(true);
+    expect(
+      planOpenInEditor({
+        path: "/a",
+        editorId: "system",
+        editorsFound: 0,
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("keeps explicit editorId when ok", () => {
+    const p = planOpenInEditor({
+      path: "/a.ts",
+      editorId: " code ",
+      editorsFound: 3,
+    });
+    expect(p).toEqual({ ok: true, path: "/a.ts", editorId: "code" });
+  });
+});

--- a/src/lib/openEditorHonesty.ts
+++ b/src/lib/openEditorHonesty.ts
@@ -1,0 +1,548 @@
+/**
+ * OPEN-EDITOR-HONESTY — pure helpers for open-in-editor / reveal soft-fail.
+ *
+ * Classifies Host `open_in_editor` / `path_reveal` / `path_open` failures into
+ * stable kinds for toasts and banners. Never invents “opened” / “revealed”
+ * without a successful Host call. No DOM / Tauri side effects.
+ *
+ * Host message shapes (today):
+ * - `path not found: …` / `empty path`
+ * - `{editorId} not found`
+ * - `failed to open editor \`…\`: …`
+ * - permission / allowlist phrases (`path not allowed`, EACCES, …)
+ */
+
+/** Stable failure modes for open-in-editor. */
+export type OpenEditorErrorKind =
+  | "no_editor"
+  | "not_found"
+  | "path_denied"
+  | "host_only"
+  | "cancelled"
+  | "other";
+
+/** Stable failure modes for path reveal / open-with-system. */
+export type RevealErrorKind =
+  | "not_found"
+  | "path_denied"
+  | "host_only"
+  | "cancelled"
+  | "other";
+
+/** Empty / honesty states for Settings preferred-editor surface. */
+export type OpenEditorEmptyKind =
+  | "no_editors"
+  | "preferred_missing"
+  | "ok";
+
+export type OpenEditorEmptyState = {
+  kind: OpenEditorEmptyKind;
+  /** Primary i18n message key (null when ok). */
+  messageKey: string | null;
+  /** Soft-warn (empty scan or preferred missing) vs quiet ok. */
+  severity: "none" | "info" | "warn";
+};
+
+/** Soft preflight before calling Host open_in_editor. */
+export type OpenInEditorPlan =
+  | { ok: true; path: string; editorId: string | null }
+  | {
+      ok: false;
+      kind: OpenEditorErrorKind;
+      messageKey: string;
+    };
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as {
+      code?: unknown;
+      message?: unknown;
+      reason?: unknown;
+      error?: unknown;
+    };
+    const parts = [o.code, o.message, o.reason, o.error]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+function errCode(err: unknown): string {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const c = (err as { code?: unknown }).code;
+    if (typeof c === "string") return c.trim().toLowerCase();
+    if (typeof c === "number" && Number.isFinite(c)) return String(c);
+  }
+  return "";
+}
+
+function isCancelledText(s: string): boolean {
+  return (
+    /\bcancel(led|ed)?\b/.test(s) ||
+    s.includes("user cancelled") ||
+    s.includes("user canceled") ||
+    s.includes("dismissed")
+  );
+}
+
+function isHostOnlyText(s: string): boolean {
+  return (
+    s.includes("need tauri") ||
+    s.includes("need_tauri") ||
+    s.includes("requires the tauri") ||
+    s.includes("requires the desktop") ||
+    s.includes("host only") ||
+    s.includes("host_only") ||
+    s.includes("not in tauri") ||
+    s.includes("not available in browser") ||
+    s.includes("desktop only") ||
+    s.includes("desktop app")
+  );
+}
+
+function isPathDeniedText(s: string): boolean {
+  return (
+    s.includes("path not allowed") ||
+    s.includes("path_not_allowed") ||
+    s.includes("path denied") ||
+    s.includes("path_denied") ||
+    s.includes("outside allowlist") ||
+    s.includes("outside path scope") ||
+    s.includes("outside known") ||
+    s.includes("eacces") ||
+    s.includes("eperm") ||
+    (s.includes("permission") &&
+      (s.includes("denied") || s.includes("refuse"))) ||
+    s.includes("access is denied") ||
+    s.includes("operation not permitted") ||
+    s.includes("unauthorized") ||
+    s.includes("forbidden")
+  );
+}
+
+function isPathNotFoundText(s: string): boolean {
+  return (
+    s.includes("path not found") ||
+    s.includes("path_not_found") ||
+    s.includes("empty path") ||
+    s.includes("path is empty") ||
+    s.includes("file not found") ||
+    s.includes("no such file") ||
+    s.includes("does not exist") ||
+    s.includes("enoent") ||
+    s.trim() === "not found" ||
+    s.trim() === "error: not found"
+  );
+}
+
+function isNoEditorText(s: string): boolean {
+  // Host: `{id} not found` when launching a named editor / git GUI.
+  // Prefer this only when it is not clearly a filesystem path miss.
+  if (isPathNotFoundText(s) && s.includes("path")) return false;
+  return (
+    s.includes("no editor") ||
+    s.includes("no_editor") ||
+    s.includes("no code editor") ||
+    s.includes("editor not found") ||
+    s.includes("editors not found") ||
+    s.includes("no editors") ||
+    s.includes("editor unavailable") ||
+    s.includes("failed to open editor") ||
+    // bare "`code` not found" / "cursor not found" without "path not found"
+    (/\bnot found\b/.test(s) &&
+      !s.includes("path not found") &&
+      !s.includes("file not found") &&
+      !s.includes("no such file") &&
+      !s.includes("session not found") &&
+      !s.includes("project not found"))
+  );
+}
+
+/**
+ * Classify a thrown value / host error for open-in-editor.
+ * Prefer explicit `code` over free-form text. Never invents success.
+ */
+export function classifyOpenEditorError(err: unknown): OpenEditorErrorKind {
+  if (err == null || err === "") return "other";
+
+  const code = errCode(err);
+  if (
+    code === "cancelled" ||
+    code === "cancel" ||
+    code === "user_cancelled" ||
+    code === "user-cancelled"
+  ) {
+    return "cancelled";
+  }
+  if (
+    code === "host_only" ||
+    code === "host-only" ||
+    code === "need_tauri" ||
+    code === "need-tauri"
+  ) {
+    return "host_only";
+  }
+  if (
+    code === "path_denied" ||
+    code === "path-denied" ||
+    code === "path_not_allowed" ||
+    code === "path-not-allowed" ||
+    code === "eacces" ||
+    code === "eperm" ||
+    code === "forbidden"
+  ) {
+    return "path_denied";
+  }
+  if (
+    code === "no_editor" ||
+    code === "no-editor" ||
+    code === "editor_not_found" ||
+    code === "editor-not-found"
+  ) {
+    return "no_editor";
+  }
+  if (
+    code === "not_found" ||
+    code === "not-found" ||
+    code === "path_not_found" ||
+    code === "path-not-found" ||
+    code === "enoent" ||
+    code === "empty_path" ||
+    code === "empty-path"
+  ) {
+    return "not_found";
+  }
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  if (isCancelledText(s)) return "cancelled";
+  if (isHostOnlyText(s)) return "host_only";
+  if (isPathDeniedText(s)) return "path_denied";
+  // Path miss before generic “not found” editor miss.
+  if (isPathNotFoundText(s)) return "not_found";
+  if (isNoEditorText(s)) return "no_editor";
+
+  return "other";
+}
+
+/**
+ * Classify a thrown value / host error for path reveal / system open.
+ * Same honesty surface as open-in-editor minus `no_editor`.
+ */
+export function classifyRevealError(err: unknown): RevealErrorKind {
+  if (err == null || err === "") return "other";
+
+  const code = errCode(err);
+  if (
+    code === "cancelled" ||
+    code === "cancel" ||
+    code === "user_cancelled" ||
+    code === "user-cancelled"
+  ) {
+    return "cancelled";
+  }
+  if (
+    code === "host_only" ||
+    code === "host-only" ||
+    code === "need_tauri" ||
+    code === "need-tauri"
+  ) {
+    return "host_only";
+  }
+  if (
+    code === "path_denied" ||
+    code === "path-denied" ||
+    code === "path_not_allowed" ||
+    code === "path-not-allowed" ||
+    code === "eacces" ||
+    code === "eperm" ||
+    code === "forbidden"
+  ) {
+    return "path_denied";
+  }
+  if (
+    code === "not_found" ||
+    code === "not-found" ||
+    code === "path_not_found" ||
+    code === "path-not-found" ||
+    code === "enoent" ||
+    code === "empty_path" ||
+    code === "empty-path"
+  ) {
+    return "not_found";
+  }
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  if (isCancelledText(s)) return "cancelled";
+  if (isHostOnlyText(s)) return "host_only";
+  if (isPathDeniedText(s)) return "path_denied";
+  if (isPathNotFoundText(s) || s.includes("not found")) return "not_found";
+
+  return "other";
+}
+
+/** i18n message key for a classified open-in-editor error. */
+export function openEditorErrorMessageKey(kind: OpenEditorErrorKind): string {
+  switch (kind) {
+    case "no_editor":
+      return "resources.openErr.noEditor";
+    case "not_found":
+      return "resources.openErr.notFound";
+    case "path_denied":
+      return "resources.openErr.pathDenied";
+    case "host_only":
+      return "resources.openErr.hostOnly";
+    case "cancelled":
+      return "resources.openErr.cancelled";
+    case "other":
+    default:
+      return "resources.openErr.other";
+  }
+}
+
+/** i18n message key for a classified reveal error. */
+export function revealErrorMessageKey(kind: RevealErrorKind): string {
+  switch (kind) {
+    case "not_found":
+      return "resources.revealErr.notFound";
+    case "path_denied":
+      return "resources.revealErr.pathDenied";
+    case "host_only":
+      return "resources.revealErr.hostOnly";
+    case "cancelled":
+      return "resources.revealErr.cancelled";
+    case "other":
+    default:
+      return "resources.revealErr.other";
+  }
+}
+
+/**
+ * Resolve user-facing open-in-editor soft-fail copy from a thrown value.
+ * `detail` is a short technical suffix for `other` only.
+ */
+export function resolveOpenEditorError(err: unknown): {
+  kind: OpenEditorErrorKind;
+  messageKey: string;
+  detail: string;
+  /** True when UI should stay silent (user dismissed). */
+  silent: boolean;
+} {
+  const kind = classifyOpenEditorError(err);
+  const messageKey = openEditorErrorMessageKey(kind);
+  const raw = errText(err).trim();
+  let detail = "";
+  if (
+    kind === "other" &&
+    raw &&
+    !/^error:\s*$/i.test(raw) &&
+    raw.length < 200
+  ) {
+    detail = raw.replace(/^Error:\s*/i, "").trim();
+  }
+  return {
+    kind,
+    messageKey,
+    detail,
+    silent: kind === "cancelled",
+  };
+}
+
+/**
+ * Resolve user-facing reveal soft-fail copy from a thrown value.
+ */
+export function resolveRevealError(err: unknown): {
+  kind: RevealErrorKind;
+  messageKey: string;
+  detail: string;
+  silent: boolean;
+} {
+  const kind = classifyRevealError(err);
+  const messageKey = revealErrorMessageKey(kind);
+  const raw = errText(err).trim();
+  let detail = "";
+  if (
+    kind === "other" &&
+    raw &&
+    !/^error:\s*$/i.test(raw) &&
+    raw.length < 200
+  ) {
+    detail = raw.replace(/^Error:\s*/i, "").trim();
+  }
+  return {
+    kind,
+    messageKey,
+    detail,
+    silent: kind === "cancelled",
+  };
+}
+
+/**
+ * Format resolved open/reveal error with optional technical detail suffix.
+ * `tr` is typically `createT(locale)`.
+ */
+export function formatOpenEditorErrorMessage(
+  resolved: { messageKey: string; detail: string },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tr: (key: any, vars?: Record<string, string>) => string,
+): string {
+  const base = tr(resolved.messageKey);
+  if (resolved.detail && resolved.detail !== base) {
+    if (!base.toLowerCase().includes(resolved.detail.toLowerCase())) {
+      return `${base} (${resolved.detail})`;
+    }
+  }
+  return base;
+}
+
+/** Alias — same formatting rules for reveal soft-fail. */
+export const formatRevealErrorMessage = formatOpenEditorErrorMessage;
+
+/**
+ * Settings / open-target empty honesty from a detected-editor scan.
+ *
+ * - `editorsFound === 0` → warn no_editors (Finder/Explorer still works)
+ * - preferred set but not among available ids → info preferred_missing
+ * - otherwise ok (null message)
+ *
+ * Never invents installed editors.
+ */
+export function resolveOpenEditorEmptyState(input: {
+  /** Count of available (detected) code editors. */
+  editorsFound: number;
+  /**
+   * Preferred open target id (`finder` / `explorer` / `system` / editor id).
+   * OS file-manager targets never count as “preferred missing”.
+   */
+  preferred?: string | null;
+  /** Available editor ids from Host scan (optional — used when preferred set). */
+  availableIds?: readonly string[] | null;
+}): OpenEditorEmptyState {
+  const n = Math.max(0, Math.floor(Number(input.editorsFound) || 0));
+  const preferred = (input.preferred ?? "").trim().toLowerCase();
+  const isOsTarget =
+    !preferred ||
+    preferred === "finder" ||
+    preferred === "explorer" ||
+    preferred === "system" ||
+    preferred === "default";
+
+  if (n === 0) {
+    return {
+      kind: "no_editors",
+      messageKey: "settings.openTargetEmpty",
+      severity: "warn",
+    };
+  }
+
+  if (!isOsTarget && input.availableIds) {
+    const ids = input.availableIds.map((x) => String(x).trim().toLowerCase());
+    if (preferred && !ids.includes(preferred)) {
+      return {
+        kind: "preferred_missing",
+        messageKey: "settings.openTargetPreferredMissing",
+        severity: "info",
+      };
+    }
+  }
+
+  return {
+    kind: "ok",
+    messageKey: null,
+    severity: "none",
+  };
+}
+
+function normalizeOpenPath(path: string | null | undefined): string {
+  return String(path ?? "").trim();
+}
+
+/**
+ * Soft preflight before Host `open_in_editor`.
+ * Order: host_only → not_found (empty path) → no_editor → ok.
+ * Does **not** probe the filesystem (Host still does).
+ */
+export function planOpenInEditor(input: {
+  path: string | null | undefined;
+  /** Explicit editor id; empty/null → Host default. */
+  editorId?: string | null;
+  /** `api.isTauri()` — false → host_only. Default true (optimistic). */
+  isTauri?: boolean | null;
+  /**
+   * When known `0` and a non-OS preferred/editor is requested, soft-fail
+   * no_editor without calling Host. `null`/`undefined` = unknown → allow.
+   */
+  editorsFound?: number | null;
+}): OpenInEditorPlan {
+  if (input.isTauri === false) {
+    return {
+      ok: false,
+      kind: "host_only",
+      messageKey: openEditorErrorMessageKey("host_only"),
+    };
+  }
+  const path = normalizeOpenPath(input.path);
+  if (!path) {
+    return {
+      ok: false,
+      kind: "not_found",
+      messageKey: openEditorErrorMessageKey("not_found"),
+    };
+  }
+  const editorId = (input.editorId ?? "").trim() || null;
+  const wantsEditor =
+    !!editorId &&
+    editorId !== "finder" &&
+    editorId !== "explorer" &&
+    editorId !== "system" &&
+    editorId !== "default";
+  if (
+    wantsEditor &&
+    input.editorsFound != null &&
+    Number(input.editorsFound) <= 0
+  ) {
+    return {
+      ok: false,
+      kind: "no_editor",
+      messageKey: openEditorErrorMessageKey("no_editor"),
+    };
+  }
+  return { ok: true, path, editorId };
+}
+
+/** All open-in-editor error kinds (for label maps / tests). */
+export const OPEN_EDITOR_ERROR_KINDS: readonly OpenEditorErrorKind[] = [
+  "no_editor",
+  "not_found",
+  "path_denied",
+  "host_only",
+  "cancelled",
+  "other",
+] as const;
+
+/** All reveal error kinds. */
+export const REVEAL_ERROR_KINDS: readonly RevealErrorKind[] = [
+  "not_found",
+  "path_denied",
+  "host_only",
+  "cancelled",
+  "other",
+] as const;

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -1430,8 +1430,13 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
     tab: "app",
     anchorId: "settings-anchor-openTarget",
     labelKey: "settings.openTarget",
-    descKeys: ["settings.openTargetDesc", "settings.openFinder"],
-    keywords: ["open in", "finder", "editor"],
+    descKeys: [
+      "settings.openTargetDesc",
+      "settings.openFinder",
+      "settings.openTargetEmpty",
+      "settings.openTargetPreferredMissing",
+    ],
+    keywords: ["open in", "finder", "editor", "no editors", "preferred editor"],
   },
   // ── appearance · theme ──
   {


### PR DESCRIPTION
## Summary
- Pure `openEditorHonesty` helpers: classify open-in-editor / reveal soft-fails (`no_editor` · `not_found` · `path_denied` · `host_only` · `cancelled` · `other`), empty-state honesty for Settings preferred editor, and soft preflight `planOpenInEditor`.
- ResourceViewer / Open Location (App) / FilePathCard use classified i18n toasts instead of raw `Error:` dumps; cancelled is silent.
- Settings → Open files with shows warn/info when no editors are detected or preferred is missing.
- i18n en / zh / zh-TW + CHANGELOG; no `window.confirm`.

## Test plan
- [x] `pnpm test -- src/lib/openEditorHonesty.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: open missing path in editor from Changes → classified not-found toast
- [ ] Manual: reveal missing path from file chip → classified reveal error
- [ ] Manual: Settings with zero editors → empty honesty under Open files with