### PR TITLE
修复设置页签闪烁并统一胶囊切换动画

### DIFF
--- a/src/components/ExtensionsHooksPanel.tsx
+++ b/src/components/ExtensionsHooksPanel.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import * as api from "@/lib/api";
 import { createT, type Locale } from "@/i18n";
 import { GlassModal } from "@/components/GlassModal";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import {
   IconExternalLink,
   IconFolder,
@@ -1106,32 +1107,27 @@ export function ExtensionsHooksPanel({
             </div>
           </div>
           {activity.length > 0 ? (
-            <div
-              className="settings-seg ext-hooks-activity__chips"
+            <SegmentedControl
               role="tablist"
-              aria-label={tr("ext.hooks.activity.filterLabel")}
-            >
-              {OUTCOME_FILTERS.map((id) => (
-                <button
-                  key={id}
-                  type="button"
-                  role="tab"
-                  aria-selected={outcomeFilter === id}
-                  className={
-                    "settings-seg__btn" + (outcomeFilter === id ? " is-on" : "")
-                  }
-                  onClick={() => {
-                    setOutcomeFilter(id);
-                    setExportMsg(null);
-                  }}
-                >
-                  {filterChipLabel(id, tr)}
-                  <span className="ext-hooks-activity__count" aria-hidden>
-                    {activityCounts[id]}
-                  </span>
-                </button>
-              ))}
-            </div>
+              ariaLabel={tr("ext.hooks.activity.filterLabel")}
+              className="ext-hooks-activity__chips"
+              value={outcomeFilter}
+              options={OUTCOME_FILTERS.map((id) => ({
+                value: id,
+                label: (
+                  <>
+                    {filterChipLabel(id, tr)}
+                    <span className="ext-hooks-activity__count" aria-hidden>
+                      {activityCounts[id]}
+                    </span>
+                  </>
+                ),
+              }))}
+              onChange={(id) => {
+                setOutcomeFilter(id);
+                setExportMsg(null);
+              }}
+            />
           ) : null}
           {exportMsg ? (
             <p

--- a/src/components/PlanHistoryList.tsx
+++ b/src/components/PlanHistoryList.tsx
@@ -18,6 +18,7 @@ import {
   type PlanHistoryEntry,
 } from "@/lib/planHistory";
 import { formatListTimestamp } from "@/lib/formatDateTime";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 
 export type PlanHistoryDecisionFilter = "all" | PlanHistoryDecision;
 
@@ -170,28 +171,19 @@ export function PlanHistoryList({
         ) : null}
       </div>
 
-      <div
-        className="plan-history__chips settings-seg"
+      <SegmentedControl
         role="tablist"
-        aria-label={labels.listAria}
-      >
-        {chips.map((c) => (
-          <button
-            key={c.id}
-            type="button"
-            role="tab"
-            className={
-              "settings-seg__btn plan-history__chip" +
-              (decisionFilter === c.id ? " is-on" : "")
-            }
-            aria-selected={decisionFilter === c.id}
-            data-testid={`plan-history-filter-${c.id}`}
-            onClick={() => setDecisionFilter(c.id)}
-          >
-            {c.label}
-          </button>
-        ))}
-      </div>
+        ariaLabel={labels.listAria}
+        className="plan-history__chips"
+        value={decisionFilter}
+        options={chips.map((c) => ({
+          value: c.id,
+          label: c.label,
+          className: "plan-history__chip",
+          testId: `plan-history-filter-${c.id}`,
+        }))}
+        onChange={setDecisionFilter}
+      />
 
       {filtered.length === 0 ? (
         <div className="plan-history-empty" role="status">

--- a/src/components/PromptHistoryPanel.tsx
+++ b/src/components/PromptHistoryPanel.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/composerPromptHistory";
 import { previewStoredAsSlash } from "@/lib/draftDoc";
 import { IconClock, IconTrash } from "@/components/icons";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 
 export type { PromptHistoryScope };
 
@@ -185,38 +186,27 @@ export function PromptHistoryPanel({
       data-scope={scope}
     >
       <div className="prompt-history__head">
-        <div
-          className="prompt-history__tabs settings-seg"
+        <SegmentedControl
+          value={scope}
           role="tablist"
-          aria-label={labels.aria}
-        >
-          <button
-            type="button"
-            role="tab"
-            className={
-              "settings-seg__btn prompt-history__tab" +
-              (scope === "session" ? " is-on" : "")
-            }
-            aria-selected={scope === "session"}
-            data-testid="prompt-history-tab-session"
-            onClick={() => onScopeChange("session")}
-          >
-            {labels.tabSession}
-          </button>
-          <button
-            type="button"
-            role="tab"
-            className={
-              "settings-seg__btn prompt-history__tab" +
-              (scope === "recent" ? " is-on" : "")
-            }
-            aria-selected={scope === "recent"}
-            data-testid="prompt-history-tab-recent"
-            onClick={() => onScopeChange("recent")}
-          >
-            {labels.tabRecent}
-          </button>
-        </div>
+          className="prompt-history__tabs"
+          ariaLabel={labels.aria}
+          options={[
+            {
+              value: "session",
+              label: labels.tabSession,
+              className: "prompt-history__tab",
+              testId: "prompt-history-tab-session",
+            },
+            {
+              value: "recent",
+              label: labels.tabRecent,
+              className: "prompt-history__tab",
+              testId: "prompt-history-tab-recent",
+            },
+          ]}
+          onChange={onScopeChange}
+        />
         {showClearRecent ? (
           <button
             type="button"

--- a/src/components/ReliabilityCenterModal.tsx
+++ b/src/components/ReliabilityCenterModal.tsx
@@ -11,6 +11,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { GlassModal } from "@/components/GlassModal";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import {
   IconActivity,
   IconAlertTriangle,
@@ -1030,28 +1031,19 @@ export function ReliabilityCenterModal({
                   </div>
 
                   {goalPhaseChips.length > 0 ? (
-                    <div
-                      className="reliab-timeline__chips settings-seg"
+                    <SegmentedControl
                       role="tablist"
-                      aria-label={t("reliability.goal.filterAria")}
-                    >
-                      {goalChips.map((c) => (
-                        <button
-                          key={c.id}
-                          type="button"
-                          role="tab"
-                          className={
-                            "settings-seg__btn reliab-timeline__chip" +
-                            (goalPhaseFilter === c.id ? " is-on" : "")
-                          }
-                          aria-selected={goalPhaseFilter === c.id}
-                          data-testid={`reliab-goal-filter-${c.id}`}
-                          onClick={() => setGoalPhaseFilter(c.id)}
-                        >
-                          {c.label}
-                        </button>
-                      ))}
-                    </div>
+                      ariaLabel={t("reliability.goal.filterAria")}
+                      className="reliab-timeline__chips"
+                      value={goalPhaseFilter}
+                      options={goalChips.map((c) => ({
+                        value: c.id,
+                        label: c.label,
+                        className: "reliab-timeline__chip",
+                        testId: `reliab-goal-filter-${c.id}`,
+                      }))}
+                      onChange={setGoalPhaseFilter}
+                    />
                   ) : null}
                 </>
               ) : null}
@@ -1206,28 +1198,19 @@ export function ReliabilityCenterModal({
                   </button>
                 </div>
 
-                <div
-                  className="reliab-timeline__chips settings-seg"
+                <SegmentedControl
                   role="tablist"
-                  aria-label={t("reliability.timeline.filterAria")}
-                >
-                  {historyChips.map((c) => (
-                    <button
-                      key={c.id}
-                      type="button"
-                      role="tab"
-                      className={
-                        "settings-seg__btn reliab-timeline__chip" +
-                        (historyKind === c.id ? " is-on" : "")
-                      }
-                      aria-selected={historyKind === c.id}
-                      data-testid={`reliab-timeline-filter-${c.id}`}
-                      onClick={() => setHistoryKind(c.id)}
-                    >
-                      {c.label}
-                    </button>
-                  ))}
-                </div>
+                  ariaLabel={t("reliability.timeline.filterAria")}
+                  className="reliab-timeline__chips"
+                  value={historyKind}
+                  options={historyChips.map((c) => ({
+                    value: c.id,
+                    label: c.label,
+                    className: "reliab-timeline__chip",
+                    testId: `reliab-timeline-filter-${c.id}`,
+                  }))}
+                  onChange={setHistoryKind}
+                />
 
                 {timelineEmpty ? (
                   <div
@@ -1378,28 +1361,19 @@ export function ReliabilityCenterModal({
               </button>
             </div>
 
-            <div
-              className="reliab-timeline__chips settings-seg"
+            <SegmentedControl
               role="tablist"
-              aria-label={t("reliability.audit.filterAria")}
-            >
-              {auditChips.map((c) => (
-                <button
-                  key={c.id}
-                  type="button"
-                  role="tab"
-                  className={
-                    "settings-seg__btn reliab-timeline__chip" +
-                    (auditEvent === c.id ? " is-on" : "")
-                  }
-                  aria-selected={auditEvent === c.id}
-                  data-testid={`reliab-audit-filter-${c.id}`}
-                  onClick={() => setAuditEvent(c.id)}
-                >
-                  {c.label}
-                </button>
-              ))}
-            </div>
+              ariaLabel={t("reliability.audit.filterAria")}
+              className="reliab-timeline__chips"
+              value={auditEvent}
+              options={auditChips.map((c) => ({
+                value: c.id,
+                label: c.label,
+                className: "reliab-timeline__chip",
+                testId: `reliab-audit-filter-${c.id}`,
+              }))}
+              onChange={setAuditEvent}
+            />
 
             <div
               className="reliab-timeline__toolbar"

--- a/src/components/remoteIm/RimControls.tsx
+++ b/src/components/remoteIm/RimControls.tsx
@@ -6,6 +6,7 @@
 import type { ReactNode } from "react";
 import { IconCheck } from "@/components/icons";
 import { Select, type SelectOption } from "@/components/Select";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 
 export function RimSwitch({
   checked,
@@ -116,22 +117,14 @@ export function RimSeg({
   ariaLabel?: string;
 }) {
   return (
-    <div className="settings-seg settings-seg--lg" role="tablist" aria-label={ariaLabel}>
-      {options.map((o) => (
-        <button
-          key={o.value}
-          type="button"
-          role="tab"
-          aria-selected={value === o.value}
-          className={
-            "settings-seg__btn" + (value === o.value ? " is-on" : "")
-          }
-          onClick={() => onChange(o.value)}
-        >
-          {o.label}
-        </button>
-      ))}
-    </div>
+    <SegmentedControl
+      value={value}
+      role="tablist"
+      large
+      ariaLabel={ariaLabel}
+      options={options}
+      onChange={onChange}
+    />
   );
 }
 

--- a/src/components/settings/AccountSection.tsx
+++ b/src/components/settings/AccountSection.tsx
@@ -7,6 +7,7 @@ import type { SettingsViewModel } from "./types";
 import { AccountPanel } from "@/components/AccountPanel";
 import { OfficialAuxPanel } from "@/components/OfficialAuxPanel";
 import { ProvidersPanel } from "@/components/ProvidersPanel";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import { resolveLocale } from "@/i18n";
 
 
@@ -48,7 +49,6 @@ export function AccountSection() {
 <>
             <div
               className="settings-account-tabs"
-              role="tablist"
               id={
                 activeTab === "providers"
                   ? "settings-anchor-account-providers"
@@ -57,58 +57,21 @@ export function AccountSection() {
                     : "settings-anchor-account-official"
               }
             >
-              <div className="settings-seg settings-seg--lg" role="presentation">
-                <button
-                  type="button"
-                  role="tab"
-                  className={
-                    "settings-seg__btn" +
-                    (activeTab === "official" || activeTab == null
-                      ? " is-on"
-                      : "")
-                  }
-                  aria-selected={activeTab === "official" || activeTab == null}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setSectionTab("official");
-                  }}
-                >
-                  {t("settings.tabOfficial")}
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  className={
-                    "settings-seg__btn" +
-                    (activeTab === "providers" ? " is-on" : "")
-                  }
-                  aria-selected={activeTab === "providers"}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setSectionTab("providers");
-                  }}
-                >
-                  {t("settings.tabProviders")}
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  className={
-                    "settings-seg__btn" +
-                    (activeTab === "extras" ? " is-on" : "")
-                  }
-                  aria-selected={activeTab === "extras"}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setSectionTab("extras");
-                  }}
-                >
-                  {t("settings.tabExtras")}
-                </button>
-              </div>
+              <SegmentedControl
+                value={activeTab ?? "official"}
+                role="tablist"
+                large
+                options={[
+                  { value: "official", label: t("settings.tabOfficial") },
+                  { value: "providers", label: t("settings.tabProviders") },
+                  { value: "extras", label: t("settings.tabExtras") },
+                ]}
+                onChange={(tab, event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setSectionTab(tab);
+                }}
+              />
               {activeTab === "providers" ? (
                 <p className="settings-account-tabs__hint">
                   {t("settings.tabProvidersHint")}

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -7,6 +7,7 @@ import type { SettingsViewModel } from "./types";
 import { Select } from "@/components/Select";
 import { FontFamilySelect } from "./FontFamilySelect";
 import { IconAppearance, IconCrop, IconHelp } from "@/components/icons";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import { Tip } from "@/components/ui/tooltip";
 import {
   DEFAULT_WALLPAPER_FOCUS,
@@ -175,48 +176,25 @@ export function AppearanceSection() {
                         tip={t("settings.themeDesc")}
                       />
                     </div>
-                    <div
-                      className="settings-seg"
-                      role="radiogroup"
-                      aria-label={t("settings.theme")}
-                    >
-                      <button
-                        type="button"
-                        role="radio"
-                        aria-checked={themePreference === "system"}
-                        className={
-                          "settings-seg__btn" +
-                          (themePreference === "system" ? " is-on" : "")
-                        }
-                        onClick={() => onTheme("system")}
-                      >
-                        {t("settings.themeSystem")}
-                      </button>
-                      <button
-                        type="button"
-                        role="radio"
-                        aria-checked={themePreference === "light"}
-                        className={
-                          "settings-seg__btn" +
-                          (themePreference === "light" ? " is-on" : "")
-                        }
-                        onClick={() => onTheme("light")}
-                      >
-                        {t("settings.themeLight")}
-                      </button>
-                      <button
-                        type="button"
-                        role="radio"
-                        aria-checked={themePreference === "dark"}
-                        className={
-                          "settings-seg__btn" +
-                          (themePreference === "dark" ? " is-on" : "")
-                        }
-                        onClick={() => onTheme("dark")}
-                      >
-                        {t("settings.themeDark")}
-                      </button>
-                    </div>
+                    <SegmentedControl
+                      value={themePreference}
+                      ariaLabel={t("settings.theme")}
+                      options={[
+                        {
+                          value: "system",
+                          label: t("settings.themeSystem"),
+                        },
+                        {
+                          value: "light",
+                          label: t("settings.themeLight"),
+                        },
+                        {
+                          value: "dark",
+                          label: t("settings.themeDark"),
+                        },
+                      ]}
+                      onChange={onTheme}
+                    />
                   </div>
                   {onThemeSchedule ? (
                     <>
@@ -891,27 +869,15 @@ export function AppearanceSection() {
                         tip={t("settings.chatFontScaleDesc")}
                       />
                     </div>
-                    <div
-                      className="settings-seg"
-                      role="radiogroup"
-                      aria-label={t("settings.chatFontScale")}
-                    >
-                      {CHAT_FONT_SCALES.map((scale) => (
-                        <button
-                          key={scale}
-                          type="button"
-                          role="radio"
-                          aria-checked={chatFontScale === scale}
-                          className={
-                            "settings-seg__btn" +
-                            (chatFontScale === scale ? " is-on" : "")
-                          }
-                          onClick={() => onChatFontScale(scale)}
-                        >
-                          {t(`settings.chatFontScale.${scale}`)}
-                        </button>
-                      ))}
-                    </div>
+                    <SegmentedControl
+                      value={chatFontScale}
+                      ariaLabel={t("settings.chatFontScale")}
+                      options={CHAT_FONT_SCALES.map((scale) => ({
+                        value: scale,
+                        label: t(`settings.chatFontScale.${scale}`),
+                      }))}
+                      onChange={onChatFontScale}
+                    />
                   </div>
                 </div>
                 <div
@@ -928,27 +894,15 @@ export function AppearanceSection() {
                         tip={t("settings.codeFontScaleDesc")}
                       />
                     </div>
-                    <div
-                      className="settings-seg"
-                      role="radiogroup"
-                      aria-label={t("settings.codeFontScale")}
-                    >
-                      {CODE_FONT_SCALES.map((scale) => (
-                        <button
-                          key={scale}
-                          type="button"
-                          role="radio"
-                          aria-checked={codeFontScale === scale}
-                          className={
-                            "settings-seg__btn" +
-                            (codeFontScale === scale ? " is-on" : "")
-                          }
-                          onClick={() => onCodeFontScale(scale)}
-                        >
-                          {t(`settings.codeFontScale.${scale}`)}
-                        </button>
-                      ))}
-                    </div>
+                    <SegmentedControl
+                      value={codeFontScale}
+                      ariaLabel={t("settings.codeFontScale")}
+                      options={CODE_FONT_SCALES.map((scale) => ({
+                        value: scale,
+                        label: t(`settings.codeFontScale.${scale}`),
+                      }))}
+                      onChange={onCodeFontScale}
+                    />
                   </div>
                 </div>
                 <div
@@ -965,27 +919,15 @@ export function AppearanceSection() {
                         tip={t("settings.chatDensityDesc")}
                       />
                     </div>
-                    <div
-                      className="settings-seg"
-                      role="radiogroup"
-                      aria-label={t("settings.chatDensity")}
-                    >
-                      {CHAT_DENSITIES.map((density) => (
-                        <button
-                          key={density}
-                          type="button"
-                          role="radio"
-                          aria-checked={chatDensity === density}
-                          className={
-                            "settings-seg__btn" +
-                            (chatDensity === density ? " is-on" : "")
-                          }
-                          onClick={() => onChatDensity(density)}
-                        >
-                          {t(`settings.chatDensity.${density}`)}
-                        </button>
-                      ))}
-                    </div>
+                    <SegmentedControl
+                      value={chatDensity}
+                      ariaLabel={t("settings.chatDensity")}
+                      options={CHAT_DENSITIES.map((density) => ({
+                        value: density,
+                        label: t(`settings.chatDensity.${density}`),
+                      }))}
+                      onChange={onChatDensity}
+                    />
                   </div>
                 </div>
                 <div
@@ -1002,27 +944,15 @@ export function AppearanceSection() {
                         tip={t("settings.chatWidthDesc")}
                       />
                     </div>
-                    <div
-                      className="settings-seg"
-                      role="radiogroup"
-                      aria-label={t("settings.chatWidth")}
-                    >
-                      {CHAT_WIDTHS.map((width) => (
-                        <button
-                          key={width}
-                          type="button"
-                          role="radio"
-                          aria-checked={chatWidth === width}
-                          className={
-                            "settings-seg__btn" +
-                            (chatWidth === width ? " is-on" : "")
-                          }
-                          onClick={() => onChatWidth(width)}
-                        >
-                          {t(`settings.chatWidth.${width}`)}
-                        </button>
-                      ))}
-                    </div>
+                    <SegmentedControl
+                      value={chatWidth}
+                      ariaLabel={t("settings.chatWidth")}
+                      options={CHAT_WIDTHS.map((width) => ({
+                        value: width,
+                        label: t(`settings.chatWidth.${width}`),
+                      }))}
+                      onChange={onChatWidth}
+                    />
                   </div>
                 </div>
                 <div
@@ -1039,27 +969,15 @@ export function AppearanceSection() {
                         tip={t("settings.sidebarDensityDesc")}
                       />
                     </div>
-                    <div
-                      className="settings-seg"
-                      role="radiogroup"
-                      aria-label={t("settings.sidebarDensity")}
-                    >
-                      {SIDEBAR_DENSITIES.map((density) => (
-                        <button
-                          key={density}
-                          type="button"
-                          role="radio"
-                          aria-checked={sidebarDensity === density}
-                          className={
-                            "settings-seg__btn" +
-                            (sidebarDensity === density ? " is-on" : "")
-                          }
-                          onClick={() => onSidebarDensity(density)}
-                        >
-                          {t(`settings.sidebarDensity.${density}`)}
-                        </button>
-                      ))}
-                    </div>
+                    <SegmentedControl
+                      value={sidebarDensity}
+                      ariaLabel={t("settings.sidebarDensity")}
+                      options={SIDEBAR_DENSITIES.map((density) => ({
+                        value: density,
+                        label: t(`settings.sidebarDensity.${density}`),
+                      }))}
+                      onChange={onSidebarDensity}
+                    />
                   </div>
                 </div>
                 <div
@@ -1076,27 +994,15 @@ export function AppearanceSection() {
                         tip={t("settings.messageActionsDesc")}
                       />
                     </div>
-                    <div
-                      className="settings-seg"
-                      role="radiogroup"
-                      aria-label={t("settings.messageActions")}
-                    >
-                      {MESSAGE_ACTIONS_VISIBILITIES.map((mode) => (
-                        <button
-                          key={mode}
-                          type="button"
-                          role="radio"
-                          aria-checked={messageActionsVisibility === mode}
-                          className={
-                            "settings-seg__btn" +
-                            (messageActionsVisibility === mode ? " is-on" : "")
-                          }
-                          onClick={() => onMessageActionsVisibility(mode)}
-                        >
-                          {t(`settings.messageActions.${mode}`)}
-                        </button>
-                      ))}
-                    </div>
+                    <SegmentedControl
+                      value={messageActionsVisibility}
+                      ariaLabel={t("settings.messageActions")}
+                      options={MESSAGE_ACTIONS_VISIBILITIES.map((mode) => ({
+                        value: mode,
+                        label: t(`settings.messageActions.${mode}`),
+                      }))}
+                      onChange={onMessageActionsVisibility}
+                    />
                   </div>
                 </div>
                 <div
@@ -1437,27 +1343,15 @@ export function AppearanceSection() {
                           tip={t("settings.messageTimeFormatDesc")}
                         />
                       </div>
-                      <div
-                        className="settings-seg"
-                        role="radiogroup"
-                        aria-label={t("settings.messageTimeFormat")}
-                      >
-                        {MESSAGE_TIME_FORMATS.map((mode) => (
-                          <button
-                            key={mode}
-                            type="button"
-                            role="radio"
-                            aria-checked={messageTimeFormat === mode}
-                            className={
-                              "settings-seg__btn" +
-                              (messageTimeFormat === mode ? " is-on" : "")
-                            }
-                            onClick={() => onMessageTimeFormat(mode)}
-                          >
-                            {t(`settings.messageTimeFormat.${mode}`)}
-                          </button>
-                        ))}
-                      </div>
+                      <SegmentedControl
+                        value={messageTimeFormat}
+                        ariaLabel={t("settings.messageTimeFormat")}
+                        options={MESSAGE_TIME_FORMATS.map((mode) => ({
+                          value: mode,
+                          label: t(`settings.messageTimeFormat.${mode}`),
+                        }))}
+                        onChange={onMessageTimeFormat}
+                      />
                     </div>
                   </div>
                 ) : null}

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -6,6 +6,7 @@ import { useSettingsModel } from "@/providers/SettingsModelContext";
 import type { SettingsViewModel } from "./types";
 
 import { Select } from "@/components/Select";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import { IconLanguage, IconShield } from "@/components/icons";
 import {
   COMMON_DISALLOWED_TOOLS,
@@ -362,27 +363,15 @@ export function GeneralSection() {
                     {t("settings.composerMinRowsDesc")}
                   </div>
                 </div>
-                <div
-                  className="settings-seg"
-                  role="radiogroup"
-                  aria-label={t("settings.composerMinRows")}
-                >
-                  {COMPOSER_MIN_ROWS_OPTIONS.map((rows) => (
-                    <button
-                      key={rows}
-                      type="button"
-                      role="radio"
-                      aria-checked={composerMinRows === rows}
-                      className={
-                        "settings-seg__btn" +
-                        (composerMinRows === rows ? " is-on" : "")
-                      }
-                      onClick={() => onComposerMinRows(rows)}
-                    >
-                      {t(`settings.composerMinRows.${rows}`)}
-                    </button>
-                  ))}
-                </div>
+                <SegmentedControl
+                  value={composerMinRows}
+                  ariaLabel={t("settings.composerMinRows")}
+                  options={COMPOSER_MIN_ROWS_OPTIONS.map((rows) => ({
+                    value: rows,
+                    label: t(`settings.composerMinRows.${rows}`),
+                  }))}
+                  onChange={onComposerMinRows}
+                />
               </div>
               <div
                 className={

--- a/src/components/settings/RuntimeSection.tsx
+++ b/src/components/settings/RuntimeSection.tsx
@@ -5,6 +5,7 @@ import { useSettingsModel } from "@/providers/SettingsModelContext";
 import type { SettingsViewModel } from "./types";
 
 import { Select } from "@/components/Select";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import { ProjectInspectPanel } from "@/components/ProjectInspectPanel";
 import { GitPrHubPanel } from "@/components/GitPrHubPanel";
 import { PrivacyCenterPanel } from "@/components/PrivacyCenterPanel";
@@ -813,13 +814,17 @@ export function RuntimeSection() {
                           {t("reliability.audit.retentionDesc")}
                         </div>
                       </div>
-                      <div
-                        className="settings-seg"
-                        role="radiogroup"
-                        aria-label={t("reliability.audit.retentionAria")}
-                        data-testid="settings-audit-retention"
-                      >
-                        {(
+                      <SegmentedControl
+                        value={
+                          auditLedgerRetentionDays === 7 ||
+                          auditLedgerRetentionDays === 30 ||
+                          auditLedgerRetentionDays === 90
+                            ? auditLedgerRetentionDays
+                            : 0
+                        }
+                        ariaLabel={t("reliability.audit.retentionAria")}
+                        testId="settings-audit-retention"
+                        options={(
                           [
                             { days: 7, key: "reliability.audit.retention.7" as const },
                             { days: 30, key: "reliability.audit.retention.30" as const },
@@ -829,35 +834,13 @@ export function RuntimeSection() {
                               key: "reliability.audit.retention.unlimited" as const,
                             },
                           ] as const
-                        ).map((opt) => (
-                          <button
-                            key={opt.days}
-                            type="button"
-                            role="radio"
-                            aria-checked={
-                              (auditLedgerRetentionDays === 7 ||
-                              auditLedgerRetentionDays === 30 ||
-                              auditLedgerRetentionDays === 90
-                                ? auditLedgerRetentionDays
-                                : 0) === opt.days
-                            }
-                            className={
-                              "settings-seg__btn" +
-                              ((auditLedgerRetentionDays === 7 ||
-                              auditLedgerRetentionDays === 30 ||
-                              auditLedgerRetentionDays === 90
-                                ? auditLedgerRetentionDays
-                                : 0) === opt.days
-                                ? " is-on"
-                                : "")
-                            }
-                            data-testid={`settings-audit-retention-${opt.days}`}
-                            onClick={() => onAuditLedgerRetentionDays(opt.days)}
-                          >
-                            {t(opt.key)}
-                          </button>
-                        ))}
-                      </div>
+                        ).map((opt) => ({
+                          value: opt.days,
+                          label: t(opt.key),
+                          testId: `settings-audit-retention-${opt.days}`,
+                        }))}
+                        onChange={onAuditLedgerRetentionDays}
+                      />
                     </div>
                   </div>
                 ) : null}

--- a/src/components/settings/shared.tsx
+++ b/src/components/settings/shared.tsx
@@ -18,6 +18,7 @@ import {
   IconUser,
 } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import type { SettingsNavIcon, SettingsTabId } from "@/lib/settingsCatalog";
 import { intlLocale, type MessageKey } from "@/i18n";
 import type { MarqueeBox } from "./types";
@@ -177,27 +178,23 @@ export function SettingsTabStrip({
 }) {
   if (tabs.length === 0) return null;
   return (
-    <div className="settings-account-tabs settings-page__tabs" role="tablist" aria-label={ariaLabel}>
-      <div className="settings-seg settings-seg--lg settings-page__tabs-seg" role="presentation">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            role="tab"
-            className={
-              "settings-seg__btn" + (active === tab.id ? " is-on" : "")
-            }
-            aria-selected={active === tab.id}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onChange(tab.id);
-            }}
-          >
-            {t(tab.labelKey)}
-          </button>
-        ))}
-      </div>
+    <div className="settings-account-tabs settings-page__tabs">
+      <SegmentedControl
+        value={active}
+        role="tablist"
+        large
+        className="settings-page__tabs-seg"
+        ariaLabel={ariaLabel}
+        options={tabs.map((tab) => ({
+          value: tab.id,
+          label: t(tab.labelKey),
+        }))}
+        onChange={(id, event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onChange(id);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/ui/SegmentedControl.test.tsx
+++ b/src/components/ui/SegmentedControl.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SegmentedControl } from "./SegmentedControl";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("SegmentedControl", () => {
+  it("keeps radio semantics and reports numeric values", async () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        value={2}
+        ariaLabel="Rows"
+        options={[
+          { value: 1, label: "One" },
+          { value: 2, label: "Two", testId: "two" },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByRole("radiogroup", { name: "Rows" })).toBeInTheDocument();
+    expect(screen.getByTestId("two")).toHaveAttribute("aria-checked", "true");
+    await userEvent.click(screen.getByRole("radio", { name: "One" }));
+    expect(onChange).toHaveBeenCalledWith(1, expect.anything());
+  });
+
+  it("supports tab semantics and disabled options", () => {
+    render(
+      <SegmentedControl
+        value="current"
+        role="tablist"
+        options={[
+          { value: "current", label: "Current" },
+          { value: "recent", label: "Recent", disabled: true },
+        ]}
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Current" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "Recent" })).toBeDisabled();
+  });
+
+  it("uses roving focus and keyboard selection while skipping disabled options", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SegmentedControl
+        value="current"
+        role="tablist"
+        options={[
+          { value: "first", label: "First" },
+          { value: "current", label: "Current" },
+          { value: "disabled", label: "Disabled", disabled: true },
+          { value: "last", label: "Last" },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    const current = screen.getByRole("tab", { name: "Current" });
+    const last = screen.getByRole("tab", { name: "Last" });
+    const first = screen.getByRole("tab", { name: "First" });
+    expect(current).toHaveAttribute("tabindex", "0");
+    expect(last).toHaveAttribute("tabindex", "-1");
+
+    current.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(last).toHaveFocus();
+    expect(onChange).toHaveBeenLastCalledWith("last", expect.anything());
+
+    await user.keyboard("{Home}");
+    expect(first).toHaveFocus();
+    expect(onChange).toHaveBeenLastCalledWith("first", expect.anything());
+  });
+
+  it("measures the selected button instead of assuming equal widths", () => {
+    vi.spyOn(HTMLElement.prototype, "offsetLeft", "get").mockReturnValue(41);
+    vi.spyOn(HTMLElement.prototype, "offsetTop", "get").mockReturnValue(7);
+    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(83);
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(28);
+    render(
+      <SegmentedControl
+        value="long"
+        options={[
+          { value: "short", label: "A" },
+          { value: "long", label: "A translated label" },
+        ]}
+        onChange={() => undefined}
+      />,
+    );
+
+    const group = screen.getByRole("radiogroup");
+    expect(group).toHaveClass("settings-seg--sliding");
+    expect(group).toHaveStyle({
+      "--seg-x": "41px",
+      "--seg-y": "7px",
+      "--seg-width": "83px",
+      "--seg-height": "28px",
+    });
+  });
+});

--- a/src/components/ui/SegmentedControl.test.tsx
+++ b/src/components/ui/SegmentedControl.test.tsx
@@ -87,9 +87,20 @@ describe("SegmentedControl", () => {
   });
 
   it("measures the selected button instead of assuming equal widths", () => {
+    const activationOrder: Array<[string | null, string | null]> = [];
     vi.spyOn(HTMLElement.prototype, "offsetLeft", "get").mockReturnValue(41);
     vi.spyOn(HTMLElement.prototype, "offsetTop", "get").mockReturnValue(7);
-    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(83);
+    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.getAttribute("role") === "radiogroup") {
+          activationOrder.push([
+            this.getAttribute("data-segmented-ready"),
+            this.getAttribute("data-segmented-animate"),
+          ]);
+        }
+        return 83;
+      },
+    );
     vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(28);
     render(
       <SegmentedControl
@@ -104,6 +115,9 @@ describe("SegmentedControl", () => {
 
     const group = screen.getByRole("radiogroup");
     expect(group).toHaveClass("settings-seg--sliding");
+    expect(group).toHaveAttribute("data-segmented-ready", "1");
+    expect(group).toHaveAttribute("data-segmented-animate", "1");
+    expect(activationOrder).toEqual([["1", null]]);
     expect(group).toHaveStyle({
       "--seg-x": "41px",
       "--seg-y": "7px",

--- a/src/components/ui/SegmentedControl.test.tsx
+++ b/src/components/ui/SegmentedControl.test.tsx
@@ -10,6 +10,7 @@ import { SegmentedControl } from "./SegmentedControl";
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("SegmentedControl", () => {
@@ -123,6 +124,64 @@ describe("SegmentedControl", () => {
       "--seg-y": "7px",
       "--seg-width": "83px",
       "--seg-height": "28px",
+    });
+  });
+
+  it("remeasures the active option after rerender and ResizeObserver updates", () => {
+    let notifyResize: () => void = () => undefined;
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          notifyResize = () => callback([], this as unknown as ResizeObserver);
+        }
+
+        observe() {}
+        disconnect() {}
+      },
+    );
+
+    let geometry = { left: 8, top: 3, width: 52, height: 28 };
+    vi.spyOn(HTMLElement.prototype, "offsetLeft", "get").mockImplementation(
+      () => geometry.left,
+    );
+    vi.spyOn(HTMLElement.prototype, "offsetTop", "get").mockImplementation(
+      () => geometry.top,
+    );
+    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockImplementation(
+      () => geometry.width,
+    );
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+      () => geometry.height,
+    );
+
+    const options = [
+      { value: "first", label: "First" },
+      { value: "second", label: "A longer translated label" },
+    ] as const;
+    const { rerender } = render(
+      <SegmentedControl
+        value="first"
+        options={options}
+        onChange={() => undefined}
+      />,
+    );
+
+    rerender(
+      <SegmentedControl
+        value="second"
+        options={options}
+        onChange={() => undefined}
+      />,
+    );
+    geometry = { left: 66, top: 35, width: 137, height: 30 };
+    notifyResize();
+
+    expect(screen.getByRole("radiogroup")).toHaveStyle({
+      "--seg-x": "66px",
+      "--seg-y": "35px",
+      "--seg-width": "137px",
+      "--seg-height": "30px",
     });
   });
 });

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -49,6 +49,7 @@ export function SegmentedControl<T extends SegmentedControlValue>({
       const active = activeRef.current;
       if (!active) {
         delete root.dataset.segmentedReady;
+        delete root.dataset.segmentedAnimate;
         return;
       }
       root.style.setProperty("--seg-x", `${active.offsetLeft}px`);
@@ -56,6 +57,10 @@ export function SegmentedControl<T extends SegmentedControlValue>({
       root.style.setProperty("--seg-width", `${active.offsetWidth}px`);
       root.style.setProperty("--seg-height", `${active.offsetHeight}px`);
       root.dataset.segmentedReady = "1";
+      if (!root.dataset.segmentedAnimate) {
+        void root.offsetWidth;
+        root.dataset.segmentedAnimate = "1";
+      }
     };
 
     measure();

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -1,0 +1,155 @@
+import {
+  useLayoutEffect,
+  useRef,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+
+export type SegmentedControlValue = string | number;
+
+export type SegmentedControlOption<T extends SegmentedControlValue> = {
+  value: T;
+  label: ReactNode;
+  disabled?: boolean;
+  title?: string;
+  testId?: string;
+  className?: string;
+};
+
+export function SegmentedControl<T extends SegmentedControlValue>({
+  value,
+  options,
+  onChange,
+  role = "radiogroup",
+  ariaLabel,
+  className = "",
+  large = false,
+  disabled = false,
+  testId,
+}: {
+  value: T | null | undefined;
+  options: readonly SegmentedControlOption<T>[];
+  onChange: (value: T, event: MouseEvent<HTMLButtonElement>) => void;
+  role?: "radiogroup" | "tablist";
+  ariaLabel?: string;
+  className?: string;
+  large?: boolean;
+  disabled?: boolean;
+  testId?: string;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef<HTMLButtonElement>(null);
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const measure = () => {
+      const active = activeRef.current;
+      if (!active) {
+        delete root.dataset.segmentedReady;
+        return;
+      }
+      root.style.setProperty("--seg-x", `${active.offsetLeft}px`);
+      root.style.setProperty("--seg-y", `${active.offsetTop}px`);
+      root.style.setProperty("--seg-width", `${active.offsetWidth}px`);
+      root.style.setProperty("--seg-height", `${active.offsetHeight}px`);
+      root.dataset.segmentedReady = "1";
+    };
+
+    measure();
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure);
+      return () => window.removeEventListener("resize", measure);
+    }
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(root);
+    root
+      .querySelectorAll<HTMLElement>(".settings-seg__btn")
+      .forEach((button) => observer.observe(button));
+    return () => observer.disconnect();
+  }, [options, value]);
+
+  const buttonRole = role === "tablist" ? "tab" : "radio";
+  const focusableValue = disabled
+    ? undefined
+    : options.find(
+        (option) => option.value === value && !option.disabled,
+      )?.value ?? options.find((option) => !option.disabled)?.value;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (
+      !["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"].includes(
+        event.key,
+      )
+    ) {
+      return;
+    }
+
+    const buttons = Array.from(
+      rootRef.current?.querySelectorAll<HTMLButtonElement>(
+        ".settings-seg__btn:not(:disabled)",
+      ) ?? [],
+    );
+    const currentIndex = buttons.indexOf(event.currentTarget);
+    if (currentIndex < 0 || buttons.length === 0) return;
+
+    event.preventDefault();
+    const nextIndex =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? buttons.length - 1
+          : event.key === "ArrowLeft" || event.key === "ArrowUp"
+            ? (currentIndex - 1 + buttons.length) % buttons.length
+            : (currentIndex + 1) % buttons.length;
+    const next = buttons[nextIndex];
+    next?.focus();
+    if (next && next !== event.currentTarget) next.click();
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      role={role}
+      aria-orientation="horizontal"
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className={
+        "settings-seg settings-seg--sliding" +
+        (large ? " settings-seg--lg" : "") +
+        (className ? ` ${className}` : "")
+      }
+    >
+      <span className="settings-seg__indicator" aria-hidden />
+      {options.map((option) => {
+        const selected = option.value === value;
+        return (
+          <button
+            key={`${typeof option.value}:${option.value}`}
+            ref={selected ? activeRef : undefined}
+            type="button"
+            role={buttonRole}
+            aria-checked={role === "radiogroup" ? selected : undefined}
+            aria-selected={role === "tablist" ? selected : undefined}
+            disabled={disabled || option.disabled}
+            tabIndex={option.value === focusableValue ? 0 : -1}
+            title={option.title}
+            data-testid={option.testId}
+            className={
+              "settings-seg__btn" +
+              (selected ? " is-on" : "") +
+              (option.className ? ` ${option.className}` : "")
+            }
+            onClick={(event) => onChange(option.value, event)}
+            onKeyDown={handleKeyDown}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/settingsTabMotion.guard.test.ts
+++ b/src/lib/settingsTabMotion.guard.test.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from "node:fs";
+import { globSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const read = (path: string) => readFileSync(resolve(__dirname, path), "utf8");
@@ -34,24 +35,43 @@ describe("settings segmented control motion guard", () => {
     expect(css).toMatch(
       /\.settings-seg--sliding \.settings-seg__btn\s*\{[^}]*white-space:\s*nowrap;/s,
     );
+    expect(css).toMatch(
+      /\.settings-seg--sliding \.settings-seg__btn\.is-on\s*\{[^}]*font-weight:\s*600;/s,
+    );
     expect(css).not.toMatch(/\.settings-page__tabs-seg:has\(/);
   });
 
-  it("routes each exclusive settings control through the shared component", () => {
-    for (const path of [
-      "../components/settings/shared.tsx",
-      "../components/settings/AccountSection.tsx",
-      "../components/settings/AppearanceSection.tsx",
-      "../components/settings/GeneralSection.tsx",
-      "../components/settings/RuntimeSection.tsx",
-      "../components/PromptHistoryPanel.tsx",
-      "../components/remoteIm/RimControls.tsx",
-    ]) {
-      const source = read(path);
-      expect(source).toContain("<SegmentedControl");
-      expect(source).not.toMatch(
-        /className=(?:\{)?["']settings-seg(?:\s|["'])/,
-      );
-    }
+  it("discovers raw segmented markup outside the shared component", () => {
+    const componentsRoot = resolve(__dirname, "../components");
+    const bypasses = globSync("**/*.tsx", { cwd: componentsRoot }).filter(
+      (path) => {
+        if (path.replaceAll("\\", "/") === "ui/SegmentedControl.tsx") {
+          return false;
+        }
+        const source = readFileSync(resolve(componentsRoot, path), "utf8");
+        const sourceFile = ts.createSourceFile(
+          path,
+          source,
+          ts.ScriptTarget.Latest,
+          true,
+          ts.ScriptKind.TSX,
+        );
+        let bypassesSharedControl = false;
+        const visit = (node: ts.Node) => {
+          if (
+            ts.isJsxAttribute(node) &&
+            node.name.getText(sourceFile) === "className" &&
+            node.initializer?.getText(sourceFile).includes("settings-seg")
+          ) {
+            bypassesSharedControl = true;
+          }
+          ts.forEachChild(node, visit);
+        };
+        visit(sourceFile);
+        return bypassesSharedControl;
+      },
+    );
+
+    expect(bypasses).toEqual([]);
   });
 });

--- a/src/lib/settingsTabMotion.guard.test.ts
+++ b/src/lib/settingsTabMotion.guard.test.ts
@@ -2,18 +2,51 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const css = readFileSync(
-  resolve(__dirname, "../styles/settings.part1.css"),
-  "utf8",
-);
+const read = (path: string) => readFileSync(resolve(__dirname, path), "utf8");
+const component = read("../components/ui/SegmentedControl.tsx");
+const css = [
+  read("../styles/settings.part1.css"),
+  read("../styles/settings.part3.css"),
+].join("\n");
 
-describe("settings tab motion guard", () => {
-  it("slides one shared pill only across two-tab strips", () => {
+describe("settings segmented control motion guard", () => {
+  it("positions one shared indicator from the active button geometry", () => {
+    expect(component).toContain("active.offsetLeft");
+    expect(component).toContain("active.offsetTop");
+    expect(component).toContain("active.offsetWidth");
+    expect(component).toContain("active.offsetHeight");
+    expect(component).toContain("new ResizeObserver(measure)");
+    expect(component).toContain('<span className="settings-seg__indicator"');
+  });
+
+  it("limits sliding styles to explicit segmented controls", () => {
     expect(css).toMatch(
-      /\.settings-page__tabs-seg:has\(\s*> \.settings-seg__btn:nth-child\(2\):last-child\s*\)::before\s*\{[^}]*transition:\s*transform var\(--motion-normal\)/,
+      /\.settings-seg--sliding\[data-segmented-ready="1"\][^{]*\.settings-seg__indicator\s*\{[^}]*transform var\(--motion-normal\)/s,
     );
     expect(css).toMatch(
-      /\.settings-page__tabs-seg:has\(\s*> \.settings-seg__btn:nth-child\(2\)\.is-on:last-child\s*\)::before\s*\{[^}]*transform:\s*translateX\(100%\)/,
+      /\.settings-seg--sliding\s*\{[^}]*flex-wrap:\s*wrap;[^}]*max-width:\s*100%;[^}]*flex-shrink:\s*1;/s,
     );
+    expect(css).toMatch(
+      /\.settings-seg--sliding \.settings-seg__btn\s*\{[^}]*white-space:\s*nowrap;/s,
+    );
+    expect(css).not.toMatch(/\.settings-page__tabs-seg:has\(/);
+  });
+
+  it("routes each exclusive settings control through the shared component", () => {
+    for (const path of [
+      "../components/settings/shared.tsx",
+      "../components/settings/AccountSection.tsx",
+      "../components/settings/AppearanceSection.tsx",
+      "../components/settings/GeneralSection.tsx",
+      "../components/settings/RuntimeSection.tsx",
+      "../components/PromptHistoryPanel.tsx",
+      "../components/remoteIm/RimControls.tsx",
+    ]) {
+      const source = read(path);
+      expect(source).toContain("<SegmentedControl");
+      expect(source).not.toMatch(
+        /className=(?:\{)?["']settings-seg(?:\s|["'])/,
+      );
+    }
   });
 });

--- a/src/lib/settingsTabMotion.guard.test.ts
+++ b/src/lib/settingsTabMotion.guard.test.ts
@@ -15,13 +15,18 @@ describe("settings segmented control motion guard", () => {
     expect(component).toContain("active.offsetTop");
     expect(component).toContain("active.offsetWidth");
     expect(component).toContain("active.offsetHeight");
+    expect(component).toContain("void root.offsetWidth");
+    expect(component).toContain('root.dataset.segmentedAnimate = "1"');
     expect(component).toContain("new ResizeObserver(measure)");
     expect(component).toContain('<span className="settings-seg__indicator"');
   });
 
   it("limits sliding styles to explicit segmented controls", () => {
     expect(css).toMatch(
-      /\.settings-seg--sliding\[data-segmented-ready="1"\][^{]*\.settings-seg__indicator\s*\{[^}]*transform var\(--motion-normal\)/s,
+      /\.settings-seg--sliding\[data-segmented-ready="1"\][^{]*\.settings-seg__indicator\s*\{[^}]*opacity:\s*1;?[^}]*\}/s,
+    );
+    expect(css).toMatch(
+      /\.settings-seg--sliding\[data-segmented-animate="1"\][^{]*\.settings-seg__indicator\s*\{[^}]*transform var\(--motion-normal\)/s,
     );
     expect(css).toMatch(
       /\.settings-seg--sliding\s*\{[^}]*flex-wrap:\s*wrap;[^}]*max-width:\s*100%;[^}]*flex-shrink:\s*1;/s,

--- a/src/lib/settingsTabMotion.guard.test.ts
+++ b/src/lib/settingsTabMotion.guard.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(
+  resolve(__dirname, "../styles/settings.part1.css"),
+  "utf8",
+);
+
+describe("settings tab motion guard", () => {
+  it("slides one shared pill only across two-tab strips", () => {
+    expect(css).toMatch(
+      /\.settings-page__tabs-seg:has\(\s*> \.settings-seg__btn:nth-child\(2\):last-child\s*\)::before\s*\{[^}]*transition:\s*transform var\(--motion-normal\)/,
+    );
+    expect(css).toMatch(
+      /\.settings-page__tabs-seg:has\(\s*> \.settings-seg__btn:nth-child\(2\)\.is-on:last-child\s*\)::before\s*\{[^}]*transform:\s*translateX\(100%\)/,
+    );
+  });
+});

--- a/src/styles/settings.part1.css
+++ b/src/styles/settings.part1.css
@@ -520,6 +520,53 @@
   pointer-events: auto;
 }
 
+/* Two-tab strips use one shared selection pill so state changes slide. */
+.settings-page__tabs-seg:has(
+    > .settings-seg__btn:nth-child(2):last-child
+  ) {
+  position: relative;
+  display: inline-grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  isolation: isolate;
+}
+
+.settings-page__tabs-seg:has(
+    > .settings-seg__btn:nth-child(2):last-child
+  )::before {
+  content: "";
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 4px;
+  width: calc(50% - 4px);
+  box-sizing: border-box;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-pop);
+  pointer-events: none;
+  transition: transform var(--motion-normal) var(--motion-pane-ease);
+}
+
+.settings-page__tabs-seg:has(
+    > .settings-seg__btn:nth-child(2).is-on:last-child
+  )::before {
+  transform: translateX(100%);
+}
+
+.settings-page__tabs-seg:has(
+    > .settings-seg__btn:nth-child(2):last-child
+  ) > .settings-seg__btn {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  transition: color var(--motion-fast) ease;
+}
+
 .settings-page__tabs .settings-seg__btn {
   pointer-events: auto;
   cursor: pointer;

--- a/src/styles/settings.part1.css
+++ b/src/styles/settings.part1.css
@@ -520,53 +520,6 @@
   pointer-events: auto;
 }
 
-/* Two-tab strips use one shared selection pill so state changes slide. */
-.settings-page__tabs-seg:has(
-    > .settings-seg__btn:nth-child(2):last-child
-  ) {
-  position: relative;
-  display: inline-grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0;
-  isolation: isolate;
-}
-
-.settings-page__tabs-seg:has(
-    > .settings-seg__btn:nth-child(2):last-child
-  )::before {
-  content: "";
-  position: absolute;
-  top: 4px;
-  bottom: 4px;
-  left: 4px;
-  width: calc(50% - 4px);
-  box-sizing: border-box;
-  border: 1px solid var(--border-subtle);
-  border-radius: 999px;
-  background: var(--bg-elevated);
-  box-shadow: var(--shadow-pop);
-  pointer-events: none;
-  transition: transform var(--motion-normal) var(--motion-pane-ease);
-}
-
-.settings-page__tabs-seg:has(
-    > .settings-seg__btn:nth-child(2).is-on:last-child
-  )::before {
-  transform: translateX(100%);
-}
-
-.settings-page__tabs-seg:has(
-    > .settings-seg__btn:nth-child(2):last-child
-  ) > .settings-seg__btn {
-  position: relative;
-  z-index: 1;
-  min-width: 0;
-  background: transparent;
-  border: 0;
-  box-shadow: none;
-  transition: color var(--motion-fast) ease;
-}
-
 .settings-page__tabs .settings-seg__btn {
   pointer-events: auto;
   cursor: pointer;

--- a/src/styles/settings.part3.css
+++ b/src/styles/settings.part3.css
@@ -697,6 +697,55 @@ textarea.settings-input.settings-agents-json__textarea {
   border: 1px solid var(--border-subtle);
 }
 
+.settings-seg--sliding {
+  position: relative;
+  flex-wrap: wrap;
+  max-width: 100%;
+  flex-shrink: 1;
+}
+
+.settings-seg--sliding .settings-seg__indicator {
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  left: 0;
+  width: var(--seg-width, 0);
+  height: var(--seg-height, 0);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-pop);
+  pointer-events: none;
+  opacity: 0;
+  transform: translate3d(var(--seg-x, 0), var(--seg-y, 0), 0);
+}
+
+.settings-seg--sliding[data-segmented-ready="1"] .settings-seg__indicator {
+  opacity: 1;
+  transition:
+    transform var(--motion-normal) var(--motion-pane-ease),
+    width var(--motion-normal) var(--motion-pane-ease),
+    height var(--motion-normal) var(--motion-pane-ease);
+}
+
+.settings-seg--sliding .settings-seg__btn {
+  position: relative;
+  z-index: 1;
+  border: 1px solid transparent;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.settings-seg--sliding .settings-seg__btn.is-on {
+  background: transparent;
+  box-shadow: none;
+}
+
+.settings-seg--sliding .settings-seg__btn:focus-visible {
+  outline: 2px solid var(--border-focus, #6b8cff);
+  outline-offset: -2px;
+}
+
 /* Appearance: skin (left) + wallpaper (right) */
 .settings-appearance-duo {
   display: grid;

--- a/src/styles/settings.part3.css
+++ b/src/styles/settings.part3.css
@@ -742,6 +742,7 @@ textarea.settings-input.settings-agents-json__textarea {
 .settings-seg--sliding .settings-seg__btn.is-on {
   background: transparent;
   box-shadow: none;
+  font-weight: 600;
 }
 
 .settings-seg--sliding .settings-seg__btn:focus-visible {

--- a/src/styles/settings.part3.css
+++ b/src/styles/settings.part3.css
@@ -722,6 +722,9 @@ textarea.settings-input.settings-agents-json__textarea {
 
 .settings-seg--sliding[data-segmented-ready="1"] .settings-seg__indicator {
   opacity: 1;
+}
+
+.settings-seg--sliding[data-segmented-animate="1"] .settings-seg__indicator {
   transition:
     transform var(--motion-normal) var(--motion-pane-ease),
     width var(--motion-normal) var(--motion-pane-ease),


### PR DESCRIPTION
## 背景

设置页双页签和多处互斥胶囊此前使用不同的滑块实现，切换时会出现内容闪烁；部分胶囊首次挂载还会从上向下展开，外观主题选择也没有一致的横向切换动画。

## 改动

- 提供并复用公共 `SegmentedControl`，统一设置页签、主题选择及其他互斥胶囊。
- 使用共享指示块完成横向滑动，保留键盘选择和可访问性语义。
- 首次挂载只建立最终位置，不播放纵向展开动画。
- 增加结构与动效守卫，防止重新引入零散胶囊实现。

## 验证

- [x] `pnpm test -- src/components/ui/SegmentedControl.test.tsx src/lib/settingsTabMotion.guard.test.ts`（8 项通过）
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] 真实 Tauri 窗口检查主题胶囊和设置页签双向切换
