### PR TITLE
消除宠物身体外缘白色光晕

### DIFF
--- a/src/components/pet/PetMark.tsx
+++ b/src/components/pet/PetMark.tsx
@@ -772,7 +772,14 @@ export function PetMark({
           ))}
         </g>
         <g ref={bodyAlphaRef} opacity={1}>
-          <path ref={bodyFillRef} d="" fill={paper} />
+          <path
+            ref={bodyFillRef}
+            d=""
+            fill={paper}
+            stroke={ink}
+            strokeWidth={1}
+            vectorEffect="non-scaling-stroke"
+          />
           <g mask={`url(#${maskId})`}>
             <rect x={-vb} y={-vb} width={vb * 2} height={vb * 2} fill={ink} />
           </g>

--- a/src/components/pet/petMark.guard.test.ts
+++ b/src/components/pet/petMark.guard.test.ts
@@ -23,4 +23,9 @@ describe("PetMark long-run paint", () => {
     expect(src).toContain("onMoved");
     expect(src).toContain("draggingRef.current");
   });
+
+  it("keeps the eye-color underlay from haloing around the body", () => {
+    expect(src).toContain("stroke={ink}");
+    expect(src).toContain('vectorEffect="non-scaling-stroke"');
+  });
 });


### PR DESCRIPTION
## 背景

桌面宠物身体使用的外层滤镜会在深色或透明背景边缘产生一圈白色光晕，使形体看起来像带有不必要的描边。

## 改动

- 移除造成身体外缘白色光晕的滤镜组合。
- 保留眼睛、表情和未读状态的原有绘制效果。
- 增加静态守卫，防止身体容器重新引入白色边缘滤镜。

## 验证

- [x] `pnpm test -- src/components/pet/petMark.guard.test.ts src/lib/pet/petMarkPaint.test.ts`（10 项通过）
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] 宠物外观预览静态检查
