### PR TITLE
perf(chat): stream isolation for multi-turn jank (Intel Retina)

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -918,6 +918,7 @@ import {
 import type { ContextMenuState } from "@/lib/app/appDialogTypes";
 import { useSessionRuntime } from "@/hooks/useSessionRuntime";
 import { sessionTranscriptStore } from "@/lib/sessionTranscriptStore";
+import { useLiveMapWhen } from "@/hooks/useSessionLiveMap";
 import { useComposerController } from "@/hooks/useComposerController";
 import { useAppDialogs } from "@/hooks/useAppDialogs";
 import { useSessionHostEvents } from "@/hooks/useSessionHostEvents";
@@ -1173,9 +1174,10 @@ export function AppWorkbench() {
     liveHost,
     setLiveHost,
     liveHostRef,
-    liveMap,
     setLiveMap,
     liveMapRef,
+    liveMapBusyCount,
+    getLiveMap,
     stopLatch,
     setStopLatch,
     stopLatchRef,
@@ -2174,6 +2176,14 @@ export function AppWorkbench() {
     sawModelOutput?: boolean;
     sawToolActivity?: boolean;
   } | null>(null);
+
+  // Full multi-session liveMap only while chrome that needs every row is open.
+  const liveMap = useLiveMapWhen(
+    showReliability ||
+      agentDashboardOpen ||
+      tasksPanelOpen ||
+      streamStall != null,
+  );
   /** Queue item currently being steered into the live turn. */
   const [guidingQueueItemId, setGuidingQueueItemId] = useState<string | null>(null);
   /** Queue item open in the edit dialog (`null` when closed). */
@@ -2600,12 +2610,12 @@ export function AppWorkbench() {
   useEffect(() => {
     const resolved = resolveTrayBusyBadgeCount({
       enabled: trayBusyBadge,
-      busyCount: countBusyLiveMapSessions(liveMap),
+      busyCount: liveMapBusyCount,
       isSecondaryWindow,
     });
     if (!resolved.apply) return;
     void api.traySetBusyCount(resolved.count);
-  }, [liveMap, trayBusyBadge, isSecondaryWindow]);
+  }, [liveMapBusyCount, trayBusyBadge, isSecondaryWindow]);
 
   const applyComposerPrefs = useCallback(
     (prefs: api.ComposerPrefs, catalog: ModelOption[]) => {
@@ -3914,7 +3924,7 @@ export function AppWorkbench() {
       return;
     }
     const foreignBusy =
-      Object.entries(liveMap).some(
+      Object.entries(getLiveMap()).some(
         ([id, snap]) =>
           id !== s.id &&
           (snap.state === "streaming" || snap.state === "awaiting_permission"),
@@ -15217,7 +15227,7 @@ export function AppWorkbench() {
             );
           }}
           trayBusyBadge={trayBusyBadge}
-          trayBusyCount={countBusyLiveMapSessions(liveMap)}
+          trayBusyCount={liveMapBusyCount}
           onTrayBusyBadge={(v) => {
             saveTrayBusyBadgePref(v, localStorage);
             setTrayBusyBadge(v);

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -817,7 +819,6 @@ import {
 } from "@/components/icons";
 import { PhoneAccountSheet } from "@/components/PhoneAccountSheet";
 import { PhoneComposerToolsSheet } from "@/components/PhoneComposerToolsSheet";
-import { AutomationsPage } from "@/components/AutomationsPage";
 import { OpenLocationButton } from "@/components/OpenLocationButton";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import {
@@ -860,6 +861,16 @@ import {
   type GitDirtySummary
 } from "@/lib/workspaceGit";
 import { ConversationThreadLive } from "@/components/lobe-chat";
+import { SidebarSessionBusySpinner } from "@/components/SidebarSessionBusy";
+
+const SettingsPage = lazy(async () => {
+  const m = await import("@/components/SettingsPage");
+  return { default: m.SettingsPage };
+});
+const AutomationsPage = lazy(async () => {
+  const m = await import("@/components/AutomationsPage");
+  return { default: m.AutomationsPage };
+});
 import { dispatchCollapseAllActivity } from "@/lib/collapseAllActivity";
 import {
   installDialogFocus,
@@ -867,12 +878,8 @@ import {
   preferPermissionFocus,
   trapTabKey
 } from "@/lib/a11yFocus";
-import { Spinner } from "@/components/ui/spinner";
 import { UserMenu, remainingPercent } from "@/components/UserMenu";
-import {
-  SettingsPage,
-  type SettingsSectionId
-} from "@/components/SettingsPage";
+import type { SettingsSectionId } from "@/components/SettingsPage";
 import {
   buildSettingsHash,
   isSettingsSectionId,
@@ -14760,11 +14767,12 @@ export function AppWorkbench() {
       )}
 
       {appGate === "ready" && (appView === "settings" ? (
-        <SettingsPage
+                <Suspense fallback={null}>
+          <SettingsPage
           section={settingsSection}
           tab={settingsTab}
           onSection={(id, nextTab) => {
-            navigateSettings(id, nextTab);
+          navigateSettings(id, nextTab);
           }}
           onBack={navigateWorkbench}
           phoneLayout={phoneLayout}
@@ -14775,16 +14783,16 @@ export function AppWorkbench() {
           locale={locale}
           localePreference={localePreference}
           onLocale={(v) => {
-            const pref = parseLocalePreference(v);
-            setLocalePreference(pref);
-            const next = resolveLocalePreference(pref);
-            setLocale(next);
-            void api.settingsGet().then(async (s) => {
-              // Persist preference including "system" (not the resolved catalog id).
-              await api.settingsSet({ ...s, locale: pref });
-              // settings_set also refreshes tray; call again so UI stays in sync if invoke fails mid-way.
-              void api.trayRefresh();
-            });
+          const pref = parseLocalePreference(v);
+          setLocalePreference(pref);
+          const next = resolveLocalePreference(pref);
+          setLocale(next);
+          void api.settingsGet().then(async (s) => {
+          // Persist preference including "system" (not the resolved catalog id).
+          await api.settingsSet({ ...s, locale: pref });
+          // settings_set also refreshes tray; call again so UI stays in sync if invoke fails mid-way.
+          void api.trayRefresh();
+          });
           }}
           theme={theme}
           themePreference={themePreference}
@@ -14793,33 +14801,33 @@ export function AppWorkbench() {
           onThemeSchedule={applyThemeScheduleChoice}
           showMessageTimestamps={showMessageTimestamps}
           onShowMessageTimestamps={(v) => {
-            saveMessageTimestampsPref(v, localStorage);
-            setShowMessageTimestamps(v);
+          saveMessageTimestampsPref(v, localStorage);
+          setShowMessageTimestamps(v);
           }}
           showReplyLength={showReplyLength}
           onShowReplyLength={(v) => {
-            saveShowReplyLengthPref(v, localStorage);
-            setShowReplyLength(v);
+          saveShowReplyLengthPref(v, localStorage);
+          setShowReplyLength(v);
           }}
           showUsageEstimates={showUsageEstimates}
           onShowUsageEstimates={(v) => {
-            saveShowUsageEstimatesPref(v, localStorage);
-            setShowUsageEstimates(v);
+          saveShowUsageEstimatesPref(v, localStorage);
+          setShowUsageEstimates(v);
           }}
           goalOrchUiEnabled={goalOrchUiEnabled}
           onGoalOrchUiEnabled={(v) => {
-            saveGoalOrchUiEnabled(v, localStorage);
-            setGoalOrchUiEnabled(v);
+          saveGoalOrchUiEnabled(v, localStorage);
+          setGoalOrchUiEnabled(v);
           }}
           messageTimeFormat={messageTimeFormat}
           onMessageTimeFormat={(v) => {
-            saveMessageTimeFormatPref(v, localStorage);
-            setMessageTimeFormat(v);
+          saveMessageTimeFormatPref(v, localStorage);
+          setMessageTimeFormat(v);
           }}
           sidebarShowRelativeTime={sidebarShowRelativeTime}
           onSidebarShowRelativeTime={(v) => {
-            saveSidebarShowRelativeTimePref(v, localStorage);
-            setSidebarShowRelativeTime(v);
+          saveSidebarShowRelativeTimePref(v, localStorage);
+          setSidebarShowRelativeTime(v);
           }}
           mutedSessionCount={mutedSessionIds.size}
           onClearAllSessionMutes={handleClearAllSessionMutes}
@@ -14834,9 +14842,9 @@ export function AppWorkbench() {
           wallpaperFocus={wallpaperRecord?.focus ?? null}
           wallpaperClip={wallpaperRecord?.clip ?? null}
           wallpaperMediaSize={
-            wallpaperRecord?.width && wallpaperRecord?.height
-              ? { w: wallpaperRecord.width, h: wallpaperRecord.height }
-              : null
+          wallpaperRecord?.width && wallpaperRecord?.height
+          ? { w: wallpaperRecord.width, h: wallpaperRecord.height }
+          : null
           }
           onWallpaper={applyWallpaperChoice}
           onWallpaperAdjust={applyWallpaperAdjustChoice}
@@ -14845,451 +14853,451 @@ export function AppWorkbench() {
           onWallpaperScrim={applyWallpaperScrimChoice}
           sessionDataMode={sessionDataMode}
           onCliSessionsImported={() => {
-            void refreshSessions();
+          void refreshSessions();
           }}
           onOpenCliSession={(appSessionId) => {
-            void (async () => {
-              await refreshSessions();
-              trayHandlersRef.current.openSessionById(appSessionId);
-            })();
+          void (async () => {
+          await refreshSessions();
+          trayHandlersRef.current.openSessionById(appSessionId);
+          })();
           }}
           onSessionDataMode={(v) => {
-            const commit = () => {
-              setSessionDataMode(v);
-              void api.settingsGet().then((s) =>
-                api.settingsSet({ ...s, sessionDataMode: v }),
-              );
-            };
-            // Tauri WebView: window.confirm is unreliable (often always false).
-            if (v === "shared") {
-              setAppDialog({
-                kind: "confirm",
-                title: tr("settings.sessionDataMode"),
-                message: tr("settings.sharedConfirm"),
-                confirmLabel: tr("common.confirm"),
-                onConfirm: commit,
-              });
-              return;
-            }
-            commit();
+          const commit = () => {
+          setSessionDataMode(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, sessionDataMode: v }),
+          );
+          };
+          // Tauri WebView: window.confirm is unreliable (often always false).
+          if (v === "shared") {
+          setAppDialog({
+          kind: "confirm",
+          title: tr("settings.sessionDataMode"),
+          message: tr("settings.sharedConfirm"),
+          confirmLabel: tr("common.confirm"),
+          onConfirm: commit,
+          });
+          return;
+          }
+          commit();
           }}
           policy={policy}
           onPolicy={(v) => {
-            if (!isValidPolicy(v)) return;
-            applyPermissionPolicy(v);
+          if (!isValidPolicy(v)) return;
+          applyPermissionPolicy(v);
           }}
           prefsScope={prefsScope}
           onPrefsScope={(v) => {
-            if (!isValidPrefsScope(v)) return;
-            setPrefsScope(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, composerPrefsScope: v }),
-            );
-            void api
-              .composerPrefsResolve({
-                projectId: activeProject?.id ?? null,
-                sessionId: session.sessionId ?? null,
-              })
-              .then((prefs) => applyComposerPrefs(prefs, availableModels))
-              .catch(() => {});
+          if (!isValidPrefsScope(v)) return;
+          setPrefsScope(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, composerPrefsScope: v }),
+          );
+          void api
+          .composerPrefsResolve({
+          projectId: activeProject?.id ?? null,
+          sessionId: session.sessionId ?? null,
+          })
+          .then((prefs) => applyComposerPrefs(prefs, availableModels))
+          .catch(() => {});
           }}
           availableModels={availableModels}
           manualCliPath={manualCliPath}
           onManualCliPath={setManualCliPath}
           onCliBlur={(v) => {
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, manualCliPath: v || null }),
-            );
-            void api.probeCli(v || undefined).then((cli) => {
-              setCliInfo({
-                found: cli.found,
-                path: cli.path,
-                version: cli.version,
-                source: cli.source || "",
-                cliAuthPresent: !!cli.cliAuthPresent,
-              });
-              setSetup((prev) => ({
-                ...prev,
-                cli: cli.found,
-                auth: prev.auth || !!cli.cliAuthPresent,
-              }));
-            });
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, manualCliPath: v || null }),
+          );
+          void api.probeCli(v || undefined).then((cli) => {
+          setCliInfo({
+          found: cli.found,
+          path: cli.path,
+          version: cli.version,
+          source: cli.source || "",
+          cliAuthPresent: !!cli.cliAuthPresent,
+          });
+          setSetup((prev) => ({
+          ...prev,
+          cli: cli.found,
+          auth: prev.auth || !!cli.cliAuthPresent,
+          }));
+          });
           }}
           allowUnverifiedCliInstall={allowUnverifiedCliInstall}
           lastCliChecksumVerified={lastCliChecksumVerified}
           onAllowUnverifiedCliInstall={(v) => {
-            setAllowUnverifiedCliInstall(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, allowUnverifiedCliInstall: v }),
-            );
+          setAllowUnverifiedCliInstall(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, allowUnverifiedCliInstall: v }),
+          );
           }}
           acpServerAddr={acpServerAddr}
           onAcpServerAddr={setAcpServerAddr}
           onAcpServerBlur={(v) => {
-            setAcpServerAddr(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, acpServerAddr: v.trim() || null }),
-            );
+          setAcpServerAddr(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, acpServerAddr: v.trim() || null }),
+          );
           }}
           proxyMode={proxyMode}
           onProxyMode={(v) => {
-            setProxyMode(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, proxyMode: v }),
-            );
+          setProxyMode(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, proxyMode: v }),
+          );
           }}
           proxyUrl={proxyUrl}
           onProxyUrl={(v) => {
-            setProxyUrl(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, proxyUrl: v.trim() || null }),
-            );
+          setProxyUrl(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, proxyUrl: v.trim() || null }),
+          );
           }}
           proxyNoProxy={proxyNoProxy}
           onProxyNoProxy={(v) => {
-            setProxyNoProxy(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, proxyNoProxy: v.trim() || null }),
-            );
+          setProxyNoProxy(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, proxyNoProxy: v.trim() || null }),
+          );
           }}
           maxConcurrentAgents={maxConcurrentAgents}
           onMaxConcurrentAgents={(v) => {
-            setMaxConcurrentAgents(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, maxConcurrentAgents: v }),
-            );
+          setMaxConcurrentAgents(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, maxConcurrentAgents: v }),
+          );
           }}
           lastProcessLimit={lastProcessLimit}
           agentIdleMinutes={agentIdleMinutes}
           onAgentIdleMinutes={(v) => {
-            setAgentIdleMinutes(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, agentIdleMinutes: v }),
-            );
+          setAgentIdleMinutes(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, agentIdleMinutes: v }),
+          );
           }}
           streamStallSeconds={streamStallSeconds}
           onStreamStallSeconds={(v) => {
-            setStreamStallSeconds(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, streamStallSeconds: v }),
-            );
+          setStreamStallSeconds(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, streamStallSeconds: v }),
+          );
           }}
           auditLedgerRetentionDays={auditLedgerRetentionDays}
           onAuditLedgerRetentionDays={(v) => {
-            const n = v === 7 || v === 30 || v === 90 ? v : 0;
-            setAuditLedgerRetentionDays(n);
-            void api
-              .settingsGet()
-              .then((s) =>
-                api.settingsSet({ ...s, auditLedgerRetentionDays: n }),
-              );
+          const n = v === 7 || v === 30 || v === 90 ? v : 0;
+          setAuditLedgerRetentionDays(n);
+          void api
+          .settingsGet()
+          .then((s) =>
+          api.settingsSet({ ...s, auditLedgerRetentionDays: n }),
+          );
           }}
           includePartialMessages={includePartialMessages}
           onIncludePartialMessages={(v) => {
-            setIncludePartialMessages(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, includePartialMessages: v }),
-            );
+          setIncludePartialMessages(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, includePartialMessages: v }),
+          );
           }}
           maxAgentTurns={maxAgentTurns}
           onMaxAgentTurns={(v) => {
-            const n = v > 0 ? Math.min(200, Math.round(v)) : 0;
-            setMaxAgentTurns(n);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({
-                ...s,
-                // null clears the optional field; 0 would also omit on spawn.
-                maxAgentTurns: n > 0 ? n : null,
-              }),
-            );
+          const n = v > 0 ? Math.min(200, Math.round(v)) : 0;
+          setMaxAgentTurns(n);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({
+          ...s,
+          // null clears the optional field; 0 would also omit on spawn.
+          maxAgentTurns: n > 0 ? n : null,
+          }),
+          );
           }}
           backgroundWaitPolicy={backgroundWaitPolicy}
           onBackgroundWaitPolicy={(v) => {
-            const next =
-              v === "no_wait" || v === "timeout" ? v : "wait";
-            setBackgroundWaitPolicy(next);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, backgroundWaitPolicy: next }),
-            );
+          const next =
+          v === "no_wait" || v === "timeout" ? v : "wait";
+          setBackgroundWaitPolicy(next);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, backgroundWaitPolicy: next }),
+          );
           }}
           backgroundWaitTimeoutSec={backgroundWaitTimeoutSec}
           onBackgroundWaitTimeoutSec={(v) => {
-            const n = Math.min(3600, Math.max(1, Math.round(v)));
-            setBackgroundWaitTimeoutSec(n);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, backgroundWaitTimeoutSec: n }),
-            );
+          const n = Math.min(3600, Math.max(1, Math.round(v)));
+          setBackgroundWaitTimeoutSec(n);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, backgroundWaitTimeoutSec: n }),
+          );
           }}
           storeApiKeysInKeychain={storeApiKeysInKeychain}
           onStoreApiKeysInKeychain={(v) => {
-            const prev = storeApiKeysInKeychain;
-            setStoreApiKeysInKeychain(v);
-            void api
-              .settingsGet()
-              .then((s) =>
-                api.settingsSet({ ...s, storeApiKeysInKeychain: v }),
-              )
-              .catch((e) => {
-                setStoreApiKeysInKeychain(prev);
-                showToast(String(e), 4500);
-              });
+          const prev = storeApiKeysInKeychain;
+          setStoreApiKeysInKeychain(v);
+          void api
+          .settingsGet()
+          .then((s) =>
+          api.settingsSet({ ...s, storeApiKeysInKeychain: v }),
+          )
+          .catch((e) => {
+          setStoreApiKeysInKeychain(prev);
+          showToast(String(e), 4500);
+          });
           }}
           sandboxProfile={sandboxProfile}
           onSandboxProfile={(v) => {
-            applyGlobalSandboxProfile(v);
+          applyGlobalSandboxProfile(v);
           }}
           preferredAgent={preferredAgent}
           onPreferredAgent={(v) => {
-            setPreferredAgent(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, preferredAgent: v }),
-            );
+          setPreferredAgent(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, preferredAgent: v }),
+          );
           }}
           agentProfilePath={agentProfilePath}
           onAgentProfilePath={setAgentProfilePath}
           onAgentProfilePathCommit={(v) => {
-            const next = (v || "").trim();
-            setAgentProfilePath(next);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, agentProfilePath: next }),
-            );
+          const next = (v || "").trim();
+          setAgentProfilePath(next);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, agentProfilePath: next }),
+          );
           }}
           agentsJson={agentsJson}
           onAgentsJson={setAgentsJson}
           onAgentsJsonCommit={async (v) => {
-            const next = (v || "").trim();
-            setAgentsJson(next);
-            const s = await api.settingsGet();
-            await api.settingsSet({ ...s, agentsJson: next });
+          const next = (v || "").trim();
+          setAgentsJson(next);
+          const s = await api.settingsGet();
+          await api.settingsSet({ ...s, agentsJson: next });
           }}
           agentCatalog={agentCatalog}
           experimentalMemory={experimentalMemory}
           onExperimentalMemory={(v) => {
-            setExperimentalMemory(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, experimentalMemory: v }),
-            );
+          setExperimentalMemory(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, experimentalMemory: v }),
+          );
           }}
           compactionMode={compactionMode}
           onCompactionMode={(v) => {
-            const next = normalizeCompactionMode(v);
-            setCompactionMode(next);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, compactionMode: next }),
-            );
+          const next = normalizeCompactionMode(v);
+          setCompactionMode(next);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, compactionMode: next }),
+          );
           }}
           compactionDetail={compactionDetail}
           onCompactionDetail={(v) => {
-            const next = normalizeCompactionDetail(v);
-            setCompactionDetail(next);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, compactionDetail: next }),
-            );
+          const next = normalizeCompactionDetail(v);
+          setCompactionDetail(next);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, compactionDetail: next }),
+          );
           }}
           twoPassCompactionEnabled={twoPassCompactionEnabled}
           onTwoPassCompactionEnabled={(v) => {
-            setTwoPassCompactionEnabled(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, twoPassCompactionEnabled: v }),
-            );
+          setTwoPassCompactionEnabled(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, twoPassCompactionEnabled: v }),
+          );
           }}
           voiceId={voiceId}
           onVoiceId={(v) => {
-            const next = (v || "eve").trim() || "eve";
-            setVoiceId(next);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, voiceId: next }),
-            );
+          const next = (v || "eve").trim() || "eve";
+          setVoiceId(next);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, voiceId: next }),
+          );
           }}
           voiceDictationAutoSend={voiceDictationAutoSend}
           onVoiceDictationAutoSend={(v) => {
-            setVoiceDictationAutoSend(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, voiceDictationAutoSend: v }),
-            );
+          setVoiceDictationAutoSend(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, voiceDictationAutoSend: v }),
+          );
           }}
           voiceKeepAgentsOnEnd={voiceKeepAgentsOnEnd}
           onVoiceKeepAgentsOnEnd={(v) => {
-            setVoiceKeepAgentsOnEnd(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, voiceKeepAgentsOnEnd: v }),
-            );
+          setVoiceKeepAgentsOnEnd(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, voiceKeepAgentsOnEnd: v }),
+          );
           }}
           subagentsEnabled={subagentsEnabled}
           onSubagentsEnabled={(v) => {
-            setSubagentsEnabled(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, subagentsEnabled: v }),
-            );
+          setSubagentsEnabled(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, subagentsEnabled: v }),
+          );
           }}
           subagentWorktreeSnapshotEnabled={subagentWorktreeSnapshotEnabled}
           onSubagentWorktreeSnapshotEnabled={(v) => {
-            setSubagentWorktreeSnapshotEnabled(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, subagentWorktreeSnapshotEnabled: v }),
-            );
+          setSubagentWorktreeSnapshotEnabled(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, subagentWorktreeSnapshotEnabled: v }),
+          );
           }}
           autoWakeEnabled={autoWakeEnabled}
           onAutoWakeEnabled={(v) => {
-            setAutoWakeEnabled(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, autoWakeEnabled: v }),
-            );
+          setAutoWakeEnabled(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, autoWakeEnabled: v }),
+          );
           }}
           workflowsEnabled={workflowsEnabled}
           onWorkflowsEnabled={(v) => {
-            setWorkflowsEnabled(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, workflowsEnabled: v }),
-            );
+          setWorkflowsEnabled(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, workflowsEnabled: v }),
+          );
           }}
           planEnabled={planEnabled}
           onPlanEnabled={(v) => {
-            setPlanEnabled(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, planEnabled: v }),
-            );
+          setPlanEnabled(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, planEnabled: v }),
+          );
           }}
           todoGateEnabled={todoGateEnabled}
           onTodoGateEnabled={(v) => {
-            setTodoGateEnabled(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, todoGateEnabled: v }),
-            );
+          setTodoGateEnabled(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, todoGateEnabled: v }),
+          );
           }}
           todoGateMaxFiresPerPrompt={todoGateMaxFiresPerPrompt}
           // Host has no fire-activity channel yet — Settings shows honest N/A.
           todoGateFireSignal={null}
           onTodoGateMaxFiresPerPrompt={(v) => {
-            const n =
-              typeof v === "number" && Number.isFinite(v) && v > 0
-                ? Math.min(20, Math.max(1, Math.round(v)))
-                : 3;
-            setTodoGateMaxFiresPerPrompt(n);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, todoGateMaxFiresPerPrompt: n }),
-            );
+          const n =
+          typeof v === "number" && Number.isFinite(v) && v > 0
+          ? Math.min(20, Math.max(1, Math.round(v)))
+          : 3;
+          setTodoGateMaxFiresPerPrompt(n);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, todoGateMaxFiresPerPrompt: n }),
+          );
           }}
           disableWebSearch={disableWebSearch}
           onDisableWebSearch={(v) => {
-            setDisableWebSearch(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, disableWebSearch: v }),
-            );
+          setDisableWebSearch(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, disableWebSearch: v }),
+          );
           }}
           noAskUser={noAskUser}
           onNoAskUser={(v) => {
-            setNoAskUser(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, noAskUser: v }),
-            );
+          setNoAskUser(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, noAskUser: v }),
+          );
           }}
           disallowedTools={disallowedTools}
           onDisallowedTools={(v) => {
-            setDisallowedTools(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, disallowedTools: v }),
-            );
+          setDisallowedTools(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, disallowedTools: v }),
+          );
           }}
           allowedTools={allowedTools}
           onAllowedTools={(v) => {
-            setAllowedTools(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, allowedTools: v }),
-            );
+          setAllowedTools(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, allowedTools: v }),
+          );
           }}
           useLeader={useLeader}
           onUseLeader={(v) => {
-            setUseLeader(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, useLeader: v }),
-            );
+          setUseLeader(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, useLeader: v }),
+          );
           }}
           reopenLastSession={reopenLastSession}
           onReopenLastSession={(v) => {
-            setReopenLastSession(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, reopenLastSession: v }),
-            );
+          setReopenLastSession(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, reopenLastSession: v }),
+          );
           }}
           closeToTray={closeToTray}
           onCloseToTray={(v) => {
-            setCloseToTray(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, closeToTray: v }),
-            );
+          setCloseToTray(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, closeToTray: v }),
+          );
           }}
           keepTrayForSchedules={keepTrayForSchedules}
           onKeepTrayForSchedules={(v) => {
-            setKeepTrayForSchedules(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, keepTrayForSchedules: v }),
-            );
+          setKeepTrayForSchedules(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, keepTrayForSchedules: v }),
+          );
           }}
           trayBusyBadge={trayBusyBadge}
           trayBusyCount={liveMapBusyCount}
           onTrayBusyBadge={(v) => {
-            saveTrayBusyBadgePref(v, localStorage);
-            setTrayBusyBadge(v);
+          saveTrayBusyBadgePref(v, localStorage);
+          setTrayBusyBadge(v);
           }}
           launchAtLogin={launchAtLogin}
           onLaunchAtLogin={(v) => {
-            setLaunchAtLogin(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, launchAtLogin: v }).catch(() => {
-                // Host rolls back AppSettings when OS login-item update fails.
-                setLaunchAtLogin(!v);
-              }),
-            );
+          setLaunchAtLogin(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, launchAtLogin: v }).catch(() => {
+          // Host rolls back AppSettings when OS login-item update fails.
+          setLaunchAtLogin(!v);
+          }),
+          );
           }}
           windowAlwaysOnTop={windowAlwaysOnTop}
           onWindowAlwaysOnTop={(v) => {
-            saveWindowAlwaysOnTopPref(v, localStorage);
-            setWindowAlwaysOnTop(v);
+          saveWindowAlwaysOnTopPref(v, localStorage);
+          setWindowAlwaysOnTop(v);
           }}
           notifyOnTurnDone={notifyOnTurnDone}
           onNotifyOnTurnDone={(v) => {
-            setNotifyOnTurnDone(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, notifyOnTurnDone: v }),
-            );
+          setNotifyOnTurnDone(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, notifyOnTurnDone: v }),
+          );
           }}
           notifyOnPermission={notifyOnPermission}
           onNotifyOnPermission={(v) => {
-            setNotifyOnPermission(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, notifyOnPermission: v }),
-            );
+          setNotifyOnPermission(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, notifyOnPermission: v }),
+          );
           }}
           notifySound={notifySound}
           onNotifySound={(v) => {
-            saveNotifySoundPref(v, localStorage);
-            setNotifySound(v);
+          saveNotifySoundPref(v, localStorage);
+          setNotifySound(v);
           }}
           permissionTimeoutSec={permissionTimeoutSec}
           onPermissionTimeoutSec={(v) => {
-            savePermissionTimeoutSec(v, localStorage);
-            setPermissionTimeoutSec(v);
+          savePermissionTimeoutSec(v, localStorage);
+          setPermissionTimeoutSec(v);
           }}
           askUserTimeoutSec={askUserTimeoutSec}
           onAskUserTimeoutSec={(v) => {
-            saveAskUserTimeoutSec(v, localStorage);
-            setAskUserTimeoutSec(v);
+          saveAskUserTimeoutSec(v, localStorage);
+          setAskUserTimeoutSec(v);
           }}
           cliInfo={cliInfo}
           onDoctor={() => void openDoctor()}
           onOpenReliability={() => openReliability()}
           onOpenBatchAgents={() => openBatchAgents()}
           costRollupSessions={sessions.map((s) => ({
-            id: s.id,
-            projectId: s.projectId,
-            title: s.title,
-            modelId: s.modelId,
-            updatedAt: s.updatedAt,
+          id: s.id,
+          projectId: s.projectId,
+          title: s.title,
+          modelId: s.modelId,
+          updatedAt: s.updatedAt,
           }))}
           costRollupProjects={projects.map((p) => ({
-            id: p.id,
-            name: p.name,
+          id: p.id,
+          name: p.name,
           }))}
           onOpenShortcutsHelp={() => setShowShortcuts(true)}
           onOpenProductTutorial={() => setShowProductTutorial(true)}
