### PR TITLE
fix(i18n): the app boots in the wrong language, and "follow system" does not

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,42 +245,63 @@
         } catch (e) {
           /* ignore */
         }
+        /*
+         * Boot copy for every shipped catalog. The splash paints before the JS
+         * bundle arrives, so it cannot read src/i18n — src/i18n/bootShell.test.ts
+         * asserts each row still equals that locale's `setup.title` and
+         * `setup.detecting`, so the two cannot drift apart.
+         */
+        var BOOT_COPY = {
+          "de": ["Willkommen bei Grok", "Grok Build wird geprüft…"],
+          "en": ["Welcome to Grok", "Checking Grok Build…"],
+          "es": ["Te damos la bienvenida a Grok", "Comprobando Grok Build…"],
+          "fil": ["Maligayang pagdating sa Grok", "Sini-check ang Grok Build…"],
+          "fr": ["Bienvenue dans Grok", "Vérification de Grok Build…"],
+          "id": ["Selamat datang di Grok", "Memeriksa Grok Build…"],
+          "it": ["Benvenuto in Grok", "Verifica di Grok Build…"],
+          "ja": ["Grok へようこそ", "Grok Build を確認中…"],
+          "ko": ["Grok에 오신 것을 환영합니다", "Grok Build 확인 중…"],
+          "pt-BR": ["Boas-vindas ao Grok", "Verificando o Grok Build…"],
+          "ru": ["Добро пожаловать в Grok", "Проверка Grok Build…"],
+          "ta": ["Grok க்கு வரவேற்கிறோம்", "Grok Build ஐச் சரிபார்க்கிறது…"],
+          "uk": ["Ласкаво просимо до Grok", "Перевірка Grok Build…"],
+          "zh": ["欢迎使用 Grok", "正在检测 Grok Build…"],
+          "zh-TW": ["歡迎使用 Grok", "正在偵測 Grok Build…"]
+        };
         try {
           var loc = window.__GROK_BOOT_LOCALE__;
-          if (loc !== "zh" && loc !== "zh-TW" && loc !== "en") {
+          if (!BOOT_COPY[loc]) {
+            // No Host value: `vite dev` in a browser, or a settings id this
+            // build predates. Aliases mirror `normalizeLocale` in src/i18n.
             var nav = String(
               (navigator.languages && navigator.languages[0]) ||
                 navigator.language ||
                 "",
             ).toLowerCase();
-            if (
-              nav.indexOf("zh") === 0 &&
-              (nav.indexOf("tw") >= 0 ||
-                nav.indexOf("hk") >= 0 ||
-                nav.indexOf("hant") >= 0 ||
-                nav.indexOf("mo") >= 0)
-            ) {
-              loc = "zh-TW";
-            } else if (nav.indexOf("zh") === 0) {
-              loc = "zh";
+            if (nav.indexOf("zh") === 0) {
+              loc = /hant|tw|hk|mo/.test(nav) ? "zh-TW" : "zh";
+            } else if (nav.indexOf("pt") === 0) {
+              loc = "pt-BR";
+            } else if (nav.indexOf("tl") === 0) {
+              loc = "fil";
+            } else if (nav.indexOf("in") === 0) {
+              loc = "id";
             } else {
-              loc = "en";
+              var primary = nav.split(/[-_]/)[0];
+              loc = BOOT_COPY[primary] ? primary : "en";
             }
           }
-          var htmlLang =
-            loc === "zh" ? "zh-CN" : loc === "zh-TW" ? "zh-TW" : "en";
-          document.documentElement.setAttribute("lang", htmlLang);
-          var copy =
-            loc === "zh-TW"
-              ? { title: "歡迎使用 Grok", sub: "正在偵測 Grok Build…" }
-              : loc === "en"
-                ? { title: "Welcome to Grok", sub: "Checking Grok Build…" }
-                : { title: "欢迎使用 Grok", sub: "正在检测 Grok Build…" };
+          // Catalog ids are valid BCP-47 except `zh` (see htmlLangForLocale).
+          document.documentElement.setAttribute(
+            "lang",
+            loc === "zh" ? "zh-CN" : loc,
+          );
+          var copy = BOOT_COPY[loc] || BOOT_COPY["en"];
           var applyCopy = function () {
             var titleEl = document.querySelector(".boot-title");
             var subEl = document.querySelector(".boot-subtitle");
-            if (titleEl) titleEl.textContent = copy.title;
-            if (subEl) subEl.textContent = copy.sub;
+            if (titleEl) titleEl.textContent = copy[0];
+            if (subEl) subEl.textContent = copy[1];
           };
           if (document.querySelector(".boot-title")) applyCopy();
           else document.addEventListener("DOMContentLoaded", applyCopy);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -524,11 +524,7 @@ pub fn run() {
             let boot_locale = tray_i18n::Locale::parse(&boot_settings.locale);
             let boot_locale_tag = boot_locale.as_tag();
             let boot_os_lang = tray_i18n::detect_os_lang_tag();
-            let boot_html_lang = match boot_locale_tag {
-                "zh" => "zh-CN",
-                "zh-TW" => "zh-TW",
-                _ => "en",
-            };
+            let boot_html_lang = boot_locale.html_lang();
             let boot_theme_script = format!(
                 r#"(function(){{try{{Object.defineProperty(window,"__GROK_BOOT_THEME__",{{value:{theme:?},writable:false,configurable:false}});Object.defineProperty(window,"__GROK_BOOT_LOCALE__",{{value:{locale:?},writable:false,configurable:false}});Object.defineProperty(window,"__GROK_BOOT_OS_LANG__",{{value:{os_lang:?},writable:false,configurable:false}});var d=document.documentElement;if(d){{d.setAttribute("data-theme",{theme:?});d.setAttribute("lang",{html_lang:?});}}}}catch(e){{}}}})();"#,
                 theme = boot_theme,

--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -109,6 +109,16 @@ impl Locale {
         }
     }
 
+    /// `<html lang>` for the WebView. Catalog ids are already valid BCP-47
+    /// except `zh`, which must not reach the document as the macrolanguage.
+    /// Mirrors `htmlLangForLocale` in `src/i18n/index.ts`.
+    pub fn html_lang(self) -> &'static str {
+        match self {
+            Locale::Zh => "zh-CN",
+            other => other.as_tag(),
+        }
+    }
+
     /// English name of the language, for prompts that must name a target
     /// language to a model (see `session_title.rs`).
     pub fn english_name(self) -> &'static str {
@@ -721,6 +731,25 @@ mod tests {
                 "{} usage_with_reset",
                 l.as_tag()
             );
+        }
+    }
+
+    #[test]
+    fn html_lang_is_the_catalog_id_except_for_chinese() {
+        // A wrong `<html lang>` is invisible until it is not: it picks the
+        // font fallback, the hyphenation dictionary and how a screen reader
+        // pronounces the page.
+        assert_eq!(Locale::Zh.html_lang(), "zh-CN");
+        assert_eq!(Locale::ZhTw.html_lang(), "zh-TW");
+        for l in ALL {
+            let lang = l.html_lang();
+            assert!(!lang.is_empty(), "{} html_lang is empty", l.as_tag());
+            if l != Locale::En {
+                assert_ne!(lang, "en", "{} fell back to English", l.as_tag());
+            }
+            if l != Locale::Zh {
+                assert_eq!(lang, l.as_tag(), "{} should pass through", l.as_tag());
+            }
         }
     }
 

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -370,6 +370,7 @@ import {
   parseLocalePreference,
   htmlLangForLocale,
   resolveLocale,
+  readSystemLangTag,
   resolveLocaleFromSystem,
   resolveLocalePreference,
   DEFAULT_LOCALE_PREFERENCE,
@@ -3191,18 +3192,27 @@ export function AppWorkbench() {
   // Follow OS / browser UI language when preference is "system".
   useEffect(() => {
     if (localePreference !== "system") return;
-    const applySystem = () => {
-      const next = resolveLocaleFromSystem(
-        typeof navigator !== "undefined" ? navigator.language : null,
-      );
-      setLocale(next);
+    const applySystem = (tag: string | null) => {
+      setLocale(resolveLocaleFromSystem(tag));
     };
-    applySystem();
+    // `navigator.language` is the WebView's language, not the OS's: on a
+    // Windows box whose UI is Japanese it still reports `en-US`, so reading it
+    // meant "follow system" quietly settled on English. `readSystemLangTag`
+    // prefers the OS tag the Host injects and only then falls back to the
+    // navigator.
+    applySystem(readSystemLangTag());
     if (typeof window === "undefined" || !("addEventListener" in window)) {
       return;
     }
-    window.addEventListener("languagechange", applySystem);
-    return () => window.removeEventListener("languagechange", applySystem);
+    // A `languagechange` means the WebView's own list moved, which the tag
+    // captured at window build time cannot know about — trust it here.
+    const onLanguageChange = () =>
+      applySystem(
+        (typeof navigator !== "undefined" ? navigator.language : "") ||
+          readSystemLangTag(),
+      );
+    window.addEventListener("languagechange", onLanguageChange);
+    return () => window.removeEventListener("languagechange", onLanguageChange);
   }, [localePreference]);
 
 

--- a/src/i18n/bootShell.test.ts
+++ b/src/i18n/bootShell.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The boot splash paints before the JS bundle loads, so its copy lives as a
+ * table in index.html rather than a catalog lookup. Keep the two in step.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { LOCALES, messages } from "./messages";
+
+const INDEX_HTML = resolve(__dirname, "../../index.html");
+
+/** One row: `"ja": ["Grok \u3078\u3088\u3046\u3053\u305d", "..."],` */
+const ROW =
+  /^\s*"([A-Za-z-]+)":\s*\["((?:[^"\\]|\\.)*)",\s*"((?:[^"\\]|\\.)*)"\],?\s*$/gm;
+
+function readBootCopy(): Record<string, [string, string]> {
+  const html = readFileSync(INDEX_HTML, "utf8");
+  const start = html.indexOf("var BOOT_COPY = {");
+  expect(start, "BOOT_COPY table missing from index.html").toBeGreaterThan(-1);
+  const body = html.slice(start, html.indexOf("};", start));
+  const out: Record<string, [string, string]> = {};
+  for (const m of body.matchAll(ROW)) out[m[1]] = [m[2], m[3]];
+  return out;
+}
+
+describe("boot splash copy", () => {
+  const table = readBootCopy();
+
+  it("covers exactly the shipped catalogs", () => {
+    expect(Object.keys(table).sort()).toEqual([...LOCALES].sort());
+  });
+
+  it("says the same thing as each catalog's setup gate", () => {
+    // React swaps #root for the setup gate a moment later. A mismatch here
+    // shows the user two different sentences in the same second.
+    for (const locale of LOCALES) {
+      expect(table[locale], locale).toEqual([
+        messages[locale]["setup.title"],
+        messages[locale]["setup.detecting"],
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
> Rebased on `main` @ c23c17ed and re-measured there. The Windows build no longer needs #725 — you landed that fix yourself in c23c17ed.

Set the language to Japanese, restart, and the first thing on screen is `Welcome to Grok`. Set it to "Follow system" on a Japanese Windows box and the app stays English forever.

Three separate causes, one per commit.

## 1. "Follow system" read the WebView, not the system

`applySystem` resolved the locale from `navigator.language`. That is the WebView's language, not the OS's — WebView2 reports `en-US` on a Windows install whose UI language is Japanese. So the setting did nothing, and changing the system language did nothing either.

`readSystemLangTag()` already exists for exactly this and already prefers the OS tag the Host injects as `__GROK_BOOT_OS_LANG__`. This one call site simply never used it.

The `languagechange` handler keeps reading the navigator: that event means the WebView's own list moved, which a tag captured at window build time cannot know about.

## 2. `<html lang>` was `en` for twelve of fifteen locales

The Host sets `<html lang>` before first paint with:

```rust
let boot_html_lang = match boot_locale_tag {
    "zh" => "zh-CN",
    "zh-TW" => "zh-TW",
    _ => "en",
};
```

Every catalog except the two Chinese ones fell into that `_`. `<html lang>` is not decoration — it selects the font fallback (a shared CJK codepoint renders with the wrong regional glyph when the tag is wrong), the hyphenation dictionary, and how a screen reader pronounces the page.

Now `Locale::html_lang()`, mirroring `htmlLangForLocale` in `src/i18n/index.ts`, so the mapping sits next to the ids it maps and a new locale carries it automatically.

## 3. The splash spoke three languages out of fifteen

`index.html` paints before the JS bundle arrives, so its copy is a literal table. That table held `zh`, `zh-TW` and `en`. Anything else was **discarded — including a perfectly good `ja` the Host had already injected** — and re-derived from the navigator, which collapsed everything non-Chinese to English:

```js
var loc = window.__GROK_BOOT_LOCALE__;
if (loc !== "zh" && loc !== "zh-TW" && loc !== "en") {
  /* ignore what the Host said, guess from navigator, end up at "en" */
}
```

All fifteen are now filled in, taken verbatim from each catalog's `setup.title` and `setup.detecting` — the same two strings React shows a moment later when it swaps `#root` for the setup gate. `src/i18n/bootShell.test.ts` asserts they stay equal, because a table that drifts shows the user two different sentences within the same second.

The navigator fallback (browser `vite dev`, or a settings id the build predates) now walks the same table rather than collapsing to English, with the `pt` / `tl` / `in` aliases `normalizeLocale` already handles.

## Verification

`pnpm typecheck` and `pnpm lint` pass. `cargo test`: **1,373 / 1,373** at default threads, up one from the new `html_lang` test. Measured on `main` @ c23c17ed with #726 and #727 applied — without them `main` fails 38 tests on a non-English desktop before reaching anything here; neither touches these files.

`pnpm test`: **6,166 / 6,166** on a checkout with #730 applied. Without it the count is 6,165 / 6,166 — that one failure is `window-config.test.ts` asserting `tray.rs` source against `\n`, which is red on any Windows checkout with `core.autocrlf=true` and is what #730 fixes. Nothing to do with i18n, so it is its own PR rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

