### PR TITLE
fix(composer): persist per-session input drafts across thread switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- **Per-session composer drafts**: Switching threads no longer drops a half-typed follow-up. Each real session keeps text / attachments / goal mode in `localStorage` (`grok.composerSessionDrafts`); restore on open, debounced persist while typing, clear on send or explicit clear. New-chat still uses the existing per-project buffer.
+
+**中文 · 修复**
+- **按线程保留输入框草稿**：切换会话不再丢掉半截 follow-up。真实线程的文字/附件/Goal 模式写入 `localStorage`（`grok.composerSessionDrafts`），打开时恢复、输入防抖持久化、发送或清空时清除；新对话页仍用原有按项目草稿。
+
 ## [0.2.10] - 2026-08-07
 
 > **Highlight:** Align the desktop workbench with **Grok Build CLI 1.0** — default effort/workflows match the CLI, CLI version & agent-binary skew are visible and repairable, Ops (tasks/dashboard/board) is reachable from the command palette, workflow runs stream live logs, and `/goal` shows an honest session chip.

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -616,6 +616,11 @@ import {
   type ComposerProjectDraft
 } from "@/lib/composerProjectDraft";
 import {
+  clearComposerSessionDraft,
+  loadComposerSessionDraft,
+  saveComposerSessionDraft,
+} from "@/lib/composerSessionDraft";
+import {
   PromptHistoryPanel,
   type PromptHistoryScope
 } from "@/components/PromptHistoryPanel";
