### PR TITLE
feat(sidebar): rename chats on double-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ See `docs/llm-wiki/release.md`.
 
 ### Added
 - **Type-to-focus composer (#704)**: With the chat in the foreground, typing while focus is not in an input focuses the composer and inserts the character. IME composition, sidebar j/k, terminals/editors, overlays, and Space-on-button are left alone.
+- **Double-click a sidebar chat to rename (#702)**: Project and Other-session rows edit the title in place. Enter / blur save when the name changed; Escape cancels. F2 on a focused row does the same. Right-click Rename still uses the existing prompt. Multi-select does not start rename.
 - **Pet eye color, white body, and celebrate spin**: Settings → Pet can pick eyes independently of the body (body palette + Auto). White stays pale in both themes. The mark spins when a focused task finishes, or from the pet menu.
 - **Pet task bubbles can be turned off (#696)**: Settings → Pet and the pet context menu can hide the session chips above the mark. The overlay shrinks when they are off.
 
 **中文 · 新增**
 - **打字自动聚焦输入框（#704）**：对话在前台、光标不在输入框时，敲键盘会聚焦 composer 并写入该字符。中文输入法、侧栏 j/k、终端/编辑器、弹层、按钮上的空格不受影响。
+- **双击侧栏对话可重命名（#702）**：项目里和其他会话的行内直接改标题。Enter / 失焦在标题有改动时保存，Esc 取消。聚焦行按 F2 同样进入。右键「重命名」仍走原来的弹窗。多选模式不会进入重命名。
 - **宠物可改眼睛颜色、白色身体、完成转圈**：设置 → 宠物里眼睛和身体分开选（身体色板 + 自动）。白色在两种主题下都保持浅色。聚焦任务完成时（或右键菜单）会转圈。
 - **桌宠提示框可关（#696）**：设置 → 宠物，以及宠物右键菜单，都能关掉任务气泡；关掉后浮层会收小。
 

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -776,6 +776,7 @@ import {
   type SidebarDensity
 } from "@/lib/sidebarDensity";
 import { sortSessionsForSidebar } from "@/lib/sidebarDateGroups";
+import { nextSessionTitle } from "@/lib/sidebarSessionRename";
 import { GrokLogo } from "@/components/GrokLogo";
 import { SidebarBrand } from "@/components/SidebarBrand";
 import { SidebarUpdateButton } from "@/components/SidebarUpdateButton";
@@ -6648,23 +6649,28 @@ export function AppWorkbench() {
     });
   };
 
+  const persistSessionTitle = async (s: SessionRow, next: string) => {
+    try {
+      await api.sessionRename(s.id, next);
+      applySessionTitle(s.id, next);
+      await refreshSessions();
+    } catch (e) {
+      setLocalError(String(e));
+    }
+  };
+
   const renameSession = (s: SessionRow) => {
     setCtxMenu(null);
+    const shown = s.title || tr("session.untitled");
     setAppDialog({
       kind: "prompt",
       title: tr("session.renamePrompt"),
-      initial: s.title || tr("session.untitled"),
+      initial: shown,
       placeholder: tr("session.renamePlaceholder"),
       onSubmit: async (title) => {
-        const next = title.trim();
+        const next = nextSessionTitle(title, shown);
         if (!next) return;
-        try {
-          await api.sessionRename(s.id, next);
-          applySessionTitle(s.id, next);
-          await refreshSessions();
-        } catch (e) {
-          setLocalError(String(e));
-        }
+        await persistSessionTitle(s, next);
       },
     });
   };
@@ -7335,6 +7341,8 @@ export function AppWorkbench() {
   archiveSessionRef.current = archiveSession;
   const openSessionMenuRef = useRef(openSessionMenu);
   openSessionMenuRef.current = openSessionMenu;
+  const persistSessionTitleRef = useRef(persistSessionTitle);
+  persistSessionTitleRef.current = persistSessionTitle;
 
   const resolveSidebarSession = useCallback(
     (partial: { id: string }): SessionRow =>
@@ -7380,6 +7388,13 @@ export function AppWorkbench() {
     [resolveSidebarSession],
   );
 
+  const onSidebarSessionRename = useCallback(
+    (s: { id: string }, title: string) => {
+      void persistSessionTitleRef.current(resolveSidebarSession(s), title);
+    },
+    [resolveSidebarSession],
+  );
+
   const sidebarSessionLabels = useMemo<SidebarSessionRowLabels>(
     () => ({
       unreadAria: tr("session.unreadAria"),
@@ -7394,6 +7409,9 @@ export function AppWorkbench() {
       archive: tr("sidebar.archive"),
       unarchive: tr("sidebar.unarchive"),
       menu: tr("sidebar.menu"),
+      untitled: tr("session.untitled"),
+      renameLabel: tr("session.renamePrompt"),
+      renamePlaceholder: tr("session.renamePlaceholder"),
     }),
     [tr],
   );
@@ -19444,6 +19462,7 @@ export function AppWorkbench() {
                                         onPin={onSidebarSessionPin}
                                         onArchive={onSidebarSessionArchive}
                                         onMenu={onSidebarSessionMenu}
+                                        onRename={onSidebarSessionRename}
                                       />
                                     );
                                   }}
@@ -19593,6 +19612,7 @@ export function AppWorkbench() {
                               onPin={onSidebarSessionPin}
                               onArchive={onSidebarSessionArchive}
                               onMenu={onSidebarSessionMenu}
+                              onRename={onSidebarSessionRename}
                             />
                           );
                         }}

