### PR TITLE
fix(i18n): 首次安装跟随系统语言

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
+- **Follow system language on first launch**: New installs default `settings.locale` to **System**. Host reads macOS AppleLanguages / Windows UI language (not just `LANG=C`), so a Chinese OS opens in 简体/繁體. Existing installs that still have the factory `en` lift once to System (explicit 简体/繁體 stays). Boot splash and tray follow the same probe.
 - **English token units (#613)**: Context-window chip, composer model menu, phone tools sheet, heatmap, and account call-log counts use **K / M / B** when locale is `en` (e.g. `500K`, `1M`) instead of Chinese 百/千/万. zh / zh-TW still use 万·萬 / 亿·億.
 
 **中文 · 修复**
+- **首次安装跟随系统语言**：新安装默认「跟随系统」。Host 读取 macOS AppleLanguages / Windows 界面语言（不再只看经常为空的 `LANG`），中文系统会直接进入简体/繁体。旧安装里仍是出厂 `en` 的一次性改成跟随系统（用户已选的中文不变）。启动页与托盘同一套探测。
 - **英文 Token 单位 (#613)**：界面语言为英文时，上下文芯片、模型菜单、热力图与通话记录显示 **K / M / B**，不再混用「万 / 千 / 百」。简体/繁体仍用中文计数单位。
 
 ## [0.2.18] - 2026-08-14

--- a/docs/llm-wiki/i18n.md
+++ b/docs/llm-wiki/i18n.md
@@ -2,7 +2,9 @@
 
 **Rule:** User-visible UI strings must not be hard-coded. Use `t(locale, key)` / `createT(locale)`.
 
-**Product default locale is English (`en`).** Optional locales: `zh` (Simplified Chinese), `zh-TW` (Traditional Chinese). All three catalogs must share the same keys (`messages.test.ts` enforces this).
+**Catalog fallback is English (`en`).** Optional locales: `zh` (Simplified Chinese), `zh-TW` (Traditional Chinese). All three catalogs must share the same keys (`messages.test.ts` enforces this).
+
+**User preference default is `system`** (follow OS UI language). Chinese Windows / macOS / Linux installs must open in `zh` / `zh-TW` without a Settings visit. Unknown OS languages still fall back to English.
 
 ## Source locations
 
@@ -29,9 +31,9 @@
 
 | Layer | Default |
 |-------|---------|
-| `AppSettings.locale` | `"en"` (explicit; users may choose `"system"`) |
-| `resolveLocale(undefined)` | `"en"` |
-| `resolveLocale("system")` | maps `navigator.language` / OS → `en` \| `zh` \| `zh-TW` |
+| `AppSettings.locale` | `"system"` (follow OS; users may lock `en` / `zh` / `zh-TW`) |
+| `resolveLocale(undefined)` | follow system (unknown OS → `en`) |
+| `resolveLocale("system")` | maps Host OS tag / `navigator.language` → `en` \| `zh` \| `zh-TW` |
 | Tray unknown locale | English |
 | Settings language dropdown | **System** first, then English / 简体 / 繁體 |
 | Compact counts (`formatTokenCount` / `formatLocaleCount`) | `en` → K/M/B (`500K`); `zh` → 万/千/百; `zh-TW` → 萬/億. Never hard-code 万 on the English path. |
@@ -39,8 +41,9 @@
 ## Follow system
 
 - Preference value stored in `settings.locale` is the string `"system"` (not the resolved catalog id).
-- Frontend: `resolveLocaleFromSystem(langTag)` (pure) + `languagechange` while preference is system.
-- Tray: `Locale::from_lang_tag` / `from_system` via `LANG` / `LC_*` when preference is `"system"`.
+- Frontend: `resolveLocaleFromSystem(langTag)` (pure) + Host `__GROK_BOOT_OS_LANG__` + `navigator.languages` + `languagechange` while preference is system.
+- Tray / boot: `Locale::from_system` prefers macOS `AppleLanguages` / Windows UI LANGID, then POSIX `LANG` / `LC_*` (ignores `C` / `POSIX`).
+- One-shot: persisted factory `"en"` → `"system"` (`localeFollowSystemMigrated`). Explicit `zh` / `zh-TW` / `system` stay.
 
 ## Translation quality
 

--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
       }
     </style>
     <script>
-      // Apply Host-injected theme as early as possible (inline, before paint).
+      // Apply Host-injected theme + locale as early as possible (inline, before paint).
       (function () {
         try {
           var t = window.__GROK_BOOT_THEME__;
@@ -229,6 +229,48 @@
                 : "dark";
           }
           document.documentElement.setAttribute("data-theme", t);
+        } catch (e) {
+          /* ignore */
+        }
+        try {
+          var loc = window.__GROK_BOOT_LOCALE__;
+          if (loc !== "zh" && loc !== "zh-TW" && loc !== "en") {
+            var nav = String(
+              (navigator.languages && navigator.languages[0]) ||
+                navigator.language ||
+                "",
+            ).toLowerCase();
+            if (
+              nav.indexOf("zh") === 0 &&
+              (nav.indexOf("tw") >= 0 ||
+                nav.indexOf("hk") >= 0 ||
+                nav.indexOf("hant") >= 0 ||
+                nav.indexOf("mo") >= 0)
+            ) {
+              loc = "zh-TW";
+            } else if (nav.indexOf("zh") === 0) {
+              loc = "zh";
+            } else {
+              loc = "en";
+            }
+          }
+          var htmlLang =
+            loc === "zh" ? "zh-CN" : loc === "zh-TW" ? "zh-TW" : "en";
+          document.documentElement.setAttribute("lang", htmlLang);
+          var copy =
+            loc === "zh-TW"
+              ? { title: "歡迎使用 Grok", sub: "正在偵測 Grok Build…" }
+              : loc === "en"
+                ? { title: "Welcome to Grok", sub: "Checking Grok Build…" }
+                : { title: "欢迎使用 Grok", sub: "正在检测 Grok Build…" };
+          var applyCopy = function () {
+            var titleEl = document.querySelector(".boot-title");
+            var subEl = document.querySelector(".boot-subtitle");
+            if (titleEl) titleEl.textContent = copy.title;
+            if (subEl) subEl.textContent = copy.sub;
+          };
+          if (document.querySelector(".boot-title")) applyCopy();
+          else document.addEventListener("DOMContentLoaded", applyCopy);
         } catch (e) {
           /* ignore */
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -480,11 +480,23 @@ pub fn run() {
             } else {
                 main_cfg.center = true;
             }
-            // Concrete light|dark for boot shell + window chrome (from AppSettings.theme).
-            let boot_theme = resolve_boot_theme(&store::load_settings().theme);
+            // Concrete light|dark + locale for boot shell + window chrome.
+            let boot_settings = store::load_settings();
+            let boot_theme = resolve_boot_theme(&boot_settings.theme);
+            let boot_locale = tray_i18n::Locale::parse(&boot_settings.locale);
+            let boot_locale_tag = boot_locale.as_tag();
+            let boot_os_lang = tray_i18n::detect_os_lang_tag();
+            let boot_html_lang = match boot_locale_tag {
+                "zh" => "zh-CN",
+                "zh-TW" => "zh-TW",
+                _ => "en",
+            };
             let boot_theme_script = format!(
-                r#"(function(){{try{{Object.defineProperty(window,"__GROK_BOOT_THEME__",{{value:{theme:?},writable:false,configurable:false}});var d=document.documentElement;if(d)d.setAttribute("data-theme",{theme:?});}}catch(e){{}}}})();"#,
-                theme = boot_theme
+                r#"(function(){{try{{Object.defineProperty(window,"__GROK_BOOT_THEME__",{{value:{theme:?},writable:false,configurable:false}});Object.defineProperty(window,"__GROK_BOOT_LOCALE__",{{value:{locale:?},writable:false,configurable:false}});Object.defineProperty(window,"__GROK_BOOT_OS_LANG__",{{value:{os_lang:?},writable:false,configurable:false}});var d=document.documentElement;if(d){{d.setAttribute("data-theme",{theme:?});d.setAttribute("lang",{html_lang:?});}}}}catch(e){{}}}})();"#,
+                theme = boot_theme,
+                locale = boot_locale_tag,
+                os_lang = boot_os_lang,
+                html_lang = boot_html_lang
             );
             let window = tauri::WebviewWindowBuilder::from_config(app, &main_cfg)?
                 .visible(false)

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -189,7 +189,12 @@ pub struct SessionMeta {
 #[serde(rename_all = "camelCase")]
 pub struct AppSettings {
     pub theme: String,
+    #[serde(default = "default_locale")]
     pub locale: String,
+    /// One-shot: factory locale `en` → `system` so first-run follows OS language.
+    /// Missing field deserializes as false so existing installs migrate once.
+    #[serde(default)]
+    pub locale_follow_system_migrated: bool,
     pub session_data_mode: String,
     pub manual_cli_path: Option<String>,
     /// CLI launch backend: `native` (default) or `wsl` (Windows only — spawn via `wsl.exe`).
@@ -558,12 +563,17 @@ fn default_todo_gate_max_fires() -> u32 {
     crate::agent_todo_gate::DEFAULT_TODO_GATE_MAX_FIRES
 }
 
+fn default_locale() -> String {
+    "system".into()
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
             theme: "system".into(),
-            // Product default is English; users can switch to zh / zh-TW in Settings.
-            locale: "en".into(),
+            // Follow OS language (zh / zh-TW / en). Users can lock a catalog in Settings.
+            locale: default_locale(),
+            locale_follow_system_migrated: true,
             // Product default: share GROK_HOME (~/.grok) with terminal Grok Build CLI.
             // Existing installs keep whatever is already persisted in settings.json.
             session_data_mode: "shared".into(),
@@ -855,6 +865,21 @@ pub fn load_settings() -> AppSettings {
         s.official_effort_xhigh_rows_migrated = true;
         let _ = write_json(&settings_file(), &s);
     }
+    // One-time: factory UI locale `en` → `system` so Chinese (and other)
+    // OS languages apply on first launch / existing installs that never
+    // locked a language. Explicit zh / zh-TW / system stay.
+    if !s.locale_follow_system_migrated {
+        if let Some(next) = migrate_legacy_locale_default(Some(s.locale.as_str())) {
+            tracing::info!(
+                "settings migration: locale {:?} → {} (follow OS language)",
+                s.locale,
+                next
+            );
+            s.locale = next;
+        }
+        s.locale_follow_system_migrated = true;
+        let _ = write_json(&settings_file(), &s);
+    }
     // One-time: product workflows default off → on (CLI ≥0.2.111 / 1.0).
     // Only lifts false → true once; users who turn it off again stay off.
     if !s.workflows_default_migrated {
@@ -894,6 +919,16 @@ pub fn migrate_legacy_official_model_default(stored: Option<&str>) -> Option<Str
     match stored.map(str::trim).filter(|s| !s.is_empty()) {
         None => Some(DEFAULT_OFFICIAL_MODEL_ID.into()),
         Some("grok-4.5") => Some(DEFAULT_OFFICIAL_MODEL_ID.into()),
+        Some(_) => None,
+    }
+}
+
+/// One-shot: lift the old factory locale `"en"` (or empty) to `"system"`.
+/// Explicit `zh` / `zh-TW` / `system` / other catalog ids stay.
+pub fn migrate_legacy_locale_default(stored: Option<&str>) -> Option<String> {
+    match stored.map(str::trim).filter(|s| !s.is_empty()) {
+        None => Some("system".into()),
+        Some(v) if v.eq_ignore_ascii_case("en") => Some("system".into()),
         Some(_) => None,
     }
 }
@@ -2771,7 +2806,8 @@ mod tests {
         assert_eq!(s.session_data_mode, "shared");
         assert_eq!(s.permission_policy, "ask");
         assert_eq!(s.theme, "system");
-        assert_eq!(s.locale, "en");
+        assert_eq!(s.locale, "system");
+        assert!(s.locale_follow_system_migrated);
         assert_eq!(s.max_concurrent_agents, 8);
         assert_eq!(s.agent_idle_minutes, 30);
         assert_eq!(s.stream_stall_seconds, 600);
@@ -2895,6 +2931,36 @@ mod tests {
         assert_eq!(clamp_effort_for_model("grok-4.5", "xhigh"), "high");
         assert_eq!(clamp_effort_for_model("grok-4.6", "xhigh"), "xhigh");
         assert_eq!(clamp_effort_for_model("custom-relay", "xhigh"), "xhigh");
+    }
+
+    #[test]
+    fn migrate_legacy_locale_en_to_system() {
+        assert_eq!(
+            migrate_legacy_locale_default(Some("en")).as_deref(),
+            Some("system")
+        );
+        assert_eq!(
+            migrate_legacy_locale_default(Some("EN")).as_deref(),
+            Some("system")
+        );
+        assert_eq!(migrate_legacy_locale_default(Some("zh")), None);
+        assert_eq!(migrate_legacy_locale_default(Some("zh-TW")), None);
+        assert_eq!(migrate_legacy_locale_default(Some("system")), None);
+        assert_eq!(
+            migrate_legacy_locale_default(Some("")).as_deref(),
+            Some("system")
+        );
+        assert_eq!(
+            migrate_legacy_locale_default(None).as_deref(),
+            Some("system")
+        );
+    }
+
+    #[test]
+    fn legacy_json_locale_en_is_unmigrated() {
+        let s: AppSettings = serde_json::from_str(legacy_settings_json()).expect("deserialize");
+        assert_eq!(s.locale, "en");
+        assert!(!s.locale_follow_system_migrated);
     }
 
     #[test]

--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -23,15 +23,12 @@ impl Locale {
         }
     }
 
-    /// Best-effort map of OS language (LANG / LC_ALL / LC_MESSAGES) → catalog.
+    /// Best-effort map of OS UI language → catalog.
     /// Mirrors frontend `resolveLocaleFromSystem` for tray copy when preference
-    /// is `"system"`.
+    /// is `"system"`. Prefers the GUI language (AppleLanguages / Windows UI
+    /// LANGID) over POSIX `LANG=C` which Dock-launched apps often inherit.
     pub fn from_system() -> Self {
-        let tag = std::env::var("LC_ALL")
-            .or_else(|_| std::env::var("LC_MESSAGES"))
-            .or_else(|_| std::env::var("LANG"))
-            .unwrap_or_default();
-        Self::from_lang_tag(&tag)
+        Self::from_lang_tag(&detect_os_lang_tag())
     }
 
     /// Map a BCP-47 / POSIX language tag to a tray locale (pure; testable).
@@ -73,6 +70,137 @@ impl Locale {
             Locale::ZhTw => "zh-TW",
         }
     }
+}
+
+/// Raw OS UI language tag (`zh-CN`, `zh_TW`, `en-US`, …). Empty if unknown.
+pub fn detect_os_lang_tag() -> String {
+    if let Some(tag) = platform_ui_lang_tag() {
+        return tag;
+    }
+    posix_lang_tag().unwrap_or_default()
+}
+
+fn posix_lang_tag() -> Option<String> {
+    for key in ["LC_ALL", "LC_MESSAGES", "LANG"] {
+        if let Ok(v) = std::env::var(key) {
+            let t = v.trim();
+            if !t.is_empty() && !is_c_or_posix_locale(t) {
+                return Some(t.to_string());
+            }
+        }
+    }
+    None
+}
+
+pub fn is_c_or_posix_locale(raw: &str) -> bool {
+    let bare = raw
+        .trim()
+        .split('.')
+        .next()
+        .unwrap_or("")
+        .replace('_', "-")
+        .to_ascii_lowercase();
+    bare == "c" || bare == "posix"
+}
+
+/// First quoted token from `defaults read -g AppleLanguages` output.
+pub fn first_apple_languages_tag(raw: &str) -> Option<String> {
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let q = bytes[i];
+        if q == b'"' || q == b'\'' {
+            if let Some(end) = raw[i + 1..].find(q as char) {
+                let inner = raw[i + 1..i + 1 + end].trim();
+                if !inner.is_empty() {
+                    return Some(inner.to_string());
+                }
+                i += end + 2;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Map a Windows LANGID (GetUserDefaultUILanguage) to a BCP-47 tag.
+/// Unknown primary languages return `None` so callers can fall through.
+pub fn windows_langid_to_tag(id: u16) -> Option<&'static str> {
+    const LANG_CHINESE: u16 = 0x04;
+    const LANG_ENGLISH: u16 = 0x09;
+    let primary = id & 0x3ff;
+    let sub = id >> 10;
+    match primary {
+        LANG_CHINESE => match sub {
+            1 | 3 | 5 => Some("zh-TW"), // Traditional / HK / MO
+            _ => Some("zh-CN"),
+        },
+        LANG_ENGLISH => Some("en"),
+        _ => None,
+    }
+}
+
+fn platform_ui_lang_tag() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        return macos_ui_lang_tag();
+    }
+    #[cfg(windows)]
+    {
+        return windows_ui_lang_tag();
+    }
+    #[cfg(not(any(target_os = "macos", windows)))]
+    {
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_ui_lang_tag() -> Option<String> {
+    let langs = crate::process_util::command("defaults")
+        .args(["read", "-g", "AppleLanguages"])
+        .output();
+    if let Ok(o) = langs {
+        if o.status.success() {
+            let s = String::from_utf8_lossy(&o.stdout);
+            if let Some(tag) = first_apple_languages_tag(&s) {
+                return Some(tag);
+            }
+        }
+    }
+    let locale = crate::process_util::command("defaults")
+        .args(["read", "-g", "AppleLocale"])
+        .output();
+    if let Ok(o) = locale {
+        if o.status.success() {
+            let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if !s.is_empty() {
+                return Some(s);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn windows_ui_lang_tag() -> Option<String> {
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetUserDefaultUILanguage() -> u16;
+        fn GetUserDefaultLocaleName(lp_locale_name: *mut u16, cch_locale_name: i32) -> i32;
+    }
+    let id = unsafe { GetUserDefaultUILanguage() };
+    if let Some(tag) = windows_langid_to_tag(id) {
+        return Some(tag.to_string());
+    }
+    const LOCALE_NAME_MAX_LENGTH: usize = 85;
+    let mut buf = [0u16; LOCALE_NAME_MAX_LENGTH];
+    let n = unsafe { GetUserDefaultLocaleName(buf.as_mut_ptr(), buf.len() as i32) };
+    if n > 1 {
+        return String::from_utf16(&buf[..(n as usize - 1)]).ok();
+    }
+    None
 }
 
 /// Current app locale from durable settings.
@@ -189,6 +317,43 @@ mod tests {
         assert_eq!(Locale::parse("zh-TW"), Locale::ZhTw);
         assert_eq!(Locale::parse("zh-Hant"), Locale::ZhTw);
         assert_eq!(strings(Locale::ZhTw).settings, "設定…");
+    }
+
+    #[test]
+    fn first_apple_languages_tag_picks_preferred() {
+        let raw = r#"
+(
+    "zh-Hans-CN",
+    "en-US"
+)
+"#;
+        assert_eq!(
+            first_apple_languages_tag(raw).as_deref(),
+            Some("zh-Hans-CN")
+        );
+        assert_eq!(
+            first_apple_languages_tag(r#"("en-US")"#).as_deref(),
+            Some("en-US")
+        );
+        assert_eq!(first_apple_languages_tag(""), None);
+    }
+
+    #[test]
+    fn c_and_posix_locales_are_ignored() {
+        assert!(is_c_or_posix_locale("C"));
+        assert!(is_c_or_posix_locale("POSIX"));
+        assert!(is_c_or_posix_locale("C.UTF-8"));
+        assert!(!is_c_or_posix_locale("zh_CN.UTF-8"));
+        assert!(!is_c_or_posix_locale("en_US"));
+    }
+
+    #[test]
+    fn windows_langid_maps_chinese_ui() {
+        assert_eq!(windows_langid_to_tag(0x0804), Some("zh-CN"));
+        assert_eq!(windows_langid_to_tag(0x0404), Some("zh-TW"));
+        assert_eq!(windows_langid_to_tag(0x0C04), Some("zh-TW"));
+        assert_eq!(windows_langid_to_tag(0x0409), Some("en"));
+        assert_eq!(windows_langid_to_tag(0x0411), None); // Japanese — fall through
     }
 
     #[test]

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -344,9 +344,11 @@ import { deriveMirrorClientLinkStatus } from "@/lib/mirrorStatus";
 import {
   createT,
   parseLocalePreference,
+  htmlLangForLocale,
   resolveLocale,
   resolveLocaleFromSystem,
   resolveLocalePreference,
+  DEFAULT_LOCALE_PREFERENCE,
   type Locale,
   type LocalePreference
 } from "@/i18n";
@@ -2280,9 +2282,9 @@ export function AppWorkbench() {
   const clearPendingGatesRef = useRef(clearPendingGates);
   clearPendingGatesRef.current = clearPendingGates;
   const [localePreference, setLocalePreference] =
-    useState<LocalePreference>("en");
+    useState<LocalePreference>(DEFAULT_LOCALE_PREFERENCE);
   const [locale, setLocale] = useState<Locale>(() =>
-    resolveLocalePreference("en"),
+    resolveLocalePreference(DEFAULT_LOCALE_PREFERENCE),
   );
   const localeRef = useRef(locale);
   localeRef.current = locale;
@@ -2911,6 +2913,11 @@ export function AppWorkbench() {
     return () => window.removeEventListener(ZEN_MODE_CHANGE_EVENT, onChange);
   }, [setZenModeEnabled]);
 
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.lang = htmlLangForLocale(locale);
+  }, [locale]);
 
   // Follow OS / browser UI language when preference is "system".
   useEffect(() => {

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -123,7 +123,7 @@ export function GeneralSection() {
     keepTrayForSchedules,
     launchAtLogin,
     locale,
-    localePreference = "en",
+    localePreference = "system",
     maxAgentTurns = 0,
     memoryBrowserEpoch,
     setMemoryBrowserEpoch,

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -16,6 +16,9 @@ export { isLocale, messages };
 /** User preference: explicit catalog locale or follow OS / browser language. */
 export type LocalePreference = "system" | Locale;
 
+/** Factory / missing-settings preference — follow the OS language. */
+export const DEFAULT_LOCALE_PREFERENCE: LocalePreference = "system";
+
 export type Vars = Record<string, string | number | undefined | null>;
 
 function interpolate(template: string, vars?: Vars): string {
@@ -105,17 +108,66 @@ export function isLocalePreference(v: unknown): v is LocalePreference {
 
 /**
  * Parse a durable settings value into a {@link LocalePreference}.
- * Accepts `system`, canonical locales, and common aliases. Invalid → `en`.
+ * Accepts `system`, canonical locales, and common aliases.
+ * Missing / empty → follow system. Unrecognized ids → `en`.
  */
 export function parseLocalePreference(
   raw: string | null | undefined,
 ): LocalePreference {
-  if (raw == null) return "en";
+  if (raw == null) return DEFAULT_LOCALE_PREFERENCE;
   const trimmed = String(raw).trim();
-  if (!trimmed) return "en";
+  if (!trimmed) return DEFAULT_LOCALE_PREFERENCE;
   if (trimmed.toLowerCase() === "system") return "system";
   if (isLocale(trimmed)) return trimmed;
   return normalizeLocale(trimmed) ?? "en";
+}
+
+/**
+ * One-shot lift of the old factory default (`en`) to follow-system.
+ * Explicit `zh` / `zh-TW` / `system` stay. Callers still set the migrated flag.
+ */
+export function migrateLegacyLocaleDefault(
+  stored: string | null | undefined,
+): LocalePreference | null {
+  const trimmed = stored == null ? "" : String(stored).trim();
+  if (!trimmed || trimmed.toLowerCase() === "en") return "system";
+  return null;
+}
+
+/** `<html lang>` for a resolved catalog locale. */
+export function htmlLangForLocale(locale: Locale): string {
+  if (locale === "zh") return "zh-CN";
+  if (locale === "zh-TW") return "zh-TW";
+  return "en";
+}
+
+type BootWindow = {
+  __GROK_BOOT_OS_LANG__?: string;
+  navigator?: { language?: string; languages?: readonly string[] };
+};
+
+/** Host-injected OS tag, else `navigator.languages[0]` / `navigator.language`. */
+export function readSystemLangTag(): string | null {
+  const w =
+    typeof globalThis === "object"
+      ? ((globalThis as { window?: BootWindow }).window ??
+        (globalThis as BootWindow))
+      : undefined;
+  const boot = w?.__GROK_BOOT_OS_LANG__;
+  if (typeof boot === "string" && boot.trim()) return boot.trim();
+  const nav =
+    w?.navigator ??
+    (typeof navigator !== "undefined" ? navigator : undefined);
+  if (nav) {
+    const list = nav.languages;
+    if (Array.isArray(list) && typeof list[0] === "string" && list[0].trim()) {
+      return list[0];
+    }
+    if (typeof nav.language === "string" && nav.language.trim()) {
+      return nav.language;
+    }
+  }
+  return null;
 }
 
 /**
@@ -129,11 +181,7 @@ export function resolveLocalePreference(
 ): Locale {
   if (preference !== "system") return preference;
   const tag =
-    systemLangTag !== undefined
-      ? systemLangTag
-      : typeof navigator !== "undefined"
-        ? navigator.language
-        : null;
+    systemLangTag !== undefined ? systemLangTag : readSystemLangTag();
   return resolveLocaleFromSystem(tag);
 }
 
@@ -142,7 +190,7 @@ export function resolveLocalePreference(
  * `"system"` follows OS / browser language; explicit ids stay as-is.
  */
 export function resolveLocale(raw: string | undefined | null): Locale {
-  if (!raw) return "en";
+  if (!raw) return resolveLocalePreference(DEFAULT_LOCALE_PREFERENCE);
   if (raw.trim().toLowerCase() === "system") {
     return resolveLocalePreference("system");
   }

--- a/src/i18n/messages.test.ts
+++ b/src/i18n/messages.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   createT,
   messages,
+  htmlLangForLocale,
+  migrateLegacyLocaleDefault,
   parseLocalePreference,
+  readSystemLangTag,
   resolveLocale,
   resolveLocaleFromSystem,
   resolveLocalePreference,
@@ -128,8 +131,12 @@ describe("parseLocalePreference / resolveLocalePreference", () => {
     expect(parseLocalePreference("zh-cn")).toBe("zh");
     expect(parseLocalePreference("zh-hant")).toBe("zh-TW");
     expect(parseLocalePreference("fr")).toBe("en");
-    expect(parseLocalePreference("")).toBe("en");
-    expect(parseLocalePreference(undefined)).toBe("en");
+  });
+
+  it("treats a missing preference as follow-system", () => {
+    expect(parseLocalePreference("")).toBe("system");
+    expect(parseLocalePreference(undefined)).toBe("system");
+    expect(parseLocalePreference(null)).toBe("system");
   });
 
   it("resolves system preference via an explicit lang tag", () => {
@@ -143,5 +150,28 @@ describe("parseLocalePreference / resolveLocalePreference", () => {
     expect(resolveLocalePreference("zh", "en-US")).toBe("zh");
     expect(resolveLocalePreference("en", "zh-CN")).toBe("en");
     expect(resolveLocalePreference("zh-TW", "en")).toBe("zh-TW");
+  });
+
+  it("lifts the factory English default to follow-system once", () => {
+    expect(migrateLegacyLocaleDefault("en")).toBe("system");
+    expect(migrateLegacyLocaleDefault("EN")).toBe("system");
+    expect(migrateLegacyLocaleDefault("  en  ")).toBe("system");
+    expect(migrateLegacyLocaleDefault("zh")).toBeNull();
+    expect(migrateLegacyLocaleDefault("zh-TW")).toBeNull();
+    expect(migrateLegacyLocaleDefault("system")).toBeNull();
+  });
+
+  it("maps catalog locales to html lang tags", () => {
+    expect(htmlLangForLocale("zh")).toBe("zh-CN");
+    expect(htmlLangForLocale("zh-TW")).toBe("zh-TW");
+    expect(htmlLangForLocale("en")).toBe("en");
+  });
+
+  it("prefers Host boot OS lang over navigator when present", () => {
+    const g = globalThis as { window?: { __GROK_BOOT_OS_LANG__?: string } };
+    const prev = g.window;
+    g.window = { __GROK_BOOT_OS_LANG__: "zh-CN" };
+    expect(readSystemLangTag()).toBe("zh-CN");
+    g.window = prev;
   });
 });


### PR DESCRIPTION
## Summary
中文系统安装后界面默认是英文：`settings.locale` 出厂值写死 `en`，托盘/Host 又只看经常为 `C` 的 `LANG`。

- 新安装默认 **跟随系统**（`locale: system`）
- Host 优先读 macOS `AppleLanguages` / Windows UI LANGID，忽略 `LANG=C`
- 启动页、`<html lang>`、托盘与 React 首帧用同一套探测
- 旧安装里仍是出厂 `en` 的一次性迁到 `system`（已选的 简体/繁体不变）

This Mac 实测：`LANG=C.UTF-8` 但 `AppleLanguages = zh-Hans-CN` → 会进简体，不再被 `C` 打回英文。

## Test plan
- [x] `pnpm exec vitest run src/i18n/messages.test.ts` (22)
- [x] `cargo test --lib` locale / AppleLanguages / LANGID / default settings
- [ ] 中文 macOS / Windows 全新安装：启动页与设置向导为中文
- [ ] 设置 → 语言 显示「跟随系统」；可再锁 English / 简体 / 繁體
- [ ] 已手动选过 English 的用户：若 settings 里仍是出厂 `en`，更新后会跟系统；若要锁英文，再选一次 English