### PR TITLE
fix(search): restore palette wheel scroll and add keyboard selection

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -428,6 +428,11 @@ import {
   type PaletteActionDef
 } from "@/lib/paletteActions";
 import {
+  flattenSearchPanelItems,
+  type SearchPanelItem,
+} from "@/lib/searchPanelNav";
+import { useSearchPanelNav } from "@/hooks/useSearchPanelNav";
+import {
   canOfferContinueCwd,
   classifyContinueCwdEmptyResult,
   continueCwdSoftFailMessageKey,
@@ -7264,6 +7269,16 @@ export function AppWorkbench() {
     [searchQuery, tr],
   );
 
+  const searchPaletteItems = useMemo(
+    () =>
+      flattenSearchPanelItems({
+        actions: paletteActionHits,
+        projects: searchHits.matchedProjects,
+        sessions: mergedSessionHits,
+      }),
+    [paletteActionHits, searchHits.matchedProjects, mergedSessionHits],
+  );
+
   const searchEmptyState = useMemo(
     () =>
       resolveSessionSearchEmptyState({
@@ -14074,6 +14089,59 @@ export function AppWorkbench() {
         break;
     }
   };
+
+  const activateSearchPanelItem = (item: SearchPanelItem) => {
+    if (item.kind === "action") {
+      const action = paletteActionHits.find((a) => a.id === item.id);
+      if (action) runPaletteAction(action);
+      return;
+    }
+    if (item.kind === "project") {
+      const p = searchHits.matchedProjects.find((x) => x.id === item.id);
+      if (!p) return;
+      setShowSearch(false);
+      projectSpaces.revealProject(p.id);
+      setProjectsOpen(true);
+      setExpandedProjects((e) => ({ ...e, [p.id]: true }));
+      return;
+    }
+    const hit = mergedSessionHits.find((h) => h.id === item.id);
+    if (!hit) return;
+    const s = sessions.find((x) => x.id === hit.id);
+    const row: SessionRow =
+      s ??
+      normalizeSessionRow({
+        id: hit.id,
+        title: hit.title,
+        projectId: hit.projectId ?? null,
+        updatedAt: "",
+        archived: hit.archived,
+      });
+    const proj = projects.find(
+      (p) => p.id === (row.projectId ?? hit.projectId),
+    );
+    setShowSearch(false);
+    void openSession(row, proj ?? null);
+  };
+
+  const { activeIndex: searchActiveIndex, setActiveIndex: setSearchActiveIndex } =
+    useSearchPanelNav({
+      open: showSearch,
+      items: searchPaletteItems,
+      sessionCount: mergedSessionHits.length,
+      resetKey: [
+        searchQuery,
+        searchMode,
+        searchRankMode,
+        String(searchIncludeArchived),
+      ].join("\0"),
+      getRoot: () => searchPanelRef.current,
+      onActivate: activateSearchPanelItem,
+      onActivateSessionIndex: (sessionIndex) => {
+        const hit = mergedSessionHits[sessionIndex];
+        if (hit) activateSearchPanelItem({ kind: "session", id: hit.id });
+      },
+    });
 
   // Keep tray menu actions on latest closures (listeners registered once).
   const trayHandlersRef = useRef({
@@ -24053,6 +24121,15 @@ export function AppWorkbench() {
                 }
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
+                role="combobox"
+                aria-autocomplete="list"
+                aria-expanded="true"
+                aria-controls="search-panel-listbox"
+                aria-activedescendant={
+                  searchPaletteItems.length > 0
+                    ? `search-opt-${searchActiveIndex}`
+                    : undefined
+                }
               />
               <button
                 type="button"
@@ -24136,16 +24213,33 @@ export function AppWorkbench() {
                   : tr("search.rankKeywordHint")}
               </span>
             </div>
+            <OverlayScroll className="search-panel__results">
+            <div
+              id="search-panel-listbox"
+              role="listbox"
+              aria-label={tr("search.title")}
+            >
             {paletteActionHits.length > 0 && (
               <>
                 <div className="search-panel__section">
                   {tr("search.actions")}
                 </div>
-                {paletteActionHits.map((action) => (
+                {paletteActionHits.map((action, i) => {
+                  const idx = i;
+                  const active = idx === searchActiveIndex;
+                  return (
                   <button
                     key={action.id}
                     type="button"
-                    className="search-panel__row"
+                    id={`search-opt-${idx}`}
+                    data-search-idx={idx}
+                    role="option"
+                    aria-selected={active}
+                    tabIndex={-1}
+                    className={
+                      "search-panel__row" + (active ? " is-active" : "")
+                    }
+                    onMouseEnter={() => setSearchActiveIndex(idx)}
                     onClick={() => runPaletteAction(action)}
                   >
                     {paletteActionIcon(action.id)}
@@ -24153,7 +24247,8 @@ export function AppWorkbench() {
                       {tr(action.labelKey)}
                     </span>
                   </button>
-                ))}
+                  );
+                })}
               </>
             )}
             {searchHits.matchedProjects.length > 0 && (
@@ -24161,11 +24256,22 @@ export function AppWorkbench() {
                 <div className="search-panel__section">
                   {tr("sidebar.projects")}
                 </div>
-                {searchHits.matchedProjects.map((p) => (
+                {searchHits.matchedProjects.map((p, i) => {
+                  const idx = paletteActionHits.length + i;
+                  const active = idx === searchActiveIndex;
+                  return (
                   <button
                     key={p.id}
                     type="button"
-                    className="search-panel__row"
+                    id={`search-opt-${idx}`}
+                    data-search-idx={idx}
+                    role="option"
+                    aria-selected={active}
+                    tabIndex={-1}
+                    className={
+                      "search-panel__row" + (active ? " is-active" : "")
+                    }
+                    onMouseEnter={() => setSearchActiveIndex(idx)}
                     onClick={() => {
                       setShowSearch(false);
                       // Project is a folder: expand only; selection is for sessions.
@@ -24177,7 +24283,8 @@ export function AppWorkbench() {
                     <span className="search-panel__title">{p.name}</span>
                     <span className="search-panel__meta">{p.path}</span>
                   </button>
-                ))}
+                  );
+                })}
               </>
             )}
             <div className="search-panel__section">
@@ -24232,11 +24339,24 @@ export function AppWorkbench() {
                 );
               }
               if (i < 9) metaParts.push(`⌘${i + 1}`);
+              const idx =
+                paletteActionHits.length +
+                searchHits.matchedProjects.length +
+                i;
+              const active = idx === searchActiveIndex;
               return (
                 <button
                   key={hit.id}
                   type="button"
-                  className="search-panel__row"
+                  id={`search-opt-${idx}`}
+                  data-search-idx={idx}
+                  role="option"
+                  aria-selected={active}
+                  tabIndex={-1}
+                  className={
+                    "search-panel__row" + (active ? " is-active" : "")
+                  }
+                  onMouseEnter={() => setSearchActiveIndex(idx)}
                   onClick={() => {
                     setShowSearch(false);
                     void openSession(row, proj ?? null);
@@ -24275,6 +24395,8 @@ export function AppWorkbench() {
                 </button>
               );
             })}
+            </div>
+            </OverlayScroll>
           </div>
         </div>
       )}

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -14100,7 +14100,7 @@ export function AppWorkbench() {
       const p = searchHits.matchedProjects.find((x) => x.id === item.id);
       if (!p) return;
       setShowSearch(false);
-      projectSpaces.revealProject(p.id);
+      // Project is a folder: expand only; selection is for sessions.
       setProjectsOpen(true);
       setExpandedProjects((e) => ({ ...e, [p.id]: true }));
       return;

--- a/src/hooks/useSearchPanelNav.ts
+++ b/src/hooks/useSearchPanelNav.ts
@@ -1,0 +1,80 @@
+/**
+ * Keyboard highlight for the command-palette search panel.
+ * Policy lives in `searchPanelNav` (testable). This hook owns index + listeners.
+ */
+import { useEffect, useRef, useState } from "react";
+import {
+  clampSearchPanelIndex,
+  resolveSearchPanelKey,
+  type SearchPanelItem,
+} from "@/lib/searchPanelNav";
+
+export function useSearchPanelNav(opts: {
+  open: boolean;
+  items: readonly SearchPanelItem[];
+  sessionCount: number;
+  /** Change this to snap the highlight back to the first row (query / filters). */
+  resetKey: string;
+  getRoot: () => ParentNode | null | undefined;
+  onActivate: (item: SearchPanelItem) => void;
+  onActivateSessionIndex: (sessionIndex: number) => void;
+}): {
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+} {
+  const [rawIndex, setRawIndex] = useState(0);
+  const activeIndex = clampSearchPanelIndex(rawIndex, opts.items.length);
+
+  const optsRef = useRef(opts);
+  optsRef.current = opts;
+  const indexRef = useRef(activeIndex);
+  indexRef.current = activeIndex;
+
+  useEffect(() => {
+    if (!opts.open) return;
+    setRawIndex(0);
+  }, [opts.open, opts.resetKey]);
+
+  useEffect(() => {
+    if (!opts.open) return;
+    const el = optsRef.current
+      .getRoot()
+      ?.querySelector<HTMLElement>(`[data-search-idx="${activeIndex}"]`);
+    el?.scrollIntoView({ block: "nearest" });
+  }, [opts.open, activeIndex, opts.items.length]);
+
+  useEffect(() => {
+    if (!opts.open) return;
+    const onKey = (e: KeyboardEvent) => {
+      const o = optsRef.current;
+      const result = resolveSearchPanelKey({
+        key: e.key,
+        metaKey: e.metaKey,
+        ctrlKey: e.ctrlKey,
+        altKey: e.altKey,
+        shiftKey: e.shiftKey,
+        isComposing: e.isComposing,
+        activeIndex: indexRef.current,
+        itemCount: o.items.length,
+        sessionCount: o.sessionCount,
+      });
+      if (result.type === "none") return;
+      e.preventDefault();
+      e.stopPropagation();
+      if (result.type === "nav") {
+        setRawIndex(result.index);
+        return;
+      }
+      if (result.type === "activate") {
+        const item = o.items[result.index];
+        if (item) o.onActivate(item);
+        return;
+      }
+      o.onActivateSessionIndex(result.sessionIndex);
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [opts.open]);
+
+  return { activeIndex, setActiveIndex: setRawIndex };
+}

--- a/src/lib/searchPanelNav.test.ts
+++ b/src/lib/searchPanelNav.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampSearchPanelIndex,
+  flattenSearchPanelItems,
+  resolveSearchPanelKey,
+  searchPanelItemIndex,
+  searchPanelNavFromKey,
+  searchPanelSessionDigitIndex,
+  stepSearchPanelIndex,
+} from "./searchPanelNav";
+
+describe("flattenSearchPanelItems", () => {
+  it("orders actions, then projects, then sessions", () => {
+    expect(
+      flattenSearchPanelItems({
+        actions: [{ id: "new-chat" }, { id: "doctor" }],
+        projects: [{ id: "p1" }],
+        sessions: [{ id: "s1" }, { id: "s2" }],
+      }),
+    ).toEqual([
+      { kind: "action", id: "new-chat" },
+      { kind: "action", id: "doctor" },
+      { kind: "project", id: "p1" },
+      { kind: "session", id: "s1" },
+      { kind: "session", id: "s2" },
+    ]);
+  });
+
+  it("skips empty groups", () => {
+    expect(
+      flattenSearchPanelItems({
+        actions: [],
+        sessions: [{ id: "s1" }],
+      }),
+    ).toEqual([{ kind: "session", id: "s1" }]);
+  });
+});
+
+describe("searchPanelItemIndex", () => {
+  const items = flattenSearchPanelItems({
+    actions: [{ id: "a" }],
+    projects: [{ id: "p" }],
+    sessions: [{ id: "s" }],
+  });
+
+  it("finds flattened offsets", () => {
+    expect(searchPanelItemIndex(items, "action", "a")).toBe(0);
+    expect(searchPanelItemIndex(items, "project", "p")).toBe(1);
+    expect(searchPanelItemIndex(items, "session", "s")).toBe(2);
+    expect(searchPanelItemIndex(items, "session", "missing")).toBe(-1);
+  });
+});
+
+describe("clampSearchPanelIndex", () => {
+  it("clamps to last item; empty list stays 0", () => {
+    expect(clampSearchPanelIndex(8, 3)).toBe(2);
+    expect(clampSearchPanelIndex(-2, 3)).toBe(0);
+    expect(clampSearchPanelIndex(1, 0)).toBe(0);
+  });
+});
+
+describe("stepSearchPanelIndex", () => {
+  it("wraps up/down like a command palette", () => {
+    expect(stepSearchPanelIndex(0, 4, "down")).toBe(1);
+    expect(stepSearchPanelIndex(3, 4, "down")).toBe(0);
+    expect(stepSearchPanelIndex(0, 4, "up")).toBe(3);
+    expect(stepSearchPanelIndex(2, 4, "up")).toBe(1);
+  });
+
+  it("pages without wrapping past the ends", () => {
+    expect(stepSearchPanelIndex(1, 10, "pageDown", 5)).toBe(6);
+    expect(stepSearchPanelIndex(8, 10, "pageDown", 5)).toBe(9);
+    expect(stepSearchPanelIndex(3, 10, "pageUp", 5)).toBe(0);
+  });
+
+  it("empty list stays at 0", () => {
+    expect(stepSearchPanelIndex(2, 0, "down")).toBe(0);
+  });
+});
+
+describe("searchPanelNavFromKey", () => {
+  it("maps vertical keys only (Home/End stay with the query caret)", () => {
+    expect(searchPanelNavFromKey("ArrowUp")).toBe("up");
+    expect(searchPanelNavFromKey("ArrowDown")).toBe("down");
+    expect(searchPanelNavFromKey("PageUp")).toBe("pageUp");
+    expect(searchPanelNavFromKey("PageDown")).toBe("pageDown");
+    expect(searchPanelNavFromKey("Home")).toBeNull();
+    expect(searchPanelNavFromKey("End")).toBeNull();
+    expect(searchPanelNavFromKey("Enter")).toBeNull();
+  });
+});
+
+describe("searchPanelSessionDigitIndex", () => {
+  it("maps ⌘/Ctrl 1–9 to session offsets", () => {
+    expect(
+      searchPanelSessionDigitIndex({
+        key: "1",
+        metaKey: true,
+        ctrlKey: false,
+      }),
+    ).toBe(0);
+    expect(
+      searchPanelSessionDigitIndex({
+        key: "9",
+        metaKey: false,
+        ctrlKey: true,
+      }),
+    ).toBe(8);
+    expect(
+      searchPanelSessionDigitIndex({
+        key: "0",
+        metaKey: true,
+        ctrlKey: false,
+      }),
+    ).toBeNull();
+    expect(
+      searchPanelSessionDigitIndex({
+        key: "2",
+        metaKey: false,
+        ctrlKey: false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveSearchPanelKey", () => {
+  const base = {
+    activeIndex: 1,
+    itemCount: 5,
+    sessionCount: 3,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    isComposing: false,
+  };
+
+  it("navigates unmodified arrows and activates Enter", () => {
+    expect(resolveSearchPanelKey({ ...base, key: "ArrowDown" })).toEqual({
+      type: "nav",
+      index: 2,
+    });
+    expect(resolveSearchPanelKey({ ...base, key: "Enter" })).toEqual({
+      type: "activate",
+      index: 1,
+    });
+  });
+
+  it("does not steal Shift+Arrow, Home, or IME composition", () => {
+    expect(
+      resolveSearchPanelKey({ ...base, key: "ArrowDown", shiftKey: true }),
+    ).toEqual({ type: "none" });
+    expect(resolveSearchPanelKey({ ...base, key: "Home" })).toEqual({
+      type: "none",
+    });
+    expect(
+      resolveSearchPanelKey({ ...base, key: "ArrowDown", isComposing: true }),
+    ).toEqual({ type: "none" });
+  });
+
+  it("activates the Nth session via ⌘1–9", () => {
+    expect(
+      resolveSearchPanelKey({
+        ...base,
+        key: "2",
+        metaKey: true,
+      }),
+    ).toEqual({ type: "activateSession", sessionIndex: 1 });
+    expect(
+      resolveSearchPanelKey({
+        ...base,
+        key: "9",
+        metaKey: true,
+        sessionCount: 3,
+      }),
+    ).toEqual({ type: "none" });
+  });
+
+  it("Enter on an empty list is a no-op", () => {
+    expect(
+      resolveSearchPanelKey({ ...base, key: "Enter", itemCount: 0 }),
+    ).toEqual({ type: "none" });
+  });
+});

--- a/src/lib/searchPanelNav.ts
+++ b/src/lib/searchPanelNav.ts
@@ -1,0 +1,141 @@
+/**
+ * Command-palette keyboard selection for the session search panel.
+ *
+ * Rows are a flat list: actions → projects → sessions. ArrowUp/Down wrap.
+ * Home/End stay with the query caret. ⌘/Ctrl 1–9 open the Nth session row
+ * (same numbering already shown in the row meta).
+ */
+
+export type SearchPanelItemKind = "action" | "project" | "session";
+
+export type SearchPanelItem = {
+  kind: SearchPanelItemKind;
+  id: string;
+};
+
+export type SearchPanelNav = "up" | "down" | "pageUp" | "pageDown";
+
+export const SEARCH_PANEL_PAGE_SIZE = 8;
+
+export function flattenSearchPanelItems(input: {
+  actions?: ReadonlyArray<{ id: string }>;
+  projects?: ReadonlyArray<{ id: string }>;
+  sessions?: ReadonlyArray<{ id: string }>;
+}): SearchPanelItem[] {
+  const out: SearchPanelItem[] = [];
+  for (const a of input.actions ?? []) out.push({ kind: "action", id: a.id });
+  for (const p of input.projects ?? []) out.push({ kind: "project", id: p.id });
+  for (const s of input.sessions ?? []) out.push({ kind: "session", id: s.id });
+  return out;
+}
+
+export function searchPanelItemIndex(
+  items: ReadonlyArray<SearchPanelItem>,
+  kind: SearchPanelItemKind,
+  id: string,
+): number {
+  return items.findIndex((it) => it.kind === kind && it.id === id);
+}
+
+export function clampSearchPanelIndex(index: number, length: number): number {
+  if (length <= 0) return 0;
+  if (!Number.isFinite(index)) return 0;
+  return Math.min(Math.max(0, Math.trunc(index)), length - 1);
+}
+
+export function searchPanelNavFromKey(key: string): SearchPanelNav | null {
+  switch (key) {
+    case "ArrowUp":
+      return "up";
+    case "ArrowDown":
+      return "down";
+    case "PageUp":
+      return "pageUp";
+    case "PageDown":
+      return "pageDown";
+    default:
+      return null;
+  }
+}
+
+export function stepSearchPanelIndex(
+  current: number,
+  length: number,
+  nav: SearchPanelNav,
+  pageSize = SEARCH_PANEL_PAGE_SIZE,
+): number {
+  if (length <= 0) return 0;
+  const cur = clampSearchPanelIndex(current, length);
+  const page = Math.max(1, Math.trunc(pageSize) || SEARCH_PANEL_PAGE_SIZE);
+  switch (nav) {
+    case "down":
+      return (cur + 1) % length;
+    case "up":
+      return (cur - 1 + length) % length;
+    case "pageDown":
+      return clampSearchPanelIndex(cur + page, length);
+    case "pageUp":
+      return clampSearchPanelIndex(cur - page, length);
+    default:
+      return cur;
+  }
+}
+
+export function searchPanelSessionDigitIndex(e: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+}): number | null {
+  if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return null;
+  if (!/^[1-9]$/.test(e.key)) return null;
+  return Number(e.key) - 1;
+}
+
+export type SearchPanelKeyResult =
+  | { type: "none" }
+  | { type: "nav"; index: number }
+  | { type: "activate"; index: number }
+  | { type: "activateSession"; sessionIndex: number };
+
+export function resolveSearchPanelKey(input: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  isComposing?: boolean;
+  activeIndex: number;
+  itemCount: number;
+  sessionCount: number;
+}): SearchPanelKeyResult {
+  if (input.isComposing) return { type: "none" };
+
+  const digit = searchPanelSessionDigitIndex(input);
+  if (digit != null) {
+    if (digit >= 0 && digit < input.sessionCount) {
+      return { type: "activateSession", sessionIndex: digit };
+    }
+    return { type: "none" };
+  }
+
+  if (input.metaKey || input.ctrlKey || input.altKey) return { type: "none" };
+
+  const nav = searchPanelNavFromKey(input.key);
+  if (nav && !input.shiftKey) {
+    return {
+      type: "nav",
+      index: stepSearchPanelIndex(input.activeIndex, input.itemCount, nav),
+    };
+  }
+
+  if (input.key === "Enter" && !input.shiftKey && input.itemCount > 0) {
+    return {
+      type: "activate",
+      index: clampSearchPanelIndex(input.activeIndex, input.itemCount),
+    };
+  }
+
+  return { type: "none" };
+}

--- a/src/lib/searchPanelScroll.guard.test.ts
+++ b/src/lib/searchPanelScroll.guard.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Structural guard: command-palette hits must live in a dedicated scrollport.
+ * `.search-panel` clips to radius (`overflow: hidden` + max-height). Without
+ * an inner overflow-y scroller, wheel / trackpad do nothing (#543 pattern).
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(__dirname, "..");
+
+describe("search panel scrollport", () => {
+  it("wraps palette hits in OverlayScroll.search-panel__results", () => {
+    const src = readFileSync(join(ROOT, "app/AppWorkbench.tsx"), "utf8");
+    expect(src).toMatch(
+      /<OverlayScroll className="search-panel__results">/,
+    );
+    expect(src).toMatch(/<\/OverlayScroll>/);
+    const open = src.indexOf(
+      '<OverlayScroll className="search-panel__results">',
+    );
+    const close = src.indexOf("</OverlayScroll>", open);
+    const inner = src.slice(open, close);
+    expect(inner).toContain("search-panel__row");
+    expect(inner).toContain("mergedSessionHits.map");
+    expect(inner).toContain("data-search-idx");
+    expect(inner).toContain("search-opt-");
+  });
+
+  it("wires keyboard selection through useSearchPanelNav", () => {
+    const src = readFileSync(join(ROOT, "app/AppWorkbench.tsx"), "utf8");
+    expect(src).toContain("useSearchPanelNav");
+    expect(src).toContain("flattenSearchPanelItems");
+    expect(src).toContain("searchActiveIndex");
+    expect(src).toMatch(/role="combobox"/);
+  });
+
+  it("keeps results as the overflow-y scrollport under a clipping panel", () => {
+    const css = readFileSync(join(ROOT, "styles/sidebar.part2.css"), "utf8");
+    expect(css).toMatch(/\.search-panel\s*\{[^}]*overflow:\s*hidden/s);
+    expect(css).toMatch(/\.search-panel__results\s*\{[^}]*min-height:\s*0/s);
+    expect(css).toMatch(
+      /\.search-panel__results \.overlay-scroll__viewport\s*\{[^}]*overflow-y:\s*auto/s,
+    );
+    expect(css).toMatch(/\.search-panel__row\.is-active/);
+  });
+});

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -545,6 +545,7 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   border-radius: var(--modal-radius, 16px);
   display: flex;
   flex-direction: column;
+  /* Clip to radius; hits scroll in .search-panel__results (not here). */
   overflow: hidden;
   color: var(--text-primary);
   box-sizing: border-box;
@@ -557,6 +558,7 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   padding: 12px 14px;
   border-bottom: 1px solid var(--border-subtle);
   color: var(--text-tertiary);
+  flex-shrink: 0;
 }
 
 .search-panel__input {
@@ -584,6 +586,24 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   gap: 8px;
   padding: 8px 14px 10px;
   border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+/*
+ * Sole vertical scrollport for palette hits. Without this, max-height +
+ * overflow:hidden on .search-panel clips rows and wheel/trackpad do nothing
+ * (same trap as automations #543).
+ */
+.search-panel__results {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.search-panel__results .overlay-scroll__viewport {
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-bottom: 6px;
 }
 
 .search-panel__modes {
@@ -644,6 +664,7 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   gap: 8px 12px;
   padding: 8px 14px;
   border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
 }
 
 .search-panel__modes {
@@ -776,7 +797,8 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   box-sizing: border-box;
 }
 
-.search-panel__row:hover {
+.search-panel__row:hover,
+.search-panel__row.is-active {
   background: var(--menu-hover);
   color: var(--text-primary);
 }


### PR DESCRIPTION
## Why

Command-palette search (`⌘K`) could not be scrolled with a mouse wheel or trackpad. Hits sat in `.search-panel` under `max-height` + `overflow: hidden` with no inner scrollport, so the list was clipped and wheel/trackpad had nowhere to go (same trap as automations #543). After that, the list also had no keyboard highlight.

## What

- Wrap actions / projects / sessions in `OverlayScroll.search-panel__results` so the search field and filter chips stay put.
- Pin chrome with `flex-shrink: 0`; results viewport is the only `overflow-y: auto` scroller.
- `↑` / `↓` move a highlight across the flattened list (wraps); `Enter` opens the active row; `PageUp` / `PageDown` jump 8 rows; `⌘1`–`⌘9` (`Ctrl` on Windows) open the Nth **session** (same numbering already shown in the row meta).
- `Home` / `End` stay with the query caret. Changing the query or filters resets the highlight; late content hits only clamp the index.
- Mouse hover updates the highlight. Active row uses the existing menu hover surface and `scrollIntoView({ block: "nearest" })`.

## Verify

- `pnpm exec vitest run src/lib/searchPanelNav.test.ts src/lib/searchPanelScroll.guard.test.ts`
- Manual: open search, type a query that overflows the panel, wheel / trackpad the list. Then `↓` / `↑` and `Enter`. Confirm `⌘1` opens the first session row.

## Notes

Independent of #655 (Design Mode / Kanban / Spaces). No new i18n strings. No `window.confirm` / native `<select>`.