### PR TITLE
perf(files): window long resource trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Files tree windows long listings**: Side-pane / resource trees keep short folders as a full list. At 32+ visible rows, only the viewport is mounted (28px rows), instead of recursively mapping every expanded entry.
 - **L/R splitter drag no longer re-renders the workbench every move**: In-flow sidebar / aside width is written on the pane element while the pointer is down. Layout prefs commit on pointer-up. Dragging the left rail past the open min still collapses live.
 - **Bottom terminal toggle snaps height**: Ctrl+` jumps between 0 and the last panel height. The chat column is not interpolated for 320ms, so a long transcript does not reflow on every open/close. Drag-resize and persist-mounted PTY are unchanged.
 - **Chat code line numbers are one text node**: Fences with line numbers on keep a single gutter (`1\n2\n…`) instead of one React node per source line, so a 5000-line streamed/pasted block no longer mounts thousands of spans.
@@ -45,6 +46,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **文件树对长列表做窗口化**：侧栏 / 资源树短目录仍整表渲染。可见行达到 32 以上只挂视口（28px 行高），不再递归把每个展开节点打进 DOM。
 - **拖左右分割条不再每帧重绘工作台**：按住时只改侧栏/右栏元素宽度；松手才写入 layout。左栏拖过最小宽度仍即时收起。
 - **底栏终端开关改为瞬时高度**：Ctrl+` 在 0 和上次高度之间直接跳。聊天列不再插值 320ms，长对话不会每次开关都重排。拖高度和常驻 PTY 不变。
 - **聊天代码行号改成一个文本节点**：开启行号时 gutter 是一份 `1\n2\n…`，不再一行一个 React 节点；流式/粘贴的 5000 行代码块不会再挂几千个 span。

--- a/src/components/resource-viewer/ResourceViewer.tsx
+++ b/src/components/resource-viewer/ResourceViewer.tsx
@@ -10,7 +10,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type ReactNode,
 } from "react";
 import * as api from "@/lib/api";
 import { createT } from "@/i18n";
