### PR TITLE
fix(windows): keep titlebar-up a move after #784

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See `docs/llm-wiki/release.md`.
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com/](https://grok-app.com/)。
 
 ### Fixed
+- **Windows titlebar drag-up no longer grows height (#786)**: Follow-up to #783/#784. Caption maximize stayed up, but dragging the titlebar still stretched the frame. Windows skips JS `start_dragging` (`data-tauri-drag-region="false"`) and keeps compositor caption drag. Host `set_min_size` no longer runs on every `Moved` (tao re-applies inner size and double-counts the shadow offset); it skips while maximized, while the pointer is down, and when the min is unchanged.
 - **Windows caption maximize stays maximized; titlebar drag moves the window (#783)**: Follow-up to #773/#774. The button defers `maximize()` until after mouse-up so Aero does not drag-to-restore (flash). The `body` visualViewport transform pin is gone — it broke `-webkit-app-region: drag`, so pulling the titlebar up north-resized (bottom never lifted). An 8px top no-drag strip keeps native HTTOP.
 - **Windows maximize button is a real maximize (#773)**: The caption square used a Linux work-area `setSize` fill when `isMaximized()` lagged ~40ms. That cancelled the OS maximize, left the glyph as a square, and after restore, dragging the top edge panned the WebView inside the frame. Windows now waits for the OS flag and never fakes geometry; the button switches to the restore glyph.
 - **In-app update waits for Install and restart (#777)**: Settings → About Check for updates only checks and downloads. Sidebar and Install and restart open an in-app confirm (version + restart) before install+relaunch. Cancel does nothing. Unsigned GitHub download is unchanged.
@@ -36,6 +37,7 @@ See `docs/llm-wiki/release.md`.
 - **Windows Alt+Tab can type without a click first (#768)**: Tauri `unstable` (side-browser multi-webview) builds the page as a child `WRY_WEBVIEW`, so Alt-Tab / taskbar only activates the outer HWND. The host now forwards `WM_SETFOCUS` / `WM_ACTIVATE` into that child so composer and shortcuts work immediately.
 
 **中文 · 修复**
+- **Windows 标题栏往上拖不再把窗口拉高（#786）**：#783/#784 的后续。最大化能站住，但拖标题栏仍会拉长窗口。Windows 关掉 JS `start_dragging`（`data-tauri-drag-region="false"`），保留 compositor 标题栏拖动。`set_min_size` 不再在每次 `Moved` 里重设客户区（tao 会把阴影边框加两次）；最大化、按住鼠标、min 没变时都跳过。
 - **Windows 点最大化不再闪回，标题栏往上拖是移动窗口（#783）**：#773/#774 的后续。最大化推迟到鼠标松开之后，避免 Aero 当成拖拽立刻还原。去掉会破坏标题栏拖动的 `body` transform；顶边留 8px 非拖动带，标题栏中部往上拖会把整窗抬起来，不再把下沿无限拉高。
 - **Windows 右上角最大化是系统最大化（#773）**：按钮在 `isMaximized()` 还没跟上时会走 Linux 的铺满工作区 `setSize`，把真正的最大化取消掉，图标也不变；还原后再从上沿往下拉，页面会在窗口里往下挪。Windows 现在等系统标志、不再假铺满，按钮换成还原图标。
 - **应用内更新须确认「安装并重启」（#777）**：设置 → 关于「检查更新」只检查和下载。侧栏与「安装并重启」会先弹出应用内确认（版本 + 即将重启），取消不安装。未签名的 GitHub 下载路径不变。

--- a/src-tauri/src/window_min.rs
+++ b/src-tauri/src/window_min.rs
@@ -6,6 +6,8 @@
 //! min to half the current monitor work area (taskbar excluded). Large
 //! displays keep 900×600; moving onto a bigger screen restores that floor.
 
+use std::sync::Mutex;
+
 use tauri::{AppHandle, LogicalSize, Manager, Monitor};
 
 /// Comfort fallback when the window config omits min size.
@@ -73,20 +75,64 @@ fn comfort_from_config(app: &AppHandle) -> (f64, f64) {
     )
 }
 
+/// Last committed (min_w, min_h, scale×100). Skip tao `set_min_size` when
+/// unchanged — it always `set_inner_size`s, which grows undecorated-shadow
+/// windows (outer−inner added twice) and clears WS_MAXIMIZE.
+static LAST_MIN: Mutex<Option<(u32, u32, u32)>> = Mutex::new(None);
+
+pub fn should_commit_min(
+    maximized: bool,
+    pointer_down: bool,
+    last: Option<(u32, u32, u32)>,
+    next: (u32, u32, u32),
+) -> bool {
+    if maximized || pointer_down {
+        return false;
+    }
+    last != Some(next)
+}
+
+fn min_cache_key(min_w: f64, min_h: f64, scale: f64) -> (u32, u32, u32) {
+    (
+        min_w.round() as u32,
+        min_h.round() as u32,
+        (scale.max(0.1) * 100.0).round() as u32,
+    )
+}
+
 /// Recompute OS min from the main window's current monitor.
 pub fn apply_main(app: &AppHandle) {
     let Some(window) = app.get_webview_window("main") else {
         return;
     };
+    let maximized = window.is_maximized().unwrap_or(false);
+    let pointer_down = {
+        #[cfg(windows)]
+        {
+            crate::win_shell::primary_mouse_button_down()
+        }
+        #[cfg(not(windows))]
+        {
+            false
+        }
+    };
     let (cw, ch) = comfort_from_config(app);
     let monitor = window.current_monitor().ok().flatten();
     let (min_w, min_h) = cap_for_monitor(cw, ch, monitor.as_ref());
+    let scale = window.scale_factor().unwrap_or(1.0);
+    let next = min_cache_key(min_w, min_h, scale);
+    let mut last = LAST_MIN.lock().unwrap_or_else(|e| e.into_inner());
+    if !should_commit_min(maximized, pointer_down, *last, next) {
+        return;
+    }
+    *last = Some(next);
+    drop(last);
     let _ = window.set_min_size(Some(LogicalSize::new(min_w, min_h)));
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{snap_friendly_min, snap_friendly_min_size};
+    use super::{should_commit_min, snap_friendly_min, snap_friendly_min_size};
 
     #[test]
     fn half_of_1440_beats_comfort_900() {
@@ -138,5 +184,16 @@ mod tests {
             snap_friendly_min_size(900.0, 600.0, 1920.0, 1200.0),
             (900.0, 600.0)
         );
+    }
+
+    #[test]
+    fn commit_min_skips_drag_maximize_and_repeats() {
+        let key = (900, 600, 200);
+        assert!(!should_commit_min(true, false, None, key));
+        assert!(!should_commit_min(false, true, None, key));
+        assert!(!should_commit_min(false, false, Some(key), key));
+        assert!(should_commit_min(false, false, None, key));
+        assert!(should_commit_min(false, false, Some(key), (720, 600, 200)));
+        assert!(should_commit_min(false, false, Some(key), (900, 600, 100)));
     }
 }

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -1081,6 +1081,7 @@ import {
 import { Tip } from "@/components/ui/tooltip";
 import {
   WindowControls,
+  tauriDragRegion,
   titlebarMaximizeHandlers
 } from "@/components/WindowControls";
 
@@ -2736,6 +2737,7 @@ export function AppWorkbench() {
   const titlebarMax = titlebarMaximizeHandlers({
     enabled: !phoneLayout && !isMirrorClient(),
   });
+  const dragRegion = tauriDragRegion(platform);
   /** Right inset so resource chrome icons clear min/max/close. */
   const windowControlsInset = useCustomWindowChrome ? WINDOW_CONTROLS_INSET : 0;
   const [windowMaximized, setWindowMaximized] = useState(false);
@@ -18062,7 +18064,7 @@ export function AppWorkbench() {
         <div className="setup-gate" data-testid="setup-booting">
           <div
             className="setup-gate__drag"
-            data-tauri-drag-region
+            data-tauri-drag-region={dragRegion}
             {...titlebarMax}
           />
           <div className="setup-gate__center">
@@ -18979,7 +18981,7 @@ export function AppWorkbench() {
           {/* Row 1: traffic-light height — panel toggle sits just right of traffic lights */}
           <div
             className="sidebar-chrome"
-            data-tauri-drag-region
+            data-tauri-drag-region={dragRegion}
             {...titlebarMax}
           >
             <Tip label={tr("main.leftPaneHide")}>
@@ -18994,7 +18996,7 @@ export function AppWorkbench() {
             </Tip>
             <div
               className="sidebar-chrome__drag"
-              data-tauri-drag-region
+              data-tauri-drag-region={dragRegion}
               {...titlebarMax}
             />
           </div>
@@ -19942,10 +19944,10 @@ export function AppWorkbench() {
             className={
               "main__top" + (phoneLayout ? " main__top--phone" : "")
             }
-            data-tauri-drag-region
+            data-tauri-drag-region={dragRegion}
             {...titlebarMax}
           >
-            <div className="main__title-row" data-tauri-drag-region>
+            <div className="main__title-row" data-tauri-drag-region={dragRegion}>
               {/* Phone: always-visible hamburger (≥44px). Desktop: reopen when rail hidden. */}
               {phoneLayout ? (
                 <button
@@ -19981,7 +19983,7 @@ export function AppWorkbench() {
                       <IconScheduled size={16} />
                     </span>
                   ) : null}
-                  <h1 className="main__title" data-tauri-drag-region>
+                  <h1 className="main__title" data-tauri-drag-region={dragRegion}>
                     {tr("automations.title")}
                   </h1>
                 </>
@@ -19992,7 +19994,7 @@ export function AppWorkbench() {
                       <IconList size={16} />
                     </span>
                   ) : null}
-                  <h1 className="main__title" data-tauri-drag-region>
+                  <h1 className="main__title" data-tauri-drag-region={dragRegion}>
                     {tr("kanban.title")}
                   </h1>
                 </>
@@ -20023,12 +20025,12 @@ export function AppWorkbench() {
                         </span>
                       ) : null}
                       {phoneLayout ? (
-                        <h1 className="main__title" data-tauri-drag-region>
+                        <h1 className="main__title" data-tauri-drag-region={dragRegion}>
                           {title}
                         </h1>
                       ) : (
                         <Tip label={title}>
-                          <h1 className="main__title" data-tauri-drag-region>
+                          <h1 className="main__title" data-tauri-drag-region={dragRegion}>
                             {title}
                           </h1>
                         </Tip>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -93,7 +93,11 @@ import {
   type SidebarDensity,
 } from "@/lib/sidebarDensity";
 import type { WallpaperSourceTab } from "@/components/WallpaperSourceModal";
-import { titlebarMaximizeHandlers } from "@/components/WindowControls";
+import { detectAppPlatform } from "@/lib/appPlatform";
+import {
+  tauriDragRegion,
+  titlebarMaximizeHandlers,
+} from "@/components/WindowControls";
 import {
   loadComposerSendKeyPref,
   type ComposerSendKeyPref,
@@ -1755,7 +1759,7 @@ export function SettingsPage({
       {/* Full-width overlay drag band (does not break glass nav continuity) */}
       <div
         className="settings-page__chrome"
-        data-tauri-drag-region
+        data-tauri-drag-region={tauriDragRegion(detectAppPlatform())}
         aria-hidden
         {...titlebarMaximizeHandlers()}
       />

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -10,7 +10,10 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { GrokLogo } from "@/components/GrokLogo";
 import { Select } from "@/components/Select";
 import { Spinner } from "@/components/ui/spinner";
-import { titlebarMaximizeHandlers } from "@/components/WindowControls";
+import {
+  tauriDragRegion,
+  titlebarMaximizeHandlers,
+} from "@/components/WindowControls";
 import * as api from "@/lib/api";
 import type { createT } from "@/i18n";
 import type { MessageKey } from "@/i18n";
@@ -472,7 +475,7 @@ export function SetupWizard({
     >
       <div
         className="setup-gate__drag"
-        data-tauri-drag-region
+        data-tauri-drag-region={tauriDragRegion(platform)}
         {...titlebarMaximizeHandlers()}
       />
 

--- a/src/components/WindowControls.tsx
+++ b/src/components/WindowControls.tsx
@@ -11,6 +11,7 @@ import {
   IconRestore,
 } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
+import { detectAppPlatform } from "@/lib/appPlatform";
 import {
   CAPTION_BUTTON_TOGGLE_DEFER_MS,
   isFakeMaximized,
@@ -19,7 +20,10 @@ import {
   toggleMaximizeReliable,
 } from "@/lib/windowChrome";
 
-export { toggleMaximizeFromTitlebar } from "@/lib/windowChrome";
+export {
+  tauriDragRegion,
+  toggleMaximizeFromTitlebar,
+} from "@/lib/windowChrome";
 
 type Props = {
   visible: boolean;
@@ -181,7 +185,10 @@ export function titlebarMaximizeHandlers(opts?: {
     preventDefault: () => void;
   }) => void;
 } {
-  const enabled = opts?.enabled !== false;
+  // Windows: compositor caption dblclick maximizes (mouse is up). A JS
+  // toggle on mousedown(detail=2) races Aero drag-to-restore.
+  const enabled =
+    opts?.enabled !== false && detectAppPlatform() !== "win";
   return {
     onDoubleClick: (e) => {
       if (!enabled) return;

--- a/src/components/side-workbench/SideTabBar.tsx
+++ b/src/components/side-workbench/SideTabBar.tsx
@@ -43,7 +43,11 @@ import {
   type SidePickerKind,
 } from "@/lib/sideWorkbench";
 import { SidePicker } from "./SidePicker";
-import { titlebarMaximizeHandlers } from "@/components/WindowControls";
+import { detectAppPlatform } from "@/lib/appPlatform";
+import {
+  tauriDragRegion,
+  titlebarMaximizeHandlers,
+} from "@/components/WindowControls";
 
 export type SideTabBarProps = {
   locale: Locale | string;
@@ -127,6 +131,7 @@ export function SideTabBar({
 }: SideTabBarProps) {
   const tr = useMemo(() => createT(locale as Locale), [locale]);
   const titlebarMax = titlebarMaximizeHandlers();
+  const dragRegion = tauriDragRegion(detectAppPlatform());
   const [plusOpen, setPlusOpen] = useState(false);
   const plusRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -431,7 +436,7 @@ export function SideTabBar({
       {/* Empty strip between tabs/+ and right actions — window drag (titlebar). */}
       <div
         className="sw-chrome__drag"
-        data-tauri-drag-region
+        data-tauri-drag-region={dragRegion}
         aria-hidden
         {...titlebarMax}
       />

--- a/src/lib/windowChrome.test.ts
+++ b/src/lib/windowChrome.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   CAPTION_BUTTON_TOGGLE_DEFER_MS,
@@ -6,6 +8,7 @@ import {
   scheduleCaptionButtonToggle,
   shouldAcceptTitlebarMaximize,
   shouldFakeMaximizeFallback,
+  tauriDragRegion,
   TITLEBAR_MAXIMIZE_DEBOUNCE_MS,
 } from "./windowChrome";
 
@@ -25,6 +28,37 @@ describe("maximizeLooksNoop", () => {
     expect(maximizeLooksNoop(true, true)).toBe(true);
     expect(maximizeLooksNoop(false, true)).toBe(false);
     expect(maximizeLooksNoop(true, false)).toBe(false);
+  });
+});
+
+describe("tauriDragRegion", () => {
+  it("disables JS start_dragging on Windows (CSS compositor caption stays)", () => {
+    expect(tauriDragRegion("win")).toBe("false");
+    expect(tauriDragRegion("mac")).toBe("deep");
+    expect(tauriDragRegion("linux")).toBe("deep");
+  });
+
+  it("keeps compositor caption drag on Windows false-regions", () => {
+    const sidebar = readFileSync(
+      join(__dirname, "../styles/sidebar.part1.css"),
+      "utf8",
+    );
+    const settings = readFileSync(
+      join(__dirname, "../styles/settings.part1.css"),
+      "utf8",
+    );
+    expect(sidebar).toMatch(
+      /\[data-tauri-drag-region\][^{]*\{[^}]*-webkit-app-region:\s*drag/,
+    );
+    expect(sidebar).not.toMatch(
+      /\[data-tauri-drag-region="false"\][^{]*\{[^}]*no-drag/,
+    );
+    expect(sidebar).not.toMatch(
+      /html\.platform-win \[data-tauri-drag-region\][\s\S]{0,80}no-drag/,
+    );
+    expect(settings).not.toMatch(
+      /html\.platform-win \.settings-page__chrome[\s\S]{0,120}no-drag/,
+    );
   });
 });
 

--- a/src/lib/windowChrome.ts
+++ b/src/lib/windowChrome.ts
@@ -34,6 +34,16 @@ export function shouldFakeMaximizeFallback(platform: AppPlatform): boolean {
   return platform === "linux";
 }
 
+/**
+ * `data-tauri-drag-region` value.
+ * Windows: `"false"` so Tauri's drag.js skips `start_dragging`. That IPC
+ * move plus `-webkit-app-region: drag` north-resized the frame. CSS still
+ * applies compositor caption drag on the same attribute.
+ */
+export function tauriDragRegion(platform: AppPlatform): "false" | "deep" {
+  return platform === "win" ? "false" : "deep";
+}
+
 export function osMaximizeWaitMs(allowFakeFallback: boolean): number {
   return allowFakeFallback ? LINUX_MAXIMIZE_WAIT_MS : 0;
 }

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -203,7 +203,10 @@ textarea:focus-visible,
   user-select: none;
 }
 
-/* Tauri window drag regions (mac Overlay + frameless Win) */
+/* Tauri window drag regions.
+ * `false` only skips JS `start_dragging` (Tauri drag.js). Keep compositor
+ * caption drag: WebView2 covers the client, so parent WM_NCHITTEST never
+ * sees titlebar clicks. */
 [data-tauri-drag-region] {
   -webkit-app-region: drag;
   app-region: drag;
@@ -268,8 +271,8 @@ select,
 }
 
 /* Win / frameless self-drawn chrome (mac uses Overlay traffic lights) */
-/* Top 8px must not be a drag region: otherwise titlebar move is HTTOP
-   (window grows downward; you cannot lift it). Stays below .window-controls. */
+/* Top 8px: Linux/other keep a no-drag strip. Windows lets compositor caption
+   cover the client titlebar; tao already maps the non-client shadow to HTTOP. */
 .window-edge-n {
   display: none;
   position: fixed;
@@ -288,6 +291,10 @@ select,
 .platform-other .window-edge-n,
 .has-custom-chrome .window-edge-n {
   display: block;
+}
+
+html.platform-win .window-edge-n {
+  pointer-events: none;
 }
 
 .window-controls {


### PR DESCRIPTION
## Summary
- Follow-up to #783 / #784 (`c2f7f782`). Caption maximize stays maximized; **dragging the titlebar up still stretched the window** (height grew, bottom dropped).
- Two leftovers after #784:
  1. Tauri `drag.js` `start_dragging` plus `-webkit-app-region: drag` on the same strip.
  2. Host `set_min_size` on every `Moved`. tao always re-`set_inner_size`s; on an undecorated+shadow HWND that **double-counts the DWM offset**, so each drag grows height and can clear `WS_MAXIMIZE`.
- Windows now sets `data-tauri-drag-region="false"` (skip JS `start_dragging`) and keeps compositor caption drag. `set_min_size` skips while maximized, while the pointer is down, and when the min is unchanged.
- Branched from current `origin/main` (includes #784). Does **not** rewrite the #784 commit or its CHANGELOG bullet.

Fixes #786

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan
- [x] `pnpm exec vitest run src/lib/windowChrome.test.ts` (7 passed)
- [x] Windows: restore, drag the **middle** of the titlebar up — window lifts, height unchanged (`dY=-80 dH=0` at 192 DPI)
- [x] Caption maximize still stays maximized
- [ ] CI green
- [ ] Titlebar double-click still toggles maximize
- [ ] Win+Right snap min still caps to half work area after the pointer is up

## Checklist
- [x] Targeted vitest
- [x] No new i18n keys
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh), **new** #786 bullet; #783/#784 text untouched
- [x] No secrets
- [x] One commit on `origin/main` (does not rewrite #784)

Note: `pi -p` is not installed on this Windows host (no `pi` on PATH). Per repo policy this is recorded rather than skipped silently.
