### PR TITLE
fix: 新建会话首条消息不再误报「消息没有真正发给 Agent」

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
-- **New-chat first send no longer false-heals as “message never reached the agent”**: Ghost-heal treated a leftover previous-session turn clock plus the `__draft__` → real-id handoff as “Host idle, send finished”. The toast fired, the composer was restored, and the agent still ran the prompt. New chat now clears the clock; draft sends start/migrate it; heal counts the draft send claim as in-flight.
+- **New-chat first send no longer false-heals as “message never reached the agent”**: Ghost-heal treated a leftover previous-session turn clock plus the `__draft__` → real-id handoff as “Host idle, send finished”. The toast fired, the composer was restored, and the agent still ran the prompt. New chat now clears the clock; draft sends start/migrate it; `sessionCreate` moves the send claim onto the real id immediately; heal also counts the draft claim as in-flight.
 
 **中文 · 修复**
-- **新建会话首条消息不再误报「消息没有真正发给 Agent」**：上一条会话留下的计时，加上草稿 `__draft__` 切到真实 session id 的空档，会被当成 Host 空闲、发送已结束。于是 toast 弹出、输入框还原，Agent 其实已经在跑。现在新建会话会清计时，草稿发送会建/迁移计时，heal 也会把草稿发送认领当成仍在发送。
+- **新建会话首条消息不再误报「消息没有真正发给 Agent」**：上一条会话留下的计时，加上草稿 `__draft__` 切到真实 session id 的空档，会被当成 Host 空闲、发送已结束。于是 toast 弹出、输入框还原，Agent 其实已经在跑。现在新建会话会清计时，草稿发送会建/迁移计时，`sessionCreate` 当下就把发送认领迁到新 id，heal 也会把草稿认领当成仍在发送。
 
 ## [0.2.21] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- **New-chat first send no longer false-heals as “message never reached the agent”**: Ghost-heal treated a leftover previous-session turn clock plus the `__draft__` → real-id handoff as “Host idle, send finished”. The toast fired, the composer was restored, and the agent still ran the prompt. New chat now clears the clock; draft sends start/migrate it; heal counts the draft send claim as in-flight.
+
+**中文 · 修复**
+- **新建会话首条消息不再误报「消息没有真正发给 Agent」**：上一条会话留下的计时，加上草稿 `__draft__` 切到真实 session id 的空档，会被当成 Host 空闲、发送已结束。于是 toast 弹出、输入框还原，Agent 其实已经在跑。现在新建会话会清计时，草稿发送会建/迁移计时，heal 也会把草稿发送认领当成仍在发送。
+
 ## [0.2.21] - 2026-08-18
 
 > **Highlight:** Create Image / Create Video from the composer + menu; Agent Kanban and Project Spaces; chat no longer freezes on the first generated image or stays stuck Connecting.

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -726,6 +726,11 @@ import {
   type QueuedSend
 } from "@/lib/sendQueue";
 import {
+  migrateDraftTurnClock,
+  resolveTurnClockKey,
+  shouldSyncViewedTurnClock,
+} from "@/lib/turnClock";
+import {
   useSendQueue,
   type ExecuteSendFromQueue
 } from "@/hooks/useSendQueue";
