### PR TITLE
feat(hooks): redacted activity export and soft-fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Hooks activity redacted export** (Settings → Extensions → Hooks → Recent activity): **Export redacted…** downloads filtered rows as JSON and **Copy summary** copies a plain-text dump; every free-form field is re-redacted (no secrets). Soft-fail honesty for empty filter · clipboard blocked · download failure · other. Pure `hooksActivityExport` helpers (`planHooksActivityExport` / `formatHooksActivityExportText` / `classifyHooksExportError`) + tests; en/zh/zh-TW. No `window.confirm`.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitejs/plugin-react-swc':
+        specifier: ^3.11.0
+        version: 3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
       canvas:
         specifier: ^3.2.3
         version: 3.2.3
@@ -455,35 +458,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -643,79 +641,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -746,6 +731,93 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@swc/core-darwin-arm64@1.15.47':
+    resolution: {integrity: sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.47':
+    resolution: {integrity: sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    resolution: {integrity: sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    resolution: {integrity: sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    resolution: {integrity: sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    resolution: {integrity: sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    resolution: {integrity: sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    resolution: {integrity: sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    resolution: {integrity: sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    resolution: {integrity: sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    resolution: {integrity: sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    resolution: {integrity: sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.47':
+    resolution: {integrity: sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tabler/icons-react@3.45.0':
     resolution: {integrity: sha512-t/AuKs7ALMDDTY+B9IvfZnlO0mbLlP/lJxP/HnGC49QkM8mCsTN38kYyxjXxgrb1+TeK53ioVBJqIV7n/eysXQ==}
@@ -793,28 +865,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -875,35 +943,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.4':
     resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -1277,6 +1340,11 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitejs/plugin-react-swc@3.11.0':
+    resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
+    peerDependencies:
+      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1933,28 +2001,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3244,6 +3308,66 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@swc/core-darwin-arm64@1.15.47':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core@1.15.47':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.47
+      '@swc/core-darwin-x64': 1.15.47
+      '@swc/core-linux-arm-gnueabihf': 1.15.47
+      '@swc/core-linux-arm64-gnu': 1.15.47
+      '@swc/core-linux-arm64-musl': 1.15.47
+      '@swc/core-linux-ppc64-gnu': 1.15.47
+      '@swc/core-linux-s390x-gnu': 1.15.47
+      '@swc/core-linux-x64-gnu': 1.15.47
+      '@swc/core-linux-x64-musl': 1.15.47
+      '@swc/core-win32-arm64-msvc': 1.15.47
+      '@swc/core-win32-ia32-msvc': 1.15.47
+      '@swc/core-win32-x64-msvc': 1.15.47
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.28':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@tabler/icons-react@3.45.0(react@19.2.7)':
     dependencies:
       '@tabler/icons': 3.45.0
@@ -3777,6 +3901,14 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitejs/plugin-react-swc@3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@swc/core': 1.15.47
+      vite: 6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:

--- a/src/components/ExtensionsHooksPanel.tsx
+++ b/src/components/ExtensionsHooksPanel.tsx
@@ -28,6 +28,12 @@ import {
   type HookActivityRecord,
 } from "@/lib/hooksDebug";
 import {
+  classifyHooksExportError,
+  hooksExportOutcomeMessageKey,
+  planHooksActivityExport,
+  resolveHooksExportOutcome,
+} from "@/lib/hooksActivityExport";
+import {
   countHookActivityOutcomes,
   filterHookActivitiesByOutcome,
   resolveHookActivityEmptyState,
@@ -136,6 +142,10 @@ export function ExtensionsHooksPanel({
   const [outcomeFilter, setOutcomeFilter] =
     useState<HookActivityOutcomeFilter>("all");
   const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
+  const [exportMsg, setExportMsg] = useState<{
+    kind: "ok" | "err" | "info";
+    text: string;
+  } | null>(null);
 
   // Real try-run panel
   const [tryOpen, setTryOpen] = useState(true);
@@ -260,7 +270,113 @@ export function ExtensionsHooksPanel({
     clearHookActivities();
     setClearConfirmOpen(false);
     setOutcomeFilter("all");
+    setExportMsg(null);
   };
+
+  const showExportOutcome = useCallback(
+    (
+      outcome: ReturnType<typeof resolveHooksExportOutcome>,
+      count = 0,
+    ) => {
+      const key = hooksExportOutcomeMessageKey(outcome);
+      setExportMsg({
+        kind: outcome.ok ? "ok" : "err",
+        text: tr(key, { count: String(count) }),
+      });
+    },
+    [tr],
+  );
+
+  const onCopyActivitySummary = useCallback(async () => {
+    const plan = planHooksActivityExport(filteredActivity, {
+      outcomeFilter,
+    });
+    if (plan.empty || !plan.text) {
+      showExportOutcome(
+        resolveHooksExportOutcome({
+          channel: "copy",
+          empty: true,
+        }),
+        0,
+      );
+      return;
+    }
+    let copyOk = false;
+    let error: unknown;
+    try {
+      if (
+        typeof navigator !== "undefined" &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === "function"
+      ) {
+        await navigator.clipboard.writeText(plan.text);
+        copyOk = true;
+      } else {
+        error = Object.assign(new Error("clipboard unavailable"), {
+          code: "clipboard",
+        });
+      }
+    } catch (e) {
+      error = e;
+    }
+    showExportOutcome(
+      resolveHooksExportOutcome({
+        channel: "copy",
+        empty: false,
+        copyOk,
+        error,
+      }),
+      plan.count,
+    );
+  }, [filteredActivity, outcomeFilter, showExportOutcome]);
+
+  const onExportActivityJson = useCallback(() => {
+    const plan = planHooksActivityExport(filteredActivity, {
+      outcomeFilter,
+    });
+    if (plan.empty) {
+      showExportOutcome(
+        resolveHooksExportOutcome({
+          channel: "download",
+          empty: true,
+        }),
+        0,
+      );
+      return;
+    }
+    let error: unknown;
+    try {
+      const blob = new Blob([plan.json], {
+        type: "application/json;charset=utf-8",
+      });
+      const url = URL.createObjectURL(blob);
+      try {
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = plan.filenameJson;
+        a.click();
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    } catch (e) {
+      error = e;
+      // Normalize unknown throws to download soft-fail when message is vague.
+      if (classifyHooksExportError(e) === "other") {
+        error = Object.assign(
+          e instanceof Error ? e : new Error(String(e)),
+          { code: "download" },
+        );
+      }
+    }
+    showExportOutcome(
+      resolveHooksExportOutcome({
+        channel: "download",
+        empty: false,
+        error,
+      }),
+      plan.count,
+    );
+  }, [filteredActivity, outcomeFilter, showExportOutcome]);
 
   const load = useCallback(async () => {
     if (!api.isTauri()) {
@@ -856,15 +972,33 @@ export function ExtensionsHooksPanel({
           <h3 className="settings-page__h2 ext-hooks-activity__title">
             {tr("ext.hooks.activity.title")}
           </h3>
-          {!clearPlan.empty ? (
+          <div className="ext-hooks-activity__head-actions">
             <button
               type="button"
               className="btn btn--ghost btn--sm"
-              onClick={() => setClearConfirmOpen(true)}
+              title={tr("ext.hooks.activity.exportHint")}
+              onClick={onExportActivityJson}
             >
-              {tr("ext.hooks.activity.clear")}
+              {tr("ext.hooks.activity.export")}
             </button>
-          ) : null}
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              title={tr("ext.hooks.activity.copySummaryHint")}
+              onClick={() => void onCopyActivitySummary()}
+            >
+              {tr("ext.hooks.activity.copySummary")}
+            </button>
+            {!clearPlan.empty ? (
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                onClick={() => setClearConfirmOpen(true)}
+              >
+                {tr("ext.hooks.activity.clear")}
+              </button>
+            ) : null}
+          </div>
         </div>
         <p className="ext-section-note">{tr("ext.hooks.activity.desc")}</p>
         {activity.length > 0 ? (
@@ -882,7 +1016,10 @@ export function ExtensionsHooksPanel({
                 className={
                   "settings-seg__btn" + (outcomeFilter === id ? " is-on" : "")
                 }
-                onClick={() => setOutcomeFilter(id)}
+                onClick={() => {
+                  setOutcomeFilter(id);
+                  setExportMsg(null);
+                }}
               >
                 {filterChipLabel(id, tr)}
                 <span className="ext-hooks-activity__count" aria-hidden>
@@ -891,6 +1028,21 @@ export function ExtensionsHooksPanel({
               </button>
             ))}
           </div>
+        ) : null}
+        {exportMsg ? (
+          <p
+            className={
+              "ext-field-hint ext-hooks-try__msg" +
+              (exportMsg.kind === "ok"
+                ? " ext-hooks-try__msg--ok"
+                : exportMsg.kind === "err"
+                  ? " ext-hooks-try__msg--err"
+                  : "")
+            }
+            role="status"
+          >
+            {exportMsg.text}
+          </p>
         ) : null}
         {activityEmptyState === "empty" ? (
           <p className="ext-field-hint" role="status">

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -4702,6 +4702,20 @@ const en = {
     "Remove {count} recent hook activity row(s) stored on this device. This cannot be undone.",
   "ext.hooks.activity.clearConfirmOk": "Clear",
   "ext.hooks.activity.sourceDebug": "dry-run",
+  "ext.hooks.activity.export": "Export redacted…",
+  "ext.hooks.activity.exportHint":
+    "Download the filtered activity list as redacted JSON (no secrets)",
+  "ext.hooks.activity.copySummary": "Copy summary",
+  "ext.hooks.activity.copySummaryHint":
+    "Copy the filtered activity list as redacted plain text",
+  "ext.hooks.activity.exportCopied": "Copied {count} redacted row(s)",
+  "ext.hooks.activity.exportDownloaded": "Downloaded {count} redacted row(s)",
+  "ext.hooks.activity.exportEmpty": "No activity to export for this filter.",
+  "ext.hooks.activity.exportCopyFailed":
+    "Could not copy summary (clipboard blocked)",
+  "ext.hooks.activity.exportDownloadFailed":
+    "Could not download activity export",
+  "ext.hooks.activity.exportFailed": "Activity export failed",
   "ext.hooks.try.hookName": "Hook name",
   "ext.hooks.try.hookNamePlaceholder": "Optional — pick or type a file name",
   "ext.hooks.try.eventType": "Event type",
@@ -10754,6 +10768,18 @@ const zh: Record<MessageKey, string> = {
     "将移除本机保存的 {count} 条最近 hook 活动记录，此操作不可撤销。",
   "ext.hooks.activity.clearConfirmOk": "清空",
   "ext.hooks.activity.sourceDebug": "试跑",
+  "ext.hooks.activity.export": "导出脱敏…",
+  "ext.hooks.activity.exportHint":
+    "将当前筛选的活动列表下载为脱敏 JSON（不含密钥）",
+  "ext.hooks.activity.copySummary": "复制摘要",
+  "ext.hooks.activity.copySummaryHint":
+    "将当前筛选的活动列表复制为脱敏纯文本",
+  "ext.hooks.activity.exportCopied": "已复制 {count} 条脱敏记录",
+  "ext.hooks.activity.exportDownloaded": "已下载 {count} 条脱敏记录",
+  "ext.hooks.activity.exportEmpty": "当前筛选下没有可导出的活动。",
+  "ext.hooks.activity.exportCopyFailed": "无法复制摘要（剪贴板被拦截）",
+  "ext.hooks.activity.exportDownloadFailed": "无法下载活动导出",
+  "ext.hooks.activity.exportFailed": "活动导出失败",
   "ext.hooks.try.hookName": "Hook 名称",
   "ext.hooks.try.hookNamePlaceholder": "可选 — 选择或输入文件名",
   "ext.hooks.try.eventType": "事件类型",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -4516,6 +4516,18 @@ export const zhTW: Record<MessageKey, string> = {
     "將移除本機保存的 {count} 條最近 hook 活動記錄，此操作無法復原。",
   "ext.hooks.activity.clearConfirmOk": "清空",
   "ext.hooks.activity.sourceDebug": "試跑",
+  "ext.hooks.activity.export": "匯出脫敏…",
+  "ext.hooks.activity.exportHint":
+    "將目前篩選的活動列表下載為脫敏 JSON（不含密鑰）",
+  "ext.hooks.activity.copySummary": "複製摘要",
+  "ext.hooks.activity.copySummaryHint":
+    "將目前篩選的活動列表複製為脫敏純文字",
+  "ext.hooks.activity.exportCopied": "已複製 {count} 條脫敏紀錄",
+  "ext.hooks.activity.exportDownloaded": "已下載 {count} 條脫敏紀錄",
+  "ext.hooks.activity.exportEmpty": "目前篩選下沒有可匯出的活動。",
+  "ext.hooks.activity.exportCopyFailed": "無法複製摘要（剪貼簿被攔截）",
+  "ext.hooks.activity.exportDownloadFailed": "無法下載活動匯出",
+  "ext.hooks.activity.exportFailed": "活動匯出失敗",
   "ext.hooks.try.hookName": "Hook 名稱",
   "ext.hooks.try.hookNamePlaceholder": "選填 — 選擇或輸入檔名",
   "ext.hooks.try.eventType": "事件類型",

--- a/src/lib/hooksActivityExport.test.ts
+++ b/src/lib/hooksActivityExport.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+import type { HookActivityRecord } from "./hooksDebug";
+import {
+  buildHooksActivityExport,
+  classifyHooksExportError,
+  formatHooksActivityExportText,
+  HOOKS_ACTIVITY_EXPORT_MAX,
+  hooksActivityExportIsEmpty,
+  hooksActivityExportJsonFilename,
+  hooksActivityExportTextFilename,
+  hooksExportOutcomeMessageKey,
+  planHooksActivityExport,
+  resolveHooksExportOutcome,
+  serializeHooksActivityExport,
+} from "./hooksActivityExport";
+
+function rec(
+  partial: Partial<HookActivityRecord> & Pick<HookActivityRecord, "id">,
+): HookActivityRecord {
+  return {
+    type: "PreToolUse",
+    outcome: "ok",
+    atMs: 1_700_000_000_000,
+    detail: "exit 0",
+    source: "host",
+    ...partial,
+  };
+}
+
+describe("planHooksActivityExport", () => {
+  it("builds redacted JSON/text and empty honesty", () => {
+    const rows: HookActivityRecord[] = [
+      rec({
+        id: "ha-1",
+        type: "TryRun",
+        outcome: "fail",
+        detail: "hook failed key=sk-abcdefghijklmnop token: supersecretvalue123",
+        source: "try",
+        hookName: "demo.sh",
+      }),
+      rec({
+        id: "ha-2",
+        outcome: "ok",
+        detail: "loaded from user",
+        source: "stderr",
+      }),
+    ];
+
+    const plan = planHooksActivityExport(rows, {
+      generatedAt: "2026-08-01T12:00:00.000Z",
+      outcomeFilter: "all",
+    });
+
+    expect(plan.empty).toBe(false);
+    expect(plan.count).toBe(2);
+    expect(plan.truncated).toBe(false);
+    expect(plan.snapshot.kind).toBe("hooks_activity");
+    expect(plan.snapshot.summary).toEqual({
+      ok: 1,
+      fail: 1,
+      skip: 0,
+      info: 0,
+      total: 2,
+    });
+    expect(plan.filenameJson).toBe(
+      "grok-app-hooks-activity-2026-08-01-12-00-00.json",
+    );
+    expect(plan.filenameText).toBe(
+      "grok-app-hooks-activity-2026-08-01-12-00-00.txt",
+    );
+
+    const row0 = plan.snapshot.rows[0]!;
+    expect(row0.detail).toContain("[REDACTED]");
+    expect(row0.detail).not.toContain("sk-abcdefghijklmnop");
+    expect(row0.detail).not.toContain("supersecretvalue123");
+    expect(row0.hookName).toBe("demo.sh");
+
+    expect(plan.json).not.toMatch(/sk-[A-Za-z0-9]{10,}/);
+    expect(plan.json).not.toContain("supersecretvalue123");
+    expect(plan.text).toContain("# Hooks activity export (redacted)");
+    expect(plan.text).toContain("[FAIL]");
+    expect(plan.text).toContain("summary: total=2");
+    expect(plan.text).not.toMatch(/sk-[A-Za-z0-9]{10,}/);
+  });
+
+  it("soft-fails empty export without inventing rows", () => {
+    const plan = planHooksActivityExport([]);
+    expect(plan.empty).toBe(true);
+    expect(plan.count).toBe(0);
+    expect(plan.snapshot.rows).toEqual([]);
+    expect(plan.text).toBe("");
+    expect(hooksActivityExportIsEmpty(plan)).toBe(true);
+    expect(hooksActivityExportIsEmpty(plan.snapshot)).toBe(true);
+    expect(hooksActivityExportIsEmpty(null)).toBe(true);
+
+    const emptySnap = buildHooksActivityExport(null);
+    expect(emptySnap.count).toBe(0);
+    expect(formatHooksActivityExportText([])).toBe("");
+  });
+
+  it("honors soft max rows cap and marks truncated", () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      rec({ id: `ha-${i}`, detail: `row ${i}` }),
+    );
+    const plan = planHooksActivityExport(many, { max: 5 });
+    expect(plan.count).toBe(5);
+    expect(plan.truncated).toBe(true);
+    expect(plan.snapshot.rows).toHaveLength(5);
+    expect(plan.snapshot.summary.total).toBe(5);
+  });
+
+  it("dedupes by id and echoes outcome filter", () => {
+    const rows = [
+      rec({ id: "same", outcome: "fail", detail: "a" }),
+      rec({ id: "same", outcome: "fail", detail: "b" }),
+      rec({ id: "other", outcome: "skip", detail: "c" }),
+    ];
+    const snap = buildHooksActivityExport(rows, {
+      outcomeFilter: "fail",
+    });
+    expect(snap.count).toBe(2);
+    expect(snap.filter.outcome).toBe("fail");
+    expect(snap.rows.map((r) => r.id)).toEqual(["same", "other"]);
+  });
+
+  it("skips invalid records", () => {
+    const junk = { id: "x", type: "Hook" } as unknown as HookActivityRecord;
+    const plan = planHooksActivityExport([junk, rec({ id: "good" })]);
+    expect(plan.count).toBe(1);
+    expect(plan.snapshot.rows[0]!.id).toBe("good");
+  });
+
+  it("default max is soft-capped constant", () => {
+    expect(HOOKS_ACTIVITY_EXPORT_MAX).toBeGreaterThanOrEqual(30);
+    expect(HOOKS_ACTIVITY_EXPORT_MAX).toBeLessThanOrEqual(500);
+  });
+});
+
+describe("formatHooksActivityExportText", () => {
+  it("formats rows and accepts a snapshot", () => {
+    const rows = [
+      rec({
+        id: "ha-1",
+        type: "SessionStart",
+        outcome: "ok",
+        detail: "loaded",
+        source: "host",
+        toolName: "bash",
+      }),
+    ];
+    const textFromRows = formatHooksActivityExportText(rows, {
+      generatedAt: "2026-08-01T00:00:00.000Z",
+    });
+    expect(textFromRows).toContain("generatedAt: 2026-08-01T00:00:00.000Z");
+    expect(textFromRows).toContain("[OK] SessionStart");
+    expect(textFromRows).toContain("tool: bash");
+
+    const snap = buildHooksActivityExport(rows, {
+      generatedAt: "2026-08-01T00:00:00.000Z",
+    });
+    expect(formatHooksActivityExportText(snap)).toContain("### 1/1");
+    expect(serializeHooksActivityExport(snap)).toContain('"kind": "hooks_activity"');
+  });
+});
+
+describe("classifyHooksExportError / resolveHooksExportOutcome", () => {
+  it("classifies empty | clipboard | download | other", () => {
+    expect(classifyHooksExportError(new Error("nothing to export"))).toBe(
+      "empty",
+    );
+    expect(classifyHooksExportError(new Error("clipboard blocked"))).toBe(
+      "clipboard",
+    );
+    expect(classifyHooksExportError(new Error("download failed"))).toBe(
+      "download",
+    );
+    expect(classifyHooksExportError({ code: "download_failed" })).toBe(
+      "download",
+    );
+    expect(classifyHooksExportError({ code: "clipboard" })).toBe("clipboard");
+    expect(classifyHooksExportError({ code: "empty" })).toBe("empty");
+    expect(classifyHooksExportError(new Error("weird boom"))).toBe("other");
+    expect(classifyHooksExportError(null)).toBe("other");
+  });
+
+  it("resolves outcomes honestly and maps i18n keys", () => {
+    expect(
+      resolveHooksExportOutcome({
+        channel: "copy",
+        empty: true,
+        copyOk: true,
+      }),
+    ).toEqual({ ok: false, kind: "empty", channel: "copy" });
+
+    expect(
+      resolveHooksExportOutcome({
+        channel: "copy",
+        empty: false,
+        copyOk: false,
+      }),
+    ).toEqual({ ok: false, kind: "clipboard", channel: "copy" });
+
+    expect(
+      resolveHooksExportOutcome({
+        channel: "download",
+        empty: false,
+        error: new Error("blob failed"),
+      }),
+    ).toEqual({ ok: false, kind: "download", channel: "download" });
+
+    expect(
+      resolveHooksExportOutcome({
+        channel: "download",
+        empty: false,
+      }),
+    ).toEqual({ ok: true, channel: "download" });
+
+    expect(
+      hooksExportOutcomeMessageKey({ ok: true, channel: "copy" }),
+    ).toBe("ext.hooks.activity.exportCopied");
+    expect(
+      hooksExportOutcomeMessageKey({ ok: true, channel: "download" }),
+    ).toBe("ext.hooks.activity.exportDownloaded");
+    expect(
+      hooksExportOutcomeMessageKey({
+        ok: false,
+        kind: "empty",
+        channel: "copy",
+      }),
+    ).toBe("ext.hooks.activity.exportEmpty");
+    expect(
+      hooksExportOutcomeMessageKey({
+        ok: false,
+        kind: "clipboard",
+        channel: "copy",
+      }),
+    ).toBe("ext.hooks.activity.exportCopyFailed");
+    expect(
+      hooksExportOutcomeMessageKey({
+        ok: false,
+        kind: "download",
+        channel: "download",
+      }),
+    ).toBe("ext.hooks.activity.exportDownloadFailed");
+    expect(
+      hooksExportOutcomeMessageKey({
+        ok: false,
+        kind: "other",
+        channel: "download",
+      }),
+    ).toBe("ext.hooks.activity.exportFailed");
+  });
+});
+
+describe("filenames", () => {
+  it("builds safe download basenames", () => {
+    expect(
+      hooksActivityExportJsonFilename("2026-08-01T12:34:56.000Z"),
+    ).toBe("grok-app-hooks-activity-2026-08-01-12-34-56.json");
+    expect(
+      hooksActivityExportTextFilename("2026-08-01T12:34:56.000Z"),
+    ).toBe("grok-app-hooks-activity-2026-08-01-12-34-56.txt");
+  });
+});

--- a/src/lib/hooksActivityExport.ts
+++ b/src/lib/hooksActivityExport.ts
@@ -1,0 +1,520 @@
+/**
+ * Hooks activity export — pure helpers for redacted JSON/text download
+ * and clipboard summary from the local recent-activity ring.
+ *
+ * Never invents rows. Re-redacts every free-form field before export.
+ * Soft-fails empty / clipboard / download without claiming success.
+ * No DOM / Tauri side effects — callers own clipboard and downloads.
+ */
+
+import { redact } from "./redact";
+import {
+  HOOK_ACTIVITY_MAX,
+  HOOK_DETAIL_MAX,
+  parseHookActivityRecord,
+  type HookActivityOutcome,
+  type HookActivityRecord,
+  type HookActivitySource,
+} from "./hooksDebug";
+
+/** Soft max rows in a single export (UI ring is smaller; allow headroom). */
+export const HOOKS_ACTIVITY_EXPORT_MAX = 100;
+
+/** Cap free-form type / detail / name fields so exports never carry multi-kb dumps. */
+export const HOOKS_ACTIVITY_EXPORT_FIELD_MAX = 200;
+
+/** One row in a hooks activity export file (known fields only; re-redacted). */
+export type HooksActivityExportRow = {
+  id: string;
+  type: string;
+  outcome: HookActivityOutcome;
+  /** Epoch ms when recorded (local). */
+  atMs: number;
+  /** ISO timestamp for human readability. */
+  at: string;
+  detail: string;
+  source: HookActivitySource;
+  toolName?: string;
+  hookName?: string;
+};
+
+/** Echo of filters used to select rows (never free-form secrets). */
+export type HooksActivityExportFilter = {
+  outcome: "all" | HookActivityOutcome;
+};
+
+/**
+ * Redacted hooks activity export (download / clipboard).
+ * Structured fields only — details re-run through {@link redact}.
+ */
+export type HooksActivityExport = {
+  kind: "hooks_activity";
+  generatedAt: string;
+  source: "hooks_activity";
+  count: number;
+  /** True when input had more rows than the soft max cap. */
+  truncated: boolean;
+  summary: {
+    ok: number;
+    fail: number;
+    skip: number;
+    info: number;
+    total: number;
+  };
+  filter: HooksActivityExportFilter;
+  rows: HooksActivityExportRow[];
+};
+
+/**
+ * Planned export payload for UI: redacted JSON + text, empty honesty,
+ * safe filenames. Never invents rows when input is empty.
+ */
+export type HooksActivityExportPlan = {
+  empty: boolean;
+  count: number;
+  truncated: boolean;
+  snapshot: HooksActivityExport;
+  /** Pretty JSON body (always valid; empty plan still has count 0). */
+  json: string;
+  /** Plain-text summary. Empty when nothing honest to export. */
+  text: string;
+  filenameJson: string;
+  filenameText: string;
+};
+
+/** Soft-fail kinds for copy / download. */
+export type HooksExportErrorKind =
+  | "empty"
+  | "clipboard"
+  | "download"
+  | "other";
+
+export type HooksExportChannel = "copy" | "download";
+
+export type HooksExportOutcome =
+  | { ok: true; channel: HooksExportChannel }
+  | {
+      ok: false;
+      kind: HooksExportErrorKind;
+      channel: HooksExportChannel;
+    };
+
+const OUTCOMES = new Set<string>(["ok", "fail", "skip", "info"]);
+
+function capField(
+  raw: string | null | undefined,
+  max: number = HOOKS_ACTIVITY_EXPORT_FIELD_MAX,
+): string {
+  if (typeof raw !== "string") return "";
+  let s = redact(raw)
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!s) return "";
+  // Extra secret-ish key=value patterns (same spirit as hooksDebug).
+  s = s.replace(
+    /\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*["']?[^\s"',;]{6,}/gi,
+    "$1=[REDACTED]",
+  );
+  if (s.length > max) {
+    s = `${s.slice(0, Math.max(1, max - 1))}…`;
+  }
+  return s;
+}
+
+function isoFromMs(atMs: number): string {
+  if (!atMs || atMs <= 0 || !Number.isFinite(atMs)) return "";
+  try {
+    return new Date(atMs).toISOString();
+  } catch {
+    return "";
+  }
+}
+
+function normalizeOutcomeFilter(
+  raw: string | null | undefined,
+): HooksActivityExportFilter["outcome"] {
+  const s = String(raw ?? "")
+    .trim()
+    .toLowerCase();
+  if (OUTCOMES.has(s)) return s as HookActivityOutcome;
+  return "all";
+}
+
+function toExportRow(rec: HookActivityRecord): HooksActivityExportRow {
+  const detail = capField(rec.detail, HOOK_DETAIL_MAX);
+  const type = capField(rec.type, 80) || "Hook";
+  const id = capField(rec.id, 80) || "unknown";
+  const toolName = capField(rec.toolName, 120);
+  const hookName = capField(rec.hookName, 160);
+  return {
+    id,
+    type,
+    outcome: rec.outcome,
+    atMs: rec.atMs > 0 ? rec.atMs : 0,
+    at: isoFromMs(rec.atMs),
+    detail,
+    source: rec.source,
+    ...(toolName ? { toolName } : {}),
+    ...(hookName ? { hookName } : {}),
+  };
+}
+
+/**
+ * Build a redacted export snapshot from activity rows.
+ * Prefer filtered rows from the UI. Never invents data.
+ * Empty input → count 0 snapshot (caller soft-fails; no throw).
+ */
+export function buildHooksActivityExport(
+  rows: readonly HookActivityRecord[] | null | undefined,
+  opts?: {
+    nowMs?: number;
+    max?: number;
+    generatedAt?: string;
+    outcomeFilter?: string | null;
+  },
+): HooksActivityExport {
+  const maxRaw = opts?.max ?? HOOKS_ACTIVITY_EXPORT_MAX;
+  const max =
+    typeof maxRaw === "number" && Number.isFinite(maxRaw) && maxRaw > 0
+      ? Math.min(500, Math.floor(maxRaw))
+      : HOOKS_ACTIVITY_EXPORT_MAX;
+  const generatedAt =
+    opts?.generatedAt ??
+    new Date(opts?.nowMs ?? Date.now()).toISOString();
+  const filter: HooksActivityExportFilter = {
+    outcome: normalizeOutcomeFilter(opts?.outcomeFilter),
+  };
+
+  const list = Array.isArray(rows) ? rows : [];
+  const out: HooksActivityExportRow[] = [];
+  const seen = new Set<string>();
+  let truncated = false;
+
+  for (const raw of list) {
+    const parsed = parseHookActivityRecord(raw);
+    if (!parsed) continue;
+    if (seen.has(parsed.id)) continue;
+    seen.add(parsed.id);
+    if (out.length >= max) {
+      truncated = true;
+      continue;
+    }
+    out.push(toExportRow(parsed));
+  }
+
+  let ok = 0;
+  let fail = 0;
+  let skip = 0;
+  let info = 0;
+  for (const row of out) {
+    if (row.outcome === "ok") ok += 1;
+    else if (row.outcome === "fail") fail += 1;
+    else if (row.outcome === "skip") skip += 1;
+    else info += 1;
+  }
+
+  return {
+    kind: "hooks_activity",
+    generatedAt,
+    source: "hooks_activity",
+    count: out.length,
+    truncated,
+    summary: {
+      ok,
+      fail,
+      skip,
+      info,
+      total: out.length,
+    },
+    filter,
+    rows: out,
+  };
+}
+
+/** Pretty JSON for client download (known fields only; already redacted). */
+export function serializeHooksActivityExport(
+  snapshot: HooksActivityExport,
+): string {
+  return JSON.stringify(snapshot, null, 2);
+}
+
+/**
+ * Plain-text export body (clipboard / .txt).
+ * Accepts either a snapshot or raw activity rows.
+ * Empty → empty string so UI can soft-fail without inventing activity.
+ */
+export function formatHooksActivityExportText(
+  rowsOrSnapshot:
+    | readonly HookActivityRecord[]
+    | HooksActivityExport
+    | null
+    | undefined,
+  opts?: {
+    nowMs?: number;
+    max?: number;
+    generatedAt?: string;
+    outcomeFilter?: string | null;
+  },
+): string {
+  const snapshot: HooksActivityExport =
+    rowsOrSnapshot &&
+    typeof rowsOrSnapshot === "object" &&
+    !Array.isArray(rowsOrSnapshot) &&
+    (rowsOrSnapshot as HooksActivityExport).kind === "hooks_activity"
+      ? (rowsOrSnapshot as HooksActivityExport)
+      : buildHooksActivityExport(
+          rowsOrSnapshot as readonly HookActivityRecord[] | null | undefined,
+          opts,
+        );
+
+  if (!snapshot || snapshot.count === 0 || snapshot.rows.length === 0) {
+    return "";
+  }
+
+  const s = snapshot.summary;
+  const f = snapshot.filter;
+  const header = [
+    "# Hooks activity export (redacted)",
+    `generatedAt: ${snapshot.generatedAt}`,
+    `filter: outcome=${f.outcome}`,
+    `summary: total=${s.total} ok=${s.ok} fail=${s.fail} skip=${s.skip} info=${s.info}${
+      snapshot.truncated ? " truncated=true" : ""
+    }`,
+    "",
+  ];
+
+  const blocks = snapshot.rows.map((row, i) => {
+    const lines = [
+      `### ${i + 1}/${snapshot.count}`,
+      `[${row.outcome.toUpperCase()}] ${row.type}`,
+      `id: ${row.id}`,
+      `source: ${row.source}`,
+      `at: ${row.at || String(row.atMs || "")}`,
+    ];
+    if (row.hookName) lines.push(`hook: ${row.hookName}`);
+    if (row.toolName) lines.push(`tool: ${row.toolName}`);
+    if (row.detail) {
+      lines.push("");
+      lines.push(row.detail);
+    }
+    return lines.join("\n");
+  });
+
+  const body = [...header, blocks.join("\n\n")].join("\n");
+  return redact(body).trim() + "\n";
+}
+
+/** Soft-empty: nothing honest to export. */
+export function hooksActivityExportIsEmpty(
+  snapshot: HooksActivityExport | HooksActivityExportPlan | null | undefined,
+): boolean {
+  if (!snapshot) return true;
+  if ("empty" in snapshot && typeof snapshot.empty === "boolean") {
+    return snapshot.empty || snapshot.count === 0;
+  }
+  const s = snapshot as HooksActivityExport;
+  return !s.count || s.count === 0 || !s.rows || s.rows.length === 0;
+}
+
+/** Filesystem-safe download basename (no extension). */
+export function hooksActivityExportBasename(
+  generatedAt?: string | null,
+): string {
+  const stamp = (generatedAt ?? new Date().toISOString())
+    .slice(0, 19)
+    .replace(/[:T]/g, "-")
+    .replace(/[^0-9A-Za-z._-]/g, "");
+  return `grok-app-hooks-activity-${stamp || "export"}`;
+}
+
+export function hooksActivityExportJsonFilename(
+  generatedAt?: string | null,
+): string {
+  return `${hooksActivityExportBasename(generatedAt)}.json`;
+}
+
+export function hooksActivityExportTextFilename(
+  generatedAt?: string | null,
+): string {
+  return `${hooksActivityExportBasename(generatedAt)}.txt`;
+}
+
+/**
+ * Plan a redacted export from activity rows.
+ * Returns JSON + text + empty honesty for soft-fail UI.
+ * Soft max rows via {@link HOOKS_ACTIVITY_EXPORT_MAX} (overridable).
+ */
+export function planHooksActivityExport(
+  rows: readonly HookActivityRecord[] | null | undefined,
+  opts?: {
+    nowMs?: number;
+    max?: number;
+    generatedAt?: string;
+    outcomeFilter?: string | null;
+  },
+): HooksActivityExportPlan {
+  const snapshot = buildHooksActivityExport(rows, opts);
+  const empty = snapshot.count === 0;
+  const json = serializeHooksActivityExport(snapshot);
+  const text = empty ? "" : formatHooksActivityExportText(snapshot);
+  return {
+    empty,
+    count: snapshot.count,
+    truncated: snapshot.truncated,
+    snapshot,
+    json,
+    text,
+    filenameJson: hooksActivityExportJsonFilename(snapshot.generatedAt),
+    filenameText: hooksActivityExportTextFilename(snapshot.generatedAt),
+  };
+}
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as { code?: unknown; message?: unknown; reason?: unknown };
+    const parts = [o.code, o.message, o.reason]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+  }
+  return String(err);
+}
+
+/**
+ * Classify a thrown value into a stable export soft-fail kind.
+ * Prefer explicit `code` over free-form text.
+ * Kinds: empty | clipboard | download | other.
+ */
+export function classifyHooksExportError(err: unknown): HooksExportErrorKind {
+  if (err == null || err === "") return "other";
+
+  const code =
+    typeof err === "object" &&
+    err != null &&
+    typeof (err as { code?: unknown }).code === "string"
+      ? String((err as { code: string }).code).trim().toLowerCase()
+      : "";
+
+  if (
+    code === "empty" ||
+    code === "empty_view" ||
+    code === "nothing" ||
+    code === "no_rows"
+  ) {
+    return "empty";
+  }
+  if (code === "clipboard" || code === "clipboard_failed") return "clipboard";
+  if (
+    code === "download" ||
+    code === "download_failed" ||
+    code === "download-failed" ||
+    code === "write_failed" ||
+    code === "save_failed"
+  ) {
+    return "download";
+  }
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+  if (
+    s.includes("nothing to export") ||
+    s.includes("no activity") ||
+    s.includes("empty view") ||
+    s.includes("no rows") ||
+    /^empty(\s+error)?$/.test(s.trim()) ||
+    s.trim() === "error: empty"
+  ) {
+    return "empty";
+  }
+  if (
+    s.includes("clipboard") ||
+    s.includes("write text") ||
+    s.includes("copy failed") ||
+    s.includes("notallowed") ||
+    s.includes("permission denied")
+  ) {
+    return "clipboard";
+  }
+  if (
+    s.includes("download") ||
+    s.includes("save failed") ||
+    s.includes("write failed") ||
+    s.includes("createobjecturl") ||
+    s.includes("blob")
+  ) {
+    return "download";
+  }
+  return "other";
+}
+
+/**
+ * Resolve copy/download outcome for toast honesty.
+ * Empty plans always soft-fail as `empty` (never claim success).
+ */
+export function resolveHooksExportOutcome(opts: {
+  channel: HooksExportChannel;
+  empty: boolean;
+  /** For copy: false when clipboard API failed without throwing. */
+  copyOk?: boolean;
+  /** Thrown error from clipboard / download path. */
+  error?: unknown;
+}): HooksExportOutcome {
+  const channel = opts.channel === "download" ? "download" : "copy";
+  if (opts.empty) {
+    return { ok: false, kind: "empty", channel };
+  }
+  if (opts.error != null) {
+    return {
+      ok: false,
+      kind: classifyHooksExportError(opts.error),
+      channel,
+    };
+  }
+  if (channel === "copy" && opts.copyOk === false) {
+    return { ok: false, kind: "clipboard", channel };
+  }
+  return { ok: true, channel };
+}
+
+/**
+ * i18n message key for an export outcome (success or soft-fail).
+ * Keys must exist under `ext.hooks.activity.*` in messages.
+ */
+export function hooksExportOutcomeMessageKey(
+  outcome: HooksExportOutcome,
+):
+  | "ext.hooks.activity.exportCopied"
+  | "ext.hooks.activity.exportDownloaded"
+  | "ext.hooks.activity.exportEmpty"
+  | "ext.hooks.activity.exportCopyFailed"
+  | "ext.hooks.activity.exportDownloadFailed"
+  | "ext.hooks.activity.exportFailed" {
+  if (outcome.ok) {
+    return outcome.channel === "download"
+      ? "ext.hooks.activity.exportDownloaded"
+      : "ext.hooks.activity.exportCopied";
+  }
+  switch (outcome.kind) {
+    case "empty":
+      return "ext.hooks.activity.exportEmpty";
+    case "clipboard":
+      return "ext.hooks.activity.exportCopyFailed";
+    case "download":
+      return "ext.hooks.activity.exportDownloadFailed";
+    default:
+      return "ext.hooks.activity.exportFailed";
+  }
+}
+
+/** Re-export ring size for callers that want a sensible default cap. */
+export { HOOK_ACTIVITY_MAX };

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21007,6 +21007,14 @@ div.composer__input:empty::before {
   margin-top: 12px;
 }
 
+.ext-hooks-activity__head-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
 .ext-hooks-activity__head {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Pure `hooksActivityExport` helpers: `planHooksActivityExport` / `formatHooksActivityExportText` / `classifyHooksExportError` (empty · clipboard · download · other) with soft max row cap and re-redaction of free-form fields
- Settings → Extensions → Hooks → Recent activity: **Export redacted…** (JSON download) + **Copy summary** (plain text) with classified soft-fail status; empty-filter honesty; no `window.confirm`; never exports secrets
- i18n en / zh / zh-TW + CHANGELOG Unreleased note

## Test plan
- [x] `pnpm test -- src/lib/hooksActivityExport.test.ts src/lib/hooksDebug.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: open Extensions → Hooks with empty activity → export/copy soft-fails empty
- [ ] Manual: record try-run rows → export JSON + copy summary; confirm no secrets in payload
- [ ] Manual: filter to unmatched outcome → empty filter copy + export soft-fail