### PR TITLE
fix(i18n): three bugs the 15-locale rollout activated

### DIFF
--- a/src-tauri/src/remote_im/app_sessions.rs
+++ b/src-tauri/src/remote_im/app_sessions.rs
@@ -259,11 +259,12 @@ fn find_app_session_id(local_id: &str, agent_id: Option<&str>) -> Option<String>
 }
 
 fn is_placeholder_title(t: &str) -> bool {
+    // Remote IM adds one default of its own on top of the app-wide names.
+    // The shared matcher covers every shipped locale; this copy knew only
+    // English and Simplified Chinese, so a `de` or `ja` session bound to a
+    // bridge never got its first real title.
     let t = t.trim();
-    t.is_empty()
-        || t.eq_ignore_ascii_case("New chat")
-        || t == "新对话"
-        || t.starts_with("Remote IM")
+    crate::session_title::is_placeholder_title(t) || t.starts_with("Remote IM")
 }
 
 fn title_from_prompt(prompt: &str, channel: &str) -> String {

--- a/src-tauri/src/remote_im/engine.rs
+++ b/src-tauri/src/remote_im/engine.rs
@@ -2078,8 +2078,12 @@ mod tests {
             .unwrap_or_else(|e| e.into_inner());
         let engine = Engine::new_ephemeral(OutboundRouter::new(), false);
         let lang = engine.lang();
+        // Checked against the shipped roster rather than a literal list:
+        // with the literal, `app_locale()` resolving to any newer catalog
+        // panics here while holding APP_HOME_ENV_LOCK and poisons it for the
+        // rest of the suite. Green on an English runner, red on a German desktop.
         assert!(
-            matches!(lang.as_str(), "en" | "zh" | "zh-TW"),
+            crate::tray_i18n::ALL.iter().any(|l| l.as_tag() == lang),
             "unexpected catalog id {lang}"
         );
         assert_eq!(lang, i18n::resolve_engine_lang());

--- a/src-tauri/src/session_title.rs
+++ b/src-tauri/src/session_title.rs
@@ -70,13 +70,24 @@ fn clean_llm_title(raw: &str) -> Option<String> {
         t = line.to_string();
     }
     for _ in 0..3 {
-        if (t.starts_with('"') && t.ends_with('"'))
-            || (t.starts_with('「') && t.ends_with('」'))
-            || (t.starts_with('“') && t.ends_with('”'))
-            || (t.starts_with('\'') && t.ends_with('\''))
-        {
-            t = t[1..t.len() - 1].trim().to_string();
+        // Peel one matched pair per pass, by character rather than by byte:
+        // 「」 and “” are three bytes each, so `t[1..t.len() - 1]` cuts a
+        // codepoint in half and panics — and those are exactly the quotes a
+        // title model puts around Japanese and Chinese output.
+        let mut inner = t.chars();
+        let first = inner.next();
+        let last = inner.next_back();
+        let quoted = matches!(
+            (first, last),
+            (Some('"'), Some('"'))
+                | (Some('「'), Some('」'))
+                | (Some('“'), Some('”'))
+                | (Some('\''), Some('\''))
+        );
+        if !quoted {
+            break;
         }
+        t = inner.as_str().trim().to_string();
     }
     if let Some(rest) = t
         .strip_prefix("标题：")
@@ -92,7 +103,9 @@ fn clean_llm_title(raw: &str) -> Option<String> {
     {
         t = rest.trim().to_string();
     }
-    if t.is_empty() || t.len() > 120 || is_placeholder_title(&t) {
+    // Character count, not bytes: 120 bytes is only 40 Japanese characters,
+    // so a byte guard rejects titles in the CJK locales it accepts in English.
+    if t.is_empty() || t.chars().count() > 120 || is_placeholder_title(&t) {
         return None;
     }
     if skip_line(&t) {
@@ -254,6 +267,31 @@ mod tests {
         assert!(!is_placeholder_title("修权限条 bug"));
         assert!(!is_placeholder_title("Исправить панель разрешений"));
         assert!(!is_placeholder_title("馬斯克最近有發什麼貼文"));
+    }
+
+    /// `t[1..t.len() - 1]` panicked here: 「」 and “” are three bytes each, so
+    /// the slice cut a codepoint in half. `refine_title_in_background` swallows
+    /// the panic, so auto-titling simply stopped for the CJK locales.
+    #[test]
+    fn clean_strips_multibyte_quotes_without_panicking() {
+        assert_eq!(
+            clean_llm_title("「ログイン修正」\n").as_deref(),
+            Some("ログイン修正")
+        );
+        assert_eq!(clean_llm_title("“修复登录”\n").as_deref(), Some("修复登录"));
+        // An unmatched opening quote must not panic either.
+        assert_eq!(clean_llm_title("「テスト").as_deref(), Some("「テスト"));
+        // Neither may a string that is a single quote character.
+        assert_eq!(clean_llm_title("「").as_deref(), Some("「"));
+    }
+
+    /// The sanity cap counted bytes, so 120 bytes is 40 Japanese characters:
+    /// a title was rejected at a length its English equivalent passed.
+    #[test]
+    fn clean_measures_length_in_characters() {
+        let long_ja: String = "あ".repeat(64);
+        let got = clean_llm_title(&long_ja).expect("accepted");
+        assert_eq!(got.chars().count(), 32, "truncated to the char budget");
     }
 
     #[test]

--- a/src-tauri/src/session_title.rs
+++ b/src-tauri/src/session_title.rs
@@ -10,7 +10,9 @@ use crate::cli_probe;
 use crate::store::{self, SessionMeta};
 use crate::tray_i18n::{self, Locale};
 
-const PLACEHOLDERS: &[&str] = &[
+/// Default names written to disk before the locale catalogs existed.
+/// Live names come from `tray_i18n` in [`is_placeholder_title`].
+const LEGACY_PLACEHOLDERS: &[&str] = &[
     "New chat",
     "Новый чат",
     "Новая беседа",
@@ -24,9 +26,27 @@ const PLACEHOLDERS: &[&str] = &[
     "新建会话",
 ];
 
+/// True when a title is a default name rather than something about the chat.
+///
+/// Walks every shipped locale instead of a hand-kept list. The app writes
+/// `session.placeholderTitle` in the user's language, so a German session is
+/// stored as "Neuer Chat"; a matcher that only knows English and Chinese never
+/// recognises it and leaves that session on its default name forever.
 pub fn is_placeholder_title(title: &str) -> bool {
     let t = title.trim();
-    t.is_empty() || PLACEHOLDERS.iter().any(|p| p.eq_ignore_ascii_case(t))
+    if t.is_empty() {
+        return true;
+    }
+    if LEGACY_PLACEHOLDERS
+        .iter()
+        .any(|p| p.eq_ignore_ascii_case(t))
+    {
+        return true;
+    }
+    tray_i18n::ALL.iter().any(|l| {
+        let s = tray_i18n::strings(*l);
+        s.new_chat.eq_ignore_ascii_case(t) || s.untitled.eq_ignore_ascii_case(t)
+    })
 }
 
 /// Offline title: first non-empty line, collapsed whitespace, max ~28 display chars.
@@ -292,6 +312,28 @@ mod tests {
         let long_ja: String = "あ".repeat(64);
         let got = clean_llm_title(&long_ja).expect("accepted");
         assert_eq!(got.chars().count(), 32, "truncated to the char budget");
+    }
+
+    /// The app writes `session.placeholderTitle` in the user's language, so
+    /// every shipped locale's default name has to be recognised — otherwise
+    /// those sessions keep their default name forever.
+    #[test]
+    fn placeholder_detection_covers_every_shipped_locale() {
+        for locale in tray_i18n::ALL {
+            let s = tray_i18n::strings(locale);
+            assert!(
+                is_placeholder_title(s.new_chat),
+                "{}: {:?} not recognised",
+                locale.as_tag(),
+                s.new_chat
+            );
+            assert!(
+                is_placeholder_title(s.untitled),
+                "{}: {:?} not recognised",
+                locale.as_tag(),
+                s.untitled
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -626,29 +626,33 @@ pub fn format_usage(template: &str, pct: Option<f64>, time: Option<&str>) -> Str
     out
 }
 
+/// Every catalog id shipped by the frontend (`LOCALES` in
+/// `src/i18n/messages/index.ts`), in the same order.
+///
+/// Public because anything that has to recognise copy the app itself wrote
+/// must walk the whole roster; a second hand-kept list goes stale the moment
+/// a locale is added.
+pub const ALL: [Locale; 15] = [
+    Locale::En,
+    Locale::De,
+    Locale::Es,
+    Locale::Fil,
+    Locale::Fr,
+    Locale::Id,
+    Locale::It,
+    Locale::Ja,
+    Locale::Ko,
+    Locale::PtBr,
+    Locale::Ru,
+    Locale::Ta,
+    Locale::Uk,
+    Locale::Zh,
+    Locale::ZhTw,
+];
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Every catalog id shipped by the frontend (`LOCALES` in
-    /// `src/i18n/messages/index.ts`), in the same order.
-    const ALL: [Locale; 15] = [
-        Locale::En,
-        Locale::De,
-        Locale::Es,
-        Locale::Fil,
-        Locale::Fr,
-        Locale::Id,
-        Locale::It,
-        Locale::Ja,
-        Locale::Ko,
-        Locale::PtBr,
-        Locale::Ru,
-        Locale::Ta,
-        Locale::Uk,
-        Locale::Zh,
-        Locale::ZhTw,
-    ];
 
     #[test]
     fn locale_parse() {


### PR DESCRIPTION
> Rebased on `main` @ c23c17ed and re-measured there. The Windows build no longer needs #725 — you landed that fix yourself in c23c17ed.

Three bugs that shipping fifteen catalogs turned on. All three predate the rollout; none of them could fire while only `en` / `zh` / `zh-TW` existed. One commit each.

This supersedes the correctness half of #708 / #724 — the catalogs themselves are yours now, so those are closed.

## 1. Auto-titling panics on Japanese and Chinese titles

`clean_llm_title` peeled a surrounding quote pair with `t[1..t.len() - 1]`. `「」` and `“”` are three bytes each, so that slice cut a codepoint in half and panicked — and those are exactly the quotes a title model puts around CJK output. `refine_title_in_background` swallows the panic, so nothing surfaces: auto-titling just stops and the session keeps its heuristic name.

```rust
assert_eq!(clean_llm_title("「ログイン修正」\n").as_deref(), Some("ログイン修正"));  // panicked
```

The 120-unit sanity cap counted bytes too, which is 40 Japanese characters — a title was rejected at a length its English equivalent passed. Both count characters now.

## 2. Sessions in the new locales are never auto-titled

The app writes `session.placeholderTitle` to disk in the user's language, so a German session is stored as `"Neuer Chat"` and a Korean one as `"새 대화"`. `is_placeholder_title` matched a hand-kept list of English and Chinese names, so it recognised none of them — and a title that is not seen as a placeholder is never replaced, so those sessions keep their default name **forever**.

It walks `tray_i18n::ALL` now, which already carries the same names for the tray menu, so a new locale is translated once. `ALL` moves out of the test module for that; a second hand-kept roster goes stale the moment a locale is added, which is how this happened.

Remote IM kept its own two-entry copy in `app_sessions.rs` that never even knew `zh-TW`. It delegates now and keeps only its own `"Remote IM"` prefix.

## 3. `cargo test` fails 38 times on a non-English desktop

`engine_lang_follows_product_locale_not_hardcoded_zh` asserts `matches!(lang, "en" | "zh" | "zh-TW")`. That was true for three catalogs. With fifteen, `app_locale()` resolves to whatever the desktop asks for, so on a German or Japanese machine the assertion fails — while holding `APP_HOME_ENV_LOCK`. The panic poisons the lock and 37 more tests fall over with `PoisonError`.

On `main` @ c23c17ed, one thread, this desktop:

```
test result: FAILED. 1331 passed; 38 failed
  remote_im::engine::tests::engine_lang_follows_product_locale_not_hardcoded_zh
    panicked at src\remote_im\engine.rs:2081: unexpected catalog id ja
  … 37 × called `Result::unwrap()` on an `Err` value: PoisonError
```

Your runners are English, so CI never sees any of it.

## Verification

| Check | Result |
|---|---|
| `cargo check --tests` | pass |
| `cargo test`, one thread | **1,372 / 1,372** (was 1,331 / 1,369) |
| `cargo test`, default threads | 1,371 / 1,372 — the last one is the race #727 fixes |
| `pnpm typecheck` / `pnpm lint` | pass |

Three regression tests come with the fixes: the byte-slice panic, the character budget, and one that asserts every id in `tray_i18n::ALL` has its `new_chat` and `untitled` recognised — so the next locale cannot repeat #2.

## Two things I found but did not touch

- `ja/session.ts` has `"session.placeholderTitle": "新会话"` — Simplified Chinese in the Japanese catalog, while `tray_i18n`'s `JA` correctly says `"新しいチャット"`. So the tray and the stored title disagree for `ja`. It happens to survive #2 because `新会话` is on the legacy list, but it is still wrong copy. Left alone — it is a translation fix, not a logic one.
- The suite is not parallel-safe either: `plan_chrome::tests` repoints `GROK_APP_HOME` under a module-private `ENV_LOCK` instead of `paths::APP_HOME_ENV_LOCK`, so it moves the app home out from under whichever suite holds the real lock. That is a different bug from this one, so it is #727 rather than a fourth commit here. With both applied: 1,372 / 1,372 at default threads, three runs in a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

