### PR TITLE
fix(chat): stop stick-to-bottom jitter on slight scroll-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See `docs/llm-wiki/release.md`.
 - **桌宠提示框可关（#696）**：设置 → 宠物，以及宠物右键菜单，都能关掉任务气泡；关掉后浮层会收小。
 
 ### Fixed
+- **Chat no longer jitters when scrolling up from the bottom (#703)**: Stick-to-bottom only snaps rubber-band past max; a 10px trackpad nudge can leave the pin. Sending after reading history force-sticks once in layout (not a double rAF + busy-edge bump).
 - **New-chat Connecting no longer hangs when `connect_lock` is held (#709)**: The 90s wall clock now covers lock wait (sibling task, so a blocking ACP poll cannot starve the timer). A timed-out attempt is invalidated so it cannot start a handshake after the lock frees. Idle recycle kill / send / disconnect wait for the lock with a timeout. Connect enqueue + timeout also sync-append to `app.log` if the tracing worker is silent. The client drops `sessionConnect` after 100s so the pill cannot sit on Connecting forever.
 - **Finished turns no longer stay on 思考中 / 连接中**: After the last assistant body is painted, leftover streaming or a leaked connect claim kept Stop and blocked the next send. Client heal unlocks the composer (reply stays) when Host is idle, or after 90s if Host itself went stale.
 - **Late tool-turn answers paint without remount (#697 / #698)**: Stream text that arrives after a tool-only (or thinking-only) bubble can now fill that bubble in place. A ready→ready skip no longer hides the final answer.
@@ -34,6 +35,7 @@ See `docs/llm-wiki/release.md`.
 - **Windows pet overlay no longer inherits File / Edit / Window / Help; toggle follows real window visibility; hit target shrinks after drag (#696)**: The overlay keeps a window-local empty menu and strips the native bar. Hide retries if the HWND stays painted; File → Close hides instead of destroying. Host clears drag when the left button is up, and measured hit radius is clamped to the mark size.
 
 **中文 · 修复**
+- **贴底后再轻微上滑不再抖动（#703）**：贴底锁只回弹越过底部的橡皮筋；10px 触控板轻拨即可离开。先上滑再发送只会在 layout 里吸一次底，不会双 rAF + busy 再吸一次。
 - **`connect_lock` 被占住时新对话不再一直 Connecting（#709）**：90 秒墙钟覆盖等锁；握手在旁路任务里跑，ACP 阻塞也挡不住超时。超时后作废这次 connect。recycle 杀进程、发送、断开等锁都有上限。tracing 日志挂了时 connect 关键行仍会写入 `app.log`。前端 100 秒丢掉卡住的 `sessionConnect`。
 - **回合结束后不再一直「思考中 / 连接中」**：正文已经出来，UI 还停在停止键、发不了下一句。Host 已空闲（或卡住超过 90 秒）时自动解锁，回复保留。
 - **工具回合的晚到正文不再要重挂才出现（#697 / #698）**：只有工具（或只有思考）的气泡，后到的流式文字会填进同一条。ready→ready 跳过状态时也不再把最终答案藏掉。

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -94,6 +94,7 @@ import {
 } from "@/lib/contextUsage";
 import type { ModelOption } from "@/lib/grokCatalog";
 import { useStickToBottom } from "@/hooks/useStickToBottom";
+import { shouldBumpStickOnBusyEdge } from "@/lib/stickToBottom";
 import { useChatMessageVirtualizer } from "@/hooks/useChatMessageVirtualizer";
 import {
   estimateChatRowHeight,
@@ -1762,29 +1763,39 @@ export function ConversationThread({
    * ends, or a user who scrolled up mid-stream would be yanked back.
    */
   const prevTurnBusyRef = useRef(false);
+  const prevLastUserIdForStickRef = useRef<string | null>(null);
   const [stickBump, setStickBump] = useState(0);
   const turnBusyForStick =
     sessionState === "streaming" || sessionState === "awaiting_permission";
+  const lastUserIdForStick = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.role === "user") return messages[i]!.id;
+    }
+    return null;
+  }, [messages]);
   useEffect(() => {
     if (turnBusyForStick && !prevTurnBusyRef.current) {
-      // Task just started → re-enter auto-follow once.
-      setStickBump((n) => n + 1);
-    }
-    prevTurnBusyRef.current = turnBusyForStick;
-  }, [turnBusyForStick]);
-
-  const forceStickKey = useMemo(() => {
-    let lastUserId: string | null = null;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]?.role === "user") {
-        lastUserId = messages[i]!.id;
-        break;
+      // Same user turn became busy (regenerate / permission) — bump.
+      // A new lastUserId already changes forceStickKey; bumping again
+      // would snap twice (#703 send flicker).
+      if (
+        shouldBumpStickOnBusyEdge(
+          lastUserIdForStick,
+          prevLastUserIdForStickRef.current,
+        )
+      ) {
+        setStickBump((n) => n + 1);
       }
     }
-    if (!lastUserId && stickBump === 0) return null;
+    prevTurnBusyRef.current = turnBusyForStick;
+    prevLastUserIdForStickRef.current = lastUserIdForStick;
+  }, [turnBusyForStick, lastUserIdForStick]);
+
+  const forceStickKey = useMemo(() => {
+    if (!lastUserIdForStick && stickBump === 0) return null;
     // stickBump only increments on busy edge — end-of-turn leaves it stable.
-    return `${lastUserId ?? "turn"}:${stickBump}`;
-  }, [messages, stickBump]);
+    return `${lastUserIdForStick ?? "turn"}:${stickBump}`;
+  }, [lastUserIdForStick, stickBump]);
 
   /** Last non-streaming assistant in the current user turn — regenerate target. */
   const regenerableAssistantId = useMemo(

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -14,6 +14,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type RefObject,
@@ -29,6 +30,7 @@ import {
   isMeaningfulScrollUp,
   isNearBottom,
   nextStickPinState,
+  shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
   shouldReleaseStickOnScrollUp,
 } from "@/lib/stickToBottom";
@@ -202,10 +204,11 @@ export function useStickToBottom(
       const meaningfulDown =
         scrollTop - lastScrollTop >= STICK_ESCAPE_MIN_DELTA_PX;
 
-      // While locked at bottom: ignore micro jitter / rubber-band / phantom
-      // spacer play. Only a real upward drag releases the lock.
+      // While locked at bottom: only snap rubber-band past max. Do not
+      // write an upward leave back to the bottom — that fights the
+      // trackpad and is the #703 jitter.
       if (isPinnedRef.current && !escapedRef.current && !meaningfulUp) {
-        if (Math.abs(scrollTop - maxTop) > 0.5) {
+        if (shouldClampPinnedOverscroll(scrollTop, maxTop)) {
           applyScrollTop(maxTop);
         }
         return;
@@ -242,10 +245,12 @@ export function useStickToBottom(
       window.setTimeout(() => {
         if (ignore != null && scrollTop === ignore) return;
 
-        // Still locked (e.g. no escape this frame)? Keep clamped after layout.
+        // Still locked (e.g. no escape this frame)? Snap rubber-band only.
         if (isPinnedRef.current && !escapedRef.current) {
           const top = bottomScrollTop(el.scrollHeight, el.clientHeight);
-          if (Math.abs(el.scrollTop - top) > 0.5) applyScrollTop(top);
+          if (shouldClampPinnedOverscroll(el.scrollTop, top)) {
+            applyScrollTop(top);
+          }
           syncShowBack();
           return;
         }
@@ -418,21 +423,17 @@ export function useStickToBottom(
   }, [conversationKey, enabled, scrollToBottom]);
 
   // User sent / turn became busy → force follow even if they had scrolled up.
-  // Double rAF: first paint may not have the new user/assistant row height yet.
-  useEffect(() => {
+  // Layout first so the virtual list's itemCount effect sees pin=true in the
+  // same frame (avoids a browse-window flash, then a snap). One rAF covers
+  // the new bubble height that is not measured until after paint.
+  useLayoutEffect(() => {
     if (!enabled || forceStickKey == null || forceStickKey === "") return;
     escapedRef.current = false;
     isPinnedRef.current = true;
     userIntentDownRef.current = false;
-    let raf2 = 0;
-    const raf1 = requestAnimationFrame(() => {
-      scrollToBottom("instant");
-      raf2 = requestAnimationFrame(() => scrollToBottom("instant"));
-    });
-    return () => {
-      cancelAnimationFrame(raf1);
-      if (raf2) cancelAnimationFrame(raf2);
-    };
+    scrollToBottom("instant");
+    const raf = requestAnimationFrame(() => scrollToBottom("instant"));
+    return () => cancelAnimationFrame(raf);
   }, [forceStickKey, enabled, scrollToBottom]);
 
   // Content growth / shrink while pinned.

--- a/src/lib/stickToBottom.test.ts
+++ b/src/lib/stickToBottom.test.ts
@@ -11,6 +11,8 @@ import {
   isMeaningfulScrollUp,
   isNearBottom,
   nextStickPinState,
+  shouldBumpStickOnBusyEdge,
+  shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
   shouldReleaseStickOnScrollUp,
 } from "./stickToBottom";
@@ -114,13 +116,38 @@ describe("shouldClampPinnedStreamDrift", () => {
 describe("isMeaningfulScrollUp", () => {
   it("ignores micro jitter at the locked bottom", () => {
     expect(isMeaningfulScrollUp(595, 600)).toBe(false); // 5px
-    expect(isMeaningfulScrollUp(590, 600)).toBe(false); // 10px
-    expect(STICK_ESCAPE_MIN_DELTA_PX).toBe(14);
+    expect(isMeaningfulScrollUp(591, 600)).toBe(false); // 9px
+    expect(STICK_ESCAPE_MIN_DELTA_PX).toBe(10);
   });
 
-  it("accepts a clear upward drag", () => {
+  it("accepts a clear upward drag aligned with the wheel threshold", () => {
     expect(isMeaningfulScrollUp(580, 600)).toBe(true); // 20px
-    expect(isMeaningfulScrollUp(586, 600)).toBe(true); // 14px
+    expect(isMeaningfulScrollUp(590, 600)).toBe(true); // 10px
+  });
+});
+
+describe("shouldClampPinnedOverscroll", () => {
+  it("clamps only past max (rubber-band)", () => {
+    expect(shouldClampPinnedOverscroll(601, 600)).toBe(true);
+    expect(shouldClampPinnedOverscroll(600.6, 600)).toBe(true);
+  });
+
+  it("does not fight an upward leave of a few pixels", () => {
+    expect(shouldClampPinnedOverscroll(600, 600)).toBe(false);
+    expect(shouldClampPinnedOverscroll(595, 600)).toBe(false);
+    expect(shouldClampPinnedOverscroll(590, 600)).toBe(false);
+  });
+});
+
+describe("shouldBumpStickOnBusyEdge", () => {
+  it("bumps regenerate / permission on the same user turn", () => {
+    expect(shouldBumpStickOnBusyEdge("u1", "u1")).toBe(true);
+    expect(shouldBumpStickOnBusyEdge(null, null)).toBe(true);
+  });
+
+  it("does not bump when a new user message already force-sticks", () => {
+    expect(shouldBumpStickOnBusyEdge("u2", "u1")).toBe(false);
+    expect(shouldBumpStickOnBusyEdge("u1", null)).toBe(false);
   });
 });
 

--- a/src/lib/stickToBottom.ts
+++ b/src/lib/stickToBottom.ts
@@ -33,10 +33,11 @@ export const STICK_HEIGHT_NOISE_PX = 8;
 
 /**
  * Minimum upward scroll (px) to leave stick-lock.
- * Trackpad jitter, elastic overscroll, and 1–2px virtual height corrections
- * used to "unlock" the bottom then yank back — felt like bounce + flash.
+ * Keep this aligned with {@link STICK_ESCAPE_WHEEL_DELTA}: a 10–12px
+ * trackpad nudge used to be clamped by the scroll handler and then
+ * unpinned by wheel, which is the #703 jitter.
  */
-export const STICK_ESCAPE_MIN_DELTA_PX = 14;
+export const STICK_ESCAPE_MIN_DELTA_PX = 10;
 
 /**
  * Wheel deltaY (negative = read history) must exceed this to escape pin.
@@ -51,6 +52,29 @@ export function isMeaningfulScrollUp(
   minDeltaPx: number = STICK_ESCAPE_MIN_DELTA_PX,
 ): boolean {
   return previousScrollTop - scrollTop >= minDeltaPx;
+}
+
+/**
+ * While pinned, only rubber-band / overscroll *past* max should snap back.
+ * An upward scroll that stays at or below maxTop is the user leaving the
+ * bottom — fighting it with applyScrollTop is the #703 jitter.
+ */
+export function shouldClampPinnedOverscroll(
+  scrollTop: number,
+  maxTop: number,
+): boolean {
+  return scrollTop > maxTop + 0.5;
+}
+
+/**
+ * `stickBump` on streaming/permission edge: only when this is the *same*
+ * user turn (regenerate / approval). A new last user id already force-sticks.
+ */
+export function shouldBumpStickOnBusyEdge(
+  lastUserId: string | null,
+  prevLastUserId: string | null,
+): boolean {
+  return lastUserId === prevLastUserId;
 }
 
 /**


### PR DESCRIPTION
## Summary
#703: slight scroll-up from the bottom jittered, and sending after reading history flashed.

- Pinned clamp only snaps rubber-band past max (do not write a few-px upward leave back to the bottom)
- Align scroll-up escape with the 10px wheel threshold
- Force-stick on send runs in layout (one follow-up rAF), and busy-edge no longer double-bumps when lastUserId already changed

Fixes #703

## Type of change
- [x] Bug fix

## Checklist
- [x] \`pnpm exec vitest run src/lib/stickToBottom.test.ts\` (38 passed)
- [x] CHANGELOG Unreleased updated