### PR TITLE
fix(session): unlock composer when a finished turn stays on 思考中 / 连接中

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- **Finished turns no longer stay on 思考中 / 连接中**: After the last assistant body is painted, leftover streaming or a leaked connect claim kept Stop and blocked the next send. Client heal unlocks the composer (reply stays) when Host is idle, or after 90s if Host itself went stale.
+
+**中文 · 修复**
+- **回合结束后不再一直「思考中 / 连接中」**：正文已经出来，UI 还停在停止键、发不了下一句。Host 已空闲（或卡住超过 90 秒）时自动解锁，回复保留。
+
 ## [0.2.22] - 2026-08-19
 
 > **Highlight:** Move chats between projects; a persist-mounted terminal under the chat; Russian UI; pet overlay no longer steals the first click.

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -11045,6 +11045,18 @@ export function AppWorkbench() {
       showToast(tr("agent.ghostStreamingHealed"), 5200);
       setLocalError(tr("agent.ghostStreamingHealed"));
     },
+    uiConnecting: connecting,
+    connectInFlightCountRef: ensureConnectCountRef,
+    releaseConnecting: (sessionId) => {
+      releaseSessionConnection([
+        queueSessionKey(sessionId),
+        queueSessionKey(null),
+      ]);
+      syncEnsureConnectingUi();
+    },
+    onZombieHealed: () => {
+      showToast(tr("agent.zombieBusyHealed"), 4200);
+    },
   });
 
   // Soft-steer while a live turn is producing (streaming / permission). Align

--- a/src/hooks/useGhostStreamingHeal.ts
+++ b/src/hooks/useGhostStreamingHeal.ts
@@ -13,6 +13,10 @@ import {
   shouldHealGhostStreaming,
   stripGhostTurnMessages,
 } from "@/lib/ghostStreamingHeal";
+import {
+  shouldHealZombieBusy,
+  shouldReleaseStaleConnectingClaim,
+} from "@/lib/zombieBusyHeal";
 import type { SessionLiveMap } from "@/lib/sessionLiveStore";
 import { settleStoppedSessionInLiveMap } from "@/lib/sessionLiveStore";
 import { queueSessionKey } from "@/lib/sendQueue";
