### PR TITLE
feat(session): trace history filter and clear honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Trace history pro**: session trace export list gains All / Local / Uploaded filter chips with counts, search, honest empty states (no exports · filter empty + clear filters), size display when known, uploaded badge only when the export flag is true (no remote URLs), and clear-all via **GlassModal** with count honesty (no `window.confirm`). Paths-only — never loads archive contents. Pure `traceHistoryPro` helpers + tests; en/zh/zh-TW.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitejs/plugin-react-swc':
+        specifier: ^3.11.0
+        version: 3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
       canvas:
         specifier: ^3.2.3
         version: 3.2.3
@@ -455,35 +458,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -643,79 +641,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -746,6 +731,93 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@swc/core-darwin-arm64@1.15.47':
+    resolution: {integrity: sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.47':
+    resolution: {integrity: sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    resolution: {integrity: sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    resolution: {integrity: sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    resolution: {integrity: sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    resolution: {integrity: sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    resolution: {integrity: sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    resolution: {integrity: sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    resolution: {integrity: sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    resolution: {integrity: sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    resolution: {integrity: sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    resolution: {integrity: sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.47':
+    resolution: {integrity: sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tabler/icons-react@3.45.0':
     resolution: {integrity: sha512-t/AuKs7ALMDDTY+B9IvfZnlO0mbLlP/lJxP/HnGC49QkM8mCsTN38kYyxjXxgrb1+TeK53ioVBJqIV7n/eysXQ==}
@@ -793,28 +865,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -875,35 +943,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.4':
     resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -1277,6 +1340,11 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitejs/plugin-react-swc@3.11.0':
+    resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
+    peerDependencies:
+      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1933,28 +2001,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3244,6 +3308,66 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@swc/core-darwin-arm64@1.15.47':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core@1.15.47':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.47
+      '@swc/core-darwin-x64': 1.15.47
+      '@swc/core-linux-arm-gnueabihf': 1.15.47
+      '@swc/core-linux-arm64-gnu': 1.15.47
+      '@swc/core-linux-arm64-musl': 1.15.47
+      '@swc/core-linux-ppc64-gnu': 1.15.47
+      '@swc/core-linux-s390x-gnu': 1.15.47
+      '@swc/core-linux-x64-gnu': 1.15.47
+      '@swc/core-linux-x64-musl': 1.15.47
+      '@swc/core-win32-arm64-msvc': 1.15.47
+      '@swc/core-win32-ia32-msvc': 1.15.47
+      '@swc/core-win32-x64-msvc': 1.15.47
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.28':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@tabler/icons-react@3.45.0(react@19.2.7)':
     dependencies:
       '@tabler/icons': 3.45.0
@@ -3777,6 +3901,14 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitejs/plugin-react-swc@3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@swc/core': 1.15.47
+      vite: 6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21941,19 +21941,29 @@ export default function App() {
         <TraceHistoryList
           labels={{
             empty: tr("session.tracesEmpty"),
+            emptyHint: tr("session.tracesEmptyHint"),
             emptyFilter: tr("session.tracesEmptyFilter"),
+            emptyFilterHint: tr("session.tracesEmptyFilterHint"),
+            clearFilters: tr("session.tracesClearFilters"),
             reveal: tr("session.tracesReveal"),
             copyPath: tr("session.tracesCopyPath"),
             copied: tr("session.tracesCopied"),
             remove: tr("session.tracesRemove"),
             clearAll: tr("session.tracesClearAll"),
             clearConfirmTitle: tr("session.tracesClearConfirmTitle"),
+            // Leave {count} for TraceHistoryList (planClearTraceHistory).
             clearConfirmMessage: tr("session.tracesClearConfirmMessage"),
             clearConfirmAction: tr("session.tracesClearConfirmAction"),
             cancel: tr("common.cancel"),
+            closeLabel: tr("common.close"),
             searchPlaceholder: tr("session.tracesSearch"),
             listAria: tr("session.tracesTitle"),
             uploadedBadge: tr("session.tracesUploadedBadge"),
+            uploadedBadgeTitle: tr("session.tracesUploadedBadgeTitle"),
+            filterAll: tr("session.tracesFilter.all"),
+            filterLocal: tr("session.tracesFilter.local"),
+            filterUploaded: tr("session.tracesFilter.uploaded"),
+            filterAria: tr("session.tracesFilterAria"),
           }}
           onCopied={() => showToast(tr("session.tracesCopied"), 2000)}
           onError={(msg) => showToast(msg, 4000)}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -7074,13 +7074,17 @@ export function SettingsPage({
                     <TraceHistoryList
                       labels={{
                         empty: t("session.tracesEmpty"),
+                        emptyHint: t("session.tracesEmptyHint"),
                         emptyFilter: t("session.tracesEmptyFilter"),
+                        emptyFilterHint: t("session.tracesEmptyFilterHint"),
+                        clearFilters: t("session.tracesClearFilters"),
                         reveal: t("session.tracesReveal"),
                         copyPath: t("session.tracesCopyPath"),
                         copied: t("session.tracesCopied"),
                         remove: t("session.tracesRemove"),
                         clearAll: t("session.tracesClearAll"),
                         clearConfirmTitle: t("session.tracesClearConfirmTitle"),
+                        // Leave {count} for TraceHistoryList (planClearTraceHistory).
                         clearConfirmMessage: t(
                           "session.tracesClearConfirmMessage",
                         ),
@@ -7088,9 +7092,17 @@ export function SettingsPage({
                           "session.tracesClearConfirmAction",
                         ),
                         cancel: t("common.cancel"),
+                        closeLabel: t("common.close"),
                         searchPlaceholder: t("session.tracesSearch"),
                         listAria: t("session.tracesTitle"),
                         uploadedBadge: t("session.tracesUploadedBadge"),
+                        uploadedBadgeTitle: t(
+                          "session.tracesUploadedBadgeTitle",
+                        ),
+                        filterAll: t("session.tracesFilter.all"),
+                        filterLocal: t("session.tracesFilter.local"),
+                        filterUploaded: t("session.tracesFilter.uploaded"),
+                        filterAria: t("session.tracesFilterAria"),
                       }}
                       onCopied={() =>
                         showSettingsToast(t("session.tracesCopied"), 2000)

--- a/src/components/TraceHistoryList.tsx
+++ b/src/components/TraceHistoryList.tsx
@@ -2,35 +2,53 @@
  * Recent session-trace exports — paths only (never file contents).
  * Used in Settings → Runtime → Diagnostics and the Traces modal.
  *
- * Manage: search filter · remove row · clear all (in-app confirm) · size if known.
+ * Manage: scope chips (all/local/uploaded) · search · remove row ·
+ * clear all (GlassModal confirm with count) · size if known ·
+ * uploaded badge only when history flag is true.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
-import { IconClose, IconCopy, IconFolder, IconTrash } from "@/components/icons";
+import { GlassModal } from "@/components/GlassModal";
+import { IconCopy, IconFolder, IconTrash } from "@/components/icons";
 import * as api from "@/lib/api";
 import {
   TRACE_HISTORY_CHANGE_EVENT,
   TRACE_HISTORY_STORAGE_KEY,
   clearTraceHistory,
-  filterTraceHistory,
-  formatTraceHistorySize,
   loadTraceHistory,
   removeTraceHistory,
   traceHistoryFileName,
   traceHistoryLabel,
   type TraceHistoryEntry,
 } from "@/lib/traceHistory";
+import {
+  TRACE_HISTORY_SCOPES,
+  countTraceHistoryMeta,
+  filterTraceHistory,
+  formatTraceSize,
+  hasActiveTraceHistoryFilters,
+  planClearTraceHistory,
+  resolveTraceHistoryEmptyState,
+  shouldShowTraceUploadedBadge,
+  traceHistoryScopeLabelKey,
+  type TraceHistoryScope,
+} from "@/lib/traceHistoryPro";
 
 export type TraceHistoryListLabels = {
   empty: string;
+  /** Optional secondary empty hint (export prompt). */
+  emptyHint?: string;
   emptyFilter: string;
+  /** Optional filter-empty hint. */
+  emptyFilterHint?: string;
+  clearFilters?: string;
   reveal: string;
   copyPath: string;
   copied: string;
   remove: string;
   clearAll: string;
   clearConfirmTitle: string;
+  /** Prefer with `{count}` — plan count is interpolated by caller when provided. */
   clearConfirmMessage: string;
   clearConfirmAction: string;
   cancel: string;
@@ -39,6 +57,14 @@ export type TraceHistoryListLabels = {
   listAria?: string;
   /** Optional badge when history notes uploaded=true (no URLs). */
   uploadedBadge?: string;
+  /** Honest tooltip: upload reported by export, no remote URL stored. */
+  uploadedBadgeTitle?: string;
+  /** Filter chip labels */
+  filterAll?: string;
+  filterLocal?: string;
+  filterUploaded?: string;
+  filterAria?: string;
+  closeLabel?: string;
 };
 
 export type TraceHistoryListProps = {
@@ -68,6 +94,17 @@ function formatExportedAt(iso: string): string {
   }
 }
 
+function scopeLabel(
+  scope: TraceHistoryScope,
+  labels: TraceHistoryListLabels,
+): string {
+  if (scope === "local" && labels.filterLocal) return labels.filterLocal;
+  if (scope === "uploaded" && labels.filterUploaded) return labels.filterUploaded;
+  if (scope === "all" && labels.filterAll) return labels.filterAll;
+  // Fallback keys are only for aria when labels omitted (tests).
+  return traceHistoryScopeLabelKey(scope);
+}
+
 export function TraceHistoryList({
   labels,
   onCopied,
@@ -79,6 +116,7 @@ export function TraceHistoryList({
     loadTraceHistory(),
   );
   const [query, setQuery] = useState("");
+  const [scope, setScope] = useState<TraceHistoryScope>("all");
   const [confirmClear, setConfirmClear] = useState(false);
 
   useEffect(() => {
@@ -97,10 +135,35 @@ export function TraceHistoryList({
     };
   }, []);
 
+  const meta = useMemo(() => countTraceHistoryMeta(entries), [entries]);
+
   const filtered = useMemo(
-    () => filterTraceHistory(entries, query),
-    [entries, query],
+    () => filterTraceHistory(entries, { query, scope }),
+    [entries, query, scope],
   );
+
+  const emptyState = useMemo(
+    () =>
+      resolveTraceHistoryEmptyState({
+        total: entries.length,
+        filtered: filtered.length,
+        query,
+        scope,
+      }),
+    [entries.length, filtered.length, query, scope],
+  );
+
+  const clearPlan = useMemo(() => planClearTraceHistory(entries), [entries]);
+
+  const filtersActive = useMemo(
+    () => hasActiveTraceHistoryFilters({ query, scope }),
+    [query, scope],
+  );
+
+  const clearFilters = useCallback(() => {
+    setQuery("");
+    setScope("all");
+  }, []);
 
   const reveal = useCallback(
     async (path: string) => {
@@ -131,105 +194,132 @@ export function TraceHistoryList({
   }, []);
 
   const doClearAll = useCallback(() => {
+    if (!clearPlan.confirmNeeded) {
+      setConfirmClear(false);
+      return;
+    }
     const next = clearTraceHistory();
     setEntries(next);
     setQuery("");
+    setScope("all");
     setConfirmClear(false);
-  }, []);
+  }, [clearPlan.confirmNeeded]);
 
   const rootClass =
     "trace-history" +
     (compact ? " trace-history--compact" : "") +
     (className ? ` ${className}` : "");
 
+  const chipCounts: Record<TraceHistoryScope, number> = {
+    all: meta.total,
+    local: meta.local,
+    uploaded: meta.uploaded,
+  };
+
   const toolbar =
     entries.length > 0 ? (
-      <div className="trace-history-toolbar">
-        <input
-          type="search"
-          className="trace-history-search"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder={labels.searchPlaceholder}
-          aria-label={labels.searchPlaceholder}
-        />
-        <button
-          type="button"
-          className="btn btn--ghost btn--sm"
-          onClick={() => setConfirmClear(true)}
-          title={labels.clearAll}
-          aria-label={labels.clearAll}
+      <div className="trace-history-toolbar-block">
+        <div
+          className="trace-history-chips"
+          role="toolbar"
+          aria-label={labels.filterAria ?? labels.listAria}
         >
-          <IconTrash size={14} />
-          <span className="trace-history-row__action-label">
-            {labels.clearAll}
-          </span>
-        </button>
+          {TRACE_HISTORY_SCOPES.map((id) => {
+            const n = chipCounts[id];
+            // Hide zero-count chips except "all" and the active selection.
+            if (id !== "all" && n === 0 && scope !== id) return null;
+            return (
+              <button
+                key={id}
+                type="button"
+                className={
+                  "trace-history-chip" + (scope === id ? " is-active" : "")
+                }
+                aria-pressed={scope === id}
+                onClick={() => setScope(id)}
+              >
+                <span>{scopeLabel(id, labels)}</span>
+                <span className="trace-history-chip__count">{n}</span>
+              </button>
+            );
+          })}
+        </div>
+        <div className="trace-history-toolbar">
+          <input
+            type="search"
+            className="trace-history-search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={labels.searchPlaceholder}
+            aria-label={labels.searchPlaceholder}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm"
+            onClick={() => {
+              if (clearPlan.confirmNeeded) setConfirmClear(true);
+            }}
+            disabled={!clearPlan.confirmNeeded}
+            title={labels.clearAll}
+            aria-label={labels.clearAll}
+          >
+            <IconTrash size={14} />
+            <span className="trace-history-row__action-label">
+              {labels.clearAll}
+            </span>
+          </button>
+        </div>
       </div>
     ) : null;
 
-  const confirmPortal =
-    confirmClear &&
-    typeof document !== "undefined" &&
-    createPortal(
-      <div
-        className="overlay app-dialog-overlay"
-        role="presentation"
-        onMouseDown={(e) => {
-          if (e.target === e.currentTarget) setConfirmClear(false);
-        }}
-      >
-        <div
-          className="modal app-dialog"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="trace-history-clear-title"
-          onMouseDown={(e) => e.stopPropagation()}
-        >
-          <header className="modal-head">
-            <h2 id="trace-history-clear-title" className="modal-title">
-              {labels.clearConfirmTitle}
-            </h2>
-            <button
-              type="button"
-              className="icon-btn modal-close"
-              onClick={() => setConfirmClear(false)}
-              aria-label={labels.cancel}
-            >
-              <IconClose size={16} />
-            </button>
-          </header>
-          <div className="app-dialog__form">
-            <p className="app-dialog__msg">{labels.clearConfirmMessage}</p>
-            <div className="app-dialog__actions modal-actions">
-              <button
-                type="button"
-                className="btn btn--ghost"
-                onClick={() => setConfirmClear(false)}
-              >
-                {labels.cancel}
-              </button>
-              <button
-                type="button"
-                className="btn btn--danger"
-                onClick={doClearAll}
-              >
-                {labels.clearConfirmAction}
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>,
-      document.body,
-    );
+  const clearModal = (
+    <GlassModal
+      open={confirmClear}
+      onClose={() => setConfirmClear(false)}
+      title={labels.clearConfirmTitle}
+      size="sm"
+      closeLabel={labels.closeLabel ?? labels.cancel}
+      footer={
+        <>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={() => setConfirmClear(false)}
+          >
+            {labels.cancel}
+          </button>
+          <button
+            type="button"
+            className="btn btn--danger"
+            onClick={doClearAll}
+            disabled={!clearPlan.confirmNeeded}
+          >
+            {labels.clearConfirmAction}
+          </button>
+        </>
+      }
+    >
+      <p className="trace-history-clear-msg" style={{ margin: 0 }}>
+        {labels.clearConfirmMessage.replace(
+          /\{count\}/g,
+          String(clearPlan.count),
+        )}
+      </p>
+    </GlassModal>
+  );
 
-  if (entries.length === 0) {
+  if (emptyState && emptyState.kind === "empty" && entries.length === 0) {
     return (
       <div className={rootClass}>
         <div className="trace-history-empty" role="status">
-          {labels.empty}
+          <div className="trace-history-empty__title">{labels.empty}</div>
+          {labels.emptyHint ? (
+            <div className="trace-history-empty__hint">{labels.emptyHint}</div>
+          ) : null}
         </div>
-        {confirmPortal}
+        {clearModal}
       </div>
     );
   }
@@ -237,9 +327,34 @@ export function TraceHistoryList({
   return (
     <div className={rootClass}>
       {toolbar}
-      {filtered.length === 0 ? (
-        <div className="trace-history-empty" role="status">
-          {labels.emptyFilter}
+      {emptyState ? (
+        <div
+          className="trace-history-empty"
+          role="status"
+          data-kind={emptyState.kind}
+        >
+          <div className="trace-history-empty__title">
+            {emptyState.kind === "filter_empty"
+              ? labels.emptyFilter
+              : labels.empty}
+          </div>
+          {emptyState.kind === "filter_empty" && labels.emptyFilterHint ? (
+            <div className="trace-history-empty__hint">
+              {labels.emptyFilterHint}
+            </div>
+          ) : null}
+          {emptyState.kind === "empty" && labels.emptyHint ? (
+            <div className="trace-history-empty__hint">{labels.emptyHint}</div>
+          ) : null}
+          {emptyState.showClearFilters && filtersActive && labels.clearFilters ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm trace-history-clear-filters"
+              onClick={clearFilters}
+            >
+              {labels.clearFilters}
+            </button>
+          ) : null}
         </div>
       ) : (
         <ul
@@ -252,7 +367,10 @@ export function TraceHistoryList({
           {filtered.map((e) => {
             const file = traceHistoryFileName(e.path);
             const label = traceHistoryLabel(e);
-            const sizeLabel = formatTraceHistorySize(e.sizeBytes);
+            // Size only when known — never invent from path.
+            const sizeLabel = formatTraceSize(e.sizeBytes);
+            const showUploaded =
+              shouldShowTraceUploadedBadge(e) && Boolean(labels.uploadedBadge);
             return (
               <li
                 key={`${e.path}|${e.exportedAt}`}
@@ -269,10 +387,12 @@ export function TraceHistoryList({
                         {sizeLabel}
                       </span>
                     ) : null}
-                    {e.uploaded && labels.uploadedBadge ? (
+                    {showUploaded ? (
                       <span
                         className="trace-history-row__uploaded"
-                        title={labels.uploadedBadge}
+                        title={
+                          labels.uploadedBadgeTitle ?? labels.uploadedBadge
+                        }
                       >
                         {labels.uploadedBadge}
                       </span>
@@ -327,7 +447,7 @@ export function TraceHistoryList({
           })}
         </ul>
       )}
-      {confirmPortal}
+      {clearModal}
     </div>
   );
 }

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -3990,8 +3990,9 @@ const en = {
   "session.tracesTitle": "Recent traces",
   "session.tracesDesc":
     "Local history of session trace exports (paths only). Open the folder or copy the path — large archives are not loaded into the app.",
-  "session.tracesEmpty":
-    "No traces exported yet. Use Export local or Export and upload from a chat menu after a conversation has an agent session.",
+  "session.tracesEmpty": "No traces exported yet",
+  "session.tracesEmptyHint":
+    "Use Export local or Export and upload from a chat menu after a conversation has an agent session. Paths only — archives are never loaded into the app.",
   "session.tracesReveal": "Reveal in folder",
   "session.tracesCopyPath": "Copy path",
   "session.tracesCopied": "Path copied",
@@ -3999,11 +4000,20 @@ const en = {
   "session.tracesClearAll": "Clear all",
   "session.tracesClearConfirmTitle": "Clear trace history?",
   "session.tracesClearConfirmMessage":
-    "Remove all recent trace export paths from this list. Archive files on disk are not deleted.",
+    "Remove {count} recent trace export path(s) from this list. Archive files on disk are not deleted.",
   "session.tracesClearConfirmAction": "Clear all",
   "session.tracesSearch": "Filter by title or path…",
   "session.tracesEmptyFilter": "No traces match this filter",
+  "session.tracesEmptyFilterHint":
+    "Try another search, or switch the All / Local / Uploaded chip.",
+  "session.tracesClearFilters": "Clear filters",
+  "session.tracesFilterAria": "Trace export scope",
+  "session.tracesFilter.all": "All",
+  "session.tracesFilter.local": "Local",
+  "session.tracesFilter.uploaded": "Uploaded",
   "session.tracesUploadedBadge": "Uploaded",
+  "session.tracesUploadedBadgeTitle":
+    "Upload reported by export (path only — no remote URL stored)",
   "session.exportBundle": "Export diagnostic package",
   "session.exportBundleDone": "Diagnostic package saved",
   "session.exportBundleFail": "Diagnostic export failed",
@@ -10067,8 +10077,9 @@ const zh: Record<MessageKey, string> = {
   "session.tracesTitle": "最近的 trace",
   "session.tracesDesc":
     "会话 trace 导出的本地历史（仅路径）。可在文件夹中显示或复制路径 — 大文件不会加载进应用。",
-  "session.tracesEmpty":
-    "还没有导出过 trace。在有 agent 会话的对话菜单中选择「仅本地导出」或「导出并上传」。",
+  "session.tracesEmpty": "还没有导出过 trace",
+  "session.tracesEmptyHint":
+    "在有 agent 会话的对话菜单中选择「仅本地导出」或「导出并上传」。仅保存路径 — 不会把归档加载进应用。",
   "session.tracesReveal": "在文件夹中显示",
   "session.tracesCopyPath": "复制路径",
   "session.tracesCopied": "路径已复制",
@@ -10076,11 +10087,19 @@ const zh: Record<MessageKey, string> = {
   "session.tracesClearAll": "全部清除",
   "session.tracesClearConfirmTitle": "清除 trace 历史？",
   "session.tracesClearConfirmMessage":
-    "将从列表中移除全部最近的 trace 导出路径。磁盘上的归档文件不会被删除。",
+    "将从列表中移除 {count} 条最近的 trace 导出路径。磁盘上的归档文件不会被删除。",
   "session.tracesClearConfirmAction": "全部清除",
   "session.tracesSearch": "按标题或路径筛选…",
   "session.tracesEmptyFilter": "没有匹配的 trace",
+  "session.tracesEmptyFilterHint": "试试其他关键词，或切换「全部 / 本地 / 已上传」筛选。",
+  "session.tracesClearFilters": "清除筛选",
+  "session.tracesFilterAria": "Trace 导出范围",
+  "session.tracesFilter.all": "全部",
+  "session.tracesFilter.local": "本地",
+  "session.tracesFilter.uploaded": "已上传",
   "session.tracesUploadedBadge": "已上传",
+  "session.tracesUploadedBadgeTitle":
+    "导出所报告的上传状态（仅路径 — 不保存远程 URL）",
   "session.exportBundle": "导出完整诊断包",
   "session.exportBundleDone": "诊断包已保存",
   "session.exportBundleFail": "诊断包导出失败",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -3829,8 +3829,9 @@ export const zhTW: Record<MessageKey, string> = {
   "session.tracesTitle": "最近的 trace",
   "session.tracesDesc":
     "對話 trace 匯出的本機歷史（僅路徑）。可在資料夾中顯示或複製路徑 — 大檔不會載入應用。",
-  "session.tracesEmpty":
-    "還沒有匯出過 trace。在有 agent 對話的選單中選擇「僅本機匯出」或「匯出並上傳」。",
+  "session.tracesEmpty": "還沒有匯出過 trace",
+  "session.tracesEmptyHint":
+    "在有 agent 對話的選單中選擇「僅本機匯出」或「匯出並上傳」。僅儲存路徑 — 不會把封存載入應用。",
   "session.tracesReveal": "在資料夾中顯示",
   "session.tracesCopyPath": "複製路徑",
   "session.tracesCopied": "路徑已複製",
@@ -3838,11 +3839,19 @@ export const zhTW: Record<MessageKey, string> = {
   "session.tracesClearAll": "全部清除",
   "session.tracesClearConfirmTitle": "清除 trace 歷史？",
   "session.tracesClearConfirmMessage":
-    "將從列表中移除全部最近的 trace 匯出路徑。磁碟上的封存檔不會被刪除。",
+    "將從列表中移除 {count} 條最近的 trace 匯出路徑。磁碟上的封存檔不會被刪除。",
   "session.tracesClearConfirmAction": "全部清除",
   "session.tracesSearch": "依標題或路徑篩選…",
   "session.tracesEmptyFilter": "沒有相符的 trace",
+  "session.tracesEmptyFilterHint": "試試其他關鍵詞，或切換「全部 / 本機 / 已上傳」篩選。",
+  "session.tracesClearFilters": "清除篩選",
+  "session.tracesFilterAria": "Trace 匯出範圍",
+  "session.tracesFilter.all": "全部",
+  "session.tracesFilter.local": "本機",
+  "session.tracesFilter.uploaded": "已上傳",
   "session.tracesUploadedBadge": "已上傳",
+  "session.tracesUploadedBadgeTitle":
+    "匯出所報告的上傳狀態（僅路徑 — 不儲存遠端 URL）",
   "session.exportBundle": "匯出完整診斷包",
   "session.exportBundleDone": "診斷包已儲存",
   "session.exportBundleFail": "診斷包匯出失敗",

--- a/src/lib/traceHistoryPro.test.ts
+++ b/src/lib/traceHistoryPro.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vitest";
+import type { TraceHistoryEntry } from "./traceHistory";
+import {
+  TRACE_HISTORY_SCOPES,
+  countTraceHistoryMeta,
+  filterTraceHistory,
+  formatTraceSize,
+  hasActiveTraceHistoryFilters,
+  normalizeTraceHistoryScope,
+  planClearTraceHistory,
+  resolveTraceHistoryEmptyState,
+  shouldShowTraceUploadedBadge,
+  traceHistoryScopeLabelKey,
+  traceMatchesScope,
+} from "./traceHistoryPro";
+
+const sample = (
+  n: number,
+  overrides?: Partial<TraceHistoryEntry>,
+): TraceHistoryEntry => ({
+  sessionId: `sess-${n}`,
+  path: `/tmp/traces/trace-${n}.tar.gz`,
+  exportedAt: new Date(1_700_000_000_000 + n * 1000).toISOString(),
+  title: `Chat ${n}`,
+  ...overrides,
+});
+
+const LIST: TraceHistoryEntry[] = [
+  sample(1, {
+    title: "Local login",
+    path: "/tmp/local-login.tar.gz",
+    sizeBytes: 2048,
+  }),
+  sample(2, {
+    title: "Uploaded report",
+    path: "/tmp/up-report.tar.gz",
+    uploaded: true,
+    sizeBytes: 1024 * 1024,
+  }),
+  sample(3, {
+    title: "Other local",
+    path: "/tmp/other.tar.gz",
+  }),
+  sample(4, {
+    title: "Remote-ish path only",
+    path: "/tmp/remote-looking.tar.gz",
+    // no uploaded flag — must stay local
+  }),
+];
+
+describe("normalizeTraceHistoryScope / chips", () => {
+  it("orders chips all · local · uploaded", () => {
+    expect(TRACE_HISTORY_SCOPES).toEqual(["all", "local", "uploaded"]);
+  });
+
+  it("normalizes scope and uploadedOnly", () => {
+    expect(normalizeTraceHistoryScope("all")).toBe("all");
+    expect(normalizeTraceHistoryScope("local")).toBe("local");
+    expect(normalizeTraceHistoryScope("uploaded")).toBe("uploaded");
+    expect(normalizeTraceHistoryScope(undefined, true)).toBe("uploaded");
+    expect(normalizeTraceHistoryScope(undefined, false)).toBe("local");
+    expect(normalizeTraceHistoryScope(null, null)).toBe("all");
+    // scope wins over uploadedOnly
+    expect(normalizeTraceHistoryScope("local", true)).toBe("local");
+    expect(normalizeTraceHistoryScope("uploaded", false)).toBe("uploaded");
+    expect(normalizeTraceHistoryScope("nope" as "all")).toBe("all");
+  });
+
+  it("maps chip labels to i18n keys", () => {
+    expect(traceHistoryScopeLabelKey("all")).toBe("session.tracesFilter.all");
+    expect(traceHistoryScopeLabelKey("local")).toBe(
+      "session.tracesFilter.local",
+    );
+    expect(traceHistoryScopeLabelKey("uploaded")).toBe(
+      "session.tracesFilter.uploaded",
+    );
+  });
+});
+
+describe("traceMatchesScope / uploaded honesty", () => {
+  it("only uploaded===true matches uploaded scope", () => {
+    expect(traceMatchesScope({ uploaded: true }, "uploaded")).toBe(true);
+    expect(traceMatchesScope({ uploaded: false }, "uploaded")).toBe(false);
+    expect(traceMatchesScope({}, "uploaded")).toBe(false);
+    expect(traceMatchesScope(null, "uploaded")).toBe(false);
+  });
+
+  it("local excludes uploaded=true only", () => {
+    expect(traceMatchesScope({ uploaded: true }, "local")).toBe(false);
+    expect(traceMatchesScope({}, "local")).toBe(true);
+    expect(traceMatchesScope({ uploaded: false }, "local")).toBe(true);
+  });
+
+  it("shouldShowTraceUploadedBadge is strict", () => {
+    expect(shouldShowTraceUploadedBadge({ uploaded: true })).toBe(true);
+    expect(shouldShowTraceUploadedBadge({})).toBe(false);
+    expect(shouldShowTraceUploadedBadge(null)).toBe(false);
+    expect(
+      shouldShowTraceUploadedBadge({
+        uploaded: "yes" as unknown as boolean,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("filterTraceHistory", () => {
+  it("accepts string query (backward-compatible)", () => {
+    expect(filterTraceHistory(LIST, "login").map((e) => e.sessionId)).toEqual([
+      "sess-1",
+    ]);
+    expect(filterTraceHistory(LIST, "")).toHaveLength(4);
+    expect(filterTraceHistory(LIST, "  ")).toHaveLength(4);
+  });
+
+  it("filters by uploadedOnly true/false", () => {
+    expect(
+      filterTraceHistory(LIST, { uploadedOnly: true }).map((e) => e.sessionId),
+    ).toEqual(["sess-2"]);
+    expect(
+      filterTraceHistory(LIST, { uploadedOnly: false }).map((e) => e.sessionId),
+    ).toEqual(["sess-1", "sess-3", "sess-4"]);
+  });
+
+  it("filters by scope chips", () => {
+    expect(
+      filterTraceHistory(LIST, { scope: "uploaded" }).map((e) => e.sessionId),
+    ).toEqual(["sess-2"]);
+    expect(
+      filterTraceHistory(LIST, { scope: "local" }).map((e) => e.sessionId),
+    ).toEqual(["sess-1", "sess-3", "sess-4"]);
+    expect(filterTraceHistory(LIST, { scope: "all" })).toHaveLength(4);
+  });
+
+  it("combines scope + free-text (AND)", () => {
+    expect(
+      filterTraceHistory(LIST, {
+        scope: "local",
+        query: "login",
+      }).map((e) => e.sessionId),
+    ).toEqual(["sess-1"]);
+    expect(
+      filterTraceHistory(LIST, {
+        uploadedOnly: true,
+        query: "local",
+      }),
+    ).toHaveLength(0);
+    expect(
+      filterTraceHistory(LIST, {
+        scope: "uploaded",
+        query: "report",
+      }).map((e) => e.sessionId),
+    ).toEqual(["sess-2"]);
+  });
+
+  it("never invents upload from path text alone", () => {
+    // "remote" appears in path of sess-4 but uploaded is unset
+    const hits = filterTraceHistory(LIST, {
+      scope: "uploaded",
+      query: "remote",
+    });
+    expect(hits).toEqual([]);
+    expect(
+      filterTraceHistory(LIST, { scope: "local", query: "remote" }).map(
+        (e) => e.sessionId,
+      ),
+    ).toEqual(["sess-4"]);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(filterTraceHistory([], { scope: "uploaded" })).toEqual([]);
+  });
+});
+
+describe("countTraceHistoryMeta", () => {
+  it("counts total / local / uploaded honestly", () => {
+    expect(countTraceHistoryMeta(LIST)).toEqual({
+      total: 4,
+      local: 3,
+      uploaded: 1,
+    });
+    expect(countTraceHistoryMeta([])).toEqual({
+      total: 0,
+      local: 0,
+      uploaded: 0,
+    });
+    expect(countTraceHistoryMeta(null)).toEqual({
+      total: 0,
+      local: 0,
+      uploaded: 0,
+    });
+  });
+
+  it("does not invent uploaded when flag is missing", () => {
+    expect(
+      countTraceHistoryMeta([
+        sample(1),
+        sample(2, { path: "/upload/x.tar.gz" }),
+      ]),
+    ).toEqual({ total: 2, local: 2, uploaded: 0 });
+  });
+});
+
+describe("hasActiveTraceHistoryFilters", () => {
+  it("detects query and non-all scope", () => {
+    expect(hasActiveTraceHistoryFilters(undefined)).toBe(false);
+    expect(hasActiveTraceHistoryFilters("")).toBe(false);
+    expect(hasActiveTraceHistoryFilters("x")).toBe(true);
+    expect(hasActiveTraceHistoryFilters({ scope: "all", query: "" })).toBe(
+      false,
+    );
+    expect(hasActiveTraceHistoryFilters({ scope: "local" })).toBe(true);
+    expect(hasActiveTraceHistoryFilters({ uploadedOnly: true })).toBe(true);
+    expect(hasActiveTraceHistoryFilters({ query: "  hi  " })).toBe(true);
+  });
+});
+
+describe("resolveTraceHistoryEmptyState", () => {
+  it("returns null when filtered rows exist", () => {
+    expect(
+      resolveTraceHistoryEmptyState({ total: 3, filtered: 2 }),
+    ).toBeNull();
+  });
+
+  it("empty ring buffer → empty (export prompt)", () => {
+    const empty = resolveTraceHistoryEmptyState({ total: 0, filtered: 0 });
+    expect(empty).toMatchObject({
+      kind: "empty",
+      titleKey: "session.tracesEmpty",
+      hintKey: "session.tracesEmptyHint",
+      showClearFilters: false,
+    });
+  });
+
+  it("filter empty with clear CTA", () => {
+    const empty = resolveTraceHistoryEmptyState({
+      total: 4,
+      filtered: 0,
+      scope: "uploaded",
+      query: "nope",
+    });
+    expect(empty).toMatchObject({
+      kind: "filter_empty",
+      titleKey: "session.tracesEmptyFilter",
+      hintKey: "session.tracesEmptyFilterHint",
+      showClearFilters: true,
+    });
+  });
+
+  it("honors explicit hasFilters", () => {
+    expect(
+      resolveTraceHistoryEmptyState({
+        total: 2,
+        filtered: 0,
+        hasFilters: true,
+      })?.kind,
+    ).toBe("filter_empty");
+    expect(
+      resolveTraceHistoryEmptyState({
+        total: 2,
+        filtered: 0,
+        hasFilters: false,
+      })?.kind,
+    ).toBe("empty");
+  });
+});
+
+describe("planClearTraceHistory", () => {
+  it("requires confirm only when non-empty and reports count", () => {
+    const empty = planClearTraceHistory([]);
+    expect(empty).toEqual({
+      ok: true,
+      count: 0,
+      confirmNeeded: false,
+      next: [],
+      logMeta: null,
+    });
+
+    const plan = planClearTraceHistory(LIST);
+    expect(plan.ok).toBe(true);
+    expect(plan.count).toBe(4);
+    expect(plan.confirmNeeded).toBe(true);
+    expect(plan.next).toEqual([]);
+    expect(plan.logMeta).toEqual({ clearedCount: 4 });
+  });
+
+  it("tolerates null / undefined", () => {
+    expect(planClearTraceHistory(null).count).toBe(0);
+    expect(planClearTraceHistory(undefined).confirmNeeded).toBe(false);
+  });
+});
+
+describe("formatTraceSize", () => {
+  it("returns null when unknown — never invents", () => {
+    expect(formatTraceSize(undefined)).toBeNull();
+    expect(formatTraceSize(null)).toBeNull();
+    expect(formatTraceSize(-1)).toBeNull();
+  });
+
+  it("formats known sizes", () => {
+    expect(formatTraceSize(500)).toBe("500 B");
+    expect(formatTraceSize(2048)).toBe("2.0 KB");
+    expect(formatTraceSize(1024 * 1024)).toBe("1.0 MB");
+  });
+});

--- a/src/lib/traceHistoryPro.ts
+++ b/src/lib/traceHistoryPro.ts
@@ -1,0 +1,292 @@
+/**
+ * TRACE-HISTORY-PRO — pure helpers for session trace export history UX.
+ *
+ * Paths-only history (never archive contents). Filter chips · empty honesty ·
+ * clear plan with count · size display · uploaded badge honesty.
+ * Never invents sizes, remote URLs, or upload flags from paths alone.
+ */
+
+import {
+  filterTraceHistory as filterTraceHistoryByQuery,
+  formatTraceHistorySize,
+  type TraceHistoryEntry,
+} from "@/lib/traceHistory";
+
+// ── Scope chips ──────────────────────────────────────────────────────────────
+
+/** First-class scope chips for the traces list (All · Local · Uploaded). */
+export type TraceHistoryScope = "all" | "local" | "uploaded";
+
+/** Ordered chip list. */
+export const TRACE_HISTORY_SCOPES: readonly TraceHistoryScope[] = [
+  "all",
+  "local",
+  "uploaded",
+] as const;
+
+/** Combined free-text + upload-scope filter. */
+export type TraceHistoryFilterOpts = {
+  query?: string | null;
+  /**
+   * When true: only entries with `uploaded === true`.
+   * When false: only local (not uploaded).
+   * When undefined/null: no upload filter (same as scope `all`).
+   * Prefer {@link scope} when both are set.
+   */
+  uploadedOnly?: boolean | null;
+  /** Preferred chip scope; wins over `uploadedOnly` when set. */
+  scope?: TraceHistoryScope | null;
+};
+
+/** Normalize chip scope from `scope` and/or `uploadedOnly`. */
+export function normalizeTraceHistoryScope(
+  scope?: TraceHistoryScope | string | null,
+  uploadedOnly?: boolean | null,
+): TraceHistoryScope {
+  if (scope === "all" || scope === "local" || scope === "uploaded") {
+    return scope;
+  }
+  if (uploadedOnly === true) return "uploaded";
+  if (uploadedOnly === false) return "local";
+  return "all";
+}
+
+/**
+ * True when an entry matches a scope chip.
+ * Uploaded badge honesty: only `uploaded === true` counts as uploaded —
+ * never inferred from path or size.
+ */
+export function traceMatchesScope(
+  entry: Pick<TraceHistoryEntry, "uploaded"> | null | undefined,
+  scope: TraceHistoryScope | null | undefined,
+): boolean {
+  if (!entry) return false;
+  const s = scope ?? "all";
+  if (s === "all") return true;
+  if (s === "uploaded") return entry.uploaded === true;
+  // local
+  return entry.uploaded !== true;
+}
+
+/**
+ * Filter by free-text query and/or upload scope (AND).
+ *
+ * Accepts a string (query-only, backward-compatible) or
+ * `{ query; uploadedOnly?; scope? }`. Does not invent rows.
+ * Reuses base path/title/sessionId substring match for the query.
+ */
+export function filterTraceHistory(
+  entries: readonly TraceHistoryEntry[],
+  opts: TraceHistoryFilterOpts | string = {},
+): TraceHistoryEntry[] {
+  if (!entries?.length) return [];
+  const filter: TraceHistoryFilterOpts =
+    typeof opts === "string" ? { query: opts } : (opts ?? {});
+  const scope = normalizeTraceHistoryScope(filter.scope, filter.uploadedOnly);
+
+  let list: TraceHistoryEntry[] =
+    scope === "all"
+      ? [...entries]
+      : entries.filter((e) => traceMatchesScope(e, scope));
+
+  const q = (filter.query ?? "").trim();
+  if (q) {
+    list = filterTraceHistoryByQuery(list, q);
+  }
+  return list;
+}
+
+/**
+ * True when scope chip or free-text narrows the list
+ * (used for filter-empty honesty and clear-filters CTA).
+ */
+export function hasActiveTraceHistoryFilters(
+  opts: TraceHistoryFilterOpts | string | null | undefined,
+): boolean {
+  if (opts == null) return false;
+  if (typeof opts === "string") return opts.trim().length > 0;
+  const scope = normalizeTraceHistoryScope(opts.scope, opts.uploadedOnly);
+  return scope !== "all" || Boolean((opts.query ?? "").trim());
+}
+
+// ── Meta counts ──────────────────────────────────────────────────────────────
+
+/** Per-chip counts; `total` is list length. */
+export type TraceHistoryMetaCounts = {
+  total: number;
+  local: number;
+  uploaded: number;
+};
+
+/**
+ * Count uploaded vs local entries.
+ * Uploaded only when `uploaded === true` — never invent from paths.
+ */
+export function countTraceHistoryMeta(
+  entries: readonly TraceHistoryEntry[] | null | undefined,
+): TraceHistoryMetaCounts {
+  const list = Array.isArray(entries) ? entries : [];
+  let uploaded = 0;
+  for (const e of list) {
+    if (e?.uploaded === true) uploaded += 1;
+  }
+  const total = list.length;
+  return {
+    total,
+    uploaded,
+    local: Math.max(0, total - uploaded),
+  };
+}
+
+// ── Empty honesty ────────────────────────────────────────────────────────────
+
+export type TraceHistoryEmptyKind = "empty" | "filter_empty";
+
+export type TraceHistoryEmptyPresentation = {
+  kind: TraceHistoryEmptyKind;
+  /** Primary title i18n key under session.traces*. */
+  titleKey: string;
+  /** Optional hint i18n key. */
+  hintKey: string | null;
+  /** Offer clear-filters CTA. */
+  showClearFilters: boolean;
+};
+
+export type TraceHistoryEmptyInput = {
+  /** Total history rows (pre filter). */
+  total: number;
+  /** Visible rows after filters. */
+  filtered: number;
+  /** Status chip or free-text active (optional; inferred from query/scope). */
+  hasFilters?: boolean;
+  query?: string | null;
+  scope?: TraceHistoryScope | null;
+  uploadedOnly?: boolean | null;
+};
+
+/**
+ * Resolve which empty surface to show for the traces list.
+ * Returns `null` when filtered rows should render.
+ *
+ * Priority:
+ * 1. filtered > 0 → null
+ * 2. total == 0 → empty (export prompt)
+ * 3. total > 0 + filters + filtered == 0 → filter_empty
+ *
+ * Never invents history when the ring buffer is empty.
+ */
+export function resolveTraceHistoryEmptyState(
+  input: TraceHistoryEmptyInput,
+): TraceHistoryEmptyPresentation | null {
+  const total = Math.max(0, Math.floor(Number(input.total) || 0));
+  const filtered = Math.max(0, Math.floor(Number(input.filtered) || 0));
+
+  if (filtered > 0) return null;
+
+  const hasFilters =
+    input.hasFilters != null
+      ? Boolean(input.hasFilters)
+      : hasActiveTraceHistoryFilters({
+          query: input.query,
+          scope: input.scope,
+          uploadedOnly: input.uploadedOnly,
+        });
+
+  if (total === 0) {
+    return {
+      kind: "empty",
+      titleKey: "session.tracesEmpty",
+      hintKey: "session.tracesEmptyHint",
+      showClearFilters: false,
+    };
+  }
+
+  if (hasFilters) {
+    return {
+      kind: "filter_empty",
+      titleKey: "session.tracesEmptyFilter",
+      hintKey: "session.tracesEmptyFilterHint",
+      showClearFilters: true,
+    };
+  }
+
+  // Total > 0 but filtered 0 without filters should not happen; soft fallback.
+  return {
+    kind: "empty",
+    titleKey: "session.tracesEmpty",
+    hintKey: "session.tracesEmptyHint",
+    showClearFilters: false,
+  };
+}
+
+// ── Clear plan ───────────────────────────────────────────────────────────────
+
+/**
+ * Plan a clear-all of the path list (does not delete archive files).
+ * Callers open GlassModal when `confirmNeeded`, then apply via `clearTraceHistory`.
+ */
+export type ClearTraceHistoryPlan = {
+  ok: true;
+  count: number;
+  /** True when the UI should open a confirm (count > 0). */
+  confirmNeeded: boolean;
+  /** Next list after clear (always empty). */
+  next: TraceHistoryEntry[];
+  /** Safe meta for logs / toasts — count only. */
+  logMeta: { clearedCount: number } | null;
+};
+
+/**
+ * Plan clear-all with honest count (paths only — never file I/O).
+ */
+export function planClearTraceHistory(
+  entries: readonly TraceHistoryEntry[] | null | undefined,
+): ClearTraceHistoryPlan {
+  const count = Array.isArray(entries) ? entries.length : 0;
+  return {
+    ok: true,
+    count,
+    confirmNeeded: count > 0,
+    next: [],
+    logMeta: count > 0 ? { clearedCount: count } : null,
+  };
+}
+
+// ── Size display ─────────────────────────────────────────────────────────────
+
+/**
+ * Human-readable size for list rows. Returns null when unknown —
+ * never invents sizes from path or title.
+ * Pure — B/KB/MB/GB unit abbreviations (no i18n).
+ */
+export function formatTraceSize(
+  sizeBytes: number | null | undefined,
+): string | null {
+  return formatTraceHistorySize(sizeBytes);
+}
+
+// ── Chip / badge label keys ──────────────────────────────────────────────────
+
+/** Label i18n key for a scope chip. */
+export function traceHistoryScopeLabelKey(scope: TraceHistoryScope): string {
+  switch (scope) {
+    case "local":
+      return "session.tracesFilter.local";
+    case "uploaded":
+      return "session.tracesFilter.uploaded";
+    case "all":
+    default:
+      return "session.tracesFilter.all";
+  }
+}
+
+/**
+ * Whether the uploaded badge may render for a row.
+ * Honest: only when the history flag is exactly true (CLI/host reported
+ * upload success). Never from path patterns or non-empty size alone.
+ */
+export function shouldShowTraceUploadedBadge(
+  entry: Pick<TraceHistoryEntry, "uploaded"> | null | undefined,
+): boolean {
+  return entry?.uploaded === true;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -20302,6 +20302,53 @@ div.composer__input:empty::before {
   gap: 8px;
   min-width: 0;
 }
+.trace-history-toolbar-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.trace-history-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.trace-history-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle, rgba(127, 127, 127, 0.35));
+  background: transparent;
+  color: var(--text-secondary, inherit);
+  font: inherit;
+  font-size: 11px;
+  line-height: 1.3;
+  cursor: pointer;
+  max-width: 160px;
+  overflow: hidden;
+}
+.trace-history-chip:hover {
+  background: var(--hover-bg, rgba(127, 127, 127, 0.1));
+  color: var(--text-primary, inherit);
+}
+.trace-history-chip.is-active {
+  border-color: color-mix(in srgb, var(--accent, #5b8def) 30%, transparent);
+  background: color-mix(in srgb, var(--accent, #5b8def) 14%, transparent);
+  color: var(--text-primary, inherit);
+  font-weight: 560;
+}
+.trace-history-chip__count {
+  font-size: 10px;
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+.trace-history-chip.is-active .trace-history-chip__count {
+  opacity: 0.9;
+}
 .trace-history-toolbar {
   display: flex;
   align-items: center;
@@ -20328,6 +20375,28 @@ div.composer__input:empty::before {
   font-size: 13px;
   line-height: 1.45;
   color: var(--text-tertiary, var(--text-secondary));
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+.trace-history-empty__title {
+  font-size: 13px;
+  color: var(--text-secondary, inherit);
+}
+.trace-history-empty__hint {
+  font-size: 12px;
+  color: var(--text-tertiary, var(--text-secondary));
+  line-height: 1.45;
+}
+.trace-history-clear-filters {
+  margin-top: 2px;
+}
+.trace-history-clear-msg {
+  white-space: pre-wrap;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-secondary);
 }
 .trace-history-list {
   list-style: none;
@@ -20414,6 +20483,9 @@ div.composer__input:empty::before {
   }
   .trace-history-toolbar {
     flex-wrap: wrap;
+  }
+  .trace-history-chips {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- Pure `traceHistoryPro` helpers: filter (query + All/Local/Uploaded scope), empty-state honesty, clear plan with count, size formatting, uploaded/local meta counts — paths only, never invent sizes/URLs
- UI: filter chips with counts, search, GlassModal clear confirm (count honesty, no `window.confirm`), honest empty + clear-filters CTA, uploaded badge only when `uploaded === true`
- i18n en/zh/zh-TW + CHANGELOG

## Test plan
- [x] `pnpm test -- src/lib/traceHistory.test.ts src/lib/traceHistoryPro.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manually: open Traces modal / Settings diagnostics — chips, search empty, clear confirm count, size + uploaded badge honesty