### PR TITLE
fix(sidebar): align Other rows and nav icons with the project tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
-- **Other-session rows use the same left inset as project chats (#745)**: The Other group no longer keeps a shallower pad from the no-folder hierarchy and the later list-wrap reuse. Session rows share the project L3 inset.
+- **Sidebar tree text columns line up (#745)**: Projects and Other labels share one left edge. Project names and the session titles under them share `--tree-text-inset`. The L1 chevron column is 20px (was 28).
 - **Windows tray icon stays visible on a dark taskbar (#747)**: The notification-area mark is no longer a black glyph on transparency. Light taskbars get a black tile / white glyph; dark taskbars get the inverse. The host follows `SystemUsesLightTheme` (not the in-app theme) and swaps live.
 - **Windows “follow system” theme now switches with Personalization (#749)**: Boot still locks WebView2 form chrome, but that froze `prefers-color-scheme`, so the main window stayed put when the OS flipped. The host watches `AppsUseLightTheme` and the UI reapplies `data-theme`.
 - **Phone mirror serves the packaged SPA when dist is missing (#734)**: Filesystem `dist` / `GROK_MIRROR_DIST` still win in dev; packaged builds fall back to embedded `frontendDist`. Token gates on `/t/{token}` and `/assets` are unchanged.
@@ -41,7 +41,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
-- **「其他会话」子项左边距与项目内会话对齐（#745）**：不再沿用「无文件夹所以更浅」以及后来复用列表 wrap 时的补偿缩进。
+- **侧栏树文字列对齐（#745）**：Projects 与 Other 标题左缘对齐；项目名与其下会话标题共用 `--tree-text-inset`。一级箭头列从 28px 收到 20px。
 - **Windows 托盘在深色任务栏上不再隐身（#747）**：通知区不再用透明底黑标。浅色任务栏黑底白标，深色任务栏白底黑标。跟随任务栏 `SystemUsesLightTheme`（不是应用内主题），切换后即时换标。
 - **Windows「跟随系统」现在会跟个性化一起切（#749）**：启动锁 WebView2 表单颜色后，`prefers-color-scheme` 不再更新，系统换深浅色主窗不动。Host 改为监视 `AppsUseLightTheme`，前端重刷 `data-theme`。
 - **手机镜像在没有磁盘 dist 时改走打包内嵌前端（#734）**：开发模式仍优先文件系统 / `GROK_MIRROR_DIST`；正式包用 embedded `frontendDist`。`/t/{token}` 与 `/assets` 的 token 门不变。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
+- **Other-session rows use the same left inset as project chats (#745)**: The Other group no longer keeps a shallower pad from the no-folder hierarchy and the later list-wrap reuse. Session rows share the project L3 inset.
 - **Windows tray icon stays visible on a dark taskbar (#747)**: The notification-area mark is no longer a black glyph on transparency. Light taskbars get a black tile / white glyph; dark taskbars get the inverse. The host follows `SystemUsesLightTheme` (not the in-app theme) and swaps live.
 - **Windows “follow system” theme now switches with Personalization (#749)**: Boot still locks WebView2 form chrome, but that froze `prefers-color-scheme`, so the main window stayed put when the OS flipped. The host watches `AppsUseLightTheme` and the UI reapplies `data-theme`.
 - **Phone mirror serves the packaged SPA when dist is missing (#734)**: Filesystem `dist` / `GROK_MIRROR_DIST` still win in dev; packaged builds fall back to embedded `frontendDist`. Token gates on `/t/{token}` and `/assets` are unchanged.
@@ -40,6 +41,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **「其他会话」子项左边距与项目内会话对齐（#745）**：不再沿用「无文件夹所以更浅」以及后来复用列表 wrap 时的补偿缩进。
 - **Windows 托盘在深色任务栏上不再隐身（#747）**：通知区不再用透明底黑标。浅色任务栏黑底白标，深色任务栏白底黑标。跟随任务栏 `SystemUsesLightTheme`（不是应用内主题），切换后即时换标。
 - **Windows「跟随系统」现在会跟个性化一起切（#749）**：启动锁 WebView2 表单颜色后，`prefers-color-scheme` 不再更新，系统换深浅色主窗不动。Host 改为监视 `AppsUseLightTheme`，前端重刷 `data-theme`。
 - **手机镜像在没有磁盘 dist 时改走打包内嵌前端（#734）**：开发模式仍优先文件系统 / `GROK_MIRROR_DIST`；正式包用 embedded `frontendDist`。`/t/{token}` 与 `/assets` 的 token 门不变。

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -28,6 +28,11 @@
 | `--radius-full` | `9999px` | 头像、圆点状态 |
 | `--space-1` … `--space-8` | `4 / 8 / 12 / 16 / 20 / 24 / 32 / 48 px` | 间距阶梯 |
 | `--sidebar-width` | `260px` | 左栏默认（可拖 200–360） |
+| `--tree-rail-pad` | `10px` | 侧栏 nav / 会话列表共用左右内边距（图标列原点） |
+| `--tree-l1-gutter` | `--space-5`（20px） | 一级箭头 + New session 等图标槽 |
+| `--tree-l1-gutter-touch` | `44px` | 手机抽屉里只加宽 L1 箭头命中区 |
+| `--tree-l2-pad` / `--tree-l2-icon` / `--tree-l2-gap` | `--space-1` / `--space-4` / `6px` | 项目行：左垫 + 文件夹图标 + 间距 |
+| `--tree-text-inset` | 三者之和 | 项目名与会话标题左缘 |
 | `--aside-width` | `300px` | 右栏默认（可拖 240–420；可折叠 0） |
 | `--titlebar-height` | `40px` | 可拖拽顶区 |
 | `--input-min-height` | `52px` | 底部输入区最小高度 |

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -19802,11 +19802,13 @@ export function AppWorkbench() {
                 aria-expanded={historyOpen}
                 onClick={() => setHistoryOpen((v) => !v)}
               >
-                {historyOpen ? (
-                  <IconChevronDown size={14} />
-                ) : (
-                  <IconChevronRight size={14} />
-                )}
+                <span className="tree-l1__chevron" aria-hidden>
+                  {historyOpen ? (
+                    <IconChevronDown size={14} />
+                  ) : (
+                    <IconChevronRight size={14} />
+                  )}
+                </span>
                 <span className="tree-l1__label">
                   {tr("sidebar.otherSessions")}
                 </span>

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -230,6 +230,10 @@ describe("Other sessions tree wrap", () => {
 });
 
 describe("sidebar tree text columns", () => {
+  const tokens = readFileSync(
+    resolve(__dirname, "../styles/tokens.css"),
+    "utf8",
+  );
   const part1 = readFileSync(
     resolve(__dirname, "../styles/sidebar.part1.css"),
     "utf8",
@@ -238,19 +242,33 @@ describe("sidebar tree text columns", () => {
     resolve(__dirname, "../styles/sidebar.part2.css"),
     "utf8",
   );
+  const part4 = readFileSync(
+    resolve(__dirname, "../styles/sidebar.part4.css"),
+    "utf8",
+  );
   const src = readFileSync(
     resolve(__dirname, "../app/AppWorkbench.tsx"),
     "utf8",
   );
 
-  it("defines one L1 gutter and one text inset for L2 name + L3 title", () => {
-    expect(part1).toMatch(/--tree-l1-gutter:\s*20px/);
-    expect(part1).toMatch(/--tree-text-inset:\s*calc\(/);
+  it("assigns tree insets once in tokens.css", () => {
+    expect(tokens).toMatch(/--tree-rail-pad:\s*10px/);
+    expect(tokens).toMatch(/--tree-l1-gutter:\s*var\(--space-5\)/);
+    expect(tokens).toMatch(/--tree-text-inset:\s*calc\(/);
+    expect(part1).not.toMatch(/--tree-l1-gutter:/);
+    expect(part1).not.toMatch(/--tree-text-inset:/);
+  });
+
+  it("consumes tree tokens without px fallbacks", () => {
     expect(part1).toMatch(
-      /\.tree-l1__head--toggle,\s*\.tree-l1__chevron\s*\{[^}]*var\(--tree-l1-gutter/,
+      /\.tree-l1__head--toggle,\s*\.tree-l1__chevron\s*\{[^}]*var\(--tree-l1-gutter\)/,
     );
-    expect(part1).toMatch(/\.tree-l2\s*\{[^}]*var\(--tree-l2-pad/);
-    expect(part2).toMatch(/\.tree-l3\s*\{[^}]*var\(--tree-text-inset/);
+    expect(part1).toMatch(/\.tree-l2\s*\{[^}]*var\(--tree-l2-pad\)/);
+    expect(part2).toMatch(/\.tree-l3\s*\{[^}]*var\(--tree-text-inset\)/);
+    expect(part4).toMatch(/\.nav-item__icon\s*\{[^}]*var\(--tree-l1-gutter\)/);
+    expect(`${part1}\n${part2}\n${part4}`).not.toMatch(
+      /var\(--tree-[a-z0-9-]+,\s*[^)]+\)/,
+    );
   });
 
   it("wraps the Other chevron in the shared L1 gutter", () => {

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -217,4 +217,14 @@ describe("Other sessions tree wrap", () => {
       /className="tree-orphan"[\s\S]*SidebarTreeReveal open=\{historyOpen\}/,
     );
   });
+
+  it("keeps Other-session rows on the same left inset as project L3", () => {
+    const part2 = readFileSync(
+      resolve(__dirname, "../styles/sidebar.part2.css"),
+      "utf8",
+    );
+    expect(part2).not.toMatch(/\.tree-orphan\s+\.tree-l3-list-wrap/);
+    expect(part2).not.toMatch(/\.tree-l3--orphan\s*\{/);
+    expect(part2).not.toMatch(/\.tree-date-group--orphan/);
+  });
 });

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -228,3 +228,32 @@ describe("Other sessions tree wrap", () => {
     expect(part2).not.toMatch(/\.tree-date-group--orphan/);
   });
 });
+
+describe("sidebar tree text columns", () => {
+  const part1 = readFileSync(
+    resolve(__dirname, "../styles/sidebar.part1.css"),
+    "utf8",
+  );
+  const part2 = readFileSync(
+    resolve(__dirname, "../styles/sidebar.part2.css"),
+    "utf8",
+  );
+  const src = readFileSync(
+    resolve(__dirname, "../app/AppWorkbench.tsx"),
+    "utf8",
+  );
+
+  it("defines one L1 gutter and one text inset for L2 name + L3 title", () => {
+    expect(part1).toMatch(/--tree-l1-gutter:\s*20px/);
+    expect(part1).toMatch(/--tree-text-inset:\s*calc\(/);
+    expect(part1).toMatch(
+      /\.tree-l1__head--toggle,\s*\.tree-l1__chevron\s*\{[^}]*var\(--tree-l1-gutter/,
+    );
+    expect(part1).toMatch(/\.tree-l2\s*\{[^}]*var\(--tree-l2-pad/);
+    expect(part2).toMatch(/\.tree-l3\s*\{[^}]*var\(--tree-text-inset/);
+  });
+
+  it("wraps the Other chevron in the shared L1 gutter", () => {
+    expect(src).toMatch(/className="tree-l1__chevron"/);
+  });
+});

--- a/src/styles/phone.part1.css
+++ b/src/styles/phone.part1.css
@@ -242,9 +242,14 @@
     height: 44px;
   }
 
-  .app-shell--phone .tree-l1__head--toggle {
-    width: 44px;
-    min-width: 44px;
+  .app-shell--phone .tree-l1 {
+    --tree-l1-gutter: 44px;
+  }
+
+  .app-shell--phone .tree-l1__head--toggle,
+  .app-shell--phone .tree-l1__chevron {
+    width: var(--tree-l1-gutter, 44px);
+    min-width: var(--tree-l1-gutter, 44px);
   }
 
   .app-shell--phone .space-switcher__btn {

--- a/src/styles/phone.part1.css
+++ b/src/styles/phone.part1.css
@@ -243,13 +243,13 @@
   }
 
   .app-shell--phone .tree-l1 {
-    --tree-l1-gutter: 44px;
+    --tree-l1-gutter: var(--tree-l1-gutter-touch);
   }
 
   .app-shell--phone .tree-l1__head--toggle,
   .app-shell--phone .tree-l1__chevron {
-    width: var(--tree-l1-gutter, 44px);
-    min-width: var(--tree-l1-gutter, 44px);
+    width: var(--tree-l1-gutter);
+    min-width: var(--tree-l1-gutter);
   }
 
   .app-shell--phone .space-switcher__btn {

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -751,6 +751,14 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   flex-direction: column;
   gap: 2px;
   padding: 4px 10px 10px;
+  /* L1 chevron column; L2 name + L3 title share --tree-text-inset. */
+  --tree-l1-gutter: 20px;
+  --tree-l2-pad: 4px;
+  --tree-l2-icon: 16px;
+  --tree-l2-gap: 6px;
+  --tree-text-inset: calc(
+    var(--tree-l2-pad) + var(--tree-l2-icon) + var(--tree-l2-gap)
+  );
 }
 
 /*
@@ -793,7 +801,7 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 .tree-l1 {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 0;
   margin-top: 8px;
   margin-bottom: 4px;
   min-height: 28px;
@@ -803,11 +811,11 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 .tree-l1__head {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 0;
   flex: 1;
   min-width: 0;
   height: 28px;
-  padding: 0 8px;
+  padding: 0 8px 0 0;
   border-radius: var(--radius-md);
   color: var(--text-tertiary);
   font-size: 11px;
@@ -821,11 +829,14 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   color: var(--text-secondary);
 }
 
-.tree-l1__head--toggle {
+.tree-l1__head--toggle,
+.tree-l1__chevron {
   flex: 0 0 auto;
-  width: 28px;
-  min-width: 28px;
+  width: var(--tree-l1-gutter, 20px);
+  min-width: var(--tree-l1-gutter, 20px);
   padding: 0;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
 }
 
@@ -847,7 +858,7 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   min-width: 0;
   max-width: 100%;
   height: 28px;
-  padding: 0 6px 0 2px;
+  padding: 0 6px 0 0;
   border-radius: var(--radius-md);
   color: var(--text-tertiary);
   font-size: 11px;
@@ -1015,13 +1026,13 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 .tree-l2 {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--tree-l2-gap, 6px);
   width: 100%;
   height: 32px;
   min-height: 32px;
   max-height: 32px;
   box-sizing: border-box;
-  padding: 0 6px 0 8px;
+  padding: 0 6px 0 var(--tree-l2-pad, 4px);
   border-radius: 8px;
   color: var(--text-secondary);
   font-size: 13px;
@@ -1171,7 +1182,7 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
+  width: var(--tree-l2-icon, 16px);
   opacity: 0.9;
   flex-shrink: 0;
 }

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -750,15 +750,7 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  padding: 4px 10px 10px;
-  /* L1 chevron column; L2 name + L3 title share --tree-text-inset. */
-  --tree-l1-gutter: 20px;
-  --tree-l2-pad: 4px;
-  --tree-l2-icon: 16px;
-  --tree-l2-gap: 6px;
-  --tree-text-inset: calc(
-    var(--tree-l2-pad) + var(--tree-l2-icon) + var(--tree-l2-gap)
-  );
+  padding: 4px var(--tree-rail-pad) 10px;
 }
 
 /*
@@ -832,8 +824,8 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 .tree-l1__head--toggle,
 .tree-l1__chevron {
   flex: 0 0 auto;
-  width: var(--tree-l1-gutter, 20px);
-  min-width: var(--tree-l1-gutter, 20px);
+  width: var(--tree-l1-gutter);
+  min-width: var(--tree-l1-gutter);
   padding: 0;
   display: inline-flex;
   align-items: center;
@@ -1026,13 +1018,13 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 .tree-l2 {
   display: flex;
   align-items: center;
-  gap: var(--tree-l2-gap, 6px);
+  gap: var(--tree-l2-gap);
   width: 100%;
   height: 32px;
   min-height: 32px;
   max-height: 32px;
   box-sizing: border-box;
-  padding: 0 6px 0 var(--tree-l2-pad, 4px);
+  padding: 0 6px 0 var(--tree-l2-pad);
   border-radius: 8px;
   color: var(--text-secondary);
   font-size: 13px;
@@ -1182,7 +1174,7 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: var(--tree-l2-icon, 16px);
+  width: var(--tree-l2-icon);
   opacity: 0.9;
   flex-shrink: 0;
 }

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -175,11 +175,7 @@
   flex-shrink: 0;
 }
 
-.tree-orphan .tree-l3-list-wrap {
-  padding-left: 4px;
-}
-
-/* Orphan sessions under “Other sessions” (same row metrics as project L3). */
+/* Orphan sessions under Other (same row metrics and left inset as project L3). */
 .tree-orphan-list {
   display: flex;
   flex-direction: column;
@@ -219,11 +215,6 @@
   box-shadow: 0 1px 0 color-mix(in srgb, var(--border-subtle, transparent) 70%, transparent);
   user-select: none;
   pointer-events: none;
-}
-
-.tree-orphan-list .tree-date-group__head,
-.tree-date-group--orphan .tree-date-group__head {
-  padding-left: 8px;
 }
 
 html[data-sidebar-density="compact"] .tree-date-group__head {
@@ -272,11 +263,6 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
 
 .tree-l3--archived {
   opacity: 0.55;
-}
-
-.tree-l3--orphan {
-  margin-left: 0;
-  padding-left: 8px;
 }
 
 .tree-l3--hint {

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -202,7 +202,7 @@
   align-items: center;
   height: 22px;
   min-height: 22px;
-  padding: 0 6px 0 var(--tree-text-inset, 26px);
+  padding: 0 6px 0 var(--tree-text-inset);
   margin: 0;
   box-sizing: border-box;
   font-size: 11px;
@@ -239,7 +239,7 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   min-height: 30px;
   max-height: 30px;
   box-sizing: border-box;
-  padding: 0 6px 0 var(--tree-text-inset, 26px);
+  padding: 0 6px 0 var(--tree-text-inset);
   border-radius: 8px;
   color: var(--text-secondary);
   font-size: 13px;

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -157,7 +157,7 @@
 
 /* Outer wrap keeps trust hint / empty state outside the windowed list. */
 .tree-l3-list-wrap {
-  padding: 2px 0 6px 12px;
+  padding: 2px 0 6px;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -202,7 +202,7 @@
   align-items: center;
   height: 22px;
   min-height: 22px;
-  padding: 0 6px 0 12px;
+  padding: 0 6px 0 var(--tree-text-inset, 26px);
   margin: 0;
   box-sizing: border-box;
   font-size: 11px;
@@ -239,7 +239,7 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   min-height: 30px;
   max-height: 30px;
   box-sizing: border-box;
-  padding: 0 6px 0 12px;
+  padding: 0 6px 0 var(--tree-text-inset, 26px);
   border-radius: 8px;
   color: var(--text-secondary);
   font-size: 13px;

--- a/src/styles/sidebar.part4.css
+++ b/src/styles/sidebar.part4.css
@@ -1,7 +1,7 @@
 /* domain CSS chunk (move-only split; selectors unchanged) */
 
 html[data-sidebar-density="compact"] .tree-l3-list-wrap {
-  padding: 1px 0 4px 12px;
+  padding: 1px 0 4px;
   gap: 0;
 }
 

--- a/src/styles/sidebar.part4.css
+++ b/src/styles/sidebar.part4.css
@@ -88,7 +88,7 @@ html[data-sidebar-density="compact"] .session-row__meta {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  padding: 4px 10px 8px;
+  padding: 4px var(--tree-rail-pad) 8px;
   flex-shrink: 0;
 }
 
@@ -96,6 +96,7 @@ html[data-sidebar-density="compact"] .session-row__meta {
 .sidebar-nav .nav-item {
   width: 100%;
   margin: 0;
+  padding-left: 0;
 }
 
 .nav-new {
@@ -146,7 +147,11 @@ html[data-sidebar-density="compact"] .session-row__meta {
 }
 
 .nav-item__icon {
-  width: 16px;
+  width: var(--tree-l1-gutter);
+  min-width: var(--tree-l1-gutter);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   opacity: 0.85;
   font-size: 13px;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -28,6 +28,19 @@
   --space-8: 48px;
 
   --sidebar-width: 260px;
+  /*
+   * Sidebar tree columns (nav icons, L1 chevron, L2 name, L3 title).
+   * Change values here only — consumers use var() with no px fallback.
+   */
+  --tree-rail-pad: 10px;
+  --tree-l1-gutter: var(--space-5);
+  --tree-l1-gutter-touch: 44px;
+  --tree-l2-pad: var(--space-1);
+  --tree-l2-icon: var(--space-4);
+  --tree-l2-gap: 6px;
+  --tree-text-inset: calc(
+    var(--tree-l2-pad) + var(--tree-l2-icon) + var(--tree-l2-gap)
+  );
   --aside-width: 400px;
   --titlebar-height: 40px;
   /* Self-drawn min/max/close (Win / custom chrome): 3 × 46px */


### PR DESCRIPTION
## Summary
Other-session rows sat on a shallower left inset than chats under a project folder (legacy “no L2, so align with L2” plus a wrap-reuse compensation). Projects / Other labels and the primary-nav icons (New session, Scheduled, Agents, Connect device) were also off the L1 chevron column.

Fixes #745

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Behavior
- Projects and Other labels share one left edge (`--tree-l1-gutter`)
- Project name and the session titles under it share `--tree-text-inset`
- Primary-nav icons use the same L1 gutter as the Projects chevron
- Insets are defined once in `tokens.css`; CSS consumes `var()` with no px fallbacks
- Phone only widens the L1 chevron hit target (`--tree-l1-gutter-touch`)

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` — unit: `treeReveal` (19) + `SidebarSessionRow` / `SidebarTreeReveal`
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only) — no Rust changes
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new strings
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — `docs/design-tokens.md` + CHANGELOG Unreleased
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

## Community
No prior Issue/PR/Discussion on this inset. Searched `RongleCat/grok-app` for Other-session indent / `tree-l3--orphan` / tree text columns — no match (unrelated hits: #616 move-between-projects, #694 collapse interpolation).
