### PR TITLE
fix(updater): honest channel and soft-fail paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - **首选 agent 生效路径诚实 (#564)**：设置与 Agents & Personas 控制台标明 spawn `--agent` 路径 — 已连接 soft-respawn、空闲下次连接；目录缺失/非法名称 soft-fail。纯 helper + 测试；三语文案。
 
 ### Fixed
+- **App update channel honesty**: Settings → About restores full path honesty after the settings split — signed in-app vs GitHub download vs unsupported package type (Linux non-AppImage note), soft-fail error classes, idle/empty and check-failed copy. Never claims silent update on unsigned builds. Host `updater_status` reports `unsupported` when the plugin is on but the package cannot auto-update.
 - **CI baseline**: `cargo fmt` drift and ESLint non-null optional-chain in `session.test.ts`.
 - **Custom providers without official login (#557)**: Custom route always spawns with agent-home `GROK_HOME` (even in shared mode); activating custom also forces independent mode so session paths stay aligned.
 - **Post-turn journal retry (#554 / #555)**: After a successful prompt RPC, journal reconciliation retries over a short bounded window (0/125/375/750 ms) via `spawn_blocking`, with per-session locking against the next user append.
@@ -28,6 +29,7 @@ See `docs/llm-wiki/release.md`.
 - **CLI vs ACP agentVersion skew (#563)**: Doctor/Runtime soft-warn when probed `grok --version` disagrees with the last live ACP `agentVersion` (never blocks sessions).
 
 **中文 · 修复**
+- **应用更新通道诚实**：设置 → 关于 在设置拆分后恢复完整路径说明 — 已签名应用内 / GitHub 下载 / 不支持的安装包类型（Linux 非 AppImage 提示）、软失败错误分类、空闲与检查失败文案；未签名构建不宣称静默更新。Host `updater_status` 在插件开启但包类型不可自动更新时返回 `unsupported`。
 - **CI 基线**：`cargo fmt` 漂移与 `session.test.ts` ESLint optional-chain 非空断言。
 - **无官方登录的第三方通道 (#557)**：自定义路由 spawn 强制 agent-home；激活时亦切换独立模式以对齐会话路径。
 - **回合后 journal 延迟对账 (#554 / #555)**：prompt 成功后在有界窗口内重试对账，并与下一次用户写入互斥。

--- a/docs/desktop-auto-update.md
+++ b/docs/desktop-auto-update.md
@@ -76,9 +76,10 @@ Before treating silent update as “on” for users:
 3. **Release cut:** tag `vX.Y.Z` so CI builds installers **and** refreshes `grok-desktop-latest` + `latest.json` + `.sig`.
 4. **Smoke on a prior signed build:** Settings → About shows **Update channel: in-app (signed release)** → Check → Download → Install and restart → version matches tag.
 5. **Failure path:** if install fails, agents / Remote IM / mirror must keep running (`prepare_for_app_update` only after successful `install()`).
-6. **Unsigned / local builds:** About must show **GitHub download** channel and still open Release / download installer (no crash).
+6. **Unsigned / local builds:** About must show **GitHub download** channel and still open Release / download installer (no crash; never claims silent update).
+7. **Linux non-AppImage:** About shows **unsupported** package-type channel + AppImage-only note when the plugin is compiled in.
 
-In-app host command `updater_status` reports `{ channel, pluginEnabled, platformSupported, endpoint }` for Doctor / About.
+In-app host command `updater_status` reports `{ channel, pluginEnabled, platformSupported, endpoint }` for Doctor / About (`channel` is `silent` | `github_manual` | `unsupported`).
 
 ## Rolling endpoint
 
@@ -120,8 +121,10 @@ Platform keys: `darwin-aarch64`, `darwin-x86_64`, `linux-x86_64`, `windows-x86_6
 
 ## Linux note
 
-Only **AppImage** supports in-app update. `.deb` / `.rpm` installs see
-`manual-required` and open the GitHub releases page.
+Only **AppImage** supports in-app update. `.deb` / `.rpm` installs report
+channel **`unsupported`** (About: package-type cannot auto-update + AppImage
+note) and surface `manual-required` when a newer build is known so the user can
+open GitHub Releases.
 
 ## macOS note
 

--- a/docs/features/app-update-flow.md
+++ b/docs/features/app-update-flow.md
@@ -6,11 +6,13 @@ Settings → About → Check for updates.
 
 1. Signed release (plugin on + platform supports): check → download → install → `prepare_for_app_update` → relaunch.
 2. Unsigned / local / plugin off: query GitHub Releases, then **Open release page** and optional **Download installer**.
-3. Package types that cannot auto-update (e.g. Linux non-AppImage): manual path with honest unsupported channel copy.
-4. Status copy and channel honesty: pure `src/lib/appUpdateHonesty.ts` (never invents versions; agents stop only after successful install prepare).
+3. Package types that cannot auto-update (e.g. Linux non-AppImage): **unsupported** channel + Linux AppImage-only note; manual download CTAs when a newer build is known.
+4. Status copy and channel honesty: pure `src/lib/appUpdateHonesty.ts` + About row (`AboutUpdateRow`) — never invents versions; soft-fail error classes; agents stop only after successful install prepare.
+5. Empty / check-failed: idle shows “no update status yet”; check/open failures use classified soft-fail hints (never claim silent update).
 
 ## Verify
 
 1. Check update against a known newer release — download URL points at the matching asset when present.
 2. When already latest — status says up to date.
 3. Local / unsigned build shows GitHub download channel, not silent in-app.
+4. Linux non-AppImage (when plugin on) shows unsupported channel + AppImage note.

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -65,7 +65,9 @@ pub struct UpdaterStatusDto {
     pub platform_supported: bool,
     /// Release binary built with signing pubkey + endpoint.
     pub plugin_enabled: bool,
-    /// `silent` when plugin path is live; otherwise `github_manual`.
+    /// `silent` when plugin path is live; `unsupported` when plugin is on but
+    /// the package type cannot auto-update (e.g. Linux non-AppImage);
+    /// otherwise `github_manual` (unsigned / local / plugin off).
     pub channel: String,
     /// Compile-time endpoint (empty when plugin off).
     pub endpoint: String,
@@ -77,6 +79,9 @@ pub fn updater_status() -> UpdaterStatusDto {
     let plugin_enabled = is_updater_plugin_enabled();
     let channel = if plugin_enabled && platform_supported {
         "silent".to_string()
+    } else if plugin_enabled && !platform_supported {
+        // Signed binary but this install type cannot silent-update.
+        "unsupported".to_string()
     } else {
         "github_manual".to_string()
     };
@@ -162,9 +167,13 @@ mod tests {
     #[test]
     fn updater_status_channel_matches_flags() {
         let s = updater_status();
-        assert!(s.channel == "silent" || s.channel == "github_manual");
+        assert!(
+            s.channel == "silent" || s.channel == "github_manual" || s.channel == "unsupported"
+        );
         if s.plugin_enabled && s.platform_supported {
             assert_eq!(s.channel, "silent");
+        } else if s.plugin_enabled && !s.platform_supported {
+            assert_eq!(s.channel, "unsupported");
         } else {
             assert_eq!(s.channel, "github_manual");
         }

--- a/src/components/settings/AboutUpdateRow.tsx
+++ b/src/components/settings/AboutUpdateRow.tsx
@@ -1,9 +1,28 @@
 /**
  * App auto-update row for Settings → About.
+ *
+ * Channel + status copy via appUpdateHonesty — never invent versions or claim
+ * silent install on unsigned / unsupported / host-only paths.
  */
 import { useState } from "react";
 import { useUpdaterContext } from "@/hooks/UpdaterProvider";
 import * as api from "@/lib/api";
+import {
+  channelExtraBodyKey,
+  classifyUpdateError,
+  isAutoUpdatePath,
+  isUpdateActionBusy,
+  mapUpdateStatusCopy,
+  resolveManualUpdateUrls,
+  resolveUpdateChannelHonestyPreferHost,
+  shouldShowInstallButton,
+  shouldShowInstallProgress,
+  shouldShowManualDownloadCtas,
+  updateChannelLabelKey,
+  updateErrorBodyKey,
+  updateStatusToneClass,
+  type AppUpdateStatusLike,
+} from "@/lib/appUpdateHonesty";
 import type { MessageKey } from "@/i18n";
 
 export function AboutUpdateRow({
@@ -30,72 +49,87 @@ export function AboutUpdateRow({
     }
   };
 
+  const statusLike = status as AppUpdateStatusLike;
+  const copy = mapUpdateStatusCopy(statusLike);
+  const channel = resolveUpdateChannelHonestyPreferHost({
+    hostChannel: channelInfo.channel,
+    pluginEnabled: channelInfo.pluginEnabled,
+    autoUpdateSupported: channelInfo.platformSupported,
+    isDesktopHost: api.isDesktopHost(),
+    status: statusLike,
+  });
+  const channelLabelKey = updateChannelLabelKey(channel);
+  const channelExtraKey = channelExtraBodyKey(channel);
+
   const statusText = (() => {
-    switch (status.state) {
-      case "checking":
-        return t("settings.autoUpdateChecking");
-      case "up-to-date":
-        return status.version
-          ? t("settings.checkUpdateLatest", { version: status.version })
-          : t("settings.autoUpdateUpToDate");
-      case "available":
-        return t("settings.autoUpdateAvailable", { version: status.version });
-      case "downloading":
-        return t("settings.autoUpdateDownloading");
-      case "ready":
-        return t("settings.autoUpdateReady");
-      case "installing":
-        return t("settings.autoUpdateInstalling");
-      case "restarting":
-        return t("settings.autoUpdateRestarting");
-      case "manual-required":
-        return t("settings.autoUpdateManualRequired", {
-          version: status.version,
-        });
-      case "error":
-        return null;
-      default:
-        return null;
+    if (!copy.titleKey || status.state === "error") return null;
+    // Idle: honest empty line (no invented "up to date").
+    if (status.state === "idle") {
+      return t(copy.titleKey);
     }
+    if (copy.version) {
+      return t(copy.titleKey, { version: copy.version });
+    }
+    return t(copy.titleKey);
   })();
 
-  const busy =
-    status.state === "checking" ||
-    status.state === "downloading" ||
-    status.state === "installing" ||
-    status.state === "restarting";
+  const bodyText = (() => {
+    if (!copy.bodyKey) return null;
+    // Error body is shown under the alert line separately.
+    if (status.state === "error") return null;
+    // Agents note only on auto path; manual path uses manual body.
+    if (
+      copy.bodyKey === "settings.autoUpdateBody.agentsNote" &&
+      !isAutoUpdatePath(channel)
+    ) {
+      return null;
+    }
+    return t(copy.bodyKey);
+  })();
 
+  const busy = isUpdateActionBusy(statusLike);
+  const showInstallProgress = shouldShowInstallProgress(statusLike);
   // Only show install when download finished (ready), never on available.
   // After install, restart runs automatically (no second click).
-  const showInstall = status.state === "ready";
-  const showInstalling =
-    status.state === "installing" || status.state === "restarting";
-  const showOpenRelease = status.state === "manual-required";
-  const releaseUrl =
-    status.state === "manual-required" ? status.releaseUrl : githubReleasesUrl;
-  const downloadUrl =
-    status.state === "manual-required" ? status.downloadUrl : null;
-  const assetNames =
-    status.state === "manual-required" ? status.assetNames : undefined;
-  const highlight =
-    status.state === "available" ||
-    status.state === "ready" ||
-    status.state === "downloading" ||
-    status.state === "manual-required";
+  const showInstall = shouldShowInstallButton(statusLike);
+  const showOpenRelease = shouldShowManualDownloadCtas(statusLike);
+  const manualUrls = showOpenRelease
+    ? resolveManualUpdateUrls(statusLike, githubReleasesUrl)
+    : null;
+  const releaseUrl = manualUrls?.releaseUrl ?? githubReleasesUrl;
+  const downloadUrl = manualUrls?.downloadUrl ?? null;
+  const assetNames = manualUrls?.assetNames;
+  const toneClass = updateStatusToneClass(copy.severity);
+
+  const openErrorKind = openError ? classifyUpdateError(openError) : null;
+  const openErrorHintKey =
+    openErrorKind && openErrorKind !== "other"
+      ? updateErrorBodyKey(openErrorKind)
+      : null;
 
   return (
     <div className="settings-row settings-row--stack">
       <div className="settings-row__text">
         <div className="settings-row__label">{t("settings.checkUpdate")}</div>
         <div className="settings-row__desc">{t("settings.checkUpdateDesc")}</div>
-        <div className="settings-row__hint" data-updater-channel={channelInfo.channel}>
-          {channelInfo.channel === "silent"
-            ? t("settings.autoUpdateChannelSilent")
-            : t("settings.autoUpdateChannelManual")}
-          {channelInfo.endpoint
+        <div
+          className="settings-row__hint"
+          data-updater-channel={channel}
+          data-updater-host-channel={channelInfo.channel}
+        >
+          {t(channelLabelKey)}
+          {channelInfo.endpoint && isAutoUpdatePath(channel)
             ? ` · ${channelInfo.endpoint.replace(/^https:\/\//, "")}`
             : ""}
         </div>
+        {channelExtraKey ? (
+          <div
+            className="settings-row__hint settings-about-update__channel-note"
+            data-update-channel-note={channelExtraKey}
+          >
+            {t(channelExtraKey)}
+          </div>
+        ) : null}
       </div>
       <div className="settings-about-update">
         <div className="settings-about-update__actions">
@@ -109,7 +143,8 @@ export function AboutUpdateRow({
               ? t("settings.checkUpdateChecking")
               : t("settings.checkUpdate")}
           </button>
-          {showInstalling ? (
+          {showInstallProgress &&
+          (status.state === "installing" || status.state === "restarting") ? (
             <button type="button" className="btn btn--solid" disabled>
               {status.state === "restarting"
                 ? t("settings.autoUpdateRestarting")
@@ -147,21 +182,52 @@ export function AboutUpdateRow({
         {statusText ? (
           <div
             className={
-              "settings-about-update__status" + (highlight ? " is-available" : "")
+              "settings-about-update__status" +
+              (toneClass ? ` ${toneClass}` : "")
             }
             role="status"
+            data-update-state={status.state}
+            data-update-severity={copy.severity}
           >
             {statusText}
           </div>
         ) : null}
+        {bodyText ? (
+          <div
+            className="settings-about-update__body"
+            data-update-body={copy.bodyKey ?? undefined}
+          >
+            {bodyText}
+          </div>
+        ) : null}
         {status.state === "error" ? (
-          <div className="settings-about-update__err" role="alert">
-            {t("settings.autoUpdateError", { error: status.message })}
+          <div
+            className="settings-about-update__err"
+            role="alert"
+            data-update-error-kind={copy.errorKind ?? "other"}
+          >
+            {t("settings.autoUpdateError", {
+              error: copy.errorMessage ?? status.message,
+            })}
+            {copy.bodyKey ? (
+              <div className="settings-about-update__err-hint">
+                {t(copy.bodyKey)}
+              </div>
+            ) : null}
           </div>
         ) : null}
         {openError ? (
-          <div className="settings-about-update__err" role="alert">
+          <div
+            className="settings-about-update__err"
+            role="alert"
+            data-update-error-kind={openErrorKind ?? "other"}
+          >
             {t("settings.checkUpdateFailed", { error: openError })}
+            {openErrorHintKey ? (
+              <div className="settings-about-update__err-hint">
+                {t(openErrorHintKey)}
+              </div>
+            ) : null}
           </div>
         ) : null}
         {assetNames && assetNames.length > 0 ? (

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -115,8 +115,14 @@ async function githubCheckUpdate(): Promise<AppUpdateCheck> {
 }
 
 export type UpdaterChannelInfo = {
-  /** `silent` when signed release plugin path is live; else `github_manual`. */
-  channel: "silent" | "github_manual" | "unknown";
+  /**
+   * Host channel honesty:
+   * - `silent` — signed release plugin + platform supports in-app install
+   * - `github_manual` — unsigned / local / plugin off
+   * - `unsupported` — plugin on but package type cannot auto-update (e.g. Linux non-AppImage)
+   * - `unknown` — not yet probed
+   */
+  channel: "silent" | "github_manual" | "unsupported" | "unknown";
   pluginEnabled: boolean;
   platformSupported: boolean;
   endpoint: string;
@@ -642,13 +648,25 @@ export function useUpdater() {
         endpoint: string;
       }>("updater_status");
       if (!aliveRef.current) return;
+      // Prefer host string when known; derive unsupported from flags so a
+      // collapsed github_manual never claims silent for non-AppImage Linux.
+      let channel: UpdaterChannelInfo["channel"] = "unknown";
+      if (s.channel === "silent") {
+        channel = "silent";
+      } else if (s.channel === "unsupported") {
+        channel = "unsupported";
+      } else if (s.channel === "github_manual") {
+        channel =
+          s.pluginEnabled && !s.platformSupported
+            ? "unsupported"
+            : "github_manual";
+      } else if (s.pluginEnabled && !s.platformSupported) {
+        channel = "unsupported";
+      } else if (!s.pluginEnabled) {
+        channel = "github_manual";
+      }
       setChannelInfo({
-        channel:
-          s.channel === "silent"
-            ? "silent"
-            : s.channel === "github_manual"
-              ? "github_manual"
-              : "unknown",
+        channel,
         pluginEnabled: !!s.pluginEnabled,
         platformSupported: !!s.platformSupported,
         endpoint: s.endpoint || "",

--- a/src/i18n/messages/en/settings-ui.ts
+++ b/src/i18n/messages/en/settings-ui.ts
@@ -393,6 +393,7 @@ export const enSettingsUi = {
   "settings.autoUpdateBody.ready": "One more step: install stages the package, then the app restarts automatically.",
   "settings.autoUpdateBody.manual": "Open the release page or download the installer for this platform. In-app silent install is not available on this build.",
   "settings.autoUpdateBody.agentsNote": "Agents, voice, Remote IM, and mirror keep running; they stop only after a successful install prepare.",
+  "settings.autoUpdateBody.linuxAppImage": "On Linux, only AppImage installs support in-app update. .deb / .rpm (and similar) need a manual download from GitHub Releases.",
   "settings.autoUpdateError.network": "Could not reach the update server. Check your network or proxy, then try again.",
   "settings.autoUpdateError.signature": "The update package failed signature verification. Use a signed release build or download from GitHub Releases.",
   "settings.autoUpdateError.pluginMissing": "In-app updater is not available in this build (unsigned or local). Use Check for updates to open GitHub Releases.",

--- a/src/i18n/messages/zh-TW/settings-ui.ts
+++ b/src/i18n/messages/zh-TW/settings-ui.ts
@@ -393,6 +393,7 @@ export const zhTWSettingsUi = {
   "settings.autoUpdateBody.ready": "下一步：安裝會暫存套件，然後應用程式自動重新啟動。",
   "settings.autoUpdateBody.manual": "請開啟發佈頁或下載本平台安裝包。此建置不支援應用程式內靜默安裝。",
   "settings.autoUpdateBody.agentsNote": "智慧體、語音、遠端 IM 與鏡像繼續執行；僅在安裝準備成功後才會停止。",
+  "settings.autoUpdateBody.linuxAppImage": "在 Linux 上，僅 AppImage 安裝支援應用程式內更新。.deb / .rpm（及類似套件）需從 GitHub Releases 手動下載。",
   "settings.autoUpdateError.network": "無法連線更新伺服器。請檢查網路或代理後重試。",
   "settings.autoUpdateError.signature": "更新包簽名校驗失敗。請使用已簽名正式版，或從 GitHub Releases 下載。",
   "settings.autoUpdateError.pluginMissing": "此建置未啟用應用程式內更新（未簽名或本機版）。請點「檢查更新」開啟 GitHub Releases。",

--- a/src/i18n/messages/zh/settings-ui.ts
+++ b/src/i18n/messages/zh/settings-ui.ts
@@ -393,6 +393,7 @@ export const zhSettingsUi = {
   "settings.autoUpdateBody.ready": "下一步：安装会暂存包，然后应用自动重启。",
   "settings.autoUpdateBody.manual": "请打开发布页或下载本平台安装包。此构建不支持应用内静默安装。",
   "settings.autoUpdateBody.agentsNote": "智能体、语音、远程 IM 与镜像继续运行；仅在安装准备成功后才会停止。",
+  "settings.autoUpdateBody.linuxAppImage": "在 Linux 上，仅 AppImage 安装支持应用内更新。.deb / .rpm（及类似包）需从 GitHub Releases 手动下载。",
   "settings.autoUpdateError.network": "无法连接更新服务器。请检查网络或代理后重试。",
   "settings.autoUpdateError.signature": "更新包签名校验失败。请使用已签名正式版，或从 GitHub Releases 下载。",
   "settings.autoUpdateError.pluginMissing": "此构建未启用应用内更新（未签名或本地版）。请点「检查更新」打开 GitHub Releases。",

--- a/src/lib/appUpdateHonesty.test.ts
+++ b/src/lib/appUpdateHonesty.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  channelExtraBodyKey,
   channelFromHostString,
   classifyUpdateError,
   formatUpdateProgressLine,
@@ -116,11 +117,12 @@ describe("updateChannelLabelKey / isAutoUpdatePath", () => {
 });
 
 describe("mapUpdateStatusCopy", () => {
-  it("maps idle with no invented version", () => {
+  it("maps idle with no invented version (empty honesty)", () => {
     const c = mapUpdateStatusCopy({ state: "idle" });
     expect(c.titleKey).toBe("settings.autoUpdateIdle");
     expect(c.version).toBeNull();
     expect(c.severity).toBe("none");
+    expect(c.bodyKey).toBeNull();
   });
 
   it("maps checking / progress states with body notes", () => {
@@ -342,7 +344,7 @@ describe("channelFromHostString / prefer host", () => {
     expect(channelFromHostString("")).toBeNull();
   });
 
-  it("prefer host silent, but live manual-required wins", () => {
+  it("prefer host silent when capability is auto; live manual-required wins", () => {
     expect(
       resolveUpdateChannelHonestyPreferHost({
         hostChannel: "silent",
@@ -365,6 +367,50 @@ describe("channelFromHostString / prefer host", () => {
         },
       }),
     ).toBe("unsupported");
+  });
+
+  it("never claims silent when plugin is off (stale host silent)", () => {
+    expect(
+      resolveUpdateChannelHonestyPreferHost({
+        hostChannel: "silent",
+        pluginEnabled: false,
+        autoUpdateSupported: false,
+        isDesktopHost: true,
+      }),
+    ).toBe("manual_github");
+  });
+
+  it("capability unsupported wins over collapsed host github_manual", () => {
+    expect(
+      resolveUpdateChannelHonestyPreferHost({
+        hostChannel: "github_manual",
+        pluginEnabled: true,
+        autoUpdateSupported: false,
+        isDesktopHost: true,
+      }),
+    ).toBe("unsupported");
+  });
+
+  it("safer host non-auto wins when capability looks auto", () => {
+    expect(
+      resolveUpdateChannelHonestyPreferHost({
+        hostChannel: "github_manual",
+        pluginEnabled: true,
+        autoUpdateSupported: true,
+        isDesktopHost: true,
+      }),
+    ).toBe("manual_github");
+  });
+});
+
+describe("channelExtraBodyKey", () => {
+  it("adds Linux AppImage note only for unsupported channel", () => {
+    expect(channelExtraBodyKey("unsupported")).toBe(
+      "settings.autoUpdateBody.linuxAppImage",
+    );
+    expect(channelExtraBodyKey("auto")).toBeNull();
+    expect(channelExtraBodyKey("manual_github")).toBeNull();
+    expect(channelExtraBodyKey("host_only")).toBeNull();
   });
 });
 

--- a/src/lib/appUpdateHonesty.ts
+++ b/src/lib/appUpdateHonesty.ts
@@ -84,6 +84,7 @@ export type UpdateStatusBodyKey =
   | "settings.autoUpdateBody.ready"
   | "settings.autoUpdateBody.manual"
   | "settings.autoUpdateBody.agentsNote"
+  | "settings.autoUpdateBody.linuxAppImage"
   | "settings.autoUpdateError.network"
   | "settings.autoUpdateError.signature"
   | "settings.autoUpdateError.pluginMissing"
@@ -522,7 +523,9 @@ export function channelFromHostString(
 }
 
 /**
- * Prefer host channel when known; else capability resolve.
+ * Prefer capability resolve for non-auto paths so unsigned / unsupported never
+ * claim silent install. Host channel is only a hint when capability says auto
+ * (or is unknown); a safer non-auto host report still wins over "auto".
  * Live `manual-required` still forces non-auto honesty.
  */
 export function resolveUpdateChannelHonestyPreferHost(input: {
@@ -539,7 +542,7 @@ export function resolveUpdateChannelHonestyPreferHost(input: {
     status: input.status,
   });
 
-  // Live manual path wins over a stale "silent" host report.
+  // Live manual path and host_only always win.
   if (
     input.status?.state === "manual-required" ||
     fromStatus === "host_only"
@@ -547,9 +550,31 @@ export function resolveUpdateChannelHonestyPreferHost(input: {
     return fromStatus;
   }
 
+  // Capability-backed manual / unsupported is authoritative — never let a stale
+  // host "silent" claim override unsigned or package-type limits.
+  if (fromStatus !== "auto") {
+    return fromStatus;
+  }
+
   const fromHost = channelFromHostString(input.hostChannel);
-  if (fromHost) return fromHost;
+  // Safer honesty: if host says non-auto while capability looks auto, prefer host.
+  if (fromHost && fromHost !== "auto") {
+    return fromHost;
+  }
   return fromStatus;
+}
+
+/**
+ * Extra channel body for package-type limits (Linux AppImage-only, etc.).
+ * Null when no extra note — never invents a silent-install claim.
+ */
+export function channelExtraBodyKey(
+  channel: UpdateChannelHonesty,
+): UpdateStatusBodyKey | null {
+  if (channel === "unsupported") {
+    return "settings.autoUpdateBody.linuxAppImage";
+  }
+  return null;
 }
 
 /** CSS modifier for About status strip (`is-available` / `is-error` / …). */

--- a/src/styles/settings.part5.css
+++ b/src/styles/settings.part5.css
@@ -195,6 +195,11 @@
   font-weight: 500;
 }
 
+.settings-about-update__status.is-error {
+  color: var(--danger, #d33);
+  font-weight: 500;
+}
+
 .settings-about-update__err {
   font-size: 12.5px;
   color: var(--danger, #d33);


### PR DESCRIPTION
## Summary

Settings → About had the pure honesty helpers and i18n, but the row itself still collapsed channels to “silent vs manual” after the settings split. This restores the product story:

- **Clear channel label**: signed in-app · GitHub download · unsupported package type · desktop-only
- **Never claim silent update** on unsigned / local builds (stale host “silent” cannot override)
- **Soft-fail errors** classified (network / signature / plugin missing / …) with a short hint under the raw message
- **Linux**: AppImage-only note when the package type cannot auto-update
- **Empty / check-failed**: idle says “no update status yet”; open/check failures get soft-fail hints

Host `updater_status` now reports `unsupported` when the plugin is compiled in but the install type cannot auto-update (e.g. Linux non-AppImage). Frontend also derives that from flags if an older host only sent `github_manual`.

No App.tsx growth; no real signing secrets required.

## What changed

| Area | Change |
|------|--------|
| `AboutUpdateRow` | Wired back to `appUpdateHonesty` (channel, status body, CTAs, soft-fail errors) |
| `appUpdateHonesty` | Prefer capability over stale silent; Linux AppImage extra body key |
| `useUpdater` | Channel type includes `unsupported`; maps host flags honestly |
| `updater.rs` | `updater_status.channel` → `silent` \| `github_manual` \| `unsupported` |
| i18n | en / zh / zh-TW: `settings.autoUpdateBody.linuxAppImage` |
| docs + CHANGELOG | Linux note + verify steps |

## Test plan

- [x] `pnpm test -- src/lib/appUpdateHonesty.test.ts` (37)
- [x] `pnpm test -- src/i18n/messages.test.ts`
- [x] `pnpm typecheck`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml updater::`
- [ ] Local / unsigned build: About shows **GitHub download**, not silent; Check still opens Releases
- [ ] Signed AppImage (or mac/win release): channel **in-app (signed)**; check → download → install still works
- [ ] Linux non-AppImage with plugin on: **unsupported** + AppImage note; manual CTAs when update known
- [ ] Force network/signature error: classified hint under the error line

## Notes

Residual honesty polish for the app auto-update path. Agents / voice / IM / mirror still stop only after successful `install()` prepare — unchanged P0.