### PR TITLE
fix(side-browser): avoid child webview creation deadlock

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -80,7 +80,7 @@ pub async fn terminal_pty_kill(session_id: String) -> Result<(), String> {
 /// Create/replace a side-browser child webview with download save-dialog wiring.
 /// Prefer this over frontend `new Webview()` so WKWebView downloads can prompt.
 #[tauri::command]
-pub fn side_browser_create(
+pub async fn side_browser_create(
     app: AppHandle,
     label: String,
     url: String,
@@ -90,7 +90,16 @@ pub fn side_browser_create(
     width: f64,
     height: f64,
 ) -> Result<(), String> {
-    side_browser_host::create(&app, label, url, window_label, x, y, width, height)
+    // `Window::add_child` dispatches work to the platform event loop and waits
+    // for completion. Running it inside a synchronous IPC command can occupy
+    // that same loop on Windows, leaving WebView2 half-created (renderer starts,
+    // but the command never returns). Match Tauri's own async create_webview
+    // command and keep the blocking wait off the UI/invoke thread.
+    tauri::async_runtime::spawn_blocking(move || {
+        side_browser_host::create(&app, label, url, window_label, x, y, width, height)
+    })
+    .await
+    .map_err(|e| format!("side_browser_create join: {e}"))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/side_browser_host.rs
+++ b/src-tauri/src/side_browser_host.rs
@@ -273,15 +273,45 @@ pub fn create(
     let width = width.max(40.0);
     let height = height.max(40.0);
 
-    if let Some(existing) = app.get_webview(&label) {
-        existing
-            .close()
-            .map_err(|e| format!("close existing side browser: {e}"))?;
-    }
-
     let window = app
         .get_window(win_label)
         .ok_or_else(|| format!("window not found: {win_label}"))?;
+
+    // A quick React remount (including development StrictMode) can ask for the
+    // same label while its native WebView is still alive. Reuse it instead of
+    // synchronously destroying and recreating a WebView2 controller. On
+    // Windows, close -> add_child overlap can re-enter controller teardown and
+    // leave the create command waiting forever.
+    if let Some(existing) = app.get_webview(&label) {
+        tracing::info!(
+            target: "side_browser",
+            webview_label = %label,
+            window = %win_label,
+            url = %url,
+            "reusing existing side browser webview"
+        );
+        existing
+            .set_position(LogicalPosition::new(x, y))
+            .map_err(|e| format!("reuse side browser position: {e}"))?;
+        existing
+            .set_size(LogicalSize::new(width, height))
+            .map_err(|e| format!("reuse side browser size: {e}"))?;
+        let should_navigate = existing
+            .url()
+            .map(|current| current != parsed)
+            .unwrap_or(true);
+        if should_navigate {
+            existing
+                .navigate(parsed)
+                .map_err(|e| format!("reuse side browser navigate: {e}"))?;
+        }
+        tracing::info!(
+            target: "side_browser",
+            webview_label = %label,
+            "existing side browser webview ready"
+        );
+        return Ok(());
+    }
 
     let webview_label = label.clone();
     // Polyfill blob:/data: `<a download>` (ChatCut etc.) — WKWebView skips on_download.
@@ -290,8 +320,7 @@ pub fn create(
     let polyfill_reload = polyfill.clone();
     let title_label = label.clone();
     // Do not steal keyboard focus from the main chat/composer on create —
-    // focused(true) made panel open + first load feel frozen while WKWebView
-    // took the key view. Users click the page when they want to type there.
+    // users click the page when they want to type there.
     let builder = WebviewBuilder::new(label.clone(), WebviewUrl::External(parsed))
         .accept_first_mouse(true)
         .focused(false)
@@ -535,6 +564,18 @@ pub fn create(
                 _ => true,
             }
         });
+
+    tracing::info!(
+        target: "side_browser",
+        %webview_label,
+        window = %win_label,
+        url = %url,
+        x,
+        y,
+        width,
+        height,
+        "creating side browser child webview"
+    );
 
     window
         .add_child(

--- a/src/components/EmbeddedBrowser.tsx
+++ b/src/components/EmbeddedBrowser.tsx
@@ -107,6 +107,51 @@ function hostRectForWebview(hostEl: HTMLElement): HostRectPx {
 
 const WEBVIEW_LABEL_DEFAULT = "resource-browser";
 const DOWNLOAD_EVENT = "side-browser://download";
+const CREATE_TIMEOUT_MS = 15_000;
+const CLOSE_GRACE_MS = 150;
+
+// React StrictMode and quick pane remounts run effect cleanup immediately
+// before mounting the same label again. Closing the native WebView in that
+// gap can overlap the next WebView2 add_child call on Windows. Delay the close
+// briefly and cancel it when the same label is mounted again.
+const pendingCloseTimers = new Map<string, number>();
+
+function cancelPendingClose(label: string) {
+  const timer = pendingCloseTimers.get(label);
+  if (timer === undefined) return;
+  window.clearTimeout(timer);
+  pendingCloseTimers.delete(label);
+}
+
+function scheduleClose(label: string) {
+  cancelPendingClose(label);
+  const timer = window.setTimeout(() => {
+    if (pendingCloseTimers.get(label) !== timer) return;
+    pendingCloseTimers.delete(label);
+    void sideBrowserClose(label).catch((e) => {
+      console.warn("[EmbeddedBrowser] delayed close failed", e);
+    });
+  }, CLOSE_GRACE_MS);
+  pendingCloseTimers.set(label, timer);
+}
+
+async function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer = 0;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_, reject) => {
+        timer = window.setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
 
 /** How many parent elements to observe so pane/splitter moves re-sync position. */
 const ANCESTOR_OBSERVE_DEPTH = 6;
@@ -405,6 +450,7 @@ export function EmbeddedBrowser({
     lastVisibleRef.current = null;
 
     const boot = async () => {
+      cancelPendingClose(webviewLabel);
       setError(null);
       setReady(false);
       try {
@@ -415,12 +461,8 @@ export function EmbeddedBrowser({
         const { LogicalPosition, LogicalSize } = await loadDpi();
         const win = getCurrentWindow();
 
-        // Prefer host close only — avoids double-close races with getByLabel.
-        try {
-          await sideBrowserClose(webviewLabel);
-        } catch {
-          /* ignore */
-        }
+        // Do not close before create. The host reuses a live label, which avoids
+        // overlapping WebView2 controller teardown with a new add_child call.
         webviewRef.current = null;
         currentUrlRef.current = "";
         lastVisibleRef.current = null;
@@ -436,15 +478,19 @@ export function EmbeddedBrowser({
         // Use latest desired URL in case props changed while we awaited imports.
         const target = bootUrlRef.current || initialUrl;
 
-        await sideBrowserCreate({
-          label: webviewLabel,
-          url: target,
-          windowLabel: win.label,
-          x,
-          y,
-          width: w,
-          height: h,
-        });
+        await withTimeout(
+          sideBrowserCreate({
+            label: webviewLabel,
+            url: target,
+            windowLabel: win.label,
+            x,
+            y,
+            width: w,
+            height: h,
+          }),
+          CREATE_TIMEOUT_MS,
+          `side browser create timed out after ${CREATE_TIMEOUT_MS / 1000}s (${webviewLabel})`,
+        );
 
         if (cancelled) {
           try {
@@ -548,9 +594,10 @@ export function EmbeddedBrowser({
       currentUrlRef.current = "";
       lastBoundsRef.current = null;
       lastVisibleRef.current = null;
-      // Single host close path (do not also call frontend Webview.close).
+      // Single delayed host close path (do not also call frontend Webview.close).
+      // A same-label remount cancels this timer and reuses the existing WebView.
       if (isTauri()) {
-        void sideBrowserClose(webviewLabel).catch(() => undefined);
+        scheduleClose(webviewLabel);
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes #530

## 背景

Windows 版打开右侧内嵌浏览器时，界面可能永久停留在“加载中”。目标页面本身可访问，但 WebView2 renderer 启动后没有发起页面请求，Rust 侧也没有输出 `side browser webview created`。

阶段日志确认调用停在 `window.add_child(...)`。根因是 `side_browser_create` 原本是同步 Tauri command：同步 command 默认在主线程执行，而 `add_child` 会等待平台事件循环完成 child WebView 创建，Windows 下可能形成自等待。

## 修改内容

- 将 `side_browser_create` 改为异步 command，并通过 `spawn_blocking` 执行同步的 WebView 创建过程，避免占用 UI/IPC 主线程。
- 创建前不再无条件关闭同 label WebView；已有实例时复用、同步尺寸并按需导航。
- React cleanup 延迟 150ms 关闭，同 label 快速重挂载会取消关闭，避免 StrictMode/快速切换产生 close-create 重叠。
- 增加 15 秒创建超时，底层异常时展示错误和外部浏览器入口，不再无限加载。
- 在 `add_child` 前增加阶段日志，方便区分创建阻塞和页面导航问题。
- 保留原有 `.focused(false)` 行为，避免新建页面抢走主输入框焦点。

## 修复验证

环境：

- Windows 11 x64
- Grok App 0.2.9
- Tauri 2.11.5
- Wry 0.55.1
- WebView2 Runtime 151.0.4129.59

修复前：

- WebView2 renderer 已启动；
- 只有 `creating side browser child webview`；
- `window.add_child(...)` 不返回；
- 页面无网络请求，前端持续显示“加载中”。

修复后：

- 第一次创建约 90ms 完成；
- 恢复 `.focused(false)` 后再次创建约 77ms 完成；
- 两次均输出 `side browser webview created`；
- 后续下载 polyfill 注入成功。

## 检查结果

- `pnpm typecheck`：通过
- 目标文件 ESLint：通过
- `cargo check`：通过（仅仓库已有 warnings）
- `pnpm build:ui`：通过
- Vitest：346 个测试文件、4909 条测试通过

本机另有两个图片导出测试 suite 因 `canvas.node` 预编译包下载失败而未启动；Rust 单元测试可执行文件因本机 DLL 入口点错误 `0xc0000139` 未进入测试。二者均不是测试断言失败，建议由 CI 完成全量验证。

## 平台说明

故障已在 Windows/WebView2 上复现，但异步 command 修复不做 Windows 条件编译。同步 command 默认运行主线程是跨平台行为；macOS WKWebView 和 Linux WebKitGTK 同样不应在主线程执行会等待平台事件循环的创建操作。

Linux child webview 的 Wayland 支持仍建议单独验证。
