### PR TITLE
chore(rust): restore zero-warning clippy across host builds

### DIFF
--- a/docs/plans/2026-08-22-pr785-pi-review-fix.md
+++ b/docs/plans/2026-08-22-pr785-pi-review-fix.md
@@ -1,0 +1,36 @@
+# PR #785 审核记录（fix 阶段）：**PENDING — pi 服务不可用**
+
+- 分支 `codex/clippy-zero-warnings`（f800fbf2），Fixes #785。
+- 目标：`cargo clippy --all-targets` 在 macOS/Linux/Windows 主机构建恢复 0 警告（98 → 0），无行为变更。
+
+## ⚠️ pi 审核校对状态
+
+按 AGENTS.md §8 强制流程，修复完成后须由 `pi -p`（tools: read,bash）审核校对。
+**2026-08-22 尝试 5 次（间隔递增至 3 分钟），全部返回 `503 Service temporarily unavailable`，
+含最小连通性探测。按规则不以自我复查/子 agent/其它模型顶替，本项保持未完成状态。**
+pi 恢复后补跑审核并回填结论；draft PR 转正前必须完成。
+
+## 本地验证证据（非 pi 结论，仅为机器门禁）
+
+| 门禁 | 结果 |
+|------|------|
+| `cargo clippy --all-targets` | **0 warnings**（基线 98） |
+| `cargo fmt --all -- --check` | clean |
+| `cargo test` | 1414 passed; 0 failed; 1 ignored |
+| 前端 | 未触碰 |
+| Windows 目标本地交叉编译 | 不可行：`ring` C 依赖需 MSVC C 编译器（环境限制）；cfg_attr 门控在 Windows 上为 no-op，语义等价改写双平台一致，交 Windows CI 验证 |
+
+## 改动分类（供 pi 复核）
+
+| 类别 | 内容 |
+|------|------|
+| 全平台真死代码删除 | `session_attach::build_attached_chats_context` 包装、`connect::busy_process_ids_for_warm_reuse` 方法（无生产无测试引用）、`stream::journal_has_assistant_body`、`PrewarmedProcess.model_id/backend`、`ParkedAgent.sandbox_profile` 及级联（`AcpClient::sandbox_profile()` getter + 字段）、`PetHitChrome.window_w/window_h` |
+| cfg_attr(not(windows)) 门控（Windows 生产有调用，保跨平台单测） | `win_taskbar_overlay` 模块级、wsl_backend 四符号、os_theme 两符号、tray_i18n::windows_langid_to_tag、session_api shim 四件套 |
+| cfg_attr(not(test)) 门控（生产孤儿但测试覆盖的纯函数） | warm-reuse 三自由函数、proxy::decision_from、remote_im/i18n::normalize_lang、side_browser_blob::unique_download_path、voice_stt::SttErrorCtx、compact wrapper、extract_chat_session_ids |
+| 机械 style | needless return/ref/clone、collapsible if、identical blocks 合并、is_multiple_of、contains()、from_ref、let-else→?、too_many_arguments allow ×7（Tauri command 按仓库惯例）、assertions_on_constants allow ×4（const 规格护栏测试）、可见性对齐（PetHitChrome、ToolIdentity pub(crate)） |
+
+## 待办
+
+- [ ] pi 补审 → 回填结论
+- [ ] `gh pr ready`
+- [ ] CI 绿后交接维护者合并

