### PR TITLE
统一设置页不透明内容表面

### DIFF
--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -1811,6 +1811,7 @@ export function ExtensionsPanel({
         </div>
       )}
 
+      <div className="settings-card ext-panel__surface">
       {/* Plugins — reference layout: installed strip + 2-col featured catalog */}
       {tab === "plugins" && (
       <div className="ext-ref-stack ext-ref-plugins-scroll">
@@ -2685,6 +2686,7 @@ export function ExtensionsPanel({
           }}
         />
       )}
+      </div>
 
       <GlassModal
         open={chatcutInstallOpen}

--- a/src/components/OfficialAuxPanel.tsx
+++ b/src/components/OfficialAuxPanel.tsx
@@ -122,7 +122,8 @@ export function OfficialAuxPanel({
 
       <div
         className={
-          "prov-official-aux" + (!injectAllowed ? " is-disabled" : "")
+          "settings-card prov-official-aux" +
+          (!injectAllowed ? " is-disabled" : "")
         }
         id="settings-anchor-official-aux-inject"
       >
@@ -156,7 +157,7 @@ export function OfficialAuxPanel({
 
       {injectAllowed && officialAuxInject ? (
         <div
-          className="prov-official-aux prov-official-aux--sub"
+          className="settings-card prov-official-aux prov-official-aux--sub"
           id="settings-anchor-official-aux-user-mcp"
         >
           <div className="prov-official-aux__text">

--- a/src/lib/extensionsSurface.guard.test.ts
+++ b/src/lib/extensionsSurface.guard.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(resolve(__dirname, path), "utf8");
+
+describe("extensions settings surface guard", () => {
+  it("wraps every extension tab in the shared opaque settings card", () => {
+    const component = read("../components/ExtensionsPanel.tsx");
+    const surface = component.match(
+      /<div className="settings-card ext-panel__surface">([\s\S]*?)\n\s*<\/div>\n\n\s*<GlassModal/,
+    )?.[1];
+
+    expect(surface).toBeDefined();
+    for (const tab of ["plugins", "skills", "mcp", "hooks", "agents"]) {
+      expect(surface).toContain(`tab === "${tab}"`);
+    }
+  });
+
+  it("reuses the shared card material and keeps its modifier layout-only", () => {
+    const extensionCss = read("../styles/extensions-ref.part1.css");
+    const settingsCss = read("../styles/settings.part1.css");
+
+    expect(settingsCss).toMatch(
+      /\.settings-card\s*\{[^}]*background:\s*var\(--bg-card\);/s,
+    );
+    expect(extensionCss).toMatch(
+      /\.ext-panel__surface\s*\{[^}]*padding:\s*16px;[^}]*min-width:\s*0;/s,
+    );
+    expect(extensionCss).not.toMatch(
+      /\.ext-panel__surface\s*\{[^}]*background:/s,
+    );
+  });
+});

--- a/src/lib/settingsOpaqueSurface.guard.test.ts
+++ b/src/lib/settingsOpaqueSurface.guard.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const components = join(__dirname, "../components");
+const styles = join(__dirname, "../styles");
+
+describe("settings content surfaces stay opaque", () => {
+  it("reuses the shared settings card for official aux controls", () => {
+    const panel = readFileSync(join(components, "OfficialAuxPanel.tsx"), "utf8");
+
+    expect(panel).toContain('"settings-card prov-official-aux"');
+    expect(panel).toContain(
+      'className="settings-card prov-official-aux prov-official-aux--sub"',
+    );
+  });
+
+  it("keeps the official aux modifier layout-only", () => {
+    const css = readFileSync(join(styles, "composer.part1.css"), "utf8");
+    const baseRule = css.match(/\.prov-official-aux\s*\{[^}]*\}/s)?.[0];
+
+    expect(baseRule).toBeDefined();
+    expect(baseRule).not.toMatch(/(?:background|border|border-radius)\s*:/);
+  });
+
+  it("dims disabled official aux content without fading its surface", () => {
+    const css = readFileSync(join(styles, "composer.part1.css"), "utf8");
+    const disabledRule = css.match(
+      /\.prov-official-aux\.is-disabled\s*>\s*:is\([^{]+\)\s*\{[^}]*\}/s,
+    )?.[0];
+
+    expect(css).not.toMatch(
+      /\.prov-official-aux\.is-disabled\s*\{[^}]*opacity\s*:/s,
+    );
+    expect(disabledRule).toContain("opacity: 0.72");
+  });
+
+  it("keeps the shared settings card on the solid card token", () => {
+    const css = readFileSync(join(styles, "settings.part1.css"), "utf8");
+
+    expect(css).toMatch(
+      /\.settings-card\s*\{[^}]*background:\s*var\(--bg-card\)/s,
+    );
+  });
+});

--- a/src/styles/composer.part1.css
+++ b/src/styles/composer.part1.css
@@ -851,12 +851,12 @@ textarea::-webkit-scrollbar-thumb:active,
   gap: 12px 18px;
   margin: 0 0 14px;
   padding: 12px 14px;
-  border-radius: 12px;
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-card);
 }
 
-.prov-official-aux.is-disabled {
+.prov-official-aux.is-disabled > :is(
+  .prov-official-aux__text,
+  .prov-official-aux__switch
+) {
   opacity: 0.72;
 }
 

--- a/src/styles/extensions-ref.part1.css
+++ b/src/styles/extensions-ref.part1.css
@@ -10,6 +10,11 @@
   margin: 0 0 14px;
 }
 
+.ext-panel__surface {
+  padding: 16px;
+  min-width: 0;
+}
+
 .ext-ref-stack {
   display: flex;
   flex-direction: column;
@@ -663,4 +668,3 @@
   padding: 0 2px 4px;
   letter-spacing: 0.02em;
 }
-


### PR DESCRIPTION
## 背景

扩展页与账户官方工具注入区域仍使用透明底，和设置页其他不透明内容卡片的设计语言不一致，也会让壁纸干扰文字。

## 修改

- 让扩展设置内容复用现有不透明设置表面
- 让账户“注入官方工具能力”区域使用同一表面规则
- 清理被替代的透明背景覆盖
- 更新拆分后的 CSS 与对应守卫

## 验证

- Vitest：41/41 通过
- ESLint：通过
- TypeScript typecheck：通过
- git diff --check：通过

## 范围

本 PR 只统一设置内容表面，不包含设置公共控件重构。
