### PR TITLE
style: cargo fmt --check is red on main

### DIFF
--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -1734,13 +1734,9 @@ pub fn try_reconcile_linked_session(app_session_id: &str) -> u32 {
             .find(|p| p.id == pid)
             .map(|p| p.path)
     });
-    let changed = reconcile_journal_from_chat_history(
-        app_session_id,
-        agent_id,
-        cwd_hint.as_deref(),
-        &mode,
-    )
-    .unwrap_or(0);
+    let changed =
+        reconcile_journal_from_chat_history(app_session_id, agent_id, cwd_hint.as_deref(), &mode)
+            .unwrap_or(0);
     // Do not heal here: session_messages / post-turn reconcile can run while
     // this process still has a live prompt. Boot + connect heal instead.
     changed

--- a/src-tauri/src/remote_im/i18n.rs
+++ b/src-tauri/src/remote_im/i18n.rs
@@ -146,11 +146,23 @@ mod tests {
 
     #[test]
     fn added_locales_are_translated_not_english() {
-        assert_eq!(t("ja", MessageKey::StopSignalSent), "中断信号を送信しました。");
-        assert_eq!(t("ko", MessageKey::NoInFlightTurn), "진행 중인 턴이 없습니다.");
+        assert_eq!(
+            t("ja", MessageKey::StopSignalSent),
+            "中断信号を送信しました。"
+        );
+        assert_eq!(
+            t("ko", MessageKey::NoInFlightTurn),
+            "진행 중인 턴이 없습니다."
+        );
         assert_eq!(t("de", MessageKey::NoInFlightTurn), "Kein laufender Zug.");
-        assert_eq!(t("pt-BR", MessageKey::StopSignalSent), "Sinal de parada enviado.");
-        assert_eq!(t("uk", MessageKey::StopSignalSent), "Сигнал зупинки надіслано.");
+        assert_eq!(
+            t("pt-BR", MessageKey::StopSignalSent),
+            "Sinal de parada enviado."
+        );
+        assert_eq!(
+            t("uk", MessageKey::StopSignalSent),
+            "Сигнал зупинки надіслано."
+        );
     }
 
     #[test]

--- a/src-tauri/src/session_title.rs
+++ b/src-tauri/src/session_title.rs
@@ -339,8 +339,16 @@ mod tests {
                 "{} prompt must name {language}",
                 locale.as_tag()
             );
-            assert!(p.contains("list open prs"), "{} keeps the snippet", locale.as_tag());
-            assert!(p.contains("User message:"), "{} keeps the anchor", locale.as_tag());
+            assert!(
+                p.contains("list open prs"),
+                "{} keeps the snippet",
+                locale.as_tag()
+            );
+            assert!(
+                p.contains("User message:"),
+                "{} keeps the anchor",
+                locale.as_tag()
+            );
         }
     }
 }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -597,7 +597,6 @@ fn default_stt_zh_script() -> String {
     "auto".into()
 }
 
-
 fn default_close_to_tray() -> bool {
     true
 }

