### PR TITLE
feat(account): heatmap empty honesty and range summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Account heatmap empty honesty** (HEATMAP-USAGE-PRO): soft-fail when local session signals are missing (never invent activity cells or SuperGrok quota); day/week range chips + active-days / tokens / sessions summary chips; classified Host errors (`host_only` · `network` · `empty` · `other`). Pure `heatmapUsagePro` / `heatmapRange` helpers + tests; en/zh/zh-TW.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitejs/plugin-react-swc':
+        specifier: ^3.11.0
+        version: 3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
       canvas:
         specifier: ^3.2.3
         version: 3.2.3
@@ -455,35 +458,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -643,79 +641,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -746,6 +731,93 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@swc/core-darwin-arm64@1.15.47':
+    resolution: {integrity: sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.47':
+    resolution: {integrity: sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    resolution: {integrity: sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    resolution: {integrity: sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    resolution: {integrity: sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    resolution: {integrity: sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    resolution: {integrity: sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    resolution: {integrity: sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    resolution: {integrity: sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    resolution: {integrity: sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    resolution: {integrity: sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    resolution: {integrity: sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.47':
+    resolution: {integrity: sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tabler/icons-react@3.45.0':
     resolution: {integrity: sha512-t/AuKs7ALMDDTY+B9IvfZnlO0mbLlP/lJxP/HnGC49QkM8mCsTN38kYyxjXxgrb1+TeK53ioVBJqIV7n/eysXQ==}
@@ -793,28 +865,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -875,35 +943,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.4':
     resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -1277,6 +1340,11 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitejs/plugin-react-swc@3.11.0':
+    resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
+    peerDependencies:
+      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1933,28 +2001,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3244,6 +3308,66 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@swc/core-darwin-arm64@1.15.47':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core@1.15.47':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.47
+      '@swc/core-darwin-x64': 1.15.47
+      '@swc/core-linux-arm-gnueabihf': 1.15.47
+      '@swc/core-linux-arm64-gnu': 1.15.47
+      '@swc/core-linux-arm64-musl': 1.15.47
+      '@swc/core-linux-ppc64-gnu': 1.15.47
+      '@swc/core-linux-s390x-gnu': 1.15.47
+      '@swc/core-linux-x64-gnu': 1.15.47
+      '@swc/core-linux-x64-musl': 1.15.47
+      '@swc/core-win32-arm64-msvc': 1.15.47
+      '@swc/core-win32-ia32-msvc': 1.15.47
+      '@swc/core-win32-x64-msvc': 1.15.47
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.28':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@tabler/icons-react@3.45.0(react@19.2.7)':
     dependencies:
       '@tabler/icons': 3.45.0
@@ -3777,6 +3901,14 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitejs/plugin-react-swc@3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@swc/core': 1.15.47
+      vite: 6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2660,6 +2660,8 @@ export default function App() {
   const [account, setAccount] = useState<api.AccountStatus | null>(null);
   const [accountLoading, setAccountLoading] = useState(false);
   const [accountBusy, setAccountBusy] = useState(false);
+  /** Soft-fail heatmap / account_status error (never invents activity or quota). */
+  const [accountHeatmapError, setAccountHeatmapError] = useState<unknown>(null);
   const [loginHint, setLoginHint] = useState<string | null>(null);
   const platform = useMemo(() => detectAppPlatform(), []);
   /** Self-drawn chrome when OS title bar is disabled (Windows release config). */
@@ -14397,7 +14399,11 @@ export default function App() {
 
   const refreshAccount = useCallback(
     async (opts?: { refreshBilling?: boolean }) => {
-      if (!api.isTauri()) return;
+      if (!api.isTauri()) {
+        // Browser preview: soft-fail host_only — never invent heatmap/quota.
+        setAccountHeatmapError({ code: "host_only", message: "need tauri" });
+        return;
+      }
       setAccountLoading(true);
       try {
         const st = await api.accountStatus({
@@ -14405,6 +14411,7 @@ export default function App() {
           manualCliPath: manualCliPath || null,
         });
         setAccount(st);
+        setAccountHeatmapError(null);
         setSetup((s) => ({
           ...s,
           auth: isAccountConnected(st),
@@ -14421,6 +14428,7 @@ export default function App() {
         void api.trayRefresh();
       } catch (e) {
         console.warn("account status failed", e);
+        setAccountHeatmapError(e);
       } finally {
         setAccountLoading(false);
       }
@@ -17102,6 +17110,7 @@ export default function App() {
           account={account}
           accountLoading={accountLoading}
           accountBusy={accountBusy}
+          accountHeatmapError={accountHeatmapError}
           loginHint={loginHint}
           savedAccounts={savedAccounts}
           activeAccountId={activeAccountId}

--- a/src/components/AccountPanel.tsx
+++ b/src/components/AccountPanel.tsx
@@ -26,6 +26,14 @@ import {
   type HeatGranularity,
   type HeatRange,
 } from "@/components/Heatmap";
+import {
+  heatmapErrorView,
+  heatmapHasSamples,
+  heatmapSummaryChips,
+  listHeatmapGranularityChips,
+  resolveHeatmapErrorChip,
+  summarizeHeatmapRange,
+} from "@/lib/heatmapUsagePro";
 import { GlassModal } from "@/components/GlassModal";
 import { Tip } from "@/components/ui/tooltip";
 import { IconPlus, IconTrash, IconUser } from "@/components/icons";
@@ -70,6 +78,12 @@ export interface AccountPanelLabels {
   fetchedAt: string;
   products: string;
   heatmapNoData: string;
+  /** Body under no-data empty (local sessions only — not SuperGrok quota). */
+  heatmapNoDataHint: string;
+  heatmapLoading: string;
+  heatmapLoadingHint: string;
+  heatmapRangeEmpty: string;
+  heatmapRangeEmptyHint: string;
   heatmapAria: string;
   heatmapRequests: string;
   heatmapTokens: string;
@@ -83,6 +97,10 @@ export interface AccountPanelLabels {
   heatmapWeek: string;
   /** Total tokens across heatmap (or selected range). Includes `{count}`. */
   heatmapTotalTokens: string;
+  /** Active days chip. Includes `{count}`. */
+  heatmapActiveDays: string;
+  /** Sessions count chip. Includes `{count}`. */
+  heatmapSessionsCount: string;
   weeklyTitle: string;
   loginHelpTitle: string;
   loginHelpBody: string;
@@ -113,6 +131,11 @@ export interface AccountPanelProps {
   labels: AccountPanelLabels;
   compact?: boolean;
   loginHint?: string | null;
+  /**
+   * Soft-fail error from account_status / host (heatmap only surfaces this —
+   * never invents activity cells or SuperGrok quota from it).
+   */
+  heatmapError?: unknown;
   savedAccounts?: SavedAccount[];
   activeAccountId?: string | null;
   onLoginOauth: () => void;
@@ -149,6 +172,7 @@ export function AccountPanel({
   labels,
   compact = false,
   loginHint = null,
+  heatmapError = null,
   savedAccounts = [],
   activeAccountId = null,
   onLoginOauth,
@@ -186,20 +210,48 @@ export function AccountPanel({
   /** Same absolute clock as sidebar UserMenu (`MM-DD HH:mm`). */
   const resetTime = formatQuotaResetTime(billing?.resetsAt);
 
+  const heatDays = status?.heatmap ?? [];
+  const heatHasSamples = useMemo(
+    () => heatmapHasSamples(heatDays),
+    [heatDays],
+  );
+
+  /** Honest counts for full heatmap or selected day/week range. */
+  const heatSummary = useMemo(
+    () => summarizeHeatmapRange(heatDays, selectedHeatRange),
+    [heatDays, selectedHeatRange],
+  );
+  const heatChips = useMemo(
+    () => heatmapSummaryChips(heatSummary),
+    [heatSummary],
+  );
+  const heatErrChip = useMemo(
+    () => resolveHeatmapErrorChip(heatmapError),
+    [heatmapError],
+  );
+  const heatErrView = useMemo(
+    () => (heatmapError != null && heatmapError !== ""
+      ? heatmapErrorView(heatmapError)
+      : null),
+    [heatmapError],
+  );
+  const heatmapErrTitle = heatErrView
+    ? t(heatErrView.titleKey)
+    : t("account.heatmap.err.other");
+  const heatmapErrHint = heatErrView
+    ? t(heatErrView.hintKey)
+    : t("account.heatmap.err.otherHint");
+  const granularityChips = useMemo(
+    () => listHeatmapGranularityChips(heatGranularity),
+    [heatGranularity],
+  );
+
   const rangeSessionCount = selectedHeatRange
-    ? sumHeatInRange(status?.heatmap ?? [], selectedHeatRange).requests
+    ? sumHeatInRange(heatDays, selectedHeatRange).requests
     : null;
 
-  /** Full heatmap total, or tokens in the selected day/week range. */
-  const heatTokenTotal = useMemo(() => {
-    const days = status?.heatmap ?? [];
-    if (selectedHeatRange) {
-      return sumHeatInRange(days, selectedHeatRange).tokens;
-    }
-    let tokens = 0;
-    for (const d of days) tokens += d.tokens;
-    return tokens;
-  }, [status?.heatmap, selectedHeatRange]);
+  /** Tokens in selected range or full heatmap — only when real activity exists. */
+  const heatTokenTotal = heatChips?.totalTokens ?? 0;
 
   const filteredCallLogs = useMemo(() => {
     const logs = status?.callLogs ?? [];
@@ -616,68 +668,120 @@ export function AccountPanel({
             <div className="account-section__title account-section__title--row">
               <span>{labels.heatmap}</span>
               <div className="account-heatmap-title-meta">
-                <span
-                  className="account-heatmap-total"
-                  title={
-                    Number.isFinite(heatTokenTotal)
-                      ? String(Math.round(heatTokenTotal))
-                      : undefined
-                  }
-                >
-                  {labels.heatmapTotalTokens.replace(
-                    "{count}",
-                    // Always Chinese units (千 / 万·萬 / 亿·億), not English k/M.
-                    formatChineseCount(
-                      heatTokenTotal,
-                      locale === "zh-TW" ? "zh-TW" : "zh",
-                    ),
-                  )}
-                </span>
+                {heatErrChip ? (
+                  <span
+                    className="account-heatmap-err-chip"
+                    title={heatmapErrHint}
+                    data-kind={heatErrChip.kind}
+                  >
+                    {heatmapErrTitle}
+                  </span>
+                ) : null}
+                {heatChips ? (
+                  <div className="account-heatmap-summary" aria-live="polite">
+                    <span
+                      className="account-heatmap-total account-heatmap-chip"
+                      title={String(heatChips.activeDays)}
+                    >
+                      {labels.heatmapActiveDays.replace(
+                        "{count}",
+                        formatChineseCount(
+                          heatChips.activeDays,
+                          locale === "zh-TW" ? "zh-TW" : "zh",
+                        ),
+                      )}
+                    </span>
+                    <span
+                      className="account-heatmap-total account-heatmap-chip"
+                      title={
+                        Number.isFinite(heatTokenTotal)
+                          ? String(Math.round(heatTokenTotal))
+                          : undefined
+                      }
+                    >
+                      {labels.heatmapTotalTokens.replace(
+                        "{count}",
+                        // Always Chinese units (千 / 万·萬 / 亿·億), not English k/M.
+                        formatChineseCount(
+                          heatTokenTotal,
+                          locale === "zh-TW" ? "zh-TW" : "zh",
+                        ),
+                      )}
+                    </span>
+                    <span
+                      className="account-heatmap-total account-heatmap-chip"
+                      title={String(heatChips.totalRequests)}
+                    >
+                      {labels.heatmapSessionsCount.replace(
+                        "{count}",
+                        formatChineseCount(
+                          heatChips.totalRequests,
+                          locale === "zh-TW" ? "zh-TW" : "zh",
+                        ),
+                      )}
+                    </span>
+                  </div>
+                ) : heatHasSamples || loading ? null : (
+                  <span
+                    className="account-heatmap-total account-heatmap-chip account-heatmap-chip--muted"
+                    title={labels.heatmapNoDataHint}
+                  >
+                    {labels.heatmapNoData}
+                  </span>
+                )}
                 <div
                   className="account-heat-toggle"
                   role="group"
                   aria-label={labels.heatmap}
                 >
-                  <button
-                    type="button"
-                    className={
-                      "account-heat-toggle__btn" +
-                      (heatGranularity === "day" ? " is-active" : "")
-                    }
-                    aria-pressed={heatGranularity === "day"}
-                    onClick={() => setGranularity("day")}
-                  >
-                    {labels.heatmapDay}
-                  </button>
-                  <button
-                    type="button"
-                    className={
-                      "account-heat-toggle__btn" +
-                      (heatGranularity === "week" ? " is-active" : "")
-                    }
-                    aria-pressed={heatGranularity === "week"}
-                    onClick={() => setGranularity("week")}
-                  >
-                    {labels.heatmapWeek}
-                  </button>
+                  {granularityChips.map((chip) => (
+                    <button
+                      key={chip.id}
+                      type="button"
+                      className={
+                        "account-heat-toggle__btn" +
+                        (chip.active ? " is-active" : "")
+                      }
+                      aria-pressed={chip.active}
+                      onClick={() => setGranularity(chip.id)}
+                    >
+                      {chip.id === "day"
+                        ? labels.heatmapDay
+                        : labels.heatmapWeek}
+                    </button>
+                  ))}
                 </div>
               </div>
             </div>
+            <p className="account-section__hint account-heatmap-hint">
+              {labels.heatmapHint}
+            </p>
             <div className="account-section__body account-section__body--heat">
               <Heatmap
-                days={status?.heatmap ?? []}
+                days={heatDays}
                 metric="tokens"
                 granularity={heatGranularity}
                 locale={locale}
                 selectedRange={selectedHeatRange}
                 onSelectRange={onHeatSelect}
+                loading={loading}
+                error={heatmapError}
+                onClearRange={() => setSelectedHeatRange(null)}
                 labels={{
                   less: labels.less,
                   more: labels.more,
                   noData: labels.heatmapNoData,
+                  noDataHint: labels.heatmapNoDataHint,
+                  loading: labels.heatmapLoading,
+                  loadingHint: labels.heatmapLoadingHint,
+                  rangeEmpty: labels.heatmapRangeEmpty,
+                  rangeEmptyHint: labels.heatmapRangeEmptyHint,
+                  clearRange: labels.callLogsClearDay,
                   aria: labels.heatmapAria,
                   requests: labels.heatmapRequests,
                   tokens: labels.heatmapTokens,
+                  errorTitle: heatmapErrTitle,
+                  errorHint: heatmapErrHint,
                 }}
               />
             </div>

--- a/src/components/Heatmap.tsx
+++ b/src/components/Heatmap.tsx
@@ -5,20 +5,33 @@
  * Granularity: day (7×N grid) or week (1×N row of aggregated weeks).
  * Hover: instant portaled tip (token usage) — no Tip delay.
  * Click: select a day or week range for parent (call-log filter).
+ *
+ * Empty honesty (HEATMAP-USAGE-PRO): never invent activity cells or SuperGrok
+ * quota. Zero-padded host calendars surface no-data / soft-fail chrome instead
+ * of a fake “busy” grid of invented levels.
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { HeatmapDay } from "@/lib/api";
 import { formatLocaleCount } from "@/lib/accountUi";
+import {
+  dateInHeatRange,
+  heatRangesEqual,
+  sumHeatInRange,
+  type HeatRange,
+} from "@/lib/heatmapRange";
+import {
+  heatmapHasSamples,
+  resolveHeatmapEmptyState,
+  summarizeHeatmapRange,
+  type HeatmapEmptyState,
+} from "@/lib/heatmapUsagePro";
 
 export type HeatGranularity = "day" | "week";
 
-/** Inclusive local calendar range (YYYY-MM-DD). Day mode: start === end. */
-export type HeatRange = {
-  start: string;
-  end: string;
-};
+export type { HeatRange };
+export { dateInHeatRange, heatRangesEqual, sumHeatInRange };
 
 type Metric = "requests" | "tokens";
 
@@ -62,34 +75,6 @@ const LEVEL_COLORS = [
   "var(--heatmap-3, #30a14e)",
   "var(--heatmap-4, #216e39)",
 ] as const;
-
-export function heatRangesEqual(
-  a: HeatRange | null | undefined,
-  b: HeatRange | null | undefined,
-): boolean {
-  if (!a && !b) return true;
-  if (!a || !b) return false;
-  return a.start === b.start && a.end === b.end;
-}
-
-export function dateInHeatRange(ymd: string, range: HeatRange): boolean {
-  return ymd >= range.start && ymd <= range.end;
-}
-
-export function sumHeatInRange(
-  days: HeatmapDay[],
-  range: HeatRange,
-): { requests: number; tokens: number } {
-  let requests = 0;
-  let tokens = 0;
-  for (const d of days) {
-    if (dateInHeatRange(d.date, range)) {
-      requests += d.requests;
-      tokens += d.tokens;
-    }
-  }
-  return { requests, tokens };
-}
 
 function metricValue(day: HeatmapDay, metric: Metric): number {
   if (metric === "tokens") return day.tokens;
@@ -294,6 +279,9 @@ export function Heatmap({
   labels,
   selectedRange = null,
   onSelectRange,
+  loading = false,
+  error = null,
+  onClearRange,
 }: {
   days: HeatmapDay[];
   metric?: Metric;
@@ -303,12 +291,28 @@ export function Heatmap({
     less: string;
     more: string;
     noData: string;
+    /** Optional no-data body (falls back to heatmapHint-style copy). */
+    noDataHint?: string;
+    loading?: string;
+    loadingHint?: string;
+    rangeEmpty?: string;
+    rangeEmptyHint?: string;
+    clearRange?: string;
     aria: string;
     requests: string;
     tokens: string;
+    /** Map error title/hint keys → localized strings. */
+    errorTitle?: string;
+    errorHint?: string;
   };
   selectedRange?: HeatRange | null;
   onSelectRange?: (range: HeatRange | null) => void;
+  /** Account status still loading. */
+  loading?: boolean;
+  /** Host / account_status soft-fail error. */
+  error?: unknown;
+  /** Clear selected range (range_empty CTA). */
+  onClearRange?: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -320,13 +324,37 @@ export function Heatmap({
     placeAbove: boolean;
   } | null>(null);
 
+  const hasSamples = useMemo(() => heatmapHasSamples(days), [days]);
+  const rangeSummary = useMemo(
+    () => summarizeHeatmapRange(days, selectedRange),
+    [days, selectedRange],
+  );
+
+  const emptyState: HeatmapEmptyState | null = useMemo(
+    () =>
+      resolveHeatmapEmptyState({
+        loading,
+        hasSamples,
+        range: selectedRange,
+        rangeHasSamples: selectedRange ? rangeSummary.hasActivity : undefined,
+        error: error ?? undefined,
+      }),
+    [loading, hasSamples, selectedRange, rangeSummary.hasActivity, error],
+  );
+
+  // Only build the contribution grid when we have real samples and no hard empty.
+  const showGrid =
+    emptyState == null || emptyState.kind === "range_empty";
+
   const dayGrid = useMemo(
-    () => (granularity === "day" ? buildDayGrid(days, metric) : null),
-    [days, metric, granularity],
+    () =>
+      showGrid && granularity === "day" ? buildDayGrid(days, metric) : null,
+    [days, metric, granularity, showGrid],
   );
   const weekRow = useMemo(
-    () => (granularity === "week" ? buildWeekRow(days, metric) : null),
-    [days, metric, granularity],
+    () =>
+      showGrid && granularity === "week" ? buildWeekRow(days, metric) : null,
+    [days, metric, granularity, showGrid],
   );
 
   const weekCount =
@@ -397,8 +425,75 @@ export function Heatmap({
     );
   };
 
+  const emptyTitle = (() => {
+    if (!emptyState) return labels.noData;
+    switch (emptyState.kind) {
+      case "loading":
+        return labels.loading ?? emptyState.titleKey;
+      case "error":
+        return labels.errorTitle ?? emptyState.titleKey;
+      case "range_empty":
+        return labels.rangeEmpty ?? emptyState.titleKey;
+      case "no_data":
+      default:
+        return labels.noData;
+    }
+  })();
+
+  const emptyBody = (() => {
+    if (!emptyState) return null;
+    switch (emptyState.kind) {
+      case "loading":
+        return labels.loadingHint ?? null;
+      case "error":
+        return labels.errorHint ?? null;
+      case "range_empty":
+        return labels.rangeEmptyHint ?? null;
+      case "no_data":
+        return labels.noDataHint ?? null;
+      default:
+        return null;
+    }
+  })();
+
+  // Full empty (loading / error / no samples) — no invented contribution grid.
+  if (emptyState && emptyState.kind !== "range_empty") {
+    return (
+      <div
+        className={
+          "account-heatmap__empty" +
+          (emptyState.softFail ? " account-heatmap__empty--soft" : "") +
+          (emptyState.kind === "loading"
+            ? " account-heatmap__empty--loading"
+            : "") +
+          (emptyState.kind === "error" ? " account-heatmap__empty--error" : "")
+        }
+        data-heatmap-empty={emptyState.kind}
+        role="status"
+      >
+        {emptyState.kind === "error" ? (
+          <span className="account-heatmap__err-chip" data-kind={emptyState.error?.kind}>
+            {emptyTitle}
+          </span>
+        ) : (
+          <div className="account-heatmap__empty-title">{emptyTitle}</div>
+        )}
+        {emptyBody ? (
+          <div className="account-heatmap__empty-body">{emptyBody}</div>
+        ) : null}
+      </div>
+    );
+  }
+
   if (weekCount === 0) {
-    return <div className="account-heatmap__empty">{labels.noData}</div>;
+    return (
+      <div className="account-heatmap__empty" data-heatmap-empty="no_data" role="status">
+        <div className="account-heatmap__empty-title">{labels.noData}</div>
+        {labels.noDataHint ? (
+          <div className="account-heatmap__empty-body">{labels.noDataHint}</div>
+        ) : null}
+      </div>
+    );
   }
 
   const graphWidth = weekCount * (cell + GAP) - GAP;
@@ -419,6 +514,32 @@ export function Heatmap({
 
   return (
     <div ref={containerRef} className="gh-heatmap">
+      {emptyState?.kind === "range_empty" ? (
+        <div
+          className="account-heatmap__range-empty"
+          data-heatmap-empty="range_empty"
+          role="status"
+        >
+          <div className="account-heatmap__range-empty-text">
+            <span className="account-heatmap__empty-title">{emptyTitle}</span>
+            {emptyBody ? (
+              <span className="account-heatmap__empty-body">{emptyBody}</span>
+            ) : null}
+          </div>
+          {emptyState.showClearRange && (onClearRange || onSelectRange) ? (
+            <button
+              type="button"
+              className="account-link account-heatmap__clear-range"
+              onClick={() => {
+                if (onClearRange) onClearRange();
+                else onSelectRange?.(null);
+              }}
+            >
+              {labels.clearRange ?? labels.rangeEmpty ?? "Show all"}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
       <div className="gh-heatmap__inner" style={{ width: totalWidth }}>
         <div
           className="gh-heatmap__months"

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -713,6 +713,11 @@ export interface SettingsPageProps {
   account: AccountStatus | null;
   accountLoading: boolean;
   accountBusy: boolean;
+  /**
+   * Soft-fail error from account_status (heatmap empty honesty).
+   * Never invents activity cells or SuperGrok quota.
+   */
+  accountHeatmapError?: unknown;
   loginHint?: string | null;
   savedAccounts?: import("@/lib/api").SavedAccount[];
   activeAccountId?: string | null;
@@ -1417,6 +1422,7 @@ export function SettingsPage({
   account,
   accountLoading,
   accountBusy,
+  accountHeatmapError = null,
   loginHint = null,
   savedAccounts = [],
   activeAccountId = null,
@@ -6064,6 +6070,7 @@ export function SettingsPage({
             busy={accountBusy}
             locale={locale}
             t={t}
+            heatmapError={accountHeatmapError}
             labels={{
               signedIn: t("account.signedIn"),
               signedOut: t("account.signedOut"),
@@ -6104,6 +6111,11 @@ export function SettingsPage({
               fetchedAt: t("account.fetchedAt"),
               products: t("account.products"),
               heatmapNoData: t("account.heatmap.noData"),
+              heatmapNoDataHint: t("account.heatmap.noDataHint"),
+              heatmapLoading: t("account.heatmap.loading"),
+              heatmapLoadingHint: t("account.heatmap.loadingHint"),
+              heatmapRangeEmpty: t("account.heatmap.rangeEmpty"),
+              heatmapRangeEmptyHint: t("account.heatmap.rangeEmptyHint"),
               heatmapAria: t("account.heatmap.aria"),
               heatmapRequests: t("account.heatmap.requests"),
               heatmapTokens: t("account.heatmap.tokens"),
@@ -6114,6 +6126,8 @@ export function SettingsPage({
               heatmapDay: t("account.heatmap.day"),
               heatmapWeek: t("account.heatmap.week"),
               heatmapTotalTokens: t("account.heatmap.totalTokens"),
+              heatmapActiveDays: t("account.heatmap.activeDays"),
+              heatmapSessionsCount: t("account.heatmap.sessionsCount"),
               weeklyTitle: t("account.weeklyTitle"),
               loginHelpTitle: t("account.loginHelpTitle"),
               loginHelpBody: t("account.loginHelpBody"),

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -3265,14 +3265,35 @@ const en = {
   "account.products": "By product",
   "account.heatmap": "Activity heatmap",
   "account.heatmapHint":
-    "Local Grok Build session activity (about one year). Color = tokens used; hover for detail; click a day to filter recent logs by session count.",
+    "Local Grok Build session activity (about one year). Color = tokens used; hover for detail; click a day to filter recent logs by session count. Not SuperGrok quota.",
   "account.heatmap.less": "Less",
   "account.heatmap.more": "More",
   "account.heatmap.noData": "No activity data yet",
+  "account.heatmap.noDataHint":
+    "No local session signals under ~/.grok/sessions for this range. This is not SuperGrok quota — chat still works.",
+  "account.heatmap.loading": "Loading activity…",
+  "account.heatmap.loadingHint": "Reading local session signals.",
+  "account.heatmap.rangeEmpty": "No activity in this range",
+  "account.heatmap.rangeEmptyHint":
+    "The selected day or week has no local sessions. Clear the selection to see the full heatmap.",
   "account.heatmap.aria": "Token activity heatmap",
   "account.heatmap.requests": "Sessions",
   "account.heatmap.tokens": "Tokens used",
-  "account.heatmap.totalTokens": "Total tokens: {count}",
+  "account.heatmap.totalTokens": "Tokens {count}",
+  "account.heatmap.activeDays": "Active days {count}",
+  "account.heatmap.sessionsCount": "Sessions {count}",
+  "account.heatmap.err.host_only": "Desktop only",
+  "account.heatmap.err.host_onlyHint":
+    "Activity heatmap needs the desktop app Host. Browser preview never invents local usage.",
+  "account.heatmap.err.network": "Could not refresh usage",
+  "account.heatmap.err.networkHint":
+    "Network soft-fail — local heatmap may still load after reconnect. Never invents quota.",
+  "account.heatmap.err.empty": "No usage path",
+  "account.heatmap.err.emptyHint":
+    "Host found no local session signals. Soft-fail — not the same as SuperGrok quota empty.",
+  "account.heatmap.err.other": "Usage load soft-fail",
+  "account.heatmap.err.otherHint":
+    "Could not load local activity. Refresh to retry; we never invent heatmap cells or quota.",
   "account.callLogs": "Recent sessions",
   "account.callLogsEmpty": "No local session activity found under ~/.grok/sessions.",
   "account.callLogs.dayFilter": "{date} · {count} sessions",
@@ -9365,14 +9386,35 @@ const zh: Record<MessageKey, string> = {
   "account.products": "产品拆分",
   "account.heatmap": "活动热力图",
   "account.heatmapHint":
-    "本机 Grok Build 会话活动（约一年）。颜色按 Token 用量；悬停看用量；点击某天按会话数筛选下方日志。",
+    "本机 Grok Build 会话活动（约一年）。颜色按 Token 用量；悬停看用量；点击某天按会话数筛选下方日志。不是 SuperGrok 额度。",
   "account.heatmap.less": "少",
   "account.heatmap.more": "多",
   "account.heatmap.noData": "暂无活动数据",
+  "account.heatmap.noDataHint":
+    "在 ~/.grok/sessions 下未找到该时段的本机会话信号。这不是 SuperGrok 额度——对话仍可正常使用。",
+  "account.heatmap.loading": "正在加载活动…",
+  "account.heatmap.loadingHint": "正在读取本机会话信号。",
+  "account.heatmap.rangeEmpty": "该时段无活动",
+  "account.heatmap.rangeEmptyHint":
+    "所选日或周没有本机会话。清除选择可查看完整热力图。",
   "account.heatmap.aria": "Token 活动热力图",
   "account.heatmap.requests": "会话数",
   "account.heatmap.tokens": "已用 Token",
-  "account.heatmap.totalTokens": "总 Token：{count}",
+  "account.heatmap.totalTokens": "Token {count}",
+  "account.heatmap.activeDays": "活跃天 {count}",
+  "account.heatmap.sessionsCount": "会话 {count}",
+  "account.heatmap.err.host_only": "仅桌面端",
+  "account.heatmap.err.host_onlyHint":
+    "活动热力图需要桌面 Host。浏览器预览不会编造本机用量。",
+  "account.heatmap.err.network": "无法刷新用量",
+  "account.heatmap.err.networkHint":
+    "网络 soft-fail——重连后本机热力图仍可能加载。不会编造额度。",
+  "account.heatmap.err.empty": "无用量路径",
+  "account.heatmap.err.emptyHint":
+    "Host 未找到本机会话信号。soft-fail——不等于 SuperGrok 额度为 0。",
+  "account.heatmap.err.other": "用量加载 soft-fail",
+  "account.heatmap.err.otherHint":
+    "无法加载本机活动。可刷新重试；我们不会编造热力格或额度。",
   "account.callLogs": "近期调用日志",
   "account.callLogsEmpty": "在 ~/.grok/sessions 下未发现本地会话活动。",
   "account.callLogs.dayFilter": "{date} · {count} 个会话",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -3126,14 +3126,35 @@ export const zhTW: Record<MessageKey, string> = {
   "account.products": "產品明細",
   "account.heatmap": "活動熱力圖",
   "account.heatmapHint":
-    "本機 Grok Build 對話活動（約一年）。顏色依 Token 用量；懸停看用量；點某天依對話數篩選下方日誌。",
+    "本機 Grok Build 對話活動（約一年）。顏色依 Token 用量；懸停看用量；點某天依對話數篩選下方日誌。不是 SuperGrok 額度。",
   "account.heatmap.less": "少",
   "account.heatmap.more": "多",
   "account.heatmap.noData": "尚無活動資料",
+  "account.heatmap.noDataHint":
+    "在 ~/.grok/sessions 下未找到該時段的本機對話訊號。這不是 SuperGrok 額度——對話仍可正常使用。",
+  "account.heatmap.loading": "正在載入活動…",
+  "account.heatmap.loadingHint": "正在讀取本機對話訊號。",
+  "account.heatmap.rangeEmpty": "該時段無活動",
+  "account.heatmap.rangeEmptyHint":
+    "所選日或週沒有本機對話。清除選擇可查看完整熱力圖。",
   "account.heatmap.aria": "Token 活動熱力圖",
   "account.heatmap.requests": "對話數",
   "account.heatmap.tokens": "已用 Token",
-  "account.heatmap.totalTokens": "總 Token：{count}",
+  "account.heatmap.totalTokens": "Token {count}",
+  "account.heatmap.activeDays": "活躍天 {count}",
+  "account.heatmap.sessionsCount": "對話 {count}",
+  "account.heatmap.err.host_only": "僅桌面端",
+  "account.heatmap.err.host_onlyHint":
+    "活動熱力圖需要桌面 Host。瀏覽器預覽不會編造本機用量。",
+  "account.heatmap.err.network": "無法重新整理用量",
+  "account.heatmap.err.networkHint":
+    "網路 soft-fail——重連後本機熱力圖仍可能載入。不會編造額度。",
+  "account.heatmap.err.empty": "無用量路徑",
+  "account.heatmap.err.emptyHint":
+    "Host 未找到本機對話訊號。soft-fail——不等於 SuperGrok 額度為 0。",
+  "account.heatmap.err.other": "用量載入 soft-fail",
+  "account.heatmap.err.otherHint":
+    "無法載入本機活動。可重新整理重試；我們不會編造熱力格或額度。",
   "account.callLogs": "近期呼叫日誌",
   "account.callLogsEmpty": "在 ~/.grok/sessions 下未發現本機對話活動。",
   "account.callLogs.dayFilter": "{date} · {count} 個對話",

--- a/src/lib/heatmapRange.test.ts
+++ b/src/lib/heatmapRange.test.ts
@@ -3,7 +3,7 @@ import {
   dateInHeatRange,
   heatRangesEqual,
   sumHeatInRange,
-} from "@/components/Heatmap";
+} from "@/lib/heatmapRange";
 import type { HeatmapDay } from "@/lib/api";
 
 describe("heat range helpers", () => {
@@ -26,7 +26,7 @@ describe("heat range helpers", () => {
     expect(dateInHeatRange("2026-04-13", r)).toBe(false);
   });
 
-  it("sums heatmap days in range", () => {
+  it("sums heatmap days in range without inventing zeros as activity math side effects", () => {
     const days: HeatmapDay[] = [
       { date: "2026-04-06", requests: 1, tokens: 100, costUsd: 0 },
       { date: "2026-04-07", requests: 2, tokens: 50, costUsd: 0 },
@@ -35,5 +35,15 @@ describe("heat range helpers", () => {
     expect(
       sumHeatInRange(days, { start: "2026-04-06", end: "2026-04-07" }),
     ).toEqual({ requests: 3, tokens: 150 });
+  });
+
+  it("ignores non-positive / invalid counts", () => {
+    const days: HeatmapDay[] = [
+      { date: "2026-04-06", requests: 0, tokens: 0, costUsd: 0 },
+      { date: "2026-04-07", requests: -1, tokens: NaN, costUsd: 0 },
+    ];
+    expect(
+      sumHeatInRange(days, { start: "2026-04-06", end: "2026-04-07" }),
+    ).toEqual({ requests: 0, tokens: 0 });
   });
 });

--- a/src/lib/heatmapRange.ts
+++ b/src/lib/heatmapRange.ts
@@ -1,0 +1,55 @@
+/**
+ * Heatmap range helpers — pure inclusive calendar-range math for Account
+ * activity heatmap selection (day cell vs week strip).
+ *
+ * Shared by Heatmap UI and heatmapUsagePro. No DOM / Tauri side effects.
+ * Never invents activity cells or SuperGrok quota from range math alone.
+ */
+
+/** Inclusive local calendar range (YYYY-MM-DD). Day mode: start === end. */
+export type HeatRange = {
+  start: string;
+  end: string;
+};
+
+/** Minimal day row used by sum helpers (matches HeatmapDay fields). */
+export type HeatmapRangeDay = {
+  date: string;
+  requests: number;
+  tokens: number;
+};
+
+export function heatRangesEqual(
+  a: HeatRange | null | undefined,
+  b: HeatRange | null | undefined,
+): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return a.start === b.start && a.end === b.end;
+}
+
+/** Inclusive YYYY-MM-DD compare (lexicographic is valid for ISO dates). */
+export function dateInHeatRange(ymd: string, range: HeatRange): boolean {
+  return ymd >= range.start && ymd <= range.end;
+}
+
+/**
+ * Sum requests / tokens for days inside an inclusive range.
+ * Days outside the range are ignored; missing days contribute nothing
+ * (never invent activity).
+ */
+export function sumHeatInRange(
+  days: readonly HeatmapRangeDay[],
+  range: HeatRange,
+): { requests: number; tokens: number } {
+  let requests = 0;
+  let tokens = 0;
+  for (const d of days) {
+    if (!d?.date || !dateInHeatRange(d.date, range)) continue;
+    const r = Number(d.requests);
+    const t = Number(d.tokens);
+    if (Number.isFinite(r) && r > 0) requests += Math.floor(r);
+    if (Number.isFinite(t) && t > 0) tokens += Math.floor(t);
+  }
+  return { requests, tokens };
+}

--- a/src/lib/heatmapUsagePro.test.ts
+++ b/src/lib/heatmapUsagePro.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyHeatmapError,
+  heatmapDayHasActivity,
+  heatmapErrorView,
+  heatmapHasSamples,
+  heatmapSummaryChips,
+  listHeatmapGranularityChips,
+  resolveHeatmapEmptyState,
+  resolveHeatmapErrorChip,
+  summarizeHeatmapRange,
+  type HeatmapUsageDay,
+} from "./heatmapUsagePro";
+
+const sampleDays: HeatmapUsageDay[] = [
+  { date: "2026-04-01", requests: 0, tokens: 0 },
+  { date: "2026-04-02", requests: 2, tokens: 1200 },
+  { date: "2026-04-03", requests: 0, tokens: 0 },
+  { date: "2026-04-04", requests: 1, tokens: 50 },
+];
+
+const emptyCalendar: HeatmapUsageDay[] = [
+  { date: "2026-04-01", requests: 0, tokens: 0 },
+  { date: "2026-04-02", requests: 0, tokens: 0 },
+];
+
+describe("heatmapDayHasActivity / heatmapHasSamples", () => {
+  it("treats zero-padded calendar rows as no activity", () => {
+    expect(heatmapDayHasActivity({ requests: 0, tokens: 0 })).toBe(false);
+    expect(heatmapDayHasActivity({ requests: 1, tokens: 0 })).toBe(true);
+    expect(heatmapDayHasActivity({ requests: 0, tokens: 10 })).toBe(true);
+    expect(heatmapDayHasActivity(null)).toBe(false);
+  });
+
+  it("never invents samples from empty or zero-filled lists", () => {
+    expect(heatmapHasSamples(null)).toBe(false);
+    expect(heatmapHasSamples([])).toBe(false);
+    expect(heatmapHasSamples(emptyCalendar)).toBe(false);
+    expect(heatmapHasSamples(sampleDays)).toBe(true);
+  });
+});
+
+describe("summarizeHeatmapRange", () => {
+  it("counts honesty over full list", () => {
+    const s = summarizeHeatmapRange(sampleDays);
+    expect(s).toMatchObject({
+      dayCount: 4,
+      activeDays: 2,
+      totalRequests: 3,
+      totalTokens: 1250,
+      hasActivity: true,
+      isEmptyCalendar: false,
+    });
+  });
+
+  it("clips to inclusive range without inventing missing days", () => {
+    const s = summarizeHeatmapRange(sampleDays, {
+      start: "2026-04-02",
+      end: "2026-04-03",
+    });
+    expect(s).toMatchObject({
+      dayCount: 2,
+      activeDays: 1,
+      totalRequests: 2,
+      totalTokens: 1200,
+      hasActivity: true,
+    });
+  });
+
+  it("empty calendar summary is honest (not fake quota)", () => {
+    const s = summarizeHeatmapRange(emptyCalendar);
+    expect(s.hasActivity).toBe(false);
+    expect(s.isEmptyCalendar).toBe(true);
+    expect(s.totalTokens).toBe(0);
+    expect(s.totalRequests).toBe(0);
+    expect(heatmapSummaryChips(s)).toBeNull();
+  });
+
+  it("range with no activity → empty summary chips null", () => {
+    const s = summarizeHeatmapRange(sampleDays, {
+      start: "2026-04-01",
+      end: "2026-04-01",
+    });
+    expect(s.hasActivity).toBe(false);
+    expect(heatmapSummaryChips(s)).toBeNull();
+  });
+
+  it("null / invalid days never invent counts", () => {
+    expect(summarizeHeatmapRange(null).dayCount).toBe(0);
+    expect(
+      summarizeHeatmapRange([
+        { date: "", requests: 9, tokens: 9 },
+        { date: "2026-01-01", requests: NaN, tokens: -1 },
+      ]).hasActivity,
+    ).toBe(false);
+  });
+});
+
+describe("classifyHeatmapError / heatmapErrorView", () => {
+  it("classifies host_only | network | empty | other", () => {
+    expect(classifyHeatmapError("need tauri")).toBe("host_only");
+    expect(classifyHeatmapError({ code: "host_only" })).toBe("host_only");
+    expect(classifyHeatmapError("network offline")).toBe("network");
+    expect(classifyHeatmapError(new Error("Failed to fetch"))).toBe("network");
+    expect(classifyHeatmapError("no activity data under sessions")).toBe(
+      "empty",
+    );
+    expect(classifyHeatmapError({ code: "empty" })).toBe("empty");
+    expect(classifyHeatmapError("something weird")).toBe("other");
+    expect(classifyHeatmapError(null)).toBe("other");
+  });
+
+  it("error view is always soft-fail with i18n keys", () => {
+    const v = heatmapErrorView("need_tauri");
+    expect(v.softFail).toBe(true);
+    expect(v.kind).toBe("host_only");
+    expect(v.titleKey).toBe("account.heatmap.err.host_only");
+    expect(v.hintKey).toBe("account.heatmap.err.host_onlyHint");
+  });
+
+  it("resolveHeatmapErrorChip null when no error", () => {
+    expect(resolveHeatmapErrorChip(null)).toBeNull();
+    expect(resolveHeatmapErrorChip("")).toBeNull();
+    expect(resolveHeatmapErrorChip("offline")?.kind).toBe("network");
+  });
+});
+
+describe("resolveHeatmapEmptyState", () => {
+  it("loading only when no samples yet (keeps grid on refresh)", () => {
+    expect(
+      resolveHeatmapEmptyState({
+        loading: true,
+        hasSamples: false,
+      })?.kind,
+    ).toBe("loading");
+    // Existing samples stay visible while refreshing.
+    expect(
+      resolveHeatmapEmptyState({
+        loading: true,
+        hasSamples: true,
+        error: "network",
+      }),
+    ).toBeNull();
+  });
+
+  it("error soft-fails only when there are no samples (never invent cells)", () => {
+    const e = resolveHeatmapEmptyState({
+      loading: false,
+      hasSamples: false,
+      error: "need tauri",
+    });
+    expect(e?.kind).toBe("error");
+    expect(e?.softFail).toBe(true);
+    expect(e?.error?.kind).toBe("host_only");
+    expect(e?.showClearRange).toBe(false);
+    // Error chip belongs in chrome; grid stays if samples exist.
+    expect(
+      resolveHeatmapEmptyState({
+        loading: false,
+        hasSamples: true,
+        error: "network offline",
+      }),
+    ).toBeNull();
+  });
+
+  it("no_data when loaded without samples (zero calendar is not data)", () => {
+    const e = resolveHeatmapEmptyState({
+      loading: false,
+      hasSamples: false,
+    });
+    expect(e).toMatchObject({
+      kind: "no_data",
+      titleKey: "account.heatmap.noData",
+      bodyKey: "account.heatmap.noDataHint",
+      softFail: true,
+    });
+  });
+
+  it("range_empty when overall samples exist but range does not", () => {
+    const e = resolveHeatmapEmptyState({
+      loading: false,
+      hasSamples: true,
+      range: { start: "2026-04-01", end: "2026-04-01" },
+      rangeHasSamples: false,
+    });
+    expect(e).toMatchObject({
+      kind: "range_empty",
+      titleKey: "account.heatmap.rangeEmpty",
+      showClearRange: true,
+      softFail: false,
+    });
+  });
+
+  it("null when samples exist and no empty range", () => {
+    expect(
+      resolveHeatmapEmptyState({
+        loading: false,
+        hasSamples: true,
+      }),
+    ).toBeNull();
+    expect(
+      resolveHeatmapEmptyState({
+        loading: false,
+        hasSamples: true,
+        range: { start: "2026-04-02", end: "2026-04-02" },
+        rangeHasSamples: true,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("listHeatmapGranularityChips", () => {
+  it("orders day · week with active state", () => {
+    expect(listHeatmapGranularityChips("day")).toEqual([
+      { id: "day", labelKey: "account.heatmap.day", active: true },
+      { id: "week", labelKey: "account.heatmap.week", active: false },
+    ]);
+    expect(listHeatmapGranularityChips("week")[1]?.active).toBe(true);
+    expect(listHeatmapGranularityChips(null)[0]?.active).toBe(true);
+  });
+});
+
+describe("heatmapSummaryChips", () => {
+  it("exposes honest counts only when activity exists", () => {
+    const chips = heatmapSummaryChips(summarizeHeatmapRange(sampleDays));
+    expect(chips).toMatchObject({
+      activeDays: 2,
+      totalTokens: 1250,
+      totalRequests: 3,
+      activeDaysKey: "account.heatmap.activeDays",
+      totalTokensKey: "account.heatmap.totalTokens",
+      sessionsKey: "account.heatmap.sessionsCount",
+    });
+  });
+});

--- a/src/lib/heatmapUsagePro.ts
+++ b/src/lib/heatmapUsagePro.ts
@@ -1,0 +1,468 @@
+/**
+ * HEATMAP-USAGE-PRO — pure helpers for Account activity heatmap honesty.
+ *
+ * Rules:
+ * - Never invent activity cells or SuperGrok quota from local session signals.
+ * - Zero-filled calendar days are **not** samples (host pads ~371 empty days).
+ * - Soft-fail when Host / network fails or usage is empty — warn, do not fake data.
+ * - No DOM / Tauri side effects.
+ *
+ * See docs/llm-wiki/account.md (heatmap = local ~/.grok/sessions signals).
+ */
+
+import {
+  dateInHeatRange,
+  type HeatRange,
+  type HeatmapRangeDay,
+} from "@/lib/heatmapRange";
+
+// ── Day / sample honesty ─────────────────────────────────────────────────────
+
+/** Minimal day shape accepted by pro helpers. */
+export type HeatmapUsageDay = HeatmapRangeDay & {
+  costUsd?: number;
+};
+
+/**
+ * True when a day has real local activity (sessions/requests or tokens).
+ * Zero-padded host calendar rows return false.
+ */
+export function heatmapDayHasActivity(
+  day: Pick<HeatmapUsageDay, "requests" | "tokens"> | null | undefined,
+): boolean {
+  if (!day) return false;
+  const r = Number(day.requests);
+  const t = Number(day.tokens);
+  return (Number.isFinite(r) && r > 0) || (Number.isFinite(t) && t > 0);
+}
+
+/**
+ * True when at least one day in the list has real activity.
+ * Empty / null lists → false (never invent samples).
+ */
+export function heatmapHasSamples(
+  days: readonly HeatmapUsageDay[] | null | undefined,
+): boolean {
+  if (!days || days.length === 0) return false;
+  for (const d of days) {
+    if (heatmapDayHasActivity(d)) return true;
+  }
+  return false;
+}
+
+// ── Range summary ────────────────────────────────────────────────────────────
+
+/**
+ * Honest counts for a day list, optionally clipped to an inclusive range.
+ * Missing days contribute nothing; zeros never become fake activity.
+ */
+export type HeatmapRangeSummary = {
+  /** Calendar rows considered (after optional range clip). */
+  dayCount: number;
+  /** Days with requests > 0 or tokens > 0. */
+  activeDays: number;
+  /** Sum of known session/request counts. */
+  totalRequests: number;
+  /** Sum of known tokens. */
+  totalTokens: number;
+  /** True when activeDays > 0. */
+  hasActivity: boolean;
+  /**
+   * True when we only have zero-filled (or empty) calendar rows —
+   * UI should prefer empty honesty over a “busy” total chip.
+   */
+  isEmptyCalendar: boolean;
+};
+
+/**
+ * Summarize heatmap days with honest counts.
+ * When `range` is set, only days inside that inclusive range are counted.
+ */
+export function summarizeHeatmapRange(
+  days: readonly HeatmapUsageDay[] | null | undefined,
+  range?: HeatRange | null,
+): HeatmapRangeSummary {
+  const list = Array.isArray(days) ? days : [];
+  let dayCount = 0;
+  let activeDays = 0;
+  let totalRequests = 0;
+  let totalTokens = 0;
+
+  for (const d of list) {
+    if (!d?.date) continue;
+    if (range && !dateInHeatRange(d.date, range)) continue;
+    dayCount += 1;
+    const r = Number(d.requests);
+    const t = Number(d.tokens);
+    const req = Number.isFinite(r) && r > 0 ? Math.floor(r) : 0;
+    const tok = Number.isFinite(t) && t > 0 ? Math.floor(t) : 0;
+    if (req > 0 || tok > 0) {
+      activeDays += 1;
+      totalRequests += req;
+      totalTokens += tok;
+    }
+  }
+
+  const hasActivity = activeDays > 0;
+  return {
+    dayCount,
+    activeDays,
+    totalRequests,
+    totalTokens,
+    hasActivity,
+    isEmptyCalendar: !hasActivity,
+  };
+}
+
+// ── Error classification ─────────────────────────────────────────────────────
+
+/**
+ * Stable heatmap / account-status failure kinds.
+ * - `host_only` — browser / mirror without desktop Host
+ * - `network` — transport / offline while loading status
+ * - `empty` — host returned no usage path / empty signals root
+ * - `other` — unclassified soft-fail
+ */
+export type HeatmapErrorKind = "host_only" | "network" | "empty" | "other";
+
+export type HeatmapErrorView = {
+  kind: HeatmapErrorKind;
+  /** Soft-fail: never invent cells/quota; warn chrome only. */
+  softFail: boolean;
+  /** Short detail excerpt (no secrets expected). */
+  detail: string;
+  /** i18n title key under account.heatmap.err.*. */
+  titleKey: string;
+  /** i18n hint key under account.heatmap.err.*. */
+  hintKey: string;
+};
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as {
+      code?: unknown;
+      message?: unknown;
+      reason?: unknown;
+      error?: unknown;
+    };
+    const parts = [o.code, o.message, o.reason, o.error]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+function errCode(err: unknown): string {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const c = (err as { code?: unknown }).code;
+    if (typeof c === "string") return c.trim().toLowerCase();
+    if (typeof c === "number" && Number.isFinite(c)) return String(c);
+  }
+  return "";
+}
+
+/**
+ * Classify heatmap / account_status failures into a stable kind.
+ * Prefer explicit codes and known host phrases over free-form text.
+ */
+export function classifyHeatmapError(err: unknown): HeatmapErrorKind {
+  if (err == null || err === "") return "other";
+
+  const code = errCode(err);
+  if (
+    code === "host_only" ||
+    code === "host-only" ||
+    code === "need_tauri" ||
+    code === "need-tauri" ||
+    code === "desktop_only"
+  ) {
+    return "host_only";
+  }
+  if (
+    code === "network" ||
+    code === "offline" ||
+    code === "econnrefused" ||
+    code === "etimedout" ||
+    code === "timeout"
+  ) {
+    return "network";
+  }
+  if (
+    code === "empty" ||
+    code === "no_data" ||
+    code === "no-data" ||
+    code === "not_found" ||
+    code === "enoent"
+  ) {
+    return "empty";
+  }
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  if (
+    /need[_\s-]?tauri|desktop\s+app|host[_\s-]?only|not\s+available\s+in\s+browser|webview\s+only|requires\s+the\s+(tauri|desktop)/i.test(
+      s,
+    )
+  ) {
+    return "host_only";
+  }
+  if (
+    /network|offline|fetch\s+failed|failed\s+to\s+fetch|econnrefused|enotfound|etimedout|timed?\s*out|dns|connection\s+(reset|refused|error)|socket/i.test(
+      s,
+    )
+  ) {
+    return "network";
+  }
+  if (
+    /no\s+(activity|usage|sessions?|signals?|heatmap|data)|empty\s+(heatmap|usage|sessions?)|signals?\.json|~\.?\/\.grok\/sessions|sessions?\s+(dir|folder|path)\s+(missing|not\s+found)/i.test(
+      s,
+    )
+  ) {
+    return "empty";
+  }
+
+  return "other";
+}
+
+/**
+ * Build soft-fail presentation for a heatmap load error.
+ * All kinds soft-fail — never invent activity cells or quota.
+ */
+export function heatmapErrorView(err: unknown): HeatmapErrorView {
+  const kind = classifyHeatmapError(err);
+  const detail = errText(err).trim().slice(0, 280);
+  return {
+    kind,
+    softFail: true,
+    detail,
+    titleKey: `account.heatmap.err.${kind}`,
+    hintKey: `account.heatmap.err.${kind}Hint`,
+  };
+}
+
+// ── Empty honesty ────────────────────────────────────────────────────────────
+
+/**
+ * Contextual empty surfaces for the heatmap body.
+ * - `loading` — status still fetching
+ * - `error` — classified Host/network failure (soft-fail)
+ * - `no_data` — loaded but no real activity samples
+ * - `range_empty` — overall samples exist; selected day/week has none
+ */
+export type HeatmapEmptyKind = "loading" | "error" | "no_data" | "range_empty";
+
+export type HeatmapEmptyState = {
+  kind: HeatmapEmptyKind;
+  /** Primary title i18n key under account.heatmap.*. */
+  titleKey: string;
+  /** Optional body / hint i18n key. */
+  bodyKey: string | null;
+  /**
+   * Soft-fail chrome (warn chip) vs quiet empty.
+   * loading / no_data / range_empty are quiet; error is soft-warn.
+   */
+  softFail: boolean;
+  /** When kind === "error", the classified error view. */
+  error: HeatmapErrorView | null;
+  /** Offer clear-range CTA when a selected range is empty. */
+  showClearRange: boolean;
+};
+
+export type HeatmapEmptyInput = {
+  loading: boolean;
+  /**
+   * True when any day in the **full** heatmap has real activity.
+   * Prefer {@link heatmapHasSamples}(days) — do not pass dayCount > 0 alone
+   * (host pads empty calendar rows).
+   */
+  hasSamples: boolean;
+  /**
+   * Selected day/week range, if any.
+   * When set and overall has samples but the range does not, → range_empty.
+   */
+  range?: HeatRange | null;
+  /**
+   * True when the selected range has activity.
+   * Ignored when `range` is null. Prefer summarizing the range with
+   * {@link summarizeHeatmapRange}.
+   */
+  rangeHasSamples?: boolean;
+  /** Optional Host / account_status error (soft-fail). */
+  error?: unknown;
+};
+
+/**
+ * Resolve which empty surface to show for the heatmap body.
+ * Returns `null` when the contribution grid should render (real samples,
+ * and either no range or range has activity).
+ *
+ * Priority:
+ * 1. loading → loading (only when no samples yet — keep grid on refresh)
+ * 2. error + !hasSamples → error (soft-fail; never invent cells)
+ * 3. !hasSamples → no_data
+ * 4. range set + !rangeHasSamples → range_empty
+ * 5. otherwise null (render grid; error chip may still show in chrome)
+ *
+ * Never invents activity cells or SuperGrok quota.
+ */
+export function resolveHeatmapEmptyState(
+  opts: HeatmapEmptyInput,
+): HeatmapEmptyState | null {
+  const hasErr = opts.error != null && opts.error !== "";
+
+  // Keep an existing grid visible while a background refresh is in flight.
+  if (opts.loading && !opts.hasSamples) {
+    return {
+      kind: "loading",
+      titleKey: "account.heatmap.loading",
+      bodyKey: "account.heatmap.loadingHint",
+      softFail: false,
+      error: null,
+      showClearRange: false,
+    };
+  }
+
+  if (hasErr && !opts.hasSamples) {
+    const view = heatmapErrorView(opts.error);
+    return {
+      kind: "error",
+      titleKey: view.titleKey,
+      bodyKey: view.hintKey,
+      softFail: true,
+      error: view,
+      showClearRange: false,
+    };
+  }
+
+  if (!opts.hasSamples) {
+    return {
+      kind: "no_data",
+      titleKey: "account.heatmap.noData",
+      bodyKey: "account.heatmap.noDataHint",
+      softFail: true,
+      error: null,
+      showClearRange: false,
+    };
+  }
+
+  const range = opts.range ?? null;
+  if (range && opts.rangeHasSamples === false) {
+    return {
+      kind: "range_empty",
+      titleKey: "account.heatmap.rangeEmpty",
+      bodyKey: "account.heatmap.rangeEmptyHint",
+      softFail: false,
+      error: null,
+      showClearRange: true,
+    };
+  }
+
+  return null;
+}
+
+// ── Range chip presentation ──────────────────────────────────────────────────
+
+/** Day / week granularity chips (Account heatmap toggle). */
+export type HeatmapGranularity = "day" | "week";
+
+export type HeatmapGranularityChip = {
+  id: HeatmapGranularity;
+  /** i18n label key. */
+  labelKey: "account.heatmap.day" | "account.heatmap.week";
+  active: boolean;
+};
+
+/** Ordered day · week chips with active state. */
+export function listHeatmapGranularityChips(
+  active: HeatmapGranularity | null | undefined,
+): HeatmapGranularityChip[] {
+  const a: HeatmapGranularity = active === "week" ? "week" : "day";
+  return [
+    {
+      id: "day",
+      labelKey: "account.heatmap.day",
+      active: a === "day",
+    },
+    {
+      id: "week",
+      labelKey: "account.heatmap.week",
+      active: a === "week",
+    },
+  ];
+}
+
+/**
+ * Summary chip keys for the title meta row.
+ * Returns null when empty calendar (caller hides total inventing "0 tokens"
+ * as if it were SuperGrok quota).
+ */
+export type HeatmapSummaryChips = {
+  /** i18n key with `{count}` for active days. */
+  activeDaysKey: "account.heatmap.activeDays";
+  activeDays: number;
+  /** i18n key with `{count}` for total tokens (caller formats count). */
+  totalTokensKey: "account.heatmap.totalTokens";
+  totalTokens: number;
+  /** i18n key with `{count}` for sessions/requests. */
+  sessionsKey: "account.heatmap.sessionsCount";
+  totalRequests: number;
+};
+
+/**
+ * Build honest summary chips from a range summary.
+ * Returns `null` when there is no activity (never invent quota-looking zeros).
+ */
+export function heatmapSummaryChips(
+  summary: HeatmapRangeSummary,
+): HeatmapSummaryChips | null {
+  if (!summary.hasActivity) return null;
+  return {
+    activeDaysKey: "account.heatmap.activeDays",
+    activeDays: summary.activeDays,
+    totalTokensKey: "account.heatmap.totalTokens",
+    totalTokens: summary.totalTokens,
+    sessionsKey: "account.heatmap.sessionsCount",
+    totalRequests: summary.totalRequests,
+  };
+}
+
+/** Soft-fail error chip for the heatmap title row. */
+export type HeatmapErrorChip = {
+  kind: HeatmapErrorKind;
+  titleKey: string;
+  hintKey: string;
+  softFail: true;
+};
+
+/**
+ * Resolve an error chip for the heatmap chrome.
+ * Returns `null` when there is no error.
+ */
+export function resolveHeatmapErrorChip(
+  error: unknown,
+): HeatmapErrorChip | null {
+  if (error == null || error === "") return null;
+  const view = heatmapErrorView(error);
+  return {
+    kind: view.kind,
+    titleKey: view.titleKey,
+    hintKey: view.hintKey,
+    softFail: true,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3976,8 +3976,124 @@ html[data-sidebar-density="compact"] .session-row__meta {
 }
 
 .account-heatmap__empty {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 4px 8px;
   font-size: 13px;
   color: var(--text-secondary);
+}
+
+.account-heatmap__empty--soft {
+  color: var(--text-secondary);
+}
+
+.account-heatmap__empty--error {
+  gap: 8px;
+}
+
+.account-heatmap__empty--loading {
+  opacity: 0.85;
+}
+
+.account-heatmap__empty-title {
+  font-size: 13px;
+  font-weight: 550;
+  color: var(--text-primary);
+}
+
+.account-heatmap__empty-body {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+  max-width: 52ch;
+}
+
+.account-heatmap__err-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 550;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--warn, #d97706) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warn, #d97706) 28%, transparent);
+  width: fit-content;
+}
+
+.account-heatmap__range-empty {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
+}
+
+.account-heatmap__range-empty-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.account-heatmap__clear-range {
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.account-heatmap-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.account-heatmap-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 1.45;
+  background: color-mix(in srgb, var(--text-primary) 5%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
+}
+
+.account-heatmap-chip--muted {
+  color: var(--text-tertiary);
+  font-weight: 450;
+}
+
+.account-heatmap-err-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 550;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--warn, #d97706) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warn, #d97706) 28%, transparent);
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-heatmap-hint {
+  margin: 0 0 8px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
 }
 
 /* GitHub-style heatmap (grok-go port) */
@@ -4106,10 +4222,12 @@ html[data-sidebar-density="compact"] .session-row__meta {
 
 .account-heatmap-title-meta {
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
+  justify-content: flex-end;
+  gap: 8px;
   min-width: 0;
-  flex-shrink: 0;
+  flex-shrink: 1;
 }
 
 .account-heatmap-total {


### PR DESCRIPTION
## Summary
- Pure **HEATMAP-USAGE-PRO** helpers (`resolveHeatmapEmptyState`, `classifyHeatmapError`, `summarizeHeatmapRange`) — never invent activity cells or SuperGrok quota from zero-padded local calendars
- Account heatmap UI: honest empty / loading / soft-fail error surfaces, day·week range chips polish, active-days / tokens / sessions summary chips
- Extract `heatmapRange` range math; en / zh / zh-TW + CHANGELOG

## Verify
```
pnpm test -- src/lib/heatmapUsagePro.test.ts src/lib/heatmapRange.test.ts src/i18n/messages.test.ts
pnpm typecheck
```

## Test plan
- [ ] Settings → Account with no local sessions: no-data empty (not a fake grey year of invented cells)
- [ ] With activity: day/week chips + summary chips (active days · tokens · sessions)
- [ ] Click a zero day: range-empty banner + clear selection
- [ ] Browser/host_only: soft-fail error chip, no invented quota
- [ ] SuperGrok quota bar still independent of heatmap (billing path unchanged)