### PR TITLE
fix(pet,macos): pet press does not wake main; launch keys reach the DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ See `docs/llm-wiki/release.md`.
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com](https://grok-app.com)（无末尾斜杠）。
 
 ### Fixed
+- **Desktop pet press no longer wakes the workbench**: Dragging or single-clicking the mark only moves it / plays an emote. Double-click opens the main window (or the focused session). The overlay no longer yields key to main on pointer-down, and on macOS it opts out of app activation so a pet press cannot raise a background or hidden workbench.
+- **macOS launch can type and use shortcuts without a first click**: After `show()`, the Host reasserts key/activation once the page has loaded, retries briefly if NSApp stayed inactive while the window claimed key, and points firstResponder at the WKWebView so ⌘, and other web shortcuts reach the DOM.
 - **Settings covers the window with wallpaper on (#846)**: Wallpaper chrome lift no longer forces `position: relative` on the settings overlay. Short tabs (Pet, Archived chats) were shrinking to content height, so wallpaper (and the desktop pet) showed in the leftover strip.
 - **Agent questionnaire no longer freezes the workbench (#844)**: Answering or dismissing `_x.ai/ask_user_question` used to wait on the Host IPC with every control disabled. The modal now closes first and restores only if a failed accept is still the live request. Portaled overlays also opt out of the window-drag region so macOS titlebar drag cannot swallow clicks.
 - **Windows titlebar drag-up no longer grows height (#786)**: Follow-up to #783/#784. Caption maximize stayed up, but dragging the titlebar still stretched the frame. Windows skips JS `start_dragging` (`data-tauri-drag-region="false"`) and keeps compositor caption drag. Host `set_min_size` no longer runs on every `Moved` (tao re-applies inner size and double-counts the shadow offset); it skips while maximized, while the pointer is down, and when the min is unchanged.
@@ -112,6 +114,8 @@ See `docs/llm-wiki/release.md`.
 - **Windows Alt+Tab can type without a click first (#768)**: Tauri `unstable` (side-browser multi-webview) builds the page as a child `WRY_WEBVIEW`, so Alt-Tab / taskbar only activates the outer HWND. The host now forwards `WM_SETFOCUS` / `WM_ACTIVATE` into that child so composer and shortcuts work immediately.
 
 **中文 · 修复**
+- **按下桌面宠物不再唤醒主窗口**：拖动或单击标记只移动 / 做表情；双击才打开主窗口（或聚焦当前会话）。浮层在按下时不再把键盘焦点交回主窗口；macOS 上宠物窗选择不激活应用，避免后台或已隐藏的工作台被带起来。
+- **macOS 启动后不用先点一下就能打字和用快捷键**：`show()` 之后等页面加载完再确认一次键盘焦点/激活；若窗口已是 key 但 NSApp 仍 inactive，短重试几次；并把 firstResponder 指到 WKWebView，让 ⌘, 等网页快捷键进 DOM。
 - **有壁纸时设置页铺满窗口（#846）**：壁纸层级提升不再给设置 overlay 强制 `position: relative`。内容短的页（宠物、归档对话）以前按内容高度收缩，壁纸和桌面宠物会从底下露出来。
 - **Agent 提问弹窗不再卡住工作台（#844）**：回答或忽略 `_x.ai/ask_user_question` 以前会等 Host IPC，期间所有按钮都禁用。现在先关弹窗，只有失败的接受且仍是当前请求时才恢复。浮层也退出窗口拖动区，避免 macOS 标题栏拖动吞掉点击。
 - **Windows 标题栏往上拖不再把窗口拉高（#786）**：#783/#784 的后续。最大化能站住，但拖标题栏仍会拉长窗口。Windows 关掉 JS `start_dragging`（`data-tauri-drag-region="false"`），保留 compositor 标题栏拖动。`set_min_size` 不再在每次 `Moved` 里重设客户区（tao 会把阴影边框加两次）；最大化、按住鼠标、min 没变时都跳过。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1865,6 +1865,7 @@ dependencies = [
  "mac-notification-sys",
  "mac-usernotifications",
  "notify-rust",
+ "objc2",
  "parking_lot",
  "portable-pty",
  "rand 0.8.7",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -115,6 +115,8 @@ tauri-plugin-window-state = "2"
 [target.'cfg(target_os = "macos")'.dependencies]
 mac-notification-sys = "0.6"
 mac-usernotifications = "0.3"
+# Pet overlay: setPreventsActivation. Launch: NSApp.isActive / firstResponder.
+objc2 = "0.6"
 
 [profile.release]
 codegen-units = 1

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -492,6 +492,12 @@ pub fn run() {
                     if window.label() == "main" => {
                         schedule_persist_main_window_state(window.app_handle());
                     }
+                WindowEvent::Focused(focused) if window.label() == "main" => {
+                    // Launch first-interaction dead-zone diagnosis: trace every
+                    // key-window transition so a lost activation race is visible
+                    // in the log (first click / ⌘, eaten = no Focused(true)).
+                    tracing::info!("main window focused={focused}");
+                }
                 _ => {}
             }
         })
@@ -573,6 +579,75 @@ pub fn run() {
                 .visible(false)
                 .accept_first_mouse(true)
                 .initialization_script(&boot_theme_script)
+                .on_page_load(|window, payload| {
+                    // Cold-launch first-click / first-key dead zone: the
+                    // set_focus() right after show() occasionally loses the
+                    // activation race, leaving a key window whose app is still
+                    // INACTIVE (macOS cooperative activation silently ignores
+                    // activateIgnoringOtherApps from a background process — e.g.
+                    // dev launched from a terminal). isKeyWindow is then true,
+                    // so an is_focused guard would wrongly skip; clicks still
+                    // land (accept_first_mouse) but NO key events reach the app
+                    // while NSApp is inactive — ⌘, stays dead until one click
+                    // activates us. Reassert unconditionally ONCE when the page
+                    // has loaded, then repair the residual stuck state (key
+                    // window + inactive app) with guarded retries. Note: tao's
+                    // set_focus short-circuits while hidden — setup shows the
+                    // window synchronously before any page load can finish,
+                    // which this reassert relies on.
+                    use std::sync::atomic::{AtomicBool, Ordering};
+                    static REASSERTED: AtomicBool = AtomicBool::new(false);
+                    if payload.event() != tauri::webview::PageLoadEvent::Finished {
+                        return;
+                    }
+                    if REASSERTED.swap(true, Ordering::SeqCst) {
+                        return;
+                    }
+                    let app_active_at_load = ns_app_is_active();
+                    tracing::info!(
+                        focused_at_load = window.is_focused().unwrap_or(false),
+                        app_active_at_load,
+                        "main page loaded — reasserting launch focus/activation"
+                    );
+                    let _ = window.set_focus();
+                    {
+                        let w = window.clone();
+                        let _ = window.run_on_main_thread(move || {
+                            point_keys_at_webview(&w);
+                        });
+                    }
+                    if !app_active_at_load && cfg!(target_os = "macos") {
+                        // Repair loop for the pathological state: the window
+                        // claims key while NSApp is inactive (cooperative
+                        // activation denied/raced). Retry a few times over ~2s.
+                        // Guard: if the user deliberately switched away, our
+                        // window loses key → bail instead of yanking them back;
+                        // once active, stop immediately.
+                        let w = window.clone();
+                        tauri::async_runtime::spawn(async move {
+                            for attempt in 1..=8u8 {
+                                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                                if ns_app_is_active() {
+                                    return;
+                                }
+                                if !w.is_focused().unwrap_or(false) {
+                                    tracing::info!(
+                                        attempt,
+                                        "launch activation repair: window lost key (user moved on or pet briefly keyed)"
+                                    );
+                                    return;
+                                }
+                                tracing::info!(attempt, "repairing launch activation (key window + inactive app)");
+                                let _ = w.set_focus();
+                                let wr = w.clone();
+                                let _ = w.run_on_main_thread(move || {
+                                    point_keys_at_webview(&wr);
+                                });
+                            }
+                            tracing::warn!("launch activation repair gave up; first click will activate");
+                        });
+                    }
+                })
                 .build()?;
             #[cfg(debug_assertions)]
             {
@@ -1697,6 +1772,52 @@ pub fn run() {
 
         });
 }
+
+/// NSApp activation state. Key events only reach the web while the app is
+/// ACTIVE; a key window on an inactive app is the launch dead-zone pathology
+/// (macOS cooperative activation silently denies background self-activation).
+#[cfg(target_os = "macos")]
+fn ns_app_is_active() -> bool {
+    use objc2::{class, msg_send, runtime::AnyObject};
+    unsafe {
+        let app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
+        if app.is_null() {
+            return false;
+        }
+        msg_send![app, isActive]
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn ns_app_is_active() -> bool {
+    true
+}
+
+/// Point the key window's first responder at the WKWebView so key events reach
+/// the DOM (web shortcuts like ⌘,). `makeKeyAndOrderFront` alone can leave the
+/// NSWindow itself as initial first responder: app ACTIVE + window key, yet
+/// every keystroke dies in the responder chain until one click focuses the
+/// web view. Idempotent; logs when it had to re-point.
+#[cfg(target_os = "macos")]
+fn point_keys_at_webview(win: &tauri::WebviewWindow) {
+    use objc2::{class, msg_send, runtime::AnyObject};
+    let (Ok(ns_win), Ok(ns_view)) = (win.ns_window(), win.ns_view()) else {
+        return;
+    };
+    unsafe {
+        let ns_win = ns_win as *mut AnyObject;
+        let ns_view = ns_view as *mut AnyObject;
+        let resp: *mut AnyObject = msg_send![ns_win, firstResponder];
+        let resp_is_webview: bool = msg_send![resp, isKindOfClass: class!(WKWebView)];
+        if !resp_is_webview {
+            tracing::info!("main first responder is not the webview — re-pointing keys at DOM");
+            let _: () = msg_send![ns_win, makeFirstResponder: ns_view];
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn point_keys_at_webview(_win: &tauri::WebviewWindow) {}
 
 /// Resolve AppSettings.theme (`system` | `light` | `dark`) to a concrete
 /// boot theme for the static shell and native chrome before React loads.

--- a/src-tauri/src/pet_window.rs
+++ b/src-tauri/src/pet_window.rs
@@ -9,6 +9,7 @@
 //! the key window. WKWebView then eats the first click on the workbench just
 //! to focus it. `focusable(false)` maps to `canBecomeKeyWindow = NO` /
 //! `WS_EX_NOACTIVATE` so the pet stays above other apps without stealing key.
+//! A press on the mark is for drag / emote; only a double-click shows main.
 //!
 //! Linux/KWin drops pointer events on `accept_focus=false` windows, so the
 //! overlay stays focusable there and does not yield key on the same click.
@@ -472,9 +473,14 @@ pub fn pet_overlay_focusable(linux: bool) -> bool {
     linux
 }
 
-/// Immediate Focused(true) → yield cancels the click / move serial on Linux.
-pub fn should_yield_key_on_pet_focus(linux: bool, dragging: bool, menu_open: bool) -> bool {
-    !linux && !dragging && !menu_open
+/// Clicking or dragging the overlay must not raise the workbench.
+///
+/// Linux: a same-tick yield also eats the click / move serial.
+/// macOS/Windows: yielding `set_focus` on main is what made a pet press
+/// wake the main window. Key is returned after pet `show()` via
+/// `should_force_return_main_key_after_show`.
+pub fn should_yield_key_on_pet_focus(_linux: bool, _dragging: bool, _menu_open: bool) -> bool {
+    false
 }
 
 pub fn pet_nudge_origin(x: f64, y: f64, dx: f64, dy: f64) -> (f64, f64) {
@@ -732,9 +738,40 @@ fn apply_window_chrome(win: &tauri::WebviewWindow) {
     let _ = win.set_decorations(false);
     let _ = win.set_shadow(false);
     let _ = win.set_focusable(pet_overlay_focusable(cfg!(target_os = "linux")));
+    apply_pet_prevents_activation(win);
     detach_native_menu(win);
     if pet_wayland_display() {
         let _ = win.set_ignore_cursor_events(false);
+    }
+}
+
+/// Clicking the overlay must not activate Grok (macOS would otherwise raise
+/// every window of the app, including the hidden/background workbench).
+fn apply_pet_prevents_activation(#[allow(unused_variables)] win: &tauri::WebviewWindow) {
+    #[cfg(target_os = "macos")]
+    {
+        let Ok(ptr) = win.ns_window() else {
+            return;
+        };
+        if ptr.is_null() {
+            return;
+        }
+        unsafe {
+            use objc2::runtime::{AnyObject, Bool};
+            use objc2::{msg_send, sel};
+            let window = ptr as *mut AnyObject;
+            let public = sel!(setPreventsActivation:);
+            let responds: Bool = msg_send![window, respondsToSelector: public];
+            if responds.as_bool() {
+                let _: () = msg_send![window, setPreventsActivation: true];
+                return;
+            }
+            let private = sel!(_setPreventsActivation:);
+            let responds: Bool = msg_send![window, respondsToSelector: private];
+            if responds.as_bool() {
+                let _: () = msg_send![window, _setPreventsActivation: true];
+            }
+        }
     }
 }
 
@@ -977,10 +1014,8 @@ pub fn ensure_pet_window(app: &AppHandle) -> Result<tauri::WebviewWindow, String
             }
             tauri::WindowEvent::Focused(true) => {
                 // show() uses makeKeyAndOrderFront even when focused(false).
-                // If the workbench is already up, give key back immediately.
-                // Skip while dragging / menu is open so pointer capture stays.
-                // On Linux a same-tick yield eats the click (KWin) and the
-                // xdg_toplevel.move serial — show_pet already yields.
+                // Do not yield on a user press — that raised the workbench
+                // when the user only meant to drag. show_pet already yields.
                 if should_yield_key_on_pet_focus(
                     cfg!(target_os = "linux"),
                     DRAGGING.load(Ordering::Relaxed),
@@ -1730,9 +1765,11 @@ mod tests {
     }
 
     #[test]
-    fn linux_focus_does_not_yield_key_on_the_same_click() {
+    fn pet_pointer_down_does_not_yield_key_to_main() {
+        // Click / drag the overlay to move it — never raise the workbench.
+        // Key is returned after pet show() via should_force_return_main_key_after_show.
         assert!(!should_yield_key_on_pet_focus(true, false, false));
-        assert!(should_yield_key_on_pet_focus(false, false, false));
+        assert!(!should_yield_key_on_pet_focus(false, false, false));
         assert!(!should_yield_key_on_pet_focus(false, true, false));
         assert!(!should_yield_key_on_pet_focus(false, false, true));
     }

--- a/src/components/pet/PetOverlay.tsx
+++ b/src/components/pet/PetOverlay.tsx
@@ -49,7 +49,6 @@ import {
   petSetHitChrome,
   petSetIgnoreCursor,
   petSetMenuOpen,
-  petHideMain,
   petShowMain,
   petStartDragging,
   petSyncOverlaySize,
@@ -114,7 +113,6 @@ export function PetOverlay({
     expanded: !hugMark,
   });
   const pendingClickRef = useRef<number | null>(null);
-  const openedAtRef = useRef<number | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const markRef = useRef<HTMLDivElement | null>(null);
   const stackRef = useRef<HTMLDivElement | null>(null);
@@ -335,7 +333,7 @@ export function PetOverlay({
   useEffect(() => {
     const end = () => {
       // Only an in-progress OS drag. A click still has originRef but must
-      // reach onPointerUp so double-click / open-session still works.
+      // reach onPointerUp so double-click can open the workbench.
       if (!draggedRef.current) return;
       finishDrag();
     };
@@ -399,24 +397,19 @@ export function PetOverlay({
       if (petDragPassedSlop(e.screenX - start.x, e.screenY - start.y)) return;
       const intent = petMarkClickIntent({
         pendingSingle: pendingClickRef.current != null,
-        openedAt: openedAtRef.current,
-        now: Date.now(),
       });
-      if (intent === "hide-double" || intent === "hide-peek") {
+      if (intent === "open-double") {
         if (pendingClickRef.current != null) {
           window.clearTimeout(pendingClickRef.current);
           pendingClickRef.current = null;
         }
-        openedAtRef.current = null;
-        void petHideMain();
+        if (focus.sessionId) void petFocusSession(focus.sessionId);
+        else void petShowMain();
         return;
       }
       pendingClickRef.current = window.setTimeout(() => {
         pendingClickRef.current = null;
         setEmoteSignal((n) => n + 1);
-        if (focus.sessionId) void petFocusSession(focus.sessionId);
-        else void petShowMain();
-        openedAtRef.current = Date.now();
       }, PET_DBLCLICK_MS);
     },
     [finishDrag, focus.sessionId],

--- a/src/components/pet/petOverlay.guard.test.ts
+++ b/src/components/pet/petOverlay.guard.test.ts
@@ -19,11 +19,13 @@ describe("PetOverlay drag hit target", () => {
     expect(src).toContain("bubblesEnabled");
   });
 
-  it("opens on click, hides on double-click or a peek click within 3s", () => {
+  it("opens the workbench only on double-click; a single click emotes", () => {
     expect(src).toContain("petMarkClickIntent");
-    expect(src).toContain("petHideMain");
     expect(src).toContain("PET_DBLCLICK_MS");
-    expect(src).toContain("openedAtRef");
+    expect(src).toContain('"open-double"');
+    expect(src).toContain("setEmoteSignal");
+    expect(src).not.toContain("petHideMain");
+    expect(src).not.toContain("openedAtRef");
   });
 
   it("keeps celebrate spin after drag and bubble changes", () => {

--- a/src/lib/pet/index.ts
+++ b/src/lib/pet/index.ts
@@ -56,11 +56,7 @@ export {
   type PetBubbleStyle,
 } from "./petBubbleChrome";
 
-export {
-  PET_DBLCLICK_MS,
-  PET_PEEK_HIDE_MS,
-  petMarkClickIntent,
-} from "./petClick";
+export { PET_DBLCLICK_MS, petMarkClickIntent } from "./petClick";
 
 export {
   petStageSnippetStore,

--- a/src/lib/pet/petClick.test.ts
+++ b/src/lib/pet/petClick.test.ts
@@ -1,33 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { PET_PEEK_HIDE_MS, petMarkClickIntent } from "./petClick";
+import { petMarkClickIntent } from "./petClick";
 
 describe("petMarkClickIntent", () => {
-  it("arms a single click to open", () => {
-    expect(
-      petMarkClickIntent({ pendingSingle: false, openedAt: null, now: 1_000 }),
-    ).toBe("arm-open");
+  it("arms a single click as an emote, not an open", () => {
+    expect(petMarkClickIntent({ pendingSingle: false })).toBe("arm-emote");
   });
 
-  it("treats a second click inside the double-click window as hide", () => {
-    expect(
-      petMarkClickIntent({ pendingSingle: true, openedAt: null, now: 1_100 }),
-    ).toBe("hide-double");
-  });
-
-  it("hides on a follow-up click within 3s of opening", () => {
-    expect(
-      petMarkClickIntent({
-        pendingSingle: false,
-        openedAt: 1_000,
-        now: 1_000 + PET_PEEK_HIDE_MS - 1,
-      }),
-    ).toBe("hide-peek");
-    expect(
-      petMarkClickIntent({
-        pendingSingle: false,
-        openedAt: 1_000,
-        now: 1_000 + PET_PEEK_HIDE_MS,
-      }),
-    ).toBe("arm-open");
+  it("treats a second click inside the double-click window as open", () => {
+    expect(petMarkClickIntent({ pendingSingle: true })).toBe("open-double");
   });
 });

--- a/src/lib/pet/petClick.ts
+++ b/src/lib/pet/petClick.ts
@@ -1,20 +1,12 @@
-/** Pet mark click: open, double-click hide, peek-hide within 3s of opening. */
+/** Pet mark click: single click emotes; only double-click opens the workbench. */
 
 export const PET_DBLCLICK_MS = 280;
-export const PET_PEEK_HIDE_MS = 3_000;
 
-export type PetMarkClickIntent = "arm-open" | "hide-double" | "hide-peek";
+export type PetMarkClickIntent = "arm-emote" | "open-double";
 
 export function petMarkClickIntent(input: {
   pendingSingle: boolean;
-  openedAt: number | null;
-  now: number;
-  peekMs?: number;
 }): PetMarkClickIntent {
-  if (input.pendingSingle) return "hide-double";
-  const peek = input.peekMs ?? PET_PEEK_HIDE_MS;
-  if (input.openedAt != null && input.now - input.openedAt < peek) {
-    return "hide-peek";
-  }
-  return "arm-open";
+  if (input.pendingSingle) return "open-double";
+  return "arm-emote";
 }


### PR DESCRIPTION
Restore two local fixes that were parked while landing community PRs.

1. **Desktop pet press no longer wakes the workbench**
   Single-click / drag only moves the mark or plays an emote. Double-click opens main (or the focused session). Overlay does not yield key on pointer-down. macOS `setPreventsActivation` so a press cannot raise a hidden/background workbench.

2. **macOS launch can type without a first click**
   After `show()`, reassert key/activation once the page loads. If NSApp stayed inactive while the window claimed key, retry briefly (bail if the user left). Point firstResponder at the WKWebView so ⌘, and other web shortcuts reach the DOM.

## Checklist
- [x] vitest: petClick + petOverlay.guard
- [x] `cargo test pet_pointer_down_does_not_yield_key_to_main`
- [x] `cargo clippy --lib -- -D warnings`
- [x] CHANGELOG Unreleased (en + zh)
- [x] No new in-app copy / native dialogs / secrets