### PR TITLE
fix(chat): 对话返还图片时不要先加载原图（#675）

### DIFF
--- a/src-tauri/src/image_thumb.rs
+++ b/src-tauri/src/image_thumb.rs
@@ -146,6 +146,52 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
     Ok(())
 }
 
+/// Sidecar next to `{hash}.jpg` so a cache hit can return **source** width/height
+/// without decoding the original (or even the thumb).
+fn dims_sidecar_path(thumb: &Path) -> PathBuf {
+    thumb.with_extension("dims")
+}
+
+fn write_source_dims_sidecar(thumb: &Path, width: u32, height: u32) {
+    if width == 0 || height == 0 {
+        return;
+    }
+    let _ = fs::write(dims_sidecar_path(thumb), format!("{width} {height}\n"));
+}
+
+fn read_source_dims_sidecar(thumb: &Path) -> Option<(u32, u32)> {
+    let raw = fs::read_to_string(dims_sidecar_path(thumb)).ok()?;
+    let mut parts = raw.split_whitespace();
+    let width = parts.next()?.parse::<u32>().ok()?;
+    let height = parts.next()?.parse::<u32>().ok()?;
+    if width > 0 && height > 0 {
+        Some((width, height))
+    } else {
+        None
+    }
+}
+
+/// Header-only dimensions from a cached JPEG thumb (old cache without sidecar).
+/// Never opens the original file.
+fn thumb_header_dims(thumb: &Path) -> Option<(u32, u32)> {
+    let reader = image::ImageReader::open(thumb)
+        .ok()?
+        .with_guessed_format()
+        .ok()?;
+    let (w, h) = reader.into_dimensions().ok()?;
+    if w > 0 && h > 0 {
+        Some((w, h))
+    } else {
+        None
+    }
+}
+
+fn cached_thumb_dims(thumb: &Path) -> (u32, u32) {
+    read_source_dims_sidecar(thumb)
+        .or_else(|| thumb_header_dims(thumb))
+        .unwrap_or((0, 0))
+}
+
 fn decode_image_bytes(bytes: &[u8]) -> Result<DynamicImage, String> {
     image::load_from_memory(bytes).map_err(|e| format!("decode image: {e}"))
 }
@@ -164,6 +210,7 @@ fn build_thumb_from_bytes(bytes: &[u8], out: &Path) -> Result<(u32, u32, bool), 
     };
     let jpeg = encode_jpeg(&thumb_img)?;
     write_atomic(out, &jpeg)?;
+    write_source_dims_sidecar(out, width, height);
     Ok((width, height, false))
 }
 
