### PR TITLE
fix(slash): make /rc and /review- select review-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- **Slash palette `/rc` and `/review-` select `review-commit` (#644)**: Treat `-` as a word boundary so kebab initials match, rank name prefix above description, and keep description as fallback only when no name hits. Peer skills that mention `review-commit` in YAML no longer steal the default highlight.
+
+**中文 · 修复**
+- **斜杠菜单 `/rc`、`/review-` 会选中 `review-commit`（#644）**：把 `-` 当词界以匹配 kebab 首字母，名字前缀优先于描述，且只有名字全无命中时才用描述兜底。YAML 里互相点名 `review-commit` 的 skill 不再抢走默认高亮。
+
 ## [0.2.20] - 2026-08-17
 
 > **Highlight:** Grok Build-compatible custom relay; local session list/continue API; official-site installer aliases; opening a chat shows a real loading state instead of a fake empty session.

--- a/docs/ACCEPTANCE-slash-composer.md
+++ b/docs/ACCEPTANCE-slash-composer.md
@@ -19,7 +19,7 @@ Run after implementation. Every item is pass/fail.
 |---|--------|-----|
 | S1 | `skills_list` / inspect returns invocable skills | Host command or UI list non-empty when CLI present |
 | S2 | Plus menu Skills section lists real skills (or empty state) | Open + menu |
-| S3 | Skills filter by name/description | Type `/aih` → aihot-like skills |
+| S3 | Skills filter by name/description | Type `/aih` → aihot-like skills; `/rc` and `/review-` highlight `review-commit` |
 
 ## C. Contenteditable + chips
 

--- a/docs/llm-wiki/slash-composer.md
+++ b/docs/llm-wiki/slash-composer.md
@@ -21,7 +21,7 @@ Open when the caret is immediately after a `/` that is:
 1. at the start of the draft, or
 2. preceded by whitespace.
 
-Filter by the query after `/` (name + description fuzzy contains).  
+Filter by the query after `/`: exact name, prefix (including a trailing hyphen), kebab initials (`/rc` → `review-commit`), then name substring. Description is fallback only when no name hits.  
 ↑↓ highlight, Enter apply, Esc close. Hover and keyboard share the same `is-active` style.  
 While the palette is open, Enter does **not** send the message.
 

--- a/src/lib/slashCatalog.test.ts
+++ b/src/lib/slashCatalog.test.ts
@@ -305,6 +305,88 @@ describe("filterSlashItems", () => {
   });
 });
 
