### PR TITLE
fix(plan): close plan mode enter review exit loop

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -200,6 +200,7 @@ import {
   restorePlanFromPersistence,
   type SessionPlanState
 } from "@/lib/planSession";
+import { shouldExitComposerPlanModeAfterDecision } from "@/lib/planModePro";
 import {
   collectActivitySessions,
   countQuitBlockingSessions,
@@ -2080,7 +2081,7 @@ export function AppWorkbench() {
   const [planHistoryPreview, setPlanHistoryPreview] =
     useState<PlanHistoryEntry | null>(null);
   /** Non-empty archive — drives Plan empty-state history CTA. */
-  const [, setPlanHistoryNonEmpty] = useState(
+  const [planHistoryNonEmpty, setPlanHistoryNonEmpty] = useState(
     () => loadPlanHistory().length > 0,
   );
   /** Request-changes note modal (optional free-form feedback). */
@@ -9807,10 +9808,35 @@ export function AppWorkbench() {
         rpcId: null,
         userClosed: false,
       });
+      // Product loop: Approve & build → agent mode so the idle plan chip
+      // does not stick after the review gate closes.
+      if (
+        shouldExitComposerPlanModeAfterDecision({
+          decision: "approved",
+          composerMode: modeRef.current,
+        })
+      ) {
+        setMode("agent");
+        setGoalMode(false);
+        void api
+          .composerPrefsSet({
+            projectId: activeProject?.id ?? null,
+            sessionId: session.sessionId ?? null,
+            mode: "agent",
+          })
+          .catch((e) => showToast(String(e), 4000));
+      }
     } catch (e) {
       showToast(String(e), 4500);
     }
-  }, [archivePlanDecision, plan.rpcId, showToast, writePlanForViewing]);
+  }, [
+    activeProject?.id,
+    archivePlanDecision,
+    plan.rpcId,
+    session.sessionId,
+    showToast,
+    writePlanForViewing,
+  ]);
 
   /**
    * Resolve pending plan review as "cancelled" (revise).
@@ -9977,9 +10003,12 @@ export function AppWorkbench() {
     });
   }, [archivePlanDecision, tr, writePlanForViewing]);
 
-  /** Open resource pane Plan review (replaces scroll-to-card “详情”). */
+  /** Open Side Workbench Plan tab (review / waiting empty / open-in-resources). */
   const openPlanInResource = useCallback(() => {
     planOpenedAsideRef.current = true;
+    setSideWorkbench((s) =>
+      openSideTab(s, "plan", { name: "side.tab.plan" }),
+    );
     openAsidePane();
     setPlanFocusKey((k) => k + 1);
   }, [openAsidePane]);
@@ -18801,6 +18830,7 @@ export function AppWorkbench() {
                 approve: tr("plan.approve"),
                 changes: tr("plan.changes"),
                 dismiss: tr("plan.dismiss"),
+                exitPlanMode: tr("plan.exitPlanMode"),
                 expand: tr("planBar.expand"),
                 clearGoal: tr("planBar.clearGoal"),
                 aria: tr("planBar.aria"),
@@ -20217,9 +20247,16 @@ export function AppWorkbench() {
                 }
                 plan={plan}
                 planFocusKey={planFocusKey}
+                planChrome={{
+                  composerMode: mode,
+                  planEnabled,
+                  userClosed: plan.userClosed,
+                  hasHistory: planHistoryNonEmpty,
+                }}
                 onApprovePlan={() => void approvePlan()}
                 onRequestPlanChanges={() => openRequestPlanChanges()}
                 onDismissPlan={() => void dismissPlan()}
+                onOpenPlanHistory={() => setShowPlanHistory(true)}
                 openRequest={resourceOpenTarget}
                 onOpenRequestConsumed={() => setResourceOpenTarget(null)}
                 onCloseSide={closeAsidePane}
@@ -20227,7 +20264,6 @@ export function AppWorkbench() {
                   if (phoneLayout) return;
                   if (!expanded) setSideDockComposer(false);
                 }}
-              
                 skillInfos={skillInfos}
                 skillsLoading={skillsLoading}
                 skillsLoadError={skillsLoadError}

