### PR TITLE
fix(chat): stop bounce-up when images and PDF previews decode

### DIFF
--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -11,6 +11,8 @@
  * - Per-row ResizeObserver so image/video decode updates height cache (callback
  *   refs alone only fire on mount).
  * - Debounced recompute so measure storms cannot oscillate the window.
+ * - Pinned: no per-row scrollTop snap. Image/PDF decode used to snap on
+ *   every commit, then the window layout snapped again (bounce-up).
  *
  * Long-session perf:
  * - rAF-coalesce scroll recomputes (one window update per frame while flinging).
@@ -35,6 +37,7 @@ import {
   resolveChatOverscanPx,
   scrollTopAfterHeightChange,
   shouldCommitRowHeight,
+  shouldWriteScrollOnRowCommit,
   shouldVirtualizeChat,
   type ChatVirtualWindow,
 } from "@/lib/chatVirtualList";
@@ -473,9 +476,10 @@ export function useChatMessageVirtualizer(
       }
 
       recompute();
-      // Sync (not rAF): RO already ran after layout and before paint.
-      // Deferring one frame painted the stale scrollTop — bottom jitter.
-      if (pin && viewport) {
+      // Pinned: do not snap here. Each image/PDF decode used to write
+      // scrollTop, then the debounced window layout wrote it again — bounce.
+      // One snap lives in the window-metrics layout effect after coalesce.
+      if (pin && viewport && shouldWriteScrollOnRowCommit(true)) {
         const top = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
         if (Math.abs(viewport.scrollTop - top) > 0.5) {
           ignoreScrollAdjustRef.current = true;

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -30,6 +30,7 @@ import {
   isMeaningfulScrollUp,
   isNearBottom,
   nextStickPinState,
+  pinnedFollowDelayMs,
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
   shouldReleaseStickOnScrollUp,
@@ -444,6 +445,7 @@ export function useStickToBottom(
 
     let previousHeight: number | undefined;
     let raf = 0;
+    let mediaFollowTimer: ReturnType<typeof setTimeout> | null = null;
 
     const onHeightChange = (height: number) => {
       const difference = height - (previousHeight ?? height);
@@ -506,9 +508,22 @@ export function useStickToBottom(
       // Grow, shrink, or viewport-only resize: follow only while pinned.
       // Do NOT compensate scrollTop while escaped — stream growth is almost
       // always at the bottom; adding the full height delta would yank the
-      // user down. Image cards use fixed-aspect frames so residual media
-      // reflow (the old jump-to-top cause) should be ~0.
-      followIfPinned();
+      // user down. Large jumps (image/PDF decode) wait so a storm of
+      // screenshots is one snap, not one per file.
+      const delay = pinnedFollowDelayMs(difference);
+      if (delay <= 0) {
+        if (mediaFollowTimer != null) {
+          clearTimeout(mediaFollowTimer);
+          mediaFollowTimer = null;
+        }
+        followIfPinned();
+      } else {
+        if (mediaFollowTimer != null) clearTimeout(mediaFollowTimer);
+        mediaFollowTimer = setTimeout(() => {
+          mediaFollowTimer = null;
+          followIfPinned();
+        }, delay);
+      }
 
       previousHeight = height;
       requestAnimationFrame(() => {
@@ -549,6 +564,7 @@ export function useStickToBottom(
 
     return () => {
       if (raf) cancelAnimationFrame(raf);
+      if (mediaFollowTimer != null) clearTimeout(mediaFollowTimer);
       ro.disconnect();
     };
   }, [enabled, conversationKey, applyScrollTop, followIfPinned]);

--- a/src/lib/chatVirtualList.test.ts
+++ b/src/lib/chatVirtualList.test.ts
@@ -15,6 +15,7 @@ import {
   resolveChatOverscanPx,
   scrollTopAfterHeightChange,
   shouldCommitRowHeight,
+  shouldWriteScrollOnRowCommit,
   shouldVirtualizeChat,
   splitVirtSpacerHeights,
 } from "./chatVirtualList";
@@ -304,6 +305,16 @@ describe("estimateChatRowHeight", () => {
     expect(images).toBeGreaterThan(chips);
     // 6 cards → 2 rows × ~160px
     expect(images - chips).toBeGreaterThanOrEqual(200);
+  });
+});
+
+describe("shouldWriteScrollOnRowCommit", () => {
+  it("never writes scrollTop from a row commit while pinned", () => {
+    expect(shouldWriteScrollOnRowCommit(true)).toBe(false);
+  });
+
+  it("still allows escaped history-anchor writes", () => {
+    expect(shouldWriteScrollOnRowCommit(false)).toBe(true);
   });
 });
 

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -488,6 +488,18 @@ export function scrollTopAfterHeightChange(input: {
  * Image-heavy rows used to oscillate by a few px after decode (scrollbar
  * gutter / subpixel) → virtual window rebuild → visible chat "shiver".
  */
+/**
+ * Whether a row-height commit may write scrollTop while stick-pinned.
+ *
+ * Per-row image/PDF decode used to snap to max on every commit, then the
+ * virtual window rebuild snapped again. That is the bounce-up on long
+ * media-heavy turns. Pinned snaps belong on the coalesced window layout,
+ * not on each ResizeObserver.
+ */
+export function shouldWriteScrollOnRowCommit(pinned: boolean): boolean {
+  return !pinned;
+}
+
 export function shouldCommitRowHeight(
   prev: number | undefined,
   next: number,

--- a/src/lib/stickToBottom.test.ts
+++ b/src/lib/stickToBottom.test.ts
@@ -11,11 +11,14 @@ import {
   isMeaningfulScrollUp,
   isNearBottom,
   nextStickPinState,
+  pinnedFollowDelayMs,
   shouldBumpStickOnBusyEdge,
   stabilizeStickUserId,
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
   shouldReleaseStickOnScrollUp,
+  STICK_MEDIA_FOLLOW_DELAY_MS,
+  STICK_MEDIA_HEIGHT_PX,
 } from "./stickToBottom";
 
 describe("distanceFromBottom", () => {
@@ -67,6 +70,25 @@ describe("bottomScrollTop", () => {
 
   it("is 0 when content shorter than viewport", () => {
     expect(bottomScrollTop(200, 400)).toBe(0);
+  });
+});
+
+describe("pinnedFollowDelayMs", () => {
+  it("follows stream-sized growth this frame", () => {
+    expect(pinnedFollowDelayMs(0)).toBe(0);
+    expect(pinnedFollowDelayMs(8)).toBe(0);
+    expect(pinnedFollowDelayMs(23)).toBe(0);
+  });
+
+  it("coalesces image/PDF-sized jumps", () => {
+    expect(STICK_MEDIA_HEIGHT_PX).toBe(24);
+    expect(pinnedFollowDelayMs(24)).toBe(STICK_MEDIA_FOLLOW_DELAY_MS);
+    expect(pinnedFollowDelayMs(400)).toBe(STICK_MEDIA_FOLLOW_DELAY_MS);
+    expect(pinnedFollowDelayMs(-180)).toBe(STICK_MEDIA_FOLLOW_DELAY_MS);
+  });
+
+  it("treats non-finite as immediate", () => {
+    expect(pinnedFollowDelayMs(Number.NaN)).toBe(0);
   });
 });
 

--- a/src/lib/stickToBottom.ts
+++ b/src/lib/stickToBottom.ts
@@ -32,6 +32,15 @@ export const STICK_HARD_BOTTOM_PX = 2;
 export const STICK_HEIGHT_NOISE_PX = 8;
 
 /**
+ * Content growth this large is media / virtual-window rebuild, not a stream
+ * token. Follow immediately and every image decode snaps the transcript up.
+ */
+export const STICK_MEDIA_HEIGHT_PX = 24;
+
+/** Trailing delay so a decode storm becomes one pin snap. */
+export const STICK_MEDIA_FOLLOW_DELAY_MS = 64;
+
+/**
  * Minimum upward scroll (px) to leave stick-lock.
  * Keep this aligned with {@link STICK_ESCAPE_WHEEL_DELTA}: a 10–12px
  * trackpad nudge used to be clamped by the scroll handler and then
@@ -190,6 +199,21 @@ export function isHeightDeltaNoise(
   noisePx: number = STICK_HEIGHT_NOISE_PX,
 ): boolean {
   return Math.abs(difference) < noisePx;
+}
+
+/**
+ * Delay before stick-follow after a content-height change.
+ * Stream tokens (small) follow this frame. Image/PDF decode jumps wait so
+ * a row of screenshots does not bounce the chat once per file.
+ */
+export function pinnedFollowDelayMs(
+  heightDelta: number,
+  mediaPx: number = STICK_MEDIA_HEIGHT_PX,
+  delayMs: number = STICK_MEDIA_FOLLOW_DELAY_MS,
+): number {
+  if (!Number.isFinite(heightDelta)) return 0;
+  if (Math.abs(heightDelta) < mediaPx) return 0;
+  return delayMs;
 }
 
 /**


### PR DESCRIPTION
## Summary
Long chats pinned at the bottom bounce upward while screenshots / PDF page previews decode. Stick-to-bottom and the virtual list both wrote `scrollTop = max` on every row height jump.

This PR:
- Stops per-row pinned snaps in `commitRowHeight` (one snap after the coalesced window layout)
- Trailing-coalesces stick follows for media-sized height jumps (24px+) so a decode storm is one follow, not one per file

Fixes #771.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] vitest: `stickToBottom` + `chatVirtualList` (84 tests)
- [ ] full `tsc -b` (pre-existing `@testing-library/*` errors in workbench-modals tests, not this change)
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — n/a, no copy
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [ ] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
