### PR TITLE
feat(editors): default open target and open-with honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Added
+- **Default open target / open-with honesty**: Settings → Open files with lists probed editors (unavailable preferred soft-disabled + empty/preferred-missing honesty); Open Location menus put the preferred editor first with icons; Resource/Review open-in-editor uses session/global default and soft-fails with i18n copy when the editor is missing. Pure selection helpers + tests; en/zh/zh-TW.
 - **Sandbox product path honesty (F4)**: Settings → Permissions surfaces App **Workspace** default vs terminal CLI **Off**, Open sandbox guide wizard CTA, disabled-off soft-empty note, Linux userns / `SANDBOX_BLOCKED` platform note, and leader ↔ non-off sandbox mutual exclusion (also on Runtime → Leader). Wizard re-wired after project trust (when global profile is Off) and from project sandbox menu. Pure helpers + en/zh/zh-TW + tests.
 - **Export path honesty**: Session export menu shows clear format labels (name + extension) with **Journal** / **CLI export** badges. Markdown full-transcript download prefers `grok export` when an agent session is linked (soft-fails to local journal); other formats and copy stay journal-only. Pure path-resolution helpers + tests; en/zh/zh-TW.
 - **Live Voice delegate session honesty**: Overlay restores delegated/active session chips with real titles + liveMap progress while Live Voice is open; keep-agents default stays on (opt-out cancels turns). Soft-fail mic/auth/network/cli surfaces classified toasts in addition to overlay copy. Host never records blank delegated ids. Pure helpers + tests; existing en/zh/zh-TW `voice.err.*` / `voice.center.*`.
@@ -25,6 +26,7 @@ See `docs/llm-wiki/release.md`.
 - **导出路径诚实徽章**：导出会话菜单显示格式名+扩展名，并标注 **会话记录 / CLI 导出**。完整 Markdown 下载在已关联 agent 时优先 `grok export`（失败回退本地记录）；其他格式与复制仅用会话记录。纯路径解析 + 测试；中英繁。
 - **实时语音委派会话诚实**：叠加层恢复委派/活动会话芯片（真实标题 + liveMap 进度）；结束后默认保留 Agent（关闭则取消回合）。麦克风/鉴权/网络/CLI 软失败额外 toast 分类文案。Host 不记录空委派 id。纯 helper + 测试；沿用三语 `voice.err.*` / `voice.center.*`。
 - **Composer 口述诚实性**：麦克风始终可见并标明插入/发送；转写中可取消；空语音/鉴权 soft-fail；自动发送被权限挡住时提示已插入。纯 helper + 测试；三语文案。不含 Live Voice S2S。
