### PR TITLE
fix(session): skip set_mode after fork so parent chat can send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ See `docs/llm-wiki/release.md`.
 **中文 · 变更**
 - **README Gatekeeper 说明**：官方 Release 从 v0.2.19 起已签名并公证。`xattr` 仅留给 fork / 旧的未签名包。
 
+### Fixed
+- **Fork no longer pins the parent chat on 连接中**: After `_x.ai/session/fork` the CLI is still hydrating parent context. Post-open `session/set_mode` used to walk every agent-mode alias (`agent` / `default` / `code` / `normal` / `Agent`) at 45s each — ~4 minutes of handshake, no `session/prompt`, both the fork and the original chat stuck on Connecting / Thinking. Fork skips that nudge (spawn already has `--permission-mode`); any later `set_mode` transport timeout aborts the remaining aliases.
+
+**中文 · 修复**
+- **分叉后不再把原会话卡在「连接中」**：`session/fork` 之后 CLI 还在灌父会话。以前会连试 5 个 `session/set_mode` 别名，每个等 45 秒，握手约 4 分钟，消息发不出去，分叉和原会话一起停在连接中/思考中。分叉后不再做这次 nudge；之后若 `set_mode` 是传输超时，立刻停掉剩余别名。
+
 ## [0.2.19] - 2026-08-15
 
 > **Highlight:** SuperGrok quota auto-refresh every 10 minutes; macOS Release notarization when Apple secrets are present; first launch follows the OS language; mid-turn steer no longer flashes the transcript; composer clears as soon as the user bubble appears.

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -5697,12 +5697,7 @@ mod prompt_wait_timeout_tests {
         let started = Instant::now();
         let last = started + Duration::from_secs(10);
         let now = last + idle();
-        assert!(prompt_wait_should_timeout(
-            Some(last),
-            started,
-            now,
-            idle()
-        ));
+        assert!(prompt_wait_should_timeout(Some(last), started, now, idle()));
     }
 
     #[test]

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -412,6 +412,17 @@ pub fn parse_fork_session_id(
     Some(raw.to_string())
 }
 
+/// `session/set_mode` walks product-mode aliases. A transport failure is not
+/// "unknown modeId" — abort the rest so agent mode cannot spend 5×45s and
+/// leave fork + parent chats stuck on 连接中.
+pub fn set_mode_abort_remaining_candidates(err: &str) -> bool {
+    let e = err.to_ascii_lowercase();
+    e.contains("rpc timeout")
+        || e.contains("rpc channel closed")
+        || e.contains("stdout closed")
+        || e.contains("write session/set_mode failed")
+}
+
 /// Pure helper: top-level CLI args for session extra rules (before `agent`).
 ///
 /// `["--rules", text]` — empty when none. Trims, drops empty, clamps length.
@@ -3139,6 +3150,12 @@ impl AcpClient {
                 Err(e) => {
                     last_err = e;
                     tracing::debug!("acp session/set_mode {mode_id} soft-fail: {last_err}");
+                    // Unknown modeId fails fast. A timeout / dead transport is
+                    // not "try the next alias" — agent mode has 5 candidates ×
+                    // 45s and left fork + parent chats stuck on 连接中.
+                    if set_mode_abort_remaining_candidates(&last_err) {
+                        break;
+                    }
                 }
             }
         }
@@ -5794,6 +5811,25 @@ mod background_wait_policy_tests {
         assert_eq!(cli_supports_background_wait("grok 0.2.117"), Some(true));
         assert_eq!(cli_supports_background_wait("0.2.116"), Some(false));
         assert_eq!(cli_supports_background_wait(""), None);
+    }
+
+    #[test]
+    fn set_mode_stops_on_transport_errors_not_unknown_mode() {
+        assert!(set_mode_abort_remaining_candidates(
+            "rpc timeout on session/set_mode (id=5) after 45s"
+        ));
+        assert!(set_mode_abort_remaining_candidates(
+            "rpc channel closed while waiting for session/set_mode (id=6)"
+        ));
+        assert!(set_mode_abort_remaining_candidates(
+            "agent stdout closed before session/set_mode; process dead"
+        ));
+        assert!(!set_mode_abort_remaining_candidates(
+            "Method not found (code -32601)"
+        ));
+        assert!(!set_mode_abort_remaining_candidates(
+            "invalid params: unknown modeId"
+        ));
     }
 }
 

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -950,9 +950,19 @@ impl SessionManager {
                 // Cold-spawn path: the process was spawned with `--model` =
                 // active channel model, and `session/new` inherits the process
                 // default — the post-open `set_model` here was a redundant RPC
-                // on every connect. Keep `set_mode` (product mode is
-                // per-prompt in Grok Build, so the App's mode is only nudged).
-                if let Err(e) = client.set_mode(&prefs.mode).await {
+                // on every connect. Keep `set_mode` on a normal resume (product
+                // mode is per-prompt; this is only a nudge).
+                // After `session/fork` the CLI is still hydrating parent
+                // context — `set_mode` timed out 5×45s (agent/default/code/…)
+                // and pinned both the fork and the parent chat on 连接中.
+                // Spawn already passed `--permission-mode`; skip the nudge.
+                if fork_agent {
+                    tracing::info!(
+                        target: "session",
+                        session = %meta.id,
+                        "connect skip set_mode after fork (parent mode already applied)"
+                    );
+                } else if let Err(e) = client.set_mode(&prefs.mode).await {
                     tracing::warn!("acp set_mode after session open soft-fail: {e}");
                 }
                 // Native resume / successful fork = full agent context. Fresh


### PR DESCRIPTION
## Why

Forking a live chat (e.g. `a51171b5` from `59f5638a`) succeeded at `_x.ai/session/fork`, then Host walked every agent-mode alias on `session/set_mode` (`agent` / `default` / `code` / `normal` / `Agent`) at **45s each**. After fork the CLI is still hydrating parent context, so those RPCs time out.

Handshake sat in **连接中** for ~4 minutes. Host never logged `session/prompt`. The fork painted **思考中**; switching back to the original chat also showed Connecting and could not send.

## What

- Skip the post-open `set_mode` nudge after a successful fork. Spawn already passed `--permission-mode`; parent mode is already on the forked session.
- If a later `set_mode` hits a transport timeout / closed channel / dead stdout, abort the remaining aliases instead of trying all five.

## Test

- `cargo test --lib set_mode_stops_on_transport_errors` (src-tauri)
- Local 0.2.19 rebuild installed; reproduced from `app.log.2026-08-16` (`session/set_mode` id=5…9, 45s each, then `session_open_ok` with no prompt)