### PR TITLE
perf(ui): stream-perf mode cuts wallpaper and backdrop thrash

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -920,6 +920,7 @@ import { useSessionRuntime } from "@/hooks/useSessionRuntime";
 import { useComposerController } from "@/hooks/useComposerController";
 import { useAppDialogs } from "@/hooks/useAppDialogs";
 import { useSessionHostEvents } from "@/hooks/useSessionHostEvents";
+import { useStreamPerfMode } from "@/hooks/useStreamPerfMode";
 
 /** App-local plan chrome state (session-scoped via planBySessionRef). */
 type PlanState = SessionPlanState;
@@ -12335,6 +12336,25 @@ export function AppWorkbench() {
     }
     wasStreamingRef.current = streaming;
   }, [session.state, messages, tr]);
+
+  /**
+   * Stream-perf mode: dim wallpaper / hide video / drop backdrop-filter while
+   * tokens stream (cuts Intel Retina composite thrash). Always on during stream
+   * for consistent cost; CSS is cheap on high-power GPUs.
+   */
+  const streamPerfActive = useMemo(() => {
+    if (session.state === "streaming" || isSessionLiveStreaming(liveHost.state)) {
+      return true;
+    }
+    if (messages.some((m) => m.role === "assistant" && m.streaming)) {
+      return true;
+    }
+    if (session.sessionId && busyIds.has(session.sessionId)) {
+      return true;
+    }
+    return false;
+  }, [session.state, session.sessionId, liveHost.state, messages, busyIds]);
+  useStreamPerfMode(streamPerfActive);
 
   /** Same path as Deny button / Escape / optional auto-deny timeout. */
   const resolvePermission = useCallback(

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -495,15 +495,34 @@ export function useStickToBottom(
       return el.scrollHeight;
     };
 
-    const ro = new ResizeObserver(() => {
-      // Coalesce multi-node notifications to one frame. Always read the
-      // content column height from the DOM — viewport RO entries report
-      // client box size, which is not what we want for grow/shrink.
+    /** Extra throttle while stream-perf mode is on (token growth is dense). */
+    let throttleTimer = 0;
+
+    const scheduleMeasure = () => {
       if (raf) return;
       raf = requestAnimationFrame(() => {
         raf = 0;
         onHeightChange(measureContentHeight());
       });
+    };
+
+    const ro = new ResizeObserver(() => {
+      // Coalesce multi-node notifications to one frame. Always read the
+      // content column height from the DOM — viewport RO entries report
+      // client box size, which is not what we want for grow/shrink.
+      // During stream-perf, further throttle to ~100ms to cut layout thrash
+      // without dropping pin-to-bottom (follow still runs on each fire).
+      if (
+        document.documentElement.getAttribute("data-stream-perf") === "1"
+      ) {
+        if (throttleTimer || raf) return;
+        throttleTimer = window.setTimeout(() => {
+          throttleTimer = 0;
+          scheduleMeasure();
+        }, 100);
+        return;
+      }
+      scheduleMeasure();
     });
 
     const content = contentRef.current ?? el.firstElementChild;
@@ -513,6 +532,7 @@ export function useStickToBottom(
 
     return () => {
       if (raf) cancelAnimationFrame(raf);
+      if (throttleTimer) window.clearTimeout(throttleTimer);
       ro.disconnect();
     };
   }, [enabled, conversationKey, applyScrollTop, followIfPinned]);

--- a/src/hooks/useStreamPerfMode.ts
+++ b/src/hooks/useStreamPerfMode.ts
@@ -1,0 +1,23 @@
+/**
+ * Toggle html[data-stream-perf] while a turn is actively streaming so CSS can
+ * cut wallpaper video decode + backdrop-filter composite cost (Intel Retina).
+ *
+ * Signal should be true when the focused session (or live host) is streaming,
+ * any assistant message has streaming=true, or busyIds covers the session.
+ */
+
+import { useEffect } from "react";
+
+export function useStreamPerfMode(active: boolean): void {
+  useEffect(() => {
+    const root = document.documentElement;
+    if (active) {
+      root.setAttribute("data-stream-perf", "1");
+    } else {
+      root.removeAttribute("data-stream-perf");
+    }
+    return () => {
+      root.removeAttribute("data-stream-perf");
+    };
+  }, [active]);
+}

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -52,6 +52,26 @@ html[data-wallpaper="1"] .app-shell::after {
   transition: opacity 120ms ease-out;
 }
 
+/*
+ * Stream-perf mode (html[data-stream-perf="1"]): cut GPU composite thrash on
+ * Intel Retina while tokens stream — dim/static wallpaper, hide video layer,
+ * drop backdrop-filter on heavy chrome. Toggled from AppWorkbench.
+ */
+html[data-stream-perf="1"] .app-wallpaper-media {
+  opacity: 0.25;
+  filter: none;
+  pointer-events: none;
+}
+html[data-stream-perf="1"] .app-wallpaper-media video {
+  visibility: hidden;
+}
+html[data-stream-perf="1"] .glass-surface,
+html[data-stream-perf="1"] .sidebar,
+html[data-stream-perf="1"] .composer-wrap--float {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
 /* Lift real chrome above the media + scrim.
  * Excludes .window-controls (must keep position: fixed; right:0; z:10040 —
  * otherwise the buttons jump to the left and the drag strip is clobbered)


### PR DESCRIPTION
## Summary
While a turn is streaming / busy, set `data-stream-perf=1` on `<html>`:

- Dim / hide wallpaper video decode
- Disable backdrop-filter on glass / sidebar / floating composer
- Throttle stick-to-bottom ResizeObserver (~100ms)

Targets Intel integrated-GPU Retina composite thrash during multi-turn streams.

## Test plan
- [ ] Start a streaming turn — wallpaper dim, blur off; after turn ends, restore
- [ ] Pin-to-bottom still works while streaming
- [ ] `pnpm typecheck`

Independent of #505.