### PR TITLE
增强壁纸下设置页面的背景模糊

### DIFF
--- a/src/lib/settingsOverlayFill.guard.test.ts
+++ b/src/lib/settingsOverlayFill.guard.test.ts
@@ -28,6 +28,13 @@ describe("settings overlay fills the window with wallpaper on", () => {
     expect(css).toMatch(/\.app-settings-stage\s*\{[^}]*inset:\s*0/s);
   });
 
+  it("frosts the still-mounted workbench behind settings", () => {
+    const css = readFileSync(join(STYLES, "skins.css"), "utf8");
+    expect(css).toMatch(
+      /html\[data-wallpaper="1"\] \.app-settings-stage\s*\{[^}]*backdrop-filter:\s*blur\(var\(--glass-blur\)\)/s,
+    );
+  });
+
   it("does not force the settings stage to position:relative", () => {
     const css = readFileSync(join(STYLES, "skins.css"), "utf8").replace(
       /\/\*[\s\S]*?\*\//g,

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -70,6 +70,9 @@ html[data-wallpaper="1"] .workbench {
 /* Keep the atomic Settings swap above the lifted workbench chrome. */
 html[data-wallpaper="1"] .app-settings-stage {
   z-index: 20;
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur))
+    saturate(var(--glass-saturate));
 }
 
 /* Pane fills scale with scrim: 0% = fully clear wallpaper under chrome.


### PR DESCRIPTION
## 背景

启用自定义壁纸后，设置页面的导航和内容层对背景分离不足，壁纸细节会穿透文字区域，影响设置内容可读性。

## 改动

- 增强壁纸模式下设置舞台与导航区域的 `backdrop-filter` 模糊。
- 保持原有透明层级和主题颜色，不引入额外实色遮挡面。
- 增加设置覆盖层守卫，锁定壁纸模式的模糊行为。

## 验证

- [x] `pnpm test -- src/lib/settingsOverlayFill.guard.test.ts`（4 项通过）
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] 浅色壁纸下设置页静态截图检查

## 后续依赖

浅色壁纸可读性与通透效果优化将作为独立后续 PR，在本 PR 合并后从更新后的 `main` 创建。
