### PR TITLE
perf(layout): overlay side panes on a tight window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Wide windows toggle side panes instantly; narrow windows overlay them**: Ctrl+B / Ctrl+Alt+B no longer interpolate flex width against the chat column. When sidebar + chat + aside fit, the split snaps with no animation. When they would crush chat, the pane overlays with a transform and the OS window does not grow.
 - **Resource code preview windows long files**: Side-pane / Changes `CodePreview` keeps short files as a full list. Files at 200+ lines (including 5000-line sources) only mount the visible rows and highlight those lines, instead of highlight.js + one DOM node per line for the whole file.
 - **Permission countdown, git dirty chip, and Tasks liveMap stay off the workbench shell**: Auto-deny seconds tick inside the permission bar. Git chip setState runs only when the count/label change. The Tasks panel subscribes to liveMap itself. ConversationThreadLive is memoized with stable callbacks.
 - **Pet overlay does not parse the workbench**: `#/pet` `import()`s `PetApp`; the main window `import()`s `App`.
@@ -41,6 +42,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **宽窗瞬时切换侧栏，窄窗改为覆盖层**：Ctrl+B / Ctrl+Alt+B 不再用 flex 宽度去挤聊天列。侧栏 + 聊天 + 右栏能放下时无动画直接切分；会压到聊天时改为 overlay + transform，也不再拉大系统窗口。
 - **资源栏代码预览对长文件做窗口化**：侧栏 / Changes 的 `CodePreview` 短文件仍整表渲染。200 行以上（含 5000 行源文件）只挂可见行并高亮这些行，不再对整文件跑 highlight.js、也不再一行一个 DOM 节点。
 - **权限倒计时、git 脏文件芯片和 Tasks liveMap 不再打穿工作台**：自动拒绝秒数在权限条内部跳动。git 芯片只在条数/文案变化时 setState。Tasks 面板自己订阅 liveMap。ConversationThreadLive 带稳定回调并 memo。
 - **宠物浮层不再解析工作台**：`#/pet` 动态加载 `PetApp`；主窗口动态加载 `App`。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -94,6 +94,7 @@ import {
   SIDEBAR_WIDTH_MIN,
   saveLayout,
 } from "@/lib/layout";
+import { resolveWorkbenchPaneOverlay } from "@/lib/paneOverlay";
 import {
   ensureWindowFitsLayout,
   isWindowFitSuppressed
@@ -2731,10 +2732,42 @@ export function AppWorkbench() {
   );
   const [resizingAside, setResizingAside] = useState(false);
   const [resizingSidebar, setResizingSidebar] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    typeof window !== "undefined" ? window.innerWidth : 1280,
+  );
+  const sidebarOpenW = layout.sidebarWidth || SIDEBAR_DEFAULT_WIDTH;
+  const asideOpenW = Math.max(
+    layout.asideWidth || 0,
+    DEFAULT_LAYOUT.asideWidth,
+    ASIDE_WIDTH_MIN,
+  );
+  const sidebarOverlay =
+    !phoneLayout &&
+    resolveWorkbenchPaneOverlay({
+      viewportWidth,
+      sidebarOpen: true,
+      sidebarWidth: sidebarOpenW,
+      asideOpen: !layout.asideCollapsed,
+      asideWidth: asideOpenW,
+    }).sidebarOverlay;
+  const asideOverlay =
+    !phoneLayout &&
+    !shouldHideChatForSideExpand({
+      expanded: sideWorkbench.expanded,
+      phoneLayout,
+    }) &&
+    resolveWorkbenchPaneOverlay({
+      viewportWidth,
+      sidebarOpen: !layout.sidebarCollapsed,
+      sidebarWidth: sidebarOpenW,
+      asideOpen: true,
+      asideWidth: asideOpenW,
+    }).asideOverlay;
   const { paneMotionClass } = usePaneSplitMotion({
     sidebarCollapsed: layout.sidebarCollapsed,
     asideCollapsed: layout.asideCollapsed,
     phoneLayout,
+    asideOverlay,
   });
   const asideFitGenRef = useRef(0);
   const sidebarFitGenRef = useRef(0);
