### PR TITLE
perf(terminal): coalesce PTY data IPC on a 16ms / 4KiB budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **PTY output is coalesced**: `terminal://data` flushes every 16ms or 4KiB instead of one IPC per 8KiB OS read.
 - **Pet cursor watch idles when hidden**: Overlay pointer polling stays ~64ms while visible or dragging, and sleeps 500ms when the pet is hidden or disabled.
 - **Session journals write compact JSON**: `messages.json` mid-stream flushes rewrite the whole file; pretty-print indent was extra disk/CPU on long chats. Existing pretty files still load.
 - **Stream-perf actually drops wallpaper GPU cost**: `html[data-stream-perf="1"]` now turns off wallpaper sidebar/settings blur and pauses wallpaper video for the live turn (the flag already existed; CSS/JS did not honor it).
@@ -29,6 +30,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **终端 PTY 输出合并发送**：`terminal://data` 每 16ms 或满 4KiB 再发，不再每次 OS read（8KiB）打一次 IPC。
 - **桌宠隐藏时降低光标轮询**：可见或拖动时仍约 64ms；隐藏/关闭时睡 500ms。
 - **会话 journal 改写紧凑 JSON**：流式落盘会重写整份 `messages.json`，pretty 缩进在长对话上白烧磁盘。旧的 pretty 文件仍能读。
 - **流式性能模式真正减壁纸 GPU**：`html[data-stream-perf="1"]` 会关掉壁纸侧栏/设置毛玻璃，并暂停壁纸视频（旗标早就有，CSS/JS 之前没接上）。

--- a/src-tauri/src/pty_host.rs
+++ b/src-tauri/src/pty_host.rs
@@ -7,8 +7,10 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::Path;
+use std::sync::mpsc;
 use std::sync::{Mutex, OnceLock};
 use std::thread;
+use std::time::Duration;
 
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
@@ -17,6 +19,18 @@ use uuid::Uuid;
 
 const EVENT_DATA: &str = "terminal://data";
 const EVENT_EXIT: &str = "terminal://exit";
+
+/// Coalesce window for `terminal://data` (flood of 8KiB reads).
+pub const PTY_DATA_FLUSH_MS: u64 = 16;
+/// Flush once the batch reaches this many UTF-8 bytes.
+pub const PTY_DATA_FLUSH_CHARS: usize = 4096;
+
+pub fn should_flush_pty_data(pending_chars: usize, force: bool) -> bool {
+    if pending_chars == 0 {
+        return false;
+    }
+    force || pending_chars >= PTY_DATA_FLUSH_CHARS
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -203,6 +217,44 @@ pub fn spawn(
 
     let app_r = app.clone();
     let sid_r = sid.clone();
+    let app_emit = app_r.clone();
+    let sid_emit = sid_r.clone();
+    let (tx, rx) = mpsc::channel::<String>();
+    thread::Builder::new()
+        .name(format!("pty-emit-{sid}"))
+        .spawn(move || {
+            let mut batch = String::new();
+            let flush = |batch: &mut String, force: bool| {
+                if !should_flush_pty_data(batch.len(), force) {
+                    return;
+                }
+                if batch.is_empty() {
+                    return;
+                }
+                let data = std::mem::take(batch);
+                let _ = app_emit.emit(
+                    EVENT_DATA,
+                    &PtyDataPayload {
+                        session_id: sid_emit.clone(),
+                        data,
+                    },
+                );
+            };
+            loop {
+                match rx.recv_timeout(Duration::from_millis(PTY_DATA_FLUSH_MS)) {
+                    Ok(chunk) => {
+                        batch.push_str(&chunk);
+                        flush(&mut batch, false);
+                    }
+                    Err(mpsc::RecvTimeoutError::Timeout) => flush(&mut batch, true),
+                    Err(mpsc::RecvTimeoutError::Disconnected) => {
+                        flush(&mut batch, true);
+                        break;
+                    }
+                }
+            }
+        })
+        .map_err(|e| format!("spawn pty emit: {e}"))?;
     thread::Builder::new()
         .name(format!("pty-read-{sid}"))
         .spawn(move || {
@@ -239,26 +291,16 @@ pub fn spawn(
                         if data.is_empty() {
                             continue;
                         }
-                        let _ = app_r.emit(
-                            EVENT_DATA,
-                            &PtyDataPayload {
-                                session_id: sid_r.clone(),
-                                data,
-                            },
-                        );
+                        if tx.send(data).is_err() {
+                            break;
+                        }
                     }
                     Err(_) => break,
                 }
             }
             if !pending.is_empty() {
                 let data = String::from_utf8_lossy(&pending).into_owned();
-                let _ = app_r.emit(
-                    EVENT_DATA,
-                    &PtyDataPayload {
-                        session_id: sid_r.clone(),
-                        data,
-                    },
-                );
+                let _ = tx.send(data);
             }
             // Only remove *this* id — never a later remount (unique UUID).
             if let Ok(mut g) = sessions().lock() {
@@ -334,6 +376,16 @@ mod tests {
 
     fn env_str(cmd: &CommandBuilder, key: &str) -> Option<String> {
         cmd.get_env(key).map(|v| v.to_string_lossy().into_owned())
+    }
+
+    #[test]
+    fn pty_data_flushes_on_size_or_force() {
+        assert!(!should_flush_pty_data(0, false));
+        assert!(!should_flush_pty_data(0, true));
+        assert!(!should_flush_pty_data(16, false));
+        assert!(should_flush_pty_data(16, true));
+        assert!(should_flush_pty_data(PTY_DATA_FLUSH_CHARS, false));
+        assert!(should_flush_pty_data(PTY_DATA_FLUSH_CHARS + 1, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Each PTY `read` used to emit `terminal://data` immediately. A second thread now batches UTF-8 output and flushes every 16ms or 4KiB so a flood of 8KiB OS reads does not hammer the WebView. Keystrokes still flush on the timeout.

Fixes #803

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `should_flush_pty_data` unit test added
- [ ] Side / bottom terminal: typing still appears promptly; `yes` or a long compile should not freeze the main UI
- [ ] CI `cargo test`

## Checklist

- [x] Host unit test added
- [x] No UI strings / i18n
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
