### PR TITLE
fix(windows): follow OS light/dark in the main window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
+- **Windows “follow system” theme now switches with Personalization (#749)**: Boot still locks WebView2 form chrome, but that froze `prefers-color-scheme`, so the main window stayed put when the OS flipped. The host watches `AppsUseLightTheme` and the UI reapplies `data-theme`.
 - **Phone mirror serves the packaged SPA when dist is missing (#734)**: Filesystem `dist` / `GROK_MIRROR_DIST` still win in dev; packaged builds fall back to embedded `frontendDist`. Token gates on `/t/{token}` and `/assets` are unchanged.
 - **macOS green zoom no longer deadlocks the UI (#735)**: After a resize/move debounce, window-state persist hops back to the main thread before `save_window_state`. The plugin mutex + macOS geometry getters could AB-deadlock when maximize fired a Resized storm.
 - **Queued follow-up reply no longer stays blank until you switch chats (#737)**: Turn-1 journal rehydrate (400/900ms) was copying the previous answer onto the queued `a-pending-*` bubble. Turn-2 tokens then looked like a replay and were dropped. Same-turn lift still runs once disk has the new user prompt; a stale Host `ready` no longer freezes that pending shell.
@@ -38,6 +39,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **Windows「跟随系统」现在会跟个性化一起切（#749）**：启动锁 WebView2 表单颜色后，`prefers-color-scheme` 不再更新，系统换深浅色主窗不动。Host 改为监视 `AppsUseLightTheme`，前端重刷 `data-theme`。
 - **手机镜像在没有磁盘 dist 时改走打包内嵌前端（#734）**：开发模式仍优先文件系统 / `GROK_MIRROR_DIST`；正式包用 embedded `frontendDist`。`/t/{token}` 与 `/assets` 的 token 门不变。
 - **macOS 点绿色放大不再卡死（#735）**：resize/move debounce 到期后先 hop 回主线程再 `save_window_state`。插件 mutex 加上跨线程几何查询会在 maximize 的 Resized 风暴里 AB 死锁。
 - **排队跟进跑完后，不用切会话才看到回复（#737）**：上一轮 journal 补刷会把旧正文盖到新的空 pending 气泡上，跟进 token 被当成 replay 丢掉。磁盘追上新 user 之后仍会做同轮抬升；过期的 Host `ready` 也不会把排队中的 pending 结算掉。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -186,6 +186,8 @@ mod tray;
 
 mod tray_i18n;
 
+mod os_theme;
+
 mod desktop_notify;
 
 mod turn_complete;
@@ -567,6 +569,8 @@ pub fn run() {
             // Lock WebView / native form chrome to the boot theme on every OS.
             // Windows WebView2 otherwise follows the OS scheme, so number/date/time
             // inputs paint as black boxes on a light Settings page (Agent tab).
+            // Live follow-system on Windows is os_theme::watch → frontend — this
+            // lock freezes prefers-color-scheme inside WebView2.
             let _ = window.set_theme(Some(if boot_theme == "light" {
                 tauri::Theme::Light
             } else {
@@ -673,6 +677,9 @@ pub fn run() {
             if let Err(e) = tray::setup_tray(app.handle()) {
                 tracing::warn!("tray setup: {e}");
             }
+
+            // Windows: AppsUseLightTheme → frontend (WebView2 matchMedia stays frozen).
+            os_theme::watch(app.handle());
 
             // macOS: pin notification delivery to com.grokapp.desktop and request
             // UNUserNotificationCenter auth so Grok appears in System Settings.
@@ -1283,6 +1290,8 @@ pub fn run() {
 
             tray::tray_set_busy_count,
 
+            os_theme::os_theme_current,
+
             desktop_notify::desktop_notify_show,
 
             desktop_notify::desktop_notify_available,
@@ -1574,62 +1583,12 @@ fn resolve_boot_theme(pref: &str) -> &'static str {
         "dark" => "dark",
         // system / empty / unknown
         _ => {
-            if os_prefers_dark() {
+            if os_theme::os_prefers_dark() {
                 "dark"
             } else {
                 "light"
             }
         }
-    }
-}
-
-/// Best-effort OS dark/light probe (no extra deps).
-fn os_prefers_dark() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        // AppleInterfaceStyle is set only in dark mode; missing → light.
-        let out = process_util::command("defaults")
-            .args(["read", "-g", "AppleInterfaceStyle"])
-            .output();
-        if let Ok(o) = out {
-            let s = String::from_utf8_lossy(&o.stdout).to_ascii_lowercase();
-            return s.contains("dark");
-        }
-        return true;
-    }
-    #[cfg(target_os = "windows")]
-    {
-        // AppsUseLightTheme DWORD: 0 = dark apps, 1 = light.
-        // `reg query` is a console app — hide the window (Fixes boot black flash).
-        let out = process_util::command("reg")
-            .args([
-                "query",
-                r"HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
-                "/v",
-                "AppsUseLightTheme",
-            ])
-            .output();
-        if let Ok(o) = out {
-            let s = String::from_utf8_lossy(&o.stdout);
-            for line in s.lines() {
-                if !line.contains("AppsUseLightTheme") {
-                    continue;
-                }
-                // line ends like "0x0" or "0x1"
-                if line.contains("0x0") {
-                    return true;
-                }
-                if line.contains("0x1") {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        // GNOME etc. — soft default dark when unknown
-        true
     }
 }
 

--- a/src-tauri/src/os_theme.rs
+++ b/src-tauri/src/os_theme.rs
@@ -1,0 +1,113 @@
+//! OS light/dark probe + live Windows app-theme watch.
+//!
+//! Boot locks WebView2 to a concrete theme (form chrome). That freezes
+//! `prefers-color-scheme`, so Settings → Personalization flips never reach
+//! matchMedia. On Windows we watch `AppsUseLightTheme` and emit
+//! `os-theme://changed` for the frontend to paint `data-theme`.
+
+use tauri::AppHandle;
+
+/// Host → frontend when Windows default *app* mode changes.
+pub const OS_THEME_CHANGED_EVENT: &str = "os-theme://changed";
+
+/// `AppsUseLightTheme` DWORD: `0` = dark apps, `1` = light. Missing → dark.
+pub fn apps_prefer_dark_from_dword(apps: Option<u32>) -> bool {
+    !apps.is_some_and(|v| v != 0)
+}
+
+/// Best-effort OS dark/light probe (no extra deps).
+pub fn os_prefers_dark() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        // AppleInterfaceStyle is set only in dark mode; missing → light.
+        let out = crate::process_util::command("defaults")
+            .args(["read", "-g", "AppleInterfaceStyle"])
+            .output();
+        if let Ok(o) = out {
+            let s = String::from_utf8_lossy(&o.stdout).to_ascii_lowercase();
+            return s.contains("dark");
+        }
+        return true;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return apps_prefer_dark();
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        // GNOME etc. — soft default dark when unknown
+        true
+    }
+}
+
+#[cfg(windows)]
+fn apps_prefer_dark() -> bool {
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let apps = hkcu
+        .open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize")
+        .ok()
+        .and_then(|key| key.get_value::<u32, _>("AppsUseLightTheme").ok());
+    apps_prefer_dark_from_dword(apps)
+}
+
+pub fn resolved_os_theme() -> &'static str {
+    if os_prefers_dark() {
+        "dark"
+    } else {
+        "light"
+    }
+}
+
+#[tauri::command]
+pub fn os_theme_current() -> String {
+    resolved_os_theme().to_string()
+}
+
+/// Poll Windows app mode. No-op on other OS (matchMedia / Tauri theme-changed).
+pub fn watch(app: &AppHandle) {
+    #[cfg(windows)]
+    watch_apps_theme(app.clone());
+    #[cfg(not(windows))]
+    let _ = app;
+}
+
+#[cfg(windows)]
+fn watch_apps_theme(app: AppHandle) {
+    use tauri::Emitter;
+    std::thread::Builder::new()
+        .name("grok-os-theme".into())
+        .spawn(move || {
+            let mut last = resolved_os_theme();
+            loop {
+                std::thread::sleep(std::time::Duration::from_secs(1));
+                let now = resolved_os_theme();
+                if now == last {
+                    continue;
+                }
+                last = now;
+                let _ = app.emit(OS_THEME_CHANGED_EVENT, serde_json::json!({ "theme": now }));
+            }
+        })
+        .ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apps_dword_zero_is_dark() {
+        assert!(apps_prefer_dark_from_dword(Some(0)));
+        assert!(!apps_prefer_dark_from_dword(Some(1)));
+        assert!(apps_prefer_dark_from_dword(None));
+    }
+
+    #[test]
+    fn resolved_theme_matches_probe() {
+        let t = resolved_os_theme();
+        assert!(t == "light" || t == "dark");
+        assert_eq!(t == "dark", os_prefers_dark());
+    }
+}

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -5,11 +5,16 @@ import {
   getSystemTheme,
   loadTheme,
   loadThemePreference,
+  nativeWindowThemeArg,
+  OS_THEME_CHANGED_EVENT,
+  parseOsThemePayload,
   parseTheme,
   parseThemePreference,
+  readOsTheme,
   resolveTheme,
   saveTheme,
   saveThemePreference,
+  subscribeHostOsTheme,
   subscribeSystemTheme,
   switchTheme,
   THEME_STORAGE_KEY,
@@ -144,5 +149,47 @@ describe("theme preference + resolve", () => {
     // After unlock, caller passes freshly read OS theme — must win over stale state.
     expect(resolveTheme("system", "dark")).toBe("dark");
     expect(resolveTheme("system", "light")).toBe("light");
+  });
+
+  it("Windows follow-system locks native chrome to the resolved theme", () => {
+    // WebView2 matchMedia does not live-update after boot lock — push concrete.
+    expect(nativeWindowThemeArg("system", false, "light", "win")).toBe("light");
+    expect(nativeWindowThemeArg("system", false, "dark", "win")).toBe("dark");
+    expect(nativeWindowThemeArg("system", false, "dark", "mac")).toBeNull();
+    expect(nativeWindowThemeArg("system", false, "light", "linux")).toBeNull();
+    expect(nativeWindowThemeArg("system", true, "light", "mac")).toBe("light");
+    expect(nativeWindowThemeArg("dark", false, "dark", "win")).toBe("dark");
+    expect(nativeWindowThemeArg("light", false, "light", "mac")).toBe("light");
+  });
+
+  it("parseOsThemePayload accepts command strings and host events", () => {
+    expect(parseOsThemePayload("light")).toBe("light");
+    expect(parseOsThemePayload("dark")).toBe("dark");
+    expect(parseOsThemePayload({ theme: "light" })).toBe("light");
+    expect(parseOsThemePayload({ theme: "nope" })).toBeNull();
+    expect(parseOsThemePayload(null)).toBeNull();
+  });
+
+  it("readOsTheme prefers a host probe over matchMedia", async () => {
+    await expect(readOsTheme(async () => ({ theme: "light" }))).resolves.toBe(
+      "light",
+    );
+    await expect(readOsTheme(async () => "dark")).resolves.toBe("dark");
+  });
+
+  it("subscribeHostOsTheme forwards parsed host payloads", async () => {
+    const listeners = new Map<string, (p: unknown) => void>();
+    const listen = async (event: string, handler: (p: unknown) => void) => {
+      listeners.set(event, handler);
+      return () => {
+        listeners.delete(event);
+      };
+    };
+    const seen: string[] = [];
+    const unsub = await subscribeHostOsTheme((t) => seen.push(t), listen);
+    listeners.get(OS_THEME_CHANGED_EVENT)?.({ theme: "light" });
+    expect(seen).toEqual(["light"]);
+    unsub();
+    expect(listeners.size).toBe(0);
   });
 });

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -4,9 +4,14 @@
  * concrete `data-theme="light|dark"`. Default preference is follow system.
  */
 
+import { detectAppPlatform, type AppPlatform } from "./appPlatform";
+
 export type Theme = "dark" | "light";
 /** User-facing choice including follow-OS. */
 export type ThemePreference = "system" | Theme;
+
+/** Host → frontend when Windows `AppsUseLightTheme` flips. */
+export const OS_THEME_CHANGED_EVENT = "os-theme://changed";
 
 export const THEME_STORAGE_KEY = "grok-app.theme";
 /** Fallback when OS scheme cannot be read (tests / SSR). */
@@ -93,11 +98,62 @@ export function applyThemeToDocument(
 }
 
 /**
+ * Native chrome lock vs Auto when the user follows the OS.
+ *
+ * macOS / Linux: `null` (Auto) so WKWebView matchMedia + Tauri theme-changed
+ * stay live. Windows WebView2: Auto after a boot lock does not fire
+ * `prefers-color-scheme` changes — push the resolved theme instead; the host
+ * watches `AppsUseLightTheme` and the frontend re-applies.
+ */
+export function nativeWindowThemeArg(
+  preference: ThemePreference,
+  scheduleEnabled: boolean,
+  resolved: Theme,
+  platform: AppPlatform,
+): Theme | null {
+  if (preference === "system" && !scheduleEnabled && platform !== "win") {
+    return null;
+  }
+  return resolved;
+}
+
+/** Host event / command payload → concrete theme. */
+export function parseOsThemePayload(raw: unknown): Theme | null {
+  if (raw === "light" || raw === "dark") return raw;
+  if (raw && typeof raw === "object" && "theme" in raw) {
+    const theme = (raw as { theme: unknown }).theme;
+    if (theme === "light" || theme === "dark") return theme;
+  }
+  return null;
+}
+
+/** Authoritative OS theme: Host probe, then matchMedia. */
+export async function readOsTheme(
+  hostRead?: () => Promise<unknown>,
+): Promise<Theme> {
+  try {
+    const read =
+      hostRead ??
+      (async () => {
+        const { isDesktopHost, invoke } = await import("@/lib/api/host");
+        if (!isDesktopHost()) return null;
+        return invoke<string>("os_theme_current");
+      });
+    const parsed = parseOsThemePayload(await read());
+    if (parsed) return parsed;
+  } catch {
+    /* browser / older host */
+  }
+  return getSystemTheme();
+}
+
+/**
  * Sync Tauri / macOS native chrome (NSAppearance + vibrancy) with app theme.
  * Without this, light UI still sits on dark Sidebar vibrancy → dirty gray rail + black edges.
  *
- * Pass `null` to **follow the OS** (required for live system switching — locking
- * light/dark freezes `prefers-color-scheme` inside the WebView).
+ * Pass `null` to **follow the OS** (required for live system switching on
+ * macOS — locking light/dark freezes `prefers-color-scheme` inside the WebView).
+ * On Windows, pass the concrete theme (see `nativeWindowThemeArg`).
  * No-op outside Tauri.
  */
 export async function applyNativeWindowTheme(
@@ -118,8 +174,7 @@ export async function applyNativeWindowTheme(
 
 /**
  * Apply preference end-to-end: unlock/lock native chrome, resolve system if
- * needed, write `data-theme`. When switching **to** system, native is unlocked
- * first so matchMedia reflects the real OS scheme.
+ * needed, write `data-theme`. Host probe wins over matchMedia on Windows.
  */
 export async function applyThemePreference(
   preference: ThemePreference,
@@ -129,17 +184,11 @@ export async function applyThemePreference(
   },
 ): Promise<Theme> {
   if (preference === "system") {
-    // Unlock WebView appearance so prefers-color-scheme tracks the OS.
-    await applyNativeWindowTheme(null);
-    // matchMedia can lag one frame after native unlock — re-read twice.
-    let system = getSystemTheme();
-    if (typeof requestAnimationFrame === "function") {
-      await new Promise<void>((r) => {
-        requestAnimationFrame(() => r());
-      });
-      system = getSystemTheme();
-    }
+    const system = await readOsTheme();
     applyThemeToDocument(system);
+    await applyNativeWindowTheme(
+      nativeWindowThemeArg("system", false, system, detectAppPlatform()),
+    );
     options?.onResolved?.(system, system);
     return system;
   }
@@ -230,4 +279,45 @@ export function subscribeSystemTheme(
   };
   legacy.addListener?.(handler);
   return () => legacy.removeListener?.(handler);
+}
+
+/**
+ * Host OS-theme event (+ Tauri window theme-changed when not injecting listen).
+ * WebView2 matchMedia often stays frozen; this is the live path on Windows.
+ */
+export async function subscribeHostOsTheme(
+  onChange: (systemTheme: Theme) => void,
+  listenFn?: (
+    event: string,
+    handler: (payload: unknown) => void,
+  ) => Promise<() => void>,
+): Promise<() => void> {
+  const listen =
+    listenFn ??
+    (async (event, handler) => {
+      const { listen: hostListen } = await import("@/lib/api/host");
+      return hostListen<unknown>(event, handler);
+    });
+  const unsubs: Array<() => void> = [];
+  unsubs.push(
+    await listen(OS_THEME_CHANGED_EVENT, (payload) => {
+      const theme = parseOsThemePayload(payload);
+      if (theme) onChange(theme);
+    }),
+  );
+  if (!listenFn) {
+    try {
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      unsubs.push(
+        await getCurrentWindow().onThemeChanged(({ payload }) => {
+          if (payload === "light" || payload === "dark") onChange(payload);
+        }),
+      );
+    } catch {
+      /* browser / older runtime */
+    }
+  }
+  return () => {
+    for (const unsub of unsubs) unsub();
+  };
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,11 +10,13 @@ import "./styles/tailwind.css";
 import "streamdown/styles.css";
 import "./styles/app.css";
 import "./styles/setup-wizard.css";
+import { detectAppPlatform } from "./lib/appPlatform";
 import {
   applyNativeWindowTheme,
   applyThemeToDocument,
   getSystemTheme,
   loadThemePreference,
+  nativeWindowThemeArg,
   resolveTheme,
 } from "./lib/theme";
 import {
@@ -96,10 +98,15 @@ applyComposerMinRows(loadComposerMinRows(localStorage));
 // the IndexedDB blob is loaded — no synchronous access to IDB is possible.
 applyWallpaperFlag(loadWallpaperMeta(localStorage) !== null);
 applyWallpaperScrimToDocument(loadWallpaperScrim(localStorage));
-// Native: null = follow OS (required for live system theme); light/dark or
-// schedule-resolved theme locks chrome so WebView matchMedia cannot fight us.
+// macOS: null = follow OS (live matchMedia). Windows: lock to the resolved
+// theme — WebView2 matchMedia does not track Personalization flips.
 void applyNativeWindowTheme(
-  bootPref === "system" && !bootSchedule.enabled ? null : bootTheme,
+  nativeWindowThemeArg(
+    bootPref,
+    bootSchedule.enabled,
+    bootTheme,
+    detectAppPlatform(),
+  ),
 );
 const petShell =
   typeof window !== "undefined" && isPetShellHash(window.location.hash);

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -12,14 +12,18 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { detectAppPlatform } from "@/lib/appPlatform";
 import {
   applyNativeWindowTheme,
   applyThemePreference,
   applyThemeToDocument,
   getSystemTheme,
   loadThemePreference,
+  nativeWindowThemeArg,
   parseThemePreference,
+  readOsTheme,
   saveThemePreference,
+  subscribeHostOsTheme,
   subscribeSystemTheme,
   type Theme,
   type ThemePreference,
@@ -139,28 +143,55 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     applyThemeToDocument(theme);
     void applyNativeWindowTheme(
-      themePreference === "system" && !themeSchedule.enabled ? null : theme,
+      nativeWindowThemeArg(
+        themePreference,
+        themeSchedule.enabled,
+        theme,
+        detectAppPlatform(),
+      ),
     );
   }, [theme, themePreference, themeSchedule.enabled]);
 
   useEffect(() => {
     if (themePreference !== "system" || themeSchedule.enabled) return;
     let cancelled = false;
-    void (async () => {
-      await applyNativeWindowTheme(null);
-      if (cancelled) return;
-      const sys = getSystemTheme();
-      setSystemTheme(sys);
-      applyThemeToDocument(sys);
-    })();
-    const unsub = subscribeSystemTheme((next) => {
+    let unsubHost = () => {};
+    const platform = detectAppPlatform();
+    let applied: Theme | null = null;
+    const applySystem = (next: Theme) => {
+      if (applied === next) return;
+      applied = next;
       setSystemTheme(next);
       applyThemeToDocument(next);
-      void applyNativeWindowTheme(null);
+      void applyNativeWindowTheme(
+        nativeWindowThemeArg("system", false, next, platform),
+      );
+    };
+    void (async () => {
+      const sys = await readOsTheme();
+      if (cancelled) return;
+      applySystem(sys);
+    })();
+    const unsubMql = subscribeSystemTheme(applySystem);
+    void subscribeHostOsTheme(applySystem).then((unsub) => {
+      if (cancelled) {
+        unsub();
+        return;
+      }
+      unsubHost = unsub;
     });
+    const onVis = () => {
+      if (document.visibilityState !== "visible") return;
+      void readOsTheme().then((sys) => {
+        if (!cancelled) applySystem(sys);
+      });
+    };
+    document.addEventListener("visibilitychange", onVis);
     return () => {
       cancelled = true;
-      unsub();
+      unsubMql();
+      unsubHost();
+      document.removeEventListener("visibilitychange", onVis);
     };
   }, [themePreference, themeSchedule.enabled]);
 


### PR DESCRIPTION
## Summary
- Fixes #749: Windows 主题设「系统」时，主窗现在会跟个性化（`AppsUseLightTheme`）一起切深浅色。
- 启动仍会锁 WebView2 表单颜色；Host 轮询注册表并推 `os-theme://changed`，前端重刷 `data-theme`，不再空等已冻住的 `matchMedia`。
- 和 #747 / #748 不是同一条：那是托盘跟任务栏，这条是主窗跟应用模式。#747 当时把主窗锁死标成题外话。

## Test plan
- [x] Windows 11，主题 = 系统，关主题定时；改「个性化 → 颜色」应用默认深/浅色，主窗约 1 秒内跟着切
- [x] `pnpm exec vitest run src/lib/theme.test.ts`
- [x] `cargo check --lib`
- [ ] `pnpm typecheck` / 全量 `pnpm test`（CI）
- [ ] 强制浅色 / 深色仍锁死，不跟系统
- [ ] 主题定时开启时仍按钟点走，不跟系统
- [ ] macOS：跟随系统仍靠 Auto + `matchMedia`（本 PR 不改这条路径的语义）
