### PR TITLE
对齐 macOS 原生窗口按钮与顶栏

### DIFF
--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -18,7 +18,7 @@
         "shadow": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 16, "y": 18 }
+        "trafficLightPosition": { "x": 16, "y": 22 }
       }
     ],
     "macOSPrivateApi": true

--- a/src/lib/window-config.test.ts
+++ b/src/lib/window-config.test.ts
@@ -48,7 +48,7 @@ describe("window chrome", () => {
     const main = conf.app.windows[0]!;
     expect(main.titleBarStyle).toBe("Overlay");
     expect(main.hiddenTitle).toBe(true);
-    expect(main.trafficLightPosition).toBeTruthy();
+    expect(main.trafficLightPosition).toEqual({ x: 16, y: 22 });
     expect(main.transparent).toBe(true);
     expect(main.decorations).toBe(true);
     expect(conf.app.macOSPrivateApi).toBe(true);

--- a/src/styles/sidebar.part1b.css
+++ b/src/styles/sidebar.part1b.css
@@ -1,4 +1,4 @@
-/* Match mac traffic light vertical center (~18px y + half button) */
+/* Share the 40px titlebar center line with the native mac traffic lights. */
 .chrome-btn--traffic {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
## 背景

macOS 原生红黄绿窗口按钮与应用顶栏控件不在同一水平线上，窗口顶部视觉基线不一致。

## 修改

- 调整 macOS 标题栏原生按钮坐标，使其与应用顶栏垂直居中
- 保留主仓已经合入的侧面板交通灯避让规则，不重复实现

## 验证

- window-config 测试：9/9 通过
- ESLint：通过
- TypeScript typecheck：通过
- Tauri JSON 坐标解析：通过
- git diff --check：通过

## 范围

本 PR 只调整 macOS 原生窗口按钮位置，不改变侧栏或顶栏交互。
