### PR TITLE
perf(chat): virtualize long grok activity step lists

### DIFF
--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -17,7 +17,7 @@
  * Live: steps + “Working for …s” footer
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
 import { COLLAPSE_ALL_ACTIVITY_EVENT } from "@/lib/collapseAllActivity";
@@ -35,6 +35,12 @@ import {
   buildGrokActivitySteps,
   type GrokActivityStep,
 } from "@/lib/grokActivitySteps";
+import {
+  GROK_ACTIVITY_STEP_ROW_PX,
+  grokActivityVirtualMaxHeightPx,
+  shouldVirtualizeGrokActivitySteps,
+} from "@/lib/grokActivityVirtualize";
+import { VirtualList } from "@/components/VirtualList";
 import {
   IconBulb,
   IconChevronDown,
@@ -118,73 +124,133 @@ function StepMainText({
   }
 }
 
+const GrokActivityStepRow = memo(function GrokActivityStepRow({
+  step,
+  isLast,
+  tr,
+}: {
+  step: GrokActivityStep;
+  isLast: boolean;
+  tr: ReturnType<typeof createT>;
+}) {
+  const failed =
+    step.type !== "thought" && "failed" in step ? !!step.failed : false;
+  const running =
+    step.type === "thought"
+      ? !!step.streaming
+      : "running" in step
+        ? !!step.running
+        : false;
+  const resultCount =
+    step.type === "web-search" ? step.resultCount : undefined;
+  const domains =
+    step.type === "web-search" ? step.resultDomains : undefined;
+
+  return (
+    <div
+      className={
+        "grok-act__step" +
+        (failed ? " is-error" : "") +
+        (running ? " is-running" : "") +
+        (isLast ? " is-last" : "")
+      }
+      role="listitem"
+      data-step-type={step.type}
+    >
+      <div className="grok-act__icon-col" aria-hidden>
+        <span className="grok-act__icon">
+          <StepIcon step={step} />
+        </span>
+        {!isLast ? <span className="grok-act__rail" /> : null}
+      </div>
+      <div className="grok-act__main">
+        <div className="grok-act__label-row">
+          <StepMainText step={step} tr={tr} />
+          {resultCount != null || (domains && domains.length > 0) ? (
+            <span className="grok-act__meta">
+              {resultCount != null ? (
+                <span className="grok-act__meta-count">
+                  {tr("chat.searchResults", { n: String(resultCount) })}
+                </span>
+              ) : null}
+              {domains && domains.length > 0 ? (
+                <span className="grok-act__favicons">
+                  {domains.slice(0, 3).map((d) => (
+                    <FaviconChip key={d} domain={d} />
+                  ))}
+                </span>
+              ) : null}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+/**
+ * Grok activity step list. Short lists map fully; long lists window via
+ * VirtualList so multi-turn phases with 20–100+ steps stay light.
+ * Live phases pin the scroller to the tail (last step key).
+ */
 export function GrokActivitySteps({
   steps,
   tr,
+  live = false,
 }: {
   steps: GrokActivityStep[];
   tr: ReturnType<typeof createT>;
+  /** When true, prefer showing the tail of a virtualized list. */
+  live?: boolean;
 }) {
-  if (!steps.length) return null;
-  return (
-    <div className="grok-act__steps" role="list">
-      {steps.map((step, idx) => {
-        const failed =
-          step.type !== "thought" && "failed" in step ? !!step.failed : false;
-        const running =
-          step.type === "thought"
-            ? !!step.streaming
-            : "running" in step
-              ? !!step.running
-              : false;
-        const isLast = idx === steps.length - 1;
-        const resultCount =
-          step.type === "web-search" ? step.resultCount : undefined;
-        const domains =
-          step.type === "web-search" ? step.resultDomains : undefined;
+  const total = steps.length;
+  const virtualize = shouldVirtualizeGrokActivitySteps(total);
+  const lastKey = total > 0 ? steps[total - 1]!.key : null;
 
-        return (
-          <div
+  const getKey = useCallback((step: GrokActivityStep) => step.key, []);
+  const renderItem = useCallback(
+    (step: GrokActivityStep, idx: number) => (
+      <GrokActivityStepRow
+        step={step}
+        isLast={idx === total - 1}
+        tr={tr}
+      />
+    ),
+    [total, tr],
+  );
+
+  if (!total) return null;
+
+  if (!virtualize) {
+    return (
+      <div className="grok-act__steps" role="list">
+        {steps.map((step, idx) => (
+          <GrokActivityStepRow
             key={step.key}
-            className={
-              "grok-act__step" +
-              (failed ? " is-error" : "") +
-              (running ? " is-running" : "") +
-              (isLast ? " is-last" : "")
-            }
-            role="listitem"
-            data-step-type={step.type}
-          >
-            <div className="grok-act__icon-col" aria-hidden>
-              <span className="grok-act__icon">
-                <StepIcon step={step} />
-              </span>
-              {!isLast ? <span className="grok-act__rail" /> : null}
-            </div>
-            <div className="grok-act__main">
-              <div className="grok-act__label-row">
-                <StepMainText step={step} tr={tr} />
-                {resultCount != null || (domains && domains.length > 0) ? (
-                  <span className="grok-act__meta">
-                    {resultCount != null ? (
-                      <span className="grok-act__meta-count">
-                        {tr("chat.searchResults", { n: String(resultCount) })}
-                      </span>
-                    ) : null}
-                    {domains && domains.length > 0 ? (
-                      <span className="grok-act__favicons">
-                        {domains.slice(0, 3).map((d) => (
-                          <FaviconChip key={d} domain={d} />
-                        ))}
-                      </span>
-                    ) : null}
-                  </span>
-                ) : null}
-              </div>
-            </div>
-          </div>
-        );
-      })}
+            step={step}
+            isLast={idx === total - 1}
+            tr={tr}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="grok-act__steps grok-act__steps--virtual"
+      role="list"
+      style={{ maxHeight: grokActivityVirtualMaxHeightPx(total) }}
+    >
+      <VirtualList
+        items={steps}
+        getKey={getKey}
+        renderItem={renderItem}
+        rowHeight={GROK_ACTIVITY_STEP_ROW_PX}
+        gap={0}
+        threshold={0}
+        scrollToKey={live ? lastKey : null}
+      />
     </div>
   );
 }
@@ -324,7 +390,7 @@ export function TimelinePhaseBlock({
         data-phase-id={phase.id}
         data-live="1"
       >
-        <GrokActivitySteps steps={stepsResolved} tr={tr} />
+        <GrokActivitySteps steps={stepsResolved} tr={tr} live />
         <div className="grok-act__working" role="status" aria-live="polite">
           <span className="grok-act__working-icon" aria-hidden>
             <IconGridDots size={14} stroke={1.5} />

--- a/src/components/lobe-chat/lobe-chat.part2.css
+++ b/src/components/lobe-chat/lobe-chat.part2.css
@@ -41,6 +41,33 @@
   padding: 0;
 }
 
+/* Long step lists: fixed max-height scroller for VirtualList windowing.
+   Row height must stay in sync with GROK_ACTIVITY_STEP_ROW_PX (30). */
+.grok-act__steps--virtual {
+  max-height: 360px; /* fallback; inline style sets min(12, n) * 30 */
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  /* VirtualList root is the only child; stretch full width */
+  min-height: 0;
+}
+.grok-act__steps--virtual .grok-act__step {
+  height: 30px;
+  min-height: 30px;
+  flex-shrink: 0;
+  box-sizing: border-box;
+}
+.grok-act__steps--virtual .grok-act__main {
+  padding-bottom: 0;
+  justify-content: center;
+}
+.grok-act__steps--virtual .grok-act__icon-col {
+  padding-top: 7px; /* center 16px icon in 30px row */
+}
+.grok-act__steps--virtual .grok-act__step.is-last .grok-act__main {
+  padding-bottom: 0;
+}
+
 /* One step row — icon | continuous rail + label */
 .grok-act__step {
   display: flex;

--- a/src/lib/grokActivityVirtualize.test.ts
+++ b/src/lib/grokActivityVirtualize.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  GROK_ACTIVITY_STEP_ROW_PX,
+  GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS,
+  GROK_ACTIVITY_VIRTUALIZE_THRESHOLD,
+  grokActivityVirtualMaxHeightPx,
+  shouldVirtualizeGrokActivitySteps,
+} from "./grokActivityVirtualize";
+
+describe("grokActivityVirtualize", () => {
+  it("keeps short lists non-virtual (≤ threshold)", () => {
+    expect(shouldVirtualizeGrokActivitySteps(0)).toBe(false);
+    expect(shouldVirtualizeGrokActivitySteps(1)).toBe(false);
+    expect(
+      shouldVirtualizeGrokActivitySteps(GROK_ACTIVITY_VIRTUALIZE_THRESHOLD),
+    ).toBe(false);
+  });
+
+  it("virtualizes when count exceeds threshold", () => {
+    expect(
+      shouldVirtualizeGrokActivitySteps(GROK_ACTIVITY_VIRTUALIZE_THRESHOLD + 1),
+    ).toBe(true);
+    expect(shouldVirtualizeGrokActivitySteps(100)).toBe(true);
+  });
+
+  it("maxHeight is min(visibleRows, count) × row height", () => {
+    expect(grokActivityVirtualMaxHeightPx(0)).toBe(0);
+    expect(grokActivityVirtualMaxHeightPx(5)).toBe(5 * GROK_ACTIVITY_STEP_ROW_PX);
+    expect(grokActivityVirtualMaxHeightPx(15)).toBe(
+      GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS * GROK_ACTIVITY_STEP_ROW_PX,
+    );
+    expect(grokActivityVirtualMaxHeightPx(100)).toBe(
+      GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS * GROK_ACTIVITY_STEP_ROW_PX,
+    );
+  });
+
+  it("row height constant matches virtual CSS contract (30px)", () => {
+    expect(GROK_ACTIVITY_STEP_ROW_PX).toBe(30);
+    expect(GROK_ACTIVITY_VIRTUALIZE_THRESHOLD).toBe(14);
+    expect(GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS).toBe(12);
+  });
+});

--- a/src/lib/grokActivityVirtualize.ts
+++ b/src/lib/grokActivityVirtualize.ts
@@ -1,0 +1,37 @@
+/**
+ * Windowing thresholds for Grok activity step lists (TimelinePhaseBlock).
+ * Pure helpers — unit-test without DOM.
+ *
+ * Short lists keep a full DOM map (identical pre-virtualization UX).
+ * Longer lists use VirtualList inside a max-height scroller.
+ */
+
+/** Virtualize when step count exceeds this (≤ threshold → full map). */
+export const GROK_ACTIVITY_VIRTUALIZE_THRESHOLD = 14;
+
+/**
+ * Fixed row height for windowed activity steps.
+ * Matches virtual CSS on `.grok-act__steps--virtual .grok-act__step`
+ * (natural non-virtual rows are ~line 1.4×15 + padding ≈ 30–31px).
+ */
+export const GROK_ACTIVITY_STEP_ROW_PX = 30;
+
+/** Max rows visible in the virtual scroller before overflow. */
+export const GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS = 12;
+
+/** True when the list should use VirtualList + max-height scroller. */
+export function shouldVirtualizeGrokActivitySteps(stepCount: number): boolean {
+  return stepCount > GROK_ACTIVITY_VIRTUALIZE_THRESHOLD;
+}
+
+/**
+ * maxHeight for the virtual steps scroller: min(visibleRows, count) × rowPx.
+ * Empty / non-positive counts return 0.
+ */
+export function grokActivityVirtualMaxHeightPx(stepCount: number): number {
+  const n = Math.min(
+    GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS,
+    Math.max(0, Math.floor(stepCount)),
+  );
+  return n * GROK_ACTIVITY_STEP_ROW_PX;
+}


### PR DESCRIPTION
## Summary
When a phase has many tool/activity steps (>14), window the DOM with fixed-row virtualization:

- Threshold 14; row height 30px; max ~12 visible rows
- Live phases pin scroll to the last step
- Short lists keep full map (identical UX)

## Test plan
- [ ] Agent turn with many tools: expanded “Worked for” list scrolls smoothly
- [ ] Live phase shows newest steps at the tail
- [ ] Collapsed / short phases unchanged
- [ ] unit tests for virtualize helpers

Independent of #505 / #511.