### PR TITLE
fix(chat): stop long-transcript flash on send and turn settle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
+- **Long chats no longer flash on send and at turn settle (#760)**: This is not #714 / #703 (stick-lock no longer yanks a slight scroll-up, and send only sticks once). After send, the virtual list no longer fights two `itemCount`s; journal rewrite of the last user id no longer force-sticks.
 - **Windows paste of Explorer files (.dmp) no longer dies on NotReadableError (#755)**: Composer paste of an on-disk file (crash dumps, locked/large binaries) now reads the OS clipboard path list (`CF_HDROP`) and attaches `@path` like drag-drop. WebView `File.arrayBuffer()` is only used for in-memory blobs (screenshots). Unreadable blobs get a dedicated i18n hint instead of the Chromium English `NotReadableError`.
 - **Windows no longer freezes at end of a long turn (#754)**: A trailing `prompt_complete` after `session/prompt` RPC Ok used to re-arm the end-of-turn handler. The second pass emitted IPC while journal reconcile still held the store lock; the WebView WndProc waited on that lock inside `SendMessage` and the window stopped painting. Duplicate finish is now a no-op, and post-turn UI rehydrate reads App `messages.json` only (Host already merged agent history).
 - **Local session API no longer wedges after the first turn**: A hung ACP handshake used to keep `connect_lock` forever (90s timeout abandoned the waiter without aborting the task). Later `--session-send` / `POST /turns` then waited ~180s and the CLI lied with `app_not_running`. Connect now aborts and bounded-kills pending children; dispatch returns `retry_later` in 15s; health exposes `connectLockBusy`; CLI maps timeouts to `error`; queued external prompts persist on disk and the Host drains them without the main window.
@@ -47,6 +48,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **长对话发送/回合结束不再整页闪（#760）**：不是 #714 / #703（那是贴底后轻滑被拽回、发送双吸底）。发送后虚拟列表不再用两套条数抢窗口；日记改写最后一条 user id 时不再强制吸底。
 - **Windows 粘贴资源管理器文件（.dmp）不再报 NotReadableError（#755）**：Explorer 复制的已有磁盘路径改为读系统剪贴板文件列表（`CF_HDROP`）并按 `@path` 附加，与拖放一致。截图等无路径内容仍走 `arrayBuffer`。读不了的 blob 用专用文案，不再把 Chromium 英文 `NotReadableError` 拼进横幅。
 - **Windows 长回合结束不再卡死整窗（#754）**：`session/prompt` RPC 已经结束之后，迟到的 `prompt_complete` 会再次武装结束逻辑。第二次结束在 journal 对账还占着 store 锁时发 IPC，WebView 的 WndProc 在 `SendMessage` 里等这把锁，窗口不再重绘。重复结束现在是空操作；回合结束后的 UI 补刷只读 App `messages.json`（Host 已经合并过 agent 历史）。
 - **本地 session API 干完一轮后不再卡死**：卡住的 ACP 握手会把 `connect_lock` 永久占住（90s 超时只放弃等待、不 abort 任务），之后的 `--session-send` / `POST /turns` 会挂到约 180s，CLI 还谎称 `app_not_running`。现在超时会 abort 并用有上界的 kill 清 pending 子进程；派活 15s 内回 `retry_later`；health 带 `connectLockBusy`；CLI 把超时映射成 `error`；外部 queued 落盘，由 Host drain，不依赖主窗口。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -8157,17 +8157,28 @@ export function AppWorkbench() {
 
   const lastUserMessageId = transcriptMeta.lastUserId;
 
-  // Streaming perf mode — cheapen wallpaper/glass on integrated GPU Retina.
+  // Streaming perf mode — shrink browse overscan on integrated GPU Retina.
+  // Do not zero the flag in the update cleanup (that flashes 1→0→1).
+  // Turn it off after paint so it does not restyle in the same frame as settle.
   useEffect(() => {
     const on =
       session.state === "streaming" ||
       session.state === "awaiting_permission" ||
       transcriptMeta.hasStreamingAssistant;
-    document.documentElement.dataset.streamPerf = on ? "1" : "0";
+    if (on) {
+      document.documentElement.dataset.streamPerf = "1";
+      return;
+    }
+    const id = window.setTimeout(() => {
+      document.documentElement.dataset.streamPerf = "0";
+    }, 80);
+    return () => window.clearTimeout(id);
+  }, [session.state, transcriptMeta.hasStreamingAssistant]);
+  useEffect(() => {
     return () => {
       document.documentElement.dataset.streamPerf = "0";
     };
-  }, [session.state, transcriptMeta.hasStreamingAssistant]);
+  }, []);
 
   const canEditLastUser =
     !!lastUserMessageId &&

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -97,7 +97,10 @@ import {
 } from "@/lib/contextUsage";
 import type { ModelOption } from "@/lib/grokCatalog";
 import { useStickToBottom } from "@/hooks/useStickToBottom";
-import { shouldBumpStickOnBusyEdge } from "@/lib/stickToBottom";
+import {
+  shouldBumpStickOnBusyEdge,
+  stabilizeStickUserId,
+} from "@/lib/stickToBottom";
 import { useChatMessageVirtualizer } from "@/hooks/useChatMessageVirtualizer";
 import {
   estimateChatRowHeight,
@@ -1791,15 +1794,43 @@ export function ConversationThread({
    */
   const prevTurnBusyRef = useRef(false);
   const prevLastUserIdForStickRef = useRef<string | null>(null);
+  const stickUserRef = useRef<{
+    id: string | null;
+    count: number;
+    conversationKey: string;
+  }>({ id: null, count: 0, conversationKey: "" });
   const [stickBump, setStickBump] = useState(0);
   const turnBusyForStick =
     sessionState === "streaming" || sessionState === "awaiting_permission";
-  const lastUserIdForStick = useMemo(() => {
+  const lastUserIdRaw = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i]?.role === "user") return messages[i]!.id;
     }
     return null;
   }, [messages]);
+  const lastUserCount = useMemo(() => {
+    let n = 0;
+    for (const m of messages) if (m.role === "user") n += 1;
+    return n;
+  }, [messages]);
+  const conversationKeyForStick = sessionKey ?? "chat";
+  const lastUserIdForStick = useMemo(() => {
+    const conversationChanged =
+      stickUserRef.current.conversationKey !== conversationKeyForStick;
+    const next = stabilizeStickUserId({
+      prevId: stickUserRef.current.id,
+      nextId: lastUserIdRaw,
+      prevUserCount: stickUserRef.current.count,
+      nextUserCount: lastUserCount,
+      conversationChanged,
+    });
+    stickUserRef.current = {
+      id: next,
+      count: lastUserCount,
+      conversationKey: conversationKeyForStick,
+    };
+    return next;
+  }, [lastUserIdRaw, lastUserCount, conversationKeyForStick]);
   useEffect(() => {
     if (turnBusyForStick && !prevTurnBusyRef.current) {
       // Same user turn became busy (regenerate / permission) — bump.
@@ -2432,6 +2463,7 @@ export function ConversationThread({
     !showQuietThinking &&
     !liveTool &&
     !turnBusy;
+
   const emptyCopy = resolveChatTranscriptEmptyState({
     empty,
     suppressEmptyCopy,

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -37,7 +37,10 @@ import {
   type SoftBufferState,
 } from "@/lib/softStreamBuffer";
 import { softCloseMarkdown } from "@/lib/softCloseMarkdown";
-import { resolveStreamMarkdownParseMs } from "@/lib/streamRenderPolicy";
+import {
+  resolveMarkdownPaintSource,
+  resolveStreamMarkdownParseMs,
+} from "@/lib/streamRenderPolicy";
 import { revealInOsLabel } from "@/lib/appPlatform";
 import { cn } from "@/lib/utils";
 import { CodeBlock } from "./CodeBlock";
@@ -241,6 +244,7 @@ export const MarkdownChat = memo(function MarkdownChat({
     }, parseMs);
     return () => window.clearTimeout(id);
   }, [source, streaming, parseMs]);
+  const painted = resolveMarkdownPaintSource(streaming, source, mdSource);
 
   const renderPathOrUrl = (token: string, linkText?: string) => {
     const rawIn = token.trim().replace(/^<|>$/g, "");
@@ -572,7 +576,7 @@ export const MarkdownChat = memo(function MarkdownChat({
           },
         }}
       >
-        {mdSource}
+        {painted}
       </ReactMarkdown>
     </div>
   );

--- a/src/components/lobe-chat/Thinking.tsx
+++ b/src/components/lobe-chat/Thinking.tsx
@@ -18,6 +18,7 @@ import { createT, type Locale } from "@/i18n";
 import { COLLAPSE_ALL_ACTIVITY_EVENT } from "@/lib/collapseAllActivity";
 import { formatWorkDuration } from "@/lib/formatWorkDuration";
 import { resolveThinkingChromeLabel } from "@/lib/thinkingChromeLabel";
+import { resolveFoldExpanded } from "@/lib/toolStepsAutoCollapsePref";
 import {
   freezeThinkingDurationMs,
   nextThinkingStartAnchor,
@@ -55,6 +56,11 @@ export const Thinking = memo(function Thinking({
   const userToggled = useRef(false);
   const thinkingRef = useRef(!!thinking);
   thinkingRef.current = !!thinking;
+  const expanded = resolveFoldExpanded({
+    userToggled: userToggled.current,
+    storedOpen: open,
+    defaultOpen: !!thinking,
+  });
 
   useEffect(() => {
     const onCollapseAll = () => {
@@ -156,11 +162,8 @@ export const Thinking = memo(function Thinking({
     // the global default (that retroactively opened/collapsed every other
     // block via THINKING_PREF_EVENT). The global pref is Settings-only and
     // applies to blocks the user has not toggled.
-    setOpen((v) => {
-      const next = !v;
-      userToggled.current = true;
-      return next;
-    });
+    userToggled.current = true;
+    setOpen(!expanded);
   };
 
   return (
@@ -168,15 +171,15 @@ export const Thinking = memo(function Thinking({
       className={
         "grok-thought" +
         (thinking ? " is-live" : "") +
-        (open && hasBody ? " is-open" : " is-collapsed")
+        (expanded && hasBody ? " is-open" : " is-collapsed")
       }
       data-testid="thinking-block"
-      data-expanded={open && hasBody ? "1" : "0"}
+      data-expanded={expanded && hasBody ? "1" : "0"}
     >
       <button
         type="button"
         className="grok-thought__header"
-        aria-expanded={hasBody ? open : undefined}
+        aria-expanded={hasBody ? expanded : undefined}
         onClick={toggle}
         disabled={!hasBody}
       >
@@ -193,7 +196,7 @@ export const Thinking = memo(function Thinking({
         </span>
         {hasBody ? (
           <span className="grok-thought__caret" aria-hidden>
-            {open ? (
+            {expanded ? (
               <IconChevronDown size={12} stroke={2} />
             ) : (
               <IconChevronRight size={12} stroke={2} />
@@ -203,7 +206,7 @@ export const Thinking = memo(function Thinking({
       </button>
 
       {/* Collapsed: header only. Expanded: muted dig-in body. */}
-      {open && hasBody ? (
+      {expanded && hasBody ? (
         <div className="grok-thought__body">
           {typeof content === "string" ? (
             <MarkdownChat

--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -32,6 +32,7 @@ import { COLLAPSE_ALL_ACTIVITY_EVENT } from "@/lib/collapseAllActivity";
 import type { TimelinePhase } from "@/lib/timelinePhases";
 import {
   loadToolStepsAutoCollapsePref,
+  resolveFoldExpanded,
   workPhaseDefaultOpen,
   TOOL_STEPS_AUTO_COLLAPSE_CHANGE_EVENT,
 } from "@/lib/toolStepsAutoCollapsePref";
@@ -724,6 +725,11 @@ export const TimelinePhaseBlock = memo(function TimelinePhaseBlock({
   });
   const [open, setOpen] = useState(() => wantOpen);
   const userToggled = useRef(false);
+  const expanded = resolveFoldExpanded({
+    userToggled: userToggled.current,
+    storedOpen: open,
+    defaultOpen: wantOpen,
+  });
 
   useEffect(() => {
     if (userToggled.current) return;
@@ -820,20 +826,20 @@ export const TimelinePhaseBlock = memo(function TimelinePhaseBlock({
     <div
       className={
         "grok-act" +
-        (phaseRunning ? " is-live" : open ? " is-open" : " is-collapsed")
+        (phaseRunning ? " is-live" : expanded ? " is-open" : " is-collapsed")
       }
       data-testid="timeline-phase"
       data-phase-id={phase.id}
       data-live={phaseRunning ? "1" : "0"}
-      data-expanded={open ? "1" : "0"}
+      data-expanded={expanded ? "1" : "0"}
     >
       <button
         type="button"
         className="grok-act__header"
-        aria-expanded={open}
+        aria-expanded={expanded}
         onClick={() => {
           userToggled.current = true;
-          setOpen((v) => !v);
+          setOpen(!expanded);
         }}
       >
         <span className="grok-act__header-icon" aria-hidden>
@@ -841,14 +847,14 @@ export const TimelinePhaseBlock = memo(function TimelinePhaseBlock({
         </span>
         <span className="grok-act__header-text">{phaseChromeLabel}</span>
         <span className="grok-act__header-caret" aria-hidden>
-          {open ? (
+          {expanded ? (
             <IconChevronDown size={12} stroke={2} />
           ) : (
             <IconChevronRight size={12} stroke={2} />
           )}
         </span>
       </button>
-      {open ? (
+      {expanded ? (
         <GrokActivitySteps
           steps={stepsResolved}
           tr={tr}

--- a/src/components/lobe-chat/TimelineToolRow.tsx
+++ b/src/components/lobe-chat/TimelineToolRow.tsx
@@ -23,6 +23,7 @@ import {
 import { normalizeTaskStatus } from "@/lib/sessionTasks";
 import {
   loadToolStepsAutoCollapsePref,
+  resolveFoldExpanded,
   toolStepDefaultOpen,
   TOOL_STEPS_AUTO_COLLAPSE_CHANGE_EVENT,
 } from "@/lib/toolStepsAutoCollapsePref";
@@ -126,6 +127,11 @@ export const TimelineToolRow = memo(function TimelineToolRow({
       : toolStepDefaultOpen(running, autoCollapse);
 
   const [open, setOpen] = useState(() => prefOpen);
+  const expanded = resolveFoldExpanded({
+    userToggled: userToggled.current,
+    storedOpen: open,
+    defaultOpen: prefOpen,
+  });
 
   useEffect(() => {
     if (running) {
@@ -143,7 +149,7 @@ export const TimelineToolRow = memo(function TimelineToolRow({
     }
   }, [running, autoCollapse, defaultExpanded, tool.toolCallId]);
 
-  const showBody = hasBody && open;
+  const showBody = hasBody && expanded;
 
   return (
     <div
@@ -156,7 +162,7 @@ export const TimelineToolRow = memo(function TimelineToolRow({
       role="status"
       data-tool-id={tool.toolCallId}
       data-testid="timeline-tool"
-      data-expanded={hasBody ? (open ? "1" : "0") : undefined}
+      data-expanded={hasBody ? (expanded ? "1" : "0") : undefined}
       title={tool.input || tool.path || tool.detail || summary}
     >
       <div className="grok-act__icon-col" aria-hidden>
@@ -168,15 +174,15 @@ export const TimelineToolRow = memo(function TimelineToolRow({
         <button
           type="button"
           className="grok-act__step-btn grok-act__step-btn--grow"
-          aria-expanded={open}
+          aria-expanded={expanded}
           onClick={() => {
             userToggled.current = true;
-            setOpen((v) => !v);
+            setOpen(!expanded);
           }}
         >
           <span className="grok-act__label">{summary}</span>
           <span
-            className={"grok-act__mini-caret" + (open ? " is-open" : "")}
+            className={"grok-act__mini-caret" + (expanded ? " is-open" : "")}
             aria-hidden
           >
             <IconChevronRight size={11} />
@@ -241,6 +247,12 @@ export function TimelineToolGroup({
   const [open, setOpen] = useState(() =>
     toolStepDefaultOpen(running, autoCollapse),
   );
+  const groupDefaultOpen = toolStepDefaultOpen(running, autoCollapse);
+  const expanded = resolveFoldExpanded({
+    userToggled: userToggled.current,
+    storedOpen: open,
+    defaultOpen: groupDefaultOpen,
+  });
 
   useEffect(() => {
     if (running) {
@@ -308,10 +320,10 @@ export function TimelineToolGroup({
       <button
         type="button"
         className="grok-act__step is-last grok-act__step-btn"
-        aria-expanded={open}
+        aria-expanded={expanded}
         onClick={() => {
           userToggled.current = true;
-          setOpen((v) => !v);
+          setOpen(!expanded);
         }}
       >
         <div className="grok-act__icon-col" aria-hidden>
@@ -325,13 +337,13 @@ export function TimelineToolGroup({
         </div>
         <span className="grok-act__label">{groupLabel}</span>
         <span
-          className={"grok-act__mini-caret" + (open ? " is-open" : "")}
+          className={"grok-act__mini-caret" + (expanded ? " is-open" : "")}
           aria-hidden
         >
           <IconChevronRight size={11} />
         </span>
       </button>
-      {open ? (
+      {expanded ? (
         <div className="lobe-timeline-tool-group__list">
           {tools.map((t) => (
             <TimelineToolRow

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -126,6 +126,10 @@ export function useChatMessageVirtualizer(
   estimateRef.current = getEstimateHeight;
   const forceRef = useRef(forceIndices);
   forceRef.current = forceIndices;
+  const itemCountRef = useRef(itemCount);
+  itemCountRef.current = itemCount;
+  const virtualizedRef = useRef(virtualized);
+  virtualizedRef.current = virtualized;
   const recomputeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** Programmatic scrollTop from height correction — ignore once for stick. */
   const ignoreScrollAdjustRef = useRef(false);
@@ -187,24 +191,26 @@ export function useChatMessageVirtualizer(
   }, []);
 
   const getOffsets = useCallback(() => {
+    const count = itemCountRef.current;
     const version = heightsVersionRef.current;
     const cached = offsetsCacheRef.current;
     if (
       cached &&
       cached.version === version &&
-      cached.count === itemCount
+      cached.count === count
     ) {
       return cached.offsets;
     }
-    const offsets = cumulativeOffsets(itemCount, getHeight);
-    offsetsCacheRef.current = { version, count: itemCount, offsets };
+    const offsets = cumulativeOffsets(count, getHeight);
+    offsetsCacheRef.current = { version, count, offsets };
     return offsets;
-  }, [itemCount, getHeight]);
+  }, [getHeight]);
 
   const recomputeNow = useCallback(() => {
-    if (!virtualized) {
+    const count = itemCountRef.current;
+    if (!virtualizedRef.current) {
       setWin((prev) => {
-        const next = full(itemCount);
+        const next = full(count);
         return prev.start === next.start &&
           prev.end === next.end &&
           prev.paddingTop === 0 &&
@@ -216,13 +222,13 @@ export function useChatMessageVirtualizer(
     }
     const el = viewportRef.current;
     if (!el) {
-      setWin(full(itemCount));
+      setWin(full(count));
       return;
     }
     const pin = !!isPinnedRef.current;
     const offsets = getOffsets();
     const next = computeChatVirtualWindow({
-      count: itemCount,
+      count,
       getHeight,
       scrollTop: el.scrollTop,
       viewportHeight: el.clientHeight,
@@ -261,7 +267,7 @@ export function useChatMessageVirtualizer(
       }
       return next;
     });
-  }, [virtualized, itemCount, viewportRef, isPinnedRef, getHeight, getOffsets]);
+  }, [viewportRef, isPinnedRef, getHeight, getOffsets]);
 
   const recompute = useCallback(() => {
     // Never rebuild the virtual window from height churn mid-scroll — that
@@ -283,9 +289,11 @@ export function useChatMessageVirtualizer(
   }, [recomputeNow, isPinnedRef]);
 
   // Scroll → recompute window range only (rAF). Height-driven rebuilds wait for idle.
+  // Do not list itemCount: a send must not tear down scroll/RO while old row
+  // observers still fire with a stale count (window fight = flash).
   useEffect(() => {
     if (!virtualized) {
-      setWin(full(itemCount));
+      setWin(full(itemCountRef.current));
       return;
     }
     const el = viewportRef.current;
@@ -359,7 +367,7 @@ export function useChatMessageVirtualizer(
         scrollIdleTimerRef.current = null;
       }
     };
-  }, [virtualized, itemCount, viewportRef, recompute, recomputeNow, conversationKey]);
+  }, [virtualized, viewportRef, recompute, recomputeNow, conversationKey]);
 
   // Streaming growth / force index changes while mounted.
   useLayoutEffect(() => {
@@ -398,7 +406,7 @@ export function useChatMessageVirtualizer(
 
   const commitRowHeight = useCallback(
     (index: number, el: HTMLElement) => {
-      if (!virtualized) return;
+      if (!virtualizedRef.current) return;
       if (runAfterPaneSplitMotion(() => commitRowHeight(index, el))) return;
       const key = getKeyRef.current(index);
       const nextH = Math.round(el.getBoundingClientRect().height);
@@ -440,7 +448,7 @@ export function useChatMessageVirtualizer(
       if (viewport && !pin && Math.abs(nextH - prevH) >= 4) {
         // Offsets for scroll anchor must use prevH for this row.
         heightsRef.current.set(key, prevH);
-        const offsetsBefore = cumulativeOffsets(itemCount, (i) => {
+        const offsetsBefore = cumulativeOffsets(itemCountRef.current, (i) => {
           const k = getKeyRef.current(i);
           const m = heightsRef.current.get(k);
           if (m != null) return m;
@@ -475,8 +483,11 @@ export function useChatMessageVirtualizer(
         }
       }
     },
-    [virtualized, isPinnedRef, viewportRef, recompute, itemCount],
+    [isPinnedRef, viewportRef, recompute],
   );
+
+  const commitRowHeightRef = useRef(commitRowHeight);
+  commitRowHeightRef.current = commitRowHeight;
 
   /**
    * Stable per-index ref callbacks. Returning a fresh function from measureRef(i)
@@ -502,17 +513,17 @@ export function useChatMessageVirtualizer(
           prevRo.disconnect();
           rowObserversRef.current.delete(index);
         }
-        if (!el || !virtualized) return;
+        if (!el || !virtualizedRef.current) return;
 
         // Immediate sample (mount) + observe media/layout growth afterward.
-        commitRowHeight(index, el);
+        commitRowHeightRef.current(index, el);
         // Coalesce RO storms (multi-image decode) — one commit per frame.
         let roRaf = 0;
         const ro = new ResizeObserver(() => {
           if (roRaf) return;
           roRaf = requestAnimationFrame(() => {
             roRaf = 0;
-            commitRowHeight(index, el);
+            commitRowHeightRef.current(index, el);
           });
         });
         ro.observe(el);
@@ -521,7 +532,7 @@ export function useChatMessageVirtualizer(
       measureCallbackCacheRef.current.set(index, cb);
       return cb;
     },
-    [virtualized, commitRowHeight],
+    [],
   );
 
   if (!virtualized) {

--- a/src/lib/chatUxFixtures.test.ts
+++ b/src/lib/chatUxFixtures.test.ts
@@ -214,14 +214,14 @@ describe("chat UX fixtures (shipped path)", () => {
     units = buildTimelineUnits(segs, { streaming: true });
     expect(units.map((u) => u.kind)).toEqual(["phase", "content"]);
     if (units[0]?.kind === "phase") expect(units[0].live).toBe(false);
-    // First status sentence must not freeze later reasoning: either a live
-    // trailing thought, or a placeholder while waiting for the next episode.
+    // Placeholder under live last content unmounts at settle and flashes the
+    // tail. Later reasoning paints as a thought row when it arrives.
     expect(
       shouldShowTrailingLiveThinking(units, {
         messageStreaming: true,
         hasRunningTool: false,
       }),
-    ).toBe(true);
+    ).toBe(false);
 
     messages = applyStreamChunk(messages, {
       sessionId: "s",

--- a/src/lib/chatVirtualList.test.ts
+++ b/src/lib/chatVirtualList.test.ts
@@ -200,6 +200,23 @@ describe("resolveChatOverscanPx", () => {
     expect(pin).toBeGreaterThanOrEqual(CHAT_PIN_OVERSCAN_MIN_PX);
     expect(pin).toBeLessThanOrEqual(CHAT_PIN_OVERSCAN_MAX_PX);
   });
+
+  it("does not shrink pin overscan under stream-perf scale", () => {
+    const vh = 811;
+    const pin = resolveChatOverscanPx({
+      viewportHeight: vh,
+      pinToBottom: true,
+    });
+    const scaled = resolveChatOverscanPx({
+      viewportHeight: vh,
+      pinToBottom: true,
+      scale: 0.55,
+    });
+    expect(scaled).toBe(pin);
+    const browse = resolveChatOverscanPx({ viewportHeight: vh, scale: 0.55 });
+    const browseFull = resolveChatOverscanPx({ viewportHeight: vh });
+    expect(browse).toBeLessThan(browseFull);
+  });
 });
 
 describe("applyForceIndices", () => {

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -210,6 +210,9 @@ export function resolveChatOverscanPx(input: {
       ),
     );
   }
+  // Pin window must not shrink under stream-perf. Scaling it down mid-turn
+  // then restoring at ready jumps start by a few rows — one tail flash.
+  if (input.pinToBottom) return px;
   const scale =
     input.scale != null && Number.isFinite(input.scale)
       ? Math.min(1, Math.max(0.35, input.scale))

--- a/src/lib/stickToBottom.test.ts
+++ b/src/lib/stickToBottom.test.ts
@@ -12,6 +12,7 @@ import {
   isNearBottom,
   nextStickPinState,
   shouldBumpStickOnBusyEdge,
+  stabilizeStickUserId,
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
   shouldReleaseStickOnScrollUp,
@@ -148,6 +149,50 @@ describe("shouldBumpStickOnBusyEdge", () => {
   it("does not bump when a new user message already force-sticks", () => {
     expect(shouldBumpStickOnBusyEdge("u2", "u1")).toBe(false);
     expect(shouldBumpStickOnBusyEdge("u1", null)).toBe(false);
+  });
+});
+
+describe("stabilizeStickUserId", () => {
+  it("keeps the optimistic id when journal rewrites the last user", () => {
+    expect(
+      stabilizeStickUserId({
+        prevId: "u-1787240481019",
+        nextId: "857cd02c-7159-41a2-8083-ce28d831e5b7",
+        prevUserCount: 12,
+        nextUserCount: 12,
+      }),
+    ).toBe("u-1787240481019");
+  });
+
+  it("takes the new id on a new send or rewind", () => {
+    expect(
+      stabilizeStickUserId({
+        prevId: "u-1",
+        nextId: "u-2",
+        prevUserCount: 11,
+        nextUserCount: 12,
+      }),
+    ).toBe("u-2");
+    expect(
+      stabilizeStickUserId({
+        prevId: "u-2",
+        nextId: "u-1",
+        prevUserCount: 12,
+        nextUserCount: 11,
+      }),
+    ).toBe("u-1");
+  });
+
+  it("takes the new id on conversation switch", () => {
+    expect(
+      stabilizeStickUserId({
+        prevId: "u-1",
+        nextId: "other-user",
+        prevUserCount: 12,
+        nextUserCount: 12,
+        conversationChanged: true,
+      }),
+    ).toBe("other-user");
   });
 });
 

--- a/src/lib/stickToBottom.ts
+++ b/src/lib/stickToBottom.ts
@@ -78,6 +78,30 @@ export function shouldBumpStickOnBusyEdge(
 }
 
 /**
+ * `forceStickKey` is last-user-id + bump. Journal hydrate rewrites the
+ * optimistic `u-${ts}` to a uuid without adding a user — treating that as a
+ * new key instant-scrolls at settle.
+ *
+ * Not #714 / #703 (pin yank / double stick on send). This only freezes the
+ * id when the user *count* is unchanged. New send / rewind / conversation
+ * switch still take `nextId`.
+ */
+export function stabilizeStickUserId(input: {
+  prevId: string | null;
+  nextId: string | null;
+  prevUserCount: number;
+  nextUserCount: number;
+  conversationChanged?: boolean;
+}): string | null {
+  if (input.conversationChanged) return input.nextId;
+  if (input.nextUserCount !== input.prevUserCount) return input.nextId;
+  if (input.prevId && input.nextId && input.prevId !== input.nextId) {
+    return input.prevId;
+  }
+  return input.nextId;
+}
+
+/**
  * Whether an upward scroll should release stick-to-bottom.
  *
  * Escape only when the viewport actually left the bottom **and** ended

--- a/src/lib/streamRenderPolicy.test.ts
+++ b/src/lib/streamRenderPolicy.test.ts
@@ -4,6 +4,7 @@ import {
   resolveStreamFlushMs,
   resolveStreamMarkdownParseMs,
   resolveStreamOverscanScale,
+  resolveMarkdownPaintSource,
   resolveTranscriptContentNotifyMs,
   shouldUsePlainStreamBody,
   STREAM_COALESCE_FLUSH_MS,
@@ -48,6 +49,12 @@ describe("streamRenderPolicy", () => {
     expect(resolveStreamFlushMs(4)).toBeGreaterThanOrEqual(STREAM_COALESCE_FLUSH_MS);
     expect(resolveStreamFlushMs(12)).toBe(STREAM_COALESCE_FLUSH_MS);
     expect(resolveStreamFlushMs(16)).toBeLessThan(STREAM_COALESCE_FLUSH_MS);
+  });
+
+  it("settled markdown paints live source, not the throttle lag", () => {
+    expect(resolveMarkdownPaintSource(true, "live", "lag")).toBe("lag");
+    expect(resolveMarkdownPaintSource(false, "live", "lag")).toBe("live");
+    expect(resolveMarkdownPaintSource(false, "final", "final")).toBe("final");
   });
 
   it("overscan scale shrinks only while streaming", () => {

--- a/src/lib/streamRenderPolicy.ts
+++ b/src/lib/streamRenderPolicy.ts
@@ -109,3 +109,16 @@ export function resolveStreamOverscanScale(
   if (!streaming) return 1;
   return isLowPowerClient(hardwareConcurrency) ? 0.55 : 0.75;
 }
+
+/**
+ * Streaming markdown parse is throttled. On settle, paint the live source in
+ * the same render — a useEffect flush leaves one frame of stale tree at the
+ * tail (the end-of-answer flash).
+ */
+export function resolveMarkdownPaintSource(
+  streaming: boolean,
+  liveSource: string,
+  throttledSource: string,
+): string {
+  return streaming ? throttledSource : liveSource;
+}

--- a/src/lib/timelinePhases.test.ts
+++ b/src/lib/timelinePhases.test.ts
@@ -249,7 +249,7 @@ describe("timelinePhases", () => {
     if (first.kind === "thought") expect(first.streaming).toBe(false);
   });
 
-  it("shouldShowTrailingLiveThinking after body while waiting for next episode", () => {
+  it("shouldShowTrailingLiveThinking skips a live last content tail", () => {
     const segs: MessageSegment[] = [
       { kind: "thought", text: "round1" },
       tool("t1", "Read a"),
@@ -259,7 +259,7 @@ describe("timelinePhases", () => {
     expect(shouldShowTrailingLiveThinking(units, {
       messageStreaming: true,
       hasRunningTool: false,
-    })).toBe(true);
+    })).toBe(false);
     expect(shouldShowTrailingLiveThinking(units, {
       messageStreaming: true,
       hasRunningTool: true,
@@ -275,6 +275,19 @@ describe("timelinePhases", () => {
     );
     expect(shouldShowTrailingLiveThinking(thinking, {
       messageStreaming: true,
+      hasRunningTool: false,
+    })).toBe(false);
+  });
+
+  it("shouldShowTrailingLiveThinking after a last bare tool while waiting", () => {
+    const segs: MessageSegment[] = [tool("t1", "Read a")];
+    const units = buildTimelineUnits(segs, { streaming: true });
+    expect(shouldShowTrailingLiveThinking(units, {
+      messageStreaming: true,
+      hasRunningTool: false,
+    })).toBe(true);
+    expect(shouldShowTrailingLiveThinking(units, {
+      messageStreaming: false,
       hasRunningTool: false,
     })).toBe(false);
   });

--- a/src/lib/timelinePhases.ts
+++ b/src/lib/timelinePhases.ts
@@ -392,8 +392,9 @@ export function coalesceAdjacentThoughts(
 /**
  * After the first answer fragment, later think→tool loops still need a live
  * “思考中” row. Timeline units already mark the trailing thought/phase live;
- * when the last unit is finished content or a closed phase, paint a trailing
+ * when the last unit is a closed phase or bare tool, paint a trailing
  * thinking placeholder until the next thought/tool arrives.
+ * Do not put it under last content — that row unmounts at settle and jumps the tail.
  *
  * Empty timelines stay on the existing empty-shell placeholder.
  */
@@ -421,6 +422,9 @@ export function shouldShowTrailingLiveThinking(
     return false;
   }
   if (last.kind === "phase" && last.live) return false;
+  // Last content is the live tail. A placeholder under it unmounts when
+  // the turn settles and jumps the answer. Next thought/tool paints itself.
+  if (last.kind === "content") return false;
   return true;
 }
 

--- a/src/lib/toolStepsAutoCollapsePref.test.ts
+++ b/src/lib/toolStepsAutoCollapsePref.test.ts
@@ -8,6 +8,7 @@ import {
   saveToolStepsAutoCollapsePref,
   toolStepDefaultOpen,
   workPhaseDefaultOpen,
+  resolveFoldExpanded,
   type ToolStepsAutoCollapseStorage,
 } from "./toolStepsAutoCollapsePref";
 
@@ -66,6 +67,37 @@ describe("toolStepsAutoCollapsePref", () => {
     // Default arg uses DEFAULT_TOOL_STEPS_AUTO_COLLAPSE (true)
     expect(toolStepDefaultOpen(false)).toBe(false);
     expect(toolStepDefaultOpen(true)).toBe(true);
+  });
+
+  it("resolveFoldExpanded follows default until the user toggles", () => {
+    expect(
+      resolveFoldExpanded({
+        userToggled: false,
+        storedOpen: true,
+        defaultOpen: false,
+      }),
+    ).toBe(false);
+    expect(
+      resolveFoldExpanded({
+        userToggled: false,
+        storedOpen: false,
+        defaultOpen: true,
+      }),
+    ).toBe(true);
+    expect(
+      resolveFoldExpanded({
+        userToggled: true,
+        storedOpen: true,
+        defaultOpen: false,
+      }),
+    ).toBe(true);
+    expect(
+      resolveFoldExpanded({
+        userToggled: true,
+        storedOpen: false,
+        defaultOpen: true,
+      }),
+    ).toBe(false);
   });
 
   it("workPhaseDefaultOpen: live stays expanded; done collapses unless errors", () => {

--- a/src/lib/toolStepsAutoCollapsePref.ts
+++ b/src/lib/toolStepsAutoCollapsePref.ts
@@ -97,3 +97,15 @@ export function workPhaseDefaultOpen(opts: {
   if ((opts.errorCount ?? 0) > 0) return true;
   return !(opts.autoCollapse ?? DEFAULT_TOOL_STEPS_AUTO_COLLAPSE);
 }
+
+/**
+ * Live→idle folds must follow `defaultOpen` on the same render the turn
+ * settles. Waiting on useEffect paints one expanded idle frame then collapses.
+ */
+export function resolveFoldExpanded(input: {
+  userToggled: boolean;
+  storedOpen: boolean;
+  defaultOpen: boolean;
+}): boolean {
+  return input.userToggled ? input.storedOpen : input.defaultOpen;
+}


### PR DESCRIPTION
## Summary

Fixes #760.

Long virtualized chats flashed on send and sometimes once more when the turn settled.

**Not #714 / #703.** That already-on-main work stops stick-lock from yanking a slight scroll-up and from double-sticking on send. This still reproduced with #714 applied.

- Virtual list reads the current `itemCount` (send must not tear down scroll/RO with a stale count — two windows fighting).
- Pin overscan does not shrink under stream-perf.
- Keep `forceStickKey` when journal rewrites the last user id (`u-${ts}` → uuid) without adding a user.
- Fold thinking/work chrome on the settle render; paint live markdown immediately.
- Do not mount a trailing “thinking” placeholder under last content.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm exec vitest run` on the touched unit tests (126 passed)
- [ ] I ran `cargo test` in `src-tauri` (UI-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new copy
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] CHANGELOG Unreleased updated
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
