### PR TITLE
fix(settings): switch views atomically without blank frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **macOS workbench sidebar uses the same frost as Settings**: Left rail (sessions + Settings nav) applies `--sidebar-blur` backdrop-filter instead of relying on native vibrancy alone. Settings is available before first navigation and swaps atomically with the workbench; the account portal closes in the same commit. Settings nav width follows the workbench rail. The glass meets the chat column with no opaque black seam. Returning keeps the workbench painted instead of hiding Settings for 320ms and leaving only the wallpaper in WKWebView.
+- **macOS sidebar right edge no longer flashes while dragging**: The seam is an inset hairline on the solid chat column, not a 1px layout border on Sidebar vibrancy. Window drag and split resize no longer alias that pixel light/dark.
 - **Chat transcript scroll no longer thrashes layout on mounted rows**: Virtual rows share a single `ResizeObserver` and measure via `borderBoxSize` instead of synchronous `getBoundingClientRect()` on mount; code block line-wrap/number preferences use in-memory caches to avoid blocking `localStorage` reads; right-edge message node rail uses memoized node IDs and skips redundant tick scrolls.
 - **UI font and terminal font are local-font dropdowns**: Settings → Appearance lists installed families (searchable) instead of a free-text name. UI default is the app sans stack; terminal default is the built-in Nerd Font stack. Reset is unchanged.
 - **Debug dock icon is the white invert**: `pnpm dev` uses `src-tauri/icons/dev` (white plate, dark mark) so the running debug app is distinct from the installed black production icon. Release bundles are unchanged.
