### PR TITLE
fix(composer): clear new-session draft after a successful send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ See `docs/llm-wiki/release.md`.
 
 ### Fixed
 - **Fork no longer pins the parent chat on 连接中**: After `_x.ai/session/fork` the CLI is still hydrating parent context. Post-open `session/set_mode` used to walk every agent-mode alias (`agent` / `default` / `code` / `normal` / `Agent`) at 45s each — ~4 minutes of handshake, no `session/prompt`, both the fork and the original chat stuck on Connecting / Thinking. Fork skips that nudge (spawn already has `--permission-mode`); any later `set_mode` transport timeout aborts the remaining aliases.
+- **New-session composer no longer restores the just-sent prompt (#620)**: Sending from the New session page materializes a chat and leaves the draft view, so persist-clear used to be skipped. The per-project new-session buffer is now wiped on success.
 
 **中文 · 修复**
 - **分叉后不再把原会话卡在「连接中」**：`session/fork` 之后 CLI 还在灌父会话。以前会连试 5 个 `session/set_mode` 别名，每个等 45 秒，握手约 4 分钟，消息发不出去，分叉和原会话一起停在连接中/思考中。分叉后不再做这次 nudge；之后若 `set_mode` 是传输超时，立刻停掉剩余别名。
+- **新建会话发送后不再把刚发出的草稿带回来（#620）**：从「新建会话」发出去会落成真实会话并离开草稿页，以前会跳过清空。成功后现在会清掉该项目的新建会话草稿。
 
 ## [0.2.19] - 2026-08-15
 

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -673,7 +673,10 @@ import {
   loadComposerSessionDraft,
   saveComposerSessionDraft,
 } from "@/lib/composerSessionDraft";
-import { nextComposerSubmitSettlement } from "@/lib/composerSubmitClear";
+import {
+  nextComposerSubmitSettlement,
+  shouldClearProjectDraftAfterNewChatSend,
+} from "@/lib/composerSubmitClear";
 import {
   DEFERRED_RECONCILE_MS,
   WARM_CONNECT_DEBOUNCE_MS,
@@ -8137,7 +8140,20 @@ export function AppWorkbench() {
     }
     // Navigated away: leaving already persisted the composer-at-leave
     // (follow-up text stays). Only refill an empty origin buffer on fail.
-    if (sent) return;
+    // New-chat send adopts the materialized session, so stillHere is false —
+    // still wipe the per-project new-session buffer or the next "New session"
+    // restores the just-sent prompt (#620).
+    if (sent) {
+      if (
+        shouldClearProjectDraftAfterNewChatSend({
+          fromNewChatPage: clearDraftOpts.clearProjectDraft,
+          sendSucceeded: true,
+        })
+      ) {
+        persistComposerSubmitClear({ clearProjectDraft: true });
+      }
+      return;
+    }
     if (clearDraftOpts.clearSessionDraft && clearDraftOpts.sessionDraftId) {
       if (!loadComposerSessionDraft(clearDraftOpts.sessionDraftId)) {
         saveComposerSessionDraft(clearDraftOpts.sessionDraftId, {

--- a/src/lib/composerSubmitClear.test.ts
+++ b/src/lib/composerSubmitClear.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   nextComposerSubmitSettlement,
   shouldClearComposerAfterSubmit,
+  shouldClearProjectDraftAfterNewChatSend,
 } from "./composerSubmitClear";
 
 const file = { path: "/tmp/a.txt" };
@@ -128,5 +129,34 @@ describe("nextComposerSubmitSettlement", () => {
         currentAttachments: [file],
       }),
     ).toBe("leave");
+  });
+});
+
+describe("shouldClearProjectDraftAfterNewChatSend", () => {
+  it("wipes the new-session buffer after a successful draft send", () => {
+    expect(
+      shouldClearProjectDraftAfterNewChatSend({
+        fromNewChatPage: true,
+        sendSucceeded: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the new-session buffer when the draft send fails", () => {
+    expect(
+      shouldClearProjectDraftAfterNewChatSend({
+        fromNewChatPage: true,
+        sendSucceeded: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not touch the project buffer on an existing-thread send", () => {
+    expect(
+      shouldClearProjectDraftAfterNewChatSend({
+        fromNewChatPage: false,
+        sendSucceeded: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/lib/composerSubmitClear.ts
+++ b/src/lib/composerSubmitClear.ts
@@ -63,3 +63,18 @@ export function nextComposerSubmitSettlement(
   if (!idle && !composerMatchesSentPayload(opts)) return "leave";
   return opts.sendSucceeded ? "persist-clear" : "restore";
 }
+
+/**
+ * A new-chat send materializes a session and adopts that view, so `stillHere`
+ * is false. The per-project new-session buffer must still be wiped on success,
+ * or the next "New session" restores the just-sent prompt (#620).
+ *
+ * Follow-up on the new thread is a per-session draft — do not keep the
+ * project buffer just because we left the draft page.
+ */
+export function shouldClearProjectDraftAfterNewChatSend(opts: {
+  fromNewChatPage: boolean;
+  sendSucceeded: boolean;
+}): boolean {
+  return opts.fromNewChatPage && opts.sendSucceeded;
+}


### PR DESCRIPTION
## What

Sending from **New session** materializes a chat and adopts that view, so `stillHere` is false and persist-clear was skipped. The per-project new-session buffer still held the just-sent prompt. Clicking **New session** again restored it.

## Fix

On a successful new-chat send, always wipe the per-project buffer even after the workbench has left the draft page. Failed sends still refill an empty buffer. Existing-thread follow-ups are unchanged.

## Test

- `pnpm exec vitest run src/lib/composerSubmitClear.test.ts src/lib/composerProjectDraft.test.ts`

Fixes #620