### PR TITLE
perf(ui): lazy-load bottom terminal, project-rules TipTap, and lightbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Heavy surfaces leave first paint**: Bottom terminal (xterm) mounts after first open; project-rules TipTap and the image lightbox load on demand.
 - **Live tool title rows keep activity VirtualList**: Only streaming thought bodies (variable height) drop windowing. Running 36px tool titles no longer dump the whole step list into the DOM.
 - **Weaving tools no longer clones every chat row**: History message object identity is kept so memoized transcript rows survive stream ticks. Row memo no longer busts on a new `wovenMessages` array.
 - **Completed tool journal writes leave the ACP pump**: `load_messages` / `save_messages` for finished tools run on `spawn_blocking` so disk IO does not stall later stream tokens.
@@ -33,6 +34,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **重表面离开首屏**：底栏终端（xterm）第一次打开才挂载；项目规则 TipTap 和图片灯箱按需加载。
 - **进行中的 tool 标题行仍走活动列表虚拟化**：只有流式 thought（变高）才关掉窗口化；36px 的 running tool 不再把整表打进 DOM。
 - **织入 tool 不再克隆整份 transcript**：历史消息保持同一对象引用，流式时 memo 行能活下来；行比较也不再被新的 `wovenMessages` 数组打穿。
 - **完成态 tool journal 不再堵 ACP 泵**：落盘改 `spawn_blocking`，磁盘 IO 不再挡住后续 token。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -936,7 +936,7 @@ import {
 } from "@/lib/sideFloatComposer";
 import { applySideContextOpen } from "@/lib/sideContextOpen";
 import { resolveSidePathDeepLink } from "@/lib/sidePathDeepLink";
-import { ProjectRulesModal } from "@/components/ProjectRulesModal";
+
 import { PromptHistoryClearModal } from "@/components/workbench-modals/PromptHistoryClearModal";
 import { ArchiveAgeConfirmModal } from "@/components/workbench-modals/ArchiveAgeConfirmModal";
 import { WorktreeCreateModal } from "@/components/workbench-modals/WorktreeCreateModal";
@@ -1036,6 +1036,14 @@ const SetupWizard = lazy(async () => {
   const m = await import("@/components/SetupWizard");
   return { default: m.SetupWizard };
 });
+const BottomTerminal = lazy(async () => {
+  const m = await import("@/components/bottom-terminal/BottomTerminal");
+  return { default: m.BottomTerminal };
+});
+const ProjectRulesModal = lazy(async () => {
+  const m = await import("@/components/ProjectRulesModal");
+  return { default: m.ProjectRulesModal };
+});
 import { dispatchCollapseAllActivity } from "@/lib/collapseAllActivity";
 import {
   installDialogFocus,
@@ -1106,10 +1114,7 @@ import { useSidebarSessionMoveDrag } from "@/hooks/useSidebarSessionMoveDrag";
 import { SESSION_DROP_ORPHAN } from "@/lib/sessionMoveProject";
 import { useSideWorkbenchProjectIsolation } from "@/hooks/useSideWorkbenchProjectIsolation";
 import { useBottomTerminal } from "@/hooks/useBottomTerminal";
-import {
-  BottomTerminal,
-  BottomTerminalToggle,
-} from "@/components/bottom-terminal";
+import { BottomTerminalToggle } from "@/components/bottom-terminal/BottomTerminalToggle";
 import { useProjectSpaces } from "@/hooks/useProjectSpaces";
 import { SpaceSwitcher } from "@/components/SpaceSwitcher";
 import {
@@ -1682,6 +1687,12 @@ export function AppWorkbench() {
     setSideWorkbench,
   );
   const bottomTerminal = useBottomTerminal(activeProject?.id);
+  const [bottomTerminalMounted, setBottomTerminalMounted] = useState(false);
+  useEffect(() => {
+    if (bottomTerminal.state.open || bottomTerminal.state.tabs.length > 0) {
+      setBottomTerminalMounted(true);
+    }
+  }, [bottomTerminal.state.open, bottomTerminal.state.tabs.length]);
   /**
    * On-disk default cwd for unbound chats (`workspaces/general`).
    * Not a sidebar project — used by connect / resource pane when no folder bound.
@@ -22103,16 +22114,20 @@ export function AppWorkbench() {
           </div>
           </>
           )}
-          <BottomTerminal
-            locale={locale}
-            projectPath={effectiveProjectPath}
-            state={bottomTerminal.state}
-            onAddTab={bottomTerminal.addTab}
-            onCloseTab={bottomTerminal.closeTab}
-            onActivateTab={bottomTerminal.activateTab}
-            onHeightChange={bottomTerminal.setHeight}
-            onClosePanel={bottomTerminal.closePanel}
-          />
+          {bottomTerminalMounted ? (
+            <Suspense fallback={null}>
+              <BottomTerminal
+                locale={locale}
+                projectPath={effectiveProjectPath}
+                state={bottomTerminal.state}
+                onAddTab={bottomTerminal.addTab}
+                onCloseTab={bottomTerminal.closeTab}
+                onActivateTab={bottomTerminal.activateTab}
+                onHeightChange={bottomTerminal.setHeight}
+                onClosePanel={bottomTerminal.closePanel}
+              />
+            </Suspense>
+          ) : null}
         </main>
 
         {/* RIGHT — session-linked project resource viewer (fully hideable + resizable) */}
@@ -22384,13 +22399,17 @@ export function AppWorkbench() {
       />
       </Suspense>
       ) : null}
