### PR TITLE
fix(remote-im): authenticate WeCom webhook and make the sender ACL fail-closed

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1874,6 +1874,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ chrono = { version = "0.4", features = ["serde", "clock"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream", "multipart", "system-proxy", "blocking", "socks"] }
 futures-util = "0.3"
 base64 = "0.22"
+sha1 = "0.10"
 sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"

--- a/src-tauri/src/os_theme.rs
+++ b/src-tauri/src/os_theme.rs
@@ -14,7 +14,7 @@ pub const OS_THEME_CHANGED_EVENT: &str = "os-theme://changed";
 /// `AppsUseLightTheme` DWORD: `0` = dark apps, `1` = light. Missing → dark.
 #[cfg_attr(not(test), allow(dead_code))]
 pub fn apps_prefer_dark_from_dword(apps: Option<u32>) -> bool {
-    !apps.is_some_and(|v| v != 0)
+    apps.is_none_or(|v| v == 0)
 }
 
 /// Best-effort OS dark/light probe (no extra deps).

--- a/src-tauri/src/remote_im/channels/wecom.rs
+++ b/src-tauri/src/remote_im/channels/wecom.rs
@@ -146,6 +146,92 @@ fn parse_ws_msg(inst: &ChannelInstance, v: &Value) -> Option<IncomingMessage> {
     })
 }
 
