### PR TITLE
fix(remote-im): keep Telegram replies in the source topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ See `docs/llm-wiki/release.md`.
 ### Fixed
 - **Fork no longer pins the parent chat on 连接中**: After `_x.ai/session/fork` the CLI is still hydrating parent context. Post-open `session/set_mode` used to walk every agent-mode alias (`agent` / `default` / `code` / `normal` / `Agent`) at 45s each — ~4 minutes of handshake, no `session/prompt`, both the fork and the original chat stuck on Connecting / Thinking. Fork skips that nudge (spawn already has `--permission-mode`); any later `set_mode` transport timeout aborts the remaining aliases.
 - **New-session composer no longer restores the just-sent prompt (#620)**: Sending from the New session page materializes a chat and leaves the draft view, so persist-clear used to be skipped. The per-project new-session buffer is now wiped on success.
+- **Telegram topic replies stay in the topic (#623)**: Inbound `message_thread_id` is kept and sent back on `sendMessage` / cards / edits. With **thread isolation** on, each topic is its own agent binding.
 
 **中文 · 修复**
 - **分叉后不再把原会话卡在「连接中」**：`session/fork` 之后 CLI 还在灌父会话。以前会连试 5 个 `session/set_mode` 别名，每个等 45 秒，握手约 4 分钟，消息发不出去，分叉和原会话一起停在连接中/思考中。分叉后不再做这次 nudge；之后若 `set_mode` 是传输超时，立刻停掉剩余别名。
 - **新建会话发送后不再把刚发出的草稿带回来（#620）**：从「新建会话」发出去会落成真实会话并离开草稿页，以前会跳过清空。成功后现在会清掉该项目的新建会话草稿。
+- **Telegram 话题回复回到原话题（#623）**：入站保留 `message_thread_id`，出站 `sendMessage` / 卡片 / 编辑一并带回。打开 **按话题隔离** 后，每个 Topic 是独立 Agent 绑定。
 
 ## [0.2.19] - 2026-08-15
 

--- a/src-tauri/src/remote_im/channels/dingtalk.rs
+++ b/src-tauri/src/remote_im/channels/dingtalk.rs
@@ -173,7 +173,7 @@ async fn run_stream_once(
                                 sender_id: sender,
                                 content: format!("__card_action__:{action_id}"),
                                 mentioned_bot: true,
-                            }).await;
+                                thread_id: None,                            }).await;
                             let ack = json!({ "code": 200 });
                             let _ = write.send(Message::Text(ack.to_string().into())).await;
                             continue;
@@ -266,6 +266,7 @@ fn parse_bot_callback(inst: &ChannelInstance, data: &Value) -> Option<IncomingMe
         sender_id: sender,
         content: text,
         mentioned_bot: true,
+        thread_id: None,
     })
 }
 

--- a/src-tauri/src/remote_im/channels/discord.rs
+++ b/src-tauri/src/remote_im/channels/discord.rs
@@ -192,6 +192,7 @@ fn parse_message(inst: &ChannelInstance, d: &Value) -> Option<IncomingMessage> {
         sender_id,
         content,
         mentioned_bot,
+        thread_id: None,
     })
 }
 

--- a/src-tauri/src/remote_im/channels/feishu.rs
+++ b/src-tauri/src/remote_im/channels/feishu.rs
@@ -211,7 +211,7 @@ async fn run_once(
                                         sender_id: sender,
                                         content,
                                         mentioned_bot: true,
-                                    })
+                                        thread_id: None,                                    })
                                     .await
                                 {
                                     tracing::error!(
@@ -412,6 +412,7 @@ fn parse_im_event(inst: &ChannelInstance, root: &Value) -> Option<IncomingMessag
         sender_id,
         content: re_clean,
         mentioned_bot: mentioned_bot || chat_type == "p2p",
+        thread_id: None,
     })
 }
 

--- a/src-tauri/src/remote_im/channels/line.rs
+++ b/src-tauri/src/remote_im/channels/line.rs
@@ -127,7 +127,7 @@ pub async fn run(
                                     sender_id: user.into(),
                                     content: text.into(),
                                     mentioned_bot: true,
-                                }).await;
+                                    thread_id: None,                                }).await;
                             }
                         }
                     }

--- a/src-tauri/src/remote_im/channels/matrix.rs
+++ b/src-tauri/src/remote_im/channels/matrix.rs
@@ -86,6 +86,7 @@ pub async fn run(
                                     sender_id: sender,
                                     content: body.into(),
                                     mentioned_bot: true,
+                                    thread_id: None,
                                 })
                                 .await;
                         }

