### PR TITLE
perf(chat): keep ReactMarkdown components stable while streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Streaming markdown keeps a stable ReactMarkdown component map**: `remarkPlugins` and leaf tags are module-level; path/code/img handlers memoize so a token tick does not remount the tree.
 - **Streamdown CSS no longer loads at boot**: Chat uses `MarkdownChat`, not Streamdown. Styles move onto the unused `MessageResponse` module so a later import still looks right.
 - **Vendor JS split for markdown / TipTap / xterm**: Vite emits separate chunks so those stacks can cache independently of the app shell (and drop off first paint once their call sites are lazy).
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **流式 markdown 不再每跳一次 token 换一套 components**：`remarkPlugins` 和叶子标签提到模块级；路径/代码/图片处理器 memo，避免 ReactMarkdown 整树重挂。
 - **启动不再加载 Streamdown CSS**：聊天走 `MarkdownChat`，不走 Streamdown。样式挪到未接入的 `MessageResponse`，以后真用到时才会带上。
 - **markdown / TipTap / xterm 拆成独立 JS chunk**：Vite 单独打包这三坨，壳改动不再带着重库一起失效；后续 lazy 后它们可以离开首屏。
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com/](https://grok-app.com/)。

--- a/src/components/lobe-chat/MarkdownChat.test.tsx
+++ b/src/components/lobe-chat/MarkdownChat.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import remarkGfm from "remark-gfm";
+import {
+  MARKDOWN_CHAT_LEAF_COMPONENTS,
+  MARKDOWN_CHAT_REMARK_PLUGINS,
+  MarkdownChat,
+} from "./MarkdownChat";
+
+describe("MarkdownChat", () => {
+  it("keeps a stable remarkPlugins array", () => {
+    expect(MARKDOWN_CHAT_REMARK_PLUGINS).toEqual([remarkGfm]);
+    expect(MARKDOWN_CHAT_REMARK_PLUGINS[0]).toBe(remarkGfm);
+  });
+
+  it("reuses module-level leaf components when find is off", () => {
+    expect(MARKDOWN_CHAT_LEAF_COMPONENTS.p).toBe(
+      MARKDOWN_CHAT_LEAF_COMPONENTS.p,
+    );
+    expect(MARKDOWN_CHAT_LEAF_COMPONENTS.pre).toBeDefined();
+    expect(MARKDOWN_CHAT_LEAF_COMPONENTS.hr).toBeDefined();
+  });
+
+  it("turns http links into path cards and keeps inline code", () => {
+    const html = renderToStaticMarkup(
+      <MarkdownChat>
+        {"See [docs](https://example.com/path) and `code`."}
+      </MarkdownChat>,
+    );
+    expect(html).toContain("file-path-card--url");
+    expect(html).toContain("example.com");
+    expect(html).toContain("chat-md__inline-code");
+    expect(html).toContain("code");
+  });
+
+  it("highlights find hits in string leaves", () => {
+    const html = renderToStaticMarkup(
+      <MarkdownChat findQuery="please">
+        {"Hello please stay."}
+      </MarkdownChat>,
+    );
+    expect(html).toContain("please");
+  });
+});

--- a/src/components/lobe-chat/MarkdownChat.test.tsx
+++ b/src/components/lobe-chat/MarkdownChat.test.tsx
@@ -1,11 +1,17 @@
-import { describe, expect, it } from "vitest";
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+import { cleanup, render } from "@testing-library/react";
 import remarkGfm from "remark-gfm";
 import {
   MARKDOWN_CHAT_LEAF_COMPONENTS,
   MARKDOWN_CHAT_REMARK_PLUGINS,
   MarkdownChat,
 } from "./MarkdownChat";
+
+afterEach(cleanup);
 
 describe("MarkdownChat", () => {
   it("keeps a stable remarkPlugins array", () => {
@@ -40,5 +46,25 @@ describe("MarkdownChat", () => {
       </MarkdownChat>,
     );
     expect(html).toContain("please");
+  });
+
+  it("resets find occurrence indices when the same components map paints more text", () => {
+    const { rerender, container } = render(
+      <MarkdownChat findQuery="foo" findActiveOccurrence={0}>
+        {"foo"}
+      </MarkdownChat>,
+    );
+    expect(container.querySelectorAll("[data-find-mark='current']")).toHaveLength(
+      1,
+    );
+    rerender(
+      <MarkdownChat findQuery="foo" findActiveOccurrence={0}>
+        {"foo and foo"}
+      </MarkdownChat>,
+    );
+    const currents = container.querySelectorAll("[data-find-mark='current']");
+    expect(currents).toHaveLength(1);
+    expect(currents[0]?.textContent).toBe("foo");
+    expect(container.querySelectorAll("[data-find-mark]")).toHaveLength(2);
   });
 });

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -345,11 +345,19 @@ export const MarkdownChat = memo(function MarkdownChat({
   const painted = resolveMarkdownPaintSource(streaming, source, mdSource);
 
   const qFind = findQuery.trim();
+  // Fresh counter each render (including stream ticks). Kept on a ref so the
+  // memoized components map can stay stable without drifting occurrence indices.
+  const findCounterRef = useRef({ n: findOccurrenceBase });
+  findCounterRef.current = { n: findOccurrenceBase };
   const components = useMemo((): Components => {
-    const findCounter = { n: findOccurrenceBase };
     const paint = (node: ReactNode) =>
       qFind
-        ? highlightChildren(node, qFind, findActiveOccurrence, findCounter)
+        ? highlightChildren(
+            node,
+            qFind,
+            findActiveOccurrence,
+            findCounterRef.current,
+          )
         : node;
 
     const renderPathOrUrl = (token: string, linkText?: string) => {
@@ -644,7 +652,6 @@ export const MarkdownChat = memo(function MarkdownChat({
   }, [
     qFind,
     findActiveOccurrence,
-    findOccurrenceBase,
     pathCards,
     projectPath,
     imagePathMap,

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -2,8 +2,15 @@
  * Chat markdown — path/url → cards (image/video/file); open in resource pane.
  */
 
-import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import ReactMarkdown from "react-markdown";
+import {
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
@@ -103,6 +110,97 @@ function textFromChildren(children: ReactNode): string {
     return children.map(textFromChildren).join("");
   }
   return "";
+}
+
+/** Stable identity so ReactMarkdown does not remount the tree every stream tick. */
+export const MARKDOWN_CHAT_REMARK_PLUGINS = [remarkGfm];
+
+type MdKids = { children?: ReactNode };
+
+function MdP({ children }: MdKids) {
+  return <p>{children}</p>;
+}
+function MdLi({ children }: MdKids) {
+  return <li>{children}</li>;
+}
+function MdStrong({ children }: MdKids) {
+  return <strong>{children}</strong>;
+}
+function MdEm({ children }: MdKids) {
+  return <em>{children}</em>;
+}
+function MdH1({ children }: MdKids) {
+  return <h1>{children}</h1>;
+}
+function MdH2({ children }: MdKids) {
+  return <h2>{children}</h2>;
+}
+function MdH3({ children }: MdKids) {
+  return <h3>{children}</h3>;
+}
+function MdH4({ children }: MdKids) {
+  return <h4>{children}</h4>;
+}
+function MdBlockquote({ children }: MdKids) {
+  return <blockquote>{children}</blockquote>;
+}
+function MdTd({ children }: MdKids) {
+  return <td>{children}</td>;
+}
+function MdTh({ children }: MdKids) {
+  return <th>{children}</th>;
+}
+function MdPre({ children }: MdKids) {
+  return <>{children}</>;
+}
+function MdTable({ children }: MdKids) {
+  return (
+    <div className="chat-md__table-wrap">
+      <table>{children}</table>
+    </div>
+  );
+}
+function MdHr() {
+  return null;
+}
+
+/** Leaf tags with no find-highlight wrap — reused on the stream hot path. */
+export const MARKDOWN_CHAT_LEAF_COMPONENTS: Components = {
+  p: MdP,
+  li: MdLi,
+  strong: MdStrong,
+  em: MdEm,
+  h1: MdH1,
+  h2: MdH2,
+  h3: MdH3,
+  h4: MdH4,
+  blockquote: MdBlockquote,
+  td: MdTd,
+  th: MdTh,
+  pre: MdPre,
+  table: MdTable,
+  hr: MdHr,
+};
+
+function paintedLeaves(
+  paint: (node: ReactNode) => ReactNode,
+): Components {
+  return {
+    p: ({ children: c }) => <p>{paint(c)}</p>,
+    li: ({ children: c }) => <li>{paint(c)}</li>,
+    strong: ({ children: c }) => <strong>{paint(c)}</strong>,
+    em: ({ children: c }) => <em>{paint(c)}</em>,
+    h1: ({ children: c }) => <h1>{paint(c)}</h1>,
+    h2: ({ children: c }) => <h2>{paint(c)}</h2>,
+    h3: ({ children: c }) => <h3>{paint(c)}</h3>,
+    h4: ({ children: c }) => <h4>{paint(c)}</h4>,
+    blockquote: ({ children: c }) => <blockquote>{paint(c)}</blockquote>,
+    td: ({ children: c }) => <td>{paint(c)}</td>,
+    th: ({ children: c }) => <th>{paint(c)}</th>,
+    pre: MdPre,
+    table: MdTable,
+    hr: MdHr,
+  };
 }
 
 export const MarkdownChat = memo(function MarkdownChat({
@@ -246,7 +344,15 @@ export const MarkdownChat = memo(function MarkdownChat({
   }, [source, streaming, parseMs]);
   const painted = resolveMarkdownPaintSource(streaming, source, mdSource);
 
-  const renderPathOrUrl = (token: string, linkText?: string) => {
+  const qFind = findQuery.trim();
+  const components = useMemo((): Components => {
+    const findCounter = { n: findOccurrenceBase };
+    const paint = (node: ReactNode) =>
+      qFind
+        ? highlightChildren(node, qFind, findActiveOccurrence, findCounter)
+        : node;
+
+    const renderPathOrUrl = (token: string, linkText?: string) => {
     const rawIn = token.trim().replace(/^<|>$/g, "");
     if (!rawIn) return null;
     // Strip path:line[:col] before path resolution (soft-fail keeps original).
@@ -444,15 +550,114 @@ export const MarkdownChat = memo(function MarkdownChat({
         }}
       />
     );
-  };
+    };
 
-  // Fresh counter each render so occurrence indices stay stable for the mark.
-  const findCounter = { n: findOccurrenceBase };
-  const qFind = findQuery.trim();
-  const paint = (node: ReactNode) =>
-    qFind
-      ? highlightChildren(node, qFind, findActiveOccurrence, findCounter)
-      : node;
+    const leaves = qFind
+      ? paintedLeaves(paint)
+      : MARKDOWN_CHAT_LEAF_COMPONENTS;
+
+    return {
+      ...leaves,
+      a: ({ href, children: c }) => {
+        const text = textFromChildren(c).trim();
+        const hrefStr = typeof href === "string" ? href : "";
+        if (onOpenExternalLink && isExternalHttpUrl(hrefStr)) {
+          return (
+            <a
+              className="chat-md__link"
+              href={hrefStr}
+              rel="noreferrer noopener"
+              onClick={(e) => {
+                e.preventDefault();
+                onOpenExternalLink(hrefStr);
+              }}
+            >
+              {paint(c)}
+            </a>
+          );
+        }
+        const card =
+          (hrefStr && renderPathOrUrl(hrefStr, text)) ||
+          (text && text !== hrefStr ? renderPathOrUrl(text) : null);
+        if (card) return card;
+        return (
+          <a
+            className="chat-md__link"
+            href={href}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {paint(c)}
+          </a>
+        );
+      },
+      code: ({ className: cnCode, children: c }) => {
+        const match =
+          typeof cnCode === "string"
+            ? /language-([\w#+-]+)/.exec(cnCode)
+            : null;
+        const block = Boolean(match) || String(c).includes("\n");
+        if (!block) {
+          const raw = textFromChildren(c).replace(/\n$/, "").trim();
+          const card = renderPathOrUrl(raw);
+          if (card) return card;
+          return <code className="chat-md__inline-code">{paint(c)}</code>;
+        }
+        return (
+          <CodeBlock
+            language={match?.[1] || "text"}
+            wrapLabel={tr("chat.codeWrap")}
+            unwrapLabel={tr("chat.codeUnwrap")}
+            copyLabel={tr("message.copy")}
+          >
+            {c as ReactNode}
+          </CodeBlock>
+        );
+      },
+      img: ({ src, alt }) => {
+        if (!src || typeof src !== "string") return null;
+        const card = renderPathOrUrl(
+          src,
+          typeof alt === "string" ? alt : undefined,
+        );
+        if (card) return card;
+        const viewable =
+          isHttpUrl(src) ||
+          src.startsWith("data:") ||
+          (isRealLocalAbsolutePath(src) && isPlausibleLocalMediaAbs(src));
+        if (!viewable) return null;
+        return (
+          <ImageUi
+            className="md-body__img md-body__img--card"
+            src={src}
+            alt={typeof alt === "string" ? alt : ""}
+            path={
+              isRealLocalAbsolutePath(src) && isPlausibleLocalMediaAbs(src)
+                ? src
+                : undefined
+            }
+            labels={imageLabels}
+          />
+        );
+      },
+    };
+  }, [
+    qFind,
+    findActiveOccurrence,
+    findOccurrenceBase,
+    pathCards,
+    projectPath,
+    imagePathMap,
+    fileLabels,
+    onOpenError,
+    onOpenResource,
+    onOpenExternalLink,
+    gallery,
+    imageLabels,
+    videoLabels,
+    locale,
+    tr,
+  ]);
 
   return (
     <div
@@ -464,117 +669,8 @@ export const MarkdownChat = memo(function MarkdownChat({
       )}
     >
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          p: ({ children: c }) => <p>{paint(c)}</p>,
-          li: ({ children: c }) => <li>{paint(c)}</li>,
-          strong: ({ children: c }) => <strong>{paint(c)}</strong>,
-          em: ({ children: c }) => <em>{paint(c)}</em>,
-          h1: ({ children: c }) => <h1>{paint(c)}</h1>,
-          h2: ({ children: c }) => <h2>{paint(c)}</h2>,
-          h3: ({ children: c }) => <h3>{paint(c)}</h3>,
-          h4: ({ children: c }) => <h4>{paint(c)}</h4>,
-          blockquote: ({ children: c }) => (
-            <blockquote>{paint(c)}</blockquote>
-          ),
-          td: ({ children: c }) => <td>{paint(c)}</td>,
-          th: ({ children: c }) => <th>{paint(c)}</th>,
-          a: ({ href, children: c }) => {
-            const text = textFromChildren(c).trim();
-            const hrefStr = typeof href === "string" ? href : "";
-            // Prefer app-controlled external open (Tauri shell + optional confirm)
-            // over path cards / target=_blank for absolute http(s) links.
-            if (onOpenExternalLink && isExternalHttpUrl(hrefStr)) {
-              return (
-                <a
-                  className="chat-md__link"
-                  href={hrefStr}
-                  rel="noreferrer noopener"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    onOpenExternalLink(hrefStr);
-                  }}
-                >
-                  {paint(c)}
-                </a>
-              );
-            }
-            const card =
-              (hrefStr && renderPathOrUrl(hrefStr, text)) ||
-              (text && text !== hrefStr ? renderPathOrUrl(text) : null);
-            if (card) return card;
-            return (
-              <a
-                className="chat-md__link"
-                href={href}
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                {paint(c)}
-              </a>
-            );
-          },
-          pre: ({ children: c }) => <>{c}</>,
-          code: ({ className: cnCode, children: c }) => {
-            const match =
-              typeof cnCode === "string"
-                ? /language-([\w#+-]+)/.exec(cnCode)
-                : null;
-            const block = Boolean(match) || String(c).includes("\n");
-            if (!block) {
-              const raw = textFromChildren(c).replace(/\n$/, "").trim();
-              const card = renderPathOrUrl(raw);
-              if (card) return card;
-              return (
-                <code className="chat-md__inline-code">{paint(c)}</code>
-              );
-            }
-            return (
-              <CodeBlock
-                language={match?.[1] || "text"}
-                wrapLabel={tr("chat.codeWrap")}
-                unwrapLabel={tr("chat.codeUnwrap")}
-                copyLabel={tr("message.copy")}
-              >
-                {c as ReactNode}
-              </CodeBlock>
-            );
-          },
-          table: ({ children: c }) => (
-            <div className="chat-md__table-wrap">
-              <table>{c}</table>
-            </div>
-          ),
-          hr: () => null,
-          img: ({ src, alt }) => {
-            if (!src || typeof src !== "string") return null;
-            const card = renderPathOrUrl(
-              src,
-              typeof alt === "string" ? alt : undefined,
-            );
-            if (card) return card;
-            // Unresolved relative / site-root: never mount a dead ImageUi
-            // (that painted the alt as an empty 150px card and never recovered).
-            const viewable =
-              isHttpUrl(src) ||
-              src.startsWith("data:") ||
-              (isRealLocalAbsolutePath(src) && isPlausibleLocalMediaAbs(src));
-            if (!viewable) return null;
-            return (
-              <ImageUi
-                className="md-body__img md-body__img--card"
-                src={src}
-                alt={typeof alt === "string" ? alt : ""}
-                path={
-                  isRealLocalAbsolutePath(src) && isPlausibleLocalMediaAbs(src)
-                    ? src
-                    : undefined
-                }
-                labels={imageLabels}
-              />
-            );
-          },
-        }}
+        remarkPlugins={MARKDOWN_CHAT_REMARK_PLUGINS}
+        components={components}
       >
         {painted}
       </ReactMarkdown>


### PR DESCRIPTION
## Summary

`MarkdownChat` used to pass a new `remarkPlugins` array and `components` object on every stream tick, which remounts the markdown tree. `remark-gfm` and leaf tags (`p` / headings / table / …) are now module-level. Path, code, and image handlers sit in `useMemo`. Find-in-chat still wraps leaves when a query is active.

Fixes #795

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `pnpm exec vitest run src/components/lobe-chat/MarkdownChat.test.tsx`
- [x] `pnpm exec eslint src/components/lobe-chat/MarkdownChat.tsx`
- [ ] Stream a long answer: code fences and path cards should not flash remount
- [ ] CI green

## Checklist

- [x] Targeted vitest + eslint
- [x] `pnpm typecheck` (`tsc -b` passed on this branch)
- [x] No new i18n keys
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
- Independent of #788 / #789 / #791 / #792. Does not touch AppWorkbench.
