### PR TITLE
fix(ask-user): close questionnaire before Host IPC (#844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ See `docs/llm-wiki/release.md`.
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com](https://grok-app.com)（无末尾斜杠）。
 
 ### Fixed
+- **Agent questionnaire no longer freezes the workbench (#844)**: Answering or dismissing `_x.ai/ask_user_question` used to wait on the Host IPC with every control disabled. The modal now closes first and restores only if a failed accept is still the live request. Portaled overlays also opt out of the window-drag region so macOS titlebar drag cannot swallow clicks.
 - **Windows titlebar drag-up no longer grows height (#786)**: Follow-up to #783/#784. Caption maximize stayed up, but dragging the titlebar still stretched the frame. Windows skips JS `start_dragging` (`data-tauri-drag-region="false"`) and keeps compositor caption drag. Host `set_min_size` no longer runs on every `Moved` (tao re-applies inner size and double-counts the shadow offset); it skips while maximized, while the pointer is down, and when the min is unchanged.
 - **Desktop pet stays the chosen body, celebrates once, and no longer stalls on Windows**: Typing and in-progress tools no longer morph the mark into the catalog `!` or orbit/comet ribbons — the rest shape stays, with an attentive/curious face. Colorful belts fire only when the last live turn becomes unread-ready, then a corner pastille. Overlay paint throttles after idle, pauses while hidden, and cursor look events stay on the pet window (no duplicate still-cursor wakeups) so a long-running Windows overlay no longer freezes until restart.
 - **Windows caption maximize stays maximized; titlebar drag moves the window (#783)**: Follow-up to #773/#774. The button defers `maximize()` until after mouse-up so Aero does not drag-to-restore (flash). The `body` visualViewport transform pin is gone — it broke `-webkit-app-region: drag`, so pulling the titlebar up north-resized (bottom never lifted). An 8px top no-drag strip keeps native HTTOP.
@@ -106,6 +107,7 @@ See `docs/llm-wiki/release.md`.
 - **Windows Alt+Tab can type without a click first (#768)**: Tauri `unstable` (side-browser multi-webview) builds the page as a child `WRY_WEBVIEW`, so Alt-Tab / taskbar only activates the outer HWND. The host now forwards `WM_SETFOCUS` / `WM_ACTIVATE` into that child so composer and shortcuts work immediately.
 
 **中文 · 修复**
+- **Agent 提问弹窗不再卡住工作台（#844）**：回答或忽略 `_x.ai/ask_user_question` 以前会等 Host IPC，期间所有按钮都禁用。现在先关弹窗，只有失败的接受且仍是当前请求时才恢复。浮层也退出窗口拖动区，避免 macOS 标题栏拖动吞掉点击。
 - **Windows 标题栏往上拖不再把窗口拉高（#786）**：#783/#784 的后续。最大化能站住，但拖标题栏仍会拉长窗口。Windows 关掉 JS `start_dragging`（`data-tauri-drag-region="false"`），保留 compositor 标题栏拖动。`set_min_size` 不再在每次 `Moved` 里重设客户区（tao 会把阴影边框加两次）；最大化、按住鼠标、min 没变时都跳过。
 - **桌面宠物以本体为主、只在全部完成时撒彩带，Windows 长跑不再卡死**：打字和工具进行中不再把标记变成感叹号或轨道/彗星彩带，始终显示所选形体（专注/好奇脸）。彩带只在最后一个进行中的回合变成未读完成时播一次，然后右上角亮未读小圆点。空闲后降低绘制频率、隐藏时暂停，光标看向事件只发给宠物窗且静止不再重复唤醒，避免 Windows 透明浮层用久了卡顿卡死、重启才恢复。
 - **Windows 点最大化不再闪回，标题栏往上拖是移动窗口（#783）**：#773/#774 的后续。最大化推迟到鼠标松开之后，避免 Aero 当成拖拽立刻还原。去掉会破坏标题栏拖动的 `body` transform；顶边留 8px 非拖动带，标题栏中部往上拖会把整窗抬起来，不再把下沿无限拉高。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -82,6 +82,11 @@ import {
 } from "@/lib/gateClock";
 import { savePermissionTimeoutSec } from "@/lib/permissionTimeout";
 import { saveAskUserTimeoutSec } from "@/lib/askUserTimeout";
+import {
+  canClaimAskUserSettle,
+  settleAskUserDecision,
+  shouldClearAskUserGate,
+} from "@/lib/askUserSettle";
 import { WallpaperMediaLayer } from "@/components/WallpaperMediaLayer";
 import {
   ASIDE_WIDTH_MIN,
@@ -2328,6 +2333,9 @@ export function AppWorkbench() {
   const [perm, setPerm] = useState<PermissionPayload | null>(null);
   const permBarRef = useRef<HTMLDivElement | null>(null);
   const [askUser, setAskUser] = useState<AskUserPayload | null>(null);
+  const askUserRef = useRef(askUser);
+  askUserRef.current = askUser;
+  const askUserSettlingRpcRef = useRef<number | null>(null);
   /**
    * Unanswered gates per session (`sessionId` → payload).
    *
@@ -22770,32 +22778,71 @@ export function AppWorkbench() {
         }}
         onSubmit={async (answers) => {
           if (!askUser) return;
-          try {
-            await api.sessionResolveAskUser({
-              decision: "accepted",
-              answers,
-              rpcId: askUser.rpcId,
-              sessionId: askUser.sessionId,
-            });
-            clearPendingGates(askUser.sessionId);
-            setAskUser(null);
-          } catch (e) {
-            showToast(String(e), 4500);
+          if (!canClaimAskUserSettle(askUserSettlingRpcRef.current, askUser.rpcId)) {
+            return;
+          }
+          const payload = askUser;
+          askUserSettlingRpcRef.current = payload.rpcId;
+          // Hide before the ACP write. Waiting left every control disabled
+          // for the Host stdin timeout when the agent was wedged (#844).
+          setAskUser(null);
+          const settled = await settleAskUserDecision({
+            payload,
+            decision: "accepted",
+            answers,
+            viewingSessionId: () => viewingSessionIdRef.current,
+            currentRpcId: () => askUserRef.current?.rpcId ?? null,
+            resolve: (args) => api.sessionResolveAskUser(args),
+          });
+          if (settled.kind === "restore") {
+            if (askUserSettlingRpcRef.current === payload.rpcId) {
+              askUserSettlingRpcRef.current = null;
+            }
+            showToast(String(settled.error), 4500);
+            pendingAskUserBySessionRef.current.set(payload.sessionId, payload);
+            if (viewingSessionIdRef.current === payload.sessionId) {
+              setAskUser(payload);
+            }
+            return;
+          }
+          if (askUserSettlingRpcRef.current === payload.rpcId) {
+            askUserSettlingRpcRef.current = null;
+          }
+          if (
+            shouldClearAskUserGate({
+              settledRpcId: payload.rpcId,
+              currentRpcId: askUserRef.current?.rpcId ?? null,
+            })
+          ) {
+            clearPendingGates(payload.sessionId);
           }
         }}
         onCancel={async () => {
           if (!askUser) return;
-          try {
-            await api.sessionResolveAskUser({
-              decision: "cancelled",
-              rpcId: askUser.rpcId,
-              sessionId: askUser.sessionId,
-            });
-          } catch {
-            /* still hide UI */
+          if (!canClaimAskUserSettle(askUserSettlingRpcRef.current, askUser.rpcId)) {
+            return;
           }
-          clearPendingGates(askUser.sessionId);
+          const payload = askUser;
+          askUserSettlingRpcRef.current = payload.rpcId;
           setAskUser(null);
+          await settleAskUserDecision({
+            payload,
+            decision: "cancelled",
+            viewingSessionId: () => viewingSessionIdRef.current,
+            currentRpcId: () => askUserRef.current?.rpcId ?? null,
+            resolve: (args) => api.sessionResolveAskUser(args),
+          });
+          if (askUserSettlingRpcRef.current === payload.rpcId) {
+            askUserSettlingRpcRef.current = null;
+          }
+          if (
+            shouldClearAskUserGate({
+              settledRpcId: payload.rpcId,
+              currentRpcId: askUserRef.current?.rpcId ?? null,
+            })
+          ) {
+            clearPendingGates(payload.sessionId);
+          }
         }}
       />
       <StatusModal

--- a/src/components/AskUserModal.tsx
+++ b/src/components/AskUserModal.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { GlassModal } from "@/components/GlassModal";
 import type { AskUserPayload, AskUserQuestionItem } from "@/lib/session";
 import { askUserTimeoutRemainingSec } from "@/lib/askUserTimeout";
+import { askUserDismissLocked } from "@/lib/askUserSettle";
 import { dropGateClock, gateClockKey, resumeGateClock } from "@/lib/gateClock";
 
 /**
@@ -207,14 +208,9 @@ export function AskUserModal({
   };
 
   const cancel = async () => {
-    if (busy) return;
-    setBusy(true);
+    // Dismiss / X must stay available while accept IPC is in flight (#844).
     dropClock();
-    try {
-      await onCancel();
-    } finally {
-      setBusy(false);
-    }
+    await onCancel();
   };
 
   // Single-select, single question, option click → immediate answer.
@@ -249,7 +245,7 @@ export function AskUserModal({
           <button
             type="button"
             className="btn btn--ghost"
-            disabled={busy}
+            disabled={askUserDismissLocked(busy)}
             onClick={() => void cancel()}
           >
             {labels.cancel}

--- a/src/lib/askUserSettle.test.ts
+++ b/src/lib/askUserSettle.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  askUserDismissLocked,
+  canClaimAskUserSettle,
+  settleAskUserDecision,
+  shouldClearAskUserGate,
+  shouldRestoreAskUserOnError,
+} from "./askUserSettle";
+
+const payload = { rpcId: 7, sessionId: "s1" };
+
+describe("askUserDismissLocked", () => {
+  it("never locks Dismiss / X while accept IPC is in flight (#844)", () => {
+    expect(askUserDismissLocked(false)).toBe(false);
+    expect(askUserDismissLocked(true)).toBe(false);
+  });
+});
+
+describe("canClaimAskUserSettle", () => {
+  it("lets the first accept or cancel claim the request", () => {
+    expect(canClaimAskUserSettle(null, 7)).toBe(true);
+  });
+
+  it("rejects a second settle for the same rpcId", () => {
+    expect(canClaimAskUserSettle(7, 7)).toBe(false);
+  });
+});
+
+describe("shouldRestoreAskUserOnError", () => {
+  it("restores a failed accept on the same chat", () => {
+    expect(
+      shouldRestoreAskUserOnError({
+        decision: "accepted",
+        payload,
+        viewingSessionId: "s1",
+        currentRpcId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not restore a failed cancel", () => {
+    expect(
+      shouldRestoreAskUserOnError({
+        decision: "cancelled",
+        payload,
+        viewingSessionId: "s1",
+        currentRpcId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not restore after the user left the chat", () => {
+    expect(
+      shouldRestoreAskUserOnError({
+        decision: "accepted",
+        payload,
+        viewingSessionId: "s2",
+        currentRpcId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not restore over a newer questionnaire", () => {
+    expect(
+      shouldRestoreAskUserOnError({
+        decision: "accepted",
+        payload,
+        viewingSessionId: "s1",
+        currentRpcId: 8,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldClearAskUserGate", () => {
+  it("clears when nothing newer is showing", () => {
+    expect(shouldClearAskUserGate({ settledRpcId: 7, currentRpcId: null })).toBe(
+      true,
+    );
+    expect(shouldClearAskUserGate({ settledRpcId: 7, currentRpcId: 7 })).toBe(
+      true,
+    );
+  });
+
+  it("keeps a newer questionnaire that arrived during IPC", () => {
+    expect(shouldClearAskUserGate({ settledRpcId: 7, currentRpcId: 8 })).toBe(
+      false,
+    );
+  });
+});
+
+describe("settleAskUserDecision", () => {
+  it("dismisses after a successful accept", async () => {
+    const resolve = vi.fn().mockResolvedValue(undefined);
+    const out = await settleAskUserDecision({
+      payload,
+      decision: "accepted",
+      answers: { q: "yes" },
+      viewingSessionId: () => "s1",
+      currentRpcId: () => null,
+      resolve,
+    });
+    expect(out).toEqual({ kind: "dismiss" });
+    expect(resolve).toHaveBeenCalledWith({
+      decision: "accepted",
+      answers: { q: "yes" },
+      rpcId: 7,
+      sessionId: "s1",
+    });
+  });
+
+  it("restores a failed accept so the user can retry", async () => {
+    const err = new Error("stdin write timeout");
+    const out = await settleAskUserDecision({
+      payload,
+      decision: "accepted",
+      viewingSessionId: () => "s1",
+      currentRpcId: () => null,
+      resolve: vi.fn().mockRejectedValue(err),
+    });
+    expect(out).toEqual({ kind: "restore", error: err });
+  });
+
+  it("does not restore over a newer questionnaire that arrived during IPC", async () => {
+    const out = await settleAskUserDecision({
+      payload,
+      decision: "accepted",
+      viewingSessionId: () => "s1",
+      currentRpcId: () => 8,
+      resolve: vi.fn().mockRejectedValue(new Error("timeout")),
+    });
+    expect(out).toEqual({ kind: "dismiss" });
+  });
+
+  it("still hides after a failed cancel", async () => {
+    const out = await settleAskUserDecision({
+      payload,
+      decision: "cancelled",
+      viewingSessionId: () => "s1",
+      currentRpcId: () => null,
+      resolve: vi.fn().mockRejectedValue(new Error("gone")),
+    });
+    expect(out).toEqual({ kind: "dismiss" });
+  });
+});

--- a/src/lib/askUserSettle.ts
+++ b/src/lib/askUserSettle.ts
@@ -1,0 +1,95 @@
+/**
+ * Ask-user questionnaire settle policy (#844).
+ *
+ * Waiting on `session_resolve_ask_user` before hiding the modal left every
+ * control `disabled={busy}` for the whole Host stdin timeout when the agent
+ * was wedged. Dismiss first; restore only a failed accept if this chat is
+ * still showing the same request.
+ */
+
+export type AskUserSettleDecision = "accepted" | "cancelled";
+
+export type AskUserSettlePayload = {
+  rpcId: number;
+  sessionId: string;
+};
+
+export type AskUserSettleOutcome =
+  | { kind: "dismiss" }
+  | { kind: "restore"; error: unknown };
+
+/** Dismiss / X stay clickable while an accept IPC is in flight. */
+export function askUserDismissLocked(_busy: boolean): boolean {
+  return false;
+}
+
+/** First settle for an rpcId wins; a second accept/cancel is a no-op. */
+export function canClaimAskUserSettle(
+  claimedRpcId: number | null | undefined,
+  rpcId: number,
+): boolean {
+  return claimedRpcId !== rpcId;
+}
+
+/**
+ * After a failed ACP reply, reopen the questionnaire only for a failed
+ * accept on the same chat with no newer request.
+ */
+export function shouldRestoreAskUserOnError(input: {
+  decision: AskUserSettleDecision;
+  payload: AskUserSettlePayload;
+  viewingSessionId: string | null | undefined;
+  currentRpcId: number | null | undefined;
+}): boolean {
+  if (input.decision !== "accepted") return false;
+  if (!input.viewingSessionId) return false;
+  if (input.viewingSessionId !== input.payload.sessionId) return false;
+  if (input.currentRpcId != null && input.currentRpcId !== input.payload.rpcId) {
+    return false;
+  }
+  return true;
+}
+
+/** Drop the stored gate only if no newer questionnaire owns this chat. */
+export function shouldClearAskUserGate(input: {
+  settledRpcId: number;
+  currentRpcId: number | null | undefined;
+}): boolean {
+  return input.currentRpcId == null || input.currentRpcId === input.settledRpcId;
+}
+
+export async function settleAskUserDecision(input: {
+  payload: AskUserSettlePayload;
+  decision: AskUserSettleDecision;
+  answers?: Record<string, string> | null;
+  viewingSessionId: () => string | null | undefined;
+  currentRpcId: () => number | null | undefined;
+  resolve: (args: {
+    decision: AskUserSettleDecision;
+    answers?: Record<string, string> | null;
+    rpcId: number;
+    sessionId: string;
+  }) => Promise<unknown>;
+}): Promise<AskUserSettleOutcome> {
+  try {
+    await input.resolve({
+      decision: input.decision,
+      answers: input.answers ?? null,
+      rpcId: input.payload.rpcId,
+      sessionId: input.payload.sessionId,
+    });
+    return { kind: "dismiss" };
+  } catch (error) {
+    if (
+      shouldRestoreAskUserOnError({
+        decision: input.decision,
+        payload: input.payload,
+        viewingSessionId: input.viewingSessionId(),
+        currentRpcId: input.currentRpcId(),
+      })
+    ) {
+      return { kind: "restore", error };
+    }
+    return { kind: "dismiss" };
+  }
+}

--- a/src/lib/windowChrome.test.ts
+++ b/src/lib/windowChrome.test.ts
@@ -60,6 +60,19 @@ describe("tauriDragRegion", () => {
       /html\.platform-win \.settings-page__chrome[\s\S]{0,120}no-drag/,
     );
   });
+
+  it("keeps portaled GlassModal overlays off the window-drag region (#844)", () => {
+    const chrome = readFileSync(
+      join(__dirname, "../styles/chat.part4.css"),
+      "utf8",
+    );
+    expect(chrome).toMatch(
+      /\.overlay\s*\{[^}]*-webkit-app-region:\s*no-drag/s,
+    );
+    expect(chrome).toMatch(
+      /\.modal\s*\{[^}]*-webkit-app-region:\s*no-drag/s,
+    );
+  });
 });
 
 describe("shouldFakeMaximizeFallback", () => {

--- a/src/styles/chat.part4.css
+++ b/src/styles/chat.part4.css
@@ -687,6 +687,10 @@
   z-index: 12000;
   padding: 24px;
   box-sizing: border-box;
+  /* WKWebView drag regions ignore z-index; keep portaled dialogs clickable. */
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+  pointer-events: auto;
 }
 
 .modal {
@@ -701,6 +705,9 @@
   padding: var(--modal-pad-y, 20px) var(--modal-pad-x, 24px);
   box-sizing: border-box;
   color: var(--text-primary);
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+  pointer-events: auto;
 }
 
 .modal.glass-modal--sm,


### PR DESCRIPTION
Fixes #844

The Agent questionnaire waited on `session_resolve_ask_user` with every control `disabled={busy}`. A wedged ACP stdin write (up to the Host timeout) made the modal look frozen: options, Submit, Dismiss, and X all dead. macOS titlebar drag regions can also swallow clicks on portaled overlays because they ignore z-index.

- Hide the modal before the Host write; restore only a failed accept that is still the live request
- Dismiss / X stay available while accept IPC is in flight
- `.overlay` / `.modal` opt out of `-webkit-app-region: drag`

## Type of change
- [x] Bug fix

## Checklist
- [x] I ran `pnpm exec vitest run` on `askUserSettle` / `windowChrome` / `askUserPayload` / `escapeStop`
- [x] `tsc --noEmit` clean
- [x] User-facing strings go through `src/i18n/messages.ts` (no new copy)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No secrets