### PR TITLE
feat(voice): delegate session honesty in overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Added
+- **Live Voice delegate session honesty**: Overlay restores delegated/active session chips with real titles + liveMap progress while Live Voice is open; keep-agents default stays on (opt-out cancels turns). Soft-fail mic/auth/network/cli surfaces classified toasts in addition to overlay copy. Host never records blank delegated ids. Pure helpers + tests; existing en/zh/zh-TW `voice.err.*` / `voice.center.*`.
 - **Appearance fonts (#553)**: Settings → Appearance can set UI font family and side-terminal font family/size (localStorage; terminal prefers Nerd Fonts for Starship glyphs).
 - **Preferred agent apply honesty (#564)**: Settings preferred-agent and Agents & Personas console document spawn-time `--agent` apply paths — live agent soft-respawns on change; idle waits for next connect. Soft-fail when the saved name is missing from the catalog or has invalid characters. Pure `preferredAgentApply` helpers + tests; en/zh/zh-TW.
 - **Memory clear scopes + dream honesty**: Memory ops center GlassModal clear for host scopes **workspace / global / all** (real `grok memory clear` flags; no `window.confirm`). Dream/watcher chips remain config-presence only — never a live “running” status. Experimental memory stays **off** by default with `--no-memory` force-disable honesty.
 
 **中文 · 新增**
+- **实时语音委派会话诚实**：叠加层恢复委派/活动会话芯片（真实标题 + liveMap 进度）；结束后默认保留 Agent（关闭则取消回合）。麦克风/鉴权/网络/CLI 软失败额外 toast 分类文案。Host 不记录空委派 id。纯 helper + 测试；沿用三语 `voice.err.*` / `voice.center.*`。
 - **外观字体 (#553)**：设置 → 外观 可配置界面字体与内置终端字体/字号（本机偏好；终端优先 Nerd Font 以显示 Starship 图标）。
 - **首选 agent 生效路径诚实 (#564)**：设置与 Agents & Personas 控制台标明 spawn `--agent` 路径 — 已连接 soft-respawn、空闲下次连接；目录缺失/非法名称 soft-fail。纯 helper + 测试；三语文案。
 - **记忆清除范围 + Dream 诚实**：操作中心 GlassModal 清除 host 作用域 **workspace / global / all**（真实 CLI 参数，不用 `window.confirm`）。Dream/Watcher 仅表示配置存在性，绝不伪造「运行中」。跨会话记忆默认关闭并强制 `--no-memory`。

--- a/src-tauri/src/voice_host.rs
+++ b/src-tauri/src/voice_host.rs
@@ -316,14 +316,13 @@ impl VoiceHost {
     }
 
     fn push_delegated(&self, session_id: &str) {
+        // Never invent / store blank ids from incomplete tool results.
+        let Some(sid) = voice_tools::recordable_delegated_session_id(Some(session_id)) else {
+            return;
+        };
         let mut g = self.inner.lock();
-        if !g
-            .state
-            .delegated_session_ids
-            .iter()
-            .any(|s| s == session_id)
-        {
-            g.state.delegated_session_ids.push(session_id.to_string());
+        if !g.state.delegated_session_ids.iter().any(|s| s == &sid) {
+            g.state.delegated_session_ids.push(sid);
         }
     }
 }
@@ -558,8 +557,10 @@ async fn execute_tool_inner(
 ) -> Result<Value, String> {
     if VoiceHost::is_mock_env() {
         let out = voice_tools::mock_execute_tool(name, args_json)?;
-        if let Some(sid) = out.get("session_id").and_then(|x| x.as_str()) {
-            host.push_delegated(sid);
+        if let Some(sid) = voice_tools::recordable_delegated_session_id(
+            out.get("session_id").and_then(|x| x.as_str()),
+        ) {
+            host.push_delegated(&sid);
             host.emit_state(app);
         }
         return Ok(out);

--- a/src-tauri/src/voice_tools.rs
+++ b/src-tauri/src/voice_tools.rs
@@ -293,6 +293,15 @@ pub fn should_cancel_delegated_agents_on_voice_stop(keep_agents_on_end: bool) ->
     !keep_agents_on_end
 }
 
+/// Non-empty session id suitable for delegated tracking.
+/// Never invents ids — empty / whitespace → None.
+pub fn recordable_delegated_session_id(session_id: Option<&str>) -> Option<String> {
+    session_id
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
 /// Canonical tool-loop status tokens emitted on `voice://tool` (VOX-BUILD-FULL).
 pub fn normalize_tool_status(raw: &str) -> &'static str {
     match raw.trim().to_lowercase().as_str() {
@@ -459,6 +468,34 @@ mod tests {
     fn cancel_agents_only_when_keep_false() {
         assert!(!should_cancel_delegated_agents_on_voice_stop(true));
         assert!(should_cancel_delegated_agents_on_voice_stop(false));
+    }
+
+    #[test]
+    fn recordable_delegated_id_never_invents() {
+        assert_eq!(recordable_delegated_session_id(None), None);
+        assert_eq!(recordable_delegated_session_id(Some("")), None);
+        assert_eq!(recordable_delegated_session_id(Some("   ")), None);
+        assert_eq!(
+            recordable_delegated_session_id(Some("  abc-1  ")).as_deref(),
+            Some("abc-1")
+        );
+    }
+
+    #[test]
+    fn classifies_mic_missing_and_soft_vs_fatal() {
+        assert_eq!(
+            classify_tool_error("No microphone device found"),
+            "mic_missing"
+        );
+        assert_eq!(
+            classify_tool_error("NotAllowedError: Permission denied"),
+            "mic_denied"
+        );
+        // Soft tool loop classes keep voice open; mic/auth/network are classified
+        // for UI toasts but are not agent soft-fail tool results.
+        assert!(!is_soft_tool_error("mic_denied"));
+        assert!(!is_soft_tool_error("auth"));
+        assert!(!is_soft_tool_error("network"));
     }
 
     #[test]

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -2445,13 +2445,15 @@ export function AppWorkbench() {
     sawToolActivity?: boolean;
   } | null>(null);
 
-  // Full multi-session liveMap only while chrome that needs every row is open.
+  // Full multi-session liveMap only while chrome that needs every row is open
+  // (Reliability / Agents dashboard / task board / stall / Live Voice chips).
   const liveMap = useLiveMapWhen(
     showReliability ||
       agentDashboardOpen ||
       taskBoardOpen ||
       tasksPanelOpen ||
-      streamStall != null,
+      streamStall != null ||
+      liveVoiceOpen,
   );
   /** Queue item currently being steered into the live turn. */
   const [guidingQueueItemId, setGuidingQueueItemId] = useState<string | null>(null);
@@ -21066,7 +21068,14 @@ export function AppWorkbench() {
         voiceId={voiceId}
         keepAgentsOnEnd={voiceKeepAgentsOnEnd}
         hasActiveSession={Boolean(session.sessionId)}
+        hasVoiceAuth={voiceGate.available}
+        sessions={sessions.map((s) => ({
+          id: s.id,
+          title: s.title || tr("session.untitled"),
+          status: liveMap[s.id]?.state ?? "idle",
+        }))}
         onClose={() => setLiveVoiceOpen(false)}
+        onClassifiedNotice={(message) => showToast(message, 4800)}
         onSendTranscriptAsPrompt={
           session.sessionId
             ? async (prompt) => {
@@ -21079,7 +21088,7 @@ export function AppWorkbench() {
               }
             : undefined
         }
-        onOpenSession={(id) => {
+        onFocusSession={(id) => {
           setLiveVoiceOpen(false);
           void (async () => {
             await refreshSessions();

--- a/src/components/VoiceOverlay.tsx
+++ b/src/components/VoiceOverlay.tsx
@@ -41,6 +41,7 @@ import {
   formatTranscriptAsPrompt,
   hasDelegatedSessions,
   initialToolLoopState,
+  isClassifiedSoftFailNotice,
   isPermissionDenyDecision,
   isPermissionForDelegatedSession,
   isPermissionPending,
@@ -93,6 +94,11 @@ export type VoiceOverlayProps = {
    * session. Omit when host/app does not support it — control stays hidden.
    */
   onSendTranscriptAsPrompt?: (prompt: string) => void | Promise<void>;
+  /**
+   * Optional toast for classified soft-fail notices (mic / auth / network).
+   * Overlay still shows inline warn/error; toast is for workbench discoverability.
+   */
+  onClassifiedNotice?: (message: string) => void;
 };
 
 function phaseMessageKey(phase: VoiceDelegatePhase): MessageKey {
@@ -145,11 +151,22 @@ export function VoiceOverlay({
   onFocusSession,
   onOpenSession,
   onSendTranscriptAsPrompt,
+  onClassifiedNotice,
 }: VoiceOverlayProps) {
   const focusSession = onFocusSession ?? onOpenSession;
   const tt = useCallback(
     (key: MessageKey, vars?: Record<string, string | number>) => t(locale, key, vars),
     [locale],
+  );
+  /** Toast mic/auth/network/cli soft-fail classes (inline UI still primary). */
+  const noticeClassified = useCallback(
+    (raw: string | null | undefined, errorClass?: string | null) => {
+      if (!onClassifiedNotice) return;
+      const cls = classifyLiveVoiceError(raw, errorClass);
+      if (!isClassifiedSoftFailNotice(cls)) return;
+      onClassifiedNotice(formatLiveError(tt, raw, errorClass));
+    },
+    [onClassifiedNotice, tt],
   );
   const [state, setState] = useState<VoiceSessionState | null>(null);
   const [lines, setLines] = useState<VoiceTranscriptLine[]>([]);
@@ -367,8 +384,10 @@ export function VoiceOverlay({
           if (isSoftMicFailure(cls)) {
             setSoftMicWarning(cls);
             appendLine("system", tt(liveVoiceErrorMessageKey(cls) as MessageKey), true);
+            noticeClassified(String(micErr), cls);
           } else {
             setError(formatLiveError(tt, String(micErr)));
+            noticeClassified(String(micErr), cls);
           }
         }
 
@@ -435,9 +454,11 @@ export function VoiceOverlay({
               tt(liveVoiceErrorMessageKey(cls) as MessageKey),
               true,
             );
+            noticeClassified(e.payload.message, e.payload.errorClass);
             return;
           }
           setError(formatLiveError(tt, e.payload.message, e.payload.errorClass));
+          noticeClassified(e.payload.message, e.payload.errorClass);
         });
         unsubs.push(u4);
 
@@ -491,6 +512,7 @@ export function VoiceOverlay({
         unsubs.push(u7);
       } catch (e) {
         setError(formatLiveError(tt, String(e)));
+        noticeClassified(String(e));
       } finally {
         setBusy(false);
       }
@@ -514,6 +536,7 @@ export function VoiceOverlay({
     keepAgentsOnEnd,
     appendLine,
     applyToolEvent,
+    noticeClassified,
     tt,
   ]);
 

--- a/src/lib/voiceCommandCenter.test.ts
+++ b/src/lib/voiceCommandCenter.test.ts
@@ -4,6 +4,7 @@ import {
   formatVoiceSessionChipLabel,
   formatVoiceToolStatus,
   hasRunningVoiceDelegates,
+  mapSessionsToVoiceChipInputs,
   mergeVoiceSessionsForChips,
   normalizeVoiceChipStatus,
   planVoiceEnd,
@@ -109,6 +110,33 @@ describe("mergeVoiceSessionsForChips", () => {
     expect(d2?.isDelegated).toBe(true);
     expect(d2?.title).toBeNull();
     expect(side?.isDelegated).toBe(false);
+  });
+});
+
+describe("mapSessionsToVoiceChipInputs", () => {
+  it("maps real sessions + liveMap status; drops empty ids", () => {
+    const rows = mapSessionsToVoiceChipInputs({
+      sessions: [
+        { id: "a", title: "Fix tests" },
+        { id: "  ", title: "skip" },
+        { id: "b", title: "" },
+      ],
+      liveStates: { a: "streaming", b: undefined },
+      untitledLabel: "Untitled",
+    });
+    expect(rows).toEqual([
+      { id: "a", title: "Fix tests", status: "streaming" },
+      { id: "b", title: "Untitled", status: "idle" },
+    ]);
+  });
+
+  it("never invents streaming without liveMap", () => {
+    const rows = mapSessionsToVoiceChipInputs({
+      sessions: [{ id: "x", title: "Chat" }],
+      liveStates: null,
+      untitledLabel: "Untitled",
+    });
+    expect(rows[0].status).toBe("idle");
   });
 });
 

--- a/src/lib/voiceCommandCenter.ts
+++ b/src/lib/voiceCommandCenter.ts
@@ -177,6 +177,28 @@ export function buildVoiceSessionChips(
 }
 
 /**
+ * Map App session rows + liveMap states into chip inputs.
+ * Only real session ids; status from liveMap when present (else idle).
+ * Never invents sessions or streaming state.
+ */
+export function mapSessionsToVoiceChipInputs(opts: {
+  sessions: readonly { id: string; title?: string | null }[] | null | undefined;
+  /** sessionId → host live state token (streaming · idle · …). */
+  liveStates?: Record<string, string | undefined | null> | null;
+  untitledLabel: string;
+}): VoiceSessionChipInput[] {
+  const out: VoiceSessionChipInput[] = [];
+  for (const s of opts.sessions ?? []) {
+    const id = (s.id ?? "").trim();
+    if (!id) continue;
+    const title = (s.title ?? "").trim() || opts.untitledLabel;
+    const status = (opts.liveStates?.[id] ?? "").trim() || "idle";
+    out.push({ id, title, status });
+  }
+  return out;
+}
+
+/**
  * Merge host delegated ids with sidebar session summaries for chips.
  * Host ids without a title stay as short-id labels (honest).
  */

--- a/src/lib/voiceOverlay.test.ts
+++ b/src/lib/voiceOverlay.test.ts
@@ -6,6 +6,7 @@ import {
   formatTranscriptAsPrompt,
   hasDelegatedSessions,
   initialToolLoopState,
+  isClassifiedSoftFailNotice,
   isConversationalRole,
   isFatalLiveVoiceError,
   isPermissionDenyDecision,
@@ -20,6 +21,7 @@ import {
   parseToolLoopEvent,
   parseVoicePermissionPrompt,
   permissionPendingToolLoopState,
+  recordableDelegatedSessionId,
   reduceToolLoopState,
   shouldCancelDelegatedAgentsOnVoiceStop,
   softFailFromPermissionBlocked,
@@ -492,5 +494,23 @@ describe("transcriptEmptyKind / delegated / tools", () => {
   it("recognizes conversational roles", () => {
     expect(isConversationalRole("User")).toBe(true);
     expect(isConversationalRole("system")).toBe(false);
+  });
+
+  it("never invents delegated session ids", () => {
+    expect(recordableDelegatedSessionId(null)).toBeNull();
+    expect(recordableDelegatedSessionId("")).toBeNull();
+    expect(recordableDelegatedSessionId("   ")).toBeNull();
+    expect(recordableDelegatedSessionId("  sid-9  ")).toBe("sid-9");
+  });
+
+  it("marks mic/auth/network/cli as classified soft-fail notices", () => {
+    expect(isClassifiedSoftFailNotice("mic_denied")).toBe(true);
+    expect(isClassifiedSoftFailNotice("mic_missing")).toBe(true);
+    expect(isClassifiedSoftFailNotice("auth")).toBe(true);
+    expect(isClassifiedSoftFailNotice("network")).toBe(true);
+    expect(isClassifiedSoftFailNotice("cli_missing")).toBe(true);
+    expect(isClassifiedSoftFailNotice("not_available")).toBe(true);
+    expect(isClassifiedSoftFailNotice("timeout")).toBe(false);
+    expect(isClassifiedSoftFailNotice("unknown")).toBe(false);
   });
 });

--- a/src/lib/voiceOverlay.ts
+++ b/src/lib/voiceOverlay.ts
@@ -757,6 +757,34 @@ export function hasDelegatedSessions(
 }
 
 /**
+ * Non-empty session id for delegated tracking.
+ * Never invents — empty / whitespace → null.
+ */
+export function recordableDelegatedSessionId(
+  sessionId: string | null | undefined,
+): string | null {
+  const s = (sessionId ?? "").trim();
+  return s || null;
+}
+
+/**
+ * Soft-fail classes that surface as classified toasts/banners without
+ * inventing tool success (mic / auth / network / CLI).
+ */
+export function isClassifiedSoftFailNotice(
+  cls: VoiceLiveErrorClass | null | undefined,
+): boolean {
+  return (
+    cls === "mic_denied" ||
+    cls === "mic_missing" ||
+    cls === "auth" ||
+    cls === "network" ||
+    cls === "cli_missing" ||
+    cls === "not_available"
+  );
+}
+
+/**
  * Normalize a host tool event name. Returns null when absent — never invents.
  */
 export function toolEventName(payload: {


### PR DESCRIPTION
## Summary

Polish Live Voice → Build **delegate session honesty** (restore wiring lost after AppWorkbench split + host id guards):

- **Delegated sessions list with progress**: re-wire `sessions` + `liveMap` into `VoiceOverlay` while Live Voice is open so chips show real titles and running/permission status (not only host ids).
- **Keep agents on end**: product default remains `keepAgentsOnEnd=true`; opt-out still cancels delegated turns via host `should_cancel_delegated_agents_on_voice_stop`.
- **Soft-fail classified toasts**: mic / auth / network / CLI / not_available surface workbench toasts in addition to overlay warn/error copy (`onClassifiedNotice`).
- **Never invent delegates**: host `push_delegated` + `recordable_delegated_session_id` ignore blank ids; pure TS helpers mirror the same honesty.
- Pure helpers + tests (`voiceOverlay`, `voiceCommandCenter`, `voice_tools`); CHANGELOG; existing en/zh/zh-TW `voice.err.*` / `voice.center.*`.

## Anchors

- `src/app/AppWorkbench.tsx` — `sessions` / `hasVoiceAuth` / `liveMap` while open / classified toast
- `src/components/VoiceOverlay.tsx` — `onClassifiedNotice`
- `src/lib/voiceOverlay.ts` · `voiceCommandCenter.ts` (+ tests)
- `src-tauri/src/voice_tools.rs` · `voice_host.rs`
- `CHANGELOG.md` Unreleased

## Verification

- [x] `pnpm exec vitest run src/lib/voiceOverlay.test.ts src/lib/voiceCommandCenter.test.ts` (59)
- [x] `pnpm exec vitest run src/i18n/messages.test.ts` (18)
- [x] `pnpm typecheck`
- [x] `cargo test --lib voice_tools::tests` (11)

## Test plan

- [ ] Start Live Voice with project open → connecting → listening
- [ ] Mock / real delegate: chip list shows **title + running/permission** from liveMap; click focuses session
- [ ] Deny mic → overlay warn **and** classified toast; voice stays open for playback/tools
- [ ] Auth/network soft-fail → classified toast + `voice.err.*` copy (no invented STT)
- [ ] Settings → Keep coding sessions **on** (default): Stop ends voice only; agents keep running
- [ ] Keep coding sessions **off**: Stop cancels delegated turns
- [ ] Host never lists empty delegated ids after incomplete tool results