### PR TITLE
fix(session): stabilize send/stream/permission core path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- **Agent turn finish no longer drops the last stream batch**: Process crash / RPC fail now flushes the coalesced `session://stream` buffer and journal tail before clearing the live slot (answers no longer stop mid-sentence).
+- **Early `prompt_complete` no longer discards a silent long tool**: Host keeps the turn deferred while tools are still open instead of force-clearing them after 3s and treating later chunks as load-replay.
+- **Shared-process prompt complete is per session**: `last_update` and waiter matching no longer let chat B's stream finish or extend chat A's turn.
+- **Stop / stall during Host vision no longer marks a scheduled task as run**: `send_message` returns `TURN_CANCELLED` when the turn was cleared before `session/prompt`; automations do not advance `next_run_at`.
+- **YOLO / effort / proxy mid-turn actually apply after the turn**: Busy `soft_respawn` is queued; parked agents with stale `--reasoning-effort` / permission flags are dropped so the next connect cold-spawns. Fixes Grok 4.6 Extra High not taking effect (#598) and UI “Ask” while the CLI still has `--always-approve`.
+- **Allow for session on write/edit tools no longer cancels the turn (#600)**: When the CLI list has no session-scoped option, Host answers with `allow-once` (and still caches session scope) instead of inventing `always-allow`.
+- **Stop cancels pending tool permission** (not only ask/plan), so reconnect is not stuck on an unanswered `request_permission`.
+- **Media path grant is file-exact**: `paths_classify` / `grant_path` no longer authorize the parent directory (no sibling read of e.g. `~/.ssh`).
+- **Composer draft is kept until send succeeds**; send targets the viewing chat, not a stale shell session id.
+- **Changing proxy settings respawns warm agents** so the new `HTTP_PROXY` is picked up.
+- **Background turns honor provider `RetryState`**: switching away no longer leaves a hung chat until the CLI idle/absolute timeout; Host applies the same abort + `NETWORK_PROVIDER` path as the focused session.
+- **cwd-relative downloads (`curl -O` / `wget` without `-o`) prompt** unless YOLO — no longer assumed to write inside the project.
+
+**中文 · 修复**
+- **回合结束不再丢掉最后一批流式字**：进程崩溃 / RPC 失败会先刷出合批缓冲和 journal 尾巴。
+- **提前 `prompt_complete` 不再丢掉仍在跑的静默工具**：不再 3 秒后强清 open tools，后续 chunk 也不会被当成 load-replay 丢掉。
+- **共享进程的收尾按会话隔离**：A 的回合不会被 B 的流续命或提前结束。
+- **Stop / 准备阶段取消不再把定时任务标成已跑**：未真正派发 `session/prompt` 时返回 `TURN_CANCELLED`。
+- **回合中改 YOLO / 推理强度 / 代理会在本轮结束后重生进程**：修好 Grok 4.6 极高不生效（#598）以及 UI 已是「询问」但 CLI 仍 `--always-approve`。
+- **写文件等工具点「会话内允许」不再整轮取消（#600）**：没有 session 档 option 时用列表里的 `allow-once` 作答。
+- **Stop 会取消未答复的工具权限**，避免重连卡在 `request_permission`。
+- **媒体路径只授权该文件本身**，不再授权父目录。
+- **发送失败前不丢草稿**；发送目标跟当前查看的会话，而不是过期的 shell id。
+- **改代理设置会回收 warm 进程**。
+- **后台回合也认 provider RetryState**：切走后不再空转到 CLI 超时，和前台一样熔断并记 `NETWORK_PROVIDER`。
+- **不带 `-o` 的下载默认要批准**（YOLO 除外）。
+
 ## [0.2.16] - 2026-08-13
 
 > **Highlight:** Official default is Grok 4.6 with Extra High (`xhigh`); Changes / Remote IM / Voice / workbench honesty remediations; Amux/Yun effort ids match official `low`/`medium`/`high`/`xhigh`.

--- a/docs/llm-wiki/catalog.md
+++ b/docs/llm-wiki/catalog.md
@@ -175,7 +175,9 @@ grok --no-auto-update --permission-mode <mode> agent [--model <id>] [--reasoning
 
 **Independent 模式**：写入 `~/.grok-app/agent-home/config.toml` 与 `agent-home/.claude/settings.json`，agent 进程侧真正按策略执行；与 CLI `~/.grok` 隔离。
 
-中途改权限：同步配置 + soft-respawn（含 YOLO 降级）。Host 在收到 `session/request_permission` 时仍按 live policy 自动放行/拒绝。
+中途改权限：同步配置 + soft-respawn（含 YOLO 降级）。**回合进行中**不会立刻杀进程（CLI 仍带 spawn 时的 `--always-approve`）；Host 记下待 respawn，本轮结束后或下次 connect 时再重生。Host 在收到 `session/request_permission` 时仍按 live policy 自动放行/拒绝。
+
+**会话内允许（permission bar）**：按钮始终展示。write / image 的 CLI 档是 `allow-always`（不是反序的 `always-allow`）；空列表时 Host 按工具族回退。若列表里**没有** session 档，wire 用已发布的 `allow-once`（Host 仍缓存 scope）。发送列表里没有的 id 会被 CLI 当成 `unknown permission option` 并取消回合。
 
 注意：读工具与部分只读 shell 在 agent 内建白名单下仍可能不弹窗（Grok Build 设计）。
 

--- a/docs/plans/2026-08-13-agent-core-interaction-audit.md
+++ b/docs/plans/2026-08-13-agent-core-interaction-audit.md
@@ -1,0 +1,254 @@
+# Agent 核心交互链路稳定性排查（发送 · 流式 · 路径解析 · 任务 · 会话隔离）
+
+> 日期：2026-08-13 · 范围：从「聊天输入框 → 流式输出 → 路径解析 → 任务处理 → 会话隔离」这条与 Grok Build CLI（ACP over stdio）交互的核心链路出发，围绕**权限 / 网络 / 授权 / 进程生命周期**这些「小毛病」体验问题做的一次全量代码级排查。
+>
+> **整改（同日）**：P0-1～P0-6 与 #600 / #598 以及一批高信号 P1 已落地，见下方「已落地」。剩余 P1/P2 仍是诊断项。
+>
+> 方法：五条链路并行深读源码 + 全量测试模拟（前端 `pnpm test` 5414 passed / 后端 `cargo test` 1169 passed）。所有 P0 与关键 P1 已回到 HEAD 代码逐条人工复核。下文「已落地」为同日整改记录。
+>
+> 严重度口径：**P0** = 数据丢失 / 访问控制 / 核心功能静默失效；**P1** = 明显错误 UX / 长时间卡死 / 静默误配；**P2** = 边缘、诊断、次要体验。
+
+## 自动化基线（本次实跑）
+
+| 套件 | 结果 | 备注 |
+| --- | --- | --- |
+| `pnpm test`（vitest） | **5414 passed / 6 skipped**，2 个套件加载失败 | 失败仅因本机缺 `canvas.node` 原生模块（`sessionExportImage.*`），非代码问题 |
+| `cargo test`（全量并行） | **1169 passed / 1 failed / 1 ignored** | 唯一失败 `media_server::tests::missing_file_is_404_not_403` 是**测试并行竞态**（见附录 T1），单独重跑 + 整个 `media_server` 模块单跑均通过 |
+
+> 结论：仓库当前是绿的。下述问题都是**逻辑 / 竞态 / 边界**层面的隐患，测试覆盖不到或本就是「按当前设计通过」的坑。
+
+---
+
+## 架构速览（便于对照）
+
+**发送链路（composer → CLI）**
+1. UI `send()` → `executeSend`（`AppWorkbench.tsx`）：先乐观渲染 user 气泡 + 空 streaming assistant，置 `sendInFlight` / `sendEpoch`。
+2. `ensureConnected` → Tauri `session_connect`（在 Host `connect_lock` 下 park/unpark/冷启动）。
+3. `sessionSend` → Rust `SessionManager::send_message`（`session_manager/turn.rs`）。
+4. `connect_lock` 内：`ensure_promptable_session`（live / background 原地 / parked→bg|focus），开 turn（置 `prompt_in_flight`、FSM Streaming），**先**写 user journal 行。
+5. 可选 Host vision / `prepare_agent_prompt`（**仍持锁**），再 `tokio::spawn(acp.prompt_for)`。
+6. ACP stdio `session/prompt` 等待：空闲 600s / 绝对 4h；早到的 `_x.ai/session/prompt_complete` + 3s 静默兜底。
+7. 流 / 工具事件 → live 或 background；收尾靠 PromptComplete / #522 RPC-Ok heal / stall 看门狗。
+8. 前端队列 Ready 时自动 flush；ghost heal 在 Host 从未进入 mid-turn 时（~45s）清掉纯乐观「Thinking…」。
+
+**流式链路**：`AcpClient` 解 `session/update` → `handle_acp_event`（live/bg/drop）→ 追加 `stream_buf`、节流写 `messages.json`、合批进 `pending_stream_emit`（~40ms/600 字）→ `session://stream` IPC。前端 `StreamCoalescer`（~60–104ms）→ `sessionTranscriptStore` → 虚拟列表 + stick-to-bottom；journal reconcile / rehydrate 补截断尾巴。
+
+**权限门**：CLI 反向 RPC `session/request_permission`（及 `exit_plan_mode` / `ask_user_question`）→ Host 建 `scope_key` 跑 `may_auto_allow/deny` → 自动放行或存**单个** pending gate 并 emit `session://permission` → UI 按 sessionId parking，仅 viewing 时显示 → 用户操作 `session_resolve_permission/_plan/_ask_user` → 写回**该会话自己的** ACP 子进程 → 清 pending。进程死亡 / recycle → `session://permissions_invalidated`。
+
+**进程/网络**：`AcpClient::spawn_with_home` 起 `grok … agent … stdio`；`GROK_HOME` = 共享 `~/.grok` 或独立 `~/.grok-app/agent-home`（自定义路由强制独立）。`proxy::apply_to_tokio_command` 注入 `HTTP(S)_PROXY`/`ALL_PROXY`/`NO_PROXY`。子进程 `kill_on_drop(true)`，stderr ring。live/background/parked 池（默认 8，30 分钟空闲回收）。
+
+**路径解析 + 媒体**：前端扫描助手/工具文本（`attachments.ts` / `pathNormalize.ts` / `sessionPathMap.ts`）→ Host `paths_classify` / `fs_resolve_path` 解析确认 → loopback axum `127.0.0.1:0`（`media_server.rs`，per-process token + `path_scope` 白名单）投递；`media://` 仅冷启动兜底。
+
+**会话隔离**：每个 App 会话一份 UI journal（`{app_data}/sessions/<id>/`）+ 可选 CLI agent id（`{GROK_HOME}/sessions/<encoded-cwd>/<agentSessionId>/`）；Host 一进程一会话（live/background/parked），ACP 事件按 `process_id` + stamped `agentSessionId` 路由；前端 `messagesOwnerSessionId` / `viewFocus` epoch / `openSessionGen` 三道防跨聊天污染。
+
+---
+
+## P0 —— 数据丢失 / 访问控制 / 核心功能静默失效
+
+### P0-1　进程崩溃 / 退出时丢弃流合批缓冲 → 回答被截断
+- **位置**：`src-tauri/src/session_manager/events.rs:853-895`（live `ProcessExited`）、`events_bg.rs:525-558`（background）。对照正确做法 `stream.rs:290-297`（`flush_pending_stream_emit_done`）、`stream.rs:352`、`stream.rs:572`。
+- **触发**：agent/CLI 在流式中途崩溃或被杀（网络导致 fatal、OOM、被回收）。
+- **根因**：`ProcessExited` 分支清了 tools、`prompt_in_flight`、`deferred_prompt_complete`、`streaming_message_id`，但**从不调用 `flush_pending_stream_emit_done`**。最后 ~40ms / 600 字仍在 `pending_stream_emit` 里，被直接丢弃。`force_end` / deferred finish 都会 flush，唯独 exit 路径不 flush。
+- **症状**：气泡停在半句；重开会话可能因 journal 节流也没落盘而同样截断。
+- **确认**：已 grep 全部 `flush_pending_stream_emit*` 调用点，两个 `ProcessExited` 分支确实没有。
+
+### P0-2　`connect_lock` 全程覆盖 Host vision/prepare，且「turn 已失效」时 Host 返回 Ok 而不发 prompt → 前端假流式 + 任务被误判「已执行」
+- **位置**：`turn.rs:306-337`（prepare 后 `still_this_turn` 检查，任一不满足即 `return Ok(snapshot)` 而**不发 `session/prompt`**）；前端 `AppWorkbench.tsx:7837-7861`（不读返回 state，直接投 `streaming`）。
+- **触发**：发送带 Host vision / 长 prepare 的一轮；用户在 prepare 期间按 Stop（或 stall 清了这轮）。
+- **根因**：user journal 行与 turn 开启发生在 prepare **之前**（`turn.rs:152-164`）。取消清了 `prompt_in_flight` / turn id；prepare 回来后 `still_this_turn=false`，Host 返回 **Ok** 但没派发 prompt。前端从不读这个返回值，仍把 liveMap 置 streaming。ghost heal 可能 45s 后清掉 UI，但**磁盘已留下孤儿 user 行**。
+- **连锁到任务（真正的 P0）**：`automation_runner.rs:409-420` 把任意 `send_message` Ok 当作「已触发」，随即 `mark_automation_run` 推进 `next_run_at` / once 任务置 disabled。→ **定时任务其实没跑，却被标记为已跑并推进/关闭**。
+- **确认**：`turn.rs:310-337` 的 skip-prompt-return-Ok 分支属实；`automation_runner.rs:410` 只 `map_err`，Ok 即视为成功。
+
+### P0-3　早到 `prompt_complete` 后强清 open tools → 后续真实 chunk 被当 load-replay 丢弃
+- **位置**：`stream.rs:304-348`（`try_finish_deferred_prompt_complete`，`#453` 强清 `open_tool_ids`）；replay gate `stream.rs:116-133`、`events.rs:138-147`；兜底计时 `acp_client.rs:1995-2011`。
+- **触发**：agent 先发 `prompt_complete`，然后跑一个**长时间静默**的工具（无 `session/update`）。
+- **根因**：兜底在 agent 静默 **3s** 后释放 RPC（心跳**不**刷新 `last_update_at`）；此时 `prompt_in_flight=false`，`try_finish_deferred_prompt_complete` 会**清空所有 `open_tool_ids`** 并收尾。之后真正到达的 chunk 命中 `is_session_load_replay(true)` 被丢；background 路径甚至 warn「lost chunk」。
+- **症状**：回答截断 / 卡「思考中」直到 reconcile 或切会话；`#522` 同类。
+- **确认**：`stream.rs:334-344` 的强清逻辑与 warn 属实；replay gate 只看 `!prompt_in_flight`。
+
+### P0-4　进程级共享 `last_update_at` + 宽松 `pending_prompt_matches` → 多会话串扰（早收尾 / 迟收尾 / 卡死）
+- **位置**：`acp_client.rs:288`（单个 `last_update_at`）、`1987-2038`、`2491-2530`；匹配 `2035-2038`（`(Some(_), None) => true`、`(None, _) => true`）。
+- **触发**：共享进程多会话（warm 复用同一 CLI）；或事件缺 `sessionId`。
+- **根因**：一个 `AcpClient`（一进程）只有一个 `last_update_at`，兜底 grace 与 prompt 空闲超时都用它。会话 A 的早 `prompt_complete` 会被 B 的持续流一直续命；A 的空闲超时被 B 的更新扭曲。缺 sid 的 `prompt_complete` 可能完成**另一个** waiter。
+- **症状**：多聊天并发时回答被提前截断、或迟迟不收尾、或卡 busy。
+
+### P0-5　YOLO / `--always-approve` 关不掉：mid-turn 切「询问」后旧进程仍放行
+- **位置**：`control.rs:36-50`（`soft_respawn` 在 `live_session_is_busy` 时直接 `return` 不杀）、`control.rs:386-401`（`apply_permission_policy` 立即改 `s.policy` 再 soft_respawn）；spawn flag 在 `acp_client.rs:1447-1448`。
+- **触发**：一轮流式进行中，用户把权限从 YOLO 切到「询问」。
+- **根因**：`s.policy` 立刻更新，但 `soft_respawn` 因 busy 跳过，不杀进程；CLI 仍带 spawn 时的 `--always-approve` / `bypassPermissions`。Host 策略与 CLI flag **发散**，直到某次成功 respawn。catalog 文档声称 mid-turn 变更会 soft-respawn（含 YOLO 降级），实际被 busy 短路。
+- **症状**：UI 显示「询问」，工具却继续无提示执行到本轮结束，信任被打破。
+- **确认**：两处代码属实；`live_session_is_busy` 覆盖 Streaming 即会跳过。
+
+### P0-6　`paths_classify` / `fs_resolve_path` 对任意存在路径授权（且授的是父目录）→ 本地任意读放大
+- **位置**：`commands/fs.rs:492-494`（`if exists { grant_path(pb) }`，**无**项目/白名单校验）；`path_scope.rs:74-94`（`grant_path` 对文件授的是**父目录**）；`fs_browser.rs:780-787, 945-974`（`fs_resolve_path`/`open_path_smart` 同样存在即 grant）。历史加载入口 `AppWorkbench.tsx:4514-4519`。
+- **触发**：打开一个 journal attachments 含 `~/.ssh/id_rsa`（或任意桌面路径）的会话 → 历史加载调 `pathsClassify` → 之后 loopback 媒体服务器可服务该**父目录下的兄弟文件**。
+- **根因**：与结构化 attach 的 `prepare_media_attachment_path`（有白名单）不同，classify/resolve 路径只判「存在」就 `grant_path`，而 `grant_path` 授父目录。
+- **威胁模型**：需要拿到 media token（`?t=`）或主 webview XSS；属于「本地任意读放大」，非远程直接可利。
+- **确认**：`fs.rs:492-494` 与 `path_scope.rs:76-83`（file → parent）均属实。
+
+---
+
+## P1 —— 明显错误 UX / 长时间卡死 / 静默误配
+
+### 发送 / 连接 / 队列
+
+| 编号 | 位置 | 症状 & 根因 |
+| --- | --- | --- |
+| P1-1 | `AppWorkbench.tsx:8038`、`21544`（`send()` / voice 恒传 `targetSessionId: session.sessionId`） | **跨聊天误投**。`executeSend` 只有在 `targetSessionId === undefined` 时才用 `resolveComposerSendSessionId`（`viewFocus.ts:66-74` 优先 viewing 修复 openSession 竞态）。而 `send()` 总是显式传 shell id，把这道修复短路了。切到 B 但 shell 还指 A 时发送 → 落到 A。**注**：`executeSend` 内部又用 `resolveComposerSendSessionId` 兜了一层，实际误投窗口比标题窄，但显式传 shell id 与修复初衷相悖。 |
+| P1-2 | `turn.rs:152-164`（append 在 prepare 前）；回滚仅在缺 ACP 时清 flag（`405-416`） | **孤儿 user 气泡**：prompt 从未派发（P0-2）时 journal 已写。重载后多出用户气泡；ghost heal 又把文本还原到 composer → 二次发送**重复 user 轮**。 |
+| P1-3 | `AppWorkbench.tsx:8029-8038`（`clearComposerAfterSubmit` 先于 `executeSend`）；失败仅 `failStrip`（`7891-7895`） | **发送失败后草稿丢失且不回填**。乐观清空无条件发生，失败路径不像 ghost heal 那样把文本放回，用户得重打。 |
+| P1-4 | `AppWorkbench.tsx:7614-7615`；`useSendQueue.ts:233,302` | **进程级 `sendInFlightRef` 挡住并发发送**。A 的 `ensureConnected`/send 很慢时，B 的 Send / 队列 flush 直接 no-op（`return false`），与 Host 多会话 demote+spawn 的设计矛盾。 |
+| P1-5 | `useSendQueue.ts:264-270`（`setHold(true)`）、`289-297`（仅 streaming/permission 清） | **队列 flush 失败后 hold 永久粘住**。连接失败 → toast → 会话回到 Ready → 自动 flush 再也不重试，直到手动 resume。 |
+| P1-6 | `AppWorkbench.tsx:7368-7384` | **`ensureConnected` 等别的连接可丢发送**。A 连接在飞，B 的发送等待；若 120s 后 A 仍在连 → 返回 `null` → `failStrip`。外部连接饿死本目标。 |
+| P1-7 | `turn.rs:56-58` `_focus_guard` 持到 `~565` | **`connect_lock` 覆盖整个 vision/prepare**。一个会话 prepare 几分钟，其它会话的 connect/send 全被串行阻塞，UI 看着像卡死。 |
+| P1-8 | `AppWorkbench.tsx:7837-7850`；`session.ts:1878-1889`（`isSessionNotLiveError` 字符串分类） | **CONNECT_FAILED 重试可能重复派发**。首个 `session_send` 已开 turn / 写 journal，随后 IPC/错误被分类为「无 live agent」→ 强连 + 第二次 `sessionSend`。重试假设首调是纯拒绝，但 Host 可能已持久化。 |
+
+### 流式 / 收尾
+
+| 编号 | 位置 | 症状 & 根因 |
+| --- | --- | --- |
+| P1-9 | `process.rs:213-228`（`release_failed_turn_markers` 置 `pending_stream_emit=None` 无 flush） | provider/RPC 失败时最后几个 token 丢失（P0-1 同类，失败路径版）。 |
+| P1-10 | `useSessionHostEvents.ts:778-785`（`chunk.done` 立即投 `state:"ready"`） | **前端 done 抢先置 Ready**，而 Host 可能仍在 deferred complete + open tools（FSM Streaming）。侧栏显示空闲/未读、stall 横幅被清、尾 token 门控异常。 |
+| P1-11 | `streamLateToken.ts:25-63`；`useSessionHostEvents.ts:734-748` | **`shouldApplyLateStreamText` 可能丢真实尾段**：聚焦 host 且 assistant 已有非空 body 且 `streaming:false` → return false，被 settle 的 partial body 挡住结尾。且用的是 `messagesBySessionRef`，可能与已绘制 store 短暂不一致。 |
+| P1-12 | `useSessionHostEvents.ts:472-516`；`sessionTranscriptStore.ts:167-186` | **空 streaming 壳残留**：Ready 时先 flush coalescer 再清 streaming；漏 `done` / 后台转前台 / content 节流可留下空壳。ghost heal 只清**空**壳（45s + Host idle），不管 partial 粘滞流。 |
+| P1-13 | `cli_sessions.rs:1280-1309, 1548-1574`；FE `upgradeMessagesFromJournal:2276-2340` | **journal reconcile 重复气泡**：cover 用 exact/contains/prefix，空白或 thought-vs-body 分裂不匹配 → `Missing` → 新 UUID 行。前端 upgrade 按长度/id 补但不总能合并多余行。post-turn 0/125/375/750ms 重试可与新发送竞争。 |
+| P1-14 | `stream.rs:90-108`（`resolve_turn_event_route`）；`events.rs:107-114` | **≥2 个 busy background 且事件缺 sid → Drop**：`busy_bg` 多匹配返回 `TurnEventRoute::Drop`，无缓冲无重试，静默丢 chunk/tool（依赖 CLI 是否 stamp sid）。 |
+
+### 权限 / 授权 / 账号
+
+| 编号 | 位置 | 症状 & 根因 |
+| --- | --- | --- |
+| P1-15 | `turn.rs:769-868`（stop 只 `take()` ask/plan）；`AppWorkbench.tsx:12220-12226` | **Stop 取消 ask/plan 反向 RPC，但不取消 permission**。UI 清了横幅，agent 可能仍坐在未答的 `request_permission` 上；下次 reconnect/send 看着卡或报困惑的 cancel/auth 错误。 |
+| P1-16 | `process.rs:213-227`、`live_session_is_busy:173-175`、`stream.rs:614-616`、`watchdog.rs:85-87` | **失败/heal/busy 判定漏了 pending permission**：多处只看 FSM 或 plan/ask id，与 recycle invalidation（**含** permission）不一致 → Approve 可能残留 / soft-respawn 在 permission RPC 仍开时推进。 |
+| P1-17 | `events.rs:393-397`；`events_bg.rs:262-267`；`types.rs:200-207` | **单 pending-permission 槽被覆盖**：一次只存一个 `pending_permission_rpc_id`。两个工具接近同时请求批准 → 第一个 Approve 消失，或答了一个另一个永远挂着。 |
+| P1-18 | `control.rs:601-685`（用 client `rpc_id` 应答，匹配才清） | **`resolve_permission` 写 stdin 前不校验 `rpc_id == pending`**：陈旧/幽灵 Approve（recycle 竞态、双击、错 map）可用任意 id 写进活进程 → CLI「unknown」/取消轮/放行错工具。plan/ask 至少 peek 了 pending id。 |
+| P1-19 | `control.rs:386-398`（只改 `inner` live）；bg 用 `s.policy`（`events_bg.rs:189`） | **策略变更只作用于 live 焦点会话**：改全局/会话权限时另一个后台会话仍用旧 auto-allow/deny（含 YOLO），直到其进程死亡。 |
+| P1-20 | `agent_prefs.rs:54-65`（仅独立模式写）；`catalog.md:174-178` | **共享模式 YOLO 泄漏**：App 显示「询问」但 `~/.grok` 里 `yolo=true` / `permission_mode=always-approve` 时，CLI 仍读共享 config，提示比 UI 暗示的少。文档已记，仍是产品陷阱。 |
+| P1-21 | `acp_client.rs:2635-2673`（`cached_token` 失败后软继续）；`classify_rpc_error:4957-4979` | **authenticate 软失败 → mid-turn AUTH_FAILED**：连接看着 OK，第一个工具调用才报 auth_kind=none。`read_auth_profile` 可能仍显示已登录（读 `~/.grok`）。握手不 fail-closed，靠后续 RPC 分类 + 登录后 recycle。 |
+| P1-22 | `permission.rs:413-434`（`dests.is_empty() → true`） | **下载空目标即 auto-allow 假设 cwd=项目**：`wget`/`curl -O`（无 `-o`）在 agent cwd ≠ 项目根时也被自动批准，非 YOLO 也会写到项目外且无提示。 |
+| P1-23 | `AppWorkbench.tsx:14339-14375`；`AskUserModal.tsx:114+`；`gateClock.ts` | **auto-deny/ask-user 超时只在横幅/弹窗挂载时走**：开了「30s 后自动拒绝」，切走到后台权限 toast → 计时不启动，请求不会自动拒绝直到重开，轮次可能挂到 CLI 超时。计时是 React effect 而非 Host 侧截止时间。 |
+
+### 网络 / 进程生命周期
+
+| 编号 | 位置 | 症状 & 根因 |
+| --- | --- | --- |
+| P1-24 | `events_bg.rs:751-754`（`_ =>` 忽略 stderr/retry/other）；对照 live `events.rs:989-1074` | **后台轮忽略 `RetryState`，无 Host 熔断**：切走后中转/DNS 挂了，后台会话没有 abort + `NETWORK_PROVIDER`，会一直「运行」到 CLI 耗尽重试 / 空闲超时（~10 分钟空闲 / 4h 绝对）。后台降级很常见。 |
+| P1-25 | `relay_stream_proxy.rs:448-464`（`Err(e) => break;` 无错误帧） | **中转 sanitize 代理吞掉流中途上游错误**：mid-SSE 连接重置/DNS 抖动时，非流路径返回 502 JSON，流路径只是关流。CLI 收不到结构化失败 → 挂「思考中」或诡异 fatal。 |
+| P1-26 | `events.rs:853-885`（`fsm.crash("Agent process exited")`）；`acp_client.rs:1674-1679`（EOF `code:None`） | **CLI 崩溃统一显示「Agent process exited」而非网络**：退出码从不 `wait`，ProcessExited 忽略 stderr 分类。即便 stderr 是 502/reset，用户也只看到崩溃/`agent_exit` chip。 |
+| P1-27 | `commands/settings.rs:199-284`（soft_respawn 触发条件**不含** `proxy_*`）；spawn 注入 `acp_client.rs:1484-1486` | **改代理设置不回收 warm 进程**：改完 Manual proxy / System→None，warm live/parked CLI 仍带旧 `HTTP_PROXY`，轮次持续失败直到回收/空闲杀。**已确认**：`settings.rs` 的 `need_soft_respawn` 列表里没有任何 proxy 字段。 |
+| P1-28 | `proxy.rs:465-472`（坏 manual → Inherit）、`497-506`（PAC 未解析 → Inherit + warn） | **无效手动代理 / 未解析 PAC 静默回退直连**：设置看着「已配置」，流量绕过代理 → auth/timeout 失败但聊天里无代理提示。 |
+| P1-29 | `acp_client.rs:3361-3366`（`child.kill()` 非进程组）；对照 `leader.rs:664-695` / `serve.rs:387-400` | **`AcpClient::kill` 不是进程组杀**：嵌套 `agent`/工具在 Host kill 后存活 → 孤儿进程、卡端口、池计数与现实不符。leader/serve 用 setsid/taskkill 树。 |
+| P1-30 | `leader.rs:647-662`（只设 PATH/HOME，无 proxy 注入） | **leader spawn 跳过代理注入**：`use_leader` 且在公司代理后，leader 连不上网，挂载的 agents 看着「坏了」。 |
+| P1-31 | `acp_client.rs:1602-1607`（`std::net::TcpStream::connect` 无超时） | **阻塞式 TCP ACP 连接跑在 Tokio worker 上**：坏 `acp_server_addr` / 黑洞主机会在连接期卡住一个运行时 worker。其它探测都用了 `timeout`。 |
+| P1-32 | `official_aux.rs:270-283`；`models_aux.rs:900-914`（`cmd.output()` 后事后判 `elapsed > timeout` 只 warn） | **headless official/aux「超时」不杀挂死 CLI**：vision/search 侧信道网络挂起时 Host 线程阻塞到进程退出，超时只记日志（ACP 路径有真正的 `tokio::time::timeout`）。 |
+| P1-33 | `relay_stream_proxy.rs:162-195`（`LISTEN_PORT` 只设一次，serve 错误只 log） | **sanitize 代理监听死亡是进程级永久故障**：loopback serve 挂了后，providers 仍指 `127.0.0.1:{port}/r/…` → 所有被 sanitize 的中转 502 直到重启 app。无健康检查/重启。 |
+| P1-34 | `acp_client.rs:5082-5138`；`providers.rs:885-907`（`max_retries` 抬到 12） | **硬传输 abort 关键词不全 → 长「思考」**：`timed out` / `proxy connect` / `socks handshake` 等措辞不在硬传输列表 → 等到软下限（~8/12）或 15。fail-fast 是子串匹配，中转乱造措辞；软 stall 从不自动取消。 |
+
+### 会话隔离
+
+| 编号 | 位置 | 症状 & 根因 |
+| --- | --- | --- |
+| P1-35 | `control.rs:256-370`（尤其 `310-313` vs `325-349`）；`commands/settings.rs:182-196` | **切换 GROK_HOME 只清 live 的 `agentSessionId`**：独立↔共享翻转时 recycle 杀进程，但 `sessions_index` 里 parked/background 会话仍指向旧 home 的 agent id → 重连 `session/load` 打到错的 home → 失败/新建/bootstrap，极端情况错误 resume。文档声称 data-root 变更会清 live id，实际只 `take()` live meta 到盘，parked/bg map 直接丢弃不清持久化 id。 |
+| P1-36 | `store.rs:1457-1523, 743-747`；`store_lock.rs:40-71` | **`sessions_index` RMW 非事务**：两个 App 实例（或 App + 快速 meta 更新）load-mutate-save，锁只包最终写字节（3s `LOCK_BUSY`）→ 经典 lost-update。JSON 损坏 → `read_json_recover` 隔离为空 `[]` → **侧栏会话消失**直到备份恢复。 |
+| P1-37 | `events.rs:716-721`；`events_bg.rs:408-413`；对照 `store.rs:1866-1877`（`append_message` 有锁 RMW） | **工具 journal upsert 与无锁 `save_messages` 竞争**：流 `append_message` 与工具 upsert（load→mutate→save）并发 → 同一聊天丢工具行或丢流刷新。upsert 路径不在 `with_exclusive_lock` 内跨 load+save。 |
+| P1-38 | `agent_home_config.rs:43-56`；`cli_sessions.rs:4-5` | **共享 GROK_HOME 下 App + 终端撞同一 agent 会话**：共享模式里终端 Grok Build 和 App 同时 resume 同一 `agentSessionId` → `chat_history` / ACP 状态互相竞争。UI journal 分开但 agent 上下文/工具会撞。跨进程无会话锁。 |
+| P1-39 | `paths.rs:156-198`；`cli_sessions.rs:175-181, 255-267` | **encoded-cwd 身份碰撞 / 大小写**：同一项目不同字符串形式（`/Users/Me` vs `/Users/me`）→ 不同 percent-encoded 目录；`normalize_cwd_path` 只为匹配 lowercase，不用于落盘编码 → 重复 CLI 会话树 / 错误「最新」选择。符号链接 cwd 同理。 |
+
+---
+
+## P2 —— 边缘 / 诊断 / 次要体验
+
+**流式渲染**
+- P2-1 `useChatMessageVirtualizer.ts` / `useStickToBottom.ts:194-320`：虚拟列表高度估算→实测校正与 stick-to-bottom 争抢，长 markdown / 媒体流式时滚动跳动。
+- P2-2 `stream_emit.rs:42-61` + `streamCoalesce.ts:62-80`：Host 保**首个** thought_phase、前端偏好**最新**，双层合批（40ms + 60–104ms）叠加延迟 →「思考 2/3」artifact、慢机首屏卡顿。
+- P2-3 `session.ts:2738-2750`：done+空文本显式**保留**空 streaming 壳（为 steer），无后续 token 时卡到 Ready/ghost heal。
+- P2-4 `sessionTranscriptStore.ts:162-186`：非结构增长用 leading+trailing 节流，末批可能非结构 → 文本短暂冻结再跳。
+
+**stall / 看门狗**
+- P2-5 `watchdog.rs:59-70,129-150`；`useSessionHostEvents.ts:1344-1352`：后台/未聚焦聊天软 stall 误判**漏报**——Host 发了但前端非 viewing 忽略，切过去要等下个软窗口（默认 600s）。
+- P2-6 `tool_heartbeat.rs:15-42`：>3h 开着的工具心跳停止 → 之后静默计入 stall → 软 stall **误报**。
+- P2-7 `watchdog.rs:80-83`：heal/stall 都要求 FSM==Streaming，早期路径 FSM 与 `prompt_in_flight`/前端 desync 时卡 busy 却无 stall UI。
+- P2-8 `watchdog.rs:180-233`：`HardEnded` 分支是**死代码**（tick 只返回 Healed/SoftStall），前端仍监听 → 维护性/虚假可靠性。
+
+**权限 / 账号（次要）**
+- P2-9 `events.rs:287-292` + `permission.rs:96-126`：shell「本会话允许」scope_key 在 `path_target` 空时用**标题**而非命令 → 缓存怪 key，下条相似命令不复用。
+- P2-10 `permission.rs:63-80`：`is_edit_tool` 用 `contains("edit"|"write"|"replace")` 子串 → AcceptEdits 下过度放行意外工具名。
+- P2-11 `turn.rs:606-678`：interject/steer 同样只取消 ask/plan，不取消 permission → 有开着的工具权限时 interject 看着接受了但轮次仍阻塞。
+- P2-12 `acp_client.rs:4930-4948` + `supergrok_quota.rs`：mid-turn 配额/计费错误靠字符串分类，Settings 配额组件可能仍显示 stale「unknown」。
+- P2-13 `remote_im/config.rs:187-199` → `grok_agent:1097`：Remote IM 的 `allow_remote_yolo` 是独立于 App chip 的开关，易误解为「App 权限模式」。
+- P2-14 前端权限/ask_user map 全在内存（`AppWorkbench.tsx:2214+`），仅 plan chrome 持久化 → **重启丢 mid-approval 门**，agent 可能仍等到超时。
+
+**路径 / 媒体（次要）**
+- P2-15 `path_scope.rs:23-64`：always-on roots 含 `temp_dir()` + `~/.grok` + agent home，远比「受信项目」宽。
+- P2-16 `media_protocol.rs:201-371`：legacy `media://` **无 token**，只查 Origin + path_scope，且缺 Origin 时放行。
+- P2-17 `media_server.rs:11-14,201-250` + `imageSrc.ts:125-132`：token 放在 `?t=` query，可能进 webview URL / 日志 / `lsof`；`tokens_equal` 只对等长做「近似」常量时间比较（`media_server.rs:475`，已确认存在）。
+- P2-18 `path_scope.rs:87-92`：grant 上限 256 FIFO 淘汰，长会话多附件后旧缩略图 403 直到重新 classify。
+- P2-19 `media_server.rs:333-344`：`Cache-Control: immutable` + 弱长度 ETag，同字节长原地替换后最多 7 天显示旧图。
+- P2-20 `media_server.rs:429-436` / `media_protocol.rs:496-506`：短读保留预分配 buf → 文件在 stat 与 read 间被截断/增长时 body 长度错 / 尾零 → 解码坏。
+- P2-21 `path_scope.rs:96-99`：`is_allowed` 用 `canonicalize().unwrap_or(path)`，符号链接替换 / 缺路径回退非规范字符串匹配存在 TOCTOU。
+- P2-22 `media_server.rs:100-118`：serve task 若在启动后死亡无 Host 侧重启，预览全断。
+- P2-23 `attachments.ts:242-460`：裸路径提取对含空格的 Windows 路径 / 非常见根 CJK 粘连 **漏识别**（false negative）。
+- P2-24 `sessionPathMap.ts:360-371`：同名（多个 `正文.md`）路径 last-touch 胜出，短引用可能打开非引用文件却「成功」。
+- P2-25 `commands/fs.rs` `paths_classify` 仍**不拒绝 `..`**（前端 `sidePathDeepLink.ts` 已折叠加固，Host 侧未做纵深防御）。
+- P2-26 `media_server.rs:505`：SVG 以 `image/svg+xml` 投递，白名单内恶意 SVG 在会执行 SVG 的上下文有风险（`<img>` 场景较低）。
+
+**会话隔离 / 进程（次要）**
+- P2-27 `cli_sessions.rs:107-114,244-250`：linked `agentSessionId` 用 HashMap first-wins，两会话共用一个 agent id 时只链到第一行。
+- P2-28 `paths.rs:201-214`：`find_agent_session_dir` 同 UUID 在两个 encoded-cwd 下时首个 `read_dir` 命中胜出，无 mtime 消歧。
+- P2-29 `pending_quit.rs:27-45`：`app.exit(0)` 3s 后强退不做 agent 拆解，靠 `kill_on_drop`，与嵌套子进程竞争。
+- P2-30 `agent_auto_wake.rs`：config-only，后台工作后的合成轮次可能看着像「卡死/复活」会话。
+- P2-31 `stream.rs:50-86` + `connect.rs:1033-1097`：parked co-tenant Drop 与 live connect 竞态；任何 sid mis-stamp → 静默 Drop（安全权衡，但路由正确性依赖 CLI stamp）。文档仍提到 `rescue_parked_to_background`，生产路由实际已不调用（仅定义+测试），**文档与代码不一致**。
+
+---
+
+## 已落地（2026-08-13 整改）
+
+| 条目 | 处理 |
+| --- | --- |
+| P0-1 / P1-9 | `ProcessExited` / `release_failed_turn_markers` 先 `flush_pending_stream_emit_done` + journal |
+| P0-2 / P1-2 | prepare 后 turn 已失效返回 `TURN_CANCELLED`（自动化不再误推进）；前端静默收尾、去掉空 assistant 壳 |
+| P0-3 | 不再强清仍年轻的 `open_tool_ids`；replay 门把 `deferred_prompt_complete` 当活回合 |
+| P0-4 | `last_update` 按 session 记账；`pending_prompt` 不再跨 sid 宽松匹配 |
+| P0-5 / #598 | busy `soft_respawn` 入队；effort/policy 改 parked/bg；unpark 校验 spawn flags |
+| P0-6 | `grant_path` 只授文件本身；`paths_classify` 不授目录 |
+| #600 | 无 session option 的工具用 `allow-once` 作答，Host 仍缓存 session allow |
+| P1-1 / P1-3 | send 不再硬传 shell id；成功后再清草稿 |
+| P1-15 / P1-16 / P1-18 | Stop 取消 permission；busy 含 pending permission；resolve 校验 rpc_id |
+| P1-19 | 后台会话同步 policy |
+| P1-22 | 无显式 `-o` 的下载不再默认放行 |
+| P1-24 | 后台轮处理 `RetryState` 并 Host 熔断 |
+| P1-27 | 代理设置变更触发 soft-respawn |
+
+未做（仍见后文）：P1-4/5/6/7 发送队列与 `connect_lock`、P1-10～14 前端合批、P1-17 单 permission 槽、P1-20/21/23 账号与超时时钟、P1-25～34 其余网络/进程、P1-35～39 会话隔离、全部 P2。
+
+## 高信号问题聚类（建议优先级）
+
+| 主题 | 相关条目 | 用户可见症状 | 建议顺序 |
+| --- | --- | --- | --- |
+| **收尾丢数据** | P0-1, P0-3, P0-4, P1-9 | 崩溃/长工具/多会话时回答被截断、卡「思考中」 | 1（最高，直接丢答案） |
+| **Stop/prepare 竞态 + 任务误判** | P0-2, P1-2, P1-3 | 假流式、孤儿气泡、**定时任务没跑却标记已跑** | 2（任务侧是数据/信任问题） |
+| **权限/YOLO 与 UI 发散** | P0-5, P1-15~P1-20, P1-22 | UI 说「询问」实际仍放行；Approve 幽灵/丢门 | 3（安全信任） |
+| **本地任意读放大** | P0-6, P2-15~P2-18 | 需 token/XSS 前提，但父目录 grant 面过宽 | 4（收窄 grant 到精确文件） |
+| **网络失败的可见性** | P1-24~P1-28, P1-33, P1-34 | 后台轮卡死、崩溃被误报为非网络、改代理不生效 | 5（体验「小毛病」重灾区） |
+| **多会话路由/发送** | P1-1, P1-4, P1-6, P1-7, P1-14, P0-4 | 跨聊天误投、并发发送被串行/丢弃 | 6 |
+| **会话隔离持久化** | P1-35~P1-39, P1-13 | 切 home 后错误 resume、index lost-update、重复气泡 | 7 |
+
+## 与既有计划的关系
+
+`docs/plans/2026-08-13-v0.2.16-review-fix-plan.md`（批次 H：Session core）已覆盖本文若干条的近亲：H4（`append_message` RMW，对应 P1-37 的同族）、H2（"permission denied" 误报）、H6/H7（gate/ask-user 时钟清理，对应 P1-16/P1-23）。**本文新增的、v0.2.16 计划里没有的核心项**：P0-1（exit 不 flush 流缓冲）、P0-2/P0-3/P0-4（收尾竞态三连）、P0-5（YOLO mid-turn 关不掉）、P0-6（classify 父目录 grant）、P1-24（后台轮忽略 retry）、P1-27（代理变更不回收）、P1-33（sanitize 代理死亡不可恢复）、P1-35（GROK_HOME 切换只清 live id）。
+
+## 附录
+
+### T1 —— `cargo test` 唯一失败是测试竞态，非产品 bug
+`media_server::tests::missing_file_is_404_not_403` 在全量并行跑时偶发返回 403（期望 404）。根因：`path_scope` 的 roots/grants 是进程级 `OnceLock<RwLock<…>>` 全局态（`path_scope.rs:13-21`），`media_server` 各测试用例并行修改同一全局，`grant_path` 的授权在断言前被其它用例的 `*roots().write() = Vec::new()` 之类操作影响。**证据**：单独 `cargo test --lib media_server::tests::missing_file_is_404_not_403` 通过，整模块 `cargo test --lib media_server` 也通过（9/9）。属测试隔离问题，不影响产品逻辑；若要根治可给这组测试串行化（如 `serial_test` 或共享 `Mutex`，路径同 `path_scope::tests` 里已有的 `TEST_LOCK` 模式）。
+
+### 复核记录（P0/关键 P1 已回读源码确认）
+- P0-1：grep 全部 `flush_pending_stream_emit*` 调用点，`events.rs:853-895` / `events_bg.rs:525-558` 的 `ProcessExited` 无 flush —— 属实。
+- P0-2：`turn.rs:310-337` skip-prompt-return-Ok；`automation_runner.rs:410` Ok 即成功 —— 属实。
+- P0-3：`stream.rs:334-344` `#453` 强清 open tools + warn；replay gate 只看 `!prompt_in_flight` —— 属实。
+- P0-4：`acp_client.rs:288` 单 `last_update_at`；`2035-2038` 宽松匹配 —— 属实。
+- P0-5：`control.rs:43-50` busy 时 `return`；`control.rs:386-401` 先改 policy 再 soft_respawn —— 属实。
+- P0-6：`fs.rs:492-494` exists 即 grant；`path_scope.rs:76-83` file→parent —— 属实。
+- P1-1：`AppWorkbench.tsx:8038`/`21544` 恒传 shell id；`executeSend:7626-7632` 仅 undefined 时用 resolve —— 属实（内部有二次兜底，窗口较窄）。
+- P1-27：`settings.rs:199-284` `need_soft_respawn` 列表无 proxy 字段 —— 属实。
+- P2-17：`media_server.rs:475` `tokens_equal` 仅等长近似常量时间 —— 属实。

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -247,14 +247,45 @@ fn prompt_wait_should_timeout(
 }
 
 /// Whether a pending prompt belongs to the fallback target session.
-/// A prompt without a recorded sid matches any target (legacy single-session);
-/// an explicit target only frees its own session's waiter (concurrent).
+///
+/// Only exact matches: both sides stamped with the same sid, or both unknown.
+/// Cross-matching `(Some, None)` used to let session A's early `prompt_complete`
+/// free session B's waiter on a shared process (P0-4). Unstamped / unique
+/// fallbacks go through [`pending_prompt_ids_for`].
 fn pending_prompt_matches(prompt_sid: Option<&str>, target: Option<&str>) -> bool {
     match (target, prompt_sid) {
         (Some(a), Some(b)) => a == b,
-        (None, _) => true,
-        (Some(_), None) => true,
+        (None, None) => true,
+        _ => false,
     }
+}
+
+/// Select `session/prompt` waiters for a `prompt_complete` fallback.
+///
+/// Prefer exact sid matches. Only when that set is empty and **exactly one**
+/// pending prompt exists, allow an unstamped/legacy pairing so single-session
+/// CLI traffic without `sessionId` still completes.
+fn pending_prompt_ids_for(pending: &HashMap<u64, Pending>, target: Option<&str>) -> Vec<u64> {
+    let prompts: Vec<(u64, Option<&str>)> = pending
+        .iter()
+        .filter(|(_, p)| p.method == "session/prompt")
+        .map(|(id, p)| (*id, p.session_id.as_deref()))
+        .collect();
+    let exact: Vec<u64> = prompts
+        .iter()
+        .filter(|(_, sid)| pending_prompt_matches(*sid, target))
+        .map(|(id, _)| *id)
+        .collect();
+    if !exact.is_empty() {
+        return exact;
+    }
+    if prompts.len() == 1 {
+        let (id, sid) = prompts[0];
+        if target.is_none() || sid.is_none() {
+            return vec![id];
+        }
+    }
+    Vec::new()
 }
 
 /// Pure decision for the `prompt_complete` fallback: release the waiter only
@@ -283,9 +314,11 @@ pub struct AcpClient {
     reader_alive: AtomicBool,
     /// Recent stderr lines for crash diagnostics (ring, newest last).
     stderr_tail: ParkingMutex<Vec<String>>,
-    /// Last inbound `session/update` — proof the agent is still producing turn
-    /// output. Re-arms the `prompt_complete` fallback window.
-    last_update_at: ParkingMutex<Option<Instant>>,
+    /// Last inbound `session/update` per agent session id (P0-4).
+    /// Stamped updates only extend that session's idle / prompt_complete grace.
+    last_update_by_session: ParkingMutex<HashMap<String, Instant>>,
+    /// Unstamped `session/update` (CLI omitted sessionId) — process-level only.
+    last_update_unstamped: ParkingMutex<Option<Instant>>,
     /// Official side-channel: skip App MCP inject on session/new.
     empty_mcp_servers: bool,
     /// Effective `--sandbox` profile at spawn (process-level gate for parked reuse).
@@ -1546,7 +1579,8 @@ impl AcpClient {
             stopped: AtomicBool::new(false),
             reader_alive: AtomicBool::new(true),
             stderr_tail: ParkingMutex::new(Vec::new()),
-            last_update_at: ParkingMutex::new(None),
+            last_update_by_session: ParkingMutex::new(HashMap::new()),
+            last_update_unstamped: ParkingMutex::new(None),
             empty_mcp_servers,
             sandbox_profile: ParkingMutex::new(sandbox.map(|sb| sb.profile.clone())),
             custom_route,
@@ -1629,7 +1663,8 @@ impl AcpClient {
             stopped: AtomicBool::new(false),
             reader_alive: AtomicBool::new(true),
             stderr_tail: ParkingMutex::new(Vec::new()),
-            last_update_at: ParkingMutex::new(None),
+            last_update_by_session: ParkingMutex::new(HashMap::new()),
+            last_update_unstamped: ParkingMutex::new(None),
             // TCP connect path keeps default MCP inject (not official side-channel).
             empty_mcp_servers: false,
             sandbox_profile: ParkingMutex::new(None),
@@ -1966,10 +2001,26 @@ impl AcpClient {
 
     /// Whether a `session/prompt` request is still awaiting its RPC result.
     fn has_pending_prompt_for(&self, session_id: Option<&str>) -> bool {
-        self.pending.lock().values().any(|p| {
-            p.method == "session/prompt"
-                && pending_prompt_matches(p.session_id.as_deref(), session_id)
-        })
+        !pending_prompt_ids_for(&self.pending.lock(), session_id).is_empty()
+    }
+
+    fn touch_last_update(&self, session_id: Option<&str>, at: Instant) {
+        if let Some(sid) = session_id.filter(|s| !s.is_empty()) {
+            self.last_update_by_session
+                .lock()
+                .insert(sid.to_string(), at);
+        } else {
+            *self.last_update_unstamped.lock() = Some(at);
+        }
+    }
+
+    fn last_update_for(&self, session_id: Option<&str>) -> Option<Instant> {
+        if let Some(sid) = session_id.filter(|s| !s.is_empty()) {
+            if let Some(t) = self.last_update_by_session.lock().get(sid).copied() {
+                return Some(t);
+            }
+        }
+        *self.last_update_unstamped.lock()
     }
 
     /// Release the `session/prompt` waiter only once the agent has actually gone
@@ -1999,7 +2050,7 @@ impl AcpClient {
                 if !this.has_pending_prompt_for(sid.as_deref()) {
                     return;
                 }
-                let last = *this.last_update_at.lock();
+                let last = this.last_update_for(sid.as_deref());
                 if prompt_fallback_due(last, grace, Instant::now()) {
                     break;
                 }
@@ -2014,14 +2065,7 @@ impl AcpClient {
     /// If agent never returned a session/prompt result after prompt_complete, free waiters.
     fn complete_pending_prompt_fallback(&self, session_id: &Option<String>, stop_reason: &str) {
         let mut pending = self.pending.lock();
-        let prompt_ids: Vec<u64> = pending
-            .iter()
-            .filter(|(_, p)| {
-                p.method == "session/prompt"
-                    && pending_prompt_matches(p.session_id.as_deref(), session_id.as_deref())
-            })
-            .map(|(id, _)| *id)
-            .collect();
+        let prompt_ids = pending_prompt_ids_for(&pending, session_id.as_deref());
         for id in prompt_ids {
             if let Some(p) = pending.remove(&id) {
                 info!(
@@ -2035,17 +2079,19 @@ impl AcpClient {
     fn handle_session_update(&self, params: &Value) {
         // Proof of life for the turn: re-arms the `prompt_complete` fallback so
         // an early completion notification cannot cut the answer short.
-        *self.last_update_at.lock() = Some(Instant::now());
-        // Multi-session routing: every update notification carries its
-        // `sessionId` at params top level (Grok gateway envelope). Stamp the
-        // decoded events so the SessionManager can route them to the right
-        // App session when one process hosts several. Missing sid → None
-        // (process-scoped fallback).
+        // Stamp per-session so another chat on this process cannot extend
+        // (or expire) this turn's grace window.
         let sid = params
             .get("sessionId")
             .or_else(|| params.get("session_id"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        self.touch_last_update(sid.as_deref(), Instant::now());
+        // Multi-session routing: every update notification carries its
+        // `sessionId` at params top level (Grok gateway envelope). Stamp the
+        // decoded events so the SessionManager can route them to the right
+        // App session when one process hosts several. Missing sid → None
+        // (process-scoped fallback).
         let events = decode_session_update(params);
         if events.is_empty() {
             let update = params.get("update").unwrap_or(params);
@@ -2471,7 +2517,7 @@ impl AcpClient {
             Pending {
                 method: method.to_string(),
                 tx,
-                session_id: prompt_sid,
+                session_id: prompt_sid.clone(),
             },
         );
         let msg = json!({
@@ -2488,7 +2534,7 @@ impl AcpClient {
 
         let wait_started = Instant::now();
         // Mark activity at dispatch so pure silence is measured from send time.
-        *self.last_update_at.lock() = Some(wait_started);
+        self.touch_last_update(prompt_sid.as_deref(), wait_started);
         let idle = Duration::from_secs(PROMPT_IDLE_TIMEOUT_SECS);
         let absolute = Duration::from_secs(PROMPT_ABSOLUTE_TIMEOUT_SECS);
         let slice = Duration::from_secs(PROMPT_WAIT_SLICE_SECS);
@@ -2524,7 +2570,7 @@ impl AcpClient {
                         error!("{}", self.format_exit_detail(&head));
                         return Err(head);
                     }
-                    let last = *self.last_update_at.lock();
+                    let last = self.last_update_for(prompt_sid.as_deref());
                     let now = Instant::now();
                     if let Some(kind) =
                         prompt_wait_should_timeout(last, wait_started, now, idle, absolute)
@@ -5488,13 +5534,11 @@ mod prompt_fallback_tests {
     #[test]
     fn fallback_sid_match_is_scoped_per_session() {
         // Concurrent turns on one process: an explicit target only matches its
-        // own session's prompt.
+        // own session's prompt. Cross-None matching is no longer allowed (P0-4).
         assert!(pending_prompt_matches(Some("sidA"), Some("sidA")));
         assert!(!pending_prompt_matches(Some("sidA"), Some("sidB")));
-        // Legacy prompts without a recorded sid match any target (never stranded).
-        assert!(pending_prompt_matches(None, Some("sidA")));
-        // Unscoped fallback (no target) frees any pending prompt.
-        assert!(pending_prompt_matches(Some("sidA"), None));
+        assert!(!pending_prompt_matches(None, Some("sidA")));
+        assert!(!pending_prompt_matches(Some("sidA"), None));
         assert!(pending_prompt_matches(None, None));
     }
 

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -486,10 +486,11 @@ fn paths_classify_sync(paths: Vec<String>) -> Vec<PathEntry> {
             let meta = std::fs::metadata(&pb).ok();
             let exists = meta.is_some();
             let is_dir = meta.map(|m| m.is_dir()).unwrap_or(false);
-            // User-attached / chat-history paths often sit outside trusted project
-            // roots (Desktop, Downloads, Screenshots). Grant them so media://
-            // previews in the composer and thread can load.
-            if exists {
+            // User-attached / chat-history files often sit outside trusted
+            // project roots (Desktop, Downloads). Grant the **file** so media
+            // HTTP can preview it — never directories (that would unlock every
+            // sibling under e.g. ~/.ssh).
+            if exists && !is_dir {
                 crate::path_scope::grant_path(&pb);
             }
             PathEntry {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -111,6 +111,10 @@ pub async fn settings_set(
     };
     // API-mode address is a spawn-path flip (local CLI ↔ TCP). Soft-respawn so
     // the next connect uses the new target; mid-turn sessions stay skipped.
+    let proxy_flip = prev.proxy_mode.trim() != settings.proxy_mode.trim()
+        || prev.proxy_url.as_deref().map(str::trim) != settings.proxy_url.as_deref().map(str::trim)
+        || prev.proxy_no_proxy.as_deref().map(str::trim)
+            != settings.proxy_no_proxy.as_deref().map(str::trim);
     let acp_addr_flip = {
         let a = prev
             .acp_server_addr
@@ -276,6 +280,7 @@ pub async fn settings_set(
         || sandbox_flip
         || compaction_flip
         || acp_addr_flip
+        || proxy_flip
     {
         need_soft_respawn = true;
     }

--- a/src-tauri/src/path_scope.rs
+++ b/src-tauri/src/path_scope.rs
@@ -70,17 +70,14 @@ pub fn refresh_from_store() {
 }
 
 /// Grant a one-off absolute path (e.g. user-picked file outside projects).
-/// Parent directory of a file is granted so re-reads of the same file work.
+///
+/// Files are granted **exactly** — never the parent directory. Granting the
+/// parent used to let loopback media serve siblings (e.g. `~/.ssh/id_rsa`
+/// classified from journal history also unlocked `id_rsa.pub`). Re-reads of
+/// the same file still work because `is_allowed` treats the grant as a root
+/// that matches that path.
 pub fn grant_path(path: &Path) {
-    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let grant = if canonical.is_file() {
-        canonical
-            .parent()
-            .map(|p| p.to_path_buf())
-            .unwrap_or(canonical)
-    } else {
-        canonical
-    };
+    let grant = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     let mut g = extra_grants().write();
     if !g.iter().any(|x| x == &grant) {
         g.push(grant);
@@ -233,6 +230,12 @@ mod tests {
             assert!(!is_allowed(&file));
             grant_path(&file);
             assert!(is_allowed(&file));
+            let sibling = other.join("secret.key");
+            fs::write(&sibling, "no").unwrap();
+            assert!(
+                !is_allowed(&sibling),
+                "granting a file must not unlock siblings in the parent dir"
+            );
         });
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/src-tauri/src/permission.rs
+++ b/src-tauri/src/permission.rs
@@ -1315,12 +1315,7 @@ mod tests {
             "allow-always"
         );
         assert_eq!(
-            coerce_wire_option_id_for_tool(
-                "allow_session",
-                Some("always-allow"),
-                &empty,
-                "write",
-            ),
+            coerce_wire_option_id_for_tool("allow_session", Some("always-allow"), &empty, "write",),
             "allow-always"
         );
     }

--- a/src-tauri/src/permission.rs
+++ b/src-tauri/src/permission.rs
@@ -428,8 +428,9 @@ pub fn may_auto_allow_download(
     };
     let dests = extract_download_destinations(command);
     if dests.is_empty() {
-        // wget without -O writes into cwd (project root when agent cwd = project).
-        return true;
+        // wget/curl -O without -o writes into agent cwd, which is not
+        // guaranteed to be the project root (P1-22). Ask unless YOLO.
+        return matches!(policy, PermissionPolicy::AlwaysApprove);
     }
     dests.iter().all(|d| download_dest_in_project(root, d))
 }
@@ -533,6 +534,24 @@ fn norm_perm_token(s: &str) -> String {
     s.trim().to_ascii_lowercase().replace(['_', '-'], "")
 }
 
+/// `always-allow` and `allow-always` are the same CLI session id with
+/// reversed word order (`alwaysallow` ≠ `allowalways` after hyphen strip).
+fn session_allow_alias_norm(norm: &str) -> Option<&'static str> {
+    match norm {
+        "alwaysallow" => Some("allowalways"),
+        "allowalways" => Some("alwaysallow"),
+        _ => None,
+    }
+}
+
+fn extract_option_id(o: &serde_json::Value) -> Option<String> {
+    o.get("optionId")
+        .or_else(|| o.get("option_id"))
+        .or_else(|| o.get("id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
 /// Pick optionId from ACP permission options by preferred kind (or id).
 ///
 /// Prefer matching `kind` (underscore forms like `allow_once`), then exact
@@ -544,20 +563,14 @@ pub fn pick_option_id(options: &serde_json::Value, prefer: &str) -> Option<Strin
     if prefer_norm.is_empty() {
         return None;
     }
-    let extract_id = |o: &serde_json::Value| {
-        o.get("optionId")
-            .or_else(|| o.get("id"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-    };
     for o in arr {
         let kind = o.get("kind").and_then(|v| v.as_str()).unwrap_or("");
         if !kind.is_empty() && norm_perm_token(kind) == prefer_norm {
-            return extract_id(o);
+            return extract_option_id(o);
         }
     }
     for o in arr {
-        if let Some(id) = extract_id(o) {
+        if let Some(id) = extract_option_id(o) {
             if norm_perm_token(&id) == prefer_norm {
                 return Some(id);
             }
@@ -576,7 +589,7 @@ pub fn pick_option_id(options: &serde_json::Value, prefer: &str) -> Option<Strin
             || name.contains(&prefer_lower.replace('_', "-"))
             || name.contains(&prefer_lower.replace('-', " "))
         {
-            return extract_id(o);
+            return extract_option_id(o);
         }
     }
     None
@@ -618,6 +631,17 @@ pub fn fallback_always_allow_for_tool(tool_name: &str) -> &'static str {
     {
         return "allow-always-mcp";
     }
+    // Write / edit / image: CLI fixture publishes `allow-always`, not the
+    // reversed `always-allow` (#600).
+    if t.contains("write")
+        || t.contains("edit")
+        || t.contains("replace")
+        || t.contains("image")
+        || t == "read_file"
+        || t == "read-file"
+    {
+        return "allow-always";
+    }
     FALLBACK_ALWAYS_ALLOW
 }
 
@@ -651,27 +675,23 @@ pub fn resolve_always_allow_option_id_for_tool(
 /// Scan options for session-scoped allow kinds/ids (`allow_always*`, `allow-always-*`).
 fn pick_session_scoped_option_id(options: &serde_json::Value) -> Option<String> {
     let arr = options.as_array()?;
-    let extract_id = |o: &serde_json::Value| {
-        o.get("optionId")
-            .or_else(|| o.get("id"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-    };
     for o in arr {
         let kind = o.get("kind").and_then(|v| v.as_str()).unwrap_or("");
         let kn = norm_perm_token(kind);
         // allowalways / allowalwaysbash / allowalwayscommand — not allowonce
         if kn.starts_with("allowalways") {
-            if let Some(id) = extract_id(o) {
+            if let Some(id) = extract_option_id(o) {
                 return Some(id);
             }
         }
-        if let Some(id) = extract_id(o) {
+        if let Some(id) = extract_option_id(o) {
             let id_l = id.to_ascii_lowercase();
             if id_l.starts_with("allow-always-")
                 || id_l.starts_with("allow_always_")
                 || id_l == "always-allow"
                 || id_l == "always_allow"
+                || id_l == "allow-always"
+                || id_l == "allow_always"
             {
                 return Some(id);
             }
@@ -690,13 +710,16 @@ pub fn option_id_in_list(options: &serde_json::Value, option_id: &str) -> bool {
     if want.is_empty() {
         return false;
     }
+    let alias = session_allow_alias_norm(&want);
     for o in arr {
-        let id = o
-            .get("optionId")
-            .or_else(|| o.get("id"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        if !id.is_empty() && (id == option_id || norm_perm_token(id) == want) {
+        let id = extract_option_id(o).unwrap_or_default();
+        if id.is_empty() {
+            continue;
+        }
+        if id == option_id || norm_perm_token(&id) == want {
+            return true;
+        }
+        if alias.is_some_and(|a| norm_perm_token(&id) == a) {
             return true;
         }
     }
@@ -711,13 +734,14 @@ pub fn wire_option_id_from_list(options: &serde_json::Value, option_id: &str) ->
     if want.is_empty() {
         return None;
     }
+    let alias = session_allow_alias_norm(&want);
     for o in arr {
-        let id = o
-            .get("optionId")
-            .or_else(|| o.get("id"))
-            .and_then(|v| v.as_str())?;
-        if id == option_id || norm_perm_token(id) == want {
-            return Some(id.to_string());
+        let id = extract_option_id(o)?;
+        if id == option_id || norm_perm_token(&id) == want {
+            return Some(id);
+        }
+        if alias.is_some_and(|a| norm_perm_token(&id) == a) {
+            return Some(id);
         }
     }
     None
@@ -783,6 +807,16 @@ pub fn coerce_wire_option_id_for_tool(
     match decision {
         "deny" => resolve_reject_option_id(options),
         "allow_session" | "allow_for_session" | "allow_always" | "allow-always" => {
+            if has_list {
+                if let Some(id) = pick_session_scoped_option_id(options) {
+                    return id;
+                }
+                // Write / edit tools often publish only allow-once + reject.
+                // Inventing `always-allow` is rejected as "unknown permission
+                // option" and cancels the turn (#600). Host still caches
+                // session-allow; the wire reply must be a listed id.
+                return resolve_allow_once_option_id(options);
+            }
             resolve_always_allow_option_id_for_tool(options, tool_name)
         }
         "allow_once" | "allow-once" | "allow" => resolve_allow_once_option_id(options),
@@ -1039,6 +1073,33 @@ mod tests {
     }
 
     #[test]
+    fn download_without_dest_not_auto_allowed() {
+        let c = SessionAllowCache::default();
+        let root = std::env::temp_dir().join("grok-app-perm-dl-cwd");
+        let _ = std::fs::create_dir_all(&root);
+        let cmd = "curl -sL -O https://example.com/a.png";
+        assert!(is_download_command(cmd));
+        assert!(!may_auto_allow(
+            PermissionPolicy::Ask,
+            &c,
+            "execute:run_terminal_command",
+            Some(&root),
+            "",
+            "run_terminal_command",
+            cmd,
+        ));
+        assert!(may_auto_allow(
+            PermissionPolicy::AlwaysApprove,
+            &c,
+            "execute:run_terminal_command",
+            Some(&root),
+            "",
+            "run_terminal_command",
+            cmd,
+        ));
+    }
+
+    #[test]
     fn download_outside_project_not_auto_allowed() {
         let c = SessionAllowCache::default();
         let root = std::env::temp_dir().join("grok-app-perm-dl-out");
@@ -1251,7 +1312,49 @@ mod tests {
                 &empty,
                 "search_replace",
             ),
-            "always-allow"
+            "allow-always"
+        );
+        assert_eq!(
+            coerce_wire_option_id_for_tool(
+                "allow_session",
+                Some("always-allow"),
+                &empty,
+                "write",
+            ),
+            "allow-always"
+        );
+    }
+
+    #[test]
+    fn session_allow_without_session_option_uses_allow_once() {
+        // #600: write/edit tools list allow-once + reject only. Sending
+        // always-allow cancels the turn with "unknown permission option".
+        let write = serde_json::json!([
+            {"optionId": "allow-once", "kind": "allow_once"},
+            {"optionId": "reject-once", "kind": "reject_once"}
+        ]);
+        assert_eq!(
+            coerce_wire_option_id("allow_session", Some("always-allow"), &write),
+            "allow-once"
+        );
+        // Write fixture publishes `allow-always`; client always-allow must alias.
+        let write_session = serde_json::json!([
+            {"optionId": "allow-once", "kind": "allow_once"},
+            {"optionId": "allow-always", "kind": "allow_always"},
+            {"optionId": "reject-once", "kind": "reject_once"}
+        ]);
+        assert_eq!(
+            coerce_wire_option_id("allow_session", Some("always-allow"), &write_session),
+            "allow-always"
+        );
+        assert_eq!(
+            coerce_wire_option_id_for_tool(
+                "allow_session",
+                Some("always-allow"),
+                &write,
+                "search_replace",
+            ),
+            "allow-once"
         );
     }
 

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -103,6 +103,13 @@ impl SessionManager {
             "connect open_start"
         );
 
+        // Mid-turn policy / effort / proxy changes queue a respawn. If this
+        // chat is now idle, drop the old process before the no-op / unpark
+        // paths reuse spawn flags (P0-5 / #598).
+        if self.pending_soft_respawn.lock().contains_key(&meta.id) {
+            self.flush_pending_soft_respawn(&app, &meta.id).await;
+        }
+
         // Resolve model / effort / permission / mode for this project+session scope.
         let prefs =
             store::resolve_composer_prefs(meta.project_id.as_deref(), Some(meta.id.as_str()));
@@ -215,35 +222,52 @@ impl SessionManager {
                 return Err(format!("{}: {}", e.code.as_str(), e.message));
             }
             if let Some(live) = self.unpark_to_live(&meta.id) {
-                // Refresh prefs on shell (model may have changed in UI).
-                let mut live = live;
-                live.model_id = Some(prefs.model_id.clone());
-                live.effort = Some(prefs.effort.clone());
-                live.product_mode = Some(prefs.mode.clone());
-                live.policy = policy;
-                live.project_path = project_path.clone();
-                live.meta.model_id = Some(prefs.model_id.clone());
-                live.meta.mode = Some(prefs.mode.clone());
-                live.meta.effort = Some(prefs.effort.clone());
-                live.meta.permission_policy = Some(prefs.permission_policy.clone());
-                // Best-effort align agent process to channel prefs. Target the
-                // session explicitly — on a shared process the "recently bound"
-                // agent session id may belong to another App session.
-                if let Some(acp) = live.acp.clone() {
-                    if let Some(sid) = live.meta.agent_session_id.clone() {
-                        if let Err(e) = acp.set_model_for(&sid, &agent_model).await {
-                            tracing::warn!("acp set_model on unpark soft-fail: {e}");
-                        }
-                        if let Err(e) = acp.set_mode_for(&sid, &prefs.mode).await {
-                            tracing::warn!("acp set_mode on unpark soft-fail: {e}");
+                // Spawn flags are process-level. Effort / policy mismatch
+                // cannot be hot-patched — kill and fall through to cold spawn.
+                let effort_ok = live.effort.as_deref() == Some(prefs.effort.as_str());
+                let policy_ok = live.policy == policy;
+                if !effort_ok || !policy_ok {
+                    tracing::info!(
+                        session = %meta.id,
+                        parked_effort = ?live.effort,
+                        want_effort = %prefs.effort,
+                        parked_policy = ?live.policy,
+                        "unpark spawn-flag mismatch — cold spawn"
+                    );
+                    if let Some(acp) = live.acp {
+                        acp.kill().await;
+                    }
+                } else {
+                    // Refresh prefs on shell (model may have changed in UI).
+                    let mut live = live;
+                    live.model_id = Some(prefs.model_id.clone());
+                    live.effort = Some(prefs.effort.clone());
+                    live.product_mode = Some(prefs.mode.clone());
+                    live.policy = policy;
+                    live.project_path = project_path.clone();
+                    live.meta.model_id = Some(prefs.model_id.clone());
+                    live.meta.mode = Some(prefs.mode.clone());
+                    live.meta.effort = Some(prefs.effort.clone());
+                    live.meta.permission_policy = Some(prefs.permission_policy.clone());
+                    // Best-effort align agent process to channel prefs. Target the
+                    // session explicitly — on a shared process the "recently bound"
+                    // agent session id may belong to another App session.
+                    if let Some(acp) = live.acp.clone() {
+                        if let Some(sid) = live.meta.agent_session_id.clone() {
+                            if let Err(e) = acp.set_model_for(&sid, &agent_model).await {
+                                tracing::warn!("acp set_model on unpark soft-fail: {e}");
+                            }
+                            if let Err(e) = acp.set_mode_for(&sid, &prefs.mode).await {
+                                tracing::warn!("acp set_mode on unpark soft-fail: {e}");
+                            }
                         }
                     }
+                    *self.inner.lock() = Some(live);
+                    let snap = self.snapshot();
+                    Self::emit_state(&app, &snap);
+                    tracing::info!("acp unparked warm session={}", meta.id);
+                    return Ok(snap);
                 }
-                *self.inner.lock() = Some(live);
-                let snap = self.snapshot();
-                Self::emit_state(&app, &snap);
-                tracing::info!("acp unparked warm session={}", meta.id);
-                return Ok(snap);
             }
             // Parked process died — fall through to cold spawn.
         }
@@ -1474,7 +1498,7 @@ mod connect_preserve_tests {
         assert!(SessionManager::live_session_is_busy(&s));
         assert!(!SessionManager::should_preserve_live_process(&s));
 
-        SessionManager::release_failed_turn_markers(&mut s);
+        SessionManager::release_failed_turn_markers(&mut s, None);
         assert!(!SessionManager::live_session_is_busy(&s));
         assert!(s.deferred_prompt_complete.is_none());
         assert!(!s.prompt_in_flight);

--- a/src-tauri/src/session_manager/control.rs
+++ b/src-tauri/src/session_manager/control.rs
@@ -34,7 +34,7 @@ impl SessionManager {
 
     /// Soft-respawn and tell the UI why the agent process was reloaded.
     pub async fn soft_respawn_with_reason(&self, app: &AppHandle, reason: &str) {
-        let acp = {
+        let (acp, sid) = {
             let mut guard = self.inner.lock();
             if let Some(s) = guard.as_mut() {
                 if s.acp.is_none() {
@@ -42,30 +42,72 @@ impl SessionManager {
                 }
                 if Self::live_session_is_busy(s) {
                     tracing::warn!(
-                        "soft_respawn skipped: live session mid-turn sid={} state={:?}",
+                        "soft_respawn deferred: live session mid-turn sid={} state={:?} reason={}",
                         s.app_session_id,
-                        s.fsm.state()
+                        s.fsm.state(),
+                        reason
                     );
+                    self.pending_soft_respawn
+                        .lock()
+                        .insert(s.app_session_id.clone(), reason.to_string());
                     return;
                 }
+                let sid = s.app_session_id.clone();
                 let acp = s.acp.take();
                 // Prefer resume on next connect; bootstrap only if load fails.
                 s.needs_history_bootstrap = false;
                 s.fsm.soft_disconnect();
                 // New process gets a new id on next connect.
                 s.process_id = String::new();
-                acp
+                (acp, Some(sid))
             } else {
-                None
+                (None, None)
             }
         };
         if let Some(acp) = acp {
             acp.kill().await;
+            if let Some(sid) = sid {
+                self.pending_soft_respawn.lock().remove(&sid);
+            }
             let _ = app.emit(
                 "session://agent_soft_respawn",
                 serde_json::json!({ "reason": reason }),
             );
             Self::emit_state(app, &self.snapshot());
+        }
+    }
+
+    /// If a mid-turn policy/effort/proxy change queued a respawn, run it
+    /// now that the session is idle (or drop a parked process so next
+    /// connect cold-spawns with the new flags).
+    pub async fn flush_pending_soft_respawn(&self, app: &AppHandle, session_id: &str) {
+        let reason = { self.pending_soft_respawn.lock().remove(session_id) };
+        let Some(reason) = reason else {
+            return;
+        };
+        let busy = self
+            .with_session_mut(session_id, |s| Self::live_session_is_busy(s))
+            .unwrap_or(false);
+        if busy {
+            self.pending_soft_respawn
+                .lock()
+                .insert(session_id.to_string(), reason);
+            return;
+        }
+        if self.is_live_session(session_id) {
+            self.soft_respawn_with_reason(app, &reason).await;
+            return;
+        }
+        // Parked: drop the warm process so the next connect respawns.
+        // Take the entry first — parking_lot guards are !Send across await.
+        let parked = self.parked.lock().remove(session_id);
+        if let Some(p) = parked {
+            p.acp.kill().await;
+            tracing::info!(
+                session = %session_id,
+                reason = %reason,
+                "dropped parked agent for pending soft-respawn"
+            );
         }
     }
 
@@ -383,7 +425,7 @@ impl SessionManager {
             policy.as_str(),
         );
 
-        let need_respawn = {
+        let (need_respawn, live_sid) = {
             let mut guard = self.inner.lock();
             if let Some(s) = guard.as_mut() {
                 let prev = s.policy;
@@ -391,13 +433,50 @@ impl SessionManager {
                 s.meta.permission_policy = Some(policy.as_str().into());
                 let _ = store::update_session_meta(&s.meta);
                 // Any policy change can affect agent-side enforcement / --always-approve.
-                prev != policy && s.acp.is_some()
+                (
+                    prev != policy && s.acp.is_some(),
+                    Some(s.app_session_id.clone()),
+                )
             } else {
-                false
+                (false, None)
             }
         };
+        // Background turns keep using s.policy for auto-allow (P1-19).
+        {
+            let mut bg = self.background.lock();
+            for s in bg.values_mut() {
+                s.policy = policy;
+                s.meta.permission_policy = Some(policy.as_str().into());
+                let _ = store::update_session_meta(&s.meta);
+                if s.acp.is_some() {
+                    self.pending_soft_respawn
+                        .lock()
+                        .insert(s.app_session_id.clone(), "permission_policy".into());
+                }
+            }
+        }
+        {
+            let mut parked = self.parked.lock();
+            let stale: Vec<String> = parked
+                .iter()
+                .filter(|(_, p)| p.policy != policy)
+                .map(|(id, _)| id.clone())
+                .collect();
+            for id in stale {
+                if let Some(p) = parked.remove(&id) {
+                    // Kill after drop to avoid holding the map lock across await.
+                    tokio::spawn(async move {
+                        p.acp.kill().await;
+                    });
+                }
+            }
+        }
         if need_respawn {
-            self.soft_respawn(app).await;
+            self.soft_respawn_with_reason(app, "permission_policy")
+                .await;
+            if let Some(sid) = live_sid {
+                self.flush_pending_soft_respawn(app, &sid).await;
+            }
         }
         Ok(())
     }
@@ -550,15 +629,42 @@ impl SessionManager {
                 Some(s) if session_id.is_some_and(|id| id == s.app_session_id) => {
                     let same = s.effort.as_deref() == Some(effort.as_str());
                     s.effort = Some(effort.clone());
-                    s.meta.effort = Some(effort);
+                    s.meta.effort = Some(effort.clone());
                     let _ = store::update_session_meta(&s.meta);
                     !same && s.acp.is_some()
                 }
                 _ => false,
             }
         };
+        // Parked / background chats own their process — updating only the live
+        // slot left them running the previous `--reasoning-effort` (#598).
+        if let Some(sid) = session_id {
+            if let Some(s) = self.background.lock().get_mut(sid) {
+                let same = s.effort.as_deref() == Some(effort.as_str());
+                s.effort = Some(effort.clone());
+                s.meta.effort = Some(effort.clone());
+                let _ = store::update_session_meta(&s.meta);
+                if !same && s.acp.is_some() {
+                    self.pending_soft_respawn
+                        .lock()
+                        .insert(sid.to_string(), "effort".into());
+                }
+            }
+            if let Some(p) = self.parked.lock().remove(sid) {
+                if p.effort.as_deref() != Some(effort.as_str()) {
+                    tokio::spawn(async move {
+                        p.acp.kill().await;
+                    });
+                } else {
+                    self.parked.lock().insert(sid.to_string(), p);
+                }
+            }
+        }
         if need {
-            self.soft_respawn(app).await;
+            self.soft_respawn_with_reason(app, "effort").await;
+            if let Some(sid) = session_id {
+                self.flush_pending_soft_respawn(app, sid).await;
+            }
         }
         Ok(())
     }
@@ -598,7 +704,7 @@ impl SessionManager {
         } else {
             None
         };
-        let (acp, project_path, pending_options, tool_name) = self
+        let (acp, project_path, pending_options, tool_name, pending_rpc) = self
             .with_session_mut(&target, |s| {
                 Self::touch_activity_locked(s);
                 let opts = s
@@ -616,9 +722,31 @@ impl SessionManager {
                             .filter(|s| !s.is_empty())
                     })
                     .unwrap_or_default();
-                (s.acp.clone(), s.project_path.clone(), opts, tool)
+                (
+                    s.acp.clone(),
+                    s.project_path.clone(),
+                    opts,
+                    tool,
+                    s.pending_permission_rpc_id,
+                )
             })
             .ok_or("no session")?;
+        // Stale / double-click / recycled Approve must not write an arbitrary
+        // rpc_id into a live process (P1-18).
+        match pending_rpc {
+            Some(id) if id == rpc_id => {}
+            Some(_) => {
+                return Err(
+                    "stale permission request — this approval no longer matches the pending gate"
+                        .into(),
+                );
+            }
+            None => {
+                return Err(
+                    "no pending permission on this chat — request expired or was cancelled".into(),
+                );
+            }
+        }
 
         // Prefer Host-stored options; if empty, accept the UI snapshot so we
         // can still coerce tool-scoped ids (shell allow-always-command, …).

--- a/src-tauri/src/session_manager/events.rs
+++ b/src-tauri/src/session_manager/events.rs
@@ -139,7 +139,7 @@ impl SessionManager {
                         // fire `prompt_complete` early (which Readies the FSM) and
                         // keep streaming for many more seconds. Gating on the FSM
                         // silently truncated those answers mid-sentence.
-                        if Self::is_session_load_replay(s.prompt_in_flight) {
+                        if Self::is_session_load_replay(s) {
                             tracing::debug!(
                                 "acp stream dropped: no prompt in flight (fsm={:?}) — replay",
                                 s.fsm.state()
@@ -261,7 +261,7 @@ impl SessionManager {
                 let replay_acp = {
                     let guard = self.inner.lock();
                     guard.as_ref().and_then(|s| {
-                        if Self::is_session_load_replay(s.prompt_in_flight) {
+                        if Self::is_session_load_replay(s) {
                             s.acp.clone()
                         } else {
                             None
@@ -424,7 +424,7 @@ impl SessionManager {
                 {
                     let guard = self.inner.lock();
                     if let Some(s) = guard.as_ref() {
-                        if Self::is_session_load_replay(s.prompt_in_flight) {
+                        if Self::is_session_load_replay(s) {
                             tracing::debug!(
                                 "acp tool_call dropped: no prompt in flight (replay) id={tool_call_id} status={status}"
                             );
@@ -741,7 +741,7 @@ impl SessionManager {
                 let empty_run = {
                     let mut guard = self.inner.lock();
                     if let Some(s) = guard.as_mut() {
-                        if Self::is_session_load_replay(s.prompt_in_flight) {
+                        if Self::is_session_load_replay(s) {
                             return;
                         }
                         Self::release_tool_open_on_session(s, &tool_call_id);
@@ -843,7 +843,7 @@ impl SessionManager {
                         } else {
                             // Retry path already recorded the error; still drop busy
                             // markers so reconnect is not stuck Disconnected+busy.
-                            Self::release_failed_turn_markers(s);
+                            Self::release_failed_turn_markers(s, Some(app));
                         }
                         let _ = s.fsm.fail_with(error);
                     }
@@ -855,6 +855,12 @@ impl SessionManager {
                 {
                     let mut guard = self.inner.lock();
                     if let Some(s) = guard.as_mut() {
+                        // Deliver the last coalesced stream batch before we drop
+                        // the live slot — otherwise ~40ms / 600 chars vanish.
+                        // Do not mark done: that would Ready the UI before
+                        // fsm.crash / Disconnected (P1-10).
+                        Self::flush_pending_stream_emit(s, app);
+                        Self::maybe_flush_stream_journal(s, true, false);
                         let st = s.fsm.state();
                         // Busy includes pending plan / ask_user (not only Streaming FSM).
                         let was_busy = Self::live_session_is_busy(s)
@@ -1086,7 +1092,7 @@ impl SessionManager {
                         return;
                     };
                     // Compact markers during load/replay would spam the journal.
-                    if Self::is_session_load_replay(s.prompt_in_flight) {
+                    if Self::is_session_load_replay(s) {
                         tracing::debug!(
                             "acp context_compact dropped: no prompt in flight (replay)"
                         );
@@ -1168,7 +1174,7 @@ impl SessionManager {
                     let Some(s) = guard.as_ref() else {
                         return;
                     };
-                    if Self::is_session_load_replay(s.prompt_in_flight) {
+                    if Self::is_session_load_replay(s) {
                         return;
                     }
                     s.app_session_id.clone()

--- a/src-tauri/src/session_manager/events_bg.rs
+++ b/src-tauri/src/session_manager/events_bg.rs
@@ -5,7 +5,11 @@ use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
-use crate::acp_client::{AcpEvent, PermissionOutcome, StreamKind};
+use crate::acp_client::{
+    should_abort_provider_retry_ex, AcpEvent, PermissionOutcome, StreamKind,
+    HOST_PROVIDER_MAX_RETRIES,
+};
+use crate::error::{AgentError, AgentErrorCode};
 use crate::journal_throttle::is_paragraph_break;
 use crate::permission::{
     coerce_wire_option_id_for_tool, extract_path_target, extract_shell_command, may_auto_allow,
@@ -41,7 +45,7 @@ impl SessionManager {
                     // A background chat never runs `session/load` — a drop here
                     // after the RPC resolved is a real lost chunk and must leave
                     // a trace.
-                    if Self::is_session_load_replay(s.prompt_in_flight) {
+                    if Self::is_session_load_replay(s) {
                         tracing::warn!(
                             "background stream chunk dropped after turn close sid={} fsm={:?} len={}",
                             app_session_id,
@@ -361,7 +365,7 @@ impl SessionManager {
                     if let Some(s) = bg.get_mut(app_session_id) {
                         // Defensive: background turns never load-replay, but if
                         // prompt_in_flight is already false, do not mutate journal.
-                        if Self::is_session_load_replay(s.prompt_in_flight) {
+                        if Self::is_session_load_replay(s) {
                             tracing::debug!(
                                 "background tool_call dropped after turn close sid={} id={tool_call_id}",
                                 app_session_id
@@ -494,7 +498,7 @@ impl SessionManager {
                 let finished = {
                     let mut bg = self.background.lock();
                     if let Some(s) = bg.get_mut(app_session_id) {
-                        if Self::is_session_load_replay(s.prompt_in_flight) {
+                        if Self::is_session_load_replay(s) {
                             return;
                         }
                         Self::release_tool_open_on_session(s, &tool_call_id);
@@ -526,6 +530,10 @@ impl SessionManager {
                 let mut gate_invalidations: Vec<serde_json::Value> = Vec::new();
                 let mut bg = self.background.lock();
                 if let Some(mut s) = bg.remove(app_session_id) {
+                    // No done flag — crash must not Ready the UI before
+                    // Disconnected (P1-10).
+                    Self::flush_pending_stream_emit(&mut s, app);
+                    Self::maybe_flush_stream_journal(&mut s, true, false);
                     let busy = Self::live_session_is_busy(&s)
                         || matches!(
                             s.fsm.state(),
@@ -748,8 +756,81 @@ impl SessionManager {
                     Self::emit_runtime(app, &snap);
                 }
             }
+            AcpEvent::RetryState {
+                attempt,
+                max_retries,
+                reason,
+                status,
+            } => {
+                let cap = max_retries.clamp(1, HOST_PROVIDER_MAX_RETRIES);
+                let abort = {
+                    let mut bg = self.background.lock();
+                    if let Some(s) = bg.get_mut(app_session_id) {
+                        s.provider_retry_attempt = attempt;
+                        if !Self::should_apply_provider_retry_abort(s) {
+                            false
+                        } else if s.provider_retry_aborted {
+                            false
+                        } else {
+                            should_abort_provider_retry_ex(attempt, max_retries, &status, &reason)
+                        }
+                    } else {
+                        false
+                    }
+                };
+                let _ = app.emit(
+                    "session://retry",
+                    serde_json::json!({
+                        "sessionId": app_session_id,
+                        "attempt": attempt,
+                        "maxRetries": cap,
+                        "reason": reason,
+                        "status": status,
+                        "aborting": abort,
+                    }),
+                );
+                if abort {
+                    let (acp, agent_sid) = {
+                        let mut bg = self.background.lock();
+                        if let Some(s) = bg.get_mut(app_session_id) {
+                            if s.provider_retry_aborted {
+                                (None, None)
+                            } else {
+                                s.provider_retry_aborted = true;
+                                let msg = if reason.trim().is_empty() {
+                                    format!(
+                                        "Provider request failed after {attempt} attempts (budget {cap})"
+                                    )
+                                } else {
+                                    format!(
+                                        "Provider request failed after {attempt} attempts (budget {cap}): {reason}"
+                                    )
+                                };
+                                let err = AgentError::new(AgentErrorCode::NetworkProvider, msg);
+                                Self::record_turn_error(s, app, &err);
+                                let _ = s.fsm.fail_with(err);
+                                (s.acp.clone(), s.meta.agent_session_id.clone())
+                            }
+                        } else {
+                            (None, None)
+                        }
+                    };
+                    if let Some(acp) = acp {
+                        let abort_msg = format!(
+                            "provider retries exhausted (host cap {HOST_PROVIDER_MAX_RETRIES})"
+                        );
+                        acp.abort_pending_prompts(&abort_msg);
+                        let _ = match agent_sid {
+                            Some(sid) => acp.cancel_for(&sid).await,
+                            None => acp.cancel().await,
+                        };
+                    }
+                    self.promote_background_ready_to_parked(app_session_id);
+                    Self::emit_state(app, &self.snapshot());
+                }
+            }
             _ => {
-                // stderr / retry / other variants — log only
+                // stderr / other variants — log only
                 tracing::debug!("background acp event ignored variant for sid={app_session_id}");
             }
         }

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -76,6 +76,10 @@ pub struct SessionManager {
     /// post-turn reconciliation. Retry sleeps never hold these locks, and one
     /// chat never delays another chat's send.
     pub(super) post_turn_journal_locks: Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Soft-respawn requested while the session was mid-turn (YOLO off,
+    /// effort change, proxy, …). Flushed when the turn becomes idle so
+    /// the next process picks up spawn flags (P0-5 / #598).
+    pub(super) pending_soft_respawn: Mutex<HashMap<String, String>>,
 }
 
 impl Default for SessionManager {
@@ -94,6 +98,7 @@ impl SessionManager {
             tool_identities: std::sync::Mutex::new(std::collections::HashMap::new()),
             connect_lock: tokio::sync::Mutex::new(()),
             post_turn_journal_locks: Mutex::new(HashMap::new()),
+            pending_soft_respawn: Mutex::new(HashMap::new()),
         }
     }
 

--- a/src-tauri/src/session_manager/process.rs
+++ b/src-tauri/src/session_manager/process.rs
@@ -170,7 +170,10 @@ impl SessionManager {
         if s.deferred_prompt_complete.is_some() {
             return true;
         }
-        if s.pending_plan_rpc_id.is_some() || s.pending_ask_user_rpc_id.is_some() {
+        if s.pending_plan_rpc_id.is_some()
+            || s.pending_ask_user_rpc_id.is_some()
+            || s.pending_permission_rpc_id.is_some()
+        {
             return true;
         }
         false
@@ -210,7 +213,12 @@ impl SessionManager {
 
     /// Drop all in-turn busy markers after a terminal turn failure.
     /// Complements FSM `fail_with` (which only flips state + last_error).
-    pub(super) fn release_failed_turn_markers(s: &mut LiveSession) {
+    pub(super) fn release_failed_turn_markers(s: &mut LiveSession, app: Option<&AppHandle>) {
+        // Flush the last coalesced tokens before dropping the buffer (P0-1 / P1-9).
+        // No done flag: the error / fail_with state should win over a fake Ready.
+        if let Some(app) = app {
+            Self::flush_pending_stream_emit(s, app);
+        }
         s.prompt_in_flight = false;
         s.streaming_message_id = None;
         s.active_turn_id = None;
@@ -1067,7 +1075,7 @@ impl SessionManager {
         // Clear *all* busy markers (including deferred prompt_complete / open tools).
         // Leaving them set after fail_with left the session as Disconnected+busy,
         // so connect no-oped forever and local sends failed while Remote IM still worked.
-        Self::release_failed_turn_markers(s);
+        Self::release_failed_turn_markers(s, Some(app));
 
         let _ = app.emit(
             "session://turn_error",

--- a/src-tauri/src/session_manager/routing_tests.rs
+++ b/src-tauri/src/session_manager/routing_tests.rs
@@ -191,10 +191,12 @@ fn empty_run_skips_ask_mode_and_tool_turns() {
 
 #[test]
 fn session_load_replay_gate_matches_prompt_in_flight() {
-    // session/load replay: no prompt RPC → drop stream/tool side effects.
-    assert!(SessionManager::is_session_load_replay(false));
+    // session/load replay: no prompt RPC and no deferred complete → drop.
+    assert!(SessionManager::is_session_load_replay_flags(false, false));
     // Live turn (prompt in flight): apply all side effects.
-    assert!(!SessionManager::is_session_load_replay(true));
+    assert!(!SessionManager::is_session_load_replay_flags(true, false));
+    // Early prompt_complete with tools still open: keep applying chunks (P0-3).
+    assert!(!SessionManager::is_session_load_replay_flags(false, true));
 }
 
 #[test]

--- a/src-tauri/src/session_manager/stall_tests.rs
+++ b/src-tauri/src/session_manager/stall_tests.rs
@@ -217,24 +217,51 @@ fn hard_silence_never_force_ends_user_turn() {
     });
 }
 
-/// #453: after authoritative prompt RPC (`prompt_in_flight=false`), leftover
-/// open_tool_ids must not keep Streaming/busy forever when no human gate remains.
+/// P0-3: a recently-seen open tool after early prompt_complete must keep the
+/// turn deferred — force-clearing dropped the rest of the answer as replay.
 #[test]
-fn deferred_prompt_complete_force_clears_open_tools_after_rpc() {
+fn deferred_prompt_complete_keeps_recent_open_tools() {
     with_temp_app_home(|| {
         let t0 = Instant::now();
         let mut s = streaming_session(t0, |s| {
             s.prompt_in_flight = false;
             s.deferred_prompt_complete = Some("end_turn".into());
+            s.open_tool_ids.insert("live_silent_tool".into());
+            s.open_tool_seen_at.insert("live_silent_tool".into(), t0);
+            s.tools_this_turn = 1;
+            s.saw_model_output = true;
+        });
+        let finished = SessionManager::try_finish_deferred_prompt_complete(&mut s, None);
+        assert!(
+            finished.is_none(),
+            "recent open tools must keep deferred prompt_complete"
+        );
+        assert!(s.open_tool_ids.contains("live_silent_tool"));
+        assert_eq!(s.deferred_prompt_complete.as_deref(), Some("end_turn"));
+        assert_eq!(s.fsm.state(), SessionState::Streaming);
+    });
+}
+
+/// #453 residual: aged orphan tool ids (TOOL_ORPHAN_SECONDS) prune, then
+/// deferred complete may finish without a human gate.
+#[test]
+fn deferred_prompt_complete_finishes_after_orphan_prune() {
+    with_temp_app_home(|| {
+        let t0 = Instant::now();
+        let aged = t0 - Duration::from_secs(crate::stream_stall::TOOL_ORPHAN_SECONDS as u64 + 5);
+        let mut s = streaming_session(t0, |s| {
+            s.prompt_in_flight = false;
+            s.deferred_prompt_complete = Some("end_turn".into());
             s.open_tool_ids.insert("ghost_bg_tool".into());
-            s.open_tool_seen_at.insert("ghost_bg_tool".into(), t0);
+            s.open_tool_seen_at.insert("ghost_bg_tool".into(), aged);
+            s.last_stream_progress = aged;
             s.tools_this_turn = 1;
             s.saw_model_output = true;
         });
         let finished = SessionManager::try_finish_deferred_prompt_complete(&mut s, None);
         assert!(
             finished.is_some(),
-            "expected deferred finish after force-clear open tools"
+            "expected deferred finish after orphan prune"
         );
         assert!(s.open_tool_ids.is_empty());
         assert!(s.deferred_prompt_complete.is_none());

--- a/src-tauri/src/session_manager/stream.rs
+++ b/src-tauri/src/session_manager/stream.rs
@@ -119,8 +119,11 @@ impl SessionManager {
     /// RPC is in flight. UI history must come only from the App journal — any
     /// turn side-effect event (`tool_call`, stream, …) must be dropped.
     ///
-    /// Gate on `prompt_in_flight` (not the FSM): early `prompt_complete` Readies
-    /// the FSM while the agent may still stream live output.
+    /// Gate on `prompt_in_flight` **or** a still-deferred `prompt_complete`
+    /// (not the FSM): early `prompt_complete` Readies the FSM and may release
+    /// the RPC after a short silence while a long tool is still running. If
+    /// we only looked at `prompt_in_flight`, those later chunks were dropped
+    /// as load-replay (P0-3).
     ///
     /// **Human gates are different:** `exit_plan_mode` / `ask_user_question` are
     /// live reverse-RPCs that Grok Build may re-issue after resume with **no**
@@ -128,8 +131,16 @@ impl SessionManager {
     /// [`Self::should_drop_plan_event`] / [`Self::should_drop_ask_user_event`]
     /// for those — never this helper alone.
     #[inline]
-    pub(super) fn is_session_load_replay(prompt_in_flight: bool) -> bool {
-        !prompt_in_flight
+    pub(super) fn is_session_load_replay(s: &LiveSession) -> bool {
+        Self::is_session_load_replay_flags(s.prompt_in_flight, s.deferred_prompt_complete.is_some())
+    }
+
+    #[inline]
+    pub(super) fn is_session_load_replay_flags(
+        prompt_in_flight: bool,
+        deferred_prompt_complete: bool,
+    ) -> bool {
+        !prompt_in_flight && !deferred_prompt_complete
     }
 
     /// Whether to drop an `AcpEvent::Plan` (progress update and/or exit_plan_mode).
@@ -327,24 +338,13 @@ impl SessionManager {
             pending_ask,
             s.open_tool_ids.len(),
         ) {
-            // #453: prompt RPC already resolved (`prompt_in_flight` false) and no
-            // human gate remains — leftover `open_tool_ids` are Host accounting
-            // leaks (bg task id mismatch / missing terminal tool_call_update).
-            // Holding Streaming/busy here blocks reconnect and new-session send.
-            if !awaiting_perm && !pending_plan && !pending_ask && !s.open_tool_ids.is_empty() {
-                tracing::warn!(
-                    target: "session",
-                    session = %s.app_session_id,
-                    open_tools = s.open_tool_ids.len(),
-                    "force-clear open_tool_ids after authoritative prompt complete (#453)"
-                );
-                for id in s.open_tool_ids.drain() {
-                    s.terminal_tool_ids.insert(id);
-                }
-                s.open_tool_seen_at.clear();
-            } else {
-                return None;
-            }
+            // Keep the turn open while tools or human gates remain. Orphans
+            // older than TOOL_ORPHAN_SECONDS were already pruned above; a
+            // still-open id is treated as a live (possibly silent) tool.
+            // Force-clearing here dropped the rest of the answer as
+            // load-replay (P0-3). #453 reconnect-stuck is recovered by
+            // the orphan prune + stall watchdog, not by discarding chunks.
+            return None;
         }
         let empty = Self::empty_run_signal_from_live(s, &stop_reason);
         s.deferred_prompt_complete = None;

--- a/src-tauri/src/session_manager/turn.rs
+++ b/src-tauri/src/session_manager/turn.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
-use crate::acp_client::{AcpClient, AskUserOutcome};
+use crate::acp_client::{AcpClient, AskUserOutcome, PermissionOutcome};
 use crate::error::{AgentError, AgentErrorCode};
 use crate::journal_throttle::is_paragraph_break;
 use crate::mock_acp::{self, StreamChunk};
@@ -322,18 +322,12 @@ impl SessionManager {
                 "send_message: turn no longer active after prepare; skip prompt_for"
             );
             self.emit_for_session(&app, &app_sid);
-            if self.is_live_session(&app_sid) {
-                return Ok(self.snapshot());
-            }
-            if let Some(snap) = self
-                .background
-                .lock()
-                .get(&app_sid)
-                .map(Self::snapshot_from_live)
-            {
-                return Ok(snap);
-            }
-            return Ok(self.snapshot());
+            // Must not return Ok — automations treat Ok as "fired" and
+            // advance next_run_at / disable once tasks (P0-2). Frontend
+            // maps TURN_CANCELLED to a silent cancel (user Stop / stall).
+            return Err(format!(
+                "TURN_CANCELLED: turn {turn_id} no longer active after prepare; prompt not dispatched"
+            ));
         }
 
         if backend == "mock_acp" || AcpClient::use_mock() {
@@ -768,7 +762,7 @@ impl SessionManager {
         // Also release ask_user / plan reverse-RPCs. Leaving them set kept
         // `live_session_is_busy` true after stop, so Send/park paths stayed
         // wedged until process kill (user diag 5bda6b52).
-        let (acp, agent_sid, pending_ask, pending_plan) = self
+        let (acp, agent_sid, pending_ask, pending_plan, pending_perm) = self
             .with_session_mut(&target, move |s| {
                 let app = app_for_marker;
                 if let Some(h) = s.mock_stream.take() {
@@ -776,13 +770,17 @@ impl SessionManager {
                 }
                 let pending_ask = s.pending_ask_user_rpc_id.take();
                 let pending_plan = s.pending_plan_rpc_id.take();
+                let pending_perm = s.pending_permission_rpc_id.take();
+                s.pending_permission_options = None;
+                s.pending_permission_tool_name = None;
                 let was_busy = s.fsm.state() == SessionState::Streaming
                     || s.fsm.state() == SessionState::AwaitingPermission
                     || s.streaming_message_id.is_some()
                     || !s.open_tool_ids.is_empty()
                     || s.prompt_in_flight
                     || pending_ask.is_some()
-                    || pending_plan.is_some();
+                    || pending_plan.is_some()
+                    || pending_perm.is_some();
                 // Journal a cancel marker so UI history is not left as user-only silence.
                 if was_busy {
                     // Shared helper: durable chip + live emit (history matches live).
@@ -814,6 +812,7 @@ impl SessionManager {
                     s.meta.agent_session_id.clone(),
                     pending_ask,
                     pending_plan,
+                    pending_perm,
                 )
             })
             .ok_or("no active session")?;
@@ -866,6 +865,24 @@ impl SessionManager {
                     tracing::warn!("stop: cancel plan id={id} failed: {e}");
                 }
             }
+            if let Some(id) = pending_perm {
+                if let Err(e) = acp
+                    .respond_permission(id, PermissionOutcome::Cancelled)
+                    .await
+                {
+                    tracing::warn!("stop: cancel permission id={id} failed: {e}");
+                }
+                let _ = app.emit(
+                    "session://permissions_invalidated",
+                    serde_json::json!({
+                        "reason": "user_stop",
+                        "gates": [{
+                            "sessionId": target,
+                            "rpcId": id,
+                        }],
+                    }),
+                );
+            }
             // Target the session explicitly (shared process safety).
             if let Err(e) = match agent_sid {
                 Some(ref sid) => acp.cancel_for(sid).await,
@@ -878,6 +895,7 @@ impl SessionManager {
                 );
             }
         }
+        self.flush_pending_soft_respawn(&app, &target).await;
         Ok(stopped_snap)
     }
 }

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -153,6 +153,7 @@ import {
   clearPriorTurnStreaming,
   isSessionLiveStreaming,
   isSessionNotLiveError,
+  isTurnCancelledError,
   preferSessionMessages,
   presentErrorBanner,
   snapshotOutgoingMessages,
@@ -7836,6 +7837,33 @@ export function AppWorkbench() {
       try {
         await api.sessionSend(agentText, storedDisplay, sessionId, att);
       } catch (sendErr) {
+        // Stop / stall during Host vision/prepare: prompt never left.
+        // Do not retry and do not treat as CONNECT_FAILED (P0-2).
+        if (isTurnCancelledError(sendErr)) {
+          // Journal already has the user row; drop only the empty assistant shell.
+          if (sendTargetId) {
+            patchSessionMessages(sendTargetId, (m) =>
+              m.filter((x) => x.id !== pendingAssistantId),
+            );
+          } else if (viewingTarget()) {
+            setMessages((m) => m.filter((x) => x.id !== pendingAssistantId));
+          }
+          if (viewingTarget()) {
+            setSession((prev) =>
+              prev.state === "streaming"
+                ? { ...prev, state: prev.sessionId ? "ready" : prev.state }
+                : prev,
+            );
+          }
+          setLiveMap((prev) =>
+            projectHostIntoLiveMap(prev, {
+              sessionId,
+              state: "ready",
+              streamingMessageId: null,
+            }),
+          );
+          return true;
+        }
         // Host refuses rather than misroute when the chat lost its process
         // (idle recycle / crash while `liveHost` still looked ready).
         // Cold-connect that chat once, then retry the same turn.
@@ -8030,13 +8058,12 @@ export function AppWorkbench() {
       return;
     }
 
-    clearComposerAfterSubmit(clearDraftOpts);
-    await executeSend({
+    const sent = await executeSend({
       storedDisplay,
       att,
       goalMode,
-      targetSessionId: session.sessionId,
     });
+    if (sent) clearComposerAfterSubmit(clearDraftOpts);
   };
   sendRef.current = send;
   voiceDictationAutoSendRef.current = voiceDictationAutoSend;
@@ -21541,7 +21568,6 @@ export function AppWorkbench() {
                   storedDisplay: prompt,
                   att: [],
                   goalMode: false,
-                  targetSessionId: session.sessionId,
                 });
               }
             : undefined

--- a/src/lib/grokCatalog.test.ts
+++ b/src/lib/grokCatalog.test.ts
@@ -209,6 +209,18 @@ describe("effort UI ladder", () => {
     );
   });
 
+  it("prefers xhigh over max for 极高 when a 4-tier catalog lists both (#598)", () => {
+    const dual: EffortOption[] = [
+      { id: "low" },
+      { id: "medium" },
+      { id: "high" },
+      { id: "xhigh" },
+      { id: "max" },
+    ];
+    const opts = effortUiOptionsForCatalog(dual);
+    expect(opts.find((o) => o.uiId === "xhigh")?.spawnId).toBe("xhigh");
+  });
+
   it("orders DeepSeek as 低/中/高/极高 with real spawn ids", () => {
     const opts = effortUiOptionsForCatalog(deepseek);
     expect(opts.map((o) => o.uiId)).toEqual([

--- a/src/lib/grokCatalog.ts
+++ b/src/lib/grokCatalog.ts
@@ -329,7 +329,9 @@ function spawnMapForCatalog(
       low: byLower.get("low"),
       medium: byLower.get("medium"),
       high: byLower.get("high"),
-      xhigh: byLower.get("max") ?? byLower.get("xhigh"),
+      // Official grok-4.6 极高 is `xhigh`. Prefer it when both xhigh and
+      // max appear (CLI cache has dual defaults) — `max` is ignored (#598).
+      xhigh: byLower.get("xhigh") ?? byLower.get("max"),
     };
   }
   if (kind === "deepseek4") {

--- a/src/lib/permissionOptions.test.ts
+++ b/src/lib/permissionOptions.test.ts
@@ -81,6 +81,33 @@ describe("mapPermissionButtons (shipped)", () => {
     );
     expect(buttons[0]!.label).toBe("Allow once");
   });
+
+  it("does not bind session chip to reject-always via name", () => {
+    const buttons = mapPermissionButtons([
+      { optionId: "allow-once", kind: "allow_once" },
+      {
+        optionId: "reject-always",
+        kind: "reject_always",
+        name: "Reject always for this session",
+      },
+    ]);
+    expect(buttons[1]!.decision).toBe("allow_session");
+    expect(buttons[1]!.optionId).not.toBe("reject-always");
+    expect(buttons[1]!.optionId).toBe("allow-once");
+  });
+
+  it("session-allow on write/edit lists uses allow-once wire id (#600)", () => {
+    const buttons = mapPermissionButtons(
+      [
+        { optionId: "allow-once", kind: "allow_once" },
+        { optionId: "reject-once", kind: "reject_once" },
+      ],
+      undefined,
+      "search_replace",
+    );
+    expect(buttons[1]!.decision).toBe("allow_session");
+    expect(buttons[1]!.optionId).toBe("allow-once");
+  });
 });
 
 describe("fallbackSessionOptionId", () => {
@@ -90,7 +117,10 @@ describe("fallbackSessionOptionId", () => {
     );
     expect(fallbackSessionOptionId("web_fetch")).toBe("allow-always-domain");
     expect(fallbackSessionOptionId("mcp_foo")).toBe("allow-always-mcp");
-    expect(fallbackSessionOptionId("read_file")).toBe("always-allow");
+    expect(fallbackSessionOptionId("read_file")).toBe("allow-always");
+    expect(fallbackSessionOptionId("write")).toBe("allow-always");
+    expect(fallbackSessionOptionId("search_replace")).toBe("allow-always");
+    expect(fallbackSessionOptionId("unknown_tool")).toBe("always-allow");
   });
 });
 

--- a/src/lib/permissionOptions.ts
+++ b/src/lib/permissionOptions.ts
@@ -2,6 +2,7 @@
 
 export interface AcpPermissionOption {
   optionId?: string;
+  option_id?: string;
   id?: string;
   name?: string;
   label?: string;
@@ -49,7 +50,7 @@ export interface MappedPermButton {
 }
 
 function oid(o: AcpPermissionOption): string {
-  return o.optionId || o.id || "";
+  return o.optionId || o.option_id || o.id || "";
 }
 
 function kindOf(o: AcpPermissionOption): string {
@@ -100,6 +101,16 @@ export function fallbackSessionOptionId(toolName?: string | null): string {
   ) {
     return "allow-always-mcp";
   }
+  if (
+    t.includes("write") ||
+    t.includes("edit") ||
+    t.includes("replace") ||
+    t.includes("image") ||
+    t === "read_file" ||
+    t === "read-file"
+  ) {
+    return "allow-always";
+  }
   return "always-allow";
 }
 
@@ -143,14 +154,16 @@ export function mapPermissionButtons(
         id.startsWith("allow_always_")
       );
     }) ||
-    find(
-      (o) =>
-        nameOf(o).includes("always") ||
-        nameOf(o).includes("session") ||
-        // CLI bash copy: "don't ask again for bash commands"
-        (nameOf(o).includes("don't ask again") && nameOf(o).includes("bash")) ||
-        (nameOf(o).includes("dont ask again") && nameOf(o).includes("bash")),
-    );
+    find((o) => {
+      const n = nameOf(o);
+      if (n.includes("reject") || n.includes("deny")) return false;
+      return (
+        (n.includes("allow") && n.includes("always")) ||
+        (n.includes("allow") && n.includes("session")) ||
+        (n.includes("don't ask again") && n.includes("bash")) ||
+        (n.includes("dont ask again") && n.includes("bash"))
+      );
+    });
 
   const reject =
     find((o) => kindOf(o) === "reject_once" || kindOf(o) === "reject_always") ||
@@ -193,6 +206,15 @@ export function mapPermissionButtons(
     out.push({
       decision: "allow_session",
       optionId: oid(always),
+      label: L.allowSession,
+    });
+  } else if (arr.length > 0 && once && oid(once)) {
+    // #600: listed tools without a session-scoped option (write/edit)
+    // still show "Allow for session" (Host caches scope) but the wire
+    // id must be a published option — inventing always-allow cancels.
+    out.push({
+      decision: "allow_session",
+      optionId: oid(once),
       label: L.allowSession,
     });
   } else {

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -20,6 +20,7 @@ import {
   isSessionBusy,
   isSessionLiveStreaming,
   isSessionNotLiveError,
+  isTurnCancelledError,
   parseCompactContent,
   parseToolStepContent,
   pickLatestTurnTool,
@@ -112,6 +113,28 @@ describe("session projection", () => {
     expect(isSessionNotLiveError("PROCESS_LIMIT: pool full")).toBe(false);
     expect(isSessionNotLiveError(null)).toBe(false);
     expect(isSessionNotLiveError(undefined)).toBe(false);
+    expect(
+      isSessionNotLiveError(
+        "TURN_CANCELLED: turn x no longer active after prepare; prompt not dispatched",
+      ),
+    ).toBe(false);
+  });
+
+  it("isTurnCancelledError matches Host skip-prompt after Stop/stall", () => {
+    expect(
+      isTurnCancelledError(
+        "TURN_CANCELLED: turn x no longer active after prepare; prompt not dispatched",
+      ),
+    ).toBe(true);
+    expect(
+      isTurnCancelledError({
+        message:
+          "TURN_CANCELLED: turn x no longer active after prepare; prompt not dispatched",
+      }),
+    ).toBe(true);
+    expect(isTurnCancelledError("CONNECT_FAILED: no live agent process")).toBe(
+      false,
+    );
   });
 
   it("truncateBeforeLastUser drops last user turn and everything after", () => {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1889,6 +1889,20 @@ export function isSessionNotLiveError(err: unknown): boolean {
   );
 }
 
+/**
+ * Host skipped `session/prompt` because Stop / stall cleared the turn during
+ * Host vision / prepare. Not a send failure — the prompt was never dispatched.
+ */
+export function isTurnCancelledError(err: unknown): boolean {
+  const text =
+    typeof err === "string"
+      ? err
+      : err && typeof err === "object"
+        ? String((err as { message?: unknown }).message ?? err)
+        : String(err);
+  return text.includes("TURN_CANCELLED");
+}
+
 /** Host / UI “in progress” — sidebar spinner and cache preference. */
 export function isSessionBusy(state: SessionState): boolean {
   return (


### PR DESCRIPTION
## Summary

Remediation of the agent core interaction audit plus the two open bugs.

- **#600** — 会话内允许 on write/edit tools no longer sends an unpublished `always-allow` / word-order mismatch. Host answers with a listed id (`allow-always` or `allow-once`) and still caches session allow.
- **#598** — Grok 4.6 Extra High now respawns after the turn (or cold-spawns on unpark) and prefers `xhigh` over `max` when both exist in the catalog.
- Stream crash/fail flushes the last coalesced tokens without faking Ready.
- Early `prompt_complete` no longer force-clears live tools or drops later chunks as load-replay.
- Shared-process prompt complete / idle clocks are per session.
- Stop/stall during Host prepare returns `TURN_CANCELLED` so scheduled tasks are not marked as run.
- Mid-turn YOLO / effort / proxy changes queue a soft-respawn instead of silently skipping.
- Media `grant_path` / `paths_classify` grant the exact file, not the parent directory.
- Stop cancels pending tool permission; resolve requires the pending `rpc_id`.
- Background turns honor provider `RetryState`.
- Composer draft stays until send succeeds; send follows the viewing chat.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest` — permissionOptions / session / grokCatalog (136)
- [x] `cargo test --lib` — permission / session_manager / path_scope / prompt_fallback
- [ ] CI on this PR

## Notes

Remaining audit P1/P2 (queue/connect_lock, single permission slot, GROK_HOME index, sanitize proxy death) are **not** in this PR. See `docs/plans/2026-08-13-agent-core-interaction-audit.md`.

Fixes #600
Fixes #598