--- a/src-tauri/src/remote_im/channels/qq.rs
+++ b/src-tauri/src/remote_im/channels/qq.rs
@@ -131,6 +131,7 @@ fn parse_event(inst: &ChannelInstance, v: &Value) -> Option<IncomingMessage> {
         chat_type: chat_type.into(),
         sender_id: user_id,
         mentioned_bot: chat_type == "p2p" || text.contains("[CQ:at"),
+        thread_id: None,
         content: text,
     })
 }

--- a/src-tauri/src/remote_im/channels/qqbot.rs
+++ b/src-tauri/src/remote_im/channels/qqbot.rs
@@ -175,6 +175,7 @@ fn parse_dispatch(inst: &ChannelInstance, d: &Value) -> Option<IncomingMessage> 
         sender_id: author,
         content,
         mentioned_bot: true,
+        thread_id: None,
     })
 }
 

--- a/src-tauri/src/remote_im/channels/slack.rs
+++ b/src-tauri/src/remote_im/channels/slack.rs
@@ -187,6 +187,7 @@ fn parse_event(inst: &ChannelInstance, payload: &Value) -> Option<IncomingMessag
         chat_type: chat_type.into(),
         sender_id,
         mentioned_bot: chat_type == "p2p" || text.contains("<@"),
+        thread_id: None,
         content: text,
     })
 }

--- a/src-tauri/src/remote_im/channels/telegram.rs
+++ b/src-tauri/src/remote_im/channels/telegram.rs
@@ -123,6 +123,7 @@ pub async fn run(
                     _ => String::new(),
                 })
                 .unwrap_or_default();
+            let thread_id = telegram_thread_id(msg);
             // Private chats always; groups when @mentioned or a native bot_command entity.
             let mentioned_bot = chat_type == "p2p"
                 || entities
@@ -147,6 +148,7 @@ pub async fn run(
                     sender_id,
                     content: text,
                     mentioned_bot,
+                    thread_id,
                 })
                 .await;
         }
@@ -192,6 +194,7 @@ async fn handle_callback_query(
         return;
     }
     let chat_id = incoming.chat_id.clone();
+    let thread_id = incoming.thread_id.clone();
     if tx.send(incoming).await.is_ok() && !is_pagination {
         // Best-effort consume the keyboard so a stale project/session/account action
         // cannot be clicked repeatedly after the selection has been accepted.
@@ -199,11 +202,14 @@ async fn handle_callback_query(
             client,
             token,
             "editMessageReplyMarkup",
-            &json!({
-                "chat_id": chat_id,
-                "message_id": message_id,
-                "reply_markup": { "inline_keyboard": [] },
-            }),
+            &with_thread_id(
+                json!({
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "reply_markup": { "inline_keyboard": [] },
+                }),
+                thread_id.as_deref(),
+            ),
         )
         .await;
     }
@@ -244,9 +250,31 @@ fn callback_query_to_incoming(
             sender_id,
             content: format!("__card_action__:{data}"),
             mentioned_bot: true,
+            thread_id: telegram_thread_id(message),
         },
         message_id,
     ))
