### PR TITLE
fix(composer): paste Explorer files (.dmp) via native clipboard paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
+- **Windows paste of Explorer files (.dmp) no longer dies on NotReadableError (#755)**: Composer paste of an on-disk file (crash dumps, locked/large binaries) now reads the OS clipboard path list (`CF_HDROP`) and attaches `@path` like drag-drop. WebView `File.arrayBuffer()` is only used for in-memory blobs (screenshots). Unreadable blobs get a dedicated i18n hint instead of the Chromium English `NotReadableError`.
 - **Windows no longer freezes at end of a long turn (#754)**: A trailing `prompt_complete` after `session/prompt` RPC Ok used to re-arm the end-of-turn handler. The second pass emitted IPC while journal reconcile still held the store lock; the WebView WndProc waited on that lock inside `SendMessage` and the window stopped painting. Duplicate finish is now a no-op, and post-turn UI rehydrate reads App `messages.json` only (Host already merged agent history).
 - **Local session API no longer wedges after the first turn**: A hung ACP handshake used to keep `connect_lock` forever (90s timeout abandoned the waiter without aborting the task). Later `--session-send` / `POST /turns` then waited ~180s and the CLI lied with `app_not_running`. Connect now aborts and bounded-kills pending children; dispatch returns `retry_later` in 15s; health exposes `connectLockBusy`; CLI maps timeouts to `error`; queued external prompts persist on disk and the Host drains them without the main window.
 - **Japanese PR hub and Ukrainian agent command keep `{name}` (#751)**: `ja` `prHub.author` was `作成者` with no author; `uk` `preferredCurrent` shipped `--agent ` with nothing to paste. Catalog tests now fail if any locale drops or renames an `en` placeholder.
@@ -46,6 +47,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **Windows 粘贴资源管理器文件（.dmp）不再报 NotReadableError（#755）**：Explorer 复制的已有磁盘路径改为读系统剪贴板文件列表（`CF_HDROP`）并按 `@path` 附加，与拖放一致。截图等无路径内容仍走 `arrayBuffer`。读不了的 blob 用专用文案，不再把 Chromium 英文 `NotReadableError` 拼进横幅。
 - **Windows 长回合结束不再卡死整窗（#754）**：`session/prompt` RPC 已经结束之后，迟到的 `prompt_complete` 会再次武装结束逻辑。第二次结束在 journal 对账还占着 store 锁时发 IPC，WebView 的 WndProc 在 `SendMessage` 里等这把锁，窗口不再重绘。重复结束现在是空操作；回合结束后的 UI 补刷只读 App `messages.json`（Host 已经合并过 agent 历史）。
 - **本地 session API 干完一轮后不再卡死**：卡住的 ACP 握手会把 `connect_lock` 永久占住（90s 超时只放弃等待、不 abort 任务），之后的 `--session-send` / `POST /turns` 会挂到约 180s，CLI 还谎称 `app_not_running`。现在超时会 abort 并用有上界的 kill 清 pending 子进程；派活 15s 内回 `retry_later`；health 带 `connectLockBusy`；CLI 把超时映射成 `error`；外部 queued 落盘，由 Host drain，不依赖主窗口。
 - **日语 PR hub 和乌克兰语 agent 命令不再丢掉 `{name}`（#751）**：`ja` 的 `prHub.author` 只有「作成者」没有人名；`uk` 的 `preferredCurrent` 复制出来是空的 `--agent `。目录测试会拦截任何语言丢掉或改名 en 占位符。

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,6 +88,7 @@ tauri-plugin-notification = "2"
 # `tauri-winrt-notification` — toast click (`on_activated`); the notification
 # plugin's desktop path is fire-and-forget and drops `extra`.
 [target.'cfg(windows)'.dependencies]
+clipboard-win = "5"
 winreg = "0.55"
 windows = { version = "0.61", features = [
     "Win32_Foundation",

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -119,6 +119,69 @@ pub async fn clipboard_paste_image() -> Result<Option<PathEntry>, String> {
         .map_err(|e| format!("clipboard task: {e}"))?
 }
 
+/// Absolute paths from the OS clipboard file list (Explorer / Finder copy).
+/// Empty when the clipboard has no files (screenshots, text). Never errors
+/// on a missing format — paste of images must keep working.
+#[tauri::command]
+pub async fn clipboard_file_paths() -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(clipboard_file_paths_sync)
+        .await
+        .map_err(|e| format!("clipboard task: {e}"))
+}
+
+fn clipboard_file_paths_sync() -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for raw in clipboard_file_paths_os() {
+        let n = normalize_fs_path(&raw);
+        if n.is_empty() || !seen.insert(n.clone()) {
+            continue;
+        }
+        out.push(n);
+    }
+    out
+}
+
+fn clipboard_file_paths_os() -> Vec<String> {
+    #[cfg(windows)]
+    {
+        use clipboard_win::{formats, get_clipboard};
+        if let Ok(list) = get_clipboard(formats::FileList) {
+            if !list.is_empty() {
+                return list;
+            }
+        }
+    }
+    let text = match arboard::Clipboard::new() {
+        Ok(mut cb) => cb.get_text().unwrap_or_default(),
+        Err(_) => String::new(),
+    };
+    parse_clipboard_file_list_text(&text)
+}
+
+/// text/uri-list, GNOME copied-files, or one absolute path per line.
+fn parse_clipboard_file_list_text(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.eq_ignore_ascii_case("copy") || line.eq_ignore_ascii_case("cut") {
+            continue;
+        }
+        if line.starts_with("file://")
+            || line.starts_with('/')
+            || (line.len() >= 3
+                && line.as_bytes()[1] == b':'
+                && (line.as_bytes()[2] == b'\\' || line.as_bytes()[2] == b'/'))
+        {
+            out.push(line.to_string());
+        }
+    }
+    out
+}
+
 /// Write a PNG (base64, no data: prefix) to the OS clipboard as an image.
 /// WebView `navigator.clipboard.write(image/png)` is unreliable in Tauri.
 #[tauri::command]
@@ -296,6 +359,15 @@ mod clipboard_paste_tests {
     #[test]
     fn rgba_rejects_short_buffer() {
         assert!(rgba_to_png_bytes(2, 2, &[0u8; 4]).is_err());
+    }
+
+    #[test]
+    fn parse_uri_list_and_windows_path() {
+        let text = "copy\n# comment\nfile:///C:/dumps/crash.dmp\nC:\\temp\\a.dmp\nnot-a-path";
+        let got = super::parse_clipboard_file_list_text(text);
+        assert!(got.iter().any(|p| p.contains("crash.dmp")), "{got:?}");
+        assert!(got.iter().any(|p| p.contains("a.dmp")), "{got:?}");
+        assert!(!got.iter().any(|p| p == "not-a-path"));
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1216,6 +1216,9 @@ pub fn run() {
             commands::save_temp_attachment,
 
             commands::clipboard_paste_image,
+
+            commands::clipboard_file_paths,
+
             commands::clipboard_write_image_path,
 
             commands::clipboard_write_image,

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -9148,6 +9148,14 @@ export function AppWorkbench() {
         requestComposerFocus();
         return;
       }
+      // 1b. Explorer/Finder file list (native paths — do not arrayBuffer dumps).
+      if (api.isTauri()) {
+        const native = await api.clipboardFilePaths();
+        if (native.length) {
+          await addAttachmentsFromPaths(native);
+          return;
+        }
+      }
       // 2. Image via the async Clipboard API (Chromium / some WKWebView).
       const files = await readClipboardMediaFiles();
       if (files.length) {
@@ -18073,9 +18081,26 @@ export function AppWorkbench() {
 
   const onComposerPasteFiles = useCallback(
     (files: File[]) => {
-      void addAttachmentsFromFiles(files);
+      void (async () => {
+        // Explorer copy already has an on-disk path (CF_HDROP). Reading the
+        // WebView File via arrayBuffer() throws NotReadableError for .dmp and
+        // other locked/large files — attach the original path instead.
+        if (api.isTauri()) {
+          const native = await api.clipboardFilePaths();
+          if (native.length) {
+            await addAttachmentsFromPaths(native);
+            setLocalError(null);
+            return;
+          }
+        }
+        if (files.length) {
+          await addAttachmentsFromFiles(files);
+          return;
+        }
+        reportAttachError({ code: "unreadable" }, "paste");
+      })();
     },
-    [addAttachmentsFromFiles],
+    [addAttachmentsFromFiles, addAttachmentsFromPaths, reportAttachError],
   );
 
   const onComposerPasteMediaFallback = useCallback(

--- a/src/components/ComposerEditor.tsx
+++ b/src/components/ComposerEditor.tsx
@@ -23,6 +23,7 @@ import {
 import { skillChipGlyphSvg } from "@/components/SkillChip";
 import {
   clipboardLooksLikeMedia,
+  clipboardLooksLikeOsFiles,
   clipboardPlainText,
   collectFilesFromDataTransfer,
   isFileUrlOnlyText,
@@ -1268,9 +1269,9 @@ export const ComposerEditor = memo(function ComposerEditor({
     const files = collectFilesFromDataTransfer(cd);
     const plain = clipboardPlainText(cd);
 
-    if (files.length && onPasteFiles) {
-      // Sync path: event already has File(s). Do not also run async/native
-      // fallbacks — that was a common source of duplicate attachments.
+    if ((files.length || clipboardLooksLikeOsFiles(cd)) && onPasteFiles) {
+      // Explorer/Finder copy: File blobs are often unreadable (NotReadableError
+      // on .dmp). Parent should prefer native clipboard paths over arrayBuffer.
       onPasteFiles(files);
     } else if (onPasteFiles && clipboardLooksLikeMedia(cd)) {
       // Screenshot paste: event often has image/* types but no File objects.

--- a/src/i18n/messages/de/composer.ts
+++ b/src/i18n/messages/de/composer.ts
@@ -51,6 +51,7 @@ export const deComposer = {
   "attach.err.cancelled": "Anhang abgebrochen.",
   "attach.err.openFailed": "Diese Datei konnte nicht geöffnet werden.",
   "attach.err.previewFailed": "Anhangsvorschau konnte nicht geladen werden.",
+  "attach.err.unreadable": "Die eingefügte Datei konnte nicht gelesen werden. Ziehen Sie sie in den Chat oder fügen Sie sie über + → Dateien hinzu.",
   "attach.preview.broken": "Keine Vorschau — Datei fehlt oder ist unlesbar.",
   "attach.preview.missing": "Datei nicht auf der Festplatte gefunden.",
   "attach.preview.pending": "Vorschau wird geladen…",

--- a/src/i18n/messages/en/composer.ts
+++ b/src/i18n/messages/en/composer.ts
@@ -51,6 +51,7 @@ export const enComposer = {
   "attach.err.cancelled": "Attachment cancelled.",
   "attach.err.openFailed": "Could not open this file.",
   "attach.err.previewFailed": "Could not load the attachment preview.",
+  "attach.err.unreadable": "Could not read the pasted file. Drag it into the chat or attach it with + → Files.",
   "attach.preview.broken": "Preview unavailable — file may be missing or unreadable.",
   "attach.preview.missing": "File not found on disk.",
   "attach.preview.pending": "Loading preview…",

--- a/src/i18n/messages/es/composer.ts
+++ b/src/i18n/messages/es/composer.ts
@@ -51,6 +51,7 @@ export const esComposer = {
   "attach.err.cancelled": "Adjunto cancelado.",
   "attach.err.openFailed": "No se pudo abrir este archivo.",
   "attach.err.previewFailed": "No se pudo cargar la vista previa del adjunto.",
+  "attach.err.unreadable": "No se pudo leer el archivo pegado. Arrástrelo al chat o adjúntelo con + → Archivos.",
   "attach.preview.broken": "Vista previa no disponible: el archivo puede faltar o ser ilegible.",
   "attach.preview.missing": "Archivo no encontrado en el disco.",
   "attach.preview.pending": "Cargando vista previa…",

--- a/src/i18n/messages/fil/composer.ts
+++ b/src/i18n/messages/fil/composer.ts
@@ -51,6 +51,7 @@ export const filComposer = {
   "attach.err.cancelled": "Nakansela ang attachment.",
   "attach.err.openFailed": "Hindi mabuksan ang file na ito.",
   "attach.err.previewFailed": "Hindi ma-load ang preview ng attachment.",
+  "attach.err.unreadable": "Hindi mabasa ang na-paste na file. I-drag ito sa chat o i-attach gamit ang + → Files.",
   "attach.preview.broken": "Hindi available ang preview — maaaring nawawala o hindi mabasa ang file.",
   "attach.preview.missing": "Hindi nahanap ang file sa disk.",
   "attach.preview.pending": "Nilo-load ang preview…",

--- a/src/i18n/messages/fr/composer.ts
+++ b/src/i18n/messages/fr/composer.ts
@@ -51,6 +51,7 @@ export const frComposer = {
   "attach.err.cancelled": "Pièce jointe annulée.",
   "attach.err.openFailed": "Impossible d’ouvrir ce fichier.",
   "attach.err.previewFailed": "Impossible de charger l’aperçu de la pièce jointe.",
+  "attach.err.unreadable": "Impossible de lire le fichier collé. Déposez-le dans le chat ou joignez-le via + → Fichiers.",
   "attach.preview.broken": "Aperçu indisponible — le fichier est peut-être manquant ou illisible.",
   "attach.preview.missing": "Fichier introuvable sur le disque.",
   "attach.preview.pending": "Chargement de l’aperçu…",

--- a/src/i18n/messages/id/composer.ts
+++ b/src/i18n/messages/id/composer.ts
@@ -51,6 +51,7 @@ export const idComposer = {
   "attach.err.cancelled": "Lampiran dibatalkan.",
   "attach.err.openFailed": "Berkas ini tidak dapat dibuka.",
   "attach.err.previewFailed": "Pratinjau lampiran tidak dapat dimuat.",
+  "attach.err.unreadable": "Tidak bisa membaca file yang ditempel. Seret ke chat atau lampirkan lewat + → File.",
   "attach.preview.broken": "Pratinjau tidak tersedia — berkas mungkin hilang atau tidak dapat dibaca.",
   "attach.preview.missing": "Berkas tidak ditemukan di disk.",
   "attach.preview.pending": "Memuat pratinjau…",

--- a/src/i18n/messages/it/composer.ts
+++ b/src/i18n/messages/it/composer.ts
@@ -51,6 +51,7 @@ export const itComposer = {
   "attach.err.cancelled": "Allegato annullato.",
   "attach.err.openFailed": "Impossibile aprire questo file.",
   "attach.err.previewFailed": "Impossibile caricare l’anteprima dell’allegato.",
+  "attach.err.unreadable": "Impossibile leggere il file incollato. Trascinalo nella chat o allegalo con + → File.",
   "attach.preview.broken": "Anteprima non disponibile — il file potrebbe mancare o essere illeggibile.",
   "attach.preview.missing": "File non trovato sul disco.",
   "attach.preview.pending": "Caricamento anteprima…",

--- a/src/i18n/messages/ja/composer.ts
+++ b/src/i18n/messages/ja/composer.ts
@@ -51,6 +51,7 @@ export const jaComposer = {
   "attach.err.cancelled": "添付をキャンセルしました。",
   "attach.err.openFailed": "このファイルを開けませんでした。",
   "attach.err.previewFailed": "添付のプレビューを読み込めませんでした。",
+  "attach.err.unreadable": "貼り付けたファイルを読めませんでした。チャットにドラッグするか、+ → ファイルで追加してください。",
   "attach.preview.broken": "プレビュー不可 — ファイルがないか読めない可能性があります。",
   "attach.preview.missing": "ディスク上にファイルが見つかりません。",
   "attach.preview.pending": "プレビューを読み込み中…",

--- a/src/i18n/messages/ko/composer.ts
+++ b/src/i18n/messages/ko/composer.ts
@@ -51,6 +51,7 @@ export const koComposer = {
   "attach.err.cancelled": "첨부가 취소되었습니다.",
   "attach.err.openFailed": "이 파일을 열지 못했습니다.",
   "attach.err.previewFailed": "첨부 미리보기를 불러오지 못했습니다.",
+  "attach.err.unreadable": "붙여넣은 파일을 읽을 수 없습니다. 채팅으로 끌어오거나 + → 파일로 첨부하세요.",
   "attach.preview.broken": "미리보기를 사용할 수 없습니다 — 파일이 없거나 읽을 수 없을 수 있습니다.",
   "attach.preview.missing": "디스크에서 파일을 찾을 수 없습니다.",
   "attach.preview.pending": "미리보기 불러오는 중…",

--- a/src/i18n/messages/pt-BR/composer.ts
+++ b/src/i18n/messages/pt-BR/composer.ts
@@ -51,6 +51,7 @@ export const ptBRComposer = {
   "attach.err.cancelled": "Anexo cancelado.",
   "attach.err.openFailed": "Não foi possível abrir este arquivo.",
   "attach.err.previewFailed": "Não foi possível carregar a pré-visualização do anexo.",
+  "attach.err.unreadable": "Não foi possível ler o arquivo colado. Arraste-o para o chat ou anexe com + → Arquivos.",
   "attach.preview.broken": "Pré-visualização indisponível — o arquivo pode estar ausente ou ilegível.",
   "attach.preview.missing": "Arquivo não encontrado no disco.",
   "attach.preview.pending": "Carregando pré-visualização…",

--- a/src/i18n/messages/ru/composer.ts
+++ b/src/i18n/messages/ru/composer.ts
@@ -51,6 +51,7 @@ export const ruComposer = {
   "attach.err.cancelled": "Вложение отменено.",
   "attach.err.openFailed": "Не удалось открыть этот файл.",
   "attach.err.previewFailed": "Не удалось загрузить предпросмотр вложения.",
+  "attach.err.unreadable": "Не удалось прочитать вставленный файл. Перетащите его в чат или добавьте через + → Файлы.",
   "attach.preview.broken": "Предпросмотр недоступен — файл может отсутствовать или быть нечитаемым.",
   "attach.preview.missing": "Файл не найден на диске.",
   "attach.preview.pending": "Загрузка предпросмотра…",

--- a/src/i18n/messages/ta/composer.ts
+++ b/src/i18n/messages/ta/composer.ts
@@ -51,6 +51,7 @@ export const taComposer = {
   "attach.err.cancelled": "இணைப்பு ரத்து செய்யப்பட்டது.",
   "attach.err.openFailed": "இந்தக் கோப்பைத் திறக்க முடியவில்லை.",
   "attach.err.previewFailed": "இணைப்பு மாதிரிக்காட்சியை ஏற்ற முடியவில்லை.",
+  "attach.err.unreadable": "ஒட்டிய கோப்பை படிக்க முடியவில்லை. அரட்டைக்கு இழுக்கவும் அல்லது + → Files மூலம் இணைக்கவும்.",
   "attach.preview.broken": "முன்னோட்டம் கிடைக்கவில்லை - கோப்பு காணாமல் போயிருக்கலாம் அல்லது படிக்கமுடியாமல் இருக்கலாம்.",
   "attach.preview.missing": "கோப்பு வட்டில் காணப்படவில்லை.",
   "attach.preview.pending": "முன்னோட்டத்தை ஏற்றுகிறது…",

--- a/src/i18n/messages/uk/composer.ts
+++ b/src/i18n/messages/uk/composer.ts
@@ -51,6 +51,7 @@ export const ukComposer = {
   "attach.err.cancelled": "Вкладення скасовано.",
   "attach.err.openFailed": "Не вдалося відкрити цей файл.",
   "attach.err.previewFailed": "Не вдалося завантажити попередній перегляд вкладення.",
+  "attach.err.unreadable": "Не вдалося прочитати вставлений файл. Перетягніть його в чат або додайте через + → Файли.",
   "attach.preview.broken": "Попередній перегляд недоступний — файл може бути відсутній або нечитабельний.",
   "attach.preview.missing": "Файл не знайдено на диску.",
   "attach.preview.pending": "Завантаження попереднього перегляду…",

--- a/src/i18n/messages/zh-TW/composer.ts
+++ b/src/i18n/messages/zh-TW/composer.ts
@@ -84,6 +84,7 @@ export const zhTWComposer = {
   "attach.err.cancelled": "已取消附加。",
   "attach.err.openFailed": "無法開啟該檔案。",
   "attach.err.previewFailed": "無法載入附件預覽。",
+  "attach.err.unreadable": "無法讀取貼上的檔案。請拖入對話，或用 + → 檔案 新增。",
   "attach.preview.broken": "預覽不可用 — 檔案可能缺失或無法讀取。",
   "attach.preview.missing": "磁碟上未找到該檔案。",
   "attach.preview.pending": "正在載入預覽…",

--- a/src/i18n/messages/zh/composer.ts
+++ b/src/i18n/messages/zh/composer.ts
@@ -51,6 +51,7 @@ export const zhComposer = {
   "attach.err.cancelled": "已取消附加。",
   "attach.err.openFailed": "无法打开该文件。",
   "attach.err.previewFailed": "无法加载附件预览。",
+  "attach.err.unreadable": "无法读取粘贴的文件。请拖入对话，或用 + → 文件 添加。",
   "attach.preview.broken": "预览不可用 — 文件可能缺失或无法读取。",
   "attach.preview.missing": "磁盘上未找到该文件。",
   "attach.preview.pending": "正在加载预览…",

--- a/src/lib/api/fs.ts
+++ b/src/lib/api/fs.ts
@@ -55,6 +55,20 @@ export async function clipboardPasteImage() {
   return invoke<PathEntry | null>("clipboard_paste_image");
 }
 
+/**
+ * Absolute paths from the OS clipboard file list (Explorer / Finder copy).
+ * Empty when the clipboard has no files (screenshots, text).
+ */
+export async function clipboardFilePaths() {
+  if (!isTauri()) return [];
+  try {
+    const paths = await invoke<string[]>("clipboard_file_paths");
+    return Array.isArray(paths) ? paths.filter((p) => !!p?.trim()) : [];
+  } catch {
+    return [];
+  }
+}
+
 export interface PathEntry {
   path: string;
   name: string;

--- a/src/lib/attachmentsPro.test.ts
+++ b/src/lib/attachmentsPro.test.ts
@@ -64,6 +64,18 @@ describe("classifyAttachError", () => {
     expect(classifyAttachError("something weird happened")).toBe("other");
     expect(classifyAttachError(null)).toBe("other");
   });
+
+  it("classifies WebView NotReadableError as unreadable", () => {
+    expect(
+      classifyAttachError(
+        "The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired. NotReadableError",
+      ),
+    ).toBe("unreadable");
+    expect(classifyAttachError({ code: "unreadable" })).toBe("unreadable");
+    expect(attachErrorMessageKey("unreadable", "paste")).toBe(
+      "attach.err.unreadable",
+    );
+  });
 });
 
 describe("attachErrorMessageKey / silent", () => {

--- a/src/lib/attachmentsPro.ts
+++ b/src/lib/attachmentsPro.ts
@@ -26,6 +26,7 @@ export type AttachErrorKind =
   | "unsupported"
   | "open_failed"
   | "preview_failed"
+  | "unreadable"
   | "other";
 
 /** Where the failure was observed (affects default copy slightly). */
@@ -115,6 +116,9 @@ export function classifyAttachError(err: unknown): AttachErrorKind {
   if (code === "open_failed" || code === "open-failed") return "open_failed";
   if (code === "preview_failed" || code === "preview-failed") {
     return "preview_failed";
+  }
+  if (code === "unreadable" || code === "not_readable" || code === "notreadableerror") {
+    return "unreadable";
   }
 
   const s = errText(err).toLowerCase();
@@ -245,6 +249,15 @@ export function classifyAttachError(err: unknown): AttachErrorKind {
     return "preview_failed";
   }
 
+  // WebView2 / Chromium: Explorer-copied files (esp. .dmp) fail File.arrayBuffer().
+  if (
+    s.includes("notreadableerror") ||
+    s.includes("could not be read, typically due to permission") ||
+    s.includes("not readable")
+  ) {
+    return "unreadable";
+  }
+
   // Generic path classify / attach path failures
   if (
     s.includes("paths_classify") ||
@@ -293,6 +306,8 @@ export function attachErrorMessageKey(
       return "attach.err.openFailed";
     case "preview_failed":
       return "attach.err.previewFailed";
+    case "unreadable":
+      return "attach.err.unreadable";
     case "other":
     default:
       if (source === "paste" || source === "native_clipboard") {

--- a/src/lib/clipboardPaste.test.ts
+++ b/src/lib/clipboardPaste.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   clipboardLooksLikeMedia,
+  clipboardLooksLikeOsFiles,
   clipboardPlainText,
   collectFilesFromDataTransfer,
   fileKey,
+  fileNativePath,
   isFileUrlOnlyText,
+  isNotReadableBlobError,
   readClipboardMediaFiles,
 } from "./clipboardPaste";
 
@@ -122,6 +125,40 @@ describe("fileKey", () => {
     const a = fakeFile("image.png", "image/png", 40, 1);
     const b = fakeFile("paste.png", "image/png", 40, 2);
     expect(fileKey(a)).toBe(fileKey(b));
+  });
+});
+
+describe("clipboardLooksLikeOsFiles / fileNativePath / isNotReadableBlobError", () => {
+  it("detects Explorer Files list without readable blobs", () => {
+    const data = {
+      files: { length: 0, item: () => null } as unknown as FileList,
+      items: [{ kind: "file", type: "", getAsFile: () => null }],
+      types: ["Files"],
+      getData: () => "",
+    } as unknown as DataTransfer;
+    expect(clipboardLooksLikeOsFiles(data)).toBe(true);
+    expect(clipboardLooksLikeOsFiles({
+      files: { length: 0, item: () => null } as unknown as FileList,
+      items: [],
+      types: ["image/png"],
+      getData: () => "",
+    } as unknown as DataTransfer)).toBe(false);
+  });
+
+  it("reads Tauri File.path when present", () => {
+    const f = Object.assign(fakeFile("crash.dmp", ""), {
+      path: "C:\\\\dumps\\\\crash.dmp",
+    });
+    expect(fileNativePath(f)).toBe("C:\\\\dumps\\\\crash.dmp");
+    expect(fileNativePath(fakeFile("crash.dmp", ""))).toBe("");
+  });
+
+  it("classifies Chromium NotReadableError", () => {
+    const err = Object.assign(new Error(
+      "The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.",
+    ), { name: "NotReadableError" });
+    expect(isNotReadableBlobError(err)).toBe(true);
+    expect(isNotReadableBlobError(new Error("disk full"))).toBe(false);
   });
 });
 

--- a/src/lib/clipboardPaste.test.ts
+++ b/src/lib/clipboardPaste.test.ts
@@ -145,6 +145,20 @@ describe("clipboardLooksLikeOsFiles / fileNativePath / isNotReadableBlobError", 
     } as unknown as DataTransfer)).toBe(false);
   });
 
+  it("does not treat a copied http URL uri-list as OS files", () => {
+    const data = {
+      files: { length: 0, item: () => null } as unknown as FileList,
+      items: [{ kind: "string", type: "text/plain", getAsFile: () => null }],
+      types: ["text/uri-list", "text/plain"],
+      getData: (t: string) =>
+        t === "text/plain" || t === "text/uri-list"
+          ? "https://example.com/shot.png"
+          : "",
+    } as unknown as DataTransfer;
+    expect(clipboardLooksLikeOsFiles(data)).toBe(false);
+    expect(clipboardLooksLikeMedia(data)).toBe(false);
+  });
+
   it("reads Tauri File.path when present", () => {
     const f = Object.assign(fakeFile("crash.dmp", ""), {
       path: "C:\\\\dumps\\\\crash.dmp",

--- a/src/lib/clipboardPaste.ts
+++ b/src/lib/clipboardPaste.ts
@@ -4,8 +4,9 @@
  * Tauri / WKWebView often omits File objects from the paste event for
  * screenshots (only `image/png` types, or nothing usable). Callers should:
  * 1. collectFilesFromDataTransfer(clipboardData)
- * 2. if empty + clipboardLooksLikeMedia → readClipboardMediaFiles()
- * 3. if still empty → native Host clipboard (arboard)
+ * 2. if OS file-list paste (Explorer/Finder) → native Host file paths
+ * 3. if empty + clipboardLooksLikeMedia → readClipboardMediaFiles()
+ * 4. if still empty → native Host clipboard image (arboard)
  *
  * Always dedupe before attach: WebViews often expose the same blob via both
  * `data.files` and `data.items`, or multiple image/* MIME flavors.
@@ -43,6 +44,53 @@ export function collectFilesFromDataTransfer(
   }
 
   return Array.from(fileMap.values());
+}
+
+/** Absolute path on Tauri/WebView File objects when the host filled it in. */
+export function fileNativePath(f: File): string {
+  const p = (f as File & { path?: string }).path;
+  return typeof p === "string" ? p.trim() : "";
+}
+
+/**
+ * Explorer / Finder file copy. Distinct from a screenshot (`image/png` types
+ * with no `Files` list): WebView File blobs from CF_HDROP are often
+ * unreadable (`NotReadableError`), so the Host must use native paths.
+ */
+export function clipboardLooksLikeOsFiles(
+  data: DataTransfer | null | undefined,
+): boolean {
+  if (!data) return false;
+  const types = Array.from(data.types ?? []);
+  if (types.some((t) => t === "Files" || t === "text/uri-list")) return true;
+  if (data.files && data.files.length > 0) return true;
+  const items = data.items;
+  if (items) {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (!item) continue;
+      if (item.kind === "file" && !item.type.startsWith("image/")) return true;
+    }
+  }
+  return false;
+}
+
+/** Chromium/WebView2 cannot read the pasted File blob (locked / sandboxed). */
+export function isNotReadableBlobError(err: unknown): boolean {
+  const name =
+    err && typeof err === "object" && "name" in err
+      ? String((err as { name?: unknown }).name)
+      : "";
+  if (name === "NotReadableError") return true;
+  const msg =
+    err instanceof Error
+      ? `${err.name} ${err.message}`
+      : err == null
+        ? ""
+        : String(err);
+  return /notreadableerror|could not be read, typically due to permission/i.test(
+    msg,
+  );
 }
 
 /**

--- a/src/lib/clipboardPaste.ts
+++ b/src/lib/clipboardPaste.ts
@@ -62,7 +62,10 @@ export function clipboardLooksLikeOsFiles(
 ): boolean {
   if (!data) return false;
   const types = Array.from(data.types ?? []);
-  if (types.some((t) => t === "Files" || t === "text/uri-list")) return true;
+  // `Files` is Explorer/Finder. Do not treat bare `text/uri-list` as an OS
+  // file list — Firefox and Chromium/Linux put uri-list on copied links and
+  // browser images, which must stay on the media/text paste path (#756).
+  if (types.some((t) => t === "Files")) return true;
   if (data.files && data.files.length > 0) return true;
   const items = data.items;
   if (items) {


### PR DESCRIPTION
## Summary
- Windows Explorer paste of on-disk files (especially `.dmp`) no longer calls WebView `File.arrayBuffer()`, which throws Chromium `NotReadableError`.
- Host reads the OS clipboard file list (`CF_HDROP` on Windows; `file://` / uri-list elsewhere) and attaches the original `@path`, same as drag-drop.
- Screenshots / in-memory blobs still go through `save_temp_attachment`.
- Unreadable blobs map to `attach.err.unreadable` (15 locales) instead of dumping English `NotReadableError` in the banner.

Fixes #755

## Type of change
- [x] Bug fix

## Test plan
- [x] `clipboardPaste.test.ts` covers OS-file detection, `File.path`, and `NotReadableError`
- [x] `attachmentsPro.test.ts` classifies `NotReadableError` as `unreadable`
- [x] Rust `parse_clipboard_file_list_text` unit test
- [ ] `pnpm typecheck` / `pnpm test` / `cargo test` (CI)
- [ ] Windows: copy a `.dmp` in Explorer, paste into composer → attaches original path
- [ ] Windows: paste a screenshot still saves `attachments/paste/*.png`
- [ ] Drag-drop of the same dump still works (unchanged)

## Checklist
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh + zh-TW + other catalogs)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased
- [x] No secrets
