### PR TITLE
增强壁纸下智能体看板可读性

### DIFF
--- a/src/lib/kanbanBoard.test.ts
+++ b/src/lib/kanbanBoard.test.ts
@@ -325,6 +325,28 @@ describe("buildAgentKanban (shipped buildTaskBoard path)", () => {
 describe("agent kanban surface is not a todo list", () => {
   const root = join(__dirname, "..");
 
+  it("keeps wallpaper glass and contrast scoped to the agent board", () => {
+    const css = readFileSync(
+      join(root, "styles/workbench.part1b.css"),
+      "utf8",
+    );
+    expect(css).toMatch(
+      /html\[data-wallpaper="1"\]\s+\.agent-kanban-page\s+\.agent-kanban__col\s*\{[^}]*background:\s*color-mix\([^;]*var\(--bg-elevated\) 68%[^;]*transparent[^;]*\);[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-settings-blur, 14px\)\)/s,
+    );
+    expect(css).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\]\s+\.agent-kanban-page\s+\.settings-input\s*\{[^}]*background:\s*color-mix\([^;]*var\(--bg-input\) 72%[^;]*transparent/s,
+    );
+    expect(css).toMatch(
+      /html\[data-theme="dark"\]\[data-wallpaper="1"\]\s+\.agent-kanban-page\s+\.settings-input\s*\{[^}]*background:\s*color-mix\([^;]*var\(--bg-input\) 68%[^;]*transparent/s,
+    );
+    expect(css).toMatch(
+      /html\[data-wallpaper="1"\]\s+\.agent-kanban-page\s+:is\(\.agent-kanban__col-title, \.agent-kanban__col-count\)\s*\{[^}]*color:\s*var\(--text-primary\)/s,
+    );
+    expect(css).toMatch(
+      /html\[data-wallpaper="1"\]\s+\.agent-kanban-page\s+:is\([^)]*\.agent-kanban__none[^)]*\.agent-kanban__card-age[^)]*\)\s*\{[^}]*color:\s*var\(--text-secondary\)/s,
+    );
+  });
+
   it("page uses live agent columns + i18n, not a GlassModal todo list", () => {
     const src = readFileSync(
       join(root, "components/KanbanBoardPage.tsx"),

--- a/src/lib/kanbanBoard.test.ts
+++ b/src/lib/kanbanBoard.test.ts
@@ -345,6 +345,9 @@ describe("agent kanban surface is not a todo list", () => {
     expect(css).toMatch(
       /html\[data-wallpaper="1"\]\s+\.agent-kanban-page\s+:is\([^)]*\.agent-kanban__none[^)]*\.agent-kanban__card-age[^)]*\)\s*\{[^}]*color:\s*var\(--text-secondary\)/s,
     );
+    expect(css).toMatch(
+      /html\[data-theme="dark"\]\[data-wallpaper="1"\]\s+\.agent-kanban-page\s+:is\(\.auto-page__title, \.auto-page__subtitle\)\s*\{[^}]*color:\s*var\(--text-primary\)[^}]*text-shadow:/s,
+    );
   });
 
   it("page uses live agent columns + i18n, not a GlassModal todo list", () => {

--- a/src/styles/workbench.part1b.css
+++ b/src/styles/workbench.part1b.css
@@ -630,6 +630,7 @@ html[data-theme="light"][data-wallpaper="1"]
 html[data-theme="dark"][data-wallpaper="1"]
   .agent-kanban-page
   :is(.auto-page__title, .auto-page__subtitle) {
+  color: var(--text-primary);
   text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
 }
 

--- a/src/styles/workbench.part1b.css
+++ b/src/styles/workbench.part1b.css
@@ -553,6 +553,98 @@
   color: var(--text-primary);
 }
 
+/* Wallpaper trial: keep the agent board legible without changing other pages. */
+html[data-wallpaper="1"] .agent-kanban-page .agent-kanban__col {
+  background: color-mix(
+    in srgb,
+    var(--bg-elevated) 68%,
+    transparent
+  );
+  backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+  box-shadow: inset 0 0 0 0.5px color-mix(in srgb, var(--text-primary) 8%, transparent);
+}
+
+html[data-wallpaper="1"]
+  .agent-kanban-page
+  :is(.agent-kanban__col-title, .agent-kanban__col-count) {
+  color: var(--text-primary);
+}
+
+html[data-wallpaper="1"]
+  .agent-kanban-page
+  :is(
+    .agent-kanban__none,
+    .agent-kanban__card-tool,
+    .agent-kanban__card-meta,
+    .agent-kanban__card-age
+  ) {
+  color: var(--text-secondary);
+}
+
+html[data-wallpaper="1"] .agent-kanban-page .agent-kanban__views,
+html[data-wallpaper="1"]
+  .agent-kanban-page
+  .agent-kanban__filter-btn:not(.is-active) {
+  background: color-mix(in srgb, var(--bg-elevated) 68%, transparent);
+  backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+}
+
+html[data-wallpaper="1"] .agent-kanban-page .agent-kanban__views {
+  padding: 3px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+}
+
+html[data-wallpaper="1"] .agent-kanban-page .settings-input {
+  backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  .agent-kanban-page
+  .settings-input {
+  background: color-mix(in srgb, var(--bg-input) 72%, transparent);
+}
+
+html[data-theme="dark"][data-wallpaper="1"]
+  .agent-kanban-page
+  .settings-input {
+  background: color-mix(in srgb, var(--bg-input) 68%, transparent);
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  .agent-kanban-page
+  :is(.auto-page__title, .auto-page__subtitle) {
+  color: var(--wallpaper-chrome-foreground);
+  text-shadow: 0 1px 2px var(--wallpaper-chrome-shadow-color);
+}
+
+html[data-theme="dark"][data-wallpaper="1"]
+  .agent-kanban-page
+  :is(.auto-page__title, .auto-page__subtitle) {
+  text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
+}
+
+html[data-stream-perf="1"][data-wallpaper="1"]
+  .agent-kanban-page
+  :is(
+    .agent-kanban__col,
+    .agent-kanban__views,
+    .agent-kanban__filter-btn,
+    .settings-input
+  ) {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
 /* --- merged --- */
 
 .settings-agents-personas {


### PR DESCRIPTION
## 背景

智能体看板叠加自定义壁纸时，三栏容器和说明文字会被背景干扰，浅色、深色主题下都存在可读性不足。

## 修改

- 为“需要你 / 工作中 / 已完成”三栏增加轻量玻璃模糊表面
- 按主题统一标题、计数、空态及辅助文字的对比度
- 补充壁纸与深色主题样式守卫，避免后续回退

## 验证

- Vitest：42/42 通过
- ESLint：通过
- TypeScript typecheck：通过
- git diff --check：通过

## 范围

本 PR 只调整智能体看板，不包含主工作区其他暴露文字的全局优化。
