### PR TITLE
feat(appearance): wallpaper gallery empty honesty and filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Wallpaper gallery pro** (Settings → Appearance → wallpaper source modal): honest empty states (idle · loading · no results · filter empty · classified error), kind filter chips (All · Images · Videos) with counts, client-side gallery filter, and soft-fail error chips (network · host · untrusted · empty · other). Never invents CDN gallery tiles — only real Host/search items. Pure `wallpaperGalleryPro` helpers + tests; en/zh/zh-TW.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitejs/plugin-react-swc':
+        specifier: ^3.11.0
+        version: 3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
       canvas:
         specifier: ^3.2.3
         version: 3.2.3
@@ -455,35 +458,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -643,79 +641,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -746,6 +731,93 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@swc/core-darwin-arm64@1.15.47':
+    resolution: {integrity: sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.47':
+    resolution: {integrity: sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    resolution: {integrity: sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    resolution: {integrity: sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    resolution: {integrity: sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    resolution: {integrity: sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    resolution: {integrity: sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    resolution: {integrity: sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    resolution: {integrity: sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    resolution: {integrity: sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    resolution: {integrity: sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    resolution: {integrity: sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.47':
+    resolution: {integrity: sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tabler/icons-react@3.45.0':
     resolution: {integrity: sha512-t/AuKs7ALMDDTY+B9IvfZnlO0mbLlP/lJxP/HnGC49QkM8mCsTN38kYyxjXxgrb1+TeK53ioVBJqIV7n/eysXQ==}
@@ -793,28 +865,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -875,35 +943,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.4':
     resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -1277,6 +1340,11 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitejs/plugin-react-swc@3.11.0':
+    resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
+    peerDependencies:
+      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1933,28 +2001,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3244,6 +3308,66 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@swc/core-darwin-arm64@1.15.47':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core@1.15.47':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.47
+      '@swc/core-darwin-x64': 1.15.47
+      '@swc/core-linux-arm-gnueabihf': 1.15.47
+      '@swc/core-linux-arm64-gnu': 1.15.47
+      '@swc/core-linux-arm64-musl': 1.15.47
+      '@swc/core-linux-ppc64-gnu': 1.15.47
+      '@swc/core-linux-s390x-gnu': 1.15.47
+      '@swc/core-linux-x64-gnu': 1.15.47
+      '@swc/core-linux-x64-musl': 1.15.47
+      '@swc/core-win32-arm64-msvc': 1.15.47
+      '@swc/core-win32-ia32-msvc': 1.15.47
+      '@swc/core-win32-x64-msvc': 1.15.47
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.28':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@tabler/icons-react@3.45.0(react@19.2.7)':
     dependencies:
       '@tabler/icons': 3.45.0
@@ -3777,6 +3901,14 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitejs/plugin-react-swc@3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@swc/core': 1.15.47
+      vite: 6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:

--- a/src/components/WallpaperSourceModal.tsx
+++ b/src/components/WallpaperSourceModal.tsx
@@ -25,6 +25,18 @@ import {
   type WallpaperGalleryItem,
   type WallpaperSourceErrorCode,
 } from "@/lib/wallpaperSource";
+import {
+  classifyWallpaperGalleryError,
+  countGalleryByKind,
+  filterGalleryItems,
+  isWallpaperGallerySoftFail,
+  resolveWallpaperGalleryEmptyState,
+  wallpaperGalleryErrorTitleKey,
+  wallpaperGalleryHasActiveFilters,
+  wallpaperGalleryKindFilterLabelKey,
+  WALLPAPER_GALLERY_KIND_FILTERS,
+  type WallpaperGalleryKindFilter,
+} from "@/lib/wallpaperGalleryPro";
 import { WallpaperPrepareError } from "@/lib/themeSkin";
 import { resolveImageSrcSync } from "@/lib/imageSrc";
 import type { MessageKey } from "@/i18n";
@@ -103,6 +115,12 @@ export function WallpaperSourceModal({
   const [prompt, setPrompt] = useState("");
   const [aspect, setAspect] = useState("16:9");
   const [items, setItems] = useState<WallpaperGalleryItem[]>([]);
+  /** Client-side gallery filter (not the X search box). */
+  const [galleryFilter, setGalleryFilter] = useState("");
+  const [kindFilter, setKindFilter] =
+    useState<WallpaperGalleryKindFilter>("all");
+  /** True after at least one search/generate finished this open. */
+  const [hasSearched, setHasSearched] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [applying, setApplying] = useState(false);
@@ -121,11 +139,71 @@ export function WallpaperSourceModal({
     setStatusHint(null);
     setSelectedId(null);
     setPreviewingId(null);
+    setGalleryFilter("");
+    setKindFilter("all");
+    setHasSearched(false);
   }, [open, initialTab]);
 
+  const kindCounts = useMemo(() => countGalleryByKind(items), [items]);
+
+  const visibleItems = useMemo(
+    () =>
+      filterGalleryItems(items, {
+        query: galleryFilter,
+        kind: kindFilter,
+      }),
+    [items, galleryFilter, kindFilter],
+  );
+
+  const filtersActive = wallpaperGalleryHasActiveFilters({
+    query: galleryFilter,
+    kind: kindFilter,
+  });
+
+  const emptyState = useMemo(
+    () =>
+      resolveWallpaperGalleryEmptyState({
+        loading: busy,
+        query: galleryFilter,
+        itemCount: visibleItems.length,
+        error: errorCode
+          ? { code: errorCode, message: error ?? errorCode }
+          : error,
+        totalCount: items.length,
+        kindFilter,
+        hasSearched,
+      }),
+    [
+      busy,
+      galleryFilter,
+      visibleItems.length,
+      errorCode,
+      error,
+      items.length,
+      kindFilter,
+      hasSearched,
+    ],
+  );
+
+  const galleryErrorKind = useMemo(() => {
+    if (!errorCode && !error) return null;
+    // Prefer structured code + detail so desktop-only / free-text still classify
+    // (e.g. generic + "desktop app" → host soft-fail).
+    return classifyWallpaperGalleryError(
+      errorCode
+        ? { code: errorCode, message: error ?? errorCode }
+        : error,
+    );
+  }, [errorCode, error]);
+
+  const clearGalleryFilters = useCallback(() => {
+    setGalleryFilter("");
+    setKindFilter("all");
+  }, []);
+
   const selected = useMemo(
-    () => items.find((i) => i.id === selectedId) ?? null,
-    [items, selectedId],
+    () => visibleItems.find((i) => i.id === selectedId) ?? null,
+    [visibleItems, selectedId],
   );
 
   const sortOptions = useMemo(
@@ -164,11 +242,15 @@ export function WallpaperSourceModal({
     setErrorCode(null);
     setStatusHint(t("settings.wallpaperSource.searching"));
     setSelectedId(null);
+    setGalleryFilter("");
+    setKindFilter("all");
     try {
       const res = await api.wallpaperXSearch(q, sort);
       const list = dedupeGalleryItems(res.items || []);
       const code = errorCodeFromSearchResult({ ...res, items: list });
+      setHasSearched(true);
       if (code) {
+        // Honest empty/error — never invent CDN gallery cards
         setItems([]);
         setErrorCode(code);
         setError(errorMessage(t, code));
@@ -178,6 +260,7 @@ export function WallpaperSourceModal({
         setErrorCode(null);
       }
     } catch (e) {
+      setHasSearched(true);
       setItems([]);
       const code = parseWallpaperSourceError(e);
       setErrorCode(code);
@@ -205,10 +288,13 @@ export function WallpaperSourceModal({
     setErrorCode(null);
     setStatusHint(t("settings.wallpaperSource.generating"));
     setSelectedId(null);
+    setGalleryFilter("");
+    setKindFilter("all");
     try {
       const res = await api.wallpaperImagine(p, aspect);
       const list = dedupeGalleryItems(res.items || []);
       const code = errorCodeFromSearchResult({ ...res, items: list });
+      setHasSearched(true);
       if (code) {
         setItems([]);
         setErrorCode(code);
@@ -220,6 +306,7 @@ export function WallpaperSourceModal({
         if (list[0]) setSelectedId(list[0].id);
       }
     } catch (e) {
+      setHasSearched(true);
       setItems([]);
       const code = parseWallpaperSourceError(e);
       setErrorCode(code);
@@ -270,7 +357,8 @@ export function WallpaperSourceModal({
         );
 
         // Only open downloadable / already-local siblings in the lightbox
-        const viable = items.filter(
+        // (visible set only — never invent off-filter CDN cards).
+        const viable = visibleItems.filter(
           (it) => it.id === item.id || it.localPath || it.fullUrl.startsWith("http"),
         );
         const slides = viable.map((it) => {
@@ -306,7 +394,7 @@ export function WallpaperSourceModal({
         setStatusHint(null);
       }
     },
-    [busy, applying, previewingId, items, t, viewer, dropItem],
+    [busy, applying, previewingId, visibleItems, t, viewer, dropItem],
   );
 
   const applySelected = useCallback(async () => {
@@ -349,6 +437,17 @@ export function WallpaperSourceModal({
   const authNeeded = errorCode === "auth_required";
   const locked = busy || applying || previewingId !== null;
   const isImagineLayout = tab === "imagine";
+  const showGalleryFilters = items.length > 0 || filtersActive;
+  const softFailError =
+    galleryErrorKind != null && isWallpaperGallerySoftFail(galleryErrorKind);
+  // Error banner already carries detail for empty/error — avoid stacking the
+  // same honesty block; still show loading / idle / filter-empty surfaces.
+  const showEmptyBlock =
+    emptyState != null &&
+    (emptyState.kind === "loading" ||
+      emptyState.kind === "idle" ||
+      emptyState.kind === "filter_empty" ||
+      !error);
 
   return (
     <GlassModal
@@ -510,7 +609,24 @@ export function WallpaperSourceModal({
       ) : null}
 
       {error ? (
-        <div className="wallpaper-source-error" role="alert">
+        <div
+          className={
+            "wallpaper-source-error" +
+            (softFailError ? " wallpaper-source-error--soft" : "")
+          }
+          role="alert"
+        >
+          {galleryErrorKind ? (
+            <span
+              className={
+                "wallpaper-source-err-chip" +
+                (softFailError ? " wallpaper-source-err-chip--soft" : "")
+              }
+              data-kind={galleryErrorKind}
+            >
+              {t(wallpaperGalleryErrorTitleKey(galleryErrorKind) as MessageKey)}
+            </span>
+          ) : null}
           <p>{error}</p>
           {authNeeded && onRequestLogin ? (
             <button
@@ -519,6 +635,63 @@ export function WallpaperSourceModal({
               onClick={onRequestLogin}
             >
               {t("settings.wallpaperSource.goLogin")}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {showGalleryFilters ? (
+        <div className="wallpaper-source-filters">
+          <div
+            className="wallpaper-source-chips"
+            role="toolbar"
+            aria-label={t("settings.wallpaperSource.kindLabel")}
+          >
+            {WALLPAPER_GALLERY_KIND_FILTERS.map((id) => {
+              const n = kindCounts[id];
+              // Hide zero-count chips except "all" and the active selection.
+              if (id !== "all" && n === 0 && kindFilter !== id) return null;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  className={
+                    "wallpaper-source-chip" +
+                    (kindFilter === id ? " is-active" : "")
+                  }
+                  aria-pressed={kindFilter === id}
+                  disabled={locked && id !== kindFilter}
+                  onClick={() => setKindFilter(id)}
+                >
+                  <span>
+                    {t(
+                      wallpaperGalleryKindFilterLabelKey(id) as MessageKey,
+                    )}
+                  </span>
+                  <span className="wallpaper-source-chip-count">{n}</span>
+                </button>
+              );
+            })}
+          </div>
+          <input
+            type="search"
+            className="wallpaper-source-form__input wallpaper-source-filters__query"
+            value={galleryFilter}
+            placeholder={t("settings.wallpaperSource.filterPlaceholder")}
+            disabled={locked}
+            onChange={(e) => setGalleryFilter(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+            aria-label={t("settings.wallpaperSource.filterPlaceholder")}
+          />
+          {filtersActive ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={clearGalleryFilters}
+              disabled={locked}
+            >
+              {t("settings.wallpaperSource.clearFilters")}
             </button>
           ) : null}
         </div>
@@ -534,7 +707,7 @@ export function WallpaperSourceModal({
         role="list"
         aria-label={t("settings.wallpaperSource.gallery")}
         aria-busy={busy || previewingId !== null}
-        tabIndex={items.length > 0 ? 0 : undefined}
+        tabIndex={visibleItems.length > 0 ? 0 : undefined}
       >
         <div
           className={
@@ -542,12 +715,40 @@ export function WallpaperSourceModal({
             (isImagineLayout ? " wallpaper-masonry--full" : "")
           }
         >
-          {items.length === 0 && !busy && !error ? (
-            <p className="wallpaper-masonry__empty">
-              {t("settings.wallpaperSource.emptyGallery")}
-            </p>
+          {showEmptyBlock && emptyState ? (
+            <div
+              className={
+                "wallpaper-masonry__empty" +
+                (emptyState.kind === "filter_empty"
+                  ? " wallpaper-masonry__empty--filter"
+                  : "") +
+                (emptyState.kind === "error"
+                  ? " wallpaper-masonry__empty--error"
+                  : "")
+              }
+              data-kind={emptyState.kind}
+              data-soft-fail={emptyState.softFail ? "1" : "0"}
+            >
+              <p className="wallpaper-masonry__empty-title">
+                {t(emptyState.titleKey as MessageKey)}
+              </p>
+              {emptyState.hintKey ? (
+                <p className="wallpaper-masonry__empty-hint">
+                  {t(emptyState.hintKey as MessageKey)}
+                </p>
+              ) : null}
+              {emptyState.showClearFilters ? (
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  onClick={clearGalleryFilters}
+                >
+                  {t("settings.wallpaperSource.clearFilters")}
+                </button>
+              ) : null}
+            </div>
           ) : null}
-          {items.map((item) => {
+          {visibleItems.map((item) => {
             const active = item.id === selectedId;
             const loadingThis = previewingId === item.id;
             const src = itemThumbSrc(item);

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2771,6 +2771,38 @@ const en = {
   "settings.wallpaperSource.gallery": "Wallpaper gallery",
   "settings.wallpaperSource.emptyGallery":
     "Results will appear here as a gallery. Search or generate to begin.",
+  "settings.wallpaperSource.empty.idleHint":
+    "No wallpapers are loaded yet. Search X or generate with Imagine — results come from the Host only (never invented CDN tiles).",
+  "settings.wallpaperSource.empty.loading": "Loading gallery…",
+  "settings.wallpaperSource.empty.loadingHint":
+    "Waiting for real search or Imagine results. Nothing is fabricated while loading.",
+  "settings.wallpaperSource.empty.noResults": "No wallpapers found",
+  "settings.wallpaperSource.empty.noResultsHint":
+    "Try different keywords or another prompt. Empty means the Host returned zero media — not a placeholder gallery.",
+  "settings.wallpaperSource.empty.filterEmpty": "No matches in this gallery",
+  "settings.wallpaperSource.empty.filterEmptyHint":
+    "Kind chips or the filter hid every result. Clear filters to see the real Host items again.",
+  "settings.wallpaperSource.clearFilters": "Clear filters",
+  "settings.wallpaperSource.filterPlaceholder": "Filter gallery…",
+  "settings.wallpaperSource.kindLabel": "Media kind",
+  "settings.wallpaperSource.kind.all": "All",
+  "settings.wallpaperSource.kind.image": "Images",
+  "settings.wallpaperSource.kind.video": "Videos",
+  "settings.wallpaperSource.errKind.network": "Network",
+  "settings.wallpaperSource.errKind.host": "Host / CLI",
+  "settings.wallpaperSource.errKind.untrusted": "Blocked URL",
+  "settings.wallpaperSource.errKind.empty": "Empty",
+  "settings.wallpaperSource.errKind.other": "Error",
+  "settings.wallpaperSource.errKind.hint.network":
+    "Check the connection and retry search or download.",
+  "settings.wallpaperSource.errKind.hint.host":
+    "Install or path the Grok CLI, or open the desktop app.",
+  "settings.wallpaperSource.errKind.hint.untrusted":
+    "That host is outside the wallpaper allowlist (twimg / filesystem.site).",
+  "settings.wallpaperSource.errKind.hint.empty":
+    "No media returned — try another query or prompt.",
+  "settings.wallpaperSource.errKind.hint.other":
+    "See the detail above; sign in or retry if needed.",
   "settings.wallpaperSource.goLogin": "Sign in",
   "settings.wallpaperSource.loadingOriginal": "Loading full image…",
   "settings.wallpaperSource.openPreview": "Open full-size preview",
@@ -8884,6 +8916,38 @@ const zh: Record<MessageKey, string> = {
   "settings.wallpaperSource.gallery": "壁纸画廊",
   "settings.wallpaperSource.emptyGallery":
     "结果会以瀑布流展示。请先搜索或生成。",
+  "settings.wallpaperSource.empty.idleHint":
+    "尚未加载任何壁纸。请搜索 X 或用 Imagine 生成 — 结果仅来自 Host，不会伪造 CDN 占位图。",
+  "settings.wallpaperSource.empty.loading": "正在加载画廊…",
+  "settings.wallpaperSource.empty.loadingHint":
+    "等待真实搜索或 Imagine 结果；加载过程中不会伪造条目。",
+  "settings.wallpaperSource.empty.noResults": "没有找到壁纸",
+  "settings.wallpaperSource.empty.noResultsHint":
+    "请换个关键词或提示词。空结果表示 Host 返回了零条媒体，不是占位画廊。",
+  "settings.wallpaperSource.empty.filterEmpty": "当前筛选无匹配",
+  "settings.wallpaperSource.empty.filterEmptyHint":
+    "类型芯片或筛选隐藏了全部结果。清除筛选可重新看到 Host 返回的真实条目。",
+  "settings.wallpaperSource.clearFilters": "清除筛选",
+  "settings.wallpaperSource.filterPlaceholder": "筛选画廊…",
+  "settings.wallpaperSource.kindLabel": "媒体类型",
+  "settings.wallpaperSource.kind.all": "全部",
+  "settings.wallpaperSource.kind.image": "图片",
+  "settings.wallpaperSource.kind.video": "视频",
+  "settings.wallpaperSource.errKind.network": "网络",
+  "settings.wallpaperSource.errKind.host": "Host / CLI",
+  "settings.wallpaperSource.errKind.untrusted": "已拦截网址",
+  "settings.wallpaperSource.errKind.empty": "空结果",
+  "settings.wallpaperSource.errKind.other": "错误",
+  "settings.wallpaperSource.errKind.hint.network":
+    "请检查网络后重试搜索或下载。",
+  "settings.wallpaperSource.errKind.hint.host":
+    "请安装或配置 Grok CLI，或使用桌面端应用。",
+  "settings.wallpaperSource.errKind.hint.untrusted":
+    "该主机不在壁纸下载允许列表（twimg / filesystem.site）。",
+  "settings.wallpaperSource.errKind.hint.empty":
+    "未返回媒体 — 请换个查询或提示词。",
+  "settings.wallpaperSource.errKind.hint.other":
+    "见上方详情；必要时请登录或重试。",
   "settings.wallpaperSource.goLogin": "去登录",
   "settings.wallpaperSource.loadingOriginal": "正在加载原图…",
   "settings.wallpaperSource.openPreview": "打开大图预览",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -2646,6 +2646,38 @@ export const zhTW: Record<MessageKey, string> = {
   "settings.wallpaperSource.gallery": "壁紙畫廊",
   "settings.wallpaperSource.emptyGallery":
     "結果會以瀑布流展示。請先搜尋或生成。",
+  "settings.wallpaperSource.empty.idleHint":
+    "尚未載入任何壁紙。請搜尋 X 或用 Imagine 生成 — 結果僅來自 Host，不會偽造 CDN 佔位圖。",
+  "settings.wallpaperSource.empty.loading": "正在載入畫廊…",
+  "settings.wallpaperSource.empty.loadingHint":
+    "等待真實搜尋或 Imagine 結果；載入過程中不會偽造條目。",
+  "settings.wallpaperSource.empty.noResults": "沒有找到壁紙",
+  "settings.wallpaperSource.empty.noResultsHint":
+    "請換個關鍵字或提示詞。空結果表示 Host 回傳了零筆媒體，不是佔位畫廊。",
+  "settings.wallpaperSource.empty.filterEmpty": "目前篩選無相符項目",
+  "settings.wallpaperSource.empty.filterEmptyHint":
+    "類型晶片或篩選隱藏了全部結果。清除篩選可重新看到 Host 回傳的真實條目。",
+  "settings.wallpaperSource.clearFilters": "清除篩選",
+  "settings.wallpaperSource.filterPlaceholder": "篩選畫廊…",
+  "settings.wallpaperSource.kindLabel": "媒體類型",
+  "settings.wallpaperSource.kind.all": "全部",
+  "settings.wallpaperSource.kind.image": "圖片",
+  "settings.wallpaperSource.kind.video": "影片",
+  "settings.wallpaperSource.errKind.network": "網路",
+  "settings.wallpaperSource.errKind.host": "Host / CLI",
+  "settings.wallpaperSource.errKind.untrusted": "已封鎖網址",
+  "settings.wallpaperSource.errKind.empty": "空結果",
+  "settings.wallpaperSource.errKind.other": "錯誤",
+  "settings.wallpaperSource.errKind.hint.network":
+    "請檢查網路後重試搜尋或下載。",
+  "settings.wallpaperSource.errKind.hint.host":
+    "請安裝或設定 Grok CLI，或使用桌面端應用程式。",
+  "settings.wallpaperSource.errKind.hint.untrusted":
+    "該主機不在壁紙下載允許清單（twimg / filesystem.site）。",
+  "settings.wallpaperSource.errKind.hint.empty":
+    "未回傳媒體 — 請換個查詢或提示詞。",
+  "settings.wallpaperSource.errKind.hint.other":
+    "見上方詳情；必要時請登入或重試。",
   "settings.wallpaperSource.goLogin": "去登入",
   "settings.wallpaperSource.loadingOriginal": "正在載入原圖…",
   "settings.wallpaperSource.openPreview": "開啟大圖預覽",

--- a/src/lib/wallpaperGalleryPro.test.ts
+++ b/src/lib/wallpaperGalleryPro.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyWallpaperGalleryError,
+  countGalleryByKind,
+  filterGalleryItems,
+  galleryKindBucket,
+  isWallpaperGallerySoftFail,
+  resolveWallpaperGalleryEmptyState,
+  wallpaperGalleryErrorHintKey,
+  wallpaperGalleryErrorTitleKey,
+  wallpaperGalleryHasActiveFilters,
+  wallpaperGalleryKindFilterLabelKey,
+  WALLPAPER_GALLERY_ERROR_KINDS,
+  WALLPAPER_GALLERY_KIND_FILTERS,
+  type WallpaperGalleryItemLike,
+} from "./wallpaperGalleryPro";
+
+function item(
+  partial: Partial<WallpaperGalleryItemLike> &
+    Pick<WallpaperGalleryItemLike, "kind"> & { id?: string },
+): WallpaperGalleryItemLike & { id: string } {
+  return {
+    id: partial.id ?? "1",
+    kind: partial.kind,
+    source: partial.source ?? "x",
+    username: partial.username ?? null,
+    textPreview: partial.textPreview ?? null,
+    prompt: partial.prompt ?? null,
+    fullUrl: partial.fullUrl ?? "https://pbs.twimg.com/media/a.jpg",
+    thumbUrl: partial.thumbUrl ?? partial.fullUrl ?? "https://pbs.twimg.com/media/a.jpg",
+    localPath: partial.localPath ?? null,
+    postUrl: partial.postUrl ?? null,
+  };
+}
+
+describe("classifyWallpaperGalleryError", () => {
+  it("maps explicit codes", () => {
+    expect(classifyWallpaperGalleryError({ code: "network" })).toBe("network");
+    expect(classifyWallpaperGalleryError({ code: "search_failed" })).toBe(
+      "network",
+    );
+    expect(classifyWallpaperGalleryError({ code: "timeout" })).toBe("network");
+    expect(classifyWallpaperGalleryError({ code: "download_failed" })).toBe(
+      "network",
+    );
+    expect(classifyWallpaperGalleryError({ code: "cli_missing" })).toBe("host");
+    expect(classifyWallpaperGalleryError({ code: "host_only" })).toBe("host");
+    expect(classifyWallpaperGalleryError({ code: "desktop_only" })).toBe(
+      "host",
+    );
+    expect(classifyWallpaperGalleryError({ code: "url_blocked" })).toBe(
+      "untrusted",
+    );
+    expect(classifyWallpaperGalleryError({ code: "untrusted" })).toBe(
+      "untrusted",
+    );
+    expect(classifyWallpaperGalleryError({ code: "empty" })).toBe("empty");
+    expect(classifyWallpaperGalleryError({ code: "auth_required" })).toBe(
+      "other",
+    );
+    expect(classifyWallpaperGalleryError({ errorCode: "imagine_failed" })).toBe(
+      "other",
+    );
+  });
+
+  it("maps free-form host strings", () => {
+    expect(classifyWallpaperGalleryError("search_failed: boom")).toBe(
+      "network",
+    );
+    expect(classifyWallpaperGalleryError("download_failed: HTTP 403")).toBe(
+      "network",
+    );
+    expect(classifyWallpaperGalleryError(new Error("timed out"))).toBe(
+      "network",
+    );
+    expect(classifyWallpaperGalleryError("cli_missing")).toBe("host");
+    expect(
+      classifyWallpaperGalleryError("Wallpaper search requires the desktop app"),
+    ).toBe("host");
+    expect(classifyWallpaperGalleryError("url_blocked: evil.com")).toBe(
+      "untrusted",
+    );
+    expect(classifyWallpaperGalleryError("path not allowed")).toBe("untrusted");
+    expect(classifyWallpaperGalleryError("empty")).toBe("empty");
+    expect(classifyWallpaperGalleryError("No images found")).toBe("empty");
+    expect(classifyWallpaperGalleryError("auth_required")).toBe("other");
+    expect(classifyWallpaperGalleryError("weird boom")).toBe("other");
+    expect(classifyWallpaperGalleryError(null)).toBe("other");
+    expect(classifyWallpaperGalleryError("")).toBe("other");
+  });
+
+  it("maps every kind to title + hint keys", () => {
+    for (const kind of WALLPAPER_GALLERY_ERROR_KINDS) {
+      expect(wallpaperGalleryErrorTitleKey(kind)).toMatch(
+        /^settings\.wallpaperSource\.errKind\./,
+      );
+      expect(wallpaperGalleryErrorHintKey(kind)).toMatch(
+        /^settings\.wallpaperSource\.errKind\.hint\./,
+      );
+    }
+  });
+
+  it("soft-fails host / empty / untrusted only", () => {
+    expect(isWallpaperGallerySoftFail("host")).toBe(true);
+    expect(isWallpaperGallerySoftFail("empty")).toBe(true);
+    expect(isWallpaperGallerySoftFail("untrusted")).toBe(true);
+    expect(isWallpaperGallerySoftFail("network")).toBe(false);
+    expect(isWallpaperGallerySoftFail("other")).toBe(false);
+  });
+});
+
+describe("countGalleryByKind / galleryKindBucket", () => {
+  it("buckets image vs video kinds", () => {
+    expect(galleryKindBucket("image")).toBe("image");
+    expect(galleryKindBucket("IMAGE")).toBe("image");
+    expect(galleryKindBucket("video")).toBe("video");
+    expect(galleryKindBucket("video/mp4")).toBe("video");
+    expect(galleryKindBucket("mp4")).toBe("video");
+    expect(galleryKindBucket("")).toBe("image");
+    expect(galleryKindBucket(null)).toBe("image");
+  });
+
+  it("counts kinds without inventing rows", () => {
+    const items = [
+      item({ id: "1", kind: "image" }),
+      item({ id: "2", kind: "image" }),
+      item({ id: "3", kind: "video" }),
+      item({ id: "4", kind: "video/mp4" }),
+    ];
+    expect(countGalleryByKind(items)).toEqual({
+      all: 4,
+      image: 2,
+      video: 2,
+    });
+    expect(countGalleryByKind([])).toEqual({ all: 0, image: 0, video: 0 });
+  });
+
+  it("exports ordered kind filters + label keys", () => {
+    expect([...WALLPAPER_GALLERY_KIND_FILTERS]).toEqual([
+      "all",
+      "image",
+      "video",
+    ]);
+    expect(wallpaperGalleryKindFilterLabelKey("all")).toBe(
+      "settings.wallpaperSource.kind.all",
+    );
+    expect(wallpaperGalleryKindFilterLabelKey("image")).toBe(
+      "settings.wallpaperSource.kind.image",
+    );
+    expect(wallpaperGalleryKindFilterLabelKey("video")).toBe(
+      "settings.wallpaperSource.kind.video",
+    );
+  });
+});
+
+describe("filterGalleryItems", () => {
+  const items = [
+    item({
+      id: "a",
+      kind: "image",
+      username: "alice",
+      textPreview: "cyberpunk city neon",
+      fullUrl: "https://pbs.twimg.com/media/a.jpg",
+    }),
+    item({
+      id: "b",
+      kind: "video",
+      username: "bob",
+      textPreview: "ocean waves",
+      fullUrl: "https://video.twimg.com/b.mp4",
+    }),
+    item({
+      id: "c",
+      kind: "image",
+      source: "imagine",
+      prompt: "misty mountain lake",
+      fullUrl: "file:///wallpapers/c.png",
+      localPath: "/wallpapers/c.png",
+    }),
+  ];
+
+  it("filters by free-text query string overload", () => {
+    expect(filterGalleryItems(items, "alice").map((i) => i.id)).toEqual(["a"]);
+    expect(filterGalleryItems(items, "OCEAN").map((i) => i.id)).toEqual(["b"]);
+    expect(filterGalleryItems(items, "mountain").map((i) => i.id)).toEqual([
+      "c",
+    ]);
+    expect(filterGalleryItems(items, "twimg").map((i) => i.id)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("filters by kind chip", () => {
+    expect(
+      filterGalleryItems(items, { kind: "video" }).map((i) => i.id),
+    ).toEqual(["b"]);
+    expect(
+      filterGalleryItems(items, { kind: "image" }).map((i) => i.id),
+    ).toEqual(["a", "c"]);
+    expect(filterGalleryItems(items, { kind: "all" })).toHaveLength(3);
+  });
+
+  it("combines kind + query with AND", () => {
+    expect(
+      filterGalleryItems(items, { kind: "image", query: "city" }).map(
+        (i) => i.id,
+      ),
+    ).toEqual(["a"]);
+    expect(
+      filterGalleryItems(items, { kind: "video", query: "city" }),
+    ).toEqual([]);
+  });
+
+  it("never invents items when source list is empty", () => {
+    expect(filterGalleryItems([], "anything")).toEqual([]);
+    expect(filterGalleryItems([], { kind: "image", query: "x" })).toEqual([]);
+  });
+
+  it("hasActiveFilters detects kind and query", () => {
+    expect(wallpaperGalleryHasActiveFilters({})).toBe(false);
+    expect(wallpaperGalleryHasActiveFilters({ kind: "all", query: "" })).toBe(
+      false,
+    );
+    expect(wallpaperGalleryHasActiveFilters({ kind: "video" })).toBe(true);
+    expect(wallpaperGalleryHasActiveFilters({ query: "  neon " })).toBe(true);
+  });
+});
+
+describe("resolveWallpaperGalleryEmptyState", () => {
+  const base = {
+    loading: false,
+    query: "",
+    itemCount: 0,
+  };
+
+  it("returns null when there are visible items", () => {
+    expect(
+      resolveWallpaperGalleryEmptyState({ ...base, itemCount: 3 }),
+    ).toBeNull();
+  });
+
+  it("loading while search/generate is in flight", () => {
+    const empty = resolveWallpaperGalleryEmptyState({
+      ...base,
+      loading: true,
+    });
+    expect(empty?.kind).toBe("loading");
+    expect(empty?.titleKey).toBe("settings.wallpaperSource.empty.loading");
+    expect(empty?.softFail).toBe(true);
+    expect(empty?.showClearFilters).toBe(false);
+  });
+
+  it("idle when never searched", () => {
+    const empty = resolveWallpaperGalleryEmptyState(base);
+    expect(empty?.kind).toBe("idle");
+    expect(empty?.titleKey).toBe("settings.wallpaperSource.emptyGallery");
+    expect(empty?.hintKey).toBe("settings.wallpaperSource.empty.idleHint");
+    expect(empty?.softFail).toBe(true);
+  });
+
+  it("empty after search with zero results", () => {
+    const empty = resolveWallpaperGalleryEmptyState({
+      ...base,
+      hasSearched: true,
+      totalCount: 0,
+    });
+    expect(empty?.kind).toBe("empty");
+    expect(empty?.titleKey).toBe("settings.wallpaperSource.empty.noResults");
+    expect(empty?.showClearFilters).toBe(false);
+  });
+
+  it("empty from classified empty error code", () => {
+    const empty = resolveWallpaperGalleryEmptyState({
+      ...base,
+      error: "empty",
+    });
+    expect(empty?.kind).toBe("empty");
+    expect(empty?.errorKind).toBe("empty");
+    expect(empty?.softFail).toBe(true);
+  });
+
+  it("error from network / host / untrusted with soft-fail flags", () => {
+    const net = resolveWallpaperGalleryEmptyState({
+      ...base,
+      error: { code: "search_failed" },
+    });
+    expect(net?.kind).toBe("error");
+    expect(net?.errorKind).toBe("network");
+    expect(net?.softFail).toBe(false);
+    expect(net?.titleKey).toBe("settings.wallpaperSource.errKind.network");
+
+    const host = resolveWallpaperGalleryEmptyState({
+      ...base,
+      error: "cli_missing",
+    });
+    expect(host?.kind).toBe("error");
+    expect(host?.errorKind).toBe("host");
+    expect(host?.softFail).toBe(true);
+
+    const blocked = resolveWallpaperGalleryEmptyState({
+      ...base,
+      error: "url_blocked",
+    });
+    expect(blocked?.kind).toBe("error");
+    expect(blocked?.errorKind).toBe("untrusted");
+    expect(blocked?.softFail).toBe(true);
+  });
+
+  it("filter_empty when chips/query hide all items", () => {
+    const empty = resolveWallpaperGalleryEmptyState({
+      ...base,
+      query: "zzzz",
+      totalCount: 5,
+      itemCount: 0,
+    });
+    expect(empty?.kind).toBe("filter_empty");
+    expect(empty?.showClearFilters).toBe(true);
+    expect(empty?.softFail).toBe(true);
+
+    const kindOnly = resolveWallpaperGalleryEmptyState({
+      ...base,
+      kindFilter: "video",
+      totalCount: 3,
+      itemCount: 0,
+    });
+    expect(kindOnly?.kind).toBe("filter_empty");
+    expect(kindOnly?.showClearFilters).toBe(true);
+  });
+
+  it("prefers loading over error when both set", () => {
+    const empty = resolveWallpaperGalleryEmptyState({
+      ...base,
+      loading: true,
+      error: "search_failed",
+    });
+    expect(empty?.kind).toBe("loading");
+  });
+
+  it("does not invent gallery content on error", () => {
+    // itemCount stays 0 — UI must not fabricate CDN cards
+    const empty = resolveWallpaperGalleryEmptyState({
+      ...base,
+      error: { code: "network", message: "fetch failed" },
+      itemCount: 0,
+      totalCount: 0,
+    });
+    expect(empty).not.toBeNull();
+    expect(empty?.kind).toBe("error");
+  });
+});

--- a/src/lib/wallpaperGalleryPro.ts
+++ b/src/lib/wallpaperGalleryPro.ts
@@ -1,0 +1,555 @@
+/**
+ * WALLPAPER-GALLERY-PRO — pure helpers for wallpaper source gallery:
+ * empty honesty, kind filter chips, client-side text filter, classified
+ * load errors. Never invents CDN images — only real Host/search items.
+ *
+ * No DOM / Tauri side effects.
+ */
+
+import type { WallpaperGalleryItem } from "@/lib/wallpaperSource";
+
+// ── Error classification ─────────────────────────────────────────────────────
+
+/**
+ * Stable gallery load / search failure kinds for soft-fail chips.
+ * Broader than raw host codes — maps network · host · untrusted · empty · other.
+ */
+export type WallpaperGalleryErrorKind =
+  | "network"
+  | "host"
+  | "untrusted"
+  | "empty"
+  | "other";
+
+/** All error kinds (for label maps / tests). */
+export const WALLPAPER_GALLERY_ERROR_KINDS: readonly WallpaperGalleryErrorKind[] =
+  ["network", "host", "untrusted", "empty", "other"] as const;
+
+// ── Kind filter chips ────────────────────────────────────────────────────────
+
+/**
+ * First-class kind chip buckets for the gallery.
+ * `video` covers video/mp4-like kinds; everything else buckets as `image`.
+ */
+export type WallpaperGalleryKindFilter = "all" | "image" | "video";
+
+/** Ordered chip list (All · Image · Video). */
+export const WALLPAPER_GALLERY_KIND_FILTERS: readonly WallpaperGalleryKindFilter[] =
+  ["all", "image", "video"] as const;
+
+/** Per-chip counts; `all` is total length. */
+export type WallpaperGalleryKindCounts = Record<
+  WallpaperGalleryKindFilter,
+  number
+>;
+
+/** Minimal item shape for filter / count helpers. */
+export type WallpaperGalleryItemLike = Pick<
+  WallpaperGalleryItem,
+  "kind" | "source" | "username" | "textPreview" | "prompt" | "fullUrl" | "thumbUrl"
+> & {
+  id?: string;
+  localPath?: string | null;
+  postUrl?: string | null;
+};
+
+// ── Empty honesty ────────────────────────────────────────────────────────────
+
+/** Contextual empty surfaces for the gallery body. */
+export type WallpaperGalleryEmptyKind =
+  | "loading"
+  | "idle"
+  | "empty"
+  | "filter_empty"
+  | "error";
+
+export type WallpaperGalleryEmptyPresentation = {
+  kind: WallpaperGalleryEmptyKind;
+  /** Primary title i18n key under settings.wallpaperSource.*. */
+  titleKey: string;
+  /** Optional hint i18n key. */
+  hintKey: string | null;
+  /** Offer clear-filters CTA when client filters hide all items. */
+  showClearFilters: boolean;
+  /**
+   * Soft-fail: capability / empty / filter gap — warn, do not invent results.
+   * Hard error for network/other when a real failure occurred.
+   */
+  softFail: boolean;
+  /** Classified error when kind === "error" or empty-from-error. */
+  errorKind?: WallpaperGalleryErrorKind | null;
+};
+
+export type WallpaperGalleryEmptyInput = {
+  /** Search / generate / download in flight. */
+  loading: boolean;
+  /**
+   * Client-side gallery filter query (not the X search / Imagine prompt).
+   * Non-empty with zero visible rows → filter_empty when items exist.
+   */
+  query: string;
+  /** Visible item count after kind + text filters. */
+  itemCount: number;
+  /**
+   * Classified load / search failure (string code, Error, or host payload).
+   * When set with zero items, surfaces error (or empty) honesty.
+   */
+  error?: unknown | null;
+  /**
+   * Pre-filter total (optional). When known and > 0 while itemCount is 0 and
+   * filters are active → filter_empty. When 0 after a completed search → empty.
+   */
+  totalCount?: number | null;
+  /** Kind chip filter (`all` = no kind narrowing). */
+  kindFilter?: WallpaperGalleryKindFilter | null;
+  /**
+   * True after at least one search/generate completed this open.
+   * Distinguishes idle (never searched) from empty (searched, zero results).
+   */
+  hasSearched?: boolean;
+};
+
+// ── Error text helpers ───────────────────────────────────────────────────────
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as {
+      code?: unknown;
+      message?: unknown;
+      reason?: unknown;
+      error?: unknown;
+      errorCode?: unknown;
+    };
+    const parts = [o.code, o.errorCode, o.message, o.reason, o.error]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+function errCode(err: unknown): string {
+  if (typeof err === "object" && err !== null) {
+    const o = err as { code?: unknown; errorCode?: unknown; reason?: unknown };
+    for (const key of ["code", "errorCode", "reason"] as const) {
+      const c = o[key];
+      if (typeof c === "string" && c.trim()) {
+        return c.trim().toLowerCase().replace(/-/g, "_");
+      }
+    }
+  }
+  if (typeof err === "string") {
+    const t = err.trim().toLowerCase().replace(/-/g, "_");
+    // bare codes
+    if (/^[a-z_]+$/.test(t)) return t;
+  }
+  return "";
+}
+
+/**
+ * Classify a thrown value / host / wallpaper source code into a stable gallery
+ * error kind for soft-fail chips. Prefer explicit codes over free-form text.
+ *
+ * Mapping notes:
+ * - network — search_failed, timeout, download, fetch/connect failures
+ * - host — CLI missing, desktop-only, need Tauri
+ * - untrusted — url_blocked, path not allowed, forbidden hosts
+ * - empty — no images / empty search
+ * - other — auth, imagine fail, generic
+ *
+ * Never invents success or CDN gallery rows.
+ */
+export function classifyWallpaperGalleryError(
+  err: unknown,
+): WallpaperGalleryErrorKind {
+  if (err == null || err === "") return "other";
+
+  const code = errCode(err);
+  if (
+    code === "network" ||
+    code === "offline" ||
+    code === "timeout" ||
+    code === "timed_out" ||
+    code === "search_failed" ||
+    code === "download_failed" ||
+    code === "fetch_failed" ||
+    code === "read_failed"
+  ) {
+    return "network";
+  }
+  if (
+    code === "host" ||
+    code === "host_only" ||
+    code === "host_error" ||
+    code === "cli_missing" ||
+    code === "need_tauri" ||
+    code === "desktop_only"
+  ) {
+    return "host";
+  }
+  if (
+    code === "untrusted" ||
+    code === "url_blocked" ||
+    code === "path_not_allowed" ||
+    code === "path_denied" ||
+    code === "forbidden"
+  ) {
+    return "untrusted";
+  }
+  if (code === "empty" || code === "no_results" || code === "no_images") {
+    return "empty";
+  }
+  if (
+    code === "auth_required" ||
+    code === "imagine_failed" ||
+    code === "generic" ||
+    code === "other"
+  ) {
+    return "other";
+  }
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  // empty first (soft “no results”)
+  if (
+    /\bempty\b/.test(s) ||
+    s.includes("no images") ||
+    s.includes("no results") ||
+    s.includes("no wallpapers") ||
+    s.includes("nothing found")
+  ) {
+    return "empty";
+  }
+
+  // untrusted / blocked hosts (before generic network)
+  if (
+    s.includes("url_blocked") ||
+    s.includes("url blocked") ||
+    s.includes("not allowed") ||
+    s.includes("path_not_allowed") ||
+    s.includes("untrusted") ||
+    s.includes("allowlist") ||
+    s.includes("forbidden host") ||
+    s.includes("blocked host")
+  ) {
+    return "untrusted";
+  }
+
+  // host / CLI / desktop
+  if (
+    s.includes("cli_missing") ||
+    s.includes("cli not found") ||
+    s.includes("cli missing") ||
+    s.includes("need tauri") ||
+    s.includes("need_tauri") ||
+    s.includes("host only") ||
+    s.includes("host_only") ||
+    s.includes("desktop only") ||
+    s.includes("desktop_only") ||
+    s.includes("requires the desktop") ||
+    s.includes("not available in browser")
+  ) {
+    return "host";
+  }
+
+  // network
+  if (
+    s.includes("search_failed") ||
+    s.includes("download_failed") ||
+    s.includes("read_failed") ||
+    s.includes("timeout") ||
+    s.includes("timed out") ||
+    s.includes("network") ||
+    s.includes("offline") ||
+    s.includes("econnrefused") ||
+    s.includes("enotfound") ||
+    s.includes("fetch failed") ||
+    s.includes("failed to fetch") ||
+    /\b(502|503|504)\b/.test(s)
+  ) {
+    return "network";
+  }
+
+  return "other";
+}
+
+/** i18n title key for a classified gallery error kind. */
+export function wallpaperGalleryErrorTitleKey(
+  kind: WallpaperGalleryErrorKind,
+): string {
+  switch (kind) {
+    case "network":
+      return "settings.wallpaperSource.errKind.network";
+    case "host":
+      return "settings.wallpaperSource.errKind.host";
+    case "untrusted":
+      return "settings.wallpaperSource.errKind.untrusted";
+    case "empty":
+      return "settings.wallpaperSource.errKind.empty";
+    case "other":
+    default:
+      return "settings.wallpaperSource.errKind.other";
+  }
+}
+
+/** i18n hint key for a classified gallery error kind. */
+export function wallpaperGalleryErrorHintKey(
+  kind: WallpaperGalleryErrorKind,
+): string {
+  switch (kind) {
+    case "network":
+      return "settings.wallpaperSource.errKind.hint.network";
+    case "host":
+      return "settings.wallpaperSource.errKind.hint.host";
+    case "untrusted":
+      return "settings.wallpaperSource.errKind.hint.untrusted";
+    case "empty":
+      return "settings.wallpaperSource.errKind.hint.empty";
+    case "other":
+    default:
+      return "settings.wallpaperSource.errKind.hint.other";
+  }
+}
+
+/**
+ * Soft-fail when the failure is a capability/empty gap rather than a hard
+ * crash: host gaps, empty results, and untrusted URL blocks stay warn-level.
+ * Network / other stay as actionable errors (still non-fatal to the app).
+ */
+export function isWallpaperGallerySoftFail(
+  kind: WallpaperGalleryErrorKind,
+): boolean {
+  return kind === "host" || kind === "empty" || kind === "untrusted";
+}
+
+// ── Kind helpers ─────────────────────────────────────────────────────────────
+
+/** Normalize media kind into a chip bucket (`image` | `video`). */
+export function galleryKindBucket(
+  kind: string | null | undefined,
+): Exclude<WallpaperGalleryKindFilter, "all"> {
+  const k = String(kind ?? "")
+    .toLowerCase()
+    .trim();
+  if (
+    k === "video" ||
+    k.startsWith("video/") ||
+    k.includes("mp4") ||
+    k.includes("webm") ||
+    k.includes("mov")
+  ) {
+    return "video";
+  }
+  return "image";
+}
+
+/** Whether an item matches the kind chip (`all` always matches). */
+export function itemMatchesKindFilter(
+  item: Pick<WallpaperGalleryItemLike, "kind"> | null | undefined,
+  filter: WallpaperGalleryKindFilter | null | undefined,
+): boolean {
+  if (!item) return false;
+  const f = filter ?? "all";
+  if (f === "all") return true;
+  return galleryKindBucket(item.kind) === f;
+}
+
+/** Count items per kind chip bucket. Never invents rows. */
+export function countGalleryByKind(
+  items: readonly Pick<WallpaperGalleryItemLike, "kind">[],
+): WallpaperGalleryKindCounts {
+  const counts: WallpaperGalleryKindCounts = {
+    all: items.length,
+    image: 0,
+    video: 0,
+  };
+  for (const it of items) {
+    counts[galleryKindBucket(it.kind)] += 1;
+  }
+  return counts;
+}
+
+/** i18n label key for a kind chip. */
+export function wallpaperGalleryKindFilterLabelKey(
+  filter: WallpaperGalleryKindFilter,
+): string {
+  switch (filter) {
+    case "image":
+      return "settings.wallpaperSource.kind.image";
+    case "video":
+      return "settings.wallpaperSource.kind.video";
+    case "all":
+    default:
+      return "settings.wallpaperSource.kind.all";
+  }
+}
+
+// ── Filter ───────────────────────────────────────────────────────────────────
+
+export type WallpaperGalleryListFilter = {
+  query?: string | null;
+  kind?: WallpaperGalleryKindFilter | null;
+};
+
+/**
+ * True when kind chip or free-text narrows the list
+ * (used for filter-empty honesty and clear-filters CTA).
+ */
+export function wallpaperGalleryHasActiveFilters(
+  filter: WallpaperGalleryListFilter | null | undefined,
+): boolean {
+  if (!filter) return false;
+  const kind = filter.kind ?? "all";
+  const q = (filter.query ?? "").trim();
+  return kind !== "all" || q.length > 0;
+}
+
+/**
+ * Filter gallery items by free-text query and optional kind chip (AND).
+ *
+ * Text matches username, textPreview, prompt, urls, source, kind, id.
+ * Does **not** invent CDN rows — only filters the provided list.
+ *
+ * Overload: `filterGalleryItems(items, queryString)` for query-only.
+ */
+export function filterGalleryItems<T extends WallpaperGalleryItemLike>(
+  items: readonly T[],
+  queryOrFilter: string | WallpaperGalleryListFilter | null | undefined = {},
+): T[] {
+  const opts: WallpaperGalleryListFilter =
+    typeof queryOrFilter === "string"
+      ? { query: queryOrFilter }
+      : queryOrFilter ?? {};
+
+  const kind = opts.kind ?? "all";
+  let out: T[] = items as T[];
+
+  if (kind !== "all") {
+    out = out.filter((it) => itemMatchesKindFilter(it, kind));
+  }
+
+  const q = (opts.query ?? "").trim().toLowerCase();
+  if (!q) return out;
+
+  return out.filter((it) => {
+    const hay = [
+      it.id ?? "",
+      it.kind ?? "",
+      it.source ?? "",
+      it.username ?? "",
+      it.textPreview ?? "",
+      it.prompt ?? "",
+      it.fullUrl ?? "",
+      it.thumbUrl ?? "",
+      it.localPath ?? "",
+      it.postUrl ?? "",
+      galleryKindBucket(it.kind),
+    ]
+      .join("\n")
+      .toLowerCase();
+    return hay.includes(q);
+  });
+}
+
+// ── Empty state resolve ──────────────────────────────────────────────────────
+
+/**
+ * Resolve which empty surface to show for the wallpaper gallery body.
+ * Returns `null` when filtered item rows should render.
+ *
+ * Priority:
+ * 1. itemCount > 0 → null (render gallery — never invent extras)
+ * 2. loading → loading
+ * 3. error → empty (soft) or error (classified)
+ * 4. filters active + (total unknown or total > 0) → filter_empty
+ * 5. hasSearched or totalCount === 0 → empty
+ * 6. idle (never searched)
+ */
+export function resolveWallpaperGalleryEmptyState(
+  input: WallpaperGalleryEmptyInput,
+): WallpaperGalleryEmptyPresentation | null {
+  const itemCount = Math.max(0, Math.floor(Number(input.itemCount) || 0));
+  if (itemCount > 0) return null;
+
+  if (input.loading) {
+    return {
+      kind: "loading",
+      titleKey: "settings.wallpaperSource.empty.loading",
+      hintKey: "settings.wallpaperSource.empty.loadingHint",
+      showClearFilters: false,
+      softFail: true,
+    };
+  }
+
+  if (input.error != null && String(errText(input.error)).trim()) {
+    const errorKind = classifyWallpaperGalleryError(input.error);
+    if (errorKind === "empty") {
+      return {
+        kind: "empty",
+        titleKey: "settings.wallpaperSource.empty.noResults",
+        hintKey: "settings.wallpaperSource.empty.noResultsHint",
+        showClearFilters: false,
+        softFail: true,
+        errorKind,
+      };
+    }
+    return {
+      kind: "error",
+      titleKey: wallpaperGalleryErrorTitleKey(errorKind),
+      hintKey: wallpaperGalleryErrorHintKey(errorKind),
+      showClearFilters: false,
+      softFail: isWallpaperGallerySoftFail(errorKind),
+      errorKind,
+    };
+  }
+
+  const q = (input.query ?? "").trim();
+  const kind = input.kindFilter ?? "all";
+  const hasFilters = kind !== "all" || q.length > 0;
+  const totalRaw = input.totalCount;
+  const totalKnown = totalRaw != null && Number.isFinite(Number(totalRaw));
+  const total = totalKnown ? Math.max(0, Math.floor(Number(totalRaw) || 0)) : null;
+
+  if (hasFilters && (total == null || total > 0)) {
+    return {
+      kind: "filter_empty",
+      titleKey: "settings.wallpaperSource.empty.filterEmpty",
+      hintKey: "settings.wallpaperSource.empty.filterEmptyHint",
+      showClearFilters: true,
+      softFail: true,
+    };
+  }
+
+  if (input.hasSearched || total === 0) {
+    return {
+      kind: "empty",
+      titleKey: "settings.wallpaperSource.empty.noResults",
+      hintKey: "settings.wallpaperSource.empty.noResultsHint",
+      showClearFilters: false,
+      softFail: true,
+    };
+  }
+
+  return {
+    kind: "idle",
+    titleKey: "settings.wallpaperSource.emptyGallery",
+    hintKey: "settings.wallpaperSource.empty.idleHint",
+    showClearFilters: false,
+    softFail: true,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6594,9 +6594,102 @@ textarea.settings-input.settings-agents-json__textarea {
   font-size: 12.5px;
 }
 
+.wallpaper-source-error--soft {
+  background: color-mix(in srgb, var(--warning, #c90) 12%, var(--bg-elevated));
+}
+
 .wallpaper-source-error p {
   margin: 0;
   flex: 1 1 auto;
+}
+
+.wallpaper-source-err-chip {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--danger, #e55) 35%, transparent);
+  background: color-mix(in srgb, var(--danger, #e55) 10%, transparent);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 560;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.wallpaper-source-err-chip--soft {
+  border-color: color-mix(in srgb, var(--warning, #c90) 40%, transparent);
+  background: color-mix(in srgb, var(--warning, #c90) 12%, transparent);
+}
+
+.wallpaper-source-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.wallpaper-source-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.wallpaper-source-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.3;
+  cursor: pointer;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wallpaper-source-chip:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.wallpaper-source-chip.is-active {
+  border-color: color-mix(in srgb, var(--accent, #6b8cff) 30%, transparent);
+  background: color-mix(in srgb, var(--accent, #6b8cff) 14%, transparent);
+  color: var(--text-primary);
+  font-weight: 560;
+}
+
+.wallpaper-source-chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.wallpaper-source-chip-count {
+  font-size: 11px;
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+
+.wallpaper-source-chip.is-active .wallpaper-source-chip-count {
+  opacity: 0.9;
+}
+
+.wallpaper-source-filters__query {
+  flex: 1 1 140px;
+  min-width: 120px;
+  max-width: 280px;
 }
 
 /*
@@ -6652,10 +6745,34 @@ textarea.settings-input.settings-agents-json__textarea {
 
 .wallpaper-masonry__empty {
   column-span: all;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
   margin: 24px 8px;
   text-align: center;
   color: var(--text-tertiary);
   font-size: 13px;
+}
+
+.wallpaper-masonry__empty-title {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13.5px;
+  font-weight: 550;
+}
+
+.wallpaper-masonry__empty-hint {
+  margin: 0;
+  max-width: 36em;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+}
+
+.wallpaper-masonry__empty--filter .wallpaper-masonry__empty-title,
+.wallpaper-masonry__empty--error .wallpaper-masonry__empty-title {
+  color: var(--text-primary);
 }
 
 .wallpaper-masonry__card {
@@ -6738,7 +6855,8 @@ textarea.settings-input.settings-agents-json__textarea {
 .wallpaper-source-modal__body > .wallpaper-source-tabs,
 .wallpaper-source-modal__body > .wallpaper-source-form,
 .wallpaper-source-modal__body > .wallpaper-source-status,
-.wallpaper-source-modal__body > .wallpaper-source-error {
+.wallpaper-source-modal__body > .wallpaper-source-error,
+.wallpaper-source-modal__body > .wallpaper-source-filters {
   flex: 0 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- Wallpaper gallery **empty honesty**: idle · loading · no results · filter empty · classified error (never invents CDN tiles)
- **Kind filter chips** (All · Images · Videos) with counts + client-side gallery text filter + clear filters CTA
- **Classified soft-fail load errors**: network · host · untrusted · empty · other chips on the error banner
- Pure helpers + tests in `wallpaperGalleryPro`; i18n en/zh/zh-TW; CHANGELOG

## Test plan
- [x] `pnpm test -- src/lib/wallpaperGalleryPro.test.ts src/lib/wallpaperSource.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm install --frozen-lockfile`
- [ ] Manual: Settings → Appearance → Find wallpapers — idle empty, search empty, filter chips, soft-fail chip on CLI missing / blocked URL