### PR TITLE
fix(chat): 长会话滚动缩小 overscan，避免卡死

### DIFF
--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -342,6 +342,7 @@ export function useChatMessageVirtualizer(
       overscanPx: resolveChatOverscanPx({
         viewportHeight: el.clientHeight,
         pinToBottom: pin,
+        rowCount: count,
         scale: resolveStreamOverscanScale(
           typeof document !== "undefined" &&
             document.documentElement.dataset.streamPerf === "1",

--- a/src/lib/chatVirtualList.test.ts
+++ b/src/lib/chatVirtualList.test.ts
@@ -218,6 +218,33 @@ describe("resolveChatOverscanPx", () => {
     const browseFull = resolveChatOverscanPx({ viewportHeight: vh });
     expect(browse).toBeLessThan(browseFull);
   });
+
+  it("shrinks browse overscan on long transcripts so scroll stays windowed (#881)", () => {
+    const vh = 900;
+    const short = resolveChatOverscanPx({ viewportHeight: vh, rowCount: 12 });
+    const long = resolveChatOverscanPx({ viewportHeight: vh, rowCount: 180 });
+    const veryLong = resolveChatOverscanPx({
+      viewportHeight: vh,
+      rowCount: 400,
+    });
+    expect(long).toBeLessThan(short);
+    expect(veryLong).toBeLessThan(long);
+    expect(veryLong).toBeGreaterThanOrEqual(900);
+  });
+
+  it("does not shrink pin overscan for long transcripts", () => {
+    const vh = 900;
+    const pin = resolveChatOverscanPx({
+      viewportHeight: vh,
+      pinToBottom: true,
+    });
+    const pinLong = resolveChatOverscanPx({
+      viewportHeight: vh,
+      pinToBottom: true,
+      rowCount: 400,
+    });
+    expect(pinLong).toBe(pin);
+  });
 });
 
 describe("applyForceIndices", () => {

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -206,6 +206,8 @@ export function resolveChatOverscanPx(input: {
    * fewer offscreen markdown rows).
    */
   scale?: number;
+  /** Transcript row count. Long chats shrink browse overscan (#881). */
+  rowCount?: number;
 }): number {
   if (input.overscanPx != null && Number.isFinite(input.overscanPx)) {
     return Math.max(0, input.overscanPx);
@@ -236,10 +238,14 @@ export function resolveChatOverscanPx(input: {
   // Pin window must not shrink under stream-perf. Scaling it down mid-turn
   // then restoring at ready jumps start by a few rows — one tail flash.
   if (input.pinToBottom) return px;
-  const scale =
+  let scale =
     input.scale != null && Number.isFinite(input.scale)
       ? Math.min(1, Math.max(0.35, input.scale))
       : 1;
+  const rows = input.rowCount ?? 0;
+  if (rows >= 80) {
+    scale *= rows >= 240 ? 0.42 : rows >= 140 ? 0.55 : 0.72;
+  }
   return Math.round(px * scale);
 }
 


### PR DESCRIPTION
Closes #881

长会话上下滚动会卡死：浏览历史时 overscan 下限仍是 4800px，一甩就挂太多 markdown。

浏览窗口按行数缩小 overscan（≥80 / ≥140 / ≥240）；钉在底部的窗口不变，避免流式尾巴闪一下。