### PR TITLE
fix(workbench): close side tabs before window

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -889,7 +889,7 @@ import {
 import type { ResourceOpenTarget } from "@/components/ResourceViewer";
 import { EnvInfoButton } from "@/components/side-workbench/EnvInfoButton";
 import {
-  closeActiveSideTab,
+  applySideStripClose,
   emptySideWorkbenchState,
   openSideTab,
   openSideTabFromPicker,
@@ -13691,29 +13691,33 @@ export function AppWorkbench() {
   }, [requestAppQuit]);
 
   /**
-   * Host menu ⌘W / Ctrl+W (replaces native Close Window). Close the active
-   * side tab when the strip has any; otherwise close the window (tray / quit).
+   * Host menu ⌘W / Ctrl+W (replaces native Close Window). Browser-like:
+   * active side tab first when the strip is non-empty and the aside is open;
+   * empty strip (or collapsed leftover tabs) falls through to window close.
+   * Decision is pure — see {@link applySideStripClose}.
    */
   const closeSideTabOrWindow = useCallback(() => {
     const s = sideWorkbenchRef.current;
-    // Only steal ⌘W when the side pane is visible with open tabs. Collapsed
-    // leftover tabs must not block closing the window.
-    if (s.tabs.length > 0 && !layoutRef.current.asideCollapsed) {
-      const next = closeActiveSideTab(s);
-      setSideWorkbench(next);
-      if (next.tabs.length === 0) {
-        closeAsidePane();
-      }
+    const result = applySideStripClose(s, {
+      asideCollapsed: layoutRef.current.asideCollapsed,
+    });
+    if (result.closeWindow) {
+      void (async () => {
+        try {
+          const { getCurrentWindow } = await import("@tauri-apps/api/window");
+          await getCurrentWindow().close();
+        } catch (e) {
+          console.warn("close window after empty side tabs failed", e);
+        }
+      })();
       return;
     }
-    void (async () => {
-      try {
-        const { getCurrentWindow } = await import("@tauri-apps/api/window");
-        await getCurrentWindow().close();
-      } catch (e) {
-        console.warn("close window after empty side tabs failed", e);
-      }
-    })();
+    // needsConfirm: host has no dirty map for outer side tabs yet — force close.
+    // Nested FilesWorkspace drafts keep their own discard dialogs.
+    setSideWorkbench(result.state);
+    if (result.state.tabs.length === 0) {
+      closeAsidePane();
+    }
   }, [closeAsidePane]);
 
   useEffect(() => {

--- a/src/components/side-workbench/SideTabBar.tsx
+++ b/src/components/side-workbench/SideTabBar.tsx
@@ -34,6 +34,7 @@ import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
 import { Tip } from "@/components/ui/tooltip";
 import { useFloatingMenu } from "@/lib/floatingMenu";
 import {
+  isSideTabMiddleClick,
   resolveSideTabLabel,
   sideTabCopyPath,
   sideTabNeighborFlags,
@@ -303,6 +304,18 @@ export function SideTabBar({
                   }
                   data-testid={`side-tab-${tab.kind}`}
                   onClick={() => onActivate(tab.id)}
+                  onAuxClick={(e) => {
+                    // Browser-style middle-click closes the *clicked* tab
+                    // (not only the active one). Same path as the × button.
+                    if (!isSideTabMiddleClick(e)) return;
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onCloseTab(tab.id);
+                  }}
+                  onMouseDown={(e) => {
+                    // Prevent middle-click auto-scroll / paste chrome.
+                    if (isSideTabMiddleClick(e)) e.preventDefault();
+                  }}
                   onContextMenu={(e) => openTabMenu(e, tab)}
                 >
                   {tabIcon(tab)}
@@ -315,6 +328,12 @@ export function SideTabBar({
                         tabIndex={0}
                         title={tr("side.tabClose")}
                         onClick={(e) => {
+                          e.stopPropagation();
+                          onCloseTab(tab.id);
+                        }}
+                        onAuxClick={(e) => {
+                          if (!isSideTabMiddleClick(e)) return;
+                          e.preventDefault();
                           e.stopPropagation();
                           onCloseTab(tab.id);
                         }}

--- a/src/components/side-workbench/SideWorkbench.tsx
+++ b/src/components/side-workbench/SideWorkbench.tsx
@@ -10,7 +10,7 @@ import type { PlanReviewState } from "@/lib/planBody";
 import type { SessionFileChange } from "@/lib/sessionChanges";
 import {
   activeSideTab,
-  closeActiveSideTab,
+  applySideStripClose,
   closeAllSideTabs,
   closeOtherSideTabs,
   closeSideTab,
@@ -121,10 +121,11 @@ export function SideWorkbench({
   );
 
   /**
-   * Browser / non-Tauri preview: ⌘W closes the active side tab.
-   * In the desktop host, File → Close (⌘W) is owned by the native app menu
-   * and routed via `app://close-tab-or-window` (see AppWorkbench) so the OS
-   * does not close the window before JS can run.
+   * Browser / non-Tauri preview: ⌘W closes the active side tab first
+   * (same pure target as the desktop menu path). Empty strip is a no-op
+   * here — there is no host window close in web preview.
+   * Desktop: File → Close (⌘W) is owned by the native app menu and routed
+   * via `app://close-tab-or-window` (see AppWorkbench).
    */
   useEffect(() => {
     if (!paneActive || api.isTauri()) return;
@@ -132,10 +133,11 @@ export function SideWorkbench({
       if (e.isComposing) return;
       if (isShortcutRecordingActive()) return;
       if (!isCloseSideTabChord(e)) return;
-      if (state.tabs.length === 0) return;
+      const result = applySideStripClose(state);
+      if (result.closeWindow || result.needsConfirm) return;
       e.preventDefault();
       e.stopImmediatePropagation();
-      applyCloseState(closeActiveSideTab(state));
+      applyCloseState(result.state);
     };
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);

--- a/src/lib/sideWorkbench.test.ts
+++ b/src/lib/sideWorkbench.test.ts
@@ -11,6 +11,10 @@ import {
   closeSideTabsToLeft,
   closeSideTabsToRight,
   isCloseSideTabChord,
+  isSideTabMiddleClick,
+  resolveSideStripCloseTarget,
+  applySideStripClose,
+  sideTabCloseNeedsConfirm,
   setActiveSideTab,
   sidePickerOptions,
   SIDE_PICKER_EXCLUDED,
@@ -204,6 +208,12 @@ describe("openSideTab / close / activate", () => {
     ).toBe(false);
   });
 
+  it("isSideTabMiddleClick is button 1 only", () => {
+    expect(isSideTabMiddleClick({ button: 1 })).toBe(true);
+    expect(isSideTabMiddleClick({ button: 0 })).toBe(false);
+    expect(isSideTabMiddleClick({ button: 2 })).toBe(false);
+  });
+
   it("toggles expanded", () => {
     const s = emptySideWorkbenchState();
     expect(s.expanded).toBe(false);
@@ -299,5 +309,97 @@ describe("tab close batch helpers", () => {
     const flags = sideTabNeighborFlags(s.tabs, s.tabs[1]!.id);
     expect(flags).toEqual({ hasLeft: true, hasRight: true, hasOthers: true });
     expect(sideTabNeighborFlags(s.tabs, s.tabs[0]!.id).hasLeft).toBe(false);
+  });
+});
+
+describe("resolveSideStripCloseTarget / applySideStripClose (what closes next)", () => {
+  function stripWithActive(): ReturnType<typeof emptySideWorkbenchState> {
+    let s = emptySideWorkbenchState();
+    s = openSideTab(s, "file", { path: "/a.ts", id: "a" });
+    s = openSideTab(s, "browser", { url: "https://b", id: "b" });
+    // [b, a], active b
+    return s;
+  }
+
+  it("prefers active side tab when strip non-empty and aside open", () => {
+    const s = stripWithActive();
+    expect(resolveSideStripCloseTarget(s)).toEqual({
+      kind: "side-tab",
+      tabId: "b",
+    });
+    expect(resolveSideStripCloseTarget(s, { asideCollapsed: false })).toEqual({
+      kind: "side-tab",
+      tabId: "b",
+    });
+  });
+
+  it("falls through to window when strip is empty", () => {
+    expect(resolveSideStripCloseTarget(emptySideWorkbenchState())).toEqual({
+      kind: "window",
+    });
+  });
+
+  it("falls through to window when aside is collapsed (leftover tabs)", () => {
+    const s = stripWithActive();
+    expect(
+      resolveSideStripCloseTarget(s, { asideCollapsed: true }),
+    ).toEqual({ kind: "window" });
+  });
+
+  it("uses first tab when activeId is missing or stale", () => {
+    let s = stripWithActive();
+    s = { ...s, activeId: null };
+    expect(resolveSideStripCloseTarget(s)).toEqual({
+      kind: "side-tab",
+      tabId: "b",
+    });
+    s = { ...s, activeId: "gone" };
+    expect(resolveSideStripCloseTarget(s)).toEqual({
+      kind: "side-tab",
+      tabId: "b",
+    });
+  });
+
+  it("applySideStripClose closes active tab then window on empty", () => {
+    let s = stripWithActive();
+    let r = applySideStripClose(s);
+    expect(r.closeWindow).toBe(false);
+    expect(r.needsConfirm).toBe(false);
+    expect(r.closedTabId).toBe("b");
+    expect(r.state.tabs.map((t) => t.id)).toEqual(["a"]);
+    s = r.state;
+    r = applySideStripClose(s);
+    expect(r.closeWindow).toBe(false);
+    expect(r.closedTabId).toBe("a");
+    expect(r.state.tabs).toEqual([]);
+    r = applySideStripClose(r.state);
+    expect(r.closeWindow).toBe(true);
+    expect(r.closedTabId).toBeNull();
+    expect(r.state.tabs).toEqual([]);
+  });
+
+  it("applySideStripClose does not mutate when aside collapsed", () => {
+    const s = stripWithActive();
+    const r = applySideStripClose(s, { asideCollapsed: true });
+    expect(r.closeWindow).toBe(true);
+    expect(r.state).toBe(s);
+  });
+
+  it("dirty target needs confirm and leaves state unchanged", () => {
+    const s = stripWithActive();
+    expect(sideTabCloseNeedsConfirm("b", { dirtyTabIds: ["b"] })).toBe(true);
+    expect(sideTabCloseNeedsConfirm("a", { dirtyTabIds: new Set(["b"]) })).toBe(
+      false,
+    );
+    const r = applySideStripClose(s, { dirtyTabIds: ["b"] });
+    expect(r.needsConfirm).toBe(true);
+    expect(r.closeWindow).toBe(false);
+    expect(r.closedTabId).toBe("b");
+    expect(r.state).toBe(s);
+    // After forced close (caller discarded), next close proceeds
+    const forced = closeSideTab(s, "b");
+    const next = applySideStripClose(forced, { dirtyTabIds: ["b"] });
+    expect(next.needsConfirm).toBe(false);
+    expect(next.closedTabId).toBe("a");
   });
 });

--- a/src/lib/sideWorkbench.ts
+++ b/src/lib/sideWorkbench.ts
@@ -317,6 +317,116 @@ export function closeActiveSideTab(
 }
 
 /**
+ * What Close / ⌘W should do next for the side workbench strip.
+ * - `side-tab` — close that tab id (active, or first when active is missing)
+ * - `window` — fall through to window close (empty strip or collapsed aside)
+ *
+ * Collapsed leftover tabs must not steal ⌘W from the window.
+ */
+export type SideStripCloseTarget =
+  | { kind: "side-tab"; tabId: string }
+  | { kind: "window" };
+
+export type SideStripCloseOpts = {
+  /** When true, side chrome is hidden — never prefer leftover strip tabs. */
+  asideCollapsed?: boolean;
+  /**
+   * Optional dirty side-tab ids. When the chosen tab is dirty, callers should
+   * confirm discard before applying the close (middle-click / × / ⌘W share this).
+   */
+  dirtyTabIds?: ReadonlySet<string> | readonly string[];
+};
+
+function dirtySideTabIdSet(
+  dirtyTabIds?: SideStripCloseOpts["dirtyTabIds"],
+): ReadonlySet<string> | null {
+  if (!dirtyTabIds) return null;
+  if (dirtyTabIds instanceof Set) return dirtyTabIds;
+  return new Set(dirtyTabIds);
+}
+
+function isDirtySideTabId(
+  tabId: string,
+  dirtyTabIds?: SideStripCloseOpts["dirtyTabIds"],
+): boolean {
+  const set = dirtySideTabIdSet(dirtyTabIds);
+  return set ? set.has(tabId) : false;
+}
+
+/**
+ * Pure decision: close active side tab vs fall through to window close.
+ * Does not mutate state — pair with {@link applySideStripClose} or
+ * {@link closeSideTab} after any discard confirm.
+ */
+export function resolveSideStripCloseTarget(
+  state: Pick<SideWorkbenchState, "tabs" | "activeId">,
+  opts?: SideStripCloseOpts,
+): SideStripCloseTarget {
+  if (opts?.asideCollapsed) return { kind: "window" };
+  if (!state.tabs.length) return { kind: "window" };
+  const tabId = state.activeId ?? state.tabs[0]?.id;
+  if (!tabId) return { kind: "window" };
+  // Guard: activeId can lag behind a removed tab — fall back to first strip entry.
+  if (!state.tabs.some((t) => t.id === tabId)) {
+    const first = state.tabs[0]?.id;
+    if (!first) return { kind: "window" };
+    return { kind: "side-tab", tabId: first };
+  }
+  return { kind: "side-tab", tabId };
+}
+
+/**
+ * Whether closing `tabId` (× / middle-click / ⌘W) needs an unsaved-discard prompt.
+ */
+export function sideTabCloseNeedsConfirm(
+  tabId: string,
+  opts?: Pick<SideStripCloseOpts, "dirtyTabIds">,
+): boolean {
+  return isDirtySideTabId(tabId, opts?.dirtyTabIds);
+}
+
+/**
+ * Apply browser-like Close / ⌘W against the strip.
+ * Returns next state and whether the host should close the window instead.
+ * Does **not** auto-discard dirty tabs — when `dirtyTabIds` marks the target,
+ * returns the prior state with `needsConfirm: true` and no mutation.
+ */
+export function applySideStripClose(
+  state: SideWorkbenchState,
+  opts?: SideStripCloseOpts,
+): {
+  state: SideWorkbenchState;
+  closeWindow: boolean;
+  closedTabId: string | null;
+  needsConfirm: boolean;
+} {
+  const target = resolveSideStripCloseTarget(state, opts);
+  if (target.kind === "window") {
+    return {
+      state,
+      closeWindow: true,
+      closedTabId: null,
+      needsConfirm: false,
+    };
+  }
+  if (isDirtySideTabId(target.tabId, opts?.dirtyTabIds)) {
+    return {
+      state,
+      closeWindow: false,
+      closedTabId: target.tabId,
+      needsConfirm: true,
+    };
+  }
+  const next = closeSideTab(state, target.tabId);
+  return {
+    state: next,
+    closeWindow: false,
+    closedTabId: target.tabId,
+    needsConfirm: false,
+  };
+}
+
+/**
  * ⌘W / Ctrl+W — close the active side tab when the strip has tabs
  * (browser-style; empty strip leaves the chord for window close).
  */
@@ -329,6 +439,15 @@ export function isCloseSideTabChord(e: {
 }): boolean {
   if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return false;
   return e.key === "w" || e.key === "W";
+}
+
+/**
+ * Middle mouse button (button === 1) on a tab chip — browser-style close.
+ */
+export function isSideTabMiddleClick(e: {
+  button: number;
+}): boolean {
+  return e.button === 1;
 }
 
 /**


### PR DESCRIPTION
## Summary

Browser-like side workbench strip Close / ⌘W:

1. **Active side tab first** when the strip is non-empty and the aside is open
2. **Empty strip / collapsed leftover tabs** fall through to window close (tray / quit path)
3. **Middle-click** on a tab chip closes *that* tab (same path as ×)
4. **Pure helpers** encode “what closes next” so menu, web preview, and tests share one decision

## Changes

- `resolveSideStripCloseTarget` / `applySideStripClose` / `sideTabCloseNeedsConfirm` / `isSideTabMiddleClick` in `src/lib/sideWorkbench.ts`
- `AppWorkbench` host menu path (`app://close-tab-or-window`) uses the pure apply helper
- `SideWorkbench` browser/non-Tauri ⌘W uses the same target
- `SideTabBar` middle-click (`auxclick` button 1) closes the clicked tab
- Vitest coverage for the full decision matrix (active / empty / collapsed / dirty confirm)

Dirty ids are optional: when provided, apply leaves state unchanged and returns `needsConfirm`. Nested `FilesWorkspace` drafts keep their own discard dialogs.

## Test plan

- [x] `vitest run src/lib/sideWorkbench.test.ts src/lib/shortcuts.test.ts` (58 passed)
- [x] `tsc -b` clean on touched modules
- [ ] Manual: open side file/browser tabs → ⌘W closes active tab one-by-one
- [ ] Manual: last tab closed → next ⌘W closes window
- [ ] Manual: collapse aside with leftover tabs → ⌘W closes window (does not steal)
- [ ] Manual: middle-click inactive tab closes that tab; × still closes active