--- a/src-tauri/src/turn_interrupt.rs
+++ b/src-tauri/src/turn_interrupt.rs
@@ -55,16 +55,18 @@ pub fn inspect_agent_trail(agent_dir: &Path) -> TrailVerdict {
             match typ {
                 "permission_requested" => {
                     requested += 1;
-                    last_tool = Some(pending_from_event(&v).or(last_tool).unwrap_or(PendingTool {
-                        tool_call_id: String::new(),
-                        tool_name: v
-                            .get("tool_name")
-                            .and_then(|x| x.as_str())
-                            .unwrap_or("tool")
-                            .to_string(),
-                        title: String::new(),
-                        command: String::new(),
-                    }));
+                    last_tool = Some(
+                        pending_from_event(&v).or(last_tool).unwrap_or(PendingTool {
+                            tool_call_id: String::new(),
+                            tool_name: v
+                                .get("tool_name")
+                                .and_then(|x| x.as_str())
+                                .unwrap_or("tool")
+                                .to_string(),
+                            title: String::new(),
+                            command: String::new(),
+                        }),
+                    );
                 }
                 "permission_resolved" => resolved += 1,
                 "turn_completed" => {
@@ -159,10 +161,7 @@ fn pending_from_event(v: &Value) -> Option<PendingTool> {
 }
 
 fn pending_from_tool_call(call: &Value) -> PendingTool {
-    let args = call
-        .get("arguments")
-        .and_then(|x| x.as_str())
-        .unwrap_or("");
+    let args = call.get("arguments").and_then(|x| x.as_str()).unwrap_or("");
     let command = serde_json::from_str::<Value>(args)
         .ok()
         .and_then(|v| {
@@ -214,10 +213,7 @@ pub fn heal_interrupted_turn(session_id: &str) -> Option<String> {
         return None;
     }
     let lease = read_lease(session_id);
-    let lease_active = matches!(
-        lease.as_ref().map(|l| &l.status),
-        Some(LeaseStatus::Active)
-    );
+    let lease_active = matches!(lease.as_ref().map(|l| &l.status), Some(LeaseStatus::Active));
     let trail = resolve_agent_dir(session_id)
         .map(|d| inspect_agent_trail(&d))
         .unwrap_or_default();
@@ -410,7 +406,10 @@ mod tests {
             r#"{"type":"assistant","tool_calls":[{"id":"call-later","name":"run_terminal_command","arguments":"{\"command\":\"git log\"}"}]}"#,
         );
         let v = inspect_agent_trail(&dir);
-        assert!(v.abandoned, "a later unfinished turn must not be hidden by an earlier turn_completed");
+        assert!(
+            v.abandoned,
+            "a later unfinished turn must not be hidden by an earlier turn_completed"
+        );
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -430,10 +429,7 @@ mod tests {
             begin_active(sid, Some("agent-1"), Some("turn-1"));
             assert!(heal_interrupted_turn(sid).is_some());
             assert_eq!(host_exit_count(sid), 1);
-            assert_eq!(
-                read_lease(sid).unwrap().status,
-                LeaseStatus::Interrupted
-            );
+            assert_eq!(read_lease(sid).unwrap().status, LeaseStatus::Interrupted);
         });
     }
 

--- a/src-tauri/src/turn_lease.rs
+++ b/src-tauri/src/turn_lease.rs
@@ -98,11 +98,7 @@ pub fn mark_interrupted(session_id: &str) -> Option<TurnLease> {
 }
 
 /// Fresh active lease for a newly dispatched prompt (drops leftover pending).
-pub fn begin_active(
-    session_id: &str,
-    agent_session_id: Option<&str>,
-    turn_id: Option<&str>,
-) {
+pub fn begin_active(session_id: &str, agent_session_id: Option<&str>, turn_id: Option<&str>) {
     let now = now_rfc3339();
     let lease = TurnLease {
         schema: SCHEMA,
@@ -134,9 +130,7 @@ pub fn update_active(
         schema: SCHEMA,
         status: LeaseStatus::Active,
         session_id: session_id.to_string(),
-        agent_session_id: existing
-            .as_ref()
-            .and_then(|e| e.agent_session_id.clone()),
+        agent_session_id: existing.as_ref().and_then(|e| e.agent_session_id.clone()),
         turn_id: existing.as_ref().and_then(|e| e.turn_id.clone()),
         started_at: existing
             .as_ref()
@@ -166,7 +160,10 @@ pub fn list_active_lease_session_ids() -> Vec<String> {
         let Some(id) = path.file_name().and_then(|s| s.to_str()) else {
             continue;
         };
-        if matches!(read_lease(id).as_ref().map(|l| &l.status), Some(LeaseStatus::Active)) {
+        if matches!(
+            read_lease(id).as_ref().map(|l| &l.status),
+            Some(LeaseStatus::Active)
+        ) {
             out.push(id.to_string());
         }
     }
@@ -253,10 +250,7 @@ mod tests {
             write_lease(&sample(sid)).unwrap();
             let got = mark_interrupted(sid).expect("marked");
             assert_eq!(got.status, LeaseStatus::Interrupted);
-            assert_eq!(
-                got.pending_tool.unwrap().tool_call_id,
-                "call-9e5f0e0d"
-            );
+            assert_eq!(got.pending_tool.unwrap().tool_call_id, "call-9e5f0e0d");
             assert_eq!(read_lease(sid).unwrap().status, LeaseStatus::Interrupted);
         });
     }


### PR DESCRIPTION
**Rewritten on `main` @ c23c17ed.** Two of the three commits this PR opened with are no longer needed — you landed both fixes independently while it was open:

- the Windows crash-handler build → c23c17ed (`fix(windows): enable Kernel feature for last-crash filter`), same diagnosis and same fix
- the `AUTH_NO_CONTEXT` deck test → #715 (`fix(auth): point AUTH_NO_CONTEXT at custom providers`), which updated the assertion at the source

Both are dropped. What is left is the one that is still red.

## `cargo fmt --check` fails on `main`

```
Diff in src-tauri/src/cli_sessions.rs
Diff in src-tauri/src/remote_im/i18n.rs
Diff in src-tauri/src/session_title.rs
Diff in src-tauri/src/store.rs
Diff in src-tauri/src/turn_interrupt.rs
Diff in src-tauri/src/turn_lease.rs
```

Six files, so every branch cut from `main` starts red and every contributor sees a formatting failure that is not theirs.

## What this is

`cargo fmt` with the committed config and nothing else — no hand edits, no logic touched. Regenerated fresh on c23c17ed rather than rebased, so it is exactly what the tool produces today. `cargo fmt --check` is clean afterwards.

## Verification

With this and my six other open PRs stacked on c23c17ed:

| | |
|---|---|
| `cargo test`, default threads | **1,374 / 1,374** |
| `pnpm test` | **6,174 / 6,174** |
| `pnpm typecheck`, `pnpm lint` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
