### PR TITLE
feat(runtime): recommend CLI 1.0 honesty chip

### DIFF
--- a/src/components/DoctorModal.tsx
+++ b/src/components/DoctorModal.tsx
@@ -51,6 +51,12 @@ import {
 } from "@/lib/doctorFindings";
 import { CliUpdateRow } from "@/components/CliUpdateRow";
 import { detectAppPlatform } from "@/lib/appPlatform";
+import {
+  classifyCliVersionStatus,
+  cliVersionStatusHintClass,
+  cliVersionStatusMessageKey,
+  cliVersionStatusMessageParams,
+} from "@/lib/cliVersionStatus";
 import { DEFAULT_SANDBOX_PROFILE } from "@/lib/sandboxProfile";
 import {
   buildDoctorPlatformMatrix,
@@ -920,6 +926,10 @@ export function DoctorModal({
             path?: string | null;
             version?: string | null;
             source?: string | null;
+            minVersion?: string | null;
+            recommendedVersion?: string | null;
+            meetsRecommended?: boolean | null;
+            versionSupported?: boolean | null;
             agentVersion?: string | null;
             agentBinarySkew?: boolean;
             acpAgentVersion?: string | null;
@@ -936,6 +946,16 @@ export function DoctorModal({
       path: trimOrNull(cli.path),
       version: trimOrNull(cli.version),
       source: trimOrNull(cli.source),
+      minVersion: trimOrNull(cli.minVersion),
+      recommendedVersion: trimOrNull(cli.recommendedVersion),
+      meetsRecommended:
+        typeof cli.meetsRecommended === "boolean"
+          ? cli.meetsRecommended
+          : null,
+      versionSupported:
+        typeof cli.versionSupported === "boolean"
+          ? cli.versionSupported
+          : null,
       agentVersion: trimOrNull(cli.agentVersion),
       agentBinarySkew: !!cli.agentBinarySkew,
       acpAgentVersion: trimOrNull(cli.acpAgentVersion),
@@ -1263,6 +1283,25 @@ export function DoctorModal({
                   </div>
                 ) : null}
               </dl>
+              {(() => {
+                const status = classifyCliVersionStatus(cliResolved);
+                const tone = cliVersionStatusHintClass(status);
+                return (
+                  <div
+                    className={
+                      "settings-row__hint doctor-cli-resolved__recommend" +
+                      (tone ? ` ${tone}` : "")
+                    }
+                    data-testid="doctor-cli-version-status"
+                    data-status={status}
+                  >
+                    {t(
+                      cliVersionStatusMessageKey(status),
+                      cliVersionStatusMessageParams(cliResolved),
+                    )}
+                  </div>
+                );
+              })()}
             </div>
           )}
 

--- a/src/components/settings/RuntimeSection.tsx
+++ b/src/components/settings/RuntimeSection.tsx
@@ -36,7 +36,9 @@ import { detectAppPlatform } from "@/lib/appPlatform";
 import { resolveLocale, type MessageKey } from "@/i18n";
 import {
   classifyCliVersionStatus,
+  cliVersionStatusHintClass,
   cliVersionStatusMessageKey,
+  cliVersionStatusMessageParams,
 } from "@/lib/cliVersionStatus";
 
 
@@ -144,25 +146,20 @@ export function RuntimeSection() {
                   )}
                   {(() => {
                     const status = classifyCliVersionStatus(cliInfo);
-                    const key = cliVersionStatusMessageKey(status);
+                    const tone = cliVersionStatusHintClass(status);
                     return (
                       <div
                         className={
-                          "settings-row__hint" +
-                          (status === "too_old" || status === "below_recommended"
-                            ? " settings-row__hint--warn"
-                            : status === "recommended"
-                              ? " settings-row__hint--ok"
-                              : "")
+                          "settings-row__hint" + (tone ? ` ${tone}` : "")
                         }
                         id="settings-anchor-cliVersionStatus"
+                        data-testid="settings-cli-version-status"
+                        data-status={status}
                       >
-                        {t(key, {
-                          version: cliInfo.version || "—",
-                          recommended:
-                            cliInfo.recommendedVersion || "1.0.0",
-                          min: cliInfo.minVersion || "0.2.112",
-                        })}
+                        {t(
+                          cliVersionStatusMessageKey(status),
+                          cliVersionStatusMessageParams(cliInfo),
+                        )}
                       </div>
                     );
                   })()}

--- a/src/lib/cliVersionStatus.test.ts
+++ b/src/lib/cliVersionStatus.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyCliVersionStatus,
+  cliVersionStatusHintClass,
   cliVersionStatusMessageKey,
+  cliVersionStatusMessageParams,
   extractSemverCore,
   mapProbeToCliInfo,
   probeVsAcpAgentVersionSkew,
@@ -40,13 +42,44 @@ describe("classifyCliVersionStatus", () => {
     ).toBe("unknown");
   });
 
-  it("maps status to i18n keys", () => {
+  it("maps status to i18n keys and hint tones", () => {
     expect(cliVersionStatusMessageKey("recommended")).toBe(
       "settings.cliVersion.recommended",
     );
     expect(cliVersionStatusMessageKey("below_recommended")).toBe(
       "settings.cliVersion.belowRecommended",
     );
+    expect(cliVersionStatusHintClass("recommended")).toBe(
+      "settings-row__hint--ok",
+    );
+    expect(cliVersionStatusHintClass("below_recommended")).toBe(
+      "settings-row__hint--warn",
+    );
+    expect(cliVersionStatusHintClass("too_old")).toBe(
+      "settings-row__hint--warn",
+    );
+    expect(cliVersionStatusHintClass("unknown")).toBe("");
+    expect(cliVersionStatusHintClass("missing")).toBe("");
+  });
+
+  it("fills message params with 1.0 recommend defaults", () => {
+    expect(
+      cliVersionStatusMessageParams({
+        found: true,
+        version: "grok 1.0.0",
+        recommendedVersion: "1.0.0",
+        minVersion: "0.2.112",
+      }),
+    ).toEqual({
+      version: "grok 1.0.0",
+      recommended: "1.0.0",
+      min: "0.2.112",
+    });
+    expect(cliVersionStatusMessageParams({ found: false })).toEqual({
+      version: "—",
+      recommended: "1.0.0",
+      min: "0.2.112",
+    });
   });
 });
 

--- a/src/lib/cliVersionStatus.ts
+++ b/src/lib/cliVersionStatus.ts
@@ -65,7 +65,7 @@ export function classifyCliVersionStatus(
   return "unknown";
 }
 
-/** i18n key for the soft status line under Settings → Runtime · CLI. */
+/** i18n key for the soft status line (Settings → Runtime · CLI, Doctor resolved). */
 export function cliVersionStatusMessageKey(
   status: CliRecommendStatus,
 ):
@@ -86,6 +86,29 @@ export function cliVersionStatusMessageKey(
     default:
       return "settings.cliVersion.unknown";
   }
+}
+
+/**
+ * Tone class for the honesty chip.
+ * `recommended` → positive; below recommended / too old → soft warn (never hard-block).
+ */
+export function cliVersionStatusHintClass(status: CliRecommendStatus): string {
+  if (status === "too_old" || status === "below_recommended") {
+    return "settings-row__hint--warn";
+  }
+  if (status === "recommended") return "settings-row__hint--ok";
+  return "";
+}
+
+/** Interpolations for `cliVersionStatusMessageKey` strings. */
+export function cliVersionStatusMessageParams(
+  p: CliProbeVersionFields | null | undefined,
+): { version: string; recommended: string; min: string } {
+  return {
+    version: p?.version?.trim() || "—",
+    recommended: p?.recommendedVersion?.trim() || "1.0.0",
+    min: p?.minVersion?.trim() || "0.2.112",
+  };
 }
 
 /**

--- a/src/styles/chat.part4.css
+++ b/src/styles/chat.part4.css
@@ -893,3 +893,7 @@
   font-size: 12px;
   word-break: break-all;
 }
+.doctor-cli-resolved__recommend {
+  margin: 10px 0 0;
+  line-height: 1.4;
+}

--- a/src/styles/settings.part3.css
+++ b/src/styles/settings.part3.css
@@ -141,6 +141,14 @@
   font-family: var(--font-mono);
 }
 
+/* CLI recommend honesty chip (Runtime + Doctor) — soft tones only */
+.settings-row__hint--ok {
+  color: var(--success, #3d9a5f);
+}
+.settings-row__hint--warn {
+  color: var(--warning, #c90);
+}
+
 /* CLI update check (Settings → Runtime / About + Doctor) */
 .settings-cli-update {
   display: flex;


### PR DESCRIPTION
## Summary
- Fill A5 residual: Doctor **Resolved CLI** now shows the same soft recommend chip as Settings → Runtime (`≥ 1.0.0 · features unlocked` / below-recommended upgrade hint).
- Reuse `classifyCliVersionStatus` / message keys; map probe `meetsRecommended` + version floor fields from Doctor `raw.cli`.
- Add missing `--ok` / `--warn` tones so the chip is visually honest (not block).

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm test -- src/lib/cliVersionStatus.test.ts`
- [ ] I ran `pnpm typecheck` / `cargo test` (TS-only UI residual)
- [x] User-facing strings go through `src/i18n` (reuse existing `settings.cliVersion.*`)
- [x] No `window.confirm` / `prompt` / `alert`
- [ ] Docs / `docs/llm-wiki` updated if behavior changed (n/a — fills planned A5 surface)
- [x] No secrets included

## Notes
- ≥ recommended → positive chip; older-but-supported → soft warn only; `too_old` remains the hard floor (existing spawn gate).
- `CliUpdateRow` unchanged; chip sits above it in Runtime / under resolved meta in Doctor.