### PR TITLE
fix(mirror): retry Docker tunnel over HTTP/2

### DIFF
--- a/src-tauri/src/commands/hooks_setup_p1.rs
+++ b/src-tauri/src/commands/hooks_setup_p1.rs
@@ -682,49 +682,7 @@ pub fn sanitize_worktree_ref(raw: Option<&str>) -> Result<Option<String>, String
 }
 
 #[cfg(test)]
-mod worktree_path_tests {
-    use super::*;
-    use std::path::Path;
-
-    #[test]
-    fn layout_defaults_to_cli() {
-        assert_eq!(normalize_worktree_layout(None), "cli");
-        assert_eq!(normalize_worktree_layout(Some("")), "cli");
-        assert_eq!(normalize_worktree_layout(Some("CLI")), "cli");
-        assert_eq!(normalize_worktree_layout(Some("sibling")), "sibling");
-    }
-
-    #[test]
-    fn sibling_path_next_to_main() {
-        assert_eq!(
-            build_worktree_sibling_path("/Users/me/repo", "feat").unwrap(),
-            "/Users/me/repo-feat"
-        );
-    }
-
-    #[test]
-    fn cli_path_under_grok_worktrees() {
-        let home = Path::new("/Users/me/.grok");
-        assert_eq!(
-            build_worktree_cli_path("/Users/me/Code/oss-grok-app", "feat", home).unwrap(),
-            "/Users/me/.grok/worktrees/oss-grok-app/feat"
-        );
-        assert_eq!(
-            worktree_repo_slug("/Users/me/Code/oss-grok-app").unwrap(),
-            "oss-grok-app"
-        );
-    }
-
-    #[test]
-    fn sanitize_ref_rejects_flags() {
-        assert!(sanitize_worktree_ref(Some("-b")).is_err());
-        assert_eq!(
-            sanitize_worktree_ref(Some("  origin/main  ")).unwrap().as_deref(),
-            Some("origin/main")
-        );
-        assert_eq!(sanitize_worktree_ref(None).unwrap(), None);
-    }
-}
+include!("hooks_setup_worktree_path_tests.rs");
 
 // from PR #77
 
@@ -1036,4 +994,3 @@ pub async fn setup_preview() -> Result<serde_json::Value, String> {
 
     Ok(setup_preview_from_body(body))
 }
-

--- a/src-tauri/src/commands/hooks_setup_worktree_path_tests.rs
+++ b/src-tauri/src/commands/hooks_setup_worktree_path_tests.rs
@@ -1,0 +1,43 @@
+mod worktree_path_tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn layout_defaults_to_cli() {
+        assert_eq!(normalize_worktree_layout(None), "cli");
+        assert_eq!(normalize_worktree_layout(Some("")), "cli");
+        assert_eq!(normalize_worktree_layout(Some("CLI")), "cli");
+        assert_eq!(normalize_worktree_layout(Some("sibling")), "sibling");
+    }
+
+    #[test]
+    fn sibling_path_next_to_main() {
+        assert_eq!(
+            build_worktree_sibling_path("/Users/me/repo", "feat").unwrap(),
+            "/Users/me/repo-feat"
+        );
+    }
+
+    #[test]
+    fn cli_path_under_grok_worktrees() {
+        let home = Path::new("/Users/me/.grok");
+        assert_eq!(
+            build_worktree_cli_path("/Users/me/Code/oss-grok-app", "feat", home).unwrap(),
+            "/Users/me/.grok/worktrees/oss-grok-app/feat"
+        );
+        assert_eq!(
+            worktree_repo_slug("/Users/me/Code/oss-grok-app").unwrap(),
+            "oss-grok-app"
+        );
+    }
+
+    #[test]
+    fn sanitize_ref_rejects_flags() {
+        assert!(sanitize_worktree_ref(Some("-b")).is_err());
+        assert_eq!(
+            sanitize_worktree_ref(Some("  origin/main  ")).unwrap().as_deref(),
+            Some("origin/main")
+        );
+        assert_eq!(sanitize_worktree_ref(None).unwrap(), None);
+    }
+}

--- a/src-tauri/src/extensions.rs
+++ b/src-tauri/src/extensions.rs
@@ -1935,9 +1935,9 @@ x-chatcut-mcp-surface = "codex"
         assert_eq!(entry["type"], "http");
         assert_eq!(entry["url"], "https://api.chatcut.io/api/external-mcp/mcp");
         let headers = entry["headers"].as_array().unwrap();
-        assert!(headers.iter().any(|h| {
-            h["name"] == "x-chatcut-mcp-surface" && h["value"] == "codex"
-        }));
+        assert!(headers
+            .iter()
+            .any(|h| { h["name"] == "x-chatcut-mcp-surface" && h["value"] == "codex" }));
     }
 
     #[test]

