### PR TITLE
perf(boot): keep Streamdown CSS off the startup graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Streamdown CSS no longer loads at boot**: Chat uses `MarkdownChat`, not Streamdown. Styles move onto the unused `MessageResponse` module so a later import still looks right.
 - **Vendor JS split for markdown / TipTap / xterm**: Vite emits separate chunks so those stacks can cache independently of the app shell (and drop off first paint once their call sites are lazy).
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **启动不再加载 Streamdown CSS**：聊天走 `MarkdownChat`，不走 Streamdown。样式挪到未接入的 `MessageResponse`，以后真用到时才会带上。
 - **markdown / TipTap / xterm 拆成独立 JS chunk**：Vite 单独打包这三坨，壳改动不再带着重库一起失效；后续 lazy 后它们可以离开首屏。
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com/](https://grok-app.com/)。
 

--- a/src/components/ui/message-response.tsx
+++ b/src/components/ui/message-response.tsx
@@ -1,11 +1,14 @@
 /**
  * Streaming markdown body — Streamdown (AI Elements MessageResponse).
+ * Not used by ConversationThread (that path is MarkdownChat). CSS is
+ * imported here so boot does not pay for an unused stylesheet.
  * Media paths → image/video cards; other file paths & URLs → FilePathCard
  * (open in right resource pane).
  */
 
 import { memo, useMemo, type ReactNode } from "react";
 import { Streamdown } from "streamdown";
+import "streamdown/styles.css";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
 import { ImageUi, imageUiLabels } from "@/components/ImageUi";

--- a/src/main.bootCss.test.ts
+++ b/src/main.bootCss.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe("boot CSS", () => {
+  it("does not import streamdown styles in main.tsx", () => {
+    const src = readFileSync(join(here, "main.tsx"), "utf8");
+    expect(src).not.toContain("streamdown/styles.css");
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,6 @@ import { UpdaterProvider } from "./hooks/UpdaterProvider";
 import "./styles/tokens.css";
 import "./styles/skins.css";
 import "./styles/tailwind.css";
-import "streamdown/styles.css";
 import "./styles/app.css";
 import "./styles/setup-wizard.css";
 import { detectAppPlatform } from "./lib/appPlatform";


### PR DESCRIPTION
## Summary

Chat renders with `MarkdownChat` (react-markdown), not Streamdown. Boot no longer imports `streamdown/styles.css`. The unused `MessageResponse` module now owns that stylesheet so a future import still looks right.

Fixes #794

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/main.bootCss.test.ts`
- [x] `src/main.tsx` has no `streamdown/styles.css` import
- [ ] CI green

## Checklist

- [x] Targeted vitest
- [ ] `pnpm typecheck` / full `pnpm test` (CI)
- [x] No new i18n keys
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
- Independent of #788 / #790–#792. Does not touch AppWorkbench.
