### PR TITLE
feat(composer): type-to-focus when chat is frontmost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Added
+- **Type-to-focus composer (#704)**: With the chat in the foreground, typing while focus is not in an input focuses the composer and inserts the character. IME composition, sidebar j/k, terminals/editors, overlays, and Space-on-button are left alone.
 - **Pet eye color, white body, and celebrate spin**: Settings → Pet can pick eyes independently of the body (body palette + Auto). White stays pale in both themes. The mark spins when a focused task finishes, or from the pet menu.
 - **Pet task bubbles can be turned off (#696)**: Settings → Pet and the pet context menu can hide the session chips above the mark. The overlay shrinks when they are off.
 
 **中文 · 新增**
+- **打字自动聚焦输入框（#704）**：对话在前台、光标不在输入框时，敲键盘会聚焦 composer 并写入该字符。中文输入法、侧栏 j/k、终端/编辑器、弹层、按钮上的空格不受影响。
 - **宠物可改眼睛颜色、白色身体、完成转圈**：设置 → 宠物里眼睛和身体分开选（身体色板 + 自动）。白色在两种主题下都保持浅色。聚焦任务完成时（或右键菜单）会转圈。
 - **桌宠提示框可关（#696）**：设置 → 宠物，以及宠物右键菜单，都能关掉任务气泡；关掉后浮层会收小。
 

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -1177,6 +1177,7 @@ import { useSessionRuntime } from "@/hooks/useSessionRuntime";
 import { sessionTranscriptStore } from "@/lib/sessionTranscriptStore";
 import { useLiveMapWhen } from "@/hooks/useSessionLiveMap";
 import { useComposerController } from "@/hooks/useComposerController";
+import { useTypeToFocusComposer } from "@/hooks/useTypeToFocusComposer";
 import { useAppDialogs } from "@/hooks/useAppDialogs";
 import { useSessionHostEvents } from "@/hooks/useSessionHostEvents";
 import { useSessionSpend } from "@/hooks/useSessionSpend";
@@ -1637,6 +1638,11 @@ export function AppWorkbench() {
     composerFloatPad,
     setComposerFloatPad,
   } = useComposerController();
+  const typeToFocusLiveRef = useRef({ enabled: false, overlayOpen: false });
+  useTypeToFocusComposer({
+    getEditor: () => composerInputRef.current,
+    getLive: () => typeToFocusLiveRef.current,
+  });
 
   /**
    * Archive-by-age pro confirm (GlassModal with preview count + title samples).
@@ -17722,6 +17728,24 @@ export function AppWorkbench() {
     slashOrMenuOpen:
       composerMenuOpen || phoneToolsOpen || !!ctxMenu || showUserMenu,
     promptHistoryOpen,
+  };
+  typeToFocusLiveRef.current = {
+    enabled:
+      appGate === "ready" &&
+      appView === "workbench" &&
+      mainPane === "chat" &&
+      canType(session.state),
+    overlayOpen: Boolean(
+      escapeStopLiveRef.current.overlayOpen ||
+        escapeStopLiveRef.current.permOpen ||
+        escapeStopLiveRef.current.askUserOpen ||
+        escapeStopLiveRef.current.slashOrMenuOpen ||
+        escapeStopLiveRef.current.promptHistoryOpen ||
+        liveVoiceOpen ||
+        showJsonSchemaModal ||
+        phoneAccountOpen ||
+        sessionSelectMode,
+    ),
   };
 
   /**

--- a/src/hooks/useTypeToFocusComposer.ts
+++ b/src/hooks/useTypeToFocusComposer.ts
@@ -1,0 +1,66 @@
+/**
+ * Capture-phase type-to-focus: printable keys outside inputs land in composer.
+ */
+
+import { useEffect, useRef } from "react";
+import { querySidebarEl } from "@/lib/dragZone";
+import { isShortcutRecordingActive } from "@/lib/shortcutRemap";
+import {
+  applyTypeToFocusComposer,
+  decideTypeToFocusComposer,
+  isActivateKeyControl,
+  isComposerRedirectBlocked,
+  isSidebarSessionNavKey,
+} from "@/lib/typeToFocusComposer";
+
+export type TypeToFocusLive = {
+  enabled: boolean;
+  overlayOpen: boolean;
+};
+
+export function useTypeToFocusComposer(opts: {
+  getEditor: () => HTMLDivElement | null;
+  getLive: () => TypeToFocusLive;
+}): void {
+  const optsRef = useRef(opts);
+  optsRef.current = opts;
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const editor = optsRef.current.getEditor();
+      if (!editor || editor.getAttribute("contenteditable") === "false") {
+        return;
+      }
+      const live = optsRef.current.getLive();
+      const target = e.target as HTMLElement | null;
+      const sidebar = querySidebarEl();
+      const sidebarOwns =
+        !!sidebar && !!target && sidebar.contains(target);
+      const decision = decideTypeToFocusComposer(
+        {
+          key: e.key,
+          keyCode: e.keyCode,
+          ctrlKey: e.ctrlKey,
+          metaKey: e.metaKey,
+          altKey: e.altKey,
+          isComposing: e.isComposing,
+        },
+        {
+          enabled: live.enabled,
+          overlayOpen: live.overlayOpen,
+          recordingShortcut: isShortcutRecordingActive(),
+          blockedSurface: isComposerRedirectBlocked(target),
+          sidebarNavOwnsKey:
+            sidebarOwns && isSidebarSessionNavKey(e.key),
+          spaceActivatesControl:
+            e.key === " " && isActivateKeyControl(target),
+        },
+      );
+      if (decision.action === "ignore") return;
+      if (decision.preventDefault) e.preventDefault();
+      applyTypeToFocusComposer(editor, decision);
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, []);
+}

--- a/src/lib/typeToFocusComposer.test.ts
+++ b/src/lib/typeToFocusComposer.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideTypeToFocusComposer,
+  isActivateKeyControl,
+  isComposerRedirectBlocked,
+  isImeOrDeadKey,
+  isPasteFocusKey,
+  isPrintableTypeKey,
+  isSidebarSessionNavKey,
+  type TypeToFocusContext,
+  type TypeToFocusKey,
+} from "./typeToFocusComposer";
+
+const baseKey = (over: Partial<TypeToFocusKey> = {}): TypeToFocusKey => ({
+  key: "h",
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  isComposing: false,
+  ...over,
+});
+
+const ready: TypeToFocusContext = {
+  enabled: true,
+  overlayOpen: false,
+  recordingShortcut: false,
+  blockedSurface: false,
+  sidebarNavOwnsKey: false,
+  spaceActivatesControl: false,
+};
+
+describe("isImeOrDeadKey", () => {
+  it("detects composing, 229, Process, Unidentified, Dead", () => {
+    expect(isImeOrDeadKey(baseKey({ isComposing: true }))).toBe(true);
+    expect(isImeOrDeadKey(baseKey({ keyCode: 229 }))).toBe(true);
+    expect(isImeOrDeadKey(baseKey({ key: "Process" }))).toBe(true);
+    expect(isImeOrDeadKey(baseKey({ key: "Unidentified" }))).toBe(true);
+    expect(isImeOrDeadKey(baseKey({ key: "Dead" }))).toBe(true);
+    expect(isImeOrDeadKey(baseKey())).toBe(false);
+  });
+});
+
+describe("isPrintableTypeKey / isPasteFocusKey / isSidebarSessionNavKey", () => {
+  it("accepts unmodified single chars including space and punctuation", () => {
+    expect(isPrintableTypeKey(baseKey({ key: "a" }))).toBe(true);
+    expect(isPrintableTypeKey(baseKey({ key: "你" }))).toBe(true);
+    expect(isPrintableTypeKey(baseKey({ key: "/" }))).toBe(true);
+    expect(isPrintableTypeKey(baseKey({ key: " " }))).toBe(true);
+    expect(isPrintableTypeKey(baseKey({ key: "Enter" }))).toBe(false);
+    expect(isPrintableTypeKey(baseKey({ key: "a", ctrlKey: true }))).toBe(false);
+    expect(isPrintableTypeKey(baseKey({ key: "a", metaKey: true }))).toBe(false);
+    expect(isPrintableTypeKey(baseKey({ key: "a", altKey: true }))).toBe(false);
+  });
+
+  it("matches Cmd/Ctrl+V only", () => {
+    expect(isPasteFocusKey(baseKey({ key: "v", metaKey: true }))).toBe(true);
+    expect(isPasteFocusKey(baseKey({ key: "V", ctrlKey: true }))).toBe(true);
+    expect(isPasteFocusKey(baseKey({ key: "v", ctrlKey: true, altKey: true }))).toBe(
+      false,
+    );
+    expect(isPasteFocusKey(baseKey({ key: "c", metaKey: true }))).toBe(false);
+    expect(isPasteFocusKey(baseKey({ key: "v" }))).toBe(false);
+  });
+
+  it("matches sidebar j/k/arrows case-insensitively", () => {
+    expect(isSidebarSessionNavKey("j")).toBe(true);
+    expect(isSidebarSessionNavKey("K")).toBe(true);
+    expect(isSidebarSessionNavKey("ArrowDown")).toBe(true);
+    expect(isSidebarSessionNavKey("arrowup")).toBe(true);
+    expect(isSidebarSessionNavKey("h")).toBe(false);
+    expect(isSidebarSessionNavKey("Enter")).toBe(false);
+  });
+});
+
+describe("isActivateKeyControl / isComposerRedirectBlocked", () => {
+  it("detects buttons, links, and ARIA controls", () => {
+    expect(isActivateKeyControl(null)).toBe(false);
+    expect(
+      isActivateKeyControl({ tagName: "BUTTON" } as unknown as EventTarget),
+    ).toBe(true);
+    expect(
+      isActivateKeyControl({ tagName: "A" } as unknown as EventTarget),
+    ).toBe(true);
+    expect(
+      isActivateKeyControl({
+        tagName: "DIV",
+        getAttribute: (n: string) => (n === "role" ? "tab" : null),
+      } as unknown as EventTarget),
+    ).toBe(true);
+    expect(
+      isActivateKeyControl({
+        tagName: "DIV",
+        getAttribute: () => null,
+      } as unknown as EventTarget),
+    ).toBe(false);
+  });
+
+  it("blocks typing targets and protected closest matches", () => {
+    expect(isComposerRedirectBlocked(null)).toBe(false);
+    expect(
+      isComposerRedirectBlocked({
+        tagName: "TEXTAREA",
+        isContentEditable: false,
+      } as unknown as EventTarget),
+    ).toBe(true);
+    expect(
+      isComposerRedirectBlocked({
+        tagName: "DIV",
+        isContentEditable: false,
+        closest: (sel: string) => (sel.includes(".xterm") ? {} : null),
+      } as unknown as EventTarget),
+    ).toBe(true);
+    expect(
+      isComposerRedirectBlocked({
+        tagName: "DIV",
+        isContentEditable: false,
+        closest: () => null,
+      } as unknown as EventTarget),
+    ).toBe(false);
+  });
+});
+
+describe("decideTypeToFocusComposer", () => {
+  it("ignores when disabled, overlay, recording, blocked, or sidebar nav", () => {
+    expect(
+      decideTypeToFocusComposer(baseKey(), { ...ready, enabled: false }),
+    ).toEqual({ action: "ignore" });
+    expect(
+      decideTypeToFocusComposer(baseKey(), { ...ready, overlayOpen: true }),
+    ).toEqual({ action: "ignore" });
+    expect(
+      decideTypeToFocusComposer(baseKey(), {
+        ...ready,
+        recordingShortcut: true,
+      }),
+    ).toEqual({ action: "ignore" });
+    expect(
+      decideTypeToFocusComposer(baseKey(), { ...ready, blockedSurface: true }),
+    ).toEqual({ action: "ignore" });
+    expect(
+      decideTypeToFocusComposer(baseKey({ key: "j" }), {
+        ...ready,
+        sidebarNavOwnsKey: true,
+      }),
+    ).toEqual({ action: "ignore" });
+  });
+
+  it("focuses only for IME / dead keys (no preventDefault, no insert)", () => {
+    expect(
+      decideTypeToFocusComposer(baseKey({ keyCode: 229, key: "Process" }), ready),
+    ).toEqual({ action: "focus", preventDefault: false });
+    expect(
+      decideTypeToFocusComposer(baseKey({ isComposing: true }), ready),
+    ).toEqual({ action: "focus", preventDefault: false });
+  });
+
+  it("focuses for paste without preventDefault", () => {
+    expect(
+      decideTypeToFocusComposer(baseKey({ key: "v", metaKey: true }), ready),
+    ).toEqual({ action: "focus", preventDefault: false });
+  });
+
+  it("inserts printable keys and prevents default only for space", () => {
+    expect(decideTypeToFocusComposer(baseKey({ key: "h" }), ready)).toEqual({
+      action: "focus-and-insert",
+      text: "h",
+      preventDefault: false,
+    });
+    expect(decideTypeToFocusComposer(baseKey({ key: "/" }), ready)).toEqual({
+      action: "focus-and-insert",
+      text: "/",
+      preventDefault: false,
+    });
+    expect(decideTypeToFocusComposer(baseKey({ key: " " }), ready)).toEqual({
+      action: "focus-and-insert",
+      text: " ",
+      preventDefault: true,
+    });
+  });
+
+  it("leaves Space on a focused button alone", () => {
+    expect(
+      decideTypeToFocusComposer(baseKey({ key: " " }), {
+        ...ready,
+        spaceActivatesControl: true,
+      }),
+    ).toEqual({ action: "ignore" });
+  });
+
+  it("does not steal Enter, Tab, Escape, or Backspace", () => {
+    for (const key of ["Enter", "Tab", "Escape", "Backspace", "ArrowDown"]) {
+      expect(decideTypeToFocusComposer(baseKey({ key }), ready)).toEqual({
+        action: "ignore",
+      });
+    }
+  });
+
+  it("still inserts letters while a button is focused", () => {
+    expect(
+      decideTypeToFocusComposer(baseKey({ key: "a" }), {
+        ...ready,
+        spaceActivatesControl: true,
+      }),
+    ).toEqual({
+      action: "focus-and-insert",
+      text: "a",
+      preventDefault: false,
+    });
+  });
+});