@@ -23,6 +22,7 @@ import {
 import { resolveChangesPreviewEmptyState } from "@/lib/resourceChangesHonesty";
 import { EmbeddedBrowser } from "@/components/EmbeddedBrowser";
 import { OverlayScroll } from "@/components/OverlayScroll";
+import { VirtualList } from "@/components/VirtualList";
 import { detectAppPlatform, revealInOsLabel } from "@/lib/appPlatform";
 import {
   IconChevronDown,
@@ -71,6 +71,11 @@ import {
 import {
   setActiveTab,
 } from "@/lib/resourceTabs";
+import {
+  RESOURCE_TREE_ROW_HEIGHT_PX,
+  RESOURCE_TREE_VIRTUALIZE_THRESHOLD,
+  flattenVisibleResourceTree,
+} from "@/lib/resourceTree";
 import {
   asideSurfaceFromPreviewKind,
   type AsideSurface,
@@ -749,52 +754,14 @@ export function ResourceViewer({
     [query],
   );
 
-  const renderTree = (nodes: TreeNode[], depth: number): ReactNode =>
-    nodes
-      .filter((n) => filterMatch(n.name, n.relativePath) || n.isDir)
-      .map((n) => {
-        const isOpen = !!expanded[n.relativePath];
-        const active = activeTab?.relativePath === n.relativePath;
-        return (
-          <div key={n.relativePath || n.name}>
-            <Tip label={n.relativePath}>
-              <button
-                type="button"
-                className={
-                  "rp-tree__row" +
-                  (active ? " is-active" : "") +
-                  (n.isDir ? " is-dir" : "")
-                }
-                style={{ paddingLeft: 8 + depth * 12 }}
-                onClick={(e) => {
-                  e.preventDefault();
-                  if (n.isDir) void toggleDir(n);
-                  else void openFile(n.relativePath);
-                }}
-              >
-                <span className="rp-tree__chev">
-                  {n.isDir ? (
-                    isOpen ? (
-                      <IconChevronDown size={12} />
-                    ) : (
-                      <IconChevronRight size={12} />
-                    )
-                  ) : (
-                    <span className="rp-tree__gap" />
-                  )}
-                </span>
-                <FileKindMark name={n.name} isDir={n.isDir} />
-                <span className="rp-tree__name">{n.name}</span>
-              </button>
-            </Tip>
-            {n.isDir && isOpen && n.children && n.children.length > 0 && (
-              <div className="rp-tree__kids">
-                {renderTree(n.children, depth + 1)}
-              </div>
-            )}
-          </div>
-        );
-      });
+  const visibleRows = useMemo(
+    () =>
+      flattenVisibleResourceTree(root, expanded, (n) =>
+        filterMatch(n.name, n.relativePath) || !!n.isDir,
+      ),
+    [root, expanded, filterMatch],
+  );
+  const selectedTreeKey = activeTab?.relativePath || null;
 
 
   const previewBody = (
@@ -1626,7 +1593,50 @@ export function ResourceViewer({
                     {tr("resources.empty")}
                   </div>
                 ) : (
-                  renderTree(root, 0)
+                  <VirtualList
+                    items={visibleRows}
+                    getKey={(row) => row.node.relativePath || row.node.name}
+                    rowHeight={RESOURCE_TREE_ROW_HEIGHT_PX}
+                    threshold={RESOURCE_TREE_VIRTUALIZE_THRESHOLD}
+                    scrollToKey={selectedTreeKey}
+                    renderItem={(row) => {
+                      const n = row.node;
+                      const isOpen = !!expanded[n.relativePath];
+                      const active = activeTab?.relativePath === n.relativePath;
+                      return (
+                        <Tip label={n.relativePath}>
+                          <button
+                            type="button"
+                            className={
+                              "rp-tree__row" +
+                              (active ? " is-active" : "") +
+                              (n.isDir ? " is-dir" : "")
+                            }
+                            style={{ paddingLeft: 8 + row.depth * 12 }}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              if (n.isDir) void toggleDir(n);
+                              else void openFile(n.relativePath);
+                            }}
+                          >
+                            <span className="rp-tree__chev">
+                              {n.isDir ? (
+                                isOpen ? (
+                                  <IconChevronDown size={12} />
+                                ) : (
+                                  <IconChevronRight size={12} />
+                                )
+                              ) : (
+                                <span className="rp-tree__gap" />
+                              )}
+                            </span>
+                            <FileKindMark name={n.name} isDir={n.isDir} />
+                            <span className="rp-tree__name">{n.name}</span>
+                          </button>
+                        </Tip>
+                      );
+                    }}
+                  />
                 )}
               </OverlayScroll>
                 </>

--- a/src/components/side-workbench/FilesWorkspace.tsx
+++ b/src/components/side-workbench/FilesWorkspace.tsx
@@ -10,7 +10,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type ReactNode,
 } from "react";
 import * as api from "@/lib/api";
 import { createT, type Locale } from "@/i18n";
@@ -24,6 +23,7 @@ import {
 } from "@/components/icons";
 import { OpenLocationButton } from "@/components/OpenLocationButton";
 import { OverlayScroll } from "@/components/OverlayScroll";
+import { VirtualList } from "@/components/VirtualList";
 import { Tip } from "@/components/ui/tooltip";
 import { GlassModal } from "@/components/GlassModal";
 import { FileKindMark } from "@/components/resource-viewer/FileKindMark";
@@ -44,8 +44,11 @@ import {
 } from "@/lib/openEditorHonesty";
 import { resolveFilesWorkbenchSplitLayout } from "@/lib/resourceTabs";
 import {
+  RESOURCE_TREE_ROW_HEIGHT_PX,
+  RESOURCE_TREE_VIRTUALIZE_THRESHOLD,
   expandKeysForResourceTreeFilter,
   filterResourceTreeNodes,
+  flattenVisibleResourceTree,
   loadTreeExpanded,
   mergeTreeExpandedForFilter,
   saveTreeExpanded,
@@ -314,48 +317,12 @@ export function FilesWorkspace({
     [openFile, onFileOpen],
   );
 
-  const renderTree = (nodes: TreeNode[], depth: number): ReactNode =>
-    nodes.map((n) => {
-      const open = !!displayExpanded[n.relativePath];
-      const selected =
-        activeTab &&
-        (activeTab.relativePath === n.relativePath ||
-          activeTab.absolutePath === n.relativePath);
-      return (
-        <div key={n.relativePath}>
-          <button
-            type="button"
-            className={
-              "rp-tree__row" + (selected ? " is-selected" : "")
-            }
-            style={{ paddingLeft: 8 + depth * 12 }}
-            onClick={() => {
-              if (n.isDir) void toggleDir(n);
-              else void onTreeFileClick(n.relativePath, n.name);
-            }}
-          >
-            <span className="rp-tree__chev">
-              {n.isDir ? (
-                open ? (
-                  <IconChevronDown size={14} />
-                ) : (
-                  <IconChevronRight size={14} />
-                )
-              ) : (
-                <span className="rp-tree__gap" />
-              )}
-            </span>
-            <FileKindMark name={n.name} isDir={n.isDir} />
-            <span className="rp-tree__name">{n.name}</span>
-          </button>
-          {n.isDir && open && n.children?.length ? (
-            <div className="rp-tree__kids">
-              {renderTree(n.children as TreeNode[], depth + 1)}
-            </div>
-          ) : null}
-        </div>
-      );
-    });
+  const visibleRows = useMemo(
+    () => flattenVisibleResourceTree(filteredRoot, displayExpanded),
+    [filteredRoot, displayExpanded],
+  );
+  const selectedTreeKey =
+    activeTab?.relativePath || activeTab?.absolutePath || null;
 
   // Tree resize — persist final width via functional update (no stale width).
   useEffect(() => {
@@ -648,7 +615,48 @@ export function FilesWorkspace({
                       : tr("resources.empty")}
                   </div>
                 ) : (
-                  renderTree(filteredRoot, 0)
+                  <VirtualList
+                    items={visibleRows}
+                    getKey={(row) => row.node.relativePath || row.node.name}
+                    rowHeight={RESOURCE_TREE_ROW_HEIGHT_PX}
+                    threshold={RESOURCE_TREE_VIRTUALIZE_THRESHOLD}
+                    scrollToKey={selectedTreeKey}
+                    renderItem={(row) => {
+                      const n = row.node;
+                      const open = !!displayExpanded[n.relativePath];
+                      const selected =
+                        !!activeTab &&
+                        (activeTab.relativePath === n.relativePath ||
+                          activeTab.absolutePath === n.relativePath);
+                      return (
+                        <button
+                          type="button"
+                          className={
+                            "rp-tree__row" + (selected ? " is-selected" : "")
+                          }
+                          style={{ paddingLeft: 8 + row.depth * 12 }}
+                          onClick={() => {
+                            if (n.isDir) void toggleDir(n);
+                            else void onTreeFileClick(n.relativePath, n.name);
+                          }}
+                        >
+                          <span className="rp-tree__chev">
+                            {n.isDir ? (
+                              open ? (
+                                <IconChevronDown size={14} />
+                              ) : (
+                                <IconChevronRight size={14} />
+                              )
+                            ) : (
+                              <span className="rp-tree__gap" />
+                            )}
+                          </span>
+                          <FileKindMark name={n.name} isDir={n.isDir} />
+                          <span className="rp-tree__name">{n.name}</span>
+                        </button>
+                      );
+                    }}
+                  />
                 )}
               </OverlayScroll>
             </div>

--- a/src/lib/resourceTree.test.ts
+++ b/src/lib/resourceTree.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  RESOURCE_TREE_VIRTUALIZE_THRESHOLD,
   TREE_WIDTH_DEFAULT,
   TREE_WIDTH_MAX,
   TREE_WIDTH_MIN,
   clampTreeWidth,
   expandKeysForResourceTreeFilter,
   filterResourceTreeNodes,
+  flattenVisibleResourceTree,
   loadTreeExpanded,
   loadTreeWidth,
   mergeTreeExpandedForFilter,
@@ -122,6 +124,54 @@ describe("filterResourceTreeNodes", () => {
   it("matches by basename", () => {
     const filtered = filterResourceTreeNodes(sample, "readme");
     expect(filtered.map((n) => n.name)).toEqual(["README.md"]);
+  });
+});
+
+describe("flattenVisibleResourceTree", () => {
+  it("omits children of collapsed dirs", () => {
+    const rows = flattenVisibleResourceTree(sample, { "": true });
+    expect(rows.map((r) => r.node.relativePath)).toEqual(["src", "README.md"]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 0]);
+  });
+
+  it("walks expanded dirs in depth-first order", () => {
+    const rows = flattenVisibleResourceTree(sample, {
+      "": true,
+      src: true,
+      "src/lib": true,
+    });
+    expect(rows.map((r) => r.node.relativePath)).toEqual([
+      "src",
+      "src/App.tsx",
+      "src/lib",
+      "src/lib/resourceTabs.ts",
+      "README.md",
+    ]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 1, 1, 2, 0]);
+  });
+
+  it("include skips a node and its descendants", () => {
+    const rows = flattenVisibleResourceTree(
+      sample,
+      { "": true, src: true, "src/lib": true },
+      (n) => n.isDir === true || n.name.toLowerCase().includes("readme"),
+    );
+    expect(rows.map((r) => r.node.relativePath)).toEqual([
+      "src",
+      "src/lib",
+      "README.md",
+    ]);
+  });
+
+  it("windowing threshold is below a 5000-row expanded listing", () => {
+    const many: ResourceTreeNodeLike[] = Array.from({ length: 5000 }, (_, i) => ({
+      name: `f${i}.ts`,
+      relativePath: `f${i}.ts`,
+      isDir: false,
+    }));
+    const rows = flattenVisibleResourceTree(many, { "": true });
+    expect(rows).toHaveLength(5000);
+    expect(rows.length).toBeGreaterThan(RESOURCE_TREE_VIRTUALIZE_THRESHOLD);
   });
 });
 

--- a/src/lib/resourceTree.ts
+++ b/src/lib/resourceTree.ts
@@ -16,6 +16,47 @@ export type ResourceTreeNodeLike = {
   children?: ResourceTreeNodeLike[] | null;
 };
 
+/** Must match `.rp-tree__row` height. */
+export const RESOURCE_TREE_ROW_HEIGHT_PX = 28;
+
+/** Below this visible-row count, the files tree renders every row. */
+export const RESOURCE_TREE_VIRTUALIZE_THRESHOLD = 32;
+
+export type VisibleResourceTreeRow<T extends ResourceTreeNodeLike = ResourceTreeNodeLike> =
+  {
+    node: T;
+    depth: number;
+  };
+
+/**
+ * Depth-first visible rows for the expanded map.
+ * Collapsed dirs contribute the dir row only. `include` skips a node
+ * and its descendants (ResourceViewer query: keep dirs, hide non-hits).
+ */
+export function flattenVisibleResourceTree<T extends ResourceTreeNodeLike>(
+  nodes: readonly T[],
+  expanded: Record<string, boolean>,
+  include?: (node: T) => boolean,
+): VisibleResourceTreeRow<T>[] {
+  const out: VisibleResourceTreeRow<T>[] = [];
+  const walk = (list: readonly T[], depth: number) => {
+    for (const n of list) {
+      if (include && !include(n)) continue;
+      out.push({ node: n, depth });
+      if (
+        n.isDir &&
+        expanded[n.relativePath] &&
+        Array.isArray(n.children) &&
+        n.children.length > 0
+      ) {
+        walk(n.children as T[], depth + 1);
+      }
+    }
+  };
+  walk(nodes, 0);
+  return out;
+}
+
 export function loadTreeWidth(
   storage: Pick<Storage, "getItem"> | null = defaultStorage(),
 ): number {


### PR DESCRIPTION
## Summary

Side-pane / resource files trees keep short folders as a full list. At 32+ visible rows, only the viewport is mounted (28px rows), instead of recursively mapping every expanded entry.

Fixes #831

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/lib/resourceTree.test.ts` (14 passed)
- [ ] Open a small project tree: expand/collapse and open a file unchanged
- [ ] Expand a large folder (32+ visible rows): scroll stays responsive
- [ ] Filter still shows matching files and ancestor dirs
- [ ] Active file still highlights; opening a file from the tree still works
- [ ] CI green

## Checklist

- [x] User-facing strings go through `t()` / `createT`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
