### PR TITLE
perf(preview): window long CodePreview files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Resource code preview windows long files**: Side-pane / Changes `CodePreview` keeps short files as a full list. Files at 200+ lines (including 5000-line sources) only mount the visible rows and highlight those lines, instead of highlight.js + one DOM node per line for the whole file.
 - **Permission countdown, git dirty chip, and Tasks liveMap stay off the workbench shell**: Auto-deny seconds tick inside the permission bar. Git chip setState runs only when the count/label change. The Tasks panel subscribes to liveMap itself. ConversationThreadLive is memoized with stable callbacks.
 - **Pet overlay does not parse the workbench**: `#/pet` `import()`s `PetApp`; the main window `import()`s `App`.
 - **Clippy is silent on macOS host builds again (#785)**: Windows-only overlay/WSL/shim items use the existing `cfg_attr(not(windows), allow(dead_code))` idiom so cross-platform tests stay; mechanical style lints and Tauri `too_many_arguments` allows restore zero `cargo clippy --all-targets` warnings without behavior change.
@@ -40,6 +41,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **资源栏代码预览对长文件做窗口化**：侧栏 / Changes 的 `CodePreview` 短文件仍整表渲染。200 行以上（含 5000 行源文件）只挂可见行并高亮这些行，不再对整文件跑 highlight.js、也不再一行一个 DOM 节点。
 - **权限倒计时、git 脏文件芯片和 Tasks liveMap 不再打穿工作台**：自动拒绝秒数在权限条内部跳动。git 芯片只在条数/文案变化时 setState。Tasks 面板自己订阅 liveMap。ConversationThreadLive 带稳定回调并 memo。
 - **宠物浮层不再解析工作台**：`#/pet` 动态加载 `PetApp`；主窗口动态加载 `App`。
 - **macOS 上 clippy 再次零警告（#785）**：Windows 专用 overlay/WSL/shim 用既有 `cfg_attr(not(windows), allow(dead_code))`，跨平台测试仍跑；机械风格与 Tauri `too_many_arguments` allow 恢复 `cargo clippy --all-targets` 零警告，无行为变化。

--- a/src/components/CodePreview.test.tsx
+++ b/src/components/CodePreview.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@/test/jsdomStubs";
+import { CodePreview } from "./CodePreview";
+import { CODE_PREVIEW_VIRTUALIZE_THRESHOLD } from "@/lib/codePreviewWindow";
+
+afterEach(cleanup);
+
+describe("CodePreview", () => {
+  it("renders every line for a short file", () => {
+    render(
+      <CodePreview code={"const a = 1;\nconst b = 2;\n"} fileName="a.ts" />,
+    );
+    expect(document.querySelectorAll("[data-line]")).toHaveLength(2);
+    expect(document.querySelector(".rp-code")?.getAttribute("data-virtualized")).toBe(
+      "0",
+    );
+  });
+
+  it("does not mount every row of a 5000-line file", () => {
+    const code = Array.from(
+      { length: 5000 },
+      (_, i) => `const n${i} = ${i};`,
+    ).join("\n");
+    render(<CodePreview code={code} fileName="big.ts" />);
+    const mounted = document.querySelectorAll("[data-line]").length;
+    expect(mounted).toBeGreaterThan(0);
+    expect(mounted).toBeLessThan(CODE_PREVIEW_VIRTUALIZE_THRESHOLD);
+    expect(document.querySelector(".rp-code")?.getAttribute("data-virtualized")).toBe(
+      "1",
+    );
+  });
+});

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -7,6 +7,14 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import hljs from "highlight.js/lib/core";
 import { normalizeFocusLine } from "@/lib/pathLineCitation";
+import { VirtualList } from "@/components/VirtualList";
+import {
+  CODE_PREVIEW_LINE_HEIGHT_PX,
+  CODE_PREVIEW_OVERSCAN,
+  CODE_PREVIEW_VIRTUALIZE_THRESHOLD,
+  shouldVirtualizeCodePreview,
+  splitSourceLines,
+} from "@/lib/codePreviewWindow";
 
 import javascript from "highlight.js/lib/languages/javascript";
 import typescript from "highlight.js/lib/languages/typescript";
@@ -231,6 +239,25 @@ function splitHighlightedLines(html: string): string[] {
   return lines;
 }
 
+function highlightSource(code: string, lang: string): string {
+  try {
+    if (lang && hljs.getLanguage(lang)) {
+      return hljs.highlight(code, {
+        language: lang,
+        ignoreIllegals: true,
+      }).value;
+    }
+  } catch {
+    /* fall through */
+  }
+  return escapeHtml(code);
+}
+
+function highlightOneLine(text: string, lang: string): string {
+  if (!text) return "";
+  return highlightSource(text, lang);
+}
+
 export function CodePreview({
   code,
   fileName,
@@ -243,7 +270,6 @@ export function CodePreview({
   ensureLangs();
 
   const [theme, setTheme] = useState<"light" | "dark">(readDocTheme);
-  const focusRef = useRef<HTMLSpanElement | null>(null);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -260,44 +286,40 @@ export function CodePreview({
     return "plaintext";
   }, [language, fileName]);
 
-  const lineHtml = useMemo(() => {
-    let highlighted: string;
-    try {
-      if (lang && hljs.getLanguage(lang)) {
-        highlighted = hljs.highlight(code, {
-          language: lang,
-          ignoreIllegals: true,
-        }).value;
-      } else {
-        // Prefer plain escape over highlightAuto for unknown langs — auto is
-        // slow on large files and often wrong for short snippets.
-        highlighted = escapeHtml(code);
-      }
-    } catch {
-      highlighted = escapeHtml(code);
-    }
-    const parts = splitHighlightedLines(highlighted);
-    // Match source line count: trailing newline does not add an extra gutter row.
+  const sourceLines = useMemo(() => splitSourceLines(code), [code]);
+  const virtualize = shouldVirtualizeCodePreview(sourceLines.length);
+
+  const smallHtml = useMemo(() => {
+    if (virtualize) return null;
+    const parts = splitHighlightedLines(highlightSource(code, lang));
     if (parts.length > 0 && parts[parts.length - 1] === "") parts.pop();
     if (parts.length === 0) parts.push("");
     return parts;
-  }, [code, lang]);
+  }, [code, lang, virtualize]);
 
-  const lines = lineHtml.length;
+  const lineCacheRef = useRef<{
+    lang: string;
+    code: string;
+    map: Map<number, string>;
+  }>({ lang: "", code: "", map: new Map() });
+  if (
+    lineCacheRef.current.lang !== lang ||
+    lineCacheRef.current.code !== code
+  ) {
+    lineCacheRef.current = { lang, code, map: new Map() };
+  }
+
+  const htmlAt = (index: number): string => {
+    if (smallHtml) return smallHtml[index] ?? "";
+    const cached = lineCacheRef.current.map.get(index);
+    if (cached != null) return cached;
+    const html = highlightOneLine(sourceLines[index] ?? "", lang);
+    lineCacheRef.current.map.set(index, html);
+    return html;
+  };
+
+  const lines = sourceLines.length;
   const activeLine = normalizeFocusLine(focusLine, lines);
-
-  useEffect(() => {
-    if (activeLine == null) return;
-    const el = focusRef.current;
-    if (!el) return;
-    // Double rAF: wait for layout after tab switch / async read.
-    const id = requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        el.scrollIntoView({ block: "center", behavior: "smooth" });
-      });
-    });
-    return () => cancelAnimationFrame(id);
-  }, [activeLine, code, fileName]);
 
   return (
     <div
@@ -309,45 +331,54 @@ export function CodePreview({
       )}
       data-language={lang}
       data-focus-line={activeLine ?? undefined}
+      data-virtualized={virtualize ? "1" : "0"}
     >
-      <div className="rp-code__scroll">
-        {showLineNumbers ? (
-          <div className="rp-code__gutter" aria-hidden>
-            {Array.from({ length: lines }, (_, i) => (
-              <span
-                key={i}
-                className={cn(
-                  "rp-code__ln",
-                  activeLine === i + 1 && "rp-code__ln--focus",
-                )}
+      <div className="rp-code__scroll" style={{ overflow: "auto" }}>
+        <VirtualList
+          className="rp-code__list"
+          items={sourceLines}
+          getKey={(_line, index) => String(index)}
+          rowHeight={CODE_PREVIEW_LINE_HEIGHT_PX}
+          threshold={CODE_PREVIEW_VIRTUALIZE_THRESHOLD}
+          overscan={CODE_PREVIEW_OVERSCAN}
+          scrollToKey={
+            activeLine != null ? String(activeLine - 1) : null
+          }
+          style={{ paddingTop: 14, paddingBottom: 20 }}
+          renderItem={(_line, index) => {
+            const isFocus = activeLine === index + 1;
+            const html = htmlAt(index);
+            return (
+              <div
+                className={cn("rp-code__row", isFocus && "is-focus")}
+                data-line={index + 1}
               >
-                {i + 1}
-              </span>
-            ))}
-          </div>
-        ) : null}
-        <pre className="rp-code__pre">
-          <code className={`hljs language-${lang}`}>
-            {lineHtml.map((html, i) => {
-              const isFocus = activeLine === i + 1;
-              return (
+                {showLineNumbers ? (
+                  <span
+                    className={cn(
+                      "rp-code__ln",
+                      isFocus && "rp-code__ln--focus",
+                    )}
+                    aria-hidden
+                  >
+                    {index + 1}
+                  </span>
+                ) : null}
                 <span
-                  key={i}
-                  ref={isFocus ? focusRef : undefined}
                   className={cn(
                     "rp-code__line",
+                    "hljs",
+                    `language-${lang}`,
                     isFocus && "rp-code__line--focus",
                   )}
-                  data-line={i + 1}
-                  // Empty lines need a non-collapsing marker for gutter alignment.
                   dangerouslySetInnerHTML={{
                     __html: html.length ? html : "&#8203;",
                   }}
                 />
-              );
-            })}
-          </code>
-        </pre>
+              </div>
+            );
+          }}
+        />
       </div>
       {footer ? <div className="rp-code__footer">{footer}</div> : null}
     </div>

--- a/src/components/VirtualList.tsx
+++ b/src/components/VirtualList.tsx
@@ -7,7 +7,6 @@
 import {
   Fragment,
   useCallback,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -16,6 +15,7 @@ import {
 } from "react";
 import {
   computeVirtualWindow,
+  DEFAULT_OVERSCAN,
   scrollTopForIndex,
   SIDEBAR_VIRTUALIZE_THRESHOLD,
   type VirtualWindow,
@@ -81,6 +81,24 @@ const fullWindow = (count: number): VirtualWindow => ({
   totalHeight: 0,
 });
 
+/** First paint must not mount every row before the scroll parent is measured. */
+function initialWindow(
+  count: number,
+  virtualize: boolean,
+  overscan?: number,
+): VirtualWindow {
+  if (!virtualize) return fullWindow(count);
+  const over = Math.max(0, overscan ?? DEFAULT_OVERSCAN);
+  const end = Math.min(count, Math.max(1, over * 2 + 1));
+  return {
+    start: 0,
+    end,
+    paddingTop: 0,
+    paddingBottom: 0,
+    totalHeight: 0,
+  };
+}
+
 export function VirtualList<T>({
   items,
   getKey,
@@ -98,7 +116,9 @@ export function VirtualList<T>({
   const count = items.length;
   const shouldVirtualize = count >= threshold;
 
-  const [win, setWin] = useState<VirtualWindow>(() => fullWindow(count));
+  const [win, setWin] = useState<VirtualWindow>(() =>
+    initialWindow(count, shouldVirtualize, overscan),
+  );
 
   const recompute = useCallback(() => {
     const root = rootRef.current;
@@ -115,7 +135,7 @@ export function VirtualList<T>({
 
     if (!scrollParent) {
       setWin((prev) => {
-        const next = fullWindow(count);
+        const next = initialWindow(count, true, overscan);
         return windowsEqual(prev, next) ? prev : next;
       });
       return;
@@ -136,7 +156,7 @@ export function VirtualList<T>({
     setWin((prev) => (windowsEqual(prev, next) ? prev : next));
   }, [count, rowHeight, gap, overscan, shouldVirtualize]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!shouldVirtualize) {
       setWin(fullWindow(count));
       return;

--- a/src/lib/codePreviewWindow.test.ts
+++ b/src/lib/codePreviewWindow.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODE_PREVIEW_VIRTUALIZE_THRESHOLD,
+  shouldVirtualizeCodePreview,
+  splitSourceLines,
+} from "./codePreviewWindow";
+
+describe("splitSourceLines", () => {
+  it("keeps a single empty row for empty input", () => {
+    expect(splitSourceLines("")).toEqual([""]);
+  });
+
+  it("does not add a gutter row for a trailing newline", () => {
+    expect(splitSourceLines("a\nb\n")).toEqual(["a", "b"]);
+  });
+
+  it("keeps an internal empty line", () => {
+    expect(splitSourceLines("a\n\nb")).toEqual(["a", "", "b"]);
+  });
+});
+
+describe("shouldVirtualizeCodePreview", () => {
+  it("leaves short files fully rendered", () => {
+    expect(shouldVirtualizeCodePreview(1)).toBe(false);
+    expect(
+      shouldVirtualizeCodePreview(CODE_PREVIEW_VIRTUALIZE_THRESHOLD - 1),
+    ).toBe(false);
+  });
+
+  it("windows at the threshold (5000-line files included)", () => {
+    expect(
+      shouldVirtualizeCodePreview(CODE_PREVIEW_VIRTUALIZE_THRESHOLD),
+    ).toBe(true);
+    expect(shouldVirtualizeCodePreview(5000)).toBe(true);
+  });
+});

--- a/src/lib/codePreviewWindow.ts
+++ b/src/lib/codePreviewWindow.ts
@@ -1,0 +1,26 @@
+/**
+ * Fixed-row windowing for resource-pane code preview.
+ * Short files stay a full DOM list; large files must not mount every line.
+ */
+
+/** Below this line count, CodePreview renders every row. */
+export const CODE_PREVIEW_VIRTUALIZE_THRESHOLD = 200;
+
+/** Must match `.rp-code__row` height in `code-preview.css`. */
+export const CODE_PREVIEW_LINE_HEIGHT_PX = 20;
+
+/** Extra rows above/below the viewport when windowed. */
+export const CODE_PREVIEW_OVERSCAN = 40;
+
+/** Split source into gutter rows. Trailing newline does not add an empty row. */
+export function splitSourceLines(code: string): string[] {
+  if (!code) return [""];
+  const parts = code.split("\n");
+  if (parts.length > 0 && parts[parts.length - 1] === "") parts.pop();
+  if (parts.length === 0) parts.push("");
+  return parts;
+}
+
+export function shouldVirtualizeCodePreview(lineCount: number): boolean {
+  return lineCount >= CODE_PREVIEW_VIRTUALIZE_THRESHOLD;
+}

--- a/src/styles/code-preview.css
+++ b/src/styles/code-preview.css
@@ -10,25 +10,44 @@
   flex: 1;
   font-family: var(--font-mono);
   font-size: 12.5px;
-  line-height: 1.55;
+  line-height: 20px;
   border-radius: 0;
   -webkit-user-select: text;
   user-select: text;
 }
 
 .rp-code__scroll {
-  display: flex;
+  display: block;
   flex: 1;
   min-height: 0;
   overflow: auto;
-  align-items: flex-start;
 }
 
-.rp-code__gutter {
-  flex: 0 0 auto;
-  min-width: 2.75rem;
-  padding: 14px 0 20px;
+.rp-code__list {
+  min-width: 100%;
+  box-sizing: border-box;
+}
+
+.rp-code__row {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  height: 20px;
+  min-height: 20px;
+  width: max-content;
+  min-width: 100%;
+  box-sizing: border-box;
+}
+
+.rp-code__ln {
+  flex: 0 0 2.75rem;
+  width: 2.75rem;
+  height: 20px;
+  line-height: 20px;
+  padding: 0 10px 0 8px;
   text-align: right;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.75;
   -webkit-user-select: none;
   user-select: none;
   color: var(--text-tertiary);
@@ -37,52 +56,22 @@
   position: sticky;
   left: 0;
   z-index: 1;
+  box-sizing: border-box;
 }
 
-.rp-code__ln {
-  display: block;
-  padding: 0 10px 0 8px;
-  min-height: 1.55em;
-  line-height: 1.55;
-  font-variant-numeric: tabular-nums;
-  opacity: 0.75;
-  -webkit-user-select: none;
-  user-select: none;
-}
-
-.rp-code__pre {
-  flex: 1;
-  margin: 0;
-  padding: 14px 16px 20px 14px;
-  min-width: 0;
-  overflow: visible;
-  background: transparent !important;
-  -webkit-user-select: text;
-  user-select: text;
-  cursor: text;
-}
-
-.rp-code__pre code.hljs {
-  display: block;
-  padding: 0 !important;
-  background: transparent !important;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  white-space: pre;
-  word-break: normal;
-  overflow-wrap: normal;
-  tab-size: 2;
-  -webkit-user-select: text;
-  user-select: text;
-  cursor: text;
-}
-
-/* One block per source line — keeps gutter and body locked together. */
 .rp-code__line {
   display: block;
-  min-height: 1.55em;
-  line-height: 1.55;
+  height: 20px;
+  line-height: 20px;
+  padding: 0 16px 0 14px;
+  white-space: pre;
+  tab-size: 2;
+  font-family: inherit;
+  font-size: inherit;
+  background: transparent !important;
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: text;
 }
 
 /* path:line citation focus (soft highlight; theme-aware) */
@@ -116,7 +105,7 @@
   background: #282c34;
 }
 
-.rp-code--dark .rp-code__gutter {
+.rp-code--dark .rp-code__ln {
   background: #21252b;
   color: #5c6370;
   border-right-color: #181a1f;
@@ -205,7 +194,7 @@
   background: #fafafa;
 }
 
-.rp-code--light .rp-code__gutter {
+.rp-code--light .rp-code__ln {
   background: #f0f0f0;
   color: #9d9d9f;
   border-right-color: #e5e5e6;


### PR DESCRIPTION
## Summary

Side-pane and Changes code preview keeps short files as a full list. Files at 200+ lines only mount the visible rows and highlight those lines, instead of highlight.js plus one DOM node per line for the whole file.

Fixes #817

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/lib/codePreviewWindow.test.ts src/components/CodePreview.test.tsx` (7 passed)
- [ ] Open a short file in the side pane: line numbers and highlight unchanged
- [ ] Open a 5000-line file: preview scrolls, UI stays responsive
- [ ] Changes / split diff of a large file still shows code
- [ ] `path:line` focus still scrolls that line into view
- [ ] CI green

## Checklist

- [x] User-facing strings go through `t()` / `createT`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
