### PR TITLE
perf(build): split markdown, TipTap, and xterm into vendor chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Vendor JS split for markdown / TipTap / xterm**: Vite emits separate chunks so those stacks can cache independently of the app shell (and drop off first paint once their call sites are lazy).
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **markdown / TipTap / xterm 拆成独立 JS chunk**：Vite 单独打包这三坨，壳改动不再带着重库一起失效；后续 lazy 后它们可以离开首屏。
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com/](https://grok-app.com/)。
 
 ### Fixed

--- a/docs/plans/2026-08-21-vite-vendor-chunks-pi-review.md
+++ b/docs/plans/2026-08-21-vite-vendor-chunks-pi-review.md
@@ -1,0 +1,15 @@
+## 结论：**未完成（pi 不可用）**
+
+审查对象：`a778e60f` perf(build): split markdown, TipTap, and xterm into vendor chunks。
+
+按 AGENTS.md §8 调用 `pi -p`（工具仅 `read`/`bash`）。本机 PowerShell 报：
+
+```
+pi: The term 'pi' is not recognized as a name of a cmdlet, function, script file, or executable program.
+```
+
+`Get-Command pi` 空；`~/.grok/bin` 仅有 `grok.exe` / `agent.exe`。未用其它模型顶替审查。
+
+**本项不得标为已 pi 审过。** 装好 `pi` 后对本提交重跑 `pi -p`，有 blocker 再修。
+
+自测（不能代替 pi）：`viteManualChunks.test.ts` 4 通过；`tsc -b` 通过；`vite build` 产出 `markdown-*.js` ~153KB、`tiptap-*.js` ~523KB、`xterm-*.js` ~436KB，主包 `index-*.js` ~11.0MB。

--- a/src/lib/viteManualChunks.test.ts
+++ b/src/lib/viteManualChunks.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { vendorManualChunk } from "./viteManualChunks";
+
+describe("vendorManualChunk", () => {
+  it("ignores app source", () => {
+    expect(vendorManualChunk("/repo/src/components/MarkdownChat.tsx")).toBeUndefined();
+  });
+
+  it("groups xterm including Windows paths", () => {
+    expect(
+      vendorManualChunk("D:\\repo\\node_modules\\@xterm\\xterm\\lib\\xterm.js"),
+    ).toBe("xterm");
+    expect(
+      vendorManualChunk("/repo/node_modules/@xterm/addon-webgl/lib/addon.js"),
+    ).toBe("xterm");
+  });
+
+  it("groups TipTap / ProseMirror, not React", () => {
+    expect(
+      vendorManualChunk("/repo/node_modules/@tiptap/react/dist/index.js"),
+    ).toBe("tiptap");
+    expect(
+      vendorManualChunk("/repo/node_modules/prosemirror-model/dist/index.js"),
+    ).toBe("tiptap");
+    expect(
+      vendorManualChunk("/repo/node_modules/react-dom/index.js"),
+    ).toBeUndefined();
+  });
+
+  it("groups react-markdown and remark-gfm", () => {
+    expect(
+      vendorManualChunk("/repo/node_modules/react-markdown/index.js"),
+    ).toBe("markdown");
+    expect(
+      vendorManualChunk("/repo/node_modules/remark-gfm/index.js"),
+    ).toBe("markdown");
+    expect(
+      vendorManualChunk("/repo/node_modules/micromark/index.js"),
+    ).toBe("markdown");
+  });
+});

--- a/src/lib/viteManualChunks.ts
+++ b/src/lib/viteManualChunks.ts
@@ -1,0 +1,54 @@
+/**
+ * Vite `manualChunks` matcher. Only vite.config.ts should import this.
+ * Windows module ids use backslash — normalize before matching.
+ */
+export function vendorManualChunk(id: string): string | undefined {
+  const n = id.replace(/\\/g, "/");
+  const marker = "/node_modules/";
+  const at = n.lastIndexOf(marker);
+  if (at < 0) return;
+  const rest = n.slice(at + marker.length);
+
+  if (rest.startsWith("@xterm/") || rest.startsWith("xterm/")) {
+    return "xterm";
+  }
+  if (
+    rest.startsWith("@tiptap/") ||
+    rest.startsWith("tiptap-markdown/") ||
+    rest.startsWith("prosemirror-")
+  ) {
+    return "tiptap";
+  }
+  if (
+    rest.startsWith("react-markdown/") ||
+    rest.startsWith("remark-gfm/") ||
+    rest.startsWith("remark-parse/") ||
+    rest.startsWith("remark-rehype/") ||
+    rest.startsWith("micromark/") ||
+    rest.startsWith("micromark-") ||
+    rest.startsWith("mdast-util-") ||
+    rest.startsWith("unist-util-") ||
+    rest.startsWith("hast-util-") ||
+    rest.startsWith("unified/") ||
+    rest.startsWith("vfile/") ||
+    rest.startsWith("vfile-message/") ||
+    rest.startsWith("property-information/") ||
+    rest.startsWith("comma-separated-tokens/") ||
+    rest.startsWith("space-separated-tokens/") ||
+    rest.startsWith("decode-named-character-reference/") ||
+    rest.startsWith("character-entities") ||
+    rest.startsWith("ccount/") ||
+    rest.startsWith("escape-string-regexp/") ||
+    rest.startsWith("trim-lines/") ||
+    rest.startsWith("longest-streak/") ||
+    rest.startsWith("zwitch/") ||
+    rest.startsWith("markdown-table/") ||
+    rest.startsWith("devlop/") ||
+    rest.startsWith("estree-util-") ||
+    rest.startsWith("html-url-attributes/") ||
+    rest.startsWith("mdast-util-to-hast/") ||
+    rest.startsWith("mdast-util-to-string/")
+  ) {
+    return "markdown";
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
 import process from "node:process";
+import { vendorManualChunk } from "./src/lib/viteManualChunks";
 
 const host = process.env.TAURI_DEV_HOST;
 
@@ -28,6 +29,13 @@ export default defineConfig(() => ({
       : undefined,
     watch: {
       ignored: ["**/src-tauri/**"],
+    },
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: vendorManualChunk,
+      },
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Vite `manualChunks` splits `react-markdown` / remark-gfm, TipTap / ProseMirror, and `@xterm` into `markdown-*.js`, `tiptap-*.js`, and `xterm-*.js`. The app shell can change without busting those caches; later lazy() PRs can keep them off first paint.

Fixes #793

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/lib/viteManualChunks.test.ts`
- [x] `pnpm exec vite build` — emits `markdown-*.js`, `tiptap-*.js`, `xterm-*.js`; index dropped from ~12.4MB to ~11.0MB (chunks still eager until call sites are lazy)
- [ ] CI green

## Checklist

- [x] Targeted vitest
- [ ] `pnpm typecheck` / full `pnpm test` (CI)
- [x] No new i18n keys
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- Matcher normalizes Windows backslash module ids.
- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
- Independent of #789–#792. Does not touch AppWorkbench.
