### PR TITLE
修复展开侧面板与 macOS 交通灯重叠

### DIFF
--- a/src/lib/window-config.test.ts
+++ b/src/lib/window-config.test.ts
@@ -10,6 +10,10 @@ const CONF_PATH = resolve(TAURI_DIR, "tauri.conf.json");
 const MAC_PATH = resolve(TAURI_DIR, "tauri.macos.conf.json");
 const WIN_PATH = resolve(TAURI_DIR, "tauri.windows.conf.json");
 const LINUX_PATH = resolve(TAURI_DIR, "tauri.linux.conf.json");
+const SIDE_WORKBENCH_CSS_PATH = resolve(
+  __dirname,
+  "../styles/side-workbench.css",
+);
 
 /**
  * Read a source file for text assertions, normalized to LF.
@@ -48,6 +52,13 @@ describe("window chrome", () => {
     expect(main.transparent).toBe(true);
     expect(main.decorations).toBe(true);
     expect(conf.app.macOSPrivateApi).toBe(true);
+  });
+
+  it("keeps expanded side-workbench tabs clear of mac traffic lights", () => {
+    const css = readSource(SIDE_WORKBENCH_CSS_PATH);
+    expect(css).toMatch(
+      /\.platform-mac\s+\.workbench--side-expanded:has\(\s*>\s*\.sidebar:is\(\.sidebar--hidden,\s*\.sidebar--overlay\)\s*\)\s+\.aside\s+\.sw-chrome\s*\{[^}]*padding-left:\s*var\(--titlebar-safe-left,\s*96px\)/s,
+    );
   });
 
   it("comfort min stays 900; Host caps OS min to half the work area", () => {

--- a/src/styles/side-workbench.css
+++ b/src/styles/side-workbench.css
@@ -141,6 +141,16 @@ html[data-wallpaper="1"].platform-mac[data-theme="light"]
   -webkit-backdrop-filter: none !important;
 }
 
+/* Expanded pane starts at x=0 when the sidebar is hidden/overlayed. */
+.platform-mac
+  .workbench--side-expanded:has(
+    > .sidebar:is(.sidebar--hidden, .sidebar--overlay)
+  )
+  .aside
+  .sw-chrome {
+  padding-left: var(--titlebar-safe-left, 96px);
+}
+
 /* Content shell under chrome — solid fill; terminal keeps its own veil layer */
 .workbench--side-expanded .aside .rp.sw,
 .workbench--side-expanded .aside .sw__content,
@@ -2053,4 +2063,3 @@ html[data-theme="light"] .sw-terminal--pty {
   align-self: flex-start;
   margin-top: 4px;
 }
-


### PR DESCRIPTION
## 背景

在 macOS 上，当左侧栏隐藏或以 overlay 展示时，展开后的计划/资源 SideWorkbench 会从窗口左边缘开始，共享顶部标签栏与红黄绿交通灯重叠。

## 改动

- 复用已有 `--titlebar-safe-left` 安全区变量。
- 仅在 macOS、SideWorkbench 展开且左侧栏为 hidden/overlay 时，为共享 `.sw-chrome` 增加左侧安全内边距。
- 修复作用于所有 SideWorkbench 标签，不限定计划内容。
- 正常占位侧栏、未展开状态以及 Windows/Linux 保持原样。
- 增加 CSS 守卫测试，锁定选择器与安全区变量。

## 验证

- pnpm exec vitest run --reporter=dot：501 个测试文件、6556 个测试通过。
- pnpm lint：通过。
- pnpm typecheck：通过。
- pnpm build:ui：通过；仅有既有 Vite chunk/dynamic import 警告。
- git diff --check origin/main...HEAD：通过。
- 用户已在整合分支完成实际界面测试。
- 独立只读审查：PASS。

## 范围

本 PR 不包含计划/终端动效、浅色壁纸可读性或侧栏项目高度改动。