--- a/src/lib/typeToFocusComposer.ts
+++ b/src/lib/typeToFocusComposer.ts
@@ -1,0 +1,205 @@
+/**
+ * Type-to-focus composer: when the chat is frontmost but focus is not in
+ * an input, a printable key focuses the composer and the character lands.
+ *
+ * Decision is pure (no DOM). The hook applies focus / insert.
+ */
+
+import { isTypingTarget } from "@/lib/a11yFocus";
+
+/** Surfaces that must keep their own keyboard (terminal, code, rich text). */
+export const TYPE_TO_FOCUS_PROTECTED_SEL = [
+  ".xterm",
+  ".xterm-helper-textarea",
+  ".sw-terminal",
+  ".bt",
+  ".cm-editor",
+  ".cm-content",
+  ".ProseMirror",
+  "[data-testid='side-terminal-xterm']",
+  "[data-testid='bottom-terminal']",
+].join(", ");
+
+export type TypeToFocusKey = {
+  key: string;
+  /** Legacy IME signal (Windows / some WebKit). */
+  keyCode?: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  isComposing: boolean;
+};
+
+export type TypeToFocusContext = {
+  /** Chat workbench is showing a typeable composer. */
+  enabled: boolean;
+  /** Dialog / palette / menu / permission / voice owns the keyboard. */
+  overlayOpen: boolean;
+  /** Settings is capturing a new shortcut chord. */
+  recordingShortcut: boolean;
+  /** Target is an input / terminal / editor. */
+  blockedSurface: boolean;
+  /** Sidebar list has focus and this key is j/k/arrows. */
+  sidebarNavOwnsKey: boolean;
+  /** Space/Enter would activate the focused button/link. */
+  spaceActivatesControl: boolean;
+};
+
+export type TypeToFocusDecision =
+  | { action: "ignore" }
+  | { action: "focus"; preventDefault: boolean }
+  | { action: "focus-and-insert"; text: string; preventDefault: boolean };
+
+/** IME / dead-key: focus only, never insert the latin letter ourselves. */
+export function isImeOrDeadKey(e: TypeToFocusKey): boolean {
+  if (e.isComposing) return true;
+  if (e.keyCode === 229) return true;
+  const k = e.key;
+  return k === "Process" || k === "Unidentified" || k === "Dead";
+}
+
+/** Unmodified single Unicode key (letters, digits, punctuation, space). */
+export function isPrintableTypeKey(e: TypeToFocusKey): boolean {
+  if (e.key.length !== 1) return false;
+  if (e.ctrlKey || e.metaKey || e.altKey) return false;
+  return true;
+}
+
+/** Cmd/Ctrl+V — focus composer so paste can land there. */
+export function isPasteFocusKey(e: TypeToFocusKey): boolean {
+  if (e.altKey) return false;
+  if (!(e.ctrlKey || e.metaKey)) return false;
+  return e.key.toLowerCase() === "v";
+}
+
+/** Sidebar session nav (same keys as AppWorkbench j/k handler). */
+export function isSidebarSessionNavKey(key: string): boolean {
+  const k = key.length === 1 ? key.toLowerCase() : key.toLowerCase();
+  return k === "j" || k === "k" || k === "arrowdown" || k === "arrowup";
+}
+
+/** Space/Enter should fire the focused control, not type into the composer. */
+export function isActivateKeyControl(
+  el: EventTarget | null | undefined,
+): boolean {
+  if (!el || typeof (el as HTMLElement).tagName !== "string") return false;
+  const node = el as HTMLElement;
+  const tag = node.tagName.toLowerCase();
+  if (tag === "button" || tag === "a" || tag === "summary") return true;
+  const role =
+    typeof node.getAttribute === "function" ? node.getAttribute("role") : null;
+  return (
+    role === "button" ||
+    role === "menuitem" ||
+    role === "tab" ||
+    role === "switch" ||
+    role === "checkbox" ||
+    role === "radio" ||
+    role === "option" ||
+    role === "link"
+  );
+}
+
+/**
+ * True when typing must stay on the current surface (inputs, xterm, CM).
+ * Composer itself is a contenteditable — this is also true when it is focused.
+ */
+export function isComposerRedirectBlocked(
+  el: EventTarget | null | undefined,
+): boolean {
+  if (isTypingTarget(el)) return true;
+  if (!el || typeof (el as HTMLElement).closest !== "function") return false;
+  try {
+    return !!(el as HTMLElement).closest(TYPE_TO_FOCUS_PROTECTED_SEL);
+  } catch {
+    return false;
+  }
+}
+
+export function decideTypeToFocusComposer(
+  e: TypeToFocusKey,
+  ctx: TypeToFocusContext,
+): TypeToFocusDecision {
+  if (!ctx.enabled) return { action: "ignore" };
+  if (ctx.overlayOpen) return { action: "ignore" };
+  if (ctx.recordingShortcut) return { action: "ignore" };
+  if (ctx.blockedSurface) return { action: "ignore" };
+  if (ctx.sidebarNavOwnsKey) return { action: "ignore" };
+
+  if (isImeOrDeadKey(e)) {
+    return { action: "focus", preventDefault: false };
+  }
+
+  if (isPasteFocusKey(e)) {
+    return { action: "focus", preventDefault: false };
+  }
+
+  if (!isPrintableTypeKey(e)) return { action: "ignore" };
+
+  if (e.key === " " && ctx.spaceActivatesControl) {
+    return { action: "ignore" };
+  }
+
+  // Space scrolls the page if we let the default through on body.
+  const preventDefault = e.key === " ";
+  return { action: "focus-and-insert", text: e.key, preventDefault };
+}
+
+export function focusComposerForTyping(el: HTMLElement): void {
+  el.focus({ preventScroll: true });
+  const sel = window.getSelection();
+  if (!sel) return;
+  if (sel.anchorNode && el.contains(sel.anchorNode)) return;
+  try {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Insert only if the engine did not already type into the newly focused editor. */
+export function scheduleInsertIfNeeded(el: HTMLElement, text: string): void {
+  if (typeof document === "undefined") return;
+  let canceled = false;
+  const onComp = () => {
+    canceled = true;
+  };
+  const onInput = () => {
+    canceled = true;
+  };
+  document.addEventListener("compositionstart", onComp, true);
+  el.addEventListener("input", onInput);
+  queueMicrotask(() => {
+    document.removeEventListener("compositionstart", onComp, true);
+    el.removeEventListener("input", onInput);
+    if (canceled || !el.isConnected) return;
+    insertTextIntoFocusedComposer(el, text);
+  });
+}
+
+export function insertTextIntoFocusedComposer(
+  el: HTMLElement,
+  text: string,
+): void {
+  if (!text) return;
+  focusComposerForTyping(el);
+  try {
+    document.execCommand("insertText", false, text);
+  } catch {
+    /* contenteditable engines that reject execCommand */
+  }
+}
+
+export function applyTypeToFocusComposer(
+  el: HTMLElement,
+  decision: Exclude<TypeToFocusDecision, { action: "ignore" }>,
+): void {
+  focusComposerForTyping(el);
+  if (decision.action === "focus-and-insert") {
+    scheduleInsertIfNeeded(el, decision.text);
+  }
+}


### PR DESCRIPTION
## Summary
When the chat is frontmost but focus is not in the composer, typing now focuses the input and inserts the character (Slack/Telegram-style).

Fixes #704

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Behavior
- Unmodified printable keys → focus composer + insert
- IME / dead keys (`keyCode === 229`, `Process`, composing) → focus only (CJK pinyin still starts)
- `Cmd/Ctrl+V` → focus so paste can land in the composer
- Does **not** steal from inputs, xterm / bottom terminal, CodeMirror / TipTap
- Does **not** steal sidebar `j`/`k`/arrows
- Does **not** steal Space on a focused button/link
- Off on settings, dialogs, palettes, menus, permission/ask-user, live voice, shortcut recording

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (unit: `typeToFocusComposer` + `a11yFocus`)
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only) — no Rust changes
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new strings
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — CHANGELOG Unreleased only
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

## Community
No prior Issue/PR/Discussion on this (Discussions disabled). Nearby but different: #654 / #658 (notification focus), #277 (sidebar j/k), #328 (shortcut scopes).