@@ -3983,8 +3988,16 @@ export function AppWorkbench() {
     if (phoneLayout) closePhoneDrawer();
 
     // Leaving a new-chat page: stash composer under the project so newChat can restore.
-    if (viewingSessionIdRef.current == null) {
+    // Leaving a real thread: stash per-session so switching back restores the follow-up.
+    const leavingBeforeOpen = viewingSessionIdRef.current;
+    if (leavingBeforeOpen == null) {
       saveComposerProjectDraft(projectDraftKey(activeProject?.id ?? null), {
+        text: getDraft(),
+        attachments,
+        goalMode,
+      });
+    } else {
+      saveComposerSessionDraft(leavingBeforeOpen, {
         text: getDraft(),
         attachments,
         goalMode,
@@ -3994,7 +4007,7 @@ export function AppWorkbench() {
     // User navigation: invalidate any in-flight work that wants the workbench.
     bumpViewEpoch();
     // Snapshot the outgoing thread so a mid-turn switch does not lose the user bubble.
-    const leavingId = viewingSessionIdRef.current;
+    const leavingId = leavingBeforeOpen;
     if (leavingId) {
       messagesBySessionRef.current.set(
         leavingId,
@@ -4010,6 +4023,26 @@ export function AppWorkbench() {
     // Point viewing id immediately so late stream chunks land in the right cache.
     openingSessionIdRef.current = s.id;
     viewingSessionIdRef.current = s.id;
+    // Restore this thread's follow-up draft immediately (sync localStorage) so
+    // the composer matches the session before journal load, and mid-load typing
+    // is attributed to the right thread on the next switch.
+    {
+      const saved = loadComposerSessionDraft(s.id);
+      suppressProjectDraftPersistRef.current = true;
+      if (saved) {
+        setDraft(saved.text || "");
+        setAttachments(saved.attachments ?? []);
+        if (typeof saved.goalMode === "boolean") {
+          setGoalMode(saved.goalMode);
+        }
+      } else {
+        setDraft("");
+        setAttachments([]);
+      }
+      requestAnimationFrame(() => {
+        suppressProjectDraftPersistRef.current = false;
+      });
+    }
     // P0 (#529): immediately paint this session's cache (or empty) so stream /
     // rehydrate / clear-streaming never reduce against the previous chat while
     // viewing id has already moved. Disk load below may replace with prefer().
@@ -4237,14 +4270,7 @@ export function AppWorkbench() {
     }
     // Orphan sessions clear project context; project sessions select their folder.
     setActiveProject(proj);
-    // Existing session: clear composer UI (project buffer already saved above).
-    // Follow-ups start empty; new-chat buffers stay in per-project storage.
-    suppressProjectDraftPersistRef.current = true;
-    setDraft("");
-    setAttachments([]);
-    requestAnimationFrame(() => {
-      suppressProjectDraftPersistRef.current = false;
-    });
+    // Composer follow-up draft was restored at switch time (per-session buffer).
     // Reattach live host snapshot when reopening the session that is still running.
     const live = liveHostRef.current;
     if (live.sessionId === s.id) {
@@ -4455,6 +4481,38 @@ export function AppWorkbench() {
     };
   }, [attachments, goalMode, activeProject?.id, session.sessionId]);
 
+  /**
+   * While viewing a real thread, keep the per-session follow-up buffer in sync
+   * so crash / hard switch mid-type still restores when reopening that thread.
+   */
+  useEffect(() => {
+    let t: number | undefined;
+    const sessionKey = () =>
+      viewingSessionIdRef.current ?? session.sessionId ?? null;
+    const persist = () => {
+      if (suppressProjectDraftPersistRef.current) return;
+      const id = sessionKey();
+      if (!id) return;
+      saveComposerSessionDraft(id, {
+        text: getComposerDraft(),
+        attachments,
+        goalMode,
+      });
+    };
+    const schedule = () => {
+      if (suppressProjectDraftPersistRef.current) return;
+      if (!sessionKey()) return;
+      window.clearTimeout(t);
+      t = window.setTimeout(persist, 280);
+    };
+    schedule();
+    const unsub = composerDraftStore.subscribe(schedule);
+    return () => {
+      window.clearTimeout(t);
+      unsub();
+    };
+  }, [attachments, goalMode, session.sessionId]);
+
   useEffect(() => {
     if (appGate !== "ready") return;
     if (didRestoreLastRef.current) return;
@@ -4605,8 +4663,9 @@ export function AppWorkbench() {
    * Pass `null` for a project-less session (listed under “其他会话”).
    * Omit / pass undefined to use the active project (requires one).
    *
-   * Composer text/attachments are restored from per-project memory so a
-   * half-typed task survives switching to another chat and back.
+   * Composer text/attachments: leaving a real thread stashes per-session
+   * follow-ups; the new-chat page restores the per-project buffer so a
+   * half-typed new task survives switching away and back.
    */
   const newChat = async (
     project?: Project | null,
@@ -4629,11 +4688,18 @@ export function AppWorkbench() {
       return;
     }
 
-    // Snapshot outgoing new-chat buffer under the *previous* project before switch.
+    // Snapshot outgoing composer: new-chat → per-project; real thread → per-session.
     const prevKey = projectDraftKey(activeProject?.id ?? null);
     const wasDraftPage = viewingSessionIdRef.current == null;
+    const leavingId = viewingSessionIdRef.current;
     if (wasDraftPage) {
       saveComposerProjectDraft(prevKey, {
+        text: getDraft(),
+        attachments,
+        goalMode,
+      });
+    } else if (leavingId) {
+      saveComposerSessionDraft(leavingId, {
         text: getDraft(),
         attachments,
         goalMode,
@@ -4658,7 +4724,6 @@ export function AppWorkbench() {
     // Preserve outgoing thread in cache before clearing the draft UI.
     // Always snapshot current messages (not only if already cached) so a mid-send
     // switch does not drop the optimistic user/assistant bubbles.
-    const leavingId = viewingSessionIdRef.current;
     if (leavingId) {
       messagesBySessionRef.current.set(
         leavingId,
@@ -7292,6 +7357,9 @@ export function AppWorkbench() {
   const clearComposerAfterSubmit = (opts?: {
     /** Drop the per-project new-chat buffer (only when leaving a draft send). */
     clearProjectDraft?: boolean;
+    /** Drop the per-session follow-up buffer (send / clear on a real thread). */
+    clearSessionDraft?: boolean;
+    sessionDraftId?: string | null;
   }) => {
     setDraft("");
     promptHistoryIndexRef.current = null;
@@ -7306,6 +7374,14 @@ export function AppWorkbench() {
     if (opts?.clearProjectDraft) {
       clearComposerProjectDraft(projectDraftKey(activeProject?.id ?? null));
     }
+    if (opts?.clearSessionDraft) {
+      const sid =
+        opts.sessionDraftId ??
+        viewingSessionIdRef.current ??
+        session.sessionId ??
+        null;
+      if (sid) clearComposerSessionDraft(sid);
+    }
     requestAnimationFrame(() => {
       const el = document.querySelector<HTMLElement>(".composer__input");
       if (el) el.style.height = "auto";
@@ -7314,12 +7390,15 @@ export function AppWorkbench() {
 
   /**
    * Wipe the main composer (text + attachments). Also leaves inline edit mode
-   * and drops the per-project new-chat buffer when on a draft page.
+   * and drops the per-project new-chat buffer when on a draft page, or the
+   * per-session follow-up buffer when on a real thread.
    */
   const applyClearComposerDraft = useCallback(() => {
+    const onDraftPage =
+      session.sessionId == null && viewingSessionIdRef.current == null;
     clearComposerAfterSubmit({
-      clearProjectDraft:
-        session.sessionId == null && viewingSessionIdRef.current == null,
+      clearProjectDraft: onDraftPage,
+      clearSessionDraft: !onDraftPage,
     });
     if (!editSubmitting) {
       setEditingUserMessageId(null);
@@ -7367,8 +7446,13 @@ export function AppWorkbench() {
     sendQueue.releaseFlushHold();
 
     // New-chat page → after send, forget the project buffer so restore is empty.
-    // Existing-session follow-ups must not wipe a half-typed new-task draft.
+    // Existing-session follow-ups clear the per-session buffer only (not project).
     const fromNewChatPage = session.sessionId == null;
+    const clearDraftOpts = {
+      clearProjectDraft: fromNewChatPage,
+      clearSessionDraft: !fromNewChatPage,
+      sessionDraftId: viewingSessionIdRef.current ?? session.sessionId,
+    };
 
     // Enqueue only when *this viewed chat* FSM is busy (streaming/connecting).
     // Host mid-turn on another session → executeSend demotes + spawns concurrent
@@ -7382,11 +7466,11 @@ export function AppWorkbench() {
         attachments: att,
         goalMode,
       });
-      clearComposerAfterSubmit({ clearProjectDraft: fromNewChatPage });
+      clearComposerAfterSubmit(clearDraftOpts);
       return;
     }
 
-    clearComposerAfterSubmit({ clearProjectDraft: fromNewChatPage });
+    clearComposerAfterSubmit(clearDraftOpts);
     await executeSend({
       storedDisplay,
       att,

--- a/src/lib/composerSessionDraft.test.ts
+++ b/src/lib/composerSessionDraft.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearComposerSessionDraft,
+  COMPOSER_SESSION_DRAFTS_STORAGE_KEY,
+  emptyComposerSessionDraft,
+  isComposerSessionDraftEmpty,
+  loadAllComposerSessionDrafts,
+  loadComposerSessionDraft,
+  saveComposerSessionDraft,
+  sessionDraftKey,
+  type ComposerSessionDraftStorage,
+} from "./composerSessionDraft";
+
+function memoryStorage(
+  seed: Record<string, string> = {},
+): ComposerSessionDraftStorage {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+    removeItem: (k) => {
+      map.delete(k);
+    },
+  };
+}
+
+describe("sessionDraftKey", () => {
+  it("rejects empty / null", () => {
+    expect(sessionDraftKey(null)).toBeNull();
+    expect(sessionDraftKey(undefined)).toBeNull();
+    expect(sessionDraftKey("")).toBeNull();
+    expect(sessionDraftKey("  ")).toBeNull();
+  });
+
+  it("trims session ids", () => {
+    expect(sessionDraftKey(" abc ")).toBe("abc");
+  });
+});
+
+describe("isComposerSessionDraftEmpty", () => {
+  it("treats whitespace-only as empty", () => {
+    expect(isComposerSessionDraftEmpty(null)).toBe(true);
+    expect(
+      isComposerSessionDraftEmpty({
+        text: "  \n  ",
+        attachments: [],
+        updatedAt: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps skill-only or attachment drafts", () => {
+    expect(
+      isComposerSessionDraftEmpty({
+        text: "[[skill:foo]]",
+        attachments: [],
+        updatedAt: 1,
+      }),
+    ).toBe(false);
+    expect(
+      isComposerSessionDraftEmpty({
+        text: "",
+        attachments: [{ path: "/a.png", name: "a.png", isDir: false }],
+        updatedAt: 1,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("save / load / clear", () => {
+  it("round-trips per session", () => {
+    const s = memoryStorage();
+    saveComposerSessionDraft(
+      "sess-1",
+      { text: "hello thread", attachments: [], goalMode: true },
+      s,
+    );
+    saveComposerSessionDraft(
+      "sess-2",
+      {
+        text: "other thread",
+        attachments: [{ path: "/x.md", name: "x.md", isDir: false }],
+      },
+      s,
+    );
+
+    expect(loadComposerSessionDraft("sess-1", s)?.text).toBe("hello thread");
+    expect(loadComposerSessionDraft("sess-1", s)?.goalMode).toBe(true);
+    expect(loadComposerSessionDraft("sess-2", s)?.text).toBe("other thread");
+    expect(loadComposerSessionDraft("sess-2", s)?.attachments).toHaveLength(1);
+    expect(loadComposerSessionDraft("missing", s)).toBeNull();
+    expect(loadComposerSessionDraft(null, s)).toBeNull();
+  });
+
+  it("clears empty saves and clearComposerSessionDraft", () => {
+    const s = memoryStorage();
+    saveComposerSessionDraft("s1", { text: "keep" }, s);
+    saveComposerSessionDraft("s1", { text: "   " }, s);
+    expect(loadComposerSessionDraft("s1", s)).toBeNull();
+
+    saveComposerSessionDraft("s2", { text: "x" }, s);
+    clearComposerSessionDraft("s2", s);
+    expect(loadComposerSessionDraft("s2", s)).toBeNull();
+  });
+
+  it("ignores corrupt storage", () => {
+    const s = memoryStorage({
+      [COMPOSER_SESSION_DRAFTS_STORAGE_KEY]: "{not-json",
+    });
+    expect(loadAllComposerSessionDrafts(s)).toEqual({});
+  });
+
+  it("emptyComposerSessionDraft is empty", () => {
+    expect(isComposerSessionDraftEmpty(emptyComposerSessionDraft())).toBe(
+      true,
+    );
+  });
+
+  it("does not write when session id is empty", () => {
+    const s = memoryStorage();
+    saveComposerSessionDraft(null, { text: "nope" }, s);
+    saveComposerSessionDraft("  ", { text: "nope" }, s);
+    expect(loadAllComposerSessionDrafts(s)).toEqual({});
+  });
+});

--- a/src/lib/composerSessionDraft.ts
+++ b/src/lib/composerSessionDraft.ts
@@ -1,0 +1,168 @@
+/**
+ * Per-session composer draft memory (localStorage).
+ *
+ * One buffer per real session so a half-typed follow-up survives switching
+ * threads and coming back. Complements `composerProjectDraft` (new-chat page
+ * only). Cleared after a successful send or explicit composer clear.
+ */
+
+import type { Attachment } from "@/lib/attachments";
+import { isDraftEmpty, parseStoredContent } from "@/lib/draftDoc";
+
+export const COMPOSER_SESSION_DRAFTS_STORAGE_KEY = "grok.composerSessionDrafts";
+
+export type ComposerSessionDraft = {
+  text: string;
+  attachments: Attachment[];
+  goalMode?: boolean;
+  updatedAt: number;
+};
+
+/** Minimal storage surface for unit tests without jsdom. */
+export interface ComposerSessionDraftStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+function defaultStorage(): ComposerSessionDraftStorage {
+  if (typeof localStorage !== "undefined") return localStorage;
+  return {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+}
+
+export function sessionDraftKey(
+  sessionId: string | null | undefined,
+): string | null {
+  const id = (sessionId ?? "").trim();
+  return id || null;
+}
+
+export function emptyComposerSessionDraft(): ComposerSessionDraft {
+  return { text: "", attachments: [], goalMode: false, updatedAt: 0 };
+}
+
+export function isComposerSessionDraftEmpty(
+  draft: ComposerSessionDraft | null | undefined,
+): boolean {
+  if (!draft) return true;
+  if (draft.attachments?.length) return false;
+  return isDraftEmpty(parseStoredContent(draft.text || ""));
+}
+
+function normalizeAttachment(raw: unknown): Attachment | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const path = typeof o.path === "string" ? o.path.trim() : "";
+  if (!path) return null;
+  const name =
+    typeof o.name === "string" && o.name.trim()
+      ? o.name.trim()
+      : path.split(/[/\\]/).pop() || path;
+  return { path, name, isDir: !!o.isDir };
+}
+
+function normalizeDraft(raw: unknown): ComposerSessionDraft | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const text = typeof o.text === "string" ? o.text : "";
+  const attsRaw = Array.isArray(o.attachments) ? o.attachments : [];
+  const attachments = attsRaw
+    .map(normalizeAttachment)
+    .filter((a): a is Attachment => !!a);
+  const updatedAt =
+    typeof o.updatedAt === "number" && Number.isFinite(o.updatedAt)
+      ? o.updatedAt
+      : 0;
+  const goalMode = o.goalMode === true;
+  return { text, attachments, goalMode, updatedAt };
+}
+
+/** Load full map (invalid JSON → {}). */
+export function loadAllComposerSessionDrafts(
+  storage: ComposerSessionDraftStorage = defaultStorage(),
+): Record<string, ComposerSessionDraft> {
+  try {
+    const raw = storage.getItem(COMPOSER_SESSION_DRAFTS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const out: Record<string, ComposerSessionDraft> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      const key = (k || "").trim();
+      if (!key) continue;
+      const d = normalizeDraft(v);
+      if (d && !isComposerSessionDraftEmpty(d)) out[key] = d;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export function loadComposerSessionDraft(
+  sessionId: string | null | undefined,
+  storage: ComposerSessionDraftStorage = defaultStorage(),
+): ComposerSessionDraft | null {
+  const k = sessionDraftKey(sessionId);
+  if (!k) return null;
+  const map = loadAllComposerSessionDrafts(storage);
+  const direct = map[k] ?? null;
+  return direct && !isComposerSessionDraftEmpty(direct) ? direct : null;
+}
+
+export function saveComposerSessionDraft(
+  sessionId: string | null | undefined,
+  draft: {
+    text: string;
+    attachments?: Attachment[];
+    goalMode?: boolean;
+  },
+  storage: ComposerSessionDraftStorage = defaultStorage(),
+): void {
+  const k = sessionDraftKey(sessionId);
+  if (!k) return;
+  const next: ComposerSessionDraft = {
+    text: draft.text ?? "",
+    attachments: (draft.attachments ?? [])
+      .map((a) => normalizeAttachment(a))
+      .filter((a): a is Attachment => !!a),
+    goalMode: !!draft.goalMode,
+    updatedAt: Date.now(),
+  };
+
+  try {
+    const map = loadAllComposerSessionDrafts(storage);
+    if (isComposerSessionDraftEmpty(next)) {
+      delete map[k];
+    } else {
+      map[k] = next;
+    }
+    // Cap entries so a long-lived profile cannot grow forever.
+    const keys = Object.keys(map);
+    const MAX = 120;
+    if (keys.length > MAX) {
+      const sorted = keys
+        .map((id) => ({ id, t: map[id]?.updatedAt ?? 0 }))
+        .sort((a, b) => a.t - b.t);
+      for (let i = 0; i < sorted.length - MAX; i++) {
+        delete map[sorted[i]!.id];
+      }
+    }
+    storage.setItem(COMPOSER_SESSION_DRAFTS_STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+export function clearComposerSessionDraft(
+  sessionId: string | null | undefined,
+  storage: ComposerSessionDraftStorage = defaultStorage(),
+): void {
+  saveComposerSessionDraft(sessionId, { text: "", attachments: [] }, storage);
+}


### PR DESCRIPTION
## Summary

- Switching between existing threads no longer drops a half-typed follow-up in the composer.
- Adds per-session draft storage (`localStorage` key `grok.composerSessionDrafts`): text, attachments, and goal mode.
- Save when leaving a real session, restore immediately when opening it, debounced persist while typing, clear on send or explicit clear.
- New-chat continues to use the existing per-project draft buffer; the two paths stay separate.

## Why

`openSession` always cleared the composer for real sessions, and only new-chat pages stashed drafts under the project key. Users typing a follow-up, switching threads, and coming back lost their text.

## Test plan

- [x] Unit tests: `src/lib/composerSessionDraft.test.ts` (9 cases) + existing project draft tests
- [x] Manual: type in thread A → switch to B → back to A → draft restored
- [x] Manual: send from A → switch away and back → composer empty
- [x] Manual: new-chat project buffer still restores independently
- [ ] CI green

## Notes

Local smoke verified on a rebuilt `Grok.app` after a full process restart (replacing the binary while the old process was still running does not pick up the fix until relaunch).