### PR TITLE
fix(session): paint queued follow-up replies without remount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
+- **Queued follow-up reply no longer stays blank until you switch chats (#737)**: Turn-1 journal rehydrate (400/900ms) was copying the previous answer onto the queued `a-pending-*` bubble. Turn-2 tokens then looked like a replay and were dropped. Same-turn lift still runs once disk has the new user prompt; a stale Host `ready` no longer freezes that pending shell.
+- **User bubbles paint the hydrated draft, not a leftover `/goal` or `/skill` first line**: Optimistic send and reload already hydrates; the live bubble now uses the same text.
 - **Type-to-focus no longer doubles letters (#739)**: Printable keys only focus the composer. Chromium/WebView2 already types that key into the newly focused editor; a second `insertText` made `aa` from one `a` (#706). Space still inserts itself (`preventDefault` so the page does not scroll).
 - **Pet typing / settings / spin**: composer typing plays the catalog alert morph (slanted !) and returns to the chosen rest shape when keystrokes stop; Settings → Pet shape and rest-face clicks update the preview immediately; **Spin spin spin** restores the colorful orbit belts instead of collapsing to a point.
 - **Japanese UI is no longer two-thirds Simplified Chinese (#732)**: Settings / Doctor / extensions / session catalogs that still copied `zh` verbatim are Japanese. `session.placeholderTitle` is `新しいチャット` (matches the tray). A catalog test fails if a non-Chinese locale copies simplified-only Han from `zh`.
@@ -30,6 +32,8 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **排队跟进跑完后，不用切会话才看到回复（#737）**：上一轮 journal 补刷会把旧正文盖到新的空 pending 气泡上，跟进 token 被当成 replay 丢掉。磁盘追上新 user 之后仍会做同轮抬升；过期的 Host `ready` 也不会把排队中的 pending 结算掉。
+- **用户气泡按 hydrated 草稿画，不再露出 `/goal` / `/skill` 首行**。
 - **打字聚焦输入框不再重复字母（#739）**：可打印键只负责聚焦。Chromium/WebView2 会把该键打进刚聚焦的输入框；再 `insertText` 一次就会变成按 `a` 出 `aa`（#706）。空格仍自己插入（必须 `preventDefault`，否则会滚页面）。
 - **宠物打字 / 设置 / 转圈**：输入走目录里的警示（斜感叹号），停打后回到原形；设置里点形状和表情会马上反映到预览；「转转转」找回彩带轨道，不再缩成一个点。
 - **日语界面不再有三分之二简体中文（#732）**：原先原样复制 `zh` 的设置 / Doctor / 扩展 / 会话词条改为日语。`session.placeholderTitle` 与托盘一致为 `新しいチャット`。CI 会拦截非中文目录复制简体专用汉字。

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -402,14 +402,14 @@ function UserBodyText({
       return (
         <span className="user-msg-body">
           <HighlightedText
-            text={content}
+            text={hydrated}
             query={findQuery}
             activeOccurrence={findActiveOccurrence ?? null}
           />
         </span>
       );
     }
-    return <span className="user-msg-body">{content}</span>;
+    return <span className="user-msg-body">{hydrated}</span>;
   }
   return (
     <span className="user-msg-body">

--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -412,9 +412,7 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
               const cached: ChatMessage[] =
                 c.messagesBySessionRef.current.get(sid) ?? [];
               const base = shouldClear
-                ? cached.map((m) =>
-                    m.streaming ? { ...m, streaming: false } : m,
-                  )
+                ? settleStreamingOnHostReady(cached)
                 : cached;
               // Empty cache → journal is sole source (openSession may race-write).
               // Non-empty → lift longer journal tails into this session only.
@@ -422,6 +420,11 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
                 base.length === 0
                   ? woven
                   : upgradeMessagesFromJournal(base, woven);
+              // Lift may have filled the queued pending from disk. Settle
+              // again so a complete body is frozen and replay cannot append.
+              if (shouldClear) {
+                next = settleStreamingOnHostReady(next);
+              }
               if (stillBusy) {
                 next = ensureBusyTurnStreaming(next, hostState);
                 next = weaveToolsIntoAssistantSegments(next);

--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -21,6 +21,7 @@ import {
   upgradeMessagesFromJournal,
   weaveToolsIntoAssistantSegments,
   ensureBusyTurnStreaming,
+  settleStreamingOnHostReady,
   type AskUserPayload,
   type ChatMessage,
   type GeneratedImagePayload,
@@ -649,13 +650,12 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
                 // Session-scoped: a background chat going idle must not stop the
                 // clock of the chat the user is watching.
                 c.clearTurnClock(s.sessionId);
-                // Ensure no assistant is left with streaming=true after the turn
-                // (missed done chunk) — otherwise the next send can bind to it.
+                // Freeze the turn that just finished. Do not settle an
+                // optimistic queued pending — auto-flush may already have
+                // painted the next shell on this same ready.
                 c.setMessages((prev) => {
-                  if (!prev.some((m) => m.streaming)) return prev;
-                  const next = prev.map((m) =>
-                    m.streaming ? { ...m, streaming: false } : m,
-                  );
+                  const next = settleStreamingOnHostReady(prev);
+                  if (next === prev) return prev;
                   if (s.sessionId) {
                     c.messagesBySessionRef.current.set(s.sessionId, next);
                   }
@@ -772,10 +772,8 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
                 s.state !== "awaiting_permission"
               ) {
                 c.setMessages((prev) => {
-                  if (!prev.some((m) => m.streaming)) return prev;
-                  const next = prev.map((m) =>
-                    m.streaming ? { ...m, streaming: false } : m,
-                  );
+                  const next = settleStreamingOnHostReady(prev);
+                  if (next === prev) return prev;
                   c.messagesBySessionRef.current.set(s.sessionId!, next);
                   return next;
                 });

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1276,7 +1276,16 @@ describe("session projection", () => {
     expect(out.find((m) => m.id === "a-pending-1")?.content).toBe(
       "short follow-up",
     );
+    // Upgrade keeps the live flag; Host-ready settle then freezes a
+    // filled pending so a replay chunk cannot append.
     expect(out.find((m) => m.id === "a-pending-1")?.streaming).toBe(true);
+    const settled = settleStreamingOnHostReady(out);
+    expect(settled.find((m) => m.id === "a-pending-1")?.streaming).toBe(
+      false,
+    );
+    expect(settled.find((m) => m.id === "a-pending-1")?.content).toBe(
+      "short follow-up",
+    );
   });
 
   it("settleStreamingOnHostReady keeps a queued pending live", () => {
@@ -1313,6 +1322,20 @@ describe("session projection", () => {
     ];
     const next = settleStreamingOnHostReady(msgs);
     expect(next.find((m) => m.id === "host-a1")?.streaming).toBe(false);
+  });
+
+  it("settleStreamingOnHostReady freezes a solo current-turn pending", () => {
+    const msgs: ChatMessage[] = [
+      { id: "u1", role: "user", content: "first" },
+      {
+        id: "a-pending-1",
+        role: "assistant",
+        content: "",
+        streaming: true,
+      },
+    ];
+    const next = settleStreamingOnHostReady(msgs);
+    expect(next.find((m) => m.id === "a-pending-1")?.streaming).toBe(false);
   });
 
   it("applyStreamChunk binds queued-turn tokens to the pending shell, not turn 1", () => {

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -30,6 +30,8 @@ import {
   presentErrorBanner,
   snapshotOutgoingMessages,
   upgradeMessagesFromJournal,
+  canLiftJournalLastTurn,
+  settleStreamingOnHostReady,
   ensureBusyTurnStreaming,
   mergeSessionMessagesById,
   reconcileOptimisticDuplicates,
@@ -1214,6 +1216,132 @@ describe("session projection", () => {
     ];
     const out = upgradeMessagesFromJournal(ui, journal);
     expect(out.find((m) => m.id === "a1")?.content).toBe("昨晚那批已经清掉了。");
+  });
+
+  it("upgradeMessagesFromJournal does not copy the previous turn onto a queued pending", () => {
+    const turn1 =
+      "LONG TURN1 REPLY ".repeat(20);
+    const ui: ChatMessage[] = [
+      { id: "u1", role: "user", content: "long task" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: turn1,
+        streaming: false,
+      },
+      { id: "u-queued", role: "user", content: "ok continue" },
+      {
+        id: "a-pending-1",
+        role: "assistant",
+        content: "",
+        streaming: true,
+      },
+    ];
+    const journal: ChatMessage[] = [
+      { id: "u1", role: "user", content: "long task" },
+      { id: "a1", role: "assistant", content: turn1 },
+    ];
+    expect(canLiftJournalLastTurn(ui, journal)).toBe(false);
+    const out = upgradeMessagesFromJournal(ui, journal);
+    const pending = out.find((m) => m.id === "a-pending-1");
+    expect(pending?.content ?? "").toBe("");
+    expect(pending?.streaming).toBe(true);
+    expect(out.find((m) => m.id === "a1")?.content).toBe(turn1);
+  });
+
+  it("upgradeMessagesFromJournal still lifts the queued turn once disk has caught up", () => {
+    const ui: ChatMessage[] = [
+      { id: "u1", role: "user", content: "long task" },
+      { id: "a1", role: "assistant", content: "turn 1 answer" },
+      { id: "u-queued", role: "user", content: "ok continue" },
+      {
+        id: "a-pending-1",
+        role: "assistant",
+        content: "",
+        streaming: true,
+      },
+    ];
+    const journal: ChatMessage[] = [
+      { id: "u1", role: "user", content: "long task" },
+      { id: "a1", role: "assistant", content: "turn 1 answer" },
+      { id: "host-u2", role: "user", content: "ok continue" },
+      {
+        id: "host-a2",
+        role: "assistant",
+        content: "short follow-up",
+      },
+    ];
+    expect(canLiftJournalLastTurn(ui, journal)).toBe(true);
+    const out = upgradeMessagesFromJournal(ui, journal);
+    expect(out.find((m) => m.id === "a-pending-1")?.content).toBe(
+      "short follow-up",
+    );
+    expect(out.find((m) => m.id === "a-pending-1")?.streaming).toBe(true);
+  });
+
+  it("settleStreamingOnHostReady keeps a queued pending live", () => {
+    const msgs: ChatMessage[] = [
+      { id: "u1", role: "user", content: "first" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "answer one",
+        streaming: true,
+      },
+      { id: "u-queued", role: "user", content: "second" },
+      {
+        id: "a-pending-2",
+        role: "assistant",
+        content: "",
+        streaming: true,
+      },
+    ];
+    const next = settleStreamingOnHostReady(msgs);
+    expect(next.find((m) => m.id === "a1")?.streaming).toBe(false);
+    expect(next.find((m) => m.id === "a-pending-2")?.streaming).toBe(true);
+  });
+
+  it("settleStreamingOnHostReady still freezes the finished turn when nothing is queued", () => {
+    const msgs: ChatMessage[] = [
+      { id: "u1", role: "user", content: "first" },
+      {
+        id: "host-a1",
+        role: "assistant",
+        content: "answer one",
+        streaming: true,
+      },
+    ];
+    const next = settleStreamingOnHostReady(msgs);
+    expect(next.find((m) => m.id === "host-a1")?.streaming).toBe(false);
+  });
+
+  it("applyStreamChunk binds queued-turn tokens to the pending shell, not turn 1", () => {
+    const msgs: ChatMessage[] = [
+      { id: "u1", role: "user", content: "long task" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "turn 1 answer",
+        streaming: false,
+      },
+      { id: "u-queued", role: "user", content: "ok continue" },
+      {
+        id: "a-pending-1",
+        role: "assistant",
+        content: "",
+        streaming: true,
+      },
+    ];
+    const out = applyStreamChunk(msgs, {
+      sessionId: "s1",
+      messageId: "host-a2",
+      text: "short follow-up",
+      done: true,
+      kind: "assistant",
+    });
+    expect(out.find((m) => m.id === "a1")?.content).toBe("turn 1 answer");
+    expect(out.find((m) => m.id === "a-pending-1")).toBeUndefined();
+    expect(out.find((m) => m.id === "host-a2")?.content).toBe("short follow-up");
   });
 
   it("applyStreamChunk attaches a late answer onto a settled empty assistant", () => {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -2315,6 +2315,29 @@ function lastTurnAssistantIndex(messages: ChatMessage[]): number {
   return -1;
 }
 
+/** User prompts that start a turn (skip mid-turn 引导). */
+function promptUserCount(messages: ChatMessage[]): number {
+  let n = 0;
+  for (const m of messages) {
+    if (m.role === "user" && m.marker !== "interjection") n += 1;
+  }
+  return n;
+}
+
+/**
+ * Cross-id last-turn lift is only valid when journal has caught up to the
+ * UI's last user prompt. Queue flush paints the next `u-*` + empty
+ * `a-pending-*` while turn-1 rehydrate retries (400/900ms) still hold the
+ * previous journal; copying that longer body onto the pending bubble then
+ * makes turn-2 tokens look like a replay.
+ */
+export function canLiftJournalLastTurn(
+  ui: ChatMessage[],
+  journal: ChatMessage[],
+): boolean {
+  return promptUserCount(ui) <= promptUserCount(journal);
+}
+
 /**
  * After a turn ends, lift any longer body/thought/attachments from the journal
  * into the live UI list (same id, or last-turn id-mismatch heal).
@@ -2326,6 +2349,8 @@ function lastTurnAssistantIndex(messages: ChatMessage[]): number {
  * Cross-id heal: mid-turn reconcile can mint a new assistant UUID while the
  * live bubble still uses the stream id. Match the last turn's richest journal
  * body onto the UI's last assistant when it is strictly longer.
+ * Skip when the UI already has a newer user prompt than disk (queued
+ * follow-up painted during turn-1 rehydrate retries).
  */
 export function upgradeMessagesFromJournal(
   ui: ChatMessage[],
@@ -2395,10 +2420,16 @@ export function upgradeMessagesFromJournal(
     return out;
   });
 
-  // Last-turn cross-id heal (after per-id pass).
+  // Last-turn cross-id heal (after per-id pass). Skip when the UI already
+  // has a newer user prompt than disk — that's the queued follow-up, not
+  // an id mismatch on the turn that just finished.
   const uiAsstIdx = lastTurnAssistantIndex(next);
   const jAsstIdx = lastTurnAssistantIndex(journal);
-  if (uiAsstIdx >= 0 && jAsstIdx >= 0) {
+  if (
+    uiAsstIdx >= 0 &&
+    jAsstIdx >= 0 &&
+    canLiftJournalLastTurn(next, journal)
+  ) {
     const uiAsst = next[uiAsstIdx]!;
     const jAsst = journal[jAsstIdx]!;
     // Prefer the richest journal assistant in the same turn (not only the
@@ -2469,6 +2500,38 @@ export function upgradeMessagesFromJournal(
   }
 
   return changed ? next : ui;
+}
+
+/**
+ * Host `ready` for the turn that just finished. Freeze leftover streaming on
+ * older rows, but keep an optimistic queued pending (`a-pending-*` / `t-*`)
+ * after the last user — auto-flush may already have painted the next shell,
+ * and a stale ready must not settle it.
+ */
+export function settleStreamingOnHostReady(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  let lastUser = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role === "user" && m.marker !== "interjection") {
+      lastUser = i;
+      break;
+    }
+  }
+  let changed = false;
+  const next = messages.map((m, i) => {
+    if (m.role !== "assistant" || !m.streaming) return m;
+    if (
+      i > lastUser &&
+      (m.id.startsWith("a-pending-") || m.id.startsWith("t-"))
+    ) {
+      return m;
+    }
+    changed = true;
+    return { ...m, streaming: false };
+  });
+  return changed ? next : messages;
 }
 
 /**

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -2504,9 +2504,13 @@ export function upgradeMessagesFromJournal(
 
 /**
  * Host `ready` for the turn that just finished. Freeze leftover streaming on
- * older rows, but keep an optimistic queued pending (`a-pending-*` / `t-*`)
- * after the last user — auto-flush may already have painted the next shell,
- * and a stale ready must not settle it.
+ * older rows, but keep an *empty* optimistic queued pending (`a-pending-*` /
+ * `t-*`) after the last user when a follow-up is already on screen — auto-flush
+ * may have painted that shell, and a stale ready must not settle it.
+ *
+ * A filled pending (journal already lifted the body) is frozen so a later
+ * replay chunk cannot append. A solo current-turn pending is frozen the same
+ * as a host-id bubble.
  */
 export function settleStreamingOnHostReady(
   messages: ChatMessage[],
@@ -2519,12 +2523,15 @@ export function settleStreamingOnHostReady(
       break;
     }
   }
+  const queuedFollowUp = promptUserCount(messages) >= 2;
   let changed = false;
   const next = messages.map((m, i) => {
     if (m.role !== "assistant" || !m.streaming) return m;
     if (
+      queuedFollowUp &&
       i > lastUser &&
-      (m.id.startsWith("a-pending-") || m.id.startsWith("t-"))
+      (m.id.startsWith("a-pending-") || m.id.startsWith("t-")) &&
+      !(m.content ?? "").trim()
     ) {
       return m;
     }

--- a/src/lib/streamLateToken.test.ts
+++ b/src/lib/streamLateToken.test.ts
@@ -131,6 +131,42 @@ describe("shouldApplyLateStreamText", () => {
       }),
     ).toBe(true);
   });
+
+  it("applies to an empty queued pending after the previous turn settled", () => {
+    expect(
+      shouldApplyLateStreamText({
+        hostLiveStreaming: false,
+        chunkIsForFocusedHost: true,
+        messages: [
+          { role: "user", content: "long task" },
+          { role: "assistant", streaming: false, content: "turn 1 answer" },
+          { role: "user", content: "ok continue" },
+          { role: "assistant", streaming: false, content: "" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("drops tokens if a stale heal copied the previous turn onto the pending", () => {
+    // What the queued-turn bug looks like before canLiftJournalLastTurn:
+    // last assistant already has turn-1 body, so turn-2 tokens are replay.
+    expect(
+      shouldApplyLateStreamText({
+        hostLiveStreaming: false,
+        chunkIsForFocusedHost: true,
+        messages: [
+          { role: "user", content: "long task" },
+          { role: "assistant", streaming: false, content: "turn 1 answer" },
+          { role: "user", content: "ok continue" },
+          {
+            role: "assistant",
+            streaming: false,
+            content: "turn 1 answer",
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("shouldHealJournalOnStreamDone", () => {


### PR DESCRIPTION
Turn-1 journal rehydrate was copying the previous answer onto the queued empty pending bubble. Turn-2 tokens then looked like a replay and never painted. Switching sessions remounted from disk, so the reply “appeared” after a hop.

## What
- Skip last-turn cross-id lift when the UI already has a newer user prompt than disk (`canLiftJournalLastTurn`)
- On Host `ready`, freeze the finished turn but keep an `a-pending-*` / `t-*` shell after the last user (`settleStreamingOnHostReady`)
- User bubbles paint hydrated draft text (no leftover `/goal` / `/skill` first line)

## Tests
- `upgradeMessagesFromJournal does not copy the previous turn onto a queued pending`
- `upgradeMessagesFromJournal still lifts the queued turn once disk has caught up`
- `settleStreamingOnHostReady keeps a queued pending live`
- `applyStreamChunk binds queued-turn tokens to the pending shell, not turn 1`
- late-token: empty queued pending still applies; poisoned previous-turn body still drops

Closes #737