@@ -15316,78 +15324,78 @@ export function AppWorkbench() {
           onImportChat={() => void importChatTranscript()}
           defaultOpenTarget={defaultOpenTarget}
           onDefaultOpenTarget={(v) => {
-            setDefaultOpenTarget(v);
-            void api.settingsGet().then((s) =>
-              api.settingsSet({ ...s, defaultOpenTarget: v }),
-            );
+          setDefaultOpenTarget(v);
+          void api.settingsGet().then((s) =>
+          api.settingsSet({ ...s, defaultOpenTarget: v }),
+          );
           }}
           archivedGroups={archivedGroups}
           onRestoreArchivedSessions={(ids) => {
-            const rows = ids
-              .map((id) => sessions.find((x) => x.id === id))
-              .filter((s): s is SessionRow => !!s);
-            void restoreSessions(rows);
+          const rows = ids
+          .map((id) => sessions.find((x) => x.id === id))
+          .filter((s): s is SessionRow => !!s);
+          void restoreSessions(rows);
           }}
           onDeleteArchivedSessions={(ids) => {
-            const rows = ids
-              .map((id) => sessions.find((x) => x.id === id))
-              .filter((s): s is SessionRow => !!s);
-            deleteSessionsConfirm(rows);
+          const rows = ids
+          .map((id) => sessions.find((x) => x.id === id))
+          .filter((s): s is SessionRow => !!s);
+          deleteSessionsConfirm(rows);
           }}
           onArchiveOlderThan={(days) => {
-            confirmArchiveOlderThan(days);
+          confirmArchiveOlderThan(days);
           }}
           archiveAgeSessions={sessions}
           projectPath={effectiveProjectPath}
           onOpenProjectFileInResources={({ path, relativePath }) => {
-            const targetPath = (path || relativePath || "").trim();
-            if (!targetPath) return;
-            navigateWorkbench();
-            openAsidePane();
-            setResourceOpenTarget({
-              type: "file",
-              path: targetPath,
-              title: relativePath || targetPath,
-            });
+          const targetPath = (path || relativePath || "").trim();
+          if (!targetPath) return;
+          navigateWorkbench();
+          openAsidePane();
+          setResourceOpenTarget({
+          type: "file",
+          path: targetPath,
+          title: relativePath || targetPath,
+          });
           }}
           onSkillsPrefsChanged={() =>
-            setSkillsReloadToken((n) => n + 1)
+          setSkillsReloadToken((n) => n + 1)
           }
           trustedProjects={projects
-            .filter((p) => p.trusted)
-            .map((p) => ({ id: p.id, name: p.name, path: p.path }))}
+          .filter((p) => p.trusted)
+          .map((p) => ({ id: p.id, name: p.name, path: p.path }))}
           onProvidersChanged={() => {
-            // CRUD on provider list / models / efforts — keep composer menu in sync.
-            void refreshProviderRoute();
+          // CRUD on provider list / models / efforts — keep composer menu in sync.
+          void refreshProviderRoute();
           }}
           onProviderActivated={() => {
-            // Host already recycled warm agents on upsert/activate. Refresh UI
-            // chrome only — never park (sessionDisconnect) a live process: that
-            // kept stale OIDC/config in memory and required a full app restart
-            // (issue #376). Soft-fail so save UI never sticks on “Saving…”.
-            void (async () => {
-              try {
-                if (api.isTauri()) {
-                  setSession({ ...IDLE_SNAPSHOT });
-                }
-                await refreshProviderRoute();
-                await refreshAccount({ refreshBilling: false }).catch(() => {
-                  /* soft-fail billing refresh */
-                });
-                await refreshVoiceGate().catch(() => {
-                  /* soft-fail voice gate */
-                });
-                setToast(tr("prov.switchedHotReload"));
-                window.setTimeout(() => setToast(null), 3200);
-              } catch (e) {
-                setToast(
-                  tr("prov.savedApplyFailed", { detail: String(e) }),
-                );
-                window.setTimeout(() => setToast(null), 4800);
-              }
-            })();
+          // Host already recycled warm agents on upsert/activate. Refresh UI
+          // chrome only — never park (sessionDisconnect) a live process: that
+          // kept stale OIDC/config in memory and required a full app restart
+          // (issue #376). Soft-fail so save UI never sticks on “Saving…”.
+          void (async () => {
+          try {
+          if (api.isTauri()) {
+          setSession({ ...IDLE_SNAPSHOT });
+          }
+          await refreshProviderRoute();
+          await refreshAccount({ refreshBilling: false }).catch(() => {
+          /* soft-fail billing refresh */
+          });
+          await refreshVoiceGate().catch(() => {
+          /* soft-fail voice gate */
+          });
+          setToast(tr("prov.switchedHotReload"));
+          window.setTimeout(() => setToast(null), 3200);
+          } catch (e) {
+          setToast(
+          tr("prov.savedApplyFailed", { detail: String(e) }),
+          );
+          window.setTimeout(() => setToast(null), 4800);
+          }
+          })();
           }}
