### PR TITLE
feat(account): quota unknown and soft-fail honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Account SuperGrok quota honesty**: never invent remaining % when Host is silent — pure `accountQuotaHonesty` helpers (`resolveQuotaEmptyState` · `classifyQuotaError` network|auth|host_only|other · `formatQuotaUnknown` chips); Account panel unknown/empty chips + soft-fail when billing probe fails; en/zh/zh-TW + tests.
+
 ## [0.2.3] - 2026-07-31
 
 > **Highlight:** Composer model picker with custom multi-model providers (DeepSeek / Amux / Yun presets); large pro-honesty batch across settings, Remote IM, MCP, and sessions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitejs/plugin-react-swc':
+        specifier: ^3.11.0
+        version: 3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
       canvas:
         specifier: ^3.2.3
         version: 3.2.3
@@ -455,35 +458,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -643,79 +641,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -746,6 +731,93 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@swc/core-darwin-arm64@1.15.47':
+    resolution: {integrity: sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.47':
+    resolution: {integrity: sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    resolution: {integrity: sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    resolution: {integrity: sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    resolution: {integrity: sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    resolution: {integrity: sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    resolution: {integrity: sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    resolution: {integrity: sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    resolution: {integrity: sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    resolution: {integrity: sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    resolution: {integrity: sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    resolution: {integrity: sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.47':
+    resolution: {integrity: sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tabler/icons-react@3.45.0':
     resolution: {integrity: sha512-t/AuKs7ALMDDTY+B9IvfZnlO0mbLlP/lJxP/HnGC49QkM8mCsTN38kYyxjXxgrb1+TeK53ioVBJqIV7n/eysXQ==}
@@ -793,28 +865,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -875,35 +943,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.4':
     resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -1277,6 +1340,11 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitejs/plugin-react-swc@3.11.0':
+    resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
+    peerDependencies:
+      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1933,28 +2001,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3244,6 +3308,66 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@swc/core-darwin-arm64@1.15.47':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.47':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core@1.15.47':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.47
+      '@swc/core-darwin-x64': 1.15.47
+      '@swc/core-linux-arm-gnueabihf': 1.15.47
+      '@swc/core-linux-arm64-gnu': 1.15.47
+      '@swc/core-linux-arm64-musl': 1.15.47
+      '@swc/core-linux-ppc64-gnu': 1.15.47
+      '@swc/core-linux-s390x-gnu': 1.15.47
+      '@swc/core-linux-x64-gnu': 1.15.47
+      '@swc/core-linux-x64-musl': 1.15.47
+      '@swc/core-win32-arm64-msvc': 1.15.47
+      '@swc/core-win32-ia32-msvc': 1.15.47
+      '@swc/core-win32-x64-msvc': 1.15.47
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.28':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@tabler/icons-react@3.45.0(react@19.2.7)':
     dependencies:
       '@tabler/icons': 3.45.0
@@ -3777,6 +3901,14 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitejs/plugin-react-swc@3.11.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@swc/core': 1.15.47
+      vite: 6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2660,6 +2660,8 @@ export default function App() {
   const [account, setAccount] = useState<api.AccountStatus | null>(null);
   const [accountLoading, setAccountLoading] = useState(false);
   const [accountBusy, setAccountBusy] = useState(false);
+  /** Soft-fail last account_status / billing probe error (never invents quota %). */
+  const [accountProbeError, setAccountProbeError] = useState<unknown>(null);
   const [loginHint, setLoginHint] = useState<string | null>(null);
   const platform = useMemo(() => detectAppPlatform(), []);
   /** Self-drawn chrome when OS title bar is disabled (Windows release config). */
@@ -14397,7 +14399,14 @@ export default function App() {
 
   const refreshAccount = useCallback(
     async (opts?: { refreshBilling?: boolean }) => {
-      if (!api.isTauri()) return;
+      if (!api.isTauri()) {
+        // Browser / non-host: soft-fail host_only so Account never invents %.
+        setAccountProbeError({
+          code: "host_only",
+          message: "Account requires Tauri desktop runtime",
+        });
+        return;
+      }
       setAccountLoading(true);
       try {
         const st = await api.accountStatus({
@@ -14405,6 +14414,7 @@ export default function App() {
           manualCliPath: manualCliPath || null,
         });
         setAccount(st);
+        setAccountProbeError(null);
         setSetup((s) => ({
           ...s,
           auth: isAccountConnected(st),
@@ -14421,6 +14431,7 @@ export default function App() {
         void api.trayRefresh();
       } catch (e) {
         console.warn("account status failed", e);
+        setAccountProbeError(e);
       } finally {
         setAccountLoading(false);
       }
@@ -16388,6 +16399,25 @@ export default function App() {
       "account.quotaRemaining",
       "account.quotaUsed",
       "account.quotaUnknown",
+      "account.quota.loading",
+      "account.quota.loadingHint",
+      "account.quota.signedOut",
+      "account.quota.signedOutHint",
+      "account.quota.chip.loading",
+      "account.quota.chip.unknown",
+      "account.quota.chip.signedOut",
+      "account.quota.chip.err.network",
+      "account.quota.chip.err.auth",
+      "account.quota.chip.err.host_only",
+      "account.quota.chip.err.other",
+      "account.quota.err.network",
+      "account.quota.err.networkHint",
+      "account.quota.err.auth",
+      "account.quota.err.authHint",
+      "account.quota.err.host_only",
+      "account.quota.err.host_onlyHint",
+      "account.quota.err.other",
+      "account.quota.err.otherHint",
       "account.period",
       "account.prepaid",
       "account.onDemand",
@@ -17102,6 +17132,7 @@ export default function App() {
           account={account}
           accountLoading={accountLoading}
           accountBusy={accountBusy}
+          accountProbeError={accountProbeError}
           loginHint={loginHint}
           savedAccounts={savedAccounts}
           activeAccountId={activeAccountId}

--- a/src/components/AccountPanel.tsx
+++ b/src/components/AccountPanel.tsx
@@ -17,8 +17,14 @@ import {
   formatRelativeTime,
   localDateKeyFromIso,
   tierLabel,
-  usagePercent,
 } from "@/lib/accountUi";
+import {
+  formatQuotaRemainLabel,
+  isQuotaUsageKnown,
+  resolveQuotaEmptyState,
+  resolveQuotaErrorChip,
+  resolveQuotaPercents,
+} from "@/lib/accountQuotaHonesty";
 import {
   Heatmap,
   dateInHeatRange,
@@ -102,6 +108,23 @@ export interface AccountPanelLabels {
   importChatHint: string;
   importChatBtn: string;
   close: string;
+  /** SuperGrok quota honesty — loading / unknown / error chips */
+  quotaLoading: string;
+  quotaLoadingHint: string;
+  quotaChipLoading: string;
+  quotaChipUnknown: string;
+  quotaChipErrNetwork: string;
+  quotaChipErrAuth: string;
+  quotaChipErrHostOnly: string;
+  quotaChipErrOther: string;
+  quotaErrNetwork: string;
+  quotaErrNetworkHint: string;
+  quotaErrAuth: string;
+  quotaErrAuthHint: string;
+  quotaErrHostOnly: string;
+  quotaErrHostOnlyHint: string;
+  quotaErrOther: string;
+  quotaErrOtherHint: string;
 }
 
 export interface AccountPanelProps {
@@ -113,6 +136,11 @@ export interface AccountPanelProps {
   labels: AccountPanelLabels;
   compact?: boolean;
   loginHint?: string | null;
+  /**
+   * Soft-fail error from account_status / billing probe.
+   * Never invents remaining % — surfaces unknown/error chips instead.
+   */
+  probeError?: unknown;
   savedAccounts?: SavedAccount[];
   activeAccountId?: string | null;
   onLoginOauth: () => void;
@@ -149,6 +177,7 @@ export function AccountPanel({
   labels,
   compact = false,
   loginHint = null,
+  probeError = null,
   savedAccounts = [],
   activeAccountId = null,
   onLoginOauth,
@@ -182,9 +211,27 @@ export function AccountPanel({
   const initials = profile ? accountInitials(profile) : "G";
   const channel = status?.channel ?? "none";
   const billing = status?.billing;
-  const usedPct = billing ? usagePercent(billing) : null;
+  const usageKnown = isQuotaUsageKnown(billing);
+  const { usedPercent: usedPct, remainingPercent: remaining } =
+    resolveQuotaPercents(billing);
   /** Same absolute clock as sidebar UserMenu (`MM-DD HH:mm`). */
   const resetTime = formatQuotaResetTime(billing?.resetsAt);
+
+  /**
+   * SuperGrok quota empty / soft-fail surface.
+   * Never invent remaining % when Host is silent or probe fails.
+   */
+  const quotaEmpty = resolveQuotaEmptyState({
+    loading,
+    membership: signedIn,
+    usageKnown,
+    error: probeError,
+  });
+  const quotaErrChip =
+    usageKnown && probeError != null
+      ? resolveQuotaErrorChip(probeError)
+      : null;
+  const remainLabel = formatQuotaRemainLabel(remaining);
 
   const rangeSessionCount = selectedHeatRange
     ? sumHeatInRange(status?.heatmap ?? [], selectedHeatRange).requests
@@ -246,17 +293,72 @@ export function AccountPanel({
     setSelectedHeatRange(null);
   };
 
-  const remaining =
-    billing?.remainingPercent != null
-      ? billing.remainingPercent
-      : usedPct != null
-        ? Math.max(0, 100 - usedPct)
-        : null;
   const products = (billing?.products ?? []).filter(
     (p) => p.usedPercent > 0 || p.productId === 1 || p.productId === 2,
   );
   const plan = billing ? tierLabel(billing, channel) : "—";
-  const hasQuota = signedIn && !!billing?.available && remaining != null;
+  /** Known remaining only — never invent when Host silent. */
+  const hasQuota = signedIn && usageKnown && remainLabel != null;
+
+  const quotaChipText = (() => {
+    if (!quotaEmpty) return null;
+    switch (quotaEmpty.chipKey) {
+      case "account.quota.chip.loading":
+        return labels.quotaChipLoading;
+      case "account.quota.chip.err.network":
+        return labels.quotaChipErrNetwork;
+      case "account.quota.chip.err.auth":
+        return labels.quotaChipErrAuth;
+      case "account.quota.chip.err.host_only":
+        return labels.quotaChipErrHostOnly;
+      case "account.quota.chip.err.other":
+        return labels.quotaChipErrOther;
+      case "account.quota.chip.unknown":
+      default:
+        return labels.quotaChipUnknown;
+    }
+  })();
+
+  const quotaEmptyTitle = (() => {
+    if (!quotaEmpty) return null;
+    if (quotaEmpty.kind === "loading") return labels.quotaLoading;
+    if (quotaEmpty.kind === "error" && quotaEmpty.error) {
+      switch (quotaEmpty.error.kind) {
+        case "network":
+          return labels.quotaErrNetwork;
+        case "auth":
+          return labels.quotaErrAuth;
+        case "host_only":
+          return labels.quotaErrHostOnly;
+        default:
+          return labels.quotaErrOther;
+      }
+    }
+    if (quotaEmpty.kind === "unknown") return labels.quotaUnknown;
+    return labels.quotaUnknown;
+  })();
+
+  const quotaEmptyBody = (() => {
+    if (!quotaEmpty) return null;
+    if (quotaEmpty.kind === "loading") return labels.quotaLoadingHint;
+    if (quotaEmpty.kind === "error" && quotaEmpty.error) {
+      switch (quotaEmpty.error.kind) {
+        case "network":
+          return labels.quotaErrNetworkHint;
+        case "auth":
+          return labels.quotaErrAuthHint;
+        case "host_only":
+          return labels.quotaErrHostOnlyHint;
+        default:
+          return labels.quotaErrOtherHint;
+      }
+    }
+    if (quotaEmpty.kind === "unknown") {
+      // Prefer host message when present; else honest billing-unavailable copy.
+      return billing?.message?.trim() || labels.billingUnavailable;
+    }
+    return null;
+  })();
 
   const canManageAccounts =
     !!onSwitchAccount ||
@@ -512,25 +614,56 @@ export function AccountPanel({
                 <div className="account-hero__plan-head">
                   <span className="account-hero__plan-name">{plan}</span>
                   <span className="account-hero__plan-remain">
-                    {remaining!.toFixed(0)}% {labels.quotaRemaining}
+                    {remainLabel} {labels.quotaRemaining}
                   </span>
                 </div>
+                {quotaErrChip ? (
+                  <span
+                    className="account-quota-err-chip"
+                    title={
+                      quotaErrChip.kind === "network"
+                        ? labels.quotaErrNetworkHint
+                        : quotaErrChip.kind === "auth"
+                          ? labels.quotaErrAuthHint
+                          : quotaErrChip.kind === "host_only"
+                            ? labels.quotaErrHostOnlyHint
+                            : labels.quotaErrOtherHint
+                    }
+                  >
+                    {quotaErrChip.kind === "network"
+                      ? labels.quotaErrNetwork
+                      : quotaErrChip.kind === "auth"
+                        ? labels.quotaErrAuth
+                        : quotaErrChip.kind === "host_only"
+                          ? labels.quotaErrHostOnly
+                          : labels.quotaErrOther}
+                  </span>
+                ) : null}
                 <div className="account-quota-bar" aria-hidden>
                   <div
                     className={
                       "account-quota-bar__fill" +
-                      ((usedPct ?? 0) >= 90
+                      (usedPct != null && usedPct >= 90
                         ? " is-danger"
-                        : (usedPct ?? 0) >= 70
+                        : usedPct != null && usedPct >= 70
                           ? " is-warn"
                           : "")
                     }
-                    style={{ width: `${Math.min(100, usedPct ?? 0)}%` }}
+                    style={{
+                      // Only paint fill when used is known — never invent 0%.
+                      width:
+                        usedPct != null
+                          ? `${Math.min(100, usedPct)}%`
+                          : "0%",
+                      opacity: usedPct != null ? 1 : 0.35,
+                    }}
                   />
                 </div>
                 <div className="account-hero__plan-meta">
                   <span>
-                    {labels.quotaUsed} {(usedPct ?? 0).toFixed(0)}%
+                    {usedPct != null
+                      ? `${labels.quotaUsed} ${usedPct.toFixed(0)}%`
+                      : labels.quotaChipUnknown}
                     {resetTime
                       ? ` · ${labels.resetsAt} ${resetTime}`
                       : ""}
@@ -550,11 +683,39 @@ export function AccountPanel({
                 </div>
               </>
             ) : (
-              <div className="account-hero__plan-empty">
+              <div
+                className={
+                  "account-hero__plan-empty" +
+                  (quotaEmpty?.softFail ? " is-soft-fail" : "")
+                }
+                data-testid="account-quota-empty"
+                data-quota-kind={quotaEmpty?.kind ?? "unknown"}
+              >
                 <span className="account-hero__plan-name">{plan}</span>
-                <span className="account-hero__plan-meta-text">
-                  {billing?.message || labels.quotaUnknown}
-                </span>
+                {quotaChipText ? (
+                  <span
+                    className={
+                      "account-quota-chip" +
+                      (quotaEmpty?.softFail
+                        ? " account-quota-chip--warn"
+                        : " account-quota-chip--muted")
+                    }
+                  >
+                    {quotaChipText}
+                  </span>
+                ) : null}
+                <div className="account-hero__plan-empty-copy">
+                  {quotaEmptyTitle ? (
+                    <span className="account-hero__plan-empty-title">
+                      {quotaEmptyTitle}
+                    </span>
+                  ) : null}
+                  {quotaEmptyBody ? (
+                    <span className="account-hero__plan-meta-text">
+                      {quotaEmptyBody}
+                    </span>
+                  ) : null}
+                </div>
               </div>
             )}
           </div>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -713,6 +713,11 @@ export interface SettingsPageProps {
   account: AccountStatus | null;
   accountLoading: boolean;
   accountBusy: boolean;
+  /**
+   * Soft-fail error from last account_status / billing probe.
+   * Account panel never invents remaining % when this is set without usage.
+   */
+  accountProbeError?: unknown;
   loginHint?: string | null;
   savedAccounts?: import("@/lib/api").SavedAccount[];
   activeAccountId?: string | null;
@@ -1417,6 +1422,7 @@ export function SettingsPage({
   account,
   accountLoading,
   accountBusy,
+  accountProbeError = null,
   loginHint = null,
   savedAccounts = [],
   activeAccountId = null,
@@ -6062,6 +6068,7 @@ export function SettingsPage({
             status={account}
             loading={accountLoading}
             busy={accountBusy}
+            probeError={accountProbeError}
             locale={locale}
             t={t}
             labels={{
@@ -6131,6 +6138,22 @@ export function SettingsPage({
               importChatHint: t("account.importChatHint"),
               importChatBtn: t("account.importChatBtn"),
               close: t("common.close"),
+              quotaLoading: t("account.quota.loading"),
+              quotaLoadingHint: t("account.quota.loadingHint"),
+              quotaChipLoading: t("account.quota.chip.loading"),
+              quotaChipUnknown: t("account.quota.chip.unknown"),
+              quotaChipErrNetwork: t("account.quota.chip.err.network"),
+              quotaChipErrAuth: t("account.quota.chip.err.auth"),
+              quotaChipErrHostOnly: t("account.quota.chip.err.host_only"),
+              quotaChipErrOther: t("account.quota.chip.err.other"),
+              quotaErrNetwork: t("account.quota.err.network"),
+              quotaErrNetworkHint: t("account.quota.err.networkHint"),
+              quotaErrAuth: t("account.quota.err.auth"),
+              quotaErrAuthHint: t("account.quota.err.authHint"),
+              quotaErrHostOnly: t("account.quota.err.host_only"),
+              quotaErrHostOnlyHint: t("account.quota.err.host_onlyHint"),
+              quotaErrOther: t("account.quota.err.other"),
+              quotaErrOtherHint: t("account.quota.err.otherHint"),
             }}
             loginHint={loginHint}
             savedAccounts={savedAccounts}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -3257,6 +3257,30 @@ const en = {
   "account.quotaRemaining": "remaining",
   "account.quotaUsed": "used",
   "account.quotaUnknown": "Quota not loaded yet",
+  "account.quota.loading": "Loading SuperGrok quota…",
+  "account.quota.loadingHint": "Fetching membership usage from the host.",
+  "account.quota.signedOut": "Sign in to see SuperGrok quota",
+  "account.quota.signedOutHint":
+    "Remaining percentage comes from official Grok Build billing — never invented offline.",
+  "account.quota.chip.loading": "Loading…",
+  "account.quota.chip.unknown": "Unknown",
+  "account.quota.chip.signedOut": "—",
+  "account.quota.chip.err.network": "Network",
+  "account.quota.chip.err.auth": "Sign-in",
+  "account.quota.chip.err.host_only": "Desktop",
+  "account.quota.chip.err.other": "Soft-fail",
+  "account.quota.err.network": "Could not load quota",
+  "account.quota.err.networkHint":
+    "Network soft-fail — chat still works. Check connection or proxy (Settings → Network), then refresh. Remaining % is not invented while offline.",
+  "account.quota.err.auth": "Sign-in required for quota",
+  "account.quota.err.authHint":
+    "Auth soft-fail — token may be expired. Sign in again to refresh SuperGrok remaining. No percentage is shown until the host responds.",
+  "account.quota.err.host_only": "Desktop only",
+  "account.quota.err.host_onlyHint":
+    "SuperGrok quota needs the desktop app host. Browser preview never invents remaining %.",
+  "account.quota.err.other": "Quota load soft-fail",
+  "account.quota.err.otherHint":
+    "Could not refresh SuperGrok quota. Chat is unaffected; remaining % stays unknown until a successful probe.",
   "account.period": "Billing period",
   "account.prepaid": "Prepaid",
   "account.onDemand": "On-demand",
@@ -9357,6 +9381,30 @@ const zh: Record<MessageKey, string> = {
   "account.quotaRemaining": "剩余",
   "account.quotaUsed": "已用",
   "account.quotaUnknown": "尚未获取用量",
+  "account.quota.loading": "正在加载 SuperGrok 额度…",
+  "account.quota.loadingHint": "正在从 Host 拉取会员用量。",
+  "account.quota.signedOut": "登录后可查看 SuperGrok 额度",
+  "account.quota.signedOutHint":
+    "剩余百分比来自官方 Grok Build 计费接口——离线时不会编造数字。",
+  "account.quota.chip.loading": "加载中…",
+  "account.quota.chip.unknown": "未知",
+  "account.quota.chip.signedOut": "—",
+  "account.quota.chip.err.network": "网络",
+  "account.quota.chip.err.auth": "登录",
+  "account.quota.chip.err.host_only": "桌面端",
+  "account.quota.chip.err.other": "软失败",
+  "account.quota.err.network": "无法加载额度",
+  "account.quota.err.networkHint":
+    "网络 soft-fail——对话仍可用。请检查网络或代理（设置 → 网络）后刷新。离线时不会编造剩余百分比。",
+  "account.quota.err.auth": "需重新登录才能查看额度",
+  "account.quota.err.authHint":
+    "鉴权 soft-fail——凭证可能已过期。请重新登录以刷新 SuperGrok 剩余额度；Host 未响应前不显示百分比。",
+  "account.quota.err.host_only": "仅桌面端可用",
+  "account.quota.err.host_onlyHint":
+    "SuperGrok 额度需桌面 Host。浏览器预览不会编造剩余百分比。",
+  "account.quota.err.other": "额度加载 soft-fail",
+  "account.quota.err.otherHint":
+    "无法刷新 SuperGrok 额度（不影响对话）。成功探测前剩余百分比保持未知。",
   "account.period": "账期",
   "account.prepaid": "预付",
   "account.onDemand": "按需",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -3118,6 +3118,30 @@ export const zhTW: Record<MessageKey, string> = {
   "account.quotaRemaining": "剩餘",
   "account.quotaUsed": "已用",
   "account.quotaUnknown": "尚未取得用量",
+  "account.quota.loading": "正在載入 SuperGrok 額度…",
+  "account.quota.loadingHint": "正在從 Host 拉取會員用量。",
+  "account.quota.signedOut": "登入後可檢視 SuperGrok 額度",
+  "account.quota.signedOutHint":
+    "剩餘百分比來自官方 Grok Build 計費介面——離線時不會編造數字。",
+  "account.quota.chip.loading": "載入中…",
+  "account.quota.chip.unknown": "未知",
+  "account.quota.chip.signedOut": "—",
+  "account.quota.chip.err.network": "網路",
+  "account.quota.chip.err.auth": "登入",
+  "account.quota.chip.err.host_only": "桌面端",
+  "account.quota.chip.err.other": "軟失敗",
+  "account.quota.err.network": "無法載入額度",
+  "account.quota.err.networkHint":
+    "網路 soft-fail——對話仍可用。請檢查網路或代理（設定 → 網路）後重新整理。離線時不會編造剩餘百分比。",
+  "account.quota.err.auth": "需重新登入才能檢視額度",
+  "account.quota.err.authHint":
+    "鑑權 soft-fail——憑證可能已過期。請重新登入以重新整理 SuperGrok 剩餘額度；Host 未回應前不顯示百分比。",
+  "account.quota.err.host_only": "僅桌面端可用",
+  "account.quota.err.host_onlyHint":
+    "SuperGrok 額度需桌面 Host。瀏覽器預覽不會編造剩餘百分比。",
+  "account.quota.err.other": "額度載入 soft-fail",
+  "account.quota.err.otherHint":
+    "無法重新整理 SuperGrok 額度（不影響對話）。成功探測前剩餘百分比保持未知。",
   "account.period": "帳期",
   "account.prepaid": "預付",
   "account.onDemand": "隨需",

--- a/src/lib/accountQuotaHonesty.test.ts
+++ b/src/lib/accountQuotaHonesty.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyQuotaError,
+  formatQuotaRemainLabel,
+  formatQuotaUnknown,
+  isQuotaUsageKnown,
+  quotaErrorView,
+  resolveQuotaEmptyState,
+  resolveQuotaErrorChip,
+  resolveQuotaPercents,
+  type QuotaBillingLike,
+} from "./accountQuotaHonesty";
+
+function billing(partial: Partial<QuotaBillingLike> = {}): QuotaBillingLike {
+  return {
+    available: false,
+    creditUsagePercent: null,
+    remainingPercent: null,
+    monthlyLimit: null,
+    includedUsed: null,
+    message: null,
+    ...partial,
+  };
+}
+
+describe("isQuotaUsageKnown", () => {
+  it("never invents known usage from available flag alone", () => {
+    expect(isQuotaUsageKnown(null)).toBe(false);
+    expect(isQuotaUsageKnown(undefined)).toBe(false);
+    expect(isQuotaUsageKnown(billing({ available: true }))).toBe(false);
+    expect(isQuotaUsageKnown(billing({ available: false }))).toBe(false);
+  });
+
+  it("accepts finite credit / remaining / limit path", () => {
+    expect(
+      isQuotaUsageKnown(billing({ creditUsagePercent: 12.5 })),
+    ).toBe(true);
+    expect(isQuotaUsageKnown(billing({ remainingPercent: 88 }))).toBe(true);
+    expect(
+      isQuotaUsageKnown(
+        billing({ monthlyLimit: 1000, includedUsed: 250 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects non-finite and incomplete limit pairs", () => {
+    expect(isQuotaUsageKnown(billing({ creditUsagePercent: NaN }))).toBe(
+      false,
+    );
+    expect(
+      isQuotaUsageKnown(billing({ monthlyLimit: 0, includedUsed: 10 })),
+    ).toBe(false);
+    expect(
+      isQuotaUsageKnown(billing({ monthlyLimit: 100, includedUsed: null })),
+    ).toBe(false);
+  });
+});
+
+describe("resolveQuotaPercents", () => {
+  it("returns nulls when host silent — never invents 0/100", () => {
+    expect(resolveQuotaPercents(null)).toEqual({
+      usedPercent: null,
+      remainingPercent: null,
+    });
+    expect(resolveQuotaPercents(billing({ available: true }))).toEqual({
+      usedPercent: null,
+      remainingPercent: null,
+    });
+  });
+
+  it("derives remaining from credit usage and vice versa", () => {
+    expect(resolveQuotaPercents(billing({ creditUsagePercent: 30 }))).toEqual({
+      usedPercent: 30,
+      remainingPercent: 70,
+    });
+    expect(resolveQuotaPercents(billing({ remainingPercent: 40 }))).toEqual({
+      usedPercent: 60,
+      remainingPercent: 40,
+    });
+  });
+
+  it("uses monthly limit ratio when only that is present", () => {
+    const p = resolveQuotaPercents(
+      billing({ monthlyLimit: 200, includedUsed: 50 }),
+    );
+    expect(p.usedPercent).toBe(25);
+    expect(p.remainingPercent).toBe(75);
+  });
+
+  it("clamps remaining to 0..100", () => {
+    const p = resolveQuotaPercents(billing({ remainingPercent: 150 }));
+    expect(p.remainingPercent).toBe(100);
+  });
+});
+
+describe("formatQuotaRemainLabel", () => {
+  it("never invents a percent string when unknown", () => {
+    expect(formatQuotaRemainLabel(null)).toBeNull();
+    expect(formatQuotaRemainLabel(undefined)).toBeNull();
+    expect(formatQuotaRemainLabel(NaN)).toBeNull();
+  });
+
+  it("formats known remaining without inventing extra digits", () => {
+    expect(formatQuotaRemainLabel(42.4)).toBe("42%");
+    expect(formatQuotaRemainLabel(0)).toBe("0%");
+    expect(formatQuotaRemainLabel(100)).toBe("100%");
+  });
+});
+
+describe("classifyQuotaError / quotaErrorView", () => {
+  it("classifies host_only | network | auth | other", () => {
+    expect(classifyQuotaError("need tauri")).toBe("host_only");
+    expect(classifyQuotaError({ code: "host_only" })).toBe("host_only");
+    expect(
+      classifyQuotaError("Account requires Tauri desktop runtime"),
+    ).toBe("host_only");
+    expect(classifyQuotaError("network offline")).toBe("network");
+    expect(classifyQuotaError(new Error("Failed to fetch"))).toBe("network");
+    expect(classifyQuotaError({ code: "timeout" })).toBe("network");
+    expect(classifyQuotaError("401 unauthorized")).toBe("auth");
+    expect(classifyQuotaError({ code: "token_expired" })).toBe("auth");
+    expect(classifyQuotaError("sign-in expired")).toBe("auth");
+    expect(classifyQuotaError("something weird")).toBe("other");
+    expect(classifyQuotaError(null)).toBe("other");
+  });
+
+  it("error view is always soft-fail with i18n keys", () => {
+    const v = quotaErrorView("need_tauri");
+    expect(v.softFail).toBe(true);
+    expect(v.kind).toBe("host_only");
+    expect(v.titleKey).toBe("account.quota.err.host_only");
+    expect(v.hintKey).toBe("account.quota.err.host_onlyHint");
+  });
+
+  it("resolveQuotaErrorChip null for empty", () => {
+    expect(resolveQuotaErrorChip(null)).toBeNull();
+    expect(resolveQuotaErrorChip("")).toBeNull();
+    const chip = resolveQuotaErrorChip({ code: "network" });
+    expect(chip?.softFail).toBe(true);
+    expect(chip?.kind).toBe("network");
+  });
+});
+
+describe("resolveQuotaEmptyState", () => {
+  it("loading wins only when usage not yet known", () => {
+    const s = resolveQuotaEmptyState({
+      loading: true,
+      membership: true,
+      usageKnown: false,
+    });
+    expect(s?.kind).toBe("loading");
+    expect(s?.softFail).toBe(false);
+    expect(s?.chipKey).toBe("account.quota.chip.loading");
+
+    // Background refresh: keep known bar.
+    expect(
+      resolveQuotaEmptyState({
+        loading: true,
+        membership: true,
+        usageKnown: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("signed_out when no membership — never invent remaining", () => {
+    const s = resolveQuotaEmptyState({
+      loading: false,
+      membership: false,
+      usageKnown: false,
+    });
+    expect(s?.kind).toBe("signed_out");
+    expect(s?.softFail).toBe(false);
+    expect(formatQuotaRemainLabel(null)).toBeNull();
+  });
+
+  it("error soft-fail when probe fails and usage unknown", () => {
+    const s = resolveQuotaEmptyState({
+      loading: false,
+      membership: true,
+      usageKnown: false,
+      error: { code: "network", message: "offline" },
+    });
+    expect(s?.kind).toBe("error");
+    expect(s?.softFail).toBe(true);
+    expect(s?.error?.kind).toBe("network");
+    expect(s?.showRefresh).toBe(true);
+    expect(s?.chipKey).toBe("account.quota.chip.err.network");
+  });
+
+  it("auth soft-fail when token expired", () => {
+    const s = resolveQuotaEmptyState({
+      loading: false,
+      membership: true,
+      usageKnown: false,
+      error: "token expired — sign in again",
+    });
+    expect(s?.kind).toBe("error");
+    expect(s?.error?.kind).toBe("auth");
+  });
+
+  it("unknown when membership present but host silent", () => {
+    const s = resolveQuotaEmptyState({
+      loading: false,
+      membership: true,
+      usageKnown: false,
+    });
+    expect(s?.kind).toBe("unknown");
+    expect(s?.softFail).toBe(true);
+    expect(s?.titleKey).toBe("account.quotaUnknown");
+    expect(s?.bodyKey).toBe("account.billingUnavailable");
+    expect(s?.chipKey).toBe("account.quota.chip.unknown");
+  });
+
+  it("returns null when usage is known (render bar)", () => {
+    expect(
+      resolveQuotaEmptyState({
+        loading: false,
+        membership: true,
+        usageKnown: true,
+      }),
+    ).toBeNull();
+
+    // Known usage with soft error → still show bar (chip may be separate).
+    expect(
+      resolveQuotaEmptyState({
+        loading: false,
+        membership: true,
+        usageKnown: true,
+        error: "network offline",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("formatQuotaUnknown", () => {
+  it("returns honesty label keys — never a numeric percent", () => {
+    for (const kind of [
+      "loading",
+      "signed_out",
+      "unknown",
+      "error",
+      "network",
+      "auth",
+      "host_only",
+      "other",
+      null,
+      undefined,
+    ] as const) {
+      const labels = formatQuotaUnknown(kind);
+      expect(labels.chipKey.startsWith("account.quota.")).toBe(true);
+      expect(labels.titleKey.startsWith("account.")).toBe(true);
+      expect(labels.chipKey).not.toMatch(/%/);
+      expect(labels.titleKey).not.toMatch(/\d+%/);
+    }
+  });
+
+  it("maps error kinds to account.quota.err.*", () => {
+    expect(formatQuotaUnknown("network").titleKey).toBe(
+      "account.quota.err.network",
+    );
+    expect(formatQuotaUnknown("auth").chipKey).toBe(
+      "account.quota.chip.err.auth",
+    );
+    expect(formatQuotaUnknown("host_only").bodyKey).toBe(
+      "account.quota.err.host_onlyHint",
+    );
+  });
+});

--- a/src/lib/accountQuotaHonesty.ts
+++ b/src/lib/accountQuotaHonesty.ts
@@ -1,0 +1,495 @@
+/**
+ * ACCOUNT-QUOTA-HONESTY — pure helpers for SuperGrok quota surface.
+ *
+ * Rules:
+ * - Never invent remaining % / used % when the Host is silent.
+ * - Soft-fail probe errors (network · auth · host_only · other).
+ * - Unknown / empty chips instead of fake "100%" or "0%".
+ * - No DOM / Tauri side effects.
+ *
+ * See docs/llm-wiki/account.md (billing / quota aligned with grok-go).
+ */
+
+// ── Usage known? ─────────────────────────────────────────────────────────────
+
+/** Minimal billing shape accepted by honesty helpers (matches BillingSnapshot). */
+export type QuotaBillingLike = {
+  available?: boolean | null;
+  creditUsagePercent?: number | null;
+  remainingPercent?: number | null;
+  monthlyLimit?: number | null;
+  includedUsed?: number | null;
+  message?: string | null;
+};
+
+/**
+ * True when Host returned a finite usage figure we can display.
+ * Never treats `available: true` alone as known remaining.
+ */
+export function isQuotaUsageKnown(
+  billing: QuotaBillingLike | null | undefined,
+): boolean {
+  if (!billing) return false;
+  if (
+    billing.creditUsagePercent != null &&
+    Number.isFinite(billing.creditUsagePercent)
+  ) {
+    return true;
+  }
+  if (
+    billing.remainingPercent != null &&
+    Number.isFinite(billing.remainingPercent)
+  ) {
+    return true;
+  }
+  if (
+    billing.monthlyLimit != null &&
+    Number.isFinite(billing.monthlyLimit) &&
+    billing.monthlyLimit > 0 &&
+    billing.includedUsed != null &&
+    Number.isFinite(billing.includedUsed)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Honest used / remaining percents from a billing snapshot.
+ * Returns nulls when Host is silent — never invents 0 or 100.
+ */
+export type QuotaPercents = {
+  usedPercent: number | null;
+  remainingPercent: number | null;
+};
+
+export function resolveQuotaPercents(
+  billing: QuotaBillingLike | null | undefined,
+): QuotaPercents {
+  if (!billing) {
+    return { usedPercent: null, remainingPercent: null };
+  }
+
+  let used: number | null = null;
+  if (
+    billing.creditUsagePercent != null &&
+    Number.isFinite(billing.creditUsagePercent)
+  ) {
+    // Allow slight overflow past 100 like grok-go.
+    used = Math.max(0, Math.min(200, billing.creditUsagePercent));
+  } else if (
+    billing.remainingPercent != null &&
+    Number.isFinite(billing.remainingPercent)
+  ) {
+    used = Math.max(0, 100 - billing.remainingPercent);
+  } else if (
+    billing.monthlyLimit != null &&
+    billing.monthlyLimit > 0 &&
+    billing.includedUsed != null &&
+    Number.isFinite(billing.includedUsed)
+  ) {
+    used = Math.max(
+      0,
+      Math.min(100, (billing.includedUsed / billing.monthlyLimit) * 100),
+    );
+  }
+
+  let remaining: number | null = null;
+  if (
+    billing.remainingPercent != null &&
+    Number.isFinite(billing.remainingPercent)
+  ) {
+    remaining = Math.max(0, Math.min(100, billing.remainingPercent));
+  } else if (used != null) {
+    remaining = Math.max(0, Math.min(100, 100 - used));
+  }
+
+  return { usedPercent: used, remainingPercent: remaining };
+}
+
+/**
+ * Format a known remaining percent for chips ("42%").
+ * Returns `null` when unknown — callers must use {@link formatQuotaUnknown}
+ * instead of inventing "0%" / "100%".
+ */
+export function formatQuotaRemainLabel(
+  remainingPercent: number | null | undefined,
+): string | null {
+  if (remainingPercent == null || !Number.isFinite(remainingPercent)) {
+    return null;
+  }
+  const n = Math.max(0, Math.min(100, remainingPercent));
+  return `${n.toFixed(0)}%`;
+}
+
+// ── Error classification ─────────────────────────────────────────────────────
+
+/**
+ * Stable SuperGrok quota probe failure kinds.
+ * - `network` — transport / offline / timeout while fetching billing
+ * - `auth` — signed-out / expired token / 401-class
+ * - `host_only` — browser / mirror without desktop Host
+ * - `other` — unclassified soft-fail
+ */
+export type QuotaErrorKind = "network" | "auth" | "host_only" | "other";
+
+export type QuotaErrorView = {
+  kind: QuotaErrorKind;
+  /** Soft-fail: never invent remaining; warn chrome only. */
+  softFail: boolean;
+  /** Short detail excerpt (no secrets expected). */
+  detail: string;
+  /** i18n title key under account.quota.err.*. */
+  titleKey: string;
+  /** i18n hint key under account.quota.err.*. */
+  hintKey: string;
+};
+
+function errText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    const code =
+      typeof (err as Error & { code?: unknown }).code === "string"
+        ? String((err as Error & { code?: string }).code)
+        : "";
+    return `${code} ${err.message} ${err.name}`.trim();
+  }
+  if (typeof err === "object") {
+    const o = err as {
+      code?: unknown;
+      message?: unknown;
+      reason?: unknown;
+      error?: unknown;
+      status?: unknown;
+    };
+    const parts = [o.code, o.status, o.message, o.reason, o.error]
+      .filter((x) => x != null && String(x).trim())
+      .map(String);
+    if (parts.length) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+function errCode(err: unknown): string {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const c = (err as { code?: unknown }).code;
+    if (typeof c === "string") return c.trim().toLowerCase();
+    if (typeof c === "number" && Number.isFinite(c)) return String(c);
+  }
+  return "";
+}
+
+/**
+ * Classify SuperGrok quota / account_status failures into a stable kind.
+ * Prefer explicit codes and known host phrases over free-form text.
+ */
+export function classifyQuotaError(err: unknown): QuotaErrorKind {
+  if (err == null || err === "") return "other";
+
+  const code = errCode(err);
+  if (
+    code === "host_only" ||
+    code === "host-only" ||
+    code === "need_tauri" ||
+    code === "need-tauri" ||
+    code === "desktop_only"
+  ) {
+    return "host_only";
+  }
+  if (
+    code === "network" ||
+    code === "offline" ||
+    code === "econnrefused" ||
+    code === "etimedout" ||
+    code === "timeout"
+  ) {
+    return "network";
+  }
+  if (
+    code === "auth" ||
+    code === "unauthorized" ||
+    code === "unauthenticated" ||
+    code === "401" ||
+    code === "403" ||
+    code === "token_expired" ||
+    code === "expired"
+  ) {
+    return "auth";
+  }
+
+  const s = errText(err).toLowerCase();
+  if (!s.trim()) return "other";
+
+  if (
+    /need[_\s-]?tauri|desktop\s+app|host[_\s-]?only|not\s+available\s+in\s+browser|webview\s+only|requires\s+the\s+(tauri|desktop)|account\s+requires\s+tauri/i.test(
+      s,
+    )
+  ) {
+    return "host_only";
+  }
+  if (
+    /network|offline|fetch\s+failed|failed\s+to\s+fetch|econnrefused|enotfound|etimedout|timed?\s*out|dns|connection\s+(reset|refused|error)|socket|proxy/i.test(
+      s,
+    )
+  ) {
+    return "network";
+  }
+  if (
+    /\b401\b|\b403\b|unauthori[sz]ed|unauthenticated|token\s+expir|auth(entication)?\s+(fail|error|expir|required)|sign[-\s]?in\s+(expir|required|again)|not\s+signed\s+in|login\s+required|expired\s+(token|session|credential)/i.test(
+      s,
+    )
+  ) {
+    return "auth";
+  }
+
+  return "other";
+}
+
+/**
+ * Build soft-fail presentation for a quota probe error.
+ * All kinds soft-fail — never invent remaining %.
+ */
+export function quotaErrorView(err: unknown): QuotaErrorView {
+  const kind = classifyQuotaError(err);
+  const detail = errText(err).trim().slice(0, 280);
+  return {
+    kind,
+    softFail: true,
+    detail,
+    titleKey: `account.quota.err.${kind}`,
+    hintKey: `account.quota.err.${kind}Hint`,
+  };
+}
+
+// ── Empty honesty ────────────────────────────────────────────────────────────
+
+/**
+ * Contextual empty surfaces for the SuperGrok quota block.
+ * - `loading` — status still fetching, no known usage yet
+ * - `signed_out` — no official membership
+ * - `unknown` — membership present but Host silent on remaining
+ * - `error` — classified Host/network/auth failure (soft-fail)
+ */
+export type QuotaEmptyKind = "loading" | "signed_out" | "unknown" | "error";
+
+export type QuotaEmptyState = {
+  kind: QuotaEmptyKind;
+  /** Primary title i18n key under account.quota.*. */
+  titleKey: string;
+  /** Optional body / hint i18n key. */
+  bodyKey: string | null;
+  /**
+   * Short chip label key (remain slot) — never a numeric percent.
+   * Use with {@link formatQuotaUnknown}.
+   */
+  chipKey: string;
+  /**
+   * Soft-fail chrome (warn chip) vs quiet empty.
+   * loading / signed_out are quiet; unknown / error are soft-warn.
+   */
+  softFail: boolean;
+  /** When kind === "error", the classified error view. */
+  error: QuotaErrorView | null;
+  /** Offer refresh CTA (loading already has busy button). */
+  showRefresh: boolean;
+};
+
+export type QuotaEmptyInput = {
+  loading: boolean;
+  /**
+   * True when the user has official SuperGrok / Grok Build membership
+   * (signed in via OAuth or key). Custom relay alone is not membership.
+   */
+  membership: boolean;
+  /**
+   * True when Host returned finite remaining / used figures.
+   * Prefer {@link isQuotaUsageKnown}(billing).
+   */
+  usageKnown: boolean;
+  /** Optional Host / account_status / billing probe error (soft-fail). */
+  error?: unknown;
+};
+
+/**
+ * Resolve which empty surface to show for the quota block.
+ * Returns `null` when known usage should render (progress bar + %).
+ *
+ * Priority:
+ * 1. loading + !usageKnown → loading (keep bar on background refresh)
+ * 2. !membership → signed_out
+ * 3. error + !usageKnown → error (soft-fail; never invent remaining)
+ * 4. membership + !usageKnown → unknown
+ * 5. otherwise null (render known bar; error chip may still show in chrome)
+ *
+ * Never invents remaining / used percentages.
+ */
+export function resolveQuotaEmptyState(
+  opts: QuotaEmptyInput,
+): QuotaEmptyState | null {
+  const hasErr = opts.error != null && opts.error !== "";
+
+  // Keep an existing known bar visible while a background refresh is in flight.
+  if (opts.loading && !opts.usageKnown) {
+    return {
+      kind: "loading",
+      titleKey: "account.quota.loading",
+      bodyKey: "account.quota.loadingHint",
+      chipKey: "account.quota.chip.loading",
+      softFail: false,
+      error: null,
+      showRefresh: false,
+    };
+  }
+
+  if (!opts.membership) {
+    return {
+      kind: "signed_out",
+      titleKey: "account.quota.signedOut",
+      bodyKey: "account.quota.signedOutHint",
+      chipKey: "account.quota.chip.signedOut",
+      softFail: false,
+      error: null,
+      showRefresh: false,
+    };
+  }
+
+  if (hasErr && !opts.usageKnown) {
+    const view = quotaErrorView(opts.error);
+    return {
+      kind: "error",
+      titleKey: view.titleKey,
+      bodyKey: view.hintKey,
+      chipKey: `account.quota.chip.err.${view.kind}`,
+      softFail: true,
+      error: view,
+      showRefresh: true,
+    };
+  }
+
+  if (!opts.usageKnown) {
+    return {
+      kind: "unknown",
+      titleKey: "account.quotaUnknown",
+      bodyKey: "account.billingUnavailable",
+      chipKey: "account.quota.chip.unknown",
+      softFail: true,
+      error: null,
+      showRefresh: true,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Honesty labels for unknown / empty remaining chips.
+ * Never returns a numeric percent string.
+ */
+export type QuotaUnknownLabels = {
+  kind: QuotaEmptyKind | QuotaErrorKind | "unknown";
+  /** Short remain-slot chip key. */
+  chipKey: string;
+  /** Primary title key. */
+  titleKey: string;
+  /** Body / hint key (nullable for minimal chips). */
+  bodyKey: string | null;
+};
+
+/**
+ * Map an empty-state or error kind to i18n honesty label keys.
+ * Callers translate via `t(chipKey)` — never invent "0%" remaining.
+ */
+export function formatQuotaUnknown(
+  kind: QuotaEmptyKind | QuotaErrorKind | "unknown" | null | undefined,
+): QuotaUnknownLabels {
+  switch (kind) {
+    case "loading":
+      return {
+        kind: "loading",
+        chipKey: "account.quota.chip.loading",
+        titleKey: "account.quota.loading",
+        bodyKey: "account.quota.loadingHint",
+      };
+    case "signed_out":
+      return {
+        kind: "signed_out",
+        chipKey: "account.quota.chip.signedOut",
+        titleKey: "account.quota.signedOut",
+        bodyKey: "account.quota.signedOutHint",
+      };
+    case "network":
+      return {
+        kind: "network",
+        chipKey: "account.quota.chip.err.network",
+        titleKey: "account.quota.err.network",
+        bodyKey: "account.quota.err.networkHint",
+      };
+    case "auth":
+      return {
+        kind: "auth",
+        chipKey: "account.quota.chip.err.auth",
+        titleKey: "account.quota.err.auth",
+        bodyKey: "account.quota.err.authHint",
+      };
+    case "host_only":
+      return {
+        kind: "host_only",
+        chipKey: "account.quota.chip.err.host_only",
+        titleKey: "account.quota.err.host_only",
+        bodyKey: "account.quota.err.host_onlyHint",
+      };
+    case "other":
+      return {
+        kind: "other",
+        chipKey: "account.quota.chip.err.other",
+        titleKey: "account.quota.err.other",
+        bodyKey: "account.quota.err.otherHint",
+      };
+    case "error":
+      return {
+        kind: "error",
+        chipKey: "account.quota.chip.err.other",
+        titleKey: "account.quota.err.other",
+        bodyKey: "account.quota.err.otherHint",
+      };
+    case "unknown":
+    default:
+      return {
+        kind: "unknown",
+        chipKey: "account.quota.chip.unknown",
+        titleKey: "account.quotaUnknown",
+        bodyKey: "account.billingUnavailable",
+      };
+  }
+}
+
+/**
+ * Soft-fail error chip for the plan/quota title row when usage is known
+ * but a background refresh failed (or as compact error chrome).
+ */
+export type QuotaErrorChip = {
+  kind: QuotaErrorKind;
+  titleKey: string;
+  hintKey: string;
+  softFail: true;
+};
+
+/** Build a title-row error chip; always soft-fail. */
+export function resolveQuotaErrorChip(
+  err: unknown,
+): QuotaErrorChip | null {
+  if (err == null || err === "") return null;
+  const view = quotaErrorView(err);
+  return {
+    kind: view.kind,
+    titleKey: view.titleKey,
+    hintKey: view.hintKey,
+    softFail: true,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3158,9 +3158,66 @@ html[data-sidebar-density="compact"] .session-row__meta {
   gap: 8px 14px;
 }
 
+.account-hero__plan-empty.is-soft-fail {
+  align-items: flex-start;
+}
+
+.account-hero__plan-empty-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1 1 12rem;
+}
+
+.account-hero__plan-empty-title {
+  font-size: 12.5px;
+  font-weight: 550;
+  color: var(--text-secondary);
+}
+
 .account-hero__plan-meta-text {
   font-size: 12px;
   color: var(--text-tertiary);
+  line-height: 1.45;
+}
+
+/* SuperGrok quota honesty chips (unknown / error — never invent remaining %) */
+.account-quota-chip {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.account-quota-chip--muted {
+  color: var(--text-tertiary);
+}
+
+.account-quota-chip--warn {
+  color: var(--warn, #e6b450);
+  border-color: color-mix(in srgb, var(--warn, #e6b450) 35%, transparent);
+  background: color-mix(in srgb, var(--warn, #e6b450) 12%, transparent);
+}
+
+.account-quota-err-chip {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--warn, #e6b450);
+  border: 1px solid color-mix(in srgb, var(--warn, #e6b450) 35%, transparent);
+  background: color-mix(in srgb, var(--warn, #e6b450) 12%, transparent);
+  max-width: 100%;
 }
 
 .account-hero__links {


### PR DESCRIPTION
## Summary

- SuperGrok quota surface never invents remaining % when Host is silent
- Pure `accountQuotaHonesty` helpers: `resolveQuotaEmptyState`, `classifyQuotaError` (`network` | `auth` | `host_only` | `other`), `formatQuotaUnknown` honesty chips
- Account panel: unknown/empty chips; soft-fail chrome when billing probe fails
- en / zh / zh-TW + CHANGELOG; no `window.confirm`

## Test plan

- [x] `pnpm test -- src/lib/accountQuotaHonesty.test.ts src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: Settings → Account signed-in with failed network probe shows soft-fail chip, not a fake %
- [ ] Manual: Signed-in with silent billing shows Unknown chip + billingUnavailable body
- [ ] Manual: Known remaining still renders bar + remaining % as before