### PR TITLE
fix(windows): cap OS min so Win+Right snaps to half

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ See `docs/llm-wiki/release.md`.
 - **工作台外壳拆分（#757）**：偏好/布局 hook、GlassModal、紧凑浮层、应用内对话框、命令面板进 `workbench-modals/`；会话 transcript 助手进 `src/lib/session/*`（barrel 保持 `@/lib/session`）。发送 / 打开会话 / rewind 仍在 AppWorkbench。
 
 ### Fixed
+- **Win+Right snap is true half on short displays (#765)**: Comfort `minWidth` stays 900. The Host caps the OS min to half the current monitor work area (height too), so a 1440×900 work area snaps to 720 instead of sticking at 900 (~2/3). A larger display restores the 900 floor.
 - **Windows Host builds again after Explorer-file paste (#763)**: `clipboard-win` 5.4’s `FileList` implements `Getter` for both `Vec<String>` and `Vec<PathBuf>`, so rustc could not infer `get_clipboard` (`E0282`). Name `Vec<String>` explicitly. Follow-up to #756.
 - **Desktop pet remembers its last place after quit**: Drag origin is flushed on pointer-up, hide, and process exit. A stuck OS-drag flag can no longer persist 0,0 while hiding. Settings writes keep the live overlay instead of stale x/y. Reopen places the window so the mark (not just the frame’s top-left) stays put when overlay size changes.
 - **Long chats no longer flash on send and at turn settle (#760)**: This is not #714 / #703 (stick-lock no longer yanks a slight scroll-up, and send only sticks once). After send, the virtual list no longer fights two `itemCount`s; journal rewrite of the last user id no longer force-sticks.
@@ -86,6 +87,7 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
+- **Win+Right 在矮屏上能贴真正半屏（#765）**：舒适下限仍是 900。Host 把系统 min 限制在当前显示器工作区的一半（高度同样），1440×900 会贴 720 而不是卡在 900（约 2/3）。拖到更大屏后 900 下限会回来。
 - **Windows Host 在资源管理器粘贴修复后重新能编过（#763）**：`clipboard-win` 5.4 的 `FileList` 同时实现 `Vec<String>` 和 `Vec<PathBuf>`，`get_clipboard` 推不出类型（`E0282`）。显式标成 `Vec<String>`。#756 的后续。
 - **桌面宠物关闭再开会回到上次位置**：松手、隐藏、退出都会把坐标写盘。卡住的系统拖动标记不会在隐藏时把 0,0 存进去。改设置不再用过期的 x/y 覆盖现场。重新打开时按宠物（不是窗口左上角）对齐，浮层大小变了也不会把宠物挪走。
 - **长对话发送/回合结束不再整页闪（#760）**：不是 #714 / #703（那是贴底后轻滑被拽回、发送双吸底）。发送后虚拟列表不再用两套条数抢窗口；日记改写最后一条 user id 时不再强制吸底。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ See `docs/llm-wiki/release.md`.
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com/](https://grok-app.com/)。
 
 ### Fixed
+- **Win+Right snap is true half on short displays (#765)**: Comfort `minWidth` stays 900. The Host caps the OS min to half the current monitor work area (height too), so a 1440×900 work area snaps to 720 instead of sticking at 900 (~2/3). A larger display restores the 900 floor.
 - **Windows Alt+Tab can type without a click first (#768)**: Tauri `unstable` (side-browser multi-webview) builds the page as a child `WRY_WEBVIEW`, so Alt-Tab / taskbar only activates the outer HWND. The host now forwards `WM_SETFOCUS` / `WM_ACTIVATE` into that child so composer and shortcuts work immediately.
 
 **中文 · 修复**
+- **Win+Right 在矮屏上能贴真正半屏（#765）**：舒适下限仍是 900。Host 把系统 min 限制在当前显示器工作区的一半（高度同样），1440×900 会贴 720 而不是卡在 900（约 2/3）。拖到更大屏后 900 下限会回来。
 - **Windows Alt+Tab 后不用先点一下就能打字（#768）**：Tauri `unstable`（资源栏内嵌浏览器）把页面建成子窗口 `WRY_WEBVIEW`，Alt+Tab / 任务栏只激活外层 HWND。Host 现在把 `WM_SETFOCUS` / `WM_ACTIVATE` 转进该子窗口，输入框和快捷键立刻可用。
 
 ## [0.2.24] - 2026-08-21
@@ -60,7 +62,6 @@ See `docs/llm-wiki/release.md`.
 - **工作台外壳拆分（#757）**：偏好/布局 hook、GlassModal、紧凑浮层、应用内对话框、命令面板进 `workbench-modals/`；会话 transcript 助手进 `src/lib/session/*`（barrel 保持 `@/lib/session`）。发送 / 打开会话 / rewind 仍在 AppWorkbench。
 
 ### Fixed
-- **Win+Right snap is true half on short displays (#765)**: Comfort `minWidth` stays 900. The Host caps the OS min to half the current monitor work area (height too), so a 1440×900 work area snaps to 720 instead of sticking at 900 (~2/3). A larger display restores the 900 floor.
 - **Windows Host builds again after Explorer-file paste (#763)**: `clipboard-win` 5.4’s `FileList` implements `Getter` for both `Vec<String>` and `Vec<PathBuf>`, so rustc could not infer `get_clipboard` (`E0282`). Name `Vec<String>` explicitly. Follow-up to #756.
 - **Desktop pet remembers its last place after quit**: Drag origin is flushed on pointer-up, hide, and process exit. A stuck OS-drag flag can no longer persist 0,0 while hiding. Settings writes keep the live overlay instead of stale x/y. Reopen places the window so the mark (not just the frame’s top-left) stays put when overlay size changes.
 - **Long chats no longer flash on send and at turn settle (#760)**: This is not #714 / #703 (stick-lock no longer yanks a slight scroll-up, and send only sticks once). After send, the virtual list no longer fights two `itemCount`s; journal rewrite of the last user id no longer force-sticks.
@@ -87,7 +88,6 @@ See `docs/llm-wiki/release.md`.
 - **`cargo fmt --check` is green on main (#725)**.
 
 **中文 · 修复**
-- **Win+Right 在矮屏上能贴真正半屏（#765）**：舒适下限仍是 900。Host 把系统 min 限制在当前显示器工作区的一半（高度同样），1440×900 会贴 720 而不是卡在 900（约 2/3）。拖到更大屏后 900 下限会回来。
 - **Windows Host 在资源管理器粘贴修复后重新能编过（#763）**：`clipboard-win` 5.4 的 `FileList` 同时实现 `Vec<String>` 和 `Vec<PathBuf>`，`get_clipboard` 推不出类型（`E0282`）。显式标成 `Vec<String>`。#756 的后续。
 - **桌面宠物关闭再开会回到上次位置**：松手、隐藏、退出都会把坐标写盘。卡住的系统拖动标记不会在隐藏时把 0,0 存进去。改设置不再用过期的 x/y 覆盖现场。重新打开时按宠物（不是窗口左上角）对齐，浮层大小变了也不会把宠物挪走。
 - **长对话发送/回合结束不再整页闪（#760）**：不是 #714 / #703（那是贴底后轻滑被拽回、发送双吸底）。发送后虚拟列表不再用两套条数抢窗口；日记改写最后一条 user id 时不再强制吸底。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -215,6 +215,8 @@ mod voice_tools;
 
 mod wallpaper_source;
 
+mod window_min;
+
 #[cfg(windows)]
 mod win_shell;
 
@@ -456,9 +458,13 @@ pub fn run() {
                 // Plugin keeps in-memory state on Resized/Moved but only writes disk
                 // on process Exit. Debounce-persist so force-quit / crash / tauri-dev
                 // restart / OS reboot still remember the last user size.
-                WindowEvent::Resized(_)
-                | WindowEvent::Moved(_)
-                | WindowEvent::ScaleFactorChanged { .. } => {
+                WindowEvent::Moved(_) | WindowEvent::ScaleFactorChanged { .. } => {
+                    if window.label() == "main" {
+                        window_min::apply_main(window.app_handle());
+                        schedule_persist_main_window_state(window.app_handle());
+                    }
+                }
+                WindowEvent::Resized(_) => {
                     if window.label() == "main" {
                         schedule_persist_main_window_state(window.app_handle());
                     }
@@ -491,14 +497,20 @@ pub fn run() {
                 .ok_or_else(|| "main window config missing".to_string())?;
             main_cfg.visible = false;
             main_cfg.focus = false;
+            // Comfort min from JSON, capped so Win+Left/Right can be a true half.
+            let comfort_w = main_cfg.min_width.unwrap_or(900.0);
+            let comfort_h = main_cfg.min_height.unwrap_or(600.0);
+            let snap_mon = on_monitor
+                .clone()
+                .or_else(|| app.primary_monitor().ok().flatten());
+            let (min_w, min_h) =
+                window_min::cap_for_monitor(comfort_w, comfort_h, snap_mon.as_ref());
+            main_cfg.min_width = Some(min_w);
+            main_cfg.min_height = Some(min_h);
             if let Some(g) = &saved_geometry {
                 let (mut w, mut h) = (g.width as f64 / scale, g.height as f64 / scale);
-                if let Some(min_w) = main_cfg.min_width {
-                    w = w.max(min_w);
-                }
-                if let Some(min_h) = main_cfg.min_height {
-                    h = h.max(min_h);
-                }
+                w = w.max(min_w);
+                h = h.max(min_h);
                 main_cfg.width = w;
                 main_cfg.height = h;
                 let (px, py) = if g.maximized {
@@ -539,6 +551,7 @@ pub fn run() {
                 .accept_first_mouse(true)
                 .initialization_script(&boot_theme_script)
                 .build()?;
+            window_min::apply_main(window.app_handle());
 
             #[cfg(target_os = "macos")]
             {

--- a/src-tauri/src/window_min.rs
+++ b/src-tauri/src/window_min.rs
@@ -99,7 +99,10 @@ mod tests {
     fn large_display_keeps_comfort() {
         assert_eq!(snap_friendly_min(900.0, 1920.0), 900.0);
         assert_eq!(snap_friendly_min(900.0, 2560.0), 900.0);
-        assert_eq!(snap_friendly_min(600.0, 1080.0), 600.0);
+        // 1080 work height: half is 540, so comfort 600 cannot be kept.
+        assert_eq!(snap_friendly_min(600.0, 1080.0), 540.0);
+        // 1200+ work height keeps 600.
+        assert_eq!(snap_friendly_min(600.0, 1200.0), 600.0);
     }
 
     #[test]
@@ -129,6 +132,10 @@ mod tests {
         );
         assert_eq!(
             snap_friendly_min_size(900.0, 600.0, 1920.0, 1080.0),
+            (900.0, 540.0)
+        );
+        assert_eq!(
+            snap_friendly_min_size(900.0, 600.0, 1920.0, 1200.0),
             (900.0, 600.0)
         );
     }

--- a/src-tauri/src/window_min.rs
+++ b/src-tauri/src/window_min.rs
@@ -1,0 +1,135 @@
+//! Main-window OS min size vs tiling.
+//!
+//! Config `minWidth` / `minHeight` are a comfort floor. Aero Snap, Win+arrows,
+//! and tiling WMs refuse to size below `WM_GETMINMAXINFO` / the Tauri min, so a
+//! 900px floor on a 1440-wide work area becomes ~2/3 of the screen. Cap the OS
+//! min to half the current monitor work area (taskbar excluded). Large
+//! displays keep 900×600; moving onto a bigger screen restores that floor.
+
+use tauri::{AppHandle, LogicalSize, Manager, Monitor};
+
+/// Comfort fallback when the window config omits min size.
+const FALLBACK_MIN_W: f64 = 900.0;
+const FALLBACK_MIN_H: f64 = 600.0;
+
+/// Cap one axis: never larger than half of `work` (floored so min ≤ true half).
+pub fn snap_friendly_min(comfort: f64, work: f64) -> f64 {
+    let comfort = if comfort.is_finite() && comfort > 0.0 {
+        comfort
+    } else {
+        1.0
+    };
+    if !work.is_finite() || work <= 0.0 {
+        return comfort;
+    }
+    let half = (work / 2.0).floor();
+    if half <= 0.0 {
+        return comfort;
+    }
+    comfort.min(half)
+}
+
+pub fn snap_friendly_min_size(
+    comfort_w: f64,
+    comfort_h: f64,
+    work_w: f64,
+    work_h: f64,
+) -> (f64, f64) {
+    (
+        snap_friendly_min(comfort_w, work_w),
+        snap_friendly_min(comfort_h, work_h),
+    )
+}
+
+/// Logical work-area size (taskbar excluded), matching OS snap.
+pub fn work_logical(monitor: &Monitor) -> (f64, f64) {
+    let scale = monitor.scale_factor().max(0.1);
+    let s = monitor.work_area().size;
+    (f64::from(s.width) / scale, f64::from(s.height) / scale)
+}
+
+pub fn cap_for_monitor(comfort_w: f64, comfort_h: f64, monitor: Option<&Monitor>) -> (f64, f64) {
+    match monitor {
+        Some(m) => {
+            let (ww, wh) = work_logical(m);
+            snap_friendly_min_size(comfort_w, comfort_h, ww, wh)
+        }
+        None => (
+            snap_friendly_min(comfort_w, f64::INFINITY),
+            snap_friendly_min(comfort_h, f64::INFINITY),
+        ),
+    }
+}
+
+fn comfort_from_config(app: &AppHandle) -> (f64, f64) {
+    let w = app.config().app.windows.iter().find(|w| w.label == "main");
+    (
+        w.and_then(|c| c.min_width)
+            .filter(|v| v.is_finite() && *v > 0.0)
+            .unwrap_or(FALLBACK_MIN_W),
+        w.and_then(|c| c.min_height)
+            .filter(|v| v.is_finite() && *v > 0.0)
+            .unwrap_or(FALLBACK_MIN_H),
+    )
+}
+
+/// Recompute OS min from the main window's current monitor.
+pub fn apply_main(app: &AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    let (cw, ch) = comfort_from_config(app);
+    let monitor = window.current_monitor().ok().flatten();
+    let (min_w, min_h) = cap_for_monitor(cw, ch, monitor.as_ref());
+    let _ = window.set_min_size(Some(LogicalSize::new(min_w, min_h)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{snap_friendly_min, snap_friendly_min_size};
+
+    #[test]
+    fn half_of_1440_beats_comfort_900() {
+        // 1440×900 @ 100%, work 1440×852. Win+Right half = 720.
+        assert_eq!(snap_friendly_min(900.0, 1440.0), 720.0);
+        assert_eq!(snap_friendly_min(600.0, 852.0), 426.0);
+    }
+
+    #[test]
+    fn large_display_keeps_comfort() {
+        assert_eq!(snap_friendly_min(900.0, 1920.0), 900.0);
+        assert_eq!(snap_friendly_min(900.0, 2560.0), 900.0);
+        assert_eq!(snap_friendly_min(600.0, 1080.0), 600.0);
+    }
+
+    #[test]
+    fn scaled_1080p_and_1366() {
+        assert_eq!(snap_friendly_min(900.0, 1280.0), 640.0); // 1920@150%
+        assert_eq!(snap_friendly_min(900.0, 1366.0), 683.0);
+        assert_eq!(snap_friendly_min(900.0, 1536.0), 768.0); // 1920@125%
+    }
+
+    #[test]
+    fn floor_keeps_min_at_or_below_half() {
+        assert_eq!(snap_friendly_min(900.0, 1001.0), 500.0);
+    }
+
+    #[test]
+    fn missing_work_keeps_comfort() {
+        assert_eq!(snap_friendly_min(900.0, f64::INFINITY), 900.0);
+        assert_eq!(snap_friendly_min(900.0, 0.0), 900.0);
+        assert_eq!(snap_friendly_min(900.0, f64::NAN), 900.0);
+    }
+
+    #[test]
+    fn size_caps_both_axes() {
+        assert_eq!(
+            snap_friendly_min_size(900.0, 600.0, 1440.0, 852.0),
+            (720.0, 426.0)
+        );
+        assert_eq!(
+            snap_friendly_min_size(900.0, 600.0, 1920.0, 1080.0),
+            (900.0, 600.0)
+        );
+    }
+}

--- a/src/lib/window-config.test.ts
+++ b/src/lib/window-config.test.ts
@@ -9,6 +9,7 @@ const TAURI_DIR = resolve(__dirname, "../../src-tauri");
 const CONF_PATH = resolve(TAURI_DIR, "tauri.conf.json");
 const MAC_PATH = resolve(TAURI_DIR, "tauri.macos.conf.json");
 const WIN_PATH = resolve(TAURI_DIR, "tauri.windows.conf.json");
+const LINUX_PATH = resolve(TAURI_DIR, "tauri.linux.conf.json");
 
 /**
  * Read a source file for text assertions, normalized to LF.
@@ -47,6 +48,31 @@ describe("window chrome", () => {
     expect(main.transparent).toBe(true);
     expect(main.decorations).toBe(true);
     expect(conf.app.macOSPrivateApi).toBe(true);
+  });
+
+  it("comfort min stays 900; Host caps OS min to half the work area", () => {
+    // Do not drop JSON minWidth to "fit" 1440 — large screens keep 900.
+    // window_min.rs caps WM_GETMINMAXINFO to half the current work area.
+    for (const path of [CONF_PATH, MAC_PATH, WIN_PATH, LINUX_PATH]) {
+      const conf = JSON.parse(readFileSync(path, "utf8")) as {
+        app: { windows: Array<{ minWidth?: number }> };
+      };
+      expect(conf.app.windows[0]!.minWidth).toBe(900);
+    }
+    const host = readSource(resolve(TAURI_DIR, "src/window_min.rs"));
+    expect(host).toMatch(/fn snap_friendly_min/);
+    expect(host).toContain("work_area");
+    // Same cases as src-tauri/src/window_min.rs (comfort stays 900; OS min ≤ half).
+    const snapFriendlyMin = (comfort: number, work: number) => {
+      if (!Number.isFinite(comfort) || comfort <= 0) return 1;
+      if (!Number.isFinite(work) || work <= 0) return comfort;
+      const half = Math.floor(work / 2);
+      if (half <= 0) return comfort;
+      return Math.min(comfort, half);
+    };
+    expect(snapFriendlyMin(900, 1440)).toBe(720);
+    expect(snapFriendlyMin(900, 1920)).toBe(900);
+    expect(snapFriendlyMin(600, 852)).toBe(426);
   });
 
   it("windows is frameless for self-drawn controls", () => {


### PR DESCRIPTION
## Summary
- On 1440-wide work areas, Win+Right stuck at `minWidth` 900 (~2/3 of the screen) because Aero Snap cannot go below `WM_GETMINMAXINFO`.
- Keep JSON comfort floor at 900. Host caps the OS min to half the current monitor work area (height too). A 1440×900 display snaps to 720; 1920+ keeps 900. Moving onto a larger display restores the floor.
- Do not drop JSON `minWidth` to 640 (large screens would lose the floor; still-narrower halves can be < 640).

Fixes #765

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan
- [x] `pnpm exec vitest run src/lib/window-config.test.ts` (8 passed; comfort stays 900, 1440→720 / 1920→900)
- [x] `cargo check` of the Host lib (`window_min` compiles; `cargo test --lib window_min` binary hits `STATUS_ENTRYPOINT_NOT_FOUND` on this host — pre-existing DLL load, not this change)
- [ ] CI green
- [ ] Windows 1440×900: Win+Right occupies the true right half (~720), not ~900
- [ ] Windows 1920+: window still cannot drag below 900

## Checklist
- [x] `pnpm exec vitest run src/lib/window-config.test.ts`
- [x] Host compiles (`window_min`)
- [x] No UI strings / i18n
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

Note: `pi -p` is not installed on this Windows host (no `pi` on PATH). Per repo policy this is recorded rather than skipped silently.