### PR TITLE
fix: 「思考中」不再沿用上一会话的几十分钟计时

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- **Live “思考中” timer no longer inherits another chat’s clock**: A leftover `turnStartedAt` (or a later correction) used to stick at 50+ minutes, then jump to the real duration after remount. The live timer now follows this turn’s clock and will not start before the assistant bubble’s `createdAt`.
+
+**中文 · 修复**
+- **「思考中」不再沿用上一会话的计时**：上一轮留下的 `turnStartedAt` 会把时长钉在 50 多分钟，滑一下或重挂载后又变成真正的几分钟。现在跟本轮时钟走，也不会早于这条助手气泡的 `createdAt`。
+
 ## [0.2.21] - 2026-08-18
 
 > **Highlight:** Create Image / Create Video from the composer + menu; Agent Kanban and Project Spaces; chat no longer freezes on the first generated image or stays stuck Connecting.

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -80,6 +80,10 @@ import {
   IconTarget,
 } from "@/components/icons";
 import { setDraft } from "@/lib/composerDraftStore";
+import {
+  clampThinkingStartToMessage,
+  parseCreatedAtMs,
+} from "@/lib/thinkingStartAnchor";
 import { formatMessageTime, formatRelativeTime } from "@/lib/accountUi";
 import type { MessageTimeFormat } from "@/lib/messageTimeFormatPref";
 import { computeMessageLength } from "@/lib/messageLength";
