### PR TITLE
fix(providers): allow custom route without official login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@
 
 3. When adding models or permission modes, update `src/lib/grokCatalog.ts` **and** `docs/llm-wiki/catalog.md`.
 
-3b. Default `session_data_mode` is **shared** (`GROK_HOME=~/.grok`, same as terminal Grok Build). **Independent** mode uses `~/.grok-app/agent-home` and is where App rewrites agent `config.toml` (custom providers, privacy, workflows, …). Shared mode refuses rewriting `~/.grok`. Do not leave relay keys only in App secrets.
+3b. Default `session_data_mode` is **shared** (`GROK_HOME=~/.grok` for **official** route, same as terminal Grok Build). **Independent** mode uses `~/.grok-app/agent-home` and is where App rewrites agent `config.toml` (custom providers, privacy, workflows, …). **Custom route always spawns with agent-home** even when session mode is shared (relay keys never require official login). Shared mode refuses rewriting `~/.grok`. Do not leave relay keys only in App secrets.
 
 4. Prefer real Grok Build CLI behavior (`grok models`, `--always-approve`, `--effort`).
 

--- a/docs/llm-wiki/account.md
+++ b/docs/llm-wiki/account.md
@@ -26,8 +26,9 @@ CLI auth is shared with Grok Build TUI (hot-reload of `auth.json` is CLI-side).
 | Step | Path |
 |------|------|
 | `grok login` / App login | writes `~/.grok/auth.json` |
-| Agent spawn (`session_data_mode=shared`, product default) | `GROK_HOME=~/.grok` |
-| Agent spawn (`session_data_mode=independent`) | `GROK_HOME=~/.grok-app/agent-home` |
+| Agent spawn (`shared` + official) | `GROK_HOME=~/.grok` |
+| Agent spawn (`shared` + custom route) | `GROK_HOME=~/.grok-app/agent-home` (relay config; no official login required) |
+| Agent spawn (`independent`) | `GROK_HOME=~/.grok-app/agent-home` |
 
 Host **must** sync `auth.json` into agent-home on login and before each ACP spawn; otherwise the UI shows signed-in while the agent reports `auth_kind=none` → HTTP 401. Logout clears both copies.
 

--- a/docs/llm-wiki/providers.md
+++ b/docs/llm-wiki/providers.md
@@ -17,12 +17,13 @@ Desktop never reimplements tools/sampling. It is an ACP client + UI shell.
 
 ## Agent profile (`GROK_HOME`)
 
-| Session data mode | `GROK_HOME` for spawned agent |
-|-------------------|-------------------------------|
-| `shared` (default) | `~/.grok` (same home as terminal Grok Build CLI) |
-| `independent` | `~/.grok-app/agent-home` (or `$GROK_APP_HOME/agent-home`) |
+| Session data mode | Active route | `GROK_HOME` for spawned agent |
+|-------------------|--------------|-------------------------------|
+| `shared` (default) | official | `~/.grok` (same home as terminal Grok Build CLI) |
+| `shared` (default) | **custom** | `~/.grok-app/agent-home` (App-owned; never rewrites `~/.grok`) |
+| `independent` | official or custom | `~/.grok-app/agent-home` (or `$GROK_APP_HOME/agent-home`) |
 