+describe("filterSlashItems ranking", () => {
+  const peerDesc =
+    "call review-commit after execute-spec, thread-closeout, or thread-scope";
+
+  function skill(name: string, description: string): SlashItem {
+    return {
+      id: `skill:${name}`,
+      kind: "skill",
+      name,
+      displayTitle: name,
+      displayDescription: description,
+    };
+  }
+
+  const items: SlashItem[] = [
+    skill("commit", peerDesc),
+    skill("execute-spec", peerDesc),
+    skill("thread-closeout", peerDesc),
+    skill("thread-scope", peerDesc),
+    skill("review-commit", "Review changes, fix, verify, and commit"),
+    { id: "goal", kind: "mode", name: "goal", mode: "goal" },
+    { id: "goal-clear", kind: "action", name: "goal-clear", action: "goal-clear" },
+    {
+      id: "skill:aihot",
+      kind: "skill",
+      name: "aihot",
+      displayTitle: "aihot",
+      displayDescription: "AI hot reload helper",
+    },
+  ];
+
+  it("selects review-commit from kebab initials (/rc)", () => {
+    expect(filterSlashItems(items, "rc").map((i) => i.name)).toEqual([
+      "review-commit",
+    ]);
+  });
+
+  it("selects review-commit from a hyphenated name prefix (/review-)", () => {
+    expect(filterSlashItems(items, "review-").map((i) => i.name)).toEqual([
+      "review-commit",
+    ]);
+  });
+
+  it("does not let peer descriptions steal the highlight from review-commit", () => {
+    expect(filterSlashItems(items, "review-co").map((i) => i.name)).toEqual([
+      "review-commit",
+    ]);
+  });
+
+  it("ranks exact name ahead of a longer substring (/commit)", () => {
+    expect(filterSlashItems(items, "commit").map((i) => i.name)[0]).toBe(
+      "commit",
+    );
+  });
+
+  it("keeps existing name-substring matches", () => {
+    expect(filterSlashItems(items, "go").map((i) => i.name)).toEqual([
+      "goal",
+      "goal-clear",
+    ]);
+    expect(filterSlashItems(items, "aih").map((i) => i.name)).toEqual([
+      "aihot",
+    ]);
+  });
+
+  it("puts review-commit first in the flattened palette", () => {
+    const cat = buildSlashCatalog([
+      { name: "commit", description: peerDesc },
+      { name: "execute-spec", description: peerDesc },
+      { name: "thread-closeout", description: peerDesc },
+      { name: "thread-scope", description: peerDesc },
+      { name: "review-commit", description: "Review changes and commit" },
+    ]);
+    expect(flattenFilteredCatalog(cat, "rc").flat[0]!.name).toBe(
+      "review-commit",
+    );
+    expect(flattenFilteredCatalog(cat, "review-").flat[0]!.name).toBe(
+      "review-commit",
+    );
+  });
+});
+
 describe("buildSlashCatalog", () => {
   it("splits commands and skills", () => {
     const skills: SkillInfo[] = [

--- a/src/lib/slashCatalog.ts
+++ b/src/lib/slashCatalog.ts
@@ -353,11 +353,73 @@ export function filterSlashItemsByKind(
   return items.filter((item) => item.kind === kind);
 }
 
+/** Lower is better. Query change resets highlight to index 0, so rank first. */
+const SLASH_RANK_EXACT = 0;
+const SLASH_RANK_PREFIX = 1;
+const SLASH_RANK_INITIALS = 2;
+const SLASH_RANK_SUBSTRING = 3;
+const SLASH_RANK_DESCRIPTION = 4;
+
+function slashNameFields(
+  item: SlashItem,
+  resolved: SlashSearchText | null | undefined,
+): string[] {
+  return [
+    item.name,
+    item.displayTitle,
+    // strip "skill:" prefix from id for matching
+    item.id?.replace(/^skill:/, ""),
+    resolved?.title,
+    ...(item.aliases ?? []),
+  ]
+    .filter((field): field is string => Boolean(field))
+    .map((field) => field.toLowerCase());
+}
+
+function kebabInitials(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0))
+    .join("");
+}
+
+function rankSlashName(value: string, query: string): number | null {
+  if (value === query) return SLASH_RANK_EXACT;
+  if (value.startsWith(query)) return SLASH_RANK_PREFIX;
+  const compactQuery = query.replace(/[-_\s]+/g, "");
+  const initials = kebabInitials(value);
+  // Multi-segment initials only (`rc` → review-commit). Single letters
+  // already match via prefix on the first word.
+  if (
+    compactQuery.length >= 2 &&
+    initials.length >= 2 &&
+    initials.startsWith(compactQuery)
+  ) {
+    return SLASH_RANK_INITIALS;
+  }
+  if (value.includes(query)) return SLASH_RANK_SUBSTRING;
+  return null;
+}
+
+function bestSlashNameRank(fields: readonly string[], query: string): number | null {
+  let best: number | null = null;
+  for (const field of fields) {
+    const rank = rankSlashName(field, query);
+    if (rank == null) continue;
+    if (best == null || rank < best) best = rank;
+  }
+  return best;
+}
+
 /**
- * Filter items by query (case-insensitive substring) and optional kind chip.
+ * Filter items by query and optional kind chip, then rank so the default
+ * highlight (activeIndex 0) is the intended command.
  *
- * Prefer name/title hits; descriptions only when query is longer (4+ chars
- * for ASCII, 2+ for CJK) so short tokens don't light up half the catalog.
+ * Rank: exact name > prefix (including a trailing hyphen) > kebab initials
+ * (`rc` → `review-commit`) > name substring. Description is fallback only
+ * when no item matches a name field, and still requires 4+ ASCII / 2+ CJK
+ * characters so short tokens don't light up half the catalog.
  * Empty query returns kind-filtered items (or all when kind is `all`).
  *
  * Second arg accepts a plain query string (backward compatible) or
@@ -376,25 +438,32 @@ export function filterSlashItems(
   const byKind = filterSlashItemsByKind(items, kind);
   const q = (opts.query ?? "").trim().toLowerCase();
   if (!q) return byKind;
-  return byKind.filter((item) => {
+
+  const asciiOnly = /^[\x00-\x7f]+$/.test(q);
+  const allowDescription = q.length >= (asciiOnly ? 4 : 2);
+  const scored: { item: SlashItem; rank: number; index: number }[] = [];
+
+  for (let index = 0; index < byKind.length; index++) {
+    const item = byKind[index]!;
     const resolved = resolveSearchText?.(item);
-    // Name / title only for short queries (strict).
-    const nameFields = [
-      item.name,
-      item.displayTitle,
-      // strip "skill:" prefix from id for matching
-      item.id?.replace(/^skill:/, ""),
-      resolved?.title,
-      ...(item.aliases ?? []),
-    ];
-    if (nameFields.some((f) => f && f.toLowerCase().includes(q))) return true;
-    // Description: ASCII needs 4+ chars (avoid "the"/"and" style noise);
-    // CJK tokens are already dense at 2 characters.
-    const asciiOnly = /^[\x00-\x7f]+$/.test(q);
-    if (q.length < (asciiOnly ? 4 : 2)) return false;
+    const nameRank = bestSlashNameRank(slashNameFields(item, resolved), q);
+    if (nameRank != null) {
+      scored.push({ item, rank: nameRank, index });
+      continue;
+    }
+    if (!allowDescription) continue;
     const descFields = [item.displayDescription, resolved?.description];
-    return descFields.some((f) => f && f.toLowerCase().includes(q));
-  });
+    if (descFields.some((field) => field && field.toLowerCase().includes(q))) {
+      scored.push({ item, rank: SLASH_RANK_DESCRIPTION, index });
+    }
+  }
+
+  const hasNameHit = scored.some((row) => row.rank < SLASH_RANK_DESCRIPTION);
+  const visible = hasNameHit
+    ? scored.filter((row) => row.rank < SLASH_RANK_DESCRIPTION)
+    : scored;
+  visible.sort((a, b) => a.rank - b.rank || a.index - b.index);
+  return visible.map((row) => row.item);
 }
 
 /** Full catalog split into built-in commands and skill items. */


### PR DESCRIPTION
Fixes #644.

## Problem

`/rc` and `/review-` did not highlight `review-commit`.

`filterSlashItems` was a flat `includes()` over name, then description. Query changes reset `activeIndex` to `0`, so Enter selected the first visible row.

- `/rc` is not a substring of `review-commit` (hyphens were not word boundaries).
- `/review-` also listed `commit` / `execute-spec` / `thread-closeout` / `thread-scope`, whose YAML descriptions mention the literal string `review-commit`. Catalog order put `commit` first.

## Change

App `filterSlashItems` only (not Grok CLI). Rank:

1. exact name
2. prefix, including a trailing hyphen (`review-`)
3. kebab initials (`rc` → `review-commit`)
4. name substring
5. description — only when no item matches a name field

Existing `/go` → `goal` and `/aih` → `aihot` substring tests stay.

## Verify

```bash
pnpm exec vitest run src/lib/slashCatalog.test.ts
pnpm typecheck
```

36 tests passed, including new ranking cases and a flattened-palette check that `/rc` and `/review-` put `review-commit` first.
