### PR TITLE
perf(chat): keep long-transcript scroll off the urgent lane (#853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,11 @@ See `docs/llm-wiki/release.md`.
 **中文 · 变更**
 
 ### Fixed
+- **Long chat transcript scroll no longer hitches on Worked-for blocks or lift-off (#853)**: Follow-up to #842. Virtual-window growth that still covers the viewport commits in the background (`startTransition`) and at most 3 rows per frame; collapsed tool steps skip `toolExpandBody` until opened; scroll settle uses velocity + a 160ms stillness floor so touchpad lift-off is not treated as a stop; hover is disabled while moving; pin snap restores the pre-commit distance from the bottom so expanding overscan does not bounce.
 
 **中文 · 修复**
+- **长对话滑过「Worked for …」和抬手时不再卡顿（#853）**：#842 的后续。视口已被覆盖时的窗口扩张走后台提交，每帧最多挂 3 行；折叠的 tool 步骤在展开前不算 `toolExpandBody`；settle 用速度 + 160ms 静止下限，触控板抬手不再被当成停下；滑动中关掉 hover；贴底 snap 恢复 commit 前的离底距离，扩张 overscan 时不再弹跳。
+
 
 ## [0.2.25] - 2026-08-23
 

--- a/src/components/FilePathCard.tsx
+++ b/src/components/FilePathCard.tsx
@@ -540,7 +540,7 @@ export function FilePathCard({
 
   return (
     <>
-      <div
+      <span
         className={
           "file-path-card" +
           (isUrl ? " file-path-card--url" : "") +
@@ -572,7 +572,7 @@ export function FilePathCard({
             <span className="file-path-card__name">{name}</span>
           </span>
         </button>
-      </div>
+      </span>
 
       <ContextMenu
         open={!!menu}

--- a/src/components/lobe-chat/BackBottom.tsx
+++ b/src/components/lobe-chat/BackBottom.tsx
@@ -1,22 +1,40 @@
-import { memo } from "react";
+import { memo, useEffect, useState } from "react";
 import { IconChevronDown } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export const BackBottom = memo(function BackBottom({
   visible,
+  subscribeVisible,
+  alwaysVisible,
   onClick,
   label,
 }: {
-  visible: boolean;
+  visible?: boolean;
+  subscribeVisible?: (cb: (val: boolean) => void) => () => void;
+  alwaysVisible?: boolean;
   onClick: () => void;
   label: string;
 }) {
+  const [internalVisible, setInternalVisible] = useState(!!visible);
+
+  useEffect(() => {
+    if (!subscribeVisible) {
+      setInternalVisible(!!visible);
+      return;
+    }
+    return subscribeVisible((val) => {
+      setInternalVisible(val);
+    });
+  }, [subscribeVisible, visible]);
+
+  const isVisible = alwaysVisible || internalVisible;
+
   return (
     <Tip label={label}>
       <button
         type="button"
-        className={cn("lobe-chat-back-bottom", visible && "is-visible")}
+        className={cn("lobe-chat-back-bottom", isVisible && "is-visible")}
         aria-label={label}
         onClick={onClick}
       >

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -14,7 +14,6 @@ import {
   useRef,
   useState,
   type ReactNode,
-  type UIEvent,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import type { Locale } from "@/i18n";
@@ -25,7 +24,6 @@ import {
   lastRegenerableAssistantId,
   messageSegments,
   isTurnPromptMessage,
-  userPromptIndexContaining,
   weaveToolsIntoAssistantSegments,
   type ChatMessage,
   type MessageToolSegment,
@@ -166,7 +164,6 @@ import { Spinner } from "@/components/ui/spinner";
 import {
   BACK_BOTTOM_ALWAYS_CHANGE_EVENT,
   loadBackBottomAlwaysPref,
-  shouldShowBackBottom,
 } from "@/lib/backBottomAlwaysPref";
 import {
   TOOL_STEPS_AUTO_COLLAPSE_CHANGE_EVENT,
@@ -189,7 +186,6 @@ type AttachLabels = {
   addToComposer: string;
   remove: string;
 };
-
 
 /** Keep path-map object identity when tool paths did not change (stream text growth). */
 function useStableSessionPathMap(
@@ -643,6 +639,7 @@ const UserMessageBody = memo(function UserMessageBody({
   );
 });
 
+
 export interface ConversationThreadProps {
   locale: Locale;
   messages: ChatMessage[];
@@ -983,16 +980,23 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
   latestContinuableEndId,
 }: TranscriptMessageRowProps) {
   void _timeTick;
-  const renderStart = performance.now();
+  const renderStartRef = useRef<number | null>(null);
+  if (import.meta.env.DEV && renderStartRef.current === null) {
+    renderStartRef.current = performance.now();
+  }
   useEffect(() => {
-    const dur = performance.now() - renderStart;
-    scrollPerfDebug.recordRowMount(
-      m.id,
-      msgIndex,
-      m.role,
-      dur,
-      m.content?.length ?? 0,
-    );
+    if (import.meta.env.DEV && renderStartRef.current !== null) {
+      const dur = performance.now() - renderStartRef.current;
+      // StrictMode re-runs mount effects; null the ref so we log once.
+      renderStartRef.current = null;
+      scrollPerfDebug.recordRowMount(
+        m.id,
+        msgIndex,
+        m.role,
+        dur,
+        m.content?.length ?? 0,
+      );
+    }
   }, [m.id, msgIndex, m.role]);
 
   const wrap = (node: ReactNode) =>
@@ -1435,9 +1439,13 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
   const isNodeFocus = focusMessageId === m.id;
   // Phase projection: thought+tools collapse when phase ends (content
   // / next thought), not only when the full answer is done.
-  const timelineUnits = buildAssistantTimeline(segs, {
-    streaming: !!m.streaming,
-  });
+  const timelineUnits = useMemo(
+    () =>
+      buildAssistantTimeline(segs, {
+        streaming: !!m.streaming,
+      }),
+    [segs, m.streaming],
+  );
   // Live chrome follows the *current* episode (trailing thought / phase),
   // not “this message already has some body text”. Grok 4.x think→tool
   // loops keep reasoning after the first status sentence.
@@ -1542,7 +1550,7 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
                     ? unit.texts
                     : [unit.text];
                 const joined = texts
-                  .map((t) => t.trim())
+                  .map((t: string) => t.trim())
                   .filter(Boolean)
                   .join("\n\n");
                 const streaming = unit.streaming;
@@ -1945,10 +1953,9 @@ export function ConversationThread({
   const {
     viewportRef: scrollRef,
     contentRef,
-    onScroll: onStickScroll,
     scrollToBottom,
     isPinnedRef,
-    showBack,
+    subscribeShowBack,
   } = useStickToBottom({
     conversationKey: sessionKey ?? "chat",
     forceStickKey,
@@ -1967,7 +1974,6 @@ export function ConversationThread({
     return () =>
       window.removeEventListener(BACK_BOTTOM_ALWAYS_CHANGE_EVENT, onPref);
   }, []);
-  const backBottomVisible = shouldShowBackBottom(backBottomAlways, showBack);
 
   /** Finished tool steps start collapsed when true (default). */
   const [toolStepsAutoCollapse, setToolStepsAutoCollapse] = useState(() =>
@@ -2245,15 +2251,6 @@ export function ConversationThread({
     if (performance.now() < navLockUntilRef.current) return;
     railCursorRef.current = id;
   }, []);
-
-  const onScroll = useCallback(
-    (e: UIEvent<HTMLDivElement>) => {
-      scrollPerfDebug.recordScrollStart();
-      onStickScroll(e);
-      // Do NOT setActiveNodeId here — MessageNodeRail owns free-scroll highlight (#280).
-    },
-    [onStickScroll],
-  );
 
   const applyScrollToNodeDom = useCallback(
     (node: SessionMessageNode, attempt = 0) => {
@@ -2637,6 +2634,15 @@ export function ConversationThread({
     turnBusy,
   ]);
 
+  const estimateCacheRef = useRef<
+    Map<string, { len: number; atts: number; h: number }>
+  >(new Map());
+
+  // Invalidate estimate cache on session key change
+  useEffect(() => {
+    estimateCacheRef.current.clear();
+  }, [sessionKey]);
+
   const getEstimateHeight = useCallback(
     (i: number) => {
       const m = transcriptMessages[i];
@@ -2650,8 +2656,19 @@ export function ConversationThread({
           role: "tool",
         });
       }
+
       const body = m.content || "";
       const atts = m.attachments ?? [];
+      const cached = estimateCacheRef.current.get(m.id);
+      if (
+        cached &&
+        cached.len === body.length &&
+        cached.atts === atts.length &&
+        !m.streaming
+      ) {
+        return cached.h;
+      }
+
       const imageFromAtts = atts.filter(
         (a) => !a.isDir && isImagePath(a.path),
       ).length;
@@ -2698,8 +2715,15 @@ export function ConversationThread({
         m.role === "user" && shouldFoldUserMessage(body)
           ? USER_MSG_PREVIEW_CHARS
           : body.length;
-      return estimateChatRowHeight({
+      const toolCount = m.segments
+        ? m.segments.filter((s) => s.kind === "tool").length
+        : m.toolCallId
+          ? 1
+          : 0;
+      const est = estimateChatRowHeight({
         contentLength: effectiveContentLength,
+        rawContent: body,
+        toolCount,
         thoughtLength: m.thought?.length ?? 0,
         role: m.role,
         attachmentCount,
@@ -2707,8 +2731,21 @@ export function ConversationThread({
         hasVideoCard,
         collapsed: collapsedTool,
       });
+
+      if (!m.streaming) {
+        if (estimateCacheRef.current.size > 500) {
+          const firstKey = estimateCacheRef.current.keys().next().value;
+          if (firstKey) estimateCacheRef.current.delete(firstKey);
+        }
+        estimateCacheRef.current.set(m.id, {
+          len: body.length,
+          atts: atts.length,
+          h: est,
+        });
+      }
+      return est;
     },
-    [transcriptMessages, standaloneToolGroups],
+    [transcriptMessages, standaloneToolGroups, wovenMessages],
   );
 
   const {
@@ -2727,6 +2764,20 @@ export function ConversationThread({
     conversationKey: sessionKey ?? "chat",
     forceIndices: forceVirtualIndices,
   });
+
+  const parentPromptIndexMap = useMemo(() => {
+    const map = new Map<string, number>();
+    let lastPrompt = -1;
+    let idx = -1;
+    for (const m of messages) {
+      if (isTurnPromptMessage(m)) {
+        idx += 1;
+        lastPrompt = idx;
+      }
+      map.set(m.id, lastPrompt);
+    }
+    return map;
+  }, [messages]);
 
   const visibleMessages = useMemo(() => {
     if (!virtualized) {
@@ -2751,7 +2802,6 @@ export function ConversationThread({
       <div
         ref={scrollRef}
         className="lobe-chat__scroll"
-        onScroll={onScroll}
         onContextMenu={onTranscriptContextMenu}
       >
         <div ref={contentRef} className="lobe-chat__inner">
@@ -2816,7 +2866,7 @@ export function ConversationThread({
                   sessionState === "streaming" ||
                   sessionState === "awaiting_permission",
                 canRewindSession,
-                parentPromptIndex: userPromptIndexContaining(messages, m.id),
+                parentPromptIndex: parentPromptIndexMap.get(m.id) ?? -1,
               })}
               regenerableAssistantId={regenerableAssistantId}
               regenerateModels={regenerateModels}
@@ -2920,7 +2970,8 @@ export function ConversationThread({
       />
 
       <BackBottom
-        visible={backBottomVisible}
+        subscribeVisible={subscribeShowBack}
+        alwaysVisible={backBottomAlways}
         label={tr("chat.scrollBottom")}
         onClick={() => scrollToBottom("smooth")}
       />

--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -241,22 +241,13 @@ export function getMarkdownFileLabels(locale: Locale): FilePathCardLabels {
   return cached;
 }
 
-const StaticMarkdownBody = memo(function StaticMarkdownBody({
-  source,
-  components,
-}: {
-  source: string;
-  components: Components;
-}) {
-  return (
-    <ReactMarkdown
-      remarkPlugins={MARKDOWN_CHAT_REMARK_PLUGINS}
-      components={components}
-    >
-      {source}
-    </ReactMarkdown>
-  );
-});
+function isSimplePlainText(text: string): boolean {
+  if (!text || text.length > 500) return false;
+  if (/[\n#*_`\[\]|~<>]|^\s*[-*+]\s|^\s*\d+\.\s/m.test(text)) {
+    return false;
+  }
+  return true;
+}
 
 export const MarkdownChat = memo(function MarkdownChat({
   children,
@@ -692,6 +683,8 @@ export const MarkdownChat = memo(function MarkdownChat({
     tr,
   ]);
 
+  const isPlain = !streaming && !qFind && isSimplePlainText(painted);
+
   return (
     <div
       className={cn(
@@ -701,15 +694,15 @@ export const MarkdownChat = memo(function MarkdownChat({
         className,
       )}
     >
-      {streaming ? (
+      {isPlain ? (
+        <p>{painted}</p>
+      ) : (
         <ReactMarkdown
           remarkPlugins={MARKDOWN_CHAT_REMARK_PLUGINS}
           components={components}
         >
           {painted}
         </ReactMarkdown>
-      ) : (
-        <StaticMarkdownBody source={painted} components={components} />
       )}
     </div>
   );

--- a/src/components/lobe-chat/MessageNodeRail.tsx
+++ b/src/components/lobe-chat/MessageNodeRail.tsx
@@ -21,7 +21,6 @@ import type { SessionMessageNode } from "@/lib/sessionMessageNodes";
 import {
   estimateMessageIndexAtY,
   nearestNodeIdFromPaintList,
-  pickActiveNodeIdFromRects,
 } from "@/lib/sessionMessageNodes";
 import type { ChatMessage } from "@/lib/session";
 import { cn } from "@/lib/utils";
@@ -105,9 +104,9 @@ export function MessageNodeRail({
 
   const nodeIdSet = useMemo(() => new Set(nodes.map((n) => n.id)), [nodes]);
 
-  // Keep the active tick roughly in view inside a long rail.
+  // Keep the active tick roughly in view inside a long rail (programmatic jumps only, skip on free-scroll to avoid layout thrashing).
   useEffect(() => {
-    if (activeIndex < 0 || !listRef.current) return;
+    if (activeIndex < 0 || !listRef.current || scrollActiveId != null) return;
     const list = listRef.current;
     const tick = list.querySelector(
       `[data-node-id="${CSS.escape(nodes[activeIndex]!.id)}"]`,
@@ -121,9 +120,9 @@ export function MessageNodeRail({
     if (tickTop < viewTop || tickBottom > viewBottom) {
       tick.scrollIntoView({ block: "nearest", behavior: "auto" });
     }
-  }, [activeIndex, nodes]);
+  }, [activeIndex, nodes, scrollActiveId]);
 
-  // Free-scroll highlight: rAF throttle + one querySelectorAll per frame.
+  // Free-scroll highlight: rAF throttle + pure numerical index calculation on hot scroll path.
   useEffect(() => {
     const viewport = scrollParentRef?.current;
     if (!viewport || nodes.length < 2) return;
@@ -138,30 +137,19 @@ export function MessageNodeRail({
       }
       const t0 = performance.now();
 
-      const viewportRect = viewport.getBoundingClientRect();
-      const focusY = viewportRect.top + viewport.clientHeight * 0.28;
+      let bestId: string | null = null;
 
-      // Single pass over mounted message rows (virtual window only).
-      const mounted = viewport.querySelectorAll<HTMLElement>("[data-message-id]");
-      const rects: { id: string; top: number; bottom: number }[] = [];
-      for (const row of mounted) {
-        const id = row.getAttribute("data-message-id");
-        if (!id || !nodeIdSet.has(id)) continue;
-        const r = row.getBoundingClientRect();
-        rects.push({ id, top: r.top, bottom: r.bottom });
-      }
-
-      let bestId = pickActiveNodeIdFromRects(rects, focusY);
-
-      if (!bestId && messages && messages.length > 0) {
+      // Fast path: pure mathematical index lookup from scrollTop (0 forced reflows)
+      if (messages && messages.length > 0) {
         const y = viewport.scrollTop + viewport.clientHeight * 0.28;
         const msgIdx = estimateMessageIndexAtY(messages, y);
-        // Id walk on the paint list — not journal messageIndex (filtered lists).
         bestId = nearestNodeIdFromPaintList(messages, nodes, msgIdx);
       }
 
-      const syncDuration = performance.now() - t0;
-      scrollPerfDebug.recordNodeRailSyncTime(syncDuration, mounted.length);
+      if (import.meta.env.DEV) {
+        const syncDuration = performance.now() - t0;
+        scrollPerfDebug.recordNodeRailSyncTime(syncDuration, 0);
+      }
 
       if (bestId) {
         setScrollActiveId((prev) => {

--- a/src/components/lobe-chat/TimelinePhaseBlock.tsx
+++ b/src/components/lobe-chat/TimelinePhaseBlock.tsx
@@ -50,6 +50,7 @@ import {
 import {
   resolveToolPrimaryLabel,
   toolExpandBody,
+  toolExpandHasBody,
   type ToolDisplayKind,
 } from "@/lib/toolDisplay";
 import {
@@ -313,16 +314,6 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
     step.type === "web-search" ? step.resultDomains : undefined;
 
   const expandTool = step.type === "tool" ? step.tool : null;
-  const expand = expandTool
-    ? toolExpandBody(expandTool, failed)
-    : {
-        failHint: "",
-        failHintShort: "",
-        detailTail: "",
-        outputBody: "",
-        command: "",
-        hasBody: false,
-      };
   // An explore-group is always expandable: its body is the child step list.
   // A thought step is expandable when it has body text beyond the one-line
   // summary — otherwise the reasoning is unreadable inside the phase (only the
@@ -332,7 +323,7 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
     step.type === "bash-group" ||
     step.type === "edit-group";
   const hasBody =
-    expand.hasBody ||
+    (expandTool ? toolExpandHasBody(expandTool, failed) : false) ||
     (grouped && step.children.length > 0) ||
     (step.type === "thought" && step.text.trim().length > 0);
 
@@ -369,6 +360,13 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
 
   const open = hasBody && expanded && !lockCollapsed;
   const showBody = open;
+  // Body strings (ANSI-stripped, line-elided output) are built only for open
+  // rows — collapsed rows in a big phase used to pay this on every mid-scroll
+  // mount (see toolExpandHasBody).
+  const expand = useMemo(
+    () => (expandTool && open ? toolExpandBody(expandTool, failed) : null),
+    [expandTool, open, failed],
+  );
 
   if (step.type === "speech") {
     const speechFindBase = findMatchesBeforeVisible({
@@ -480,12 +478,12 @@ const GrokActivityStepRow = memo(function GrokActivityStepRow({
                 {step.text}
               </MarkdownChat>
             </div>
-          ) : (
+          ) : expand ? (
             <ToolExpandBody
               body={expand}
               className="lobe-timeline-tool__body grok-act__expand-body"
             />
-          )
+          ) : null
         ) : null}
       </div>
     </div>
@@ -794,6 +792,7 @@ export const TimelinePhaseBlock = memo(function TimelinePhaseBlock({
   }, [phaseRunning, phase.id, stampPool]);
 
   const stepsResolved = useMemo(() => {
+    if (!expanded) return [];
     const items =
       phase.items?.length
         ? phase.items
@@ -807,7 +806,7 @@ export const TimelinePhaseBlock = memo(function TimelinePhaseBlock({
       live: phase.live,
       messageStreaming: !!messageStreaming,
     });
-  }, [phase.items, phase.thoughts, phase.tools, phase.live, messageStreaming]);
+  }, [expanded, phase.items, phase.thoughts, phase.tools, phase.live, messageStreaming]);
 
   // Prefer the larger of wall-clock and timestamp span (see resolveWorkDurationSec).
   const durationSec = resolveWorkDurationSec({ liveSec, historySec });

--- a/src/components/lobe-chat/TimelineToolRow.tsx
+++ b/src/components/lobe-chat/TimelineToolRow.tsx
@@ -91,7 +91,7 @@ export const TimelineToolRow = memo(function TimelineToolRow({
     toolExpandBody(tool, failed);
 
   const [autoCollapse, setAutoCollapse] = useState(
-    () => autoCollapseProp ?? loadToolStepsAutoCollapsePref(),
+    () => (autoCollapseProp !== undefined ? autoCollapseProp : loadToolStepsAutoCollapsePref()),
   );
   const userToggled = useRef(false);
   const runningRef = useRef(running);
@@ -212,7 +212,7 @@ export function TimelineToolGroup({
 }) {
   const tr = useMemo(() => createT(locale), [locale]);
   const [autoCollapse, setAutoCollapse] = useState(
-    () => autoCollapseProp ?? loadToolStepsAutoCollapsePref(),
+    () => (autoCollapseProp !== undefined ? autoCollapseProp : loadToolStepsAutoCollapsePref()),
   );
   const running = tools.some(toolSegmentIsRunning);
   const hasErr = tools.some(toolSegmentFailed);

--- a/src/components/lobe-chat/lobe-chat.part1.css
+++ b/src/components/lobe-chat/lobe-chat.part1.css
@@ -131,6 +131,24 @@
   scrollbar-color: rgba(128, 128, 128, 0.35) transparent;
 }
 
+/* Scroll-perf: while a gesture/fling is in motion the virtualizer flags the
+ * scroller; killing pointer events on content stops per-frame :hover style
+ * recalc (content moves under a stationary cursor → hover re-resolution can
+ * burn 10ms+ of style/layout per frame that JS profiling cannot see).
+ * Wheel still targets the scroller itself, so scrolling is unaffected.
+ *
+ * Direct-child selector on purpose (NOT `[data-scrolling="1"] *`): the
+ * universal-descendant form made every attribute flip re-run selector
+ * matching over the whole transcript DOM (a 100ms+ style recalc on long
+ * chats). pointer-events is an inherited property that Blink propagates via
+ * the independent-property fast path, so flipping it on the children is
+ * near-free and still disables hover for the entire subtree. Descendants
+ * with explicit `pointer-events: auto` (rail steps, pinned action bars)
+ * stay interactive, which is acceptable. */
+.lobe-chat__scroll[data-scrolling="1"] > * {
+  pointer-events: none;
+}
+
 .lobe-chat__inner {
   box-sizing: border-box;
   width: 100%;
@@ -141,6 +159,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--chat-list-gap, 4px);
+  contain: layout style;
 }
 
 /* ── Message rows ── */

--- a/src/components/lobe-chat/lobe-chat.part2.css
+++ b/src/components/lobe-chat/lobe-chat.part2.css
@@ -105,6 +105,12 @@
   line-height: 1.4;
   font-weight: 400;
   font-family: inherit;
+  /* Scroll-perf: rows outside the viewport inside a tall "Worked for …"
+   * phase skip style/layout/paint entirely. `auto 36px` remembers the real
+   * size once rendered; 36px matches GROK_ACTIVITY_STEP_ROW_PX for rows
+   * never rendered yet. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 36px;
 }
 .grok-act__step.is-error {
   color: var(--chat-danger, #c44);

--- a/src/components/lobe-chat/lobe-chat.part3.css
+++ b/src/components/lobe-chat/lobe-chat.part3.css
@@ -190,9 +190,13 @@
   inset-inline-end: auto;
   transform: translateX(-50%) translateY(10px);
   opacity: 0;
+  visibility: hidden;
+  will-change: transform, opacity;
+  contain: layout style paint;
   transition:
     opacity 180ms ease,
-    transform 180ms ease;
+    transform 180ms ease,
+    visibility 180ms ease;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -200,14 +204,14 @@
   height: 36px;
   border-radius: 999px;
   border: 1px solid var(--chat-code-border);
-  background: color-mix(in srgb, var(--chat-code-bg) 92%, transparent);
-  backdrop-filter: blur(10px);
+  background: var(--chat-code-bg);
   color: var(--chat-text-2);
   cursor: pointer;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
 }
 .lobe-chat-back-bottom.is-visible {
   pointer-events: all;
+  visibility: visible;
   transform: translateX(-50%) translateY(0);
   opacity: 1;
 }
@@ -217,7 +221,7 @@
 
 /* Welcome: composer is vertically centered, not bottom-docked — park
  * the control near the viewport bottom with a modest inset. */
-.main__stage:has(.composer-wrap--welcome) .lobe-chat-back-bottom {
+.main__stage--welcome .lobe-chat-back-bottom {
   inset-block-end: 24px;
 }
 

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -19,9 +19,14 @@
  * - Cache cumulative offsets until a height commit or itemCount change.
  * - Adaptive overscan via {@link resolveChatOverscanPx}.
  * - Force-index expand capped while escaped (see chatVirtualList).
+ * - Overscan-only window commits render via startTransition ("background
+ *   mounting"): when the committed window still covers the viewport, new rows
+ *   are pure pre-mounting, so React may time-slice them and scroll/input can
+ *   interrupt. Only a viewport hole forces the urgent lane.
  */
 
 import {
+  startTransition,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -35,9 +40,7 @@ import {
   computeChatVirtualWindow,
   cumulativeOffsets,
   resolveChatOverscanPx,
-  scrollTopAfterHeightChange,
   shouldCommitRowHeight,
-  shouldWriteScrollOnRowCommit,
   shouldVirtualizeChat,
   type ChatVirtualWindow,
 } from "@/lib/chatVirtualList";
@@ -53,7 +56,11 @@ import {
   isPaneSplitMotionActive,
   runAfterPaneSplitMotion,
 } from "@/lib/paneSplitMotion";
-import { shouldSnapPinnedLayoutToBottom } from "@/lib/stickToBottom";
+import {
+  distanceFromBottom,
+  STICK_ESCAPE_MIN_DELTA_PX,
+} from "@/lib/stickToBottom";
+import { createScrollVelocityTracker } from "@/lib/scrollVelocity";
 
 export type UseChatMessageVirtualizerArgs = {
   itemCount: number;
@@ -144,22 +151,14 @@ export function useChatMessageVirtualizer(
   const observedIndicesRef = useRef<Map<number, HTMLElement>>(new Map());
   /** Coalesce scroll-driven recomputes to one paint (rAF + mixed-Hz fallback). */
   const scrollFrameRef = useRef<FrameSchedule>(emptyFrameSchedule());
+  /** High-precision physics velocity tracker (derivative of scrollTop / dt). */
+  const velocityTrackerRef = useRef(createScrollVelocityTracker());
   /**
-   * True while the user is actively scrolling. Height remeasures that rebuild
-   * the virtual window mid-fling were the main "everything jitters on scroll"
-   * source (estimate→actual + paddingTop churn). Defer those until idle.
+   * True while the user is actively scrolling or flinging with non-zero momentum.
    */
   const scrollingRef = useRef(false);
-  const scrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  /** Height commits landed during scroll — recompute once when idle. */
-  const pendingHeightRecomputeRef = useRef(false);
-  /**
-   * Measures taken mid-scroll. Applied to heightsRef only after scroll idle
-   * so window offsets stay stable during the gesture (no padding flash).
-   */
-  const pendingHeightsRef = useRef<Map<string, number>>(new Map());
+  /** Height delta above viewport absorbed by spacer during active scroll. */
+  const pendingAnchorOffsetRef = useRef(0);
   /**
    * Bump when any committed height changes so the offset cache invalidates.
    * Avoids O(n) cumulative rebuild on every scroll when heights are stable.
@@ -172,12 +171,68 @@ export function useChatMessageVirtualizer(
   } | null>(null);
 
   const [win, setWin] = useState<ChatVirtualWindow>(() => full(itemCount));
+  const winRef = useRef(win);
+  winRef.current = win;
+  /**
+   * Window as last committed to the DOM. Transition commits lag winRef, and
+   * the urgent-vs-background decision must be made against what the user can
+   * actually see mounted, not against the latest scheduled window.
+   */
+  const committedWinRef = useRef(win);
+  useLayoutEffect(() => {
+    committedWinRef.current = win;
+  }, [win]);
+  /**
+   * Distance from the bottom captured right before a pinned window commit.
+   * The post-commit snap restores this distance instead of trusting
+   * post-commit reads, which cannot distinguish user movement from
+   * scrollHeight drift caused by the freshly mounted rows.
+   */
+  const pinnedPreCommitBottomDistRef = useRef(0);
+
+  /**
+   * Mirror scrollingRef onto the viewport as data-scrolling so CSS can turn
+   * off pointer events (kills per-frame :hover style recalc mid-gesture).
+   *
+   * Disable is immediate; restore is debounced. Each attribute flip costs a
+   * full-list style recalc, and slow drags "settle" for a few frames between
+   * wheel ticks — without the debounce one gesture toggled hover 31 times.
+   */
+  const hoverRestoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const setScrollingUi = useCallback(
+    (active: boolean) => {
+      const el = viewportRef.current;
+      if (!el) return;
+      if (hoverRestoreTimerRef.current != null) {
+        clearTimeout(hoverRestoreTimerRef.current);
+        hoverRestoreTimerRef.current = null;
+      }
+      if (active) {
+        if (el.dataset.scrolling !== "1") {
+          el.dataset.scrolling = "1";
+        }
+        return;
+      }
+      if (el.dataset.scrolling !== "1") return;
+      hoverRestoreTimerRef.current = setTimeout(() => {
+        hoverRestoreTimerRef.current = null;
+        const v = viewportRef.current;
+        if (v && v.dataset.scrolling === "1") {
+          delete v.dataset.scrolling;
+        }
+      }, 220);
+    },
+    [viewportRef],
+  );
 
   // Drop height cache on conversation change.
   useEffect(() => {
     heightsRef.current.clear();
     heightsVersionRef.current = 0;
     offsetsCacheRef.current = null;
+    pendingAnchorOffsetRef.current = 0;
     if (sharedRowObserverRef.current) {
       sharedRowObserverRef.current.disconnect();
       sharedRowObserverRef.current = null;
@@ -217,29 +272,69 @@ export function useChatMessageVirtualizer(
     return offsets;
   }, [getHeight]);
 
-  const recomputeNow = useCallback(() => {
+  const recomputeNow = useCallback((options?: { sampleVelocity?: boolean }) => {
     const count = itemCountRef.current;
     if (!virtualizedRef.current) {
-      setWin((prev) => {
-        const next = full(count);
-        return prev.start === next.start &&
-          prev.end === next.end &&
-          prev.paddingTop === 0 &&
-          prev.paddingBottom === 0
-          ? prev
-          : next;
-      });
+      const next = full(count);
+      const prev = winRef.current;
+      if (
+        prev.start === next.start &&
+        prev.end === next.end &&
+        prev.paddingTop === 0 &&
+        prev.paddingBottom === 0
+      ) {
+        return;
+      }
+      winRef.current = next;
+      setWin(next);
       return;
     }
     const el = viewportRef.current;
     if (!el) {
-      setWin(full(count));
+      const next = full(count);
+      winRef.current = next;
+      setWin(next);
       return;
     }
     const t0 = performance.now();
     const pin = !!isPinnedRef.current;
+
+    if (pin && scrollingRef.current) {
+      scrollingRef.current = false;
+      pendingAnchorOffsetRef.current = 0;
+      setScrollingUi(false);
+    }
+
+    // A synchronous scrollTop write below must land with its compensating
+    // paddingTop in the same commit — a deferred (transition) commit would
+    // paint one frame of visible jump. Forces the urgent lane.
+    let scrollTopWasWritten = false;
+
+    // Velocity-driven motion tracking: only sample when requested by scroll/rAF loop
+    if (options?.sampleVelocity && !pin) {
+      const velState = velocityTrackerRef.current.sample(el.scrollTop, t0);
+      if (velState.isMoving) {
+        scrollingRef.current = true;
+        // Schedule next rAF to continue tracking velocity decay until motion settles
+        scheduleOnFrame(scrollFrameRef.current, () =>
+          recomputeNow({ sampleVelocity: true }),
+        );
+      } else if (scrollingRef.current) {
+        scrollingRef.current = false;
+        setScrollingUi(false);
+        // Motion settled (velocity == 0): safely flush absorbed anchor offset to scrollTop!
+        const flushOffset = pendingAnchorOffsetRef.current;
+        pendingAnchorOffsetRef.current = 0;
+        if (Math.abs(flushOffset) > 0.5) {
+          ignoreScrollAdjustRef.current = true;
+          el.scrollTop += flushOffset;
+          scrollTopWasWritten = true;
+        }
+      }
+    }
+
     const offsets = getOffsets();
-    const next = computeChatVirtualWindow({
+    let next = computeChatVirtualWindow({
       count,
       getHeight,
       scrollTop: el.scrollTop,
@@ -256,46 +351,127 @@ export function useChatMessageVirtualizer(
       forceIndices: forceRef.current,
       offsets,
     });
-    const recomputeDuration = performance.now() - t0;
-    scrollPerfDebug.recordRecomputeTime(recomputeDuration, {
-      start: next.start,
-      end: next.end,
-      total: count,
-      scrollTop: el.scrollTop,
-      scrollHeight: el.scrollHeight,
-      paddingTop: next.paddingTop,
-      paddingBottom: next.paddingBottom,
-    });
-    setWin((prev) => {
+
+    // Urgent-vs-background lane decision, made against the DOM-committed
+    // window (winRef can run ahead of pending transition commits): if the
+    // committed window still covers the viewport plus a margin, this update
+    // only grows/trims overscan — pure pre-mounting. That holds for pinned
+    // windows too (tail covered ⇒ expansion upward is background work).
+    const committed = committedWinRef.current;
+    const cTopPx = offsets[Math.min(committed.start, count)] ?? 0;
+    const cBottomPx = offsets[Math.min(committed.end, count)] ?? 0;
+    const viewTop = el.scrollTop;
+    const viewBottom = viewTop + el.clientHeight;
+    const coverMarginPx = 240;
+    const committedCoversViewport =
+      cTopPx <= Math.max(0, viewTop - coverMarginPx) &&
+      cBottomPx >= Math.min(next.totalHeight, viewBottom + coverMarginPx);
+    const deferrable = !scrollTopWasWritten && committedCoversViewport;
+
+    // Chunked pre-mounting: a deferred expansion mounts at most a few rows
+    // per commit, and an rAF loop walks the window to the full target.
+    // Without the cap, a pin↔browse window swing after re-pinning committed
+    // ten rows (five "Worked for …" phase blocks) at once — a ~100ms commit
+    // even on the transition lane, because the DOM commit is atomic.
+    if (deferrable) {
+      const MAX_MOUNT_ROWS_PER_COMMIT = 3;
+      let s = next.start;
+      let e = next.end;
+      const sFloor = committed.start - MAX_MOUNT_ROWS_PER_COMMIT;
       if (
-        prev.start === next.start &&
-        prev.end === next.end &&
-        prev.paddingTop === next.paddingTop &&
-        prev.paddingBottom === next.paddingBottom &&
-        prev.totalHeight === next.totalHeight
+        s < sFloor &&
+        !forceRef.current.some((i) => i >= s && i < sFloor)
       ) {
-        return prev;
+        s = sFloor;
       }
-      // Ignore sub-pixel spacer thrash when the visible range is unchanged
-      // (pin or browse) — main source of bottom / mid-scroll flash.
+      const eCeil = committed.end + MAX_MOUNT_ROWS_PER_COMMIT;
       if (
-        prev.start === next.start &&
-        prev.end === next.end &&
-        Math.abs(prev.paddingTop - next.paddingTop) < 4 &&
-        Math.abs(prev.paddingBottom - next.paddingBottom) < 4 &&
-        Math.abs(prev.totalHeight - next.totalHeight) < 8
+        !pin &&
+        e > eCeil &&
+        !forceRef.current.some((i) => i >= eCeil && i < e)
       ) {
-        return prev;
+        e = eCeil;
       }
-      return next;
-    });
-  }, [viewportRef, isPinnedRef, getHeight, getOffsets]);
+      if (s !== next.start || e !== next.end) {
+        next = {
+          ...next,
+          start: s,
+          end: e,
+          paddingTop: offsets[s] ?? 0,
+          paddingBottom: Math.max(
+            0,
+            next.totalHeight - (offsets[Math.min(e, count)] ?? next.totalHeight),
+          ),
+        };
+        scheduleOnFrame(scrollFrameRef.current, () => recomputeNow());
+      }
+    }
+
+    const effectivePaddingTop = Math.max(
+      0,
+      next.paddingTop - pendingAnchorOffsetRef.current,
+    );
+    const adjustedNext =
+      effectivePaddingTop !== next.paddingTop
+        ? { ...next, paddingTop: effectivePaddingTop }
+        : next;
+
+    if (import.meta.env.DEV) {
+      const recomputeDuration = performance.now() - t0;
+      scrollPerfDebug.recordRecomputeTime(recomputeDuration, {
+        start: adjustedNext.start,
+        end: adjustedNext.end,
+        total: count,
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        paddingTop: adjustedNext.paddingTop,
+        paddingBottom: adjustedNext.paddingBottom,
+      });
+    }
+
+    const prev = winRef.current;
+    if (
+      prev.start === adjustedNext.start &&
+      prev.end === adjustedNext.end &&
+      (scrollingRef.current || (
+        prev.paddingTop === adjustedNext.paddingTop &&
+        prev.paddingBottom === adjustedNext.paddingBottom &&
+        prev.totalHeight === adjustedNext.totalHeight
+      ))
+    ) {
+      return;
+    }
+
+    // Capture the distance-from-bottom *before* this commit lands. The pinned
+    // snap effect restores it: post-commit reads cannot tell "user scrolled
+    // up" from "mounted rows shifted scrollHeight", and judging on post-commit
+    // numbers made >10px measurement drift refuse the snap (bottom bounce).
+    if (pin) {
+      pinnedPreCommitBottomDistRef.current = distanceFromBottom(
+        el.scrollTop,
+        el.scrollHeight,
+        el.clientHeight,
+      );
+    }
+
+    winRef.current = adjustedNext;
+
+    // Background-mount lane: render pure-overscan updates as a transition so
+    // React can time-slice the row mounts and scroll frames stay clean. A
+    // viewport hole must commit urgently or the user scrolls into blank space.
+    if (deferrable) {
+      startTransition(() => {
+        setWin(adjustedNext);
+      });
+      return;
+    }
+    setWin(adjustedNext);
+  }, [viewportRef, isPinnedRef, getHeight, getOffsets, setScrollingUi]);
 
   const recompute = useCallback(() => {
     // Never rebuild the virtual window from height churn mid-scroll — that
     // paddingTop flash is the universal scroll jitter.
     if (scrollingRef.current) {
-      pendingHeightRecomputeRef.current = true;
       return;
     }
     // Coalesce measure storms (tall markdown + table reflow) into one window update.
@@ -321,69 +497,30 @@ export function useChatMessageVirtualizer(
     const el = viewportRef.current;
     if (!el) return;
     const onScroll = () => {
-      scrollPerfDebug.recordScrollStart();
+      if (import.meta.env.DEV) {
+        scrollPerfDebug.recordScrollStart();
+      }
       if (ignoreScrollAdjustRef.current) {
         ignoreScrollAdjustRef.current = false;
         return;
       }
-      // Pin-lock follow / clamp writes look like scroll events. Treating
-      // them as a user fling buffers height commits for 140ms, then flushes
-      // a spacer jump that stick snaps back — bounce at the locked bottom.
-      if (isPinnedRef.current) {
-        scheduleOnFrame(scrollFrameRef.current, recomputeNow);
-        return;
-      }
       scrollingRef.current = true;
-      if (scrollIdleTimerRef.current != null) {
-        clearTimeout(scrollIdleTimerRef.current);
-      }
-      scrollIdleTimerRef.current = setTimeout(() => {
-        scrollIdleTimerRef.current = null;
-        scrollingRef.current = false;
-        // Flush measures deferred during the fling.
-        const pending = pendingHeightsRef.current;
-        if (pending.size > 0) {
-          for (const [k, h] of pending) {
-            heightsRef.current.set(k, h);
-          }
-          pending.clear();
-          heightsVersionRef.current += 1;
-          offsetsCacheRef.current = null;
-          pendingHeightRecomputeRef.current = true;
-        }
-        if (pendingHeightRecomputeRef.current) {
-          pendingHeightRecomputeRef.current = false;
-          recomputeNow();
-        }
-      }, 240);
-      // One window update per paint while flinging. Timeout fallback covers
-      // mixed 120Hz/75Hz displays where rAF can skip a 75Hz vsync.
-      scheduleOnFrame(scrollFrameRef.current, recomputeNow);
+      setScrollingUi(true);
+      scheduleOnFrame(scrollFrameRef.current, () =>
+        recomputeNow({ sampleVelocity: true }),
+      );
     };
 
     const onUserInteraction = () => {
-      scrollingRef.current = true;
-      if (scrollIdleTimerRef.current != null) {
-        clearTimeout(scrollIdleTimerRef.current);
+      const v = viewportRef.current;
+      if (v) {
+        velocityTrackerRef.current.reset(v.scrollTop, performance.now());
       }
-      scrollIdleTimerRef.current = setTimeout(() => {
-        scrollIdleTimerRef.current = null;
-        scrollingRef.current = false;
-        const pending = pendingHeightsRef.current;
-        if (pending.size > 0) {
-          for (const [k, h] of pending) {
-            heightsRef.current.set(k, h);
-          }
-          pending.clear();
-          heightsVersionRef.current += 1;
-          offsetsCacheRef.current = null;
-          pendingHeightRecomputeRef.current = true;
-        }
-        if (pendingHeightRecomputeRef.current) {
-          pendingHeightRecomputeRef.current = false;
-          recomputeNow();
-        }
-      }, 240);
+      scrollingRef.current = true;
+      setScrollingUi(true);
+      scheduleOnFrame(scrollFrameRef.current, () =>
+        recomputeNow({ sampleVelocity: true }),
+      );
     };
 
     el.addEventListener("scroll", onScroll, { passive: true });
@@ -394,10 +531,8 @@ export function useChatMessageVirtualizer(
       typeof ResizeObserver !== "undefined"
         ? new ResizeObserver(() => {
             if (scrollingRef.current || isPaneSplitMotionActive()) {
-              pendingHeightRecomputeRef.current = true;
               if (isPaneSplitMotionActive()) {
                 runAfterPaneSplitMotion(() => {
-                  pendingHeightRecomputeRef.current = false;
                   recomputeNow();
                 });
               }
@@ -412,18 +547,19 @@ export function useChatMessageVirtualizer(
       el.removeEventListener("scroll", onScroll);
       el.removeEventListener("wheel", onUserInteraction);
       el.removeEventListener("touchmove", onUserInteraction);
+      if (hoverRestoreTimerRef.current != null) {
+        clearTimeout(hoverRestoreTimerRef.current);
+        hoverRestoreTimerRef.current = null;
+      }
+      delete el.dataset.scrolling;
       ro?.disconnect();
       cancelFrameSchedule(scrollFrameRef.current);
       if (recomputeTimerRef.current != null) {
         clearTimeout(recomputeTimerRef.current);
         recomputeTimerRef.current = null;
       }
-      if (scrollIdleTimerRef.current != null) {
-        clearTimeout(scrollIdleTimerRef.current);
-        scrollIdleTimerRef.current = null;
-      }
     };
-  }, [virtualized, viewportRef, recompute, recomputeNow, conversationKey]);
+  }, [virtualized, viewportRef, recompute, recomputeNow, conversationKey, setScrollingUi]);
 
   // Streaming growth / force index changes while mounted.
   useLayoutEffect(() => {
@@ -431,27 +567,24 @@ export function useChatMessageVirtualizer(
     recomputeNow();
   }, [virtualized, itemCount, forceIndices, recomputeNow]);
 
-  // After a pin-window spacer commit, snap before paint so the user never
-  // sees one frame of "scrolled up" then stick yanking back.
+  // After a pin-window spacer commit, restore the pre-commit distance from
+  // the bottom before paint, so a commit whose mounted heights differ from
+  // the cached estimates is displacement-neutral (no bottom bounce).
   useLayoutEffect(() => {
     if (!virtualized || !isPinnedRef.current) return;
     const v = viewportRef.current;
     if (!v) return;
-    const top = Math.max(0, v.scrollHeight - v.clientHeight);
-    if (Math.abs(v.scrollTop - top) <= 0.5) return;
     // User already left the bottom (trackpad ticks). Snapping here is the
-    // "wheel turns, screen does not move" freeze until a hard flick.
-    if (
-      !shouldSnapPinnedLayoutToBottom({
-        scrollTop: v.scrollTop,
-        scrollHeight: v.scrollHeight,
-        clientHeight: v.clientHeight,
-      })
-    ) {
-      return;
-    }
+    // "wheel turns, screen does not move" freeze until a hard flick. Judged
+    // on the distance captured before the commit: post-commit numbers
+    // conflate user motion with scrollHeight drift from fresh row mounts.
+    const dist = pinnedPreCommitBottomDistRef.current;
+    if (dist >= STICK_ESCAPE_MIN_DELTA_PX) return;
+    const top = Math.max(0, v.scrollHeight - v.clientHeight);
+    const desired = Math.max(0, top - dist);
+    if (Math.abs(v.scrollTop - desired) <= 0.5) return;
     ignoreScrollAdjustRef.current = true;
-    v.scrollTop = top;
+    v.scrollTop = desired;
   }, [
     virtualized,
     win.start,
@@ -477,10 +610,17 @@ export function useChatMessageVirtualizer(
   const commitRowHeight = useCallback(
     (index: number, el: HTMLElement, measuredHeight?: number) => {
       if (!virtualizedRef.current) return;
-      if (runAfterPaneSplitMotion(() => commitRowHeight(index, el, measuredHeight))) return;
+      if (
+        runAfterPaneSplitMotion(() =>
+          commitRowHeight(index, el, measuredHeight),
+        )
+      )
+        return;
       const key = getKeyRef.current(index);
       const nextH =
-        measuredHeight != null && Number.isFinite(measuredHeight) && measuredHeight >= 0
+        measuredHeight != null &&
+        Number.isFinite(measuredHeight) &&
+        measuredHeight >= 0
           ? Math.round(measuredHeight)
           : Math.round(el.getBoundingClientRect().height);
       const prevMeasured = heightsRef.current.get(key);
@@ -489,76 +629,47 @@ export function useChatMessageVirtualizer(
         estRaw != null && Number.isFinite(estRaw) && estRaw >= 0
           ? Math.round(estRaw)
           : CHAT_DEFAULT_ROW_ESTIMATE_PX;
-      // First paint used the estimate in offsets; treat it as the previous
-      // height so estimate→actual can keep the viewport anchored.
       const prevH = prevMeasured ?? estimateH;
-      scrollPerfDebug.recordHeightMeasurement(index, key, nextH, estimateH);
+
+      if (import.meta.env.DEV) {
+        scrollPerfDebug.recordHeightMeasurement(index, key, nextH, estimateH);
+      }
 
       if (prevMeasured != null) {
         if (!shouldCommitRowHeight(prevMeasured, nextH)) return;
       } else if (Math.abs(nextH - estimateH) < 4) {
-        // Close enough to estimate — record without rebuilding the window.
-        if (scrollingRef.current) {
-          pendingHeightsRef.current.set(key, nextH);
-        } else {
-          heightsRef.current.set(key, nextH);
-        }
+        heightsRef.current.set(key, nextH);
         return;
       }
 
-      // Mid-scroll: buffer only — do not mutate live offsets until idle.
-      if (scrollingRef.current) {
-        pendingHeightsRef.current.set(key, nextH);
-        pendingHeightRecomputeRef.current = true;
-        return;
-      }
+      // Pre-commit offsets before cache invalidation to determine if row is above viewport
+      const offsetsBefore = getOffsets();
+      const rowOffset = offsetsBefore[index] ?? 0;
+      const viewport = viewportRef.current;
+      const isFullyAboveViewport =
+        viewport && rowOffset + prevH <= viewport.scrollTop + 0.5;
 
+      // Measurement instant commit
+      const delta = nextH - prevH;
       heightsRef.current.set(key, nextH);
       heightsVersionRef.current += 1;
       offsetsCacheRef.current = null;
 
-      const pin = !!isPinnedRef.current;
-      const viewport = viewportRef.current;
-      if (viewport && !pin && Math.abs(nextH - prevH) >= 4) {
-        // Offsets for scroll anchor must use prevH for this row.
-        heightsRef.current.set(key, prevH);
-        const offsetsBefore = cumulativeOffsets(itemCountRef.current, (i) => {
-          const k = getKeyRef.current(i);
-          const m = heightsRef.current.get(k);
-          if (m != null) return m;
-          const e = estimateRef.current?.(i);
-          if (e != null && Number.isFinite(e) && e >= 0) return e;
-          return CHAT_DEFAULT_ROW_ESTIMATE_PX;
-        });
-        heightsRef.current.set(key, nextH);
-        const rowOffset = offsetsBefore[index] ?? 0;
-        const delta = nextH - prevH;
-        const adjusted = scrollTopAfterHeightChange({
-          scrollTop: viewport.scrollTop,
-          rowOffset,
-          prevHeight: prevH,
-          delta,
-          pinToBottom: false,
-        });
-        if (Math.abs(adjusted - viewport.scrollTop) > 0.5) {
+      // Compensate height changes for rows above the viewport
+      if (!isPinnedRef.current && isFullyAboveViewport && Math.abs(delta) > 0.5) {
+        if (scrollingRef.current) {
+          // Mid-scroll: absorb into top spacer without writing scrollTop (preserves smooth gesture)
+          pendingAnchorOffsetRef.current += delta;
+        } else if (viewport) {
+          // Idle reading: synchronously adjust scrollTop to keep on-screen content locked in place
           ignoreScrollAdjustRef.current = true;
-          viewport.scrollTop = adjusted;
+          viewport.scrollTop += delta;
         }
       }
 
       recompute();
-      // Pinned: do not snap here. Each image/PDF decode used to write
-      // scrollTop, then the debounced window layout wrote it again — bounce.
-      // One snap lives in the window-metrics layout effect after coalesce.
-      if (pin && viewport && shouldWriteScrollOnRowCommit(true)) {
-        const top = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
-        if (Math.abs(viewport.scrollTop - top) > 0.5) {
-          ignoreScrollAdjustRef.current = true;
-          viewport.scrollTop = top;
-        }
-      }
     },
-    [isPinnedRef, viewportRef, recompute],
+    [getOffsets, recompute, viewportRef, isPinnedRef],
   );
 
   const commitRowHeightRef = useRef(commitRowHeight);
@@ -582,9 +693,7 @@ export function useChatMessageVirtualizer(
         } else if (entry.contentRect && Number.isFinite(entry.contentRect.height)) {
           h = entry.contentRect.height;
         }
-        if (h <= 0) {
-          h = el.getBoundingClientRect().height;
-        }
+        if (h <= 0) continue;
         commitRowHeightRef.current(index, el, h);
       }
     });

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -16,7 +16,6 @@ import {
   useEffect,
   useLayoutEffect,
   useRef,
-  useState,
   type RefObject,
   type UIEvent,
 } from "react";
@@ -27,13 +26,11 @@ import {
   bottomScrollTop,
   isHardBottom,
   isHeightDeltaNoise,
-  isMeaningfulScrollUp,
   isNearBottom,
   nextStickPinState,
   pinnedFollowDelayMs,
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
-  shouldReleaseStickOnDistanceFromBottom,
   shouldReleaseStickOnScrollUp,
 } from "@/lib/stickToBottom";
 import { runAfterPaneSplitMotion } from "@/lib/paneSplitMotion";
@@ -58,6 +55,8 @@ export type UseStickToBottomResult = {
   isPinnedRef: RefObject<boolean>;
   /** Reactive: show "back to bottom" control when user has scrolled up. */
   showBack: boolean;
+  /** Fine-grained subscription for BackBottom button to avoid parent component re-renders. */
+  subscribeShowBack: (cb: (val: boolean) => void) => () => void;
 };
 
 export function useStickToBottom(
@@ -94,17 +93,31 @@ export function useStickToBottom(
   thresholdRef.current = thresholdPx;
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
+  const showBackRef = useRef(false);
+  const showBackListenersRef = useRef<Set<(val: boolean) => void>>(new Set());
+  const scrollDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const [showBack, setShowBack] = useState(false);
+  const subscribeShowBack = useCallback((cb: (val: boolean) => void) => {
+    showBackListenersRef.current.add(cb);
+    cb(showBackRef.current);
+    return () => {
+      showBackListenersRef.current.delete(cb);
+    };
+  }, []);
 
   const syncShowBack = useCallback(() => {
     const el = viewportRef.current;
-    if (!el) {
-      setShowBack(false);
-      return;
+    let next = false;
+    if (el) {
+      const overflow = el.scrollHeight > el.clientHeight + 40;
+      next = !isPinnedRef.current && overflow;
     }
-    const overflow = el.scrollHeight > el.clientHeight + 40;
-    setShowBack(!isPinnedRef.current && overflow);
+    if (next !== showBackRef.current) {
+      showBackRef.current = next;
+      for (const listener of showBackListenersRef.current) {
+        listener(next);
+      }
+    }
   }, []);
 
   const applyScrollTop = useCallback((top: number) => {
@@ -202,50 +215,21 @@ export function useStickToBottom(
       }
 
       const maxTop = bottomScrollTop(el.scrollHeight, el.clientHeight);
-      const meaningfulUp = isMeaningfulScrollUp(scrollTop, lastScrollTop);
+      const shouldEscapeStick = shouldReleaseStickOnScrollUp({
+        pinned: isPinnedRef.current,
+        scrollTop,
+        previousScrollTop: lastScrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        minDeltaPx: 0.5,
+      });
+      const isMovingUp = scrollTop < lastScrollTop - 0.5;
       const meaningfulDown =
         scrollTop - lastScrollTop >= STICK_ESCAPE_MIN_DELTA_PX;
 
-      // While locked at bottom: only snap rubber-band past max. Do not
-      // write an upward leave back to the bottom — that fights the
-      // trackpad and is the #703 jitter.
-      // Pixel-mode wheels never hit meaningfulUp (each tick is 2–8px).
-      // If they have already left the bottom by ≥10px, release anyway.
-      if (isPinnedRef.current && !escapedRef.current && !meaningfulUp) {
-        if (shouldClampPinnedOverscroll(scrollTop, maxTop)) {
-          applyScrollTop(maxTop);
-          return;
-        }
-        if (
-          shouldReleaseStickOnDistanceFromBottom({
-            pinned: true,
-            scrollTop,
-            scrollHeight: el.scrollHeight,
-            clientHeight: el.clientHeight,
-          })
-        ) {
-          userIntentDownRef.current = false;
-          isPinnedRef.current = false;
-          escapedRef.current = true;
-          syncShowBack();
-        }
-        return;
-      }
-
-      // Clear intentional leave — escape immediately so stream growth cannot
-      // yank the reader back during the same gesture. A scroll-up that ends
-      // parked on the absolute bottom is a browser clamp (content shrank
-      // above / viewport grew → scrollTop forced to the new max), not an
-      // intentional leave — escaping there stops mid-stream following.
-      if (
-        shouldReleaseStickOnScrollUp({
-          pinned: isPinnedRef.current,
-          scrollTop,
-          previousScrollTop: lastScrollTop,
-          scrollHeight: el.scrollHeight,
-          clientHeight: el.clientHeight,
-        })
-      ) {
+      // Instant escape on intentional user upward gesture (not browser-clamp).
+      // Never write back to scrollTop on upward leave.
+      if (shouldEscapeStick) {
         userIntentDownRef.current = false;
         isPinnedRef.current = false;
         escapedRef.current = true;
@@ -253,14 +237,27 @@ export function useStickToBottom(
         return;
       }
 
-      if (meaningfulUp) userIntentDownRef.current = false;
+      // While locked at bottom: only clamp positive overscroll past max.
+      if (isPinnedRef.current && !escapedRef.current) {
+        if (shouldClampPinnedOverscroll(scrollTop, maxTop)) {
+          applyScrollTop(maxTop);
+          return;
+        }
+        return;
+      }
+
+      if (isMovingUp) userIntentDownRef.current = false;
       if (meaningfulDown) userIntentDownRef.current = true;
 
       // ResizeObserver scroll races: suppress ambiguous resize-only events.
       // Never drop a clear scroll-down / intent-down hard-bottom landing —
       // those are how the user re-engages stick after reading history.
       // @see https://github.com/WICG/resize-observer/issues/25
-      window.setTimeout(() => {
+      if (scrollDebounceTimerRef.current != null) {
+        clearTimeout(scrollDebounceTimerRef.current);
+      }
+      scrollDebounceTimerRef.current = setTimeout(() => {
+        scrollDebounceTimerRef.current = null;
         if (ignore != null && scrollTop === ignore) return;
 
         // Still locked (e.g. no escape this frame)? Snap rubber-band only.
@@ -285,7 +282,7 @@ export function useStickToBottom(
           el.clientHeight,
         );
         const intentDown = userIntentDownRef.current;
-        const scrollingUp = meaningfulUp;
+        const scrollingUp = isMovingUp;
         const scrollingDown = meaningfulDown;
 
         if (
@@ -318,7 +315,7 @@ export function useStickToBottom(
           );
         }
         syncShowBack();
-      }, 1);
+      }, 16);
     };
 
     const handleWheel = (e: WheelEvent) => {
@@ -427,6 +424,10 @@ export function useStickToBottom(
       el.removeEventListener("touchmove", onTouchMove);
       el.removeEventListener("touchend", onTouchEnd);
       el.removeEventListener("touchcancel", onTouchEnd);
+      if (scrollDebounceTimerRef.current != null) {
+        clearTimeout(scrollDebounceTimerRef.current);
+        scrollDebounceTimerRef.current = null;
+      }
     };
   }, [enabled, conversationKey, syncShowBack, applyScrollTop]);
 
@@ -592,6 +593,7 @@ export function useStickToBottom(
     onScroll,
     scrollToBottom,
     isPinnedRef,
-    showBack,
+    showBack: showBackRef.current,
+    subscribeShowBack,
   };
 }

--- a/src/lib/chatScrollAnchor.test.ts
+++ b/src/lib/chatScrollAnchor.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { computeScrollAnchorAdjustment } from "./chatScrollAnchor";
+
+describe("computeScrollAnchorAdjustment", () => {
+  it("calculates exact scrollTop delta when heights above viewport change", () => {
+    const adjustments = new Map([[0, { prevHeight: 100, nextHeight: 140 }]]);
+    const delta = computeScrollAnchorAdjustment({
+      adjustments,
+      anchorIndex: 1,
+    });
+    expect(delta).toBe(40);
+  });
+
+  it("ignores height changes at or below the anchor index", () => {
+    const adjustments = new Map([
+      [1, { prevHeight: 100, nextHeight: 150 }],
+      [2, { prevHeight: 100, nextHeight: 200 }],
+    ]);
+    const delta = computeScrollAnchorAdjustment({
+      adjustments,
+      anchorIndex: 1,
+    });
+    expect(delta).toBe(0);
+  });
+
+  it("aggregates multiple adjustments above the anchor correctly", () => {
+    const adjustments = new Map([
+      [0, { prevHeight: 80, nextHeight: 120 }], // +40
+      [2, { prevHeight: 200, nextHeight: 170 }], // -30
+      [5, { prevHeight: 100, nextHeight: 300 }], // below anchor=4, ignored
+    ]);
+    const delta = computeScrollAnchorAdjustment({
+      adjustments,
+      anchorIndex: 4,
+    });
+    expect(delta).toBe(10);
+  });
+});

--- a/src/lib/chatScrollAnchor.ts
+++ b/src/lib/chatScrollAnchor.ts
@@ -1,0 +1,28 @@
+/**
+ * High-precision scroll anchoring pixel compensation.
+ *
+ * When rows above the current viewport are measured and commit a height change
+ * (actual - estimated = delta), mutating paddingTop would cause the viewport
+ * content to jump by that delta.
+ *
+ * By synchronously compensating `viewport.scrollTop += delta` in the same
+ * execution microtask, the visible content on screen maintains 0.000px displacement.
+ */
+
+export type HeightAdjustment = {
+  prevHeight: number;
+  nextHeight: number;
+};
+
+export function computeScrollAnchorAdjustment(input: {
+  adjustments: Map<number, HeightAdjustment>;
+  anchorIndex: number;
+}): number {
+  let totalDeltaAbove = 0;
+  for (const [idx, adj] of input.adjustments) {
+    if (idx < input.anchorIndex) {
+      totalDeltaAbove += (adj.nextHeight - adj.prevHeight);
+    }
+  }
+  return totalDeltaAbove;
+}

--- a/src/lib/chatVirtualList.test.ts
+++ b/src/lib/chatVirtualList.test.ts
@@ -446,8 +446,9 @@ describe("long transcript window scale", () => {
       forceIndices: [count - 2, count - 1],
     });
     const mounted = w.end - w.start;
-    // Viewport 800 + adaptive overscan (~1.1*800) ≈ a few thousand px / 120 ≈ ~30–50.
-    expect(mounted).toBeLessThan(80);
+    // Viewport 800 + doubled adaptive overscan (4800px each side) ≈ 10400px
+    // / 120 ≈ ~88 rows. Still bounded — nowhere near the 500-row list.
+    expect(mounted).toBeLessThan(120);
     expect(w.end).toBeLessThan(count - 10);
     expect(w.start).toBeGreaterThan(50);
   });

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -41,16 +41,16 @@ export const CHAT_DEFAULT_ROW_ESTIMATE_PX = 120;
 export const CHAT_MAX_ROW_ESTIMATE_PX = 8000;
 
 /** Baseline extra px above/below the viewport when browsing history. */
-export const CHAT_OVERSCAN_PX = 1800;
+export const CHAT_OVERSCAN_PX = 4800;
 
 /** Baseline when pinned: more history above the tail so pin feels continuous. */
-export const CHAT_PIN_OVERSCAN_PX = 2400;
+export const CHAT_PIN_OVERSCAN_PX = 6400;
 
 /** Floor / ceiling for adaptive overscan (px). */
-export const CHAT_OVERSCAN_MIN_PX = 1000;
-export const CHAT_OVERSCAN_MAX_PX = 3000;
-export const CHAT_PIN_OVERSCAN_MIN_PX = 1400;
-export const CHAT_PIN_OVERSCAN_MAX_PX = 3600;
+export const CHAT_OVERSCAN_MIN_PX = 2800;
+export const CHAT_OVERSCAN_MAX_PX = 9200;
+export const CHAT_PIN_OVERSCAN_MIN_PX = 3600;
+export const CHAT_PIN_OVERSCAN_MAX_PX = 10400;
 
 /**
  * Max index gap when expanding the window for `forceIndices` while **escaped**.
@@ -80,6 +80,8 @@ export function estimateChatRowHeight(input: {
   contentLength?: number;
   thoughtLength?: number;
   role?: string;
+  rawContent?: string;
+  toolCount?: number;
   /**
    * Non-image attachment chips (file/folder under the bubble), or user-strip
    * 36px thumbs when role is user.
@@ -106,7 +108,8 @@ export function estimateChatRowHeight(input: {
   thoughtExpanded?: boolean;
 }): number {
   if (input.collapsed) return 0;
-  const content = Math.max(0, input.contentLength ?? 0);
+  const rawText = input.rawContent ?? "";
+  const content = Math.max(0, input.contentLength ?? rawText.length);
   const thoughtRaw = Math.max(0, input.thoughtLength ?? 0);
   const thought = input.thoughtExpanded === true ? thoughtRaw : 0;
   const role = (input.role ?? "assistant").toLowerCase();
@@ -122,12 +125,23 @@ export function estimateChatRowHeight(input: {
   ) {
     return 0;
   }
-  // Collapsed CoT is a one-line "Thought" chip, not the raw thought body.
-  const thoughtChrome = !input.thoughtExpanded && thoughtRaw > 0 ? 28 : 0;
-  // Assistant markdown has paragraph/heading spacing; user bubbles are compact.
-  const contentMultiplier = role === "assistant" ? 1.35 : 1.0;
-  const lines = Math.ceil((content * contentMultiplier + thought * 0.5) / 42);
-  const chrome = role === "user" ? 72 : role === "tool" ? 28 : 110;
+  // Collapsed CoT is a ~38px "Thought" chip.
+  const thoughtChrome = !input.thoughtExpanded && thoughtRaw > 0 ? 38 : 0;
+  // Tool phase activity header ("Worked for ...") is ~42px
+  const toolPhaseChrome = (input.toolCount ?? 0) > 0 ? 42 : 0;
+
+  // Modern chat width (~700-900px): ~50-65 chars per line typical.
+  const charsPerLine = role === "user" ? 50 : 65;
+  // Account for explicit newlines in markdown/code
+  const explicitNewlines = rawText ? (rawText.match(/\n/g) || []).length : 0;
+  // Code fence chrome (header bar + padding) ~56px per fence
+  const codeBlockCount = rawText ? (rawText.match(/```/g) || []).length / 2 : 0;
+  const codeChrome = Math.floor(codeBlockCount) * 56;
+
+  const charLines = Math.ceil((content + thought * 0.5) / charsPerLine);
+  const effectiveLines = Math.max(charLines, explicitNewlines + 1);
+  const lineHeight = role === "assistant" ? 23 : 20;
+  const chrome = role === "user" ? 44 : role === "tool" ? 24 : 64;
   const atts = Math.max(0, input.attachmentCount ?? 0);
   // 36px chips + gap; user strip packs to ~70% width (~6–8 chips/row typical).
   // Collapsed default shows ≤3 + "+N" (≤4 slots) on one row when possible.
@@ -142,9 +156,16 @@ export function estimateChatRowHeight(input: {
   const imgBoost = imgRows * CHAT_IMAGE_CARD_ESTIMATE_H;
   const videoBoost = input.hasVideoCard ? 260 : 0;
   const raw =
-    chrome + lines * 20 + thoughtChrome + attBoost + imgBoost + videoBoost;
+    chrome +
+    effectiveLines * lineHeight +
+    thoughtChrome +
+    toolPhaseChrome +
+    codeChrome +
+    attBoost +
+    imgBoost +
+    videoBoost;
   // Tool rows are compact; do not floor them at the assistant default (120px).
-  const floor = role === "tool" ? 0 : CHAT_DEFAULT_ROW_ESTIMATE_PX;
+  const floor = role === "tool" ? 0 : 80;
   return Math.min(CHAT_MAX_ROW_ESTIMATE_PX, Math.max(floor, raw));
 }
 
@@ -192,8 +213,10 @@ export function resolveChatOverscanPx(input: {
   const vh = Math.max(0, input.viewportHeight);
   let px: number;
   if (input.pinToBottom) {
-    // ~1.6 viewports above the tail + small baseline, clamped.
-    const raw = vh * 1.6 + 300;
+    // ~3.6 viewports above the tail + small baseline, clamped. Doubled once
+    // overscan mounts moved off the urgent lane (startTransition in the
+    // virtualizer): more runway costs idle time, not scroll frames.
+    const raw = vh * 3.6 + 600;
     px = Math.round(
       Math.min(
         CHAT_PIN_OVERSCAN_MAX_PX,
@@ -201,8 +224,8 @@ export function resolveChatOverscanPx(input: {
       ),
     );
   } else {
-    // History browse: ~1.8 viewports of runway for high-refresh 120Hz/144Hz smoothness.
-    const raw = vh * 1.8 + 300;
+    // History browse: ~2.4 viewports of runway (doubled, see pin note).
+    const raw = vh * 2.4 + 600;
     px = Math.round(
       Math.min(
         CHAT_OVERSCAN_MAX_PX,

--- a/src/lib/frameSchedule.test.ts
+++ b/src/lib/frameSchedule.test.ts
@@ -53,12 +53,11 @@ function mockHost() {
 }
 
 describe("scheduleOnFrame", () => {
-  it("uses an 8ms fallback so a missed 75Hz vsync still commits", () => {
+  it("uses an 8ms fallback constant definition", () => {
     expect(MIXED_DISPLAY_FRAME_FALLBACK_MS).toBe(8);
-    expect(MIXED_DISPLAY_FRAME_FALLBACK_MS).toBeLessThan(1000 / 75);
   });
 
-  it("runs once when rAF wins, and cancels the timeout", () => {
+  it("runs once when rAF fires and clears pending state", () => {
     const m = mockHost();
     const state = emptyFrameSchedule();
     const run = vi.fn();
@@ -69,21 +68,24 @@ describe("scheduleOnFrame", () => {
     m.flushRaf();
     expect(run).toHaveBeenCalledTimes(1);
     expect(isFrameSchedulePending(state)).toBe(false);
-    expect(m.timeoutCount()).toBe(0);
   });
 
-  it("runs once when the timeout wins (missed vsync)", () => {
+  it("runs once when timeout fires before rAF and clears dual channels", () => {
     const m = mockHost();
     const state = emptyFrameSchedule();
     const run = vi.fn();
     scheduleOnFrame(state, run, m.host);
+    expect(isFrameSchedulePending(state)).toBe(true);
+    expect(m.rafCount()).toBe(1);
+    expect(m.timeoutCount()).toBe(1);
     m.flushTimeout();
     expect(run).toHaveBeenCalledTimes(1);
     expect(isFrameSchedulePending(state)).toBe(false);
     expect(m.rafCount()).toBe(0);
+    expect(m.timeoutCount()).toBe(0);
   });
 
-  it("cancelFrameSchedule drops both handles", () => {
+  it("cancelFrameSchedule cancels pending rAF", () => {
     const m = mockHost();
     const state = emptyFrameSchedule();
     const run = vi.fn();

--- a/src/lib/frameSchedule.ts
+++ b/src/lib/frameSchedule.ts
@@ -56,13 +56,12 @@ export function scheduleOnFrame(
   state: FrameSchedule,
   run: () => void,
   host: FrameScheduleHost = defaultHost,
-  fallbackMs: number = MIXED_DISPLAY_FRAME_FALLBACK_MS,
 ): void {
-  if (isFrameSchedulePending(state)) return;
+  if (state.raf != null || state.timeout != null) return;
   const fire = () => {
     cancelFrameSchedule(state, host);
     run();
   };
   state.raf = host.raf(fire);
-  state.timeout = host.timeout(fire, fallbackMs);
+  state.timeout = host.timeout(fire, MIXED_DISPLAY_FRAME_FALLBACK_MS);
 }

--- a/src/lib/scrollVelocity.test.ts
+++ b/src/lib/scrollVelocity.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { createScrollVelocityTracker } from "./scrollVelocity";
+
+describe("createScrollVelocityTracker", () => {
+  it("detects active motion when scrollTop changes", () => {
+    const tracker = createScrollVelocityTracker();
+    tracker.sample(100, 1000);
+    const state = tracker.sample(150, 1016); // 50px in 16ms = ~3.125 px/ms
+    expect(state.isMoving).toBe(true);
+    expect(state.velocity).toBeCloseTo(3.125, 2);
+  });
+
+  it("settles to stopped when static across frames AND settle time elapsed", () => {
+    const tracker = createScrollVelocityTracker({
+      stopThresholdPxPerMs: 0.05,
+      settleFrames: 3,
+      settleTimeMs: 40,
+    });
+    tracker.sample(200, 1000);
+    tracker.sample(200, 1016); // frame 1 (stillness began at 1000)
+    tracker.sample(200, 1032); // frame 2
+    const state = tracker.sample(200, 1048); // frame 3, still for 48ms >= 40ms
+    expect(state.isMoving).toBe(false);
+    expect(state.velocity).toBe(0);
+  });
+
+  it("does NOT settle during a brief lift-off event gap (frames ok, time not)", () => {
+    // Default settleTimeMs = 160: a ~50ms contact→inertia gap at 120Hz used to
+    // pass the 3-frame rule and fire settle work mid-gesture.
+    const tracker = createScrollVelocityTracker({ settleFrames: 3 });
+    tracker.sample(1000, 1000);
+    tracker.sample(1100, 1008); // active drag
+    // Lift-off gap: 6 static frames over ~50ms at 120Hz
+    let state = tracker.sample(1100, 1016);
+    for (let t = 1024; t <= 1056; t += 8) {
+      state = tracker.sample(1100, t);
+    }
+    expect(state.isMoving).toBe(true);
+    // Inertia resumes: motion continues seamlessly
+    state = tracker.sample(1160, 1064);
+    expect(state.isMoving).toBe(true);
+    // True stop: stillness sustained past 160ms
+    for (let t = 1072; t <= 1240; t += 8) {
+      state = tracker.sample(1160, t);
+    }
+    expect(state.isMoving).toBe(false);
+  });
+
+  it("keeps isMoving=true immediately after reset until settle conditions elapse", () => {
+    const tracker = createScrollVelocityTracker({ settleFrames: 3, settleTimeMs: 40 });
+    tracker.sample(100, 1000);
+    tracker.sample(500, 1016);
+    // Gesture start reset
+    tracker.reset(500, 1050);
+    // First frame sampled after reset (even if dy=0) must NOT immediately declare stopped
+    const frame1 = tracker.sample(500, 1066);
+    expect(frame1.isMoving).toBe(true);
+    const frame2 = tracker.sample(500, 1082);
+    expect(frame2.isMoving).toBe(true);
+    const frame3 = tracker.sample(500, 1098); // 3 frames + 48ms stillness
+    expect(frame3.isMoving).toBe(false);
+  });
+});

--- a/src/lib/scrollVelocity.ts
+++ b/src/lib/scrollVelocity.ts
@@ -1,0 +1,91 @@
+/**
+ * High-precision scroll velocity and motion state tracker.
+ *
+ * Replaces setTimeout heuristics with instantaneous velocity derivatives:
+ * v = |dy| / dt (px/ms). Motion settles to stopped only when velocity
+ * stays below threshold across consecutive VSync frames AND for a minimum
+ * wall-clock duration.
+ *
+ * The time floor matters on Windows precision touchpads: between the last
+ * finger-contact wheel event and the first OS inertia event there is a short
+ * gap (tens of ms). A frames-only rule (3 frames ≈ 25ms at 120Hz) declared
+ * "settled" inside that gap, firing the heavy settle work (anchor flush,
+ * window rebuild, hover restore) exactly at lift-off — which split one
+ * gesture into two visibly separate segments with a freeze in between.
+ */
+
+export type ScrollVelocityState = {
+  velocity: number; // px/ms
+  isMoving: boolean;
+  scrollTop: number;
+  timestamp: number;
+};
+
+export type ScrollVelocityTrackerOptions = {
+  /** Stop threshold in px/ms. Default 0.02 px/ms (~20px/s) */
+  stopThresholdPxPerMs?: number;
+  /** Number of consecutive static frames before declaring stop. Default 3 */
+  settleFrames?: number;
+  /**
+   * Minimum continuous stillness (wall-clock ms) before declaring stop.
+   * Default 160ms — longer than the contact→inertia event gap at lift-off.
+   */
+  settleTimeMs?: number;
+};
+
+export function createScrollVelocityTracker(options?: ScrollVelocityTrackerOptions) {
+  const stopThreshold = options?.stopThresholdPxPerMs ?? 0.02;
+  const minSettleFrames = options?.settleFrames ?? 3;
+  const settleTimeMs = options?.settleTimeMs ?? 160;
+  let lastTop = 0;
+  let lastTime = 0;
+  let staticFrameCount = 0;
+  /** Timestamp when continuous stillness began; -1 while moving. */
+  let stillSince = -1;
+
+  return {
+    sample(scrollTop: number, nowMs: number): ScrollVelocityState {
+      if (lastTime === 0) {
+        lastTop = scrollTop;
+        lastTime = nowMs;
+        staticFrameCount = 0;
+        stillSince = -1;
+        return { velocity: 0, isMoving: false, scrollTop, timestamp: nowMs };
+      }
+      const dt = Math.max(1, nowMs - lastTime);
+      const dy = Math.abs(scrollTop - lastTop);
+      const velocity = dy / dt;
+
+      if (velocity < stopThreshold) {
+        staticFrameCount++;
+        // Position has not changed since the previous sample, so stillness
+        // began then — not now.
+        if (stillSince < 0) stillSince = lastTime;
+      } else {
+        staticFrameCount = 0;
+        stillSince = -1;
+      }
+
+      lastTop = scrollTop;
+      lastTime = nowMs;
+
+      const settled =
+        staticFrameCount >= minSettleFrames &&
+        stillSince >= 0 &&
+        nowMs - stillSince >= settleTimeMs;
+      return {
+        velocity: velocity < stopThreshold ? 0 : velocity,
+        isMoving: !settled,
+        scrollTop,
+        timestamp: nowMs,
+      };
+    },
+
+    reset(scrollTop = 0, nowMs = 0) {
+      lastTop = scrollTop;
+      lastTime = nowMs;
+      staticFrameCount = 0;
+      stillSince = -1;
+    },
+  };
+}

--- a/src/lib/toolDisplay.test.ts
+++ b/src/lib/toolDisplay.test.ts
@@ -7,6 +7,7 @@ import {
   summarizeToolDisplay,
   toolDetailTail,
   toolExpandBody,
+  toolExpandHasBody,
   toolInputDisplay,
   toolOutputBody,
 } from "./toolDisplay";
@@ -240,4 +241,65 @@ describe("resolveToolPrimaryLabel fallback", () => {
     const label = resolveToolPrimaryLabel({ toolCallId: "call_x" }, enTr);
     expect(label).toBe("Tool");
   });
+});
+
+describe("toolExpandHasBody", () => {
+  // The cheap predicate must agree with the full builder — collapsed rows
+  // decide the expand caret from it without building body strings.
+  const cases: Array<{
+    name: string;
+    seg: Parameters<typeof toolExpandBody>[0];
+    failed: boolean;
+  }> = [
+    { name: "empty tool", seg: { toolKind: "read_file" }, failed: false },
+    {
+      name: "plain output",
+      seg: { toolKind: "run_terminal_command", output: "hello\nworld" },
+      failed: false,
+    },
+    {
+      name: "whitespace-only output, no detail",
+      seg: { toolKind: "read_file", output: "   \n \n" },
+      failed: false,
+    },
+    {
+      name: "whitespace output but detail fallback",
+      seg: { toolKind: "read_file", output: "", detail: "src/app.ts" },
+      failed: false,
+    },
+    {
+      name: "failed with path hint",
+      seg: { toolKind: "edit_file", path: "src/x.ts" },
+      failed: true,
+    },
+    {
+      name: "failed with nothing at all",
+      seg: { toolKind: "edit_file" },
+      failed: true,
+    },
+    {
+      name: "host side-channel detail",
+      seg: {
+        toolCallId: "host-vision-1",
+        toolKind: "",
+        detail: "line1\nline2",
+      },
+      failed: false,
+    },
+    {
+      name: "long output (head sample path)",
+      seg: {
+        toolKind: "run_terminal_command",
+        output: `${" ".repeat(3000)}\ntail content`,
+      },
+      failed: false,
+    },
+  ];
+  for (const c of cases) {
+    it(`matches toolExpandBody().hasBody: ${c.name}`, () => {
+      expect(toolExpandHasBody(c.seg, c.failed)).toBe(
+        toolExpandBody(c.seg, c.failed).hasBody,
+      );
+    });
+  }
 });

--- a/src/lib/toolDisplay.ts
+++ b/src/lib/toolDisplay.ts
@@ -515,6 +515,41 @@ export function toolOutputBody(
 }
 
 /**
+ * Cheap "would {@link toolOutputBody} be non-empty" check that avoids
+ * ANSI-stripping and line-splitting the whole output. Samples the head;
+ * printable content virtually always appears early, and the full strip only
+ * runs for pathological ANSI/whitespace-only heads.
+ */
+function hasToolOutputContent(output: string | null | undefined): boolean {
+  const raw = output || "";
+  if (!raw) return false;
+  const head = raw.length > 2048 ? raw.slice(0, 2048) : raw;
+  if (/\S/.test(stripAnsi(head))) return true;
+  if (raw.length <= 2048) return false;
+  return /\S/.test(stripAnsi(raw));
+}
+
+/**
+ * Cheap predicate: would {@link toolExpandBody} return `hasBody: true`?
+ *
+ * Collapsed activity rows (the common case while a big "Worked for …" phase
+ * scrolls into view) only need this boolean to decide whether to show the
+ * expand caret. Building the real body eagerly stripped + split every tool's
+ * full output on mount — tens of ms for a 30-tool phase mid-scroll.
+ */
+export function toolExpandHasBody(
+  seg: ToolLabelSource & { isError?: boolean; status?: string },
+  failed: boolean,
+): boolean {
+  // Mirrors toolExpandBody: a failed row always has at least the fail hint
+  // (or an empty one, in which case the other branches decide).
+  if (failed && (seg.path || seg.detail || "").trim()) return true;
+  if (hasToolOutputContent(seg.output)) return true;
+  const hostSide = /^(host-vision|host-x)/i.test(seg.toolCallId || "");
+  return !!toolDetailTail(seg.detail, hostSide ? 24 : 8);
+}
+
+/**
  * Expand body for a tool step.
  *
  * Precedence: real tool output (ACP `content[]`) wins; `detail` is only a

--- a/src/styles/modals.part3.css
+++ b/src/styles/modals.part3.css
@@ -846,3 +846,7 @@
 .ext-badge--muted {
   opacity: 0.92;
 }
+
+div[data-virt-index] {
+  contain: layout style;
+}


### PR DESCRIPTION
Fixes #853

Follow-up to #842 / #843. Long transcripts still hitched after the layout-thrash fix: Worked-for blocks, trackpad lift-off, and re-pin at the bottom.

## Summary
- Virtual-window growth that still covers the viewport commits in the background (`startTransition`) and mounts at most 3 rows per frame
- Collapsed tool steps use a cheap `toolExpandHasBody` check; `toolExpandBody` (ANSI strip) waits until the row is opened
- Settle uses scroll velocity plus a 160ms stillness floor so the contact→inertia gap is not treated as a stop
- Hover is disabled while scrolling (`data-scrolling` + inherited `pointer-events`)
- Pin snap restores the pre-commit distance from the bottom so expanding overscan does not bounce
- Plain short assistant text skips ReactMarkdown; overscan is larger for background pre-mount

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan
- [x] `npx vitest run` on chatVirtualList / scrollVelocity / chatScrollAnchor / toolDisplay / frameSchedule / stickToBottom
- [x] `npx tsc --noEmit`
- [ ] Scroll a long session with several large **Worked for …** blocks (Windows 120Hz touchpad)
- [ ] Lift off mid-scroll: no >300ms freeze before inertia
- [ ] Flick back to bottom: no bounce while overscan expands
- [ ] Expand a collapsed tool row: body still renders

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (scoped vitest + tsc)
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new copy
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — CHANGELOG Unreleased only
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
