### PR TITLE
fix(preview): bound Office and PDF range reassembly

### DIFF
--- a/docs/llm-wiki/media-delivery.md
+++ b/docs/llm-wiki/media-delivery.md
@@ -19,6 +19,7 @@ GET http://127.0.0.1:{port}/v1/media?t={token}&p={urlencode(absPath)}
 - **path_scope**: same allowlist as fs absolute APIs (trusted projects, app data, agent home, grants).
 - **Images**: no-Range GET returns **full 200 body** (up to 40 MiB). `<img>` cannot reassemble Range/206 — truncating at 2 MiB breaks chat thumbs and composer drops.
 - **Range**: 206 + max 2 MiB chunk for video/audio/PDF (and Range requests on any type).
+- **Rich document previews**: Office/PDF full-file renderers cap input at 40 MiB, validate every `Content-Range`, assemble into one bounded buffer, and abort fetches when the preview changes. Video/audio remain streamed rather than reassembled.
 - **CORS**: main-window origins only (for `fetch` / copy / office reassembly); never `*`.
 - **CSP**: `img-src` / `media-src` / `connect-src` allow `http://127.0.0.1:*`.
 

--- a/src-tauri/src/fs_browser.rs
+++ b/src-tauri/src/fs_browser.rs
@@ -1,16 +1,16 @@
 //! Project-scoped filesystem browser for the right-pane resource viewer.
 //! All paths are resolved under an explicit project root (no escape).
 
-#![allow(dead_code)] // residual-clippy: MAX_BINARY_BYTES const
+#![allow(dead_code)] // Legacy Office text-extraction helpers remain available.
 use serde::Serialize;
 use std::fs;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 
 const MAX_TEXT_BYTES: u64 = 2 * 1024 * 1024; // 2 MiB text preview
-const MAX_BINARY_BYTES: u64 = 8 * 1024 * 1024; // 8 MiB image / pdf
 /// Office packages streamed to the UI for rich render (docx-preview / xlsx / pdf).
 const MAX_OFFICE_STREAM_BYTES: u64 = 40 * 1024 * 1024;
