### PR TITLE
fix(session): stop local session API stalling after the first turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
+- **Local session API no longer wedges after the first turn**: A hung ACP handshake used to keep `connect_lock` forever (90s timeout abandoned the waiter without aborting the task). Later `--session-send` / `POST /turns` then waited ~180s and the CLI lied with `app_not_running`. Connect now aborts and bounded-kills pending children; dispatch returns `retry_later` in 15s; health exposes `connectLockBusy`; CLI maps timeouts to `error`; queued external prompts persist on disk and the Host drains them without the main window.
 - **Japanese PR hub and Ukrainian agent command keep `{name}` (#751)**: `ja` `prHub.author` was `作成者` with no author; `uk` `preferredCurrent` shipped `--agent ` with nothing to paste. Catalog tests now fail if any locale drops or renames an `en` placeholder.
 - **Sidebar tree text columns line up (#745)**: Projects and Other labels share one left edge. Project names and the session titles under them share `--tree-text-inset`. The L1 chevron column is 20px (was 28).
 - **Windows tray icon stays visible on a dark taskbar (#747)**: The notification-area mark is no longer a black glyph on transparency. Light taskbars get a black tile / white glyph; dark taskbars get the inverse. The host follows `SystemUsesLightTheme` (not the in-app theme) and swaps live.
@@ -44,6 +45,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **本地 session API 干完一轮后不再卡死**：卡住的 ACP 握手会把 `connect_lock` 永久占住（90s 超时只放弃等待、不 abort 任务），之后的 `--session-send` / `POST /turns` 会挂到约 180s，CLI 还谎称 `app_not_running`。现在超时会 abort 并用有上界的 kill 清 pending 子进程；派活 15s 内回 `retry_later`；health 带 `connectLockBusy`；CLI 把超时映射成 `error`；外部 queued 落盘，由 Host drain，不依赖主窗口。
 - **日语 PR hub 和乌克兰语 agent 命令不再丢掉 `{name}`（#751）**：`ja` 的 `prHub.author` 只有「作成者」没有人名；`uk` 的 `preferredCurrent` 复制出来是空的 `--agent `。目录测试会拦截任何语言丢掉或改名 en 占位符。
 - **侧栏树文字列对齐（#745）**：Projects 与 Other 标题左缘对齐；项目名与其下会话标题共用 `--tree-text-inset`。一级箭头列从 28px 收到 20px。
 - **Windows 托盘在深色任务栏上不再隐身（#747）**：通知区不再用透明底黑标。浅色任务栏黑底白标，深色任务栏白底黑标。跟随任务栏 `SystemUsesLightTheme`（不是应用内主题），切换后即时换标。

--- a/docs/llm-wiki/session-api.md
+++ b/docs/llm-wiki/session-api.md
@@ -27,7 +27,7 @@ App 启动后 Host 绑定 `127.0.0.1:0`，把 `{url, token, pid}` 写到：
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| GET | `/v1/health` | 探活 |
+| GET | `/v1/health` | 探活。JSON：`{ ok, connectLockBusy }`。`connectLockBusy: true` 表示会话通道卡住，App 仍在跑 |
 | GET | `/v1/sessions?include_archived=` | 列表 |
 | POST | `/v1/sessions/{id}/turns` | 续跑。body：`{ "prompt", "idempotencyKey"? }` |
 
@@ -38,11 +38,12 @@ App 启动后 Host 绑定 `127.0.0.1:0`，把 `{url, token, pid}` 写到：
 | status | HTTP | 含义 |
 |--------|------|------|
 | `turn_started` | 200 | 已 `connect` + `send_message`，同一条 App session |
-| `queued` | 202 | 该会话正在跑一轮（绘画 / 工具 / 流式）。提示词进入**同一条** composer 跟进队列；Host 发 `session://send_queue`，主窗口队列条立刻显示。**不打断**当前轮，本轮结束后自动发送 |
+| `queued` | 202 | 该会话正在跑一轮（绘画 / 工具 / 流式）。提示词**落盘**并由 Host 在本轮结束后 drain；主窗口若在则发 `session://send_queue` 给队列条展示。**不打断**当前轮 |
 | `busy` | 409 | 保留：无法入队时的冲突（正常路径走 `queued`） |
 | `not_found` | 404 | 没有这条 App session |
-| `app_not_running` | 503 | 没有在跑的 Host（CLI 侧） |
-| `error` | 400 | 空 prompt / 项目未信任 / 连接失败等 |
+| `app_not_running` | 503 | **CLI 侧**：连不上 loopback（没有在跑的 Host）。HTTP 超时 / 5xx **不是**这个状态 |
+| `retry_later` | 503 | Host 忙于 connect（15s 内没派出去）。请稍后重试；App 仍在跑 |
+| `error` | 400 | 空 prompt / 项目未信任 / 连接失败等；CLI 把 HTTP 超时也映射成 `error` |
 
 `idempotencyKey` 命中则回放上次结果（磁盘 cap 200）。
 
@@ -59,7 +60,7 @@ grok-app --session-send <session-id> --prompt "…" --idempotency-key k1
 ```
 
 - `--sessions`：优先打回环；没有 App 则读磁盘索引。
-- `--session-send`：必须有正在跑的 App（或托盘）。否则 `app_not_running`，exit 2。正在跑一轮时回 `queued`（exit 0），不抢窗口、不打断。
+- `--session-send`：必须有正在跑的 App（或托盘）。**连不上端口** → `app_not_running`，exit 2。**HTTP 超时 / 5xx** → `error`（带原始信息），exit 1；不要把它当成 App 没开。正在跑一轮时回 `queued`（exit 0），不抢窗口、不打断。
 - 二进制名随安装变化（macOS `.app` 内可执行文件 / Windows exe）。设置 → 运行时 → 连接 可把用户级命令装到 `~/.local/bin/grok-app`（指向当前正在跑的二进制）。
 
 ## Host 路径
@@ -67,9 +68,9 @@ grok-app --session-send <session-id> --prompt "…" --idempotency-key k1
 `src-tauri/src/session_api.rs`
 
 1. `prepare_send`：会话必须已在索引里；绑定项目须 `trusted` + `path_ok`；cwd 优先 `worktree_path`。
-2. `dispatch_turn`：若 `session_turn_busy`（含绘画 / 工具 / `prompt_in_flight`）→ `enqueue_while_busy`，fanout `session://send_queue`，**不** `connect` 抢槽。空闲才 `connect` + `send_message`。
+2. `dispatch_turn`：若 `session_turn_busy`（含绘画 / 工具 / `prompt_in_flight`）→ `enqueue_while_busy`（落盘 + 可选 GUI 事件），**不** `connect` 抢槽。空闲才 `connect` + `send_message`。HTTP 层 **15s** 超时回 `retry_later`。
 3. 发送竞态仍 `still running` / `task_already_running` → 同样入队，不回硬 `busy`。
-4. 主窗口 `useSendQueue(acceptExternal)` 把事件 merge 进现有跟进队列（`source: external`）；副窗口不听，避免双发。
+4. 主窗口 `useSendQueue(acceptExternal)` 把事件 merge 进现有跟进队列（`source: external`，**只展示**；Host drain 真正发送）。副窗口不听，避免双发。
 
 ## Settings
 
@@ -79,9 +80,32 @@ grok-app --session-send <session-id> --prompt "…" --idempotency-key k1
 
 新条目必须进 `settingsCatalog`。
 
+## 故障排查
+
+### `app_not_running` 的真实含义
+
+| 现象 | 含义 | 怎么处理 |
+|------|------|----------|
+| 没有 `session-api.json` / 连不上 127.0.0.1 端口 | App 确实没在跑（或托盘已退出） | 启动 App 或留在托盘 |
+| CLI 报 `app_not_running` 但探活其实 200 | **旧 CLI 把任何 HTTP 错误（含超时）都映射成这个报文** | 升级 App；看 JSON `status` 字段，不要只看这句话 |
+| `POST /turns` 超时 / `retry_later` | Host 正在 connect，或 `connect_lock` 被卡住的握手占住 | 等 ≤90s 或看 `/v1/health` 的 `connectLockBusy`；不要立刻连发重试（会堆僵尸 `grok.exe`） |
+| `/v1/health` 的 `connectLockBusy: true` | App 活着，会话通道卡住 | 等 wall-clock abort 放锁；一直 busy 则重启 App |
+| `/v1/health` 自己也超时 | 多半是调用方超时（CLI 默认 8s）或 runtime 被阻塞 IO 卡死 | 先确认 token；若 lockBusy 探活都 >1s，属于另一类 bug |
+
+### Windows 代理
+
+Grok App **启动时**读系统代理，子进程继承 App 环境。命令行派活的 CLI **自身**不读系统代理设置。若子进程连不上上游（握手 wedge）：
+
+1. 把 `HTTPS_PROXY` / `HTTP_PROXY` 设成**用户级/系统级环境变量**
+2. **彻底退出再启动** Grok App（托盘右键退出，不是关窗口）
+
+### 派活建议
+
+- 串行：上一轮 `turn_started` 且本轮结束后再发下一条
+- 收到超时不要立刻重试轰炸
+
 ## 后续（本切片不做）
 
 - 外部创建新会话
-- 退出后磁盘队列 drain
 - interrupt 模式
 - 回执 / 完整 transcript 拉取

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -2281,7 +2281,18 @@ impl AcpClient {
                 let _ = self
                     .event_tx
                     .send((None, AcpEvent::ProcessExited { code: None }));
-                self.kill().await;
+                if tokio::time::timeout(
+                    std::time::Duration::from_secs(STDIN_WRITE_TIMEOUT_SECS),
+                    self.kill(),
+                )
+                .await
+                .is_err()
+                {
+                    tracing::warn!(
+                        secs = STDIN_WRITE_TIMEOUT_SECS,
+                        "acp kill after stdin timeout also timed out"
+                    );
+                }
                 Err(head)
             }
         }

--- a/src-tauri/src/session_api.rs
+++ b/src-tauri/src/session_api.rs
@@ -31,7 +31,24 @@ pub const INCLUDE_ARCHIVED_FLAG: &str = "--include-archived";
 
 const ENDPOINT_FILE: &str = "session-api.json";
 const IDEMPOTENCY_FILE: &str = "session-api-idempotency.json";
+const QUEUE_FILE: &str = "session-api-queue.json";
 const IDEMPOTENCY_CAP: usize = 200;
+const QUEUE_CAP: usize = 200;
+
+/// Bound `dispatch_turn` so HTTP/CLI never wait the connect 90s + send 90s
+/// worst case (~180s). Lock recovery is still knife-1's wall-clock abort.
+pub const DISPATCH_TURN_TIMEOUT_SECS: u64 = 15;
+/// CLI HTTP client must outlive the server dispatch budget so `--session-send`
+/// can parse `retry_later` instead of surfacing a transport timeout.
+pub const CLI_HTTP_TIMEOUT_SECS: u64 = DISPATCH_TURN_TIMEOUT_SECS + 5;
+const HOST_BUSY_RETRY_MESSAGE: &str = "host busy: connect in progress, retry later";
+
+static QUEUE_FILE_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+fn drain_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -43,6 +60,8 @@ pub enum TurnStatus {
     Busy,
     NotFound,
     AppNotRunning,
+    /// Host is wedged on connect/send; caller should retry shortly. HTTP 503.
+    RetryLater,
     Error,
 }
 
@@ -85,6 +104,7 @@ pub struct TurnResult {
 }
 
 pub const SEND_QUEUE_EVENT: &str = "session://send_queue";
+pub const SEND_QUEUE_TAKE_EVENT: &str = "session://send_queue_take";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -138,7 +158,15 @@ pub fn emit_external_queue(app: &AppHandle, session_id: &str, prompt: &str, item
 
 pub fn enqueue_while_busy(app: &AppHandle, session_id: &str, prompt: &str) -> TurnResult {
     let item_id = format!("q-ext-{}", uuid::Uuid::new_v4());
-    emit_external_queue(app, session_id, prompt, &item_id);
+    persist_queue_item(PersistedQueueItem {
+        session_id: session_id.to_string(),
+        item_id: item_id.clone(),
+        prompt: prompt.to_string(),
+        created_at: chrono::Utc::now().timestamp_millis(),
+    });
+    if main_webview_can_drain(app) {
+        emit_external_queue(app, session_id, prompt, &item_id);
+    }
     TurnResult {
         ok: true,
         status: TurnStatus::Queued,
@@ -147,6 +175,162 @@ pub fn enqueue_while_busy(app: &AppHandle, session_id: &str, prompt: &str) -> Tu
         message: Some("queued until the current turn ends".into()),
         queue_item_id: Some(item_id),
         queued_prompt: Some(prompt.to_string()),
+    }
+}
+
+fn main_webview_can_drain(app: &AppHandle) -> bool {
+    app.get_webview_window("main")
+        .and_then(|w| w.is_visible().ok())
+        .unwrap_or(false)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct PersistedQueue {
+    #[serde(default)]
+    items: Vec<PersistedQueueItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedQueueItem {
+    session_id: String,
+    item_id: String,
+    prompt: String,
+    created_at: i64,
+}
+
+fn queue_path() -> PathBuf {
+    app_data_root().join(QUEUE_FILE)
+}
+
+fn load_persisted_queue_unlocked() -> PersistedQueue {
+    fs::read_to_string(queue_path())
+        .ok()
+        .and_then(|raw| serde_json::from_str::<PersistedQueue>(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn save_persisted_queue_unlocked(store: &PersistedQueue) {
+    let _ = ensure_app_dirs();
+    if let Ok(body) = serde_json::to_string_pretty(store) {
+        let _ = fs::write(queue_path(), body);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(queue_path(), fs::Permissions::from_mode(0o600));
+        }
+    }
+}
+
+fn load_persisted_queue() -> PersistedQueue {
+    let _g = QUEUE_FILE_LOCK.lock();
+    load_persisted_queue_unlocked()
+}
+
+fn persist_queue_item(item: PersistedQueueItem) {
+    let _g = QUEUE_FILE_LOCK.lock();
+    let mut store = load_persisted_queue_unlocked();
+    store.items.retain(|e| e.item_id != item.item_id);
+    store.items.push(item);
+    if store.items.len() > QUEUE_CAP {
+        let drop_n = store.items.len() - QUEUE_CAP;
+        store.items.drain(0..drop_n);
+    }
+    save_persisted_queue_unlocked(&store);
+}
+
+fn take_persisted_head(session_id: &str) -> Option<PersistedQueueItem> {
+    let _g = QUEUE_FILE_LOCK.lock();
+    let mut store = load_persisted_queue_unlocked();
+    let idx = store
+        .items
+        .iter()
+        .position(|e| e.session_id == session_id)?;
+    let item = store.items.remove(idx);
+    save_persisted_queue_unlocked(&store);
+    Some(item)
+}
+
+fn requeue_persisted_front(item: PersistedQueueItem) {
+    let _g = QUEUE_FILE_LOCK.lock();
+    let mut store = load_persisted_queue_unlocked();
+    store.items.retain(|e| e.item_id != item.item_id);
+    store.items.insert(0, item);
+    save_persisted_queue_unlocked(&store);
+}
+
+pub fn emit_external_queue_take(app: &AppHandle, session_id: &str, item_id: &str) {
+    crate::mirror::fanout_event(
+        app,
+        SEND_QUEUE_TAKE_EVENT,
+        serde_json::json!({
+            "sessionId": session_id,
+            "itemId": item_id,
+        }),
+    );
+}
+
+/// Host-side drain of persisted external prompts (webview is display-only).
+pub async fn drain_ready_external_queues(app: &AppHandle, mgr: &Arc<SessionManager>) {
+    let Ok(_drain) = drain_lock().try_lock() else {
+        return;
+    };
+    let items = load_persisted_queue().items;
+    let mut seen = std::collections::HashSet::<String>::new();
+    for item in items {
+        if !seen.insert(item.session_id.clone()) {
+            continue;
+        }
+        if mgr.session_turn_busy(&item.session_id) {
+            continue;
+        }
+        let Some(head) = take_persisted_head(&item.session_id) else {
+            continue;
+        };
+        let prepared = match prepare_send(&head.session_id, &head.prompt) {
+            Ok(p) => p,
+            Err(e) => {
+                if e.status == TurnStatus::NotFound {
+                    tracing::warn!(
+                        session = %head.session_id,
+                        "external queue drain dropped (session gone)"
+                    );
+                    continue;
+                }
+                tracing::warn!(
+                    session = %head.session_id,
+                    error = ?e.message,
+                    "external queue drain skipped (prepare_send); requeued"
+                );
+                requeue_persisted_front(head);
+                continue;
+            }
+        };
+        let result = dispatch_turn_or_timeout(app, mgr, prepared).await;
+        if result.status == TurnStatus::TurnStarted || result.status == TurnStatus::Queued {
+            emit_external_queue_take(app, &head.session_id, &head.item_id);
+        } else {
+            requeue_persisted_front(head.clone());
+            if main_webview_can_drain(app) {
+                emit_external_queue(app, &head.session_id, &head.prompt, &head.item_id);
+            }
+        }
+    }
+}
+
+/// Fire-and-forget so the stream-stall watchdog is not blocked on dispatch.
+pub fn schedule_drain_ready_external_queues(app: AppHandle, mgr: Arc<SessionManager>) {
+    tauri::async_runtime::spawn(async move {
+        drain_ready_external_queues(&app, &mgr).await;
+    });
+}
+
+fn fanout_persisted_queue(app: &AppHandle) {
+    if !main_webview_can_drain(app) {
+        return;
+    }
+    for item in load_persisted_queue().items {
+        emit_external_queue(app, &item.session_id, &item.prompt, &item.item_id);
     }
 }
 
@@ -589,6 +773,44 @@ pub fn remember_idempotency(key: &str, result: &TurnResult) {
     }
 }
 
+/// HTTP-layer errors from the CLI client.
+/// Connection-refused / DNS → app is not listening (`app_not_running`).
+/// Timeouts and 5xx-shaped transport failures → `error` (app may still be up).
+pub fn classify_cli_transport_error(err: &str, session_id: &str) -> (TurnStatus, i32, String) {
+    if cli_error_means_app_not_running(err) {
+        (
+            TurnStatus::AppNotRunning,
+            2,
+            format!(
+                "Grok App is not running ({err}). Start the app (or leave it in the tray), then retry."
+            ),
+        )
+    } else {
+        (
+            TurnStatus::Error,
+            1,
+            format!("session-api request failed ({err}) for session {session_id}"),
+        )
+    }
+}
+
+pub fn cli_error_means_app_not_running(err: &str) -> bool {
+    let e = err.to_ascii_lowercase();
+    if e.contains("timed out") || e.contains("timeout") {
+        return false;
+    }
+    if e.contains("503") || e.contains("500") || e.contains("502") || e.contains("504") {
+        return false;
+    }
+    e.contains("connection refused")
+        || e.contains("connect error")
+        || e.contains("error connecting")
+        || e.contains("dns error")
+        || e.contains("no such host")
+        || e.contains("network is unreachable")
+        || e.contains("failed to lookup")
+}
+
 pub fn classify_send_error(err: &str) -> TurnStatus {
     let e = err.to_ascii_lowercase();
     if e.contains("still running") || e.contains("task_already_running") {
@@ -670,6 +892,34 @@ pub struct PreparedSend {
     pub prompt: String,
 }
 
+pub async fn with_dispatch_timeout_for<F>(
+    budget: std::time::Duration,
+    session_id: String,
+    fut: F,
+) -> TurnResult
+where
+    F: std::future::Future<Output = TurnResult>,
+{
+    match tokio::time::timeout(budget, fut).await {
+        Ok(result) => result,
+        Err(_) => TurnResult::fail(TurnStatus::RetryLater, session_id, HOST_BUSY_RETRY_MESSAGE),
+    }
+}
+
+pub async fn dispatch_turn_or_timeout(
+    app: &AppHandle,
+    mgr: &Arc<SessionManager>,
+    req: PreparedSend,
+) -> TurnResult {
+    let sid = req.session_id.clone();
+    with_dispatch_timeout_for(
+        std::time::Duration::from_secs(DISPATCH_TURN_TIMEOUT_SECS),
+        sid,
+        dispatch_turn(app, mgr, req),
+    )
+    .await
+}
+
 pub async fn dispatch_turn(
     app: &AppHandle,
     mgr: &Arc<SessionManager>,
@@ -742,10 +992,12 @@ async fn handle_turn(
             return (status_for(&r.status), Json(r));
         }
     };
-    let mut result = dispatch_turn(&state.app, &state.mgr, prepared).await;
+    let mut result = dispatch_turn_or_timeout(&state.app, &state.mgr, prepared).await;
     result.idempotency_key = key.clone();
-    if let Some(ref k) = key {
-        remember_idempotency(k, &result);
+    if result.status != TurnStatus::RetryLater {
+        if let Some(ref k) = key {
+            remember_idempotency(k, &result);
+        }
     }
     (status_for(&result.status), Json(result))
 }
@@ -756,7 +1008,7 @@ fn status_for(s: &TurnStatus) -> StatusCode {
         TurnStatus::Queued => StatusCode::ACCEPTED,
         TurnStatus::Busy => StatusCode::CONFLICT,
         TurnStatus::NotFound => StatusCode::NOT_FOUND,
-        TurnStatus::AppNotRunning => StatusCode::SERVICE_UNAVAILABLE,
+        TurnStatus::AppNotRunning | TurnStatus::RetryLater => StatusCode::SERVICE_UNAVAILABLE,
         TurnStatus::Error => StatusCode::BAD_REQUEST,
     }
 }
@@ -796,15 +1048,24 @@ async fn post_turn(
     (code, json).into_response()
 }
 
+pub fn health_payload(mgr: &SessionManager) -> serde_json::Value {
+    serde_json::json!({
+        "ok": true,
+        "connectLockBusy": mgr.connect_lock_busy(),
+    })
+}
+
 async fn get_health(State(state): State<HttpState>, headers: HeaderMap) -> impl IntoResponse {
     if !token_ok(&headers, &state.token) {
         return unauthorized().into_response();
     }
-    Json(serde_json::json!({ "ok": true })).into_response()
+    Json(health_payload(&state.mgr)).into_response()
 }
 
 pub async fn start(app: AppHandle, mgr: Arc<SessionManager>) -> Result<SessionApiHandle, String> {
     let token = random_token();
+    fanout_persisted_queue(&app);
+    schedule_drain_ready_external_queues(app.clone(), Arc::clone(&mgr));
     let state = HttpState {
         token: token.clone(),
         mgr,
@@ -973,16 +1234,11 @@ pub fn run_cli() -> i32 {
                     }
                 }
                 Err(e) => {
-                    let mut out = TurnResult::fail(
-                        TurnStatus::AppNotRunning,
-                        session_id,
-                        format!(
-                            "Grok App is not reachable ({e}). Start the app (or leave it in the tray), then retry."
-                        ),
-                    );
+                    let (status, code, message) = classify_cli_transport_error(&e, &session_id);
+                    let mut out = TurnResult::fail(status, session_id, message);
                     out.idempotency_key = idempotency_key;
                     print_turn(&out);
-                    2
+                    code
                 }
             }
         }
@@ -1005,7 +1261,7 @@ fn print_turn(r: &TurnResult) {
 
 fn http_client() -> Result<reqwest::blocking::Client, String> {
     reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(8))
+        .timeout(std::time::Duration::from_secs(CLI_HTTP_TIMEOUT_SECS))
         .build()
         .map_err(|e| e.to_string())
 }
@@ -1223,5 +1479,103 @@ mod tests {
             Ok(_) => true,
             Err(e) => !e.contains("not a session-api command"),
         }
+    }
+
+    #[test]
+    fn retry_later_is_503_and_serializes() {
+        assert_eq!(
+            status_for(&TurnStatus::RetryLater),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        let raw = serde_json::to_value(TurnStatus::RetryLater).unwrap();
+        assert_eq!(raw, serde_json::json!("retry_later"));
+        assert!(DISPATCH_TURN_TIMEOUT_SECS < 90);
+        assert!(CLI_HTTP_TIMEOUT_SECS > DISPATCH_TURN_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn cli_timeout_is_not_app_not_running() {
+        assert!(!cli_error_means_app_not_running(
+            "error sending request for url (http://127.0.0.1:9/v1/sessions/x/turns): operation timed out"
+        ));
+        let (status, code, msg) = classify_cli_transport_error("operation timed out", "abc");
+        assert_eq!(status, TurnStatus::Error);
+        assert_eq!(code, 1);
+        assert!(!msg.to_ascii_lowercase().contains("not running"), "{msg}");
+    }
+
+    #[test]
+    fn cli_connection_refused_is_app_not_running() {
+        assert!(cli_error_means_app_not_running(
+            "error sending request for url (http://127.0.0.1:9/v1/sessions/x/turns): connection refused"
+        ));
+        let (status, code, msg) = classify_cli_transport_error("connection refused", "abc");
+        assert_eq!(status, TurnStatus::AppNotRunning);
+        assert_eq!(code, 2);
+        assert!(msg.contains("not running"), "{msg}");
+    }
+
+    #[test]
+    fn persist_queue_roundtrip_and_take() {
+        let _lock = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-app-session-api-q-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        persist_queue_item(PersistedQueueItem {
+            session_id: "s1".into(),
+            item_id: "q-1".into(),
+            prompt: "hello".into(),
+            created_at: 1,
+        });
+        persist_queue_item(PersistedQueueItem {
+            session_id: "s1".into(),
+            item_id: "q-2".into(),
+            prompt: "world".into(),
+            created_at: 2,
+        });
+        let head = take_persisted_head("s1").expect("head");
+        assert_eq!(head.item_id, "q-1");
+        assert_eq!(head.prompt, "hello");
+        let rest = load_persisted_queue();
+        assert_eq!(rest.items.len(), 1);
+        assert_eq!(rest.items[0].item_id, "q-2");
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn dispatch_timeout_returns_retry_later() {
+        let sid = "s-timeout".to_string();
+        let r = with_dispatch_timeout_for(
+            std::time::Duration::from_millis(30),
+            sid.clone(),
+            std::future::pending::<TurnResult>(),
+        )
+        .await;
+        assert_eq!(r.status, TurnStatus::RetryLater);
+        assert_eq!(r.session_id, sid);
+        assert!(
+            r.message
+                .as_deref()
+                .unwrap_or("")
+                .contains("host busy: connect in progress"),
+            "{:?}",
+            r.message
+        );
+    }
+
+    #[test]
+    fn health_payload_reports_lock_busy() {
+        let mgr = SessionManager::new();
+        let v = health_payload(&mgr);
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["connectLockBusy"], false);
     }
 }

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -18,6 +18,25 @@ use crate::store::{self};
 
 use super::*;
 
+/// Drops `connect_lock` holder diagnostics when the lock guard goes out of
+/// scope — including on task abort, where tokio drops the future's stack.
+struct ConnectHolderGuard {
+    mgr: Arc<SessionManager>,
+}
+
+impl ConnectHolderGuard {
+    fn enter(mgr: Arc<SessionManager>, session_id: Option<String>, phase: &'static str) -> Self {
+        mgr.record_connect_holder(session_id, phase);
+        Self { mgr }
+    }
+}
+
+impl Drop for ConnectHolderGuard {
+    fn drop(&mut self) {
+        self.mgr.clear_connect_holder();
+    }
+}
+
 fn emit_host_exit_heal(app: &AppHandle, session_id: &str) {
     let Some(message_id) = crate::turn_interrupt::heal_interrupted_turn(session_id) else {
         return;
@@ -43,8 +62,8 @@ impl SessionManager {
         mock_mode: Option<String>,
     ) -> Result<SessionSnapshot, String> {
         // Enqueue is logged before `connect_lock` so a stuck holder still
-        // leaves a trail. The 90s timer runs on this task; handshake + lock
-        // wait run on a sibling so a blocking ACP poll cannot starve it.
+        // leaves a trail. The 90s timer runs *inside* the sibling so dropping
+        // this JoinHandle (HTTP 15s) still reaps the lock.
         tracing::info!(
             target: "session",
             session = ?app_session_id,
@@ -60,57 +79,114 @@ impl SessionManager {
         let mgr = Arc::clone(self);
         let app_task = app.clone();
         let sid = app_session_id.clone();
+        // Wall-clock lives *inside* the sibling. HTTP 15s may drop this JoinHandle
+        // (detach, not abort); recovery must not depend on the caller future.
         let join = tauri::async_runtime::spawn(async move {
-            let _connect_guard = mgr.connect_lock.lock().await;
-            if !connect_attempt_still_current(
-                mgr.connect_epoch.load(std::sync::atomic::Ordering::SeqCst),
-                my_gen,
-            ) {
-                return Err(format!(
-                    "{}: {}",
-                    crate::error::AgentErrorCode::ConnectFailed.as_str(),
-                    connect_gave_up_reason(false)
-                ));
+            match tokio::time::timeout(Duration::from_secs(CONNECT_WALL_CLOCK_SECS), async {
+                let _connect_guard = mgr.connect_lock.lock().await;
+                let _holder =
+                    ConnectHolderGuard::enter(Arc::clone(&mgr), sid.clone(), "connect_inner");
+                if !connect_attempt_still_current(
+                    mgr.connect_epoch.load(std::sync::atomic::Ordering::SeqCst),
+                    my_gen,
+                ) {
+                    return Err(format!(
+                        "{}: {}",
+                        crate::error::AgentErrorCode::ConnectFailed.as_str(),
+                        connect_gave_up_reason(false)
+                    ));
+                }
+                mgr.connect_inner(app_task.clone(), project_path, sid.clone(), mock_mode)
+                    .await
+            })
+            .await
+            {
+                Ok(inner) => inner,
+                Err(_) => {
+                    mgr.reap_timed_out_connect(&app_task, sid.as_deref(), my_gen)
+                        .await
+                }
             }
-            mgr.connect_inner(app_task, project_path, sid, mock_mode)
-                .await
         });
 
-        match tokio::time::timeout(Duration::from_secs(CONNECT_WALL_CLOCK_SECS), async {
-            join.await
-        })
-        .await
-        {
-            Ok(Ok(inner)) => inner,
-            Ok(Err(join_err)) => {
+        match join.await {
+            Ok(inner) => inner,
+            Err(join_err) => {
                 tracing::error!(error = %join_err, "connect task failed");
                 Err(format!("connect task failed: {join_err}"))
             }
-            Err(_) => {
-                let current = self.connect_epoch.load(std::sync::atomic::Ordering::SeqCst);
-                let next = next_connect_epoch_on_timeout(current, my_gen);
-                if next != current {
-                    self.connect_epoch
-                        .store(next, std::sync::atomic::Ordering::SeqCst);
-                }
-                tracing::warn!(
-                    target: "session",
-                    session = ?app_session_id,
-                    secs = CONNECT_WALL_CLOCK_SECS,
-                    "connect wall-clock timeout"
-                );
-                crate::logging::sync_diag(&format!(
-                    "connect wall-clock timeout session={:?} secs={}",
-                    app_session_id, CONNECT_WALL_CLOCK_SECS
-                ));
-                Ok(self
-                    .fail_stale_connecting(
-                        &app,
-                        app_session_id.as_deref(),
-                        connect_gave_up_reason(true),
-                    )
-                    .await)
-            }
+        }
+    }
+
+    /// Epoch bump + fail stale handshake + reap pending children.
+    /// Runs on the connect sibling so a dropped HTTP waiter cannot cancel it.
+    pub(super) async fn reap_timed_out_connect(
+        self: &Arc<Self>,
+        app: &AppHandle,
+        app_session_id: Option<&str>,
+        my_gen: u64,
+    ) -> Result<SessionSnapshot, String> {
+        let current = self.connect_epoch.load(std::sync::atomic::Ordering::SeqCst);
+        let next = next_connect_epoch_on_timeout(current, my_gen);
+        if next != current {
+            self.connect_epoch
+                .store(next, std::sync::atomic::Ordering::SeqCst);
+        }
+        tracing::warn!(
+            target: "session",
+            session = ?app_session_id,
+            secs = CONNECT_WALL_CLOCK_SECS,
+            "connect wall-clock timeout"
+        );
+        crate::logging::sync_diag(&format!(
+            "connect wall-clock timeout session={:?} secs={}",
+            app_session_id, CONNECT_WALL_CLOCK_SECS
+        ));
+        // Slot cleanup first: Ready/Streaming is a no-op. Then reap children
+        // still in pending (never bound, or bound but still Connecting).
+        let snap = self
+            .fail_stale_connecting(app, app_session_id, connect_gave_up_reason(true))
+            .await;
+        self.sweep_pending_children().await;
+        Ok(snap)
+    }
+
+    /// Outer handshake RPC budget (initialize + openSession). Smaller than
+    /// wall-clock so a wedged child fails without relying on abort.
+    pub(super) async fn with_handshake_budget<T, F>(fut: F) -> Result<T, AgentError>
+    where
+        F: std::future::Future<Output = Result<T, AgentError>>,
+    {
+        Self::with_handshake_budget_for(Duration::from_secs(CONNECT_HANDSHAKE_BUDGET_SECS), fut)
+            .await
+    }
+
+    pub(super) async fn with_handshake_budget_for<T, F>(
+        budget: Duration,
+        fut: F,
+    ) -> Result<T, AgentError>
+    where
+        F: std::future::Future<Output = Result<T, AgentError>>,
+    {
+        match tokio::time::timeout(budget, fut).await {
+            Ok(inner) => inner,
+            Err(_) => Err(AgentError::new(
+                AgentErrorCode::ConnectFailed,
+                format!("handshake timed out after {}s", budget.as_secs().max(1)),
+            )),
+        }
+    }
+
+    /// Soft-fail RPCs (set_model / set_mode) must not pin `connect_lock`.
+    pub(super) async fn with_soft_rpc_budget<T, F>(fut: F) -> Result<T, String>
+    where
+        F: std::future::Future<Output = Result<T, String>>,
+    {
+        match tokio::time::timeout(Duration::from_secs(CONNECT_HANDSHAKE_BUDGET_SECS), fut).await {
+            Ok(inner) => inner,
+            Err(_) => Err(format!(
+                "rpc timed out after {CONNECT_HANDSHAKE_BUDGET_SECS}s"
+            )),
         }
     }
 
@@ -154,7 +230,7 @@ impl SessionManager {
             }
         }
         for acp in acps {
-            acp.kill().await;
+            Self::kill_acp_bounded(&acp).await;
         }
         let snap = self.snapshot();
         Self::emit_state(app, &snap);
@@ -171,6 +247,9 @@ impl SessionManager {
         let settings = store::load_settings();
         let max_concurrent = normalize_max_concurrent(settings.max_concurrent_agents);
         self.sweep_dead_parked();
+        if let Some(ref sid) = app_session_id {
+            self.sweep_pending_for_session(sid).await;
+        }
 
         // Ensure app session meta — never panic on disk/index races.
         let mut meta = if let Some(id) = app_session_id {
@@ -298,7 +377,7 @@ impl SessionManager {
                         "pending fork detached shared ACP without killing co-tenant"
                     );
                 } else {
-                    acp.kill().await;
+                    Self::kill_acp_bounded(&acp).await;
                 }
             }
             // Invalidate only after the busy early-return above. A deferred
@@ -319,7 +398,7 @@ impl SessionManager {
                 }
             };
             if let Some(acp) = prewarm_to_kill {
-                acp.kill().await;
+                Self::kill_acp_bounded(&acp).await;
             }
             tracing::info!(
                 target: "session",
@@ -397,7 +476,7 @@ impl SessionManager {
                         let shared_with_other =
                             self.has_other_process_tenant(&live.process_id, &meta.id);
                         if !shared_with_other {
-                            acp.kill().await;
+                            Self::kill_acp_bounded(&acp).await;
                         } else {
                             tracing::info!(
                                 session = %meta.id,
@@ -423,10 +502,16 @@ impl SessionManager {
                     // agent session id may belong to another App session.
                     if let Some(acp) = live.acp.clone() {
                         if let Some(sid) = live.meta.agent_session_id.clone() {
-                            if let Err(e) = acp.set_model_for(&sid, &agent_model).await {
+                            if let Err(e) =
+                                Self::with_soft_rpc_budget(acp.set_model_for(&sid, &agent_model))
+                                    .await
+                            {
                                 tracing::warn!("acp set_model on unpark soft-fail: {e}");
                             }
-                            if let Err(e) = acp.set_mode_for(&sid, &prefs.mode).await {
+                            if let Err(e) =
+                                Self::with_soft_rpc_budget(acp.set_mode_for(&sid, &prefs.mode))
+                                    .await
+                            {
                                 tracing::warn!("acp set_mode on unpark soft-fail: {e}");
                             }
                         }
@@ -490,7 +575,7 @@ impl SessionManager {
                     }
                 };
                 if let Some(acp) = leftover {
-                    acp.kill().await;
+                    Self::kill_acp_bounded(&acp).await;
                 }
             }
             Self::emit_state(&app, &self.snapshot());
@@ -756,7 +841,7 @@ impl SessionManager {
                 best.map(|(acp, pid, _)| (acp, pid))
             };
             for acp in stale_prewarm {
-                acp.kill().await;
+                Self::kill_acp_bounded(&acp).await;
             }
             if let Some((acp, reused_process)) = reused {
                 tracing::info!(
@@ -796,9 +881,12 @@ impl SessionManager {
                     }
                 }
                 let cwd_str = cwd.to_string_lossy().to_string();
-                let open_result = acp
-                    .open_session_at(resume_agent_sid.as_deref(), false, &cwd_str)
-                    .await;
+                let open_result = Self::with_handshake_budget(acp.open_session_at(
+                    resume_agent_sid.as_deref(),
+                    false,
+                    &cwd_str,
+                ))
+                .await;
                 match open_result {
                     Ok((agent_sid, resumed)) => {
                         let need_bootstrap = !resumed && journal_has_history;
@@ -867,7 +955,7 @@ impl SessionManager {
                             error = %e.message,
                             "connect warm-reuse open_session failed; cold spawn"
                         );
-                        acp.kill().await;
+                        Self::kill_acp_bounded(&acp).await;
                     }
                 }
             }
@@ -971,37 +1059,68 @@ impl SessionManager {
             empty_mcp_servers: false,
         };
 
-        let (client, mut events) =
-            match AcpClient::spawn_with_options(cli_path, cwd, spawn_opts).await {
-                Ok(v) => {
-                    tracing::info!(
-                        target: "session",
-                        session = %meta.id,
-                        process = %process_id,
-                        fork_session = fork_agent,
-                        "connect spawn_ok"
-                    );
-                    v
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        target: "session",
-                        session = %meta.id,
-                        code = e.code.as_str(),
-                        error = %e.message,
-                        "connect spawn_fail"
-                    );
-                    {
-                        let mut guard = self.inner.lock();
-                        if let Some(s) = guard.as_mut() {
-                            let _ = s.fsm.connect_failed(e);
-                        }
+        let spawn_result = tokio::time::timeout(
+            Duration::from_secs(CONNECT_HANDSHAKE_BUDGET_SECS),
+            AcpClient::spawn_with_options(cli_path, cwd, spawn_opts),
+        )
+        .await;
+        let (client, mut events) = match spawn_result {
+            Ok(Ok(v)) => {
+                tracing::info!(
+                    target: "session",
+                    session = %meta.id,
+                    process = %process_id,
+                    fork_session = fork_agent,
+                    "connect spawn_ok"
+                );
+                v
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    target: "session",
+                    session = %meta.id,
+                    code = e.code.as_str(),
+                    error = %e.message,
+                    "connect spawn_fail"
+                );
+                {
+                    let mut guard = self.inner.lock();
+                    if let Some(s) = guard.as_mut() {
+                        let _ = s.fsm.connect_failed(e);
                     }
-                    let snap = self.snapshot();
-                    Self::emit_state(&app, &snap);
-                    return Ok(snap);
                 }
-            };
+                let snap = self.snapshot();
+                Self::emit_state(&app, &snap);
+                return Ok(snap);
+            }
+            Err(_) => {
+                let e = AgentError::new(
+                    AgentErrorCode::ConnectFailed,
+                    format!("spawn timed out after {CONNECT_HANDSHAKE_BUDGET_SECS}s"),
+                );
+                tracing::warn!(
+                    target: "session",
+                    session = %meta.id,
+                    code = e.code.as_str(),
+                    error = %e.message,
+                    "connect spawn_fail"
+                );
+                {
+                    let mut guard = self.inner.lock();
+                    if let Some(s) = guard.as_mut() {
+                        let _ = s.fsm.connect_failed(e);
+                    }
+                }
+                let snap = self.snapshot();
+                Self::emit_state(&app, &snap);
+                return Ok(snap);
+            }
+        };
+        self.register_pending_child(PendingAcpChild {
+            session_id: Some(meta.id.clone()),
+            process_id: process_id.clone(),
+            acp: client.clone(),
+        });
 
         // Event pump tagged with process_id (multi-process routing). Events
         // carry the CLI's owning sessionId when known so a reused process
@@ -1037,9 +1156,10 @@ impl SessionManager {
             fork_session = fork_agent,
             "connect session_open_begin"
         );
-        let open_result = client
-            .initialize_and_open_session(resume_agent_sid.as_deref(), fork_agent)
-            .await;
+        let open_result = Self::with_handshake_budget(
+            client.initialize_and_open_session(resume_agent_sid.as_deref(), fork_agent),
+        )
+        .await;
 
         // One-shot flag: clear whether fork succeeded or fell through to new/load.
         if meta.fork_agent_session {
@@ -1079,7 +1199,7 @@ impl SessionManager {
                     if let Some(s) = guard.as_mut() {
                         let _ = s.fsm.handshake_ok();
                         s.acp = Some(client.clone());
-                        s.process_id = process_id;
+                        s.process_id = process_id.clone();
                         s.meta.agent_session_id = Some(agent_sid);
                         s.meta.fork_agent_session = false;
                         s.meta.model_id = Some(prefs.model_id.clone());
@@ -1098,6 +1218,9 @@ impl SessionManager {
                 let _ = store::update_session_meta(&meta);
                 let snap = self.snapshot();
                 Self::emit_state(&app, &snap);
+                // Child is live/Ready — drop it from the abort-reap list before
+                // set_mode so a wall-clock sweep cannot kill a working agent.
+                self.unregister_pending_child(&process_id);
                 // Nudge mode *after* Ready so a slow/failed set_mode cannot pin
                 // the pill on 连接中. Fork already inherited parent mode.
                 if fork_agent {
@@ -1106,7 +1229,9 @@ impl SessionManager {
                         session = %meta.id,
                         "connect skip set_mode after fork (parent mode already applied)"
                     );
-                } else if let Err(e) = client.set_mode(&prefs.mode).await {
+                } else if let Err(e) =
+                    Self::with_soft_rpc_budget(client.set_mode(&prefs.mode)).await
+                {
                     tracing::warn!("acp set_mode after session open soft-fail: {e}");
                 }
                 emit_host_exit_heal(&app, &meta.id);
@@ -1120,7 +1245,8 @@ impl SessionManager {
                     error = %e.message,
                     "connect session_open_fail"
                 );
-                client.kill().await;
+                Self::kill_acp_bounded(&client).await;
+                self.unregister_pending_child(&process_id);
                 {
                     let mut guard = self.inner.lock();
                     if let Some(s) = guard.as_mut() {
@@ -1311,7 +1437,7 @@ impl SessionManager {
                     },
                 ) {
                     tokio::spawn(async move {
-                        p.acp.kill().await;
+                        SessionManager::kill_acp_bounded(&p.acp).await;
                     });
                 }
             } else {
@@ -1399,7 +1525,7 @@ impl SessionManager {
         }
         if let Err(e) = client.initialize_and_auth().await {
             tracing::warn!(code = e.code.as_str(), error = %e.message, "prewarm init failed");
-            client.kill().await;
+            Self::kill_acp_bounded(&client).await;
             self.clear_prewarm_if_current(epoch);
             return;
         }
@@ -1426,7 +1552,7 @@ impl SessionManager {
         if !published {
             // A pending fork or route reset cancelled this prewarm while it
             // was starting. Do not leak the initialized child.
-            client.kill().await;
+            Self::kill_acp_bounded(&client).await;
             return;
         }
         tracing::info!(target: "session", "prewarm ready (spawn+init+auth, no session)");
@@ -1450,7 +1576,7 @@ impl SessionManager {
         };
         if let Some(p) = victim {
             tracing::info!("prewarm process {} recycled (dead)", p.process_id);
-            p.acp.kill().await;
+            Self::kill_acp_bounded(&p.acp).await;
         }
     }
 
@@ -1659,6 +1785,8 @@ mod connect_preserve_tests {
         assert_eq!(connect_gave_up_reason(true), "connect timed out");
         assert!(CONNECT_LOCK_WATCHDOG_SECS < CONNECT_WALL_CLOCK_SECS);
         assert!(ACP_KILL_TIMEOUT_SECS <= CONNECT_LOCK_WATCHDOG_SECS);
+        assert!(CONNECT_HANDSHAKE_BUDGET_SECS < CONNECT_WALL_CLOCK_SECS);
+        assert!(CONNECT_HANDSHAKE_BUDGET_SECS >= 45);
     }
 
     #[test]
@@ -1915,5 +2043,143 @@ mod reuse_gate_tests {
         ));
         // Empty id never matches the busy set → treat as unshared (kill).
         assert!(should_kill_parked_after_flag_mismatch("", &busy));
+    }
+}
+
+#[cfg(test)]
+mod connect_timeout_tests {
+    use super::*;
+    use crate::error::AgentError;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    #[tokio::test]
+    async fn aborting_connect_task_releases_connect_lock() {
+        let mgr = Arc::new(SessionManager::new());
+        let mgr_hold = Arc::clone(&mgr);
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel::<()>();
+        let join: tauri::async_runtime::JoinHandle<Result<SessionSnapshot, String>> =
+            tauri::async_runtime::spawn(async move {
+                let _g = mgr_hold.connect_lock.lock().await;
+                let _ = entered_tx.send(());
+                std::future::pending::<()>().await;
+                Ok(mgr_hold.snapshot())
+            });
+        entered_rx.await.expect("holder entered");
+        assert!(
+            mgr.try_lock_connect(Duration::ZERO).await.is_none(),
+            "lock must be held before abort"
+        );
+        join.abort();
+        let _ = join.await;
+        assert!(
+            mgr.try_lock_connect(Duration::ZERO).await.is_some(),
+            "abort must drop connect_lock so the next waiter is not pinned"
+        );
+    }
+
+    #[tokio::test]
+    async fn abort_drops_holder_and_sweep_does_not_hang() {
+        let mgr = Arc::new(SessionManager::new());
+        let mgr_hold = Arc::clone(&mgr);
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel::<()>();
+        let join: tauri::async_runtime::JoinHandle<Result<SessionSnapshot, String>> =
+            tauri::async_runtime::spawn(async move {
+                let _g = mgr_hold.connect_lock.lock().await;
+                let _holder = ConnectHolderGuard::enter(
+                    Arc::clone(&mgr_hold),
+                    Some("sess-wedge".into()),
+                    "connect_inner",
+                );
+                let _ = entered_tx.send(());
+                std::future::pending::<()>().await;
+                Ok(mgr_hold.snapshot())
+            });
+        entered_rx.await.expect("holder entered");
+        assert!(mgr.connect_lock_busy());
+        assert!(mgr.connect_holder_snapshot().is_some());
+        join.abort();
+        let _ = join.await;
+        mgr.sweep_pending_children().await;
+        assert!(
+            mgr.try_lock_connect(Duration::ZERO).await.is_some(),
+            "lock free after abort+reap"
+        );
+        assert!(
+            mgr.connect_holder_snapshot().is_none(),
+            "holder guard drops on abort"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_probe_stays_fast_while_lock_held() {
+        let mgr = Arc::new(SessionManager::new());
+        let mgr_hold = Arc::clone(&mgr);
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel::<()>();
+        let hold = tokio::spawn(async move {
+            let _g = mgr_hold.connect_lock.lock().await;
+            let _ = entered_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        entered_rx.await.unwrap();
+        let t0 = Instant::now();
+        let busy = mgr.connect_lock_busy();
+        let elapsed = t0.elapsed();
+        assert!(busy);
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "lock probe took {elapsed:?}, health must stay <1s during wedge"
+        );
+        hold.abort();
+    }
+
+    #[tokio::test]
+    async fn inner_wall_clock_releases_lock_after_caller_drops() {
+        // Simulates POST /turns 15s dropping the connect JoinHandle: the
+        // sibling must still time out and drop connect_lock by itself.
+        let mgr = Arc::new(SessionManager::new());
+        let mgr_hold = Arc::clone(&mgr);
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel::<()>();
+        let join = tokio::spawn(async move {
+            match tokio::time::timeout(Duration::from_millis(80), async {
+                let _g = mgr_hold.connect_lock.lock().await;
+                let _ = entered_tx.send(());
+                std::future::pending::<()>().await;
+                Ok::<(), String>(())
+            })
+            .await
+            {
+                Ok(inner) => inner,
+                Err(_) => Ok(()),
+            }
+        });
+        entered_rx.await.expect("holder entered");
+        drop(join);
+        let deadline = Instant::now() + Duration::from_millis(400);
+        loop {
+            if mgr.try_lock_connect(Duration::ZERO).await.is_some() {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "inner wall-clock must release connect_lock after caller drop"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn handshake_budget_fails_closed() {
+        let err = SessionManager::with_handshake_budget_for(
+            Duration::from_millis(30),
+            std::future::pending::<Result<(), AgentError>>(),
+        )
+        .await
+        .expect_err("handshake budget must fire");
+        assert!(
+            err.message.contains("handshake timed out"),
+            "{}",
+            err.message
+        );
     }
 }

--- a/src-tauri/src/session_manager/control.rs
+++ b/src-tauri/src/session_manager/control.rs
@@ -80,7 +80,7 @@ impl SessionManager {
                 .as_deref()
                 .is_none_or(|session_id| !self.has_other_process_tenant(&process_id, session_id));
             if kill_allowed {
-                acp.kill().await;
+                Self::kill_acp_bounded(&acp).await;
             } else {
                 tracing::info!(
                     reason = %reason,
@@ -135,7 +135,7 @@ impl SessionManager {
                         "pending soft-respawn detached shared background ACP without killing co-tenant"
                     );
                 } else {
-                    acp.kill().await;
+                    Self::kill_acp_bounded(&acp).await;
                     tracing::info!(
                         session = %session_id,
                         reason = %reason,
@@ -151,7 +151,7 @@ impl SessionManager {
         let parked = self.parked.lock().remove(session_id);
         if let Some(p) = parked {
             if !self.has_other_process_tenant(&p.process_id, session_id) {
-                p.acp.kill().await;
+                Self::kill_acp_bounded(&p.acp).await;
                 tracing::info!(
                     session = %session_id,
                     reason = %reason,
@@ -268,7 +268,7 @@ impl SessionManager {
         let drained = self.drain_all_agent_slots();
         let total = drained.acps.len();
         for acp in drained.acps {
-            acp.kill().await;
+            Self::kill_acp_bounded(&acp).await;
         }
         tracing::info!(
             "recycle_all_agents reason={reason} killed={total} (live_shell={} bg={} parked={} prewarm={}) pending_invalidated={}",
@@ -568,7 +568,7 @@ impl SessionManager {
                 let acp = p.acp;
                 // Kill after drop to avoid holding the map lock across await.
                 tokio::spawn(async move {
-                    acp.kill().await;
+                    SessionManager::kill_acp_bounded(&acp).await;
                 });
             }
         }
@@ -776,7 +776,7 @@ impl SessionManager {
                 if p.effort.as_deref() != Some(effort.as_str()) {
                     if !self.has_other_process_tenant(&p.process_id, sid) {
                         tokio::spawn(async move {
-                            p.acp.kill().await;
+                            SessionManager::kill_acp_bounded(&p.acp).await;
                         });
                     } else {
                         tracing::info!(
@@ -1131,13 +1131,13 @@ impl SessionManager {
         if let Some(acp) = orphan {
             // Dead / non-alive client handle only.
             if !acp.is_alive() {
-                acp.kill().await;
+                Self::kill_acp_bounded(&acp).await;
             } else {
                 // Alive but unparkable — do not kill; leave Arc drop alone would kill.
                 // Re-insert as anonymous? Safer to kill only if not busy — we already
                 // tried demote. Keep process alive by forgetting kill.
                 tracing::warn!("disconnect: orphan alive acp left without map entry — killing");
-                acp.kill().await;
+                Self::kill_acp_bounded(&acp).await;
             }
         }
         Self::emit_state(app, &self.snapshot());
@@ -1201,17 +1201,17 @@ impl SessionManager {
         let parked = self.parked.lock().remove(session_id);
         if let Some(acp) = live_acp {
             if !self.has_other_process_tenant(&live_process_id, session_id) {
-                acp.kill().await;
+                Self::kill_acp_bounded(&acp).await;
             }
         }
         if let Some(acp) = bg_acp {
             if !self.has_other_process_tenant(&bg_process_id, session_id) {
-                acp.kill().await;
+                Self::kill_acp_bounded(&acp).await;
             }
         }
         if let Some(p) = parked {
             if !self.has_other_process_tenant(&p.process_id, session_id) {
-                p.acp.kill().await;
+                Self::kill_acp_bounded(&p.acp).await;
             }
         }
         self.pending_soft_respawn.lock().remove(session_id);

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -45,7 +45,10 @@ mod stall_tests;
 
 use std::{
     collections::HashMap,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{
+        atomic::{AtomicU32, AtomicU64},
+        Arc,
+    },
 };
 
 use parking_lot::Mutex;
@@ -84,6 +87,14 @@ pub struct SessionManager {
     /// Latest-wins generation for `session_connect`. A timed-out or superseded
     /// waiter must not enter `connect_inner` after it finally acquires the lock.
     pub(super) connect_epoch: AtomicU64,
+    /// ACP children spawned inside `connect_inner` that are not yet (or no
+    /// longer) the live/parked slot owner. Wall-clock abort sweeps this list
+    /// with `kill_acp_bounded` so a cancelled handshake cannot leak workers.
+    pub(super) pending_children: Mutex<Vec<PendingAcpChild>>,
+    /// Diagnostic snapshot of the current `connect_lock` holder.
+    pub(super) connect_holder: Mutex<Option<ConnectLockHolderInfo>>,
+    /// Consecutive idle-recycle ticks that failed to acquire `connect_lock`.
+    pub(super) connect_lock_busy_ticks: AtomicU32,
     /// Per-session locks that serialize a prompt's user-journal append with
     /// post-turn reconciliation. Retry sleeps never hold these locks, and one
     /// chat never delays another chat's send.
@@ -111,6 +122,9 @@ impl SessionManager {
             tool_identities: std::sync::Mutex::new(std::collections::HashMap::new()),
             connect_lock: tokio::sync::Mutex::new(()),
             connect_epoch: AtomicU64::new(0),
+            pending_children: Mutex::new(Vec::new()),
+            connect_holder: Mutex::new(None),
+            connect_lock_busy_ticks: AtomicU32::new(0),
             post_turn_journal_locks: Mutex::new(HashMap::new()),
             pending_soft_respawn: Mutex::new(HashMap::new()),
         }
@@ -119,6 +133,26 @@ impl SessionManager {
     /// Drop bookkeeping for a chat that no longer exists in the store.
     pub fn forget_deleted_session(&self, session_id: &str) {
         self.pending_soft_respawn.lock().remove(session_id);
+        let kids: Vec<PendingAcpChild> = {
+            let mut list = self.pending_children.lock();
+            let mut taken = Vec::new();
+            list.retain(|c| {
+                if c.session_id.as_deref() == Some(session_id) {
+                    taken.push(c.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            taken
+        };
+        if !kids.is_empty() {
+            tokio::spawn(async move {
+                for child in kids {
+                    SessionManager::kill_acp_bounded(&child.acp).await;
+                }
+            });
+        }
     }
 
     pub(super) fn invalidate_prewarm_epoch(&self) {

--- a/src-tauri/src/session_manager/process.rs
+++ b/src-tauri/src/session_manager/process.rs
@@ -457,7 +457,7 @@ impl SessionManager {
                         );
                         let c = acp;
                         tokio::spawn(async move {
-                            c.kill().await;
+                            SessionManager::kill_acp_bounded(&c).await;
                         });
                     } else {
                         tracing::info!(
@@ -893,7 +893,7 @@ impl SessionManager {
                 entries.len()
             );
             if let Some(acp) = entries.first().map(|p| p.acp.clone()) {
-                self.kill_acp_bounded(&acp).await;
+                Self::kill_acp_bounded(&acp).await;
             }
             for p in entries {
                 Self::emit_idle_recycled(app, &p.app_session_id, "capacity");
@@ -958,12 +958,71 @@ impl SessionManager {
             .ok()
     }
 
-    pub(super) async fn kill_acp_bounded(&self, acp: &AcpClient) {
+    /// Non-blocking probe: true when some task currently holds `connect_lock`.
+    pub fn connect_lock_busy(&self) -> bool {
+        self.connect_lock.try_lock().is_err()
+    }
+
+    pub(super) fn record_connect_holder(&self, session_id: Option<String>, phase: &'static str) {
+        *self.connect_holder.lock() = Some(ConnectLockHolderInfo {
+            session_id,
+            phase,
+            since: Instant::now(),
+        });
+    }
+
+    pub(super) fn clear_connect_holder(&self) {
+        *self.connect_holder.lock() = None;
+        self.connect_lock_busy_ticks
+            .store(0, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    pub(super) fn connect_holder_snapshot(&self) -> Option<ConnectLockHolderInfo> {
+        self.connect_holder.lock().clone()
+    }
+
+    pub(super) async fn kill_acp_bounded(acp: &AcpClient) {
         if tokio::time::timeout(Duration::from_secs(ACP_KILL_TIMEOUT_SECS), acp.kill())
             .await
             .is_err()
         {
             tracing::warn!(secs = ACP_KILL_TIMEOUT_SECS, "acp kill timed out");
+        }
+    }
+
+    pub(super) fn register_pending_child(&self, child: PendingAcpChild) {
+        self.pending_children.lock().push(child);
+    }
+
+    pub(super) fn unregister_pending_child(&self, process_id: &str) {
+        self.pending_children
+            .lock()
+            .retain(|c| c.process_id != process_id);
+    }
+
+    pub(super) async fn sweep_pending_children(&self) {
+        let kids = std::mem::take(&mut *self.pending_children.lock());
+        for child in kids {
+            Self::kill_acp_bounded(&child.acp).await;
+        }
+    }
+
+    pub(super) async fn sweep_pending_for_session(&self, session_id: &str) {
+        let kids: Vec<PendingAcpChild> = {
+            let mut list = self.pending_children.lock();
+            let mut taken = Vec::new();
+            list.retain(|c| {
+                if c.session_id.as_deref() == Some(session_id) {
+                    taken.push(c.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            taken
+        };
+        for child in kids {
+            Self::kill_acp_bounded(&child.acp).await;
         }
     }
 
@@ -975,12 +1034,42 @@ impl SessionManager {
             .try_lock_connect(Duration::from_secs(CONNECT_LOCK_WATCHDOG_SECS))
             .await
         else {
-            tracing::warn!(
-                secs = CONNECT_LOCK_WATCHDOG_SECS,
-                "idle recycle skipped: connect_lock busy"
-            );
+            let ticks = self
+                .connect_lock_busy_ticks
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                .saturating_add(1);
+            let holder = self.connect_holder_snapshot();
+            let held_secs = holder
+                .as_ref()
+                .map(|h| h.since.elapsed().as_secs())
+                .unwrap_or(0);
+            let session = holder
+                .as_ref()
+                .and_then(|h| h.session_id.clone())
+                .unwrap_or_else(|| "-".into());
+            let phase = holder.as_ref().map(|h| h.phase).unwrap_or("unknown");
+            if ticks >= CONNECT_LOCK_BUSY_ESCALATE_TICKS {
+                tracing::error!(
+                    secs = CONNECT_LOCK_WATCHDOG_SECS,
+                    ticks,
+                    session = %session,
+                    phase,
+                    held_secs,
+                    "connect_lock held by session={session} phase={phase} since={held_secs}s"
+                );
+            } else {
+                tracing::warn!(
+                    secs = CONNECT_LOCK_WATCHDOG_SECS,
+                    session = %session,
+                    phase,
+                    held_secs,
+                    "idle recycle skipped: connect_lock busy"
+                );
+            }
             return;
         };
+        self.connect_lock_busy_ticks
+            .store(0, std::sync::atomic::Ordering::SeqCst);
         let idle_mins = Self::idle_minutes_from_settings();
         let now = Instant::now();
         self.sweep_dead_parked();
@@ -1028,7 +1117,7 @@ impl SessionManager {
                 entries.len()
             );
             if let Some(acp) = entries.first().map(|p| p.acp.clone()) {
-                self.kill_acp_bounded(&acp).await;
+                Self::kill_acp_bounded(&acp).await;
             }
             for p in entries {
                 Self::emit_idle_recycled(app, &p.app_session_id, "idle");
@@ -1116,7 +1205,7 @@ impl SessionManager {
                     .filter_map(|session_id| parked.remove(&session_id))
                     .collect::<Vec<_>>()
             };
-            self.kill_acp_bounded(&acp).await;
+            Self::kill_acp_bounded(&acp).await;
             Self::emit_idle_recycled(app, &sid, "idle");
             for p in parked_cotenants {
                 Self::emit_idle_recycled(app, &p.app_session_id, "idle");

--- a/src-tauri/src/session_manager/turn.rs
+++ b/src-tauri/src/session_manager/turn.rs
@@ -846,7 +846,7 @@ impl SessionManager {
         });
         if let Some((true, acp)) = abort_handshake {
             if let Some(acp) = acp {
-                acp.kill().await;
+                Self::kill_acp_bounded(&acp).await;
             }
             self.emit_for_session(&app, &target);
             return Ok(self.snapshot());

--- a/src-tauri/src/session_manager/types.rs
+++ b/src-tauri/src/session_manager/types.rs
@@ -1711,6 +1711,34 @@ pub const CONNECT_LOCK_WATCHDOG_SECS: u64 = 5;
 /// pin `connect_lock` for the rest of the process lifetime.
 pub const ACP_KILL_TIMEOUT_SECS: u64 = 5;
 
+/// Hard bound for initialize / openSession RPC inside `connect_lock`.
+/// Must stay below the 90s wall-clock so a wedged handshake fails closed
+/// without waiting for abort as the only backstop.
+pub const CONNECT_HANDSHAKE_BUDGET_SECS: u64 = 60;
+
+/// Consecutive idle-recycle skips before `connect_lock busy` escalates from
+/// warn to error with holder context. Idle recycle ticks every 30s, so 12
+/// skips is about six minutes — long enough that a 90s wall-clock abort
+/// should already have run.
+pub const CONNECT_LOCK_BUSY_ESCALATE_TICKS: u32 = 12;
+
+/// Child spawned during connect, recorded before it is bound into a live
+/// slot so a wall-clock abort can still `kill_acp_bounded` it.
+#[derive(Clone)]
+pub struct PendingAcpChild {
+    pub session_id: Option<String>,
+    pub process_id: String,
+    pub acp: std::sync::Arc<crate::acp_client::AcpClient>,
+}
+
+/// Who currently holds `connect_lock` (best-effort diagnostics).
+#[derive(Clone, Debug)]
+pub struct ConnectLockHolderInfo {
+    pub session_id: Option<String>,
+    pub phase: &'static str,
+    pub since: std::time::Instant,
+}
+
 /// Why a connect attempt gave up. `lock_acquired` is false when we never
 /// entered `connect_inner`.
 pub fn connect_gave_up_reason(lock_acquired: bool) -> &'static str {

--- a/src-tauri/src/session_manager/watchdog.rs
+++ b/src-tauri/src/session_manager/watchdog.rs
@@ -41,6 +41,10 @@ impl SessionManager {
                 ticker.tick().await;
                 mgr.tick_tool_heartbeats(&app);
                 mgr.tick_stream_stall(&app);
+                crate::session_api::schedule_drain_ready_external_queues(
+                    app.clone(),
+                    Arc::clone(&mgr),
+                );
             }
         });
     }

--- a/src/hooks/useSendQueue.ts
+++ b/src/hooks/useSendQueue.ts
@@ -13,6 +13,7 @@ import type { SessionSnapshot, SessionState } from "@/lib/session";
 import {
   applyClearSendQueuePlan,
   applyExternalQueuePush,
+  applyExternalQueueTake,
   claimQueueHead,
   dropQueuesForSessions,
   enqueueSend,
@@ -33,6 +34,7 @@ import {
   updateQueuedSend,
   type ClearSendQueuePlan,
   type ExternalQueuePush,
+  type ExternalQueueTake,
   type QueueMoveDirection,
   type QueuedSend,
   type QueuedSendPatch,
@@ -97,9 +99,7 @@ export function useSendQueue({
   const queueFlushHoldByKeyRef = useRef<Set<string>>(new Set());
   /** UI-visible hold (ref alone does not re-render). */
   const [flushHold, setFlushHold] = useState(false);
-  const flushQueueTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
+  const flushQueueTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const activeQueue = useMemo(
     () => getQueueForKey(sendQueueByKey, queueSessionKey(sessionId)),
@@ -166,6 +166,7 @@ export function useSendQueue({
     if (!acceptExternal || !api.hasHost()) return;
     let cancelled = false;
     let unlisten: (() => void) | undefined;
+    let unlistenTake: (() => void) | undefined;
     let retryTimer: number | null = null;
     let wakeRetry: (() => void) | null = null;
     const onPush = (push: ExternalQueuePush) => {
@@ -184,6 +185,12 @@ export function useSendQueue({
         : labels.externalAddedOther?.(preview);
       if (toast) showToast(toast, same ? 2800 : 4200);
     };
+    const onTake = (take: ExternalQueueTake) => {
+      if (cancelled) return;
+      const r = applyExternalQueueTake(sendQueueByKeyRef.current, take);
+      if (!r.removed) return;
+      writeMap(r.byKey);
+    };
     const register = async () => {
       let attempt = 0;
       while (!cancelled) {
@@ -192,8 +199,17 @@ export function useSendQueue({
             "session://send_queue",
             onPush,
           );
-          if (cancelled) fn();
-          else unlisten = fn;
+          const fnTake = await api.listen<ExternalQueueTake>(
+            "session://send_queue_take",
+            onTake,
+          );
+          if (cancelled) {
+            fn();
+            fnTake();
+          } else {
+            unlisten = fn;
+            unlistenTake = fnTake;
+          }
           return;
         } catch (e) {
           if (cancelled) return;
@@ -226,6 +242,7 @@ export function useSendQueue({
       wakeRetry?.();
       wakeRetry = null;
       unlisten?.();
+      unlistenTake?.();
     };
   }, [
     acceptExternal,
@@ -245,11 +262,12 @@ export function useSendQueue({
       goalMode: boolean;
     }) => {
       // Prefer viewing ref so a mid-render session switch cannot mis-key the item.
-      const key = queueSessionKey(
-        viewingSessionIdRef.current ?? sessionId,
-      );
+      const key = queueSessionKey(viewingSessionIdRef.current ?? sessionId);
       const item = makeQueuedSend(input);
-      const r = enqueueSend(getQueueForKey(sendQueueByKeyRef.current, key), item);
+      const r = enqueueSend(
+        getQueueForKey(sendQueueByKeyRef.current, key),
+        item,
+      );
       writeMap(setQueueForKey(sendQueueByKeyRef.current, key, r.queue));
       if (r.dropped > 0) {
         showToast(labels.droppedOldest(r.dropped, SEND_QUEUE_MAX), 3200);
@@ -339,10 +357,7 @@ export function useSendQueue({
 
   const dropSessions = useCallback(
     (sessionIds: Iterable<string>) => {
-      const next = dropQueuesForSessions(
-        sendQueueByKeyRef.current,
-        sessionIds,
-      );
+      const next = dropQueuesForSessions(sendQueueByKeyRef.current, sessionIds);
       if (next !== sendQueueByKeyRef.current) writeMap(next);
     },
     [writeMap],
@@ -472,7 +487,10 @@ export function useSendQueue({
       return;
     }
     // Viewed key only — never the live host's key when they differ.
-    if (!getQueueForKey(sendQueueByKeyRef.current, key).length) return;
+    const viewed = getQueueForKey(sendQueueByKeyRef.current, key);
+    if (!viewed.length) return;
+    // Host owns `source: external` drain; GUI only displays those rows.
+    if (viewed[0]?.source === "external") return;
     const live = liveHostRef.current;
     // Hold only when this same session is mid-turn on Host.
     if (shouldHoldFlushForLive(live.sessionId, live.state, viewId)) {

--- a/src/lib/sendQueue.test.ts
+++ b/src/lib/sendQueue.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyClearSendQueuePlan,
   applyExternalQueuePush,
+  applyExternalQueueTake,
   canReorderSendQueue,
   canShowQueueButton,
   claimQueueHead,
@@ -111,7 +112,12 @@ describe("sendQueue", () => {
   it("applyExternalQueuePush keys by session, dedups, and tags source", () => {
     const first = applyExternalQueuePush(
       {},
-      { sessionId: "s1", itemId: "q-ext-1", prompt: "keep drawing", createdAt: 9 },
+      {
+        sessionId: "s1",
+        itemId: "q-ext-1",
+        prompt: "keep drawing",
+        createdAt: 9,
+      },
     );
     expect(first.added).toBe(true);
     expect(first.dropped).toBe(0);
@@ -134,9 +140,10 @@ describe("sendQueue", () => {
     });
     expect(other.added).toBe(true);
     expect(other.byKey.s2).toHaveLength(1);
-    expect(applyExternalQueuePush({}, { sessionId: "s1", itemId: "x", prompt: "" }).added).toBe(
-      false,
-    );
+    expect(
+      applyExternalQueuePush({}, { sessionId: "s1", itemId: "x", prompt: "" })
+        .added,
+    ).toBe(false);
   });
 
   it("enqueue drops oldest past max and reports dropped", () => {
@@ -159,9 +166,7 @@ describe("sendQueue", () => {
     expect(q).toHaveLength(SEND_QUEUE_MAX);
     expect(lastDropped).toBe(1);
     expect(q[0]!.storedDisplay).toBe("m3");
-    expect(q[q.length - 1]!.storedDisplay).toBe(
-      `m${SEND_QUEUE_MAX + 2}`,
-    );
+    expect(q[q.length - 1]!.storedDisplay).toBe(`m${SEND_QUEUE_MAX + 2}`);
   });
 
   it("dequeue and remove", () => {
@@ -394,17 +399,13 @@ describe("sendQueue", () => {
     expect(r.queue).toHaveLength(max);
     expect(r.queue[0]!.id).toBe(head.id);
     // Dropped oldest of rest (r1); kept r2, r3 + head
-    expect(r.queue.map((x) => x.storedDisplay)).toEqual([
-      "head",
-      "r2",
-      "r3",
-    ]);
+    expect(r.queue.map((x) => x.storedDisplay)).toEqual(["head", "r2", "r3"]);
   });
 
   it("preview prefers text then attachments", () => {
-    expect(
-      queuePreviewText("hello [[skill:foo]] world", [], 20),
-    ).toBe("hello /foo world");
+    expect(queuePreviewText("hello [[skill:foo]] world", [], 20)).toBe(
+      "hello /foo world",
+    );
     expect(
       queuePreviewText("", [{ path: "/a", name: "a.png", isDir: false }]),
     ).toBe("a.png");
@@ -442,6 +443,36 @@ describe("sendQueue", () => {
   });
 
   describe("integration-style flows", () => {
+    it("does not claim external heads (Host drains them)", () => {
+      const ext = makeQueuedSend({
+        storedDisplay: "from api",
+        attachments: [],
+        goalMode: false,
+        now: 1,
+        source: "external",
+      });
+      const map = setQueueForKey({}, "s1", [ext]);
+      expect(claimQueueHead(map, "s1")).toBeNull();
+    });
+
+    it("applyExternalQueueTake removes the drained item", () => {
+      const ext = makeQueuedSend({
+        id: "q-ext-1",
+        storedDisplay: "from api",
+        attachments: [],
+        goalMode: false,
+        now: 1,
+        source: "external",
+      });
+      const map = setQueueForKey({}, "s1", [ext]);
+      const r = applyExternalQueueTake(map, {
+        sessionId: "s1",
+        itemId: "q-ext-1",
+      });
+      expect(r.removed).toBe(true);
+      expect(getQueueForKey(r.byKey, "s1")).toEqual([]);
+    });
+
     it("flush fail requeues claimed head at front", () => {
       const a = makeQueuedSend({
         storedDisplay: "first",
@@ -455,7 +486,11 @@ describe("sendQueue", () => {
         goalMode: false,
         now: 2,
       });
-      let map = setQueueForKey({}, "s1", enqueueSend(enqueueSend([], a).queue, b).queue);
+      let map = setQueueForKey(
+        {},
+        "s1",
+        enqueueSend(enqueueSend([], a).queue, b).queue,
+      );
       const claimed = claimQueueHead(map, "s1");
       expect(claimed).not.toBeNull();
       expect(claimed!.head.id).toBe(a.id);
@@ -463,7 +498,11 @@ describe("sendQueue", () => {
         b.id,
       ]);
       // executeSend failed → restore
-      const restored = requeueAfterFlushFail(claimed!.byKey, "s1", claimed!.head);
+      const restored = requeueAfterFlushFail(
+        claimed!.byKey,
+        "s1",
+        claimed!.head,
+      );
       expect(getQueueForKey(restored.byKey, "s1").map((x) => x.id)).toEqual([
         a.id,
         b.id,
@@ -499,11 +538,9 @@ describe("sendQueue", () => {
       map = setQueueForKey(map, "sid-real", [existing]);
       const next = migrateDraftQueue(map, "sid-real");
       expect(next).not.toHaveProperty("__draft__");
-      expect(getQueueForKey(next, "sid-real").map((x) => x.storedDisplay)).toEqual([
-        "already",
-        "draft-1",
-        "draft-2",
-      ]);
+      expect(
+        getQueueForKey(next, "sid-real").map((x) => x.storedDisplay),
+      ).toEqual(["already", "draft-1", "draft-2"]);
       // no-op when draft empty
       expect(migrateDraftQueue(next, "sid-real")).toBe(next);
     });
@@ -622,7 +659,10 @@ describe("sendQueue", () => {
         isFull: false,
         canReorder: false,
       });
-      expect(summarizeSendQueue(null)).toMatchObject({ count: 0, isEmpty: true });
+      expect(summarizeSendQueue(null)).toMatchObject({
+        count: 0,
+        isEmpty: true,
+      });
       const full = Array.from({ length: 3 }, (_, i) =>
         makeQueuedSend({
           storedDisplay: `m${i}`,

--- a/src/lib/sendQueue.ts
+++ b/src/lib/sendQueue.ts
@@ -138,15 +138,15 @@ export function queuePreviewText(
   maxLen = 72,
   labels?: QueuePreviewLabels,
 ): string {
-  const line = previewStoredAsSlash(storedDisplay)
-    .replace(/\s+/g, " ")
-    .trim();
+  const line = previewStoredAsSlash(storedDisplay).replace(/\s+/g, " ").trim();
   if (line) {
     return line.length > maxLen ? `${line.slice(0, maxLen - 1)}…` : line;
   }
   const chatCount = (storedDisplay.match(/\[\[chat:/g) || []).length;
   if (chatCount > 0) {
-    return labels?.chatsCount?.(chatCount) ?? labels?.empty ?? String(chatCount);
+    return (
+      labels?.chatsCount?.(chatCount) ?? labels?.empty ?? String(chatCount)
+    );
   }
   if (attachments.length === 1) return attachments[0]!.name;
   if (attachments.length > 1) {
@@ -222,10 +222,7 @@ export function shouldHoldFlushForLive(
   if (!liveSessionId || !liveState) return false;
   // Only a live turn holds flush. Handshake `connecting` must not park the
   // queue — executeSend waits on ensureConnected instead.
-  if (
-    liveState !== "streaming" &&
-    liveState !== "awaiting_permission"
-  ) {
+  if (liveState !== "streaming" && liveState !== "awaiting_permission") {
     return false;
   }
   // Draft queue is never the live mid-turn session.
@@ -325,8 +322,7 @@ export function updateQueuedSend(
     patch.attachments !== undefined
       ? patch.attachments.map((a) => ({ ...a }))
       : cur.attachments;
-  const nextGoal =
-    patch.goalMode !== undefined ? patch.goalMode : cur.goalMode;
+  const nextGoal = patch.goalMode !== undefined ? patch.goalMode : cur.goalMode;
 
   // Reject empty body with no attachments (caller may also validate).
   if (!nextDisplay.trim() && nextAttachments.length === 0) {
@@ -341,10 +337,7 @@ export function updateQueuedSend(
       nextAttachments.some((a, i) => {
         const b = cur.attachments[i];
         return (
-          !b ||
-          a.path !== b.path ||
-          a.name !== b.name ||
-          a.isDir !== b.isDir
+          !b || a.path !== b.path || a.name !== b.name || a.isDir !== b.isDir
         );
       }));
 
@@ -457,9 +450,39 @@ export function claimQueueHead(
   key: string,
 ): { head: QueuedSend; byKey: Record<string, QueuedSend[]> } | null {
   const q = getQueueForKey(byKey, key);
+  // Host drains `source: external` items. The webview only displays them.
+  if (q[0]?.source === "external") return null;
   const [head, rest] = dequeueSend(q);
   if (!head) return null;
   return { head, byKey: setQueueForKey(byKey, key, rest) };
+}
+
+/** Host `session://send_queue_take` payload (camelCase). */
+export type ExternalQueueTake = {
+  sessionId?: string;
+  itemId?: string;
+};
+
+/** Drop a Host-drained external item from the display map. */
+export function applyExternalQueueTake(
+  byKey: Record<string, QueuedSend[]>,
+  take: ExternalQueueTake,
+): { byKey: Record<string, QueuedSend[]>; removed: boolean } {
+  const itemId = (take.itemId ?? "").trim();
+  if (!itemId) return { byKey, removed: false };
+  const sessionId = (take.sessionId ?? "").trim();
+  const keys = sessionId ? [queueSessionKey(sessionId)] : Object.keys(byKey);
+  let next = byKey;
+  let removed = false;
+  for (const key of keys) {
+    const q = getQueueForKey(next, key);
+    const filtered = removeQueuedSend(q, itemId);
+    if (filtered.length !== q.length) {
+      next = setQueueForKey(next, key, filtered);
+      removed = true;
+    }
+  }
+  return { byKey: next, removed };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Hung ACP handshakes no longer pin `connect_lock` forever. The 90s wall-clock now lives **inside** the connect sibling, so dropping a 15s HTTP waiter only detaches; the sibling still times out, `fail_stale_connecting`, and bounded-kills pending children.
- `POST /turns` returns `503 retry_later` within 15s. CLI maps transport timeout/5xx to `error` (exit 1), not `app_not_running`. `/v1/health` reports `connectLockBusy`.
- External queued prompts persist on disk. Host drains them; the main window only displays `source: external`. CLI HTTP timeout is 20s so it can see `retry_later`.
- Lock-holder diagnostics escalate after ~6 minutes of idle-recycle skips.

Windows users hitting this after `--session-send` / Codex dispatch: still set system `HTTPS_PROXY` and fully quit the tray so children inherit the proxy. After this change the host recovers in ≤90s instead of needing a restart.

## Type of change
- [x] Bug fix

## Test plan
- [x] `cargo test --lib connect_timeout` (5)
- [x] `cargo test --lib session_api::` (14)
- [x] `vitest run src/lib/sendQueue.test.ts` (35)
- [ ] Windows: disconnect proxy, `--session-send` twice; health stays fast; second send is `retry_later` then recovers; no extra idle `grok.exe`

## Checklist
- [x] User-facing API strings are machine-facing JSON (`retry_later`, health field); docs in `session-api.md`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased
- [x] No secrets