@@ -2649,7 +2653,10 @@ export function ConversationThread({
               wovenMessages={wovenMessages}
               thinkingStartedAt={
                 m.streaming && m.id === activeAssistantId
-                  ? turnStartedAt
+                  ? clampThinkingStartToMessage({
+                      turnStartedAt,
+                      messageCreatedAtMs: parseCreatedAtMs(m.createdAt),
+                    })
                   : null
               }
               findQuery={findQuery}
@@ -2709,7 +2716,13 @@ export function ConversationThread({
               <Thinking
                 locale={locale}
                 thinking
-                startedAt={turnStartedAt}
+                startedAt={clampThinkingStartToMessage({
+                  turnStartedAt,
+                  messageCreatedAtMs: parseCreatedAtMs(
+                    messages.find((x) => x.id === activeAssistantId)
+                      ?.createdAt,
+                  ),
+                })}
               />
             </div>
           ) : null}

--- a/src/components/lobe-chat/Thinking.tsx
+++ b/src/components/lobe-chat/Thinking.tsx
@@ -18,6 +18,7 @@ import { createT, type Locale } from "@/i18n";
 import { COLLAPSE_ALL_ACTIVITY_EVENT } from "@/lib/collapseAllActivity";
 import { formatWorkDuration } from "@/lib/formatWorkDuration";
 import { resolveThinkingChromeLabel } from "@/lib/thinkingChromeLabel";
+import { nextThinkingStartAnchor } from "@/lib/thinkingStartAnchor";
 
 export const Thinking = memo(function Thinking({
   content,
@@ -67,22 +68,19 @@ export const Thinking = memo(function Thinking({
   // Live wall-clock while streaming; freeze when done.
   // Prefer `startedAt` (turn / post-steer clock) so remounts after steer /
   // session switch do not collapse a long wait into “Thought for 1s”.
+  // Also adopt a *later* startedAt: a leftover previous-session clock must
+  // not pin “思考中 51分” after this turn’s real start arrives.
   const frozenRef = useRef(false);
   useEffect(() => {
     if (thinking) {
       frozenRef.current = false;
       setOpen(true);
       userToggled.current = false;
-      const anchor =
-        typeof startedAt === "number" && Number.isFinite(startedAt)
-          ? startedAt
-          : null;
-      if (startRef.current == null) {
-        startRef.current = anchor ?? Date.now();
-      } else if (anchor != null && anchor < startRef.current) {
-        // Host pulled the episode start earlier (e.g. steer) — honor it.
-        startRef.current = anchor;
-      }
+      startRef.current = nextThinkingStartAnchor({
+        prevAnchor: startRef.current,
+        startedAt,
+        nowMs: Date.now(),
+      });
       const tick = () => {
         const origin = startRef.current;
         if (origin != null) {

--- a/src/lib/thinkingStartAnchor.test.ts
+++ b/src/lib/thinkingStartAnchor.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampThinkingStartToMessage,
+  nextThinkingStartAnchor,
+  parseCreatedAtMs,
+} from "./thinkingStartAnchor";
+
+const MIN = 60_000;
+
+describe("nextThinkingStartAnchor", () => {
+  it("uses startedAt on first paint", () => {
+    expect(
+      nextThinkingStartAnchor({
+        prevAnchor: null,
+        startedAt: 1_000,
+        nowMs: 9_000,
+      }),
+    ).toBe(1_000);
+  });
+
+  it("falls back to now when nothing is known", () => {
+    expect(
+      nextThinkingStartAnchor({
+        prevAnchor: null,
+        startedAt: null,
+        nowMs: 9_000,
+      }),
+    ).toBe(9_000);
+  });
+
+  it("keeps the previous origin when startedAt flickers to null", () => {
+    expect(
+      nextThinkingStartAnchor({
+        prevAnchor: 1_000,
+        startedAt: null,
+        nowMs: 9_000,
+      }),
+    ).toBe(1_000);
+  });
+
+  it("adopts a later startedAt so a leftover previous-session clock can correct", () => {
+    const leftover = 0;
+    const thisTurn = 45 * MIN + 14_000;
+    const now = 51 * MIN + 31_000;
+    expect(
+      nextThinkingStartAnchor({
+        prevAnchor: leftover,
+        startedAt: thisTurn,
+        nowMs: now,
+      }),
+    ).toBe(thisTurn);
+    expect(now - thisTurn).toBe(6 * MIN + 17_000);
+  });
+
+  it("still adopts an earlier startedAt (Host / remount pulled the episode back)", () => {
+    expect(
+      nextThinkingStartAnchor({
+        prevAnchor: 8_000,
+        startedAt: 1_000,
+        nowMs: 9_000,
+      }),
+    ).toBe(1_000);
+  });
+});
+
+describe("clampThinkingStartToMessage", () => {
+  it("raises a leftover turn clock up to this bubble’s createdAt", () => {
+    const created = Date.parse("2026-08-18T10:00:00.000Z");
+    const leftover = created - 45 * MIN;
+    expect(
+      clampThinkingStartToMessage({
+        turnStartedAt: leftover,
+        messageCreatedAtMs: created,
+      }),
+    ).toBe(created);
+  });
+
+  it("keeps a later turn clock (steer restarts the episode)", () => {
+    const created = Date.parse("2026-08-18T10:00:00.000Z");
+    const steered = created + 6 * MIN;
+    expect(
+      clampThinkingStartToMessage({
+        turnStartedAt: steered,
+        messageCreatedAtMs: created,
+      }),
+    ).toBe(steered);
+  });
+
+  it("passes through whichever side exists", () => {
+    expect(
+      clampThinkingStartToMessage({
+        turnStartedAt: 12,
+        messageCreatedAtMs: null,
+      }),
+    ).toBe(12);
+    expect(
+      clampThinkingStartToMessage({
+        turnStartedAt: null,
+        messageCreatedAtMs: 34,
+      }),
+    ).toBe(34);
+    expect(
+      clampThinkingStartToMessage({
+        turnStartedAt: null,
+        messageCreatedAtMs: null,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parseCreatedAtMs", () => {
+  it("parses ISO strings and finite numbers", () => {
+    expect(parseCreatedAtMs("2026-08-18T10:00:00.000Z")).toBe(
+      Date.parse("2026-08-18T10:00:00.000Z"),
+    );
+    expect(parseCreatedAtMs(123)).toBe(123);
+    expect(parseCreatedAtMs("")).toBeNull();
+    expect(parseCreatedAtMs(undefined)).toBeNull();
+  });
+});

--- a/src/lib/thinkingStartAnchor.ts
+++ b/src/lib/thinkingStartAnchor.ts
@@ -1,0 +1,65 @@
+/**
+ * Live “思考中 / Thinking for” wall-clock.
+ *
+ * The workbench turn clock can briefly (or leftover) be an older session’s
+ * start. Thinking.tsx used to only pull the anchor *earlier*, so a stale
+ * 50-minute clock stuck, and a later correction (this turn’s real start)
+ * was ignored. After remount the same block showed the honest duration.
+ */
+
+export function parseCreatedAtMs(
+  value: string | number | null | undefined,
+): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const n = Date.parse(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/**
+ * Next live-timer origin.
+ *
+ * - Trust `startedAt` whenever it is a finite number (earlier *or* later).
+ * - If `startedAt` is missing, keep the previous origin so a remount flicker
+ *   does not reset to “1s”.
+ * - First paint with no clock: `nowMs`.
+ */
+export function nextThinkingStartAnchor(opts: {
+  prevAnchor: number | null;
+  startedAt: number | null | undefined;
+  nowMs: number;
+}): number {
+  const incoming =
+    typeof opts.startedAt === "number" && Number.isFinite(opts.startedAt)
+      ? opts.startedAt
+      : null;
+  if (incoming != null) return incoming;
+  if (opts.prevAnchor != null) return opts.prevAnchor;
+  return opts.nowMs;
+}
+
+/**
+ * Do not start the live timer before this assistant bubble existed.
+ * A leftover previous-session `turnStartedAt` is older than `createdAt`
+ * and would show “思考中 51分…”.
+ */
+export function clampThinkingStartToMessage(opts: {
+  turnStartedAt: number | null | undefined;
+  messageCreatedAtMs: number | null | undefined;
+}): number | null {
+  const turn =
+    typeof opts.turnStartedAt === "number" &&
+    Number.isFinite(opts.turnStartedAt)
+      ? opts.turnStartedAt
+      : null;
+  const created =
+    typeof opts.messageCreatedAtMs === "number" &&
+    Number.isFinite(opts.messageCreatedAtMs)
+      ? opts.messageCreatedAtMs
+      : null;
+  if (turn == null) return created;
+  if (created == null) return turn;
+  return Math.max(turn, created);
+}


### PR DESCRIPTION
Fixes #685

## 现象

「思考中」有时会先显示几十分钟（例如 51分31秒），实际没想那么久。滑一下、切走再回来，或等这轮结束再重挂载，数字会掉回真实时长（例如 6分17秒）。

## 原因

`Thinking` 的 `startRef` 只接受**更早**的 `startedAt`，怕 remount 变成 1 秒。

工作台的 `turnStartedAt` 经常是上一会话留下的。于是先钉在旧起点（51分31秒），本轮真正的起点稍后到达（更晚）被丢掉。重挂载后只用本轮时钟，才变成 6分17秒。

单测用这组数字钉死：`src/lib/thinkingStartAnchor.test.ts`。

## 改动

- `nextThinkingStartAnchor`：有 `startedAt` 就跟，不论更早还是更晚；缺了才沿用上一帧，避免闪成 1 秒。
- `clampThinkingStartToMessage`：计时不能早于这条助手气泡的 `createdAt`（发送时写下的）。
- `ConversationThread` 传给思考行 / 安静思考行之前先 clamp。

## Test plan

- [x] `vitest run src/lib/thinkingStartAnchor.test.ts`（9）以及 chrome / duration 相关测试
- [ ] 真机：上一轮跑过之后新开或切到正在思考的会话。「思考中」应接近本轮，不该先跳到几十分钟再掉下来

---

## What

Live 思考中 can read 51m 31s, then later snap to the real 6m 17s after remount.

## Why

`Thinking` only accepted an *earlier* `startedAt`. Workbench `turnStartedAt` is often leftover from the previous chat. The later, correct clock was ignored until remount.

## Change

Follow this turn’s clock when it arrives. Do not start the timer before the assistant bubble’s `createdAt`.
