### PR TITLE
fix(chat): fold process speech and actions inside 工作了

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,11 @@ See `docs/llm-wiki/release.md`.
 
 ### Changed
 - **README Gatekeeper copy**: Official Releases from v0.2.19 are Developer ID signed and Apple-notarized. The `xattr` workaround stays for forks / older unsigned builds.
-- **Assistant process vs answer**: First-person work diaries inside a single reply fold into a muted Process row (same chrome as progress notes). The visible markdown starts at the first heading, `---`, or `**01 ·` after that diary, so the conclusion is no longer mashed into the work log.
+- **Assistant process vs answer**: Mid-turn speech and folded actions (explore / run / edit) live inside one **工作了** fold (collapsed by default). The conclusion stays visible below. Journal CoT stays a separate **思考了** row — not dumped into the rail or mashed into the answer.
 
 **中文 · 变更**
 - **README Gatekeeper 说明**：官方 Release 从 v0.2.19 起已签名并公证。`xattr` 仅留给 fork / 旧的未签名包。
-- **助手过程与结论分开**：单条正文里的第一人称工作日记收成一条淡的「过程」折叠（和过程说明同一套 chrome）。可见正文从第一条标题、横线或 `**01 ·` 开始，结论不再和工作日志挤在一起。
+- **助手过程与结论分开**：中间穿插的话和折叠动作（探索 / 运行 / 编辑）收进同一条「工作了」（默认收起），结论始终在下面。日记 CoT 仍是单独的「思考了」，不灌进活动轨，也不和结论挤在一起。
 
 ### Fixed
 - **Chat image previews**: Project-relative markdown images (`design-demos/shots/foo.png`) resolve from attachments instead of painting an empty alt card. A first-paint miss (file still being written, or path grant not ready) retries instead of locking the card as broken.

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -103,7 +103,6 @@ import { InlineUserEdit } from "./InlineUserEdit";
 import { SkillChip } from "@/components/SkillChip";
 import { HighlightedText } from "@/components/HighlightedText";
 import { findChatMatches } from "@/lib/chatFind";
-import { splitAssistantAnswer } from "@/lib/assistantAnswerSplit";
 import { hydrateDisplayContent, parseStoredContent } from "@/lib/draftDoc";
 import { parseScheduledUserContent } from "@/lib/automations";
 import {
@@ -125,7 +124,7 @@ import {
 } from "./TimelineToolRow";
 import { TimelinePhaseBlock } from "./TimelinePhaseBlock";
 import {
-  buildTimelineUnits,
+  buildAssistantTimeline,
   shouldShowTrailingLiveThinking,
 } from "@/lib/timelinePhases";
 import {
@@ -273,18 +272,6 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
       galleryPaths: images.map((x) => x.path),
     };
   }, [bottomAtts]);
-  const tr = useMemo(() => createT(locale), [locale]);
-  const split = useMemo(
-    () => splitAssistantAnswer(displayContent),
-    [displayContent],
-  );
-  const processMatchCount = useMemo(() => {
-    if (!findQuery?.trim() || !split.process) return 0;
-    return findChatMatches(findQuery, [
-      { id: "process", role: "assistant", content: split.process },
-    ]).length;
-  }, [findQuery, split.process]);
-
   if (
     !(displayContent || "").trim() &&
     !(bottomImages.length || bottomFiles.length)
@@ -292,50 +279,22 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
     return null;
   }
 
