### PR TITLE
perf(ui): honor stream-perf by pausing wallpaper video and dropping blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Stream-perf actually drops wallpaper GPU cost**: `html[data-stream-perf="1"]` now turns off wallpaper sidebar/settings blur and pauses wallpaper video for the live turn (the flag already existed; CSS/JS did not honor it).
 - **Streaming markdown keeps a stable ReactMarkdown component map**: `remarkPlugins` and leaf tags are module-level; path/code/img handlers memoize so a token tick does not remount the tree.
 - **Streamdown CSS no longer loads at boot**: Chat uses `MarkdownChat`, not Streamdown. Styles move onto the unused `MessageResponse` module so a later import still looks right.
 - **Vendor JS split for markdown / TipTap / xterm**: Vite emits separate chunks so those stacks can cache independently of the app shell (and drop off first paint once their call sites are lazy).
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **流式性能模式真正减壁纸 GPU**：`html[data-stream-perf="1"]` 会关掉壁纸侧栏/设置毛玻璃，并暂停壁纸视频（旗标早就有，CSS/JS 之前没接上）。
 - **流式 markdown 不再每跳一次 token 换一套 components**：`remarkPlugins` 和叶子标签提到模块级；路径/代码/图片处理器 memo，避免 ReactMarkdown 整树重挂。
 - **启动不再加载 Streamdown CSS**：聊天走 `MarkdownChat`，不走 Streamdown。样式挪到未接入的 `MessageResponse`，以后真用到时才会带上。
 - **markdown / TipTap / xterm 拆成独立 JS chunk**：Vite 单独打包这三坨，壳改动不再带着重库一起失效；后续 lazy 后它们可以离开首屏。

--- a/src/components/WallpaperMediaLayer.tsx
+++ b/src/components/WallpaperMediaLayer.tsx
@@ -24,6 +24,10 @@ import {
   wallpaperMediaLayout,
   type WallpaperFocus,
 } from "@/lib/themeSkin";
+import {
+  readStreamPerfFlag,
+  shouldPlayWallpaperVideo,
+} from "@/lib/streamRenderPolicy";
 
 export type WallpaperMediaSize = { w: number; h: number };
 
@@ -194,26 +198,38 @@ export function WallpaperMediaLayer({
     return undefined;
   }, [kind, clip, url]);
 
