### PR TITLE
fix: Working rail overlap and leftover ANSI in tool output

### DIFF
--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -250,6 +250,7 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
   expanded,
   onUserToggle,
   onPolicySync,
+  lockCollapsed,
   findQuery,
   findActiveOccurrence,
   messageContent,
@@ -263,6 +264,11 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
   expanded: boolean;
   /** User click: mark user-toggled + set open (parent). */
   onUserToggle?: (key: string, open: boolean) => void;
+  /**
+   * Fixed-height VirtualList rows cannot host expand bodies. Hide detail
+   * while windowed so stdout / thought text cannot paint over the next row.
+   */
+  lockCollapsed?: boolean;
   /**
    * Running / auto-collapse policy sync (parent). Applies even when currently
    * expanded so running→finished collapses under default autoCollapse.
@@ -351,7 +357,7 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
     });
   }, [running, autoCollapse, step.key, hasBody, onPolicySync]);
 
-  const open = hasBody && expanded;
+  const open = hasBody && expanded && !lockCollapsed;
   const showBody = open;
 
   if (step.type === "speech") {
@@ -520,11 +526,17 @@ export function GrokActivitySteps({
     },
     [],
   );
+  const liveBodyCount = steps.reduce((n, s) => {
+    if (s.type === "speech") return n;
+    if (s.type === "thought") return n + (s.streaming && s.text.trim() ? 1 : 0);
+    return n + ("running" in s && s.running ? 1 : 0);
+  }, 0);
   const virtualize =
     !steps.some((s) => s.type === "speech") &&
     shouldVirtualizeActivityWithExpand(
       total,
       expandState.expandedKeys.size,
+      liveBodyCount,
     );
   const lastKey = total > 0 ? steps[total - 1]!.key : null;
 
@@ -539,6 +551,7 @@ export function GrokActivitySteps({
         expanded={expandState.expandedKeys.has(step.key)}
         onUserToggle={onUserToggle}
         onPolicySync={onPolicySync}
+        lockCollapsed={virtualize}
         findQuery={findQuery}
         findActiveOccurrence={findActiveOccurrence}
         messageContent={messageContent}
@@ -552,6 +565,7 @@ export function GrokActivitySteps({
       expandState.expandedKeys,
       onUserToggle,
       onPolicySync,
+      virtualize,
       findQuery,
       findActiveOccurrence,
       messageContent,

--- a/src/components/lobe-chat/lobe-chat.part2.css
+++ b/src/components/lobe-chat/lobe-chat.part2.css
@@ -66,6 +66,8 @@
 .grok-act__steps--virtual .grok-act__step {
   height: 30px;
   min-height: 30px;
+  max-height: 30px;
+  overflow: hidden;
   flex-shrink: 0;
   box-sizing: border-box;
 }

--- a/src/lib/ansi.test.ts
+++ b/src/lib/ansi.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { stripAnsi } from "./ansi";
+
+describe("stripAnsi", () => {
+  it("removes SGR sequences", () => {
+    expect(stripAnsi("\u001b[31mERROR\u001b[0m boom")).toBe("ERROR boom");
+  });
+
+  it("removes leftover SGR after ESC was dropped", () => {
+    expect(stripAnsi("[39mBuild complete in [32m42169ms[39m")).toBe(
+      "Build complete in 42169ms",
+    );
+    expect(stripAnsi("[30m WARN [39m Unsupported platform")).toBe(
+      " WARN  Unsupported platform",
+    );
+  });
+
+  it("keeps ordinary bracket text", () => {
+    expect(stripAnsi("array[0] ok")).toBe("array[0] ok");
+    expect(stripAnsi("see issue [39] later")).toBe("see issue [39] later");
+  });
+});

--- a/src/lib/ansi.ts
+++ b/src/lib/ansi.ts
@@ -1,0 +1,16 @@
+/**
+ * Strip terminal color / cursor sequences from CLI and MCP dumps.
+ * Also removes leftover SGR like `[39m` after the ESC byte was dropped
+ * (common on Windows / electron-builder / pnpm color output).
+ */
+export function stripAnsi(text: string): string {
+  return String(text ?? "")
+    .replace(/\u001b\][\s\S]*?(?:\u0007|\u001b\\)/g, "")
+    .replace(/\u001b\[[\d;?]*(?:[ -/]*[@-~])/g, "")
+    .replace(/\x1b\[[\d;?]*(?:[ -/]*[@-~])/g, "")
+    .replace(/\u009b[\d;?]*(?:[ -/]*[@-~])/g, "")
+    .replace(/\u001b[PX^_][\s\S]*?\u001b\\/g, "")
+    .replace(/\u001b[@-_]/g, "")
+    .replace(/\x1b/g, "")
+    .replace(/\[(?:\d{1,3};)*\d{1,3}m/g, "");
+}

--- a/src/lib/grokActivityVirtualize.test.ts
+++ b/src/lib/grokActivityVirtualize.test.ts
@@ -50,6 +50,12 @@ describe("grokActivityVirtualize", () => {
     expect(GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS).toBe(12);
   });
 
+  it("live tool bodies leave VirtualList even before expand policy runs", () => {
+    const stepCount = GROK_ACTIVITY_VIRTUALIZE_THRESHOLD + 5;
+    expect(shouldVirtualizeActivityWithExpand(stepCount, 0, 0)).toBe(true);
+    expect(shouldVirtualizeActivityWithExpand(stepCount, 0, 1)).toBe(false);
+  });
+
   it("expand leaves VirtualList and user toggle survives remount", () => {
     const stepCount = GROK_ACTIVITY_VIRTUALIZE_THRESHOLD + 5;
     expect(shouldVirtualizeActivityWithExpand(stepCount, 0)).toBe(true);

--- a/src/lib/grokActivityVirtualize.ts
+++ b/src/lib/grokActivityVirtualize.ts
@@ -35,9 +35,12 @@ export function shouldVirtualizeGrokActivitySteps(stepCount: number): boolean {
 export function shouldVirtualizeActivityWithExpand(
   stepCount: number,
   expandedKeyCount: number,
+  liveBodyCount = 0,
 ): boolean {
   return (
-    shouldVirtualizeGrokActivitySteps(stepCount) && expandedKeyCount === 0
+    shouldVirtualizeGrokActivitySteps(stepCount) &&
+    expandedKeyCount === 0 &&
+    liveBodyCount === 0
   );
 }
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -11,6 +11,7 @@ import type {
   ErrorDeckCode,
   ErrorDeckResolveOpts,
 } from "./errorDeck";
+import { stripAnsi } from "./ansi";
 import { bashArgFromToolTitle, inferKindFromToolCallId } from "./toolDisplay";
 
 export type SessionState =
@@ -3008,10 +3009,7 @@ const AGENT_ERROR_CODE_RE =
 const MARKDOWN_CODE_RE =
   /^\*\*(CLI_NOT_FOUND|AUTH_FAILED|NETWORK_PROVIDER|AGENT_CRASHED|QUOTA_EXCEEDED|CONNECT_FAILED|PROCESS_LIMIT|CLI_TOO_OLD|SANDBOX_BLOCKED)\*\*(?:\s*[\r\n]+([\s\S]*))?$/;
 
-/** Strip ANSI SGR sequences from CLI/MCP stderr dumps. */
-export function stripAnsi(text: string): string {
-  return text.replace(/\u001b\[[0-9;]*m/g, "").replace(/\x1b\[[0-9;]*m/g, "");
-}
+export { stripAnsi };
 
 /** Drop stderr tails and other bulky transport noise from error strings. */
 export function stripErrorNoise(text: string): string {

--- a/src/lib/toolDisplay.test.ts
+++ b/src/lib/toolDisplay.test.ts
@@ -197,6 +197,12 @@ describe("toolDisplay", () => {
     expect(body.command).toBe(""); // not a bash tool
   });
 
+  it("toolOutputBody strips leftover ANSI from CLI dumps", () => {
+    expect(toolOutputBody("[39mBuild complete in [32m42169ms[39m")).toBe(
+      "Build complete in 42169ms",
+    );
+  });
+
   it("toolOutputBody elides the middle of very long output", () => {
     const long = Array.from({ length: 1000 }, (_, i) => `line ${i}`).join("\n");
     const body = toolOutputBody(long, 100);

--- a/src/lib/toolDisplay.ts
+++ b/src/lib/toolDisplay.ts
@@ -3,6 +3,8 @@
  * Summaries only; live mid-stream still prefers Host title via toolStepDisplayTitle.
  */
 
+import { stripAnsi } from "./ansi";
+
 export type ToolDisplayKind =
   | "bash"
   | "read"
@@ -496,7 +498,9 @@ export function toolOutputBody(
   output: string | null | undefined,
   maxLines = TOOL_OUTPUT_BODY_MAX_LINES,
 ): string {
-  const raw = (output || "").replace(/\r\n/g, "\n").replace(/\s+$/, "");
+  const raw = stripAnsi(output || "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\s+$/, "");
   if (!raw) return "";
   const lines = raw.split("\n");
   if (lines.length <= maxLines) return raw;


### PR DESCRIPTION
Fixes #667

## Motivation

On Windows (150% DPI, light theme, Grok App 0.2.20), expanding a long live **Working / 工作中** block sometimes paints tool summaries and raw CLI stdout on top of each other. After the first clip fix, a long finished **工作了** list still looked crushed: expanding one file/tool painted its body over later rows. `electron-builder` / pnpm color dumps also leak leftover SGR like `[39m` / `[32m`.

## Cause

1. Activity steps virtualize at a fixed row height. Expanded thought/tool bodies used `.grok-act__expand-body { overflow: visible }`, so a stdout block painted over the next rows.
2. Leaving `VirtualList` still put speech/expanded steps in a `12 × 30px` flex box (`max-height: 360px`). Default `flex-shrink` plus `min-height: 0` mashed every row into that box, so expand bodies overlapped later tools.
3. `stripAnsi` only removed CSI SGR. After the ESC byte was dropped (common on Windows CLI dumps), `[39m` remained and was shown in the rail.

## Change

- Leave `VirtualList` when any step is live or expanded.
- Do not render expand bodies while the list is windowed; clip virtual rows (`max-height` + `overflow: hidden`).
- Mapped (speech / expanded) lists: do not shrink step rows; cap the scroller at `min(70vh, 40rem)` instead of `N × 30px`.
- Widen the activity rail so labels and file tails have room.
- Shared `stripAnsi` also removes leftover `[39m`-style SGR and skips the regex chain when the dump has no ESC/SGR; `toolOutputBody` runs it on CLI dumps.

## Verify

- `pnpm exec vitest run src/lib/ansi.test.ts src/lib/grokActivityVirtualize.test.ts src/lib/session.test.ts src/lib/toolDisplay.test.ts`
- Manual: long Agent turn with colored `pnpm` / `electron-builder` output → expand **工作中** / a file row → rows stay one-line, expand pushes later tools down, no `[39m`.

## Env (reporter)

Windows 11 26200 · Grok App 0.2.20 · CLI 1.0.4 · 2560×1600 @ 150% · light theme · `grok-4.6` / `xhigh` / agent.