-  const answerFindBase = (findOccurrenceBase ?? 0) + processMatchCount;
   const body = (displayContent || "").trim() ? (
-    split.process ? (
-      <>
-        <LeadFragmentsStrip
-          fragments={[split.process]}
-          locale={locale}
-          label={tr("chat.processNotes")}
-          testId="assistant-process-notes"
-          variant="process"
-          onOpenExternalLink={onOpenExternalLink}
-        />
-        <MarkdownChat
-          locale={locale}
-          className="chat-md--answer"
-          streaming={!!streaming}
-          imagePathMap={pathMapProp}
-          projectPath={projectPath}
-          onOpenResource={onOpenResource}
-          onOpenError={onOpenError}
-          onOpenExternalLink={onOpenExternalLink}
-          findQuery={findQuery}
-          findActiveOccurrence={findActiveOccurrence}
-          findOccurrenceBase={answerFindBase}
-        >
-          {split.answer}
-        </MarkdownChat>
-      </>
-    ) : (
-      <MarkdownChat
-        locale={locale}
-        streaming={!!streaming}
-        imagePathMap={pathMapProp}
-        projectPath={projectPath}
-        onOpenResource={onOpenResource}
-        onOpenError={onOpenError}
-        onOpenExternalLink={onOpenExternalLink}
-        findQuery={findQuery}
-        findActiveOccurrence={findActiveOccurrence}
-        findOccurrenceBase={findOccurrenceBase}
-      >
-        {displayContent}
-      </MarkdownChat>
-    )
+    <MarkdownChat
+      locale={locale}
+      className="chat-md--answer"
+      streaming={!!streaming}
+      imagePathMap={pathMapProp}
+      projectPath={projectPath}
+      onOpenResource={onOpenResource}
+      onOpenError={onOpenError}
+      onOpenExternalLink={onOpenExternalLink}
+      findQuery={findQuery}
+      findActiveOccurrence={findActiveOccurrence}
+      findOccurrenceBase={findOccurrenceBase}
+    >
+      {displayContent}
+    </MarkdownChat>
   ) : null;
 
   return (
@@ -1265,7 +1224,7 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
   const isNodeFocus = focusMessageId === m.id;
   // Phase projection: thought+tools collapse when phase ends (content
   // / next thought), not only when the full answer is done.
-  const timelineUnits = buildTimelineUnits(segs, {
+  const timelineUnits = buildAssistantTimeline(segs, {
     streaming: !!m.streaming,
   });
   // Live chrome follows the *current* episode (trailing thought / phase),
@@ -1409,7 +1368,7 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
                   </div>
                 );
               }
-              // content — never folded into a work phase
+              // content — conclusion stays outside the work fold
               const segBase = contentOccBase;
               if (findQuery.trim()) {
                 contentOccBase += findChatMatches(findQuery, [

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -102,7 +102,7 @@ import { BackBottom } from "./BackBottom";
 import { InlineUserEdit } from "./InlineUserEdit";
 import { SkillChip } from "@/components/SkillChip";
 import { HighlightedText } from "@/components/HighlightedText";
-import { findChatMatches } from "@/lib/chatFind";
+import { findChatMatches, findMatchesBeforeVisible } from "@/lib/chatFind";
 import { hydrateDisplayContent, parseStoredContent } from "@/lib/draftDoc";
 import { parseScheduledUserContent } from "@/lib/automations";
 import {
@@ -1276,7 +1276,20 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
           {(() => {
             // Running occurrence base across content segments so
             // find marks stay aligned with message-level match index.
-            let contentOccBase = 0;
+            // Hits in the folded process prefix of m.content must be skipped
+            // so the conclusion highlight uses the same occurrence as Cmd+F.
+            const lastVisibleContent = (() => {
+              for (let i = timelineUnits.length - 1; i >= 0; i--) {
+                const u = timelineUnits[i]!;
+                if (u.kind === "content") return u.text;
+              }
+              return "";
+            })();
+            let contentOccBase = findMatchesBeforeVisible({
+              full: m.content ?? "",
+              visible: lastVisibleContent,
+              query: findQuery,
+            });
             // First bare thought uses a stable live key for the whole episode
             // (placeholder → tokens → done) so the wall clock does not reset.
             const primaryThoughtSi = (() => {
@@ -1303,6 +1316,14 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
                       m.createdAt,
                       ...unit.tools.map((t) => t.createdAt),
                     ]}
+                    findQuery={findQuery}
+                    findActiveOccurrence={
+                      isFindCurrent
+                        ? (findActive?.occurrence ?? null)
+                        : null
+                    }
+                    messageContent={m.content}
+                    onOpenExternalLink={onOpenExternalLink}
                   />
                 );
               }

--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -56,6 +56,7 @@ import {
 import { VirtualList } from "@/components/VirtualList";
 import { ToolExpandBody } from "./ToolExpandBody";
 import { MarkdownChat } from "./MarkdownChat";
+import { findMatchesBeforeVisible } from "@/lib/chatFind";
 import {
   IconBulb,
   IconChevronDown,
@@ -249,6 +250,10 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
   expanded,
   onUserToggle,
   onPolicySync,
+  findQuery,
+  findActiveOccurrence,
+  messageContent,
+  onOpenExternalLink,
 }: {
   step: GrokActivityStep;
   isLast: boolean;
@@ -267,6 +272,10 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
     key: string,
     opts: { hasBody: boolean; running: boolean; autoCollapse: boolean },
   ) => void;
+  findQuery?: string;
+  findActiveOccurrence?: number | null;
+  messageContent?: string;
+  onOpenExternalLink?: (url: string) => void;
 }) {
   const failed =
     step.type !== "thought" &&
@@ -346,6 +355,11 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
   const showBody = open;
 
   if (step.type === "speech") {
+    const speechFindBase = findMatchesBeforeVisible({
+      full: messageContent ?? "",
+      visible: step.text,
+      query: findQuery ?? "",
+    });
     return (
       <div
         className={"grok-act__step grok-act__step--speech" + (isLast ? " is-last" : "")}
@@ -354,7 +368,14 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
         data-testid="timeline-process-speech"
       >
         <div className="grok-act__speech">
-          <MarkdownChat locale={locale} pathCards={false}>
+          <MarkdownChat
+            locale={locale}
+            pathCards={false}
+            findQuery={findQuery}
+            findActiveOccurrence={findActiveOccurrence}
+            findOccurrenceBase={speechFindBase}
+            onOpenExternalLink={onOpenExternalLink}
+          >
             {step.text}
           </MarkdownChat>
         </div>
@@ -425,7 +446,15 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
           step.type === "bash-group" ||
           step.type === "edit-group" ? (
             <div className="grok-act__explore-children">
-              <GrokActivitySteps steps={step.children} tr={tr} locale={locale} />
+              <GrokActivitySteps
+                steps={step.children}
+                tr={tr}
+                locale={locale}
+                findQuery={findQuery}
+                findActiveOccurrence={findActiveOccurrence}
+                messageContent={messageContent}
+                onOpenExternalLink={onOpenExternalLink}
+              />
             </div>
           ) : step.type === "thought" ? (
             <div className="grok-act__thought-body">
@@ -459,12 +488,20 @@ export function GrokActivitySteps({
   tr,
   locale,
   live = false,
+  findQuery,
+  findActiveOccurrence,
+  messageContent,
+  onOpenExternalLink,
 }: {
   steps: GrokActivityStep[];
   tr: ReturnType<typeof createT>;
   locale: Locale;
   /** When true, prefer showing the tail of a virtualized list. */
   live?: boolean;
+  findQuery?: string;
+  findActiveOccurrence?: number | null;
+  messageContent?: string;
+  onOpenExternalLink?: (url: string) => void;
 }) {
   const total = steps.length;
   const [expandState, setExpandState] = useState<ActivityStepExpandState>(() =>
@@ -502,9 +539,24 @@ export function GrokActivitySteps({
         expanded={expandState.expandedKeys.has(step.key)}
         onUserToggle={onUserToggle}
         onPolicySync={onPolicySync}
+        findQuery={findQuery}
+        findActiveOccurrence={findActiveOccurrence}
+        messageContent={messageContent}
+        onOpenExternalLink={onOpenExternalLink}
       />
     ),
-    [total, tr, locale, expandState.expandedKeys, onUserToggle, onPolicySync],
+    [
+      total,
+      tr,
+      locale,
+      expandState.expandedKeys,
+      onUserToggle,
+      onPolicySync,
+      findQuery,
+      findActiveOccurrence,
+      messageContent,
+      onOpenExternalLink,
+    ],
   );
 
   if (!total) return null;
@@ -532,6 +584,10 @@ export function GrokActivitySteps({
             isLast={idx === total - 1}
             tr={tr}
             locale={locale}
+            findQuery={findQuery}
+            findActiveOccurrence={findActiveOccurrence}
+            messageContent={messageContent}
+            onOpenExternalLink={onOpenExternalLink}
             expanded={expandState.expandedKeys.has(step.key)}
             onUserToggle={onUserToggle}
             onPolicySync={onPolicySync}
@@ -567,6 +623,10 @@ export const TimelinePhaseBlock = memo(function TimelinePhaseBlock({
   autoCollapse: autoCollapseProp,
   durationSec: durationSecProp,
   historyTimestamps,
+  findQuery,
+  findActiveOccurrence,
+  messageContent,
+  onOpenExternalLink,
 }: {
   phase: TimelinePhase;
   locale: Locale;
@@ -574,6 +634,10 @@ export const TimelinePhaseBlock = memo(function TimelinePhaseBlock({
   autoCollapse?: boolean;
   durationSec?: number | null;
   historyTimestamps?: Array<string | undefined | null>;
+  findQuery?: string;
+  findActiveOccurrence?: number | null;
+  messageContent?: string;
+  onOpenExternalLink?: (url: string) => void;
 }) {
   const tr = useMemo(() => createT(locale), [locale]);
   const [autoCollapse, setAutoCollapse] = useState(
@@ -749,6 +813,10 @@ export const TimelinePhaseBlock = memo(function TimelinePhaseBlock({
           tr={tr}
           locale={locale}
           live={phaseRunning}
+          findQuery={findQuery}
+          findActiveOccurrence={findActiveOccurrence}
+          messageContent={messageContent}
+          onOpenExternalLink={onOpenExternalLink}
         />
       ) : null}
     </div>

--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -127,7 +127,12 @@ function StepIcon({ step }: { step: GrokActivityStep }) {
   // Official icons are ~15–16px, thin stroke, muted gray
   const size = 15;
   const stroke = 1.5;
+  if (step.type === "speech") return null;
   if (step.type === "thought") return <IconBulb size={size} stroke={stroke} />;
+  if (step.type === "bash-group")
+    return <IconTerminal size={size} stroke={stroke} />;
+  if (step.type === "edit-group")
+    return <IconEdit size={size} stroke={stroke} />;
   if (step.type === "search-group" || step.type === "explore-group")
     return <IconSearch size={size} stroke={stroke} />;
   if (step.type === "web-search")
@@ -174,10 +179,28 @@ function StepMainText({
   tr: ReturnType<typeof createT>;
 }) {
   switch (step.type) {
+    case "speech":
+      return null;
     case "thought":
       return (
         <span className="grok-act__label-text">
           {step.summary || tr("chat.thinkingLabel")}
+        </span>
+      );
+    case "bash-group":
+      return (
+        <span className="grok-act__label-text">
+          {step.count === 1
+            ? tr("chat.ranCommandsOne")
+            : tr("chat.ranCommands", { n: String(step.count) })}
+        </span>
+      );
+    case "edit-group":
+      return (
+        <span className="grok-act__label-text">
+          {step.count === 1
+            ? tr("chat.editedFilesOne")
+            : tr("chat.editedFiles", { n: String(step.count) })}
         </span>
       );
     case "search-group":
@@ -246,13 +269,19 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
   ) => void;
 }) {
   const failed =
-    step.type !== "thought" && "failed" in step ? !!step.failed : false;
+    step.type !== "thought" &&
+    step.type !== "speech" &&
+    "failed" in step
+      ? !!step.failed
+      : false;
   const running =
     step.type === "thought"
       ? !!step.streaming
-      : "running" in step
-        ? !!step.running
-        : false;
+      : step.type === "speech"
+        ? false
+        : "running" in step
+          ? !!step.running
+          : false;
   const resultCount =
     step.type === "web-search" ? step.resultCount : undefined;
   const domains =
@@ -273,9 +302,13 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
   // A thought step is expandable when it has body text beyond the one-line
   // summary — otherwise the reasoning is unreadable inside the phase (only the
   // summary showed, with no way to open the full text like tools could).
+  const grouped =
+    step.type === "explore-group" ||
+    step.type === "bash-group" ||
+    step.type === "edit-group";
   const hasBody =
     expand.hasBody ||
-    (step.type === "explore-group" && step.children.length > 0) ||
+    (grouped && step.children.length > 0) ||
     (step.type === "thought" && step.text.trim().length > 0);
 
   const runningRef = useRef(running);
@@ -311,6 +344,23 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
 
   const open = hasBody && expanded;
   const showBody = open;
+
+  if (step.type === "speech") {
+    return (
+      <div
+        className={"grok-act__step grok-act__step--speech" + (isLast ? " is-last" : "")}
+        role="listitem"
+        data-step-type="speech"
+        data-testid="timeline-process-speech"
+      >
+        <div className="grok-act__speech">
+          <MarkdownChat locale={locale} pathCards={false}>
+            {step.text}
+          </MarkdownChat>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -371,7 +421,9 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
           ) : null}
         </div>
         {showBody ? (
-          step.type === "explore-group" ? (
+          step.type === "explore-group" ||
+          step.type === "bash-group" ||
+          step.type === "edit-group" ? (
             <div className="grok-act__explore-children">
               <GrokActivitySteps steps={step.children} tr={tr} locale={locale} />
             </div>
@@ -431,10 +483,12 @@ export function GrokActivitySteps({
     },
     [],
   );
-  const virtualize = shouldVirtualizeActivityWithExpand(
-    total,
-    expandState.expandedKeys.size,
-  );
+  const virtualize =
+    !steps.some((s) => s.type === "speech") &&
+    shouldVirtualizeActivityWithExpand(
+      total,
+      expandState.expandedKeys.size,
+    );
   const lastKey = total > 0 ? steps[total - 1]!.key : null;
 
   const getKey = useCallback((step: GrokActivityStep) => step.key, []);

--- a/src/components/lobe-chat/lobe-chat.part2.css
+++ b/src/components/lobe-chat/lobe-chat.part2.css
@@ -399,6 +399,31 @@
   padding-left: 4px;
   border-left: 1px solid var(--chat-border, rgb(255 255 255 / 6%));
 }
+/* User-facing mid-turn speech inside 工作了 — body text, not a 30px rail row. */
+.grok-act__step--speech {
+  display: block;
+  min-height: 0;
+  padding: 4px 0 10px;
+  align-items: stretch;
+}
+.grok-act__speech {
+  color: var(--chat-text);
+  font-size: 14px;
+  line-height: 1.65;
+}
+.grok-act__speech .chat-md,
+.grok-act__speech .md-body {
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+}
+.grok-act__speech p {
+  margin: 0 0 0.7em;
+}
+.grok-act__speech p:last-child {
+  margin-bottom: 0;
+}
+
 /* Full thought text revealed when a phase’s 💡 step is expanded — muted like
    the standalone Thinking block, capped so a huge reasoning trace does not
    bury the tool rows around it. */
@@ -580,14 +605,12 @@
   display: none;
 }
 
-/* Process diary sits with the work rail; conclusion starts after one beat */
-.grok-fragments[data-variant="process"] {
-  margin: 0 0 2px;
-}
+/* Conclusion sits below the 工作了 fold (or a thought row), with one beat. */
 .chat-md--answer {
   margin-top: 10px;
 }
-.lobe-chat-assistant-timeline > .grok-fragments[data-variant="process"] + .chat-md--answer {
+.lobe-chat-assistant-timeline > .grok-act + .chat-md--answer,
+.lobe-chat-assistant-timeline > .lobe-timeline-rail + .chat-md--answer {
   margin-top: 10px;
 }
 

--- a/src/i18n/messages/en/chat.ts
+++ b/src/i18n/messages/en/chat.ts
@@ -106,6 +106,10 @@ export const enChat = {
   "chat.exploreSearchesOne": "1 search",
   "chat.exploreFiles": "{n} files",
   "chat.exploreFilesOne": "1 file",
+  "chat.ranCommands": "Ran {n} commands",
+  "chat.ranCommandsOne": "Ran 1 command",
+  "chat.editedFiles": "Edited {n} files",
+  "chat.editedFilesOne": "Edited 1 file",
   "chat.leadFragments": "{n} progress notes",
   /** Folded first-person work diary inside a single assistant body. */
   "chat.processNotes": "Process",

--- a/src/i18n/messages/zh-TW/chat.ts
+++ b/src/i18n/messages/zh-TW/chat.ts
@@ -106,6 +106,10 @@ export const zhTWChat = {
   "chat.exploreSearchesOne": "1 次搜尋",
   "chat.exploreFiles": "{n} 個檔案",
   "chat.exploreFilesOne": "1 個檔案",
+  "chat.ranCommands": "執行了 {n} 個命令",
+  "chat.ranCommandsOne": "執行了 1 個命令",
+  "chat.editedFiles": "編輯了 {n} 個檔案",
+  "chat.editedFilesOne": "編輯了 1 個檔案",
   "chat.leadFragments": "{n} 段過程說明",
   /** 單條正文裡、結論之前的第一人稱工作日記摺疊頭。 */
   "chat.processNotes": "過程",

--- a/src/i18n/messages/zh/chat.ts
+++ b/src/i18n/messages/zh/chat.ts
@@ -106,6 +106,10 @@ export const zhChat = {
   "chat.exploreSearchesOne": "1 次搜索",
   "chat.exploreFiles": "{n} 个文件",
   "chat.exploreFilesOne": "1 个文件",
+  "chat.ranCommands": "运行了 {n} 个命令",
+  "chat.ranCommandsOne": "运行了 1 个命令",
+  "chat.editedFiles": "编辑了 {n} 个文件",
+  "chat.editedFilesOne": "编辑了 1 个文件",
   "chat.leadFragments": "{n} 段过程说明",
   /** 单条正文里、结论之前的第一人称工作日记折叠头。 */
   "chat.processNotes": "过程",

--- a/src/lib/assistantAnswerSplit.test.ts
+++ b/src/lib/assistantAnswerSplit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { splitAssistantAnswer } from "./assistantAnswerSplit";
+import { processSpeechParagraphs, splitAssistantAnswer } from "./assistantAnswerSplit";
 
 /** Shape of journal a51171b5 / message 428d3ffa (process diary + --- + 01/02/03). */
 const FORK_FIXTURE = `已有品牌事实和第一版列表稿。接下来读规格、现稿和风格库，确认另外两版的结构差异再动手。先把 \`bflabs-ui\` 仓库当品牌源核对一遍，再按同一套 token 补完另外两版结构不同的稿。本地已经有 \`bflabs-ui\`。我先拆它的 token、组件和官网入口，再按同一套语言写另外两版。设计系统已经对上。接着读组件用法、官网动效和技能站参考，保证三版共用同一套 \`bflabs-ui\`，只换信息架构。接下来把 \`bflabs-ui\` 的 token 和组件样式落到本地，并抽出官网轨道几何，三版共用同一套语言。用户还提到团队官网入口。我先核一下除了 \`bflabs.cn\` 之外还有没有独立团队站，避免三版把外链写错。资产已经落到仓库。下面写共用套件，并按同一套 \`bflabs-ui\` 出三版结构不同的稿。共用套件写好了。接下来三版分开写：列表索引、货架网格、官网巨字，骨架互不重复。第一版还缺页脚。我补上官网同款页脚，再按 1440×900 把三版一起截出来。截图已经出了。我先肉眼过三张首屏，看骨架、品牌件和可读性有没有明显翻车。三张首屏都空了：导航、文案和列表都没渲染出来。我先查脚本加载和报错，再改。根因是共用脚本把 \`t\` 泄漏到全局，和页面里的 \`const { t }\` 撞名，整页 JS 直接停了。我把套件收进闭包，再重截三版。第三版标题把「智能体」拆开了。我按官网的断行方式改一版，再截首屏。三版都按 Sunnyender-org/bflabs-ui 出了：同一套 token、bf-* 组件、BF 标、顶栏/中英切换/轨道线/页脚，和 bflabs.cn 同一套语言。内容一样，骨架不一样。
@@ -61,6 +61,40 @@ A hairline directory.`;
     expect(split.answer.startsWith("**01 · List index**")).toBe(true);
   });
 
+  it("folds a process paragraph that ends at the first blank line", () => {
+    const decode = `按上次说的做：先把 8 张 hard-set 都 decode 对照手写种子，再拿反推稿出图，跑 decode → render 闭环。8 张类型全对。接着用反推稿出图，文件名加 \`-decode\`，不覆盖旧成品。H1 出图撞上 Cloudflare 524。我给生图加上有限次重试，然后从 H1 接着跑。8 张 decode 稿都出了。
+
+成品文件名带 \`-decode\`，旧的手写成品没动。Finder 已打开。
+
+| 看这张闭环 | 结果 |
+|---|---|
+| \`H6-type-poster-decode.png\` | **最好**。标题、眼窗、口号都在 |`;
+    const split = splitAssistantAnswer(decode);
+    expect(split.cut).toBe("break");
+    expect(split.process).toContain("先把 8 张");
+    expect(split.process).not.toContain("成品文件名");
+    expect(split.answer.startsWith("成品文件名带")).toBe(true);
+    expect(split.answer).toContain("H6-type-poster-decode.png");
+  });
+
+  it("folds 先接手 diary before the factual recap", () => {
+    const site = `先接手这个 Claude 会话，核对项目上下文和站点上线状态。接着按 resume 协议读会话交接文档，并拉项目上下文。正在读取该 Claude 会话，并核对仓库与上线相关证据。会话 ID 没直接命中，接着列本地会话并核对站点是否真的上线。
+
+刚接手的是 Grok.app 分叉会话，不是 Claude。
+
+今天刚核过的线上事实：
+
+| 入口 | 现状 |
+|---|---|
+| \`skills.bflabs.cn\` | 无 DNS，解析失败 |`;
+    const split = splitAssistantAnswer(site);
+    expect(split.cut).toBe("break");
+    expect(split.process).toContain("先接手这个");
+    expect(split.process).not.toContain("刚接手的是");
+    expect(split.answer).toContain("刚接手的是");
+    expect(split.answer).toContain("skills.bflabs.cn");
+  });
+
   it("does not fold a short intro before a heading", () => {
     const split = splitAssistantAnswer(
       "先说结论。\n\n**团队入口**：官网目前回 bflabs.cn。",
@@ -101,6 +135,12 @@ not a cut
     expect(splitAssistantAnswer("").process).toBeNull();
     expect(splitAssistantAnswer("   \n").process).toBeNull();
     expect(splitAssistantAnswer("短").process).toBeNull();
+  });
+
+  it("splits a process diary into paragraphs", () => {
+    expect(
+      processSpeechParagraphs("先接手这个会话。\n\n正在读取证据。"),
+    ).toEqual(["先接手这个会话。", "正在读取证据。"]);
   });
 
   it("does not cut yaml-like front matter with an empty prefix", () => {

--- a/src/lib/assistantAnswerSplit.test.ts
+++ b/src/lib/assistantAnswerSplit.test.ts
@@ -95,6 +95,19 @@ A hairline directory.`;
     expect(split.answer).toContain("skills.bflabs.cn");
   });
 
+  it("does not fold a long conclusion that uses process-like verbs then a table", () => {
+    const text = `已经按你说的把闭环跑完，8 张类型都对，成品都写在 evals/renders 下面、文件名带 -decode。接下来是结论，也是我核过之后愿意签字的推荐，下面这张表按可读性和品牌件排过序。
+
+| 图 | 结果 |
+|---|---|
+| a | 过 |`;
+    const split = splitAssistantAnswer(text);
+    expect(split.cut).toBeNull();
+    expect(split.process).toBeNull();
+    expect(split.answer).toContain("接下来是结论");
+    expect(split.answer).toContain("| a | 过 |");
+  });
+
   it("does not fold a short intro before a heading", () => {
     const split = splitAssistantAnswer(
       "先说结论。\n\n**团队入口**：官网目前回 bflabs.cn。",

--- a/src/lib/assistantAnswerSplit.ts
+++ b/src/lib/assistantAnswerSplit.ts
@@ -9,14 +9,15 @@
  *
  * Cut, earliest wins:
  * 1. First-person process prefix, then a heading / `**title**：` line
- * 2. Standalone markdown `---` / `***` / `___` (not a table rule, not in a fence)
- * 3. Numbered deliverable heading (`**01 ·` / `## 01.`)
+ * 2. Process-like first paragraph, then a blank line (the common Grok 4.6 shape)
+ * 3. Standalone markdown `---` / `***` / `___` (not a table rule, not in a fence)
+ * 4. Numbered deliverable heading (`**01 ·` / `## 01.`)
  *
  * No cut when the prefix is too short, the remainder is empty, or the
  * only hit is inside a fence / table separator.
  */
 
-export type AssistantAnswerCut = "heading" | "hr" | "numbered";
+export type AssistantAnswerCut = "heading" | "break" | "hr" | "numbered";
 
 export type AssistantAnswerSplit = {
   process: string | null;
@@ -40,6 +41,10 @@ const PROCESS_MARKERS: RegExp[] = [
   /已经/,
   /先把/,
   /先读/,
+  /先接手/,
+  /正在读/,
+  /正在核/,
+  /我给/,
   /根因是/,
   /本地已经/,
   /截图已经/,
@@ -115,6 +120,23 @@ export function splitAssistantAnswer(
       cands.push({ line: firstHeading, kind: "heading", skipLine: false });
     }
   }
+  const breakAt = firstContentParagraphEnd(lines);
+  if (breakAt >= 0) {
+    const prefix = lines.slice(0, breakAt).join("\n");
+    let j = breakAt;
+    while (j < lines.length && !(lines[j] ?? "").trim()) j += 1;
+    const next = lines[j] ?? "";
+    // Leave --- / **01 · / **title** to those dedicated cuts.
+    if (
+      looksLikeProcessDiary(prefix) &&
+      prefixLooksUnstructured(prefix) &&
+      !HR_RE.test(next) &&
+      !NUMBERED_RE.test(next) &&
+      !isAnswerHeading(next)
+    ) {
+      cands.push({ line: breakAt, kind: "break", skipLine: true });
+    }
+  }
   if (firstHr >= 0) {
     cands.push({ line: firstHr, kind: "hr", skipLine: true });
   }
@@ -155,10 +177,46 @@ function looksLikeProcessDiary(prefix: string): boolean {
   return countProcessMarkers(t) >= 2;
 }
 
+/** Index of the first blank line after the opening paragraph, or -1. */
+function firstContentParagraphEnd(lines: string[]): number {
+  let i = 0;
+  while (i < lines.length && !(lines[i] ?? "").trim()) i += 1;
+  if (i >= lines.length) return -1;
+  let inFence = false;
+  let fenceMark = "";
+  for (; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const fence = line.match(FENCE_RE);
+    if (fence) {
+      const mark = fence[1]!.charAt(0);
+      if (!inFence) {
+        inFence = true;
+        fenceMark = mark;
+      } else if (mark === fenceMark) {
+        inFence = false;
+        fenceMark = "";
+      }
+      continue;
+    }
+    if (inFence) continue;
+    if (!line.trim()) return i;
+  }
+  return -1;
+}
+
 function prefixLooksUnstructured(prefix: string): boolean {
   for (const line of prefix.split(/\r?\n/)) {
     if (!line.trim()) continue;
     if (NUMBERED_RE.test(line) || isAnswerHeading(line)) return false;
   }
   return true;
+}
+
+/** Split a process diary into speech paragraphs (stream-order turns). */
+export function processSpeechParagraphs(process: string | null | undefined): string[] {
+  if (!process?.trim()) return [];
+  return process
+    .split(/\n\n+/)
+    .map((p) => p.trim())
+    .filter(Boolean);
 }

--- a/src/lib/assistantAnswerSplit.ts
+++ b/src/lib/assistantAnswerSplit.ts
@@ -129,6 +129,7 @@ export function splitAssistantAnswer(
     // Leave --- / **01 · / **title** to those dedicated cuts.
     if (
       looksLikeProcessDiary(prefix) &&
+      looksLikeMidTurnDiary(prefix) &&
       prefixLooksUnstructured(prefix) &&
       !HR_RE.test(next) &&
       !NUMBERED_RE.test(next) &&
@@ -175,6 +176,29 @@ function looksLikeProcessDiary(prefix: string): boolean {
   const t = prefix.trim();
   if (t.length < MIN_PROCESS_CHARS) return false;
   return countProcessMarkers(t) >= 2;
+}
+
+/** Blank-line cuts need a first-person / in-progress verb, not just 已经/接下来. */
+const MID_TURN_DIARY_MARKERS: RegExp[] = [
+  /我先/,
+  /我再/,
+  /我把/,
+  /我补/,
+  /我给/,
+  /先接手/,
+  /先把/,
+  /先读/,
+  /正在读/,
+  /正在核/,
+  /根因是/,
+  /\bLet me\b/i,
+  /\bI(?:'ll| will)\b/,
+  /\bI've (?:now|already)\b/i,
+  /\bLooking at\b/i,
+];
+
+function looksLikeMidTurnDiary(prefix: string): boolean {
+  return MID_TURN_DIARY_MARKERS.some((re) => re.test(prefix));
 }
 
 /** Index of the first blank line after the opening paragraph, or -1. */

--- a/src/lib/chatFind.test.ts
+++ b/src/lib/chatFind.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   findChatMatches,
+  findMatchesBeforeVisible,
   formatChatFindCount,
   searchableTextForMessage,
   splitHighlightParts,
@@ -85,6 +86,38 @@ describe("findChatMatches", () => {
       { id: "sys", role: "system", content: "xxx" },
     ]);
     expect(hits).toHaveLength(0);
+  });
+});
+
+describe("findMatchesBeforeVisible", () => {
+  it("counts hits in the folded prefix of a process + conclusion body", () => {
+    const process =
+      "先把 8 张 hard-set 都 decode。接着补重试。8 张 decode 稿都出了。";
+    const answer = "成品文件名带 -decode，旧的手写成品没动。";
+    expect(
+      findMatchesBeforeVisible({
+        full: `${process}\n\n${answer}`,
+        visible: answer,
+        query: "decode",
+      }),
+    ).toBe(2);
+    expect(
+      findMatchesBeforeVisible({
+        full: `${process}\n\n${answer}`,
+        visible: answer,
+        query: "成品",
+      }),
+    ).toBe(0);
+  });
+
+  it("returns 0 when the visible slice is the whole body", () => {
+    expect(
+      findMatchesBeforeVisible({
+        full: "正在写结论，还没有分段。",
+        visible: "正在写结论，还没有分段。",
+        query: "结论",
+      }),
+    ).toBe(0);
   });
 });
 

--- a/src/lib/chatFind.ts
+++ b/src/lib/chatFind.ts
@@ -91,6 +91,35 @@ export function findChatMatches(
   return out;
 }
 
+/**
+ * How many query hits sit in `full` before the visible slice.
+ * Used so Cmd+F occurrence indexes (scanned on the raw message body) line
+ * up with highlights on a folded conclusion / speech paragraph.
+ */
+export function findMatchesBeforeVisible(input: {
+  full: string;
+  visible: string;
+  query: string;
+}): number {
+  const full = input.full ?? "";
+  const visible = input.visible ?? "";
+  const query = input.query;
+  if (!query.trim() || !full) return 0;
+  let prefix = "";
+  if (visible && full.endsWith(visible)) {
+    prefix = full.slice(0, full.length - visible.length);
+  } else if (visible) {
+    const at = full.indexOf(visible);
+    prefix = at >= 0 ? full.slice(0, at) : "";
+  } else {
+    prefix = full;
+  }
+  if (!prefix) return 0;
+  return findChatMatches(query, [
+    { id: "_", role: "assistant", content: prefix },
+  ]).length;
+}
+
 /** Next / previous match index with wrap-around. */
 export function stepChatFindIndex(
   current: number,

--- a/src/lib/grokActivitySteps.test.ts
+++ b/src/lib/grokActivitySteps.test.ts
@@ -236,6 +236,42 @@ describe("grokActivitySteps explore-group", () => {
     expect(steps.map((s) => s.type)).toEqual(["tool", "tool"]);
   });
 
+  it("folds consecutive bash / edit bursts and keeps speech as its own step", () => {
+    const items: GrokPhaseItem[] = [
+      { kind: "speech", text: "先核对仓库。" },
+      {
+        kind: "tool",
+        tool: tool("b1", "run_terminal_command", "Run", { input: "ls" }),
+      },
+      {
+        kind: "tool",
+        tool: tool("b2", "run_terminal_command", "Run", { input: "pwd" }),
+      },
+      {
+        kind: "tool",
+        tool: tool("b3", "run_terminal_command", "Run", { input: "git status" }),
+      },
+      { kind: "speech", text: "接着改两处。" },
+      {
+        kind: "tool",
+        tool: tool("e1", "search_replace", "Edit", { input: "a.ts" }),
+      },
+      {
+        kind: "tool",
+        tool: tool("e2", "search_replace", "Edit", { input: "b.ts" }),
+      },
+    ];
+    const steps = buildGrokActivitySteps(items);
+    expect(steps.map((s) => s.type)).toEqual([
+      "speech",
+      "bash-group",
+      "speech",
+      "edit-group",
+    ]);
+    expect(steps[1]).toMatchObject({ type: "bash-group", count: 3 });
+    expect(steps[3]).toMatchObject({ type: "edit-group", count: 2 });
+  });
+
   it("browse breaks an explore run (keeps its own Browsed row)", () => {
     const items: GrokPhaseItem[] = [
       { kind: "tool", tool: tool("r1", "read_file", "Read", { input: "a.ts" }) },

--- a/src/lib/grokActivitySteps.ts
+++ b/src/lib/grokActivitySteps.ts
@@ -24,11 +24,33 @@ import {
 
 export type GrokActivityStep =
   | {
+      /** User-facing mid-turn prose inside 工作了 (not journal CoT). */
+      type: "speech";
+      key: string;
+      text: string;
+    }
+  | {
       type: "thought";
       key: string;
       summary: string | null;
       streaming: boolean;
       text: string;
+    }
+  | {
+      type: "bash-group";
+      key: string;
+      count: number;
+      failed: boolean;
+      running: boolean;
+      children: GrokActivityStep[];
+    }
+  | {
+      type: "edit-group";
+      key: string;
+      count: number;
+      failed: boolean;
+      running: boolean;
+      children: GrokActivityStep[];
     }
   | {
       type: "search-group";
@@ -89,6 +111,7 @@ export type GrokActivityStep =
 
 export type GrokPhaseItem =
   | { kind: "thought"; text: string }
+  | { kind: "speech"; text: string }
   | { kind: "tool"; tool: MessageToolSegment };
 
 function toolRunning(t: MessageToolSegment): boolean {
@@ -273,6 +296,17 @@ function buildStepsInternal(
 
   while (i < items.length) {
     const item = items[i]!;
+    if (item.kind === "speech") {
+      if (item.text.trim()) {
+        steps.push({
+          type: "speech",
+          key: `sp-${i}`,
+          text: item.text,
+        });
+      }
+      i += 1;
+      continue;
+    }
     if (item.kind === "thought") {
       const parts = splitThoughtForActivity(item.text);
       const toolsAfter = items.slice(i + 1).some((x) => x.kind === "tool");
@@ -396,6 +430,49 @@ function buildStepsInternal(
         });
         i = runEnd;
         continue;
+      }
+    }
+
+    // Consecutive bash / edit bursts → one folded action row (mock: 运行了 N /
+    // 编辑了 N). Singles stay individual so a lone command is still a tool row.
+    if (grouping) {
+      const bucket = classifyToolKind(tool.toolKind, tool.title, tool.toolCallId);
+      if (bucket === "bash" || bucket === "edit") {
+        let runEnd = i;
+        while (runEnd < items.length) {
+          const it = items[runEnd]!;
+          if (it.kind !== "tool") break;
+          if (
+            classifyToolKind(
+              it.tool.toolKind,
+              it.tool.title,
+              it.tool.toolCallId,
+            ) !== bucket
+          ) {
+            break;
+          }
+          runEnd += 1;
+        }
+        if (runEnd - i >= 2) {
+          let failed = false;
+          let running = false;
+          for (let k = i; k < runEnd; k++) {
+            const t = (items[k] as { kind: "tool"; tool: MessageToolSegment })
+              .tool;
+            if (toolFailed(t)) failed = true;
+            if (stepRunning(t, messageStreaming)) running = true;
+          }
+          steps.push({
+            type: bucket === "bash" ? "bash-group" : "edit-group",
+            key: `${bucket}-${i}`,
+            count: runEnd - i,
+            failed,
+            running,
+            children: buildStepsInternal(items.slice(i, runEnd), options, false),
+          });
+          i = runEnd;
+          continue;
+        }
       }
     }
 

--- a/src/lib/timelinePhases.test.ts
+++ b/src/lib/timelinePhases.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { MessageSegment } from "./session";
 import {
+  buildAssistantTimeline,
   buildTimelineUnits,
+  foldProcessIntoTimeline,
   isPhaseWorthy,
   phaseTitleModel,
   shouldShowTrailingLiveThinking,
+  weaveSpeechAndTools,
 } from "./timelinePhases";
+import type { MessageToolSegment } from "./session";
 
 function tool(
   id: string,
@@ -273,5 +277,189 @@ describe("timelinePhases", () => {
       messageStreaming: true,
       hasRunningTool: false,
     })).toBe(false);
+  });
+});
+
+function bash(id: string): MessageToolSegment {
+  return {
+    kind: "tool",
+    toolCallId: id,
+    title: "Run",
+    toolKind: "run_terminal_command",
+    status: "completed",
+    streaming: false,
+  };
+}
+
+function edit(id: string): MessageToolSegment {
+  return {
+    kind: "tool",
+    toolCallId: id,
+    title: "Edit",
+    toolKind: "search_replace",
+    status: "completed",
+    streaming: false,
+  };
+}
+
+describe("foldProcessIntoTimeline", () => {
+  it("puts process speech inside 工作了 and leaves the conclusion below", () => {
+    const segs: MessageSegment[] = [
+      { kind: "thought", text: "The plan is to decode eight shots" },
+      tool("r1", "Read a"),
+      tool("r2", "Read b"),
+      bash("b1"),
+      bash("b2"),
+      bash("b3"),
+      edit("e1"),
+      edit("e2"),
+      {
+        kind: "content",
+        text: `按上次说的做：先把 8 张 hard-set 都 decode 对照手写种子，再拿反推稿出图，跑 decode → render 闭环。8 张类型全对。接着用反推稿出图，文件名加 \`-decode\`，不覆盖旧成品。H1 出图撞上 Cloudflare 524。我给生图加上有限次重试，然后从 H1 接着跑。8 张 decode 稿都出了。
+
+成品文件名带 \`-decode\`，旧的手写成品没动。Finder 已打开。
+
+| 看这张闭环 | 结果 |
+|---|---|
+| \`H6-type-poster-decode.png\` | **最好**。标题、眼窗、口号都在 |`,
+      },
+    ];
+    const units = buildAssistantTimeline(segs, { streaming: false });
+    expect(units.map((u) => u.kind)).toEqual(["thought", "phase", "content"]);
+    const thought = units[0]!;
+    expect(thought.kind).toBe("thought");
+    if (thought.kind === "thought") {
+      expect(thought.text).toContain("decode eight");
+    }
+    const phase = units[1]!;
+    expect(phase.kind).toBe("phase");
+    if (phase.kind === "phase") {
+      expect(phase.thoughts).toEqual([]);
+      expect(phase.items.some((i) => i.kind === "speech")).toBe(true);
+      expect(phase.items.some((i) => i.kind === "tool")).toBe(true);
+      const firstSpeech = phase.items.find((i) => i.kind === "speech");
+      expect(firstSpeech && firstSpeech.kind === "speech" && firstSpeech.text).toContain(
+        "先把 8 张",
+      );
+    }
+    const answer = units[2]!;
+    expect(answer.kind).toBe("content");
+    if (answer.kind === "content") {
+      expect(answer.text.startsWith("成品文件名带")).toBe(true);
+      expect(answer.text).not.toContain("先把 8 张");
+    }
+  });
+
+  it("keeps interleaved mid-turn content in stream order", () => {
+    const segs: MessageSegment[] = [
+      { kind: "thought", text: "round1" },
+      tool("r1", "Read a"),
+      tool("r2", "Read b"),
+      { kind: "content", text: "先看仓库结构，接着对一下入口。" },
+      bash("b1"),
+      bash("b2"),
+      {
+        kind: "content",
+        text: `本地已经改完，接下来装一遍确认。我再把对照表写清楚。先把重试补上，再核一遍成品路径，避免旧文件被覆盖。已经对上类型，接着把对照表写进正文，并把 Finder 打开给用户看。本地路径都对上了。
+
+成品在 \`evals/renders/\`，对照表如下。
+
+| 图 | 结果 |
+|---|---|
+| a | 过 |`,
+      },
+    ];
+    const units = buildAssistantTimeline(segs, { streaming: false });
+    expect(units.map((u) => u.kind)).toEqual(["thought", "phase", "content"]);
+    const phase = units[1]!;
+    expect(phase.kind).toBe("phase");
+    if (phase.kind === "phase") {
+      expect(phase.items.map((i) => i.kind)).toEqual([
+        "tool",
+        "tool",
+        "speech",
+        "tool",
+        "tool",
+        "speech",
+      ]);
+      const speeches = phase.items.filter((i) => i.kind === "speech");
+      expect(speeches[0]).toMatchObject({
+        kind: "speech",
+        text: "先看仓库结构，接着对一下入口。",
+      });
+    }
+    const answer = units[2]!;
+    expect(answer.kind).toBe("content");
+    if (answer.kind === "content") {
+      expect(answer.text).toContain("成品在");
+    }
+  });
+
+  it("weaves a trailing process blob in front of tool family groups", () => {
+    const woven = weaveSpeechAndTools([
+      { kind: "tool", tool: tool("r1", "Read a") },
+      { kind: "tool", tool: tool("r2", "Read b") },
+      { kind: "tool", tool: bash("b1") },
+      { kind: "tool", tool: bash("b2") },
+      { kind: "speech", text: "先对照手写种子。" },
+      { kind: "speech", text: "再补重试。" },
+    ]);
+    expect(woven.map((i) => i.kind)).toEqual([
+      "speech",
+      "tool",
+      "tool",
+      "speech",
+      "tool",
+      "tool",
+    ]);
+  });
+
+  it("does not hide a streaming last content that has no cut yet", () => {
+    const segs: MessageSegment[] = [
+      { kind: "thought", text: "plan" },
+      tool("r1", "Read a"),
+      tool("r2", "Read b"),
+      { kind: "content", text: "正在写结论，还没有分段。" },
+    ];
+    const live = foldProcessIntoTimeline(
+      buildTimelineUnits(segs, { streaming: true }),
+      { streaming: true },
+    );
+    expect(live.map((u) => u.kind)).toEqual(["thought", "phase", "content"]);
+    const content = live[2]!;
+    expect(content.kind).toBe("content");
+    if (content.kind === "content") {
+      expect(content.text).toContain("正在写结论");
+    }
+  });
+
+  it("synthesizes a work fold when there is process speech but no tools", () => {
+    const segs: MessageSegment[] = [
+      {
+        kind: "content",
+        text: `先接手这个 Claude 会话，核对项目上下文和站点上线状态。接着按 resume 协议读会话交接文档，并拉项目上下文。正在读取该 Claude 会话，并核对仓库与上线相关证据。会话 ID 没直接命中，接着列本地会话并核对站点是否真的上线。
+
+刚接手的是 Grok.app 分叉会话，不是 Claude。
+
+今天刚核过的线上事实：
+
+| 入口 | 现状 |
+|---|---|
+| \`skills.bflabs.cn\` | 无 DNS，解析失败 |`,
+      },
+    ];
+    const units = buildAssistantTimeline(segs, { streaming: false });
+    expect(units.map((u) => u.kind)).toEqual(["phase", "content"]);
+    const phase = units[0]!;
+    expect(phase.kind).toBe("phase");
+    if (phase.kind === "phase") {
+      expect(phase.items.every((i) => i.kind === "speech")).toBe(true);
+      expect(phase.tools).toHaveLength(0);
+    }
+    const answer = units[1]!;
+    expect(answer.kind).toBe("content");
+    if (answer.kind === "content") {
+      expect(answer.text).toContain("刚接手的是");
+    }
   });
 });

--- a/src/lib/timelinePhases.test.ts
+++ b/src/lib/timelinePhases.test.ts
@@ -433,6 +433,48 @@ describe("foldProcessIntoTimeline", () => {
     }
   });
 
+  it("keeps the last-content conclusion visible when tools follow it", () => {
+    const segs: MessageSegment[] = [
+      { kind: "thought", text: "plan" },
+      tool("r1", "Read a"),
+      tool("r2", "Read b"),
+      {
+        kind: "content",
+        text: `按上次说的做：先把 8 张 hard-set 都 decode 对照手写种子，再拿反推稿出图，跑 decode → render 闭环。8 张类型全对。接着用反推稿出图，文件名加 \`-decode\`，不覆盖旧成品。H1 出图撞上 Cloudflare 524。我给生图加上有限次重试，然后从 H1 接着跑。8 张 decode 稿都出了。
+
+成品文件名带 \`-decode\`，旧的手写成品没动。Finder 已打开。`,
+      },
+      bash("open-finder"),
+    ];
+    const units = buildAssistantTimeline(segs, { streaming: false });
+    expect(units.map((u) => u.kind)).toContain("content");
+    const answer = units.find((u) => u.kind === "content");
+    expect(answer && answer.kind === "content" && answer.text).toContain(
+      "成品文件名带",
+    );
+    expect(answer && answer.kind === "content" && answer.text).not.toContain(
+      "先把 8 张",
+    );
+  });
+
+  it("does not swallow a streaming last content when a later tool arrives", () => {
+    const segs: MessageSegment[] = [
+      { kind: "thought", text: "plan" },
+      tool("r1", "Read a"),
+      tool("r2", "Read b"),
+      { kind: "content", text: "正在写结论，还没有分段。" },
+      bash("open-finder"),
+    ];
+    const live = foldProcessIntoTimeline(
+      buildTimelineUnits(segs, { streaming: true }),
+      { streaming: true },
+    );
+    const content = live.find((u) => u.kind === "content");
+    expect(content && content.kind === "content" && content.text).toContain(
+      "正在写结论",
+    );
+  });
+
   it("synthesizes a work fold when there is process speech but no tools", () => {
     const segs: MessageSegment[] = [
       {

--- a/src/lib/timelinePhases.ts
+++ b/src/lib/timelinePhases.ts
@@ -443,14 +443,6 @@ function lastContentIndex(units: TimelineUnit[]): number {
   return -1;
 }
 
-function hasWorkAfter(units: TimelineUnit[], idx: number): boolean {
-  for (let i = idx + 1; i < units.length; i++) {
-    const u = units[i]!;
-    if (u.kind === "phase" || u.kind === "tool") return true;
-  }
-  return false;
-}
-
 function speechItemsFromText(text: string): TimelinePhaseItem[] {
   return processSpeechParagraphs(text).map((t) => ({
     kind: "speech" as const,
@@ -695,8 +687,9 @@ export function foldProcessIntoTimeline(
     }
     // content
     const isLast = i === lastCi;
-    const midTurn = !isLast || hasWorkAfter(units, i);
-    if (midTurn) {
+    // Only earlier content bodies are mid-turn chatter. The last content is
+    // the conclusion slot even when tools (open Finder, screenshot) follow.
+    if (!isLast) {
       for (const s of speechItemsFromText(u.text)) {
         pushWork(s, u.si, false);
       }

--- a/src/lib/timelinePhases.ts
+++ b/src/lib/timelinePhases.ts
@@ -18,10 +18,17 @@
 import type { MessageSegment, MessageToolSegment } from "./session";
 import { hostToolFamilyKey } from "./session";
 import { extractThinkingSummary } from "./thinkingSummary";
+import {
+  processSpeechParagraphs,
+  splitAssistantAnswer,
+} from "./assistantAnswerSplit";
+import { classifyToolKind } from "./toolDisplay";
 
 /** Ordered work unit inside a phase (Grok activity rail). */
 export type TimelinePhaseItem =
   | { kind: "thought"; text: string }
+  /** User-facing mid-turn prose (not journal CoT). */
+  | { kind: "speech"; text: string }
   | { kind: "tool"; tool: MessageToolSegment };
 
 export interface TimelinePhase {
@@ -127,8 +134,11 @@ function bufThoughts(buf: WorkBuf): string[] {
 
 function bufTools(buf: WorkBuf): MessageToolSegment[] {
   return buf.items
-    .filter((x) => x.item.kind === "tool")
-    .map((x) => (x.item as { kind: "tool"; tool: MessageToolSegment }).tool);
+    .filter(
+      (x): x is { item: { kind: "tool"; tool: MessageToolSegment }; si: number } =>
+        x.item.kind === "tool",
+    )
+    .map((x) => x.item.tool);
 }
 
 /** Collapse Host vision/X duplicates inside a work buffer before paint. */
@@ -217,7 +227,7 @@ export function buildTimelineUnits(
           streaming:
             live && streaming && isLastThought && !hasTools,
         });
-      } else {
+      } else if (entry.item.kind === "tool") {
         out.push({ kind: "tool", tool: entry.item.tool, si: entry.si });
       }
     }
@@ -424,4 +434,314 @@ export function phaseTitleModel(phase: TimelinePhase): {
     running: phase.live && phase.runningCount > 0,
     live: phase.live,
   };
+}
+
+function lastContentIndex(units: TimelineUnit[]): number {
+  for (let i = units.length - 1; i >= 0; i--) {
+    if (units[i]!.kind === "content") return i;
+  }
+  return -1;
+}
+
+function hasWorkAfter(units: TimelineUnit[], idx: number): boolean {
+  for (let i = idx + 1; i < units.length; i++) {
+    const u = units[i]!;
+    if (u.kind === "phase" || u.kind === "tool") return true;
+  }
+  return false;
+}
+
+function speechItemsFromText(text: string): TimelinePhaseItem[] {
+  return processSpeechParagraphs(text).map((t) => ({
+    kind: "speech" as const,
+    text: t,
+  }));
+}
+
+function toolFamilyKey(tool: MessageToolSegment): string {
+  const b = classifyToolKind(tool.toolKind, tool.title, tool.toolCallId);
+  if (b === "read" || b === "search") return "explore";
+  return b;
+}
+
+function speechLayout(
+  items: TimelinePhaseItem[],
+): "leading" | "trailing" | "mixed" | "none" {
+  const flags = items.map((i) => i.kind === "speech");
+  if (!flags.some(Boolean)) return "none";
+  const first = flags.indexOf(true);
+  const last = flags.lastIndexOf(true);
+  const allSpeechInRange = flags.slice(first, last + 1).every(Boolean);
+  if (!allSpeechInRange) return "mixed";
+  if (first === 0) return "leading";
+  if (last === flags.length - 1) return "trailing";
+  return "mixed";
+}
+
+function partitionToolGroups(
+  tools: MessageToolSegment[],
+): MessageToolSegment[][] {
+  const groups: MessageToolSegment[][] = [];
+  for (const t of tools) {
+    const fam = toolFamilyKey(t);
+    const prev = groups[groups.length - 1];
+    if (prev && toolFamilyKey(prev[0]!) === fam) prev.push(t);
+    else groups.push([t]);
+  }
+  return groups;
+}
+
+/**
+ * When process speech is a trailing (or leading) block after/before all
+ * tools, place a paragraph before each tool family group — the mock’s
+ * 「话 → 折叠动作 → 话」. Already-interleaved stream order is left alone.
+ */
+export function weaveSpeechAndTools(
+  items: TimelinePhaseItem[],
+): TimelinePhaseItem[] {
+  const layout = speechLayout(items);
+  if (layout !== "trailing" && layout !== "leading") return items;
+  const speeches = items.filter(
+    (i): i is { kind: "speech"; text: string } => i.kind === "speech",
+  );
+  const tools = items
+    .filter(
+      (i): i is { kind: "tool"; tool: MessageToolSegment } => i.kind === "tool",
+    )
+    .map((i) => i.tool);
+  if (!speeches.length || !tools.length) return items;
+  const groups = partitionToolGroups(tools);
+  const out: TimelinePhaseItem[] = [];
+  const pairs = Math.min(speeches.length, groups.length);
+  for (let i = 0; i < pairs; i++) {
+    out.push(speeches[i]!);
+    for (const tool of groups[i]!) out.push({ kind: "tool", tool });
+  }
+  for (let i = pairs; i < speeches.length; i++) out.push(speeches[i]!);
+  for (let i = pairs; i < groups.length; i++) {
+    for (const tool of groups[i]!) out.push({ kind: "tool", tool });
+  }
+  return out;
+}
+
+function emitThoughtUnit(
+  texts: string[],
+  si: number,
+  streaming: boolean,
+): TimelineUnit | null {
+  const cleaned = texts.map((t) => t.trim()).filter(Boolean);
+  if (!cleaned.length && !streaming) return null;
+  if (cleaned.length <= 1) {
+    return {
+      kind: "thought",
+      text: cleaned[0] ?? "",
+      si,
+      streaming,
+    };
+  }
+  return {
+    kind: "thought-group",
+    texts: cleaned,
+    si,
+    streaming,
+  };
+}
+
+function emitWorkUnits(
+  items: TimelinePhaseItem[],
+  meta: {
+    startSi: number;
+    endSi: number;
+    live: boolean;
+    streaming: boolean;
+  },
+): TimelineUnit[] {
+  const woven = weaveSpeechAndTools(items.filter((i) => i.kind !== "thought"));
+  const tools = woven
+    .filter(
+      (i): i is { kind: "tool"; tool: MessageToolSegment } => i.kind === "tool",
+    )
+    .map((i) => i.tool);
+  const speechCount = woven.filter((i) => i.kind === "speech").length;
+  if (!woven.length) return [];
+  if (speechCount === 0 && !isPhaseWorthy([], tools)) {
+    return tools.map((tool, idx) => ({
+      kind: "tool" as const,
+      tool,
+      si: meta.startSi + idx,
+    }));
+  }
+  const stats = phaseStats(tools);
+  return [
+    {
+      kind: "phase",
+      id: `p-${meta.startSi}`,
+      items: woven,
+      thoughts: [],
+      tools,
+      startSi: meta.startSi,
+      endSi: meta.endSi,
+      live: meta.live,
+      errorCount: stats.errorCount,
+      runningCount: meta.streaming ? stats.runningCount : 0,
+    },
+  ];
+}
+
+function phaseItemsOf(phase: TimelinePhase): TimelinePhaseItem[] {
+  if (phase.items?.length) return phase.items;
+  return [
+    ...phase.thoughts
+      .filter((t) => t.trim())
+      .map((text) => ({ kind: "thought" as const, text })),
+    ...phase.tools.map((tool) => ({ kind: "tool" as const, tool })),
+  ];
+}
+
+/**
+ * Display contract (confirmed mock):
+ * - Journal CoT → one 思考了 row (never dumped as body text).
+ * - Mid-turn speech + folded tools → one 工作了 fold (default collapsed).
+ * - Last-content conclusion stays visible below the fold.
+ */
+export function foldProcessIntoTimeline(
+  units: TimelineUnit[],
+  options: { streaming?: boolean } = {},
+): TimelineUnit[] {
+  const streaming = !!options.streaming;
+  const lastCi = lastContentIndex(units);
+  const hoisted: string[] = [];
+  let hoistSi = 0;
+  let hoistStreaming = false;
+  const workItems: TimelinePhaseItem[] = [];
+  let workStartSi = 0;
+  let workEndSi = 0;
+  let workLive = false;
+  let workStarted = false;
+  let answer: Extract<TimelineUnit, { kind: "content" }> | null = null;
+  const suffix: TimelineUnit[] = [];
+  let sawAnswerSlot = false;
+
+  const hoistThought = (text: string, si: number, thoughtStreaming: boolean) => {
+    if (!text.trim() && !thoughtStreaming) return;
+    if (!hoisted.length) hoistSi = si;
+    if (text.trim()) hoisted.push(text);
+    if (thoughtStreaming) hoistStreaming = true;
+  };
+
+  const pushWork = (item: TimelinePhaseItem, si: number, live: boolean) => {
+    if (!workStarted) {
+      workStarted = true;
+      workStartSi = si;
+      workEndSi = si;
+    }
+    workItems.push(item);
+    workEndSi = Math.max(workEndSi, si);
+    if (live) workLive = true;
+  };
+
+  for (let i = 0; i < units.length; i++) {
+    const u = units[i]!;
+    if (u.kind === "thought") {
+      if (sawAnswerSlot) suffix.push(u);
+      else hoistThought(u.text, u.si, u.streaming);
+      continue;
+    }
+    if (u.kind === "thought-group") {
+      if (sawAnswerSlot) {
+        suffix.push(u);
+      } else {
+        for (const t of u.texts) hoistThought(t, u.si, u.streaming);
+      }
+      continue;
+    }
+    if (u.kind === "tool") {
+      pushWork({ kind: "tool", tool: u.tool }, u.si, false);
+      continue;
+    }
+    if (u.kind === "phase") {
+      const items = phaseItemsOf(u);
+      let lastThoughtIdx = -1;
+      for (let k = items.length - 1; k >= 0; k--) {
+        if (items[k]!.kind === "thought") {
+          lastThoughtIdx = k;
+          break;
+        }
+      }
+      const thoughtLive =
+        streaming &&
+        u.live &&
+        lastThoughtIdx >= 0 &&
+        items
+          .slice(lastThoughtIdx + 1)
+          .every((x) => x.kind === "thought");
+      if (thoughtLive) hoistStreaming = true;
+      for (const it of items) {
+        if (it.kind === "thought") {
+          hoistThought(it.text, u.startSi, false);
+        } else {
+          pushWork(it, u.startSi, u.live);
+        }
+      }
+      if (u.live) {
+        if (!workStarted) {
+          workStarted = true;
+          workStartSi = u.startSi;
+        }
+        workEndSi = Math.max(workEndSi, u.endSi);
+        workLive = true;
+      }
+      continue;
+    }
+    // content
+    const isLast = i === lastCi;
+    const midTurn = !isLast || hasWorkAfter(units, i);
+    if (midTurn) {
+      for (const s of speechItemsFromText(u.text)) {
+        pushWork(s, u.si, false);
+      }
+      continue;
+    }
+    const split = splitAssistantAnswer(u.text);
+    const keepVisible = streaming && u.streaming && !split.cut;
+    if (!keepVisible && split.process) {
+      for (const s of speechItemsFromText(split.process)) {
+        pushWork(s, u.si, false);
+      }
+    }
+    sawAnswerSlot = true;
+    answer = {
+      kind: "content",
+      text: keepVisible || !split.process ? u.text : split.answer,
+      si: u.si,
+      streaming: u.streaming,
+    };
+  }
+
+  const out: TimelineUnit[] = [];
+  const thoughtU = emitThoughtUnit(hoisted, hoistSi, hoistStreaming);
+  if (thoughtU) out.push(thoughtU);
+  if (workStarted) {
+    out.push(
+      ...emitWorkUnits(workItems, {
+        startSi: workStartSi,
+        endSi: workEndSi,
+        live: workLive,
+        streaming,
+      }),
+    );
+  }
+  if (answer) out.push(answer);
+  out.push(...suffix);
+  return out;
+}
+
+/** Phase projection + process/conclusion fold (what the transcript renders). */
+export function buildAssistantTimeline(
+  segs: MessageSegment[],
+  options: { streaming?: boolean } = {},
+): TimelineUnit[] {
+  return foldProcessIntoTimeline(buildTimelineUnits(segs, options), {
+    streaming: !!options.streaming,
+  });
 }


### PR DESCRIPTION
## Why

#631 folded first-person diaries into a separate **过程** strip. The conclusion still sat under a tools-only **工作了** rail, so a long Grok 4.6 turn looked like: thought titles + tools, then another process blob, then the answer. Grok Build’s stream is **speech → folded actions → speech → folded actions**, with the conclusion always visible.

## What

Follow-up to #631 (image-preview fixes stay on `main`).

- Mid-turn `content` and the process half of the last body go **inside** one **工作了** fold (default collapsed).
- Inside the fold: user-facing speech interleaved with collapsed action groups (探索 / 运行了 N 个命令 / 编辑了 N 个文件). Individual rows still expand.
- Journal CoT is hoisted to a separate **思考了** row — not dumped into the rail.
- The last-content conclusion stays **below** the fold.

## Test

- `pnpm exec vitest run src/lib/timelinePhases.test.ts src/lib/assistantAnswerSplit.test.ts src/lib/grokActivitySteps.test.ts src/i18n/messages.test.ts`
- `pnpm typecheck`
- Local 0.2.19 rebuild installed; open a long Grok 4.6 turn: collapsed `工作了` + conclusion, expand to speech ↔ folded actions.

## 中文

过程（中间说的话 + 折叠动作）收进同一条「工作了」，默认收起；结论一直在下面。「思考了」仍单独一行。