### PR TITLE
Add A3 regression tests for partial hunk accept isolation

### DIFF
--- a/src/lib/diffAccept.test.ts
+++ b/src/lib/diffAccept.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+﻿import { describe, expect, it } from "vitest";
 import {
   applyHunks,
   applySelectedHunks,
@@ -287,6 +287,69 @@ describe("resolveDiffAfterSource", () => {
         preferCache: true,
       }),
     ).toBe("CACHED_FULL");
+  });
+
+  describe("A3 regression: partial hunk accept does not corrupt other files' restorable cache", () => {
+    it("accepting hunk on file B does not overwrite file A's restorable cache", () => {
+      const cacheBefore = { "/proj/a.ts": "FULL_A_AFTER" };
+      const bDiffView = {
+        path: "/proj/b.ts",
+        afterText: "PARTIAL_B_AFTER_HUNK0",
+      };
+      const bAfter = resolveDiffAfterSource({
+        key: "/proj/b.ts",
+        diffView: bDiffView,
+        cache: cacheBefore,
+      });
+      expect(bAfter).toBe("PARTIAL_B_AFTER_HUNK0");
+      const cacheAfter = {
+        ...cacheBefore,
+        "/proj/b.ts": "FULL_B_AFTER",
+      };
+      const aAfter = resolveDiffAfterSource({
+        key: "/proj/a.ts",
+        diffView: bDiffView,
+        cache: cacheAfter,
+        preferCache: true,
+      });
+      expect(aAfter).toBe("FULL_A_AFTER");
+    });
+
+    it("A3: rebuildDiffViewAfterHunkAccept keeps full after in rebuilt view", () => {
+      const fullAfter = "A\nB\nC\nD\n";
+      const written = "A\nb\nc\nd\n";
+      const rebuilt = rebuildDiffViewAfterHunkAccept({
+        fileName: "f.txt",
+        written,
+        fullAfter,
+      });
+      expect(rebuilt.beforeText).toBe(written);
+      expect(rebuilt.afterText).toBe(fullAfter);
+      const remaining = parseUnifiedDiff(rebuilt.unified).hunks;
+      expect(remaining.length).toBe(3);
+      const composed = applySelectedHunks(written, remaining, [0, 1, 2]);
+      expect(composed.ok).toBe(true);
+      if (composed.ok) expect(composed.content).toBe(fullAfter);
+    });
+
+    it("A3: partial accept on file A does not contaminate cache entry for file B", () => {
+      const cacheBefore = { "/proj/b.ts": "FULL_B_AFTER" };
+      const aPartialAfter = "A_part1\nb\nc\nd\n";
+      const aAfter = resolveDiffAfterSource({
+        key: "/proj/a.ts",
+        diffView: { path: "/proj/a.ts", afterText: aPartialAfter },
+        cache: cacheBefore,
+      });
+      expect(aAfter).toBe(aPartialAfter);
+      const cacheAfter = { ...cacheBefore, "/proj/a.ts": aPartialAfter };
+      const bAfter = resolveDiffAfterSource({
+        key: "/proj/b.ts",
+        diffView: { path: "/proj/a.ts", afterText: aPartialAfter },
+        cache: cacheAfter,
+        preferCache: true,
+      });
+      expect(bAfter).toBe("FULL_B_AFTER");
+    });
   });
 });
 

--- a/src/lib/diffAccept.test.ts
+++ b/src/lib/diffAccept.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   applyHunks,
   applySelectedHunks,
@@ -326,8 +326,13 @@ describe("resolveDiffAfterSource", () => {
       expect(rebuilt.beforeText).toBe(written);
       expect(rebuilt.afterText).toBe(fullAfter);
       const remaining = parseUnifiedDiff(rebuilt.unified).hunks;
-      expect(remaining.length).toBe(3);
-      const composed = applySelectedHunks(written, remaining, [0, 1, 2]);
+      // Adjacent line edits coalesce into one unified hunk.
+      expect(remaining.length).toBeGreaterThan(0);
+      const composed = applySelectedHunks(
+        written,
+        remaining,
+        remaining.map((_, i) => i),
+      );
       expect(composed.ok).toBe(true);
       if (composed.ok) expect(composed.content).toBe(fullAfter);
     });


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [ ] I ran `pnpm typecheck` and `pnpm test`
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [ ] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [ ] No `window.confirm` / `prompt` / `alert` for product dialogs
- [ ] Docs / `docs/llm-wiki` updated if behavior changed
- [ ] No secrets (`secrets.json`, tokens, `auth.json`) included
