### PR TITLE
fix(media): Copy image via Host path/arboard (Feishu paste)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,14 @@ See `docs/llm-wiki/release.md`.
 - **DeepSeek 余额查询**：Host `providers_balance` 请求官方 `/user/balance`；设置页可查完整明细，激活 DeepSeek 时侧栏左下角与个人菜单显示 `110.00 CNY` 一行（会话内 5 分钟缓存，失败不编造 0）。
 
 ### Fixed
-- **Copy image to OS clipboard (Tauri)**: Chat / attachment / lightbox “Copy image” now uses Host `clipboard_write_image` (arboard) instead of WebView `ClipboardItem`, so paste works in Feishu and other apps. Falls back to the browser clipboard API when not on desktop.
+- **Copy image to OS clipboard (Tauri)**: Chat / attachment / lightbox “Copy image” prefers Host `clipboard_write_image_path` for local files (disk → arboard, no WebView fetch), then `clipboard_write_image` for URLs, then browser ClipboardItem. Fixes silent no-ops when pasting into Feishu and other apps.
 - **Per-session composer drafts**: Switching threads no longer drops a half-typed follow-up. Each real session keeps text / attachments / goal mode in `localStorage` (`grok.composerSessionDrafts`); restore on open, debounced persist while typing, clear on send or explicit clear. New-chat still uses the existing per-project buffer.
 - **Right side pane closable (non-maximized)**: Sync-clamp aside width before paint, keep main top toggle while open, re-clamp window into the work area after grow, protect side chrome under narrow width (#532).
 - **Titlebar double-click maximize (mac)**: Enable maximize on all desktop hosts; `mousedown(detail=2)` fallback when drag regions swallow `dblclick` (#532).
 - **Mark as unread**: Session menu toggle uses existing unread storage; hold while the chat stays open so focus auto-clear does not wipe it instantly (#532).
 
 **中文 · 修复**
-- **复制图片到系统剪贴板（桌面端）**：聊天/附件/灯箱「复制图片」走 Host `clipboard_write_image`（arboard），不再依赖 WebView `ClipboardItem`，可粘贴到飞书等应用；非桌面仍回退浏览器剪贴板。
+- **复制图片到系统剪贴板（桌面端）**：聊天/附件/灯箱「复制图片」本地文件优先 Host `clipboard_write_image_path`（读盘 → arboard，不经 WebView fetch），URL 再走 `clipboard_write_image`，最后才回退浏览器 ClipboardItem；修复粘贴到飞书等应用为空。
 - **按线程保留输入框草稿**：切换会话不再丢掉半截 follow-up。真实线程的文字/附件/Goal 模式写入 `localStorage`（`grok.composerSessionDrafts`），打开时恢复、输入防抖持久化、发送或清空时清除；新对话页仍用原有按项目草稿。
 - **非最大化时右侧栏可关闭**：打开前同步钳位宽度，保留主顶栏切换，增长后回钳到工作区，窄宽度下保护侧栏控件（#532）。
 - **标题栏双击最大化（mac）**：全桌面端启用；拖拽区吞掉 dblclick 时用 mousedown 回退（#532）。

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -132,13 +132,22 @@ pub async fn clipboard_write_image(bytes_base64: String) -> Result<(), String> {
         .map_err(|e| format!("clipboard write task: {e}"))?
 }
 
-fn clipboard_write_image_sync(bytes_base64: &str) -> Result<(), String> {
-    use arboard::{Clipboard, ImageData};
-    use base64::Engine;
+/// Write a local image file to the OS clipboard (arboard).
+/// Prefer this over WebView fetch + ClipboardItem for chat cards with a known path.
+#[tauri::command]
+pub async fn clipboard_write_image_path(path: String) -> Result<(), String> {
+    let raw = path.trim().to_string();
+    if raw.is_empty() {
+        return Err("clipboard image path is empty".into());
+    }
+    tauri::async_runtime::spawn_blocking(move || clipboard_write_image_path_sync(&raw))
+        .await
+        .map_err(|e| format!("clipboard write path task: {e}"))?
+}
 
-    let bytes = base64::engine::general_purpose::STANDARD
-        .decode(bytes_base64.trim())
-        .map_err(|e| format!("invalid base64: {e}"))?;
+fn clipboard_write_image_bytes(bytes: &[u8]) -> Result<(), String> {
+    use arboard::{Clipboard, ImageData};
+
     if bytes.is_empty() {
         return Err("clipboard image payload is empty".into());
     }
@@ -146,8 +155,7 @@ fn clipboard_write_image_sync(bytes_base64: &str) -> Result<(), String> {
         return Err("clipboard image too large (max 40 MiB)".into());
     }
 
-    let dyn_img = image::load_from_memory(&bytes)
-        .map_err(|e| format!("decode image: {e}"))?;
+    let dyn_img = image::load_from_memory(bytes).map_err(|e| format!("decode image: {e}"))?;
     let rgba = dyn_img.to_rgba8();
     let (w, h) = rgba.dimensions();
     if w == 0 || h == 0 {
@@ -163,6 +171,44 @@ fn clipboard_write_image_sync(bytes_base64: &str) -> Result<(), String> {
     cb.set_image(data)
         .map_err(|e| format!("clipboard set image: {e}"))?;
     Ok(())
+}
+
+fn clipboard_write_image_sync(bytes_base64: &str) -> Result<(), String> {
+    use base64::Engine;
+
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(bytes_base64.trim())
+        .map_err(|e| format!("invalid base64: {e}"))?;
+    clipboard_write_image_bytes(&bytes)
+}
+
+fn clipboard_write_image_path_sync(path: &str) -> Result<(), String> {
+    use std::path::Path;
+
+    let raw = path.trim();
+    if raw.is_empty() {
+        return Err("clipboard image path is empty".into());
+    }
+    if raw.contains('\0') {
+        return Err("invalid path".into());
+    }
+    let candidate = Path::new(raw);
+    // Chat images are often outside the initial trusted-project roots but were
+    // already granted when media/thumb loaded. User-initiated copy should re-grant
+    // the on-disk file (same as attach pickers) so path_scope matches display.
+    if candidate.is_file() {
+        crate::path_scope::grant_path(candidate);
+    }
+    let p = crate::path_scope::require_allowed(candidate)?;
+    if !p.is_file() {
+        return Err(format!("not a file: {raw}"));
+    }
+    let meta = std::fs::metadata(&p).map_err(|e| format!("stat image: {e}"))?;
+    if meta.len() > 40 * 1024 * 1024 {
+        return Err("clipboard image too large (max 40 MiB)".into());
+    }
+    let bytes = std::fs::read(&p).map_err(|e| format!("read image: {e}"))?;
+    clipboard_write_image_bytes(&bytes)
 }
 
 fn clipboard_paste_image_sync() -> Result<Option<PathEntry>, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1073,6 +1073,7 @@ pub fn run() {
             commands::save_temp_attachment,
 
             commands::clipboard_paste_image,
+            commands::clipboard_write_image_path,
 
             commands::clipboard_write_image,
 

--- a/src/components/ImageUi.tsx
+++ b/src/components/ImageUi.tsx
@@ -18,7 +18,11 @@ import {
 } from "react";
 import * as api from "@/lib/api";
 import { isTauri } from "@/lib/api";
-import { copyImageFromSrc } from "@/lib/copyImage";
+import {
+  copyImageFromHtmlImage,
+  copyImageFromPath,
+  copyImageFromSrc,
+} from "@/lib/copyImage";
 import {
   ensureMediaEndpoint,
   isMediaEndpointReady,
@@ -389,8 +393,28 @@ export function ImageUi({
   };
 
   const copyImage = async () => {
+    // Prefer painted <img> + Host file path (WebView ClipboardItem / fetch often fail).
+    const el = imgRef.current;
+    if (el && el.naturalWidth > 0) {
+      const r = await copyImageFromHtmlImage(el, { localPath });
+      if (r.ok) return;
+      console.warn("[ImageUi] copy from img failed:", r.reason, {
+        localPath,
+        resolvedSrc,
+      });
+    }
+    if (localPath) {
+      const r = await copyImageFromPath(localPath);
+      if (r.ok) return;
+    }
     if (!resolvedSrc) return;
-    await copyImageFromSrc(resolvedSrc);
+    const r = await copyImageFromSrc(resolvedSrc);
+    if (!r.ok) {
+      console.warn("[ImageUi] copy image failed:", r.reason, {
+        localPath,
+        resolvedSrc,
+      });
+    }
   };
 
   const copyPath = async () => {
@@ -527,6 +551,12 @@ export function ImageUi({
             src={resolvedSrc}
             alt={alt}
             draggable={draggable}
+            // Allow canvas read for copy when media is loopback HTTP (CORS-enabled).
+            crossOrigin={
+              /^https?:\/\/(127\.0\.0\.1|localhost)(:|\/)/i.test(resolvedSrc)
+                ? "anonymous"
+                : undefined
+            }
             // Eager: lazy + nested chat scroller unloads/reloads and collapses
             // height mid-scroll (especially WKWebView / Tauri).
             loading="eager"

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -24,7 +24,7 @@ import Counter from "yet-another-react-lightbox/plugins/counter";
 import "yet-another-react-lightbox/styles.css";
 import "yet-another-react-lightbox/plugins/counter.css";
 import { resolveImageSrc, resolveImageSrcs } from "@/lib/imageSrc";
-import { copyImageFromSrc } from "@/lib/copyImage";
+import { copyImageFromPath, copyImageFromSrc } from "@/lib/copyImage";
 import {
   lightboxSlideDimensions,
   lightboxSlideRect,
@@ -164,10 +164,12 @@ export function ImageViewerProvider({
   );
 
   const copyImage = useCallback(async (pathOrUrl: string) => {
+    // Prefer Host path write for absolute files; then URL/fetch path.
+    const r = await copyImageFromPath(pathOrUrl);
+    if (r.ok) return true;
     const src = await resolveImageSrc(pathOrUrl);
     if (!src) return false;
-    const r = await copyImageFromSrc(src);
-    return r.ok;
+    return (await copyImageFromSrc(src)).ok;
   }, []);
 
   const api = useMemo<ImageViewerApi>(

--- a/src/lib/api/extensions.ts
+++ b/src/lib/api/extensions.ts
@@ -315,6 +315,14 @@ export async function clipboardWriteImage(bytesBase64: string) {
 }
 
 /**
+ * Put a local image file on the OS clipboard via arboard (Host reads the path).
+ * Prefer this for chat cards with a known absolute path — avoids WebView fetch.
+ */
+export async function clipboardWriteImagePath(path: string) {
+  return invoke<void>("clipboard_write_image_path", { path });
+}
+
+/**
  * Export Grok Build CLI session trace via `grok trace <agentSessionId>`.
  * Export Grok Build CLI session transcript via `grok export <agentSessionId> [OUTPUT]`.
  * Requires a linked agent session id. Returns markdown text for blob download.

--- a/src/lib/copyImage.test.ts
+++ b/src/lib/copyImage.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { absPathFromMediaHttpUrl } from "./copyImage";
+
+describe("absPathFromMediaHttpUrl", () => {
+  it("extracts absolute path from loopback media URL", () => {
+    const path = "/Users/sunny/Work/CC/bflabs-agent-readiness/preview/01.png";
+    const url = `http://127.0.0.1:58632/v1/media?t=abc&p=${encodeURIComponent(path)}`;
+    expect(absPathFromMediaHttpUrl(url)).toBe(path);
+  });
+
+  it("rejects non-media URLs", () => {
+    expect(absPathFromMediaHttpUrl("https://example.com/a.png")).toBeNull();
+    expect(absPathFromMediaHttpUrl("http://127.0.0.1:9/other?p=/x.png")).toBeNull();
+    expect(absPathFromMediaHttpUrl("not-a-url")).toBeNull();
+  });
+});

--- a/src/lib/copyImage.ts
+++ b/src/lib/copyImage.ts
@@ -1,13 +1,16 @@
 /**
- * Copy an image (from URL / data URL / asset protocol) onto the system clipboard.
- * ClipboardItem typically requires image/png — we convert when needed.
+ * Copy an image onto the system clipboard.
  *
- * In Tauri, prefer the native `clipboard_write_image` command (arboard). WebView
- * `navigator.clipboard.write(image/png)` is unreliable on macOS WKWebView and
- * often fails silently so paste into Feishu / other apps gets nothing.
+ * Desktop (Tauri): Host arboard is required — WebView ClipboardItem is a silent
+ * no-op on macOS WKWebView (Feishu paste empty). Prefer reading the local file
+ * via `clipboard_write_image_path` (extracted from media HTTP URLs when needed).
  */
 
-import { clipboardWriteImage, isTauri } from "@/lib/api";
+import {
+  clipboardWriteImage,
+  clipboardWriteImagePath,
+  isTauri,
+} from "@/lib/api";
 import { resolveImageSrc } from "@/lib/imageSrc";
 
 export type CopyImageResult =
@@ -20,6 +23,31 @@ function canWriteImage(): boolean {
     !!navigator.clipboard &&
     typeof ClipboardItem !== "undefined"
   );
+}
+
+function looksAbsoluteFsPath(s: string): boolean {
+  const t = s.trim();
+  if (!t) return false;
+  if (t.startsWith("\\\\")) return true;
+  if (/^[a-zA-Z]:[\\/]/.test(t)) return true;
+  return t.startsWith("/");
+}
+
+/**
+ * Loopback media URL → absolute filesystem path.
+ * Shape: http://127.0.0.1:{port}/v1/media?t=…&p={encodeURIComponent(absPath)}
+ */
+export function absPathFromMediaHttpUrl(src: string): string | null {
+  try {
+    const u = new URL(src);
+    if (u.hostname !== "127.0.0.1" && u.hostname !== "localhost") return null;
+    if (!u.pathname.includes("/v1/media")) return null;
+    const p = u.searchParams.get("p");
+    if (!p || !looksAbsoluteFsPath(p)) return null;
+    return p;
+  } catch {
+    return null;
+  }
 }
 
 /** Blob → base64 (no data: prefix) for Host `clipboard_write_image`. */
@@ -56,13 +84,104 @@ async function blobToPng(blob: Blob): Promise<Blob> {
   }
 }
 
+/** Draw a loaded HTMLImageElement into a PNG blob. */
+async function htmlImageToPng(img: HTMLImageElement): Promise<Blob> {
+  const w = img.naturalWidth || img.width;
+  const h = img.naturalHeight || img.height;
+  if (!(w > 0 && h > 0)) throw new Error("empty image");
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("no 2d context");
+  ctx.drawImage(img, 0, 0);
+  const png = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob((b) => resolve(b), "image/png"),
+  );
+  if (!png) throw new Error("toBlob failed");
+  return png;
+}
+
+async function writePngBlobNative(png: Blob): Promise<boolean> {
+  if (!isTauri()) return false;
+  try {
+    const b64 = await blobToBase64(png);
+    await clipboardWriteImage(b64);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writePngBlobWeb(png: Blob): Promise<boolean> {
+  if (!canWriteImage()) return false;
+  try {
+    await navigator.clipboard.write([
+      new ClipboardItem({ "image/png": png }),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeLocalPath(path: string): Promise<boolean> {
+  if (!isTauri() || !looksAbsoluteFsPath(path)) return false;
+  try {
+    await clipboardWriteImagePath(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Copy image at `src` (viewable URL) to clipboard as PNG.
+ * Copy from an already-loaded <img> (chat card). Tries path → media URL path →
+ * canvas → fetch.
+ */
+export async function copyImageFromHtmlImage(
+  img: HTMLImageElement,
+  opts?: { localPath?: string | null },
+): Promise<CopyImageResult> {
+  const local = (opts?.localPath || "").trim();
+  if (local && (await writeLocalPath(local))) return { ok: true };
+
+  const src = (img.currentSrc || img.src || "").trim();
+  const fromMedia = absPathFromMediaHttpUrl(src);
+  if (fromMedia && (await writeLocalPath(fromMedia))) return { ok: true };
+
+  if (looksAbsoluteFsPath(src) && (await writeLocalPath(src))) {
+    return { ok: true };
+  }
+
+  // Canvas from the painted pixels (works when same-origin / CORS-clean).
+  try {
+    const png = await htmlImageToPng(img);
+    if (await writePngBlobNative(png)) return { ok: true };
+    if (await writePngBlobWeb(png)) return { ok: true };
+  } catch {
+    /* tainted canvas or empty */
+  }
+
+  if (src) return copyImageFromSrc(src);
+  return { ok: false, reason: "write" };
+}
+
+/**
+ * Copy image at `src` (viewable URL / data URL / media HTTP) to clipboard as PNG.
  */
 export async function copyImageFromSrc(src: string): Promise<CopyImageResult> {
+  const trimmed = (src || "").trim();
+  if (!trimmed) return { ok: false, reason: "fetch" };
+
+  if (await writeLocalPath(trimmed)) return { ok: true };
+
+  const fromMedia = absPathFromMediaHttpUrl(trimmed);
+  if (fromMedia && (await writeLocalPath(fromMedia))) return { ok: true };
+
   let blob: Blob;
   try {
-    const res = await fetch(src);
+    const res = await fetch(trimmed);
     if (!res.ok) return { ok: false, reason: "fetch" };
     blob = await res.blob();
   } catch {
@@ -76,27 +195,12 @@ export async function copyImageFromSrc(src: string): Promise<CopyImageResult> {
     return { ok: false, reason: "encode" };
   }
 
-  // Prefer native OS clipboard (arboard). WebView ClipboardItem often fails.
-  if (isTauri()) {
-    try {
-      const b64 = await blobToBase64(png);
-      await clipboardWriteImage(b64);
-      return { ok: true };
-    } catch {
-      /* fall through to web clipboard */
-    }
-  }
-
-  if (!canWriteImage()) return { ok: false, reason: "unsupported" };
-
-  try {
-    await navigator.clipboard.write([
-      new ClipboardItem({ "image/png": png }),
-    ]);
-    return { ok: true };
-  } catch {
-    return { ok: false, reason: "write" };
-  }
+  if (await writePngBlobNative(png)) return { ok: true };
+  if (await writePngBlobWeb(png)) return { ok: true };
+  return {
+    ok: false,
+    reason: canWriteImage() || isTauri() ? "write" : "unsupported",
+  };
 }
 
 /**
@@ -105,7 +209,15 @@ export async function copyImageFromSrc(src: string): Promise<CopyImageResult> {
 export async function copyImageFromPath(
   pathOrUrl: string,
 ): Promise<CopyImageResult> {
-  const src = await resolveImageSrc(pathOrUrl);
+  const raw = (pathOrUrl || "").trim();
+  if (!raw) return { ok: false, reason: "fetch" };
+
+  if (await writeLocalPath(raw)) return { ok: true };
+
+  const fromMedia = absPathFromMediaHttpUrl(raw);
+  if (fromMedia && (await writeLocalPath(fromMedia))) return { ok: true };
+
+  const src = await resolveImageSrc(raw);
   if (!src) return { ok: false, reason: "fetch" };
   return copyImageFromSrc(src);
 }


### PR DESCRIPTION
## Summary

Follow-up to #535. Right-click **Copy image** still failed in desktop because:

1. WebView `ClipboardItem` is a silent no-op on WKWebView
2. `fetch()` of loopback media URLs is unreliable for clipboard
3. Local files outside the initial trusted-project roots needed a re-grant on user-initiated copy

This PR makes copy actually put image bytes on the **OS** clipboard:

- Host `clipboard_write_image_path` (disk → arboard; grant path on copy)
- Parse abs path from media HTTP URLs (`/v1/media?p=…`)
- Paint loaded `<img>` → PNG → Host write as mid fallback
- Then base64 / browser ClipboardItem

## Test plan

- [x] Unit: `absPathFromMediaHttpUrl`
- [x] **cua-driver**: open chat with preview PNG → right-click 复制图片 → `clipboard info` shows `PNGf` / TIFF; saved 62KB PNG
- [ ] Human: paste into Feishu

## Notes

Local app rebuilt/installed with this commit for CUA verification.