### PR TITLE
为深浅主题切换增加平滑过渡并保持侧栏模糊

### DIFF
--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -12,6 +12,7 @@ import {
   parseThemePreference,
   readOsTheme,
   resolveTheme,
+  runThemeTransition,
   saveTheme,
   saveThemePreference,
   subscribeHostOsTheme,
@@ -175,6 +176,68 @@ describe("theme preference + resolve", () => {
       "light",
     );
     await expect(readOsTheme(async () => "dark")).resolves.toBe("dark");
+  });
+
+  it("runs theme updates directly without View Transition support", () => {
+    const update = vi.fn();
+    const doc = {
+      defaultView: { matchMedia: () => ({ matches: false }) },
+      documentElement: { dataset: {} },
+      visibilityState: "visible",
+    } as unknown as Document;
+
+    runThemeTransition(update, doc);
+
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it("skips animation when reduced motion is enabled", () => {
+    const update = vi.fn();
+    const startViewTransition = vi.fn();
+    const doc = {
+      defaultView: { matchMedia: () => ({ matches: true }) },
+      documentElement: { dataset: {} },
+      visibilityState: "visible",
+      startViewTransition,
+    } as unknown as Document;
+
+    runThemeTransition(update, doc);
+
+    expect(update).toHaveBeenCalledOnce();
+    expect(startViewTransition).not.toHaveBeenCalled();
+  });
+
+  it("keeps only the latest rapid theme transition update", async () => {
+    const callbacks: Array<() => void> = [];
+    const transitions: Array<{
+      finished: Promise<void>;
+      skipTransition: ReturnType<typeof vi.fn>;
+    }> = [];
+    const doc = {
+      defaultView: { matchMedia: () => ({ matches: false }) },
+      documentElement: { dataset: {} },
+      visibilityState: "visible",
+      startViewTransition: (callback: () => void) => {
+        callbacks.push(callback);
+        const transition = {
+          finished: Promise.resolve(),
+          skipTransition: vi.fn(),
+        };
+        transitions.push(transition);
+        return transition;
+      },
+    } as unknown as Document;
+    const seen: string[] = [];
+
+    runThemeTransition(() => seen.push("light"), doc);
+    runThemeTransition(() => seen.push("dark"), doc);
+    callbacks[1]?.();
+    callbacks[0]?.();
+    await Promise.resolve();
+
+    expect(transitions[0]?.skipTransition).toHaveBeenCalledOnce();
+    expect(seen).toEqual(["dark"]);
+    expect(doc.documentElement.dataset.themeTransition).toBeUndefined();
   });
 
   it("subscribeHostOsTheme forwards parsed host payloads", async () => {

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -207,29 +207,94 @@ describe("theme preference + resolve", () => {
     expect(startViewTransition).not.toHaveBeenCalled();
   });
 
-  it("keeps WebKit glass live instead of using a View Transition snapshot", () => {
-    const update = vi.fn();
-    const startViewTransition = vi.fn((commit: () => void) => {
-      commit();
-      return { finished: Promise.resolve(), skipTransition: vi.fn() };
-    });
-    const doc = {
-      defaultView: {
-        matchMedia: () => ({ matches: false }),
-        navigator: {
-          userAgent:
-            "Mozilla/5.0 AppleWebKit/605.1.15 Version/26.0 Safari/605.1.15",
+  it("animates WebKit theme colors without using a glass-breaking snapshot", () => {
+    vi.useFakeTimers();
+    try {
+      let updated = false;
+      const animation = {
+        cancel: vi.fn(),
+        finished: new Promise<void>(() => {}),
+      };
+      const animate = vi.fn(
+        (
+          _keyframes: Keyframe[] | PropertyIndexedKeyframes | null,
+          _options?: number | KeyframeAnimationOptions,
+        ) => animation as unknown as Animation,
+      );
+      const update = vi.fn(() => {
+        updated = true;
+      });
+      const startViewTransition = vi.fn((commit: () => void) => {
+        commit();
+        return { finished: Promise.resolve(), skipTransition: vi.fn() };
+      });
+      const doc = {
+        defaultView: {
+          matchMedia: () => ({ matches: false }),
+          navigator: {
+            userAgent:
+              "Mozilla/5.0 AppleWebKit/605.1.15 Version/26.0 Safari/605.1.15",
+          },
+          innerWidth: 1200,
+          innerHeight: 800,
+          getComputedStyle: () => ({
+            color: updated ? "rgb(255, 255, 255)" : "rgb(0, 0, 0)",
+            backgroundColor: updated
+              ? "rgb(20, 20, 20)"
+              : "rgb(255, 255, 255)",
+            borderTopColor: "rgba(0, 0, 0, 0)",
+            borderRightColor: "rgba(0, 0, 0, 0)",
+            borderBottomColor: "rgba(0, 0, 0, 0)",
+            borderLeftColor: "rgba(0, 0, 0, 0)",
+            outlineColor: "rgba(0, 0, 0, 0)",
+            fill: "none",
+            stroke: "none",
+          }),
         },
-      },
-      documentElement: { dataset: {} },
-      visibilityState: "visible",
-      startViewTransition,
-    } as unknown as Document;
+        documentElement: {
+          animate,
+          dataset: {},
+          getBoundingClientRect: () => ({
+            bottom: 800,
+            height: 800,
+            left: 0,
+            right: 1200,
+            top: 0,
+            width: 1200,
+          }),
+          isConnected: true,
+        },
+        querySelectorAll: () => [],
+        visibilityState: "visible",
+        startViewTransition,
+      } as unknown as Document;
 
-    runThemeTransition(update, doc);
+      runThemeTransition(update, doc);
 
-    expect(update).toHaveBeenCalledOnce();
-    expect(startViewTransition).not.toHaveBeenCalled();
+      expect(update).toHaveBeenCalledOnce();
+      expect(startViewTransition).not.toHaveBeenCalled();
+      expect(doc.documentElement.dataset.themeTransition).toBe("webkit");
+      expect(animate).toHaveBeenCalledOnce();
+      const keyframes = animate.mock.calls[0]?.[0];
+      expect(keyframes).toEqual([
+        expect.objectContaining({
+          backgroundColor: "rgb(255, 255, 255)",
+          color: "rgb(0, 0, 0)",
+        }),
+        expect.objectContaining({
+          backgroundColor: "rgb(20, 20, 20)",
+          color: "rgb(255, 255, 255)",
+        }),
+      ]);
+      expect(JSON.stringify(keyframes)).not.toMatch(
+        /(?:transform|opacity|backdropFilter)/,
+      );
+
+      vi.runAllTimers();
+      expect(doc.documentElement.dataset.themeTransition).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps only the latest rapid theme transition update", async () => {

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -207,6 +207,31 @@ describe("theme preference + resolve", () => {
     expect(startViewTransition).not.toHaveBeenCalled();
   });
 
+  it("keeps WebKit glass live instead of using a View Transition snapshot", () => {
+    const update = vi.fn();
+    const startViewTransition = vi.fn((commit: () => void) => {
+      commit();
+      return { finished: Promise.resolve(), skipTransition: vi.fn() };
+    });
+    const doc = {
+      defaultView: {
+        matchMedia: () => ({ matches: false }),
+        navigator: {
+          userAgent:
+            "Mozilla/5.0 AppleWebKit/605.1.15 Version/26.0 Safari/605.1.15",
+        },
+      },
+      documentElement: { dataset: {} },
+      visibilityState: "visible",
+      startViewTransition,
+    } as unknown as Document;
+
+    runThemeTransition(update, doc);
+
+    expect(update).toHaveBeenCalledOnce();
+    expect(startViewTransition).not.toHaveBeenCalled();
+  });
+
   it("keeps only the latest rapid theme transition update", async () => {
     const callbacks: Array<() => void> = [];
     const transitions: Array<{

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -97,6 +97,51 @@ export function applyThemeToDocument(
   root.setAttribute("data-theme", theme);
 }
 
+let themeTransitionGeneration = 0;
+let activeThemeTransition: ViewTransition | null = null;
+
+/** Run one user-triggered theme update inside the native page cross-fade. */
+export function runThemeTransition(
+  update: () => void,
+  doc: Document = document,
+): void {
+  const generation = ++themeTransitionGeneration;
+  activeThemeTransition?.skipTransition();
+  activeThemeTransition = null;
+  delete doc.documentElement.dataset.themeTransition;
+
+  let reduceMotion = false;
+  try {
+    reduceMotion =
+      doc.defaultView?.matchMedia("(prefers-reduced-motion: reduce)").matches ??
+      false;
+  } catch {
+    /* restricted / test window */
+  }
+
+  const commit = () => {
+    if (generation === themeTransitionGeneration) update();
+  };
+  if (
+    reduceMotion ||
+    doc.visibilityState === "hidden" ||
+    typeof doc.startViewTransition !== "function"
+  ) {
+    commit();
+    return;
+  }
+
+  doc.documentElement.dataset.themeTransition = "1";
+  const transition = doc.startViewTransition(commit);
+  activeThemeTransition = transition;
+  const cleanup = () => {
+    if (activeThemeTransition !== transition) return;
+    activeThemeTransition = null;
+    delete doc.documentElement.dataset.themeTransition;
+  };
+  void transition.finished.then(cleanup, cleanup);
+}
+
 /**
  * Native chrome lock vs Auto when the user follows the OS.
  *

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -122,8 +122,14 @@ export function runThemeTransition(
   const commit = () => {
     if (generation === themeTransitionGeneration) update();
   };
+  const userAgent = doc.defaultView?.navigator?.userAgent ?? "";
+  // WebKit bug 302256 drops backdrop-filter for the whole snapshot animation.
+  const webKitDropsGlass =
+    /AppleWebKit/i.test(userAgent) &&
+    !/(Chrome|Chromium|CriOS|Edg)/i.test(userAgent);
   if (
     reduceMotion ||
+    webKitDropsGlass ||
     doc.visibilityState === "hidden" ||
     typeof doc.startViewTransition !== "function"
   ) {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -99,6 +99,108 @@ export function applyThemeToDocument(
 
 let themeTransitionGeneration = 0;
 let activeThemeTransition: ViewTransition | null = null;
+let activeWebKitThemeAnimations: Animation[] = [];
+let themeTransitionCleanupTimer: ReturnType<typeof setTimeout> | null = null;
+
+const WEBKIT_THEME_TRANSITION_DURATION_MS = 200;
+const WEBKIT_THEME_TRANSITION_CLEANUP_MS =
+  WEBKIT_THEME_TRANSITION_DURATION_MS + 50;
+const WEBKIT_THEME_ANIMATED_PROPERTIES = [
+  "color",
+  "backgroundColor",
+  "borderTopColor",
+  "borderRightColor",
+  "borderBottomColor",
+  "borderLeftColor",
+  "outlineColor",
+  "fill",
+  "stroke",
+] as const;
+
+type WebKitThemeAnimatedProperty =
+  (typeof WEBKIT_THEME_ANIMATED_PROPERTIES)[number];
+type WebKitThemeFrame = Partial<Record<WebKitThemeAnimatedProperty, string>>;
+type WebKitThemeSnapshot = {
+  element: Element;
+  before: WebKitThemeFrame;
+};
+
+function readWebKitThemeFrame(style: CSSStyleDeclaration): WebKitThemeFrame {
+  const frame: WebKitThemeFrame = {};
+  for (const property of WEBKIT_THEME_ANIMATED_PROPERTIES) {
+    const value = style[property];
+    if (typeof value === "string") frame[property] = value;
+  }
+  return frame;
+}
+
+function captureVisibleThemeFrames(doc: Document): WebKitThemeSnapshot[] {
+  const view = doc.defaultView;
+  if (!view || typeof view.getComputedStyle !== "function") return [];
+  const width = view.innerWidth;
+  const height = view.innerHeight;
+  const elements = [
+    doc.documentElement,
+    ...Array.from(doc.querySelectorAll("body, body *")),
+  ];
+  const snapshots: WebKitThemeSnapshot[] = [];
+  for (const element of elements) {
+    const rect = element.getBoundingClientRect();
+    if (
+      element !== doc.documentElement &&
+      (rect.width <= 0 ||
+        rect.height <= 0 ||
+        rect.right < 0 ||
+        rect.bottom < 0 ||
+        rect.left > width ||
+        rect.top > height)
+    ) {
+      continue;
+    }
+    snapshots.push({
+      element,
+      before: readWebKitThemeFrame(view.getComputedStyle(element)),
+    });
+  }
+  return snapshots;
+}
+
+function animateThemeFrames(
+  snapshots: WebKitThemeSnapshot[],
+  doc: Document,
+): Animation[] {
+  const view = doc.defaultView;
+  if (!view || typeof view.getComputedStyle !== "function") return [];
+  const animations: Animation[] = [];
+  for (const { element, before } of snapshots) {
+    if (!element.isConnected || typeof element.animate !== "function") continue;
+    const after = readWebKitThemeFrame(view.getComputedStyle(element));
+    const from: WebKitThemeFrame = {};
+    const to: WebKitThemeFrame = {};
+    for (const property of WEBKIT_THEME_ANIMATED_PROPERTIES) {
+      if (before[property] === after[property]) continue;
+      from[property] = before[property];
+      to[property] = after[property];
+    }
+    if (Object.keys(from).length === 0) continue;
+    try {
+      animations.push(
+        element.animate([from, to], {
+          duration: WEBKIT_THEME_TRANSITION_DURATION_MS,
+          easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+        }),
+      );
+    } catch {
+      /* unsupported SVG / native control property — the theme still applies */
+    }
+  }
+  return animations;
+}
+
+function cancelWebKitThemeAnimations(): void {
+  for (const animation of activeWebKitThemeAnimations) animation.cancel();
+  activeWebKitThemeAnimations = [];
+}
 
 /** Run one user-triggered theme update inside the native page cross-fade. */
 export function runThemeTransition(
@@ -108,7 +210,11 @@ export function runThemeTransition(
   const generation = ++themeTransitionGeneration;
   activeThemeTransition?.skipTransition();
   activeThemeTransition = null;
-  delete doc.documentElement.dataset.themeTransition;
+  if (themeTransitionCleanupTimer !== null) {
+    clearTimeout(themeTransitionCleanupTimer);
+    themeTransitionCleanupTimer = null;
+  }
+  const root = doc.documentElement;
 
   let reduceMotion = false;
   try {
@@ -127,23 +233,44 @@ export function runThemeTransition(
   const webKitDropsGlass =
     /AppleWebKit/i.test(userAgent) &&
     !/(Chrome|Chromium|CriOS|Edg)/i.test(userAgent);
-  if (
-    reduceMotion ||
-    webKitDropsGlass ||
-    doc.visibilityState === "hidden" ||
-    typeof doc.startViewTransition !== "function"
-  ) {
+  if (reduceMotion || doc.visibilityState === "hidden") {
+    cancelWebKitThemeAnimations();
+    delete root.dataset.themeTransition;
     commit();
     return;
   }
 
-  doc.documentElement.dataset.themeTransition = "1";
+  if (webKitDropsGlass) {
+    // WebKit's root snapshot drops backdrop-filter. Animate only the visible
+    // ink/surface properties with WAAPI so glass and component motion stay live.
+    const snapshots = captureVisibleThemeFrames(doc);
+    cancelWebKitThemeAnimations();
+    root.dataset.themeTransition = "webkit";
+    commit();
+    activeWebKitThemeAnimations = animateThemeFrames(snapshots, doc);
+    themeTransitionCleanupTimer = setTimeout(() => {
+      if (generation !== themeTransitionGeneration) return;
+      themeTransitionCleanupTimer = null;
+      activeWebKitThemeAnimations = [];
+      delete root.dataset.themeTransition;
+    }, WEBKIT_THEME_TRANSITION_CLEANUP_MS);
+    return;
+  }
+
+  cancelWebKitThemeAnimations();
+  delete root.dataset.themeTransition;
+  if (typeof doc.startViewTransition !== "function") {
+    commit();
+    return;
+  }
+
+  root.dataset.themeTransition = "1";
   const transition = doc.startViewTransition(commit);
   activeThemeTransition = transition;
   const cleanup = () => {
     if (activeThemeTransition !== transition) return;
     activeThemeTransition = null;
-    delete doc.documentElement.dataset.themeTransition;
+    delete root.dataset.themeTransition;
   };
   void transition.finished.then(cleanup, cleanup);
 }

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -12,6 +12,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { flushSync } from "react-dom";
 import { detectAppPlatform } from "@/lib/appPlatform";
 import {
   applyNativeWindowTheme,
@@ -22,6 +23,7 @@ import {
   nativeWindowThemeArg,
   parseThemePreference,
   readOsTheme,
+  runThemeTransition,
   saveThemePreference,
   subscribeHostOsTheme,
   subscribeSystemTheme,
@@ -243,10 +245,17 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const applyThemeChoice = useCallback(
     (next: ThemePreference) => {
       saveThemePreference(localStorage, next);
-      setThemePreference(next);
       // Dual-write Host settings so the next cold start can paint the boot
       // shell + native chrome before React loads (see resolve_boot_theme).
       void persistThemeToHostSettings(next);
+      if (next === "light" || next === "dark") {
+        runThemeTransition(() => {
+          applyThemeToDocument(next);
+          flushSync(() => setThemePreference(next));
+        });
+        return;
+      }
+      setThemePreference(next);
       if (next === "system" && themeSchedule.enabled) {
         const resolved = resolveThemeWithSchedule(
           next,

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -323,6 +323,20 @@
   }
 }
 
+/* Explicit light/dark choices use the browser's compositor cross-fade. */
+html[data-theme-transition="1"]::view-transition-old(root),
+html[data-theme-transition="1"]::view-transition-new(root) {
+  animation-duration: var(--motion-normal);
+  animation-timing-function: var(--motion-pane-ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-theme-transition="1"]::view-transition-old(root),
+  html[data-theme-transition="1"]::view-transition-new(root) {
+    animation: none;
+  }
+}
+
 /*
  * Native form chrome follows WebView color-scheme. On Windows WebView2 a
  * mismatch (OS dark + app light, or :root dark leaking) paints number/date/


### PR DESCRIPTION
## 背景

显式浅色/深色主题此前直接切换。浏览器 View Transition 可以提供交叉淡化，但 WebKit 在整页快照期间会丢失 `backdrop-filter`，导致玻璃侧栏先变清晰再恢复；直接禁用快照又会退化为单帧硬切。

## 改动

- 非 WebKit 环境继续使用原生 View Transition 交叉淡化。
- WebKit 改为采集视口内实际变化的颜色，并使用 WAAPI 插值 `color`、背景、边框、描边等颜色属性。
- 明确不动画 `transform`、`opacity` 和 `backdrop-filter`，避免覆盖胶囊滑动或破坏实时玻璃模糊。
- 快速连续切换会取消旧动画并以最新主题为准；减弱动态效果继续直接应用。

## 验证

- [x] `pnpm test -- src/lib/theme.test.ts`（22 项通过）
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build:ui`
- [x] `git diff --check`
- [x] 真实 Tauri/WKWebView 60fps 逐帧检查：双向各约 10 个中间帧，侧栏模糊连续

## 风险说明

WebKit fallback 只在用户显式切换主题时采样当前视口内节点。现有虚拟化页面未观察到卡顿；极端超大 DOM 可后续结合性能数据进一步收窄采样范围。
