### PR TITLE
fix(dev): follow bundled identifier for Windows AUMID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ See `docs/llm-wiki/release.md`.
 ### Changed
 - **UI font and terminal font are local-font dropdowns**: Settings → Appearance lists installed families (searchable) instead of a free-text name. UI default is the app sans stack; terminal default is the built-in Nerd Font stack. Reset is unchanged.
 - **Debug dock icon is the white invert**: `pnpm dev` uses `src-tauri/icons/dev` (white plate, dark mark) so the running debug app is distinct from the installed black production icon. Release bundles are unchanged.
+- **Windows AUMID follows the bundled identifier**: `pnpm dev` (`com.grokapp.desktop.dev`) is no longer grouped with official Grok on the taskbar / WinRT toasts. Release stays `com.grokapp.desktop`. Sessions still share App data unless `GROK_APP_HOME` is set.
 - **Resource markdown preview windows long files**: Side-pane `.md` keeps short files as one tree. Files at 200+ lines split on headings (and length caps) and only mount visible sections, instead of ReactMarkdown for the whole buffer.
 - **In-chat find stays off the workbench shell**: Ctrl+F match scanning and stream ticks live in the find bar / transcript island. Opening or closing find still toggles the shell; typing and token growth do not.
 - **Files tree windows long listings**: Side-pane / resource trees keep short folders as a full list. At 32+ visible rows, only the viewport is mounted (28px rows), instead of recursively mapping every expanded entry.
@@ -61,6 +62,7 @@ See `docs/llm-wiki/release.md`.
 **中文 · 变更**
 - **界面字体和终端字体改为本机字体下拉**：设置 → 外观列出本机已安装字体族（可搜索），不再手填名称。界面默认是应用无衬线栈；终端默认是内置 Nerd Font。重置不变。
 - **开发版 Dock 图标改白底反色**：`pnpm dev` 使用 `src-tauri/icons/dev`（白底深色标），和已安装的黑底正式版区分。发布包图标不变。
+- **Windows AUMID 跟随 bundled identifier**：`pnpm dev`（`com.grokapp.desktop.dev`）不再和正式版抢任务栏分组 / WinRT toast。发布包仍是 `com.grokapp.desktop`。会话/设置仍共用，除非设置 `GROK_APP_HOME`。
 - **资源栏 Markdown 对长文件做窗口化**：侧栏 `.md` 短文件仍整树渲染。200 行以上按标题（及长度上限）切块，只挂可见节，不再对整份 buffer 跑 ReactMarkdown。
 - **对话内查找不再打穿工作台**：Ctrl+F 的匹配和流式跳动留在找条 / 对话岛。开关查找仍会切壳；打字和 token 增长不会。
 - **文件树对长列表做窗口化**：侧栏 / 资源树短目录仍整表渲染。可见行达到 32 以上只挂视口（28px 行高），不再递归把每个展开节点打进 DOM。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for your interest in contributing.
 
 ```bash
 pnpm install
-pnpm dev          # Tauri + Vite
+pnpm dev          # Tauri + Vite; identifier com.grokapp.desktop.dev (beside installed Grok)
 ```
 
 Windows: to run already-merged `origin/main` beside the official **Grok** install, double-click [`install-latest.cmd`](./install-latest.cmd) (see [docs/BUILD.md](./docs/BUILD.md)).

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ cd src-tauri && cargo test
 pnpm build
 ```
 
+`pnpm dev` merges `src-tauri/tauri.dev.conf.json` (`identifier` `com.grokapp.desktop.dev`, product **Grok Dev**) so it can run beside installed **Grok**. Sessions still share App data unless `GROK_APP_HOME` is set. Bare `tauri dev` without `--config` uses the official identifier and will steal the installed instance.
+
 Windows (optional): double-click [`install-latest.cmd`](./install-latest.cmd) to fast-forward `origin/main` and silently install an unsigned side-by-side **grok-app-latest** (does not replace official **Grok**). Needs VS Build Tools + Rust MSVC; details in [docs/BUILD.md](./docs/BUILD.md).
 
 For cross-compilation and packaging instructions, see [docs/BUILD.md](./docs/BUILD.md).

--- a/README_EN.md
+++ b/README_EN.md
@@ -263,6 +263,8 @@ cd src-tauri && cargo test
 pnpm build
 ```
 
