### PR TITLE
feat(resources): jump to path line in preview

### DIFF
--- a/docs/llm-wiki/media-delivery.md
+++ b/docs/llm-wiki/media-delivery.md
@@ -66,6 +66,7 @@ Host injects always-on **path citation** text into session `grok --rules` via `p
 2. **Not tool-journal form** in user-facing prose: no `input:/abs/path`, no `tool_step|…` dumps as the citation style.
 3. **Disambiguate homonyms**: article / template trees often share short tails (`正文.md`, `04-正文/正文.md`). Cite from project root with unique parents so Host + path map open the right file.
 4. **Spaces**: write real spaces in absolute paths (e.g. `Mac Studio…`); never shell-escape `\ `.
+5. **Optional line jump**: `` `path/to/file.ts:42` `` or `` `path/to/file.ts:42:10` `` (line / line:col). UI opens the side preview scrolled to that line when possible; external `open_in_editor` gets `-g path:line`. Invalid lines soft-fail (open file, no jump). Parse helpers: `src/lib/pathLineCitation.ts`.
 
 Frontend path map (`sessionPathMap.ts`) collects tool `input:` / last-touched abs paths so short tokens in the same session can still resolve after tools ran — but **user-facing citations should still be unambiguous** without relying on that.
 

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -17451,7 +17451,7 @@ export function AppWorkbench() {
           }}
           archiveAgeSessions={sessions}
           projectPath={effectiveProjectPath}
-          onOpenProjectFileInResources={({ path, relativePath }) => {
+          onOpenProjectFileInResources={({ path, relativePath, line }) => {
           const targetPath = (path || relativePath || "").trim();
           if (!targetPath) return;
           navigateWorkbench();
@@ -17460,6 +17460,7 @@ export function AppWorkbench() {
           type: "file",
           path: targetPath,
           title: relativePath || targetPath,
+          line: line ?? null,
           });
           }}
           onSkillsPrefsChanged={() =>

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -4,8 +4,9 @@
  * Line-number gutter is always on for pane previews.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import hljs from "highlight.js/lib/core";
+import { normalizeFocusLine } from "@/lib/pathLineCitation";
 
 import javascript from "highlight.js/lib/languages/javascript";
 import typescript from "highlight.js/lib/languages/typescript";
@@ -175,6 +176,11 @@ export interface CodePreviewProps {
   footer?: string | null;
   /** Show line-number gutter (default true for resource pane). */
   showLineNumbers?: boolean;
+  /**
+   * 1-based line to scroll into view and highlight.
+   * Soft-fail when out of range / invalid (no scroll, no highlight).
+   */
+  focusLine?: number | null;
 }
 
 function readDocTheme(): "light" | "dark" {
@@ -232,10 +238,12 @@ export function CodePreview({
   className,
   footer,
   showLineNumbers = true,
+  focusLine = null,
 }: CodePreviewProps) {
   ensureLangs();
 
   const [theme, setTheme] = useState<"light" | "dark">(readDocTheme);
+  const focusRef = useRef<HTMLSpanElement | null>(null);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -276,6 +284,20 @@ export function CodePreview({
   }, [code, lang]);
 
   const lines = lineHtml.length;
+  const activeLine = normalizeFocusLine(focusLine, lines);
+
+  useEffect(() => {
+    if (activeLine == null) return;
+    const el = focusRef.current;
+    if (!el) return;
+    // Double rAF: wait for layout after tab switch / async read.
+    const id = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        el.scrollIntoView({ block: "center", behavior: "smooth" });
+      });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [activeLine, code, fileName]);
 
   return (
     <div
@@ -286,12 +308,19 @@ export function CodePreview({
         className,
       )}
       data-language={lang}
+      data-focus-line={activeLine ?? undefined}
     >
       <div className="rp-code__scroll">
         {showLineNumbers ? (
           <div className="rp-code__gutter" aria-hidden>
             {Array.from({ length: lines }, (_, i) => (
-              <span key={i} className="rp-code__ln">
+              <span
+                key={i}
+                className={cn(
+                  "rp-code__ln",
+                  activeLine === i + 1 && "rp-code__ln--focus",
+                )}
+              >
                 {i + 1}
               </span>
             ))}
@@ -299,16 +328,24 @@ export function CodePreview({
         ) : null}
         <pre className="rp-code__pre">
           <code className={`hljs language-${lang}`}>
-            {lineHtml.map((html, i) => (
-              <span
-                key={i}
-                className="rp-code__line"
-                // Empty lines need a non-collapsing marker for gutter alignment.
-                dangerouslySetInnerHTML={{
-                  __html: html.length ? html : "&#8203;",
-                }}
-              />
-            ))}
+            {lineHtml.map((html, i) => {
+              const isFocus = activeLine === i + 1;
+              return (
+                <span
+                  key={i}
+                  ref={isFocus ? focusRef : undefined}
+                  className={cn(
+                    "rp-code__line",
+                    isFocus && "rp-code__line--focus",
+                  )}
+                  data-line={i + 1}
+                  // Empty lines need a non-collapsing marker for gutter alignment.
+                  dangerouslySetInnerHTML={{
+                    __html: html.length ? html : "&#8203;",
+                  }}
+                />
+              );
+            })}
           </code>
         </pre>
       </div>

--- a/src/components/FilePathCard.tsx
+++ b/src/components/FilePathCard.tsx
@@ -84,12 +84,21 @@ export interface FilePathCardProps {
   /** Project root for monorepo suffix search. */
   projectPath?: string | null;
   subtitle?: string;
+  /**
+   * 1-based line from a `path:line` citation.
+   * Used for side preview scroll + open_in_editor `-g`. Soft-fail if invalid.
+   */
+  line?: number | null;
+  /** Optional 1-based column (open_in_editor when supported). */
+  column?: number | null;
   labels: FilePathCardLabels;
   onOpenInPanel?: (target: {
     type: "file" | "url";
     path?: string;
     url?: string;
     title?: string;
+    line?: number | null;
+    column?: number | null;
   }) => void;
   /** Optional toast / banner when open-external or reveal soft-fails. */
   onOpenError?: (message: string) => void;
@@ -147,11 +156,17 @@ export function FilePathCard({
   kind = "file",
   projectPath,
   subtitle: _subtitle,
+  line = null,
+  column = null,
   labels,
   onOpenInPanel,
   onOpenError,
 }: FilePathCardProps) {
   void _subtitle; // callers may pass; card no longer shows path/subtitle
+  const focusLine =
+    line != null && Number.isInteger(line) && line >= 1 ? line : null;
+  const focusColumn =
+    column != null && Number.isInteger(column) && column >= 1 ? column : null;
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [detailsOpen, setDetailsOpen] = useState(false);
   const isUrl = kind === "url" || isHttpUrl(path);
@@ -378,7 +393,13 @@ export function FilePathCard({
         onOpenError?.(filePathCardErrLabel(labels, "not_found"));
         return;
       }
-      onOpenInPanel?.({ type: "file", path: abs, title: name });
+      onOpenInPanel?.({
+        type: "file",
+        path: abs,
+        title: name,
+        line: focusLine,
+        column: focusColumn,
+      });
     } finally {
       setBusy(false);
     }
@@ -402,7 +423,12 @@ export function FilePathCard({
         onOpenError?.(filePathCardErrLabel(labels, "not_found"));
         return;
       }
-      await api.pathOpen(abs);
+      // path:line citations jump in the default editor when line is known.
+      if (focusLine != null) {
+        await api.openInEditor({ path: abs, line: focusLine });
+      } else {
+        await api.pathOpen(abs);
+      }
     } catch (e) {
       // path_open shares reveal-like Host phrases; open classifier is a superset.
       const resolved = resolveOpenEditorError(e);

--- a/src/components/OpenLocationButton.tsx
+++ b/src/components/OpenLocationButton.tsx
@@ -27,6 +27,11 @@ export type OpenLocationTarget = string; // finder | explorer | system | editor 
 export interface OpenLocationButtonProps {
   /** Absolute path to open (project root or file). Hidden when null/empty. */
   path: string | null | undefined;
+  /**
+   * Optional 1-based line for editor `-g path:line` when opening a code editor.
+   * Soft-fail / ignored for Finder / system default.
+   */
+  line?: number | null;
   /** Last selected target id (persisted by parent). */
   target: OpenLocationTarget;
   /** Called when user picks a menu item (parent should persist). */
@@ -58,6 +63,7 @@ function normalizeTarget(t: string | undefined | null): string {
 
 export function OpenLocationButton({
   path,
+  line = null,
   target,
   onTargetChange,
   onOpenError,
@@ -199,19 +205,21 @@ export function OpenLocationButton({
         t = finderTarget;
       }
       if (remember) onTargetChange(t);
+      const gotoLine =
+        line != null && Number.isInteger(line) && line >= 1 ? line : undefined;
       try {
         if (t === "finder" || t === "explorer") {
           await api.pathReveal(path);
         } else if (t === "system" || t === "default") {
           await api.pathOpen(path);
         } else {
-          await api.openInEditor({ path, editor: t });
+          await api.openInEditor({ path, editor: t, line: gotoLine });
         }
       } catch (e) {
         onOpenError?.(String(e));
       }
     },
-    [path, disabled, onTargetChange, onOpenError, isGitRepo, finderTarget],
+    [path, line, disabled, onTargetChange, onOpenError, isGitRepo, finderTarget],
   );
 
   if (!path) return null;

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -29,6 +29,7 @@ import {
   normalizePathToken,
   resolveFileToken,
 } from "@/lib/pathRefs";
+import { parsePathLineCitation } from "@/lib/pathLineCitation";
 import { isExternalHttpUrl } from "@/lib/externalLinkPref";
 import {
   createSoftBufferState,
@@ -244,8 +245,15 @@ export const MarkdownChat = memo(function MarkdownChat({
   const renderPathOrUrl = (token: string, linkText?: string) => {
     const rawIn = token.trim().replace(/^<|>$/g, "");
     if (!rawIn) return null;
+    // Strip path:line[:col] before path resolution (soft-fail keeps original).
+    const citeIn = parsePathLineCitation(rawIn);
+    const citeNorm = parsePathLineCitation(normalizePathToken(rawIn) || rawIn);
+    const line = citeNorm.line ?? citeIn.line;
+    const column = citeNorm.column ?? citeIn.column;
     // Prefer ellipsis-stripped + shell-unescaped form for open/search.
-    const raw = normalizePathToken(rawIn) || rawIn;
+    const raw =
+      normalizePathToken(citeNorm.path || citeIn.path || rawIn) || rawIn;
+    const pathForLooks = citeNorm.path || citeIn.path || raw;
 
     // Thinking: keep URL/path as original text (no FilePathCard). Media still
     // handled below when pathCards is on; when off, skip cards entirely.
@@ -278,6 +286,7 @@ export const MarkdownChat = memo(function MarkdownChat({
 
     const mediaAbs =
       resolveInlineMediaToken(raw, imagePathMap) ||
+      resolveInlineMediaToken(pathForLooks, imagePathMap) ||
       resolveInlineMediaToken(rawIn, imagePathMap);
     // Real multi-segment local abs only (pathMap verified in resolveInlineMediaToken).
     if (
@@ -314,7 +323,12 @@ export const MarkdownChat = memo(function MarkdownChat({
       );
     }
 
-    if (!looksLikeFilePath(rawIn) && !looksLikeFilePath(raw) && !mediaAbs) {
+    if (
+      !looksLikeFilePath(rawIn) &&
+      !looksLikeFilePath(raw) &&
+      !looksLikeFilePath(pathForLooks) &&
+      !mediaAbs
+    ) {
       return null;
     }
 
@@ -322,10 +336,12 @@ export const MarkdownChat = memo(function MarkdownChat({
     const resolved =
       mediaAbs ||
       resolveFileToken(raw, { projectPath, pathMap: imagePathMap }) ||
+      resolveFileToken(pathForLooks, { projectPath, pathMap: imagePathMap }) ||
       resolveFileToken(rawIn, { projectPath, pathMap: imagePathMap });
     if (
       !resolved &&
       !looksLikeFilePath(raw) &&
+      !looksLikeFilePath(pathForLooks) &&
       !looksLikeFilePath(rawIn)
     ) {
       return null;
@@ -333,7 +349,7 @@ export const MarkdownChat = memo(function MarkdownChat({
 
     // Prefer multi-segment relative after ellipsis strip for smart open.
     // Display token: keep short relative when we only have that; abs is for open.
-    const pathToken = resolved || raw || rawIn;
+    const pathToken = resolved || raw || pathForLooks || rawIn;
     // Video/image only when we have a real multi-segment local absolute.
     // Never promote site-root, single-segment tails, or unresolved relative media.
     const asLocalMedia = (p: string | null | undefined, kind: "image" | "video") => {
@@ -406,12 +422,20 @@ export const MarkdownChat = memo(function MarkdownChat({
         }
         projectPath={projectPath}
         kind="file"
+        line={line}
+        column={column}
         subtitle={fileSubtitle(tokenForCard, locale === "en" ? "en" : "zh")}
         labels={fileLabels}
         onOpenError={onOpenError}
         onOpenInPanel={(t) => {
           if (t.type === "file" && t.path) {
-            onOpenResource?.({ type: "file", path: t.path, title: t.title });
+            onOpenResource?.({
+              type: "file",
+              path: t.path,
+              title: t.title,
+              line: t.line ?? line,
+              column: t.column ?? column,
+            });
           }
         }}
       />

--- a/src/components/resource-viewer/ResourcePreviewBody.tsx
+++ b/src/components/resource-viewer/ResourcePreviewBody.tsx
@@ -720,6 +720,7 @@ export function ResourcePreviewBody({
                 code={codePreviewBody}
                 fileName={preview.name}
                 language={preview.kind === "json" ? "json" : undefined}
+                focusLine={activeTab.focusLine}
                 footer={
                   preview.truncated ? tr("resources.truncated") : null
                 }
@@ -842,6 +843,7 @@ export function ResourcePreviewBody({
           code={body}
           fileName={preview.name.endsWith(".json") ? preview.name : "data.json"}
           language="json"
+          focusLine={activeTab?.focusLine}
           footer={
           preview.truncated ? tr("resources.truncated") : null
           }
@@ -855,6 +857,7 @@ export function ResourcePreviewBody({
             <CodePreview
             code={preview.text}
             fileName={preview.name}
+            focusLine={activeTab?.focusLine}
             footer={
             preview.truncated ? tr("resources.truncated") : null
             }

--- a/src/components/resource-viewer/ResourceViewer.tsx
+++ b/src/components/resource-viewer/ResourceViewer.tsx
@@ -501,7 +501,10 @@ export function ResourceViewer({
     if (openRequest.type === "file") {
       // Leave plan workbench so file preview is not hidden behind Plan UI.
       setSideMode("files");
-      void openAbsoluteFile(openRequest.path, openRequest.title);
+      void openAbsoluteFile(openRequest.path, openRequest.title, {
+        line: openRequest.line,
+        column: openRequest.column,
+      });
     } else if (openRequest.type === "url") {
       setSideMode("files");
       openUrl(openRequest.url, openRequest.title);
@@ -880,6 +883,7 @@ export function ResourceViewer({
           {absPath ? (
             <OpenLocationButton
               path={absPath}
+              line={activeTab?.focusLine}
               target={openWithTarget}
               onTargetChange={(t) => {
                 setOpenWithTarget(t);
@@ -1091,6 +1095,7 @@ export function ResourceViewer({
             {absPath ? (
               <OpenLocationButton
                 path={absPath}
+                line={activeTab?.focusLine}
                 target={openWithTarget}
                 onTargetChange={(t) => {
                   setOpenWithTarget(t);

--- a/src/components/resource-viewer/types.ts
+++ b/src/components/resource-viewer/types.ts
@@ -14,7 +14,15 @@ import type { FsReadResult } from "@/lib/api";
 
 /** Request from chat (or elsewhere) to open a path/URL in this pane. */
 export type ResourceOpenTarget =
-  | { type: "file"; path: string; title?: string }
+  | {
+      type: "file";
+      path: string;
+      title?: string;
+      /** 1-based line from path:line citation; soft-fail if out of range. */
+      line?: number | null;
+      /** Optional 1-based column (passed to open_in_editor when supported). */
+      column?: number | null;
+    }
   | { type: "url"; url: string; title?: string }
   /** Open the Changes side panel (session + workspace diffs). */
   | { type: "changes"; path?: string };
@@ -161,6 +169,13 @@ export interface FileTab {
   /** true = textarea editor; false = preview (markdown default). */
   editMode?: boolean;
   saving?: boolean;
+  /**
+   * 1-based focus line from a path:line open request.
+   * Soft-fail when out of range (preview ignores).
+   */
+  focusLine?: number | null;
+  /** Optional 1-based column (open_in_editor / future caret). */
+  focusColumn?: number | null;
 }
 
 export type RejectConfirmState = {

--- a/src/components/resource-viewer/useResourceFileTabs.ts
+++ b/src/components/resource-viewer/useResourceFileTabs.ts
@@ -340,13 +340,27 @@ const openFile = async (relativePath: string) => {
  * (handles monorepo: agent writes `05-handoff/next.md` under a subfolder).
  */
 const openAbsoluteFile = useCallback(
-  async (absolutePath: string, title?: string) => {
+  async (
+    absolutePath: string,
+    title?: string,
+    opts?: { line?: number | null; column?: number | null },
+  ) => {
     if (!api.isTauri()) {
       setError(tr("resources.openFailed"));
       return;
     }
     const norm = absolutePath.trim();
     if (!norm) return;
+    const focusLine =
+      opts?.line != null && Number.isInteger(opts.line) && opts.line >= 1
+        ? opts.line
+        : null;
+    const focusColumn =
+      opts?.column != null &&
+      Number.isInteger(opts.column) &&
+      opts.column >= 1
+        ? opts.column
+        : null;
     const existing = tabs.find(
       (t) => t.tabKind !== "url" && fileTabMatchesPath(t, norm),
     );
@@ -364,7 +378,14 @@ const openAbsoluteFile = useCallback(
     );
     if (!open.created) {
       // Move existing to front + activate (Chrome-like focus / MRU)
-      setTabs((prev) => mergeFileTabsFromOpen(prev, open));
+      // Refresh focus line when re-opening the same path from a citation.
+      setTabs((prev) =>
+        mergeFileTabsFromOpen(prev, open).map((t) =>
+          t.id === open.activeId
+            ? { ...t, focusLine, focusColumn }
+            : t,
+        ),
+      );
       setActiveId(open.activeId);
       return;
     }
@@ -379,6 +400,8 @@ const openAbsoluteFile = useCallback(
       error: null,
       loading: true,
       tabKind: "file",
+      focusLine,
+      focusColumn,
     };
     setTabs((prev) => mergeFileTabsFromOpen(prev, open, tab));
     setActiveId(id);
@@ -403,6 +426,14 @@ const openAbsoluteFile = useCallback(
         }
       }
       applyReadResult(id, r, src, relKey);
+      // applyReadResult replaces the tab fields — re-apply focus after read.
+      if (focusLine != null || focusColumn != null) {
+        setTabs((prev) =>
+          prev.map((t) =>
+            t.id === id ? { ...t, focusLine, focusColumn } : t,
+          ),
+        );
+      }
     } catch (e) {
       // Directory / non-file: drop the tab so the preview shows empty placeholder.
       const msg = String(e || "");

--- a/src/components/side-workbench/FilesWorkspace.tsx
+++ b/src/components/side-workbench/FilesWorkspace.tsx
@@ -52,6 +52,9 @@ export type FilesWorkspaceProps = {
    * When set, focus/open that path in the shared preview tabs.
    */
   activePath?: string | null;
+  /** 1-based line from path:line open request (soft-fail if out of range). */
+  activeLine?: number | null;
+  activeColumn?: number | null;
   /** Report file open from tree so parent can create/focus a SideTab. */
   onFileOpen?: (path: string, name: string) => void;
   paneActive?: boolean;
@@ -67,6 +70,8 @@ export function FilesWorkspace({
   treeVisible,
   onTreeVisibleChange,
   activePath,
+  activeLine = null,
+  activeColumn = null,
   onFileOpen,
   paneActive = true,
 }: FilesWorkspaceProps) {
@@ -176,12 +181,15 @@ export function FilesWorkspace({
       }
       if (cancelled) return;
       // Prefer absolute open (handles chat paths); falls back internally.
-      void openAbsoluteFile(p);
+      void openAbsoluteFile(p, undefined, {
+        line: activeLine,
+        column: activeColumn,
+      });
     })();
     return () => {
       cancelled = true;
     };
-  }, [activePath, paneActive, projectPath]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activePath, activeLine, activeColumn, paneActive, projectPath]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleDir = useCallback(
     async (node: TreeNode) => {
@@ -388,6 +396,7 @@ export function FilesWorkspace({
           {absPath ? (
             <OpenLocationButton
               path={absPath}
+              line={activeTab?.focusLine ?? activeLine}
               target={openWithTarget}
               onTargetChange={(t) => {
                 setOpenWithTarget(t);

--- a/src/components/side-workbench/SideWorkbench.tsx
+++ b/src/components/side-workbench/SideWorkbench.tsx
@@ -154,6 +154,10 @@ export function SideWorkbench({
   const hasFileTabs = state.tabs.some((t) => t.kind === "file");
   const activeFilePath =
     active?.kind === "file" ? (active.path ?? null) : null;
+  const activeFileLine =
+    active?.kind === "file" ? (active.line ?? null) : null;
+  const activeFileColumn =
+    active?.kind === "file" ? (active.column ?? null) : null;
 
   const pick = useCallback(
     (kind: SidePickerKind) => {
@@ -203,6 +207,8 @@ export function SideWorkbench({
         openSideTab(state, "file", {
           path: openRequest.path,
           name: openRequest.title,
+          line: openRequest.line,
+          column: openRequest.column,
         }),
       );
     } else if (openRequest.type === "url" && openRequest.url) {
@@ -272,6 +278,8 @@ export function SideWorkbench({
                     setState(setTreeVisible(state, v))
                   }
                   activePath={activeFilePath}
+                  activeLine={activeFileLine}
+                  activeColumn={activeFileColumn}
                   onFileOpen={onTreeFileOpen}
                   paneActive={paneActive && active.kind === "file"}
                 />

--- a/src/components/ui/message-response.tsx
+++ b/src/components/ui/message-response.tsx
@@ -28,6 +28,7 @@ import {
   normalizePathToken,
   resolveFileToken,
 } from "@/lib/pathRefs";
+import { parsePathLineCitation } from "@/lib/pathLineCitation";
 import type { ResourceOpenTarget } from "@/components/ResourceViewer";
 import { useSmoothStream } from "@/hooks/useSmoothStream";
 import { revealInOsLabel } from "@/lib/appPlatform";
@@ -108,7 +109,13 @@ function MessageResponseImpl({
   const renderPathOrUrl = (token: string, linkText?: string) => {
     const rawIn = token.trim().replace(/^<|>$/g, "");
     if (!rawIn) return null;
-    const raw = normalizePathToken(rawIn) || rawIn;
+    // Strip path:line[:col] before path resolution (soft-fail keeps original).
+    const citeIn = parsePathLineCitation(rawIn);
+    const citeNorm = parsePathLineCitation(normalizePathToken(rawIn) || rawIn);
+    const line = citeNorm.line ?? citeIn.line;
+    const column = citeNorm.column ?? citeIn.column;
+    const raw = normalizePathToken(citeNorm.path || citeIn.path || rawIn) || rawIn;
+    const pathForLooks = citeNorm.path || citeIn.path || raw;
 
     if (isHttpUrl(rawIn) || isHttpUrl(raw)) {
       const url = isHttpUrl(rawIn) ? rawIn : raw;
@@ -134,6 +141,7 @@ function MessageResponseImpl({
     // Prefer media map (images/videos session paths) — multi-segment local only.
     const mediaAbs =
       resolveInlineMediaToken(raw, imagePathMap) ||
+      resolveInlineMediaToken(pathForLooks, imagePathMap) ||
       resolveInlineMediaToken(rawIn, imagePathMap);
     if (
       mediaAbs &&
@@ -169,7 +177,12 @@ function MessageResponseImpl({
       );
     }
 
-    if (!looksLikeFilePath(raw) && !looksLikeFilePath(rawIn) && !mediaAbs) {
+    if (
+      !looksLikeFilePath(raw) &&
+      !looksLikeFilePath(pathForLooks) &&
+      !looksLikeFilePath(rawIn) &&
+      !mediaAbs
+    ) {
       return null;
     }
 
@@ -178,12 +191,18 @@ function MessageResponseImpl({
     const resolved =
       mediaAbs ||
       resolveFileToken(raw, { projectPath, pathMap: imagePathMap }) ||
+      resolveFileToken(pathForLooks, { projectPath, pathMap: imagePathMap }) ||
       resolveFileToken(rawIn, { projectPath, pathMap: imagePathMap });
-    if (!resolved && !looksLikeFilePath(raw) && !looksLikeFilePath(rawIn)) {
+    if (
+      !resolved &&
+      !looksLikeFilePath(raw) &&
+      !looksLikeFilePath(pathForLooks) &&
+      !looksLikeFilePath(rawIn)
+    ) {
       return null;
     }
 
-    const pathToken = resolved || raw || rawIn;
+    const pathToken = resolved || raw || pathForLooks || rawIn;
     const asLocalMedia = (p: string | null | undefined, kind: "image" | "video") => {
       if (!p || !isRealLocalAbsolutePath(p) || !isPlausibleLocalMediaAbs(p)) {
         return null;
@@ -243,11 +262,19 @@ function MessageResponseImpl({
         }
         projectPath={projectPath}
         kind="file"
+        line={line}
+        column={column}
         subtitle={fileSubtitle(pathToken, locale === "en" ? "en" : "zh")}
         labels={fileLabels}
         onOpenInPanel={(t) => {
           if (t.type === "file" && t.path) {
-            onOpenResource?.({ type: "file", path: t.path, title: t.title });
+            onOpenResource?.({
+              type: "file",
+              path: t.path,
+              title: t.title,
+              line: t.line ?? line,
+              column: t.column ?? column,
+            });
           }
         }}
       />

--- a/src/lib/pathLineCitation.test.ts
+++ b/src/lib/pathLineCitation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeFocusLine,
+  parsePathLineCitation,
+  pathWithoutLineSuffix,
+} from "./pathLineCitation";
+
+describe("parsePathLineCitation", () => {
+  it("parses path:line", () => {
+    expect(parsePathLineCitation("src/lib/foo.ts:42")).toEqual({
+      path: "src/lib/foo.ts",
+      line: 42,
+      column: null,
+    });
+  });
+
+  it("parses path:line:col", () => {
+    expect(parsePathLineCitation("src/lib/foo.ts:42:10")).toEqual({
+      path: "src/lib/foo.ts",
+      line: 42,
+      column: 10,
+    });
+  });
+
+  it("parses absolute unix path:line", () => {
+    expect(parsePathLineCitation("/Users/me/proj/a.md:1")).toEqual({
+      path: "/Users/me/proj/a.md",
+      line: 1,
+      column: null,
+    });
+  });
+
+  it("handles Windows drive letters", () => {
+    expect(parsePathLineCitation("C:\\Users\\me\\a.ts:12")).toEqual({
+      path: "C:\\Users\\me\\a.ts",
+      line: 12,
+      column: null,
+    });
+    expect(parsePathLineCitation("C:/Users/me/a.ts:12:3")).toEqual({
+      path: "C:/Users/me/a.ts",
+      line: 12,
+      column: 3,
+    });
+  });
+
+  it("leaves plain paths alone", () => {
+    expect(parsePathLineCitation("src/lib/foo.ts")).toEqual({
+      path: "src/lib/foo.ts",
+      line: null,
+      column: null,
+    });
+  });
+
+  it("soft-fails invalid line (zero) — keeps full token", () => {
+    expect(parsePathLineCitation("src/foo.ts:0")).toEqual({
+      path: "src/foo.ts:0",
+      line: null,
+      column: null,
+    });
+  });
+
+  it("does not rewrite URLs with ports", () => {
+    const u = "https://example.com:8080/path";
+    expect(parsePathLineCitation(u)).toEqual({
+      path: u,
+      line: null,
+      column: null,
+    });
+  });
+
+  it("does not treat bare words:number as path citations", () => {
+    expect(parsePathLineCitation("error:404")).toEqual({
+      path: "error:404",
+      line: null,
+      column: null,
+    });
+  });
+
+  it("accepts bare filename with extension", () => {
+    expect(parsePathLineCitation("README.md:3")).toEqual({
+      path: "README.md",
+      line: 3,
+      column: null,
+    });
+  });
+
+  it("trims whitespace", () => {
+    expect(parsePathLineCitation("  src/a.ts:9  ")).toEqual({
+      path: "src/a.ts",
+      line: 9,
+      column: null,
+    });
+  });
+});
+
+describe("normalizeFocusLine", () => {
+  it("accepts in-range lines", () => {
+    expect(normalizeFocusLine(3, 10)).toBe(3);
+    expect(normalizeFocusLine(1, 1)).toBe(1);
+  });
+
+  it("soft-fails out of range / invalid", () => {
+    expect(normalizeFocusLine(0, 10)).toBeNull();
+    expect(normalizeFocusLine(11, 10)).toBeNull();
+    expect(normalizeFocusLine(null, 10)).toBeNull();
+    expect(normalizeFocusLine(5, 0)).toBeNull();
+    expect(normalizeFocusLine(1.5, 10)).toBeNull();
+  });
+
+  it("allows unbounded when lineCount omitted", () => {
+    expect(normalizeFocusLine(999)).toBe(999);
+  });
+});
+
+describe("pathWithoutLineSuffix", () => {
+  it("strips valid suffix", () => {
+    expect(pathWithoutLineSuffix("a/b.ts:2:1")).toBe("a/b.ts");
+  });
+});

--- a/src/lib/pathLineCitation.ts
+++ b/src/lib/pathLineCitation.ts
@@ -1,0 +1,123 @@
+/**
+ * Parse `path:line` / `path:line:col` citations (rg / LSP / agent style).
+ * Pure helpers — soft-fail invalid line/col (never throw).
+ */
+
+export type PathLineCitation = {
+  /** Path with line/col suffix removed when a valid numeric suffix was present. */
+  path: string;
+  /** 1-based line, or null when absent / invalid. */
+  line: number | null;
+  /** 1-based column, or null when absent / invalid. */
+  column: number | null;
+};
+
+const MAX_LINE = 10_000_000;
+const MAX_COL = 10_000_000;
+
+/**
+ * True when `s` looks like `C:` / `D:` Windows drive prefix at index 0.
+ */
+function isWindowsDrivePrefix(s: string): boolean {
+  return s.length >= 2 && /[A-Za-z]/.test(s[0]!) && s[1] === ":";
+}
+
+/**
+ * Parse a trailing `:digits` or `:digits:digits` suffix as line / line:col.
+ * Does not treat Windows drive letters as the first separator.
+ * Soft-fail: zero, negative, non-finite, or oversized → null fields; path
+ * stays the original token when nothing valid was stripped.
+ */
+export function parsePathLineCitation(raw: string): PathLineCitation {
+  const input = (raw ?? "").trim();
+  if (!input) {
+    return { path: "", line: null, column: null };
+  }
+
+  // Never rewrite URLs (host:port) or schemes.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(input) || /^https?:\/\//i.test(input)) {
+    return { path: input, line: null, column: null };
+  }
+
+  const start = isWindowsDrivePrefix(input) ? 2 : 0;
+  const rest = input.slice(start);
+  // Prefer :line:col from the end, then :line only (greedy .* would steal :line).
+  let pathBody = "";
+  let lineRaw = "";
+  let colRaw: string | undefined;
+  const both = rest.match(/^(.*):(\d{1,9}):(\d{1,9})$/);
+  if (both) {
+    pathBody = both[1] ?? "";
+    lineRaw = both[2] ?? "";
+    colRaw = both[3];
+  } else {
+    const one = rest.match(/^(.*):(\d{1,9})$/);
+    if (!one) {
+      return { path: input, line: null, column: null };
+    }
+    pathBody = one[1] ?? "";
+    lineRaw = one[2] ?? "";
+  }
+  // Path must be non-empty after strip (avoid bare `:12`).
+  if (!pathBody) {
+    return { path: input, line: null, column: null };
+  }
+
+  const path = input.slice(0, start) + pathBody;
+  // Require the stripped path to still look path-like (avoid `error:404` etc.).
+  // Allow extensions, separators, or absolute/home roots.
+  const looksPath =
+    /[/\\]/.test(path) ||
+    /\.\w{1,12}$/.test(path) ||
+    path.startsWith("~") ||
+    isWindowsDrivePrefix(path);
+  if (!looksPath) {
+    return { path: input, line: null, column: null };
+  }
+
+  const line = parsePositiveInt(lineRaw, MAX_LINE);
+  const column =
+    colRaw != null && colRaw !== ""
+      ? parsePositiveInt(colRaw, MAX_COL)
+      : null;
+
+  // Soft-fail invalid line: keep full token (do not invent a partial strip).
+  if (line == null) {
+    return { path: input, line: null, column: null };
+  }
+
+  return { path, line, column };
+}
+
+function parsePositiveInt(s: string, max: number): number | null {
+  if (!/^\d+$/.test(s)) return null;
+  // Avoid Number('') / leading zeros issues; BigInt not needed for line numbers.
+  const n = Number(s);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) return null;
+  if (n < 1 || n > max) return null;
+  return n;
+}
+
+/**
+ * Clamp a 1-based focus line into `[1, lineCount]`.
+ * Soft-fail: missing / invalid / empty file → null (caller skips scroll).
+ */
+export function normalizeFocusLine(
+  line: number | null | undefined,
+  lineCount?: number | null,
+): number | null {
+  if (line == null || !Number.isFinite(line) || !Number.isInteger(line)) {
+    return null;
+  }
+  if (line < 1) return null;
+  if (lineCount != null) {
+    if (!Number.isFinite(lineCount) || lineCount < 1) return null;
+    if (line > lineCount) return null;
+  }
+  return line;
+}
+
+/** Path only (line/col stripped when valid). */
+export function pathWithoutLineSuffix(raw: string): string {
+  return parsePathLineCitation(raw).path;
+}

--- a/src/lib/sideContextOpen.test.ts
+++ b/src/lib/sideContextOpen.test.ts
@@ -17,6 +17,22 @@ describe("applySideContextOpen", () => {
     );
   });
 
+  it("forwards path:line focus onto the file tab", () => {
+    const r = applySideContextOpen(emptySideWorkbenchState(), {
+      type: "file",
+      path: "/a/b.ts",
+      title: "b.ts",
+      line: 42,
+      column: 3,
+    });
+    const tab = r.state.tabs[0];
+    expect(tab?.kind).toBe("file");
+    if (tab?.kind === "file") {
+      expect(tab.line).toBe(42);
+      expect(tab.column).toBe(3);
+    }
+  });
+
   it("opens browser tab for url", () => {
     const r = applySideContextOpen(emptySideWorkbenchState(), {
       type: "url",

--- a/src/lib/sideContextOpen.ts
+++ b/src/lib/sideContextOpen.ts
@@ -9,7 +9,13 @@ import {
 } from "@/lib/sideWorkbench";
 
 export type SideContextOpenTarget =
-  | { type: "file"; path: string; title?: string }
+  | {
+      type: "file";
+      path: string;
+      title?: string;
+      line?: number | null;
+      column?: number | null;
+    }
   | { type: "url"; url: string; title?: string }
   | { type: "changes"; path?: string };
 
@@ -33,6 +39,8 @@ export function applySideContextOpen(
     const next = openSideTab(state, "file", {
       path: target.path,
       name: target.title,
+      line: target.line,
+      column: target.column,
     });
     return { state: next, needAsideOpen: true, kind: "file" };
   }

--- a/src/lib/sideWorkbench.test.ts
+++ b/src/lib/sideWorkbench.test.ts
@@ -110,6 +110,25 @@ describe("openSideTab / close / activate", () => {
     expect(r2.tabs.filter((t) => t.kind === "review")).toHaveLength(1);
   });
 
+  it("stores and refreshes path:line on file tabs", () => {
+    let s = emptySideWorkbenchState();
+    s = openSideTab(s, "file", { path: "/p/a.ts", line: 10, column: 2 });
+    const first = s.tabs[0];
+    expect(first?.kind).toBe("file");
+    if (first?.kind === "file") {
+      expect(first.line).toBe(10);
+      expect(first.column).toBe(2);
+    }
+    const again = openSideTab(s, "file", { path: "/p/a.ts", line: 99 });
+    expect(again.created).toBe(false);
+    const tab = again.tabs[0];
+    expect(tab?.kind).toBe("file");
+    if (tab?.kind === "file") {
+      expect(tab.line).toBe(99);
+      expect(tab.column).toBeNull();
+    }
+  });
+
   it("allows multiple terminals", () => {
     let s = emptySideWorkbenchState();
     s = openSideTab(s, "terminal");

--- a/src/lib/sideWorkbench.ts
+++ b/src/lib/sideWorkbench.ts
@@ -12,7 +12,15 @@ export type SidePickerKind = "file" | "browser" | "terminal" | "review" | "skill
 export type SideTabKind = SidePickerKind | "plan";
 
 export type SideTab =
-  | { id: string; kind: "file"; path?: string; name: string }
+  | {
+      id: string;
+      kind: "file";
+      path?: string;
+      name: string;
+      /** 1-based line from path:line open (soft-fail if out of range). */
+      line?: number | null;
+      column?: number | null;
+    }
   | { id: string; kind: "browser"; url?: string; title?: string; name: string }
   | { id: string; kind: "terminal"; sessionKey: string; name: string }
   | { id: string; kind: "review"; name: string }
@@ -44,6 +52,9 @@ export type CreateSideTabMeta = {
   title?: string;
   planRef?: string;
   sessionKey?: string;
+  /** 1-based line for file path:line open. */
+  line?: number | null;
+  column?: number | null;
 };
 
 export type OpenSideTabResult = SideWorkbenchState & {
@@ -180,7 +191,14 @@ function buildTab(kind: SideTabKind, meta?: CreateSideTabMeta): SideTab {
   const name = defaultName(kind, meta);
   switch (kind) {
     case "file":
-      return { id, kind, path: meta?.path, name };
+      return {
+        id,
+        kind,
+        path: meta?.path,
+        name,
+        line: meta?.line ?? null,
+        column: meta?.column ?? null,
+      };
     case "browser":
       return {
         id,
@@ -250,12 +268,23 @@ export function openSideTab(
 
   if (existingIdx >= 0) {
     const hit = tabs[existingIdx]!;
+    // Refresh path:line focus when re-opening the same file citation.
+    const refreshed: SideTab =
+      hit.kind === "file" && kind === "file"
+        ? {
+            ...hit,
+            line: meta?.line ?? null,
+            column: meta?.column ?? null,
+            name: meta?.name?.trim() || hit.name,
+            path: meta?.path?.trim() || hit.path,
+          }
+        : hit;
     const rest = tabs.filter((_, i) => i !== existingIdx);
-    const nextTabs = [hit, ...rest];
+    const nextTabs = [refreshed, ...rest];
     return {
       ...state,
       tabs: nextTabs,
-      activeId: hit.id,
+      activeId: refreshed.id,
       created: false,
       droppedIds: [],
     };

--- a/src/styles/code-preview.css
+++ b/src/styles/code-preview.css
@@ -85,6 +85,18 @@
   line-height: 1.55;
 }
 
+/* path:line citation focus (soft highlight; theme-aware) */
+.rp-code__line--focus {
+  background: color-mix(in srgb, var(--accent, #61afef) 18%, transparent);
+  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--accent, #61afef) 70%, transparent);
+}
+
+.rp-code__ln--focus {
+  color: var(--accent, #61afef);
+  opacity: 1;
+  font-weight: 600;
+}
+
 .rp-code__footer {
   flex-shrink: 0;
   padding: 6px 12px;


### PR DESCRIPTION
## Summary
Open `path:line` / `path:line:col` citations from chat into the side resource preview scrolled and highlighted to that line, and pass the line to external `open_in_editor` (`-g path:line`). Invalid lines soft-fail (file still opens, no jump).

## Type of change
- [x] New feature

## What changed
- Pure parse helpers: `src/lib/pathLineCitation.ts` (+ tests) for `path:line` / `path:line:col` (Windows drive-safe)
- Chat path cards (`FilePathCard`, `MarkdownChat`, `message-response`) strip line/col, resolve path, pass focus line through `ResourceOpenTarget`
- Side workbench file tabs + `openAbsoluteFile` store `focusLine`; `CodePreview` scrolls/highlights
- `OpenLocationButton` / card open-external pass line to `openInEditor` when present
- Codebase search open-in-resources also forwards `line`
- Docs: `docs/llm-wiki/media-delivery.md` path citation rule #5

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (targeted: pathLineCitation / sideContextOpen / sideWorkbench)
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only) — N/A (frontend-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new UI strings (soft-fail silent)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included