-      <ProjectRulesModal
-        open={!!projectRulesTarget}
-        onClose={() => setProjectRulesTarget(null)}
-        projectPath={projectRulesTarget?.path ?? null}
-        projectName={projectRulesTarget?.name ?? null}
-        locale={locale}
-      />
+      {projectRulesTarget ? (
+        <Suspense fallback={null}>
+          <ProjectRulesModal
+            open
+            onClose={() => setProjectRulesTarget(null)}
+            projectPath={projectRulesTarget.path}
+            projectName={projectRulesTarget.name}
+            locale={locale}
+          />
+        </Suspense>
+      ) : null}
       <PromptHistoryClearModal
         locale={locale}
         open={promptHistoryClearOpen}

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,0 +1,92 @@
+/**
+ * yet-another-react-lightbox — loaded only when a gallery opens.
+ */
+
+import Lightbox from "yet-another-react-lightbox";
+import Zoom from "yet-another-react-lightbox/plugins/zoom";
+import Counter from "yet-another-react-lightbox/plugins/counter";
+import "yet-another-react-lightbox/styles.css";
+import "yet-another-react-lightbox/plugins/counter.css";
+
+export type ImageLightboxSlide = {
+  src: string;
+  alt?: string;
+  title?: string;
+  width?: number;
+  height?: number;
+  srcSet?: Array<{ src: string; width: number; height: number }>;
+};
+
+export function ImageLightbox({
+  open,
+  close,
+  index,
+  slides,
+  onView,
+  labels,
+}: {
+  open: boolean;
+  close: () => void;
+  index: number;
+  slides: ImageLightboxSlide[];
+  onView: (index: number) => void;
+  labels: {
+    next: string;
+    prev: string;
+    close: string;
+    zoomIn: string;
+    zoomOut: string;
+  };
+}) {
+  return (
+    <Lightbox
+      open={open}
+      close={close}
+      index={index}
+      slides={slides.map((s) => ({
+        src: s.src,
+        alt: s.alt ?? s.title,
+        title: s.title,
+        width: s.width,
+        height: s.height,
+        ...(s.srcSet?.length ? { srcSet: s.srcSet } : {}),
+      }))}
+      on={{
+        view: ({ index: i }) => onView(i),
+      }}
+      plugins={[Zoom, Counter]}
+      zoom={{
+        maxZoomPixelRatio: 4,
+        scrollToZoom: true,
+      }}
+      carousel={{
+        finite: slides.length <= 1,
+        preload: 2,
+        imageFit: "contain",
+        imageProps: {
+          style: {
+            maxWidth: "100%",
+            maxHeight: "100%",
+            width: "100%",
+            height: "100%",
+            objectFit: "contain",
+          },
+          draggable: false,
+        },
+      }}
+      controller={{
+        closeOnBackdropClick: true,
+      }}
+      styles={{
+        container: { backgroundColor: "rgba(0, 0, 0, 0.92)" },
+      }}
+      labels={{
+        Next: labels.next,
+        Previous: labels.prev,
+        Close: labels.close,
+        "Zoom in": labels.zoomIn,
+        "Zoom out": labels.zoomOut,
+      }}
+    />
+  );
+}

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -10,6 +10,8 @@
 
 import {
   createContext,
+  lazy,
+  Suspense,
   useCallback,
   useContext,
   useEffect,
@@ -18,11 +20,6 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import Lightbox from "yet-another-react-lightbox";
-import Zoom from "yet-another-react-lightbox/plugins/zoom";
-import Counter from "yet-another-react-lightbox/plugins/counter";
-import "yet-another-react-lightbox/styles.css";
-import "yet-another-react-lightbox/plugins/counter.css";
 import { resolveImageSrc, resolveImageSrcs } from "@/lib/imageSrc";
 import { copyImageFromPath, copyImageFromSrc } from "@/lib/copyImage";
 import {
@@ -32,6 +29,11 @@ import {
   loadImageNaturalSize,
 } from "@/lib/imageLightboxFit";
 import { createT, type Locale } from "@/i18n";
+
+const ImageLightbox = lazy(async () => {
+  const m = await import("./ImageLightbox");
+  return { default: m.ImageLightbox };
+});
 
 export interface ImageSlideInput {
   /** Local absolute path or already-viewable URL. */
@@ -256,63 +258,24 @@ export function ImageViewerProvider({
   return (
     <ImageViewerContext.Provider value={api}>
       {children}
-      <Lightbox
-        open={isOpen}
-        close={close}
-        index={index}
-        slides={slides.map((s) => ({
-          src: s.src,
-          alt: s.alt ?? s.title,
-          title: s.title,
-          width: s.width,
-          height: s.height,
-          // Critical for drag-pan: srcSet logical size beats naturalWidth
-          // overwrite inside Zoom's useZoomImageRect (Math.max).
-          ...(s.srcSet?.length ? { srcSet: s.srcSet } : {}),
-        }))}
-        on={{
-          view: ({ index: i }) => setIndex(i),
-        }}
-        plugins={[Zoom, Counter]}
-        zoom={{
-          // Relative to logical slide size (fit-to-stage at zoom=1).
-          // After zoom-in, built-in pointer drag pans (offsetX/Y).
-          maxZoomPixelRatio: 4,
-          scrollToZoom: true,
-        }}
-        carousel={{
-          finite: slides.length <= 1,
-          preload: 2,
-          imageFit: "contain",
-          // Force fill of the stage with object-fit contain so small bitmaps
-          // actually paint at the logical (upscaled) size — YARL's default
-          // only sets max-width/max-height which never upscales.
-          imageProps: {
-            style: {
-              maxWidth: "100%",
-              maxHeight: "100%",
-              width: "100%",
-              height: "100%",
-              objectFit: "contain",
-            },
-            draggable: false,
-          },
-        }}
-        controller={{
-          closeOnBackdropClick: true,
-        }}
-        styles={{
-          // z-index via .yarl__portal in app.css (above GlassModal 12000)
-          container: { backgroundColor: "rgba(0, 0, 0, 0.92)" },
-        }}
-        labels={{
-          Next: tr("image.next"),
-          Previous: tr("image.prev"),
-          Close: tr("image.close"),
-          "Zoom in": tr("image.zoomIn"),
-          "Zoom out": tr("image.zoomOut"),
-        }}
-      />
+      {isOpen ? (
+        <Suspense fallback={null}>
+          <ImageLightbox
+            open={isOpen}
+            close={close}
+            index={index}
+            slides={slides}
+            onView={setIndex}
+            labels={{
+              next: tr("image.next"),
+              prev: tr("image.prev"),
+              close: tr("image.close"),
+              zoomIn: tr("image.zoomIn"),
+              zoomOut: tr("image.zoomOut"),
+            }}
+          />
+        </Suspense>
+      ) : null}
     </ImageViewerContext.Provider>
   );
 }

--- a/src/components/bottom-terminal/BottomTerminal.tsx
+++ b/src/components/bottom-terminal/BottomTerminal.tsx
@@ -15,6 +15,7 @@ import {
   IconChevronDown,
   IconClose,
   IconPlus,
+  IconTerminal,
 } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { TerminalTab } from "@/components/side-workbench/TerminalTab";

--- a/src/components/bottom-terminal/BottomTerminal.tsx
+++ b/src/components/bottom-terminal/BottomTerminal.tsx
@@ -15,7 +15,6 @@ import {
   IconChevronDown,
   IconClose,
   IconPlus,
-  IconTerminal,
 } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { TerminalTab } from "@/components/side-workbench/TerminalTab";
@@ -34,35 +33,6 @@ export type BottomTerminalProps = {
   onHeightChange: (height: number, maxPx?: number) => void;
   onClosePanel: () => void;
 };
-
-export type BottomTerminalToggleProps = {
-  locale: Locale | string;
-  open: boolean;
-  onToggle: () => void;
-};
-
-export function BottomTerminalToggle({
-  locale,
-  open,
-  onToggle,
-}: BottomTerminalToggleProps) {
-  const tr = useMemo(() => createT(locale as Locale), [locale]);
-  const label = open ? tr("terminal.toggleHide") : tr("terminal.toggleShow");
-  return (
-    <Tip label={label}>
-      <button
-        type="button"
-        className={"chrome-btn main__pane-toggle" + (open ? " is-on" : "")}
-        aria-label={label}
-        aria-pressed={open}
-        data-testid="bottom-terminal-toggle"
-        onClick={onToggle}
-      >
-        <IconTerminal size={16} />
-      </button>
-    </Tip>
-  );
-}
 
 export function BottomTerminal({
   locale,

--- a/src/components/bottom-terminal/BottomTerminalToggle.tsx
+++ b/src/components/bottom-terminal/BottomTerminalToggle.tsx
@@ -1,0 +1,38 @@
+/**
+ * Chrome toggle for the bottom PTY panel.
+ * Kept out of BottomTerminal.tsx so xterm is not on the startup graph.
+ */
+
+import { useMemo } from "react";
+import { createT, type Locale } from "@/i18n";
+import { IconTerminal } from "@/components/icons";
+import { Tip } from "@/components/ui/tooltip";
+
+export type BottomTerminalToggleProps = {
+  locale: Locale | string;
+  open: boolean;
+  onToggle: () => void;
+};
+
+export function BottomTerminalToggle({
+  locale,
+  open,
+  onToggle,
+}: BottomTerminalToggleProps) {
+  const tr = useMemo(() => createT(locale as Locale), [locale]);
+  const label = open ? tr("terminal.toggleHide") : tr("terminal.toggleShow");
+  return (
+    <Tip label={label}>
+      <button
+        type="button"
+        className={"chrome-btn main__pane-toggle" + (open ? " is-on" : "")}
+        aria-label={label}
+        aria-pressed={open}
+        data-testid="bottom-terminal-toggle"
+        onClick={onToggle}
+      >
+        <IconTerminal size={16} />
+      </button>
+    </Tip>
+  );
+}

--- a/src/components/bottom-terminal/index.ts
+++ b/src/components/bottom-terminal/index.ts
@@ -1,8 +1,4 @@
-export {
-  BottomTerminal,
-  BottomTerminalToggle,
-} from "./BottomTerminal";
-export type {
-  BottomTerminalProps,
-  BottomTerminalToggleProps,
-} from "./BottomTerminal";
+export { BottomTerminal } from "./BottomTerminal";
+export type { BottomTerminalProps } from "./BottomTerminal";
+export { BottomTerminalToggle } from "./BottomTerminalToggle";
+export type { BottomTerminalToggleProps } from "./BottomTerminalToggle";


### PR DESCRIPTION
## Summary

xterm, project-rules TipTap, and yet-another-react-lightbox were on the startup graph.

- `BottomTerminalToggle` is a thin chrome button; the PTY panel (xterm) mounts after the first open and stays mounted so sessions survive hide.
- `ProjectRulesModal` loads when opened.
- The image lightbox module loads when a gallery opens.

Fixes #799

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec eslint` on touched files
- [ ] First paint: no xterm/TipTap/lightbox in the main chunk (optional `vite build`)
- [ ] Open bottom terminal: PTY works; hide and show without losing the session
- [ ] Open project rules: TipTap editor works
- [ ] Click a chat image: lightbox still opens
- [ ] CI green

## Checklist

- [x] eslint on touched files
- [x] No new i18n keys
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets

## Notes

- Remaining workbench modals (SearchPalette, export, rewind, …) still static — follow-up.
- `pi -p` is not on this Windows PATH. Do not treat as pi-reviewed.
