### PR TITLE
feat(windows): install latest main beside official Grok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Added
+- **Windows `install-latest.cmd`**: with Node / pnpm / Rust / VS Build Tools, double-click to fast-forward `origin/main` and silently install an unsigned side-by-side **grok-app-latest** under `%LOCALAPPDATA%\grok-app-latest`. Does not replace official **Grok**. For people waiting on the next GitHub Release; not a signed production build (`docs/BUILD.md`).
 - **Appearance packs (.grokskin)**: Settings → Appearance can save, import, and export the current skin + wallpaper + crop + clip + overlay. Apply always confirms first. `grok://` and `.grokskin` files write a pending import and never auto-apply. Export bakes the visible wallpaper crop (video uses system ffmpeg when present).
 - **Custom provider extra request headers (#812)**: Settings → Account → Providers can add key/value HTTP headers. They write Grok Build `extra_headers` on `[model.<id>]` (sent verbatim). Use for AgentRouter / AnyRouter WAF (`User-Agent`, `Originator`) or Anthropic `x-api-key`. Empty list omits the field.
 - **Optional Windows taskbar overlay for unread sessions** (#775): Settings → General → App toggle, **off by default**, independent of the dock/tray unread badge. When on, the host paints 1–9 / 10+ via `set_overlay_icon` (Tauri `set_badge_count` is a no-op on Windows). Hide-to-tray restore re-applies the last overlay count after Explorer AddTab.
 - **Shortcuts help (Ctrl+/)**: the overlay now searches by label / id / chord, groups like Settings → Keyboard, and lists zoom, newline, prompt history, and type-to-focus. The list scrolls instead of clipping the last rows.
 
 **中文 · 新增**
+- **Windows `install-latest.cmd`**：已有 Node / pnpm / Rust / VS Build Tools 时可双击，把 `origin/main` fast-forward 后静默安装一份未签名的并排 **grok-app-latest**（`%LOCALAPPDATA%\grok-app-latest`），不覆盖正式版 **Grok**。给等不及下一版 GitHub Release 的人用，不是签名生产包（`docs/BUILD.md`）。
 - **外观包（.grokskin）**：设置 → 外观可保存/导入/导出当前皮肤 + 壁纸 + 裁切 + 片段 + 遮罩。套用前必须确认。`grok://` 和 `.grokskin` 只写入待导入槽，从不静默套用。导出按当前窗口可见区域烘焙壁纸（视频在本机有 ffmpeg 时裁切）。
 - **自定义提供商可填额外请求头（#812）**：设置 → 账号 → 提供商可添加键/值 HTTP 头，写入 Grok Build `[model.<id>].extra_headers`（推理请求原样发送）。用于 AgentRouter / AnyRouter 校验 `User-Agent` / `Originator`，或 Anthropic 的 `x-api-key`。空列表不写该字段。
 - **可选 Windows 任务栏未读 overlay**（#775）：设置 → 通用 → 应用里开关，**默认关闭**，与程序坞/托盘未读角标互不绑定。开启后 Host 用 `set_overlay_icon` 画 1–9 / 10+（Tauri 的 `set_badge_count` 在 Windows 上是空操作）。从托盘还原时按上次 overlay 计数在 Explorer AddTab 后再贴一次。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ pnpm install
 pnpm dev          # Tauri + Vite
 ```
 
+Windows: to run already-merged `origin/main` beside the official **Grok** install, double-click [`install-latest.cmd`](./install-latest.cmd) (see [docs/BUILD.md](./docs/BUILD.md)).
+
 Frontend only:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ cd src-tauri && cargo test
 pnpm build
 ```
 
+Windows (optional): double-click [`install-latest.cmd`](./install-latest.cmd) to fast-forward `origin/main` and silently install an unsigned side-by-side **grok-app-latest** (does not replace official **Grok**). Needs VS Build Tools + Rust MSVC; details in [docs/BUILD.md](./docs/BUILD.md).
+
 Cross-compile and release notes: [docs/BUILD.md](./docs/BUILD.md).
 
 Release (write the matching `CHANGELOG.md` section first):

--- a/README_EN.md
+++ b/README_EN.md
@@ -308,6 +308,8 @@ cd src-tauri && cargo test
 pnpm build
 ```
 
+Windows (optional): double-click [`install-latest.cmd`](./install-latest.cmd) to fast-forward `origin/main` and silently install an unsigned side-by-side **grok-app-latest** (does not replace official **Grok**). Needs VS Build Tools + Rust MSVC; details in [docs/BUILD.md](./docs/BUILD.md).
+
 Cross-compile and release notes: [docs/BUILD.md](./docs/BUILD.md).
 
 Release (write the matching `CHANGELOG.md` section first):

--- a/README_RU.md
+++ b/README_RU.md
@@ -306,6 +306,8 @@ cd src-tauri && cargo test
 pnpm build
 ```
 
+Windows (необязательно): дважды щёлкните [`install-latest.cmd`](./install-latest.cmd), чтобы fast-forward `origin/main` и тихо поставить неподписанный рядом стоящий **grok-app-latest** (официальный **Grok** не заменяется). Нужны VS Build Tools + Rust MSVC; подробности в [docs/BUILD.md](./docs/BUILD.md).
+
 Кросс-компиляция и выпуск: [docs/BUILD.md](./docs/BUILD.md).
 
 Релиз (сначала добавьте соответствующий раздел в `CHANGELOG.md`):

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -291,6 +291,8 @@ cd src-tauri && cargo test
 pnpm build
 ```
 
+Windows（可选）：双击 [`install-latest.cmd`](./install-latest.cmd) 会把 `main` fast-forward 到 `origin/main`，并静默安装一份未签名的并排 **grok-app-latest**（不覆盖正式版 **Grok**）。需要 VS Build Tools + Rust MSVC；详见 [docs/BUILD.md](./docs/BUILD.md)。
+
 交叉编译、发版与可选签名见 [docs/BUILD.md](./docs/BUILD.md)。
 
 发版（需先写好 `CHANGELOG.md` 对应章节）：

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -48,6 +48,8 @@ pnpm setup:cross   # rust targets + (macOS) cargo-xwin / nsis / llvm 检查
 - [WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/)（多数 Win10/11 已带）
 - Rust MSVC toolchain：`rustup default stable-x86_64-pc-windows-msvc`
 
+装好上述工具后，可双击仓库根目录 [`install-latest.cmd`](../install-latest.cmd)，把 **已合入的 `origin/main`** 打成并排安装的 **grok-app-latest**。这不是 GitHub Release，也不覆盖正式版 **Grok**。详见下文「Windows：并排安装已合入的 main」。
+
 ### Linux（含 Arch / Ubuntu / Debian）
 
 ```bash
@@ -110,6 +112,32 @@ pnpm build:all          # mac-arm + mac-intel + win（仅 macOS 主机）
 ./scripts/build-local.sh linux
 ./scripts/build-local.sh all
 ```
+
+### Windows：并排安装已合入的 main
+
+给**已经有编译环境**、等不及下一版 GitHub Release 的人：把当前仓库 fast-forward 到 `origin/main`，打一份**未签名** NSIS，静默装到 `%LOCALAPPDATA%\grok-app-latest`。
+
+```bat
+install-latest.cmd
+```
+
+或：
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/install-latest.ps1
+```
+
+行为：
+
+- 要求 **tracked 工作区干净**；`git fetch` 后把 `main` **fast-forward** 到 `origin/main`（当前在别的分支也会切走）
+- 临时 Tauri overlay：`productName=grok-app-latest`，`identifier=com.grokapp.desktop.latest`（single-instance mutex 与正式版隔离）
+- 只打 NSIS（`--bundles nsis --no-sign --ci`），`/S` 静默安装
+- **不覆盖** 正式 **Grok** 安装目录；开始菜单多一项 `grok-app-latest`
+- 会话/设置仍走同一套 App data（`%APPDATA%\grokapp\grok-app`，可用 `GROK_APP_HOME` 覆盖）——不要和正式版同时当写入端开着
+- 本机 NSIS 仍会注册 `grok://` / `.grokskin`（后装的覆盖系统关联）
+- 不是 nightly CI；没有 macOS / Linux 对等脚本
+
+`origin` 应指向你想跟上的 GitHub 仓库（贡献者通常是 `RongleCat/grok-app`）。
 
 ### Apple Silicon 本机安装包（示例）
 

--- a/install-latest.cmd
+++ b/install-latest.cmd
@@ -1,0 +1,17 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+where pwsh >nul 2>nul
+if %ERRORLEVEL%==0 (
+  pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\install-latest.ps1"
+) else (
+  powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\install-latest.ps1"
+)
+set ERR=%ERRORLEVEL%
+if not %ERR%==0 (
+  echo FAILED exit %ERR%
+  pause
+  exit /b %ERR%
+)
+echo OK
+pause

--- a/scripts/install-latest.ps1
+++ b/scripts/install-latest.ps1
@@ -1,0 +1,152 @@
+# Sync origin/main, build a side-by-side Windows NSIS, install to
+# %LOCALAPPDATA%\grok-app-latest.
+#
+# Overlay productName + identifier so the single-instance mutex is
+# com.grokapp.desktop.latest-sim (not the official com.grokapp.desktop-sim).
+# App settings/sessions stay on the shared %APPDATA%\grokapp\grok-app root —
+# do not run this build and official Grok as writers at the same time.
+#
+# Requires a clean tracked tree. Unsigned (--no-sign). Not a GitHub Release.
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$ProductName = "grok-app-latest"
+$InstallDir = Join-Path $env:LOCALAPPDATA $ProductName
+$Triple = "x86_64-pc-windows-msvc"
+$Root = Split-Path -Parent $PSScriptRoot
+Set-Location $Root
+
+function Step([string]$msg) {
+  Write-Host ""
+  Write-Host "======== $msg ========"
+}
+
+function Need-Cmd([string]$name) {
+  if (-not (Get-Command $name -ErrorAction SilentlyContinue)) {
+    throw "missing '$name'. Windows native deps: Node 22+, pnpm 9, Rust MSVC, VS Build Tools. See docs/BUILD.md."
+  }
+}
+
+function Restore-BuildNoise {
+  # cargo/tauri may retouch Cargo.toml with CRLF; no content change.
+  $file = "src-tauri/Cargo.toml"
+  if (-not (git diff --ignore-cr-at-eol -- $file)) {
+    git restore -- $file
+  }
+}
+
+function Assert-CleanTracked {
+  Restore-BuildNoise
+  $dirty = git status --porcelain --untracked-files=no
+  if ($LASTEXITCODE -ne 0) { throw "git status failed" }
+  if ($dirty) { throw "tracked files are dirty:`n$dirty" }
+}
+
+function Get-InstalledAppProcesses {
+  Get-CimInstance Win32_Process |
+    Where-Object {
+      $_.ExecutablePath -and
+      $_.ExecutablePath.StartsWith($InstallDir, [StringComparison]::OrdinalIgnoreCase)
+    }
+}
+
+function Stop-InstalledApp {
+  Get-InstalledAppProcesses | ForEach-Object {
+    Write-Host "stop pid $($_.ProcessId) $($_.ExecutablePath)"
+    Stop-Process -Id $_.ProcessId -Force
+  }
+  $deadline = (Get-Date).AddSeconds(15)
+  do {
+    if (-not (Get-InstalledAppProcesses)) { return }
+    Start-Sleep -Milliseconds 400
+  } while ((Get-Date) -lt $deadline)
+  throw "app still running under $InstallDir"
+}
+
+Need-Cmd git
+Need-Cmd pnpm
+Need-Cmd rustc
+Need-Cmd cargo
+
+Write-Host "side-by-side unsigned install → $InstallDir"
+Write-Host "does not replace official Grok. origin/main, clean tracked tree required."
+
+Step "sync origin/main"
+Assert-CleanTracked
+$originUrl = (git remote get-url origin).Trim()
+if ($LASTEXITCODE -ne 0) { throw "git remote get-url origin failed" }
+Write-Host "origin $originUrl"
+$prev = (git branch --show-current).Trim()
+git fetch origin
+if ($LASTEXITCODE -ne 0) { throw "git fetch origin failed" }
+if ($prev -and $prev -ne "main") {
+  Write-Host "leaving branch $prev → main"
+}
+git checkout main
+if ($LASTEXITCODE -ne 0) { throw "git checkout main failed" }
+git merge --ff-only origin/main
+if ($LASTEXITCODE -ne 0) { throw "fast-forward main to origin/main failed" }
+$sha = (git rev-parse --short HEAD).Trim()
+$fullSha = (git rev-parse HEAD).Trim()
+Write-Host "HEAD $sha"
+
+Step "pnpm install"
+pnpm install
+if ($LASTEXITCODE -ne 0) { throw "pnpm install failed" }
+
+$override = Join-Path $env:TEMP "tauri.$ProductName.json"
+$utf8 = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText(
+  $override,
+  (@{
+    productName = $ProductName
+    identifier = "com.grokapp.desktop.latest"
+  } | ConvertTo-Json -Compress),
+  $utf8
+)
+
+Step "build $Triple as $ProductName"
+pnpm exec tauri build --target $Triple --bundles nsis --no-sign --ci --config $override
+if ($LASTEXITCODE -ne 0) { throw "tauri build failed" }
+Restore-BuildNoise
+
+$nsisDir = Join-Path $Root "src-tauri\target\$Triple\release\bundle\nsis"
+$setup = Get-ChildItem $nsisDir -Filter "${ProductName}_*-setup.exe" |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1
+if (-not $setup) { throw "NSIS setup not found in $nsisDir" }
+Write-Host "setup $($setup.FullName)"
+
+Step "install $InstallDir"
+Stop-InstalledApp
+Start-Process -Wait -FilePath $setup.FullName -ArgumentList "/S"
+
+$exe = $null
+foreach ($name in @("grok-app.exe", "${ProductName}.exe")) {
+  $candidate = Join-Path $InstallDir $name
+  if (Test-Path $candidate) {
+    $exe = $candidate
+    break
+  }
+}
+if (-not $exe) { throw "missing grok-app.exe under $InstallDir" }
+$item = Get-Item $exe
+if ($item.Length -lt 1MB) { throw "exe too small: $($item.Length)" }
+if ($item.LastWriteTime -lt $setup.LastWriteTime.AddMinutes(-5)) {
+  throw "exe older than setup: $($item.LastWriteTime) vs $($setup.LastWriteTime)"
+}
+
+$lnk = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\$ProductName.lnk"
+$ver = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($exe).FileVersion
+$pkgVer = (Get-Content (Join-Path $Root "package.json") -Raw | ConvertFrom-Json).version
+
+Write-Host ""
+Write-Host "VERIFY OK"
+Write-Host "sha     $fullSha"
+Write-Host "pkg     $pkgVer"
+Write-Host "exe     $exe"
+Write-Host "size    $($item.Length)"
+Write-Host "mtime   $($item.LastWriteTime.ToString('s'))"
+Write-Host "filever $ver"
+Write-Host "setup   $($setup.Name)"
+Write-Host "start   $(Test-Path $lnk)"


### PR DESCRIPTION
## Summary

Windows contributors who already have Node / pnpm / Rust / VS Build Tools can double-click `install-latest.cmd` to fast-forward `origin/main` and silently install an **unsigned** side-by-side **grok-app-latest** (`%LOCALAPPDATA%\grok-app-latest`). It does not replace the official **Grok** install.

- Overlay `productName=grok-app-latest` + `identifier=com.grokapp.desktop.latest` so the single-instance mutex is isolated
- Clean tracked tree required; `git checkout main` + ff-only to `origin/main`
- Docs: `docs/BUILD.md`, README variants, CONTRIBUTING, CHANGELOG Unreleased

Fixes #837

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Checklist
- [ ] I ran `pnpm typecheck` and `pnpm test` (N/A — no app TS/Rust change)
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only) (docs + Windows scripts only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) (N/A — no in-app copy)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed (`docs/BUILD.md` + public READMEs)
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

## Notes
- Shared App data (`%APPDATA%\grokapp\grok-app`) — do not run this build and official Grok as writers at once
- NSIS still registers `grok://` / `.grokskin` (last installer wins)
- Not a signed production / nightly CI channel