### PR TITLE
fix(session): paint late tool-turn answers without remount

### DIFF
--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -102,7 +102,9 @@ import {
   toolEventNeedsImmediateFlush,
 } from "@/lib/streamCoalesce";
 import {
+  JOURNAL_REHYDRATE_RETRY_GAPS_MS,
   shouldApplyLateStreamText,
+  shouldHealJournalOnStreamDone,
   shouldIgnorePrematureStreamDone,
 } from "@/lib/streamLateToken";
 import {
@@ -393,10 +395,13 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
               // truncated stream. Apply must run post-rehydrate for the
               // *viewed* session too (stream `done` alone is not enough).
               void c.tryApplyAutomationFromSession(sid);
-              if (attempt === 0) {
+              const gap = JOURNAL_REHYDRATE_RETRY_GAPS_MS[attempt];
+              if (gap != null) {
                 window.setTimeout(() => {
-                  if (!cancelled) scheduleJournalRehydrate(sid, 1, opts);
-                }, 400);
+                  if (!cancelled) {
+                    scheduleJournalRehydrate(sid, attempt + 1, opts);
+                  }
+                }, gap);
               }
             })
             .catch(() => {
@@ -948,6 +953,18 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
                 streamingMessageId: null,
               }),
             );
+            // liveMap is already ready here, so session://state ready→ready
+            // will not schedule a heal. Lift any journal tail the late-token
+            // filter or a dropped IPC batch missed.
+            if (
+              shouldHealJournalOnStreamDone({
+                isViewingSession:
+                  chunk.sessionId === c.viewingSessionIdRef.current,
+                streamDone: true,
+              })
+            ) {
+              scheduleJournalRehydrate(chunk.sessionId, 0);
+            }
           }
           c.patchSessionMessages(chunk.sessionId, (prev) => {
             const next = applyStreamChunk(prev, effective);

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1186,6 +1186,56 @@ describe("session projection", () => {
     );
   });
 
+  it("upgradeMessagesFromJournal lifts a tool-only empty bubble from disk", () => {
+    const ui: ChatMessage[] = [
+      { id: "u1", role: "user", content: "删 branch" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "",
+        streaming: false,
+        segments: [
+          toolSegmentFromFields({
+            toolCallId: "t1",
+            title: "git",
+            status: "completed",
+          }),
+        ],
+      },
+    ];
+    const journal: ChatMessage[] = [
+      { id: "u1", role: "user", content: "删 branch" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "昨晚那批已经清掉了。",
+      },
+    ];
+    const out = upgradeMessagesFromJournal(ui, journal);
+    expect(out.find((m) => m.id === "a1")?.content).toBe("昨晚那批已经清掉了。");
+  });
+
+  it("applyStreamChunk attaches a late answer onto a settled empty assistant", () => {
+    const msgs: ChatMessage[] = [
+      { id: "u1", role: "user", content: "删 branch" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "",
+        streaming: false,
+      },
+    ];
+    const out = applyStreamChunk(msgs, {
+      sessionId: "s1",
+      messageId: "a1",
+      text: "昨晚那批已经清掉了。",
+      done: true,
+      kind: "assistant",
+    });
+    expect(out.find((m) => m.id === "a1")?.content).toContain("清掉");
+    expect(out.find((m) => m.id === "a1")?.streaming).toBe(false);
+  });
+
   it("weaveToolsIntoAssistantSegments puts journal tools between thought and content", () => {
     // Host journal shape: U → A (final) → tools (tools ran mid-turn).
     const woven = weaveToolsIntoAssistantSegments([

--- a/src/lib/streamLateToken.test.ts
+++ b/src/lib/streamLateToken.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  JOURNAL_REHYDRATE_RETRY_GAPS_MS,
   shouldApplyLateStreamText,
+  shouldHealJournalOnStreamDone,
   shouldIgnorePrematureStreamDone,
 } from "./streamLateToken";
 
@@ -77,13 +79,17 @@ describe("shouldApplyLateStreamText", () => {
     ).toBe(false);
   });
 
-  it("drops settled tool-only empty body (no thought)", () => {
+  it("applies late answer after a tool-only bubble was settled by early ready", () => {
+    // Repro: long tool turn → stream done / host ready first → real answer
+    // tokens. Old code treated empty+no-thought as "settled final" and
+    // dropped the body. Switching sessions remounted from journal and
+    // the text appeared.
     expect(
       shouldApplyLateStreamText({
         hostLiveStreaming: false,
         chunkIsForFocusedHost: true,
         messages: [
-          { role: "user", content: "q" },
+          { role: "user", content: "删掉昨晚的 branches" },
           {
             role: "assistant",
             streaming: false,
@@ -92,7 +98,7 @@ describe("shouldApplyLateStreamText", () => {
           },
         ],
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("ignores stream-done while host or tools are still live", () => {
@@ -124,5 +130,37 @@ describe("shouldApplyLateStreamText", () => {
         messages: [{ role: "user", content: "q" }],
       }),
     ).toBe(true);
+  });
+});
+
+describe("shouldHealJournalOnStreamDone", () => {
+  it("heals the viewed chat on stream done (ready→ready skips state heal)", () => {
+    expect(
+      shouldHealJournalOnStreamDone({
+        isViewingSession: true,
+        streamDone: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not heal a background chat or a non-done chunk", () => {
+    expect(
+      shouldHealJournalOnStreamDone({
+        isViewingSession: false,
+        streamDone: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldHealJournalOnStreamDone({
+        isViewingSession: true,
+        streamDone: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("retries long enough to cover Host post-turn journal flush", () => {
+    const total = JOURNAL_REHYDRATE_RETRY_GAPS_MS.reduce((a, b) => a + b, 0);
+    expect(JOURNAL_REHYDRATE_RETRY_GAPS_MS).toEqual([400, 500]);
+    expect(total).toBeGreaterThanOrEqual(750);
   });
 });

--- a/src/lib/streamLateToken.ts
+++ b/src/lib/streamLateToken.ts
@@ -55,13 +55,32 @@ export function shouldApplyLateStreamText(opts: {
   if (turnAsst.streaming) return true;
 
   const bodyEmpty = !((turnAsst.content ?? "").trim());
-  const hasThought = !((turnAsst.thought ?? "").trim() === "");
-  // Thinking landed, body still empty (host may have cleared streaming on ready).
-  if (bodyEmpty && hasThought) return true;
+  // Empty body after early ready: thinking-only *or* tool-only. A long tool
+  // turn settles the bubble (streaming=false, no thought) before the real
+  // answer tokens arrive. Dropping those tokens left the viewed chat blank
+  // until the user switched sessions and remounted from disk.
+  if (bodyEmpty) return true;
 
-  // Settled with body already present, or tool-only empty final → drop replays.
+  // Settled with a body already present → drop post-turn replays that
+  // would double-append into the finished bubble.
   return false;
 }
+
+/**
+ * Stream `done` flips liveMap to `ready`. The session://state ready
+ * handler then sees ready→ready and skips journal heal
+ * (`isTurnDoneReadyTransition` is false). Heal the viewed chat on
+ * stream done so a dropped tail is lifted without a remount.
+ */
+export function shouldHealJournalOnStreamDone(opts: {
+  isViewingSession: boolean;
+  streamDone: boolean;
+}): boolean {
+  return opts.streamDone && opts.isViewingSession;
+}
+
+/** Gaps after attempt 0: 400ms then +500ms (900ms), covering Host's 750ms flush. */
+export const JOURNAL_REHYDRATE_RETRY_GAPS_MS = [400, 500] as const;
 
 /**
  * Early `session://stream` `done:true` (prompt_complete / prompt RPC


### PR DESCRIPTION
Closes #697

## Why

Long tool turns settle the assistant bubble (`streaming=false`, empty body, no thought) before the real answer tokens arrive. Two holes stacked:

1. `shouldApplyLateStreamText` dropped that tail as a replay.
2. Stream `done` flipped liveMap to `ready` first, so the later `session://state` ready event skipped journal heal (`ready→ready`). Host often already had the row on disk (`changed == 0`), so `session://journal_reconciled` never fired either.

Switching sessions remounted from disk and the text appeared.

## What

- Apply late stream text whenever the last-turn body is empty (thinking-only or tool-only).
- Heal the viewed journal on stream `done`.
- Retry rehydrate at 400ms then 900ms so it covers Host's 750ms post-turn flush.

## Tests

`src/lib/streamLateToken.test.ts` and the two new cases in `src/lib/session.test.ts`.
