### PR TITLE
优化浅色壁纸模式的可读性与通透效果

### DIFF
--- a/src/lib/settingsOverlayFill.guard.test.ts
+++ b/src/lib/settingsOverlayFill.guard.test.ts
@@ -28,10 +28,20 @@ describe("settings overlay fills the window with wallpaper on", () => {
     expect(css).toMatch(/\.app-settings-stage\s*\{[^}]*inset:\s*0/s);
   });
 
-  it("frosts the still-mounted workbench behind settings", () => {
+  it("lightly frosts the still-mounted workbench behind settings", () => {
     const css = readFileSync(join(STYLES, "skins.css"), "utf8");
     expect(css).toMatch(
-      /html\[data-wallpaper="1"\] \.app-settings-stage\s*\{[^}]*backdrop-filter:\s*blur\(var\(--glass-blur\)\)/s,
+      /html\[data-wallpaper="1"\] \.app-settings-stage\s*\{[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-settings-blur, 14px\)\)/s,
+    );
+  });
+
+  it("drops settings-stage blur for stream-perf and a clear wallpaper", () => {
+    const css = readFileSync(join(STYLES, "skins.css"), "utf8");
+    expect(css).toMatch(
+      /html\[data-stream-perf="1"\]\[data-wallpaper="1"\] \.app-settings-stage,[^{]*\{[^}]*backdrop-filter:\s*none\s*!important/s,
+    );
+    expect(css).toMatch(
+      /html\[data-wallpaper="1"\]\[data-wallpaper-clear="1"\] \.app-settings-stage,[^{]*\{[^}]*backdrop-filter:\s*none\s*!important/s,
     );
   });
 

--- a/src/lib/themeSkin.test.ts
+++ b/src/lib/themeSkin.test.ts
@@ -337,9 +337,6 @@ describe("wallpaper scrim", () => {
     expect(props.get("--wallpaper-sidebar-blur")).toBe("5.5px");
     expect(props.get("--wallpaper-settings-blur")).toBe("3.5px");
     expect(props.get("--wallpaper-sidebar-shadow-alpha")).toBe("0.420");
-    expect(props.get("--wallpaper-light-foreground-shadow-alpha")).toBe(
-      "0.550",
-    );
 
     applyWallpaperScrimToDocument(0, el);
     expect(attrs.get("data-wallpaper-clear")).toBe("1");
@@ -355,9 +352,6 @@ describe("wallpaper scrim", () => {
     expect(props.get("--wallpaper-sidebar-blur")).toBe("0.0px");
     expect(props.get("--wallpaper-settings-blur")).toBe("0.0px");
     expect(props.get("--wallpaper-sidebar-shadow-alpha")).toBe("0.560");
-    expect(props.get("--wallpaper-light-foreground-shadow-alpha")).toBe(
-      "0.660",
-    );
 
     applyWallpaperScrimToDocument(100, el);
     expect(attrs.has("data-wallpaper-clear")).toBe(false);
@@ -373,9 +367,7 @@ describe("wallpaper scrim", () => {
     expect(props.get("--wallpaper-sidebar-blur")).toBe("22.0px");
     expect(props.get("--wallpaper-settings-blur")).toBe("14.0px");
     expect(props.get("--wallpaper-sidebar-shadow-alpha")).toBe("0.000");
-    expect(props.get("--wallpaper-light-foreground-shadow-alpha")).toBe(
-      "0.220",
-    );
+    expect(props.has("--wallpaper-light-foreground-shadow-alpha")).toBe(false);
   });
 });
 

--- a/src/lib/themeSkin.test.ts
+++ b/src/lib/themeSkin.test.ts
@@ -329,7 +329,17 @@ describe("wallpaper scrim", () => {
     expect(props.get("--wallpaper-mix-main")).toBe("18%"); // 70 * 0.25
     expect(props.get("--wallpaper-mix-sidebar")).toBe("15%"); // 58 * 0.25
     expect(props.get("--wallpaper-mix-settings")).toBe("20%"); // 78 * 0.25
+    expect(props.get("--wallpaper-light-scrim-opacity")).toBe("0.113");
+    expect(props.get("--wallpaper-light-mix-sidebar")).toBe("18%");
+    expect(props.get("--wallpaper-light-mix-main")).toBe("6%");
+    expect(props.get("--wallpaper-light-mix-aside")).toBe("8%");
+    expect(props.get("--wallpaper-light-mix-settings")).toBe("18%");
     expect(props.get("--wallpaper-sidebar-blur")).toBe("5.5px");
+    expect(props.get("--wallpaper-settings-blur")).toBe("3.5px");
+    expect(props.get("--wallpaper-sidebar-shadow-alpha")).toBe("0.420");
+    expect(props.get("--wallpaper-light-foreground-shadow-alpha")).toBe(
+      "0.550",
+    );
 
     applyWallpaperScrimToDocument(0, el);
     expect(attrs.get("data-wallpaper-clear")).toBe("1");
@@ -337,7 +347,17 @@ describe("wallpaper scrim", () => {
     expect(props.get("--wallpaper-mix-main")).toBe("0%");
     expect(props.get("--wallpaper-mix-sidebar")).toBe("0%");
     expect(props.get("--wallpaper-mix-settings")).toBe("0%");
+    expect(props.get("--wallpaper-light-scrim-opacity")).toBe("0.000");
+    expect(props.get("--wallpaper-light-mix-sidebar")).toBe("0%");
+    expect(props.get("--wallpaper-light-mix-main")).toBe("0%");
+    expect(props.get("--wallpaper-light-mix-aside")).toBe("0%");
+    expect(props.get("--wallpaper-light-mix-settings")).toBe("0%");
     expect(props.get("--wallpaper-sidebar-blur")).toBe("0.0px");
+    expect(props.get("--wallpaper-settings-blur")).toBe("0.0px");
+    expect(props.get("--wallpaper-sidebar-shadow-alpha")).toBe("0.560");
+    expect(props.get("--wallpaper-light-foreground-shadow-alpha")).toBe(
+      "0.660",
+    );
 
     applyWallpaperScrimToDocument(100, el);
     expect(attrs.has("data-wallpaper-clear")).toBe(false);
@@ -345,7 +365,17 @@ describe("wallpaper scrim", () => {
     expect(props.get("--wallpaper-mix-main")).toBe("70%");
     expect(props.get("--wallpaper-mix-sidebar")).toBe("58%");
     expect(props.get("--wallpaper-mix-settings")).toBe("78%");
+    expect(props.get("--wallpaper-light-scrim-opacity")).toBe("0.450");
+    expect(props.get("--wallpaper-light-mix-sidebar")).toBe("72%");
+    expect(props.get("--wallpaper-light-mix-main")).toBe("24%");
+    expect(props.get("--wallpaper-light-mix-aside")).toBe("32%");
+    expect(props.get("--wallpaper-light-mix-settings")).toBe("72%");
     expect(props.get("--wallpaper-sidebar-blur")).toBe("22.0px");
+    expect(props.get("--wallpaper-settings-blur")).toBe("14.0px");
+    expect(props.get("--wallpaper-sidebar-shadow-alpha")).toBe("0.000");
+    expect(props.get("--wallpaper-light-foreground-shadow-alpha")).toBe(
+      "0.220",
+    );
   });
 });
 

--- a/src/lib/themeSkin.ts
+++ b/src/lib/themeSkin.ts
@@ -300,10 +300,6 @@ export function applyWallpaperScrimToDocument(
     "--wallpaper-sidebar-shadow-alpha",
     `${(0.56 * (1 - t)).toFixed(3)}`,
   );
-  root.style.setProperty(
-    "--wallpaper-light-foreground-shadow-alpha",
-    `${(0.22 + 0.44 * (1 - t)).toFixed(3)}`,
-  );
 }
 
 /**

--- a/src/lib/themeSkin.ts
+++ b/src/lib/themeSkin.ts
@@ -237,8 +237,9 @@ export function saveWallpaperScrim(
 
 /**
  * Apply scrim strength as CSS vars on the root.
- * Scales the full-window veil, pane/settings fills, and sidebar blur.
- * Text and control fills stay solid (they do not read these variables).
+ * Scales theme-specific full-window veils, pane/settings fills, and background
+ * blurs. Light keeps a weaker veil and clearer main pane than dark so a white
+ * scrim does not wash the wallpaper gray.
  *
  * Derived mix/%/px vars avoid flaky `calc(% * var)` inside `color-mix`
  * in some WebViews. At 0, also sets `data-wallpaper-clear` so CSS can force
@@ -268,8 +269,40 @@ export function applyWallpaperScrimToDocument(
     `${Math.round(78 * t)}%`,
   );
   root.style.setProperty(
+    "--wallpaper-light-scrim-opacity",
+    `${(0.45 * t).toFixed(3)}`,
+  );
+  root.style.setProperty(
+    "--wallpaper-light-mix-sidebar",
+    `${Math.round(72 * t)}%`,
+  );
+  root.style.setProperty(
+    "--wallpaper-light-mix-main",
+    `${Math.round(24 * t)}%`,
+  );
+  root.style.setProperty(
+    "--wallpaper-light-mix-aside",
+    `${Math.round(32 * t)}%`,
+  );
+  root.style.setProperty(
+    "--wallpaper-light-mix-settings",
+    `${Math.round(72 * t)}%`,
+  );
+  root.style.setProperty(
     "--wallpaper-sidebar-blur",
     `${(22 * t).toFixed(1)}px`,
+  );
+  root.style.setProperty(
+    "--wallpaper-settings-blur",
+    `${(14 * t).toFixed(1)}px`,
+  );
+  root.style.setProperty(
+    "--wallpaper-sidebar-shadow-alpha",
+    `${(0.56 * (1 - t)).toFixed(3)}`,
+  );
+  root.style.setProperty(
+    "--wallpaper-light-foreground-shadow-alpha",
+    `${(0.22 + 0.44 * (1 - t)).toFixed(3)}`,
   );
 }
 

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -14,7 +14,7 @@ describe("wallpaper theme contrast CSS", () => {
     );
   });
 
-  it("keeps light controls readable without adding another blur layer", () => {
+  it("keeps light controls readable without adding structural surfaces", () => {
     const material = css.match(
       /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\(\.composer, \.composer__context-bar, \.main__top \.status-pill\)\s*\{[^}]*\}/s,
     )?.[0];
@@ -26,32 +26,49 @@ describe("wallpaper theme contrast CSS", () => {
       /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\([^)]*, \.status-pill\)\s*\{/s,
     );
     expect(css).toMatch(
-      /--wallpaper-light-elevated-surface:\s*color-mix\(\s*in srgb,\s*var\(--bg-elevated\) 82%,\s*transparent/s,
+      /--wallpaper-light-elevated-surface:\s*color-mix\(\s*in srgb,\s*var\(--bg-elevated\) 74%,\s*transparent/s,
     );
-    expect(css).toMatch(
-      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.sidebar\s*\{[^}]*--text-tertiary:[^}]*70%[^}]*background:\s*var\(--wallpaper-light-elevated-surface\)\s*!important/s,
+    expect(css).not.toContain("--wallpaper-light-surface-border");
+    expect(css).not.toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.sidebar\s*\{[^}]*background:\s*var\(--wallpaper-light-elevated-surface\)/s,
     );
-    expect(css).toMatch(
+    expect(css).not.toMatch(
       /html\[data-theme="light"\]\[data-wallpaper="1"\] \.main__top\s*\{[^}]*background:\s*var\(--wallpaper-light-elevated-surface\)/s,
     );
-    expect(css).toMatch(
-      /\.composer-welcome-mark\s*\{[^}]*background:\s*var\(--wallpaper-light-elevated-surface\)/s,
+    expect(css).not.toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*\.composer-welcome-mark\s*\{[^}]*(?:background|border|box-shadow):/s,
     );
     expect(css).toMatch(
       /\.lobe-chat-assistant-timeline\s+:is\(\s*pre,\s*code,\s*\.chat-code,\s*\.chat-md__table-wrap,[^)]*\.lobe-timeline-tool__output,[^)]*\.lobe-chat-plan,[^)]*\.struct-json,[^)]*\.att-card[^)]*\)\s*\{[^}]*text-shadow:\s*none/s,
     );
   });
 
-  it("uses foreground shadows only for dark wallpaper chrome", () => {
+  it("uses a dark edge on exposed light wallpaper chrome", () => {
     const lightRoot = css.match(
       /html\[data-theme="light"\]\[data-wallpaper="1"\]\s*\{[^}]*\}/s,
     )?.[0];
-    expect(lightRoot).not.toContain("foreground-shadow");
+    expect(lightRoot).toContain("--wallpaper-chrome-foreground");
+    expect(lightRoot).toContain("--wallpaper-chrome-shadow-color");
     expect(css).toMatch(
       /html\[data-theme="dark"\]\[data-wallpaper="1"\] \.sidebar\s*\{[^}]*text-shadow:/s,
     );
-    expect(css).not.toMatch(
-      /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*\{[^}]*text-shadow:/s,
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.sidebar\s*\{[^}]*--text-primary:\s*var\(--wallpaper-chrome-foreground\)[^}]*text-shadow:\s*0 1px 2px var\(--wallpaper-chrome-shadow-color\)/s,
+    );
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\]\s+\.sidebar\s+\.user-avatar--logo\s+\.grok-logo\s+svg\s*\{[^}]*color:\s*var\(--text-inverse\)[^}]*filter:\s*none/s,
+    );
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\]\s+\.sidebar\s+\.user-avatar--logo\s+\.provider-brand-icon\s*\{[^}]*filter:\s*none/s,
+    );
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\]\s+\.sidebar\s+\.user-avatar--logo\s+:is\(\.provider-brand-icon--amux,\s*\.provider-brand-icon--opencode-go\)\s*\{[^}]*color:\s*var\(--text-inverse\)/s,
+    );
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\(\.main__title,[^)]*\.main__title-row \.chrome-btn,[^)]*\.main__top-actions \.chrome-btn[^)]*\)\s*\{[^}]*color:\s*var\(--wallpaper-chrome-foreground\)[^}]*text-shadow:/s,
+    );
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.composer-welcome-mark\s*\{[^}]*--text-primary:\s*var\(--wallpaper-chrome-foreground\)[^}]*text-shadow:/s,
     );
   });
 });

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -71,4 +71,37 @@ describe("wallpaper theme contrast CSS", () => {
       /html\[data-theme="light"\]\[data-wallpaper="1"\] \.composer-welcome-mark\s*\{[^}]*--text-primary:\s*var\(--wallpaper-chrome-foreground\)[^}]*text-shadow:/s,
     );
   });
+
+  it("protects light wallpaper assistant ink while preserving carried surfaces", () => {
+    const timeline = css.match(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.lobe-chat-assistant-timeline\s*\{[^}]*\}/s,
+    )?.[0];
+    expect(timeline).toContain(
+      "--chat-text: var(--wallpaper-chrome-foreground)",
+    );
+    expect(timeline).toContain(
+      "text-shadow: 0 1px 2px var(--wallpaper-chrome-shadow-color)",
+    );
+    expect(timeline).not.toMatch(/(?:background|border|box-shadow):/);
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.lobe-chat-assistant-timeline svg\s*\{[^}]*filter:\s*drop-shadow\(0 1px 1px var\(--wallpaper-chrome-shadow-color\)\)/s,
+    );
+
+    const carriedSurface = css.match(
+      /\.lobe-chat-assistant-timeline\s+:is\([^{]*\.lobe-timeline-tool__output,[^{]*\.lobe-chat-plan,[^{]*\.struct-json,[^{]*\.att-card,[^{]*\.file-path-card[^)]*\)\s*\{[^}]*\}/s,
+    )?.[0];
+    expect(carriedSurface).toContain("--chat-text: var(--text-primary)");
+    expect(carriedSurface).toContain("--chat-text-2: var(--text-secondary)");
+    expect(carriedSurface).toContain("--chat-text-3: var(--text-tertiary)");
+    expect(carriedSurface).toContain("text-shadow: none");
+    expect(css).toMatch(
+      /html\[data-wallpaper="1"\]\s+\.lobe-chat\s+\.lobe-chat-assistant-timeline\s+:is\([^{]*\.lobe-chat-plan,[^{]*\.struct-json,[^{]*\.att-card,[^{]*\.file-path-card[^)]*\)\s+svg\s*\{[^}]*filter:\s*none/s,
+    );
+  });
+
+  it("does not paint a light fade beneath the floating wallpaper composer", () => {
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.composer-wrap--float\s*\{[^}]*background:\s*transparent/s,
+    );
+  });
 });

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -28,11 +28,21 @@ describe("wallpaper theme contrast CSS", () => {
     expect(css).toMatch(
       /--wallpaper-light-elevated-surface:\s*color-mix\(\s*in srgb,\s*var\(--bg-elevated\) 74%,\s*transparent/s,
     );
-    expect(css).toContain(
-      'html[data-wallpaper="1"] .lobe-chat-assistant-timeline',
-    );
     expect(css).toMatch(
       /\.lobe-chat-assistant-timeline\s+:is\(\s*pre,\s*code,\s*\.chat-code,\s*\.chat-md__table-wrap,[^)]*\.lobe-timeline-tool__output,[^)]*\.lobe-chat-plan,[^)]*\.struct-json,[^)]*\.att-card[^)]*\)\s*\{[^}]*text-shadow:\s*none/s,
+    );
+  });
+
+  it("uses foreground shadows only for dark wallpaper chrome", () => {
+    const lightRoot = css.match(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\]\s*\{[^}]*\}/s,
+    )?.[0];
+    expect(lightRoot).not.toContain("foreground-shadow");
+    expect(css).toMatch(
+      /html\[data-theme="dark"\]\[data-wallpaper="1"\] \.sidebar\s*\{[^}]*text-shadow:/s,
+    );
+    expect(css).not.toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*\{[^}]*text-shadow:/s,
     );
   });
 });

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -26,7 +26,16 @@ describe("wallpaper theme contrast CSS", () => {
       /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\([^)]*, \.status-pill\)\s*\{/s,
     );
     expect(css).toMatch(
-      /--wallpaper-light-elevated-surface:\s*color-mix\(\s*in srgb,\s*var\(--bg-elevated\) 74%,\s*transparent/s,
+      /--wallpaper-light-elevated-surface:\s*color-mix\(\s*in srgb,\s*var\(--bg-elevated\) 82%,\s*transparent/s,
+    );
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.sidebar\s*\{[^}]*--text-tertiary:[^}]*70%[^}]*background:\s*var\(--wallpaper-light-elevated-surface\)\s*!important/s,
+    );
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.main__top\s*\{[^}]*background:\s*var\(--wallpaper-light-elevated-surface\)/s,
+    );
+    expect(css).toMatch(
+      /\.composer-welcome-mark\s*\{[^}]*background:\s*var\(--wallpaper-light-elevated-surface\)/s,
     );
     expect(css).toMatch(
       /\.lobe-chat-assistant-timeline\s+:is\(\s*pre,\s*code,\s*\.chat-code,\s*\.chat-md__table-wrap,[^)]*\.lobe-timeline-tool__output,[^)]*\.lobe-chat-plan,[^)]*\.struct-json,[^)]*\.att-card[^)]*\)\s*\{[^}]*text-shadow:\s*none/s,

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(join(__dirname, "../styles/skins.css"), "utf8");
+
+describe("wallpaper theme contrast CSS", () => {
+  it("maps light wallpaper to its own white veil and pane curves", () => {
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\]\s*\{[^}]*--wallpaper-theme-scrim-color:\s*#ffffff[^}]*--wallpaper-theme-scrim-opacity:\s*var\(\s*--wallpaper-light-scrim-opacity[^}]*--wallpaper-theme-mix-main:\s*var\(--wallpaper-light-mix-main/s,
+    );
+    expect(css).toMatch(
+      /html\[data-wallpaper="1"\]\s*\{[^}]*--wallpaper-theme-scrim-opacity:\s*var\(--wallpaper-scrim-opacity[^}]*--wallpaper-theme-mix-main:\s*var\(--wallpaper-mix-main/s,
+    );
+  });
+
+  it("keeps light controls readable without adding another blur layer", () => {
+    const material = css.match(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\(\.composer, \.composer__context-bar, \.main__top \.status-pill\)\s*\{[^}]*\}/s,
+    )?.[0];
+    expect(material).toContain(
+      "background: var(--wallpaper-light-elevated-surface)",
+    );
+    expect(material).not.toContain("backdrop-filter");
+    expect(css).not.toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\([^)]*, \.status-pill\)\s*\{/s,
+    );
+    expect(css).toMatch(
+      /--wallpaper-light-elevated-surface:\s*color-mix\(\s*in srgb,\s*var\(--bg-elevated\) 74%,\s*transparent/s,
+    );
+    expect(css).toContain(
+      'html[data-wallpaper="1"] .lobe-chat-assistant-timeline',
+    );
+    expect(css).toMatch(
+      /\.lobe-chat-assistant-timeline\s+:is\(\s*pre,\s*code,\s*\.chat-code,\s*\.chat-md__table-wrap,[^)]*\.lobe-timeline-tool__output,[^)]*\.lobe-chat-plan,[^)]*\.struct-json,[^)]*\.att-card[^)]*\)\s*\{[^}]*text-shadow:\s*none/s,
+    );
+  });
+});

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -35,7 +35,12 @@ html[data-theme="light"][data-wallpaper="1"] {
   --wallpaper-theme-mix-settings: var(--wallpaper-light-mix-settings, 72%);
   --wallpaper-light-elevated-surface: color-mix(
     in srgb,
-    var(--bg-elevated) 74%,
+    var(--bg-elevated) 82%,
+    transparent
+  );
+  --wallpaper-light-surface-border: color-mix(
+    in srgb,
+    var(--text-primary) 10%,
     transparent
   );
 }
@@ -284,8 +289,8 @@ html[data-theme="light"][data-wallpaper="1"]
 }
 
 /*
- * Hard clear at 0% scrim — bypass color-mix residuals / platform solid fills
- * so the wallpaper is actually unobstructed under chrome.
+ * Hard clear at 0% scrim — clear the canvas and pane curves completely.
+ * The critical light-theme chrome below keeps its local readability surface.
  */
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .app-shell::after {
   opacity: 0 !important;
@@ -306,6 +311,31 @@ html[data-wallpaper="1"][data-wallpaper-clear="1"].platform-mac[data-theme="ligh
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
   box-shadow: none !important;
+}
+
+/* Wallpaper luminance is unknowable, so critical light-theme chrome keeps a
+ * fixed local surface even when the full-canvas scrim is explicitly clear. */
+html[data-theme="light"][data-wallpaper="1"] .sidebar {
+  --text-tertiary: color-mix(
+    in srgb,
+    var(--text-primary) 70%,
+    transparent
+  );
+  background: var(--wallpaper-light-elevated-surface) !important;
+}
+
+html[data-theme="light"][data-wallpaper="1"] .main__top {
+  background: var(--wallpaper-light-elevated-surface);
+  border-bottom-color: var(--wallpaper-light-surface-border);
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  .app-shell:not(.app-shell--phone)
+  .composer-welcome-mark {
+  border: 1px solid var(--wallpaper-light-surface-border);
+  border-radius: 24px;
+  background: var(--wallpaper-light-elevated-surface);
+  box-shadow: 0 8px 28px rgb(0 0 0 / 0.08);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -7,12 +7,42 @@
  * Media is rendered by a React layer (.app-wallpaper-media) so video & gif
  * actually play; scrim on ::after; panes go translucent.
  *
- * Scrim strength (Settings slider) writes:
- *   --wallpaper-scrim-opacity   0–1  (full-window ::after veil)
- *   --wallpaper-mix-sidebar|main|aside|settings  (pane tint %)
- *   --wallpaper-sidebar-blur
- * At 0% every dimming fill is fully transparent so the wallpaper is clear;
- * text/buttons keep their own solid colors. Settings cards stay solid. */
+ * Scrim strength (Settings slider) writes separate dark/light veil + pane
+ * curves, along with sidebar/settings blur and foreground contrast strength.
+ * At 0% pane fills are clear; foreground halos and elevated controls remain so
+ * the wallpaper can stay visible without sacrificing essential readability. */
+html[data-wallpaper="1"] {
+  --wallpaper-theme-scrim-color: var(--bg-app);
+  --wallpaper-theme-scrim-opacity: var(--wallpaper-scrim-opacity, 1);
+  --wallpaper-theme-mix-sidebar: var(--wallpaper-mix-sidebar, 58%);
+  --wallpaper-theme-mix-main: var(--wallpaper-mix-main, 70%);
+  --wallpaper-theme-mix-aside: var(--wallpaper-mix-aside, 70%);
+  --wallpaper-theme-mix-settings: var(--wallpaper-mix-settings, 78%);
+  --wallpaper-foreground-shadow-color: rgb(
+    0 0 0 / var(--wallpaper-sidebar-shadow-alpha, 0)
+  );
+}
+
+html[data-theme="light"][data-wallpaper="1"] {
+  --wallpaper-theme-scrim-color: #ffffff;
+  --wallpaper-theme-scrim-opacity: var(
+    --wallpaper-light-scrim-opacity,
+    0.45
+  );
+  --wallpaper-theme-mix-sidebar: var(--wallpaper-light-mix-sidebar, 72%);
+  --wallpaper-theme-mix-main: var(--wallpaper-light-mix-main, 24%);
+  --wallpaper-theme-mix-aside: var(--wallpaper-light-mix-aside, 32%);
+  --wallpaper-theme-mix-settings: var(--wallpaper-light-mix-settings, 72%);
+  --wallpaper-foreground-shadow-color: rgb(
+    255 255 255 / var(--wallpaper-light-foreground-shadow-alpha, 0.22)
+  );
+  --wallpaper-light-elevated-surface: color-mix(
+    in srgb,
+    var(--bg-elevated) 74%,
+    transparent
+  );
+}
+
 html[data-wallpaper="1"] .app-shell {
   background: transparent !important;
 }
@@ -23,14 +53,14 @@ html[data-wallpaper="1"] .app-shell::after {
   inset: 0;
   z-index: 0;
   pointer-events: none;
-  opacity: var(--wallpaper-scrim-opacity, 1);
+  opacity: var(--wallpaper-theme-scrim-opacity);
   /* Left-weighted scrim so chrome stays readable (Dream Skin safe-area left). */
   background: linear-gradient(
     105deg,
-    color-mix(in srgb, var(--bg-app) 88%, transparent) 0%,
-    color-mix(in srgb, var(--bg-app) 62%, transparent) 42%,
-    color-mix(in srgb, var(--bg-app) 28%, transparent) 78%,
-    color-mix(in srgb, var(--bg-app) 12%, transparent) 100%
+    color-mix(in srgb, var(--wallpaper-theme-scrim-color) 88%, transparent) 0%,
+    color-mix(in srgb, var(--wallpaper-theme-scrim-color) 62%, transparent) 42%,
+    color-mix(in srgb, var(--wallpaper-theme-scrim-color) 28%, transparent) 78%,
+    color-mix(in srgb, var(--wallpaper-theme-scrim-color) 12%, transparent) 100%
   );
 }
 
@@ -70,29 +100,86 @@ html[data-wallpaper="1"] .workbench {
 /* Keep the atomic Settings swap above the lifted workbench chrome. */
 html[data-wallpaper="1"] .app-settings-stage {
   z-index: 20;
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur))
+  backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
     saturate(var(--glass-saturate));
 }
 
 /* Pane fills scale with scrim: 0% = fully clear wallpaper under chrome.
  * !important beats platform-win solid fills and mac light #ffffff rules. */
 html[data-wallpaper="1"] .sidebar {
+  --text-secondary: color-mix(
+    in srgb,
+    var(--text-primary) 80%,
+    transparent
+  );
+  --text-tertiary: color-mix(
+    in srgb,
+    var(--text-primary) 62%,
+    transparent
+  );
   background: color-mix(
     in srgb,
     var(--bg-sidebar-solid, var(--bg-sidebar))
-      var(--wallpaper-mix-sidebar, 58%),
+      var(--wallpaper-theme-mix-sidebar),
     transparent
   ) !important;
   backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px)) saturate(1.25);
   -webkit-backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px))
     saturate(1.25);
+  text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
+}
+
+html[data-wallpaper="1"] .sidebar svg {
+  filter: drop-shadow(0 1px 1px var(--wallpaper-foreground-shadow-color));
+}
+
+html[data-wallpaper="1"] .main__top,
+html[data-wallpaper="1"] .composer-welcome-mark,
+html[data-wallpaper="1"] .lobe-chat-assistant-timeline {
+  text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
+}
+
+html[data-wallpaper="1"] .main__top svg,
+html[data-wallpaper="1"] .composer-welcome-mark svg,
+html[data-wallpaper="1"] .lobe-chat-assistant-timeline svg {
+  filter: drop-shadow(0 1px 1px var(--wallpaper-foreground-shadow-color));
+}
+
+html[data-wallpaper="1"]
+  .lobe-chat-assistant-timeline
+  :is(
+    pre,
+    code,
+    .chat-code,
+    .chat-md__table-wrap,
+    .lobe-timeline-tool__output,
+    .lobe-timeline-tool__cmd,
+    .lobe-chat-plan,
+    .struct-json,
+    .att-card
+  ) {
+  text-shadow: none;
+}
+
+html[data-wallpaper="1"]
+  .lobe-chat-assistant-timeline
+  :is(
+    .chat-code,
+    .chat-md__table-wrap,
+    .lobe-chat-plan,
+    .struct-json,
+    .att-card
+  )
+  svg {
+  filter: none;
 }
 
 html[data-wallpaper="1"] .main {
   background: color-mix(
     in srgb,
-    var(--bg-main) var(--wallpaper-mix-main, 70%),
+    var(--bg-main) var(--wallpaper-theme-mix-main),
     transparent
   ) !important;
   /* Drop soft lift shadow that reads as a gray edge over clear wallpaper. */
@@ -102,7 +189,7 @@ html[data-wallpaper="1"] .main {
 html[data-wallpaper="1"] .aside {
   background: color-mix(
     in srgb,
-    var(--bg-aside) var(--wallpaper-mix-aside, 70%),
+    var(--bg-aside) var(--wallpaper-theme-mix-aside),
     transparent
   ) !important;
 }
@@ -111,7 +198,7 @@ html[data-wallpaper="1"] .settings-page,
 html[data-wallpaper="1"] .setup-gate {
   background: color-mix(
     in srgb,
-    var(--bg-main) var(--wallpaper-mix-settings, 78%),
+    var(--bg-main) var(--wallpaper-theme-mix-settings),
     transparent
   ) !important;
 }
@@ -128,7 +215,7 @@ html[data-wallpaper="1"] .platform-mac .settings-page__nav {
   background: color-mix(
     in srgb,
     var(--bg-sidebar-solid, var(--bg-sidebar))
-      var(--wallpaper-mix-sidebar, 58%),
+      var(--wallpaper-theme-mix-sidebar),
     transparent
   ) !important;
   backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px)) saturate(1.25);
@@ -141,6 +228,7 @@ html[data-wallpaper="1"] .platform-mac .settings-page__nav {
  * Frosted wallpaper panes on a playing video are a WebView2 GPU sink.
  * Video pause is JS (WallpaperMediaLayer).
  */
+html[data-stream-perf="1"][data-wallpaper="1"] .app-settings-stage,
 html[data-stream-perf="1"][data-wallpaper="1"] .sidebar,
 html[data-stream-perf="1"][data-wallpaper="1"] .settings-page__nav,
 html[data-stream-perf="1"][data-wallpaper="1"] .platform-win .settings-page__nav,
@@ -155,20 +243,44 @@ html[data-wallpaper="1"].platform-mac .settings-page__content,
 html[data-wallpaper="1"].platform-mac[data-theme="light"] .settings-page__content {
   background: color-mix(
     in srgb,
-    var(--bg-main) var(--wallpaper-mix-settings, 78%),
+    var(--bg-main) var(--wallpaper-theme-mix-settings),
     transparent
   ) !important;
   box-shadow: none !important;
 }
 
-/* mac light workbench main is forced #ffffff — keep it tied to scrim too. */
-html[data-wallpaper="1"].platform-mac[data-theme="light"] .main,
+/* mac light workbench is forced #ffffff — keep each pane on its light curve. */
+html[data-wallpaper="1"].platform-mac[data-theme="light"] .main {
+  background: color-mix(
+    in srgb,
+    #ffffff var(--wallpaper-theme-mix-main),
+    transparent
+  ) !important;
+}
+
 html[data-wallpaper="1"].platform-mac[data-theme="light"] .aside {
   background: color-mix(
     in srgb,
-    #ffffff var(--wallpaper-mix-main, 70%),
+    #ffffff var(--wallpaper-theme-mix-aside),
     transparent
   ) !important;
+}
+
+/* Light wallpaper controls share one translucent elevated material. It stays
+ * readable when stream-perf removes pane blur and when the scrim is low. */
+html[data-theme="light"][data-wallpaper="1"]
+  :is(.composer, .composer__context-bar, .main__top .status-pill) {
+  background: var(--wallpaper-light-elevated-surface);
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  .main__top
+  .status-pill--action:hover {
+  background: color-mix(
+    in srgb,
+    var(--wallpaper-light-elevated-surface) 90%,
+    var(--text-primary) 10%
+  );
 }
 
 /*
@@ -179,6 +291,7 @@ html[data-wallpaper="1"][data-wallpaper-clear="1"] .app-shell::after {
   opacity: 0 !important;
 }
 
+html[data-wallpaper="1"][data-wallpaper-clear="1"] .app-settings-stage,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .sidebar,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .main,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .aside,

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -35,14 +35,11 @@ html[data-theme="light"][data-wallpaper="1"] {
   --wallpaper-theme-mix-settings: var(--wallpaper-light-mix-settings, 72%);
   --wallpaper-light-elevated-surface: color-mix(
     in srgb,
-    var(--bg-elevated) 82%,
+    var(--bg-elevated) 74%,
     transparent
   );
-  --wallpaper-light-surface-border: color-mix(
-    in srgb,
-    var(--text-primary) 10%,
-    transparent
-  );
+  --wallpaper-chrome-foreground: rgb(255 255 255 / 0.96);
+  --wallpaper-chrome-shadow-color: rgb(0 0 0 / 0.68);
 }
 
 html[data-wallpaper="1"] .app-shell {
@@ -290,7 +287,6 @@ html[data-theme="light"][data-wallpaper="1"]
 
 /*
  * Hard clear at 0% scrim — clear the canvas and pane curves completely.
- * The critical light-theme chrome below keeps its local readability surface.
  */
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .app-shell::after {
   opacity: 0 !important;
@@ -313,29 +309,72 @@ html[data-wallpaper="1"][data-wallpaper-clear="1"].platform-mac[data-theme="ligh
   box-shadow: none !important;
 }
 
-/* Wallpaper luminance is unknowable, so critical light-theme chrome keeps a
- * fixed local surface even when the full-canvas scrim is explicitly clear. */
+/* Wallpaper luminance is unknowable. Keep light and dark wallpaper layouts
+ * structurally identical, then protect only foreground ink with the same
+ * white-on-dark-edge treatment used by the dark shell. */
 html[data-theme="light"][data-wallpaper="1"] .sidebar {
-  --text-tertiary: color-mix(
-    in srgb,
-    var(--text-primary) 70%,
-    transparent
-  );
-  background: var(--wallpaper-light-elevated-surface) !important;
+  --text-primary: var(--wallpaper-chrome-foreground);
+  --text-inverse: rgb(15 15 15 / 0.96);
+  --bg-hover: rgb(0 0 0 / 0.14);
+  --bg-active: rgb(0 0 0 / 0.2);
+  color: var(--wallpaper-chrome-foreground);
+  text-shadow: 0 1px 2px var(--wallpaper-chrome-shadow-color);
 }
 
-html[data-theme="light"][data-wallpaper="1"] .main__top {
-  background: var(--wallpaper-light-elevated-surface);
-  border-bottom-color: var(--wallpaper-light-surface-border);
+html[data-theme="light"][data-wallpaper="1"] .sidebar svg {
+  filter: drop-shadow(0 1px 1px var(--wallpaper-chrome-shadow-color));
 }
 
 html[data-theme="light"][data-wallpaper="1"]
-  .app-shell:not(.app-shell--phone)
-  .composer-welcome-mark {
-  border: 1px solid var(--wallpaper-light-surface-border);
-  border-radius: 24px;
-  background: var(--wallpaper-light-elevated-surface);
-  box-shadow: 0 8px 28px rgb(0 0 0 / 0.08);
+  .sidebar
+  .user-avatar--logo
+  .grok-logo
+  svg {
+  color: var(--text-inverse);
+  filter: none;
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  .sidebar
+  .user-avatar--logo
+  .provider-brand-icon {
+  filter: none;
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  .sidebar
+  .user-avatar--logo
+  :is(.provider-brand-icon--amux, .provider-brand-icon--opencode-go) {
+  color: var(--text-inverse);
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  :is(.main__title, .main__title-icon, .main__title-row .chrome-btn, .main__top-actions .chrome-btn) {
+  color: var(--wallpaper-chrome-foreground);
+  text-shadow: 0 1px 2px var(--wallpaper-chrome-shadow-color);
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  :is(.main__title-icon, .main__title-row .chrome-btn, .main__top-actions .chrome-btn)
+  svg {
+  filter: drop-shadow(0 1px 1px var(--wallpaper-chrome-shadow-color));
+}
+
+html[data-theme="light"][data-wallpaper="1"] .composer-welcome-mark {
+  --text-primary: var(--wallpaper-chrome-foreground);
+  color: var(--wallpaper-chrome-foreground);
+  text-shadow: 0 1px 2px var(--wallpaper-chrome-shadow-color);
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  .composer-welcome-mark
+  :is(.deepseek-full-mark__ink, .opencode-wordmark) {
+  color: var(--wallpaper-chrome-foreground);
+  fill: var(--wallpaper-chrome-foreground);
+}
+
+html[data-theme="light"][data-wallpaper="1"] .composer-welcome-mark svg {
+  filter: drop-shadow(0 1px 1px var(--wallpaper-chrome-shadow-color));
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -8,9 +8,9 @@
  * actually play; scrim on ::after; panes go translucent.
  *
  * Scrim strength (Settings slider) writes separate dark/light veil + pane
- * curves, along with sidebar/settings blur and foreground contrast strength.
- * At 0% pane fills are clear; foreground halos and elevated controls remain so
- * the wallpaper can stay visible without sacrificing essential readability. */
+ * curves, along with sidebar/settings blur and dark-theme foreground contrast.
+ * At 0% pane fills are clear; elevated controls remain readable without adding
+ * a light halo to dark text. */
 html[data-wallpaper="1"] {
   --wallpaper-theme-scrim-color: var(--bg-app);
   --wallpaper-theme-scrim-opacity: var(--wallpaper-scrim-opacity, 1);
@@ -33,9 +33,6 @@ html[data-theme="light"][data-wallpaper="1"] {
   --wallpaper-theme-mix-main: var(--wallpaper-light-mix-main, 24%);
   --wallpaper-theme-mix-aside: var(--wallpaper-light-mix-aside, 32%);
   --wallpaper-theme-mix-settings: var(--wallpaper-light-mix-settings, 72%);
-  --wallpaper-foreground-shadow-color: rgb(
-    255 255 255 / var(--wallpaper-light-foreground-shadow-alpha, 0.22)
-  );
   --wallpaper-light-elevated-surface: color-mix(
     in srgb,
     var(--bg-elevated) 74%,
@@ -128,22 +125,25 @@ html[data-wallpaper="1"] .sidebar {
   backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px)) saturate(1.25);
   -webkit-backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px))
     saturate(1.25);
+}
+
+html[data-theme="dark"][data-wallpaper="1"] .sidebar {
   text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
 }
 
-html[data-wallpaper="1"] .sidebar svg {
+html[data-theme="dark"][data-wallpaper="1"] .sidebar svg {
   filter: drop-shadow(0 1px 1px var(--wallpaper-foreground-shadow-color));
 }
 
-html[data-wallpaper="1"] .main__top,
-html[data-wallpaper="1"] .composer-welcome-mark,
-html[data-wallpaper="1"] .lobe-chat-assistant-timeline {
+html[data-theme="dark"][data-wallpaper="1"] .main__top,
+html[data-theme="dark"][data-wallpaper="1"] .composer-welcome-mark,
+html[data-theme="dark"][data-wallpaper="1"] .lobe-chat-assistant-timeline {
   text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
 }
 
-html[data-wallpaper="1"] .main__top svg,
-html[data-wallpaper="1"] .composer-welcome-mark svg,
-html[data-wallpaper="1"] .lobe-chat-assistant-timeline svg {
+html[data-theme="dark"][data-wallpaper="1"] .main__top svg,
+html[data-theme="dark"][data-wallpaper="1"] .composer-welcome-mark svg,
+html[data-theme="dark"][data-wallpaper="1"] .lobe-chat-assistant-timeline svg {
   filter: drop-shadow(0 1px 1px var(--wallpaper-foreground-shadow-color));
 }
 

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -150,6 +150,7 @@ html[data-theme="dark"][data-wallpaper="1"] .lobe-chat-assistant-timeline svg {
 }
 
 html[data-wallpaper="1"]
+  .lobe-chat
   .lobe-chat-assistant-timeline
   :is(
     pre,
@@ -160,19 +161,25 @@ html[data-wallpaper="1"]
     .lobe-timeline-tool__cmd,
     .lobe-chat-plan,
     .struct-json,
-    .att-card
+    .att-card,
+    .file-path-card
   ) {
+  --chat-text: var(--text-primary);
+  --chat-text-2: var(--text-secondary);
+  --chat-text-3: var(--text-tertiary);
   text-shadow: none;
 }
 
 html[data-wallpaper="1"]
+  .lobe-chat
   .lobe-chat-assistant-timeline
   :is(
     .chat-code,
     .chat-md__table-wrap,
     .lobe-chat-plan,
     .struct-json,
-    .att-card
+    .att-card,
+    .file-path-card
   )
   svg {
   filter: none;
@@ -285,6 +292,10 @@ html[data-theme="light"][data-wallpaper="1"]
   );
 }
 
+html[data-theme="light"][data-wallpaper="1"] .composer-wrap--float {
+  background: transparent;
+}
+
 /*
  * Hard clear at 0% scrim — clear the canvas and pane curves completely.
  */
@@ -357,6 +368,26 @@ html[data-theme="light"][data-wallpaper="1"]
 html[data-theme="light"][data-wallpaper="1"]
   :is(.main__title-icon, .main__title-row .chrome-btn, .main__top-actions .chrome-btn)
   svg {
+  filter: drop-shadow(0 1px 1px var(--wallpaper-chrome-shadow-color));
+}
+
+html[data-theme="light"][data-wallpaper="1"] .lobe-chat-assistant-timeline {
+  --chat-text: var(--wallpaper-chrome-foreground);
+  --chat-text-2: color-mix(
+    in srgb,
+    var(--wallpaper-chrome-foreground) 84%,
+    transparent
+  );
+  --chat-text-3: color-mix(
+    in srgb,
+    var(--wallpaper-chrome-foreground) 72%,
+    transparent
+  );
+  color: var(--wallpaper-chrome-foreground);
+  text-shadow: 0 1px 2px var(--wallpaper-chrome-shadow-color);
+}
+
+html[data-theme="light"][data-wallpaper="1"] .lobe-chat-assistant-timeline svg {
   filter: drop-shadow(0 1px 1px var(--wallpaper-chrome-shadow-color));
 }
 


### PR DESCRIPTION
## 背景

主仓 PR #859 已先完成壁纸下设置页面的背景模糊，并明确将浅色壁纸可读性作为独立后续工作。浅色主题在自定义背景的亮暗区域之间仍存在文字失读，同时浮动输入区底部的白色渐变会形成突兀泛白。

## 改动

- 为浅色壁纸建立独立的白色 veil 与 pane 混合曲线，保持浅色、深色布局结构一致。
- 对直接暴露在壁纸上的侧栏、标题、欢迎区和主对话文字使用高对比前景与深色边缘，不新增底部承载卡片。
- 让代码、表格、工具输出、计划、附件和文件路径卡继续使用各自主题文字 token，避免白字落在浅色承载面上。
- 移除浅色壁纸下浮动输入区外层的白色渐变，保留输入框自身材质。
- 保留 0% 遮罩的通透效果，并覆盖 stream-perf 与自定义皮肤边界。

## 验证

- [x] 全量 Vitest：502 个测试文件、6561 项测试通过
- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm build:ui
- [x] git diff --check
- [x] 独立 Tauri 测试实例整合验收
- [x] Pi 只读审查 PASS

## 范围

本 PR 仅处理浅色自定义壁纸的 veil、pane 与文字可读性，不包含计划/终端动效或 macOS 交通灯避让。