### PR TITLE
优化底部终端的分隔与玻璃层次

### DIFF
--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -173,9 +173,36 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(terminal).toMatch(
       /\.bt\[data-open="true"\]:not\(\.is-resizing\)[\s\S]*?:is\(\.bt__chrome, \.bt__body\)\s*\{[^}]*animation:\s*bt-panel-in/,
     );
-    expect(terminal).toMatch(/@keyframes bt-panel-in/);
+    expect(terminal).toMatch(
+      /@keyframes bt-panel-in\s*\{\s*from\s*\{\s*opacity:\s*0;\s*translate:\s*0 6px;\s*\}\s*to\s*\{\s*opacity:\s*1;\s*translate:\s*0;\s*\}\s*\}/s,
+    );
     expect(terminal).toMatch(
       /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.bt\[data-open="true"\]:not\(\.is-resizing\)[\s\S]*?animation:\s*none/,
+    );
+  });
+
+  it("keeps the bottom terminal separator and surfaces theme-native", () => {
+    const terminal = readFileSync(
+      resolve(__dirname, "../styles/bottom-terminal.css"),
+      "utf8",
+    );
+    expect(terminal).toMatch(
+      /\.bt__resize::after\s*\{[^}]*height:\s*1px;[^}]*background:\s*var\(--border-subtle\)/s,
+    );
+    expect(terminal).toMatch(
+      /\.bt__resize:hover::after,\s*\.bt\.is-resizing \.bt__resize::after\s*\{[^}]*background:\s*var\(--border-focus\)/s,
+    );
+    expect(ruleBody(terminal, "\n.bt__chrome {")).toMatch(
+      /background:\s*color-mix\([^;]*var\(--bg-card\)[^;]*var\(--bg-main\)/s,
+    );
+    expect(ruleBody(terminal, "\n.bt__body {")).toMatch(
+      /background:\s*var\(--bg-main\)/,
+    );
+    expect(terminal).toMatch(
+      /html\[data-wallpaper="1"\] \.bt\s*\{[^}]*var\(--wallpaper-theme-mix-main\)[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-settings-blur, 14px\)\)/s,
+    );
+    expect(terminal).not.toMatch(
+      /(?:background|border(?:-color)?):\s*(?:#000(?:000)?\b|black\b)/i,
     );
   });
 

--- a/src/styles/bottom-terminal.css
+++ b/src/styles/bottom-terminal.css
@@ -13,16 +13,10 @@
   min-width: 0;
   overflow: hidden;
   background: var(--bg-main);
-  border-top: 1px solid transparent;
-  transition: border-color var(--motion-pane) ease;
 }
 
 .bt[data-open="false"] {
   pointer-events: none;
-}
-
-.bt[data-open="true"] {
-  border-top-color: var(--border-subtle);
 }
 
 .bt[data-open="true"]:not(.is-resizing)
@@ -33,7 +27,7 @@
 @keyframes bt-panel-in {
   from {
     opacity: 0;
-    translate: 0 10px;
+    translate: 0 6px;
   }
   to {
     opacity: 1;
@@ -54,20 +48,31 @@
 
 .bt__resize {
   flex-shrink: 0;
-  height: 5px;
-  margin-top: -2px;
+  height: 7px;
+  margin-top: -3px;
   cursor: ns-resize;
   touch-action: none;
   position: relative;
   z-index: 2;
 }
 
-.bt__resize:hover,
-.bt__resize:active {
-  background: color-mix(in srgb, var(--text-secondary) 28%, transparent);
+.bt__resize::after {
+  content: "";
+  position: absolute;
+  inset: 3px 0 auto;
+  height: 1px;
+  background: var(--border-subtle);
+  transition: background var(--motion-fast) ease;
+  pointer-events: none;
+}
+
+.bt__resize:hover::after,
+.bt.is-resizing .bt__resize::after {
+  background: var(--border-focus);
 }
 
 .bt__chrome {
+  background: color-mix(in srgb, var(--bg-card) 72%, var(--bg-main));
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -99,6 +104,27 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  background: var(--bg-main);
+}
+
+html[data-wallpaper="1"] .bt {
+  background: color-mix(
+    in srgb,
+    var(--bg-main) var(--wallpaper-theme-mix-main),
+    transparent
+  );
+  backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+}
+
+html[data-wallpaper="1"] .bt__chrome {
+  background: color-mix(in srgb, var(--bg-card) 72%, transparent);
+}
+
+html[data-wallpaper="1"] .bt__body {
+  background: transparent;
 }
 
 .bt__persist-host {


### PR DESCRIPTION
## 背景

主仓已合入计划侧栏与底部终端的进入动效，但底部终端仍使用整块悬停底色作为拖拽提示，分隔线、终端顶栏与壁纸玻璃层次不够统一。

## 改动

- 使用独立 1px 分隔线呈现终端拖拽边界，悬停和拖拽时切换到现有焦点色。
- 终端顶栏与正文复用主题表面变量，不再使用固定黑色或额外实色。
- 壁纸模式下复用现有主题混合比例、模糊与饱和度变量。
- 将内容入场位移从 10px 收敛到 6px，并保留主仓现有的 `prefers-reduced-motion` 处理。
- 增加守卫测试，约束分隔线、主题表面与壁纸玻璃实现。

## 验证

- `pnpm exec vitest run src/lib/paneSplitMotion.test.ts src/lib/bottomTerminal.test.ts --reporter=dot`：2 个测试文件、38 项测试通过。
- `pnpm exec eslint src/lib/paneSplitMotion.test.ts`：通过。
- `pnpm typecheck`：通过。
- `git diff --check origin/main...HEAD`：通过。

## 范围

本 PR 仅调整底部终端的分隔、表面和既有入场动效参数，不包含计划面板、侧栏或设置页面改动。
