### PR TITLE
perf(runtime): adaptive host stream coalesce (longer flush)

### DIFF
--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -87,7 +87,12 @@ import {
 } from "@/lib/hooksDebug";
 import { recordCostUsageSample, sampleFromUsageEvent } from "@/lib/costRollup";
 import { mapSessionListRow } from "@/lib/app/sidebarModels";
-import { StreamCoalescer } from "@/lib/streamCoalesce";
+import {
+  StreamCoalescer,
+  TimedBatchQueue,
+  resolveStreamFlushMs,
+  toolEventNeedsImmediateFlush,
+} from "@/lib/streamCoalesce";
 
 /** Mutable bag of AppWorkbench bindings used by Host event handlers. */
 export type SessionHostEventsCtx = {
@@ -124,6 +129,24 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
 
     void (async () => {
       try {
+        // Populated before stream/tool listeners; flushed on turn end for honesty.
+        let streamCoalescer: StreamCoalescer | null = null;
+        let toolEventCoalescer: TimedBatchQueue<{
+          sessionId?: string;
+          toolCallId?: string;
+          title?: string;
+          kind?: string;
+          status?: string;
+          path?: string | null;
+          detail?: string | null;
+          before?: string | null;
+          after?: string | null;
+        }> | null = null;
+        const flushHostCoalescers = () => {
+          toolEventCoalescer?.flushAll();
+          streamCoalescer?.flushAll();
+        };
+
         const snap = await api.sessionGetState();
         if (!cancelled) {
           c.setLiveHost(snap);
@@ -214,6 +237,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
               }));
               // Clear retry chip / turn timer / stall banner when turn ends or errors out
               if (s.state !== "streaming" && s.state !== "awaiting_permission") {
+                // Drain coalesced stream/tool so final tokens land before streaming=false.
+                flushHostCoalescers();
                 c.setRetryStatus(null);
                 c.setStreamStall(null);
                 c.setTurnStartedAt(null);
@@ -402,6 +427,83 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }),
         );
+        // Adaptive flush: longer on ≤8-core (Intel) laptops, snappier on high-core.
+        const streamFlushMs = resolveStreamFlushMs();
+
+        type HostToolEvent = {
+          sessionId?: string;
+          toolCallId?: string;
+          title?: string;
+          kind?: string;
+          status?: string;
+          path?: string | null;
+          detail?: string | null;
+          before?: string | null;
+          after?: string | null;
+        };
+
+        // Batch high-frequency tool progress/detail into one setMessages apply.
+        // Terminal statuses flush immediately so the Tasks panel stays honest.
+        const applyToolBatchToUi = (events: HostToolEvent[]) => {
+          if (cancelled || !events.length) return;
+          // Group by session so multi-session tool traffic stays correct.
+          const bySid = new Map<string, HostToolEvent[]>();
+          for (const p of events) {
+            const sid = p.sessionId || c.viewingSessionIdRef.current;
+            if (!sid || !p.toolCallId) continue;
+            const list = bySid.get(sid);
+            if (list) list.push(p);
+            else bySid.set(sid, [p]);
+          }
+          for (const [sid, list] of bySid) {
+            c.patchSessionMessages(sid, (prev) => {
+              let next = prev;
+              for (const p of list) {
+                next = applyToolEvent(next, p);
+              }
+              c.setLiveMap((lm) => {
+                let m = projectLiveToolFromMessages(lm, sid, next);
+                m = markSawToolActivity(m, sid);
+                return m;
+              });
+              return next;
+            });
+            c.setSessionChangesById((prev) => {
+              let listChanges = prev[sid] ?? [];
+              let changed = false;
+              for (const p of list) {
+                const next = mergeSessionChange(listChanges, {
+                  toolCallId: p.toolCallId,
+                  title: p.title,
+                  kind: p.kind,
+                  status: p.status,
+                  path: p.path,
+                  detail: p.detail,
+                  before: p.before,
+                  after: p.after,
+                });
+                if (next !== listChanges) {
+                  listChanges = next;
+                  changed = true;
+                }
+              }
+              if (!changed) return prev;
+              return { ...prev, [sid]: listChanges };
+            });
+            if (sid === c.viewingSessionIdRef.current) {
+              c.setTurnStartedAt((t) => t ?? Date.now());
+              // Tool activity counts as progress — clear stall banner (I06).
+              c.setStreamStall(null);
+            }
+          }
+        };
+        toolEventCoalescer = new TimedBatchQueue<HostToolEvent>({
+          flushMs: streamFlushMs,
+          shouldFlushImmediate: (p) => toolEventNeedsImmediateFlush(p.status),
+          onFlush: applyToolBatchToUi,
+        });
+        cleanups.push(() => toolEventCoalescer?.dispose());
+
         // Batch high-frequency stream tokens before React setState (long turns).
         const applyStreamToUi = (chunk: StreamPayload) => {
           if (cancelled) return;
@@ -483,8 +585,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             void c.tryApplyAutomationFromSession(chunk.sessionId);
           }
         };
