### PR TITLE
修复主仓 CI 基线检查

### DIFF
--- a/src-tauri/src/official_aux.rs
+++ b/src-tauri/src/official_aux.rs
@@ -2421,10 +2421,8 @@ A UI screenshot.
         assert!(js.contains("x_keyword_search"));
         assert!(js.contains("image_gen"));
         assert!(js.contains("official-aux"));
-        let dir = std::env::temp_dir().join(format!(
-            "grok-official-aux-script-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("grok-official-aux-script-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).expect("temp home");
         let path = write_official_aux_mcp_script(&dir).expect("write script");

--- a/src/styles/sidebar.part4.css
+++ b/src/styles/sidebar.part4.css
@@ -990,20 +990,3 @@ html[data-sidebar-density="compact"] .session-row__meta {
   font-size: 12px;
   font-family: var(--font-mono, ui-monospace, monospace);
 }
-
-/* Multi-account manager modal */
-.account-mgr__hint {
-  margin: 0 0 12px;
-  font-size: 12.5px;
-  line-height: 1.45;
-  color: var(--text-tertiary);
-}
-
-.account-mgr__empty {
-  padding: 20px 12px;
-  text-align: center;
-  font-size: 13px;
-  color: var(--text-tertiary);
-  border-radius: 10px;
-  border: 1px dashed var(--border-subtle);
-}

--- a/src/styles/sidebar.part5.css
+++ b/src/styles/sidebar.part5.css
@@ -1,5 +1,21 @@
 /* domain CSS chunk (move-only split; selectors unchanged) */
 
+/* Multi-account manager modal */
+.account-mgr__hint {
+  margin: 0 0 12px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-tertiary);
+}
+
+.account-mgr__empty {
+  padding: 20px 12px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-tertiary);
+  border-radius: 10px;
+  border: 1px dashed var(--border-subtle);
+}
 
 .account-mgr__list {
   list-style: none;
@@ -800,4 +816,3 @@
   line-height: 1;
   color: var(--text-tertiary);
 }
-


### PR DESCRIPTION
## 背景

当前远端 main（fb843d9b）以及基于它的功能 PR 会同时命中两项基线失败：

- `cargo fmt --all -- --check` 在 `official_aux.rs` 报格式差异
- 最终代码质量门禁统计出 81 个千行文件，超过预算 80

## 改动

- 仅按 rustfmt 结果调整 `official_aux.rs` 的测试表达式，不改变语义
- 将完整的多账户管理器样式段从 `sidebar.part4.css` 原样移动到 `sidebar.part5.css`
- 保持 `part4 → part5` 的导入与选择器级联顺序，不提高门禁阈值、不压缩代码

## 验证

- `pnpm test`：501 个测试文件、6555 项测试通过
- TypeScript typecheck、ESLint、生产构建通过
- `pnpm run audit:prod`：无已知漏洞
- 依赖卫生、代码质量最终门禁、网站下载脚本自测通过
- `cargo fmt --all -- --check` 通过
- `cargo clippy --all-targets -- -D warnings` 通过
- `cargo test`：1494 项通过、1 项忽略
- `git diff --check origin/main...HEAD` 通过
- 合并前只读审查：PASS

## 范围

本 PR 只恢复主仓 CI 基线，不包含功能或 UI 行为变更。