### PR TITLE
fix(windows): use OS maximize for caption button, not work-area fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See `docs/llm-wiki/release.md`.
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com/](https://grok-app.com/)。
 
 ### Fixed
+- **Windows maximize button is a real maximize (#773)**: The caption square used a Linux work-area `setSize` fill when `isMaximized()` lagged ~40ms. That cancelled the OS maximize, left the glyph as a square, and after restore, dragging the top edge panned the WebView inside the frame. Windows now waits for the OS flag and never fakes geometry; the button switches to the restore glyph; visualViewport pan is pinned.
 - **In-app update waits for Install and restart (#777)**: Settings → About Check for updates only checks and downloads. Sidebar and Install and restart open an in-app confirm (version + restart) before install+relaunch. Cancel does nothing. Unsigned GitHub download is unchanged.
 - **Windows dark-taskbar tray is a white glyph, not a white square (#776)**: Follow-up to #747/#748, not a revert of the invisibility fix. Light taskbars keep the black rounded tile + white glyph. Dark taskbars drop the white fill and show a white Grok mark on transparency. The host still follows `SystemUsesLightTheme` (not the in-app theme) and does not restore black-on-transparent.
 - **Slow trackpad scroll-up can leave stick-to-bottom (#778)**: Pixel-mode wheels send 2–8px ticks, so a single 10px event never unpinned. Release once the viewport is 10px off the bottom, even across ticks, and do not snap the virtual list back after the user has left.
@@ -34,6 +35,7 @@ See `docs/llm-wiki/release.md`.
 - **Windows Alt+Tab can type without a click first (#768)**: Tauri `unstable` (side-browser multi-webview) builds the page as a child `WRY_WEBVIEW`, so Alt-Tab / taskbar only activates the outer HWND. The host now forwards `WM_SETFOCUS` / `WM_ACTIVATE` into that child so composer and shortcuts work immediately.
 
 **中文 · 修复**
+- **Windows 右上角最大化是系统最大化（#773）**：按钮在 `isMaximized()` 还没跟上时会走 Linux 的铺满工作区 `setSize`，把真正的最大化取消掉，图标也不变；还原后再从上沿往下拉，页面会在窗口里往下挪。Windows 现在等系统标志、不再假铺满，按钮换成还原图标，并钉住 visualViewport 偏移。
 - **应用内更新须确认「安装并重启」（#777）**：设置 → 关于「检查更新」只检查和下载。侧栏与「安装并重启」会先弹出应用内确认（版本 + 即将重启），取消不安装。未签名的 GitHub 下载路径不变。
 - **Windows 深色任务栏托盘改为白标透明底，不再是白方块（#776）**：#747/#748 的后续，不是撤回可见性修复。浅色任务栏仍是黑底圆角块 + 白标；深色任务栏去掉白色填充，只用透明底上的白色 Grok 标。仍跟任务栏 `SystemUsesLightTheme`，不跟应用内主题；也不会退回深色栏上看不见的黑标。
 - **触控板慢慢往上滚能离开贴底锁（#778）**：像素模式滚轮每次只有 2–8px，单次 10px 永远松不开。离开底部累计 10px 就放锁，虚拟列表不再把你弹回去。

--- a/src-tauri/src/win_shell.rs
+++ b/src-tauri/src/win_shell.rs
@@ -36,7 +36,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
     SetWindowLongW, SetWindowPos, GWLP_HWNDPARENT, GWLP_WNDPROC, GWL_EXSTYLE, GWL_STYLE, GW_CHILD,
     GW_HWNDNEXT, GW_OWNER, HWND_NOTOPMOST, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE,
     SWP_NOSIZE, SWP_NOZORDER, WA_ACTIVE, WA_CLICKACTIVE, WM_ACTIVATE, WM_NCDESTROY, WM_SETFOCUS,
-    WNDPROC, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_MINIMIZEBOX,
+    WNDPROC, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_MAXIMIZEBOX, WS_MINIMIZEBOX,
 };
 
 /// Product AUMID — must match `identifier` in tauri.conf.json / NSIS shortcuts.
@@ -154,6 +154,11 @@ fn ensure_hwnd_shell_integration(hwnd: HWND, register_taskbar: bool) {
 
         if style & WS_MINIMIZEBOX.0 == 0 {
             style |= WS_MINIMIZEBOX.0;
+            changed = true;
+        }
+        // Frameless HWNDs still need MAXIMIZEBOX so IsZoomed / SW_MAXIMIZE work.
+        if style & WS_MAXIMIZEBOX.0 == 0 {
+            style |= WS_MAXIMIZEBOX.0;
             changed = true;
         }
         // Visible app windows must not be tool windows — TOOLWINDOW alone is excluded

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -101,6 +101,7 @@ import {
   ensureWindowFitsLayout,
   isWindowFitSuppressed
 } from "@/lib/windowFit";
+import { isFakeMaximized } from "@/lib/windowChrome";
 import {
   bumpPaneSplitMotion,
   isPaneSplitMotionActive,
@@ -3029,6 +3030,7 @@ export function AppWorkbench() {
   useEffect(() => {
     if (!api.isDesktopHost() || !api.isTauri()) return;
     let unlistenResize: (() => void) | undefined;
+    let unlistenMoved: (() => void) | undefined;
     let unlistenScale: (() => void) | undefined;
     let cancelled = false;
     void (async () => {
@@ -3037,7 +3039,9 @@ export function AppWorkbench() {
         const w = getCurrentWindow();
         const sync = async () => {
           try {
-            setWindowMaximized(await w.isMaximized());
+            setWindowMaximized(
+              (await w.isMaximized()) || isFakeMaximized(),
+            );
           } catch {
             /* ignore */
           }
@@ -3047,6 +3051,13 @@ export function AppWorkbench() {
           void sync();
         });
         try {
+          unlistenMoved = await w.onMoved(() => {
+            void sync();
+          });
+        } catch {
+          /* older API */
+        }
+        try {
           unlistenScale = await w.onScaleChanged(() => {
             void sync();
           });
@@ -3055,6 +3066,7 @@ export function AppWorkbench() {
         }
         if (cancelled) {
           unlistenResize?.();
+          unlistenMoved?.();
           unlistenScale?.();
         }
       } catch {
@@ -3064,6 +3076,7 @@ export function AppWorkbench() {
     return () => {
       cancelled = true;
       unlistenResize?.();
+      unlistenMoved?.();
       unlistenScale?.();
     };
   }, []);

--- a/src/components/WindowControls.tsx
+++ b/src/components/WindowControls.tsx
@@ -4,10 +4,16 @@
  * traffic lights.
  */
 import { useCallback, useEffect, useState } from "react";
-import { IconClose, IconMaximize, IconMinimize } from "@/components/icons";
+import {
+  IconClose,
+  IconMaximize,
+  IconMinimize,
+  IconRestore,
+} from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import {
   isFakeMaximized,
+  subscribeDesktopViewportPin,
   toggleMaximizeFromTitlebar,
   toggleMaximizeReliable,
 } from "@/lib/windowChrome";
@@ -40,23 +46,36 @@ export function WindowControls({ visible, labels }: Props) {
   useEffect(() => {
     if (!visible) return;
     void refreshMaximized();
-    let unlisten: (() => void) | undefined;
+    const unpin = subscribeDesktopViewportPin();
+    let unlistenResize: (() => void) | undefined;
+    let unlistenMoved: (() => void) | undefined;
     let cancelled = false;
     void (async () => {
       try {
         const { getCurrentWindow } = await import("@tauri-apps/api/window");
         const w = getCurrentWindow();
-        unlisten = await w.onResized(() => {
+        const sync = () => {
           void refreshMaximized();
-        });
-        if (cancelled && unlisten) unlisten();
+        };
+        unlistenResize = await w.onResized(sync);
+        try {
+          unlistenMoved = await w.onMoved(sync);
+        } catch {
+          /* older API */
+        }
+        if (cancelled) {
+          unlistenResize?.();
+          unlistenMoved?.();
+        }
       } catch {
         /* ignore */
       }
     })();
     return () => {
       cancelled = true;
-      unlisten?.();
+      unlistenResize?.();
+      unlistenMoved?.();
+      unpin();
     };
   }, [visible, refreshMaximized]);
 
@@ -101,7 +120,7 @@ export function WindowControls({ visible, labels }: Props) {
             void winChrome("toggleMaximize");
           }}
         >
-          <IconMaximize size={14} />
+          {maximized ? <IconRestore size={14} /> : <IconMaximize size={14} />}
         </button>
       </Tip>
       <Tip label={labels.close}>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -25,6 +25,7 @@ import {
   IconGitBranch as TbGitBranch,
   IconGitCommit as TbGitCommit,
   IconBox as TbBox,
+  IconBoxMultiple as TbBoxMultiple,
   IconBrush as TbBrush,
   IconCalendarTime as TbCalendarTime,
   IconCheck as TbCheck,
@@ -393,6 +394,8 @@ export const IconFileText = wrap(TbFileText);
 export const IconBolt = wrap(TbBolt);
 export const IconMinimize = wrap(TbMinus);
 export const IconMaximize = wrap(TbSquare);
+/** Caption restore (overlapping squares). */
+export const IconRestore = wrap(TbBoxMultiple);
 export const IconPlan = wrap(TbList);
 export const IconPin = wrap(TbPinned);
 export const IconPinOff = wrap(TbPinnedOff);

--- a/src/lib/window-config.test.ts
+++ b/src/lib/window-config.test.ts
@@ -97,6 +97,7 @@ describe("window chrome", () => {
     const body = readSource(winShell);
     expect(body).toMatch(/SetCurrentProcessExplicitAppUserModelID/);
     expect(body).toMatch(/WS_EX_APPWINDOW/);
+    expect(body).toMatch(/WS_MAXIMIZEBOX/);
     expect(body).toMatch(/ensure_main_window_shell_integration/);
     expect(body).toMatch(/set_main_window_skip_taskbar/);
     const conf = JSON.parse(readFileSync(CONF_PATH, "utf8")) as { identifier?: string };

--- a/src/lib/windowChrome.test.ts
+++ b/src/lib/windowChrome.test.ts
@@ -1,8 +1,16 @@
+/** @vitest-environment jsdom */
 import { describe, expect, it } from "vitest";
 import {
+  applyViewportPan,
   maximizeLooksNoop,
+  osMaximizeWaitMs,
   shouldAcceptTitlebarMaximize,
+  shouldFakeMaximizeFallback,
   TITLEBAR_MAXIMIZE_DEBOUNCE_MS,
+  viewportPanFromOffset,
+  VIEWPORT_PAN_CLASS,
+  VIEWPORT_PAN_X_VAR,
+  VIEWPORT_PAN_Y_VAR,
 } from "./windowChrome";
 
 describe("shouldAcceptTitlebarMaximize", () => {
@@ -21,5 +29,48 @@ describe("maximizeLooksNoop", () => {
     expect(maximizeLooksNoop(true, true)).toBe(true);
     expect(maximizeLooksNoop(false, true)).toBe(false);
     expect(maximizeLooksNoop(true, false)).toBe(false);
+  });
+});
+
+describe("shouldFakeMaximizeFallback", () => {
+  it("is Linux-only — Windows/mac must use OS maximize, not setSize fill", () => {
+    expect(shouldFakeMaximizeFallback("linux")).toBe(true);
+    expect(shouldFakeMaximizeFallback("win")).toBe(false);
+    expect(shouldFakeMaximizeFallback("mac")).toBe(false);
+    expect(shouldFakeMaximizeFallback("other")).toBe(false);
+  });
+});
+
+describe("osMaximizeWaitMs", () => {
+  it("waits longer when there is no work-area fill fallback", () => {
+    expect(osMaximizeWaitMs(true)).toBeLessThan(osMaximizeWaitMs(false));
+    expect(osMaximizeWaitMs(true)).toBe(40);
+    expect(osMaximizeWaitMs(false)).toBe(280);
+  });
+});
+
+describe("viewportPanFromOffset", () => {
+  it("returns null when the visual viewport is not panned", () => {
+    expect(viewportPanFromOffset(0, 0)).toBeNull();
+    expect(viewportPanFromOffset(0.2, -0.2)).toBeNull();
+  });
+
+  it("negates top/left offset so chrome stays pinned in the frame", () => {
+    expect(viewportPanFromOffset(0, 48)).toEqual({ x: 0, y: -48 });
+    expect(viewportPanFromOffset(12.6, 20.4)).toEqual({ x: -13, y: -20 });
+  });
+});
+
+describe("applyViewportPan", () => {
+  it("sets CSS vars while panned and clears them at identity", () => {
+    const root = document.createElement("html");
+    applyViewportPan(root, { x: 0, y: -48 });
+    expect(root.classList.contains(VIEWPORT_PAN_CLASS)).toBe(true);
+    expect(root.style.getPropertyValue(VIEWPORT_PAN_X_VAR)).toBe("0px");
+    expect(root.style.getPropertyValue(VIEWPORT_PAN_Y_VAR)).toBe("-48px");
+    applyViewportPan(root, null);
+    expect(root.classList.contains(VIEWPORT_PAN_CLASS)).toBe(false);
+    expect(root.style.getPropertyValue(VIEWPORT_PAN_X_VAR)).toBe("");
+    expect(root.style.getPropertyValue(VIEWPORT_PAN_Y_VAR)).toBe("");
   });
 });

--- a/src/lib/windowChrome.ts
+++ b/src/lib/windowChrome.ts
@@ -3,9 +3,103 @@
  *
  * GTK/Wayland maximize is often a no-op; fall back to filling the monitor
  * work area and remember the previous bounds so Restore works.
+ * Windows/macOS must not take that path: a follow-up setSize cancels a real
+ * maximize that was still settling.
  */
 
+import type { AppPlatform } from "@/lib/appPlatform";
+import { detectAppPlatform } from "@/lib/appPlatform";
+
 export const TITLEBAR_MAXIMIZE_DEBOUNCE_MS = 400;
+
+/** Poll interval while waiting for OS `isMaximized` to catch up. */
+export const OS_MAXIMIZE_POLL_MS = 16;
+
+/** Linux: short wait then work-area fill. */
+export const LINUX_MAXIMIZE_WAIT_MS = 40;
+
+/** Windows/mac: give ShowWindow(SW_MAXIMIZE) time; never fake-fill. */
+export const OS_MAXIMIZE_WAIT_MS = 280;
+
+export const VIEWPORT_PAN_CLASS = "has-viewport-pan";
+export const VIEWPORT_PAN_X_VAR = "--viewport-pan-x";
+export const VIEWPORT_PAN_Y_VAR = "--viewport-pan-y";
+
+/** Work-area fill is only for compositors that ignore gtk_window_maximize. */
+export function shouldFakeMaximizeFallback(platform: AppPlatform): boolean {
+  return platform === "linux";
+}
+
+export function osMaximizeWaitMs(allowFakeFallback: boolean): number {
+  return allowFakeFallback ? LINUX_MAXIMIZE_WAIT_MS : OS_MAXIMIZE_WAIT_MS;
+}
+
+/**
+ * CSS translate that cancels visualViewport pan (WebView2 top/left resize).
+ * `null` means identity — drop the pin class.
+ */
+export function viewportPanFromOffset(
+  offsetLeft: number,
+  offsetTop: number,
+): { x: number; y: number } | null {
+  const x = Number.isFinite(offsetLeft) ? Math.round(-offsetLeft) : 0;
+  const y = Number.isFinite(offsetTop) ? Math.round(-offsetTop) : 0;
+  if (x === 0 && y === 0) return null;
+  return { x: x === 0 ? 0 : x, y: y === 0 ? 0 : y };
+}
+
+export function applyViewportPan(
+  root: HTMLElement,
+  pan: { x: number; y: number } | null,
+): void {
+  if (!pan) {
+    root.classList.remove(VIEWPORT_PAN_CLASS);
+    root.style.removeProperty(VIEWPORT_PAN_X_VAR);
+    root.style.removeProperty(VIEWPORT_PAN_Y_VAR);
+    return;
+  }
+  root.classList.add(VIEWPORT_PAN_CLASS);
+  root.style.setProperty(VIEWPORT_PAN_X_VAR, `${pan.x}px`);
+  root.style.setProperty(VIEWPORT_PAN_Y_VAR, `${pan.y}px`);
+}
+
+/** Pin the page when WebView2 shifts visualViewport during edge resize. */
+export function subscribeDesktopViewportPin(
+  opts?: {
+    root?: HTMLElement;
+    getOffset?: () => { offsetLeft: number; offsetTop: number } | null;
+  },
+): () => void {
+  const root = opts?.root ?? document.documentElement;
+  const apply = () => {
+    let offset: { offsetLeft: number; offsetTop: number } | null;
+    if (opts?.getOffset) {
+      offset = opts.getOffset();
+    } else {
+      const vv = window.visualViewport;
+      offset = vv
+        ? { offsetLeft: vv.offsetLeft, offsetTop: vv.offsetTop }
+        : null;
+    }
+    applyViewportPan(
+      root,
+      offset
+        ? viewportPanFromOffset(offset.offsetLeft, offset.offsetTop)
+        : null,
+    );
+  };
+  apply();
+  const vv = typeof window !== "undefined" ? window.visualViewport : null;
+  vv?.addEventListener("resize", apply);
+  vv?.addEventListener("scroll", apply);
+  window.addEventListener("resize", apply);
+  return () => {
+    vv?.removeEventListener("resize", apply);
+    vv?.removeEventListener("scroll", apply);
+    window.removeEventListener("resize", apply);
+    applyViewportPan(root, null);
+  };
+}
 
 /** Double-click / mousedown(detail=2) must not toggle twice. */
 export function shouldAcceptTitlebarMaximize(
@@ -91,14 +185,35 @@ async function fillMonitorWorkArea(
   }
 }
 
+type HostWindow = Awaited<
+  ReturnType<typeof import("@tauri-apps/api/window").getCurrentWindow>
+>;
+
+async function waitForOsMaximized(
+  w: HostWindow,
+  expect: boolean,
+  timeoutMs: number,
+): Promise<boolean> {
+  const start = Date.now();
+  for (;;) {
+    const v = await w.isMaximized().catch(() => false);
+    if (v === expect) return v;
+    if (Date.now() - start >= timeoutMs) return v;
+    await new Promise((r) => setTimeout(r, OS_MAXIMIZE_POLL_MS));
+  }
+}
+
 /**
  * Maximize / restore. Prefers the OS API; on Linux Wayland no-ops, fills
  * the work area and treats that as maximized until the next toggle.
+ * Windows never fills the work area — that undoes a real maximize.
  * Returns whether the window should display as maximized.
  */
 export async function toggleMaximizeReliable(): Promise<boolean> {
   const { getCurrentWindow } = await import("@tauri-apps/api/window");
   const w = getCurrentWindow();
+  const allowFake = shouldFakeMaximizeFallback(detectAppPlatform());
+  const waitMs = osMaximizeWaitMs(allowFake);
   const wasOs = await w.isMaximized().catch(() => false);
   const was = wasOs || fakeMaximized;
 
@@ -110,8 +225,9 @@ export async function toggleMaximizeReliable(): Promise<boolean> {
       } catch {
         /* ignore */
       }
+      await waitForOsMaximized(w, false, waitMs);
     }
-    if (restoreBounds) {
+    if (allowFake && restoreBounds) {
       const prev = restoreBounds;
       restoreBounds = null;
       try {
@@ -119,22 +235,27 @@ export async function toggleMaximizeReliable(): Promise<boolean> {
       } catch {
         /* ignore */
       }
+    } else {
+      restoreBounds = null;
     }
     return w.isMaximized().catch(() => false);
   }
 
-  const before = await readLogicalBounds(w);
+  const before = allowFake ? await readLogicalBounds(w) : null;
   try {
     await w.maximize();
   } catch {
     /* some compositors reject maximize() */
   }
-  await new Promise((r) => setTimeout(r, 40));
-  const nowOs = await w.isMaximized().catch(() => false);
+  const nowOs = await waitForOsMaximized(w, true, waitMs);
   if (nowOs) {
     restoreBounds = null;
     fakeMaximized = false;
     return true;
+  }
+
+  if (!allowFake) {
+    return w.isMaximized().catch(() => false);
   }
 
   if (before) restoreBounds = before;

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -22,6 +22,15 @@ body,
   -webkit-font-smoothing: antialiased;
 }
 
+/* WebView2 shifts visualViewport when a frameless window is resized from the
+   top; pin the page so chrome does not walk down inside the frame. */
+html.has-viewport-pan body {
+  transform: translate(
+    var(--viewport-pan-x, 0px),
+    var(--viewport-pan-y, 0px)
+  );
+}
+
 button,
 input,
 textarea,


### PR DESCRIPTION
## Summary
- Windows caption **maximize** does not OS-maximize. The glyph stays a square. After restore, dragging the top edge pans the **page inside the frame**.
- `00dd8ef5` (#628) replaced `toggleMaximize()` with `toggleMaximizeReliable()`. The Linux work-area `setSize` fill runs when `isMaximized()` still lags ~40ms. That path was not gated to Linux, so Windows `setSize` cancels a settling OS maximize. Titlebar double-click still hits native caption maximize, so it looks better.
- Windows/mac now wait for the OS flag and never fake-fill. Caption switches to the restore glyph. WebView2 `visualViewport` pan is pinned. Linux work-area fill is unchanged. Frameless HWND also keeps `WS_MAXIMIZEBOX`.

Fixes #773

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan
- [x] `pnpm exec vitest run src/lib/windowChrome.test.ts src/lib/window-config.test.ts` (15 passed)
- [x] `pnpm exec eslint` on touched TS (clean)
- [ ] `cargo test --lib win_shell::tests` — harness compiled; run aborted with `STATUS_ENTRYPOINT_NOT_FOUND` on this host (same environment issue as nearby Windows Host tests)
- [ ] CI green
- [ ] Windows: caption maximize is real OS maximize + restore glyph; restore; drag the top edge — UI stays pinned in the frame
- [ ] Titlebar double-click still toggles maximize
- [ ] Linux: compositor no-op still fills the work area

## Checklist
- [x] I ran `pnpm typecheck` (no errors in touched files) and targeted vitest
- [ ] `cargo test` in `src-tauri` (see test plan)
- [x] No new i18n keys (reuses `window.maximize` / `window.restore`)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

Note: `pi -p` is not installed on this Windows host (no `pi` on PATH). Per repo policy this is recorded rather than skipped silently.