-  // Pause wallpaper video while the window is hidden (save decode + avoid
-  // thrashing media pipelines when the user Cmd-Tabs away and back).
+  // Pause wallpaper video while hidden or while stream-perf is on (live turn).
   useEffect(() => {
     if (kind !== "video") return;
-    const onVis = () => {
+    const apply = () => {
       const el = mediaRef.current;
       if (!(el instanceof HTMLVideoElement)) return;
-      if (document.visibilityState === "hidden") {
-        try {
-          if (!el.paused) el.pause();
-        } catch {
-          /* ignore */
-        }
+      const play = shouldPlayWallpaperVideo({
+        visibilityState: document.visibilityState,
+        streamPerf: readStreamPerfFlag(document.documentElement.dataset),
+      });
+      if (play) {
+        void el.play().catch(() => {});
         return;
       }
-      // Resume muted autoplay wallpaper when visible again.
-      void el.play().catch(() => {});
+      try {
+        if (!el.paused) el.pause();
+      } catch {
+        /* ignore */
+      }
     };
-    document.addEventListener("visibilitychange", onVis);
-    return () => document.removeEventListener("visibilitychange", onVis);
+    apply();
+    document.addEventListener("visibilitychange", apply);
+    const root = document.documentElement;
+    const obs = new MutationObserver(apply);
+    obs.observe(root, {
+      attributes: true,
+      attributeFilter: ["data-stream-perf"],
+    });
+    return () => {
+      document.removeEventListener("visibilitychange", apply);
+      obs.disconnect();
+    };
   }, [kind, url]);
 
   const layout =

--- a/src/lib/streamRenderPolicy.test.ts
+++ b/src/lib/streamRenderPolicy.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   CHAT_VIRTUALIZE_THRESHOLD_PERF,
+  readStreamPerfFlag,
   resolveStreamFlushMs,
   resolveStreamMarkdownParseMs,
   resolveStreamOverscanScale,
   resolveMarkdownPaintSource,
   resolveTranscriptContentNotifyMs,
+  shouldPlayWallpaperVideo,
   shouldUsePlainStreamBody,
   STREAM_COALESCE_FLUSH_MS,
   STREAM_MARKDOWN_PARSE_MS,
@@ -76,5 +78,25 @@ describe("streamRenderPolicy", () => {
     expect(resolveTranscriptContentNotifyMs(16)).toBeLessThan(
       TRANSCRIPT_CONTENT_NOTIFY_MS,
     );
+  });
+
+  it("reads html dataset.streamPerf", () => {
+    expect(readStreamPerfFlag(undefined)).toBe(false);
+    expect(readStreamPerfFlag({})).toBe(false);
+    expect(readStreamPerfFlag({ streamPerf: "0" })).toBe(false);
+    expect(readStreamPerfFlag({ streamPerf: "1" })).toBe(true);
+  });
+
+  it("pauses wallpaper video when hidden or stream-perf", () => {
+    expect(shouldPlayWallpaperVideo({})).toBe(true);
+    expect(shouldPlayWallpaperVideo({ visibilityState: "visible" })).toBe(true);
+    expect(shouldPlayWallpaperVideo({ visibilityState: "hidden" })).toBe(false);
+    expect(shouldPlayWallpaperVideo({ streamPerf: true })).toBe(false);
+    expect(
+      shouldPlayWallpaperVideo({
+        visibilityState: "visible",
+        streamPerf: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/lib/streamRenderPolicy.ts
+++ b/src/lib/streamRenderPolicy.ts
@@ -122,3 +122,22 @@ export function resolveMarkdownPaintSource(
 ): string {
   return streaming ? throttledSource : liveSource;
 }
+
+/** `html[data-stream-perf]` as written by AppWorkbench during a live turn. */
+export function readStreamPerfFlag(
+  dataset: { streamPerf?: string } | null | undefined,
+): boolean {
+  return dataset?.streamPerf === "1";
+}
+
+/**
+ * Wallpaper `<video>` should decode only when the window is visible and
+ * stream-perf is off. CSS drops sidebar blur separately.
+ */
+export function shouldPlayWallpaperVideo(opts: {
+  visibilityState?: string;
+  streamPerf?: boolean;
+}): boolean {
+  if ((opts.visibilityState ?? "visible") === "hidden") return false;
+  return !opts.streamPerf;
+}

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -126,6 +126,20 @@ html[data-wallpaper="1"] .platform-mac .settings-page__nav {
     saturate(1.25);
 }
 
+/*
+ * Live turn: AppWorkbench sets html[data-stream-perf="1"].
+ * Frosted wallpaper panes on a playing video are a WebView2 GPU sink.
+ * Video pause is JS (WallpaperMediaLayer).
+ */
+html[data-stream-perf="1"][data-wallpaper="1"] .sidebar,
+html[data-stream-perf="1"][data-wallpaper="1"] .settings-page__nav,
+html[data-stream-perf="1"][data-wallpaper="1"] .platform-win .settings-page__nav,
+html[data-stream-perf="1"][data-wallpaper="1"] .platform-other .settings-page__nav,
+html[data-stream-perf="1"][data-wallpaper="1"] .platform-mac .settings-page__nav {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
 html[data-wallpaper="1"] .settings-page__content,
 html[data-wallpaper="1"].platform-mac .settings-page__content,
 html[data-wallpaper="1"].platform-mac[data-theme="light"] .settings-page__content {

--- a/src/styles/skins.streamPerf.test.ts
+++ b/src/styles/skins.streamPerf.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe("stream-perf wallpaper CSS", () => {
+  it("drops wallpaper pane blur while data-stream-perf is on", () => {
+    const css = readFileSync(join(here, "skins.css"), "utf8");
+    expect(css).toContain(
+      'html[data-stream-perf="1"][data-wallpaper="1"] .sidebar',
+    );
+    expect(css).toContain(
+      'html[data-stream-perf="1"][data-wallpaper="1"] .settings-page__nav',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`html[data-stream-perf]` was already set during a live turn, but no CSS/JS used it. This wires it:

- Wallpaper sidebar / settings nav `backdrop-filter` off while the flag is on.
- Wallpaper `<video>` pauses (same path as hide-window pause) and resumes when the turn settles.

Fixes #796

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `pnpm exec vitest run src/lib/streamRenderPolicy.test.ts src/styles/skins.streamPerf.test.ts`
- [ ] Set a video wallpaper, send a long turn: video should freeze and the sidebar should lose frost; it should resume when idle
- [ ] CI green

## Checklist

- [x] Targeted vitest
- [x] No new i18n keys
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
- Independent of #788–#790 / #792. Does not touch AppWorkbench (the dataset write is already there).