+`pnpm dev` merges `src-tauri/tauri.dev.conf.json` (`identifier` `com.grokapp.desktop.dev`, product **Grok Dev**) so it can run beside installed **Grok**. Sessions still share App data unless `GROK_APP_HOME` is set. Bare `tauri dev` without `--config` uses the official identifier and will steal the installed instance.
+
 Windows (optional): double-click [`install-latest.cmd`](./install-latest.cmd) to fast-forward `origin/main` and silently install an unsigned side-by-side **grok-app-latest** (does not replace official **Grok**). Needs VS Build Tools + Rust MSVC; details in [docs/BUILD.md](./docs/BUILD.md).
 
 For cross-compilation and packaging instructions, see [docs/BUILD.md](./docs/BUILD.md).

--- a/README_RU.md
+++ b/README_RU.md
@@ -263,6 +263,8 @@ cd src-tauri && cargo test
 pnpm build
 ```
 
+`pnpm dev` подмешивает `src-tauri/tauri.dev.conf.json` (`identifier` `com.grokapp.desktop.dev`, имя **Grok Dev`), поэтому его можно запускать рядом с установленным **Grok**. Сессии по-прежнему общие, если не задан `GROK_APP_HOME`. Голый `tauri dev` без `--config` берёт официальный identifier и перехватывает установленный экземпляр.
+
 Windows (необязательно): дважды щёлкните [`install-latest.cmd`](./install-latest.cmd), чтобы fast-forward `origin/main` и тихо поставить неподписанный рядом стоящий **grok-app-latest** (официальный **Grok** не заменяется). Нужны VS Build Tools + Rust MSVC; подробности в [docs/BUILD.md](./docs/BUILD.md).
 
 Подробное руководство по кросс-компиляции и выпуску релизов см. в [docs/BUILD.md](./docs/BUILD.md).

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -263,6 +263,8 @@ cd src-tauri && cargo test
 pnpm build
 ```
 
+`pnpm dev` 会 merge `src-tauri/tauri.dev.conf.json`（`identifier` 为 `com.grokapp.desktop.dev`，产品名 **Grok Dev**），可与已安装的 **Grok** 并排运行。会话/设置仍共用同一套 App data，除非设置 `GROK_APP_HOME`。裸跑 `tauri dev`（不带 `--config`）会用正式版 identifier，抢走已安装实例。
+
 Windows（可选）：双击 [`install-latest.cmd`](./install-latest.cmd) 会把 `main` fast-forward 到 `origin/main`，并静默安装一份未签名的并排 **grok-app-latest**（不覆盖正式版 **Grok**）。需要 VS Build Tools + Rust MSVC；详见 [docs/BUILD.md](./docs/BUILD.md)。
 
 更多跨平台交叉编译与发版指南请参阅 [docs/BUILD.md](./docs/BUILD.md)。

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -29,6 +29,16 @@ pnpm install
 pnpm setup:cross   # rust targets + (macOS) cargo-xwin / nsis / llvm 检查
 ```
 
+### `pnpm dev` 与已安装版并排
+
+`pnpm dev` 会 merge [`src-tauri/tauri.dev.conf.json`](../src-tauri/tauri.dev.conf.json)：
+
+- `identifier=com.grokapp.desktop.dev`（single-instance mutex 与正式版 / **grok-app-latest** 隔离）
+- `productName=Grok Dev`，Dock / 窗口图标用 `src-tauri/icons/dev` 白底反色
+- Windows AUMID / WinRT toast 跟 bundled identifier，不和正式版抢任务栏分组
+- 会话/设置仍默认同一套 App data（`%APPDATA%\grokapp\grok-app`）；可用 `GROK_APP_HOME` 覆盖（`scripts/dev-white-icon.sh` 会指到临时目录）
+- **不要**裸跑 `tauri dev` / `pnpm tauri dev`（没有 `--config` 会撞正式版单实例锁）
+
 ### macOS
 
 - Xcode Command Line Tools：`xcode-select --install`

