### PR TITLE
feat(chat): Windows 超长回复/粘贴改为 txt 文件卡片

### DIFF
--- a/src/components/ComposerEditor.tsx
+++ b/src/components/ComposerEditor.tsx
@@ -34,6 +34,12 @@ import {
   readStoredEditorText,
   type DraftSegment,
 } from "@/lib/draftDoc";
+import { detectAppPlatform } from "@/lib/appPlatform";
+import {
+  hugePlainTextFileName,
+  hugePlainTextToFile,
+  shouldSpillHugePlainText,
+} from "@/lib/longAssistantSpill";
 
 /** Caret landing pad around non-editable skill chips (stripped on serialize). */
 const CARET_PAD = "\u200B";
@@ -960,6 +966,17 @@ export const ComposerEditor = memo(function ComposerEditor({
 
     if (!plain) return;
     if (files.length && isFileUrlOnlyText(plain)) return;
+    // Windows: a huge clipboard insert freezes the contenteditable + draft
+    // store. Attach as .txt instead — same path as image/file paste.
+    if (
+      onPasteFiles &&
+      shouldSpillHugePlainText(plain.length, detectAppPlatform())
+    ) {
+      onPasteFiles([
+        hugePlainTextToFile(plain, hugePlainTextFileName(plain)),
+      ]);
+      return;
+    }
     insertPlainTextAtSelection(plain);
     const el = elRef.current;
     if (el) commitFromDom(el);

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -101,6 +101,7 @@ import {
   previewLongAssistant,
   shouldSpillLongAssistant,
 } from "@/lib/longAssistantSpill";
+import { detectAppPlatform } from "@/lib/appPlatform";
 import { Thinking } from "./Thinking";
 import { LeadFragmentsStrip } from "./LeadFragmentsStrip";
 import { BackBottom } from "./BackBottom";
@@ -282,6 +283,7 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
       galleryPaths: images.map((x) => x.path),
     };
   }, [bottomAtts]);
+  const [showFullReply, setShowFullReply] = useState(false);
   if (
     !(displayContent || "").trim() &&
     !(bottomImages.length || bottomFiles.length)
@@ -289,7 +291,13 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
     return null;
   }
 
-  const spill = shouldSpillLongAssistant((displayContent || "").length);
+  const findActiveHere = !!findQuery?.trim();
+  const canSpill =
+    shouldSpillLongAssistant(
+      (displayContent || "").length,
+      detectAppPlatform(),
+    ) && !findActiveHere;
+  const spill = canSpill && !showFullReply;
   const markdownSource = spill
     ? previewLongAssistant(displayContent || "")
     : displayContent;
