### PR TITLE
feat(desktop): Cmd/Ctrl +/- webview zoom hotkeys

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -34,6 +34,7 @@
     "core:webview:allow-set-webview-position",
     "core:webview:allow-set-webview-size",
     "core:webview:allow-set-webview-focus",
+    "core:webview:allow-set-webview-zoom",
     "core:webview:allow-webview-position",
     "core:webview:allow-webview-size",
     "core:webview:allow-get-all-webviews",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,8 @@
         "decorations": true,
         "transparent": false,
         "center": true,
-        "shadow": true
+        "shadow": true,
+        "zoomHotkeysEnabled": true
       }
     ],
     "macOSPrivateApi": true,

--- a/src/lib/zoomHotkeys.test.ts
+++ b/src/lib/zoomHotkeys.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_ZOOM_LEVEL,
+  installZoomHotkeys,
+  MAX_ZOOM_LEVEL,
+  MIN_ZOOM_LEVEL,
+  nextZoomLevel,
+  zoomHotkeyAction,
+} from "./zoomHotkeys";
+
+function key(
+  values: Partial<KeyboardEvent> = {},
+): Pick<KeyboardEvent, "altKey" | "code" | "ctrlKey" | "key" | "metaKey"> {
+  return {
+    altKey: false,
+    code: "",
+    ctrlKey: false,
+    key: "",
+    metaKey: false,
+    ...values,
+  };
+}
+
+describe("zoomHotkeys", () => {
+  it("recognizes command and control zoom keys including physical key codes", () => {
+    expect(zoomHotkeyAction(key({ metaKey: true, code: "Minus", key: "ß" }))).toBe(
+      "out",
+    );
+    expect(zoomHotkeyAction(key({ metaKey: true, code: "Equal", key: "+" }))).toBe(
+      "in",
+    );
+    expect(zoomHotkeyAction(key({ ctrlKey: true, key: "0" }))).toBe("reset");
+    expect(zoomHotkeyAction(key({ metaKey: true, altKey: true, key: "=" }))).toBe(
+      null,
+    );
+  });
+
+  it("clamps zoom levels and resets to the default", () => {
+    expect(nextZoomLevel(DEFAULT_ZOOM_LEVEL, "in")).toBe(1.2);
+    expect(nextZoomLevel(DEFAULT_ZOOM_LEVEL, "out")).toBe(0.8);
+    expect(nextZoomLevel(MAX_ZOOM_LEVEL, "in")).toBe(MAX_ZOOM_LEVEL);
+    expect(nextZoomLevel(MIN_ZOOM_LEVEL, "out")).toBe(MIN_ZOOM_LEVEL);
+    expect(nextZoomLevel(3.4, "reset")).toBe(DEFAULT_ZOOM_LEVEL);
+  });
+
+  it("handles the shortcut in capture phase and removes the listener", async () => {
+    const listeners = new Map<string, (event: KeyboardEvent) => void>();
+    const target = {
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        listeners.set(type, listener as (event: KeyboardEvent) => void);
+      }),
+      removeEventListener: vi.fn((type: string) => {
+        listeners.delete(type);
+      }),
+    };
+    const setZoom = vi.fn().mockResolvedValue(undefined);
+    const dispose = installZoomHotkeys(target, setZoom);
+    const event = {
+      ...key({ metaKey: true, code: "Minus", key: "ß" }),
+      preventDefault: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+    } as unknown as KeyboardEvent;
+
+    listeners.get("keydown")?.(event);
+    await Promise.resolve();
+
+    expect(target.addEventListener).toHaveBeenCalledWith(
+      "keydown",
+      expect.any(Function),
+      true,
+    );
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopImmediatePropagation).toHaveBeenCalledOnce();
+    expect(setZoom).toHaveBeenCalledWith(0.8);
+
+    dispose();
+    expect(target.removeEventListener).toHaveBeenCalledWith(
+      "keydown",
+      expect.any(Function),
+      true,
+    );
+  });
+});

