### PR TITLE
test(win): pnpm test is red on any Windows clone

### DIFF
--- a/src/lib/window-config.test.ts
+++ b/src/lib/window-config.test.ts
@@ -10,6 +10,16 @@ const CONF_PATH = resolve(TAURI_DIR, "tauri.conf.json");
 const MAC_PATH = resolve(TAURI_DIR, "tauri.macos.conf.json");
 const WIN_PATH = resolve(TAURI_DIR, "tauri.windows.conf.json");
 
+/**
+ * Read a source file for text assertions, normalized to LF.
+ *
+ * The repo stores LF, but git's default `core.autocrlf=true` on Windows writes
+ * CRLF into the working tree. Asserting on raw bytes then fails against source
+ * that is perfectly correct, and only ever for Windows contributors.
+ */
+const readSource = (path: string) =>
+  readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+
 describe("window chrome", () => {
   it("ships platform-specific window configs", () => {
     expect(existsSync(CONF_PATH)).toBe(true);
@@ -58,7 +68,7 @@ describe("window chrome", () => {
     // ToggleDesktop still minimizes when Grok is the only window.
     const winShell = resolve(TAURI_DIR, "src/win_shell.rs");
     expect(existsSync(winShell)).toBe(true);
-    const body = readFileSync(winShell, "utf8");
+    const body = readSource(winShell);
     expect(body).toMatch(/SetCurrentProcessExplicitAppUserModelID/);
     expect(body).toMatch(/WS_EX_APPWINDOW/);
     expect(body).toMatch(/ensure_main_window_shell_integration/);
@@ -69,7 +79,7 @@ describe("window chrome", () => {
   });
 
   it("user close keeps the macOS Dock icon", () => {
-    const tray = readFileSync(resolve(TAURI_DIR, "src/tray.rs"), "utf8");
+    const tray = readSource(resolve(TAURI_DIR, "src/tray.rs"));
     expect(tray).toContain("pub fn hide_to_tray");
     expect(tray).toContain("pub fn hide_to_tray_accessory");
     const hideFn = tray.slice(tray.indexOf("pub fn hide_to_tray("));
@@ -92,7 +102,7 @@ describe("window chrome", () => {
   });
 
   it("uses window-vibrancy for native frosted glass on macOS", () => {
-    const cargo = readFileSync(resolve(TAURI_DIR, "Cargo.toml"), "utf8");
+    const cargo = readSource(resolve(TAURI_DIR, "Cargo.toml"));
     expect(cargo).toMatch(/window-vibrancy/);
   });
 });


### PR DESCRIPTION
> Rebased on `main` @ c23c17ed and re-measured there. The Windows build no longer needs #725 — you landed that fix yourself in c23c17ed.

`pnpm test` fails on a fresh Windows clone, and the failure has nothing to do with the code.

```
FAIL src/lib/window-config.test.ts > window chrome > user close keeps the macOS Dock icon
```

## Why

The test asserts on the raw bytes of `tray.rs`:

```ts
expect(hideFn.startsWith("pub fn hide_to_tray(app: &AppHandle) {\n    hide_to_tray_inner(app, false);"))
```

The repo stores LF. Git's default on Windows is `core.autocrlf=true`, which writes CRLF into the working tree — so the file on disk has `\r\n`, `startsWith` returns false, and the assertion fails against source that is perfectly correct.

It is the worst shape of red: CI is green, the source is right, and a first-time Windows contributor has to work out that the failure is about their git config rather than their change.

## Measured

Pristine `main`, clean working tree, `git checkout-index -a -f` so every file carries the checkout's line endings:

| | |
|---|---|
| before | `window-config.test.ts` red |
| after | green |

It is the **only** failure on that tree: `main` is 6,165 / 6,166, and this takes it to 6,166 / 6,166.

## Scope

`readSource` also covers the other two source reads in the file (`win_shell.rs`, `Cargo.toml`). Those only use `toMatch` today, so they pass either way — but the next `\n` someone writes into an expectation there should not bring this back.

A repo-level `.gitattributes` with `* text=auto eol=lf` would stop the CRLF from ever reaching the working tree, and is the deeper fix. I deliberately did **not** put it in this PR: it rewrites every Windows contributor's checkout on their next pull, and that is a repo policy call that belongs to you rather than to a test fix. The helper is also the more complete of the two on its own — it covers checkouts made before such a file would exist, and source archives, which carry whatever line endings they were packed with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

