### PR TITLE
fix(sidebar): interpolate project collapse and hide leftover scrollbar

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -37,8 +37,8 @@
 | `--text-xs` / `sm` / `md` / `lg` | `12 / 13 / 14 / 16 px` | 字号 |
 | `--leading-tight` / `normal` | `1.35 / 1.55` | 行高 |
 | `--shadow-window` | 见主题表 | 窗口投影 |
-| `--motion-fast` / `normal` | `120ms` / `200ms` | 过渡（含项目会话列表开合）；尊重 `prefers-reduced-motion` |
-| `--motion-pane` / `--motion-pane-ease` | `320ms` / `cubic-bezier(0.22, 1, 0.36, 1)` | 左右分栏 / 底栏开合 / 设置页叠在工作台上的进出（无过冲）。分栏 token **不**随 `prefers-reduced-motion` 清零；设置 overlay 与菜单在 reduce 下关掉 transform / transition |
+| `--motion-fast` / `normal` | `120ms` / `200ms` | 过渡；尊重 `prefers-reduced-motion` |
+| `--motion-pane` / `--motion-pane-ease` | `320ms` / `cubic-bezier(0.22, 1, 0.36, 1)` | 左右分栏 / 底栏开合 / 设置页叠在工作台上的进出 / 项目会话列表开合（无过冲）。分栏 token **不**随 `prefers-reduced-motion` 清零；设置 overlay 与菜单在 reduce 下关掉 transform / transition |
 
 **栏宽持久化：** `layout.sidebarWidth` / `layout.asideWidth` / `layout.asideCollapsed` 写入 App 配置。
 

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -37,8 +37,8 @@
 | `--text-xs` / `sm` / `md` / `lg` | `12 / 13 / 14 / 16 px` | 字号 |
 | `--leading-tight` / `normal` | `1.35 / 1.55` | 行高 |
 | `--shadow-window` | 见主题表 | 窗口投影 |
