### PR TITLE
fix: preserve reasoning effort across session respawns

### DIFF
--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -1571,9 +1571,11 @@ impl AcpClient {
             crate::wsl_backend::apply_wslenv(&mut cmd);
         }
         tracing::info!(
-            "acp: spawn home={} mode={} native_grok_proxy={} sandbox={:?} max_turns={:?} fork_session={} no_ask_user={} leader={} subagents={} memory={} compaction_mode={} compaction_detail={} compaction_flags={} agent_profile={:?} agents_json={}",
+            "acp: spawn home={} mode={} model={} effort={:?} native_grok_proxy={} sandbox={:?} max_turns={:?} fork_session={} no_ask_user={} leader={} subagents={} memory={} compaction_mode={} compaction_detail={} compaction_flags={} agent_profile={:?} agents_json={}",
             grok_home.display(),
             session_data_mode,
+            spawn_model,
+            opts.effort,
             grok_build_proxy.is_some(),
             sandbox.as_ref().map(|s| s.profile.as_str()),
             max_turns.as_ref().map(|m| m.turns),

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -354,6 +354,9 @@ pub async fn composer_prefs_set(
     } else {
         session_id.or(live_sess)
     };
+    let previous_effort = effort.as_ref().map(|_| {
+        store::resolve_composer_prefs(project_id.as_deref(), session_id.as_deref()).effort
+    });
 
     let prefs = store::save_composer_prefs(
         project_id.as_deref(),
@@ -375,8 +378,14 @@ pub async fn composer_prefs_set(
         }
     }
     if let Some(eff) = effort {
+        let effort_changed = previous_effort.as_deref() != Some(eff.trim());
         if let Err(e) = mgr
-            .set_effort_and_respawn_needed(&app, eff, session_id.as_deref())
+            .set_effort_and_respawn_needed(
+                &app,
+                eff,
+                session_id.as_deref(),
+                effort_changed,
+            )
             .await
         {
             tracing::warn!("composer_prefs_set set_effort soft-fail: {e}");

--- a/src-tauri/src/image_thumb.rs
+++ b/src-tauri/src/image_thumb.rs
@@ -442,7 +442,12 @@ mod tests {
         // no longer a valid image. A cache hit that re-decodes the original
         // would lose dimensions (or error).
         fs::write(&src, vec![0u8; size as usize]).unwrap();
-        fs::File::open(&src).unwrap().set_modified(mtime).unwrap();
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&src)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
 
         let hit = ensure_local_image_thumb(&src_str).expect("cache hit");
         assert!(hit.from_cache);

--- a/src-tauri/src/providers.rs
+++ b/src-tauri/src/providers.rs
@@ -112,6 +112,8 @@ pub struct UpsertProviderInput {
 const APP_MODELS_KEY: &str = "app_models";
 /// TOML field (ignored by Grok Build) storing JSON array of `{id,name,isDefault}`.
 const APP_EFFORTS_KEY: &str = "app_efforts";
+/// Grok Build capability gate for forwarding `--reasoning-effort` to inference.
+const SUPPORTS_REASONING_EFFORT_KEY: &str = "supports_reasoning_effort";
 /// TOML field (ignored by Grok Build): when true, do not auto-append `/v1` to base_url.
 const APP_BASE_URL_FULL_PATH_KEY: &str = "app_base_url_full_path";
 /// TOML field (ignored by Grok Build): extra rules appended to the system prompt.
@@ -313,7 +315,7 @@ fn format_toml_field_value(key: &str, value: &str) -> String {
         }
     }
     // App-managed bool flags: write bare `true` / `false` when clearly boolean.
-    if key == APP_BASE_URL_FULL_PATH_KEY {
+    if key == APP_BASE_URL_FULL_PATH_KEY || key == SUPPORTS_REASONING_EFFORT_KEY {
         let raw = unquote(value.trim());
         match raw.to_ascii_lowercase().as_str() {
             "true" | "1" | "yes" | "on" => return "true".into(),
@@ -383,6 +385,58 @@ pub fn ensure_model_integer_fields() -> Result<bool, String> {
     tracing::info!(
         target: "providers",
         "repaired quoted integer fields (e.g. context_window) in agent-home config.toml"
+    );
+    Ok(true)
+}
+
+/// Enable Grok Build's native effort forwarding for existing custom providers
+/// that already expose effort choices in the App.
+fn ensure_reasoning_effort_support_fields() -> Result<bool, String> {
+    let _ = ensure_agent_home()?;
+    let path = agent_config_toml();
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let text = read_text(&path);
+    let sections = parse_model_sections(&text);
+    let mut insertions = Vec::new();
+    for section in sections {
+        if !is_custom(&section.fields)
+            || section.fields.contains_key(SUPPORTS_REASONING_EFFORT_KEY)
+            || decode_app_efforts(
+                section
+                    .fields
+                    .get(APP_EFFORTS_KEY)
+                    .map(std::string::String::as_str),
+            )
+            .is_empty()
+        {
+            continue;
+        }
+
+        let lines = config_lines(&text);
+        let index = (section.start + 1..section.end)
+            .find(|&i| assignment_key_exact(lines[i].trim()) == Some(APP_EFFORTS_KEY))
+            .map_or(section.end, |i| i + 1);
+        insertions.push(index);
+    }
+    if insertions.is_empty() {
+        return Ok(false);
+    }
+
+    let mut lines: Vec<_> = config_lines(&text).into_iter().map(str::to_owned).collect();
+    for index in insertions.into_iter().rev() {
+        lines.insert(index, format!("{SUPPORTS_REASONING_EFFORT_KEY} = true"));
+    }
+    let mut repaired = lines.join("\n");
+    if text.ends_with('\n') {
+        repaired.push('\n');
+    }
+    write_text(&path, &repaired)?;
+    tracing::info!(
+        target: "providers",
+        "enabled reasoning-effort forwarding for existing custom providers"
     );
     Ok(true)
 }
@@ -1176,6 +1230,8 @@ pub fn list_custom_providers() -> Result<ProvidersListResult, String> {
     let path = agent_config_toml();
     // Heal legacy App writes that stringified context_window (#538).
     let _ = ensure_model_integer_fields();
+    // Existing App-only effort choices need the native Grok Build capability gate.
+    let _ = ensure_reasoning_effort_support_fields();
     let text = read_text(&path);
     Ok(build_list_result(home, path, &text))
 }
@@ -1585,6 +1641,10 @@ pub fn upsert_custom_provider(input: UpsertProviderInput) -> Result<ProvidersLis
     if !app_efforts_json.is_empty() && app_efforts_json != "[]" {
         fields.push((APP_EFFORTS_KEY.into(), app_efforts_json));
     }
+    fields.push((
+        SUPPORTS_REASONING_EFFORT_KEY.into(),
+        (!efforts.is_empty()).to_string(),
+    ));
     if let Some(ref p) = resolved_append_prompt {
         fields.push((APP_APPEND_PROMPT_KEY.into(), p.clone()));
     }
@@ -3007,6 +3067,104 @@ api_backend = \"responses\"";
         let json = encode_app_efforts(&list);
         let decoded = decode_app_efforts(Some(&json));
         assert_eq!(decoded, list);
+    }
+
+    #[test]
+    fn custom_provider_efforts_enable_cli_reasoning_effort() {
+        let _lock = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home =
+            std::env::temp_dir().join(format!("grok-app-provider-effort-{}", uuid::Uuid::new_v4()));
+        let previous_home = std::env::var("GROK_APP_HOME").ok();
+        std::env::set_var("GROK_APP_HOME", &home);
+
+        let result = upsert_custom_provider(UpsertProviderInput {
+            id: "custom_gateway".into(),
+            model: "custom-reasoner".into(),
+            base_url: "https://custom.example/v1".into(),
+            name: Some("Custom Gateway".into()),
+            api_key: Some("test-key".into()),
+            api_backend: Some("responses".into()),
+            provider_mode: Some(PROVIDER_MODE_GENERIC.into()),
+            set_as_default: Some(false),
+            create_only: Some(true),
+            models: Some(vec![ProviderModelEntry {
+                id: "custom-reasoner".into(),
+                name: "Custom Reasoner".into(),
+            }]),
+            efforts: Some(vec![ProviderEffortEntry {
+                id: "xhigh".into(),
+                name: "Extra high".into(),
+                is_default: true,
+            }]),
+            context_window: None,
+            base_url_full_path: Some(false),
+            append_prompt: None,
+            supports_vision: Some(false),
+        })
+        .and_then(|_| std::fs::read_to_string(agent_config_toml()).map_err(|e| e.to_string()));
+
+        match previous_home {
+            Some(value) => std::env::set_var("GROK_APP_HOME", value),
+            None => std::env::remove_var("GROK_APP_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&home);
+
+        let config = result.expect("custom provider should be written");
+        assert!(
+            config.contains("supports_reasoning_effort = true"),
+            "Grok Build must see the native capability gate:\n{config}"
+        );
+        assert!(
+            !config.contains("supports_reasoning_effort = \"true\""),
+            "Grok Build requires a TOML boolean, not a string:\n{config}"
+        );
+    }
+
+    #[test]
+    fn list_repairs_existing_custom_provider_reasoning_support() {
+        let _lock = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!(
+            "grok-app-provider-effort-repair-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let previous_home = std::env::var("GROK_APP_HOME").ok();
+        std::env::set_var("GROK_APP_HOME", &home);
+
+        let result = (|| -> Result<String, String> {
+            ensure_app_dirs().map_err(|e| e.to_string())?;
+            let path = agent_config_toml();
+            write_text(
+                &path,
+                r#"[models]
+default = "custom_gateway"
+
+[model.custom_gateway]
+model = "custom-reasoner"
+base_url = "https://custom.example/v1"
+api_key = "test-key"
+api_backend = "responses"
+app_efforts = "[{\"id\":\"xhigh\",\"name\":\"Extra high\",\"isDefault\":true}]"
+"#,
+            )?;
+            list_custom_providers()?;
+            std::fs::read_to_string(path).map_err(|e| e.to_string())
+        })();
+
+        match previous_home {
+            Some(value) => std::env::set_var("GROK_APP_HOME", value),
+            None => std::env::remove_var("GROK_APP_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&home);
+
+        let config = result.expect("existing provider should be repaired");
+        assert!(
+            config.contains("supports_reasoning_effort = true"),
+            "existing App providers must be migrated without a manual re-save:\n{config}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -29,12 +29,7 @@ impl SessionManager {
         let _connect_guard = self.connect_lock.lock().await;
         match tokio::time::timeout(
             Duration::from_secs(CONNECT_WALL_CLOCK_SECS),
-            self.connect_inner(
-                app.clone(),
-                project_path,
-                app_session_id.clone(),
-                mock_mode,
-            ),
+            self.connect_inner(app.clone(), project_path, app_session_id.clone(), mock_mode),
         )
         .await
         {
@@ -1578,9 +1573,7 @@ mod connect_preserve_tests {
 
     #[test]
     fn wall_clock_and_stop_only_abort_handshake() {
-        assert!(should_fail_connect_on_wall_clock(
-            SessionState::Connecting
-        ));
+        assert!(should_fail_connect_on_wall_clock(SessionState::Connecting));
         assert!(!should_fail_connect_on_wall_clock(SessionState::Ready));
         assert!(stop_should_abort_handshake(SessionState::Connecting));
         assert!(!stop_should_abort_handshake(SessionState::Streaming));

--- a/src-tauri/src/session_manager/control.rs
+++ b/src-tauri/src/session_manager/control.rs
@@ -707,6 +707,7 @@ impl SessionManager {
         app: &AppHandle,
         effort: String,
         session_id: Option<&str>,
+        effort_changed: bool,
     ) -> Result<(), String> {
         let effort = effort.trim().to_string();
         // Accept CLI catalog values; unknown efforts still fail closed with a clear error.
@@ -720,6 +721,14 @@ impl SessionManager {
         if !ok {
             return Err(format!("invalid effort: {effort}"));
         }
+        // Grok Build's session/load restores the old model and reasoning effort,
+        // overriding this process's fresh spawn flags. On a real effort change,
+        // force session/new; the existing journal bootstrap preserves continuity.
+        if effort_changed {
+            if let Some(sid) = session_id {
+                store::clear_session_agent_session_id(sid)?;
+            }
+        }
         let need = {
             let mut guard = self.inner.lock();
             match guard.as_mut() {
@@ -727,6 +736,9 @@ impl SessionManager {
                     let same = s.effort.as_deref() == Some(effort.as_str());
                     s.effort = Some(effort.clone());
                     s.meta.effort = Some(effort.clone());
+                    if effort_changed {
+                        s.meta.agent_session_id = None;
+                    }
                     let _ = store::update_session_meta(&s.meta);
                     !same && s.acp.is_some()
                 }
@@ -740,6 +752,9 @@ impl SessionManager {
                 let same = s.effort.as_deref() == Some(effort.as_str());
                 s.effort = Some(effort.clone());
                 s.meta.effort = Some(effort.clone());
+                if effort_changed {
+                    s.meta.agent_session_id = None;
+                }
                 let _ = store::update_session_meta(&s.meta);
                 !same && s.acp.is_some()
             } else {

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -1635,6 +1635,30 @@ pub fn update_session_meta(meta: &SessionMeta) -> Result<(), String> {
     update_session_index_row(meta).map(|_| ())
 }
 
+fn clear_agent_session_id(list: &mut [SessionMeta], id: &str) -> bool {
+    let Some(session) = list.iter_mut().find(|session| session.id == id) else {
+        return false;
+    };
+    if session.agent_session_id.take().is_none() {
+        return false;
+    }
+    session.updated_at = Utc::now();
+    true
+}
+
+/// Force the next CLI connection to create a fresh agent session.
+///
+/// `session/load` restores process-level model/effort from the old CLI journal,
+/// overriding new `--model` / `--reasoning-effort` spawn flags.
+pub fn clear_session_agent_session_id(id: &str) -> Result<bool, String> {
+    let mut list = load_sessions_index();
+    let changed = clear_agent_session_id(&mut list, id);
+    if changed {
+        save_sessions_index(&list)?;
+    }
+    Ok(changed)
+}
+
 pub fn delete_session(id: &str) -> Result<(), String> {
     let id_for_index = id.to_string();
     update_sessions_index(move |list| {
@@ -3432,6 +3456,21 @@ mod tests {
             fork_agent_session: false,
             no_ask_user: None,
         }
+    }
+
+    #[test]
+    fn effort_change_can_invalidate_cli_session_resume() {
+        let now = Utc::now();
+        let mut keep = sample_session("keep", false, now);
+        keep.agent_session_id = Some("agent-keep".into());
+        let mut changed = sample_session("changed", false, now);
+        changed.agent_session_id = Some("agent-old".into());
+        let mut sessions = vec![keep, changed];
+
+        assert!(clear_agent_session_id(&mut sessions, "changed"));
+        assert_eq!(sessions[0].agent_session_id.as_deref(), Some("agent-keep"));
+        assert!(sessions[1].agent_session_id.is_none());
+        assert!(!clear_agent_session_id(&mut sessions, "changed"));
     }
 
     #[test]

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -285,6 +285,7 @@ import {
   type GoalOrchEvent
 } from "@/lib/goalOrch";
 import * as api from "@/lib/api";
+import { queueComposerPreferenceApply } from "@/lib/composerPrefsBarrier";
 import {
   DEFAULT_SANDBOX_PROFILE,
   SANDBOX_PROFILES,
@@ -2695,6 +2696,8 @@ export function AppWorkbench() {
   useEffect(() => {
     syncEnsureConnectingUi();
   }, [session.sessionId]);
+  /** Effort changes respawn the CLI; sends must wait for that write to settle. */
+  const effortApplyRef = useRef<Promise<void>>(Promise.resolve());
   /** Live provider retry progress (session://retry); cleared on success/stop/error. */
   // Value intentionally unbound (retry chip hidden): only the setter is kept
   // for cleanup calls. See the hidden-retry comment at the status-pill site.
@@ -7953,6 +7956,7 @@ export function AppWorkbench() {
     }
     const { storedDisplay, att, goalMode: useGoal, fromQueue } = opts;
     const quotesForSend = opts.quotes ?? [];
+    if (!fromQueue) await effortApplyRef.current;
     const segments = parseStoredContent(storedDisplay);
     if (isDraftEmpty(segments) && !att.length && !quotesForSend.length) {
       sendInFlightRef.current = false;
@@ -12686,6 +12690,24 @@ export function AppWorkbench() {
     );
     if (next !== effort) setEffort(next);
   }, [activeEffortCatalog, effort]);
+
+  const handleEffortPick = useCallback(
+    (nextEffort: string) => {
+      if (!isValidEffort(nextEffort, activeEffortCatalog)) return;
+      setEffort(nextEffort);
+      effortApplyRef.current = queueComposerPreferenceApply(
+        effortApplyRef.current,
+        () =>
+          api.composerPrefsSet({
+            projectId: activeProject?.id ?? null,
+            sessionId: session.sessionId ?? null,
+            effort: nextEffort,
+          }),
+        (error) => showToast(String(error), 4000),
+      );
+    },
+    [activeEffortCatalog, activeProject?.id, session.sessionId, showToast],
+  );
 
   const handleModelPick = useCallback(
     async (pick: ComposerModelPick) => {
@@ -21497,17 +21519,7 @@ export function AppWorkbench() {
                       onModelPick={(pick) => {
                         void handleModelPick(pick);
                       }}
-                      onEffort={(v) => {
-                        if (!isValidEffort(v, activeEffortCatalog)) return;
-                        setEffort(v);
-                        void api
-                          .composerPrefsSet({
-                            projectId: activeProject?.id ?? null,
-                            sessionId: session.sessionId ?? null,
-                            effort: v,
-                          })
-                          .catch((e) => showToast(String(e), 4000));
-                      }}
+                      onEffort={handleEffortPick}
                     />
                     <ComposerAccessMenu
                       mode={mode}
@@ -21850,17 +21862,7 @@ export function AppWorkbench() {
             onModelPick={(pick) => {
               void handleModelPick(pick);
             }}
-            onEffort={(v) => {
-              if (!isValidEffort(v, activeEffortCatalog)) return;
-              setEffort(v);
-              void api
-                .composerPrefsSet({
-                  projectId: activeProject?.id ?? null,
-                  sessionId: session.sessionId ?? null,
-                  effort: v,
-                })
-                .catch((e) => showToast(String(e), 4000));
-            }}
+            onEffort={handleEffortPick}
             onMode={(v) => {
               setMode(v);
               if (v === "plan") setGoalMode(false);

--- a/src/lib/composerPrefsBarrier.test.ts
+++ b/src/lib/composerPrefsBarrier.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { queueComposerPreferenceApply } from "./composerPrefsBarrier";
+
+describe("composer preference apply barrier", () => {
+  it("holds the next send until the effort change is applied", async () => {
+    let finishApply!: () => void;
+    const applying = new Promise<void>((resolve) => {
+      finishApply = resolve;
+    });
+    const applied: string[] = [];
+    const first = queueComposerPreferenceApply(
+      Promise.resolve(),
+      async () => {
+        applied.push("high");
+        await applying;
+      },
+      () => undefined,
+    );
+    const pending = queueComposerPreferenceApply(
+      first,
+      async () => {
+        applied.push("xhigh");
+      },
+      () => undefined,
+    );
+    let sent = false;
+    const send = pending.then(() => {
+      sent = true;
+    });
+
+    await Promise.resolve();
+    expect(sent).toBe(false);
+    expect(applied).toEqual(["high"]);
+
+    finishApply();
+    await send;
+    expect(sent).toBe(true);
+    expect(applied).toEqual(["high", "xhigh"]);
+  });
+});

--- a/src/lib/composerPrefsBarrier.ts
+++ b/src/lib/composerPrefsBarrier.ts
@@ -1,0 +1,11 @@
+/** Serialize a composer preference write so the next send can await it. */
+export function queueComposerPreferenceApply(
+  previous: Promise<void>,
+  apply: () => Promise<unknown>,
+  onError: (error: unknown) => void,
+): Promise<void> {
+  return previous
+    .then(apply, apply)
+    .then(() => undefined)
+    .catch(onError);
+}

--- a/src/lib/errorDeck.test.ts
+++ b/src/lib/errorDeck.test.ts
@@ -193,6 +193,9 @@ describe("buildErrorDeck", () => {
       }),
     ).toBe("AUTH_CUSTOM_PROVIDER");
     expect(
+      refineAuthDeckCode(noCtx, { activeSource: "custom" }),
+    ).toBe("AUTH_CUSTOM_PROVIDER");
+    expect(
       resolveErrorDeckCode("AUTH_FAILED", "401 unauthorized", {
         activeSource: "custom",
       }),

--- a/src/lib/errorDeck.ts
+++ b/src/lib/errorDeck.ts
@@ -439,6 +439,9 @@ export function refineAuthDeckCode(
   const s = (message ?? "").toLowerCase();
   const custom = opts?.activeSource === "custom";
 
+  // Custom routes never become valid by re-logging into the official account.
+  if (custom) return "AUTH_CUSTOM_PROVIDER";
+
   // Process / agent-home has no usable credentials (not just "wrong key").
   if (
     s.includes("no auth context") ||
@@ -462,12 +465,7 @@ export function refineAuthDeckCode(
         s.includes("not provided") ||
         s.includes("provided")));
   if (apiKeyish) {
-    return custom ? "AUTH_CUSTOM_PROVIDER" : "AUTH_API_KEY";
-  }
-
-  // Active custom relay: official re-login will not fix a bad key / OIDC mix.
-  if (custom) {
-    return "AUTH_CUSTOM_PROVIDER";
+    return "AUTH_API_KEY";
   }
 
   // Invalid/expired bearer with no more specific marker → generic re-login.


### PR DESCRIPTION
## Summary

Fix reasoning-effort changes that appear in the UI but are overwritten when an existing CLI session is resumed.

- serialize effort preference updates with the next send
- expose native reasoning-effort capability for custom provider effort catalogs
- invalidate the stored CLI agent session only when the effort actually changes
- force `session/new` so fresh `--model` and `--reasoning-effort` flags remain authoritative
- preserve conversation continuity through the existing local journal bootstrap
- improve safe spawn diagnostics and the custom-provider credential error message

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Root cause

Changing the effort soft-respawns the CLI with new process flags. For an existing conversation, the App then resumed the previous CLI agent session with `session/load`.

Grok Build restores the prior model and reasoning effort from that CLI journal, overriding the new process flags. The App therefore displayed the newly selected effort while requests could continue using the previous value.

With some custom API configurations, the restored model identifier can also resolve to a built-in route instead of the intended custom endpoint. If that route has no valid first-party credential context, the App reports an unavailable credential and the ACP connection drops.

This is not provider-specific: it depends on session resume state, model identifier resolution, and whether the custom backend exposes reasoning-effort support.

## Reproduction

1. Configure a custom model using the Responses backend and an effort catalog that includes `high` / `xhigh`.
2. Start a conversation with that custom model and complete one turn.
3. After the turn is idle, change the reasoning effort.
4. Send another message in the same conversation; repeating the switch makes the failure easier to observe.
5. Inspect the custom API trace or CLI session summary.

Before this change:

- the UI shows the new effort
- the resumed CLI session may keep the previous effort
- some custom configurations may restore a different route and surface a credential/disconnection error

Expected:

- the selected effort applies to the next turn
- the custom route remains selected
- the conversation remains usable

## Implementation

On a real effort change, clear the stored `agent_session_id` before the soft respawn. The next connection uses `session/new`, then the existing App journal bootstrap supplies recent conversation context.

The frontend also queues the preference write and awaits it before a direct send, closing the race where a message could reuse the old ready process before the host finished applying the effort.

## Validation

### Automated

- `pnpm test`: 407 test files, 5,769 tests passed
- `pnpm typecheck`: passed
- `pnpm lint`: passed
- focused Rust regression tests cover custom-provider reasoning capability serialization, migration of existing configs, and invalidation of only the selected CLI session
- `cargo test`: 1,250 passed, 1 ignored; one unrelated existing `plan_chrome::tests::upsert_and_mark_stale_round_trip` test is flaky under the full parallel run and passes when rerun in isolation
- `cargo fmt --all -- --check` currently reports two pre-existing formatting differences in `session_manager/connect.rs` on upstream `main`; this PR does not modify that file

### Manual end-to-end

Tested a custom Responses API in one existing conversation while switching:

`medium → xhigh → high`

For both effort changes:

- the CLI process spawned with the custom model alias and requested effort
- ACP used `session/new`, not `session/load`
- the new CLI session summary recorded the custom model alias and exact selected effort
- inference completed successfully
- no route fallback, credential error, or ACP disconnect occurred

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri`
- [ ] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [ ] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
