### PR TITLE
feat(settings): toggle Settings closed with Ctrl+, or Esc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Added
+- **Settings closes with Ctrl+, / Esc (#752)**: Pressing the settings chord again on the Settings page (including in a field) returns to the workbench. Esc does the same, without stopping a background turn. Nested dialogs and Select menus still own Escape first. The account-menu Settings row, slash `/settings`, command-palette settings actions, and “Back to app” show the live chord.
 - **Ctrl+Q twice to quit (#743)**: First press toasts; second within 2s exits. Side-terminal Ctrl+Q (XON after Ctrl+S freeze) is not swallowed. macOS tray does not advertise `(Ctrl+Q)` — ⌘Q is still immediate quit; the catalog mac column is `⌃ Q`.
 - **Ctrl+Enter steers a live turn (Grok Build CLI chord) (#741)**: While the agent is mid-turn, Ctrl+Enter (Cmd+Enter on macOS too) injects the composer draft via Steer / `sessionInterject`. Empty composer + a queued follow-up steers the head. You no longer have to queue first and click **Steer**. Plain Enter still queues.
 - **Pet uses the full bloub morph catalogue**: the overlay now runs the measured SVG engine (idle, thinking, wink, notify, alert, hexagon, orbit, comet, …) instead of the old clip-path faces. Settings pick the 8 rest shapes plus 16 rest expressions. Typing in the composer plays the catalog alert morph (slanted !) and returns to the chosen rest shape after a short pause; unread ready chats show a vivid orange-red pastille (lime on already-hot bodies) rather than the video’s blue.
 
 **中文 · 新增**
+- **设置页再按 Ctrl+, / Esc 回到主窗（#752）**：设置页再按一次设置快捷键（输入框里也能关）走「返回应用」。Esc 同样离开设置，不误停后台生成；嵌套对话框和 Select 仍先处理 Esc。账号菜单 Settings、`/settings`、命令面板设置项、「返回应用」显示当前和弦。
 - **Ctrl+Q 连按两次退出（#743）**：第一次提示，2 秒内再按才退出。侧栏终端的 Ctrl+Q（XON，Ctrl+S 冻结后靠它解冻）不吞。macOS 托盘不写 `(Ctrl+Q)`，⌘Q 仍立即退出；目录 mac 列是 `⌃ Q`。
 - **Ctrl+Enter 引导当前回合（对标 Grok Build CLI）（#741）**：Agent 正在跑时，Ctrl+Enter（macOS 也认 Cmd+Enter）把输入框里的内容直接 Steer 进当前回合。输入框空、队列里有跟进时引导队首。不用先排队再点「引导」。普通 Enter 仍是排队。
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -339,7 +339,11 @@ import {
   tickStopLatch,
   STOP_LATCH_MS
 } from "@/lib/stopLatch";
-import { shouldEscapeStopGeneration } from "@/lib/escapeStop";
+import {
+  isSettingsEscapeOwnedByNestedLayer,
+  shouldEscapeCloseSettings,
+  shouldEscapeStopGeneration,
+} from "@/lib/escapeStop";
 import {
   isSameView,
   isViewingSendTarget,
@@ -538,6 +542,7 @@ import {
   shouldDisableReconnectBecauseConnecting,
 } from "@/lib/connStatus";
 import {
+  formatShortcutHint,
   matchGlobalShortcut,
   shortcutsForPlatform
 } from "@/lib/shortcuts";
@@ -2069,6 +2074,7 @@ export function AppWorkbench() {
   const shortcutHandlersRef = useRef({
     newChat: () => {},
     openSettings: () => {},
+    closeSettings: () => {},
     openChatFind: () => {},
     copyLastReply: () => {},
     toggleSidebar: () => {},
@@ -2098,6 +2104,7 @@ export function AppWorkbench() {
     chatFindOpen: false,
     slashOrMenuOpen: false,
     promptHistoryOpen: false,
+    settingsOpen: false,
   });
   /** Live user remaps for capture-phase matching + help table. */
   const [shortcutRemaps, setShortcutRemaps] = useState<ShortcutRemapMap>(() =>
@@ -2148,13 +2155,31 @@ export function AppWorkbench() {
         shortcutHandlersRef.current.cancelVoice();
         return;
       }
-      // Esc stops the active turn when nothing else owns Escape (catalog: shortcuts.stop).
+      // Esc: leave Settings, else stop the active turn (catalog: shortcuts.stop).
       if (e.key === "Escape") {
         const gate = escapeStopLiveRef.current;
+        const voiceSteals = voiceStealsEscape(voiceRef.current.phase);
+        const nestedLayerOpen =
+          gate.settingsOpen &&
+          isSettingsEscapeOwnedByNestedLayer(
+            typeof document !== "undefined" ? document : null,
+          );
+        if (
+          shouldEscapeCloseSettings({
+            ...gate,
+            voiceStealsEscape: voiceSteals,
+            nestedLayerOpen,
+          })
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          shortcutHandlersRef.current.closeSettings();
+          return;
+        }
         if (
           shouldEscapeStopGeneration({
             ...gate,
-            voiceStealsEscape: voiceStealsEscape(voiceRef.current.phase),
+            voiceStealsEscape: voiceSteals,
           })
         ) {
           e.preventDefault();
@@ -2220,7 +2245,10 @@ export function AppWorkbench() {
           typing,
         },
         shortcutRemapsRef.current,
-        { voiceHotkeyEnabled: voiceHotkeyEnabledRef.current },
+        {
+          voiceHotkeyEnabled: voiceHotkeyEnabledRef.current,
+          settingsOpen: escapeStopLiveRef.current.settingsOpen,
+        },
       );
       if (!matched) return;
       e.preventDefault();
@@ -2235,7 +2263,11 @@ export function AppWorkbench() {
           setShowShortcuts((v) => !v);
           return;
         case "settings":
-          shortcutHandlersRef.current.openSettings();
+          if (escapeStopLiveRef.current.settingsOpen) {
+            shortcutHandlersRef.current.closeSettings();
+          } else {
+            shortcutHandlersRef.current.openSettings();
+          }
           return;
         case "newChat":
           shortcutHandlersRef.current.newChat();
@@ -2863,6 +2895,15 @@ export function AppWorkbench() {
   const [accountProbeError, setAccountProbeError] = useState<unknown>(null);
   const [loginHint, setLoginHint] = useState<string | null>(null);
   const platform = useMemo(() => detectAppPlatform(), []);
+  const settingsShortcutHint = useMemo(
+    () =>
+      formatShortcutHint(
+        "settings",
+        shortcutRemaps,
+        platform === "mac" ? "mac" : "win",
+      ),
+    [shortcutRemaps, platform],
+  );
   /** Self-drawn chrome when OS title bar is disabled (Win / Linux frameless). */
   const useCustomWindowChrome = usesCustomWindowChrome(platform);
   /** Titlebar / chrome-strip double-click → maximize on mac + win. */
@@ -15089,6 +15130,9 @@ export function AppWorkbench() {
     openSettings: (section?: SettingsSectionId) => {
       navigateSettings(section);
     },
+    closeSettings: () => {
+      navigateWorkbench();
+    },
     openChatFind: () => {
       openChatFind();
     },
@@ -17956,6 +18000,7 @@ export function AppWorkbench() {
   // Keep Esc→stop gate current for the capture-phase shortcut listener.
   escapeStopLiveRef.current = {
     streamingOrBusy: effectiveCanStop,
+    settingsOpen: appView === "settings",
     overlayOpen: Boolean(
       appDialog ||
         showSearch ||
@@ -25532,6 +25577,11 @@ export function AppWorkbench() {
                     <span className="search-panel__title">
                       {tr(action.labelKey)}
                     </span>
+                    {action.group === "settings" ? (
+                      <kbd className="menu-shortcut" aria-hidden>
+                        {settingsShortcutHint}
+                      </kbd>
+                    ) : null}
                   </button>
                   );
                 })}

--- a/src/components/ComposerPlusPanel.tsx
+++ b/src/components/ComposerPlusPanel.tsx
@@ -26,6 +26,7 @@ import {
   type SlashKindFilter,
   type SlashMenuEmptyPresentation,
 } from "@/lib/slashCatalog";
+import { formatShortcutHint } from "@/lib/shortcuts";
 import {
   IconActivity,
   IconArrowsMinimize,
@@ -341,6 +342,10 @@ export function ComposerPlusPanel({
 }) {
   const tr = createT(locale);
   const listRef = useRef<HTMLDivElement | null>(null);
+  const settingsHint = useMemo(
+    () => (open ? formatShortcutHint("settings") : ""),
+    [open],
+  );
 
   const setRefs = (node: HTMLDivElement | null) => {
     listRef.current = node;
@@ -593,6 +598,8 @@ export function ComposerPlusPanel({
         const item = entry.item;
         const title = resolveTitle(item);
         const desc = resolveDescription(item);
+        const settingsChord =
+          item.action === "settings" && settingsHint ? settingsHint : "";
         const right =
           desc.trim() ||
           (item.kind === "skill" && item.source ? item.source : "") ||
@@ -626,7 +633,11 @@ export function ComposerPlusPanel({
                 </span>
               ) : null}
             </span>
-            {right ? (
+            {settingsChord ? (
+              <kbd className="menu-shortcut" aria-hidden>
+                {settingsChord}
+              </kbd>
+            ) : right ? (
               <span className="composer-plus__desc">{right}</span>
             ) : null}
           </button>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -98,6 +98,8 @@ import {
   loadComposerSendKeyPref,
   type ComposerSendKeyPref,
 } from "@/lib/composerSendKey";
+import { formatShortcutHint } from "@/lib/shortcuts";
+import { SHORTCUT_REMAP_CHANGED_EVENT } from "@/lib/shortcutRemap";
 import {
   loadComposerDraftStatsPref,
 } from "@/lib/draftStats";
@@ -448,6 +450,14 @@ export function SettingsPage({
   } = { section: sectionGate, tab: tabGate, onSection: onSectionGate, onBack: onBackGate, phoneLayout: phoneLayoutGate, labels: labelsGate, locale: localeGate, focusAnchorId: focusAnchorIdGate, prHubHighlightPr: prHubHighlightPrGate, onFocusAnchorConsumed: onFocusAnchorConsumedGate, ...rest } as SettingsPageProps;
 
   const [query, setQuery] = useState("");
+  const [settingsHint, setSettingsHint] = useState(() =>
+    formatShortcutHint("settings"),
+  );
+  useEffect(() => {
+    const sync = () => setSettingsHint(formatShortcutHint("settings"));
+    window.addEventListener(SHORTCUT_REMAP_CHANGED_EVENT, sync);
+    return () => window.removeEventListener(SHORTCUT_REMAP_CHANGED_EVENT, sync);
+  }, []);
   /** Client-side validation error for Agents JSON (invalid blocks save). */
   const [agentsJsonError, setAgentsJsonError] = useState<string | null>(null);
   const [agentsJsonSaving, setAgentsJsonSaving] = useState(false);
@@ -1759,6 +1769,11 @@ export function SettingsPage({
         >
           <IconArrowLeft size={16} />
           <span>{t("settings.backToApp")}</span>
+          {settingsHint ? (
+            <kbd className="menu-shortcut" aria-hidden>
+              {settingsHint}
+            </kbd>
+          ) : null}
         </button>
 
         <div className="settings-page__search">

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -52,6 +53,7 @@ import {
   switcherDisplayName,
   type SwitcherQuota,
 } from "@/lib/accountSwitcherQuota";
+import { formatShortcutHint } from "@/lib/shortcuts";
 
 export interface UserMenuProps {
   open: boolean;
@@ -187,6 +189,10 @@ export function UserMenu({
   const [themeSubOpen, setThemeSubOpen] = useState(false);
   const [flyoutStyle, setFlyoutStyle] = useState<CSSProperties | null>(null);
   const closeTimerRef = useRef<number | null>(null);
+  const settingsHint = useMemo(
+    () => (open ? formatShortcutHint("settings") : ""),
+    [open],
+  );
 
   useEffect(() => {
     if (!open) setThemeSubOpen(false);
@@ -634,7 +640,12 @@ export function UserMenu({
               }}
             >
               <IconSettings size={16} />
-              <span>{labels.settings}</span>
+              <span className="user-menu__item-label">{labels.settings}</span>
+              {settingsHint ? (
+                <kbd className="menu-shortcut" aria-hidden>
+                  {settingsHint}
+                </kbd>
+              ) : null}
             </button>
 
             {onTutorial && labels.tutorial ? (

--- a/src/lib/escapeStop.test.ts
+++ b/src/lib/escapeStop.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { shouldEscapeStopGeneration, type EscapeStopOpts } from "./escapeStop";
+import {
+  SETTINGS_NESTED_ESCAPE_SELECTOR,
+  isSettingsEscapeOwnedByNestedLayer,
+  shouldEscapeCloseSettings,
+  shouldEscapeStopGeneration,
+  type EscapeStopOpts,
+} from "./escapeStop";
 
 const free: EscapeStopOpts = {
   streamingOrBusy: true,
@@ -76,5 +82,88 @@ describe("shouldEscapeStopGeneration", () => {
         slashOrMenuOpen: false,
       }),
     ).toBe(true);
+  });
+
+  it("does not stop while Settings is open (Esc leaves settings)", () => {
+    expect(
+      shouldEscapeStopGeneration({ ...free, settingsOpen: true }),
+    ).toBe(false);
+  });
+});
+
+const settingsFree = {
+  settingsOpen: true,
+  overlayOpen: false,
+  permOpen: false,
+  askUserOpen: false,
+  chatFindOpen: false,
+  slashOrMenuOpen: false,
+  promptHistoryOpen: false,
+  voiceStealsEscape: false,
+  nestedLayerOpen: false,
+};
+
+describe("shouldEscapeCloseSettings", () => {
+  it("closes settings when the page is open and nothing else owns Escape", () => {
+    expect(shouldEscapeCloseSettings(settingsFree)).toBe(true);
+  });
+
+  it("does not close when settings are not open", () => {
+    expect(
+      shouldEscapeCloseSettings({ ...settingsFree, settingsOpen: false }),
+    ).toBe(false);
+  });
+
+  it("defers to voice, overlays, menus, and nested dialogs / selects", () => {
+    expect(
+      shouldEscapeCloseSettings({ ...settingsFree, voiceStealsEscape: true }),
+    ).toBe(false);
+    expect(
+      shouldEscapeCloseSettings({ ...settingsFree, overlayOpen: true }),
+    ).toBe(false);
+    expect(
+      shouldEscapeCloseSettings({ ...settingsFree, permOpen: true }),
+    ).toBe(false);
+    expect(
+      shouldEscapeCloseSettings({ ...settingsFree, askUserOpen: true }),
+    ).toBe(false);
+    expect(
+      shouldEscapeCloseSettings({ ...settingsFree, chatFindOpen: true }),
+    ).toBe(false);
+    expect(
+      shouldEscapeCloseSettings({ ...settingsFree, slashOrMenuOpen: true }),
+    ).toBe(false);
+    expect(
+      shouldEscapeCloseSettings({ ...settingsFree, promptHistoryOpen: true }),
+    ).toBe(false);
+    expect(
+      shouldEscapeCloseSettings({ ...settingsFree, nestedLayerOpen: true }),
+    ).toBe(false);
+  });
+});
+
+describe("isSettingsEscapeOwnedByNestedLayer", () => {
+  it("is false for missing roots or no matching node", () => {
+    expect(isSettingsEscapeOwnedByNestedLayer(null)).toBe(false);
+    expect(
+      isSettingsEscapeOwnedByNestedLayer({
+        querySelector: () => null,
+      } as unknown as ParentNode),
+    ).toBe(false);
+  });
+
+  it("is true when querySelector finds a nested layer", () => {
+    const seen: string[] = [];
+    expect(
+      isSettingsEscapeOwnedByNestedLayer({
+        querySelector: (sel: string) => {
+          seen.push(sel);
+          return {} as Element;
+        },
+      } as unknown as ParentNode),
+    ).toBe(true);
+    expect(seen).toEqual([SETTINGS_NESTED_ESCAPE_SELECTOR]);
+    expect(SETTINGS_NESTED_ESCAPE_SELECTOR).toContain(".overlay .modal");
+    expect(SETTINGS_NESTED_ESCAPE_SELECTOR).toContain(".c-select__menu");
   });
 });

--- a/src/lib/escapeStop.ts
+++ b/src/lib/escapeStop.ts
@@ -1,9 +1,9 @@
 /**
- * Esc → stop generation gate.
+ * Esc → stop generation / leave Settings.
  *
- * Shortcuts catalog documents Esc as “Stop generation / close overlay”.
- * Overlays, permission, ask-user, find, menus, and voice own Escape first;
- * stop only when the turn is busy and nothing else claims the key.
+ * Overlays, permission, ask-user, find, menus, and voice own Escape first.
+ * Settings is a full-page view: Esc leaves it instead of stopping a
+ * background turn. Nested GlassModal / Select layers still own Escape.
  */
 
 export type EscapeStopOpts = {
@@ -23,21 +23,66 @@ export type EscapeStopOpts = {
   promptHistoryOpen?: boolean;
   /** In-progress voice dictation steals Esc. */
   voiceStealsEscape?: boolean;
+  /** Settings view is showing (Esc leaves; does not stop). */
+  settingsOpen?: boolean;
 };
 
-/**
- * Whether global Escape should call `stop()` instead of doing nothing.
- * True only when a stoppable turn is active and no higher-priority owner
- * of Escape is open.
- */
+export type EscapeCloseSettingsOpts = Omit<
+  EscapeStopOpts,
+  "streamingOrBusy"
+> & {
+  settingsOpen: boolean;
+  /** GlassModal / Select already owns Escape. */
+  nestedLayerOpen?: boolean;
+};
+
+/** GlassModal overlay and Settings Select menus — Esc closes those first. */
+export const SETTINGS_NESTED_ESCAPE_SELECTOR =
+  ".overlay .modal, .c-select__menu";
+
+function escapeOwnedByOverlay(
+  opts: Pick<
+    EscapeStopOpts,
+    | "overlayOpen"
+    | "permOpen"
+    | "askUserOpen"
+    | "chatFindOpen"
+    | "slashOrMenuOpen"
+    | "promptHistoryOpen"
+    | "voiceStealsEscape"
+  >,
+): boolean {
+  return Boolean(
+    opts.voiceStealsEscape ||
+      opts.overlayOpen ||
+      opts.permOpen ||
+      opts.askUserOpen ||
+      opts.chatFindOpen ||
+      opts.slashOrMenuOpen ||
+      opts.promptHistoryOpen,
+  );
+}
+
+/** Stop the turn only when busy and nothing else owns Escape. */
 export function shouldEscapeStopGeneration(opts: EscapeStopOpts): boolean {
   if (!opts.streamingOrBusy) return false;
-  if (opts.voiceStealsEscape) return false;
-  if (opts.overlayOpen) return false;
-  if (opts.permOpen) return false;
-  if (opts.askUserOpen) return false;
-  if (opts.chatFindOpen) return false;
-  if (opts.slashOrMenuOpen) return false;
-  if (opts.promptHistoryOpen) return false;
-  return true;
+  if (opts.settingsOpen) return false;
+  return !escapeOwnedByOverlay(opts);
+}
+
+/** Leave Settings for the workbench when nothing else owns Escape. */
+export function shouldEscapeCloseSettings(
+  opts: EscapeCloseSettingsOpts,
+): boolean {
+  if (!opts.settingsOpen) return false;
+  if (opts.nestedLayerOpen) return false;
+  return !escapeOwnedByOverlay(opts);
+}
+
+/** Nested Settings dialog / Select should get Escape before leaving the page. */
+export function isSettingsEscapeOwnedByNestedLayer(
+  root: ParentNode | null | undefined,
+): boolean {
+  if (!root || typeof root.querySelector !== "function") return false;
+  return Boolean(root.querySelector(SETTINGS_NESTED_ESCAPE_SELECTOR));
 }

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -4,6 +4,7 @@ import {
   SHORTCUT_SCOPE_ORDER,
   filterShortcutGroups,
   filterShortcutRows,
+  formatShortcutHint,
   matchGlobalShortcut,
   sendShortcutDisplay,
   SHORTCUT_IDS,
@@ -106,6 +107,14 @@ describe("shortcuts catalog", () => {
     expect(
       (GLOBAL_MOD_SHORTCUT_IDS as readonly string[]).includes("sidebarSessionNav"),
     ).toBe(false);
+  });
+
+  it("formats settings hint for the current platform and remaps", () => {
+    expect(formatShortcutHint("settings", {}, "win")).toBe("Ctrl ,");
+    expect(formatShortcutHint("settings", {}, "mac")).toBe("⌘ ,");
+    expect(
+      formatShortcutHint("settings", { settings: "mod+shift+," }, "win"),
+    ).toBe("Ctrl Shift ,");
   });
 
   it("lists close side tab as display-only ⌘W / Ctrl+W", () => {
@@ -287,6 +296,19 @@ describe("matchGlobalShortcut", () => {
     ).toBeNull();
     expect(
       matchGlobalShortcut(chord({ key: ",", typing: true }), noRemaps),
+    ).toBeNull();
+  });
+
+  it("matches settings while typing when settings are already open", () => {
+    expect(
+      matchGlobalShortcut(chord({ key: ",", typing: true }), noRemaps, {
+        settingsOpen: true,
+      }),
+    ).toBe("settings");
+    expect(
+      matchGlobalShortcut(chord({ key: "n", typing: true }), noRemaps, {
+        settingsOpen: true,
+      }),
     ).toBeNull();
   });
 

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -324,6 +324,11 @@ export type MatchGlobalShortcutOpts = {
    * (composer / slash / menus stay available). Defaults to loaded pref / true.
    */
   voiceHotkeyEnabled?: boolean;
+  /**
+   * Settings page is showing. The settings chord still matches while a
+   * settings field is focused so ⌘, / Ctrl+, can leave the page.
+   */
+  settingsOpen?: boolean;
 };
 
 function resolveVoiceHotkeyEnabled(explicit?: boolean): boolean {
@@ -350,7 +355,9 @@ function resolveVoiceHotkeyEnabled(explicit?: boolean): boolean {
  *
  * Behavior preserved from the previous inline App handler (with defaults):
  * - findInChat works while typing
- * - newChat / settings skip when typing
+ * - newChat / settings skip when typing, except settings still matches
+ *   while typing when {@link MatchGlobalShortcutOpts.settingsOpen} is true
+ *   (toggle / leave Settings from a focused field)
  * - search / help / doctor / copyLastReply / liveVoice / toggleSidebar /
  *   sideFiles / sideBrowser / sideTerminal work while typing
  *   (layout + side / bottom-terminal chords are not blocked by composers)
@@ -385,8 +392,10 @@ export function matchGlobalShortcut(
       continue;
     }
     // newChat / settings: skip while typing (same as pre-remap handler).
+    // Settings chord still fires while typing if the page is already open
+    // so the same shortcut can leave Settings from a focused field.
     if ((id === "newChat" || id === "settings") && ctx.typing) {
-      continue;
+      if (!(id === "settings" && opts?.settingsOpen)) continue;
     }
     // Live Voice hotkey can be disabled in Settings (composer / menus still work).
     if (id === "liveVoice" && !shouldFireLiveVoiceHotkey(voiceHotkeyEnabled)) {
@@ -519,6 +528,22 @@ export function detectShortcutPlatform(): "mac" | "win" | "other" {
   }
   if (/Win/i.test(p) || /Windows/i.test(ua)) return "win";
   return "other";
+}
+
+/** Visible chord for a catalog id (remap-aware, current OS). */
+export function formatShortcutHint(
+  id: ShortcutId,
+  remaps?: ShortcutRemapMap | null,
+  platform: "mac" | "win" | "other" = detectShortcutPlatform(),
+): string {
+  const map =
+    remaps !== undefined
+      ? remaps
+      : typeof localStorage !== "undefined"
+        ? loadShortcutRemaps()
+        : {};
+  const plat = platform === "mac" ? "mac" : "win";
+  return formatChordDisplay(effectiveShortcutChord(id, map), plat);
 }
 
 export function shortcutsByGroup(

--- a/src/styles/sidebar.part3.css
+++ b/src/styles/sidebar.part3.css
@@ -128,6 +128,17 @@
   white-space: nowrap;
 }
 
+.menu-shortcut {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  color: var(--text-tertiary);
+  opacity: 0.55;
+}
+
 /* Context menu rows — tighter L/R pad (unified + legacy) */
 .context-menu__item,
 .ctx-menu button,

--- a/src/styles/sidebar.part4.css
+++ b/src/styles/sidebar.part4.css
@@ -377,6 +377,12 @@ html[data-sidebar-density="compact"] .session-row__meta {
   min-width: 0;
 }
 
+.user-menu__item > .menu-shortcut {
+  display: inline;
+  flex-direction: unset;
+  gap: 0;
+}
+
 .user-menu__item em {
   font-style: normal;
   font-size: 11px;


### PR DESCRIPTION
## Summary
- 设置页再按 **Ctrl+,** / **Cmd+,**（输入框聚焦也能关）走同一条「返回应用」路径
- **Esc** 离开设置，不误停后台生成；录音 / 确认框 / Select 仍先处理 Esc
- 账号菜单 Settings、`/settings`、命令面板设置项、「返回应用」显示当前和弦（尊重改键）

Closes #752

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan
- [ ] 主窗 Ctrl+, 打开设置；再按一次回到主窗
- [ ] 设置页输入框聚焦时 Ctrl+, 仍能关
- [ ] 设置页 Esc 回到主窗
- [ ] 设置里打开 Select / 对话框时 Esc 先关层，不立刻离开设置
- [ ] 设置页开着、后台生成中：Esc 不 Stop
- [ ] 左下角账号菜单 Settings 行显示 `Ctrl ,`（macOS `⌘ ,`）
- [ ] `/settings` 与命令面板设置项同样显示和弦
- [ ] 设置页「返回应用」显示和弦

## Checklist
- [x] I ran `pnpm exec vitest run src/lib/shortcuts.test.ts src/lib/escapeStop.test.ts`
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included