### PR TITLE
fix(session): Windows 权限卡点击无响应、回退弹窗关不掉

### DIFF
--- a/src-tauri/src/permission.rs
+++ b/src-tauri/src/permission.rs
@@ -238,6 +238,67 @@ pub fn extract_shell_command(raw: &serde_json::Value) -> String {
     String::new()
 }
 
+fn truncate_permission_preview(s: &str) -> String {
+    s.chars().take(2000).collect()
+}
+
+fn extract_permission_input(raw: &serde_json::Value) -> String {
+    let ri = raw
+        .pointer("/toolCall/rawInput")
+        .or_else(|| raw.get("rawInput"))
+        .or_else(|| raw.get("raw_input"));
+    let Some(ri) = ri else {
+        return String::new();
+    };
+    if let Some(s) = ri.as_str() {
+        return s.trim().to_string();
+    }
+    let Some(obj) = ri.as_object() else {
+        return String::new();
+    };
+    for key in [
+        "command",
+        "cmd",
+        "target_file",
+        "file_path",
+        "path",
+        "query",
+        "url",
+        "description",
+    ] {
+        if let Some(s) = obj.get(key).and_then(|v| v.as_str()) {
+            let t = s.trim();
+            if !t.is_empty() {
+                return t.to_string();
+            }
+        }
+    }
+    String::new()
+}
+
+/// Human preview for the permission card. Never dump the ACP request JSON
+/// (`options` + `sessionId`) — that is wire, not the command the user is
+/// approving.
+pub fn permission_preview_text(raw: &serde_json::Value, title: &str) -> String {
+    let cmd = extract_shell_command(raw);
+    if !cmd.is_empty() {
+        return truncate_permission_preview(&cmd);
+    }
+    let path = extract_path_target(raw);
+    if !path.is_empty() {
+        return truncate_permission_preview(&path);
+    }
+    let input = extract_permission_input(raw);
+    if !input.is_empty() {
+        return truncate_permission_preview(&input);
+    }
+    let t = title.trim();
+    if !t.is_empty() && t != "Tool permission" {
+        return truncate_permission_preview(t);
+    }
+    String::new()
+}
+
 fn shell_has_token(cmd_lower: &str, token: &str) -> bool {
     // Word-ish match so `curl` does not hit `curly`.
     for part in cmd_lower.split(|c: char| {
@@ -1125,6 +1186,34 @@ mod tests {
             }
         });
         assert_eq!(extract_shell_command(&raw), "curl -o out.png https://x");
+    }
+
+    #[test]
+    fn permission_preview_prefers_command_not_raw_json() {
+        let raw = serde_json::json!({
+            "sessionId": "01aa",
+            "options": [
+                {"kind": "allow_once", "optionId": "allow-once"},
+                {"kind": "reject_once", "optionId": "reject-once"}
+            ],
+            "toolCall": {
+                "title": "Execute `python ./get_context.py`",
+                "rawInput": { "command": "python ./get_context.py" }
+            }
+        });
+        assert_eq!(
+            permission_preview_text(&raw, "Execute `python ./get_context.py`"),
+            "python ./get_context.py"
+        );
+        let options_only = serde_json::json!({
+            "options": [{"kind": "allow_once", "optionId": "allow-once"}],
+            "sessionId": "01aa"
+        });
+        assert_eq!(
+            permission_preview_text(&options_only, "Execute `python ./get_context.py`"),
+            "Execute `python ./get_context.py`"
+        );
+        assert!(!permission_preview_text(&options_only, "Tool permission").contains('{'));
     }
 
     #[test]

