### PR TITLE
fix(chat): fold process diaries and recover markdown image previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@ See `docs/llm-wiki/release.md`.
 
 ### Changed
 - **README Gatekeeper copy**: Official Releases from v0.2.19 are Developer ID signed and Apple-notarized. The `xattr` workaround stays for forks / older unsigned builds.
+- **Assistant process vs answer**: First-person work diaries inside a single reply fold into a muted Process row (same chrome as progress notes). The visible markdown starts at the first heading, `---`, or `**01 ·` after that diary, so the conclusion is no longer mashed into the work log.
 
 **中文 · 变更**
 - **README Gatekeeper 说明**：官方 Release 从 v0.2.19 起已签名并公证。`xattr` 仅留给 fork / 旧的未签名包。
+- **助手过程与结论分开**：单条正文里的第一人称工作日记收成一条淡的「过程」折叠（和过程说明同一套 chrome）。可见正文从第一条标题、横线或 `**01 ·` 开始，结论不再和工作日志挤在一起。
 
 ### Fixed
+- **Chat image previews**: Project-relative markdown images (`design-demos/shots/foo.png`) resolve from attachments instead of painting an empty alt card. A first-paint miss (file still being written, or path grant not ready) retries instead of locking the card as broken.
 - **Windows file / image drop into the composer**: WebView2 cannot use HTML5 `Files` while Tauri owns the drop target. Windows builds now set `dragDropEnabled: false` and handle Explorer drops in capture-phase HTML5 (temp-file attach when `File.path` is missing). Overlay + `@path` still work.
 - **Linux maximize / minimize**: Linux was decorated with no in-app caption buttons, and GTK/Wayland often no-ops `toggleMaximize`. Linux is now frameless with the same min/max/close chrome as Windows; maximize falls back to filling the monitor work area when the compositor ignores GTK.
 - **Long chat / long article blanks the transcript** (community, [@y7469591](https://x.com/y7469591/status/2088917279966917116)): One huge message or spacer could exceed the WebView compositor layer and paint white (scroll also stuck). Virtualize by estimated height, split tall spacers, and cap a single message body at 4096px with inner scroll.
@@ -37,6 +40,7 @@ See `docs/llm-wiki/release.md`.
 - **Custom Grok / vision relays can read image attachments (#618)**: Settings → Account → Custom providers has **This model can see images**. Grok / GPT-4o / Claude / Gemini names already count. Unknown relays stay text-only so DeepSeek-style APIs do not 400 on `image_url`. Vision mains keep `@path` pixels and no longer hit the `read_file` image hook.
 
 **中文 · 修复**
+- **聊天图片预览**：项目相对路径的 markdown 图（`design-demos/shots/foo.png`）会跟附件对上，不再画出一张空的 alt 卡。文件还没写完或授权还没落到的第一次失败会重试，不再把卡片锁死。
 - **Windows 无法把图片/文件拖进输入框**：Tauri 接管 WebView2 拖放后 HTML5 `Files` 是空的。Windows 现在关掉原生 drop handler，改用捕获阶段 HTML5（没有 `File.path` 就存临时文件再附加）。
 - **Linux 无法最大化/最小化**：以前走系统标题栏、应用内没有按钮，GTK/Wayland 上 `toggleMaximize` 经常没反应。Linux 改为与 Windows 一样的无边框自绘按钮；合成器忽略 GTK 最大化时，退化为铺满工作区。
 - **长对话 / 长文章后聊天变空白、滚不动**（社区反馈 [@y7469591](https://x.com/y7469591/status/2088917279966917116)）：超高消息或占位层会撑爆 WebView 合成层。现在按预估高度虚拟化、拆开超高 spacer，单条消息正文限高 4096px 内部滚动。

--- a/src/components/ImageUi.tsx
+++ b/src/components/ImageUi.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/copyImage";
 import {
   ensureMediaEndpoint,
+  invalidateImageSrc,
   isMediaEndpointReady,
   isViewableSrc,
   resolveImageSrc,
@@ -32,8 +33,10 @@ import {
 } from "@/lib/imageSrc";
 import {
   mediaLoadErrorLabelMap,
+  nextLocalMediaRetryMs,
   resolveMediaSrcFailure,
   shouldApplyChatImageLoadError,
+  shouldRetryLocalMediaFailure,
   type MediaLoadErrorKind,
 } from "@/lib/mediaLoadPro";
 import {
@@ -42,6 +45,7 @@ import {
 } from "@/lib/imageAspectCache";
 import {
   canUseImageThumb,
+  invalidateChatImageThumb,
   nextChatCardDisplaySrc,
   peekChatImageThumb,
   resolveChatImageThumb,
@@ -214,7 +218,7 @@ export function ImageUi({
     initialResolvedSrc(src, path, layout),
   );
   paintedSrcRef.current = resolvedSrc;
-  /** Once load fails, keep a stable broken state — never re-fetch on re-render. */
+  /** True after retries are exhausted (or a non-retryable decode error). */
   const [loadFailed, setLoadFailed] = useState(false);
   /** Classified reason when resolve or decode fails (MEDIA-LOAD-PRO). */
   const [failKind, setFailKind] = useState<MediaLoadErrorKind | null>(null);
@@ -228,6 +232,12 @@ export function ImageUi({
   const [ratioKnown, setRatioKnown] = useState(
     () => readCachedAr(src, path) != null,
   );
+  const [retryTick, setRetryTick] = useState(0);
+  const paintRetryRef = useRef(0);
+
+  useEffect(() => {
+    paintRetryRef.current = 0;
+  }, [src, path]);
   /** Once we painted from cache or decode, freeze width unless AR shifts a lot. */
   const lockedArRef = useRef<number | null>(readCachedAr(src, path));
 
@@ -264,30 +274,68 @@ export function ImageUi({
 
   useEffect(() => {
     let cancelled = false;
-    const next = initialResolvedSrc(src, path, layout);
-    paintedSrcRef.current = next;
-    setResolvedSrc(next);
-    setLoadFailed(false);
-    setFailKind(null);
-    const cached = readCachedAr(src, path);
-    if (cached != null) {
-      lockedArRef.current = cached;
-      setAspectRatio(cached);
-      setRatioKnown(true);
-    } else {
-      // Height is fixed for chat cards — AR only affects width. Default is fine
-      // until decode; avoid flashing a different height (that was the jitter).
-      lockedArRef.current = null;
-      setAspectRatio(DEFAULT_AR);
-      setRatioKnown(false);
-    }
+    let attempt = 0;
+    let retryTimer: number | null = null;
+    const localTarget = isLocalFsPath(path)
+      ? path
+      : isLocalFsPath(src)
+        ? src
+        : undefined;
 
-    const useThumb = layout === "card" && canUseImageThumb(src, path);
+    const seed = () => {
+      const next = initialResolvedSrc(src, path, layout);
+      paintedSrcRef.current = next;
+      setResolvedSrc(next);
+      setLoadFailed(false);
+      setFailKind(null);
+      const cached = readCachedAr(src, path);
+      if (cached != null) {
+        lockedArRef.current = cached;
+        setAspectRatio(cached);
+        setRatioKnown(true);
+      } else {
+        // Height is fixed for chat cards — AR only affects width. Default is fine
+        // until decode; avoid flashing a different height (that was the jitter).
+        lockedArRef.current = null;
+        setAspectRatio(DEFAULT_AR);
+        setRatioKnown(false);
+      }
+      return next;
+    };
 
-    if (useThumb) {
-      // Chat cards: Host disk thumb (≤480px) + session URL cache — not full original.
-      void resolveChatImageThumb(src, path)
-        .then((r) => {
+    const lockFail = (kind: MediaLoadErrorKind) => {
+      if (cancelled) return;
+      setResolvedSrc(null);
+      setFailKind(kind);
+    };
+
+    const scheduleRetry = (kind: MediaLoadErrorKind) => {
+      if (!localTarget || !shouldRetryLocalMediaFailure(kind)) {
+        lockFail(kind);
+        return;
+      }
+      const wait = nextLocalMediaRetryMs(attempt);
+      if (wait == null) {
+        lockFail(kind);
+        return;
+      }
+      attempt += 1;
+      retryTimer = window.setTimeout(() => {
+        invalidateImageSrc(localTarget);
+        invalidateImageSrc(src);
+        invalidateChatImageThumb(src, path);
+        void runResolve();
+      }, wait);
+    };
+
+    const runResolve = async () => {
+      if (cancelled) return;
+      const next = seed();
+      const useThumb = layout === "card" && canUseImageThumb(src, path);
+
+      if (useThumb) {
+        try {
+          const r = await resolveChatImageThumb(src, path);
           if (cancelled) return;
           const display = nextChatCardDisplaySrc(next, r);
           if (display) {
@@ -298,81 +346,94 @@ export function ImageUi({
             if (r && r.width > 0 && r.height > 0) {
               applyNaturalSize(r.width, r.height);
             }
-          } else {
-            setResolvedSrc(null);
-            const fail = resolveMediaSrcFailure({
-              pathOrUrl: path || src,
-              resolvedSrc: null,
-              isTauri: isTauri(),
-              mediaEndpointReady: isMediaEndpointReady(),
-            });
-            setFailKind(fail.kind);
+            return;
           }
-        })
-        .catch(() => {
-          if (cancelled) return;
-          // Soft fallback: full resolve path.
-          void ensureMediaEndpoint()
-            .then(() => resolveImageSrc(path || src))
-            .then((url) => {
-              if (cancelled) return;
-              if (url) {
-                setResolvedSrc(url);
-                setLoadFailed(false);
-                setFailKind(null);
-              }
-            });
-        });
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    // Pane / non-thumb: ensure loopback HTTP, then re-resolve full asset.
-    if (!isViewableSrc(src) || !next?.startsWith("http://127.0.0.1")) {
-      void ensureMediaEndpoint()
-        .then(() => resolveImageSrc(src))
-        .then((url) => {
-          if (cancelled) return;
-          if (url) {
-            if (url !== next) setResolvedSrc(url);
-            setLoadFailed(false);
-            setFailKind(null);
-          } else {
-            setResolvedSrc(null);
-            const r = resolveMediaSrcFailure({
-              pathOrUrl: path || src,
-              resolvedSrc: null,
-              isTauri: isTauri(),
-              mediaEndpointReady: isMediaEndpointReady(),
-            });
-            setFailKind(r.kind);
-          }
-        })
-        .catch(() => {
-          /* keep sync resolve — soft-fail, never crash */
-          if (cancelled || next) return;
-          const r = resolveMediaSrcFailure({
+          const fail = resolveMediaSrcFailure({
             pathOrUrl: path || src,
             resolvedSrc: null,
             isTauri: isTauri(),
             mediaEndpointReady: isMediaEndpointReady(),
           });
-          setFailKind(r.kind);
-        });
-    } else if (!next) {
-      const r = resolveMediaSrcFailure({
-        pathOrUrl: path || src,
-        resolvedSrc: null,
-        isTauri: isTauri(),
-        mediaEndpointReady: isMediaEndpointReady(),
-      });
-      setFailKind(r.kind);
-    }
+          scheduleRetry(fail.kind);
+        } catch {
+          if (cancelled) return;
+          try {
+            await ensureMediaEndpoint();
+            const url = await resolveImageSrc(path || src);
+            if (cancelled) return;
+            if (url) {
+              setResolvedSrc(url);
+              setLoadFailed(false);
+              setFailKind(null);
+              return;
+            }
+          } catch {
+            /* fall through */
+          }
+          if (cancelled) return;
+          scheduleRetry(
+            resolveMediaSrcFailure({
+              pathOrUrl: path || src,
+              resolvedSrc: null,
+              isTauri: isTauri(),
+              mediaEndpointReady: isMediaEndpointReady(),
+            }).kind,
+          );
+        }
+        return;
+      }
+
+      if (!isViewableSrc(src) || !next?.startsWith("http://127.0.0.1")) {
+        try {
+          await ensureMediaEndpoint();
+          const url = await resolveImageSrc(src);
+          if (cancelled) return;
+          if (url) {
+            if (url !== next) setResolvedSrc(url);
+            setLoadFailed(false);
+            setFailKind(null);
+            return;
+          }
+          scheduleRetry(
+            resolveMediaSrcFailure({
+              pathOrUrl: path || src,
+              resolvedSrc: null,
+              isTauri: isTauri(),
+              mediaEndpointReady: isMediaEndpointReady(),
+            }).kind,
+          );
+        } catch {
+          if (cancelled || next) return;
+          scheduleRetry(
+            resolveMediaSrcFailure({
+              pathOrUrl: path || src,
+              resolvedSrc: null,
+              isTauri: isTauri(),
+              mediaEndpointReady: isMediaEndpointReady(),
+            }).kind,
+          );
+        }
+        return;
+      }
+
+      if (!next) {
+        scheduleRetry(
+          resolveMediaSrcFailure({
+            pathOrUrl: path || src,
+            resolvedSrc: null,
+            isTauri: isTauri(),
+            mediaEndpointReady: isMediaEndpointReady(),
+          }).kind,
+        );
+      }
+    };
+
+    void runResolve();
     return () => {
       cancelled = true;
+      if (retryTimer != null) window.clearTimeout(retryTimer);
     };
-  }, [src, path, layout, applyNaturalSize]);
+  }, [src, path, layout, applyNaturalSize, retryTick]);
 
   // Recover size if decode finished before onLoad bound (disk cache).
   useEffect(() => {
@@ -601,7 +662,6 @@ export function ImageUi({
               ) {
                 return;
               }
-              setLoadFailed(true);
               const r = resolveMediaSrcFailure({
                 pathOrUrl: path || src,
                 resolvedSrc: paintedSrcRef.current,
@@ -609,6 +669,21 @@ export function ImageUi({
                 isTauri: isTauri(),
                 mediaEndpointReady: isMediaEndpointReady(),
               });
+              if (
+                localPath &&
+                shouldRetryLocalMediaFailure(r.kind) &&
+                nextLocalMediaRetryMs(paintRetryRef.current) != null
+              ) {
+                paintRetryRef.current += 1;
+                invalidateImageSrc(localPath);
+                invalidateImageSrc(src);
+                invalidateChatImageThumb(src, path);
+                setLoadFailed(false);
+                setFailKind(null);
+                setRetryTick((n) => n + 1);
+                return;
+              }
+              setLoadFailed(true);
               setFailKind(r.kind);
             }}
             onClick={(e) => {

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -103,6 +103,7 @@ import { InlineUserEdit } from "./InlineUserEdit";
 import { SkillChip } from "@/components/SkillChip";
 import { HighlightedText } from "@/components/HighlightedText";
 import { findChatMatches } from "@/lib/chatFind";
+import { splitAssistantAnswer } from "@/lib/assistantAnswerSplit";
 import { hydrateDisplayContent, parseStoredContent } from "@/lib/draftDoc";
 import { parseScheduledUserContent } from "@/lib/automations";
 import {
@@ -272,6 +273,17 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
       galleryPaths: images.map((x) => x.path),
     };
   }, [bottomAtts]);
+  const tr = useMemo(() => createT(locale), [locale]);
+  const split = useMemo(
+    () => splitAssistantAnswer(displayContent),
+    [displayContent],
+  );
+  const processMatchCount = useMemo(() => {
+    if (!findQuery?.trim() || !split.process) return 0;
+    return findChatMatches(findQuery, [
+      { id: "process", role: "assistant", content: split.process },
+    ]).length;
+  }, [findQuery, split.process]);
 
   if (
     !(displayContent || "").trim() &&
@@ -280,11 +292,21 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
     return null;
   }
 
-  return (
-    <>
-      {(displayContent || "").trim() ? (
+  const answerFindBase = (findOccurrenceBase ?? 0) + processMatchCount;
+  const body = (displayContent || "").trim() ? (
+    split.process ? (
+      <>
+        <LeadFragmentsStrip
+          fragments={[split.process]}
+          locale={locale}
+          label={tr("chat.processNotes")}
+          testId="assistant-process-notes"
+          variant="process"
+          onOpenExternalLink={onOpenExternalLink}
+        />
         <MarkdownChat
           locale={locale}
+          className="chat-md--answer"
           streaming={!!streaming}
           imagePathMap={pathMapProp}
           projectPath={projectPath}
@@ -293,11 +315,32 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
           onOpenExternalLink={onOpenExternalLink}
           findQuery={findQuery}
           findActiveOccurrence={findActiveOccurrence}
-          findOccurrenceBase={findOccurrenceBase}
+          findOccurrenceBase={answerFindBase}
         >
-          {displayContent}
+          {split.answer}
         </MarkdownChat>
-      ) : null}
+      </>
+    ) : (
+      <MarkdownChat
+        locale={locale}
+        streaming={!!streaming}
+        imagePathMap={pathMapProp}
+        projectPath={projectPath}
+        onOpenResource={onOpenResource}
+        onOpenError={onOpenError}
+        onOpenExternalLink={onOpenExternalLink}
+        findQuery={findQuery}
+        findActiveOccurrence={findActiveOccurrence}
+        findOccurrenceBase={findOccurrenceBase}
+      >
+        {displayContent}
+      </MarkdownChat>
+    )
+  ) : null;
+
+  return (
+    <>
+      {body}
       {bottomImages.length > 0 ? (
         <div className="lobe-chat-atts lobe-chat-atts--images">
           {bottomImages.map((a) => (

--- a/src/components/lobe-chat/LeadFragmentsStrip.tsx
+++ b/src/components/lobe-chat/LeadFragmentsStrip.tsx
@@ -11,16 +11,28 @@
 import { memo, useMemo, useState } from "react";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
-import { IconChevronDown, IconChevronRight, IconSparkles } from "@/components/icons";
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconNotes,
+  IconSparkles,
+} from "@/components/icons";
 import { MarkdownChat } from "./MarkdownChat";
 
 export const LeadFragmentsStrip = memo(function LeadFragmentsStrip({
   fragments,
   locale,
+  label,
+  testId = "lead-fragments",
+  variant = "fragments",
   onOpenExternalLink,
 }: {
   fragments: string[];
   locale: Locale;
+  /** Override the count label (e.g. a single in-body process diary). */
+  label?: string;
+  testId?: string;
+  variant?: "fragments" | "process";
   onOpenExternalLink?: (url: string) => void;
 }) {
   const tr = useMemo(() => createT(locale), [locale]);
@@ -33,10 +45,14 @@ export const LeadFragmentsStrip = memo(function LeadFragmentsStrip({
   );
   if (!joined.trim()) return null;
 
+  const chrome =
+    label ?? tr("chat.leadFragments", { n: String(fragments.length) });
+
   return (
     <div
       className={"grok-fragments" + (open ? " is-open" : " is-collapsed")}
-      data-testid="lead-fragments"
+      data-testid={testId}
+      data-variant={variant}
       data-expanded={open ? "1" : "0"}
     >
       <button
@@ -46,11 +62,13 @@ export const LeadFragmentsStrip = memo(function LeadFragmentsStrip({
         onClick={() => setOpen((v) => !v)}
       >
         <span className="grok-fragments__icon" aria-hidden>
-          <IconSparkles size={14} stroke={1.5} />
+          {variant === "process" ? (
+            <IconNotes size={14} stroke={1.5} />
+          ) : (
+            <IconSparkles size={14} stroke={1.5} />
+          )}
         </span>
-        <span className="grok-fragments__label">
-          {tr("chat.leadFragments", { n: String(fragments.length) })}
-        </span>
+        <span className="grok-fragments__label">{chrome}</span>
         <span className="grok-fragments__caret" aria-hidden>
           {open ? (
             <IconChevronDown size={13} stroke={1.75} />

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -549,11 +549,23 @@ export const MarkdownChat = memo(function MarkdownChat({
               typeof alt === "string" ? alt : undefined,
             );
             if (card) return card;
+            // Unresolved relative / site-root: never mount a dead ImageUi
+            // (that painted the alt as an empty 150px card and never recovered).
+            const viewable =
+              isHttpUrl(src) ||
+              src.startsWith("data:") ||
+              (isRealLocalAbsolutePath(src) && isPlausibleLocalMediaAbs(src));
+            if (!viewable) return null;
             return (
               <ImageUi
                 className="md-body__img md-body__img--card"
                 src={src}
                 alt={typeof alt === "string" ? alt : ""}
+                path={
+                  isRealLocalAbsolutePath(src) && isPlausibleLocalMediaAbs(src)
+                    ? src
+                    : undefined
+                }
                 labels={imageLabels}
               />
             );

--- a/src/components/lobe-chat/lobe-chat.part2.css
+++ b/src/components/lobe-chat/lobe-chat.part2.css
@@ -580,6 +580,17 @@
   display: none;
 }
 
+/* Process diary sits with the work rail; conclusion starts after one beat */
+.grok-fragments[data-variant="process"] {
+  margin: 0 0 2px;
+}
+.chat-md--answer {
+  margin-top: 10px;
+}
+.lobe-chat-assistant-timeline > .grok-fragments[data-variant="process"] + .chat-md--answer {
+  margin-top: 10px;
+}
+
 /* ── Turn activity summary (tasks panel / legacy) ── */
 .lobe-turn-activity {
   width: 100%;

--- a/src/i18n/messages/en/chat.ts
+++ b/src/i18n/messages/en/chat.ts
@@ -107,6 +107,8 @@ export const enChat = {
   "chat.exploreFiles": "{n} files",
   "chat.exploreFilesOne": "1 file",
   "chat.leadFragments": "{n} progress notes",
+  /** Folded first-person work diary inside a single assistant body. */
+  "chat.processNotes": "Process",
   "chat.tool.bash": "Run command",
   "chat.tool.read": "Read file",
   "chat.tool.list": "List folder",

--- a/src/i18n/messages/zh-TW/chat.ts
+++ b/src/i18n/messages/zh-TW/chat.ts
@@ -107,6 +107,8 @@ export const zhTWChat = {
   "chat.exploreFiles": "{n} 個檔案",
   "chat.exploreFilesOne": "1 個檔案",
   "chat.leadFragments": "{n} 段過程說明",
+  /** 單條正文裡、結論之前的第一人稱工作日記摺疊頭。 */
+  "chat.processNotes": "過程",
   "chat.tool.bash": "執行命令",
   "chat.tool.read": "讀取檔案",
   "chat.tool.list": "檢視目錄",

--- a/src/i18n/messages/zh/chat.ts
+++ b/src/i18n/messages/zh/chat.ts
@@ -107,6 +107,8 @@ export const zhChat = {
   "chat.exploreFiles": "{n} 个文件",
   "chat.exploreFilesOne": "1 个文件",
   "chat.leadFragments": "{n} 段过程说明",
+  /** 单条正文里、结论之前的第一人称工作日记折叠头。 */
+  "chat.processNotes": "过程",
   "chat.tool.bash": "运行命令",
   "chat.tool.read": "读取文件",
   "chat.tool.list": "查看目录",

--- a/src/lib/assistantAnswerSplit.test.ts
+++ b/src/lib/assistantAnswerSplit.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { splitAssistantAnswer } from "./assistantAnswerSplit";
+
+/** Shape of journal a51171b5 / message 428d3ffa (process diary + --- + 01/02/03). */
+const FORK_FIXTURE = `已有品牌事实和第一版列表稿。接下来读规格、现稿和风格库，确认另外两版的结构差异再动手。先把 \`bflabs-ui\` 仓库当品牌源核对一遍，再按同一套 token 补完另外两版结构不同的稿。本地已经有 \`bflabs-ui\`。我先拆它的 token、组件和官网入口，再按同一套语言写另外两版。设计系统已经对上。接着读组件用法、官网动效和技能站参考，保证三版共用同一套 \`bflabs-ui\`，只换信息架构。接下来把 \`bflabs-ui\` 的 token 和组件样式落到本地，并抽出官网轨道几何，三版共用同一套语言。用户还提到团队官网入口。我先核一下除了 \`bflabs.cn\` 之外还有没有独立团队站，避免三版把外链写错。资产已经落到仓库。下面写共用套件，并按同一套 \`bflabs-ui\` 出三版结构不同的稿。共用套件写好了。接下来三版分开写：列表索引、货架网格、官网巨字，骨架互不重复。第一版还缺页脚。我补上官网同款页脚，再按 1440×900 把三版一起截出来。截图已经出了。我先肉眼过三张首屏，看骨架、品牌件和可读性有没有明显翻车。三张首屏都空了：导航、文案和列表都没渲染出来。我先查脚本加载和报错，再改。根因是共用脚本把 \`t\` 泄漏到全局，和页面里的 \`const { t }\` 撞名，整页 JS 直接停了。我把套件收进闭包，再重截三版。第三版标题把「智能体」拆开了。我按官网的断行方式改一版，再截首屏。三版都按 Sunnyender-org/bflabs-ui 出了：同一套 token、bf-* 组件、BF 标、顶栏/中英切换/轨道线/页脚，和 bflabs.cn 同一套语言。内容一样，骨架不一样。
+
+**团队入口**：顶栏「官网 / 团队」目前都回 \`https://bflabs.cn\`。独立团队站 URL 还没核到，选定方向后再加第二外链。
+
+---
+
+**01 · 轮盘 17 Functional Brutalism / Are.na**
+发丝目录 + 右侧检验栏。适合当内部索引，不像商店。
+
+---
+
+**02 · 现实参照 · Raycast Store / Vercel Marketplace**
+左侧过滤 + 搜索 + 货架卡片。
+
+---
+
+**03 · 官网续章 · bflabs.cn 同一套巨字**
+Skills 当成官网下一章。
+
+选一版深化，或混搭。选定之前我停在这里。`;
+
+describe("splitAssistantAnswer", () => {
+  it("folds the first-person diary and keeps 团队入口 in the answer", () => {
+    const split = splitAssistantAnswer(FORK_FIXTURE);
+    expect(split.cut).toBe("heading");
+    expect(split.process).toContain("接下来读规格");
+    expect(split.process).toContain("根因是共用脚本");
+    expect(split.process).not.toContain("团队入口");
+    expect(split.answer.startsWith("**团队入口**")).toBe(true);
+    expect(split.answer).toContain("**01 · 轮盘");
+    expect(split.answer).toContain("**03 · 官网续章");
+  });
+
+  it("cuts at the first standalone hr when there is no earlier heading", () => {
+    const text = `${"接下来我会先读仓库，已经对上设计系统。".repeat(6)}
+
+---
+
+这是结论正文，从这里开始给用户看，不再夹带工作日记。`;
+    const split = splitAssistantAnswer(text);
+    expect(split.cut).toBe("hr");
+    expect(split.process).toContain("接下来我会先读仓库");
+    expect(split.answer).toBe(
+      "这是结论正文，从这里开始给用户看，不再夹带工作日记。",
+    );
+    expect(split.answer).not.toContain("---");
+  });
+
+  it("cuts at **01 · when that is the first deliverable marker", () => {
+    const text = `${"Let me read the spec next. I'll then write the three variants and screenshot them. ".repeat(2)}
+
+**01 · List index**
+A hairline directory.`;
+    const split = splitAssistantAnswer(text);
+    expect(split.cut).toBe("numbered");
+    expect(split.process).toMatch(/Let me read the spec/i);
+    expect(split.answer.startsWith("**01 · List index**")).toBe(true);
+  });
+
+  it("does not fold a short intro before a heading", () => {
+    const split = splitAssistantAnswer(
+      "先说结论。\n\n**团队入口**：官网目前回 bflabs.cn。",
+    );
+    expect(split.cut).toBeNull();
+    expect(split.process).toBeNull();
+    expect(split.answer).toContain("先说结论");
+  });
+
+  it("does not fold when the body already starts with the deliverable", () => {
+    const split = splitAssistantAnswer(
+      "**01 · 轮盘**\n发丝目录 + 右侧检验栏。",
+    );
+    expect(split.process).toBeNull();
+    expect(split.answer).toContain("**01 · 轮盘**");
+  });
+
+  it("ignores table separators and fenced ---", () => {
+    const text = `结论用表。
+
+| a | b |
+| --- | --- |
+| 1 | 2 |
+
+\`\`\`
+---
+not a cut
+\`\`\`
+
+正文继续写，没有工作日记。`;
+    const split = splitAssistantAnswer(text);
+    expect(split.process).toBeNull();
+    expect(split.answer).toContain("| --- | --- |");
+    expect(split.answer).toContain("not a cut");
+  });
+
+  it("leaves empty / tiny strings alone", () => {
+    expect(splitAssistantAnswer("").process).toBeNull();
+    expect(splitAssistantAnswer("   \n").process).toBeNull();
+    expect(splitAssistantAnswer("短").process).toBeNull();
+  });
+
+  it("does not cut yaml-like front matter with an empty prefix", () => {
+    const text = `---
+title: note
+---
+
+# Hello
+
+A normal document.`;
+    const split = splitAssistantAnswer(text);
+    expect(split.process).toBeNull();
+  });
+});

--- a/src/lib/assistantAnswerSplit.ts
+++ b/src/lib/assistantAnswerSplit.ts
@@ -1,0 +1,164 @@
+/**
+ * Split an assistant content blob into a foldable work diary vs the
+ * visible conclusion.
+ *
+ * Grok Build TUI and Codex desktop keep thinking / tools off the answer
+ * surface. Grok 4.6 sometimes writes first-person progress into `content`
+ * (the real thought stream is already on the Worked-for rail). This is a
+ * conservative client rescue so that diary does not mash into the reply.
+ *
+ * Cut, earliest wins:
+ * 1. First-person process prefix, then a heading / `**title**：` line
+ * 2. Standalone markdown `---` / `***` / `___` (not a table rule, not in a fence)
+ * 3. Numbered deliverable heading (`**01 ·` / `## 01.`)
+ *
+ * No cut when the prefix is too short, the remainder is empty, or the
+ * only hit is inside a fence / table separator.
+ */
+
+export type AssistantAnswerCut = "heading" | "hr" | "numbered";
+
+export type AssistantAnswerSplit = {
+  process: string | null;
+  answer: string;
+  cut: AssistantAnswerCut | null;
+};
+
+const MIN_PROCESS_CHARS = 80;
+const MIN_ANSWER_CHARS = 20;
+
+const PROCESS_MARKERS: RegExp[] = [
+  /接下来/,
+  /我先/,
+  /我再/,
+  /我把/,
+  /我补/,
+  /我按/,
+  /我核/,
+  /下面/,
+  /接着/,
+  /已经/,
+  /先把/,
+  /先读/,
+  /根因是/,
+  /本地已经/,
+  /截图已经/,
+  /\bLet me\b/i,
+  /\bI(?:'ll| will)\b/,
+  /\bNext[, ]/i,
+  /\bI've (?:now|already)\b/i,
+  /\bLooking at\b/i,
+];
+
+const HR_RE = /^\s{0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/;
+const TABLE_SEP_RE =
+  /^\s*\|?\s*:?-{2,}:?\s*(?:\|\s*:?-{2,}:?\s*)+\|?\s*$/;
+const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})/;
+const NUMBERED_RE =
+  /^(?:\s{0,3}#{1,3}\s+\*{0,2}|\s*\*\*)(?:0?[1-9]|[1-9]\d)\s*[.·、.)]/;
+const ATX_HEADING_RE = /^\s{0,3}#{1,6}\s+\S/;
+const BOLD_LEAD_RE = /^\s*\*\*([^*]{1,40})\*\*\s*[:：]?/;
+
+export function splitAssistantAnswer(
+  raw: string | null | undefined,
+): AssistantAnswerSplit {
+  const text = raw ?? "";
+  if (!text.trim()) {
+    return { process: null, answer: text, cut: null };
+  }
+
+  const lines = text.split(/\r?\n/);
+  let inFence = false;
+  let fenceMark = "";
+  let firstHr = -1;
+  let firstNumbered = -1;
+  let firstHeading = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const fence = line.match(FENCE_RE);
+    if (fence) {
+      const mark = fence[1]!.charAt(0);
+      if (!inFence) {
+        inFence = true;
+        fenceMark = mark;
+      } else if (mark === fenceMark) {
+        inFence = false;
+        fenceMark = "";
+      }
+      continue;
+    }
+    if (inFence) continue;
+    if (TABLE_SEP_RE.test(line)) continue;
+    if (HR_RE.test(line)) {
+      if (firstHr < 0) firstHr = i;
+      continue;
+    }
+    if (NUMBERED_RE.test(line)) {
+      if (firstNumbered < 0) firstNumbered = i;
+      continue;
+    }
+    if (isAnswerHeading(line) && firstHeading < 0) {
+      firstHeading = i;
+    }
+  }
+
+  type Cand = {
+    line: number;
+    kind: AssistantAnswerCut;
+    skipLine: boolean;
+  };
+  const cands: Cand[] = [];
+  if (firstHeading >= 0) {
+    const prefix = lines.slice(0, firstHeading).join("\n");
+    if (looksLikeProcessDiary(prefix) && prefixLooksUnstructured(prefix)) {
+      cands.push({ line: firstHeading, kind: "heading", skipLine: false });
+    }
+  }
+  if (firstHr >= 0) {
+    cands.push({ line: firstHr, kind: "hr", skipLine: true });
+  }
+  if (firstNumbered >= 0) {
+    cands.push({ line: firstNumbered, kind: "numbered", skipLine: false });
+  }
+  cands.sort((a, b) => a.line - b.line);
+
+  for (const cand of cands) {
+    const process = lines.slice(0, cand.line).join("\n").trim();
+    const answerStart = cand.skipLine ? cand.line + 1 : cand.line;
+    const answer = lines.slice(answerStart).join("\n").trim();
+    if (process.length < MIN_PROCESS_CHARS) continue;
+    if (answer.length < MIN_ANSWER_CHARS) continue;
+    return { process, answer, cut: cand.kind };
+  }
+
+  return { process: null, answer: text, cut: null };
+}
+
+function isAnswerHeading(line: string): boolean {
+  if (ATX_HEADING_RE.test(line)) return true;
+  const bold = line.match(BOLD_LEAD_RE);
+  return !!bold?.[1]?.trim();
+}
+
+function countProcessMarkers(text: string): number {
+  let n = 0;
+  for (const re of PROCESS_MARKERS) {
+    if (re.test(text)) n += 1;
+  }
+  return n;
+}
+
+function looksLikeProcessDiary(prefix: string): boolean {
+  const t = prefix.trim();
+  if (t.length < MIN_PROCESS_CHARS) return false;
+  return countProcessMarkers(t) >= 2;
+}
+
+function prefixLooksUnstructured(prefix: string): boolean {
+  for (const line of prefix.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    if (NUMBERED_RE.test(line) || isAnswerHeading(line)) return false;
+  }
+  return true;
+}

--- a/src/lib/attachments.test.ts
+++ b/src/lib/attachments.test.ts
@@ -7,6 +7,7 @@ import {
   extractMediaPathsFromContent,
   extractSessionRelativeMediaRefs,
   filterAttachmentsNotInlined,
+  mediaTailFromPath,
   isDisplayableAttachmentPath,
   isImagePath,
   isMediaPath,
@@ -327,6 +328,49 @@ also /tmp/other.png and /tmp/clip.mp4 and not a file.`;
       "/sess/images/1.jpg",
       "/sess/videos/1.mp4",
     ]);
+  });
+
+  it("mediaTailFromPath keeps design-demo / shots tails", () => {
+    expect(
+      mediaTailFromPath(
+        "/Users/sunny/GROK/VIKO/design-demos/shots/preview-v3-03-editorial.png",
+      ),
+    ).toBe("design-demos/shots/preview-v3-03-editorial.png");
+    expect(mediaTailFromPath("/sess/images/1.jpg")).toBe("images/1.jpg");
+  });
+
+  it("resolveInlineMediaToken maps project-relative markdown href via basename", () => {
+    const map = buildInlineMediaPathMap([
+      {
+        path: "/Users/me/proj/design-demos/shots/preview-v3-03-editorial.png",
+        name: "preview-v3-03-editorial.png",
+        isDir: false,
+      },
+    ]);
+    expect(
+      resolveInlineMediaToken(
+        "design-demos/shots/preview-v3-03-editorial.png",
+        map,
+      ),
+    ).toBe("/Users/me/proj/design-demos/shots/preview-v3-03-editorial.png");
+    expect(map["design-demos/shots/preview-v3-03-editorial.png"]).toBe(
+      "/Users/me/proj/design-demos/shots/preview-v3-03-editorial.png",
+    );
+  });
+
+  it("filterAttachmentsNotInlined drops project-relative markdown images", () => {
+    const atts: Attachment[] = [
+      {
+        path: "/Users/me/proj/design-demos/shots/preview-v3-03-editorial.png",
+        name: "preview-v3-03-editorial.png",
+        isDir: false,
+      },
+    ];
+    const out = filterAttachmentsNotInlined(
+      "![03 巨字](design-demos/shots/preview-v3-03-editorial.png)",
+      atts,
+    );
+    expect(out).toBeUndefined();
   });
 
   it("buildInlineMediaPathMap maps short tokens to absolute", () => {

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -292,7 +292,13 @@ export function mediaTailFromPath(abs: string): string | null {
       best = norm.slice(idx + 1);
     }
   }
-  return best;
+  if (best) return best;
+  // Project shots / design-demos / arbitrary folders: last 2–3 segments so
+  // `![alt](design-demos/shots/foo.png)` matches the attachment abs path.
+  if (!isMediaPath(norm)) return null;
+  const parts = norm.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+  return parts.slice(-Math.min(3, parts.length)).join("/");
 }
 
 /**
@@ -631,7 +637,14 @@ export function applyResolvedSessionMedia<T extends MessageWithAttachments>(
     const extra: Attachment[] = [];
     for (const rel of rels) {
       const key = rel.replace(/\\/g, "/");
-      const hit = byTail.get(key) || byName.get(pathBasename(rel));
+      const hit =
+        byTail.get(key) ||
+        byName.get(pathBasename(rel)) ||
+        resolved.find(
+          (a) =>
+            a.path.replace(/\\/g, "/").endsWith(`/${key}`) ||
+            key.endsWith(`/${pathBasename(a.path)}`),
+        );
       if (hit) extra.push(hit);
     }
     if (!extra.length) return m;
@@ -737,6 +750,19 @@ export function resolveInlineMediaToken(
     mappedOk(pathMap?.[norm]) ||
     mappedOk(pathMap?.[norm.toLowerCase()]);
   if (fromNorm) return fromNorm;
+
+  // Markdown often cites `design-demos/shots/foo.png` while the map only
+  // has the basename or a shorter tail from the attachment abs path.
+  if (pathMap && isMediaPath(norm)) {
+    const slashNorm = norm.replace(/\\/g, "/").replace(/^\.\//, "");
+    const parts = slashNorm.split("/").filter(Boolean);
+    for (let n = parts.length; n >= 1; n--) {
+      const suffix = parts.slice(-n).join("/");
+      const hit =
+        mappedOk(pathMap[suffix]) || mappedOk(pathMap[suffix.toLowerCase()]);
+      if (hit) return hit;
+    }
+  }
   // Real local absolute without a map — multi-segment only.
   if (
     isRealLocalAbsolutePath(norm) &&
@@ -813,6 +839,10 @@ export function filterAttachmentsNotInlined(
     if (rel && rels.has(rel)) return false;
     if (absInText.has(a.path)) return false;
     if (rel && content.includes(rel)) return false;
+    if (rels.has(name)) return false;
+    if ([...rels].some((r) => r === name || r.endsWith(`/${name}`))) {
+      return false;
+    }
     if (
       content.includes(`\`${name}\``) ||
       content.includes(`\`${a.path}\``) ||
@@ -820,8 +850,9 @@ export function filterAttachmentsNotInlined(
     ) {
       return false;
     }
-    // Markdown link form
+    // Markdown link / image form (`![alt](rel)` or `](basename)`)
     if (rel && content.includes(`](${rel})`)) return false;
+    if (content.includes(`](${name})`)) return false;
     return true;
   });
   return out.length ? out : undefined;

--- a/src/lib/imageSrc.ts
+++ b/src/lib/imageSrc.ts
@@ -309,6 +309,12 @@ export async function resolveImageSrcs(
   return out;
 }
 
+/** Drop a cached resolve (including a sticky null) so a later retry can hit disk. */
+export function invalidateImageSrc(pathOrUrl: string): void {
+  const key = pathOrUrl.trim();
+  if (key) resolveCache.delete(key);
+}
+
 /** Test helper — clear the resolve cache. */
 export function clearImageSrcCache(): void {
   resolveCache.clear();

--- a/src/lib/imageThumbClient.ts
+++ b/src/lib/imageThumbClient.ts
@@ -203,6 +203,12 @@ export async function resolveChatImageThumb(
   return r;
 }
 
+/** Drop a sticky thumb miss so a later retry can rematerialize. */
+export function invalidateChatImageThumb(src: string, path?: string): void {
+  const key = cacheKey(src, path);
+  if (key) displayCache.delete(key);
+}
+
 /** Test helper. */
 export function clearChatImageThumbClientCache(): void {
   displayCache.clear();

--- a/src/lib/mediaLoadPro.test.ts
+++ b/src/lib/mediaLoadPro.test.ts
@@ -12,6 +12,8 @@ import {
   resolveMediaLoadError,
   resolveMediaSrcFailure,
   shouldApplyChatImageLoadError,
+  nextLocalMediaRetryMs,
+  shouldRetryLocalMediaFailure,
 } from "./mediaLoadPro";
 
 describe("classifyMediaLoadError", () => {
@@ -198,6 +200,26 @@ describe("isSafeLocalMediaUrl", () => {
     expect(isSafeLocalMediaUrl("http://evil.example/v1/media")).toBe(false);
     expect(isSafeLocalMediaUrl("https://cdn.example/a.png")).toBe(false);
     expect(isSafeLocalMediaUrl("")).toBe(false);
+  });
+});
+
+describe("local media retry", () => {
+  it("retries missing / grant / server races, not decode", () => {
+    expect(shouldRetryLocalMediaFailure(null)).toBe(true);
+    expect(shouldRetryLocalMediaFailure("missing_path")).toBe(true);
+    expect(shouldRetryLocalMediaFailure("untrusted")).toBe(true);
+    expect(shouldRetryLocalMediaFailure("media_server_unavailable")).toBe(
+      true,
+    );
+    expect(shouldRetryLocalMediaFailure("broken_blob")).toBe(false);
+    expect(shouldRetryLocalMediaFailure("unsupported_type")).toBe(false);
+  });
+
+  it("caps retry delays", () => {
+    expect(nextLocalMediaRetryMs(0)).toBe(250);
+    expect(nextLocalMediaRetryMs(1)).toBe(800);
+    expect(nextLocalMediaRetryMs(2)).toBe(2000);
+    expect(nextLocalMediaRetryMs(3)).toBeNull();
   });
 });
 

--- a/src/lib/mediaLoadPro.ts
+++ b/src/lib/mediaLoadPro.ts
@@ -321,6 +321,33 @@ export function mediaUrlPathParam(
  * Ignore leftover abort from a src swap (https → cached thumb on remount)
  * and explicit media-element abort codes.
  */
+/** Delays (ms) before retrying a local preview that missed the first paint. */
+const LOCAL_MEDIA_RETRY_MS = [250, 800, 2000] as const;
+
+/** Next retry delay, or null when retries are exhausted. */
+export function nextLocalMediaRetryMs(attempt: number): number | null {
+  if (attempt < 0 || attempt >= LOCAL_MEDIA_RETRY_MS.length) return null;
+  return LOCAL_MEDIA_RETRY_MS[attempt]!;
+}
+
+/**
+ * Transient failures: file written after the markdown streamed, path_scope
+ * grant not yet applied, or media server cold-start. Decode / type errors
+ * are not retried (the bytes will not change).
+ */
+export function shouldRetryLocalMediaFailure(
+  kind: MediaLoadErrorKind | null | undefined,
+): boolean {
+  return (
+    kind == null ||
+    kind === "missing_path" ||
+    kind === "untrusted" ||
+    kind === "media_server_unavailable" ||
+    kind === "timeout" ||
+    kind === "other"
+  );
+}
+
 export function shouldApplyChatImageLoadError(input: {
   failedSrc?: string | null;
   paintedSrc?: string | null;


### PR DESCRIPTION
## Why

Long Grok 4.6 turns write first-person progress into `content` (the real thought stream is already on the Worked-for rail). The transcript mashed that diary into the conclusion, so **团队入口** / **01 ·** never read as the answer.

The same turns cite project-relative screenshots (`![03 巨字](design-demos/shots/preview-v3-03-editorial.png)`). Path maps only recognized `images/`-style tails, so MarkdownChat mounted a dead ImageUi on the raw relative src (empty alt card). A first-paint 404 / path-scope miss then locked the card, so the preview looked lost even after the file existed.

## What

- Split the assistant body at the first process-like heading, standalone `---`, or `**01 ·`. Fold the prefix into a muted **过程 / Process** row (same chrome as progress notes). Visible markdown starts at the conclusion.
- Map attachment tails / basenames so `design-demos/shots/foo.png` resolves. Do not mount ImageUi on an unresolved relative href.
- Retry local preview resolve/load a few times (file still being written, grant not ready) instead of locking broken on the first miss.

## Test

- `pnpm exec vitest run src/lib/assistantAnswerSplit.test.ts src/lib/attachments.test.ts src/lib/mediaLoadPro.test.ts src/i18n/messages.test.ts`
- Local 0.2.19 rebuild installed; check the Viko fork session: diary folded, **03 巨字** paints.