### PR TITLE
优化计划面板与底部终端的出现动效

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -2779,6 +2779,10 @@ export function AppWorkbench() {
     DEFAULT_LAYOUT.asideWidth,
     ASIDE_WIDTH_MIN,
   );
+  const hideChatForSideExpand = shouldHideChatForSideExpand({
+    expanded: sideWorkbench.expanded,
+    phoneLayout,
+  });
   const sidebarOverlay =
     !phoneLayout &&
     resolveWorkbenchPaneOverlay({
@@ -2807,6 +2811,7 @@ export function AppWorkbench() {
     phoneLayout,
     sidebarOverlay,
     asideOverlay,
+    asideInFlow: !phoneLayout && !hideChatForSideExpand && !asideOverlay,
   });
   const asideFitGenRef = useRef(0);
   const sidebarFitGenRef = useRef(0);
@@ -13198,10 +13203,6 @@ export function AppWorkbench() {
     welcomeBrandKind,
   ]);
 
-  const hideChatForSideExpand = shouldHideChatForSideExpand({
-    expanded: sideWorkbench.expanded,
-    phoneLayout,
-  });
   const sidebarPaint =
     layout.sidebarCollapsed || sidebarOverlay
       ? 0

--- a/src/hooks/usePaneSplitMotion.test.tsx
+++ b/src/hooks/usePaneSplitMotion.test.tsx
@@ -85,4 +85,46 @@ describe("usePaneSplitMotion", () => {
     act(() => dispatchWidthTransitionEnd("sidebar"));
     expect(isPaneSplitMotionActive()).toBe(false);
   });
+
+  it("covers native webviews while an in-flow aside interpolates", () => {
+    const props = { ...initialProps, asideOverlay: false };
+    const { result, rerender } = renderHook(
+      (next) => usePaneSplitMotion(next),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, asideCollapsed: true });
+    expect(result.current.paneMotionClass).toContain(
+      "workbench--aside-motion",
+    );
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    expect(isPaneSplitMotionActive()).toBe(true);
+
+    act(() => dispatchWidthTransitionEnd("aside"));
+    expect(nativeWebviewCoverDepth()).toBe(0);
+    expect(isPaneSplitMotionActive()).toBe(false);
+  });
+
+  it("waits for both in-flow panes before ending a shared motion", () => {
+    const props = { ...initialProps, asideOverlay: false };
+    const { rerender } = renderHook((next) => usePaneSplitMotion(next), {
+      initialProps: props,
+    });
+
+    rerender({
+      ...props,
+      sidebarCollapsed: true,
+      asideCollapsed: true,
+    });
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    expect(isPaneSplitMotionActive()).toBe(true);
+
+    act(() => dispatchWidthTransitionEnd("sidebar"));
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    expect(isPaneSplitMotionActive()).toBe(true);
+
+    act(() => dispatchWidthTransitionEnd("aside"));
+    expect(nativeWebviewCoverDepth()).toBe(0);
+    expect(isPaneSplitMotionActive()).toBe(false);
+  });
 });