+}
+
+pub fn telegram_thread_id(msg: &Value) -> Option<String> {
+    let raw = msg.get("message_thread_id")?;
+    let id = json_id_to_string(raw);
+    if id.is_empty() {
+        None
+    } else {
+        Some(id)
+    }
+}
+
+pub fn with_thread_id(mut body: Value, thread_id: Option<&str>) -> Value {
+    let Some(tid) = thread_id.map(str::trim).filter(|s| !s.is_empty()) else {
+        return body;
+    };
+    body["message_thread_id"] = match tid.parse::<i64>() {
+        Ok(n) => json!(n),
+        Err(_) => json!(tid),
+    };
+    body
 }
 
 fn json_id_to_string(value: &Value) -> String {
@@ -430,15 +458,19 @@ pub async fn send_text(
     secrets: &std::collections::HashMap<String, String>,
     chat_id: &str,
     text: &str,
+    thread_id: Option<&str>,
 ) -> Result<(), String> {
     let token = bot_token(secrets)?;
     post_with_markdown_fallback(
         token,
         "sendMessage",
-        json!({
-            "chat_id": chat_id,
-            "text": text,
-        }),
+        with_thread_id(
+            json!({
+                "chat_id": chat_id,
+                "text": text,
+            }),
+            thread_id,
+        ),
     )
     .await
 }
@@ -447,6 +479,7 @@ pub async fn send_card(
     secrets: &std::collections::HashMap<String, String>,
     chat_id: &str,
     card: &Value,
+    thread_id: Option<&str>,
 ) -> Result<(), String> {
     let token = bot_token(secrets)?;
     let text = card
@@ -460,11 +493,14 @@ pub async fn send_card(
     post_with_markdown_fallback(
         token,
         "sendMessage",
-        json!({
-            "chat_id": chat_id,
-            "text": text,
-            "reply_markup": reply_markup,
-        }),
+        with_thread_id(
+            json!({
+                "chat_id": chat_id,
+                "text": text,
+                "reply_markup": reply_markup,
+            }),
+            thread_id,
+        ),
     )
     .await
 }
@@ -474,6 +510,7 @@ pub async fn edit_card(
     chat_id: &str,
     message_id: &str,
     card: &Value,
+    thread_id: Option<&str>,
 ) -> Result<(), String> {
     let token = bot_token(secrets)?;
     let message_id = message_id
@@ -490,12 +527,15 @@ pub async fn edit_card(
     post_with_markdown_fallback(
         token,
         "editMessageText",
-        json!({
-            "chat_id": chat_id,
-            "message_id": message_id,
-            "text": text,
-            "reply_markup": reply_markup,
-        }),
+        with_thread_id(
+            json!({
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "text": text,
+                "reply_markup": reply_markup,
+            }),
+            thread_id,
+        ),
     )
     .await
 }
@@ -571,5 +611,48 @@ mod tests {
         assert_eq!(incoming.chat_type, "group");
         assert_eq!(incoming.content, "__card_action__:project:project-1");
         assert!(incoming.mentioned_bot);
+        assert_eq!(incoming.thread_id, None);
+    }
+
+    #[test]
+    fn parses_and_stamps_message_thread_id() {
+        let msg = json!({
+            "message_id": 12,
+            "message_thread_id": 77,
+            "chat": { "id": 42, "type": "private" },
+            "text": "hi"
+        });
+        assert_eq!(telegram_thread_id(&msg).as_deref(), Some("77"));
+        let stamped = with_thread_id(json!({ "chat_id": 42, "text": "ok" }), Some("77"));
+        assert_eq!(stamped["message_thread_id"], json!(77));
+        let skipped = with_thread_id(json!({ "chat_id": 42, "text": "ok" }), None);
+        assert!(skipped.get("message_thread_id").is_none());
+    }
+
+    #[test]
+    fn callback_query_keeps_topic_thread_id() {
+        let inst = ChannelInstance {
+            id: "tg-1".into(),
+            channel: "telegram".into(),
+            name: "Bot".into(),
+            enabled: true,
+            secrets: std::collections::HashMap::new(),
+            options: json!({}),
+            acl: json!({}),
+            project_scope: json!({}),
+        };
+        let callback = json!({
+            "id": "cb-1",
+            "from": { "id": 42 },
+            "data": "project:project-1",
+            "message": {
+                "message_id": 99,
+                "message_thread_id": 8,
+                "chat": { "id": 42, "type": "private" }
+            }
+        });
+        let (incoming, _) = callback_query_to_incoming(&inst, &callback).unwrap();
+        assert_eq!(incoming.thread_id.as_deref(), Some("8"));
+        assert_eq!(incoming.chat_type, "p2p");
     }
 }

--- a/src-tauri/src/remote_im/channels/wecom.rs
+++ b/src-tauri/src/remote_im/channels/wecom.rs
@@ -142,6 +142,7 @@ fn parse_ws_msg(inst: &ChannelInstance, v: &Value) -> Option<IncomingMessage> {
         sender_id: sender,
         content: text,
         mentioned_bot: true,
+        thread_id: None,
     })
 }
 
@@ -249,7 +250,7 @@ async fn run_webhook(
                                 sender_id: user.into(),
                                 content: text.into(),
                                 mentioned_bot: true,
-                            }).await;
+                                thread_id: None,                            }).await;
                         }
                     }
                     let _ = socket.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 7\r\n\r\nsuccess").await;

