### PR TITLE
perf(chat): keep code line numbers as one text node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Chat code line numbers are one text node**: Fences with line numbers on keep a single gutter (`1\n2\n…`) instead of one React node per source line, so a 5000-line streamed/pasted block no longer mounts thousands of spans.
 - **Wide windows toggle side panes instantly; narrow windows overlay them**: Ctrl+B / Ctrl+Alt+B no longer interpolate flex width against the chat column. When sidebar + chat + aside fit, the split snaps with no animation. When they would crush chat, the pane overlays with a transform and the OS window does not grow.
 - **Resource code preview windows long files**: Side-pane / Changes `CodePreview` keeps short files as a full list. Files at 200+ lines (including 5000-line sources) only mount the visible rows and highlight those lines, instead of highlight.js + one DOM node per line for the whole file.
 - **Permission countdown, git dirty chip, and Tasks liveMap stay off the workbench shell**: Auto-deny seconds tick inside the permission bar. Git chip setState runs only when the count/label change. The Tasks panel subscribes to liveMap itself. ConversationThreadLive is memoized with stable callbacks.
@@ -42,6 +43,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **聊天代码行号改成一个文本节点**：开启行号时 gutter 是一份 `1\n2\n…`，不再一行一个 React 节点；流式/粘贴的 5000 行代码块不会再挂几千个 span。
 - **宽窗瞬时切换侧栏，窄窗改为覆盖层**：Ctrl+B / Ctrl+Alt+B 不再用 flex 宽度去挤聊天列。侧栏 + 聊天 + 右栏能放下时无动画直接切分；会压到聊天时改为 overlay + transform，也不再拉大系统窗口。
 - **资源栏代码预览对长文件做窗口化**：侧栏 / Changes 的 `CodePreview` 短文件仍整表渲染。200 行以上（含 5000 行源文件）只挂可见行并高亮这些行，不再对整文件跑 highlight.js、也不再一行一个 DOM 节点。
 - **权限倒计时、git 脏文件芯片和 Tasks liveMap 不再打穿工作台**：自动拒绝秒数在权限条内部跳动。git 芯片只在条数/文案变化时 setState。Tasks 面板自己订阅 liveMap。ConversationThreadLive 带稳定回调并 memo。

--- a/src/components/lobe-chat/CodeBlock.test.tsx
+++ b/src/components/lobe-chat/CodeBlock.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@/test/jsdomStubs";
+import { CodeBlock } from "./CodeBlock";
+
+afterEach(cleanup);
+
+describe("CodeBlock line gutter", () => {
+  it("omits the gutter when line numbers are off", () => {
+    render(
+      <CodeBlock showLineNumbers={false}>{"a\nb"}</CodeBlock>,
+    );
+    expect(document.querySelector(".chat-code__gutter")).toBeNull();
+    expect(document.querySelector(".chat-code--lines")).toBeNull();
+  });
+
+  it("renders a short fence as one gutter text node", () => {
+    render(
+      <CodeBlock showLineNumbers language="ts">
+        {"const a = 1;\nconst b = 2;\n"}
+      </CodeBlock>,
+    );
+    expect(document.querySelectorAll(".chat-code__ln")).toHaveLength(0);
+    const gutter = document.querySelector(".chat-code__gutter");
+    expect(gutter?.tagName).toBe("PRE");
+    expect(gutter?.textContent).toBe("1\n2");
+  });
+
+  it("does not mount one node per line on a 5000-line fence", () => {
+    const code = Array.from(
+      { length: 5000 },
+      (_, i) => `const n${i} = ${i};`,
+    ).join("\n");
+    render(
+      <CodeBlock showLineNumbers language="ts">
+        {code}
+      </CodeBlock>,
+    );
+    expect(document.querySelectorAll(".chat-code__ln")).toHaveLength(0);
+    const gutter = document.querySelector(".chat-code__gutter");
+    expect(gutter?.childNodes).toHaveLength(1);
+    expect(gutter?.textContent?.startsWith("1\n2\n")).toBe(true);
+    expect(gutter?.textContent?.endsWith("\n4999\n5000")).toBe(true);
+  });
+});