--- a/docs/llm-wiki/icons.md
+++ b/docs/llm-wiki/icons.md
@@ -24,7 +24,7 @@ Two **separate** pipelines — never mix them.
   - Headless `--start-in-tray` / fire-due uses `hide_to_tray_accessory` (Dock hidden + Accessory).
 - **Windows unread overlay** (opt-in, **default off**, independent of dock/tray `trayBusyBadge`): frontend `tray_set_windows_overlay` uses `WebviewWindow::set_overlay_icon` (16×16 painted badge from `win_taskbar_overlay`). `set_busy_count` does **not** drive the overlay. Do **not** call `set_badge_count` on Windows — Tauri documents it as unsupported and wry no-ops it. Re-apply the last overlay count after AddTab.
 - Reopen via **Dock click** (`RunEvent::Reopen` → `show_main_window`) or tray **Open Grok** / menu actions.
-- **Windows shell**: `win_shell.rs` sets process AppUserModelID (`com.grokapp.desktop`) and re-asserts `WS_EX_APPWINDOW` / `WS_MINIMIZEBOX` / taskbar tab on setup and every show so Explorer **Show Desktop** (taskbar far-right) minimizes the window even when it is alone.
+- **Windows shell**: `win_shell.rs` sets process AppUserModelID from the bundled `identifier` (release `com.grokapp.desktop`; `pnpm dev` overlay `com.grokapp.desktop.dev`) and re-asserts `WS_EX_APPWINDOW` / `WS_MINIMIZEBOX` / taskbar tab on setup and every show so Explorer **Show Desktop** (taskbar far-right) minimizes the window even when it is alone.
 - **Quit Grok** in the tray menu (or app quit) fully exits.
 
 ## Window chrome by platform

--- a/src-tauri/src/desktop_notify.rs
+++ b/src-tauri/src/desktop_notify.rs
@@ -21,9 +21,10 @@ use tauri::{AppHandle, Emitter};
 #[cfg(not(target_os = "macos"))]
 use tauri_plugin_notification::NotificationExt;
 
-/// Product bundle id / AUMID (must match `tauri.conf.json` `identifier`).
-/// Linux notifications carry no app id; the const stays for WinToast/macOS.
-#[cfg_attr(target_os = "linux", allow(dead_code))]
+/// Packaged-macOS NS notification id. `tauri dev` is a bare binary and skips
+/// this path. Windows WinRT toasts use `app.config().identifier` so `pnpm dev`
+/// matches the overlay (`com.grokapp.desktop.dev`).
+#[cfg(target_os = "macos")]
 const APP_BUNDLE_ID: &str = "com.grokapp.desktop";
 
 /// Frontend listens for this after a native notification body click.
@@ -251,7 +252,7 @@ fn show_via_winrt(
 
     let app_click = app.clone();
     let sid = session_id.map(|s| s.to_string());
-    let mut toast = Toast::new(APP_BUNDLE_ID).title(title);
+    let mut toast = Toast::new(&app.config().identifier).title(title);
     if !body.is_empty() {
         toast = toast.text1(body);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -259,12 +259,13 @@ pub fn run() {
     crate::host_runtime::on_process_start();
     crate::win_crash::install();
 
-    // Windows: AppUserModelID before window/taskbar so Show Desktop / jump lists
+    let context = tauri::generate_context!();
 
-    // treat us as a normal app (matches NSIS shortcut AUMID).
+    // Windows: AppUserModelID before window/taskbar so Show Desktop / jump lists
+    // treat us as a normal app (matches NSIS shortcut AUMID / `pnpm dev` overlay).
 
     #[cfg(windows)]
-    win_shell::set_process_app_user_model_id();
+    win_shell::set_process_app_user_model_id(&context.config().identifier);
 
     let session_mgr = Arc::new(SessionManager::new());
 
@@ -1649,7 +1650,7 @@ pub fn run() {
 
         ])
 
-        .build(tauri::generate_context!())
+        .build(context)
 
         .expect("error while building Grok App")
 

--- a/src-tauri/src/win_shell.rs
+++ b/src-tauri/src/win_shell.rs
@@ -39,15 +39,13 @@ use windows::Win32::UI::WindowsAndMessaging::{
     WNDPROC, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_MAXIMIZEBOX, WS_MINIMIZEBOX,
 };
 
-/// Product AUMID — must match `identifier` in tauri.conf.json / NSIS shortcuts.
-const APP_USER_MODEL_ID: &str = "com.grokapp.desktop";
-
 /// Call once early in process startup (before or right after creating the main window).
-pub fn set_process_app_user_model_id() {
-    let wide: Vec<u16> = APP_USER_MODEL_ID
-        .encode_utf16()
-        .chain(std::iter::once(0))
-        .collect();
+///
+/// `id` must be the bundled Tauri `identifier` (release `com.grokapp.desktop`;
+/// `pnpm dev` overlay `com.grokapp.desktop.dev`) so Explorer groups this
+/// process with the matching shortcuts / toasts, not the other install.
+pub fn set_process_app_user_model_id(id: &str) {
+    let wide: Vec<u16> = id.encode_utf16().chain(std::iter::once(0)).collect();
     unsafe {
         if let Err(e) = SetCurrentProcessExplicitAppUserModelID(PCWSTR(wide.as_ptr())) {
             tracing::warn!("SetCurrentProcessExplicitAppUserModelID: {e}");

--- a/src/lib/tauri-dev-config.test.ts
+++ b/src/lib/tauri-dev-config.test.ts
@@ -1,0 +1,32 @@
+/**
+ * `pnpm dev` must merge tauri.dev.conf.json so debug does not steal the
+ * installed Grok single-instance mutex / WebView2 user-data dir.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(__dirname, "../..");
+const PKG = resolve(ROOT, "package.json");
+const BASE_CONF = resolve(ROOT, "src-tauri/tauri.conf.json");
+const DEV_CONF = resolve(ROOT, "src-tauri/tauri.dev.conf.json");
+
+describe("tauri dev identifier overlay", () => {
+  it("ships a distinct identifier from the release bundle", () => {
+    expect(existsSync(DEV_CONF)).toBe(true);
+    const base = JSON.parse(readFileSync(BASE_CONF, "utf8")) as { identifier: string };
+    const dev = JSON.parse(readFileSync(DEV_CONF, "utf8")) as {
+      identifier: string;
+      productName?: string;
+    };
+    expect(base.identifier).toBe("com.grokapp.desktop");
+    expect(dev.identifier).toBe("com.grokapp.desktop.dev");
+    expect(dev.productName).toBe("Grok Dev");
+  });
+
+  it("wires pnpm dev to merge the overlay", () => {
+    const pkg = JSON.parse(readFileSync(PKG, "utf8")) as { scripts: { dev: string } };
+    expect(pkg.scripts.dev).toContain("--config");
+    expect(pkg.scripts.dev).toContain("src-tauri/tauri.dev.conf.json");
+  });
+});

--- a/src/lib/window-config.test.ts
+++ b/src/lib/window-config.test.ts
@@ -102,7 +102,7 @@ describe("window chrome", () => {
     expect(body).toMatch(/set_main_window_skip_taskbar/);
     const conf = JSON.parse(readFileSync(CONF_PATH, "utf8")) as { identifier?: string };
     expect(conf.identifier).toBe("com.grokapp.desktop");
-    expect(body).toContain("com.grokapp.desktop");
+    expect(body).toMatch(/pub fn set_process_app_user_model_id\(id: &str\)/);
   });
 
   it("user close keeps the macOS Dock icon", () => {


### PR DESCRIPTION
## Summary

#839 already wired `pnpm dev` to `src-tauri/tauri.dev.conf.json` (`identifier` `com.grokapp.desktop.dev`, **Grok Dev**, white invert icon). This follow-up makes the overlay actually isolate Windows shell identity, and documents / tests it.

- Windows AUMID = bundled `identifier` (`SetCurrentProcessExplicitAppUserModelID`)
- WinRT toasts use `app.config().identifier` instead of hardcoded `com.grokapp.desktop`
- BUILD.md / README / CONTRIBUTING: `pnpm dev` can run beside installed Grok; bare `tauri dev` still steals it
- Vitest locks overlay identifier + `package.json` `dev --config`

Sessions still share App data unless `GROK_APP_HOME` is set.

Fixes #840

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (`vitest run` on `tauri-dev-config` + `window-config`)
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only) (`cargo check` + `cargo clippy --all-targets -- -D warnings`)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) (N/A — no in-app copy)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed (`BUILD.md`, `icons.md`, READMEs)
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included