--- a/src-tauri/src/remote_im/channels/weibo.rs
+++ b/src-tauri/src/remote_im/channels/weibo.rs
@@ -89,7 +89,7 @@ async fn run_once(
                             sender_id: sender,
                             content: text.into(),
                             mentioned_bot: true,
-                        }).await;
+                            thread_id: None,                        }).await;
                     }
                     Some(Ok(Message::Close(_))) | None => return Ok(()),
                     Some(Ok(Message::Ping(p))) => { let _ = write.send(Message::Pong(p)).await; }

--- a/src-tauri/src/remote_im/channels/weixin.rs
+++ b/src-tauri/src/remote_im/channels/weixin.rs
@@ -262,6 +262,7 @@ fn parse_msg(inst: &ChannelInstance, m: &Value) -> Option<IncomingMessage> {
         sender_id: sender,
         content: text,
         mentioned_bot: true,
+        thread_id: None,
     })
 }
 

--- a/src-tauri/src/remote_im/channels/wps_xiezuo.rs
+++ b/src-tauri/src/remote_im/channels/wps_xiezuo.rs
@@ -167,6 +167,7 @@ fn parse_event(inst: &ChannelInstance, v: &Value) -> Option<IncomingMessage> {
         sender_id: sender,
         content: text.into(),
         mentioned_bot: true,
+        thread_id: None,
     })
 }
 

--- a/src-tauri/src/remote_im/engine.rs
+++ b/src-tauri/src/remote_im/engine.rs
@@ -184,6 +184,24 @@ impl Engine {
         agent_error_user_message(&self.lang(), classify_rim_error(error), error)
     }
 
