### PR TITLE
补全计划面板展开与收回动效

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -2252,6 +2252,7 @@ export function AppWorkbench() {
     sidebarOverlay,
     asideOverlay,
     asideInFlow: !phoneLayout && !hideChatForSideExpand && !asideOverlay,
+    sideExpanded: hideChatForSideExpand,
   });
   const [account, setAccount] = useState<api.AccountStatus | null>(null);
   voiceSignedInRef.current = !!account?.profile?.signedIn;

--- a/src/app/WorkbenchResourcesAside.tsx
+++ b/src/app/WorkbenchResourcesAside.tsx
@@ -117,8 +117,16 @@ export function WorkbenchResourcesAside(props: WorkbenchResourcesAsideProps) {
       aria-label={tr("a11y.resourcesPane")}
       aria-hidden={layout.asideCollapsed}
       style={
-        phoneLayout || hideChatForSideExpand
+        phoneLayout
           ? undefined
+          : hideChatForSideExpand
+            ? ({
+                width: "calc(100% - var(--sw-sidebar-occupied, 0px))",
+                minWidth: "calc(100% - var(--sw-sidebar-occupied, 0px))",
+                maxWidth: "calc(100% - var(--sw-sidebar-occupied, 0px))",
+                flexBasis: "calc(100% - var(--sw-sidebar-occupied, 0px))",
+                ["--aside-rail-min"]: `${asideMin}px`,
+              } as CSSProperties)
           : asideOverlay
             ? ({
                 width: asideOpenW,

--- a/src/hooks/usePaneSplitMotion.test.tsx
+++ b/src/hooks/usePaneSplitMotion.test.tsx
@@ -22,6 +22,7 @@ const initialProps = {
   sidebarOverlay: false,
   asideOverlay: true,
   asideInFlow: false,
+  sideExpanded: false,
 };
 
 function dispatchWidthTransitionEnd(className: string): void {
@@ -142,7 +143,7 @@ describe("usePaneSplitMotion", () => {
     expect(isPaneSplitMotionActive()).toBe(false);
   });
 
-  it("does not animate an aside leaving the in-flow split", () => {
+  it("animates an aside expanding out of the in-flow split", () => {
     const props = {
       ...initialProps,
       asideOverlay: false,
@@ -153,27 +154,41 @@ describe("usePaneSplitMotion", () => {
       { initialProps: props },
     );
 
-    rerender({ ...props, asideCollapsed: true, asideInFlow: false });
-    expect(result.current.paneMotionClass).not.toContain(
+    rerender({ ...props, asideInFlow: false, sideExpanded: true });
+    expect(result.current.paneMotionClass).toContain(
       "workbench--aside-motion",
     );
+    expect(result.current.paneMotionClass).toContain(
+      "workbench--side-expand-motion",
+    );
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    expect(isPaneSplitMotionActive()).toBe(true);
+
+    act(() => dispatchWidthTransitionEnd("aside"));
     expect(nativeWebviewCoverDepth()).toBe(0);
     expect(isPaneSplitMotionActive()).toBe(false);
   });
 
-  it("does not cover webviews when an overlay becomes side-expanded", () => {
+  it("covers webviews when an overlay becomes side-expanded", () => {
     const { result, rerender } = renderHook(
       (next) => usePaneSplitMotion(next),
       { initialProps },
     );
 
-    rerender({ ...initialProps, asideOverlay: false, asideInFlow: false });
-    expect(result.current.paneMotionClass).toBe("");
-    expect(nativeWebviewCoverDepth()).toBe(0);
-    expect(isPaneSplitMotionActive()).toBe(false);
+    rerender({
+      ...initialProps,
+      asideOverlay: false,
+      asideInFlow: false,
+      sideExpanded: true,
+    });
+    expect(result.current.paneMotionClass).toContain(
+      "workbench--side-expand-motion",
+    );
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    expect(isPaneSplitMotionActive()).toBe(true);
   });
 
-  it("ends an active in-flow aside motion when side-expanded takes over", () => {
+  it("replaces an active in-flow aside motion when side-expanded takes over", () => {
     const props = {
       ...initialProps,
       asideOverlay: false,
@@ -192,13 +207,16 @@ describe("usePaneSplitMotion", () => {
       ...props,
       asideCollapsed: true,
       asideInFlow: false,
+      sideExpanded: true,
     });
-    expect(result.current.paneMotionClass).toBe("");
-    expect(nativeWebviewCoverDepth()).toBe(0);
-    expect(isPaneSplitMotionActive()).toBe(false);
+    expect(result.current.paneMotionClass).toContain(
+      "workbench--side-expand-motion",
+    );
+    expect(nativeWebviewCoverDepth()).toBe(1);
+    expect(isPaneSplitMotionActive()).toBe(true);
   });
 
-  it("ends an active overlay token when side-expanded takes over", () => {
+  it("keeps width motion across a rapid side-expanded reversal", () => {
     const props = {
       ...initialProps,
       asideOverlay: false,
@@ -209,12 +227,21 @@ describe("usePaneSplitMotion", () => {
       { initialProps: props },
     );
 
-    rerender({ ...props, asideOverlay: true, asideInFlow: false });
+    rerender({
+      ...props,
+      asideInFlow: false,
+      sideExpanded: true,
+    });
     expect(nativeWebviewCoverDepth()).toBe(1);
     expect(isPaneSplitMotionActive()).toBe(true);
 
-    rerender({ ...props, asideOverlay: false, asideInFlow: false });
-    expect(result.current.paneMotionClass).toBe("");
+    rerender({ ...props, sideExpanded: false });
+    expect(result.current.paneMotionClass).toContain(
+      "workbench--side-expand-motion",
+    );
+    expect(nativeWebviewCoverDepth()).toBe(1);
+
+    act(() => dispatchWidthTransitionEnd("aside"));
     expect(nativeWebviewCoverDepth()).toBe(0);
     expect(isPaneSplitMotionActive()).toBe(false);
   });

--- a/src/hooks/usePaneSplitMotion.ts
+++ b/src/hooks/usePaneSplitMotion.ts
@@ -32,11 +32,15 @@ export function usePaneSplitMotion(opts: {
   asideOverlay?: boolean;
   /** Right pane participates in the workbench width split. */
   asideInFlow: boolean;
+  /** Right pane occupies all space not used by the left sidebar. */
+  sideExpanded: boolean;
 }): { paneMotionClass: string } {
   const [, setEpoch] = useState(0);
   const keyRef = useRef<string | null>(null);
   const asideOverlayRef = useRef(Boolean(opts.asideOverlay));
   const asideInFlowRef = useRef(opts.asideInFlow);
+  const sideExpandedRef = useRef(opts.sideExpanded);
+  const sideExpandMotionRef = useRef(false);
   const tokenRef = useRef(0);
   const releaseRef = useRef<(() => void) | null>(null);
   const timerRef = useRef<number | null>(null);
@@ -46,21 +50,14 @@ export function usePaneSplitMotion(opts: {
   const asideOverlayModeChanged = asideOverlayRef.current !== asideOverlay;
   const asideOverlayMotionChanged =
     asideOverlayModeChanged && (asideOverlay || opts.asideInFlow);
-  const enteredSideExpanded =
-    !asideOverlay &&
-    !opts.asideInFlow &&
-    (asideOverlayRef.current || asideInFlowRef.current);
-  if (
-    enteredSideExpanded &&
-    tokenRef.current &&
-    (isPaneSplitAsideMotionActive() || isPaneSplitCoverActive())
-  ) {
-    endPaneSplitMotion(tokenRef.current);
-    tokenRef.current = 0;
-  }
+  const sideExpandedChanged = sideExpandedRef.current !== opts.sideExpanded;
   if (keyRef.current === null) {
     keyRef.current = key;
-  } else if (keyRef.current !== key || asideOverlayMotionChanged) {
+  } else if (
+    keyRef.current !== key ||
+    asideOverlayMotionChanged ||
+    sideExpandedChanged
+  ) {
     const colon = keyRef.current.indexOf(":");
     const sidebarChanged =
       keyRef.current.slice(0, colon) !== String(opts.sidebarCollapsed);
@@ -68,7 +65,8 @@ export function usePaneSplitMotion(opts: {
       keyRef.current.slice(colon + 1) !== String(opts.asideCollapsed);
     const sidebarWidthChanged = sidebarChanged && !opts.sidebarOverlay;
     const asideWidthChanged =
-      asideChanged && opts.asideInFlow && asideInFlowRef.current;
+      sideExpandedChanged ||
+      (asideChanged && opts.asideInFlow && asideInFlowRef.current);
     const asideOverlayChanged =
       asideChanged &&
       (asideOverlay || opts.asideInFlow) &&
@@ -86,6 +84,7 @@ export function usePaneSplitMotion(opts: {
       })
     ) {
       if (tokenRef.current) endPaneSplitMotion(tokenRef.current);
+      if (sideExpandedChanged) sideExpandMotionRef.current = true;
       tokenRef.current = beginPaneSplitMotion({
         cover: coverChanged,
         width: sidebarWidthChanged || asideWidthChanged,
@@ -96,6 +95,7 @@ export function usePaneSplitMotion(opts: {
   }
   asideOverlayRef.current = asideOverlay;
   asideInFlowRef.current = opts.asideInFlow;
+  sideExpandedRef.current = opts.sideExpanded;
 
   useLayoutEffect(() => {
     const token = tokenRef.current;
@@ -125,6 +125,7 @@ export function usePaneSplitMotion(opts: {
       releaseRef.current = null;
       endPaneSplitMotion(token);
       tokenRef.current = 0;
+      sideExpandMotionRef.current = false;
       setEpoch((n) => n + 1);
     };
 
@@ -164,6 +165,7 @@ export function usePaneSplitMotion(opts: {
     opts.sidebarOverlay,
     opts.asideOverlay,
     opts.asideInFlow,
+    opts.sideExpanded,
   ]);
 
   useEffect(() => {
@@ -171,6 +173,7 @@ export function usePaneSplitMotion(opts: {
       if (timerRef.current != null) window.clearTimeout(timerRef.current);
       releaseRef.current?.();
       releaseRef.current = null;
+      sideExpandMotionRef.current = false;
       if (tokenRef.current) endPaneSplitMotion(tokenRef.current);
     };
   }, []);
@@ -181,5 +184,8 @@ export function usePaneSplitMotion(opts: {
     classes.push(PANE_SPLIT_SIDEBAR_MOTION_CLASS);
   }
   if (isPaneSplitAsideMotionActive()) classes.push(PANE_SPLIT_ASIDE_MOTION_CLASS);
+  if (sideExpandMotionRef.current && isPaneSplitAsideMotionActive()) {
+    classes.push("workbench--side-expand-motion");
+  }
   return { paneMotionClass: classes.length ? ` ${classes.join(" ")}` : "" };
 }

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -199,6 +199,42 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(hook).toContain("pendingWidthPanes.delete(pane)");
   });
 
+  it("interpolates the right-aligned side workbench between rail and full width", () => {
+    const hook = readFileSync(
+      resolve(__dirname, "../hooks/usePaneSplitMotion.ts"),
+      "utf8",
+    );
+    const aside = readFileSync(
+      resolve(__dirname, "../app/WorkbenchResourcesAside.tsx"),
+      "utf8",
+    );
+    const side = readFileSync(
+      resolve(__dirname, "../styles/side-workbench.part1.css"),
+      "utf8",
+    );
+
+    expect(hook).toContain("sideExpanded: boolean");
+    expect(hook).toContain("workbench--side-expand-motion");
+    expect(aside).toContain(
+      'width: "calc(100% - var(--sw-sidebar-occupied, 0px))"',
+    );
+    expect(side).not.toMatch(
+      /\.workbench--side-expanded \.aside\s*\{[^}]*transition:\s*none/s,
+    );
+    expect(side).toMatch(
+      /\.workbench--side-expand-motion \.aside:not\(\.is-resizing\)\s*\{[^}]*width var\(--motion-pane\)[^}]*min-width var\(--motion-pane\)[^}]*max-width var\(--motion-pane\)/s,
+    );
+    expect(side).toMatch(
+      /\.workbench--side-expanded \.aside:not\(\.aside--hidden\)\s*\{[^}]*right:\s*0;[^}]*left:\s*auto;/s,
+    );
+    expect(side).toMatch(
+      /\.workbench--side-expand-motion \.main\s*\{[^}]*min-width:\s*0;[^}]*overflow:\s*hidden/s,
+    );
+    expect(side).not.toMatch(
+      /\.workbench--side-expanded\.workbench--side-expand-motion \.main\s*\{[^}]*visibility:\s*visible/s,
+    );
+  });
+
   it("mac sidebar seam is not a 1px layout border on vibrancy", () => {
     const sidebar = readFileSync(
       resolve(__dirname, "../styles/sidebar.part1.css"),

--- a/src/styles/side-workbench.part1.css
+++ b/src/styles/side-workbench.part1.css
@@ -85,24 +85,40 @@ body > .composer-wrap.composer-wrap--side-dock {
     0 4px 14px rgba(0, 0, 0, 0.1);
 }
 
-/* Expanded overlay is a mode switch, not a split open — do not interpolate width. */
-.workbench--side-expanded .aside {
-  transition: none;
-}
-
 /* Side pane: full free area when no dock; bottom inset only with --sw-dock-composer-h */
 .workbench--side-expanded .aside:not(.aside--hidden) {
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
-  left: var(--sw-sidebar-occupied, 0px);
-  width: auto !important;
-  min-width: 0 !important;
-  max-width: none !important;
+  left: auto;
   z-index: 40;
   border-left: 1px solid var(--border-subtle);
   flex-shrink: 0;
+}
+
+/* Interpolate the right-aligned pane without scaling or distorting its text. */
+.workbench--side-expand-motion .aside:not(.is-resizing) {
+  transition:
+    width var(--motion-pane) var(--motion-pane-ease),
+    min-width var(--motion-pane) var(--motion-pane-ease),
+    max-width var(--motion-pane) var(--motion-pane-ease),
+    flex-basis var(--motion-pane) var(--motion-pane-ease),
+    transform var(--motion-pane) var(--motion-pane-ease),
+    box-shadow var(--motion-pane) ease,
+    border-color var(--motion-pane) ease;
+}
+
+.workbench--side-expand-motion .aside:not(.is-resizing) .aside__inner {
+  width: 100%;
+  min-width: 0;
+  max-width: none;
+}
+
+/* Let the chat column yield while the full-width pane contracts. */
+.workbench--side-expand-motion .main {
+  min-width: 0;
+  overflow: hidden;
 }
 
 /*
@@ -988,4 +1004,3 @@ html[data-theme="light"] .sw-terminal--pty {
 .sw-terminal__xterm .xterm-scrollable-element > .scrollbar > .slider {
   box-shadow: none !important;
 }
-

--- a/src/styles/side-workbench.part1.css
+++ b/src/styles/side-workbench.part1.css
@@ -987,20 +987,3 @@ html[data-theme="light"] .sw-terminal--pty {
   background: transparent !important;
   box-shadow: none !important;
 }
-
-.sw-terminal__xterm .xterm-scrollable-element > .shadow,
-.sw-terminal__xterm .xterm-scrollable-element > .shadow.top,
-.sw-terminal__xterm .xterm-scrollable-element > .shadow.left,
-.sw-terminal__xterm .xterm-scrollable-element > .shadow.top-left-corner,
-.sw-terminal__xterm .xterm-scrollable-element > .shadow.top.left {
-  display: none !important;
-  opacity: 0 !important;
-  box-shadow: none !important;
-  background: transparent !important;
-  pointer-events: none !important;
-}
-
-.sw-terminal__xterm .xterm-scrollable-element > .scrollbar,
-.sw-terminal__xterm .xterm-scrollable-element > .scrollbar > .slider {
-  box-shadow: none !important;
-}

--- a/src/styles/side-workbench.part2.css
+++ b/src/styles/side-workbench.part2.css
@@ -1,3 +1,20 @@
+.sw-terminal__xterm .xterm-scrollable-element > .shadow,
+.sw-terminal__xterm .xterm-scrollable-element > .shadow.top,
+.sw-terminal__xterm .xterm-scrollable-element > .shadow.left,
+.sw-terminal__xterm .xterm-scrollable-element > .shadow.top-left-corner,
+.sw-terminal__xterm .xterm-scrollable-element > .shadow.top.left {
+  display: none !important;
+  opacity: 0 !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  pointer-events: none !important;
+}
+
+.sw-terminal__xterm .xterm-scrollable-element > .scrollbar,
+.sw-terminal__xterm .xterm-scrollable-element > .scrollbar > .slider {
+  box-shadow: none !important;
+}
+
 .sw-terminal__xterm .xterm-scrollable-element > .scrollbar.horizontal {
   display: none !important;
   height: 0 !important;
@@ -611,4 +628,3 @@
 .sw-review-more:hover {
   text-decoration: underline;
 }
-


### PR DESCRIPTION
## 背景

计划面板从侧栏展开到全屏、再收回时存在直接切换和收尾不自然，主工作区还可能在过渡帧透出。

## 修改

- 让计划面板侧栏、展开和收回共用同一套面板位移动效状态
- 在展开/收回期间保持主区遮挡边界，避免内容穿透
- 修顺取消全屏的收尾曲线与状态清理
- 补充动效状态与样式守卫

## 验证

- Vitest：32/32 通过
- ESLint：通过
- TypeScript typecheck：通过
- UI build：通过（仅既有动态导入/chunk 警告）
- git diff --check：通过

## 范围

本 PR 只处理计划面板展开/收回动效，不包含壁纸玻璃、空态居中、窗口 resize 重放、窄窗覆盖残留或顶栏材质。