--- a/src/components/lobe-chat/CodeBlock.tsx
+++ b/src/components/lobe-chat/CodeBlock.tsx
@@ -2,9 +2,10 @@
  * Path / code block — Cursor-style soft chrome (label + wrap + copy).
  */
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { IconCheck, IconCopy } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
+import { formatLineNumberGutter } from "@/lib/codeBlockGutter";
 import {
   CODE_LINE_NUMBERS_PREF_EVENT,
   loadCodeLineNumbersPref,
@@ -48,6 +49,10 @@ export function CodeBlock({
   const text = extractText(children).replace(/\n$/, "");
   const showLineNumbers = showLineNumbersProp ?? prefLineNumbers;
   const lineCount = Math.max(1, text.split("\n").length);
+  const gutterText = useMemo(
+    () => (showLineNumbers ? formatLineNumberGutter(lineCount) : ""),
+    [showLineNumbers, lineCount],
+  );
 
   useEffect(() => {
     if (showLineNumbersProp !== undefined) return;
@@ -102,13 +107,9 @@ export function CodeBlock({
       </div>
       <div className="chat-code__body">
         {showLineNumbers ? (
-          <div className="chat-code__gutter" aria-hidden>
-            {Array.from({ length: lineCount }, (_, i) => (
-              <span key={i} className="chat-code__ln">
-                {i + 1}
-              </span>
-            ))}
-          </div>
+          <pre className="chat-code__gutter" aria-hidden>
+            {gutterText}
+          </pre>
         ) : null}
         <pre className={cn("chat-code__pre", wrap && "is-wrap")}>
           <code>{children}</code>

--- a/src/components/lobe-chat/lobe-chat.part1.css
+++ b/src/components/lobe-chat/lobe-chat.part1.css
@@ -636,26 +636,22 @@ html[data-msg-actions="always"] .lobe-chat-item__actions {
 
 .chat-code--lines .chat-code__gutter {
   flex: 0 0 auto;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  padding: 10px 0 14px 12px;
+  min-width: 1.5em;
+  padding: 10px 10px 14px 12px;
   margin: 0;
   font-family: var(--chat-mono);
   font-size: var(--code-fs, var(--chat-fs-sm));
   line-height: 1.55;
   color: var(--chat-text-3);
-  user-select: none;
-  pointer-events: none;
+  background: transparent;
+  border: none;
   border-right: 1px solid var(--chat-code-border);
-}
-
-.chat-code--lines .chat-code__ln {
-  display: block;
-  min-width: 1.5em;
-  padding-right: 10px;
+  border-radius: 0;
+  white-space: pre;
   text-align: right;
   opacity: 0.72;
+  user-select: none;
+  pointer-events: none;
 }
 
 .chat-code--lines .chat-code__pre {

--- a/src/lib/codeBlockGutter.test.ts
+++ b/src/lib/codeBlockGutter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { formatLineNumberGutter } from "./codeBlockGutter";
+
+describe("formatLineNumberGutter", () => {
+  it("always has at least line 1", () => {
+    expect(formatLineNumberGutter(0)).toBe("1");
+    expect(formatLineNumberGutter(-3)).toBe("1");
+    expect(formatLineNumberGutter(Number.NaN)).toBe("1");
+    expect(formatLineNumberGutter(1)).toBe("1");
+  });
+
+  it("is one newline-separated text node", () => {
+    expect(formatLineNumberGutter(3)).toBe("1\n2\n3");
+    expect(formatLineNumberGutter(3.9)).toBe("1\n2\n3");
+  });
+
+  it("covers a 5000-line fence without per-line tokens", () => {
+    const gutter = formatLineNumberGutter(5000);
+    expect(gutter.startsWith("1\n2\n")).toBe(true);
+    expect(gutter.endsWith("\n4999\n5000")).toBe(true);
+    expect(gutter.split("\n")).toHaveLength(5000);
+  });
+});

--- a/src/lib/codeBlockGutter.ts
+++ b/src/lib/codeBlockGutter.ts
@@ -1,0 +1,9 @@
+/** One text node of 1..N so chat fences do not mount a DOM node per line. */
+
+export function formatLineNumberGutter(lineCount: number): string {
+  const n = Number.isFinite(lineCount) ? Math.max(1, Math.floor(lineCount)) : 1;
+  if (n === 1) return "1";
+  const parts = new Array<string>(n);
+  for (let i = 0; i < n; i++) parts[i] = String(i + 1);
+  return parts.join("\n");
+}


### PR DESCRIPTION
## Summary

Chat fences with line numbers on keep a single gutter text node (`1\n2\n…`) instead of one React span per source line. A 5000-line streamed or pasted block no longer mounts thousands of gutter nodes.

Fixes #821

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/lib/codeBlockGutter.test.ts src/components/lobe-chat/CodeBlock.test.tsx` (6 passed)
- [ ] Settings → Appearance → Interface: line numbers on, short fence still shows 1, 2, 3 aligned
- [ ] Line numbers off: no gutter
- [ ] Wrap toggle and copy still work
- [ ] Stream or paste a ~5000-line fence with line numbers on: UI stays responsive
- [ ] CI green

## Checklist

- [x] User-facing strings go through `t()` / `createT`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