--- a/src-tauri/src/session_manager/events.rs
+++ b/src-tauri/src/session_manager/events.rs
@@ -12,7 +12,7 @@ use crate::acp_client::{
 use crate::journal_throttle::is_paragraph_break;
 use crate::permission::{
     coerce_wire_option_id_for_tool, extract_path_target, extract_shell_command, may_auto_allow,
-    may_auto_deny, resolve_reject_option_id, scope_key,
+    may_auto_deny, permission_preview_text, resolve_reject_option_id, scope_key,
 };
 use crate::session_fsm::SessionState;
 use crate::store::{self, ChatMessageStored};
@@ -344,7 +344,7 @@ impl SessionManager {
                     return;
                 }
 
-                let preview = raw.to_string();
+                let preview = permission_preview_text(&raw, &title);
                 let path_target = extract_path_target(&raw);
                 let shell_command = extract_shell_command(&raw);
                 let sk_source = if path_target.is_empty() {

--- a/src-tauri/src/session_manager/events_bg.rs
+++ b/src-tauri/src/session_manager/events_bg.rs
@@ -11,7 +11,7 @@ use crate::acp_client::{
 use crate::journal_throttle::is_paragraph_break;
 use crate::permission::{
     coerce_wire_option_id_for_tool, extract_path_target, extract_shell_command, may_auto_allow,
-    may_auto_deny, resolve_reject_option_id, scope_key,
+    may_auto_deny, permission_preview_text, resolve_reject_option_id, scope_key,
 };
 use crate::session_fsm::SessionState;
 use crate::store::{self, ChatMessageStored};
@@ -206,7 +206,7 @@ impl SessionManager {
                 options,
                 raw,
             } => {
-                let preview = raw.to_string();
+                let preview = permission_preview_text(&raw, &title);
                 let path_target = extract_path_target(&raw);
                 let shell_command = extract_shell_command(&raw);
                 let sk_source = if path_target.is_empty() {

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -938,6 +938,8 @@ export function AppWorkbench() {
     setRewindConfirm,
     rewindRestoreFiles,
     setRewindRestoreFiles,
+    rewindError,
+    setRewindError,
     rewindModalRef,
     forkConfirm,
     setForkConfirm,
@@ -8676,13 +8678,18 @@ export function AppWorkbench() {
       restoreFiles = false,
     ) => {
       if (!api.isTauri()) {
-        showToast(tr("error.needTauri"));
+        const msg = tr("error.needTauri");
+        setRewindError(msg);
+        showToast(msg);
         return;
       }
       if (!canRewindSession) {
-        showToast(tr("session.rewindBusy"));
+        const msg = tr("session.rewindBusy");
+        setRewindError(msg);
+        showToast(msg);
         return;
       }
+      setRewindError(null);
       setRewindBusy(true);
       try {
         // Prefer live connect so agent rewind can run; local truncate still works if not.
@@ -8724,12 +8731,15 @@ export function AppWorkbench() {
         setRewindTimeline(null);
         setRewindConfirm(null);
         setRewindRestoreFiles(false);
+        setRewindError(null);
         if (!result.agentOk) {
           showToast(tr("session.rewindLocalOnly"), 4200);
         }
         await refreshSessions();
       } catch (e) {
-        showToast(tr("session.rewindFailed") + ": " + String(e), 4500);
+        const msg = tr("session.rewindFailed") + ": " + String(e);
+        setRewindError(msg);
+        showToast(msg, 4500);
       } finally {
         setRewindBusy(false);
       }
@@ -8743,7 +8753,10 @@ export function AppWorkbench() {
     (sessionId: string, targetPromptIndex: number, preview?: string) => {
       setCtxMenu(null);
       // GlassModal with restore-files checkbox (default off) — not bare setAppDialog.
+      // Close the timeline first so two overlays cannot swallow the confirm click.
+      setRewindTimeline(null);
       setRewindRestoreFiles(false);
+      setRewindError(null);
       setRewindConfirm({
         sessionId,
         targetPromptIndex,
@@ -11993,7 +12006,7 @@ export function AppWorkbench() {
       decision: "allow_once" | "allow_session" | "deny",
       optionId: string,
     ) => {
-      void api
+      return api
         .sessionResolvePermission({
           rpcId: p.rpcId,
           decision,
@@ -12014,12 +12027,10 @@ export function AppWorkbench() {
             e && typeof e === "object" && "code" in e
               ? String((e as { code?: string }).code)
               : "";
-          showToast(
-            code === "UNSUPPORTED"
-              ? tr("mirror.unsupported")
-              : String(e),
-            4000,
-          );
+          const msg =
+            code === "UNSUPPORTED" ? tr("mirror.unsupported") : String(e);
+          showToast(msg, 4000);
+          throw e instanceof Error ? e : new Error(msg);
         });
     },
     [clearPendingGates, showToast, tr],
@@ -12037,7 +12048,9 @@ export function AppWorkbench() {
         p.toolName,
       ).find((b) => b.decision === "deny");
       if (!deny) return;
-      resolvePermission(p, deny.decision, deny.optionId);
+      void resolvePermission(p, deny.decision, deny.optionId).catch(() => {
+        /* toast already shown */
+      });
     },
     [resolvePermission, tr],
   );
@@ -14897,8 +14910,10 @@ export function AppWorkbench() {
         resumeRestoreConfirm={resumeRestoreConfirm}
         rewindBusy={rewindBusy}
         rewindConfirm={rewindConfirm}
+        rewindError={rewindError}
         rewindModalRef={rewindModalRef}
         rewindRestoreFiles={rewindRestoreFiles}
+        setRewindError={setRewindError}
         rewindTimeline={rewindTimeline}
         runBatchAgentsDispatch={runBatchAgentsDispatch}
         runForkSession={runForkSession}

--- a/src/app/WorkbenchComposerColumn.tsx
+++ b/src/app/WorkbenchComposerColumn.tsx
@@ -11,8 +11,12 @@ import { IconFileDiff, IconGitBranch } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import { projectDisplayName } from "@/lib/app/sidebarModels";
 import { isMirrorClient } from "@/lib/mirrorTransport";
-import { formatPermissionSummary, mapPermissionButtons } from "@/lib/permissionOptions";
-import { type CSSProperties } from "react";
+import {
+  displayPermissionPreview,
+  formatPermissionSummary,
+  mapPermissionButtons,
+} from "@/lib/permissionOptions";
+import { type CSSProperties, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { WorkbenchComposerShell } from "@/app/WorkbenchComposerShell";
 
@@ -70,6 +74,13 @@ export function WorkbenchComposerColumn(p: WorkbenchComposerColumnProps) {
     tr,
     session,
   } = p;
+  const [permBusy, setPermBusy] = useState(false);
+  const [permError, setPermError] = useState<string | null>(null);
+  const previewText = displayPermissionPreview(perm?.preview);
+  useEffect(() => {
+    setPermBusy(false);
+    setPermError(null);
+  }, [perm?.rpcId, perm?.sessionId]);
   return (() => {
             const composerNode = (
           <div
@@ -161,11 +172,16 @@ export function WorkbenchComposerColumn(p: WorkbenchComposerColumnProps) {
                   {formatPermissionSummary({
                     toolName: perm.toolName,
                     title: perm.title,
-                    command: perm.preview,
+                    command: previewText,
                   })}
                 </p>
-                {perm.preview?.trim() ? (
-                  <pre className="perm-bar__preview">{perm.preview.trim()}</pre>
+                {previewText ? (
+                  <pre className="perm-bar__preview">{previewText}</pre>
+                ) : null}
+                {permError ? (
+                  <p className="perm-bar__error" role="alert">
+                    {permError}
+                  </p>
                 ) : null}
                 <div className="perm-bar__actions" role="group">
                   {mapPermissionButtons(
@@ -188,6 +204,7 @@ export function WorkbenchComposerColumn(p: WorkbenchComposerColumnProps) {
                             ? " perm-bar__btn--deny"
                             : " perm-bar__btn--session")
                       }
+                      disabled={permBusy}
                       title={
                         btn.decision === "allow_once"
                           ? tr("perm.hintOnce")
@@ -195,9 +212,18 @@ export function WorkbenchComposerColumn(p: WorkbenchComposerColumnProps) {
                             ? tr("perm.hintSession")
                             : tr("perm.hintDeny")
                       }
-                      onClick={() =>
-                        resolvePermission(perm, btn.decision, btn.optionId)
-                      }
+                      onClick={() => {
+                        if (permBusy) return;
+                        setPermBusy(true);
+                        setPermError(null);
+                        void Promise.resolve(
+                          resolvePermission(perm, btn.decision, btn.optionId),
+                        )
+                          .catch((e: unknown) => {
+                            setPermError(String(e));
+                          })
+                          .finally(() => setPermBusy(false));
+                      }}
                     >
                       {btn.label}
                     </button>

--- a/src/app/WorkbenchMain.tsx
+++ b/src/app/WorkbenchMain.tsx
@@ -3,6 +3,7 @@
  * Chat / kanban / automations body stay with the host as children.
  */
 import type { Dispatch, MouseEvent, ReactNode, SetStateAction } from "react";
+import { createPortal } from "react-dom";
 import { Tip } from "@/components/ui/tooltip";
 import { OpenLocationButton } from "@/components/OpenLocationButton";
 import { EnvInfoButton } from "@/components/side-workbench/EnvInfoButton";
@@ -173,11 +174,19 @@ export function WorkbenchMain(props: WorkbenchMainProps) {
         </div>
       )}
 
-      {toast && (
-        <div className="app-toast" role="status">
-          {toast}
-        </div>
-      )}
+      {toast &&
+        (typeof document !== "undefined"
+          ? createPortal(
+              <div className="app-toast" role="status">
+                {toast}
+              </div>,
+              document.body,
+            )
+          : (
+              <div className="app-toast" role="status">
+                {toast}
+              </div>
+            ))}
       <div
         className={"main__top" + (phoneLayout ? " main__top--phone" : "")}
         data-tauri-drag-region={dragRegion}

--- a/src/app/WorkbenchSessionModals.tsx
+++ b/src/app/WorkbenchSessionModals.tsx
@@ -126,6 +126,8 @@ export function WorkbenchSessionModals(p: WorkbenchSessionModalsProps) {
     resumeRestoreConfirm,
     rewindBusy,
     rewindConfirm,
+    rewindError,
+    setRewindError,
     rewindModalRef,
     rewindRestoreFiles,
     rewindTimeline,
@@ -425,11 +427,13 @@ export function WorkbenchSessionModals(p: WorkbenchSessionModalsProps) {
         locale={locale}
         confirm={rewindConfirm}
         busy={rewindBusy}
+        error={typeof rewindError === "string" ? rewindError : null}
         restoreFiles={rewindRestoreFiles}
         onRestoreFilesChange={setRewindRestoreFiles}
         onClose={() => {
           setRewindConfirm(null);
           setRewindRestoreFiles(false);
+          (setRewindError as (v: string | null) => void)(null);
         }}
         onConfirm={() => {
           if (!rewindConfirm) return;

--- a/src/components/workbench-modals/RewindConfirmModal.tsx
+++ b/src/components/workbench-modals/RewindConfirmModal.tsx
@@ -6,6 +6,7 @@ export function RewindConfirmModal(props: {
   locale: Locale;
   confirm: RewindConfirmState | null;
   busy: boolean;
+  error?: string | null;
   restoreFiles: boolean;
   onRestoreFilesChange: (value: boolean) => void;
   onClose: () => void;
@@ -65,6 +66,11 @@ export function RewindConfirmModal(props: {
         <p className="rewind-confirm__hint">
           {tr("session.rewindRestoreFilesHint")}
         </p>
+        {props.error ? (
+          <p className="rewind-confirm__error" role="alert">
+            {props.error}
+          </p>
+        ) : null}
       </div>
     </GlassModal>
   );

--- a/src/hooks/useAppDialogs.ts
+++ b/src/hooks/useAppDialogs.ts
@@ -202,6 +202,7 @@ export function useAppDialogs() {
   const [rewindConfirm, setRewindConfirm] =
     useState<RewindConfirmState | null>(null);
   const [rewindRestoreFiles, setRewindRestoreFiles] = useState(false);
+  const [rewindError, setRewindError] = useState<string | null>(null);
   const rewindModalRef = useRef<HTMLDivElement>(null);
 
   // Rewind timeline dialog — focus trap + Escape.
@@ -298,6 +299,8 @@ export function useAppDialogs() {
     setRewindConfirm,
     rewindRestoreFiles,
     setRewindRestoreFiles,
+    rewindError,
+    setRewindError,
     rewindModalRef,
 
     forkConfirm,

--- a/src/lib/composerChatWidth.guard.test.ts
+++ b/src/lib/composerChatWidth.guard.test.ts
@@ -47,6 +47,10 @@ describe("composer tracks chat reading width", () => {
 
     const perm = part1.match(/(?:^|\n)\.perm-bar\s*\{[^}]*\}/);
     expect(perm?.[0]).toMatch(/max-width:\s*var\(--chat-width-max/);
+    // Floating composer wrap is pointer-events:none; the card must opt back in
+    // and stay no-drag so Windows WebView2 does not swallow Approve / Deny.
+    expect(perm?.[0]).toMatch(/pointer-events:\s*auto/);
+    expect(perm?.[0]).toMatch(/-webkit-app-region:\s*no-drag/);
 
     // Prefer the standalone .composer rule (not .composer-stack .composer).
     const composer = [...part2.matchAll(/(?:^|\n)\.composer\s*\{[^}]*\}/g)].map(

--- a/src/lib/overlayToast.guard.test.ts
+++ b/src/lib/overlayToast.guard.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Toasts must paint above GlassModal overlays, otherwise rewind / fork
+ * errors are invisible and the dialog looks stuck.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const STYLES = join(__dirname, "../styles");
+
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function block(css: string, selector: string): string {
+  const re = new RegExp(
+    `(?:^|\\n)${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\{[^}]*\\}`,
+  );
+  return css.match(re)?.[0] ?? "";
+}
+
+describe("toast vs modal overlay stacking", () => {
+  it("places app-toast above .overlay (12000)", () => {
+    const toastCss = stripComments(
+      readFileSync(join(STYLES, "settings.part5.css"), "utf8"),
+    );
+    const overlayCss = stripComments(
+      readFileSync(join(STYLES, "chat.part4.css"), "utf8"),
+    );
+    const toast = block(toastCss, ".app-toast");
+    const overlay = block(overlayCss, ".overlay");
+    expect(toast).toMatch(/z-index:\s*14000/);
+    expect(overlay).toMatch(/z-index:\s*12000/);
+  });
+});

--- a/src/lib/permissionOptions.test.ts
+++ b/src/lib/permissionOptions.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  displayPermissionPreview,
   fallbackSessionOptionId,
   formatPermissionSummary,
   mapPermissionButtons,
+  normalizePermissionOptions,
   permissionDecisionHint,
 } from "./permissionOptions";
 
@@ -108,6 +110,24 @@ describe("mapPermissionButtons (shipped)", () => {
     expect(buttons[1]!.decision).toBe("allow_session");
     expect(buttons[1]!.optionId).toBe("allow-once");
   });
+
+  it("unwraps ACP params blobs that nest the option list", () => {
+    const wrapped = {
+      options: [
+        { optionId: "allow-once", kind: "allow_once" },
+        { optionId: "reject-once", kind: "reject_once" },
+      ],
+      sessionId: "01aa",
+    };
+    expect(normalizePermissionOptions(wrapped)).toHaveLength(2);
+    const buttons = mapPermissionButtons(
+      wrapped,
+      undefined,
+      "run_terminal_command",
+    );
+    expect(buttons[0]!.optionId).toBe("allow-once");
+    expect(buttons[2]!.optionId).toBe("reject-once");
+  });
 });
 
 describe("fallbackSessionOptionId", () => {
@@ -132,6 +152,22 @@ describe("formatPermissionSummary", () => {
         command: "rm -rf /tmp/foo",
       }),
     ).toBe("bash: rm -rf /tmp/foo");
+  });
+
+  it("does not treat ACP permission JSON dumps as the command", () => {
+    const dump =
+      '{"options":[{"kind":"allow_once","optionId":"allow-once"},{"kind":"reject_once","optionId":"reject-once"}],"sessionId":"01aa"}';
+    expect(
+      formatPermissionSummary({
+        toolName: "run_terminal_command",
+        title: "Execute `python ./get_context.py`",
+        command: dump,
+      }),
+    ).toBe("run_terminal_command");
+    expect(displayPermissionPreview(dump)).toBe("");
+    expect(displayPermissionPreview("python ./get_context.py")).toBe(
+      "python ./get_context.py",
+    );
   });
 
   it("falls back to path", () => {

--- a/src/lib/permissionOptions.ts
+++ b/src/lib/permissionOptions.ts
@@ -9,6 +9,37 @@ export interface AcpPermissionOption {
   kind?: string;
 }
 
+/** True when `preview` is the ACP request blob, not a command/path. */
+export function isRawPermissionDump(text: string): boolean {
+  const t = text.trim();
+  if (!t.startsWith("{")) return false;
+  return (
+    t.includes('"options"') ||
+    t.includes('"sessionId"') ||
+    t.includes('"toolCall"')
+  );
+}
+
+/** Strip ACP JSON dumps so the permission bar shows a command, not wire. */
+export function displayPermissionPreview(
+  preview?: string | null,
+): string {
+  const t = (preview || "").trim();
+  if (!t || isRawPermissionDump(t)) return "";
+  return t;
+}
+
+export function normalizePermissionOptions(
+  options: unknown,
+): AcpPermissionOption[] {
+  if (Array.isArray(options)) return options as AcpPermissionOption[];
+  if (options && typeof options === "object") {
+    const inner = (options as { options?: unknown }).options;
+    if (Array.isArray(inner)) return inner as AcpPermissionOption[];
+  }
+  return [];
+}
+
 /** Human-readable summary for the permission bar header / aria. */
 export function formatPermissionSummary(input: {
   toolName?: string | null;
@@ -18,7 +49,7 @@ export function formatPermissionSummary(input: {
 }): string {
   const tool = (input.toolName || input.title || "").trim();
   const path = (input.path || "").trim();
-  const command = (input.command || "").trim();
+  const command = displayPermissionPreview(input.command);
   if (command) {
     const short =
       command.length > 96 ? `${command.slice(0, 96)}…` : command;
@@ -121,9 +152,7 @@ export function mapPermissionButtons(
   /** Real tool name when options list is empty (#542 / #544). */
   toolName?: string | null,
 ): MappedPermButton[] {
-  const arr: AcpPermissionOption[] = Array.isArray(options)
-    ? (options as AcpPermissionOption[])
-    : [];
+  const arr: AcpPermissionOption[] = normalizePermissionOptions(options);
 
   const find = (pred: (o: AcpPermissionOption) => boolean) => arr.find(pred);
 

--- a/src/styles/chat.part1.css
+++ b/src/styles/chat.part1.css
@@ -202,6 +202,8 @@
  */
 .perm-bar {
   pointer-events: auto;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
   width: 100%;
   max-width: var(--chat-width-max, 800px);
   margin: 0 auto;
@@ -280,6 +282,9 @@
 }
 
 .perm-bar__actions {
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
@@ -287,6 +292,9 @@
 }
 
 .perm-bar__btn {
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
   appearance: none;
   border: 1px solid var(--border-subtle);
   background: transparent;
@@ -306,6 +314,18 @@
 .perm-bar__btn:hover {
   background: var(--bg-hover);
   border-color: var(--border-strong);
+}
+
+.perm-bar__btn:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.perm-bar__error {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--danger);
 }
 
 .perm-bar__btn--allow {

--- a/src/styles/chat.part4.css
+++ b/src/styles/chat.part4.css
@@ -790,6 +790,9 @@
   margin-top: auto;
   padding-top: var(--space-3, 12px);
   border-top: 1px solid color-mix(in srgb, var(--glass-border) 70%, transparent);
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
 }
 
 /* Body status lines (loading / error / empty) */

--- a/src/styles/modals.part2.css
+++ b/src/styles/modals.part2.css
@@ -631,6 +631,13 @@
   flex-shrink: 0;
 }
 
+.rewind-confirm__error {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--danger);
+}
+
 .export-md-options {
   display: flex;
   flex-direction: column;

--- a/src/styles/settings.part5.css
+++ b/src/styles/settings.part5.css
@@ -349,11 +349,12 @@
 }
 
 .app-toast {
-  position: absolute;
+  position: fixed;
   top: 56px;
   left: 50%;
   transform: translateX(-50%) translateZ(0);
-  z-index: 60;
+  /* Above GlassModal .overlay (12000) so rewind/fork errors are visible. */
+  z-index: 14000;
   max-width: min(420px, 90%);
   padding: 8px 14px;
   border-radius: var(--menu-radius, 12px);

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -227,6 +227,9 @@ select,
 [contenteditable="true"],
 .composer-wrap,
 .composer,
+.perm-bar,
+.overlay,
+.modal,
 .lobe-chat,
 .chat-surface {
   -webkit-app-region: no-drag;


### PR DESCRIPTION
Closes #878
Closes #879

## 问题

社区 Windows 反馈（微信「意念合一」）：

1. **权限卡**「允许一次 / 会话内允许 / 拒绝」点了没反应，预览是 ACP JSON。
2. **回退对话**确认窗点「回退」后不关，错误 toast 被挡在遮罩下面。

## 修复

- Host 权限预览改为命令 / 路径 / 标题，不再 dump 请求信封。
- 权限卡与弹窗按钮显式 `pointer-events: auto` + `app-region: no-drag`。
- 权限按钮忙态 + 卡片内错误。
- Toast portal 到 `document.body`，z-index 高于 GlassModal overlay。
- 回退失败在弹窗内显示错误；打开确认时关掉时间线 overlay。

## 验证

- `pnpm exec vitest run src/lib/permissionOptions.test.ts src/lib/composerChatWidth.guard.test.ts src/lib/overlayToast.guard.test.ts`
- `cargo test permission_preview_prefers_command`
- `pnpm exec tsc -b`

未能在真实 Windows WebView2 上点测。