@@ -2776,7 +2809,8 @@ export function AppWorkbench() {
     viewportWidth?: number;
     sidebarOccupiedWidth?: number;
   } => {
-    const sidebarOpen = !layout.sidebarCollapsed && !phoneLayout;
+    const sidebarOpen =
+      !layout.sidebarCollapsed && !phoneLayout && !sidebarOverlay;
     return {
       windowControlsInset,
       viewportWidth:
@@ -2791,6 +2825,7 @@ export function AppWorkbench() {
     layout.sidebarCollapsed,
     layout.sidebarWidth,
     phoneLayout,
+    sidebarOverlay,
   ]);
 
   /**
@@ -2858,21 +2893,33 @@ export function AppWorkbench() {
       DEFAULT_LAYOUT.asideWidth,
       ASIDE_WIDTH_MIN,
     );
+    const vw =
+      typeof window !== "undefined" ? window.innerWidth : viewportWidth;
+    const overlay = resolveWorkbenchPaneOverlay({
+      viewportWidth: vw,
+      sidebarOpen: !cur.sidebarCollapsed,
+      sidebarWidth: cur.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
+      asideOpen: true,
+      asideWidth: preferredAside,
+    });
     // Sync-clamp to the *current* viewport before paint. Opening at preferred
     // width first (old path) made sidebar + main min + aside overflow narrow
     // non-maximized windows, clipping the side chrome close control off-screen.
-    const syncWidth = clampAsideWidth(preferredAside, {
-      ...asideClampOpts(),
-      viewportWidth:
-        typeof window !== "undefined" ? window.innerWidth : undefined,
-      sidebarOccupiedWidth: cur.sidebarCollapsed
-        ? 0
-        : cur.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
-    });
+    const syncWidth = overlay.asideOverlay
+      ? preferredAside
+      : clampAsideWidth(preferredAside, {
+          ...asideClampOpts(),
+          viewportWidth: vw,
+          sidebarOccupiedWidth:
+            cur.sidebarCollapsed || overlay.sidebarOverlay
+              ? 0
+              : cur.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
+        });
     // If the frame is too tight for any aside (syncWidth 0), still paint a
     // small pane and let window fit / expand try to recover.
-    const paintWidth =
-      syncWidth > 0
+    const paintWidth = overlay.asideOverlay
+      ? preferredAside
+      : syncWidth > 0
         ? syncWidth
         : Math.min(preferredAside, ASIDE_WIDTH_MIN);
     setLayout((l) => {
@@ -2891,6 +2938,7 @@ export function AppWorkbench() {
       asideCollapsed: false as const,
       asideWidth: preferredAside,
     };
+    if (overlay.asideOverlay) return;
     const fitGen = ++asideFitGenRef.current;
     void fitWindowThenClampAside(projected).then((width) => {
       if (asideFitGenRef.current !== fitGen) return;
@@ -2904,7 +2952,7 @@ export function AppWorkbench() {
         return n;
       });
     });
-  }, [asideClampOpts, fitWindowThenClampAside, phoneLayout]);
+  }, [asideClampOpts, fitWindowThenClampAside, phoneLayout, viewportWidth]);
 
   /** Collapse the right Side Workbench (and exit expand / dock composer). */
   const closeAsidePane = useCallback(() => {
@@ -2956,14 +3004,30 @@ export function AppWorkbench() {
     }
     const cur = layoutRef.current;
     if (!cur.sidebarCollapsed) return;
+    const vw =
+      typeof window !== "undefined" ? window.innerWidth : viewportWidth;
+    const asideW = Math.max(
+      cur.asideWidth || 0,
+      DEFAULT_LAYOUT.asideWidth,
+      ASIDE_WIDTH_MIN,
+    );
+    const overlay = resolveWorkbenchPaneOverlay({
+      viewportWidth: vw,
+      sidebarOpen: true,
+      sidebarWidth: cur.sidebarWidth || SIDEBAR_WIDTH_MIN,
+      asideOpen: !cur.asideCollapsed,
+      asideWidth: asideW,
+    });
     // After auto-collapse (drag below threshold) width is stored as MIN;
     // always open at least SIDEBAR_WIDTH_MIN.
     const openWidth = clampSidebarWidth(
       cur.sidebarWidth || SIDEBAR_WIDTH_MIN,
       {
-        viewportWidth:
-          typeof window !== "undefined" ? window.innerWidth : undefined,
-        asideOccupiedWidth: cur.asideCollapsed ? 0 : cur.asideWidth || 0,
+        viewportWidth: vw,
+        asideOccupiedWidth:
+          cur.asideCollapsed || overlay.asideOverlay
+            ? 0
+            : cur.asideWidth || 0,
       },
     );
     setLayout((l) => {
@@ -2984,6 +3048,7 @@ export function AppWorkbench() {
         ? cur.asideWidth
         : Math.max(cur.asideWidth || 0, DEFAULT_LAYOUT.asideWidth),
     };
+    if (overlay.sidebarOverlay) return;
     const fitGen = ++sidebarFitGenRef.current;
     void fitWindowThenClampAside(projected).then((width) => {
       if (sidebarFitGenRef.current !== fitGen) return;
@@ -2996,7 +3061,7 @@ export function AppWorkbench() {
         return n;
       });
     });
-  }, [fitWindowThenClampAside, phoneLayout]);
+  }, [fitWindowThenClampAside, phoneLayout, viewportWidth]);
 
   const closeSidebarPane = useCallback(() => {
     sidebarFitGenRef.current += 1;
@@ -3989,6 +4054,13 @@ export function AppWorkbench() {
       for (const u of cleanups) u();
     };
   }, [tr]);
