### PR TITLE
fix: premature 工作了 + copy/retry while turn still running

### DIFF
--- a/src-tauri/src/session_manager/events.rs
+++ b/src-tauri/src/session_manager/events.rs
@@ -192,10 +192,28 @@ impl SessionManager {
                         };
                         // I04: throttled mid-stream journal (force on terminal done chunk).
                         let para = is_paragraph_break(&text);
-                        Self::maybe_flush_stream_journal(s, done, para);
+                        // prompt_for emits an empty done tick when the RPC
+                        // returns — often while tools are still open. Do not
+                        // paint 工作了 / copy-retry until the turn can finish.
+                        let emit_done = done
+                            && crate::turn_complete::should_emit_stream_done(
+                                s.prompt_in_flight,
+                                s.fsm.state() == SessionState::AwaitingPermission,
+                                s.pending_plan_rpc_id.is_some(),
+                                s.pending_ask_user_rpc_id.is_some(),
+                                s.open_tool_ids.len(),
+                            );
+                        Self::maybe_flush_stream_journal(s, emit_done, para);
                         let mid = s.streaming_message_id.clone().unwrap_or_default();
-                        let need =
-                            Self::queue_stream_emit(s, app, kind, mid, text, thought_phase, done);
+                        let need = Self::queue_stream_emit(
+                            s,
+                            app,
+                            kind,
+                            mid,
+                            text,
+                            thought_phase,
+                            emit_done,
+                        );
                         if need {
                             s.stream_emit_flush_gen = s.stream_emit_flush_gen.wrapping_add(1);
                             Some((s.app_session_id.clone(), s.stream_emit_flush_gen))
@@ -555,12 +573,12 @@ impl SessionManager {
                         };
                         s.tools_this_turn = s.tools_this_turn.saturating_add(1);
                         // Tools settled → apply deferred prompt_complete if any (#52).
-                        let empty =
-                            Self::try_finish_deferred_prompt_complete(s, Some(app)).flatten();
+                        let finished =
+                            Self::try_finish_deferred_prompt_complete(s, Some(app));
                         (
                             s.app_session_id.clone(),
                             s.project_path.clone(),
-                            empty,
+                            finished,
                             open_changed,
                             already_terminal,
                         )
@@ -568,7 +586,12 @@ impl SessionManager {
                         (String::new(), None, None, false, false)
                     }
                 };
-                Self::emit_empty_run_if_any(app, empty_run);
+                Self::emit_empty_run_if_any(app, empty_run.clone().flatten());
+                // Live ToolCall used to flatten away Some(None)=finished, so
+                // Ready never reached the UI and the composer stayed on Stop.
+                if empty_run.is_some() {
+                    Self::emit_state(app, &self.snapshot());
+                }
 
                 // Live tool activity for UI — recover identity when completed
                 // updates omit title/kind (sparse status-only payloads).

--- a/src-tauri/src/session_manager/events.rs
+++ b/src-tauri/src/session_manager/events.rs
@@ -573,8 +573,7 @@ impl SessionManager {
                         };
                         s.tools_this_turn = s.tools_this_turn.saturating_add(1);
                         // Tools settled → apply deferred prompt_complete if any (#52).
