### PR TITLE
fix(session): retry delayed post-turn journal reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- **Delayed post-turn history flush (#554)**: Journal reconciliation now retries over a short bounded window after a successful prompt RPC, so final assistant/tool rows that reach CLI history slightly late are recovered without reopening the session. Per-session locking prevents races with an immediate next send; disk reads run off the async executor and remain platform-neutral.
+
+**中文 · 修复**
+- **回合结束历史稍晚落盘（#554）**：prompt RPC 成功后在短时有界窗口内重试 journal 对账，无需重开会话即可补回稍晚写入 CLI 历史的最终回复/工具记录；会话级锁避免与紧接着的下一次发送竞争，磁盘读取移出异步执行线程，且不依赖平台特性。
+
 ## [0.2.15] - 2026-08-12
 
 > **Highlight:** Tool/activity timeline shows real expandable output and explore groups; session open never hangs on MCP/OAuth; ask-user with rpcId 0 works; sticky composer target and optimistic Stop; project drag-reorder.

--- a/docs/llm-wiki/session-continuity.md
+++ b/docs/llm-wiki/session-continuity.md
@@ -85,10 +85,14 @@ gates) as forever-busy, or demote/focus for other chats stays blocked.
 
 **Turn end journal heal (P0):** after every successful `session/prompt` Ok, Host
 force-finishes sticky Streaming (#522) **and** runs
-`try_reconcile_linked_session` to pull missing assistant/tool rows from agent
-`chat_history`. Emits `session://journal_reconciled` so the viewed chat rehydrates
-even when stream chunks never painted the final body (user saw endless thinking
-while CLI already had the full answer).
+`try_reconcile_linked_session` over a short bounded retry window to pull missing
+assistant/tool rows from agent `chat_history`. Filesystem reads run off the async
+executor; every idempotent pass is aggregated before one
+`session://journal_reconciled` event. This covers both dropped stream chunks and
+a CLI history flush that becomes visible just after the prompt RPC returns
+(user saw endless thinking while CLI already had the full answer). A per-session
+journal lock prevents read-modify-write loss against an immediate next send; if
+that newer turn is already running, the previous turn's remaining retries stop.
 
 **UI transcript ownership (P0, #529):** `openSession` points `viewingSessionId`
 at the target **before** disk journal load. Until messages swap, stream /

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -24,6 +24,7 @@ mod control;
 mod events;
 mod events_bg;
 mod journal;
+mod post_turn_reconcile;
 mod process;
 mod stream;
 mod turn;
@@ -40,7 +41,7 @@ mod routing_tests;
 #[cfg(test)]
 mod stall_tests;
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use parking_lot::Mutex;
 
@@ -70,6 +71,10 @@ pub struct SessionManager {
         std::sync::Mutex<std::collections::HashMap<String, std::collections::HashMap<String, ToolIdentity>>>,
     /// Serialize connect / park / unpark so openSession prefetch cannot race first send.
     pub(super) connect_lock: tokio::sync::Mutex<()>,
+    /// Per-session locks that serialize a prompt's user-journal append with
+    /// post-turn reconciliation. Retry sleeps never hold these locks, and one
+    /// chat never delays another chat's send.
+    pub(super) post_turn_journal_locks: Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl Default for SessionManager {
@@ -87,7 +92,20 @@ impl SessionManager {
             prewarm: Mutex::new(PrewarmState::None),
             tool_identities: std::sync::Mutex::new(std::collections::HashMap::new()),
             connect_lock: tokio::sync::Mutex::new(()),
+            post_turn_journal_locks: Mutex::new(HashMap::new()),
         }
+    }
+
+    pub(super) fn post_turn_journal_lock(
+        &self,
+        app_session_id: &str,
+    ) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self.post_turn_journal_locks.lock();
+        Arc::clone(
+            locks
+                .entry(app_session_id.to_string())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
+        )
     }
 
     /// True when any live or background session is mid-turn (streaming / tools / connect).

--- a/src-tauri/src/session_manager/post_turn_reconcile.rs
+++ b/src-tauri/src/session_manager/post_turn_reconcile.rs
@@ -1,0 +1,178 @@
+use std::{future::Future, time::Duration};
+
+// The CLI normally flushes chat_history before the prompt RPC resolves, but
+// filesystem scheduling can make the final rows visible slightly later. Keep
+// this window short and bounded while covering both a late first write and an
+// incrementally flushed turn.
+const POST_TURN_RECONCILE_DELAYS: [Duration; 4] = [
+    Duration::ZERO,
+    Duration::from_millis(125),
+    Duration::from_millis(375),
+    Duration::from_millis(750),
+];
+
+async fn retry_reconcile_with<F, Fut>(delays: &[Duration], mut reconcile: F) -> u32
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Option<u32>>,
+{
+    let mut total_changed = 0_u32;
+    for delay in delays {
+        if !delay.is_zero() {
+            tokio::time::sleep(*delay).await;
+        }
+        // Reconciliation is idempotent. Run every bounded attempt instead of
+        // stopping at the first change so a partially visible history file can
+        // contribute its remaining rows on a later pass.
+        let Some(changed) = reconcile().await else {
+            break;
+        };
+        total_changed = total_changed.saturating_add(changed);
+    }
+    total_changed
+}
+
+pub(super) async fn reconcile_linked_session(
+    manager: &super::SessionManager,
+    app_session_id: &str,
+    completed_turn_id: &str,
+) -> u32 {
+    let app_session_id = app_session_id.to_string();
+    let completed_turn_id = completed_turn_id.to_string();
+    let journal_lock = manager.post_turn_journal_lock(&app_session_id);
+    retry_reconcile_with(&POST_TURN_RECONCILE_DELAYS, || {
+        let app_session_id = app_session_id.clone();
+        let completed_turn_id = completed_turn_id.clone();
+        let journal_lock = journal_lock.clone();
+        async move {
+            // A new turn can begin while this bounded retry is sleeping. Lock
+            // against its user-message append, then stop before importing any
+            // partial rows that belong to that newer turn.
+            let _journal_guard = journal_lock.lock().await;
+            let superseded = manager
+                .with_session_mut(&app_session_id, |session| {
+                    session.prompt_in_flight
+                        && session.active_turn_id.as_deref() != Some(completed_turn_id.as_str())
+                })
+                .unwrap_or(false);
+            if superseded {
+                return None;
+            }
+
+            let session_for_log = app_session_id.clone();
+            match tokio::task::spawn_blocking(move || {
+                crate::cli_sessions::try_reconcile_linked_session(&app_session_id)
+            })
+            .await
+            {
+                Ok(changed) => Some(changed),
+                Err(error) => {
+                    tracing::warn!(
+                        target: "session",
+                        session = %session_for_log,
+                        error = %error,
+                        "post-turn journal reconcile task failed"
+                    );
+                    Some(0)
+                }
+            }
+        }
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{retry_reconcile_with, POST_TURN_RECONCILE_DELAYS};
+    use std::{
+        future::ready,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
+    const NO_DELAYS: [Duration; 4] = [Duration::ZERO; 4];
+
+    #[test]
+    fn retry_window_starts_immediately_and_stays_bounded() {
+        assert_eq!(POST_TURN_RECONCILE_DELAYS[0], Duration::ZERO);
+        assert!(POST_TURN_RECONCILE_DELAYS.len() <= 4);
+        assert!(POST_TURN_RECONCILE_DELAYS.iter().sum::<Duration>() <= Duration::from_secs(2));
+    }
+
+    #[tokio::test]
+    async fn retries_after_no_change_and_aggregates_incremental_flushes() {
+        let outcomes = Arc::new([0_u32, 2, 0, 3]);
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let changed = retry_reconcile_with(&NO_DELAYS, {
+            let outcomes = Arc::clone(&outcomes);
+            let attempts = Arc::clone(&attempts);
+            move || {
+                let index = attempts.fetch_add(1, Ordering::SeqCst);
+                ready(Some(outcomes[index]))
+            }
+        })
+        .await;
+
+        assert_eq!(changed, 5);
+        assert_eq!(attempts.load(Ordering::SeqCst), NO_DELAYS.len());
+    }
+
+    #[tokio::test]
+    async fn exhausts_the_bounded_window_when_history_never_changes() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let changed = retry_reconcile_with(&NO_DELAYS, {
+            let attempts = Arc::clone(&attempts);
+            move || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                ready(Some(0))
+            }
+        })
+        .await;
+
+        assert_eq!(changed, 0);
+        assert_eq!(attempts.load(Ordering::SeqCst), NO_DELAYS.len());
+    }
+
+    #[tokio::test]
+    async fn saturates_the_aggregated_change_count() {
+        let outcomes = Arc::new([u32::MAX, 1]);
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let changed = retry_reconcile_with(&NO_DELAYS[..2], {
+            let outcomes = Arc::clone(&outcomes);
+            let attempts = Arc::clone(&attempts);
+            move || {
+                let index = attempts.fetch_add(1, Ordering::SeqCst);
+                ready(Some(outcomes[index]))
+            }
+        })
+        .await;
+
+        assert_eq!(changed, u32::MAX);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn stops_retrying_when_a_new_turn_supersedes_the_completed_one() {
+        let outcomes = Arc::new([Some(2_u32), None, Some(99)]);
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let changed = retry_reconcile_with(&NO_DELAYS[..3], {
+            let outcomes = Arc::clone(&outcomes);
+            let attempts = Arc::clone(&attempts);
+            move || {
+                let index = attempts.fetch_add(1, Ordering::SeqCst);
+                ready(outcomes[index])
+            }
+        })
+        .await;
+
+        assert_eq!(changed, 2);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+}

--- a/src-tauri/src/session_manager/turn.rs
+++ b/src-tauri/src/session_manager/turn.rs
@@ -79,6 +79,11 @@ impl SessionManager {
             return Err("no active session".into());
         };
 
+        // A delayed reconcile from the preceding turn performs a journal
+        // read-modify-write. Keep this user append mutually exclusive with
+        // each reconcile attempt so neither can overwrite the other's rows.
+        let journal_lock = self.post_turn_journal_lock(&app_sid);
+        let journal_guard = journal_lock.lock().await;
         let open = self.with_session_mut(&app_sid, |s| {
             if let Some(target) = session_id.as_deref() {
                 if s.app_session_id != target {
@@ -167,6 +172,7 @@ impl SessionManager {
                 turn_id,
             ))
         });
+        drop(journal_guard);
         let (backend, app_sid, acp, agent_sid, agent_prompt, message_id, turn_id) = match open {
             Some(Ok(v)) => v,
             Some(Err(e)) => return Err(e),
@@ -524,16 +530,16 @@ impl SessionManager {
                             }
                         }
                     });
-                    // Always best-effort pull missing assistant/tool rows from
-                    // agent chat_history after the prompt RPC completes. Stream
-                    // path can leave App journal on a partial mid-sentence while
-                    // the CLI already has the full turn (user: stuck thinking,
-                    // no final result — agent finished, UI never got body).
-                    let changed =
-                        crate::cli_sessions::try_reconcile_linked_session(&turn_sid);
                     if need_emit {
                         mgr.emit_for_session(&app2, &turn_sid);
                     }
+                    // Always best-effort pull missing assistant/tool rows from
+                    // agent chat_history after the prompt RPC completes. The
+                    // CLI's final disk flush can trail the RPC response, so use
+                    // a short bounded retry window off the async worker thread.
+                    let changed =
+                        post_turn_reconcile::reconcile_linked_session(&mgr, &turn_sid, &turn_id)
+                            .await;
                     if changed > 0 {
                         let _ = app2.emit(
                             "session://journal_reconciled",


### PR DESCRIPTION
Closes #554.

## What changed

- retry linked-session journal reconciliation after a successful prompt RPC at 0 / 125 / 375 / 750 ms
- run every filesystem reconciliation attempt through `tokio::task::spawn_blocking`
- aggregate idempotent changes and emit one existing `session://journal_reconciled` event
- serialize reconciliation and the next prompt's user-journal append with a per-App-session async lock
- stop the old retry window when a newer turn has already started
- document the continuity rule and add an Unreleased changelog entry

## Why

The v0.2.15 immediate reconciliation closes the common dropped-stream path, but a final or incremental `chat_history.jsonl` flush can become visible just after the prompt RPC returns. A one-shot read then sees no change (or only a partial answer) and the journal remains incomplete until a later session open.

## Cross-platform notes

The change uses only platform-neutral Rust/Tokio primitives and the existing session/path reconciliation abstraction:

- no Windows APIs, path separators, or polling APIs
- no macOS/Linux-specific behavior changes
- per-session locking avoids cross-chat blocking
- all blocking filesystem work is isolated with `spawn_blocking`

The branch is based on `upstream/main` at `c6a38201` (v0.2.15). GitHub CI should exercise Windows, macOS, and Linux; local execution was on Windows.

## Validation

Passed locally on Windows:

- focused retry tests: 5 passed
- full Rust suite: 1121 passed, 0 failed, 1 ignored
- `cargo clippy --all-targets -- -W clippy::all` (exit 0; existing warnings only)
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm test`: 5102 passed
- `pnpm build:ui`

Known upstream-main baseline failures, reproduced without modifying their files:

- `pnpm lint`: existing `src/lib/session.test.ts:2148` optional-chain non-null assertion
- `cargo fmt --all --check`: existing repository-wide formatting drift; the new module passes standalone `rustfmt --check`

## Test coverage

The new unit tests cover:

- immediate first attempt and a bounded <= 2-second schedule
- initial no-change followed by delayed history visibility
- incremental flushes aggregated across attempts
- no-change exhaustion at the fixed attempt count
- saturation of the emitted change count
- cancellation of remaining old-turn retries when a newer turn starts