### PR TITLE
perf(layout): keep splitter drag off the workbench render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **L/R splitter drag no longer re-renders the workbench every move**: In-flow sidebar / aside width is written on the pane element while the pointer is down. Layout prefs commit on pointer-up. Dragging the left rail past the open min still collapses live.
 - **Bottom terminal toggle snaps height**: Ctrl+` jumps between 0 and the last panel height. The chat column is not interpolated for 320ms, so a long transcript does not reflow on every open/close. Drag-resize and persist-mounted PTY are unchanged.
 - **Chat code line numbers are one text node**: Fences with line numbers on keep a single gutter (`1\n2\n…`) instead of one React node per source line, so a 5000-line streamed/pasted block no longer mounts thousands of spans.
 - **Wide windows toggle side panes instantly; narrow windows overlay them**: Ctrl+B / Ctrl+Alt+B no longer interpolate flex width against the chat column. When sidebar + chat + aside fit, the split snaps with no animation. When they would crush chat, the pane overlays with a transform and the OS window does not grow.
@@ -44,6 +45,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **拖左右分割条不再每帧重绘工作台**：按住时只改侧栏/右栏元素宽度；松手才写入 layout。左栏拖过最小宽度仍即时收起。
 - **底栏终端开关改为瞬时高度**：Ctrl+` 在 0 和上次高度之间直接跳。聊天列不再插值 320ms，长对话不会每次开关都重排。拖高度和常驻 PTY 不变。
 - **聊天代码行号改成一个文本节点**：开启行号时 gutter 是一份 `1\n2\n…`，不再一行一个 React 节点；流式/粘贴的 5000 行代码块不会再挂几千个 span。
 - **宽窗瞬时切换侧栏，窄窗改为覆盖层**：Ctrl+B / Ctrl+Alt+B 不再用 flex 宽度去挤聊天列。侧栏 + 聊天 + 右栏能放下时无动画直接切分；会压到聊天时改为 overlay + transform，也不再拉大系统窗口。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -3,6 +3,7 @@ import {
   Suspense,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -94,6 +95,10 @@ import {
   SIDEBAR_WIDTH_MIN,
   saveLayout,
 } from "@/lib/layout";
+import {
+  applyLiveSplitWidth,
+  queryWorkbenchSplitPane,
+} from "@/lib/paneDragLive";
 import { resolveWorkbenchPaneOverlay } from "@/lib/paneOverlay";
 import {
   ensureWindowFitsLayout,
@@ -2775,6 +2780,8 @@ export function AppWorkbench() {
   const sidebarResizeStartRef = useRef<{ x: number; width: number } | null>(
     null,
   );
+  const liveSidebarWidthRef = useRef(sidebarOpenW);
+  const liveAsideWidthRef = useRef(asideOpenW);
   const [account, setAccount] = useState<api.AccountStatus | null>(null);
   const [accountLoading, setAccountLoading] = useState(false);
   const [accountBusy, setAccountBusy] = useState(false);
@@ -9245,27 +9252,32 @@ export function AppWorkbench() {
   // Drag-resize right resource pane.
   // Live clamp only — do NOT fitWindowThenClampAside on pointer-up (that
   // re-applied preferred min / window grow and bounced the divider back).
+  // Width is written on the aside element during move; layout commits on up.
   useEffect(() => {
     if (!resizingAside) return;
     const clampOpts = () => ({
       ...asideClampOpts(),
       viewportWidth: window.innerWidth,
     });
+    const pane = queryWorkbenchSplitPane("aside");
+    liveAsideWidthRef.current = clampAsideWidth(
+      layoutRef.current.asideWidth,
+      clampOpts(),
+    );
+    applyLiveSplitWidth(pane, liveAsideWidthRef.current);
     const onMove = (e: PointerEvent) => {
       if (isWindowFitSuppressed()) return;
       const desired = Math.round(window.innerWidth - e.clientX);
       const next = clampAsideWidth(desired, clampOpts());
-      setLayout((l) => {
-        if (l.asideWidth === next && !l.asideCollapsed) return l;
-        return { ...l, asideWidth: next, asideCollapsed: false };
-      });
+      if (next === liveAsideWidthRef.current) return;
+      liveAsideWidthRef.current = next;
+      applyLiveSplitWidth(pane, next);
     };
     const onUp = () => {
       setResizingAside(false);
       // Persist the last live width (same clamp as drag). No window grow /
       // preferredAside bump — those caused a visible spring-back at chat min.
-      const cur = layoutRef.current;
-      const width = clampAsideWidth(cur.asideWidth, clampOpts());
+      const width = clampAsideWidth(liveAsideWidthRef.current, clampOpts());
       setLayout((l) => {
         const n = {
           ...l,
@@ -9304,6 +9316,10 @@ export function AppWorkbench() {
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
     };
+    const pane = queryWorkbenchSplitPane("sidebar");
+    liveSidebarWidthRef.current =
+      layoutRef.current.sidebarWidth || SIDEBAR_DEFAULT_WIDTH;
+    applyLiveSplitWidth(pane, liveSidebarWidthRef.current);
     const applyCollapseLive = () => {
       const cur = layoutRef.current;
       const n = {
@@ -9328,10 +9344,9 @@ export function AppWorkbench() {
         return;
       }
       const next = clampSidebarDragWidth(desired, clampOpts());
-      setLayout((l) => {
-        if (l.sidebarWidth === next && !l.sidebarCollapsed) return l;
-        return { ...l, sidebarWidth: next, sidebarCollapsed: false };
-      });
+      if (next === liveSidebarWidthRef.current) return;
+      liveSidebarWidthRef.current = next;
+      applyLiveSplitWidth(pane, next);
     };
     const onUp = () => {
       // If we already live-collapsed, effect teardown cleared state — still safe.
@@ -9348,7 +9363,7 @@ export function AppWorkbench() {
         return;
       }
       const resolved = resolveSidebarDragEnd(
-        cur.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
+        liveSidebarWidthRef.current || SIDEBAR_DEFAULT_WIDTH,
         clampOpts(),
       );
       const n =
@@ -9376,6 +9391,21 @@ export function AppWorkbench() {
       window.removeEventListener("pointerup", onUp);
     };
   }, [resizingSidebar]);
+
+  useLayoutEffect(() => {
+    if (resizingSidebar) {
+      applyLiveSplitWidth(
+        queryWorkbenchSplitPane("sidebar"),
+        liveSidebarWidthRef.current,
+      );
+    }
+    if (resizingAside) {
+      applyLiveSplitWidth(
+        queryWorkbenchSplitPane("aside"),
+        liveAsideWidthRef.current,
+      );
+    }
+  }, [resizingSidebar, resizingAside]);
 
   /** Programmatic draft / layout changes: recompute height after paint. */
   const syncComposerHeight = useCallback(() => {
@@ -19214,10 +19244,14 @@ export function AppWorkbench() {
                     maxWidth: sidebarOpenW,
                     ["--sidebar-rail-min"]: `${sidebarOpenW}px`,
                   } as CSSProperties)
-                : ({
-                    ...paneSplitSizeStyle(sidebarPaint, "x", resizingSidebar),
-                    ["--sidebar-rail-min"]: `${sidebarOpenW}px`,
-                  } as CSSProperties)
+                : resizingSidebar
+                  ? ({
+                      ["--sidebar-rail-min"]: `${sidebarOpenW}px`,
+                    } as CSSProperties)
+                  : ({
+                      ...paneSplitSizeStyle(sidebarPaint, "x", false),
+                      ["--sidebar-rail-min"]: `${sidebarOpenW}px`,
+                    } as CSSProperties)
           }
         >
           {dragZone === "sidebar" && (
@@ -19243,10 +19277,12 @@ export function AppWorkbench() {
               onPointerDown={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                const width = layout.sidebarWidth || SIDEBAR_DEFAULT_WIDTH;
                 sidebarResizeStartRef.current = {
                   x: e.clientX,
-                  width: layout.sidebarWidth || SIDEBAR_DEFAULT_WIDTH,
+                  width,
                 };
+                liveSidebarWidthRef.current = width;
                 setResizingSidebar(true);
               }}
             />
@@ -22300,10 +22336,14 @@ export function AppWorkbench() {
                     maxWidth: asideOpenW,
                     ["--aside-rail-min"]: `${asideOpenW}px`,
                   } as CSSProperties)
-                : ({
-                    ...paneSplitSizeStyle(asidePaint, "x", resizingAside),
-                    ["--aside-rail-min"]: `${layout.asideWidth || DEFAULT_LAYOUT.asideWidth}px`,
-                  } as CSSProperties)
+                : resizingAside
+                  ? ({
+                      ["--aside-rail-min"]: `${layout.asideWidth || DEFAULT_LAYOUT.asideWidth}px`,
+                    } as CSSProperties)
+                  : ({
+                      ...paneSplitSizeStyle(asidePaint, "x", false),
+                      ["--aside-rail-min"]: `${layout.asideWidth || DEFAULT_LAYOUT.asideWidth}px`,
+                    } as CSSProperties)
           }
         >
           {!layout.asideCollapsed && !hideChatForSideExpand && !asideOverlay && (
@@ -22314,6 +22354,8 @@ export function AppWorkbench() {
               aria-label="Resize files pane"
               onPointerDown={(e) => {
                 e.preventDefault();
+                liveAsideWidthRef.current =
+                  layout.asideWidth || DEFAULT_LAYOUT.asideWidth;
                 setResizingAside(true);
               }}
             />

--- a/src/lib/paneDragLive.test.ts
+++ b/src/lib/paneDragLive.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+import { applyLiveSplitWidth, queryWorkbenchSplitPane } from "./paneDragLive";
+
+describe("applyLiveSplitWidth", () => {
+  it("writes the flex size tuple and rounds", () => {
+    const el = document.createElement("div");
+    expect(applyLiveSplitWidth(el, 240.4)).toBe(240);
+    expect(el.style.width).toBe("240px");
+    expect(el.style.minWidth).toBe("240px");
+    expect(el.style.maxWidth).toBe("240px");
+    expect(el.style.flexBasis).toBe("240px");
+  });
+
+  it("is a no-op on a missing node", () => {
+    expect(applyLiveSplitWidth(null, 180)).toBe(180);
+  });
+});
+
+describe("queryWorkbenchSplitPane", () => {
+  it("picks the workbench sidebar and aside, not a nested aside", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <div class="workbench">
+        <aside class="sidebar"></aside>
+        <main></main>
+        <aside class="aside"><aside class="nested"></aside></aside>
+      </div>
+    `;
+    expect(queryWorkbenchSplitPane("sidebar", root)?.className).toBe("sidebar");
+    expect(queryWorkbenchSplitPane("aside", root)?.className).toBe("aside");
+  });
+});

--- a/src/lib/paneDragLive.ts
+++ b/src/lib/paneDragLive.ts
@@ -1,0 +1,31 @@
+/**
+ * In-flow split drag writes the pane box on the element.
+ * React layout state commits on pointer-up so AppWorkbench does not
+ * reconcile every pointermove.
+ */
+
+export type WorkbenchSplitPane = "sidebar" | "aside";
+
+export function queryWorkbenchSplitPane(
+  which: WorkbenchSplitPane,
+  root: ParentNode = document,
+): HTMLElement | null {
+  return root.querySelector(
+    which === "sidebar" ? ".workbench > .sidebar" : ".workbench > .aside",
+  );
+}
+
+/** Same tuple as `paneSplitSizeStyle(n, "x")`. */
+export function applyLiveSplitWidth(
+  el: HTMLElement | null,
+  sizePx: number,
+): number {
+  const n = Math.max(0, Math.round(sizePx));
+  if (!el) return n;
+  const px = `${n}px`;
+  el.style.width = px;
+  el.style.minWidth = px;
+  el.style.maxWidth = px;
+  el.style.flexBasis = px;
+  return n;
+}


### PR DESCRIPTION
## Summary

Dragging the in-flow L/R splitter writes pane width on the element while the pointer is down. `setLayout` and layout prefs commit on pointer-up, so the transcript/composer do not reconcile every `pointermove`. Dragging the left rail past the open min still collapses live. Overlay drawers have no splitter (#820).

Fixes #826

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/lib/paneDragLive.test.ts src/lib/layout.test.ts src/lib/paneSplitMotion.test.ts` (36 passed)
- [ ] Drag left rail: width follows the pointer; chat does not hitch; prefs persist on release
- [ ] Drag left rail past min: rail collapses immediately
- [ ] Drag right files pane: same, no spring-back at chat min
- [ ] Overlay / phone: no splitter (unchanged)
- [ ] CI green

## Checklist

- [x] User-facing strings go through `t()` / `createT`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
