### PR TITLE
perf(chat): keep in-chat find off the workbench shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **In-chat find stays off the workbench shell**: Ctrl+F match scanning and stream ticks live in the find bar / transcript island. Opening or closing find still toggles the shell; typing and token growth do not.
 - **Files tree windows long listings**: Side-pane / resource trees keep short folders as a full list. At 32+ visible rows, only the viewport is mounted (28px rows), instead of recursively mapping every expanded entry.
 - **L/R splitter drag no longer re-renders the workbench every move**: In-flow sidebar / aside width is written on the pane element while the pointer is down. Layout prefs commit on pointer-up. Dragging the left rail past the open min still collapses live.
 - **Bottom terminal toggle snaps height**: Ctrl+` jumps between 0 and the last panel height. The chat column is not interpolated for 320ms, so a long transcript does not reflow on every open/close. Drag-resize and persist-mounted PTY are unchanged.
@@ -48,6 +49,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **对话内查找不再打穿工作台**：Ctrl+F 的匹配和流式跳动留在找条 / 对话岛。开关查找仍会切壳；打字和 token 增长不会。
 - **文件树对长列表做窗口化**：侧栏 / 资源树短目录仍整表渲染。可见行达到 32 以上只挂视口（28px 行高），不再递归把每个展开节点打进 DOM。
 - **拖左右分割条不再每帧重绘工作台**：按住时只改侧栏/右栏元素宽度；松手才写入 layout。左栏拖过最小宽度仍即时收起。
 - **底栏终端开关改为瞬时高度**：Ctrl+` 在 0 和上次高度之间直接跳。聊天列不再插值 320ms，长对话不会每次开关都重排。拖高度和常驻 PTY 不变。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -461,11 +461,7 @@ import {
 } from "@/lib/planHistory";
 import type { PlanHistoryEntry } from "@/lib/planHistory";
 import { planDisplayMarkdown } from "@/lib/planBody";
-import {
-  findChatMatches,
-  stepChatFindIndex,
-  type ChatFindMatch
-} from "@/lib/chatFind";
+
 import {
   connPillForState,
   connPillRetryable,
@@ -530,7 +526,7 @@ import {
   markDone as markProductTutorialDone,
   shouldAutoOffer as shouldAutoOfferProductTutorial
 } from "@/lib/productTutorial";
-import { ChatFindBar } from "@/components/ChatFindBar";
+import { ChatFindLive } from "@/components/ChatFindLive";
 import {
   applyResolvedSessionMedia,
   buildAgentPrompt,
@@ -2320,8 +2316,6 @@ export function AppWorkbench() {
   }, [appGate]);
   /** In-conversation find (Cmd/Ctrl+F) — not the palette/session search. */
   const [showChatFind, setShowChatFind] = useState(false);
-  const [chatFindQuery, setChatFindQuery] = useState("");
-  const [chatFindIndex, setChatFindIndex] = useState(0);
   const [savedAccounts, setSavedAccounts] = useState<api.SavedAccount[]>([]);
   const [activeAccountId, setActiveAccountId] = useState<string | null>(null);
   const [accountQuotas, setAccountQuotas] = useState<
@@ -12513,75 +12507,9 @@ export function AppWorkbench() {
     return summarizeSessionChanges(list);
   }, [session.sessionId, sessionChangesById]);
 
