### PR TITLE
perf(markdown): lazy highlight.js + plain stream body

### DIFF
--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -1,40 +1,13 @@
 /**
  * Resource-pane code preview — highlight.js (same stack as Grok Desktop)
  * with light/dark themes bound to `data-theme` on documentElement.
+ *
+ * highlight.js core + languages load on first mount via a cached dynamic
+ * import so ResourceViewer / chat cold path never pay language-pack cost at
+ * module eval. While loading, plain escaped text is shown immediately.
  */
 
 import { useEffect, useMemo, useState } from "react";
-import hljs from "highlight.js/lib/core";
-
-import javascript from "highlight.js/lib/languages/javascript";
-import typescript from "highlight.js/lib/languages/typescript";
-import json from "highlight.js/lib/languages/json";
-import markdown from "highlight.js/lib/languages/markdown";
-import rust from "highlight.js/lib/languages/rust";
-import python from "highlight.js/lib/languages/python";
-import go from "highlight.js/lib/languages/go";
-import java from "highlight.js/lib/languages/java";
-import kotlin from "highlight.js/lib/languages/kotlin";
-import c from "highlight.js/lib/languages/c";
-import cpp from "highlight.js/lib/languages/cpp";
-import csharp from "highlight.js/lib/languages/csharp";
-import ruby from "highlight.js/lib/languages/ruby";
-import php from "highlight.js/lib/languages/php";
-import swift from "highlight.js/lib/languages/swift";
-import sql from "highlight.js/lib/languages/sql";
-import bash from "highlight.js/lib/languages/bash";
-import yaml from "highlight.js/lib/languages/yaml";
-import ini from "highlight.js/lib/languages/ini";
-import css from "highlight.js/lib/languages/css";
-import scss from "highlight.js/lib/languages/scss";
-import xml from "highlight.js/lib/languages/xml";
-import dockerfile from "highlight.js/lib/languages/dockerfile";
-import makefile from "highlight.js/lib/languages/makefile";
-import diff from "highlight.js/lib/languages/diff";
-import graphql from "highlight.js/lib/languages/graphql";
-import lua from "highlight.js/lib/languages/lua";
-import r from "highlight.js/lib/languages/r";
-import plaintext from "highlight.js/lib/languages/plaintext";
 
 import { languageFromFileName } from "@/lib/codeLang";
 import { cn } from "@/lib/utils";
@@ -42,46 +15,125 @@ import { cn } from "@/lib/utils";
 // Themes: Atom One Dark / One Light (scoped in code-preview.css)
 import "@/styles/code-preview.css";
 
-let registered = false;
-function ensureLangs() {
-  if (registered) return;
-  registered = true;
-  const langs: [string, typeof javascript][] = [
-    ["javascript", javascript],
-    ["typescript", typescript],
-    ["json", json],
-    ["markdown", markdown],
-    ["rust", rust],
-    ["python", python],
-    ["go", go],
-    ["java", java],
-    ["kotlin", kotlin],
-    ["c", c],
-    ["cpp", cpp],
-    ["csharp", csharp],
-    ["ruby", ruby],
-    ["php", php],
-    ["swift", swift],
-    ["sql", sql],
-    ["bash", bash],
-    ["shell", bash],
-    ["yaml", yaml],
-    ["ini", ini],
-    ["css", css],
-    ["scss", scss],
-    ["xml", xml],
-    ["html", xml],
-    ["dockerfile", dockerfile],
-    ["makefile", makefile],
-    ["diff", diff],
-    ["graphql", graphql],
-    ["lua", lua],
-    ["r", r],
-    ["plaintext", plaintext],
-  ];
-  for (const [name, def] of langs) {
-    if (!hljs.getLanguage(name)) hljs.registerLanguage(name, def);
+type HljsCore = typeof import("highlight.js/lib/core").default;
+
+/** Module-level cached promise — languages register exactly once. */
+let hljsLoadPromise: Promise<HljsCore> | null = null;
+
+function loadHljs(): Promise<HljsCore> {
+  if (!hljsLoadPromise) {
+    hljsLoadPromise = (async () => {
+      const [
+        { default: hljs },
+        { default: javascript },
+        { default: typescript },
+        { default: json },
+        { default: markdown },
+        { default: rust },
+        { default: python },
+        { default: go },
+        { default: java },
+        { default: kotlin },
+        { default: c },
+        { default: cpp },
+        { default: csharp },
+        { default: ruby },
+        { default: php },
+        { default: swift },
+        { default: sql },
+        { default: bash },
+        { default: yaml },
+        { default: ini },
+        { default: css },
+        { default: scss },
+        { default: xml },
+        { default: dockerfile },
+        { default: makefile },
+        { default: diff },
+        { default: graphql },
+        { default: lua },
+        { default: r },
+        { default: plaintext },
+      ] = await Promise.all([
+        import("highlight.js/lib/core"),
+        import("highlight.js/lib/languages/javascript"),
+        import("highlight.js/lib/languages/typescript"),
+        import("highlight.js/lib/languages/json"),
+        import("highlight.js/lib/languages/markdown"),
+        import("highlight.js/lib/languages/rust"),
+        import("highlight.js/lib/languages/python"),
+        import("highlight.js/lib/languages/go"),
+        import("highlight.js/lib/languages/java"),
+        import("highlight.js/lib/languages/kotlin"),
+        import("highlight.js/lib/languages/c"),
+        import("highlight.js/lib/languages/cpp"),
+        import("highlight.js/lib/languages/csharp"),
+        import("highlight.js/lib/languages/ruby"),
+        import("highlight.js/lib/languages/php"),
+        import("highlight.js/lib/languages/swift"),
+        import("highlight.js/lib/languages/sql"),
+        import("highlight.js/lib/languages/bash"),
+        import("highlight.js/lib/languages/yaml"),
+        import("highlight.js/lib/languages/ini"),
+        import("highlight.js/lib/languages/css"),
+        import("highlight.js/lib/languages/scss"),
+        import("highlight.js/lib/languages/xml"),
+        import("highlight.js/lib/languages/dockerfile"),
+        import("highlight.js/lib/languages/makefile"),
+        import("highlight.js/lib/languages/diff"),
+        import("highlight.js/lib/languages/graphql"),
+        import("highlight.js/lib/languages/lua"),
+        import("highlight.js/lib/languages/r"),
+        import("highlight.js/lib/languages/plaintext"),
+      ]);
+
+      const langs: [string, typeof javascript][] = [
+        ["javascript", javascript],
+        ["typescript", typescript],
+        ["json", json],
+        ["markdown", markdown],
+        ["rust", rust],
+        ["python", python],
+        ["go", go],
+        ["java", java],
+        ["kotlin", kotlin],
+        ["c", c],
+        ["cpp", cpp],
+        ["csharp", csharp],
+        ["ruby", ruby],
+        ["php", php],
+        ["swift", swift],
+        ["sql", sql],
+        ["bash", bash],
+        ["shell", bash],
+        ["yaml", yaml],
+        ["ini", ini],
+        ["css", css],
+        ["scss", scss],
+        ["xml", xml],
+        ["html", xml],
+        ["dockerfile", dockerfile],
+        ["makefile", makefile],
+        ["diff", diff],
+        ["graphql", graphql],
+        ["lua", lua],
+        ["r", r],
+        ["plaintext", plaintext],
+      ];
+      for (const [name, def] of langs) {
+        if (!hljs.getLanguage(name)) hljs.registerLanguage(name, def);
+      }
+      return hljs;
+    })();
   }
+  return hljsLoadPromise;
+}
+
+function escapeCodeHtml(code: string): string {
+  return code
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 export interface CodePreviewProps {
@@ -108,9 +160,8 @@ export function CodePreview({
   className,
   footer,
 }: CodePreviewProps) {
-  ensureLangs();
-
   const [theme, setTheme] = useState<"light" | "dark">(readDocTheme);
+  const [hljs, setHljs] = useState<HljsCore | null>(null);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -121,6 +172,16 @@ export function CodePreview({
     return () => mo.disconnect();
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    void loadHljs().then((mod) => {
+      if (!cancelled) setHljs(mod);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const lang = useMemo(() => {
     if (language && language !== "auto") return language;
     if (fileName) return languageFromFileName(fileName);
@@ -128,6 +189,8 @@ export function CodePreview({
   }, [language, fileName]);
 
   const html = useMemo(() => {
+    // Show plain escaped text immediately while highlight.js loads (no empty flash).
+    if (!hljs) return escapeCodeHtml(code);
     try {
       if (lang && hljs.getLanguage(lang)) {
         return hljs.highlight(code, { language: lang, ignoreIllegals: true })
@@ -135,13 +198,9 @@ export function CodePreview({
       }
       return hljs.highlightAuto(code).value;
     } catch {
-      // Escape minimal HTML if highlight fails
-      return code
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
+      return escapeCodeHtml(code);
     }
-  }, [code, lang]);
+  }, [code, lang, hljs]);
 
   const lines = useMemo(() => {
     // Keep trailing newline as empty last line for gutter count

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -2,7 +2,16 @@
  * Chat markdown — path/url → cards (image/video/file); open in resource pane.
  */
 
-import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  lazy,
+  memo,
+  Suspense,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Locale } from "@/i18n";
@@ -34,9 +43,16 @@ import {
   stepSoftBuffer,
   type SoftBufferState,
 } from "@/lib/softStreamBuffer";
+import {
+  shouldUsePlainStreamBody,
+  STREAM_MARKDOWN_PARSE_MS,
+} from "@/lib/streamRenderPolicy";
 import { revealInOsLabel } from "@/lib/appPlatform";
 import { cn } from "@/lib/utils";
-import { CodeBlock } from "./CodeBlock";
+
+const CodeBlock = lazy(() =>
+  import("./CodeBlock").then((m) => ({ default: m.CodeBlock })),
+);
 
 /** Highlight string leaves for in-chat find (markdown-safe). */
 function highlightChildren(
@@ -219,11 +235,34 @@ export const MarkdownChat = memo(function MarkdownChat({
   }, [children, streaming]);
 
   const buffered = streaming ? softDisplayed : children || "";
-  const smoothChildren = useSmoothStream(buffered, streaming && !!buffered);
-  const source = softCloseMarkdown(
-    smoothChildren || (streaming ? " " : ""),
+  const longStream = shouldUsePlainStreamBody(
+    (buffered || children || "").length,
     streaming,
   );
+  const smoothChildren = useSmoothStream(
+    buffered,
+    streaming && !!buffered && !longStream,
+  );
+  const liveText =
+    (longStream ? buffered : smoothChildren) || (streaming ? " " : "");
+  const source = softCloseMarkdown(liveText, streaming);
+
+  /**
+   * Throttle ReactMarkdown input while streaming so we re-parse ~6×/s instead
+   * of every smooth-stream tick. Final (non-streaming) content always syncs.
+   */
+  const [mdSource, setMdSource] = useState(source);
+  useEffect(() => {
+    if (!streaming) {
+      setMdSource(source);
+      return;
+    }
+    if (longStream) return;
+    const id = window.setTimeout(() => {
+      setMdSource(source);
+    }, STREAM_MARKDOWN_PARSE_MS);
+    return () => window.clearTimeout(id);
+  }, [source, streaming, longStream]);
 
   const renderPathOrUrl = (token: string, linkText?: string) => {
     const rawIn = token.trim().replace(/^<|>$/g, "");
@@ -376,6 +415,25 @@ export const MarkdownChat = memo(function MarkdownChat({
       ? highlightChildren(node, qFind, findActiveOccurrence, findCounter)
       : node;
 
+  // Long streaming bodies: plain pre-wrap (no remark parse) until the turn
+  // settles — one full markdown pass on done. Prevents O(n) parse storms.
+  if (longStream) {
+    return (
+      <div
+        className={cn(
+          "chat-md",
+          "chat-md--streaming",
+          "chat-md--plain-stream",
+          muted && "chat-md--muted",
+          className,
+        )}
+        data-stream-mode="plain"
+      >
+        <pre className="chat-md__plain-stream">{liveText}</pre>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -452,14 +510,22 @@ export const MarkdownChat = memo(function MarkdownChat({
               );
             }
             return (
-              <CodeBlock
-                language={match?.[1] || "text"}
-                wrapLabel={tr("chat.codeWrap")}
-                unwrapLabel={tr("chat.codeUnwrap")}
-                copyLabel={tr("message.copy")}
+              <Suspense
+                fallback={
+                  <pre className="chat-code__pre">
+                    <code>{c as ReactNode}</code>
+                  </pre>
+                }
               >
-                {c as ReactNode}
-              </CodeBlock>
+                <CodeBlock
+                  language={match?.[1] || "text"}
+                  wrapLabel={tr("chat.codeWrap")}
+                  unwrapLabel={tr("chat.codeUnwrap")}
+                  copyLabel={tr("message.copy")}
+                >
+                  {c as ReactNode}
+                </CodeBlock>
+              </Suspense>
             );
           },
           table: ({ children: c }) => (
@@ -486,7 +552,7 @@ export const MarkdownChat = memo(function MarkdownChat({
           },
         }}
       >
-        {source}
+        {mdSource}
       </ReactMarkdown>
     </div>
   );

--- a/src/components/lobe-chat/lobe-chat.part1.css
+++ b/src/components/lobe-chat/lobe-chat.part1.css
@@ -704,6 +704,22 @@ html[data-msg-actions="always"] .lobe-chat-item__actions {
   display: none;
 }
 
+/* Long stream: skip ReactMarkdown — plain pre-wrap until turn settles */
+.chat-md--plain-stream {
+  white-space: normal;
+}
+.chat-md__plain-stream {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
 /* Muted prose only — do not paint code blocks with secondary/low-contrast ink */
 .chat-md--muted {
   color: var(--chat-text-2);

--- a/src/components/resource-viewer/ResourcePreviewBody.tsx
+++ b/src/components/resource-viewer/ResourcePreviewBody.tsx
@@ -3,7 +3,7 @@
  * Presentational: all actions/state come from props (behavior freeze).
  */
 
-import type { ReactNode } from "react";
+import { lazy, Suspense, type ReactNode } from "react";
 import * as api from "@/lib/api";
 import type { Locale, MessageKey } from "@/i18n";
 import {
@@ -30,7 +30,6 @@ import {
   IconRewind,
 } from "@/components/icons";
 import { OfficeDocumentPreview } from "@/components/OfficeDocumentPreview";
-import { CodePreview } from "@/components/CodePreview";
 import { isOfficeKind } from "@/lib/filePreviewSrc";
 import { Tip } from "@/components/ui/tooltip";
 import { normalizePath } from "@/lib/sessionChanges";
@@ -42,6 +41,36 @@ import {
 } from "@/lib/resourceEdit";
 import type { DiffLayout, DiffViewState, FileTab, SideMode } from "./types";
 import { formatSize, guessOfficeKind } from "./helpers";
+
+const CodePreview = lazy(() =>
+  import("@/components/CodePreview").then((m) => ({ default: m.CodePreview })),
+);
+
+/** Plain pre while highlight.js / CodePreview chunk loads. */
+function CodePreviewFallback({
+  code,
+  className,
+}: {
+  code: string;
+  className?: string;
+}) {
+  return (
+    <pre
+      className={className}
+      style={{
+        margin: 0,
+        padding: "12px 14px",
+        whiteSpace: "pre",
+        overflow: "auto",
+        fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+        fontSize: 12.5,
+        lineHeight: 1.55,
+      }}
+    >
+      {code}
+    </pre>
+  );
+}
 
 export type ResourcePreviewBodyProps = {
   tr: (key: MessageKey, vars?: Record<string, string>) => string;
@@ -386,21 +415,39 @@ export function ResourcePreviewBody({
               <div className="rp-diff-split__label">
                 {tr("changes.split.before")}
               </div>
-              <CodePreview
-                code={diffView.beforeText ?? ""}
-                fileName={diffView.name}
-                className="rp-diff-split__code"
-              />
+              <Suspense
+                fallback={
+                  <CodePreviewFallback
+                    code={diffView.beforeText ?? ""}
+                    className="rp-diff-split__code"
+                  />
+                }
+              >
+                <CodePreview
+                  code={diffView.beforeText ?? ""}
+                  fileName={diffView.name}
+                  className="rp-diff-split__code"
+                />
+              </Suspense>
             </div>
             <div className="rp-diff-split__pane">
               <div className="rp-diff-split__label">
                 {tr("changes.split.after")}
               </div>
-              <CodePreview
-                code={diffView.afterText ?? ""}
-                fileName={diffView.name}
-                className="rp-diff-split__code"
-              />
+              <Suspense
+                fallback={
+                  <CodePreviewFallback
+                    code={diffView.afterText ?? ""}
+                    className="rp-diff-split__code"
+                  />
+                }
+              >
+                <CodePreview
+                  code={diffView.afterText ?? ""}
+                  fileName={diffView.name}
+                  className="rp-diff-split__code"
+                />
+              </Suspense>
             </div>
           </div>
         </div>
@@ -412,12 +459,16 @@ export function ResourcePreviewBody({
         <div className="rp-diff-host">
           {toolbar}
           {hunkBar}
-          <CodePreview
-            code={diffView.unified}
-            fileName={`${diffView.name}.diff`}
-            language="diff"
-            footer={srcLabel}
-          />
+          <Suspense
+            fallback={<CodePreviewFallback code={diffView.unified} />}
+          >
+            <CodePreview
+              code={diffView.unified}
+              fileName={`${diffView.name}.diff`}
+              language="diff"
+              footer={srcLabel}
+            />
+          </Suspense>
         </div>
       );
     }
@@ -425,11 +476,15 @@ export function ResourcePreviewBody({
       return (
         <div className="rp-diff-host">
           {toolbar}
-          <CodePreview
-            code={diffView.afterOnly}
-            fileName={diffView.name}
-            footer={tr("changes.afterOnly")}
-          />
+          <Suspense
+            fallback={<CodePreviewFallback code={diffView.afterOnly} />}
+          >
+            <CodePreview
+              code={diffView.afterOnly}
+              fileName={diffView.name}
+              footer={tr("changes.afterOnly")}
+            />
+          </Suspense>
         </div>
       );
     }
@@ -784,26 +839,30 @@ export function ResourcePreviewBody({
         /* keep raw */
       }
       return (
-        <CodePreview
-          code={body}
-          fileName={preview.name.endsWith(".json") ? preview.name : "data.json"}
-          language="json"
-          footer={
-            preview.truncated ? tr("resources.truncated") : null
-          }
-        />
+        <Suspense fallback={<CodePreviewFallback code={body} />}>
+          <CodePreview
+            code={body}
+            fileName={preview.name.endsWith(".json") ? preview.name : "data.json"}
+            language="json"
+            footer={
+              preview.truncated ? tr("resources.truncated") : null
+            }
+          />
+        </Suspense>
       );
     }
     default:
       if (preview.text) {
         return (
-          <CodePreview
-            code={preview.text}
-            fileName={preview.name}
-            footer={
-              preview.truncated ? tr("resources.truncated") : null
-            }
-          />
+          <Suspense fallback={<CodePreviewFallback code={preview.text} />}>
+            <CodePreview
+              code={preview.text}
+              fileName={preview.name}
+              footer={
+                preview.truncated ? tr("resources.truncated") : null
+              }
+            />
+          </Suspense>
         );
       }
       return (

--- a/src/lib/streamRenderPolicy.test.ts
+++ b/src/lib/streamRenderPolicy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldUsePlainStreamBody,
+  STREAM_PLAIN_TEXT_CHAR_THRESHOLD,
+} from "./streamRenderPolicy";
+
+describe("shouldUsePlainStreamBody", () => {
+  it("is false when not streaming", () => {
+    expect(shouldUsePlainStreamBody(0, false)).toBe(false);
+    expect(
+      shouldUsePlainStreamBody(STREAM_PLAIN_TEXT_CHAR_THRESHOLD + 100, false),
+    ).toBe(false);
+  });
+
+  it("is false while streaming below the char threshold", () => {
+    expect(shouldUsePlainStreamBody(0, true)).toBe(false);
+    expect(shouldUsePlainStreamBody(100, true)).toBe(false);
+    expect(
+      shouldUsePlainStreamBody(STREAM_PLAIN_TEXT_CHAR_THRESHOLD - 1, true),
+    ).toBe(false);
+  });
+
+  it("is true while streaming at or past the char threshold", () => {
+    expect(
+      shouldUsePlainStreamBody(STREAM_PLAIN_TEXT_CHAR_THRESHOLD, true),
+    ).toBe(true);
+    expect(
+      shouldUsePlainStreamBody(STREAM_PLAIN_TEXT_CHAR_THRESHOLD + 1, true),
+    ).toBe(true);
+  });
+
+  it("respects a custom threshold", () => {
+    expect(shouldUsePlainStreamBody(50, true, 100)).toBe(false);
+    expect(shouldUsePlainStreamBody(100, true, 100)).toBe(true);
+  });
+});

--- a/src/lib/streamRenderPolicy.ts
+++ b/src/lib/streamRenderPolicy.ts
@@ -1,0 +1,28 @@
+/**
+ * Streaming render policy for chat markdown.
+ *
+ * Long assistant turns re-parse markdown on every chunk. These knobs cheapen
+ * the hot path without changing final (non-streaming) fidelity.
+ */
+
+/**
+ * While streaming, re-run ReactMarkdown at most this often (ms).
+ * Smooth/plain text can still update more often; only the parse is throttled.
+ */
+export const STREAM_MARKDOWN_PARSE_MS = 160;
+
+/**
+ * Past this many characters while streaming, skip live markdown and show
+ * plain pre-wrap until the turn settles (one full parse on done).
+ */
+export const STREAM_PLAIN_TEXT_CHAR_THRESHOLD = 2000;
+
+/** Prefer plain streaming body once content crosses the threshold. */
+export function shouldUsePlainStreamBody(
+  contentLength: number,
+  streaming: boolean,
+  threshold: number = STREAM_PLAIN_TEXT_CHAR_THRESHOLD,
+): boolean {
+  if (!streaming) return false;
+  return contentLength >= threshold;
+}


### PR DESCRIPTION
## Summary
Secondary code-splitting for the markdown/code path so chat cold start and long streaming turns do not pay full highlight.js / remark cost up front.

- **CodePreview**: dynamic `import()` of highlight.js core + languages (cached); plain escaped text until ready
- **ResourceViewer**: `React.lazy` CodePreview with plain-code Suspense fallback
- **MarkdownChat**: plain pre-wrap body while streaming past 2000 chars; throttle ReactMarkdown re-parse (~160ms); lazy `CodeBlock`

## Test plan
- [ ] Open a code file in the resource pane — first open may load hljs chunk; content still readable immediately
- [ ] Stream a long assistant reply with code fences — UI stays responsive; settles to full markdown when done
- [ ] `pnpm exec tsc --noEmit`
- [ ] `pnpm exec vitest run src/lib/streamRenderPolicy.test.ts`

Independent of #505 stream isolation PR.