--- a/src-tauri/src/mcp_oauth.rs
+++ b/src-tauri/src/mcp_oauth.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use base64::engine::general_purpose::{URL_SAFE_NO_PAD, STANDARD};
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -59,8 +59,12 @@ enum FlowPhase {
         auth_url: String,
         started: Instant,
     },
-    Success { message: String },
-    Error { message: String },
+    Success {
+        message: String,
+    },
+    Error {
+        message: String,
+    },
 }
 
 struct FlowState {
@@ -217,19 +221,18 @@ fn http_post_json(url: &str, body: &Value) -> Result<Value, String> {
             text.chars().take(200).collect::<String>()
         ));
     }
-    serde_json::from_str(&text).map_err(|e| format!("JSON parse: {e}; body={}", text.chars().take(120).collect::<String>()))
+    serde_json::from_str(&text).map_err(|e| {
+        format!(
+            "JSON parse: {e}; body={}",
+            text.chars().take(120).collect::<String>()
+        )
+    })
 }
 
 fn form_encode(pairs: &[(&str, &str)]) -> String {
     pairs
         .iter()
-        .map(|(k, v)| {
-            format!(
-                "{}={}",
-                urlencoding_encode(k),
-                urlencoding_encode(v)
-            )
-        })
+        .map(|(k, v)| format!("{}={}", urlencoding_encode(k), urlencoding_encode(v)))
         .collect::<Vec<_>>()
         .join("&")
 }
@@ -247,13 +250,13 @@ fn urlencoding_encode(s: &str) -> String {
     out
 }
 