-  /**
-   * In-chat find matches — user + assistant bodies only.
-   * Historical tool_step rows are not rendered in the transcript, so matching
-   * them would land on invisible hits.
-   */
-  const [chatFindLiveTick, setChatFindLiveTick] = useState(0);
-  useEffect(() => {
-    if (!showChatFind) return;
-    let raf = 0;
-    const unsub = sessionTranscriptStore.subscribeContent(() => {
-      cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(() => setChatFindLiveTick((n) => n + 1));
-    });
-    return () => {
-      cancelAnimationFrame(raf);
-      unsub();
-    };
-  }, [showChatFind]);
-
-  const chatFindMatches = useMemo((): ChatFindMatch[] => {
-    if (!showChatFind) return [];
-    void chatFindLiveTick;
-    const live = sessionTranscriptStore.getMessages();
-    return findChatMatches(
-      chatFindQuery,
-      live
-        .filter((m) => m.role === "user" || m.role === "assistant")
-        .map((m) => ({
-          id: m.id,
-          role: m.role,
-          content: m.content,
-          marker: m.marker,
-        })),
-    );
-  }, [showChatFind, chatFindQuery, chatFindLiveTick, messages]);
-
-  const chatFindHitIds = useMemo(() => {
-    const s = new Set<string>();
-    for (const m of chatFindMatches) s.add(m.messageId);
-    return s;
-  }, [chatFindMatches]);
-
-  const chatFindActive = useMemo(() => {
-    if (!showChatFind || chatFindMatches.length === 0) return null;
-    const idx =
-      chatFindIndex >= 0 && chatFindIndex < chatFindMatches.length
-        ? chatFindIndex
-        : 0;
-    const hit = chatFindMatches[idx]!;
-    return { messageId: hit.messageId, occurrence: hit.occurrence };
-  }, [showChatFind, chatFindMatches, chatFindIndex]);
-
-  // Clamp active index when the match list shrinks (query edit / new messages).
-  useEffect(() => {
-    if (!showChatFind) return;
-    if (chatFindMatches.length === 0) {
-      if (chatFindIndex !== 0) setChatFindIndex(0);
-      return;
-    }
-    if (chatFindIndex >= chatFindMatches.length) {
-      setChatFindIndex(0);
-    }
-  }, [showChatFind, chatFindMatches.length, chatFindIndex]);
-
   // Reset find when switching conversation (keep open across same session).
   useEffect(() => {
     setShowChatFind(false);
-    setChatFindQuery("");
-    setChatFindIndex(0);
   }, [session.sessionId]);
 
   // Close find when leaving the chat pane (not when opening from another pane).
@@ -12616,18 +12544,6 @@ export function AppWorkbench() {
     setShowChatFind(true);
     setChatFindFocusKey((k) => k + 1);
   }, [mainPane]);
