### PR TITLE
补齐深色壁纸输入框玻璃效果

### DIFF
--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -43,6 +43,15 @@ describe("wallpaper theme contrast CSS", () => {
     );
   });
 
+  it("gives dark wallpaper composers a translucent blurred surface", () => {
+    expect(css).toMatch(
+      /html\[data-theme="dark"\]\[data-wallpaper="1"\][^{]*:is\(\.composer, \.composer__context-bar\)\s*\{[^}]*background:\s*color-mix\(\s*in srgb,\s*var\(--bg-elevated\) 68%,\s*transparent\s*\)[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-settings-blur, 14px\)\)/s,
+    );
+    expect(css).toMatch(
+      /html\[data-stream-perf="1"\]\[data-wallpaper="1"\][^{]*:is\(\.composer, \.composer__context-bar\)\s*\{[^}]*backdrop-filter:\s*none !important/s,
+    );
+  });
+
   it("uses a dark edge on exposed light wallpaper chrome", () => {
     const lightRoot = css.match(
       /html\[data-theme="light"\]\[data-wallpaper="1"\]\s*\{[^}]*\}/s,

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -282,6 +282,25 @@ html[data-theme="light"][data-wallpaper="1"]
   background: var(--wallpaper-light-elevated-surface);
 }
 
+html[data-theme="dark"][data-wallpaper="1"]
+  :is(.composer, .composer__context-bar) {
+  background: color-mix(
+    in srgb,
+    var(--bg-elevated) 68%,
+    transparent
+  );
+  backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--wallpaper-settings-blur, 14px))
+    saturate(var(--glass-saturate));
+}
+
+html[data-stream-perf="1"][data-wallpaper="1"]
+  :is(.composer, .composer__context-bar) {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
 html[data-theme="light"][data-wallpaper="1"]
   .main__top
   .status-pill--action:hover {


### PR DESCRIPTION
## 背景

浅色壁纸模式的聊天输入区已经使用透明模糊表面，深色模式仍是实色背景，导致同一组件在主题切换后视觉语言不一致。

## 修改

- 为深色壁纸模式下的输入框和工作区栏补齐半透明玻璃表面
- 复用现有主题变量与模糊参数
- 在 stream-perf 模式关闭模糊，保持既有性能降级
- 增加主题样式守卫

## 验证

- Vitest：27/27 通过
- ESLint：通过
- TypeScript typecheck：通过
- git diff --check：通过

## 范围

本 PR 只补齐深色壁纸输入区材质，不调整输入框布局或交互。
