### PR TITLE
fix(i18n): dates and clocks ignore the chosen language

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -139,28 +139,27 @@ pub fn build_menu(app: &AppHandle) -> Result<Menu<Wry>, tauri::Error> {
     builder.build()
 }
 
-/// Format quota refresh ISO → local `MM-DD HH:mm` (same as in-app user menu).
-fn format_reset_mm_dd_hm(iso: &str) -> Option<String> {
+/// Format quota refresh ISO → local short date and clock, in `fmt`.
+///
+/// `fmt` comes from the active locale's `TrayStrings`, so this stays the same
+/// instant the in-app user menu shows, written the way that language writes it.
+fn format_reset_time(iso: &str, fmt: &str) -> Option<String> {
     let s = iso.trim();
     if s.is_empty() {
         return None;
     }
     // Prefer RFC3339 (what BillingSnapshot writes).
     if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
-        return Some(
-            dt.with_timezone(&chrono::Local)
-                .format("%m-%d %H:%M")
-                .to_string(),
-        );
+        return Some(dt.with_timezone(&chrono::Local).format(fmt).to_string());
     }
     // Fallback: UTC Z without offset, or naive local.
     if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.fZ") {
         let dt = ndt.and_utc().with_timezone(&chrono::Local);
-        return Some(dt.format("%m-%d %H:%M").to_string());
+        return Some(dt.format(fmt).to_string());
     }
     if let Ok(ndt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%SZ") {
         let dt = ndt.and_utc().with_timezone(&chrono::Local);
-        return Some(dt.format("%m-%d %H:%M").to_string());
+        return Some(dt.format(fmt).to_string());
     }
     None
 }
