### PR TITLE
feat(pet): horizontal-mirror the mark on the right half of the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
+- **Desktop pet on the right is a horizontal mirror**: Bottom-left keeps the authored ¾-right face. On the right half of the work area the mark is `scaleX(-1)` so the eyes look toward screen centre. The flip follows the overlay while dragging.
 - **macOS workbench sidebar uses the same frost as Settings**: Left rail (sessions + Settings nav) applies `--sidebar-blur` backdrop-filter instead of relying on native vibrancy alone. Settings is available before first navigation and swaps atomically with the workbench; the account portal closes in the same commit. Settings nav width follows the workbench rail. The glass meets the chat column with no opaque black seam. Returning keeps the workbench painted instead of hiding Settings for 320ms and leaving only the wallpaper in WKWebView.
 - **macOS sidebar right edge no longer flashes while dragging**: The seam is an inset hairline on the solid chat column, not a 1px layout border on Sidebar vibrancy. Window drag and split resize no longer alias that pixel light/dark.
 - **Chat transcript scroll no longer thrashes layout on mounted rows**: Virtual rows share a single `ResizeObserver` and measure via `borderBoxSize` instead of synchronous `getBoundingClientRect()` on mount; code block line-wrap/number preferences use in-memory caches to avoid blocking `localStorage` reads; right-edge message node rail uses memoized node IDs and skips redundant tick scrolls.
