### PR TITLE
fix: harden session interruption recovery

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -14,7 +14,7 @@ use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::process::{Child, Command};
-use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex};
+use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex, Notify};
 use tracing::{debug, error, info, warn};
 
 use crate::error::{AgentError, AgentErrorCode};
@@ -316,6 +316,10 @@ pub struct AcpClient {
     cwd: PathBuf,
     stopped: AtomicBool,
     reader_alive: AtomicBool,
+    /// Cancels the stdout/TCP read loop on an intentional shutdown. Without
+    /// this, a remote ACP socket could keep its read half open and deliver late
+    /// events after `kill()` had already released the session slot.
+    reader_stop: Arc<Notify>,
     /// Recent stderr lines for crash diagnostics (ring, newest last).
     stderr_tail: ParkingMutex<Vec<String>>,
     /// Last inbound `session/update` per agent session id (P0-4).
@@ -1103,7 +1107,7 @@ impl AcpClient {
             .unwrap_or(false)
     }
 
-    pub fn spawn(
+    pub async fn spawn(
         cli_path: PathBuf,
         cwd: PathBuf,
     ) -> Result<
@@ -1113,10 +1117,10 @@ impl AcpClient {
         ),
         AgentError,
     > {
-        Self::spawn_with_options(cli_path, cwd, SpawnOptions::default())
+        Self::spawn_with_options(cli_path, cwd, SpawnOptions::default()).await
     }
 
-    pub fn spawn_with_options(
+    pub async fn spawn_with_options(
         cli_path: PathBuf,
         cwd: PathBuf,
         opts: SpawnOptions,
@@ -1128,11 +1132,11 @@ impl AcpClient {
         AgentError,
     > {
         let settings = crate::store::load_settings();
-        Self::spawn_with_home(cli_path, cwd, &settings.session_data_mode, opts)
+        Self::spawn_with_home(cli_path, cwd, &settings.session_data_mode, opts).await
     }
 
     /// Spawn `grok agent stdio` with GROK_HOME from session_data_mode.
-    pub fn spawn_with_home(
+    pub async fn spawn_with_home(
         cli_path: PathBuf,
         cwd: PathBuf,
         session_data_mode: &str,
@@ -1155,7 +1159,7 @@ impl AcpClient {
             .map(str::trim)
             .filter(|s| !s.is_empty())
         {
-            return Self::connect_tcp(addr, cwd);
+            return Self::connect_tcp(addr, cwd).await;
         }
 
         let wsl_launch = crate::wsl_backend::resolve_wsl_launch(&settings_early);
@@ -1620,6 +1624,7 @@ impl AcpClient {
             cwd,
             stopped: AtomicBool::new(false),
             reader_alive: AtomicBool::new(true),
+            reader_stop: Arc::new(Notify::new()),
             stderr_tail: ParkingMutex::new(Vec::new()),
             last_update_by_session: ParkingMutex::new(HashMap::new()),
             last_update_unstamped: ParkingMutex::new(None),
@@ -1663,9 +1668,11 @@ impl AcpClient {
     /// shared build host, or a `socat`-fronted CLI). No child process, no
     /// stderr stream; the read half is wired to the same line reader.
     ///
-    /// Sync (uses a blocking connect + `from_std`) to match `spawn_with_home`;
-    /// must be called from within the Tokio runtime.
-    pub fn connect_tcp(
+    /// Connect to an ACP server without blocking a Tokio worker. The explicit
+    /// connect deadline is important for unreachable/half-open API endpoints:
+    /// a synchronous `std::net::TcpStream::connect` here used to hold the
+    /// session connect lock and starve every other chat until the OS timeout.
+    pub async fn connect_tcp(
         addr: &str,
         cwd: PathBuf,
     ) -> Result<
@@ -1675,18 +1682,24 @@ impl AcpClient {
         ),
         AgentError,
     > {
-        let std_stream = std::net::TcpStream::connect(addr).map_err(|e| {
-            AgentError::new(
-                AgentErrorCode::CliNotFound,
-                format!("failed to connect ACP server {addr}: {e}"),
-            )
-        })?;
-        std_stream.set_nonblocking(true).map_err(|e| {
-            AgentError::new(AgentErrorCode::AgentCrashed, format!("socket setup: {e}"))
-        })?;
-        let stream = TcpStream::from_std(std_stream).map_err(|e| {
-            AgentError::new(AgentErrorCode::AgentCrashed, format!("socket adopt: {e}"))
-        })?;
+        const ACP_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+        let stream = tokio::time::timeout(ACP_CONNECT_TIMEOUT, TcpStream::connect(addr))
+            .await
+            .map_err(|_| {
+                AgentError::new(
+                    AgentErrorCode::CliNotFound,
+                    format!(
+                        "ACP server connect timed out after {}s: {addr}",
+                        ACP_CONNECT_TIMEOUT.as_secs()
+                    ),
+                )
+            })?
+            .map_err(|e| {
+                AgentError::new(
+                    AgentErrorCode::CliNotFound,
+                    format!("failed to connect ACP server {addr}: {e}"),
+                )
+            })?;
         let _ = stream.set_nodelay(true);
         let (read_half, write_half) = stream.into_split();
 
@@ -1704,6 +1717,7 @@ impl AcpClient {
             cwd,
             stopped: AtomicBool::new(false),
             reader_alive: AtomicBool::new(true),
+            reader_stop: Arc::new(Notify::new()),
             stderr_tail: ParkingMutex::new(Vec::new()),
             last_update_by_session: ParkingMutex::new(HashMap::new()),
             last_update_unstamped: ParkingMutex::new(None),
@@ -1732,8 +1746,15 @@ impl AcpClient {
             let mut reader = BufReader::with_capacity(8 * 1024 * 1024, reader);
             let mut line = String::new();
             loop {
+                if !c.reader_alive.load(Ordering::SeqCst) {
+                    return;
+                }
                 line.clear();
-                match reader.read_line(&mut line).await {
+                let read = tokio::select! {
+                    _ = c.reader_stop.notified() => return,
+                    result = reader.read_line(&mut line) => result,
+                };
+                match read {
                     Ok(0) => break,
                     Ok(_) => {
                         let trimmed = line.trim();
@@ -1748,12 +1769,29 @@ impl AcpClient {
                     }
                 }
             }
-            c.reader_alive.store(false, Ordering::SeqCst);
+            // Do not turn an intentional kill into a second, late
+            // `ProcessExited` event. The owner already transitioned the
+            // session during `kill()`.
+            if !c.reader_alive.swap(false, Ordering::SeqCst) {
+                return;
+            }
+            // Stdout EOF normally follows child termination. Capture the
+            // status when it is already available so the Host can distinguish
+            // a clean/failed CLI exit from a remote TCP EOF. `try_wait` keeps
+            // the reader task bounded if a malformed child leaves the handle
+            // alive after closing stdout.
+            let exit_code = {
+                let mut child = c.child.lock().await;
+                child
+                    .as_mut()
+                    .and_then(|process| process.try_wait().ok().flatten())
+                    .and_then(|status| status.code())
+            };
             let detail = c.format_exit_detail("Agent stream closed (EOF)");
             c.fail_all_pending(&detail);
             let _ = c
                 .event_tx
-                .send((None, AcpEvent::ProcessExited { code: None }));
+                .send((None, AcpEvent::ProcessExited { code: exit_code }));
         });
     }
 
@@ -3486,6 +3524,19 @@ impl AcpClient {
     }
 
     pub async fn kill(&self) {
+        // Stop both halves of the transport before touching the child. This is
+        // essential for TCP ACP: closing only the writer left the reader task
+        // alive and allowed ghost events from a remote peer after recycle.
+        self.stopped.store(true, Ordering::SeqCst);
+        self.reader_alive.store(false, Ordering::SeqCst);
+        // `notify_waiters` only wakes tasks that are already waiting.  The
+        // reader checks `reader_alive` immediately before entering `select!`,
+        // so a kill racing that boundary could otherwise leave a TCP read
+        // blocked forever.  `notify_one` stores a permit when no waiter exists,
+        // making the cancellation edge-triggered and race-safe for the single
+        // reader task.
+        self.reader_stop.notify_one();
+        self.fail_all_pending("agent stopped");
         if let Some(mut child) = self.child.lock().await.take() {
             let _ = child.kill().await;
         }
@@ -6602,7 +6653,7 @@ mod live_handshake_tests {
             .expect("grok cli");
         let cwd = std::env::current_dir().unwrap();
         let t0 = std::time::Instant::now();
-        let (client, mut events) = AcpClient::spawn(cli, cwd).expect("spawn");
+        let (client, mut events) = AcpClient::spawn(cli, cwd).await.expect("spawn");
         // drain events in bg
         tokio::spawn(async move {
             while let Some((_sid, ev)) = events.recv().await {

--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -1775,13 +1775,18 @@ pub fn import_cli_session(
     store::save_messages(&meta.id, &msgs)?;
     meta.updated_at = now;
     // Persist agent_session_id link.
-    let mut list = store::load_sessions_index();
-    if let Some(row) = list.iter_mut().find(|s| s.id == meta.id) {
-        row.agent_session_id = meta.agent_session_id.clone();
+    let sid = meta.id.clone();
+    let agent_session_id = meta.agent_session_id.clone();
+    if let Some(updated) = store::update_sessions_index(move |list| {
+        let Some(row) = list.iter_mut().find(|s| s.id == sid) else {
+            return Ok(None);
+        };
+        row.agent_session_id = agent_session_id;
         row.updated_at = now;
-        meta = row.clone();
+        Ok(Some(row.clone()))
+    })? {
+        meta = updated;
     }
-    store::save_sessions_index(&list)?;
     Ok(meta)
 }
 

--- a/src-tauri/src/mirror/ws.rs
+++ b/src-tauri/src/mirror/ws.rs
@@ -119,7 +119,12 @@ pub async fn handle_socket(
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!(skipped = n, "mirror ws client lagged; dropped events");
+                        // A lagged receiver cannot reconstruct ordering from
+                        // the broadcast ring. Close this socket so the client
+                        // transport's normal reconnect path can rehydrate its
+                        // listeners/snapshot instead of silently staying stale.
+                        tracing::warn!(skipped = n, "mirror ws client lagged; forcing resync reconnect");
+                        break;
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
                 }

--- a/src-tauri/src/official_aux.rs
+++ b/src-tauri/src/official_aux.rs
@@ -19,7 +19,7 @@
 #![allow(dead_code)] // residual-clippy: x_search / aux helpers retained for tests and future host wiring
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -267,20 +267,38 @@ pub fn run_official_headless(
     );
 
     let started = Instant::now();
-    let output = std::thread::spawn(move || cmd.output())
-        .join()
-        .map_err(|_| "official aux thread join failed".to_string())?
+    // `Command::output()` cannot be interrupted once the child wedges. Poll a
+    // spawned child instead so the timeout actually kills the fallback and
+    // releases the caller's side-channel slot.
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| format!("official aux spawn: {e}"))?;
+    loop {
+        if child
+            .try_wait()
+            .map_err(|e| format!("official aux wait: {e}"))?
+            .is_some()
+        {
+            break;
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!(
+                "official aux timed out after {}s",
+                timeout.as_secs()
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("official aux wait: {e}"))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    if started.elapsed() > timeout {
-        tracing::warn!(
-            target: "official_aux",
-            "headless slow elapsed={:?}",
-            started.elapsed()
-        );
-    }
     if !output.status.success() && stdout.trim().is_empty() {
         let preview: String = stderr.chars().take(500).collect();
         return Err(format!("official aux failed: {preview}"));
@@ -411,6 +429,7 @@ No repo edits. Prefer built-in tools. Keep the final answer concise and complete
     );
 
     let (client, mut events) = AcpClient::spawn_with_home(cli_path, cwd, "independent", opts)
+        .await
         .map_err(|e| format!("official ACP spawn: {}", e.message))?;
 
     let acc = Arc::new(std::sync::Mutex::new(String::new()));

--- a/src-tauri/src/relay_stream_proxy.rs
+++ b/src-tauri/src/relay_stream_proxy.rs
@@ -31,6 +31,9 @@ pub const APP_UPSTREAM_BASE_URL_KEY: &str = "app_upstream_base_url";
 static LISTEN_PORT: AtomicU16 = AtomicU16::new(0);
 static START_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+const RELAY_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const RELAY_STREAM_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
 fn start_lock() -> &'static Mutex<()> {
     START_LOCK.get_or_init(|| Mutex::new(()))
 }
@@ -180,13 +183,22 @@ pub async fn ensure_started() -> Result<u16, String> {
     let bound = addr.port();
 
     let app = Router::new().fallback(any(proxy_fallback));
+    // Publish the port only after the listener has been bound, but before the
+    // serve task is spawned. If `axum::serve` fails immediately, its cleanup
+    // compare-exchange below can reliably clear this exact generation; doing
+    // the store after `spawn` left a race where a fast failure was overwritten
+    // by the stale port value.
+    LISTEN_PORT.store(bound, Ordering::SeqCst);
     tokio::spawn(async move {
         if let Err(e) = axum::serve(listener, app).await {
             tracing::error!(target: "relay_stream_proxy", "serve error: {e}");
         }
+        // A bound port is not useful after the serving task exits, whether it
+        // returns an error or a graceful `Ok(())`. Clear only this generation
+        // so a newer listener cannot be invalidated by an old task.
+        let _ = LISTEN_PORT.compare_exchange(bound, 0, Ordering::SeqCst, Ordering::SeqCst);
     });
 
-    LISTEN_PORT.store(bound, Ordering::SeqCst);
     tracing::info!(
         target: "relay_stream_proxy",
         port = bound,
@@ -396,7 +408,12 @@ async fn proxy_request(req: Request) -> Result<Response, String> {
         .map_err(|e| format!("read body: {e}"))?;
 
     let client = {
-        let b = reqwest::Client::builder().timeout(std::time::Duration::from_secs(600));
+        // Do not install a total request deadline: a healthy SSE response may
+        // legitimately run for hours. Bound only connection setup and idle
+        // reads; the latter resets whenever an upstream chunk arrives.
+        let b = reqwest::Client::builder()
+            .connect_timeout(RELAY_CONNECT_TIMEOUT)
+            .read_timeout(RELAY_STREAM_IDLE_TIMEOUT);
         crate::proxy::apply_to_reqwest(b)
             .build()
             .map_err(|e| e.to_string())?
@@ -445,13 +462,24 @@ async fn proxy_request(req: Request) -> Result<Response, String> {
         let mut stream = byte_stream;
         let mut utf8_pending: Vec<u8> = Vec::new();
         let mut line_buf = String::new();
-        while let Some(item) = stream.next().await {
+        loop {
+            let item = match tokio::time::timeout(RELAY_STREAM_IDLE_TIMEOUT, stream.next()).await {
+                Ok(item) => item,
+                Err(_) => {
+                    let msg = "upstream SSE idle timeout";
+                    tracing::warn!(target: "relay_stream_proxy", "{msg}");
+                    yield Ok::<Bytes, Infallible>(Bytes::from(format_sse_error(msg)));
+                    break;
+                }
+            };
+            let Some(item) = item else { break };
             match item {
                 Ok(chunk) => {
                     push_utf8_stream(&mut utf8_pending, &chunk, &mut line_buf);
-                    while let Some(pos) = line_buf.find("\n\n") {
-                        let event = line_buf[..pos + 2].to_string();
-                        line_buf = line_buf[pos + 2..].to_string();
+                    while let Some((pos, delimiter_len)) = find_sse_event_end(&line_buf) {
+                        let end = pos + delimiter_len;
+                        let event = line_buf[..end].to_string();
+                        line_buf = line_buf[end..].to_string();
                         let kept = filter_sse_event(&event);
                         if !kept.is_empty() {
                             yield Ok::<Bytes, Infallible>(Bytes::from(kept));
@@ -460,6 +488,7 @@ async fn proxy_request(req: Request) -> Result<Response, String> {
                 }
                 Err(e) => {
                     tracing::warn!(target: "relay_stream_proxy", "upstream stream: {e}");
+                    yield Ok::<Bytes, Infallible>(Bytes::from(format_sse_error(&format!("upstream SSE read failed: {e}"))));
                     break;
                 }
             }
@@ -483,6 +512,29 @@ async fn proxy_request(req: Request) -> Result<Response, String> {
         .header(header::CACHE_CONTROL, "no-cache")
         .body(Body::from_stream(filtered))
         .map_err(|e| e.to_string())
+}
+
+/// Return the first complete SSE event boundary, accepting both the LF form
+/// emitted by most providers and the strict CRLF form required by the SSE spec.
+fn find_sse_event_end(input: &str) -> Option<(usize, usize)> {
+    let lf = input.find("\n\n").map(|pos| (pos, 2));
+    let crlf = input.find("\r\n\r\n").map(|pos| (pos, 4));
+    match (lf, crlf) {
+        (Some(a), Some(b)) => Some(if a.0 <= b.0 { a } else { b }),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+fn format_sse_error(message: &str) -> String {
+    let payload = serde_json::json!({
+        "error": {
+            "message": message,
+            "type": "upstream_stream_error"
+        }
+    });
+    format!("event: error\ndata: {payload}\n\n")
 }
 
 fn filter_request_headers(src: &HeaderMap) -> HeaderMap {
@@ -567,6 +619,21 @@ mod tests {
         let ev = "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"choices\":[]}\n\n";
         let out = filter_sse_event(ev);
         assert!(out.contains("chat.completion.chunk"));
+    }
+
+    #[test]
+    fn finds_lf_and_crlf_event_boundaries() {
+        assert_eq!(find_sse_event_end("data: x\n\nrest"), Some((7, 2)));
+        assert_eq!(find_sse_event_end("data: x\r\n\r\nrest"), Some((7, 4)));
+        assert_eq!(find_sse_event_end("data: x\nrest"), None);
+    }
+
+    #[test]
+    fn structured_stream_error_is_sse() {
+        let out = format_sse_error("upstream broke");
+        assert!(out.starts_with("event: error\n"));
+        assert!(out.contains("upstream broke"));
+        assert!(out.ends_with("\n\n"));
     }
 
     #[test]

--- a/src-tauri/src/remote_im/app_sessions.rs
+++ b/src-tauri/src/remote_im/app_sessions.rs
@@ -175,23 +175,28 @@ pub fn sync_turn_to_app(
             }
         }
     } else if let Some(ref id) = app_id {
-        // Touch meta + keep agent id in sync
-        let mut list = store::load_sessions_index();
-        if let Some(s) = list.iter_mut().find(|s| s.id == *id) {
-            if let Some(aid) = agent_id {
-                s.agent_session_id = Some(aid.to_string());
+        // Touch meta + keep agent id in sync under one sessions-index
+        // transaction. A load/modify/update sequence here could overwrite a
+        // stream's newer agent-session binding from another process.
+        let id_for_update = id.clone();
+        let project_id = binding.project_id.clone();
+        let title = title_from_prompt(user_prompt, channel);
+        let _ = store::update_sessions_index(move |list| {
+            if let Some(s) = list.iter_mut().find(|s| s.id == id_for_update) {
+                if let Some(aid) = agent_id {
+                    s.agent_session_id = Some(aid.to_string());
+                }
+                if s.project_id.is_none() {
+                    s.project_id = project_id;
+                }
+                // First meaningful title: replace default "New chat" / placeholder
+                if is_placeholder_title(&s.title) {
+                    s.title = title;
+                }
+                s.updated_at = Utc::now();
             }
-            if s.project_id.is_none() {
-                s.project_id = binding.project_id.clone();
-            }
-            // First meaningful title: replace default "New chat" / placeholder
-            if is_placeholder_title(&s.title) {
-                s.title = title_from_prompt(user_prompt, channel);
-            }
-            s.updated_at = Utc::now();
-            let clone = s.clone();
-            let _ = store::update_session_meta(&clone);
-        }
+            Ok(())
+        });
         next.local_session_id = id.clone();
     }
 

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -137,11 +137,12 @@ impl SessionManager {
                             );
                             return Ok(self.snapshot());
                         }
+                        let process_id = s.process_id.clone();
                         let acp = s.acp.take();
                         s.needs_history_bootstrap = false;
                         s.fsm.soft_disconnect();
                         s.process_id = String::new();
-                        acp
+                        acp.map(|client| (client, process_id))
                     } else {
                         None
                     }
@@ -153,15 +154,41 @@ impl SessionManager {
                 .background
                 .lock()
                 .remove(&meta.id)
-                .and_then(|mut bg| bg.acp.take());
-            let parked_acp = self.parked.lock().remove(&meta.id).map(|p| p.acp);
-            if let Some(acp) = acp_to_kill {
-                acp.kill().await;
+                .and_then(|mut bg| bg.acp.take().map(|acp| (acp, bg.process_id)));
+            let parked_acp = self
+                .parked
+                .lock()
+                .remove(&meta.id)
+                .map(|p| (p.acp, p.process_id));
+            for (acp, process_id) in acp_to_kill.into_iter().chain(bg_acp).chain(parked_acp) {
+                if self.has_other_process_tenant(&process_id, &meta.id) {
+                    tracing::info!(
+                        session = %meta.id,
+                        process = %process_id,
+                        "pending fork detached shared ACP without killing co-tenant"
+                    );
+                } else {
+                    acp.kill().await;
+                }
             }
-            if let Some(acp) = bg_acp {
-                acp.kill().await;
-            }
-            if let Some(acp) = parked_acp {
+            // Invalidate only after the busy early-return above. A deferred
+            // fork must leave an in-flight prewarm producer valid; otherwise
+            // its completion is rejected by the epoch check while the slot
+            // remains stuck in `Spawning` forever.
+            self.invalidate_prewarm_epoch();
+            // Fork must not leave an ownerless prewarm child alongside the
+            // forced cold-spawn process. If a prewarm is still Spawning, set
+            // the slot to None; the producer checks the state before publish
+            // and will kill the just-initialized child instead of resurrecting
+            // a stale Ready slot.
+            let prewarm_to_kill = {
+                let mut pw = self.prewarm.lock();
+                match std::mem::replace(&mut *pw, PrewarmState::None) {
+                    PrewarmState::Ready(p) => Some(p.acp),
+                    PrewarmState::Spawning { .. } | PrewarmState::None => None,
+                }
+            };
+            if let Some(acp) = prewarm_to_kill {
                 acp.kill().await;
             }
             tracing::info!(
@@ -235,8 +262,9 @@ impl SessionManager {
                         "unpark spawn-flag mismatch — cold spawn"
                     );
                     if let Some(acp) = live.acp {
-                        let busy = self.busy_process_ids_for_warm_reuse();
-                        if should_kill_parked_after_flag_mismatch(&live.process_id, &busy) {
+                        let shared_with_other =
+                            self.has_other_process_tenant(&live.process_id, &meta.id);
+                        if !shared_with_other {
                             acp.kill().await;
                         } else {
                             tracing::info!(
@@ -417,17 +445,12 @@ impl SessionManager {
         });
 
         // ── Warm-process reuse (per-route pool) ────────────────────────────
-        // A Ready parked (or idle background) process with identical
-        // process-level spawn flags (permission / effort / sandbox / route)
-        // can host this App session: no CLI spawn, just session/load or
-        // session/new. The parked shell stays — switch-back is an unpark.
-        //
-        // Never reuse a process that still has a mid-turn live/background
-        // co-tenant. CLI 1.0.3 load-replay is often unstamped; unique-busy-
-        // background routing would then write B's history into A's journal
-        // (00f647cd diagnostic: 009ea8c2 / 407d65e2 load on the Streaming
-        // process). Idle Ready reuse is unchanged. Unstamped routing is
-        // unchanged so A's own chunks still land after demote.
+        // Only an ownerless prewarm process with identical process-level
+        // spawn flags (permission / effort / sandbox / route) may cross an
+        // App-session boundary. Session-bound parked/background ACPs stay
+        // attached to their owner; sharing an Arc across sessions lets
+        // unstamped load replay and process-level kill paths corrupt or abort
+        // a co-tenant.
         if !pending_fork {
             let eff_sandbox = {
                 let project_sandbox = meta.project_id.as_deref().and_then(|pid| {
@@ -441,8 +464,9 @@ impl SessionManager {
                     project_sandbox.as_deref(),
                 )
             };
+            let mut stale_prewarm: Vec<Arc<AcpClient>> = Vec::new();
             let reused = {
-                // Reuse candidates = idle parked + idle background only.
+                // Only an ownerless prewarm process may cross a session boundary.
                 // Mid-turn background keeps exclusive ownership of its process
                 // so session/load on a peer cannot poison that journal.
                 // Route class must follow active_route(), not prefs.model_id.
@@ -450,7 +474,8 @@ impl SessionManager {
                 // (e.g. deepseek-v4-flash), which is_custom_provider_id rejects
                 // — processes were mis-labeled official and reused after
                 // auth.json was stripped (#528 intermittent re-login).
-                let busy_process_ids = self.busy_process_ids_for_warm_reuse();
+                // Only the ownerless prewarm process is eligible for reuse.
+                // Session-bound ACP processes stay with their App session.
                 let target_custom = matches!(
                     crate::providers::active_route(),
                     crate::providers::ActiveRoute::Custom { .. }
@@ -531,6 +556,13 @@ impl SessionManager {
                                 ) {
                                     Some((p.acp, p.process_id, p.created_at))
                                 } else {
+                                    // `PrewarmState::Ready` is ownerless, so
+                                    // a gate mismatch cannot be handed back to
+                                    // another session. Drop and explicitly
+                                    // kill it after leaving the map lock; an
+                                    // Arc/Child drop alone does not terminate
+                                    // the CLI process.
+                                    stale_prewarm.push(p.acp.clone());
                                     rejected.push(format!(
                                         "prewarm: {}",
                                         reject_reason(
@@ -569,80 +601,13 @@ impl SessionManager {
                     // outside connect_lock, so this cannot deadlock).
                     tokio::time::sleep(std::time::Duration::from_millis(120)).await;
                 }
-                if best.is_none() {
-                    let parked = self.parked.lock();
-                    for p in parked.values() {
-                        if process_blocked_for_warm_reuse(&p.process_id, &busy_process_ids) {
-                            rejected.push(format!(
-                                "parked {}: mid-turn co-tenant on process",
-                                p.app_session_id
-                            ));
-                            continue;
-                        }
-                        if !gate(
-                            p.acp.is_alive(),
-                            p.policy,
-                            p.effort.as_deref(),
-                            p.acp.sandbox_profile().as_deref(),
-                            p.acp.is_custom_route(),
-                        ) {
-                            rejected.push(format!(
-                                "parked {}: {}",
-                                p.app_session_id,
-                                reject_reason(
-                                    p.acp.is_alive(),
-                                    p.policy,
-                                    p.effort.as_deref(),
-                                    p.acp.sandbox_profile().as_deref(),
-                                    p.acp.is_custom_route(),
-                                )
-                            ));
-                            continue;
-                        }
-                        let cand = (p.acp.clone(), p.process_id.clone(), p.last_activity);
-                        if best.as_ref().is_none_or(|b| cand.2 > b.2) {
-                            best = Some(cand);
-                        }
-                    }
-                }
-                if best.is_none() {
-                    let bg = self.background.lock();
-                    for s in bg.values() {
-                        let s_custom = s.acp.as_ref().is_some_and(|c| c.is_custom_route());
-                        if process_blocked_for_warm_reuse(&s.process_id, &busy_process_ids) {
-                            rejected.push(format!("background {}: mid-turn", s.app_session_id));
-                            continue;
-                        }
-                        if !gate(
-                            s.acp.as_ref().is_some_and(|c| c.is_alive()),
-                            s.policy,
-                            s.effort.as_deref(),
-                            s.acp.as_ref().and_then(|c| c.sandbox_profile()).as_deref(),
-                            s_custom,
-                        ) {
-                            rejected.push(format!(
-                                "background {}: {}",
-                                s.app_session_id,
-                                reject_reason(
-                                    s.acp.as_ref().is_some_and(|c| c.is_alive()),
-                                    s.policy,
-                                    s.effort.as_deref(),
-                                    s.acp.as_ref().and_then(|c| c.sandbox_profile()).as_deref(),
-                                    s_custom,
-                                )
-                            ));
-                            continue;
-                        }
-                        let cand = (
-                            s.acp.clone().unwrap(),
-                            s.process_id.clone(),
-                            s.last_activity,
-                        );
-                        if best.as_ref().is_none_or(|b| cand.2 > b.2) {
-                            best = Some(cand);
-                        }
-                    }
-                }
+                // A session-bound ACP process is never transferred to another
+                // App session. The old parked/background reuse path shared an
+                // `Arc<AcpClient>` while leaving the original owner registered;
+                // capacity and event routing could then kill or apply events to
+                // the wrong tenant. Only the ownerless prewarm process above is
+                // eligible for reuse. The target session is opened on a fresh
+                // process once its own parked entry is no longer focused.
                 if best.is_none() && !rejected.is_empty() {
                     tracing::warn!(
                         target: "session",
@@ -657,26 +622,15 @@ impl SessionManager {
                 }
                 best.map(|(acp, pid, _)| (acp, pid))
             };
+            for acp in stale_prewarm {
+                acp.kill().await;
+            }
             if let Some((acp, reused_process)) = reused {
-                let reused_from = self
-                    .parked
-                    .lock()
-                    .values()
-                    .find(|p| p.process_id == reused_process)
-                    .map(|p| p.app_session_id.clone())
-                    .or_else(|| {
-                        self.background
-                            .lock()
-                            .values()
-                            .find(|s| s.process_id == reused_process)
-                            .map(|s| s.app_session_id.clone())
-                    });
                 tracing::info!(
                     target: "session",
                     session = %meta.id,
                     reused_process = %reused_process,
-                    reused_from = ?reused_from,
-                    "connect warm-process reuse (shared, no spawn)"
+                    "connect prewarm reuse (ownerless process, no cross-session sharing)"
                 );
                 // #528: warm reuse skips cold spawn (no prepare_route_auth).
                 // Re-apply route auth so official OIDC is on disk after any
@@ -883,36 +837,37 @@ impl SessionManager {
             empty_mcp_servers: false,
         };
 
-        let (client, mut events) = match AcpClient::spawn_with_options(cli_path, cwd, spawn_opts) {
-            Ok(v) => {
-                tracing::info!(
-                    target: "session",
-                    session = %meta.id,
-                    process = %process_id,
-                    fork_session = fork_agent,
-                    "connect spawn_ok"
-                );
-                v
-            }
-            Err(e) => {
-                tracing::warn!(
-                    target: "session",
-                    session = %meta.id,
-                    code = e.code.as_str(),
-                    error = %e.message,
-                    "connect spawn_fail"
-                );
-                {
-                    let mut guard = self.inner.lock();
-                    if let Some(s) = guard.as_mut() {
-                        let _ = s.fsm.connect_failed(e);
-                    }
+        let (client, mut events) =
+            match AcpClient::spawn_with_options(cli_path, cwd, spawn_opts).await {
+                Ok(v) => {
+                    tracing::info!(
+                        target: "session",
+                        session = %meta.id,
+                        process = %process_id,
+                        fork_session = fork_agent,
+                        "connect spawn_ok"
+                    );
+                    v
                 }
-                let snap = self.snapshot();
-                Self::emit_state(&app, &snap);
-                return Ok(snap);
-            }
-        };
+                Err(e) => {
+                    tracing::warn!(
+                        target: "session",
+                        session = %meta.id,
+                        code = e.code.as_str(),
+                        error = %e.message,
+                        "connect spawn_fail"
+                    );
+                    {
+                        let mut guard = self.inner.lock();
+                        if let Some(s) = guard.as_mut() {
+                            let _ = s.fsm.connect_failed(e);
+                        }
+                    }
+                    let snap = self.snapshot();
+                    Self::emit_state(&app, &snap);
+                    return Ok(snap);
+                }
+            };
 
         // Event pump tagged with process_id (multi-process routing). Events
         // carry the CLI's owning sessionId when known so a reused process
@@ -1181,17 +1136,30 @@ impl SessionManager {
         self.prewarm_inner(app, true).await;
     }
 
+    fn clear_prewarm_if_current(&self, epoch: u64) {
+        let mut pw = self.prewarm.lock();
+        if self.prewarm_epoch.load(std::sync::atomic::Ordering::SeqCst) == epoch
+            && matches!(*pw, PrewarmState::Spawning { .. })
+        {
+            *pw = PrewarmState::None;
+        }
+    }
+
     async fn prewarm_inner(self: &Arc<Self>, app: AppHandle, force: bool) {
         // Quick gate (no connect_lock — connect may be awaiting a Spawning
         // prewarm; grabbing the lock here would deadlock it). The prewarm
         // Mutex serializes concurrent prewarm calls.
-        {
+        let epoch = {
             let mut pw = self.prewarm.lock();
             match &*pw {
                 PrewarmState::Spawning { .. } => return,
                 PrewarmState::Ready(p) if p.acp.is_alive() && !force => return,
                 _ => {}
             }
+            let epoch = self
+                .prewarm_epoch
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                .saturating_add(1);
             if force {
                 // Retire the old prewarm process (async kill) — otherwise
                 // every refresh leaks a CLI process.
@@ -1225,7 +1193,8 @@ impl SessionManager {
                     since: Instant::now(),
                 };
             }
-        }
+            epoch
+        };
 
         let settings = store::load_settings();
         // WSL backend probes inside the distro (a WSL-only install has no native grok.exe).
@@ -1234,7 +1203,7 @@ impl SessionManager {
             settings.manual_cli_path.as_deref(),
         );
         let Some(cli_path) = probe.path else {
-            *self.prewarm.lock() = PrewarmState::None;
+            self.clear_prewarm_if_current(epoch);
             return;
         };
         let cli_path = std::path::PathBuf::from(cli_path);
@@ -1265,11 +1234,13 @@ impl SessionManager {
             sandbox_profile: Some(effective_sandbox.clone()),
             ..Default::default()
         };
-        let (client, mut events) = match AcpClient::spawn_with_options(cli_path, cwd, spawn_opts) {
+        let (client, mut events) = match AcpClient::spawn_with_options(cli_path, cwd, spawn_opts)
+            .await
+        {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(code = e.code.as_str(), error = %e.message, "prewarm spawn failed");
-                *self.prewarm.lock() = PrewarmState::None;
+                self.clear_prewarm_if_current(epoch);
                 return;
             }
         };
@@ -1288,19 +1259,35 @@ impl SessionManager {
         if let Err(e) = client.initialize_and_auth().await {
             tracing::warn!(code = e.code.as_str(), error = %e.message, "prewarm init failed");
             client.kill().await;
-            *self.prewarm.lock() = PrewarmState::None;
+            self.clear_prewarm_if_current(epoch);
             return;
         }
-        *self.prewarm.lock() = PrewarmState::Ready(PrewarmedProcess {
-            acp: client,
-            process_id,
-            policy,
-            effort: Some(prefs.effort),
-            sandbox_profile: Some(effective_sandbox),
-            model_id: Some(prefs.model_id),
-            created_at: Instant::now(),
-            backend: "grok_agent_stdio".into(),
-        });
+        let published = {
+            let mut pw = self.prewarm.lock();
+            if self.prewarm_epoch.load(std::sync::atomic::Ordering::SeqCst) == epoch
+                && matches!(*pw, PrewarmState::Spawning { .. })
+            {
+                *pw = PrewarmState::Ready(PrewarmedProcess {
+                    acp: client.clone(),
+                    process_id,
+                    policy,
+                    effort: Some(prefs.effort),
+                    sandbox_profile: Some(effective_sandbox),
+                    model_id: Some(prefs.model_id),
+                    created_at: Instant::now(),
+                    backend: "grok_agent_stdio".into(),
+                });
+                true
+            } else {
+                false
+            }
+        };
+        if !published {
+            // A pending fork or route reset cancelled this prewarm while it
+            // was starting. Do not leak the initialized child.
+            client.kill().await;
+            return;
+        }
         tracing::info!(target: "session", "prewarm ready (spawn+init+auth, no session)");
     }
 

--- a/src-tauri/src/session_manager/control.rs
+++ b/src-tauri/src/session_manager/control.rs
@@ -1,7 +1,7 @@
 //! Policy, model, disconnect, recycle, permission resolution.
 
 #![allow(dead_code)] // residual-clippy: set_permission_policy / tracked counts
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tauri::{AppHandle, Emitter};
@@ -12,7 +12,6 @@ use crate::process_limits::{normalize_idle_minutes, normalize_max_concurrent};
 use crate::session_fsm::SessionState;
 use crate::store::{self};
 
-use super::connect::should_kill_parked_after_flag_mismatch;
 use super::*;
 
 impl SessionManager {
@@ -35,38 +34,58 @@ impl SessionManager {
 
     /// Soft-respawn and tell the UI why the agent process was reloaded.
     pub async fn soft_respawn_with_reason(&self, app: &AppHandle, reason: &str) {
-        let (acp, sid) = {
+        let (acp, sid, process_id, deferred) = {
             let mut guard = self.inner.lock();
             if let Some(s) = guard.as_mut() {
                 if s.acp.is_none() {
-                    return;
-                }
-                if Self::live_session_is_busy(s) {
+                    (None, Some(s.app_session_id.clone()), String::new(), false)
+                } else if Self::live_session_is_busy(s) {
                     tracing::warn!(
                         "soft_respawn deferred: live session mid-turn sid={} state={:?} reason={}",
                         s.app_session_id,
                         s.fsm.state(),
                         reason
                     );
-                    self.pending_soft_respawn
-                        .lock()
-                        .insert(s.app_session_id.clone(), reason.to_string());
-                    return;
+                    (None, Some(s.app_session_id.clone()), String::new(), true)
+                } else {
+                    let sid = s.app_session_id.clone();
+                    let process_id = s.process_id.clone();
+                    let acp = s.acp.take();
+                    // Prefer resume on next connect; bootstrap only if load fails.
+                    s.needs_history_bootstrap = false;
+                    s.fsm.soft_disconnect();
+                    // New process gets a new id on next connect.
+                    s.process_id = String::new();
+                    (acp, Some(sid), process_id, false)
                 }
-                let sid = s.app_session_id.clone();
-                let acp = s.acp.take();
-                // Prefer resume on next connect; bootstrap only if load fails.
-                s.needs_history_bootstrap = false;
-                s.fsm.soft_disconnect();
-                // New process gets a new id on next connect.
-                s.process_id = String::new();
-                (acp, Some(sid))
             } else {
-                (None, None)
+                (None, None, String::new(), false)
             }
         };
+        if let Some(sid) = sid.as_deref() {
+            if deferred {
+                self.pending_soft_respawn
+                    .lock()
+                    .insert(sid.to_string(), reason.to_string());
+                return;
+            }
+            if acp.is_none() {
+                self.pending_soft_respawn.lock().remove(sid);
+                return;
+            }
+        }
         if let Some(acp) = acp {
-            acp.kill().await;
+            let kill_allowed = sid
+                .as_deref()
+                .is_none_or(|session_id| !self.has_other_process_tenant(&process_id, session_id));
+            if kill_allowed {
+                acp.kill().await;
+            } else {
+                tracing::info!(
+                    reason = %reason,
+                    "soft-respawn detached shared ACP without killing co-tenant"
+                );
+            }
             if let Some(sid) = sid {
                 self.pending_soft_respawn.lock().remove(&sid);
             }
@@ -99,13 +118,38 @@ impl SessionManager {
             self.soft_respawn_with_reason(app, &reason).await;
             return;
         }
+        // A background session can be idle after its turn completed. Pending
+        // respawn flags still belong to that session; leaving its old ACP in
+        // `background` lets connect promote it and silently ignore the new
+        // process-level settings.
+        let background = self.background.lock().remove(session_id);
+        if let Some(mut s) = background {
+            let process_id = s.process_id.clone();
+            if let Some(acp) = s.acp.take() {
+                if self.has_other_process_tenant(&process_id, session_id) {
+                    tracing::info!(
+                        session = %session_id,
+                        process = %process_id,
+                        reason = %reason,
+                        "pending soft-respawn detached shared background ACP without killing co-tenant"
+                    );
+                } else {
+                    acp.kill().await;
+                    tracing::info!(
+                        session = %session_id,
+                        reason = %reason,
+                        "dropped background agent for pending soft-respawn"
+                    );
+                }
+            }
+            return;
+        }
         // Parked: drop the warm entry so the next connect respawns.
         // Take the entry first — parking_lot guards are !Send across await.
         // Do not kill a process that still hosts a mid-turn cohabitant.
         let parked = self.parked.lock().remove(session_id);
         if let Some(p) = parked {
-            let busy = self.busy_process_ids_for_warm_reuse();
-            if should_kill_parked_after_flag_mismatch(&p.process_id, &busy) {
+            if !self.has_other_process_tenant(&p.process_id, session_id) {
                 p.acp.kill().await;
                 tracing::info!(
                     session = %session_id,
@@ -140,6 +184,17 @@ impl SessionManager {
         let settings = store::load_settings();
         let max = normalize_max_concurrent(settings.max_concurrent_agents);
         let idle = normalize_idle_minutes(settings.agent_idle_minutes);
+        // Diagnostics must use the same process-level accounting as capacity;
+        // a warm-reused ACP can appear in more than one session map entry.
+        let mut seen_processes: HashSet<String> = HashSet::new();
+        let mut claim_process = |process_id: &str| {
+            if process_id.trim().is_empty() {
+                // Unknown ids are transitional; count them conservatively.
+                true
+            } else {
+                seen_processes.insert(process_id.to_string())
+            }
+        };
 
         let mut live_ids: Vec<String> = Vec::new();
         let live = {
@@ -147,7 +202,7 @@ impl SessionManager {
             match guard.as_ref() {
                 Some(s) if s.acp.as_ref().is_some_and(|c| c.is_alive()) => {
                     live_ids.push(s.app_session_id.clone());
-                    1u32
+                    claim_process(&s.process_id) as u32
                 }
                 _ => 0u32,
             }
@@ -161,7 +216,11 @@ impl SessionManager {
                     background_ids.push(id.clone());
                 }
             }
-            background_ids.len() as u32
+            bg.iter()
+                .filter(|(_, s)| {
+                    s.acp.as_ref().is_some_and(|c| c.is_alive()) && claim_process(&s.process_id)
+                })
+                .count() as u32
         };
 
         let mut parked_ids: Vec<String> = Vec::new();
@@ -172,7 +231,9 @@ impl SessionManager {
                     parked_ids.push(id.clone());
                 }
             }
-            parked_ids.len() as u32
+            p.iter()
+                .filter(|(_, agent)| agent.acp.is_alive() && claim_process(&agent.process_id))
+                .count() as u32
         };
 
         crate::process_limits::ProcessBudgetSnapshot::from_counts(
@@ -404,6 +465,7 @@ impl SessionManager {
 
         // New-chat prewarm (spawn+init+auth, no session). Connect prefers this
         // slot — leaving it alive after auth rebind reuses stale credentials.
+        self.invalidate_prewarm_epoch();
         let prewarm_count = {
             let mut pw = self.prewarm.lock();
             match std::mem::replace(&mut *pw, PrewarmState::None) {
@@ -454,46 +516,52 @@ impl SessionManager {
             }
         };
         // Background turns keep using s.policy for auto-allow (P1-19).
-        {
+        let background_respawn_ids: Vec<String> = {
             let mut bg = self.background.lock();
-            for s in bg.values_mut() {
-                s.policy = policy;
-                s.meta.permission_policy = Some(policy.as_str().into());
-                let _ = store::update_session_meta(&s.meta);
-                if s.acp.is_some() {
-                    self.pending_soft_respawn
-                        .lock()
-                        .insert(s.app_session_id.clone(), "permission_policy".into());
-                }
-            }
+            bg.values_mut()
+                .filter_map(|s| {
+                    s.policy = policy;
+                    s.meta.permission_policy = Some(policy.as_str().into());
+                    let _ = store::update_session_meta(&s.meta);
+                    s.acp.as_ref().map(|_| s.app_session_id.clone())
+                })
+                .collect()
+        };
+        for sid in background_respawn_ids {
+            self.pending_soft_respawn
+                .lock()
+                .insert(sid, "permission_policy".into());
         }
         {
-            // Snapshot busy pids before locking parked (distinct locks).
-            let busy = self.busy_process_ids_for_warm_reuse();
-            let to_kill: Vec<Arc<AcpClient>> = {
+            let removed: Vec<(String, ParkedAgent)> = {
                 let mut parked = self.parked.lock();
                 let stale: Vec<String> = parked
                     .iter()
                     .filter(|(_, p)| p.policy != policy)
                     .map(|(id, _)| id.clone())
                     .collect();
-                let mut kill = Vec::new();
+                let mut removed = Vec::with_capacity(stale.len());
                 for id in stale {
-                    if let Some(p) = parked.remove(&id) {
-                        if should_kill_parked_after_flag_mismatch(&p.process_id, &busy) {
-                            kill.push(p.acp);
-                        } else {
-                            tracing::info!(
-                                session = %id,
-                                process = %p.process_id,
-                                "permission policy: removed parked entry, skip kill (mid-turn cohabitant)"
-                            );
-                        }
-                    }
+                    // Remove while holding the map lock; process ownership is
+                    // checked after the guard drops so the helper can inspect
+                    // all tenant maps without self-deadlocking.
+                    let Some(p) = parked.remove(&id) else {
+                        continue;
+                    };
+                    removed.push((id, p));
                 }
-                kill
+                removed
             };
-            for acp in to_kill {
+            for (id, p) in removed {
+                if self.has_other_process_tenant(&p.process_id, &id) {
+                    tracing::info!(
+                        session = %id,
+                        process = %p.process_id,
+                        "permission policy: removed parked entry, skip kill (co-tenant)"
+                    );
+                    continue;
+                }
+                let acp = p.acp;
                 // Kill after drop to avoid holding the map lock across await.
                 tokio::spawn(async move {
                     acp.kill().await;
@@ -668,24 +736,26 @@ impl SessionManager {
         // Parked / background chats own their process — updating only the live
         // slot left them running the previous `--reasoning-effort` (#598).
         if let Some(sid) = session_id {
-            if let Some(s) = self.background.lock().get_mut(sid) {
+            let background_needs_respawn = if let Some(s) = self.background.lock().get_mut(sid) {
                 let same = s.effort.as_deref() == Some(effort.as_str());
                 s.effort = Some(effort.clone());
                 s.meta.effort = Some(effort.clone());
                 let _ = store::update_session_meta(&s.meta);
-                if !same && s.acp.is_some() {
-                    self.pending_soft_respawn
-                        .lock()
-                        .insert(sid.to_string(), "effort".into());
-                }
+                !same && s.acp.is_some()
+            } else {
+                false
+            };
+            if background_needs_respawn {
+                self.pending_soft_respawn
+                    .lock()
+                    .insert(sid.to_string(), "effort".into());
             }
             // Let-binding so the parking_lot guard drops before the if-let body
             // (edition 2021 keeps if-let temps alive through else — re-lock deadlock).
             let removed = self.parked.lock().remove(sid);
             if let Some(p) = removed {
                 if p.effort.as_deref() != Some(effort.as_str()) {
-                    let busy = self.busy_process_ids_for_warm_reuse();
-                    if should_kill_parked_after_flag_mismatch(&p.process_id, &busy) {
+                    if !self.has_other_process_tenant(&p.process_id, sid) {
                         tokio::spawn(async move {
                             p.acp.kill().await;
                         });

--- a/src-tauri/src/session_manager/events.rs
+++ b/src-tauri/src/session_manager/events.rs
@@ -45,20 +45,27 @@ impl SessionManager {
                 .map(|(id, _)| id.clone())
                 .collect();
             for bg_id in bg_ids {
+                self.pending_soft_respawn.lock().remove(&bg_id);
                 self.handle_acp_event_on_background(
                     app,
                     &bg_id,
+                    process_id,
+                    None,
                     AcpEvent::ProcessExited { code: exit_code },
                 )
                 .await;
             }
-            let is_live = self
+            let live_sid = self
                 .inner
                 .lock()
                 .as_ref()
-                .is_some_and(|s| s.process_id == process_id);
-            if !is_live {
+                .filter(|s| s.process_id == process_id)
+                .map(|s| s.app_session_id.clone());
+            if live_sid.is_none() {
                 return;
+            }
+            if let Some(sid) = live_sid {
+                self.pending_soft_respawn.lock().remove(&sid);
             }
             // Fall through to live ProcessExited handling below.
         } else {
@@ -101,7 +108,8 @@ impl SessionManager {
                 &parked_hints,
             ) {
                 TurnEventRoute::Background(bg_sid) => {
-                    self.handle_acp_event_on_background(app, &bg_sid, ev).await;
+                    self.handle_acp_event_on_background(app, &bg_sid, process_id, session_id, ev)
+                        .await;
                     return;
                 }
                 TurnEventRoute::Drop => {
@@ -117,6 +125,31 @@ impl SessionManager {
                     // Fall through to live match below.
                 }
             }
+        }
+
+        // The route snapshot above is advisory. Re-check the live slot before
+        // applying the event so a concurrent focus/park transition cannot
+        // deliver a late process event to the next chat occupying the slot.
+        let live_route_matches = self.inner.lock().as_ref().is_some_and(|s| {
+            s.process_id == process_id
+                && session_id.is_none_or(|sid| {
+                    // Once the wire event carries a session id, require an
+                    // exact owner match. Treating an unbound live hint as a
+                    // wildcard lets late events from a co-tenant land in the
+                    // newly focused session during connect/park races.
+                    s.meta.agent_session_id.as_deref() == Some(sid)
+                })
+        });
+        if !live_route_matches {
+            if Self::event_carries_turn_output(&ev) {
+                tracing::debug!(
+                    process = %process_id,
+                    agent = ?session_id,
+                    ev = Self::event_kind_name(&ev),
+                    "live ACP event dropped after route changed"
+                );
+            }
+            return;
         }
 
         match ev {
@@ -718,10 +751,16 @@ impl SessionManager {
                         if tool_journal_richer(&slot.content, &content) {
                             slot.content = content.clone();
                             slot.marker = Some("tool_step".into());
-                            let _ = store::save_messages(&app_sid, &msgs);
+                            if let Err(e) = store::save_messages(&app_sid, &msgs) {
+                                tracing::error!(
+                                    session = %app_sid,
+                                    tool = %tool_call_id,
+                                    "tool journal update failed: {e}"
+                                );
+                            }
                         }
                     } else {
-                        let _ = store::append_message(
+                        if let Err(e) = store::append_message(
                             &app_sid,
                             ChatMessageStored {
                                 id: mid,
@@ -733,7 +772,13 @@ impl SessionManager {
                                 attachments: None,
                                 marker: Some("tool_step".into()),
                             },
-                        );
+                        ) {
+                            tracing::error!(
+                                session = %app_sid,
+                                tool = %tool_call_id,
+                                "tool journal append failed: {e}"
+                            );
+                        }
                     }
                 }
             }
@@ -850,7 +895,7 @@ impl SessionManager {
                 }
                 Self::emit_state(app, &self.snapshot());
             }
-            AcpEvent::ProcessExited { .. } => {
+            AcpEvent::ProcessExited { code } => {
                 let mut gate_invalidations: Vec<serde_json::Value> = Vec::new();
                 {
                     let mut guard = self.inner.lock();
@@ -887,7 +932,11 @@ impl SessionManager {
                                     | SessionState::AwaitingPermission
                             )
                         {
-                            let _ = s.fsm.crash("Agent process exited");
+                            let detail = match code {
+                                Some(status) => format!("Agent process exited (code {status})"),
+                                None => "Agent process exited (EOF/unknown status)".into(),
+                            };
+                            let _ = s.fsm.crash(detail);
                         }
                         s.acp = None;
                         s.open_tool_ids.clear();
@@ -1127,7 +1176,7 @@ impl SessionManager {
                     (s.app_session_id.clone(), content)
                 };
                 let mid = Uuid::new_v4().to_string();
-                let _ = store::append_message(
+                if let Err(e) = store::append_message(
                     &app_sid,
                     ChatMessageStored {
                         id: mid.clone(),
@@ -1139,7 +1188,9 @@ impl SessionManager {
                         attachments: None,
                         marker: Some("context_compact".into()),
                     },
-                );
+                ) {
+                    tracing::error!(session = %app_sid, "context compact journal append failed: {e}");
+                }
                 let _ = app.emit(
                     "session://context_compact",
                     serde_json::json!({

--- a/src-tauri/src/session_manager/events_bg.rs
+++ b/src-tauri/src/session_manager/events_bg.rs
@@ -25,8 +25,32 @@ impl SessionManager {
         self: &Arc<Self>,
         app: &AppHandle,
         app_session_id: &str,
+        process_id: &str,
+        agent_session_id: Option<&str>,
         ev: AcpEvent,
     ) {
+        // Routing is decided from a snapshot, but focus/park transitions can
+        // move the map before this async handler is polled. Re-check the
+        // process and (when stamped) ACP session identity at the application
+        // boundary so a late event cannot write into a newly reused slot.
+        let route_matches = self.background.lock().get(app_session_id).is_some_and(|s| {
+            s.process_id == process_id
+                && agent_session_id.is_none_or(|sid| {
+                    // Stamped events must name this background session
+                    // exactly; an unset owner is not a safe wildcard while a
+                    // focus/park transition is moving the same process.
+                    s.meta.agent_session_id.as_deref() == Some(sid)
+                })
+        });
+        if !route_matches {
+            tracing::debug!(
+                session = %app_session_id,
+                process = %process_id,
+                agent = ?agent_session_id,
+                "background ACP event dropped after route changed"
+            );
+            return;
+        }
         match ev {
             AcpEvent::Stream {
                 kind,
@@ -414,10 +438,16 @@ impl SessionManager {
                                 if tool_journal_richer(&slot.content, &content) {
                                     slot.content = content.clone();
                                     slot.marker = Some("tool_step".into());
-                                    let _ = store::save_messages(&s.app_session_id, &msgs);
+                                    if let Err(e) = store::save_messages(&s.app_session_id, &msgs) {
+                                        tracing::error!(
+                                            session = %s.app_session_id,
+                                            tool = %tool_call_id,
+                                            "background tool journal update failed: {e}"
+                                        );
+                                    }
                                 }
                             } else {
-                                let _ = store::append_message(
+                                if let Err(e) = store::append_message(
                                     &s.app_session_id,
                                     ChatMessageStored {
                                         id: mid,
@@ -429,7 +459,13 @@ impl SessionManager {
                                         attachments: None,
                                         marker: Some("tool_step".into()),
                                     },
-                                );
+                                ) {
+                                    tracing::error!(
+                                        session = %s.app_session_id,
+                                        tool = %tool_call_id,
+                                        "background tool journal append failed: {e}"
+                                    );
+                                }
                             }
                         }
                         (
@@ -526,7 +562,8 @@ impl SessionManager {
                     );
                 }
             }
-            AcpEvent::ProcessExited { .. } => {
+            AcpEvent::ProcessExited { code } => {
+                self.pending_soft_respawn.lock().remove(app_session_id);
                 let mut gate_invalidations: Vec<serde_json::Value> = Vec::new();
                 let mut bg = self.background.lock();
                 if let Some(mut s) = bg.remove(app_session_id) {
@@ -550,7 +587,13 @@ impl SessionManager {
                         crate::plan_chrome::mark_gate_stale(&s.app_session_id);
                         gate_invalidations.push(row);
                     }
-                    let _ = s.fsm.crash("Agent process exited (background)");
+                    let detail = match code {
+                        Some(status) => {
+                            format!("Agent process exited (background, code {status})")
+                        }
+                        None => "Agent process exited (background, EOF/unknown status)".into(),
+                    };
+                    let _ = s.fsm.crash(detail);
                     s.acp = None;
                     s.open_tool_ids.clear();
                     s.terminal_tool_ids.clear();

--- a/src-tauri/src/session_manager/journal.rs
+++ b/src-tauri/src/session_manager/journal.rs
@@ -111,7 +111,7 @@ impl SessionManager {
             }
         }
         let kept: Vec<_> = msgs.into_iter().take(cut).collect();
-        store::save_messages(&app_sid, &kept)?;
+        store::replace_messages(&app_sid, &kept)?;
 
         {
             let mut guard = self.inner.lock();
@@ -264,15 +264,17 @@ impl SessionManager {
 
         let kept = store::truncate_through_user_prompt(&msgs, target_prompt_index)?;
         let kept_count = kept.len();
-        store::save_messages(&app_sid, &kept)?;
+        store::replace_messages(&app_sid, &kept)?;
 
         // Touch meta updated_at for index sort.
-        if let Some(mut meta) = store::load_sessions_index()
-            .into_iter()
-            .find(|s| s.id == app_sid)
-        {
-            meta.updated_at = chrono::Utc::now();
-            let _ = store::update_session_meta(&meta);
+        let updated_at = chrono::Utc::now();
+        if let Ok(Some(meta)) = store::update_sessions_index(|list| {
+            let Some(meta) = list.iter_mut().find(|s| s.id == app_sid) else {
+                return Ok(None);
+            };
+            meta.updated_at = updated_at;
+            Ok(Some(meta.clone()))
+        }) {
             if live_match {
                 let mut guard = self.inner.lock();
                 if let Some(s) = guard.as_mut() {

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -41,7 +41,10 @@ mod routing_tests;
 #[cfg(test)]
 mod stall_tests;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicU64, Arc},
+};
 
 use parking_lot::Mutex;
 
@@ -64,6 +67,10 @@ pub struct SessionManager {
     pub(super) parked: Mutex<HashMap<String, ParkedAgent>>,
     /// Process prewarmed while the user is composing a new chat (no session yet).
     pub(super) prewarm: Mutex<PrewarmState>,
+    /// Generation token for cancellable prewarm tasks. A task that started
+    /// before recycle/route change must not publish a stale Ready child after
+    /// a newer prewarm has taken ownership of the slot.
+    pub(super) prewarm_epoch: AtomicU64,
     /// Tool identity learned from in_progress `tool_call` notifications
     /// (terminal `tool_call_update` payloads are status-only). Keyed by
     /// app session id → tool call id. See `remember_tool_identity`.
@@ -95,6 +102,7 @@ impl SessionManager {
             background: Mutex::new(HashMap::new()),
             parked: Mutex::new(HashMap::new()),
             prewarm: Mutex::new(PrewarmState::None),
+            prewarm_epoch: AtomicU64::new(0),
             tool_identities: std::sync::Mutex::new(std::collections::HashMap::new()),
             connect_lock: tokio::sync::Mutex::new(()),
             post_turn_journal_locks: Mutex::new(HashMap::new()),
@@ -105,6 +113,11 @@ impl SessionManager {
     /// Drop bookkeeping for a chat that no longer exists in the store.
     pub fn forget_deleted_session(&self, session_id: &str) {
         self.pending_soft_respawn.lock().remove(session_id);
+    }
+
+    pub(super) fn invalidate_prewarm_epoch(&self) {
+        self.prewarm_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
 
     pub(super) fn post_turn_journal_lock(

--- a/src-tauri/src/session_manager/process.rs
+++ b/src-tauri/src/session_manager/process.rs
@@ -20,28 +20,70 @@ use crate::store::{self, ChatMessageStored};
 
 use super::*;
 
+/// Count living ACP children by their process identity rather than by session
+/// map entries. Warm reuse intentionally leaves multiple session shells with
+/// the same `process_id` / `Arc<AcpClient>`, so counting entries can make a
+/// single child consume multiple pool slots.
+///
+/// A missing process id is counted conservatively as a distinct child. That
+/// should only occur during an incomplete connect / teardown, and collapsing
+/// unknown identities would let capacity accounting under-count real children.
+fn count_unique_alive_processes<I>(entries: I) -> u32
+where
+    I: IntoIterator<Item = (String, bool)>,
+{
+    let mut process_ids = HashSet::new();
+    let mut unknown_alive = 0u32;
+    for (process_id, alive) in entries {
+        if !alive {
+            continue;
+        }
+        if process_id.trim().is_empty() {
+            unknown_alive = unknown_alive.saturating_add(1);
+        } else {
+            process_ids.insert(process_id);
+        }
+    }
+    (process_ids.len() as u32).saturating_add(unknown_alive)
+}
+
+/// A parked entry is only a handle to a process. Never recycle it when that
+/// process identity is unknown or still has a live/background tenant.
+#[inline]
+fn process_recycle_is_blocked(process_id: &str, protected_process_ids: &HashSet<String>) -> bool {
+    process_id.trim().is_empty() || protected_process_ids.contains(process_id)
+}
+
 impl SessionManager {
     pub(super) fn active_process_count(&self) -> u32 {
-        let live = self
-            .inner
-            .lock()
-            .as_ref()
-            .and_then(|s| s.acp.as_ref())
-            .filter(|c| c.is_alive())
-            .is_some() as u32;
-        let background = self
-            .background
-            .lock()
-            .values()
-            .filter(|s| s.acp.as_ref().is_some_and(|c| c.is_alive()))
-            .count() as u32;
-        let parked = self
-            .parked
-            .lock()
-            .values()
-            .filter(|p| p.acp.is_alive())
-            .count() as u32;
-        live + background + parked
+        let mut entries = Vec::new();
+        {
+            let live = self.inner.lock();
+            if let Some(s) = live.as_ref() {
+                entries.push((
+                    s.process_id.clone(),
+                    s.acp.as_ref().is_some_and(|c| c.is_alive()),
+                ));
+            }
+        }
+        {
+            let background = self.background.lock();
+            entries.extend(background.values().map(|s| {
+                (
+                    s.process_id.clone(),
+                    s.acp.as_ref().is_some_and(|c| c.is_alive()),
+                )
+            }));
+        }
+        {
+            let parked = self.parked.lock();
+            entries.extend(
+                parked
+                    .values()
+                    .map(|p| (p.process_id.clone(), p.acp.is_alive())),
+            );
+        }
+        count_unique_alive_processes(entries)
     }
 
     /// Process ids that currently run a turn (live busy or demoted background).
@@ -50,19 +92,86 @@ impl SessionManager {
     #[allow(dead_code)] // kept for diagnostics; reuse now includes busy processes
     pub(super) fn busy_process_ids(&self) -> std::collections::HashSet<String> {
         let mut out = std::collections::HashSet::new();
-        if let Some(s) = self.inner.lock().as_ref() {
-            if Self::live_session_is_busy(s) {
-                if !s.process_id.is_empty() {
+        {
+            let live = self.inner.lock();
+            if let Some(s) = live.as_ref() {
+                if Self::live_session_is_busy(s)
+                    && s.acp.as_ref().is_some_and(|c| c.is_alive())
+                    && !s.process_id.is_empty()
+                {
                     out.insert(s.process_id.clone());
                 }
             }
         }
-        for s in self.background.lock().values() {
-            if !s.process_id.is_empty() {
-                out.insert(s.process_id.clone());
+        {
+            let background = self.background.lock();
+            for s in background.values() {
+                if Self::live_session_is_busy(s)
+                    && s.acp.as_ref().is_some_and(|c| c.is_alive())
+                    && !s.process_id.is_empty()
+                {
+                    out.insert(s.process_id.clone());
+                }
             }
         }
         out
+    }
+
+    /// Process ids with any living live/background tenant. This is deliberately
+    /// stricter than [`Self::busy_process_ids`] for parked reclamation: killing a
+    /// parked handle kills the whole child, including a Ready live shell that
+    /// has not yet become busy.
+    pub(super) fn live_or_background_process_ids(&self) -> HashSet<String> {
+        let mut out = HashSet::new();
+        {
+            let live = self.inner.lock();
+            if let Some(s) = live.as_ref() {
+                if s.acp.as_ref().is_some_and(|c| c.is_alive()) && !s.process_id.is_empty() {
+                    out.insert(s.process_id.clone());
+                }
+            }
+        }
+        {
+            let background = self.background.lock();
+            for s in background.values() {
+                if s.acp.as_ref().is_some_and(|c| c.is_alive()) && !s.process_id.is_empty() {
+                    out.insert(s.process_id.clone());
+                }
+            }
+        }
+        out
+    }
+
+    /// Whether another session tenant still owns `process_id`.
+    /// Process-level ACP shutdown must never be decided from one session map
+    /// entry when an older shared-process state may still be present. Include
+    /// parked co-tenants too: dropping a background/live handle can otherwise
+    /// kill a Ready peer that is still represented in the parked map.
+    pub(super) fn has_other_process_tenant(
+        &self,
+        process_id: &str,
+        except_session_id: &str,
+    ) -> bool {
+        if process_id.trim().is_empty() {
+            return false;
+        }
+        {
+            let live = self.inner.lock();
+            if live.as_ref().is_some_and(|s| {
+                s.app_session_id != except_session_id
+                    && s.process_id == process_id
+                    && s.acp.as_ref().is_some_and(|c| c.is_alive())
+            }) {
+                return true;
+            }
+        }
+        self.background.lock().values().any(|s| {
+            s.app_session_id != except_session_id
+                && s.process_id == process_id
+                && s.acp.as_ref().is_some_and(|c| c.is_alive())
+        }) || self.parked.lock().values().any(|p| {
+            p.app_session_id != except_session_id && p.process_id == process_id && p.acp.is_alive()
+        })
     }
 
     pub(super) fn max_concurrent_from_settings() -> u32 {
@@ -114,20 +223,26 @@ impl SessionManager {
     /// Live + background process count (excludes reclaimable parked idle).
     /// Used for diagnostics / limit messaging after parked reclaim.
     pub(super) fn busy_process_count(&self) -> u32 {
-        let live = self
-            .inner
-            .lock()
-            .as_ref()
-            .and_then(|s| s.acp.as_ref())
-            .filter(|c| c.is_alive())
-            .is_some() as u32;
-        let background = self
-            .background
-            .lock()
-            .values()
-            .filter(|s| s.acp.as_ref().is_some_and(|c| c.is_alive()))
-            .count() as u32;
-        live + background
+        let mut entries = Vec::new();
+        {
+            let live = self.inner.lock();
+            if let Some(s) = live.as_ref() {
+                entries.push((
+                    s.process_id.clone(),
+                    s.acp.as_ref().is_some_and(|c| c.is_alive()),
+                ));
+            }
+        }
+        {
+            let background = self.background.lock();
+            entries.extend(background.values().map(|s| {
+                (
+                    s.process_id.clone(),
+                    s.acp.as_ref().is_some_and(|c| c.is_alive()),
+                )
+            }));
+        }
+        count_unique_alive_processes(entries)
     }
 
     /// True while a turn is still in flight — must demote to `background`, never park.
@@ -690,46 +805,51 @@ impl SessionManager {
 
     /// Kill oldest parked agents until `need_slots` are freed (or none left).
     /// Parked = Ready idle; never touches background busy turns.
-    pub(super) async fn free_parked_for_capacity(&self, app: &AppHandle, need_slots: u32) {
+    pub(super) async fn free_parked_for_capacity(&self, app: &AppHandle, need_slots: u32) -> usize {
         if need_slots == 0 {
-            return;
+            return 0;
         }
         // One slot = one process. Parked entries may now SHARE a process, so
         // recycle whole process groups (all sessions on the oldest process),
         // never individual entries (killing one session's handle would kill
         // the shared CLI under its co-tenants).
+        let mut freed = 0usize;
         for _ in 0..need_slots {
+            // Capacity reclaim runs under `connect_lock` in the normal spawn
+            // path. Protect every living live/background process anyway: a
+            // parked entry can be a stale co-tenant handle left behind by warm
+            // reuse, and killing it would terminate the active child.
+            let protected_process_ids = self.live_or_background_process_ids();
             let victim = {
                 let mut parked = self.parked.lock();
-                let mut groups: HashMap<String, Vec<ParkedAgent>> = HashMap::new();
-                let keys: Vec<String> = parked.keys().cloned().collect();
-                for k in keys {
-                    if let Some(p) = parked.remove(&k) {
-                        groups.entry(p.process_id.clone()).or_default().push(p);
-                    }
-                }
-                let oldest_pid = groups
-                    .iter()
-                    .min_by_key(|(_, es)| {
-                        es.iter()
-                            .map(|p| p.last_activity)
-                            .min()
-                            .unwrap_or(std::time::Instant::now())
-                    })
-                    .map(|(pid, _)| pid.clone());
+                // Select only an unshared process group. Do not temporarily
+                // drain all entries: a concurrent reader should never observe
+                // unrelated parked sessions disappearing from the pool.
+                let oldest_pid = parked
+                    .values()
+                    .filter(|p| !process_recycle_is_blocked(&p.process_id, &protected_process_ids))
+                    .min_by_key(|p| p.last_activity)
+                    .map(|p| p.process_id.clone());
                 match oldest_pid {
-                    Some(pid) => {
-                        let entries = groups.remove(&pid).unwrap_or_default();
-                        let mut rest: Vec<ParkedAgent> = Vec::new();
-                        for (_, es) in groups {
-                            rest.extend(es);
-                        }
-                        for p in rest {
-                            parked.insert(p.app_session_id.clone(), p);
-                        }
-                        Some((pid, entries))
-                    }
                     None => None,
+                    Some(pid) => {
+                        let keys: Vec<String> = parked
+                            .iter()
+                            .filter(|(_, p)| p.process_id == pid)
+                            .map(|(sid, _)| sid.clone())
+                            .collect();
+                        let mut entries = Vec::with_capacity(keys.len());
+                        for sid in keys {
+                            if let Some(p) = parked.remove(&sid) {
+                                entries.push(p);
+                            }
+                        }
+                        if entries.is_empty() {
+                            None
+                        } else {
+                            Some((pid, entries))
+                        }
+                    }
                 }
             };
             let Some((pid, entries)) = victim else {
@@ -745,7 +865,9 @@ impl SessionManager {
             for p in entries {
                 Self::emit_idle_recycled(app, &p.app_session_id, "capacity");
             }
+            freed += 1;
         }
+        freed
     }
 
     /// Move every finished `background` turn into `parked`.
@@ -777,7 +899,7 @@ impl SessionManager {
         let active = self.active_process_count();
         let need = parked_slots_to_free_for_spawn(active, max_concurrent);
         if need > 0 {
-            self.free_parked_for_capacity(app, need).await;
+            let _ = self.free_parked_for_capacity(app, need).await;
         }
         // If still full (e.g. free returned fewer), keep freeing until spawnable or empty.
         while !can_spawn_process(self.active_process_count(), max_concurrent) {
@@ -785,12 +907,21 @@ impl SessionManager {
             if parked_n == 0 {
                 break;
             }
-            self.free_parked_for_capacity(app, 1).await;
+            if self.free_parked_for_capacity(app, 1).await == 0 {
+                // All remaining parked handles belong to a living process
+                // that is still owned by another tenant. Retrying forever
+                // would spin the connect task while no safe victim exists.
+                break;
+            }
         }
     }
 
     /// Idle recycle for live + parked (I03).
     pub(super) async fn tick_idle_recycle(&self, app: &AppHandle) {
+        // Serialize watchdog recycling with connect/park/unpark. Without this
+        // boundary a warm-reuse connect can bind a new live session to a PID
+        // immediately after the watchdog decides that a parked handle is idle.
+        let _connect_guard = self.connect_lock.lock().await;
         let idle_mins = Self::idle_minutes_from_settings();
         let now = Instant::now();
         self.sweep_dead_parked();
@@ -801,6 +932,10 @@ impl SessionManager {
         // Parked first — recycle whole process groups when EVERY session on the
         // process is idle-expired (a shared process must not be killed while a
         // co-tenant session is still warm).
+        // A parked handle may still share its ACP with a live/background
+        // tenant after warm reuse. Protect every living tenant PID (not only
+        // busy ones) before any process-level kill.
+        let protected_process_ids = self.live_or_background_process_ids();
         let expired_groups: Vec<(String, Vec<ParkedAgent>)> = {
             let mut parked = self.parked.lock();
             let mut groups: HashMap<String, Vec<ParkedAgent>> = HashMap::new();
@@ -813,9 +948,10 @@ impl SessionManager {
             let mut keep: HashMap<String, ParkedAgent> = HashMap::new();
             let mut expired: Vec<(String, Vec<ParkedAgent>)> = Vec::new();
             for (pid, entries) in groups {
-                if entries
-                    .iter()
-                    .all(|p| is_idle_expired(p.last_activity, idle_mins, now))
+                if !process_recycle_is_blocked(&pid, &protected_process_ids)
+                    && entries
+                        .iter()
+                        .all(|p| is_idle_expired(p.last_activity, idle_mins, now))
                 {
                     expired.push((pid, entries));
                 } else {
@@ -842,33 +978,90 @@ impl SessionManager {
 
         // Live: only true idle Ready (never mid-turn / open tools). Killing a
         // live process also reaps any parked co-tenant entries sharing it.
-        let live_kill = {
-            let mut guard = self.inner.lock();
-            if let Some(s) = guard.as_mut() {
+        let live_candidate = {
+            let guard = self.inner.lock();
+            guard.as_ref().and_then(|s| {
                 let idle = is_idle_expired(s.last_activity, idle_mins, now);
-                let ready_idle =
-                    matches!(s.fsm.state(), SessionState::Ready) && !Self::live_session_is_busy(s);
+                let ready_idle = matches!(s.fsm.state(), SessionState::Ready)
+                    && !Self::live_session_is_busy(s)
+                    && s.acp.as_ref().is_some_and(|c| c.is_alive());
                 if idle && ready_idle {
-                    if let Some(acp) = s.acp.take() {
-                        s.fsm.soft_disconnect();
-                        s.needs_history_bootstrap = false;
-                        Some((s.app_session_id.clone(), s.process_id.clone(), acp))
-                    } else {
-                        None
-                    }
+                    Some((s.app_session_id.clone(), s.process_id.clone()))
                 } else {
                     None
                 }
-            } else {
-                None
+            })
+        };
+        let live_shared_with_background = live_candidate.as_ref().is_some_and(|(_, pid)| {
+            self.background
+                .lock()
+                .values()
+                .any(|s| s.process_id == *pid && s.acp.as_ref().is_some_and(|c| c.is_alive()))
+        });
+        if live_shared_with_background {
+            if let Some((sid, pid)) = live_candidate.as_ref() {
+                tracing::debug!(
+                    session = %sid,
+                    process = %pid,
+                    "idle recycle live skipped: shared background tenant"
+                );
             }
+        }
+        let live_kill = if live_shared_with_background {
+            None
+        } else if let Some((candidate_sid, candidate_pid)) = live_candidate {
+            // Re-check the candidate while taking the ACP. The connect lock
+            // prevents map moves, but event handling can still mark a turn
+            // terminal between the first snapshot and this point.
+            let mut guard = self.inner.lock();
+            match guard.as_mut() {
+                None => None,
+                Some(s) if s.app_session_id != candidate_sid || s.process_id != candidate_pid => {
+                    None
+                }
+                Some(s) => {
+                    let idle = is_idle_expired(s.last_activity, idle_mins, now);
+                    let ready_idle = matches!(s.fsm.state(), SessionState::Ready)
+                        && !Self::live_session_is_busy(s)
+                        && s.acp.as_ref().is_some_and(|c| c.is_alive());
+                    if idle && ready_idle {
+                        if let Some(acp) = s.acp.take() {
+                            s.fsm.soft_disconnect();
+                            s.needs_history_bootstrap = false;
+                            Some((s.app_session_id.clone(), s.process_id.clone(), acp))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                }
+            }
+        } else {
+            None
         };
         if let Some((sid, pid, acp)) = live_kill {
             tracing::info!("idle recycle live session={sid} after {idle_mins}min");
+            // Remove parked co-tenants before killing so their eventual
+            // ProcessExited notification cannot race a later reconnect.
+            let parked_cotenants = if pid.is_empty() {
+                Vec::new()
+            } else {
+                let mut parked = self.parked.lock();
+                let keys: Vec<String> = parked
+                    .iter()
+                    .filter(|(_, p)| p.process_id == pid)
+                    .map(|(session_id, _)| session_id.clone())
+                    .collect();
+                keys.into_iter()
+                    .filter_map(|session_id| parked.remove(&session_id))
+                    .collect::<Vec<_>>()
+            };
             acp.kill().await;
-            // Co-tenants on the same process lose their process too.
-            self.parked.lock().retain(|_, p| p.process_id != pid);
             Self::emit_idle_recycled(app, &sid, "idle");
+            for p in parked_cotenants {
+                Self::emit_idle_recycled(app, &p.app_session_id, "idle");
+            }
             Self::emit_state(app, &self.snapshot());
         }
     }
@@ -1064,7 +1257,7 @@ impl SessionManager {
         } else {
             format!("**{code}**\n\n{detail}")
         };
-        let _ = store::append_message(
+        if let Err(e) = store::append_message(
             &s.app_session_id,
             ChatMessageStored {
                 id: mid.clone(),
@@ -1076,9 +1269,13 @@ impl SessionManager {
                 attachments: None,
                 marker: None,
             },
-        );
+        ) {
+            tracing::error!(session = %s.app_session_id, "turn-error journal append failed: {e}");
+        }
         s.meta.updated_at = chrono::Utc::now();
-        let _ = store::update_session_meta(&s.meta);
+        if let Err(e) = store::update_session_meta(&s.meta) {
+            tracing::warn!(session = %s.app_session_id, "turn-error metadata update failed: {e}");
+        }
         // Clear *all* busy markers (including deferred prompt_complete / open tools).
         // Leaving them set after fail_with left the session as Disconnected+busy,
         // so connect no-oped forever and local sends failed while Remote IM still worked.
@@ -1094,5 +1291,42 @@ impl SessionManager {
                 "content": content,
             }),
         );
+    }
+}
+
+#[cfg(test)]
+mod process_accounting_tests {
+    use super::{count_unique_alive_processes, process_recycle_is_blocked};
+    use std::collections::HashSet;
+
+    #[test]
+    fn shared_process_id_counts_once_across_session_slots() {
+        let count = count_unique_alive_processes([
+            ("proc-shared".to_string(), true), // live
+            ("proc-shared".to_string(), true), // background co-tenant
+            ("proc-shared".to_string(), true), // parked co-tenant
+            ("proc-other".to_string(), true),
+            ("proc-dead".to_string(), false),
+        ]);
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn unknown_alive_processes_are_counted_conservatively() {
+        let count = count_unique_alive_processes([
+            (String::new(), true),
+            (String::new(), true),
+            ("proc-dead".to_string(), false),
+        ]);
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn parked_recycle_is_blocked_for_shared_or_unknown_processes() {
+        let protected = HashSet::from(["proc-busy".to_string(), "proc-ready".to_string()]);
+        assert!(process_recycle_is_blocked("proc-busy", &protected));
+        assert!(process_recycle_is_blocked("proc-ready", &protected));
+        assert!(process_recycle_is_blocked("", &protected));
+        assert!(!process_recycle_is_blocked("proc-idle", &protected));
     }
 }

--- a/src-tauri/src/session_manager/routing_tests.rs
+++ b/src-tauri/src/session_manager/routing_tests.rs
@@ -396,6 +396,29 @@ fn route_stamped_foreign_load_never_hits_parked_co_tenant() {
 }
 
 #[test]
+fn route_stamped_event_does_not_wildcard_unbound_live_hint() {
+    // During a connect/open transition the live slot may not have recorded
+    // its agent id yet. A stamped event from another session must be dropped,
+    // not accepted merely because the process id matches.
+    let live = hint("chat-live", "proc-p", None, true);
+    let parked = [hint("chat-other", "proc-p", Some("agent-other"), false)];
+    assert_eq!(
+        resolve_turn_event_route("proc-p", Some("agent-other"), Some(&live), &[], &parked),
+        TurnEventRoute::Drop
+    );
+}
+
+#[test]
+fn route_stamped_event_does_not_wildcard_unbound_background_hint() {
+    let live = hint("chat-live", "proc-other", Some("agent-live"), false);
+    let bg = [hint("chat-bg", "proc-p", None, true)];
+    assert_eq!(
+        resolve_turn_event_route("proc-p", Some("agent-foreign"), Some(&live), &bg, &[]),
+        TurnEventRoute::Drop
+    );
+}
+
+#[test]
 fn route_unstamped_load_on_shared_process_does_not_rescue_parked() {
     // Before fix: unstamped load replay → rescue parked A with pif=true → journal poison.
     let live = hint("chat-b", "proc-p", Some("agent-b"), false);

--- a/src-tauri/src/session_manager/stream.rs
+++ b/src-tauri/src/session_manager/stream.rs
@@ -66,6 +66,11 @@ pub(crate) fn resolve_turn_event_route(
 ) -> TurnEventRoute {
     if let Some(sid) = agent_session_id {
         if live.is_some_and(|l| {
+            // A stamped event is authoritative: an unknown owner must not be
+            // treated as a wildcard. During connect/open the live hint can
+            // briefly lack an agent id; dropping that handshake-side event is
+            // safer than allowing a late foreign session update to mutate the
+            // current chat.
             l.process_id == process_id && l.agent_session_id.as_deref() == Some(sid)
         }) {
             return TurnEventRoute::Live;
@@ -404,7 +409,7 @@ impl SessionManager {
         // Neutral chips: user stop + generic mid-run cancel. Infra / permission
         // hard ends stay is_error so history can highlight them if needed.
         let is_error = !matches!(reason, "user_stop" | "cancelled");
-        let _ = store::append_message(
+        if let Err(e) = store::append_message(
             &s.app_session_id,
             ChatMessageStored {
                 id: mid.clone(),
@@ -416,9 +421,13 @@ impl SessionManager {
                 attachments: None,
                 marker: Some("turn_cancelled".into()),
             },
-        );
+        ) {
+            tracing::error!(session = %s.app_session_id, "turn-cancelled journal append failed: {e}");
+        }
         s.meta.updated_at = chrono::Utc::now();
-        let _ = store::update_session_meta(&s.meta);
+        if let Err(e) = store::update_session_meta(&s.meta) {
+            tracing::warn!(session = %s.app_session_id, "turn-cancelled metadata update failed: {e}");
+        }
         if let Some(app) = app {
             let _ = app.emit(
                 "session://turn_marker",
@@ -716,25 +725,37 @@ impl SessionManager {
         } else {
             Some(s.stream_attachments.clone())
         };
-        let _ = store::append_message(
-            &s.app_session_id,
-            ChatMessageStored {
-                id: mid,
-                role: "assistant".into(),
-                content: s.stream_buf.clone(),
-                thought: if s.stream_thought.is_empty() {
-                    None
-                } else {
-                    Some(s.stream_thought.clone())
-                },
-                created_at: chrono::Utc::now(),
-                is_error: false,
-                attachments: atts,
-                marker: None,
+        let message = ChatMessageStored {
+            id: mid,
+            role: "assistant".into(),
+            content: s.stream_buf.clone(),
+            thought: if s.stream_thought.is_empty() {
+                None
+            } else {
+                Some(s.stream_thought.clone())
             },
-        );
+            created_at: chrono::Utc::now(),
+            is_error: false,
+            attachments: atts,
+            marker: None,
+        };
+        if let Err(e) = store::append_message(&s.app_session_id, message) {
+            // Keep the throttle watermark untouched so the next chunk retries
+            // the durable write instead of silently advancing past a lost
+            // assistant tail.
+            tracing::error!(
+                session = %s.app_session_id,
+                "stream journal append failed: {e}"
+            );
+            return;
+        }
         s.meta.updated_at = chrono::Utc::now();
-        let _ = store::update_session_meta(&s.meta);
+        if let Err(e) = store::update_session_meta(&s.meta) {
+            tracing::warn!(
+                session = %s.app_session_id,
+                "stream session metadata update failed after journal append: {e}"
+            );
+        }
         s.journal_throttle.mark_flushed(now);
         if force {
             s.journal_throttle.reset();

--- a/src-tauri/src/session_manager/turn.rs
+++ b/src-tauri/src/session_manager/turn.rs
@@ -146,10 +146,10 @@ impl SessionManager {
                 agent_prompt = format!("{hint}\n{agent_prompt}");
             }
 
-            // persist user message (display form for skill chips on reload)
-            // Journal stores the user-facing turn only — not the bootstrap wrapper.
-            // Attachments are structured so history reloads image/file cards.
-            let _ = store::append_message(
+            // Persist the user-facing turn before dispatching the prompt. A
+            // failed journal write must not leave the runtime in Streaming
+            // with a prompt that cannot be reconstructed after reload.
+            if let Err(e) = store::append_message(
                 &s.app_session_id,
                 ChatMessageStored {
                     id: Uuid::new_v4().to_string(),
@@ -161,7 +161,24 @@ impl SessionManager {
                     attachments: journal_attachments.clone(),
                     marker: None,
                 },
-            );
+            ) {
+                let _ = s.fsm.end_stream();
+                s.prompt_in_flight = false;
+                s.sent_prompt_this_visit = false;
+                s.active_turn_id = None;
+                s.streaming_message_id = None;
+                s.stream_buf.clear();
+                s.stream_thought.clear();
+                s.stream_last_was_assistant = false;
+                s.stream_attachments.clear();
+                s.journal_throttle.reset();
+                s.open_tool_ids.clear();
+                s.open_tool_seen_at.clear();
+                s.terminal_tool_ids.clear();
+                s.deferred_prompt_complete = None;
+                s.saw_model_output = false;
+                return Err(format!("JOURNAL_WRITE_FAILED: {e}"));
+            }
             Ok((
                 s.backend.clone(),
                 s.app_session_id.clone(),
@@ -175,7 +192,10 @@ impl SessionManager {
         drop(journal_guard);
         let (backend, app_sid, acp, agent_sid, agent_prompt, message_id, turn_id) = match open {
             Some(Ok(v)) => v,
-            Some(Err(e)) => return Err(e),
+            Some(Err(e)) => {
+                self.emit_for_session(&app, &app_sid);
+                return Err(e);
+            }
             None => {
                 return Err(format!(
                     "{}: chat {app_sid} has no live agent process — reconnect and retry",
@@ -183,6 +203,12 @@ impl SessionManager {
                 ));
             }
         };
+        // The session slot is now in `Streaming` and owns its ACP client. Do
+        // not hold the global connect/park lock while host vision or another
+        // side-channel performs network/CLI work (official vision can take
+        // minutes). Keeping the guard here used to block every other chat's
+        // connect/send path until that preparation completed.
+        drop(_focus_guard);
         // Host side-channels before main model (vision first, then X). Emit tool
         // chips immediately so the UI shows waiting state instead of freezing.
         // Copy is non-technical (no `grok -p` / command lines in chip detail).
@@ -454,6 +480,10 @@ impl SessionManager {
                     if record_error {
                         mgr.emit_for_session(&app2, &turn_sid);
                     }
+                    // A policy/effort change queued during this turn must be
+                    // applied once the prompt RPC is terminal; otherwise the
+                    // next ready fast-path promotes the stale ACP forever.
+                    mgr.flush_pending_soft_respawn(&app2, &turn_sid).await;
                 }
                 Ok(()) => {
                     // #522: even if PromptComplete events were dropped/raced,
@@ -541,6 +571,10 @@ impl SessionManager {
                             }),
                         );
                     }
+                    // Apply deferred process-level settings only after the
+                    // final journal reconcile has had a chance to read the
+                    // completed turn from the agent's disk log.
+                    mgr.flush_pending_soft_respawn(&app2, &turn_sid).await;
                 }
             }
         });

--- a/src-tauri/src/session_manager/types.rs
+++ b/src-tauri/src/session_manager/types.rs
@@ -861,10 +861,12 @@ pub(super) fn journal_host_tool_step(
             slot.content = content;
             slot.marker = Some("tool_step".into());
             slot.is_error = matches!(st, "failed" | "error");
-            let _ = store::save_messages(app_sid, &msgs);
+            if let Err(e) = store::save_messages(app_sid, &msgs) {
+                tracing::error!(session = %app_sid, tool = %tool_call_id, "host tool journal update failed: {e}");
+            }
         }
     } else {
-        let _ = store::append_message(
+        if let Err(e) = store::append_message(
             app_sid,
             ChatMessageStored {
                 id: mid,
@@ -876,7 +878,9 @@ pub(super) fn journal_host_tool_step(
                 attachments: None,
                 marker: Some("tool_step".into()),
             },
-        );
+        ) {
+            tracing::error!(session = %app_sid, tool = %tool_call_id, "host tool journal append failed: {e}");
+        }
     }
 }
 

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -969,22 +969,19 @@ pub fn row_should_lift_official_high_to_xhigh(
 }
 
 fn migrate_official_effort_xhigh_rows(global_model_id: Option<&str>) {
-    let mut sessions = load_sessions_index();
-    let mut sessions_changed = false;
-    for s in &mut sessions {
-        if row_should_lift_official_high_to_xhigh(
-            s.model_id.as_deref(),
-            s.effort.as_deref(),
-            global_model_id,
-        ) {
-            s.effort = Some(DEFAULT_OFFICIAL_EFFORT.into());
-            sessions_changed = true;
+    if let Err(e) = update_sessions_index(|sessions| {
+        for s in sessions {
+            if row_should_lift_official_high_to_xhigh(
+                s.model_id.as_deref(),
+                s.effort.as_deref(),
+                global_model_id,
+            ) {
+                s.effort = Some(DEFAULT_OFFICIAL_EFFORT.into());
+            }
         }
-    }
-    if sessions_changed {
-        if let Err(e) = save_sessions_index(&sessions) {
-            tracing::warn!("effort row migration: sessions_index: {e}");
-        }
+        Ok(())
+    }) {
+        tracing::warn!("effort row migration: sessions_index: {e}");
     }
     let mut projects = load_projects();
     let mut projects_changed = false;
@@ -1129,17 +1126,14 @@ fn migrate_legacy_general_project(list: &mut Vec<Project>) {
 }
 
 fn rehome_general_sessions() {
-    let mut sessions: Vec<SessionMeta> = read_json_recover(&sessions_index_file());
-    let mut dirty = false;
-    for s in &mut sessions {
-        if s.project_id.as_deref() == Some(GENERAL_PROJECT_ID) {
-            s.project_id = None;
-            dirty = true;
+    let _ = update_sessions_index(|sessions| {
+        for s in sessions {
+            if s.project_id.as_deref() == Some(GENERAL_PROJECT_ID) {
+                s.project_id = None;
+            }
         }
-    }
-    if dirty {
-        let _ = write_json(&sessions_index_file(), &sessions);
-    }
+        Ok(())
+    });
 }
 
 pub fn save_projects(list: &[Project]) -> Result<(), String> {
@@ -1501,6 +1495,69 @@ pub fn save_sessions_index(list: &[SessionMeta]) -> Result<(), String> {
     write_json(&sessions_index_file(), &list)
 }
 
+/// Atomically load, mutate, and persist the sessions index.
+///
+/// The file lock must cover the *entire* read-modify-write transaction.  A
+/// lock around only `save_sessions_index` still allows two App instances to
+/// read the same stale snapshot and overwrite one another's session metadata.
+/// Callers receive their mutation result only after a required replacement
+/// write has completed successfully, so a failed write cannot be mistaken for
+/// a commit. No-op mutations avoid touching the file.
+pub fn update_sessions_index<R>(
+    mutate: impl FnOnce(&mut Vec<SessionMeta>) -> Result<R, String>,
+) -> Result<R, String> {
+    let _ = ensure_app_dirs();
+    let path = sessions_index_file();
+    crate::store_lock::with_exclusive_lock(&path, || {
+        let mut list: Vec<SessionMeta> = read_json_recover(&path);
+        sort_sessions_by_pin_then_updated(&mut list);
+        let before = serde_json::to_vec(&list).map_err(|e| e.to_string())?;
+        let result = mutate(&mut list)?;
+        sort_sessions_by_pin_then_updated(&mut list);
+        let serialized = serde_json::to_string_pretty(&list).map_err(|e| e.to_string())?;
+        // Avoid rewriting the index for no-op migrations (load_projects calls
+        // the legacy rehome check on every read), while still keeping the
+        // comparison inside the transaction boundary.
+        let after = serde_json::to_vec(&list).map_err(|e| e.to_string())?;
+        if before != after {
+            crate::store_lock::write_bytes_replace(&path, serialized.as_bytes())?;
+        }
+        Ok(result)
+    })
+}
+
+/// Update a session row under the index transaction boundary.
+///
+/// This small convenience keeps external callers from accidentally falling
+/// back to `load_sessions_index` + `save_sessions_index` and reintroducing a
+/// stale-snapshot race.
+pub fn update_session_index_row(meta: &SessionMeta) -> Result<SessionMeta, String> {
+    let meta = meta.clone();
+    update_sessions_index(move |list| {
+        if let Some(slot) = list.iter_mut().find(|s| s.id == meta.id) {
+            *slot = meta.clone();
+        } else {
+            list.insert(0, meta.clone());
+        }
+        Ok(meta)
+    })
+}
+
+/// Mutate one session row while holding the sessions-index transaction lock.
+fn update_session_row<R>(
+    id: &str,
+    mutate: impl FnOnce(&mut SessionMeta) -> Result<R, String>,
+) -> Result<R, String> {
+    let id = id.to_string();
+    update_sessions_index(move |list| {
+        let session = list
+            .iter_mut()
+            .find(|s| s.id == id)
+            .ok_or_else(|| "session not found".to_string())?;
+        mutate(session)
+    })
+}
+
 pub fn create_session(
     project_id: Option<String>,
     title: Option<String>,
@@ -1539,9 +1596,13 @@ pub fn create_session(
         fork_agent_session: false,
         no_ask_user: None,
     };
-    let mut list = load_sessions_index();
-    list.insert(0, meta.clone());
-    save_sessions_index(&list)?;
+    update_sessions_index({
+        let meta = meta.clone();
+        move |list| {
+            list.insert(0, meta);
+            Ok(())
+        }
+    })?;
     let dir = session_dir(&id);
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     write_json(&dir.join("messages.json"), &Vec::<ChatMessageStored>::new())?;
@@ -1549,19 +1610,15 @@ pub fn create_session(
 }
 
 pub fn update_session_meta(meta: &SessionMeta) -> Result<(), String> {
-    let mut list = load_sessions_index();
-    if let Some(s) = list.iter_mut().find(|s| s.id == meta.id) {
-        *s = meta.clone();
-    } else {
-        list.insert(0, meta.clone());
-    }
-    save_sessions_index(&list)
+    update_session_index_row(meta).map(|_| ())
 }
 
 pub fn delete_session(id: &str) -> Result<(), String> {
-    let mut list = load_sessions_index();
-    list.retain(|s| s.id != id);
-    save_sessions_index(&list)?;
+    let id_for_index = id.to_string();
+    update_sessions_index(move |list| {
+        list.retain(|s| s.id != id_for_index);
+        Ok(())
+    })?;
     let dir = session_dir(id);
     let _ = fs::remove_dir_all(dir);
     Ok(())
@@ -1572,55 +1629,35 @@ pub fn rename_session(id: &str, title: &str) -> Result<SessionMeta, String> {
     if title.is_empty() {
         return Err("title empty".into());
     }
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.title = title.to_string();
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.title = title.to_string();
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 pub fn set_session_scheduled(id: &str, scheduled: bool) -> Result<SessionMeta, String> {
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.scheduled = scheduled;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.scheduled = scheduled;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 pub fn set_session_archived(id: &str, archived: bool) -> Result<SessionMeta, String> {
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.archived = archived;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.archived = archived;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 pub fn set_session_pinned(id: &str, pinned: bool) -> Result<SessionMeta, String> {
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.pinned = pinned;
-    // Do not bump updated_at — pin is organizational (same as project pin).
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.pinned = pinned;
+        // Do not bump updated_at — pin is organizational (same as project pin).
+        Ok(s.clone())
+    })
 }
 
 /// Attach or clear worktree linkage on a session (path/branch/badge flag).
@@ -1636,23 +1673,18 @@ pub fn set_session_worktree(
     let branch = worktree_branch
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    if let Some(p) = path {
-        s.worktree_path = Some(p);
-        s.worktree_branch = branch;
-        s.is_worktree_session = true;
-    } else {
-        s.worktree_path = None;
-        s.worktree_branch = None;
-        s.is_worktree_session = false;
-    }
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        if let Some(p) = path {
+            s.worktree_path = Some(p);
+            s.worktree_branch = branch;
+            s.is_worktree_session = true;
+        } else {
+            s.worktree_path = None;
+            s.worktree_branch = None;
+            s.is_worktree_session = false;
+        }
+        Ok(s.clone())
+    })
 }
 
 /// Soft cap aligned with the frontend helper (~256 KiB).
@@ -1686,16 +1718,11 @@ pub fn set_session_json_schema(
             }
         }
     };
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.json_schema = normalized;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.json_schema = normalized;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 /// Normalize session plugin dirs: trim, drop empty, dedupe (first wins).
@@ -1718,16 +1745,11 @@ pub fn normalize_plugin_dirs(dirs: impl IntoIterator<Item = String>) -> Vec<Stri
 /// Set session-only `--plugin-dir` paths (empty clears). Does not touch global plugins.
 pub fn set_session_plugin_dirs(id: &str, plugin_dirs: Vec<String>) -> Result<SessionMeta, String> {
     let dirs = normalize_plugin_dirs(plugin_dirs);
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.plugin_dirs = dirs;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.plugin_dirs = dirs;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 /// Soft cap aligned with the frontend helper (~32 KiB).
@@ -1780,16 +1802,11 @@ pub fn set_session_extra_rules(
     extra_rules: Option<String>,
 ) -> Result<SessionMeta, String> {
     let normalized = sanitize_extra_rules(extra_rules);
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.extra_rules = normalized;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.extra_rules = normalized;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 /// Set or clear per-session max agent turns (`grok --max-turns` on next spawn).
@@ -1801,16 +1818,11 @@ pub fn set_session_max_agent_turns(
     max_agent_turns: Option<u32>,
 ) -> Result<SessionMeta, String> {
     let normalized = crate::acp_client::normalize_max_agent_turns(max_agent_turns);
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.max_agent_turns = normalized;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.max_agent_turns = normalized;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 /// Set or clear per-session system prompt override
@@ -1819,16 +1831,11 @@ pub fn set_session_max_agent_turns(
 /// Set or clear per-session `--no-ask-user` override.
 /// `None` inherits global `AppSettings.no_ask_user`.
 pub fn set_session_no_ask_user(id: &str, no_ask_user: Option<bool>) -> Result<SessionMeta, String> {
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.no_ask_user = no_ask_user;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.no_ask_user = no_ask_user;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 pub fn set_session_system_prompt_override(
@@ -1836,16 +1843,11 @@ pub fn set_session_system_prompt_override(
     system_prompt_override: Option<String>,
 ) -> Result<SessionMeta, String> {
     let normalized = sanitize_system_prompt_override(system_prompt_override);
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.system_prompt_override = normalized;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.system_prompt_override = normalized;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 /// Bind (or clear) a session's project folder. Used to attach orphan / legacy
@@ -1863,39 +1865,129 @@ pub fn set_session_project(id: &str, project_id: Option<String>) -> Result<Sessi
     } else {
         let _ = ensure_general_workspace_dir();
     }
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    s.project_id = pid;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        s.project_id = pid;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 /// Archive every non-archived session under a project.
 pub fn archive_project_sessions(project_id: &str) -> Result<usize, String> {
-    let mut list = load_sessions_index();
-    let mut n = 0usize;
-    for s in list.iter_mut() {
-        if s.project_id.as_deref() == Some(project_id) && !s.archived {
-            s.archived = true;
-            s.updated_at = Utc::now();
-            n += 1;
+    let project_id = project_id.to_string();
+    update_sessions_index(move |list| {
+        let mut n = 0usize;
+        for s in list.iter_mut() {
+            if s.project_id.as_deref() == Some(project_id.as_str()) && !s.archived {
+                s.archived = true;
+                s.updated_at = Utc::now();
+                n += 1;
+            }
         }
-    }
-    save_sessions_index(&list)?;
-    Ok(n)
+        Ok(n)
+    })
 }
 
 pub fn load_messages(session_id: &str) -> Vec<ChatMessageStored> {
     read_json_recover(&session_dir(session_id).join("messages.json"))
 }
 
+fn write_messages_locked(path: &Path, messages: &[ChatMessageStored]) -> Result<(), String> {
+    let serialized = serde_json::to_string_pretty(messages).map_err(|e| e.to_string())?;
+    crate::store_lock::write_bytes_replace(path, serialized.as_bytes())
+}
+
+/// Merge an incoming message snapshot with the latest on-disk journal.
+///
+/// Stream/tool writers use per-message ids and may append while a stale
+/// snapshot is being prepared.  Keep rows that are absent from the incoming
+/// snapshot, and for duplicate ids prefer the row with the newer
+/// `created_at` revision.  New rows are inserted relative to their nearest
+/// incoming neighbours so reconciliation does not scramble transcript order.
+fn merge_message_snapshots(
+    existing: &[ChatMessageStored],
+    incoming: &[ChatMessageStored],
+) -> Vec<ChatMessageStored> {
+    use std::collections::{HashMap, HashSet};
+
+    let mut merged = existing.to_vec();
+    let mut positions: HashMap<String, usize> = merged
+        .iter()
+        .enumerate()
+        .map(|(i, m)| (m.id.clone(), i))
+        .collect();
+
+    // Apply updates to rows that were already present.  A stale full snapshot
+    // must not roll a newer stream row back to an older body.
+    for message in incoming {
+        if let Some(&index) = positions.get(&message.id) {
+            if message.created_at >= merged[index].created_at {
+                merged[index] = message.clone();
+            }
+        }
+    }
+
+    let incoming_ids: HashSet<&str> = incoming.iter().map(|m| m.id.as_str()).collect();
+    for (incoming_index, message) in incoming.iter().enumerate() {
+        if positions.contains_key(&message.id) {
+            continue;
+        }
+
+        // Prefer an existing/injected predecessor, otherwise insert before the
+        // next known incoming row.  This preserves the order of a reconcile
+        // snapshot while retaining concurrent rows not present in it.
+        let predecessor = incoming[..incoming_index]
+            .iter()
+            .rev()
+            .find_map(|candidate| positions.get(&candidate.id).copied());
+        let successor = incoming[incoming_index + 1..]
+            .iter()
+            .find_map(|candidate| positions.get(&candidate.id).copied());
+        let at = if let Some(index) = predecessor {
+            index + 1
+        } else if let Some(index) = successor {
+            index
+        } else {
+            merged.len()
+        };
+        merged.insert(at, message.clone());
+        // Insertion shifts positions at/after `at`.
+        for index in positions.values_mut() {
+            if *index >= at {
+                *index += 1;
+            }
+        }
+        positions.insert(message.id.clone(), at);
+    }
+
+    // Silence an otherwise easy-to-miss accidental duplicate in malformed
+    // input without dropping the latest row from the normal path.
+    if incoming_ids.len() < incoming.len() {
+        let mut seen = HashSet::new();
+        merged.retain(|m| seen.insert(m.id.clone()));
+    }
+    merged
+}
+
+/// Save a journal snapshot without clobbering rows appended concurrently.
+///
+/// This is the default for journal reconciliation and enrichment.  Call
+/// [`replace_messages`] for an intentional destructive operation such as
+/// rewind/truncate.
 pub fn save_messages(session_id: &str, messages: &[ChatMessageStored]) -> Result<(), String> {
-    write_json(&session_dir(session_id).join("messages.json"), &messages)
+    let path = session_dir(session_id).join("messages.json");
+    crate::store_lock::with_exclusive_lock(&path, || {
+        let existing: Vec<ChatMessageStored> = read_json_recover(&path);
+        let merged = merge_message_snapshots(&existing, messages);
+        write_messages_locked(&path, &merged)
+    })
+}
+
+/// Intentionally replace a session journal under the same lock used by stream
+/// appends.  This is the only API that removes rows from an existing journal.
+pub fn replace_messages(session_id: &str, messages: &[ChatMessageStored]) -> Result<(), String> {
+    let path = session_dir(session_id).join("messages.json");
+    crate::store_lock::with_exclusive_lock(&path, || write_messages_locked(&path, messages))
 }
 
 pub fn append_message(session_id: &str, msg: ChatMessageStored) -> Result<(), String> {
@@ -1903,12 +1995,16 @@ pub fn append_message(session_id: &str, msg: ChatMessageStored) -> Result<(), St
     crate::store_lock::with_exclusive_lock(&path, || {
         let mut msgs: Vec<ChatMessageStored> = read_json_recover(&path);
         if let Some(slot) = msgs.iter_mut().find(|m| m.id == msg.id) {
-            *slot = msg;
+            // `created_at` doubles as a lightweight per-row revision.  A
+            // stale append from a delayed task must not roll back newer stream
+            // text; equal timestamps are treated as an intentional update.
+            if msg.created_at >= slot.created_at {
+                *slot = msg;
+            }
         } else {
             msgs.push(msg);
         }
-        let s = serde_json::to_string_pretty(&msgs).map_err(|e| e.to_string())?;
-        crate::store_lock::write_bytes_replace(&path, s.as_bytes())
+        write_messages_locked(&path, &msgs)
     })
 }
 
@@ -2044,21 +2140,15 @@ pub fn set_session_fork_agent_session(
     id: &str,
     fork_agent_session: bool,
 ) -> Result<SessionMeta, String> {
-    let mut list = load_sessions_index();
-    let s = list
-        .iter_mut()
-        .find(|s| s.id == id)
-        .ok_or_else(|| "session not found".to_string())?;
-    let has_agent = s
-        .agent_session_id
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|a| !a.is_empty());
-    s.fork_agent_session = fork_agent_session && has_agent;
-    s.updated_at = Utc::now();
-    let clone = s.clone();
-    save_sessions_index(&list)?;
-    Ok(clone)
+    update_session_row(id, move |s| {
+        let has_agent = s
+            .agent_session_id
+            .as_deref()
+            .is_some_and(|a| !a.trim().is_empty());
+        s.fork_agent_session = fork_agent_session && has_agent;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
 }
 
 /// Clear the one-shot fork flag after a connect attempt (success or fallthrough).
@@ -2514,14 +2604,15 @@ fn save_effort_on_session(
     let Some(sid) = session_id.filter(|s| !s.is_empty()) else {
         return Ok(Some(effort));
     };
-    let mut list = load_sessions_index();
-    let Some(sess) = list.iter_mut().find(|s| s.id == sid) else {
-        return Ok(Some(effort));
-    };
-    sess.effort = Some(effort);
-    sess.updated_at = Utc::now();
-    save_sessions_index(&list)?;
-    Ok(None)
+    let sid = sid.to_string();
+    update_sessions_index(move |list| {
+        let Some(sess) = list.iter_mut().find(|s| s.id == sid) else {
+            return Ok(Some(effort));
+        };
+        sess.effort = Some(effort);
+        sess.updated_at = Utc::now();
+        Ok(None)
+    })
 }
 
 /// Persist a partial composer prefs update at the configured scope.
@@ -2605,23 +2696,27 @@ pub fn save_composer_prefs(
         ComposerPrefsScope::Session => {
             let sid = session_id.filter(|s| !s.is_empty());
             if let Some(sid) = sid {
-                let mut list = load_sessions_index();
-                if let Some(sess) = list.iter_mut().find(|s| s.id == sid) {
-                    if let Some(v) = model_id {
+                let sid = sid.to_string();
+                let row_updated = update_sessions_index(|list| {
+                    let Some(sess) = list.iter_mut().find(|s| s.id == sid) else {
+                        return Ok(false);
+                    };
+                    if let Some(v) = model_id.clone() {
                         sess.model_id = Some(v);
                     }
-                    if let Some(v) = effort {
+                    if let Some(v) = effort.clone() {
                         sess.effort = Some(v);
                     }
-                    if let Some(v) = mode {
+                    if let Some(v) = mode.clone() {
                         sess.mode = Some(v);
                     }
-                    if let Some(v) = permission_policy {
+                    if let Some(v) = permission_policy.clone() {
                         sess.permission_policy = Some(v);
                     }
                     sess.updated_at = Utc::now();
-                    save_sessions_index(&list)?;
-                } else {
+                    Ok(true)
+                })?;
+                if !row_updated {
                     // No session row yet — fall back to global so the chip still sticks.
                     let mut s = load_settings();
                     if let Some(v) = model_id {
@@ -2664,6 +2759,7 @@ pub fn save_composer_prefs(
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use std::thread;
 
     #[test]
     fn non_plan_mode_heals_plan_default() {
@@ -3716,6 +3812,138 @@ mod tests {
         assert_eq!(resolve_composer_prefs(None, None).effort, "low");
 
         let _ = delete_session(&existing.id);
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sessions_index_transaction_preserves_concurrent_mutations() {
+        let _env = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-store-index-rmw-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = ensure_app_dirs();
+
+        let mut workers = Vec::new();
+        for n in 0..8 {
+            workers.push(thread::spawn(move || {
+                let id = format!("concurrent-session-{n}");
+                update_sessions_index(move |list| {
+                    list.push(sample_session(&id, false, Utc::now()));
+                    Ok(())
+                })
+                .expect("atomic index mutation");
+            }));
+        }
+        for worker in workers {
+            worker.join().expect("worker panicked");
+        }
+
+        let ids: std::collections::HashSet<String> = load_sessions_index()
+            .into_iter()
+            .map(|session| session.id)
+            .collect();
+        for n in 0..8 {
+            assert!(ids.contains(&format!("concurrent-session-{n}")));
+        }
+
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sessions_index_mutation_error_does_not_commit_partial_changes() {
+        let _env = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-store-index-error-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = ensure_app_dirs();
+        let original = sample_session("original", false, Utc::now());
+        update_sessions_index({
+            let original = original.clone();
+            move |list| {
+                list.push(original);
+                Ok(())
+            }
+        })
+        .expect("seed index");
+
+        let err = update_sessions_index(|list| {
+            list.push(sample_session("partial", false, Utc::now()));
+            Err::<(), _>("abort before commit".into())
+        });
+        assert!(err.is_err());
+        let ids: Vec<String> = load_sessions_index()
+            .into_iter()
+            .map(|session| session.id)
+            .collect();
+        assert_eq!(ids, vec!["original"]);
+
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn merged_message_save_keeps_concurrent_append_and_replace_truncates() {
+        let _env = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-store-journal-rmw-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = ensure_app_dirs();
+
+        let session = create_session(None, Some("journal race".into()), false).expect("session");
+        let at = Utc::now();
+        let base = ChatMessageStored {
+            id: "user-1".into(),
+            role: "user".into(),
+            content: "prompt".into(),
+            thought: None,
+            created_at: at,
+            is_error: false,
+            attachments: None,
+            marker: None,
+        };
+        let appended = ChatMessageStored {
+            id: "assistant-1".into(),
+            role: "assistant".into(),
+            content: "stream tail".into(),
+            thought: None,
+            created_at: at + chrono::Duration::milliseconds(1),
+            is_error: false,
+            attachments: None,
+            marker: None,
+        };
+
+        // `base` models a snapshot taken before the stream append.
+        append_message(&session.id, appended.clone()).expect("append stream row");
+        save_messages(&session.id, &[base.clone()]).expect("merge stale snapshot");
+        let merged = load_messages(&session.id);
+        assert!(merged.iter().any(|message| message.id == base.id));
+        assert!(merged
+            .iter()
+            .any(|message| message.id == appended.id && message.content == "stream tail"));
+
+        // Rewind-style operations must opt into destructive replacement.
+        replace_messages(&session.id, &[base]).expect("replace truncated journal");
+        let truncated = load_messages(&session.id);
+        assert_eq!(truncated.len(), 1);
+        assert_eq!(truncated[0].id, "user-1");
+
         std::env::remove_var("GROK_APP_HOME");
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/src-tauri/src/store_lock.rs
+++ b/src-tauri/src/store_lock.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)] // residual-clippy: is_lock_busy helper
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -15,6 +16,12 @@ use fs2::FileExt;
 /// How long to wait for a lock before failing with a clear error.
 const LOCK_WAIT: Duration = Duration::from_secs(3);
 const LOCK_POLL: Duration = Duration::from_millis(40);
+
+/// `fs2` locks coordinate separate processes, but some platforms treat a
+/// second descriptor in the same process as re-entrant.  Keep an in-process
+/// guard as well so two threads can never interleave a read-modify-write
+/// transaction (the common path for stream/journal updates).
+static PROCESS_STORE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Sidecar lock path for `foo.json` → `foo.json.lock`.
 pub fn lock_path_for(target: &Path) -> PathBuf {
@@ -25,20 +32,25 @@ pub fn lock_path_for(target: &Path) -> PathBuf {
 
 /// Holds an exclusive lock until dropped.
 pub struct ExclusiveLock {
+    // The guard must live for the full file-lock lifetime.  A single process
+    // mutex is intentionally conservative: store transactions are short and
+    // correctness matters more than parallel JSON writes.
+    _process_guard: MutexGuard<'static, ()>,
     _file: File,
-    path: PathBuf,
 }
 
 impl Drop for ExclusiveLock {
     fn drop(&mut self) {
         // Best-effort unlock; File drop also releases the lock on most OSes.
         let _ = self._file.unlock();
-        let _ = fs::remove_file(&self.path);
     }
 }
 
 /// Acquire exclusive lock for `target` (creates `target.lock`).
 pub fn lock_exclusive(target: &Path) -> Result<ExclusiveLock, String> {
+    let process_guard = PROCESS_STORE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let path = lock_path_for(target);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("lock dir: {e}"))?;
@@ -55,7 +67,10 @@ pub fn lock_exclusive(target: &Path) -> Result<ExclusiveLock, String> {
     loop {
         match file.try_lock_exclusive() {
             Ok(()) => {
-                return Ok(ExclusiveLock { _file: file, path });
+                return Ok(ExclusiveLock {
+                    _process_guard: process_guard,
+                    _file: file,
+                });
             }
             Err(_) if Instant::now() < deadline => {
                 thread::sleep(LOCK_POLL);

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -699,6 +699,7 @@ import {
 } from "@/components/PromptHistoryPanel";
 import {
   planClearSendQueue,
+  queueSessionKey,
   queuePreviewText,
   resolveSendQueueStripState,
   shouldEnqueueSend,
@@ -1578,8 +1579,28 @@ export function AppWorkbench() {
   sessionJsonSchemaRef.current = sessionJsonSchema;
   const [showJsonSchemaModal, setShowJsonSchemaModal] = useState(false);
   const [jsonSchemaDraft, setJsonSchemaDraft] = useState("");
-  /** Prevent overlapping executeSend / queue auto-flush races. */
+  /**
+   * Prevent overlapping sends per App session.  The boolean ref is retained
+   * as a compatibility aggregate for older hooks; all new claims use the
+   * session-keyed set so chat B is never blocked by chat A.
+   */
   const sendInFlightRef = useRef(false);
+  const sendInFlightBySessionRef = useRef<Set<string>>(new Set());
+  const sendEpochBySessionRef = useRef<Map<string, number>>(new Map());
+  const isSendInFlightForSession = (sessionId: string | null | undefined) =>
+    sendInFlightBySessionRef.current.has(queueSessionKey(sessionId));
+  const claimSendForSession = (sessionId: string | null | undefined) => {
+    const key = queueSessionKey(sessionId);
+    const set = sendInFlightBySessionRef.current;
+    if (set.has(key)) return false;
+    set.add(key);
+    sendInFlightRef.current = set.size > 0;
+    return true;
+  };
+  const releaseSendForSession = (sessionId: string | null | undefined) => {
+    sendInFlightBySessionRef.current.delete(queueSessionKey(sessionId));
+    sendInFlightRef.current = sendInFlightBySessionRef.current.size > 0;
+  };
   /**
    * Bumped when a send is superseded (ghost heal / new attempt) so a hung
    * `sessionSend` await cannot re-apply liveMap busy after UI already healed.
@@ -2577,6 +2598,25 @@ export function AppWorkbench() {
   const [connecting, setConnecting] = useState(false);
   /** Sync gate for ensureConnected (React state alone races two rapid sends). */
   const connectingRef = useRef(false);
+  /** Host connection claims are per session; warm-connect must not block B on A. */
+  const connectingBySessionRef = useRef<Set<string>>(new Set());
+  const ensureConnectCountRef = useRef(0);
+  const claimSessionConnection = (sessionId: string | null | undefined) => {
+    const key = queueSessionKey(sessionId);
+    const set = connectingBySessionRef.current;
+    if (set.has(key)) return false;
+    set.add(key);
+    return true;
+  };
+  const releaseSessionConnection = (keys: Iterable<string>) => {
+    const set = connectingBySessionRef.current;
+    for (const key of keys) set.delete(key);
+  };
+  const syncEnsureConnectingUi = () => {
+    const active = ensureConnectCountRef.current > 0;
+    connectingRef.current = active;
+    setConnecting(active);
+  };
   /** Live provider retry progress (session://retry); cleared on success/stop/error. */
   // Value intentionally unbound (retry chip hidden): only the setter is kept
   // for cleanup calls. See the hidden-retry comment at the status-pill site.
@@ -4856,8 +4896,8 @@ export function AppWorkbench() {
     if (
       api.isTauri() &&
       !deferForeign &&
-      !sendInFlightRef.current &&
-      !connectingRef.current &&
+      !isSendInFlightForSession(s.id) &&
+      !connectingBySessionRef.current.has(queueSessionKey(s.id)) &&
       (!proj || (proj.trusted && !isProjectPathMissing(proj.pathOk))) &&
       !(live.sessionId === s.id && live.state === "ready")
     ) {
@@ -4870,11 +4910,19 @@ export function AppWorkbench() {
       warmConnectTimerRef.current = setTimeout(() => {
         warmConnectTimerRef.current = null;
         if (!stillThisOpen()) return;
-        if (sendInFlightRef.current || connectingRef.current) return;
+        if (
+          isSendInFlightForSession(warmId) ||
+          connectingBySessionRef.current.has(queueSessionKey(warmId))
+        ) {
+          return;
+        }
         if (shouldSkipWarmConnect(isSecondaryWindowRef.current)) return;
+        if (!claimSessionConnection(warmId)) return;
         void (async () => {
-          if (!stillThisOpen()) return;
-          if (sendInFlightRef.current || connectingRef.current) return;
+          if (!stillThisOpen()) {
+            releaseSessionConnection([queueSessionKey(warmId)]);
+            return;
+          }
           try {
             const snap = await api.sessionConnect({
               projectPath: warmProjPath,
@@ -4899,6 +4947,8 @@ export function AppWorkbench() {
             }
           } catch (e) {
             console.warn("warm connect failed", e);
+          } finally {
+            releaseSessionConnection([queueSessionKey(warmId)]);
           }
         })();
       }, WARM_CONNECT_DEBOUNCE_MS);
@@ -7472,11 +7522,16 @@ export function AppWorkbench() {
     }
     // Serialize connects with a ref so two rapid sends cannot both pass a stale
     // `connecting` state check (React setState is async).
-    if (connectingRef.current) {
+    const connectKey = queueSessionKey(preferredId);
+    const heldConnectKeys = new Set<string>([connectKey]);
+    if (connectingBySessionRef.current.has(connectKey)) {
       // Another connect is in flight — do not drop the caller's send. Wait briefly
       // for the in-flight connect if it targets the same preferred session.
       const waitStart = Date.now();
-      while (connectingRef.current && Date.now() - waitStart < 120_000) {
+      while (
+        connectingBySessionRef.current.has(connectKey) &&
+        Date.now() - waitStart < 120_000
+      ) {
         await new Promise((r) => setTimeout(r, 50));
         const live = liveHostRef.current;
         if (
@@ -7488,10 +7543,11 @@ export function AppWorkbench() {
           return preferredId;
         }
       }
-      if (connectingRef.current) return null;
+      if (connectingBySessionRef.current.has(connectKey)) return null;
     }
-    connectingRef.current = true;
-    setConnecting(true);
+    if (!claimSessionConnection(preferredId)) return null;
+    ensureConnectCountRef.current += 1;
+    syncEnsureConnectingUi();
     // Capture view identity before awaits. Drafts are all `null`, so the epoch
     // is what distinguishes "still on my draft" from "user opened a new one".
     const originView = currentViewFocus();
@@ -7507,6 +7563,18 @@ export function AppWorkbench() {
           tr("session.new"),
         )) as { id: string; title?: string };
         sessionId = meta.id;
+        // Atomically move the draft connection claim onto the real id. After
+        // this synchronous handoff, a second send to the materialized session
+        // observes the same claim, while a newly opened draft stays independent.
+        const materializedKey = queueSessionKey(sessionId);
+        if (!heldConnectKeys.has(materializedKey)) {
+          const claims = connectingBySessionRef.current;
+          if (claims.has(materializedKey)) return null;
+          claims.delete(connectKey);
+          heldConnectKeys.delete(connectKey);
+          claims.add(materializedKey);
+          heldConnectKeys.add(materializedKey);
+        }
         // Persist draft-page JSON Schema onto the new session before connect
         // so spawn can take top-level `grok --json-schema`.
         const pendingSchema = sessionJsonSchemaRef.current?.trim() || "";
@@ -7628,8 +7696,9 @@ export function AppWorkbench() {
       }
       return null;
     } finally {
-      connectingRef.current = false;
-      setConnecting(false);
+      releaseSessionConnection(heldConnectKeys);
+      ensureConnectCountRef.current = Math.max(0, ensureConnectCountRef.current - 1);
+      syncEnsureConnectingUi();
     }
   };
 
@@ -7718,18 +7787,9 @@ export function AppWorkbench() {
       setLocalError(tr("session.secondaryLiveBanner"));
       return false;
     }
-    if (sendInFlightRef.current) return false;
-    sendInFlightRef.current = true;
-    const sendEpoch = ++sendEpochRef.current;
     const { storedDisplay, att, goalMode: useGoal, fromQueue } = opts;
-    const segments = parseStoredContent(storedDisplay);
-    if (isDraftEmpty(segments) && !att.length) {
-      sendInFlightRef.current = false;
-      return false;
-    }
-    // Prefer viewing id over shell sessionId — openSession points viewing at
-    // the new chat before journal load finishes setSession; using only shell
-    // mis-routed sends into the previous (often stuck) chat.
+    // Resolve the target before claiming so the lock is scoped to the chat
+    // that will actually receive the prompt (drafts use a stable sentinel).
     const sendTargetId =
       opts.targetSessionId !== undefined
         ? opts.targetSessionId
@@ -7737,6 +7797,27 @@ export function AppWorkbench() {
             viewingSessionId: viewingSessionIdRef.current,
             shellSessionId: session.sessionId,
           });
+    const sendKey = queueSessionKey(sendTargetId);
+    if (!claimSendForSession(sendTargetId)) return false;
+    const heldSendKeys = new Set<string>([sendKey]);
+    const sendEpoch = (sendEpochBySessionRef.current.get(sendKey) ?? 0) + 1;
+    sendEpochBySessionRef.current.set(sendKey, sendEpoch);
+    sendEpochRef.current += 1;
+    const sendEpochCurrent = () =>
+      [...heldSendKeys].every(
+        (key) => sendEpochBySessionRef.current.get(key) === sendEpoch,
+      );
+    const segments = parseStoredContent(storedDisplay);
+    if (isDraftEmpty(segments) && !att.length) {
+      releaseSendForSession(sendTargetId);
+      if (sendEpochBySessionRef.current.get(sendKey) === sendEpoch) {
+        sendEpochBySessionRef.current.delete(sendKey);
+      }
+      return false;
+    }
+    // Prefer viewing id over shell sessionId — openSession points viewing at
+    // the new chat before journal load finishes setSession; using only shell
+    // mis-routed sends into the previous (often stuck) chat.
     const cacheKey = sendTargetId ?? "__draft__";
     // Draft sends have no id to compare, so pin them to the view they came from:
     // otherwise the optimistic bubbles / streaming state paint whatever *new*
@@ -7907,6 +7988,25 @@ export function AppWorkbench() {
         failStrip();
         return false;
       }
+      // Draft sends materialize a real id during ensureConnected. Atomically
+      // migrate the claim so a second call targeting the new id cannot slip
+      // through, while a newly opened draft remains independent.
+      const materializedSendKey = queueSessionKey(sessionId);
+      if (!heldSendKeys.has(materializedSendKey)) {
+        const claims = sendInFlightBySessionRef.current;
+        if (claims.has(materializedSendKey)) {
+          failStrip();
+          return false;
+        }
+        claims.delete(sendKey);
+        heldSendKeys.delete(sendKey);
+        if (sendEpochBySessionRef.current.get(sendKey) === sendEpoch) {
+          sendEpochBySessionRef.current.delete(sendKey);
+        }
+        claims.add(materializedSendKey);
+        heldSendKeys.add(materializedSendKey);
+        sendEpochBySessionRef.current.set(materializedSendKey, sendEpoch);
+      }
       if (fromQueue && sendTargetId && sessionId !== sendTargetId) {
         failStrip();
         return false;
@@ -7974,17 +8074,17 @@ export function AppWorkbench() {
         // (idle recycle / crash while `liveHost` still looked ready).
         // Cold-connect that chat once, then retry the same turn.
         if (!isSessionNotLiveError(sendErr)) throw sendErr;
-        if (sendEpoch !== sendEpochRef.current) return false;
+        if (!sendEpochCurrent()) return false;
         const reconnected = await ensureConnected({
           sessionId,
           force: true,
         });
         if (reconnected !== sessionId) throw sendErr;
-        if (sendEpoch !== sendEpochRef.current) return false;
+        if (!sendEpochCurrent()) return false;
         await api.sessionSend(agentText, storedDisplay, sessionId, att);
       }
       // Ghost heal / newer send superseded this await — do not re-dirty UI.
-      if (sendEpoch !== sendEpochRef.current) return false;
+      if (!sendEpochCurrent()) return false;
       // Keep liveMap busy for this session if the user already left the thread.
       setLiveMap((prev) =>
         projectHostIntoLiveMap(prev, {
@@ -8023,14 +8123,19 @@ export function AppWorkbench() {
       }
       return true;
     } catch (e) {
-      if (sendEpoch !== sendEpochRef.current) return false;
+      if (!sendEpochCurrent()) return false;
       failStrip();
       if (viewingTarget()) setLocalError(String(e));
       return false;
     } finally {
-      if (sendEpoch === sendEpochRef.current) {
-        sendInFlightRef.current = false;
+      for (const key of heldSendKeys) {
+        // A ghost-heal or newer send may already own this session key. An old
+        // await must not release that newer claim when it finally settles.
+        if (sendEpochBySessionRef.current.get(key) !== sendEpoch) continue;
+        sendInFlightBySessionRef.current.delete(key);
+        sendEpochBySessionRef.current.delete(key);
       }
+      sendInFlightRef.current = sendInFlightBySessionRef.current.size > 0;
     }
   };
 
@@ -10497,6 +10602,8 @@ export function AppWorkbench() {
     liveHostRef,
     viewingSessionIdRef,
     sendInFlightRef,
+    sendInFlightBySessionRef,
+    connectingBySessionRef,
     executeSendRef: executeSendFromQueueRef,
     showToast,
     acceptExternal: !isSecondaryWindow,
@@ -10526,6 +10633,8 @@ export function AppWorkbench() {
     setLiveMap,
     clearTurnClock,
     setStreamStall: (v) => setStreamStall(v),
+    sendInFlightBySessionRef,
+    sendEpochBySessionRef,
     restoreComposer: (text) => {
       setDraft(text);
       requestComposerFocus();
@@ -10623,7 +10732,14 @@ export function AppWorkbench() {
 
   const sendQueuedMessageNow = useCallback(
     async (item: QueuedSend) => {
-      if (guidingQueueItemId || sendInFlightRef.current) return;
+      if (
+        guidingQueueItemId ||
+        isSendInFlightForSession(
+          viewingSessionIdRef.current ?? session.sessionId,
+        )
+      ) {
+        return;
+      }
       sendQueue.removeItem(item.id);
       setGuidingQueueItemId(item.id);
       const ok = await executeSendFromQueueRef.current({

--- a/src/hooks/useGhostStreamingHeal.ts
+++ b/src/hooks/useGhostStreamingHeal.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/ghostStreamingHeal";
 import type { SessionLiveMap } from "@/lib/sessionLiveStore";
 import { settleStoppedSessionInLiveMap } from "@/lib/sessionLiveStore";
+import { queueSessionKey } from "@/lib/sendQueue";
 import type {
   ChatMessage,
   SessionSnapshot,
@@ -32,6 +33,9 @@ export type GhostStreamingHealDeps = {
   /** Bumped on heal so a hung sessionSend cannot re-dirty UI after return. */
   sendEpochRef: MutableRefObject<number>;
   sendInFlightRef: MutableRefObject<boolean>;
+  /** Optional session-keyed claims/epochs (legacy refs remain supported). */
+  sendInFlightBySessionRef?: MutableRefObject<Set<string>>;
+  sendEpochBySessionRef?: MutableRefObject<Map<string, number>>;
   messagesBySessionRef: MutableRefObject<Map<string, ChatMessage[]>>;
   patchSessionMessages: (
     sessionId: string,
@@ -113,7 +117,11 @@ export function useGhostStreamingHeal(deps: GhostStreamingHealDeps): void {
           turnStartedAt: d.turnStartedAt,
           nowMs: Date.now(),
           hostStateForSession: hostState,
-          sendInFlight: d.sendInFlightRef.current,
+          sendInFlight: d.sendInFlightBySessionRef
+            ? d.sendInFlightBySessionRef.current.has(
+                queueSessionKey(d.sessionId),
+              )
+            : d.sendInFlightRef.current,
         })
       ) {
         return;
@@ -125,8 +133,20 @@ export function useGhostStreamingHeal(deps: GhostStreamingHealDeps): void {
       healingRef.current = true;
       try {
         // Invalidate any hung executeSend still awaiting sessionSend.
+        const sessionKey = queueSessionKey(d.sessionId);
         d.sendEpochRef.current += 1;
-        d.sendInFlightRef.current = false;
+        if (d.sendEpochBySessionRef) {
+          const next =
+            (d.sendEpochBySessionRef.current.get(sessionKey) ?? 0) + 1;
+          d.sendEpochBySessionRef.current.set(sessionKey, next);
+        }
+        if (d.sendInFlightBySessionRef) {
+          d.sendInFlightBySessionRef.current.delete(sessionKey);
+          d.sendInFlightRef.current =
+            d.sendInFlightBySessionRef.current.size > 0;
+        } else {
+          d.sendInFlightRef.current = false;
+        }
 
         const drop = new Set(turn.dropIds);
         const strip = (prev: ChatMessage[]) =>

--- a/src/hooks/useSendQueue.ts
+++ b/src/hooks/useSendQueue.ts
@@ -52,7 +52,10 @@ export type UseSendQueueOptions = {
   connecting: boolean;
   liveHostRef: RefObject<SessionSnapshot>;
   viewingSessionIdRef: MutableRefObject<string | null>;
+  /** Optional session-keyed claims; the boolean remains a legacy fallback. */
   sendInFlightRef: MutableRefObject<boolean>;
+  sendInFlightBySessionRef?: MutableRefObject<Set<string>>;
+  connectingBySessionRef?: MutableRefObject<Set<string>>;
   /** Always call via ref so flush sees the latest executeSend. */
   executeSendRef: MutableRefObject<ExecuteSendFromQueue>;
   showToast: (msg: string, ms?: number) => void;
@@ -77,6 +80,8 @@ export function useSendQueue({
   liveHostRef,
   viewingSessionIdRef,
   sendInFlightRef,
+  sendInFlightBySessionRef,
+  connectingBySessionRef,
   executeSendRef,
   showToast,
   acceptExternal = false,
@@ -88,7 +93,7 @@ export function useSendQueue({
   const sendQueueByKeyRef = useRef(sendQueueByKey);
   sendQueueByKeyRef.current = sendQueueByKey;
 
-  const queueFlushHoldRef = useRef(false);
+  const queueFlushHoldByKeyRef = useRef<Set<string>>(new Set());
   /** UI-visible hold (ref alone does not re-render). */
   const [flushHold, setFlushHold] = useState(false);
   const flushQueueTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -100,10 +105,43 @@ export function useSendQueue({
     [sendQueueByKey, sessionId],
   );
 
-  const setHold = useCallback((on: boolean) => {
-    queueFlushHoldRef.current = on;
-    setFlushHold(on);
-  }, []);
+  const viewedQueueKey = useCallback(
+    () => queueSessionKey(viewingSessionIdRef.current ?? sessionId),
+    [sessionId, viewingSessionIdRef],
+  );
+
+  const isSendInFlightForKey = useCallback(
+    (key: string) =>
+      sendInFlightBySessionRef
+        ? sendInFlightBySessionRef.current.has(key)
+        : sendInFlightRef.current,
+    [sendInFlightBySessionRef, sendInFlightRef],
+  );
+
+  const isConnectingForKey = useCallback(
+    (key: string) =>
+      connectingBySessionRef
+        ? connectingBySessionRef.current.has(key)
+        : connecting,
+    [connectingBySessionRef, connecting],
+  );
+
+  const setHoldForKey = useCallback(
+    (key: string, on: boolean) => {
+      const holds = queueFlushHoldByKeyRef.current;
+      if (on) holds.add(key);
+      else holds.delete(key);
+      // The strip represents the queue currently on screen only. A failed
+      // background queue must not paint/hold this session's composer.
+      setFlushHold(holds.has(viewedQueueKey()));
+    },
+    [viewedQueueKey],
+  );
+
+  const setHold = useCallback(
+    (on: boolean) => setHoldForKey(viewedQueueKey(), on),
+    [setHoldForKey, viewedQueueKey],
+  );
 
   const releaseFlushHold = useCallback(() => {
     setHold(false);
@@ -127,29 +165,65 @@ export function useSendQueue({
     if (!acceptExternal || !api.hasHost()) return;
     let cancelled = false;
     let unlisten: (() => void) | undefined;
-    void api
-      .listen<ExternalQueuePush>("session://send_queue", (push) => {
-        if (cancelled) return;
-        const r = applyExternalQueuePush(sendQueueByKeyRef.current, push);
-        if (!r.added) return;
-        writeMap(r.byKey);
-        if (r.dropped > 0) {
-          showToast(labels.droppedOldest(r.dropped, SEND_QUEUE_MAX), 3200);
+    let retryTimer: number | null = null;
+    let wakeRetry: (() => void) | null = null;
+    const onPush = (push: ExternalQueuePush) => {
+      if (cancelled) return;
+      const r = applyExternalQueuePush(sendQueueByKeyRef.current, push);
+      if (!r.added) return;
+      writeMap(r.byKey);
+      if (r.dropped > 0) {
+        showToast(labels.droppedOldest(r.dropped, SEND_QUEUE_MAX), 3200);
+      }
+      const preview = queuePreviewText(push.prompt ?? "", [], 48);
+      const viewId = viewingSessionIdRef.current ?? sessionId;
+      const same = !!viewId && viewId === (push.sessionId ?? "").trim();
+      const toast = same
+        ? labels.externalAdded?.(preview)
+        : labels.externalAddedOther?.(preview);
+      if (toast) showToast(toast, same ? 2800 : 4200);
+    };
+    const register = async () => {
+      let attempt = 0;
+      while (!cancelled) {
+        try {
+          const fn = await api.listen<ExternalQueuePush>(
+            "session://send_queue",
+            onPush,
+          );
+          if (cancelled) fn();
+          else unlisten = fn;
+          return;
+        } catch (e) {
+          if (cancelled) return;
+          const delayMs = Math.min(5_000, 250 * 2 ** Math.min(attempt, 4));
+          attempt += 1;
+          if (attempt === 1 || attempt % 5 === 0) {
+            console.warn(
+              "[send-queue] external listener registration failed; retrying",
+              e,
+            );
+          }
+          await new Promise<void>((resolve) => {
+            wakeRetry = resolve;
+            retryTimer = window.setTimeout(() => {
+              retryTimer = null;
+              wakeRetry = null;
+              resolve();
+            }, delayMs);
+          });
         }
-        const preview = queuePreviewText(push.prompt ?? "", [], 48);
-        const viewId = viewingSessionIdRef.current ?? sessionId;
-        const same = !!viewId && viewId === (push.sessionId ?? "").trim();
-        const toast = same
-          ? labels.externalAdded?.(preview)
-          : labels.externalAddedOther?.(preview);
-        if (toast) showToast(toast, same ? 2800 : 4200);
-      })
-      .then((fn) => {
-        if (cancelled) fn();
-        else unlisten = fn;
-      });
+      }
+    };
+    void register();
     return () => {
       cancelled = true;
+      if (retryTimer !== null) {
+        window.clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      wakeRetry?.();
+      wakeRetry = null;
       unlisten?.();
     };
   }, [
@@ -246,8 +320,9 @@ export function useSendQueue({
     const plan = planClearSendQueue(prev);
     cancelFlushTimer();
     writeMap(applyClearSendQueuePlan(sendQueueByKeyRef.current, key, plan));
+    setHoldForKey(key, false);
     return plan;
-  }, [sessionId, writeMap, cancelFlushTimer]);
+  }, [sessionId, writeMap, cancelFlushTimer, setHoldForKey]);
 
   /** Pure clear plan for the viewed queue (does not mutate). */
   const planClearQueue = useCallback((): ClearSendQueuePlan => {
@@ -257,7 +332,8 @@ export function useSendQueue({
 
   const clearDraftQueue = useCallback(() => {
     writeMap(setQueueForKey(sendQueueByKeyRef.current, "__draft__", []));
-  }, [writeMap]);
+    setHoldForKey("__draft__", false);
+  }, [writeMap, setHoldForKey]);
 
   const dropSessions = useCallback(
     (sessionIds: Iterable<string>) => {
@@ -279,14 +355,14 @@ export function useSendQueue({
   );
 
   const flush = useCallback(() => {
-    if (sendInFlightRef.current) return;
-    if (connecting) return;
-    if (queueFlushHoldRef.current) return;
     const live = liveHostRef.current;
     const viewId = viewingSessionIdRef.current;
     // Strict isolation: only ever claim the *viewed* session's queue.
     // Never fall back to live.sessionId (that mixed draft UI with foreign queues).
     const claimKey = queueSessionKey(viewId);
+    if (isSendInFlightForKey(claimKey)) return;
+    if (isConnectingForKey(claimKey)) return;
+    if (queueFlushHoldByKeyRef.current.has(claimKey)) return;
     if (!getQueueForKey(sendQueueByKeyRef.current, claimKey).length) return;
 
     // Same-session busy only: wait for this chat's turn to finish.
@@ -302,58 +378,97 @@ export function useSendQueue({
     writeMap(claimed.byKey);
 
     void (async () => {
-      const ok = await executeSendRef.current({
-        storedDisplay: head.storedDisplay,
-        att: head.attachments,
-        goalMode: head.goalMode,
-        fromQueue: true,
-        targetSessionId,
-      });
-      if (ok) return;
-      const r = requeueAfterFlushFail(
-        sendQueueByKeyRef.current,
-        claimKey,
-        head,
-      );
-      writeMap(r.byKey);
-      setHold(true);
-      if (r.dropped > 0) {
-        showToast(labels.droppedOldest(r.dropped, SEND_QUEUE_MAX), 3500);
-      } else {
-        showToast(labels.sendFailed, 3500);
+      try {
+        const ok = await executeSendRef.current({
+          storedDisplay: head.storedDisplay,
+          att: head.attachments,
+          goalMode: head.goalMode,
+          fromQueue: true,
+          targetSessionId,
+        });
+        if (ok) return;
+        const r = requeueAfterFlushFail(
+          sendQueueByKeyRef.current,
+          claimKey,
+          head,
+        );
+        writeMap(r.byKey);
+        // Hold only while the session is still live/busy. Terminal failures
+        // (error/cancel/disconnect) must release the key so it can recover.
+        const liveAfter = liveHostRef.current;
+        const terminal =
+          liveAfter.state === "ready" ||
+          liveAfter.state === "disconnected" ||
+          !!liveAfter.lastError;
+        setHoldForKey(claimKey, !terminal);
+        if (r.dropped > 0) {
+          showToast(labels.droppedOldest(r.dropped, SEND_QUEUE_MAX), 3500);
+        } else {
+          showToast(labels.sendFailed, 3500);
+        }
+      } catch (e) {
+        // Keep a rejected executeSend from leaving the queue claimed or the
+        // hold permanently wedged. Requeue is idempotent by item id.
+        const r = requeueAfterFlushFail(
+          sendQueueByKeyRef.current,
+          claimKey,
+          head,
+        );
+        writeMap(r.byKey);
+        setHoldForKey(claimKey, false);
+        console.warn("[send-queue] flush failed", e);
       }
     })();
   }, [
-    connecting,
     liveHostRef,
     viewingSessionIdRef,
     sendInFlightRef,
+    sendInFlightBySessionRef,
+    connectingBySessionRef,
     executeSendRef,
     showToast,
     labels,
     writeMap,
-    setHold,
+    setHoldForKey,
+    isSendInFlightForKey,
+    isConnectingForKey,
   ]);
 
-  // Clear flush hold once a real turn is in progress again.
+  // Clear the viewed key's hold once a real turn is in progress again, and on
+  // terminal/disconnected transitions. Holds for other sessions remain local.
+  const previousSessionStateRef = useRef(sessionState);
   useEffect(() => {
-    if (
-      sessionState === "streaming" ||
-      sessionState === "awaiting_permission"
-    ) {
-      setHold(false);
+    const key = viewedQueueKey();
+    const wasBusy =
+      previousSessionStateRef.current === "streaming" ||
+      previousSessionStateRef.current === "awaiting_permission";
+    const isBusy =
+      sessionState === "streaming" || sessionState === "awaiting_permission";
+    if (isBusy || (wasBusy && !isBusy) || sessionState === "disconnected") {
+      setHoldForKey(key, false);
     }
-  }, [sessionState, setHold]);
+    previousSessionStateRef.current = sessionState;
+  }, [sessionState, sessionId, setHoldForKey, viewedQueueKey]);
+
+  // Keep the visible strip in sync when navigation changes without touching
+  // another session's hold bit.
+  useEffect(() => {
+    setFlushHold(queueFlushHoldByKeyRef.current.has(viewedQueueKey()));
+  }, [sessionId, viewedQueueKey]);
 
   // Auto-send next queued follow-up when *this viewed session* can take a turn.
   useEffect(() => {
     if (sessionState !== "ready" && sessionState !== "idle") return;
-    if (connecting || sendInFlightRef.current || queueFlushHoldRef.current) {
+    const viewId = viewingSessionIdRef.current ?? sessionId;
+    const key = queueSessionKey(viewId);
+    if (
+      isConnectingForKey(key) ||
+      isSendInFlightForKey(key) ||
+      queueFlushHoldByKeyRef.current.has(key)
+    ) {
       return;
     }
     // Viewed key only — never the live host's key when they differ.
-    const viewId = viewingSessionIdRef.current ?? sessionId;
-    const key = queueSessionKey(viewId);
     if (!getQueueForKey(sendQueueByKeyRef.current, key).length) return;
     const live = liveHostRef.current;
     // Hold only when this same session is mid-turn on Host.
@@ -369,11 +484,15 @@ export function useSendQueue({
   }, [
     sessionState,
     sessionId,
-    connecting,
     sendQueueByKey,
     flush,
     cancelFlushTimer,
     sendInFlightRef,
+    sendInFlightBySessionRef,
+    connectingBySessionRef,
+    isConnectingForKey,
+    isSendInFlightForKey,
+    viewedQueueKey,
     viewingSessionIdRef,
     liveHostRef,
   ]);

--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -260,14 +260,72 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
 
     let cancelled = false;
     const cleanups: Array<() => void> = [];
+    const registrationPromises: Promise<unknown>[] = [];
 
-    const track = async (p: Promise<() => void>) => {
-      const un = await p;
-      if (cancelled) {
-        un();
-      } else {
-        cleanups.push(un);
+    /**
+     * Registering a listener is an IPC operation in both desktop and mirror
+     * modes.  A transient transport failure must not abort the rest of the
+    * listener boot sequence (the old `track(...)` chain did exactly
+     * that).  Keep retrying with a capped backoff until this subscription epoch
+     * is disposed; this also lets a mirror reconnect heal a missed listener
+     * without requiring a full window remount.
+     */
+    const listenWithRetry = async <T>(
+      event: string,
+      handler: (payload: T) => void,
+    ): Promise<() => void> => {
+      let attempt = 0;
+      let lastError: unknown;
+      while (!cancelled) {
+        try {
+          return await api.listen<T>(event, handler);
+        } catch (e) {
+          lastError = e;
+          const delayMs = Math.min(5_000, 250 * 2 ** Math.min(attempt, 4));
+          attempt += 1;
+          if (attempt === 1 || attempt % 5 === 0) {
+            console.warn(
+              `[host-events] listener registration failed (${event}); retrying`,
+              e,
+            );
+          }
+          await new Promise<void>((resolve) => {
+            window.setTimeout(resolve, delayMs);
+          });
+        }
       }
+      // The caller will immediately dispose this no-op when cancellation wins
+      // the race with an in-flight registration.
+      if (lastError) {
+        console.debug(`[host-events] listener registration cancelled (${event})`);
+      }
+      return () => {};
+    };
+
+    /**
+     * Start registration independently.  Do not await one listener before
+     * starting the next: a single broken event channel must not create a
+     * startup-wide event window for every later channel.
+     */
+    const track = (p: Promise<() => void>) => {
+      const registration = p
+        .then((un) => {
+          if (cancelled) {
+            un();
+          } else {
+            cleanups.push(un);
+          }
+        })
+        .catch((e) => {
+          // `listenWithRetry` normally only rejects on an unexpected API
+          // failure.  Keep this isolated so one listener can never suppress
+          // snapshot hydration or the remaining listeners.
+          if (!cancelled) {
+            console.warn("[host-events] listener registration abandoned", e);
+          }
+        });
+      registrationPromises.push(registration);
+      void registration;
     };
 
     void (async () => {
@@ -360,8 +418,15 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           streamCoalescer?.flushAll();
         };
 
-        const snap = await api.sessionGetState();
-        if (!cancelled) {
+        // Snapshot hydration runs after all event channels are registered.
+        const hydrateInitialSnapshot = async (opts?: {
+          adoptHostFocus?: boolean;
+        }) => {
+          const adoptHostFocus = opts?.adoptHostFocus ?? true;
+          const requestedViewing = c.viewingSessionIdRef.current;
+          const requestedOpening = c.openingSessionIdRef?.current ?? null;
+          const snap = await api.sessionGetState();
+          if (!cancelled) {
           c.setLiveHost(snap);
           c.liveHostRef.current = snap;
           // Project Host live row into liveMap for sidebar busy badges.
@@ -378,7 +443,12 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
                 streamingMessageId: snap.streamingMessageId,
               }),
             );
-            if (!secondary) {
+            const canAdoptHostFocus =
+              adoptHostFocus &&
+              (requestedViewing == null || requestedViewing === snap.sessionId) &&
+              c.viewingSessionIdRef.current === requestedViewing &&
+              (c.openingSessionIdRef?.current ?? null) === requestedOpening;
+            if (!secondary && canAdoptHostFocus) {
               c.setSession((prev) => ({
                 ...snap,
                 state: reconcileSessionState(snap.state, prev.state),
@@ -397,13 +467,38 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
               c.viewingSessionIdRef.current = snap.sessionId;
             }
           }
+          }
+        };
+
+        // Mirror clients force a reconnect when the broadcast ring reports a
+        // lagged receiver. Rehydrate the host snapshot and the currently
+        // viewed journal as soon as that socket is back so dropped stream
+        // frames cannot leave the phone UI permanently stale.
+        if (isMirrorClient()) {
+          track(
+            listenWithRetry<{ resumed?: boolean }>(
+              "mirror://reconnected",
+              () => {
+                void hydrateInitialSnapshot({ adoptHostFocus: false })
+                  .then(() => {
+                    const sid = c.viewingSessionIdRef.current;
+                    if (sid) scheduleJournalRehydrate(sid, 0);
+                  })
+                  .catch((e) => {
+                    if (!cancelled) {
+                      console.warn("[host-events] mirror resync failed", e);
+                    }
+                  });
+              },
+            ),
+          );
         }
 
         // Host finished a turn but App journal may still miss the final
         // assistant body (stream dropped / sticky finish). Rehydrate so UI
         // leaves "thinking" and shows the real answer.
-        await track(
-          api.listen<{ sessionId?: string; changed?: number }>(
+       track(
+          listenWithRetry<{ sessionId?: string; changed?: number }>(
             "session://journal_reconciled",
             (p) => {
               if (cancelled || !p?.sessionId) return;
@@ -421,8 +516,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             },
           ),
         );
-        await track(
-          api.listen<SessionSnapshot>("session://state", (s) => {
+       track(
+          listenWithRetry<SessionSnapshot>("session://state", (s) => {
             if (cancelled) return;
             // Host focus slot (the process under the live cursor). Multi-session
             // busy demotions also emit session://runtime so liveMap stays honest.
@@ -581,8 +676,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           }),
         );
         // Background / parked multi-session runtime (does not steal liveHost focus).
-        await track(
-          api.listen<SessionSnapshot>("session://runtime", (s) => {
+       track(
+          listenWithRetry<SessionSnapshot>("session://runtime", (s) => {
             if (cancelled || !s.sessionId) return;
             const prevLiveState = c.liveMapRef.current[s.sessionId]?.state;
             c.setLiveMap((prev) =>
@@ -848,16 +943,16 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           },
         });
         cleanups.push(() => streamCoalescer?.dispose());
-        await track(
-          api.listen<StreamPayload>("session://stream", (chunk) => {
+       track(
+          listenWithRetry<StreamPayload>("session://stream", (chunk) => {
             if (cancelled) return;
             // Turn-end honesty: drain pending tool progress before applying done.
             if (chunk.done) toolEventCoalescer?.flushAll();
             streamCoalescer?.push(chunk);
           }),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId: string;
             message: ChatMessage;
             postStreamMessageId?: string | null;
@@ -880,8 +975,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             c.restartTurnClock(payload.sessionId);
           }),
         );
-        await track(
-          api.listen<GeneratedImagePayload>(
+       track(
+          listenWithRetry<GeneratedImagePayload>(
             "session://generated_image",
             (p) => {
               if (cancelled || !p?.path) return;
@@ -891,8 +986,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             },
           ),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId?: string;
             messageId?: string;
             trigger?: string;
@@ -977,8 +1072,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId?: string;
             totalTokens?: number;
             inputTokens?: number;
@@ -1079,8 +1174,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             );
           }),
         );
-        await track(
-          api.listen<HostToolEvent>("session://tool", (p) => {
+       track(
+          listenWithRetry<HostToolEvent>("session://tool", (p) => {
             if (cancelled || !p?.toolCallId) return;
             const sid = p.sessionId || c.viewingSessionIdRef.current;
             if (!sid) return;
@@ -1109,8 +1204,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId?: string;
             kind?: string;
             eventName?: string;
@@ -1124,8 +1219,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             ingestHostHookPayload(p);
           }),
         );
-        await track(
-          api.listen<GoalOrchHostPayload>("session://goal", (p) => {
+       track(
+          listenWithRetry<GoalOrchHostPayload>("session://goal", (p) => {
             if (cancelled || !p) return;
             // CLI 0.2.117+ goal_updated — soft-fail when CLI never emits.
             const ev = goalEventFromHostPayload(p);
@@ -1135,15 +1230,15 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             );
           }),
         );
-        await track(
-          api.listen<{ line?: string }>("session://stderr", (p) => {
+       track(
+          listenWithRetry<{ line?: string }>("session://stderr", (p) => {
             if (cancelled || !p?.line) return;
             // Fallback: agent log lines that mention hooks (fail-open, timeouts, …).
             ingestHookLogLine(p.line);
           }),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId?: string;
             messageId?: string;
             marker?: string;
@@ -1164,8 +1259,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }),
         );
-        await track(
-          api.listen<{ sessionId?: string; reason?: string }>(
+       track(
+          listenWithRetry<{ sessionId?: string; reason?: string }>(
             "session://idle_recycled",
             (p) => {
               if (cancelled || !p) return;
@@ -1195,8 +1290,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             },
           ),
         );
-        await track(
-          api.listen<{ reason?: string; killed?: number }>(
+       track(
+          listenWithRetry<{ reason?: string; killed?: number }>(
             "session://agents_recycled",
             (p) => {
               if (cancelled || !p) return;
@@ -1232,8 +1327,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
         // #524 + plan gates: agent recycled / exited while a human gate was open —
         // drop stale Approve (permission / plan / ask_user) so UI never writes to
         // a dead stdin. Host payload includes planRpcId / askUserRpcId.
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             reason?: string;
             sessions?: Array<{
               sessionId?: string;
@@ -1294,8 +1389,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }),
         );
-        await track(
-          api.listen<{ reason?: string }>(
+       track(
+          listenWithRetry<{ reason?: string }>(
             "session://agent_soft_respawn",
             (p) => {
               if (cancelled || !p) return;
@@ -1305,8 +1400,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             },
           ),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId?: string;
             stopReason?: string;
             toolCount?: number;
@@ -1347,8 +1442,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             window.setTimeout(() => c.setToast(null), 7200);
           }),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId?: string;
             code?: string;
             message?: string;
@@ -1372,8 +1467,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId?: string;
             stallSeconds?: number;
             code?: string;
@@ -1436,8 +1531,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           }),
         );
         // Long-tool heartbeat: Host re-armed stall; clear soft banner for this chat.
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId?: string;
             toolCallIds?: string[];
             openCount?: number;
@@ -1450,8 +1545,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             sessionId?: string;
             stallSeconds?: number;
             code?: string;
@@ -1507,8 +1602,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             attempt?: number;
             maxRetries?: number;
             reason?: string;
@@ -1535,8 +1630,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             c.setRetryStatus({ attempt, maxRetries, reason });
           }),
         );
-        await track(
-          api.listen<TurnErrorPayload>("session://turn_error", (p) => {
+       track(
+          listenWithRetry<TurnErrorPayload>("session://turn_error", (p) => {
             if (cancelled) return;
             c.clearPendingGatesRef.current(p.sessionId);
             if (p.sessionId === c.viewingSessionIdRef.current) {
@@ -1547,8 +1642,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             );
           }),
         );
-        await track(
-          api.listen<PermissionPayload>("session://permission", (p) => {
+       track(
+          listenWithRetry<PermissionPayload>("session://permission", (p) => {
             if (cancelled) return;
             // Park it against its session so returning to that chat can answer.
             if (p.sessionId) {
@@ -1592,8 +1687,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }),
         );
-        await track(
-          api.listen<AskUserPayload>("session://ask_user", (p) => {
+       track(
+          listenWithRetry<AskUserPayload>("session://ask_user", (p) => {
             if (cancelled) return;
             // rpcId may legitimately be 0 (JSON-RPC ids start at 0). A truthy
             // guard here used to drop id=0 questions, so the modal never showed
@@ -1640,8 +1735,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           }),
         );
         // Host stop / interject auto-cancels pending questionnaires — drop the modal.
-        await track(
-          api.listen<{ sessionId?: string; reason?: string }>(
+       track(
+          listenWithRetry<{ sessionId?: string; reason?: string }>(
             "session://ask_user_cleared",
             (p) => {
               if (cancelled) return;
@@ -1654,8 +1749,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             },
           ),
         );
-        await track(
-          api.listen<{
+       track(
+          listenWithRetry<{
             entries?: unknown[];
             body?: string | null;
             sessionId?: string;
@@ -1801,8 +1896,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             });
           }),
         );
-        await track(
-          api.listen<{ sessionId?: string; title?: string }>(
+       track(
+          listenWithRetry<{ sessionId?: string; title?: string }>(
             "session://title",
             (p) => {
               if (cancelled || !p.sessionId || !p.title) return;
@@ -1826,8 +1921,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
         );
         // Remote IM wrote sessions_index / messages.json — refresh sidebar +
         // reload journal if the user is currently viewing that session.
-        await track(
-          api.listen<{ sessionId?: string; source?: string }>(
+       track(
+          listenWithRetry<{ sessionId?: string; source?: string }>(
             "session://index_changed",
             (p) => {
               if (cancelled) return;
@@ -1861,6 +1956,22 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             },
           ),
         );
+        // Give successful listener registrations a chance to settle before
+        // hydrating the snapshot. A broken channel must not block startup
+        // forever: listenWithRetry keeps retrying independently, while this
+        // bounded barrier lets snapshot/journal hydration compensate for any
+        // subscription that is still unavailable.
+        await Promise.race([
+          Promise.allSettled(registrationPromises),
+          new Promise<void>((resolve) => window.setTimeout(resolve, 1000)),
+        ]);
+        await hydrateInitialSnapshot().catch((e) => {
+          if (!cancelled) {
+            console.warn("[host-events] initial snapshot failed", e);
+          }
+        });
+        const initialSid = c.viewingSessionIdRef.current;
+        if (initialSid) scheduleJournalRehydrate(initialSid, 0);
       } catch (e) {
         if (!cancelled) c.setLocalError(String(e));
       }

--- a/src/lib/mirrorTransport.ts
+++ b/src/lib/mirrorTransport.ts
@@ -205,8 +205,13 @@ export function mirrorEnsureTransport(): Promise<void> {
         ws.close();
         return;
       }
+      const resumed = state.hello !== null;
       state.connectPromise = null;
       resolve();
+      // A reconnect can follow a server-side lag reset. The event ring is not
+      // replayable, so let the host-event hook rehydrate state/journal after
+      // the transport is live again.
+      dispatchEvent("mirror://reconnected", { resumed });
     };
 
     ws.onmessage = (ev) => {


### PR DESCRIPTION
## Summary

- Harden ACP process shutdown and TCP reader cancellation so recycled agents do not leave a blocked reader or emit ghost events.
- Make stamped ACP events require an exact agent-session owner, with regression coverage for unbound live/background hints.
- Isolate per-session send claims and epochs, preserve the viewed session during mirror rehydration, and clean draft-send state transitions.
- Retry external `session://send_queue` listener registration after transient IPC failures.
- Preserve the existing journal, mirror, relay, and process-lifecycle recovery fixes from the audit implementation.

## Root cause

The interruption path mixed process-scoped state with session-scoped state. A kill could race the TCP reader before `Notify` registration, while late stamped events could be accepted when the current slot had no recorded owner. Frontend hydration and queue listeners also assumed a single successful registration, allowing stale focus or permanently missed follow-ups after reconnects.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test -- --testTimeout=15000` 鈥?389 files, 5571 tests passed
- `pnpm vitest run src/lib/sendQueue.test.ts --testTimeout=15000` 鈥?30 tests passed
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- Rust compile/test execution is environment-blocked here: MSVC `link.exe` and GNU `dlltool.exe` are not installed.

