### PR TITLE
fix(test): make cargo test parallel-safe again

### DIFF
--- a/src-tauri/src/agent_config_edit.rs
+++ b/src-tauri/src/agent_config_edit.rs
@@ -832,7 +832,7 @@ two_pass_compaction = true
 
     #[test]
     fn path_scope_is_agent_home() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let p = agent_config_toml();
         assert!(is_agent_home_config_path(&p));
         let other = PathBuf::from("/tmp/not-agent-home/config.toml");
@@ -841,7 +841,7 @@ two_pass_compaction = true
 
     #[test]
     fn load_and_save_roundtrip_independent() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = temp_app_home("roundtrip");
         let prev = std::env::var("GROK_APP_HOME").ok();
         std::env::set_var("GROK_APP_HOME", &tmp);
@@ -904,7 +904,7 @@ two_pass_compaction = true
 
     #[test]
     fn save_refuses_shared_mode() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = temp_app_home("shared");
         let prev = std::env::var("GROK_APP_HOME").ok();
         std::env::set_var("GROK_APP_HOME", &tmp);

--- a/src-tauri/src/agent_config_view.rs
+++ b/src-tauri/src/agent_config_view.rs
@@ -408,7 +408,7 @@ theme = "dark"
 
     #[test]
     fn read_missing_file_reports_exists_false() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = temp_app_home("missing");
         let prev = std::env::var("GROK_APP_HOME").ok();
         std::env::set_var("GROK_APP_HOME", &tmp);
@@ -426,7 +426,7 @@ theme = "dark"
 
     #[test]
     fn read_existing_file_redacts() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = temp_app_home("exists");
         let prev = std::env::var("GROK_APP_HOME").ok();
         std::env::set_var("GROK_APP_HOME", &tmp);

--- a/src-tauri/src/agent_memory.rs
+++ b/src-tauri/src/agent_memory.rs
@@ -1278,7 +1278,7 @@ mod tests {
         fs::write(ws.join("index.sqlite"), b"SQLite format 3\0fake").unwrap();
 
         // Point independent mode agent home at tmp via GROK_APP_HOME.
-        let _guard = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _guard = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Safety: only for this process during test.
         std::env::set_var("GROK_APP_HOME", &tmp);
         // agent-home is under app data; memory for independent is agent-home/memory
@@ -1440,7 +1440,7 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         ));
-        let _guard = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _guard = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("GROK_APP_HOME", &tmp);
         let agent_mem = tmp.join("agent-home").join("memory");
         let slug = "demo-search-cafe0123";

--- a/src-tauri/src/agent_memory_embed.rs
+++ b/src-tauri/src/agent_memory_embed.rs
@@ -828,7 +828,7 @@ api_key = "sk-abcdefghijklmnopqrstuvwxyz0123"
 
     #[test]
     fn load_and_save_roundtrip_independent() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = temp_app_home("roundtrip");
         let prev = std::env::var("GROK_APP_HOME").ok();
         std::env::set_var("GROK_APP_HOME", &tmp);
@@ -886,7 +886,7 @@ api_key = "sk-abcdefghijklmnopqrstuvwxyz0123"
 
     #[test]
     fn save_refuses_shared_mode() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = temp_app_home("shared");
         let prev = std::env::var("GROK_APP_HOME").ok();
         std::env::set_var("GROK_APP_HOME", &tmp);

--- a/src-tauri/src/agent_privacy.rs
+++ b/src-tauri/src/agent_privacy.rs
@@ -454,7 +454,7 @@ trace_upload = false
 
     #[test]
     fn load_and_save_roundtrip_independent() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = temp_app_home("roundtrip");
         let prev = std::env::var("GROK_APP_HOME").ok();
         std::env::set_var("GROK_APP_HOME", &tmp);
@@ -505,7 +505,7 @@ trace_upload = false
 
     #[test]
     fn save_refuses_shared_mode() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = temp_app_home("shared");
         let prev = std::env::var("GROK_APP_HOME").ok();
         std::env::set_var("GROK_APP_HOME", &tmp);

