### PR TITLE
perf(host): write session journals as compact JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Session journals write compact JSON**: `messages.json` mid-stream flushes rewrite the whole file; pretty-print indent was extra disk/CPU on long chats. Existing pretty files still load.
 - **Stream-perf actually drops wallpaper GPU cost**: `html[data-stream-perf="1"]` now turns off wallpaper sidebar/settings blur and pauses wallpaper video for the live turn (the flag already existed; CSS/JS did not honor it).
 - **Streaming markdown keeps a stable ReactMarkdown component map**: `remarkPlugins` and leaf tags are module-level; path/code/img handlers memoize so a token tick does not remount the tree.
 - **Streamdown CSS no longer loads at boot**: Chat uses `MarkdownChat`, not Streamdown. Styles move onto the unused `MessageResponse` module so a later import still looks right.
@@ -27,6 +28,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **会话 journal 改写紧凑 JSON**：流式落盘会重写整份 `messages.json`，pretty 缩进在长对话上白烧磁盘。旧的 pretty 文件仍能读。
 - **流式性能模式真正减壁纸 GPU**：`html[data-stream-perf="1"]` 会关掉壁纸侧栏/设置毛玻璃，并暂停壁纸视频（旗标早就有，CSS/JS 之前没接上）。
 - **流式 markdown 不再每跳一次 token 换一套 components**：`remarkPlugins` 和叶子标签提到模块级；路径/代码/图片处理器 memo，避免 ReactMarkdown 整树重挂。
 - **启动不再加载 Streamdown CSS**：聊天走 `MarkdownChat`，不走 Streamdown。样式挪到未接入的 `MessageResponse`，以后真用到时才会带上。

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -2077,7 +2077,9 @@ pub fn load_messages(session_id: &str) -> Vec<ChatMessageStored> {
 }
 
 fn write_messages_locked(path: &Path, messages: &[ChatMessageStored]) -> Result<(), String> {
-    let serialized = serde_json::to_string_pretty(messages).map_err(|e| e.to_string())?;
+    // Compact JSON: mid-stream flushes rewrite the whole journal. Pretty
+    // indent made long chats a disk sink. `from_str` still accepts pretty files.
+    let serialized = serde_json::to_string(messages).map_err(|e| e.to_string())?;
     crate::store_lock::write_bytes_replace(path, serialized.as_bytes())
 }
 
@@ -4333,6 +4335,42 @@ mod tests {
         let truncated = load_messages(&session.id);
         assert_eq!(truncated.len(), 1);
         assert_eq!(truncated[0].id, "user-1");
+
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn journal_writes_compact_json() {
+        let _env = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-store-journal-compact-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = ensure_app_dirs();
+
+        let session =
+            create_session(None, Some("compact journal".into()), false).expect("session");
+        let row = stored_msg("u1", "user", "hello", None);
+        save_messages(&session.id, &[row.clone()]).expect("save");
+        let path = session_dir(&session.id).join("messages.json");
+        let raw = fs::read_to_string(&path).expect("read journal");
+        assert!(raw.starts_with('['), "journal is a JSON array");
+        assert!(!raw.contains("\n  "), "pretty indent must not appear");
+        let parsed: Vec<ChatMessageStored> =
+            serde_json::from_str(&raw).expect("compact journal parses");
+        assert_eq!(parsed[0].id, "u1");
+
+        fs::write(&path, serde_json::to_string_pretty(&[row]).unwrap()).unwrap();
+        let loaded = load_messages(&session.id);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "u1");
 
         std::env::remove_var("GROK_APP_HOME");
         let _ = fs::remove_dir_all(&tmp);

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -4355,8 +4355,7 @@ mod tests {
         std::env::set_var("GROK_APP_HOME", &tmp);
         let _ = ensure_app_dirs();
 
-        let session =
-            create_session(None, Some("compact journal".into()), false).expect("session");
+        let session = create_session(None, Some("compact journal".into()), false).expect("session");
         let row = stored_msg("u1", "user", "hello", None);
         save_messages(&session.id, &[row.clone()]).expect("save");
         let path = session_dir(&session.id).join("messages.json");


### PR DESCRIPTION
## Summary

`messages.json` is rewritten on a throttle during streaming. Pretty-print indent made long chats a disk/CPU sink. Writes are now compact JSON. Existing pretty files still load.

Fixes #797

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `cargo test --lib journal_writes_compact_json` compiled; this host still fails to *run* test binaries with `STATUS_ENTRYPOINT_NOT_FOUND` (same as unchanged store tests)
- [ ] Open a session that already has a pretty `messages.json` — it should still render. After the next turn, the file should be one compact array
- [ ] CI green (`cargo test`)

## Checklist

- [x] Host compiles; new unit test added
- [x] No UI strings / i18n
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- Sessions index and other store files stay pretty (small).
- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
- Independent of #788–#791. Rust-only besides CHANGELOG.
