### PR TITLE
fix(i18n): English token counts use K/M/B (#613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- **English token units (#613)**: Context-window chip, composer model menu, phone tools sheet, heatmap, and account call-log counts use **K / M / B** when locale is `en` (e.g. `500K`, `1M`) instead of Chinese 百/千/万. zh / zh-TW still use 万·萬 / 亿·億.
+
+**中文 · 修复**
+- **英文 Token 单位 (#613)**：界面语言为英文时，上下文芯片、模型菜单、热力图与通话记录显示 **K / M / B**，不再混用「万 / 千 / 百」。简体/繁体仍用中文计数单位。
+
 ## [0.2.18] - 2026-08-14
 
 > **Highlight:** TUI-parity Usage limit (`/usage`, `/cost`) with this-session spend plus heatmap Tokens / Cumulative stats; long image and tool turns no longer die at 4 hours; Windows Settings Agent tab no longer flashes a black console; chat image cards survive remount.

--- a/docs/llm-wiki/i18n.md
+++ b/docs/llm-wiki/i18n.md
@@ -34,6 +34,7 @@
 | `resolveLocale("system")` | maps `navigator.language` / OS → `en` \| `zh` \| `zh-TW` |
 | Tray unknown locale | English |
 | Settings language dropdown | **System** first, then English / 简体 / 繁體 |
+| Compact counts (`formatTokenCount` / `formatLocaleCount`) | `en` → K/M/B (`500K`); `zh` → 万/千/百; `zh-TW` → 萬/億. Never hard-code 万 on the English path. |
 
 ## Follow system
 

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -20506,6 +20506,7 @@ export function AppWorkbench() {
                       </Tip>
                     ) : null}
                     <ComposerModelMenu
+                      locale={locale}
                       modelId={modelId}
                       effort={effort}
                       models={availableModels}
@@ -20823,6 +20824,7 @@ export function AppWorkbench() {
       {phoneLayout ? (
         <>
           <PhoneComposerToolsSheet
+            locale={locale}
             open={phoneToolsOpen}
             onClose={() => setPhoneToolsOpen(false)}
             labels={{

--- a/src/components/AccountPanel.tsx
+++ b/src/components/AccountPanel.tsx
@@ -11,8 +11,8 @@ import type { AccountStatus, SavedAccount } from "@/lib/api";
 import {
   accountDisplayName,
   accountInitials,
-  formatChineseCount,
   formatCompactNumber,
+  formatLocaleCount,
   formatDuration,
   formatQuotaResetTime,
   formatRelativeTime,
@@ -320,7 +320,7 @@ export function AccountPanel({
     () => summarizeHeatmapStats(heatDays, status?.callLogs),
     [heatDays, status?.callLogs],
   );
-  const locCount = locale === "zh-TW" ? "zh-TW" : "zh";
+  const locCount = locale;
   const statDays = (n: number | null) =>
     n == null
       ? "—"
@@ -988,7 +988,7 @@ export function AccountPanel({
                   }
                 >
                   <span className="account-heat-stat__value">
-                    {formatChineseCount(heatStats.totalTokens, locCount)}
+                    {formatLocaleCount(heatStats.totalTokens, locCount)}
                   </span>
                   <span className="account-heat-stat__label">
                     {t("account.heatmap.stat.total")}
@@ -999,7 +999,7 @@ export function AccountPanel({
                   title={heatStats.peakDate ?? undefined}
                 >
                   <span className="account-heat-stat__value">
-                    {formatChineseCount(heatStats.peakTokens, locCount)}
+                    {formatLocaleCount(heatStats.peakTokens, locCount)}
                   </span>
                   <span className="account-heat-stat__label">
                     {t("account.heatmap.stat.peak")}
@@ -1127,14 +1127,14 @@ export function AccountPanel({
                         {row.usageTokens != null && row.usageTokens > 0
                           ? formatCompactNumber(
                               row.usageTokens,
-                              locale === "zh-TW" ? "zh-TW" : "zh",
+                              locale,
                             )
                           : "—"}
                       </span>
                       <span>
                         {formatCompactNumber(
                           row.contextTokens,
-                          locale === "zh-TW" ? "zh-TW" : "zh",
+                          locale,
                         )}
                       </span>
                       <span>{formatDuration(row.durationSecs)}</span>

--- a/src/components/ComposerModelMenu.tsx
+++ b/src/components/ComposerModelMenu.tsx
@@ -234,6 +234,8 @@ export interface ComposerModelMenuProps {
     contextWindowSave: string;
     contextWindowOfficialHint: string;
   };
+  /** Resolved UI locale — token window uses K/M (en) vs 万/千 (zh). */
+  locale?: string;
   /** Effective context window (tokens) for the active route. */
   contextWindow?: number | null;
   /** True for custom routes (editable); false for official (read-only). */
@@ -292,6 +294,7 @@ export function ComposerModelMenu({
   onModel,
   onEffort,
   applyNotes,
+  locale = "en",
   contextWindow = null,
   contextWindowEditable = false,
   onContextWindow,
@@ -470,7 +473,7 @@ export function ComposerModelMenu({
             <span>{labels.contextWindow}</span>
             <span className="cmm__row-val">
               <span className="cmm__row-val-text">
-                {contextWindow ? formatTokenCount(contextWindow) : "—"}
+                {contextWindow ? formatTokenCount(contextWindow, locale) : "—"}
               </span>
               <IconChevronRight size={14} />
             </span>
@@ -644,7 +647,7 @@ export function ComposerModelMenu({
                 <span className="cmm__opt-main">
                   <span className="cmm__opt-title">
                     {contextWindow
-                      ? formatTokenCount(contextWindow)
+                      ? formatTokenCount(contextWindow, locale)
                       : "—"}
                   </span>
                   <span className="cmm__opt-desc">

--- a/src/components/PhoneComposerToolsSheet.tsx
+++ b/src/components/PhoneComposerToolsSheet.tsx
@@ -123,6 +123,8 @@ export type PhoneComposerToolsSheetProps = {
   mode: string;
   policy: string;
   contextDisplay: ContextUsageDisplay;
+  /** Resolved UI locale — fallback token counts use K/M (en) vs 万/千 (zh). */
+  locale?: string;
   onAttach: () => void;
   onSelectProject: (project: PhoneProjectOption | null) => void;
   onAddProject: () => void;
@@ -226,6 +228,7 @@ export function PhoneComposerToolsSheet({
   mode,
   policy,
   contextDisplay,
+  locale = "en",
   onAttach,
   onSelectProject,
   onAddProject,
@@ -315,11 +318,11 @@ export function PhoneComposerToolsSheet({
 
   if (!open || typeof document === "undefined") return null;
 
-  // Prefer pre-resolved chip label (already locale-aware Chinese units).
+  // Prefer pre-resolved chip label (already locale-aware units).
   const contextValue =
     contextDisplay.tokens != null
       ? contextDisplay.label.replace(/^~/, "") ||
-        formatTokenCount(contextDisplay.tokens)
+        formatTokenCount(contextDisplay.tokens, locale)
       : labels.contextUnknown;
 
   const headerTitle =
@@ -615,7 +618,7 @@ export function PhoneComposerToolsSheet({
                   <div className="phone-sheet__info-row">
                     <span>{labels.contextWindow}</span>
                     <strong className="phone-sheet__nums">
-                      {formatTokenCount(contextDisplay.windowSize)}
+                      {formatTokenCount(contextDisplay.windowSize, locale)}
                     </strong>
                   </div>
                 ) : null}
@@ -661,7 +664,7 @@ export function PhoneComposerToolsSheet({
                         >
                           <span>{lab}</span>
                           <strong className="phone-sheet__nums">
-                            ~{formatTokenCount(tokens)}
+                            ~{formatTokenCount(tokens, locale)}
                           </strong>
                         </div>
                       );

--- a/src/lib/accountUi.test.ts
+++ b/src/lib/accountUi.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import {
   formatChineseCount,
+  formatCompactNumber,
+  formatLocaleCount,
   formatMessageTime,
   formatQuotaResetTime,
   formatRelativeTime,
@@ -217,8 +219,28 @@ describe("formatChineseCount", () => {
     expect(formatChineseCount(100_000_000, "zh-TW")).toBe("1億");
   });
 
+  it("stays on Chinese units even when locale is en", () => {
+    expect(formatChineseCount(12_500, "en")).toBe("1.3万");
+  });
+
   it("handles null / non-finite", () => {
     expect(formatChineseCount(null)).toBe("—");
     expect(formatChineseCount(Number.NaN)).toBe("—");
+  });
+});
+
+describe("formatLocaleCount / formatCompactNumber", () => {
+  it("uses K/M/B when locale is English", () => {
+    expect(formatLocaleCount(300, "en")).toBe("300");
+    expect(formatLocaleCount(12_500, "en")).toBe("12.5K");
+    expect(formatLocaleCount(500_000, "en")).toBe("500K");
+    expect(formatLocaleCount(1_000_000, "en")).toBe("1M");
+    expect(formatCompactNumber(12_500, "en")).toBe("12.5K");
+  });
+
+  it("keeps Chinese units for zh / zh-TW", () => {
+    expect(formatLocaleCount(12_500, "zh")).toBe("1.3万");
+    expect(formatLocaleCount(12_500, "zh-TW")).toBe("1.3萬");
+    expect(formatCompactNumber(12_500, "zh")).toBe("1.3万");
   });
 });

--- a/src/lib/accountUi.ts
+++ b/src/lib/accountUi.ts
@@ -6,6 +6,10 @@ import type {
   BillingSnapshot,
 } from "./api";
 import type { SuperGrokBrandKind } from "@/components/SuperGrokMark";
+import {
+  formatEnglishCompactCount,
+  usesChineseCountUnits,
+} from "./formatCompactCount";
 
 export function accountDisplayName(
   profile: AccountProfile,
@@ -192,14 +196,13 @@ export function usagePercent(billing: BillingSnapshot): number | null {
 
 /**
  * Compact counts for account / heatmap / call logs.
- * Always Chinese units (千 / 万 / 亿) — never English k/M.
- * Pass locale for 萬/億 (zh-TW) vs 万/亿.
+ * zh / zh-TW: 千 / 万·萬 / 亿·億. Other locales (incl. en): K / M / B.
  */
 export function formatCompactNumber(
   n: number | null | undefined,
   locale: string = "zh",
 ): string {
-  return formatChineseCount(n, locale);
+  return formatLocaleCount(n, locale);
 }
 
 /** Strip trailing `.0` from one-decimal compact forms (`1.0万` → `1万`). */
@@ -245,11 +248,15 @@ export function formatChineseCount(
   return `${sign}${abs.toFixed(1)}`;
 }
 
-/** Locale-aware compact number (Chinese units for all locales in this product). */
+/** Locale-aware compact number: K/M/B for en, 百/千/万 for zh. */
 export function formatLocaleCount(
   n: number | null | undefined,
   locale: string = "zh",
 ): string {
+  if (n == null || !Number.isFinite(n)) return "—";
+  if (!usesChineseCountUnits(locale)) {
+    return formatEnglishCompactCount(n);
+  }
   return formatChineseCount(n, locale);
 }
 

--- a/src/lib/contextUsage.test.ts
+++ b/src/lib/contextUsage.test.ts
@@ -62,6 +62,16 @@ describe("formatTokenCount", () => {
     expect(formatTokenCount(100_000_000, "zh-TW")).toBe("1億");
     expect(formatTokenCount(1_000_000, "zh-TW")).toBe("100萬");
   });
+
+  it("uses K/M/B for English (and other non-zh) locales", () => {
+    expect(formatTokenCount(300, "en")).toBe("300");
+    expect(formatTokenCount(5_000, "en")).toBe("5K");
+    expect(formatTokenCount(12_400, "en")).toBe("12.4K");
+    expect(formatTokenCount(500_000, "en")).toBe("500K");
+    expect(formatTokenCount(1_000_000, "en")).toBe("1M");
+    expect(formatTokenCount(1_500_000, "en-US")).toBe("1.5M");
+    expect(formatTokenCount(2_000_000_000, "en")).toBe("2B");
+  });
 });
 
 describe("formatContextChipLabel", () => {
@@ -70,6 +80,8 @@ describe("formatContextChipLabel", () => {
     expect(formatContextChipLabel(1200, "known")).toBe("1.2千");
     expect(formatContextChipLabel(1200, "estimated")).toBe("~1.2千");
     expect(formatContextChipLabel(12_000, "known", "zh-TW")).toBe("1.2萬");
+    expect(formatContextChipLabel(500_000, "known", "en")).toBe("500K");
+    expect(formatContextChipLabel(1200, "estimated", "en")).toBe("~1.2K");
   });
 });
 
@@ -748,7 +760,7 @@ describe("compact presets", () => {
         locale: "en",
         template: "{before} → {after}",
       }),
-    ).toBe("~1.2万 → ~4千");
+    ).toBe("~12K → ~4K");
     expect(
       formatCompactBeforeAfterRange(10_000, null, {
         beforeEstimated: false,

--- a/src/lib/contextUsage.ts
+++ b/src/lib/contextUsage.ts
@@ -24,6 +24,12 @@
  * - Zero estimated role buckets render as "—" (not "~0").
  */
 
+import {
+  formatEnglishCompactCount,
+  trimTrailingDotZero,
+  usesChineseCountUnits,
+} from "./formatCompactCount";
+
 export type ContextUsageSource = "known" | "estimated" | "unknown";
 
 export interface LastCompactSummary {
@@ -713,19 +719,18 @@ export function mergeKnownBucketsIntoBreakdown(
   };
 }
 
-/** Strip trailing `.0` from one-decimal forms (`1.0万` → `1万`). */
-function trimTrailingDotZero(s: string): string {
-  return s.endsWith(".0") ? s.slice(0, -2) : s;
-}
-
 /**
- * Compact token display — Chinese units only (百 / 千 / 万·萬 / 亿·億).
- * Never English k/M. Pass locale for 萬/億 (zh-TW) vs 万/亿.
- * Example: 500 → 5百 · 1500 → 1.5千 · 12500 → 1.3万 · 1e6 → 100万
+ * Compact token display.
+ * zh / zh-TW: 百 / 千 / 万·萬 / 亿·億. Other locales (incl. en): K / M / B.
+ * Example zh: 500 → 5百 · 1500 → 1.5千 · 12500 → 1.3万
+ * Example en: 300 → 300 · 5000 → 5K · 500000 → 500K · 1e6 → 1M
  */
 export function formatTokenCount(n: number, locale: string = "zh"): string {
   if (!Number.isFinite(n) || n < 0) return "—";
   const whole = Math.round(n);
+  if (!usesChineseCountUnits(locale)) {
+    return formatEnglishCompactCount(whole);
+  }
   const isTw =
     locale === "zh-TW" ||
     locale.toLowerCase() === "zh-hant" ||
@@ -960,7 +965,7 @@ export function cacheHitRate(usage: KnownUsageBreakdown | null): {
 
 /**
  * Resolve what the chip should show from reducer state + live messages.
- * `locale` selects 万/亿 vs 萬/億 (and 百/千) for the chip label.
+ * `locale` selects English K/M/B vs 万/亿 vs 萬/億 for the chip label.
  * `windowSize` is the effective context window (tokens) for the "% used" row;
  * null hides the percent row.
  */

--- a/src/lib/formatCompactCount.ts
+++ b/src/lib/formatCompactCount.ts
@@ -1,0 +1,29 @@
+/** Strip trailing `.0` from one-decimal compact forms (`1.0K` → `1K`). */
+export function trimTrailingDotZero(s: string): string {
+  return s.endsWith(".0") ? s.slice(0, -2) : s;
+}
+
+/** True for zh / zh-CN / zh-TW / zh-Hant… — CJK myriad units (百/千/万/亿). */
+export function usesChineseCountUnits(locale: string): boolean {
+  const v = locale.trim().toLowerCase().replace(/_/g, "-");
+  return v === "zh" || v.startsWith("zh-");
+}
+
+/**
+ * English compact count: K / M / B (not 百/千/万).
+ * Bands: ≥1e9 B, ≥1e6 M, ≥1e3 K, else integer.
+ */
+export function formatEnglishCompactCount(n: number): string {
+  const sign = n < 0 ? "-" : "";
+  const whole = Math.round(Math.abs(n));
+  if (whole >= 1_000_000_000) {
+    return `${sign}${trimTrailingDotZero((whole / 1_000_000_000).toFixed(1))}B`;
+  }
+  if (whole >= 1_000_000) {
+    return `${sign}${trimTrailingDotZero((whole / 1_000_000).toFixed(1))}M`;
+  }
+  if (whole >= 1_000) {
+    return `${sign}${trimTrailingDotZero((whole / 1_000).toFixed(1))}K`;
+  }
+  return `${sign}${whole}`;
+}


### PR DESCRIPTION
## Summary
English locale (`settings.locale = en`) was still rendering context-window and usage counts with Chinese myriad units (`50万`, `5千`). Product default language is English.

`formatTokenCount` / `formatLocaleCount` only switched 万 vs 萬. Non-zh locales now use **K / M / B** (`500K`, `1M`). zh / zh-TW keep 百/千/万·萬/亿·億.

Also stop forcing `zh` in Account heatmap/call-log formatters, and pass `locale` into Composer model menu + phone tools sheet.

Fixes #613

## Test plan
- [x] `pnpm exec vitest run src/lib/contextUsage.test.ts src/lib/accountUi.test.ts` (88 passed)
- [x] `pnpm exec eslint` on touched files
- [ ] Switch Settings language to English: context chip / model-menu window shows `500K` not `50万`
- [ ] Switch to 简体 / 繁體: still `50万` / `50萬`