### PR TITLE
feat(chat): open path cards in side workbench tabs

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -932,6 +932,7 @@ import {
   shouldHideChatForSideExpand,
 } from "@/lib/sideFloatComposer";
 import { applySideContextOpen } from "@/lib/sideContextOpen";
+import { resolveSidePathDeepLink } from "@/lib/sidePathDeepLink";
 import { ProjectRulesModal } from "@/components/ProjectRulesModal";
 import {
   mergeSessionChange,
@@ -19351,6 +19352,41 @@ export function AppWorkbench() {
               setResourceOpenTarget({ type: "changes", path });
             }}
             onOpenResource={(target) => {
+              // Path cards → Side Workbench Files tab when project-trusted.
+              // Soft-fail outside/untrusted/no project; optional OS reveal.
+              // URLs / changes keep the prior applySideContextOpen path.
+              if (target.type === "file" && target.path) {
+                const decision = resolveSidePathDeepLink({
+                  path: target.path,
+                  title: target.title,
+                  projectPath: effectiveProjectPath,
+                  projectTrusted: activeProject
+                    ? activeProject.trusted
+                    : effectiveProjectPath
+                      ? true
+                      : null,
+                });
+                if (!decision.ok) {
+                  setLocalError(tr(decision.messageKey));
+                  if (
+                    decision.shouldReveal &&
+                    decision.revealPath &&
+                    api.isTauri()
+                  ) {
+                    void api.pathReveal(decision.revealPath).catch(() => {
+                      /* reveal is best-effort fallback */
+                    });
+                  }
+                  return;
+                }
+                openAsidePane();
+                setResourceOpenTarget({
+                  type: "file",
+                  path: decision.path,
+                  title: decision.title,
+                });
+                return;
+              }
               openAsidePane();
               setResourceOpenTarget(target);
             }}

