### PR TITLE
fix: stop capped Working lists from crushing rows into overlap

### DIFF
--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -45,11 +45,11 @@ import {
 } from "@/lib/toolDisplay";
 import {
   GROK_ACTIVITY_STEP_ROW_PX,
-  GROK_ACTIVITY_VIRTUALIZE_THRESHOLD,
   applyActivityStepExpandPolicy,
   applyActivityStepUserToggle,
   emptyActivityStepExpandState,
   grokActivityVirtualMaxHeightPx,
+  shouldCapMappedGrokActivitySteps,
   shouldVirtualizeActivityWithExpand,
   type ActivityStepExpandState,
 } from "@/lib/grokActivityVirtualize";
@@ -576,20 +576,17 @@ export function GrokActivitySteps({
   if (!total) return null;
 
   if (!virtualize) {
-    // Keep the same max-height scroller as the virtual path. Leaving the
-    // cap when a running step auto-expands used to dump 20–200 rows into
-    // the chat and fight stick-to-bottom (transcript flash).
-    const cap =
-      total > GROK_ACTIVITY_VIRTUALIZE_THRESHOLD
-        ? grokActivityVirtualMaxHeightPx(total)
-        : undefined;
+    // Long mapped lists (speech / expanded detail) keep a tall CSS cap so
+    // they do not dump 20–200 rows into the transcript. Do not set an
+    // inline N×rowHeight — that 360px box used to flex-shrink every row
+    // and paint expand bodies over the next tools.
+    const cap = shouldCapMappedGrokActivitySteps(total);
     return (
       <div
         className={
           "grok-act__steps" + (cap ? " grok-act__steps--capped" : "")
         }
         role="list"
-        style={cap ? { maxHeight: cap } : undefined}
       >
         {steps.map((step, idx) => (
           <GrokActivityStepRow

--- a/src/components/lobe-chat/lobe-chat.part1.css
+++ b/src/components/lobe-chat/lobe-chat.part1.css
@@ -746,7 +746,7 @@ html[data-msg-actions="always"] .lobe-chat-item__actions {
 
 .lobe-timeline-rail {
   width: 100%;
-  max-width: var(--chat-content-max, 48rem);
+  max-width: var(--grok-act-max, min(64rem, 100%));
   margin: 0;
   padding: 0;
   border-left: none;
@@ -771,7 +771,7 @@ html[data-msg-actions="always"] .lobe-chat-item__actions {
   --grok-act-gap: 8px;
   --grok-act-font: 13px;
   width: 100%;
-  max-width: var(--chat-content-max, 48rem);
+  max-width: var(--grok-act-max, min(64rem, 100%));
   margin: 0 0 6px;
   color: var(--grok-act-fg);
   font-size: var(--grok-act-font);

--- a/src/components/lobe-chat/lobe-chat.part2.css
+++ b/src/components/lobe-chat/lobe-chat.part2.css
@@ -54,19 +54,27 @@
 }
 
 /* Long step lists: max-height scroller so expand / live cannot dump
-   dozens of rows into the transcript (stick-to-bottom flash). */
-.grok-act__steps--capped,
+   dozens of rows into the transcript (stick-to-bottom flash).
+   Mapped (capped) lists are variable-height — keep this taller than the
+   old 12×30=360 box and never flex-shrink children (that stacked rows). */
+.grok-act__steps--capped {
+  max-height: min(70vh, 40rem);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  min-height: 0;
+}
 .grok-act__steps--virtual {
-  max-height: 360px; /* fallback; inline style sets min(12, n) * 30 */
+  max-height: 648px; /* fallback; inline style sets min(18, n) * 36 */
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
   min-height: 0;
 }
 .grok-act__steps--virtual .grok-act__step {
-  height: 30px;
-  min-height: 30px;
-  max-height: 30px;
+  height: 36px;
+  min-height: 36px;
+  max-height: 36px;
   overflow: hidden;
   flex-shrink: 0;
   box-sizing: border-box;
@@ -76,7 +84,7 @@
   justify-content: center;
 }
 .grok-act__steps--virtual .grok-act__icon-col {
-  padding-top: 7px; /* center 16px icon in 30px row */
+  padding-top: 10px; /* center 16px icon in 36px row */
 }
 .grok-act__steps--virtual .grok-act__step.is-last .grok-act__main {
   padding-bottom: 0;
@@ -89,6 +97,7 @@
   gap: var(--grok-act-gap, 8px);
   width: 100%;
   min-height: 0;
+  flex-shrink: 0;
   margin: 0;
   padding: 0;
   color: var(--grok-act-fg);
@@ -144,7 +153,7 @@
 .grok-act__main {
   flex: 1;
   min-width: 0;
-  padding: 0 0 8px;
+  padding: 2px 0 10px;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;

--- a/src/lib/ansi.test.ts
+++ b/src/lib/ansi.test.ts
@@ -19,4 +19,10 @@ describe("stripAnsi", () => {
     expect(stripAnsi("array[0] ok")).toBe("array[0] ok");
     expect(stripAnsi("see issue [39] later")).toBe("see issue [39] later");
   });
+
+  it("returns clean output unchanged (no regex work)", () => {
+    const plain = "ran 3 searches, 4 files";
+    expect(stripAnsi(plain)).toBe(plain);
+    expect(stripAnsi("")).toBe("");
+  });
 });

--- a/src/lib/ansi.ts
+++ b/src/lib/ansi.ts
@@ -2,9 +2,16 @@
  * Strip terminal color / cursor sequences from CLI and MCP dumps.
  * Also removes leftover SGR like `[39m` after the ESC byte was dropped
  * (common on Windows / electron-builder / pnpm color output).
+ *
+ * Fast-path: skip the regex chain when the string has no ESC/CSI and no
+ * leftover `[39m`-style SGR (hot path for clean tool output).
  */
+const ANSI_HINT = /[\u001b\u009b\x1b]|\[(?:\d{1,3};)*\d{1,3}m/;
+
 export function stripAnsi(text: string): string {
-  return String(text ?? "")
+  const s = String(text ?? "");
+  if (!ANSI_HINT.test(s)) return s;
+  return s
     .replace(/\u001b\][\s\S]*?(?:\u0007|\u001b\\)/g, "")
     .replace(/\u001b\[[\d;?]*(?:[ -/]*[@-~])/g, "")
     .replace(/\x1b\[[\d;?]*(?:[ -/]*[@-~])/g, "")

--- a/src/lib/grokActivityVirtualize.test.ts
+++ b/src/lib/grokActivityVirtualize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  GROK_ACTIVITY_MAPPED_CAP_PX,
   GROK_ACTIVITY_STEP_ROW_PX,
   GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS,
   GROK_ACTIVITY_VIRTUALIZE_THRESHOLD,
@@ -8,6 +9,7 @@ import {
   emptyActivityStepExpandState,
   grokActivityVirtualMaxHeightPx,
   resolveActivityStepExpandDesired,
+  shouldCapMappedGrokActivitySteps,
   shouldVirtualizeActivityWithExpand,
   shouldVirtualizeGrokActivitySteps,
 } from "./grokActivityVirtualize";
@@ -36,18 +38,32 @@ describe("grokActivityVirtualize", () => {
   it("maxHeight is min(visibleRows, count) × row height", () => {
     expect(grokActivityVirtualMaxHeightPx(0)).toBe(0);
     expect(grokActivityVirtualMaxHeightPx(5)).toBe(5 * GROK_ACTIVITY_STEP_ROW_PX);
-    expect(grokActivityVirtualMaxHeightPx(15)).toBe(
-      GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS * GROK_ACTIVITY_STEP_ROW_PX,
-    );
+    expect(grokActivityVirtualMaxHeightPx(15)).toBe(15 * GROK_ACTIVITY_STEP_ROW_PX);
+    expect(
+      grokActivityVirtualMaxHeightPx(GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS + 3),
+    ).toBe(GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS * GROK_ACTIVITY_STEP_ROW_PX);
     expect(grokActivityVirtualMaxHeightPx(100)).toBe(
       GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS * GROK_ACTIVITY_STEP_ROW_PX,
     );
   });
 
-  it("row height constant matches virtual CSS contract (30px)", () => {
-    expect(GROK_ACTIVITY_STEP_ROW_PX).toBe(30);
+  it("row height constant matches virtual CSS contract (36px)", () => {
+    expect(GROK_ACTIVITY_STEP_ROW_PX).toBe(36);
     expect(GROK_ACTIVITY_VIRTUALIZE_THRESHOLD).toBe(14);
-    expect(GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS).toBe(12);
+    expect(GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS).toBe(18);
+    expect(GROK_ACTIVITY_MAPPED_CAP_PX).toBe(640);
+  });
+
+  it("mapped lists cap only past the virtualize threshold (CSS 70vh/40rem, not N×row)", () => {
+    expect(shouldCapMappedGrokActivitySteps(GROK_ACTIVITY_VIRTUALIZE_THRESHOLD)).toBe(
+      false,
+    );
+    expect(
+      shouldCapMappedGrokActivitySteps(GROK_ACTIVITY_VIRTUALIZE_THRESHOLD + 1),
+    ).toBe(true);
+    expect(grokActivityVirtualMaxHeightPx(100)).not.toBe(
+      GROK_ACTIVITY_MAPPED_CAP_PX,
+    );
   });
 
   it("live tool bodies leave VirtualList even before expand policy runs", () => {

--- a/src/lib/grokActivityVirtualize.ts
+++ b/src/lib/grokActivityVirtualize.ts
@@ -15,12 +15,18 @@ export const GROK_ACTIVITY_VIRTUALIZE_THRESHOLD = 14;
 /**
  * Fixed row height for windowed activity steps.
  * Matches virtual CSS on `.grok-act__steps--virtual .grok-act__step`
- * (natural non-virtual rows are ~line 1.4×15 + padding ≈ 30–31px).
+ * (label 13px × 1.4 + icon padding ≈ 34–36px).
  */
-export const GROK_ACTIVITY_STEP_ROW_PX = 30;
+export const GROK_ACTIVITY_STEP_ROW_PX = 36;
 
 /** Max rows visible in the virtual scroller before overflow. */
-export const GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS = 12;
+export const GROK_ACTIVITY_VIRTUAL_VISIBLE_ROWS = 18;
+
+/**
+ * Mapped (speech / expanded) lists use this CSS cap — not N × 36.
+ * Must stay in sync with `.grok-act__steps--capped { max-height: min(70vh, 40rem) }`.
+ */
+export const GROK_ACTIVITY_MAPPED_CAP_PX = 640;
 
 /** True when the list should use VirtualList + max-height scroller. */
 export function shouldVirtualizeGrokActivitySteps(stepCount: number): boolean {
@@ -144,4 +150,13 @@ export function grokActivityVirtualMaxHeightPx(stepCount: number): number {
     Math.max(0, Math.floor(stepCount)),
   );
   return n * GROK_ACTIVITY_STEP_ROW_PX;
+}
+
+/**
+ * Whether a mapped (non-virtual) step list should use the tall CSS cap.
+ * Speech / expanded rows are variable height — never reuse the virtual
+ * N × rowPx math or flex will crush them into that box.
+ */
+export function shouldCapMappedGrokActivitySteps(stepCount: number): boolean {
+  return shouldVirtualizeGrokActivitySteps(stepCount);
 }


### PR DESCRIPTION
Follow-up to #668 (already merged).

## Motivation

#668 stopped leftover `[39m` and clipped virtual 30px rows. After merge, a long **工作了** list still looked crushed: expanding one file/tool painted its body over later rows (`探索` / `Use tool`).

## Cause

Leaving `VirtualList` still put speech / expanded steps in a `12 × 30px` flex box (`max-height: 360px`). Default `flex-shrink` plus `min-height: 0` mashed every row into that box, so expand bodies overlapped later tools. The rail was also capped at `48rem`, so labels and file tails felt tight.

## Change

- Do not shrink `.grok-act__step` rows
- Mapped (speech / expanded) lists use `min(70vh, 40rem)` instead of `N × 30px`
- Widen the activity rail so labels and file tails have room
- `stripAnsi` skips the regex chain when the dump has no ESC/SGR (Copilot review on #668)

## Verify

- `pnpm exec vitest run src/lib/ansi.test.ts src/lib/grokActivityVirtualize.test.ts`
- Manual: expand **工作了** with 20+ steps → open one file/tool → later rows move down, no overlap

## Env

Windows 11 · Grok App 0.2.20 + local patch · 2560×1600 @ 150% · light theme
