### PR TITLE
fix(chat): let slow scroll-up leave the bottom lock

### DIFF
--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -11,6 +11,8 @@
  * - Per-row ResizeObserver so image/video decode updates height cache (callback
  *   refs alone only fire on mount).
  * - Debounced recompute so measure storms cannot oscillate the window.
+ * - Pinned: no per-row scrollTop snap. Image/PDF decode used to snap on
+ *   every commit, then the window layout snapped again (bounce-up).
  *
  * Long-session perf:
  * - rAF-coalesce scroll recomputes (one window update per frame while flinging).
@@ -35,6 +37,7 @@ import {
   resolveChatOverscanPx,
   scrollTopAfterHeightChange,
   shouldCommitRowHeight,
+  shouldWriteScrollOnRowCommit,
   shouldVirtualizeChat,
   type ChatVirtualWindow,
 } from "@/lib/chatVirtualList";
@@ -473,9 +476,10 @@ export function useChatMessageVirtualizer(
       }
 
       recompute();
-      // Sync (not rAF): RO already ran after layout and before paint.
-      // Deferring one frame painted the stale scrollTop — bottom jitter.
-      if (pin && viewport) {
+      // Pinned: do not snap here. Each image/PDF decode used to write
+      // scrollTop, then the debounced window layout wrote it again — bounce.
+      // One snap lives in the window-metrics layout effect after coalesce.
+      if (pin && viewport && shouldWriteScrollOnRowCommit(true)) {
         const top = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
         if (Math.abs(viewport.scrollTop - top) > 0.5) {
           ignoreScrollAdjustRef.current = true;

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -52,6 +52,7 @@ import {
   isPaneSplitMotionActive,
   runAfterPaneSplitMotion,
 } from "@/lib/paneSplitMotion";
+import { shouldSnapPinnedLayoutToBottom } from "@/lib/stickToBottom";
 
 export type UseChatMessageVirtualizerArgs = {
   itemCount: number;
@@ -385,10 +386,20 @@ export function useChatMessageVirtualizer(
     const v = viewportRef.current;
     if (!v) return;
     const top = Math.max(0, v.scrollHeight - v.clientHeight);
-    if (Math.abs(v.scrollTop - top) > 0.5) {
-      ignoreScrollAdjustRef.current = true;
-      v.scrollTop = top;
+    if (Math.abs(v.scrollTop - top) <= 0.5) return;
+    // User already left the bottom (trackpad ticks). Snapping here is the
+    // "wheel turns, screen does not move" freeze until a hard flick.
+    if (
+      !shouldSnapPinnedLayoutToBottom({
+        scrollTop: v.scrollTop,
+        scrollHeight: v.scrollHeight,
+        clientHeight: v.clientHeight,
+      })
+    ) {
+      return;
     }
+    ignoreScrollAdjustRef.current = true;
+    v.scrollTop = top;
   }, [
     virtualized,
     win.start,

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -30,6 +30,7 @@ import {
   isMeaningfulScrollUp,
   isNearBottom,
   nextStickPinState,
+  pinnedFollowDelayMs,
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
   shouldReleaseStickOnScrollUp,
@@ -444,6 +445,7 @@ export function useStickToBottom(
 
     let previousHeight: number | undefined;
     let raf = 0;
+    let mediaFollowTimer: ReturnType<typeof setTimeout> | null = null;
 
     const onHeightChange = (height: number) => {
       const difference = height - (previousHeight ?? height);
@@ -506,9 +508,22 @@ export function useStickToBottom(
       // Grow, shrink, or viewport-only resize: follow only while pinned.
       // Do NOT compensate scrollTop while escaped — stream growth is almost
       // always at the bottom; adding the full height delta would yank the
-      // user down. Image cards use fixed-aspect frames so residual media
-      // reflow (the old jump-to-top cause) should be ~0.
-      followIfPinned();
+      // user down. Large jumps (image/PDF decode) wait so a storm of
+      // screenshots is one snap, not one per file.
+      const delay = pinnedFollowDelayMs(difference);
+      if (delay <= 0) {
+        if (mediaFollowTimer != null) {
+          clearTimeout(mediaFollowTimer);
+          mediaFollowTimer = null;
+        }
+        followIfPinned();
+      } else {
+        if (mediaFollowTimer != null) clearTimeout(mediaFollowTimer);
+        mediaFollowTimer = setTimeout(() => {
+          mediaFollowTimer = null;
+          followIfPinned();
+        }, delay);
+      }
 
       previousHeight = height;
       requestAnimationFrame(() => {
@@ -549,6 +564,7 @@ export function useStickToBottom(
 
     return () => {
       if (raf) cancelAnimationFrame(raf);
+      if (mediaFollowTimer != null) clearTimeout(mediaFollowTimer);
       ro.disconnect();
     };
   }, [enabled, conversationKey, applyScrollTop, followIfPinned]);

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -33,6 +33,7 @@ import {
   pinnedFollowDelayMs,
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
+  shouldReleaseStickOnDistanceFromBottom,
   shouldReleaseStickOnScrollUp,
 } from "@/lib/stickToBottom";
 import { runAfterPaneSplitMotion } from "@/lib/paneSplitMotion";
@@ -208,9 +209,25 @@ export function useStickToBottom(
       // While locked at bottom: only snap rubber-band past max. Do not
       // write an upward leave back to the bottom — that fights the
       // trackpad and is the #703 jitter.
+      // Pixel-mode wheels never hit meaningfulUp (each tick is 2–8px).
+      // If they have already left the bottom by ≥10px, release anyway.
       if (isPinnedRef.current && !escapedRef.current && !meaningfulUp) {
         if (shouldClampPinnedOverscroll(scrollTop, maxTop)) {
           applyScrollTop(maxTop);
+          return;
+        }
+        if (
+          shouldReleaseStickOnDistanceFromBottom({
+            pinned: true,
+            scrollTop,
+            scrollHeight: el.scrollHeight,
+            clientHeight: el.clientHeight,
+          })
+        ) {
+          userIntentDownRef.current = false;
+          isPinnedRef.current = false;
+          escapedRef.current = true;
+          syncShowBack();
         }
         return;
       }

--- a/src/lib/chatVirtualList.test.ts
+++ b/src/lib/chatVirtualList.test.ts
@@ -15,6 +15,7 @@ import {
   resolveChatOverscanPx,
   scrollTopAfterHeightChange,
   shouldCommitRowHeight,
+  shouldWriteScrollOnRowCommit,
   shouldVirtualizeChat,
   splitVirtSpacerHeights,
 } from "./chatVirtualList";
@@ -304,6 +305,16 @@ describe("estimateChatRowHeight", () => {
     expect(images).toBeGreaterThan(chips);
     // 6 cards → 2 rows × ~160px
     expect(images - chips).toBeGreaterThanOrEqual(200);
+  });
+});
+
+describe("shouldWriteScrollOnRowCommit", () => {
+  it("never writes scrollTop from a row commit while pinned", () => {
+    expect(shouldWriteScrollOnRowCommit(true)).toBe(false);
+  });
+
+  it("still allows escaped history-anchor writes", () => {
+    expect(shouldWriteScrollOnRowCommit(false)).toBe(true);
   });
 });
 

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -488,6 +488,18 @@ export function scrollTopAfterHeightChange(input: {
  * Image-heavy rows used to oscillate by a few px after decode (scrollbar
  * gutter / subpixel) → virtual window rebuild → visible chat "shiver".
  */
+/**
+ * Whether a row-height commit may write scrollTop while stick-pinned.
+ *
+ * Per-row image/PDF decode used to snap to max on every commit, then the
+ * virtual window rebuild snapped again. That is the bounce-up on long
+ * media-heavy turns. Pinned snaps belong on the coalesced window layout,
+ * not on each ResizeObserver.
+ */
+export function shouldWriteScrollOnRowCommit(pinned: boolean): boolean {
+  return !pinned;
+}
+
 export function shouldCommitRowHeight(
   prev: number | undefined,
   next: number,

--- a/src/lib/stickToBottom.test.ts
+++ b/src/lib/stickToBottom.test.ts
@@ -16,7 +16,9 @@ import {
   stabilizeStickUserId,
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
+  shouldReleaseStickOnDistanceFromBottom,
   shouldReleaseStickOnScrollUp,
+  shouldSnapPinnedLayoutToBottom,
   STICK_MEDIA_FOLLOW_DELAY_MS,
   STICK_MEDIA_HEIGHT_PX,
 } from "./stickToBottom";
@@ -133,6 +135,102 @@ describe("shouldClampPinnedStreamDrift", () => {
 
   it("does not clamp when unpinned without escape flag either", () => {
     expect(shouldClampPinnedStreamDrift(false, false, 200, sh, ch)).toBe(false);
+  });
+});
+
+describe("shouldReleaseStickOnDistanceFromBottom", () => {
+  const sh = 1000;
+  const ch = 400;
+  // maxTop = 600
+
+  it("stays pinned for tiny ticks under 10px from the bottom", () => {
+    expect(
+      shouldReleaseStickOnDistanceFromBottom({
+        pinned: true,
+        scrollTop: 595,
+        scrollHeight: sh,
+        clientHeight: ch,
+      }),
+    ).toBe(false); // 5px
+    expect(
+      shouldReleaseStickOnDistanceFromBottom({
+        pinned: true,
+        scrollTop: 591,
+        scrollHeight: sh,
+        clientHeight: ch,
+      }),
+    ).toBe(false); // 9px
+  });
+
+  it("releases after accumulated 10px even if no single tick was 10px", () => {
+    // Three 4px trackpad ticks: 600 → 596 → 592 → 588. Last event is 4px,
+    // so isMeaningfulScrollUp is false; distance from bottom is 12px.
+    expect(isMeaningfulScrollUp(588, 592)).toBe(false);
+    expect(
+      shouldReleaseStickOnDistanceFromBottom({
+        pinned: true,
+        scrollTop: 588,
+        scrollHeight: sh,
+        clientHeight: ch,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not release when unpinned or already escaped", () => {
+    const away = {
+      scrollTop: 500,
+      scrollHeight: sh,
+      clientHeight: ch,
+    };
+    expect(
+      shouldReleaseStickOnDistanceFromBottom({ pinned: false, ...away }),
+    ).toBe(false);
+    expect(
+      shouldReleaseStickOnDistanceFromBottom({
+        pinned: true,
+        escaped: true,
+        ...away,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldSnapPinnedLayoutToBottom", () => {
+  const sh = 1000;
+  const ch = 400;
+
+  it("snaps only while still near the absolute bottom", () => {
+    expect(
+      shouldSnapPinnedLayoutToBottom({
+        scrollTop: 600,
+        scrollHeight: sh,
+        clientHeight: ch,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSnapPinnedLayoutToBottom({
+        scrollTop: 592,
+        scrollHeight: sh,
+        clientHeight: ch,
+      }),
+    ).toBe(true); // 8px, still under leave threshold
+  });
+
+  it("does not snap once the user has left by 10px", () => {
+    expect(
+      shouldSnapPinnedLayoutToBottom({
+        scrollTop: 590,
+        scrollHeight: sh,
+        clientHeight: ch,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSnapPinnedLayoutToBottom({
+        scrollTop: 400,
+        scrollHeight: sh,
+        clientHeight: ch,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/lib/stickToBottom.test.ts
+++ b/src/lib/stickToBottom.test.ts
@@ -11,11 +11,14 @@ import {
   isMeaningfulScrollUp,
   isNearBottom,
   nextStickPinState,
+  pinnedFollowDelayMs,
   shouldBumpStickOnBusyEdge,
   stabilizeStickUserId,
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
   shouldReleaseStickOnScrollUp,
+  STICK_MEDIA_FOLLOW_DELAY_MS,
+  STICK_MEDIA_HEIGHT_PX,
 } from "./stickToBottom";
 
 describe("distanceFromBottom", () => {
@@ -67,6 +70,25 @@ describe("bottomScrollTop", () => {
 
   it("is 0 when content shorter than viewport", () => {
     expect(bottomScrollTop(200, 400)).toBe(0);
+  });
+});
+
+describe("pinnedFollowDelayMs", () => {
+  it("follows stream-sized growth this frame", () => {
+    expect(pinnedFollowDelayMs(0)).toBe(0);
+    expect(pinnedFollowDelayMs(8)).toBe(0);
+    expect(pinnedFollowDelayMs(23)).toBe(0);
+  });
+
+  it("coalesces image/PDF-sized jumps", () => {
+    expect(STICK_MEDIA_HEIGHT_PX).toBe(24);
+    expect(pinnedFollowDelayMs(24)).toBe(STICK_MEDIA_FOLLOW_DELAY_MS);
+    expect(pinnedFollowDelayMs(400)).toBe(STICK_MEDIA_FOLLOW_DELAY_MS);
+    expect(pinnedFollowDelayMs(-180)).toBe(STICK_MEDIA_FOLLOW_DELAY_MS);
+  });
+
+  it("treats non-finite as immediate", () => {
+    expect(pinnedFollowDelayMs(Number.NaN)).toBe(0);
   });
 });
 

--- a/src/lib/stickToBottom.ts
+++ b/src/lib/stickToBottom.ts
@@ -111,6 +111,55 @@ export function stabilizeStickUserId(input: {
 }
 
 /**
+ * Escape pin when the viewport has moved far enough off the absolute
+ * bottom, even if no single wheel/scroll event was large.
+ *
+ * Pixel-mode trackpads send many 2–8px ticks. Escape used to require ≥10px
+ * in *one* event (`isMeaningfulScrollUp`), so those ticks never released
+ * the pin. The list kept using the "stuck at bottom" window and the screen
+ * did not walk into history until a harder flick.
+ */
+export function shouldReleaseStickOnDistanceFromBottom(input: {
+  pinned: boolean;
+  escaped?: boolean;
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  minDeltaPx?: number;
+}): boolean {
+  if (!input.pinned || input.escaped) return false;
+  const min = input.minDeltaPx ?? STICK_ESCAPE_MIN_DELTA_PX;
+  return (
+    distanceFromBottom(
+      input.scrollTop,
+      input.scrollHeight,
+      input.clientHeight,
+    ) >= min
+  );
+}
+
+/**
+ * Virtual-list layout may snap to max while stick is still pinned. Do that
+ * only if the user is still on the bottom. If they already scrolled away,
+ * snapping is the "wheel turns, screen does not move" freeze.
+ */
+export function shouldSnapPinnedLayoutToBottom(input: {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  minLeavePx?: number;
+}): boolean {
+  const min = input.minLeavePx ?? STICK_ESCAPE_MIN_DELTA_PX;
+  return (
+    distanceFromBottom(
+      input.scrollTop,
+      input.scrollHeight,
+      input.clientHeight,
+    ) < min
+  );
+}
+
+/**
  * Whether an upward scroll should release stick-to-bottom.
  *
  * Escape only when the viewport actually left the bottom **and** ended

--- a/src/lib/stickToBottom.ts
+++ b/src/lib/stickToBottom.ts
@@ -32,6 +32,15 @@ export const STICK_HARD_BOTTOM_PX = 2;
 export const STICK_HEIGHT_NOISE_PX = 8;
 
 /**
+ * Content growth this large is media / virtual-window rebuild, not a stream
+ * token. Follow immediately and every image decode snaps the transcript up.
+ */
+export const STICK_MEDIA_HEIGHT_PX = 24;
+
+/** Trailing delay so a decode storm becomes one pin snap. */
+export const STICK_MEDIA_FOLLOW_DELAY_MS = 64;
+
+/**
  * Minimum upward scroll (px) to leave stick-lock.
  * Keep this aligned with {@link STICK_ESCAPE_WHEEL_DELTA}: a 10–12px
  * trackpad nudge used to be clamped by the scroll handler and then
@@ -190,6 +199,21 @@ export function isHeightDeltaNoise(
   noisePx: number = STICK_HEIGHT_NOISE_PX,
 ): boolean {
   return Math.abs(difference) < noisePx;
+}
+
+/**
+ * Delay before stick-follow after a content-height change.
+ * Stream tokens (small) follow this frame. Image/PDF decode jumps wait so
+ * a row of screenshots does not bounce the chat once per file.
+ */
+export function pinnedFollowDelayMs(
+  heightDelta: number,
+  mediaPx: number = STICK_MEDIA_HEIGHT_PX,
+  delayMs: number = STICK_MEDIA_FOLLOW_DELAY_MS,
+): number {
+  if (!Number.isFinite(heightDelta)) return 0;
+  if (Math.abs(heightDelta) < mediaPx) return 0;
+  return delayMs;
 }
 
 /**


### PR DESCRIPTION
## Summary

In a long chat, scrolling up slowly often did nothing until you flicked harder. The wheel was turning. The messages stayed put.

Stick-to-bottom only let go if **one** scroll event moved 10 pixels. A laptop trackpad sends many 2–8px ticks, so the lock never opened. While it stayed closed, the list was still built as if you were at the latest message, and a layout pass could jump you back to the bottom. That is why the screen did not move.

This PR:

1. Lets go of the lock once you are 10 pixels off the bottom, even if that 10 pixels came from several small ticks.
2. Stops the virtual-list layout from snapping back to the bottom after you have already left.

Fixes #778.

This branch also includes the image/PDF bounce-up fix from #771 / #772.

## How we tested it

- 5 new cases in `stickToBottom.test.ts`: tiny ticks stay locked; three 4px ticks add up to 12px and release; unpinned/escaped stay put; layout snap only while still near the bottom.
- Full files: `stickToBottom.test.ts` + `chatVirtualList.test.ts` = **89 tests, all passing**.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] vitest: 89 tests in stickToBottom + chatVirtualList
- [ ] full `tsc -b` (pre-existing `@testing-library/*` errors elsewhere, not this change)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — n/a, no copy
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [ ] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
