### PR TITLE
fix(mcp): discover OAuth from the selected server URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
+- **MCP authorize uses the selected server** (#605): Host OAuth discovery no longer tries ChatCut's well-known metadata first. Authorizing Appwrite (or any other remote MCP) opens that provider's consent screen, not `api.chatcut.io`. ChatCut still works — its metadata is derived from its own MCP URL. Loopback success page is generic (no longer says "ChatCut").
 - **Fork / connecting send queue**: A first message after fork (or during warm-connect) no longer parks in the follow-up queue. Handshake `connecting` is not a live turn — Send goes through `ensureConnected`. Queue **Steer** becomes **Send now** when no turn is running.
 - **Agent turn finish no longer drops the last stream batch**: Process crash / RPC fail now flushes the coalesced `session://stream` buffer and journal tail before clearing the live slot (answers no longer stop mid-sentence).
 - **Early `prompt_complete` no longer discards a silent long tool**: Host keeps the turn deferred while tools are still open instead of force-clearing them after 3s and treating later chunks as load-replay.
@@ -27,6 +28,7 @@ See `docs/llm-wiki/release.md`.
 - **cwd-relative downloads (`curl -O` / `wget` without `-o`) prompt** unless YOLO — no longer assumed to write inside the project.
 
 **中文 · 修复**
+- **MCP 授权跟所选服务器走**（#605）：OAuth 发现不再先打 ChatCut 的 well-known。给 Appwrite 等其它远程 MCP 点授权时，打开的是该服务商的登录页，而不是 `api.chatcut.io`。ChatCut 仍可用（从它自己的 MCP URL 推导元数据）。回环成功页不再写死 ChatCut。
 - **分叉后发不出消息**：预热连接中的 `connecting` 不再把第一条消息当成跟进入队。握手不是进行中的回合；发送走 `ensureConnected`。无回合时队列「引导」改为「立即发送」。
 - **回合结束不再丢掉最后一批流式字**：进程崩溃 / RPC 失败会先刷出合批缓冲和 journal 尾巴。
 - **提前 `prompt_complete` 不再丢掉仍在跑的静默工具**：不再 3 秒后强清 open tools，后续 chunk 也不会被当成 load-replay 丢掉。

--- a/docs/llm-wiki/chatcut.md
+++ b/docs/llm-wiki/chatcut.md
@@ -32,6 +32,8 @@ Do **not** invent a `grok` surface value without upstream support — tools will
 
 ## OAuth lifetime (Host responsibility)
 
+Discovery of the authorization server is **per MCP URL** (RFC 9728 well-known on that origin). Do **not** fall back to ChatCut’s well-known endpoint for other servers — that sends Appwrite (and every other remote MCP) to `api.chatcut.io` (#605).
+
 ChatCut’s AS issues **short-lived access tokens** (`expires_in` ≈ 3600s) plus a **`refresh_token`** when scope includes `offline_access`. The official plugin does **not** refresh; Codex does (Keychain + silent refresh). Grok App Host must:
 
 1. Persist `access_token` + `refresh_token` + `client_id` + `token_endpoint` in `mcp_credentials.json` (agent-home and `~/.grok`, mode `0600`).

--- a/src-tauri/src/mcp_oauth.rs
+++ b/src-tauri/src/mcp_oauth.rs
@@ -439,39 +439,34 @@ fn urlencoding_encode(s: &str) -> String {
     out
 }
 
+/// RFC 9728 well-known metadata URLs derived **only** from this MCP endpoint.
+/// Never prepend a third-party (ChatCut) URL — that would authorize the wrong
+/// provider for every other remote MCP (#605).
+fn protected_resource_meta_urls(mcp_url: &str) -> Vec<String> {
+    let mcp_url = mcp_url.trim().trim_end_matches('/');
+    let Ok(u) = reqwest::Url::parse(mcp_url) else {
+        return Vec::new();
+    };
+    let Some(host) = u.host_str().filter(|h| !h.is_empty()) else {
+        return Vec::new();
+    };
+    let origin = format!("{}://{}", u.scheme(), host);
+    let path = u.path().trim_start_matches('/');
+    let mut urls = Vec::new();
+    if !path.is_empty() {
+        urls.push(format!(
+            "{origin}/.well-known/oauth-protected-resource/{path}"
+        ));
+    }
+    urls.push(format!("{origin}/.well-known/oauth-protected-resource"));
+    urls
+}
+
 fn discover_for_mcp_url(
     mcp_url: &str,
 ) -> Result<(ProtectedResourceMeta, AuthServerMeta, String), String> {
     let mcp_url = mcp_url.trim().trim_end_matches('/');
-    // RFC 9728 style path under well-known
-    let resource_meta_urls = [
-        format!("https://api.chatcut.io/.well-known/oauth-protected-resource/api/external-mcp/mcp"),
-        // Generic: origin + /.well-known/oauth-protected-resource + path
-        {
-            if let Ok(u) = reqwest::Url::parse(mcp_url) {
-                let origin = format!("{}://{}", u.scheme(), u.host_str().unwrap_or(""));
-                let path = u.path().trim_start_matches('/');
-                if path.is_empty() {
-                    format!("{origin}/.well-known/oauth-protected-resource")
-                } else {
-                    format!("{origin}/.well-known/oauth-protected-resource/{path}")
-                }
-            } else {
-                String::new()
-            }
-        },
-        {
-            if let Ok(u) = reqwest::Url::parse(mcp_url) {
-                format!(
-                    "{}://{}/.well-known/oauth-protected-resource",
-                    u.scheme(),
-                    u.host_str().unwrap_or("")
-                )
-            } else {
-                String::new()
-            }
-        },
-    ];
+    let resource_meta_urls = protected_resource_meta_urls(mcp_url);
 
     let mut pr: Option<ProtectedResourceMeta> = None;
     for u in &resource_meta_urls {
@@ -561,7 +556,7 @@ fn wait_for_code(listener: TcpListener, expect_state: &str) -> Result<String, St
         }
     }
     let body = if code.is_some() {
-        "<html><body><h2>ChatCut authorization complete</h2><p>You can close this tab and return to Grok App.</p></body></html>"
+        "<html><body><h2>Authorization complete</h2><p>You can close this tab and return to Grok App.</p></body></html>"
     } else {
         "<html><body><h2>Authorization failed</h2><p>Return to Grok App and retry.</p></body></html>"
     };
@@ -1282,5 +1277,40 @@ mod tests {
             s2.resource.as_deref(),
             Some("https://api.chatcut.io/api/external-mcp/mcp")
         );
+    }
+
+    #[test]
+    fn protected_resource_meta_urls_follow_mcp_origin_not_chatcut() {
+        let urls = protected_resource_meta_urls("https://mcp.appwrite.io/mcp");
+        assert!(!urls.is_empty());
+        assert!(
+            urls.iter()
+                .all(|u| !u.to_ascii_lowercase().contains("chatcut")),
+            "non-ChatCut MCP must not probe ChatCut metadata: {urls:?}"
+        );
+        assert_eq!(
+            urls[0],
+            "https://mcp.appwrite.io/.well-known/oauth-protected-resource/mcp"
+        );
+        assert_eq!(
+            urls[1],
+            "https://mcp.appwrite.io/.well-known/oauth-protected-resource"
+        );
+    }
+
+    #[test]
+    fn protected_resource_meta_urls_chatcut_still_derives_from_own_url() {
+        let urls = protected_resource_meta_urls("https://api.chatcut.io/api/external-mcp/mcp/");
+        assert_eq!(
+            urls[0],
+            "https://api.chatcut.io/.well-known/oauth-protected-resource/api/external-mcp/mcp"
+        );
+        assert!(urls.iter().all(|u| u.contains("api.chatcut.io")));
+    }
+
+    #[test]
+    fn protected_resource_meta_urls_rejects_garbage() {
+        assert!(protected_resource_meta_urls("not a url").is_empty());
+        assert!(protected_resource_meta_urls("").is_empty());
     }
 }


### PR DESCRIPTION
## Summary
Fixes #605 — authorizing a non-ChatCut MCP (e.g. Appwrite) opened ChatCut's consent screen.

Host `discover_for_mcp_url` always probed `api.chatcut.io/.well-known/oauth-protected-resource/…` first. The first successful fetch won, so every remote MCP that needs OAuth inherited ChatCut's authorization server.

- Derive RFC 9728 well-known URLs only from the selected server's MCP URL.
- ChatCut still works: its metadata is derived from its own URL.
- Loopback success page is generic (no longer says "ChatCut").
- Wiki note: discovery is per-MCP-URL; never a ChatCut-first fallback.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `cargo test --lib mcp_oauth` (7 passed, including 3 new URL-derivation tests)
- [ ] I ran `pnpm typecheck` and `pnpm test` (Rust-only change)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new App UI strings
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included