@@ -190,7 +189,7 @@ fn usage_status_label(tr: &TrayStrings) -> String {
                 .pointer("/resetsAt")
                 .or_else(|| v.pointer("/resets_at"))
                 .and_then(|x| x.as_str())
-                .and_then(format_reset_mm_dd_hm);
+                .and_then(|s| format_reset_time(s, tr.reset_time_fmt));
             if let Some(r) = rem {
                 return match reset.as_deref() {
                     Some(t) => tray_i18n::format_usage(tr.usage_with_reset, Some(r), Some(t)),

--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -318,6 +318,12 @@ pub struct TrayStrings {
     pub usage_pct: &'static str,
     /// `Usage  ·  —`
     pub usage_unknown: &'static str,
+    /// `chrono` format for the reset clock inside `usage_with_reset`.
+    ///
+    /// Day-first locales must not read a month-first date, and `%p` appears
+    /// only where chrono's English "AM"/"PM" is the local convention — it has
+    /// no localized form, so every other locale gets a 24-hour clock.
+    pub reset_time_fmt: &'static str,
 }
 
 const EN: TrayStrings = TrayStrings {
@@ -336,6 +342,7 @@ const EN: TrayStrings = TrayStrings {
     usage_with_reset: "Usage  ·  {pct}% left  ·  {time}",
     usage_pct: "Usage  ·  {pct}% left",
     usage_unknown: "Usage  ·  —",
+    reset_time_fmt: "%m/%d %I:%M %p",
 };
 
 const DE: TrayStrings = TrayStrings {
@@ -354,6 +361,7 @@ const DE: TrayStrings = TrayStrings {
     usage_with_reset: "Nutzung  ·  {pct}% übrig  ·  {time}",
     usage_pct: "Nutzung  ·  {pct}% übrig",
     usage_unknown: "Nutzung  ·  —",
+    reset_time_fmt: "%d.%m. %H:%M",
 };
 
 const ES: TrayStrings = TrayStrings {
@@ -372,6 +380,7 @@ const ES: TrayStrings = TrayStrings {
     usage_with_reset: "Uso  ·  {pct}% restante  ·  {time}",
     usage_pct: "Uso  ·  {pct}% restante",
     usage_unknown: "Uso  ·  —",
+    reset_time_fmt: "%d/%m %H:%M",
 };
 
 const FIL: TrayStrings = TrayStrings {
@@ -390,6 +399,7 @@ const FIL: TrayStrings = TrayStrings {
     usage_with_reset: "Paggamit  ·  {pct}% natitira  ·  {time}",
     usage_pct: "Paggamit  ·  {pct}% natitira",
     usage_unknown: "Paggamit  ·  —",
+    reset_time_fmt: "%m/%d %I:%M %p",
 };
 
 const FR: TrayStrings = TrayStrings {
@@ -408,6 +418,7 @@ const FR: TrayStrings = TrayStrings {
     usage_with_reset: "Usage  ·  {pct}% restants  ·  {time}",
     usage_pct: "Usage  ·  {pct}% restants",
     usage_unknown: "Usage  ·  —",
+    reset_time_fmt: "%d/%m %H:%M",
 };
 
 const ID: TrayStrings = TrayStrings {
@@ -426,6 +437,7 @@ const ID: TrayStrings = TrayStrings {
     usage_with_reset: "Pemakaian  ·  sisa {pct}%  ·  {time}",
     usage_pct: "Pemakaian  ·  sisa {pct}%",
     usage_unknown: "Pemakaian  ·  —",
+    reset_time_fmt: "%d/%m %H:%M",
 };
 
 const IT: TrayStrings = TrayStrings {
@@ -444,6 +456,7 @@ const IT: TrayStrings = TrayStrings {
     usage_with_reset: "Utilizzo  ·  {pct}% rimasto  ·  {time}",
     usage_pct: "Utilizzo  ·  {pct}% rimasto",
     usage_unknown: "Utilizzo  ·  —",
+    reset_time_fmt: "%d/%m %H:%M",
 };
 
 const JA: TrayStrings = TrayStrings {
@@ -462,6 +475,7 @@ const JA: TrayStrings = TrayStrings {
     usage_with_reset: "使用量  ·  残り {pct}%  ·  {time}",
     usage_pct: "使用量  ·  残り {pct}%",
     usage_unknown: "使用量  ·  —",
+    reset_time_fmt: "%m/%d %H:%M",
 };
 
 const KO: TrayStrings = TrayStrings {
@@ -480,6 +494,7 @@ const KO: TrayStrings = TrayStrings {
     usage_with_reset: "사용량  ·  {pct}% 남음  ·  {time}",
     usage_pct: "사용량  ·  {pct}% 남음",
     usage_unknown: "사용량  ·  —",
+    reset_time_fmt: "%m. %d. %H:%M",
 };
 
 const PT_BR: TrayStrings = TrayStrings {
@@ -498,6 +513,7 @@ const PT_BR: TrayStrings = TrayStrings {
     usage_with_reset: "Uso  ·  {pct}% restante  ·  {time}",
     usage_pct: "Uso  ·  {pct}% restante",
     usage_unknown: "Uso  ·  —",
+    reset_time_fmt: "%d/%m %H:%M",
 };
 
 const RU: TrayStrings = TrayStrings {
@@ -516,6 +532,7 @@ const RU: TrayStrings = TrayStrings {
     usage_with_reset: "Лимит  ·  осталось {pct}%  ·  {time}",
     usage_pct: "Лимит  ·  осталось {pct}%",
     usage_unknown: "Лимит  ·  —",
+    reset_time_fmt: "%d.%m %H:%M",
 };
 
 const TA: TrayStrings = TrayStrings {
@@ -534,6 +551,7 @@ const TA: TrayStrings = TrayStrings {
     usage_with_reset: "பயன்பாடு  ·  {pct}% மீதம்  ·  {time}",
     usage_pct: "பயன்பாடு  ·  {pct}% மீதம்",
     usage_unknown: "பயன்பாடு  ·  —",
+    reset_time_fmt: "%d/%m %H:%M",
 };
 
 const UK: TrayStrings = TrayStrings {
@@ -552,6 +570,7 @@ const UK: TrayStrings = TrayStrings {
     usage_with_reset: "Ліміт  ·  залишилось {pct}%  ·  {time}",
     usage_pct: "Ліміт  ·  залишилось {pct}%",
     usage_unknown: "Ліміт  ·  —",
+    reset_time_fmt: "%d.%m %H:%M",
 };
 
 const ZH: TrayStrings = TrayStrings {
@@ -570,6 +589,7 @@ const ZH: TrayStrings = TrayStrings {
     usage_with_reset: "额度  ·  剩余 {pct}%  ·  {time}",
     usage_pct: "额度  ·  剩余 {pct}%",
     usage_unknown: "额度  ·  —",
+    reset_time_fmt: "%m/%d %H:%M",
 };
 
 const ZH_TW: TrayStrings = TrayStrings {
@@ -588,6 +608,7 @@ const ZH_TW: TrayStrings = TrayStrings {
     usage_with_reset: "額度  ·  剩餘 {pct}%  ·  {time}",
     usage_pct: "額度  ·  剩餘 {pct}%",
     usage_unknown: "額度  ·  —",
+    reset_time_fmt: "%m/%d %H:%M",
 };
 
 pub fn strings(locale: Locale) -> &'static TrayStrings {
@@ -722,6 +743,28 @@ mod tests {
                 l.as_tag()
             );
         }
+    }
+
+    #[test]
+    fn every_locale_renders_its_reset_clock() {
+        // chrono panics at Display time on a bad format spec, so render all 15
+        // rather than trusting the table by inspection.
+        let at = chrono::NaiveDate::from_ymd_opt(2026, 4, 15)
+            .unwrap()
+            .and_hms_opt(9, 5, 0)
+            .unwrap();
+        for l in ALL {
+            let out = at.format(strings(l).reset_time_fmt).to_string();
+            assert!(out.contains("15"), "{} lost the day: {out}", l.as_tag());
+            assert!(out.contains("05"), "{} lost the minute: {out}", l.as_tag());
+        }
+        // The reason the table exists at all.
+        let de = at.format(strings(Locale::De).reset_time_fmt).to_string();
+        let ja = at.format(strings(Locale::Ja).reset_time_fmt).to_string();
+        let en = at.format(strings(Locale::En).reset_time_fmt).to_string();
+        assert!(de.starts_with("15."), "de should be day-first: {de}");
+        assert!(ja.starts_with("04/"), "ja should be month-first: {ja}");
+        assert!(en.ends_with("AM"), "en should keep its 12-hour clock: {en}");
     }
 
     #[test]

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -405,6 +405,7 @@ import {
 import { AskUserModal, dropAskUserClocks } from "@/components/AskUserModal";
 import { TraceHistoryList } from "@/components/TraceHistoryList";
 import { PlanHistoryList } from "@/components/PlanHistoryList";
+import { formatListTimestamp } from "@/lib/formatDateTime";
 import { MarkdownBody } from "@/components/MarkdownBody";
 import {
   clearSessionSearchFilters,
@@ -23714,6 +23715,7 @@ export function AppWorkbench() {
       >
         <p className="trace-history-modal__desc">{tr("session.tracesDesc")}</p>
         <TraceHistoryList
+          locale={locale}
           labels={{
             empty: tr("session.tracesEmpty"),
             emptyFilter: tr("session.tracesEmptyFilter"),
@@ -23754,6 +23756,7 @@ export function AppWorkbench() {
       >
         <p className="plan-history-modal__desc">{tr("plan.historyDesc")}</p>
         <PlanHistoryList
+          locale={locale}
           labels={{
             empty: tr("plan.historyEmpty"),
             emptyFilter: tr("plan.historyEmptyFilter"),
@@ -23825,15 +23828,7 @@ export function AppWorkbench() {
               ) : null}
               {planHistoryPreview.at ? (
                 <span>
-                  {(() => {
-                    const d = Date.parse(planHistoryPreview.at);
-                    if (!Number.isFinite(d)) return planHistoryPreview.at;
-                    try {
-                      return new Date(d).toLocaleString();
-                    } catch {
-                      return planHistoryPreview.at;
-                    }
-                  })()}
+                  {formatListTimestamp(planHistoryPreview.at, locale)}
                 </span>
               ) : null}
             </div>

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -19881,6 +19881,7 @@ export function AppWorkbench() {
             onClose={() => setShowUserMenu(false)}
             theme={theme}
             themePreference={themePreference}
+            locale={locale}
             account={account}
             activeProvider={activeCustomProvider}
             accountBusy={accountBusy}

--- a/src/components/AccountPanel.tsx
+++ b/src/components/AccountPanel.tsx
@@ -266,8 +266,8 @@ export function AccountPanel({
   const usageKnown = isQuotaUsageKnown(billing);
   const { usedPercent: usedPct, remainingPercent: remaining } =
     resolveQuotaPercents(billing);
-  /** Same absolute clock as sidebar UserMenu (`MM-DD HH:mm`). */
-  const resetTime = formatQuotaResetTime(billing?.resetsAt);
+  /** Same absolute clock as the sidebar UserMenu. */
+  const resetTime = formatQuotaResetTime(billing?.resetsAt, locale);
 
   const heatDays = status?.heatmap ?? [];
   const heatHasSamples = useMemo(

--- a/src/components/MirrorConnectPanel.tsx
+++ b/src/components/MirrorConnectPanel.tsx
@@ -17,6 +17,7 @@ import { GlassModal } from "@/components/GlassModal";
 import { IconCopy, IconDeviceMobile } from "@/components/icons";
 import type { MirrorStatus } from "@/lib/api";
 import * as api from "@/lib/api";
+import { formatListTimestamp } from "@/lib/formatDateTime";
 import {
   clampMirrorMaxClients,
   formatMirrorClientCapLine,
@@ -197,6 +198,8 @@ export type MirrorConnectPanelProps = {
   open?: boolean;
   onClose?: () => void;
   labels: MirrorConnectLabels;
+  /** App locale, so the audit timestamps follow Settings and not the WebView. */
+  locale: string | null;
   /**
    * In-app confirm for stop / enable-write (no window.confirm).
    * Prefer GlassModal / setAppDialog from the parent.
@@ -457,22 +460,6 @@ function MirrorClientCapStrip({
   );
 }
 
-function formatAuditAt(iso: string): string {
-  const d = Date.parse(iso);
-  if (!Number.isFinite(d)) return iso || "";
-  try {
-    return new Date(d).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}
-
 function auditTypeLabel(
   type: MirrorWriteAuditType,
   labels: MirrorConnectLabels,
@@ -495,9 +482,11 @@ function auditTypeLabel(
 
 function MirrorWriteAuditSection({
   labels,
+  locale,
   onRequestConfirm,
 }: {
   labels: MirrorConnectLabels;
+  locale: string | null;
   onRequestConfirm: (opts: MirrorConfirmRequest) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -568,7 +557,7 @@ function MirrorWriteAuditSection({
             {events.map((e) => (
               <li key={e.id} className="mirror-connect__audit-row">
                 <span className="mirror-connect__audit-when" title={e.at}>
-                  {formatAuditAt(e.at)}
+                  {formatListTimestamp(e.at, locale)}
                 </span>
                 <span className="mirror-connect__audit-label">
                   {auditTypeLabel(e.type, labels)}
@@ -610,6 +599,7 @@ function MirrorWriteCategories({ labels }: { labels: MirrorConnectLabels }) {
 
 function MirrorConnectBody({
   labels,
+  locale,
   status,
   connect,
   busy,
@@ -626,6 +616,7 @@ function MirrorConnectBody({
   onRequestConfirm,
 }: {
   labels: MirrorConnectLabels;
+  locale: string | null;
   status: MirrorStatus;
   connect: MirrorHostConnectStatus;
   busy: boolean;
@@ -901,6 +892,7 @@ function MirrorConnectBody({
 
       <MirrorWriteAuditSection
         labels={labels}
+        locale={locale}
         onRequestConfirm={onRequestConfirm}
       />
     </>
@@ -912,6 +904,7 @@ export function MirrorConnectPanel({
   open = true,
   onClose,
   labels,
+  locale,
   onRequestConfirm,
   showToast,
   autoStart = true,
@@ -1153,6 +1146,7 @@ export function MirrorConnectPanel({
   const body = (
     <MirrorConnectBody
       labels={labels}
+      locale={locale}
       status={status}
       connect={connect}
       busy={busy}

--- a/src/components/PlanHistoryList.tsx
+++ b/src/components/PlanHistoryList.tsx
@@ -17,6 +17,7 @@ import {
   type PlanHistoryDecision,
   type PlanHistoryEntry,
 } from "@/lib/planHistory";
+import { formatListTimestamp } from "@/lib/formatDateTime";
 
 export type PlanHistoryDecisionFilter = "all" | PlanHistoryDecision;
 
@@ -38,6 +39,8 @@ export type PlanHistoryListLabels = {
 
 export type PlanHistoryListProps = {
   labels: PlanHistoryListLabels;
+  /** App locale, so the timestamps follow Settings and not the WebView. */
+  locale: string | null;
   onOpen?: (entry: PlanHistoryEntry) => void;
   /**
    * Open the chat that produced this plan when it still exists.
@@ -54,22 +57,6 @@ export type PlanHistoryListProps = {
   className?: string;
   compact?: boolean;
 };
-
-function formatAt(iso: string): string {
-  const d = Date.parse(iso);
-  if (!Number.isFinite(d)) return iso || "";
-  try {
-    return new Date(d).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}
 
 function decisionLabel(
   decision: PlanHistoryDecision,
@@ -90,6 +77,7 @@ function toSessionIdSet(
 
 export function PlanHistoryList({
   labels,
+  locale,
   onOpen,
   onOpenSession,
   existingSessionIds,
@@ -246,7 +234,7 @@ export function PlanHistoryList({
                       </span>
                       {e.at ? (
                         <span className="plan-history-row__when">
-                          {formatAt(e.at)}
+                          {formatListTimestamp(e.at, locale)}
                         </span>
                       ) : null}
                     </div>

--- a/src/components/TraceHistoryList.tsx
+++ b/src/components/TraceHistoryList.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { GlassModal } from "@/components/GlassModal";
 import { IconCopy, IconFolder, IconTrash } from "@/components/icons";
 import * as api from "@/lib/api";
+import { formatListTimestamp } from "@/lib/formatDateTime";
 import {
   TRACE_HISTORY_CHANGE_EVENT,
   TRACE_HISTORY_STORAGE_KEY,
@@ -69,6 +70,8 @@ export type TraceHistoryListLabels = {
 
 export type TraceHistoryListProps = {
   labels: TraceHistoryListLabels;
+  /** App locale, so the timestamps follow Settings and not the WebView. */
+  locale: string | null;
   /** Called after copy-path success (toast). */
   onCopied?: () => void;
   /** Called after reveal failure. */
@@ -77,22 +80,6 @@ export type TraceHistoryListProps = {
   /** Compact rows for modal. */
   compact?: boolean;
 };
-
-function formatExportedAt(iso: string): string {
-  const d = Date.parse(iso);
-  if (!Number.isFinite(d)) return iso || "";
-  try {
-    return new Date(d).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
-}
 
 function scopeLabel(
   scope: TraceHistoryScope,
@@ -107,6 +94,7 @@ function scopeLabel(
 
 export function TraceHistoryList({
   labels,
+  locale,
   onCopied,
   onError,
   className = "",
@@ -399,7 +387,7 @@ export function TraceHistoryList({
                     ) : null}
                     {e.exportedAt ? (
                       <span className="trace-history-row__when">
-                        {formatExportedAt(e.exportedAt)}
+                        {formatListTimestamp(e.exportedAt, locale)}
                       </span>
                     ) : null}
                   </div>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -60,6 +60,8 @@ export interface UserMenuProps {
   theme: Theme;
   /** Preference driving the theme submenu selection. */
   themePreference: ThemePreference;
+  /** App locale, so the quota reset clock follows Settings. */
+  locale: string;
   labels: {
     settings: string;
     /** Optional product tour entry label */
@@ -156,6 +158,7 @@ export function UserMenu({
   onClose,
   theme,
   themePreference,
+  locale,
   labels,
   account,
   activeProvider,
@@ -280,7 +283,7 @@ export function UserMenu({
   const livePercents = resolveQuotaPercents(billing ?? null);
   const usedPct = livePercents.usedPercent;
   const remaining = livePercents.remainingPercent;
-  const resetTime = formatQuotaResetTime(billing?.resetsAt);
+  const resetTime = formatQuotaResetTime(billing?.resetsAt, locale);
   const remainLabel = formatQuotaRemainLabel(remaining);
   const remainText = remainLabel ? `${remainLabel} ${labels.remaining}` : "—";
   const showSavedOfficialAccounts = signedIn && savedAccounts.length > 0;
@@ -377,7 +380,7 @@ export function UserMenu({
                   );
                   const rowRemain = q?.remainingPercent ?? null;
                   const rowUsed = q?.usedPercent ?? null;
-                  const rowReset = formatQuotaResetTime(q?.resetsAt);
+                  const rowReset = formatQuotaResetTime(q?.resetsAt, locale);
                   const rowRemainLabel = formatQuotaRemainLabel(rowRemain);
                   const low = rowRemain != null && rowRemain <= 10;
                   return (

--- a/src/components/settings/RemoteImSection.tsx
+++ b/src/components/settings/RemoteImSection.tsx
@@ -54,6 +54,7 @@ export function RemoteImSection() {
                   <MirrorConnectPanel
                     variant="inline"
                     open
+                    locale={locale}
                     labels={{
                       title: t("mirror.connectTitle"),
                       close: t("common.close"),

--- a/src/components/settings/RuntimeSection.tsx
+++ b/src/components/settings/RuntimeSection.tsx
@@ -743,6 +743,7 @@ export function RuntimeSection() {
                   </div>
                   <div className="trace-history-settings">
                     <TraceHistoryList
+                      locale={resolveLocale(locale)}
                       labels={{
                         empty: t("session.tracesEmpty"),
                         emptyFilter: t("session.tracesEmptyFilter"),

--- a/src/lib/accountUi.test.ts
+++ b/src/lib/accountUi.test.ts
@@ -182,13 +182,27 @@ describe("formatRelativeTime", () => {
 });
 
 describe("formatQuotaResetTime", () => {
-  it("formats MM-DD HH:mm in local time", () => {
-    // Fixed local instant via Date components
-    const d = new Date(2026, 3, 15, 9, 5); // Apr 15 09:05
-    const iso = d.toISOString();
-    expect(formatQuotaResetTime(iso)).toBe("04-15 09:05");
-    expect(formatQuotaResetTime(null)).toBe("");
-    expect(formatQuotaResetTime("not-a-date")).toBe("");
+  // Fixed local instant via Date components: Apr 15 09:05, whatever the
+  // runner's time zone is.
+  const iso = new Date(2026, 3, 15, 9, 5).toISOString();
+
+  it("orders the parts the way the locale does", () => {
+    // en-GB and en-US share a language and disagree on both of the things
+    // this function prints, so a passing assertion here means the tag really
+    // reached Intl rather than a hard-coded template.
+    expect(formatQuotaResetTime(iso, "en")).toContain("04/15");
+    expect(formatQuotaResetTime(iso, "de")).toContain("15.04");
+    expect(formatQuotaResetTime(iso, "ja")).toContain("04/15");
+  });
+
+  it("keeps the clock in local time", () => {
+    expect(formatQuotaResetTime(iso, "de")).toContain("09:05");
+  });
+
+  it("returns an empty string for nothing to show", () => {
+    expect(formatQuotaResetTime(null, "en")).toBe("");
+    expect(formatQuotaResetTime(undefined, "en")).toBe("");
+    expect(formatQuotaResetTime("not-a-date", "en")).toBe("");
   });
 });
 

--- a/src/lib/accountUi.ts
+++ b/src/lib/accountUi.ts
@@ -311,19 +311,27 @@ export function formatRelativeTime(
   return rtf.format(-day, "day");
 }
 
-/** Quota refresh time for menus: `MM-DD HH:mm` (local). */
+/**
+ * Quota refresh time for menus: month, day and clock in local time.
+ *
+ * The order and separators come from the locale. Hand-building `MM-DD HH:mm`
+ * reads as a date only to someone who already expects month first — a German
+ * user parses `04-15` as the 4th of month 15, and an en-US user loses the
+ * am/pm their clock format needs.
+ */
 export function formatQuotaResetTime(
   iso: string | null | undefined,
+  locale: string,
 ): string {
   if (!iso) return "";
   const t = Date.parse(iso);
   if (Number.isNaN(t)) return "";
-  const d = new Date(t);
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  const hh = String(d.getHours()).padStart(2, "0");
-  const min = String(d.getMinutes()).padStart(2, "0");
-  return `${mm}-${dd} ${hh}:${min}`;
+  return new Intl.DateTimeFormat(intlLocale(locale), {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(t));
 }
 
 export function isAccountConnected(status: AccountStatus | null): boolean {

--- a/src/lib/formatDateTime.test.ts
+++ b/src/lib/formatDateTime.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { formatListTimestamp } from "./formatDateTime";
+
+const ISO = "2026-04-15T09:05:00Z";
+
+describe("formatListTimestamp", () => {
+  it("follows the locale it is given", () => {
+    // Deliberately no exact-string assertions: the output also depends on the
+    // runner's time zone. What must hold is that the locale reaches Intl.
+    const ja = formatListTimestamp(ISO, "ja");
+    const de = formatListTimestamp(ISO, "de");
+    const en = formatListTimestamp(ISO, "en");
+
+    expect(ja).toContain("年");
+    expect(ja).toContain("月");
+    expect(de).not.toBe(en);
+    expect(new Set([ja, de, en]).size).toBe(3);
+  });
+
+  it("maps a catalog id to its full BCP-47 tag", () => {
+    // `zh` and `zh-TW` share a language but not a calendar rendering, so the
+    // helper must not collapse them onto the macrolanguage.
+    expect(formatListTimestamp(ISO, "zh")).not.toBe(
+      formatListTimestamp(ISO, "zh-TW"),
+    );
+  });
+
+  it("falls back to English for an unset or unknown locale", () => {
+    const en = formatListTimestamp(ISO, "en");
+    expect(formatListTimestamp(ISO, null)).toBe(en);
+    expect(formatListTimestamp(ISO, undefined)).toBe(en);
+    expect(formatListTimestamp(ISO, "kl")).toBe(en);
+  });
+
+  it("returns unparseable input untouched", () => {
+    expect(formatListTimestamp("not a date", "ja")).toBe("not a date");
+    expect(formatListTimestamp("", "ja")).toBe("");
+  });
+});

--- a/src/lib/formatDateTime.ts
+++ b/src/lib/formatDateTime.ts
@@ -1,0 +1,28 @@
+import { intlLocale } from "@/i18n";
+
+/**
+ * Absolute timestamp for history / audit lists.
+ *
+ * Takes the app locale rather than reading the WebView's: passing `undefined`
+ * to `toLocaleString` formats in whatever language the WebView reports, which
+ * is the OS language on some launch paths and `en-US` on others — never the
+ * language the user picked in Settings.
+ */
+export function formatListTimestamp(
+  iso: string,
+  locale: string | null | undefined,
+): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return iso || "";
+  try {
+    return new Intl.DateTimeFormat(intlLocale(locale), {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(t));
+  } catch {
+    return iso;
+  }
+}


### PR DESCRIPTION
> Rebased on `main` @ c23c17ed and re-measured there. The Windows build no longer needs #725 — you landed that fix yourself in c23c17ed.

Six places print a date or a clock. All six ignore the language the user picked in Settings.

| where | today | should be (de) |
|---|---|---|
| Plan history rows | `Apr 15, 2026, 09:05` | `15. Apr. 2026, 09:05` |
| Trace export rows | `Apr 15, 2026, 09:05` | `15. Apr. 2026, 09:05` |
| Mirror write-ACL audit | `Apr 15, 2026, 09:05` | `15. Apr. 2026, 09:05` |
| Plan history preview header | `4/15/2026, 9:05:00 AM` | `15.4.2026, 09:05:00` |
| Quota reset (user menu, saved accounts, account panel) | `04-15 09:05` | `15.04. 09:05` |
| Quota reset (native tray usage row) | `04-15 09:05` | `15.04. 09:05` |

## Why they were wrong

The first four called `toLocaleString(undefined, …)`. `undefined` does not mean "the app's language" — it means whatever the WebView reports, which is the OS language on some launch paths and `en-US` on others. Switching the app to German never reaches it.

The last two never asked a formatter at all: both hand-assembled `MM-DD HH:mm`. That string is a date only to a reader who already expects month first. A German user parses `04-15` as the 4th of month 15, and an en-US user never gets the am/pm their clock format needs.

## What changed

**One helper instead of four copies.** `PlanHistoryList`, `TraceHistoryList` and `MirrorConnectPanel` each carried a byte-identical `formatAt`/`formatExportedAt`/`formatAuditAt`, and `AppWorkbench` inlined a fourth. They are now one `formatListTimestamp(iso, locale)` in `src/lib/formatDateTime.ts`, built on the existing `intlLocale()` so `zh` resolves to `zh-CN` rather than the macrolanguage.

**`locale` is a required prop**, not optional. Optional would have left every call site that forgot it on the old behaviour, silently — which is the bug this PR is fixing. `UserMenu` had no locale at all and gains one; `AccountPanel`, `RuntimeSection` and `RemoteImSection` already had one in scope.

**The tray format lives in `TrayStrings`.** `reset_time_fmt` travels with the rest of that locale's tray copy, so adding a locale means filling one more field in a table the compiler already forces you to complete — not remembering that a `chrono` format string exists in another file. `%p` appears only for `en` and `fil`: chrono spells it `AM`/`PM` in English with no localized form, so a 12-hour clock would be wrong in the other thirteen.

## Verification

`pnpm typecheck` and `pnpm lint` pass. `pnpm test`: **6,166 / 6,166** on a checkout with #730 applied, or 6,165 / 6,166 without it — the one failure there is the CRLF assertion #730 fixes, in a file this PR does not touch.

`cargo test`: **1,373 / 1,373** at default threads, up one from the new locale test. Measured on `main` @ c23c17ed with #726 and #727 applied — without them `main` fails 38 tests on a non-English desktop before reaching anything here. Neither touches these files.

New tests: `formatDateTime.test.ts` (4) asserts the tag really reaches `Intl` rather than a template — `zh` and `zh-TW` must not collapse onto each other. `accountUi.test.ts`'s reset-time case now asserts `de` is day-first and `en` keeps 12-hour, instead of pinning the old hand-built shape. `tray_i18n.rs` renders all 15 formats, because `chrono` panics at `Display` time on a bad spec rather than at compile time.

## Note on the date order table

I picked each locale's short-date shape from the usual convention for that language (day-first for `de` `es` `fr` `id` `it` `pt-BR` `ru` `ta` `uk`, month-first for `en` `fil` `ja` `zh` `zh-TW`, and `ko` as `04. 15.`). The JS side does not need this — `Intl` knows — but the tray has no `Intl`, so the table is hand-written and worth a glance from anyone who reads one of those languages natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