@@ -315,13 +323,15 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
   return (
     <>
       {body}
-      {spill ? (
+      {canSpill ? (
         <LongAssistantSpillNote
           fullText={displayContent || ""}
           streaming={!!streaming}
           locale={locale}
           messageId={messageId}
           projectPath={projectPath}
+          expanded={showFullReply}
+          onToggleExpanded={() => setShowFullReply((v) => !v)}
           onOpenResource={onOpenResource}
           onOpenError={onOpenError}
         />

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -96,6 +96,11 @@ import {
 } from "./MessageAction";
 import { ChatItem } from "./ChatItem";
 import { MarkdownChat } from "./MarkdownChat";
+import { LongAssistantSpillNote } from "./LongAssistantSpillNote";
+import {
+  previewLongAssistant,
+  shouldSpillLongAssistant,
+} from "@/lib/longAssistantSpill";
 import { Thinking } from "./Thinking";
 import { LeadFragmentsStrip } from "./LeadFragmentsStrip";
 import { BackBottom } from "./BackBottom";
@@ -191,6 +196,7 @@ function useStableSessionPathMap(
  */
 const AssistantMessageBody = memo(function AssistantMessageBody({
   content,
+  messageId,
   attachments,
   /**
    * When false, still resolve pathMap from attachments for inline ImageUi,
@@ -217,6 +223,8 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
   findOccurrenceBase = 0,
 }: {
   content: string;
+  /** Session message id — used to cache the spilled .txt path. */
+  messageId?: string;
   attachments?: Attachment[];
   showBottomAttachments?: boolean;
   fullContentForInlineFilter?: string;
@@ -281,6 +289,11 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
     return null;
   }
 
+  const spill = shouldSpillLongAssistant((displayContent || "").length);
+  const markdownSource = spill
+    ? previewLongAssistant(displayContent || "")
+    : displayContent;
+
   const body = (displayContent || "").trim() ? (
     <MarkdownChat
       locale={locale}
@@ -295,13 +308,24 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
       findActiveOccurrence={findActiveOccurrence}
       findOccurrenceBase={findOccurrenceBase}
     >
-      {displayContent}
+      {markdownSource}
     </MarkdownChat>
   ) : null;
 
   return (
     <>
       {body}
+      {spill ? (
+        <LongAssistantSpillNote
+          fullText={displayContent || ""}
+          streaming={!!streaming}
+          locale={locale}
+          messageId={messageId}
+          projectPath={projectPath}
+          onOpenResource={onOpenResource}
+          onOpenError={onOpenError}
+        />
+      ) : null}
       {bottomImages.length > 0 ? (
         <div className="lobe-chat-atts lobe-chat-atts--images">
           {bottomImages.map((a) => (
@@ -1411,6 +1435,7 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
               return (
                 <AssistantMessageBody
                   key={`${m.id}-c-${unit.si}`}
+                  messageId={m.id}
                   content={unit.text}
                   // Always pass attachments so every content segment can
                   // resolve `images/N.jpg` → ImageUi at stream position.
@@ -1457,6 +1482,7 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
           {!contentSegCount && m.attachments?.length ? (
             <AssistantMessageBody
               content=""
+              messageId={m.id}
               attachments={m.attachments}
               showBottomAttachments
               fullContentForInlineFilter={m.content}

--- a/src/components/lobe-chat/LongAssistantSpillNote.tsx
+++ b/src/components/lobe-chat/LongAssistantSpillNote.tsx
@@ -25,6 +25,8 @@ export function LongAssistantSpillNote({
   locale,
   messageId,
   projectPath,
+  expanded,
+  onToggleExpanded,
   onOpenResource,
   onOpenError,
 }: {
@@ -33,6 +35,8 @@ export function LongAssistantSpillNote({
   locale: Locale;
   messageId?: string;
   projectPath?: string | null;
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
   onOpenResource?: (target: ResourceOpenTarget) => void;
   onOpenError?: (message: string) => void;
 }) {
@@ -115,14 +119,26 @@ export function LongAssistantSpillNote({
   return (
     <div className="lobe-chat-long-reply" data-testid="long-assistant-spill">
       <div className="lobe-chat-reply-length">
-        {tr("chat.longReplyPreview")}
-        {" · "}
-        {streaming
-          ? tr("chat.longReplySaving")
-          : path
-            ? tr("chat.longReplySaved")
-            : tr("chat.longReplyDownload")}
+        {expanded
+          ? tr("chat.longReplyShowingFull")
+          : tr("chat.longReplyPreview")}
+        {expanded
+          ? null
+          : streaming
+            ? ` · ${tr("chat.longReplySaving")}`
+            : path
+              ? ` · ${tr("chat.longReplySaved")}`
+              : null}
       </div>
+      {onToggleExpanded && !streaming ? (
+        <button
+          type="button"
+          className="btn btn--ghost"
+          onClick={onToggleExpanded}
+        >
+          {expanded ? tr("chat.longReplyCollapse") : tr("chat.longReplyShowFull")}
+        </button>
+      ) : null}
       {path ? (
         <div className="lobe-chat-atts">
           <FilePathCard

--- a/src/components/lobe-chat/LongAssistantSpillNote.tsx
+++ b/src/components/lobe-chat/LongAssistantSpillNote.tsx
@@ -1,0 +1,156 @@
+/**
+ * Note + file card under a spilled (preview-only) assistant body.
+ * Writes the full reply once via save_temp_attachment; remounts reuse cache
+ * so the virtual list does not create a new paste file every scroll.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import type { Locale } from "@/i18n";
+import { createT } from "@/i18n";
+import * as api from "@/lib/api";
+import { FilePathCard } from "@/components/FilePathCard";
+import { revealInOsLabel } from "@/lib/appPlatform";
+import {
+  getCachedSpillPath,
+  safeSpillFileStem,
+  setCachedSpillPath,
+  spillCacheKey,
+  utf8ToBase64,
+} from "@/lib/longAssistantSpill";
+import type { ResourceOpenTarget } from "@/components/ResourceViewer";
+
+export function LongAssistantSpillNote({
+  fullText,
+  streaming,
+  locale,
+  messageId,
+  projectPath,
+  onOpenResource,
+  onOpenError,
+}: {
+  fullText: string;
+  streaming: boolean;
+  locale: Locale;
+  messageId?: string;
+  projectPath?: string | null;
+  onOpenResource?: (target: ResourceOpenTarget) => void;
+  onOpenError?: (message: string) => void;
+}) {
+  const tr = useMemo(() => createT(locale), [locale]);
+  const key = spillCacheKey(messageId || "anon", fullText.length);
+  const [path, setPath] = useState<string | null>(
+    () => getCachedSpillPath(key) ?? null,
+  );
+
+  useEffect(() => {
+    if (streaming) return;
+    if (!fullText.trim()) return;
+    const cached = getCachedSpillPath(key);
+    if (cached) {
+      setPath(cached);
+      return;
+    }
+    if (!api.isTauri()) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const entry = await api.saveTempAttachment(
+          utf8ToBase64(fullText),
+          `${safeSpillFileStem(messageId || "reply")}.txt`,
+          "text/plain",
+        );
+        if (cancelled || !entry?.path) return;
+        setCachedSpillPath(key, entry.path);
+        setPath(entry.path);
+      } catch {
+        /* keep preview + download fallback */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [streaming, fullText, key, messageId]);
+
+  const downloadLocal = () => {
+    const blob = new Blob([fullText], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${safeSpillFileStem(messageId || "reply")}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const fileLabels = useMemo(
+    () => ({
+      open: tr("attach.open"),
+      reveal: revealInOsLabel(tr),
+      copyPath: tr("attach.copyPath"),
+      openInPanel: tr("resources.openInPanel"),
+      openExternal: tr("resources.openExternal"),
+      details: tr("attach.details"),
+      detailsTitle: tr("attach.detailsTitle"),
+      detailsName: tr("attach.detailsName"),
+      detailsType: tr("attach.detailsType"),
+      detailsPath: tr("attach.detailsPath"),
+      detailsResolved: tr("attach.detailsResolved"),
+      detailsStatus: tr("attach.detailsStatus"),
+      detailsMissing: tr("attach.detailsMissing"),
+      detailsOk: tr("attach.detailsOk"),
+      detailsClose: tr("attach.detailsClose"),
+      typeFile: tr("attach.typeFile"),
+      typeUrl: tr("attach.typeUrl"),
+      typeDir: tr("attach.typeDir"),
+      errNotFound: tr("resources.openErr.notFound"),
+      errPathDenied: tr("resources.openErr.pathDenied"),
+      errHostOnly: tr("resources.openErr.hostOnly"),
+      errNoEditor: tr("resources.openErr.noEditor"),
+      errCancelled: tr("resources.openErr.cancelled"),
+      errOther: tr("resources.openErr.other"),
+      errRevealOther: tr("resources.revealErr.other"),
+    }),
+    [tr],
+  );
+
+  return (
+    <div className="lobe-chat-long-reply" data-testid="long-assistant-spill">
+      <div className="lobe-chat-reply-length">
+        {tr("chat.longReplyPreview")}
+        {" · "}
+        {streaming
+          ? tr("chat.longReplySaving")
+          : path
+            ? tr("chat.longReplySaved")
+            : tr("chat.longReplyDownload")}
+      </div>
+      {path ? (
+        <div className="lobe-chat-atts">
+          <FilePathCard
+            path={path}
+            absolutePath={path}
+            projectPath={projectPath}
+            labels={fileLabels}
+            onOpenError={onOpenError}
+            onOpenInPanel={(t) => {
+              if (t.type === "file" && t.path) {
+                onOpenResource?.({
+                  type: "file",
+                  path: t.path,
+                  title: t.title,
+                });
+              }
+            }}
+          />
+        </div>
+      ) : !streaming ? (
+        <button
+          type="button"
+          className="btn btn--ghost"
+          onClick={downloadLocal}
+        >
+          {tr("chat.longReplyDownload")}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/i18n/messages/en/chat.ts
+++ b/src/i18n/messages/en/chat.ts
@@ -158,4 +158,7 @@ export const enChat = {
   "chat.longReplySaving": "Long reply — full text will be saved as a file when this turn finishes",
   "chat.longReplySaved": "Full reply saved as a text file",
   "chat.longReplyDownload": "Save full reply as .txt",
+  "chat.longReplyShowFull": "Show full reply",
+  "chat.longReplyCollapse": "Show preview only",
+  "chat.longReplyShowingFull": "Showing the full reply",
 } as const;

--- a/src/i18n/messages/en/chat.ts
+++ b/src/i18n/messages/en/chat.ts
@@ -154,4 +154,8 @@ export const enChat = {
   "message.copyLink": "Copy link",
   "message.linkCopied": "Link copied",
   "message.deepLinkMissing": "Message not found in this conversation",
+  "chat.longReplyPreview": "Showing a preview so the chat stays responsive",
+  "chat.longReplySaving": "Long reply — full text will be saved as a file when this turn finishes",
+  "chat.longReplySaved": "Full reply saved as a text file",
+  "chat.longReplyDownload": "Save full reply as .txt",
 } as const;

--- a/src/i18n/messages/zh-TW/chat.ts
+++ b/src/i18n/messages/zh-TW/chat.ts
@@ -154,4 +154,8 @@ export const zhTWChat = {
   "message.copyLink": "複製連結",
   "message.linkCopied": "連結已複製",
   "message.deepLinkMissing": "此對話中找不到該訊息",
+  "chat.longReplyPreview": "僅顯示預覽，避免對話卡死",
+  "chat.longReplySaving": "回覆較長 — 本輪結束後會儲存為文字檔",
+  "chat.longReplySaved": "全文已儲存為文字檔",
+  "chat.longReplyDownload": "將全文另存為 .txt",
 };

--- a/src/i18n/messages/zh-TW/chat.ts
+++ b/src/i18n/messages/zh-TW/chat.ts
@@ -158,4 +158,7 @@ export const zhTWChat = {
   "chat.longReplySaving": "回覆較長 — 本輪結束後會儲存為文字檔",
   "chat.longReplySaved": "全文已儲存為文字檔",
   "chat.longReplyDownload": "將全文另存為 .txt",
+  "chat.longReplyShowFull": "顯示全文",
+  "chat.longReplyCollapse": "只顯示預覽",
+  "chat.longReplyShowingFull": "正在顯示全文",
 };

--- a/src/i18n/messages/zh/chat.ts
+++ b/src/i18n/messages/zh/chat.ts
@@ -158,4 +158,7 @@ export const zhChat = {
   "chat.longReplySaving": "回复较长 — 本轮结束后会保存为文本文件",
   "chat.longReplySaved": "全文已保存为文本文件",
   "chat.longReplyDownload": "将全文另存为 .txt",
+  "chat.longReplyShowFull": "显示全文",
+  "chat.longReplyCollapse": "只显示预览",
+  "chat.longReplyShowingFull": "正在显示全文",
 };

--- a/src/i18n/messages/zh/chat.ts
+++ b/src/i18n/messages/zh/chat.ts
@@ -154,4 +154,8 @@ export const zhChat = {
   "message.copyLink": "复制链接",
   "message.linkCopied": "链接已复制",
   "message.deepLinkMissing": "此对话中未找到该消息",
+  "chat.longReplyPreview": "仅显示预览，避免对话卡死",
+  "chat.longReplySaving": "回复较长 — 本轮结束后会保存为文本文件",
+  "chat.longReplySaved": "全文已保存为文本文件",
+  "chat.longReplyDownload": "将全文另存为 .txt",
 };

--- a/src/lib/longAssistantSpill.test.ts
+++ b/src/lib/longAssistantSpill.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  LONG_ASSISTANT_PREVIEW_CHARS,
+  LONG_ASSISTANT_SPILL_CHARS,
+  clearSpillPathCache,
+  getCachedSpillPath,
+  previewLongAssistant,
+  safeSpillFileStem,
+  setCachedSpillPath,
+  shouldSpillLongAssistant,
+  spillCacheKey,
+  utf8ToBase64,
+} from "./longAssistantSpill";
+
+describe("longAssistantSpill", () => {
+  beforeEach(() => {
+    clearSpillPathCache();
+  });
+
+  it("does not spill short replies", () => {
+    expect(shouldSpillLongAssistant(0)).toBe(false);
+    expect(shouldSpillLongAssistant(LONG_ASSISTANT_SPILL_CHARS - 1)).toBe(
+      false,
+    );
+  });
+
+  it("spills at the character threshold", () => {
+    expect(shouldSpillLongAssistant(LONG_ASSISTANT_SPILL_CHARS)).toBe(true);
+    expect(shouldSpillLongAssistant(LONG_ASSISTANT_SPILL_CHARS + 50_000)).toBe(
+      true,
+    );
+  });
+
+  it("preview is shorter than a spilling body and snaps to a newline", () => {
+    const head = "alpha\nbeta\n";
+    const rest = "x".repeat(LONG_ASSISTANT_SPILL_CHARS);
+    const src = head + rest;
+    const preview = previewLongAssistant(src, 20);
+    expect(preview.length).toBeLessThan(src.length);
+    expect(preview.endsWith("\n")).toBe(true);
+    expect(preview.startsWith("alpha")).toBe(true);
+    expect(preview.includes("beta")).toBe(true);
+  });
+
+  it("preview default width stays far below the spill threshold", () => {
+    const src = "n".repeat(LONG_ASSISTANT_SPILL_CHARS);
+    const preview = previewLongAssistant(src);
+    expect(preview.length).toBeLessThanOrEqual(LONG_ASSISTANT_PREVIEW_CHARS + 1);
+    expect(preview.length).toBeLessThan(LONG_ASSISTANT_SPILL_CHARS);
+  });
+
+  it("utf8ToBase64 round-trips CJK", () => {
+    const src = "全文已保存为文本文件";
+    const b64 = utf8ToBase64(src);
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    expect(new TextDecoder().decode(bytes)).toBe(src);
+  });
+
+  it("caches spill paths by message id + length", () => {
+    const key = spillCacheKey("abc-123", 9000);
+    expect(getCachedSpillPath(key)).toBeUndefined();
+    setCachedSpillPath(key, "C:\\\\tmp\\\\assistant-abc.txt");
+    expect(getCachedSpillPath(key)).toBe("C:\\\\tmp\\\\assistant-abc.txt");
+  });
+
+  it("sanitizes the file stem", () => {
+    expect(safeSpillFileStem("msg/../evil id!")).toBe("assistant-msgevilid");
+    expect(safeSpillFileStem("")).toBe("assistant-reply");
+  });
+});

--- a/src/lib/longAssistantSpill.test.ts
+++ b/src/lib/longAssistantSpill.test.ts
@@ -17,18 +17,27 @@ describe("longAssistantSpill", () => {
     clearSpillPathCache();
   });
 
-  it("does not spill short replies", () => {
-    expect(shouldSpillLongAssistant(0)).toBe(false);
-    expect(shouldSpillLongAssistant(LONG_ASSISTANT_SPILL_CHARS - 1)).toBe(
-      false,
-    );
+  it("does not spill short replies on Windows", () => {
+    expect(shouldSpillLongAssistant(0, "win")).toBe(false);
+    expect(
+      shouldSpillLongAssistant(LONG_ASSISTANT_SPILL_CHARS - 1, "win"),
+    ).toBe(false);
   });
 
-  it("spills at the character threshold", () => {
-    expect(shouldSpillLongAssistant(LONG_ASSISTANT_SPILL_CHARS)).toBe(true);
-    expect(shouldSpillLongAssistant(LONG_ASSISTANT_SPILL_CHARS + 50_000)).toBe(
+  it("never auto-spills macOS or Linux (keep existing full markdown)", () => {
+    const huge = LONG_ASSISTANT_SPILL_CHARS + 50_000;
+    expect(shouldSpillLongAssistant(huge, "mac")).toBe(false);
+    expect(shouldSpillLongAssistant(huge, "linux")).toBe(false);
+    expect(shouldSpillLongAssistant(huge, "other")).toBe(false);
+  });
+
+  it("spills at the character threshold only on Windows", () => {
+    expect(shouldSpillLongAssistant(LONG_ASSISTANT_SPILL_CHARS, "win")).toBe(
       true,
     );
+    expect(
+      shouldSpillLongAssistant(LONG_ASSISTANT_SPILL_CHARS + 50_000, "win"),
+    ).toBe(true);
   });
 
   it("preview is shorter than a spilling body and snaps to a newline", () => {

--- a/src/lib/longAssistantSpill.test.ts
+++ b/src/lib/longAssistantSpill.test.ts
@@ -4,9 +4,12 @@ import {
   LONG_ASSISTANT_SPILL_CHARS,
   clearSpillPathCache,
   getCachedSpillPath,
+  hugePlainTextFileName,
+  hugePlainTextToFile,
   previewLongAssistant,
   safeSpillFileStem,
   setCachedSpillPath,
+  shouldSpillHugePlainText,
   shouldSpillLongAssistant,
   spillCacheKey,
   utf8ToBase64,
@@ -70,6 +73,25 @@ describe("longAssistantSpill", () => {
     expect(getCachedSpillPath(key)).toBeUndefined();
     setCachedSpillPath(key, "C:\\\\tmp\\\\assistant-abc.txt");
     expect(getCachedSpillPath(key)).toBe("C:\\\\tmp\\\\assistant-abc.txt");
+  });
+
+  it("names the paste file from the first line", () => {
+    expect(
+      hugePlainTextFileName("const Version = '2026-08-17'\nmore"),
+    ).toBe("const Version = '2026-08-17'.txt");
+  });
+
+  it("turns huge clipboard text into a text File", () => {
+    const f = hugePlainTextToFile("hello-world", "paste.txt");
+    expect(f.name).toBe("paste.txt");
+    expect(f.type).toBe("text/plain");
+    expect(f.size).toBeGreaterThan(0);
+    expect(shouldSpillHugePlainText(LONG_ASSISTANT_SPILL_CHARS, "win")).toBe(
+      true,
+    );
+    expect(shouldSpillHugePlainText(LONG_ASSISTANT_SPILL_CHARS, "mac")).toBe(
+      false,
+    );
   });
 
   it("sanitizes the file stem", () => {

--- a/src/lib/longAssistantSpill.ts
+++ b/src/lib/longAssistantSpill.ts
@@ -1,12 +1,14 @@
 /**
  * Spill oversized assistant bubbles to a .txt file card.
  *
- * Virtualizing the transcript by *row count* does not help a single huge
- * reply: ReactMarkdown still re-parses the whole string. Preview the head
- * in-chat and persist the full body via save_temp_attachment.
+ * Only Windows WebView2 is known to freeze on a single huge markdown tree.
+ * macOS / Linux keep the existing full-body render. Callers must also skip
+ * spilling while in-chat find is active so matches in the tail stay visible.
  */
 
-/** Paint a file card / preview instead of the full markdown tree. */
+import type { AppPlatform } from "@/lib/appPlatform";
+
+/** Paint a file card / preview instead of the full markdown tree (Windows). */
 export const LONG_ASSISTANT_SPILL_CHARS = 8000;
 
 /** Characters kept in the live/preview markdown parse. */
@@ -14,7 +16,11 @@ export const LONG_ASSISTANT_PREVIEW_CHARS = 800;
 
 const spillPathCache = new Map<string, string>();
 
-export function shouldSpillLongAssistant(length: number): boolean {
+export function shouldSpillLongAssistant(
+  length: number,
+  platform: AppPlatform,
+): boolean {
+  if (platform !== "win") return false;
   return length >= LONG_ASSISTANT_SPILL_CHARS;
 }
 

--- a/src/lib/longAssistantSpill.ts
+++ b/src/lib/longAssistantSpill.ts
@@ -16,12 +16,41 @@ export const LONG_ASSISTANT_PREVIEW_CHARS = 800;
 
 const spillPathCache = new Map<string, string>();
 
-export function shouldSpillLongAssistant(
+/** Windows WebView only — huge plain text in the composer or one bubble. */
+export function shouldSpillHugePlainText(
   length: number,
   platform: AppPlatform,
 ): boolean {
   if (platform !== "win") return false;
   return length >= LONG_ASSISTANT_SPILL_CHARS;
+}
+
+export function shouldSpillLongAssistant(
+  length: number,
+  platform: AppPlatform,
+): boolean {
+  return shouldSpillHugePlainText(length, platform);
+}
+
+/** First-line preview filename, same idea as DeepSeek's paste chip. */
+export function hugePlainTextFileName(text: string): string {
+  const first = (text.trim().split(/\r?\n/, 1)[0] || "paste").trim();
+  const stem = first
+    .replace(/[<>:"/\\|?*\u0000-\u001f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .slice(0, 36)
+    .trim() || "paste";
+  return `${stem}.txt`;
+}
+
+/** Turn a huge clipboard string into a .txt File for the existing attach path. */
+export function hugePlainTextToFile(
+  text: string,
+  name = "paste.txt",
+): File {
+  return new File([text], name || hugePlainTextFileName(text), {
+    type: "text/plain",
+  });
 }
 
 /**

--- a/src/lib/longAssistantSpill.ts
+++ b/src/lib/longAssistantSpill.ts
@@ -1,0 +1,69 @@
+/**
+ * Spill oversized assistant bubbles to a .txt file card.
+ *
+ * Virtualizing the transcript by *row count* does not help a single huge
+ * reply: ReactMarkdown still re-parses the whole string. Preview the head
+ * in-chat and persist the full body via save_temp_attachment.
+ */
+
+/** Paint a file card / preview instead of the full markdown tree. */
+export const LONG_ASSISTANT_SPILL_CHARS = 8000;
+
+/** Characters kept in the live/preview markdown parse. */
+export const LONG_ASSISTANT_PREVIEW_CHARS = 800;
+
+const spillPathCache = new Map<string, string>();
+
+export function shouldSpillLongAssistant(length: number): boolean {
+  return length >= LONG_ASSISTANT_SPILL_CHARS;
+}
+
+/**
+ * First ~previewChars, snapped back to a nearby newline so we rarely split
+ * a fence or table row. Always shorter than `src` when spilling.
+ */
+export function previewLongAssistant(
+  src: string,
+  max: number = LONG_ASSISTANT_PREVIEW_CHARS,
+): string {
+  if (src.length <= max) return src;
+  const slice = src.slice(0, max);
+  const nl = slice.lastIndexOf("\n");
+  const cut = nl >= Math.floor(max * 0.6) ? nl : max;
+  return src.slice(0, cut).trimEnd() + "\n";
+}
+
+export function spillCacheKey(messageId: string, length: number): string {
+  return `${messageId}:${length}`;
+}
+
+export function getCachedSpillPath(key: string): string | undefined {
+  return spillPathCache.get(key);
+}
+
+export function setCachedSpillPath(key: string, path: string): void {
+  if (!key || !path) return;
+  spillPathCache.set(key, path);
+}
+
+/** Test-only. */
+export function clearSpillPathCache(): void {
+  spillPathCache.clear();
+}
+
+/** UTF-8 → standard base64 for save_temp_attachment. */
+export function utf8ToBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+export function safeSpillFileStem(messageId: string): string {
+  const raw = (messageId || "reply").replace(/[^a-zA-Z0-9_-]+/g, "");
+  const stem = raw.slice(0, 12) || "reply";
+  return `assistant-${stem}`;
+}


### PR DESCRIPTION
## 摘要

修复 #647。

Windows 上**一条超长助手气泡**或**往输入框粘贴超长文本**会把 WebView 卡死。虚拟列表和 Markdown 节流解决不了「单段特别长」。

本 PR **不改会话里存的原文**，只改界面，并且**只动 Windows**：

- 助手正文 `≥ 8000` 字：只渲染约 800 字预览；结束后写成 `.txt` 文件卡片。可点「显示全文」。
- 查找（Ctrl+F）时显示全文。
- 粘贴 `≥ 8000` 字：不进输入框，改成附件 `.txt`（和 DeepSeek 一样，文件名用第一行）。
- **macOS / Linux 行为不变。** 复制 / 导出 MD 仍是全文。

## Summary (EN)

Fixes #647.

Windows-only: preview + `.txt` file card for huge assistant replies; huge composer paste attaches as `.txt` instead of inserting into the contenteditable. macOS / Linux unchanged. Journal / Copy / Export MD still use the full stored text.

## Type of change

- [x] Bug fix
- [x] New feature

## Checklist

- [x] `src/lib/longAssistantSpill.test.ts` 覆盖阈值、平台门闩、文件名
- [ ] 本环境没有 pnpm/cargo，请走 CI
- [x] 文案走 i18n（en / zh / zh-TW）
- [x] 不用 `window.confirm` / `prompt` / `alert`
- [x] 无密钥

## 怎么测

1. Windows：让助手输出超过 8000 字 → 预览 + txt 卡片，界面不卡；可「显示全文」。
2. Windows：往输入框粘贴超长文本 → 出现附件芯片，输入框保持空/短。
3. macOS / Linux：同样操作应仍是完整正文/正常粘贴。
4. 查找、复制、导出 MD 仍能拿到全文。
5. 短回复、短粘贴不变。
