### PR TITLE
移除聊天输入区底部渐变遮罩

### DIFF
--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -3,6 +3,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const css = readFileSync(join(__dirname, "../styles/skins.css"), "utf8");
+const composerLayoutCss = readFileSync(
+  join(__dirname, "../styles/chat.part1.css"),
+  "utf8",
+);
 
 describe("wallpaper theme contrast CSS", () => {
   it("maps light wallpaper to its own white veil and pane curves", () => {
@@ -99,9 +103,14 @@ describe("wallpaper theme contrast CSS", () => {
     );
   });
 
-  it("does not paint a light fade beneath the floating wallpaper composer", () => {
-    expect(css).toMatch(
-      /html\[data-theme="light"\]\[data-wallpaper="1"\] \.composer-wrap--float\s*\{[^}]*background:\s*transparent/s,
+  it("keeps the floating composer free of theme-specific fades", () => {
+    const floatingComposer = composerLayoutCss.match(
+      /\.composer-wrap--float\s*\{[^}]*\}/s,
+    )?.[0];
+    expect(floatingComposer).toBeTruthy();
+    expect(floatingComposer).not.toMatch(/\bbackground(?:-image)?:/);
+    expect(css).not.toMatch(
+      /data-theme="(?:light|dark)"[^}]*\.composer-wrap--float/,
     );
   });
 });

--- a/src/styles/chat.part1.css
+++ b/src/styles/chat.part1.css
@@ -723,20 +723,13 @@
   right: 0;
   bottom: 0;
   z-index: 20;
-  /* Pass scroll through the fade; only the card captures pointer */
+  /* Only the card captures pointer; chat remains scrollable underneath. */
   pointer-events: none;
   padding: 28px 16px 16px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 10px;
-  background: linear-gradient(
-    to top,
-    var(--bg-main) 0%,
-    color-mix(in srgb, var(--bg-main) 92%, transparent) 42%,
-    color-mix(in srgb, var(--bg-main) 55%, transparent) 72%,
-    transparent 100%
-  );
 }
 
 /* Empty / new session: logo + composer vertically centered in the stage */
@@ -750,8 +743,6 @@
   justify-content: center;
   gap: 22px;
   padding: 24px 16px;
-  /* Full-area overlay — no bottom fade while centered */
-  background: transparent;
 }
 
 .composer-wrap--welcome .composer {

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -292,10 +292,6 @@ html[data-theme="light"][data-wallpaper="1"]
   );
 }
 
-html[data-theme="light"][data-wallpaper="1"] .composer-wrap--float {
-  background: transparent;
-}
-
 /*
  * Hard clear at 0% scrim — clear the canvas and pane curves completely.
  */


### PR DESCRIPTION
## 背景

聊天输入区底部渐变遮罩已在浅色主题移除，但深色主题仍保留旧覆盖，造成底部发黑并与壁纸割裂。

## 修改

- 从共享浮动输入区规则移除底部线性渐变
- 删除浅色主题的冗余透明覆盖，让浅色与深色共用同一规则
- 更新守卫，禁止重新引入主题专属输入区背景覆盖

## 验证

- Vitest：5/5 通过
- ESLint：通过
- TypeScript typecheck：通过
- git diff --check：通过

## 范围

本 PR 只清理聊天输入区底部渐变遮罩，不修改输入框玻璃材质。