@@ -61,6 +63,8 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com](https://grok-app.com) (no trailing slash).
 
 **中文 · 变更**
+- **macOS 主页面侧栏与设置导航同一套毛玻璃**：会话列表和设置左栏都用 `--sidebar-blur` 的 backdrop-filter，不再只靠系统 vibrancy。设置页在首次导航前就已可用，并与工作台原子切换；账户菜单浮层在同一次提交中收起。设置左栏宽度跟工作台侧栏走，玻璃接到聊天列不再夹实色黑边。返回时工作台始终保持已绘制，不再先隐藏设置层并等待 320ms、让 WKWebView 只剩壁纸。
+- **macOS 侧栏右缘拖动不再明暗闪烁**：分割线画在实色聊天列上，不再用 Sidebar 毛玻璃上的 1px layout 边框。拖窗口和拖分割条时那一像素不会再在亮/暗之间跳。
 - **长对话滚动消除挂载重排与同步存储阻塞**：虚拟列表改用单个共享 `ResizeObserver` 并通过 `borderBoxSize` 获取高度，消除新行挂载时的 `getBoundingClientRect()` 强制同步重排（Layout Thrashing）；代码块换行与行号偏好使用内存缓存，避免挂载时同步读取 `localStorage` 阻塞主线程；右侧消息节点轴缓存节点 ID 集合并在可视范围内跳过冗余滚动。
 - **界面字体和终端字体改为本机字体下拉**：设置 → 外观列出本机已安装字体族（可搜索），不再手填名称。界面默认是应用无衬线栈；终端默认是内置 Nerd Font。重置不变。
 - **开发版 Dock 图标改白底反色**：`pnpm dev` 使用 `src-tauri/icons/dev`（白底深色标），和已安装的黑底正式版区分。发布包图标不变。

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -27,7 +27,7 @@
 | `--radius-sm` | `6px` | chip、小按钮 |
 | `--radius-full` | `9999px` | 头像、圆点状态 |
 | `--space-1` … `--space-8` | `4 / 8 / 12 / 16 / 20 / 24 / 32 / 48 px` | 间距阶梯 |
-| `--sidebar-width` | `260px` | 左栏默认（可拖 200–360） |
+| `--sidebar-width` | `268px` | 左栏默认（可拖 200–420，与 `SIDEBAR_DEFAULT_WIDTH` 一致） |
 | `--tree-rail-pad` | `10px` | 侧栏 nav / 会话列表共用左右内边距（图标列原点） |
 | `--tree-l1-gutter` | `--space-5`（20px） | 一级箭头 + New session 等图标槽 |
 | `--tree-l1-gutter-touch` | `44px` | 手机抽屉里只加宽 L1 箭头命中区 |
@@ -43,7 +43,7 @@
 | `--leading-tight` / `normal` | `1.35 / 1.55` | 行高 |
 | `--shadow-window` | 见主题表 | 窗口投影 |
 | `--motion-fast` / `normal` | `120ms` / `200ms` | 过渡（含侧栏项目列表开合）；尊重 `prefers-reduced-motion` |
-| `--motion-pane` / `--motion-pane-ease` | `320ms` / `cubic-bezier(0.22, 1, 0.36, 1)` | 左右分栏 / 底栏开合 / 设置页叠在工作台上的进出（无过冲）。分栏 token **不**随 `prefers-reduced-motion` 清零；设置 overlay 与菜单在 reduce 下关掉 transform / transition |
+| `--motion-pane` / `--motion-pane-ease` | `320ms` / `cubic-bezier(0.22, 1, 0.36, 1)` | 左右分栏 / 底栏开合（无过冲）；设置页与工作台直接切换，不使用该 token。分栏 token **不**随 `prefers-reduced-motion` 清零 |
 
 **栏宽持久化：** `layout.sidebarWidth` / `layout.asideWidth` / `layout.asideCollapsed` 写入 App 配置。
 

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -116,7 +116,6 @@ import {
   paneSplitSizeStyle,
 } from "@/lib/paneSplitMotion";
 import { usePaneSplitMotion } from "@/hooks/usePaneSplitMotion";
-import { useOpenPresence, VIEW_PRESENCE_MS } from "@/lib/openPresence";
 import { acquireNativeWebviewCover } from "@/lib/nativeWebviewCover";
 import {
   PHONE_KEYBOARD_INSET_VAR,
@@ -983,10 +982,6 @@ import { ConversationThreadLive } from "@/components/lobe-chat";
 import { AgentTasksPanelLive } from "@/components/AgentTasksPanelLive";
 import { PermissionCountdown } from "@/components/PermissionCountdown";
 
-const SettingsPage = lazy(async () => {
-  const m = await import("@/components/SettingsPage");
-  return { default: m.SettingsPage };
-});
 const AutomationsPage = lazy(async () => {
   const m = await import("@/components/AutomationsPage");
   return { default: m.AutomationsPage };
@@ -1063,7 +1058,10 @@ import {
   quotaFromHostItem,
   type SwitcherQuota,
 } from "@/lib/accountSwitcherQuota";
-import type { SettingsSectionId } from "@/components/SettingsPage";
+import {
+  SettingsPage,
+  type SettingsSectionId,
+} from "@/components/SettingsPage";
 import {
   buildSettingsHash,
   isSettingsSectionId,
@@ -1803,6 +1801,10 @@ export function AppWorkbench() {
   const [phoneAccountOpen, setPhoneAccountOpen] = useState(false);
   /** Hash route: workbench | settings/:section | automations */
   const [appView, setAppView] = useState<"workbench" | "settings">("workbench");
+  const settingsNativeCoverReleaseRef = useRef<(() => void) | null>(null);
+  const ensureSettingsNativeCover = useCallback(() => {
+    settingsNativeCoverReleaseRef.current ??= acquireNativeWebviewCover();
+  }, []);
   /** Inside workbench: chat thread vs scheduled tasks vs agent kanban. */
   const [mainPane, setMainPane] = useState<"chat" | "automations" | "kanban">(
     "chat",
@@ -4343,6 +4345,7 @@ export function AppWorkbench() {
         tab,
         last: section == null ? loadSettingsLastRoute() : null,
       });
+      ensureSettingsNativeCover();
       setSettingsSection(loc.section);
       setSettingsTab(loc.tab);
       setAppView("settings");
@@ -4362,7 +4365,7 @@ export function AppWorkbench() {
         }
       }
     },
-    [],
+    [ensureSettingsNativeCover],
   );
 
   /** Settings → Runtime → Tools, scrolled to the workflows card. */
@@ -4378,6 +4381,8 @@ export function AppWorkbench() {
       const fullHash = window.location.hash || "";
       const raw = fullHash.replace(/^#\/?/, "");
       if (raw.startsWith("settings")) {
+        ensureSettingsNativeCover();
+        setShowUserMenu(false);
         const parts = raw.split("/").filter(Boolean);
         // parts[0] === "settings"; parts[1] may be section (ignore ?query)
         const sectionPart = (parts[1] ?? "").split("?")[0];
@@ -4423,7 +4428,7 @@ export function AppWorkbench() {
     syncFromHash();
     window.addEventListener("hashchange", syncFromHash);
     return () => window.removeEventListener("hashchange", syncFromHash);
-  }, []);
+  }, [ensureSettingsNativeCover]);
 
   /**
    * Open a stored session. Loads journal immediately; warms the ACP agent in
@@ -18234,20 +18239,22 @@ export function AppWorkbench() {
     [],
   );
 
-  const settingsPresence = useOpenPresence(
-    appView === "settings",
-    true,
-    VIEW_PRESENCE_MS,
+  useLayoutEffect(() => {
+    if (appView === "settings") {
+      ensureSettingsNativeCover();
+      return;
+    }
+    const release = settingsNativeCoverReleaseRef.current;
+    settingsNativeCoverReleaseRef.current = null;
+    release?.();
+  }, [appView, ensureSettingsNativeCover]);
+  useEffect(
+    () => () => {
+      settingsNativeCoverReleaseRef.current?.();
+      settingsNativeCoverReleaseRef.current = null;
+    },
+    [],
   );
-  useEffect(() => {
-    if (!settingsPresence.mounted) return;
-    return acquireNativeWebviewCover();
-  }, [settingsPresence.mounted]);
-  useEffect(() => {
-    if (!showUserMenu) return;
-    void import("@/components/SettingsPage");
-  }, [showUserMenu]);
-
   return (
     <ImageViewerProvider locale={locale}>
     <div
@@ -18261,6 +18268,11 @@ export function AppWorkbench() {
       data-testid="app-shell"
       data-mirror={isMirrorClient() ? "1" : undefined}
       data-phone={phoneLayout ? "1" : undefined}
+      style={
+        {
+          ["--sidebar-rail-width"]: `${layout.sidebarWidth || SIDEBAR_DEFAULT_WIDTH}px`,
+        } as CSSProperties
+      }
     >
       <WindowControls
         visible={useCustomWindowChrome && !isMirrorClient()}
@@ -18382,16 +18394,8 @@ export function AppWorkbench() {
 
       {appGate === "ready" && (
       <>
-      {settingsPresence.mounted ? (
-        <div
-          className={
-            "app-settings-stage" +
-            (settingsPresence.entered ? " is-open" : "")
-          }
-          data-testid="settings-stage"
-          aria-hidden={!settingsPresence.entered || undefined}
-        >
-                <Suspense fallback={null}>
+      {appView === "settings" ? (
+        <div className="app-settings-stage" data-testid="settings-stage">
           <SettingsPage
           section={settingsSection}
           tab={settingsTab}
@@ -19112,7 +19116,7 @@ export function AppWorkbench() {
           }
           })();
           }}
-          />        </Suspense>
+          />
         </div>
       ) : null}
       <div
@@ -19121,9 +19125,6 @@ export function AppWorkbench() {
           (phoneLayout ? " workbench--phone" : "") +
           (hideChatForSideExpand ? " workbench--side-expanded" : "") +
           (sideDockActive ? " workbench--side-dock" : "") +
-          (appView === "settings" && settingsPresence.entered
-            ? " is-view-idle"
-            : "") +
           paneMotionClass
         }
         aria-hidden={appView === "settings" || undefined}
@@ -19229,6 +19230,7 @@ export function AppWorkbench() {
               onPointerDown={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                e.currentTarget.setPointerCapture?.(e.pointerId);
                 const width = layout.sidebarWidth || SIDEBAR_DEFAULT_WIDTH;
                 sidebarResizeStartRef.current = {
                   x: e.clientX,
@@ -19994,6 +19996,7 @@ export function AppWorkbench() {
 
           <UserMenu
             open={showUserMenu}
+            closeImmediately={appView === "settings"}
             onClose={() => setShowUserMenu(false)}
             theme={theme}
             themePreference={themePreference}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -27,7 +27,7 @@ import {
   FLOATING_MENU_Z_INDEX,
   useFloatingMenu,
 } from "@/lib/floatingMenu";
-import { useOpenPresence } from "@/lib/openPresence";
+import { OPEN_PRESENCE_MS, useOpenPresence } from "@/lib/openPresence";
 import type {
   AccountStatus,
   CustomProvider,
@@ -57,6 +57,8 @@ import { formatShortcutHint } from "@/lib/shortcuts";
 
 export interface UserMenuProps {
   open: boolean;
+  /** Skip the portal exit when a full-page view replaces the workbench. */
+  closeImmediately?: boolean;
   onClose: () => void;
   /** Resolved light/dark for icons. */
   theme: Theme;
@@ -157,6 +159,7 @@ function computeThemeFlyoutStyle(
 
 export function UserMenu({
   open,
+  closeImmediately = false,
   onClose,
   theme,
   themePreference,
@@ -251,9 +254,13 @@ export function UserMenu({
     updateFlyoutPos();
   }, [open, themeSubOpen, updateFlyoutPos, themePreference]);
 
-  const panelPresence = useOpenPresence(open);
+  const panelPresence = useOpenPresence(
+    open,
+    true,
+    closeImmediately ? 0 : OPEN_PRESENCE_MS,
+  );
   const { pos, style, settled } = useFloatingMenu({
-    open: panelPresence.mounted,
+    open: !closeImmediately && panelPresence.mounted,
     triggerRef,
     panelRef,
     roots: [rootRef, themeFlyoutRef],
@@ -267,7 +274,11 @@ export function UserMenu({
     // CSS owns transform (rise from the footer). Do not apply placeAbove -100%.
     anchorTransform: false,
   });
-  const panelEntered = useOpenPresence(Boolean(open && settled)).entered;
+  const panelEntered = useOpenPresence(
+    Boolean(open && settled),
+    true,
+    closeImmediately ? 0 : OPEN_PRESENCE_MS,
+  ).entered;
 
   const profile = account?.profile;
   const isCustomProvider = activeProvider != null;
@@ -305,8 +316,13 @@ export function UserMenu({
     return labels.themeDark;
   };
 
-  const flyoutPresence = useOpenPresence(open && themeSubOpen, !!flyoutStyle);
+  const flyoutPresence = useOpenPresence(
+    open && themeSubOpen,
+    !!flyoutStyle,
+    closeImmediately ? 0 : OPEN_PRESENCE_MS,
+  );
   const themeFlyout =
+    !closeImmediately &&
     flyoutPresence.mounted &&
     flyoutStyle &&
     typeof document !== "undefined"
@@ -356,7 +372,10 @@ export function UserMenu({
       : null;
 
   const panel =
-    panelPresence.mounted && pos && typeof document !== "undefined"
+    !closeImmediately &&
+    panelPresence.mounted &&
+    pos &&
+    typeof document !== "undefined"
       ? createPortal(
           <div
             ref={panelRef}

--- a/src/lib/openPresence.test.ts
+++ b/src/lib/openPresence.test.ts
@@ -3,7 +3,6 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   OPEN_PRESENCE_MS,
-  VIEW_PRESENCE_MS,
   reduceOpenPresence,
   type OpenPresenceState,
 } from "./openPresence";
@@ -73,8 +72,20 @@ describe("floating pop CSS", () => {
     resolve(__dirname, "../styles/sidebar.part1.css"),
     "utf8",
   );
+  const skins = readFileSync(
+    resolve(__dirname, "../styles/skins.css"),
+    "utf8",
+  );
   const tree = readFileSync(
     resolve(__dirname, "../styles/sidebar.part2.css"),
+    "utf8",
+  );
+  const appWorkbench = readFileSync(
+    resolve(__dirname, "../app/AppWorkbench.tsx"),
+    "utf8",
+  );
+  const userMenu = readFileSync(
+    resolve(__dirname, "../components/UserMenu.tsx"),
     "utf8",
   );
 
@@ -89,12 +100,95 @@ describe("floating pop CSS", () => {
     expect(env).toMatch(/var\(--motion-normal\) var\(--motion-pane-ease\)/);
   });
 
-  it("crossfades settings over a still-mounted workbench", () => {
-    expect(VIEW_PRESENCE_MS).toBe(320);
-    expect(settings).toMatch(/\.app-settings-stage\.is-open/);
-    expect(settings).toMatch(/transform-origin:\s*bottom left/);
-    expect(settings).toMatch(/var\(--motion-pane\) var\(--motion-pane-ease\)/);
-    expect(workbenchCss).toMatch(/\.workbench\.is-view-idle/);
+  it("switches settings atomically without a presence or paint gap", () => {
+    const start = settings.indexOf(".app-settings-stage {");
+    expect(start).toBeGreaterThanOrEqual(0);
+    const stageCss = settings.slice(
+      start,
+      settings.indexOf("/* ===== Settings full page"),
+    );
+    expect(stageCss).not.toMatch(/visibility\s*:/);
+    expect(stageCss).not.toMatch(/opacity\s*:/);
+    expect(stageCss).not.toMatch(/transform\s*:/);
+    expect(stageCss).not.toMatch(/(?:transition|animation)\s*:/);
+    expect(stageCss).toMatch(/z-index:\s*20/);
+    expect(appWorkbench).toMatch(/\{appView === "settings" \? \(/);
+    expect(appWorkbench).not.toMatch(/settingsPresence|VIEW_PRESENCE_MS/);
+    expect(settings).not.toMatch(/settings-stage-(?:enter|leave)/);
+  });
+
+  it("uses the same CSS frost on workbench sidebar and settings nav", () => {
+    const blur =
+      /backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)\s*saturate\(var\(--sidebar-saturate\)\)/;
+    expect(workbenchCss).toMatch(
+      /\.platform-mac \.sidebar\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/,
+    );
+    expect(workbenchCss).toMatch(
+      /\.platform-mac \.settings-page__nav\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/,
+    );
+    expect(workbenchCss).toMatch(blur);
+  });
+
+  it("keeps the workbench fully painted behind the direct settings swap", () => {
+    expect(appWorkbench).not.toMatch(/is-view-idle/);
+    expect(workbenchCss).not.toMatch(/\.workbench\.is-view-idle/);
+    expect(workbenchCss).toMatch(/\.workbench\s*\{[^}]*z-index:\s*0/);
+    expect(skins).toMatch(
+      /html\[data-wallpaper="1"\] \.app-settings-stage\s*\{[^}]*z-index:\s*20/,
+    );
+    expect(skins).toMatch(
+      /> \*:not\(\.window-controls\):not\(\.window-edge-n\):not\(\.app-wallpaper-media\):not\(\.app-settings-stage\)/,
+    );
+  });
+
+  it("closes the account portal immediately when settings takes over", () => {
+    expect(appWorkbench).toMatch(/closeImmediately=\{appView === "settings"\}/);
+    expect(userMenu).toMatch(
+      /useOpenPresence\(\s*open,\s*true,\s*closeImmediately \? 0 : OPEN_PRESENCE_MS,\s*\)/,
+    );
+    expect(userMenu).toMatch(
+      /const panel\s*=\s*!closeImmediately\s*&&\s*panelPresence\.mounted/,
+    );
+    const hashRoute = appWorkbench.slice(
+      appWorkbench.indexOf("const syncFromHash = () =>"),
+      appWorkbench.indexOf("window.addEventListener(\"hashchange\""),
+    );
+    expect(hashRoute).toMatch(
+      /if \(raw\.startsWith\("settings"\)\) \{\s*ensureSettingsNativeCover\(\);\s*setShowUserMenu\(false\);/,
+    );
+  });
+
+  it("covers native child webviews before committing settings", () => {
+    const navigateStart = appWorkbench.indexOf(
+      "const navigateSettings = useCallback(",
+    );
+    const navigateEnd = appWorkbench.indexOf(
+      "/** Settings → Runtime",
+      navigateStart,
+    );
+    const navigate = appWorkbench.slice(navigateStart, navigateEnd);
+    expect(navigate.indexOf("ensureSettingsNativeCover();")).toBeGreaterThan(0);
+    expect(navigate.indexOf("ensureSettingsNativeCover();")).toBeLessThan(
+      navigate.indexOf('setAppView("settings")'),
+    );
+    expect(appWorkbench).toMatch(
+      /useLayoutEffect\(\(\) => \{\s*if \(appView === "settings"\)/,
+    );
+  });
+
+  it("loads settings before the first navigation can hard-cut in", () => {
+    expect(appWorkbench).toMatch(
+      /import\s*\{\s*SettingsPage,\s*type SettingsSectionId,\s*\}\s*from "@\/components\/SettingsPage"/,
+    );
+    expect(appWorkbench).not.toMatch(
+      /(?:lazy|import)\([^\n]*@\/components\/SettingsPage/,
+    );
+  });
+
+  it("settings nav width follows the workbench rail token", () => {
+    expect(settings).toMatch(
+      /\.settings-page__nav\s*\{[^}]*width:\s*var\(--sidebar-rail-width/,
+    );
   });
 
   it("interpolates project session lists instead of hard-cutting", () => {

--- a/src/lib/openPresence.test.ts
+++ b/src/lib/openPresence.test.ts
@@ -136,8 +136,12 @@ describe("floating pop CSS", () => {
     expect(skins).toMatch(
       /html\[data-wallpaper="1"\] \.app-settings-stage\s*\{[^}]*z-index:\s*20/,
     );
+    // #846: lift only .workbench so the settings stage keeps inset:0.
     expect(skins).toMatch(
-      /> \*:not\(\.window-controls\):not\(\.window-edge-n\):not\(\.app-wallpaper-media\):not\(\.app-settings-stage\)/,
+      /html\[data-wallpaper="1"\] \.app-shell > \.workbench\s*\{[^}]*position:\s*relative/s,
+    );
+    expect(skins).not.toMatch(
+      /html\[data-wallpaper="1"\] \.app-shell\s*>\s*\*:not\(/s,
     );
   });
 

--- a/src/lib/openPresence.ts
+++ b/src/lib/openPresence.ts
@@ -9,8 +9,6 @@ import { prefersReducedMotion } from "@/lib/paneSplitMotion";
 
 /** Matches `--motion-normal` (tokens.css). */
 export const OPEN_PRESENCE_MS = 200;
-/** Matches `--motion-pane` — full view swaps (settings ↔ workbench). */
-export const VIEW_PRESENCE_MS = 320;
 
 export type OpenPresenceState = {
   mounted: boolean;

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -149,6 +149,27 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(bt).not.toMatch(/^\s*height\s*:\s*0\s*!important/m);
   });
 
+  it("mac sidebar seam is not a 1px layout border on vibrancy", () => {
+    const sidebar = readFileSync(
+      resolve(__dirname, "../styles/sidebar.part1.css"),
+      "utf8",
+    );
+    const tokens = readFileSync(
+      resolve(__dirname, "../styles/tokens.css"),
+      "utf8",
+    );
+    expect(sidebar).toMatch(
+      /\.platform-mac \.sidebar\s*\{[^}]*border-right:\s*none/,
+    );
+    expect(sidebar).toMatch(
+      /\.platform-mac \.main[^{]*\{[^}]*box-shadow:\s*var\(--sidebar-seam\)/,
+    );
+    expect(tokens).toMatch(/--sidebar-edge-shadow:\s*none/);
+    expect(tokens).not.toMatch(
+      /--sidebar-edge-shadow:[^;]*1px 0 0 var\(--bg-main\)/,
+    );
+  });
+
   it("sidebar-only motion does not overflow-hidden or contain a stable aside", () => {
     const css = readFileSync(
       resolve(__dirname, "../styles/chat.part6.css"),

--- a/src/styles/settings.part1.css
+++ b/src/styles/settings.part1.css
@@ -354,10 +354,7 @@
   }
 }
 
-/*
- * Settings overlays the still-mounted workbench. Rise from the account
- * menu (bottom-left) and sink back on close — not a hard view cut.
- */
+/* Settings is an atomic full-page swap over the still-mounted workbench. */
 .app-settings-stage {
   position: absolute;
   inset: 0;
@@ -365,26 +362,10 @@
   display: flex;
   min-width: 0;
   min-height: 0;
-  opacity: 0;
-  transform: translateY(18px);
-  transform-origin: bottom left;
-  transition:
-    opacity var(--motion-pane) var(--motion-pane-ease),
-    transform var(--motion-pane) var(--motion-pane-ease);
-  pointer-events: none;
 }
 
-.app-settings-stage.is-open {
-  opacity: 1;
-  transform: none;
-  pointer-events: auto;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .app-settings-stage {
-    transform: none;
-    transition: none;
-  }
+.app-settings-stage .settings-page {
+  background: transparent;
 }
 
 /* ===== Settings full page (ChatGPT-desktop style) ===== */
@@ -419,19 +400,21 @@
 }
 
 .settings-page__nav {
-  width: 220px;
-  min-width: 200px;
-  max-width: 240px;
+  /* Match workbench rail (layout.sidebarWidth → --sidebar-rail-width). */
+  width: var(--sidebar-rail-width, var(--sidebar-width));
+  min-width: var(--sidebar-rail-width, var(--sidebar-width));
+  max-width: var(--sidebar-rail-width, var(--sidebar-width));
   flex-shrink: 0;
   border-right: 1px solid var(--border-subtle);
   /*
    * Same token as workbench .sidebar. On mac, parent .settings-page is
    * transparent so glass samples vibrancy. Win keeps solid shell + this fill.
+   * overflow lives on __nav-inner — hidden here clips backdrop-filter.
    */
   background: var(--bg-sidebar);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
   /* Clear traffic-light / drag band */
   padding-top: var(--titlebar-height, 40px);
   box-sizing: border-box;

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -380,17 +380,13 @@ html.platform-win .window-edge-n {
   flex: 1;
   min-height: 0;
   position: relative;
+  z-index: 0;
   /* Transparent on mac so sidebar vibrancy is not covered by solid paint */
   background: transparent;
-  transition:
-    --sw-sidebar-occupied var(--motion-pane) var(--motion-pane-ease),
-    opacity var(--motion-pane) var(--motion-pane-ease);
-}
-
-/* Covered by settings overlay — keep mounted so chat/webview state survives. */
-.workbench.is-view-idle {
-  opacity: 0;
-  pointer-events: none;
+  /* Do not transition opacity: a parent opacity group flattens the glass
+   * rail with the solid chat column, and WKWebView keeps that flatten after
+   * settings closes — sidebar frost then matches .main. */
+  transition: --sw-sidebar-occupied var(--motion-pane) var(--motion-pane-ease);
 }
 
 .workbench:has(.sidebar.is-resizing) {
@@ -497,10 +493,39 @@ html.platform-win .window-edge-n {
   background: var(--border-focus, #6b8cff);
 }
 
-/* mac: tint only — native vibrancy provides blur */
+.sidebar.is-resizing .sidebar-resizer::after {
+  transition: none;
+}
+
+/*
+ * mac rail: same frost as Settings nav — CSS blur + tint over native Sidebar.
+ * Do not wait on native vibrancy alone: a sibling opaque .main (or a parent
+ * opacity/transform) makes the rail look like a flat tint of the chat column.
+ * Overlay / phone drawers keep their drop shadow (set below).
+ */
 .platform-mac .sidebar {
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
+  -webkit-backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
+  backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
+  border-right: none;
+}
+
+.platform-mac .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {
+  box-shadow: var(--sidebar-edge-shadow);
+}
+
+.platform-mac .sidebar.sidebar--overlay {
+  border-right: none;
+}
+
+/* Hairline on solid main — composites against --bg-main, not vibrancy. */
+.platform-mac .main {
+  box-shadow: var(--sidebar-seam);
+}
+
+.workbench:has(> .sidebar.sidebar--hidden) .main,
+.workbench:has(> .sidebar.sidebar--collapsed) .main,
+.workbench:has(> .sidebar.sidebar--overlay) .main,
+.app-shell--phone .main {
   box-shadow: none;
 }
 
@@ -521,21 +546,26 @@ html.platform-mac[data-theme="light"] .workbench {
   background: transparent;
 }
 
-html.platform-mac[data-theme="light"] .sidebar,
-.platform-mac[data-theme="light"] .sidebar {
+html.platform-mac[data-theme="light"] .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer),
+.platform-mac[data-theme="light"] .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {
   background: var(--bg-sidebar);
-  /* Edge treated by box-shadow only — no border-right (avoids double line) */
   border-right: none;
-  box-shadow: var(--sidebar-edge-inset);
+  box-shadow: var(--sidebar-edge-shadow);
 }
 
 /* Solid elevated content columns — pure white, sit above glass rail */
 html.platform-mac[data-theme="light"] .main {
   background: #ffffff;
   border-left: none;
-  /* Barely-there lift; rail inset carries the edge hierarchy */
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.02);
+  box-shadow: var(--sidebar-seam);
   z-index: 2;
+}
+
+html.platform-mac[data-theme="light"] .workbench:has(> .sidebar.sidebar--hidden) .main,
+html.platform-mac[data-theme="light"] .workbench:has(> .sidebar.sidebar--collapsed) .main,
+html.platform-mac[data-theme="light"] .workbench:has(> .sidebar.sidebar--overlay) .main,
+html.platform-mac[data-theme="light"] .app-shell--phone .main {
+  box-shadow: none;
 }
 
 html.platform-mac[data-theme="light"] .aside {
@@ -555,27 +585,28 @@ html.platform-mac[data-theme="light"] .aside {
 
 .platform-mac .settings-page__nav {
   background: var(--bg-sidebar);
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-  /* same default edge as workbench rail */
-  border-right: 1px solid var(--border-subtle);
-  box-shadow: none;
+  -webkit-backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
+  backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
+  border-right: none;
+  box-shadow: var(--sidebar-edge-shadow);
+  /* overflow on the blur element kills backdrop sampling in WKWebView */
+  overflow: visible;
 }
 
 .platform-mac .settings-page__content {
   background: var(--bg-main);
   z-index: 2;
+  box-shadow: var(--sidebar-seam);
 }
 
-/* Light: same edge inset + no hard border + soft content lift as .main */
 html.platform-mac[data-theme="light"] .settings-page__nav {
   border-right: none;
-  box-shadow: var(--sidebar-edge-inset);
+  box-shadow: var(--sidebar-edge-shadow);
 }
 
 html.platform-mac[data-theme="light"] .settings-page__content {
   background: #ffffff;
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.02);
+  box-shadow: var(--sidebar-seam);
 }
 
 /* Fully closed left pane (no icon rail) — reopen from main top icons.
@@ -764,10 +795,6 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 @media (prefers-reduced-motion: reduce) {
   .sidebar-update-btn__dot--pulse {
     animation: none;
-  }
-
-  .workbench.is-view-idle {
-    transition: none;
   }
 }
 

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -67,6 +67,11 @@ html[data-wallpaper="1"] .workbench {
   background: transparent !important;
 }
 
+/* Keep the atomic Settings swap above the lifted workbench chrome. */
+html[data-wallpaper="1"] .app-settings-stage {
+  z-index: 20;
+}
+
 /* Pane fills scale with scrim: 0% = fully clear wallpaper under chrome.
  * !important beats platform-win solid fills and mac light #ffffff rules. */
 html[data-wallpaper="1"] .sidebar {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -27,7 +27,8 @@
   --space-7: 32px;
   --space-8: 48px;
 
-  --sidebar-width: 260px;
+  /* Keep in sync with SIDEBAR_DEFAULT_WIDTH in layout.ts */
+  --sidebar-width: 268px;
   /*
    * Sidebar tree columns (nav icons, L1 chevron, L2 name, L3 title).
    * Change values here only — consumers use var() with no px fallback.
@@ -99,13 +100,16 @@
     0 24px 64px rgba(0, 0, 0, 0.32);
 
   /*
-   * Sidebar CSS blur is unused on mac (native vibrancy only).
-   * Kept for experiments / non-mac CSS glass if re-enabled later.
+   * Left rail frost (workbench + settings). Native Sidebar vibrancy is the
+   * window plate; this CSS blur is what actually reads on the rail — WKWebView
+   * does not sample vibrancy while a parent is mid-opacity/transform.
    */
-  --sidebar-blur: 120px;
-  --sidebar-saturate: 2;
-  --sidebar-edge-line: rgba(255, 255, 255, 0.06);
-  --sidebar-edge-inset: none;
+  --sidebar-blur: 64px;
+  --sidebar-saturate: 1.85;
+  --sidebar-edge-line: rgba(255, 255, 255, 0.08);
+  /* No opaque --bg-main strip — that read as a black bar cutting the glass. */
+  --sidebar-edge-shadow: none;
+  --sidebar-seam: none;
 
   --border-subtle: rgba(255, 255, 255, 0.06);
   --border-strong: rgba(255, 255, 255, 0.12);
@@ -217,7 +221,7 @@
    * ChatGPT/Cursor-style light chrome:
    * - Sidebar: translucent white glass over native light vibrancy (airier than solid)
    * - Main / aside: pure solid white (elevated content column)
-   * - Edge: soft inward shade at sidebar→main (see --sidebar-edge-inset)
+   * - Edge: soft inward shade on the rail + hairline on solid main (--sidebar-seam)
    */
   /* More open glass — translucent white over light vibrancy */
   --bg-sidebar: rgba(255, 255, 255, 0.38);
@@ -233,11 +237,10 @@
   --bg-card: #ffffff;
   --bg-user-bubble: #e8e8ed;
 
-  /* Subtle edge only — tight inset, low opacity (hierarchy without drama) */
+  /* Soft inward shade on glass; no 1px fill of --bg-main (that cut the frost). */
   --sidebar-edge-line: rgba(0, 0, 0, 0.04);
-  --sidebar-edge-inset:
-    inset -1px 0 0 var(--sidebar-edge-line),
-    inset -8px 0 12px -8px rgba(0, 0, 0, 0.035);
+  --sidebar-edge-shadow: inset -8px 0 12px -8px rgba(0, 0, 0, 0.035);
+  --sidebar-seam: -4px 0 12px rgba(0, 0, 0, 0.02);
 
   --glass-surface: rgba(255, 255, 255, 0.72);
   --glass-surface-solid: rgba(255, 255, 255, 0.96);
@@ -249,7 +252,7 @@
     0 8px 28px rgba(0, 0, 0, 0.1),
     0 20px 48px rgba(0, 0, 0, 0.08);
 
-  --sidebar-blur: 120px;
+  --sidebar-blur: 64px;
   --sidebar-saturate: 1.85;
 
   --border-subtle: rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
## Summary

- Replace the delayed Settings presence with an atomic view switch while keeping the workbench painted and inert underneath.
- Close account-menu portals and cover native child webviews before Settings navigation, including hash/deep-link entry.
- Align Settings/sidebar stacking, frost, width, and seam behavior, with regression tests for blank-frame and flash paths.

## Root cause

The Settings stage became visually hidden immediately on close but remained mounted for 320 ms. In WKWebView, repainting the underlying workbench could be deferred until that stage unmounted, which exposed wallpaper-only frames. Lazy first-load and overlay/stacking paths added one-frame flashes around the same transition.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Validation

- User verified the native macOS transition in both directions.
- `pnpm test` — 490 files / 6481 tests passed.
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:ui`
- `cargo test --locked -- --test-threads=1` — 1480 passed / 1 ignored.
- `pnpm tauri build --debug --bundles app --config src-tauri/tauri.dev.conf.json`
- Chromium regression: 5 flows / 80 commit-frame samples, including wallpaper and hash navigation.
- Final integrated Pi review: PASS.

The default parallel Cargo run hit one shared temporary-directory rename race; that test passed in isolation and the full serial suite passed.

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] No new user-facing strings were added
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Behavior docs and changelog were updated
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