@@ -2717,7 +2722,14 @@ export function AppWorkbench() {
   const turnStartedAtBySessionRef = useRef<Map<string, number>>(new Map());
   /** Mirror a chat's clock into the visible timer when it is the viewed one. */
   const syncViewedTurnClock = useCallback((sessionId: string) => {
-    if (sessionId !== viewingSessionIdRef.current) return;
+    if (
+      !shouldSyncViewedTurnClock({
+        clockSessionId: sessionId,
+        viewingSessionId: viewingSessionIdRef.current,
+      })
+    ) {
+      return;
+    }
     setTurnStartedAt(turnStartedAtBySessionRef.current.get(sessionId) ?? null);
   }, [viewingSessionIdRef]);
   /** Begin a chat's turn clock, keeping the start of a turn already running. */
@@ -2744,6 +2756,9 @@ export function AppWorkbench() {
   const clearTurnClock = useCallback(
     (sessionId?: string | null) => {
       if (!sessionId) {
+        // Viewed timer only. An in-flight new-chat send still owns `__draft__`
+        // in the map until migrateDraftTurnClock; deleting it here would leave
+        // that background session with no grace clock if the user hits New chat.
         setTurnStartedAt(null);
         return;
       }
@@ -5507,6 +5522,12 @@ export function AppWorkbench() {
       state: "idle",
       backend: "grok_agent_stdio",
     });
+    // Drop the previous chat's elapsed timer. Ghost-heal grace uses this
+    // value; leaving it in place made a new-chat first send look 45s+ old.
+    clearTurnClock();
+    if (!isSendInFlightForSession(null)) {
+      turnStartedAtBySessionRef.current.delete(resolveTurnClockKey(null));
+    }
     setLocalError(null);
     // Multi-session: NEVER sessionDisconnect here.
     // Disconnect kills the live ACP process — that aborted in-flight turns when
@@ -7750,6 +7771,9 @@ export function AppWorkbench() {
           messagesBySessionRef.current.set(meta.id, draftMsgs);
           messagesBySessionRef.current.delete("__draft__");
         }
+        if (migrateDraftTurnClock(turnStartedAtBySessionRef.current, meta.id)) {
+          syncViewedTurnClock(meta.id);
+        }
         // Auto-tag worktree-bound chats when cwd is a linked worktree.
         if (api.isTauri() && connectProject?.path) {
           const linked = resolveSessionWorktreeBadge(
@@ -8073,7 +8097,11 @@ export function AppWorkbench() {
           ? prev
           : { ...prev, state: "streaming", lastError: null },
       );
-      restartTurnClock(sendTargetId ?? viewingSessionIdRef.current);
+      restartTurnClock(
+        resolveTurnClockKey(
+          sendTargetId ?? viewingSessionIdRef.current,
+        ),
+      );
     }
     // Optimistic liveHost only when we already own the live slot (or nothing is live).
     // Never stamp streaming onto a foreign mid-turn — ensureConnected demotes first.
@@ -8186,6 +8214,9 @@ export function AppWorkbench() {
         if (draftMsgs?.length) {
           messagesBySessionRef.current.set(sessionId, draftMsgs);
           messagesBySessionRef.current.delete("__draft__");
+        }
+        if (migrateDraftTurnClock(turnStartedAtBySessionRef.current, sessionId)) {
+          syncViewedTurnClock(sessionId);
         }
       }
       // Sticky setup only for explicit “用 AI 创建”, so a one-off “每天…” line

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -718,6 +718,7 @@ import {
   type PromptHistoryScope
 } from "@/components/PromptHistoryPanel";
 import {
+  migrateDraftSendClaim,
   planClearSendQueue,
   queueSessionKey,
   queuePreviewText,
@@ -7743,6 +7744,19 @@ export function AppWorkbench() {
           claims.add(materializedKey);
           heldConnectKeys.add(materializedKey);
         }
+        // Same handoff for the send claim. Heal re-arms on setSession(newId)
+        // below; if the claim stayed on __draft__ until connect returned,
+        // it looked like the turn never left.
+        if (
+          migrateDraftSendClaim(
+            sendInFlightBySessionRef.current,
+            sendEpochBySessionRef.current,
+            sessionId,
+          )
+        ) {
+          sendInFlightRef.current =
+            sendInFlightBySessionRef.current.size > 0;
+        }
         // Persist draft-page JSON Schema onto the new session before connect
         // so spawn can take top-level `grok --json-schema`.
         const pendingSchema = sessionJsonSchemaRef.current?.trim() || "";
@@ -8189,7 +8203,11 @@ export function AppWorkbench() {
       const materializedSendKey = queueSessionKey(sessionId);
       if (!heldSendKeys.has(materializedSendKey)) {
         const claims = sendInFlightBySessionRef.current;
-        if (claims.has(materializedSendKey)) {
+        const alreadyOurs =
+          claims.has(materializedSendKey) &&
+          sendEpochBySessionRef.current.get(materializedSendKey) ===
+            sendEpoch;
+        if (claims.has(materializedSendKey) && !alreadyOurs) {
           failStrip();
           return false;
         }
@@ -8198,9 +8216,11 @@ export function AppWorkbench() {
         if (sendEpochBySessionRef.current.get(sendKey) === sendEpoch) {
           sendEpochBySessionRef.current.delete(sendKey);
         }
-        claims.add(materializedSendKey);
+        if (!alreadyOurs) {
+          claims.add(materializedSendKey);
+          sendEpochBySessionRef.current.set(materializedSendKey, sendEpoch);
+        }
         heldSendKeys.add(materializedSendKey);
-        sendEpochBySessionRef.current.set(materializedSendKey, sendEpoch);
       }
       if (fromQueue && sendTargetId && sessionId !== sendTargetId) {
         failStrip();

--- a/src/hooks/useGhostStreamingHeal.ts
+++ b/src/hooks/useGhostStreamingHeal.ts
@@ -8,6 +8,7 @@
 import { useEffect, useRef, type MutableRefObject } from "react";
 import {
   findOptimisticGhostTurn,
+  ghostSendInFlight,
   GHOST_STREAMING_POLL_MS,
   shouldHealGhostStreaming,
   stripGhostTurnMessages,
@@ -118,8 +119,9 @@ export function useGhostStreamingHeal(deps: GhostStreamingHealDeps): void {
           nowMs: Date.now(),
           hostStateForSession: hostState,
           sendInFlight: d.sendInFlightBySessionRef
-            ? d.sendInFlightBySessionRef.current.has(
-                queueSessionKey(d.sessionId),
+            ? ghostSendInFlight(
+                d.sendInFlightBySessionRef.current,
+                d.sessionId,
               )
             : d.sendInFlightRef.current,
         })
@@ -133,15 +135,21 @@ export function useGhostStreamingHeal(deps: GhostStreamingHealDeps): void {
       healingRef.current = true;
       try {
         // Invalidate any hung executeSend still awaiting sessionSend.
+        // Also drop `__draft__`: a new-chat first send may still be claimed
+        // there after setSession(newId).
         const sessionKey = queueSessionKey(d.sessionId);
+        const draftKey = queueSessionKey(null);
         d.sendEpochRef.current += 1;
         if (d.sendEpochBySessionRef) {
-          const next =
-            (d.sendEpochBySessionRef.current.get(sessionKey) ?? 0) + 1;
-          d.sendEpochBySessionRef.current.set(sessionKey, next);
+          for (const key of new Set([sessionKey, draftKey])) {
+            const next =
+              (d.sendEpochBySessionRef.current.get(key) ?? 0) + 1;
+            d.sendEpochBySessionRef.current.set(key, next);
+          }
         }
         if (d.sendInFlightBySessionRef) {
           d.sendInFlightBySessionRef.current.delete(sessionKey);
+          d.sendInFlightBySessionRef.current.delete(draftKey);
           d.sendInFlightRef.current =
             d.sendInFlightBySessionRef.current.size > 0;
         } else {

--- a/src/lib/ghostStreamingHeal.test.ts
+++ b/src/lib/ghostStreamingHeal.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   findOptimisticGhostTurn,
+  ghostSendInFlight,
   GHOST_STREAMING_GRACE_MS,
   hostLooksIdleForSession,
   shouldHealGhostStreaming,
   stripGhostTurnMessages,
   type GhostChatMessage,
 } from "./ghostStreamingHeal";
+import { queueSessionKey } from "./sendQueue";
 
 const baseMsgs = (extra: GhostChatMessage[] = []): GhostChatMessage[] => [
   { id: "u1", role: "user", content: "hello" },
@@ -126,6 +128,98 @@ describe("ghostStreamingHeal", () => {
         hostStateForSession: "streaming",
       }),
     ).toBe(false);
+  });
+
+  it("ghostSendInFlight treats a draft claim as in-flight after session id materializes", () => {
+    const claims = new Set([queueSessionKey(null)]);
+    expect(ghostSendInFlight(claims, null)).toBe(true);
+    // ensureConnected already called setSession(newId); claim still on __draft__.
+    expect(ghostSendInFlight(claims, "s-new")).toBe(true);
+    expect(ghostSendInFlight(new Set(["s-new"]), "s-new")).toBe(true);
+    expect(ghostSendInFlight(new Set(["s-other"]), "s-new")).toBe(false);
+    expect(ghostSendInFlight([], "s-new")).toBe(false);
+    // Draft claim is global: another chat waits, it does not heal mid-send.
+    expect(ghostSendInFlight(claims, "s-other")).toBe(true);
+  });
+
+  it("does not heal a new-session first send while the draft claim is still held", () => {
+    const messages = [
+      { id: "u1", role: "user", content: "four lines of a new-chat prompt" },
+      { id: "a1", role: "assistant", content: "", streaming: true },
+    ];
+    const started = 1_000_000;
+    const stalePreviousTurn = started - GHOST_STREAMING_GRACE_MS - 60_000;
+    expect(
+      shouldHealGhostStreaming({
+        uiSessionState: "streaming",
+        viewedSessionId: "s-new",
+        messages,
+        // leftover clock from the previous chat (newChat used to keep it)
+        turnStartedAt: stalePreviousTurn,
+        nowMs: started,
+        hostStateForSession: "ready",
+        sendInFlight: ghostSendInFlight(
+          new Set([queueSessionKey(null)]),
+          "s-new",
+        ),
+      }),
+    ).toBe(false);
+  });
+
+  it("heals when a leftover previous-session clock is past grace and send is done", () => {
+    const messages = [
+      { id: "u1", role: "user", content: "four lines of a new-chat prompt" },
+      { id: "a1", role: "assistant", content: "", streaming: true },
+    ];
+    const started = 1_000_000;
+    expect(
+      shouldHealGhostStreaming({
+        uiSessionState: "streaming",
+        viewedSessionId: "s-new",
+        messages,
+        turnStartedAt: started - GHOST_STREAMING_GRACE_MS - 1,
+        nowMs: started,
+        hostStateForSession: "ready",
+        sendInFlight: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not heal when the viewed turn clock is missing", () => {
+    const messages = [
+      { id: "u1", role: "user", content: "four lines of a new-chat prompt" },
+      { id: "a1", role: "assistant", content: "", streaming: true },
+    ];
+    expect(
+      shouldHealGhostStreaming({
+        uiSessionState: "streaming",
+        viewedSessionId: "s-new",
+        messages,
+        turnStartedAt: null,
+        nowMs: 1_000_000 + GHOST_STREAMING_GRACE_MS + 60_000,
+        hostStateForSession: "ready",
+        sendInFlight: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("still heals a real ghost after the send claim is gone and Host stayed idle", () => {
+    const messages = [
+      { id: "u1", role: "user", content: "four lines of a new-chat prompt" },
+      { id: "a1", role: "assistant", content: "", streaming: true },
+    ];
+    const started = 1_000_000;
+    expect(
+      shouldHealGhostStreaming({
+        uiSessionState: "streaming",
+        viewedSessionId: "s-new",
+        messages,
+        turnStartedAt: started,
+        nowMs: started + GHOST_STREAMING_GRACE_MS,
+        hostStateForSession: "ready",
+        sendInFlight: ghostSendInFlight([], "s-new"),
+      }),
+    ).toBe(true);
   });
 
   it("stripGhostTurnMessages drops only the ghost pair", () => {

--- a/src/lib/ghostStreamingHeal.ts
+++ b/src/lib/ghostStreamingHeal.ts
@@ -19,6 +19,7 @@
 
 import type { SessionState } from "./session";
 import { isSessionLiveStreaming } from "./session";
+import { queueSessionKey } from "./sendQueue";
 
 /**
  * Wait this long after optimistic send before considering Host-absent a ghost.
@@ -117,6 +118,29 @@ export function findOptimisticGhostTurn(
     userMessageId: user.id,
     assistantMessageId: last.id,
   };
+}
+
+/**
+ * Whether ghost-heal should treat a send as still in flight for this view.
+ *
+ * New-chat first send claims `__draft__` and only moves that claim onto the
+ * real id *after* `ensureConnected` returns. `setSession(newId)` happens
+ * earlier, so a heal tick on the materialized id must still see the draft
+ * claim — otherwise it thinks Host is idle and restores the composer while
+ * `sessionSend` is about to run (or already running).
+ *
+ * A live `__draft__` claim counts for *every* viewed id (including a
+ * different chat). That can delay an unrelated heal until the draft send
+ * settles; it will not skip a real ghost forever.
+ */
+export function ghostSendInFlight(
+  claims: Iterable<string>,
+  viewedSessionId: string | null | undefined,
+): boolean {
+  const set = claims instanceof Set ? claims : new Set(claims);
+  if (set.has(queueSessionKey(viewedSessionId))) return true;
+  if (set.has(queueSessionKey(null))) return true;
+  return false;
 }
 
 /**

--- a/src/lib/sendQueue.test.ts
+++ b/src/lib/sendQueue.test.ts
@@ -12,6 +12,7 @@ import {
   isForeignLiveBusy,
   makeQueuedSend,
   migrateDraftQueue,
+  migrateDraftSendClaim,
   moveQueuedSend,
   planClearSendQueue,
   queuePreviewText,
@@ -35,6 +36,34 @@ describe("sendQueue", () => {
     expect(queueSessionKey(null)).toBe("__draft__");
     expect(queueSessionKey(undefined)).toBe("__draft__");
     expect(queueSessionKey("abc")).toBe("abc");
+  });
+
+  it("migrateDraftSendClaim moves the draft claim and epoch onto the real id", () => {
+    const claims = new Set([queueSessionKey(null)]);
+    const epochs = new Map<string, number>([[queueSessionKey(null), 7]]);
+    expect(migrateDraftSendClaim(claims, epochs, "s-new")).toBe(true);
+    expect(claims.has("__draft__")).toBe(false);
+    expect(claims.has("s-new")).toBe(true);
+    expect(epochs.get("s-new")).toBe(7);
+    expect(epochs.has("__draft__")).toBe(false);
+  });
+
+  it("migrateDraftSendClaim does not steal a claim the real id already holds", () => {
+    const claims = new Set([queueSessionKey(null), "s-new"]);
+    const epochs = new Map<string, number>([
+      [queueSessionKey(null), 1],
+      ["s-new", 2],
+    ]);
+    expect(migrateDraftSendClaim(claims, epochs, "s-new")).toBe(false);
+    expect(claims.has("__draft__")).toBe(true);
+    expect(epochs.get("s-new")).toBe(2);
+  });
+
+  it("migrateDraftSendClaim is a no-op without a draft claim", () => {
+    const claims = new Set(["s1"]);
+    const epochs = new Map<string, number>([["s1", 3]]);
+    expect(migrateDraftSendClaim(claims, epochs, "s-new")).toBe(false);
+    expect(claims.size).toBe(1);
   });
 
   it("shouldEnqueueSend covers busy states (same session only)", () => {

--- a/src/lib/sendQueue.ts
+++ b/src/lib/sendQueue.ts
@@ -24,6 +24,29 @@ export function queueSessionKey(sessionId: string | null | undefined): string {
   return sessionId ?? "__draft__";
 }
 
+/**
+ * Move a new-chat send claim off `__draft__` as soon as `sessionCreate`
+ * returns a real id. Heal and a second send then see the same key the UI
+ * already adopted, instead of waiting until `ensureConnected` fully returns.
+ */
+export function migrateDraftSendClaim(
+  claims: Set<string>,
+  epochs: Map<string, number>,
+  newSessionId: string,
+): boolean {
+  const draftKey = queueSessionKey(null);
+  const newKey = queueSessionKey(newSessionId);
+  if (!newKey || newKey === draftKey) return false;
+  if (!claims.has(draftKey)) return false;
+  if (claims.has(newKey)) return false;
+  const draftEpoch = epochs.get(draftKey);
+  claims.delete(draftKey);
+  epochs.delete(draftKey);
+  claims.add(newKey);
+  if (draftEpoch != null) epochs.set(newKey, draftEpoch);
+  return true;
+}
+
 function newQueueId(): string {
   const c = globalThis.crypto;
   if (c && typeof c.randomUUID === "function") {

--- a/src/lib/turnClock.test.ts
+++ b/src/lib/turnClock.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  DRAFT_TURN_CLOCK_KEY,
+  migrateDraftTurnClock,
+  resolveTurnClockKey,
+  shouldSyncViewedTurnClock,
+} from "./turnClock";
+
+describe("turnClock", () => {
+  it("resolveTurnClockKey uses the draft sentinel when id is missing", () => {
+    expect(resolveTurnClockKey(null)).toBe(DRAFT_TURN_CLOCK_KEY);
+    expect(resolveTurnClockKey(undefined)).toBe(DRAFT_TURN_CLOCK_KEY);
+    expect(resolveTurnClockKey("s1")).toBe("s1");
+  });
+
+  it("syncs the viewed clock for the draft page and the matching session", () => {
+    expect(
+      shouldSyncViewedTurnClock({
+        clockSessionId: DRAFT_TURN_CLOCK_KEY,
+        viewingSessionId: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSyncViewedTurnClock({
+        clockSessionId: "s1",
+        viewingSessionId: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSyncViewedTurnClock({
+        clockSessionId: "s1",
+        viewingSessionId: "s1",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSyncViewedTurnClock({
+        clockSessionId: "s2",
+        viewingSessionId: "s1",
+      }),
+    ).toBe(false);
+  });
+
+  it("migrates a draft clock onto the materialized session id", () => {
+    const clocks = new Map<string, number>([[DRAFT_TURN_CLOCK_KEY, 1_000]]);
+    expect(migrateDraftTurnClock(clocks, "s-new")).toBe(true);
+    expect(clocks.get("s-new")).toBe(1_000);
+    expect(clocks.has(DRAFT_TURN_CLOCK_KEY)).toBe(false);
+  });
+
+  it("does not overwrite a clock the new session already started", () => {
+    const clocks = new Map<string, number>([
+      [DRAFT_TURN_CLOCK_KEY, 1_000],
+      ["s-new", 2_000],
+    ]);
+    expect(migrateDraftTurnClock(clocks, "s-new")).toBe(true);
+    expect(clocks.get("s-new")).toBe(2_000);
+    expect(clocks.has(DRAFT_TURN_CLOCK_KEY)).toBe(false);
+  });
+
+  it("is a no-op when there is no draft clock", () => {
+    const clocks = new Map<string, number>([["s1", 1_000]]);
+    expect(migrateDraftTurnClock(clocks, "s-new")).toBe(false);
+    expect(clocks.size).toBe(1);
+  });
+
+  it("refuses to migrate onto an empty or draft key", () => {
+    const clocks = new Map<string, number>([[DRAFT_TURN_CLOCK_KEY, 1_000]]);
+    expect(migrateDraftTurnClock(clocks, "")).toBe(false);
+    expect(migrateDraftTurnClock(clocks, DRAFT_TURN_CLOCK_KEY)).toBe(false);
+    expect(clocks.get(DRAFT_TURN_CLOCK_KEY)).toBe(1_000);
+  });
+});

--- a/src/lib/turnClock.ts
+++ b/src/lib/turnClock.ts
@@ -1,0 +1,44 @@
+/**
+ * Per-chat turn-clock keys.
+ *
+ * Draft (new-chat) sends have no session id yet. The workbench stores that
+ * clock under the same sentinel as the send-queue draft key (`__draft__`) and
+ * copies it onto the materialized id after `sessionCreate`.
+ */
+
+export const DRAFT_TURN_CLOCK_KEY = "__draft__";
+
+/** Map a viewed / send-target id onto the clock map key. */
+export function resolveTurnClockKey(
+  sessionId: string | null | undefined,
+): string {
+  return sessionId ?? DRAFT_TURN_CLOCK_KEY;
+}
+
+/**
+ * Whether updating `clockSessionId` should rewrite the on-screen timer.
+ * Draft page (`viewingSessionId == null`) only accepts the draft key.
+ */
+export function shouldSyncViewedTurnClock(args: {
+  clockSessionId: string;
+  viewingSessionId: string | null | undefined;
+}): boolean {
+  return args.clockSessionId === resolveTurnClockKey(args.viewingSessionId);
+}
+
+/**
+ * Move a draft-page clock onto the real session id created by first send.
+ * Keeps the existing start time so ghost-heal grace is measured from send,
+ * not from a leftover previous chat.
+ */
+export function migrateDraftTurnClock(
+  clocks: Map<string, number>,
+  newSessionId: string,
+): boolean {
+  if (!newSessionId || newSessionId === DRAFT_TURN_CLOCK_KEY) return false;
+  const at = clocks.get(DRAFT_TURN_CLOCK_KEY);
+  if (at == null) return false;
+  if (!clocks.has(newSessionId)) clocks.set(newSessionId, at);
+  clocks.delete(DRAFT_TURN_CLOCK_KEY);
+  return true;
+}


### PR DESCRIPTION
Fixes #683

## 现象

新建会话里一次写比较长的一段（大概四行），点发送，有时会弹出 `agent.ghostStreamingHealed`：

「消息没有真正发给 Agent。已恢复到输入框，请重新发送。」

Agent 其实已经开工了，输入框里的字也还在。再发一次就会变成两条。

## 原因

`useGhostStreamingHeal` 在「乐观 UI 在转、Host 看起来空闲」超过 45 秒时，会拆掉气泡、把原文塞回输入框。

新建会话首发会叠三件事：

1. `newChat()` 不清屏幕上的 `turnStartedAt`。上一轮留下的计时，对 heal 来说已经过了宽限。
2. 草稿发送走 `restartTurnClock(null)`，直接 return，新计时建不起来。
3. `sessionCreate` 之后立刻 `setSession(newId)`，heal 用新 id 查 `sendInFlight`；发送认领这时还在 `__draft__`。`liveMap` 是空或 `ready`，被当成 Host 空闲。

于是 toast 先响，`sessionSend` 照常发出去。

字多一点更容易中，是因为欢迎页切到对话页会多一次重绘，heal effect 正好在 id 落地时立刻 tick。

## 改动

- `newChat` 清掉屏幕上的上一轮计时；进行中的草稿发送仍保留 `__draft__` 时钟，方便后面 migrate。
- 草稿发送用 `__draft__` 建计时，`sessionCreate` 后迁到真实 id。
- `ghostSendInFlight`：`__draft__` 认领对已落地的新 id 也算 in-flight。
- 单测覆盖这条竞态，以及「真 ghost 该 heal / 没有计时不 heal」。

## Test plan

- [x] `vitest run src/lib/ghostStreamingHeal.test.ts src/lib/turnClock.test.ts`（19）
- [x] 相关 `composerSubmitClear` / `sendQueue` 也过了
- [x] 全量 `pnpm test`：本改动相关全绿。3 个失败是 `sessionExportImage` canvas 超时，和这次无关
- [ ] 真机：上一轮跑过之后点新建会话，打四行发送。不该弹 toast，输入框保持空，Agent 只跑这一条

---

## What

New-chat first send could fire `agent.ghostStreamingHealed` (`Message never reached the agent`) while the agent already had the prompt. Composer text came back.

## Why

Ghost-heal thought Host was idle past the 45s grace:

1. `newChat()` left the previous chat's `turnStartedAt` on screen.
2. Draft send called `restartTurnClock(null)`, which no-ops.
3. `setSession(newId)` re-armed heal against the new id while the send claim was still `__draft__`. `liveMap` was missing or `ready`.

## Change

Clear the viewed clock on new chat (keep an in-flight `__draft__` clock until migrate). Start/migrate the draft clock. Count the draft send claim as in-flight after the id materializes.

## Tests

New cases in `ghostStreamingHeal.test.ts` and `turnClock.test.ts`. Full `pnpm test` is green except unrelated canvas export timeouts.