--- a/src/lib/zoomHotkeys.ts
+++ b/src/lib/zoomHotkeys.ts
@@ -1,0 +1,93 @@
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+
+export type ZoomHotkeyAction = "in" | "out" | "reset";
+
+export const DEFAULT_ZOOM_LEVEL = 1;
+export const ZOOM_STEP = 0.2;
+export const MIN_ZOOM_LEVEL = 0.2;
+export const MAX_ZOOM_LEVEL = 10;
+
+type ZoomHotkeyEvent = Pick<
+  KeyboardEvent,
+  "altKey" | "code" | "ctrlKey" | "key" | "metaKey"
+>;
+
+export type ZoomHotkeyTarget = Pick<
+  Window,
+  "addEventListener" | "removeEventListener"
+>;
+
+export function zoomHotkeyAction(
+  event: ZoomHotkeyEvent,
+): ZoomHotkeyAction | null {
+  if (!(event.metaKey || event.ctrlKey) || event.altKey) return null;
+
+  if (
+    event.key === "-" ||
+    event.key === "Subtract" ||
+    event.code === "Minus" ||
+    event.code === "NumpadSubtract"
+  ) {
+    return "out";
+  }
+
+  if (
+    event.key === "=" ||
+    event.key === "+" ||
+    event.key === "Add" ||
+    event.code === "Equal" ||
+    event.code === "NumpadAdd"
+  ) {
+    return "in";
+  }
+
+  if (
+    event.key === "0" ||
+    event.code === "Digit0" ||
+    event.code === "Numpad0"
+  ) {
+    return "reset";
+  }
+
+  return null;
+}
+
+export function nextZoomLevel(
+  current: number,
+  action: ZoomHotkeyAction,
+): number {
+  const next =
+    action === "reset"
+      ? DEFAULT_ZOOM_LEVEL
+      : current + (action === "in" ? ZOOM_STEP : -ZOOM_STEP);
+  const clamped = Math.min(Math.max(next, MIN_ZOOM_LEVEL), MAX_ZOOM_LEVEL);
+  return Math.round(clamped * 10) / 10;
+}
+
+export function installZoomHotkeys(
+  target: ZoomHotkeyTarget,
+  setZoom: (level: number) => Promise<void> | void = (level) =>
+    getCurrentWebview().setZoom(level),
+): () => void {
+  let zoomLevel = DEFAULT_ZOOM_LEVEL;
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    const action = zoomHotkeyAction(event);
+    if (!action) return;
+
+    // Run before the app's document-level shortcut handlers and before the
+    // Tauri initialization script's bubble listener.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    zoomLevel = nextZoomLevel(zoomLevel, action);
+
+    try {
+      void Promise.resolve(setZoom(zoomLevel)).catch(() => undefined);
+    } catch {
+      // Browser previews and older hosts may not expose the Tauri command.
+    }
+  };
+
+  target.addEventListener("keydown", onKeyDown, true);
+  return () => target.removeEventListener("keydown", onKeyDown, true);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -60,6 +60,7 @@ import {
   applyWindowAlwaysOnTop,
   loadWindowAlwaysOnTopPref,
 } from "./lib/windowAlwaysOnTop";
+import { installZoomHotkeys } from "./lib/zoomHotkeys";
 
 // Apply persisted theme preference (default: system) before first React paint.
 // Optional clock schedule (under System) wins over OS scheme when enabled.
@@ -97,6 +98,15 @@ void applyNativeWindowTheme(
 );
 // Desktop always-on-top (localStorage; fail-closed outside Tauri).
 void applyWindowAlwaysOnTop(loadWindowAlwaysOnTopPref(localStorage));
+
+// The app has document-level capture handlers. Install the zoom handler on
+// window capture so Command +/- is handled before those shortcuts.
+if (
+  typeof window !== "undefined" &&
+  ("__TAURI_INTERNALS__" in window || "__TAURI__" in window)
+) {
+  installZoomHotkeys(window);
+}
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
Adds reliable desktop webview zoom via keyboard shortcuts so users can enlarge or shrink the whole UI without fighting the app's existing document-level shortcut handlers.

- **⌘/Ctrl +** zoom in (step 0.2)
- **⌘/Ctrl −** zoom out
- **⌘/Ctrl 0** reset to 1.0
- Range: 0.2–10.0

## Why
On macOS desktop, the app installs capture-phase handlers that can swallow Command +/- before Tauri's default zoom path. Installing a window-capture handler first makes zoom work consistently for accessibility / readability.

## Changes
- `src/lib/zoomHotkeys.ts` + unit tests
- wire-up in `src/main.tsx` (Tauri only)
- capability: `core:webview:allow-set-webview-zoom`
- window config: `zoomHotkeysEnabled: true`

## Test plan
- [ ] Build desktop app on macOS arm64
- [ ] ⌘+ increases UI size
- [ ] ⌘− decreases UI size
- [ ] ⌘0 resets zoom
- [ ] Shortcuts still work while chat input is focused
- [ ] unit tests for `zoomHotkeys` helpers pass

## Notes
Small self-contained UX/accessibility improvement. No settings schema migration; current zoom level is held in the hotkey installer for the process lifetime.

Thanks for considering this contribution.