+
+  useEffect(() => {
+    const sync = () => setViewportWidth(window.innerWidth);
+    sync();
+    window.addEventListener("resize", sync);
+    return () => window.removeEventListener("resize", sync);
+  }, []);
 
   // User-driven window resize only: clamp open aside. Ignore programmatic setSize
   // (isWindowFitSuppressed) so open-pane fit does not fight resize handlers.
@@ -13115,17 +13187,21 @@ export function AppWorkbench() {
     expanded: sideWorkbench.expanded,
     phoneLayout,
   });
-  const sidebarPaint = layout.sidebarCollapsed
-    ? 0
-    : layout.sidebarWidth || SIDEBAR_DEFAULT_WIDTH;
-  const asidePaint = layout.asideCollapsed ? 0 : layout.asideWidth;
+  const sidebarPaint =
+    layout.sidebarCollapsed || sidebarOverlay
+      ? 0
+      : layout.sidebarWidth || SIDEBAR_DEFAULT_WIDTH;
+  const asidePaint =
+    layout.asideCollapsed || asideOverlay ? 0 : layout.asideWidth;
   const sideDockActive = isSideDockComposerActive({
     expanded: sideWorkbench.expanded,
     dockComposer: sideDockComposer,
     phoneLayout,
   });
   const dockSidebarOccupied =
