### PR TITLE
fix(ask-user): show the questionnaire when rpcId is 0

### DIFF
--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -6,6 +6,7 @@
 import { useEffect, useRef } from "react";
 import * as api from "@/lib/api";
 import { isMirrorClient } from "@/lib/mirrorTransport";
+import { isValidAskUserPayload } from "@/lib/askUserPayload";
 import {
   applyContextCompact,
   applyGeneratedImage,
@@ -1513,7 +1514,10 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
         await track(
           api.listen<AskUserPayload>("session://ask_user", (p) => {
             if (cancelled) return;
-            if (!p?.rpcId || !Array.isArray(p.questions) || !p.questions.length) {
+            // rpcId may legitimately be 0 (JSON-RPC ids start at 0). A truthy
+            // guard here used to drop id=0 questions, so the modal never showed
+            // and the turn hung until cancelled.
+            if (!isValidAskUserPayload(p)) {
               return;
             }
             if (p.sessionId) {

--- a/src/lib/askUserPayload.test.ts
+++ b/src/lib/askUserPayload.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { isValidAskUserPayload } from "./askUserPayload";
+import type { AskUserPayload } from "./session";
+
+function payload(over: Partial<AskUserPayload> = {}): AskUserPayload {
+  return {
+    rpcId: 1,
+    sessionId: "s1",
+    questions: [{ question: "q?", options: [], header: "" } as any],
+    ...over,
+  };
+}
+
+describe("isValidAskUserPayload", () => {
+  it("accepts a valid payload", () => {
+    expect(isValidAskUserPayload(payload())).toBe(true);
+  });
+
+  it("accepts rpcId = 0 (JSON-RPC ids start at 0)", () => {
+    // Regression: a truthy guard dropped id=0 questions, the modal never
+    // showed, and the turn hung until cancelled.
+    expect(isValidAskUserPayload(payload({ rpcId: 0 }))).toBe(true);
+  });
+
+  it("rejects missing rpcId", () => {
+    expect(isValidAskUserPayload(payload({ rpcId: undefined as any }))).toBe(
+      false,
+    );
+    expect(isValidAskUserPayload(payload({ rpcId: null as any }))).toBe(false);
+  });
+
+  it("rejects empty / missing questions", () => {
+    expect(isValidAskUserPayload(payload({ questions: [] }))).toBe(false);
+    expect(
+      isValidAskUserPayload(payload({ questions: undefined as any })),
+    ).toBe(false);
+  });
+
+  it("rejects null / undefined payload", () => {
+    expect(isValidAskUserPayload(null)).toBe(false);
+    expect(isValidAskUserPayload(undefined)).toBe(false);
+  });
+});

--- a/src/lib/askUserPayload.ts
+++ b/src/lib/askUserPayload.ts
@@ -1,0 +1,24 @@
+/**
+ * Validation for the live `_x.ai/ask_user_question` payload.
+ *
+ * Extracted from the `session://ask_user` listener so the rpcId=0 regression
+ * (a truthy guard used to drop valid id-0 questions and hang the turn) can be
+ * unit-tested in isolation.
+ */
+import type { AskUserPayload } from "./session";
+
+/**
+ * A live ask-user payload is showable when it has an rpc id and at least one
+ * question. `rpcId` may legitimately be 0 (JSON-RPC ids start at 0), so the
+ * check is an explicit null test — never truthy.
+ */
+export function isValidAskUserPayload(
+  p: Partial<AskUserPayload> | null | undefined,
+): p is AskUserPayload {
+  return (
+    !!p &&
+    p.rpcId != null &&
+    Array.isArray(p.questions) &&
+    p.questions.length > 0
+  );
+}


### PR DESCRIPTION
## What

The `session://ask_user` listener validated the payload with `!p?.rpcId`, which treated a valid JSON-RPC id of 0 as missing. The agent’s first `_x.ai/ask_user_question` carries rpc id 0, so the modal was silently dropped and the turn hung with the stop button showing “working” until the user cancelled.

Replace the truthy guard with an explicit null check (`p.rpcId != null`). Extracted into `isValidAskUserPayload` so the rpcId=0 regression is unit-tested.

## Reproduced from a real session log
```
acp ask_user_question id=0 questions=1 tool_call=call_00_…
<2 min hang — modal never shown>
acp → ask_user_question reply id=0 outcome=cancelled
```

## Tests
+5 `isValidAskUserPayload` (accepts id 0, rejects missing rpcId / empty questions / null payload).

## Scope
Independent of the tool-timeline / thinking stack (#547–#551); branches off `main`.