### PR TITLE
docs(readme): install and update honesty gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ Compare the PowerShell hash against the matching line in `SHA256SUMS`.
 
 Community / unsigned Windows builds show SmartScreen “Windows protected your PC / Unknown publisher” on first run — click **More info → Run anyway** and verify the checksum above if in doubt. Release CI can Authenticode-sign installers when `WINDOWS_CERTIFICATE` + `WINDOWS_CERTIFICATE_PASSWORD` secrets are configured (see `docs/BUILD.md`); signed builds use the publisher name on the certificate.
 
+#### In-app auto-update
+
+Silent updates from **Settings → About** only work on **signed production builds** (Tauri updater key embedded + matching signed archives on the rolling release). Unsigned community builds, local `pnpm dev` / debug binaries, and some package types (e.g. non-AppImage on Linux) stay on the **GitHub open-release / download installer** path — they will not receive silent in-app updates. Full matrix and maintainer checklist: [docs/desktop-auto-update.md](./docs/desktop-auto-update.md).
+
 ### 2. First run
 
 1. Launch → **Setup wizard** ensures CLI is installed (multi-mirror install supported)  

--- a/README_EN.md
+++ b/README_EN.md
@@ -147,6 +147,10 @@ Compare the PowerShell hash against the matching line in `SHA256SUMS`.
 
 Community / unsigned Windows builds show SmartScreen “Windows protected your PC / Unknown publisher” on first run — click **More info → Run anyway** and verify the checksum above if in doubt. Release CI can Authenticode-sign installers when `WINDOWS_CERTIFICATE` + `WINDOWS_CERTIFICATE_PASSWORD` secrets are configured (see `docs/BUILD.md`); signed builds use the publisher name on the certificate.
 
+#### In-app auto-update
+
+Silent updates from **Settings → About** only work on **signed production builds** (Tauri updater key embedded + matching signed archives on the rolling release). Unsigned community builds, local `pnpm dev` / debug binaries, and some package types (e.g. non-AppImage on Linux) stay on the **GitHub open-release / download installer** path — they will not receive silent in-app updates. Full matrix and maintainer checklist: [docs/desktop-auto-update.md](./docs/desktop-auto-update.md).
+
 ### 2. First run
 
 1. Launch → **Setup wizard** ensures CLI is installed (multi-mirror install supported)  

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -128,6 +128,14 @@
 
 **Arch / Manjaro / EndeavourOS 等：** **AppImage** 不依赖发行版打包格式（`chmod +x` 后运行）。官方 CI 不单独发布 AUR 包。在 **Wayland（如 Hyprland）+ AMD** 上，部分主机的 AppImage 会黑屏——可改用 **`.deb` / `.rpm`**（系统 WebKit），或见 [Linux 黑屏 / 空白窗](#linux-黑屏--空白窗webkit)。
 
+#### Windows SmartScreen
+
+社区 / 未 Authenticode 签名的 Windows 安装包首次运行时，SmartScreen 可能提示「Windows 已保护你的电脑 / 未知发布者」——点 **更多信息 → 仍要运行**；有疑虑时请对照 Release 中的 `SHA256SUMS` 校验哈希。CI 在配置了 `WINDOWS_CERTIFICATE` + `WINDOWS_CERTIFICATE_PASSWORD` 时可对安装包签名（见 `docs/BUILD.md`）；已签名包显示证书上的发布者名称。
+
+#### 应用内自动更新
+
+**设置 → 关于** 中的静默更新**仅**在**已签名的生产构建**上可用（嵌入 Tauri updater 公钥 + 滚动 Release 上对应签名包）。未签名社区包、本地 `pnpm dev` / debug 构建，以及部分包类型（如 Linux 非 AppImage）仍走 **打开 GitHub Release / 下载安装包** 路径——**不会**静默自动更新。完整矩阵与维护清单见 [docs/desktop-auto-update.md](./docs/desktop-auto-update.md)。
+
 ### 2. 首次使用
 
 1. 启动 App → **Setup 向导** 确认 CLI 已安装（可一键多镜像安装）  

--- a/docs/llm-wiki/setup.md
+++ b/docs/llm-wiki/setup.md
@@ -126,9 +126,22 @@ Signature UI status (pure `deriveSignatureStatus` / `buildSignatureView`):
 
 The App **does not re-verify cryptographic signatures**; path presence and `managedSettingsActive` never invent `verify_ok`. CLI rejects bad signatures before writing. Soft-fail when CLI/inspect is missing.
 
+## OS install caveats (before the wizard)
+
+The setup gate assumes the **desktop package already launches**. OS blocks and update-channel honesty are documented for users in the README — do not invent signature / SmartScreen status in the wizard:
+
+| Topic | Source of truth |
+|-------|-----------------|
+| macOS Gatekeeper / “damaged” / `xattr -cr` | README → *macOS “damaged” / Gatekeeper* (中文：*macOS 无法打开 / 提示已损坏*) |
+| Windows SmartScreen (unsigned / unknown publisher) | README → *Install* → Windows SmartScreen |
+| In-app auto-update needs **signed** production builds | [desktop-auto-update.md](../desktop-auto-update.md); unsigned / dev stay on GitHub manual download |
+
+Doctor / Windows day-use checklist may surface related rows but **must not invent** notarization or SmartScreen state.
+
 ## Non-goals
 
 - Embedding the CLI binary in the app package (B04).
 - Silent download without multi-mirror retry.
 - Forcing project selection before home.
 - App-side re-implementation of managed-config crypto verification.
+- Claiming silent auto-update for unsigned / local builds (see [desktop-auto-update.md](../desktop-auto-update.md)).


### PR DESCRIPTION
## Summary

Residual **distribution honesty** for install / update docs only (no product code).

| Caveat | Before | After |
|--------|--------|-------|
| macOS Gatekeeper + `xattr -cr` | Already in README / README_EN / README_ZH | Unchanged |
| Windows SmartScreen | EN only | + **README_ZH** |
| Auto-update needs **signed** production builds | Missing from READMEs | README / README_EN / README_ZH → [docs/desktop-auto-update.md](docs/desktop-auto-update.md) |
| Setup wiki inventing OS/update status | No pointer | `docs/llm-wiki/setup.md` table → README + desktop-auto-update |

## Scope

- `README.md`, `README_EN.md`, `README_ZH.md`
- `docs/llm-wiki/setup.md` (install caveats pointer only)
- No product code / Doctor changes

## Test plan

- [ ] Read install sections: SmartScreen + Gatekeeper + auto-update honesty present in EN + ZH
- [ ] Links resolve to `docs/desktop-auto-update.md`
- [ ] Setup wiki does not claim silent update for unsigned builds