-
-  const chatFindNext = useCallback(() => {
-    setChatFindIndex((i) =>
-      stepChatFindIndex(i, chatFindMatches.length, 1),
-    );
-  }, [chatFindMatches.length]);
-
-  const chatFindPrev = useCallback(() => {
-    setChatFindIndex((i) =>
-      stepChatFindIndex(i, chatFindMatches.length, -1),
-    );
-  }, [chatFindMatches.length]);
 
   /** Copy last non-error assistant reply body to the clipboard. */
   const copyLastAssistantReply = useCallback(async () => {
@@ -20949,11 +20865,8 @@ export function AppWorkbench() {
           ) : null}
 
           {mainPane === "chat" && showChatFind && (
-            <ChatFindBar
-              key={chatFindFocusKey}
-              query={chatFindQuery}
-              activeIndex={chatFindIndex}
-              matchCount={chatFindMatches.length}
+            <ChatFindLive
+              focusNonce={chatFindFocusKey}
               labels={{
                 placeholder: tr("chatFind.placeholder"),
                 prev: tr("chatFind.prev"),
@@ -20963,12 +20876,6 @@ export function AppWorkbench() {
                 noMatches: tr("chatFind.noMatches"),
                 aria: tr("chatFind.aria"),
               }}
-              onQueryChange={(q) => {
-                setChatFindQuery(q);
-                setChatFindIndex(0);
-              }}
-              onPrev={chatFindPrev}
-              onNext={chatFindNext}
               onClose={() => setShowChatFind(false)}
             />
           )}
@@ -21185,9 +21092,6 @@ export function AppWorkbench() {
             onOpenExternalLink={openExternalLinkFromChat}
             onAddAttachmentToComposer={onThreadAddAttachmentToComposer}
             attachLabels={attachLabels}
-            findQuery={showChatFind ? chatFindQuery : ""}
-            findHitMessageIds={showChatFind ? chatFindHitIds : undefined}
-            findActive={showChatFind ? chatFindActive : null}
             showTimestamps={showMessageTimestamps}
             messageTimeFormat={messageTimeFormat}
             showReplyLength={showReplyLength}

--- a/src/components/ChatFindBar.tsx
+++ b/src/components/ChatFindBar.tsx
@@ -28,6 +28,8 @@ export type ChatFindBarProps = {
   activeIndex: number;
   matchCount: number;
   labels: ChatFindBarLabels;
+  /** Bump to focus+select the input without remounting the live island. */
+  focusNonce?: number;
   onQueryChange: (q: string) => void;
   onPrev: () => void;
   onNext: () => void;
@@ -39,6 +41,7 @@ export function ChatFindBar({
   activeIndex,
   matchCount,
   labels,
+  focusNonce = 0,
   onQueryChange,
   onPrev,
   onNext,
@@ -52,7 +55,7 @@ export function ChatFindBar({
       inputRef.current?.select();
     }, 0);
     return () => window.clearTimeout(t);
-  }, []);
+  }, [focusNonce]);
 
   const { current, total } = formatChatFindCount(activeIndex, matchCount);
   const countText =

--- a/src/components/ChatFindLive.tsx
+++ b/src/components/ChatFindLive.tsx
@@ -1,0 +1,100 @@
+/**
+ * In-chat find island — query, matches, and stream ticks stay off the shell.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { ChatFindBar, type ChatFindBarLabels } from "@/components/ChatFindBar";
+import {
+  findChatMatches,
+  stepChatFindIndex,
+  type ChatFindMessage,
+} from "@/lib/chatFind";
+import {
+  publishChatFindLive,
+  resetChatFindLive,
+} from "@/lib/chatFindLiveStore";
+import { sessionTranscriptStore } from "@/lib/sessionTranscriptStore";
+
+export function ChatFindLive({
+  labels,
+  focusNonce,
+  onClose,
+}: {
+  labels: ChatFindBarLabels;
+  focusNonce: number;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [index, setIndex] = useState(0);
+  const [liveTick, setLiveTick] = useState(0);
+
+  useEffect(() => {
+    let raf = 0;
+    const unsub = sessionTranscriptStore.subscribeContent(() => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => setLiveTick((n) => n + 1));
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      unsub();
+    };
+  }, []);
+
+  const matches = useMemo(() => {
+    void liveTick;
+    const live = sessionTranscriptStore.getMessages();
+    const rows: ChatFindMessage[] = [];
+    for (const m of live) {
+      if (m.role !== "user" && m.role !== "assistant") continue;
+      rows.push({
+        id: m.id,
+        role: m.role,
+        content: m.content,
+        marker: m.marker,
+      });
+    }
+    return findChatMatches(query, rows);
+  }, [query, liveTick]);
+
+  const clamped =
+    matches.length === 0
+      ? 0
+      : index >= 0 && index < matches.length
+        ? index
+        : 0;
+
+  useEffect(() => {
+    if (clamped !== index) setIndex(clamped);
+  }, [clamped, index]);
+
+  useEffect(() => {
+    publishChatFindLive({ query, index: clamped, matches });
+  }, [query, clamped, matches]);
+
+  useEffect(() => {
+    return () => {
+      resetChatFindLive();
+    };
+  }, []);
+
+  return (
+    <ChatFindBar
+      focusNonce={focusNonce}
+      query={query}
+      activeIndex={clamped}
+      matchCount={matches.length}
+      labels={labels}
+      onQueryChange={(q) => {
+        setQuery(q);
+        setIndex(0);
+      }}
+      onPrev={() =>
+        setIndex((i) => stepChatFindIndex(i, matches.length, -1))
+      }
+      onNext={() =>
+        setIndex((i) => stepChatFindIndex(i, matches.length, 1))
+      }
+      onClose={onClose}
+    />
+  );
+}

--- a/src/components/lobe-chat/ConversationThreadLive.tsx
+++ b/src/components/lobe-chat/ConversationThreadLive.tsx
@@ -3,12 +3,24 @@
  * Isolates stream token re-renders from the App shell.
  */
 
-import { memo } from "react";
+import { memo, useSyncExternalStore } from "react";
 import { ConversationThread, type ConversationThreadProps } from "./ConversationThread";
+import {
+  getChatFindLiveSnapshot,
+  subscribeChatFindLive,
+} from "@/lib/chatFindLiveStore";
 import {
   useTranscriptMeta,
   useViewingMessages,
 } from "@/hooks/useSessionTranscript";
+
+function useChatFindLive() {
+  return useSyncExternalStore(
+    subscribeChatFindLive,
+    getChatFindLiveSnapshot,
+    getChatFindLiveSnapshot,
+  );
+}
 
 export type ConversationThreadLiveProps = Omit<
   ConversationThreadProps,
@@ -20,12 +32,16 @@ export const ConversationThreadLive = memo(function ConversationThreadLive(
 ) {
   const messages = useViewingMessages();
   const meta = useTranscriptMeta();
+  const find = useChatFindLive();
   const journalLoading = !!props.journalLoading || meta.journalLoading;
   return (
     <ConversationThread
       {...props}
       messages={messages}
       journalLoading={journalLoading}
+      findQuery={find.query}
+      findHitMessageIds={find.hitIds}
+      findActive={find.active}
     />
   );
 });

--- a/src/lib/chatFindLiveStore.test.ts
+++ b/src/lib/chatFindLiveStore.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { findChatMatches } from "./chatFind";
+import {
+  EMPTY_CHAT_FIND_LIVE,
+  buildChatFindLiveSnapshot,
+  getChatFindLiveSnapshot,
+  publishChatFindLive,
+  resetChatFindLive,
+  resetChatFindLiveForTests,
+  subscribeChatFindLive,
+} from "./chatFindLiveStore";
+
+afterEach(() => {
+  resetChatFindLiveForTests();
+});
+
+const matches = findChatMatches("ab", [
+  { id: "u", role: "user", content: "ab ab" },
+  { id: "a", role: "assistant", content: "ab" },
+]);
+
+describe("buildChatFindLiveSnapshot", () => {
+  it("is empty when there are no matches", () => {
+    const snap = buildChatFindLiveSnapshot({
+      query: "zz",
+      index: 3,
+      matches: [],
+    });
+    expect(snap.matchCount).toBe(0);
+    expect(snap.index).toBe(0);
+    expect(snap.active).toBeNull();
+    expect(snap.hitIds.size).toBe(0);
+    expect(snap.query).toBe("zz");
+  });
+
+  it("clamps a stale index and reuses hitIds / active", () => {
+    const first = buildChatFindLiveSnapshot({
+      query: "ab",
+      index: 0,
+      matches,
+    });
+    expect(first.matchCount).toBe(3);
+    expect([...first.hitIds]).toEqual(["u", "a"]);
+    const second = buildChatFindLiveSnapshot(
+      { query: "ab", index: 99, matches },
+      first,
+    );
+    expect(second.index).toBe(0);
+    expect(second.hitIds).toBe(first.hitIds);
+    expect(second.active).toBe(first.active);
+  });
+});
+
+describe("chatFindLiveStore", () => {
+  it("notifies on publish and skips identical snapshots", () => {
+    const listener = vi.fn();
+    const unsub = subscribeChatFindLive(listener);
+    publishChatFindLive({ query: "ab", index: 0, matches });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getChatFindLiveSnapshot().matchCount).toBe(3);
+    publishChatFindLive({ query: "ab", index: 0, matches });
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsub();
+  });
+
+  it("reset restores the empty snapshot", () => {
+    publishChatFindLive({ query: "ab", index: 1, matches });
+    resetChatFindLive();
+    expect(getChatFindLiveSnapshot()).toBe(EMPTY_CHAT_FIND_LIVE);
+  });
+});

--- a/src/lib/chatFindLiveStore.ts
+++ b/src/lib/chatFindLiveStore.ts
@@ -1,0 +1,132 @@
+/**
+ * Live in-chat find snapshot.
+ * The find bar publishes here so stream ticks do not setState the workbench.
+ */
+
+import type { ChatFindMatch } from "@/lib/chatFind";
+
+export type ChatFindLiveActive = {
+  messageId: string;
+  occurrence: number;
+};
+
+export type ChatFindLiveSnapshot = {
+  query: string;
+  index: number;
+  matchCount: number;
+  hitIds: ReadonlySet<string>;
+  active: ChatFindLiveActive | null;
+};
+
+const EMPTY_HITS: ReadonlySet<string> = new Set();
+
+export const EMPTY_CHAT_FIND_LIVE: ChatFindLiveSnapshot = {
+  query: "",
+  index: 0,
+  matchCount: 0,
+  hitIds: EMPTY_HITS,
+  active: null,
+};
+
+type Listener = () => void;
+
+let snapshot: ChatFindLiveSnapshot = EMPTY_CHAT_FIND_LIVE;
+const listeners = new Set<Listener>();
+
+function emit(): void {
+  for (const fn of listeners) fn();
+}
+
+export function getChatFindLiveSnapshot(): ChatFindLiveSnapshot {
+  return snapshot;
+}
+
+export function subscribeChatFindLive(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetChatFindLive(): void {
+  if (snapshot === EMPTY_CHAT_FIND_LIVE) return;
+  snapshot = EMPTY_CHAT_FIND_LIVE;
+  emit();
+}
+
+export function publishChatFindLive(input: {
+  query: string;
+  index: number;
+  matches: readonly ChatFindMatch[];
+}): void {
+  const next = buildChatFindLiveSnapshot(input, snapshot);
+  if (next === snapshot) return;
+  snapshot = next;
+  emit();
+}
+
+export function buildChatFindLiveSnapshot(
+  input: {
+    query: string;
+    index: number;
+    matches: readonly ChatFindMatch[];
+  },
+  prev: ChatFindLiveSnapshot = EMPTY_CHAT_FIND_LIVE,
+): ChatFindLiveSnapshot {
+  const query = input.query;
+  const matches = input.matches;
+  const matchCount = matches.length;
+  const clamped =
+    matchCount === 0
+      ? 0
+      : input.index >= 0 && input.index < matchCount
+        ? input.index
+        : 0;
+
+  const hitIds = hitIdsFromMatches(matches, prev.hitIds);
+  const hit = matchCount > 0 ? matches[clamped]! : null;
+  const active: ChatFindLiveActive | null = hit
+    ? prev.active &&
+      prev.active.messageId === hit.messageId &&
+      prev.active.occurrence === hit.occurrence
+      ? prev.active
+      : { messageId: hit.messageId, occurrence: hit.occurrence }
+    : null;
+
+  if (
+    prev.query === query &&
+    prev.index === clamped &&
+    prev.matchCount === matchCount &&
+    prev.hitIds === hitIds &&
+    prev.active === active
+  ) {
+    return prev;
+  }
+
+  return { query, index: clamped, matchCount, hitIds, active };
+}
+
+function hitIdsFromMatches(
+  matches: readonly ChatFindMatch[],
+  prev: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (matches.length === 0) return EMPTY_HITS;
+  const next = new Set<string>();
+  for (const m of matches) next.add(m.messageId);
+  if (next.size === prev.size) {
+    let same = true;
+    for (const id of next) {
+      if (!prev.has(id)) {
+        same = false;
+        break;
+      }
+    }
+    if (same) return prev;
+  }
+  return next;
+}
+
+export function resetChatFindLiveForTests(): void {
+  snapshot = EMPTY_CHAT_FIND_LIVE;
+  listeners.clear();
+}


### PR DESCRIPTION
## Summary

Ctrl+F match scanning and stream ticks live in the find bar / transcript island. Opening or closing find still toggles the workbench; typing and token growth do not.

Fixes #833

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/lib/chatFindLiveStore.test.ts src/lib/chatFind.test.ts src/lib/escapeStop.test.ts` (35 passed)
- [ ] Ctrl+F opens the bar; typing filters matches without hitching the rails
- [ ] Prev/next and Escape still work; switching session closes find
- [ ] Stream a long reply with find open: highlights update, composer/sidebar stay calm
- [ ] Ctrl+F while already open refocuses the input and keeps the query
- [ ] CI green

## Checklist

- [x] User-facing strings go through `t()` / `createT`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
