### PR TITLE
perf(sidebar): memo session row + isolate relative time

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -37,10 +37,7 @@ import {
   saveSidebarShowRelativeTimePref,
   SIDEBAR_SHOW_RELATIVE_TIME_CHANGE_EVENT
 } from "@/lib/sidebarShowRelativeTimePref";
-import {
-  formatMessageTime,
-  formatRelativeTime
-} from "@/lib/accountUi";
+import { formatRelativeTime } from "@/lib/accountUi";
 import { loadConfirmExternalLinksPref } from "@/lib/externalLinkPref";
 import { loadStopAllSkipConfirmPref } from "@/lib/stopAllSkipConfirmPref";
 import { detectAppPlatform, revealInOsLabel } from "@/lib/appPlatform";
@@ -645,7 +642,11 @@ import { AttachmentCard } from "@/components/AttachmentCard";
 import { ImageViewerProvider } from "@/components/ImageViewer";
 import { OverlayScroll } from "@/components/OverlayScroll";
 import { VirtualList } from "@/components/VirtualList";
-import { SidebarSessionName } from "@/components/SidebarSessionName";
+import {
+  SidebarSessionRow,
+  type SidebarSessionRowLabels,
+  type SidebarSessionWorktreeBadgeProp,
+} from "@/components/SidebarSessionRow";
 import {
   SIDEBAR_DENSITY_EVENT,
   loadSidebarDensity,
@@ -867,7 +868,6 @@ import {
   preferPermissionFocus,
   trapTabKey
 } from "@/lib/a11yFocus";
-import { Spinner } from "@/components/ui/spinner";
 import { UserMenu, remainingPercent } from "@/components/UserMenu";
 import {
   SettingsPage,
@@ -963,8 +963,6 @@ export function AppWorkbench() {
   const [sidebarShowRelativeTime, setSidebarShowRelativeTime] = useState(() =>
     loadSidebarShowRelativeTimePref(localStorage),
   );
-  /** Shared tick so relative session labels recompute ~once a minute. */
-  const [sidebarRelativeTick, setSidebarRelativeTick] = useState(0);
   // Warm loopback media HTTP endpoint ASAP so chat images resolve to
   // http://127.0.0.1 (not media://) before the first history paint.
   useEffect(() => {
@@ -974,13 +972,6 @@ export function AppWorkbench() {
         /* non-Tauri / server down */
       });
   }, []);
-  useEffect(() => {
-    if (!sidebarShowRelativeTime) return;
-    const id = window.setInterval(() => {
-      setSidebarRelativeTick((n) => n + 1);
-    }, 60_000);
-    return () => window.clearInterval(id);
-  }, [sidebarShowRelativeTime]);
   useEffect(() => {
     const reload = () =>
       setSidebarShowRelativeTime(loadSidebarShowRelativeTimePref(localStorage));
@@ -5946,21 +5937,6 @@ export function AppWorkbench() {
     }
   };
 
-  /** One-line muted relative updated time for sidebar session rows. */
-  const renderSessionRelativeTime = (updatedAt: string | undefined) => {
-    // Keep tick in the render graph so the shared 60s interval refreshes labels.
-    void sidebarRelativeTick;
-    if (!sidebarShowRelativeTime || !updatedAt) return null;
-    const label = formatRelativeTime(updatedAt, locale);
-    if (!label || label === "—") return null;
-    const absolute = formatMessageTime(updatedAt, locale);
-    return (
-      <span className="tree-l3__time" title={absolute || undefined}>
-        {label}
-      </span>
-    );
-  };
-
   const copySessionId = async (s: SessionRow) => {
     setCtxMenu(null);
     try {
@@ -5975,6 +5951,75 @@ export function AppWorkbench() {
     e.stopPropagation();
     setCtxMenu({ kind: "session", id: s.id, x: e.clientX, y: e.clientY });
   };
+
+  // Stable refs so memoized SidebarSessionRow does not re-render on App stream ticks.
+  const pinSessionRef = useRef(pinSession);
+  pinSessionRef.current = pinSession;
+  const archiveSessionRef = useRef(archiveSession);
+  archiveSessionRef.current = archiveSession;
+  const openSessionMenuRef = useRef(openSessionMenu);
+  openSessionMenuRef.current = openSessionMenu;
+
+  const resolveSidebarSession = useCallback(
+    (partial: { id: string }): SessionRow =>
+      sessionsRef.current.find((x) => x.id === partial.id) ??
+      (partial as SessionRow),
+    [],
+  );
+
+  const onSidebarSessionOpen = useCallback(
+    (s: { id: string }) => {
+      void openSessionRef.current(resolveSidebarSession(s));
+    },
+    [resolveSidebarSession],
+  );
+
+  const onSidebarSessionContextMenu = useCallback(
+    (e: ReactMouseEvent, s: { id: string }) => {
+      openSessionMenuRef.current(e, resolveSidebarSession(s));
+    },
+    [resolveSidebarSession],
+  );
+
+  const onSidebarSessionPin = useCallback(
+    (s: { id: string; pinned?: boolean }) => {
+      const full = resolveSidebarSession(s);
+      void pinSessionRef.current(full, !full.pinned);
+    },
+    [resolveSidebarSession],
+  );
+
+  const onSidebarSessionArchive = useCallback(
+    (s: { id: string; archived?: boolean }) => {
+      const full = resolveSidebarSession(s);
+      void archiveSessionRef.current(full, !full.archived);
+    },
+    [resolveSidebarSession],
+  );
+
+  const onSidebarSessionMenu = useCallback(
+    (e: ReactMouseEvent, s: { id: string }) => {
+      openSessionMenuRef.current(e, resolveSidebarSession(s));
+    },
+    [resolveSidebarSession],
+  );
+
+  const sidebarSessionLabels = useMemo<SidebarSessionRowLabels>(
+    () => ({
+      unreadAria: tr("session.unreadAria"),
+      pinned: tr("session.pinned"),
+      muted: tr("session.muted"),
+      noteAria: tr("session.noteAria"),
+      automationsTag: tr("automations.msgTag"),
+      working: tr("sidebar.sessionWorking"),
+      pin: tr("session.pin"),
+      unpin: tr("session.unpin"),
+      archive: tr("sidebar.archive"),
+      unarchive: tr("sidebar.unarchive"),
+      menu: tr("sidebar.menu"),
+    }),
+    [tr],
+  );
 
   const handleToggleSessionMute = useCallback((sessionId: string) => {
     toggleSessionMute(sessionId);
@@ -11377,6 +11422,34 @@ export function AppWorkbench() {
     [cliGrokHome, gitWorktrees, projects],
   );
 
+  /** Pre-translated worktree chip for memoized SidebarSessionRow. */
+  const buildSidebarWorktreeBadge = useCallback(
+    (s: SessionRow): SidebarSessionWorktreeBadgeProp | null => {
+      const wtBadge = sessionWorktreeBadgeFor(s);
+      if (!wtBadge) return null;
+      const title = sessionWorktreeTooltip(wtBadge, {
+        detachedLabel: tr("composer.worktreeDetached"),
+        cliLayoutLabel: tr("session.worktreeLayoutCli"),
+        siblingLayoutLabel: tr("session.worktreeLayoutSibling"),
+        otherLayoutLabel: tr("session.worktreeBadge"),
+      });
+      const ariaKey =
+        wtBadge.layoutKind === "cli"
+          ? "session.worktreeBadgeCliAria"
+          : "session.worktreeBadgeAria";
+      return {
+        label: wtBadge.label,
+        branch: wtBadge.branch,
+        layoutKind: wtBadge.layoutKind,
+        title,
+        ariaLabel: tr(ariaKey, {
+          branch: wtBadge.branch || tr("composer.worktreeDetached"),
+        }),
+      };
+    },
+    [sessionWorktreeBadgeFor, tr],
+  );
+
   /**
    * Create worktree → refresh list → add as project (trust inherited) →
    * either bind current session or start a draft chat on that path.
@@ -15781,258 +15854,41 @@ export function AppWorkbench() {
                                     const checked =
                                       selectedSessionIds.has(s.id);
                                     const unread = unreadSessionIds.has(s.id);
+                                    const noteRaw =
+                                      sessionNotesMap[s.id]?.trim() || "";
                                     return (
-                                      <div
-                                        className={
-                                          "tree-l3" +
-                                          (session.sessionId === s.id
-                                            ? " tree-l3--active"
-                                            : "") +
-                                          (s.archived
-                                            ? " tree-l3--archived"
-                                            : "") +
-                                          (working ? " tree-l3--working" : "") +
-                                          (unread ? " tree-l3--unread" : "") +
-                                          (sessionSelectMode
-                                            ? " tree-l3--select-mode"
-                                            : "") +
-                                          (checked ? " tree-l3--checked" : "")
+                                      <SidebarSessionRow
+                                        session={s}
+                                        variant="project"
+                                        active={session.sessionId === s.id}
+                                        working={working}
+                                        unread={unread}
+                                        checked={checked}
+                                        selectMode={sessionSelectMode}
+                                        muted={mutedSessionIds.has(s.id)}
+                                        noteTitle={
+                                          noteRaw
+                                            ? notePreview(noteRaw) ||
+                                              sidebarSessionLabels.noteAria
+                                            : null
                                         }
-                                        role="button"
-                                        tabIndex={0}
-                                        aria-checked={
-                                          sessionSelectMode
-                                            ? checked
-                                            : undefined
-                                        }
-                                        onClick={() => {
-                                          if (sessionSelectMode) {
-                                            toggleSessionSelected(s.id);
-                                            return;
-                                          }
-                                          void openSession(s, proj);
-                                        }}
-                                        onContextMenu={(e) =>
-                                          openSessionMenu(e, s)
-                                        }
-                                        onKeyDown={(e) => {
-                                          if (
-                                            e.key === "Enter" ||
-                                            e.key === " "
-                                          ) {
-                                            if (sessionSelectMode) {
-                                              e.preventDefault();
-                                              toggleSessionSelected(s.id);
-                                              return;
-                                            }
-                                            if (e.key === "Enter")
-                                              void openSession(s, proj);
-                                          }
-                                        }}
-                                      >
-                                        {sessionSelectMode ? (
-                                          <span
-                                            className={
-                                              "tree-l3__check" +
-                                              (checked ? " is-on" : "")
-                                            }
-                                            aria-hidden
-                                          >
-                                            {checked ? (
-                                              <IconCheck
-                                                size={11}
-                                                stroke={2.4}
-                                              />
-                                            ) : null}
-                                          </span>
-                                        ) : null}
-                                        <span className="tree-l3__title">
-                                          {unread ? (
-                                            <span
-                                              className="tree-l3__unread"
-                                              title={tr("session.unreadAria")}
-                                              aria-label={tr(
-                                                "session.unreadAria",
-                                              )}
-                                            />
-                                          ) : null}
-                                          {s.pinned ? (
-                                            <span
-                                              className="tree-l3__kind"
-                                              title={tr("session.pinned")}
-                                              aria-label={tr("session.pinned")}
-                                            >
-                                              <IconPin
-                                                size={12}
-                                                className="tree-l3__pin"
-                                              />
-                                            </span>
-                                          ) : null}
-                                          {mutedSessionIds.has(s.id) ? (
-                                            <span
-                                              className="tree-l3__kind tree-l3__muted"
-                                              title={tr("session.muted")}
-                                              aria-label={tr("session.muted")}
-                                            >
-                                              <IconBellOff size={12} />
-                                            </span>
-                                          ) : null}
-                                          {sessionNotesMap[s.id]?.trim() ? (
-                                            <span
-                                              className="tree-l3__kind"
-                                              title={
-                                                notePreview(
-                                                  sessionNotesMap[s.id],
-                                                ) || tr("session.noteAria")
-                                              }
-                                              aria-label={tr("session.noteAria")}
-                                            >
-                                              <IconNotes size={12} />
-                                            </span>
-                                          ) : null}
-                                          {s.scheduled ? (
-                                            <span
-                                              className="tree-l3__kind"
-                                              title={tr("automations.msgTag")}
-                                              aria-label={tr(
-                                                "automations.msgTag",
-                                              )}
-                                            >
-                                              <IconClock size={13} />
-                                            </span>
-                                          ) : null}
-                                          {(() => {
-                                            const wtBadge =
-                                              sessionWorktreeBadgeFor(s);
-                                            if (!wtBadge) return null;
-                                            const tip = sessionWorktreeTooltip(
-                                              wtBadge,
-                                              {
-                                                detachedLabel: tr(
-                                                  "composer.worktreeDetached",
-                                                ),
-                                                cliLayoutLabel: tr(
-                                                  "session.worktreeLayoutCli",
-                                                ),
-                                                siblingLayoutLabel: tr(
-                                                  "session.worktreeLayoutSibling",
-                                                ),
-                                                otherLayoutLabel: tr(
-                                                  "session.worktreeBadge",
-                                                ),
-                                              },
-                                            );
-                                            const ariaKey =
-                                              wtBadge.layoutKind === "cli"
-                                                ? "session.worktreeBadgeCliAria"
-                                                : "session.worktreeBadgeAria";
-                                            return (
-                                              <span
-                                                className={
-                                                  "tree-l3__wt" +
-                                                  (wtBadge.layoutKind === "cli"
-                                                    ? " tree-l3__wt--cli"
-                                                    : wtBadge.layoutKind ===
-                                                        "sibling"
-                                                      ? " tree-l3__wt--sibling"
-                                                      : "")
-                                                }
-                                                title={tip}
-                                                aria-label={tr(ariaKey, {
-                                                  branch:
-                                                    wtBadge.branch ||
-                                                    tr(
-                                                      "composer.worktreeDetached",
-                                                    ),
-                                                })}
-                                              >
-                                                {wtBadge.label}
-                                              </span>
-                                            );
-                                          })()}
-                                          <SidebarSessionName
-                                            title={s.title || "Untitled"}
-                                          />
-                                        </span>
-                                        {renderSessionRelativeTime(s.updatedAt)}
-                                        {sessionSelectMode ? null : working ? (
-                                          <Tip
-                                            label={tr("sidebar.sessionWorking")}
-                                          >
-                                            <span
-                                              className="tree-l3__status"
-                                              aria-label={tr(
-                                                "sidebar.sessionWorking",
-                                              )}
-                                            >
-                                              <Spinner
-                                                size={14}
-                                                className="tree-l3__spinner"
-                                              />
-                                            </span>
-                                          </Tip>
-                                        ) : (
-                                          <span className="tree-l3__actions tree-l3__actions--triple">
-                                            <Tip
-                                              label={
-                                                s.pinned
-                                                  ? tr("session.unpin")
-                                                  : tr("session.pin")
-                                              }
-                                            >
-                                              <button
-                                                type="button"
-                                                className="tree-icon-btn"
-                                                onClick={(e) => {
-                                                  e.stopPropagation();
-                                                  void pinSession(
-                                                    s,
-                                                    !s.pinned,
-                                                  );
-                                                }}
-                                              >
-                                                {s.pinned ? (
-                                                  <IconPinOff size={13} />
-                                                ) : (
-                                                  <IconPin size={13} />
-                                                )}
-                                              </button>
-                                            </Tip>
-                                            <Tip
-                                              label={
-                                                s.archived
-                                                  ? tr("sidebar.unarchive")
-                                                  : tr("sidebar.archive")
-                                              }
-                                            >
-                                              <button
-                                                type="button"
-                                                className="tree-icon-btn"
-                                                onClick={(e) => {
-                                                  e.stopPropagation();
-                                                  void archiveSession(
-                                                    s,
-                                                    !s.archived,
-                                                  );
-                                                }}
-                                              >
-                                                <IconArchive size={13} />
-                                              </button>
-                                            </Tip>
-                                            <Tip label={tr("sidebar.menu")}>
-                                              <button
-                                                type="button"
-                                                className="tree-icon-btn"
-                                                onClick={(e) =>
-                                                  openSessionMenu(e, s)
-                                                }
-                                              >
-                                                <IconMore size={13} />
-                                              </button>
-                                            </Tip>
-                                          </span>
+                                        worktreeBadge={buildSidebarWorktreeBadge(
+                                          s,
                                         )}
-                                      </div>
+                                        labels={sidebarSessionLabels}
+                                        locale={locale}
+                                        showRelativeTime={
+                                          sidebarShowRelativeTime
+                                        }
+                                        onOpen={onSidebarSessionOpen}
+                                        onContextMenu={
+                                          onSidebarSessionContextMenu
+                                        }
+                                        onToggleSelect={toggleSessionSelected}
+                                        onPin={onSidebarSessionPin}
+                                        onArchive={onSidebarSessionArchive}
+                                        onMenu={onSidebarSessionMenu}
+                                      />
                                     );
                                   }}
                                 />
@@ -16089,212 +15945,35 @@ export function AppWorkbench() {
                           const working = busyIds.has(s.id);
                           const checked = selectedSessionIds.has(s.id);
                           const unread = unreadSessionIds.has(s.id);
+                          const noteRaw =
+                            sessionNotesMap[s.id]?.trim() || "";
                           return (
-                            <div
-                              className={
-                                "tree-l3 tree-l3--orphan" +
-                                (session.sessionId === s.id
-                                  ? " tree-l3--active"
-                                  : "") +
-                                (working ? " tree-l3--working" : "") +
-                                (unread ? " tree-l3--unread" : "") +
-                                (sessionSelectMode
-                                  ? " tree-l3--select-mode"
-                                  : "") +
-                                (checked ? " tree-l3--checked" : "")
+                            <SidebarSessionRow
+                              session={s}
+                              variant="orphan"
+                              active={session.sessionId === s.id}
+                              working={working}
+                              unread={unread}
+                              checked={checked}
+                              selectMode={sessionSelectMode}
+                              muted={mutedSessionIds.has(s.id)}
+                              noteTitle={
+                                noteRaw
+                                  ? notePreview(noteRaw) ||
+                                    sidebarSessionLabels.noteAria
+                                  : null
                               }
-                              role="button"
-                              tabIndex={0}
-                              aria-checked={
-                                sessionSelectMode ? checked : undefined
-                              }
-                              onClick={() => {
-                                if (sessionSelectMode) {
-                                  toggleSessionSelected(s.id);
-                                  return;
-                                }
-                                void openSession(s);
-                              }}
-                              onContextMenu={(e) => openSessionMenu(e, s)}
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter" || e.key === " ") {
-                                  if (sessionSelectMode) {
-                                    e.preventDefault();
-                                    toggleSessionSelected(s.id);
-                                    return;
-                                  }
-                                  if (e.key === "Enter") void openSession(s);
-                                }
-                              }}
-                            >
-                              {sessionSelectMode ? (
-                                <span
-                                  className={
-                                    "tree-l3__check" +
-                                    (checked ? " is-on" : "")
-                                  }
-                                  aria-hidden
-                                >
-                                  {checked ? (
-                                    <IconCheck size={11} stroke={2.4} />
-                                  ) : null}
-                                </span>
-                              ) : null}
-                              <span className="tree-l3__title">
-                                {unread ? (
-                                  <span
-                                    className="tree-l3__unread"
-                                    title={tr("session.unreadAria")}
-                                    aria-label={tr("session.unreadAria")}
-                                  />
-                                ) : null}
-                                {s.pinned ? (
-                                  <span
-                                    className="tree-l3__kind"
-                                    title={tr("session.pinned")}
-                                    aria-label={tr("session.pinned")}
-                                  >
-                                    <IconPin
-                                      size={12}
-                                      className="tree-l3__pin"
-                                    />
-                                  </span>
-                                ) : null}
-                                {mutedSessionIds.has(s.id) ? (
-                                  <span
-                                    className="tree-l3__kind tree-l3__muted"
-                                    title={tr("session.muted")}
-                                    aria-label={tr("session.muted")}
-                                  >
-                                    <IconBellOff size={12} />
-                                  </span>
-                                ) : null}
-                                {sessionNotesMap[s.id]?.trim() ? (
-                                  <span
-                                    className="tree-l3__kind"
-                                    title={
-                                      notePreview(sessionNotesMap[s.id]) ||
-                                      tr("session.noteAria")
-                                    }
-                                    aria-label={tr("session.noteAria")}
-                                  >
-                                    <IconNotes size={12} />
-                                  </span>
-                                ) : null}
-                                {s.scheduled ? (
-                                  <span
-                                    className="tree-l3__kind"
-                                    title={tr("automations.msgTag")}
-                                    aria-label={tr("automations.msgTag")}
-                                  >
-                                    <IconClock size={13} />
-                                  </span>
-                                ) : null}
-                                {(() => {
-                                  const wtBadge = sessionWorktreeBadgeFor(s);
-                                  if (!wtBadge) return null;
-                                  const tip = sessionWorktreeTooltip(wtBadge, {
-                                    detachedLabel: tr(
-                                      "composer.worktreeDetached",
-                                    ),
-                                    cliLayoutLabel: tr(
-                                      "session.worktreeLayoutCli",
-                                    ),
-                                    siblingLayoutLabel: tr(
-                                      "session.worktreeLayoutSibling",
-                                    ),
-                                    otherLayoutLabel: tr(
-                                      "session.worktreeBadge",
-                                    ),
-                                  });
-                                  const ariaKey =
-                                    wtBadge.layoutKind === "cli"
-                                      ? "session.worktreeBadgeCliAria"
-                                      : "session.worktreeBadgeAria";
-                                  return (
-                                    <span
-                                      className={
-                                        "tree-l3__wt" +
-                                        (wtBadge.layoutKind === "cli"
-                                          ? " tree-l3__wt--cli"
-                                          : wtBadge.layoutKind === "sibling"
-                                            ? " tree-l3__wt--sibling"
-                                            : "")
-                                      }
-                                      title={tip}
-                                      aria-label={tr(ariaKey, {
-                                        branch:
-                                          wtBadge.branch ||
-                                          tr("composer.worktreeDetached"),
-                                      })}
-                                    >
-                                      {wtBadge.label}
-                                    </span>
-                                  );
-                                })()}
-                                <SidebarSessionName
-                                  title={s.title || "Untitled"}
-                                />
-                              </span>
-                              {renderSessionRelativeTime(s.updatedAt)}
-                              {sessionSelectMode ? null : working ? (
-                                <Tip label={tr("sidebar.sessionWorking")}>
-                                  <span
-                                    className="tree-l3__status"
-                                    aria-label={tr("sidebar.sessionWorking")}
-                                  >
-                                    <Spinner
-                                      size={14}
-                                      className="tree-l3__spinner"
-                                    />
-                                  </span>
-                                </Tip>
-                              ) : (
-                                <span className="tree-l3__actions tree-l3__actions--triple">
-                                  <Tip
-                                    label={
-                                      s.pinned
-                                        ? tr("session.unpin")
-                                        : tr("session.pin")
-                                    }
-                                  >
-                                    <button
-                                      type="button"
-                                      className="tree-icon-btn"
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        void pinSession(s, !s.pinned);
-                                      }}
-                                    >
-                                      {s.pinned ? (
-                                        <IconPinOff size={13} />
-                                      ) : (
-                                        <IconPin size={13} />
-                                      )}
-                                    </button>
-                                  </Tip>
-                                  <Tip label={tr("sidebar.archive")}>
-                                    <button
-                                      type="button"
-                                      className="tree-icon-btn"
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        void archiveSession(s, !s.archived);
-                                      }}
-                                    >
-                                      <IconArchive size={13} />
-                                    </button>
-                                  </Tip>
-                                  <button
-                                    type="button"
-                                    className="tree-icon-btn"
-                                    onClick={(e) => openSessionMenu(e, s)}
-                                  >
-                                    <IconMore size={13} />
-                                  </button>
-                                </span>
-                              )}
-                            </div>
+                              worktreeBadge={buildSidebarWorktreeBadge(s)}
+                              labels={sidebarSessionLabels}
+                              locale={locale}
+                              showRelativeTime={sidebarShowRelativeTime}
+                              onOpen={onSidebarSessionOpen}
+                              onContextMenu={onSidebarSessionContextMenu}
+                              onToggleSelect={toggleSessionSelected}
+                              onPin={onSidebarSessionPin}
+                              onArchive={onSidebarSessionArchive}
+                              onMenu={onSidebarSessionMenu}
+                            />
                           );
                         }}
                       />

--- a/src/components/SidebarSessionRelativeTime.tsx
+++ b/src/components/SidebarSessionRelativeTime.tsx
@@ -1,0 +1,49 @@
+/**
+ * Sidebar session relative-time label.
+ * Owns its own 60s tick subscription so App stream re-renders and the
+ * shared interval do not force every session row through App state.
+ */
+
+import { memo, useSyncExternalStore } from "react";
+import { formatMessageTime, formatRelativeTime } from "@/lib/accountUi";
+import type { Locale } from "@/i18n";
+import {
+  getRelativeTimeTick,
+  getRelativeTimeTickServerSnapshot,
+  subscribeRelativeTimeTick,
+  subscribeRelativeTimeTickNoop,
+} from "@/lib/relativeTimeTickStore";
+
+export type SidebarSessionRelativeTimeProps = {
+  updatedAt: string | undefined;
+  locale: Locale;
+  /** Mirrors settings `sidebarShowRelativeTime`. */
+  enabled: boolean;
+};
+
+function SidebarSessionRelativeTimeInner({
+  updatedAt,
+  locale,
+  enabled,
+}: SidebarSessionRelativeTimeProps) {
+  const active = enabled && !!updatedAt;
+  // Always call the hook; only subscribe when the label is shown.
+  useSyncExternalStore(
+    active ? subscribeRelativeTimeTick : subscribeRelativeTimeTickNoop,
+    getRelativeTimeTick,
+    getRelativeTimeTickServerSnapshot,
+  );
+
+  if (!active || !updatedAt) return null;
+
+  const label = formatRelativeTime(updatedAt, locale);
+  if (!label || label === "—") return null;
+  const absolute = formatMessageTime(updatedAt, locale);
+  return (
+    <span className="tree-l3__time" title={absolute || undefined}>
+      {label}
+    </span>
+  );
+}
+
+export const SidebarSessionRelativeTime = memo(SidebarSessionRelativeTimeInner);

--- a/src/components/SidebarSessionRow.test.tsx
+++ b/src/components/SidebarSessionRow.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import React from "react";
+import {
+  SidebarSessionRow,
+  type SidebarSessionRowLabels,
+} from "@/components/SidebarSessionRow";
+import { SidebarSessionRelativeTime } from "@/components/SidebarSessionRelativeTime";
+
+const labels: SidebarSessionRowLabels = {
+  unreadAria: "Unread",
+  pinned: "Pinned",
+  muted: "Muted",
+  noteAria: "Note",
+  automationsTag: "Automation",
+  working: "Working",
+  pin: "Pin",
+  unpin: "Unpin",
+  archive: "Archive",
+  unarchive: "Unarchive",
+  menu: "Menu",
+};
+
+describe("SidebarSessionRow", () => {
+  it("exports and renders a project session row", () => {
+    const html = renderToString(
+      React.createElement(SidebarSessionRow, {
+        session: {
+          id: "s1",
+          title: "Hello chat",
+          pinned: true,
+          updatedAt: new Date().toISOString(),
+        },
+        variant: "project",
+        active: true,
+        working: false,
+        unread: true,
+        checked: false,
+        selectMode: false,
+        muted: false,
+        noteTitle: null,
+        worktreeBadge: null,
+        labels,
+        locale: "en",
+        showRelativeTime: false,
+        onOpen: vi.fn(),
+        onContextMenu: vi.fn(),
+        onToggleSelect: vi.fn(),
+        onPin: vi.fn(),
+        onArchive: vi.fn(),
+        onMenu: vi.fn(),
+      }),
+    );
+    expect(html).toContain("tree-l3");
+    expect(html).toContain("tree-l3--active");
+    expect(html).toContain("Hello chat");
+    expect(html).toContain("tree-l3--unread");
+  });
+
+  it("renders orphan variant class", () => {
+    const html = renderToString(
+      React.createElement(SidebarSessionRow, {
+        session: { id: "s2", title: "Orphan" },
+        variant: "orphan",
+        active: false,
+        working: true,
+        unread: false,
+        checked: false,
+        selectMode: false,
+        muted: false,
+        noteTitle: null,
+        worktreeBadge: null,
+        labels,
+        locale: "en",
+        showRelativeTime: false,
+        onOpen: vi.fn(),
+        onContextMenu: vi.fn(),
+        onToggleSelect: vi.fn(),
+        onPin: vi.fn(),
+        onArchive: vi.fn(),
+        onMenu: vi.fn(),
+      }),
+    );
+    expect(html).toContain("tree-l3--orphan");
+    expect(html).toContain("tree-l3--working");
+  });
+});
+
+describe("SidebarSessionRelativeTime", () => {
+  it("returns empty when disabled", () => {
+    const html = renderToString(
+      React.createElement(SidebarSessionRelativeTime, {
+        updatedAt: new Date().toISOString(),
+        locale: "en",
+        enabled: false,
+      }),
+    );
+    expect(html).toBe("");
+  });
+
+  it("returns empty when no updatedAt", () => {
+    const html = renderToString(
+      React.createElement(SidebarSessionRelativeTime, {
+        updatedAt: undefined,
+        locale: "en",
+        enabled: true,
+      }),
+    );
+    expect(html).toBe("");
+  });
+});

--- a/src/components/SidebarSessionRow.tsx
+++ b/src/components/SidebarSessionRow.tsx
@@ -1,0 +1,329 @@
+/**
+ * Memoized sidebar session row (project tree + orphan history).
+ * Keeps row UI out of App so stream re-renders skip unchanged rows.
+ */
+
+import { memo, type KeyboardEvent, type MouseEvent } from "react";
+import type { Locale } from "@/i18n";
+import {
+  IconArchive,
+  IconBellOff,
+  IconCheck,
+  IconClock,
+  IconMore,
+  IconNotes,
+  IconPin,
+  IconPinOff,
+} from "@/components/icons";
+import { Spinner } from "@/components/ui/spinner";
+import { Tip } from "@/components/ui/tooltip";
+import { SidebarSessionName } from "@/components/SidebarSessionName";
+import { SidebarSessionRelativeTime } from "@/components/SidebarSessionRelativeTime";
+
+export type SidebarSessionRowSession = {
+  id: string;
+  title: string;
+  pinned?: boolean;
+  archived?: boolean;
+  scheduled?: boolean;
+  updatedAt?: string;
+};
+
+export type SidebarSessionWorktreeBadgeProp = {
+  label: string;
+  branch: string | null;
+  layoutKind: "cli" | "sibling" | "other";
+  /** Pre-translated tooltip body. */
+  title: string;
+  /** Pre-translated aria-label. */
+  ariaLabel: string;
+};
+
+/** Plain strings already translated by the parent (row does not call tr()). */
+export type SidebarSessionRowLabels = {
+  unreadAria: string;
+  pinned: string;
+  muted: string;
+  noteAria: string;
+  automationsTag: string;
+  working: string;
+  pin: string;
+  unpin: string;
+  archive: string;
+  unarchive: string;
+  menu: string;
+};
+
+export type SidebarSessionRowProps = {
+  session: SidebarSessionRowSession;
+  variant: "project" | "orphan";
+  active: boolean;
+  working: boolean;
+  unread: boolean;
+  checked: boolean;
+  selectMode: boolean;
+  muted: boolean;
+  /** Non-null when session has a note; used as title (+ falls back to noteAria). */
+  noteTitle: string | null;
+  worktreeBadge: SidebarSessionWorktreeBadgeProp | null;
+  labels: SidebarSessionRowLabels;
+  locale: Locale;
+  showRelativeTime: boolean;
+  /** Prefer stable useCallbacks from App (session-parameterized). */
+  onOpen: (session: SidebarSessionRowSession) => void;
+  onContextMenu: (e: MouseEvent, session: SidebarSessionRowSession) => void;
+  onToggleSelect: (sessionId: string) => void;
+  onPin: (session: SidebarSessionRowSession) => void;
+  onArchive: (session: SidebarSessionRowSession) => void;
+  onMenu: (e: MouseEvent, session: SidebarSessionRowSession) => void;
+};
+
+function SidebarSessionRowInner({
+  session,
+  variant,
+  active,
+  working,
+  unread,
+  checked,
+  selectMode,
+  muted,
+  noteTitle,
+  worktreeBadge,
+  labels,
+  locale,
+  showRelativeTime,
+  onOpen,
+  onContextMenu,
+  onToggleSelect,
+  onPin,
+  onArchive,
+  onMenu,
+}: SidebarSessionRowProps) {
+  const className =
+    (variant === "orphan" ? "tree-l3 tree-l3--orphan" : "tree-l3") +
+    (active ? " tree-l3--active" : "") +
+    (variant === "project" && session.archived ? " tree-l3--archived" : "") +
+    (working ? " tree-l3--working" : "") +
+    (unread ? " tree-l3--unread" : "") +
+    (selectMode ? " tree-l3--select-mode" : "") +
+    (checked ? " tree-l3--checked" : "");
+
+  const handleClick = () => {
+    if (selectMode) {
+      onToggleSelect(session.id);
+      return;
+    }
+    onOpen(session);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      if (selectMode) {
+        e.preventDefault();
+        onToggleSelect(session.id);
+        return;
+      }
+      if (e.key === "Enter") onOpen(session);
+    }
+  };
+
+  const pinLabel = session.pinned ? labels.unpin : labels.pin;
+  // Project rows toggle archive tip; orphans always show "archive" (legacy).
+  const archiveLabel =
+    variant === "project" && session.archived
+      ? labels.unarchive
+      : labels.archive;
+
+  const menuButton = (
+    <button
+      type="button"
+      className="tree-icon-btn"
+      onClick={(e) => onMenu(e, session)}
+    >
+      <IconMore size={13} />
+    </button>
+  );
+
+  return (
+    <div
+      className={className}
+      role="button"
+      tabIndex={0}
+      aria-checked={selectMode ? checked : undefined}
+      onClick={handleClick}
+      onContextMenu={(e) => onContextMenu(e, session)}
+      onKeyDown={handleKeyDown}
+    >
+      {selectMode ? (
+        <span
+          className={"tree-l3__check" + (checked ? " is-on" : "")}
+          aria-hidden
+        >
+          {checked ? <IconCheck size={11} stroke={2.4} /> : null}
+        </span>
+      ) : null}
+      <span className="tree-l3__title">
+        {unread ? (
+          <span
+            className="tree-l3__unread"
+            title={labels.unreadAria}
+            aria-label={labels.unreadAria}
+          />
+        ) : null}
+        {session.pinned ? (
+          <span
+            className="tree-l3__kind"
+            title={labels.pinned}
+            aria-label={labels.pinned}
+          >
+            <IconPin size={12} className="tree-l3__pin" />
+          </span>
+        ) : null}
+        {muted ? (
+          <span
+            className="tree-l3__kind tree-l3__muted"
+            title={labels.muted}
+            aria-label={labels.muted}
+          >
+            <IconBellOff size={12} />
+          </span>
+        ) : null}
+        {noteTitle ? (
+          <span
+            className="tree-l3__kind"
+            title={noteTitle}
+            aria-label={labels.noteAria}
+          >
+            <IconNotes size={12} />
+          </span>
+        ) : null}
+        {session.scheduled ? (
+          <span
+            className="tree-l3__kind"
+            title={labels.automationsTag}
+            aria-label={labels.automationsTag}
+          >
+            <IconClock size={13} />
+          </span>
+        ) : null}
+        {worktreeBadge ? (
+          <span
+            className={
+              "tree-l3__wt" +
+              (worktreeBadge.layoutKind === "cli"
+                ? " tree-l3__wt--cli"
+                : worktreeBadge.layoutKind === "sibling"
+                  ? " tree-l3__wt--sibling"
+                  : "")
+            }
+            title={worktreeBadge.title}
+            aria-label={worktreeBadge.ariaLabel}
+          >
+            {worktreeBadge.label}
+          </span>
+        ) : null}
+        <SidebarSessionName title={session.title || "Untitled"} />
+      </span>
+      <SidebarSessionRelativeTime
+        updatedAt={session.updatedAt}
+        locale={locale}
+        enabled={showRelativeTime}
+      />
+      {selectMode ? null : working ? (
+        <Tip label={labels.working}>
+          <span className="tree-l3__status" aria-label={labels.working}>
+            <Spinner size={14} className="tree-l3__spinner" />
+          </span>
+        </Tip>
+      ) : (
+        <span className="tree-l3__actions tree-l3__actions--triple">
+          <Tip label={pinLabel}>
+            <button
+              type="button"
+              className="tree-icon-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onPin(session);
+              }}
+            >
+              {session.pinned ? (
+                <IconPinOff size={13} />
+              ) : (
+                <IconPin size={13} />
+              )}
+            </button>
+          </Tip>
+          <Tip label={archiveLabel}>
+            <button
+              type="button"
+              className="tree-icon-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onArchive(session);
+              }}
+            >
+              <IconArchive size={13} />
+            </button>
+          </Tip>
+          {variant === "project" ? (
+            <Tip label={labels.menu}>{menuButton}</Tip>
+          ) : (
+            menuButton
+          )}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function worktreeBadgeEqual(
+  a: SidebarSessionWorktreeBadgeProp | null,
+  b: SidebarSessionWorktreeBadgeProp | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.label === b.label &&
+    a.branch === b.branch &&
+    a.layoutKind === b.layoutKind &&
+    a.title === b.title &&
+    a.ariaLabel === b.ariaLabel
+  );
+}
+
+function sidebarSessionRowPropsEqual(
+  prev: SidebarSessionRowProps,
+  next: SidebarSessionRowProps,
+): boolean {
+  return (
+    prev.session.id === next.session.id &&
+    prev.session.title === next.session.title &&
+    prev.session.pinned === next.session.pinned &&
+    prev.session.archived === next.session.archived &&
+    prev.session.scheduled === next.session.scheduled &&
+    prev.session.updatedAt === next.session.updatedAt &&
+    prev.variant === next.variant &&
+    prev.active === next.active &&
+    prev.working === next.working &&
+    prev.unread === next.unread &&
+    prev.checked === next.checked &&
+    prev.selectMode === next.selectMode &&
+    prev.muted === next.muted &&
+    prev.noteTitle === next.noteTitle &&
+    prev.locale === next.locale &&
+    prev.showRelativeTime === next.showRelativeTime &&
+    prev.labels === next.labels &&
+    prev.onOpen === next.onOpen &&
+    prev.onContextMenu === next.onContextMenu &&
+    prev.onToggleSelect === next.onToggleSelect &&
+    prev.onPin === next.onPin &&
+    prev.onArchive === next.onArchive &&
+    prev.onMenu === next.onMenu &&
+    worktreeBadgeEqual(prev.worktreeBadge, next.worktreeBadge)
+  );
+}
+
+export const SidebarSessionRow = memo(
+  SidebarSessionRowInner,
+  sidebarSessionRowPropsEqual,
+);

--- a/src/lib/relativeTimeTickStore.test.ts
+++ b/src/lib/relativeTimeTickStore.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testAdvanceRelativeTimeTick,
+  __testResetRelativeTimeTickStore,
+  getRelativeTimeTick,
+  subscribeRelativeTimeTick,
+  subscribeRelativeTimeTickNoop,
+} from "./relativeTimeTickStore";
+
+describe("relativeTimeTickStore", () => {
+  afterEach(() => {
+    __testResetRelativeTimeTickStore();
+    vi.useRealTimers();
+  });
+
+  it("starts at 0 and advances on test helper", () => {
+    expect(getRelativeTimeTick()).toBe(0);
+    expect(__testAdvanceRelativeTimeTick()).toBe(1);
+    expect(getRelativeTimeTick()).toBe(1);
+  });
+
+  it("notifies subscribers when tick advances", () => {
+    const spy = vi.fn();
+    const unsub = subscribeRelativeTimeTick(spy);
+    __testAdvanceRelativeTimeTick();
+    expect(spy).toHaveBeenCalledTimes(1);
+    unsub();
+    __testAdvanceRelativeTimeTick();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("noop subscribe never fires", () => {
+    const spy = vi.fn();
+    const unsub = subscribeRelativeTimeTickNoop(spy);
+    __testAdvanceRelativeTimeTick();
+    expect(spy).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it("interval ticks every 60s while subscribed", () => {
+    vi.useFakeTimers();
+    const spy = vi.fn();
+    const unsub = subscribeRelativeTimeTick(spy);
+    expect(getRelativeTimeTick()).toBe(0);
+    vi.advanceTimersByTime(60_000);
+    expect(getRelativeTimeTick()).toBe(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(60_000);
+    expect(getRelativeTimeTick()).toBe(2);
+    unsub();
+  });
+});

--- a/src/lib/relativeTimeTickStore.ts
+++ b/src/lib/relativeTimeTickStore.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared 60s tick for relative-time labels (sidebar session rows, etc.).
+ * Components subscribe via useSyncExternalStore so only those that need
+ * relative time re-render — App state is not coupled to the interval.
+ */
+
+let tick = 0;
+const listeners = new Set<() => void>();
+let intervalId: ReturnType<typeof globalThis.setInterval> | null = null;
+
+function ensureInterval(): void {
+  if (intervalId != null) return;
+  intervalId = globalThis.setInterval(() => {
+    tick += 1;
+    for (const l of listeners) l();
+  }, 60_000);
+}
+
+function stopIntervalIfIdle(): void {
+  if (listeners.size > 0 || intervalId == null) return;
+  globalThis.clearInterval(intervalId);
+  intervalId = null;
+}
+
+/** Subscribe to the shared 60s tick. Starts the interval on first listener. */
+export function subscribeRelativeTimeTick(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  ensureInterval();
+  return () => {
+    listeners.delete(onStoreChange);
+    stopIntervalIfIdle();
+  };
+}
+
+export function getRelativeTimeTick(): number {
+  return tick;
+}
+
+/** No-op subscribe for when relative time is disabled (hooks still called). */
+export function subscribeRelativeTimeTickNoop(
+  _onStoreChange: () => void,
+): () => void {
+  return () => {};
+}
+
+/** SSR / test snapshot. */
+export function getRelativeTimeTickServerSnapshot(): number {
+  return 0;
+}
+
+/** Test helper: advance the store and notify subscribers. */
+export function __testAdvanceRelativeTimeTick(): number {
+  tick += 1;
+  for (const l of listeners) l();
+  return tick;
+}
+
+/** Test helper: reset store state. */
+export function __testResetRelativeTimeTickStore(): void {
+  tick = 0;
+  listeners.clear();
+  if (intervalId != null) {
+    globalThis.clearInterval(intervalId);
+    intervalId = null;
+  }
+}

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -202,6 +202,10 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   font-size: 13px;
   cursor: pointer;
   text-align: left;
+  /* Offscreen rows skip paint work in long virtualized lists. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 36px;
+  contain: layout style;
 }
 
 .tree-l3:hover {


### PR DESCRIPTION
## Summary
Isolate sidebar session rows so App re-renders (stream / chrome) do not rebuild every row tree when props are unchanged.

- **SidebarSessionRow** — memoized row for project + orphan VirtualLists
- **SidebarSessionRelativeTime** — 60s tick via `relativeTimeTickStore` (no App-wide `setState` every minute)
- **CSS** — `content-visibility` / `contain` on `.tree-l3`

## Test plan
- [ ] Sidebar sessions list: open, pin, archive, context menu still work
- [ ] Busy spinner still shows on working sessions
- [ ] Relative time labels refresh without janking the whole app
- [ ] `pnpm exec tsc --noEmit`
- [ ] Vitest: `relativeTimeTickStore` + `SidebarSessionRow` tests

Independent of #505 stream isolation PR.