### PR TITLE
fix(floating-menu): stop max-height feedback loop

### DIFF
--- a/src/lib/floatingMenu.ts
+++ b/src/lib/floatingMenu.ts
@@ -321,7 +321,6 @@ export function useFloatingMenu({
             ...next,
             top: idealTop,
             placeAbove: false,
-            maxHeight: Math.max(next.maxHeight, ph + 8),
           };
         } else {
           const maxH = Math.max(120, r.top - gap - margin);


### PR DESCRIPTION
## 问题

浮层位于触发器上方时，首次定位已经根据可用空间算出 `maxHeight`。面板挂载后又把当前渲染高度加 8px 回写为新的 `maxHeight`；`ResizeObserver` 会因尺寸变化再次触发定位，从而形成持续增长的反馈循环，表现为模型选择框底边反复闪烁。

## 修改

- 不再根据面板当前高度持续放大 `maxHeight`
- 保留首次定位根据视口空间计算出的高度上限
- 撤回之前固定 320px 宽度的方案，模型菜单继续使用原有自适应宽度
- 最终 diff 仅删除一行，无新增依赖

## 验证

- `pnpm test`：377 个测试文件、5424 项测试全部通过
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:mac-arm`
- 将构建结果安装到 `/Applications/Grok.app` 后，真实打开模型列表并连续采样 12 帧；菜单底边区域像素哈希完全一致，宽度保持原有窄版