--- a/src/components/SidebarSessionRow.test.tsx
+++ b/src/components/SidebarSessionRow.test.tsx
@@ -20,6 +20,9 @@ const labels: SidebarSessionRowLabels = {
   archive: "Archive",
   unarchive: "Unarchive",
   menu: "Menu",
+  untitled: "Untitled",
+  renameLabel: "Rename chat",
+  renamePlaceholder: "Chat title",
 };
 
 describe("SidebarSessionRow", () => {
@@ -50,6 +53,7 @@ describe("SidebarSessionRow", () => {
         onPin: vi.fn(),
         onArchive: vi.fn(),
         onMenu: vi.fn(),
+        onRename: vi.fn(),
       }),
     );
     expect(html).toContain("tree-l3");
@@ -81,6 +85,7 @@ describe("SidebarSessionRow", () => {
         onPin: vi.fn(),
         onArchive: vi.fn(),
         onMenu: vi.fn(),
+        onRename: vi.fn(),
       }),
     );
     expect(html).toContain("tree-l3--orphan");
@@ -110,6 +115,7 @@ describe("SidebarSessionRow", () => {
         onPin: vi.fn(),
         onArchive: vi.fn(),
         onMenu: vi.fn(),
+        onRename: vi.fn(),
       }),
     );
     expect(html).toContain("tree-l3--plan-pending");
@@ -117,6 +123,36 @@ describe("SidebarSessionRow", () => {
     expect(html).toContain("Plan awaiting review");
     // Actions stay available (not replaced by spinner) when not working.
     expect(html).toContain("tree-l3__actions");
+  });
+
+  it("uses untitled fallback and does not render a rename field at rest", () => {
+    const html = renderToString(
+      React.createElement(SidebarSessionRow, {
+        session: { id: "s4", title: "" },
+        variant: "project",
+        active: false,
+        working: false,
+        unread: false,
+        checked: false,
+        selectMode: false,
+        muted: false,
+        noteTitle: null,
+        worktreeBadge: null,
+        labels,
+        locale: "en",
+        showRelativeTime: false,
+        onOpen: vi.fn(),
+        onContextMenu: vi.fn(),
+        onToggleSelect: vi.fn(),
+        onPin: vi.fn(),
+        onArchive: vi.fn(),
+        onMenu: vi.fn(),
+        onRename: vi.fn(),
+      }),
+    );
+    expect(html).toContain("Untitled");
+    expect(html).not.toContain("sidebar-session-rename");
+    expect(html).not.toContain("tree-l3--renaming");
   });
 });
 

--- a/src/components/SidebarSessionRow.tsx
+++ b/src/components/SidebarSessionRow.tsx
@@ -3,7 +3,15 @@
  * Keeps row UI out of App so stream re-renders skip unchanged rows.
  */
 
