### PR TITLE
perf(chat): keep activity VirtualList while live tools run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Live tool title rows keep activity VirtualList**: Only streaming thought bodies (variable height) drop windowing. Running 36px tool titles no longer dump the whole step list into the DOM.
 - **Weaving tools no longer clones every chat row**: History message object identity is kept so memoized transcript rows survive stream ticks. Row memo no longer busts on a new `wovenMessages` array.
 - **Completed tool journal writes leave the ACP pump**: `load_messages` / `save_messages` for finished tools run on `spawn_blocking` so disk IO does not stall later stream tokens.
 - **PTY output is coalesced**: `terminal://data` flushes every 16ms or 4KiB instead of one IPC per 8KiB OS read.
@@ -32,6 +33,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **进行中的 tool 标题行仍走活动列表虚拟化**：只有流式 thought（变高）才关掉窗口化；36px 的 running tool 不再把整表打进 DOM。
 - **织入 tool 不再克隆整份 transcript**：历史消息保持同一对象引用，流式时 memo 行能活下来；行比较也不再被新的 `wovenMessages` 数组打穿。
 - **完成态 tool journal 不再堵 ACP 泵**：落盘改 `spawn_blocking`，磁盘 IO 不再挡住后续 token。
 - **终端 PTY 输出合并发送**：`terminal://data` 每 16ms 或满 4KiB 再发，不再每次 OS read（8KiB）打一次 IPC。

--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -538,17 +538,16 @@ export function GrokActivitySteps({
     },
     [],
   );
-  const liveBodyCount = steps.reduce((n, s) => {
-    if (s.type === "speech") return n;
-    if (s.type === "thought") return n + (s.streaming && s.text.trim() ? 1 : 0);
-    return n + ("running" in s && s.running ? 1 : 0);
+  const liveThoughtCount = steps.reduce((n, s) => {
+    if (s.type !== "thought") return n;
+    return n + (s.streaming && s.text.trim() ? 1 : 0);
   }, 0);
   const virtualize =
     !steps.some((s) => s.type === "speech") &&
     shouldVirtualizeActivityWithExpand(
       total,
       expandState.expandedKeys.size,
-      liveBodyCount,
+      liveThoughtCount,
     );
   const lastKey = total > 0 ? steps[total - 1]!.key : null;
   const followKey = live ? liveActivityFollowKey(steps) : lastKey;

--- a/src/lib/grokActivityVirtualize.test.ts
+++ b/src/lib/grokActivityVirtualize.test.ts
@@ -91,7 +91,7 @@ describe("grokActivityVirtualize", () => {
     );
   });
 
-  it("live tool bodies leave VirtualList even before expand policy runs", () => {
+  it("streaming thought bodies leave VirtualList; running tool titles do not", () => {
     const stepCount = GROK_ACTIVITY_VIRTUALIZE_THRESHOLD + 5;
     expect(shouldVirtualizeActivityWithExpand(stepCount, 0, 0)).toBe(true);
     expect(shouldVirtualizeActivityWithExpand(stepCount, 0, 1)).toBe(false);

--- a/src/lib/grokActivityVirtualize.ts
+++ b/src/lib/grokActivityVirtualize.ts
@@ -34,19 +34,22 @@ export function shouldVirtualizeGrokActivitySteps(stepCount: number): boolean {
 }
 
 /**
- * Fixed VirtualList row height cannot host expanded detail.
- * Leave windowing whenever any step is expanded (parent owns expanded keys so
+ * Fixed VirtualList row height cannot host expanded detail or a streaming
+ * thought body. Running tool *titles* stay 36px — they must not disable
+ * windowing (that was dumping 20–200 live steps into the DOM).
+ *
+ * Leave windowing when any step is expanded (parent owns expanded keys so
  * the virtual→map remount does not wipe open state).
  */
 export function shouldVirtualizeActivityWithExpand(
   stepCount: number,
   expandedKeyCount: number,
-  liveBodyCount = 0,
+  liveThoughtCount = 0,
 ): boolean {
   return (
     shouldVirtualizeGrokActivitySteps(stepCount) &&
     expandedKeyCount === 0 &&
-    liveBodyCount === 0
+    liveThoughtCount === 0
   );
 }
 


### PR DESCRIPTION
## Summary

`shouldVirtualizeActivityWithExpand` treated any live tool body as a reason to map every activity step. Running tool titles are still 36px, so they now keep VirtualList. Only streaming thought bodies (variable height) drop windowing.

Fixes #801

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `pnpm exec vitest run src/lib/grokActivityVirtualize.test.ts` (9 passed)
- [ ] Tool-heavy turn with many bash steps: activity list stays windowed
- [ ] Streaming thought still expands / mapped layout
- [ ] CI green

## Checklist

- [x] Targeted vitest
- [x] No new i18n keys
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