@@ -200,12 +247,9 @@ pub fn ensure_local_image_thumb(path: &str) -> Result<ImageThumbResult, String> 
     let key = local_cache_key(&canonical, mtime, size);
     let out = thumb_path_for_key(&key);
     if out.is_file() && fs::metadata(&out).map(|m| m.len()).unwrap_or(0) >= 32 {
-        // Dims from original (prefer re-read header only once).
-        let (w, h) = fs::read(&canonical)
-            .ok()
-            .and_then(|b| decode_image_bytes(&b).ok())
-            .map(|im| (im.width(), im.height()))
-            .unwrap_or((0, 0));
+        // Source dims from sidecar (or thumb JPEG header). Never decode the
+        // original — that is what froze chat on image-return remounts (#675).
+        let (w, h) = cached_thumb_dims(&out);
         path_scope::grant_path(&out);
         return Ok(ImageThumbResult {
             thumb_path: out.to_string_lossy().to_string(),
@@ -246,12 +290,7 @@ pub fn ensure_remote_image_thumb(url: &str) -> Result<ImageThumbResult, String> 
     let out = thumb_path_for_key(&key);
     if out.is_file() && fs::metadata(&out).map(|m| m.len()).unwrap_or(0) >= 32 {
         path_scope::grant_path(&out);
-        // Dims unknown without decode; decode cheap from small thumb.
-        let (w, h) = fs::read(&out)
-            .ok()
-            .and_then(|b| decode_image_bytes(&b).ok())
-            .map(|im| (im.width(), im.height()))
-            .unwrap_or((0, 0));
+        let (w, h) = cached_thumb_dims(&out);
         return Ok(ImageThumbResult {
             thumb_path: out.to_string_lossy().to_string(),
             from_cache: true,
@@ -343,5 +382,93 @@ mod tests {
         let k1 = local_cache_key(&p, 1, 100);
         let k2 = local_cache_key(&p, 2, 100);
         assert_ne!(k1, k2);
+    }
+
+    fn write_noisy_png_larger_than_skip(path: &Path) -> (u32, u32) {
+        let (w, h) = (640u32, 480u32);
+        let mut img = image::RgbImage::new(w, h);
+        for (x, y, p) in img.enumerate_pixels_mut() {
+            *p = image::Rgb([
+                (x.wrapping_mul(37) % 256) as u8,
+                (y.wrapping_mul(53) % 256) as u8,
+                ((x + y).wrapping_mul(17) % 256) as u8,
+            ]);
+        }
+        DynamicImage::ImageRgb8(img)
+            .save_with_format(path, ImageFormat::Png)
+            .unwrap();
+        let size = fs::metadata(path).unwrap().len();
+        assert!(
+            size > SKIP_IF_SMALLER_THAN,
+            "fixture too small to leave the skip-reencode path: {size}"
+        );
+        (w, h)
+    }
+
+    #[test]
+    fn cache_hit_returns_source_dims_without_decoding_original() {
+        let _scope = crate::path_scope::TEST_LOCK.blocking_lock();
+        let _home = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "grok-img-thumb-hit-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let app = dir.join("app");
+        fs::create_dir_all(&app).unwrap();
+        let prev_home = std::env::var("GROK_APP_HOME").ok();
+        std::env::set_var("GROK_APP_HOME", &app);
+        let src = dir.join("big.png");
+        let (src_w, src_h) = write_noisy_png_larger_than_skip(&src);
+        let src_str = src.to_string_lossy().to_string();
+
+        let miss = ensure_local_image_thumb(&src_str).expect("cache miss");
+        assert!(!miss.is_original);
+        assert_eq!((miss.width, miss.height), (src_w, src_h));
+        assert!(Path::new(&miss.thumb_path).is_file());
+        assert!(dims_sidecar_path(Path::new(&miss.thumb_path)).is_file());
+
+        let meta = fs::metadata(&src).unwrap();
+        let size = meta.len();
+        let mtime = meta.modified().unwrap();
+        // Same size + mtime so the cache key still hits, but the bytes are
+        // no longer a valid image. A cache hit that re-decodes the original
+        // would lose dimensions (or error).
+        fs::write(&src, vec![0u8; size as usize]).unwrap();
+        fs::File::open(&src).unwrap().set_modified(mtime).unwrap();
+
+        let hit = ensure_local_image_thumb(&src_str).expect("cache hit");
+        assert!(hit.from_cache);
+        assert_eq!(hit.thumb_path, miss.thumb_path);
+        assert_eq!((hit.width, hit.height), (src_w, src_h));
+        assert!(hit.width > 0 && hit.height > 0);
+
+        match prev_home {
+            Some(v) => std::env::set_var("GROK_APP_HOME", v),
+            None => std::env::remove_var("GROK_APP_HOME"),
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cached_thumb_dims_fall_back_to_jpeg_header() {
+        let dir = std::env::temp_dir().join(format!("grok-img-thumb-hdr-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let out = dir.join("only.jpg");
+        let img =
+            DynamicImage::ImageRgb8(image::RgbImage::from_pixel(32, 16, image::Rgb([1, 2, 3])));
+        let jpeg = encode_jpeg(&img).unwrap();
+        write_atomic(&out, &jpeg).unwrap();
+        assert!(read_source_dims_sidecar(&out).is_none());
+        assert_eq!(cached_thumb_dims(&out), (32, 16));
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/src/components/ImageUi.tsx
+++ b/src/components/ImageUi.tsx
@@ -29,7 +29,6 @@ import {
   isMediaEndpointReady,
   isViewableSrc,
   resolveImageSrc,
-  resolveImageSrcSync,
 } from "@/lib/imageSrc";
 import {
   mediaLoadErrorLabelMap,
@@ -45,9 +44,9 @@ import {
 } from "@/lib/imageAspectCache";
 import {
   canUseImageThumb,
+  chatCardFirstPaintSrc,
   invalidateChatImageThumb,
   nextChatCardDisplaySrc,
-  peekChatImageThumb,
   resolveChatImageThumb,
 } from "@/lib/imageThumbClient";
 import { isFusedQueryKeyPath } from "@/lib/pathNormalize";
@@ -129,15 +128,11 @@ function initialResolvedSrc(
   path?: string,
   layout?: ImageUiLayout,
 ): string | null {
-  // Remount after journal rehydrate must first-paint the cached thumb.
-  // Painting https then swapping to loopback aborts the in-flight <img>
-  // load; WKWebView onError then locked the card as broken_blob.
-  if (layout !== "pane") {
-    const peek = peekChatImageThumb(src, path)?.displaySrc;
-    if (peek) return peek;
-  }
-  if (isViewableSrc(src)) return src;
-  return resolveImageSrcSync(src);
+  return chatCardFirstPaintSrc(
+    src,
+    path,
+    layout === "pane" ? "pane" : "card",
+  );
 }
 
 function readCachedAr(src: string, path?: string): number | null {

--- a/src/lib/imageThumbClient.test.ts
+++ b/src/lib/imageThumbClient.test.ts
@@ -3,12 +3,14 @@ import * as api from "@/lib/api";
 import {
   clearChatImageThumbClientCache,
   canUseImageThumb,
+  chatCardFirstPaintSrc,
   getThumbCacheEndpoint,
   nextChatCardDisplaySrc,
   peekChatImageThumb,
   resolveChatImageThumb,
 } from "./imageThumbClient";
 import {
+  localPathToMediaHttpUrl,
   resetMediaEndpointForTests,
   setMediaEndpoint,
 } from "./imageSrc";
@@ -94,6 +96,64 @@ describe("peekChatImageThumb / nextChatCardDisplaySrc", () => {
         fromCache: true,
       }),
     ).toBe("http://127.0.0.1:9/v1/media?t=tok&p=%2Ftmp%2Ft.jpg");
+  });
+});
+
+describe("chatCardFirstPaintSrc — empty cache vs remount (#675)", () => {
+  it("does not first-paint the original media URL when the thumb cache is empty", () => {
+    setMediaEndpoint({ baseUrl: "http://127.0.0.1:9", token: "tok" });
+    const local = "/Users/me/imagine/1.png";
+    const originalUrl = localPathToMediaHttpUrl(local);
+    expect(originalUrl).toContain("/v1/media");
+    expect(originalUrl).toContain(encodeURIComponent(local));
+    expect(peekChatImageThumb(local, local)).toBeNull();
+
+    const first = chatCardFirstPaintSrc(local, local, "card");
+    expect(first).toBeNull();
+    expect(first).not.toBe(originalUrl);
+    expect(first).not.toBe(local);
+  });
+
+  it("does not first-paint a remote https original on an empty card cache", () => {
+    const remote = "https://cdn.example/chart.png";
+    expect(peekChatImageThumb(remote)).toBeNull();
+    expect(chatCardFirstPaintSrc(remote, undefined, "card")).toBeNull();
+  });
+
+  it("first-paints the cached thumb on remount", async () => {
+    setMediaEndpoint({ baseUrl: "http://127.0.0.1:9", token: "tok" });
+    vi.spyOn(api, "isDesktopHost").mockReturnValue(true);
+    vi.spyOn(api, "mediaImageThumb").mockResolvedValue({
+      thumbPath: "/tmp/cache/image-thumbs/x.jpg",
+      fromCache: true,
+      width: 1024,
+      height: 768,
+      isOriginal: false,
+    });
+    const local = "/Users/me/imagine/2.png";
+    expect(chatCardFirstPaintSrc(local, local, "card")).toBeNull();
+
+    const resolved = await resolveChatImageThumb(local, local);
+    expect(resolved?.displaySrc).toContain("127.0.0.1:9");
+    expect(resolved?.displaySrc).toContain(encodeURIComponent("/tmp/cache/image-thumbs/x.jpg"));
+
+    const remount = chatCardFirstPaintSrc(local, local, "card");
+    expect(remount).toBe(resolved?.displaySrc);
+    expect(remount).not.toBe(localPathToMediaHttpUrl(local));
+  });
+
+  it("pane layout still resolves the original on first paint", () => {
+    setMediaEndpoint({ baseUrl: "http://127.0.0.1:9", token: "tok" });
+    const local = "/Users/me/imagine/3.png";
+    expect(chatCardFirstPaintSrc(local, local, "pane")).toBe(
+      localPathToMediaHttpUrl(local),
+    );
+  });
+
+  it("keeps data/blob src when the card cannot use a host thumb", () => {
+    const data = "data:image/png;base64,xx";
+    expect(canUseImageThumb(data)).toBe(false);
+    expect(chatCardFirstPaintSrc(data, undefined, "card")).toBe(data);
   });
 });
 

--- a/src/lib/imageThumbClient.ts
+++ b/src/lib/imageThumbClient.ts
@@ -12,6 +12,7 @@ import {
   localPathToMediaHttpUrl,
   onMediaEndpointChange,
   resolveImageSrc,
+  resolveImageSrcSync,
 } from "@/lib/imageSrc";
 import { isFusedQueryKeyPath } from "@/lib/pathNormalize";
 import { setImageAspect } from "@/lib/imageAspectCache";
@@ -88,6 +89,30 @@ export function nextChatCardDisplaySrc(
   if (next) return next;
   const keep = (current || "").trim();
   return keep || null;
+}
+
+/**
+ * Sync first-paint src for a chat card (or resource pane).
+ *
+ * Card + empty thumb cache: return null so `<img>` does not load the full
+ * original (WKWebView decode of a multi-MB Imagine PNG freezes the UI).
+ * Remounts first-paint the in-memory thumb. Pane / non-thumb sources still
+ * resolve the original (lightbox and resource preview stay full-size).
+ */
+export function chatCardFirstPaintSrc(
+  src: string,
+  path?: string,
+  layout: "card" | "pane" = "card",
+): string | null {
+  if (layout === "pane") {
+    if (isViewableSrc(src)) return src;
+    return resolveImageSrcSync(path && isLocalAbs(path) ? path : src);
+  }
+  const peek = peekChatImageThumb(src, path)?.displaySrc?.trim();
+  if (peek) return peek;
+  if (canUseImageThumb(src, path)) return null;
+  if (isViewableSrc(src)) return src;
+  return resolveImageSrcSync(path && isLocalAbs(path) ? path : src);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #675.

When `image_gen` / Imagine writes a file, the chat card used to put the **full original** into `<img>` on first paint. WKWebView decoded that PNG on the UI thread and the window froze. At the same time the Host decoded the same file again to build a 480px JPEG. After the thumb existed, a cache hit still `load_from_memory`'d the original just to read width/height.

Two changes:

1. **Card first paint** (`chatCardFirstPaintSrc`): if there is no in-memory thumb yet, return `null` and show the existing placeholder. Do not point `<img>` at the original. Remounts still first-paint the cached thumb. Resource pane and lightbox still use the original.
2. **Host cache hit** (`ensure_local_image_thumb`): write a `{hash}.dims` sidecar with source width/height. A later hit reads the sidecar (or the thumb JPEG header). It never decodes the original.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `pnpm exec vitest run src/lib/imageThumbClient.test.ts src/lib/imageSrc.test.ts` — 26 passed, including empty-cache first paint (not the original media URL) and remount peek (thumb URL)
- [x] `cargo test --lib image_thumb` — 4 passed, including cache-miss write + cache-hit after the original bytes are replaced with same-size garbage (dims still come from the sidecar)
- [ ] `pnpm typecheck` — fails on `AppWorkbench.tsx` `segments` redeclare; that is on `main` (lines 7928 / 7953), not this branch
- [ ] Live Grok.app out-an-image check (not run here)

## Checklist
- [x] I ran `pnpm test` (image-related vitest files)
- [x] I ran `cargo test` in `src-tauri` (`image_thumb`)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] No new user-facing strings; llm-wiki media page unchanged (internal first-paint / cache-hit only)
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included