### PR TITLE
fix(session): time out connect_lock so Connecting cannot hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - **桌宠提示框可关（#696）**：设置 → 宠物，以及宠物右键菜单，都能关掉任务气泡；关掉后浮层会收小。
 
 ### Fixed
+- **New-chat Connecting no longer hangs when `connect_lock` is held (#709)**: The 90s wall clock now covers lock wait (sibling task, so a blocking ACP poll cannot starve the timer). A timed-out attempt is invalidated so it cannot start a handshake after the lock frees. Idle recycle kill / send / disconnect wait for the lock with a timeout. Connect enqueue + timeout also sync-append to `app.log` if the tracing worker is silent. The client drops `sessionConnect` after 100s so the pill cannot sit on Connecting forever.
 - **Finished turns no longer stay on 思考中 / 连接中**: After the last assistant body is painted, leftover streaming or a leaked connect claim kept Stop and blocked the next send. Client heal unlocks the composer (reply stays) when Host is idle, or after 90s if Host itself went stale.
 - **Late tool-turn answers paint without remount (#697 / #698)**: Stream text that arrives after a tool-only (or thinking-only) bubble can now fill that bubble in place. A ready→ready skip no longer hides the final answer.
 - **Permission bars and journal flush after live lock**: A remounted WebView can recover the full approval card instead of looking stuck thinking. The stream journal flushes after the live lock is released.
@@ -27,6 +28,7 @@ See `docs/llm-wiki/release.md`.
 - **Windows pet overlay no longer inherits File / Edit / Window / Help; toggle follows real window visibility; hit target shrinks after drag (#696)**: The overlay keeps a window-local empty menu and strips the native bar. Hide retries if the HWND stays painted; File → Close hides instead of destroying. Host clears drag when the left button is up, and measured hit radius is clamped to the mark size.
 
 **中文 · 修复**
+- **`connect_lock` 被占住时新对话不再一直 Connecting（#709）**：90 秒墙钟覆盖等锁；握手在旁路任务里跑，ACP 阻塞也挡不住超时。超时后作废这次 connect。recycle 杀进程、发送、断开等锁都有上限。tracing 日志挂了时 connect 关键行仍会写入 `app.log`。前端 100 秒丢掉卡住的 `sessionConnect`。
 - **回合结束后不再一直「思考中 / 连接中」**：正文已经出来，UI 还停在停止键、发不了下一句。Host 已空闲（或卡住超过 90 秒）时自动解锁，回复保留。
 - **工具回合的晚到正文不再要重挂才出现（#697 / #698）**：只有工具（或只有思考）的气泡，后到的流式文字会填进同一条。ready→ready 跳过状态时也不再把最终答案藏掉。
 - **权限条和日记在解开 live lock 后会补上**：WebView 重挂后能恢复完整审批卡，不再看起来卡在思考。流式日记在释放锁之后再刷盘。

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -68,6 +68,26 @@ pub fn logs_dir() -> PathBuf {
     crate::paths::app_data_root().join("logs")
 }
 
+/// Append one line to today's rolling file and flush. Survives a wedged
+/// `tracing-appender` worker (lossy non-blocking sink can go silent while
+/// Host is still serving commands).
+pub fn sync_diag(message: &str) {
+    let log_dir = logs_dir();
+    let _ = std::fs::create_dir_all(&log_dir);
+    let day = chrono::Local::now().format("%Y-%m-%d");
+    let path = log_dir.join(format!("app.log.{day}"));
+    let ts = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+    let line = format!("{ts}  WARN grok_app::logging: {message}\n");
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        let _ = f.write_all(line.as_bytes());
+        let _ = f.flush();
+    }
+}
+
 /// Install a panic hook that **sync-writes** to `logs/panic.log` and today's
 /// `app.log.YYYY-MM-DD` before chaining to the previous hook.
 ///

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -26,23 +26,73 @@ impl SessionManager {
         app_session_id: Option<String>,
         mock_mode: Option<String>,
     ) -> Result<SessionSnapshot, String> {
-        let _connect_guard = self.connect_lock.lock().await;
-        match tokio::time::timeout(
-            Duration::from_secs(CONNECT_WALL_CLOCK_SECS),
-            self.connect_inner(app.clone(), project_path, app_session_id.clone(), mock_mode),
-        )
+        // Enqueue is logged before `connect_lock` so a stuck holder still
+        // leaves a trail. The 90s timer runs on this task; handshake + lock
+        // wait run on a sibling so a blocking ACP poll cannot starve it.
+        tracing::info!(
+            target: "session",
+            session = ?app_session_id,
+            "connect enqueue"
+        );
+        crate::logging::sync_diag(&format!("connect enqueue session={:?}", app_session_id));
+
+        let my_gen = self
+            .connect_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            .wrapping_add(1);
+
+        let mgr = Arc::clone(self);
+        let app_task = app.clone();
+        let sid = app_session_id.clone();
+        let join = tauri::async_runtime::spawn(async move {
+            let _connect_guard = mgr.connect_lock.lock().await;
+            if !connect_attempt_still_current(
+                mgr.connect_epoch.load(std::sync::atomic::Ordering::SeqCst),
+                my_gen,
+            ) {
+                return Err(format!(
+                    "{}: {}",
+                    crate::error::AgentErrorCode::ConnectFailed.as_str(),
+                    connect_gave_up_reason(false)
+                ));
+            }
+            mgr.connect_inner(app_task, project_path, sid, mock_mode)
+                .await
+        });
+
+        match tokio::time::timeout(Duration::from_secs(CONNECT_WALL_CLOCK_SECS), async {
+            join.await
+        })
         .await
         {
-            Ok(r) => r,
+            Ok(Ok(inner)) => inner,
+            Ok(Err(join_err)) => {
+                tracing::error!(error = %join_err, "connect task failed");
+                Err(format!("connect task failed: {join_err}"))
+            }
             Err(_) => {
+                let current = self.connect_epoch.load(std::sync::atomic::Ordering::SeqCst);
+                let next = next_connect_epoch_on_timeout(current, my_gen);
+                if next != current {
+                    self.connect_epoch
+                        .store(next, std::sync::atomic::Ordering::SeqCst);
+                }
                 tracing::warn!(
                     target: "session",
                     session = ?app_session_id,
                     secs = CONNECT_WALL_CLOCK_SECS,
                     "connect wall-clock timeout"
                 );
+                crate::logging::sync_diag(&format!(
+                    "connect wall-clock timeout session={:?} secs={}",
+                    app_session_id, CONNECT_WALL_CLOCK_SECS
+                ));
                 Ok(self
-                    .fail_stale_connecting(&app, app_session_id.as_deref(), "connect timed out")
+                    .fail_stale_connecting(
+                        &app,
+                        app_session_id.as_deref(),
+                        connect_gave_up_reason(true),
+                    )
                     .await)
             }
         }
@@ -1583,6 +1633,24 @@ mod connect_preserve_tests {
         assert!(!stop_should_abort_handshake(SessionState::Streaming));
         assert!(CONNECT_WALL_CLOCK_SECS >= 60);
         assert!(CONNECT_WALL_CLOCK_SECS <= 90);
+    }
+
+    #[test]
+    fn wall_clock_covers_lock_wait_and_handshake() {
+        assert_eq!(connect_gave_up_reason(false), "connect lock busy");
+        assert_eq!(connect_gave_up_reason(true), "connect timed out");
+        assert!(CONNECT_LOCK_WATCHDOG_SECS < CONNECT_WALL_CLOCK_SECS);
+        assert!(ACP_KILL_TIMEOUT_SECS <= CONNECT_LOCK_WATCHDOG_SECS);
+    }
+
+    #[test]
+    fn timed_out_connect_invalidates_only_its_own_generation() {
+        assert!(connect_attempt_still_current(7, 7));
+        assert!(!connect_attempt_still_current(8, 7));
+        // Latest attempt timed out → bump so a waiter cannot start handshake.
+        assert_eq!(next_connect_epoch_on_timeout(7, 7), 8);
+        // A newer connect already owns the epoch → leave it.
+        assert_eq!(next_connect_epoch_on_timeout(9, 7), 9);
     }
 
     #[test]

--- a/src-tauri/src/session_manager/control.rs
+++ b/src-tauri/src/session_manager/control.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)] // residual-clippy: set_permission_policy / tracked counts
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use tauri::{AppHandle, Emitter};
 
@@ -987,10 +988,7 @@ impl SessionManager {
     /// window that remounts while a turn waits on approval misses it, and the
     /// chat looks stuck "thinking" with no way to answer (diag f1daa64c). The
     /// frontend pulls this on session open to restore the approval bar.
-    pub fn pending_permission(
-        &self,
-        session_id: Option<String>,
-    ) -> Option<UiPermissionRequest> {
+    pub fn pending_permission(&self, session_id: Option<String>) -> Option<UiPermissionRequest> {
         let target = self.resolve_target_session(session_id).ok()?;
         self.with_session_mut(&target, |s| {
             // Gate on rpc_id: it is the field every invalidation path clears.
@@ -1151,7 +1149,16 @@ impl SessionManager {
         // never interleave with a background→live promote in `connect_inner`
         // / `focus_session`. All callers are top-level commands, so no caller
         // already holds `connect_lock`.
-        let _connect_guard = self.connect_lock.lock().await;
+        let Some(_connect_guard) = self
+            .try_lock_connect(Duration::from_secs(CONNECT_WALL_CLOCK_SECS))
+            .await
+        else {
+            return Err(format!(
+                "{}: {}",
+                crate::error::AgentErrorCode::ConnectFailed.as_str(),
+                connect_gave_up_reason(false)
+            ));
+        };
         // Clear live focus without aborting background/parked multi-session work.
         self.disconnect_inner(&app).await;
         Ok(self.snapshot())

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -79,6 +79,9 @@ pub struct SessionManager {
     >,
     /// Serialize connect / park / unpark so openSession prefetch cannot race first send.
     pub(super) connect_lock: tokio::sync::Mutex<()>,
+    /// Latest-wins generation for `session_connect`. A timed-out or superseded
+    /// waiter must not enter `connect_inner` after it finally acquires the lock.
+    pub(super) connect_epoch: AtomicU64,
     /// Per-session locks that serialize a prompt's user-journal append with
     /// post-turn reconciliation. Retry sleeps never hold these locks, and one
     /// chat never delays another chat's send.
@@ -105,6 +108,7 @@ impl SessionManager {
             prewarm_epoch: AtomicU64::new(0),
             tool_identities: std::sync::Mutex::new(std::collections::HashMap::new()),
             connect_lock: tokio::sync::Mutex::new(()),
+            connect_epoch: AtomicU64::new(0),
             post_turn_journal_locks: Mutex::new(HashMap::new()),
             pending_soft_respawn: Mutex::new(HashMap::new()),
         }

--- a/src-tauri/src/session_manager/process.rs
+++ b/src-tauri/src/session_manager/process.rs
@@ -893,7 +893,7 @@ impl SessionManager {
                 entries.len()
             );
             if let Some(acp) = entries.first().map(|p| p.acp.clone()) {
-                acp.kill().await;
+                self.kill_acp_bounded(&acp).await;
             }
             for p in entries {
                 Self::emit_idle_recycled(app, &p.app_session_id, "capacity");
@@ -949,12 +949,38 @@ impl SessionManager {
         }
     }
 
+    pub(super) async fn try_lock_connect(
+        &self,
+        wait: Duration,
+    ) -> Option<tokio::sync::MutexGuard<'_, ()>> {
+        tokio::time::timeout(wait, self.connect_lock.lock())
+            .await
+            .ok()
+    }
+
+    pub(super) async fn kill_acp_bounded(&self, acp: &AcpClient) {
+        if tokio::time::timeout(Duration::from_secs(ACP_KILL_TIMEOUT_SECS), acp.kill())
+            .await
+            .is_err()
+        {
+            tracing::warn!(secs = ACP_KILL_TIMEOUT_SECS, "acp kill timed out");
+        }
+    }
+
     /// Idle recycle for live + parked (I03).
     pub(super) async fn tick_idle_recycle(&self, app: &AppHandle) {
-        // Serialize watchdog recycling with connect/park/unpark. Without this
-        // boundary a warm-reuse connect can bind a new live session to a PID
-        // immediately after the watchdog decides that a parked handle is idle.
-        let _connect_guard = self.connect_lock.lock().await;
+        // Serialize recycle with connect/park/unpark. Bound the wait so a
+        // wedged handshake cannot pin this watchdog (and every later connect).
+        let Some(_connect_guard) = self
+            .try_lock_connect(Duration::from_secs(CONNECT_LOCK_WATCHDOG_SECS))
+            .await
+        else {
+            tracing::warn!(
+                secs = CONNECT_LOCK_WATCHDOG_SECS,
+                "idle recycle skipped: connect_lock busy"
+            );
+            return;
+        };
         let idle_mins = Self::idle_minutes_from_settings();
         let now = Instant::now();
         self.sweep_dead_parked();
@@ -1002,7 +1028,7 @@ impl SessionManager {
                 entries.len()
             );
             if let Some(acp) = entries.first().map(|p| p.acp.clone()) {
-                acp.kill().await;
+                self.kill_acp_bounded(&acp).await;
             }
             for p in entries {
                 Self::emit_idle_recycled(app, &p.app_session_id, "idle");
@@ -1090,7 +1116,7 @@ impl SessionManager {
                     .filter_map(|session_id| parked.remove(&session_id))
                     .collect::<Vec<_>>()
             };
-            acp.kill().await;
+            self.kill_acp_bounded(&acp).await;
             Self::emit_idle_recycled(app, &sid, "idle");
             for p in parked_cotenants {
                 Self::emit_idle_recycled(app, &p.app_session_id, "idle");

--- a/src-tauri/src/session_manager/turn.rs
+++ b/src-tauri/src/session_manager/turn.rs
@@ -55,7 +55,16 @@ impl SessionManager {
 
         // Serialize against connect for the whole focus + turn-open window, so
         // the slot cannot move between the target check and `begin_stream`.
-        let _focus_guard = self.connect_lock.lock().await;
+        let Some(_focus_guard) = self
+            .try_lock_connect(Duration::from_secs(CONNECT_WALL_CLOCK_SECS))
+            .await
+        else {
+            return Err(format!(
+                "{}: {}",
+                AgentErrorCode::ConnectFailed.as_str(),
+                connect_gave_up_reason(false)
+            ));
+        };
         if let Some(target) = session_id.as_deref() {
             match self.ensure_promptable_session(&app, target) {
                 Ok(true) => {}

--- a/src-tauri/src/session_manager/types.rs
+++ b/src-tauri/src/session_manager/types.rs
@@ -1736,10 +1736,41 @@ pub(super) struct DrainedAgents {
     pub(super) prewarm_count: usize,
 }
 
-/// Whole-connect budget (spawn + initialize + load/new). Sequential RPCs each
-/// have their own 45s cap; without a wall clock the pill can sit on 连接中
-/// for minutes, and a hung spawn never leaves Connecting.
+/// Whole-connect budget: lock wait + spawn + initialize + load/new.
+/// Sibling-task timer so a blocking ACP poll cannot starve it; lock wait is
+/// inside this budget (otherwise Connecting never times out).
 pub const CONNECT_WALL_CLOCK_SECS: u64 = 90;
+
+/// Idle recycle / disconnect must not wait forever for `connect_lock`.
+pub const CONNECT_LOCK_WATCHDOG_SECS: u64 = 5;
+
+/// `AcpClient::kill` under the recycle watchdog — a hung child must not
+/// pin `connect_lock` for the rest of the process lifetime.
+pub const ACP_KILL_TIMEOUT_SECS: u64 = 5;
+
+/// Why a connect attempt gave up. `lock_acquired` is false when we never
+/// entered `connect_inner`.
+pub fn connect_gave_up_reason(lock_acquired: bool) -> &'static str {
+    if lock_acquired {
+        "connect timed out"
+    } else {
+        "connect lock busy"
+    }
+}
+
+/// Latest-wins generation: only the current attempt may enter `connect_inner`.
+pub fn connect_attempt_still_current(current: u64, attempt_gen: u64) -> bool {
+    current == attempt_gen
+}
+
+/// Invalidate `attempt_gen` only if it is still the latest connect.
+pub fn next_connect_epoch_on_timeout(current: u64, attempt_gen: u64) -> u64 {
+    if current == attempt_gen {
+        attempt_gen.wrapping_add(1)
+    } else {
+        current
+    }
+}
 
 /// Pure policy: should connect keep the live agent process instead of respawning?
 ///

--- a/src/lib/api/session.ts
+++ b/src/lib/api/session.ts
@@ -7,6 +7,11 @@ import {
 } from "./host";
 import type { PermissionPayload, SessionSnapshot } from "../session";
 import { IDLE_SNAPSHOT } from "../session";
+import {
+  SESSION_CONNECT_CLIENT_TIMEOUT_MS,
+  sessionConnectTimeoutError,
+  withDeadline,
+} from "../sessionConnectTimeout";
 
 export async function sessionGetState(): Promise<SessionSnapshot> {
   if (isMirrorClient()) return invoke("session_get_state");
@@ -20,11 +25,15 @@ export async function sessionConnect(opts?: {
   mode?: string;
 }): Promise<SessionSnapshot> {
   if (isMirrorClient()) {
-    return invoke("session_connect", {
-      projectPath: opts?.projectPath ?? null,
-      sessionId: opts?.sessionId ?? null,
-      mode: opts?.mode ?? null,
-    });
+    return withDeadline(
+      invoke("session_connect", {
+        projectPath: opts?.projectPath ?? null,
+        sessionId: opts?.sessionId ?? null,
+        mode: opts?.mode ?? null,
+      }),
+      SESSION_CONNECT_CLIENT_TIMEOUT_MS,
+      () => sessionConnectTimeoutError(),
+    );
   }
   if (!isTauri()) {
     return {
@@ -35,11 +44,15 @@ export async function sessionConnect(opts?: {
       title: "Browser preview",
     };
   }
-  return invoke("session_connect", {
-    projectPath: opts?.projectPath ?? null,
-    sessionId: opts?.sessionId ?? null,
-    mode: opts?.mode ?? null,
-  });
+  return withDeadline(
+    invoke("session_connect", {
+      projectPath: opts?.projectPath ?? null,
+      sessionId: opts?.sessionId ?? null,
+      mode: opts?.mode ?? null,
+    }),
+    SESSION_CONNECT_CLIENT_TIMEOUT_MS,
+    () => sessionConnectTimeoutError(),
+  );
 }
 
 /**

--- a/src/lib/sessionConnectTimeout.test.ts
+++ b/src/lib/sessionConnectTimeout.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  SESSION_CONNECT_CLIENT_TIMEOUT_MS,
+  sessionConnectTimeoutError,
+  withDeadline,
+} from "./sessionConnectTimeout";
+
+describe("sessionConnectTimeout", () => {
+  it("sits above the Host 90s wall clock", () => {
+    expect(SESSION_CONNECT_CLIENT_TIMEOUT_MS).toBeGreaterThan(90_000);
+    expect(SESSION_CONNECT_CLIENT_TIMEOUT_MS).toBeLessThanOrEqual(120_000);
+  });
+
+  it("uses the CONNECT_FAILED deck code", () => {
+    expect(sessionConnectTimeoutError(100_000).message).toBe(
+      "CONNECT_FAILED: connect timed out after 100s",
+    );
+  });
+
+  it("resolves when the work finishes in time", async () => {
+    await expect(
+      withDeadline(Promise.resolve("ok"), 50, () => new Error("late")),
+    ).resolves.toBe("ok");
+  });
+
+  it("rejects when the work misses the budget", async () => {
+    await expect(
+      withDeadline(
+        new Promise<string>(() => {
+          /* never */
+        }),
+        20,
+        () => sessionConnectTimeoutError(20),
+      ),
+    ).rejects.toThrow("CONNECT_FAILED: connect timed out after 1s");
+  });
+});

--- a/src/lib/sessionConnectTimeout.ts
+++ b/src/lib/sessionConnectTimeout.ts
@@ -1,0 +1,40 @@
+/**
+ * Client deadline for `session_connect`.
+ *
+ * Host wall-clock is 90s and now includes `connect_lock` wait. If Host IPC
+ * itself never returns (wedged runtime), the UI must still drop 连接中.
+ * Stay slightly above the Host budget so a real Host timeout wins.
+ */
+export const SESSION_CONNECT_CLIENT_TIMEOUT_MS = 100_000;
+
+export function sessionConnectTimeoutError(
+  budgetMs = SESSION_CONNECT_CLIENT_TIMEOUT_MS,
+): Error {
+  const secs = Math.max(1, Math.round(budgetMs / 1000));
+  return new Error(`CONNECT_FAILED: connect timed out after ${secs}s`);
+}
+
+export function withDeadline<T>(
+  promise: Promise<T>,
+  budgetMs: number,
+  onTimeout: () => Error,
+): Promise<T> {
+  if (!Number.isFinite(budgetMs) || budgetMs <= 0) {
+    return promise;
+  }
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(onTimeout());
+    }, budgetMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Windows 0.2.22 can sit on **Connecting** after tray restore + new chat + `hi`. CLI still works. Host already spawned grok earlier; `session_create` writes an empty row, but `session_connect` never logs `connect open_start` and `app.log` goes silent.

`connect()` waited on `connect_lock` **before** the 90s wall clock. A held lock (recycle/`acp.kill`, or a blocking ACP poll starving the timer) made every later handshake wait forever.

This is **not** #699. That PR heals a leftover frontend 连接中 claim when Host is already idle. Here Host never enters `connect_inner`.

Fixes #709

## Changes

- Run the 90s timer on the caller; lock wait + handshake on a sibling task so a blocking ACP poll cannot starve it
- Latest-wins `connect_epoch` so a timed-out waiter cannot start a handshake after the lock frees
- Bound idle-recycle lock wait and `acp.kill`; send/disconnect wait for the lock with the same 90s budget
- Sync-append connect enqueue / timeout to `app.log` if the tracing worker is silent
- Client `sessionConnect` deadline 100s (`CONNECT_FAILED`) so the pill cannot hang if Host IPC never returns

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targeted `pnpm exec vitest run src/lib/sessionConnectTimeout.test.ts src/lib/connStatus.test.ts` (11 passed)
- [x] `cargo test --lib session_manager::connect::tests --no-run` (compiles; running the exe on this machine hits `STATUS_ENTRYPOINT_NOT_FOUND`, pre-existing)
- [x] No new user-facing copy (reuses `CONNECT_FAILED`)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased updated
- [x] No secrets

## Test plan

- [ ] Reproduce #709: tray-close after leftover `grok agent stdio`, new chat, send `hi`. Pill must leave Connecting within 90–100s with a retryable `CONNECT_FAILED` (or succeed).
- [ ] `app.log` must show `connect enqueue` even if later handshake is slow.
- [ ] A healthy first send still connects in ~1s (no extra wait).
- [ ] A live mid-turn chat is not torn down by the wall clock (`fail_stale_connecting` still only aborts handshake).