### PR TITLE
fix(desktop): Windows file drop, Linux window chrome, long-chat blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,18 @@ See `docs/llm-wiki/release.md`.
 - **README Gatekeeper 说明**：官方 Release 从 v0.2.19 起已签名并公证。`xattr` 仅留给 fork / 旧的未签名包。
 
 ### Fixed
+- **Windows file / image drop into the composer**: WebView2 cannot use HTML5 `Files` while Tauri owns the drop target. Windows builds now set `dragDropEnabled: false` and handle Explorer drops in capture-phase HTML5 (temp-file attach when `File.path` is missing). Overlay + `@path` still work.
+- **Linux maximize / minimize**: Linux was decorated with no in-app caption buttons, and GTK/Wayland often no-ops `toggleMaximize`. Linux is now frameless with the same min/max/close chrome as Windows; maximize falls back to filling the monitor work area when the compositor ignores GTK.
+- **Long chat / long article blanks the transcript** (community, [@y7469591](https://x.com/y7469591/status/2088917279966917116)): One huge message or spacer could exceed the WebView compositor layer and paint white (scroll also stuck). Virtualize by estimated height, split tall spacers, and cap a single message body at 4096px with inner scroll.
 - **Fork no longer pins the parent chat on 连接中**: After `_x.ai/session/fork` the CLI is still hydrating parent context. Post-open `session/set_mode` used to walk every agent-mode alias (`agent` / `default` / `code` / `normal` / `Agent`) at 45s each — ~4 minutes of handshake, no `session/prompt`, both the fork and the original chat stuck on Connecting / Thinking. Fork skips that nudge (spawn already has `--permission-mode`); any later `set_mode` transport timeout aborts the remaining aliases.
 - **New-session composer no longer restores the just-sent prompt (#620)**: Sending from the New session page materializes a chat and leaves the draft view, so persist-clear used to be skipped. The per-project new-session buffer is now wiped on success.
 - **Telegram topic replies stay in the topic (#623)**: Inbound `message_thread_id` is kept and sent back on `sendMessage` / cards / edits. With **thread isolation** on, each topic is its own agent binding.
 - **Custom Grok / vision relays can read image attachments (#618)**: Settings → Account → Custom providers has **This model can see images**. Grok / GPT-4o / Claude / Gemini names already count. Unknown relays stay text-only so DeepSeek-style APIs do not 400 on `image_url`. Vision mains keep `@path` pixels and no longer hit the `read_file` image hook.
 
 **中文 · 修复**
+- **Windows 无法把图片/文件拖进输入框**：Tauri 接管 WebView2 拖放后 HTML5 `Files` 是空的。Windows 现在关掉原生 drop handler，改用捕获阶段 HTML5（没有 `File.path` 就存临时文件再附加）。
+- **Linux 无法最大化/最小化**：以前走系统标题栏、应用内没有按钮，GTK/Wayland 上 `toggleMaximize` 经常没反应。Linux 改为与 Windows 一样的无边框自绘按钮；合成器忽略 GTK 最大化时，退化为铺满工作区。
+- **长对话 / 长文章后聊天变空白、滚不动**（社区反馈 [@y7469591](https://x.com/y7469591/status/2088917279966917116)）：超高消息或占位层会撑爆 WebView 合成层。现在按预估高度虚拟化、拆开超高 spacer，单条消息正文限高 4096px 内部滚动。
 - **分叉后不再把原会话卡在「连接中」**：`session/fork` 之后 CLI 还在灌父会话。以前会连试 5 个 `session/set_mode` 别名，每个等 45 秒，握手约 4 分钟，消息发不出去，分叉和原会话一起停在连接中/思考中。分叉后不再做这次 nudge；之后若 `set_mode` 是传输超时，立刻停掉剩余别名。
 - **新建会话发送后不再把刚发出的草稿带回来（#620）**：从「新建会话」发出去会落成真实会话并离开草稿页，以前会跳过清空。成功后现在会清掉该项目的新建会话草稿。
 - **Telegram 话题回复回到原话题（#623）**：入站保留 `message_thread_id`，出站 `sendMessage` / 卡片 / 编辑一并带回。打开 **按话题隔离** 后，每个 Topic 是独立 Agent 绑定。

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,7 @@
     "core:window:allow-outer-position",
     "core:window:allow-scale-factor",
     "core:window:allow-set-size",
+    "core:window:allow-set-position",
     "core:window:allow-set-title",
     "core:window:allow-set-focus",
     "core:window:allow-show",

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -15,8 +15,7 @@
         "decorations": false,
         "transparent": false,
         "center": true,
-        "shadow": true,
-        "dragDropEnabled": false
+        "shadow": true
       }
     ]
   }

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -58,7 +58,16 @@ import {
   stopAllResultToast,
   type StopAllSurface,
 } from "@/lib/stopAllHonesty";
-import { detectAppPlatform, revealInOsLabel } from "@/lib/appPlatform";
+import {
+  detectAppPlatform,
+  revealInOsLabel,
+  usesCustomWindowChrome,
+} from "@/lib/appPlatform";
+import {
+  isFileDrag,
+  pathsFromDroppedFiles,
+  shouldSkipHtml5AfterNative,
+} from "@/lib/fileDrop";
 import { writeOpenTargetStorage } from "@/lib/openEditorHonesty";
 import {
   APP_CLOSE_REQUESTED_EVENT,
@@ -2372,6 +2381,9 @@ export function AppWorkbench() {
   const [dragZone, setDragZone] = useState<"sidebar" | "main" | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const dragPathsRef = useRef<string[]>([]);
+  /** Tauri OS drop timestamp — HTML5 fallback must not double-attach. */
+  const lastNativeDropAtRef = useRef(0);
+  const html5DragDepthRef = useRef(0);
   const layoutRef = useRef(layout);
   layoutRef.current = layout;
   const [, setSetup] = useState({ cli: false, auth: false, project: false });
@@ -2630,8 +2642,8 @@ export function AppWorkbench() {
   const [accountProbeError, setAccountProbeError] = useState<unknown>(null);
   const [loginHint, setLoginHint] = useState<string | null>(null);
   const platform = useMemo(() => detectAppPlatform(), []);
-  /** Self-drawn chrome when OS title bar is disabled (Windows release config). */
-  const useCustomWindowChrome = platform === "win" || platform === "other";
+  /** Self-drawn chrome when OS title bar is disabled (Win / Linux frameless). */
+  const useCustomWindowChrome = usesCustomWindowChrome(platform);
   /** Titlebar / chrome-strip double-click → maximize on mac + win. */
   const titlebarMax = titlebarMaximizeHandlers({
     enabled: !phoneLayout && !isMirrorClient(),
@@ -2956,10 +2968,12 @@ export function AppWorkbench() {
     document.documentElement.classList.remove(
       "platform-mac",
       "platform-win",
+      "platform-linux",
       "platform-other",
     );
     if (platform === "mac") document.documentElement.classList.add("platform-mac");
     if (platform === "win") document.documentElement.classList.add("platform-win");
+    if (platform === "linux") document.documentElement.classList.add("platform-linux");
     if (platform === "other") document.documentElement.classList.add("platform-other");
   }, [platform]);
 
@@ -8259,8 +8273,10 @@ export function AppWorkbench() {
       const seenPath = new Set<string>();
       const seenBlob = new Set<string>();
       for (const f of files) {
-        if (!f || f.size <= 0) continue;
+        if (!f) continue;
         const anyF = f as File & { path?: string };
+        // WebView2 Explorer drops can report size 0 while File.path is set.
+        if (f.size <= 0 && !anyF.path) continue;
         if (anyF.path) {
           if (seenPath.has(anyF.path)) continue;
           seenPath.add(anyF.path);
@@ -8653,6 +8669,7 @@ export function AppWorkbench() {
               : dragPathsRef.current;
             setDragZone(null);
             dragPathsRef.current = [];
+            lastNativeDropAtRef.current = Date.now();
             if (!paths.length) {
               setLocalError(tr("attach.droppedNone"));
               return;
@@ -8682,50 +8699,71 @@ export function AppWorkbench() {
     tr,
   ]);
 
-  // HTML5 fallback: some image drags only expose File list in the webview.
-  // Prefer Tauri paths; use File.path when present (Tauri webview).
+  // HTML5 fallback. Windows sets dragDropEnabled:false so WebView2 actually
+  // delivers File blobs (Tauri's native handler otherwise swallows Explorer
+  // drops). Capture phase so contenteditable cannot cancel the drop.
   useEffect(() => {
-    const onDragOver = (e: DragEvent) => {
-      if (!e.dataTransfer?.types?.includes("Files")) return;
+    const onDragEnter = (e: DragEvent) => {
+      if (!isFileDrag(e.dataTransfer)) return;
       e.preventDefault();
-      e.dataTransfer.dropEffect = "copy";
+      html5DragDepthRef.current += 1;
+      setDragZone(hitDragZone(e.clientX, e.clientY));
+    };
+    const onDragOver = (e: DragEvent) => {
+      if (!isFileDrag(e.dataTransfer)) return;
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+      setDragZone(hitDragZone(e.clientX, e.clientY));
+    };
+    const onDragLeave = (e: DragEvent) => {
+      if (!isFileDrag(e.dataTransfer)) return;
+      html5DragDepthRef.current = Math.max(0, html5DragDepthRef.current - 1);
+      if (html5DragDepthRef.current === 0) setDragZone(null);
     };
     const onDrop = (e: DragEvent) => {
-      if (!e.dataTransfer?.files?.length) return;
-      // If Tauri already handled this OS drop, paths may be empty here.
-      const files = Array.from(e.dataTransfer.files);
-      const paths = files
-        .map((f) => {
-          const anyF = f as File & { path?: string };
-          return anyF.path || "";
-        })
-        .filter(Boolean);
+      html5DragDepthRef.current = 0;
+      setDragZone(null);
+      if (!isFileDrag(e.dataTransfer)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      if (shouldSkipHtml5AfterNative(lastNativeDropAtRef.current, Date.now())) {
+        return;
+      }
+      const files = e.dataTransfer?.files?.length
+        ? Array.from(e.dataTransfer.files)
+        : [];
+      const paths = pathsFromDroppedFiles(files);
       const zone = hitDragZone(e.clientX, e.clientY);
       if (paths.length) {
-        e.preventDefault();
-        e.stopPropagation();
         if (zone === "sidebar") void addProjectsFromPaths(paths);
         else void addAttachmentsFromPaths(paths);
         return;
       }
-      // Browser-only / path-less File list (e.g. image from another app)
+      // Path-less File list (Windows Explorer after dragDropEnabled:false,
+      // or an image dragged from another app).
       if (zone !== "sidebar" && files.length) {
-        e.preventDefault();
-        e.stopPropagation();
         void addAttachmentsFromFiles(files);
+      } else if (!files.length) {
+        setLocalError(tr("attach.droppedNone"));
       }
     };
-    window.addEventListener("dragover", onDragOver);
-    window.addEventListener("drop", onDrop);
+    const opts: AddEventListenerOptions = { capture: true };
+    window.addEventListener("dragenter", onDragEnter, opts);
+    window.addEventListener("dragover", onDragOver, opts);
+    window.addEventListener("dragleave", onDragLeave, opts);
+    window.addEventListener("drop", onDrop, opts);
     return () => {
-      window.removeEventListener("dragover", onDragOver);
-      window.removeEventListener("drop", onDrop);
+      window.removeEventListener("dragenter", onDragEnter, opts);
+      window.removeEventListener("dragover", onDragOver, opts);
+      window.removeEventListener("dragleave", onDragLeave, opts);
+      window.removeEventListener("drop", onDrop, opts);
     };
   }, [
     addAttachmentsFromFiles,
     addAttachmentsFromPaths,
     addProjectsFromPaths,
     hitDragZone,
+    tr,
   ]);
 
   // Drag-resize right resource pane.

--- a/src/components/WindowControls.tsx
+++ b/src/components/WindowControls.tsx
@@ -1,10 +1,18 @@
 /**
- * Self-drawn window chrome for Windows (and other non-mac platforms when
- * decorations are disabled). macOS uses native Overlay traffic lights.
+ * Self-drawn window chrome for Windows / Linux (frameless) and other
+ * non-mac platforms when decorations are disabled. macOS uses Overlay
+ * traffic lights.
  */
 import { useCallback, useEffect, useState } from "react";
 import { IconClose, IconMaximize, IconMinimize } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
+import {
+  isFakeMaximized,
+  toggleMaximizeFromTitlebar,
+  toggleMaximizeReliable,
+} from "@/lib/windowChrome";
+
+export { toggleMaximizeFromTitlebar } from "@/lib/windowChrome";
 
 type Props = {
   visible: boolean;
@@ -22,7 +30,8 @@ export function WindowControls({ visible, labels }: Props) {
   const refreshMaximized = useCallback(async () => {
     try {
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
-      setMaximized(await getCurrentWindow().isMaximized());
+      const os = await getCurrentWindow().isMaximized();
+      setMaximized(os || isFakeMaximized());
     } catch {
       /* browser / no window API */
     }
@@ -57,8 +66,7 @@ export function WindowControls({ visible, labels }: Props) {
       const w = getCurrentWindow();
       if (action === "minimize") await w.minimize();
       if (action === "toggleMaximize") {
-        await w.toggleMaximize();
-        await refreshMaximized();
+        setMaximized(await toggleMaximizeReliable());
       }
       if (action === "close") await w.close();
     } catch {
@@ -111,29 +119,6 @@ export function WindowControls({ visible, labels }: Props) {
       </Tip>
     </div>
   );
-}
-
-/**
- * Double-click titlebar / chrome drag strip → maximize/restore.
- * Used on every desktop host (mac Overlay drag regions do not always get
- * native zoom; Win frameless has no system caption). Prefer true maximize
- * over macOS "zoom" so the workbench can use the full work area.
- *
- * Debounced: drag regions may emit both mousedown(detail=2) and dblclick;
- * without a guard that would toggleMaximize twice (no-op).
- */
-let lastTitlebarMaximizeMs = 0;
-
-export async function toggleMaximizeFromTitlebar(): Promise<void> {
-  const now = Date.now();
-  if (now - lastTitlebarMaximizeMs < 400) return;
-  lastTitlebarMaximizeMs = now;
-  try {
-    const { getCurrentWindow } = await import("@tauri-apps/api/window");
-    await getCurrentWindow().toggleMaximize();
-  } catch {
-    /* browser / no window API */
-  }
 }
 
 /** True when the event target is chrome that should not start window chrome actions. */

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -84,7 +84,10 @@ import {
 import type { ModelOption } from "@/lib/grokCatalog";
 import { useStickToBottom } from "@/hooks/useStickToBottom";
 import { useChatMessageVirtualizer } from "@/hooks/useChatMessageVirtualizer";
-import { estimateChatRowHeight } from "@/lib/chatVirtualList";
+import {
+  estimateChatRowHeight,
+  splitVirtSpacerHeights,
+} from "@/lib/chatVirtualList";
 import { StructuredJsonPanel } from "./StructuredJsonPanel";
 import {
   MessageActionButton,
@@ -2362,13 +2365,16 @@ export function ConversationThread({
             </div>
           ) : null}
 
-          {virtualized && paddingTop > 0 ? (
-            <div
-              aria-hidden
-              className="lobe-chat__virt-spacer"
-              style={{ height: paddingTop, flexShrink: 0 }}
-            />
-          ) : null}
+          {virtualized && paddingTop > 0
+            ? splitVirtSpacerHeights(paddingTop).map((h, i) => (
+                <div
+                  key={`virt-top-${i}`}
+                  aria-hidden
+                  className="lobe-chat__virt-spacer"
+                  style={{ height: h, flexShrink: 0 }}
+                />
+              ))
+            : null}
 
           {visibleMessages.map(({ m, index: msgIndex }) => (
             <TranscriptMessageRow
@@ -2431,13 +2437,16 @@ export function ConversationThread({
             />
           ))}
 
-          {virtualized && paddingBottom > 0 ? (
-            <div
-              aria-hidden
-              className="lobe-chat__virt-spacer"
-              style={{ height: paddingBottom, flexShrink: 0 }}
-            />
-          ) : null}
+          {virtualized && paddingBottom > 0
+            ? splitVirtSpacerHeights(paddingBottom).map((h, i) => (
+                <div
+                  key={`virt-bot-${i}`}
+                  aria-hidden
+                  className="lobe-chat__virt-spacer"
+                  style={{ height: h, flexShrink: 0 }}
+                />
+              ))
+            : null}
 
           {/* Tool before any assistant bubble — only if not already a message row. */}
           {showToolChrome &&

--- a/src/components/lobe-chat/lobe-chat.part1.css
+++ b/src/components/lobe-chat/lobe-chat.part1.css
@@ -153,8 +153,9 @@
   gap: var(--chat-item-gap, 8px);
   /* Isolate layout so stream growth on the tail row dirties less of the
    * surrounding tree during markdown reflow (Intel Retina). Avoid
-   * content-visibility here — the list is already virtualized. */
-  contain: layout style;
+   * content-visibility here — the list is already virtualized.
+   * paint: keep one tall article from compositing the whole transcript. */
+  contain: layout style paint;
 }
 
 .lobe-chat-item--user {
@@ -177,7 +178,18 @@
   gap: var(--chat-item-body-gap, 10px);
   max-width: 100%;
   min-width: 0;
+  /* Cap one mega-article so WebView/WebKit does not blank the layer
+   * (GPU texture limit; see CHAT_MESSAGE_PAINT_CAP_PX). */
+  max-height: 4096px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.lobe-chat__virt-spacer {
+  contain: strict;
   overflow: hidden;
+  pointer-events: none;
 }
 
 .lobe-chat-item--assistant .lobe-chat-item__body {

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -35,6 +35,7 @@ import {
   resolveChatOverscanPx,
   scrollTopAfterHeightChange,
   shouldCommitRowHeight,
+  shouldVirtualizeChat,
   type ChatVirtualWindow,
 } from "@/lib/chatVirtualList";
 import { resolveStreamOverscanScale } from "@/lib/streamRenderPolicy";
@@ -92,7 +93,22 @@ export function useChatMessageVirtualizer(
     enabled = true,
   } = args;
 
-  const virtualized = enabled && itemCount >= threshold;
+  let estimatedTotal = 0;
+  if (enabled && itemCount > 0 && itemCount < threshold) {
+    for (let i = 0; i < itemCount; i++) {
+      const est = getEstimateHeight?.(i);
+      estimatedTotal +=
+        est != null && Number.isFinite(est) && est >= 0
+          ? est
+          : CHAT_DEFAULT_ROW_ESTIMATE_PX;
+    }
+  }
+  const virtualized = shouldVirtualizeChat({
+    itemCount,
+    threshold,
+    enabled,
+    estimatedTotalHeight: estimatedTotal,
+  });
   const heightsRef = useRef<Map<string, number>>(new Map());
   const getKeyRef = useRef(getKey);
   getKeyRef.current = getKey;

--- a/src/i18n/messages/en/composer.ts
+++ b/src/i18n/messages/en/composer.ts
@@ -188,7 +188,7 @@ export const enComposer = {
   "attach.copyPath": "Copy path",
   "attach.copyImage": "Copy image",
   "attach.addToComposer": "Add to input",
-  "attach.droppedNone": "Could not read dropped paths. Try again from Finder.",
+  "attach.droppedNone": "Could not read the dropped files. Try again from the file manager.",
   "attach.details": "Details",
   "attach.detailsTitle": "Details",
   "attach.detailsName": "Name",

--- a/src/i18n/messages/en/doctor.ts
+++ b/src/i18n/messages/en/doctor.ts
@@ -386,7 +386,7 @@ export const enDoctor = {
   "doctor.platformMatrix.msg.sandbox.unknown": "Sandbox kernel support unknown on this platform.",
   "doctor.platformMatrix.msg.chrome.macOverlay": "macOS Overlay title bar + traffic lights (tauri.macos.conf).",
   "doctor.platformMatrix.msg.chrome.winFrameless": "Windows frameless custom chrome (min / max / close) — tauri.windows.conf.",
-  "doctor.platformMatrix.msg.chrome.linuxDecorated": "Linux uses standard window decorations (base tauri.conf).",
+  "doctor.platformMatrix.msg.chrome.linuxFrameless": "Linux frameless custom chrome (min / max / close) — tauri.linux.conf.",
   "doctor.platformMatrix.msg.chrome.unknown": "Window chrome layout not classified for this platform.",
   "doctor.platformMatrix.msg.update.silent": "Signed release path: silent in-app auto-update is available.",
   "doctor.platformMatrix.msg.update.manual": "Manual / GitHub update path (local, unsigned, or plugin off) — open Releases; no silent install claimed.",

--- a/src/i18n/messages/zh-TW/composer.ts
+++ b/src/i18n/messages/zh-TW/composer.ts
@@ -187,7 +187,7 @@ export const zhTWComposer = {
   "attach.copyPath": "複製路徑",
   "attach.copyImage": "複製圖片",
   "attach.addToComposer": "新增到輸入框",
-  "attach.droppedNone": "無法讀取拖入的路徑，請從 Finder 再試一次。",
+  "attach.droppedNone": "無法讀取拖入的檔案，請從檔案管理員再試一次。",
   "attach.details": "詳情",
   "attach.detailsTitle": "詳情",
   "attach.detailsName": "名稱",

--- a/src/i18n/messages/zh-TW/doctor.ts
+++ b/src/i18n/messages/zh-TW/doctor.ts
@@ -386,7 +386,7 @@ export const zhTWDoctor = {
   "doctor.platformMatrix.msg.sandbox.unknown": "此平台的沙箱核心支援未知。",
   "doctor.platformMatrix.msg.chrome.macOverlay": "macOS Overlay 標題列 + 交通燈（tauri.macos.conf）。",
   "doctor.platformMatrix.msg.chrome.winFrameless": "Windows 無邊框自繪窗控（最小化 / 最大化 / 關閉）— tauri.windows.conf。",
-  "doctor.platformMatrix.msg.chrome.linuxDecorated": "Linux 使用標準視窗裝飾（基礎 tauri.conf）。",
+  "doctor.platformMatrix.msg.chrome.linuxFrameless": "Linux 無邊框自繪視窗按鈕（最小化 / 最大化 / 關閉）— tauri.linux.conf。",
   "doctor.platformMatrix.msg.chrome.unknown": "此平台的視窗裝飾佈局未分類。",
   "doctor.platformMatrix.msg.update.silent": "已簽名發行路徑：支援應用內靜默自動更新。",
   "doctor.platformMatrix.msg.update.manual": "手動 / GitHub 更新路徑（本機、未簽名或外掛關閉）— 開啟 Releases；不宣稱靜默安裝。",

--- a/src/i18n/messages/zh/composer.ts
+++ b/src/i18n/messages/zh/composer.ts
@@ -187,7 +187,7 @@ export const zhComposer = {
   "attach.copyPath": "复制路径",
   "attach.copyImage": "复制图片",
   "attach.addToComposer": "添加到输入框",
-  "attach.droppedNone": "无法读取拖入的路径，请从访达再试一次。",
+  "attach.droppedNone": "无法读取拖入的文件，请从文件管理器再试一次。",
   "attach.details": "详情",
   "attach.detailsTitle": "详情",
   "attach.detailsName": "名称",

--- a/src/i18n/messages/zh/doctor.ts
+++ b/src/i18n/messages/zh/doctor.ts
@@ -386,7 +386,7 @@ export const zhDoctor = {
   "doctor.platformMatrix.msg.sandbox.unknown": "此平台的沙箱内核支持未知。",
   "doctor.platformMatrix.msg.chrome.macOverlay": "macOS Overlay 标题栏 + 交通灯（tauri.macos.conf）。",
   "doctor.platformMatrix.msg.chrome.winFrameless": "Windows 无边框自绘窗控（最小化 / 最大化 / 关闭）— tauri.windows.conf。",
-  "doctor.platformMatrix.msg.chrome.linuxDecorated": "Linux 使用标准窗口装饰（基础 tauri.conf）。",
+  "doctor.platformMatrix.msg.chrome.linuxFrameless": "Linux 无边框自绘窗口按钮（最小化 / 最大化 / 关闭）— tauri.linux.conf。",
   "doctor.platformMatrix.msg.chrome.unknown": "此平台的窗口装饰布局未分类。",
   "doctor.platformMatrix.msg.update.silent": "已签名发行路径：支持应用内静默自动更新。",
   "doctor.platformMatrix.msg.update.manual": "手动 / GitHub 更新路径（本地、未签名或插件关闭）— 打开 Releases；不宣称静默安装。",

--- a/src/lib/appPlatform.test.ts
+++ b/src/lib/appPlatform.test.ts
@@ -3,6 +3,7 @@ import {
   detectAppPlatform,
   fileManagerOpenTarget,
   revealInOsMessageKey,
+  usesCustomWindowChrome,
 } from "./appPlatform";
 
 describe("detectAppPlatform", () => {
@@ -23,6 +24,15 @@ describe("revealInOsMessageKey", () => {
     expect(revealInOsMessageKey("win")).toBe("main.openInExplorer");
     expect(revealInOsMessageKey("linux")).toBe("main.openInFileManager");
     expect(revealInOsMessageKey("other")).toBe("main.openInFileManager");
+  });
+});
+
+describe("usesCustomWindowChrome", () => {
+  it("is frameless on Windows / Linux / other, native Overlay on mac", () => {
+    expect(usesCustomWindowChrome("win")).toBe(true);
+    expect(usesCustomWindowChrome("linux")).toBe(true);
+    expect(usesCustomWindowChrome("other")).toBe(true);
+    expect(usesCustomWindowChrome("mac")).toBe(false);
   });
 });
 

--- a/src/lib/appPlatform.ts
+++ b/src/lib/appPlatform.ts
@@ -7,6 +7,14 @@ import type { MessageKey } from "@/i18n";
 
 export type AppPlatform = "mac" | "win" | "linux" | "other";
 
+/**
+ * Self-drawn min/max/close (no native title bar).
+ * Windows + Linux ship frameless; `other` is the same fallback.
+ */
+export function usesCustomWindowChrome(platform: AppPlatform): boolean {
+  return platform === "win" || platform === "linux" || platform === "other";
+}
+
 /** Detect mac / Windows / Linux from a UA string (or `navigator.userAgent`). */
 export function detectAppPlatform(
   userAgent?: string | null,

--- a/src/lib/chatVirtualList.test.ts
+++ b/src/lib/chatVirtualList.test.ts
@@ -15,6 +15,8 @@ import {
   resolveChatOverscanPx,
   scrollTopAfterHeightChange,
   shouldCommitRowHeight,
+  shouldVirtualizeChat,
+  splitVirtSpacerHeights,
 } from "./chatVirtualList";
 
 const fixed = (h: number) => () => h;
@@ -414,5 +416,45 @@ describe("long transcript window scale", () => {
     expect(w.paddingBottom).toBe(0);
     // Not the whole list — only overscan above the tail.
     expect(w.start).toBeGreaterThan(count - 80);
+  });
+});
+
+describe("shouldVirtualizeChat", () => {
+  it("windows by row count or estimated height", () => {
+    expect(
+      shouldVirtualizeChat({ itemCount: 2, threshold: 16, estimatedTotalHeight: 200 }),
+    ).toBe(false);
+    expect(
+      shouldVirtualizeChat({ itemCount: 16, threshold: 16, estimatedTotalHeight: 200 }),
+    ).toBe(true);
+    expect(
+      shouldVirtualizeChat({
+        itemCount: 2,
+        threshold: 16,
+        estimatedTotalHeight: 5000,
+      }),
+    ).toBe(true);
+    expect(
+      shouldVirtualizeChat({
+        itemCount: 80,
+        enabled: false,
+        estimatedTotalHeight: 50_000,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("splitVirtSpacerHeights", () => {
+  it("returns nothing for empty / non-positive", () => {
+    expect(splitVirtSpacerHeights(0)).toEqual([]);
+    expect(splitVirtSpacerHeights(-10)).toEqual([]);
+  });
+
+  it("keeps a short spacer as one box", () => {
+    expect(splitVirtSpacerHeights(400)).toEqual([400]);
+  });
+
+  it("chunks a tall spacer under the compositor cap", () => {
+    expect(splitVirtSpacerHeights(9000, 4096)).toEqual([4096, 4096, 808]);
   });
 });

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -22,6 +22,24 @@ import { CHAT_VIRTUALIZE_THRESHOLD_PERF } from "@/lib/streamRenderPolicy";
  */
 export const CHAT_VIRTUALIZE_THRESHOLD = CHAT_VIRTUALIZE_THRESHOLD_PERF;
 
+/**
+ * Also virtualize when estimated transcript height exceeds this, even with
+ * few rows (one long article still creates a compositor-killing layer).
+ */
+export const CHAT_VIRTUALIZE_HEIGHT_PX = 4000;
+
+/**
+ * Max height of one spacer element. A single 50k-px box becomes one GPU
+ * layer and WebView/WebKit go blank (community: long article / long chat).
+ */
+export const CHAT_VIRT_SPACER_CHUNK_PX = 4096;
+
+/**
+ * CSS paint cap for a single message body (must match lobe-chat CSS).
+ * Keeps one markdown article under typical GPU texture limits (~8k).
+ */
+export const CHAT_MESSAGE_PAINT_CAP_PX = 4096;
+
 /** Fallback height before a row is measured (px). */
 export const CHAT_DEFAULT_ROW_ESTIMATE_PX = 120;
 
@@ -361,6 +379,45 @@ export function computeChatVirtualWindow(input: {
   const paddingBottom = Math.max(0, totalHeight - paddingTop - rendered);
 
   return { start, end, paddingTop, paddingBottom, totalHeight };
+}
+
+/** Window the DOM when row count or estimated height is large enough. */
+export function shouldVirtualizeChat(input: {
+  itemCount: number;
+  threshold?: number;
+  enabled?: boolean;
+  estimatedTotalHeight?: number;
+  heightThreshold?: number;
+}): boolean {
+  if (input.enabled === false) return false;
+  const count = Math.max(0, input.itemCount);
+  const rowThreshold = input.threshold ?? CHAT_VIRTUALIZE_THRESHOLD;
+  if (count >= rowThreshold) return true;
+  const height = input.estimatedTotalHeight ?? 0;
+  const heightThreshold = input.heightThreshold ?? CHAT_VIRTUALIZE_HEIGHT_PX;
+  return height >= heightThreshold;
+}
+
+/**
+ * Split a virtual spacer into compositor-safe chunks so one tall empty
+ * box cannot blank the WebView layer.
+ */
+export function splitVirtSpacerHeights(
+  total: number,
+  chunkPx: number = CHAT_VIRT_SPACER_CHUNK_PX,
+): number[] {
+  const h = Math.max(0, Math.round(total));
+  const chunk = Math.max(1, Math.round(chunkPx));
+  if (h <= 0) return [];
+  if (h <= chunk) return [h];
+  const out: number[] = [];
+  let left = h;
+  while (left > 0) {
+    const next = Math.min(chunk, left);
+    out.push(next);
+    left -= next;
+  }
+  return out;
 }
 
 /**

--- a/src/lib/doctorPlatformMatrix.test.ts
+++ b/src/lib/doctorPlatformMatrix.test.ts
@@ -117,7 +117,7 @@ describe("buildDoctorPlatformMatrix", () => {
     });
     const chrome = m.rows.find((r) => r.rowId === "window_chrome");
     expect(chrome?.messageKey).toBe(
-      "doctor.platformMatrix.msg.chrome.linuxDecorated",
+      "doctor.platformMatrix.msg.chrome.linuxFrameless",
     );
     const update = m.rows.find((r) => r.rowId === "auto_update");
     expect(update).toMatchObject({

--- a/src/lib/doctorPlatformMatrix.ts
+++ b/src/lib/doctorPlatformMatrix.ts
@@ -255,7 +255,7 @@ function sandboxEnforcementRow(
  * Window chrome from packaging configs:
  * - mac: Overlay title bar + traffic lights
  * - win: frameless custom chrome
- * - linux: standard decorations (base tauri.conf)
+ * - linux: frameless custom chrome (tauri.linux.conf)
  */
 function windowChromeRow(platform: AppPlatform): DoctorPlatformMatrixCell {
   switch (platform) {
@@ -275,7 +275,7 @@ function windowChromeRow(platform: AppPlatform): DoctorPlatformMatrixCell {
       return cell(
         "window_chrome",
         "pass",
-        "doctor.platformMatrix.msg.chrome.linuxDecorated",
+        "doctor.platformMatrix.msg.chrome.linuxFrameless",
       );
     case "other":
     default:

--- a/src/lib/fileDrop.test.ts
+++ b/src/lib/fileDrop.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  HTML5_NATIVE_DROP_GUARD_MS,
+  isFileDrag,
+  pathsFromDroppedFiles,
+  shouldSkipHtml5AfterNative,
+} from "./fileDrop";
+
+function dt(partial: {
+  types?: string[];
+  files?: { length: number };
+  items?: Array<{ kind: string }>;
+}): DataTransfer {
+  return partial as unknown as DataTransfer;
+}
+
+describe("isFileDrag", () => {
+  it("rejects null / empty", () => {
+    expect(isFileDrag(null)).toBe(false);
+    expect(isFileDrag(dt({ types: ["text/plain"] }))).toBe(false);
+  });
+
+  it("accepts Files / moz-file / uri-list", () => {
+    expect(isFileDrag(dt({ types: ["Files"] }))).toBe(true);
+    expect(isFileDrag(dt({ types: ["application/x-moz-file"] }))).toBe(true);
+    expect(isFileDrag(dt({ types: ["text/uri-list"] }))).toBe(true);
+  });
+
+  it("accepts FileList or items kind=file even without types", () => {
+    expect(isFileDrag(dt({ types: [], files: { length: 1 } }))).toBe(true);
+    expect(isFileDrag(dt({ types: [], items: [{ kind: "file" }] }))).toBe(
+      true,
+    );
+  });
+});
+
+describe("pathsFromDroppedFiles", () => {
+  it("keeps unique non-empty File.path", () => {
+    const a = { name: "a.png", path: "/tmp/a.png" } as File & { path: string };
+    const b = { name: "b.png", path: "" } as File & { path: string };
+    const c = { name: "a2.png", path: "/tmp/a.png" } as File & { path: string };
+    expect(pathsFromDroppedFiles([a, b, c])).toEqual(["/tmp/a.png"]);
+  });
+});
+
+describe("shouldSkipHtml5AfterNative", () => {
+  it("skips only inside the guard window", () => {
+    expect(shouldSkipHtml5AfterNative(1000, 1000)).toBe(true);
+    expect(
+      shouldSkipHtml5AfterNative(1000, 1000 + HTML5_NATIVE_DROP_GUARD_MS - 1),
+    ).toBe(true);
+    expect(
+      shouldSkipHtml5AfterNative(1000, 1000 + HTML5_NATIVE_DROP_GUARD_MS),
+    ).toBe(false);
+    expect(shouldSkipHtml5AfterNative(0, 50)).toBe(false);
+  });
+});

--- a/src/lib/fileDrop.ts
+++ b/src/lib/fileDrop.ts
@@ -1,0 +1,58 @@
+/**
+ * File drag-drop helpers (HTML5 DataTransfer + Tauri native path events).
+ *
+ * Windows WebView2: Tauri's native handler *replaces* the WebView2 drop
+ * target, so HTML5 `Files` is empty unless `dragDropEnabled` is false.
+ * See tauri.windows.conf.json. Path-less File blobs are saved via Host temp.
+ */
+
+/** How long HTML5 drop should yield to a just-handled Tauri OS drop. */
+export const HTML5_NATIVE_DROP_GUARD_MS = 400;
+
+/** True when this drag looks like OS files (Explorer / Finder / Nautilus). */
+export function isFileDrag(data: DataTransfer | null | undefined): boolean {
+  if (!data) return false;
+  const types = Array.from(data.types ?? []);
+  if (
+    types.includes("Files") ||
+    types.includes("application/x-moz-file") ||
+    types.includes("text/uri-list")
+  ) {
+    return true;
+  }
+  if (data.files && data.files.length > 0) return true;
+  const items = data.items;
+  if (items) {
+    for (let i = 0; i < items.length; i++) {
+      if (items[i]?.kind === "file") return true;
+    }
+  }
+  return false;
+}
+
+/** Absolute paths from WebView `File.path` (Electron / some WKWebView). */
+export function pathsFromDroppedFiles(files: Iterable<File>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const f of files) {
+    const path = ((f as File & { path?: string }).path || "").trim();
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    out.push(path);
+  }
+  return out;
+}
+
+/**
+ * Skip the HTML5 fallback when Tauri already consumed this OS drop.
+ * Prevents a second temp-file attach of the same Explorer/Finder files.
+ */
+export function shouldSkipHtml5AfterNative(
+  nativeDropAtMs: number,
+  nowMs: number,
+  windowMs: number = HTML5_NATIVE_DROP_GUARD_MS,
+): boolean {
+  if (!(nativeDropAtMs > 0) || !(nowMs >= 0)) return false;
+  const dt = nowMs - nativeDropAtMs;
+  return dt >= 0 && dt < windowMs;
+}

--- a/src/lib/windowChrome.test.ts
+++ b/src/lib/windowChrome.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  maximizeLooksNoop,
+  shouldAcceptTitlebarMaximize,
+  TITLEBAR_MAXIMIZE_DEBOUNCE_MS,
+} from "./windowChrome";
+
+describe("shouldAcceptTitlebarMaximize", () => {
+  it("debounces the second click of a drag-region pair", () => {
+    expect(shouldAcceptTitlebarMaximize(1000, 1000)).toBe(false);
+    expect(shouldAcceptTitlebarMaximize(1000, 1000 + 399)).toBe(false);
+    expect(
+      shouldAcceptTitlebarMaximize(1000, 1000 + TITLEBAR_MAXIMIZE_DEBOUNCE_MS),
+    ).toBe(true);
+  });
+});
+
+describe("maximizeLooksNoop", () => {
+  it("is true only when the flag did not flip", () => {
+    expect(maximizeLooksNoop(false, false)).toBe(true);
+    expect(maximizeLooksNoop(true, true)).toBe(true);
+    expect(maximizeLooksNoop(false, true)).toBe(false);
+    expect(maximizeLooksNoop(true, false)).toBe(false);
+  });
+});

--- a/src/lib/windowChrome.ts
+++ b/src/lib/windowChrome.ts
@@ -1,0 +1,155 @@
+/**
+ * Desktop window chrome helpers (frameless Win/Linux + titlebar dblclick).
+ *
+ * GTK/Wayland maximize is often a no-op; fall back to filling the monitor
+ * work area and remember the previous bounds so Restore works.
+ */
+
+export const TITLEBAR_MAXIMIZE_DEBOUNCE_MS = 400;
+
+/** Double-click / mousedown(detail=2) must not toggle twice. */
+export function shouldAcceptTitlebarMaximize(
+  lastMs: number,
+  nowMs: number,
+  debounceMs: number = TITLEBAR_MAXIMIZE_DEBOUNCE_MS,
+): boolean {
+  if (!(nowMs >= 0)) return false;
+  return nowMs - lastMs >= debounceMs;
+}
+
+/** OS `isMaximized` did not change after maximize/unmaximize. */
+export function maximizeLooksNoop(before: boolean, after: boolean): boolean {
+  return before === after;
+}
+
+type LogicalBounds = { x: number; y: number; w: number; h: number };
+
+let lastTitlebarMaximizeMs = 0;
+let fakeMaximized = false;
+let restoreBounds: LogicalBounds | null = null;
+
+/** Work-area fill used when the compositor ignores gtk_window_maximize. */
+export function isFakeMaximized(): boolean {
+  return fakeMaximized;
+}
+
+export function resetWindowChromeTestState(): void {
+  lastTitlebarMaximizeMs = 0;
+  fakeMaximized = false;
+  restoreBounds = null;
+}
+
+async function readLogicalBounds(
+  w: Awaited<ReturnType<typeof import("@tauri-apps/api/window").getCurrentWindow>>,
+): Promise<LogicalBounds | null> {
+  try {
+    const pos = await w.outerPosition();
+    const size = await w.outerSize();
+    const factor = await w.scaleFactor();
+    const f = factor > 0 ? factor : 1;
+    return {
+      x: pos.x / f,
+      y: pos.y / f,
+      w: size.width / f,
+      h: size.height / f,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function applyLogicalBounds(
+  w: Awaited<ReturnType<typeof import("@tauri-apps/api/window").getCurrentWindow>>,
+  b: LogicalBounds,
+): Promise<void> {
+  const { LogicalPosition, LogicalSize } = await import("@tauri-apps/api/dpi");
+  await w.setPosition(new LogicalPosition(b.x, b.y));
+  await w.setSize(new LogicalSize(b.w, b.h));
+}
+
+async function fillMonitorWorkArea(
+  w: Awaited<ReturnType<typeof import("@tauri-apps/api/window").getCurrentWindow>>,
+): Promise<boolean> {
+  try {
+    const { currentMonitor } = await import("@tauri-apps/api/window");
+    const mon = await currentMonitor();
+    const wa = mon?.workArea;
+    if (!mon || !wa) return false;
+    const factor = mon.scaleFactor > 0 ? mon.scaleFactor : await w.scaleFactor();
+    const f = factor > 0 ? factor : 1;
+    const bounds: LogicalBounds = {
+      x: wa.position.x / f,
+      y: wa.position.y / f,
+      w: wa.size.width / f,
+      h: wa.size.height / f,
+    };
+    if (!(bounds.w > 80 && bounds.h > 80)) return false;
+    await applyLogicalBounds(w, bounds);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Maximize / restore. Prefers the OS API; on Linux Wayland no-ops, fills
+ * the work area and treats that as maximized until the next toggle.
+ * Returns whether the window should display as maximized.
+ */
+export async function toggleMaximizeReliable(): Promise<boolean> {
+  const { getCurrentWindow } = await import("@tauri-apps/api/window");
+  const w = getCurrentWindow();
+  const wasOs = await w.isMaximized().catch(() => false);
+  const was = wasOs || fakeMaximized;
+
+  if (was) {
+    fakeMaximized = false;
+    if (wasOs) {
+      try {
+        await w.unmaximize();
+      } catch {
+        /* ignore */
+      }
+    }
+    if (restoreBounds) {
+      const prev = restoreBounds;
+      restoreBounds = null;
+      try {
+        await applyLogicalBounds(w, prev);
+      } catch {
+        /* ignore */
+      }
+    }
+    return w.isMaximized().catch(() => false);
+  }
+
+  const before = await readLogicalBounds(w);
+  try {
+    await w.maximize();
+  } catch {
+    /* some compositors reject maximize() */
+  }
+  await new Promise((r) => setTimeout(r, 40));
+  const nowOs = await w.isMaximized().catch(() => false);
+  if (nowOs) {
+    restoreBounds = null;
+    fakeMaximized = false;
+    return true;
+  }
+
+  if (before) restoreBounds = before;
+  const filled = await fillMonitorWorkArea(w);
+  fakeMaximized = filled;
+  return filled || (await w.isMaximized().catch(() => false));
+}
+
+export async function toggleMaximizeFromTitlebar(): Promise<void> {
+  const now = Date.now();
+  if (!shouldAcceptTitlebarMaximize(lastTitlebarMaximizeMs, now)) return;
+  lastTitlebarMaximizeMs = now;
+  try {
+    await toggleMaximizeReliable();
+  } catch {
+    /* browser / no window API */
+  }
+}

--- a/src/styles/settings.part5.css
+++ b/src/styles/settings.part5.css
@@ -398,22 +398,28 @@
 }
 
 .platform-win .main__top,
+.platform-linux .main__top,
 .platform-other .main__top,
 .has-custom-chrome .main__top,
 .platform-win .settings-page__chrome,
+.platform-linux .settings-page__chrome,
 .platform-other .settings-page__chrome,
 .has-custom-chrome .settings-page__chrome,
 .platform-win .settings-page__titlebar,
+.platform-linux .settings-page__titlebar,
 .platform-other .settings-page__titlebar,
 .has-custom-chrome .settings-page__titlebar,
 .platform-win .auto-page__head,
+.platform-linux .auto-page__head,
 .has-custom-chrome .auto-page__head,
 /* Resource pane chrome (tabs + actions) — both legacy .rp__chrome empty state
    and live .rp-chrome toolbar. Must clear fixed .window-controls (3 × 46px). */
 .platform-win .rp__chrome,
+.platform-linux .rp__chrome,
 .platform-other .rp__chrome,
 .has-custom-chrome .rp__chrome,
 .platform-win .rp-chrome,
+.platform-linux .rp-chrome,
 .platform-other .rp-chrome,
 .has-custom-chrome .rp-chrome {
   padding-right: var(--window-controls-inset, 138px); /* 46px × 3 window controls */

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -204,7 +204,9 @@ textarea:focus-visible,
   app-region: drag;
 }
 
-/* Interactive controls inside drag regions stay clickable */
+/* Interactive controls inside drag regions stay clickable.
+ * Composer / chat must stay no-drag so Windows file drops are not
+ * swallowed as window-move. */
 button,
 a,
 input,
@@ -214,7 +216,11 @@ select,
 [role="tab"],
 [role="menuitem"],
 [role="option"],
-[contenteditable="true"] {
+[contenteditable="true"],
+.composer-wrap,
+.composer,
+.lobe-chat,
+.chat-surface {
   -webkit-app-region: no-drag;
   app-region: no-drag;
 }
@@ -270,6 +276,7 @@ select,
 }
 
 .platform-win .window-controls,
+.platform-linux .window-controls,
 .platform-other .window-controls,
 .has-custom-chrome .window-controls {
   display: flex;
@@ -320,7 +327,9 @@ select,
 }
 
 .platform-win .sidebar,
-.platform-other .sidebar {
+.platform-linux .sidebar,
+.platform-other .sidebar,
+.has-custom-chrome .sidebar {
   background: var(--bg-sidebar-solid, var(--bg-sidebar));
   backdrop-filter: none;
   -webkit-backdrop-filter: none;


### PR DESCRIPTION
## Summary
- **Windows:** Explorer image/file drops never reached the composer because Tauri owned the WebView2 drop target. Disable native `dragDropEnabled` and handle HTML5 drops in capture phase (temp-file attach when `File.path` is missing).
- **Linux:** No in-app caption buttons; GTK/Wayland often no-ops `toggleMaximize`. Ship frameless custom chrome like Windows, with a work-area fallback when maximize is ignored.
- **Long chat / long article:** Community report that a long transcript or one long article blanks the page and cannot scroll ([@y7469591](https://x.com/y7469591/status/2088917279966917116)). Virtualize by estimated height, chunk tall spacers, cap a single message body at 4096px.

## Test plan
- [x] `vitest` helpers: `fileDrop`, `windowChrome`, `appPlatform`, `chatVirtualList`, `doctorPlatformMatrix`, i18n key parity
- [ ] Windows: drag image + file from Explorer onto the composer
- [ ] Linux: min / max / restore / close; double-click titlebar
- [ ] Open a long assistant article and scroll the transcript without a blank viewport