+    fn thread_isolation_for(&self, instance_id: &str) -> bool {
+        self.instances
+            .lock()
+            .get(instance_id)
+            .map(|i| {
+                i.options
+                    .get("thread_isolation")
+                    .and_then(|x| x.as_bool())
+                    .unwrap_or(false)
+                    || i.options.get("thread_isolation").and_then(|x| x.as_str()) == Some("true")
+            })
+            .unwrap_or(false)
+    }
+
+    fn scope_for(&self, msg: &IncomingMessage) -> String {
+        SessionStore::scope_key_for(msg, self.thread_isolation_for(&msg.instance_id))
+    }
+
     fn channel_prefers_cards(&self, msg: &IncomingMessage) -> bool {
         let opts = self
             .instances
@@ -211,8 +229,7 @@ impl Engine {
     /// Register before spawning so a following `/stop` cannot overtake an
     /// inbound free-form message that Tokio has not polled yet.
     pub(super) fn spawn_cancellable(self: &Arc<Self>, msg: IncomingMessage) -> JoinHandle<()> {
-        let scope =
-            SessionStore::scope_key(&msg.channel, &msg.instance_id, &msg.chat_id, &msg.sender_id);
+        let scope = self.scope_for(&msg);
         let registered = self.register_active_turn(&scope);
         let engine = self.clone();
         tokio::spawn(async move {
@@ -288,8 +305,7 @@ impl Engine {
             return;
         }
 
-        let scope =
-            SessionStore::scope_key(&msg.channel, &msg.instance_id, &msg.chat_id, &msg.sender_id);
+        let scope = self.scope_for(&msg);
         let alt_scope = SessionStore::scope_key(
             &msg.channel,
             &msg.instance_id,
@@ -384,8 +400,7 @@ impl Engine {
             let _ = self.reply_msg(msg, text).await;
             return;
         }
-        let scope =
-            SessionStore::scope_key(&msg.channel, &msg.instance_id, &msg.chat_id, &msg.sender_id);
+        let scope = self.scope_for(msg);
         // Also clear pending under sender-only scopes (chat_id may differ on card callback).
         let alt_scope = SessionStore::scope_key(
             &msg.channel,
@@ -582,13 +597,19 @@ impl Engine {
 
         if self
             .outbound
-            .edit_card(&msg.instance_id, &msg.chat_id, &msg.message_id, &card)
+            .edit_card(
+                &msg.instance_id,
+                &msg.chat_id,
+                &msg.message_id,
+                &card,
+                msg.thread_id(),
+            )
             .await
             .is_err()
         {
             let _ = self
                 .outbound
-                .reply_card(&msg.instance_id, &msg.chat_id, None, &card)
+                .reply_card(&msg.instance_id, &msg.chat_id, None, &card, msg.thread_id())
                 .await;
         }
     }
@@ -782,7 +803,13 @@ impl Engine {
             let card = control_plane::build_telegram_account_card(&text, &choices, &self.lang(), 0);
             let _ = self
                 .outbound
-                .reply_card(&msg.instance_id, &msg.chat_id, Some(&msg.message_id), &card)
+                .reply_card(
+                    &msg.instance_id,
+                    &msg.chat_id,
+                    Some(&msg.message_id),
+                    &card,
+                    msg.thread_id(),
+                )
                 .await;
         } else {
             let _ = self.reply_msg(msg, &text).await;
@@ -1231,7 +1258,13 @@ impl Engine {
             };
             let _ = self
                 .outbound
-                .reply_card(&msg.instance_id, &msg.chat_id, Some(&msg.message_id), &card)
+                .reply_card(
+                    &msg.instance_id,
+                    &msg.chat_id,
+                    Some(&msg.message_id),
+                    &card,
+                    msg.thread_id(),
+                )
                 .await;
             // Still allow text pick as fallback (number / name). Mirror under sender scope
             // so card callbacks with different chat_id still clear the same pending.
@@ -1346,7 +1379,13 @@ impl Engine {
             };
             let _ = self
                 .outbound
-                .reply_card(&msg.instance_id, &msg.chat_id, Some(&msg.message_id), &card)
+                .reply_card(
+                    &msg.instance_id,
+                    &msg.chat_id,
+                    Some(&msg.message_id),
+                    &card,
+                    msg.thread_id(),
+                )
                 .await;
             self.insert_pending(
                 scope,
@@ -1524,7 +1563,13 @@ impl Engine {
         );
         match self
             .outbound
-            .reply(&msg.instance_id, &msg.chat_id, Some(&msg.message_id), text)
+            .reply(
+                &msg.instance_id,
+                &msg.chat_id,
+                Some(&msg.message_id),
+                text,
+                msg.thread_id(),
+            )
             .await
         {
             Ok(()) => {
@@ -1541,7 +1586,13 @@ impl Engine {
                 if !msg.sender_id.is_empty() && msg.sender_id != msg.chat_id {
                     match self
                         .outbound
-                        .reply(&msg.instance_id, &msg.sender_id, None, text)
+                        .reply(
+                            &msg.instance_id,
+                            &msg.sender_id,
+                            None,
+                            text,
+                            msg.thread_id(),
+                        )
                         .await
                     {
                         Ok(()) => {
@@ -1955,6 +2006,7 @@ mod tests {
             sender_id: "sender".into(),
             content: "/stop".into(),
             mentioned_bot: true,
+            thread_id: None,
         };
         engine
             .handle_slash(BuiltinCommand::Stop, &stop_message, "scope-a", "", None)
@@ -2133,6 +2185,7 @@ mod tests {
             sender_id: "peer@im.wechat".into(),
             content: "/p".into(),
             mentioned_bot: true,
+            thread_id: None,
         };
         // Pre-fix: nested pending.lock() in or_else deadlocked forever here.
         tokio::time::timeout(Duration::from_secs(3), engine.handle(msg))

--- a/src-tauri/src/remote_im/outbound.rs
+++ b/src-tauri/src/remote_im/outbound.rs
@@ -65,6 +65,7 @@ impl OutboundRouter {
         chat_id: &str,
         reply_to: Option<&str>,
         text: &str,
+        thread_id: Option<&str>,
     ) -> Result<(), String> {
         let cred = self
             .creds
@@ -84,7 +85,9 @@ impl OutboundRouter {
                 )
                 .await
             }
-            "telegram" => super::channels::telegram::send_text(&cred.secrets, chat_id, text).await,
+            "telegram" => {
+                super::channels::telegram::send_text(&cred.secrets, chat_id, text, thread_id).await
+            }
             "discord" => super::channels::discord::send_text(&cred.secrets, chat_id, text).await,
             "slack" => super::channels::slack::send_text(&cred.secrets, chat_id, text).await,
             "dingtalk" => super::channels::dingtalk::send_text(&cred.secrets, chat_id, text).await,
@@ -112,6 +115,7 @@ impl OutboundRouter {
         chat_id: &str,
         reply_to: Option<&str>,
         card: &serde_json::Value,
+        thread_id: Option<&str>,
     ) -> Result<(), String> {
         let cred = self
             .creds
@@ -132,7 +136,9 @@ impl OutboundRouter {
                 .await
             }
             "dingtalk" => super::channels::dingtalk::send_card(&cred.secrets, chat_id, card).await,
-            "telegram" => super::channels::telegram::send_card(&cred.secrets, chat_id, card).await,
+            "telegram" => {
+                super::channels::telegram::send_card(&cred.secrets, chat_id, card, thread_id).await
+            }
             _ => {
                 // Fallback: dump card as text menu summary
                 let text = format!(
@@ -147,6 +153,7 @@ impl OutboundRouter {
                     chat_id,
                     reply_to,
                     &text.chars().take(2000).collect::<String>(),
+                    thread_id,
                 )
                 .await
             }
@@ -160,6 +167,7 @@ impl OutboundRouter {
         chat_id: &str,
         message_id: &str,
         card: &serde_json::Value,
+        thread_id: Option<&str>,
     ) -> Result<(), String> {
         let cred = self
             .creds
@@ -169,9 +177,19 @@ impl OutboundRouter {
             .ok_or_else(|| format!("no outbound creds for {instance_id}"))?;
         match cred.channel.as_str() {
             "telegram" => {
-                super::channels::telegram::edit_card(&cred.secrets, chat_id, message_id, card).await
+                super::channels::telegram::edit_card(
+                    &cred.secrets,
+                    chat_id,
+                    message_id,
+                    card,
+                    thread_id,
+                )
+                .await
             }
-            _ => self.reply_card(instance_id, chat_id, None, card).await,
+            _ => {
+                self.reply_card(instance_id, chat_id, None, card, thread_id)
+                    .await
+            }
         }
     }
 }

--- a/src-tauri/src/remote_im/session.rs
+++ b/src-tauri/src/remote_im/session.rs
@@ -55,6 +55,16 @@ impl SessionStore {
         format!("{channel}:{instance_id}:{chat_id}:{sender_id}")
     }
 
+    /// Same as [`scope_key`], but when `isolate_thread` the Telegram / forum
+    /// topic id is folded into the chat segment so each topic is its own binding.
+    pub fn scope_key_for(msg: &super::types::IncomingMessage, isolate_thread: bool) -> String {
+        let chat_id = match (isolate_thread, msg.thread_id()) {
+            (true, Some(tid)) => format!("{}#t{tid}", msg.chat_id),
+            _ => msg.chat_id.clone(),
+        };
+        Self::scope_key(&msg.channel, &msg.instance_id, &chat_id, &msg.sender_id)
+    }
+
     fn load_disk(&self) {
         if !self.path.is_file() {
             return;
@@ -108,5 +118,39 @@ impl SessionStore {
     pub fn remove(&self, key: &str) {
         self.inner.lock().remove(key);
         self.save_disk();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_im::types::IncomingMessage;
+
+    fn msg(thread_id: Option<&str>) -> IncomingMessage {
+        IncomingMessage {
+            channel: "telegram".into(),
+            instance_id: "bot".into(),
+            message_id: "1".into(),
+            chat_id: "42".into(),
+            chat_type: "p2p".into(),
+            sender_id: "7".into(),
+            content: "hi".into(),
+            mentioned_bot: true,
+            thread_id: thread_id.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn scope_ignores_topic_unless_isolation_on() {
+        let m = msg(Some("77"));
+        assert_eq!(SessionStore::scope_key_for(&m, false), "telegram:bot:42:7");
+        assert_eq!(
+            SessionStore::scope_key_for(&m, true),
+            "telegram:bot:42#t77:7"
+        );
+        assert_eq!(
+            SessionStore::scope_key_for(&msg(None), true),
+            "telegram:bot:42:7"
+        );
     }
 }

--- a/src-tauri/src/remote_im/types.rs
+++ b/src-tauri/src/remote_im/types.rs
@@ -27,6 +27,17 @@ pub struct IncomingMessage {
     pub sender_id: String,
     pub content: String,
     pub mentioned_bot: bool,
+    /// Telegram forum / private-topic thread (`message_thread_id`).
+    pub thread_id: Option<String>,
+}
+
+impl IncomingMessage {
+    pub fn thread_id(&self) -> Option<&str> {
+        self.thread_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## What

Telegram Bot replies from a private/forum **Topic** were sent without `message_thread_id`, so they landed in the general chat instead of the topic that asked.

## Fix

- Parse and keep inbound `message_thread_id` (messages + callback queries)
- Stamp it on `sendMessage`, cards, `editMessageText`, and `editMessageReplyMarkup`
- When **thread isolation** is on, fold the topic id into the session scope so topics do not share agent context

## Test

- `cargo test --lib remote_im` (125 passed)

Fixes #623