### PR TITLE
perf(session): persist completed tool journal off the ACP pump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Completed tool journal writes leave the ACP pump**: `load_messages` / `save_messages` for finished tools run on `spawn_blocking` so disk IO does not stall later stream tokens.
 - **PTY output is coalesced**: `terminal://data` flushes every 16ms or 4KiB instead of one IPC per 8KiB OS read.
 - **Pet cursor watch idles when hidden**: Overlay pointer polling stays ~64ms while visible or dragging, and sleeps 500ms when the pet is hidden or disabled.
 - **Session journals write compact JSON**: `messages.json` mid-stream flushes rewrite the whole file; pretty-print indent was extra disk/CPU on long chats. Existing pretty files still load.
@@ -30,6 +31,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **完成态 tool journal 不再堵 ACP 泵**：落盘改 `spawn_blocking`，磁盘 IO 不再挡住后续 token。
 - **终端 PTY 输出合并发送**：`terminal://data` 每 16ms 或满 4KiB 再发，不再每次 OS read（8KiB）打一次 IPC。
 - **桌宠隐藏时降低光标轮询**：可见或拖动时仍约 64ms；隐藏/关闭时睡 500ms。
 - **会话 journal 改写紧凑 JSON**：流式落盘会重写整份 `messages.json`，pretty 缩进在长对话上白烧磁盘。旧的 pretty 文件仍能读。

--- a/src-tauri/src/session_manager/events.rs
+++ b/src-tauri/src/session_manager/events.rs
@@ -780,42 +780,19 @@ impl SessionManager {
                         content.push_str(o);
                     }
                     let mid = format!("tool-{tool_call_id}");
-                    // Upsert: replace only when new content is richer (never downgrade
-                    // a Fetch:https://… row to bare "tool" on a sparse completed tick).
-                    let mut msgs = store::load_messages(&app_sid);
-                    if let Some(slot) = msgs.iter_mut().find(|m| m.id == mid) {
-                        if tool_journal_richer(&slot.content, &content) {
-                            slot.content = content.clone();
-                            slot.marker = Some("tool_step".into());
-                            if let Err(e) = store::save_messages(&app_sid, &msgs) {
-                                tracing::error!(
-                                    session = %app_sid,
-                                    tool = %tool_call_id,
-                                    "tool journal update failed: {e}"
-                                );
-                            }
-                        }
-                    } else {
-                        if let Err(e) = store::append_message(
-                            &app_sid,
-                            ChatMessageStored {
-                                id: mid,
-                                role: "tool".into(),
-                                content,
-                                thought: None,
-                                created_at: chrono::Utc::now(),
-                                is_error: matches!(st, "failed" | "error"),
-                                attachments: None,
-                                marker: Some("tool_step".into()),
-                            },
-                        ) {
-                            tracing::error!(
-                                session = %app_sid,
-                                tool = %tool_call_id,
-                                "tool journal append failed: {e}"
-                            );
-                        }
-                    }
+                    let is_error = matches!(st, "failed" | "error");
+                    let app_sid_j = app_sid.clone();
+                    let tool_call_id_j = tool_call_id.clone();
+                    // Disk RMW must not stall the ACP pump (later stream tokens).
+                    tauri::async_runtime::spawn_blocking(move || {
+                        persist_completed_tool_journal(
+                            app_sid_j,
+                            tool_call_id_j,
+                            mid,
+                            content,
+                            is_error,
+                        );
+                    });
                 }
             }
             AcpEvent::ToolOpenReleased { tool_call_id } => {
@@ -1278,5 +1255,48 @@ impl SessionManager {
                 );
             }
         }
+    }
+}
+
+fn persist_completed_tool_journal(
+    app_sid: String,
+    tool_call_id: String,
+    mid: String,
+    content: String,
+    is_error: bool,
+) {
+    let mut msgs = store::load_messages(&app_sid);
+    if let Some(slot) = msgs.iter_mut().find(|m| m.id == mid) {
+        if tool_journal_richer(&slot.content, &content) {
+            slot.content = content;
+            slot.marker = Some("tool_step".into());
+            if let Err(e) = store::save_messages(&app_sid, &msgs) {
+                tracing::error!(
+                    session = %app_sid,
+                    tool = %tool_call_id,
+                    "tool journal update failed: {e}"
+                );
+            }
+        }
+        return;
+    }
+    if let Err(e) = store::append_message(
+        &app_sid,
+        ChatMessageStored {
+            id: mid,
+            role: "tool".into(),
+            content,
+            thought: None,
+            created_at: chrono::Utc::now(),
+            is_error,
+            attachments: None,
+            marker: Some("tool_step".into()),
+        },
+    ) {
+        tracing::error!(
+            session = %app_sid,
+            tool = %tool_call_id,
+            "tool journal append failed: {e}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Finished tool rows used to `load_messages` + `save_messages` on the ACP event pump, blocking later stream tokens on disk IO. The journal upsert now runs on `spawn_blocking`. The existing store file lock still serializes writes.

Fixes #802

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [ ] Long tool-heavy turn: tokens keep flowing when tools complete
- [ ] Reload the session: completed tool steps still appear
- [ ] CI `cargo test`

## Checklist

- [x] No UI strings / i18n
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