--- a/src/hooks/usePaneSplitMotion.test.tsx
+++ b/src/hooks/usePaneSplitMotion.test.tsx
@@ -21,6 +21,7 @@ const initialProps = {
   phoneLayout: false,
   sidebarOverlay: false,
   asideOverlay: true,
+  asideInFlow: false,
 };
 
 function dispatchWidthTransitionEnd(className: string): void {
@@ -52,7 +53,7 @@ describe("usePaneSplitMotion", () => {
       initialProps,
     });
 
-    rerender({ ...initialProps, asideOverlay: false });
+    rerender({ ...initialProps, asideOverlay: false, asideInFlow: true });
     expect(nativeWebviewCoverDepth()).toBe(1);
     expect(isPaneSplitMotionActive()).toBe(true);
 
@@ -72,12 +73,17 @@ describe("usePaneSplitMotion", () => {
 
   it("ends an in-flow sidebar token on its width transition", () => {
     const { rerender } = renderHook((props) => usePaneSplitMotion(props), {
-      initialProps: { ...initialProps, asideOverlay: false },
+      initialProps: {
+        ...initialProps,
+        asideOverlay: false,
+        asideInFlow: true,
+      },
     });
 
     rerender({
       ...initialProps,
       asideOverlay: false,
+      asideInFlow: true,
       sidebarCollapsed: true,
     });
     expect(isPaneSplitMotionActive()).toBe(true);
@@ -87,7 +93,11 @@ describe("usePaneSplitMotion", () => {
   });
 
   it("covers native webviews while an in-flow aside interpolates", () => {
-    const props = { ...initialProps, asideOverlay: false };
+    const props = {
+      ...initialProps,
+      asideOverlay: false,
+      asideInFlow: true,
+    };
     const { result, rerender } = renderHook(
       (next) => usePaneSplitMotion(next),
       { initialProps: props },
@@ -106,7 +116,11 @@ describe("usePaneSplitMotion", () => {
   });
 
   it("waits for both in-flow panes before ending a shared motion", () => {
-    const props = { ...initialProps, asideOverlay: false };
+    const props = {
+      ...initialProps,
+      asideOverlay: false,
+      asideInFlow: true,
+    };
     const { rerender } = renderHook((next) => usePaneSplitMotion(next), {
       initialProps: props,
     });
@@ -124,6 +138,83 @@ describe("usePaneSplitMotion", () => {
     expect(isPaneSplitMotionActive()).toBe(true);
 
     act(() => dispatchWidthTransitionEnd("aside"));
+    expect(nativeWebviewCoverDepth()).toBe(0);
+    expect(isPaneSplitMotionActive()).toBe(false);
+  });
+
+  it("does not animate an aside leaving the in-flow split", () => {
+    const props = {
+      ...initialProps,
+      asideOverlay: false,
+      asideInFlow: true,
+    };
+    const { result, rerender } = renderHook(
+      (next) => usePaneSplitMotion(next),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, asideCollapsed: true, asideInFlow: false });
+    expect(result.current.paneMotionClass).not.toContain(
+      "workbench--aside-motion",
+    );
+    expect(nativeWebviewCoverDepth()).toBe(0);
+    expect(isPaneSplitMotionActive()).toBe(false);
+  });
+
+  it("does not cover webviews when an overlay becomes side-expanded", () => {
+    const { result, rerender } = renderHook(
+      (next) => usePaneSplitMotion(next),
+      { initialProps },
+    );
+
+    rerender({ ...initialProps, asideOverlay: false, asideInFlow: false });
+    expect(result.current.paneMotionClass).toBe("");
+    expect(nativeWebviewCoverDepth()).toBe(0);
+    expect(isPaneSplitMotionActive()).toBe(false);
+  });
+
+  it("ends an active in-flow aside motion when side-expanded takes over", () => {
+    const props = {
+      ...initialProps,
+      asideOverlay: false,
+      asideInFlow: true,
+    };
+    const { result, rerender } = renderHook(
+      (next) => usePaneSplitMotion(next),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, asideCollapsed: true });
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    expect(isPaneSplitMotionActive()).toBe(true);
+
+    rerender({
+      ...props,
+      asideCollapsed: true,
+      asideInFlow: false,
+    });
+    expect(result.current.paneMotionClass).toBe("");
+    expect(nativeWebviewCoverDepth()).toBe(0);
+    expect(isPaneSplitMotionActive()).toBe(false);
+  });
+
+  it("ends an active overlay token when side-expanded takes over", () => {
+    const props = {
+      ...initialProps,
+      asideOverlay: false,
+      asideInFlow: true,
+    };
+    const { result, rerender } = renderHook(
+      (next) => usePaneSplitMotion(next),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, asideOverlay: true, asideInFlow: false });
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    expect(isPaneSplitMotionActive()).toBe(true);
+
+    rerender({ ...props, asideOverlay: false, asideInFlow: false });
+    expect(result.current.paneMotionClass).toBe("");
     expect(nativeWebviewCoverDepth()).toBe(0);
     expect(isPaneSplitMotionActive()).toBe(false);
   });

--- a/src/hooks/usePaneSplitMotion.ts
+++ b/src/hooks/usePaneSplitMotion.ts
@@ -50,9 +50,12 @@ export function usePaneSplitMotion(opts: {
     const asideChanged =
       keyRef.current.slice(colon + 1) !== String(opts.asideCollapsed);
     const sidebarWidthChanged = sidebarChanged && !opts.sidebarOverlay;
+    const asideWidthChanged =
+      asideChanged && !opts.asideOverlay && !asideOverlayRef.current;
     const asideOverlayChanged =
       asideChanged && (asideOverlayRef.current || asideOverlay);
-    const coverChanged = asideOverlayChanged || asideOverlayModeChanged;
+    const coverChanged =
+      asideWidthChanged || asideOverlayChanged || asideOverlayModeChanged;
     keyRef.current = key;
     if (
       !opts.phoneLayout &&
@@ -66,9 +69,9 @@ export function usePaneSplitMotion(opts: {
       if (tokenRef.current) endPaneSplitMotion(tokenRef.current);
       tokenRef.current = beginPaneSplitMotion({
         cover: coverChanged,
-        width: sidebarWidthChanged,
+        width: sidebarWidthChanged || asideWidthChanged,
         sidebar: sidebarWidthChanged,
-        aside: false,
+        aside: asideWidthChanged,
       });
     }
   }
@@ -79,6 +82,9 @@ export function usePaneSplitMotion(opts: {
     if (!token) return;
     const finishOnSidebarWidth = isPaneSplitSidebarMotionActive();
     const finishOnAsideWidth = isPaneSplitAsideMotionActive();
+    const pendingWidthPanes = new Set<"sidebar" | "aside">();
+    if (finishOnSidebarWidth) pendingWidthPanes.add("sidebar");
+    if (finishOnAsideWidth) pendingWidthPanes.add("aside");
 
     if (isPaneSplitCoverActive() && !releaseRef.current) {
       releaseRef.current = acquireNativeWebviewCover();
@@ -106,14 +112,13 @@ export function usePaneSplitMotion(opts: {
       const t = e.target;
       if (!(t instanceof HTMLElement)) return;
       if (e.propertyName !== "width") return;
-      if (t.classList.contains("sidebar") && !finishOnSidebarWidth) return;
-      if (t.classList.contains("aside") && !finishOnAsideWidth) return;
-      if (
-        !t.classList.contains("sidebar") &&
-        !t.classList.contains("aside")
-      ) {
-        return;
-      }
+      const pane = t.classList.contains("sidebar")
+        ? "sidebar"
+        : t.classList.contains("aside")
+          ? "aside"
+          : null;
+      if (!pane || !pendingWidthPanes.delete(pane)) return;
+      if (pendingWidthPanes.size) return;
       finish();
     };
     document.addEventListener("transitionend", onEnd);

--- a/src/hooks/usePaneSplitMotion.ts
+++ b/src/hooks/usePaneSplitMotion.ts
@@ -30,10 +30,13 @@ export function usePaneSplitMotion(opts: {
   sidebarOverlay?: boolean;
   /** Right pane is an overlay drawer — cover native webviews during transform. */
   asideOverlay?: boolean;
+  /** Right pane participates in the workbench width split. */
+  asideInFlow: boolean;
 }): { paneMotionClass: string } {
   const [, setEpoch] = useState(0);
   const keyRef = useRef<string | null>(null);
   const asideOverlayRef = useRef(Boolean(opts.asideOverlay));
+  const asideInFlowRef = useRef(opts.asideInFlow);
   const tokenRef = useRef(0);
   const releaseRef = useRef<(() => void) | null>(null);
   const timerRef = useRef<number | null>(null);
@@ -41,9 +44,23 @@ export function usePaneSplitMotion(opts: {
   const key = `${opts.sidebarCollapsed}:${opts.asideCollapsed}`;
   const asideOverlay = Boolean(opts.asideOverlay);
   const asideOverlayModeChanged = asideOverlayRef.current !== asideOverlay;
+  const asideOverlayMotionChanged =
+    asideOverlayModeChanged && (asideOverlay || opts.asideInFlow);
+  const enteredSideExpanded =
+    !asideOverlay &&
+    !opts.asideInFlow &&
+    (asideOverlayRef.current || asideInFlowRef.current);
+  if (
+    enteredSideExpanded &&
+    tokenRef.current &&
+    (isPaneSplitAsideMotionActive() || isPaneSplitCoverActive())
+  ) {
+    endPaneSplitMotion(tokenRef.current);
+    tokenRef.current = 0;
+  }
   if (keyRef.current === null) {
     keyRef.current = key;
-  } else if (keyRef.current !== key || asideOverlayModeChanged) {
+  } else if (keyRef.current !== key || asideOverlayMotionChanged) {
     const colon = keyRef.current.indexOf(":");
     const sidebarChanged =
       keyRef.current.slice(0, colon) !== String(opts.sidebarCollapsed);
@@ -51,11 +68,13 @@ export function usePaneSplitMotion(opts: {
       keyRef.current.slice(colon + 1) !== String(opts.asideCollapsed);
     const sidebarWidthChanged = sidebarChanged && !opts.sidebarOverlay;
     const asideWidthChanged =
-      asideChanged && !opts.asideOverlay && !asideOverlayRef.current;
+      asideChanged && opts.asideInFlow && asideInFlowRef.current;
     const asideOverlayChanged =
-      asideChanged && (asideOverlayRef.current || asideOverlay);
+      asideChanged &&
+      (asideOverlay || opts.asideInFlow) &&
+      (asideOverlayRef.current || asideOverlay);
     const coverChanged =
-      asideWidthChanged || asideOverlayChanged || asideOverlayModeChanged;
+      asideWidthChanged || asideOverlayChanged || asideOverlayMotionChanged;
     keyRef.current = key;
     if (
       !opts.phoneLayout &&
@@ -76,10 +95,17 @@ export function usePaneSplitMotion(opts: {
     }
   }
   asideOverlayRef.current = asideOverlay;
+  asideInFlowRef.current = opts.asideInFlow;
 
   useLayoutEffect(() => {
     const token = tokenRef.current;
-    if (!token) return;
+    if (!token) {
+      if (releaseRef.current && !isPaneSplitCoverActive()) {
+        releaseRef.current();
+        releaseRef.current = null;
+      }
+      return;
+    }
     const finishOnSidebarWidth = isPaneSplitSidebarMotionActive();
     const finishOnAsideWidth = isPaneSplitAsideMotionActive();
     const pendingWidthPanes = new Set<"sidebar" | "aside">();
@@ -137,6 +163,7 @@ export function usePaneSplitMotion(opts: {
     opts.phoneLayout,
     opts.sidebarOverlay,
     opts.asideOverlay,
+    opts.asideInFlow,
   ]);
 
   useEffect(() => {

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -115,7 +115,7 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(block).not.toMatch(/--motion-pane\s*:\s*0ms/);
   });
 
-  it("in-flow sidebar interpolates while aside and bottom terminal snap", () => {
+  it("in-flow sidebar and aside interpolate while bottom terminal snaps", () => {
     const settings = readFileSync(
       resolve(__dirname, "../styles/settings.part5.css"),
       "utf8",
@@ -143,8 +143,8 @@ describe("desktop hidden CSS must not force width 0", () => {
       resolve(__dirname, "../styles/chat.part6.css"),
       "utf8",
     );
-    expect(ruleBody(aside, "\n.aside {")).not.toMatch(
-      /width var\(--motion-pane\)/,
+    expect(aside).toMatch(
+      /\.workbench--aside-motion\s+\.aside:not\(\.is-resizing\):not\(\.aside--overlay\)\s*\{[^}]*width var\(--motion-pane\)[^,]*,[^}]*min-width var\(--motion-pane\)[^,]*,[^}]*max-width var\(--motion-pane\)[^,]*,[^}]*flex-basis var\(--motion-pane\)/s,
     );
     expect(aside).toMatch(
       /\.aside\.aside--overlay[^{]*\{[^}]*transform var\(--motion-pane\)/,
@@ -165,20 +165,34 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(bt).not.toMatch(/^\s*height\s*:\s*0\s*!important/m);
   });
 
-  it("starts sidebar width motion only outside overlay and phone layouts", () => {
+  it("reveals the terminal content without interpolating the chat layout", () => {
+    const terminal = readFileSync(
+      resolve(__dirname, "../styles/bottom-terminal.css"),
+      "utf8",
+    );
+    expect(terminal).toMatch(
+      /\.bt\[data-open="true"\]:not\(\.is-resizing\)[\s\S]*?:is\(\.bt__chrome, \.bt__body\)\s*\{[^}]*animation:\s*bt-panel-in/,
+    );
+    expect(terminal).toMatch(/@keyframes bt-panel-in/);
+  });
+
+  it("starts pane width motion only outside overlay and phone layouts", () => {
     const hook = readFileSync(
       resolve(__dirname, "../hooks/usePaneSplitMotion.ts"),
       "utf8",
     );
     expect(hook).toContain("sidebarChanged && !opts.sidebarOverlay");
+    expect(hook).toContain("asideChanged && !opts.asideOverlay");
     expect(hook).toContain("!opts.phoneLayout");
-    expect(hook).toContain("width: sidebarWidthChanged");
+    expect(hook).toContain("width: sidebarWidthChanged || asideWidthChanged");
     expect(hook).toContain("sidebar: sidebarWidthChanged");
+    expect(hook).toContain("aside: asideWidthChanged");
     expect(hook).toContain("asideOverlayModeChanged");
     expect(hook).toContain("asideOverlayRef.current || asideOverlay");
     expect(hook).toContain("cover: coverChanged");
-    expect(hook).toContain("!finishOnSidebarWidth");
-    expect(hook).toContain("!finishOnAsideWidth");
+    expect(hook).toContain('pendingWidthPanes.add("sidebar")');
+    expect(hook).toContain('pendingWidthPanes.add("aside")');
+    expect(hook).toContain("pendingWidthPanes.delete(pane)");
   });
 
   it("mac sidebar seam is not a 1px layout border on vibrancy", () => {

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -182,12 +182,13 @@ describe("desktop hidden CSS must not force width 0", () => {
       "utf8",
     );
     expect(hook).toContain("sidebarChanged && !opts.sidebarOverlay");
-    expect(hook).toContain("asideChanged && !opts.asideOverlay");
+    expect(hook).toContain("asideChanged && opts.asideInFlow");
+    expect(hook).toContain("asideInFlowRef.current");
     expect(hook).toContain("!opts.phoneLayout");
     expect(hook).toContain("width: sidebarWidthChanged || asideWidthChanged");
     expect(hook).toContain("sidebar: sidebarWidthChanged");
     expect(hook).toContain("aside: asideWidthChanged");
-    expect(hook).toContain("asideOverlayModeChanged");
+    expect(hook).toContain("asideOverlayMotionChanged");
     expect(hook).toContain("asideOverlayRef.current || asideOverlay");
     expect(hook).toContain("cover: coverChanged");
     expect(hook).toContain('pendingWidthPanes.add("sidebar")');

--- a/src/styles/bottom-terminal.css
+++ b/src/styles/bottom-terminal.css
@@ -25,6 +25,22 @@
   border-top-color: var(--border-subtle);
 }
 
+.bt[data-open="true"]:not(.is-resizing)
+  :is(.bt__chrome, .bt__body) {
+  animation: bt-panel-in var(--motion-normal) var(--motion-pane-ease) both;
+}
+
+@keyframes bt-panel-in {
+  from {
+    opacity: 0;
+    translate: 0 10px;
+  }
+  to {
+    opacity: 1;
+    translate: 0;
+  }
+}
+
 .bt.is-resizing {
   transition: none;
 }

--- a/src/styles/chat.part6.css
+++ b/src/styles/chat.part6.css
@@ -586,6 +586,16 @@
   transition: none;
 }
 
+.workbench--aside-motion
+  .aside:not(.is-resizing):not(.aside--overlay) {
+  transition:
+    width var(--motion-pane) var(--motion-pane-ease),
+    min-width var(--motion-pane) var(--motion-pane-ease),
+    max-width var(--motion-pane) var(--motion-pane-ease),
+    flex-basis var(--motion-pane) var(--motion-pane-ease),
+    border-color var(--motion-pane) ease;
+}
+
 .aside.aside--overlay {
   position: absolute;
   top: var(--titlebar-height, 40px);


### PR DESCRIPTION
## 背景

计划/资源侧面板与底部终端出现时过于突兀，需要与现有桌面分栏动效保持一致，同时避免恢复会让长对话频繁 reflow 的外层高度动画。

## 改动

- 普通桌面、非 overlay、非 phone 的右侧面板复用分栏宽度插值动效。
- 面板变化期间持有原生 WebView 遮罩；左右面板同时变化时等待两个 width transitionend。
- 明确区分 in-flow、overlay 与 side-expanded；展开覆盖主区时不会误启用或残留右栏动效/遮罩。
- 底部终端外层高度一次到位，仅让 chrome/body 以 opacity + translate 入场。
- 保留 timeout、快速反向切换与 reduced-motion 路径。

## 验证

- pnpm exec vitest run --reporter=dot：501 个测试文件、6562 个测试通过。
- pnpm lint：通过。
- pnpm typecheck：通过。
- pnpm build:ui：通过；仅有既有 Vite chunk/dynamic import 警告。
- git diff --check origin/main...HEAD：通过。
- 用户已在整合分支完成实际界面测试。
- 独立只读终审：PASS。

## 范围

本 PR 不包含浅色壁纸可读性、macOS 交通灯避让或侧栏项目高度改动。