### PR TITLE
修复计划面板的壁纸玻璃效果

### DIFF
--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -3,10 +3,14 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const css = readFileSync(join(__dirname, "../styles/skins.css"), "utf8");
-const sideWorkbenchCss = readFileSync(
-  join(__dirname, "../styles/side-workbench.part1.css"),
-  "utf8",
-);
+const sideWorkbenchCss = ["part1", "part2"]
+  .map((part) =>
+    readFileSync(
+      join(__dirname, `../styles/side-workbench.${part}.css`),
+      "utf8",
+    ),
+  )
+  .join("\n");
 
 describe("wallpaper theme contrast CSS", () => {
   it("maps light wallpaper to its own white veil and pane curves", () => {

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -3,6 +3,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const css = readFileSync(join(__dirname, "../styles/skins.css"), "utf8");
+const sideWorkbenchCss = readFileSync(
+  join(__dirname, "../styles/side-workbench.part1.css"),
+  "utf8",
+);
 
 describe("wallpaper theme contrast CSS", () => {
   it("maps light wallpaper to its own white veil and pane curves", () => {
@@ -102,6 +106,24 @@ describe("wallpaper theme contrast CSS", () => {
   it("does not paint a light fade beneath the floating wallpaper composer", () => {
     expect(css).toMatch(
       /html\[data-theme="light"\]\[data-wallpaper="1"\] \.composer-wrap--float\s*\{[^}]*background:\s*transparent/s,
+    );
+  });
+
+  it("keeps an expanded wallpaper side pane frosted without exposing chat", () => {
+    expect(css).toMatch(
+      /html\[data-wallpaper="1"\]\s+:is\(\.sidebar, \.aside\)\s*\{[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-sidebar-blur, 22px\)\)/s,
+    );
+    expect(css).toMatch(
+      /html\[data-stream-perf="1"\]\[data-wallpaper="1"\] \.aside,/,
+    );
+    expect(sideWorkbenchCss).toMatch(
+      /\.workbench--side-expanded \.main\s*\{[^}]*visibility:\s*hidden/s,
+    );
+    expect(sideWorkbenchCss).toMatch(
+      /html:not\(\[data-wallpaper="1"\]\)\s+\.workbench--side-expanded\s+\.aside:not\(\.aside--hidden\)\s*\{[^}]*background:\s*var\(--bg-aside\)/s,
+    );
+    expect(sideWorkbenchCss).toMatch(
+      /html\[data-wallpaper="1"\]\s+\.workbench--side-expanded\s+\.aside\s+:is\([^)]*\.rp-chrome[^)]*\.sw__empty[^)]*\)\s*\{[^}]*background:\s*transparent/s,
     );
   });
 });

--- a/src/styles/side-workbench.part1.css
+++ b/src/styles/side-workbench.part1.css
@@ -10,6 +10,7 @@
   /* Keep size & subtree; only block interaction while covered by aside */
   pointer-events: none;
   user-select: none;
+  visibility: hidden;
 }
 
 /*
@@ -105,17 +106,8 @@ body > .composer-wrap.composer-wrap--side-dock {
   flex-shrink: 0;
 }
 
-/*
- * Expanded free area: theme-solid surfaces only.
- * Wallpaper mode uses color-mix(... transparent) !important on .aside — beat it
- * so the expanded side (chrome + body) never shows custom wallpaper through.
- */
-.workbench--side-expanded .aside:not(.aside--hidden),
-html[data-wallpaper="1"] .workbench--side-expanded .aside:not(.aside--hidden),
-html[data-wallpaper="1"][data-wallpaper-clear="1"]
-  .workbench--side-expanded
-  .aside:not(.aside--hidden),
-html[data-wallpaper="1"].platform-mac[data-theme="light"]
+/* Without a wallpaper, expanded panes keep the normal solid theme surface. */
+html:not([data-wallpaper="1"])
   .workbench--side-expanded
   .aside:not(.aside--hidden) {
   background: var(--bg-aside) !important;
@@ -124,13 +116,22 @@ html[data-wallpaper="1"].platform-mac[data-theme="light"]
   box-shadow: none !important;
 }
 
-.workbench--side-expanded .aside .aside__inner {
+html:not([data-wallpaper="1"])
+  .workbench--side-expanded
+  .aside
+  .aside__inner {
   background: var(--bg-aside) !important;
 }
 
 /* Top tab strip: solid chrome (not glass mix over wallpaper) */
-.workbench--side-expanded .aside .rp-chrome,
-.workbench--side-expanded .aside .rp-chrome.sw-chrome {
+html:not([data-wallpaper="1"])
+  .workbench--side-expanded
+  .aside
+  .rp-chrome,
+html:not([data-wallpaper="1"])
+  .workbench--side-expanded
+  .aside
+  .rp-chrome.sw-chrome {
   background: var(--bg-card) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
@@ -147,13 +148,33 @@ html[data-wallpaper="1"].platform-mac[data-theme="light"]
 }
 
 /* Content shell under chrome — solid fill; terminal keeps its own veil layer */
-.workbench--side-expanded .aside .rp.sw,
-.workbench--side-expanded .aside .sw__content,
-.workbench--side-expanded .aside .sw__empty,
-.workbench--side-expanded .aside .sw__persist-host,
-.workbench--side-expanded .aside .sw-browser,
-.workbench--side-expanded .aside .sw-browser__host {
+html:not([data-wallpaper="1"])
+  .workbench--side-expanded
+  .aside
+  :is(
+    .rp.sw,
+    .sw__content,
+    .sw__empty,
+    .sw__persist-host,
+    .sw-browser,
+    .sw-browser__host
+  ) {
   background: var(--bg-aside) !important;
+}
+
+/* The outer aside owns wallpaper frost; common Plan/chrome shells stay clear. */
+html[data-wallpaper="1"]
+  .workbench--side-expanded
+  .aside
+  :is(
+    .aside__inner,
+    .rp-chrome,
+    .rp.sw,
+    .sw__content,
+    .sw__empty,
+    .sw__persist-host
+  ) {
+  background: transparent !important;
 }
 
 /* Files still use card surfaces; ensure no transparent hole under expand */
@@ -988,4 +1009,3 @@ html[data-theme="light"] .sw-terminal--pty {
 .sw-terminal__xterm .xterm-scrollable-element > .scrollbar > .slider {
   box-shadow: none !important;
 }
-

--- a/src/styles/side-workbench.part1.css
+++ b/src/styles/side-workbench.part1.css
@@ -162,21 +162,6 @@ html:not([data-wallpaper="1"])
   background: var(--bg-aside) !important;
 }
 
-/* The outer aside owns wallpaper frost; common Plan/chrome shells stay clear. */
-html[data-wallpaper="1"]
-  .workbench--side-expanded
-  .aside
-  :is(
-    .aside__inner,
-    .rp-chrome,
-    .rp.sw,
-    .sw__content,
-    .sw__empty,
-    .sw__persist-host
-  ) {
-  background: transparent !important;
-}
-
 /* Files still use card surfaces; ensure no transparent hole under expand */
 .workbench--side-expanded .aside .sw__files-host,
 .workbench--side-expanded .aside .sw-files {

--- a/src/styles/side-workbench.part2.css
+++ b/src/styles/side-workbench.part2.css
@@ -1,3 +1,18 @@
+/* The outer aside owns wallpaper frost; common Plan/chrome shells stay clear. */
+html[data-wallpaper="1"]
+  .workbench--side-expanded
+  .aside
+  :is(
+    .aside__inner,
+    .rp-chrome,
+    .rp.sw,
+    .sw__content,
+    .sw__empty,
+    .sw__persist-host
+  ) {
+  background: transparent !important;
+}
+
 .sw-terminal__xterm .xterm-scrollable-element > .scrollbar.horizontal {
   display: none !important;
   height: 0 !important;
@@ -611,4 +626,3 @@
 .sw-review-more:hover {
   text-decoration: underline;
 }
-

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -124,6 +124,9 @@ html[data-wallpaper="1"] .sidebar {
       var(--wallpaper-theme-mix-sidebar),
     transparent
   ) !important;
+}
+
+html[data-wallpaper="1"] :is(.sidebar, .aside) {
   backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px)) saturate(1.25);
   -webkit-backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px))
     saturate(1.25);
@@ -239,6 +242,7 @@ html[data-wallpaper="1"] .platform-mac .settings-page__nav {
  */
 html[data-stream-perf="1"][data-wallpaper="1"] .app-settings-stage,
 html[data-stream-perf="1"][data-wallpaper="1"] .sidebar,
+html[data-stream-perf="1"][data-wallpaper="1"] .aside,
 html[data-stream-perf="1"][data-wallpaper="1"] .settings-page__nav,
 html[data-stream-perf="1"][data-wallpaper="1"] .platform-win .settings-page__nav,
 html[data-stream-perf="1"][data-wallpaper="1"] .platform-other .settings-page__nav,

--- a/src/styles/skins.streamPerf.test.ts
+++ b/src/styles/skins.streamPerf.test.ts
@@ -12,6 +12,9 @@ describe("stream-perf wallpaper CSS", () => {
       'html[data-stream-perf="1"][data-wallpaper="1"] .sidebar',
     );
     expect(css).toContain(
+      'html[data-stream-perf="1"][data-wallpaper="1"] .aside',
+    );
+    expect(css).toContain(
       'html[data-stream-perf="1"][data-wallpaper="1"] .settings-page__nav',
     );
   });


### PR DESCRIPTION
## 背景

计划面板在壁纸模式下仍使用实色表面，展开后还可能透出主工作区内容，与左侧栏的玻璃材质不一致。

## 修改

- 让计划面板复用侧栏的壁纸模糊与性能降级规则
- 壁纸模式清除计划容器的重复实色背景，无壁纸模式保持原有表面
- 展开覆盖时隐藏主工作区绘制，避免内容穿透玻璃层
- 更新样式守卫以适配拆分后的 CSS 文件

## 验证

- Vitest：37/37 通过
- ESLint：通过
- TypeScript typecheck：通过
- UI build：通过（仅保留既有 chunk 警告）
- git diff --check：通过

## 范围

本 PR 只处理计划面板的壁纸玻璃材质；空态居中及计划面板后续动效不在本 PR 内。
