### PR TITLE
fix(composer): type-to-focus no longer doubles letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
+- **Type-to-focus no longer doubles letters (#739)**: Printable keys only focus the composer. Chromium/WebView2 already types that key into the newly focused editor; a second `insertText` made `aa` from one `a` (#706). Space still inserts itself (`preventDefault` so the page does not scroll).
 - **Pet typing / settings / spin**: composer typing plays the catalog alert morph (slanted !) and returns to the chosen rest shape when keystrokes stop; Settings → Pet shape and rest-face clicks update the preview immediately; **Spin spin spin** restores the colorful orbit belts instead of collapsing to a point.
 - **Japanese UI is no longer two-thirds Simplified Chinese (#732)**: Settings / Doctor / extensions / session catalogs that still copied `zh` verbatim are Japanese. `session.placeholderTitle` is `新しいチャット` (matches the tray). A catalog test fails if a non-Chinese locale copies simplified-only Han from `zh`.
 - **Windows `pnpm test` no longer fails on a fresh clone (#730)**: `window-config.test.ts` now normalizes CRLF before asserting on Host source, so `core.autocrlf=true` checkouts stay green.
@@ -29,6 +30,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **打字聚焦输入框不再重复字母（#739）**：可打印键只负责聚焦。Chromium/WebView2 会把该键打进刚聚焦的输入框；再 `insertText` 一次就会变成按 `a` 出 `aa`（#706）。空格仍自己插入（必须 `preventDefault`，否则会滚页面）。
 - **宠物打字 / 设置 / 转圈**：输入走目录里的警示（斜感叹号），停打后回到原形；设置里点形状和表情会马上反映到预览；「转转转」找回彩带轨道，不再缩成一个点。
 - **日语界面不再有三分之二简体中文（#732）**：原先原样复制 `zh` 的设置 / Doctor / 扩展 / 会话词条改为日语。`session.placeholderTitle` 与托盘一致为 `新しいチャット`。CI 会拦截非中文目录复制简体专用汉字。
 - **Windows 全新 clone 上 `pnpm test` 不再红（#730）**：断言 Host 源码前把 CRLF 归一成 LF。

--- a/src/hooks/useTypeToFocusComposer.ts
+++ b/src/hooks/useTypeToFocusComposer.ts
@@ -7,6 +7,7 @@ import { querySidebarEl } from "@/lib/dragZone";
 import { isShortcutRecordingActive } from "@/lib/shortcutRemap";
 import {
   applyTypeToFocusComposer,
+  composerOwnsFocus,
   decideTypeToFocusComposer,
   isActivateKeyControl,
   isComposerRedirectBlocked,
@@ -49,7 +50,9 @@ export function useTypeToFocusComposer(opts: {
           enabled: live.enabled,
           overlayOpen: live.overlayOpen,
           recordingShortcut: isShortcutRecordingActive(),
-          blockedSurface: isComposerRedirectBlocked(target),
+          blockedSurface:
+            isComposerRedirectBlocked(target) ||
+            composerOwnsFocus(editor, document.activeElement),
           sidebarNavOwnsKey:
             sidebarOwns && isSidebarSessionNavKey(e.key),
           spaceActivatesControl:

--- a/src/lib/typeToFocusComposer.test.ts
+++ b/src/lib/typeToFocusComposer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  composerOwnsFocus,
   decideTypeToFocusComposer,
   isActivateKeyControl,
   isComposerRedirectBlocked,
@@ -160,15 +161,14 @@ describe("decideTypeToFocusComposer", () => {
     ).toEqual({ action: "focus", preventDefault: false });
   });
 
-  it("inserts printable keys and prevents default only for space", () => {
+  it("focuses printable keys; only Space inserts (and preventDefault)", () => {
+    // Letters must not insert: Chromium types into the newly focused editor.
     expect(decideTypeToFocusComposer(baseKey({ key: "h" }), ready)).toEqual({
-      action: "focus-and-insert",
-      text: "h",
+      action: "focus",
       preventDefault: false,
     });
     expect(decideTypeToFocusComposer(baseKey({ key: "/" }), ready)).toEqual({
-      action: "focus-and-insert",
-      text: "/",
+      action: "focus",
       preventDefault: false,
     });
     expect(decideTypeToFocusComposer(baseKey({ key: " " }), ready)).toEqual({
@@ -195,16 +195,31 @@ describe("decideTypeToFocusComposer", () => {
     }
   });
 
-  it("still inserts letters while a button is focused", () => {
+  it("still focuses for letters while a button is focused", () => {
     expect(
       decideTypeToFocusComposer(baseKey({ key: "a" }), {
         ...ready,
         spaceActivatesControl: true,
       }),
     ).toEqual({
-      action: "focus-and-insert",
-      text: "a",
+      action: "focus",
       preventDefault: false,
     });
+  });
+});
+
+describe("composerOwnsFocus", () => {
+  it("is true when the editor or a descendant is active", () => {
+    const child = { id: "child" } as unknown as EventTarget;
+    const editor = {
+      contains: (n: unknown) => n === child,
+    } as unknown as EventTarget;
+    expect(composerOwnsFocus(null, editor)).toBe(false);
+    expect(composerOwnsFocus(editor, null)).toBe(false);
+    expect(composerOwnsFocus(editor, editor)).toBe(true);
+    expect(composerOwnsFocus(editor, child)).toBe(true);
+    expect(
+      composerOwnsFocus(editor, { id: "other" } as unknown as EventTarget),
+    ).toBe(false);
   });
 });

--- a/src/lib/typeToFocusComposer.ts
+++ b/src/lib/typeToFocusComposer.ts
@@ -1,6 +1,8 @@
 /**
  * Type-to-focus composer: when the chat is frontmost but focus is not in
- * an input, a printable key focuses the composer and the character lands.
+ * an input, a printable key focuses the composer so the character lands
+ * there. Letters are focus-only (native types once). Space inserts after
+ * preventDefault so the page does not scroll.
  *
  * Decision is pure (no DOM). The hook applies focus / insert.
  */
@@ -116,6 +118,17 @@ export function isComposerRedirectBlocked(
   }
 }
 
+/** Composer already has the caret — never steal or re-insert. */
+export function composerOwnsFocus(
+  editor: EventTarget | null | undefined,
+  active: EventTarget | null | undefined,
+): boolean {
+  if (!editor || !active) return false;
+  if (editor === active) return true;
+  const node = editor as HTMLElement;
+  return typeof node.contains === "function" && node.contains(active as Node);
+}
+
 export function decideTypeToFocusComposer(
   e: TypeToFocusKey,
   ctx: TypeToFocusContext,
@@ -140,9 +153,14 @@ export function decideTypeToFocusComposer(
     return { action: "ignore" };
   }
 
-  // Space scrolls the page if we let the default through on body.
-  const preventDefault = e.key === " ";
-  return { action: "focus-and-insert", text: e.key, preventDefault };
+  // Letters: focus only. Inserting as well doubles the glyph in Chromium
+  // (WebView2) — the same key still types into the newly focused editor.
+  // Do not preventDefault: IME needs the key (macOS pinyin first letter).
+  if (e.key !== " ") {
+    return { action: "focus", preventDefault: false };
+  }
+  // Space would scroll the page if we let the default through on body.
+  return { action: "focus-and-insert", text: " ", preventDefault: true };
 }
 
 export function focusComposerForTyping(el: HTMLElement): void {
@@ -159,26 +177,6 @@ export function focusComposerForTyping(el: HTMLElement): void {
   } catch {
     /* ignore */
   }
-}
-
-/** Insert only if the engine did not already type into the newly focused editor. */
-export function scheduleInsertIfNeeded(el: HTMLElement, text: string): void {
-  if (typeof document === "undefined") return;
-  let canceled = false;
-  const onComp = () => {
-    canceled = true;
-  };
-  const onInput = () => {
-    canceled = true;
-  };
-  document.addEventListener("compositionstart", onComp, true);
-  el.addEventListener("input", onInput);
-  queueMicrotask(() => {
-    document.removeEventListener("compositionstart", onComp, true);
-    el.removeEventListener("input", onInput);
-    if (canceled || !el.isConnected) return;
-    insertTextIntoFocusedComposer(el, text);
-  });
 }
 
 export function insertTextIntoFocusedComposer(
@@ -200,6 +198,6 @@ export function applyTypeToFocusComposer(
 ): void {
   focusComposerForTyping(el);
   if (decision.action === "focus-and-insert") {
-    scheduleInsertIfNeeded(el, decision.text);
+    insertTextIntoFocusedComposer(el, decision.text);
   }
 }


### PR DESCRIPTION
## Summary
Type-to-focus (#706 / #704) inserted the first printable key twice on Windows/WebView2: capture-phase `focus()` plus a microtask `insertText`, while Chromium still typed the original key into the newly focused editor.

Fixes #739

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Behavior
- Printable letters / punctuation → **focus only** (`preventDefault: false` so IME can start)
- Space → `preventDefault` + insert (otherwise the page scrolls)
- Composer already focused (`activeElement` inside the editor) → ignore
- Removed the `queueMicrotask` fallback insert that raced native `input`

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (unit: `typeToFocusComposer`)
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only) — no Rust changes
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new strings
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — CHANGELOG Unreleased only
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

## Community
No prior Issue/PR/Discussion on this regression. Discussions disabled. Parent: #704 / #706.