-fn discover_for_mcp_url(mcp_url: &str) -> Result<(ProtectedResourceMeta, AuthServerMeta, String), String> {
+fn discover_for_mcp_url(
+    mcp_url: &str,
+) -> Result<(ProtectedResourceMeta, AuthServerMeta, String), String> {
     let mcp_url = mcp_url.trim().trim_end_matches('/');
     // RFC 9728 style path under well-known
     let resource_meta_urls = [
-        format!(
-            "https://api.chatcut.io/.well-known/oauth-protected-resource/api/external-mcp/mcp"
-        ),
+        format!("https://api.chatcut.io/.well-known/oauth-protected-resource/api/external-mcp/mcp"),
         // Generic: origin + /.well-known/oauth-protected-resource + path
         {
             if let Ok(u) = reqwest::Url::parse(mcp_url) {
@@ -308,27 +311,20 @@ fn discover_for_mcp_url(mcp_url: &str) -> Result<(ProtectedResourceMeta, AuthSer
     let as_val = http_get_json(&as_meta_url)?;
     let as_meta: AuthServerMeta =
         serde_json::from_value(as_val).map_err(|e| format!("auth server meta: {e}"))?;
-    let resource = pr
-        .resource
-        .clone()
-        .unwrap_or_else(|| mcp_url.to_string());
+    let resource = pr.resource.clone().unwrap_or_else(|| mcp_url.to_string());
     Ok((pr, as_meta, resource))
 }
 
 fn bind_loopback() -> Result<(TcpListener, String, u16), String> {
     let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| e.to_string())?;
-    listener
-        .set_nonblocking(false)
-        .map_err(|e| e.to_string())?;
+    listener.set_nonblocking(false).map_err(|e| e.to_string())?;
     let port = listener.local_addr().map_err(|e| e.to_string())?.port();
     let redirect = format!("http://127.0.0.1:{port}/callback");
     Ok((listener, redirect, port))
 }
 
 fn wait_for_code(listener: TcpListener, expect_state: &str) -> Result<String, String> {
-    listener
-        .set_nonblocking(true)
-        .map_err(|e| e.to_string())?;
+    listener.set_nonblocking(true).map_err(|e| e.to_string())?;
     let deadline = Instant::now() + Duration::from_secs(OAUTH_WAIT_SECS);
     let (mut stream, _) = loop {
         match listener.accept() {
@@ -472,7 +468,11 @@ fn exchange_token(
     serde_json::from_str(&text).map_err(|e| format!("token JSON: {e}"))
 }
 
-fn persist_bearer(server: &str, access_token: &str, extra_headers: Option<&HashMap<String, String>>) -> Result<(), String> {
+fn persist_bearer(
+    server: &str,
+    access_token: &str,
+    extra_headers: Option<&HashMap<String, String>>,
+) -> Result<(), String> {
     let settings = store::load_settings();
     let _ = mirror_user_http_mcp_into_agent_home(&settings.session_data_mode);
 
@@ -500,10 +500,7 @@ fn persist_bearer(server: &str, access_token: &str, extra_headers: Option<&HashM
             .entry("x-chatcut-mcp-surface".into())
             .or_insert_with(|| "codex".into());
     }
-    headers.insert(
-        "Authorization".into(),
-        format!("Bearer {access_token}"),
-    );
+    headers.insert("Authorization".into(), format!("Bearer {access_token}"));
 
     // Write agent-home (independent) + user ~/.grok so doctor/CLI both see it.
     let paths: Vec<PathBuf> = {
@@ -542,7 +539,11 @@ fn persist_bearer(server: &str, access_token: &str, extra_headers: Option<&HashM
     Ok(())
 }
 
-fn write_mcp_credentials_best_effort(server: &str, access_token: &str, resource: &str) -> Result<(), String> {
+fn write_mcp_credentials_best_effort(
+    server: &str,
+    access_token: &str,
+    resource: &str,
+) -> Result<(), String> {
     let settings = store::load_settings();
     let homes = [
         crate::paths::resolve_agent_grok_home(&settings.session_data_mode),
@@ -605,15 +606,12 @@ pub fn mcp_oauth_start(server_name: &str) -> Result<McpOauthStartResult, String>
     let settings = store::load_settings();
     let _ = mirror_user_http_mcp_into_agent_home(&settings.session_data_mode);
     let defs = list_mcp_server_defs(None);
-    let def = defs
-        .iter()
-        .find(|d| d.name == server)
-        .ok_or_else(|| {
-            format!(
-                "MCP server '{server}' not found under App agent-home / ~/.grok. \
+    let def = defs.iter().find(|d| d.name == server).ok_or_else(|| {
+        format!(
+            "MCP server '{server}' not found under App agent-home / ~/.grok. \
                  Add it first (Settings → MCP or grok mcp add)."
-            )
-        })?;
+        )
+    })?;
     let mcp_url = def
         .url
         .as_deref()
@@ -692,11 +690,7 @@ pub fn mcp_oauth_start(server_name: &str) -> Result<McpOauthStartResult, String>
                 &verifier,
                 &resource_owned,
             )?;
-            persist_bearer(
-                &server_owned,
-                &tok.access_token,
-                existing_headers.as_ref(),
-            )?;
+            persist_bearer(&server_owned, &tok.access_token, existing_headers.as_ref())?;
             // keep refresh_token in credentials file if present
             if let Some(rt) = tok.refresh_token.as_deref() {
                 let _ = rt; // already stored access; refresh optional later
@@ -724,8 +718,9 @@ pub fn mcp_oauth_start(server_name: &str) -> Result<McpOauthStartResult, String>
         server: server.to_string(),
         auth_url,
         redirect_uri,
-        message: "Open the URL, sign in to the provider, then wait for App to capture the callback."
-            .into(),
+        message:
+            "Open the URL, sign in to the provider, then wait for App to capture the callback."
+                .into(),
     })
 }
 

--- a/src-tauri/src/mirror/tunnel.rs
+++ b/src-tauri/src/mirror/tunnel.rs
@@ -25,6 +25,10 @@ const TUNNEL_READY_TIMEOUT: Duration = Duration::from_secs(90);
 /// First Docker run can pull the official image before cloudflared starts.
 const DOCKER_TUNNEL_READY_TIMEOUT: Duration = Duration::from_secs(180);
 const DOCKER_DAEMON_TIMEOUT: Duration = Duration::from_secs(8);
+/// A single QUIC disconnect can be transient. Two failures before registration
+/// are enough to prove the default transport is not becoming usable, while
+/// keeping the HTTP/2 retry well below the normal Docker readiness timeout.
+const QUIC_FAILURES_BEFORE_HTTP2_RETRY: usize = 2;
 const DEFAULT_CLOUDFLARED_IMAGE: &str = "cloudflare/cloudflared:latest";
 const DOCKER_CONTAINER_PREFIX: &str = "grok-mirror-cloudflared-";
 const DOCKER_MIRROR_LABEL: &str = "com.grokapp.mirror=1";
@@ -57,8 +61,45 @@ struct TunnelCommandSpec {
     docker_cleanup: Option<DockerCleanup>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TunnelProtocol {
+    Auto,
+    Http2,
+}
+
+impl TunnelProtocol {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Http2 => "http2",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TunnelAttemptError {
+    message: String,
+    retry_with_http2: bool,
+}
+
+impl TunnelAttemptError {
+    fn other(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            retry_with_http2: false,
+        }
+    }
+
+    fn quic_unavailable() -> Self {
+        Self {
+            message: "cloudflared QUIC transport failed repeatedly before registration".into(),
+            retry_with_http2: true,
+        }
+    }
+}
+
 impl TunnelAdapter {
-    fn command_spec(&self, local_port: u16) -> TunnelCommandSpec {
+    fn command_spec(&self, local_port: u16, protocol: TunnelProtocol) -> TunnelCommandSpec {
         match self {
             Self::HostBinary { bin } => TunnelCommandSpec {
                 program: bin.clone(),
@@ -92,8 +133,11 @@ impl TunnelAdapter {
                     "tunnel".into(),
                     "--url".into(),
                     docker_tunnel_origin(local_port),
-                    "--no-autoupdate".into(),
                 ]);
+                if protocol == TunnelProtocol::Http2 {
+                    args.extend(["--protocol".into(), "http2".into()]);
+                }
+                args.push("--no-autoupdate".into());
                 TunnelCommandSpec {
                     program: bin.clone(),
                     args,
@@ -186,7 +230,34 @@ pub struct TunnelStart {
 /// `Registered tunnel connection` (or errors out).
 pub async fn start_quick_tunnel(local_port: u16) -> Result<TunnelStart, String> {
     let adapter = select_tunnel_adapter(local_port).await?;
-    let spec = adapter.command_spec(local_port);
+    match start_tunnel_attempt(&adapter, local_port, TunnelProtocol::Auto).await {
+        Ok(start) => Ok(start),
+        Err(primary)
+            if matches!(adapter, TunnelAdapter::Docker { .. }) && primary.retry_with_http2 =>
+        {
+            tracing::warn!(
+                error = %primary.message,
+                "mirror Docker tunnel retrying with HTTP/2 transport"
+            );
+            start_tunnel_attempt(&adapter, local_port, TunnelProtocol::Http2)
+                .await
+                .map_err(|fallback| {
+                    format!(
+                        "{}; HTTP/2 retry failed: {}",
+                        primary.message, fallback.message
+                    )
+                })
+        }
+        Err(error) => Err(error.message),
+    }
+}
+
+async fn start_tunnel_attempt(
+    adapter: &TunnelAdapter,
+    local_port: u16,
+    protocol: TunnelProtocol,
+) -> Result<TunnelStart, TunnelAttemptError> {
+    let spec = adapter.command_spec(local_port, protocol);
     let mut cmd = Command::new(&spec.program);
     cmd.args(&spec.args)
         .stdin(Stdio::null())
@@ -215,10 +286,10 @@ pub async fn start_quick_tunnel(local_port: u16) -> Result<TunnelStart, String> 
     }
 
     let mut child = cmd.spawn().map_err(|e| {
-        format!(
+        TunnelAttemptError::other(format!(
             "failed to spawn {} cloudflared adapter: {e}",
             spec.adapter_name
-        )
+        ))
     })?;
     let pid = child.id();
     let pgid = pid.map(|p| p as i32);
@@ -227,20 +298,22 @@ pub async fn start_quick_tunnel(local_port: u16) -> Result<TunnelStart, String> 
         Some(stdout) => stdout,
         None => {
             terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
-            return Err("cloudflared stdout missing".into());
+            return Err(TunnelAttemptError::other("cloudflared stdout missing"));
         }
     };
     let stderr = match child.stderr.take() {
         Some(stderr) => stderr,
         None => {
             terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
-            return Err("cloudflared stderr missing".into());
+            return Err(TunnelAttemptError::other("cloudflared stderr missing"));
         }
     };
 
-    let (tx, rx) = oneshot::channel::<Result<(String, bool), String>>();
+    let detect_quic_failure =
+        matches!(adapter, TunnelAdapter::Docker { .. }) && protocol == TunnelProtocol::Auto;
+    let (tx, rx) = oneshot::channel::<Result<(String, bool), TunnelAttemptError>>();
     tauri::async_runtime::spawn(async move {
-        let result = pump_tunnel_logs(stdout, stderr).await;
+        let result = pump_tunnel_logs(stdout, stderr, detect_quic_failure).await;
         let _ = tx.send(result);
     });
 
@@ -253,25 +326,35 @@ pub async fn start_quick_tunnel(local_port: u16) -> Result<TunnelStart, String> 
         }
         Ok(Err(_)) => {
             terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
-            return Err("cloudflared log pump closed without ready signal".into());
+            return Err(TunnelAttemptError::other(
+                "cloudflared log pump closed without ready signal",
+            ));
         }
         Err(_) => {
             terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
-            return Err(format!(
+            return Err(TunnelAttemptError::other(format!(
                 "cloudflared did not become ready within {}s",
                 spec.ready_timeout.as_secs()
-            ));
+            )));
         }
     };
 
     if !registered {
         terminate_failed_tunnel(&mut child, pid, pgid, spec.docker_cleanup.clone());
-        return Err("cloudflared printed URL but never 'Registered tunnel connection'".into());
+        return Err(TunnelAttemptError::other(
+            "cloudflared printed URL but never 'Registered tunnel connection'",
+        ));
     }
 
     let public_url = public_url.trim_end_matches('/').to_string();
 
-    tracing::info!(%public_url, ?pid, adapter = spec.adapter_name, "mirror cloudflared tunnel registered");
+    tracing::info!(
+        %public_url,
+        ?pid,
+        adapter = spec.adapter_name,
+        protocol = protocol.label(),
+        "mirror cloudflared tunnel registered"
+    );
 
     Ok(TunnelStart {
         handle: TunnelHandle {
@@ -485,7 +568,8 @@ fn cleanup_docker_container_in_background(cleanup: Option<DockerCleanup>) {
 async fn pump_tunnel_logs(
     stdout: impl tokio::io::AsyncRead + Unpin + Send + 'static,
     stderr: impl tokio::io::AsyncRead + Unpin + Send + 'static,
-) -> Result<(String, bool), String> {
+    detect_quic_failure: bool,
+) -> Result<(String, bool), TunnelAttemptError> {
     let (line_tx, mut line_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
     let tx_out = line_tx.clone();
@@ -505,6 +589,7 @@ async fn pump_tunnel_logs(
 
     let mut public_url: Option<String> = None;
     let mut registered = false;
+    let mut quic_failures = 0usize;
 
     while let Some(line) = line_rx.recv().await {
         tracing::debug!(target: "mirror_tunnel", "{line}");
@@ -516,6 +601,12 @@ async fn pump_tunnel_logs(
         if line.contains("Registered tunnel connection") {
             registered = true;
         }
+        if detect_quic_failure && is_quic_connectivity_failure(&line) {
+            quic_failures += 1;
+            if quic_failures >= QUIC_FAILURES_BEFORE_HTTP2_RETRY {
+                return Err(TunnelAttemptError::quic_unavailable());
+            }
+        }
         if let Some(ref u) = public_url {
             if registered {
                 return Ok((u.clone(), true));
@@ -526,8 +617,18 @@ async fn pump_tunnel_logs(
     match public_url {
         Some(u) if registered => Ok((u, true)),
         Some(u) => Ok((u, false)),
-        None => Err("cloudflared exited before printing a public URL".into()),
+        None => Err(TunnelAttemptError::other(
+            "cloudflared exited before printing a public URL",
+        )),
     }
+}
+
+fn is_quic_connectivity_failure(line: &str) -> bool {
+    let line = line.to_ascii_lowercase();
+    line.contains("quic")
+        && (line.contains("failed")
+            || line.contains("timeout")
+            || line.contains("no recent network activity"))
 }
 
 /// Extract first `https://*.trycloudflare.com` (or similar quick-tunnel host) from a log line.
@@ -614,6 +715,7 @@ fn libc_kill(pid: i32, sig: i32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncWriteExt;
 
     #[test]
     fn extracts_trycloudflare_url() {
@@ -644,7 +746,7 @@ mod tests {
         let adapter = TunnelAdapter::HostBinary {
             bin: PathBuf::from("/usr/local/bin/cloudflared"),
         };
-        let spec = adapter.command_spec(52770);
+        let spec = adapter.command_spec(52770, TunnelProtocol::Auto);
         assert_eq!(spec.adapter_name, "host_binary");
         assert_eq!(spec.program, PathBuf::from("/usr/local/bin/cloudflared"));
         assert!(spec.args.iter().any(|arg| arg == "http://127.0.0.1:52770"));
@@ -658,7 +760,7 @@ mod tests {
             image: DEFAULT_CLOUDFLARED_IMAGE.into(),
             container_name: "grok-mirror-test".into(),
         };
-        let spec = adapter.command_spec(52770);
+        let spec = adapter.command_spec(52770, TunnelProtocol::Auto);
         assert_eq!(spec.adapter_name, "docker");
         assert!(spec.args.iter().any(|arg| arg == DEFAULT_CLOUDFLARED_IMAGE));
         assert!(spec
@@ -689,5 +791,68 @@ mod tests {
             .args
             .iter()
             .any(|arg| arg == "http://host.docker.internal:52770"));
+    }
+
+    #[test]
+    fn docker_http2_retry_adds_transport_override() {
+        let adapter = TunnelAdapter::Docker {
+            bin: PathBuf::from("/usr/local/bin/docker"),
+            image: DEFAULT_CLOUDFLARED_IMAGE.into(),
+            container_name: "grok-mirror-test".into(),
+        };
+
+        let automatic = adapter.command_spec(52770, TunnelProtocol::Auto);
+        assert!(!automatic
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--protocol"));
+
+        let http2 = adapter.command_spec(52770, TunnelProtocol::Http2);
+        assert!(http2
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--protocol" && pair[1] == "http2"));
+    }
+
+    #[test]
+    fn identifies_real_quic_failures_but_ignores_successful_prechecks() {
+        assert!(is_quic_connectivity_failure(
+            "ERR Failed to dial a quic connection error=timeout: no recent network activity"
+        ));
+        assert!(is_quic_connectivity_failure(
+            "ERR failed to accept QUIC stream: timeout: no recent network activity"
+        ));
+        assert!(!is_quic_connectivity_failure(
+            "UDP Connectivity region1.v2.argotunnel.com PASS QUIC connection successful"
+        ));
+        assert!(!is_quic_connectivity_failure(
+            "INF Registered tunnel connection protocol=http2"
+        ));
+    }
+
+    #[tokio::test]
+    async fn repeated_quic_failures_request_http2_retry() {
+        let (mut stdout_writer, stdout_reader) = tokio::io::duplex(2048);
+        let (mut stderr_writer, stderr_reader) = tokio::io::duplex(2048);
+
+        stdout_writer
+            .write_all(b"INF https://retry-me.trycloudflare.com\n")
+            .await
+            .unwrap();
+        stderr_writer
+            .write_all(
+                b"ERR failed to accept QUIC stream: timeout: no recent network activity\n\
+                  ERR Failed to dial a quic connection: timeout: no recent network activity\n",
+            )
+            .await
+            .unwrap();
+        stdout_writer.shutdown().await.unwrap();
+        stderr_writer.shutdown().await.unwrap();
+
+        let error = pump_tunnel_logs(stdout_reader, stderr_reader, true)
+            .await
+            .unwrap_err();
+        assert!(error.retry_with_http2);
+        assert!(error.message.contains("QUIC"));
     }
 }

--- a/src-tauri/src/session_manager/media_tests.rs
+++ b/src-tauri/src/session_manager/media_tests.rs
@@ -51,9 +51,7 @@ fn normalizes_chatcut_protocol_relative_s3_url() {
         )
     );
     assert!(!is_local_media_fs_path(raw));
-    assert!(is_media_fs_path(
-        &normalize_media_ref(raw).unwrap()
-    ));
+    assert!(is_media_fs_path(&normalize_media_ref(raw).unwrap()));
 }
 
 #[test]

--- a/src-tauri/src/session_manager/types.rs
+++ b/src-tauri/src/session_manager/types.rs
@@ -409,7 +409,9 @@ fn extract_chatcut_detail_snippet(raw: &serde_json::Value) -> Option<String> {
                 || p.ends_with("browserHandoff")
             {
                 if let Ok(s) = serde_json::to_string(v) {
-                    if s.contains("chatcut") || s.contains("browserHandoff") || s.contains("editorUrl")
+                    if s.contains("chatcut")
+                        || s.contains("browserHandoff")
+                        || s.contains("editorUrl")
                     {
                         return Some(s.chars().take(1200).collect());
                     }
@@ -434,8 +436,9 @@ fn find_chatcut_editor_url_in_text(text: &str) -> Option<String> {
             return Some(url);
         }
     }
-    find_https_url_near(text, "chatcut.io")
-        .filter(|u| u.contains("/editor") || u.contains("dockviewLayout") || u.contains("editor-boot-token"))
+    find_https_url_near(text, "chatcut.io").filter(|u| {
+        u.contains("/editor") || u.contains("dockviewLayout") || u.contains("editor-boot-token")
+    })
 }
 
 fn find_https_url_near(text: &str, must_contain: &str) -> Option<String> {
@@ -830,7 +833,11 @@ pub(super) fn normalize_media_ref(path: &str) -> Option<String> {
     }
     if t.starts_with('/') {
         // Local absolute: collapse accidental double slashes (…/T//chatcut-…).
-        let collapsed = t.split('/').filter(|s| !s.is_empty()).collect::<Vec<_>>().join("/");
+        let collapsed = t
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("/");
         return Some(format!("/{collapsed}"));
     }
     // Windows absolute
@@ -869,7 +876,9 @@ pub(super) fn first_media_path_in_text(text: &str) -> Option<String> {
         if let Some(n) = normalize_media_ref(p) {
             if is_media_fs_path(&n) {
                 // Prefer remote URLs and real local paths; skip non-media.
-                if n.starts_with("http://") || n.starts_with("https://") || is_local_media_fs_path(&n)
+                if n.starts_with("http://")
+                    || n.starts_with("https://")
+                    || is_local_media_fs_path(&n)
                 {
                     return Some(n);
                 }
@@ -1032,10 +1041,9 @@ fn urlencoding_soft_decode(s: &str) -> String {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(v) = u8::from_str_radix(
-                std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or(""),
-                16,
-            ) {
+            if let Ok(v) =
+                u8::from_str_radix(std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or(""), 16)
+            {
                 out.push(v);
                 i += 3;
                 continue;

--- a/src-tauri/src/session_manager/watchdog.rs
+++ b/src-tauri/src/session_manager/watchdog.rs
@@ -7,7 +7,7 @@ use tauri::{AppHandle, Emitter};
 
 use crate::session_fsm::SessionState;
 use crate::stream_stall::{
-    is_stream_stalled, is_maybe_done_candidate, should_emit_soft_stall, stall_tier_from_evidence,
+    is_maybe_done_candidate, is_stream_stalled, should_emit_soft_stall, stall_tier_from_evidence,
 };
 
 use super::*;

--- a/src-tauri/src/stream_stall.rs
+++ b/src-tauri/src/stream_stall.rs
@@ -260,7 +260,13 @@ mod tests {
         let stall_at = t0 + Duration::from_secs(180);
         assert!(should_emit_soft_stall(t0, None, 180, 0, stall_at));
         // Same moment as last emit — do not re-spam.
-        assert!(!should_emit_soft_stall(t0, Some(stall_at), 180, 1, stall_at));
+        assert!(!should_emit_soft_stall(
+            t0,
+            Some(stall_at),
+            180,
+            1,
+            stall_at
+        ));
         // Another full soft window of silence → re-prompt (never auto-end).
         assert!(should_emit_soft_stall(
             t0,

--- a/src/components/ProjectInspectPanel.tsx
+++ b/src/components/ProjectInspectPanel.tsx
@@ -21,6 +21,7 @@ import {
   inspectSectionCounts,
   inspectSectionDocsUrl,
   inspectSectionPaths,
+  normalizeProjectInspectSummary,
   sliceInspectList,
   type InspectSectionId,
   type ProjectInspectSummary,
@@ -93,51 +94,6 @@ function sectionChipLabel(
   }
 }
 
-/** Normalize host payload so older shapes (missing names/hooks) still render. */
-function normalizeSummary(raw: ProjectInspectSummary): ProjectInspectSummary {
-  const skills = raw.skills ?? {
-    total: 0,
-    userInvocable: 0,
-    bySource: {},
-    sample: [],
-    names: [],
-  };
-  const names =
-    Array.isArray(skills.names) && skills.names.length > 0
-      ? skills.names
-      : Array.isArray(skills.sample)
-        ? [...skills.sample]
-        : [];
-  const hooks = Array.isArray(raw.hooks) ? raw.hooks : [];
-  const hooksCount =
-    typeof raw.hooksCount === "number" && raw.hooksCount > 0
-      ? raw.hooksCount
-      : hooks.length;
-  return {
-    ...raw,
-    skills: {
-      total: skills.total ?? names.length,
-      userInvocable: skills.userInvocable ?? 0,
-      bySource: skills.bySource ?? {},
-      sample: skills.sample ?? [],
-      names,
-    },
-    hooks,
-    hooksCount,
-    plugins: raw.plugins ?? [],
-    mcp: raw.mcp ?? [],
-    agents: raw.agents ?? [],
-    rules: raw.rules ?? [],
-    configLayers: raw.configLayers ?? [],
-    modelsHints: raw.modelsHints ?? [],
-    permissions: raw.permissions ?? {
-      loaded: 0,
-      sourcesCount: 0,
-      managedSettingsActive: false,
-    },
-  };
-}
-
 export function ProjectInspectPanel({
   locale,
   projectPath = null,
@@ -176,7 +132,7 @@ export function ProjectInspectPanel({
     setHint(null);
     try {
       const res = await api.projectInspect(cwd);
-      setSummary(normalizeSummary(res));
+      setSummary(normalizeProjectInspectSummary(res));
       if (res.error?.trim()) {
         setError(res.error.trim());
       }

--- a/src/lib/projectInspect.test.ts
+++ b/src/lib/projectInspect.test.ts
@@ -12,11 +12,28 @@ import {
   inspectSectionPaths,
   inspectSectionSlice,
   isSensitiveKey,
+  normalizeProjectInspectSummary,
   redactSensitiveValue,
   sliceInspectList,
   summarizeInspectJson,
   INSPECT_SECTION_IDS,
 } from "./projectInspect";
+
+describe("normalizeProjectInspectSummary", () => {
+  it("fills list fields and derives names/hooks for older host payloads", () => {
+    const base = emptyProjectInspectSummary();
+    const normalized = normalizeProjectInspectSummary({
+      ...base,
+      skills: { ...base.skills, names: [], sample: ["fallback-skill"] },
+      hooks: [{ event: "stop" }],
+      hooksCount: 0,
+    });
+
+    expect(normalized.skills.names).toEqual(["fallback-skill"]);
+    expect(normalized.hooksCount).toBe(1);
+    expect(normalized.plugins).toEqual([]);
+  });
+});
 
 const SAMPLE_INSPECT = {
   grokVersion: "0.2.111",

--- a/src/lib/projectInspect.ts
+++ b/src/lib/projectInspect.ts
@@ -285,6 +285,53 @@ export function emptyProjectInspectSummary(
   };
 }
 
+/** Normalize older host payloads that may omit names, hooks, or list fields. */
+export function normalizeProjectInspectSummary(
+  raw: ProjectInspectSummary,
+): ProjectInspectSummary {
+  const skills = raw.skills ?? {
+    total: 0,
+    userInvocable: 0,
+    bySource: {},
+    sample: [],
+    names: [],
+  };
+  const names =
+    Array.isArray(skills.names) && skills.names.length > 0
+      ? skills.names
+      : Array.isArray(skills.sample)
+        ? [...skills.sample]
+        : [];
+  const hooks = Array.isArray(raw.hooks) ? raw.hooks : [];
+  const hooksCount =
+    typeof raw.hooksCount === "number" && raw.hooksCount > 0
+      ? raw.hooksCount
+      : hooks.length;
+  return {
+    ...raw,
+    skills: {
+      total: skills.total ?? names.length,
+      userInvocable: skills.userInvocable ?? 0,
+      bySource: skills.bySource ?? {},
+      sample: skills.sample ?? [],
+      names,
+    },
+    hooks,
+    hooksCount,
+    plugins: raw.plugins ?? [],
+    mcp: raw.mcp ?? [],
+    agents: raw.agents ?? [],
+    rules: raw.rules ?? [],
+    configLayers: raw.configLayers ?? [],
+    modelsHints: raw.modelsHints ?? [],
+    permissions: raw.permissions ?? {
+      loaded: 0,
+      sourcesCount: 0,
+      managedSettingsActive: false,
+    },
+  };
+}
+
 /**
  * Build a secret-safe summary from raw `grok inspect --json` output.
  * Only copies known safe fields — never passes through unknown blobs wholesale.


### PR DESCRIPTION
## Summary

- detect repeated pre-registration QUIC connectivity failures in the Docker cloudflared adapter
- clean up the failed Docker attempt and retry the Quick Tunnel with `--protocol http2`
- keep the host-binary adapter and successful default Docker transport unchanged
- restore the repository's Rust formatting baseline required by CI
- reduce the ≥1000-line file count from 47 to the configured limit of 45 by moving existing worktree tests and a pure Project Inspect normalizer into existing module seams

## Root cause

On networks where cloudflared's connectivity precheck succeeds but the QUIC control stream repeatedly times out, the Docker adapter kept retrying QUIC until the 180-second readiness timeout. The App therefore never received a registered tunnel and the generated `trycloudflare.com` endpoint returned HTTP 530.

The PR initially inherited two existing red CI baselines from `main`: six Rust files did not match the current `cargo fmt --all` output, and the final code-quality gate counted 47 files at or above 1000 lines against a limit of 45. This PR includes the approved baseline cleanup so all checks can run normally.

## User impact

Phone mirror startup can now recover automatically on networks with unstable or blocked QUIC. A single transient disconnect does not trigger fallback; two failures before tunnel registration switch the managed Docker attempt to HTTP/2.

The CI cleanup is behavior-preserving: Rust changes outside the tunnel are formatting-only; worktree tests moved to a dedicated include file; Project Inspect keeps the same normalization behavior through its existing utility module.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --all-targets -- -W clippy::all` — completed with two pre-existing warnings
- `cargo test -- --test-threads=1` — 955 passed, 1 ignored
- focused tunnel tests — 8 passed
- moved worktree tests — 4 passed
- `pnpm lint` — passed
- `python3 scripts/check-code-quality-gates.py --mode final` — passed (`files_ge_1000=45`)
- Project Inspect tests — 19 passed
- two locally cold-starting canvas suites rerun — 16 passed
- `pnpm build:mac-arm` — passed before the CI baseline follow-up
- live Docker Quick Tunnel: reproduced QUIC failure, observed automatic HTTP/2 retry and `Registered tunnel connection ... protocol=http2`
- live phone-mirror URL returned HTTP 200 after fallback
