### PR TITLE
perf(chat): keep history message identity when weaving tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Weaving tools no longer clones every chat row**: History message object identity is kept so memoized transcript rows survive stream ticks. Row memo no longer busts on a new `wovenMessages` array.
 - **Completed tool journal writes leave the ACP pump**: `load_messages` / `save_messages` for finished tools run on `spawn_blocking` so disk IO does not stall later stream tokens.
 - **PTY output is coalesced**: `terminal://data` flushes every 16ms or 4KiB instead of one IPC per 8KiB OS read.
 - **Pet cursor watch idles when hidden**: Overlay pointer polling stays ~64ms while visible or dragging, and sleeps 500ms when the pet is hidden or disabled.
@@ -31,6 +32,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **织入 tool 不再克隆整份 transcript**：历史消息保持同一对象引用，流式时 memo 行能活下来；行比较也不再被新的 `wovenMessages` 数组打穿。
 - **完成态 tool journal 不再堵 ACP 泵**：落盘改 `spawn_blocking`，磁盘 IO 不再挡住后续 token。
 - **终端 PTY 输出合并发送**：`terminal://data` 每 16ms 或满 4KiB 再发，不再每次 OS read（8KiB）打一次 IPC。
 - **桌宠隐藏时降低光标轮询**：可见或拖动时仍约 64ms；隐藏/关闭时睡 500ms。

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -860,7 +860,9 @@ function transcriptRowPropsEqual(
   if (a.regenerateModelId !== b.regenerateModelId) return false;
   if (a.activeAssistantId !== b.activeAssistantId) return false;
   if (a.liveTool !== b.liveTool) return false;
-  if (a.wovenMessages !== b.wovenMessages) return false;
+  // Do not compare wovenMessages by array identity — weave used to clone every
+  // row on each stream notify and bust all memos. History `m` refs + toolInlined
+  // via `a.m` are enough; the streaming assistant already has a new `m`.
   if (a.standaloneToolGroups !== b.standaloneToolGroups) return false;
   if (a.findQuery !== b.findQuery) return false;
   if (a.findHitMessageIds !== b.findHitMessageIds) return false;

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1653,6 +1653,21 @@ describe("session projection", () => {
     expect(segs[5]).toMatchObject({ kind: "content", text: " final" });
   });
 
+  it("weaveToolsIntoAssistantSegments keeps history row identity", () => {
+    const user = { id: "u1", role: "user" as const, content: "q" };
+    const asst = {
+      id: "a1",
+      role: "assistant" as const,
+      content: "done",
+      streaming: false,
+      segments: [{ kind: "content" as const, text: "done" }],
+    };
+    const laterUser = { id: "u2", role: "user" as const, content: "next" };
+    const woven = weaveToolsIntoAssistantSegments([user, asst, laterUser]);
+    expect(woven[0]).toBe(user);
+    expect(woven[2]).toBe(laterUser);
+  });
+
   it("weaveToolsIntoAssistantSegments keeps finished live interleave without remount", () => {
     // Live turn left thought/tool interleaved with content; streaming=false.
     const woven = weaveToolsIntoAssistantSegments([

--- a/src/lib/session/tools.ts
+++ b/src/lib/session/tools.ts
@@ -417,11 +417,9 @@ export function weaveToolsIntoAssistantSegments(
   // a single message (final fragment as body, earlier ones folded). Runs
   // before tool weaving so multi-assistant turns become single-assistant.
   messages = mergeAssistantFragments(messages);
-  const out = messages.map((m) =>
-    m.segments
-      ? { ...m, segments: m.segments.map((s) => ({ ...s })) as MessageSegment[] }
-      : { ...m },
-  );
+  // Keep history row identity so memoized transcript rows survive stream ticks.
+  // Only assistants we actually rewrite are replaced below.
+  const out = messages.slice();
 
   // Walk by user turns so tools before/after assistant all attach to that turn.
   let i = 0;


### PR DESCRIPTION
## Summary

`weaveToolsIntoAssistantSegments` cloned every chat row on each stream notify, so memoized transcript rows failed `a.m !== b.m`. It now slices the array and only replaces assistants it actually rewrites. Row memo no longer busts on a new `wovenMessages` array.

Fixes #800

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `pnpm exec vitest run src/lib/session.test.ts -t weaveToolsIntoAssistantSegments` (6 passed, including history identity)
- [ ] Stream a long tool-heavy answer: older bubbles should not remount
- [ ] CI green

## Checklist

- [x] Targeted vitest
- [x] No new i18n keys
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