-                        let finished =
-                            Self::try_finish_deferred_prompt_complete(s, Some(app));
+                        let finished = Self::try_finish_deferred_prompt_complete(s, Some(app));
                         (
                             s.app_session_id.clone(),
                             s.project_path.clone(),

--- a/src-tauri/src/turn_complete.rs
+++ b/src-tauri/src/turn_complete.rs
@@ -40,6 +40,28 @@ pub fn should_defer_prompt_complete(
     awaiting_permission || pending_plan || pending_ask_user || open_tool_count > 0
 }
 
+/// Whether a `session://stream` `done:true` tick may close the UI turn.
+///
+/// `session/prompt` often resolves (or the 3s `prompt_complete` fallback
+/// fires) while tools are still open. Forwarding that empty done tick makes
+/// the transcript show 工作了 + copy/retry while the Host FSM is still
+/// Streaming — the frozen-tail / stuck-composer bug.
+pub fn should_emit_stream_done(
+    prompt_in_flight: bool,
+    awaiting_permission: bool,
+    pending_plan: bool,
+    pending_ask_user: bool,
+    open_tool_count: usize,
+) -> bool {
+    !prompt_in_flight
+        && !should_defer_prompt_complete(
+            awaiting_permission,
+            pending_plan,
+            pending_ask_user,
+            open_tool_count,
+        )
+}
+
 /// Update open-tool tracking for one tool_call / tool_call_update.
 ///
 /// **Monotonic terminal:** once a tool id is terminal this turn, later
@@ -112,6 +134,14 @@ mod tests {
         assert!(should_defer_prompt_complete(false, true, false, 0));
         assert!(should_defer_prompt_complete(false, false, true, 0));
         assert!(should_defer_prompt_complete(false, false, false, 2));
+    }
+
+    #[test]
+    fn stream_done_suppressed_while_prompt_or_tools_live() {
+        assert!(should_emit_stream_done(false, false, false, false, 0));
+        assert!(!should_emit_stream_done(true, false, false, false, 0));
+        assert!(!should_emit_stream_done(false, false, false, false, 1));
+        assert!(!should_emit_stream_done(false, true, false, false, 0));
     }
 
     #[test]

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -659,6 +659,8 @@ type TranscriptMessageRowProps = {
   editAttachments: Attachment[];
   canEditLastUser: boolean;
   canRegenerate: boolean;
+  /** Host still mid-turn — hide copy/MD/retry even if this row already settled. */
+  turnLive: boolean;
   canRewindSession: boolean;
   regenerableAssistantId: string | null;
   regenerateModels: ModelOption[];
@@ -726,6 +728,7 @@ function transcriptRowPropsEqual(
   if (a.editAttachments !== b.editAttachments) return false;
   if (a.canEditLastUser !== b.canEditLastUser) return false;
   if (a.canRegenerate !== b.canRegenerate) return false;
+  if (a.turnLive !== b.turnLive) return false;
   if (a.canRewindSession !== b.canRewindSession) return false;
   if (a.regenerableAssistantId !== b.regenerableAssistantId) return false;
   if (a.regenerateModels !== b.regenerateModels) return false;
@@ -770,6 +773,7 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
   editAttachments,
   canEditLastUser,
   canRegenerate,
+  turnLive,
   canRewindSession,
   regenerableAssistantId,
   regenerateModels,
@@ -1518,7 +1522,7 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
         ) : null
       }
       actions={(() => {
-        if (m.streaming) return null;
+        if (m.streaming || turnLive) return null;
         const showCopy = !!m.content.trim();
         const showRegen =
           !!onRegenerateAssistant && regenerableAssistantId === m.id;
@@ -2449,6 +2453,10 @@ export function ConversationThread({
               editAttachments={editAttachments}
               canEditLastUser={canEditLastUser}
               canRegenerate={canRegenerate}
+              turnLive={
+                sessionState === "streaming" ||
+                sessionState === "awaiting_permission"
+              }
               canRewindSession={canRewindSession}
               regenerableAssistantId={regenerableAssistantId}
               regenerateModels={regenerateModels}

--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -17,6 +17,7 @@ import {
   applyTurnMarker,
   isSessionBusy,
   isSessionLiveStreaming,
+  pickRunningTurnTool,
   upgradeMessagesFromJournal,
   weaveToolsIntoAssistantSegments,
   ensureBusyTurnStreaming,
@@ -100,7 +101,10 @@ import {
   resolveStreamFlushMs,
   toolEventNeedsImmediateFlush,
 } from "@/lib/streamCoalesce";
-import { shouldApplyLateStreamText } from "@/lib/streamLateToken";
+import {
+  shouldApplyLateStreamText,
+  shouldIgnorePrematureStreamDone,
+} from "@/lib/streamLateToken";
 import {
   chatcutHandoffToResourceOpenTarget,
   resolveChatcutHandoffFromToolEvent,
@@ -757,6 +761,26 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           // Anti-replay vs late answer after early ready (see streamLateToken).
           // Busy/liveMap re-promotion stays gated via mayPromoteStreamingFromStreamChunk.
           const host = c.liveHostRef.current;
+          const sidForChunk = chunk.sessionId || "";
+          const cachedForChunk = sidForChunk
+            ? (c.messagesBySessionRef.current.get(sidForChunk) ?? [])
+            : [];
+          const hostLive =
+            !!sidForChunk &&
+            ((host.sessionId === sidForChunk &&
+              isSessionLiveStreaming(host.state)) ||
+              isSessionLiveStreaming(
+                c.liveMapRef.current[sidForChunk]?.state,
+              ));
+          const ignoreDone =
+            !!chunk.done &&
+            shouldIgnorePrematureStreamDone({
+              hostLiveStreaming: hostLive,
+              hasRunningTool: !!pickRunningTurnTool(cachedForChunk),
+            });
+          const effective: StreamPayload = ignoreDone
+            ? { ...chunk, done: false }
+            : chunk;
           if (chunk.text && chunk.sessionId) {
             const msgs =
               c.messagesBySessionRef.current.get(chunk.sessionId) ?? [];
@@ -781,12 +805,12 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           // Multi-session busy projection for in-progress streams only.
           // Never re-promote a turn already settled to ready/idle (late/coalesced
           // tokens after host ready — issue #225 stuck sidebar spinner).
-          if (chunk.sessionId && !chunk.done) {
+          if (chunk.sessionId && !effective.done) {
             c.setLiveMap((prev) => {
               const sid = chunk.sessionId!;
               if (
                 !mayPromoteStreamingFromStreamChunk(prev[sid], {
-                  done: chunk.done,
+                  done: effective.done,
                 })
               ) {
                 return prev;
@@ -798,7 +822,7 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
               });
             });
           }
-          if (chunk.done && chunk.sessionId) {
+          if (effective.done && chunk.sessionId) {
             c.setLiveMap((prev) =>
               projectHostIntoLiveMap(prev, {
                 sessionId: chunk.sessionId!,
@@ -817,7 +841,7 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             }
           }
           c.patchSessionMessages(chunk.sessionId, (prev) => {
-            const next = applyStreamChunk(prev, chunk);
+            const next = applyStreamChunk(prev, effective);
             // Keep cache in sync immediately so post-turn apply sees final text.
             if (chunk.sessionId) {
               c.messagesBySessionRef.current.set(chunk.sessionId, next);
@@ -830,7 +854,7 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             );
           }
           // After a completed assistant stream, try silent automation create.
-          if (chunk.done && chunk.sessionId) {
+          if (effective.done && chunk.sessionId) {
             void c.tryApplyAutomationFromSession(chunk.sessionId);
           }
         };

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1042,6 +1042,42 @@ describe("session projection", () => {
     expect(asst[0]!.content).toContain("kernel rebuild failed");
   });
 
+  it("mergeAssistantFragments does not duplicate multi-segment finished bodies", () => {
+    const rows: ChatMessage[] = [
+      { id: "u1", role: "user", content: "go" },
+      {
+        id: "a-live",
+        role: "assistant",
+        content: "looking",
+        streaming: true,
+      },
+      {
+        id: "a-done",
+        role: "assistant",
+        content: "part one\n\npart two",
+        streaming: false,
+        segments: [
+          { kind: "content", text: "part one" },
+          { kind: "thought", text: "hmm" },
+          { kind: "content", text: "part two" },
+        ],
+      },
+    ];
+    const merged = mergeAssistantFragments(rows);
+    const asst = merged.filter((m) => m.role === "assistant");
+    expect(asst).toHaveLength(1);
+    const body = asst[0]!.content ?? "";
+    expect(body.match(/part one/g)?.length).toBe(1);
+    expect(body.match(/part two/g)?.length).toBe(1);
+    const contentSegs = (asst[0]!.segments ?? []).filter((s) => s.kind === "content");
+    const joined = contentSegs.map((s) => s.text).join("\n");
+    expect(joined.match(/part one/g)?.length).toBe(1);
+    expect(joined.match(/part two/g)?.length).toBe(1);
+    expect(asst[0]!.segments?.some((s) => s.kind === "thought" && s.text === "hmm")).toBe(
+      true,
+    );
+  });
+
   it("mergeAssistantFragments leaves live / single-row turns untouched", () => {
     const rows: ChatMessage[] = [
       { id: "u1", role: "user", content: "hi" },

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1017,6 +1017,31 @@ describe("session projection", () => {
     ).toBeGreaterThanOrEqual(1);
   });
 
+  it("mergeAssistantFragments folds a later finished fragment into a live sibling", () => {
+    const rows: ChatMessage[] = [
+      { id: "u1", role: "user", content: "pack it" },
+      {
+        id: "a-live",
+        role: "assistant",
+        content: "still working on the increment",
+        streaming: true,
+      },
+      {
+        id: "a-done",
+        role: "assistant",
+        content: "kernel rebuild failed; switching runtime",
+        streaming: false,
+      },
+    ];
+    const merged = mergeAssistantFragments(rows);
+    const asst = merged.filter((m) => m.role === "assistant");
+    expect(asst).toHaveLength(1);
+    expect(asst[0]!.id).toBe("a-live");
+    expect(asst[0]!.streaming).toBe(true);
+    expect(asst[0]!.content).toContain("still working on the increment");
+    expect(asst[0]!.content).toContain("kernel rebuild failed");
+  });
+
   it("mergeAssistantFragments leaves live / single-row turns untouched", () => {
     const rows: ChatMessage[] = [
       { id: "u1", role: "user", content: "hi" },

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -792,6 +792,68 @@ export function mergeAssistantFragments(messages: ChatMessage[]): ChatMessage[] 
   let i = 0;
   while (i < messages.length) {
     const m = messages[i]!;
+    if (m.role === "assistant" && !m.isError && m.streaming) {
+      // Live row + a later finished fragment in the same turn (early
+      // stream-done) painted 工作中 above a frozen 工作了 + copy/retry.
+      let j = i + 1;
+      const finishedIdx: number[] = [];
+      while (j < messages.length && messages[j]!.role !== "user") {
+        const mm = messages[j]!;
+        if (mm.role === "assistant" && !mm.isError && !mm.streaming) {
+          finishedIdx.push(j);
+        }
+        j += 1;
+      }
+      if (finishedIdx.length === 0) {
+        out.push(m);
+        i += 1;
+        continue;
+      }
+      const extraBodies: string[] = [];
+      const extraThoughts: string[] = [];
+      let segs = ensureSegments(m);
+      for (const idx of finishedIdx) {
+        const f = messages[idx]!;
+        const body = (f.content ?? "").trim();
+        if (body && !(m.content ?? "").includes(body)) extraBodies.push(body);
+        if (f.thought?.trim()) extraThoughts.push(f.thought.trim());
+        const fsegs =
+          f.segments?.length
+            ? f.segments
+            : buildSegmentsFromLegacy(f.content, f.thought, f.thoughtPhases);
+        for (const s of fsegs) {
+          if (s.kind === "content") {
+            if (s.text.trim() && !(m.content ?? "").includes(s.text.trim())) {
+              segs = appendContentToSegments(segs, `\n\n${s.text.trim()}`);
+            }
+            continue;
+          }
+          segs.push(s.kind === "tool" ? { ...s } : { kind: "thought", text: s.text });
+        }
+      }
+      const extraBlock = extraBodies.join("\n\n");
+      const content = extraBlock
+        ? `${m.content || ""}${m.content?.trim() ? "\n\n" : ""}${extraBlock}`
+        : m.content;
+      if (extraBlock && extraBodies.every((b) => !segs.some((s) => s.kind === "content" && s.text.includes(b)))) {
+        segs = appendContentToSegments(segs, extraBlock);
+      }
+      const thoughts = [m.thought?.trim(), ...extraThoughts].filter(Boolean);
+      out.push({
+        ...m,
+        content,
+        thought: thoughts.length ? thoughts.join("\n\n⟪phase⟫\n\n") : m.thought,
+        segments: compactMessageSegments(segs),
+        streaming: true,
+      });
+      for (let k = i + 1; k < j; k++) {
+        const row = messages[k]!;
+        if (row.role === "assistant" && !row.isError && !row.streaming) continue;
+        out.push(row);
+      }
+      i = j;
+      continue;
+    }
     if (m.role !== "assistant" || m.isError || m.streaming) {
       out.push(m);
       i += 1;

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -11,6 +11,7 @@ import type {
   ErrorDeckCode,
   ErrorDeckResolveOpts,
 } from "./errorDeck";
+import { stripAnsi } from "./ansi";
 import { bashArgFromToolTitle, inferKindFromToolCallId } from "./toolDisplay";
 
 export type SessionState =
@@ -822,12 +823,11 @@ export function mergeAssistantFragments(messages: ChatMessage[]): ChatMessage[] 
             ? f.segments
             : buildSegmentsFromLegacy(f.content, f.thought, f.thoughtPhases);
         for (const s of fsegs) {
-          if (s.kind === "content") {
-            if (s.text.trim() && !(m.content ?? "").includes(s.text.trim())) {
-              segs = appendContentToSegments(segs, `\n\n${s.text.trim()}`);
-            }
-            continue;
-          }
+          // Answer text is merged once via extraBlock / f.content below.
+          // Appending each content segment here AND extraBlock doubled
+          // mid-turn prose when a finished fragment had several content
+          // parts (thought/tools interleaved).
+          if (s.kind === "content") continue;
           segs.push(s.kind === "tool" ? { ...s } : { kind: "thought", text: s.text });
         }
       }
@@ -3070,10 +3070,7 @@ const AGENT_ERROR_CODE_RE =
 const MARKDOWN_CODE_RE =
   /^\*\*(CLI_NOT_FOUND|AUTH_FAILED|NETWORK_PROVIDER|AGENT_CRASHED|QUOTA_EXCEEDED|CONNECT_FAILED|PROCESS_LIMIT|CLI_TOO_OLD|SANDBOX_BLOCKED)\*\*(?:\s*[\r\n]+([\s\S]*))?$/;
 
-/** Strip ANSI SGR sequences from CLI/MCP stderr dumps. */
-export function stripAnsi(text: string): string {
-  return text.replace(/\u001b\[[0-9;]*m/g, "").replace(/\x1b\[[0-9;]*m/g, "");
-}
+export { stripAnsi };
 
 /** Drop stderr tails and other bulky transport noise from error strings. */
 export function stripErrorNoise(text: string): string {

--- a/src/lib/streamLateToken.test.ts
+++ b/src/lib/streamLateToken.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { shouldApplyLateStreamText } from "./streamLateToken";
+import {
+  shouldApplyLateStreamText,
+  shouldIgnorePrematureStreamDone,
+} from "./streamLateToken";
 
 describe("shouldApplyLateStreamText", () => {
   it("always applies when host is still live-streaming", () => {
@@ -88,6 +91,27 @@ describe("shouldApplyLateStreamText", () => {
             thought: "",
           },
         ],
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores stream-done while host or tools are still live", () => {
+    expect(
+      shouldIgnorePrematureStreamDone({
+        hostLiveStreaming: true,
+        hasRunningTool: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldIgnorePrematureStreamDone({
+        hostLiveStreaming: false,
+        hasRunningTool: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldIgnorePrematureStreamDone({
+        hostLiveStreaming: false,
+        hasRunningTool: false,
       }),
     ).toBe(false);
   });

--- a/src/lib/streamLateToken.ts
+++ b/src/lib/streamLateToken.ts
@@ -62,3 +62,16 @@ export function shouldApplyLateStreamText(opts: {
   // Settled with body already present, or tool-only empty final → drop replays.
   return false;
 }
+
+/**
+ * Early `session://stream` `done:true` (prompt_complete / prompt RPC
+ * fallback) must not freeze the bubble while Host is still mid-turn.
+ * A later fragment would then render as 工作了 + copy/MD/retry under a
+ * still-live 工作中 rail.
+ */
+export function shouldIgnorePrematureStreamDone(opts: {
+  hostLiveStreaming: boolean;
+  hasRunningTool: boolean;
+}): boolean {
+  return opts.hostLiveStreaming || opts.hasRunningTool;
+}


### PR DESCRIPTION
Fixes #670

## Problem

On a long Agent turn, the transcript can split into two rails:

- Upper bubble keeps **工作中** and still refreshes step summaries
- Lower bubble freezes as **工作了** with copy / MD / retry (retry disabled)
- Sidebar still says the agent is running; composer stays on the red Stop square
- When the real work ends, Ready is sometimes never painted, so send stays blocked

## Cause

1. `session/prompt` often resolves (or the 3s `prompt_complete` fallback fires) while tools are still open. Host forwarded an empty `session://stream` `done:true`. The UI settled that fragment and showed copy/MD/retry.
2. Later work kept attaching to the still-live sibling, so **工作中** continued above the frozen tail.
3. Live `ToolCall` called `try_finish_deferred_prompt_complete(...).flatten()`, which turns `Some(None)` (finished, not empty) into `None`. Ready was never `emit_state`'d, so the composer/sidebar stayed streaming.

## Change

- Host: do not emit stream `done` while prompt is in flight or tools/gates are open (`should_emit_stream_done`).
- Host: emit session state when deferred prompt_complete actually finishes on the live ToolCall path.
- UI: ignore premature `done` if Host/liveMap is still streaming or a tool is running.
- UI: fold a later finished assistant fragment into the live sibling.
- UI: hide copy/MD/retry while `sessionState` is streaming / awaiting permission.

## Verify

- `pnpm exec vitest run src/lib/streamLateToken.test.ts src/lib/session.test.ts`
- Manual: long Agent turn with tools after the first status paragraph — should stay one live 工作中, no copy/retry until Host is actually Ready; after the last tool, Stop should become Send.
