### PR TITLE
fix(media): copy image via native OS clipboard on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ See `docs/llm-wiki/release.md`.
 - **DeepSeek 余额查询**：Host `providers_balance` 请求官方 `/user/balance`；设置页可查完整明细，激活 DeepSeek 时侧栏左下角与个人菜单显示 `110.00 CNY` 一行（会话内 5 分钟缓存，失败不编造 0）。
 
 ### Fixed
+- **Copy image to OS clipboard (Tauri)**: Chat / attachment / lightbox “Copy image” now uses Host `clipboard_write_image` (arboard) instead of WebView `ClipboardItem`, so paste works in Feishu and other apps. Falls back to the browser clipboard API when not on desktop.
 - **Per-session composer drafts**: Switching threads no longer drops a half-typed follow-up. Each real session keeps text / attachments / goal mode in `localStorage` (`grok.composerSessionDrafts`); restore on open, debounced persist while typing, clear on send or explicit clear. New-chat still uses the existing per-project buffer.
 - **Right side pane closable (non-maximized)**: Sync-clamp aside width before paint, keep main top toggle while open, re-clamp window into the work area after grow, protect side chrome under narrow width (#532).
 - **Titlebar double-click maximize (mac)**: Enable maximize on all desktop hosts; `mousedown(detail=2)` fallback when drag regions swallow `dblclick` (#532).
 - **Mark as unread**: Session menu toggle uses existing unread storage; hold while the chat stays open so focus auto-clear does not wipe it instantly (#532).
 
 **中文 · 修复**
+- **复制图片到系统剪贴板（桌面端）**：聊天/附件/灯箱「复制图片」走 Host `clipboard_write_image`（arboard），不再依赖 WebView `ClipboardItem`，可粘贴到飞书等应用；非桌面仍回退浏览器剪贴板。
 - **按线程保留输入框草稿**：切换会话不再丢掉半截 follow-up。真实线程的文字/附件/Goal 模式写入 `localStorage`（`grok.composerSessionDrafts`），打开时恢复、输入防抖持久化、发送或清空时清除；新对话页仍用原有按项目草稿。
 - **非最大化时右侧栏可关闭**：打开前同步钳位宽度，保留主顶栏切换，增长后回钳到工作区，窄宽度下保护侧栏控件（#532）。
 - **标题栏双击最大化（mac）**：全桌面端启用；拖拽区吞掉 dblclick 时用 mousedown 回退（#532）。

--- a/src/lib/copyImage.ts
+++ b/src/lib/copyImage.ts
@@ -1,8 +1,13 @@
 /**
  * Copy an image (from URL / data URL / asset protocol) onto the system clipboard.
  * ClipboardItem typically requires image/png — we convert when needed.
+ *
+ * In Tauri, prefer the native `clipboard_write_image` command (arboard). WebView
+ * `navigator.clipboard.write(image/png)` is unreliable on macOS WKWebView and
+ * often fails silently so paste into Feishu / other apps gets nothing.
  */
 
+import { clipboardWriteImage, isTauri } from "@/lib/api";
 import { resolveImageSrc } from "@/lib/imageSrc";
 
 export type CopyImageResult =
@@ -15,6 +20,18 @@ function canWriteImage(): boolean {
     !!navigator.clipboard &&
     typeof ClipboardItem !== "undefined"
   );
+}
+
+/** Blob → base64 (no data: prefix) for Host `clipboard_write_image`. */
+async function blobToBase64(blob: Blob): Promise<string> {
+  const buf = await blob.arrayBuffer();
+  const bytes = new Uint8Array(buf);
+  const chunk = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
 }
 
 /** Draw arbitrary image blob into a PNG blob (clipboard-friendly). */
@@ -43,8 +60,6 @@ async function blobToPng(blob: Blob): Promise<Blob> {
  * Copy image at `src` (viewable URL) to clipboard as PNG.
  */
 export async function copyImageFromSrc(src: string): Promise<CopyImageResult> {
-  if (!canWriteImage()) return { ok: false, reason: "unsupported" };
-
   let blob: Blob;
   try {
     const res = await fetch(src);
@@ -60,6 +75,19 @@ export async function copyImageFromSrc(src: string): Promise<CopyImageResult> {
   } catch {
     return { ok: false, reason: "encode" };
   }
+
+  // Prefer native OS clipboard (arboard). WebView ClipboardItem often fails.
+  if (isTauri()) {
+    try {
+      const b64 = await blobToBase64(png);
+      await clipboardWriteImage(b64);
+      return { ok: true };
+    } catch {
+      /* fall through to web clipboard */
+    }
+  }
+
+  if (!canWriteImage()) return { ok: false, reason: "unsupported" };
 
   try {
     await navigator.clipboard.write([


### PR DESCRIPTION
## Summary

- Chat / attachment / lightbox **Copy image** now prefers Host `clipboard_write_image` (arboard) on Tauri, so the image lands on the real OS clipboard.
- WebView `navigator.clipboard.write(ClipboardItem image/png)` often fails silently on macOS WKWebView — paste into Feishu and other apps gets nothing.
- Falls back to the browser clipboard API when not on desktop or if the native path throws.

## Why

Session export already used `api.clipboardWriteImage` for this reason; image cards still went through `copyImageFromSrc` → WebView only.

## Test plan

- [ ] Open a chat with an agent image (e.g. relative `images/*.png` / project preview PNG)
- [ ] Right-click → **Copy image**
- [ ] Paste into Feishu / Preview / Notes — image should appear
- [ ] Attachment card copy image still works
- [ ] Lightbox right-click copy still works