--- a/src/i18n/messages/en/workspace.ts
+++ b/src/i18n/messages/en/workspace.ts
@@ -361,6 +361,12 @@ export const enWorkspace = {
   "resources.revealErr.hostOnly": "Reveal needs the desktop app.",
   "resources.revealErr.cancelled": "Reveal cancelled.",
   "resources.revealErr.other": "Could not reveal in file manager.",
+  /** Chat path card → Side Workbench Files tab soft-fail honesty */
+  "resources.sideOpen.empty": "No file path to open.",
+  "resources.sideOpen.url": "Links open in the browser tab, not the Files workbench.",
+  "resources.sideOpen.noProject": "Select a project to open files in the side workbench. Revealing in the file manager when possible.",
+  "resources.sideOpen.untrusted": "Trust this project first to open files in the side workbench.",
+  "resources.sideOpen.outsideProject": "That path is outside the project. Opening in the file manager instead.",
   // Side Workbench (Codex-style right pane)
   "side.picker.aria": "Open in side workbench",
   "side.picker.file": "Files",

--- a/src/i18n/messages/zh-TW/workspace.ts
+++ b/src/i18n/messages/zh-TW/workspace.ts
@@ -361,6 +361,12 @@ export const zhTWWorkspace = {
   "resources.revealErr.hostOnly": "在檔案管理員中顯示需要桌面端應用程式。",
   "resources.revealErr.cancelled": "已取消顯示。",
   "resources.revealErr.other": "無法在檔案管理員中顯示。",
+  /** 對話路徑卡片 → 側欄 Files 深鏈軟失敗 */
+  "resources.sideOpen.empty": "沒有可開啟的檔案路徑。",
+  "resources.sideOpen.url": "連結會在瀏覽器分頁中開啟，而不是檔案工作台。",
+  "resources.sideOpen.noProject": "請先選擇專案，才能在側欄開啟檔案。若可能，將在檔案管理員中顯示。",
+  "resources.sideOpen.untrusted": "請先信任此專案，才能在側欄開啟檔案。",
+  "resources.sideOpen.outsideProject": "該路徑不在目前專案內。已改為在檔案管理員中開啟。",
   // Side Workbench (Codex-style right pane)
   "side.picker.aria": "在側邊工作台中開啟",
   "side.picker.file": "檔案",

--- a/src/i18n/messages/zh/workspace.ts
+++ b/src/i18n/messages/zh/workspace.ts
@@ -361,6 +361,12 @@ export const zhWorkspace = {
   "resources.revealErr.hostOnly": "在文件管理器中显示需要桌面端应用。",
   "resources.revealErr.cancelled": "已取消显示。",
   "resources.revealErr.other": "无法在文件管理器中显示。",
+  /** 对话路径卡片 → 侧栏 Files 深链软失败 */
+  "resources.sideOpen.empty": "没有可打开的文件路径。",
+  "resources.sideOpen.url": "链接会在浏览器标签中打开，而不是文件工作台。",
+  "resources.sideOpen.noProject": "请先选择项目，才能在侧栏打开文件。若可能，将在文件管理器中显示。",
+  "resources.sideOpen.untrusted": "请先信任该项目，才能在侧栏打开文件。",
+  "resources.sideOpen.outsideProject": "该路径不在当前项目内。已改为在文件管理器中打开。",
   // Side Workbench (Codex-style right pane)
   "side.picker.aria": "在侧边工作台中打开",
   "side.picker.file": "文件",

--- a/src/lib/sidePathDeepLink.test.ts
+++ b/src/lib/sidePathDeepLink.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPathUnderProject,
+  joinProjectRoot,
+  normalizeSidePath,
+  resolveSidePathDeepLink,
+  toProjectRelative,
+} from "./sidePathDeepLink";
+
+describe("normalizeSidePath", () => {
+  it("trims, unescapes shell spaces, collapses trailing slash", () => {
+    expect(normalizeSidePath("  /a/b/c/  ")).toBe("/a/b/c");
+    expect(normalizeSidePath("file\\ name.ts")).toBe("file name.ts");
+  });
+
+  it("normalizes Windows separators to /", () => {
+    expect(normalizeSidePath("C:\\proj\\src\\a.ts")).toBe("C:/proj/src/a.ts");
+  });
+});
+
+describe("joinProjectRoot / under-project", () => {
+  it("joins posix project + relative", () => {
+    expect(joinProjectRoot("/Users/me/proj", "src/a.ts")).toBe(
+      "/Users/me/proj/src/a.ts",
+    );
+  });
+
+  it("joins Windows-style project root", () => {
+    expect(joinProjectRoot("C:\\proj", "src\\a.ts")).toBe("C:\\proj\\src\\a.ts");
+  });
+
+  it("detects under-project and relative form", () => {
+    expect(isPathUnderProject("/p", "/p/src/a.ts")).toBe(true);
+    expect(isPathUnderProject("/p", "/p")).toBe(true);
+    expect(isPathUnderProject("/p", "/other/a.ts")).toBe(false);
+    expect(toProjectRelative("/p", "/p/src/a.ts")).toBe("src/a.ts");
+    expect(toProjectRelative("/p", "/p")).toBe("");
+    expect(toProjectRelative("/p", "/x")).toBeNull();
+  });
+
+  it("does not treat sibling prefix as under root", () => {
+    expect(isPathUnderProject("/proj", "/proj-extra/a.ts")).toBe(false);
+  });
+});
+
+describe("resolveSidePathDeepLink", () => {
+  const root = "/Users/me/proj";
+
+  it("opens absolute path under trusted project", () => {
+    const r = resolveSidePathDeepLink({
+      path: "/Users/me/proj/src/App.tsx",
+      title: "App.tsx",
+      projectPath: root,
+      projectTrusted: true,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.path).toBe("/Users/me/proj/src/App.tsx");
+    expect(r.relativePath).toBe("src/App.tsx");
+    expect(r.title).toBe("App.tsx");
+  });
+
+  it("joins relative path under project", () => {
+    const r = resolveSidePathDeepLink({
+      path: "docs/README.md",
+      projectPath: root,
+      projectTrusted: true,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.path).toBe("/Users/me/proj/docs/README.md");
+    expect(r.relativePath).toBe("docs/README.md");
+  });
+
+  it("soft-fails with no project + reveal when abs known", () => {
+    const r = resolveSidePathDeepLink({
+      path: "/tmp/x.ts",
+      projectPath: null,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("no_project");
+    expect(r.messageKey).toBe("resources.sideOpen.noProject");
+    expect(r.shouldReveal).toBe(true);
+    expect(r.revealPath).toBe("/tmp/x.ts");
+  });
+
+  it("soft-fails untrusted without auto-reveal", () => {
+    const r = resolveSidePathDeepLink({
+      path: "/Users/me/proj/a.ts",
+      projectPath: root,
+      projectTrusted: false,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("untrusted");
+    expect(r.messageKey).toBe("resources.sideOpen.untrusted");
+    expect(r.shouldReveal).toBe(false);
+  });
+
+  it("soft-fails outside project with reveal fallback", () => {
+    const r = resolveSidePathDeepLink({
+      path: "/etc/hosts",
+      projectPath: root,
+      projectTrusted: true,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("outside_project");
+    expect(r.messageKey).toBe("resources.sideOpen.outsideProject");
+    expect(r.shouldReveal).toBe(true);
+    expect(r.revealPath).toBe("/etc/hosts");
+  });
+
+  it("soft-fails missing", () => {
+    const r = resolveSidePathDeepLink({
+      path: "/Users/me/proj/gone.ts",
+      projectPath: root,
+      projectTrusted: true,
+      missing: true,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("missing");
+    expect(r.messageKey).toBe("resources.openErr.notFound");
+    expect(r.shouldReveal).toBe(false);
+  });
+
+  it("rejects empty and http urls", () => {
+    expect(resolveSidePathDeepLink({ path: "  " }).ok).toBe(false);
+    const u = resolveSidePathDeepLink({
+      path: "https://example.com",
+      projectPath: root,
+      projectTrusted: true,
+    });
+    expect(u.ok).toBe(false);
+    if (!u.ok) expect(u.reason).toBe("url");
+  });
+
+  it("allows when trusted is undefined (only false blocks)", () => {
+    const r = resolveSidePathDeepLink({
+      path: "a.ts",
+      projectPath: root,
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/src/lib/sidePathDeepLink.ts
+++ b/src/lib/sidePathDeepLink.ts
@@ -1,0 +1,224 @@
+/**
+ * Chat path card → Side Workbench Files tab deep-link (pure).
+ *
+ * Gates: project present + trusted + path under project root.
+ * Soft-fail reasons map to i18n keys; optional OS reveal when side open is denied.
+ * No DOM / Tauri / i18n side effects.
+ */
+
+import type { MessageKey } from "@/i18n";
+import {
+  isHomeRelativePath,
+  isHttpUrl,
+  normalizeLocalPathToken,
+} from "@/lib/pathRefs";
+import {
+  isFsAbsolutePath,
+  joinProjectPath,
+} from "@/lib/sideWorkbench";
+
+/** Stable soft-fail reasons for chat → side Files tab. */
+export type SidePathDeepLinkReason =
+  | "empty"
+  | "url"
+  | "no_project"
+  | "untrusted"
+  | "outside_project"
+  | "missing";
+
+export type SidePathDeepLinkInput = {
+  /** Resolved absolute path preferred; project-relative also accepted. */
+  path: string;
+  title?: string;
+  projectPath?: string | null;
+  /**
+   * When `false`, refuse (project must be trusted first).
+   * `true` / `null` / `undefined` → allow if a project path exists.
+   */
+  projectTrusted?: boolean | null;
+  /** When true, path is known missing on disk (card layer already probed). */
+  missing?: boolean;
+};
+
+export type SidePathDeepLinkOk = {
+  ok: true;
+  /** Absolute (or joined) path for SideTab + FilesWorkspace. */
+  path: string;
+  /** Project-relative key when under root; empty string for the root itself. */
+  relativePath: string | null;
+  title: string;
+};
+
+export type SidePathDeepLinkFail = {
+  ok: false;
+  reason: SidePathDeepLinkReason;
+  /** i18n key for toast honesty. */
+  messageKey: MessageKey;
+  /** Absolute path for optional OS reveal fallback (when known). */
+  revealPath?: string;
+  /** Whether caller should attempt pathReveal after toast. */
+  shouldReveal: boolean;
+};
+
+export type SidePathDeepLinkResult = SidePathDeepLinkOk | SidePathDeepLinkFail;
+
+const MSG: Record<SidePathDeepLinkReason, MessageKey> = {
+  empty: "resources.sideOpen.empty",
+  url: "resources.sideOpen.url",
+  no_project: "resources.sideOpen.noProject",
+  untrusted: "resources.sideOpen.untrusted",
+  outside_project: "resources.sideOpen.outsideProject",
+  missing: "resources.openErr.notFound",
+};
+
+/** Normalize for open / under-root compare (POSIX separators, trim trailing slash). */
+export function normalizeSidePath(path: string): string {
+  const raw = (path ?? "").trim().replace(/^<|>$/g, "");
+  if (!raw) return "";
+  const unescaped = normalizeLocalPathToken(raw) || raw;
+  // Collapse trailing separators except drive roots (`C:/`, `/`).
+  if (/^[A-Za-z]:\/?$/.test(unescaped.replace(/\\/g, "/"))) {
+    return unescaped.replace(/\\/g, "/").replace(/\/?$/, "/");
+  }
+  if (unescaped === "/" || unescaped === "\\") return "/";
+  return unescaped.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+/** True when `target` is the project root or a path inside it. */
+export function isPathUnderProject(
+  projectRoot: string,
+  target: string,
+): boolean {
+  const root = normalizeSidePath(projectRoot);
+  const tgt = normalizeSidePath(target);
+  if (!root || !tgt) return false;
+  return tgt === root || tgt.startsWith(root + "/");
+}
+
+/**
+ * Project-relative form of an absolute path, or null when outside root.
+ * Root itself → `""`.
+ */
+export function toProjectRelative(
+  projectRoot: string,
+  targetAbs: string,
+): string | null {
+  if (!isPathUnderProject(projectRoot, targetAbs)) return null;
+  const root = normalizeSidePath(projectRoot);
+  const tgt = normalizeSidePath(targetAbs);
+  if (tgt === root) return "";
+  return tgt.slice(root.length + 1);
+}
+
+/** Join project root + relative segment (delegates style to sideWorkbench). */
+export function joinProjectRoot(
+  projectRoot: string,
+  relative: string,
+): string {
+  return joinProjectPath(projectRoot, relative);
+}
+
+function basenameTitle(path: string, fallback?: string): string {
+  if (fallback?.trim()) return fallback.trim();
+  const n = normalizeSidePath(path);
+  if (!n) return path || "file";
+  const parts = n.split("/").filter(Boolean);
+  return parts[parts.length - 1] || n;
+}
+
+function fail(
+  reason: SidePathDeepLinkReason,
+  opts?: { revealPath?: string; shouldReveal?: boolean },
+): SidePathDeepLinkFail {
+  const revealPath = opts?.revealPath?.trim() || undefined;
+  return {
+    ok: false,
+    reason,
+    messageKey: MSG[reason],
+    revealPath,
+    shouldReveal: !!opts?.shouldReveal && !!revealPath,
+  };
+}
+
+/**
+ * Decide whether a chat path card may open a Side Workbench Files tab.
+ *
+ * - URLs are not file deep-links (browser path stays separate).
+ * - Relative tokens join project root (no monorepo invent — caller should
+ *   pass Host-resolved abs when available).
+ * - Absolute paths must sit under the trusted project root.
+ * - Soft-fail outside / untrusted / no project may set `shouldReveal` so the
+ *   UI can fall back to OS reveal without pretending the side tab opened.
+ */
+export function resolveSidePathDeepLink(
+  input: SidePathDeepLinkInput,
+): SidePathDeepLinkResult {
+  const raw = (input.path ?? "").trim();
+  if (!raw) return fail("empty");
+
+  if (isHttpUrl(raw)) return fail("url");
+
+  if (input.missing) {
+    const hint = isFsAbsolutePath(raw) || isHomeRelativePath(raw)
+      ? normalizeSidePath(raw) || raw
+      : undefined;
+    return fail("missing", { revealPath: hint, shouldReveal: false });
+  }
+
+  const projectPath = (input.projectPath ?? "").trim();
+  if (!projectPath) {
+    const reveal =
+      isFsAbsolutePath(raw) || isHomeRelativePath(raw)
+        ? normalizeSidePath(raw) || raw
+        : undefined;
+    return fail("no_project", {
+      revealPath: reveal,
+      shouldReveal: !!reveal,
+    });
+  }
+
+  if (input.projectTrusted === false) {
+    return fail("untrusted", {
+      revealPath:
+        isFsAbsolutePath(raw) || isHomeRelativePath(raw)
+          ? normalizeSidePath(raw) || raw
+          : undefined,
+      shouldReveal: false,
+    });
+  }
+
+  const norm = normalizeSidePath(raw) || raw;
+
+  // Home-relative / absolute outside pure join — must already be under root.
+  if (isHomeRelativePath(norm)) {
+    // Pure helper cannot expand `~`; treat as outside unless it literally
+    // matches a home-style project root (rare). Soft-fail with reveal.
+    return fail("outside_project", {
+      revealPath: norm,
+      shouldReveal: true,
+    });
+  }
+
+  let abs: string;
+  if (isFsAbsolutePath(norm)) {
+    abs = norm;
+  } else {
+    // Project-relative → join root (path style follows project root).
+    abs = normalizeSidePath(joinProjectRoot(projectPath, norm)) || joinProjectRoot(projectPath, norm);
+  }
+
+  if (!isPathUnderProject(projectPath, abs)) {
+    return fail("outside_project", {
+      revealPath: abs,
+      shouldReveal: true,
+    });
+  }
+
+  const relativePath = toProjectRelative(projectPath, abs);
+  return {
+    ok: true,
+    path: abs,
+    relativePath,
+    title: basenameTitle(abs, input.title),
+  };
+}


### PR DESCRIPTION
## Summary

Chat path citations/cards now open (or focus) a **Side Workbench Files** tab for that path when the project is trusted and the file is under the project root — not only OS reveal.

- Pure gate + resolve helpers: `src/lib/sidePathDeepLink.ts` (normalize, project-root join, under-project check)
- Soft-fail honesty toasts: no project / untrusted / outside project / missing
- Optional **OS reveal** fallback when side open is denied (no project / outside project)
- i18n (en / zh / zh-TW): `resources.sideOpen.*`
- Minimal `AppWorkbench` wiring on existing `onOpenResource` (URLs / changes / media ImageUi unchanged)

## Test plan

- [x] `pnpm exec vitest run src/lib/sidePathDeepLink.test.ts` (14 passed)
- [x] `pnpm exec vitest run src/i18n/messages.test.ts` (parity)
- [x] `pnpm exec tsc -b --pretty false` (clean)
- [ ] Manual: trusted project + path card under root → side Files tab opens/focuses preview
- [ ] Manual: untrusted project → toast, no side open
- [ ] Manual: absolute path outside project → toast + Finder/Explorer reveal
- [ ] Manual: no project → toast + reveal when abs known
- [ ] Manual: image/video path cards still use ImageUi/VideoUi (not Files tab)
- [ ] Manual: http(s) cards still open browser tab