@@ -63,6 +64,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com](https://grok-app.com) (no trailing slash).
 
 **中文 · 变更**
+- **桌面宠物在右半边水平镜像**：左下角仍是原来的 ¾ 右视脸。到工作区右半边时整只 `scaleX(-1)`，眼睛看向画面中间。拖动过程中跟着翻，不是松手后才跳。
 - **macOS 主页面侧栏与设置导航同一套毛玻璃**：会话列表和设置左栏都用 `--sidebar-blur` 的 backdrop-filter，不再只靠系统 vibrancy。设置页在首次导航前就已可用，并与工作台原子切换；账户菜单浮层在同一次提交中收起。设置左栏宽度跟工作台侧栏走，玻璃接到聊天列不再夹实色黑边。返回时工作台始终保持已绘制，不再先隐藏设置层并等待 320ms、让 WKWebView 只剩壁纸。
 - **macOS 侧栏右缘拖动不再明暗闪烁**：分割线画在实色聊天列上，不再用 Sidebar 毛玻璃上的 1px layout 边框。拖窗口和拖分割条时那一像素不会再在亮/暗之间跳。
 - **长对话滚动消除挂载重排与同步存储阻塞**：虚拟列表改用单个共享 `ResizeObserver` 并通过 `borderBoxSize` 获取高度，消除新行挂载时的 `getBoundingClientRect()` 强制同步重排（Layout Thrashing）；代码块换行与行号偏好使用内存缓存，避免挂载时同步读取 `localStorage` 阻塞主线程；右侧消息节点轴缓存节点 ID 集合并在可视范围内跳过冗余滚动。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ See `docs/llm-wiki/release.md`.
 - **快捷键帮助（Ctrl+/）**：面板可按名称 / id / 组合键筛选，按设置页同样的分组列出；补上缩放、换行、历史提示、打字聚焦；列表可滚动，不再裁掉末尾几项。
 
 ### Changed
-- **Desktop pet on the right is a horizontal mirror**: Bottom-left keeps the authored ¾-right face. On the right half of the work area the mark is `scaleX(-1)` so the eyes look toward screen centre. The flip follows the overlay while dragging.
+- **Desktop pet on the right is a horizontal mirror**: Bottom-left keeps the authored ¾-right face. On the right half of the **screen work area** the mark is `scaleX(-1)` so the eyes look toward centre. Position comes from the overlay window (not `window.screenX`, which is 0 in the pet webview). The flip follows while dragging.
 - **macOS workbench sidebar uses the same frost as Settings**: Left rail (sessions + Settings nav) applies `--sidebar-blur` backdrop-filter instead of relying on native vibrancy alone. Settings is available before first navigation and swaps atomically with the workbench; the account portal closes in the same commit. Settings nav width follows the workbench rail. The glass meets the chat column with no opaque black seam. Returning keeps the workbench painted instead of hiding Settings for 320ms and leaving only the wallpaper in WKWebView.
 - **macOS sidebar right edge no longer flashes while dragging**: The seam is an inset hairline on the solid chat column, not a 1px layout border on Sidebar vibrancy. Window drag and split resize no longer alias that pixel light/dark.
 - **Chat transcript scroll no longer thrashes layout on mounted rows**: Virtual rows share a single `ResizeObserver` and measure via `borderBoxSize` instead of synchronous `getBoundingClientRect()` on mount; code block line-wrap/number preferences use in-memory caches to avoid blocking `localStorage` reads; right-edge message node rail uses memoized node IDs and skips redundant tick scrolls.
@@ -64,7 +64,7 @@ See `docs/llm-wiki/release.md`.
 - **Official site on GitHub About and README**: Repo homepage, `package.json` `homepage`, and public READMEs now point to [https://grok-app.com](https://grok-app.com) (no trailing slash).
 
 **中文 · 变更**
-- **桌面宠物在右半边水平镜像**：左下角仍是原来的 ¾ 右视脸。到工作区右半边时整只 `scaleX(-1)`，眼睛看向画面中间。拖动过程中跟着翻，不是松手后才跳。
+- **桌面宠物在屏幕右半边水平镜像**：左侧仍是原来的 ¾ 右视脸。到屏幕工作区右半边时整只 `scaleX(-1)`。位置用宠物窗口坐标（不用 `window.screenX`，浮层 WebView 里经常是 0）。拖动过程中跟着翻。
 - **macOS 主页面侧栏与设置导航同一套毛玻璃**：会话列表和设置左栏都用 `--sidebar-blur` 的 backdrop-filter，不再只靠系统 vibrancy。设置页在首次导航前就已可用，并与工作台原子切换；账户菜单浮层在同一次提交中收起。设置左栏宽度跟工作台侧栏走，玻璃接到聊天列不再夹实色黑边。返回时工作台始终保持已绘制，不再先隐藏设置层并等待 320ms、让 WKWebView 只剩壁纸。
 - **macOS 侧栏右缘拖动不再明暗闪烁**：分割线画在实色聊天列上，不再用 Sidebar 毛玻璃上的 1px layout 边框。拖窗口和拖分割条时那一像素不会再在亮/暗之间跳。
 - **长对话滚动消除挂载重排与同步存储阻塞**：虚拟列表改用单个共享 `ResizeObserver` 并通过 `borderBoxSize` 获取高度，消除新行挂载时的 `getBoundingClientRect()` 强制同步重排（Layout Thrashing）；代码块换行与行号偏好使用内存缓存，避免挂载时同步读取 `localStorage` 阻塞主线程；右侧消息节点轴缓存节点 ID 集合并在可视范围内跳过冗余滚动。

--- a/src/components/pet/PetMark.tsx
+++ b/src/components/pet/PetMark.tsx
@@ -8,6 +8,7 @@
  */
 import { useEffect, useId, useRef } from "react";
 import { listen } from "@/lib/api/host";
+import { petReadOverlayFrame, type PetOverlayFrame } from "@/lib/api/pet";
 import type { PetColor, PetEyeColor, PetShape, PetVerb } from "@/lib/pet";
 import { isPetColor, resolvePetBodyInk, resolvePetEyeInk } from "@/lib/pet";
 import {
@@ -34,6 +35,7 @@ import {
   petMarkScreenCenter,
   petNormXOnWorkArea,
   petShouldMirrorFace,
+  petShouldMirrorFromOverlay,
 } from "@/lib/pet/petFaceMirror";
 import { MARK_CENTER, verbToMarkState } from "@/lib/pet/markTables";
 import { createMarkOrbit } from "@/lib/pet/markOrbit";
@@ -279,6 +281,16 @@ export function PetMark({
     let mirrored = false;
     let markBox: DOMRect | null = null;
     let markBoxAt = 0;
+    let overlayFrame: PetOverlayFrame | null = null;
+    let overlayFrameBusy = false;
+    const pullOverlayFrame = () => {
+      if (overlayFrameBusy || restOnlyRef.current) return;
+      overlayFrameBusy = true;
+      void petReadOverlayFrame().then((frame) => {
+        overlayFrameBusy = false;
+        if (frame) overlayFrame = frame;
+      });
+    };
     const measureMark = () => {
       const now = performance.now();
       if (!markBox || now - markBoxAt > 500) {
@@ -298,21 +310,33 @@ export function PetMark({
       if (draggingRef.current) {
         markBox = svg.getBoundingClientRect();
         markBoxAt = performance.now();
+        pullOverlayFrame();
       }
       const box = measureMark();
       if (!box) return;
-      const { cx } = petMarkScreenCenter({
-        screenX: window.screenX,
-        screenY: window.screenY,
-        rect: box,
-      });
-      const nx = petNormXOnWorkArea({
-        cx,
-        left: window.screen.availLeft,
-        width: window.screen.availWidth,
-      });
-      mirrored = petShouldMirrorFace(nx);
+      if (overlayFrame) {
+        mirrored = petShouldMirrorFromOverlay({
+          winX: overlayFrame.winX,
+          markLeft: box.left,
+          markWidth: box.width,
+          workX: overlayFrame.work.x,
+          workW: overlayFrame.work.w,
+        });
+      } else {
+        const { cx } = petMarkScreenCenter({
+          screenX: window.screenX,
+          screenY: window.screenY,
+          rect: box,
+        });
+        const nx = petNormXOnWorkArea({
+          cx,
+          left: window.screen.availLeft,
+          width: window.screen.availWidth,
+        });
+        mirrored = petShouldMirrorFace(nx);
+      }
       svg.style.transform = mirrored ? "scaleX(-1)" : "";
+      svg.style.transformOrigin = "center center";
     };
 
     const onPointerMove = (e: PointerEvent) => {
@@ -328,7 +352,19 @@ export function PetMark({
       if (!look.fromScreen) look.at = 0;
     };
 
+    let unlistenMoved: (() => void) | undefined;
     if (!pausedRef.current && !reduce && !restOnlyRef.current) {
+      pullOverlayFrame();
+      void (async () => {
+        try {
+          const { getCurrentWindow } = await import("@tauri-apps/api/window");
+          unlistenMoved = await getCurrentWindow().onMoved(() => {
+            pullOverlayFrame();
+          });
+        } catch {
+          /* browser / tests */
+        }
+      })();
       window.addEventListener("pointermove", onPointerMove, { passive: true });
       window.addEventListener("pointerleave", onPointerLeave);
       void listen<{ dx?: number; dy?: number; localR?: number }>(
@@ -596,6 +632,7 @@ export function PetMark({
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("pointerleave", onPointerLeave);
       unlistenCursor?.();
+      unlistenMoved?.();
     };
   }, [paused, uid]);
 

--- a/src/components/pet/PetMark.tsx
+++ b/src/components/pet/PetMark.tsx
@@ -330,8 +330,8 @@ export function PetMark({
         });
         const nx = petNormXOnWorkArea({
           cx,
-          left: window.screen.availLeft,
-          width: window.screen.availWidth,
+          left: 0,
+          width: window.screen.availWidth || window.innerWidth || 1,
         });
         mirrored = petShouldMirrorFace(nx);
       }

--- a/src/components/pet/PetMark.tsx
+++ b/src/components/pet/PetMark.tsx
@@ -30,6 +30,11 @@ import {
 } from "@/lib/pet/bloubPlay";
 import { pickRestEmote, resolveLivingMood } from "@/lib/pet/petMood";
 import { petLookIsNear, petPaintMinMs } from "@/lib/pet/petMarkPaint";
+import {
+  petMarkScreenCenter,
+  petNormXOnWorkArea,
+  petShouldMirrorFace,
+} from "@/lib/pet/petFaceMirror";
 import { MARK_CENTER, verbToMarkState } from "@/lib/pet/markTables";
 import { createMarkOrbit } from "@/lib/pet/markOrbit";
 import {
@@ -271,6 +276,7 @@ export function PetMark({
     const look = { dx: 0, dy: 0, localR: 48, at: 0, fromScreen: false };
     let unlistenCursor: (() => void) | undefined;
     let aiming = false;
+    let mirrored = false;
     let markBox: DOMRect | null = null;
     let markBoxAt = 0;
     const measureMark = () => {
@@ -280,6 +286,33 @@ export function PetMark({
         markBoxAt = now;
       }
       return markBox;
+    };
+    const syncFaceMirror = () => {
+      const svg = svgRef.current;
+      if (!svg || typeof window === "undefined") return;
+      if (restOnlyRef.current) {
+        svg.style.transform = "";
+        mirrored = false;
+        return;
+      }
+      if (draggingRef.current) {
+        markBox = svg.getBoundingClientRect();
+        markBoxAt = performance.now();
+      }
+      const box = measureMark();
+      if (!box) return;
+      const { cx } = petMarkScreenCenter({
+        screenX: window.screenX,
+        screenY: window.screenY,
+        rect: box,
+      });
+      const nx = petNormXOnWorkArea({
+        cx,
+        left: window.screen.availLeft,
+        width: window.screen.availWidth,
+      });
+      mirrored = petShouldMirrorFace(nx);
+      svg.style.transform = mirrored ? "scaleX(-1)" : "";
     };
 
     const onPointerMove = (e: PointerEvent) => {
@@ -413,6 +446,7 @@ export function PetMark({
       }
       const frozen = pausedRef.current || reduce;
       const t = frozen ? (POSES[play.state] ?? 1) : clock;
+      syncFaceMirror();
       const baseFace =
         play.state === "idle" || play.state === "swirl";
       const fresh = petLookIsNear({
@@ -441,7 +475,10 @@ export function PetMark({
           ny = (look.dy - (box.top + box.height / 2)) / Math.max(1, box.height);
         }
         if (Number.isFinite(nx) && Number.isFinite(ny)) {
-          engine.setLook(bloubLookAtPointer(nx, ny, true), clock);
+          engine.setLook(
+            bloubLookAtPointer(mirrored ? -nx : nx, ny, true),
+            clock,
+          );
           aiming = true;
         }
       }
@@ -513,13 +550,13 @@ export function PetMark({
       const morphing =
         wantSpinRef.current !== playedSpinRef.current ||
         clockRef.current - stateSince < 1.2;
-      if (trackingLook || spin || morphing) {
+      if (trackingLook || spin || morphing || draggingRef.current) {
         idleSince = nowMs;
       }
       const minMs = petPaintMinMs({
         spinning: spin != null || wantSpinRef.current !== playedSpinRef.current,
         morphing,
-        trackingLook,
+        trackingLook: trackingLook || draggingRef.current,
         idleMs: nowMs - idleSince,
       });
       if (lastPaint && ms - lastPaint < minMs) {

--- a/src/components/pet/petMark.guard.test.ts
+++ b/src/components/pet/petMark.guard.test.ts
@@ -16,10 +16,11 @@ describe("PetMark long-run paint", () => {
     expect(src).toContain("pet://cursor");
   });
 
-  it("mirrors the face with CSS scaleX while dragging on the right half", () => {
-    expect(src).toContain("petShouldMirrorFace");
+  it("mirrors the face from Host overlay position, not window.screenX", () => {
+    expect(src).toContain("petReadOverlayFrame");
+    expect(src).toContain("petShouldMirrorFromOverlay");
     expect(src).toContain('scaleX(-1)');
-    expect(src).toContain("window.screenX");
+    expect(src).toContain("onMoved");
     expect(src).toContain("draggingRef.current");
   });
 });

--- a/src/components/pet/petMark.guard.test.ts
+++ b/src/components/pet/petMark.guard.test.ts
@@ -15,4 +15,11 @@ describe("PetMark long-run paint", () => {
     expect(src).toContain("!restOnlyRef.current");
     expect(src).toContain("pet://cursor");
   });
+
+  it("mirrors the face with CSS scaleX while dragging on the right half", () => {
+    expect(src).toContain("petShouldMirrorFace");
+    expect(src).toContain('scaleX(-1)');
+    expect(src).toContain("window.screenX");
+    expect(src).toContain("draggingRef.current");
+  });
 });

--- a/src/lib/pet/index.ts
+++ b/src/lib/pet/index.ts
@@ -147,6 +147,7 @@ export {
   petMarkScreenCenter,
   petNormXOnWorkArea,
   petShouldMirrorFace,
+  petShouldMirrorFromOverlay,
 } from "./petFaceMirror";
 
 export {

--- a/src/lib/pet/index.ts
+++ b/src/lib/pet/index.ts
@@ -144,6 +144,12 @@ export {
 } from "./petMarkPaint";
 
 export {
+  petMarkScreenCenter,
+  petNormXOnWorkArea,
+  petShouldMirrorFace,
+} from "./petFaceMirror";
+
+export {
   PET_HOVER_LISTEN_MS,
   PET_REST_MOODS,
   isPetRestMood,

--- a/src/lib/pet/petFaceMirror.test.ts
+++ b/src/lib/pet/petFaceMirror.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  petNormXOnWorkArea,
+  petShouldMirrorFace,
+  petMarkScreenCenter,
+} from "./petFaceMirror";
+
+describe("petShouldMirrorFace", () => {
+  it("keeps the authored face on the left half (bottom-left)", () => {
+    expect(petShouldMirrorFace(0)).toBe(false);
+    expect(petShouldMirrorFace(0.5)).toBe(false);
+  });
+
+  it("mirrors on the right half (bottom-right)", () => {
+    expect(petShouldMirrorFace(0.51)).toBe(true);
+    expect(petShouldMirrorFace(1)).toBe(true);
+  });
+
+  it("does not mirror invalid positions", () => {
+    expect(petShouldMirrorFace(Number.NaN)).toBe(false);
+  });
+});
+
+describe("petNormXOnWorkArea", () => {
+  it("maps the mark centre onto 0..1 across the work area", () => {
+    expect(petNormXOnWorkArea({ cx: 100, left: 100, width: 1000 })).toBe(0);
+    expect(petNormXOnWorkArea({ cx: 1100, left: 100, width: 1000 })).toBe(1);
+    expect(petNormXOnWorkArea({ cx: 600, left: 100, width: 1000 })).toBe(0.5);
+  });
+
+  it("returns 0 when the work area has no width", () => {
+    expect(petNormXOnWorkArea({ cx: 10, left: 0, width: 0 })).toBe(0);
+  });
+});
+
+describe("petMarkScreenCenter", () => {
+  it("adds the CSS box onto the window screen origin", () => {
+    expect(
+      petMarkScreenCenter({
+        screenX: 200,
+        screenY: 40,
+        rect: { left: 10, top: 20, width: 100, height: 80 },
+      }),
+    ).toEqual({ cx: 260, cy: 100 });
+  });
+});

--- a/src/lib/pet/petFaceMirror.test.ts
+++ b/src/lib/pet/petFaceMirror.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   petNormXOnWorkArea,
   petShouldMirrorFace,
+  petShouldMirrorFromOverlay,
   petMarkScreenCenter,
 } from "./petFaceMirror";
 
@@ -30,6 +31,32 @@ describe("petNormXOnWorkArea", () => {
 
   it("returns 0 when the work area has no width", () => {
     expect(petNormXOnWorkArea({ cx: 10, left: 0, width: 0 })).toBe(0);
+  });
+});
+
+describe("petShouldMirrorFromOverlay", () => {
+  const work = { workX: 0, workW: 1440 };
+
+  it("does not flip a mark on the left of the work area", () => {
+    expect(
+      petShouldMirrorFromOverlay({
+        winX: 24,
+        markLeft: 16,
+        markWidth: 128,
+        ...work,
+      }),
+    ).toBe(false);
+  });
+
+  it("flips a mark on the right of the work area", () => {
+    expect(
+      petShouldMirrorFromOverlay({
+        winX: 1200,
+        markLeft: 16,
+        markWidth: 128,
+        ...work,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/lib/pet/petFaceMirror.ts
+++ b/src/lib/pet/petFaceMirror.ts
@@ -1,0 +1,30 @@
+/**
+ * Horizontal face flip when the overlay sits on the right of the work area.
+ * Bottom-left keeps the authored ¾-right look; bottom-right is a CSS scaleX(-1).
+ */
+
+import { clamp } from "./bloub/math";
+
+export function petShouldMirrorFace(nx: number): boolean {
+  return Number.isFinite(nx) && nx > 0.5;
+}
+
+export function petNormXOnWorkArea(input: {
+  cx: number;
+  left: number;
+  width: number;
+}): number {
+  if (!(input.width > 0) || !Number.isFinite(input.cx)) return 0;
+  return clamp((input.cx - input.left) / input.width);
+}
+
+export function petMarkScreenCenter(input: {
+  screenX: number;
+  screenY: number;
+  rect: { left: number; top: number; width: number; height: number };
+}): { cx: number; cy: number } {
+  return {
+    cx: input.screenX + input.rect.left + input.rect.width / 2,
+    cy: input.screenY + input.rect.top + input.rect.height / 2,
+  };
+}

--- a/src/lib/pet/petFaceMirror.ts
+++ b/src/lib/pet/petFaceMirror.ts
@@ -28,3 +28,21 @@ export function petMarkScreenCenter(input: {
     cy: input.screenY + input.rect.top + input.rect.height / 2,
   };
 }
+
+/** Overlay window origin is Host outerPosition (logical CSS), not `window.screenX`. */
+export function petShouldMirrorFromOverlay(input: {
+  winX: number;
+  markLeft: number;
+  markWidth: number;
+  workX: number;
+  workW: number;
+}): boolean {
+  const cx = input.winX + input.markLeft + input.markWidth / 2;
+  return petShouldMirrorFace(
+    petNormXOnWorkArea({
+      cx,
+      left: input.workX,
+      width: input.workW,
+    }),
+  );
+}


### PR DESCRIPTION
Desktop pet on the **right half of the screen work area** is `scaleX(-1)` so the ¾ face looks toward centre. Left half stays the authored look.

Uses Host overlay `outerPosition` + monitor work area (not `window.screenX`, which is 0 in the pet webview). Flip follows while dragging.

## Checklist
- [x] vitest: petFaceMirror + petMark.guard
- [x] CHANGELOG Unreleased (en + zh)
- [x] No new in-app copy / native dialogs / secrets