### PR TITLE
fix(i18n): two translated strings dropped their {name} placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
+- **Japanese PR hub and Ukrainian agent command keep `{name}` (#751)**: `ja` `prHub.author` was `作成者` with no author; `uk` `preferredCurrent` shipped `--agent ` with nothing to paste. Catalog tests now fail if any locale drops or renames an `en` placeholder.
 - **Sidebar tree text columns line up (#745)**: Projects and Other labels share one left edge. Project names and the session titles under them share `--tree-text-inset`. The L1 chevron column is 20px (was 28).
 - **Windows tray icon stays visible on a dark taskbar (#747)**: The notification-area mark is no longer a black glyph on transparency. Light taskbars get a black tile / white glyph; dark taskbars get the inverse. The host follows `SystemUsesLightTheme` (not the in-app theme) and swaps live.
 - **Windows “follow system” theme now switches with Personalization (#749)**: Boot still locks WebView2 form chrome, but that froze `prefers-color-scheme`, so the main window stayed put when the OS flipped. The host watches `AppsUseLightTheme` and the UI reapplies `data-theme`.
@@ -41,6 +42,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **日语 PR hub 和乌克兰语 agent 命令不再丢掉 `{name}`（#751）**：`ja` 的 `prHub.author` 只有「作成者」没有人名；`uk` 的 `preferredCurrent` 复制出来是空的 `--agent `。目录测试会拦截任何语言丢掉或改名 en 占位符。
 - **侧栏树文字列对齐（#745）**：Projects 与 Other 标题左缘对齐；项目名与其下会话标题共用 `--tree-text-inset`。一级箭头列从 28px 收到 20px。
 - **Windows 托盘在深色任务栏上不再隐身（#747）**：通知区不再用透明底黑标。浅色任务栏黑底白标，深色任务栏白底黑标。跟随任务栏 `SystemUsesLightTheme`（不是应用内主题），切换后即时换标。
 - **Windows「跟随系统」现在会跟个性化一起切（#749）**：启动锁 WebView2 表单颜色后，`prefers-color-scheme` 不再更新，系统换深浅色主窗不动。Host 改为监视 `AppsUseLightTheme`，前端重刷 `data-theme`。

--- a/src/i18n/messages.test.ts
+++ b/src/i18n/messages.test.ts
@@ -134,6 +134,35 @@ describe("i18n catalog", () => {
     ).toEqual([]);
   });
 
+  it("every locale keeps the placeholders its en string declares", () => {
+    // `t()` substitutes by name, so a translation that drops `{name}` renders
+    // without the value and one that renames it renders the literal braces.
+    // Neither is a missing key, so nothing else catches it: `prHub.author`
+    // read "作成者" with no author, and the Ukrainian
+    // `--agent {name}` shipped as a command with no agent to copy.
+    const named = /\{[A-Za-z_][A-Za-z0-9_]*\}/g;
+    const placeholders = (s: string) =>
+      [...s.matchAll(named)]
+        .map((m) => m[0])
+        .sort()
+        .join(",");
+    const broken: string[] = [];
+    for (const loc of LOCALES) {
+      if (loc === "en") continue;
+      for (const [k, v] of Object.entries(messages.en)) {
+        const want = placeholders(v);
+        const got = placeholders(messages[loc][k as MessageKey]);
+        if (want !== got) {
+          broken.push(`${loc}.${k}: en has [${want}], ${loc} has [${got}]`);
+        }
+      }
+    }
+    expect(
+      broken,
+      `${broken.length} placeholder mismatches: ${broken.join("; ")}`,
+    ).toEqual([]);
+  });
+
   it("translates the always-visible chrome in every locale", () => {
     // These render on first paint in every session, so a locale that still
     // falls back to English here is not usable as a UI language.

--- a/src/i18n/messages/ja/features.ts
+++ b/src/i18n/messages/ja/features.ts
@@ -442,7 +442,7 @@ export const jaFeatures = {
   "prHub.mergeable": "マージ可能",
   "prHub.conflicting": "競合",
   "prHub.mergeableUnknown": "不明",
-  "prHub.author": "作成者",
+  "prHub.author": "作成者 {name}",
   "prHub.untitled": "（タイトルなし）",
   "prHub.expandDetails": "チェックとコメントを表示",
   "prHub.collapseDetails": "チェックとコメントを隠す",

--- a/src/i18n/messages/uk/settings-agent.ts
+++ b/src/i18n/messages/uk/settings-agent.ts
@@ -332,7 +332,7 @@ export const ukSettingsAgent = {
   "settings.agentsPersonas.setPreferred": "Зробити бажаним",
   "settings.agentsPersonas.preferredBadge": "Бажаний",
   "settings.agentsPersonas.preferredDefault": "Бажаний агент: за замовчуванням (CLI) — породження пропускає `--agent`. Живі агенти м'яко відроджуються при зміні; неактивний, очікує наступного підключення.",
-  "settings.agentsPersonas.preferredCurrent": "Бажаний агент: {name} · {source} — запуск `--agent ` (м’який перезапуск, коли живе).",
+  "settings.agentsPersonas.preferredCurrent": "Бажаний агент: {name} · {source} — запуск `--agent {name}` (м’який перезапуск, коли живе).",
   "settings.agentsPersonas.preferredMissing": "Бажаного агента «{name}» немає в каталозі",
   "settings.agentsPersonas.preferredMissingHint": "Можливо, його було перейменовано або видалено. Виберіть іншого агента або за замовчуванням (CLI). М'яка помилка: spawn все ще передає збережену назву, доки ви її не зміните (CLI може бути помилкою).",
   "settings.workflows.authorHint": "Створіть повні конвеєри за допомогою навику create-workflow (/create-workflow) або відредагуйте файл.rhai. Ця панель створює лише короткий шаблон і може димити/запускатися за назвою — не візуальний редактор.",


### PR DESCRIPTION
`t()` substitutes by name, so a translation that drops `{name}` renders without the value. It is not a missing key and not an empty string, so none of the existing catalog checks sees it. Two strings shipped that way.

### 1. Japanese PR hub shows no author

`GitPrHubPanel.tsx` calls `tr("prHub.author", { name: pr.author })`, but `ja` reads `"作成者"` with no placeholder, so every row says "created by" and stops. All fourteen other locales keep `{name}`:

| | |
|---|---|
| en | `by {name}` |
| ja | `作成者` ← |
| ko | `{name} 작성` |
| zh | `作者 {name}` |
| de | `von {name}` |

### 2. Ukrainian ships a command with no argument

`settings.agentsPersonas.preferredCurrent` renders a command the user is meant to copy. `uk` lost the `{name}` inside the backticks:

```
en: spawn `--agent {name}` (soft-respawn when live).
uk: запуск `--agent ` (м'який перезапуск, коли живе).
```

### Regression guard

`messages.test.ts` already spot-checks six keys for their placeholders. This generalises that into a catalog-wide sweep: every locale must carry exactly the placeholders its `en` string declares — dropped, added, or renamed all fail. The two bugs above are the only strings in the fifteen catalogs that fail it, so the sweep goes green with this fix and stays that way.

Both strings predate the recent i18n work (`06a56956` and `574d7f18`); `#732` re-translated `ja` but did not touch this line.

### Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` (451 files, 6176 tests) all green. No Rust touched. I also confirmed the guard is not vacuous by reintroducing the `ja` bug and watching it fail.