-        const streamCoalescer = new StreamCoalescer({
-          flushMs: 48,
+        streamCoalescer = new StreamCoalescer({
+          flushMs: streamFlushMs,
           onFlush: (raw) => {
             applyStreamToUi({
               sessionId: raw.sessionId ?? "",
@@ -496,11 +598,13 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             });
           },
         });
-        cleanups.push(() => streamCoalescer.dispose());
+        cleanups.push(() => streamCoalescer?.dispose());
         await track(
           api.listen<StreamPayload>("session://stream", (chunk) => {
             if (cancelled) return;
-            streamCoalescer.push(chunk);
+            // Turn-end honesty: drain pending tool progress before applying done.
+            if (chunk.done) toolEventCoalescer?.flushAll();
+            streamCoalescer?.push(chunk);
           }),
         );
         await track(
@@ -650,21 +754,12 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           }),
         );
         await track(
-          api.listen<{
-            sessionId?: string;
-            toolCallId?: string;
-            title?: string;
-            kind?: string;
-            status?: string;
-            path?: string | null;
-            detail?: string | null;
-            before?: string | null;
-            after?: string | null;
-          }>("session://tool", (p) => {
+          api.listen<HostToolEvent>("session://tool", (p) => {
             if (cancelled || !p?.toolCallId) return;
             const sid = p.sessionId || c.viewingSessionIdRef.current;
             if (!sid) return;
             // Hooks debug: tool failures / hookSpecificOutput (Extensions → Hooks).
+            // Keep immediate — not a React message path; failures should surface now.
             ingestToolHookSignal({
               title: p.title,
               kind: p.kind,
@@ -673,36 +768,7 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
               path: p.path,
               toolCallId: p.toolCallId,
             });
-            c.patchSessionMessages(sid, (prev) => {
-              const next = applyToolEvent(prev, p);
-              c.setLiveMap((lm) => {
-                let m = projectLiveToolFromMessages(lm, sid, next);
-                m = markSawToolActivity(m, sid);
-                return m;
-              });
-              return next;
-            });
-            // Track write/edit tools for the session Changes panel.
-            c.setSessionChangesById((prev) => {
-              const list = prev[sid] ?? [];
-              const next = mergeSessionChange(list, {
-                toolCallId: p.toolCallId,
-                title: p.title,
-                kind: p.kind,
-                status: p.status,
-                path: p.path,
-                detail: p.detail,
-                before: p.before,
-                after: p.after,
-              });
-              if (next === list) return prev;
-              return { ...prev, [sid]: next };
-            });
-            if (sid === c.viewingSessionIdRef.current) {
-              c.setTurnStartedAt((t) => t ?? Date.now());
-              // Tool activity counts as progress — clear stall banner (I06).
-              c.setStreamStall(null);
-            }
+            toolEventCoalescer?.push({ ...p, sessionId: sid });
           }),
         );
         await track(
@@ -749,6 +815,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             if (cancelled || !p) return;
             const sid = p.sessionId;
             if (!sid) return;
+            // Drain coalesced tool/stream so marker sees final rows.
+            flushHostCoalescers();
             c.patchSessionMessages(sid, (prev) => applyTurnMarker(prev, p));
             // Turn is over — any gate it raised can no longer be answered.
             c.clearPendingGatesRef.current(sid);

--- a/src/lib/streamCoalesce.test.ts
+++ b/src/lib/streamCoalesce.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  STREAM_COALESCE_FLUSH_MS,
+  TimedBatchQueue,
   mergeStreamChunks,
+  resolveStreamFlushMs,
   StreamCoalescer,
   streamChunkNeedsImmediateFlush,
   streamCoalesceKey,
+  toolEventNeedsImmediateFlush,
 } from "./streamCoalesce";
 
 describe("streamCoalesce", () => {
@@ -48,6 +52,34 @@ describe("streamCoalesce", () => {
     expect(streamChunkNeedsImmediateFlush({ text: "hi" })).toBe(false);
   });
 
+  it("resolveStreamFlushMs scales with cores (Intel longer, high-core snappier)", () => {
+    expect(resolveStreamFlushMs(4)).toBe(128);
+    expect(resolveStreamFlushMs(8)).toBe(128);
+    expect(resolveStreamFlushMs(10)).toBe(STREAM_COALESCE_FLUSH_MS);
+    expect(resolveStreamFlushMs(12)).toBe(STREAM_COALESCE_FLUSH_MS);
+    expect(resolveStreamFlushMs(16)).toBe(72);
+    expect(STREAM_COALESCE_FLUSH_MS).toBe(110);
+  });
+
+  it("default flush uses STREAM_COALESCE_FLUSH_MS (higher than historical 48)", () => {
+    vi.useFakeTimers();
+    const out: string[] = [];
+    const c = new StreamCoalescer({
+      onFlush: (ch) => out.push(ch.text ?? ""),
+    });
+    expect(c.intervalMs).toBe(STREAM_COALESCE_FLUSH_MS);
+    expect(c.intervalMs).toBeGreaterThan(48);
+    c.push({ sessionId: "s", messageId: "m", kind: "assistant", text: "a" });
+    c.push({ sessionId: "s", messageId: "m", kind: "assistant", text: "b" });
+    expect(out).toEqual([]);
+    vi.advanceTimersByTime(STREAM_COALESCE_FLUSH_MS - 1);
+    expect(out).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(out).toEqual(["ab"]);
+    c.dispose();
+    vi.useRealTimers();
+  });
+
   it("coalescer batches then flushes on timer", async () => {
     vi.useFakeTimers();
     const out: string[] = [];
@@ -80,5 +112,65 @@ describe("streamCoalesce", () => {
     });
     expect(out).toEqual(["ab|d"]);
     c.dispose();
+  });
+
+  it("trailing re-arm flushes chunks pushed during onFlush", () => {
+    vi.useFakeTimers();
+    const out: string[] = [];
+    let reentered = false;
+    const c = new StreamCoalescer({
+      flushMs: 50,
+      onFlush: (ch) => {
+        out.push(ch.text ?? "");
+        if (!reentered && ch.text === "ab") {
+          reentered = true;
+          // Simulate a late token arriving while React is applying the flush.
+          c.push({
+            sessionId: "s",
+            messageId: "m",
+            kind: "assistant",
+            text: "c",
+          });
+        }
+      },
+    });
+    c.push({ sessionId: "s", messageId: "m", kind: "assistant", text: "a" });
+    c.push({ sessionId: "s", messageId: "m", kind: "assistant", text: "b" });
+    vi.advanceTimersByTime(50);
+    expect(out).toEqual(["ab"]);
+    // Trailing arm should schedule another flush for "c".
+    vi.advanceTimersByTime(50);
+    expect(out).toEqual(["ab", "c"]);
+    c.dispose();
+    vi.useRealTimers();
+  });
+
+  it("toolEventNeedsImmediateFlush only for terminal statuses", () => {
+    expect(toolEventNeedsImmediateFlush("in_progress")).toBe(false);
+    expect(toolEventNeedsImmediateFlush("running")).toBe(false);
+    expect(toolEventNeedsImmediateFlush("completed")).toBe(true);
+    expect(toolEventNeedsImmediateFlush("failed")).toBe(true);
+    expect(toolEventNeedsImmediateFlush("error")).toBe(true);
+    expect(toolEventNeedsImmediateFlush("cancelled")).toBe(true);
+  });
+
+  it("TimedBatchQueue batches then flushes; terminal is immediate", () => {
+    vi.useFakeTimers();
+    const out: string[][] = [];
+    const q = new TimedBatchQueue<{ id: string; status?: string }>({
+      flushMs: 60,
+      shouldFlushImmediate: (i) => toolEventNeedsImmediateFlush(i.status),
+      onFlush: (items) => out.push(items.map((i) => i.id)),
+    });
+    q.push({ id: "a", status: "in_progress" });
+    q.push({ id: "b", status: "in_progress" });
+    expect(out).toEqual([]);
+    vi.advanceTimersByTime(60);
+    expect(out).toEqual([["a", "b"]]);
+    q.push({ id: "c", status: "in_progress" });
+    q.push({ id: "d", status: "completed" });
+    expect(out).toEqual([["a", "b"], ["c", "d"]]);
+    q.dispose();
+    vi.useRealTimers();
   });
 });

--- a/src/lib/streamCoalesce.ts
+++ b/src/lib/streamCoalesce.ts
@@ -2,6 +2,9 @@
  * Merge high-frequency stream chunks before React setState.
  * Same session + messageId + kind text is concatenated; terminal `done`
  * and thought phase boundaries flush immediately.
+ *
+ * Adaptive flushMs targets fewer setMessages/sec on lower-core (Intel) machines
+ * without delaying turn-end honesty (`done` / phase boundaries stay immediate).
  */
 
 export type CoalesceStreamChunk = {
@@ -12,6 +15,28 @@ export type CoalesceStreamChunk = {
   kind?: string | null;
   thoughtPhase?: string | null;
 };
+
+/**
+ * Default stream coalesce interval (ms). Used when core count is mid-range
+ * or when the caller does not pass an explicit flushMs.
+ * Higher than the historical 48ms to cut React message flushes on long turns.
+ */
+export const STREAM_COALESCE_FLUSH_MS = 110;
+
+/**
+ * Pick a stream flush interval from hardware concurrency.
+ * Fewer cores → longer batch window (Intel MBP / low-power laptops).
+ * More cores → slightly snappier UI updates.
+ */
+export function resolveStreamFlushMs(
+  hardwareConcurrency: number = typeof navigator !== "undefined"
+    ? navigator.hardwareConcurrency || 8
+    : 8,
+): number {
+  if (hardwareConcurrency <= 8) return 128;
+  if (hardwareConcurrency <= 12) return STREAM_COALESCE_FLUSH_MS;
+  return 72;
+}
 
 /** Stable key for mergeable stream rows. */
 export function streamCoalesceKey(chunk: CoalesceStreamChunk): string {
@@ -56,7 +81,7 @@ export function mergeStreamChunks(
 }
 
 export type StreamCoalescerOptions = {
-  /** Max hold time before a non-terminal batch is flushed (default 48ms). */
+  /** Max hold time before a non-terminal batch is flushed (default STREAM_COALESCE_FLUSH_MS). */
   flushMs?: number;
   /** Deliver one (possibly merged) chunk to the UI reducer. */
   onFlush: (chunk: CoalesceStreamChunk) => void;
@@ -74,8 +99,13 @@ export class StreamCoalescer {
   private disposed = false;
 
   constructor(opts: StreamCoalescerOptions) {
-    this.flushMs = Math.max(8, opts.flushMs ?? 48);
+    this.flushMs = Math.max(8, opts.flushMs ?? STREAM_COALESCE_FLUSH_MS);
     this.onFlush = opts.onFlush;
+  }
+
+  /** Current flush interval (ms). */
+  get intervalMs(): number {
+    return this.flushMs;
   }
 
   push(chunk: CoalesceStreamChunk): void {
@@ -138,6 +168,95 @@ export class StreamCoalescer {
     this.timer = setTimeout(() => {
       this.timer = null;
       this.flushAll();
+      // Trailing re-arm: if onFlush callbacks pushed more chunks, schedule again.
+      this.armOrClear();
     }, this.flushMs);
   }
+}
+
+// ─── High-frequency non-stream batching (tool progress / detail) ────────────
+
+export type TimedBatchQueueOptions<T> = {
+  /** Max hold time before a non-terminal batch is flushed. */
+  flushMs?: number;
+  /** Deliver the ordered batch to the UI (single setState preferred). */
+  onFlush: (items: T[]) => void;
+  /** When true, flush immediately including this item (terminal statuses). */
+  shouldFlushImmediate?: (item: T) => boolean;
+};
+
+/**
+ * Order-preserving timer batch for heterogeneous high-frequency events
+ * (e.g. `session://tool` progress/detail). Unlike {@link StreamCoalescer},
+ * items are not text-merged — they are applied in sequence in one flush.
+ */
+export class TimedBatchQueue<T> {
+  private readonly flushMs: number;
+  private readonly onFlush: (items: T[]) => void;
+  private readonly shouldFlushImmediate?: (item: T) => boolean;
+  private pending: T[] = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  constructor(opts: TimedBatchQueueOptions<T>) {
+    this.flushMs = Math.max(8, opts.flushMs ?? STREAM_COALESCE_FLUSH_MS);
+    this.onFlush = opts.onFlush;
+    this.shouldFlushImmediate = opts.shouldFlushImmediate;
+  }
+
+  push(item: T): void {
+    if (this.disposed) return;
+    this.pending.push(item);
+    if (this.shouldFlushImmediate?.(item)) {
+      this.flushAll();
+      return;
+    }
+    this.armOrClear();
+  }
+
+  flushAll(): void {
+    if (this.timer != null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.pending.length === 0) return;
+    const items = this.pending;
+    this.pending = [];
+    this.onFlush(items);
+  }
+
+  dispose(): void {
+    this.flushAll();
+    this.disposed = true;
+  }
+
+  private armOrClear(): void {
+    if (this.pending.length === 0) {
+      if (this.timer != null) {
+        clearTimeout(this.timer);
+        this.timer = null;
+      }
+      return;
+    }
+    if (this.timer != null) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.flushAll();
+      // Trailing re-arm if flush callbacks enqueued more work.
+      this.armOrClear();
+    }, this.flushMs);
+  }
+}
+
+/** Terminal tool statuses that must not wait in the tool batch buffer. */
+export function toolEventNeedsImmediateFlush(status?: string | null): boolean {
+  const s = (status ?? "").toLowerCase();
+  return (
+    s === "completed" ||
+    s === "failed" ||
+    s === "error" ||
+    s === "cancelled" ||
+    s === "canceled" ||
+    s === "done"
+  );
 }


### PR DESCRIPTION
## Summary
Press Host → React coalesce harder on thermally limited machines:

| Cores | flushMs |
|-------|---------|
| ≤ 8 | **128** |
| 9–12 | **110** |
| ≥ 13 | **72** |

- Default raised from **48 → 110**
- `session://tool` progress also batch-queued (terminal statuses flush immediately)
- Trailing re-arm if chunks arrive during flush
- Stream `done` / thought phase open still immediate

## Test plan
- [ ] Streaming text still feels continuous; turn end still settles immediately
- [ ] Tool steps complete without stuck “running”
- [ ] `vitest src/lib/streamCoalesce.test.ts`

Independent of #505 (overlaps coalesce knobs — rebase if both land).