### PR TITLE
fix(chat): 对话历史里的图不要再解原图（#692）

### DIFF
--- a/src/components/AttachmentCard.tsx
+++ b/src/components/AttachmentCard.tsx
@@ -15,7 +15,12 @@ import {
   deriveAttachPreviewPhase,
 } from "@/lib/attachmentsPro";
 import * as api from "@/lib/api";
-import { ensureMediaEndpoint, resolveImageSrc, resolveImageSrcSync } from "@/lib/imageSrc";
+import { ensureMediaEndpoint } from "@/lib/imageSrc";
+import {
+  chatCardFirstPaintSrc,
+  nextChatCardDisplaySrc,
+  resolveChatImageThumb,
+} from "@/lib/imageThumbClient";
 import { copyImageFromPath } from "@/lib/copyImage";
 import { useImageViewerOptional } from "@/components/ImageViewer";
 import {
@@ -70,7 +75,9 @@ export function AttachmentCard({
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const isImg = !attachment.isDir && isImagePath(attachment.path);
   const [thumbSrc, setThumbSrc] = useState<string | null>(() =>
-    isImg ? resolveImageSrcSync(attachment.path) : null,
+    isImg
+      ? chatCardFirstPaintSrc(attachment.path, attachment.path, "card")
+      : null,
   );
   /** Once decode fails, stay broken — do not re-claim readiness on re-render. */
   const [thumbFailed, setThumbFailed] = useState(false);
@@ -83,21 +90,34 @@ export function AttachmentCard({
       setThumbFailed(false);
       return;
     }
-    // Sync resolve + cache: avoid empty→thumb height flash in the thread.
-    setThumbSrc(resolveImageSrcSync(attachment.path));
+    // Same thumb path as chat ImageUi (#675). Full originals in a 36px
+    // <img> make WKWebView hitch / flash when a long virtualized thread
+    // remounts the row (paste screenshots in history).
+    const first = chatCardFirstPaintSrc(
+      attachment.path,
+      attachment.path,
+      "card",
+    );
+    setThumbSrc((prev) => nextChatCardDisplaySrc(prev, { displaySrc: first }));
     setThumbFailed(false);
     let cancelled = false;
-    void ensureMediaEndpoint()
-      .then(() => resolveImageSrc(attachment.path))
-      .then((url) => {
-        if (!cancelled && url) {
-          setThumbSrc(url);
+    void (async () => {
+      try {
+        await ensureMediaEndpoint();
+        const r = await resolveChatImageThumb(
+          attachment.path,
+          attachment.path,
+        );
+        if (cancelled) return;
+        const display = nextChatCardDisplaySrc(first, r);
+        if (display) {
+          setThumbSrc(display);
           setThumbFailed(false);
         }
-      })
-      .catch(() => {
-        /* keep sync; do not invent a working thumb */
-      });
+      } catch {
+        /* keep first paint; do not invent a working thumb */
+      }
+    })();
     return () => {
       cancelled = true;
     };
@@ -264,6 +284,8 @@ export function AttachmentCard({
                 src={thumbSrc!}
                 alt={attachment.name}
                 draggable={false}
+                loading="eager"
+                decoding="async"
                 onError={() => {
                   setThumbFailed(true);
                   setThumbSrc(null);
@@ -352,6 +374,8 @@ export function AttachmentCard({
               src={thumbSrc!}
               alt={attachment.name}
               draggable={false}
+              loading="eager"
+              decoding="async"
               onError={() => {
                 setThumbFailed(true);
                 setThumbSrc(null);

--- a/src/components/ImageUi.tsx
+++ b/src/components/ImageUi.tsx
@@ -278,9 +278,14 @@ export function ImageUi({
         : undefined;
 
     const seed = () => {
-      const next = initialResolvedSrc(src, path, layout);
+      const first = initialResolvedSrc(src, path, layout);
+      // Effect re-runs (retry / path alias) must not blank a card that
+      // already has a live URL — that gray↔image swap is the chat flash.
+      const next = nextChatCardDisplaySrc(paintedSrcRef.current, {
+        displaySrc: first ?? undefined,
+      });
       paintedSrcRef.current = next;
-      setResolvedSrc(next);
+      setResolvedSrc((prev) => (prev === next ? prev : next));
       setLoadFailed(false);
       setFailKind(null);
       const cached = readCachedAr(src, path);
@@ -626,7 +631,6 @@ export function ImageUi({
           </span>
         ) : resolvedSrc ? (
           <img
-            key={resolvedSrc}
             ref={imgRef}
             className="md-body__img-frame__el"
             src={resolvedSrc}

--- a/src/lib/imageThumbClient.test.ts
+++ b/src/lib/imageThumbClient.test.ts
@@ -86,6 +86,16 @@ describe("peekChatImageThumb / nextChatCardDisplaySrc", () => {
     );
   });
 
+  it("keeps a live loopback src when first-paint seed is empty (no gray flash)", () => {
+    const live = "http://127.0.0.1:9/v1/media?t=tok&p=%2Ftmp%2Ft.jpg";
+    expect(
+      nextChatCardDisplaySrc(live, { displaySrc: undefined } as never),
+    ).toBe(live);
+    expect(nextChatCardDisplaySrc(live, { displaySrc: null } as never)).toBe(
+      live,
+    );
+  });
+
   it("prefers a successful thumb displaySrc over the live src", () => {
     expect(
       nextChatCardDisplaySrc("https://cdn.example/chart.png", {
@@ -100,6 +110,20 @@ describe("peekChatImageThumb / nextChatCardDisplaySrc", () => {
 });
 
 describe("chatCardFirstPaintSrc — empty cache vs remount (#675)", () => {
+  it("does not first-paint a user-paste attachment original (history flash)", () => {
+    setMediaEndpoint({ baseUrl: "http://127.0.0.1:9", token: "tok" });
+    const paste =
+      "/Users/me/Library/Application Support/com.grokapp.grok-app/attachments/paste/20260818-173813-602-paste.png";
+    const originalUrl = localPathToMediaHttpUrl(paste);
+    expect(originalUrl).toContain("/v1/media");
+    expect(peekChatImageThumb(paste, paste)).toBeNull();
+
+    const first = chatCardFirstPaintSrc(paste, paste, "card");
+    expect(first).toBeNull();
+    expect(first).not.toBe(originalUrl);
+    expect(first).not.toBe(paste);
+  });
+
   it("does not first-paint the original media URL when the thumb cache is empty", () => {
     setMediaEndpoint({ baseUrl: "http://127.0.0.1:9", token: "tok" });
     const local = "/Users/me/imagine/1.png";


### PR DESCRIPTION
## Summary

Fixes #692.

对话历史里的用户附图（粘贴的截图）还在把原图塞进 36px 的 `<img>`。对话一长，列表会拆掉再挂上那一行，WebView 又解一遍整张 PNG，窗口就闪。#675 只改了助手气泡里的图卡，用户附件这条线没动。

User-message image chips still loaded the full PNG. A long virtualized thread remounts that row; WKWebView decodes the original again and the window flashes. #675 fixed assistant cards only.

改动：

1. 用户附图走和对话图卡同一套缩略图，空缓存时先占位，不要先加载原图。
2. 已经在显示的地址不要清成空（灰一下再出图）。
3. 缩略图 `loading="eager"`，避免滚出视口被卸掉再加载。
4. 去掉 `key={src}`，换地址时不要把整张 `<img>` 拆掉重挂。

## Type of change
- [x] Bug fix

## Test plan

- [x] `pnpm exec vitest run src/lib/imageThumbClient.test.ts src/lib/mediaLoadPro.test.ts` — 51 passed
  - paste 附件路径首次不能指向原图 media URL
  - 已有 loopback 地址时，空的 first-paint 不能把它清掉
- [ ] 本机：贴一张截图，聊长，停在底部再发一条，看窗口还闪不闪

## Checklist
- [x] imageThumbClient + mediaLoadPro tests
- [x] No new user-facing strings
- [x] No `window.confirm` / `prompt` / `alert`
- [x] No secrets
