### PR TITLE
fix(windows): defer caption maximize and restore titlebar move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ See `docs/llm-wiki/release.md`.
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com/](https://grok-app.com/)。
 
 ### Fixed
-- **Windows maximize button is a real maximize (#773)**: The caption square used a Linux work-area `setSize` fill when `isMaximized()` lagged ~40ms. That cancelled the OS maximize, left the glyph as a square, and after restore, dragging the top edge panned the WebView inside the frame. Windows now waits for the OS flag and never fakes geometry; the button switches to the restore glyph; visualViewport pan is pinned.
+- **Windows caption maximize stays maximized; titlebar drag moves the window (#783)**: Follow-up to #773/#774. The button defers `maximize()` until after mouse-up so Aero does not drag-to-restore (flash). The `body` visualViewport transform pin is gone — it broke `-webkit-app-region: drag`, so pulling the titlebar up north-resized (bottom never lifted). An 8px top no-drag strip keeps native HTTOP.
+- **Windows maximize button is a real maximize (#773)**: The caption square used a Linux work-area `setSize` fill when `isMaximized()` lagged ~40ms. That cancelled the OS maximize, left the glyph as a square, and after restore, dragging the top edge panned the WebView inside the frame. Windows now waits for the OS flag and never fakes geometry; the button switches to the restore glyph.
 - **In-app update waits for Install and restart (#777)**: Settings → About Check for updates only checks and downloads. Sidebar and Install and restart open an in-app confirm (version + restart) before install+relaunch. Cancel does nothing. Unsigned GitHub download is unchanged.
 - **Windows dark-taskbar tray is a white glyph, not a white square (#776)**: Follow-up to #747/#748, not a revert of the invisibility fix. Light taskbars keep the black rounded tile + white glyph. Dark taskbars drop the white fill and show a white Grok mark on transparency. The host still follows `SystemUsesLightTheme` (not the in-app theme) and does not restore black-on-transparent.
 - **Slow trackpad scroll-up can leave stick-to-bottom (#778)**: Pixel-mode wheels send 2–8px ticks, so a single 10px event never unpinned. Release once the viewport is 10px off the bottom, even across ticks, and do not snap the virtual list back after the user has left.
@@ -35,7 +36,8 @@ See `docs/llm-wiki/release.md`.
 - **Windows Alt+Tab can type without a click first (#768)**: Tauri `unstable` (side-browser multi-webview) builds the page as a child `WRY_WEBVIEW`, so Alt-Tab / taskbar only activates the outer HWND. The host now forwards `WM_SETFOCUS` / `WM_ACTIVATE` into that child so composer and shortcuts work immediately.
 
 **中文 · 修复**
-- **Windows 右上角最大化是系统最大化（#773）**：按钮在 `isMaximized()` 还没跟上时会走 Linux 的铺满工作区 `setSize`，把真正的最大化取消掉，图标也不变；还原后再从上沿往下拉，页面会在窗口里往下挪。Windows 现在等系统标志、不再假铺满，按钮换成还原图标，并钉住 visualViewport 偏移。
+- **Windows 点最大化不再闪回，标题栏往上拖是移动窗口（#783）**：#773/#774 的后续。最大化推迟到鼠标松开之后，避免 Aero 当成拖拽立刻还原。去掉会破坏标题栏拖动的 `body` transform；顶边留 8px 非拖动带，标题栏中部往上拖会把整窗抬起来，不再把下沿无限拉高。
+- **Windows 右上角最大化是系统最大化（#773）**：按钮在 `isMaximized()` 还没跟上时会走 Linux 的铺满工作区 `setSize`，把真正的最大化取消掉，图标也不变；还原后再从上沿往下拉，页面会在窗口里往下挪。Windows 现在等系统标志、不再假铺满，按钮换成还原图标。
 - **应用内更新须确认「安装并重启」（#777）**：设置 → 关于「检查更新」只检查和下载。侧栏与「安装并重启」会先弹出应用内确认（版本 + 即将重启），取消不安装。未签名的 GitHub 下载路径不变。
 - **Windows 深色任务栏托盘改为白标透明底，不再是白方块（#776）**：#747/#748 的后续，不是撤回可见性修复。浅色任务栏仍是黑底圆角块 + 白标；深色任务栏去掉白色填充，只用透明底上的白色 Grok 标。仍跟任务栏 `SystemUsesLightTheme`，不跟应用内主题；也不会退回深色栏上看不见的黑标。
 - **触控板慢慢往上滚能离开贴底锁（#778）**：像素模式滚轮每次只有 2–8px，单次 10px 永远松不开。离开底部累计 10px 就放锁，虚拟列表不再把你弹回去。

--- a/src/components/WindowControls.tsx
+++ b/src/components/WindowControls.tsx
@@ -12,8 +12,9 @@ import {
 } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import {
+  CAPTION_BUTTON_TOGGLE_DEFER_MS,
   isFakeMaximized,
-  subscribeDesktopViewportPin,
+  scheduleCaptionButtonToggle,
   toggleMaximizeFromTitlebar,
   toggleMaximizeReliable,
 } from "@/lib/windowChrome";
@@ -46,7 +47,6 @@ export function WindowControls({ visible, labels }: Props) {
   useEffect(() => {
     if (!visible) return;
     void refreshMaximized();
-    const unpin = subscribeDesktopViewportPin();
     let unlistenResize: (() => void) | undefined;
     let unlistenMoved: (() => void) | undefined;
     let cancelled = false;
@@ -75,7 +75,6 @@ export function WindowControls({ visible, labels }: Props) {
       cancelled = true;
       unlistenResize?.();
       unlistenMoved?.();
-      unpin();
     };
   }, [visible, refreshMaximized]);
 
@@ -95,13 +94,24 @@ export function WindowControls({ visible, labels }: Props) {
 
   if (!visible) return null;
 
+  const stopChromePointer = (e: { stopPropagation: () => void }) => {
+    e.stopPropagation();
+  };
+
   return (
-    <div className="window-controls" data-tauri-drag-region={undefined}>
-      <Tip label={labels.minimize}>
+    <>
+      <div className="window-edge-n" aria-hidden="true" />
+      <div
+        className="window-controls"
+        data-tauri-drag-region={undefined}
+        onPointerDown={stopChromePointer}
+      >
+        <Tip label={labels.minimize}>
         <button
           type="button"
           className="window-controls__btn"
           aria-label={labels.minimize}
+          onPointerDown={stopChromePointer}
           onClick={(e) => {
             e.stopPropagation();
             void winChrome("minimize");
@@ -109,25 +119,30 @@ export function WindowControls({ visible, labels }: Props) {
         >
           <IconMinimize size={14} />
         </button>
-      </Tip>
-      <Tip label={maximized ? labels.restore : labels.maximize}>
+        </Tip>
+        <Tip label={maximized ? labels.restore : labels.maximize}>
         <button
           type="button"
           className="window-controls__btn"
           aria-label={maximized ? labels.restore : labels.maximize}
+          onPointerDown={stopChromePointer}
           onClick={(e) => {
             e.stopPropagation();
-            void winChrome("toggleMaximize");
+            e.preventDefault();
+            scheduleCaptionButtonToggle(() => {
+              void winChrome("toggleMaximize");
+            }, CAPTION_BUTTON_TOGGLE_DEFER_MS);
           }}
         >
           {maximized ? <IconRestore size={14} /> : <IconMaximize size={14} />}
         </button>
-      </Tip>
-      <Tip label={labels.close}>
+        </Tip>
+        <Tip label={labels.close}>
         <button
           type="button"
           className="window-controls__btn window-controls__btn--close"
           aria-label={labels.close}
+          onPointerDown={stopChromePointer}
           onClick={(e) => {
             e.stopPropagation();
             void winChrome("close");
@@ -135,8 +150,9 @@ export function WindowControls({ visible, labels }: Props) {
         >
           <IconClose size={14} />
         </button>
-      </Tip>
-    </div>
+        </Tip>
+      </div>
+    </>
   );
 }
 

--- a/src/lib/windowChrome.test.ts
+++ b/src/lib/windowChrome.test.ts
@@ -1,16 +1,12 @@
-/** @vitest-environment jsdom */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
-  applyViewportPan,
+  CAPTION_BUTTON_TOGGLE_DEFER_MS,
   maximizeLooksNoop,
   osMaximizeWaitMs,
+  scheduleCaptionButtonToggle,
   shouldAcceptTitlebarMaximize,
   shouldFakeMaximizeFallback,
   TITLEBAR_MAXIMIZE_DEBOUNCE_MS,
-  viewportPanFromOffset,
-  VIEWPORT_PAN_CLASS,
-  VIEWPORT_PAN_X_VAR,
-  VIEWPORT_PAN_Y_VAR,
 } from "./windowChrome";
 
 describe("shouldAcceptTitlebarMaximize", () => {
@@ -42,35 +38,23 @@ describe("shouldFakeMaximizeFallback", () => {
 });
 
 describe("osMaximizeWaitMs", () => {
-  it("waits longer when there is no work-area fill fallback", () => {
-    expect(osMaximizeWaitMs(true)).toBeLessThan(osMaximizeWaitMs(false));
+  it("only waits on the Linux work-area fill path", () => {
     expect(osMaximizeWaitMs(true)).toBe(40);
-    expect(osMaximizeWaitMs(false)).toBe(280);
+    expect(osMaximizeWaitMs(false)).toBe(0);
   });
 });
 
-describe("viewportPanFromOffset", () => {
-  it("returns null when the visual viewport is not panned", () => {
-    expect(viewportPanFromOffset(0, 0)).toBeNull();
-    expect(viewportPanFromOffset(0.2, -0.2)).toBeNull();
-  });
-
-  it("negates top/left offset so chrome stays pinned in the frame", () => {
-    expect(viewportPanFromOffset(0, 48)).toEqual({ x: 0, y: -48 });
-    expect(viewportPanFromOffset(12.6, 20.4)).toEqual({ x: -13, y: -20 });
-  });
-});
-
-describe("applyViewportPan", () => {
-  it("sets CSS vars while panned and clears them at identity", () => {
-    const root = document.createElement("html");
-    applyViewportPan(root, { x: 0, y: -48 });
-    expect(root.classList.contains(VIEWPORT_PAN_CLASS)).toBe(true);
-    expect(root.style.getPropertyValue(VIEWPORT_PAN_X_VAR)).toBe("0px");
-    expect(root.style.getPropertyValue(VIEWPORT_PAN_Y_VAR)).toBe("-48px");
-    applyViewportPan(root, null);
-    expect(root.classList.contains(VIEWPORT_PAN_CLASS)).toBe(false);
-    expect(root.style.getPropertyValue(VIEWPORT_PAN_X_VAR)).toBe("");
-    expect(root.style.getPropertyValue(VIEWPORT_PAN_Y_VAR)).toBe("");
+describe("scheduleCaptionButtonToggle", () => {
+  it("defers past mouse-up so Windows does not drag-to-restore", () => {
+    expect(CAPTION_BUTTON_TOGGLE_DEFER_MS).toBeGreaterThan(0);
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    scheduleCaptionButtonToggle(fn, CAPTION_BUTTON_TOGGLE_DEFER_MS);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(CAPTION_BUTTON_TOGGLE_DEFER_MS - 1);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 });

--- a/src/lib/windowChrome.ts
+++ b/src/lib/windowChrome.ts
@@ -5,6 +5,10 @@
  * work area and remember the previous bounds so Restore works.
  * Windows/macOS must not take that path: a follow-up setSize cancels a real
  * maximize that was still settling.
+ *
+ * Do not put a CSS transform on `html`/`body` to "pin" visualViewport — that
+ * breaks `-webkit-app-region: drag`, so titlebar moves become north-resize
+ * (window grows downward; you cannot lift it).
  */
 
 import type { AppPlatform } from "@/lib/appPlatform";
@@ -12,18 +16,18 @@ import { detectAppPlatform } from "@/lib/appPlatform";
 
 export const TITLEBAR_MAXIMIZE_DEBOUNCE_MS = 400;
 
-/** Poll interval while waiting for OS `isMaximized` to catch up. */
+/** Poll interval while waiting for OS `isMaximized` to catch up (Linux only). */
 export const OS_MAXIMIZE_POLL_MS = 16;
 
 /** Linux: short wait then work-area fill. */
 export const LINUX_MAXIMIZE_WAIT_MS = 40;
 
-/** Windows/mac: give ShowWindow(SW_MAXIMIZE) time; never fake-fill. */
-export const OS_MAXIMIZE_WAIT_MS = 280;
-
-export const VIEWPORT_PAN_CLASS = "has-viewport-pan";
-export const VIEWPORT_PAN_X_VAR = "--viewport-pan-x";
-export const VIEWPORT_PAN_Y_VAR = "--viewport-pan-y";
+/**
+ * Caption min/max/close: wait until the pointer is fully up before
+ * maximize(). Otherwise Windows treats the still-held click as a drag on
+ * a maximized window and immediately restores (flash).
+ */
+export const CAPTION_BUTTON_TOGGLE_DEFER_MS = 32;
 
 /** Work-area fill is only for compositors that ignore gtk_window_maximize. */
 export function shouldFakeMaximizeFallback(platform: AppPlatform): boolean {
@@ -31,74 +35,14 @@ export function shouldFakeMaximizeFallback(platform: AppPlatform): boolean {
 }
 
 export function osMaximizeWaitMs(allowFakeFallback: boolean): number {
-  return allowFakeFallback ? LINUX_MAXIMIZE_WAIT_MS : OS_MAXIMIZE_WAIT_MS;
+  return allowFakeFallback ? LINUX_MAXIMIZE_WAIT_MS : 0;
 }
 
-/**
- * CSS translate that cancels visualViewport pan (WebView2 top/left resize).
- * `null` means identity — drop the pin class.
- */
-export function viewportPanFromOffset(
-  offsetLeft: number,
-  offsetTop: number,
-): { x: number; y: number } | null {
-  const x = Number.isFinite(offsetLeft) ? Math.round(-offsetLeft) : 0;
-  const y = Number.isFinite(offsetTop) ? Math.round(-offsetTop) : 0;
-  if (x === 0 && y === 0) return null;
-  return { x: x === 0 ? 0 : x, y: y === 0 ? 0 : y };
-}
-
-export function applyViewportPan(
-  root: HTMLElement,
-  pan: { x: number; y: number } | null,
-): void {
-  if (!pan) {
-    root.classList.remove(VIEWPORT_PAN_CLASS);
-    root.style.removeProperty(VIEWPORT_PAN_X_VAR);
-    root.style.removeProperty(VIEWPORT_PAN_Y_VAR);
-    return;
-  }
-  root.classList.add(VIEWPORT_PAN_CLASS);
-  root.style.setProperty(VIEWPORT_PAN_X_VAR, `${pan.x}px`);
-  root.style.setProperty(VIEWPORT_PAN_Y_VAR, `${pan.y}px`);
-}
-
-/** Pin the page when WebView2 shifts visualViewport during edge resize. */
-export function subscribeDesktopViewportPin(
-  opts?: {
-    root?: HTMLElement;
-    getOffset?: () => { offsetLeft: number; offsetTop: number } | null;
-  },
-): () => void {
-  const root = opts?.root ?? document.documentElement;
-  const apply = () => {
-    let offset: { offsetLeft: number; offsetTop: number } | null;
-    if (opts?.getOffset) {
-      offset = opts.getOffset();
-    } else {
-      const vv = window.visualViewport;
-      offset = vv
-        ? { offsetLeft: vv.offsetLeft, offsetTop: vv.offsetTop }
-        : null;
-    }
-    applyViewportPan(
-      root,
-      offset
-        ? viewportPanFromOffset(offset.offsetLeft, offset.offsetTop)
-        : null,
-    );
-  };
-  apply();
-  const vv = typeof window !== "undefined" ? window.visualViewport : null;
-  vv?.addEventListener("resize", apply);
-  vv?.addEventListener("scroll", apply);
-  window.addEventListener("resize", apply);
-  return () => {
-    vv?.removeEventListener("resize", apply);
-    vv?.removeEventListener("scroll", apply);
-    window.removeEventListener("resize", apply);
-    applyViewportPan(root, null);
-  };
+export function scheduleCaptionButtonToggle(
+  fn: () => void,
+  deferMs: number = CAPTION_BUTTON_TOGGLE_DEFER_MS,
+): ReturnType<typeof setTimeout> {
+  return setTimeout(fn, Math.max(0, deferMs));
 }
 
 /** Double-click / mousedown(detail=2) must not toggle twice. */
@@ -206,15 +150,35 @@ async function waitForOsMaximized(
 /**
  * Maximize / restore. Prefers the OS API; on Linux Wayland no-ops, fills
  * the work area and treats that as maximized until the next toggle.
- * Windows never fills the work area — that undoes a real maximize.
- * Returns whether the window should display as maximized.
+ * Windows/mac: one OS call, no wait, no setSize. Returns the intended
+ * caption state; onResized corrects the glyph if the OS disagrees.
  */
 export async function toggleMaximizeReliable(): Promise<boolean> {
   const { getCurrentWindow } = await import("@tauri-apps/api/window");
   const w = getCurrentWindow();
   const allowFake = shouldFakeMaximizeFallback(detectAppPlatform());
-  const waitMs = osMaximizeWaitMs(allowFake);
   const wasOs = await w.isMaximized().catch(() => false);
+
+  if (!allowFake) {
+    fakeMaximized = false;
+    restoreBounds = null;
+    if (wasOs) {
+      try {
+        await w.unmaximize();
+      } catch {
+        /* ignore */
+      }
+      return false;
+    }
+    try {
+      await w.maximize();
+    } catch {
+      /* ignore */
+    }
+    return true;
+  }
+
+  const waitMs = osMaximizeWaitMs(true);
   const was = wasOs || fakeMaximized;
 
   if (was) {
@@ -227,7 +191,7 @@ export async function toggleMaximizeReliable(): Promise<boolean> {
       }
       await waitForOsMaximized(w, false, waitMs);
     }
-    if (allowFake && restoreBounds) {
+    if (restoreBounds) {
       const prev = restoreBounds;
       restoreBounds = null;
       try {
@@ -235,13 +199,11 @@ export async function toggleMaximizeReliable(): Promise<boolean> {
       } catch {
         /* ignore */
       }
-    } else {
-      restoreBounds = null;
     }
     return w.isMaximized().catch(() => false);
   }
 
-  const before = allowFake ? await readLogicalBounds(w) : null;
+  const before = await readLogicalBounds(w);
   try {
     await w.maximize();
   } catch {
@@ -252,10 +214,6 @@ export async function toggleMaximizeReliable(): Promise<boolean> {
     restoreBounds = null;
     fakeMaximized = false;
     return true;
-  }
-
-  if (!allowFake) {
-    return w.isMaximized().catch(() => false);
   }
 
   if (before) restoreBounds = before;

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -22,15 +22,6 @@ body,
   -webkit-font-smoothing: antialiased;
 }
 
-/* WebView2 shifts visualViewport when a frameless window is resized from the
-   top; pin the page so chrome does not walk down inside the frame. */
-html.has-viewport-pan body {
-  transform: translate(
-    var(--viewport-pan-x, 0px),
-    var(--viewport-pan-y, 0px)
-  );
-}
-
 button,
 input,
 textarea,
@@ -277,6 +268,28 @@ select,
 }
 
 /* Win / frameless self-drawn chrome (mac uses Overlay traffic lights) */
+/* Top 8px must not be a drag region: otherwise titlebar move is HTTOP
+   (window grows downward; you cannot lift it). Stays below .window-controls. */
+.window-edge-n {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: var(--window-controls-inset, 138px);
+  height: 8px;
+  z-index: 10039;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+  pointer-events: auto;
+}
+
+.platform-win .window-edge-n,
+.platform-linux .window-edge-n,
+.platform-other .window-edge-n,
+.has-custom-chrome .window-edge-n {
+  display: block;
+}
+
 .window-controls {
   display: none;
   align-items: stretch;

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -53,11 +53,10 @@ html[data-wallpaper="1"] .app-shell::after {
 }
 
 /* Lift real chrome above the media + scrim.
- * Excludes .window-controls (must keep position: fixed; right:0; z:10040 —
- * otherwise the buttons jump to the left and the drag strip is clobbered)
+ * Excludes .window-controls / .window-edge-n (must keep position: fixed)
  * and the media layer itself (already positioned/z-indexed above). */
 html[data-wallpaper="1"] .app-shell
-  > *:not(.window-controls):not(.app-wallpaper-media) {
+  > *:not(.window-controls):not(.window-edge-n):not(.app-wallpaper-media) {
   position: relative;
   z-index: 2;
 }


### PR DESCRIPTION
## Summary
- Follow-up to #773 / #774. Titlebar double-click maximizes correctly; **clicking the caption maximize button** flashes then restores.
- `maximize()` ran during the same click while the pointer was still down. Windows treats that as Aero **drag-to-restore**.
- #774 pinned `visualViewport` with a `body` transform. That breaks `-webkit-app-region: drag`, so dragging the titlebar **up** north-resizes (bottom edge never lifts).
- Defer caption `maximize()` 32ms past mouse-up. Drop the transform pin. 8px top no-drag strip keeps native HTTOP.

Fixes #783

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan
- [x] `pnpm exec vitest run src/lib/windowChrome.test.ts` (5 passed)
- [ ] CI green
- [ ] Windows: click caption maximize — stays maximized, restore glyph
- [ ] Windows: not maximized, drag the **middle** of the titlebar up — whole window moves
- [ ] Top few pixels still north-resize
- [ ] Titlebar double-click still toggles maximize
- [ ] Linux work-area fill path unchanged

## Checklist
- [x] Targeted vitest
- [x] No new i18n keys
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh), separate from #773
- [x] No secrets
- [x] One commit on `origin/main` (does not rewrite #774)

Note: `pi -p` is not installed on this Windows host.