### PR TITLE
统一壁纸主页面暴露文字对比

### DIFF
--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -3,6 +3,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const css = readFileSync(join(__dirname, "../styles/skins.css"), "utf8");
+const workbenchCss = readFileSync(
+  join(__dirname, "../styles/workbench.part1b.css"),
+  "utf8",
+);
 
 describe("wallpaper theme contrast CSS", () => {
   it("maps light wallpaper to its own white veil and pane curves", () => {
@@ -97,6 +101,35 @@ describe("wallpaper theme contrast CSS", () => {
     expect(css).toMatch(
       /html\[data-wallpaper="1"\]\s+\.lobe-chat\s+\.lobe-chat-assistant-timeline\s+:is\([^{]*\.lobe-chat-plan,[^{]*\.struct-json,[^{]*\.att-card,[^{]*\.file-path-card[^)]*\)\s+svg\s*\{[^}]*filter:\s*none/s,
     );
+  });
+
+  it("extends wallpaper contrast only to exposed main-page text", () => {
+    const darkTimeline = css.match(
+      /html\[data-theme="dark"\]\[data-wallpaper="1"\] \.lobe-chat-assistant-timeline\s*\{[^}]*\}/s,
+    )?.[0];
+    expect(darkTimeline).toContain("--chat-text: var(--text-primary)");
+    expect(darkTimeline).toContain("var(--text-primary) 84%");
+    expect(darkTimeline).toContain("var(--text-primary) 72%");
+
+    const lightExposed = css.match(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\]\s+:is\(\.lobe-chat-empty, \.main__stage > \.conn-bar\)\s*\{[^}]*color:\s*var\(--wallpaper-chrome-foreground\)[^}]*text-shadow:\s*0 1px 2px var\(--wallpaper-chrome-shadow-color\)[^}]*\}/s,
+    )?.[0];
+    const darkExposed = css.match(
+      /html\[data-theme="dark"\]\[data-wallpaper="1"\]\s+:is\(\.lobe-chat-empty, \.main__stage > \.conn-bar\)\s*\{[^}]*color:\s*var\(--text-primary\)[^}]*text-shadow:\s*0 1px 2px var\(--wallpaper-foreground-shadow-color\)[^}]*\}/s,
+    )?.[0];
+    expect(lightExposed).toBeTruthy();
+    expect(darkExposed).toBeTruthy();
+    expect(workbenchCss).toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\]\s+\.auto-page\s+:is\(\.auto-page__title, \.auto-page__subtitle\)\s*\{/s,
+    );
+    expect(workbenchCss).toMatch(
+      /html\[data-theme="dark"\]\[data-wallpaper="1"\]\s+\.auto-page\s+:is\(\.auto-page__title, \.auto-page__subtitle\)\s*\{/s,
+    );
+    for (const exposed of [lightExposed, darkExposed]) {
+      expect(exposed).not.toMatch(
+        /(?:\.lobe-chat-bubble|\.composer|\.chat-code|\.att-card)/,
+      );
+    }
   });
 
   it("does not paint a light fade beneath the floating wallpaper composer", () => {

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -138,8 +138,15 @@ html[data-theme="dark"][data-wallpaper="1"] .sidebar svg {
 }
 
 html[data-theme="dark"][data-wallpaper="1"] .main__top,
-html[data-theme="dark"][data-wallpaper="1"] .composer-welcome-mark,
+html[data-theme="dark"][data-wallpaper="1"] .composer-welcome-mark {
+  text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
+}
+
 html[data-theme="dark"][data-wallpaper="1"] .lobe-chat-assistant-timeline {
+  --chat-text: var(--text-primary);
+  --chat-text-2: color-mix(in srgb, var(--text-primary) 84%, transparent);
+  --chat-text-3: color-mix(in srgb, var(--text-primary) 72%, transparent);
+  color: var(--text-primary);
   text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
 }
 
@@ -406,6 +413,44 @@ html[data-theme="light"][data-wallpaper="1"]
 
 html[data-theme="light"][data-wallpaper="1"] .composer-welcome-mark svg {
   filter: drop-shadow(0 1px 1px var(--wallpaper-chrome-shadow-color));
+}
+
+html[data-theme="light"][data-wallpaper="1"]
+  :is(.lobe-chat-empty, .main__stage > .conn-bar) {
+  color: var(--wallpaper-chrome-foreground);
+  text-shadow: 0 1px 2px var(--wallpaper-chrome-shadow-color);
+}
+
+html[data-theme="light"][data-wallpaper="1"] .lobe-chat-empty {
+  --chat-text: var(--wallpaper-chrome-foreground);
+  --chat-text-3: color-mix(
+    in srgb,
+    var(--wallpaper-chrome-foreground) 72%,
+    transparent
+  );
+}
+
+html[data-theme="light"][data-wallpaper="1"] .main__stage > .conn-bar strong {
+  color: color-mix(
+    in srgb,
+    var(--wallpaper-chrome-foreground) 84%,
+    transparent
+  );
+}
+
+html[data-theme="dark"][data-wallpaper="1"]
+  :is(.lobe-chat-empty, .main__stage > .conn-bar) {
+  color: var(--text-primary);
+  text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
+}
+
+html[data-theme="dark"][data-wallpaper="1"] .lobe-chat-empty {
+  --chat-text: var(--text-primary);
+  --chat-text-3: color-mix(in srgb, var(--text-primary) 72%, transparent);
+}
+
+html[data-theme="dark"][data-wallpaper="1"] .main__stage > .conn-bar strong {
+  color: color-mix(in srgb, var(--text-primary) 84%, transparent);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/src/styles/workbench.part1b.css
+++ b/src/styles/workbench.part1b.css
@@ -553,6 +553,20 @@
   color: var(--text-primary);
 }
 
+html[data-theme="light"][data-wallpaper="1"]
+  .auto-page
+  :is(.auto-page__title, .auto-page__subtitle) {
+  color: var(--wallpaper-chrome-foreground);
+  text-shadow: 0 1px 2px var(--wallpaper-chrome-shadow-color);
+}
+
+html[data-theme="dark"][data-wallpaper="1"]
+  .auto-page
+  :is(.auto-page__title, .auto-page__subtitle) {
+  color: var(--text-primary);
+  text-shadow: 0 1px 2px var(--wallpaper-foreground-shadow-color);
+}
+
 /* --- merged --- */
 
 .settings-agents-personas {


### PR DESCRIPTION
## 背景

主页面直接叠加在自定义壁纸上的标题、导航和辅助文字会随背景明暗丢失对比度，仅靠浅色阴影无法覆盖复杂图片。

## 修改

- 统一壁纸模式下主工作区暴露文字的前景色与暗色描边
- 同步浅色、深色主题规则，避免只修单一主题
- 删除被新规则替代的旧主题覆盖
- 增加样式守卫，防止重复引入浅色文字阴影

## 验证

- Vitest：43/43 通过
- ESLint：通过
- TypeScript typecheck：通过
- git diff --check：通过

## 范围

本 PR 处理主页面通用暴露文字，不包含智能体看板三栏的专属玻璃样式。