--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -1102,8 +1102,8 @@ fn local_usage_from_roots(
     let skip_before = start - ChronoDuration::days(1);
     let skip_before_epoch = skip_before
         .and_hms_opt(0, 0, 0)
-        .and_then(|d| d.and_utc().timestamp().try_into().ok())
-        .unwrap_or(0i64);
+        .map(|d| d.and_utc().timestamp())
+        .unwrap_or(0);
 
     for root in roots {
         if root.is_dir() {
@@ -2078,7 +2078,7 @@ mod tests {
         )
         .unwrap();
 
-        let (heatmap, logs) = local_usage_from_roots(7, 10, &[temp.clone()]);
+        let (heatmap, logs) = local_usage_from_roots(7, 10, std::slice::from_ref(&temp));
         assert_eq!(logs.len(), 1);
         assert_eq!(logs[0].context_tokens, 8000);
         assert_eq!(logs[0].usage_tokens, 35000);

--- a/src-tauri/src/account_profiles.rs
+++ b/src-tauri/src/account_profiles.rs
@@ -475,7 +475,7 @@ mod tests {
     fn quota_item_hides_empty_placeholder_snapshot() {
         let snap = crate::supergrok_quota::default_unused_quota_snapshot();
         let item = quota_item_from_snapshot("u1".into(), snap);
-        assert_eq!(item.available, false);
+        assert!(!item.available);
         assert!(item.remaining_percent.is_none());
     }
 

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -329,8 +329,6 @@ pub struct AcpClient {
     last_update_unstamped: ParkingMutex<Option<Instant>>,
     /// Official side-channel: skip App MCP inject on session/new.
     empty_mcp_servers: bool,
-    /// Effective `--sandbox` profile at spawn (process-level gate for parked reuse).
-    sandbox_profile: ParkingMutex<Option<String>>,
     /// Route class at spawn: custom relay (api_key, no OIDC) vs official OIDC.
     /// Used by process reuse gate — must **not** be inferred from composer
     /// model id (custom routes often store the upstream model name, not the
@@ -1110,11 +1108,6 @@ pub fn should_authenticate_cached_token(custom_route: bool) -> bool {
 }
 
 impl AcpClient {
-    /// Effective sandbox profile this process was spawned with (reuse gate).
-    pub fn sandbox_profile(&self) -> Option<String> {
-        self.sandbox_profile.lock().clone()
-    }
-
     pub fn use_mock() -> bool {
         std::env::var("GROK_APP_ACP")
             .map(|v| v.eq_ignore_ascii_case("mock"))
@@ -1650,7 +1643,6 @@ impl AcpClient {
             last_update_by_session: ParkingMutex::new(HashMap::new()),
             last_update_unstamped: ParkingMutex::new(None),
             empty_mcp_servers,
-            sandbox_profile: ParkingMutex::new(sandbox.map(|sb| sb.profile.clone())),
             custom_route,
             rewind_supported: ParkingMutex::new(None),
         });
@@ -1745,7 +1737,6 @@ impl AcpClient {
             last_update_unstamped: ParkingMutex::new(None),
             // TCP connect path keeps default MCP inject (not official side-channel).
             empty_mcp_servers: false,
-            sandbox_profile: ParkingMutex::new(None),
             // Remote ACP: treat as official-class for reuse (no local auth strip).
             custom_route: false,
             rewind_supported: ParkingMutex::new(None),
@@ -2478,9 +2469,9 @@ pub fn parse_usage_update(kind: &str, update: &Value) -> Option<AcpEvent> {
     // Normalize source so the frontend occupancy classifier matches CLI events.
     let source = if kind == "auto_compact_started" || kind.ends_with("auto_compact_started") {
         "auto_compact_started".to_string()
-    } else if kind == "tokens_used" {
-        "tokens_used".to_string()
-    } else if occupancy.is_some() && input.is_none() && output.is_none() && kind.is_empty() {
+    } else if kind == "tokens_used"
+        || (occupancy.is_some() && input.is_none() && output.is_none() && kind.is_empty())
+    {
         "tokens_used".to_string()
     } else {
         kind.to_string()
@@ -4905,8 +4896,8 @@ mod context_tokens_tests {
         let windows = parse_model_context_tokens(&init);
         assert_eq!(windows.len(), 1);
         assert_eq!(windows.get("has-window"), Some(&128000));
-        assert!(windows.get("no-window").is_none());
-        assert!(windows.get("no-meta").is_none());
+        assert!(!windows.contains_key("no-window"));
+        assert!(!windows.contains_key("no-meta"));
     }
 
     #[test]

--- a/src-tauri/src/agent_workflows.rs
+++ b/src-tauri/src/agent_workflows.rs
@@ -758,7 +758,7 @@ fn run_workflow_inner(
 
     if let Some(out) = child.stdout.take() {
         let buf = Arc::clone(&stdout_buf);
-        let app_c = app.map(|a| a.clone());
+        let app_c = app.cloned();
         let n = name_owned.clone();
         let m = mode_owned.clone();
         let st = Arc::clone(&started_arc);
@@ -784,7 +784,7 @@ fn run_workflow_inner(
     }
     if let Some(err) = child.stderr.take() {
         let buf = Arc::clone(&stderr_buf);
-        let app_c = app.map(|a| a.clone());
+        let app_c = app.cloned();
         let n = name_owned.clone();
         let m = mode_owned.clone();
         let st = Arc::clone(&started_arc);

--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -204,12 +204,9 @@ fn dispatch_close_tab_or_window(app: &AppHandle) {
 }
 
 fn focused_webview(app: &AppHandle) -> Option<WebviewWindow> {
-    for (_, w) in app.webview_windows() {
-        if w.is_focused().unwrap_or(false) {
-            return Some(w);
-        }
-    }
-    None
+    app.webview_windows()
+        .into_values()
+        .find(|w| w.is_focused().unwrap_or(false))
 }
 
 /// Refresh labels when the user changes locale in Settings (best-effort).

--- a/src-tauri/src/cc_switch_import.rs
+++ b/src-tauri/src/cc_switch_import.rs
@@ -1103,9 +1103,7 @@ app_provider_mode = "grok_build_proxy"
             );",
         )
         .expect("schema");
-        let config = format!(
-            "[models]\ndefault = \"grok-4.6\"\n\n[model.\"grok-4.6\"]\nmodel = \"grok-4.6\"\nbase_url = \"https://relay.example/v1\"\nname = \"Relay\"\napi_backend = \"responses\"\napi_key = \"runtime-key\"\n"
-        );
+        let config = "[models]\ndefault = \"grok-4.6\"\n\n[model.\"grok-4.6\"]\nmodel = \"grok-4.6\"\nbase_url = \"https://relay.example/v1\"\nname = \"Relay\"\napi_backend = \"responses\"\napi_key = \"runtime-key\"\n";
         let settings = serde_json::json!({ "config": config }).to_string();
         conn.execute(
             "INSERT INTO providers (id, app_type, name, settings_config, category, is_current)

--- a/src-tauri/src/commands/session_p1.rs
+++ b/src-tauri/src/commands/session_p1.rs
@@ -263,6 +263,7 @@ pub async fn session_reattach(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn session_resolve_permission(
     app: tauri::AppHandle,
     mgr: State<'_, Arc<SessionManager>>,

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -76,6 +76,7 @@ pub async fn terminal_pty_kill(session_id: String) -> Result<(), String> {
 /// Create/replace a side-browser child webview with download save-dialog wiring.
 /// Prefer this over frontend `new Webview()` so WKWebView downloads can prompt.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn side_browser_create(
     app: AppHandle,
     label: String,

--- a/src-tauri/src/desktop_notify.rs
+++ b/src-tauri/src/desktop_notify.rs
@@ -18,7 +18,6 @@
 //! Returns the delivery **path** string on success so Settings can be honest.
 
 use tauri::{AppHandle, Emitter};
-use tauri_plugin_notification::NotificationExt;
 
 /// Product bundle id / AUMID (must match `tauri.conf.json` `identifier`).
 const APP_BUNDLE_ID: &str = "com.grokapp.desktop";
@@ -64,7 +63,7 @@ pub fn desktop_notify_show(
                     %path,
                     "native notification delivered"
                 );
-                return Ok(path.to_string());
+                Ok(path.to_string())
             }
             Err(e) => {
                 tracing::warn!(
@@ -73,7 +72,7 @@ pub fn desktop_notify_show(
                     title = %title,
                     "macos native path failed"
                 );
-                return Err(e);
+                Err(e)
             }
         }
     }

--- a/src-tauri/src/image_thumb.rs
+++ b/src-tauri/src/image_thumb.rs
@@ -13,7 +13,7 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use image::imageops::FilterType;
-use image::{DynamicImage, ImageFormat};
+use image::DynamicImage;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
@@ -354,6 +354,7 @@ pub fn ensure_image_thumb(path_or_url: &str) -> Result<ImageThumbResult, String>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use image::ImageFormat;
 
     #[test]
     fn builds_thumb_from_png_bytes() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -466,10 +466,8 @@ pub fn run() {
                         schedule_persist_main_window_state(window.app_handle());
                     }
                 }
-                WindowEvent::Resized(_) => {
-                    if window.label() == "main" {
-                        schedule_persist_main_window_state(window.app_handle());
-                    }
+                WindowEvent::Resized(_) if window.label() == "main" => {
+                    schedule_persist_main_window_state(window.app_handle());
                 }
                 _ => {}
             }
@@ -828,7 +826,7 @@ pub fn run() {
 
             let pet_prefs = pet_window::load_prefs();
             if pet_prefs.enabled && pet_prefs.visible {
-                if let Err(e) = pet_window::show_pet(&app.handle()) {
+                if let Err(e) = pet_window::show_pet(app.handle()) {
                     tracing::warn!("pet restore: {e}");
                 }
             }

--- a/src-tauri/src/os_theme.rs
+++ b/src-tauri/src/os_theme.rs
@@ -8,9 +8,11 @@
 use tauri::AppHandle;
 
 /// Host → frontend when Windows default *app* mode changes.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub const OS_THEME_CHANGED_EVENT: &str = "os-theme://changed";
 
 /// `AppsUseLightTheme` DWORD: `0` = dark apps, `1` = light. Missing → dark.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub fn apps_prefer_dark_from_dword(apps: Option<u32>) -> bool {
     !apps.is_some_and(|v| v != 0)
 }
@@ -27,7 +29,7 @@ pub fn os_prefers_dark() -> bool {
             let s = String::from_utf8_lossy(&o.stdout).to_ascii_lowercase();
             return s.contains("dark");
         }
-        return true;
+        true
     }
     #[cfg(target_os = "windows")]
     {

--- a/src-tauri/src/pet_window.rs
+++ b/src-tauri/src/pet_window.rs
@@ -193,7 +193,7 @@ pub struct PetTaskPayload {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct PetHitChrome {
+pub(crate) struct PetHitChrome {
     valid: bool,
     mark_cx: f64,
     mark_cy: f64,
@@ -202,8 +202,6 @@ struct PetHitChrome {
     bubble_y: f64,
     bubble_w: f64,
     bubble_h: f64,
-    window_w: f64,
-    window_h: f64,
 }
 
 impl PetHitChrome {
@@ -217,8 +215,6 @@ impl PetHitChrome {
             bubble_y: 0.0,
             bubble_w: 0.0,
             bubble_h: 0.0,
-            window_w: 0.0,
-            window_h: 0.0,
         }
     }
 
@@ -654,6 +650,7 @@ pub fn persist_pet_window_pos(app: &AppHandle) {
 }
 
 /// Physical cursor vs logical hit chrome (mark disc + task-bubble stack).
+#[allow(clippy::too_many_arguments)]
 pub fn pet_cursor_over_chrome(
     cursor_x: f64,
     cursor_y: f64,
@@ -689,6 +686,7 @@ pub fn pet_hit_radius(size_px: u32, scale_factor: f64) -> f64 {
     f64::from(size_px.max(64)) * scale_factor.max(0.5) * 0.52
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn pet_cursor_over_mark(
     cursor_x: f64,
     cursor_y: f64,
@@ -1358,8 +1356,6 @@ pub fn pet_set_hit_chrome(chrome: PetHitChromeIn) {
             bubble_y: chrome.bubble_y,
             bubble_w: chrome.bubble_w.max(0.0).min(max_w),
             bubble_h: chrome.bubble_h.max(0.0).min(max_h),
-            window_w: chrome.window_w.max(0.0),
-            window_h: chrome.window_h.max(0.0),
         };
     }
 }
@@ -1524,8 +1520,6 @@ mod tests {
             bubble_y: 8.0,
             bubble_w: 216.0,
             bubble_h: 80.0,
-            window_w: 260.0,
-            window_h: 280.0,
         };
         let scale = 2.0;
         let win_w = 260.0 * scale;

--- a/src-tauri/src/plan_chrome.rs
+++ b/src-tauri/src/plan_chrome.rs
@@ -231,7 +231,7 @@ pub fn apply_decision(session_id: &str, decision: &str, keep_body: bool) {
         return;
     }
     let mut prev = load_plan_chrome(session_id).unwrap_or_default();
-    let closed = prev.rpc_id.clone();
+    let closed = prev.rpc_id;
     let d = decision.trim().to_ascii_lowercase();
     prev.rpc_id = None;
     prev.gate_stale = false;

--- a/src-tauri/src/process_util.rs
+++ b/src-tauri/src/process_util.rs
@@ -96,7 +96,7 @@ pub fn ensure_home_env_std(cmd: &mut StdCommand) {
         return;
     }
     let home = user_home();
-    if home.as_os_str().is_empty() || home == PathBuf::from(".") {
+    if home.as_os_str().is_empty() || home == Path::new(".") {
         return;
     }
     cmd.env("HOME", home);
@@ -108,7 +108,7 @@ pub fn ensure_home_env_tokio(cmd: &mut tokio::process::Command) {
         return;
     }
     let home = user_home();
-    if home.as_os_str().is_empty() || home == PathBuf::from(".") {
+    if home.as_os_str().is_empty() || home == Path::new(".") {
         return;
     }
     cmd.env("HOME", home);

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -130,7 +130,7 @@ pub fn first_proxy_from_pac(pac_body: &str) -> Option<String> {
             let abs = search_from + rel + prefix.len();
             let rest = pac_body.get(abs..).unwrap_or("");
             let end = rest
-                .find(|c: char| c == ';' || c == '"' || c == '\'' || c == '\n' || c == '\r')
+                .find([';', '"', '\'', '\n', '\r'])
                 .unwrap_or(rest.len());
             let addr = rest[..end].trim();
             if addr.is_empty() || addr.eq_ignore_ascii_case("DIRECT") {
@@ -427,6 +427,7 @@ pub fn decision() -> ProxyDecision {
 
 /// Pure resolution used by tests and callers that only need [`ProxyDecision`]
 /// (system OS reads are live when mode is `system`).
+#[cfg_attr(not(test), allow(dead_code))]
 #[inline]
 pub fn decision_from(
     mode: &str,

--- a/src-tauri/src/remote_im/engine.rs
+++ b/src-tauri/src/remote_im/engine.rs
@@ -1073,7 +1073,7 @@ impl Engine {
             } else {
                 "当前没有可压缩的 agent 会话。请先发送一条消息，或使用 /r 恢复会话。"
             };
-            let _ = self.reply_msg(msg, &text).await;
+            let _ = self.reply_msg(msg, text).await;
             return;
         };
         let Some(agent_session_id) = binding

--- a/src-tauri/src/remote_im/grok_agent.rs
+++ b/src-tauri/src/remote_im/grok_agent.rs
@@ -237,6 +237,7 @@ async fn run_turn_with_binary(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_turn_with_binary_and_env(
     binary: &Path,
     work_dir: &Path,

--- a/src-tauri/src/remote_im/i18n.rs
+++ b/src-tauri/src/remote_im/i18n.rs
@@ -13,6 +13,8 @@ pub enum MessageKey {
 }
 
 /// Canonical catalog id: `en` | `de` | … | `zh-TW`.
+/// Test convenience over [`Locale::parse`]; prod resolves via `resolve_engine_lang`.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn normalize_lang(lang: &str) -> &'static str {
     Locale::parse(lang).as_tag()
 }

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -24,9 +24,6 @@ use parking_lot::Mutex;
 use crate::paths::{ensure_app_dirs, secrets_file};
 use crate::store::SecretsFile;
 
-#[cfg(test)]
-use std::collections::HashMap;
-
 /// Reverse-DNS service id shared with app data layout (`com.grokapp.grok-app`).
 const KEYRING_SERVICE: &str = "com.grokapp.grok-app";
 

--- a/src-tauri/src/session_api.rs
+++ b/src-tauri/src/session_api.rs
@@ -367,6 +367,7 @@ pub struct SessionApiCliLink {
     pub desired_target: String,
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
 const WIN_SHIM_MARKER: &str = "grok-app session-api shim (managed by Grok App)";
 
 pub fn cli_link_name() -> &'static str {
@@ -399,10 +400,12 @@ fn paths_match(a: &std::path::Path, b: &std::path::Path) -> bool {
     ca == cb
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
 fn is_windows_shim(contents: &str) -> bool {
     contents.contains(WIN_SHIM_MARKER)
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
 fn parse_windows_shim_target(contents: &str) -> Option<PathBuf> {
     if !is_windows_shim(contents) {
         return None;
@@ -423,6 +426,7 @@ fn parse_windows_shim_target(contents: &str) -> Option<PathBuf> {
     })
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn render_windows_shim(target: &std::path::Path) -> String {
     format!(
         "@echo off\r\nREM {WIN_SHIM_MARKER}\r\n\"{}\" %*\r\n",
@@ -592,9 +596,9 @@ pub enum CliCommand {
 
 pub fn parse_cli(argv: &[String]) -> Result<CliCommand, String> {
     let args: Vec<&str> = argv.iter().skip(1).map(String::as_str).collect();
-    if args.iter().any(|a| *a == SESSIONS_FLAG) {
+    if args.contains(&SESSIONS_FLAG) {
         return Ok(CliCommand::List {
-            include_archived: args.iter().any(|a| *a == INCLUDE_ARCHIVED_FLAG),
+            include_archived: args.contains(&INCLUDE_ARCHIVED_FLAG),
         });
     }
     if let Some(i) = args.iter().position(|a| *a == SESSION_SEND_FLAG) {
@@ -822,6 +826,9 @@ pub fn classify_send_error(err: &str) -> TurnStatus {
     TurnStatus::Error
 }
 
+// TurnResult carries full error context strings; boxing it would ripple
+// through every caller for no measurable win on this cold path.
+#[allow(clippy::result_large_err)]
 pub fn prepare_send(session_id: &str, prompt: &str) -> Result<PreparedSend, TurnResult> {
     let prompt = prompt.trim();
     if prompt.is_empty() {
@@ -1482,6 +1489,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // const comparison pins the spec budget
     fn retry_later_is_503_and_serializes() {
         assert_eq!(
             status_for(&TurnStatus::RetryLater),

--- a/src-tauri/src/session_attach.rs
+++ b/src-tauri/src/session_attach.rs
@@ -85,6 +85,7 @@ pub fn extract_attached_chats(text: &str) -> Vec<AttachedChatSpec> {
 }
 
 /// Ordered unique session ids from `[[chat:<uuid>]]` tokens.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn extract_chat_session_ids(text: &str) -> Vec<String> {
     extract_attached_chats(text)
         .into_iter()
@@ -242,6 +243,9 @@ fn rewrite_one_token(
 /// Compact user/assistant turns into markdown blocks (no wrapper).
 ///
 /// Char budget is applied **newest-first**: oldest turns drop when over budget.
+/// Test convenience over [`compact_user_assistant_turns_with`]; prod callers
+/// pass the journal explicitly.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn compact_user_assistant_turns(
     msgs: &[ChatMessageStored],
     max_msgs: usize,
@@ -349,13 +353,9 @@ do NOT re-answer prior turns; use it only as background for the user's new messa
 }
 
 /// Build the agent-only prefix for attached chats. Skips self + missing journals.
-pub fn build_attached_chats_context(
-    specs: &[AttachedChatSpec],
-    current_id: &str,
-) -> Option<String> {
-    build_attached_chats_context_with(specs, current_id, &StoreAttachJournal)
-}
-
+/// Unit tests exercise this entry; prod currently reads attach context via
+/// [`compact_user_assistant_turns_with`] during history bootstrap.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn build_attached_chats_context_with(
     specs: &[AttachedChatSpec],
     current_id: &str,

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -1625,9 +1625,7 @@ impl SessionManager {
                     policy,
                     effort: Some(prefs.effort),
                     sandbox_profile: Some(effective_sandbox),
-                    model_id: Some(prefs.model_id),
                     created_at: Instant::now(),
-                    backend: "grok_agent_stdio".into(),
                 });
                 true
             } else {
@@ -1665,29 +1663,6 @@ impl SessionManager {
         }
     }
 
-    /// Process ids that currently host a mid-turn live or background session.
-    /// Parked is never mid-turn (`prompt_in_flight` blocks parking).
-    pub(super) fn busy_process_ids_for_warm_reuse(&self) -> HashSet<String> {
-        let live_pid = {
-            let guard = self.inner.lock();
-            guard.as_ref().and_then(|s| {
-                if s.acp.as_ref().is_some_and(|c| c.is_alive()) && Self::live_session_is_busy(s) {
-                    Some(s.process_id.clone())
-                } else {
-                    None
-                }
-            })
-        };
-        let bg_pids: Vec<String> = {
-            let bg = self.background.lock();
-            bg.values()
-                .filter(|s| Self::live_session_is_busy(s))
-                .map(|s| s.process_id.clone())
-                .collect()
-        };
-        collect_busy_reuse_process_ids(live_pid.as_deref(), bg_pids.iter().map(String::as_str))
-    }
-
     /// Pure reuse gate — split out for unit tests (no AcpClient needed).
     /// Process-level spawn flags must match: permission policy, reasoning
     /// effort, sandbox profile, and route class (official OIDC vs custom
@@ -1697,6 +1672,7 @@ impl SessionManager {
     /// Sandbox: the CLI normalizes "off" to no `--sandbox` flag (stored as
     /// `None` on the client), while settings resolve to the string "off".
     /// Treat None as "off" so both representations match.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn reuse_gate(
         alive: bool,
         p_policy: PermissionPolicy,
@@ -1757,6 +1733,10 @@ impl SessionManager {
 /// `live` is included only when that live shell is itself mid-turn on a
 /// real ACP (the Connecting placeholder with a fresh UUID is omitted by
 /// the caller).
+///
+/// Pure helpers kept for the warm-reuse unit tests; the live connect path
+/// currently gates reuse inline.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn collect_busy_reuse_process_ids<'a>(
     live: Option<&'a str>,
     backgrounds: impl IntoIterator<Item = &'a str>,
@@ -1776,6 +1756,7 @@ pub(super) fn collect_busy_reuse_process_ids<'a>(
 }
 
 /// True when this process currently hosts a mid-turn co-tenant.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn process_blocked_for_warm_reuse(
     process_id: &str,
     busy_process_ids: &HashSet<String>,
@@ -1790,6 +1771,7 @@ pub(super) fn process_blocked_for_warm_reuse(
 /// Parked entries are per-session; the ACP child is shared. Killing on the
 /// parked grain would abort a cohabitant's in-flight turn. The parked row
 /// stays gone so this chat cold-spawns on next connect.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn should_kill_parked_after_flag_mismatch(
     process_id: &str,
     busy_process_ids: &HashSet<String>,
@@ -1854,7 +1836,9 @@ mod connect_preserve_tests {
         assert!(!process_exit_should_fail_fsm(SessionState::Idle, false));
     }
 
+    // Const comparisons are deliberate spec guards pinning the wall-clock budget.
     #[test]
+    #[allow(clippy::assertions_on_constants)]
     fn wall_clock_and_stop_only_abort_handshake() {
         assert!(should_fail_connect_on_wall_clock(SessionState::Connecting));
         assert!(!should_fail_connect_on_wall_clock(SessionState::Ready));
@@ -1865,6 +1849,7 @@ mod connect_preserve_tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)]
     fn wall_clock_covers_lock_wait_and_handshake() {
         assert_eq!(connect_gave_up_reason(false), "connect lock busy");
         assert_eq!(connect_gave_up_reason(true), "connect timed out");

--- a/src-tauri/src/session_manager/control.rs
+++ b/src-tauri/src/session_manager/control.rs
@@ -813,6 +813,7 @@ impl SessionManager {
     /// permissions too (`session://background_permission`), and their rpc id
     /// belongs to *their* ACP child. Resolving against the live slot dropped the
     /// answer on the wrong process and left the background turn stuck forever.
+    #[allow(clippy::too_many_arguments)]
     pub async fn resolve_permission(
         self: &Arc<Self>,
         app: AppHandle,
@@ -1018,7 +1019,7 @@ impl SessionManager {
         let (acp, id) = self
             .with_session_mut(&target, |s| {
                 Self::touch_activity_locked(s);
-                let id = rpc_id.or_else(|| s.pending_plan_rpc_id.clone());
+                let id = rpc_id.or(s.pending_plan_rpc_id);
                 (s.acp.clone(), id)
             })
             .ok_or("no session")?;
@@ -1054,7 +1055,7 @@ impl SessionManager {
         // Peek pending id without taking — only clear after a successful RPC.
         let (acp, id) = self
             .with_session_mut(&target, |s| {
-                let id = rpc_id.or_else(|| s.pending_ask_user_rpc_id.clone());
+                let id = rpc_id.or(s.pending_ask_user_rpc_id);
                 (s.acp.clone(), id)
             })
             .ok_or("no session")?;

--- a/src-tauri/src/session_manager/events_bg.rs
+++ b/src-tauri/src/session_manager/events_bg.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use tauri::{AppHandle, Emitter};
-use uuid::Uuid;
 
 use crate::acp_client::{
     provider_retry_abort_error, provider_retry_abort_rpc_message, should_abort_provider_retry_ex,
@@ -844,12 +843,10 @@ impl SessionManager {
                     let mut bg = self.background.lock();
                     if let Some(s) = bg.get_mut(app_session_id) {
                         s.provider_retry_attempt = attempt;
-                        if !Self::should_apply_provider_retry_abort(s) {
-                            false
-                        } else if s.provider_retry_aborted {
-                            false
-                        } else {
+                        if Self::should_apply_provider_retry_abort(s) && !s.provider_retry_aborted {
                             should_abort_provider_retry_ex(attempt, max_retries, &status, &reason)
+                        } else {
+                            false
                         }
                     } else {
                         false

--- a/src-tauri/src/session_manager/process.rs
+++ b/src-tauri/src/session_manager/process.rs
@@ -476,7 +476,6 @@ impl SessionManager {
                     }
                     return Ok(());
                 }
-                let sandbox_profile = acp.sandbox_profile();
                 let parked = ParkedAgent {
                     process_id: s.process_id.clone(),
                     app_session_id: s.app_session_id.clone(),
@@ -488,7 +487,6 @@ impl SessionManager {
                     product_mode: s.product_mode.clone(),
                     project_path: s.project_path.clone(),
                     policy: s.policy,
-                    sandbox_profile,
                     needs_history_bootstrap: s.needs_history_bootstrap,
                     backend: s.backend.clone(),
                 };
@@ -561,7 +559,6 @@ impl SessionManager {
         let Some(acp) = s.acp.take() else {
             return;
         };
-        let sandbox_profile = acp.sandbox_profile();
         let parked = ParkedAgent {
             process_id: s.process_id.clone(),
             app_session_id: s.app_session_id.clone(),
@@ -573,7 +570,6 @@ impl SessionManager {
             product_mode: s.product_mode.clone(),
             project_path: s.project_path.clone(),
             policy: s.policy,
-            sandbox_profile,
             needs_history_bootstrap: s.needs_history_bootstrap,
             backend: s.backend.clone(),
         };

--- a/src-tauri/src/session_manager/stream.rs
+++ b/src-tauri/src/session_manager/stream.rs
@@ -564,15 +564,6 @@ impl SessionManager {
         out
     }
 
-    /// True when the journal has a non-empty, non-error assistant body (any turn).
-    /// Used only as a silent heal signal when Host is stuck Streaming after work finished.
-    pub(super) fn journal_has_assistant_body(app_session_id: &str) -> bool {
-        store::load_messages(app_session_id)
-            .iter()
-            .rev()
-            .any(|m| m.role == "assistant" && !m.is_error && !m.content.trim().is_empty())
-    }
-
     /// Drop leaked open tool ids (journal already terminal, or aged without updates).
     pub(super) fn prune_orphan_open_tools(s: &mut LiveSession, now: Instant) -> usize {
         if s.open_tool_ids.is_empty() {

--- a/src-tauri/src/session_manager/types.rs
+++ b/src-tauri/src/session_manager/types.rs
@@ -262,9 +262,7 @@ pub(crate) struct PrewarmedProcess {
     pub(super) policy: PermissionPolicy,
     pub(super) effort: Option<String>,
     pub(super) sandbox_profile: Option<String>,
-    pub(super) model_id: Option<String>,
     pub(super) created_at: Instant,
-    pub(super) backend: String,
 }
 
 /// Prewarm slot state. A process that was detached (viewed-only session) is
@@ -291,8 +289,6 @@ pub(crate) struct ParkedAgent {
     pub(super) product_mode: Option<String>,
     pub(super) project_path: Option<String>,
     pub(super) policy: PermissionPolicy,
-    /// Process-level `--sandbox` profile at spawn (reuse gate).
-    pub(super) sandbox_profile: Option<String>,
     pub(super) needs_history_bootstrap: bool,
     pub(super) backend: String,
 }
@@ -536,7 +532,7 @@ pub(super) fn tool_meta_str(raw: &serde_json::Value, field: &str) -> Option<Stri
 /// (`{toolCallId, status, content, rawOutput, locations}`) — without this map
 /// the journal would record bare `tool_step|completed|tool|tool`.
 #[derive(Debug, Clone, Default)]
-pub(super) struct ToolIdentity {
+pub(crate) struct ToolIdentity {
     /// Machine tool name, e.g. `read_file` (from `toolName`).
     pub(super) name: String,
     /// Human title, e.g. `Read` / `Run Command`.
@@ -627,7 +623,7 @@ pub(super) fn remember_tool_identity(
         return;
     }
     let existing = per.get(tool_call_id);
-    let richer = existing.map_or(true, |e| {
+    let richer = existing.is_none_or(|e| {
         let e_sparse =
             e.name.is_empty() && e.title.is_empty() && e.kind.is_empty() && e.input.is_none();
         let mine_sparse = name.is_empty() && t.is_empty() && k.is_empty() && input.is_none();

--- a/src-tauri/src/session_manager/watchdog.rs
+++ b/src-tauri/src/session_manager/watchdog.rs
@@ -203,21 +203,19 @@ impl SessionManager {
                 );
                 // Unblock the agent: force_end only cleared Host FSM; without cancel
                 // the CLI stays blocked on model inference and refuses the next send.
-                if let Some((acp, agent_sid)) = self.with_session_mut(&session_id, |s| {
+                if let Some((Some(acp), agent_sid)) = self.with_session_mut(&session_id, |s| {
                     (s.acp.clone(), s.meta.agent_session_id.clone())
                 }) {
-                    if let Some(acp) = acp {
-                        let msg = format!("stream stall recovery ({reason})");
-                        acp.abort_pending_prompts(&msg);
-                        let sid = agent_sid;
-                        tauri::async_runtime::spawn(async move {
-                            // Target the session explicitly (shared process safety).
-                            let _ = match sid {
-                                Some(sid) => acp.cancel_for(&sid).await,
-                                None => acp.cancel().await,
-                            };
-                        });
-                    }
+                    let msg = format!("stream stall recovery ({reason})");
+                    acp.abort_pending_prompts(&msg);
+                    let sid = agent_sid;
+                    tauri::async_runtime::spawn(async move {
+                        // Target the session explicitly (shared process safety).
+                        let _ = match sid {
+                            Some(sid) => acp.cancel_for(&sid).await,
+                            None => acp.cancel().await,
+                        };
+                    });
                 }
                 Self::emit_runtime(
                     app,

--- a/src-tauri/src/side_browser_blob.rs
+++ b/src-tauri/src/side_browser_blob.rs
@@ -1277,6 +1277,9 @@ fn system_downloads_dir() -> PathBuf {
     crate::process_util::user_home().join("Downloads")
 }
 
+/// Collision-safe download target (`name.ext` → `name (2).ext` → …).
+/// Unit-tested pure helper; the live download path resolves naming inline.
+#[cfg_attr(not(test), allow(dead_code))]
 fn unique_download_path(dir: &Path, suggested: &str) -> PathBuf {
     let name = sanitize_filename(suggested);
     let (stem, ext) = match name.rsplit_once('.') {

--- a/src-tauri/src/side_browser_host.rs
+++ b/src-tauri/src/side_browser_host.rs
@@ -274,6 +274,7 @@ fn suggested_from_staging_name(file_name: &str) -> String {
 ///
 /// `window_label` is usually `main` or `session-*` — the window that hosts the
 /// overlay bounds. Position/size are logical pixels matching the host DOM rect.
+#[allow(clippy::too_many_arguments)]
 pub fn create(
     app: &AppHandle,
     label: String,
@@ -364,10 +365,10 @@ pub fn create(
             };
             match payload.event() {
                 PageLoadEvent::Started => {
-                    emit_page_load(&webview.app_handle(), "started", &label, &url);
+                    emit_page_load(webview.app_handle(), "started", &label, &url);
                 }
                 PageLoadEvent::Finished => {
-                    emit_page_load(&webview.app_handle(), "finished", &label, &url);
+                    emit_page_load(webview.app_handle(), "finished", &label, &url);
                     let _ = webview.eval(polyfill_reload.clone());
                 }
             }
@@ -381,11 +382,7 @@ pub fn create(
                 } else {
                     label
                 };
-                crate::side_browser_blob::handle_title_signal(
-                    &webview.app_handle(),
-                    &label,
-                    &title,
-                );
+                crate::side_browser_blob::handle_title_signal(webview.app_handle(), &label, &title);
             }
         })
         .on_download(move |webview, event| {
@@ -421,7 +418,7 @@ pub fn create(
                     *destination = staging;
 
                     emit_download(
-                        &webview.app_handle(),
+                        webview.app_handle(),
                         SideBrowserDownloadPayload {
                             phase: "requested".into(),
                             label,
@@ -464,7 +461,7 @@ pub fn create(
                             "download failed"
                         );
                         emit_download(
-                            &webview.app_handle(),
+                            webview.app_handle(),
                             SideBrowserDownloadPayload {
                                 phase: "finished".into(),
                                 label,
@@ -485,7 +482,7 @@ pub fn create(
                             "download finished without path"
                         );
                         emit_download(
-                            &webview.app_handle(),
+                            webview.app_handle(),
                             SideBrowserDownloadPayload {
                                 phase: "finished".into(),
                                 label,
@@ -507,7 +504,7 @@ pub fn create(
                             "download staging missing"
                         );
                         emit_download(
-                            &webview.app_handle(),
+                            webview.app_handle(),
                             SideBrowserDownloadPayload {
                                 phase: "finished".into(),
                                 label,

--- a/src-tauri/src/skill_compat.rs
+++ b/src-tauri/src/skill_compat.rs
@@ -77,9 +77,7 @@ pub fn compat_skill_kind(source: &str, path: Option<&str>) -> Option<CompatSkill
     if src == "cursor" || src.starts_with("cursor") {
         return Some(CompatSkillKind::Cursor);
     }
-    let Some(raw) = path.map(str::trim).filter(|s| !s.is_empty()) else {
-        return None;
-    };
+    let raw = path.map(str::trim).filter(|s| !s.is_empty())?;
     let p = normalize_fs_path(raw);
     if p.contains("/.claude/skills/")
         || p.contains("/.claude/commands/")

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -4321,7 +4321,7 @@ mod tests {
 
         // `base` models a snapshot taken before the stream append.
         append_message(&session.id, appended.clone()).expect("append stream row");
-        save_messages(&session.id, &[base.clone()]).expect("merge stale snapshot");
+        save_messages(&session.id, std::slice::from_ref(&base)).expect("merge stale snapshot");
         let merged = load_messages(&session.id);
         assert!(merged.iter().any(|message| message.id == base.id));
         assert!(merged

--- a/src-tauri/src/stream_stall.rs
+++ b/src-tauri/src/stream_stall.rs
@@ -363,6 +363,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // const comparisons pin the spec defaults
     fn defaults_match_spec() {
         assert_eq!(DEFAULT_STREAM_STALL_SECONDS, 600);
         assert_eq!(MIN_STREAM_STALL_SECONDS, 15);

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -133,7 +133,7 @@ pub fn build_menu(app: &AppHandle) -> Result<Menu<Wry>, tauri::Error> {
     builder = builder.item(&MenuItem::with_id(
         app,
         "quit",
-        &quit_tray_label(tr.quit),
+        quit_tray_label(tr.quit),
         true,
         None::<&str>,
     )?);

--- a/src-tauri/src/tray_i18n.rs
+++ b/src-tauri/src/tray_i18n.rs
@@ -197,6 +197,7 @@ pub fn first_apple_languages_tag(raw: &str) -> Option<String> {
 /// Map a Windows LANGID (GetUserDefaultUILanguage) to a BCP-47 tag.
 /// Unknown primary languages return `None` so callers can fall through to
 /// GetUserDefaultLocaleName (which covers locales without an entry here).
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub fn windows_langid_to_tag(id: u16) -> Option<&'static str> {
     const LANG_CHINESE: u16 = 0x04;
     const LANG_GERMAN: u16 = 0x07;
@@ -243,11 +244,11 @@ pub fn windows_langid_to_tag(id: u16) -> Option<&'static str> {
 fn platform_ui_lang_tag() -> Option<String> {
     #[cfg(target_os = "macos")]
     {
-        return macos_ui_lang_tag();
+        macos_ui_lang_tag()
     }
     #[cfg(windows)]
     {
-        return windows_ui_lang_tag();
+        windows_ui_lang_tag()
     }
     #[cfg(not(any(target_os = "macos", windows)))]
     {

--- a/src-tauri/src/voice_stt.rs
+++ b/src-tauri/src/voice_stt.rs
@@ -437,7 +437,11 @@ fn mentions_param(body: &str, param: &str) -> bool {
 /// Error-classification context: official xAI endpoint vs custom endpoint
 /// (which may be a local service). Keeps 401/403 and connectivity failures in
 /// the right buckets so the UI can show accurate copy.
+///
+/// Prod currently transcribes only through custom-compatible endpoints; the
+/// `Official` variant and `local` flag stay for the classification unit tests.
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
 enum SttErrorCtx {
     Official,
     Custom { local: bool },

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -1703,7 +1703,9 @@ and https://pbs.twimg.com/media/HNccFG2X0AE8gQ6.jpg?format=jpg&name=small
         assert!(
             extract_status_id_from_url("https://x.com/victim/photo?u=/status/99999999").is_none()
         );
-        assert!(is_canonical_x_status_url("ftp://x.com/user/status/12345678") == false);
+        assert!(!is_canonical_x_status_url(
+            "ftp://x.com/user/status/12345678"
+        ));
         assert!(normalize_status_url("https://cdn.evil.com/x.com/status/12345678", None).is_none());
         assert!(
             normalize_status_url("https://x.com.evil.com/user/status/12345678", None).is_none()

--- a/src-tauri/src/win_taskbar_overlay.rs
+++ b/src-tauri/src/win_taskbar_overlay.rs
@@ -6,6 +6,11 @@
 //! `DeleteTab` / `AddTab` can put it back. Driven by `tray_set_windows_overlay`,
 //! not `tray_set_busy_count`.
 
+// Prod callers live behind `#[cfg(windows)]` in tray.rs; unit tests run on all
+// platforms, so keep the module compiled everywhere and silence dead_code only
+// where the feature is absent.
+#![cfg_attr(not(target_os = "windows"), allow(dead_code))]
+
 use std::sync::atomic::{AtomicU32, Ordering};
 
 pub const SIZE: u32 = 16;

--- a/src-tauri/src/wsl_backend.rs
+++ b/src-tauri/src/wsl_backend.rs
@@ -24,6 +24,7 @@ use crate::store::AppSettings;
 /// Settings value for native Windows/macOS/Linux CLI spawn.
 pub const CLI_BACKEND_NATIVE: &str = "native";
 /// Settings value for spawning through `wsl.exe` (Windows only).
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub const CLI_BACKEND_WSL: &str = "wsl";
 
 const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(8);
@@ -39,18 +40,18 @@ pub struct WslLaunch {
 
 /// Whether settings request the WSL spawn path on this host.
 pub fn wsl_backend_active(settings: &AppSettings) -> bool {
-    #[cfg(not(target_os = "windows"))]
-    {
-        let _ = settings;
-        return false;
-    }
     #[cfg(target_os = "windows")]
-    {
-        normalize_cli_backend(&settings.cli_backend) == CLI_BACKEND_WSL
-    }
+    let requested = normalize_cli_backend(&settings.cli_backend) == CLI_BACKEND_WSL;
+    #[cfg(not(target_os = "windows"))]
+    let requested = {
+        let _ = settings;
+        false
+    };
+    requested
 }
 
 /// Normalize stored backend id (`native` | `wsl`). Unknown → `native`.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub fn normalize_cli_backend(raw: &str) -> String {
     match raw.trim().to_ascii_lowercase().as_str() {
         CLI_BACKEND_WSL => CLI_BACKEND_WSL.into(),
@@ -160,6 +161,7 @@ pub fn find_wsl_exe() -> Option<PathBuf> {
 }
 
 /// List installed WSL distro names (`wsl.exe -l -q`). Best-effort; empty on failure.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub fn list_wsl_distros() -> Vec<String> {
     let Some(wsl) = find_wsl_exe() else {
         return Vec::new();
@@ -187,8 +189,9 @@ pub fn list_wsl_distros() -> Vec<String> {
         .collect()
 }
 
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 fn decode_wsl_list_output(bytes: &[u8]) -> String {
-    if bytes.len() >= 2 && bytes.len() % 2 == 0 {
+    if bytes.len() >= 2 && bytes.len().is_multiple_of(2) {
         // UTF-16 LE BOM or high null density → treat as UTF-16 LE
         let looks_utf16 = bytes[0] == 0xFF && bytes[1] == 0xFE
             || bytes
@@ -364,11 +367,7 @@ echo "$CLI"
                         l.to_ascii_lowercase().contains("grok")
                             || extract_version_token(l).is_some()
                     })
-                    .map(|s| s.to_string())
-                    .or_else(|| {
-                        // Single-line --version sometimes only on first line after path
-                        path.as_ref().and_then(|_| None)
-                    });
+                    .map(|s| s.to_string());
                 // If path line itself looks like a version banner, treat carefully
                 let (resolved_path, version) = match (&path, &version_line) {
                     (Some(p), Some(v)) => (Some(p.clone()), Some(v.clone())),
@@ -529,20 +528,8 @@ pub struct WslStatus {
 
 /// Collect WSL availability + optional CLI probe for Settings.
 pub fn wsl_status(settings: &AppSettings) -> WslStatus {
-    #[cfg(not(target_os = "windows"))]
-    {
-        let _ = settings;
-        return WslStatus {
-            available: false,
-            wsl_exe: None,
-            distros: Vec::new(),
-            backend_active: false,
-            probe: None,
-            error: Some("WSL backend is only available on Windows".into()),
-        };
-    }
     #[cfg(target_os = "windows")]
-    {
+    let status = {
         let wsl_exe = find_wsl_exe().map(|p| p.display().to_string());
         let available = wsl_exe.is_some();
         let distros = if available {
@@ -569,7 +556,20 @@ pub fn wsl_status(settings: &AppSettings) -> WslStatus {
             probe,
             error,
         }
-    }
+    };
+    #[cfg(not(target_os = "windows"))]
+    let status = {
+        let _ = settings;
+        WslStatus {
+            available: false,
+            wsl_exe: None,
+            distros: Vec::new(),
+            backend_active: false,
+            probe: None,
+            error: Some("WSL backend is only available on Windows".into()),
+        }
+    };
+    status
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #785

## ⚠️ Status: draft — mandatory pi review pending

Per AGENTS.md §8, every fix must pass a `pi -p` 审核校对 before it can be marked done. pi returned `503 Service temporarily unavailable` on 5 attempts (2026-08-22, escalating backoff incl. connectivity probe). The review record is persisted at `docs/plans/2026-08-22-pr785-pi-review-fix.md` and will be filled in when pi recovers; this draft flips to ready only after that gate clears. Machine gates below are green; no maintainer merge is requested until then.

## Problem

`cargo clippy --all-targets` regressed to **98 warnings across 34 files** on macOS (and any non-Linux host). CI runs clippy on all three platforms but with `-W clippy::all` (non-blocking) and expects "a small set of style lints" — the bar from the earlier residual-clippy track (478 → 0) has silently eroded:

- Windows-only prod code compiled everywhere lit up as dead code (`win_taskbar_overlay.rs` ×14, WSL backend items, os-theme watch const/parser, tray LANGID map, session-api Windows shim helpers).
- Prod-orphaned pure helpers survived only because their own unit tests call them (warm-reuse busy/block/kill chain, `proxy::decision_from`, `remote_im/i18n::normalize_lang`, `side_browser_blob::unique_download_path`, attach wrappers).
- Genuinely dead code: unused imports, never-read struct fields (`PrewarmedProcess.model_id/backend`, `ParkedAgent.sandbox_profile`, pet hit-chrome window size).
- Style debt: needless returns/refs/clones, collapsible ifs, identical blocks, clone-on-Copy, Tauri commands over the arity lint.

## Approach

1. **Delete** code unreferenced by both prod and tests. Field deletions cascade where the only reader was the deleted getter (`AcpClient.sandbox_profile`). Rust's never-read guarantee makes these behavior-neutral.
2. **Gate** Windows-only items with the existing house idiom `#[cfg_attr(not(target_os = "windows"), allow(dead_code))]` (as in `win_crash.rs`) so their unit tests keep running on mac/Linux CI.
3. **Keep** test-covered pure helpers with `#[cfg_attr(not(test), allow(dead_code))]` (house precedent in `session_manager/types.rs`) rather than deleting tested logic.
4. **Mechanical style fixes**, using the established `#[allow(clippy::too_many_arguments)]` idiom for Tauri commands (7 sites) and targeted `assertions_on_constants` allows for deliberate const spec-guard tests (4 sites).

## Test plan

- [x] `cargo clippy --all-targets` → **0 warnings** (baseline 98)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test` → 1414 passed, 0 failed
- [x] Frontend untouched
- [ ] Windows CI leg validates the cfg-gated paths locally unverifiable (cross-check blocked by `ring` needing an MSVC C compiler)