### PR TITLE
fix(composer): session 里切 branch 后刷新 composer 分支 chip（#690）

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -784,6 +784,7 @@ import {
 import { ComposerProjectMenu } from "@/components/ComposerProjectMenu";
 import { ComposerWorktreeMenu } from "@/components/ComposerWorktreeMenu";
 import {
+  applyGitStatusBranch,
   buildWorktreePath,
   canRemoveWorktree,
   mainWorktreePath,
@@ -13306,6 +13307,9 @@ export function AppWorkbench() {
       const status = await api.gitStatus(path);
       if (reqId !== gitDirtyReqRef.current) return;
       setGitDirtySummary(summarizeGitDirty(status));
+      // Same poll already has HEAD. Patch the composer branch chip so an
+      // in-place checkout does not stay stale until the menu is clicked.
+      setGitWorktrees((prev) => applyGitStatusBranch(prev, path, status));
     } catch {
       if (reqId !== gitDirtyReqRef.current) return;
       setGitDirtySummary(null);
@@ -13315,9 +13319,12 @@ export function AppWorkbench() {
   useEffect(() => {
     void refreshGitDirtyStatus();
     // Soft poll while a project is bound; refresh sooner on focus.
+    // Faster while a turn is live — agent may `git switch` mid-session.
     const path = activeProject?.path?.trim() || null;
     if (!path || !api.isTauri()) return;
-    const intervalMs = 8000;
+    const busy =
+      session.state === "streaming" || session.state === "awaiting_permission";
+    const intervalMs = busy ? 2000 : 8000;
     const id = window.setInterval(() => {
       void refreshGitDirtyStatus();
     }, intervalMs);
@@ -13334,7 +13341,12 @@ export function AppWorkbench() {
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [activeProject?.path, refreshGitDirtyStatus]);
+  }, [
+    activeProject?.path,
+    refreshGitDirtyStatus,
+    session.sessionId,
+    session.state,
+  ]);
 
   /** Soft offer sandbox guide after a successful project trust. */
   const maybeOfferSandboxWizardAfterTrust = useCallback(() => {

--- a/src/components/ComposerWorktreeMenu.test.tsx
+++ b/src/components/ComposerWorktreeMenu.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import React from "react";
+import { ComposerWorktreeMenu } from "@/components/ComposerWorktreeMenu";
+import {
+  applyGitStatusBranch,
+  parseWorktreePorcelain,
+} from "@/lib/gitWorktree";
+
+const LABELS = {
+  worktrees: "Git worktrees",
+  worktreesEmpty: "No linked worktrees",
+  worktreesUnavailable: "Worktrees unavailable",
+  worktreeCurrent: "current",
+  worktreeMain: "main",
+  worktreeDetached: "detached",
+  worktreeTip: "Switch git worktree / branch",
+  worktreeNew: "New worktree",
+  worktreeNewChat: "New worktree & chat",
+  worktreeGc: "Clean stale worktrees",
+};
+
+const PORCELAIN = `worktree /Users/me/typebooks
+HEAD abcdef0123456789
+branch refs/heads/master
+`;
+
+function renderChip(worktrees: ReturnType<typeof parseWorktreePorcelain>) {
+  return renderToString(
+    React.createElement(ComposerWorktreeMenu, {
+      activePath: "/Users/me/typebooks",
+      worktrees,
+      worktreesAvailable: true,
+      labels: LABELS,
+      variant: "context",
+      onSwitch: vi.fn(),
+      onCreate: vi.fn(),
+      onCreateAndChat: vi.fn(),
+      onGc: vi.fn(),
+    }),
+  );
+}
+
+describe("ComposerWorktreeMenu branch chip", () => {
+  it("shows the cached worktree branch on the trigger", () => {
+    const html = renderChip(parseWorktreePorcelain(PORCELAIN));
+    expect(html).toContain("composer__context-item--branch");
+    expect(html).toContain("master");
+  });
+
+  it("updates the trigger after an in-place checkout without opening the menu", () => {
+    const cached = parseWorktreePorcelain(PORCELAIN);
+    expect(renderChip(cached)).toContain("master");
+    expect(renderChip(cached)).not.toContain("feat/session-branch");
+
+    const next = applyGitStatusBranch(cached, "/Users/me/typebooks", {
+      available: true,
+      branch: "feat/session-branch",
+    });
+    const html = renderChip(next);
+    expect(html).toContain("feat/session-branch");
+    expect(html).not.toContain("master");
+  });
+});

--- a/src/lib/gitWorktree.test.ts
+++ b/src/lib/gitWorktree.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyGitStatusBranch,
   buildWorktreeCliPath,
   buildWorktreeGcArgs,
   buildWorktreePath,
@@ -90,7 +91,70 @@ describe("path helpers", () => {
     ]);
     expect(findWorktreeAt(list, "/Users/me/repo-feat")?.branch).toBe("feat/x");
   });
+});
 
+describe("applyGitStatusBranch", () => {
+  it("updates the matching worktree after an in-place checkout", () => {
+    const cached = parseWorktreePorcelain(SAMPLE);
+    expect(worktreeLabel(cached[0])).toBe("main");
+
+    // Repro: agent / user `git switch feat/x` in the same cwd. Path is
+    // unchanged so the porcelain cache still says `main` until the chip is
+    // clicked. git status already has the live branch.
+    const next = applyGitStatusBranch(cached, "/Users/me/repo/", {
+      available: true,
+      branch: "feat/x",
+    });
+    expect(next).not.toBe(cached);
+    expect(worktreeLabel(next[0])).toBe("feat/x");
+    expect(next[0].detached).toBe(false);
+    expect(next[1].branch).toBe("feat/x");
+    expect(worktreeLabel(cached[0])).toBe("main");
+  });
+
+  it("marks detached when git status reports no branch (HEAD)", () => {
+    const cached = parseWorktreePorcelain(SAMPLE);
+    const next = applyGitStatusBranch(cached, "/Users/me/repo", {
+      available: true,
+      branch: null,
+    });
+    expect(next[0].branch).toBeNull();
+    expect(next[0].detached).toBe(true);
+    expect(worktreeLabel(next[0])).toContain("repo");
+  });
+
+  it("does not invent a row when the path is missing from the cache", () => {
+    const cached = parseWorktreePorcelain(SAMPLE);
+    const next = applyGitStatusBranch(cached, "/tmp/other", {
+      available: true,
+      branch: "master",
+    });
+    expect(next).toBe(cached);
+  });
+
+  it("keeps the cache when git status is unavailable or the branch matches", () => {
+    const cached = parseWorktreePorcelain(SAMPLE);
+    expect(
+      applyGitStatusBranch(cached, "/Users/me/repo", {
+        available: false,
+        branch: "feat/x",
+      }),
+    ).toBe(cached);
+    expect(applyGitStatusBranch(cached, "/Users/me/repo", null)).toBe(cached);
+    expect(
+      applyGitStatusBranch(cached, "/Users/me/repo", {
+        available: true,
+        branch: "main",
+      }),
+    ).toBe(cached);
+    expect(applyGitStatusBranch([], "/Users/me/repo", {
+      available: true,
+      branch: "main",
+    })).toEqual([]);
+  });
+});
+
+describe("path helpers (entry resolve)", () => {
   it("worktreeEntryForPath prefers porcelain match, else synthetic", () => {
     const list = parseWorktreePorcelain(SAMPLE);
     const hit = worktreeEntryForPath("/Users/me/repo-feat/", list);

--- a/src/lib/gitWorktree.ts
+++ b/src/lib/gitWorktree.ts
@@ -132,6 +132,40 @@ export function findWorktreeAt(
 }
 
 /**
+ * Apply `git status` branch onto the cached worktree list used by the
+ * composer branch chip.
+ *
+ * In-place `git checkout` / `git switch` does not change the project path, so
+ * the porcelain list stays stale until the menu is opened. The dirty-status
+ * poll already has the live branch — patch the matching row instead of
+ * waiting for a click.
+ *
+ * Returns the same array when nothing changed (skip setState).
+ */
+export function applyGitStatusBranch(
+  worktrees: GitWorktreeEntry[],
+  projectPath: string | null | undefined,
+  status:
+    | { available?: boolean | null; branch?: string | null }
+    | null
+    | undefined,
+): GitWorktreeEntry[] {
+  if (!worktrees.length || !status?.available) return worktrees;
+  const nextBranch = (status.branch ?? "").trim() || null;
+  const detached = !nextBranch;
+  let changed = false;
+  const next = worktrees.map((wt) => {
+    if (!pathsEqual(wt.path, projectPath)) return wt;
+    if ((wt.branch ?? null) === nextBranch && wt.detached === detached) {
+      return wt;
+    }
+    changed = true;
+    return { ...wt, branch: nextBranch, detached };
+  });
+  return changed ? next : worktrees;
+}
+
+/**
  * Resolve a path to a {@link GitWorktreeEntry} for session bind / switch.
  *
  * Prefers a porcelain list match (branch / main flags intact). When the path


### PR DESCRIPTION
## Summary

Fixes #690.

同一个工作树里 `git switch` / `git checkout` 之后，composer 项目名旁边的分支 chip 还停在旧名字，要点开菜单才刷新。

chip 读的是 `gitWorktrees` 缓存。这份列表只在项目 path 变了、或点开菜单 `onOpen` 时才 `refreshGitWorktrees`。同目录切分支不改 path。工作区 dirty 轮询已经在跑 `git_status`，返回值里有 `branch`，但只用了脏文件数。

改动：

1. `applyGitStatusBranch`：用 `git status` 的 live branch 补当前 path 那一行。没变化则返回同一数组。
2. `refreshGitDirtyStatus` 把这个结果写回 `gitWorktrees`。
3. 一轮进行中把轮询从 8s 收到 2s；会话切换或 state 变化时立刻再拉一次。

Same working tree, different HEAD: the composer branch chip stayed stale until the menu opened. `git_status` already had the branch. The dirty poll now patches the matching worktree row.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `pnpm exec vitest run src/lib/gitWorktree.test.ts src/components/ComposerWorktreeMenu.test.tsx` — 33 passed
  - in-place checkout updates the matching row (`main` → `feat/x`)
  - detached HEAD (`branch: null`)
  - missing path / unavailable status keep the cache
  - chip trigger text follows the patched list without opening the menu
- [ ] Live: bind a git project, `git switch` in that cwd (or let the agent do it), chip should change without a click

## Checklist
- [x] I ran `pnpm test` (gitWorktree + ComposerWorktreeMenu)
- [x] No new user-facing strings
- [x] No `window.confirm` / `prompt` / `alert`
- [x] No secrets
