### PR TITLE
feat(account): list saved accounts and remaining quota in the user menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+- **User menu lists every saved official account (#621)**: Each row shows honest SuperGrok remaining % (never invents 0% / 100% on a failed probe). Click another account to `account_switch`; click the active row for Settings → Account. Custom-provider / signed-out cards stay as they are.
+
+**中文 · 新增**
+- **头像菜单列出全部已保存官方账号（#621）**：每行显示诚实的 SuperGrok 剩余 %（探测失败不编造 0% / 100%）。点其他号走 `account_switch`；点当前号仍进设置 → 账户。自定义提供商 / 未登录卡片不变。
+
 ### Changed
 - **README Gatekeeper copy**: Official Releases from v0.2.19 are Developer ID signed and Apple-notarized. The `xattr` workaround stays for forks / older unsigned builds.
 

--- a/docs/llm-wiki/account.md
+++ b/docs/llm-wiki/account.md
@@ -77,13 +77,14 @@ Never tell the user that official OAuth alone fixes a bad custom relay key.
 | `account_open_usage` | Open `https://grok.com/?_s=usage` |
 | `account_open_subscribe` | Open SuperGrok / subscription manage URL |
 | `accounts_list` / `account_save_current` / `account_switch` / `account_remove` | Multi-account snapshots under `~/.grok-app/accounts/` |
+| `accounts_quota` | Best-effort SuperGrok remaining % for every saved snapshot (parallel; never invent 0% / 100% on probe failure) |
 | `session_import_transcript(_file)` | Import markdown/JSON chat into a new local session |
 
 ### Multi-account
 
 - After successful login, Host **auto-snapshots** auth into `accounts/<id>/auth.json`.
 - Switch copies snapshot → `~/.grok/auth.json` + agent-home, then disconnects live ACP.
-- UI: Settings → Account → **「切换账号」** opens a modal to list / switch / remove.
+- UI: the sidebar **user menu** lists saved official accounts (honest remaining %, click → `account_switch`). Clicking the active row still opens **Settings → Account**. Custom-provider / signed-out cards stay unchanged. Settings → Account keeps the full switcher / remove / rename UI.
   **「添加账号」** saves the current profile (if signed in) then starts OAuth login.
 
 ### Login failures (Access denied)

--- a/src-tauri/src/account_profiles.rs
+++ b/src-tauri/src/account_profiles.rs
@@ -323,6 +323,87 @@ fn current_auth_source() -> Result<PathBuf, String> {
     Err("No auth.json found. Sign in first.".into())
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountQuotaItem {
+    pub id: String,
+    pub remaining_percent: Option<f64>,
+    pub used_percent: Option<f64>,
+    pub subscription_tier: Option<String>,
+    pub resets_at: Option<String>,
+    pub available: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountsQuotaResult {
+    #[serde(default)]
+    pub items: Vec<AccountQuotaItem>,
+    #[serde(default)]
+    pub fetched_at: String,
+}
+
+fn quota_probe_failed(snap: &crate::supergrok_quota::AccountQuotaSnapshot) -> bool {
+    snap.last_error.is_some() || snap.source == "error" || snap.source == "empty"
+}
+
+fn quota_item_from_snapshot(
+    id: String,
+    snap: crate::supergrok_quota::AccountQuotaSnapshot,
+) -> AccountQuotaItem {
+    // Never invent 0% / 100% when the SuperGrok probe failed.
+    if quota_probe_failed(&snap) {
+        return AccountQuotaItem {
+            id,
+            remaining_percent: None,
+            used_percent: None,
+            subscription_tier: None,
+            resets_at: None,
+            available: false,
+        };
+    }
+    AccountQuotaItem {
+        id,
+        remaining_percent: Some(f64::from(snap.remaining_percent)),
+        used_percent: Some(f64::from(snap.used_percent)),
+        subscription_tier: None,
+        resets_at: snap.resets_at.map(|d| d.to_rfc3339()),
+        available: true,
+    }
+}
+
+fn unavailable_quota_item(id: String) -> AccountQuotaItem {
+    AccountQuotaItem {
+        id,
+        remaining_percent: None,
+        used_percent: None,
+        subscription_tier: None,
+        resets_at: None,
+        available: false,
+    }
+}
+
+/// Live SuperGrok remaining % for every saved snapshot (best-effort, parallel).
+/// Reuses `fetch_quota_best_effort` — same probe as the active `account_status`.
+pub async fn fetch_accounts_quota() -> AccountsQuotaResult {
+    let idx = load_index();
+    let futs = idx.profiles.into_iter().map(|p| {
+        let id = p.id;
+        async move {
+            let Some(token) = access_token_for_account(&id) else {
+                return unavailable_quota_item(id);
+            };
+            let snap = crate::supergrok_quota::fetch_quota_best_effort(&token).await;
+            quota_item_from_snapshot(id, snap)
+        }
+    });
+    let items = futures_util::future::join_all(futs).await;
+    AccountsQuotaResult {
+        items,
+        fetched_at: Utc::now().to_rfc3339(),
+    }
+}
+
 /// After a successful login, auto-snapshot so multi-account list stays current.
 pub fn auto_snapshot_after_login() {
     match save_current_account(None) {
@@ -376,5 +457,39 @@ mod tests {
         assert_eq!(resolve_account_pick("one@x.ai", &profiles).unwrap(), "u1");
         assert!(resolve_account_pick("0", &profiles).is_err());
         assert!(resolve_account_pick("missing", &profiles).is_err());
+    }
+
+    #[test]
+    fn quota_item_hides_percent_when_probe_failed() {
+        let mut snap = crate::supergrok_quota::default_unused_quota_snapshot();
+        snap.source = "error".into();
+        snap.last_error = Some("network".into());
+        let item = quota_item_from_snapshot("u1".into(), snap);
+        assert!(!item.available);
+        assert!(item.remaining_percent.is_none());
+        assert!(item.used_percent.is_none());
+    }
+
+    #[test]
+    fn quota_item_hides_empty_placeholder_snapshot() {
+        let snap = crate::supergrok_quota::default_unused_quota_snapshot();
+        let item = quota_item_from_snapshot("u1".into(), snap);
+        assert_eq!(item.available, false);
+        assert!(item.remaining_percent.is_none());
+    }
+
+    #[test]
+    fn quota_item_keeps_real_zero_remaining() {
+        let snap = crate::supergrok_quota::AccountQuotaSnapshot::from_used(
+            100.0,
+            None,
+            None,
+            Vec::new(),
+            "grpc-web",
+        );
+        let item = quota_item_from_snapshot("u1".into(), snap);
+        assert!(item.available);
+        assert_eq!(item.remaining_percent, Some(0.0));
+        assert_eq!(item.used_percent, Some(100.0));
     }
 }

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -91,6 +91,11 @@ pub fn accounts_list() -> crate::account_profiles::AccountsListResult {
 }
 
 #[tauri::command]
+pub async fn accounts_quota() -> crate::account_profiles::AccountsQuotaResult {
+    crate::account_profiles::fetch_accounts_quota().await
+}
+
+#[tauri::command]
 pub fn account_save_current(
     label: Option<String>,
 ) -> Result<crate::account_profiles::SavedAccount, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1261,6 +1261,8 @@ pub fn run() {
 
             commands::accounts_list,
 
+            commands::accounts_quota,
+
             commands::account_save_current,
 
             commands::account_switch,

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -1033,6 +1033,10 @@ import {
   trapTabKey
 } from "@/lib/a11yFocus";
 import { UserMenu, remainingPercent } from "@/components/UserMenu";
+import {
+  quotaFromHostItem,
+  type SwitcherQuota,
+} from "@/lib/accountSwitcherQuota";
 import type { SettingsSectionId } from "@/components/SettingsPage";
 import {
   buildSettingsHash,
@@ -2209,6 +2213,9 @@ export function AppWorkbench() {
   const [chatFindIndex, setChatFindIndex] = useState(0);
   const [savedAccounts, setSavedAccounts] = useState<api.SavedAccount[]>([]);
   const [activeAccountId, setActiveAccountId] = useState<string | null>(null);
+  const [accountQuotas, setAccountQuotas] = useState<
+    Record<string, SwitcherQuota>
+  >({});
   const [perm, setPerm] = useState<PermissionPayload | null>(null);
   const permBarRef = useRef<HTMLDivElement | null>(null);
   /** Seconds until auto-deny (null when off / no active timer). */
@@ -14716,6 +14723,20 @@ export function AppWorkbench() {
     }
   }, []);
 
+  const refreshAccountQuotas = useCallback(async () => {
+    if (!api.isTauri()) return;
+    try {
+      const r = await api.accountsQuota();
+      const map: Record<string, SwitcherQuota> = {};
+      for (const item of r.items ?? []) {
+        map[item.id] = quotaFromHostItem(item);
+      }
+      setAccountQuotas(map);
+    } catch {
+      /* ignore — rows stay on live seed / em dash */
+    }
+  }, []);
+
   /** Import markdown/JSON transcript as a new local session (from PR #24). */
   const importChatTranscript = useCallback(async () => {
     if (!api.isTauri()) {
@@ -18707,6 +18728,8 @@ export function AppWorkbench() {
               login: tr("account.login"),
               logout: tr("account.logout"),
               remaining: tr("account.quotaRemaining"),
+              profileActive: tr("account.profileActive"),
+              switchTo: tr("account.switchTo"),
               customProvider: tr("prov.customProvider"),
               resetsAt: tr("account.resetsAt"),
               balanceAvailable: tr("prov.balance.available"),
@@ -18722,6 +18745,10 @@ export function AppWorkbench() {
             onTheme={applyThemeChoice}
             onLogin={() => void runAccountLogin("oauth")}
             onLogout={() => void runAccountLogout()}
+            savedAccounts={savedAccounts}
+            activeAccountId={activeAccountId}
+            accountQuotas={accountQuotas}
+            onSwitchAccount={(id) => void runSwitchAccount(id)}
           >
             <Tip label={tr("user.menu")}>
             <button
@@ -18735,6 +18762,8 @@ export function AppWorkbench() {
                 setShowUserMenu((v) => !v);
                 if (!showUserMenu) {
                   void refreshAccount({ refreshBilling: !customRouteActive });
+                  void refreshSavedAccounts();
+                  if (!customRouteActive) void refreshAccountQuotas();
                   if (
                     activeCustomProvider &&
                     supportsProviderBalance({

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -30,18 +30,27 @@ import type {
   AccountStatus,
   CustomProvider,
   ProviderBalanceResult,
+  SavedAccount,
 } from "@/lib/api";
 import {
   accountDisplayName,
   accountInitials,
   formatQuotaResetTime,
   tierLabel,
-  usagePercent,
 } from "@/lib/accountUi";
+import {
+  formatQuotaRemainLabel,
+  resolveQuotaPercents,
+} from "@/lib/accountQuotaHonesty";
 import {
   formatProviderBalanceDetailParts,
   formatProviderBalanceLine,
 } from "@/lib/providerBalanceFormat";
+import {
+  mergeAccountQuota,
+  switcherDisplayName,
+  type SwitcherQuota,
+} from "@/lib/accountSwitcherQuota";
 
 export interface UserMenuProps {
   open: boolean;
@@ -64,6 +73,8 @@ export interface UserMenuProps {
     login: string;
     logout: string;
     remaining: string;
+    profileActive: string;
+    switchTo: string;
     customProvider: string;
     /** Prefix for quota refresh time, e.g. 重置 / Resets */
     resetsAt: string;
@@ -90,18 +101,16 @@ export interface UserMenuProps {
   onTheme: (preference: ThemePreference) => void;
   onLogin: () => void;
   onLogout: () => void;
+  savedAccounts?: SavedAccount[];
+  activeAccountId?: string | null;
+  accountQuotas?: Record<string, SwitcherQuota>;
+  onSwitchAccount?: (id: string) => void;
   children: ReactNode;
 }
 
+/** Honest remaining % — never invents 0 / 100 when Host billing is silent. */
 export function remainingPercent(account: AccountStatus | null): number | null {
-  if (!account?.billing) return null;
-  const billing = account.billing;
-  if (billing.remainingPercent != null && Number.isFinite(billing.remainingPercent)) {
-    return Math.max(0, Math.min(100, billing.remainingPercent));
-  }
-  const used = usagePercent(billing);
-  if (used == null) return null;
-  return Math.max(0, Math.min(100, 100 - used));
+  return resolveQuotaPercents(account?.billing ?? null).remainingPercent;
 }
 
 const THEME_OPTIONS: ThemePreference[] = ["system", "light", "dark"];
@@ -160,6 +169,10 @@ export function UserMenu({
   onTheme,
   onLogin,
   onLogout,
+  savedAccounts = [],
+  activeAccountId = null,
+  accountQuotas = {},
+  onSwitchAccount,
   children,
 }: UserMenuProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -238,7 +251,7 @@ export function UserMenu({
     fitContent: true,
     matchTriggerWidth: true,
     minWidth: 220,
-    estHeight: 260,
+    estHeight: savedAccounts.length > 1 ? 360 : 260,
     gap: 6,
   });
 
@@ -259,9 +272,13 @@ export function UserMenu({
       : "G";
   const channel = account?.channel ?? "none";
   const billing = account?.billing;
-  const usedPct = billing ? usagePercent(billing) : null;
-  const remaining = remainingPercent(account);
+  const livePercents = resolveQuotaPercents(billing ?? null);
+  const usedPct = livePercents.usedPercent;
+  const remaining = livePercents.remainingPercent;
   const resetTime = formatQuotaResetTime(billing?.resetsAt);
+  const remainLabel = formatQuotaRemainLabel(remaining);
+  const remainText = remainLabel ? `${remainLabel} ${labels.remaining}` : "—";
+  const showSavedOfficialAccounts = signedIn && savedAccounts.length > 0;
   const tier = billing
     ? tierLabel(billing, channel)
     : signedIn
@@ -330,6 +347,128 @@ export function UserMenu({
             role="menu"
             style={style}
           >
+            {showSavedOfficialAccounts ? (
+              <div className="user-menu__accounts">
+                {savedAccounts.map((saved) => {
+                  const active = saved.id === activeAccountId;
+                  const rowName = switcherDisplayName(saved);
+                  const q = mergeAccountQuota(
+                    saved.id,
+                    saved.email,
+                    accountQuotas,
+                    {
+                      id: activeAccountId,
+                      email: profile?.email,
+                      remaining,
+                      used: usedPct,
+                      resetsAt: billing?.resetsAt ?? null,
+                    },
+                  );
+                  const rowRemain = q?.remainingPercent ?? null;
+                  const rowUsed = q?.usedPercent ?? null;
+                  const rowReset = formatQuotaResetTime(q?.resetsAt);
+                  const rowRemainLabel = formatQuotaRemainLabel(rowRemain);
+                  const low = rowRemain != null && rowRemain <= 10;
+                  return (
+                    <button
+                      key={saved.id}
+                      type="button"
+                      className={
+                        "user-menu__account" +
+                        (active ? " is-active" : "") +
+                        (low ? " is-low" : "")
+                      }
+                      role="menuitem"
+                      disabled={accountBusy}
+                      aria-current={active ? "true" : undefined}
+                      aria-label={
+                        active
+                          ? `${rowName}, ${labels.profileActive}`
+                          : `${labels.switchTo}: ${rowName}`
+                      }
+                      onClick={() => {
+                        if (active) {
+                          onClose();
+                          onAccountSettings();
+                          return;
+                        }
+                        if (!onSwitchAccount) return;
+                        onClose();
+                        onSwitchAccount(saved.id);
+                      }}
+                    >
+                      <div className="user-menu__account-top">
+                        <div
+                          className="account-avatar account-avatar--sm"
+                          aria-hidden
+                        >
+                          {active && signedIn ? (
+                            <GrokLogo size={17} />
+                          ) : (
+                            rowName.slice(0, 1).toUpperCase()
+                          )}
+                        </div>
+                        <div className="user-menu__account-text">
+                          <div className="user-menu__account-name-row">
+                            <div className="user-menu__account-id">
+                              <div className="user-menu__account-name">
+                                {rowName}
+                              </div>
+                              {active ? (
+                                <span className="user-menu__current">
+                                  {labels.profileActive}
+                                </span>
+                              ) : null}
+                            </div>
+                            {rowReset ? (
+                              <span className="user-menu__quota-reset">
+                                {labels.resetsAt} {rowReset}
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className="user-menu__quota">
+                            <div className="user-menu__quota-row">
+                              <span className="user-menu__tier">
+                                {active
+                                  ? tier
+                                  : saved.email && saved.email !== rowName
+                                    ? saved.email
+                                    : "\u00a0"}
+                              </span>
+                              <span className="user-menu__remain">
+                                {rowRemainLabel
+                                  ? `${rowRemainLabel} ${labels.remaining}`
+                                  : "—"}
+                              </span>
+                            </div>
+                            {rowRemainLabel ? (
+                              <div
+                                className="account-quota-bar account-quota-bar--sm"
+                                aria-hidden
+                              >
+                                <div
+                                  className={
+                                    "account-quota-bar__fill" +
+                                    (rowUsed != null && rowUsed >= 90
+                                      ? " is-danger"
+                                      : rowUsed != null && rowUsed >= 70
+                                        ? " is-warn"
+                                        : "")
+                                  }
+                                  style={{
+                                    width: `${Math.min(100, rowUsed ?? 0)}%`,
+                                  }}
+                                />
+                              </div>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
             <button
               type="button"
               className="user-menu__account"
@@ -441,9 +580,7 @@ export function UserMenu({
                       <div className="user-menu__quota-row">
                         <span className="user-menu__tier">{tier}</span>
                         <span className="user-menu__remain">
-                          {remaining != null
-                            ? `${remaining.toFixed(0)}% ${labels.remaining}`
-                            : "—"}
+                          {remainText}
                         </span>
                       </div>
                       {remaining != null && (
@@ -471,6 +608,7 @@ export function UserMenu({
                 </div>
               </div>
             </button>
+            )}
 
             <button
               type="button"

--- a/src/i18n/messages/en/account.ts
+++ b/src/i18n/messages/en/account.ts
@@ -113,6 +113,7 @@ export const enAccount = {
   "account.profileSwitch": "Switch",
   "account.profileRemove": "Remove",
   "account.profileActive": "Active",
+  "account.switchTo": "Switch to this account",
   "account.manageAccounts": "Switch account",
   "account.addAccount": "Add account",
   "account.profileSaved": "Account saved",

--- a/src/i18n/messages/zh-TW/account.ts
+++ b/src/i18n/messages/zh-TW/account.ts
@@ -113,6 +113,7 @@ export const zhTWAccount = {
   "account.profileSwitch": "切換",
   "account.profileRemove": "移除",
   "account.profileActive": "目前",
+  "account.switchTo": "切換到此帳號",
   "account.manageAccounts": "切換帳號",
   "account.addAccount": "新增帳號",
   "account.profileSaved": "已儲存帳號",

--- a/src/i18n/messages/zh/account.ts
+++ b/src/i18n/messages/zh/account.ts
@@ -113,6 +113,7 @@ export const zhAccount = {
   "account.profileSwitch": "切换",
   "account.profileRemove": "移除",
   "account.profileActive": "当前",
+  "account.switchTo": "切换到此账号",
   "account.manageAccounts": "切换账号",
   "account.addAccount": "添加账号",
   "account.profileSaved": "已保存账号",

--- a/src/lib/accountSwitcherQuota.test.ts
+++ b/src/lib/accountSwitcherQuota.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSwitcherQuotaKnown,
+  liveQuotaFromBilling,
+  mergeAccountQuota,
+  quotaFromHostItem,
+  switcherDisplayName,
+} from "./accountSwitcherQuota";
+
+describe("switcherDisplayName", () => {
+  it("prefers displayName", () => {
+    expect(
+      switcherDisplayName({
+        displayName: "Gusts",
+        label: "dannier87666@gmail.com",
+        email: "dannier87666@gmail.com",
+      }),
+    ).toBe("Gusts");
+  });
+
+  it("falls back to label without a trailing percent suffix", () => {
+    expect(
+      switcherDisplayName({
+        displayName: "",
+        label: "Work · 12% remaining",
+        email: "a@b.com",
+      }),
+    ).toBe("Work");
+  });
+});
+
+describe("quotaFromHostItem", () => {
+  it("nulls percents when the Host marks the probe unavailable", () => {
+    expect(
+      quotaFromHostItem({
+        remainingPercent: 0,
+        usedPercent: 100,
+        available: false,
+      }),
+    ).toEqual({
+      remainingPercent: null,
+      usedPercent: null,
+      resetsAt: null,
+      available: false,
+    });
+  });
+
+  it("keeps a real exhausted quota", () => {
+    const q = quotaFromHostItem({
+      remainingPercent: 0,
+      usedPercent: 100,
+      available: true,
+    });
+    expect(q.available).toBe(true);
+    expect(q.remainingPercent).toBe(0);
+    expect(q.usedPercent).toBe(100);
+  });
+});
+
+describe("liveQuotaFromBilling", () => {
+  it("does not invent remaining when billing is silent", () => {
+    const q = liveQuotaFromBilling({ available: true });
+    expect(q.available).toBe(false);
+    expect(q.remainingPercent).toBeNull();
+    expect(q.usedPercent).toBeNull();
+  });
+});
+
+describe("mergeAccountQuota", () => {
+  it("uses fetched snapshot when the probe is known", () => {
+    const q = mergeAccountQuota(
+      "u2",
+      "b@x.ai",
+      {
+        u2: {
+          remainingPercent: 8,
+          usedPercent: 92,
+          resetsAt: null,
+          available: true,
+        },
+      },
+      { id: "u1", email: "a@x.ai", remaining: 70, used: 30 },
+    );
+    expect(q?.remainingPercent).toBe(8);
+  });
+
+  it("seeds the current account from live billing before fetch returns", () => {
+    const q = mergeAccountQuota(
+      "u1",
+      "a@x.ai",
+      {},
+      { id: "u1", email: "a@x.ai", remaining: 69, used: 31, resetsAt: "t" },
+    );
+    expect(q).toEqual({
+      remainingPercent: 69,
+      usedPercent: 31,
+      resetsAt: "t",
+      available: true,
+    });
+  });
+
+  it("keeps live current quota when the later probe failed", () => {
+    const q = mergeAccountQuota(
+      "u1",
+      "a@x.ai",
+      {
+        u1: {
+          remainingPercent: null,
+          usedPercent: null,
+          resetsAt: null,
+          available: false,
+        },
+      },
+      { id: "u1", email: "a@x.ai", remaining: 69, used: 31 },
+    );
+    expect(q?.remainingPercent).toBe(69);
+    expect(isSwitcherQuotaKnown(q)).toBe(true);
+  });
+
+  it("does not invent quota for other accounts", () => {
+    expect(
+      mergeAccountQuota(
+        "u2",
+        "b@x.ai",
+        {},
+        { id: "u1", email: "a@x.ai", remaining: 69, used: 31 },
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/accountSwitcherQuota.ts
+++ b/src/lib/accountSwitcherQuota.ts
@@ -1,0 +1,132 @@
+/**
+ * User-menu multi-account quota list.
+ *
+ * Reuses SuperGrok honesty helpers — never invents 0% / 100% when the probe
+ * is silent. Switching still goes through `account_switch`.
+ */
+
+import {
+  resolveQuotaPercents,
+  type QuotaBillingLike,
+} from "./accountQuotaHonesty";
+
+export type SwitcherQuota = {
+  remainingPercent: number | null;
+  usedPercent: number | null;
+  resetsAt: string | null;
+  available: boolean;
+};
+
+export function switcherDisplayName(a: {
+  displayName?: string | null;
+  label: string;
+  email?: string | null;
+}): string {
+  const name = (a.displayName || "").trim();
+  if (name) return name;
+  const label = (a.label || "").replace(/\s*·\s*\d+(?:\.\d+)?%\s*.*$/, "").trim();
+  if (label) return label;
+  return (a.email || "").trim() || "Grok";
+}
+
+export function isSwitcherQuotaKnown(
+  q: SwitcherQuota | null | undefined,
+): boolean {
+  if (!q || !q.available) return false;
+  return (
+    (q.remainingPercent != null && Number.isFinite(q.remainingPercent)) ||
+    (q.usedPercent != null && Number.isFinite(q.usedPercent))
+  );
+}
+
+/** Map a Host `accounts_quota` row through the same honesty rules as billing. */
+export function quotaFromHostItem(item: {
+  remainingPercent?: number | null;
+  usedPercent?: number | null;
+  resetsAt?: string | null;
+  available: boolean;
+}): SwitcherQuota {
+  if (!item.available) {
+    return {
+      remainingPercent: null,
+      usedPercent: null,
+      resetsAt: null,
+      available: false,
+    };
+  }
+  const percents = resolveQuotaPercents({
+    remainingPercent: item.remainingPercent,
+    creditUsagePercent: item.usedPercent,
+    available: item.available,
+  } satisfies QuotaBillingLike);
+  const known =
+    percents.remainingPercent != null || percents.usedPercent != null;
+  return {
+    remainingPercent: percents.remainingPercent,
+    usedPercent: percents.usedPercent,
+    resetsAt: item.resetsAt ?? null,
+    available: known,
+  };
+}
+
+export function liveQuotaFromBilling(
+  billing: QuotaBillingLike | null | undefined,
+  resetsAt?: string | null,
+): SwitcherQuota {
+  const percents = resolveQuotaPercents(billing);
+  const known =
+    percents.remainingPercent != null || percents.usedPercent != null;
+  return {
+    remainingPercent: percents.remainingPercent,
+    usedPercent: percents.usedPercent,
+    resetsAt: resetsAt ?? null,
+    available: known,
+  };
+}
+
+/**
+ * Prefer a successful `accounts_quota` row.
+ * Current account falls back to the live `account_status` snapshot so the
+ * active row does not flash empty while other accounts are still probing.
+ * Other accounts stay null (UI shows "—") until a real probe returns.
+ */
+export function mergeAccountQuota(
+  id: string,
+  email: string | null | undefined,
+  fetched: Record<string, SwitcherQuota>,
+  current: {
+    id?: string | null;
+    email?: string | null;
+    remaining: number | null;
+    used: number | null;
+    resetsAt?: string | null;
+  },
+): SwitcherQuota | null {
+  const hit = fetched[id];
+  if (isSwitcherQuotaKnown(hit)) return hit;
+
+  const isCurrent =
+    (!!current.id && current.id === id) ||
+    (!!email && !!current.email && email === current.email);
+  const live: SwitcherQuota | null = isCurrent
+    ? {
+        remainingPercent: current.remaining,
+        usedPercent: current.used,
+        resetsAt: current.resetsAt ?? null,
+        available:
+          (current.remaining != null && Number.isFinite(current.remaining)) ||
+          (current.used != null && Number.isFinite(current.used)),
+      }
+    : null;
+
+  if (isSwitcherQuotaKnown(live)) return live;
+  if (hit) {
+    return {
+      remainingPercent: null,
+      usedPercent: null,
+      resetsAt: null,
+      available: false,
+    };
+  }
+  return live;
+}

--- a/src/lib/api/account.ts
+++ b/src/lib/api/account.ts
@@ -228,6 +228,24 @@ export async function accountsList() {
   return invoke<AccountsListResult>("accounts_list");
 }
 
+export interface AccountQuotaItem {
+  id: string;
+  remainingPercent?: number | null;
+  usedPercent?: number | null;
+  subscriptionTier?: string | null;
+  resetsAt?: string | null;
+  available: boolean;
+}
+
+export interface AccountsQuotaResult {
+  items: AccountQuotaItem[];
+  fetchedAt?: string;
+}
+
+export async function accountsQuota() {
+  return invoke<AccountsQuotaResult>("accounts_quota");
+}
+
 export async function accountSaveCurrent(label?: string | null) {
   return invoke<SavedAccount>("account_save_current", {
     label: label ?? null,

--- a/src/styles/sidebar.part4.css
+++ b/src/styles/sidebar.part4.css
@@ -364,8 +364,45 @@ html[data-sidebar-density="compact"] .session-row__meta {
   margin-bottom: 2px;
 }
 
+.user-menu__accounts {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+
 .user-menu__account:hover {
   background: var(--bg-active);
+}
+
+.user-menu__account.is-active {
+  border-color: color-mix(in srgb, var(--accent, #6b9fff) 45%, transparent);
+  background: color-mix(in srgb, var(--accent, #6b9fff) 10%, transparent);
+}
+
+.user-menu__account.is-low .user-menu__remain {
+  color: var(--danger, #e25555);
+}
+
+.user-menu__account-id {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1;
+}
+
+.user-menu__current {
+  flex-shrink: 0;
+  margin-left: 0;
+  padding: 0 5px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--text-secondary) 12%, transparent);
+  vertical-align: middle;
 }
 
 .user-menu__account-top {


### PR DESCRIPTION
## Summary

Implements [#621](https://github.com/RongleCat/grok-app/issues/621) on current `main`.

The sidebar user menu lists every saved official account with honest SuperGrok remaining %. Click a non-active row to `account_switch`. Click the active row to open **Settings → Account**. The full switcher stays in Settings.

## Constraints (from triage)

- Reuse `accounts_list` / `account_switch` / existing SuperGrok honesty helpers (`accountQuotaHonesty`, `fetch_quota_best_effort`).
- Never invent `0%` / `100%` when the probe failed — show **—**.
- Fetch other accounts when the menu **opens** (best-effort). Seed the active row from the live `account_status` snapshot so it does not flash empty.
- Active row click still opens Settings → Account. Custom-provider / signed-out cards stay as they are.
- i18n: `en` / `zh` / `zh-TW` (`account.switchTo`). No native `<select>` / `window.confirm`.

`accounts_quota` is a small Host helper so inactive snapshots can be probed in parallel without switching. It does not invent percents (`source == error|empty` or `last_error` → unavailable).

## Test plan

- [x] `vitest` for `accountSwitcherQuota` + i18n catalogs
- [x] `tsc --noEmit`
- [ ] `cargo test` `account_profiles` (Host: failed probe hides %; real 0% remaining is kept)
- [ ] Desktop: open user menu with 2+ official snapshots — current row has live % immediately; others fill or stay **—**
- [ ] Click non-active row → switches via existing `account_switch` + agent recycle
- [ ] Click active row → Settings → Account
- [ ] Custom provider / signed-out → original single card (DeepSeek balance / login)