--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -2556,7 +2556,7 @@ mod tests {
     fn find_latest_prefers_newest_under_encoded_cwd() {
         use crate::paths::{percent_encode_path_component, APP_HOME_ENV_LOCK};
 
-        let _guard = APP_HOME_ENV_LOCK.lock().unwrap();
+        let _guard = APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let app_home = std::env::temp_dir().join(format!("cli-cont-{}", Uuid::new_v4()));
         let agent_home = app_home.join("agent-home");
         let proj = "/Users/me/continue-proj";
@@ -2620,7 +2620,7 @@ mod tests {
     fn find_latest_matches_trailing_slash_variant() {
         use crate::paths::{percent_encode_path_component, APP_HOME_ENV_LOCK};
 
-        let _guard = APP_HOME_ENV_LOCK.lock().unwrap();
+        let _guard = APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let app_home = std::env::temp_dir().join(format!("cli-cont2-{}", Uuid::new_v4()));
         let agent_home = app_home.join("agent-home");
         let proj = "/Users/me/slash-proj";

--- a/src-tauri/src/host_runtime.rs
+++ b/src-tauri/src/host_runtime.rs
@@ -154,7 +154,7 @@ mod tests {
     use uuid::Uuid;
 
     fn with_home<T>(f: impl FnOnce() -> T) -> T {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-host-runtime-{}-{}",
             std::process::id(),

--- a/src-tauri/src/plan_chrome.rs
+++ b/src-tauri/src/plan_chrome.rs
@@ -350,9 +350,11 @@ pub fn load_agent_plan_snapshot(session_id: &str) -> AgentPlanSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // GROK_APP_HOME is process-global, so the tests that repoint it take
+    // `paths::APP_HOME_ENV_LOCK`. A module-private lock only serialises
+    // this file and lets it move the app home out from under any other
+    // suite that is holding the real one.
 
     #[test]
     fn cap_body_truncates() {
@@ -364,7 +366,9 @@ mod tests {
 
     #[test]
     fn upsert_and_mark_stale_round_trip() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-plan-chrome-test-{}",
             uuid::Uuid::new_v4()

--- a/src-tauri/src/process_util.rs
+++ b/src-tauri/src/process_util.rs
@@ -717,7 +717,7 @@ mod tests {
     #[test]
     fn ensure_home_env_uses_userprofile_fallback_when_home_absent() {
         // Serialise against other env-mutating tests in this crate.
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev_home = std::env::var_os("HOME");
         let prev_profile = std::env::var_os("USERPROFILE");
         // Simulate Windows GUI: no HOME, only USERPROFILE (Unix falls back the same way).
@@ -741,7 +741,7 @@ mod tests {
 
     #[test]
     fn ensure_home_env_skips_when_home_already_set() {
-        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev_home = std::env::var_os("HOME");
         std::env::set_var("HOME", "/tmp/grok-app-home-test");
         assert!(home_env_present());

--- a/src-tauri/src/session_manager/routing_tests.rs
+++ b/src-tauri/src/session_manager/routing_tests.rs
@@ -509,7 +509,7 @@ fn empty_run_skips_when_saw_model_output_even_if_buf_cleared() {
 
 #[test]
 fn journal_assistant_after_last_user_detects_answered_turn() {
-    let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+    let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp =
         std::env::temp_dir().join(format!("grok-app-replay-gate-test-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&tmp);

--- a/src-tauri/src/session_manager/stall_tests.rs
+++ b/src-tauri/src/session_manager/stall_tests.rs
@@ -18,7 +18,7 @@ use serde_json::json;
 /// Isolate store writes (`force_end` → journal/meta) from the real app home.
 /// Without this, stall heal tests once rewrote production `sessions_index.json`.
 fn with_temp_app_home<R>(f: impl FnOnce() -> R) -> R {
-    let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+    let _lock = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = std::env::temp_dir().join(format!(
         "grok-app-stall-test-{}-{}",
         std::process::id(),

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -3729,7 +3729,7 @@ mod tests {
     fn create_session_defaults_to_orphan() {
         // Isolated home: parallel tests share default data dir and can race
         // atomic renames into sessions_index (macOS CI flake).
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-create-orphan-{}-{}",
             std::process::id(),
@@ -3748,7 +3748,7 @@ mod tests {
 
     #[test]
     fn set_session_worktree_marks_and_clears() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-wt-meta-{}-{}",
             std::process::id(),
@@ -3795,7 +3795,7 @@ mod tests {
 
     #[test]
     fn migrate_legacy_general_project_rehomes_sessions() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-migrate-general-{}-{}",
             std::process::id(),
@@ -3963,7 +3963,7 @@ mod tests {
 
     #[test]
     fn set_project_pinned_moves_to_group_end() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-pin-order-{}-{}",
             std::process::id(),
@@ -4010,7 +4010,7 @@ mod tests {
         // Effort is a per-chat decision even when model/mode memory is global:
         // raising it in one chat used to rewrite `settings.effort` and therefore
         // every other chat that had already picked its own.
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-effort-scope-{}-{}",
             std::process::id(),
@@ -4043,7 +4043,7 @@ mod tests {
     fn draft_effort_seeds_global_without_touching_existing_sessions() {
         // A draft chat has no row yet, so its effort seeds the default for the
         // next chat — it must not leak into a chat that already chose one.
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-effort-draft-{}-{}",
             std::process::id(),
@@ -4083,7 +4083,7 @@ mod tests {
 
     #[test]
     fn sessions_index_transaction_preserves_concurrent_mutations() {
-        let _env = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _env = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-store-index-rmw-{}-{}",
             std::process::id(),
@@ -4123,7 +4123,7 @@ mod tests {
 
     #[test]
     fn sessions_index_mutation_error_does_not_commit_partial_changes() {
-        let _env = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _env = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-store-index-error-{}-{}",
             std::process::id(),
@@ -4160,7 +4160,7 @@ mod tests {
 
     #[test]
     fn merged_message_save_keeps_concurrent_append_and_replace_truncates() {
-        let _env = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _env = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-store-journal-rmw-{}-{}",
             std::process::id(),
@@ -4261,7 +4261,7 @@ mod tests {
 
     #[test]
     fn set_session_project_keeps_agent_id_for_fork_restore() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-set-project-keep-agent-{}-{}",
             std::process::id(),
@@ -4292,7 +4292,7 @@ mod tests {
 
     #[test]
     fn move_session_to_project_clears_agent_and_worktree() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-move-session-{}-{}",
             std::process::id(),
@@ -4337,7 +4337,7 @@ mod tests {
 
     #[test]
     fn precheck_session_move_validates_before_any_write() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-move-precheck-{}-{}",
             std::process::id(),
@@ -4395,7 +4395,7 @@ mod tests {
 
     #[test]
     fn move_session_to_project_refuses_untrusted_and_missing() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-move-refuse-{}-{}",
             std::process::id(),

--- a/src-tauri/src/support_bundle.rs
+++ b/src-tauri/src/support_bundle.rs
@@ -732,7 +732,7 @@ mod tests {
     use super::*;
     #[test]
     fn reset_keeps_secrets_when_requested() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!("grok-app-reset-test-{}", std::process::id()));
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(tmp.join("sessions")).unwrap();
@@ -752,7 +752,7 @@ mod tests {
 
     #[test]
     fn support_bundle_creates_zip_without_secrets() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!("grok-app-bundle-test-{}", std::process::id()));
         let _ = fs::remove_dir_all(&tmp);
         fs::create_dir_all(tmp.join("logs")).unwrap();
@@ -815,7 +815,7 @@ mod tests {
 
     #[test]
     fn support_bundle_includes_redacted_stall_timeline() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp =
             std::env::temp_dir().join(format!("grok-app-bundle-stall-{}", std::process::id()));
         let _ = fs::remove_dir_all(&tmp);
@@ -876,7 +876,7 @@ mod tests {
 
     #[test]
     fn session_bundle_includes_messages_without_secrets() {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-app-session-bundle-test-{}",
             std::process::id()

--- a/src-tauri/src/turn_interrupt.rs
+++ b/src-tauri/src/turn_interrupt.rs
@@ -314,7 +314,7 @@ mod tests {
     use uuid::Uuid;
 
     fn with_home<T>(f: impl FnOnce(&PathBuf) -> T) -> T {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-turn-interrupt-{}-{}",
             std::process::id(),

--- a/src-tauri/src/turn_lease.rs
+++ b/src-tauri/src/turn_lease.rs
@@ -190,7 +190,7 @@ mod tests {
     use uuid::Uuid;
 
     fn with_home<T>(f: impl FnOnce(&PathBuf) -> T) -> T {
-        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _g = crate::paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "grok-turn-lease-{}-{}",
             std::process::id(),

--- a/src-tauri/src/video_poster.rs
+++ b/src-tauri/src/video_poster.rs
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn save_client_roundtrip_under_app_home() {
-        let _lock = paths::APP_HOME_ENV_LOCK.lock().unwrap();
+        let _lock = paths::APP_HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let home =
             std::env::temp_dir().join(format!("grok-app-poster-home-{}", std::process::id()));
         let _ = fs::remove_dir_all(&home);


### PR DESCRIPTION
> Rebased on `main` @ c23c17ed and re-measured there. The Windows build no longer needs #725 — you landed that fix yourself in c23c17ed.

`cargo test` without `--test-threads=1` is not reliable, and when it fails it hides why.

## The race

`GROK_APP_HOME` is process-global. Every suite that repoints it holds `paths::APP_HOME_ENV_LOCK` while it does — except `plan_chrome::tests`, which declares its own `static ENV_LOCK: Mutex<()>`. That serialises `plan_chrome.rs` against itself and nothing else, so it moves the app home out from under whichever suite is holding the real lock.

Which test dies depends on timing:

- `plan_chrome::tests::upsert_and_mark_stale_round_trip` writes its chrome to one home and reads from another → `expect("chrome saved")`.
- `integration_test::integration::project_add_trust_remove_roundtrip` asserts against a project list written to a different home.

## The amplifier

Whichever one loses, it panics **while holding** `APP_HOME_ENV_LOCK`. 38 of that lock's acquisitions were `.lock().unwrap()`, so the poisoned lock takes the rest of the suite with it — one race becomes a wall of `PoisonError` with the real failure buried near the top.

The lock guards a `()`. It serialises an environment variable, so a panic under it leaves no invariant broken and poisoning carries no information. `with_isolated_project_store` and `store::tests` already did `unwrap_or_else(|e| e.into_inner())`; this makes it uniform across all 38.

## Measured

On `main`:

| | |
|---|---|
| `--test-threads=1` | 1,372 / 1,372 with #726 |
| default threads | 1,371 / 1,372 — one genuine race failure |

After:

| | |
|---|---|
| default threads, 3 consecutive runs | **1,372 / 1,372 each** |

Two commits, one per problem — the lock fix alone is enough to stop the race; the poison-tolerance commit is what makes the *next* one legible.

Measured on `main` @ c23c17ed with #726 applied — without it the engine locale assertion fails on a non-English desktop and poisons this very lock, which buries the race under 37 `PoisonError`s. #726 does not touch any file here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

