### PR TITLE
fix(chat): show copy/export/regenerate actions for user-stopped (cancelled) turns

### DIFF
--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -808,6 +808,72 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
   ) {
     return wrap(
       <EndOfTurnChip key={m.id} message={m} locale={locale} />,
+      // Show bottom actions (copy, export MD, regenerate) for cancelled turns so the user can still use them after stopping the request.
+      ( () => {
+        const showCopy = !!m.content.trim();
+        const showRegen = !!onRegenerateAssistant && regenerableAssistantId === m.id;
+        if (!showCopy && !showRegen) return null;
+        const deepLink =
+          sessionId != null
+            ? formatMessageDeepLink(sessionId, m.id)
+            : "";
+        const showCopyLink = !!deepLink;
+        if (!showCopy && !showRegen && !showCopyLink) return null;
+        return (
+          <>
+            {showCopy ? (
+              <>
+                <MessageCopyButton
+                  text={m.content}
+                  copyLabel={tr("message.copy")}
+                  copiedLabel={tr("message.copied")}
+                />
+                <MessageActionButton
+                  label={tr("message.exportMd")}
+                  onClick={() => {
+                    const blob = new Blob([m.content], {
+                      type: "text/markdown;charset=utf-8",
+                    });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement("a");
+                    a.href = url;
+                    a.download = `grok-${m.id.slice(0, 8)}.md`;
+                    a.click();
+                    URL.revokeObjectURL(url);
+                  }}
+                >
+                  <IconExportMd size={15} />
+                </MessageActionButton>
+              </>
+            ) : null}
+            {showCopyLink ? (
+              <MessageCopyButton
+                text={deepLink}
+                copyLabel={tr("message.copyLink")}
+                copiedLabel={tr("message.linkCopied")}
+                idleIcon={<IconLink size={15} />}
+              />
+            ) : null}
+            {showRegen ? (
+              <MessageRegenerateButton
+                label={tr("message.regenerate")}
+                sameModelLabel={tr("message.regenerateSameModel")}
+                pickModelLabel={tr("message.regeneratePickModel")}
+                disabled={!canRegenerate}
+                models={regenerateModels}
+                currentModelId={regenerateModelId}
+                onRegenerate={(modelId) => {
+                  if (!canRegenerate) return;
+                  onRegenerateAssistant?.(
+                    m,
+                    modelId ? { modelId } : undefined,
+                  );
+                }}
+              />
+            ) : null}
+          </>
+        );
+      })()
     );
   }
 


### PR DESCRIPTION
## Summary

When a request is manually stopped by the user (turn cancelled), the bottom action bar (copy, export MD, regenerate, copy link) was sometimes not rendered, so the user could not copy or regenerate the partial reply after stopping.

This PR renders the same bottom actions below the `EndOfTurnChip` for cancelled turns, matching the behavior of completed turns.

## 中文说明

用户手动停止请求后（turn_cancelled），底部操作栏（复制、导出 MD、重新生成、复制链接）有时不显示，导致停止后无法复制或重新生成部分回复。

本 PR 在 `EndOfTurnChip` 下方为被取消的 turn 渲染与正常完成 turn 一致的底部操作。

## Changes

- `src/components/lobe-chat/ConversationThread.tsx`: render copy / export MD / copy-link / regenerate actions for `turn_cancelled` markers when content or a regenerate target exists.

## Verification

- No new tests; logic mirrors the existing completed-turn branch.
- Local typecheck passed.
