### PR TITLE
统一账户设置页签布局宽度

### DIFF
--- a/src/lib/settingsTabMotion.guard.test.ts
+++ b/src/lib/settingsTabMotion.guard.test.ts
@@ -41,6 +41,15 @@ describe("settings segmented control motion guard", () => {
     expect(css).not.toMatch(/\.settings-page__tabs-seg:has\(/);
   });
 
+  it("keeps all account tabs on the shared settings page width", () => {
+    expect(css).toMatch(
+      /\.settings-page__main\s*\{[^}]*max-width:\s*960px;/s,
+    );
+    expect(css).not.toMatch(
+      /\.settings-page__main--pane-fill\s*\{[^}]*max-width:/s,
+    );
+  });
+
   it("discovers raw segmented markup outside the shared component", () => {
     const componentsRoot = resolve(__dirname, "../components");
     const bypasses = globSync("**/*.tsx", { cwd: componentsRoot }).filter(

--- a/src/styles/settings.part1.css
+++ b/src/styles/settings.part1.css
@@ -729,7 +729,6 @@
   flex-direction: column;
   /* Bottom padding lives inside scrolling panes, not the page */
   padding-bottom: 16px;
-  max-width: min(1100px, 100%);
 }
 
 .settings-page__main--pane-fill > .settings-page__title,


### PR DESCRIPTION
## 背景

设置 → 账户的“官方账户 / 自定义提供商 / 扩展”三个胶囊页签切换后，内容容器宽度和起始位置不一致，造成页面横向跳动。

## 修改

- 统一三个账户页签的内容宽度约束
- 保持页签切换时标题、说明与主体左边界一致
- 增加布局守卫

## 验证

- Vitest：4/4 通过
- ESLint：通过
- TypeScript typecheck：通过
- git diff --check：通过

## 范围

本 PR 只修复账户页签布局，不调整账户功能或数据逻辑。
