### PR TITLE
perf(pet): poll the cursor less often when the overlay is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Pet cursor watch idles when hidden**: Overlay pointer polling stays ~64ms while visible or dragging, and sleeps 500ms when the pet is hidden or disabled.
 - **Session journals write compact JSON**: `messages.json` mid-stream flushes rewrite the whole file; pretty-print indent was extra disk/CPU on long chats. Existing pretty files still load.
 - **Stream-perf actually drops wallpaper GPU cost**: `html[data-stream-perf="1"]` now turns off wallpaper sidebar/settings blur and pauses wallpaper video for the live turn (the flag already existed; CSS/JS did not honor it).
 - **Streaming markdown keeps a stable ReactMarkdown component map**: `remarkPlugins` and leaf tags are module-level; path/code/img handlers memoize so a token tick does not remount the tree.
@@ -28,6 +29,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **桌宠隐藏时降低光标轮询**：可见或拖动时仍约 64ms；隐藏/关闭时睡 500ms。
 - **会话 journal 改写紧凑 JSON**：流式落盘会重写整份 `messages.json`，pretty 缩进在长对话上白烧磁盘。旧的 pretty 文件仍能读。
 - **流式性能模式真正减壁纸 GPU**：`html[data-stream-perf="1"]` 会关掉壁纸侧栏/设置毛玻璃，并暂停壁纸视频（旗标早就有，CSS/JS 之前没接上）。
 - **流式 markdown 不再每跳一次 token 换一套 components**：`remarkPlugins` 和叶子标签提到模块级；路径/代码/图片处理器 memo，避免 ReactMarkdown 整树重挂。

--- a/src-tauri/src/pet_window.rs
+++ b/src-tauri/src/pet_window.rs
@@ -28,6 +28,22 @@ use tauri::{
 pub const PET_WINDOW_LABEL: &str = "pet";
 const PREFS_FILE: &str = "pet-prefs.json";
 
+/// Cursor/hit poll while the overlay is on screen or being dragged.
+pub const PET_CURSOR_WATCH_ACTIVE_MS: u64 = 64;
+/// Hidden / disabled overlay — do not wake every frame.
+pub const PET_CURSOR_WATCH_IDLE_MS: u64 = 500;
+
+/// Sleep between pet cursor-watch ticks.
+pub fn pet_cursor_watch_sleep_ms(want_show: bool, visible: bool, dragging: bool) -> u64 {
+    if dragging {
+        return PET_CURSOR_WATCH_ACTIVE_MS;
+    }
+    if !want_show || !visible {
+        return PET_CURSOR_WATCH_IDLE_MS;
+    }
+    PET_CURSOR_WATCH_ACTIVE_MS
+}
+
 static DRAGGING: AtomicBool = AtomicBool::new(false);
 static MENU_OPEN: AtomicBool = AtomicBool::new(false);
 static WATCH_STARTED: AtomicBool = AtomicBool::new(false);
@@ -1049,7 +1065,19 @@ pub fn start_cursor_watch(app: AppHandle) {
     tauri::async_runtime::spawn(async move {
         let wayland = pet_wayland_display();
         loop {
-            tokio::time::sleep(Duration::from_millis(64)).await;
+            let want = WANT_SHOW.load(Ordering::SeqCst);
+            let dragging = DRAGGING.load(Ordering::Relaxed);
+            let visible = app
+                .get_webview_window(PET_WINDOW_LABEL)
+                .and_then(|w| w.is_visible().ok())
+                .unwrap_or(false);
+            tokio::time::sleep(Duration::from_millis(pet_cursor_watch_sleep_ms(
+                want, visible, dragging,
+            )))
+            .await;
+            if !want && !dragging {
+                continue;
+            }
             let Some(win) = app.get_webview_window(PET_WINDOW_LABEL) else {
                 continue;
             };
@@ -1367,6 +1395,30 @@ pub fn pet_set_hit_chrome(chrome: PetHitChromeIn) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cursor_watch_sleeps_longer_when_hidden() {
+        assert_eq!(
+            pet_cursor_watch_sleep_ms(true, true, false),
+            PET_CURSOR_WATCH_ACTIVE_MS
+        );
+        assert_eq!(
+            pet_cursor_watch_sleep_ms(true, true, true),
+            PET_CURSOR_WATCH_ACTIVE_MS
+        );
+        assert_eq!(
+            pet_cursor_watch_sleep_ms(false, false, false),
+            PET_CURSOR_WATCH_IDLE_MS
+        );
+        assert_eq!(
+            pet_cursor_watch_sleep_ms(true, false, false),
+            PET_CURSOR_WATCH_IDLE_MS
+        );
+        assert_eq!(
+            pet_cursor_watch_sleep_ms(false, false, true),
+            PET_CURSOR_WATCH_ACTIVE_MS
+        );
+    }
 
     #[test]
     fn pet_init_script_hides_boot_gate() {


### PR DESCRIPTION
## Summary

Pet overlay cursor watch slept 64ms forever. It now stays ~64ms while visible or dragging, and sleeps 500ms when the pet is hidden or disabled.

Fixes #804

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] New `cursor_watch_sleeps_longer_when_hidden` unit test (compile; this host still cannot run Host test binaries)
- [ ] Hide pet: CPU of the watch loop should drop
- [ ] Drag the pet: still 64ms so pointer-up is not missed
- [ ] CI `cargo test`

## Checklist

- [x] Host unit test added
- [x] No UI strings / i18n
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