-    phoneLayout || layout.sidebarCollapsed ? 0 : layout.sidebarWidth;
+    phoneLayout || layout.sidebarCollapsed || sidebarOverlay
+      ? 0
+      : layout.sidebarWidth;
 
   // Expand ends → close dock toggle.
   useEffect(() => {
@@ -19074,7 +19150,7 @@ export function AppWorkbench() {
           {
             // Free-area left edge for expanded side overlay (px).
             ["--sw-sidebar-occupied"]:
-              phoneLayout || layout.sidebarCollapsed
+              phoneLayout || layout.sidebarCollapsed || sidebarOverlay
                 ? "0px"
                 : `${layout.sidebarWidth}px`,
             // Bottom strip reserved only while dock toggle is on.
@@ -19094,6 +19170,27 @@ export function AppWorkbench() {
             onClick={closePhoneDrawer}
           />
         ) : null}
+        {!phoneLayout &&
+        ((sidebarOverlay && !layout.sidebarCollapsed) ||
+          (asideOverlay && !layout.asideCollapsed)) ? (
+          <button
+            type="button"
+            className="workbench-pane-scrim"
+            aria-label={
+              sidebarOverlay && !layout.sidebarCollapsed
+                ? tr("phone.drawerClose")
+                : tr("main.rightPaneHide")
+            }
+            onClick={() => {
+              if (sidebarOverlay && !layout.sidebarCollapsed) {
+                closeSidebarPane();
+              }
+              if (asideOverlay && !layout.asideCollapsed) {
+                closeAsidePane();
+              }
+            }}
+          />
+        ) : null}
         {/* LEFT — fully hideable (not icon-rail); open via top-bar icon when closed */}
         <aside
           className={
@@ -19102,17 +19199,25 @@ export function AppWorkbench() {
             (resizingSidebar ? " is-resizing" : "") +
             (dragZone === "sidebar" ? " is-drop-target" : "") +
             (dragZone === "main" ? " is-drop-idle" : "") +
-            (phoneLayout ? " sidebar--phone-drawer" : "")
+            (phoneLayout ? " sidebar--phone-drawer" : "") +
+            (sidebarOverlay ? " sidebar--overlay" : "")
           }
           aria-label={tr("a11y.sidebar")}
           aria-hidden={layout.sidebarCollapsed}
           style={
             phoneLayout
               ? undefined
-              : ({
-                  ...paneSplitSizeStyle(sidebarPaint, "x", resizingSidebar),
-                  ["--sidebar-rail-min"]: `${layout.sidebarWidth || SIDEBAR_DEFAULT_WIDTH}px`,
-                } as CSSProperties)
+              : sidebarOverlay
+                ? ({
+                    width: sidebarOpenW,
+                    minWidth: sidebarOpenW,
+                    maxWidth: sidebarOpenW,
+                    ["--sidebar-rail-min"]: `${sidebarOpenW}px`,
+                  } as CSSProperties)
+                : ({
+                    ...paneSplitSizeStyle(sidebarPaint, "x", resizingSidebar),
+                    ["--sidebar-rail-min"]: `${sidebarOpenW}px`,
+                  } as CSSProperties)
           }
         >
           {dragZone === "sidebar" && (
@@ -19127,7 +19232,7 @@ export function AppWorkbench() {
             </div>
           )}
           {/* Right-edge drag handle — desktop only (phone is overlay drawer) */}
-          {!layout.sidebarCollapsed && !phoneLayout ? (
+          {!layout.sidebarCollapsed && !phoneLayout && !sidebarOverlay ? (
             <div
               className="sidebar-resizer"
               role="separator"
@@ -22180,20 +22285,28 @@ export function AppWorkbench() {
             (layout.asideCollapsed ? "aside aside--hidden" : "aside") +
             (resizingAside ? " is-resizing" : "") +
             (phoneLayout ? " aside--phone-overlay" : "") +
-            (hideChatForSideExpand ? " aside--side-expanded" : "")
+            (hideChatForSideExpand ? " aside--side-expanded" : "") +
+            (asideOverlay ? " aside--overlay" : "")
           }
           aria-label={tr("a11y.resourcesPane")}
           aria-hidden={layout.asideCollapsed}
           style={
             phoneLayout || hideChatForSideExpand
               ? undefined
-              : ({
-                  ...paneSplitSizeStyle(asidePaint, "x", resizingAside),
-                  ["--aside-rail-min"]: `${layout.asideWidth || DEFAULT_LAYOUT.asideWidth}px`,
-                } as CSSProperties)
+              : asideOverlay
+                ? ({
+                    width: asideOpenW,
+                    minWidth: asideOpenW,
+                    maxWidth: asideOpenW,
+                    ["--aside-rail-min"]: `${asideOpenW}px`,
+                  } as CSSProperties)
+                : ({
+                    ...paneSplitSizeStyle(asidePaint, "x", resizingAside),
+                    ["--aside-rail-min"]: `${layout.asideWidth || DEFAULT_LAYOUT.asideWidth}px`,
+                  } as CSSProperties)
           }
         >
-          {!layout.asideCollapsed && !hideChatForSideExpand && (
+          {!layout.asideCollapsed && !hideChatForSideExpand && !asideOverlay && (
             <div
               className="aside-resizer"
               role="separator"

--- a/src/hooks/usePaneSplitMotion.ts
+++ b/src/hooks/usePaneSplitMotion.ts
@@ -40,8 +40,6 @@ export function usePaneSplitMotion(opts: {
     keyRef.current = key;
   } else if (keyRef.current !== key) {
     const colon = keyRef.current.indexOf(":");
-    const sidebarChanged =
-      keyRef.current.slice(0, colon) !== String(opts.sidebarCollapsed);
     const asideChanged =
       keyRef.current.slice(colon + 1) !== String(opts.asideCollapsed);
     keyRef.current = key;

--- a/src/hooks/usePaneSplitMotion.ts
+++ b/src/hooks/usePaneSplitMotion.ts
@@ -26,6 +26,8 @@ export function usePaneSplitMotion(opts: {
   sidebarCollapsed: boolean;
   asideCollapsed: boolean;
   phoneLayout?: boolean;
+  /** Right pane is an overlay drawer — cover native webviews during transform. */
+  asideOverlay?: boolean;
 }): { paneMotionClass: string } {
   const [, setEpoch] = useState(0);
   const keyRef = useRef<string | null>(null);
@@ -45,6 +47,8 @@ export function usePaneSplitMotion(opts: {
     keyRef.current = key;
     if (
       !opts.phoneLayout &&
+      asideChanged &&
+      opts.asideOverlay &&
       shouldStartPaneSplitMotion({
         reducedMotion: false,
         isFirstCommit: false,
@@ -53,10 +57,10 @@ export function usePaneSplitMotion(opts: {
     ) {
       if (tokenRef.current) endPaneSplitMotion(tokenRef.current);
       tokenRef.current = beginPaneSplitMotion({
-        cover: asideChanged,
-        width: true,
-        sidebar: sidebarChanged,
-        aside: asideChanged,
+        cover: true,
+        width: false,
+        sidebar: false,
+        aside: false,
       });
     }
   }

--- a/src/lib/paneOverlay.test.ts
+++ b/src/lib/paneOverlay.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { MAIN_CHAT_MIN_WIDTH } from "@/lib/layout";
+import { resolveWorkbenchPaneOverlay } from "./paneOverlay";
+
+describe("resolveWorkbenchPaneOverlay", () => {
+  it("keeps both panes in flow when the window fits chat plus both", () => {
+    expect(
+      resolveWorkbenchPaneOverlay({
+        viewportWidth: 1400,
+        sidebarOpen: true,
+        sidebarWidth: 268,
+        asideOpen: true,
+        asideWidth: 400,
+      }),
+    ).toEqual({ sidebarOverlay: false, asideOverlay: false });
+  });
+
+  it("overlays the right pane when both open would crush chat", () => {
+    expect(
+      resolveWorkbenchPaneOverlay({
+        viewportWidth: 900,
+        sidebarOpen: true,
+        sidebarWidth: 268,
+        asideOpen: true,
+        asideWidth: 400,
+      }),
+    ).toEqual({ sidebarOverlay: false, asideOverlay: true });
+  });
+
+  it("overlays a single pane that cannot sit beside the chat floor", () => {
+    expect(
+      resolveWorkbenchPaneOverlay({
+        viewportWidth: MAIN_CHAT_MIN_WIDTH + 100,
+        sidebarOpen: true,
+        sidebarWidth: 268,
+        asideOpen: false,
+        asideWidth: 400,
+      }),
+    ).toEqual({ sidebarOverlay: true, asideOverlay: false });
+  });
+
+  it("does not overlay when both panes are closed", () => {
+    expect(
+      resolveWorkbenchPaneOverlay({
+        viewportWidth: 500,
+        sidebarOpen: false,
+        sidebarWidth: 268,
+        asideOpen: false,
+        asideWidth: 400,
+      }),
+    ).toEqual({ sidebarOverlay: false, asideOverlay: false });
+  });
+});

--- a/src/lib/paneOverlay.ts
+++ b/src/lib/paneOverlay.ts
@@ -1,0 +1,44 @@
+/**
+ * When a pane plus the chat floor would not fit, overlay it instead of
+ * interpolating flex width (and growing the OS window).
+ */
+
+import { MAIN_CHAT_MIN_WIDTH } from "@/lib/layout";
+
+export type WorkbenchPaneOverlay = {
+  sidebarOverlay: boolean;
+  asideOverlay: boolean;
+};
+
+export function resolveWorkbenchPaneOverlay(opts: {
+  viewportWidth: number;
+  sidebarOpen: boolean;
+  sidebarWidth: number;
+  asideOpen: boolean;
+  asideWidth: number;
+  chatMin?: number;
+}): WorkbenchPaneOverlay {
+  const vw = opts.viewportWidth;
+  const chatMin = opts.chatMin ?? MAIN_CHAT_MIN_WIDTH;
+  if (!(vw > 0) || !Number.isFinite(vw) || !Number.isFinite(chatMin)) {
+    return { sidebarOverlay: false, asideOverlay: false };
+  }
+  const side = opts.sidebarOpen ? Math.max(0, opts.sidebarWidth) : 0;
+  const aside = opts.asideOpen ? Math.max(0, opts.asideWidth) : 0;
+  if (side + aside + chatMin <= vw) {
+    return { sidebarOverlay: false, asideOverlay: false };
+  }
+  if (side > 0 && aside > 0) {
+    if (side + chatMin <= vw) {
+      return { sidebarOverlay: false, asideOverlay: true };
+    }
+    if (aside + chatMin <= vw) {
+      return { sidebarOverlay: true, asideOverlay: false };
+    }
+    return { sidebarOverlay: true, asideOverlay: true };
+  }
+  return {
+    sidebarOverlay: side > 0,
+    asideOverlay: aside > 0,
+  };
+}

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -115,19 +115,27 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(block).not.toMatch(/--motion-pane\s*:\s*0ms/);
   });
 
-  it("sidebar / aside / bottom terminal still interpolate the used size", () => {
+  it("in-flow sidebar / aside snap; overlay drawers interpolate transform", () => {
     const sidebar = readFileSync(
       resolve(__dirname, "../styles/sidebar.part1.css"),
       "utf8",
     );
-    expect(ruleBody(sidebar, "\n.sidebar {")).toMatch(
+    expect(ruleBody(sidebar, "\n.sidebar {")).not.toMatch(
       /width var\(--motion-pane\)/,
+    );
+    expect(sidebar).toMatch(
+      /\.sidebar\.sidebar--overlay[^{]*\{[^}]*transform var\(--motion-pane\)/,
     );
     const aside = readFileSync(
       resolve(__dirname, "../styles/chat.part6.css"),
       "utf8",
     );
-    expect(ruleBody(aside, "\n.aside {")).toMatch(/width var\(--motion-pane\)/);
+    expect(ruleBody(aside, "\n.aside {")).not.toMatch(
+      /width var\(--motion-pane\)/,
+    );
+    expect(aside).toMatch(
+      /\.aside\.aside--overlay[^{]*\{[^}]*transform var\(--motion-pane\)/,
+    );
     const hidden = ruleBody(aside, ".aside--collapsed");
     expect(hidden).not.toMatch(/width\s*:\s*0\s*!important/);
     const bt = readFileSync(

--- a/src/styles/chat.part6.css
+++ b/src/styles/chat.part6.css
@@ -571,12 +571,7 @@
   min-width: 0;
   border-left: 1px solid var(--border-subtle);
   background: var(--bg-aside);
-  transition:
-    width var(--motion-pane) var(--motion-pane-ease),
-    min-width var(--motion-pane) var(--motion-pane-ease),
-    max-width var(--motion-pane) var(--motion-pane-ease),
-    flex-basis var(--motion-pane) var(--motion-pane-ease),
-    border-color var(--motion-pane) ease;
+  transition: border-color var(--motion-pane) ease;
   /* visible so the resizer can extend slightly into main for hit-testing */
   overflow: visible;
   display: flex;
@@ -589,6 +584,27 @@
 
 .aside.is-resizing {
   transition: none;
+}
+
+.aside.aside--overlay {
+  position: absolute;
+  top: var(--titlebar-height, 40px);
+  right: 0;
+  bottom: 0;
+  z-index: 41;
+  flex-shrink: 0;
+  box-shadow: -8px 0 28px rgba(0, 0, 0, 0.22);
+  transition:
+    transform var(--motion-pane) var(--motion-pane-ease),
+    box-shadow var(--motion-pane) ease,
+    border-color var(--motion-pane) ease;
+}
+
+.aside.aside--overlay.aside--hidden,
+.aside.aside--overlay.aside--collapsed {
+  transform: translateX(105%);
+  box-shadow: none;
+  pointer-events: none;
 }
 
 /* Clip only the pane whose box is interpolating. Overflow-hidden on a

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -419,14 +419,48 @@ html.platform-win .window-edge-n {
   padding: 0;
   gap: 0;
   transition:
-    width var(--motion-pane) var(--motion-pane-ease),
-    min-width var(--motion-pane) var(--motion-pane-ease),
-    max-width var(--motion-pane) var(--motion-pane-ease),
-    flex-basis var(--motion-pane) var(--motion-pane-ease),
     border-color var(--motion-pane) ease,
     opacity 180ms ease,
     filter 180ms ease;
   z-index: 1;
+}
+
+/*
+ * Narrow desktop: overlay the rail instead of squeezing chat.
+ * Width stays the open size; motion is transform (compositor), not flex.
+ */
+.sidebar.sidebar--overlay {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 40;
+  flex-shrink: 0;
+  box-shadow: 8px 0 28px rgba(0, 0, 0, 0.22);
+  transition:
+    transform var(--motion-pane) var(--motion-pane-ease),
+    box-shadow var(--motion-pane) ease,
+    border-color var(--motion-pane) ease,
+    opacity 180ms ease,
+    filter 180ms ease;
+}
+
+.sidebar.sidebar--overlay.sidebar--hidden,
+.sidebar.sidebar--overlay.sidebar--collapsed {
+  transform: translateX(-105%);
+  box-shadow: none;
+  pointer-events: none;
+}
+
+.workbench-pane-scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 34;
+  border: none;
+  margin: 0;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.28);
+  cursor: pointer;
 }
 
 /* Drag-resize: skip width transition so the rail tracks the pointer */


### PR DESCRIPTION
## Summary

Ctrl+B / Ctrl+Alt+B no longer interpolate flex width against the chat column. When sidebar + chat + aside fit, the split snaps with no animation. When they would crush chat, the pane overlays with a transform and the OS window does not grow.

Fixes #819

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/lib/paneOverlay.test.ts src/lib/paneSplitMotion.test.ts` (19 passed)
- [ ] Wide window: Ctrl+B / Ctrl+Alt+B snap with no pane animation; chat width changes once
- [ ] Narrow window: pane overlays chat with a slide; OS frame size stays put
- [ ] Click the dimmed chat to close the overlay pane
- [ ] Phone / mirror drawer path unchanged
- [ ] CI green

## Checklist

- [x] User-facing strings go through `t()` / `createT`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