+- **默认打开目标 / 打开方式诚实提示**：设置「打开文件方式」列出探测到的编辑器（缺失首选软禁用 + 空/缺失诚实文案）；打开位置菜单优先默认编辑器并显示图标；资源/审查「在编辑器中打开」跟随会话/全局默认，缺失时 i18n 软失败。纯选择助手 + 测试；en/zh/zh-TW。
 - **外观字体 (#553)**：设置 → 外观 可配置界面字体与内置终端字体/字号（本机偏好；终端优先 Nerd Font 以显示 Starship 图标）。
 - **首选 agent 生效路径诚实 (#564)**：设置与 Agents & Personas 控制台标明 spawn `--agent` 路径 — 已连接 soft-respawn、空闲下次连接；目录缺失/非法名称 soft-fail。纯 helper + 测试；三语文案。
 - **记忆清除范围 + Dream 诚实**：操作中心 GlassModal 清除 host 作用域 **workspace / global / all**（真实 CLI 参数，不用 `window.confirm`）。Dream/Watcher 仅表示配置存在性，绝不伪造「运行中」。跨会话记忆默认关闭并强制 `--no-memory`。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -55,6 +55,7 @@ import {
   type StopAllSurface,
 } from "@/lib/stopAllHonesty";
 import { detectAppPlatform, revealInOsLabel } from "@/lib/appPlatform";
+import { writeOpenTargetStorage } from "@/lib/openEditorHonesty";
 import {
   APP_CLOSE_REQUESTED_EVENT,
   APP_CLOSE_TAB_OR_WINDOW_EVENT,
@@ -3259,10 +3260,14 @@ export function AppWorkbench() {
           settings.sessionDataMode || DEFAULT_SESSION_DATA_MODE,
         ),
       );
-      setDefaultOpenTarget(
-        (settings as { defaultOpenTarget?: string }).defaultOpenTarget ||
-          "finder",
-      );
+      {
+        const openTarget =
+          (settings as { defaultOpenTarget?: string }).defaultOpenTarget ||
+          "finder";
+        setDefaultOpenTarget(openTarget);
+        // Keep Resource/Review session storage aligned with Host settings.
+        writeOpenTargetStorage(openTarget);
+      }
       setAcpServerAddr(settings.acpServerAddr || "");
       {
         const st = settings as {
@@ -4097,11 +4102,7 @@ export function AppWorkbench() {
 
   const persistOpenTarget = useCallback((target: string) => {
     setDefaultOpenTarget(target);
-    try {
-      localStorage.setItem("grok-app.openTarget", target);
-    } catch {
-      /* ignore */
-    }
+    writeOpenTargetStorage(target);
     void api.settingsGet().then((s) =>
       api.settingsSet({ ...s, defaultOpenTarget: target }),
     );
@@ -17428,10 +17429,11 @@ export function AppWorkbench() {
           onImportChat={() => void importChatTranscript()}
           defaultOpenTarget={defaultOpenTarget}
           onDefaultOpenTarget={(v) => {
-          setDefaultOpenTarget(v);
-          void api.settingsGet().then((s) =>
-          api.settingsSet({ ...s, defaultOpenTarget: v }),
-          );
+            setDefaultOpenTarget(v);
+            writeOpenTargetStorage(v);
+            void api.settingsGet().then((s) =>
+              api.settingsSet({ ...s, defaultOpenTarget: v }),
+            );
           }}
           archivedGroups={archivedGroups}
           onRestoreArchivedSessions={(ids) => {

--- a/src/components/OpenLocationButton.tsx
+++ b/src/components/OpenLocationButton.tsx
@@ -15,6 +15,14 @@ import {
   isGitGuiEditorId,
 } from "@/lib/openApps";
 import {
+  isOsOpenTarget,
+  normalizeOpenTargetId,
+  orderOpenWithEditors,
+  planOpenInEditor,
+  resolveEffectiveOpenTarget,
+  writeOpenTargetStorage,
+} from "@/lib/openEditorHonesty";
+import {
   IconChevronDown,
   IconCopy,
   IconExternalLink,
@@ -57,8 +65,7 @@ export interface OpenLocationButtonProps {
 }
 
 function normalizeTarget(t: string | undefined | null): string {
-  const v = (t || "finder").trim().toLowerCase();
-  return v || "finder";
+  return normalizeOpenTargetId(t);
 }
 
 export function OpenLocationButton({
@@ -161,28 +168,24 @@ export function OpenLocationButton({
     };
   }, [path]);
 
-  const visibleEditors = useMemo(
-    () => filterEditorsForGitContext(editors, isGitRepo),
-    [editors, isGitRepo],
-  );
+  const visibleEditors = useMemo(() => {
+    const filtered = filterEditorsForGitContext(editors, isGitRepo);
+    // Prefer default open target first in the open-with list.
+    return orderOpenWithEditors(filtered, target);
+  }, [editors, isGitRepo, target]);
 
   const finderTarget = platform === "win" ? "explorer" : "finder";
   // linux/other also use path_reveal; target id stays "finder" for persistence.
 
   const active = normalizeTarget(target);
-  // If last-used target was a git GUI but this project is not a repo, fall back.
+  // Prefer default when available; soft-fall back to Finder when missing.
   const effectiveActive = useMemo(() => {
     if (isGitGuiEditorId(active) && !isGitRepo) return finderTarget;
-    if (
-      active !== "finder" &&
-      active !== "explorer" &&
-      active !== "system" &&
-      active !== "default" &&
-      !visibleEditors.some((e) => e.id === active)
-    ) {
-      return finderTarget;
-    }
-    return active;
+    return resolveEffectiveOpenTarget({
+      preferred: active,
+      availableIds: visibleEditors.map((e) => e.id),
+      osTarget: finderTarget,
+    });
   }, [active, isGitRepo, finderTarget, visibleEditors]);
 
   const currentIcon = useMemo(() => {
@@ -204,7 +207,18 @@ export function OpenLocationButton({
       if (isGitGuiEditorId(t) && !isGitRepo) {
         t = finderTarget;
       }
-      if (remember) onTargetChange(t);
+      // Soft-resolve preferred → available / OS fallback before Host call.
+      if (!isOsOpenTarget(t)) {
+        t = resolveEffectiveOpenTarget({
+          preferred: t,
+          availableIds: editors.map((e) => e.id),
+          osTarget: finderTarget,
+        });
+      }
+      if (remember) {
+        writeOpenTargetStorage(t);
+        onTargetChange(t);
+      }
       const gotoLine =
         line != null && Number.isInteger(line) && line >= 1 ? line : undefined;
       try {
@@ -213,13 +227,38 @@ export function OpenLocationButton({
         } else if (t === "system" || t === "default") {
           await api.pathOpen(path);
         } else {
-          await api.openInEditor({ path, editor: t, line: gotoLine });
+          const plan = planOpenInEditor({
+            path,
+            editorId: t,
+            isTauri: api.isTauri(),
+            availableIds: editors.map((e) => e.id),
+            editorsFound: editors.length,
+          });
+          if (!plan.ok) {
+            if (plan.kind === "cancelled") return;
+            onOpenError?.(plan.kind);
+            return;
+          }
+          await api.openInEditor({
+            path: plan.path,
+            editor: plan.editorId ?? t,
+            line: gotoLine,
+          });
         }
       } catch (e) {
         onOpenError?.(String(e));
       }
     },
-    [path, line, disabled, onTargetChange, onOpenError, isGitRepo, finderTarget],
+    [
+      path,
+      line,
+      disabled,
+      onTargetChange,
+      onOpenError,
+      isGitRepo,
+      finderTarget,
+      editors,
+    ],
   );
 
   if (!path) return null;

--- a/src/components/resource-viewer/ResourceViewer.tsx
+++ b/src/components/resource-viewer/ResourceViewer.tsx
@@ -16,7 +16,9 @@ import * as api from "@/lib/api";
 import { createT } from "@/i18n";
 import {
   formatOpenEditorErrorMessage,
+  readOpenTargetStorage,
   resolveOpenEditorError,
+  writeOpenTargetStorage,
 } from "@/lib/openEditorHonesty";
 import { EmbeddedBrowser } from "@/components/EmbeddedBrowser";
 import { OverlayScroll } from "@/components/OverlayScroll";
@@ -183,13 +185,21 @@ export function ResourceViewer({
   const [resizingTree, setResizingTree] = useState(false);
   const splitRef = useRef<HTMLDivElement>(null);
   /** Open-with target for the location button (finder / editor id). */
-  const [openWithTarget, setOpenWithTarget] = useState(() => {
-    try {
-      return localStorage.getItem("grok-app.openTarget") || "finder";
-    } catch {
-      return "finder";
-    }
-  });
+  const [openWithTarget, setOpenWithTarget] = useState(() =>
+    readOpenTargetStorage("finder"),
+  );
+
+  const persistOpenWithTarget = useCallback((t: string) => {
+    setOpenWithTarget(t);
+    writeOpenTargetStorage(t);
+    // Keep Host settings.defaultOpenTarget in sync with session UI default.
+    void api
+      .settingsGet()
+      .then((s) => api.settingsSet({ ...s, defaultOpenTarget: t }))
+      .catch(() => {
+        /* soft-fail — localStorage still holds session default */
+      });
+  }, []);
 
   const changes = useResourceChanges({
     projectPath,
@@ -885,14 +895,7 @@ export function ResourceViewer({
               path={absPath}
               line={activeTab?.focusLine}
               target={openWithTarget}
-              onTargetChange={(t) => {
-                setOpenWithTarget(t);
-                try {
-                  localStorage.setItem("grok-app.openTarget", t);
-                } catch {
-                  /* ignore */
-                }
-              }}
+              onTargetChange={persistOpenWithTarget}
               onOpenError={(e) => {
                 // OpenLocationButton may reveal, system-open, or open-in-editor.
                 // Prefer open-editor classifier (superset); reveal-only phrases map fine.
@@ -1097,14 +1100,7 @@ export function ResourceViewer({
                 path={absPath}
                 line={activeTab?.focusLine}
                 target={openWithTarget}
-                onTargetChange={(t) => {
-                  setOpenWithTarget(t);
-                  try {
-                    localStorage.setItem("grok-app.openTarget", t);
-                  } catch {
-                    /* ignore */
-                  }
-                }}
+                onTargetChange={persistOpenWithTarget}
                 onOpenError={(e) => {
                   const resolved = resolveOpenEditorError(e);
                   if (resolved.silent) return;

--- a/src/components/resource-viewer/useResourceChanges.ts
+++ b/src/components/resource-viewer/useResourceChanges.ts
@@ -16,7 +16,9 @@ import type { MessageKey } from "@/i18n";
 import {
   formatOpenEditorErrorMessage,
   formatRevealErrorMessage,
+  isOsOpenTarget,
   planOpenInEditor,
+  readOpenTargetStorage,
   resolveOpenEditorError,
   resolveRevealError,
 } from "@/lib/openEditorHonesty";
@@ -484,8 +486,13 @@ const loadWorkspaceDiff = useCallback(
 
 const openChangeInEditor = useCallback(
   async (path: string) => {
+    // Prefer session/global default open target when it is a code editor.
+    // OS targets fall through so Host uses settings.defaultOpenTarget.
+    const preferred = readOpenTargetStorage("finder");
+    const editorId = isOsOpenTarget(preferred) ? null : preferred;
     const plan = planOpenInEditor({
       path,
+      editorId,
       isTauri: api.isTauri(),
     });
     if (!plan.ok) {
@@ -494,7 +501,10 @@ const openChangeInEditor = useCallback(
       return;
     }
     try {
-      await api.openInEditor({ path: plan.path });
+      await api.openInEditor({
+        path: plan.path,
+        editor: plan.editorId ?? undefined,
+      });
     } catch (e) {
       const resolved = resolveOpenEditorError(e);
       if (resolved.silent) return;

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -81,7 +81,12 @@ import { AgentConfigTomlPanel } from "@/components/AgentConfigTomlPanel";
 import { CliSessionsPanel } from "./CliSessionsPanel";
 import { SettingsTabStrip, UiCheck } from "./shared";
 import { resolveLocale } from "@/i18n";
+import type { MessageKey } from "@/i18n";
 import * as api from "@/lib/api";
+import {
+  buildOpenTargetSelectOptions,
+  resolveOpenEditorEmptyState,
+} from "@/lib/openEditorHonesty";
 
 
 export function GeneralSection() {
@@ -2465,7 +2470,10 @@ export function GeneralSection() {
               </div>
               {onDefaultOpenTarget && (
                 <div
-                  className={"settings-row" + rowHighlight("settings-anchor-openTarget")}
+                  className={
+                    "settings-row settings-row--stack" +
+                    rowHighlight("settings-anchor-openTarget")
+                  }
                   id="settings-anchor-openTarget"
                 >
                   <div className="settings-row__text">
@@ -2479,14 +2487,43 @@ export function GeneralSection() {
                   <Select
                     value={defaultOpenTarget}
                     onChange={onDefaultOpenTarget}
-                    options={[
-                      { value: "finder", label: t("settings.openFinder") },
-                      ...editors.map((e: { id: string; label: string }) => ({
-                        value: e.id,
-                        label: e.label,
-                      })),
-                    ]}
+                    aria-label={t("settings.openTarget")}
+                    options={buildOpenTargetSelectOptions({
+                      finderLabel: t("settings.openFinder"),
+                      preferred: defaultOpenTarget,
+                      unavailableSuffix: t("settings.openTargetUnavailable"),
+                      editors: (editors ?? []) as {
+                        id: string;
+                        label: string;
+                        available?: boolean;
+                      }[],
+                    })}
                   />
+                  {(() => {
+                    const available = (
+                      (editors ?? []) as {
+                        id: string;
+                        available?: boolean;
+                      }[]
+                    ).filter((e) => e.available !== false);
+                    const empty = resolveOpenEditorEmptyState({
+                      editorsFound: available.length,
+                      preferred: defaultOpenTarget,
+                      availableIds: available.map((e) => e.id),
+                    });
+                    if (!empty.messageKey) return null;
+                    return (
+                      <div
+                        className={
+                          "settings-row__hint" +
+                          (empty.severity === "warn" ? " is-danger" : "")
+                        }
+                        role="status"
+                      >
+                        {t(empty.messageKey as MessageKey)}
+                      </div>
+                    );
+                  })()}
                 </div>
               )}
             </div>

--- a/src/components/side-workbench/FilesWorkspace.tsx
+++ b/src/components/side-workbench/FilesWorkspace.tsx
@@ -36,7 +36,9 @@ import type { FileTab, TreeNode } from "@/components/resource-viewer/types";
 import { useResourceFileTabs } from "@/components/resource-viewer/useResourceFileTabs";
 import {
   formatOpenEditorErrorMessage,
+  readOpenTargetStorage,
   resolveOpenEditorError,
+  writeOpenTargetStorage,
 } from "@/lib/openEditorHonesty";
 import { pathBaseName } from "@/lib/sessionChanges";
 
@@ -84,13 +86,20 @@ export function FilesWorkspace({
   const [treeWidth, setTreeWidth] = useState(loadTreeWidth);
   const [resizingTree, setResizingTree] = useState(false);
   const splitRef = useRef<HTMLDivElement>(null);
-  const [openWithTarget, setOpenWithTarget] = useState(() => {
-    try {
-      return localStorage.getItem("grok-app.openTarget") || "finder";
-    } catch {
-      return "finder";
-    }
-  });
+  const [openWithTarget, setOpenWithTarget] = useState(() =>
+    readOpenTargetStorage("finder"),
+  );
+
+  const persistOpenWithTarget = useCallback((t: string) => {
+    setOpenWithTarget(t);
+    writeOpenTargetStorage(t);
+    void api
+      .settingsGet()
+      .then((s) => api.settingsSet({ ...s, defaultOpenTarget: t }))
+      .catch(() => {
+        /* soft-fail — localStorage still holds session default */
+      });
+  }, []);
 
   const fileTabs = useResourceFileTabs({
     projectPath,
@@ -398,14 +407,7 @@ export function FilesWorkspace({
               path={absPath}
               line={activeTab?.focusLine ?? activeLine}
               target={openWithTarget}
-              onTargetChange={(t) => {
-                setOpenWithTarget(t);
-                try {
-                  localStorage.setItem("grok-app.openTarget", t);
-                } catch {
-                  /* ignore */
-                }
-              }}
+              onTargetChange={persistOpenWithTarget}
               onOpenError={(e) => {
                 const resolved = resolveOpenEditorError(e);
                 if (resolved.silent) return;

--- a/src/components/side-workbench/ReviewTab.tsx
+++ b/src/components/side-workbench/ReviewTab.tsx
@@ -13,7 +13,7 @@ import {
   type ReactNode,
 } from "react";
 import * as api from "@/lib/api";
-import { createT, type Locale } from "@/i18n";
+import { createT, type Locale, type MessageKey } from "@/i18n";
 import {
   IconArrowsMinimize,
   IconCode,
@@ -45,6 +45,15 @@ import {
   type ReviewDiffRow,
   type ReviewTreeNode,
 } from "@/lib/reviewDiff";
+import {
+  formatOpenEditorErrorMessage,
+  formatRevealErrorMessage,
+  isOsOpenTarget,
+  planOpenInEditor,
+  readOpenTargetStorage,
+  resolveOpenEditorError,
+  resolveRevealError,
+} from "@/lib/openEditorHonesty";
 
 export type ReviewTabProps = {
   locale: Locale | string;
@@ -514,25 +523,53 @@ export function ReviewTab({
     }
   }, [selectedFile]);
 
+  const [openErr, setOpenErr] = useState<string | null>(null);
+
   const revealSelected = useCallback(async () => {
     const p = selectedFile?.path;
-    if (!p || !api.isTauri()) return;
+    if (!p) return;
+    if (!api.isTauri()) {
+      const resolved = resolveRevealError({ code: "host_only" });
+      setOpenErr(formatRevealErrorMessage(resolved, tr));
+      return;
+    }
     try {
       await api.pathReveal(p);
-    } catch {
-      /* soft-fail */
+      setOpenErr(null);
+    } catch (e) {
+      const resolved = resolveRevealError(e);
+      if (resolved.silent) return;
+      setOpenErr(formatRevealErrorMessage(resolved, tr));
     }
-  }, [selectedFile]);
+  }, [selectedFile, tr]);
 
   const openSelectedInEditor = useCallback(async () => {
     const p = selectedFile?.path;
-    if (!p || !api.isTauri()) return;
-    try {
-      await api.openInEditor({ path: p });
-    } catch {
-      /* soft-fail */
+    if (!p) return;
+    const preferred = readOpenTargetStorage("finder");
+    const editorId = isOsOpenTarget(preferred) ? null : preferred;
+    const plan = planOpenInEditor({
+      path: p,
+      editorId,
+      isTauri: api.isTauri(),
+    });
+    if (!plan.ok) {
+      if (plan.kind === "cancelled") return;
+      setOpenErr(tr(plan.messageKey as MessageKey));
+      return;
     }
-  }, [selectedFile]);
+    try {
+      await api.openInEditor({
+        path: plan.path,
+        editor: plan.editorId ?? undefined,
+      });
+      setOpenErr(null);
+    } catch (e) {
+      const resolved = resolveOpenEditorError(e);
+      if (resolved.silent) return;
+      setOpenErr(formatOpenEditorErrorMessage(resolved, tr));
+    }
+  }, [selectedFile, tr]);
 
 
 
@@ -729,6 +766,15 @@ export function ReviewTab({
             ) : null}
           </div>
         )}
+        {openErr ? (
+          <div
+            className="sw-review__open-err"
+            role="status"
+            data-testid="review-open-err"
+          >
+            {openErr}
+          </div>
+        ) : null}
         <div className="sw-review__header-actions">
           <div className="sw-review__more-wrap" ref={moreMenuRef}>
             <button

--- a/src/i18n/messages/en/settings.ts
+++ b/src/i18n/messages/en/settings.ts
@@ -456,6 +456,7 @@ export const enSettings = {
   "settings.permissionRulesSimCopyFailed": "Could not copy match summary",
   "settings.openTargetEmpty": "No code editors detected — Finder/Explorer still works. Install VS Code, Cursor, or another editor to open files there.",
   "settings.openTargetPreferredMissing": "Preferred editor is not installed or not detected. Finder/Explorer will be used until you pick another.",
+  "settings.openTargetUnavailable": " (not detected)",
   "settings.compactionApply.softRespawn": "Changing mode or detail soft-respawns a live agent so the next message reloads --compaction-mode / --compaction-detail.",
   "settings.compactionApply.nextSpawn": "No live agent — mode and detail apply on the next connect / spawn.",
   "settings.compactionApply.unsupported": "This CLI version does not take compaction flags (need 0.2.117+). Env may still be set; older CLIs soft-fail and ignore unknown flags.",

--- a/src/i18n/messages/en/workspace.ts
+++ b/src/i18n/messages/en/workspace.ts
@@ -13,6 +13,7 @@ export const enWorkspace = {
   "resources.back": "Back to files",
   "resources.openFailed": "Failed to open file",
   "resources.openInEditor": "Open in editor",
+  "resources.openInEditorNamed": "Open in {name}",
   "resources.open": "Open",
   "resources.openDefault": "Open with system default",
   "resources.revealFolder": "Reveal in file manager",

--- a/src/i18n/messages/zh-TW/settings.ts
+++ b/src/i18n/messages/zh-TW/settings.ts
@@ -457,6 +457,7 @@ export const zhTWSettings = {
   "settings.permissionRulesSimCopyFailed": "無法複製符合摘要",
   "settings.openTargetEmpty": "未偵測到程式碼編輯器 — Finder／檔案總管仍可用。安裝 VS Code、Cursor 等編輯器後即可在此開啟檔案。",
   "settings.openTargetPreferredMissing": "偏好的編輯器未安裝或未偵測到。在重新選擇之前將使用 Finder／檔案總管。",
+  "settings.openTargetUnavailable": "（未偵測到）",
   "settings.compactionApply.softRespawn": "變更模式或細節會 soft-respawn 已連線的 Agent，使下一則訊息重新載入 --compaction-mode / --compaction-detail。",
   "settings.compactionApply.nextSpawn": "目前無 live Agent — 模式與細節在下次連線 / 啟動時生效。",
   "settings.compactionApply.unsupported": "此 CLI 版本不接受壓縮相關 flags（需要 0.2.117+）。仍可能設定環境變數；舊版 CLI soft-fail 並忽略未知 flags。",

--- a/src/i18n/messages/zh-TW/workspace.ts
+++ b/src/i18n/messages/zh-TW/workspace.ts
@@ -13,6 +13,7 @@ export const zhTWWorkspace = {
   "resources.back": "返回檔案清單",
   "resources.openFailed": "無法開啟檔案",
   "resources.openInEditor": "在編輯器中開啟",
+  "resources.openInEditorNamed": "在 {name} 中開啟",
   "resources.open": "開啟",
   "resources.openDefault": "以系統預設應用程式開啟",
   "resources.revealFolder": "在檔案管理員中顯示",

--- a/src/i18n/messages/zh/settings.ts
+++ b/src/i18n/messages/zh/settings.ts
@@ -456,6 +456,7 @@ export const zhSettings = {
   "settings.permissionRulesSimCopyFailed": "无法复制匹配摘要",
   "settings.openTargetEmpty": "未检测到代码编辑器 — 访达/资源管理器仍可用。安装 VS Code、Cursor 等编辑器后即可在此打开文件。",
   "settings.openTargetPreferredMissing": "首选编辑器未安装或未检测到。在重新选择之前将使用访达/资源管理器。",
+  "settings.openTargetUnavailable": "（未检测到）",
   "settings.compactionApply.softRespawn": "更改模式或细节会 soft-respawn 已连接的 Agent，使下一条消息重新加载 --compaction-mode / --compaction-detail。",
   "settings.compactionApply.nextSpawn": "当前无 live Agent — 模式与细节在下次连接 / 启动时生效。",
   "settings.compactionApply.unsupported": "此 CLI 版本不接受压缩相关 flags（需要 0.2.117+）。仍可能设置环境变量；旧版 CLI soft-fail 并忽略未知 flags。",

--- a/src/i18n/messages/zh/workspace.ts
+++ b/src/i18n/messages/zh/workspace.ts
@@ -13,6 +13,7 @@ export const zhWorkspace = {
   "resources.back": "返回文件列表",
   "resources.openFailed": "无法打开文件",
   "resources.openInEditor": "在编辑器中打开",
+  "resources.openInEditorNamed": "在 {name} 中打开",
   "resources.open": "打开",
   "resources.openDefault": "用系统默认应用打开",
   "resources.revealFolder": "在文件管理器中显示",

--- a/src/lib/openEditorHonesty.test.ts
+++ b/src/lib/openEditorHonesty.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildOpenTargetSelectOptions,
   classifyOpenEditorError,
   classifyRevealError,
   formatOpenEditorErrorMessage,
+  isOsOpenTarget,
+  normalizeOpenTargetId,
   openEditorErrorMessageKey,
+  orderOpenWithEditors,
   planOpenInEditor,
+  resolveEffectiveOpenTarget,
+  resolveLegacyEditorTarget,
   resolveOpenEditorEmptyState,
   resolveOpenEditorError,
   resolveRevealError,
@@ -286,5 +292,161 @@ describe("planOpenInEditor", () => {
       editorsFound: 3,
     });
     expect(p).toEqual({ ok: true, path: "/a.ts", editorId: "code" });
+  });
+
+  it("soft-fails no_editor when editorId missing from availableIds", () => {
+    const p = planOpenInEditor({
+      path: "/a.ts",
+      editorId: "cursor",
+      availableIds: ["code", "zed"],
+      isTauri: true,
+    });
+    expect(p.ok).toBe(false);
+    if (!p.ok) expect(p.kind).toBe("no_editor");
+  });
+
+  it("allows when editorId is among availableIds", () => {
+    const p = planOpenInEditor({
+      path: "/a.ts",
+      editorId: "Cursor",
+      availableIds: ["code", "cursor"],
+    });
+    expect(p).toEqual({ ok: true, path: "/a.ts", editorId: "cursor" });
+  });
+});
+
+describe("normalizeOpenTargetId / isOsOpenTarget", () => {
+  it("normalizes and defaults empty to finder", () => {
+    expect(normalizeOpenTargetId(" Code ")).toBe("code");
+    expect(normalizeOpenTargetId("")).toBe("finder");
+    expect(normalizeOpenTargetId(null)).toBe("finder");
+  });
+
+  it("classifies OS vs editor targets", () => {
+    expect(isOsOpenTarget("finder")).toBe(true);
+    expect(isOsOpenTarget("explorer")).toBe(true);
+    expect(isOsOpenTarget("system")).toBe(true);
+    expect(isOsOpenTarget("default")).toBe(true);
+    expect(isOsOpenTarget("cursor")).toBe(false);
+    expect(isOsOpenTarget("code")).toBe(false);
+  });
+});
+
+describe("buildOpenTargetSelectOptions", () => {
+  it("lists finder + available editors only", () => {
+    const opts = buildOpenTargetSelectOptions({
+      finderLabel: "Finder",
+      editors: [
+        { id: "code", label: "VS Code", available: true },
+        { id: "missing", label: "Gone", available: false },
+      ],
+    });
+    expect(opts).toEqual([
+      { value: "finder", label: "Finder" },
+      { value: "code", label: "VS Code" },
+    ]);
+  });
+
+  it("soft-disables preferred when missing from probe", () => {
+    const opts = buildOpenTargetSelectOptions({
+      finderLabel: "Finder",
+      preferred: "cursor",
+      unavailableSuffix: " (not detected)",
+      editors: [{ id: "code", label: "VS Code", available: true }],
+    });
+    expect(opts).toContainEqual({
+      value: "cursor",
+      label: "cursor (not detected)",
+      disabled: true,
+    });
+    expect(opts.find((o) => o.value === "code")?.disabled).toBeUndefined();
+  });
+
+  it("does not duplicate preferred when available", () => {
+    const opts = buildOpenTargetSelectOptions({
+      finderLabel: "Finder",
+      preferred: "code",
+      editors: [{ id: "code", label: "VS Code", available: true }],
+    });
+    expect(opts.filter((o) => o.value === "code")).toHaveLength(1);
+    expect(opts.find((o) => o.value === "code")?.disabled).toBeUndefined();
+  });
+});
+
+describe("resolveEffectiveOpenTarget / orderOpenWithEditors", () => {
+  it("keeps available preferred editor", () => {
+    expect(
+      resolveEffectiveOpenTarget({
+        preferred: "Cursor",
+        availableIds: ["code", "cursor"],
+      }),
+    ).toBe("cursor");
+  });
+
+  it("falls back to OS target when preferred missing", () => {
+    expect(
+      resolveEffectiveOpenTarget({
+        preferred: "cursor",
+        availableIds: ["code"],
+        osTarget: "finder",
+      }),
+    ).toBe("finder");
+  });
+
+  it("keeps finder/system even with empty scan", () => {
+    expect(
+      resolveEffectiveOpenTarget({
+        preferred: "finder",
+        availableIds: [],
+      }),
+    ).toBe("finder");
+    expect(
+      resolveEffectiveOpenTarget({
+        preferred: "system",
+        availableIds: [],
+      }),
+    ).toBe("system");
+  });
+
+  it("resolves legacy editor to cursor > code > first", () => {
+    expect(resolveLegacyEditorTarget(["code", "cursor", "zed"])).toBe(
+      "cursor",
+    );
+    expect(resolveLegacyEditorTarget(["code", "zed"])).toBe("code");
+    expect(resolveLegacyEditorTarget(["zed", "sublime"])).toBe("zed");
+    expect(resolveLegacyEditorTarget([])).toBeNull();
+    expect(
+      resolveEffectiveOpenTarget({
+        preferred: "editor",
+        availableIds: ["code", "cursor"],
+      }),
+    ).toBe("cursor");
+  });
+
+  it("orders preferred editor first in open-with menus", () => {
+    const ordered = orderOpenWithEditors(
+      [
+        { id: "code", label: "VS Code" },
+        { id: "cursor", label: "Cursor" },
+        { id: "zed", label: "Zed" },
+      ],
+      "cursor",
+    );
+    expect(ordered.map((e) => e.id)).toEqual(["cursor", "code", "zed"]);
+  });
+
+  it("leaves order unchanged when preferred is OS or missing", () => {
+    const eds = [
+      { id: "code" },
+      { id: "cursor" },
+    ];
+    expect(orderOpenWithEditors(eds, "finder").map((e) => e.id)).toEqual([
+      "code",
+      "cursor",
+    ]);
+    expect(orderOpenWithEditors(eds, "windsurf").map((e) => e.id)).toEqual([
+      "code",
+      "cursor",
+    ]);
   });
 });

--- a/src/lib/openEditorHonesty.ts
+++ b/src/lib/openEditorHonesty.ts
@@ -437,13 +437,9 @@ export function resolveOpenEditorEmptyState(input: {
   availableIds?: readonly string[] | null;
 }): OpenEditorEmptyState {
   const n = Math.max(0, Math.floor(Number(input.editorsFound) || 0));
-  const preferred = (input.preferred ?? "").trim().toLowerCase();
-  const isOsTarget =
-    !preferred ||
-    preferred === "finder" ||
-    preferred === "explorer" ||
-    preferred === "system" ||
-    preferred === "default";
+  const preferred = normalizeOpenTargetId(input.preferred);
+  // Empty preferred normalizes to finder → OS target (never preferred_missing).
+  const isOsTarget = isOsOpenTarget(input.preferred) || !String(input.preferred ?? "").trim();
 
   if (n === 0) {
     return {
@@ -454,7 +450,7 @@ export function resolveOpenEditorEmptyState(input: {
   }
 
   if (!isOsTarget && input.availableIds) {
-    const ids = input.availableIds.map((x) => String(x).trim().toLowerCase());
+    const ids = input.availableIds.map((x) => normalizeOpenTargetId(x));
     if (preferred && !ids.includes(preferred)) {
       return {
         kind: "preferred_missing",
@@ -475,6 +471,210 @@ function normalizeOpenPath(path: string | null | undefined): string {
   return String(path ?? "").trim();
 }
 
+/** localStorage key shared by Settings + Open Location + Resource/Review. */
+export const OPEN_TARGET_STORAGE_KEY = "grok-app.openTarget";
+
+/** Normalize open-target id (`Finder` → `finder`). Empty → `finder`. */
+export function normalizeOpenTargetId(
+  id: string | null | undefined,
+): string {
+  const v = String(id ?? "")
+    .trim()
+    .toLowerCase();
+  return v || "finder";
+}
+
+/**
+ * True for OS file-manager / system-default targets (not a code editor id).
+ * Includes legacy empty / `default`.
+ */
+export function isOsOpenTarget(id: string | null | undefined): boolean {
+  const v = normalizeOpenTargetId(id);
+  return (
+    v === "finder" ||
+    v === "explorer" ||
+    v === "system" ||
+    v === "default"
+  );
+}
+
+/**
+ * Read last-used / preferred open target from localStorage.
+ * Soft-fails to `fallback` on missing storage or errors.
+ */
+export function readOpenTargetStorage(fallback = "finder"): string {
+  try {
+    if (typeof localStorage === "undefined") return normalizeOpenTargetId(fallback);
+    return normalizeOpenTargetId(
+      localStorage.getItem(OPEN_TARGET_STORAGE_KEY) || fallback,
+    );
+  } catch {
+    return normalizeOpenTargetId(fallback);
+  }
+}
+
+/**
+ * Write open target to localStorage (session/global UI consistency).
+ * Never throws.
+ */
+export function writeOpenTargetStorage(target: string): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(
+      OPEN_TARGET_STORAGE_KEY,
+      normalizeOpenTargetId(target),
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+export type OpenTargetSelectOption = {
+  value: string;
+  label: string;
+  /** Soft-disabled when preferred editor is missing from probe. */
+  disabled?: boolean;
+};
+
+/**
+ * Settings Select options for default open target.
+ *
+ * - Finder/Explorer always first and enabled
+ * - Available (probed) editors enabled
+ * - Preferred editor missing from probe → soft-disabled trailing entry
+ * - Never invents installed editors
+ */
+export function buildOpenTargetSelectOptions(input: {
+  finderLabel: string;
+  editors: readonly {
+    id: string;
+    label: string;
+    available?: boolean;
+  }[];
+  preferred?: string | null;
+  /**
+   * Suffix for soft-disabled preferred label, e.g. `" (not detected)"`.
+   * Appended only when preferred is missing and not already in available.
+   */
+  unavailableSuffix?: string;
+}): OpenTargetSelectOption[] {
+  const available = (input.editors ?? []).filter(
+    (e) => e.available !== false && String(e.id ?? "").trim(),
+  );
+  const options: OpenTargetSelectOption[] = [
+    { value: "finder", label: input.finderLabel },
+  ];
+  const seen = new Set<string>(["finder"]);
+  for (const e of available) {
+    const id = normalizeOpenTargetId(e.id);
+    if (seen.has(id) || isOsOpenTarget(id)) continue;
+    seen.add(id);
+    options.push({
+      value: id,
+      label: String(e.label ?? e.id).trim() || id,
+    });
+  }
+
+  const preferred = normalizeOpenTargetId(input.preferred);
+  if (!isOsOpenTarget(preferred) && !seen.has(preferred)) {
+    const base =
+      (input.editors ?? []).find(
+        (e) => normalizeOpenTargetId(e.id) === preferred,
+      )?.label ?? preferred;
+    // Keep leading space in suffix (e.g. " (not detected)"); only skip empty.
+    const suffix = String(input.unavailableSuffix ?? "");
+    options.push({
+      value: preferred,
+      label: suffix.trim() ? `${base}${suffix}` : String(base),
+      disabled: true,
+    });
+  }
+  return options;
+}
+
+/**
+ * Resolve what primary click / Host should use when preferred may be missing.
+ *
+ * - OS targets stay as-is (finder/explorer/system)
+ * - Available editor id kept
+ * - Missing preferred → `osTarget` (default `finder`) — never invents an editor
+ * - Legacy `editor` → cursor → code → first available → osTarget
+ */
+export function resolveEffectiveOpenTarget(input: {
+  preferred?: string | null;
+  /** Available editor ids from Host scan (lowercase ok). */
+  availableIds?: readonly string[] | null;
+  /** Fallback OS target when preferred editor missing. Default `finder`. */
+  osTarget?: string | null;
+}): string {
+  const os = normalizeOpenTargetId(input.osTarget ?? "finder");
+  const osFallback =
+    os === "explorer" || os === "finder" || os === "system" || os === "default"
+      ? os === "default"
+        ? "system"
+        : os
+      : "finder";
+
+  let preferred = normalizeOpenTargetId(input.preferred);
+  if (preferred === "default") preferred = "system";
+
+  if (isOsOpenTarget(preferred)) {
+    return preferred === "system" ? "system" : preferred === "explorer" ? "explorer" : preferred === "finder" ? "finder" : osFallback;
+  }
+
+  const ids = (input.availableIds ?? []).map((x) =>
+    normalizeOpenTargetId(x),
+  );
+  const idSet = new Set(ids);
+
+  // Legacy Desktop value: pick best available code editor.
+  if (preferred === "editor") {
+    return resolveLegacyEditorTarget(ids) ?? osFallback;
+  }
+
+  if (idSet.size === 0) {
+    // Unknown scan → keep preferred (Host may still resolve); known empty handled by caller.
+    if (input.availableIds == null) return preferred;
+    return osFallback;
+  }
+  if (idSet.has(preferred)) return preferred;
+  return osFallback;
+}
+
+/**
+ * Legacy `editor` open target: Cursor → VS Code → first available.
+ * Returns null when none available (caller falls back to OS target).
+ */
+export function resolveLegacyEditorTarget(
+  availableIds: readonly string[],
+): string | null {
+  const ids = availableIds.map((x) => normalizeOpenTargetId(x));
+  if (ids.includes("cursor")) return "cursor";
+  if (ids.includes("code")) return "code";
+  const first = ids.find((id) => id && !isOsOpenTarget(id));
+  return first ?? null;
+}
+
+/**
+ * Order detected editors for open-with menus: preferred first, then probe order.
+ * Does not drop entries; does not invent editors.
+ */
+export function orderOpenWithEditors<T extends { id: string }>(
+  editors: readonly T[],
+  preferred?: string | null,
+): T[] {
+  if (!editors.length) return [];
+  const pref = normalizeOpenTargetId(preferred);
+  if (isOsOpenTarget(pref) || pref === "editor") return [...editors];
+  const idx = editors.findIndex(
+    (e) => normalizeOpenTargetId(e.id) === pref,
+  );
+  if (idx <= 0) return [...editors];
+  const copy = [...editors];
+  const [hit] = copy.splice(idx, 1);
+  return [hit, ...copy];
+}
+
 /**
  * Soft preflight before Host `open_in_editor`.
  * Order: host_only → not_found (empty path) → no_editor → ok.
@@ -491,6 +691,11 @@ export function planOpenInEditor(input: {
    * no_editor without calling Host. `null`/`undefined` = unknown → allow.
    */
   editorsFound?: number | null;
+  /**
+   * When set, a non-OS `editorId` not in this list soft-fails `no_editor`.
+   * `null`/`undefined` = unknown → allow (Host still checks).
+   */
+  availableIds?: readonly string[] | null;
 }): OpenInEditorPlan {
   if (input.isTauri === false) {
     return {
@@ -508,12 +713,7 @@ export function planOpenInEditor(input: {
     };
   }
   const editorId = (input.editorId ?? "").trim() || null;
-  const wantsEditor =
-    !!editorId &&
-    editorId !== "finder" &&
-    editorId !== "explorer" &&
-    editorId !== "system" &&
-    editorId !== "default";
+  const wantsEditor = !!editorId && !isOsOpenTarget(editorId);
   if (
     wantsEditor &&
     input.editorsFound != null &&
@@ -525,7 +725,30 @@ export function planOpenInEditor(input: {
       messageKey: openEditorErrorMessageKey("no_editor"),
     };
   }
-  return { ok: true, path, editorId };
+  if (wantsEditor && editorId && input.availableIds != null) {
+    const ids = input.availableIds.map((x) => normalizeOpenTargetId(x));
+    const want = normalizeOpenTargetId(editorId);
+    if (want === "editor") {
+      if (!resolveLegacyEditorTarget(ids)) {
+        return {
+          ok: false,
+          kind: "no_editor",
+          messageKey: openEditorErrorMessageKey("no_editor"),
+        };
+      }
+    } else if (!ids.includes(want)) {
+      return {
+        ok: false,
+        kind: "no_editor",
+        messageKey: openEditorErrorMessageKey("no_editor"),
+      };
+    }
+  }
+  return {
+    ok: true,
+    path,
+    editorId: editorId ? normalizeOpenTargetId(editorId) : null,
+  };
 }
 
 /** All open-in-editor error kinds (for label maps / tests). */

--- a/src/lib/settingsCatalog/entries/general.ts
+++ b/src/lib/settingsCatalog/entries/general.ts
@@ -1454,6 +1454,7 @@ export const GENERAL_ENTRIES: readonly SettingsEntry[] = [
       "settings.openFinder",
       "settings.openTargetEmpty",
       "settings.openTargetPreferredMissing",
+      "settings.openTargetUnavailable",
     ],
     keywords: ["open in", "finder", "editor", "no editors", "preferred editor"],
   },

--- a/src/styles/side-workbench.css
+++ b/src/styles/side-workbench.css
@@ -1011,6 +1011,16 @@ html[data-theme="light"] .sw-terminal--pty {
   opacity: 0.55;
 }
 
+.sw-review__open-err {
+  margin: 0 10px 6px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--danger, #f87171);
+  background: color-mix(in srgb, var(--danger, #f87171) 12%, transparent);
+}
+
 .sw-review__header-actions {
   position: absolute;
   top: 6px;


### PR DESCRIPTION
## Summary
Polish editor detection + default open target UX after the open-in-editor honesty base:

- **Settings → Open files with**: Select options come from Host probe (available only); preferred editor missing from probe is soft-disabled with honesty suffix; empty / preferred-missing banners restored under the control.
- **Open Location menus** (main chrome, Resources, Files): order preferred editor first among detected apps with icons; soft-resolve missing preferred → Finder/Explorer; preflight `planOpenInEditor` before Host open.
- **Session / global consistency**: `defaultOpenTarget` Host setting, localStorage, and Open Location last-used stay in sync (Settings, main, Resources, Files).
- **Resource / Review open-in-editor**: uses preferred non-OS target when set; soft-fails with classified i18n copy (Review shows a status line).
- **Pure helpers + tests**: `buildOpenTargetSelectOptions`, `resolveEffectiveOpenTarget`, `orderOpenWithEditors`, legacy `editor` → cursor → code → first, storage key helpers; 39 unit tests.
- **i18n** en / zh / zh-TW (`settings.openTargetUnavailable`, `resources.openInEditorNamed`).

## Test plan
- [x] `pnpm exec vitest run src/lib/openEditorHonesty.test.ts` — 39 passed
- [x] `pnpm exec vitest run src/i18n/messages.test.ts` — 18 passed
- [x] `pnpm exec tsc --noEmit` clean
- [ ] Manual: Settings → Open files with — only installed editors selectable; uninstall-sim (stale preferred) soft-disabled + honesty
- [ ] Manual: Open Location caret — preferred editor first with icon; missing preferred falls back to Finder without claiming success
- [ ] Manual: Resources Changes / Review “open in editor” uses default editor; error toast/status when missing
- [ ] Manual: Change target in Resources → Settings select matches after reopen