### PR TITLE
fix/feat: side pane close, titlebar maximize, mark as unread

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -952,7 +952,7 @@ import {
 import { Tip } from "@/components/ui/tooltip";
 import {
   WindowControls,
-  toggleMaximizeFromTitlebar
+  titlebarMaximizeHandlers
 } from "@/components/WindowControls";
 
 import { paletteActionIcon } from "@/app/paletteActionIcon";
@@ -2379,6 +2379,10 @@ export function AppWorkbench() {
   const platform = useMemo(() => detectAppPlatform(), []);
   /** Self-drawn chrome when OS title bar is disabled (Windows release config). */
   const useCustomWindowChrome = platform === "win" || platform === "other";
+  /** Titlebar / chrome-strip double-click → maximize on mac + win. */
+  const titlebarMax = titlebarMaximizeHandlers({
+    enabled: !phoneLayout && !isMirrorClient(),
+  });
   /** Right inset so resource chrome icons clear min/max/close. */
   const windowControlsInset = useCustomWindowChrome ? WINDOW_CONTROLS_INSET : 0;
   const [windowMaximized, setWindowMaximized] = useState(false);
@@ -2696,9 +2700,12 @@ export function AppWorkbench() {
     if (platform === "other") document.documentElement.classList.add("platform-other");
   }, [platform]);
 
+  // Track maximized on every desktop host (mac Overlay + Win frameless) so
+  // .is-maximized chrome + layout reclamp stay honest after titlebar dblclick.
   useEffect(() => {
-    if (!useCustomWindowChrome || !api.isTauri()) return;
-    let unlisten: (() => void) | undefined;
+    if (!api.isDesktopHost() || !api.isTauri()) return;
+    let unlistenResize: (() => void) | undefined;
+    let unlistenScale: (() => void) | undefined;
     let cancelled = false;
     void (async () => {
       try {
@@ -2712,19 +2719,30 @@ export function AppWorkbench() {
           }
         };
         await sync();
-        unlisten = await w.onResized(() => {
+        unlistenResize = await w.onResized(() => {
           void sync();
         });
-        if (cancelled) unlisten?.();
+        try {
+          unlistenScale = await w.onScaleChanged(() => {
+            void sync();
+          });
+        } catch {
+          /* older API */
+        }
+        if (cancelled) {
+          unlistenResize?.();
+          unlistenScale?.();
+        }
       } catch {
         /* ignore */
       }
     })();
     return () => {
       cancelled = true;
-      unlisten?.();
+      unlistenResize?.();
+      unlistenScale?.();
     };
-  }, [useCustomWindowChrome]);
+  }, []);
 
   // Apply always-on-top from localStorage on boot (and whenever state is set).
   useEffect(() => {
@@ -15451,7 +15469,11 @@ export function AppWorkbench() {
 
       {appGate === "loading" && (
         <div className="setup-gate" data-testid="setup-booting">
-          <div className="setup-gate__drag" data-tauri-drag-region />
+          <div
+            className="setup-gate__drag"
+            data-tauri-drag-region
+            {...titlebarMax}
+          />
           <div className="setup-gate__center">
             <div className="setup-hero">
               <div
@@ -16257,9 +16279,7 @@ export function AppWorkbench() {
           <div
             className="sidebar-chrome"
             data-tauri-drag-region
-            onDoubleClick={() => {
-              if (useCustomWindowChrome) void toggleMaximizeFromTitlebar();
-            }}
+            {...titlebarMax}
           >
             <Tip label={tr("main.leftPaneHide")}>
               <button
@@ -16277,7 +16297,11 @@ export function AppWorkbench() {
                 <IconPanel size={16} />
               </button>
             </Tip>
-            <div className="sidebar-chrome__drag" data-tauri-drag-region />
+            <div
+              className="sidebar-chrome__drag"
+              data-tauri-drag-region
+              {...titlebarMax}
+            />
           </div>
 
           {/* Row 2: brand + search (Codex: title left, search right) */}
@@ -17030,9 +17054,7 @@ export function AppWorkbench() {
               "main__top" + (phoneLayout ? " main__top--phone" : "")
             }
             data-tauri-drag-region
-            onDoubleClick={() => {
-              if (useCustomWindowChrome) void toggleMaximizeFromTitlebar();
-            }}
+            {...titlebarMax}
           >
             <div className="main__title-row" data-tauri-drag-region>
               {/* Phone: always-visible hamburger (≥44px). Desktop: reopen when rail hidden. */}

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -2468,14 +2468,31 @@ export function AppWorkbench() {
     const preferredAside = Math.max(
       cur.asideWidth || 0,
       DEFAULT_LAYOUT.asideWidth,
+      ASIDE_WIDTH_MIN,
     );
-    // Paint the pane first — do not block UI on window grow.
+    // Sync-clamp to the *current* viewport before paint. Opening at preferred
+    // width first (old path) made sidebar + main min + aside overflow narrow
+    // non-maximized windows, clipping the side chrome close control off-screen.
+    const syncWidth = clampAsideWidth(preferredAside, {
+      ...asideClampOpts(),
+      viewportWidth:
+        typeof window !== "undefined" ? window.innerWidth : undefined,
+      sidebarOccupiedWidth: cur.sidebarCollapsed
+        ? 0
+        : cur.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
+    });
+    // If the frame is too tight for any aside (syncWidth 0), still paint a
+    // small pane and let window fit / expand try to recover.
+    const paintWidth =
+      syncWidth > 0
+        ? syncWidth
+        : Math.min(preferredAside, ASIDE_WIDTH_MIN);
     setLayout((l) => {
-      if (!l.asideCollapsed && (l.asideWidth || 0) >= preferredAside) return l;
+      if (!l.asideCollapsed && (l.asideWidth || 0) === paintWidth) return l;
       const n = {
         ...l,
         asideCollapsed: false,
-        asideWidth: Math.max(l.asideWidth || 0, preferredAside),
+        asideWidth: paintWidth,
       };
       saveLayout(localStorage, n);
       return n;
@@ -2496,7 +2513,20 @@ export function AppWorkbench() {
         return n;
       });
     });
-  }, [fitWindowThenClampAside, phoneLayout]);
+  }, [asideClampOpts, fitWindowThenClampAside, phoneLayout]);
+
+  /** Collapse the right Side Workbench (and exit expand / dock composer). */
+  const closeAsidePane = useCallback(() => {
+    planOpenedAsideRef.current = false;
+    setSideWorkbench((s) => (s.expanded ? { ...s, expanded: false } : s));
+    setSideDockComposer(false);
+    setLayout((l) => {
+      if (l.asideCollapsed) return l;
+      const n = { ...l, asideCollapsed: true };
+      saveLayout(localStorage, n);
+      return n;
+    });
+  }, []);
 
   /** Route chat context opens into Side Workbench tabs (Phase 6). */
   useEffect(() => {
@@ -12548,15 +12578,7 @@ export function AppWorkbench() {
         openAsidePane();
         return;
       }
-      setLayout((l) => {
-        if (l.asideCollapsed) return l;
-        const n = { ...l, asideCollapsed: true };
-        saveLayout(localStorage, n);
-        return n;
-      });
-      setSideWorkbench((s) =>
-        s.expanded ? { ...s, expanded: false } : s,
-      );
+      closeAsidePane();
     },
     openSidePicker: (kind: SidePickerKind) => {
       setSideWorkbench((s) => {
@@ -17160,7 +17182,9 @@ export function AppWorkbench() {
                       stay as no-op cleanup. */}
                   {/* Codex Side Workbench chrome:
                       collapsed → open-with · env · side
-                      open      → open-with · env  (side/expand on side bar) */}
+                      open      → open-with · env · side (also on side bar)
+                      Main keeps a toggle when open so narrow/non-maximized
+                      windows can still close if side chrome is clipped. */}
                   {mainPane === "chat" &&
                     activeProject &&
                     !isMirrorClient() && (
@@ -17240,6 +17264,9 @@ export function AppWorkbench() {
                       }}
                     />
                   ) : null}
+                  {/* Always keep a main-chrome toggle: when the window is not
+                      maximized, the side pane can clip its own close control
+                      past the right edge — main column stays reachable. */}
                   {layout.asideCollapsed ? (
                     <Tip label={tr("main.rightPaneShow")}>
                       <button
@@ -17253,7 +17280,20 @@ export function AppWorkbench() {
                         <IconPanelRight size={16} />
                       </button>
                     </Tip>
-                  ) : null}
+                  ) : (
+                    <Tip label={tr("main.rightPaneHide")}>
+                      <button
+                        type="button"
+                        className="chrome-btn main__pane-toggle is-on"
+                        aria-label={tr("main.rightPaneHide")}
+                        aria-pressed
+                        data-testid="main-side-toggle"
+                        onClick={() => closeAsidePane()}
+                      >
+                        <IconPanelRight size={16} />
+                      </button>
+                    </Tip>
+                  )}
                 </>
               )}
             </div>
@@ -18965,18 +19005,7 @@ export function AppWorkbench() {
                 onDismissPlan={() => void dismissPlan()}
                 openRequest={resourceOpenTarget}
                 onOpenRequestConsumed={() => setResourceOpenTarget(null)}
-                onCloseSide={() => {
-                  planOpenedAsideRef.current = false;
-                  setSideWorkbench((s) =>
-                    s.expanded ? { ...s, expanded: false } : s,
-                  );
-                  setSideDockComposer(false);
-                  setLayout((l) => {
-                    const n = { ...l, asideCollapsed: true };
-                    saveLayout(localStorage, n);
-                    return n;
-                  });
-                }}
+                onCloseSide={closeAsidePane}
                 onExpandedChange={(expanded) => {
                   if (phoneLayout) return;
                   if (!expanded) setSideDockComposer(false);

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -484,6 +484,7 @@ import {
   clearAllUnread as clearAllSessionUnread,
   clearUnread as clearSessionUnread,
   loadUnreadSessionIds,
+  markUnread as markSessionUnread,
   SESSION_UNREAD_CHANGE_EVENT,
   shouldConfirmClearAllUnread,
 } from "@/lib/sessionUnread";
@@ -799,6 +800,7 @@ import {
   IconDeviceMobile,
   IconShield,
   IconCheck,
+  IconCircle,
   IconList,
   IconListNumbers,
   IconRobot,
@@ -1072,6 +1074,28 @@ export function AppWorkbench() {
         next.delete(id);
         return next;
       });
+    },
+    [],
+  );
+  /**
+   * Manual "mark as unread" while the chat is still open: hold the badge until
+   * the user leaves and re-opens the thread (auto clear-on-view still applies).
+   */
+  const manualUnreadHoldIdsRef = useRef<Set<string>>(new Set());
+  const applyMarkSessionUnread = useCallback(
+    (sessionId: string | null | undefined) => {
+      const id = typeof sessionId === "string" ? sessionId.trim() : "";
+      if (!id) return;
+      markSessionUnread(id);
+      setUnreadSessionIds((prev) => {
+        if (prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.add(id);
+        return next;
+      });
+      if (viewingSessionIdRef.current === id) {
+        manualUnreadHoldIdsRef.current.add(id);
+      }
     },
     [],
   );
@@ -6400,6 +6424,7 @@ export function AppWorkbench() {
 
   const applyClearAllSessionUnread = useCallback(() => {
     clearAllSessionUnread();
+    manualUnreadHoldIdsRef.current.clear();
     setUnreadSessionIds(loadUnreadSessionIds());
   }, []);
 
@@ -6450,15 +6475,26 @@ export function AppWorkbench() {
 
   const handleClearSessionUnread = useCallback(
     (sessionId: string) => {
+      // Explicit "mark as read" also drops any manual hold.
+      manualUnreadHoldIdsRef.current.delete(sessionId);
       applyClearSessionUnread(sessionId);
     },
     [applyClearSessionUnread],
   );
 
+  const handleMarkSessionUnread = useCallback(
+    (sessionId: string) => {
+      applyMarkSessionUnread(sessionId);
+    },
+    [applyMarkSessionUnread],
+  );
+
   // Any path that binds the workbench to a session clears its unread marker
   // (sidebar + dock/tray badge). Covers openSession, deep links, tray Recent.
+  // Also ends a manual "mark as unread" hold when the user re-opens the chat.
   useEffect(() => {
     if (session.sessionId) {
+      manualUnreadHoldIdsRef.current.delete(session.sessionId);
       applyClearSessionUnread(session.sessionId);
     }
   }, [session.sessionId, applyClearSessionUnread]);
@@ -6468,7 +6504,10 @@ export function AppWorkbench() {
   useEffect(() => {
     const clearViewingIfPresent = () => {
       const id = viewingSessionIdRef.current;
-      if (id) applyClearSessionUnread(id);
+      if (!id) return;
+      // Keep manual "mark as unread" until the user leaves this thread.
+      if (manualUnreadHoldIdsRef.current.has(id)) return;
+      applyClearSessionUnread(id);
     };
     const onVis = () => {
       if (
@@ -23010,16 +23049,21 @@ export function AppWorkbench() {
                 ),
                 onClick: () => handleToggleSessionMute(s.id),
               },
-              ...(sessionUnread
-                ? [
-                    {
-                      id: "clear-unread",
-                      label: tr("session.clearUnread"),
-                      icon: <IconCheck size={16} />,
-                      onClick: () => handleClearSessionUnread(s.id),
-                    } satisfies ContextMenuItem,
-                  ]
-                : []),
+              {
+                id: sessionUnread ? "clear-unread" : "mark-unread",
+                label: sessionUnread
+                  ? tr("session.clearUnread")
+                  : tr("session.markUnread"),
+                icon: sessionUnread ? (
+                  <IconCheck size={16} />
+                ) : (
+                  <IconCircle size={16} />
+                ),
+                onClick: () => {
+                  if (sessionUnread) handleClearSessionUnread(s.id);
+                  else handleMarkSessionUnread(s.id);
+                },
+              },
               ...(unreadSessionIds.size > 0
                 ? [
                     {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -80,6 +80,7 @@ import {
   type SidebarDensity,
 } from "@/lib/sidebarDensity";
 import type { WallpaperSourceTab } from "@/components/WallpaperSourceModal";
+import { titlebarMaximizeHandlers } from "@/components/WindowControls";
 import {
   loadComposerSendKeyPref,
   type ComposerSendKeyPref,
@@ -1592,11 +1593,7 @@ export function SettingsPage({
         className="settings-page__chrome"
         data-tauri-drag-region
         aria-hidden
-        onDoubleClick={() => {
-          void import("@tauri-apps/api/window")
-            .then(({ getCurrentWindow }) => getCurrentWindow().toggleMaximize())
-            .catch(() => {});
-        }}
+        {...titlebarMaximizeHandlers()}
       />
       <aside
         className="settings-page__nav"

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { GrokLogo } from "@/components/GrokLogo";
 import { Select } from "@/components/Select";
 import { Spinner } from "@/components/ui/spinner";
+import { titlebarMaximizeHandlers } from "@/components/WindowControls";
 import * as api from "@/lib/api";
 import type { createT } from "@/i18n";
 import type { MessageKey } from "@/i18n";
@@ -469,7 +470,11 @@ export function SetupWizard({
       data-platform={platform}
       data-testid="setup-wizard"
     >
-      <div className="setup-gate__drag" data-tauri-drag-region />
+      <div
+        className="setup-gate__drag"
+        data-tauri-drag-region
+        {...titlebarMaximizeHandlers()}
+      />
 
       <div className="setup-gate__center">
         <div className="setup-hero">

--- a/src/components/WindowControls.tsx
+++ b/src/components/WindowControls.tsx
@@ -113,12 +113,68 @@ export function WindowControls({ visible, labels }: Props) {
   );
 }
 
-/** Double-click titlebar strip → maximize/restore (Win habit). */
+/**
+ * Double-click titlebar / chrome drag strip → maximize/restore.
+ * Used on every desktop host (mac Overlay drag regions do not always get
+ * native zoom; Win frameless has no system caption). Prefer true maximize
+ * over macOS "zoom" so the workbench can use the full work area.
+ *
+ * Debounced: drag regions may emit both mousedown(detail=2) and dblclick;
+ * without a guard that would toggleMaximize twice (no-op).
+ */
+let lastTitlebarMaximizeMs = 0;
+
 export async function toggleMaximizeFromTitlebar(): Promise<void> {
+  const now = Date.now();
+  if (now - lastTitlebarMaximizeMs < 400) return;
+  lastTitlebarMaximizeMs = now;
   try {
     const { getCurrentWindow } = await import("@tauri-apps/api/window");
     await getCurrentWindow().toggleMaximize();
   } catch {
-    /* ignore */
+    /* browser / no window API */
   }
+}
+
+/** True when the event target is chrome that should not start window chrome actions. */
+export function isTitlebarInteractiveTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el?.closest) return false;
+  return !!el.closest(
+    "button, a, input, textarea, select, [role='button'], [role='tab'], [role='menuitem'], [role='option'], [contenteditable='true']",
+  );
+}
+
+/**
+ * Props for titlebar / drag strips: maximize on double-click even when
+ * `-webkit-app-region: drag` swallows the synthetic dblclick (mac Overlay).
+ * Pair with `data-tauri-drag-region` for native drag.
+ */
+export function titlebarMaximizeHandlers(opts?: {
+  enabled?: boolean;
+}): {
+  onDoubleClick: (e: { target: EventTarget | null; button?: number }) => void;
+  onMouseDown: (e: {
+    target: EventTarget | null;
+    button: number;
+    detail: number;
+    preventDefault: () => void;
+  }) => void;
+} {
+  const enabled = opts?.enabled !== false;
+  return {
+    onDoubleClick: (e) => {
+      if (!enabled) return;
+      if (isTitlebarInteractiveTarget(e.target)) return;
+      void toggleMaximizeFromTitlebar();
+    },
+    onMouseDown: (e) => {
+      if (!enabled) return;
+      if (e.button !== 0 || e.detail < 2) return;
+      if (isTitlebarInteractiveTarget(e.target)) return;
+      // Second click of a double-click pair.
+      e.preventDefault();
+      void toggleMaximizeFromTitlebar();
+    },
+  };
 }

--- a/src/components/side-workbench/SideTabBar.tsx
+++ b/src/components/side-workbench/SideTabBar.tsx
@@ -40,6 +40,7 @@ import {
   type SidePickerKind,
 } from "@/lib/sideWorkbench";
 import { SidePicker } from "./SidePicker";
+import { titlebarMaximizeHandlers } from "@/components/WindowControls";
 
 export type SideTabBarProps = {
   locale: Locale | string;
@@ -105,6 +106,7 @@ export function SideTabBar({
   onToggleSide,
 }: SideTabBarProps) {
   const tr = useMemo(() => createT(locale as Locale), [locale]);
+  const titlebarMax = titlebarMaximizeHandlers();
   const [plusOpen, setPlusOpen] = useState(false);
   const plusRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -259,7 +261,11 @@ export function SideTabBar({
   ]);
 
   return (
-    <div className="rp-chrome sw-chrome" data-testid="side-tab-bar">
+    <div
+      className="rp-chrome sw-chrome"
+      data-testid="side-tab-bar"
+      {...titlebarMax}
+    >
       {/* Cluster: tabs + + stick together on the left; expand/side stay flush right */}
       <div
         className={
@@ -347,7 +353,12 @@ export function SideTabBar({
       </div>
 
       {/* Empty strip between tabs/+ and right actions — window drag (titlebar). */}
-      <div className="sw-chrome__drag" data-tauri-drag-region aria-hidden />
+      <div
+        className="sw-chrome__drag"
+        data-tauri-drag-region
+        aria-hidden
+        {...titlebarMax}
+      />
 
       <div className="rp-chrome__actions">
         {/* Dock input: only when side is expanded (icon toggle, default off). */}

--- a/src/i18n/messages/en/session.ts
+++ b/src/i18n/messages/en/session.ts
@@ -9,6 +9,7 @@ export const enSession = {
   "session.unreadAria": "Unread — reply finished in background",
   "session.planPendingAria": "Plan awaiting your review",
   "session.clearUnread": "Mark as read",
+  "session.markUnread": "Mark as unread",
   "session.clearAllUnread": "Clear all unread",
   "session.clearAllUnreadTitle": "Clear all unread?",
   "session.clearAllUnreadBody": "Remove the unread marker from {n} chats. Mute settings are not changed.",

--- a/src/i18n/messages/zh-TW/session.ts
+++ b/src/i18n/messages/zh-TW/session.ts
@@ -9,6 +9,7 @@ export const zhTWSession = {
   "session.unreadAria": "未讀 — 背景回合已完成",
   "session.planPendingAria": "計劃待你審閱",
   "session.clearUnread": "標為已讀",
+  "session.markUnread": "標為未讀",
   "session.clearAllUnread": "清除全部未讀",
   "session.clearAllUnreadTitle": "清除全部未讀？",
   "session.clearAllUnreadBody": "將從 {n} 個對話移除未讀標記。不會變更靜音設定。",

--- a/src/i18n/messages/zh/session.ts
+++ b/src/i18n/messages/zh/session.ts
@@ -9,6 +9,7 @@ export const zhSession = {
   "session.unreadAria": "未读 — 后台回合已完成",
   "session.planPendingAria": "计划待你审阅",
   "session.clearUnread": "标为已读",
+  "session.markUnread": "标为未读",
   "session.clearAllUnread": "清除全部未读",
   "session.clearAllUnreadTitle": "清除全部未读？",
   "session.clearAllUnreadBody": "将从 {n} 个会话移除未读标记。不会更改静音设置。",

--- a/src/lib/layout.test.ts
+++ b/src/lib/layout.test.ts
@@ -275,4 +275,18 @@ describe("layout prefs", () => {
       false,
     );
   });
+
+  it("squeezed non-maximized frame prefers chat floor over chrome min", () => {
+    // sidebar 268 + chat 360 + preferred 400 = 1028 > 1000 viewport
+    // → aside max = 1000 - 268 - 360 = 372 (< chrome min 400)
+    const w = clampAsideWidth(400, {
+      viewportWidth: 1000,
+      sidebarOccupiedWidth: 268,
+    });
+    expect(w).toBe(1000 - 268 - MAIN_CHAT_MIN_WIDTH);
+    expect(w).toBeLessThan(ASIDE_WIDTH_MIN);
+    // Close control must still be reachable via main toggle when this happens;
+    // clamp itself only guarantees chat floor, not chrome min.
+    expect(w).toBeGreaterThan(0);
+  });
 });

--- a/src/lib/windowFit.ts
+++ b/src/lib/windowFit.ts
@@ -134,6 +134,48 @@ async function growWindowTo(
     // Suppress cascade before setSize so the resize event is ignored.
     markSuppressed();
     await win.setSize(new LogicalSize(capped, curH));
+
+    // Growing width alone can push the right edge off-monitor when the
+    // window sits near the right of the work area (common for non-maximized
+    // frames). Nudge left so the side-pane chrome (close control) stays on
+    // screen.
+    try {
+      const mon = await currentMonitor();
+      if (mon?.workArea && mon.scaleFactor > 0) {
+        const { LogicalPosition } = await import("@tauri-apps/api/dpi");
+        const outer = await win.outerPosition();
+        const outerSize = await win.outerSize();
+        const sf = mon.scaleFactor;
+        const work = mon.workArea;
+        const workX = work.position.x / sf;
+        const workY = work.position.y / sf;
+        const workW = work.size.width / sf;
+        const workH = work.size.height / sf;
+        const winX = outer.x / sf;
+        const winY = outer.y / sf;
+        const winW = outerSize.width / sf;
+        const winH = outerSize.height / sf;
+        let nextX = winX;
+        let nextY = winY;
+        if (winX + winW > workX + workW) {
+          nextX = workX + workW - winW;
+        }
+        if (nextX < workX) nextX = workX;
+        if (winY + winH > workY + workH) {
+          nextY = workY + workH - winH;
+        }
+        if (nextY < workY) nextY = workY;
+        if (
+          Math.abs(nextX - winX) > 0.5 ||
+          Math.abs(nextY - winY) > 0.5
+        ) {
+          await win.setPosition(new LogicalPosition(nextX, nextY));
+        }
+      }
+    } catch {
+      /* position clamp is best-effort */
+    }
+
     markSuppressed();
     return capped;
   } catch (e) {

--- a/src/styles/side-workbench.css
+++ b/src/styles/side-workbench.css
@@ -187,7 +187,9 @@ html[data-wallpaper="1"].platform-mac[data-theme="light"]
   position: relative;
   flex: 0 1 auto;
   min-width: 0;
-  max-width: 100%;
+  /* Leave room for expand + side-toggle (~72px) so close stays on-screen when
+   * the pane is squeezed on a non-maximized window. */
+  max-width: calc(100% - 72px);
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -1483,3 +1485,35 @@ html[data-theme="light"] .sw-terminal--pty {
   color: var(--text-tertiary);
 }
 
+
+
+/* aside-close-clip-fix
+ * When the right pane is narrower than ideal (non-maximized / tight frame),
+ * keep expand + side-toggle on screen: never let the tab cluster push them
+ * past the chrome edge. Empty picker also shrinks cleanly.
+ */
+.sw-chrome.rp-chrome {
+  min-width: 0;
+  overflow: hidden;
+}
+
+
+.sw-picker--empty {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.sw-picker--empty .sw-picker__item {
+  min-width: 0;
+}
+
+.sw-picker--empty .sw-picker__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 1100px) {
+  .sw-picker--empty .sw-picker__shortcut {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

Three desktop UX items from feedback:

### 1. Right side pane opens but cannot close (non-maximized)
- Sync-clamp aside width before first paint; keep main top toggle while open
- Re-clamp window position after grow; protect side chrome under narrow width

### 2. Double-click top chrome does not fill work area (mac)
- Enable titlebar maximize on all desktop hosts (was Win-only)
- `mousedown(detail=2)` fallback when drag regions swallow `dblclick`
- Track `is-maximized` on mac; wire sidebar / main / side tab / settings / setup

### 3. No **Mark as unread** on session menu
- Toggle: already unread → **Mark as read**; else → **Mark as unread**
- Uses existing `markUnread()` storage; sidebar dots + dock badge update immediately
- Manual mark on the **currently open** chat holds until leave + re-open (so focus/visibility auto-clear does not wipe it instantly)
- **Clear all unread** still available when any unread exists

## Test plan

- [ ] Windowed: open right pane → close via main top + side chrome + shortcut
- [ ] mac: double-click left sidebar top / main top empty → maximize / restore
- [ ] Right-click a **read** session → **标为未读** / Mark as unread → blue unread dot
- [ ] Right-click that session → **标为已读** / Mark as read → dot clears
- [ ] Mark **current** chat unread → switch away → switch back → unread clears on re-open
- [ ] Clear all unread still works
- [ ] `pnpm exec vitest run src/lib/sessionUnread.test.ts src/i18n/messages.test.ts`