-Custom providers are written to **`$GROK_HOME/config.toml`** as `[model.<id>]` sections so the agent can use `base_url` + `api_key` without OAuth fallback.
+Custom providers are always written to **App agent-home `config.toml`** as `[model.<id>]` sections (`base_url` + `api_key`). When a custom route is active, spawn forces that agent-home even if session data mode is `shared`, so a third-party key alone is enough — official OAuth / API key is **not** required (#557). Shared mode still refuses rewriting the user's personal `~/.grok`.
 
 ## Provider model (L2)
 
@@ -109,12 +110,12 @@ Grok Build 0.2.x will send **OIDC** when `auth.json` is present — even if the 
 
 Verified working combinations:
 
-| Route | `[models].default` | agent `--model` | agent-home `auth.json` |
-|-------|--------------------|-----------------|------------------------|
-| Custom relay | provider id (`yunyi`) | **provider id** | **removed** (api_key only) |
-| Official | `grok` | catalog id (`grok-4.5`) | **synced** from `~/.grok` |
+| Route | `[models].default` | agent `--model` | `GROK_HOME` | agent-home `auth.json` |
+|-------|--------------------|-----------------|-------------|------------------------|
+| Custom relay | provider id (`yunyi`) | **provider id** | **agent-home** (even if session mode is shared) | **removed** (api_key only) |
+| Official | `grok` | catalog id (`grok-4.5`) | shared → `~/.grok`; independent → agent-home | **synced** from `~/.grok` when using agent-home |
 
-Host must rebind both sides on every switch and before each ACP spawn (`prepare_route_auth_for_agent` + `agent_spawn_model_id`). Composer catalog `modelId` remains the official selection preference; spawn resolves the channel id separately. **Alternate activate entry:** picking a custom provider row in the composer model menu also calls `providers_activate` (same Host path as Settings **Use**).
+Host must rebind both sides on every switch and before each ACP spawn (`prepare_route_auth_for_agent` + `agent_spawn_model_id` + `resolve_inference_grok_home`). Composer catalog `modelId` remains the official selection preference; spawn resolves the channel id separately. **Alternate activate entry:** picking a custom provider row in the composer model menu also calls `providers_activate` (same Host path as Settings **Use**).
 
 ## Host commands
 

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -1134,14 +1134,10 @@ impl AcpClient {
         //   `--permission-mode` is top-level `grok` only — not under `grok agent`.
         let empty_mcp_servers = opts.empty_mcp_servers;
         let home_override = opts.grok_home_override.clone();
-        let grok_home = if let Some(ref h) = home_override {
-            h.clone()
-        } else {
-            crate::paths::resolve_agent_grok_home(session_data_mode)
-        };
-        let _ = std::fs::create_dir_all(&grok_home);
         // Route class is process-scoped (auth material + config.toml). Official
         // aux override home is always OIDC-side; main home follows active_route.
+        // Custom relays live only in agent-home — force that GROK_HOME even when
+        // session_data_mode=shared so third-party keys work without official login (#557).
         let custom_route = if home_override.is_some() {
             false
         } else {
@@ -1150,13 +1146,28 @@ impl AcpClient {
                 crate::providers::ActiveRoute::Custom { .. }
             )
         };
+        let grok_home = if let Some(ref h) = home_override {
+            h.clone()
+        } else {
+            crate::paths::resolve_inference_grok_home(session_data_mode, custom_route)
+        };
+        let _ = std::fs::create_dir_all(&grok_home);
+        // Prep agent-home when independent *or* custom (shared+custom still uses agent-home).
         // Side-channel with explicit home: never touch main agent-home auth.
-        if home_override.is_none() && session_data_mode != "shared" {
+        let agent_home_prep = home_override.is_none()
+            && crate::paths::needs_agent_home_spawn_prep(session_data_mode, custom_route);
+        // Preference syncs write independent-only; for shared+custom force independent
+        // so agent-home receives permission / feature pins the relay process needs.
+        let prep_mode = if custom_route {
+            "independent"
+        } else {
+            session_data_mode
+        };
+        if agent_home_prep {
             // Official → sync OIDC; custom → strip auth.json (api_key only).
             crate::providers::prepare_route_auth_for_agent();
             if let Some(ref pol) = opts.permission_policy {
-                let _ =
-                    crate::agent_prefs::sync_permission_to_agent_profile(session_data_mode, pol);
+                let _ = crate::agent_prefs::sync_permission_to_agent_profile(prep_mode, pol);
             }
         }
 
@@ -1238,40 +1249,36 @@ impl AcpClient {
         // Soft-fail older CLIs for GROK_SUBAGENT_WORKTREE_SNAPSHOT env.
         let cli_ver = version_raw.clone();
 
-        if session_data_mode != "shared" {
+        if agent_home_prep {
             let _ = crate::agent_subagents::sync_subagents_to_agent_profile(
-                session_data_mode,
+                prep_mode,
                 subagents_enabled,
             );
-            let _ = crate::agent_memory::sync_memory_to_agent_profile(
-                session_data_mode,
-                memory_enabled,
-            );
+            let _ = crate::agent_memory::sync_memory_to_agent_profile(prep_mode, memory_enabled);
             let _ = crate::agent_todo_gate::sync_todo_gate_to_agent_profile(
-                session_data_mode,
+                prep_mode,
                 todo_gate_enabled,
                 todo_gate_max_fires,
             );
             let _ = crate::agent_subagent_wt_snap::sync_subagent_wt_snap_to_agent_profile(
-                session_data_mode,
+                prep_mode,
                 subagent_wt_snap,
             );
             let _ = crate::agent_auto_wake::sync_auto_wake_to_agent_profile(
-                session_data_mode,
+                prep_mode,
                 auto_wake_enabled,
             );
             let _ = crate::agent_two_pass_compaction::sync_two_pass_compaction_to_agent_profile(
-                session_data_mode,
+                prep_mode,
                 two_pass_compaction,
             );
             // Custom + inject: PreToolUse hook blocks native Imagine (ACP ignores
             // --disallowed-tools which is headless-only). Official route / inject
             // off removes the managed hook file.
-            let _ =
-                crate::official_aux::sync_native_media_block_hook_for_current(session_data_mode);
+            let _ = crate::official_aux::sync_native_media_block_hook_for_current(prep_mode);
             // Heal duplicate keys left by older upsert bugs (e.g. yolo vs yolo_mode).
             // Valid configs are never rewritten. Soft-fail so spawn still attempts.
-            match crate::agent_home_config::ensure_agent_home_config_sane(session_data_mode) {
+            match crate::agent_home_config::ensure_agent_home_config_sane(prep_mode) {
                 Ok(report) if report.changed => {
                     tracing::info!(
                         target: "acp_client",

--- a/src-tauri/src/agent_workflows.rs
+++ b/src-tauri/src/agent_workflows.rs
@@ -717,10 +717,15 @@ fn run_workflow_inner(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     process_util::apply_cli_env_std(&mut cmd);
-    let grok_home = crate::paths::resolve_agent_grok_home(&settings.session_data_mode);
+    let custom_route = matches!(
+        crate::providers::active_route(),
+        crate::providers::ActiveRoute::Custom { .. }
+    );
+    let grok_home =
+        crate::paths::resolve_inference_grok_home(&settings.session_data_mode, custom_route);
     let _ = std::fs::create_dir_all(&grok_home);
     cmd.env("GROK_HOME", &grok_home);
-    if settings.session_data_mode != "shared" {
+    if crate::paths::needs_agent_home_spawn_prep(&settings.session_data_mode, custom_route) {
         crate::providers::prepare_route_auth_for_agent();
     }
     proxy::apply_to_std_command(&mut cmd);

--- a/src-tauri/src/batch_agents.rs
+++ b/src-tauri/src/batch_agents.rs
@@ -177,10 +177,14 @@ pub fn run_batch_headless(
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         process_util::apply_cli_env_std(&mut cmd);
-        let grok_home = crate::paths::resolve_agent_grok_home(&mode);
+        let custom_route = matches!(
+            crate::providers::active_route(),
+            crate::providers::ActiveRoute::Custom { .. }
+        );
+        let grok_home = crate::paths::resolve_inference_grok_home(&mode, custom_route);
         let _ = std::fs::create_dir_all(&grok_home);
         cmd.env("GROK_HOME", &grok_home);
-        if mode != "shared" {
+        if crate::paths::needs_agent_home_spawn_prep(&mode, custom_route) {
             crate::providers::prepare_route_auth_for_agent();
         }
         proxy::apply_to_std_command(&mut cmd);

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -94,11 +94,33 @@ pub fn agent_config_toml() -> PathBuf {
 
 /// Resolve GROK_HOME for a spawned agent process.
 pub fn resolve_agent_grok_home(session_data_mode: &str) -> PathBuf {
-    if session_data_mode == "shared" {
+    if session_data_mode.trim().eq_ignore_ascii_case("shared") {
         return crate::process_util::user_home().join(".grok");
     }
     let _ = ensure_app_dirs();
     agent_home_dir()
+}
+
+/// Whether the active inference route is a custom OpenAI-compatible relay.
+///
+/// Custom providers always live in App `agent-home/config.toml` (never written
+/// into shared `~/.grok`). Spawn must point `GROK_HOME` there even when
+/// `session_data_mode=shared` so third-party keys work without official login.
+pub fn resolve_inference_grok_home(session_data_mode: &str, custom_route: bool) -> PathBuf {
+    if custom_route {
+        let _ = ensure_app_dirs();
+        return agent_home_dir();
+    }
+    resolve_agent_grok_home(session_data_mode)
+}
+
+/// Whether spawn prep must touch App agent-home (auth strip/sync, config heal).
+///
+/// - Independent mode always uses agent-home.
+/// - Shared + official uses `~/.grok` and skips agent-home rewrites.
+/// - Shared + custom still uses agent-home (relay `config.toml` + api_key).
+pub fn needs_agent_home_spawn_prep(session_data_mode: &str, custom_route: bool) -> bool {
+    custom_route || !session_data_mode.trim().eq_ignore_ascii_case("shared")
 }
 
 pub fn projects_file() -> PathBuf {
@@ -251,5 +273,47 @@ mod tests {
         let root = PathBuf::from("/tmp/session");
         assert!(resolve_session_relative_media(&root, "../etc/passwd").is_none());
         assert!(resolve_session_relative_media(&root, "/etc/passwd").is_none());
+    }
+
+    #[test]
+    fn inference_home_custom_route_uses_agent_home_even_when_shared() {
+        let shared_official = resolve_inference_grok_home("shared", false);
+        assert!(
+            shared_official.ends_with(".grok"),
+            "shared+official → ~/.grok, got {}",
+            shared_official.display()
+        );
+
+        let shared_custom = resolve_inference_grok_home("shared", true);
+        assert!(
+            shared_custom.ends_with("agent-home"),
+            "shared+custom → agent-home, got {}",
+            shared_custom.display()
+        );
+
+        let indep_custom = resolve_inference_grok_home("independent", true);
+        assert!(
+            indep_custom.ends_with("agent-home"),
+            "independent+custom → agent-home, got {}",
+            indep_custom.display()
+        );
+
+        let indep_official = resolve_inference_grok_home("independent", false);
+        assert!(
+            indep_official.ends_with("agent-home"),
+            "independent+official → agent-home, got {}",
+            indep_official.display()
+        );
+    }
+
+    #[test]
+    fn agent_home_spawn_prep_gate() {
+        assert!(needs_agent_home_spawn_prep("shared", true));
+        assert!(!needs_agent_home_spawn_prep("shared", false));
+        assert!(needs_agent_home_spawn_prep("independent", false));
+        assert!(needs_agent_home_spawn_prep("independent", true));
+        // Case-insensitive shared.
+        assert!(!needs_agent_home_spawn_prep("Shared", false));
+        assert!(needs_agent_home_spawn_prep("SHARED", true));
     }
 }

--- a/src-tauri/src/remote_im/grok_agent.rs
+++ b/src-tauri/src/remote_im/grok_agent.rs
@@ -33,21 +33,30 @@ pub fn resolve_grok_binary() -> PathBuf {
     PathBuf::from("grok")
 }
 
-/// Same GROK_HOME the App uses for ACP (independent → agent-home, shared → ~/.grok).
+/// Same GROK_HOME the App uses for ACP inference.
+/// Independent / custom route → agent-home; shared + official → ~/.grok.
 /// Without this, `/r` resumes with an agent session id that only exists under agent-home
 /// and the CLI reports "Session not found locally" + remote 404.
 pub fn resolve_remote_grok_home() -> PathBuf {
     let mode = crate::store::load_settings().session_data_mode;
-    crate::paths::resolve_agent_grok_home(&mode)
+    let custom_route = matches!(
+        crate::providers::active_route(),
+        crate::providers::ActiveRoute::Custom { .. }
+    );
+    crate::paths::resolve_inference_grok_home(&mode, custom_route)
 }
 
 fn apply_agent_env(cmd: &mut Command) {
     let grok_home = resolve_remote_grok_home();
     let _ = std::fs::create_dir_all(&grok_home);
     cmd.env("GROK_HOME", &grok_home);
-    // Independent mode may need App-synced auth/providers (same as ACP spawn path).
+    // Independent / custom: App-synced auth/providers (same as ACP spawn path).
     let mode = crate::store::load_settings().session_data_mode;
-    if mode != "shared" {
+    let custom_route = matches!(
+        crate::providers::active_route(),
+        crate::providers::ActiveRoute::Custom { .. }
+    );
+    if crate::paths::needs_agent_home_spawn_prep(&mode, custom_route) {
         crate::providers::prepare_route_auth_for_agent();
     }
     // GUI-spawned processes often lack ~/.grok/bin on PATH.
@@ -404,16 +413,20 @@ mod tests {
     }
 
     #[test]
-    fn remote_grok_home_matches_app_session_data_mode() {
+    fn remote_grok_home_matches_app_inference_home() {
         let mode = crate::store::load_settings().session_data_mode;
+        let custom_route = matches!(
+            crate::providers::active_route(),
+            crate::providers::ActiveRoute::Custom { .. }
+        );
         let home = resolve_remote_grok_home();
-        let expected = crate::paths::resolve_agent_grok_home(&mode);
+        let expected = crate::paths::resolve_inference_grok_home(&mode, custom_route);
         assert_eq!(home, expected);
-        // Independent default: must NOT be bare ~/.grok when App stores sessions in agent-home.
-        if mode != "shared" {
+        // Independent or custom route: agent-home (not bare ~/.grok).
+        if mode != "shared" || custom_route {
             assert!(
                 home.ends_with("agent-home") || home.to_string_lossy().contains("agent-home"),
-                "independent GROK_HOME should be agent-home, got {}",
+                "inference GROK_HOME should be agent-home when independent/custom, got {}",
                 home.display()
             );
         }

--- a/src-tauri/src/streaming_acp_ndjson.rs
+++ b/src-tauri/src/streaming_acp_ndjson.rs
@@ -110,10 +110,14 @@ fn resolve_binary(manual_path: Option<&str>) -> Option<PathBuf> {
 
 fn apply_agent_env(cmd: &mut Command) {
     let mode = crate::store::load_settings().session_data_mode;
-    let grok_home = crate::paths::resolve_agent_grok_home(&mode);
+    let custom_route = matches!(
+        crate::providers::active_route(),
+        crate::providers::ActiveRoute::Custom { .. }
+    );
+    let grok_home = crate::paths::resolve_inference_grok_home(&mode, custom_route);
     let _ = std::fs::create_dir_all(&grok_home);
     cmd.env("GROK_HOME", &grok_home);
-    if mode != "shared" {
+    if crate::paths::needs_agent_home_spawn_prep(&mode, custom_route) {
         crate::providers::prepare_route_auth_for_agent();
     }
     crate::process_util::ensure_home_env_std(cmd);


### PR DESCRIPTION
## Summary

Without an official API key / OAuth login, configuring a third-party/custom model still could not run. Custom providers are stored in App **agent-home** `config.toml`, but the default `session_data_mode=shared` always spawned agents with `GROK_HOME=~/.grok`, which never saw those relay sections and required official auth. This PR forces inference `GROK_HOME` to agent-home whenever the active route is custom (including shared mode), so a custom provider + API key alone is enough.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Root cause

1. Custom providers always write to `~/.grok-app/agent-home/config.toml` (never into shared `~/.grok`).
2. After the product default became `session_data_mode=shared`, ACP/headless spawn used `resolve_agent_grok_home("shared")` → `~/.grok`.
3. Spawn also skipped `prepare_route_auth_for_agent` in shared mode (auth strip / agent-home prep).
4. Result: custom-only setup activated a relay in the UI, but the agent process never loaded `base_url` + `api_key`, and without official OIDC it could not run at all.

## Fix

- Add pure helpers `resolve_inference_grok_home` / `needs_agent_home_spawn_prep` in `paths.rs`.
- Custom active route → always `GROK_HOME=agent-home` + agent-home spawn prep (auth strip, config heal, prefs pin), even when session mode is shared.
- Official + shared → still `~/.grok`; does not rewrite the user's personal CLI home.
- Wire the same home/prep rule into ACP spawn, streaming NDJSON, batch agents, workflows, and Remote IM.
- Document the route × mode matrix in `docs/llm-wiki/providers.md` (+ brief `account.md` / `AGENTS.md`).

## Test plan

- [x] `cargo test --lib paths::tests` (includes shared+custom → agent-home and prep gate)
- [x] `cargo test --lib remote_im::grok_agent`
- [ ] Manual: fresh settings with **no** official login / key; `session_data_mode=shared`; add custom provider + API key → **Use** → send a message (expect success against relay)
- [ ] Manual: official route still works when CLI auth / official key is present
- [ ] Manual: activate custom then official again recycles warm agents (`provider_route`)

## Checklist
- [ ] I ran `pnpm typecheck` and `pnpm test` (Rust-only change; not required for this PR)
- [x] I ran `cargo test` for affected lib tests
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — N/A (no new UI strings)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

## Residual risks / follow-ups

- Custom-route sessions under shared mode write journals under agent-home (not `~/.grok/sessions`); CLI session import still only scans shared `~/.grok`.
- Shared+custom forces independent-style preference pins into agent-home on spawn; does not rewrite `~/.grok`.
- Warm processes still depend on `providers_activate` / recycle; stale warm shells after manual disk edits of config remain a pre-existing edge case.

Fixes #557