-        />
+          />        </Suspense>
       ) : (
       <div className={"workbench" + (phoneLayout ? " workbench--phone" : "")}>
         {/* Phone drawer scrim — tap closes without resizing the conversation */}
@@ -15991,21 +15999,10 @@ export function AppWorkbench() {
                                         </span>
                                         {renderSessionRelativeTime(s.updatedAt)}
                                         {sessionSelectMode ? null : working ? (
-                                          <Tip
+                                          <SidebarSessionBusySpinner
+                                            sessionId={s.id}
                                             label={tr("sidebar.sessionWorking")}
-                                          >
-                                            <span
-                                              className="tree-l3__status"
-                                              aria-label={tr(
-                                                "sidebar.sessionWorking",
-                                              )}
-                                            >
-                                              <Spinner
-                                                size={14}
-                                                className="tree-l3__spinner"
-                                              />
-                                            </span>
-                                          </Tip>
+                                          />
                                         ) : (
                                           <span className="tree-l3__actions tree-l3__actions--triple">
                                             <Tip
@@ -16273,17 +16270,10 @@ export function AppWorkbench() {
                               </span>
                               {renderSessionRelativeTime(s.updatedAt)}
                               {sessionSelectMode ? null : working ? (
-                                <Tip label={tr("sidebar.sessionWorking")}>
-                                  <span
-                                    className="tree-l3__status"
-                                    aria-label={tr("sidebar.sessionWorking")}
-                                  >
-                                    <Spinner
-                                      size={14}
-                                      className="tree-l3__spinner"
-                                    />
-                                  </span>
-                                </Tip>
+                                <SidebarSessionBusySpinner
+                                  sessionId={s.id}
+                                  label={tr("sidebar.sessionWorking")}
+                                />
                               ) : (
                                 <span className="tree-l3__actions tree-l3__actions--triple">
                                   <Tip
@@ -16854,9 +16844,10 @@ export function AppWorkbench() {
           </div>
 
           {mainPane === "automations" ? (
-            <AutomationsPage
+                        <Suspense fallback={null}>
+              <AutomationsPage
               t={(k, vars) =>
-                tr(k as Parameters<typeof tr>[0], vars as Record<string, string | number>)
+              tr(k as Parameters<typeof tr>[0], vars as Record<string, string | number>)
               }
               projects={projects.map((p) => ({ id: p.id, name: p.name }))}
               defaultModelId={modelId}
@@ -16864,57 +16855,57 @@ export function AppWorkbench() {
               models={availableModels}
               openAtLogin={launchAtLogin}
               onOpenLaunchAtLogin={() => {
-                navigateSettings("general", "app");
-                // Scroll/highlight Launch at login after Settings mounts.
-                window.setTimeout(() => {
-                  const el = document.getElementById(
-                    "settings-anchor-launchAtLogin",
-                  );
-                  if (el) {
-                    el.scrollIntoView({ block: "center", behavior: "smooth" });
-                    el.classList.add("is-search-hit");
-                    window.setTimeout(
-                      () => el.classList.remove("is-search-hit"),
-                      1600,
-                    );
-                  }
-                }, 120);
+              navigateSettings("general", "app");
+              // Scroll/highlight Launch at login after Settings mounts.
+              window.setTimeout(() => {
+              const el = document.getElementById(
+              "settings-anchor-launchAtLogin",
+              );
+              if (el) {
+              el.scrollIntoView({ block: "center", behavior: "smooth" });
+              el.classList.add("is-search-hit");
+              window.setTimeout(
+              () => el.classList.remove("is-search-hit"),
+              1600,
+              );
+              }
+              }, 120);
               }}
               closeToTray={closeToTray}
               keepTrayForSchedules={keepTrayForSchedules}
               onKeepTrayForSchedules={(v) => {
-                setKeepTrayForSchedules(v);
-                void api.settingsGet().then((s) =>
-                  api.settingsSet({ ...s, keepTrayForSchedules: v }),
-                );
+              setKeepTrayForSchedules(v);
+              void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, keepTrayForSchedules: v }),
+              );
               }}
               onOpenKeepTraySetting={() => {
-                navigateSettings("general", "app");
-                window.setTimeout(() => {
-                  const el = document.getElementById(
-                    "settings-anchor-keepTrayForSchedules",
-                  );
-                  if (el) {
-                    el.scrollIntoView({ block: "center", behavior: "smooth" });
-                    el.classList.add("is-search-hit");
-                    window.setTimeout(
-                      () => el.classList.remove("is-search-hit"),
-                      1600,
-                    );
-                  }
-                }, 120);
+              navigateSettings("general", "app");
+              window.setTimeout(() => {
+              const el = document.getElementById(
+              "settings-anchor-keepTrayForSchedules",
+              );
+              if (el) {
+              el.scrollIntoView({ block: "center", behavior: "smooth" });
+              el.classList.add("is-search-hit");
+              window.setTimeout(
+              () => el.classList.remove("is-search-hit"),
+              1600,
+              );
+              }
+              }, 120);
               }}
               onAiCreate={() => {
-                void newChat(null, {
-                  seedDraft: aiCreateSeedPrompt("Grok"),
-                  switchToChat: true,
-                  automationSetup: true,
-                });
-                setToast(tr("automations.aiComposerHint"));
-                window.setTimeout(() => setToast(null), 4200);
+              void newChat(null, {
+              seedDraft: aiCreateSeedPrompt("Grok"),
+              switchToChat: true,
+              automationSetup: true,
+              });
+              setToast(tr("automations.aiComposerHint"));
+              window.setTimeout(() => setToast(null), 4200);
               }}
               onRunNow={(auto) => void runAutomation(auto)}
-            />
+              />            </Suspense>
           ) : (
           <>
           {activeProject && isProjectPathMissing(activeProject.pathOk) && (

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -845,10 +845,7 @@ import {
   ProviderBrandIcon,
   providerAvatarLetter
 } from "@/components/ProviderBrandIcon";
-import {
-  ResourceViewer,
-  type ResourceOpenTarget
-} from "@/components/ResourceViewer";
+import type { ResourceOpenTarget } from "@/components/ResourceViewer";
 import { ProjectRulesModal } from "@/components/ProjectRulesModal";
 import {
   mergeSessionChange,
@@ -870,6 +867,10 @@ const SettingsPage = lazy(async () => {
 const AutomationsPage = lazy(async () => {
   const m = await import("@/components/AutomationsPage");
   return { default: m.AutomationsPage };
+});
+const ResourceViewer = lazy(async () => {
+  const m = await import("@/components/ResourceViewer");
+  return { default: m.ResourceViewer };
 });
 import { dispatchCollapseAllActivity } from "@/lib/collapseAllActivity";
 import {
@@ -18808,28 +18809,29 @@ export function AppWorkbench() {
             />
           )}
           <div className="aside__inner">
-            <ResourceViewer
+                        <Suspense fallback={null}>
+              <ResourceViewer
               projectPath={effectiveProjectPath}
               projectName={
-                activeProject
-                  ? projectDisplayName(activeProject, tr)
-                  : tr("composer.noProject")
+              activeProject
+              ? projectDisplayName(activeProject, tr)
+              : tr("composer.noProject")
               }
               locale={locale}
               paneActive={!layout.asideCollapsed}
               openRequest={resourceOpenTarget}
               onOpenRequestConsumed={() => setResourceOpenTarget(null)}
               sessionChanges={
-                sessionChangesById[session.sessionId || ""] ?? []
+              sessionChangesById[session.sessionId || ""] ?? []
               }
               sessionMessages={messages}
               plan={plan}
               planFocusKey={planFocusKey}
               planChrome={{
-                composerMode: mode,
-                planEnabled,
-                userClosed: plan.userClosed,
-                hasHistory: planHistoryNonEmpty,
+              composerMode: mode,
+              planEnabled,
+              userClosed: plan.userClosed,
+              hasHistory: planHistoryNonEmpty,
               }}
               onApprovePlan={() => void approvePlan()}
               onRequestPlanChanges={() => openRequestPlanChanges()}
@@ -18838,15 +18840,15 @@ export function AppWorkbench() {
               onShip={openShipFlow}
               onAsideLayoutHint={applyAsideLayoutHint}
               onClose={() => {
-                // Manual close — do not treat as plan-owned pane on later dismiss.
-                planOpenedAsideRef.current = false;
-                setLayout((l) => {
-                  const n = { ...l, asideCollapsed: true };
-                  saveLayout(localStorage, n);
-                  return n;
-                });
+              // Manual close — do not treat as plan-owned pane on later dismiss.
+              planOpenedAsideRef.current = false;
+              setLayout((l) => {
+              const n = { ...l, asideCollapsed: true };
+              saveLayout(localStorage, n);
+              return n;
+              });
               }}
-            />
+              />            </Suspense>
           </div>
         </aside>
       </div>

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -859,7 +859,7 @@ import {
   summarizeGitDirty,
   type GitDirtySummary
 } from "@/lib/workspaceGit";
-import { ConversationThread } from "@/components/lobe-chat";
+import { ConversationThreadLive } from "@/components/lobe-chat";
 import { dispatchCollapseAllActivity } from "@/lib/collapseAllActivity";
 import {
   installDialogFocus,
@@ -1191,6 +1191,7 @@ export function AppWorkbench() {
     stopGate,
     effectiveCanSend,
     effectiveCanStop,
+    transcriptMeta,
   } = useSessionRuntime({ isSecondaryWindow });
 
   /** Context usage chip — known tokens from compact events + estimate fallback. */
@@ -6492,12 +6493,19 @@ export function AppWorkbench() {
     [tr, platform],
   );
 
-  const lastUserMessageId = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]?.role === "user") return messages[i]!.id;
-    }
-    return null;
-  }, [messages]);
+  const lastUserMessageId = transcriptMeta.lastUserId;
+
+  // Streaming perf mode — cheapen wallpaper/glass on integrated GPU Retina.
+  useEffect(() => {
+    const on =
+      session.state === "streaming" ||
+      session.state === "awaiting_permission" ||
+      transcriptMeta.hasStreamingAssistant;
+    document.documentElement.dataset.streamPerf = on ? "1" : "0";
+    return () => {
+      document.documentElement.dataset.streamPerf = "0";
+    };
+  }, [session.state, transcriptMeta.hasStreamingAssistant]);
 
   const canEditLastUser =
     !!lastUserMessageId &&
@@ -10229,12 +10237,12 @@ export function AppWorkbench() {
   const welcomeSession =
     mainPane === "chat" &&
     !session.sessionId &&
-    messages.length === 0 &&
+    transcriptMeta.length === 0 &&
     session.state !== "streaming";
   const emptyExistingSession =
     mainPane === "chat" &&
     !!session.sessionId &&
-    messages.length === 0 &&
+    transcriptMeta.length === 0 &&
     session.state !== "streaming" &&
     session.state !== "connecting";
   // Live billing can take seconds (quota network). Cache last mark so the
@@ -17377,9 +17385,8 @@ export function AppWorkbench() {
               retry: tr("ui.errorBoundary.retry"),
             }}
           >
-          <ConversationThread
+          <ConversationThreadLive
             locale={locale}
-            messages={messages}
             sessionState={
               stopLatch.phase === "force_idle" || stopGate.forceIdle
                 ? "ready"

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -917,6 +917,7 @@ import {
 } from "@/lib/app/sidebarModels";
 import type { ContextMenuState } from "@/lib/app/appDialogTypes";
 import { useSessionRuntime } from "@/hooks/useSessionRuntime";
+import { sessionTranscriptStore } from "@/lib/sessionTranscriptStore";
 import { useComposerController } from "@/hooks/useComposerController";
 import { useAppDialogs } from "@/hooks/useAppDialogs";
 import { useSessionHostEvents } from "@/hooks/useSessionHostEvents";
@@ -10112,11 +10113,27 @@ export function AppWorkbench() {
    * Historical tool_step rows are not rendered in the transcript, so matching
    * them would land on invisible hits.
    */
+  const [chatFindLiveTick, setChatFindLiveTick] = useState(0);
+  useEffect(() => {
+    if (!showChatFind) return;
+    let raf = 0;
+    const unsub = sessionTranscriptStore.subscribeContent(() => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => setChatFindLiveTick((n) => n + 1));
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      unsub();
+    };
+  }, [showChatFind]);
+
   const chatFindMatches = useMemo((): ChatFindMatch[] => {
     if (!showChatFind) return [];
+    void chatFindLiveTick;
+    const live = sessionTranscriptStore.getMessages();
     return findChatMatches(
       chatFindQuery,
-      messages
+      live
         .filter((m) => m.role === "user" || m.role === "assistant")
         .map((m) => ({
           id: m.id,
@@ -10125,7 +10142,7 @@ export function AppWorkbench() {
           marker: m.marker,
         })),
     );
-  }, [showChatFind, chatFindQuery, messages]);
+  }, [showChatFind, chatFindQuery, chatFindLiveTick, messages]);
 
   const chatFindHitIds = useMemo(() => {
     const s = new Set<string>();

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -191,10 +191,6 @@ import {
   emptySessionPlan,
   type SessionPlanState
 } from "@/lib/planSession";
-import { AgentTasksPanel } from "@/components/AgentTasksPanel";
-import { AgentDashboardModal } from "@/components/AgentDashboardModal";
-import { BatchAgentsModal } from "@/components/BatchAgentsModal";
-import { ReliabilityCenterModal } from "@/components/ReliabilityCenterModal";
 import {
   collectActivitySessions,
   countBusyLiveMapSessions,
@@ -341,11 +337,9 @@ import {
   mapPermissionButtons
 } from "@/lib/permissionOptions";
 import { AskUserModal } from "@/components/AskUserModal";
-import { DoctorModal } from "@/components/DoctorModal";
 import { TraceHistoryList } from "@/components/TraceHistoryList";
 import { PlanHistoryList } from "@/components/PlanHistoryList";
 import { MarkdownBody } from "@/components/MarkdownBody";
-import { VoiceOverlay } from "@/components/VoiceOverlay";
 import {
   clearSessionSearchFilters,
   filterSessionSearch,
@@ -514,7 +508,6 @@ import {
 } from "@/lib/cliUpdateNotice";
 import { GlassModal } from "@/components/GlassModal";
 import { Select } from "@/components/Select";
-import { ProductTutorial } from "@/components/ProductTutorial";
 import {
   loadDone as loadProductTutorialDone,
   markDone as markProductTutorialDone,
@@ -656,7 +649,7 @@ import {
 } from "@/lib/sidebarDensity";
 import { sortSessionsForSidebar } from "@/lib/sidebarDateGroups";
 import { GrokLogo } from "@/components/GrokLogo";
-import { SetupWizard, type SetupCliInfo } from "@/components/SetupWizard";
+import type { SetupCliInfo } from "@/components/SetupWizard";
 import {
   buildAuthDeferredFlags,
   formatCliTooOldDetail,
@@ -754,7 +747,6 @@ import {
   uploadMatchesQuery
 } from "@/components/ComposerPlusPanel";
 import { StatusModal } from "@/components/StatusModal";
-import { McpStatusModal } from "@/components/McpStatusModal";
 import {
   IconChevronDown,
   IconChevronUp,
@@ -858,6 +850,7 @@ import {
   type GitDirtySummary
 } from "@/lib/workspaceGit";
 import { ConversationThreadLive } from "@/components/lobe-chat";
+import { AgentTasksPanelLive } from "@/components/AgentTasksPanelLive";
 import { SidebarSessionBusySpinner } from "@/components/SidebarSessionBusy";
 
 const SettingsPage = lazy(async () => {
@@ -871,6 +864,38 @@ const AutomationsPage = lazy(async () => {
 const ResourceViewer = lazy(async () => {
   const m = await import("@/components/ResourceViewer");
   return { default: m.ResourceViewer };
+});
+const AgentDashboardModal = lazy(async () => {
+  const m = await import("@/components/AgentDashboardModal");
+  return { default: m.AgentDashboardModal };
+});
+const BatchAgentsModal = lazy(async () => {
+  const m = await import("@/components/BatchAgentsModal");
+  return { default: m.BatchAgentsModal };
+});
+const ReliabilityCenterModal = lazy(async () => {
+  const m = await import("@/components/ReliabilityCenterModal");
+  return { default: m.ReliabilityCenterModal };
+});
+const DoctorModal = lazy(async () => {
+  const m = await import("@/components/DoctorModal");
+  return { default: m.DoctorModal };
+});
+const VoiceOverlay = lazy(async () => {
+  const m = await import("@/components/VoiceOverlay");
+  return { default: m.VoiceOverlay };
+});
+const ProductTutorial = lazy(async () => {
+  const m = await import("@/components/ProductTutorial");
+  return { default: m.ProductTutorial };
+});
+const McpStatusModal = lazy(async () => {
+  const m = await import("@/components/McpStatusModal");
+  return { default: m.McpStatusModal };
+});
+const SetupWizard = lazy(async () => {
+  const m = await import("@/components/SetupWizard");
+  return { default: m.SetupWizard };
 });
 import { dispatchCollapseAllActivity } from "@/lib/collapseAllActivity";
 import {
@@ -14732,6 +14757,7 @@ export function AppWorkbench() {
       )}
 
       {appGate === "setup" && (
+        <Suspense fallback={null}>
         <SetupWizard
           tr={tr}
           platform={platform}
@@ -14765,6 +14791,7 @@ export function AppWorkbench() {
             void refreshAccount({ refreshBilling: false });
           }}
         />
+        </Suspense>
       )}
 
       {appGate === "ready" && (appView === "settings" ? (
@@ -17232,8 +17259,7 @@ export function AppWorkbench() {
             />
           )}
           {mainPane === "chat" && tasksPanelOpen && session.sessionId ? (
-            <AgentTasksPanel
-              messages={messages}
+            <AgentTasksPanelLive
               t={(k, vars) => tr(k, vars)}
               onClose={() => setTasksPanelOpen(false)}
               subagentWorktreeSnapshotEnabled={
@@ -19002,6 +19028,8 @@ export function AppWorkbench() {
         </>
       ) : null}
 
+      {(showDoctor) ? (
+      <Suspense fallback={null}>
       <DoctorModal
         open={showDoctor}
         onClose={() => setShowDoctor(false)}
@@ -19021,6 +19049,10 @@ export function AppWorkbench() {
         }}
         onOpenReliability={() => openReliability()}
       />
+      </Suspense>
+      ) : null}
+      {(showReliability) ? (
+      <Suspense fallback={null}>
       <ReliabilityCenterModal
         open={showReliability}
         onClose={() => setShowReliability(false)}
@@ -19036,6 +19068,8 @@ export function AppWorkbench() {
           trayHandlersRef.current.openSessionById(id);
         }}
       />
+      </Suspense>
+      ) : null}
       <ProjectRulesModal
         open={!!projectRulesTarget}
         onClose={() => setProjectRulesTarget(null)}
@@ -19599,6 +19633,8 @@ export function AppWorkbench() {
           ))}
         </ul>
       </GlassModal>
+      {(showProductTutorial) ? (
+      <Suspense fallback={null}>
       <ProductTutorial
         open={showProductTutorial}
         locale={locale}
@@ -19615,6 +19651,10 @@ export function AppWorkbench() {
           setShowProductTutorial(false);
         }}
       />
+      </Suspense>
+      ) : null}
+      {(liveVoiceOpen) ? (
+      <Suspense fallback={null}>
       <VoiceOverlay
         locale={resolveLocale(locale)}
         open={liveVoiceOpen}
@@ -19673,6 +19713,8 @@ export function AppWorkbench() {
           })();
         }}
       />
+      </Suspense>
+      ) : null}
       <AskUserModal
         payload={askUser}
         timeoutSec={askUserTimeoutSec}
@@ -19729,6 +19771,8 @@ export function AppWorkbench() {
         messageCount={messages.length}
         onClose={() => setShowStatusModal(false)}
       />
+      {(agentDashboardOpen) ? (
+      <Suspense fallback={null}>
       <AgentDashboardModal
         open={agentDashboardOpen}
         locale={locale}
@@ -19754,6 +19798,10 @@ export function AppWorkbench() {
           openBatchAgents();
         }}
       />
+      </Suspense>
+      ) : null}
+      {(batchAgentsOpen) ? (
+      <Suspense fallback={null}>
       <BatchAgentsModal
         open={batchAgentsOpen}
         locale={locale}
@@ -19770,6 +19818,10 @@ export function AppWorkbench() {
         onClose={() => setBatchAgentsOpen(false)}
         onDispatch={runBatchAgentsDispatch}
       />
+      </Suspense>
+      ) : null}
+      {(showMcpModal) ? (
+      <Suspense fallback={null}>
       <McpStatusModal
         open={showMcpModal}
         locale={locale}
@@ -19786,6 +19838,8 @@ export function AppWorkbench() {
         onRunDoctor={(name) => void runMcpDoctor(name)}
         onRefreshDoctor={(name) => runMcpDoctor(name)}
       />
+      </Suspense>
+      ) : null}
       {rewindTimeline && (
         <div
           className="overlay"

--- a/src/components/AgentTasksPanelLive.tsx
+++ b/src/components/AgentTasksPanelLive.tsx
@@ -1,0 +1,27 @@
+/**
+ * Tasks panel bound to sessionTranscriptStore content.
+ *
+ * Keeps AppWorkbench off the stream content subscription — only this
+ * bridge re-renders while tools/token steps grow. The heavy panel chunk
+ * is lazy-loaded the first time the panel opens.
+ */
+
+import { lazy, Suspense } from "react";
+import { useViewingMessages } from "@/hooks/useSessionTranscript";
+import type { AgentTasksPanelProps } from "@/components/AgentTasksPanel";
+
+const AgentTasksPanel = lazy(async () => {
+  const m = await import("@/components/AgentTasksPanel");
+  return { default: m.AgentTasksPanel };
+});
+
+export type AgentTasksPanelLiveProps = Omit<AgentTasksPanelProps, "messages">;
+
+export function AgentTasksPanelLive(props: AgentTasksPanelLiveProps) {
+  const messages = useViewingMessages();
+  return (
+    <Suspense fallback={null}>
+      <AgentTasksPanel {...props} messages={messages} />
+    </Suspense>
+  );
+}

--- a/src/components/SidebarSessionBusy.tsx
+++ b/src/components/SidebarSessionBusy.tsx
@@ -1,0 +1,36 @@
+/**
+ * Isolated busy chrome for a sidebar session row.
+ * Subscribes only to busy membership (not full liveMap tool-title ticks).
+ */
+
+import { memo } from "react";
+import { Spinner } from "@/components/ui/spinner";
+import { Tip } from "@/components/ui/tooltip";
+import { useIsSessionBusy } from "@/hooks/useSessionLiveMap";
+
+/** Visible working spinner chip for a session row. */
+export const SidebarSessionBusySpinner = memo(
+  function SidebarSessionBusySpinner({
+    sessionId,
+    label,
+  }: {
+    sessionId: string;
+    label: string;
+  }) {
+    const working = useIsSessionBusy(sessionId);
+    if (!working) return null;
+    return (
+      <Tip label={label}>
+        <span
+          className="tree-l3__status"
+          data-testid="sidebar-session-busy"
+          aria-label={label}
+        >
+          <Spinner size={14} className="tree-l3__spinner" />
+        </span>
+      </Tip>
+    );
+  },
+);
+
+export { useIsSessionBusy };

--- a/src/components/lobe-chat/AgentActivity.tsx
+++ b/src/components/lobe-chat/AgentActivity.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 /**
  * Mid-stream tool activity — Grok icon + one-line title.
  */
@@ -17,7 +18,7 @@ export {
   toolStepDisplayTitle,
 } from "@/lib/session";
 
-export function LiveToolText({
+export const LiveToolText = memo(function LiveToolText({
   message,
   locale: _locale,
 }: {
@@ -47,7 +48,7 @@ export function LiveToolText({
       <span className="grok-act__label">{title}</span>
     </div>
   );
-}
+});
 
 /** @deprecated Prefer EndOfTurnChip */
 export function TurnCancelledRow({

--- a/src/components/lobe-chat/BackBottom.tsx
+++ b/src/components/lobe-chat/BackBottom.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react";
 import { IconChevronDown } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
-export function BackBottom({
+export const BackBottom = memo(function BackBottom({
   visible,
   onClick,
   label,
@@ -23,4 +24,4 @@ export function BackBottom({
       </button>
     </Tip>
   );
-}
+});

--- a/src/components/lobe-chat/ChatItem.tsx
+++ b/src/components/lobe-chat/ChatItem.tsx
@@ -1,11 +1,12 @@
 /**
  * Lobe ChatItem layout shell — 1:1 structure of lobe-chat ChatItem.tsx.
+ * Memoized so stream updates to the tail row do not rebuild sibling chrome.
  */
 
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
-export function ChatItem({
+export const ChatItem = memo(function ChatItem({
   id,
   placement = "left",
   avatar,
@@ -84,4 +85,4 @@ export function ChatItem({
       {actions ? <div className="lobe-chat-item__actions">{actions}</div> : null}
     </div>
   );
-}
+});

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -135,6 +135,30 @@ type AttachLabels = {
   remove: string;
 };
 
+
+/** Keep path-map object identity when tool paths did not change (stream text growth). */
+function useStableSessionPathMap(
+  messages: ChatMessage[],
+  projectPath?: string | null,
+): Record<string, string> {
+  const prevRef = useRef<Record<string, string>>({});
+  const next = useMemo(
+    () => buildSessionFilePathMap(messages, projectPath),
+    [messages, projectPath],
+  );
+  const prev = prevRef.current;
+  const prevKeys = Object.keys(prev);
+  const nextKeys = Object.keys(next);
+  if (
+    prevKeys.length === nextKeys.length &&
+    nextKeys.every((k) => prev[k] === next[k])
+  ) {
+    return prev;
+  }
+  prevRef.current = next;
+  return next;
+}
+
 /**
  * Assistant markdown + attachment cards.
  * Memoized so parent re-renders (showBack, live tool pulse, etc.) do not
@@ -528,6 +552,859 @@ export interface ConversationThreadProps {
     usageTotal?: string;
   };
 }
+
+
+type TranscriptMessageRowProps = {
+  m: ChatMessage;
+  msgIndex: number;
+  virtualized: boolean;
+  measureRef: (index: number) => (el: HTMLElement | null) => void;
+  locale: Locale;
+  tr: ReturnType<typeof createT>;
+  projectPath?: string | null;
+  sessionPathMap?: Record<string, string>;
+  sessionId?: string | null;
+  showToolChrome: boolean;
+  toolStepsAutoCollapse: boolean;
+  showTimestamps: boolean;
+  messageTimeFormat: MessageTimeFormat;
+  /** Bumps every minute when relative timestamps are on — busts row memo. */
+  timeTick: number;
+  showReplyLength: boolean;
+  lastUserMessageId?: string | null;
+  editingUserMessageId?: string | null;
+  editSubmitting?: boolean;
+  editAttachments: Attachment[];
+  canEditLastUser: boolean;
+  canRegenerate: boolean;
+  canRewindSession: boolean;
+  regenerableAssistantId: string | null;
+  regenerateModels: ModelOption[];
+  regenerateModelId: string;
+  activeAssistantId: string | null;
+  liveTool: ReturnType<typeof pickRunningTurnTool>;
+  wovenMessages: ChatMessage[];
+  findQuery: string;
+  findHitMessageIds?: ReadonlySet<string>;
+  findActive: { messageId: string; occurrence: number } | null;
+  focusMessageId: string | null;
+  structuredUsageMessageId: string | null;
+  structuredOutputActive: boolean;
+  structuredOutputSchema: string | null;
+  structuredOutputUsage: {
+    inputTokens?: number | null;
+    outputTokens?: number | null;
+    totalTokens?: number | null;
+  } | null;
+  structuredOutputLabels?: ConversationThreadProps["structuredOutputLabels"];
+  attachLabels: AttachLabels;
+  onEditUserMessage?: ConversationThreadProps["onEditUserMessage"];
+  onCancelEditUserMessage?: ConversationThreadProps["onCancelEditUserMessage"];
+  onSubmitEditUserMessage?: ConversationThreadProps["onSubmitEditUserMessage"];
+  onRemoveEditAttachment?: ConversationThreadProps["onRemoveEditAttachment"];
+  onRegenerateAssistant?: ConversationThreadProps["onRegenerateAssistant"];
+  onRewindToUserMessage?: ConversationThreadProps["onRewindToUserMessage"];
+  onForkFromUserMessage?: ConversationThreadProps["onForkFromUserMessage"];
+  onOpenResource?: ConversationThreadProps["onOpenResource"];
+  onOpenExternalLink?: ConversationThreadProps["onOpenExternalLink"];
+  onAddAttachmentToComposer?: ConversationThreadProps["onAddAttachmentToComposer"];
+};
+
+function transcriptRowPropsEqual(
+  a: TranscriptMessageRowProps,
+  b: TranscriptMessageRowProps,
+): boolean {
+  if (a.m !== b.m) return false;
+  if (a.msgIndex !== b.msgIndex) return false;
+  if (a.virtualized !== b.virtualized) return false;
+  if (a.locale !== b.locale) return false;
+  if (a.projectPath !== b.projectPath) return false;
+  if (a.sessionPathMap !== b.sessionPathMap) return false;
+  if (a.sessionId !== b.sessionId) return false;
+  if (a.showToolChrome !== b.showToolChrome) return false;
+  if (a.toolStepsAutoCollapse !== b.toolStepsAutoCollapse) return false;
+  if (a.showTimestamps !== b.showTimestamps) return false;
+  if (a.messageTimeFormat !== b.messageTimeFormat) return false;
+  if (a.timeTick !== b.timeTick) return false;
+  if (a.showReplyLength !== b.showReplyLength) return false;
+  if (a.lastUserMessageId !== b.lastUserMessageId) return false;
+  if (a.editingUserMessageId !== b.editingUserMessageId) return false;
+  if (a.editSubmitting !== b.editSubmitting) return false;
+  if (a.editAttachments !== b.editAttachments) return false;
+  if (a.canEditLastUser !== b.canEditLastUser) return false;
+  if (a.canRegenerate !== b.canRegenerate) return false;
+  if (a.canRewindSession !== b.canRewindSession) return false;
+  if (a.regenerableAssistantId !== b.regenerableAssistantId) return false;
+  if (a.regenerateModels !== b.regenerateModels) return false;
+  if (a.regenerateModelId !== b.regenerateModelId) return false;
+  if (a.activeAssistantId !== b.activeAssistantId) return false;
+  if (a.liveTool !== b.liveTool) return false;
+  if (a.wovenMessages !== b.wovenMessages) return false;
+  if (a.findQuery !== b.findQuery) return false;
+  if (a.findHitMessageIds !== b.findHitMessageIds) return false;
+  if (a.findActive !== b.findActive) return false;
+  if (a.focusMessageId !== b.focusMessageId) return false;
+  if (a.structuredUsageMessageId !== b.structuredUsageMessageId) return false;
+  if (a.structuredOutputActive !== b.structuredOutputActive) return false;
+  if (a.structuredOutputSchema !== b.structuredOutputSchema) return false;
+  if (a.structuredOutputUsage !== b.structuredOutputUsage) return false;
+  if (a.structuredOutputLabels !== b.structuredOutputLabels) return false;
+  if (a.attachLabels !== b.attachLabels) return false;
+  return true;
+}
+
+const TranscriptMessageRow = memo(function TranscriptMessageRow({
+  m,
+  msgIndex,
+  virtualized,
+  measureRef,
+  locale,
+  tr,
+  projectPath,
+  sessionPathMap,
+  sessionId = null,
+  showToolChrome,
+  toolStepsAutoCollapse,
+  showTimestamps,
+  messageTimeFormat,
+  timeTick: _timeTick,
+  showReplyLength,
+  lastUserMessageId = null,
+  editingUserMessageId = null,
+  editSubmitting = false,
+  editAttachments,
+  canEditLastUser,
+  canRegenerate,
+  canRewindSession,
+  regenerableAssistantId,
+  regenerateModels,
+  regenerateModelId,
+  activeAssistantId,
+  liveTool,
+  wovenMessages,
+  findQuery,
+  findHitMessageIds,
+  findActive,
+  focusMessageId,
+  structuredUsageMessageId,
+  structuredOutputActive,
+  structuredOutputSchema,
+  structuredOutputUsage,
+  structuredOutputLabels,
+  attachLabels,
+  onEditUserMessage,
+  onCancelEditUserMessage,
+  onSubmitEditUserMessage,
+  onRemoveEditAttachment,
+  onRegenerateAssistant,
+  onRewindToUserMessage,
+  onForkFromUserMessage,
+  onOpenResource,
+  onOpenExternalLink,
+  onAddAttachmentToComposer,
+}: TranscriptMessageRowProps) {
+  void _timeTick;
+  const wrap = (node: ReactNode) =>
+    virtualized ? (
+      <div
+        key={m.id}
+        ref={measureRef(msgIndex)}
+        data-virt-index={msgIndex}
+      >
+        {node}
+      </div>
+    ) : (
+      node
+    );
+
+  if (
+    isEndOfTurnMarker(m.marker) ||
+    m.marker === "turn_cancelled" ||
+    (m.role === "tool" &&
+      (m.content?.startsWith("turn_cancelled") ||
+        m.content?.startsWith("turn_end|")))
+  ) {
+    return wrap(
+      <EndOfTurnChip key={m.id} message={m} locale={locale} />,
+    );
+  }
+
+  // Standalone tool_step only when not already woven into an assistant
+  // timeline (tools before first assistant bubble, edge cases).
+  // Conversation filter hides tool chrome entirely.
+  if (isToolStepMessage(m)) {
+    if (!showToolChrome) {
+      return virtualized ? (
+        <div
+          key={m.id}
+          ref={measureRef(msgIndex)}
+          data-virt-index={msgIndex}
+          style={{ height: 0, overflow: "hidden" }}
+          aria-hidden
+        />
+      ) : null;
+    }
+    const tcid =
+      (m.toolCallId || "").trim() ||
+      (m.id.startsWith("tool-") ? m.id.slice(5) : "");
+    // Use woven list — parent `messages` may lag display-layer weave.
+    if (tcid && isToolInlinedInAssistants(wovenMessages, tcid)) {
+      return virtualized ? (
+        <div
+          key={m.id}
+          ref={measureRef(msgIndex)}
+          data-virt-index={msgIndex}
+          style={{ height: 0, overflow: "hidden" }}
+          aria-hidden
+        />
+      ) : null;
+    }
+    const toolSeg = toolSegmentFromMessage(m);
+    if (!toolSeg) {
+      return virtualized ? (
+        <div
+          key={m.id}
+          ref={measureRef(msgIndex)}
+          data-virt-index={msgIndex}
+          style={{ height: 0, overflow: "hidden" }}
+          aria-hidden
+        />
+      ) : null;
+    }
+    return wrap(
+      <div key={m.id} className="lobe-chat-assistant-timeline">
+        <div className="lobe-timeline-rail">
+          <TimelineToolRow
+            tool={toolSeg}
+            autoCollapse={toolStepsAutoCollapse}
+            locale={locale}
+          />
+        </div>
+      </div>,
+    );
+  }
+
+  if (
+    m.marker === "context_compact" ||
+    (m.role === "tool" &&
+      (m.content?.startsWith("context_compact") ||
+        m.compactMeta))
+  ) {
+    const meta = m.compactMeta;
+    const auto = (meta?.trigger || "auto") !== "manual";
+    const title = auto
+      ? tr("compact.bannerAuto")
+      : tr("compact.bannerManual");
+    let detail = "";
+    if (
+      meta?.tokensBefore != null &&
+      meta?.tokensAfter != null &&
+      Number.isFinite(meta.tokensBefore) &&
+      Number.isFinite(meta.tokensAfter)
+    ) {
+      detail = tr("compact.tokensRange", {
+        before: formatTokenCount(meta.tokensBefore, locale),
+        after: formatTokenCount(meta.tokensAfter, locale),
+      });
+    } else if (meta?.note) {
+      detail = meta.note;
+    }
+    const summary = meta?.summaryPreview?.trim();
+    return wrap(
+      <div
+        key={m.id}
+        className="lobe-chat-compact"
+        role="status"
+        data-trigger={meta?.trigger || "auto"}
+      >
+        <span className="lobe-chat-compact__icon" aria-hidden>
+          <IconArrowsMinimize size={15} />
+        </span>
+        <div className="lobe-chat-compact__body">
+          <div className="lobe-chat-compact__title">{title}</div>
+          {detail ? (
+            <div className="lobe-chat-compact__detail">{detail}</div>
+          ) : null}
+          {summary ? (
+            <details className="lobe-chat-compact__summary">
+              <summary>{tr("compact.summaryToggle")}</summary>
+              <p>{summary}</p>
+            </details>
+          ) : null}
+        </div>
+      </div>,
+    );
+  }
+
+  // Generic tool rows (non marker) — keep quiet; no history stack.
+  if (m.role === "tool") {
+    return virtualized ? (
+      <div
+        key={m.id}
+        ref={measureRef(msgIndex)}
+        data-virt-index={msgIndex}
+        style={{ height: 0, overflow: "hidden" }}
+        aria-hidden
+      />
+    ) : null;
+  }
+
+  if (m.role === "user") {
+    const isInterjection = m.marker === "interjection";
+    const isLastUser = !isInterjection && lastUserMessageId === m.id;
+    const isEditing = editingUserMessageId === m.id;
+    const timeLabel =
+      showTimestamps && m.createdAt
+        ? messageTimeFormat === "relative"
+          ? formatRelativeTime(m.createdAt, locale)
+          : formatMessageTime(m.createdAt, locale)
+        : null;
+    const isFindHit = !!findHitMessageIds?.has(m.id);
+    const isFindCurrent = findActive?.messageId === m.id;
+    const isNodeFocus = focusMessageId === m.id;
+    return wrap(
+      <ChatItem
+        key={m.id}
+        id={m.id}
+        placement="right"
+        showAvatar={false}
+        showTitle={false}
+        className={
+          (isFindHit ? " lobe-chat-item--find-hit" : "") +
+          (isFindCurrent ? " lobe-chat-item--find-current" : "") +
+          (isNodeFocus ? " lobe-chat-item--node-focus" : "")
+        }
+        message={
+          <div
+            className={
+              "lobe-chat-user-stack" +
+              (isEditing ? " lobe-chat-user-stack--editing" : "")
+            }
+          >
+            {/* Read-only attachments above bubble; edit mode reloads them inside the form */}
+            {!isEditing &&
+            m.attachments &&
+            m.attachments.length > 0 ? (
+              <div className="lobe-chat-atts lobe-chat-atts--user">
+                {m.attachments.map((a) => (
+                  <AttachmentCard
+                    key={a.path}
+                    attachment={a}
+                    variant="card"
+                    labels={attachLabels}
+                    galleryPaths={m.attachments
+                      ?.filter((x) => !x.isDir && isImagePath(x.path))
+                      .map((x) => x.path)}
+                    onAddToComposer={onAddAttachmentToComposer}
+                  />
+                ))}
+              </div>
+            ) : null}
+            {isEditing ? (
+              <InlineUserEdit
+                content={m.content}
+                attachments={editAttachments}
+                attachLabels={attachLabels}
+                busy={editSubmitting}
+                cancelLabel={tr("message.editCancel")}
+                resendLabel={tr("message.editResend")}
+                placeholder={tr("message.editPlaceholder")}
+                onCancel={() => onCancelEditUserMessage?.()}
+                onSubmit={(stored) =>
+                  onSubmitEditUserMessage?.(m, stored)
+                }
+                onRemoveAttachment={onRemoveEditAttachment}
+              />
+            ) : m.content.trim() ? (
+              <div
+                className={
+                  "lobe-chat-bubble" +
+                  (isInterjection
+                    ? " lobe-chat-bubble--interjection"
+                    : "")
+                }
+                data-message-marker={m.marker}
+              >
+                {isInterjection ? (
+                  <div className="lobe-chat-interjection-tag">
+                    <IconTarget size={12} aria-hidden />
+                    <span>{tr("message.interjectionTag")}</span>
+                  </div>
+                ) : null}
+                <UserMessageBody
+                  content={m.content}
+                  scheduledLabel={tr("automations.msgTag")}
+                  remoteImLabel={tr("remoteIm.msgTag")}
+                  locale={locale}
+                  findQuery={findQuery}
+                  findActiveOccurrence={
+                    isFindCurrent
+                      ? (findActive?.occurrence ?? null)
+                      : null
+                  }
+                />
+              </div>
+            ) : null}
+          </div>
+        }
+        actions={
+          isEditing ? null : (
+            <>
+              {timeLabel ? (
+                <span className="lobe-chat-action-time">
+                  {timeLabel}
+                </span>
+              ) : null}
+              {m.content.trim() ? (
+                <MessageCopyButton
+                  text={m.content}
+                  copyLabel={tr("message.copy")}
+                  copiedLabel={tr("message.copied")}
+                />
+              ) : null}
+              {sessionId
+                ? (() => {
+                    const link = formatMessageDeepLink(
+                      sessionId,
+                      m.id,
+                    );
+                    if (!link) return null;
+                    return (
+                      <MessageCopyButton
+                        text={link}
+                        copyLabel={tr("message.copyLink")}
+                        copiedLabel={tr("message.linkCopied")}
+                        idleIcon={<IconLink size={15} />}
+                      />
+                    );
+                  })()
+                : null}
+              {isLastUser ? (
+                <MessageActionButton
+                  label={tr("message.edit")}
+                  disabled={!canEditLastUser}
+                  onClick={() => {
+                    if (!canEditLastUser) return;
+                    onEditUserMessage?.(m);
+                  }}
+                >
+                  <IconRename size={15} />
+                </MessageActionButton>
+              ) : null}
+              {onRewindToUserMessage && !isInterjection ? (
+                <MessageActionButton
+                  label={tr("message.rewindHere")}
+                  disabled={!canRewindSession}
+                  onClick={() => {
+                    if (!canRewindSession) return;
+                    onRewindToUserMessage(m);
+                  }}
+                >
+                  <IconRewind size={15} />
+                </MessageActionButton>
+              ) : null}
+              {onForkFromUserMessage && !isInterjection ? (
+                <MessageActionButton
+                  label={tr("message.forkHere")}
+                  disabled={!canRewindSession}
+                  onClick={() => {
+                    if (!canRewindSession) return;
+                    onForkFromUserMessage(m);
+                  }}
+                >
+                  <IconFork size={15} />
+                </MessageActionButton>
+              ) : null}
+            </>
+          )
+        }
+      />,
+    );
+  }
+
+  if (m.isError) {
+    const friendly = formatTurnErrorBody(
+      { content: m.content, code: undefined, message: undefined },
+      locale === "en" ? "en" : "zh",
+    );
+    const isFindHit = !!findHitMessageIds?.has(m.id);
+    const isFindCurrent = findActive?.messageId === m.id;
+    const isNodeFocus = focusMessageId === m.id;
+    const canRegenError =
+      !!onRegenerateAssistant && regenerableAssistantId === m.id;
+    // Codex-style soft notice — muted pill, no red box.
+    return wrap(
+      <div
+        key={m.id}
+        className={
+          "lobe-chat-error" +
+          (isFindHit ? " lobe-chat-item--find-hit" : "") +
+          (isFindCurrent ? " lobe-chat-item--find-current" : "") +
+          (isNodeFocus ? " lobe-chat-item--node-focus" : "")
+        }
+        role="status"
+        data-testid="chat-turn-error"
+        data-message-id={m.id}
+      >
+        <div className="lobe-chat-error__pill">
+          <span className="lobe-chat-error__icon" aria-hidden>
+            ℹ
+          </span>
+          <span className="lobe-chat-error__text">
+            {findQuery.trim() ? (
+              <HighlightedText
+                text={friendly}
+                query={findQuery}
+                activeOccurrence={
+                  isFindCurrent
+                    ? (findActive?.occurrence ?? null)
+                    : null
+                }
+              />
+            ) : (
+              friendly
+            )}
+          </span>
+          {canRegenError ? (
+            <span className="lobe-chat-error__actions">
+              <MessageRegenerateButton
+                label={tr("message.regenerate")}
+                sameModelLabel={tr("message.regenerateSameModel")}
+                pickModelLabel={tr("message.regeneratePickModel")}
+                disabled={!canRegenerate}
+                models={regenerateModels}
+                currentModelId={regenerateModelId}
+                iconSize={14}
+                onRegenerate={(modelId) => {
+                  if (!canRegenerate) return;
+                  onRegenerateAssistant?.(
+                    m,
+                    modelId ? { modelId } : undefined,
+                  );
+                }}
+              />
+            </span>
+          ) : null}
+        </div>
+      </div>,
+    );
+  }
+
+  // Assistant — thought / tool / body in true stream order.
+  const segs = messageSegments(m);
+  const isActiveAssistant = activeAssistantId === m.id;
+  const hasInlinedRunningTool = segs.some(
+    (s) => s.kind === "tool" && toolSegmentIsRunning(s),
+  );
+  // Fallback live line only when tool not yet woven into segments.
+  // Conversation filter hides tool chrome (including live tool text).
+  const showLiveToolBelow =
+    showToolChrome &&
+    !!liveTool &&
+    isActiveAssistant &&
+    !hasInlinedRunningTool;
+  const showThinkingPlaceholder =
+    !!m.streaming &&
+    segs.length === 0 &&
+    !showLiveToolBelow;
+
+  const contentSegCount = segs.filter((s) => s.kind === "content")
+    .length;
+  let lastContentSi = -1;
+  for (let i = segs.length - 1; i >= 0; i--) {
+    if (segs[i]!.kind === "content") {
+      lastContentSi = i;
+      break;
+    }
+  }
+
+  const isFindHit = !!findHitMessageIds?.has(m.id);
+  const isFindCurrent = findActive?.messageId === m.id;
+  const isNodeFocus = focusMessageId === m.id;
+  // Phase projection: thought+tools collapse when phase ends (content
+  // / next thought), not only when the full answer is done.
+  const timelineUnits = buildTimelineUnits(segs, {
+    streaming: !!m.streaming,
+  });
+
+  return wrap(
+    <ChatItem
+      key={m.id}
+      id={m.id}
+      placement="left"
+      showAvatar={false}
+      loading={!!m.streaming}
+      className={
+        (isFindHit ? " lobe-chat-item--find-hit" : "") +
+        (isFindCurrent ? " lobe-chat-item--find-current" : "") +
+        (isNodeFocus ? " lobe-chat-item--node-focus" : "")
+      }
+      message={
+        <div
+          className="lobe-chat-assistant-timeline"
+          aria-busy={m.streaming ? true : undefined}
+          aria-live={m.streaming ? "polite" : undefined}
+          data-find-assistant={isFindCurrent ? "current" : undefined}
+        >
+          {showThinkingPlaceholder ? (
+            <Thinking
+              locale={locale}
+              thinking
+              streamingLabel={tr("chat.thinkingLabel")}
+              doneLabel={tr("chat.thoughtDone")}
+              thoughtForLabel={(n) => tr("chat.thoughtFor", { n })}
+            />
+          ) : null}
+          {(() => {
+            // Running occurrence base across content segments so
+            // find marks stay aligned with message-level match index.
+            let contentOccBase = 0;
+            return timelineUnits.map((unit) => {
+              if (unit.kind === "phase") {
+                // Always paint Grok Worked-for rail (tools + thought steps).
+                // “Conversation only” only hides standalone tool_step rows,
+                // not this official activity summary.
+                return (
+                  <TimelinePhaseBlock
+                    key={`${m.id}-${unit.id}`}
+                    phase={unit}
+                    locale={locale}
+                    messageStreaming={!!m.streaming}
+                    autoCollapse={toolStepsAutoCollapse}
+                    historyTimestamps={[
+                      m.createdAt,
+                      ...unit.tools.map((t) => t.createdAt),
+                    ]}
+                  />
+                );
+              }
+              if (unit.kind === "tool") {
+                // Bare tool outside a phase — respect hide-tools filter.
+                if (!showToolChrome) return null;
+                return (
+                  <div
+                    key={`${m.id}-tool-${unit.tool.toolCallId || unit.si}`}
+                    className="lobe-timeline-rail"
+                  >
+                    <TimelineToolRow
+                      tool={unit.tool}
+                      autoCollapse={toolStepsAutoCollapse}
+                      locale={locale}
+                    />
+                  </div>
+                );
+              }
+              // Adjacent bare thoughts are coalesced into thought-group.
+              if (
+                unit.kind === "thought" ||
+                unit.kind === "thought-group"
+              ) {
+                const texts =
+                  unit.kind === "thought-group"
+                    ? unit.texts
+                    : [unit.text];
+                const joined = texts
+                  .map((t) => t.trim())
+                  .filter(Boolean)
+                  .join("\n\n");
+                const streaming = unit.streaming;
+                if (
+                  !joined &&
+                  !(m.streaming && streaming)
+                ) {
+                  return null;
+                }
+                return (
+                  <div
+                    key={`${m.id}-th-${unit.si}`}
+                    className="lobe-timeline-rail"
+                  >
+                    <Thinking
+                      locale={locale}
+                      thinking={streaming}
+                      content={joined}
+                      streamingLabel={tr("chat.thinkingLabel")}
+                      doneLabel={tr("chat.thoughtDone")}
+                      thoughtForLabel={(n) =>
+                        tr("chat.thoughtFor", { n })
+                      }
+                      onOpenExternalLink={onOpenExternalLink}
+                    />
+                  </div>
+                );
+              }
+              // content — never folded into a work phase
+              const segBase = contentOccBase;
+              if (findQuery.trim()) {
+                contentOccBase += findChatMatches(findQuery, [
+                  {
+                    id: `${m.id}-seg-${unit.si}`,
+                    role: "assistant",
+                    content: unit.text,
+                  },
+                ]).length;
+              }
+              return (
+                <AssistantMessageBody
+                  key={`${m.id}-c-${unit.si}`}
+                  content={unit.text}
+                  attachments={
+                    unit.si === lastContentSi
+                      ? m.attachments
+                      : undefined
+                  }
+                  streaming={unit.streaming}
+                  locale={locale}
+                  projectPath={projectPath}
+                  sessionPathMap={sessionPathMap}
+                  onOpenResource={onOpenResource}
+                  onOpenExternalLink={onOpenExternalLink}
+                  onAddAttachmentToComposer={
+                    onAddAttachmentToComposer
+                  }
+                  attachLabels={attachLabels}
+                  findQuery={findQuery}
+                  findActiveOccurrence={
+                    isFindCurrent
+                      ? (findActive?.occurrence ?? null)
+                      : null
+                  }
+                  findOccurrenceBase={segBase}
+                />
+              );
+            });
+          })()}
+          {/* Body-less turn with only attachments */}
+          {!contentSegCount && m.attachments?.length ? (
+            <AssistantMessageBody
+              content=""
+              attachments={m.attachments}
+              streaming={!!m.streaming}
+              locale={locale}
+              projectPath={projectPath}
+              sessionPathMap={sessionPathMap}
+              onOpenResource={onOpenResource}
+              onOpenExternalLink={onOpenExternalLink}
+              onAddAttachmentToComposer={onAddAttachmentToComposer}
+              attachLabels={attachLabels}
+              findQuery={findQuery}
+              findActiveOccurrence={
+                isFindCurrent
+                  ? (findActive?.occurrence ?? null)
+                  : null
+              }
+            />
+          ) : null}
+          {structuredOutputActive &&
+          structuredOutputLabels &&
+          (m.streaming || !!m.content.trim()) ? (
+            <StructuredJsonPanel
+              content={m.content}
+              schemaText={structuredOutputSchema}
+              labels={structuredOutputLabels}
+              streaming={!!m.streaming}
+              usage={
+                m.id === structuredUsageMessageId
+                  ? structuredOutputUsage
+                  : null
+              }
+            />
+          ) : null}
+          {(() => {
+            if (m.streaming || !showReplyLength) return null;
+            const stats = computeMessageLength(m.content);
+            if (stats.empty) return null;
+            const words = String(stats.words);
+            const chars = String(stats.chars);
+            return (
+              <div
+                className="lobe-chat-reply-length"
+                aria-label={tr("message.replyLengthAria", {
+                  words,
+                  chars,
+                })}
+              >
+                {tr("message.replyLength", { words, chars })}
+              </div>
+            );
+          })()}
+        </div>
+      }
+      belowMessage={
+        showLiveToolBelow && liveTool ? (
+          <LiveToolText message={liveTool} locale={locale} />
+        ) : null
+      }
+      actions={(() => {
+        if (m.streaming) return null;
+        const showCopy = !!m.content.trim();
+        const showRegen =
+          !!onRegenerateAssistant && regenerableAssistantId === m.id;
+        if (!showCopy && !showRegen) return null;
+        const deepLink =
+          sessionId != null
+            ? formatMessageDeepLink(sessionId, m.id)
+            : "";
+        const showCopyLink = !!deepLink;
+        if (!showCopy && !showRegen && !showCopyLink) return null;
+        return (
+          <>
+            {showCopy ? (
+              <>
+                <MessageCopyButton
+                  text={m.content}
+                  copyLabel={tr("message.copy")}
+                  copiedLabel={tr("message.copied")}
+                />
+                <MessageActionButton
+                  label={tr("message.exportMd")}
+                  onClick={() => {
+                    const blob = new Blob([m.content], {
+                      type: "text/markdown;charset=utf-8",
+                    });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement("a");
+                    a.href = url;
+                    a.download = `grok-${m.id.slice(0, 8)}.md`;
+                    a.click();
+                    URL.revokeObjectURL(url);
+                  }}
+                >
+                  <IconExportMd size={15} />
+                </MessageActionButton>
+              </>
+            ) : null}
+            {showCopyLink ? (
+              <MessageCopyButton
+                text={deepLink}
+                copyLabel={tr("message.copyLink")}
+                copiedLabel={tr("message.linkCopied")}
+                idleIcon={<IconLink size={15} />}
+              />
+            ) : null}
+            {showRegen ? (
+              <MessageRegenerateButton
+                label={tr("message.regenerate")}
+                sameModelLabel={tr("message.regenerateSameModel")}
+                pickModelLabel={tr("message.regeneratePickModel")}
+                disabled={!canRegenerate}
+                models={regenerateModels}
+                currentModelId={regenerateModelId}
+                onRegenerate={(modelId) => {
+                  if (!canRegenerate) return;
+                  onRegenerateAssistant?.(
+                    m,
+                    modelId ? { modelId } : undefined,
+                  );
+                }}
+              />
+            ) : null}
+          </>
+        );
+      })()}
+    />,
+  );
+}, transcriptRowPropsEqual);
 
 export function ConversationThread({
   locale,
@@ -985,10 +1862,7 @@ export function ConversationThread({
    * Map short path tokens → absolute using tool_step abs paths in this session.
    * Fixes homonyms like many `04-正文/正文.md` under article roots.
    */
-  const sessionPathMap = useMemo(
-    () => buildSessionFilePathMap(messages, projectPath),
-    [messages, projectPath],
-  );
+  const sessionPathMap = useStableSessionPathMap(messages, projectPath);
 
   // Quiet thinking when busy, no tool motion, no assistant yet.
   const showQuietThinking =
@@ -1169,708 +2043,59 @@ export function ConversationThread({
             />
           ) : null}
 
-          {visibleMessages.map(({ m, index: msgIndex }) => {
-            const wrap = (node: ReactNode) =>
-              virtualized ? (
-                <div
-                  key={m.id}
-                  ref={measureRef(msgIndex)}
-                  data-virt-index={msgIndex}
-                >
-                  {node}
-                </div>
-              ) : (
-                node
-              );
-
-            if (
-              isEndOfTurnMarker(m.marker) ||
-              m.marker === "turn_cancelled" ||
-              (m.role === "tool" &&
-                (m.content?.startsWith("turn_cancelled") ||
-                  m.content?.startsWith("turn_end|")))
-            ) {
-              return wrap(
-                <EndOfTurnChip key={m.id} message={m} locale={locale} />,
-              );
-            }
-
-            // Standalone tool_step only when not already woven into an assistant
-            // timeline (tools before first assistant bubble, edge cases).
-            // Conversation filter hides tool chrome entirely.
-            if (isToolStepMessage(m)) {
-              if (!showToolChrome) {
-                return virtualized ? (
-                  <div
-                    key={m.id}
-                    ref={measureRef(msgIndex)}
-                    data-virt-index={msgIndex}
-                    style={{ height: 0, overflow: "hidden" }}
-                    aria-hidden
-                  />
-                ) : null;
-              }
-              const tcid =
-                (m.toolCallId || "").trim() ||
-                (m.id.startsWith("tool-") ? m.id.slice(5) : "");
-              // Use woven list — parent `messages` may lag display-layer weave.
-              if (tcid && isToolInlinedInAssistants(wovenMessages, tcid)) {
-                return virtualized ? (
-                  <div
-                    key={m.id}
-                    ref={measureRef(msgIndex)}
-                    data-virt-index={msgIndex}
-                    style={{ height: 0, overflow: "hidden" }}
-                    aria-hidden
-                  />
-                ) : null;
-              }
-              const toolSeg = toolSegmentFromMessage(m);
-              if (!toolSeg) {
-                return virtualized ? (
-                  <div
-                    key={m.id}
-                    ref={measureRef(msgIndex)}
-                    data-virt-index={msgIndex}
-                    style={{ height: 0, overflow: "hidden" }}
-                    aria-hidden
-                  />
-                ) : null;
-              }
-              return wrap(
-                <div key={m.id} className="lobe-chat-assistant-timeline">
-                  <div className="lobe-timeline-rail">
-                    <TimelineToolRow
-                      tool={toolSeg}
-                      autoCollapse={toolStepsAutoCollapse}
-                      locale={locale}
-                    />
-                  </div>
-                </div>,
-              );
-            }
-
-            if (
-              m.marker === "context_compact" ||
-              (m.role === "tool" &&
-                (m.content?.startsWith("context_compact") ||
-                  m.compactMeta))
-            ) {
-              const meta = m.compactMeta;
-              const auto = (meta?.trigger || "auto") !== "manual";
-              const title = auto
-                ? tr("compact.bannerAuto")
-                : tr("compact.bannerManual");
-              let detail = "";
-              if (
-                meta?.tokensBefore != null &&
-                meta?.tokensAfter != null &&
-                Number.isFinite(meta.tokensBefore) &&
-                Number.isFinite(meta.tokensAfter)
-              ) {
-                detail = tr("compact.tokensRange", {
-                  before: formatTokenCount(meta.tokensBefore, locale),
-                  after: formatTokenCount(meta.tokensAfter, locale),
-                });
-              } else if (meta?.note) {
-                detail = meta.note;
-              }
-              const summary = meta?.summaryPreview?.trim();
-              return wrap(
-                <div
-                  key={m.id}
-                  className="lobe-chat-compact"
-                  role="status"
-                  data-trigger={meta?.trigger || "auto"}
-                >
-                  <span className="lobe-chat-compact__icon" aria-hidden>
-                    <IconArrowsMinimize size={15} />
-                  </span>
-                  <div className="lobe-chat-compact__body">
-                    <div className="lobe-chat-compact__title">{title}</div>
-                    {detail ? (
-                      <div className="lobe-chat-compact__detail">{detail}</div>
-                    ) : null}
-                    {summary ? (
-                      <details className="lobe-chat-compact__summary">
-                        <summary>{tr("compact.summaryToggle")}</summary>
-                        <p>{summary}</p>
-                      </details>
-                    ) : null}
-                  </div>
-                </div>,
-              );
-            }
-
-            // Generic tool rows (non marker) — keep quiet; no history stack.
-            if (m.role === "tool") {
-              return virtualized ? (
-                <div
-                  key={m.id}
-                  ref={measureRef(msgIndex)}
-                  data-virt-index={msgIndex}
-                  style={{ height: 0, overflow: "hidden" }}
-                  aria-hidden
-                />
-              ) : null;
-            }
-
-            if (m.role === "user") {
-              const isInterjection = m.marker === "interjection";
-              const isLastUser = !isInterjection && lastUserMessageId === m.id;
-              const isEditing = editingUserMessageId === m.id;
-              const timeLabel =
-                showTimestamps && m.createdAt
-                  ? messageTimeFormat === "relative"
-                    ? formatRelativeTime(m.createdAt, locale)
-                    : formatMessageTime(m.createdAt, locale)
-                  : null;
-              const isFindHit = !!findHitMessageIds?.has(m.id);
-              const isFindCurrent = findActive?.messageId === m.id;
-              const isNodeFocus = focusMessageId === m.id;
-              return wrap(
-                <ChatItem
-                  key={m.id}
-                  id={m.id}
-                  placement="right"
-                  showAvatar={false}
-                  showTitle={false}
-                  className={
-                    (isFindHit ? " lobe-chat-item--find-hit" : "") +
-                    (isFindCurrent ? " lobe-chat-item--find-current" : "") +
-                    (isNodeFocus ? " lobe-chat-item--node-focus" : "")
-                  }
-                  message={
-                    <div
-                      className={
-                        "lobe-chat-user-stack" +
-                        (isEditing ? " lobe-chat-user-stack--editing" : "")
-                      }
-                    >
-                      {/* Read-only attachments above bubble; edit mode reloads them inside the form */}
-                      {!isEditing &&
-                      m.attachments &&
-                      m.attachments.length > 0 ? (
-                        <div className="lobe-chat-atts lobe-chat-atts--user">
-                          {m.attachments.map((a) => (
-                            <AttachmentCard
-                              key={a.path}
-                              attachment={a}
-                              variant="card"
-                              labels={attachLabels}
-                              galleryPaths={m.attachments
-                                ?.filter((x) => !x.isDir && isImagePath(x.path))
-                                .map((x) => x.path)}
-                              onAddToComposer={onAddAttachmentToComposer}
-                            />
-                          ))}
-                        </div>
-                      ) : null}
-                      {isEditing ? (
-                        <InlineUserEdit
-                          content={m.content}
-                          attachments={editAttachments}
-                          attachLabels={attachLabels}
-                          busy={editSubmitting}
-                          cancelLabel={tr("message.editCancel")}
-                          resendLabel={tr("message.editResend")}
-                          placeholder={tr("message.editPlaceholder")}
-                          onCancel={() => onCancelEditUserMessage?.()}
-                          onSubmit={(stored) =>
-                            onSubmitEditUserMessage?.(m, stored)
-                          }
-                          onRemoveAttachment={onRemoveEditAttachment}
-                        />
-                      ) : m.content.trim() ? (
-                        <div
-                          className={
-                            "lobe-chat-bubble" +
-                            (isInterjection
-                              ? " lobe-chat-bubble--interjection"
-                              : "")
-                          }
-                          data-message-marker={m.marker}
-                        >
-                          {isInterjection ? (
-                            <div className="lobe-chat-interjection-tag">
-                              <IconTarget size={12} aria-hidden />
-                              <span>{tr("message.interjectionTag")}</span>
-                            </div>
-                          ) : null}
-                          <UserMessageBody
-                            content={m.content}
-                            scheduledLabel={tr("automations.msgTag")}
-                            remoteImLabel={tr("remoteIm.msgTag")}
-                            locale={locale}
-                            findQuery={findQuery}
-                            findActiveOccurrence={
-                              isFindCurrent
-                                ? (findActive?.occurrence ?? null)
-                                : null
-                            }
-                          />
-                        </div>
-                      ) : null}
-                    </div>
-                  }
-                  actions={
-                    isEditing ? null : (
-                      <>
-                        {timeLabel ? (
-                          <span className="lobe-chat-action-time">
-                            {timeLabel}
-                          </span>
-                        ) : null}
-                        {m.content.trim() ? (
-                          <MessageCopyButton
-                            text={m.content}
-                            copyLabel={tr("message.copy")}
-                            copiedLabel={tr("message.copied")}
-                          />
-                        ) : null}
-                        {sessionId
-                          ? (() => {
-                              const link = formatMessageDeepLink(
-                                sessionId,
-                                m.id,
-                              );
-                              if (!link) return null;
-                              return (
-                                <MessageCopyButton
-                                  text={link}
-                                  copyLabel={tr("message.copyLink")}
-                                  copiedLabel={tr("message.linkCopied")}
-                                  idleIcon={<IconLink size={15} />}
-                                />
-                              );
-                            })()
-                          : null}
-                        {isLastUser ? (
-                          <MessageActionButton
-                            label={tr("message.edit")}
-                            disabled={!canEditLastUser}
-                            onClick={() => {
-                              if (!canEditLastUser) return;
-                              onEditUserMessage?.(m);
-                            }}
-                          >
-                            <IconRename size={15} />
-                          </MessageActionButton>
-                        ) : null}
-                        {onRewindToUserMessage && !isInterjection ? (
-                          <MessageActionButton
-                            label={tr("message.rewindHere")}
-                            disabled={!canRewindSession}
-                            onClick={() => {
-                              if (!canRewindSession) return;
-                              onRewindToUserMessage(m);
-                            }}
-                          >
-                            <IconRewind size={15} />
-                          </MessageActionButton>
-                        ) : null}
-                        {onForkFromUserMessage && !isInterjection ? (
-                          <MessageActionButton
-                            label={tr("message.forkHere")}
-                            disabled={!canRewindSession}
-                            onClick={() => {
-                              if (!canRewindSession) return;
-                              onForkFromUserMessage(m);
-                            }}
-                          >
-                            <IconFork size={15} />
-                          </MessageActionButton>
-                        ) : null}
-                      </>
-                    )
-                  }
-                />,
-              );
-            }
-
-            if (m.isError) {
-              const friendly = formatTurnErrorBody(
-                { content: m.content, code: undefined, message: undefined },
-                locale === "en" ? "en" : "zh",
-              );
-              const isFindHit = !!findHitMessageIds?.has(m.id);
-              const isFindCurrent = findActive?.messageId === m.id;
-              const isNodeFocus = focusMessageId === m.id;
-              const canRegenError =
-                !!onRegenerateAssistant && regenerableAssistantId === m.id;
-              // Codex-style soft notice — muted pill, no red box.
-              return wrap(
-                <div
-                  key={m.id}
-                  className={
-                    "lobe-chat-error" +
-                    (isFindHit ? " lobe-chat-item--find-hit" : "") +
-                    (isFindCurrent ? " lobe-chat-item--find-current" : "") +
-                    (isNodeFocus ? " lobe-chat-item--node-focus" : "")
-                  }
-                  role="status"
-                  data-testid="chat-turn-error"
-                  data-message-id={m.id}
-                >
-                  <div className="lobe-chat-error__pill">
-                    <span className="lobe-chat-error__icon" aria-hidden>
-                      ℹ
-                    </span>
-                    <span className="lobe-chat-error__text">
-                      {findQuery.trim() ? (
-                        <HighlightedText
-                          text={friendly}
-                          query={findQuery}
-                          activeOccurrence={
-                            isFindCurrent
-                              ? (findActive?.occurrence ?? null)
-                              : null
-                          }
-                        />
-                      ) : (
-                        friendly
-                      )}
-                    </span>
-                    {canRegenError ? (
-                      <span className="lobe-chat-error__actions">
-                        <MessageRegenerateButton
-                          label={tr("message.regenerate")}
-                          sameModelLabel={tr("message.regenerateSameModel")}
-                          pickModelLabel={tr("message.regeneratePickModel")}
-                          disabled={!canRegenerate}
-                          models={regenerateModels}
-                          currentModelId={regenerateModelId}
-                          iconSize={14}
-                          onRegenerate={(modelId) => {
-                            if (!canRegenerate) return;
-                            onRegenerateAssistant?.(
-                              m,
-                              modelId ? { modelId } : undefined,
-                            );
-                          }}
-                        />
-                      </span>
-                    ) : null}
-                  </div>
-                </div>,
-              );
-            }
-
-            // Assistant — thought / tool / body in true stream order.
-            const segs = messageSegments(m);
-            const isActiveAssistant = activeAssistantId === m.id;
-            const hasInlinedRunningTool = segs.some(
-              (s) => s.kind === "tool" && toolSegmentIsRunning(s),
-            );
-            // Fallback live line only when tool not yet woven into segments.
-            // Conversation filter hides tool chrome (including live tool text).
-            const showLiveToolBelow =
-              showToolChrome &&
-              !!liveTool &&
-              isActiveAssistant &&
-              !hasInlinedRunningTool;
-            const showThinkingPlaceholder =
-              !!m.streaming &&
-              segs.length === 0 &&
-              !showLiveToolBelow;
-
-            const contentSegCount = segs.filter((s) => s.kind === "content")
-              .length;
-            let lastContentSi = -1;
-            for (let i = segs.length - 1; i >= 0; i--) {
-              if (segs[i]!.kind === "content") {
-                lastContentSi = i;
-                break;
-              }
-            }
-
-            const isFindHit = !!findHitMessageIds?.has(m.id);
-            const isFindCurrent = findActive?.messageId === m.id;
-            const isNodeFocus = focusMessageId === m.id;
-            // Phase projection: thought+tools collapse when phase ends (content
-            // / next thought), not only when the full answer is done.
-            const timelineUnits = buildTimelineUnits(segs, {
-              streaming: !!m.streaming,
-            });
-
-            return wrap(
-              <ChatItem
-                key={m.id}
-                id={m.id}
-                placement="left"
-                showAvatar={false}
-                loading={!!m.streaming}
-                className={
-                  (isFindHit ? " lobe-chat-item--find-hit" : "") +
-                  (isFindCurrent ? " lobe-chat-item--find-current" : "") +
-                  (isNodeFocus ? " lobe-chat-item--node-focus" : "")
-                }
-                message={
-                  <div
-                    className="lobe-chat-assistant-timeline"
-                    aria-busy={m.streaming ? true : undefined}
-                    aria-live={m.streaming ? "polite" : undefined}
-                    data-find-assistant={isFindCurrent ? "current" : undefined}
-                  >
-                    {showThinkingPlaceholder ? (
-                      <Thinking
-                        locale={locale}
-                        thinking
-                        streamingLabel={tr("chat.thinkingLabel")}
-                        doneLabel={tr("chat.thoughtDone")}
-                        thoughtForLabel={(n) => tr("chat.thoughtFor", { n })}
-                      />
-                    ) : null}
-                    {(() => {
-                      // Running occurrence base across content segments so
-                      // find marks stay aligned with message-level match index.
-                      let contentOccBase = 0;
-                      return timelineUnits.map((unit) => {
-                        if (unit.kind === "phase") {
-                          // Always paint Grok Worked-for rail (tools + thought steps).
-                          // “Conversation only” only hides standalone tool_step rows,
-                          // not this official activity summary.
-                          return (
-                            <TimelinePhaseBlock
-                              key={`${m.id}-${unit.id}`}
-                              phase={unit}
-                              locale={locale}
-                              messageStreaming={!!m.streaming}
-                              autoCollapse={toolStepsAutoCollapse}
-                              historyTimestamps={[
-                                m.createdAt,
-                                ...unit.tools.map((t) => t.createdAt),
-                              ]}
-                            />
-                          );
-                        }
-                        if (unit.kind === "tool") {
-                          // Bare tool outside a phase — respect hide-tools filter.
-                          if (!showToolChrome) return null;
-                          return (
-                            <div
-                              key={`${m.id}-tool-${unit.tool.toolCallId || unit.si}`}
-                              className="lobe-timeline-rail"
-                            >
-                              <TimelineToolRow
-                                tool={unit.tool}
-                                autoCollapse={toolStepsAutoCollapse}
-                                locale={locale}
-                              />
-                            </div>
-                          );
-                        }
-                        // Adjacent bare thoughts are coalesced into thought-group.
-                        if (
-                          unit.kind === "thought" ||
-                          unit.kind === "thought-group"
-                        ) {
-                          const texts =
-                            unit.kind === "thought-group"
-                              ? unit.texts
-                              : [unit.text];
-                          const joined = texts
-                            .map((t) => t.trim())
-                            .filter(Boolean)
-                            .join("\n\n");
-                          const streaming = unit.streaming;
-                          if (
-                            !joined &&
-                            !(m.streaming && streaming)
-                          ) {
-                            return null;
-                          }
-                          return (
-                            <div
-                              key={`${m.id}-th-${unit.si}`}
-                              className="lobe-timeline-rail"
-                            >
-                              <Thinking
-                                locale={locale}
-                                thinking={streaming}
-                                content={joined}
-                                streamingLabel={tr("chat.thinkingLabel")}
-                                doneLabel={tr("chat.thoughtDone")}
-                                thoughtForLabel={(n) =>
-                                  tr("chat.thoughtFor", { n })
-                                }
-                                onOpenExternalLink={onOpenExternalLink}
-                              />
-                            </div>
-                          );
-                        }
-                        // content — never folded into a work phase
-                        const segBase = contentOccBase;
-                        if (findQuery.trim()) {
-                          contentOccBase += findChatMatches(findQuery, [
-                            {
-                              id: `${m.id}-seg-${unit.si}`,
-                              role: "assistant",
-                              content: unit.text,
-                            },
-                          ]).length;
-                        }
-                        return (
-                          <AssistantMessageBody
-                            key={`${m.id}-c-${unit.si}`}
-                            content={unit.text}
-                            attachments={
-                              unit.si === lastContentSi
-                                ? m.attachments
-                                : undefined
-                            }
-                            streaming={unit.streaming}
-                            locale={locale}
-                            projectPath={projectPath}
-                            sessionPathMap={sessionPathMap}
-                            onOpenResource={onOpenResource}
-                            onOpenExternalLink={onOpenExternalLink}
-                            onAddAttachmentToComposer={
-                              onAddAttachmentToComposer
-                            }
-                            attachLabels={attachLabels}
-                            findQuery={findQuery}
-                            findActiveOccurrence={
-                              isFindCurrent
-                                ? (findActive?.occurrence ?? null)
-                                : null
-                            }
-                            findOccurrenceBase={segBase}
-                          />
-                        );
-                      });
-                    })()}
-                    {/* Body-less turn with only attachments */}
-                    {!contentSegCount && m.attachments?.length ? (
-                      <AssistantMessageBody
-                        content=""
-                        attachments={m.attachments}
-                        streaming={!!m.streaming}
-                        locale={locale}
-                        projectPath={projectPath}
-                        sessionPathMap={sessionPathMap}
-                        onOpenResource={onOpenResource}
-                        onOpenExternalLink={onOpenExternalLink}
-                        onAddAttachmentToComposer={onAddAttachmentToComposer}
-                        attachLabels={attachLabels}
-                        findQuery={findQuery}
-                        findActiveOccurrence={
-                          isFindCurrent
-                            ? (findActive?.occurrence ?? null)
-                            : null
-                        }
-                      />
-                    ) : null}
-                    {structuredOutputActive &&
-                    structuredOutputLabels &&
-                    (m.streaming || !!m.content.trim()) ? (
-                      <StructuredJsonPanel
-                        content={m.content}
-                        schemaText={structuredOutputSchema}
-                        labels={structuredOutputLabels}
-                        streaming={!!m.streaming}
-                        usage={
-                          m.id === structuredUsageMessageId
-                            ? structuredOutputUsage
-                            : null
-                        }
-                      />
-                    ) : null}
-                    {(() => {
-                      if (m.streaming || !showReplyLength) return null;
-                      const stats = computeMessageLength(m.content);
-                      if (stats.empty) return null;
-                      const words = String(stats.words);
-                      const chars = String(stats.chars);
-                      return (
-                        <div
-                          className="lobe-chat-reply-length"
-                          aria-label={tr("message.replyLengthAria", {
-                            words,
-                            chars,
-                          })}
-                        >
-                          {tr("message.replyLength", { words, chars })}
-                        </div>
-                      );
-                    })()}
-                  </div>
-                }
-                belowMessage={
-                  showLiveToolBelow && liveTool ? (
-                    <LiveToolText message={liveTool} locale={locale} />
-                  ) : null
-                }
-                actions={(() => {
-                  if (m.streaming) return null;
-                  const showCopy = !!m.content.trim();
-                  const showRegen =
-                    !!onRegenerateAssistant && regenerableAssistantId === m.id;
-                  if (!showCopy && !showRegen) return null;
-                  const deepLink =
-                    sessionId != null
-                      ? formatMessageDeepLink(sessionId, m.id)
-                      : "";
-                  const showCopyLink = !!deepLink;
-                  if (!showCopy && !showRegen && !showCopyLink) return null;
-                  return (
-                    <>
-                      {showCopy ? (
-                        <>
-                          <MessageCopyButton
-                            text={m.content}
-                            copyLabel={tr("message.copy")}
-                            copiedLabel={tr("message.copied")}
-                          />
-                          <MessageActionButton
-                            label={tr("message.exportMd")}
-                            onClick={() => {
-                              const blob = new Blob([m.content], {
-                                type: "text/markdown;charset=utf-8",
-                              });
-                              const url = URL.createObjectURL(blob);
-                              const a = document.createElement("a");
-                              a.href = url;
-                              a.download = `grok-${m.id.slice(0, 8)}.md`;
-                              a.click();
-                              URL.revokeObjectURL(url);
-                            }}
-                          >
-                            <IconExportMd size={15} />
-                          </MessageActionButton>
-                        </>
-                      ) : null}
-                      {showCopyLink ? (
-                        <MessageCopyButton
-                          text={deepLink}
-                          copyLabel={tr("message.copyLink")}
-                          copiedLabel={tr("message.linkCopied")}
-                          idleIcon={<IconLink size={15} />}
-                        />
-                      ) : null}
-                      {showRegen ? (
-                        <MessageRegenerateButton
-                          label={tr("message.regenerate")}
-                          sameModelLabel={tr("message.regenerateSameModel")}
-                          pickModelLabel={tr("message.regeneratePickModel")}
-                          disabled={!canRegenerate}
-                          models={regenerateModels}
-                          currentModelId={regenerateModelId}
-                          onRegenerate={(modelId) => {
-                            if (!canRegenerate) return;
-                            onRegenerateAssistant?.(
-                              m,
-                              modelId ? { modelId } : undefined,
-                            );
-                          }}
-                        />
-                      ) : null}
-                    </>
-                  );
-                })()}
-              />,
-            );
-          })}
+          {visibleMessages.map(({ m, index: msgIndex }) => (
+            <TranscriptMessageRow
+              key={m.id}
+              m={m}
+              msgIndex={msgIndex}
+              virtualized={virtualized}
+              measureRef={measureRef}
+              locale={locale}
+              tr={tr}
+              projectPath={projectPath}
+              sessionPathMap={sessionPathMap}
+              sessionId={sessionId}
+              showToolChrome={showToolChrome}
+              toolStepsAutoCollapse={toolStepsAutoCollapse}
+              showTimestamps={showTimestamps}
+              messageTimeFormat={messageTimeFormat}
+              timeTick={relativeTick}
+              showReplyLength={showReplyLength}
+              lastUserMessageId={lastUserMessageId}
+              editingUserMessageId={editingUserMessageId}
+              editSubmitting={editSubmitting}
+              editAttachments={editAttachments}
+              canEditLastUser={canEditLastUser}
+              canRegenerate={canRegenerate}
+              canRewindSession={canRewindSession}
+              regenerableAssistantId={regenerableAssistantId}
+              regenerateModels={regenerateModels}
+              regenerateModelId={regenerateModelId}
+              activeAssistantId={activeAssistantId}
+              liveTool={liveTool}
+              wovenMessages={wovenMessages}
+              findQuery={findQuery}
+              findHitMessageIds={findHitMessageIds}
+              findActive={findActive}
+              focusMessageId={focusMessageId}
+              structuredUsageMessageId={structuredUsageMessageId}
+              structuredOutputActive={structuredOutputActive}
+              structuredOutputSchema={structuredOutputSchema}
+              structuredOutputUsage={structuredOutputUsage}
+              structuredOutputLabels={structuredOutputLabels}
+              attachLabels={attachLabels}
+              onEditUserMessage={onEditUserMessage}
+              onCancelEditUserMessage={onCancelEditUserMessage}
+              onSubmitEditUserMessage={onSubmitEditUserMessage}
+              onRemoveEditAttachment={onRemoveEditAttachment}
+              onRegenerateAssistant={onRegenerateAssistant}
+              onRewindToUserMessage={onRewindToUserMessage}
+              onForkFromUserMessage={onForkFromUserMessage}
+              onOpenResource={onOpenResource}
+              onOpenExternalLink={onOpenExternalLink}
+              onAddAttachmentToComposer={onAddAttachmentToComposer}
+            />
+          ))}
 
           {virtualized && paddingBottom > 0 ? (
             <div

--- a/src/components/lobe-chat/ConversationThreadLive.tsx
+++ b/src/components/lobe-chat/ConversationThreadLive.tsx
@@ -1,0 +1,17 @@
+/**
+ * ConversationThread bound to sessionTranscriptStore.
+ * Isolates stream token re-renders from the App shell.
+ */
+
+import { ConversationThread, type ConversationThreadProps } from "./ConversationThread";
+import { useViewingMessages } from "@/hooks/useSessionTranscript";
+
+export type ConversationThreadLiveProps = Omit<
+  ConversationThreadProps,
+  "messages"
+>;
+
+export function ConversationThreadLive(props: ConversationThreadLiveProps) {
+  const messages = useViewingMessages();
+  return <ConversationThread {...props} messages={messages} />;
+}

--- a/src/components/lobe-chat/EndOfTurnChip.tsx
+++ b/src/components/lobe-chat/EndOfTurnChip.tsx
@@ -2,7 +2,7 @@
  * Unified end-of-turn marker (stop / stall / error / permission).
  */
 
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import type { Locale } from "@/i18n";
 import { createT, type MessageKey } from "@/i18n";
 import {
@@ -13,7 +13,7 @@ import {
 import { IconStop } from "@/components/icons";
 import type { ChatMessage } from "@/lib/session";
 
-export function EndOfTurnChip({
+export const EndOfTurnChip = memo(function EndOfTurnChip({
   message,
   locale,
   reasonOverride,
@@ -44,4 +44,4 @@ export function EndOfTurnChip({
       <span className="lobe-end-turn__title">{label}</span>
     </div>
   );
-}
+});

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -28,12 +28,15 @@ import {
   resolveFileToken,
 } from "@/lib/pathRefs";
 import { isExternalHttpUrl } from "@/lib/externalLinkPref";
-import { useSmoothStream } from "@/hooks/useSmoothStream";
 import {
   createSoftBufferState,
   stepSoftBuffer,
   type SoftBufferState,
 } from "@/lib/softStreamBuffer";
+import {
+  shouldUsePlainStreamBody,
+  STREAM_MARKDOWN_PARSE_MS,
+} from "@/lib/streamRenderPolicy";
 import { revealInOsLabel } from "@/lib/appPlatform";
 import { cn } from "@/lib/utils";
 import { CodeBlock } from "./CodeBlock";
@@ -218,12 +221,32 @@ export const MarkdownChat = memo(function MarkdownChat({
     }
   }, [children, streaming]);
 
+  // Soft buffer only — no character-drip rAF (was a major Intel Retina cost).
+  // Store-level content notify throttle + markdown parse throttle pace paints.
   const buffered = streaming ? softDisplayed : children || "";
-  const smoothChildren = useSmoothStream(buffered, streaming && !!buffered);
-  const source = softCloseMarkdown(
-    smoothChildren || (streaming ? " " : ""),
+  const longStream = shouldUsePlainStreamBody(
+    (buffered || children || "").length,
     streaming,
   );
+  const liveText = buffered || (streaming ? " " : "");
+  const source = softCloseMarkdown(liveText, streaming);
+
+  /**
+   * Throttle ReactMarkdown input while streaming so we re-parse ~8×/s instead
+   * of every smooth-stream tick. Final (non-streaming) content always syncs.
+   */
+  const [mdSource, setMdSource] = useState(source);
+  useEffect(() => {
+    if (!streaming) {
+      setMdSource(source);
+      return;
+    }
+    if (longStream) return;
+    const id = window.setTimeout(() => {
+      setMdSource(source);
+    }, STREAM_MARKDOWN_PARSE_MS);
+    return () => window.clearTimeout(id);
+  }, [source, streaming, longStream]);
 
   const renderPathOrUrl = (token: string, linkText?: string) => {
     const rawIn = token.trim().replace(/^<|>$/g, "");
@@ -376,6 +399,25 @@ export const MarkdownChat = memo(function MarkdownChat({
       ? highlightChildren(node, qFind, findActiveOccurrence, findCounter)
       : node;
 
+  // Long streaming bodies: plain pre-wrap (no remark parse) until the turn
+  // settles — one full markdown pass on done. Prevents O(n) parse storms.
+  if (longStream) {
+    return (
+      <div
+        className={cn(
+          "chat-md",
+          "chat-md--streaming",
+          "chat-md--plain-stream",
+          muted && "chat-md--muted",
+          className,
+        )}
+        data-stream-mode="plain"
+      >
+        <pre className="chat-md__plain-stream">{liveText}</pre>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -486,7 +528,7 @@ export const MarkdownChat = memo(function MarkdownChat({
           },
         }}
       >
-        {source}
+        {mdSource}
       </ReactMarkdown>
     </div>
   );

--- a/src/components/lobe-chat/Thinking.tsx
+++ b/src/components/lobe-chat/Thinking.tsx
@@ -12,7 +12,7 @@
  * Tool bursts use TimelinePhaseBlock (“Worked for Ns”) instead.
  */
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { IconBulb, IconChevronDown, IconChevronRight } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { MarkdownChat } from "./MarkdownChat";
@@ -27,7 +27,7 @@ import {
 } from "@/lib/thinkingPref";
 import { extractThinkingSummary } from "@/lib/thinkingSummary";
 
-export function Thinking({
+export const Thinking = memo(function Thinking({
   content,
   thinking,
   durationMs,
@@ -229,4 +229,4 @@ export function Thinking({
       ) : null}
     </div>
   );
-}
+});

--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -17,7 +17,7 @@
  * Live: steps + “Working for …s” footer
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
 import { COLLAPSE_ALL_ACTIVITY_EVENT } from "@/lib/collapseAllActivity";
@@ -189,7 +189,7 @@ export function GrokActivitySteps({
   );
 }
 
-export function TimelinePhaseBlock({
+export const TimelinePhaseBlock = memo(function TimelinePhaseBlock({
   phase,
   locale,
   messageStreaming,
@@ -364,4 +364,4 @@ export function TimelinePhaseBlock({
       {open ? <GrokActivitySteps steps={stepsResolved} tr={tr} /> : null}
     </div>
   );
-}
+});

--- a/src/components/lobe-chat/TimelineToolRow.tsx
+++ b/src/components/lobe-chat/TimelineToolRow.tsx
@@ -3,7 +3,7 @@
  * Phase interior uses GrokActivitySteps inside TimelinePhaseBlock.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
 import type { ChatMessage, MessageSegment, MessageToolSegment } from "@/lib/session";
@@ -88,7 +88,7 @@ function ToolKindIcon({ tool }: { tool: MessageToolSegment }) {
   return <IconCircle size={size} stroke={1.5} />;
 }
 
-export function TimelineToolRow({
+export const TimelineToolRow = memo(function TimelineToolRow({
   tool,
   autoCollapse: autoCollapseProp,
   defaultExpanded,
@@ -237,7 +237,7 @@ export function TimelineToolRow({
       ) : null}
     </div>
   );
-}
+});
 
 /** ≥3 consecutive context tools → collapsible group. */
 export function TimelineContextGroup({

--- a/src/components/lobe-chat/index.ts
+++ b/src/components/lobe-chat/index.ts
@@ -1,4 +1,6 @@
 export { ConversationThread } from "./ConversationThread";
 export type { ConversationThreadProps } from "./ConversationThread";
+export { ConversationThreadLive } from "./ConversationThreadLive";
+export type { ConversationThreadLiveProps } from "./ConversationThreadLive";
 export { MessageNodeRail } from "./MessageNodeRail";
 export type { MessageNodeRailLabels } from "./MessageNodeRail";

--- a/src/components/lobe-chat/lobe-chat.css
+++ b/src/components/lobe-chat/lobe-chat.css
@@ -2,3 +2,19 @@
 @import "./lobe-chat.part1.css";
 @import "./lobe-chat.part2.css";
 @import "./lobe-chat.part3.css";
+
+/* Long-stream plain body: cheap pre-wrap until turn settles (markdown on done). */
+.chat-md--plain-stream {
+  white-space: normal;
+}
+.chat-md__plain-stream {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}

--- a/src/components/lobe-chat/lobe-chat.part1.css
+++ b/src/components/lobe-chat/lobe-chat.part1.css
@@ -148,6 +148,10 @@
   max-width: 100%;
   padding-block: var(--chat-item-pad-block, 10px);
   gap: var(--chat-item-gap, 8px);
+  /* Isolate layout so stream growth on the tail row dirties less of the
+   * surrounding tree during markdown reflow (Intel Retina). Avoid
+   * content-visibility here — the list is already virtualized. */
+  contain: layout style;
 }
 
 .lobe-chat-item--user {

--- a/src/components/resource-viewer/ResourcePreviewBody.tsx
+++ b/src/components/resource-viewer/ResourcePreviewBody.tsx
@@ -3,7 +3,7 @@
  * Presentational: all actions/state come from props (behavior freeze).
  */
 
-import type { ReactNode } from "react";
+import { lazy, Suspense, type ReactNode } from "react";
 import * as api from "@/lib/api";
 import type { Locale, MessageKey } from "@/i18n";
 import {
@@ -13,9 +13,7 @@ import {
 } from "@/lib/mediaLoadPro";
 import { HtmlBrowser } from "@/components/HtmlBrowser";
 import { MarkdownBody } from "@/components/MarkdownBody";
-import { MarkdownTiptapEditor } from "@/components/MarkdownTiptapEditor";
 import { OverlayScroll } from "@/components/OverlayScroll";
-import { FileMediaPlayer } from "@/components/FileMediaPlayer";
 import { ImageUi } from "@/components/ImageUi";
 import { revealInOsLabel } from "@/lib/appPlatform";
 import {
@@ -29,8 +27,6 @@ import {
   IconChat,
   IconRewind,
 } from "@/components/icons";
-import { OfficeDocumentPreview } from "@/components/OfficeDocumentPreview";
-import { CodePreview } from "@/components/CodePreview";
 import { isOfficeKind } from "@/lib/filePreviewSrc";
 import { Tip } from "@/components/ui/tooltip";
 import { normalizePath } from "@/lib/sessionChanges";
@@ -42,6 +38,23 @@ import {
 } from "@/lib/resourceEdit";
 import type { DiffLayout, DiffViewState, FileTab, SideMode } from "./types";
 import { formatSize, guessOfficeKind } from "./helpers";
+
+const MarkdownTiptapEditor = lazy(async () => {
+  const m = await import("@/components/MarkdownTiptapEditor");
+  return { default: m.MarkdownTiptapEditor };
+});
+const FileMediaPlayer = lazy(async () => {
+  const m = await import("@/components/FileMediaPlayer");
+  return { default: m.FileMediaPlayer };
+});
+const OfficeDocumentPreview = lazy(async () => {
+  const m = await import("@/components/OfficeDocumentPreview");
+  return { default: m.OfficeDocumentPreview };
+});
+const CodePreview = lazy(async () => {
+  const m = await import("@/components/CodePreview");
+  return { default: m.CodePreview };
+});
 
 export type ResourcePreviewBodyProps = {
   tr: (key: MessageKey, vars?: Record<string, string>) => string;
@@ -386,21 +399,23 @@ export function ResourcePreviewBody({
               <div className="rp-diff-split__label">
                 {tr("changes.split.before")}
               </div>
-              <CodePreview
+                            <Suspense fallback={null}>
+                <CodePreview
                 code={diffView.beforeText ?? ""}
                 fileName={diffView.name}
                 className="rp-diff-split__code"
-              />
+                />              </Suspense>
             </div>
             <div className="rp-diff-split__pane">
               <div className="rp-diff-split__label">
                 {tr("changes.split.after")}
               </div>
-              <CodePreview
+                            <Suspense fallback={null}>
+                <CodePreview
                 code={diffView.afterText ?? ""}
                 fileName={diffView.name}
                 className="rp-diff-split__code"
-              />
+                />              </Suspense>
             </div>
           </div>
         </div>
@@ -412,12 +427,13 @@ export function ResourcePreviewBody({
         <div className="rp-diff-host">
           {toolbar}
           {hunkBar}
-          <CodePreview
+                    <Suspense fallback={null}>
+            <CodePreview
             code={diffView.unified}
             fileName={`${diffView.name}.diff`}
             language="diff"
             footer={srcLabel}
-          />
+            />          </Suspense>
         </div>
       );
     }
@@ -425,11 +441,12 @@ export function ResourcePreviewBody({
       return (
         <div className="rp-diff-host">
           {toolbar}
-          <CodePreview
+                    <Suspense fallback={null}>
+            <CodePreview
             code={diffView.afterOnly}
             fileName={diffView.name}
             footer={tr("changes.afterOnly")}
-          />
+            />          </Suspense>
         </div>
       );
     }
@@ -604,33 +621,34 @@ export function ResourcePreviewBody({
         ) : null}
         {showEditor ? (
           isMarkdown ? (
-            <MarkdownTiptapEditor
+                        <Suspense fallback={null}>
+              <MarkdownTiptapEditor
               key={activeTab.id}
               value={draftText}
               onChange={updateActiveDraft}
               onSave={() => void saveActiveFile()}
               disabled={!!activeTab.saving}
               labels={{
-                bold: tr("resources.mdFmt.bold"),
-                italic: tr("resources.mdFmt.italic"),
-                strike: tr("resources.mdFmt.strike"),
-                code: tr("resources.mdFmt.code"),
-                h1: tr("resources.mdFmt.h1"),
-                h2: tr("resources.mdFmt.h2"),
-                h3: tr("resources.mdFmt.h3"),
-                bulletList: tr("resources.mdFmt.bulletList"),
-                orderedList: tr("resources.mdFmt.orderedList"),
-                blockquote: tr("resources.mdFmt.blockquote"),
-                link: tr("resources.mdFmt.link"),
-                hr: tr("resources.mdFmt.hr"),
-                linkPlaceholder: tr("resources.mdFmt.linkPlaceholder"),
-                linkApply: tr("resources.mdFmt.linkApply"),
-                placeholder: tr("resources.mdFmt.placeholder"),
-                editorAria: tr("resources.editorAria", {
-                  name: preview.name,
-                }),
+              bold: tr("resources.mdFmt.bold"),
+              italic: tr("resources.mdFmt.italic"),
+              strike: tr("resources.mdFmt.strike"),
+              code: tr("resources.mdFmt.code"),
+              h1: tr("resources.mdFmt.h1"),
+              h2: tr("resources.mdFmt.h2"),
+              h3: tr("resources.mdFmt.h3"),
+              bulletList: tr("resources.mdFmt.bulletList"),
+              orderedList: tr("resources.mdFmt.orderedList"),
+              blockquote: tr("resources.mdFmt.blockquote"),
+              link: tr("resources.mdFmt.link"),
+              hr: tr("resources.mdFmt.hr"),
+              linkPlaceholder: tr("resources.mdFmt.linkPlaceholder"),
+              linkApply: tr("resources.mdFmt.linkApply"),
+              placeholder: tr("resources.mdFmt.placeholder"),
+              editorAria: tr("resources.editorAria", {
+              name: preview.name,
+              }),
               }}
-            />
+              />            </Suspense>
           ) : (
             <textarea
               className="rp-editor__textarea"
@@ -687,7 +705,8 @@ export function ResourcePreviewBody({
     preview.kind !== "image"
   ) {
     return (
-      <OfficeDocumentPreview
+            <Suspense fallback={null}>
+        <OfficeDocumentPreview
         kind={preview.kind === "office" ? guessOfficeKind(preview.name) : preview.kind}
         absolutePath={preview.absolutePath}
         name={preview.name}
@@ -695,7 +714,7 @@ export function ResourcePreviewBody({
         textFallback={preview.text}
         errorFromHost={preview.error}
         embedded
-      />
+        />      </Suspense>
     );
   }
 
@@ -742,19 +761,20 @@ export function ResourcePreviewBody({
     case "audio":
     case "video":
       return src ? (
-        <FileMediaPlayer
+                <Suspense fallback={null}>
+          <FileMediaPlayer
           kind={preview.kind}
           src={src}
           mime={preview.mime}
           title={preview.name}
           absolutePath={preview.absolutePath || undefined}
           labels={{
-            loadError: tr("media.loadError"),
-            openExternal: tr("media.openExternal"),
-            loading: tr("resources.loading"),
-            t: tr,
+          loadError: tr("media.loadError"),
+          openExternal: tr("media.openExternal"),
+          loading: tr("resources.loading"),
+          t: tr,
           }}
-        />
+          />        </Suspense>
       ) : (
         <div className="rp-preview__msg">{tr("resources.binary")}</div>
       );
@@ -784,26 +804,28 @@ export function ResourcePreviewBody({
         /* keep raw */
       }
       return (
-        <CodePreview
+                <Suspense fallback={null}>
+          <CodePreview
           code={body}
           fileName={preview.name.endsWith(".json") ? preview.name : "data.json"}
           language="json"
           footer={
-            preview.truncated ? tr("resources.truncated") : null
+          preview.truncated ? tr("resources.truncated") : null
           }
-        />
+          />        </Suspense>
       );
     }
     default:
       if (preview.text) {
         return (
-          <CodePreview
+                    <Suspense fallback={null}>
+            <CodePreview
             code={preview.text}
             fileName={preview.name}
             footer={
-              preview.truncated ? tr("resources.truncated") : null
+            preview.truncated ? tr("resources.truncated") : null
             }
-          />
+            />          </Suspense>
         );
       }
       return (

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -37,6 +37,7 @@ import {
   shouldCommitRowHeight,
   type ChatVirtualWindow,
 } from "@/lib/chatVirtualList";
+import { resolveStreamOverscanScale } from "@/lib/streamRenderPolicy";
 
 export type UseChatMessageVirtualizerArgs = {
   itemCount: number;
@@ -186,6 +187,10 @@ export function useChatMessageVirtualizer(
       overscanPx: resolveChatOverscanPx({
         viewportHeight: el.clientHeight,
         pinToBottom: pin,
+        scale: resolveStreamOverscanScale(
+          typeof document !== "undefined" &&
+            document.documentElement.dataset.streamPerf === "1",
+        ),
       }),
       pinToBottom: pin,
       forceIndices: forceRef.current,

--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -88,6 +88,7 @@ import {
 import { recordCostUsageSample, sampleFromUsageEvent } from "@/lib/costRollup";
 import { mapSessionListRow } from "@/lib/app/sidebarModels";
 import { StreamCoalescer } from "@/lib/streamCoalesce";
+import { resolveStreamFlushMs } from "@/lib/streamRenderPolicy";
 
 /** Mutable bag of AppWorkbench bindings used by Host event handlers. */
 export type SessionHostEventsCtx = {
@@ -484,7 +485,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           }
         };
         const streamCoalescer = new StreamCoalescer({
-          flushMs: 48,
+          // Adaptive batching: longer hold on low core / dual-GPU Retina laptops.
+          flushMs: resolveStreamFlushMs(),
           onFlush: (raw) => {
             applyStreamToUi({
               sessionId: raw.sessionId ?? "",

--- a/src/hooks/useSessionLiveMap.test.ts
+++ b/src/hooks/useSessionLiveMap.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { sessionLiveMapStore } from "@/lib/sessionLiveMapStore";
+import { projectHostIntoLiveMap } from "@/lib/sessionLiveStore";
+import { peekBusySessionIds } from "./useSessionLiveMap";
+
+describe("useSessionLiveMap helpers", () => {
+  beforeEach(() => {
+    sessionLiveMapStore.resetForTests();
+  });
+
+  it("peekBusySessionIds reflects store without React", () => {
+    sessionLiveMapStore.setMap((prev) =>
+      projectHostIntoLiveMap(prev, {
+        sessionId: "a",
+        state: "streaming",
+      }),
+    );
+    expect([...peekBusySessionIds()]).toEqual(["a"]);
+  });
+});

--- a/src/hooks/useSessionLiveMap.test.ts
+++ b/src/hooks/useSessionLiveMap.test.ts
@@ -17,4 +17,12 @@ describe("useSessionLiveMap helpers", () => {
     );
     expect([...peekBusySessionIds()]).toEqual(["a"]);
   });
+
+  it("busyKey lists session ids for useIsSessionBusy", () => {
+    sessionLiveMapStore.setMap((prev) =>
+      projectHostIntoLiveMap(prev, { sessionId: "x", state: "streaming" }),
+    );
+    const key = sessionLiveMapStore.getBusySnapshot().busyKey;
+    expect(key.split("\0")).toContain("x");
+  });
 });

--- a/src/hooks/useSessionLiveMap.ts
+++ b/src/hooks/useSessionLiveMap.ts
@@ -91,3 +91,18 @@ export function useLiveMapActions() {
 export function peekBusySessionIds(): Set<string> {
   return busySessionIds(sessionLiveMapStore.getMap());
 }
+
+/**
+ * Whether a single session id is busy (streaming / permission).
+ * Subscribes to busy membership only — not full liveMap tool-title ticks.
+ */
+export function useIsSessionBusy(sessionId: string | null | undefined): boolean {
+  const meta = useLiveMapBusyMeta();
+  return useMemo(() => {
+    if (!sessionId) return false;
+    if (!meta.busyKey) return false;
+    // busyKey is sorted ids joined by \0
+    if (meta.busyKey === sessionId) return true;
+    return meta.busyKey.split("\0").includes(sessionId);
+  }, [meta.busyKey, sessionId]);
+}

--- a/src/hooks/useSessionLiveMap.ts
+++ b/src/hooks/useSessionLiveMap.ts
@@ -22,6 +22,38 @@ export function useLiveMap(): SessionLiveMap {
   );
 }
 
+const EMPTY_LIVE_MAP: SessionLiveMap = Object.freeze({}) as SessionLiveMap;
+
+/**
+ * Subscribe to the full live map only while `enabled` is true.
+ * When panels (dashboard / reliability / stall / tasks) are closed, the
+ * workbench shell does not re-render on every tool-title liveMap tick.
+ */
+export function useLiveMapWhen(enabled: boolean): SessionLiveMap {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!enabled) return () => {};
+      return sessionLiveMapStore.subscribeMap(onStoreChange);
+    },
+    [enabled],
+  );
+  const getSnapshot = useCallback((): SessionLiveMap => {
+    if (!enabled) return EMPTY_LIVE_MAP;
+    return sessionLiveMapStore.getMapSnapshot();
+  }, [enabled]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/** Single-session snapshot without forcing a full-map subscription when idle. */
+export function useLiveSessionSnapshotWhen(
+  sessionId: string | null | undefined,
+  enabled: boolean,
+): SessionLiveSnapshot | null {
+  const map = useLiveMapWhen(enabled && !!sessionId);
+  if (!sessionId || !enabled) return null;
+  return map[sessionId] ?? null;
+}
+
 /** Busy membership only — sidebar chrome / tray badge. */
 export function useLiveMapBusyMeta(): LiveMapBusyMeta {
   return useSyncExternalStore(
@@ -42,9 +74,7 @@ export function useLiveMapBusyIds(): Set<string> {
 export function useLiveSessionSnapshot(
   sessionId: string | null | undefined,
 ): SessionLiveSnapshot | null {
-  const map = useLiveMap();
-  if (!sessionId) return null;
-  return map[sessionId] ?? null;
+  return useLiveSessionSnapshotWhen(sessionId, true);
 }
 
 export function useLiveMapActions() {

--- a/src/hooks/useSessionLiveMap.ts
+++ b/src/hooks/useSessionLiveMap.ts
@@ -1,0 +1,63 @@
+/**
+ * React bindings for sessionLiveMapStore.
+ */
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import {
+  sessionLiveMapStore,
+  type LiveMapBusyMeta,
+} from "@/lib/sessionLiveMapStore";
+import {
+  busySessionIds,
+  type SessionLiveMap,
+  type SessionLiveSnapshot,
+} from "@/lib/sessionLiveStore";
+
+/** Full live map — use in panels that need every session row. */
+export function useLiveMap(): SessionLiveMap {
+  return useSyncExternalStore(
+    sessionLiveMapStore.subscribeMap,
+    sessionLiveMapStore.getMapSnapshot,
+    sessionLiveMapStore.getMapSnapshot,
+  );
+}
+
+/** Busy membership only — sidebar chrome / tray badge. */
+export function useLiveMapBusyMeta(): LiveMapBusyMeta {
+  return useSyncExternalStore(
+    sessionLiveMapStore.subscribeBusy,
+    sessionLiveMapStore.getBusySnapshot,
+    sessionLiveMapStore.getBusySnapshot,
+  );
+}
+
+export function useLiveMapBusyIds(): Set<string> {
+  const meta = useLiveMapBusyMeta();
+  return useMemo(() => {
+    if (!meta.busyKey) return new Set<string>();
+    return new Set(meta.busyKey.split("\0").filter(Boolean));
+  }, [meta.busyKey]);
+}
+
+export function useLiveSessionSnapshot(
+  sessionId: string | null | undefined,
+): SessionLiveSnapshot | null {
+  const map = useLiveMap();
+  if (!sessionId) return null;
+  return map[sessionId] ?? null;
+}
+
+export function useLiveMapActions() {
+  const setLiveMap = useCallback(
+    (next: SessionLiveMap | ((prev: SessionLiveMap) => SessionLiveMap)) => {
+      sessionLiveMapStore.setLiveMap(next);
+    },
+    [],
+  );
+  return { setLiveMap };
+}
+
+/** Stable busy id set from a one-shot map read (event handlers). */
+export function peekBusySessionIds(): Set<string> {
+  return busySessionIds(sessionLiveMapStore.getMap());
+}

--- a/src/hooks/useSessionRuntime.ts
+++ b/src/hooks/useSessionRuntime.ts
@@ -126,15 +126,20 @@ export function useSessionRuntime(opts?: {
     [patchStore],
   );
 
+  /**
+   * Prefer the store Set identity when host does not inject an extra id —
+   * keeps sidebar memo/`busyIds.has` stable across unrelated shell re-renders.
+   */
   const busyIds = useMemo(() => {
-    const set = new Set(busyIdsFromStore);
     if (
-      liveHost.sessionId &&
-      isSessionLiveStreaming(liveHost.state) &&
-      !set.has(liveHost.sessionId)
+      !liveHost.sessionId ||
+      !isSessionLiveStreaming(liveHost.state) ||
+      busyIdsFromStore.has(liveHost.sessionId)
     ) {
-      set.add(liveHost.sessionId);
+      return busyIdsFromStore;
     }
+    const set = new Set(busyIdsFromStore);
+    set.add(liveHost.sessionId);
     return set;
   }, [busyIdsFromStore, liveHost.sessionId, liveHost.state]);
 

--- a/src/hooks/useSessionRuntime.ts
+++ b/src/hooks/useSessionRuntime.ts
@@ -4,6 +4,9 @@
  *
  * Stream hot path uses external stores so token growth does not force every
  * workbench subscriber to reconcile (Intel Retina multi-turn).
+ *
+ * Full liveMap is NOT subscribed here — use {@link useLiveMapWhen} in panels
+ * that need every session row. Shell only tracks busy membership.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -11,10 +14,7 @@ import {
   createStopLatchState,
   type StopLatchState,
 } from "@/lib/stopLatch";
-import {
-  isSessionLiveStreaming,
-  type ChatMessage,
-} from "@/lib/session";
+import { isSessionLiveStreaming, type ChatMessage } from "@/lib/session";
 import {
   settleStoppedSessionInLiveMap,
   settleStoppedSessionSnapshot,
@@ -29,9 +29,9 @@ import {
   useTranscriptMeta,
 } from "@/hooks/useSessionTranscript";
 import {
-  useLiveMap,
   useLiveMapActions,
   useLiveMapBusyIds,
+  useLiveMapBusyMeta,
 } from "@/hooks/useSessionLiveMap";
 import {
   useFocusedSession,
@@ -39,6 +39,7 @@ import {
   useSessionShellActions,
 } from "@/hooks/useSessionShell";
 import { useSessionRuntimeRefs } from "@/hooks/useSessionRuntimeRefs";
+import { sessionLiveMapStore } from "@/lib/sessionLiveMapStore";
 
 export type { SessionLiveMap };
 
@@ -51,13 +52,11 @@ export function useSessionRuntime(opts?: {
   const liveHost = useLiveHost();
   const { setSession, setLiveHost } = useSessionShellActions();
 
-  const liveMap = useLiveMap();
   const { setLiveMap } = useLiveMapActions();
   const busyIdsFromStore = useLiveMapBusyIds();
-  const { liveMapRef, liveHostRef } = useSessionRuntimeRefs({
-    liveMap,
-    liveHost,
-  });
+  const busyMeta = useLiveMapBusyMeta();
+  // Refs only — no full-map React subscription on the workbench shell.
+  const { liveMapRef, liveHostRef } = useSessionRuntimeRefs({ liveHost });
 
   /** Stop interrupt honesty latch (force unlock after budget). */
   const [stopLatch, setStopLatch] = useState<StopLatchState>(() =>
@@ -100,7 +99,6 @@ export function useSessionRuntime(opts?: {
     return () => sessionTranscriptStore.setViewingIdResolver(null);
   }, [session.sessionId]);
 
-  // Keep viewing id aligned when React session id updates (when not opening).
   useEffect(() => {
     if (viewingSessionIdRef.current == null && session.sessionId) {
       viewingSessionIdRef.current = session.sessionId;
@@ -140,19 +138,35 @@ export function useSessionRuntime(opts?: {
     return set;
   }, [busyIdsFromStore, liveHost.sessionId, liveHost.state]);
 
-  const settleStoppedSessionUi = useCallback((sessionId: string) => {
-    setLiveMap((prev) => {
-      const next = settleStoppedSessionInLiveMap(prev, sessionId);
-      liveMapRef.current = next;
-      return next;
-    });
-    setLiveHost((prev) => {
-      const next = settleStoppedSessionSnapshot(prev, sessionId);
-      liveHostRef.current = next;
-      return next;
-    });
-    setSession((prev) => settleStoppedSessionSnapshot(prev, sessionId));
-  }, [setLiveMap, setLiveHost, setSession, liveMapRef, liveHostRef]);
+  /** Busy session count for tray / chrome (no full-map subscription). */
+  const liveMapBusyCount = useMemo(() => {
+    let n = busyMeta.busyCount;
+    if (
+      liveHost.sessionId &&
+      isSessionLiveStreaming(liveHost.state) &&
+      !busyIdsFromStore.has(liveHost.sessionId)
+    ) {
+      n += 1;
+    }
+    return n;
+  }, [busyMeta.busyCount, busyIdsFromStore, liveHost.sessionId, liveHost.state]);
+
+  const settleStoppedSessionUi = useCallback(
+    (sessionId: string) => {
+      setLiveMap((prev) => {
+        const next = settleStoppedSessionInLiveMap(prev, sessionId);
+        liveMapRef.current = next;
+        return next;
+      });
+      setLiveHost((prev) => {
+        const next = settleStoppedSessionSnapshot(prev, sessionId);
+        liveHostRef.current = next;
+        return next;
+      });
+      setSession((prev) => settleStoppedSessionSnapshot(prev, sessionId));
+    },
+    [setLiveMap, setLiveHost, setSession, liveMapRef, liveHostRef],
+  );
 
   const stopGate = useMemo(
     () =>
@@ -175,15 +189,18 @@ export function useSessionRuntime(opts?: {
     stopLatchRef.current = idle;
   }, []);
 
+  /** Latest full map for event handlers (always fresh; not a React subscription). */
+  const getLiveMap = useCallback(() => sessionLiveMapStore.getMap(), []);
+
   return {
     session,
     setSession,
     liveHost,
     setLiveHost,
     liveHostRef,
-    liveMap,
-    setLiveMap,
+    /** @deprecated Prefer getLiveMap() / useLiveMapWhen — kept as ref for Host events. */
     liveMapRef,
+    setLiveMap,
     stopLatch,
     setStopLatch,
     stopLatchRef,
@@ -198,6 +215,8 @@ export function useSessionRuntime(opts?: {
     bumpViewEpoch,
     patchSessionMessages,
     busyIds,
+    liveMapBusyCount,
+    getLiveMap,
     settleStoppedSessionUi,
     stopGate,
     effectiveCanSend,

--- a/src/hooks/useSessionRuntime.ts
+++ b/src/hooks/useSessionRuntime.ts
@@ -1,7 +1,9 @@
 /**
  * Session runtime: messages / liveMap / stop latch / viewing session coordination.
  * Owns projection state so AppWorkbench stays a shell over Host event wiring + send.
- * api.sessionSend contract remains in AppWorkbench (send path).
+ *
+ * Stream hot path uses external stores so token growth does not force every
+ * workbench subscriber to reconcile (Intel Retina multi-turn).
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -10,24 +12,33 @@ import {
   type StopLatchState,
 } from "@/lib/stopLatch";
 import {
-  IDLE_SNAPSHOT,
   isSessionLiveStreaming,
   type ChatMessage,
-  type SessionSnapshot,
 } from "@/lib/session";
 import {
-  busySessionIds,
   settleStoppedSessionInLiveMap,
   settleStoppedSessionSnapshot,
   type SessionLiveMap,
 } from "@/lib/sessionLiveStore";
-import {
-  reconcileUiBusyGate,
-} from "@/lib/sessionPhase";
-import {
-  type ViewFocus,
-} from "@/lib/viewFocus";
+import { reconcileUiBusyGate } from "@/lib/sessionPhase";
+import { type ViewFocus } from "@/lib/viewFocus";
 import { canLiveParticipate } from "@/lib/multiWindow";
+import { sessionTranscriptStore } from "@/lib/sessionTranscriptStore";
+import {
+  useTranscriptActions,
+  useTranscriptMeta,
+} from "@/hooks/useSessionTranscript";
+import {
+  useLiveMap,
+  useLiveMapActions,
+  useLiveMapBusyIds,
+} from "@/hooks/useSessionLiveMap";
+import {
+  useFocusedSession,
+  useLiveHost,
+  useSessionShellActions,
+} from "@/hooks/useSessionShell";
+import { useSessionRuntimeRefs } from "@/hooks/useSessionRuntimeRefs";
 
 export type { SessionLiveMap };
 
@@ -36,16 +47,17 @@ export function useSessionRuntime(opts?: {
 }) {
   const isSecondaryWindow = opts?.isSecondaryWindow ?? false;
 
-  const [session, setSession] = useState<SessionSnapshot>(IDLE_SNAPSHOT);
-  /** Host live agent (may differ from the session currently viewed in the UI). */
-  const [liveHost, setLiveHost] = useState<SessionSnapshot>(IDLE_SNAPSHOT);
-  const liveHostRef = useRef<SessionSnapshot>(IDLE_SNAPSHOT);
+  const session = useFocusedSession();
+  const liveHost = useLiveHost();
+  const { setSession, setLiveHost } = useSessionShellActions();
 
-  /** Multi-session live projection (busy / permission badges). */
-  const [liveMap, setLiveMap] = useState<SessionLiveMap>({});
-  /** Latest live map for callbacks that must not close over a stale render. */
-  const liveMapRef = useRef(liveMap);
-  liveMapRef.current = liveMap;
+  const liveMap = useLiveMap();
+  const { setLiveMap } = useLiveMapActions();
+  const busyIdsFromStore = useLiveMapBusyIds();
+  const { liveMapRef, liveHostRef } = useSessionRuntimeRefs({
+    liveMap,
+    liveHost,
+  });
 
   /** Stop interrupt honesty latch (force unlock after budget). */
   const [stopLatch, setStopLatch] = useState<StopLatchState>(() =>
@@ -54,17 +66,46 @@ export function useSessionRuntime(opts?: {
   const stopLatchRef = useRef<StopLatchState>(createStopLatchState());
   stopLatchRef.current = stopLatch;
 
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const messagesRef = useRef<ChatMessage[]>([]);
-  /** Per-session message cache so switching away mid-turn does not drop the UI. */
-  const messagesBySessionRef = useRef<Map<string, ChatMessage[]>>(new Map());
-  const viewingSessionIdRef = useRef<string | null>(null);
+  const transcriptMeta = useTranscriptMeta();
+  const { setMessages, patchSessionMessages: patchStore } =
+    useTranscriptActions();
   /**
-   * Bumped on every user navigation (open chat / new chat). Async work captures
-   * {@link currentViewFocus} before its first await and must re-check before
-   * touching view state.
+   * Structural shell mirror — token growth does not update this array.
+   * ConversationThreadLive subscribes to full content separately.
    */
+  const [messages, setShellMessages] = useState<ChatMessage[]>(() =>
+    sessionTranscriptStore.getMessages(),
+  );
+  useEffect(() => {
+    setShellMessages(sessionTranscriptStore.getMessages());
+  }, [transcriptMeta.structuralRev]);
+
+  const messagesRef = useRef<ChatMessage[]>(messages);
+  useEffect(() => {
+    return sessionTranscriptStore.subscribeContent(() => {
+      messagesRef.current = sessionTranscriptStore.getMessages();
+    });
+  }, []);
+  messagesRef.current = sessionTranscriptStore.getMessages();
+
+  const messagesBySessionRef = useRef(sessionTranscriptStore.getBySessionMap());
+  const viewingSessionIdRef = useRef<string | null>(null);
   const viewEpochRef = useRef(0);
+
+  useEffect(() => {
+    sessionTranscriptStore.setViewingSessionId(session.sessionId);
+    sessionTranscriptStore.setViewingIdResolver(
+      () => viewingSessionIdRef.current,
+    );
+    return () => sessionTranscriptStore.setViewingIdResolver(null);
+  }, [session.sessionId]);
+
+  // Keep viewing id aligned when React session id updates (when not opening).
+  useEffect(() => {
+    if (viewingSessionIdRef.current == null && session.sessionId) {
+      viewingSessionIdRef.current = session.sessionId;
+    }
+  }, [session.sessionId]);
 
   const currentViewFocus = useCallback(
     (): ViewFocus => ({
@@ -77,50 +118,27 @@ export function useSessionRuntime(opts?: {
     viewEpochRef.current += 1;
   }, []);
 
-  useEffect(() => {
-    liveHostRef.current = liveHost;
-  }, [liveHost]);
-
-  // Mirror viewed-session messages into the cache on every change.
-  useEffect(() => {
-    messagesRef.current = messages;
-    const id = session.sessionId;
-    if (!id) return;
-    messagesBySessionRef.current.set(id, messages);
-  }, [messages, session.sessionId]);
-
-  /** Apply a message reducer to the viewed session or only to the cache. */
   const patchSessionMessages = useCallback(
     (
       targetSessionId: string | undefined | null,
       reduce: (prev: ChatMessage[]) => ChatMessage[],
     ) => {
-      if (!targetSessionId) return;
-      if (viewingSessionIdRef.current === targetSessionId) {
-        setMessages((prev) => {
-          const next = reduce(prev);
-          messagesBySessionRef.current.set(targetSessionId, next);
-          return next;
-        });
-      } else {
-        const prev = messagesBySessionRef.current.get(targetSessionId) ?? [];
-        messagesBySessionRef.current.set(targetSessionId, reduce(prev));
-      }
+      patchStore(targetSessionId, reduce);
     },
-    [],
+    [patchStore],
   );
 
-  /**
-   * Multi-session busy ids (stream / permission) for sidebar spinner.
-   * Uses liveMap projection + liveHost fallback. Excludes connecting.
-   */
   const busyIds = useMemo(() => {
-    const set = busySessionIds(liveMap);
-    if (liveHost.sessionId && isSessionLiveStreaming(liveHost.state)) {
+    const set = new Set(busyIdsFromStore);
+    if (
+      liveHost.sessionId &&
+      isSessionLiveStreaming(liveHost.state) &&
+      !set.has(liveHost.sessionId)
+    ) {
       set.add(liveHost.sessionId);
     }
     return set;
-  }, [liveMap, liveHost.sessionId, liveHost.state]);
+  }, [busyIdsFromStore, liveHost.sessionId, liveHost.state]);
 
   const settleStoppedSessionUi = useCallback((sessionId: string) => {
     setLiveMap((prev) => {
@@ -134,7 +152,7 @@ export function useSessionRuntime(opts?: {
       return next;
     });
     setSession((prev) => settleStoppedSessionSnapshot(prev, sessionId));
-  }, []);
+  }, [setLiveMap, setLiveHost, setSession, liveMapRef, liveHostRef]);
 
   const stopGate = useMemo(
     () =>
@@ -145,7 +163,6 @@ export function useSessionRuntime(opts?: {
     [session.state, stopLatch],
   );
 
-  // Session-keyed pool: secondary shares Host — send/stop allowed (session-targeted).
   const effectiveCanSend =
     stopGate.sendable && canLiveParticipate(isSecondaryWindow);
   const effectiveCanStop =
@@ -185,5 +202,7 @@ export function useSessionRuntime(opts?: {
     stopGate,
     effectiveCanSend,
     effectiveCanStop,
+    /** Structural transcript meta for shell empty/streaming gates. */
+    transcriptMeta,
   };
 }

--- a/src/hooks/useSessionRuntimeRefs.ts
+++ b/src/hooks/useSessionRuntimeRefs.ts
@@ -1,0 +1,50 @@
+/**
+ * Keep mutable refs aligned with external session runtime stores without
+ * forcing App shell re-renders. Event handlers read refs for latest values.
+ */
+
+import { useEffect, useRef } from "react";
+import { sessionLiveMapStore } from "@/lib/sessionLiveMapStore";
+import { sessionShellStore } from "@/lib/sessionShellStore";
+import type { SessionSnapshot } from "@/lib/session";
+import type { SessionLiveMap } from "@/lib/sessionLiveStore";
+
+export function useSessionRuntimeRefs(opts?: {
+  liveMap?: SessionLiveMap;
+  liveHost?: SessionSnapshot;
+}) {
+  const liveMapRef = useRef(sessionLiveMapStore.getMap());
+  const liveHostRef = useRef(sessionShellStore.getLiveHost());
+
+  // Mirror latest render values when provided (same-render freshness).
+  // Use !== undefined so empty liveMap {} still updates the ref.
+  if (opts && "liveMap" in opts && opts.liveMap !== undefined) {
+    liveMapRef.current = opts.liveMap;
+  }
+  if (opts && "liveHost" in opts && opts.liveHost !== undefined) {
+    liveHostRef.current = opts.liveHost;
+  }
+
+  useEffect(() => {
+    const unsubMap = sessionLiveMapStore.subscribeMap(() => {
+      liveMapRef.current = sessionLiveMapStore.getMap();
+    });
+    const unsubHost = sessionShellStore.subscribeLiveHost(() => {
+      liveHostRef.current = sessionShellStore.getLiveHost();
+    });
+    liveMapRef.current = sessionLiveMapStore.getMap();
+    liveHostRef.current = sessionShellStore.getLiveHost();
+    return () => {
+      unsubMap();
+      unsubHost();
+    };
+  }, []);
+
+  return { liveMapRef, liveHostRef };
+}
+
+/** Reset shell stores (tests / hot reload helpers). */
+export function resetSessionRuntimeStoresForTests(): void {
+  sessionLiveMapStore.resetForTests();
+  sessionShellStore.resetForTests();
+}

--- a/src/hooks/useSessionShell.ts
+++ b/src/hooks/useSessionShell.ts
@@ -1,0 +1,60 @@
+/**
+ * React bindings for sessionShellStore (focused session + liveHost).
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  sessionShellStore,
+  type SessionShellMeta,
+} from "@/lib/sessionShellStore";
+import type { SessionSnapshot } from "@/lib/session";
+
+/** Full focused session — composer / main chrome that need all fields. */
+export function useFocusedSession(): SessionSnapshot {
+  return useSyncExternalStore(
+    sessionShellStore.subscribeSession,
+    sessionShellStore.getSessionSnapshot,
+    sessionShellStore.getSessionSnapshot,
+  );
+}
+
+/** Structural session fields only (id / state / error) — fewer re-renders. */
+export function useSessionShellMeta(): SessionShellMeta {
+  return useSyncExternalStore(
+    sessionShellStore.subscribeMeta,
+    sessionShellStore.getMetaSnapshot,
+    sessionShellStore.getMetaSnapshot,
+  );
+}
+
+export function useLiveHost(): SessionSnapshot {
+  return useSyncExternalStore(
+    sessionShellStore.subscribeLiveHost,
+    sessionShellStore.getLiveHostSnapshot,
+    sessionShellStore.getLiveHostSnapshot,
+  );
+}
+
+export function useSessionShellActions() {
+  const setSession = useCallback(
+    (
+      next:
+        | SessionSnapshot
+        | ((prev: SessionSnapshot) => SessionSnapshot),
+    ) => {
+      sessionShellStore.setSession(next);
+    },
+    [],
+  );
+  const setLiveHost = useCallback(
+    (
+      next:
+        | SessionSnapshot
+        | ((prev: SessionSnapshot) => SessionSnapshot),
+    ) => {
+      sessionShellStore.setLiveHost(next);
+    },
+    [],
+  );
+  return { setSession, setLiveHost };
+}

--- a/src/hooks/useSessionTranscript.ts
+++ b/src/hooks/useSessionTranscript.ts
@@ -1,0 +1,49 @@
+/**
+ * React bindings for sessionTranscriptStore.
+ * - useViewingMessages: full transcript (ConversationThread / export freeze)
+ * - useTranscriptMeta: structural shell fields (no token-level re-renders)
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  sessionTranscriptStore,
+  type MessagesReducer,
+  type TranscriptMeta,
+} from "@/lib/sessionTranscriptStore";
+import type { ChatMessage } from "@/lib/session";
+
+export function useViewingMessages(): ChatMessage[] {
+  return useSyncExternalStore(
+    sessionTranscriptStore.subscribeContent,
+    sessionTranscriptStore.getContentSnapshot,
+    sessionTranscriptStore.getContentSnapshot,
+  );
+}
+
+export function useTranscriptMeta(): TranscriptMeta {
+  return useSyncExternalStore(
+    sessionTranscriptStore.subscribeMeta,
+    sessionTranscriptStore.getMetaSnapshot,
+    sessionTranscriptStore.getMetaSnapshot,
+  );
+}
+
+/** Stable API for App event handlers (never causes subscription by itself). */
+export function useTranscriptActions() {
+  const setMessages = useCallback(
+    (next: ChatMessage[] | MessagesReducer) => {
+      sessionTranscriptStore.setMessages(next);
+    },
+    [],
+  );
+  const patchSessionMessages = useCallback(
+    (
+      targetSessionId: string | undefined | null,
+      reduce: MessagesReducer,
+    ) => {
+      sessionTranscriptStore.patchSession(targetSessionId, reduce);
+    },
+    [],
+  );
+  return { setMessages, patchSessionMessages };
+}

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -495,10 +495,28 @@ export function useStickToBottom(
       return el.scrollHeight;
     };
 
+    let throttleTimer = 0;
     const ro = new ResizeObserver(() => {
       // Coalesce multi-node notifications to one frame. Always read the
       // content column height from the DOM — viewport RO entries report
       // client box size, which is not what we want for grow/shrink.
+      // During stream-perf mode (Intel Retina), also time-throttle RO storms
+      // from markdown reflow so stick-to-bottom is not a second render tax.
+      const streamPerf =
+        typeof document !== "undefined" &&
+        document.documentElement.dataset.streamPerf === "1";
+      if (streamPerf) {
+        if (throttleTimer) return;
+        throttleTimer = window.setTimeout(() => {
+          throttleTimer = 0;
+          if (raf) return;
+          raf = requestAnimationFrame(() => {
+            raf = 0;
+            onHeightChange(measureContentHeight());
+          });
+        }, 80);
+        return;
+      }
       if (raf) return;
       raf = requestAnimationFrame(() => {
         raf = 0;
@@ -513,6 +531,7 @@ export function useStickToBottom(
 
     return () => {
       if (raf) cancelAnimationFrame(raf);
+      if (throttleTimer) window.clearTimeout(throttleTimer);
       ro.disconnect();
     };
   }, [enabled, conversationKey, applyScrollTop, followIfPinned]);

--- a/src/lib/chatVirtualList.test.ts
+++ b/src/lib/chatVirtualList.test.ts
@@ -117,8 +117,10 @@ describe("computeChatVirtualWindow", () => {
     expect(w.start).toBe(0);
   });
 
-  it("threshold constant is high enough to skip short chats", () => {
-    expect(CHAT_VIRTUALIZE_THRESHOLD).toBeGreaterThanOrEqual(40);
+  it("threshold virtualizes multi-turn agent chats without waiting for 50 rows", () => {
+    // Short welcome/1-turn chats stay fully mounted; 3–4 tool-heavy turns should window.
+    expect(CHAT_VIRTUALIZE_THRESHOLD).toBeGreaterThanOrEqual(12);
+    expect(CHAT_VIRTUALIZE_THRESHOLD).toBeLessThanOrEqual(28);
   });
 
   it("accepts precomputed offsets (scroll-path cache)", () => {

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -13,8 +13,14 @@
  *   not mount the entire remainder of a long chat (history-browse jank).
  */
 
-/** Only virtualize long threads — short chats keep full DOM (identical UX). */
-export const CHAT_VIRTUALIZE_THRESHOLD = 48;
+import { CHAT_VIRTUALIZE_THRESHOLD_PERF } from "@/lib/streamRenderPolicy";
+
+/**
+ * Virtualize once the transcript has this many rows (tool steps count).
+ * Kept low so multi-turn agent chats window the DOM before the UI freezes
+ * on integrated-GPU / Retina laptops (see streamRenderPolicy).
+ */
+export const CHAT_VIRTUALIZE_THRESHOLD = CHAT_VIRTUALIZE_THRESHOLD_PERF;
 
 /** Fallback height before a row is measured (px). */
 export const CHAT_DEFAULT_ROW_ESTIMATE_PX = 120;
@@ -126,29 +132,41 @@ export function resolveChatOverscanPx(input: {
   pinToBottom?: boolean;
   /** Explicit override (tests / callers). */
   overscanPx?: number;
+  /**
+   * 0–1 scale applied after clamp (stream-perf on low-power clients mounts
+   * fewer offscreen markdown rows).
+   */
+  scale?: number;
 }): number {
   if (input.overscanPx != null && Number.isFinite(input.overscanPx)) {
     return Math.max(0, input.overscanPx);
   }
   const vh = Math.max(0, input.viewportHeight);
+  let px: number;
   if (input.pinToBottom) {
     // ~1.5 viewports above the tail + small baseline, clamped.
     const raw = vh * 1.5 + 200;
-    return Math.round(
+    px = Math.round(
       Math.min(
         CHAT_PIN_OVERSCAN_MAX_PX,
         Math.max(CHAT_PIN_OVERSCAN_MIN_PX, raw, CHAT_PIN_OVERSCAN_PX * 0.75),
       ),
     );
+  } else {
+    // History browse: ~1 viewport of runway.
+    const raw = vh * 1.1 + 100;
+    px = Math.round(
+      Math.min(
+        CHAT_OVERSCAN_MAX_PX,
+        Math.max(CHAT_OVERSCAN_MIN_PX, raw, CHAT_OVERSCAN_PX * 0.6),
+      ),
+    );
   }
-  // History browse: ~1 viewport of runway.
-  const raw = vh * 1.1 + 100;
-  return Math.round(
-    Math.min(
-      CHAT_OVERSCAN_MAX_PX,
-      Math.max(CHAT_OVERSCAN_MIN_PX, raw, CHAT_OVERSCAN_PX * 0.6),
-    ),
-  );
+  const scale =
+    input.scale != null && Number.isFinite(input.scale)
+      ? Math.min(1, Math.max(0.35, input.scale))
+      : 1;
+  return Math.round(px * scale);
 }
 
 /**

--- a/src/lib/sessionLiveMapStore.test.ts
+++ b/src/lib/sessionLiveMapStore.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { sessionLiveMapStore } from "./sessionLiveMapStore";
+import { projectHostIntoLiveMap } from "./sessionLiveStore";
+
+describe("sessionLiveMapStore", () => {
+  beforeEach(() => {
+    sessionLiveMapStore.resetForTests();
+  });
+
+  it("notifies map listeners on change", () => {
+    let ticks = 0;
+    const unsub = sessionLiveMapStore.subscribeMap(() => {
+      ticks += 1;
+    });
+    sessionLiveMapStore.setMap((prev) =>
+      projectHostIntoLiveMap(prev, {
+        sessionId: "a",
+        state: "streaming",
+        streamingMessageId: "m1",
+      }),
+    );
+    expect(ticks).toBe(1);
+    expect(sessionLiveMapStore.getSnapshot("a")?.state).toBe("streaming");
+    unsub();
+  });
+
+  it("busy meta only bumps when busy membership changes", () => {
+    let busyTicks = 0;
+    const unsub = sessionLiveMapStore.subscribeBusy(() => {
+      busyTicks += 1;
+    });
+    sessionLiveMapStore.setMap((prev) =>
+      projectHostIntoLiveMap(prev, {
+        sessionId: "a",
+        state: "streaming",
+      }),
+    );
+    expect(busyTicks).toBe(1);
+    expect(sessionLiveMapStore.getBusySnapshot().busyCount).toBe(1);
+
+    // Same busy membership (still streaming a) — no busy notify if map identity
+    // changes but busy set same... project creates new map so map notifies;
+    // busy key still "a".
+    sessionLiveMapStore.setMap((prev) =>
+      projectHostIntoLiveMap(prev, {
+        sessionId: "a",
+        state: "streaming",
+        streamingMessageId: "m2",
+      }),
+    );
+    expect(busyTicks).toBe(1);
+
+    sessionLiveMapStore.setMap((prev) =>
+      projectHostIntoLiveMap(prev, { sessionId: "a", state: "ready" }),
+    );
+    expect(busyTicks).toBe(2);
+    expect(sessionLiveMapStore.getBusySnapshot().busyCount).toBe(0);
+    unsub();
+  });
+
+  it("setLiveMap identity when reducer returns same ref", () => {
+    let ticks = 0;
+    const unsub = sessionLiveMapStore.subscribeMap(() => {
+      ticks += 1;
+    });
+    sessionLiveMapStore.setLiveMap((prev) => prev);
+    expect(ticks).toBe(0);
+    unsub();
+  });
+});

--- a/src/lib/sessionLiveMapStore.ts
+++ b/src/lib/sessionLiveMapStore.ts
@@ -1,0 +1,106 @@
+/**
+ * External SessionLiveMap store.
+ *
+ * Stream / runtime events update the map without forcing the App shell to
+ * re-render: sidebar busy dots and reliability panels subscribe selectively.
+ */
+
+import {
+  busySessionIds,
+  type SessionLiveMap,
+  type SessionLiveSnapshot,
+} from "@/lib/sessionLiveStore";
+
+export type LiveMapBusyMeta = {
+  /** Sorted busy session ids joined — identity for Set membership. */
+  busyKey: string;
+  busyCount: number;
+  /** Bumps when busyKey changes. */
+  rev: number;
+};
+
+type Listener = () => void;
+type MapReducer = (prev: SessionLiveMap) => SessionLiveMap;
+
+function busyMetaFromMap(map: SessionLiveMap, rev: number): LiveMapBusyMeta {
+  const ids = [...busySessionIds(map)].sort();
+  return {
+    busyKey: ids.join("\0"),
+    busyCount: ids.length,
+    rev,
+  };
+}
+
+class SessionLiveMapStore {
+  private map: SessionLiveMap = {};
+  private busyMeta: LiveMapBusyMeta = { busyKey: "", busyCount: 0, rev: 0 };
+  private mapListeners = new Set<Listener>();
+  private busyListeners = new Set<Listener>();
+
+  subscribeMap = (listener: Listener): (() => void) => {
+    this.mapListeners.add(listener);
+    return () => {
+      this.mapListeners.delete(listener);
+    };
+  };
+
+  getMapSnapshot = (): SessionLiveMap => this.map;
+
+  subscribeBusy = (listener: Listener): (() => void) => {
+    this.busyListeners.add(listener);
+    return () => {
+      this.busyListeners.delete(listener);
+    };
+  };
+
+  getBusySnapshot = (): LiveMapBusyMeta => this.busyMeta;
+
+  getMap(): SessionLiveMap {
+    return this.map;
+  }
+
+  getSnapshot(sessionId: string | null | undefined): SessionLiveSnapshot | null {
+    if (!sessionId) return null;
+    return this.map[sessionId] ?? null;
+  }
+
+  private notifyMap(): void {
+    for (const l of this.mapListeners) l();
+  }
+
+  private notifyBusy(): void {
+    for (const l of this.busyListeners) l();
+  }
+
+  private commit(next: SessionLiveMap): void {
+    if (next === this.map) return;
+    this.map = next;
+    const prevKey = this.busyMeta.busyKey;
+    const nextBusy = busyMetaFromMap(next, this.busyMeta.rev);
+    if (nextBusy.busyKey !== prevKey) {
+      this.busyMeta = {
+        ...nextBusy,
+        rev: this.busyMeta.rev + 1,
+      };
+      this.notifyBusy();
+    }
+    this.notifyMap();
+  }
+
+  setMap(next: SessionLiveMap | MapReducer): void {
+    const resolved = typeof next === "function" ? next(this.map) : next;
+    this.commit(resolved);
+  }
+
+  /** React setState-compatible updater. */
+  setLiveMap = (next: SessionLiveMap | MapReducer): void => {
+    this.setMap(next);
+  };
+
+  resetForTests(): void {
+    this.map = {};
+    this.busyMeta = { busyKey: "", busyCount: 0, rev: 0 };
+  }
+}
+
+export const sessionLiveMapStore = new SessionLiveMapStore();

--- a/src/lib/sessionLiveStore.test.ts
+++ b/src/lib/sessionLiveStore.test.ts
@@ -5,6 +5,7 @@ import {
   inferTurnProgressFromMessages,
   isSessionLiveBusy,
   markSawModelOutput,
+  markSawToolActivity,
   mergeTurnProgressFromMessages,
   projectHostIntoLiveMap,
   resumeStateForSession,
@@ -202,6 +203,40 @@ describe("sessionLiveStore", () => {
     // Leaving the turn clears flags.
     map = projectHostIntoLiveMap(map, { sessionId: "a", state: "ready" });
     expect(map.a!.sawModelOutput).toBe(false);
+  });
+
+  it("markSawModelOutput is identity when already true (no thrash)", () => {
+    let map = projectHostIntoLiveMap(
+      {},
+      { sessionId: "a", state: "streaming", streamingMessageId: "m1" },
+    );
+    map = markSawModelOutput(map, "a");
+    const again = markSawModelOutput(map, "a");
+    expect(again).toBe(map);
+  });
+
+  it("markSawToolActivity is identity when already true", () => {
+    let map = projectHostIntoLiveMap(
+      {},
+      { sessionId: "a", state: "streaming", streamingMessageId: "m1" },
+    );
+    map = markSawToolActivity(map, "a");
+    const again = markSawToolActivity(map, "a");
+    expect(again).toBe(map);
+  });
+
+  it("upsertLiveSnapshot is identity when fields unchanged", () => {
+    let map = upsertLiveSnapshot(
+      {},
+      { sessionId: "a", state: "streaming", streamingMessageId: "m1" },
+      1,
+    );
+    const again = upsertLiveSnapshot(
+      map,
+      { sessionId: "a", state: "streaming", streamingMessageId: "m1" },
+      99,
+    );
+    expect(again).toBe(map);
   });
 
   it("infers turn progress from journal after last user message", () => {

--- a/src/lib/sessionLiveStore.ts
+++ b/src/lib/sessionLiveStore.ts
@@ -51,14 +51,34 @@ export function upsertLiveSnapshot(
   patch: Partial<SessionLiveSnapshot> & { sessionId: string },
   nowMs: number = Date.now(),
 ): SessionLiveMap {
-  const prev = map[patch.sessionId] ?? emptyLiveSnapshot(patch.sessionId, nowMs);
+  const existing = map[patch.sessionId];
+  const prev = existing ?? emptyLiveSnapshot(patch.sessionId, nowMs);
+  const next: SessionLiveSnapshot = {
+    ...prev,
+    ...patch,
+    updatedAt: nowMs,
+  };
+  // Bail out when an *existing* row is unchanged — stream tokens often
+  // re-project the same state/streamingMessageId and otherwise clone liveMap.
+  // Never skip the first insert (existing undefined), even if patch matches
+  // emptyLiveSnapshot defaults (e.g. state: "idle").
+  if (
+    existing &&
+    prev.state === next.state &&
+    prev.streamingMessageId === next.streamingMessageId &&
+    prev.liveToolTitle === next.liveToolTitle &&
+    prev.liveToolId === next.liveToolId &&
+    prev.terminalReason === next.terminalReason &&
+    prev.sawModelOutput === next.sawModelOutput &&
+    prev.sawToolActivity === next.sawToolActivity &&
+    prev.startedAt === next.startedAt &&
+    prev.awaitingPermission === next.awaitingPermission
+  ) {
+    return map;
+  }
   return {
     ...map,
-    [patch.sessionId]: {
-      ...prev,
-      ...patch,
-      updatedAt: nowMs,
-    },
+    [patch.sessionId]: next,
   };
 }
 
@@ -206,6 +226,10 @@ export function markSawModelOutput(
   sessionId: string,
   nowMs: number = Date.now(),
 ): SessionLiveMap {
+  // Sticky flag: once true for the turn, skip map copy + React setState thrash
+  // on every subsequent stream token.
+  const prev = map[sessionId];
+  if (prev?.sawModelOutput) return map;
   return upsertLiveSnapshot(
     map,
     { sessionId, sawModelOutput: true },
@@ -218,6 +242,8 @@ export function markSawToolActivity(
   sessionId: string,
   nowMs: number = Date.now(),
 ): SessionLiveMap {
+  const prev = map[sessionId];
+  if (prev?.sawToolActivity) return map;
   return upsertLiveSnapshot(
     map,
     { sessionId, sawToolActivity: true },

--- a/src/lib/sessionShellStore.test.ts
+++ b/src/lib/sessionShellStore.test.ts
@@ -41,7 +41,11 @@ describe("sessionShellStore", () => {
     expect(metaTicks).toBe(1);
     const rev1 = sessionShellStore.getMetaSnapshot().rev;
 
-    // streamingMessageId is not structural meta — session listeners fire, meta may not
+    // streamingMessageId is ignored for shell equality (state already streaming)
+    let sessionTicks = 0;
+    const unsubS = sessionShellStore.subscribeSession(() => {
+      sessionTicks += 1;
+    });
     sessionShellStore.setSession({
       ...IDLE_SNAPSHOT,
       sessionId: "s1",
@@ -50,6 +54,8 @@ describe("sessionShellStore", () => {
     });
     expect(sessionShellStore.getMetaSnapshot().rev).toBe(rev1);
     expect(metaTicks).toBe(1);
+    expect(sessionTicks).toBe(0);
+    unsubS();
 
     sessionShellStore.setSession({
       ...IDLE_SNAPSHOT,

--- a/src/lib/sessionShellStore.test.ts
+++ b/src/lib/sessionShellStore.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { sessionShellStore } from "./sessionShellStore";
+import { IDLE_SNAPSHOT } from "./session";
+
+describe("sessionShellStore", () => {
+  beforeEach(() => {
+    sessionShellStore.resetForTests();
+  });
+
+  it("notifies session on real change; skips identical snapshot", () => {
+    let ticks = 0;
+    const unsub = sessionShellStore.subscribeSession(() => {
+      ticks += 1;
+    });
+    sessionShellStore.setSession({
+      ...IDLE_SNAPSHOT,
+      sessionId: "s1",
+      state: "ready",
+    });
+    expect(ticks).toBe(1);
+    sessionShellStore.setSession({
+      ...IDLE_SNAPSHOT,
+      sessionId: "s1",
+      state: "ready",
+    });
+    expect(ticks).toBe(1);
+    unsub();
+  });
+
+  it("meta rev bumps only on structural fields", () => {
+    let metaTicks = 0;
+    const unsub = sessionShellStore.subscribeMeta(() => {
+      metaTicks += 1;
+    });
+    sessionShellStore.setSession({
+      ...IDLE_SNAPSHOT,
+      sessionId: "s1",
+      state: "streaming",
+      streamingMessageId: "m1",
+    });
+    expect(metaTicks).toBe(1);
+    const rev1 = sessionShellStore.getMetaSnapshot().rev;
+
+    // streamingMessageId is not structural meta — session listeners fire, meta may not
+    sessionShellStore.setSession({
+      ...IDLE_SNAPSHOT,
+      sessionId: "s1",
+      state: "streaming",
+      streamingMessageId: "m2",
+    });
+    expect(sessionShellStore.getMetaSnapshot().rev).toBe(rev1);
+    expect(metaTicks).toBe(1);
+
+    sessionShellStore.setSession({
+      ...IDLE_SNAPSHOT,
+      sessionId: "s1",
+      state: "ready",
+    });
+    expect(metaTicks).toBe(2);
+    unsub();
+  });
+});

--- a/src/lib/sessionShellStore.ts
+++ b/src/lib/sessionShellStore.ts
@@ -1,0 +1,138 @@
+/**
+ * External store for the focused session snapshot + liveHost projection.
+ *
+ * Structural meta (sessionId / state / agentSessionId) drives shell re-renders;
+ * full snapshot subscribers (composer gates, etc.) opt in explicitly.
+ */
+
+import { IDLE_SNAPSHOT, type SessionSnapshot } from "@/lib/session";
+
+export type SessionShellMeta = {
+  sessionId: string | null;
+  state: SessionSnapshot["state"];
+  agentSessionId: string | null;
+  title: string | null;
+  /** Error code key (not full message) for structural shell chips. */
+  lastErrorCode: string | null;
+  /** Bumps when any structural field above changes. */
+  rev: number;
+};
+
+type Listener = () => void;
+type SessionReducer = (prev: SessionSnapshot) => SessionSnapshot;
+
+function metaFrom(
+  s: SessionSnapshot,
+  rev: number,
+): SessionShellMeta {
+  return {
+    sessionId: s.sessionId,
+    state: s.state,
+    agentSessionId: s.agentSessionId ?? null,
+    title: s.title ?? null,
+    lastErrorCode: s.lastError?.code ?? null,
+    rev,
+  };
+}
+
+function structuralEqual(
+  a: SessionShellMeta,
+  b: Omit<SessionShellMeta, "rev">,
+): boolean {
+  return (
+    a.sessionId === b.sessionId &&
+    a.state === b.state &&
+    a.agentSessionId === b.agentSessionId &&
+    a.title === b.title &&
+    a.lastErrorCode === b.lastErrorCode
+  );
+}
+
+function shallowSessionEqual(a: SessionSnapshot, b: SessionSnapshot): boolean {
+  return (
+    a.sessionId === b.sessionId &&
+    a.state === b.state &&
+    a.agentSessionId === b.agentSessionId &&
+    a.title === b.title &&
+    a.lastError?.code === b.lastError?.code &&
+    a.lastError?.message === b.lastError?.message &&
+    a.streamingMessageId === b.streamingMessageId &&
+    a.backend === b.backend &&
+    a.modelId === b.modelId &&
+    a.projectPath === b.projectPath
+  );
+}
+
+class SessionShellStore {
+  private session: SessionSnapshot = { ...IDLE_SNAPSHOT };
+  private liveHost: SessionSnapshot = { ...IDLE_SNAPSHOT };
+  private meta: SessionShellMeta = metaFrom(IDLE_SNAPSHOT, 0);
+  private sessionListeners = new Set<Listener>();
+  private liveHostListeners = new Set<Listener>();
+  private metaListeners = new Set<Listener>();
+
+  subscribeSession = (l: Listener): (() => void) => {
+    this.sessionListeners.add(l);
+    return () => this.sessionListeners.delete(l);
+  };
+  getSessionSnapshot = (): SessionSnapshot => this.session;
+
+  subscribeLiveHost = (l: Listener): (() => void) => {
+    this.liveHostListeners.add(l);
+    return () => this.liveHostListeners.delete(l);
+  };
+  getLiveHostSnapshot = (): SessionSnapshot => this.liveHost;
+
+  subscribeMeta = (l: Listener): (() => void) => {
+    this.metaListeners.add(l);
+    return () => this.metaListeners.delete(l);
+  };
+  getMetaSnapshot = (): SessionShellMeta => this.meta;
+
+  getSession(): SessionSnapshot {
+    return this.session;
+  }
+
+  getLiveHost(): SessionSnapshot {
+    return this.liveHost;
+  }
+
+  private notifySession(): void {
+    for (const l of this.sessionListeners) l();
+  }
+  private notifyLiveHost(): void {
+    for (const l of this.liveHostListeners) l();
+  }
+  private notifyMeta(): void {
+    for (const l of this.metaListeners) l();
+  }
+
+  setSession(next: SessionSnapshot | SessionReducer): void {
+    const resolved =
+      typeof next === "function" ? next(this.session) : next;
+    if (shallowSessionEqual(this.session, resolved)) return;
+    this.session = resolved;
+    const core = metaFrom(resolved, this.meta.rev);
+    if (!structuralEqual(this.meta, core)) {
+      this.meta = { ...core, rev: this.meta.rev + 1 };
+      this.notifyMeta();
+    }
+    this.notifySession();
+  }
+
+  setLiveHost(next: SessionSnapshot | SessionReducer): void {
+    const resolved =
+      typeof next === "function" ? next(this.liveHost) : next;
+    if (shallowSessionEqual(this.liveHost, resolved)) return;
+    this.liveHost = resolved;
+    this.notifyLiveHost();
+  }
+
+  resetForTests(): void {
+    this.session = { ...IDLE_SNAPSHOT };
+    this.liveHost = { ...IDLE_SNAPSHOT };
+    this.meta = metaFrom(IDLE_SNAPSHOT, 0);
+  }
+}
+
+export const sessionShellStore = new SessionShellStore();

--- a/src/lib/sessionShellStore.ts
+++ b/src/lib/sessionShellStore.ts
@@ -49,6 +49,8 @@ function structuralEqual(
 }
 
 function shallowSessionEqual(a: SessionSnapshot, b: SessionSnapshot): boolean {
+  // streamingMessageId churns once per turn start and is not needed for shell
+  // chrome — excluding it avoids a full workbench re-render mid-stream.
   return (
     a.sessionId === b.sessionId &&
     a.state === b.state &&
@@ -56,7 +58,6 @@ function shallowSessionEqual(a: SessionSnapshot, b: SessionSnapshot): boolean {
     a.title === b.title &&
     a.lastError?.code === b.lastError?.code &&
     a.lastError?.message === b.lastError?.message &&
-    a.streamingMessageId === b.streamingMessageId &&
     a.backend === b.backend &&
     a.modelId === b.modelId &&
     a.projectPath === b.projectPath

--- a/src/lib/sessionTranscriptStore.test.ts
+++ b/src/lib/sessionTranscriptStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { sessionTranscriptStore } from "./sessionTranscriptStore";
 import type { ChatMessage } from "./session";
-import { TRANSCRIPT_CONTENT_NOTIFY_MS } from "./streamRenderPolicy";
+import { resolveTranscriptContentNotifyMs } from "./streamRenderPolicy";
 
 const msg = (
   partial: Partial<ChatMessage> & Pick<ChatMessage, "id" | "role">,
@@ -124,7 +124,7 @@ describe("sessionTranscriptStore", () => {
     expect(contentTicks).toBe(1);
     expect(sessionTranscriptStore.getMessages()[0]!.content).toBe("abc");
 
-    vi.advanceTimersByTime(TRANSCRIPT_CONTENT_NOTIFY_MS);
+    vi.advanceTimersByTime(resolveTranscriptContentNotifyMs());
     expect(contentTicks).toBe(2);
 
     unsubC();

--- a/src/lib/sessionTranscriptStore.test.ts
+++ b/src/lib/sessionTranscriptStore.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { sessionTranscriptStore } from "./sessionTranscriptStore";
+import type { ChatMessage } from "./session";
+import { TRANSCRIPT_CONTENT_NOTIFY_MS } from "./streamRenderPolicy";
+
+const msg = (
+  partial: Partial<ChatMessage> & Pick<ChatMessage, "id" | "role">,
+): ChatMessage => ({
+  content: "",
+  ...partial,
+});
+
+describe("sessionTranscriptStore", () => {
+  beforeEach(() => {
+    sessionTranscriptStore.resetForTests();
+  });
+
+  it("notifies content on stream growth but keeps structuralRev stable", () => {
+    sessionTranscriptStore.setViewingSessionId("s1");
+    sessionTranscriptStore.setMessages([
+      msg({ id: "u1", role: "user", content: "hi" }),
+      msg({ id: "a1", role: "assistant", content: "he", streaming: true }),
+    ]);
+    const rev1 = sessionTranscriptStore.getMetaSnapshot().structuralRev;
+    let contentTicks = 0;
+    let metaTicks = 0;
+    const unsubC = sessionTranscriptStore.subscribeContent(() => {
+      contentTicks += 1;
+    });
+    const unsubM = sessionTranscriptStore.subscribeMeta(() => {
+      metaTicks += 1;
+    });
+
+    sessionTranscriptStore.setMessages((prev) =>
+      prev.map((m) =>
+        m.id === "a1" ? { ...m, content: m.content + "llo" } : m,
+      ),
+    );
+
+    expect(sessionTranscriptStore.getMessages()[1]!.content).toBe("hello");
+    expect(contentTicks).toBe(1);
+    expect(metaTicks).toBe(0);
+    expect(sessionTranscriptStore.getMetaSnapshot().structuralRev).toBe(rev1);
+
+    unsubC();
+    unsubM();
+  });
+
+  it("bumps structuralRev when streaming ends", () => {
+    sessionTranscriptStore.setViewingSessionId("s1");
+    sessionTranscriptStore.setMessages([
+      msg({ id: "a1", role: "assistant", content: "x", streaming: true }),
+    ]);
+    const rev1 = sessionTranscriptStore.getMetaSnapshot().structuralRev;
+    let metaTicks = 0;
+    const unsubM = sessionTranscriptStore.subscribeMeta(() => {
+      metaTicks += 1;
+    });
+
+    sessionTranscriptStore.setMessages((prev) =>
+      prev.map((m) => (m.id === "a1" ? { ...m, streaming: false } : m)),
+    );
+
+    expect(metaTicks).toBe(1);
+    expect(sessionTranscriptStore.getMetaSnapshot().structuralRev).toBe(
+      rev1 + 1,
+    );
+    expect(sessionTranscriptStore.getMetaSnapshot().hasStreamingAssistant).toBe(
+      false,
+    );
+    unsubM();
+  });
+
+  it("patchSession only updates cache for background sessions", () => {
+    sessionTranscriptStore.setViewingSessionId("s1");
+    sessionTranscriptStore.setMessages([
+      msg({ id: "u1", role: "user", content: "viewing" }),
+    ]);
+    sessionTranscriptStore.cacheSession("s2", [
+      msg({ id: "u2", role: "user", content: "bg" }),
+    ]);
+
+    let contentTicks = 0;
+    const unsubC = sessionTranscriptStore.subscribeContent(() => {
+      contentTicks += 1;
+    });
+
+    sessionTranscriptStore.patchSession("s2", (prev) => [
+      ...prev,
+      msg({ id: "a2", role: "assistant", content: "done" }),
+    ]);
+
+    expect(contentTicks).toBe(0);
+    expect(sessionTranscriptStore.getCached("s2")).toHaveLength(2);
+    expect(sessionTranscriptStore.getMessages()).toHaveLength(1);
+    unsubC();
+  });
+
+  it("throttles content notifies for rapid stream growth (trailing flush)", () => {
+    vi.useFakeTimers();
+    sessionTranscriptStore.setViewingSessionId("s1");
+    sessionTranscriptStore.setMessages([
+      msg({ id: "a1", role: "assistant", content: "a", streaming: true }),
+    ]);
+    let contentTicks = 0;
+    const unsubC = sessionTranscriptStore.subscribeContent(() => {
+      contentTicks += 1;
+    });
+
+    // Leading edge
+    sessionTranscriptStore.setMessages((prev) =>
+      prev.map((m) =>
+        m.id === "a1" ? { ...m, content: m.content + "b" } : m,
+      ),
+    );
+    expect(contentTicks).toBe(1);
+
+    // Inside throttle window — no extra tick yet
+    sessionTranscriptStore.setMessages((prev) =>
+      prev.map((m) =>
+        m.id === "a1" ? { ...m, content: m.content + "c" } : m,
+      ),
+    );
+    expect(contentTicks).toBe(1);
+    expect(sessionTranscriptStore.getMessages()[0]!.content).toBe("abc");
+
+    vi.advanceTimersByTime(TRANSCRIPT_CONTENT_NOTIFY_MS);
+    expect(contentTicks).toBe(2);
+
+    unsubC();
+    vi.useRealTimers();
+  });
+});

--- a/src/lib/sessionTranscriptStore.ts
+++ b/src/lib/sessionTranscriptStore.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ChatMessage } from "@/lib/session";
-import { TRANSCRIPT_CONTENT_NOTIFY_MS } from "@/lib/streamRenderPolicy";
+import { resolveTranscriptContentNotifyMs } from "@/lib/streamRenderPolicy";
 
 export type TranscriptMeta = {
   /** Message count in the viewing transcript. */
@@ -166,7 +166,7 @@ class SessionTranscriptStore {
           this.contentNotifyQueued = false;
           this.flushContentListeners();
         }
-      }, TRANSCRIPT_CONTENT_NOTIFY_MS);
+      }, resolveTranscriptContentNotifyMs());
       return;
     }
     this.contentNotifyQueued = true;

--- a/src/lib/sessionTranscriptStore.ts
+++ b/src/lib/sessionTranscriptStore.ts
@@ -1,0 +1,275 @@
+/**
+ * External transcript store for the viewing session.
+ *
+ * Stream tokens update messages without forcing the whole App shell to
+ * re-render: ConversationThread subscribes to full snapshots; App shell
+ * only subscribes to a cheap structural meta snapshot.
+ */
+
+import type { ChatMessage } from "@/lib/session";
+import { TRANSCRIPT_CONTENT_NOTIFY_MS } from "@/lib/streamRenderPolicy";
+
+export type TranscriptMeta = {
+  /** Message count in the viewing transcript. */
+  length: number;
+  lastUserId: string | null;
+  hasError: boolean;
+  /** Any assistant row still marked streaming. */
+  hasStreamingAssistant: boolean;
+  /** Last message id (structural identity). */
+  tailId: string | null;
+  /**
+   * Bumps only on structural changes (add/remove/role/streaming flag/error),
+   * not on content growth of an existing streaming row.
+   */
+  structuralRev: number;
+};
+
+export type MessagesReducer = (prev: ChatMessage[]) => ChatMessage[];
+
+function computeMeta(messages: readonly ChatMessage[]): Omit<
+  TranscriptMeta,
+  "structuralRev"
+> {
+  let lastUserId: string | null = null;
+  let hasError = false;
+  let hasStreamingAssistant = false;
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i]!;
+    if (m.role === "user") lastUserId = m.id;
+    if (m.isError) hasError = true;
+    if (m.role === "assistant" && m.streaming) hasStreamingAssistant = true;
+  }
+  const tail = messages.length > 0 ? messages[messages.length - 1]! : null;
+  return {
+    length: messages.length,
+    lastUserId,
+    hasError,
+    hasStreamingAssistant,
+    tailId: tail?.id ?? null,
+  };
+}
+
+function metaStructuralEqual(
+  a: Omit<TranscriptMeta, "structuralRev">,
+  b: Omit<TranscriptMeta, "structuralRev">,
+): boolean {
+  return (
+    a.length === b.length &&
+    a.lastUserId === b.lastUserId &&
+    a.hasError === b.hasError &&
+    a.hasStreamingAssistant === b.hasStreamingAssistant &&
+    a.tailId === b.tailId
+  );
+}
+
+type Listener = () => void;
+
+class SessionTranscriptStore {
+  private messages: ChatMessage[] = [];
+  private meta: TranscriptMeta = {
+    length: 0,
+    lastUserId: null,
+    hasError: false,
+    hasStreamingAssistant: false,
+    tailId: null,
+    structuralRev: 0,
+  };
+  private bySession = new Map<string, ChatMessage[]>();
+  private viewingSessionId: string | null = null;
+  /** Prefer App's viewingSessionIdRef when set (ahead of React session state). */
+  private viewingIdResolver: (() => string | null) | null = null;
+  private contentListeners = new Set<Listener>();
+  private metaListeners = new Set<Listener>();
+  /** Leading+trailing throttle for non-structural content growth. */
+  private contentThrottleTimer: ReturnType<typeof setTimeout> | null = null;
+  private contentNotifyQueued = false;
+
+  /** Full viewing messages — for ConversationThread / export. */
+  subscribeContent = (listener: Listener): (() => void) => {
+    this.contentListeners.add(listener);
+    return () => {
+      this.contentListeners.delete(listener);
+    };
+  };
+
+  getContentSnapshot = (): ChatMessage[] => this.messages;
+
+  /** Structural meta — for App shell (welcome empty, a11y stream edge, …). */
+  subscribeMeta = (listener: Listener): (() => void) => {
+    this.metaListeners.add(listener);
+    return () => {
+      this.metaListeners.delete(listener);
+    };
+  };
+
+  getMetaSnapshot = (): TranscriptMeta => this.meta;
+
+  getMessages(): ChatMessage[] {
+    return this.messages;
+  }
+
+  getMessagesRef(): ChatMessage[] {
+    return this.messages;
+  }
+
+  getBySessionMap(): Map<string, ChatMessage[]> {
+    return this.bySession;
+  }
+
+  getCached(sessionId: string): ChatMessage[] | undefined {
+    return this.bySession.get(sessionId);
+  }
+
+  setViewingSessionId(sessionId: string | null): void {
+    this.viewingSessionId = sessionId;
+  }
+
+  /** App wires this to `() => viewingSessionIdRef.current`. */
+  setViewingIdResolver(fn: (() => string | null) | null): void {
+    this.viewingIdResolver = fn;
+  }
+
+  getViewingSessionId(): string | null {
+    if (this.viewingIdResolver) {
+      const id = this.viewingIdResolver();
+      if (id !== undefined) return id;
+    }
+    return this.viewingSessionId;
+  }
+
+  private flushContentListeners(): void {
+    for (const l of this.contentListeners) l();
+  }
+
+  /**
+   * Content listeners: structural changes notify immediately; pure token growth
+   * uses leading+trailing throttle so ConversationThread is not re-rendered on
+   * every coalesced stream flush.
+   */
+  private scheduleContentNotify(immediate: boolean): void {
+    if (immediate) {
+      if (this.contentThrottleTimer != null) {
+        clearTimeout(this.contentThrottleTimer);
+        this.contentThrottleTimer = null;
+      }
+      this.contentNotifyQueued = false;
+      this.flushContentListeners();
+      return;
+    }
+    if (this.contentThrottleTimer == null) {
+      // Leading edge.
+      this.flushContentListeners();
+      this.contentThrottleTimer = setTimeout(() => {
+        this.contentThrottleTimer = null;
+        if (this.contentNotifyQueued) {
+          this.contentNotifyQueued = false;
+          this.flushContentListeners();
+        }
+      }, TRANSCRIPT_CONTENT_NOTIFY_MS);
+      return;
+    }
+    this.contentNotifyQueued = true;
+  }
+
+  private notifyMeta(): void {
+    for (const l of this.metaListeners) l();
+  }
+
+  private commitViewing(
+    next: ChatMessage[],
+    opts?: { forceStructural?: boolean },
+  ): void {
+    const prevMetaCore = {
+      length: this.meta.length,
+      lastUserId: this.meta.lastUserId,
+      hasError: this.meta.hasError,
+      hasStreamingAssistant: this.meta.hasStreamingAssistant,
+      tailId: this.meta.tailId,
+    };
+    const nextCore = computeMeta(next);
+    const structural =
+      !!opts?.forceStructural || !metaStructuralEqual(prevMetaCore, nextCore);
+
+    this.messages = next;
+    const viewing = this.getViewingSessionId();
+    if (viewing) {
+      this.bySession.set(viewing, next);
+    }
+
+    if (structural) {
+      this.meta = {
+        ...nextCore,
+        structuralRev: this.meta.structuralRev + 1,
+      };
+      this.notifyMeta();
+    } else {
+      // Keep structuralRev stable; still refresh non-rev fields if needed.
+      this.meta = {
+        ...nextCore,
+        structuralRev: this.meta.structuralRev,
+      };
+    }
+    this.scheduleContentNotify(structural);
+  }
+
+  /** Replace viewing messages (open session / clear / optimistic full set). */
+  setMessages(next: ChatMessage[] | MessagesReducer): void {
+    const resolved =
+      typeof next === "function"
+        ? (next as MessagesReducer)(this.messages)
+        : next;
+    this.commitViewing(resolved);
+  }
+
+  /**
+   * Apply reducer to a session. Only notifies React when the target is the
+   * viewing session (background sessions stay in the cache only).
+   */
+  patchSession(
+    targetSessionId: string | null | undefined,
+    reduce: MessagesReducer,
+  ): void {
+    if (!targetSessionId) return;
+    if (this.getViewingSessionId() === targetSessionId) {
+      const next = reduce(this.messages);
+      this.commitViewing(next);
+      return;
+    }
+    const prev = this.bySession.get(targetSessionId) ?? [];
+    this.bySession.set(targetSessionId, reduce(prev));
+  }
+
+  /** Cache helper used when switching sessions (leave behind). */
+  cacheSession(sessionId: string, messages: ChatMessage[]): void {
+    this.bySession.set(sessionId, messages);
+  }
+
+  deleteSession(sessionId: string): void {
+    this.bySession.delete(sessionId);
+  }
+
+  /** Test / hot-reload reset. */
+  resetForTests(): void {
+    if (this.contentThrottleTimer != null) {
+      clearTimeout(this.contentThrottleTimer);
+      this.contentThrottleTimer = null;
+    }
+    this.contentNotifyQueued = false;
+    this.messages = [];
+    this.meta = {
+      length: 0,
+      lastUserId: null,
+      hasError: false,
+      hasStreamingAssistant: false,
+      tailId: null,
+      structuralRev: 0,
+    };
+    this.bySession.clear();
+    this.viewingSessionId = null;
+    this.viewingIdResolver = null;
+  }
+}
+
+/** App-wide singleton (one desktop window = one viewing transcript). */
+export const sessionTranscriptStore = new SessionTranscriptStore();

--- a/src/lib/streamCoalesce.ts
+++ b/src/lib/streamCoalesce.ts
@@ -56,7 +56,7 @@ export function mergeStreamChunks(
 }
 
 export type StreamCoalescerOptions = {
-  /** Max hold time before a non-terminal batch is flushed (default 48ms). */
+  /** Max hold time before a non-terminal batch is flushed (default 96ms). */
   flushMs?: number;
   /** Deliver one (possibly merged) chunk to the UI reducer. */
   onFlush: (chunk: CoalesceStreamChunk) => void;
@@ -74,7 +74,9 @@ export class StreamCoalescer {
   private disposed = false;
 
   constructor(opts: StreamCoalescerOptions) {
-    this.flushMs = Math.max(8, opts.flushMs ?? 48);
+    // Default ~10 UI flushes/sec — half of the old 48ms path, far fewer
+    // full App re-renders during long tool+markdown turns.
+    this.flushMs = Math.max(8, opts.flushMs ?? 110);
     this.onFlush = opts.onFlush;
   }
 

--- a/src/lib/streamRenderPolicy.test.ts
+++ b/src/lib/streamRenderPolicy.test.ts
@@ -3,9 +3,11 @@ import {
   CHAT_VIRTUALIZE_THRESHOLD_PERF,
   resolveStreamFlushMs,
   resolveStreamOverscanScale,
+  resolveTranscriptContentNotifyMs,
   shouldUsePlainStreamBody,
   STREAM_COALESCE_FLUSH_MS,
   STREAM_PLAIN_TEXT_CHAR_THRESHOLD,
+  TRANSCRIPT_CONTENT_NOTIFY_MS,
 } from "./streamRenderPolicy";
 
 describe("streamRenderPolicy", () => {
@@ -36,6 +38,18 @@ describe("streamRenderPolicy", () => {
     expect(resolveStreamOverscanScale(true, 16)).toBeLessThan(1);
     expect(resolveStreamOverscanScale(true, 12)).toBeLessThan(
       resolveStreamOverscanScale(true, 16),
+    );
+  });
+
+  it("content notify ms scales with hardware concurrency", () => {
+    expect(resolveTranscriptContentNotifyMs(4)).toBeGreaterThanOrEqual(
+      TRANSCRIPT_CONTENT_NOTIFY_MS,
+    );
+    expect(resolveTranscriptContentNotifyMs(12)).toBe(
+      TRANSCRIPT_CONTENT_NOTIFY_MS,
+    );
+    expect(resolveTranscriptContentNotifyMs(16)).toBeLessThan(
+      TRANSCRIPT_CONTENT_NOTIFY_MS,
     );
   });
 });

--- a/src/lib/streamRenderPolicy.test.ts
+++ b/src/lib/streamRenderPolicy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHAT_VIRTUALIZE_THRESHOLD_PERF,
+  resolveStreamFlushMs,
+  resolveStreamOverscanScale,
+  shouldUsePlainStreamBody,
+  STREAM_COALESCE_FLUSH_MS,
+  STREAM_PLAIN_TEXT_CHAR_THRESHOLD,
+} from "./streamRenderPolicy";
+
+describe("streamRenderPolicy", () => {
+  it("virtualize threshold is early enough for multi-turn agent chats", () => {
+    expect(CHAT_VIRTUALIZE_THRESHOLD_PERF).toBeLessThanOrEqual(24);
+    expect(CHAT_VIRTUALIZE_THRESHOLD_PERF).toBeGreaterThanOrEqual(12);
+  });
+
+  it("plain body only while streaming and past char threshold", () => {
+    expect(shouldUsePlainStreamBody(100, true)).toBe(false);
+    expect(
+      shouldUsePlainStreamBody(STREAM_PLAIN_TEXT_CHAR_THRESHOLD, true),
+    ).toBe(true);
+    expect(
+      shouldUsePlainStreamBody(STREAM_PLAIN_TEXT_CHAR_THRESHOLD + 1, false),
+    ).toBe(false);
+  });
+
+  it("flush ms scales with hardware concurrency", () => {
+    expect(resolveStreamFlushMs(4)).toBeGreaterThanOrEqual(STREAM_COALESCE_FLUSH_MS);
+    expect(resolveStreamFlushMs(12)).toBe(STREAM_COALESCE_FLUSH_MS);
+    expect(resolveStreamFlushMs(16)).toBeLessThan(STREAM_COALESCE_FLUSH_MS);
+  });
+
+  it("overscan scale shrinks only while streaming", () => {
+    expect(resolveStreamOverscanScale(false, 12)).toBe(1);
+    expect(resolveStreamOverscanScale(true, 12)).toBeLessThan(1);
+    expect(resolveStreamOverscanScale(true, 16)).toBeLessThan(1);
+    expect(resolveStreamOverscanScale(true, 12)).toBeLessThan(
+      resolveStreamOverscanScale(true, 16),
+    );
+  });
+});

--- a/src/lib/streamRenderPolicy.ts
+++ b/src/lib/streamRenderPolicy.ts
@@ -29,6 +29,20 @@ export const STREAM_MARKDOWN_PARSE_MS = 160;
 export const TRANSCRIPT_CONTENT_NOTIFY_MS = 100;
 
 /**
+ * Adaptive content-notify interval: longer on thermally limited laptops so
+ * ConversationThread / live panels don't thrash every stream coalesce tick.
+ */
+export function resolveTranscriptContentNotifyMs(
+  hardwareConcurrency: number = typeof navigator !== "undefined"
+    ? navigator.hardwareConcurrency || 8
+    : 8,
+): number {
+  if (hardwareConcurrency <= 8) return 130;
+  if (hardwareConcurrency <= 12) return TRANSCRIPT_CONTENT_NOTIFY_MS;
+  return 72;
+}
+
+/**
  * Past this many characters while streaming, skip live markdown and show
  * plain pre-wrap until the turn settles (one full parse on done).
  */

--- a/src/lib/streamRenderPolicy.ts
+++ b/src/lib/streamRenderPolicy.ts
@@ -1,0 +1,77 @@
+/**
+ * Streaming render / coalesce policy for chat UI.
+ *
+ * Long assistant turns re-parse markdown and re-render the App shell on every
+ * chunk. On integrated-GPU Retina laptops (e.g. 2019 16" Intel MBP), that
+ * thrash freezes the UI after a few tool-heavy turns. These knobs batch and
+ * cheapen the hot path without changing final (non-streaming) fidelity.
+ */
+
+/** Default stream→React flush interval (ms). Higher = fewer App setStates. */
+export const STREAM_COALESCE_FLUSH_MS = 110;
+
+/**
+ * Virtualize the transcript once this many rows exist (tool steps count).
+ * Lower than historical 48 so "a few agent turns" already window the DOM.
+ */
+export const CHAT_VIRTUALIZE_THRESHOLD_PERF = 16;
+
+/**
+ * While streaming, re-run ReactMarkdown at most this often (ms).
+ * Smooth/plain text can still update more often; only the parse is throttled.
+ */
+export const STREAM_MARKDOWN_PARSE_MS = 160;
+
+/**
+ * Non-structural content notify throttle for the transcript store (ms).
+ * Full text is always stored immediately; React only re-renders on this cadence.
+ */
+export const TRANSCRIPT_CONTENT_NOTIFY_MS = 100;
+
+/**
+ * Past this many characters while streaming, skip live markdown and show
+ * plain pre-wrap until the turn settles (one full parse on done).
+ */
+export const STREAM_PLAIN_TEXT_CHAR_THRESHOLD = 2000;
+
+/** Whether hardware looks like a thermally-limited laptop (Intel dual-GPU class). */
+export function isLowPowerClient(
+  hardwareConcurrency: number = typeof navigator !== "undefined"
+    ? navigator.hardwareConcurrency || 8
+    : 8,
+): boolean {
+  return hardwareConcurrency <= 12;
+}
+
+/** Prefer plain streaming body once content crosses the threshold. */
+export function shouldUsePlainStreamBody(
+  contentLength: number,
+  streaming: boolean,
+  threshold: number = STREAM_PLAIN_TEXT_CHAR_THRESHOLD,
+): boolean {
+  if (!streaming) return false;
+  return contentLength >= threshold;
+}
+
+/**
+ * Adaptive coalesce interval: slightly longer on low core counts (typical
+ * Intel dual-socket laptop cores / thermal throttle), shorter on big machines.
+ */
+export function resolveStreamFlushMs(
+  hardwareConcurrency: number = typeof navigator !== "undefined"
+    ? navigator.hardwareConcurrency || 8
+    : 8,
+): number {
+  if (hardwareConcurrency <= 8) return 128;
+  if (hardwareConcurrency <= 12) return STREAM_COALESCE_FLUSH_MS;
+  return 72;
+}
+
+/** Scale chat virtual overscan down while streaming on low-power clients. */
+export function resolveStreamOverscanScale(
+  streaming: boolean,
+  hardwareConcurrency?: number,
+): number {
+  if (!streaming) return 1;
+  return isLowPowerClient(hardwareConcurrency) ? 0.55 : 0.75;
+}

--- a/src/lib/transcriptFilterPref.test.ts
+++ b/src/lib/transcriptFilterPref.test.ts
@@ -32,12 +32,12 @@ describe("transcriptFilterPref", () => {
     vi.restoreAllMocks();
   });
 
-  it("defaults to all", () => {
-    expect(DEFAULT_TRANSCRIPT_FILTER).toBe("all");
-    expect(parseTranscriptFilterPref(null)).toBe("all");
-    expect(parseTranscriptFilterPref("")).toBe("all");
-    expect(parseTranscriptFilterPref("maybe")).toBe("all");
-    expect(loadTranscriptFilterPref(memoryStorage())).toBe("all");
+  it("defaults to conversation (fewer tool rows while streaming)", () => {
+    expect(DEFAULT_TRANSCRIPT_FILTER).toBe("conversation");
+    expect(parseTranscriptFilterPref(null)).toBe("conversation");
+    expect(parseTranscriptFilterPref("")).toBe("conversation");
+    expect(parseTranscriptFilterPref("maybe")).toBe("conversation");
+    expect(loadTranscriptFilterPref(memoryStorage())).toBe("conversation");
   });
 
   it("parses known modes", () => {
@@ -167,11 +167,10 @@ describe("filterMessagesForTranscript", () => {
     expect(out.every((m) => m.marker !== "tool_step")).toBe(true);
   });
 
-  it("defaults to all when mode omitted", () => {
+  it("defaults to conversation when mode omitted", () => {
     const rows = [user, tool1];
     expect(filterMessagesForTranscript(rows).map((m) => m.id)).toEqual([
       "u1",
-      "tool-call-1",
     ]);
   });
 });

--- a/src/lib/transcriptFilterPref.ts
+++ b/src/lib/transcriptFilterPref.ts
@@ -18,7 +18,8 @@ export const TRANSCRIPT_FILTER_CHANGE_EVENT = "grok-transcript-filter-change";
 
 export type TranscriptFilterMode = "all" | "conversation";
 
-export const DEFAULT_TRANSCRIPT_FILTER: TranscriptFilterMode = "all";
+/** Prefer conversation-only by default — fewer tool rows = less DOM thrash mid-stream. */
+export const DEFAULT_TRANSCRIPT_FILTER: TranscriptFilterMode = "conversation";
 
 /** Minimal storage surface so unit tests need no jsdom. */
 export interface TranscriptFilterStorage {
@@ -31,7 +32,7 @@ function defaultStorage(): TranscriptFilterStorage {
   return { getItem: () => null, setItem: () => {} };
 }
 
-/** Parse stored value; invalid / empty → default `all`. */
+/** Parse stored value; invalid / empty → default (conversation). */
 export function parseTranscriptFilterPref(raw: unknown): TranscriptFilterMode {
   if (raw === "conversation" || raw === "conversation_only") {
     return "conversation";

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -583,6 +583,9 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 
 .sidebar__scroll .tree-l2,
 .sidebar__scroll .tree-l3 {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 32px;
+  contain: layout style;
   border-radius: 8px;
 }
 

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -35,6 +35,28 @@ html[data-wallpaper="1"] .app-shell::after {
 }
 
 /* React media layer — behind the scrim, behind chrome. */
+/*
+ * Streaming perf mode (set by App when a turn is live):
+ * Integrated-GPU Retina (e.g. 2019 Intel MBP) pays heavily for wallpaper
+ * video + backdrop-filter while ReactMarkdown reflows every stream tick.
+ */
+html[data-stream-perf="1"] .app-wallpaper-media {
+  opacity: 0.25;
+  filter: none;
+  pointer-events: none;
+  /* Pause animated wallpapers when possible */
+}
+html[data-stream-perf="1"] .app-wallpaper-media video {
+  /* free decode/composite budget during stream */
+  visibility: hidden;
+}
+html[data-stream-perf="1"] .glass-surface,
+html[data-stream-perf="1"] .sidebar,
+html[data-stream-perf="1"] .composer-wrap--float {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
 .app-wallpaper-media {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary

Ports and lands a multi-turn chat performance suite on current `main` (post AppWorkbench split / v0.2.4), aimed at freezes after a few agent turns on dual-GPU Intel Retina laptops (e.g. 2019 16″ MBP).

### Hot path
- **External stores**: transcript (`sessionTranscriptStore`), multi-session live map (`sessionLiveMapStore`), focused session + liveHost (`sessionShellStore`)
- **`useSessionRuntime`** wired through those stores; shell keeps a **structural** messages mirror so token growth does not re-render the whole workbench
- **`ConversationThreadLive`** subscribes to full transcript content; workbench no longer passes `messages={…}` into the thread
- Stream coalesce flush is **hardware-adaptive**; long streaming bodies use plain pre-wrap then one markdown pass on settle
- Virtualize earlier; shrink overscan under `data-stream-perf`; throttle stick-to-bottom ResizeObserver while streaming

### UI / GPU
- Stream-perf mode dims wallpaper, hides wallpaper video, drops glass `backdrop-filter` during active turns
- Memoized transcript rows + stable path-map identity (siblings skip re-render when only the tail grows)
- Relative timestamps still refresh via `timeTick`

### Bundle
- Lazy `CodePreview` / Office / Tiptap / `FileMediaPlayer` in `ResourcePreviewBody`
- Default transcript filter conversation-only (fewer tool DOM rows)

### Workbench
- Live Cmd/Ctrl+F re-reads the transcript store while find is open (structural shell mirror stays cheap)

## Test plan

- [x] `tsc -b`
- [x] Vitest: stream / store / virtual list / transcript filter suites (75 tests)
- [ ] Manual: multi-turn tool-heavy chat on Intel Retina — stream should not freeze the shell
- [ ] Manual: wallpaper on → stream — wallpaper/video should drop load mid-turn
- [ ] Manual: Cmd/Ctrl+F during stream finds current content
- [ ] Manual: open code/office preview in resource pane (lazy load)