### PR TITLE
feat(runtime): process budget empty honesty and limit callout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+#### Runtime / process pool
+- **Process budget empty honesty + limit callout** (PROCESS-BUDGET-RECLAIM-PRO): pure `processBudgetPro` helpers — `resolveProcessBudgetEmptyState` (loading · unavailable · error · empty pool), `classifyProcessBudgetError` (host-only · unavailable · timeout · permission · other), `formatOccupancySummary`, `shouldShowProcessLimitCallout` / limit empty state (no recent PROCESS_LIMIT in 24h). Settings + Reliability panel never invents busy occupancy; shows honest empty-pool vs host soft-fail; last limit callout always has empty or active copy. en/zh/zh-TW + tests. Does not change spawn policy.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitejs/plugin-react-swc':
+        specifier: ^3.11.0
+        version: 3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
       canvas:
         specifier: ^3.2.3
         version: 3.2.3
@@ -455,35 +458,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -643,79 +641,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -746,6 +731,93 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@swc/core-darwin-arm64@1.15.47':
+    resolution: {integrity: sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.47':
+    resolution: {integrity: sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    resolution: {integrity: sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    resolution: {integrity: sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    resolution: {integrity: sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    resolution: {integrity: sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    resolution: {integrity: sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    resolution: {integrity: sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    resolution: {integrity: sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    resolution: {integrity: sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    resolution: {integrity: sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    resolution: {integrity: sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.47':
+    resolution: {integrity: sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tabler/icons-react@3.45.0':
     resolution: {integrity: sha512-t/AuKs7ALMDDTY+B9IvfZnlO0mbLlP/lJxP/HnGC49QkM8mCsTN38kYyxjXxgrb1+TeK53ioVBJqIV7n/eysXQ==}
@@ -793,28 +865,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -875,35 +943,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.4':
     resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -1277,6 +1340,11 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitejs/plugin-react-swc@3.11.0':
+    resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
+    peerDependencies:
+      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1933,28 +2001,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3244,6 +3308,66 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@swc/core-darwin-arm64@1.15.47':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core@1.15.47':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.47
+      '@swc/core-darwin-x64': 1.15.47
+      '@swc/core-linux-arm-gnueabihf': 1.15.47
+      '@swc/core-linux-arm64-gnu': 1.15.47
+      '@swc/core-linux-arm64-musl': 1.15.47
+      '@swc/core-linux-ppc64-gnu': 1.15.47
+      '@swc/core-linux-s390x-gnu': 1.15.47
+      '@swc/core-linux-x64-gnu': 1.15.47
+      '@swc/core-linux-x64-musl': 1.15.47
+      '@swc/core-win32-arm64-msvc': 1.15.47
+      '@swc/core-win32-ia32-msvc': 1.15.47
+      '@swc/core-win32-x64-msvc': 1.15.47
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.28':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@tabler/icons-react@3.45.0(react@19.2.7)':
     dependencies:
       '@tabler/icons': 3.45.0
@@ -3777,6 +3901,14 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitejs/plugin-react-swc@3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@swc/core': 1.15.47
+      vite: 6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:

--- a/src/components/ProcessBudgetPanel.tsx
+++ b/src/components/ProcessBudgetPanel.tsx
@@ -2,24 +2,30 @@
  * Process budget occupancy panel — live warm-agent counts vs maxConcurrentAgents.
  * Used in Settings → Runtime → Process pool and Reliability center.
  * Soft-fails when host snapshot is unavailable; never invents busy occupancy.
+ * Empty honesty + process_limit callout via processBudgetPro.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createT, type Locale, type MessageKey } from "@/i18n";
 import * as api from "@/lib/api";
 import {
+  DEFAULT_MAX_CONCURRENT_AGENTS,
   emptyProcessBudgetSnapshot,
   occupancyPercent,
   occupancyTone,
   parseProcessBudgetSnapshot,
   processBudgetCountVars,
-  processLimitAgeMinutes,
   PROCESS_BUDGET_POLL_MS,
   reclaimPlan,
   reclaimPlanCopyKey,
   type ProcessBudgetSnapshot,
   type ProcessLimitEvent,
 } from "@/lib/processBudget";
+import {
+  formatOccupancySummary,
+  resolveProcessBudgetEmptyState,
+  resolveProcessLimitCalloutState,
+} from "@/lib/processBudgetPro";
 
 export type ProcessBudgetPanelProps = {
   locale: Locale;
@@ -61,6 +67,7 @@ export function ProcessBudgetPanel({
     emptyProcessBudgetSnapshot(),
   );
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<unknown>(null);
   const [now, setNow] = useState(() => Date.now());
 
   const load = useCallback(async () => {
@@ -68,8 +75,10 @@ export function ProcessBudgetPanel({
     try {
       const raw = await api.processBudgetSnapshot();
       setSnap(parseProcessBudgetSnapshot(raw));
-    } catch {
+      setLoadError(null);
+    } catch (err) {
       setSnap(emptyProcessBudgetSnapshot());
+      setLoadError(err);
     } finally {
       setLoading(false);
       setNow(Date.now());
@@ -85,22 +94,68 @@ export function ProcessBudgetPanel({
     return () => window.clearInterval(timer);
   }, [active, load]);
 
+  const empty = resolveProcessBudgetEmptyState({
+    loading,
+    snapshot: snap,
+    error: loadError,
+  });
+  const summary = formatOccupancySummary(snap);
   const plan = reclaimPlan(snap);
   const planKey = reclaimPlanCopyKey(plan) as MessageKey;
-  const tone = occupancyTone(plan);
-  const vars = processBudgetCountVars(snap);
-  const pct = snap.available
-    ? occupancyPercent(snap.totalWarm, snap.maxConcurrent)
+  const tone = empty != null ? empty.tone : occupancyTone(plan);
+  // Count vars for i18n: use live snap when available; else max/idle only (zeros elsewhere).
+  const vars = processBudgetCountVars(
+    snap.available
+      ? snap
+      : {
+          ...emptyProcessBudgetSnapshot({
+            maxConcurrent:
+              snap.maxConcurrent || DEFAULT_MAX_CONCURRENT_AGENTS,
+            idleMinutes: snap.idleMinutes || 30,
+          }),
+          maxConcurrent:
+            snap.maxConcurrent || DEFAULT_MAX_CONCURRENT_AGENTS,
+          idleMinutes: snap.idleMinutes || 30,
+        },
+  );
+  const pct = summary.available
+    ? occupancyPercent(summary.total, summary.max)
     : 0;
 
-  const limitAgeMin = processLimitAgeMinutes(lastProcessLimit, now);
-  const showLimit =
-    lastProcessLimit != null &&
-    (limitAgeMin == null || limitAgeMin < 24 * 60);
+  const limitCallout = resolveProcessLimitCalloutState({
+    event: lastProcessLimit,
+    now,
+  });
 
   const rootClass =
     (variant === "card" ? "reliab-card process-budget-panel" : "process-budget-panel") +
     (className ? ` ${className}` : "");
+
+  const headCountLabel = (() => {
+    if (empty?.kind === "loading") return t("processBudget.loading");
+    if (empty?.kind === "error") return t("processBudget.unavailable");
+    if (empty?.kind === "unavailable") return t("processBudget.unavailable");
+    if (summary.available) return t("processBudget.counts", vars);
+    return t("processBudget.unavailable");
+  })();
+
+  const planBody = (() => {
+    if (empty?.kind === "loading") {
+      return t((empty.bodyKey ?? empty.titleKey) as MessageKey);
+    }
+    if (empty?.kind === "error") {
+      const title = t(empty.titleKey as MessageKey);
+      const body = empty.bodyKey
+        ? t(empty.bodyKey as MessageKey)
+        : "";
+      return body ? `${title} ${body}` : title;
+    }
+    if (empty?.kind === "unavailable") {
+      return t(empty.titleKey as MessageKey);
+    }
+    // empty_pool or occupancy: reclaim plan copy (includes honest empty pool).
+    return t(planKey, vars);
+  })();
 
   return (
     <section
@@ -110,6 +165,8 @@ export function ProcessBudgetPanel({
       data-testid="process-budget-panel"
       data-available={snap.available ? "1" : "0"}
       data-plan={plan}
+      data-empty-kind={empty?.kind ?? "none"}
+      data-limit-kind={limitCallout.kind}
     >
       <header className="process-budget-panel__head">
         <h3
@@ -123,20 +180,21 @@ export function ProcessBudgetPanel({
           {t("processBudget.title")}
         </h3>
         <div className="process-budget-panel__head-actions">
-          {snap.available ? (
-            <span
-              className="process-budget-panel__count"
-              aria-label={t("processBudget.countsAria", vars)}
-            >
-              {t("processBudget.counts", vars)}
-            </span>
-          ) : (
-            <span className="process-budget-panel__count process-budget-panel__count--muted">
-              {loading
-                ? t("processBudget.loading")
-                : t("processBudget.unavailable")}
-            </span>
-          )}
+          <span
+            className={
+              summary.available
+                ? "process-budget-panel__count"
+                : "process-budget-panel__count process-budget-panel__count--muted"
+            }
+            aria-label={
+              summary.available
+                ? t("processBudget.countsAria", vars)
+                : headCountLabel
+            }
+            data-testid="process-budget-count"
+          >
+            {headCountLabel}
+          </span>
           <button
             type="button"
             className="btn btn--ghost btn--sm process-budget-panel__refresh"
@@ -159,7 +217,11 @@ export function ProcessBudgetPanel({
         aria-valuemin={0}
         aria-valuemax={100}
         aria-valuenow={pct}
-        aria-label={t("processBudget.meterAria", vars)}
+        aria-label={t("processBudget.meterAria", {
+          ...vars,
+          percent: pct,
+        })}
+        data-testid="process-budget-meter"
       >
         <div
           className="process-budget-panel__meter-fill"
@@ -167,67 +229,106 @@ export function ProcessBudgetPanel({
         />
       </div>
 
-      <div className="process-budget-panel__buckets" aria-hidden={!snap.available}>
+      <div
+        className="process-budget-panel__buckets"
+        aria-hidden={!snap.available}
+        data-testid="process-budget-buckets"
+      >
         <span className="process-budget-panel__bucket">
           <span className="process-budget-panel__bucket-label">
             {t("processBudget.bucket.live")}
           </span>
-          <span className="process-budget-panel__bucket-val">{vars.live}</span>
+          <span className="process-budget-panel__bucket-val">
+            {summary.available ? summary.live : "—"}
+          </span>
         </span>
         <span className="process-budget-panel__bucket">
           <span className="process-budget-panel__bucket-label">
             {t("processBudget.bucket.background")}
           </span>
           <span className="process-budget-panel__bucket-val">
-            {vars.background}
+            {summary.available ? summary.background : "—"}
           </span>
         </span>
         <span className="process-budget-panel__bucket">
           <span className="process-budget-panel__bucket-label">
             {t("processBudget.bucket.parked")}
           </span>
-          <span className="process-budget-panel__bucket-val">{vars.parked}</span>
+          <span className="process-budget-panel__bucket-val">
+            {summary.available ? summary.parked : "—"}
+          </span>
         </span>
         <span className="process-budget-panel__bucket">
           <span className="process-budget-panel__bucket-label">
             {t("processBudget.bucket.free")}
           </span>
-          <span className="process-budget-panel__bucket-val">{vars.free}</span>
+          <span className="process-budget-panel__bucket-val">
+            {summary.available ? summary.free : "—"}
+          </span>
         </span>
       </div>
 
-      <p className="process-budget-panel__plan" data-testid="process-budget-plan">
-        {t(planKey, vars)}
+      <p
+        className={
+          empty != null && empty.kind !== "empty_pool"
+            ? "process-budget-panel__plan process-budget-panel__plan--soft"
+            : "process-budget-panel__plan"
+        }
+        data-testid="process-budget-plan"
+        data-empty-kind={empty?.kind ?? "none"}
+      >
+        {planBody}
       </p>
+
+      {empty?.kind === "empty_pool" && empty.bodyKey ? (
+        <p
+          className="process-budget-panel__empty-hint"
+          data-testid="process-budget-empty-hint"
+        >
+          {t(empty.bodyKey as MessageKey, vars)}
+        </p>
+      ) : null}
+
+      {empty?.kind === "unavailable" && empty.bodyKey ? (
+        <p
+          className="process-budget-panel__empty-hint"
+          data-testid="process-budget-unavailable-hint"
+        >
+          {t(empty.bodyKey as MessageKey)}
+        </p>
+      ) : null}
 
       <p className="process-budget-panel__policy">
         {t("processBudget.idlePolicy", { idleMinutes: vars.idleMinutes })}
       </p>
 
-      {showLimit && lastProcessLimit ? (
-        <div
-          className="process-budget-panel__limit"
-          role="status"
-          data-testid="process-budget-last-limit"
-        >
-          <div className="process-budget-panel__limit-title">
-            {t("processBudget.limit.title")}
-          </div>
-          <p className="process-budget-panel__limit-body">
-            {t("processBudget.limit.explain", {
-              max:
-                lastProcessLimit.maxConcurrentAgents ??
-                vars.max ??
-                DEFAULT_MAX_LABEL,
-              when: formatWhen(lastProcessLimit.at, locale),
-            })}
-          </p>
+      <div
+        className={
+          limitCallout.emphasized
+            ? "process-budget-panel__limit process-budget-panel__limit--active"
+            : "process-budget-panel__limit process-budget-panel__limit--none"
+        }
+        role="status"
+        data-testid="process-budget-last-limit"
+        data-limit-kind={limitCallout.kind}
+      >
+        <div className="process-budget-panel__limit-title">
+          {t(limitCallout.titleKey)}
         </div>
-      ) : null}
+        <p className="process-budget-panel__limit-body">
+          {limitCallout.kind === "active" && lastProcessLimit
+            ? t(limitCallout.bodyKey, {
+                max:
+                  lastProcessLimit.maxConcurrentAgents ??
+                  vars.max ??
+                  DEFAULT_MAX_CONCURRENT_AGENTS,
+                when: formatWhen(lastProcessLimit.at, locale),
+              })
+            : t(limitCallout.bodyKey)}
+        </p>
+      </div>
     </section>
   );
 }
-
-const DEFAULT_MAX_LABEL = 8;
 
 export type { ProcessLimitEvent };

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -2119,7 +2119,13 @@ const en = {
   "processBudget.lead":
     "Live occupancy of warm agent processes (focused live, mid-turn background, idle parked). Cap is Max concurrent agents; idle parked are reclaimed before PROCESS_LIMIT.",
   "processBudget.loading": "Loading…",
+  "processBudget.loadingHint":
+    "Reading warm-agent occupancy from the host — not claiming the pool is empty yet.",
   "processBudget.unavailable": "Occupancy unavailable",
+  "processBudget.unavailableHint":
+    "Spawn policy is unchanged. Use Refresh, or open Reliability after agents are running.",
+  "processBudget.emptyPoolHint":
+    "Honest empty pool — not a host soft-fail. Cap remains {max}; idle recycle still applies when agents go idle.",
   "processBudget.refresh": "Refresh",
   "processBudget.counts": "{total} / {max}",
   "processBudget.countsAria":
@@ -2143,9 +2149,27 @@ const en = {
     "Warm processes ({total}) exceed the configured cap ({max}). New connects reclaim idle parked first; raise the limit if this persists.",
   "processBudget.idlePolicy":
     "Idle recycle: ready agents without activity for {idleMinutes} minutes are soft-killed (history kept; next message reconnects).",
+  "processBudget.error.hostOnly": "Process budget needs the desktop host",
+  "processBudget.error.hostOnlyHint":
+    "Occupancy is only available in the Grok App desktop shell — not in a plain browser tab.",
+  "processBudget.error.unavailable": "Process pool unavailable",
+  "processBudget.error.unavailableHint":
+    "The host manager is not ready yet. Try Refresh after agents have started.",
+  "processBudget.error.timeout": "Process budget timed out",
+  "processBudget.error.timeoutHint":
+    "Snapshot took too long. Try Refresh; spawn policy is unchanged.",
+  "processBudget.error.permission": "Process budget permission denied",
+  "processBudget.error.permissionHint":
+    "The host refused the occupancy snapshot. Check app permissions or restart the desktop app.",
+  "processBudget.error.other": "Could not load process budget",
+  "processBudget.error.otherHint":
+    "Try Refresh. Occupancy is unknown — we never invent busy slots.",
   "processBudget.limit.title": "Last process limit",
   "processBudget.limit.explain":
     "PROCESS_LIMIT fired (max {max}) — idle parked were already reclaimed; every remaining slot was a busy turn. Stop a running session or raise Max concurrent agents. {when}",
+  "processBudget.limit.noneTitle": "No recent process limit",
+  "processBudget.limit.noneBody":
+    "No PROCESS_LIMIT in the last 24 hours. Idle parked are reclaimed before a hard limit; only all-busy turns block a new connect.",
   "agent.streamStallBanner":
     "No stream or tool progress for about {seconds}s. Keep waiting or end this turn.",
   "agent.streamStallCancel": "End turn",
@@ -8243,7 +8267,13 @@ const zh: Record<MessageKey, string> = {
   "processBudget.lead":
     "当前热 Agent 进程占用（焦点 live、中途 background、闲置 parked）。上限即「最大并发 Agent 数」；触发 PROCESS_LIMIT 前会先回收闲置 parked。",
   "processBudget.loading": "加载中…",
+  "processBudget.loadingHint":
+    "正在从 Host 读取热 Agent 占用 — 不会把尚未加载的状态当作空池。",
   "processBudget.unavailable": "无法读取占用",
+  "processBudget.unavailableHint":
+    "生成策略未改变。可点刷新，或在有 Agent 运行后打开可靠性中心。",
+  "processBudget.emptyPoolHint":
+    "这是诚实的空池（不是 Host 读取失败）。上限仍为 {max}；Agent 闲置后仍会按策略回收。",
   "processBudget.refresh": "刷新",
   "processBudget.counts": "{total} / {max}",
   "processBudget.countsAria":
@@ -8267,9 +8297,27 @@ const zh: Record<MessageKey, string> = {
     "热进程数（{total}）超过配置上限（{max}）。新连接会优先回收闲置 parked；若持续出现请提高上限。",
   "processBudget.idlePolicy":
     "闲置回收：就绪 Agent 连续 {idleMinutes} 分钟无活动会被软结束（历史保留；下次发送重连）。",
+  "processBudget.error.hostOnly": "进程预算需在桌面 Host 中查看",
+  "processBudget.error.hostOnlyHint":
+    "占用数据仅在 Grok App 桌面壳中可用，普通浏览器标签页无法读取。",
+  "processBudget.error.unavailable": "进程池不可用",
+  "processBudget.error.unavailableHint":
+    "Host 管理器尚未就绪。可在 Agent 启动后再点刷新。",
+  "processBudget.error.timeout": "进程预算读取超时",
+  "processBudget.error.timeoutHint":
+    "快照耗时过长。可点刷新；生成策略未改变。",
+  "processBudget.error.permission": "进程预算权限被拒绝",
+  "processBudget.error.permissionHint":
+    "Host 拒绝了占用快照。请检查应用权限或重启桌面应用。",
+  "processBudget.error.other": "无法加载进程预算",
+  "processBudget.error.otherHint":
+    "可点刷新。占用未知 — 我们不会编造忙碌槽位。",
   "processBudget.limit.title": "最近一次进程上限",
   "processBudget.limit.explain":
     "已触发 PROCESS_LIMIT（上限 {max}）— 闲置 parked 已回收完毕，剩余槽位均为忙碌回合。请停止运行中的会话，或提高「最大并发 Agent 数」。{when}",
+  "processBudget.limit.noneTitle": "近期无进程上限事件",
+  "processBudget.limit.noneBody":
+    "过去 24 小时内未触发 PROCESS_LIMIT。闲置 parked 会在硬上限前被回收；只有槽位全是忙碌回合时才会阻止新连接。",
   "agent.streamStallBanner":
     "约 {seconds} 秒无流式片段或工具活动。可继续等待或结束本轮。",
   "agent.streamStallCancel": "结束本轮",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1996,7 +1996,13 @@ export const zhTW: Record<MessageKey, string> = {
   "processBudget.lead":
     "目前熱 Agent 行程佔用（焦點 live、中途 background、閒置 parked）。上限即「最大並發 Agent 數」；觸發 PROCESS_LIMIT 前會先回收閒置 parked。",
   "processBudget.loading": "載入中…",
+  "processBudget.loadingHint":
+    "正在從 Host 讀取熱 Agent 佔用 — 不會把尚未載入的狀態當作空池。",
   "processBudget.unavailable": "無法讀取佔用",
+  "processBudget.unavailableHint":
+    "產生策略未改變。可點重新整理，或在有 Agent 執行後開啟可靠性中心。",
+  "processBudget.emptyPoolHint":
+    "這是誠實的空池（不是 Host 讀取失敗）。上限仍為 {max}；Agent 閒置後仍會依策略回收。",
   "processBudget.refresh": "重新整理",
   "processBudget.counts": "{total} / {max}",
   "processBudget.countsAria":
@@ -2020,9 +2026,27 @@ export const zhTW: Record<MessageKey, string> = {
     "熱行程數（{total}）超過設定上限（{max}）。新連線會優先回收閒置 parked；若持續出現請提高上限。",
   "processBudget.idlePolicy":
     "閒置回收：就緒 Agent 連續 {idleMinutes} 分鐘無活動會被軟結束（歷史保留；下次傳送重連）。",
+  "processBudget.error.hostOnly": "行程預算需在桌面 Host 中檢視",
+  "processBudget.error.hostOnlyHint":
+    "佔用資料僅在 Grok App 桌面殼中可用，一般瀏覽器分頁無法讀取。",
+  "processBudget.error.unavailable": "行程池不可用",
+  "processBudget.error.unavailableHint":
+    "Host 管理器尚未就緒。可在 Agent 啟動後再點重新整理。",
+  "processBudget.error.timeout": "行程預算讀取逾時",
+  "processBudget.error.timeoutHint":
+    "快照耗時過長。可點重新整理；產生策略未改變。",
+  "processBudget.error.permission": "行程預算權限被拒絕",
+  "processBudget.error.permissionHint":
+    "Host 拒絕了佔用快照。請檢查應用程式權限或重新啟動桌面應用。",
+  "processBudget.error.other": "無法載入行程預算",
+  "processBudget.error.otherHint":
+    "可點重新整理。佔用未知 — 我們不會編造忙碌槽位。",
   "processBudget.limit.title": "最近一次行程上限",
   "processBudget.limit.explain":
     "已觸發 PROCESS_LIMIT（上限 {max}）— 閒置 parked 已回收完畢，剩餘槽位均為忙碌回合。請停止執行中的工作階段，或提高「最大並發 Agent 數」。{when}",
+  "processBudget.limit.noneTitle": "近期無行程上限事件",
+  "processBudget.limit.noneBody":
+    "過去 24 小時內未觸發 PROCESS_LIMIT。閒置 parked 會在硬上限前被回收；只有槽位全是忙碌回合時才會阻止新連線。",
   "agent.streamStallBanner":
     "約 {seconds} 秒無串流片段或工具活動。可繼續等待或結束本輪。",
   "agent.streamStallCancel": "結束本輪",

--- a/src/lib/processBudgetPro.test.ts
+++ b/src/lib/processBudgetPro.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import {
+  emptyProcessBudgetSnapshot,
+  type ProcessBudgetSnapshot,
+  type ProcessLimitEvent,
+} from "./processBudget";
+import {
+  classifyProcessBudgetError,
+  formatOccupancySummary,
+  processBudgetErrorView,
+  PROCESS_LIMIT_CALLOUT_MAX_AGE_MINUTES,
+  resolveProcessBudgetEmptyState,
+  resolveProcessLimitCalloutState,
+  shouldShowProcessLimitCallout,
+} from "./processBudgetPro";
+
+function snap(
+  partial: Partial<ProcessBudgetSnapshot> & {
+    live: number;
+    background: number;
+    parked: number;
+  },
+): ProcessBudgetSnapshot {
+  const live = partial.live;
+  const background = partial.background;
+  const parked = partial.parked;
+  return {
+    live,
+    background,
+    parked,
+    totalWarm: partial.totalWarm ?? live + background + parked,
+    busy: partial.busy ?? live + background,
+    maxConcurrent: partial.maxConcurrent ?? 8,
+    idleMinutes: partial.idleMinutes ?? 30,
+    liveSessionIds: partial.liveSessionIds ?? [],
+    backgroundSessionIds: partial.backgroundSessionIds ?? [],
+    parkedSessionIds: partial.parkedSessionIds ?? [],
+    available: partial.available ?? true,
+  };
+}
+
+function limitEvent(
+  partial: Partial<ProcessLimitEvent> = {},
+): ProcessLimitEvent {
+  return {
+    at: partial.at ?? 1_700_000_000_000,
+    maxConcurrentAgents: partial.maxConcurrentAgents ?? 8,
+    sessionId: partial.sessionId ?? "s1",
+    message: partial.message ?? "Agent process limit reached",
+    code: partial.code ?? "PROCESS_LIMIT",
+  };
+}
+
+describe("classifyProcessBudgetError", () => {
+  it("classifies host_only / unavailable / timeout / permission", () => {
+    expect(classifyProcessBudgetError({ code: "host_only" })).toBe(
+      "host_only",
+    );
+    expect(classifyProcessBudgetError({ code: "need_tauri" })).toBe(
+      "host_only",
+    );
+    expect(classifyProcessBudgetError(new Error("need tauri"))).toBe(
+      "host_only",
+    );
+    expect(classifyProcessBudgetError({ code: "unavailable" })).toBe(
+      "unavailable",
+    );
+    expect(classifyProcessBudgetError(new Error("manager not ready"))).toBe(
+      "unavailable",
+    );
+    expect(classifyProcessBudgetError({ code: "timeout" })).toBe("timeout");
+    expect(classifyProcessBudgetError(new Error("request timed out"))).toBe(
+      "timeout",
+    );
+    expect(classifyProcessBudgetError({ code: "permission_denied" })).toBe(
+      "permission",
+    );
+    expect(classifyProcessBudgetError(new Error("permission denied"))).toBe(
+      "permission",
+    );
+    expect(classifyProcessBudgetError(new Error("weird boom"))).toBe("other");
+    expect(classifyProcessBudgetError(null)).toBe("other");
+  });
+
+  it("maps error views to i18n keys + soft-fail", () => {
+    const host = processBudgetErrorView({ code: "host_only" });
+    expect(host.softFail).toBe(true);
+    expect(host.titleKey).toBe("processBudget.error.hostOnly");
+    expect(host.hintKey).toBe("processBudget.error.hostOnlyHint");
+
+    const perm = processBudgetErrorView({ code: "permission" });
+    expect(perm.softFail).toBe(false);
+    expect(perm.titleKey).toBe("processBudget.error.permission");
+  });
+});
+
+describe("resolveProcessBudgetEmptyState", () => {
+  it("loading + no available snapshot → loading (never invent empty pool)", () => {
+    const e = resolveProcessBudgetEmptyState({
+      loading: true,
+      snapshot: emptyProcessBudgetSnapshot(),
+    });
+    expect(e?.kind).toBe("loading");
+    expect(e?.titleKey).toBe("processBudget.loading");
+    expect(e?.softFail).toBe(true);
+    expect(e?.showRetry).toBe(false);
+  });
+
+  it("error + unavailable → error surface with retry", () => {
+    const e = resolveProcessBudgetEmptyState({
+      loading: false,
+      snapshot: emptyProcessBudgetSnapshot(),
+      error: { code: "timeout", message: "snapshot timed out" },
+    });
+    expect(e?.kind).toBe("error");
+    expect(e?.errorKind).toBe("timeout");
+    expect(e?.titleKey).toBe("processBudget.error.timeout");
+    expect(e?.showRetry).toBe(true);
+    expect(e?.tone).toBe("warn");
+  });
+
+  it("unavailable host soft-fail (no error) → unavailable", () => {
+    const e = resolveProcessBudgetEmptyState({
+      loading: false,
+      snapshot: emptyProcessBudgetSnapshot(),
+    });
+    expect(e?.kind).toBe("unavailable");
+    expect(e?.titleKey).toBe("processBudget.plan.unavailable");
+    expect(e?.showRetry).toBe(true);
+    expect(e?.softFail).toBe(true);
+  });
+
+  it("available empty pool is honest empty — not unavailable", () => {
+    const e = resolveProcessBudgetEmptyState({
+      loading: false,
+      snapshot: snap({ live: 0, background: 0, parked: 0 }),
+    });
+    expect(e?.kind).toBe("empty_pool");
+    expect(e?.titleKey).toBe("processBudget.plan.empty");
+    expect(e?.bodyKey).toBe("processBudget.emptyPoolHint");
+    expect(e?.softFail).toBe(false);
+  });
+
+  it("returns null when warm occupancy should render", () => {
+    expect(
+      resolveProcessBudgetEmptyState({
+        loading: false,
+        snapshot: snap({ live: 1, background: 0, parked: 2 }),
+      }),
+    ).toBeNull();
+    // Loading but already have available data — keep showing occupancy.
+    expect(
+      resolveProcessBudgetEmptyState({
+        loading: true,
+        snapshot: snap({ live: 2, background: 1, parked: 0 }),
+      }),
+    ).toBeNull();
+  });
+
+  it("null snapshot treated as unavailable", () => {
+    const e = resolveProcessBudgetEmptyState({
+      loading: false,
+      snapshot: null,
+    });
+    expect(e?.kind).toBe("unavailable");
+  });
+});
+
+describe("formatOccupancySummary", () => {
+  it("soft-fails to zeros when unavailable", () => {
+    const s = formatOccupancySummary(emptyProcessBudgetSnapshot());
+    expect(s.available).toBe(false);
+    expect(s.total).toBe(0);
+    expect(s.busy).toBe(0);
+    expect(s.ratio).toBe("");
+    expect(s.tokenLine).toBe("");
+    expect(s.plan).toBe("unavailable");
+  });
+
+  it("formats ready occupancy", () => {
+    const s = formatOccupancySummary(
+      snap({ live: 1, background: 1, parked: 2, maxConcurrent: 8 }),
+    );
+    expect(s.available).toBe(true);
+    expect(s.total).toBe(4);
+    expect(s.free).toBe(4);
+    expect(s.percent).toBe(50);
+    expect(s.ratio).toBe("4/8");
+    expect(s.tokenLine).toBe("live=1 bg=1 parked=2 free=4");
+    expect(s.plan).toBe("headroom");
+  });
+
+  it("classifies at-cap-with-parked plan", () => {
+    const s = formatOccupancySummary(
+      snap({ live: 1, background: 5, parked: 2, maxConcurrent: 8 }),
+    );
+    expect(s.plan).toBe("at_cap_with_parked");
+    expect(s.free).toBe(0);
+    expect(s.percent).toBe(100);
+  });
+});
+
+describe("shouldShowProcessLimitCallout + resolveProcessLimitCalloutState", () => {
+  const base = 1_700_000_000_000;
+
+  it("hides null / missing events", () => {
+    expect(shouldShowProcessLimitCallout({ event: null })).toBe(false);
+    expect(shouldShowProcessLimitCallout({ event: undefined })).toBe(false);
+    const none = resolveProcessLimitCalloutState({ event: null });
+    expect(none.kind).toBe("none");
+    expect(none.titleKey).toBe("processBudget.limit.noneTitle");
+    expect(none.emphasized).toBe(false);
+  });
+
+  it("shows recent PROCESS_LIMIT within max age", () => {
+    const event = limitEvent({ at: base });
+    expect(
+      shouldShowProcessLimitCallout({
+        event,
+        now: base + 30 * 60_000,
+      }),
+    ).toBe(true);
+    const active = resolveProcessLimitCalloutState({
+      event,
+      now: base + 30 * 60_000,
+    });
+    expect(active.kind).toBe("active");
+    expect(active.bodyKey).toBe("processBudget.limit.explain");
+    expect(active.ageMinutes).toBe(30);
+    expect(active.maxConcurrentAgents).toBe(8);
+    expect(active.emphasized).toBe(true);
+  });
+
+  it("hides events at/after max age (default 24h)", () => {
+    const event = limitEvent({ at: base });
+    expect(PROCESS_LIMIT_CALLOUT_MAX_AGE_MINUTES).toBe(24 * 60);
+    expect(
+      shouldShowProcessLimitCallout({
+        event,
+        now: base + PROCESS_LIMIT_CALLOUT_MAX_AGE_MINUTES * 60_000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowProcessLimitCallout({
+        event,
+        now: base + (PROCESS_LIMIT_CALLOUT_MAX_AGE_MINUTES + 1) * 60_000,
+      }),
+    ).toBe(false);
+    // Custom shorter window
+    expect(
+      shouldShowProcessLimitCallout({
+        event,
+        now: base + 10 * 60_000,
+        maxAgeMinutes: 5,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/processBudgetPro.ts
+++ b/src/lib/processBudgetPro.ts
@@ -1,0 +1,509 @@
+/**
+ * PROCESS-BUDGET-PRO — pure helpers for process-pool empty honesty and
+ * process_limit callout polish (Settings → Runtime → Process pool + Reliability).
+ *
+ * Builds on `processBudget` snapshot / reclaim plan helpers.
+ * Never invents busy occupancy when the host soft-fails.
+ * No DOM / Tauri side effects.
+ */
+
+import {
+  DEFAULT_MAX_CONCURRENT_AGENTS,
+  emptyProcessBudgetSnapshot,
+  occupancyPercent,
+  processBudgetCountVars,
+  processLimitAgeMinutes,
+  reclaimPlan,
+  slotsFree,
+  type ProcessBudgetReclaimPlan,
+  type ProcessBudgetSnapshot,
+  type ProcessLimitEvent,
+} from "@/lib/processBudget";
+
+// ── Error classification ─────────────────────────────────────────────────────
+
+/** Stable failure modes for process-budget snapshot load. */
+export type ProcessBudgetErrorKind =
+  | "host_only"
+  | "unavailable"
+  | "timeout"
+  | "permission"
+  | "other";
+
+export type ProcessBudgetErrorView = {
+  kind: ProcessBudgetErrorKind;
+  /** Soft-fail: capability / manager gap — warn, do not escalate. */
+  softFail: boolean;
+  /** Primary title i18n key under processBudget.error.* */
+  titleKey:
+    | "processBudget.error.hostOnly"
+    | "processBudget.error.unavailable"
+    | "processBudget.error.timeout"
+    | "processBudget.error.permission"
+    | "processBudget.error.other";
+  /** Optional actionable hint key. */
+  hintKey:
+    | "processBudget.error.hostOnlyHint"
+    | "processBudget.error.unavailableHint"
+    | "processBudget.error.timeoutHint"
+    | "processBudget.error.permissionHint"
+    | "processBudget.error.otherHint"
+    | null;
+  /** Trimmed host detail (may be empty; never secrets). */
+  detail: string;
+};
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as {
+      code?: unknown;
+      message?: unknown;
+      reason?: unknown;
+      error?: unknown;
+    };
+    const parts = [o.code, o.message, o.reason, o.error]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+function errCode(err: unknown): string {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const c = (err as { code?: unknown }).code;
+    if (typeof c === "string") return c.trim().toLowerCase();
+    if (typeof c === "number" && Number.isFinite(c)) return String(c);
+  }
+  return "";
+}
+
+/**
+ * Classify a thrown value / host error from process budget snapshot load.
+ * Prefer explicit `code` and known host phrases over free-form text.
+ */
+export function classifyProcessBudgetError(err: unknown): ProcessBudgetErrorKind {
+  if (err == null || err === "") return "other";
+
+  const code = errCode(err);
+  if (
+    code === "host_only" ||
+    code === "host-only" ||
+    code === "need_tauri" ||
+    code === "need-tauri" ||
+    code === "not_tauri"
+  ) {
+    return "host_only";
+  }
+  if (
+    code === "unavailable" ||
+    code === "not_ready" ||
+    code === "not-ready" ||
+    code === "manager_unavailable" ||
+    code === "no_manager" ||
+    code === "process_budget_unavailable"
+  ) {
+    return "unavailable";
+  }
+  if (
+    code === "timeout" ||
+    code === "timed_out" ||
+    code === "timed-out" ||
+    code === "deadline_exceeded"
+  ) {
+    return "timeout";
+  }
+  if (
+    code === "permission" ||
+    code === "permission_denied" ||
+    code === "forbidden" ||
+    code === "eacces"
+  ) {
+    return "permission";
+  }
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  if (
+    s.includes("need tauri") ||
+    s.includes("host only") ||
+    s.includes("host-only") ||
+    s.includes("not available in browser") ||
+    s.includes("requires tauri")
+  ) {
+    return "host_only";
+  }
+  if (
+    s.includes("timeout") ||
+    s.includes("timed out") ||
+    s.includes("deadline exceeded")
+  ) {
+    return "timeout";
+  }
+  if (
+    s.includes("permission denied") ||
+    s.includes("eacces") ||
+    s.includes("not allowed") ||
+    s.includes("forbidden")
+  ) {
+    return "permission";
+  }
+  if (
+    s.includes("unavailable") ||
+    s.includes("not ready") ||
+    s.includes("no manager") ||
+    s.includes("manager not") ||
+    s.includes("process budget") ||
+    s.includes("process_budget")
+  ) {
+    return "unavailable";
+  }
+
+  return "other";
+}
+
+/** Map a classified kind to title/hint keys + soft-fail flag. */
+export function processBudgetErrorView(
+  err: unknown,
+): ProcessBudgetErrorView {
+  const kind = classifyProcessBudgetError(err);
+  const detail = errText(err).trim().slice(0, 240);
+  switch (kind) {
+    case "host_only":
+      return {
+        kind,
+        softFail: true,
+        titleKey: "processBudget.error.hostOnly",
+        hintKey: "processBudget.error.hostOnlyHint",
+        detail,
+      };
+    case "unavailable":
+      return {
+        kind,
+        softFail: true,
+        titleKey: "processBudget.error.unavailable",
+        hintKey: "processBudget.error.unavailableHint",
+        detail,
+      };
+    case "timeout":
+      return {
+        kind,
+        softFail: true,
+        titleKey: "processBudget.error.timeout",
+        hintKey: "processBudget.error.timeoutHint",
+        detail,
+      };
+    case "permission":
+      return {
+        kind,
+        softFail: false,
+        titleKey: "processBudget.error.permission",
+        hintKey: "processBudget.error.permissionHint",
+        detail,
+      };
+    case "other":
+    default:
+      return {
+        kind: "other",
+        softFail: true,
+        titleKey: "processBudget.error.other",
+        hintKey: "processBudget.error.otherHint",
+        detail,
+      };
+  }
+}
+
+// ── Empty honesty ────────────────────────────────────────────────────────────
+
+/**
+ * Contextual empty / soft-fail surfaces for the process budget panel body.
+ *
+ * - `loading` — first load; do not claim the pool is empty.
+ * - `unavailable` — host soft-fail (`available: false`); occupancy unknown.
+ * - `error` — load threw; classified error copy.
+ * - `empty_pool` — available snapshot with zero warm agents (honest empty).
+ *
+ * Returns `null` when the meter + bucket counts should render (real occupancy).
+ */
+export type ProcessBudgetEmptyKind =
+  | "loading"
+  | "unavailable"
+  | "error"
+  | "empty_pool";
+
+export type ProcessBudgetEmptyState = {
+  kind: ProcessBudgetEmptyKind;
+  /** Primary title / plan i18n key. */
+  titleKey: string;
+  /** Optional secondary body / hint key. */
+  bodyKey: string | null;
+  /** Soft-fail: capability gap — warn, do not escalate. */
+  softFail: boolean;
+  /** Offer Refresh CTA. */
+  showRetry: boolean;
+  /** Meter / chrome tone. */
+  tone: "muted" | "ok" | "warn" | "danger";
+  /** Classified error (only when kind === "error"). */
+  errorKind: ProcessBudgetErrorKind | null;
+};
+
+export type ProcessBudgetEmptyInput = {
+  loading: boolean;
+  snapshot: ProcessBudgetSnapshot | null | undefined;
+  error?: unknown;
+};
+
+/**
+ * Resolve which empty / honesty surface to show.
+ *
+ * Priority:
+ * 1. loading + no available snapshot → loading
+ * 2. error present + no available snapshot → error
+ * 3. snapshot unavailable → unavailable
+ * 4. available + totalWarm === 0 → empty_pool
+ * 5. available + occupancy → null (render meter)
+ */
+export function resolveProcessBudgetEmptyState(
+  input: ProcessBudgetEmptyInput,
+): ProcessBudgetEmptyState | null {
+  const loading = Boolean(input.loading);
+  const snap = input.snapshot ?? null;
+  const available = Boolean(snap?.available);
+  const hasError =
+    input.error != null &&
+    input.error !== "" &&
+    !(typeof input.error === "string" && !input.error.trim());
+
+  if (loading && !available) {
+    return {
+      kind: "loading",
+      titleKey: "processBudget.loading",
+      bodyKey: "processBudget.loadingHint",
+      softFail: true,
+      showRetry: false,
+      tone: "muted",
+      errorKind: null,
+    };
+  }
+
+  if (hasError && !available && !loading) {
+    const view = processBudgetErrorView(input.error);
+    return {
+      kind: "error",
+      titleKey: view.titleKey,
+      bodyKey: view.hintKey,
+      softFail: view.softFail,
+      showRetry: true,
+      tone: view.softFail ? "warn" : "danger",
+      errorKind: view.kind,
+    };
+  }
+
+  if (!available) {
+    return {
+      kind: "unavailable",
+      titleKey: "processBudget.plan.unavailable",
+      bodyKey: "processBudget.unavailableHint",
+      softFail: true,
+      showRetry: true,
+      tone: "muted",
+      errorKind: null,
+    };
+  }
+
+  // Available snapshot.
+  const totalWarm = Math.max(0, Number(snap!.totalWarm) || 0);
+  if (totalWarm <= 0) {
+    return {
+      kind: "empty_pool",
+      titleKey: "processBudget.plan.empty",
+      bodyKey: "processBudget.emptyPoolHint",
+      softFail: false,
+      showRetry: false,
+      tone: "muted",
+      errorKind: null,
+    };
+  }
+
+  return null;
+}
+
+// ── Occupancy summary ────────────────────────────────────────────────────────
+
+/**
+ * Structured occupancy summary for counts line / aria / plan vars.
+ * Never invents non-zero busy counts when `available` is false.
+ */
+export type ProcessBudgetOccupancySummary = {
+  available: boolean;
+  live: number;
+  background: number;
+  parked: number;
+  free: number;
+  total: number;
+  max: number;
+  busy: number;
+  percent: number;
+  idleMinutes: number;
+  plan: ProcessBudgetReclaimPlan;
+  /**
+   * Compact machine-readable ratio (`"4/8"`) when available;
+   * empty string when occupancy is unknown.
+   */
+  ratio: string;
+  /**
+   * Short English-neutral token bag for diagnostics / tests
+   * (`live=1 bg=0 parked=2 free=5`). Empty when unavailable.
+   */
+  tokenLine: string;
+};
+
+/**
+ * Format occupancy into structured summary vars.
+ * Soft-fails to zeros + plan `unavailable` when snapshot is missing / unavailable.
+ */
+export function formatOccupancySummary(
+  snapshot: ProcessBudgetSnapshot | null | undefined,
+): ProcessBudgetOccupancySummary {
+  if (!snapshot || !snapshot.available) {
+    const max = snapshot?.maxConcurrent ?? DEFAULT_MAX_CONCURRENT_AGENTS;
+    const idleMinutes = snapshot?.idleMinutes ?? 30;
+    return {
+      available: false,
+      live: 0,
+      background: 0,
+      parked: 0,
+      free: 0,
+      total: 0,
+      max,
+      busy: 0,
+      percent: 0,
+      idleMinutes,
+      plan: "unavailable",
+      ratio: "",
+      tokenLine: "",
+    };
+  }
+
+  const vars = processBudgetCountVars(snapshot);
+  const plan = reclaimPlan(snapshot);
+  const free = slotsFree(snapshot.totalWarm, snapshot.maxConcurrent);
+  const percent = occupancyPercent(snapshot.totalWarm, snapshot.maxConcurrent);
+  return {
+    available: true,
+    live: vars.live,
+    background: vars.background,
+    parked: vars.parked,
+    free,
+    total: vars.total,
+    max: vars.max,
+    busy: vars.busy,
+    percent,
+    idleMinutes: vars.idleMinutes,
+    plan,
+    ratio: `${vars.total}/${vars.max}`,
+    tokenLine: `live=${vars.live} bg=${vars.background} parked=${vars.parked} free=${free}`,
+  };
+}
+
+// ── Process limit callout ────────────────────────────────────────────────────
+
+/** Default max age for showing the last process_limit callout (24h). */
+export const PROCESS_LIMIT_CALLOUT_MAX_AGE_MINUTES = 24 * 60;
+
+/**
+ * Whether to show the last PROCESS_LIMIT honesty callout.
+ * Hides null/missing events and events older than `maxAgeMinutes` (default 24h).
+ */
+export function shouldShowProcessLimitCallout(opts: {
+  event: ProcessLimitEvent | null | undefined;
+  now?: number;
+  /** Max age in minutes; default {@link PROCESS_LIMIT_CALLOUT_MAX_AGE_MINUTES}. */
+  maxAgeMinutes?: number;
+}): boolean {
+  const event = opts.event;
+  if (!event || !Number.isFinite(event.at)) return false;
+  const now = Number.isFinite(opts.now) ? (opts.now as number) : Date.now();
+  const maxAge =
+    opts.maxAgeMinutes == null || !Number.isFinite(opts.maxAgeMinutes)
+      ? PROCESS_LIMIT_CALLOUT_MAX_AGE_MINUTES
+      : Math.max(0, Math.floor(opts.maxAgeMinutes));
+  const age = processLimitAgeMinutes(event, now);
+  if (age == null) return false;
+  return age < maxAge;
+}
+
+/**
+ * Limit-event empty / callout presentation for the panel footer.
+ * - `none` — no recent PROCESS_LIMIT (honest empty).
+ * - `active` — show explain callout.
+ */
+export type ProcessLimitCalloutKind = "none" | "active";
+
+export type ProcessLimitCalloutState = {
+  kind: ProcessLimitCalloutKind;
+  /** Title i18n key. */
+  titleKey: "processBudget.limit.title" | "processBudget.limit.noneTitle";
+  /** Body i18n key. */
+  bodyKey: "processBudget.limit.explain" | "processBudget.limit.noneBody";
+  /** Show warn-styled callout chrome. */
+  emphasized: boolean;
+  /** Age in minutes when active; null when none. */
+  ageMinutes: number | null;
+  /** maxConcurrentAgents from the event, or null. */
+  maxConcurrentAgents: number | null;
+};
+
+/**
+ * Resolve limit-event callout vs honest empty (no recent PROCESS_LIMIT).
+ */
+export function resolveProcessLimitCalloutState(opts: {
+  event: ProcessLimitEvent | null | undefined;
+  now?: number;
+  maxAgeMinutes?: number;
+}): ProcessLimitCalloutState {
+  const show = shouldShowProcessLimitCallout(opts);
+  if (!show || !opts.event) {
+    return {
+      kind: "none",
+      titleKey: "processBudget.limit.noneTitle",
+      bodyKey: "processBudget.limit.noneBody",
+      emphasized: false,
+      ageMinutes: null,
+      maxConcurrentAgents: null,
+    };
+  }
+  const now = Number.isFinite(opts.now) ? (opts.now as number) : Date.now();
+  return {
+    kind: "active",
+    titleKey: "processBudget.limit.title",
+    bodyKey: "processBudget.limit.explain",
+    emphasized: true,
+    ageMinutes: processLimitAgeMinutes(opts.event, now),
+    maxConcurrentAgents: opts.event.maxConcurrentAgents,
+  };
+}
+
+/** Safe defaults when UI needs a placeholder snapshot. */
+export function processBudgetProEmptySnapshot(
+  overrides?: Partial<
+    Pick<ProcessBudgetSnapshot, "maxConcurrent" | "idleMinutes">
+  >,
+): ProcessBudgetSnapshot {
+  return emptyProcessBudgetSnapshot(overrides);
+}

--- a/src/lib/settingsCatalog.ts
+++ b/src/lib/settingsCatalog.ts
@@ -2806,6 +2806,8 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "processBudget.lead",
       "processBudget.plan.headroom",
       "processBudget.plan.atCapBusy",
+      "processBudget.plan.empty",
+      "processBudget.limit.noneBody",
     ],
     keywords: [
       "process budget",
@@ -2817,6 +2819,8 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "PROCESS_LIMIT",
       "reclaim",
       "slot",
+      "empty pool",
+      "empty honesty",
       "并发",
       "並發",
       "进程池",
@@ -2826,6 +2830,7 @@ export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
       "回收",
       "闲置",
       "閒置",
+      "空池",
     ],
   },
   {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12975,6 +12975,18 @@ html[data-composer-min-rows="8"] .composer__input {
   line-height: 1.4;
 }
 
+.process-budget-panel__plan--soft {
+  color: var(--text-secondary);
+}
+
+.process-budget-panel__empty-hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  opacity: 0.92;
+}
+
 .process-budget-panel__policy {
   margin: 0;
   font-size: 11px;
@@ -12987,8 +12999,18 @@ html[data-composer-min-rows="8"] .composer__input {
   margin-top: 4px;
   padding: 8px 10px;
   border-radius: 8px;
-  border: 1px solid color-mix(in srgb, var(--warn, #d4a017) 45%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border, #444) 55%, transparent);
+  background: color-mix(in srgb, var(--surface-1, rgba(0, 0, 0, 0.08)) 70%, transparent);
+}
+
+.process-budget-panel__limit--active {
+  border-color: color-mix(in srgb, var(--warn, #d4a017) 45%, transparent);
   background: color-mix(in srgb, var(--warn, #d4a017) 12%, transparent);
+}
+
+.process-budget-panel__limit--none {
+  border-style: dashed;
+  opacity: 0.92;
 }
 
 .process-budget-panel__limit-title {
@@ -13005,6 +13027,11 @@ html[data-composer-min-rows="8"] .composer__input {
   font-size: 12px;
   color: var(--text-primary);
   line-height: 1.4;
+}
+
+.process-budget-panel__limit--none .process-budget-panel__limit-body {
+  color: var(--text-secondary);
+  font-size: 11px;
 }
 
 .reliab-card {


### PR DESCRIPTION
## Summary
- Pure `processBudgetPro` helpers: `resolveProcessBudgetEmptyState` (loading · unavailable · error · empty pool), `classifyProcessBudgetError`, `formatOccupancySummary`, `shouldShowProcessLimitCallout` / limit empty vs active callout (24h).
- ProcessBudgetPanel (Settings pool + Reliability): never invents busy occupancy; honest empty-pool vs host soft-fail; always shows limit empty or active copy.
- i18n en/zh/zh-TW + CHANGELOG; `settingsCatalog` keywords. No `window.confirm`. Spawn policy unchanged.

## Test plan
- [x] `pnpm test -- src/lib/processBudget.test.ts src/lib/processBudgetPro.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm install --frozen-lockfile`
- [ ] Manual: Settings → Runtime → Process pool shows loading then occupancy or honest empty/unavailable
- [ ] Manual: Reliability center process budget card; limit callout empty when no recent PROCESS_LIMIT