### PR TITLE
fix(session): do not freeze Windows at end of turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ See `docs/llm-wiki/release.md`.
 - **宠物换成完整 bloub 形变目录**：浮层改用测过的 SVG 引擎（静止、思考、眨眼、通知、警示、六边形、轨道、彗星等），不再用旧的 clip-path 表情。设置可选 8 种休息形体和 16 种休息表情。输入框打字会走目录里的警示（斜感叹号），停打后回到所选休息形体；未读完成会话是显眼的橙红圆点（身体已经很热时改用柠黄），不再用视频里的蓝色。
 
 ### Fixed
+- **Windows no longer freezes at end of a long turn (#754)**: A trailing `prompt_complete` after `session/prompt` RPC Ok used to re-arm the end-of-turn handler. The second pass emitted IPC while journal reconcile still held the store lock; the WebView WndProc waited on that lock inside `SendMessage` and the window stopped painting. Duplicate finish is now a no-op, and post-turn UI rehydrate reads App `messages.json` only (Host already merged agent history).
 - **Local session API no longer wedges after the first turn**: A hung ACP handshake used to keep `connect_lock` forever (90s timeout abandoned the waiter without aborting the task). Later `--session-send` / `POST /turns` then waited ~180s and the CLI lied with `app_not_running`. Connect now aborts and bounded-kills pending children; dispatch returns `retry_later` in 15s; health exposes `connectLockBusy`; CLI maps timeouts to `error`; queued external prompts persist on disk and the Host drains them without the main window.
 - **Japanese PR hub and Ukrainian agent command keep `{name}` (#751)**: `ja` `prHub.author` was `作成者` with no author; `uk` `preferredCurrent` shipped `--agent ` with nothing to paste. Catalog tests now fail if any locale drops or renames an `en` placeholder.
 - **Sidebar tree text columns line up (#745)**: Projects and Other labels share one left edge. Project names and the session titles under them share `--tree-text-inset`. The L1 chevron column is 20px (was 28).
@@ -45,6 +46,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **Windows 长回合结束不再卡死整窗（#754）**：`session/prompt` RPC 已经结束之后，迟到的 `prompt_complete` 会再次武装结束逻辑。第二次结束在 journal 对账还占着 store 锁时发 IPC，WebView 的 WndProc 在 `SendMessage` 里等这把锁，窗口不再重绘。重复结束现在是空操作；回合结束后的 UI 补刷只读 App `messages.json`（Host 已经合并过 agent 历史）。
 - **本地 session API 干完一轮后不再卡死**：卡住的 ACP 握手会把 `connect_lock` 永久占住（90s 超时只放弃等待、不 abort 任务），之后的 `--session-send` / `POST /turns` 会挂到约 180s，CLI 还谎称 `app_not_running`。现在超时会 abort 并用有上界的 kill 清 pending 子进程；派活 15s 内回 `retry_later`；health 带 `connectLockBusy`；CLI 把超时映射成 `error`；外部 queued 落盘，由 Host drain，不依赖主窗口。
 - **日语 PR hub 和乌克兰语 agent 命令不再丢掉 `{name}`（#751）**：`ja` 的 `prHub.author` 只有「作成者」没有人名；`uk` 的 `preferredCurrent` 复制出来是空的 `--agent `。目录测试会拦截任何语言丢掉或改名 en 占位符。
 - **侧栏树文字列对齐（#745）**：Projects 与 Other 标题左缘对齐；项目名与其下会话标题共用 `--tree-text-inset`。一级箭头列从 28px 收到 20px。

--- a/docs/llm-wiki/session-continuity.md
+++ b/docs/llm-wiki/session-continuity.md
@@ -124,7 +124,11 @@ stack full open pipelines.
    after each `await`, abort UI writes when gen or viewing id no longer match.  
 2. **Journal load without reconcile** — switch calls `session_messages` with
    `reconcile: false` (App `messages.json` only). Agent `chat_history` merge is
-   **deferred** (~500ms) only if the user is still on that chat.  
+   **deferred** (~500ms) only if the user is still on that chat.
+   End-of-turn UI rehydrate (`session://stream` done / `session://state` ready /
+   `session://journal_reconciled`) also passes `reconcile: false` — Host
+   `post_turn_reconcile` already merged agent history. Re-parsing jsonl on that
+   IPC path deadlocked the Windows WndProc (#754).  
 3. **Warm connect debounce** (~350ms) — only the settled viewing session may
    call `sessionConnect`; pending timers clear on the next navigation.  
 4. Host: `session_messages` / `paths_classify` run disk work on `spawn_blocking`

--- a/src-tauri/src/session_manager/events.rs
+++ b/src-tauri/src/session_manager/events.rs
@@ -284,21 +284,25 @@ impl SessionManager {
                         if authoritative {
                             s.prompt_in_flight = false;
                         }
-                        s.deferred_prompt_complete = Some(stop_reason.clone());
-                        // #52: do not Ready the UI while tools / permission / ask_user / plan
-                        // are still open — agent often fires prompt_complete early.
-                        match Self::try_finish_deferred_prompt_complete(s, Some(app)) {
-                            None => {
-                                tracing::info!(
-                                    "acp prompt_complete deferred stop={stop_reason} tools={} perm={} plan={} ask={}",
-                                    s.open_tool_ids.len(),
-                                    s.fsm.state() == SessionState::AwaitingPermission,
-                                    s.pending_plan_rpc_id.is_some(),
-                                    s.pending_ask_user_rpc_id.is_some(),
-                                );
-                                None
+                        if !Self::should_rearm_deferred_prompt_complete(s) {
+                            None
+                        } else {
+                            s.deferred_prompt_complete = Some(stop_reason.clone());
+                            // #52: do not Ready the UI while tools / permission / ask_user / plan
+                            // are still open — agent often fires prompt_complete early.
+                            match Self::try_finish_deferred_prompt_complete(s, Some(app)) {
+                                None => {
+                                    tracing::info!(
+                                        "acp prompt_complete deferred stop={stop_reason} tools={} perm={} plan={} ask={}",
+                                        s.open_tool_ids.len(),
+                                        s.fsm.state() == SessionState::AwaitingPermission,
+                                        s.pending_plan_rpc_id.is_some(),
+                                        s.pending_ask_user_rpc_id.is_some(),
+                                    );
+                                    None
+                                }
+                                Some(empty) => empty,
                             }
-                            Some(empty) => empty,
                         }
                     } else {
                         None

--- a/src-tauri/src/session_manager/events_bg.rs
+++ b/src-tauri/src/session_manager/events_bg.rs
@@ -143,18 +143,22 @@ impl SessionManager {
                         if authoritative {
                             s.prompt_in_flight = false;
                         }
-                        s.deferred_prompt_complete = Some(stop_reason.clone());
-                        // Keep turn open while tools still running (long find / subagent).
-                        match Self::try_finish_deferred_prompt_complete(s, Some(app)) {
-                            None => {
-                                tracing::info!(
-                                    "background prompt_complete deferred sid={} tools={}",
-                                    app_session_id,
-                                    s.open_tool_ids.len()
-                                );
-                                false
+                        if !Self::should_rearm_deferred_prompt_complete(s) {
+                            false
+                        } else {
+                            s.deferred_prompt_complete = Some(stop_reason.clone());
+                            // Keep turn open while tools still running (long find / subagent).
+                            match Self::try_finish_deferred_prompt_complete(s, Some(app)) {
+                                None => {
+                                    tracing::info!(
+                                        "background prompt_complete deferred sid={} tools={}",
+                                        app_session_id,
+                                        s.open_tool_ids.len()
+                                    );
+                                    false
+                                }
+                                Some(_) => true,
                             }
-                            Some(_) => true,
                         }
                     } else {
                         false

--- a/src-tauri/src/session_manager/stall_tests.rs
+++ b/src-tauri/src/session_manager/stall_tests.rs
@@ -306,6 +306,44 @@ fn deferred_prompt_complete_finishes_after_orphan_prune() {
     });
 }
 
+/// #754: session/prompt RPC Ok already finished the turn. A trailing
+/// prompt_complete notification must not re-arm deferred finish.
+#[test]
+fn prompt_complete_does_not_rearm_after_turn_is_ready() {
+    with_temp_app_home(|| {
+        let t0 = Instant::now();
+        let mut s = streaming_session(t0, |s| {
+            s.prompt_in_flight = false;
+            s.deferred_prompt_complete = Some("end_turn".into());
+            s.saw_model_output = true;
+        });
+        let first = SessionManager::try_finish_deferred_prompt_complete(&mut s, None);
+        assert!(first.is_some(), "first finish should complete the turn");
+        assert_eq!(s.fsm.state(), SessionState::Ready);
+        assert!(s.active_turn_id.is_none());
+        assert!(!SessionManager::should_rearm_deferred_prompt_complete(&s));
+
+        s.deferred_prompt_complete = Some("end_turn".into());
+        let second = SessionManager::try_finish_deferred_prompt_complete(&mut s, None);
+        assert!(
+            second.is_none(),
+            "duplicate prompt_complete must not finish again"
+        );
+        assert!(s.deferred_prompt_complete.is_none());
+        assert_eq!(s.fsm.state(), SessionState::Ready);
+    });
+}
+
+#[test]
+fn prompt_complete_still_rearms_while_rpc_in_flight() {
+    let t0 = Instant::now();
+    let s = streaming_session(t0, |s| {
+        s.prompt_in_flight = true;
+        s.deferred_prompt_complete = None;
+    });
+    assert!(SessionManager::should_rearm_deferred_prompt_complete(&s));
+}
+
 #[test]
 fn enrich_recovers_mcp_tool_name_from_sparse_completed() {
     let raw = json!({

--- a/src-tauri/src/session_manager/stream.rs
+++ b/src-tauri/src/session_manager/stream.rs
@@ -323,6 +323,23 @@ impl SessionManager {
         }
     }
 
+    /// A second `prompt_complete` (notification + `session/prompt` RPC Ok)
+    /// must not re-arm finish after the turn already left Streaming.
+    ///
+    /// Rearming `deferred_prompt_complete` ran the end-of-turn handler twice
+    /// (#754): the second pass emitted IPC while still holding `inner`, overlapping
+    /// post-turn journal reconcile's store lock. On Windows the WebView WndProc
+    /// then waited on that lock inside `SendMessage` and the window froze.
+    pub(super) fn should_rearm_deferred_prompt_complete(s: &LiveSession) -> bool {
+        if s.prompt_in_flight {
+            return true;
+        }
+        matches!(
+            s.fsm.state(),
+            SessionState::Streaming | SessionState::AwaitingPermission
+        )
+    }
+
     /// Finish turn when a deferred `prompt_complete` is safe (#52).
     /// Returns `Some(empty_run)` if finished (`None` inside = finished, not empty);
     /// returns `None` if still deferred.
@@ -338,6 +355,12 @@ impl SessionManager {
         // has gone quiet (and `PROMPT_TIMEOUT_SECS` caps a wedged RPC), so this
         // cannot hang.
         if s.prompt_in_flight {
+            return None;
+        }
+        // Duplicate prompt_complete after a successful finish: clear the
+        // re-armed deferred flag and do not flush/emit/journal again.
+        if s.active_turn_id.is_none() && s.fsm.state() == SessionState::Ready {
+            s.deferred_prompt_complete = None;
             return None;
         }
         // Drop journal-terminal / aged open tools first so bg handoff leftovers

--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -103,6 +103,7 @@ import {
   toolEventNeedsImmediateFlush,
 } from "@/lib/streamCoalesce";
 import {
+  JOURNAL_REHYDRATE_RECONCILE,
   JOURNAL_REHYDRATE_RETRY_GAPS_MS,
   shouldApplyLateStreamText,
   shouldHealJournalOnStreamDone,
@@ -390,7 +391,7 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
           opts?: { clearStreaming?: boolean },
         ) => {
           void api
-            .sessionMessages(sid)
+            .sessionMessages(sid, { reconcile: JOURNAL_REHYDRATE_RECONCILE })
             .then((stored) => {
               if (cancelled || c.viewingSessionIdRef.current !== sid) return;
               const hostState =

--- a/src/lib/streamLateToken.test.ts
+++ b/src/lib/streamLateToken.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  JOURNAL_REHYDRATE_RECONCILE,
   JOURNAL_REHYDRATE_RETRY_GAPS_MS,
   shouldApplyLateStreamText,
   shouldHealJournalOnStreamDone,
@@ -198,5 +199,9 @@ describe("shouldHealJournalOnStreamDone", () => {
     const total = JOURNAL_REHYDRATE_RETRY_GAPS_MS.reduce((a, b) => a + b, 0);
     expect(JOURNAL_REHYDRATE_RETRY_GAPS_MS).toEqual([400, 500]);
     expect(total).toBeGreaterThanOrEqual(750);
+  });
+
+  it("does not re-parse agent jsonl on end-of-turn rehydrate (#754)", () => {
+    expect(JOURNAL_REHYDRATE_RECONCILE).toBe(false);
   });
 });

--- a/src/lib/streamLateToken.ts
+++ b/src/lib/streamLateToken.ts
@@ -83,6 +83,15 @@ export function shouldHealJournalOnStreamDone(opts: {
 export const JOURNAL_REHYDRATE_RETRY_GAPS_MS = [400, 500] as const;
 
 /**
+ * End-of-turn UI rehydrate must not re-parse agent `chat_history` / `updates`.
+ * Host `post_turn_reconcile` already merged those rows. Passing `reconcile: true`
+ * here stacked a second jsonl parse on `session_messages` while the Host still
+ * held the process store lock — on Windows that wait sat inside the WebView
+ * WndProc and froze the window (#754).
+ */
+export const JOURNAL_REHYDRATE_RECONCILE = false;
+
+/**
  * Early `session://stream` `done:true` (prompt_complete / prompt RPC
  * fallback) must not freeze the bubble while Host is still mid-turn.
  * A later fragment would then render as 工作了 + copy/MD/retry under a


### PR DESCRIPTION
## Summary
- A trailing `prompt_complete` after `session/prompt` RPC Ok used to re-arm deferred finish. The second pass emitted IPC while post-turn journal reconcile still held the process store lock; on Windows the WebView WndProc waited on that lock inside `SendMessage` and the window stopped painting.
- Duplicate finish is now a no-op (`should_rearm_deferred_prompt_complete` + Ready guard).
- End-of-turn UI rehydrate reads App `messages.json` only (`JOURNAL_REHYDRATE_RECONCILE = false`). Host `post_turn_reconcile` already merged agent history. Sidebar switch still deferred-reconciles after settle.

Fixes #754

## Type of change
- [x] Bug fix

## Test plan
- [x] `prompt_complete_does_not_rearm_after_turn_is_ready`
- [x] `prompt_complete_still_rearms_while_rpc_in_flight`
- [x] `streamLateToken.test.ts` (rehydrate does not re-parse jsonl)
- [ ] Windows: long plan-mode turn → window still paints and accepts input after `stop=end_turn`

## Checklist
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
- [x] pi review: pass (no blocker)