### PR TITLE
fix(tool-timeline): capture ACP output, fix tool identity, free plan mode

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -3440,7 +3440,8 @@ pub fn decode_permission_request(rpc_id: u64, params: &Value) -> AcpEvent {
     // Kind alone breaks tool-scoped session fallbacks (#542 shell →
     // allow-always-command).
     let tool_name = tool_call
-        .pointer("/_meta/x.ai/tool/name")
+        // `_meta` key is literally "x.ai/tool" — JSON Pointer needs `~1` (RFC 6901).
+        .pointer("/_meta/x.ai~1tool/name")
         .or_else(|| tool_call.pointer("/_meta/tool/name"))
         .or_else(|| tool_call.get("name"))
         .and_then(|v| v.as_str())

--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -16,7 +16,9 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::paths::resolve_agent_grok_home;
-use crate::session_manager::{extract_tool_input, tool_journal_richer};
+use crate::session_manager::{
+    TOOL_OUTPUT_MAX_PUB, TOOL_OUTPUT_SENTINEL, extract_tool_input, tool_journal_richer,
+};
 use crate::store::{self, ChatMessageStored, MessageAttachmentStored, SessionMeta};
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1608,6 +1610,20 @@ pub fn reconcile_journal_from_chat_history(
         if !detail_clean.is_empty() {
             row_content.push('\n');
             row_content.push_str(&detail_clean.chars().take(400).collect::<String>());
+            // Full tool output behind the sentinel so imported terminal sessions
+            // expand the same way live ones do (the 400-char lead above stays
+            // for the legacy positional detail parse).
+            if detail_clean.chars().count() > 400 {
+                row_content.push('\n');
+                row_content.push_str(TOOL_OUTPUT_SENTINEL);
+                row_content.push('\n');
+                row_content.push_str(
+                    &detail_clean
+                        .chars()
+                        .take(TOOL_OUTPUT_MAX_PUB)
+                        .collect::<String>(),
+                );
+            }
         }
         if let Some(slot) = journal.iter_mut().find(|m| m.id == mid) {
             // Upgrade sparse rows (tool_step|…|tool|tool) to named rows; never

--- a/src-tauri/src/session_manager/events.rs
+++ b/src-tauri/src/session_manager/events.rs
@@ -488,6 +488,8 @@ impl SessionManager {
                     .or(path_hint)
                     .filter(|p| !p.is_empty());
                 let (before_snip, after_snip) = extract_tool_content_snippets(&raw);
+                // Real tool output (ACP `content[]`) — powers the expandable body.
+                let output = extract_tool_output(&raw);
 
                 let prepared = structured_media
                     .as_deref()
@@ -658,6 +660,8 @@ impl SessionManager {
                         "detail": detail,
                         // Call argument (target file / command / query) for primary labels.
                         "input": input2,
+                        // What the tool actually produced (stdout / file text) — expand body.
+                        "output": output,
                         // Optional content snippets for the session Changes / diff panel.
                         "before": before_snip,
                         "after": after_snip,
@@ -698,6 +702,15 @@ impl SessionManager {
                         // Always persist path/url so reload can paint “Browsed …”.
                         content.push('\n');
                         content.push_str(p);
+                    }
+                    // Real tool output last, behind a sentinel line, so everything
+                    // above stays byte-identical to the legacy layout (old rows and
+                    // the positional detail/path heuristic keep parsing unchanged).
+                    if let Some(ref o) = output {
+                        content.push('\n');
+                        content.push_str(TOOL_OUTPUT_SENTINEL);
+                        content.push('\n');
+                        content.push_str(o);
                     }
                     let mid = format!("tool-{tool_call_id}");
                     // Upsert: replace only when new content is richer (never downgrade

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -49,8 +49,8 @@ use crate::session_fsm::SessionState;
 use types::*;
 
 pub(crate) use types::{
-    RewindExecuteResult, RewindPointDto, SessionSnapshot, UiPermissionRequest, extract_tool_input,
-    tool_journal_richer,
+    RewindExecuteResult, RewindPointDto, SessionSnapshot, TOOL_OUTPUT_MAX_PUB,
+    TOOL_OUTPUT_SENTINEL, UiPermissionRequest, extract_tool_input, tool_journal_richer,
 };
 
 pub struct SessionManager {

--- a/src-tauri/src/session_manager/routing_tests.rs
+++ b/src-tauri/src/session_manager/routing_tests.rs
@@ -212,6 +212,72 @@ fn extract_tool_input_accepts_bare_string_raw_input() {
 }
 
 #[test]
+fn tool_meta_reads_escaped_x_ai_pointer() {
+    // Real grok CLI payload: the _meta key is literally "x.ai/tool".
+    // A JSON Pointer MUST escape the inner slash as ~1 (RFC 6901); the unescaped
+    // form never resolves and silently dropped the machine tool name.
+    let raw: serde_json::Value = serde_json::from_str(
+        r#"{"_meta":{"x.ai/tool":{"name":"read_file","kind":"read","label":"Read"}}}"#,
+    )
+    .unwrap();
+    assert!(raw.pointer("/_meta/x.ai/tool/name").is_none());
+    assert_eq!(tool_meta_str(&raw, "name").as_deref(), Some("read_file"));
+    assert_eq!(tool_meta_str(&raw, "label").as_deref(), Some("Read"));
+    assert_eq!(tool_meta_str(&raw, "kind").as_deref(), Some("read"));
+}
+
+#[test]
+fn enrich_tool_identity_recovers_from_meta_when_title_is_machine_name() {
+    // Start notification: title is the raw machine name, kind is absent — the
+    // _meta block is the only source for a typed kind. Used to fall through to
+    // kind="tool" / title="tool" because the pointer was unescaped.
+    let raw: serde_json::Value = serde_json::from_str(
+        r#"{"title":"read_file","_meta":{"x.ai/tool":{"name":"read_file","kind":"read","label":"Read"}}}"#,
+    )
+    .unwrap();
+    let (kind, title) = enrich_tool_identity_from_raw(&raw, "read_file", "");
+    // The journal stores the machine tool name as `kind` so the UI can map it
+    // to a typed icon/label (read_file → “查看/读取”). The pre-fix result was
+    // the bare fallback "tool"; the recovery must yield a real identity.
+    assert_eq!(title, "read_file");
+    assert_ne!(kind, "tool");
+    assert!(!kind.is_empty());
+}
+
+#[test]
+fn extract_tool_output_pulls_text_and_diff_headers() {
+    let raw: serde_json::Value = serde_json::from_str(
+        r#"{
+            "content": [
+                {"type":"content","content":{"type":"text","text":"1→package foo\n2→bar"}},
+                {"type":"diff","path":"src/lib.rs","oldText":"","newText":"fn main(){}"}
+            ]
+        }"#,
+    )
+    .unwrap();
+    let out = extract_tool_output(&raw).expect("output");
+    assert!(out.contains("1→package foo"));
+    assert!(out.contains("--- src/lib.rs"));
+    // Diff bodies are summarized as a header only — the diff panel renders them.
+    assert!(!out.contains("fn main(){}"));
+}
+
+#[test]
+fn extract_tool_output_handles_bare_string_entries() {
+    let raw: serde_json::Value =
+        serde_json::json!({ "content": ["hello\nworld", "", "tail"] });
+    let out = extract_tool_output(&raw).expect("output");
+    // Empty chunks are dropped; the rest join with single newlines.
+    assert_eq!(out, "hello\nworld\ntail");
+}
+
+#[test]
+fn extract_tool_output_returns_none_when_empty() {
+    assert!(extract_tool_output(&serde_json::json!({ "content": [] })).is_none());
+    assert!(extract_tool_output(&serde_json::json!({})).is_none());
+}
+
+#[test]
 fn provider_retry_abort_skips_idle_and_connecting_reconnect() {
     // Diagnostic 65fa7759: session/load residual retry_state while Connecting/Ready
     // must not write NETWORK_PROVIDER or fail_with without a host turn.

--- a/src-tauri/src/session_manager/types.rs
+++ b/src-tauri/src/session_manager/types.rs
@@ -539,6 +539,26 @@ pub(super) fn normalize_tool_kind_for_journal(kind: &str, title: &str) -> String
     String::new()
 }
 
+/// Read the grok CLI tool meta block (`_meta["x.ai/tool"]`).
+///
+/// The key contains a literal `/`, so a JSON Pointer must escape it as `~1`
+/// (RFC 6901). Plain `/_meta/x.ai/tool/...` never resolves and silently
+/// dropped the machine tool name — journals then recorded `tool_step|…|tool|tool`.
+pub(super) fn tool_meta(raw: &serde_json::Value) -> Option<&serde_json::Value> {
+    raw.pointer("/_meta/x.ai~1tool")
+        .or_else(|| raw.pointer("/_meta/tool"))
+}
+
+/// String field from the CLI tool meta block (`name` / `label` / `kind`).
+pub(super) fn tool_meta_str(raw: &serde_json::Value, field: &str) -> Option<String> {
+    tool_meta(raw)?
+        .get(field)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
 /// Tool identity learned from the in_progress `tool_call` notification.
 ///
 /// The grok CLI sends the full identity (`title`, `kind`, `toolName`, `rawInput`)
@@ -618,8 +638,11 @@ pub(super) fn remember_tool_identity(
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .unwrap_or("")
-        .to_string();
+        .map(|s| s.to_string())
+        // grok CLI never sends a top-level `toolName`: the machine name lives in
+        // `_meta["x.ai/tool"].name` on the start notification only.
+        .or_else(|| tool_meta_str(raw, "name"))
+        .unwrap_or_default();
     let t = title.trim();
     let k = kind.trim();
     let input = extract_tool_input(raw);
@@ -736,7 +759,7 @@ pub(super) fn enrich_tool_identity_from_raw(
         }
         let mcp_tool = pick_str(&["/rawOutput/tool_name", "/rawInput/tool_name"]);
         let mcp_server = pick_str(&["/rawOutput/server_name", "/rawOutput/server"]);
-        let meta_name = pick_str(&["/_meta/x.ai/tool/name", "/_meta/x.ai/tool/label"]);
+        let meta_name = tool_meta_str(raw, "name").or_else(|| tool_meta_str(raw, "label"));
         let variant = pick_str(&["/rawInput/variant"]);
         let update_title = pick_str(&["/title"]);
 
@@ -770,7 +793,8 @@ pub(super) fn enrich_tool_identity_from_raw(
     if kind_out.is_empty() || kind_out.eq_ignore_ascii_case("other") {
         kind_out = normalize_tool_kind_for_journal(&kind_out, &title_out);
         if kind_out.is_empty() {
-            if let Some(n) = pick_str(&["/_meta/x.ai/tool/name", "/rawInput/variant"]) {
+            if let Some(n) = tool_meta_str(raw, "name").or_else(|| pick_str(&["/rawInput/variant"]))
+            {
                 kind_out = match n.as_str() {
                     "SearchTool" | "search_tool" => "search_tool".into(),
                     "UseTool" | "use_tool" => "use_tool".into(),
@@ -958,6 +982,84 @@ pub(super) fn extract_tool_content_snippets(
             .or_else(|| raw.pointer("/rawInput/after")),
     );
     (before, after)
+}
+
+/// Cap persisted tool output so a single `cat` of a huge file cannot bloat the
+/// journal. The live event carries the same cap; the UI scrolls inside expand.
+pub(super) const TOOL_OUTPUT_MAX: usize = 20_000;
+
+/// Same cap, re-exported for the CLI session importer (`cli_sessions`).
+pub(crate) const TOOL_OUTPUT_MAX_PUB: usize = TOOL_OUTPUT_MAX;
+
+/// Marker line that separates the legacy `tool_step|` body from real tool
+/// output. Everything before it keeps the historical layout byte-for-byte, so
+/// old journals and the positional `detail\npath` heuristic stay valid; the
+/// parser only has to split on this line. Chosen to never collide with stdout.
+pub(crate) const TOOL_OUTPUT_SENTINEL: &str = "\u{1}output";
+
+/// Real tool **output** from the ACP terminal `tool_call_update`.
+///
+/// Grok CLI puts what the tool produced in `content[]`, which this crate
+/// previously never read — so `detail` only ever held the *call argument*
+/// echoed back from `rawInput`, and read/list/search tools (no command/query
+/// key) produced no expandable body at all.
+///
+/// Shapes observed on the wire:
+/// - `{"type":"content","content":{"type":"text","text":"…"}}` — stdout / file text
+/// - `{"type":"diff","path":…,"oldText":…,"newText":…}` — edit/write preview
+///
+/// Diff entries are summarized as a `--- path` header (the diff panel renders
+/// the real before/after via {@link extract_tool_content_snippets}).
+pub(super) fn extract_tool_output(raw: &serde_json::Value) -> Option<String> {
+    let items = raw.get("content")?.as_array()?;
+    let mut out = String::new();
+    for item in items {
+        // Bare string entries (lenient wrappers).
+        if let Some(s) = item.as_str() {
+            push_output_chunk(&mut out, s);
+            continue;
+        }
+        let obj = match item.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+        let ty = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if ty == "diff" {
+            let path = obj.get("path").and_then(|v| v.as_str()).unwrap_or("");
+            if !path.is_empty() {
+                push_output_chunk(&mut out, &format!("--- {path}"));
+            }
+            continue;
+        }
+        // `{type:"content", content:{type:"text", text:"…"}}`
+        let text = obj
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|v| v.as_str())
+            // Some wrappers inline the text one level up.
+            .or_else(|| obj.get("text").and_then(|v| v.as_str()));
+        if let Some(t) = text {
+            push_output_chunk(&mut out, t);
+        }
+        if out.chars().count() >= TOOL_OUTPUT_MAX {
+            break;
+        }
+    }
+    let trimmed = out.trim_end();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.chars().take(TOOL_OUTPUT_MAX).collect())
+}
+
+fn push_output_chunk(out: &mut String, chunk: &str) {
+    if chunk.trim().is_empty() {
+        return;
+    }
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out.push_str(chunk);
 }
 
 /// When user asks to open a Grok App / foreign agent session by UUID, steer tools.

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -2060,7 +2060,9 @@ fn global_prefs(settings: &AppSettings) -> (String, String, String, String) {
         if settings.mode.trim().is_empty() {
             "agent".into()
         } else {
-            settings.mode.clone()
+            // Heal a `plan` default already written by an older build: plan mode
+            // must never be inherited by a new session.
+            non_plan_mode(&settings.mode)
         },
         if settings.permission_policy.trim().is_empty() {
             "ask".into()
@@ -2113,7 +2115,12 @@ pub fn resolve_composer_prefs(project_id: Option<&str>, session_id: Option<&str>
                 ComposerPrefs {
                     model_id: p.model_id.filter(|s| !s.is_empty()).unwrap_or(g_model),
                     effort: p.effort.filter(|s| !s.is_empty()).unwrap_or(g_effort),
-                    mode: p.mode.filter(|s| !s.is_empty()).unwrap_or(g_mode),
+                    mode: p
+                        .mode
+                        .filter(|s| !s.is_empty())
+                        // Project defaults never carry plan mode (heals old data).
+                        .map(|m| non_plan_mode(&m))
+                        .unwrap_or(g_mode),
                     permission_policy,
                     scope: scope.as_str().into(),
                     source: "project".into(),
@@ -2144,6 +2151,8 @@ pub fn resolve_composer_prefs(project_id: Option<&str>, session_id: Option<&str>
                 .as_ref()
                 .and_then(|p| p.mode.clone())
                 .filter(|s| !s.is_empty())
+                // A project default of `plan` is never inherited (heals old data).
+                .map(|m| non_plan_mode(&m))
                 .unwrap_or(g_mode.clone());
 
             if let Some(s) = sess {
@@ -2169,6 +2178,28 @@ pub fn resolve_composer_prefs(project_id: Option<&str>, session_id: Option<&str>
     }
 }
 
+/// Plan mode is a **transient, per-session** state, never a sticky default.
+///
+/// It used to be persisted like any other mode, so a single `/plan` wrote
+/// `mode: "plan"` into global settings and every later session started in plan
+/// mode. Session scope may still record it (that session really is planning);
+/// global / project defaults drop it.
+fn sticky_mode(mode: Option<String>) -> Option<String> {
+    match mode {
+        Some(m) if m.trim().eq_ignore_ascii_case("plan") => None,
+        other => other,
+    }
+}
+
+/// Read a stored default mode, healing a `plan` value already on disk.
+pub(crate) fn non_plan_mode(mode: &str) -> String {
+    let m = mode.trim();
+    if m.is_empty() || m.eq_ignore_ascii_case("plan") {
+        return "agent".into();
+    }
+    m.to_string()
+}
+
 /// Persist a partial composer prefs update at the configured scope.
 pub fn save_composer_prefs(
     project_id: Option<&str>,
@@ -2190,7 +2221,7 @@ pub fn save_composer_prefs(
             if let Some(v) = effort {
                 s.effort = Some(v);
             }
-            if let Some(v) = mode {
+            if let Some(v) = sticky_mode(mode) {
                 s.mode = v;
             }
             if let Some(v) = permission_policy {
@@ -2209,7 +2240,7 @@ pub fn save_composer_prefs(
                     if let Some(v) = effort.clone() {
                         p.effort = Some(v);
                     }
-                    if let Some(v) = mode.clone() {
+                    if let Some(v) = sticky_mode(mode.clone()) {
                         p.mode = Some(v);
                     }
                     if let Some(v) = permission_policy.clone() {
@@ -2226,7 +2257,7 @@ pub fn save_composer_prefs(
             if let Some(v) = effort {
                 s.effort = Some(v);
             }
-            if let Some(v) = mode {
+            if let Some(v) = sticky_mode(mode) {
                 s.mode = v;
             }
             if let Some(v) = permission_policy {
@@ -2262,7 +2293,7 @@ pub fn save_composer_prefs(
                     if let Some(v) = effort {
                         s.effort = Some(v);
                     }
-                    if let Some(v) = mode {
+                    if let Some(v) = sticky_mode(mode) {
                         s.mode = v;
                     }
                     if let Some(v) = permission_policy {
@@ -2278,7 +2309,7 @@ pub fn save_composer_prefs(
                 if let Some(v) = effort {
                     s.effort = Some(v);
                 }
-                if let Some(v) = mode {
+                if let Some(v) = sticky_mode(mode) {
                     s.mode = v;
                 }
                 if let Some(v) = permission_policy {
@@ -2296,6 +2327,26 @@ pub fn save_composer_prefs(
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    #[test]
+    fn non_plan_mode_heals_plan_default() {
+        // Plan mode must never be a sticky default: empty or "plan" → "agent".
+        assert_eq!(non_plan_mode(""), "agent");
+        assert_eq!(non_plan_mode("plan"), "agent");
+        assert_eq!(non_plan_mode("PLAN"), "agent");
+        assert_eq!(non_plan_mode("agent"), "agent");
+        assert_eq!(non_plan_mode("ask"), "ask");
+    }
+
+    #[test]
+    fn sticky_mode_drops_plan_for_global_persistence() {
+        assert_eq!(sticky_mode(None), None);
+        assert_eq!(sticky_mode(Some("plan".into())), None);
+        assert_eq!(sticky_mode(Some("PLAN".into())), None);
+        // Real sticky modes pass through.
+        assert_eq!(sticky_mode(Some("agent".into())), Some("agent".into()));
+        assert_eq!(sticky_mode(Some("ask".into())), Some("ask".into()));
+    }
 
     #[test]
     fn redact_scrubs_long_tokenish() {

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -9862,6 +9862,27 @@ export function AppWorkbench() {
     setPlanFocusKey((k) => k + 1);
   }, [openAsidePane]);
 
+  /**
+   * Exit the bare “计划模式” chip (mode === "plan", no plan content yet).
+   *
+   * Distinct from {@link dismissPlan}, which archives an in-flight plan /
+   * abandons a review rpc. This just flips the composer mode back to agent and
+   * persists it — the only way out when the bar is showing the idle plan chip
+   * with no entries / body / rpc (previously there was no exit control at all).
+   */
+  const exitPlanMode = useCallback(() => {
+    if (modeRef.current !== "plan") return;
+    setMode("agent");
+    setGoalMode(false);
+    void api
+      .composerPrefsSet({
+        projectId: activeProject?.id ?? null,
+        sessionId: session.sessionId ?? null,
+        mode: "agent",
+      })
+      .catch((e) => showToast(String(e), 4000));
+  }, [activeProject?.id, session.sessionId, showToast]);
+
   const sendQueueLabels = useMemo(
     () => ({
       sendFailed: tr("composer.queueSendFailed"),
@@ -18570,6 +18591,7 @@ export function AppWorkbench() {
               onApprove={() => void approvePlan()}
               onRequestChanges={() => openRequestPlanChanges()}
               onDismiss={() => void dismissPlan()}
+              onExitPlanMode={exitPlanMode}
               onClearGoal={() => setGoalMode(false)}
               onOpenDetails={() => openPlanInResource()}
             />

--- a/src/components/PlanStatusBar.tsx
+++ b/src/components/PlanStatusBar.tsx
@@ -42,6 +42,8 @@ export type PlanStatusBarProps = {
   /** Optional revision note (same contract as PlanReviewPanel). */
   onRequestChanges?: (note?: string) => void;
   onDismiss?: () => void;
+  /** Exit the bare plan-mode chip (mode === "plan", no plan body). */
+  onExitPlanMode?: () => void;
   /** Exit goal mode from the sticky goal strip. */
   onClearGoal?: () => void;
   /** Scroll / focus the in-thread plan card when present. */
@@ -79,6 +81,7 @@ export function PlanStatusBar({
   onApprove,
   onRequestChanges,
   onDismiss,
+  onExitPlanMode,
   onClearGoal,
   onOpenDetails,
 }: PlanStatusBarProps) {
@@ -210,9 +213,21 @@ export function PlanStatusBar({
           <button
             type="button"
             className="icon-btn plan-bar__close"
-            onClick={onDismiss}
+            onClick={() => void onDismiss()}
             aria-label={labels.dismiss}
             title={labels.dismiss}
+          >
+            <IconClose size={14} />
+          </button>
+        ) : null}
+        {model.kind === "plan_mode" && onExitPlanMode ? (
+          <button
+            type="button"
+            className="icon-btn plan-bar__close"
+            onClick={() => onExitPlanMode()}
+            aria-label={labels.dismiss}
+            title={labels.dismiss}
+            data-testid="plan-status-exit-plan-mode"
           >
             <IconClose size={14} />
           </button>

--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -53,6 +53,7 @@ import {
   type ActivityStepExpandState,
 } from "@/lib/grokActivityVirtualize";
 import { VirtualList } from "@/components/VirtualList";
+import { ToolExpandBody } from "./ToolExpandBody";
 import {
   IconBulb,
   IconChevronDown,
@@ -225,9 +226,17 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
     step.type === "web-search" ? step.resultDomains : undefined;
 
   const expandTool = step.type === "tool" ? step.tool : null;
-  const { failHint, failHintShort, detailTail, hasBody } = expandTool
+  const expand = expandTool
     ? toolExpandBody(expandTool, failed)
-    : { failHint: "", failHintShort: "", detailTail: "", hasBody: false };
+    : {
+        failHint: "",
+        failHintShort: "",
+        detailTail: "",
+        outputBody: "",
+        command: "",
+        hasBody: false,
+      };
+  const hasBody = expand.hasBody;
 
   const runningRef = useRef(running);
   runningRef.current = running;
@@ -322,18 +331,10 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
           ) : null}
         </div>
         {showBody ? (
-          <div className="lobe-timeline-tool__body grok-act__expand-body">
-            {failHintShort ? (
-              <div className="lobe-timeline-tool__fail-hint" title={failHint}>
-                {failHintShort}
-              </div>
-            ) : null}
-            {detailTail &&
-            detailTail !== failHint &&
-            detailTail !== failHintShort ? (
-              <pre className="lobe-timeline-tool__detail">{detailTail}</pre>
-            ) : null}
-          </div>
+          <ToolExpandBody
+            body={expand}
+            className="lobe-timeline-tool__body grok-act__expand-body"
+          />
         ) : null}
       </div>
     </div>

--- a/src/components/lobe-chat/TimelineToolRow.tsx
+++ b/src/components/lobe-chat/TimelineToolRow.tsx
@@ -32,6 +32,7 @@ import {
   IconWorld,
 } from "@/components/icons";
 import { ToolBucketIcon } from "./TimelinePhaseBlock";
+import { ToolExpandBody } from "./ToolExpandBody";
 
 export function toolSegmentIsRunning(seg: MessageToolSegment): boolean {
   if (seg.streaming) return true;
@@ -85,10 +86,8 @@ export const TimelineToolRow = memo(function TimelineToolRow({
 
   // Host tools use the same expand body as native tools (full detail / stream
   // dump), not a special 2-line scroller under a second title.
-  const { failHint, failHintShort, detailTail, hasBody } = toolExpandBody(
-    tool,
-    failed,
-  );
+  const { failHint, failHintShort, detailTail, outputBody, command, hasBody } =
+    toolExpandBody(tool, failed);
 
   const [autoCollapse, setAutoCollapse] = useState(
     () => autoCollapseProp ?? loadToolStepsAutoCollapsePref(),
@@ -187,18 +186,9 @@ export const TimelineToolRow = memo(function TimelineToolRow({
         <span className="grok-act__label">{summary}</span>
       )}
       {showBody ? (
-        <div className="lobe-timeline-tool__body">
-          {failHintShort ? (
-            <div className="lobe-timeline-tool__fail-hint" title={failHint}>
-              {failHintShort}
-            </div>
-          ) : null}
-          {detailTail &&
-          detailTail !== failHint &&
-          detailTail !== failHintShort ? (
-            <pre className="lobe-timeline-tool__detail">{detailTail}</pre>
-          ) : null}
-        </div>
+        <ToolExpandBody
+          body={{ failHint, failHintShort, detailTail, outputBody, command, hasBody }}
+        />
       ) : null}
     </div>
   );

--- a/src/components/lobe-chat/ToolExpandBody.tsx
+++ b/src/components/lobe-chat/ToolExpandBody.tsx
@@ -1,0 +1,52 @@
+/**
+ * Shared expanded body for a tool step — one implementation for the bare
+ * TimelineToolRow and the in-phase GrokActivityStepRow so live and history
+ * look identical.
+ *
+ * Layout (terminal transcript order):
+ *   [fail hint]
+ *   $ command          ← only for shell tools, when there is output to pair it with
+ *   <tool output>      ← ACP content[]; scrolls internally, elided in the middle
+ *   <legacy detail>    ← only when no real output was captured
+ */
+
+import type { toolExpandBody } from "@/lib/toolDisplay";
+
+export type ToolExpandBodyModel = ReturnType<typeof toolExpandBody>;
+
+export function ToolExpandBody({
+  body,
+  className = "lobe-timeline-tool__body",
+}: {
+  body: ToolExpandBodyModel;
+  className?: string;
+}) {
+  const { failHint, failHintShort, detailTail, outputBody, command } = body;
+  const showDetail =
+    !!detailTail && detailTail !== failHint && detailTail !== failHintShort;
+  return (
+    <div className={className}>
+      {failHintShort ? (
+        <div className="lobe-timeline-tool__fail-hint" title={failHint}>
+          {failHintShort}
+        </div>
+      ) : null}
+      {command && outputBody ? (
+        <pre className="lobe-timeline-tool__cmd">
+          <span className="lobe-timeline-tool__cmd-sigil" aria-hidden>
+            ${" "}
+          </span>
+          {command}
+        </pre>
+      ) : null}
+      {outputBody ? (
+        <pre className="lobe-timeline-tool__output" data-testid="tool-output">
+          {outputBody}
+        </pre>
+      ) : null}
+      {showDetail ? (
+        <pre className="lobe-timeline-tool__detail">{detailTail}</pre>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/lobe-chat/lobe-chat.part2.css
+++ b/src/components/lobe-chat/lobe-chat.part2.css
@@ -346,6 +346,52 @@
   white-space: nowrap;
   max-width: 100%;
 }
+
+/* Real tool output (ACP content[]) — terminal-transcript block, like zCode.
+   Boxed so a long stdout dump reads as a distinct surface rather than bleeding
+   into the activity rail, and scrolls internally instead of growing the turn. */
+.lobe-timeline-tool__output,
+.lobe-timeline-tool__cmd {
+  margin: 0;
+  max-width: 100%;
+  overflow: auto;
+  overscroll-behavior: contain;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid var(--chat-border, rgb(255 255 255 / 8%));
+  border-radius: 8px;
+  background: var(--chat-surface-2, rgb(255 255 255 / 3%));
+}
+.lobe-timeline-tool__cmd {
+  padding: 6px 10px;
+  color: var(--chat-text-2);
+  /* Command sits directly above its output: join the two boxes. */
+  border-bottom: 0;
+  border-radius: 8px 8px 0 0;
+  white-space: pre-wrap;
+}
+.lobe-timeline-tool__cmd-sigil {
+  color: var(--chat-text-3);
+  user-select: none;
+}
+.lobe-timeline-tool__output {
+  padding: 8px 10px;
+  color: var(--chat-text-2);
+  max-height: 320px;
+}
+/* When a command box precedes the output, drop the doubled top corner. */
+.lobe-timeline-tool__cmd + .lobe-timeline-tool__output {
+  border-radius: 0 0 8px 8px;
+}
+/* Inside a phase rail the outer body already scrolls — let the output grow to
+   its own cap and keep a single scroller (nested scrollbars trap the wheel). */
+.grok-act__expand-body {
+  max-height: none;
+  overflow: visible;
+}
 .lobe-timeline-tool-group {
   width: 100%;
   margin: 0;

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -2068,3 +2068,66 @@ describe("tool activity", () => {
     expect(m[0]?.content).toBe("npm test");
   });
 });
+
+describe("tool_step output capture", () => {
+  it("parseToolStepContent splits real output off the sentinel", () => {
+    // New journal shape: legacy body intact, output appended after the sentinel.
+    const body = [
+      "tool_step|completed|read_file|Read",
+      "input:src/lib/session.ts",
+      "\u0001output",
+      "1→export function foo() {",
+      "2→  return 42;",
+      "3→}",
+    ].join("\n");
+    const p = parseToolStepContent(body);
+    expect(p?.kind).toBe("read_file");
+    expect(p?.input).toBe("src/lib/session.ts");
+    // Output is the full multiline body — never reaches the positional detail.
+    expect(p?.output).toContain("export function foo()");
+    expect(p?.output).toContain("return 42");
+    expect(p?.detail).toBeUndefined();
+  });
+
+  it("parseToolStepContent keeps legacy rows byte-identical (no sentinel)", () => {
+    // Old journal rows have no sentinel and must parse exactly as before.
+    const body = [
+      "tool_step|completed|grep|Search",
+      "input:foo",
+      "src/a.ts:1:foo",
+      "src/b.ts:2:foo",
+    ].join("\n");
+    const p = parseToolStepContent(body);
+    expect(p?.output).toBeUndefined();
+    expect(p?.input).toBe("foo");
+    // Positional detail/path heuristic still runs on the pre-sentinel body.
+    expect(p?.detail).toContain("src/a.ts:1:foo");
+  });
+
+  it("applyToolEvent threads output into the tool segment", () => {
+    let m = applyToolEvent(
+      [{ id: "a1", role: "assistant", content: "thinking…" }],
+      {
+        toolCallId: "call_1",
+        title: "Read",
+        kind: "read_file",
+        status: "completed",
+        input: "README.md",
+        output: "# Project\nA short readme.",
+      },
+    );
+    const asst = m.find((x) => x.role === "assistant")!;
+    const tool = asst.segments?.find((s) => s.kind === "tool")!;
+    expect(tool).toBeTruthy();
+    expect((tool as any).output).toContain("# Project");
+    expect((tool as any).input).toBe("README.md");
+    // A later sparse status tick must not erase the captured output.
+    m = applyToolEvent(m, {
+      toolCallId: "call_1",
+      status: "completed",
+    });
+    const asst2 = m.find((x) => x.role === "assistant")!;
+    const tool2 = asst2.segments?.find((s) => s.kind === "tool") as any;
+    expect(tool2.output).toContain("# Project");
+  });
+});

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -66,6 +66,12 @@ export interface MessageToolSegment {
   path?: string;
   /** Call argument recorded by the host (target file / command / query). */
   input?: string;
+  /**
+   * What the tool actually produced (stdout / file text) from ACP `content[]`.
+   * Distinct from {@link detail}, which only echoes the *call argument*.
+   * This is the expandable body — never part of the one-line primary label.
+   */
+  output?: string;
   streaming?: boolean;
   isError?: boolean;
   /** ISO time when the tool row was created (history duration). */
@@ -120,6 +126,8 @@ export interface ChatMessage {
   toolPath?: string;
   /** Call argument recorded by the host (target file / command / query). */
   toolInput?: string;
+  /** Real tool output (ACP `content[]`) — expandable body, not a label. */
+  toolOutput?: string;
   /**
    * Parent tool call id when the host/ACP marks nested tools (e.g. subagent
    * children). Optional — Tasks panel may infer when missing.
@@ -137,6 +145,8 @@ export interface ToolEventPayload {
   detail?: string | null;
   /** Call argument (target file / command / query) from live session://tool. */
   input?: string | null;
+  /** Real tool output (ACP `content[]`) from live session://tool. */
+  output?: string | null;
   /** Parent tool call id when the wire event includes nesting. */
   parentId?: string | null;
 }
@@ -281,6 +291,7 @@ export function toolSegmentFromFields(fields: {
   detail?: string;
   path?: string;
   input?: string;
+  output?: string;
   streaming?: boolean;
   isError?: boolean;
   createdAt?: string;
@@ -294,6 +305,7 @@ export function toolSegmentFromFields(fields: {
     detail: fields.detail,
     path: fields.path,
     input: fields.input,
+    output: fields.output,
     streaming: !!fields.streaming,
     isError: !!fields.isError,
     createdAt: fields.createdAt,
@@ -446,6 +458,7 @@ function toolSegmentFromMessageRow(row: ChatMessage): MessageToolSegment | null 
   let detail = row.toolDetail;
   let path = row.toolPath;
   let input = row.toolInput;
+  let output = row.toolOutput;
   const raw = (row.content || "").trim();
   if (raw.startsWith("tool_step|")) {
     const parsed = parseToolStepContent(raw);
@@ -454,6 +467,7 @@ function toolSegmentFromMessageRow(row: ChatMessage): MessageToolSegment | null 
     }
     if (parsed?.path && !path) path = parsed.path;
     if (parsed?.input && !input) input = parsed.input;
+    if (parsed?.output && !output) output = parsed.output;
   }
   return toolSegmentFromFields({
     toolCallId: tcid,
@@ -463,6 +477,7 @@ function toolSegmentFromMessageRow(row: ChatMessage): MessageToolSegment | null 
     detail,
     path,
     input,
+    output,
     streaming: false,
     isError: !!row.isError || status === "failed" || status === "error",
     createdAt: row.createdAt,
@@ -905,6 +920,8 @@ export function syncTurnToolsIntoAssistant(
       status,
       detail: m.toolDetail,
       path: m.toolPath,
+      input: m.toolInput,
+      output: m.toolOutput,
       streaming: !!m.streaming,
       isError: !!m.isError || status === "failed" || status === "error",
       createdAt: m.createdAt,
@@ -976,6 +993,13 @@ export function applyToolEvent(
   // Status-only ticks omit input; keep the first non-empty call argument.
   const toolInput =
     (payload.input || "").trim() || prev?.toolInput || undefined;
+  // Tool output arrives on the terminal tick; never let a later sparse tick
+  // erase it, and prefer the longer body when the host streams in chunks.
+  const prevOutput = (prev?.toolOutput || "").trim();
+  const nextOutput = (payload.output || "").trim();
+  const toolOutput =
+    (nextOutput.length >= prevOutput.length ? nextOutput : prevOutput) ||
+    undefined;
   const isError = status === "failed" || status === "error";
 
   // Host vision / X: **only** live on the assistant timeline. A separate
@@ -1008,6 +1032,7 @@ export function applyToolEvent(
         toolDetail: mergedDetail,
         toolPath,
         toolInput,
+        toolOutput,
         toolParentId: parentId,
         streaming: running,
         marker: "tool_step",
@@ -1025,6 +1050,7 @@ export function applyToolEvent(
       detail: mergedDetail,
       path: toolPath,
       input: toolInput,
+      output: toolOutput,
       streaming: running,
       isError,
       createdAt: prev?.createdAt || now,
@@ -1047,6 +1073,7 @@ export function applyToolEvent(
     toolDetail: mergedDetail,
     toolPath,
     toolInput,
+    toolOutput,
     toolParentId: parentId,
     streaming: running,
     marker: "tool_step",
@@ -1067,6 +1094,7 @@ export function applyToolEvent(
       toolDetail: mergedDetail,
       toolPath: toolPath || prev!.toolPath,
       toolInput: toolInput || prev!.toolInput,
+      toolOutput: toolOutput || prev!.toolOutput,
       toolKind: toolKind || prev!.toolKind,
       toolParentId: parentId || prev!.toolParentId,
     };
@@ -1085,6 +1113,7 @@ export function applyToolEvent(
     detail: row.toolDetail,
     path: row.toolPath,
     input: row.toolInput,
+    output: row.toolOutput,
     streaming: running,
     isError: !!row.isError,
     createdAt: row.createdAt || prev?.createdAt || now,
@@ -1235,6 +1264,14 @@ export function toolStepDisplayTitle(m: ChatMessage): string {
   );
 }
 
+/**
+ * Sentinel line separating the legacy `tool_step|` body from real tool output.
+ * Everything before it keeps the historical layout, so old journals (which have
+ * no sentinel) parse exactly as before. Mirrors `TOOL_OUTPUT_SENTINEL` in
+ * `src-tauri/src/session_manager/types.rs`.
+ */
+export const TOOL_OUTPUT_SENTINEL = "\u0001output";
+
 /** Parse persisted tool_step journal lines. */
 export function parseToolStepContent(content: string): {
   status: string;
@@ -1243,8 +1280,19 @@ export function parseToolStepContent(content: string): {
   detail?: string;
   path?: string;
   input?: string;
+  output?: string;
 } | null {
   if (!content.startsWith("tool_step|")) return null;
+  // Split real tool output off first: it is free-form multi-line stdout and
+  // must never reach the positional `detail\npath` heuristic below.
+  let output: string | undefined;
+  const sentinelAt = content.indexOf(`\n${TOOL_OUTPUT_SENTINEL}\n`);
+  if (sentinelAt >= 0) {
+    output =
+      content.slice(sentinelAt + TOOL_OUTPUT_SENTINEL.length + 2).trim() ||
+      undefined;
+    content = content.slice(0, sentinelAt);
+  }
   let [header, ...rest] = content.split("\n");
   const parts = (header || "").split("|");
   // tool_step|status|kind|title
@@ -1334,6 +1382,7 @@ export function parseToolStepContent(content: string): {
     detail,
     path,
     input,
+    output,
   };
 }
 
@@ -1528,11 +1577,15 @@ function preferRicherTool(
   else if (bDetail !== aDetail) pick = bDetail > aDetail ? b : a;
   else pick = b;
   const other = pick === a ? b : a;
-  // Never drop a known call argument when coalescing host-family rows.
+  // Never drop a known call argument / captured output when coalescing rows.
   return {
     ...pick,
     input: pick.input || other.input,
     path: pick.path || other.path,
+    output:
+      (pick.output || "").length >= (other.output || "").length
+        ? pick.output || other.output
+        : other.output,
   };
 }
 
@@ -1576,6 +1629,12 @@ export function compactMessageSegments(
           path: raw.path || prev.path,
           // Coalesce must not wipe a known call argument.
           input: raw.input || prev.input,
+          // …nor the captured output (terminal tick carries it; later sparse
+          // status ticks would otherwise blank the expand body).
+          output:
+            (raw.output || "").length >= (prev.output || "").length
+              ? raw.output || prev.output
+              : prev.output,
           toolKind: raw.toolKind || prev.toolKind,
         };
         continue;

--- a/src/lib/toolDisplay.test.ts
+++ b/src/lib/toolDisplay.test.ts
@@ -7,6 +7,7 @@ import {
   toolDetailTail,
   toolExpandBody,
   toolInputDisplay,
+  toolOutputBody,
 } from "./toolDisplay";
 
 const enTr = (key: string, params?: Record<string, string | number>) => {
@@ -157,5 +158,49 @@ describe("toolDisplay", () => {
     );
     expect(failed.hasBody).toBe(true);
     expect(failed.failHintShort.length).toBeGreaterThan(0);
+  });
+
+  it("toolExpandBody shows real output and echoes the bash command", () => {
+    const body = toolExpandBody(
+      {
+        toolCallId: "t3",
+        toolKind: "run_terminal_command",
+        title: "Execute `ls -la`",
+        input: "ls -la",
+        output: "total 0\ndrwxr-xr-x 2 user staff 64 Jan 1 00:00 .",
+      },
+      false,
+    );
+    expect(body.hasBody).toBe(true);
+    expect(body.outputBody).toContain("total 0");
+    expect(body.command).toBe("ls -la");
+    // When output is present, the legacy detail tail is suppressed.
+    expect(body.detailTail).toBe("");
+  });
+
+  it("toolExpandBody is expandable for read-only tools once output is captured", () => {
+    // read_file used to be non-expandable (no command/query in rawInput →
+    // detail empty → hasBody false). With real output it must open.
+    const body = toolExpandBody(
+      {
+        toolCallId: "t4",
+        toolKind: "read_file",
+        title: "Read `README.md`",
+        input: "README.md",
+        output: "# Title\nsome body",
+      },
+      false,
+    );
+    expect(body.hasBody).toBe(true);
+    expect(body.outputBody).toContain("# Title");
+    expect(body.command).toBe(""); // not a bash tool
+  });
+
+  it("toolOutputBody elides the middle of very long output", () => {
+    const long = Array.from({ length: 1000 }, (_, i) => `line ${i}`).join("\n");
+    const body = toolOutputBody(long, 100);
+    expect(body).toContain("line 0");
+    expect(body).toContain("line 999");
+    expect(body).toMatch(/… \d+ more lines …/);
   });
 });

--- a/src/lib/toolDisplay.ts
+++ b/src/lib/toolDisplay.ts
@@ -366,6 +366,8 @@ export type ToolLabelSource = {
   input?: string | null;
   path?: string | null;
   detail?: string | null;
+  /** Real tool output (ACP `content[]`) — the expand body when present. */
+  output?: string | null;
 };
 
 /** i18n translator — accepts message keys used by chat.tool.* / chat.browsed. */
@@ -451,9 +453,39 @@ function browseUrlForPrimaryLabel(tool: ToolLabelSource): string {
   return fallback || "…";
 }
 
+/** Max lines kept for a tool output body (UI scrolls inside the expand box). */
+const TOOL_OUTPUT_BODY_MAX_LINES = 400;
+
 /**
- * Expand body for tool step secondary detail (fail hint + detail tail).
- * Shared by TimelineToolRow and phase GrokActivityStepRow.
+ * Trim a tool output body: keep the head (where errors and the first rows of a
+ * file / listing live) and the tail, eliding the middle. Reading a 3k-line file
+ * must not push 3k rows into the DOM.
+ */
+export function toolOutputBody(
+  output: string | null | undefined,
+  maxLines = TOOL_OUTPUT_BODY_MAX_LINES,
+): string {
+  const raw = (output || "").replace(/\r\n/g, "\n").replace(/\s+$/, "");
+  if (!raw) return "";
+  const lines = raw.split("\n");
+  if (lines.length <= maxLines) return raw;
+  const head = Math.ceil(maxLines * 0.7);
+  const tail = maxLines - head;
+  const elided = lines.length - head - tail;
+  return [
+    ...lines.slice(0, head),
+    `… ${elided} more lines …`,
+    ...lines.slice(lines.length - tail),
+  ].join("\n");
+}
+
+/**
+ * Expand body for a tool step.
+ *
+ * Precedence: real tool output (ACP `content[]`) wins; `detail` is only a
+ * fallback for rows recorded before output capture existed (and for Host
+ * side-channels, whose body *is* the detail). `command` is surfaced separately
+ * so the UI can echo `$ cmd` above the output like a terminal transcript.
  */
 export function toolExpandBody(
   seg: ToolLabelSource & { isError?: boolean; status?: string },
@@ -462,6 +494,10 @@ export function toolExpandBody(
   failHint: string;
   failHintShort: string;
   detailTail: string;
+  /** Full tool output (elided in the middle when very long). */
+  outputBody: string;
+  /** Shell command to echo above the output, when this is a bash-ish tool. */
+  command: string;
   hasBody: boolean;
 } {
   const failHint = failed
@@ -470,9 +506,27 @@ export function toolExpandBody(
   const failHintShort =
     failHint.length > 72 ? `${failHint.slice(0, 71)}…` : failHint;
   const hostSide = /^(host-vision|host-x)/i.test(seg.toolCallId || "");
-  const detailTail = toolDetailTail(seg.detail, hostSide ? 24 : 8);
+  const outputBody = toolOutputBody(seg.output);
+  // Detail is the call argument echoed back — showing it under a label that
+  // already says the same thing is noise. Keep it only when there is no real
+  // output to show (legacy rows, Host side-channels).
+  const detailTail = outputBody ? "" : toolDetailTail(seg.detail, hostSide ? 24 : 8);
+  const bucket = classifyToolKind(seg.toolKind, seg.title, seg.toolCallId);
+  const command =
+    bucket === "bash"
+      ? (seg.input || bashArgFromToolTitle(seg.title) || "").trim()
+      : "";
   const hasBody =
     !!failHintShort ||
+    !!outputBody ||
+    (!!command && !!outputBody) ||
     (!!detailTail && detailTail !== failHint && detailTail !== failHintShort);
-  return { failHint, failHintShort, detailTail, hasBody };
+  return {
+    failHint,
+    failHintShort,
+    detailTail,
+    outputBody,
+    command,
+    hasBody,
+  };
 }


### PR DESCRIPTION
## What

Three coupled defects, verified against real session journals before fixing.

### 1. Tool output was never captured → tools couldn’t expand
`extract_tool_ui_fields` only read `rawInput` (command/query/description), so `detail` was the **call argument echoed back** — never the result. `read_file` / `grep` / `list_dir` produced no expandable body (`hasBody=false` → row rendered as a `<span>`, not a clickable `<button>`).

- New `extract_tool_output` reads ACP `content[]` (text items + diff headers).
- Emit on `session://tool`; persist behind a sentinel so the legacy `tool_step|` body parses byte-identically (old journals unaffected).
- New shared `ToolExpandBody` renders a terminal-transcript block (`$ cmd` above a boxed, internally-scrolling output), used by both `TimelineToolRow` and `GrokActivityStepRow`.

### 2. Machine tool name was unreachable → bare `tool` label
The `_meta` key is literally `"x.ai/tool"`; JSON Pointer requires the inner slash escaped as `~1` (RFC 6901). `/_meta/x.ai/tool/name` never resolved, so on sparse terminal updates the journal collapsed to `tool_step|failed|tool|tool`.

- New `tool_meta()` / `tool_meta_str()` helpers use the escaped pointer.
- Fixed both call sites (`session_manager/types` + `acp_client` permission).

### 3. Plan mode could not be cancelled
`mode: "plan"` was persisted into global settings **and** project defaults, so every new session inherited it; `PlanStatusBar` rendered no exit control for `kind==="plan_mode"`.

- Plan mode is transient/per-session: `sticky_mode` drops it at every global/project persistence site; `non_plan_mode` heals the value already on disk.
- The idle plan chip now has a close button (`exitPlanMode`) that flips back to agent.

## Verification
- `updates.jsonl` (146 real tool events): `toolName` appears 0 times, `kind` only 44 — the broken pointer was the sole identity source on sparse payloads.
- Reproduced the bare-`tool` rows in `sessions/96521dc7…/messages.json` (`tool_step|failed|tool|tool`).

## Tests
+5 Rust (pointer escape, enrich recovery, output extraction, plan-mode healing/stickiness), +5 TS (output expand body, read-file expandability, long-output elision, sentinel parser, output threading + survives sparse tick).

Base of a stack of 3. Merge order: **#547 → #548 → #549**.