### PR TITLE
fix(pet): wrap bubble body 2-3 lines and keep title readable on light chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ See `docs/llm-wiki/release.md`.
 - **把另一段对话当作上下文加入**：`/attach-chat`、输入框 `+`、侧栏对话图标或右键「加入目前对话」可加入本地对话；chip 挂在输入框；日记只存 `[[chat:id]]`；Host 只给 Agent 加一段压缩记录（最多 3 段；来源对话不改）。拖行身到项目仍是移动会话。
 
 ### Fixed
+- **Pet bubble body wraps 2–3 lines; session title stays readable on light chips**: Stage text is no longer a single ellipsis line. The session title under it uses contrast-safe muted color (paper/white no longer hides it). With the progress bar off, the chip does not keep an empty track gap.
 - **“No credentials on the agent” points to Providers, not only official Sign in (#705)**: The banner now explains that a terminal CC Switch / custom relay is unused until you click Use in Settings, and the primary action opens Custom providers.
 - **Chat no longer jitters when scrolling up from the bottom (#703)**: Stick-to-bottom only snaps rubber-band past max; a 10px trackpad nudge can leave the pin. Sending after reading history force-sticks once in layout (not a double rAF + busy-edge bump).
 - **New-chat Connecting no longer hangs when `connect_lock` is held (#709)**: The 90s wall clock now covers lock wait (sibling task, so a blocking ACP poll cannot starve the timer). A timed-out attempt is invalidated so it cannot start a handshake after the lock frees. Idle recycle kill / send / disconnect wait for the lock with a timeout. Connect enqueue + timeout also sync-append to `app.log` if the tracing worker is silent. The client drops `sessionConnect` after 100s so the pill cannot sit on Connecting forever.
@@ -52,6 +53,7 @@ See `docs/llm-wiki/release.md`.
 - Sidebar attach is an icon click (tooltip keeps the full phrase). No ⋮⋮ grip-drag. Host compact keeps the newest turns; chips-only missing/empty sources return typed errors; recycle bootstrap keeps a stub or re-expanded attach context.
 
 **中文 · 修复**
+- **宠物气泡正文可折 2–3 行；浅色底上也能看见会话标题**：阶段性回复不再只挤一行省略。下面的会话标题用对比色，纸张/白色背景不再把标题隐成空行。关掉进度条时不再留那条空白。
 - **「Agent 侧没有可用凭据」不再只叫人官方登录（#705）**：文案说明终端 CC Switch / 中转要在设置里点「使用」才会进 App；主按钮打开自定义服务商。
 - **贴底后再轻微上滑不再抖动（#703）**：贴底锁只回弹越过底部的橡皮筋；10px 触控板轻拨即可离开。先上滑再发送只会在 layout 里吸一次底，不会双 rAF + busy 再吸一次。
 - **`connect_lock` 被占住时新对话不再一直 Connecting（#709）**：90 秒墙钟覆盖等锁；握手在旁路任务里跑，ACP 阻塞也挡不住超时。超时后作废这次 connect。recycle 杀进程、发送、断开等锁都有上限。tracing 日志挂了时 connect 关键行仍会写入 `app.log`。前端 100 秒丢掉卡住的 `sessionConnect`。

--- a/src-tauri/src/pet_window.rs
+++ b/src-tauri/src/pet_window.rs
@@ -311,8 +311,8 @@ fn window_logical_size(size_px: u32) -> f64 {
 const PET_BUBBLE_WIDTH_PX: f64 = 216.0;
 /// Chip drop-shadow pad (matches JS `PET_BUBBLE_SHADOW_PAD`).
 const PET_BUBBLE_SHADOW_PAD: f64 = 20.0;
-/// 3 visible rows + shadow pad: 3*38 + 2*6 + 10 + 40. Always reserved so the mark does not jump.
-const PET_BUBBLE_VIEWPORT_H: f64 = 176.0;
+/// 3 visible rows + shadow pad: 3*68 + 2*6 + 10 + 40. Always reserved so the mark does not jump.
+const PET_BUBBLE_VIEWPORT_H: f64 = 266.0;
 /// Matches `.pet-overlay` padding-bottom — mark sits on the bottom, not centered.
 const PET_MARK_BOTTOM_PAD: f64 = 16.0;
 /// Matches `PET_COMPACT_PAD` in JS — idle Wayland window hugs the mark.
@@ -1274,7 +1274,7 @@ mod tests {
     fn overlay_extent_matches_js_width_and_does_not_use_hit_chrome() {
         let (w, h) = overlay_extent(128);
         assert_eq!(w, 128.0 + 96.0 + 216.0 + 40.0);
-        assert_eq!(h, 128.0 + 96.0 + 176.0);
+        assert_eq!(h, 128.0 + 96.0 + 266.0);
         let (w0, h0) = overlay_extent_for(128, false);
         assert_eq!(w0, 128.0 + 96.0);
         assert_eq!(h0, 128.0 + 96.0);

--- a/src/components/pet/PetTaskBubbles.tsx
+++ b/src/components/pet/PetTaskBubbles.tsx
@@ -50,9 +50,7 @@ export function PetTaskBubbles({
           task.phase === "done"
             ? t("pet.bubble.progressDone")
             : t("pet.bubble.progressActive");
-        const sub = snippet
-          ? title
-          : task.toolTitle?.trim() || phaseLabel;
+        const showSub = Boolean(snippet && title && title !== snippet);
         const pct = Math.round(Math.max(0, Math.min(1, task.progress)) * 100);
         return (
           <button
@@ -88,8 +86,16 @@ export function PetTaskBubbles({
                 )}
               </span>
               <span className="pet-bubble__text">
-                <span className="pet-bubble__title">{headline}</span>
-                <span className="pet-bubble__sub">{sub}</span>
+                <span
+                  className={
+                    "pet-bubble__title" + (showSub ? " is-2" : " is-3")
+                  }
+                >
+                  {headline}
+                </span>
+                {showSub ? (
+                  <span className="pet-bubble__sub">{title}</span>
+                ) : null}
               </span>
             </span>
             {progressBar ? (

--- a/src/lib/pet/petTasks.test.ts
+++ b/src/lib/pet/petTasks.test.ts
@@ -4,7 +4,10 @@ import type { PetFocusInput } from "./petFocus";
 import {
   collectPetTasks,
   mergeHeldPetTasks,
+  PET_BUBBLE_GAP,
+  PET_BUBBLE_ROW_H,
   PET_BUBBLE_SHADOW_PAD,
+  PET_BUBBLE_STACK_PAD,
   PET_BUBBLE_VISIBLE,
   PET_TASK_LIMIT,
   petBubbleStackHeight,
@@ -182,6 +185,12 @@ describe("pet task helpers", () => {
     expect(petBubbleStackHeight(9)).toBe(petBubbleStackHeight(3));
     expect(petBubbleViewportHeight()).toBe(
       petBubbleStackHeight(PET_BUBBLE_VISIBLE) + PET_BUBBLE_SHADOW_PAD * 2,
+    );
+    expect(petBubbleViewportHeight()).toBe(
+      PET_BUBBLE_VISIBLE * PET_BUBBLE_ROW_H +
+        (PET_BUBBLE_VISIBLE - 1) * PET_BUBBLE_GAP +
+        PET_BUBBLE_STACK_PAD +
+        PET_BUBBLE_SHADOW_PAD * 2,
     );
   });
 

--- a/src/lib/pet/petTasks.ts
+++ b/src/lib/pet/petTasks.ts
@@ -20,7 +20,8 @@ export const PET_BUBBLE_VISIBLE = 3;
 /** Collect cap — more than the viewport so the slot can scroll. */
 export const PET_TASK_LIMIT = 16;
 export const PET_BUBBLE_WIDTH = 216;
-export const PET_BUBBLE_ROW_H = 38;
+/** One chip: 2–3 wrapped body lines + optional session title. */
+export const PET_BUBBLE_ROW_H = 68;
 export const PET_BUBBLE_GAP = 6;
 export const PET_BUBBLE_STACK_PAD = 10;
 /** Inner padding so chip drop-shadows are not square-clipped by overflow. */

--- a/src/styles/pet.css
+++ b/src/styles/pet.css
@@ -147,7 +147,7 @@ html[data-pet-shell] .boot-gate {
 .pet-bubble {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 0;
   width: 100%;
   margin: 0;
   padding: 6px 8px 7px;
@@ -155,6 +155,7 @@ html[data-pet-shell] .boot-gate {
   border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.12));
   background: var(--bg-elevated, #1c1c1e);
   color: var(--text-primary, #f4f4f5);
+  --pet-bubble-muted: color-mix(in srgb, currentColor 68%, transparent);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.22);
   text-align: left;
   cursor: pointer;
@@ -198,21 +199,28 @@ html[data-pet-shell] .boot-gate {
   border-radius: 4px 16px 4px 16px;
 }
 
+.pet-bubble.has-track {
+  gap: 5px;
+}
+
 .pet-bubble--ink {
   background: var(--bg-elevated, #1c1c1e);
   color: var(--text-primary, #f4f4f5);
+  --pet-bubble-muted: color-mix(in srgb, var(--text-primary, #f4f4f5) 62%, transparent);
 }
 
 .pet-bubble--glass {
   background: color-mix(in srgb, var(--bg-elevated, #1c1c1e) 58%, transparent);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
+  --pet-bubble-muted: color-mix(in srgb, currentColor 62%, transparent);
 }
 
 .pet-bubble--solid {
   background: #141416;
   color: #f4f4f5;
   border-color: rgba(255, 255, 255, 0.08);
+  --pet-bubble-muted: rgba(244, 244, 245, 0.68);
 }
 
 .pet-bubble--paper {
@@ -220,21 +228,20 @@ html[data-pet-shell] .boot-gate {
   color: #2a241c;
   border-color: rgba(80, 60, 30, 0.18);
   box-shadow: 0 8px 18px rgba(60, 40, 20, 0.16);
-}
-
-.pet-bubble--paper .pet-bubble__sub {
-  color: rgba(42, 36, 28, 0.62);
+  --pet-bubble-muted: rgba(42, 36, 28, 0.72);
 }
 
 .pet-bubble--outline {
   background: rgba(12, 12, 14, 0.42);
   border: 1.5px solid color-mix(in srgb, var(--text-primary, #fff) 45%, transparent);
   box-shadow: none;
+  --pet-bubble-muted: color-mix(in srgb, currentColor 68%, transparent);
 }
 
 .pet-bubble--accent {
   background: color-mix(in srgb, var(--accent, #6b8cff) 22%, var(--bg-elevated, #1c1c1e));
   border-color: color-mix(in srgb, var(--accent, #6b8cff) 45%, transparent);
+  --pet-bubble-muted: color-mix(in srgb, currentColor 68%, transparent);
 }
 
 .pet-bubble-preview {
@@ -250,7 +257,7 @@ html[data-pet-shell] .boot-gate {
 
 .pet-bubble__row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 7px;
   min-width: 0;
 }
@@ -259,6 +266,7 @@ html[data-pet-shell] .boot-gate {
   flex: 0 0 16px;
   width: 16px;
   height: 16px;
+  margin-top: 1px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -296,16 +304,28 @@ html[data-pet-shell] .boot-gate {
 .pet-bubble__title {
   font-size: 12px;
   font-weight: 600;
-  line-height: 1.2;
+  line-height: 1.35;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  color: inherit;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.pet-bubble__title.is-2 {
+  -webkit-line-clamp: 2;
+}
+
+.pet-bubble__title.is-3 {
+  -webkit-line-clamp: 3;
 }
 
 .pet-bubble__sub {
   font-size: 10px;
-  line-height: 1.2;
-  color: var(--text-muted, rgba(255, 255, 255, 0.58));
+  line-height: 1.3;
+  margin-top: 2px;
+  color: var(--pet-bubble-muted, color-mix(in srgb, currentColor 68%, transparent));
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
Follow-up to #717. Stage-reply chips were a single ellipsis line, and the session title under them vanished on paper/white (or light-theme) backgrounds because the subtitle color fell back to near-white.

- Body text wraps **2 lines** when a session title is shown, **3 lines** when it is not; the chip grows with the text.
- Session title stays on its own row with contrast-safe muted color on every bubble fill (including paper/white).
- With the progress bar off, the chip no longer keeps an empty track gap.
- Overlay viewport / Rust reserved height updated so taller chips do not clip.

## Tests
- `npx vitest run src/lib/pet/petTasks.test.ts src/lib/pet/petBubbleLayout.test.ts` — 21 passed

## Screenshots
Light chips previously looked like they had a blank second row; that row was the session title. Dark chips already showed it (e.g. 「询问含义是什么」).