### PR TITLE
perf(workbench): keep permission, git, and Tasks ticks off the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Permission countdown, git dirty chip, and Tasks liveMap stay off the workbench shell**: Auto-deny seconds tick inside the permission bar. Git chip setState runs only when the count/label change. The Tasks panel subscribes to liveMap itself. ConversationThreadLive is memoized with stable callbacks.
 - **Pet overlay does not parse the workbench**: `#/pet` `import()`s `PetApp`; the main window `import()`s `App`.
 - **Clippy is silent on macOS host builds again (#785)**: Windows-only overlay/WSL/shim items use the existing `cfg_attr(not(windows), allow(dead_code))` idiom so cross-platform tests stay; mechanical style lints and Tauri `too_many_arguments` allows restore zero `cargo clippy --all-targets` warnings without behavior change.
 - **Locale catalogs load on demand**: English stays in the main bundle. The other 14 languages `import()` when selected; UI falls back to English until that chunk arrives.
@@ -39,6 +40,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **权限倒计时、git 脏文件芯片和 Tasks liveMap 不再打穿工作台**：自动拒绝秒数在权限条内部跳动。git 芯片只在条数/文案变化时 setState。Tasks 面板自己订阅 liveMap。ConversationThreadLive 带稳定回调并 memo。
 - **宠物浮层不再解析工作台**：`#/pet` 动态加载 `PetApp`；主窗口动态加载 `App`。
 - **macOS 上 clippy 再次零警告（#785）**：Windows 专用 overlay/WSL/shim 用既有 `cfg_attr(not(windows), allow(dead_code))`，跨平台测试仍跑；机械风格与 Tauri `too_many_arguments` allow 恢复 `cargo clippy --all-targets` 零警告，无行为变化。
 - **语言包按需加载**：主包只带英文。另外 14 种语言选中后再 `import()`；chunk 到达前界面先用英文。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -79,10 +79,7 @@ import {
   gateClockKey,
   resumeGateClock
 } from "@/lib/gateClock";
-import {
-  permissionTimeoutRemainingSec,
-  savePermissionTimeoutSec
-} from "@/lib/permissionTimeout";
+import { savePermissionTimeoutSec } from "@/lib/permissionTimeout";
 import { saveAskUserTimeoutSec } from "@/lib/askUserTimeout";
 import { WallpaperMediaLayer } from "@/components/WallpaperMediaLayer";
 import {
@@ -971,11 +968,13 @@ import {
   type SessionFileChange
 } from "@/lib/sessionChanges";
 import {
+  gitDirtySummariesEqual,
   summarizeGitDirty,
   type GitDirtySummary
 } from "@/lib/workspaceGit";
 import { ConversationThreadLive } from "@/components/lobe-chat";
 import { AgentTasksPanelLive } from "@/components/AgentTasksPanelLive";
+import { PermissionCountdown } from "@/components/PermissionCountdown";
 
 const SettingsPage = lazy(async () => {
   const m = await import("@/components/SettingsPage");
@@ -1627,6 +1626,17 @@ export function AppWorkbench() {
   const executeSendFromQueueRef = useRef<ExecuteSendFromQueue>(
     async () => false,
   );
+  const executeSendLatestRef = useRef<
+    (opts: {
+      storedDisplay: string;
+      att: Attachment[];
+      quotes?: ComposerQuote[];
+      goalMode: boolean;
+      fromQueue?: boolean;
+      targetSessionId?: string | null;
+      agentTextOverride?: string;
+    }) => Promise<boolean>
+  >(async () => false);
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [showUsageLimitModal, setShowUsageLimitModal] = useState(false);
   const [showMcpModal, setShowMcpModal] = useState(false);
@@ -2313,8 +2323,6 @@ export function AppWorkbench() {
   >({});
   const [perm, setPerm] = useState<PermissionPayload | null>(null);
   const permBarRef = useRef<HTMLDivElement | null>(null);
-  /** Seconds until auto-deny (null when off / no active timer). */
-  const [permCountdownSec, setPermCountdownSec] = useState<number | null>(null);
   const [askUser, setAskUser] = useState<AskUserPayload | null>(null);
   /**
    * Unanswered gates per session (`sessionId` → payload).
@@ -2608,7 +2616,6 @@ export function AppWorkbench() {
     showReliability ||
       agentDashboardOpen ||
       taskBoardOpen ||
-      tasksPanelOpen ||
       opsEntryOpen ||
       streamStall != null ||
       liveVoiceOpen ||
@@ -7819,6 +7826,43 @@ export function AppWorkbench() {
     [tr, platform],
   );
 
+  const structuredOutputLabels = useMemo(
+    () => ({
+      title: tr("message.structuredJson"),
+      badge: tr("message.structuredJsonBadge"),
+      copy: tr("message.structuredJsonCopy"),
+      copied: tr("message.copied"),
+      export: tr("message.structuredJsonExport"),
+      invalidJson: tr("message.structuredJsonInvalid"),
+      empty: tr("message.structuredJsonEmpty"),
+      valid: tr("message.structuredJsonValid"),
+      schemaMismatch: tr("message.structuredJsonSchemaMismatch"),
+      missingRequired: tr("message.structuredJsonMissingRequired"),
+      streaming: tr("message.structuredJsonStreaming"),
+      partial: tr("message.structuredJsonPartial"),
+      partialKeys: tr("message.structuredJsonPartialKeys"),
+      timeline: tr("message.structuredJsonTimeline"),
+      usage: tr("message.structuredJsonUsage"),
+      usageIo: tr("message.structuredJsonUsageIo"),
+      usageTotal: tr("message.structuredJsonUsageTotal"),
+    }),
+    [tr],
+  );
+
+  const structuredOutputUsage = useMemo(() => {
+    const u = contextUsage.knownUsage;
+    if (!u) return null;
+    return {
+      inputTokens: u.inputTokens,
+      outputTokens: u.outputTokens,
+      totalTokens: u.totalTokens,
+    };
+  }, [
+    contextUsage.knownUsage?.inputTokens,
+    contextUsage.knownUsage?.outputTokens,
+    contextUsage.knownUsage?.totalTokens,
+  ]);
+
   const lastUserMessageId = transcriptMeta.lastUserId;
 
   // Streaming perf mode — shrink browse overscan on integrated GPU Retina.
@@ -8538,6 +8582,7 @@ export function AppWorkbench() {
   voiceDictationAutoSendRef.current = voiceDictationAutoSend;
 
   executeSendFromQueueRef.current = (opts) => executeSend(opts);
+  executeSendLatestRef.current = executeSend;
 
   const queuePreviewLabels = useMemo(
     () => ({
@@ -13464,20 +13509,23 @@ export function AppWorkbench() {
     const path = activeProject?.path?.trim() || null;
     if (!path || !api.isTauri()) {
       gitDirtyReqRef.current += 1;
-      setGitDirtySummary(null);
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
       return;
     }
     const reqId = ++gitDirtyReqRef.current;
     try {
       const status = await api.gitStatus(path);
       if (reqId !== gitDirtyReqRef.current) return;
-      setGitDirtySummary(summarizeGitDirty(status));
+      const next = summarizeGitDirty(status);
+      setGitDirtySummary((prev) =>
+        gitDirtySummariesEqual(prev, next) ? prev : next,
+      );
       // Same poll already has HEAD. Patch the composer branch chip so an
       // in-place checkout does not stay stale until the menu is clicked.
       setGitWorktrees((prev) => applyGitStatusBranch(prev, path, status));
     } catch {
       if (reqId !== gitDirtyReqRef.current) return;
-      setGitDirtySummary(null);
+      setGitDirtySummary((prev) => (prev == null ? prev : null));
     }
   }, [activeProject?.path]);
 
@@ -15389,7 +15437,6 @@ export function AppWorkbench() {
   // Optional auto-deny after N seconds (Settings → Permissions; 0 = off).
   useEffect(() => {
     if (!perm || permissionTimeoutSec <= 0) {
-      setPermCountdownSec(null);
       return;
     }
     // Resume this request's own clock rather than restarting it — the bar
@@ -15399,18 +15446,6 @@ export function AppWorkbench() {
       permRaisedAtRef.current,
       gateClockKey(perm.sessionId, perm.rpcId),
     );
-    setPermCountdownSec(
-      permissionTimeoutRemainingSec(raisedAt, permissionTimeoutSec),
-    );
-    const tick = window.setInterval(() => {
-      setPermCountdownSec(
-        permissionTimeoutRemainingSec(
-          raisedAt,
-          permissionTimeoutSec,
-          Date.now(),
-        ),
-      );
-    }, 250);
     const t = window.setTimeout(
       () => {
         denyActivePermission(perm);
@@ -15419,10 +15454,16 @@ export function AppWorkbench() {
     );
     return () => {
       window.clearTimeout(t);
-      window.clearInterval(tick);
-      setPermCountdownSec(null);
     };
   }, [perm, permissionTimeoutSec, denyActivePermission]);
+
+  const permCountdownStartedAt =
+    perm && permissionTimeoutSec > 0
+      ? resumeGateClock(
+          permRaisedAtRef.current,
+          gateClockKey(perm.sessionId, perm.rpcId),
+        )
+      : 0;
 
   /** T04 deck buttons: reconnect / Doctor / Settings sections / project / MCP / dismiss. */
   const runErrorBannerAction = useCallback(
@@ -17240,6 +17281,112 @@ export function AppWorkbench() {
       tr,
       availableModels,
     ],
+  );
+
+  const onThreadContinueInterrupted = useCallback(() => {
+    const sid = session.sessionId;
+    if (!sid) return;
+    if (
+      session.state === "streaming" ||
+      session.state === "awaiting_permission" ||
+      session.state === "connecting"
+    ) {
+      return;
+    }
+    void (async () => {
+      const ctx = await api.sessionInterruptContext(sid);
+      const journal = tr("endOfTurn.continuePrompt");
+      await executeSendLatestRef.current({
+        storedDisplay: journal,
+        att: [],
+        goalMode: false,
+        targetSessionId: sid,
+        agentTextOverride: buildContinueAgentPrompt(ctx),
+      });
+    })();
+  }, [session.sessionId, session.state, tr]);
+
+  const onThreadAddQuote = useCallback(
+    (quote: { text: string; comment: string; sourceMessageId?: string }) => {
+      setQuotes((prev) => [
+        ...prev,
+        {
+          id: makeComposerQuoteId(),
+          text: quote.text,
+          comment: quote.comment,
+          sourceMessageId: quote.sourceMessageId,
+        },
+      ]);
+    },
+    [setQuotes],
+  );
+
+  const onThreadRemoveEditAttachment = useCallback((att: Attachment) => {
+    setEditAttachments((prev) => prev.filter((x) => x.path !== att.path));
+  }, []);
+
+  const onThreadOpenSessionChanges = useCallback(() => {
+    openAsidePane();
+    setResourceOpenTarget({ type: "changes" });
+  }, [openAsidePane]);
+
+  const onThreadOpenModifiedPath = useCallback(
+    (path: string) => {
+      openAsidePane();
+      setResourceOpenTarget({ type: "changes", path });
+    },
+    [openAsidePane],
+  );
+
+  const onThreadOpenResource = useCallback(
+    (target: ResourceOpenTarget) => {
+      if (target.type === "file" && target.path) {
+        const decision = resolveSidePathDeepLink({
+          path: target.path,
+          title: target.title,
+          projectPath: effectiveProjectPath,
+          projectTrusted: activeProject ? activeProject.trusted : null,
+        });
+        if (!decision.ok) {
+          setLocalError(tr(decision.messageKey));
+          if (
+            decision.shouldReveal &&
+            decision.revealPath &&
+            api.isTauri()
+          ) {
+            void api.pathReveal(decision.revealPath).catch(() => {
+              /* reveal is best-effort fallback */
+            });
+          }
+          return;
+        }
+        openAsidePane();
+        setResourceOpenTarget({
+          type: "file",
+          path: decision.path,
+          title: decision.title,
+          line: target.line ?? null,
+          column: target.column ?? null,
+        });
+        return;
+      }
+      openAsidePane();
+      setResourceOpenTarget(target);
+    },
+    [activeProject, effectiveProjectPath, openAsidePane, tr],
+  );
+
+  const onThreadAddAttachmentToComposer = useCallback((att: Attachment) => {
+    setAttachments((prev) => mergeAttachments(prev, [att]));
+  }, []);
+
+  const onThreadOpenError = useCallback((message: string) => {
+    setLocalError(message);
+  }, []);
+
+  const formatPermCountdown = useCallback(
+    (seconds: string) => tr("perm.autoDenyCountdown", { seconds }),
+    [tr],
   );
 
   const runAccountLogin = useCallback(
@@ -20691,12 +20838,9 @@ export function AppWorkbench() {
               subagentWorktreeSnapshotEnabled={
                 subagentWorktreeSnapshotEnabled
               }
-              activitySessions={collectActivitySessions({
-                liveMap,
-                sessions,
-                currentSessionId: session.sessionId,
-                untitledLabel: tr("session.untitled"),
-              })}
+              activityLookupSessions={sessions}
+              currentSessionId={session.sessionId}
+              untitledLabel={tr("session.untitled")}
               onSelectSession={(id) => {
                 const row = sessions.find((s) => s.id === id);
                 if (!row) return;
@@ -20859,39 +21003,8 @@ export function AppWorkbench() {
             }}
           >
           <ConversationThreadLive
-            onContinueInterrupted={() => {
-              const sid = session.sessionId;
-              if (!sid) return;
-              if (
-                session.state === "streaming" ||
-                session.state === "awaiting_permission" ||
-                session.state === "connecting"
-              ) {
-                return;
-              }
-              void (async () => {
-                const ctx = await api.sessionInterruptContext(sid);
-                const journal = tr("endOfTurn.continuePrompt");
-                await executeSend({
-                  storedDisplay: journal,
-                  att: [],
-                  goalMode: false,
-                  targetSessionId: sid,
-                  agentTextOverride: buildContinueAgentPrompt(ctx),
-                });
-              })();
-            }}
-            onAddQuote={(quote) => {
-              setQuotes((prev) => [
-                ...prev,
-                {
-                  id: makeComposerQuoteId(),
-                  text: quote.text,
-                  comment: quote.comment,
-                  sourceMessageId: quote.sourceMessageId,
-                },
-              ]);
-            }}
+            onContinueInterrupted={onThreadContinueInterrupted}
+            onAddQuote={onThreadAddQuote}
             locale={locale}
             sessionState={
               stopLatch.phase === "force_idle" || stopGate.forceIdle
@@ -20914,76 +21027,22 @@ export function AppWorkbench() {
             editAttachments={editAttachments}
             onEditUserMessage={beginEditLastUser}
             onCancelEditUserMessage={cancelEditUser}
-            onSubmitEditUserMessage={(msg, content) => {
-              void submitEditLastUser(msg, content);
-            }}
-            onRemoveEditAttachment={(att) =>
-              setEditAttachments((prev) =>
-                prev.filter((x) => x.path !== att.path),
-              )
-            }
+            onSubmitEditUserMessage={submitEditLastUser}
+            onRemoveEditAttachment={onThreadRemoveEditAttachment}
             canRegenerate={canEditLastUser && !editSubmitting}
-            onRegenerateAssistant={(msg, opts) => {
-              void regenerateLastAssistant(msg, opts);
-            }}
+            onRegenerateAssistant={regenerateLastAssistant}
             regenerateModels={availableModels}
             regenerateModelId={modelId}
             canRewindSession={canRewindSession && !!session.sessionId}
             onRewindToUserMessage={onRewindToUserMessage}
             onForkFromAssistantMessage={onForkFromAssistantMessage}
             turnStartedAt={turnStartedAt}
-            onOpenSessionChanges={() => {
-              openAsidePane();
-              setResourceOpenTarget({ type: "changes" });
-            }}
-            onOpenModifiedPath={(path) => {
-              openAsidePane();
-              setResourceOpenTarget({ type: "changes", path });
-            }}
-            onOpenResource={(target) => {
-              // Path cards → Side Workbench Files tab when project-trusted.
-              // Soft-fail outside/untrusted/no project; optional OS reveal.
-              // URLs / changes keep the prior applySideContextOpen path.
-              if (target.type === "file" && target.path) {
-                const decision = resolveSidePathDeepLink({
-                  path: target.path,
-                  title: target.title,
-                  projectPath: effectiveProjectPath,
-                  projectTrusted: activeProject
-                    ? activeProject.trusted
-                    : null,
-                });
-                if (!decision.ok) {
-                  setLocalError(tr(decision.messageKey));
-                  if (
-                    decision.shouldReveal &&
-                    decision.revealPath &&
-                    api.isTauri()
-                  ) {
-                    void api.pathReveal(decision.revealPath).catch(() => {
-                      /* reveal is best-effort fallback */
-                    });
-                  }
-                  return;
-                }
-                openAsidePane();
-                setResourceOpenTarget({
-                  type: "file",
-                  path: decision.path,
-                  title: decision.title,
-                  line: target.line ?? null,
-                  column: target.column ?? null,
-                });
-                return;
-              }
-              openAsidePane();
-              setResourceOpenTarget(target);
-            }}
-            onOpenError={(message) => setLocalError(message)}
+            onOpenSessionChanges={onThreadOpenSessionChanges}
+            onOpenModifiedPath={onThreadOpenModifiedPath}
+            onOpenResource={onThreadOpenResource}
+            onOpenError={onThreadOpenError}
             onOpenExternalLink={openExternalLinkFromChat}
-            onAddAttachmentToComposer={(att) =>
-              setAttachments((prev) => mergeAttachments(prev, [att]))
-            }
+            onAddAttachmentToComposer={onThreadAddAttachmentToComposer}
             attachLabels={attachLabels}
             findQuery={showChatFind ? chatFindQuery : ""}
             findHitMessageIds={showChatFind ? chatFindHitIds : undefined}
@@ -20993,34 +21052,8 @@ export function AppWorkbench() {
             showReplyLength={showReplyLength}
             structuredOutputActive={!!sessionJsonSchema}
             structuredOutputSchema={sessionJsonSchema}
-            structuredOutputUsage={
-              contextUsage.knownUsage
-                ? {
-                    inputTokens: contextUsage.knownUsage.inputTokens,
-                    outputTokens: contextUsage.knownUsage.outputTokens,
-                    totalTokens: contextUsage.knownUsage.totalTokens,
-                  }
-                : null
-            }
-            structuredOutputLabels={{
-              title: tr("message.structuredJson"),
-              badge: tr("message.structuredJsonBadge"),
-              copy: tr("message.structuredJsonCopy"),
-              copied: tr("message.copied"),
-              export: tr("message.structuredJsonExport"),
-              invalidJson: tr("message.structuredJsonInvalid"),
-              empty: tr("message.structuredJsonEmpty"),
-              valid: tr("message.structuredJsonValid"),
-              schemaMismatch: tr("message.structuredJsonSchemaMismatch"),
-              missingRequired: tr("message.structuredJsonMissingRequired"),
-              streaming: tr("message.structuredJsonStreaming"),
-              partial: tr("message.structuredJsonPartial"),
-              partialKeys: tr("message.structuredJsonPartialKeys"),
-              timeline: tr("message.structuredJsonTimeline"),
-              usage: tr("message.structuredJsonUsage"),
-              usageIo: tr("message.structuredJsonUsageIo"),
-              usageTotal: tr("message.structuredJsonUsageTotal"),
-            }}
+            structuredOutputUsage={structuredOutputUsage}
+            structuredOutputLabels={structuredOutputLabels}
           />
           </UiErrorBoundary>
           </AttachedChatLookupContext.Provider>
@@ -21083,12 +21116,12 @@ export function AppWorkbench() {
                   <span className="perm-bar__tool">
                     {perm.title || perm.toolName}
                   </span>
-                  {permCountdownSec != null && permCountdownSec > 0 ? (
-                    <span className="perm-bar__countdown" aria-live="polite">
-                      {tr("perm.autoDenyCountdown", {
-                        seconds: String(permCountdownSec),
-                      })}
-                    </span>
+                  {permissionTimeoutSec > 0 ? (
+                    <PermissionCountdown
+                      startedAtMs={permCountdownStartedAt}
+                      timeoutSec={permissionTimeoutSec}
+                      format={formatPermCountdown}
+                    />
                   ) : null}
                 </div>
                 <p className="perm-bar__summary" id="perm-bar-summary">

--- a/src/components/AgentTasksPanelLive.tsx
+++ b/src/components/AgentTasksPanelLive.tsx
@@ -1,13 +1,18 @@
 /**
- * Tasks panel bound to sessionTranscriptStore content.
+ * Tasks panel bound to sessionTranscriptStore content and liveMap.
  *
- * Keeps AppWorkbench off the stream content subscription — only this
+ * Keeps AppWorkbench off stream content and liveMap row ticks — only this
  * bridge re-renders while tools/token steps grow. The heavy panel chunk
  * is lazy-loaded the first time the panel opens.
  */
 
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useMemo } from "react";
 import { useViewingMessages } from "@/hooks/useSessionTranscript";
+import { useLiveMap } from "@/hooks/useSessionLiveMap";
+import {
+  collectActivitySessions,
+  type SessionTitleLookup,
+} from "@/lib/agentActivity";
 import type { AgentTasksPanelProps } from "@/components/AgentTasksPanel";
 
 const AgentTasksPanel = lazy(async () => {
@@ -15,13 +20,40 @@ const AgentTasksPanel = lazy(async () => {
   return { default: m.AgentTasksPanel };
 });
 
-export type AgentTasksPanelLiveProps = Omit<AgentTasksPanelProps, "messages">;
+export type AgentTasksPanelLiveProps = Omit<
+  AgentTasksPanelProps,
+  "messages" | "activitySessions"
+> & {
+  activityLookupSessions: SessionTitleLookup[];
+  currentSessionId?: string | null;
+  untitledLabel?: string;
+};
 
-export function AgentTasksPanelLive(props: AgentTasksPanelLiveProps) {
+export function AgentTasksPanelLive({
+  activityLookupSessions,
+  currentSessionId,
+  untitledLabel,
+  ...props
+}: AgentTasksPanelLiveProps) {
   const messages = useViewingMessages();
+  const liveMap = useLiveMap();
+  const activitySessions = useMemo(
+    () =>
+      collectActivitySessions({
+        liveMap,
+        sessions: activityLookupSessions,
+        currentSessionId,
+        untitledLabel,
+      }),
+    [liveMap, activityLookupSessions, currentSessionId, untitledLabel],
+  );
   return (
     <Suspense fallback={null}>
-      <AgentTasksPanel {...props} messages={messages} />
+      <AgentTasksPanel
+        {...props}
+        messages={messages}
+        activitySessions={activitySessions}
+      />
     </Suspense>
   );
 }

--- a/src/components/PermissionCountdown.test.tsx
+++ b/src/components/PermissionCountdown.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { PermissionCountdown } from "./PermissionCountdown";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("PermissionCountdown", () => {
+  it("ticks remaining seconds inside the countdown, not the parent", () => {
+    const started = 1_000_000;
+    vi.setSystemTime(started);
+    render(
+      <PermissionCountdown
+        startedAtMs={started}
+        timeoutSec={30}
+        format={(seconds) => `T${seconds}`}
+      />,
+    );
+    expect(screen.getByText("T30")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText("T29")).toBeInTheDocument();
+  });
+
+  it("hides when remaining hits zero", () => {
+    const started = 1_000_000;
+    vi.setSystemTime(started);
+    render(
+      <PermissionCountdown
+        startedAtMs={started}
+        timeoutSec={1}
+        format={(seconds) => `T${seconds}`}
+      />,
+    );
+    expect(screen.getByText("T1")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByText(/^T/)).toBeNull();
+  });
+});

--- a/src/components/PermissionCountdown.tsx
+++ b/src/components/PermissionCountdown.tsx
@@ -1,0 +1,36 @@
+/**
+ * Permission auto-deny seconds. The interval lives here so AppWorkbench
+ * does not re-render every 250ms while a gate is open.
+ */
+
+import { useEffect, useState } from "react";
+import { permissionTimeoutRemainingSec } from "@/lib/permissionTimeout";
+
+export function PermissionCountdown(props: {
+  startedAtMs: number;
+  timeoutSec: number;
+  format: (seconds: string) => string;
+}) {
+  const { startedAtMs, timeoutSec, format } = props;
+  const [sec, setSec] = useState(() =>
+    permissionTimeoutRemainingSec(startedAtMs, timeoutSec),
+  );
+
+  useEffect(() => {
+    setSec(permissionTimeoutRemainingSec(startedAtMs, timeoutSec));
+    if (!(timeoutSec > 0)) return;
+    const tick = window.setInterval(() => {
+      const left = permissionTimeoutRemainingSec(startedAtMs, timeoutSec);
+      setSec(left);
+      if (left <= 0) window.clearInterval(tick);
+    }, 250);
+    return () => window.clearInterval(tick);
+  }, [startedAtMs, timeoutSec]);
+
+  if (sec <= 0) return null;
+  return (
+    <span className="perm-bar__countdown" aria-live="polite">
+      {format(String(sec))}
+    </span>
+  );
+}

--- a/src/components/lobe-chat/ConversationThreadLive.tsx
+++ b/src/components/lobe-chat/ConversationThreadLive.tsx
@@ -3,6 +3,7 @@
  * Isolates stream token re-renders from the App shell.
  */
 
+import { memo } from "react";
 import { ConversationThread, type ConversationThreadProps } from "./ConversationThread";
 import {
   useTranscriptMeta,
@@ -14,7 +15,9 @@ export type ConversationThreadLiveProps = Omit<
   "messages"
 >;
 
-export function ConversationThreadLive(props: ConversationThreadLiveProps) {
+export const ConversationThreadLive = memo(function ConversationThreadLive(
+  props: ConversationThreadLiveProps,
+) {
   const messages = useViewingMessages();
   const meta = useTranscriptMeta();
   const journalLoading = !!props.journalLoading || meta.journalLoading;
@@ -25,4 +28,4 @@ export function ConversationThreadLive(props: ConversationThreadLiveProps) {
       journalLoading={journalLoading}
     />
   );
-}
+});

--- a/src/hooks/useSessionLiveMap.ts
+++ b/src/hooks/useSessionLiveMap.ts
@@ -26,7 +26,7 @@ const EMPTY_LIVE_MAP: SessionLiveMap = Object.freeze({}) as SessionLiveMap;
 
 /**
  * Subscribe to the full live map only while `enabled` is true.
- * When panels (dashboard / reliability / stall / tasks) are closed, the
+ * When panels (dashboard / reliability / stall) are closed, the
  * workbench shell does not re-render on every tool-title liveMap tick.
  */
 export function useLiveMapWhen(enabled: boolean): SessionLiveMap {

--- a/src/lib/workspaceGit.test.ts
+++ b/src/lib/workspaceGit.test.ts
@@ -3,6 +3,7 @@ import {
   classifyGitStatusCode,
   classifyGitStatusString,
   filterWorkspaceGitEntries,
+  gitDirtySummariesEqual,
   isSafeDiscardCandidate,
   normalizeWorkspaceGitEntries,
   normalizeWorkspaceGitEntry,
@@ -189,5 +190,26 @@ describe("summarizeGitDirty", () => {
         files: [{ path: "only.ts" }],
       }),
     ).toEqual({ count: 1, label: "1 changed" });
+  });
+});
+
+describe("gitDirtySummariesEqual", () => {
+  it("treats both nullish as equal and compares count plus label", () => {
+    expect(gitDirtySummariesEqual(null, undefined)).toBe(true);
+    expect(
+      gitDirtySummariesEqual(
+        { count: 1, label: "1 changed" },
+        { count: 1, label: "1 changed" },
+      ),
+    ).toBe(true);
+    expect(
+      gitDirtySummariesEqual(
+        { count: 1, label: "1 changed" },
+        { count: 2, label: "2 changed" },
+      ),
+    ).toBe(false);
+    expect(
+      gitDirtySummariesEqual(null, { count: 1, label: "1 changed" }),
+    ).toBe(false);
   });
 });

--- a/src/lib/workspaceGit.ts
+++ b/src/lib/workspaceGit.ts
@@ -265,3 +265,13 @@ export function summarizeGitDirty(
     label: `${count} changed`,
   };
 }
+
+/** True when two chip summaries would paint the same (skip setState). */
+export function gitDirtySummariesEqual(
+  a: GitDirtySummary | null | undefined,
+  b: GitDirtySummary | null | undefined,
+): boolean {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  return a.count === b.count && a.label === b.label;
+}


### PR DESCRIPTION
## Summary

Permission auto-deny seconds tick inside the permission bar. The git dirty chip updates only when count or label change. The Tasks panel subscribes to liveMap itself. ConversationThreadLive is memoized and receives stable callbacks, so those ticks do not re-render the workbench shell.

Fixes #814

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/lib/workspaceGit.test.ts src/components/PermissionCountdown.test.tsx` (15 passed)
- [x] `pnpm exec eslint` on touched files
- [x] `pnpm typecheck`
- [ ] Permission bar countdown still auto-denies at timeout
- [ ] Git dirty chip still appears/hides when files change
- [ ] Tasks panel still lists other busy sessions
- [ ] Continue / quote / edit / open-path from the transcript still work
- [ ] CI green

## Checklist

- [x] User-facing strings go through `t()` / `createT`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
