### PR TITLE
恢复侧栏平滑开合并稳定标题栏布局

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -2780,6 +2780,7 @@ export function AppWorkbench() {
     sidebarCollapsed: layout.sidebarCollapsed,
     asideCollapsed: layout.asideCollapsed,
     phoneLayout,
+    sidebarOverlay,
     asideOverlay,
   });
   const asideFitGenRef = useRef(0);

--- a/src/hooks/usePaneSplitMotion.test.tsx
+++ b/src/hooks/usePaneSplitMotion.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  nativeWebviewCoverDepth,
+  resetNativeWebviewCoverForTests,
+} from "@/lib/nativeWebviewCover";
+import {
+  isPaneSplitMotionActive,
+  PANE_SPLIT_MOTION_TIMEOUT_MS,
+  resetPaneSplitMotionForTests,
+} from "@/lib/paneSplitMotion";
+import { usePaneSplitMotion } from "./usePaneSplitMotion";
+
+const initialProps = {
+  sidebarCollapsed: false,
+  asideCollapsed: false,
+  phoneLayout: false,
+  sidebarOverlay: false,
+  asideOverlay: true,
+};
+
+function dispatchWidthTransitionEnd(className: string): void {
+  const pane = document.createElement("aside");
+  pane.className = className;
+  document.body.appendChild(pane);
+  const event = new Event("transitionend", { bubbles: true });
+  Object.defineProperty(event, "propertyName", { value: "width" });
+  pane.dispatchEvent(event);
+  pane.remove();
+}
+
+describe("usePaneSplitMotion", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetPaneSplitMotionForTests();
+    resetNativeWebviewCoverForTests();
+  });
+
+  afterEach(() => {
+    cleanup();
+    resetPaneSplitMotionForTests();
+    resetNativeWebviewCoverForTests();
+    vi.useRealTimers();
+  });
+
+  it("keeps native webviews covered across a rapid aside overlay reversal", () => {
+    const { rerender } = renderHook((props) => usePaneSplitMotion(props), {
+      initialProps,
+    });
+
+    rerender({ ...initialProps, asideOverlay: false });
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    expect(isPaneSplitMotionActive()).toBe(true);
+
+    act(() => dispatchWidthTransitionEnd("aside"));
+    expect(nativeWebviewCoverDepth()).toBe(1);
+
+    act(() => vi.advanceTimersByTime(200));
+    rerender(initialProps);
+    expect(nativeWebviewCoverDepth()).toBe(1);
+
+    act(() => vi.advanceTimersByTime(PANE_SPLIT_MOTION_TIMEOUT_MS - 1));
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    act(() => vi.advanceTimersByTime(1));
+    expect(nativeWebviewCoverDepth()).toBe(0);
+    expect(isPaneSplitMotionActive()).toBe(false);
+  });
+
+  it("ends an in-flow sidebar token on its width transition", () => {
+    const { rerender } = renderHook((props) => usePaneSplitMotion(props), {
+      initialProps: { ...initialProps, asideOverlay: false },
+    });
+
+    rerender({
+      ...initialProps,
+      asideOverlay: false,
+      sidebarCollapsed: true,
+    });
+    expect(isPaneSplitMotionActive()).toBe(true);
+
+    act(() => dispatchWidthTransitionEnd("sidebar"));
+    expect(isPaneSplitMotionActive()).toBe(false);
+  });
+});

