### PR TITLE
perf(boot): load PetApp and App through separate entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Pet overlay does not parse the workbench**: `#/pet` `import()`s `PetApp`; the main window `import()`s `App`.
 - **Clippy is silent on macOS host builds again (#785)**: Windows-only overlay/WSL/shim items use the existing `cfg_attr(not(windows), allow(dead_code))` idiom so cross-platform tests stay; mechanical style lints and Tauri `too_many_arguments` allows restore zero `cargo clippy --all-targets` warnings without behavior change.
 - **Locale catalogs load on demand**: English stays in the main bundle. The other 14 languages `import()` when selected; UI falls back to English until that chunk arrives.
 - **Heavy surfaces leave first paint**: Bottom terminal (xterm) mounts after first open; project-rules TipTap and the image lightbox load on demand.
@@ -38,6 +39,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **宠物浮层不再解析工作台**：`#/pet` 动态加载 `PetApp`；主窗口动态加载 `App`。
 - **macOS 上 clippy 再次零警告（#785）**：Windows 专用 overlay/WSL/shim 用既有 `cfg_attr(not(windows), allow(dead_code))`，跨平台测试仍跑；机械风格与 Tauri `too_many_arguments` allow 恢复 `cargo clippy --all-targets` 零警告，无行为变化。
 - **语言包按需加载**：主包只带英文。另外 14 种语言选中后再 `import()`；chunk 到达前界面先用英文。
 - **重表面离开首屏**：底栏终端（xterm）第一次打开才挂载；项目规则 TipTap 和图片灯箱按需加载。

--- a/src-tauri/src/desktop_notify.rs
+++ b/src-tauri/src/desktop_notify.rs
@@ -18,6 +18,8 @@
 //! Returns the delivery **path** string on success so Settings can be honest.
 
 use tauri::{AppHandle, Emitter};
+#[cfg(not(target_os = "macos"))]
+use tauri_plugin_notification::NotificationExt;
 
 /// Product bundle id / AUMID (must match `tauri.conf.json` `identifier`).
 const APP_BUNDLE_ID: &str = "com.grokapp.desktop";

--- a/src/main.bootCss.test.ts
+++ b/src/main.bootCss.test.ts
@@ -6,8 +6,16 @@ import { describe, expect, it } from "vitest";
 const here = dirname(fileURLToPath(import.meta.url));
 
 describe("boot CSS", () => {
+  const src = readFileSync(join(here, "main.tsx"), "utf8");
+
   it("does not import streamdown styles in main.tsx", () => {
-    const src = readFileSync(join(here, "main.tsx"), "utf8");
     expect(src).not.toContain("streamdown/styles.css");
+  });
+
+  it("loads PetApp and App through dynamic import", () => {
+    expect(src).not.toMatch(/import\s+App\s+from\s+["']\.\/App["']/);
+    expect(src).not.toMatch(/import\s+\{\s*PetApp\s*\}\s+from/);
+    expect(src).toContain('import("./components/pet/PetApp")');
+    expect(src).toContain('import("./App")');
   });
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,5 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
-import { PetApp } from "./components/pet/PetApp";
 import { isPetShellHash } from "@/lib/pet/petShell";
 import { UpdaterProvider } from "./hooks/UpdaterProvider";
 import "./styles/tokens.css";
@@ -230,14 +228,23 @@ document.addEventListener(
   true,
 );
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    {petShell ? (
-      <PetApp />
-    ) : (
-      <UpdaterProvider>
-        <App />
-      </UpdaterProvider>
-    )}
-  </StrictMode>,
-);
+const root = createRoot(document.getElementById("root")!);
+if (petShell) {
+  void import("./components/pet/PetApp").then(({ PetApp }) => {
+    root.render(
+      <StrictMode>
+        <PetApp />
+      </StrictMode>,
+    );
+  });
+} else {
+  void import("./App").then(({ default: App }) => {
+    root.render(
+      <StrictMode>
+        <UpdaterProvider>
+          <App />
+        </UpdaterProvider>
+      </StrictMode>,
+    );
+  });
+}

--- a/src/test/loadLocaleCatalogs.ts
+++ b/src/test/loadLocaleCatalogs.ts
@@ -1,0 +1,8 @@
+/**
+ * Vitest loads this before specs. English is always in the catalog; other
+ * locales are on-demand in the app. Tests that call createT("zh") need the
+ * table filled or they silently get English.
+ */
+import { loadAllLocaleCatalogs } from "@/i18n";
+
+await loadAllLocaleCatalogs();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,5 +41,6 @@ export default defineConfig(() => ({
   test: {
     environment: "node",
     include: ["src/**/*.{test,spec}.ts", "src/**/*.{test,spec}.tsx"],
+    setupFiles: ["./src/test/loadLocaleCatalogs.ts"],
   },
 }));


### PR DESCRIPTION
## Summary

The pet overlay (`#/pet`) dynamically imports `PetApp`. The main window dynamically imports `App`. Opening the overlay does not parse the workbench module.

Fixes #813

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/main.bootCss.test.ts` (2 passed)
- [ ] Pet overlay `#/pet` does not load the workbench chunk
- [ ] Main window still boots App + updater
- [ ] CI green

## Checklist

- [x] User-facing strings go through `t()` / `createT`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