@@ -53,6 +57,12 @@ export type GhostStreamingHealDeps = {
   restoreComposer: (text: string) => void;
   /** User-visible notice (toast / localError). */
   onHealed: (restoredText: string) => void;
+  /** Leftover ensureConnected claim paints 连接中 and blocks the next send. */
+  uiConnecting?: boolean;
+  connectInFlightCountRef?: MutableRefObject<number>;
+  releaseConnecting?: (sessionId: string | null) => void;
+  /** Finished-turn unlock (reply stays; composer becomes sendable). */
+  onZombieHealed?: () => void;
 };
 
 /**
@@ -95,6 +105,7 @@ export function useGhostStreamingHeal(deps: GhostStreamingHealDeps): void {
     deps.enabled &&
     (deps.sessionState === "streaming" ||
       deps.sessionState === "awaiting_permission" ||
+      deps.uiConnecting === true ||
       emptyStreaming);
 
   useEffect(() => {
@@ -109,6 +120,90 @@ export function useGhostStreamingHeal(deps: GhostStreamingHealDeps): void {
         d.liveMapRef.current,
         d.liveHostRef.current,
       );
+      const sendInFlight = d.sendInFlightBySessionRef
+        ? ghostSendInFlight(d.sendInFlightBySessionRef.current, d.sessionId)
+        : d.sendInFlightRef.current;
+
+      const evidence = {
+        uiSessionState: d.sessionState,
+        uiConnecting: d.uiConnecting === true,
+        viewedSessionId: d.sessionId,
+        messages: d.messages,
+        turnStartedAt: d.turnStartedAt,
+        nowMs: Date.now(),
+        hostStateForSession: hostState,
+        sendInFlight,
+        connectInFlightCount: d.connectInFlightCountRef?.current ?? 0,
+      };
+
+      if (shouldReleaseStaleConnectingClaim(evidence)) {
+        d.releaseConnecting?.(d.sessionId);
+      }
+
+      if (shouldHealZombieBusy(evidence)) {
+        healingRef.current = true;
+        try {
+          const sid = d.sessionId;
+          const settle = <
+            T extends {
+              sessionId: string | null;
+              state: SessionState;
+              streamingMessageId?: string | null;
+              lastError?: unknown;
+            },
+          >(
+            prev: T,
+          ): T => {
+            if (sid && prev.sessionId && prev.sessionId !== sid) return prev;
+            if (
+              prev.state !== "streaming" &&
+              prev.state !== "awaiting_permission" &&
+              prev.state !== "connecting"
+            ) {
+              return prev;
+            }
+            return {
+              ...prev,
+              state: prev.sessionId ? "ready" : "idle",
+              streamingMessageId: null,
+              lastError: null,
+            };
+          };
+          if (sid) {
+            d.setLiveMap((prev) => {
+              const stopped = settleStoppedSessionInLiveMap(prev, sid);
+              const row = stopped[sid];
+              if (row?.state === "connecting") {
+                return {
+                  ...stopped,
+                  [sid]: { ...row, state: "ready", streamingMessageId: null },
+                };
+              }
+              return stopped;
+            });
+            d.patchSessionMessages(sid, (prev) =>
+              prev.some((m) => m.streaming)
+                ? prev.map((m) =>
+                    m.streaming ? { ...m, streaming: false } : m,
+                  )
+                : prev,
+            );
+          }
+          d.setSession((prev) => settle(prev));
+          d.setLiveHost((prev) => {
+            const next = settle(prev);
+            d.liveHostRef.current = next;
+            return next;
+          });
+          d.clearTurnClock(sid);
+          d.setStreamStall(null);
+          d.releaseConnecting?.(sid);
+          d.onZombieHealed?.();
+        } finally {
+          healingRef.current = false;
+        }
+        return;
+      }
 
       if (
         !shouldHealGhostStreaming({
@@ -118,12 +213,7 @@ export function useGhostStreamingHeal(deps: GhostStreamingHealDeps): void {
           turnStartedAt: d.turnStartedAt,
           nowMs: Date.now(),
           hostStateForSession: hostState,
-          sendInFlight: d.sendInFlightBySessionRef
-            ? ghostSendInFlight(
-                d.sendInFlightBySessionRef.current,
-                d.sessionId,
-              )
-            : d.sendInFlightRef.current,
+          sendInFlight,
         })
       ) {
         return;
@@ -238,5 +328,6 @@ export function useGhostStreamingHeal(deps: GhostStreamingHealDeps): void {
     // Re-arm when message list shape changes (new optimistic shell).
     deps.messages.length,
     emptyStreaming,
+    deps.uiConnecting,
   ]);
 }

--- a/src/i18n/messages/en/core.ts
+++ b/src/i18n/messages/en/core.ts
@@ -74,6 +74,8 @@ export const enCore = {
   "agent.streamStallKeepWaiting": "Keep waiting",
   "agent.streamStallHardEndToast": "Turn was closed after Host recovery — your reply was kept.",
   "agent.ghostStreamingHealed": "Message never reached the agent. Restored to the composer — send again.",
+  "agent.zombieBusyHealed":
+    "This turn already finished. Composer unlocked — you can send again.",
   "app.quitBusy.title": "Quit while agents are busy?",
   "app.quitBusy.message": "{n} session(s) are still running. Quitting will stop in-progress agent work.",
   "app.quitBusy.confirm": "Quit",

--- a/src/i18n/messages/ru/extra.ts
+++ b/src/i18n/messages/ru/extra.ts
@@ -2,6 +2,8 @@
 import type { MessageKey } from "../en";
 
 export const ruExtra: Partial<Record<MessageKey, string>> = {
+  "agent.zombieBusyHealed":
+    "Этот ход уже завершён. Поле ввода снова доступно — можно отправить следующее сообщение.",
   // Project menu and trust flow.
   "project.pin": "Закрепить проект",
   "project.unpin": "Открепить проект",

--- a/src/i18n/messages/zh-TW/core.ts
+++ b/src/i18n/messages/zh-TW/core.ts
@@ -74,6 +74,7 @@ export const zhTWCore = {
   "agent.streamStallKeepWaiting": "繼續等待",
   "agent.streamStallHardEndToast": "Host 已恢復收尾，本輪內容已保留。",
   "agent.ghostStreamingHealed": "訊息沒有真正送給 Agent。已恢復到輸入框，請重新發送。",
+  "agent.zombieBusyHealed": "這一輪其實已經結束。已恢復發送，可以繼續提問。",
   "app.quitBusy.title": "仍有 Agent 忙碌，確定結束？",
   "app.quitBusy.message": "還有 {n} 個對話在執行。結束會中斷進行中的 Agent 工作。",
   "app.quitBusy.confirm": "結束",

--- a/src/i18n/messages/zh/core.ts
+++ b/src/i18n/messages/zh/core.ts
@@ -74,6 +74,7 @@ export const zhCore = {
   "agent.streamStallKeepWaiting": "继续等待",
   "agent.streamStallHardEndToast": "Host 已恢复收尾，本轮内容已保留。",
   "agent.ghostStreamingHealed": "消息没有真正发给 Agent。已恢复到输入框，请重新发送。",
+  "agent.zombieBusyHealed": "这一轮其实已经结束。已恢复发送，可以继续提问。",
   "app.quitBusy.title": "仍有 Agent 忙碌，确定退出？",
   "app.quitBusy.message": "还有 {n} 个会话在运行。退出会中断进行中的 Agent 工作。",
   "app.quitBusy.confirm": "退出",

--- a/src/lib/zombieBusyHeal.test.ts
+++ b/src/lib/zombieBusyHeal.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldHealZombieBusy,
+  shouldReleaseStaleConnectingClaim,
+  transcriptLooksTurnComplete,
+  ZOMBIE_BUSY_GRACE_MS,
+  ZOMBIE_BUSY_HOST_STALE_MS,
+} from "./zombieBusyHeal";
+
+const doneAssistant = [
+  { role: "user", content: "hi" },
+  { role: "assistant", content: "done reply", streaming: false },
+];
+
+describe("transcriptLooksTurnComplete", () => {
+  it("is true when the last assistant has a finished body", () => {
+    expect(transcriptLooksTurnComplete(doneAssistant)).toBe(true);
+  });
+
+  it("is false while any row is still streaming or the last turn is only a user", () => {
+    expect(
+      transcriptLooksTurnComplete([
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "partial", streaming: true },
+      ]),
+    ).toBe(false);
+    expect(transcriptLooksTurnComplete([{ role: "user", content: "hi" }])).toBe(
+      false,
+    );
+  });
+});
+
+describe("shouldHealZombieBusy", () => {
+  it("heals when Host is idle and the reply is already on screen", () => {
+    expect(
+      shouldHealZombieBusy({
+        uiSessionState: "streaming",
+        messages: doneAssistant,
+        turnStartedAt: 1,
+        nowMs: 1 + ZOMBIE_BUSY_GRACE_MS,
+        hostStateForSession: "ready",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not heal a live think→tool loop (streaming assistant)", () => {
+    expect(
+      shouldHealZombieBusy({
+        uiSessionState: "streaming",
+        messages: [
+          { role: "user", content: "hi" },
+          { role: "assistant", content: "working", streaming: true },
+        ],
+        turnStartedAt: 1,
+        nowMs: 1 + ZOMBIE_BUSY_HOST_STALE_MS,
+        hostStateForSession: "streaming",
+      }),
+    ).toBe(false);
+  });
+
+  it("heals a stale Host stream after the wall clock when the body is done", () => {
+    expect(
+      shouldHealZombieBusy({
+        uiSessionState: "streaming",
+        uiConnecting: true,
+        messages: doneAssistant,
+        turnStartedAt: 1,
+        nowMs: 1 + ZOMBIE_BUSY_HOST_STALE_MS,
+        hostStateForSession: "streaming",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not heal while send IPC is in flight", () => {
+    expect(
+      shouldHealZombieBusy({
+        uiSessionState: "streaming",
+        messages: doneAssistant,
+        turnStartedAt: 1,
+        nowMs: 1 + ZOMBIE_BUSY_HOST_STALE_MS,
+        hostStateForSession: "ready",
+        sendInFlight: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldReleaseStaleConnectingClaim", () => {
+  it("releases a leftover 连接中 when no handshake is running", () => {
+    expect(
+      shouldReleaseStaleConnectingClaim({
+        uiSessionState: "ready",
+        uiConnecting: true,
+        messages: doneAssistant,
+        turnStartedAt: null,
+        nowMs: 10,
+        hostStateForSession: "ready",
+        connectInFlightCount: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a real handshake", () => {
+    expect(
+      shouldReleaseStaleConnectingClaim({
+        uiSessionState: "ready",
+        uiConnecting: true,
+        messages: doneAssistant,
+        turnStartedAt: null,
+        nowMs: 10,
+        hostStateForSession: "connecting",
+        connectInFlightCount: 1,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/zombieBusyHeal.ts
+++ b/src/lib/zombieBusyHeal.ts
@@ -1,0 +1,88 @@
+/**
+ * Unlock a finished turn whose UI never left busy.
+ *
+ * After the last assistant body is painted and Host is idle (or Host itself
+ * went stale), the workbench can still sit on streaming + 思考中 + Stop, and a
+ * leftover ensureConnected claim paints 连接中 so the next send never leaves.
+ * Ghost heal only strips *empty* optimistic shells — this path keeps the reply.
+ */
+
+import type { SessionState } from "./session";
+import { hostLooksIdleForSession } from "./ghostStreamingHeal";
+
+/** Host already idle: wait a beat so a real ready event can land first. */
+export const ZOMBIE_BUSY_GRACE_MS = 8_000;
+
+/**
+ * Host still says streaming/connecting but the transcript is done.
+ * Matches the connect wall-clock so a late think→tool loop is not cut off.
+ */
+export const ZOMBIE_BUSY_HOST_STALE_MS = 90_000;
+
+export type ZombieBusyMessage = {
+  role: string;
+  content?: string;
+  streaming?: boolean;
+  marker?: string | null;
+};
+
+export type ZombieBusyEvidence = {
+  uiSessionState: SessionState;
+  uiConnecting?: boolean;
+  messages: readonly ZombieBusyMessage[];
+  turnStartedAt: number | null;
+  nowMs: number;
+  hostStateForSession: SessionState | null | undefined;
+  sendInFlight?: boolean;
+  /** In-flight ensureConnected count; 0 means a leftover 连接中 claim leaked. */
+  connectInFlightCount?: number;
+  graceMs?: number;
+  hostStaleMs?: number;
+};
+
+export function transcriptLooksTurnComplete(
+  messages: readonly ZombieBusyMessage[],
+): boolean {
+  if (messages.some((m) => m.streaming)) return false;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]!;
+    if (m.role === "user") return false;
+    if (m.marker === "turn_end" || m.marker === "turn_cancelled") return true;
+    if (m.role === "assistant" && (m.content ?? "").trim()) return true;
+  }
+  return false;
+}
+
+function uiLooksBusy(e: ZombieBusyEvidence): boolean {
+  return (
+    e.uiSessionState === "streaming" ||
+    e.uiSessionState === "awaiting_permission" ||
+    e.uiConnecting === true
+  );
+}
+
+/** Leftover 连接中 with no handshake actually running. */
+export function shouldReleaseStaleConnectingClaim(e: ZombieBusyEvidence): boolean {
+  if (!e.uiConnecting) return false;
+  if (e.sendInFlight) return false;
+  if ((e.connectInFlightCount ?? 0) > 0) return false;
+  return true;
+}
+
+export function shouldHealZombieBusy(e: ZombieBusyEvidence): boolean {
+  if (e.sendInFlight) return false;
+  if (!uiLooksBusy(e)) return false;
+  if (!transcriptLooksTurnComplete(e.messages)) return false;
+
+  const hostIdle = hostLooksIdleForSession(e.hostStateForSession);
+  const started = e.turnStartedAt;
+  const elapsed = started != null ? e.nowMs - started : Number.POSITIVE_INFINITY;
+
+  if (hostIdle) {
+    const grace = e.graceMs ?? ZOMBIE_BUSY_GRACE_MS;
+    return started == null || elapsed >= grace;
+  }
+
+  const stale = e.hostStaleMs ?? ZOMBIE_BUSY_HOST_STALE_MS;
+  return started != null && elapsed >= stale;
+}


### PR DESCRIPTION
## Summary
After the last assistant reply is already on screen, the workbench can stay on **思考中** (quiet thinking) and **Stop**, with the header stuck on **连接中**. The next send never leaves because `session.state` is still `streaming` and/or a leftover `ensureConnected` claim is held.

Ghost heal only strips *empty* optimistic shells, so a finished body never recovered.

This PR unlocks the composer **without deleting the reply** when:
- Host/liveMap is already idle/ready (8s grace), or
- the transcript is done but Host itself stayed streaming/connecting for 90s
- a 连接中 claim exists with no handshake actually running

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] Targeted `pnpm test` (`zombieBusyHeal`, `ghostStreamingHeal`, i18n catalog)
- [ ] Full `cargo test` (no Rust change)
- [x] User-facing strings via i18n (en + zh + zh-TW; ru override)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased updated
- [x] No secrets

## Test plan
- [ ] Send a turn, wait until the full reply is painted; if 思考中 + Stop linger, they should clear within ~8s and Send should work
- [ ] A live think→tool loop (assistant still `streaming`) must **not** be healed
- [ ] Header 连接中 with no in-flight handshake should drop so the next send is not blocked