+const MAX_PDF_STREAM_BYTES: u64 = 40 * 1024 * 1024;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1213,7 +1213,7 @@ fn read_path(path: PathBuf, rel_in: String) -> Result<FsReadResult, String> {
                 mime,
                 None,
                 None,
-                true,
+                false,
                 true,
                 Some(format!(
                     "file too large for in-app office preview (>{MAX_OFFICE_STREAM_BYTES} bytes)"
@@ -1256,7 +1256,27 @@ fn read_path(path: PathBuf, rel_in: String) -> Result<FsReadResult, String> {
         ));
     }
 
-    // Image / PDF — always stream via loopback media HTTP (no base64 IPC).
+    // PDF rich preview loads the full file in the WebView, so apply the same
+    // explicit memory budget as Office packages before exposing a stream URL.
+    if kind == "pdf" && size > MAX_PDF_STREAM_BYTES {
+        return Ok(ok_result(
+            &path,
+            rel_in,
+            name,
+            size,
+            kind,
+            mime,
+            None,
+            None,
+            false,
+            true,
+            Some(format!(
+                "file too large for in-app pdf preview (>{MAX_PDF_STREAM_BYTES} bytes)"
+            )),
+        ));
+    }
+
+    // Image / PDF — stream via loopback media HTTP (no base64 IPC).
     if matches!(kind.as_str(), "image" | "pdf") {
         return Ok(ok_result(
             &path, rel_in, name, size, kind, mime, None, None, true, false, None,
@@ -1354,6 +1374,34 @@ mod tests {
         assert_eq!(r.kind, "markdown");
         assert!(r.text.unwrap().contains("# hi"));
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rich_document_preview_limits_are_enforced() {
+        for (name, label, max_bytes) in [
+            ("large.docx", "office", MAX_OFFICE_STREAM_BYTES),
+            ("large.pdf", "pdf", MAX_PDF_STREAM_BYTES),
+        ] {
+            let dir = tempfile_dir();
+            let path = dir.join(name);
+            let file = fs::File::create(&path).unwrap();
+            file.set_len(max_bytes + 1).unwrap();
+
+            let result = read_path(path, name.to_string()).unwrap();
+            assert!(
+                !result.stream,
+                "{label} preview must not stream over the cap"
+            );
+            assert!(
+                result
+                    .error
+                    .as_deref()
+                    .is_some_and(|error| error.contains("too large")),
+                "{label} preview should explain the size limit: {:?}",
+                result.error
+            );
+            let _ = fs::remove_dir_all(&dir);
+        }
     }
 
     #[test]

--- a/src/components/OfficeDocumentPreview.tsx
+++ b/src/components/OfficeDocumentPreview.tsx
@@ -97,7 +97,7 @@ export function OfficeDocumentPreview({
     setActiveSheet(0);
     setSheetHtml("");
 
-    if (errorFromHost && !absolutePath) {
+    if (errorFromHost) {
       const resolved = resolveMediaLoadError(errorFromHost, "office");
       setLoad({
         status: "error",
@@ -115,9 +115,14 @@ export function OfficeDocumentPreview({
       return;
     }
 
+    const controller = new AbortController();
     void (async () => {
       try {
-        const buf = await fetchPreviewArrayBuffer(absolutePath, kind);
+        const buf = await fetchPreviewArrayBuffer(
+          absolutePath,
+          kind,
+          controller.signal,
+        );
         if (cancelled) return;
         setLoad({ status: "ready", buffer: buf });
       } catch (e) {
@@ -133,6 +138,7 @@ export function OfficeDocumentPreview({
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [absolutePath, kind, errorFromHost, tr]);
 

--- a/src/i18n/messages/en/core.ts
+++ b/src/i18n/messages/en/core.ts
@@ -19,6 +19,7 @@ export const enCore = {
   "media.err.hostOnly": "Local media preview requires the desktop app.",
   "media.err.brokenBlob": "Preview failed — the file may be corrupt or unreadable.",
   "media.err.timeout": "Timed out while loading this media.",
+  "media.err.tooLarge": "This file is too large for an in-app preview. Open it externally instead.",
   "media.err.unsupportedType": "This media type has no in-app preview.",
   "media.err.mediaServerUnavailable": "Local media server is unavailable — try again in a moment.",
   "media.err.other": "Could not load this media in the app preview.",

--- a/src/i18n/messages/zh-TW/core.ts
+++ b/src/i18n/messages/zh-TW/core.ts
@@ -19,6 +19,7 @@ export const zhTWCore = {
   "media.err.hostOnly": "本機媒體預覽需要桌面應用程式。",
   "media.err.brokenBlob": "預覽失敗 — 檔案可能已損毀或無法讀取。",
   "media.err.timeout": "載入此媒體逾時。",
+  "media.err.tooLarge": "此檔案過大，無法在應用程式內預覽。請改用外部應用程式開啟。",
   "media.err.unsupportedType": "此媒體類型尚無應用程式內預覽。",
   "media.err.mediaServerUnavailable": "本機媒體服務無法使用 — 請稍後再試。",
   "media.err.other": "應用程式內無法載入此媒體。",

--- a/src/i18n/messages/zh/core.ts
+++ b/src/i18n/messages/zh/core.ts
@@ -19,6 +19,7 @@ export const zhCore = {
   "media.err.hostOnly": "本地媒体预览需要桌面应用。",
   "media.err.brokenBlob": "预览失败 — 文件可能已损坏或无法读取。",
   "media.err.timeout": "加载此媒体超时。",
+  "media.err.tooLarge": "此文件过大，无法在应用内预览。请改用外部应用打开。",
   "media.err.unsupportedType": "此媒体类型暂无应用内预览。",
   "media.err.mediaServerUnavailable": "本地媒体服务不可用 — 请稍后重试。",
   "media.err.other": "应用内无法加载此媒体。",

--- a/src/lib/filePreviewSrc.test.ts
+++ b/src/lib/filePreviewSrc.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { pathToFileUrl } from "./filePreviewSrc";
+import { describe, expect, it, vi } from "vitest";
+import { fetchViaRange, pathToFileUrl } from "./filePreviewSrc";
 
 describe("pathToFileUrl", () => {
   it("encodes unix paths with spaces and CJK", () => {
@@ -15,5 +15,137 @@ describe("pathToFileUrl", () => {
   it("handles windows drive letters", () => {
     const u = pathToFileUrl("C:/Users/me/report.html");
     expect(u).toBe("file:///C:/Users/me/report.html");
+  });
+});
+
+describe("fetchViaRange", () => {
+  it("rejects an oversized PDF from the first Content-Range response", async () => {
+    const fetchImpl: typeof fetch = vi.fn(async () =>
+      new Response(new Uint8Array(4), {
+        status: 206,
+        headers: { "Content-Range": `bytes 0-3/${40 * 1024 * 1024 + 1}` },
+      }),
+    );
+
+    await expect(
+      fetchViaRange("http://127.0.0.1/preview", {
+        kind: "pdf",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("file too large for in-app pdf preview");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an overlarge initial range before reading its body", async () => {
+    const arrayBuffer = vi.fn(async () => new ArrayBuffer(0));
+    const fetchImpl: typeof fetch = vi.fn(async () => {
+      const response = new Response(null, {
+        status: 206,
+        headers: {
+          "Content-Range": `bytes 0-${4 * 1024 * 1024 - 1}/${8 * 1024 * 1024}`,
+        },
+      });
+      Object.defineProperty(response, "arrayBuffer", { value: arrayBuffer });
+      return response;
+    });
+
+    await expect(
+      fetchViaRange("http://127.0.0.1/preview", {
+        kind: "pdf",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("invalid Content-Range");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("passes one AbortSignal to every range request", async () => {
+    const controller = new AbortController();
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const fetchImpl: typeof fetch = vi.fn(async (_url, init) => {
+      expect(init?.signal).toBe(controller.signal);
+      const range = (init?.headers as Record<string, string> | undefined)?.Range;
+      if (!range) {
+        return new Response(bytes.slice(0, 2), {
+          status: 206,
+          headers: { "Content-Range": "bytes 0-1/4" },
+        });
+      }
+      return new Response(bytes.slice(2), {
+        status: 206,
+        headers: { "Content-Range": "bytes 2-3/4" },
+      });
+    });
+
+    await expect(
+      fetchViaRange("http://127.0.0.1/preview", {
+        kind: "pdf",
+        signal: controller.signal,
+        fetchImpl,
+        chunkSize: 2,
+      }),
+    ).resolves.toEqual(bytes.buffer);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a range response that does not start where requested", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const fetchImpl: typeof fetch = vi.fn(async (_url, init) => {
+      const range = (init?.headers as Record<string, string> | undefined)?.Range;
+      return new Response(bytes.slice(0, 2), {
+        status: 206,
+        headers: {
+          "Content-Range": range ? "bytes 0-1/4" : "bytes 0-1/4",
+        },
+      });
+    });
+
+    await expect(
+      fetchViaRange("http://127.0.0.1/preview", {
+        kind: "docx",
+        fetchImpl,
+        chunkSize: 2,
+      }),
+    ).rejects.toThrow("invalid Content-Range");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops an in-flight range request when aborted", async () => {
+    const controller = new AbortController();
+    let requestStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      requestStarted = resolve;
+    });
+    const fetchImpl: typeof fetch = vi.fn((_url, init) => {
+      const range = (init?.headers as Record<string, string> | undefined)?.Range;
+      if (!range) {
+        return Promise.resolve(
+          new Response(new Uint8Array([1, 2]), {
+            status: 206,
+            headers: { "Content-Range": "bytes 0-1/4" },
+          }),
+        );
+      }
+      requestStarted?.();
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+          once: true,
+        });
+      });
+    });
+
+    const pending = fetchViaRange("http://127.0.0.1/preview", {
+      kind: "pdf",
+      signal: controller.signal,
+      fetchImpl,
+      chunkSize: 2,
+    });
+    await started;
+    controller.abort();
+
+    await expect(pending).rejects.toSatisfy(
+      (error: unknown) => error instanceof DOMException && error.name === "AbortError",
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/filePreviewSrc.ts
+++ b/src/lib/filePreviewSrc.ts
@@ -121,72 +121,175 @@ export async function resolvePreviewSrc(
 export async function fetchPreviewArrayBuffer(
   absolutePath: string,
   kind?: string,
+  signal?: AbortSignal,
 ): Promise<ArrayBuffer> {
+  throwIfAborted(signal);
   const url = await pathToPreviewUrl(absolutePath, kind);
   if (!url) {
     throw new Error("cannot resolve local file URL");
   }
   // Large files: assemble Range chunks (server caps each response at 2 MiB).
-  return fetchViaRange(url);
+  return fetchViaRange(url, { kind, signal });
 }
 
-/** Fetch full body, following Range windowing when the server returns 206. */
-async function fetchViaRange(url: string): Promise<ArrayBuffer> {
-  const first = await fetch(url);
-  if (!first.ok && first.status !== 206) {
+export const OFFICE_PREVIEW_MAX_BYTES = 40 * 1024 * 1024;
+export const PDF_PREVIEW_MAX_BYTES = 40 * 1024 * 1024;
+const PREVIEW_RANGE_CHUNK_BYTES = 2 * 1024 * 1024;
+
+interface FetchViaRangeOptions {
+  kind?: string;
+  signal?: AbortSignal;
+  /** Test seam; production uses the browser's fetch. */
+  fetchImpl?: typeof fetch;
+  /** Test seam; production always uses the media server's 2 MiB window. */
+  chunkSize?: number;
+}
+
+interface ParsedContentRange {
+  start: number;
+  end: number;
+  total: number;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  if (signal.reason !== undefined) throw signal.reason;
+  throw new DOMException("The operation was aborted", "AbortError");
+}
+
+function previewBudget(kind?: string): { maxBytes: number; label: "office" | "pdf" } {
+  return kind === "pdf"
+    ? { maxBytes: PDF_PREVIEW_MAX_BYTES, label: "pdf" }
+    : { maxBytes: OFFICE_PREVIEW_MAX_BYTES, label: "office" };
+}
+
+function parseContentRange(header: string | null): ParsedContentRange | null {
+  if (!header) return null;
+  const match = /^bytes\s+(\d+)-(\d+)\/(\d+)$/i.exec(header.trim());
+  if (!match) return null;
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  const total = Number(match[3]);
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(end) ||
+    !Number.isSafeInteger(total) ||
+    start < 0 ||
+    end < start ||
+    total <= end
+  ) {
+    return null;
+  }
+  return { start, end, total };
+}
+
+function validateContentLength(response: Response, expected: number): void {
+  const raw = response.headers.get("content-length");
+  if (raw == null) return;
+  const length = Number(raw);
+  if (!Number.isSafeInteger(length) || length !== expected) {
+    throw new Error("invalid Content-Length for preview range");
+  }
+}
+
+function tooLargeError(label: "office" | "pdf", maxBytes: number): Error {
+  return new Error(
+    `file too large for in-app ${label} preview (max ${maxBytes} bytes)`,
+  );
+}
+
+/**
+ * Fetch a full rich-document body using bounded, validated Range windows.
+ * Exported for deterministic regression tests.
+ */
+export async function fetchViaRange(
+  url: string,
+  options: FetchViaRangeOptions = {},
+): Promise<ArrayBuffer> {
+  const { maxBytes, label } = previewBudget(options.kind);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const chunkSize = options.chunkSize ?? PREVIEW_RANGE_CHUNK_BYTES;
+  if (!Number.isSafeInteger(chunkSize) || chunkSize <= 0) {
+    throw new Error("invalid preview range chunk size");
+  }
+  throwIfAborted(options.signal);
+  const first = await fetchImpl(url, { signal: options.signal });
+  if (!first.ok) {
     throw new Error(`failed to load file (${first.status})`);
   }
 
   // Full body available
   if (first.status === 200) {
-    return first.arrayBuffer();
+    const announcedLength = Number(first.headers.get("content-length"));
+    if (Number.isFinite(announcedLength) && announcedLength > maxBytes) {
+      throw tooLargeError(label, maxBytes);
+    }
+    const full = await first.arrayBuffer();
+    if (full.byteLength > maxBytes) throw tooLargeError(label, maxBytes);
+    return full;
   }
 
-  // 206: assemble remaining ranges
-  const contentRange = first.headers.get("content-range") || "";
-  // bytes start-end/total
-  const m = /bytes\s+(\d+)-(\d+)\/(\d+|\*)/i.exec(contentRange);
+  if (first.status !== 206) {
+    throw new Error(`failed to load file (${first.status})`);
+  }
+
+  // Validate the advertised total before reading or allocating the response.
+  const initialRange = parseContentRange(first.headers.get("content-range"));
+  if (!initialRange || initialRange.start !== 0) {
+    throw new Error("invalid Content-Range for preview response");
+  }
+  if (initialRange.total > maxBytes) {
+    throw tooLargeError(label, maxBytes);
+  }
+  const expectedInitialEnd =
+    Math.min(initialRange.total, chunkSize) - 1;
+  if (initialRange.end !== expectedInitialEnd) {
+    throw new Error("invalid Content-Range for preview response");
+  }
+  const initialLength = expectedInitialEnd + 1;
+  validateContentLength(first, initialLength);
   const firstBuf = new Uint8Array(await first.arrayBuffer());
-  if (!m) {
-    return firstBuf.buffer;
-  }
-  const end = Number(m[2]);
-  const total = m[3] === "*" ? NaN : Number(m[3]);
-  if (!Number.isFinite(total) || total <= end + 1) {
-    return firstBuf.buffer;
+  if (firstBuf.byteLength !== initialLength) {
+    throw new Error("invalid preview range body length");
   }
 
-  const chunks: Uint8Array[] = [firstBuf];
-  let next = end + 1;
-  while (next < total) {
-    const res = await fetch(url, {
-      headers: { Range: `bytes=${next}-` },
+  // Allocate once after the strict budget check, then copy one bounded chunk at
+  // a time. This avoids retaining the whole file in chunks plus a second copy.
+  const out = new Uint8Array(initialRange.total);
+  out.set(firstBuf, 0);
+  let next = initialRange.end + 1;
+
+  while (next < initialRange.total) {
+    throwIfAborted(options.signal);
+    const requestedEnd = Math.min(
+      next + chunkSize - 1,
+      initialRange.total - 1,
+    );
+    const res = await fetchImpl(url, {
+      headers: { Range: `bytes=${next}-${requestedEnd}` },
+      signal: options.signal,
     });
-    if (!res.ok && res.status !== 206) {
+    if (!res.ok || res.status !== 206) {
       throw new Error(`failed to load file range (${res.status})`);
     }
+    const range = parseContentRange(res.headers.get("content-range"));
+    if (
+      !range ||
+      range.start !== next ||
+      range.end !== requestedEnd ||
+      range.total !== initialRange.total
+    ) {
+      throw new Error("invalid Content-Range for preview response");
+    }
+    const expectedLength = range.end - range.start + 1;
+    validateContentLength(res, expectedLength);
     const buf = new Uint8Array(await res.arrayBuffer());
-    if (!buf.byteLength) break;
-    chunks.push(buf);
-    const cr = res.headers.get("content-range") || "";
-    const rm = /bytes\s+(\d+)-(\d+)\//i.exec(cr);
-    if (rm) {
-      next = Number(rm[2]) + 1;
-    } else {
-      next += buf.byteLength;
+    if (buf.byteLength !== expectedLength) {
+      throw new Error("invalid preview range body length");
     }
-    // Safety: prevent infinite loops
-    if (chunks.length > 10_000) {
-      throw new Error("file too large to reassemble");
-    }
+    out.set(buf, range.start);
+    next = range.end + 1;
   }
 
-  const size = chunks.reduce((n, c) => n + c.byteLength, 0);
-  const out = new Uint8Array(size);
-  let off = 0;
-  for (const c of chunks) {
-    out.set(c, off);
-    off += c.byteLength;
-  }
   return out.buffer;
 }

--- a/src/lib/mediaLoadPro.test.ts
+++ b/src/lib/mediaLoadPro.test.ts
@@ -48,6 +48,16 @@ describe("classifyMediaLoadError", () => {
     expect(classifyMediaLoadError({ status: 504 })).toBe("timeout");
   });
 
+  it("classifies files that exceed the preview budget", () => {
+    expect(classifyMediaLoadError("file too large for in-app pdf preview")).toBe(
+      "too_large",
+    );
+    expect(classifyMediaLoadError({ status: 413 })).toBe("too_large");
+    expect(classifyMediaLoadError({ code: "payload_too_large" })).toBe(
+      "too_large",
+    );
+  });
+
   it("classifies unsupported type", () => {
     expect(classifyMediaLoadError("unsupported")).toBe("unsupported_type");
     expect(classifyMediaLoadError("format has no in-app preview")).toBe(
@@ -177,6 +187,7 @@ describe("mediaLoadErrorMessageKey / resolve", () => {
       "media.err.brokenBlob",
     );
     expect(mediaLoadErrorMessageKey("timeout")).toBe("media.err.timeout");
+    expect(mediaLoadErrorMessageKey("too_large")).toBe("media.err.tooLarge");
     expect(mediaLoadErrorMessageKey("unsupported_type")).toBe(
       "media.err.unsupportedType",
     );

--- a/src/lib/mediaLoadPro.ts
+++ b/src/lib/mediaLoadPro.ts
@@ -18,6 +18,7 @@ export type MediaLoadErrorKind =
   | "host_only"
   | "broken_blob"
   | "timeout"
+  | "too_large"
   | "unsupported_type"
   | "media_server_unavailable"
   | "other";
@@ -163,6 +164,13 @@ export function classifyMediaLoadError(err: unknown): MediaLoadErrorKind {
     return "timeout";
   }
   if (
+    code === "too_large" ||
+    code === "file_too_large" ||
+    code === "payload_too_large"
+  ) {
+    return "too_large";
+  }
+  if (
     code === "unsupported_type" ||
     code === "unsupported-type" ||
     code === "unsupported" ||
@@ -189,6 +197,7 @@ export function classifyMediaLoadError(err: unknown): MediaLoadErrorKind {
   if (status === 404) return "missing_path";
   if (status === 403 || status === 401) return "untrusted";
   if (status === 408 || status === 504) return "timeout";
+  if (status === 413) return "too_large";
   if (status === 415) return "unsupported_type";
   if (status === 502 || status === 503 || status === 0) {
     return "media_server_unavailable";
@@ -200,6 +209,9 @@ export function classifyMediaLoadError(err: unknown): MediaLoadErrorKind {
   // HTMLMediaElement / FileMediaPlayer short codes
   if (s === "timeout" || s.includes("timed out") || s.includes("timeout")) {
     return "timeout";
+  }
+  if (s.includes("too large") || s.includes("payload too large")) {
+    return "too_large";
   }
   if (
     s === "unsupported" ||
@@ -409,6 +421,8 @@ export function mediaLoadErrorMessageKey(kind: MediaLoadErrorKind): string {
       return "media.err.brokenBlob";
     case "timeout":
       return "media.err.timeout";
+    case "too_large":
+      return "media.err.tooLarge";
     case "unsupported_type":
       return "media.err.unsupportedType";
     case "media_server_unavailable":
@@ -541,6 +555,7 @@ export const MEDIA_LOAD_ERROR_KINDS: readonly MediaLoadErrorKind[] = [
   "host_only",
   "broken_blob",
   "timeout",
+  "too_large",
   "unsupported_type",
   "media_server_unavailable",
   "other",


### PR DESCRIPTION
## Summary

- Enforce a 40 MiB in-app preview budget for Office documents and PDFs in both the host and frontend.
- Validate initial and subsequent `Content-Range` and `Content-Length` headers before consuming range bodies.
- Assemble range responses into one bounded output buffer instead of retaining every chunk and allocating a second full copy.
- Abort in-flight document downloads when the preview changes or unmounts.
- Show a localized "file too large" error while preserving external-open options.

## Why

Office and PDF renderers require the complete file as an `ArrayBuffer`.

The previous range reassembly retained every 2 MiB chunk and then allocated another full-size buffer to combine them. Its only upper bound was 10,000 chunks, allowing approximately 19.5 GiB to be downloaded and reconstructed.

The existing Office limit was also ineffective because over-limit results still returned `stream: true`, and the frontend ignored the host error whenever an absolute path was present. PDFs had no equivalent host-side limit.

Rapidly switching files could additionally leave multiple reconstructions running because cancellation only prevented React state updates; it did not abort the underlying fetches.

## Implementation notes

- Video and audio remain range-streamed and are not subject to the rich-document reconstruction limit.
- The frontend independently enforces the budget so it does not rely solely on host metadata.
- Every returned range must match the requested start, end, total, and expected body length.
- The initial response must respect the media server's 2 MiB range window before its body is consumed.

## Testing

- Added frontend regression coverage for oversized totals, oversized initial ranges, invalid `Content-Range` responses, and request cancellation.
- Added host coverage for the 40 MiB Office/PDF preview limits.
