### PR TITLE
fix(context): compaction and usage chip honesty for 500k

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -11458,8 +11458,15 @@ export function AppWorkbench() {
         activeCustomProvider,
         modelId,
         models: availableModels,
+        // Prefer live agent occupancy denominator (Grok Build 1.0 → 500k).
+        agentContextWindow: contextUsage.agentContextWindow,
       }),
-    [activeCustomProvider, modelId, availableModels],
+    [
+      activeCustomProvider,
+      modelId,
+      availableModels,
+      contextUsage.agentContextWindow,
+    ],
   );
   useEffect(() => {
     if (
@@ -11471,14 +11478,34 @@ export function AppWorkbench() {
       api.modelsListAvailable()
         .then((res) => {
           if (!res?.models?.length) return;
-          setAvailableModels((prev) =>
-            prev.map((model) => {
-              const live = res.models.find((m) => m.id === model.id);
-              return live?.contextWindow != null
-                ? { ...model, contextWindow: live.contextWindow }
-                : model;
-            }),
-          );
+          // Full merge so official live windows (500k) replace cold-start null
+          // / stale catalog values — never leave a silent 200k official default.
+          setAvailableModels((prev) => {
+            const prevById = new Map(prev.map((m) => [m.id, m]));
+            return res.models.map((m) => {
+              const prior = prevById.get(m.id);
+              return {
+                id: m.id,
+                label: m.label || m.id,
+                source: m.source,
+                isDefault: m.isDefault,
+                reasoningEfforts:
+                  m.reasoningEfforts?.length
+                    ? m.reasoningEfforts.map((e) => ({
+                        id: e.id,
+                        value: e.value,
+                        label: e.label,
+                        description: e.description,
+                        isDefault: e.isDefault,
+                      }))
+                    : prior?.reasoningEfforts,
+                contextWindow:
+                  m.contextWindow != null && m.contextWindow > 0
+                    ? m.contextWindow
+                    : (prior?.contextWindow ?? null),
+              };
+            });
+          });
         })
         .catch(() => {});
     }

--- a/src/components/ContextUsageChip.tsx
+++ b/src/components/ContextUsageChip.tsx
@@ -12,6 +12,7 @@ import { IconArrowsMinimize } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { useFloatingMenu } from "@/lib/floatingMenu";
 import {
+  formatCompactBeforeAfterRange,
   formatTokenCount,
   hasContextUsageData,
   resolveContextUsageSurface,
@@ -71,18 +72,24 @@ function formatLastCompactDetail(
   labels: ContextUsageChipLabels,
   locale: string,
 ): string {
-  if (
-    last.tokensBefore != null &&
-    last.tokensAfter != null &&
-    Number.isFinite(last.tokensBefore) &&
-    Number.isFinite(last.tokensAfter)
-  ) {
-    return labels.tokensRange
-      .replace("{before}", formatTokenCount(last.tokensBefore, locale))
-      .replace("{after}", formatTokenCount(last.tokensAfter, locale));
-  }
+  // Honest partial range when only before or after is known (no invented pair).
+  const range = formatCompactBeforeAfterRange(
+    last.tokensBefore,
+    last.tokensAfter,
+    { locale, template: labels.tokensRange },
+  );
+  if (range) return range;
   if (last.note?.trim()) return last.note.trim();
   return last.trigger === "manual" ? labels.manual : labels.auto;
+}
+
+function sourceLabel(
+  source: ContextUsageDisplay["source"],
+  labels: ContextUsageChipLabels,
+): string {
+  if (source === "known") return labels.sourceKnown;
+  if (source === "estimated") return labels.sourceEstimated;
+  return labels.sourceUnknown;
 }
 
 /**
@@ -268,6 +275,9 @@ export function ContextUsageChip({
               <span className="ctx-chip__k">{labels.current}</span>
               <span className="ctx-chip__v">
                 <span className="ctx-chip__tokens">{display.label}</span>
+                <span className="ctx-chip__src">
+                  {sourceLabel(display.source, labels)}
+                </span>
               </span>
             </div>
             {display.windowSize != null && display.windowSize > 0 ? (
@@ -307,9 +317,9 @@ export function ContextUsageChip({
                 locale={locale}
               />
             ) : null}
-            <div className="ctx-chip__row">
+            <div className="ctx-chip__row ctx-chip__row--wrap">
               <span className="ctx-chip__k">{labels.lastCompact}</span>
-              <span className="ctx-chip__v">
+              <span className="ctx-chip__v ctx-chip__v--wrap">
                 {lastDetail ?? labels.lastCompactNone}
               </span>
             </div>

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -77,7 +77,10 @@ import { setDraft } from "@/lib/composerDraftStore";
 import { formatMessageTime, formatRelativeTime } from "@/lib/accountUi";
 import type { MessageTimeFormat } from "@/lib/messageTimeFormatPref";
 import { computeMessageLength } from "@/lib/messageLength";
-import { formatTokenCount } from "@/lib/contextUsage";
+import {
+  formatCompactBeforeAfterRange,
+  isContextCompactMessage,
+} from "@/lib/contextUsage";
 import type { ModelOption } from "@/lib/grokCatalog";
 import { useStickToBottom } from "@/hooks/useStickToBottom";
 import { useChatMessageVirtualizer } from "@/hooks/useChatMessageVirtualizer";
@@ -891,29 +894,19 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
     );
   }
 
-  if (
-    m.marker === "context_compact" ||
-    (m.role === "tool" &&
-      (m.content?.startsWith("context_compact") ||
-        m.compactMeta))
-  ) {
+  if (isContextCompactMessage(m)) {
     const meta = m.compactMeta;
     const auto = (meta?.trigger || "auto") !== "manual";
     const title = auto
       ? tr("compact.bannerAuto")
       : tr("compact.bannerManual");
-    let detail = "";
-    if (
-      meta?.tokensBefore != null &&
-      meta?.tokensAfter != null &&
-      Number.isFinite(meta.tokensBefore) &&
-      Number.isFinite(meta.tokensAfter)
-    ) {
-      detail = tr("compact.tokensRange", {
-        before: formatTokenCount(meta.tokensBefore, locale),
-        after: formatTokenCount(meta.tokensAfter, locale),
-      });
-    } else if (meta?.note) {
+    // Honest before→after when either side is known; never invent a pair.
+    let detail =
+      formatCompactBeforeAfterRange(meta?.tokensBefore, meta?.tokensAfter, {
+        locale,
+        template: tr("compact.tokensRange"),
+      }) ?? "";
+    if (!detail && meta?.note) {
       detail = meta.note;
     }
     const summary = meta?.summaryPreview?.trim();
@@ -2294,8 +2287,7 @@ export function ConversationThread({
         (m.role === "tool" &&
           !isToolStepMessage(m) &&
           !isEndOfTurnMarker(m.marker) &&
-          m.marker !== "context_compact" &&
-          !(m.content?.startsWith("context_compact") || m.compactMeta));
+          !isContextCompactMessage(m));
       return estimateChatRowHeight({
         contentLength: body.length,
         thoughtLength: m.thought?.length ?? 0,

--- a/src/i18n/messages/en/workspace.ts
+++ b/src/i18n/messages/en/workspace.ts
@@ -307,7 +307,7 @@ export const enWorkspace = {
   "context.chipAria": "Context usage",
   "context.chipTipUnknown": "Context tokens unknown until the agent reports usage or you compact",
   "context.chipTipEstimated": "Estimated from visible chat (~4 chars/token). Not model tokenizer output",
-  "context.chipTipKnown": "Tokens reported after last compaction",
+  "context.chipTipKnown": "Context occupancy reported by the CLI (not a multi-call billing total)",
   "context.menuTitle": "Context usage",
   "context.current": "Current",
   "context.sourceKnown": "Reported",

--- a/src/i18n/messages/zh-TW/workspace.ts
+++ b/src/i18n/messages/zh-TW/workspace.ts
@@ -307,7 +307,7 @@ export const zhTWWorkspace = {
   "context.chipAria": "上下文用量",
   "context.chipTipUnknown": "代理尚未回報用量；壓縮後可顯示 token 數",
   "context.chipTipEstimated": "依可見對話粗估（約 4 字元/token），非模型精確分詞",
-  "context.chipTipKnown": "上次壓縮後回報的 token 數",
+  "context.chipTipKnown": "CLI 回報的上下文佔用（非多輪計費合計）",
   "context.menuTitle": "上下文用量",
   "context.current": "目前",
   "context.sourceKnown": "已回報",

--- a/src/i18n/messages/zh/workspace.ts
+++ b/src/i18n/messages/zh/workspace.ts
@@ -307,7 +307,7 @@ export const zhWorkspace = {
   "context.chipAria": "上下文用量",
   "context.chipTipUnknown": "代理尚未上报用量；压缩后可显示 token 数",
   "context.chipTipEstimated": "按可见对话粗估（约 4 字符/token），非模型精确分词",
-  "context.chipTipKnown": "上次压缩后上报的 token 数",
+  "context.chipTipKnown": "CLI 上报的上下文占用（非多轮计费合计）",
   "context.menuTitle": "上下文用量",
   "context.current": "当前",
   "context.sourceKnown": "已上报",

--- a/src/lib/contextUsage.test.ts
+++ b/src/lib/contextUsage.test.ts
@@ -31,6 +31,9 @@ import {
   resolveContextUsageDisplay,
   resolveContextUsageSurface,
   resolveOccupancyPercent,
+  resolveOccupancyWindow,
+  isContextCompactContent,
+  isContextCompactMessage,
   saveSessionUsageSnapshot,
   loadSessionUsageSnapshot,
   clearSessionUsageSnapshot,
@@ -941,6 +944,113 @@ describe("occupancy vs billing classification", () => {
         source: "turn_completed",
       }),
     ).toBe(false);
+  });
+});
+
+describe("isContextCompactContent / isContextCompactMessage", () => {
+  it("accepts structured journal markers only", () => {
+    expect(isContextCompactContent("context_compact")).toBe(true);
+    expect(isContextCompactContent("context_compact|manual")).toBe(true);
+    expect(
+      isContextCompactContent("context_compact|auto|tokens:100->40\nkept"),
+    ).toBe(true);
+    expect(isContextCompactContent("context_compact\nsummary")).toBe(true);
+  });
+
+  it("rejects tool titles that merely contain the word compact", () => {
+    expect(
+      isContextCompactContent("Execute print('ALL POSTS compact') finished"),
+    ).toBe(false);
+    expect(isContextCompactContent("context_compaction_report")).toBe(false);
+    expect(isContextCompactContent("run compact now")).toBe(false);
+    expect(
+      isContextCompactMessage({
+        role: "tool",
+        content: "python print('compact')",
+      }),
+    ).toBe(false);
+  });
+
+  it("honors explicit marker even without content prefix", () => {
+    expect(
+      isContextCompactMessage({
+        marker: "context_compact",
+        role: "tool",
+        content: "ignored",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("window resolve + display surface (500k honesty)", () => {
+  it("resolveOccupancyWindow prefers agent 500k over catalog 200k", () => {
+    const state = reduceContextUsage(INITIAL_CONTEXT_USAGE, {
+      type: "usage",
+      totalTokens: 100_000,
+      contextWindow: 500_000,
+      source: "auto_compact_started",
+    });
+    expect(resolveOccupancyWindow(state, 200_000)).toBe(500_000);
+    expect(resolveOccupancyWindow(state, null)).toBe(500_000);
+  });
+
+  it("catalog 500k is the ring denominator when agent window unset", () => {
+    const state = reduceContextUsage(INITIAL_CONTEXT_USAGE, {
+      type: "usage",
+      totalTokens: 156_385,
+      source: "context_size",
+    });
+    expect(resolveOccupancyWindow(state, 500_000)).toBe(500_000);
+    const d = resolveContextUsageDisplay(state, [], "zh", 500_000);
+    expect(d.windowSize).toBe(500_000);
+    expect(d.percent).toBe(31);
+    expect(d.source).toBe("known");
+    expect(resolveContextUsageSurface(d)).toBe("visible");
+  });
+
+  it("empty session surface stays hidden; soft-unknown after compact without counts", () => {
+    const empty = resolveContextUsageDisplay(INITIAL_CONTEXT_USAGE, [], "zh", 500_000);
+    expect(resolveContextUsageSurface(empty)).toBe("hidden");
+    expect(empty.windowSize).toBe(500_000);
+
+    const soft = resolveContextUsageDisplay(
+      reduceContextUsage(INITIAL_CONTEXT_USAGE, {
+        type: "compact",
+        trigger: "manual",
+        messageId: "c1",
+      }),
+      [{ id: "c1", role: "tool", marker: "context_compact" }],
+      "zh",
+      500_000,
+    );
+    expect(soft.source).toBe("unknown");
+    expect(soft.label).toBe("—");
+    expect(resolveContextUsageSurface(soft)).toBe("soft_unknown");
+  });
+
+  it("estimated vs known labels stay honest on the display surface", () => {
+    const estimated = resolveContextUsageDisplay(
+      INITIAL_CONTEXT_USAGE,
+      [{ id: "u", role: "user", content: "a".repeat(40) }],
+      "zh",
+      500_000,
+    );
+    expect(estimated.source).toBe("estimated");
+    expect(estimated.label.startsWith("~")).toBe(true);
+    expect(estimated.windowSize).toBe(500_000);
+
+    const known = resolveContextUsageDisplay(
+      reduceContextUsage(INITIAL_CONTEXT_USAGE, {
+        type: "usage",
+        totalTokens: 12_000,
+        source: "context_size",
+      }),
+      [],
+      "zh",
+      500_000,
+    );
+    expect(known.source).toBe("known");
+    expect(known.label.startsWith("~")).toBe(false);
   });
 });
 

--- a/src/lib/contextUsage.ts
+++ b/src/lib/contextUsage.ts
@@ -414,11 +414,7 @@ export function hydrateContextUsageFromMessages(
 ): ContextUsageState {
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i]!;
-    const isCompact =
-      m.marker === "context_compact" ||
-      (m.role === "tool" &&
-        (m.content?.startsWith("context_compact") || !!m.compactMeta));
-    if (!isCompact) continue;
+    if (!isContextCompactMessage(m)) continue;
     const meta = m.compactMeta;
     const tokensAfter = finiteToken(meta?.tokensAfter);
     const tokensBefore = finiteToken(meta?.tokensBefore);
@@ -486,10 +482,42 @@ function isCjkCodePoint(code: number): boolean {
   );
 }
 
+/**
+ * True for host journal compact marker content (not free-text tool titles).
+ * Matches bare `context_compact`, `context_compact|…`, or multiline header.
+ * Does **not** match titles that merely contain the word "compact".
+ */
+export function isContextCompactContent(
+  content: string | null | undefined,
+): boolean {
+  if (!content) return false;
+  return (
+    content === "context_compact" ||
+    content.startsWith("context_compact|") ||
+    content.startsWith("context_compact\n")
+  );
+}
+
+/**
+ * Whether a chat/journal row is a real context-compact marker.
+ * Prefer explicit `marker`; fall back only to structured content prefix.
+ * Never treats tool titles containing "compact" as compaction.
+ */
+export function isContextCompactMessage(m: {
+  marker?: string | null;
+  role?: string | null;
+  content?: string | null;
+  compactMeta?: unknown;
+}): boolean {
+  if (m.marker === "context_compact") return true;
+  if (m.role === "tool" && isContextCompactContent(m.content)) return true;
+  return false;
+}
+
 /** Markers that are host journal chrome, not model context content. */
 function isJournalChromeMessage(m: ContextUsageMessage): boolean {
   return (
-    m.marker === "context_compact" ||
+    isContextCompactMessage(m) ||
     m.marker === "turn_cancelled" ||
     m.marker === "turn_end"
   );

--- a/src/lib/grokCatalog.test.ts
+++ b/src/lib/grokCatalog.test.ts
@@ -313,6 +313,57 @@ describe("resolveContextWindow", () => {
     ).toBe(256000);
   });
 
+  it("returns live official 500k from catalog (Grok Build 1.0)", () => {
+    const models: ModelOption[] = [
+      { id: "grok-4.5", label: "Grok 4.5", contextWindow: 500_000 },
+    ];
+    expect(
+      resolveContextWindow({
+        activeCustomProvider: null,
+        modelId: "grok-4.5",
+        models,
+      }),
+    ).toBe(500_000);
+  });
+
+  it("prefers agent-reported window over catalog (occupancy honesty)", () => {
+    const models: ModelOption[] = [
+      { id: "grok-4.5", label: "Grok 4.5", contextWindow: 128_000 },
+    ];
+    expect(
+      resolveContextWindow({
+        activeCustomProvider: null,
+        modelId: "grok-4.5",
+        models,
+        agentContextWindow: 500_000,
+      }),
+    ).toBe(500_000);
+  });
+
+  it("agent window wins even on custom route (CLI denominator)", () => {
+    expect(
+      resolveContextWindow({
+        activeCustomProvider: { contextWindow: 200_000 },
+        modelId: "custom-model",
+        agentContextWindow: 500_000,
+      }),
+    ).toBe(500_000);
+  });
+
+  it("never uses custom 200k default for official when catalog/agent unknown", () => {
+    const models: ModelOption[] = [
+      { id: "grok-4.5", label: "Grok 4.5" },
+    ];
+    expect(
+      resolveContextWindow({
+        activeCustomProvider: null,
+        modelId: "grok-4.5",
+        models,
+      }),
+    ).toBeNull();
+    expect(DEFAULT_CUSTOM_CONTEXT_WINDOW).toBe(200_000);
+  });
+
   it("returns null for official model without contextWindow", () => {
     const models: ModelOption[] = [
       { id: "grok-4", label: "Grok 4" },

--- a/src/lib/grokCatalog.ts
+++ b/src/lib/grokCatalog.ts
@@ -76,8 +76,10 @@ export const DEFAULT_MODEL_ID =
   GROK_BUILD_MODELS.find((m) => m.isDefault)?.id ?? "grok-4.5";
 
 /**
- * Fallback context window (tokens) for custom providers that have not set one.
- * Official models prefer the live `contextWindow` from `initialize` / cache.
+ * Fallback context window (tokens) for **custom provider** channels only.
+ * Never use this for the official Grok route — official windows come from
+ * live catalog / `initialize` / agent occupancy (`context_window`, often
+ * 500_000 on Grok Build 1.0). Unknown official → `null` (chip hides %).
  */
 export const DEFAULT_CUSTOM_CONTEXT_WINDOW = 200000;
 
@@ -467,21 +469,51 @@ export function findModel(
 /**
  * Resolve the effective context window (tokens) for the composer context.
  *
- * - Custom provider route: prefer the channel's `contextWindow`, else
- *   `DEFAULT_CUSTOM_CONTEXT_WINDOW` (channels without an explicit window
- *   still get a sensible cap for the "% used" chip).
- * - Official route: prefer the live model `contextWindow` from
- *   `initialize` / cache; `null` when unknown (chip hides the % row).
+ * Precedence:
+ * 1. Agent-reported CLI denominator (`auto_compact_started.context_window` /
+ *    occupancy usage) when positive — matches `/session-info`.
+ * 2. Custom provider route: channel `contextWindow`, else
+ *    {@link DEFAULT_CUSTOM_CONTEXT_WINDOW} (200k). **Custom only.**
+ * 3. Official route: live model `contextWindow` from `models_cache` /
+ *    `initialize` merge. Never invent 200k when live says 500k (or any
+ *    other catalog value). `null` when unknown (chip hides the % row).
  */
 export function resolveContextWindow(opts: {
   activeCustomProvider?: { contextWindow?: number | null } | null;
   modelId: string;
   models?: ModelOption[];
+  /**
+   * Agent-reported context window (tokens). When set and positive, wins
+   * over catalog so Grok Build 1.0 occupancy (500k) is never replaced by a
+   * stale catalog or the custom-channel 200k default.
+   */
+  agentContextWindow?: number | null;
 }): number | null {
-  const { activeCustomProvider, modelId, models = GROK_BUILD_MODELS } = opts;
+  const {
+    activeCustomProvider,
+    modelId,
+    models = GROK_BUILD_MODELS,
+    agentContextWindow,
+  } = opts;
+  if (
+    agentContextWindow != null &&
+    Number.isFinite(agentContextWindow) &&
+    agentContextWindow > 0
+  ) {
+    return Math.floor(agentContextWindow);
+  }
   if (activeCustomProvider) {
-    return activeCustomProvider.contextWindow ?? DEFAULT_CUSTOM_CONTEXT_WINDOW;
+    const custom = activeCustomProvider.contextWindow;
+    if (custom != null && Number.isFinite(custom) && custom > 0) {
+      return Math.floor(custom);
+    }
+    return DEFAULT_CUSTOM_CONTEXT_WINDOW;
   }
   const m = findModel(modelId, models);
-  return m?.contextWindow ?? null;
+  const catalog = m?.contextWindow;
+  if (catalog != null && Number.isFinite(catalog) && catalog > 0) {
+    return Math.floor(catalog);
+  }
+  // Official / unknown: never fall back to DEFAULT_CUSTOM_CONTEXT_WINDOW.
+  return null;
 }

--- a/src/lib/mapStoredMessages.ts
+++ b/src/lib/mapStoredMessages.ts
@@ -66,7 +66,10 @@ export function mapStoredMessageToChat(
   const rawMarker = m.marker || undefined;
   const marker =
     rawMarker ||
-    (m.role === "tool" && content.startsWith("context_compact")
+    (m.role === "tool" &&
+    (content === "context_compact" ||
+      content.startsWith("context_compact|") ||
+      content.startsWith("context_compact\n"))
       ? "context_compact"
       : m.role === "tool" && content.startsWith("tool_step|")
         ? "tool_step"

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1424,7 +1424,12 @@ export function parseToolStepContent(content: string): {
 export function parseCompactContent(
   content: string,
 ): ContextCompactMeta | null {
-  if (!content.startsWith("context_compact|") && !content.startsWith("context_compact")) {
+  // Structured journal only — not free-text titles containing "compact".
+  if (
+    content !== "context_compact" &&
+    !content.startsWith("context_compact|") &&
+    !content.startsWith("context_compact\n")
+  ) {
     return null;
   }
   const [header, ...rest] = content.split("\n");

--- a/src/styles/chat.part4.css
+++ b/src/styles/chat.part4.css
@@ -144,6 +144,10 @@
   font-size: 12px;
 }
 
+.ctx-chip__row--wrap {
+  align-items: flex-start;
+}
+
 .ctx-chip__k {
   color: var(--text-tertiary);
   flex-shrink: 0;
@@ -160,6 +164,16 @@
   align-items: baseline;
   justify-content: flex-end;
   gap: 6px;
+}
+
+/* Last-compact range / long notes must wrap, not clip the menu. */
+.ctx-chip__v--wrap {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  text-overflow: unset;
+  overflow: visible;
+  display: block;
 }
 
 .ctx-chip__tokens {


### PR DESCRIPTION
## Summary
Polish ContextUsageChip + compaction banners for Grok Build 1.0 **500K context honesty**.

- **Official window**: prefer agent occupancy denominator / live catalog (500k). Never apply the custom-channel **200k** default on the official path; unknown stays `null` (chip hides %).
- **Session catalog refresh**: full merge of live `models_list_available` so cold-start null / stale windows are replaced when cache reports 500k.
- **Compaction banner**: wrap long last-compact values; honest before→after when either side is known (`formatCompactBeforeAfterRange`); stricter `isContextCompactMessage` (structured journal only — not tool titles containing “compact”).
- **Empty/unknown honesty**: chip menu shows Reported / Estimated / Unknown next to the total; tipKnown clarifies CLI occupancy (not multi-call billing).
- **Tests**: window resolve + display surface + compact content detection.

## Test plan
- [x] `npx vitest run src/lib/contextUsage.test.ts src/lib/grokCatalog.test.ts` (93 passed)
- [ ] Manual: official grok-4.5 session — chip window/denominator is 50万 (500k), not 20万
- [ ] Manual: auto-compact banner shows before→after when host provides tokens; long notes wrap
- [ ] Manual: tool title with the word “compact” does not paint a compact banner
- [ ] Manual: empty session hides chip; after compact without counts soft-shows “—” with Unknown source