### PR TITLE
perf(preview): window long markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Resource markdown preview windows long files**: Side-pane `.md` keeps short files as one tree. Files at 200+ lines split on headings (and length caps) and only mount visible sections, instead of ReactMarkdown for the whole buffer.
 - **In-chat find stays off the workbench shell**: Ctrl+F match scanning and stream ticks live in the find bar / transcript island. Opening or closing find still toggles the shell; typing and token growth do not.
 - **Files tree windows long listings**: Side-pane / resource trees keep short folders as a full list. At 32+ visible rows, only the viewport is mounted (28px rows), instead of recursively mapping every expanded entry.
 - **L/R splitter drag no longer re-renders the workbench every move**: In-flow sidebar / aside width is written on the pane element while the pointer is down. Layout prefs commit on pointer-up. Dragging the left rail past the open min still collapses live.
@@ -49,6 +50,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com/](https://grok-app.com/).
 
 **中文 · 变更**
+- **资源栏 Markdown 对长文件做窗口化**：侧栏 `.md` 短文件仍整树渲染。200 行以上按标题（及长度上限）切块，只挂可见节，不再对整份 buffer 跑 ReactMarkdown。
 - **对话内查找不再打穿工作台**：Ctrl+F 的匹配和流式跳动留在找条 / 对话岛。开关查找仍会切壳；打字和 token 增长不会。
 - **文件树对长列表做窗口化**：侧栏 / 资源树短目录仍整表渲染。可见行达到 32 以上只挂视口（28px 行高），不再递归把每个展开节点打进 DOM。
 - **拖左右分割条不再每帧重绘工作台**：按住时只改侧栏/右栏元素宽度；松手才写入 layout。左栏拖过最小宽度仍即时收起。

--- a/src/components/MarkdownPreview.test.tsx
+++ b/src/components/MarkdownPreview.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@/test/jsdomStubs";
+import { MarkdownPreview } from "./MarkdownPreview";
+import { MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD } from "@/lib/markdownPreviewWindow";
+
+afterEach(cleanup);
+
+describe("MarkdownPreview", () => {
+  it("renders a short file as one markdown tree", () => {
+    render(<MarkdownPreview>{"# Hi\n\nHello"}</MarkdownPreview>);
+    expect(document.querySelectorAll(".md-body")).toHaveLength(1);
+    expect(document.querySelector("[data-virtualized]")).toBeNull();
+  });
+
+  it("does not mount every section of a 5000-line file", () => {
+    const chunks: string[] = [];
+    for (let i = 0; i < 500; i++) {
+      chunks.push(`# H${i}\n${"x\n".repeat(9)}`);
+    }
+    const text = chunks.join("");
+    expect(text.split("\n").length).toBeGreaterThan(
+      MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD,
+    );
+    render(<MarkdownPreview>{text}</MarkdownPreview>);
+    const mounted = document.querySelectorAll("[data-md-section]").length;
+    expect(mounted).toBeGreaterThan(0);
+    expect(mounted).toBeLessThan(MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD);
+    expect(
+      document.querySelector(".md-preview")?.getAttribute("data-virtualized"),
+    ).toBe("1");
+  });
+});

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -1,0 +1,172 @@
+/**
+ * Resource markdown preview — short files are one tree; long files window sections.
+ */
+
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { MarkdownBody } from "@/components/MarkdownBody";
+import type { Locale } from "@/i18n";
+import {
+  MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD,
+  MARKDOWN_SECTION_OVERSCAN,
+  computeMarkdownSectionWindow,
+  countMarkdownLines,
+  initialMarkdownSectionWindow,
+  markdownSectionLayout,
+  shouldWindowMarkdownPreview,
+  splitMarkdownSections,
+  type MarkdownSectionWindow,
+} from "@/lib/markdownPreviewWindow";
+
+function findScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let node: HTMLElement | null = el?.parentElement ?? null;
+  while (node) {
+    const { overflowY } = getComputedStyle(node);
+    if (
+      overflowY === "auto" ||
+      overflowY === "scroll" ||
+      overflowY === "overlay"
+    ) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+function windowsEqual(a: MarkdownSectionWindow, b: MarkdownSectionWindow): boolean {
+  return (
+    a.start === b.start &&
+    a.end === b.end &&
+    a.paddingTop === b.paddingTop &&
+    a.paddingBottom === b.paddingBottom &&
+    a.totalHeight === b.totalHeight
+  );
+}
+
+export function MarkdownPreview({
+  children,
+  locale = "en",
+}: {
+  children: string;
+  locale?: Locale;
+}) {
+  const text = children || "";
+  const lineCount = useMemo(() => countMarkdownLines(text), [text]);
+  const windowed = shouldWindowMarkdownPreview(lineCount);
+  const sections = useMemo(
+    () => (windowed ? splitMarkdownSections(text) : []),
+    [text, windowed],
+  );
+  const layout = useMemo(
+    () => (windowed ? markdownSectionLayout(sections) : null),
+    [sections, windowed],
+  );
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const scrollParentRef = useRef<HTMLElement | null>(null);
+  const [win, setWin] = useState<MarkdownSectionWindow>(() =>
+    initialMarkdownSectionWindow(sections.length, windowed),
+  );
+
+  const recompute = useCallback(() => {
+    if (!windowed || !layout) {
+      setWin((prev) => {
+        const next = initialMarkdownSectionWindow(0, false);
+        next.end = 0;
+        return windowsEqual(prev, next) ? prev : next;
+      });
+      return;
+    }
+    const root = rootRef.current;
+    if (!root) return;
+    const scrollParent = scrollParentRef.current ?? findScrollParent(root);
+    scrollParentRef.current = scrollParent;
+    if (!scrollParent) {
+      setWin((prev) => {
+        const next = initialMarkdownSectionWindow(
+          sections.length,
+          true,
+          MARKDOWN_SECTION_OVERSCAN,
+        );
+        return windowsEqual(prev, next) ? prev : next;
+      });
+      return;
+    }
+    const rootRect = root.getBoundingClientRect();
+    const parentRect = scrollParent.getBoundingClientRect();
+    const next = computeMarkdownSectionWindow({
+      offsets: layout.offsets,
+      heights: layout.heights,
+      totalHeight: layout.total,
+      scrollOffset: parentRect.top - rootRect.top,
+      viewportHeight: scrollParent.clientHeight,
+      overscan: MARKDOWN_SECTION_OVERSCAN,
+    });
+    setWin((prev) => (windowsEqual(prev, next) ? prev : next));
+  }, [layout, sections.length, windowed]);
+
+  useLayoutEffect(() => {
+    if (!windowed) return;
+    const root = rootRef.current;
+    if (!root) return;
+    const scrollParent = findScrollParent(root);
+    scrollParentRef.current = scrollParent;
+    const onScroll = () => recompute();
+    scrollParent?.addEventListener("scroll", onScroll, { passive: true });
+    const ro = new ResizeObserver(() => recompute());
+    ro.observe(root);
+    if (scrollParent) ro.observe(scrollParent);
+    recompute();
+    return () => {
+      scrollParent?.removeEventListener("scroll", onScroll);
+      ro.disconnect();
+    };
+  }, [recompute, windowed, sections.length]);
+
+  if (!windowed) {
+    return <MarkdownBody locale={locale}>{text}</MarkdownBody>;
+  }
+
+  const slice = sections.slice(win.start, win.end);
+
+  return (
+    <div
+      ref={rootRef}
+      className="md-preview md-preview--windowed"
+      data-virtualized="1"
+      data-sections={String(sections.length)}
+    >
+      {win.paddingTop > 0 ? (
+        <div
+          className="md-preview__spacer"
+          style={{ height: win.paddingTop }}
+          aria-hidden
+        />
+      ) : null}
+      {slice.map((section, i) => (
+        <div
+          key={`${section.startLine}-${win.start + i}`}
+          className="md-preview__section"
+          data-md-section={section.startLine}
+        >
+          <MarkdownBody locale={locale}>{section.source}</MarkdownBody>
+        </div>
+      ))}
+      {win.paddingBottom > 0 ? (
+        <div
+          className="md-preview__spacer"
+          style={{ height: win.paddingBottom }}
+          aria-hidden
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export { MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD };

--- a/src/components/resource-viewer/ResourcePreviewBody.tsx
+++ b/src/components/resource-viewer/ResourcePreviewBody.tsx
@@ -12,7 +12,7 @@ import {
   resolveMediaLoadError,
 } from "@/lib/mediaLoadPro";
 import { HtmlBrowser } from "@/components/HtmlBrowser";
-import { MarkdownBody } from "@/components/MarkdownBody";
+import { MarkdownPreview } from "@/components/MarkdownPreview";
 import { OverlayScroll } from "@/components/OverlayScroll";
 import { ImageUi } from "@/components/ImageUi";
 import { revealInOsLabel } from "@/lib/appPlatform";
@@ -732,9 +732,9 @@ export function ResourcePreviewBody({
         ) : isMarkdown ? (
           <OverlayScroll className="rp-editor__preview-scroll">
             <div className="rp-editor__preview-body rp-preview__md">
-              <MarkdownBody>
+              <MarkdownPreview locale={locale}>
                 {draftText || preview.text || ""}
-              </MarkdownBody>
+              </MarkdownPreview>
             </div>
           </OverlayScroll>
         ) : isHtml ? (
@@ -845,9 +845,9 @@ export function ResourcePreviewBody({
     case "markdown":
       return (
         <div className="rp-preview__md">
-          <MarkdownBody>
+          <MarkdownPreview locale={locale}>
             {activeTab?.draftText ?? preview.text ?? ""}
-          </MarkdownBody>
+          </MarkdownPreview>
         </div>
       );
     case "html":

--- a/src/lib/markdownPreviewWindow.test.ts
+++ b/src/lib/markdownPreviewWindow.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD,
+  MARKDOWN_SECTION_MAX_LINES,
+  computeMarkdownSectionWindow,
+  countMarkdownLines,
+  markdownSectionLayout,
+  shouldWindowMarkdownPreview,
+  splitMarkdownSections,
+} from "./markdownPreviewWindow";
+
+describe("countMarkdownLines / shouldWindowMarkdownPreview", () => {
+  it("does not count a trailing newline as a row", () => {
+    expect(countMarkdownLines("a\nb\n")).toBe(2);
+    expect(countMarkdownLines("")).toBe(1);
+  });
+
+  it("windows at 200 lines", () => {
+    expect(
+      shouldWindowMarkdownPreview(MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD - 1),
+    ).toBe(false);
+    expect(
+      shouldWindowMarkdownPreview(MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD),
+    ).toBe(true);
+  });
+});
+
+describe("splitMarkdownSections", () => {
+  it("keeps a short file as one section", () => {
+    const s = splitMarkdownSections("# Hi\n\nHello");
+    expect(s).toHaveLength(1);
+    expect(s[0]?.source).toBe("# Hi\n\nHello");
+  });
+
+  it("starts a section on each ATX heading", () => {
+    const s = splitMarkdownSections("# A\nbody\n# B\nmore");
+    expect(s.map((x) => x.source)).toEqual(["# A\nbody", "# B\nmore"]);
+    expect(s.map((x) => x.startLine)).toEqual([1, 3]);
+  });
+
+  it("does not split a heading inside a fence", () => {
+    const s = splitMarkdownSections("# A\n```\n# not a heading\n```\n# B");
+    expect(s.map((x) => x.source)).toEqual([
+      "# A\n```\n# not a heading\n```",
+      "# B",
+    ]);
+  });
+
+  it("caps long heading-less bodies on blank lines", () => {
+    const lines = Array.from({ length: 120 }, (_, i) => `line ${i}`);
+    lines[MARKDOWN_SECTION_MAX_LINES] = "";
+    const s = splitMarkdownSections(lines.join("\n"));
+    expect(s.length).toBeGreaterThan(1);
+    expect(s[0]?.lineCount).toBe(MARKDOWN_SECTION_MAX_LINES);
+  });
+});
+
+describe("computeMarkdownSectionWindow", () => {
+  it("covers the viewport plus overscan", () => {
+    const layout = markdownSectionLayout([
+      { lineCount: 10 },
+      { lineCount: 10 },
+      { lineCount: 10 },
+      { lineCount: 10 },
+    ]);
+    const win = computeMarkdownSectionWindow({
+      offsets: layout.offsets,
+      heights: layout.heights,
+      totalHeight: layout.total,
+      scrollOffset: 240,
+      viewportHeight: 100,
+      overscan: 1,
+    });
+    expect(win.start).toBeGreaterThanOrEqual(0);
+    expect(win.end).toBeGreaterThan(win.start);
+    expect(win.end).toBeLessThanOrEqual(4);
+    expect(win.paddingTop + win.paddingBottom).toBeLessThan(layout.total);
+  });
+});

--- a/src/lib/markdownPreviewWindow.ts
+++ b/src/lib/markdownPreviewWindow.ts
@@ -1,0 +1,177 @@
+/**
+ * Variable-height windowing for resource-pane markdown preview.
+ * Short files stay one ReactMarkdown tree; long files split into sections.
+ */
+
+export const MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD = 200;
+export const MARKDOWN_SECTION_LINE_HEIGHT_PX = 24;
+export const MARKDOWN_SECTION_MAX_LINES = 80;
+export const MARKDOWN_SECTION_OVERSCAN = 2;
+
+export type MarkdownPreviewSection = {
+  startLine: number;
+  lineCount: number;
+  source: string;
+};
+
+export type MarkdownSectionWindow = {
+  start: number;
+  end: number;
+  paddingTop: number;
+  paddingBottom: number;
+  totalHeight: number;
+};
+
+export function countMarkdownLines(text: string): number {
+  if (!text) return 1;
+  const parts = text.split("\n");
+  if (parts.length > 0 && parts[parts.length - 1] === "") parts.pop();
+  return Math.max(1, parts.length);
+}
+
+export function shouldWindowMarkdownPreview(lineCount: number): boolean {
+  return lineCount >= MARKDOWN_PREVIEW_VIRTUALIZE_THRESHOLD;
+}
+
+function isFenceLine(line: string): boolean {
+  return /^```/.test(line) || /^~~~/.test(line);
+}
+
+function isAtxHeading(line: string): boolean {
+  return /^#{1,6} /.test(line);
+}
+
+/** Split on ATX headings and on blank lines once a section hits the line cap. */
+export function splitMarkdownSections(text: string): MarkdownPreviewSection[] {
+  const lines = (text ?? "").split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  if (lines.length === 0) {
+    return [{ startLine: 1, lineCount: 1, source: "" }];
+  }
+
+  const sections: MarkdownPreviewSection[] = [];
+  let buf: string[] = [];
+  let start = 0;
+  let inFence = false;
+
+  const flush = () => {
+    if (buf.length === 0) return;
+    sections.push({
+      startLine: start + 1,
+      lineCount: buf.length,
+      source: buf.join("\n"),
+    });
+    start += buf.length;
+    buf = [];
+  };
+
+  for (const line of lines) {
+    if (isFenceLine(line)) inFence = !inFence;
+    const heading = !inFence && isAtxHeading(line) && buf.length > 0;
+    const capped =
+      !inFence &&
+      buf.length >= MARKDOWN_SECTION_MAX_LINES &&
+      (line === "" || isAtxHeading(line));
+    if (heading || capped) flush();
+    buf.push(line);
+  }
+  flush();
+  return sections;
+}
+
+export function markdownSectionLayout(
+  sections: readonly { lineCount: number }[],
+  linePx = MARKDOWN_SECTION_LINE_HEIGHT_PX,
+): { heights: number[]; offsets: number[]; total: number } {
+  const heights = sections.map((s) =>
+    Math.max(linePx, s.lineCount * linePx),
+  );
+  const offsets: number[] = [];
+  let acc = 0;
+  for (const h of heights) {
+    offsets.push(acc);
+    acc += h;
+  }
+  return { heights, offsets, total: acc };
+}
+
+function sectionIndexAt(offsets: readonly number[], y: number): number {
+  if (offsets.length === 0) return 0;
+  let lo = 0;
+  let hi = offsets.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (offsets[mid]! <= y) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+export function computeMarkdownSectionWindow(input: {
+  offsets: readonly number[];
+  heights: readonly number[];
+  totalHeight: number;
+  scrollOffset: number;
+  viewportHeight: number;
+  overscan?: number;
+}): MarkdownSectionWindow {
+  const count = input.offsets.length;
+  const totalHeight = Math.max(0, input.totalHeight);
+  if (count === 0) {
+    return {
+      start: 0,
+      end: 0,
+      paddingTop: 0,
+      paddingBottom: 0,
+      totalHeight: 0,
+    };
+  }
+  const overscan = Math.max(0, Math.floor(input.overscan ?? MARKDOWN_SECTION_OVERSCAN));
+  const visibleTop = Math.max(0, input.scrollOffset);
+  const visibleBottom = Math.max(
+    visibleTop,
+    input.scrollOffset + Math.max(0, input.viewportHeight),
+  );
+  let start = sectionIndexAt(input.offsets, visibleTop);
+  let end = sectionIndexAt(input.offsets, visibleBottom) + 1;
+  start = Math.max(0, start - overscan);
+  end = Math.min(count, end + overscan);
+  if (start >= end) {
+    start = Math.min(sectionIndexAt(input.offsets, visibleTop), count - 1);
+    end = start + 1;
+  }
+  const paddingTop = input.offsets[start] ?? 0;
+  let rendered = 0;
+  for (let i = start; i < end; i++) rendered += input.heights[i] ?? 0;
+  return {
+    start,
+    end,
+    paddingTop,
+    paddingBottom: Math.max(0, totalHeight - paddingTop - rendered),
+    totalHeight,
+  };
+}
+
+export function initialMarkdownSectionWindow(
+  count: number,
+  windowed: boolean,
+  overscan = MARKDOWN_SECTION_OVERSCAN,
+): MarkdownSectionWindow {
+  if (!windowed) {
+    return {
+      start: 0,
+      end: count,
+      paddingTop: 0,
+      paddingBottom: 0,
+      totalHeight: 0,
+    };
+  }
+  const end = Math.min(count, Math.max(1, overscan * 2 + 1));
+  return {
+    start: 0,
+    end,
+    paddingTop: 0,
+    paddingBottom: 0,
+    totalHeight: 0,
+  };
+}


### PR DESCRIPTION
## Summary

Side-pane `.md` keeps short files as one tree. Files at 200+ lines split on headings (and length caps) and only mount visible sections, instead of ReactMarkdown for the whole buffer. Fenced code is not split.

Fixes #835

## Type of change

- [x] Refactor / chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

## Test plan

- [x] `pnpm exec vitest run src/lib/markdownPreviewWindow.test.ts src/components/MarkdownPreview.test.tsx` (9 passed)
- [ ] Open a short README in the side pane: rendered markdown unchanged
- [ ] Open a 2000-line markdown file: preview scrolls, UI stays responsive
- [ ] Headings still render; a fenced block is not split mid-fence
- [ ] Edit/preview toggle still works
- [ ] CI green

## Checklist

- [x] User-facing strings go through `t()` / `createT`
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets
