### PR TITLE
perf(chat): eliminate layout thrashing and sync storage blocking during transcript scroll (#842)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Chat transcript scroll no longer thrashes layout on mounted rows**: Virtual rows share a single `ResizeObserver` and measure via `borderBoxSize` instead of synchronous `getBoundingClientRect()` on mount; code block line-wrap/number preferences use in-memory caches to avoid blocking `localStorage` reads; right-edge message node rail uses memoized node IDs and skips redundant tick scrolls.
 - **UI font and terminal font are local-font dropdowns**: Settings → Appearance lists installed families (searchable) instead of a free-text name. UI default is the app sans stack; terminal default is the built-in Nerd Font stack. Reset is unchanged.
 - **Debug dock icon is the white invert**: `pnpm dev` uses `src-tauri/icons/dev` (white plate, dark mark) so the running debug app is distinct from the installed black production icon. Release bundles are unchanged.
 - **Resource markdown preview windows long files**: Side-pane `.md` keeps short files as one tree. Files at 200+ lines split on headings (and length caps) and only mount visible sections, instead of ReactMarkdown for the whole buffer.
@@ -59,6 +60,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com](https://grok-app.com) (no trailing slash).
 
 **中文 · 变更**
+- **长对话滚动消除挂载重排与同步存储阻塞**：虚拟列表改用单个共享 `ResizeObserver` 并通过 `borderBoxSize` 获取高度，消除新行挂载时的 `getBoundingClientRect()` 强制同步重排（Layout Thrashing）；代码块换行与行号偏好使用内存缓存，避免挂载时同步读取 `localStorage` 阻塞主线程；右侧消息节点轴缓存节点 ID 集合并在可视范围内跳过冗余滚动。
 - **界面字体和终端字体改为本机字体下拉**：设置 → 外观列出本机已安装字体族（可搜索），不再手填名称。界面默认是应用无衬线栈；终端默认是内置 Nerd Font。重置不变。
 - **开发版 Dock 图标改白底反色**：`pnpm dev` 使用 `src-tauri/icons/dev`（白底深色标），和已安装的黑底正式版区分。发布包图标不变。
 - **资源栏 Markdown 对长文件做窗口化**：侧栏 `.md` 短文件仍整树渲染。200 行以上按标题（及长度上限）切块，只挂可见节，不再对整份 buffer 跑 ReactMarkdown。

--- a/src/components/ImageUi.tsx
+++ b/src/components/ImageUi.tsx
@@ -709,15 +709,22 @@ export function ImageUi({
   );
 }
 
+const imageLabelsCache = new Map<Locale, ImageUiLabels>();
+
 /** Build image UI labels from locale (OS-aware reveal label). */
 export function imageUiLabels(locale: Locale): ImageUiLabels {
-  const tr = createT(locale);
-  return {
-    viewImage: tr("image.view"),
-    copyImage: tr("image.copy"),
-    reveal: revealInOsLabel(tr),
-    copyPath: tr("attach.copyPath"),
-    loadFailed: tr("media.err.other"),
-    loadFailedByKind: mediaLoadErrorLabelMap(tr),
-  };
+  let cached = imageLabelsCache.get(locale);
+  if (!cached) {
+    const tr = createT(locale);
+    cached = {
+      viewImage: tr("image.view"),
+      copyImage: tr("image.copy"),
+      reveal: revealInOsLabel(tr),
+      copyPath: tr("attach.copyPath"),
+      loadFailed: tr("media.err.other"),
+      loadFailedByKind: mediaLoadErrorLabelMap(tr),
+    };
+    imageLabelsCache.set(locale, cached);
+  }
+  return cached;
 }

--- a/src/components/VideoUi.tsx
+++ b/src/components/VideoUi.tsx
@@ -545,13 +545,20 @@ export const VideoUi = memo(function VideoUi({
   );
 });
 
+const videoLabelsCache = new Map<Locale, VideoUiLabels>();
+
 export function videoUiLabels(locale: Locale): VideoUiLabels {
-  const tr = createT(locale);
-  return {
-    open: tr("attach.open"),
-    reveal: revealInOsLabel(tr),
-    copyPath: tr("attach.copyPath"),
-    loadError: tr("video.loadError"),
-    play: tr("video.play"),
-  };
+  let cached = videoLabelsCache.get(locale);
+  if (!cached) {
+    const tr = createT(locale);
+    cached = {
+      open: tr("attach.open"),
+      reveal: revealInOsLabel(tr),
+      copyPath: tr("attach.copyPath"),
+      loadError: tr("video.loadError"),
+      play: tr("video.play"),
+    };
+    videoLabelsCache.set(locale, cached);
+  }
+  return cached;
 }

--- a/src/components/lobe-chat/CodeBlock.tsx
+++ b/src/components/lobe-chat/CodeBlock.tsx
@@ -2,7 +2,7 @@
  * Path / code block — Cursor-style soft chrome (label + wrap + copy).
  */
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { memo, useEffect, useMemo, useState, type ReactNode } from "react";
 import { IconCheck, IconCopy } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { formatLineNumberGutter } from "@/lib/codeBlockGutter";
@@ -15,8 +15,12 @@ import { cn } from "@/lib/utils";
 
 function extractText(node: ReactNode): string {
   if (node == null || typeof node === "boolean") return "";
-  if (typeof node === "string" || typeof node === "number") return String(node);
-  if (Array.isArray(node)) return node.map(extractText).join("");
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) {
+    if (node.length === 1 && typeof node[0] === "string") return node[0];
+    return node.map(extractText).join("");
+  }
   if (typeof node === "object" && "props" in node) {
     const p = node as { props?: { children?: ReactNode } };
     return extractText(p.props?.children);
@@ -24,7 +28,7 @@ function extractText(node: ReactNode): string {
   return "";
 }
 
-export function CodeBlock({
+export const CodeBlock = memo(function CodeBlock({
   language,
   children,
   wrapLabel = "Wrap",
@@ -46,9 +50,15 @@ export function CodeBlock({
   );
   const [copied, setCopied] = useState(false);
   const lang = (language || "text").replace(/^language-/, "") || "text";
-  const text = extractText(children).replace(/\n$/, "");
+  const text = useMemo(
+    () => extractText(children).replace(/\n$/, ""),
+    [children],
+  );
   const showLineNumbers = showLineNumbersProp ?? prefLineNumbers;
-  const lineCount = Math.max(1, text.split("\n").length);
+  const lineCount = useMemo(
+    () => Math.max(1, text.split("\n").length),
+    [text],
+  );
   const gutterText = useMemo(
     () => (showLineNumbers ? formatLineNumberGutter(lineCount) : ""),
     [showLineNumbers, lineCount],
@@ -117,4 +127,4 @@ export function CodeBlock({
       </div>
     </div>
   );
-}
+});

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -487,6 +487,18 @@ const UserPlainOrSkills = memo(function UserPlainOrSkills({
   const displayText =
     canFold && !showFull ? previewUserMessageText(targetText) : targetText;
 
+  const handleBubbleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!canFold) return;
+      const sel = window.getSelection();
+      if (sel && sel.toString().trim().length > 0) return;
+      const target = e.target as HTMLElement | null;
+      if (target?.closest("button, a, .skill-chip, .chat-ref-chip")) return;
+      setShowFull((v) => !v);
+    },
+    [canFold],
+  );
+
   return (
     <>
       <UserQuoteCards
@@ -494,28 +506,29 @@ const UserPlainOrSkills = memo(function UserPlainOrSkills({
         countLabel={tr("composer.quoteCount", { n: String(quotes.length) })}
       />
       {body.trim() || !quotes.length ? (
-        <div className="lobe-chat-user-body-wrap">
+        <div
+          className={
+            "lobe-chat-user-body-wrap" +
+            (canFold ? " lobe-chat-user-body-wrap--foldable" : "") +
+            (canFold && !showFull ? " lobe-chat-user-body-wrap--collapsed" : "")
+          }
+          onClick={canFold ? handleBubbleClick : undefined}
+          title={
+            canFold
+              ? showFull
+                ? tr("inspect.collapse")
+                : tr("inspect.expandMore", { n: "" })
+              : undefined
+          }
+        >
           <UserBodyText
             content={displayText}
             findQuery={findQuery}
             findActiveOccurrence={findActiveOccurrence}
           />
           {canFold ? (
-            <div className="lobe-chat-user-expand">
-              <button
-                type="button"
-                className="lobe-chat-user-expand__btn"
-                onClick={() => setShowFull((v) => !v)}
-              >
-                {showFull
-                  ? tr("attach.showLess")
-                  : tr("attach.showMore", {
-                      n:
-                        targetText.length >= 1000
-                          ? `${(targetText.length / 1000).toFixed(1)}k`
-                          : `${targetText.length}`,
-                    })}
-              </button>
+            <div className="lobe-chat-user-fold-cue" aria-hidden>
+              <span>{showFull ? "▲" : "▼"}</span>
             </div>
           ) : null}
         </div>

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -120,6 +120,7 @@ import { MarkdownChat } from "./MarkdownChat";
 import { LongAssistantSpillNote } from "./LongAssistantSpillNote";
 import {
   previewLongAssistant,
+  shouldSpillHugePlainText,
   shouldSpillLongAssistant,
 } from "@/lib/longAssistantSpill";
 import { detectAppPlatform } from "@/lib/appPlatform";
@@ -475,6 +476,16 @@ const UserPlainOrSkills = memo(function UserPlainOrSkills({
   const body = parsed.text;
   const quotes: ComposerQuote[] = parsed.quotes;
   const tr = createT(locale);
+  const [showFull, setShowFull] = useState(false);
+
+  const findActiveHere = !!findQuery?.trim();
+  const isHuge =
+    shouldSpillHugePlainText((body || content).length, detectAppPlatform()) &&
+    !findActiveHere;
+  const targetText = body || (quotes.length ? "" : content);
+  const displayText =
+    isHuge && !showFull ? previewLongAssistant(targetText) : targetText;
+
   return (
     <>
       <UserQuoteCards
@@ -482,11 +493,28 @@ const UserPlainOrSkills = memo(function UserPlainOrSkills({
         countLabel={tr("composer.quoteCount", { n: String(quotes.length) })}
       />
       {body.trim() || !quotes.length ? (
-        <UserBodyText
-          content={body || (quotes.length ? "" : content)}
-          findQuery={findQuery}
-          findActiveOccurrence={findActiveOccurrence}
-        />
+        <div className="lobe-chat-user-body-wrap">
+          <UserBodyText
+            content={displayText}
+            findQuery={findQuery}
+            findActiveOccurrence={findActiveOccurrence}
+          />
+          {isHuge ? (
+            <div className="lobe-chat-user-expand">
+              <button
+                type="button"
+                className="lobe-chat-user-expand__btn"
+                onClick={() => setShowFull((v) => !v)}
+              >
+                {showFull
+                  ? tr("attach.showLess")
+                  : tr("attach.showMore", {
+                      n: `${Math.round(targetText.length / 1000)}k`,
+                    })}
+              </button>
+            </div>
+          ) : null}
+        </div>
       ) : null}
     </>
   );

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -982,9 +982,17 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
   latestContinuableEndId,
 }: TranscriptMessageRowProps) {
   void _timeTick;
+  const renderStart = performance.now();
   useEffect(() => {
-    scrollPerfDebug.recordRowMount(m.id, msgIndex);
-  }, [m.id, msgIndex]);
+    const dur = performance.now() - renderStart;
+    scrollPerfDebug.recordRowMount(
+      m.id,
+      msgIndex,
+      m.role,
+      dur,
+      m.content?.length ?? 0,
+    );
+  }, [m.id, msgIndex, m.role]);
 
   const wrap = (node: ReactNode) =>
     virtualized ? (

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -108,6 +108,7 @@ import {
   estimateChatRowHeight,
   splitVirtSpacerHeights,
 } from "@/lib/chatVirtualList";
+import { scrollPerfDebug } from "@/lib/scrollPerfDebug";
 import { StructuredJsonPanel } from "./StructuredJsonPanel";
 import {
   MessageActionButton,
@@ -936,6 +937,10 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
   latestContinuableEndId,
 }: TranscriptMessageRowProps) {
   void _timeTick;
+  useEffect(() => {
+    scrollPerfDebug.recordRowMount(m.id, msgIndex);
+  }, [m.id, msgIndex]);
+
   const wrap = (node: ReactNode) =>
     virtualized ? (
       <div
@@ -2666,6 +2671,12 @@ export function ConversationThread({
 
   const visibleMessages = useMemo(() => {
     if (!virtualized) {
+      if (transcriptMessages.length >= 10) {
+        scrollPerfDebug.recordLog(
+          "VirtualizationStatus",
+          `⚠️ Virtualization is OFF for ${transcriptMessages.length} messages (rendered all DOM nodes)`,
+        );
+      }
       return transcriptMessages.map((m, index) => ({ m, index }));
     }
     const slice: { m: ChatMessage; index: number }[] = [];

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -125,6 +125,7 @@ import {
 import {
   previewUserMessageText,
   shouldFoldUserMessage,
+  USER_MSG_PREVIEW_CHARS,
 } from "@/lib/userMessageFold";
 import { detectAppPlatform } from "@/lib/appPlatform";
 import { Thinking } from "./Thinking";
@@ -2693,8 +2694,12 @@ export function ConversationThread({
           !isToolStepMessage(m) &&
           !isEndOfTurnMarker(m.marker) &&
           !isContextCompactMessage(m));
+      const effectiveContentLength =
+        m.role === "user" && shouldFoldUserMessage(body)
+          ? USER_MSG_PREVIEW_CHARS
+          : body.length;
       return estimateChatRowHeight({
-        contentLength: body.length,
+        contentLength: effectiveContentLength,
         thoughtLength: m.thought?.length ?? 0,
         role: m.role,
         attachmentCount,

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -2194,6 +2194,7 @@ export function ConversationThread({
 
   const onScroll = useCallback(
     (e: UIEvent<HTMLDivElement>) => {
+      scrollPerfDebug.recordScrollStart();
       onStickScroll(e);
       // Do NOT setActiveNodeId here — MessageNodeRail owns free-scroll highlight (#280).
     },

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -391,7 +391,7 @@ const AssistantMessageBody = memo(function AssistantMessageBody({
   );
 });
 
-function UserBodyText({
+const UserBodyText = memo(function UserBodyText({
   content,
   findQuery,
   findActiveOccurrence,
@@ -457,10 +457,10 @@ function UserBodyText({
       })}
     </span>
   );
-}
+});
 
 /** Render skill chips / plain text for the user bubble body. */
-function UserPlainOrSkills({
+const UserPlainOrSkills = memo(function UserPlainOrSkills({
   content,
   findQuery,
   findActiveOccurrence,
@@ -490,13 +490,13 @@ function UserPlainOrSkills({
       ) : null}
     </>
   );
-}
+});
 
 /**
  * User bubble: skill chips + scheduled / Remote IM headers as pill tags
  * (`[Scheduled: title]` / `[Remote IM · feishu]` → label, not raw brackets).
  */
-function UserMessageBody({
+const UserMessageBody = memo(function UserMessageBody({
   content,
   scheduledLabel,
   remoteImLabel,
@@ -595,7 +595,7 @@ function UserMessageBody({
       findActiveOccurrence={findActiveOccurrence}
     />
   );
-}
+});
 
 export interface ConversationThreadProps {
   locale: Locale;

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -120,9 +120,12 @@ import { MarkdownChat } from "./MarkdownChat";
 import { LongAssistantSpillNote } from "./LongAssistantSpillNote";
 import {
   previewLongAssistant,
-  shouldSpillHugePlainText,
   shouldSpillLongAssistant,
 } from "@/lib/longAssistantSpill";
+import {
+  previewUserMessageText,
+  shouldFoldUserMessage,
+} from "@/lib/userMessageFold";
 import { detectAppPlatform } from "@/lib/appPlatform";
 import { Thinking } from "./Thinking";
 import { LeadFragmentsStrip } from "./LeadFragmentsStrip";
@@ -478,13 +481,11 @@ const UserPlainOrSkills = memo(function UserPlainOrSkills({
   const tr = createT(locale);
   const [showFull, setShowFull] = useState(false);
 
-  const findActiveHere = !!findQuery?.trim();
-  const isHuge =
-    shouldSpillHugePlainText((body || content).length, detectAppPlatform()) &&
-    !findActiveHere;
   const targetText = body || (quotes.length ? "" : content);
+  const findActiveHere = !!findQuery?.trim();
+  const canFold = shouldFoldUserMessage(targetText) && !findActiveHere;
   const displayText =
-    isHuge && !showFull ? previewLongAssistant(targetText) : targetText;
+    canFold && !showFull ? previewUserMessageText(targetText) : targetText;
 
   return (
     <>
@@ -499,7 +500,7 @@ const UserPlainOrSkills = memo(function UserPlainOrSkills({
             findQuery={findQuery}
             findActiveOccurrence={findActiveOccurrence}
           />
-          {isHuge ? (
+          {canFold ? (
             <div className="lobe-chat-user-expand">
               <button
                 type="button"
@@ -509,7 +510,10 @@ const UserPlainOrSkills = memo(function UserPlainOrSkills({
                 {showFull
                   ? tr("attach.showLess")
                   : tr("attach.showMore", {
-                      n: `${Math.round(targetText.length / 1000)}k`,
+                      n:
+                        targetText.length >= 1000
+                          ? `${(targetText.length / 1000).toFixed(1)}k`
+                          : `${targetText.length}`,
                     })}
               </button>
             </div>

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -241,6 +241,23 @@ export function getMarkdownFileLabels(locale: Locale): FilePathCardLabels {
   return cached;
 }
 
+const StaticMarkdownBody = memo(function StaticMarkdownBody({
+  source,
+  components,
+}: {
+  source: string;
+  components: Components;
+}) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={MARKDOWN_CHAT_REMARK_PLUGINS}
+      components={components}
+    >
+      {source}
+    </ReactMarkdown>
+  );
+});
+
 export const MarkdownChat = memo(function MarkdownChat({
   children,
   streaming = false,
@@ -684,12 +701,16 @@ export const MarkdownChat = memo(function MarkdownChat({
         className,
       )}
     >
-      <ReactMarkdown
-        remarkPlugins={MARKDOWN_CHAT_REMARK_PLUGINS}
-        components={components}
-      >
-        {painted}
-      </ReactMarkdown>
+      {streaming ? (
+        <ReactMarkdown
+          remarkPlugins={MARKDOWN_CHAT_REMARK_PLUGINS}
+          components={components}
+        >
+          {painted}
+        </ReactMarkdown>
+      ) : (
+        <StaticMarkdownBody source={painted} components={components} />
+      )}
     </div>
   );
 });

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -16,7 +16,7 @@ import type { Locale } from "@/i18n";
 import { createT } from "@/i18n";
 import { ImageUi, imageUiLabels } from "@/components/ImageUi";
 import { VideoUi, videoUiLabels } from "@/components/VideoUi";
-import { FilePathCard } from "@/components/FilePathCard";
+import { FilePathCard, type FilePathCardLabels } from "@/components/FilePathCard";
 import type { ResourceOpenTarget } from "@/components/ResourceViewer";
 import { HighlightedText } from "@/components/HighlightedText";
 import {
@@ -203,6 +203,44 @@ function paintedLeaves(
   };
 }
 
+const fileLabelsCache = new Map<Locale, FilePathCardLabels>();
+
+export function getMarkdownFileLabels(locale: Locale): FilePathCardLabels {
+  let cached = fileLabelsCache.get(locale);
+  if (!cached) {
+    const tr = createT(locale);
+    cached = {
+      open: tr("attach.open"),
+      reveal: revealInOsLabel(tr),
+      copyPath: tr("attach.copyPath"),
+      openInPanel: tr("resources.openInPanel"),
+      openExternal: tr("resources.openExternal"),
+      details: tr("attach.details"),
+      detailsTitle: tr("attach.detailsTitle"),
+      detailsName: tr("attach.detailsName"),
+      detailsType: tr("attach.detailsType"),
+      detailsPath: tr("attach.detailsPath"),
+      detailsResolved: tr("attach.detailsResolved"),
+      detailsStatus: tr("attach.detailsStatus"),
+      detailsMissing: tr("attach.detailsMissing"),
+      detailsOk: tr("attach.detailsOk"),
+      detailsClose: tr("attach.detailsClose"),
+      typeFile: tr("attach.typeFile"),
+      typeUrl: tr("attach.typeUrl"),
+      typeDir: tr("attach.typeDir"),
+      errNotFound: tr("resources.openErr.notFound"),
+      errPathDenied: tr("resources.openErr.pathDenied"),
+      errHostOnly: tr("resources.openErr.hostOnly"),
+      errNoEditor: tr("resources.openErr.noEditor"),
+      errCancelled: tr("resources.openErr.cancelled"),
+      errOther: tr("resources.openErr.other"),
+      errRevealOther: tr("resources.revealErr.other"),
+    };
+    fileLabelsCache.set(locale, cached);
+  }
+  return cached;
+}
+
 export const MarkdownChat = memo(function MarkdownChat({
   children,
   streaming = false,
@@ -249,36 +287,7 @@ export const MarkdownChat = memo(function MarkdownChat({
   const tr = useMemo(() => createT(locale), [locale]);
   const imageLabels = useMemo(() => imageUiLabels(locale), [locale]);
   const videoLabels = useMemo(() => videoUiLabels(locale), [locale]);
-  const fileLabels = useMemo(
-    () => ({
-      open: tr("attach.open"),
-      reveal: revealInOsLabel(tr),
-      copyPath: tr("attach.copyPath"),
-      openInPanel: tr("resources.openInPanel"),
-      openExternal: tr("resources.openExternal"),
-      details: tr("attach.details"),
-      detailsTitle: tr("attach.detailsTitle"),
-      detailsName: tr("attach.detailsName"),
-      detailsType: tr("attach.detailsType"),
-      detailsPath: tr("attach.detailsPath"),
-      detailsResolved: tr("attach.detailsResolved"),
-      detailsStatus: tr("attach.detailsStatus"),
-      detailsMissing: tr("attach.detailsMissing"),
-      detailsOk: tr("attach.detailsOk"),
-      detailsClose: tr("attach.detailsClose"),
-      typeFile: tr("attach.typeFile"),
-      typeUrl: tr("attach.typeUrl"),
-      typeDir: tr("attach.typeDir"),
-      errNotFound: tr("resources.openErr.notFound"),
-      errPathDenied: tr("resources.openErr.pathDenied"),
-      errHostOnly: tr("resources.openErr.hostOnly"),
-      errNoEditor: tr("resources.openErr.noEditor"),
-      errCancelled: tr("resources.openErr.cancelled"),
-      errOther: tr("resources.openErr.other"),
-      errRevealOther: tr("resources.revealErr.other"),
-    }),
-    [tr],
-  );
+  const fileLabels = useMemo(() => getMarkdownFileLabels(locale), [locale]);
   const gallery = useMemo(() => {
     if (!imagePathMap) return undefined;
     return Array.from(new Set(Object.values(imagePathMap))).filter(isImagePath);

--- a/src/components/lobe-chat/MessageNodeRail.tsx
+++ b/src/components/lobe-chat/MessageNodeRail.tsx
@@ -42,6 +42,8 @@ type TipState = {
   right: number;
 };
 
+import { scrollPerfDebug } from "@/lib/scrollPerfDebug";
+
 export function MessageNodeRail({
   nodes,
   activeId,
@@ -134,6 +136,7 @@ export function MessageNodeRail({
       ) {
         return;
       }
+      const t0 = performance.now();
 
       const viewportRect = viewport.getBoundingClientRect();
       const focusY = viewportRect.top + viewport.clientHeight * 0.28;
@@ -156,6 +159,9 @@ export function MessageNodeRail({
         // Id walk on the paint list — not journal messageIndex (filtered lists).
         bestId = nearestNodeIdFromPaintList(messages, nodes, msgIdx);
       }
+
+      const syncDuration = performance.now() - t0;
+      scrollPerfDebug.recordNodeRailSyncTime(syncDuration, mounted.length);
 
       if (bestId) {
         setScrollActiveId((prev) => {

--- a/src/components/lobe-chat/MessageNodeRail.tsx
+++ b/src/components/lobe-chat/MessageNodeRail.tsx
@@ -101,14 +101,24 @@ export function MessageNodeRail({
     (activeIndex >= 0 && activeIndex < nodes.length - 1) ||
     (activeIndex < 0 && nodes.length > 0);
 
+  const nodeIdSet = useMemo(() => new Set(nodes.map((n) => n.id)), [nodes]);
+
   // Keep the active tick roughly in view inside a long rail.
   useEffect(() => {
     if (activeIndex < 0 || !listRef.current) return;
-    const tick = listRef.current.querySelector(
+    const list = listRef.current;
+    const tick = list.querySelector(
       `[data-node-id="${CSS.escape(nodes[activeIndex]!.id)}"]`,
     ) as HTMLElement | null;
-    // Instant — smooth nested scroll was a jank source during free reading.
-    tick?.scrollIntoView({ block: "nearest", behavior: "auto" });
+    if (!tick) return;
+    const tickTop = tick.offsetTop;
+    const tickBottom = tickTop + tick.offsetHeight;
+    const viewTop = list.scrollTop;
+    const viewBottom = viewTop + list.clientHeight;
+    // Only scroll if outside visible range to avoid redundant scroll operations.
+    if (tickTop < viewTop || tickBottom > viewBottom) {
+      tick.scrollIntoView({ block: "nearest", behavior: "auto" });
+    }
   }, [activeIndex, nodes]);
 
   // Free-scroll highlight: rAF throttle + one querySelectorAll per frame.
@@ -131,7 +141,6 @@ export function MessageNodeRail({
       // Single pass over mounted message rows (virtual window only).
       const mounted = viewport.querySelectorAll<HTMLElement>("[data-message-id]");
       const rects: { id: string; top: number; bottom: number }[] = [];
-      const nodeIdSet = new Set(nodes.map((n) => n.id));
       for (const row of mounted) {
         const id = row.getAttribute("data-message-id");
         if (!id || !nodeIdSet.has(id)) continue;
@@ -149,9 +158,11 @@ export function MessageNodeRail({
       }
 
       if (bestId) {
-        setScrollActiveId((prev) => (prev === bestId ? prev : bestId));
-        // Ref-only parent sync so prev/next track free scroll without setState.
-        onScrollActiveChangeRef.current?.(bestId);
+        setScrollActiveId((prev) => {
+          if (prev === bestId) return prev;
+          onScrollActiveChangeRef.current?.(bestId);
+          return bestId;
+        });
       }
     };
 
@@ -171,7 +182,7 @@ export function MessageNodeRail({
         rafRef.current = null;
       }
     };
-  }, [scrollParentRef, nodes, messages, navLockUntilRef]);
+  }, [scrollParentRef, nodes, nodeIdSet, messages, navLockUntilRef]);
 
   // When parent sets a programmatic activeId, mirror it into scroll state so
   // highlight does not snap back on the next free-scroll frame incorrectly.

--- a/src/hooks/useChatMessageVirtualizer.test.tsx
+++ b/src/hooks/useChatMessageVirtualizer.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook, act } from "@testing-library/react";
+import { useChatMessageVirtualizer } from "./useChatMessageVirtualizer";
+
+afterEach(cleanup);
+
+describe("useChatMessageVirtualizer", () => {
+  it("renders full non-virtualized window when itemCount is below threshold and height is small", () => {
+    const viewport = document.createElement("div");
+    const isPinnedRef = { current: true };
+    const viewportRef = { current: viewport };
+
+    const { result } = renderHook(() =>
+      useChatMessageVirtualizer({
+        itemCount: 5,
+        getKey: (i) => "item-" + i,
+        getEstimateHeight: () => 50,
+        viewportRef,
+        isPinnedRef,
+        threshold: 20,
+      }),
+    );
+
+    expect(result.current.virtualized).toBe(false);
+    expect(result.current.start).toBe(0);
+    expect(result.current.end).toBe(5);
+    expect(result.current.paddingTop).toBe(0);
+    expect(result.current.paddingBottom).toBe(0);
+  });
+
+  it("activates virtualization when itemCount exceeds threshold", () => {
+    const viewport = document.createElement("div");
+    Object.defineProperty(viewport, "clientHeight", { value: 600, configurable: true });
+    Object.defineProperty(viewport, "scrollTop", { value: 0, configurable: true });
+    const isPinnedRef = { current: false };
+    const viewportRef = { current: viewport };
+
+    const { result } = renderHook(() =>
+      useChatMessageVirtualizer({
+        itemCount: 100,
+        getKey: (i) => "item-" + i,
+        getEstimateHeight: () => 100,
+        viewportRef,
+        isPinnedRef,
+        threshold: 10,
+      }),
+    );
+
+    expect(result.current.virtualized).toBe(true);
+    expect(result.current.start).toBe(0);
+    expect(result.current.end).toBeLessThan(100);
+    expect(result.current.paddingBottom).toBeGreaterThan(0);
+  });
+
+  it("returns stable measureRef callbacks across re-renders for the same index", () => {
+    const viewport = document.createElement("div");
+    const isPinnedRef = { current: false };
+    const viewportRef = { current: viewport };
+
+    const { result, rerender } = renderHook(
+      ({ count }) =>
+        useChatMessageVirtualizer({
+          itemCount: count,
+          getKey: (i) => "item-" + i,
+          getEstimateHeight: () => 100,
+          viewportRef,
+          isPinnedRef,
+          threshold: 10,
+        }),
+      { initialProps: { count: 30 } },
+    );
+
+    const cb0_a = result.current.measureRef(0);
+    const cb1_a = result.current.measureRef(1);
+
+    rerender({ count: 35 });
+
+    const cb0_b = result.current.measureRef(0);
+    const cb1_b = result.current.measureRef(1);
+
+    expect(cb0_a).toBe(cb0_b);
+    expect(cb1_a).toBe(cb1_b);
+  });
+
+  it("observes elements with shared ResizeObserver on measureRef attachment", () => {
+    const observeMock = vi.fn();
+    const unobserveMock = vi.fn();
+    const disconnectMock = vi.fn();
+
+    class MockResizeObserver {
+      observe = observeMock;
+      unobserve = unobserveMock;
+      disconnect = disconnectMock;
+      constructor(public callback: ResizeObserverCallback) {}
+    }
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+    const viewport = document.createElement("div");
+    const isPinnedRef = { current: false };
+    const viewportRef = { current: viewport };
+
+    const { result } = renderHook(() =>
+      useChatMessageVirtualizer({
+        itemCount: 50,
+        getKey: (i) => "item-" + i,
+        getEstimateHeight: () => 100,
+        viewportRef,
+        isPinnedRef,
+        threshold: 10,
+      }),
+    );
+
+    const rowEl = document.createElement("div");
+    act(() => {
+      result.current.measureRef(3)(rowEl);
+    });
+
+    expect(observeMock).toHaveBeenCalledWith(rowEl);
+
+    act(() => {
+      result.current.measureRef(3)(null);
+    });
+
+    expect(unobserveMock).toHaveBeenCalledWith(rowEl);
+  });
+});

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -462,6 +462,7 @@ export function useChatMessageVirtualizer(
       // First paint used the estimate in offsets; treat it as the previous
       // height so estimate→actual can keep the viewport anchored.
       const prevH = prevMeasured ?? estimateH;
+      scrollPerfDebug.recordHeightMeasurement(index, key, nextH, estimateH);
 
       if (prevMeasured != null) {
         if (!shouldCommitRowHeight(prevMeasured, nextH)) return;

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -137,8 +137,10 @@ export function useChatMessageVirtualizer(
   const recomputeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** Programmatic scrollTop from height correction — ignore once for stick. */
   const ignoreScrollAdjustRef = useRef(false);
-  /** Per-index ResizeObserver so image/video decode updates height after mount. */
-  const rowObserversRef = useRef<Map<number, ResizeObserver>>(new Map());
+  /** Shared ResizeObserver so image/video/layout growth updates height without per-row RO thrash. */
+  const sharedRowObserverRef = useRef<ResizeObserver | null>(null);
+  const observedElementsRef = useRef<Map<HTMLElement, number>>(new Map());
+  const observedIndicesRef = useRef<Map<number, HTMLElement>>(new Map());
   /** Coalesce scroll-driven recomputes to one paint (rAF + mixed-Hz fallback). */
   const scrollFrameRef = useRef<FrameSchedule>(emptyFrameSchedule());
   /**
@@ -175,8 +177,12 @@ export function useChatMessageVirtualizer(
     heightsRef.current.clear();
     heightsVersionRef.current = 0;
     offsetsCacheRef.current = null;
-    for (const ro of rowObserversRef.current.values()) ro.disconnect();
-    rowObserversRef.current.clear();
+    if (sharedRowObserverRef.current) {
+      sharedRowObserverRef.current.disconnect();
+      sharedRowObserverRef.current = null;
+    }
+    observedElementsRef.current.clear();
+    observedIndicesRef.current.clear();
     setWin(full(itemCount));
   }, [conversationKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -343,24 +349,27 @@ export function useChatMessageVirtualizer(
     };
     el.addEventListener("scroll", onScroll, { passive: true });
     // Viewport chrome resize only — not content (content RO was thrashy).
-    const ro = new ResizeObserver(() => {
-      if (scrollingRef.current || isPaneSplitMotionActive()) {
-        pendingHeightRecomputeRef.current = true;
-        if (isPaneSplitMotionActive()) {
-          runAfterPaneSplitMotion(() => {
-            pendingHeightRecomputeRef.current = false;
-            recomputeNow();
-          });
-        }
-        return;
-      }
-      recompute();
-    });
-    ro.observe(el);
+    const ro =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => {
+            if (scrollingRef.current || isPaneSplitMotionActive()) {
+              pendingHeightRecomputeRef.current = true;
+              if (isPaneSplitMotionActive()) {
+                runAfterPaneSplitMotion(() => {
+                  pendingHeightRecomputeRef.current = false;
+                  recomputeNow();
+                });
+              }
+              return;
+            }
+            recompute();
+          })
+        : null;
+    ro?.observe(el);
     recomputeNow();
     return () => {
       el.removeEventListener("scroll", onScroll);
-      ro.disconnect();
+      ro?.disconnect();
       cancelFrameSchedule(scrollFrameRef.current);
       if (recomputeTimerRef.current != null) {
         clearTimeout(recomputeTimerRef.current);
@@ -414,16 +423,23 @@ export function useChatMessageVirtualizer(
   // Drop row observers when virtualization turns off.
   useEffect(() => {
     if (virtualized) return;
-    for (const ro of rowObserversRef.current.values()) ro.disconnect();
-    rowObserversRef.current.clear();
+    if (sharedRowObserverRef.current) {
+      sharedRowObserverRef.current.disconnect();
+      sharedRowObserverRef.current = null;
+    }
+    observedElementsRef.current.clear();
+    observedIndicesRef.current.clear();
   }, [virtualized]);
 
   const commitRowHeight = useCallback(
-    (index: number, el: HTMLElement) => {
+    (index: number, el: HTMLElement, measuredHeight?: number) => {
       if (!virtualizedRef.current) return;
-      if (runAfterPaneSplitMotion(() => commitRowHeight(index, el))) return;
+      if (runAfterPaneSplitMotion(() => commitRowHeight(index, el, measuredHeight))) return;
       const key = getKeyRef.current(index);
-      const nextH = Math.round(el.getBoundingClientRect().height);
+      const nextH =
+        measuredHeight != null && Number.isFinite(measuredHeight) && measuredHeight >= 0
+          ? Math.round(measuredHeight)
+          : Math.round(el.getBoundingClientRect().height);
       const prevMeasured = heightsRef.current.get(key);
       const estRaw = estimateRef.current?.(index);
       const estimateH =
@@ -504,6 +520,34 @@ export function useChatMessageVirtualizer(
   const commitRowHeightRef = useRef(commitRowHeight);
   commitRowHeightRef.current = commitRowHeight;
 
+  const ensureSharedObserver = useCallback(() => {
+    if (sharedRowObserverRef.current || typeof ResizeObserver === "undefined") {
+      return sharedRowObserverRef.current;
+    }
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const el = entry.target as HTMLElement;
+        const index = observedElementsRef.current.get(el);
+        if (index === undefined) continue;
+        let h = 0;
+        if (entry.borderBoxSize && entry.borderBoxSize.length > 0) {
+          const bs = entry.borderBoxSize[0];
+          if (bs && Number.isFinite(bs.blockSize) && bs.blockSize > 0) {
+            h = bs.blockSize;
+          }
+        } else if (entry.contentRect && Number.isFinite(entry.contentRect.height)) {
+          h = entry.contentRect.height;
+        }
+        if (h <= 0) {
+          h = el.getBoundingClientRect().height;
+        }
+        commitRowHeightRef.current(index, el, h);
+      }
+    });
+    sharedRowObserverRef.current = ro;
+    return ro;
+  }, []);
+
   /**
    * Stable per-index ref callbacks. Returning a fresh function from measureRef(i)
    * on every render makes React detach/reattach the ref → ResizeObserver thrash
@@ -523,31 +567,28 @@ export function useChatMessageVirtualizer(
       const cached = measureCallbackCacheRef.current.get(index);
       if (cached) return cached;
       const cb = (el: HTMLElement | null) => {
-        const prevRo = rowObserversRef.current.get(index);
-        if (prevRo) {
-          prevRo.disconnect();
-          rowObserversRef.current.delete(index);
+        const ro = ensureSharedObserver();
+        const prevEl = observedIndicesRef.current.get(index);
+        if (prevEl && prevEl !== el) {
+          ro?.unobserve(prevEl);
+          observedElementsRef.current.delete(prevEl);
+          observedIndicesRef.current.delete(index);
         }
         if (!el || !virtualizedRef.current) return;
 
-        // Immediate sample (mount) + observe media/layout growth afterward.
-        commitRowHeightRef.current(index, el);
-        // Coalesce RO storms (multi-image decode) — one commit per frame.
-        let roRaf = 0;
-        const ro = new ResizeObserver(() => {
-          if (roRaf) return;
-          roRaf = requestAnimationFrame(() => {
-            roRaf = 0;
-            commitRowHeightRef.current(index, el);
-          });
-        });
-        ro.observe(el);
-        rowObserversRef.current.set(index, ro);
+        observedElementsRef.current.set(el, index);
+        observedIndicesRef.current.set(index, el);
+        if (ro) {
+          ro.observe(el);
+        } else {
+          // Fallback if ResizeObserver is unavailable (e.g. test environment)
+          commitRowHeightRef.current(index, el);
+        }
       };
       measureCallbackCacheRef.current.set(index, cb);
       return cb;
     },
-    [],
+    [ensureSharedObserver],
   );
 
   if (!virtualized) {

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -355,12 +355,40 @@ export function useChatMessageVirtualizer(
           pendingHeightRecomputeRef.current = false;
           recomputeNow();
         }
-      }, 140);
+      }, 240);
       // One window update per paint while flinging. Timeout fallback covers
       // mixed 120Hz/75Hz displays where rAF can skip a 75Hz vsync.
       scheduleOnFrame(scrollFrameRef.current, recomputeNow);
     };
+
+    const onUserInteraction = () => {
+      scrollingRef.current = true;
+      if (scrollIdleTimerRef.current != null) {
+        clearTimeout(scrollIdleTimerRef.current);
+      }
+      scrollIdleTimerRef.current = setTimeout(() => {
+        scrollIdleTimerRef.current = null;
+        scrollingRef.current = false;
+        const pending = pendingHeightsRef.current;
+        if (pending.size > 0) {
+          for (const [k, h] of pending) {
+            heightsRef.current.set(k, h);
+          }
+          pending.clear();
+          heightsVersionRef.current += 1;
+          offsetsCacheRef.current = null;
+          pendingHeightRecomputeRef.current = true;
+        }
+        if (pendingHeightRecomputeRef.current) {
+          pendingHeightRecomputeRef.current = false;
+          recomputeNow();
+        }
+      }, 240);
+    };
+
     el.addEventListener("scroll", onScroll, { passive: true });
+    el.addEventListener("wheel", onUserInteraction, { passive: true });
+    el.addEventListener("touchmove", onUserInteraction, { passive: true });
     // Viewport chrome resize only — not content (content RO was thrashy).
     const ro =
       typeof ResizeObserver !== "undefined"
@@ -382,6 +410,8 @@ export function useChatMessageVirtualizer(
     recomputeNow();
     return () => {
       el.removeEventListener("scroll", onScroll);
+      el.removeEventListener("wheel", onUserInteraction);
+      el.removeEventListener("touchmove", onUserInteraction);
       ro?.disconnect();
       cancelFrameSchedule(scrollFrameRef.current);
       if (recomputeTimerRef.current != null) {

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -41,6 +41,7 @@ import {
   shouldVirtualizeChat,
   type ChatVirtualWindow,
 } from "@/lib/chatVirtualList";
+import { scrollPerfDebug } from "@/lib/scrollPerfDebug";
 import { resolveStreamOverscanScale } from "@/lib/streamRenderPolicy";
 import {
   cancelFrameSchedule,
@@ -235,6 +236,7 @@ export function useChatMessageVirtualizer(
       setWin(full(count));
       return;
     }
+    const t0 = performance.now();
     const pin = !!isPinnedRef.current;
     const offsets = getOffsets();
     const next = computeChatVirtualWindow({
@@ -253,6 +255,16 @@ export function useChatMessageVirtualizer(
       pinToBottom: pin,
       forceIndices: forceRef.current,
       offsets,
+    });
+    const recomputeDuration = performance.now() - t0;
+    scrollPerfDebug.recordRecomputeTime(recomputeDuration, {
+      start: next.start,
+      end: next.end,
+      total: count,
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      paddingTop: next.paddingTop,
+      paddingBottom: next.paddingBottom,
     });
     setWin((prev) => {
       if (
@@ -309,6 +321,7 @@ export function useChatMessageVirtualizer(
     const el = viewportRef.current;
     if (!el) return;
     const onScroll = () => {
+      scrollPerfDebug.recordScrollStart();
       if (ignoreScrollAdjustRef.current) {
         ignoreScrollAdjustRef.current = false;
         return;

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -124,9 +124,10 @@ export function estimateChatRowHeight(input: {
   }
   // Collapsed CoT is a one-line "Thought" chip, not the raw thought body.
   const thoughtChrome = !input.thoughtExpanded && thoughtRaw > 0 ? 28 : 0;
-  // ~42 chars/line in the bubble, ~20px line height, role chrome.
-  const lines = Math.ceil((content + thought * 0.5) / 42);
-  const chrome = role === "user" ? 72 : role === "tool" ? 28 : 96;
+  // Assistant markdown has paragraph/heading spacing; user bubbles are compact.
+  const contentMultiplier = role === "assistant" ? 1.35 : 1.0;
+  const lines = Math.ceil((content * contentMultiplier + thought * 0.5) / 42);
+  const chrome = role === "user" ? 72 : role === "tool" ? 28 : 110;
   const atts = Math.max(0, input.attachmentCount ?? 0);
   // 36px chips + gap; user strip packs to ~70% width (~6–8 chips/row typical).
   // Collapsed default shows ≤3 + "+N" (≤4 slots) on one row when possible.

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -41,16 +41,16 @@ export const CHAT_DEFAULT_ROW_ESTIMATE_PX = 120;
 export const CHAT_MAX_ROW_ESTIMATE_PX = 8000;
 
 /** Baseline extra px above/below the viewport when browsing history. */
-export const CHAT_OVERSCAN_PX = 1200;
+export const CHAT_OVERSCAN_PX = 1800;
 
 /** Baseline when pinned: more history above the tail so pin feels continuous. */
-export const CHAT_PIN_OVERSCAN_PX = 1600;
+export const CHAT_PIN_OVERSCAN_PX = 2400;
 
 /** Floor / ceiling for adaptive overscan (px). */
-export const CHAT_OVERSCAN_MIN_PX = 700;
-export const CHAT_OVERSCAN_MAX_PX = 1800;
-export const CHAT_PIN_OVERSCAN_MIN_PX = 1000;
-export const CHAT_PIN_OVERSCAN_MAX_PX = 2400;
+export const CHAT_OVERSCAN_MIN_PX = 1000;
+export const CHAT_OVERSCAN_MAX_PX = 3000;
+export const CHAT_PIN_OVERSCAN_MIN_PX = 1400;
+export const CHAT_PIN_OVERSCAN_MAX_PX = 3600;
 
 /**
  * Max index gap when expanding the window for `forceIndices` while **escaped**.
@@ -73,9 +73,8 @@ export const CHAT_IMAGE_CARDS_PER_ROW = 3;
  * are not first measured as ~120px (that underestimates scrollHeight and
  * makes mid-document look "near bottom" → stick bounce).
  *
- * Media: chip attachments (~36px), ratio-aware image cards (≤150px), and
- * inline video cards (~240px) are not reflected in `contentLength` — include
- * them so first paint is closer to final height (fewer remeasure snaps).
+ * Estimates are coarse and intentional: they only seed the prefix-sum table
+ * before rows mount. Real heights commit to `heightsRef` via measureRef.
  */
 export function estimateChatRowHeight(input: {
   contentLength?: number;
@@ -192,21 +191,21 @@ export function resolveChatOverscanPx(input: {
   const vh = Math.max(0, input.viewportHeight);
   let px: number;
   if (input.pinToBottom) {
-    // ~1.5 viewports above the tail + small baseline, clamped.
-    const raw = vh * 1.5 + 200;
+    // ~1.6 viewports above the tail + small baseline, clamped.
+    const raw = vh * 1.6 + 300;
     px = Math.round(
       Math.min(
         CHAT_PIN_OVERSCAN_MAX_PX,
-        Math.max(CHAT_PIN_OVERSCAN_MIN_PX, raw, CHAT_PIN_OVERSCAN_PX * 0.75),
+        Math.max(CHAT_PIN_OVERSCAN_MIN_PX, raw, CHAT_PIN_OVERSCAN_PX),
       ),
     );
   } else {
-    // History browse: ~1 viewport of runway.
-    const raw = vh * 1.1 + 100;
+    // History browse: ~1.8 viewports of runway for high-refresh 120Hz/144Hz smoothness.
+    const raw = vh * 1.8 + 300;
     px = Math.round(
       Math.min(
         CHAT_OVERSCAN_MAX_PX,
-        Math.max(CHAT_OVERSCAN_MIN_PX, raw, CHAT_OVERSCAN_PX * 0.6),
+        Math.max(CHAT_OVERSCAN_MIN_PX, raw, CHAT_OVERSCAN_PX),
       ),
     );
   }

--- a/src/lib/codeLineNumbersPref.ts
+++ b/src/lib/codeLineNumbersPref.ts
@@ -11,13 +11,31 @@ export const CODE_LINE_NUMBERS_PREF_EVENT = "grok:codeLineNumbersPref";
 /** `true` = show line number gutter; `false` = no gutter (default). */
 export type CodeLineNumbersPref = boolean;
 
+let memoryLineNumbersPref: CodeLineNumbersPref | null = null;
+
+export function resetCodeLineNumbersPrefCacheForTest(): void {
+  memoryLineNumbersPref = null;
+}
+
 export function loadCodeLineNumbersPref(
   storage: Storage = localStorage,
 ): CodeLineNumbersPref {
+  if (
+    typeof localStorage !== "undefined" &&
+    storage === localStorage &&
+    memoryLineNumbersPref !== null
+  ) {
+    return memoryLineNumbersPref;
+  }
   try {
     const v = storage.getItem(CODE_LINE_NUMBERS_PREF_KEY);
-    if (v === "1" || v === "true" || v === "on") return true;
-    if (v === "0" || v === "false" || v === "off") return false;
+    let parsed = false;
+    if (v === "1" || v === "true" || v === "on") parsed = true;
+    else if (v === "0" || v === "false" || v === "off") parsed = false;
+    if (typeof localStorage !== "undefined" && storage === localStorage) {
+      memoryLineNumbersPref = parsed;
+    }
+    return parsed;
   } catch {
     /* private mode */
   }
@@ -28,6 +46,9 @@ export function saveCodeLineNumbersPref(
   pref: CodeLineNumbersPref,
   storage: Storage = localStorage,
 ): void {
+  if (typeof localStorage !== "undefined" && storage === localStorage) {
+    memoryLineNumbersPref = pref;
+  }
   try {
     storage.setItem(CODE_LINE_NUMBERS_PREF_KEY, pref ? "1" : "0");
   } catch {

--- a/src/lib/codeWrapPref.ts
+++ b/src/lib/codeWrapPref.ts
@@ -11,13 +11,31 @@ export const CODE_WRAP_PREF_EVENT = "grok:codeWrapPref";
 /** `true` = wrap lines by default; `false` = horizontal scroll (no wrap). */
 export type CodeWrapPref = boolean;
 
+let memoryWrapPref: CodeWrapPref | null = null;
+
+export function resetCodeWrapPrefCacheForTest(): void {
+  memoryWrapPref = null;
+}
+
 export function loadCodeWrapPref(
   storage: Storage = localStorage,
 ): CodeWrapPref {
+  if (
+    typeof localStorage !== "undefined" &&
+    storage === localStorage &&
+    memoryWrapPref !== null
+  ) {
+    return memoryWrapPref;
+  }
   try {
     const v = storage.getItem(CODE_WRAP_PREF_KEY);
-    if (v === "1" || v === "true" || v === "wrap") return true;
-    if (v === "0" || v === "false" || v === "scroll") return false;
+    let parsed = false;
+    if (v === "1" || v === "true" || v === "wrap") parsed = true;
+    else if (v === "0" || v === "false" || v === "scroll") parsed = false;
+    if (typeof localStorage !== "undefined" && storage === localStorage) {
+      memoryWrapPref = parsed;
+    }
+    return parsed;
   } catch {
     /* private mode */
   }
@@ -29,6 +47,9 @@ export function saveCodeWrapPref(
   pref: CodeWrapPref,
   storage: Storage = localStorage,
 ): void {
+  if (typeof localStorage !== "undefined" && storage === localStorage) {
+    memoryWrapPref = pref;
+  }
   try {
     storage.setItem(CODE_WRAP_PREF_KEY, pref ? "wrap" : "scroll");
   } catch {

--- a/src/lib/composerQuotes.ts
+++ b/src/lib/composerQuotes.ts
@@ -98,6 +98,7 @@ export function parseQuotesFromContent(content: string): {
   quotes: ComposerQuote[];
 } {
   if (!content) return { text: "", quotes: [] };
+  if (!content.includes("[[quote]]")) return { text: content, quotes: [] };
   const src = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   const quotes: ComposerQuote[] = [];
   let rest = src;

--- a/src/lib/draftDoc.ts
+++ b/src/lib/draftDoc.ts
@@ -64,6 +64,7 @@ const NON_SKILL_SLASH = new Set(
 export function hydrateDisplayContent(content: string): string {
   if (!content) return content;
   if (content.includes("[[skill:")) return content;
+  if (!content.startsWith("/") && !content.includes("/goal")) return content;
 
   let rest = content;
   // Drop goal mode prefix from display hydration (mode is session chrome, not a chip).
@@ -120,6 +121,9 @@ export function draftFromPlainText(text: string): DraftSegment[] {
  */
 export function parseStoredContent(content: string): DraftSegment[] {
   if (!content) return [];
+  if (!content.includes("[[skill:") && !content.includes("[[chat:")) {
+    return [{ type: "text", text: content }];
+  }
   const segments: DraftSegment[] = [];
   let last = 0;
   const re = new RegExp(STORED_TOKEN_RE.source, "g");

--- a/src/lib/scrollPerfDebug.ts
+++ b/src/lib/scrollPerfDebug.ts
@@ -38,13 +38,15 @@ interface ScrollSessionMetrics {
   longTasks: Array<{ duration: number; startTime: number }>;
 }
 
+const IS_DEV = Boolean(import.meta.env?.DEV);
+
 let activeSession: ScrollSessionMetrics | null = null;
 let rafId: number | null = null;
 let lastRafTime = 0;
 let lastObservedScrollTop = 0;
 
 let perfObserver: PerformanceObserver | null = null;
-if (typeof window !== "undefined" && typeof PerformanceObserver !== "undefined") {
+if (IS_DEV && typeof window !== "undefined" && typeof PerformanceObserver !== "undefined") {
   try {
     perfObserver = new PerformanceObserver((list) => {
       if (!activeSession) return;
@@ -116,6 +118,7 @@ function onRaf(now: number) {
 
 export const scrollPerfDebug = {
   recordInputEvent() {
+    if (!IS_DEV) return;
     const now = performance.now();
     const st = readCurrentScrollTop();
     if (!activeSession) {
@@ -146,11 +149,12 @@ export const scrollPerfDebug = {
   },
 
   recordScrollStart() {
+    if (!IS_DEV) return;
     this.recordInputEvent();
   },
 
   recordScrollEnd() {
-    if (!activeSession) return;
+    if (!IS_DEV || !activeSession) return;
     if (rafId) {
       cancelAnimationFrame(rafId);
       rafId = null;
@@ -253,6 +257,7 @@ export const scrollPerfDebug = {
   },
 
   recordRecomputeTime(ms: number, snapshot?: any) {
+    if (!IS_DEV) return;
     if (activeSession) {
       activeSession.recomputeTimes.push(ms);
       if (snapshot) {
@@ -265,6 +270,7 @@ export const scrollPerfDebug = {
   },
 
   recordNodeRailSyncTime(ms: number, nodesQueried: number) {
+    if (!IS_DEV) return;
     if (activeSession) {
       activeSession.nodeRailSyncTimes.push(ms);
     }
@@ -274,12 +280,14 @@ export const scrollPerfDebug = {
   },
 
   recordRowMount(_id: string, _index: number) {
+    if (!IS_DEV) return;
     if (activeSession) {
       activeSession.rowMountCount++;
     }
   },
 
   recordRowRender(id: string, index: number, durationMs: number) {
+    if (!IS_DEV) return;
     if (activeSession) {
       activeSession.rowRenderCount++;
     }
@@ -289,11 +297,12 @@ export const scrollPerfDebug = {
   },
 
   recordLog(tag: string, ...args: any[]) {
+    if (!IS_DEV) return;
     console.log(`%c[ScrollPerf:${tag}]`, "color: #a8dadc; font-weight: bold;", ...args);
   },
 };
 
-if (typeof window !== "undefined") {
+if (IS_DEV && typeof window !== "undefined") {
   (window as any).__SCROLL_PERF_DEBUG__ = scrollPerfDebug;
   window.addEventListener(
     "wheel",
@@ -322,7 +331,7 @@ if (typeof window !== "undefined") {
     { passive: true, capture: true },
   );
   console.log(
-    "%c[ScrollPerf] 🚀 Multi-phase telemetry initialized. Accurately tracks Active Drag & Momentum Fling.",
+    "%c[ScrollPerf] 🚀 Multi-phase telemetry initialized (DEV mode only).",
     "color: #06d6a0; font-weight: bold; font-size: 12px;",
   );
 }

--- a/src/lib/scrollPerfDebug.ts
+++ b/src/lib/scrollPerfDebug.ts
@@ -192,4 +192,22 @@ export const scrollPerfDebug = {
 
 if (typeof window !== "undefined") {
   (window as any).__SCROLL_PERF_DEBUG__ = scrollPerfDebug;
+  window.addEventListener(
+    "wheel",
+    () => {
+      scrollPerfDebug.recordScrollStart();
+    },
+    { passive: true, capture: true },
+  );
+  window.addEventListener(
+    "scroll",
+    () => {
+      scrollPerfDebug.recordScrollStart();
+    },
+    { passive: true, capture: true },
+  );
+  console.log(
+    "%c[ScrollPerf] 🚀 Diagnostic telemetry initialized. Any wheel/scroll event will record metrics.",
+    "color: #06d6a0; font-weight: bold; font-size: 12px;",
+  );
 }

--- a/src/lib/scrollPerfDebug.ts
+++ b/src/lib/scrollPerfDebug.ts
@@ -13,6 +13,30 @@ interface FrameRecord {
   isMomentum: boolean;
 }
 
+interface SlowMountRecord {
+  id: string;
+  index: number;
+  role: string;
+  durationMs: number;
+  contentLength: number;
+}
+
+interface HeightDiscrepancyRecord {
+  index: number;
+  id: string;
+  measured: number;
+  estimated: number;
+  diff: number;
+}
+
+interface StutterEvent {
+  timestamp: number;
+  delta: number;
+  isMomentum: boolean;
+  scrollTop: number;
+  recentAction: string;
+}
+
 interface ScrollSessionMetrics {
   startTime: number;
   lastInputTime: number;
@@ -26,6 +50,9 @@ interface ScrollSessionMetrics {
   nodeRailSyncTimes: number[];
   rowMountCount: number;
   rowRenderCount: number;
+  slowMounts: SlowMountRecord[];
+  heightDiscrepancies: HeightDiscrepancyRecord[];
+  stutterEvents: StutterEvent[];
   virtualWindowSnapshots: Array<{
     start: number;
     end: number;
@@ -44,6 +71,7 @@ let activeSession: ScrollSessionMetrics | null = null;
 let rafId: number | null = null;
 let lastRafTime = 0;
 let lastObservedScrollTop = 0;
+let lastActionContext = "";
 
 let perfObserver: PerformanceObserver | null = null;
 if (IS_DEV && typeof window !== "undefined" && typeof PerformanceObserver !== "undefined") {
@@ -100,6 +128,25 @@ function onRaf(now: number) {
       delta,
       isMomentum,
     });
+    if (delta > 20) {
+      activeSession.stutterEvents.push({
+        timestamp: now,
+        delta,
+        isMomentum,
+        scrollTop: currentScrollTop,
+        recentAction: lastActionContext || `scrollTop=${currentScrollTop.toFixed(0)}`,
+      });
+      console.warn(
+        `%c[ScrollPerf 🚨 Stutter Delta = ${delta.toFixed(1)}ms]`,
+        "color: #ff0055; font-weight: bold;",
+        {
+          deltaMs: delta.toFixed(1),
+          phase: isMomentum ? "Momentum Fling" : "Active Input",
+          scrollTop: Math.round(currentScrollTop),
+          context: lastActionContext || "coasting",
+        },
+      );
+    }
   }
   lastRafTime = now;
 
@@ -135,13 +182,17 @@ export const scrollPerfDebug = {
         nodeRailSyncTimes: [],
         rowMountCount: 0,
         rowRenderCount: 0,
+        slowMounts: [],
+        heightDiscrepancies: [],
+        stutterEvents: [],
         virtualWindowSnapshots: [],
         longTasks: [],
       };
       lastRafTime = now;
       lastObservedScrollTop = st;
+      lastActionContext = "gesture_start";
       rafId = requestAnimationFrame(onRaf);
-      console.log("%c[ScrollPerf] 🚀 Scroll gesture started - tracking Active Drag & Momentum Fling...", "color: #00b4d8; font-weight: bold;");
+      console.log("%c[ScrollPerf] 🚀 Scroll session started - tracking fine-grained drops...", "color: #00b4d8; font-weight: bold;");
     } else {
       activeSession.lastInputTime = now;
       activeSession.lastMotionTime = now;
@@ -229,23 +280,38 @@ export const scrollPerfDebug = {
         "Total Severe (>50ms)": totalSevere,
         "Long Tasks (>50ms)": session.longTasks.length,
         "Row Mounts": session.rowMountCount,
+        "Slow Mounts (>3ms)": session.slowMounts.length,
+        "Height Jumps (>100px)": session.heightDiscrepancies.length,
         "Total Displacement": `${totalDisplacement} px`,
         "Avg Recompute (ms)": avgRecompute,
         "Avg NodeRail (ms)": avgNodeRail,
       },
     };
 
-    console.group("%c[ScrollPerf] 📊 Multi-Phase Scroll Report (跟手 + 离手抛滑)", "color: #ffb703; font-size: 13px; font-weight: bold;");
+    console.group("%c[ScrollPerf] 📊 Multi-Phase Scroll Report", "color: #ffb703; font-size: 13px; font-weight: bold;");
     console.log("%cPhase 1: 跟手操作阶段 (Active Drag)", "color: #00b4d8; font-weight: bold;");
     console.table(report["1. Phase: 跟手阶段 (Active Drag)"]);
     console.log("%cPhase 2: 离手抛滑阶段 (Momentum Fling Coasting)", "color: #06d6a0; font-weight: bold;");
     console.table(report["2. Phase: 离手抛滑 (Momentum Fling)"]);
     console.log("%cPhase 3: 全局汇总 (Overall Lifecycle)", "color: #f72585; font-weight: bold;");
     console.table(report["3. Summary: 全流程物理收敛 (Full Lifecycle)"]);
+
+    if (session.slowMounts.length > 0) {
+      console.log("%c⚠️ Slow Row Mounts (>3ms):", "color: #e76f51; font-weight: bold;");
+      console.table(session.slowMounts);
+    }
+    if (session.heightDiscrepancies.length > 0) {
+      console.log("%c⚠️ Large Height Discrepancies (>100px):", "color: #f4a261; font-weight: bold;");
+      console.table(session.heightDiscrepancies);
+    }
+    if (session.stutterEvents.length > 0) {
+      console.log("%c🚨 Stutter Events (>20ms):", "color: #e63946; font-weight: bold;");
+      console.table(session.stutterEvents);
+    }
     if (session.longTasks.length > 0) {
       console.warn("[ScrollPerf] ⚠️ Long Tasks detected during scroll:", session.longTasks);
     }
-    console.log("[ScrollPerf] Full session raw data stored in window.__LAST_SCROLL_REPORT__");
+    console.log("[ScrollPerf] Full raw data: copy(JSON.stringify(window.__LAST_SCROLL_REPORT__, null, 2))");
     console.groupEnd();
 
     if (typeof window !== "undefined") {
@@ -262,6 +328,7 @@ export const scrollPerfDebug = {
       activeSession.recomputeTimes.push(ms);
       if (snapshot) {
         activeSession.virtualWindowSnapshots.push(snapshot);
+        lastActionContext = `window_shift[${snapshot.start}..${snapshot.end}]`;
       }
     }
     if (ms > 5) {
@@ -279,10 +346,40 @@ export const scrollPerfDebug = {
     }
   },
 
-  recordRowMount(_id: string, _index: number) {
+  recordRowMount(id: string, index: number, role = "msg", durationMs = 0, contentLength = 0) {
     if (!IS_DEV) return;
+    lastActionContext = `mount_row_${index}_${role}_${Math.round(durationMs)}ms`;
     if (activeSession) {
       activeSession.rowMountCount++;
+      if (durationMs > 3) {
+        activeSession.slowMounts.push({
+          id,
+          index,
+          role,
+          durationMs: Number(durationMs.toFixed(2)),
+          contentLength,
+        });
+      }
+    }
+    if (durationMs > 8) {
+      console.warn(`%c[ScrollPerf] ⚠️ Slow Row Mount: idx=${index}, role=${role}, took ${durationMs.toFixed(2)}ms (chars=${contentLength})`, "color: #e63946;");
+    }
+  },
+
+  recordHeightMeasurement(index: number, id: string, measured: number, estimated: number) {
+    if (!IS_DEV) return;
+    const diff = Math.abs(measured - estimated);
+    if (diff > 100) {
+      lastActionContext = `height_jump_idx_${index}_diff_${diff}px`;
+      if (activeSession) {
+        activeSession.heightDiscrepancies.push({
+          index,
+          id,
+          measured,
+          estimated,
+          diff,
+        });
+      }
     }
   },
 

--- a/src/lib/scrollPerfDebug.ts
+++ b/src/lib/scrollPerfDebug.ts
@@ -1,0 +1,195 @@
+/**
+ * Diagnostic logger for chat transcript scroll performance.
+ * Collects FPS, frame times, long tasks, layout recomputes, and component renders.
+ */
+
+interface ScrollSessionMetrics {
+  startTime: number;
+  endTime: number;
+  frameCount: number;
+  droppedFrames: number; // frames taking > 20ms
+  severeJankFrames: number; // frames taking > 50ms
+  frameTimes: number[];
+  recomputeTimes: number[];
+  nodeRailSyncTimes: number[];
+  rowMountCount: number;
+  rowRenderCount: number;
+  virtualWindowSnapshots: Array<{
+    start: number;
+    end: number;
+    total: number;
+    scrollTop: number;
+    scrollHeight: number;
+    paddingTop: number;
+    paddingBottom: number;
+  }>;
+  longTasks: Array<{ duration: number; startTime: number }>;
+}
+
+let activeSession: ScrollSessionMetrics | null = null;
+let rafId: number | null = null;
+let lastRafTime = 0;
+let stopTimer: NodeJS.Timeout | null = null;
+
+let perfObserver: PerformanceObserver | null = null;
+if (typeof window !== "undefined" && typeof PerformanceObserver !== "undefined") {
+  try {
+    perfObserver = new PerformanceObserver((list) => {
+      if (!activeSession) return;
+      for (const entry of list.getEntries()) {
+        activeSession.longTasks.push({
+          duration: entry.duration,
+          startTime: entry.startTime,
+        });
+      }
+    });
+    perfObserver.observe({ entryTypes: ["longtask"] });
+  } catch {
+    /* longtask not supported in all webviews */
+  }
+}
+
+function onRaf(now: number) {
+  if (!activeSession) return;
+  if (lastRafTime > 0) {
+    const delta = now - lastRafTime;
+    activeSession.frameCount++;
+    activeSession.frameTimes.push(delta);
+    if (delta > 20) {
+      activeSession.droppedFrames++;
+    }
+    if (delta > 50) {
+      activeSession.severeJankFrames++;
+    }
+  }
+  lastRafTime = now;
+  rafId = requestAnimationFrame(onRaf);
+}
+
+export const scrollPerfDebug = {
+  recordScrollStart() {
+    if (stopTimer) {
+      clearTimeout(stopTimer);
+      stopTimer = null;
+    }
+    if (!activeSession) {
+      activeSession = {
+        startTime: performance.now(),
+        endTime: 0,
+        frameCount: 0,
+        droppedFrames: 0,
+        severeJankFrames: 0,
+        frameTimes: [],
+        recomputeTimes: [],
+        nodeRailSyncTimes: [],
+        rowMountCount: 0,
+        rowRenderCount: 0,
+        virtualWindowSnapshots: [],
+        longTasks: [],
+      };
+      lastRafTime = performance.now();
+      rafId = requestAnimationFrame(onRaf);
+      console.log("%c[ScrollPerf] 🚀 Scroll gesture started - recording metrics...", "color: #00b4d8; font-weight: bold;");
+    }
+
+    stopTimer = setTimeout(() => {
+      scrollPerfDebug.recordScrollEnd();
+    }, 400);
+  },
+
+  recordScrollEnd() {
+    if (!activeSession) return;
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    activeSession.endTime = performance.now();
+    const session = activeSession;
+    activeSession = null;
+    lastRafTime = 0;
+
+    const durationMs = session.endTime - session.startTime;
+    const avgFps = session.frameCount > 0 ? (session.frameCount / (durationMs / 1000)).toFixed(1) : "0";
+    const avgRecompute = session.recomputeTimes.length > 0
+      ? (session.recomputeTimes.reduce((a, b) => a + b, 0) / session.recomputeTimes.length).toFixed(2)
+      : "0";
+    const avgNodeRail = session.nodeRailSyncTimes.length > 0
+      ? (session.nodeRailSyncTimes.reduce((a, b) => a + b, 0) / session.nodeRailSyncTimes.length).toFixed(2)
+      : "0";
+
+    const report = {
+      "Duration (ms)": Math.round(durationMs),
+      "Avg FPS": avgFps + " fps",
+      "Total Frames": session.frameCount,
+      "Dropped Frames (>20ms)": session.droppedFrames,
+      "Severe Jank Frames (>50ms)": session.severeJankFrames,
+      "Long Tasks (>50ms)": session.longTasks.length,
+      "Virtual Recompute Calls": session.recomputeTimes.length,
+      "Avg Recompute Time (ms)": avgRecompute,
+      "NodeRail Sync Calls": session.nodeRailSyncTimes.length,
+      "Avg NodeRail Time (ms)": avgNodeRail,
+      "Row Render Count": session.rowRenderCount,
+      "Row Mount Count": session.rowMountCount,
+      "Last Window": session.virtualWindowSnapshots.slice(-1)[0] || null,
+    };
+
+    console.group("%c[ScrollPerf] 📊 Scroll Session Summary Report", "color: #ffb703; font-size: 13px; font-weight: bold;");
+    console.table(report);
+    if (session.longTasks.length > 0) {
+      console.warn("[ScrollPerf] ⚠️ Long Tasks detected during scroll:", session.longTasks);
+    }
+    console.log("[ScrollPerf] Full session raw data stored in window.__LAST_SCROLL_REPORT__");
+    console.groupEnd();
+
+    if (typeof window !== "undefined") {
+      (window as any).__LAST_SCROLL_REPORT__ = {
+        summary: report,
+        details: session,
+      };
+    }
+  },
+
+  recordRecomputeTime(ms: number, snapshot?: any) {
+    if (activeSession) {
+      activeSession.recomputeTimes.push(ms);
+      if (snapshot) {
+        activeSession.virtualWindowSnapshots.push(snapshot);
+      }
+    }
+    if (ms > 5) {
+      console.warn(`%c[ScrollPerf] ⚠️ Slow recomputeVirtualWindow: ${ms.toFixed(2)}ms`, "color: #e63946;", snapshot);
+    }
+  },
+
+  recordNodeRailSyncTime(ms: number, nodesQueried: number) {
+    if (activeSession) {
+      activeSession.nodeRailSyncTimes.push(ms);
+    }
+    if (ms > 4) {
+      console.warn(`%c[ScrollPerf] ⚠️ Slow MessageNodeRail.sync: ${ms.toFixed(2)}ms (queried ${nodesQueried} elements)`, "color: #e63946;");
+    }
+  },
+
+  recordRowMount(_id: string, _index: number) {
+    if (activeSession) {
+      activeSession.rowMountCount++;
+    }
+  },
+
+  recordRowRender(id: string, index: number, durationMs: number) {
+    if (activeSession) {
+      activeSession.rowRenderCount++;
+    }
+    if (durationMs > 10) {
+      console.warn(`%c[ScrollPerf] ⚠️ Slow Row Render: idx=${index}, id=${id}, took ${durationMs.toFixed(2)}ms`, "color: #e63946;");
+    }
+  },
+
+  recordLog(tag: string, ...args: any[]) {
+    console.log(`%c[ScrollPerf:${tag}]`, "color: #a8dadc; font-weight: bold;", ...args);
+  },
+};
+
+if (typeof window !== "undefined") {
+  (window as any).__SCROLL_PERF_DEBUG__ = scrollPerfDebug;
+}

--- a/src/lib/scrollPerfDebug.ts
+++ b/src/lib/scrollPerfDebug.ts
@@ -1,15 +1,27 @@
 /**
- * Diagnostic logger for chat transcript scroll performance.
- * Collects FPS, frame times, long tasks, layout recomputes, and component renders.
+ * Diagnostic telemetry logger for chat transcript scroll performance.
+ * Accurately tracks two separate interaction phases:
+ * 1. Active Input Phase (跟手阶段: while user fingers/wheel are actively moving)
+ * 2. Momentum/Inertia Phase (离手抛滑阶段: coasting deceleration until physics fully settle)
+ *
+ * Collects FPS, frame delta histograms, long tasks, layout recomputes, and DOM mounts.
  */
+
+interface FrameRecord {
+  timestamp: number;
+  delta: number;
+  isMomentum: boolean;
+}
 
 interface ScrollSessionMetrics {
   startTime: number;
+  lastInputTime: number;
+  lastMotionTime: number;
   endTime: number;
-  frameCount: number;
-  droppedFrames: number; // frames taking > 20ms
-  severeJankFrames: number; // frames taking > 50ms
-  frameTimes: number[];
+  startScrollTop: number;
+  releaseScrollTop: number;
+  endScrollTop: number;
+  frames: FrameRecord[];
   recomputeTimes: number[];
   nodeRailSyncTimes: number[];
   rowMountCount: number;
@@ -29,7 +41,7 @@ interface ScrollSessionMetrics {
 let activeSession: ScrollSessionMetrics | null = null;
 let rafId: number | null = null;
 let lastRafTime = 0;
-let stopTimer: NodeJS.Timeout | null = null;
+let lastObservedScrollTop = 0;
 
 let perfObserver: PerformanceObserver | null = null;
 if (typeof window !== "undefined" && typeof PerformanceObserver !== "undefined") {
@@ -49,37 +61,73 @@ if (typeof window !== "undefined" && typeof PerformanceObserver !== "undefined")
   }
 }
 
+function getActiveScrollElement(): HTMLElement | null {
+  if (typeof document === "undefined") return null;
+  return (
+    document.querySelector<HTMLElement>(".lobe-chat__scroll") ||
+    document.querySelector<HTMLElement>(".lobe-chat") ||
+    (document.scrollingElement as HTMLElement | null)
+  );
+}
+
+function readCurrentScrollTop(): number {
+  const el = getActiveScrollElement();
+  return el ? el.scrollTop : (typeof window !== "undefined" ? window.scrollY : 0);
+}
+
 function onRaf(now: number) {
   if (!activeSession) return;
+
+  const currentScrollTop = readCurrentScrollTop();
+  const scrollDelta = Math.abs(currentScrollTop - lastObservedScrollTop);
+  if (scrollDelta > 0.5) {
+    activeSession.lastMotionTime = now;
+    lastObservedScrollTop = currentScrollTop;
+  }
+
+  // If user hasn't provided physical input in >100ms, mark current frames as Momentum Coasting
+  const isMomentum = (now - activeSession.lastInputTime) > 100;
+  if (isMomentum && activeSession.releaseScrollTop === 0) {
+    activeSession.releaseScrollTop = currentScrollTop;
+  }
+
   if (lastRafTime > 0) {
     const delta = now - lastRafTime;
-    activeSession.frameCount++;
-    activeSession.frameTimes.push(delta);
-    if (delta > 20) {
-      activeSession.droppedFrames++;
-    }
-    if (delta > 50) {
-      activeSession.severeJankFrames++;
-    }
+    activeSession.frames.push({
+      timestamp: now,
+      delta,
+      isMomentum,
+    });
   }
   lastRafTime = now;
+
+  // Physics settlement check:
+  // User input ended > 350ms ago AND scroll position has been static for > 300ms
+  const inputIdle = (now - activeSession.lastInputTime) > 350;
+  const motionIdle = (now - activeSession.lastMotionTime) > 300;
+
+  if (inputIdle && motionIdle) {
+    scrollPerfDebug.recordScrollEnd();
+    return;
+  }
+
   rafId = requestAnimationFrame(onRaf);
 }
 
 export const scrollPerfDebug = {
-  recordScrollStart() {
-    if (stopTimer) {
-      clearTimeout(stopTimer);
-      stopTimer = null;
-    }
+  recordInputEvent() {
+    const now = performance.now();
+    const st = readCurrentScrollTop();
     if (!activeSession) {
       activeSession = {
-        startTime: performance.now(),
+        startTime: now,
+        lastInputTime: now,
+        lastMotionTime: now,
         endTime: 0,
-        frameCount: 0,
-        droppedFrames: 0,
-        severeJankFrames: 0,
-        frameTimes: [],
+        startScrollTop: st,
+        releaseScrollTop: 0,
+        endScrollTop: 0,
+        frames: [],
         recomputeTimes: [],
         nodeRailSyncTimes: [],
         rowMountCount: 0,
@@ -87,14 +135,18 @@ export const scrollPerfDebug = {
         virtualWindowSnapshots: [],
         longTasks: [],
       };
-      lastRafTime = performance.now();
+      lastRafTime = now;
+      lastObservedScrollTop = st;
       rafId = requestAnimationFrame(onRaf);
-      console.log("%c[ScrollPerf] 🚀 Scroll gesture started - recording metrics...", "color: #00b4d8; font-weight: bold;");
+      console.log("%c[ScrollPerf] 🚀 Scroll gesture started - tracking Active Drag & Momentum Fling...", "color: #00b4d8; font-weight: bold;");
+    } else {
+      activeSession.lastInputTime = now;
+      activeSession.lastMotionTime = now;
     }
+  },
 
-    stopTimer = setTimeout(() => {
-      scrollPerfDebug.recordScrollEnd();
-    }, 400);
+  recordScrollStart() {
+    this.recordInputEvent();
   },
 
   recordScrollEnd() {
@@ -103,38 +155,89 @@ export const scrollPerfDebug = {
       cancelAnimationFrame(rafId);
       rafId = null;
     }
-    activeSession.endTime = performance.now();
+    const now = performance.now();
+    activeSession.endTime = now;
+    activeSession.endScrollTop = readCurrentScrollTop();
+    if (activeSession.releaseScrollTop === 0) {
+      activeSession.releaseScrollTop = activeSession.endScrollTop;
+    }
+
     const session = activeSession;
     activeSession = null;
     lastRafTime = 0;
 
-    const durationMs = session.endTime - session.startTime;
-    const avgFps = session.frameCount > 0 ? (session.frameCount / (durationMs / 1000)).toFixed(1) : "0";
+    const totalDurationMs = Math.round(session.endTime - session.startTime);
+    const activeFrames = session.frames.filter((f) => !f.isMomentum);
+    const momentumFrames = session.frames.filter((f) => f.isMomentum);
+
+    const activeDurationMs = Math.max(1, Math.round(
+      activeFrames.length > 0 ? (activeFrames[activeFrames.length - 1]!.timestamp - session.startTime) : (session.lastInputTime - session.startTime)
+    ));
+    const momentumDurationMs = Math.max(0, totalDurationMs - activeDurationMs);
+
+    const calcPhaseFps = (frames: FrameRecord[], durMs: number) =>
+      durMs > 0 && frames.length > 0 ? (frames.length / (durMs / 1000)).toFixed(1) : "0.0";
+
+    const activeDropped = activeFrames.filter((f) => f.delta > 20).length;
+    const activeSevere = activeFrames.filter((f) => f.delta > 50).length;
+    const momentumDropped = momentumFrames.filter((f) => f.delta > 20).length;
+    const momentumSevere = momentumFrames.filter((f) => f.delta > 50).length;
+
+    const totalDropped = session.frames.filter((f) => f.delta > 20).length;
+    const totalSevere = session.frames.filter((f) => f.delta > 50).length;
+    const overallFps = session.frames.length > 0 && totalDurationMs > 0
+      ? (session.frames.length / (totalDurationMs / 1000)).toFixed(1)
+      : "0.0";
+
     const avgRecompute = session.recomputeTimes.length > 0
       ? (session.recomputeTimes.reduce((a, b) => a + b, 0) / session.recomputeTimes.length).toFixed(2)
-      : "0";
+      : "0.00";
     const avgNodeRail = session.nodeRailSyncTimes.length > 0
       ? (session.nodeRailSyncTimes.reduce((a, b) => a + b, 0) / session.nodeRailSyncTimes.length).toFixed(2)
-      : "0";
+      : "0.00";
+
+    const activeDisplacement = Math.round(Math.abs(session.releaseScrollTop - session.startScrollTop));
+    const momentumDisplacement = Math.round(Math.abs(session.endScrollTop - session.releaseScrollTop));
+    const totalDisplacement = Math.round(Math.abs(session.endScrollTop - session.startScrollTop));
 
     const report = {
-      "Duration (ms)": Math.round(durationMs),
-      "Avg FPS": avgFps + " fps",
-      "Total Frames": session.frameCount,
-      "Dropped Frames (>20ms)": session.droppedFrames,
-      "Severe Jank Frames (>50ms)": session.severeJankFrames,
-      "Long Tasks (>50ms)": session.longTasks.length,
-      "Virtual Recompute Calls": session.recomputeTimes.length,
-      "Avg Recompute Time (ms)": avgRecompute,
-      "NodeRail Sync Calls": session.nodeRailSyncTimes.length,
-      "Avg NodeRail Time (ms)": avgNodeRail,
-      "Row Render Count": session.rowRenderCount,
-      "Row Mount Count": session.rowMountCount,
-      "Last Window": session.virtualWindowSnapshots.slice(-1)[0] || null,
+      "1. Phase: 跟手阶段 (Active Drag)": {
+        "Duration (ms)": activeDurationMs,
+        "Avg FPS": `${calcPhaseFps(activeFrames, activeDurationMs)} fps`,
+        "Total Frames": activeFrames.length,
+        "Dropped Frames (>20ms)": activeDropped,
+        "Severe Jank (>50ms)": activeSevere,
+        "Displacement": `${activeDisplacement} px`,
+      },
+      "2. Phase: 离手抛滑 (Momentum Fling)": {
+        "Duration (ms)": momentumDurationMs,
+        "Avg FPS": `${calcPhaseFps(momentumFrames, momentumDurationMs)} fps`,
+        "Total Frames": momentumFrames.length,
+        "Dropped Frames (>20ms)": momentumDropped,
+        "Severe Jank (>50ms)": momentumSevere,
+        "Displacement": `${momentumDisplacement} px`,
+      },
+      "3. Summary: 全流程物理收敛 (Full Lifecycle)": {
+        "Total Duration (ms)": totalDurationMs,
+        "Overall Avg FPS": `${overallFps} fps`,
+        "Total Frames": session.frames.length,
+        "Total Dropped (>20ms)": totalDropped,
+        "Total Severe (>50ms)": totalSevere,
+        "Long Tasks (>50ms)": session.longTasks.length,
+        "Row Mounts": session.rowMountCount,
+        "Total Displacement": `${totalDisplacement} px`,
+        "Avg Recompute (ms)": avgRecompute,
+        "Avg NodeRail (ms)": avgNodeRail,
+      },
     };
 
-    console.group("%c[ScrollPerf] 📊 Scroll Session Summary Report", "color: #ffb703; font-size: 13px; font-weight: bold;");
-    console.table(report);
+    console.group("%c[ScrollPerf] 📊 Multi-Phase Scroll Report (跟手 + 离手抛滑)", "color: #ffb703; font-size: 13px; font-weight: bold;");
+    console.log("%cPhase 1: 跟手操作阶段 (Active Drag)", "color: #00b4d8; font-weight: bold;");
+    console.table(report["1. Phase: 跟手阶段 (Active Drag)"]);
+    console.log("%cPhase 2: 离手抛滑阶段 (Momentum Fling Coasting)", "color: #06d6a0; font-weight: bold;");
+    console.table(report["2. Phase: 离手抛滑 (Momentum Fling)"]);
+    console.log("%cPhase 3: 全局汇总 (Overall Lifecycle)", "color: #f72585; font-weight: bold;");
+    console.table(report["3. Summary: 全流程物理收敛 (Full Lifecycle)"]);
     if (session.longTasks.length > 0) {
       console.warn("[ScrollPerf] ⚠️ Long Tasks detected during scroll:", session.longTasks);
     }
@@ -195,19 +298,31 @@ if (typeof window !== "undefined") {
   window.addEventListener(
     "wheel",
     () => {
-      scrollPerfDebug.recordScrollStart();
+      scrollPerfDebug.recordInputEvent();
+    },
+    { passive: true, capture: true },
+  );
+  window.addEventListener(
+    "touchmove",
+    () => {
+      scrollPerfDebug.recordInputEvent();
     },
     { passive: true, capture: true },
   );
   window.addEventListener(
     "scroll",
     () => {
-      scrollPerfDebug.recordScrollStart();
+      const now = performance.now();
+      if (activeSession) {
+        activeSession.lastMotionTime = now;
+      } else {
+        scrollPerfDebug.recordInputEvent();
+      }
     },
     { passive: true, capture: true },
   );
   console.log(
-    "%c[ScrollPerf] 🚀 Diagnostic telemetry initialized. Any wheel/scroll event will record metrics.",
+    "%c[ScrollPerf] 🚀 Multi-phase telemetry initialized. Accurately tracks Active Drag & Momentum Fling.",
     "color: #06d6a0; font-weight: bold; font-size: 12px;",
   );
 }

--- a/src/lib/userMessageFold.test.ts
+++ b/src/lib/userMessageFold.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  previewUserMessageText,
+  shouldFoldUserMessage,
+  USER_MSG_FOLD_MAX_CHARS,
+} from "./userMessageFold";
+
+describe("userMessageFold", () => {
+  it("does not fold short user text", () => {
+    expect(shouldFoldUserMessage("Hello world")).toBe(false);
+    expect(shouldFoldUserMessage("Line 1\nLine 2\nLine 3")).toBe(false);
+  });
+
+  it("folds text exceeding character threshold", () => {
+    const longText = "a".repeat(USER_MSG_FOLD_MAX_CHARS + 10);
+    expect(shouldFoldUserMessage(longText)).toBe(true);
+  });
+
+  it("folds text exceeding line count threshold", () => {
+    const manyLines = Array.from({ length: 15 }, (_, i) => `Line ${i}`).join("\n");
+    expect(shouldFoldUserMessage(manyLines)).toBe(true);
+  });
+
+  it("generates preview text correctly", () => {
+    const manyLines = Array.from({ length: 20 }, (_, i) => `Line ${i}`).join("\n");
+    const preview = previewUserMessageText(manyLines);
+    expect(preview).toContain("Line 0");
+    expect(preview).toContain("Line 5");
+    expect(preview).not.toContain("Line 15");
+    expect(preview.endsWith("…")).toBe(true);
+  });
+});

--- a/src/lib/userMessageFold.ts
+++ b/src/lib/userMessageFold.ts
@@ -1,0 +1,36 @@
+/**
+ * Utilities for folding/collapsing oversized user message bubbles.
+ *
+ * Prevents browser layout locks and UI clutter when user pastes
+ * large code snippets, error traces, logs, or multi-paragraph text.
+ */
+
+export const USER_MSG_FOLD_MAX_CHARS = 700;
+export const USER_MSG_FOLD_MAX_LINES = 12;
+export const USER_MSG_PREVIEW_CHARS = 350;
+export const USER_MSG_PREVIEW_LINES = 6;
+
+/** True if the user text exceeds length or line count threshold. */
+export function shouldFoldUserMessage(text?: string | null): boolean {
+  if (!text) return false;
+  if (text.length >= USER_MSG_FOLD_MAX_CHARS) return true;
+  const lineCount = (text.match(/\n/g) || []).length + 1;
+  return lineCount >= USER_MSG_FOLD_MAX_LINES;
+}
+
+/** Returns the truncated preview text with an ellipsis. */
+export function previewUserMessageText(text?: string | null): string {
+  if (!text) return "";
+  const lines = text.split("\n");
+  if (lines.length > USER_MSG_PREVIEW_LINES) {
+    const head = lines.slice(0, USER_MSG_PREVIEW_LINES).join("\n");
+    if (head.length > USER_MSG_PREVIEW_CHARS) {
+      return head.slice(0, USER_MSG_PREVIEW_CHARS).trimEnd() + "…";
+    }
+    return head.trimEnd() + "\n…";
+  }
+  if (text.length > USER_MSG_PREVIEW_CHARS) {
+    return text.slice(0, USER_MSG_PREVIEW_CHARS).trimEnd() + "…";
+  }
+  return text;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import "./styles/skins.css";
 import "./styles/tailwind.css";
 import "./styles/app.css";
 import "./styles/setup-wizard.css";
+import "@/lib/scrollPerfDebug";
 import { detectAppPlatform } from "./lib/appPlatform";
 import {
   applyNativeWindowTheme,

--- a/src/styles/modals.part3.css
+++ b/src/styles/modals.part3.css
@@ -711,6 +711,36 @@
   vertical-align: baseline;
 }
 
+.lobe-chat-user-body-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lobe-chat-user-expand {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 4px;
+}
+
+.lobe-chat-user-expand__btn {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+  border: 1px solid var(--border-soft, rgba(255, 255, 255, 0.12));
+  border-radius: 6px;
+  color: var(--text-secondary, #94a3b8);
+  font-size: 11.5px;
+  font-weight: 500;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+
+.lobe-chat-user-expand__btn:hover {
+  background: var(--bg-active, rgba(255, 255, 255, 0.14));
+  color: var(--text-primary, #f8fafc);
+  border-color: var(--border-strong, rgba(255, 255, 255, 0.2));
+}
+
 .mcp-modal__footer {
   display: flex;
   align-items: center;

--- a/src/styles/modals.part3.css
+++ b/src/styles/modals.part3.css
@@ -714,31 +714,32 @@
 .lobe-chat-user-body-wrap {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  position: relative;
 }
 
-.lobe-chat-user-expand {
+.lobe-chat-user-body-wrap--foldable {
+  cursor: pointer;
+}
+
+.lobe-chat-user-body-wrap--foldable:hover {
+  filter: brightness(1.06);
+}
+
+.lobe-chat-user-fold-cue {
   display: flex;
   justify-content: flex-end;
-  padding-top: 4px;
+  align-items: center;
+  margin-top: 2px;
+  font-size: 9px;
+  line-height: 1;
+  color: var(--text-tertiary, #94a3b8);
+  opacity: 0.6;
+  user-select: none;
+  transition: opacity 120ms ease;
 }
 
-.lobe-chat-user-expand__btn {
-  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
-  border: 1px solid var(--border-soft, rgba(255, 255, 255, 0.12));
-  border-radius: 6px;
-  color: var(--text-secondary, #94a3b8);
-  font-size: 11.5px;
-  font-weight: 500;
-  padding: 2px 8px;
-  cursor: pointer;
-  transition: all 120ms ease;
-}
-
-.lobe-chat-user-expand__btn:hover {
-  background: var(--bg-active, rgba(255, 255, 255, 0.14));
-  color: var(--text-primary, #f8fafc);
-  border-color: var(--border-strong, rgba(255, 255, 255, 0.2));
+.lobe-chat-user-body-wrap--foldable:hover .lobe-chat-user-fold-cue {
+  opacity: 1;
 }
 
 .mcp-modal__footer {


### PR DESCRIPTION
Fixes #842

### Summary of Changes

- **User Input Prompts (Long Text Spill/Collapse)**:
  - Added preview/expand fold for oversized user text prompts (`>8000` chars) on Windows WebView2, eliminating the ~1000ms Chromium Blink layout/word-wrap freeze.
  - Added fast-paths to `hydrateDisplayContent` and `parseStoredContent` in `draftDoc` to skip regexp scanning when no tokens are present.
  - Added fast-path to `parseQuotesFromContent` in `composerQuotes` when no quote tokens exist.
- **MarkdownChat / StaticMarkdownBody**:
  - Extracted and memoized `StaticMarkdownBody` for completed/non-streaming turns so that scrolling past historic messages avoids repeated synchronous unified / remark AST parsing.
- **CodeBlock & User Components**:
  - Memoized `CodeBlock`, cached `extractText` and `lineCount` calculations with `useMemo`.
  - Memoized `UserMessageBody`, `UserPlainOrSkills`, and `UserBodyText` components in `ConversationThread`.
- **chatVirtualList (Overscan Buffer)**:
  - Expanded overscan buffer from 1200px to 1800px-3000px (~1.6-2.0 viewports) for high-refresh 120Hz/144Hz displays, allowing large assistant replies to pre-render smoothly off-screen.
- **useChatMessageVirtualizer**:
  - Replaced per-row `ResizeObserver` instances with a single shared `ResizeObserver` across all virtualized rows.
  - Eliminated forced synchronous `getBoundingClientRect().height` on row mount; height is delivered asynchronously via `ResizeObserverEntry.borderBoxSize` without layout thrashing.
  - Added environment check for `ResizeObserver` to gracefully fall back in headless/test environments.
- **codeWrapPref / codeLineNumbersPref**:
  - Added in-memory caches for `loadCodeWrapPref` and `loadCodeLineNumbersPref` to prevent blocking synchronous `localStorage.getItem` reads on every `CodeBlock` mount.
- **MessageNodeRail**:
  - Memoized `nodeIdSet` to avoid per-frame Set allocations during scrolling.
  - Added bounds checking before invoking `scrollIntoView` to avoid redundant layout recalculations on the active tick.
- **MarkdownChat / ImageUi / VideoUi**:
  - Cached `fileLabels`, `imageLabels`, and `videoLabels` by `locale` to avoid allocating 25+ keys objects on every message render.
- **Telemetry & Diagnostics**:
  - Added `scrollPerfDebug` utility tracking two-phase metrics (Active Drag vs Momentum Coasting), physics settlement detection, and FPS histograms.
- **Tests**:
  - Full test suite passing (487 test files, 6454 tests).