-| `--motion-fast` / `normal` | `120ms` / `200ms` | 过渡；尊重 `prefers-reduced-motion` |
-| `--motion-pane` / `--motion-pane-ease` | `320ms` / `cubic-bezier(0.22, 1, 0.36, 1)` | 左右分栏 / 底栏开合 / 设置页叠在工作台上的进出 / 项目会话列表开合（无过冲）。分栏 token **不**随 `prefers-reduced-motion` 清零；设置 overlay 与菜单在 reduce 下关掉 transform / transition |
+| `--motion-fast` / `normal` | `120ms` / `200ms` | 过渡（含侧栏项目列表开合）；尊重 `prefers-reduced-motion` |
+| `--motion-pane` / `--motion-pane-ease` | `320ms` / `cubic-bezier(0.22, 1, 0.36, 1)` | 左右分栏 / 底栏开合 / 设置页叠在工作台上的进出（无过冲）。分栏 token **不**随 `prefers-reduced-motion` 清零；设置 overlay 与菜单在 reduce 下关掉 transform / transition |
 
 **栏宽持久化：** `layout.sidebarWidth` / `layout.asideWidth` / `layout.asideCollapsed` 写入 App 配置。
 

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -19108,14 +19108,14 @@ export function AppWorkbench() {
               </div>
             </div>
 
-            {projectsOpen && projects.length === 0 && (
+            <SidebarTreeReveal open={projectsOpen} className="tree-reveal--projects">
+            {projects.length === 0 && (
               <div className="sidebar-empty">
                 {tr("sidebar.noProjects")}
               </div>
             )}
 
-            {projectsOpen &&
-              projects.length > 0 &&
+            {projects.length > 0 &&
               visibleProjects.length === 0 && (
               <div className="sidebar-empty sidebar-empty--space">
                 {tr("sidebar.spaces.empty")}
@@ -19125,8 +19125,7 @@ export function AppWorkbench() {
               </div>
             )}
 
-            {projectsOpen &&
-              visibleProjects.map((proj) => {
+            {visibleProjects.map((proj) => {
                 const open = expandedProjects[proj.id] !== false;
                 const projSessions = sessionsForProject(proj.id);
                 const projSessionIds = projSessions.map((s) => s.id);
@@ -19394,6 +19393,7 @@ export function AppWorkbench() {
                   </div>
                 );
               })}
+            </SidebarTreeReveal>
 
             {/* Orphans / history */}
             <div className="tree-l1" style={{ marginTop: 8 }}>

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -18974,7 +18974,11 @@ export function AppWorkbench() {
             ) : null}
           </div>
 
-          <OverlayScroll className="sidebar__scroll" viewportClassName="sidebar__scroll-inner">
+          <OverlayScroll
+            className="sidebar__scroll"
+            viewportClassName="sidebar__scroll-inner"
+            syncTreeReveal
+          >
             {/* L1 — Projects section */}
             <div className="tree-l1">
               <button

--- a/src/components/OverlayScroll.tsx
+++ b/src/components/OverlayScroll.tsx
@@ -14,7 +14,10 @@ import {
   type UIEvent,
 } from "react";
 import { runAfterPaneSplitMotion } from "@/lib/paneSplitMotion";
-import { runAfterTreeRevealMotion } from "@/lib/treeReveal";
+import {
+  runAfterTreeRevealMotion,
+  subscribeTreeRevealMotion,
+} from "@/lib/treeReveal";
 
 type OverlayScrollProps = {
   children: ReactNode;
@@ -26,6 +29,8 @@ type OverlayScrollProps = {
   onScroll?: (e: UIEvent<HTMLDivElement>) => void;
   /** Optional external ref to the scrolling viewport element. */
   viewportRef?: Ref<HTMLDivElement | null>;
+  /** Sidebar project-list reveal: hide the stale thumb, remasure after. */
+  syncTreeReveal?: boolean;
 };
 
 function assignRef<T>(ref: Ref<T> | undefined, value: T) {
@@ -41,6 +46,7 @@ export function OverlayScroll({
   style,
   onScroll,
   viewportRef: viewportRefProp,
+  syncTreeReveal = false,
 }: OverlayScrollProps) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const hideTimer = useRef<number | null>(null);
@@ -66,6 +72,7 @@ export function OverlayScroll({
     if (!el) return;
     const { scrollTop, scrollHeight, clientHeight } = el;
     const needed = scrollHeight > clientHeight + 1;
+    el.style.overflowY = needed ? "auto" : "hidden";
     if (!needed) {
       setThumb((t) => (t.needed ? { top: 0, height: 0, needed: false } : t));
       return;
@@ -89,13 +96,31 @@ export function OverlayScroll({
     if (!el) return;
     const ro = new ResizeObserver(() => measure());
     ro.observe(el);
-    if (el.firstElementChild) ro.observe(el.firstElementChild);
+    for (const child of el.children) {
+      if (child instanceof Element) ro.observe(child);
+    }
     window.addEventListener("resize", measure);
     return () => {
       ro.disconnect();
       window.removeEventListener("resize", measure);
     };
   }, [measure, children]);
+
+  useEffect(() => {
+    if (!syncTreeReveal) return;
+    return subscribeTreeRevealMotion((active) => {
+      const el = viewportRef.current;
+      if (active) {
+        if (el) el.style.overflowY = "hidden";
+        setActive(false);
+        setThumb((t) =>
+          t.needed ? { top: 0, height: 0, needed: false } : t,
+        );
+        return;
+      }
+      measure();
+    });
+  }, [measure, syncTreeReveal]);
 
   const flash = () => {
     setActive(true);

--- a/src/components/OverlayScroll.tsx
+++ b/src/components/OverlayScroll.tsx
@@ -14,6 +14,7 @@ import {
   type UIEvent,
 } from "react";
 import { runAfterPaneSplitMotion } from "@/lib/paneSplitMotion";
+import { runAfterTreeRevealMotion } from "@/lib/treeReveal";
 
 type OverlayScrollProps = {
   children: ReactNode;
@@ -60,6 +61,7 @@ export function OverlayScroll({
 
   const measure = useCallback(() => {
     if (runAfterPaneSplitMotion(measure)) return;
+    if (runAfterTreeRevealMotion(measure)) return;
     const el = viewportRef.current;
     if (!el) return;
     const { scrollTop, scrollHeight, clientHeight } = el;

--- a/src/components/SidebarTreeReveal.tsx
+++ b/src/components/SidebarTreeReveal.tsx
@@ -1,7 +1,8 @@
 /**
  * Keep a sidebar tree section mounted through its exit so expand/collapse
  * interpolates height. WKWebView only interpolates concrete inline px
- * (see treeReveal.ts) — CSS 0fr/1fr snaps.
+ * (see treeReveal.ts). Stay on px after expand — settling to `auto` makes
+ * the next close an auto→0 snap.
  */
 
 import {
@@ -18,11 +19,11 @@ import {
   beginTreeRevealMotion,
   measureTreeRevealContent,
   shouldAnimateTreeReveal,
+  TREE_REVEAL_CLOSE_MS,
   TREE_REVEAL_MS,
   TREE_REVEAL_PRESENCE_MS,
   treeRevealCloseSteps,
   treeRevealSizeStyle,
-  type TreeRevealSize,
 } from "@/lib/treeReveal";
 
 type SidebarTreeRevealProps = {
@@ -52,7 +53,7 @@ export function SidebarTreeReveal({
   const animateOpenRef = useRef(false);
   const animateCloseRef = useRef(false);
   const endMotionRef = useRef<(() => void) | null>(null);
-  const [size, setSize] = useState<TreeRevealSize>(() => (open ? "auto" : 0));
+  const [size, setSize] = useState<number | null>(() => (open ? null : 0));
 
   const stopMotion = () => {
     endMotionRef.current?.();
@@ -63,7 +64,6 @@ export function SidebarTreeReveal({
     const box = boxRef.current;
     const inner = innerRef.current;
     if (!box) {
-      // Collapsed first paint returns null — the next expand must animate.
       firstCommitRef.current = false;
       return;
     }
@@ -81,7 +81,7 @@ export function SidebarTreeReveal({
     animateCloseRef.current = false;
 
     if (!animate) {
-      const next: TreeRevealSize = open ? "auto" : 0;
+      const next = open ? contentPx || visualPx : 0;
       applyTreeRevealSize(box, next);
       setSize(next);
       return;
@@ -92,16 +92,15 @@ export function SidebarTreeReveal({
     box.dataset.treeRevealMotion = "1";
 
     if (open) {
-      // Leave height at 0 for this paint. Promoting to px before paint
-      // lets WKWebView skip the transition (same class of bug as 0fr/1fr).
       applyTreeRevealSize(box, 0);
       setSize(0);
       animateOpenRef.current = true;
       return;
     }
 
-    // Leave height locked for this paint. auto→0 in one commit snaps.
-    const { lockPx } = treeRevealCloseSteps(visualPx || contentPx);
+    const { lockPx } = treeRevealCloseSteps(
+      visualPx || contentPx || size || 0,
+    );
     applyTreeRevealSize(box, lockPx);
     setSize(lockPx);
     animateCloseRef.current = true;
@@ -113,7 +112,7 @@ export function SidebarTreeReveal({
     if (!box) return;
     let cancelled = false;
 
-    const settle = (next: TreeRevealSize) => {
+    const finish = (next: number) => {
       if (cancelled) return;
       applyTreeRevealSize(box, next);
       setSize(next);
@@ -127,25 +126,14 @@ export function SidebarTreeReveal({
           if (cancelled) return;
           animateOpenRef.current = false;
           const h = measureTreeRevealContent(innerRef.current);
-          if (h <= 0) {
-            // Stay at 0 and retry once — snapping to auto flashes the list.
-            const retry = window.requestAnimationFrame(() => {
-              const again = measureTreeRevealContent(innerRef.current);
-              if (again <= 0) {
-                settle("auto");
-                return;
-              }
-              applyTreeRevealSize(box, again);
-              setSize(again);
-            });
-            if (cancelled) window.cancelAnimationFrame(retry);
-            return;
-          }
           applyTreeRevealSize(box, h);
           setSize(h);
         });
       });
-      const t = window.setTimeout(() => settle("auto"), TREE_REVEAL_MS + 32);
+      const t = window.setTimeout(() => {
+        const h = measureTreeRevealContent(innerRef.current);
+        finish(h);
+      }, TREE_REVEAL_MS + 32);
       return () => {
         cancelled = true;
         window.cancelAnimationFrame(id);
@@ -162,13 +150,33 @@ export function SidebarTreeReveal({
           setSize(0);
         });
       });
-      const t = window.setTimeout(() => settle(0), TREE_REVEAL_MS + 32);
+      const t = window.setTimeout(() => finish(0), TREE_REVEAL_CLOSE_MS + 32);
       return () => {
         cancelled = true;
         window.cancelAnimationFrame(id);
         window.clearTimeout(t);
       };
     }
+  }, [open, presence.mounted]);
+
+  useEffect(() => {
+    if (!open || !presence.mounted) return;
+    const box = boxRef.current;
+    const inner = innerRef.current;
+    if (!box || !inner) return;
+    const ro = new ResizeObserver(() => {
+      if (box.dataset.treeRevealMotion) return;
+      const h = measureTreeRevealContent(inner);
+      if (h <= 0 || h === Math.round(box.getBoundingClientRect().height)) return;
+      const prev = box.style.transition;
+      box.style.transition = "none";
+      applyTreeRevealSize(box, h);
+      setSize(h);
+      void box.getBoundingClientRect();
+      box.style.transition = prev;
+    });
+    ro.observe(inner);
+    return () => ro.disconnect();
   }, [open, presence.mounted]);
 
   useEffect(() => stopMotion, []);
@@ -183,7 +191,7 @@ export function SidebarTreeReveal({
         (!open ? " is-closing" : "") +
         (className ? ` ${className}` : "")
       }
-      style={size === "auto" ? undefined : treeRevealSizeStyle(size)}
+      style={size == null ? undefined : treeRevealSizeStyle(size)}
       data-testid="tree-reveal"
       aria-hidden={!open || undefined}
       inert={!open || undefined}

--- a/src/components/SidebarTreeReveal.tsx
+++ b/src/components/SidebarTreeReveal.tsx
@@ -11,11 +11,15 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { useOpenPresence, OPEN_PRESENCE_MS } from "@/lib/openPresence";
+import { useOpenPresence } from "@/lib/openPresence";
 import { prefersReducedMotion } from "@/lib/paneSplitMotion";
 import {
   applyTreeRevealSize,
+  beginTreeRevealMotion,
+  measureTreeRevealContent,
   shouldAnimateTreeReveal,
+  TREE_REVEAL_MS,
+  TREE_REVEAL_PRESENCE_MS,
   treeRevealCloseSteps,
   treeRevealSizeStyle,
   type TreeRevealSize,
@@ -41,14 +45,19 @@ export function SidebarTreeReveal({
   className,
   children,
 }: SidebarTreeRevealProps) {
-  // Stay mounted through lock-frame + height transition (open and close).
-  const presence = useOpenPresence(open, true, OPEN_PRESENCE_MS + 48);
+  const presence = useOpenPresence(open, true, TREE_REVEAL_PRESENCE_MS);
   const boxRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const firstCommitRef = useRef(true);
   const animateOpenRef = useRef(false);
   const animateCloseRef = useRef(false);
+  const endMotionRef = useRef<(() => void) | null>(null);
   const [size, setSize] = useState<TreeRevealSize>(() => (open ? "auto" : 0));
+
+  const stopMotion = () => {
+    endMotionRef.current?.();
+    endMotionRef.current = null;
+  };
 
   useLayoutEffect(() => {
     const box = boxRef.current;
@@ -67,7 +76,7 @@ export function SidebarTreeReveal({
       reducedMotion: reduced,
     });
     const visualPx = Math.round(box.getBoundingClientRect().height);
-    const contentPx = inner?.scrollHeight ?? 0;
+    const contentPx = measureTreeRevealContent(inner);
     animateOpenRef.current = false;
     animateCloseRef.current = false;
 
@@ -77,6 +86,10 @@ export function SidebarTreeReveal({
       setSize(next);
       return;
     }
+
+    stopMotion();
+    endMotionRef.current = beginTreeRevealMotion();
+    box.dataset.treeRevealMotion = "1";
 
     if (open) {
       // Leave height at 0 for this paint. Promoting to px before paint
@@ -100,26 +113,39 @@ export function SidebarTreeReveal({
     if (!box) return;
     let cancelled = false;
 
+    const settle = (next: TreeRevealSize) => {
+      if (cancelled) return;
+      applyTreeRevealSize(box, next);
+      setSize(next);
+      delete box.dataset.treeRevealMotion;
+      stopMotion();
+    };
+
     if (open && animateOpenRef.current) {
       const id = window.requestAnimationFrame(() => {
         window.requestAnimationFrame(() => {
           if (cancelled) return;
           animateOpenRef.current = false;
-          const h = innerRef.current?.scrollHeight ?? 0;
+          const h = measureTreeRevealContent(innerRef.current);
           if (h <= 0) {
-            applyTreeRevealSize(box, "auto");
-            setSize("auto");
+            // Stay at 0 and retry once — snapping to auto flashes the list.
+            const retry = window.requestAnimationFrame(() => {
+              const again = measureTreeRevealContent(innerRef.current);
+              if (again <= 0) {
+                settle("auto");
+                return;
+              }
+              applyTreeRevealSize(box, again);
+              setSize(again);
+            });
+            if (cancelled) window.cancelAnimationFrame(retry);
             return;
           }
           applyTreeRevealSize(box, h);
           setSize(h);
         });
       });
-      const t = window.setTimeout(() => {
-        if (cancelled) return;
-        applyTreeRevealSize(box, "auto");
-        setSize("auto");
-      }, OPEN_PRESENCE_MS + 32);
+      const t = window.setTimeout(() => settle("auto"), TREE_REVEAL_MS + 32);
       return () => {
         cancelled = true;
         window.cancelAnimationFrame(id);
@@ -136,19 +162,27 @@ export function SidebarTreeReveal({
           setSize(0);
         });
       });
+      const t = window.setTimeout(() => settle(0), TREE_REVEAL_MS + 32);
       return () => {
         cancelled = true;
         window.cancelAnimationFrame(id);
+        window.clearTimeout(t);
       };
     }
   }, [open, presence.mounted]);
+
+  useEffect(() => stopMotion, []);
 
   if (!presence.mounted) return null;
 
   return (
     <div
       ref={boxRef}
-      className={"tree-reveal" + (className ? ` ${className}` : "")}
+      className={
+        "tree-reveal" +
+        (!open ? " is-closing" : "") +
+        (className ? ` ${className}` : "")
+      }
       style={size === "auto" ? undefined : treeRevealSizeStyle(size)}
       data-testid="tree-reveal"
       aria-hidden={!open || undefined}

--- a/src/components/SidebarTreeReveal.tsx
+++ b/src/components/SidebarTreeReveal.tsx
@@ -16,6 +16,7 @@ import { prefersReducedMotion } from "@/lib/paneSplitMotion";
 import {
   applyTreeRevealSize,
   shouldAnimateTreeReveal,
+  treeRevealCloseSteps,
   treeRevealSizeStyle,
   type TreeRevealSize,
 } from "@/lib/treeReveal";
@@ -40,11 +41,13 @@ export function SidebarTreeReveal({
   className,
   children,
 }: SidebarTreeRevealProps) {
-  const presence = useOpenPresence(open, true, OPEN_PRESENCE_MS);
+  // Stay mounted through lock-frame + height transition (open and close).
+  const presence = useOpenPresence(open, true, OPEN_PRESENCE_MS + 48);
   const boxRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const firstCommitRef = useRef(true);
   const animateOpenRef = useRef(false);
+  const animateCloseRef = useRef(false);
   const [size, setSize] = useState<TreeRevealSize>(() => (open ? "auto" : 0));
 
   useLayoutEffect(() => {
@@ -63,8 +66,10 @@ export function SidebarTreeReveal({
       isFirstCommit,
       reducedMotion: reduced,
     });
+    const visualPx = Math.round(box.getBoundingClientRect().height);
     const contentPx = inner?.scrollHeight ?? 0;
     animateOpenRef.current = false;
+    animateCloseRef.current = false;
 
     if (!animate) {
       const next: TreeRevealSize = open ? "auto" : 0;
@@ -82,42 +87,60 @@ export function SidebarTreeReveal({
       return;
     }
 
-    const locked = contentPx || Math.round(box.getBoundingClientRect().height);
-    applyTreeRevealSize(box, locked);
-    void box.getBoundingClientRect();
-    applyTreeRevealSize(box, 0);
-    setSize(0);
+    // Leave height locked for this paint. auto→0 in one commit snaps.
+    const { lockPx } = treeRevealCloseSteps(visualPx || contentPx);
+    applyTreeRevealSize(box, lockPx);
+    setSize(lockPx);
+    animateCloseRef.current = true;
   }, [open, presence.mounted]);
 
   useEffect(() => {
-    if (!open || !presence.mounted || !animateOpenRef.current) return;
+    if (!presence.mounted) return;
     const box = boxRef.current;
     if (!box) return;
     let cancelled = false;
-    const id = window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
-        if (cancelled) return;
-        animateOpenRef.current = false;
-        const h = innerRef.current?.scrollHeight ?? 0;
-        if (h <= 0) {
-          applyTreeRevealSize(box, "auto");
-          setSize("auto");
-          return;
-        }
-        applyTreeRevealSize(box, h);
-        setSize(h);
+
+    if (open && animateOpenRef.current) {
+      const id = window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          if (cancelled) return;
+          animateOpenRef.current = false;
+          const h = innerRef.current?.scrollHeight ?? 0;
+          if (h <= 0) {
+            applyTreeRevealSize(box, "auto");
+            setSize("auto");
+            return;
+          }
+          applyTreeRevealSize(box, h);
+          setSize(h);
+        });
       });
-    });
-    const t = window.setTimeout(() => {
-      if (cancelled) return;
-      applyTreeRevealSize(box, "auto");
-      setSize("auto");
-    }, OPEN_PRESENCE_MS + 32);
-    return () => {
-      cancelled = true;
-      window.cancelAnimationFrame(id);
-      window.clearTimeout(t);
-    };
+      const t = window.setTimeout(() => {
+        if (cancelled) return;
+        applyTreeRevealSize(box, "auto");
+        setSize("auto");
+      }, OPEN_PRESENCE_MS + 32);
+      return () => {
+        cancelled = true;
+        window.cancelAnimationFrame(id);
+        window.clearTimeout(t);
+      };
+    }
+
+    if (!open && animateCloseRef.current) {
+      const id = window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          if (cancelled) return;
+          animateCloseRef.current = false;
+          applyTreeRevealSize(box, 0);
+          setSize(0);
+        });
+      });
+      return () => {
+        cancelled = true;
+        window.cancelAnimationFrame(id);
+      };
+    }
   }, [open, presence.mounted]);
 
   if (!presence.mounted) return null;

--- a/src/components/VirtualList.tsx
+++ b/src/components/VirtualList.tsx
@@ -20,6 +20,10 @@ import {
   SIDEBAR_VIRTUALIZE_THRESHOLD,
   type VirtualWindow,
 } from "@/lib/virtualList";
+import {
+  isTreeRevealMotionActive,
+  runAfterTreeRevealMotion,
+} from "@/lib/treeReveal";
 
 export type VirtualListProps<T> = {
   items: readonly T[];
@@ -167,30 +171,43 @@ export function VirtualList<T>({
     );
     if (index < 0) return;
 
+    const align = () => {
+      const el = rootRef.current;
+      if (!el) return;
+      const parent = scrollParentRef.current ?? findScrollParent(el);
+      if (!parent) return;
+      scrollParentRef.current = parent;
+      const rootRect = el.getBoundingClientRect();
+      const parentRect = parent.getBoundingClientRect();
+      const listOffsetTop =
+        rootRect.top - parentRect.top + parent.scrollTop;
+      const nextTop = scrollTopForIndex(index, {
+        itemCount: count,
+        rowHeight,
+        gap,
+        viewportHeight: parent.clientHeight,
+        currentScrollTop: parent.scrollTop,
+        listOffsetTop,
+      });
+      if (nextTop !== parent.scrollTop) parent.scrollTop = nextTop;
+      recompute();
+    };
+
     const root = rootRef.current;
-    if (!root) return;
-    const scrollParent = scrollParentRef.current ?? findScrollParent(root);
-    if (!scrollParent) return;
-    scrollParentRef.current = scrollParent;
-
-    const rootRect = root.getBoundingClientRect();
-    const parentRect = scrollParent.getBoundingClientRect();
-    const listOffsetTop =
-      rootRect.top - parentRect.top + scrollParent.scrollTop;
-
-    const nextTop = scrollTopForIndex(index, {
-      itemCount: count,
-      rowHeight,
-      gap,
-      viewportHeight: scrollParent.clientHeight,
-      currentScrollTop: scrollParent.scrollTop,
-      listOffsetTop,
-    });
-    if (nextTop !== scrollParent.scrollTop) {
-      scrollParent.scrollTop = nextTop;
+    // Child layout runs before the parent reveal starts motion. Wait a
+    // tick so expand/collapse can own the sidebar scroll for the duration.
+    if (root?.closest(".tree-reveal")) {
+      queueMicrotask(() => {
+        if (isTreeRevealMotionActive()) {
+          runAfterTreeRevealMotion(align);
+          return;
+        }
+        align();
+      });
+      return;
     }
-    // Recompute after scroll so the target row is mounted.
-    recompute();
+
+    align();
     // scrollToKey-driven only (not every items identity change while scrolling).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollToKey, count, rowHeight, gap]);

--- a/src/lib/openPresence.test.ts
+++ b/src/lib/openPresence.test.ts
@@ -100,9 +100,9 @@ describe("floating pop CSS", () => {
   it("interpolates project session lists instead of hard-cutting", () => {
     expect(tree).toMatch(/\.tree-reveal\s*\{/);
     expect(tree).not.toMatch(/grid-template-rows/);
-    expect(tree).toMatch(/height var\(--motion-pane\)/);
-    expect(tree).toMatch(/min-height var\(--motion-pane\)/);
-    expect(tree).toMatch(/max-height var\(--motion-pane\)/);
+    expect(tree).toMatch(/height var\(--motion-normal\)/);
+    expect(tree).toMatch(/min-height var\(--motion-normal\)/);
+    expect(tree).toMatch(/max-height var\(--motion-normal\)/);
     expect(tree).toMatch(/var\(--motion-pane-ease\)/);
   });
 });

--- a/src/lib/openPresence.test.ts
+++ b/src/lib/openPresence.test.ts
@@ -100,9 +100,9 @@ describe("floating pop CSS", () => {
   it("interpolates project session lists instead of hard-cutting", () => {
     expect(tree).toMatch(/\.tree-reveal\s*\{/);
     expect(tree).not.toMatch(/grid-template-rows/);
-    expect(tree).toMatch(/height var\(--motion-normal\)/);
-    expect(tree).toMatch(/min-height var\(--motion-normal\)/);
-    expect(tree).toMatch(/max-height var\(--motion-normal\)/);
+    expect(tree).toMatch(/height var\(--motion-pane\)/);
+    expect(tree).toMatch(/min-height var\(--motion-pane\)/);
+    expect(tree).toMatch(/max-height var\(--motion-pane\)/);
     expect(tree).toMatch(/var\(--motion-pane-ease\)/);
   });
 });

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyTreeRevealSize,
   shouldAnimateTreeReveal,
+  treeRevealCloseSteps,
   treeRevealSizeStyle,
 } from "./treeReveal";
 
@@ -33,6 +34,13 @@ describe("shouldAnimateTreeReveal", () => {
     expect(
       shouldAnimateTreeReveal({ isFirstCommit: false, reducedMotion: true }),
     ).toBe(false);
+  });
+});
+
+describe("treeRevealCloseSteps", () => {
+  it("locks the used height before writing 0 so auto→0 can interpolate", () => {
+    expect(treeRevealCloseSteps(256)).toEqual({ lockPx: 256, endPx: 0 });
+    expect(treeRevealCloseSteps(0)).toEqual({ lockPx: 0, endPx: 0 });
   });
 });
 

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -8,6 +8,7 @@ import {
   resetTreeRevealMotionForTests,
   runAfterTreeRevealMotion,
   shouldAnimateTreeReveal,
+  TREE_REVEAL_CLOSE_MS,
   TREE_REVEAL_MS,
   treeRevealCloseSteps,
   treeRevealSizeStyle,
@@ -94,6 +95,13 @@ describe("tree-reveal CSS", () => {
     expect(css).toMatch(/min-height var\(--motion-pane\)/);
     expect(css).toMatch(/max-height var\(--motion-pane\)/);
     expect(css).toMatch(/var\(--motion-pane-ease\)/);
-    expect(css).toMatch(/\.tree-reveal\.is-closing/);
+  });
+
+  it("closes slower with ease-in, not the pane expo-out", () => {
+    expect(TREE_REVEAL_CLOSE_MS).toBe(520);
+    const close = css.slice(css.indexOf(".tree-reveal.is-closing"));
+    expect(close).toMatch(/520ms/);
+    expect(close).toMatch(/cubic-bezier\(0\.42,\s*0,\s*0\.58,\s*1\)/);
+    expect(close).not.toMatch(/--motion-pane-ease/);
   });
 });

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -88,20 +88,23 @@ describe("tree-reveal CSS", () => {
     "utf8",
   );
 
-  it("interpolates the inline height tuple — not 0fr/1fr, which WKWebView snaps", () => {
-    expect(TREE_REVEAL_MS).toBe(320);
-    expect(css).not.toMatch(/grid-template-rows/);
-    expect(css).toMatch(/\.tree-reveal\s*\{[^}]*height var\(--motion-pane\)/);
-    expect(css).toMatch(/min-height var\(--motion-pane\)/);
-    expect(css).toMatch(/max-height var\(--motion-pane\)/);
-    expect(css).toMatch(/var\(--motion-pane-ease\)/);
+  it("drives the L1 projects chevron, not only per-project chats", () => {
+    const src = readFileSync(
+      resolve(__dirname, "../app/AppWorkbench.tsx"),
+      "utf8",
+    );
+    expect(src).toMatch(
+      /<SidebarTreeReveal open=\{projectsOpen\} className="tree-reveal--projects">/,
+    );
   });
 
-  it("closes slower with ease-in, not the pane expo-out", () => {
-    expect(TREE_REVEAL_CLOSE_MS).toBe(520);
-    const close = css.slice(css.indexOf(".tree-reveal.is-closing"));
-    expect(close).toMatch(/520ms/);
-    expect(close).toMatch(/cubic-bezier\(0\.42,\s*0,\s*0\.58,\s*1\)/);
-    expect(close).not.toMatch(/--motion-pane-ease/);
+  it("interpolates the inline height tuple — not 0fr/1fr, which WKWebView snaps", () => {
+    expect(TREE_REVEAL_MS).toBe(200);
+    expect(TREE_REVEAL_CLOSE_MS).toBe(200);
+    expect(css).not.toMatch(/grid-template-rows/);
+    expect(css).toMatch(/\.tree-reveal\s*\{[^}]*height var\(--motion-normal\)/);
+    expect(css).toMatch(/min-height var\(--motion-normal\)/);
+    expect(css).toMatch(/max-height var\(--motion-normal\)/);
+    expect(css).toMatch(/var\(--motion-pane-ease\)/);
   });
 });

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -1,9 +1,14 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   applyTreeRevealSize,
+  beginTreeRevealMotion,
+  isTreeRevealMotionActive,
+  resetTreeRevealMotionForTests,
+  runAfterTreeRevealMotion,
   shouldAnimateTreeReveal,
+  TREE_REVEAL_MS,
   treeRevealCloseSteps,
   treeRevealSizeStyle,
 } from "./treeReveal";
@@ -58,6 +63,24 @@ describe("applyTreeRevealSize", () => {
   });
 });
 
+describe("tree reveal motion deferral", () => {
+  afterEach(() => {
+    resetTreeRevealMotionForTests();
+  });
+
+  it("defers work until the last expand/collapse ends", () => {
+    const ran: string[] = [];
+    expect(runAfterTreeRevealMotion(() => ran.push("early"))).toBe(false);
+    const end = beginTreeRevealMotion();
+    expect(isTreeRevealMotionActive()).toBe(true);
+    expect(runAfterTreeRevealMotion(() => ran.push("later"))).toBe(true);
+    expect(ran).toEqual([]);
+    end();
+    expect(isTreeRevealMotionActive()).toBe(false);
+    expect(ran).toEqual(["later"]);
+  });
+});
+
 describe("tree-reveal CSS", () => {
   const css = readFileSync(
     resolve(__dirname, "../styles/sidebar.part2.css"),
@@ -65,10 +88,12 @@ describe("tree-reveal CSS", () => {
   );
 
   it("interpolates the inline height tuple — not 0fr/1fr, which WKWebView snaps", () => {
+    expect(TREE_REVEAL_MS).toBe(320);
     expect(css).not.toMatch(/grid-template-rows/);
-    expect(css).toMatch(/\.tree-reveal\s*\{[^}]*height var\(--motion-normal\)/);
-    expect(css).toMatch(/min-height var\(--motion-normal\)/);
-    expect(css).toMatch(/max-height var\(--motion-normal\)/);
+    expect(css).toMatch(/\.tree-reveal\s*\{[^}]*height var\(--motion-pane\)/);
+    expect(css).toMatch(/min-height var\(--motion-pane\)/);
+    expect(css).toMatch(/max-height var\(--motion-pane\)/);
     expect(css).toMatch(/var\(--motion-pane-ease\)/);
+    expect(css).toMatch(/\.tree-reveal\.is-closing/);
   });
 });

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -7,6 +7,7 @@ import {
   isTreeRevealMotionActive,
   resetTreeRevealMotionForTests,
   runAfterTreeRevealMotion,
+  subscribeTreeRevealMotion,
   shouldAnimateTreeReveal,
   TREE_REVEAL_CLOSE_MS,
   TREE_REVEAL_MS,
@@ -80,6 +81,16 @@ describe("tree reveal motion deferral", () => {
     expect(isTreeRevealMotionActive()).toBe(false);
     expect(ran).toEqual(["later"]);
   });
+
+  it("notifies subscribers on start and end even if they never deferred", () => {
+    const seen: boolean[] = [];
+    const stop = subscribeTreeRevealMotion((active) => seen.push(active));
+    const end = beginTreeRevealMotion();
+    expect(seen).toEqual([true]);
+    end();
+    expect(seen).toEqual([true, false]);
+    stop();
+  });
 });
 
 describe("tree-reveal CSS", () => {
@@ -95,6 +106,16 @@ describe("tree-reveal CSS", () => {
     );
     expect(src).toMatch(
       /<SidebarTreeReveal open=\{projectsOpen\} className="tree-reveal--projects">/,
+    );
+    expect(src).toMatch(/syncTreeReveal/);
+  });
+
+  it("hides the sidebar overlay thumb while the project list is moving", () => {
+    expect(css).toMatch(
+      /\.sidebar__scroll:has\(\[data-tree-reveal-motion\]\) \.overlay-scroll__thumb/,
+    );
+    expect(css).toMatch(
+      /\.sidebar__scroll:has\(\[data-tree-reveal-motion\]\) \.overlay-scroll__viewport/,
     );
   });
 

--- a/src/lib/treeReveal.ts
+++ b/src/lib/treeReveal.ts
@@ -5,14 +5,10 @@
  * `width: 0 !important`).
  */
 
-/** Matches `--motion-pane` — expand. */
-export const TREE_REVEAL_MS = 320;
-/**
- * Close is longer and ease-in. `--motion-pane-ease` is expo-out and dumps
- * most of the height in the first frames — that is the "whoosh".
- */
-export const TREE_REVEAL_CLOSE_MS = 520;
-export const TREE_REVEAL_PRESENCE_MS = TREE_REVEAL_CLOSE_MS + 80;
+/** Matches `--motion-normal`. */
+export const TREE_REVEAL_MS = 200;
+export const TREE_REVEAL_CLOSE_MS = 200;
+export const TREE_REVEAL_PRESENCE_MS = TREE_REVEAL_CLOSE_MS + 48;
 
 export type TreeRevealSize = number | "auto";
 

--- a/src/lib/treeReveal.ts
+++ b/src/lib/treeReveal.ts
@@ -72,13 +72,29 @@ export function measureTreeRevealContent(inner: HTMLElement | null): number {
 
 let motionCount = 0;
 const idle = new Set<() => void>();
+const watchers = new Set<(active: boolean) => void>();
 
 export function isTreeRevealMotionActive(): boolean {
   return motionCount > 0;
 }
 
+export function subscribeTreeRevealMotion(
+  fn: (active: boolean) => void,
+): () => void {
+  watchers.add(fn);
+  return () => {
+    watchers.delete(fn);
+  };
+}
+
+function emitMotion(active: boolean): void {
+  for (const fn of [...watchers]) fn(active);
+}
+
 export function beginTreeRevealMotion(): () => void {
+  const wasIdle = motionCount === 0;
   motionCount += 1;
+  if (wasIdle) emitMotion(true);
   let open = true;
   return () => {
     if (!open) return;
@@ -88,6 +104,7 @@ export function beginTreeRevealMotion(): () => void {
     const waiters = [...idle];
     idle.clear();
     for (const fn of waiters) fn();
+    emitMotion(false);
   };
 }
 

--- a/src/lib/treeReveal.ts
+++ b/src/lib/treeReveal.ts
@@ -5,6 +5,10 @@
  * `width: 0 !important`).
  */
 
+/** Matches `--motion-pane`. Extra slack keeps the node mounted through rAF. */
+export const TREE_REVEAL_MS = 320;
+export const TREE_REVEAL_PRESENCE_MS = TREE_REVEAL_MS + 64;
+
 export type TreeRevealSize = number | "auto";
 
 export type TreeRevealSizeStyle = {
@@ -52,4 +56,48 @@ export function treeRevealCloseSteps(contentPx: number): {
   endPx: number;
 } {
   return { lockPx: Math.max(0, Math.round(contentPx)), endPx: 0 };
+}
+
+export function measureTreeRevealContent(inner: HTMLElement | null): number {
+  if (!inner) return 0;
+  const direct = Math.round(inner.scrollHeight);
+  if (direct > 0) return direct;
+  let sum = 0;
+  for (let i = 0; i < inner.children.length; i++) {
+    sum += inner.children[i].getBoundingClientRect().height;
+  }
+  return Math.round(sum);
+}
+
+let motionCount = 0;
+const idle = new Set<() => void>();
+
+export function isTreeRevealMotionActive(): boolean {
+  return motionCount > 0;
+}
+
+export function beginTreeRevealMotion(): () => void {
+  motionCount += 1;
+  let open = true;
+  return () => {
+    if (!open) return;
+    open = false;
+    motionCount = Math.max(0, motionCount - 1);
+    if (motionCount > 0) return;
+    const waiters = [...idle];
+    idle.clear();
+    for (const fn of waiters) fn();
+  };
+}
+
+/** Queue `fn` until expand/collapse ends. Returns true when deferred. */
+export function runAfterTreeRevealMotion(fn: () => void): boolean {
+  if (motionCount === 0) return false;
+  idle.add(fn);
+  return true;
+}
+
+export function resetTreeRevealMotionForTests(): void {
+  motionCount = 0;
+  idle.clear();
 }

--- a/src/lib/treeReveal.ts
+++ b/src/lib/treeReveal.ts
@@ -42,3 +42,14 @@ export function shouldAnimateTreeReveal(opts: {
   if (opts.isFirstCommit || opts.reducedMotion) return false;
   return true;
 }
+
+/**
+ * Close must paint a locked px height, then 0. Writing auto→0 in one
+ * commit is the WKWebView snap (same as promoting 0→N before paint).
+ */
+export function treeRevealCloseSteps(contentPx: number): {
+  lockPx: number;
+  endPx: number;
+} {
+  return { lockPx: Math.max(0, Math.round(contentPx)), endPx: 0 };
+}

--- a/src/lib/treeReveal.ts
+++ b/src/lib/treeReveal.ts
@@ -5,9 +5,14 @@
  * `width: 0 !important`).
  */
 
-/** Matches `--motion-pane`. Extra slack keeps the node mounted through rAF. */
+/** Matches `--motion-pane` — expand. */
 export const TREE_REVEAL_MS = 320;
-export const TREE_REVEAL_PRESENCE_MS = TREE_REVEAL_MS + 64;
+/**
+ * Close is longer and ease-in. `--motion-pane-ease` is expo-out and dumps
+ * most of the height in the first frames — that is the "whoosh".
+ */
+export const TREE_REVEAL_CLOSE_MS = 520;
+export const TREE_REVEAL_PRESENCE_MS = TREE_REVEAL_CLOSE_MS + 80;
 
 export type TreeRevealSize = number | "auto";
 

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -122,21 +122,16 @@
 .tree-reveal {
   overflow: clip;
   transition:
-    height var(--motion-pane) var(--motion-pane-ease),
-    min-height var(--motion-pane) var(--motion-pane-ease),
-    max-height var(--motion-pane) var(--motion-pane-ease);
+    height var(--motion-normal) var(--motion-pane-ease),
+    min-height var(--motion-normal) var(--motion-pane-ease),
+    max-height var(--motion-normal) var(--motion-pane-ease);
 }
 
-/*
- * Full shorthand (WKWebView ignores a lone timing-function override on
- * a per-property transition). Ease-in + 520ms so close starts slow
- * instead of dumping the list in the first frames.
- */
 .tree-reveal.is-closing {
   transition:
-    height 520ms cubic-bezier(0.42, 0, 0.58, 1),
-    min-height 520ms cubic-bezier(0.42, 0, 0.58, 1),
-    max-height 520ms cubic-bezier(0.42, 0, 0.58, 1);
+    height var(--motion-normal) var(--motion-pane-ease),
+    min-height var(--motion-normal) var(--motion-pane-ease),
+    max-height var(--motion-normal) var(--motion-pane-ease);
 }
 
 .tree-reveal__inner {

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -143,6 +143,17 @@
   contain: none;
 }
 
+/* Collapsing the list leaves a stale overlay thumb (and WKWebView's
+ * native indicator) until the next hover. Hide both while height moves. */
+.sidebar__scroll:has([data-tree-reveal-motion]) .overlay-scroll__thumb {
+  opacity: 0;
+  transition: none;
+}
+
+.sidebar__scroll:has([data-tree-reveal-motion]) .overlay-scroll__viewport {
+  overflow: hidden;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .tree-reveal {
     transition: none;

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -127,10 +127,16 @@
     max-height var(--motion-pane) var(--motion-pane-ease);
 }
 
-/* Ease-out dumps most of the height in the first frames — collapse feels
- * like a snap. Use a symmetric curve so close matches the open read. */
+/*
+ * Full shorthand (WKWebView ignores a lone timing-function override on
+ * a per-property transition). Ease-in + 520ms so close starts slow
+ * instead of dumping the list in the first frames.
+ */
 .tree-reveal.is-closing {
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition:
+    height 520ms cubic-bezier(0.42, 0, 0.58, 1),
+    min-height 520ms cubic-bezier(0.42, 0, 0.58, 1),
+    max-height 520ms cubic-bezier(0.42, 0, 0.58, 1);
 }
 
 .tree-reveal__inner {

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -120,11 +120,17 @@
  * on .tree-l3-list-wrap so a closed section does not leave leftover inset.
  */
 .tree-reveal {
-  overflow: hidden;
+  overflow: clip;
   transition:
-    height var(--motion-normal) var(--motion-pane-ease),
-    min-height var(--motion-normal) var(--motion-pane-ease),
-    max-height var(--motion-normal) var(--motion-pane-ease);
+    height var(--motion-pane) var(--motion-pane-ease),
+    min-height var(--motion-pane) var(--motion-pane-ease),
+    max-height var(--motion-pane) var(--motion-pane-ease);
+}
+
+/* Ease-out dumps most of the height in the first frames — collapse feels
+ * like a snap. Use a symmetric curve so close matches the open read. */
+.tree-reveal.is-closing {
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .tree-reveal__inner {


### PR DESCRIPTION
## Summary

Follow-up to #681. Expanding a project already interpolated; collapsing it (and the L1 Projects chevron) still snapped in WKWebView, and the overlay scrollbar stayed after the list hit height 0.

- **Close path:** lock the used px height, paint it, then interpolate to 0. Writing `auto→0` in one commit is the same snap as `0→N` before paint.
- **Stay on the inline px tuple** through settle so the next close is not another `auto→0` snap.
- **L1 Projects section:** wrap `projectsOpen` in `SidebarTreeReveal` so the whole project list interpolates, not only a single project's chats. Session-row motion stays on `--motion-normal` (200ms).
- **Scrollbar:** while the list is interpolating, hide the overlay thumb, force `overflow: hidden`, and defer OverlayScroll measure / VirtualList scroll-into-view. Remeasure on settle so the rail does not flash or linger.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (targeted: `treeReveal`, `SidebarTreeReveal`; plus `pnpm typecheck`)
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only) — no Rust changes
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new strings
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed (`docs/design-tokens.md` notes sidebar project-list motion)
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

## Test plan
- [ ] Click a project row: list height interpolates open; collapse plays the reverse without snapping
- [ ] Click the L1 Projects chevron: the whole project list interpolates; siblings below slide instead of jumping
- [ ] After collapse, no leftover overlay scrollbar / WKWebView indicator on the rail
- [ ] Other sessions uses the same expand/collapse motion
- [ ] Rapid expand/collapse does not flash the rail thumb or jump the virtual list