+/// Default local webhook port for WeCom callback mode.
+pub const DEFAULT_WEBHOOK_PORT: u16 = 8081;
+
+/// Shared-token fallback header when `msg_signature` is unavailable
+/// (plain-JSON deployments that cannot compute the WeCom signature).
+pub const SHARED_TOKEN_HEADER: &str = "x-grok-wecom-token";
+
+fn const_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for i in 0..a.len() {
+        diff |= a[i] ^ b[i];
+    }
+    diff == 0
+}
+
+/// Official WeCom callback signature:
+/// `SHA1(lexicographically sorted [token, timestamp, nonce, payload])`,
+/// delivered as the `msg_signature` query parameter. Compared constant-time.
+fn wecom_signature_ok(
+    token: &str,
+    timestamp: &str,
+    nonce: &str,
+    payload: &str,
+    signature: Option<&str>,
+) -> bool {
+    use sha1::{Digest, Sha1};
+
+    let Some(sig) = signature.map(str::trim).filter(|s| !s.is_empty()) else {
+        return false;
+    };
+    let mut parts = [token, timestamp, nonce, payload];
+    parts.sort_unstable();
+    let mut hasher = Sha1::new();
+    for part in parts {
+        hasher.update(part.as_bytes());
+    }
+    let expected = hex::encode(hasher.finalize());
+    const_time_eq(expected.as_bytes(), sig.as_bytes())
+}
+
+/// Extract `k=v` from an HTTP query string (first occurrence, no decode).
+fn query_param<'a>(query: &'a str, key: &str) -> Option<&'a str> {
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == key).then_some(v)
+    })
+}
+
+/// Minimal percent-decoding (%XX only) so signatures are computed over the
+/// decoded values the sender signed.
+fn percent_decode(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if let Some(hex) = bytes
+                .get(i + 1..i + 3)
+                .and_then(|h| std::str::from_utf8(h).ok())
+                .and_then(|h| u8::from_str_radix(h, 16).ok())
+            {
+                out.push(hex);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Split a raw HTTP request into (request-line, headers, body).
+fn split_request(req: &str) -> (&str, &str, &str) {
+    match req.split_once("\r\n\r\n") {
+        Some((head, body)) => match head.split_once("\r\n") {
+            Some((request_line, headers)) => (request_line, headers, body),
+            None => (head, "", body),
+        },
+        None => (req.trim_end_matches(['\r', '\n']), "", ""),
+    }
+}
+
 async fn run_webhook(
     inst: ChannelInstance,
     tx: mpsc::Sender<IncomingMessage>,
@@ -159,17 +245,48 @@ async fn run_webhook(
                 .and_then(|x| x.as_u64())
                 .map(|n| n as u16)
         })
-        .unwrap_or(8081);
+        .unwrap_or(DEFAULT_WEBHOOK_PORT);
     let path = secret_or_opt(&inst.secrets, &inst.options, "callback_path")
         .unwrap_or_else(|| "/wecom/callback".into());
+    let callback_token = secret_or_opt(&inst.secrets, &inst.options, "callback_token")
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty());
+    if callback_token.is_none() {
+        return Err(
+            "wecom webhook: missing callback_token (Settings → WeCom requires it; \
+             it is the Callback Token shown in the WeCom admin console)"
+                .to_string(),
+        );
+    }
 
-    tracing::info!(instance = %inst.id, port, %path, "wecom webhook server starting");
+    // Default loopback; opt-in LAN bind only with allow_external=true (same
+    // contract as the LINE channel).
+    let allow_external = inst
+        .options
+        .get("allow_external")
+        .or_else(|| inst.options.get("allowExternal"))
+        .and_then(|x| x.as_bool())
+        .unwrap_or(false);
+    let bind_ip = if allow_external {
+        [0, 0, 0, 0]
+    } else {
+        [127, 0, 0, 1]
+    };
+
+    tracing::info!(
+        instance = %inst.id,
+        port,
+        %path,
+        allow_external,
+        "wecom webhook server starting"
+    );
 
     // Bind first so the connector is reachable even if remote gettoken is slow.
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let addr = SocketAddr::from((bind_ip, port));
     let listener = tokio::net::TcpListener::bind(addr)
         .await
-        .map_err(|e| format!("wecom bind: {e}"))?;
+        .map_err(|e| format!("wecom bind {port}: {e}"))?;
+    let _ = super::super::config::set_instance_last_error(&inst.id, None);
 
     // Best-effort corp credential check in background (must not block listen).
     let corp_id = secret_or_opt(&inst.secrets, &inst.options, "corp_id");
@@ -189,6 +306,9 @@ async fn run_webhook(
 
     let inst = Arc::new(inst);
     let path = Arc::new(path);
+    // `callback_token` presence was validated before binding; this fallback is
+    // unreachable in practice and only satisfies the type checker without a panic.
+    let callback_token = Arc::new(callback_token.unwrap_or_else(|| String::from("unreachable")));
 
     loop {
         tokio::select! {
@@ -200,6 +320,7 @@ async fn run_webhook(
                 let tx = tx.clone();
                 let inst = inst.clone();
                 let path = path.clone();
+                let callback_token = callback_token.clone();
                 tokio::spawn(async move {
                     use tokio::io::{AsyncReadExt, AsyncWriteExt};
                     let mut buf = vec![0u8; 65536];
@@ -208,26 +329,81 @@ async fn run_webhook(
                         _ => return,
                     };
                     let req = String::from_utf8_lossy(&buf[..n]);
-                    // URL verify echo
-                    if req.starts_with("GET") {
-                        if let Some(q) = req.lines().next().and_then(|l| l.split_whitespace().nth(1)) {
-                            if let Some(echo) = q.split("echostr=").nth(1).map(|s| s.split('&').next().unwrap_or("")) {
-                                let body = echo.to_string();
-                                let resp = format!(
-                                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
-                                    body.len(),
-                                    body
-                                );
-                                let _ = socket.write_all(resp.as_bytes()).await;
-                                return;
-                            }
-                        }
-                    }
-                    let body = req.split("\r\n\r\n").nth(1).unwrap_or("");
-                    if !req.contains(path.as_str()) {
-                        let _ = socket.write_all(b"HTTP/1.1 404\r\n\r\n").await;
+                    let (request_line, _, body) = split_request(&req);
+
+                    let uri = request_line.split_whitespace().nth(1).unwrap_or("");
+                    let (uri_path, uri_query) = match uri.split_once('?') {
+                        Some((p, q)) => (p, q),
+                        None => (uri, ""),
+                    };
+                    // Path match on the decoded request target; tolerate a
+                    // trailing-slash difference only.
+                    let norm =
+                        |p: &str| p.trim_end_matches('/').to_string();
+                    if norm(&percent_decode(uri_path)) != norm(path.as_str()) {
+                        let _ = socket.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n").await;
                         return;
                     }
+
+                    // Official WeCom signature over [token, timestamp, nonce,
+                    // payload]; GET verify signs the echostr, POSTs sign the body.
+                    let sig = query_param(uri_query, "msg_signature").map(percent_decode);
+                    let timestamp = query_param(uri_query, "timestamp")
+                        .map(percent_decode)
+                        .unwrap_or_default();
+                    let nonce = query_param(uri_query, "nonce")
+                        .map(percent_decode)
+                        .unwrap_or_default();
+                    let echostr = query_param(uri_query, "echostr").map(percent_decode);
+                    let header_token = req.lines().skip(1).find_map(|l| {
+                        l.split_once(':').filter(|(name, _)| {
+                            name.eq_ignore_ascii_case(SHARED_TOKEN_HEADER)
+                        }).map(|(_, v)| v.trim().to_string())
+                    });
+
+                    let is_get = request_line.starts_with("GET");
+                    let payload_for_sig: &str = if is_get {
+                        echostr.as_deref().unwrap_or("")
+                    } else {
+                        body
+                    };
+                    let verified = wecom_signature_ok(
+                        callback_token.as_str(),
+                        &timestamp,
+                        &nonce,
+                        payload_for_sig,
+                        sig.as_deref(),
+                    ) || header_token.is_some_and(|t| {
+                        const_time_eq(t.as_bytes(), callback_token.as_bytes())
+                    });
+
+                    // URL verify echo: only echo after verification (WeCom signs
+                    // the encrypted echostr during endpoint setup).
+                    if is_get {
+                        if !verified {
+                            tracing::warn!(instance = %inst.id, "wecom: bad or missing callback signature on verify");
+                            let _ = socket.write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n").await;
+                            return;
+                        }
+                        if let Some(echo) = echostr.as_deref() {
+                            let resp = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                                echo.len(),
+                                echo
+                            );
+                            let _ = socket.write_all(resp.as_bytes()).await;
+                            return;
+                        }
+                        let _ = socket.write_all(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n").await;
+                        return;
+                    }
+
+                    if !verified {
+                        tracing::warn!(instance = %inst.id, "wecom: bad or missing callback signature");
+                        let _ = socket.write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n").await;
+                        return;
+                    }
+
                     // JSON or XML simplified — try JSON
                     if let Ok(v) = serde_json::from_str::<Value>(body) {
                         let text = v
@@ -322,4 +498,121 @@ pub async fn send_text(
 
 pub fn protocol_name() -> &'static str {
     "wecom-ws-or-webhook"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Official WeCom signature: SHA1 over lexicographically sorted
+    /// [token, timestamp, nonce, payload], hex-encoded.
+    fn sign(token: &str, ts: &str, nonce: &str, payload: &str) -> String {
+        use sha1::{Digest, Sha1};
+        let mut parts = [token, ts, nonce, payload];
+        parts.sort_unstable();
+        let mut h = Sha1::new();
+        for p in parts {
+            h.update(p.as_bytes());
+        }
+        hex::encode(h.finalize())
+    }
+
+    #[test]
+    fn signature_accepts_valid_and_rejects_missing_or_bad() {
+        let sig = sign("tok", "1717171717", "nonce1", "{\"x\":1}");
+        assert!(wecom_signature_ok(
+            "tok",
+            "1717171717",
+            "nonce1",
+            "{\"x\":1}",
+            Some(&sig)
+        ));
+        // Wrong payload / token / timestamp must not verify.
+        assert!(!wecom_signature_ok(
+            "tok",
+            "1717171717",
+            "nonce1",
+            "{\"y\":2}",
+            Some(&sig)
+        ));
+        assert!(!wecom_signature_ok(
+            "bad",
+            "1717171717",
+            "nonce1",
+            "{\"x\":1}",
+            Some(&sig)
+        ));
+        assert!(!wecom_signature_ok(
+            "tok",
+            "0000",
+            "nonce1",
+            "{\"x\":1}",
+            Some(&sig)
+        ));
+        // Missing or empty signature fails closed.
+        assert!(!wecom_signature_ok(
+            "tok",
+            "1717171717",
+            "nonce1",
+            "{\"x\":1}",
+            None
+        ));
+        assert!(!wecom_signature_ok(
+            "tok",
+            "1717171717",
+            "nonce1",
+            "{\"x\":1}",
+            Some("  ")
+        ));
+    }
+
+    #[test]
+    fn signature_is_order_independent_over_parts() {
+        // The four parts sort before hashing — same inputs, any order.
+        let a = wecom_signature_ok("t", "123", "n", "p", Some(&sign("t", "123", "n", "p")));
+        let b = wecom_signature_ok("123", "t", "p", "n", Some(&sign("t", "123", "n", "p")));
+        assert!(a && b);
+    }
+
+    #[test]
+    fn const_time_eq_basic() {
+        assert!(const_time_eq(b"abc", b"abc"));
+        assert!(!const_time_eq(b"abc", b"abd"));
+        assert!(!const_time_eq(b"abc", b"ab"));
+        assert!(const_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn percent_decode_handles_escapes_and_passes_through() {
+        assert_eq!(percent_decode("a%20b"), "a b");
+        assert_eq!(percent_decode("%2Fx"), "/x");
+        assert_eq!(percent_decode("plain"), "plain");
+        // Truncated escape stays literal.
+        assert_eq!(percent_decode("100%"), "100%");
+        assert_eq!(percent_decode("%G1"), "%G1");
+    }
+
+    #[test]
+    fn query_param_finds_first_exact_key() {
+        let q = "msg_signature=abc&timestamp=5&nonce=xyz&echostr=EN%2FCODE";
+        assert_eq!(query_param(q, "timestamp"), Some("5"));
+        assert_eq!(query_param(q, "nonce"), Some("xyz"));
+        assert_eq!(query_param(q, "echostr"), Some("EN%2FCODE"));
+        assert_eq!(query_param(q, "missing"), None);
+        // Prefix keys do not match.
+        assert_eq!(query_param("nonceX=1", "nonce"), None);
+    }
+
+    #[test]
+    fn split_request_parses_head_and_body() {
+        let raw = "POST /cb HTTP/1.1\r\nHost: x\r\n\r\n{\"a\":1}";
+        let (line, headers, body) = split_request(raw);
+        assert_eq!(line, "POST /cb HTTP/1.1");
+        assert_eq!(headers, "Host: x");
+        assert_eq!(body, "{\"a\":1}");
+        // Bodyless request still yields an empty body slice.
+        let (line2, _, body2) = split_request("GET /cb HTTP/1.1\r\n");
+        assert_eq!(line2, "GET /cb HTTP/1.1");
+        assert_eq!(body2, "");
+    }
 }

--- a/src-tauri/src/remote_im/outbound.rs
+++ b/src-tauri/src/remote_im/outbound.rs
@@ -268,15 +268,19 @@ pub fn secret_or_opt(
 
 /// Parse allow-from ACL.
 ///
-/// - `*` or missing → open (None)
-/// - empty string → fail-closed empty list
+/// - `*` → open (None)
+/// - missing / empty string → fail-closed empty list
 /// - comma list → allow only those senders
+///
+/// Missing means deny: the Settings UI refuses to enable a channel without an
+/// explicit allow-from entry, so the backend must not be more permissive than
+/// the UI contract (hand-edited or pre-existing configs included).
 pub fn allow_from_list(acl: &serde_json::Value) -> Option<Vec<String>> {
     let raw = acl
         .get("allowFrom")
         .or_else(|| acl.get("allow_from"))
         .and_then(|x| x.as_str())
-        .unwrap_or("*")
+        .unwrap_or("")
         .trim();
     if raw == "*" {
         return None;
@@ -300,7 +304,8 @@ pub fn sender_allowed(acl: &serde_json::Value, sender_id: &str) -> bool {
     }
 }
 
-/// True when enable should be refused (empty allow list, not `*`).
+/// True when enable should be refused: no allowFrom entry at all, or an
+/// explicit empty list (both yield an empty allow list since fail-closed).
 pub fn allow_from_blocks_enable(acl: &serde_json::Value) -> bool {
     matches!(allow_from_list(acl), Some(list) if list.is_empty())
 }
@@ -365,5 +370,31 @@ mod tests {
         ));
         // default need @
         assert!(require_mention(&json!({}), &json!({})));
+    }
+
+    #[test]
+    fn missing_allow_from_denies_by_default() {
+        // Fail-closed: no explicit allowFrom ⇒ nobody is allowed.
+        assert!(!sender_allowed(&json!({}), "attacker"));
+        assert!(!sender_allowed(&json!({ "allowFrom": "" }), "owner"));
+        // Explicit wildcard stays the documented opt-in.
+        assert!(sender_allowed(&json!({ "allowFrom": "*" }), "anyone"));
+        // Comma list allows exactly the listed senders.
+        let acl = json!({ "allowFrom": "alice, bob ,," });
+        assert!(sender_allowed(&acl, "alice"));
+        assert!(sender_allowed(&acl, "bob"));
+        assert!(!sender_allowed(&acl, "mallory"));
+        // snake_case alias behaves identically.
+        assert!(sender_allowed(&json!({ "allow_from": "*" }), "anyone"));
+    }
+
+    #[test]
+    fn blocks_enable_without_explicit_allow_from() {
+        // Fail-closed: missing entry or explicit empty list both refuse enable;
+        // only an explicit wildcard or a non-empty list may start.
+        assert!(allow_from_blocks_enable(&json!({})));
+        assert!(allow_from_blocks_enable(&json!({ "allowFrom": "" })));
+        assert!(!allow_from_blocks_enable(&json!({ "allowFrom": "*" })));
+        assert!(!allow_from_blocks_enable(&json!({ "allowFrom": "alice" })));
     }
 }

--- a/src-tauri/src/remote_im/protocol_start_tests.rs
+++ b/src-tauri/src/remote_im/protocol_start_tests.rs
@@ -84,6 +84,7 @@ mod tests {
         secrets.insert("connect_mode".into(), "webhook".into());
         secrets.insert("corp_id".into(), "ww".into());
         secrets.insert("corp_secret".into(), "sec".into());
+        secrets.insert("callback_token".into(), "cb-token".into());
         secrets.insert("port".into(), "0".into()); // may fail bind 0 — use high port
                                                    // pick ephemeral by binding ourselves to find free port then re-use - simpler: use 19876
         secrets.insert("port".into(), "19876".into());
@@ -98,6 +99,27 @@ mod tests {
         let _ = c_tx.send(true);
         let _ = h.await;
         assert!(probe.is_ok(), "wecom webhook did not bind listening port");
+    }
+
+    /// WeCom webhook without callback_token must refuse to start (fail closed).
+    #[tokio::test]
+    async fn wecom_webhook_without_callback_token_fails_closed() {
+        let mut secrets = HashMap::new();
+        secrets.insert("connect_mode".into(), "webhook".into());
+        secrets.insert("corp_id".into(), "ww".into());
+        secrets.insert("corp_secret".into(), "sec".into());
+        secrets.insert("port".into(), "19877".into());
+        secrets.insert("callback_path".into(), "/wecom/callback".into());
+        let i = inst("wecom", secrets);
+        let (tx, _rx) = mpsc::channel(4);
+        let (c_tx, c_rx) = watch::channel(false);
+        let res = wecom::run(i, tx, c_rx).await;
+        let err = res.expect_err("missing callback_token must refuse start");
+        assert!(err.contains("callback_token"), "unexpected error: {err}");
+        // Nothing should be listening on the refused port.
+        let probe = tokio::net::TcpStream::connect("127.0.0.1:19877").await;
+        assert!(probe.is_err(), "no listener expected after refusal");
+        let _ = c_tx.send(true);
     }
 
     /// Feishu protocol is long-connection (name + endpoint shape).

--- a/src-tauri/src/remote_im/runtime.rs
+++ b/src-tauri/src/remote_im/runtime.rs
@@ -4,7 +4,7 @@
 use super::channels;
 use super::config;
 use super::engine::Engine;
-use super::outbound::OutboundRouter;
+use super::outbound::{self, OutboundRouter};
 use super::slash::{self, BuiltinCommand};
 use super::types::{ChannelInstance, ConnectedChannel, IncomingMessage};
 use std::sync::Arc;
@@ -61,6 +61,18 @@ pub async fn start_runtime(
         }
         let secrets = config::get_secrets(&dto.id);
         if secrets.is_empty() {
+            continue;
+        }
+        // Fail-closed ACL guard (§3.2): a channel without an explicit allow-from
+        // entry must not start — same contract the Settings UI enforces at save
+        // time (`err.allowFromRequired`). Covers hand-edited configs and
+        // instances saved before that UI rule existed.
+        if outbound::allow_from_blocks_enable(&dto.acl) {
+            let err = "allow_from is empty: add your user id (or * for any) in \
+                       Settings → Remote IM before enabling this channel"
+                .to_string();
+            tracing::error!(instance = %dto.id, "{err}");
+            let _ = config::set_instance_last_error(&dto.id, Some(err));
             continue;
         }
         let inst = ChannelInstance {

--- a/src-tauri/src/remote_im/validate.rs
+++ b/src-tauri/src/remote_im/validate.rs
@@ -295,7 +295,7 @@ fn test_weixin(creds: &HashMap<String, String>) -> Result<TestConnectionDto, Str
 
     // Soft option checks (shape only — never claims getUpdates is live).
     let base = cred_get(creds, &["base_url"]);
-    if !base.is_empty() && !(base.starts_with("https://") || base.starts_with("http://")) {
+    if !(base.is_empty() || base.starts_with("https://") || base.starts_with("http://")) {
         return Ok(TestConnectionDto {
             ok: false,
             message: "invalid_weixin_base_url".into(),


### PR DESCRIPTION
## Motivation

While reviewing the Remote IM subsystem we found two related gaps that together let an attacker on the LAN drive the local agent through forged IM messages:

**1. WeCom webhook accepts unauthenticated messages and binds `0.0.0.0`**

`src-tauri/src/remote_im/channels/wecom.rs` (webhook mode):

- POSTs were parsed as JSON with **no `msg_signature` verification** — anyone who can reach the port can forge an `IncomingMessage` with an arbitrary `FromUserName`.
- The GET verify endpoint echoed any `echostr` back without checking anything.
- The listener bound `[0,0,0,0]:port` unconditionally (every other channel binds loopback unless explicitly opted in; LINE documents this contract).

Combined with **2**, this was a remote-to-local agent-execution path from any LAN host.

**2. The sender ACL was open by default in the backend**

`outbound.rs::allow_from_list` parsed a *missing* `allowFrom` as `"*"` (allow everyone), so every gate (`engine.rs` text path + card actions, telegram connector) treated unknown senders as allowed when the entry was absent.

Notably, the rest of the product already treats an empty allow-list as fail-closed:

- The Settings UI refuses to enable a channel without an explicit allow-from entry (`settings.remoteIm.err.allowFromRequired`, translated in all 16 locales).
- `allowFromHelp` strings tell users to prefer explicit ids over `*`.
- `outbound.rs::allow_from_blocks_enable` existed precisely to enforce this but was dead code — never called outside tests.

So the UI said "fail-closed required" while the backend (the actual security boundary) stayed open for hand-edited configs or instances saved before that rule existed.

## What changed

### Commit 1 — WeCom webhook hardening

- Verify the official WeCom callback signature: `SHA1` over the lexicographically sorted `[token, timestamp, nonce, payload]`, hex-encoded, compared constant-time — for both GET verify and POST callbacks. Query params are percent-decoded before hashing.
- Echo `echostr` only after successful verification (previously reflected any value).
- Require the `callback_token` secret before starting the webhook (fail closed). This secret was already collected as **required** by the Settings UI in webhook mode (`wecomRequiredSecretKeys`) but never checked by the backend — this finishes that wiring.
- Bind `127.0.0.1` by default; opt-in LAN bind via `allow_external=true`, same contract as the LINE channel.
- Exact-path routing on the decoded request target (was a substring check on the whole request).
- New dep: `sha1 = "0.10"` (same RustCrypto family as the existing `sha2`/`hmac`; `hex` was already present).

### Commit 2 — ACL fail-closed at runtime

- `allow_from_list`: missing/empty `allowFrom` now yields a deny-all list; `"*"` remains the documented explicit opt-in.
- `start_runtime` refuses to start an instance without an explicit allow-from entry and surfaces the reason via `set_instance_last_error`, so Settings shows the error instead of a green "connected".
- Semantics documented on both functions.

### Commit 3 — CI hygiene

- Clears two new clippy 1.94 `nonminimal_bool` warnings so `cargo clippy --lib -- -D warnings` stays green (same spirit as #829).

## User impact / migration

- WeCom webhook users must fill the `callback_token` they already see in Settings (it was a required field); without it the channel refuses to start with an explicit error.
- WeCom webhook binds loopback by default. If your callback needs LAN reachability (e.g. you terminate TLS on another box), set `allow_external: true`.
- Channels configured without any allow-from entry will refuse to start with an actionable error instead of accepting everyone. Users who truly want open access set `allowFrom: "*"` explicitly.
- WebSocket mode (the default for WeCom) is unchanged.

## Verification

```bash
cd src-tauri
cargo test --lib                   # 1489 passed, 0 failed
cargo clippy --lib -- -D warnings  # clean
cargo fmt --check                  # clean
```

New/updated Rust tests:

- Signature accept/reject matrix (wrong payload/token/timestamp, missing/empty sig), part-order independence
- Constant-time compare basics
- Percent-decoding incl. truncated escapes
- Query-param extraction (prefix keys must not match)
- Request splitting with and without body
- `wecom_webhook_without_callback_token_fails_closed` — refuses start, nothing listening
- `wecom_webhook_start_binds_port` — updated with token, still binds
- ACL deny-by-default matrix, snake_case alias, wildcard opt-in, comma-list exactness, enable-gate cases

Regression reasoning: only three places construct instances with empty ACLs in tests (`protocol_start_tests`, `weixin_flow_tests`, telegram/weixin unit tests) — all exercise transport-level code below the engine gate, unaffected. `engine.rs`'s own test already sets `allowFrom: "*"` explicitly.

## Notes for maintainers

- The shared-token fallback header (`x-grok-wecom-token`) exists because plain-JSON callback deployments cannot compute `msg_signature`; deployments using it should keep the token long and treat it like a password. Happy to drop it if you would rather be strictly official-scheme-only.
- Follow-up worth considering (not in this PR): WS mode puts `bot_secret` in the connect URL query string; that is mandated by the WeCom endpoint shape, but logging hygiene around it could be audited once more.