--- a/src/hooks/usePaneSplitMotion.ts
+++ b/src/hooks/usePaneSplitMotion.ts
@@ -33,25 +33,30 @@ export function usePaneSplitMotion(opts: {
 }): { paneMotionClass: string } {
   const [, setEpoch] = useState(0);
   const keyRef = useRef<string | null>(null);
+  const asideOverlayRef = useRef(Boolean(opts.asideOverlay));
   const tokenRef = useRef(0);
   const releaseRef = useRef<(() => void) | null>(null);
   const timerRef = useRef<number | null>(null);
 
   const key = `${opts.sidebarCollapsed}:${opts.asideCollapsed}`;
+  const asideOverlay = Boolean(opts.asideOverlay);
+  const asideOverlayModeChanged = asideOverlayRef.current !== asideOverlay;
   if (keyRef.current === null) {
     keyRef.current = key;
-  } else if (keyRef.current !== key) {
+  } else if (keyRef.current !== key || asideOverlayModeChanged) {
     const colon = keyRef.current.indexOf(":");
     const sidebarChanged =
       keyRef.current.slice(0, colon) !== String(opts.sidebarCollapsed);
     const asideChanged =
       keyRef.current.slice(colon + 1) !== String(opts.asideCollapsed);
     const sidebarWidthChanged = sidebarChanged && !opts.sidebarOverlay;
-    const asideOverlayChanged = asideChanged && !!opts.asideOverlay;
+    const asideOverlayChanged =
+      asideChanged && (asideOverlayRef.current || asideOverlay);
+    const coverChanged = asideOverlayChanged || asideOverlayModeChanged;
     keyRef.current = key;
     if (
       !opts.phoneLayout &&
-      (sidebarWidthChanged || asideOverlayChanged) &&
+      (sidebarWidthChanged || coverChanged) &&
       shouldStartPaneSplitMotion({
         reducedMotion: false,
         isFirstCommit: false,
@@ -60,17 +65,20 @@ export function usePaneSplitMotion(opts: {
     ) {
       if (tokenRef.current) endPaneSplitMotion(tokenRef.current);
       tokenRef.current = beginPaneSplitMotion({
-        cover: asideOverlayChanged,
+        cover: coverChanged,
         width: sidebarWidthChanged,
         sidebar: sidebarWidthChanged,
         aside: false,
       });
     }
   }
+  asideOverlayRef.current = asideOverlay;
 
   useLayoutEffect(() => {
     const token = tokenRef.current;
     if (!token) return;
+    const finishOnSidebarWidth = isPaneSplitSidebarMotionActive();
+    const finishOnAsideWidth = isPaneSplitAsideMotionActive();
 
     if (isPaneSplitCoverActive() && !releaseRef.current) {
       releaseRef.current = acquireNativeWebviewCover();
@@ -98,7 +106,12 @@ export function usePaneSplitMotion(opts: {
       const t = e.target;
       if (!(t instanceof HTMLElement)) return;
       if (e.propertyName !== "width") return;
-      if (!t.classList.contains("sidebar") && !t.classList.contains("aside")) {
+      if (t.classList.contains("sidebar") && !finishOnSidebarWidth) return;
+      if (t.classList.contains("aside") && !finishOnAsideWidth) return;
+      if (
+        !t.classList.contains("sidebar") &&
+        !t.classList.contains("aside")
+      ) {
         return;
       }
       finish();

--- a/src/hooks/usePaneSplitMotion.ts
+++ b/src/hooks/usePaneSplitMotion.ts
@@ -26,6 +26,8 @@ export function usePaneSplitMotion(opts: {
   sidebarCollapsed: boolean;
   asideCollapsed: boolean;
   phoneLayout?: boolean;
+  /** Left pane is an overlay drawer — its transform already owns the motion. */
+  sidebarOverlay?: boolean;
   /** Right pane is an overlay drawer — cover native webviews during transform. */
   asideOverlay?: boolean;
 }): { paneMotionClass: string } {
@@ -40,13 +42,16 @@ export function usePaneSplitMotion(opts: {
     keyRef.current = key;
   } else if (keyRef.current !== key) {
     const colon = keyRef.current.indexOf(":");
+    const sidebarChanged =
+      keyRef.current.slice(0, colon) !== String(opts.sidebarCollapsed);
     const asideChanged =
       keyRef.current.slice(colon + 1) !== String(opts.asideCollapsed);
+    const sidebarWidthChanged = sidebarChanged && !opts.sidebarOverlay;
+    const asideOverlayChanged = asideChanged && !!opts.asideOverlay;
     keyRef.current = key;
     if (
       !opts.phoneLayout &&
-      asideChanged &&
-      opts.asideOverlay &&
+      (sidebarWidthChanged || asideOverlayChanged) &&
       shouldStartPaneSplitMotion({
         reducedMotion: false,
         isFirstCommit: false,
@@ -55,9 +60,9 @@ export function usePaneSplitMotion(opts: {
     ) {
       if (tokenRef.current) endPaneSplitMotion(tokenRef.current);
       tokenRef.current = beginPaneSplitMotion({
-        cover: true,
-        width: false,
-        sidebar: false,
+        cover: asideOverlayChanged,
+        width: sidebarWidthChanged,
+        sidebar: sidebarWidthChanged,
         aside: false,
       });
     }
@@ -108,7 +113,13 @@ export function usePaneSplitMotion(opts: {
       document.removeEventListener("transitionend", onEnd);
       unsubBump();
     };
-  }, [opts.sidebarCollapsed, opts.asideCollapsed, opts.phoneLayout]);
+  }, [
+    opts.sidebarCollapsed,
+    opts.asideCollapsed,
+    opts.phoneLayout,
+    opts.sidebarOverlay,
+    opts.asideOverlay,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -115,7 +115,7 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(block).not.toMatch(/--motion-pane\s*:\s*0ms/);
   });
 
-  it("in-flow sidebar / aside / bottom terminal snap; overlay drawers interpolate transform", () => {
+  it("in-flow sidebar interpolates while aside and bottom terminal snap", () => {
     const settings = readFileSync(
       resolve(__dirname, "../styles/settings.part5.css"),
       "utf8",
@@ -127,8 +127,8 @@ describe("desktop hidden CSS must not force width 0", () => {
       resolve(__dirname, "../styles/sidebar.part1.css"),
       "utf8",
     );
-    expect(ruleBody(sidebar, "\n.sidebar {")).not.toMatch(
-      /width var\(--motion-pane\)/,
+    expect(ruleBody(sidebar, "\n.sidebar {")).toMatch(
+      /width var\(--motion-pane\)[^,]*,[^}]*min-width var\(--motion-pane\)[^,]*,[^}]*max-width var\(--motion-pane\)[^,]*,[^}]*flex-basis var\(--motion-pane\)/s,
     );
     expect(sidebar).toMatch(
       /\.sidebar\.sidebar--overlay[^{]*\{[^}]*transform var\(--motion-pane\)/,
@@ -143,6 +143,9 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(aside).toMatch(
       /\.aside\.aside--overlay[^{]*\{[^}]*transform var\(--motion-pane\)/,
     );
+    expect(aside).toMatch(
+      /\.workbench--sidebar-motion \.main__top\s*\{[^}]*transition:\s*padding-left var\(--motion-pane\) var\(--motion-pane-ease\)/s,
+    );
     const hidden = ruleBody(aside, ".aside--collapsed");
     expect(hidden).not.toMatch(/width\s*:\s*0\s*!important/);
     const bt = readFileSync(
@@ -154,6 +157,17 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(btBody).not.toMatch(/min-height var\(--motion-pane\)/);
     expect(btBody).not.toMatch(/flex-basis var\(--motion-pane\)/);
     expect(bt).not.toMatch(/^\s*height\s*:\s*0\s*!important/m);
+  });
+
+  it("starts sidebar width motion only outside overlay and phone layouts", () => {
+    const hook = readFileSync(
+      resolve(__dirname, "../hooks/usePaneSplitMotion.ts"),
+      "utf8",
+    );
+    expect(hook).toContain("sidebarChanged && !opts.sidebarOverlay");
+    expect(hook).toContain("!opts.phoneLayout");
+    expect(hook).toContain("width: sidebarWidthChanged");
+    expect(hook).toContain("sidebar: sidebarWidthChanged");
   });
 
   it("mac sidebar seam is not a 1px layout border on vibrancy", () => {

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -127,8 +127,14 @@ describe("desktop hidden CSS must not force width 0", () => {
       resolve(__dirname, "../styles/sidebar.part1.css"),
       "utf8",
     );
-    expect(ruleBody(sidebar, "\n.sidebar {")).toMatch(
-      /width var\(--motion-pane\)[^,]*,[^}]*min-width var\(--motion-pane\)[^,]*,[^}]*max-width var\(--motion-pane\)[^,]*,[^}]*flex-basis var\(--motion-pane\)/s,
+    expect(ruleBody(sidebar, "\n.sidebar {")).not.toMatch(
+      /width var\(--motion-pane\)/,
+    );
+    expect(sidebar).toMatch(
+      /\.workbench--sidebar-motion\s+\.sidebar:not\(\.is-resizing\):not\(\.sidebar--overlay\)\s*\{[^}]*width var\(--motion-pane\)[^,]*,[^}]*min-width var\(--motion-pane\)[^,]*,[^}]*max-width var\(--motion-pane\)[^,]*,[^}]*flex-basis var\(--motion-pane\)/s,
+    );
+    expect(sidebar).not.toMatch(
+      /\.sidebar\.sidebar--overlay[^}]*width var\(--motion-pane\)/s,
     );
     expect(sidebar).toMatch(
       /\.sidebar\.sidebar--overlay[^{]*\{[^}]*transform var\(--motion-pane\)/,
@@ -168,6 +174,11 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(hook).toContain("!opts.phoneLayout");
     expect(hook).toContain("width: sidebarWidthChanged");
     expect(hook).toContain("sidebar: sidebarWidthChanged");
+    expect(hook).toContain("asideOverlayModeChanged");
+    expect(hook).toContain("asideOverlayRef.current || asideOverlay");
+    expect(hook).toContain("cover: coverChanged");
+    expect(hook).toContain("!finishOnSidebarWidth");
+    expect(hook).toContain("!finishOnAsideWidth");
   });
 
   it("mac sidebar seam is not a 1px layout border on vibrancy", () => {

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -116,6 +116,13 @@ describe("desktop hidden CSS must not force width 0", () => {
   });
 
   it("in-flow sidebar / aside / bottom terminal snap; overlay drawers interpolate transform", () => {
+    const settings = readFileSync(
+      resolve(__dirname, "../styles/settings.part5.css"),
+      "utf8",
+    );
+    expect(ruleBody(settings, "\n.main__top {")).not.toMatch(
+      /transition:[^;}]*padding-left/,
+    );
     const sidebar = readFileSync(
       resolve(__dirname, "../styles/sidebar.part1.css"),
       "utf8",

--- a/src/styles/chat.part6.css
+++ b/src/styles/chat.part6.css
@@ -700,6 +700,10 @@
   padding-left: var(--titlebar-safe-left, 96px);
 }
 
+.workbench--sidebar-motion .main__top {
+  transition: padding-left var(--motion-pane) var(--motion-pane-ease);
+}
+
 .main__pane-toggle.is-on {
   color: var(--text-primary);
   background: var(--bg-active);

--- a/src/styles/settings.part5.css
+++ b/src/styles/settings.part5.css
@@ -396,7 +396,6 @@
   gap: var(--space-2);
   flex-shrink: 0;
   box-sizing: border-box;
-  transition: padding-left var(--motion-pane) var(--motion-pane-ease);
 }
 
 .platform-win .main__top,

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -415,6 +415,10 @@ html.platform-win .window-edge-n {
   padding: 0;
   gap: 0;
   transition:
+    width var(--motion-pane) var(--motion-pane-ease),
+    min-width var(--motion-pane) var(--motion-pane-ease),
+    max-width var(--motion-pane) var(--motion-pane-ease),
+    flex-basis var(--motion-pane) var(--motion-pane-ease),
     border-color var(--motion-pane) ease,
     opacity 180ms ease,
     filter 180ms ease;

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -415,6 +415,14 @@ html.platform-win .window-edge-n {
   padding: 0;
   gap: 0;
   transition:
+    border-color var(--motion-pane) ease,
+    opacity 180ms ease,
+    filter 180ms ease;
+  z-index: 1;
+}
+
+.workbench--sidebar-motion .sidebar:not(.is-resizing):not(.sidebar--overlay) {
+  transition:
     width var(--motion-pane) var(--motion-pane-ease),
     min-width var(--motion-pane) var(--motion-pane-ease),
     max-width var(--motion-pane) var(--motion-pane-ease),
@@ -422,7 +430,6 @@ html.platform-win .window-edge-n {
     border-color var(--motion-pane) ease,
     opacity 180ms ease,
     filter 180ms ease;
-  z-index: 1;
 }
 
 /*


### PR DESCRIPTION
## 背景

桌面宽窗口中的侧栏开合曾被响应式边界直接截断，收起时标题栏还会短暂向 macOS 红绿灯区域回弹，整体效果与连续推动主工作区的侧栏交互不一致。

## 改动

- 恢复宽窗口侧栏平滑开合，并让主工作区随实际侧栏宽度连续移动。
- 稳定标题栏安全边距，避免收起时先撞向窗口控制区再回弹。
- 明确窄窗口与快速反向操作的响应式动效边界。
- 增加 pane split motion 单元测试与 Hook 回归测试。

## 验证

- [x] `pnpm test -- src/hooks/usePaneSplitMotion.test.tsx src/lib/paneSplitMotion.test.ts`（19 项通过）
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] 真实 Tauri 窗口检查展开、收起和标题栏位置
