### PR TITLE
perf(chat): close DEV scroll-perf session on velocity settle (#865)

### DIFF
--- a/src/lib/scrollPerfDebug.ts
+++ b/src/lib/scrollPerfDebug.ts
@@ -7,6 +7,8 @@
  * Collects FPS, frame delta histograms, long tasks, layout recomputes, and DOM mounts.
  */
 
+import { createScrollVelocityTracker } from "./scrollVelocity";
+
 interface FrameRecord {
   timestamp: number;
   delta: number;
@@ -72,6 +74,8 @@ let rafId: number | null = null;
 let lastRafTime = 0;
 let lastObservedScrollTop = 0;
 let lastActionContext = "";
+/** One tracker per session. Reset on start so first-sample `isMoving=false` cannot close immediately. */
+let sessionVelocity = createScrollVelocityTracker();
 
 let perfObserver: PerformanceObserver | null = null;
 if (IS_DEV && typeof window !== "undefined" && typeof PerformanceObserver !== "undefined") {
@@ -150,12 +154,11 @@ function onRaf(now: number) {
   }
   lastRafTime = now;
 
-  // Physics settlement check:
-  // User input ended > 350ms ago AND scroll position has been static for > 300ms
-  const inputIdle = (now - activeSession.lastInputTime) > 350;
-  const motionIdle = (now - activeSession.lastMotionTime) > 300;
-
-  if (inputIdle && motionIdle) {
+  // Close only after velocity settle (frames + 160ms stillness). A 350/300ms
+  // input/motion idle cut fires in the touchpad contact→inertia gap and
+  // splits one gesture into two reports, printing at lift-off.
+  const vel = sessionVelocity.sample(currentScrollTop, now);
+  if (!vel.isMoving) {
     scrollPerfDebug.recordScrollEnd();
     return;
   }
@@ -191,6 +194,7 @@ export const scrollPerfDebug = {
       lastRafTime = now;
       lastObservedScrollTop = st;
       lastActionContext = "gesture_start";
+      sessionVelocity.reset(st, now);
       rafId = requestAnimationFrame(onRaf);
       console.log("%c[ScrollPerf] 🚀 Scroll session started - tracking fine-grained drops...", "color: #00b4d8; font-weight: bold;");
     } else {


### PR DESCRIPTION
Fixes #865

Follow-up to #853 / #854. Product settle already uses `createScrollVelocityTracker` (frames + 160ms). DEV `scrollPerfDebug` still cut the session on 350ms input idle + 300ms `scrollTop` idle, which is the precision-touchpad contact→inertia gap.

## Summary
- Reset a velocity tracker when a DEV session starts
- End the session only when `!isMoving` (same settle as the virtualizer)
- One fling → one report, printed after coast, not at lift-off
- No product scroll change (DEV-only)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan
- [x] `npx vitest run src/lib/scrollVelocity.test.ts`
- [ ] `pnpm dev`: one touchpad fling should log a single Multi-Phase report after coast, not at finger-up

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (scoped vitest)
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only) — N/A, TS-only
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — no new copy
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — DEV telemetry only
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