--- a/src/components/PlanStatusBar.tsx
+++ b/src/components/PlanStatusBar.tsx
@@ -22,6 +22,8 @@ export type PlanStatusBarLabels = {
   approve: string;
   changes: string;
   dismiss: string;
+  /** Exit bare plan-mode chip (composer plan → agent). Falls back to dismiss. */
+  exitPlanMode?: string;
   expand: string;
   /** Exit goal mode (goal strip only). */
   clearGoal: string;
@@ -225,8 +227,8 @@ export function PlanStatusBar({
             type="button"
             className="icon-btn plan-bar__close"
             onClick={() => onExitPlanMode()}
-            aria-label={labels.dismiss}
-            title={labels.dismiss}
+            aria-label={labels.exitPlanMode ?? labels.dismiss}
+            title={labels.exitPlanMode ?? labels.dismiss}
             data-testid="plan-status-exit-plan-mode"
           >
             <IconClose size={14} />

--- a/src/components/side-workbench/PlanTab.tsx
+++ b/src/components/side-workbench/PlanTab.tsx
@@ -1,37 +1,96 @@
 /**
- * Process-only Plan tab body — wraps PlanReviewPanel when plan data present.
+ * Process-only Plan tab body — PlanReviewPanel when live; contextual empty
+ * states (parity with ResourceViewer plan empty) otherwise.
  */
 
 import { useMemo } from "react";
 import { createT, type Locale } from "@/i18n";
 import { PlanReviewPanel } from "@/components/PlanReviewPanel";
 import type { PlanReviewState } from "@/lib/planBody";
+import { resolvePlanResourceEmptyState } from "@/lib/planModePro";
+
+export type PlanTabChrome = {
+  /** Composer access mode (`plan` | `agent` | …). */
+  composerMode?: string;
+  /** Settings: allow plan mode (false → spawn --no-plan). Default true. */
+  planEnabled?: boolean;
+  /** User hard-dismissed this plan cycle. */
+  userClosed?: boolean;
+  /** Local plan history archive is non-empty. */
+  hasHistory?: boolean;
+};
 
 export type PlanTabProps = {
   locale: Locale | string;
   plan?: PlanReviewState | null;
   planFocusKey?: number | null;
+  /** PLAN-MODE-PRO empty-state context. */
+  planChrome?: PlanTabChrome | null;
   onApprovePlan?: () => void;
   onRequestPlanChanges?: (note?: string) => void;
   onDismissPlan?: () => void;
+  /** Open local plan history archive. */
+  onOpenPlanHistory?: () => void;
 };
 
 export function PlanTab({
   locale,
   plan = null,
   planFocusKey = null,
+  planChrome = null,
   onApprovePlan,
   onRequestPlanChanges,
   onDismissPlan,
+  onOpenPlanHistory,
 }: PlanTabProps) {
   const tr = useMemo(() => createT(locale as Locale), [locale]);
+
+  const planResourceEmpty = useMemo(
+    () =>
+      resolvePlanResourceEmptyState({
+        planVisible: !!plan?.visible,
+        planEnabled: planChrome?.planEnabled !== false,
+        userClosed: !!planChrome?.userClosed,
+        composerMode: planChrome?.composerMode ?? "agent",
+        hasHistory: !!planChrome?.hasHistory,
+      }),
+    [
+      plan?.visible,
+      planChrome?.planEnabled,
+      planChrome?.userClosed,
+      planChrome?.composerMode,
+      planChrome?.hasHistory,
+    ],
+  );
 
   if (!plan?.visible) {
     return (
       <div className="sw-plan" data-testid="side-plan-tab">
-        <div className="rp__empty-state">
-          <div className="rp__empty-title">{tr("resources.plan")}</div>
-          <div className="rp__empty-desc">{tr("resources.planEmpty")}</div>
+        <div
+          className={
+            "rp__empty-state plan-resource-empty plan-resource-empty--" +
+            (planResourceEmpty?.kind ?? "idle")
+          }
+          data-testid="plan-resource-empty"
+          data-empty-kind={planResourceEmpty?.kind ?? "idle"}
+          role="status"
+        >
+          <div className="rp__empty-title plan-resource-empty__title">
+            {tr(planResourceEmpty?.titleKey ?? "resources.plan")}
+          </div>
+          <div className="rp__empty-desc plan-resource-empty__hint">
+            {tr(planResourceEmpty?.hintKey ?? "resources.planEmpty")}
+          </div>
+          {(planResourceEmpty?.showHistoryCta ?? false) && onOpenPlanHistory ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm plan-resource-empty__cta"
+              onClick={onOpenPlanHistory}
+              data-testid="plan-resource-empty-history"
+            >
+              {tr("plan.history")}
+            </button>
+          ) : null}
         </div>
       </div>
     );

--- a/src/components/side-workbench/SideWorkbench.tsx
+++ b/src/components/side-workbench/SideWorkbench.tsx
@@ -4,9 +4,10 @@
  * layer only; does not invent a second design system.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Locale } from "@/i18n";
 import type { PlanReviewState } from "@/lib/planBody";
+import { shouldOpenPlanSideTab } from "@/lib/planModePro";
 import type { SessionFileChange } from "@/lib/sessionChanges";
 import {
   activeSideTab,
@@ -32,7 +33,7 @@ import type { ResourceOpenTarget } from "@/components/ResourceViewer";
 import type { SkillInfo } from "@/lib/slashCatalog";
 import type { SkillsPickerSkill } from "@/lib/skillsTaskPicker";
 import { FilesWorkspace } from "./FilesWorkspace";
-import { PlanTab } from "./PlanTab";
+import { PlanTab, type PlanTabChrome } from "./PlanTab";
 import { ReviewTab } from "./ReviewTab";
 import { SkillsTab } from "./SkillsTab";
 import { SidePicker } from "./SidePicker";
@@ -55,9 +56,12 @@ export type SideWorkbenchProps = {
   sessionChanges?: SessionFileChange[];
   plan?: PlanReviewState | null;
   planFocusKey?: number | null;
+  /** PLAN-MODE-PRO empty-state context for Plan tab. */
+  planChrome?: PlanTabChrome | null;
   onApprovePlan?: () => void;
   onRequestPlanChanges?: (note?: string) => void;
   onDismissPlan?: () => void;
+  onOpenPlanHistory?: () => void;
   openRequest?: ResourceOpenTarget | null;
   onOpenRequestConsumed?: () => void;
   autoOpenPlanTab?: boolean;
@@ -83,9 +87,11 @@ export function SideWorkbench({
   sessionChanges = [],
   plan = null,
   planFocusKey = null,
+  planChrome = null,
   onApprovePlan,
   onRequestPlanChanges,
   onDismissPlan,
+  onOpenPlanHistory,
   openRequest = null,
   onOpenRequestConsumed,
   autoOpenPlanTab = true,
@@ -96,6 +102,7 @@ export function SideWorkbench({
 }: SideWorkbenchProps) {
   const [internal, setInternal] = useState(emptySideWorkbenchState);
   const state = controlled ?? internal;
+  const lastPlanFocusKey = useRef<number | null>(null);
 
   const setState = useCallback(
     (next: SideWorkbenchState) => {
@@ -172,11 +179,17 @@ export function SideWorkbench({
     onExpandedChange?.(next.expanded);
   }, [state, setState, onExpandedChange]);
 
-  // Process-only plan tab
+  // Process-only plan tab: live plan auto-open, or planFocusKey bump
+  // (open-in-resources / review gate) even before a draft is visible.
   useEffect(() => {
-    if (!autoOpenPlanTab) return;
-    if (!plan?.visible) return;
-    if (state.tabs.some((t) => t.kind === "plan")) return;
+    const { open, nextLastFocusKey } = shouldOpenPlanSideTab({
+      autoOpenEnabled: autoOpenPlanTab,
+      planVisible: !!plan?.visible,
+      focusKey: planFocusKey,
+      lastFocusKey: lastPlanFocusKey.current,
+    });
+    lastPlanFocusKey.current = nextLastFocusKey;
+    if (!open) return;
     setState(openSideTab(state, "plan", { name: "side.tab.plan" }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [plan?.visible, planFocusKey, autoOpenPlanTab]);
@@ -280,9 +293,11 @@ export function SideWorkbench({
                 locale={locale}
                 plan={plan}
                 planFocusKey={planFocusKey}
+                planChrome={planChrome}
                 onApprovePlan={onApprovePlan}
                 onRequestPlanChanges={onRequestPlanChanges}
                 onDismissPlan={onDismissPlan}
+                onOpenPlanHistory={onOpenPlanHistory}
               />
             ) : null}
 

--- a/src/i18n/messages/en/workspace.ts
+++ b/src/i18n/messages/en/workspace.ts
@@ -258,6 +258,7 @@ export const enWorkspace = {
   "plan.approve": "Approve & build",
   "plan.changes": "Request changes",
   "plan.dismiss": "Dismiss",
+  "plan.exitPlanMode": "Exit plan mode",
   "plan.dismissConfirmTitle": "Close plan panel?",
   "plan.dismissConfirmMessage": "This hides the plan progress for this chat. It will not come back when you reopen the session. A new plan appears only after the agent starts plan work again (plan mode / new plan task).",
   "plan.approvedToast": "Plan approved — agent continues",

--- a/src/i18n/messages/zh-TW/workspace.ts
+++ b/src/i18n/messages/zh-TW/workspace.ts
@@ -258,6 +258,7 @@ export const zhTWWorkspace = {
   "plan.approve": "核准並建置",
   "plan.changes": "請求修改",
   "plan.dismiss": "關閉",
+  "plan.exitPlanMode": "退出計劃模式",
   "plan.dismissConfirmTitle": "關閉計劃面板？",
   "plan.dismissConfirmMessage": "將徹底關閉本對話的計劃進度，再次開啟該對話也不會顯示。只有對話裡再次開啟計劃任務（進入 plan 模式 / 新的 plan 工具）後才會重新出現。",
   "plan.approvedToast": "已核准計劃，Agent 繼續執行",

--- a/src/i18n/messages/zh/workspace.ts
+++ b/src/i18n/messages/zh/workspace.ts
@@ -258,6 +258,7 @@ export const zhWorkspace = {
   "plan.approve": "批准并构建",
   "plan.changes": "请求修改",
   "plan.dismiss": "关闭",
+  "plan.exitPlanMode": "退出计划模式",
   "plan.dismissConfirmTitle": "关闭计划面板？",
   "plan.dismissConfirmMessage": "将彻底关闭本会话的计划进度，再次打开该会话也不会显示。只有对话里再次开启计划任务（进入 plan 模式 / 新的 plan 工具）后才会重新出现。",
   "plan.approvedToast": "已批准计划，Agent 继续执行",

--- a/src/lib/planModePro.test.ts
+++ b/src/lib/planModePro.test.ts
@@ -5,8 +5,10 @@ import {
   resolvePlanPanelInnerEmpty,
   resolvePlanResourceEmptyState,
   shouldAutoLeavePlanSideMode,
+  shouldExitComposerPlanModeAfterDecision,
   shouldOfferOpenInResources,
   shouldOfferOpenInResourcesFromModel,
+  shouldOpenPlanSideTab,
   shouldShowPlanChromeButton,
 } from "./planModePro";
 
@@ -273,5 +275,91 @@ describe("planHasExpandableContent / inner empty", () => {
     ).toBeNull();
     expect(planPanelInnerEmptyLabelKey("waiting")).toBe("plan.waiting");
     expect(planPanelInnerEmptyLabelKey("blank")).toBe("plan.empty");
+  });
+});
+
+describe("shouldExitComposerPlanModeAfterDecision", () => {
+  it("exits plan mode only after approve", () => {
+    expect(
+      shouldExitComposerPlanModeAfterDecision({
+        decision: "approved",
+        composerMode: "plan",
+      }),
+    ).toBe(true);
+    expect(
+      shouldExitComposerPlanModeAfterDecision({
+        decision: "cancelled",
+        composerMode: "plan",
+      }),
+    ).toBe(false);
+    expect(
+      shouldExitComposerPlanModeAfterDecision({
+        decision: "abandoned",
+        composerMode: "plan",
+      }),
+    ).toBe(false);
+  });
+
+  it("is a no-op when not in plan mode", () => {
+    expect(
+      shouldExitComposerPlanModeAfterDecision({
+        decision: "approved",
+        composerMode: "agent",
+      }),
+    ).toBe(false);
+  });
+
+  it("is case-insensitive for plan", () => {
+    expect(
+      shouldExitComposerPlanModeAfterDecision({
+        decision: "approved",
+        composerMode: "Plan",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldOpenPlanSideTab", () => {
+  it("opens when plan becomes visible", () => {
+    const r = shouldOpenPlanSideTab({
+      autoOpenEnabled: true,
+      planVisible: true,
+      focusKey: 0,
+      lastFocusKey: 0,
+    });
+    expect(r.open).toBe(true);
+    expect(r.nextLastFocusKey).toBe(0);
+  });
+
+  it("opens on focus key bump even without a visible plan", () => {
+    const r = shouldOpenPlanSideTab({
+      autoOpenEnabled: true,
+      planVisible: false,
+      focusKey: 2,
+      lastFocusKey: 1,
+    });
+    expect(r.open).toBe(true);
+    expect(r.nextLastFocusKey).toBe(2);
+  });
+
+  it("does not reopen on same focus key when plan is hidden", () => {
+    const r = shouldOpenPlanSideTab({
+      autoOpenEnabled: true,
+      planVisible: false,
+      focusKey: 1,
+      lastFocusKey: 1,
+    });
+    expect(r.open).toBe(false);
+  });
+
+  it("respects autoOpenEnabled", () => {
+    const r = shouldOpenPlanSideTab({
+      autoOpenEnabled: false,
+      planVisible: true,
+      focusKey: 3,
+      lastFocusKey: 0,
+    });
+    expect(r.open).toBe(false);
+    expect(r.nextLastFocusKey).toBe(0);
   });
 });

--- a/src/lib/planModePro.ts
+++ b/src/lib/planModePro.ts
@@ -194,3 +194,43 @@ export function planPanelInnerEmptyLabelKey(
 ): "plan.waiting" | "plan.empty" {
   return kind === "waiting" ? "plan.waiting" : "plan.empty";
 }
+
+/**
+ * Product loop: after Approve & build, leave transient composer plan mode so
+ * the sticky bar does not re-show the idle “Plan mode” chip while the agent
+ * executes. Request-changes keeps plan mode; hard-dismiss leaves mode as-is
+ * (user may still want plan mode for a new draft).
+ */
+export function shouldExitComposerPlanModeAfterDecision(input: {
+  decision: "approved" | "cancelled" | "abandoned";
+  composerMode: string;
+}): boolean {
+  if ((input.composerMode ?? "").trim().toLowerCase() !== "plan") return false;
+  return input.decision === "approved";
+}
+
+/**
+ * Side Workbench / Resources: open or focus the Plan tab.
+ * Live plan visibility auto-opens; planFocusKey bumps open even when the
+ * plan is not yet visible (bare plan-mode chip → open-in-resources empty).
+ */
+export function shouldOpenPlanSideTab(input: {
+  autoOpenEnabled: boolean;
+  planVisible: boolean;
+  focusKey: number | null | undefined;
+  lastFocusKey: number | null;
+}): { open: boolean; nextLastFocusKey: number | null } {
+  if (!input.autoOpenEnabled) {
+    return { open: false, nextLastFocusKey: input.lastFocusKey };
+  }
+  let nextLast = input.lastFocusKey;
+  let focusBump = false;
+  if (input.focusKey != null && input.focusKey !== input.lastFocusKey) {
+    focusBump = true;
+    nextLast = input.focusKey;
+  }
+  return {
+    open: !!input.planVisible || focusBump,
+    nextLastFocusKey: nextLast,
+  };
+}


### PR DESCRIPTION
## Summary

Closes residual **Plan mode product loop** gaps (#15 enter → sticky bar → review → approve/exit → agent) without inventing a new plan protocol.

### Product path (documented)

1. **Enter plan** — Access menu / `/plan` → `composerPrefsSet({ mode: "plan" })` → Host `session/set_mode` (already via prefs set). Sticky bar shows `plan_mode` chip.
2. **Sticky bar** — Progress / review kinds; bare chip has **Exit plan mode** (not sticky global default — already healed in store).
3. **Review** — `exit_plan_mode` gate → auto-open Side Workbench Plan tab; Approve / Request changes / edit canvas.
4. **Approve** → archive + hide chrome + **composer plan → agent** so the idle chip does not reappear while the agent builds.
5. **Exit bare chip** → agent mode + prefs; **Open in resources** always opens Plan tab (including waiting empty).

### Fixes

| Gap | Change |
|-----|--------|
| Side **PlanTab** empty honesty lagging ResourceViewer | Contextual empty states (disabled / plan_mode / user_closed / idle + history CTA) via `planChrome` |
| Open-in-resources on bare chip opened aside without Plan tab | `openPlanInResource` + `shouldOpenPlanSideTab` focus-key bump opens Plan tab even when not visible |
| Approve left composer in plan → sticky “Plan mode” chip stuck | `shouldExitComposerPlanModeAfterDecision` → agent after approve |
| Exit control used “Dismiss” copy | i18n `plan.exitPlanMode` (en / zh / zh-TW) |
| `planHistoryNonEmpty` was discarded | Wired into Plan tab empty CTA |

### Pure helpers + tests

- `shouldExitComposerPlanModeAfterDecision`, `shouldOpenPlanSideTab` in `planModePro.ts`
- Extended `planModePro.test.ts` (29 tests green)

### Out of scope (unchanged)

- New plan protocol / invented plan steps without agent
- Request-changes / hard-dismiss still leave composer mode as-is

## Test plan

- [ ] Enter Plan from Access → sticky bar chip; Exit plan mode → agent, chip gone
- [ ] Open in resources while waiting → Side Plan tab empty with plan-mode hint
- [ ] Plan disabled in Settings → Plan tab shows disabled empty + optional history CTA
- [ ] Hard-dismiss plan → user_closed empty; residual same-cycle events stay suppressed
- [ ] Approve review → bar clears, composer Access shows Agent, agent continues
- [ ] Request changes → stays in plan mode for revise cycle
- [ ] `pnpm exec vitest run src/lib/planModePro.test.ts src/i18n/messages.test.ts`