-import { memo, type KeyboardEvent, type MouseEvent } from "react";
+import {
+  memo,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import { nextSessionTitle } from "@/lib/sidebarSessionRename";
 import type { Locale } from "@/i18n";
 import {
   IconArchive,
@@ -55,6 +63,9 @@ export type SidebarSessionRowLabels = {
   archive: string;
   unarchive: string;
   menu: string;
+  untitled: string;
+  renameLabel: string;
+  renamePlaceholder: string;
 };
 
 export type SidebarSessionRowProps = {
@@ -91,6 +102,8 @@ export type SidebarSessionRowProps = {
   onPin: (session: SidebarSessionRowSession) => void;
   onArchive: (session: SidebarSessionRowSession) => void;
   onMenu: (e: MouseEvent, session: SidebarSessionRowSession) => void;
+  /** Persist a committed in-row title (already trimmed, non-empty, changed). */
+  onRename: (session: SidebarSessionRowSession, title: string) => void;
 };
 
 function SidebarSessionRowInner({
@@ -114,7 +127,14 @@ function SidebarSessionRowInner({
   onPin,
   onArchive,
   onMenu,
+  onRename,
 }: SidebarSessionRowProps) {
+  const displayTitle = session.title || labels.untitled;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const editingRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const className =
     (variant === "orphan" ? "tree-l3 tree-l3--orphan" : "tree-l3") +
     (active ? " tree-l3--active" : "") +
@@ -123,9 +143,48 @@ function SidebarSessionRowInner({
     (unread ? " tree-l3--unread" : "") +
     (planPending ? " tree-l3--plan-pending" : "") +
     (selectMode ? " tree-l3--select-mode" : "") +
-    (checked ? " tree-l3--checked" : "");
+    (checked ? " tree-l3--checked" : "") +
+    (editing ? " tree-l3--renaming" : "");
 
+  const closeRename = (commit: boolean) => {
+    if (!editingRef.current) return;
+    editingRef.current = false;
+    setEditing(false);
+    if (!commit) return;
+    const next = nextSessionTitle(draft, displayTitle);
+    if (!next) return;
+    onRename(session, next);
+  };
+
+  const beginRename = () => {
+    if (selectMode || editingRef.current) return;
+    editingRef.current = true;
+    setDraft(displayTitle);
+    setEditing(true);
+  };
+
+  useLayoutEffect(() => {
+    if (!selectMode || !editingRef.current) return;
+    editingRef.current = false;
+    setEditing(false);
+  }, [selectMode]);
+
+  useLayoutEffect(() => {
+    if (!editing) return;
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
+  }, [editing]);
+
+  /**
+   * Double-click starts in-row rename. The first click of the pair still
+   * opens the chat — delaying onOpen would make single-click feel laggy.
+   * `detail > 1` skips the extra click so open is not invoked twice.
+   */
   const handleClick = (e: MouseEvent) => {
+    if (editingRef.current) return;
+    if (e.detail > 1) return;
     if (selectMode) {
       onToggleSelect(session.id, { shiftKey: e.shiftKey });
       return;
@@ -133,7 +192,20 @@ function SidebarSessionRowInner({
     onOpen(session);
   };
 
+  const handleDoubleClick = (e: MouseEvent) => {
+    if (selectMode) return;
+    e.preventDefault();
+    e.stopPropagation();
+    beginRename();
+  };
+
   const handleKeyDown = (e: KeyboardEvent) => {
+    if (editingRef.current) return;
+    if (e.key === "F2" && !selectMode) {
+      e.preventDefault();
+      beginRename();
+      return;
+    }
     if (e.key === "Enter" || e.key === " ") {
       if (selectMode) {
         e.preventDefault();
@@ -156,6 +228,7 @@ function SidebarSessionRowInner({
       type="button"
       className="tree-icon-btn"
       onClick={(e) => onMenu(e, session)}
+      onDoubleClick={(e) => e.stopPropagation()}
     >
       <IconMore size={13} />
     </button>
@@ -169,6 +242,7 @@ function SidebarSessionRowInner({
       tabIndex={0}
       aria-checked={selectMode ? checked : undefined}
       onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onContextMenu={(e) => onContextMenu(e, session)}
       onKeyDown={handleKeyDown}
     >
@@ -250,7 +324,37 @@ function SidebarSessionRowInner({
             {worktreeBadge.label}
           </span>
         ) : null}
-        <SidebarSessionName title={session.title || "Untitled"} />
+        {editing ? (
+          <input
+            ref={inputRef}
+            className="tree-l3__rename"
+            value={draft}
+            aria-label={labels.renameLabel}
+            placeholder={labels.renamePlaceholder}
+            spellCheck={false}
+            autoComplete="off"
+            data-no-session-move=""
+            data-testid="sidebar-session-rename"
+            onChange={(e) => setDraft(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.nativeEvent.isComposing || e.key === "Process") return;
+              if (e.key === "Enter") {
+                e.preventDefault();
+                closeRename(true);
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                closeRename(false);
+              }
+            }}
+            onBlur={() => closeRename(true)}
+          />
+        ) : (
+          <SidebarSessionName title={displayTitle} />
+        )}
       </span>
       <SidebarSessionRelativeTime
         updatedAt={session.updatedAt}
@@ -273,6 +377,7 @@ function SidebarSessionRowInner({
                 e.stopPropagation();
                 onPin(session);
               }}
+              onDoubleClick={(e) => e.stopPropagation()}
             >
               {session.pinned ? (
                 <IconPinOff size={13} />
@@ -289,6 +394,7 @@ function SidebarSessionRowInner({
                 e.stopPropagation();
                 onArchive(session);
               }}
+              onDoubleClick={(e) => e.stopPropagation()}
             >
               <IconArchive size={13} />
             </button>
@@ -348,6 +454,7 @@ function sidebarSessionRowPropsEqual(
     prev.onPin === next.onPin &&
     prev.onArchive === next.onArchive &&
     prev.onMenu === next.onMenu &&
+    prev.onRename === next.onRename &&
     worktreeBadgeEqual(prev.worktreeBadge, next.worktreeBadge)
   );
 }

--- a/src/lib/sidebarSessionRename.test.ts
+++ b/src/lib/sidebarSessionRename.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { nextSessionTitle } from "@/lib/sidebarSessionRename";
+
+describe("nextSessionTitle", () => {
+  it("returns the trimmed draft when it changed", () => {
+    expect(nextSessionTitle("  Hello  ", "Untitled")).toBe("Hello");
+  });
+
+  it("returns null for empty or whitespace", () => {
+    expect(nextSessionTitle("", "Chat")).toBeNull();
+    expect(nextSessionTitle("   ", "Chat")).toBeNull();
+  });
+
+  it("returns null when unchanged after trim", () => {
+    expect(nextSessionTitle("Chat", "Chat")).toBeNull();
+    expect(nextSessionTitle("  Chat  ", "Chat")).toBeNull();
+    expect(nextSessionTitle("Untitled", "Untitled")).toBeNull();
+  });
+});

--- a/src/lib/sidebarSessionRename.ts
+++ b/src/lib/sidebarSessionRename.ts
@@ -1,0 +1,13 @@
+/**
+ * Sidebar chat title commit. Empty or unchanged drafts are ignored.
+ * `current` is the on-screen title (untitled fallback when the row has none).
+ */
+export function nextSessionTitle(
+  draft: string,
+  current: string,
+): string | null {
+  const next = draft.trim();
+  if (!next) return null;
+  if (next === current.trim()) return null;
+  return next;
+}

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -420,6 +420,43 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   flex-shrink: 0;
 }
 
+.tree-l3__rename {
+  flex: 1 1 0;
+  min-width: 0;
+  width: 100%;
+  height: 22px;
+  margin: 0;
+  padding: 0 6px;
+  border: 1px solid var(--border-subtle, var(--glass-border));
+  border-radius: 4px;
+  background: var(--bg-app, var(--bg-elevated));
+  color: var(--text-primary);
+  font: inherit;
+  font-size: inherit;
+  line-height: 20px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.tree-l3__rename:focus,
+.tree-l3__rename:focus-visible {
+  border-color: var(--accent, var(--text-primary));
+  outline: none;
+  box-shadow: none;
+}
+
+.tree-l3--renaming {
+  opacity: 1;
+  cursor: default;
+}
+
+.tree-l3--renaming .tree-l3__actions,
+.tree-l3--renaming .tree-l3__time,
+.tree-l3--renaming .tree-l3__status {
+  display: none;
+}
+
 /*
  * One-way seamless marquee: only forward (left).
  * Hold at start → scroll through full loop (title + gap) → seamless restart.

--- a/src/styles/sidebar.part3.css
+++ b/src/styles/sidebar.part3.css
@@ -804,6 +804,12 @@ html[data-sidebar-density="compact"] .tree-l3__title {
   gap: 4px;
 }
 
+html[data-sidebar-density="compact"] .tree-l3__rename {
+  height: 18px;
+  padding: 0 4px;
+  line-height: 16px;
+}
+
 html[data-sidebar-density="compact"] .tree-l3--hint {
   height: 22px;
   min-height: 22px;


### PR DESCRIPTION
## Summary
Sidebar chats could only be renamed from the context-menu prompt. Double-click (and F2 on a focused row) now edits the title **in place** on project and Other-session rows.

- Enter / blur save when the title actually changed; Escape cancels; empty drafts are ignored.
- Multi-select does not start rename. Pin / archive / menu double-clicks do not start it either.
- Context-menu **Rename** still uses the existing in-app prompt.
- Reuses `session_rename`; no new Host API. Strings reuse `session.rename*` / `session.untitled`.

Closes #702

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and targeted `pnpm test` (`sidebarSessionRename`, `SidebarSessionRow`)
- [x] Full `pnpm test` had 2 unrelated local Windows failures (`sessionExportImage` timeout, `window-config` macOS dock); no Rust change
- [x] User-facing strings go through `src/i18n/messages` (en + zh); no new keys
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed (CHANGELOG Unreleased only)
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

## Test plan
- [ ] Double-click a project chat: inline input, change title, Enter — sidebar + header update
- [ ] Double-click, leave unchanged, blur — no API rename
- [ ] Escape restores the old title
- [ ] Other sessions row behaves the same
- [ ] Multi-select: double-click does not rename
- [ ] Right-click → Rename still opens the prompt
- [ ] F2 on a focused row starts the same inline edit