### PR TITLE
修复侧栏会话选中态与短标题重复

### DIFF
--- a/src/components/SidebarSessionName.tsx
+++ b/src/components/SidebarSessionName.tsx
@@ -9,18 +9,12 @@ type Props = {
   title: string;
 };
 
-/**
- * Approx. hover action strip (pin + archive + menu + left fade).
- * Subtracted from the clip width so marquee can clear icons under the overlay.
- */
-const HOVER_ACTIONS_RESERVE_PX = 78;
-
 /** Gap between duplicated title copies in the seamless loop (px). */
 const MARQUEE_GAP_PX = 28;
 
 /**
  * Sidebar session title: ellipsis at rest; on row hover, if text overflows
- * (including space under overlay icons), marquee-scroll left continuously
+ * (including space reserved for the action buttons), marquee-scroll left continuously
  * (one-way seamless loop — never reverse).
  */
 export function SidebarSessionName({ title }: Props) {
@@ -36,7 +30,7 @@ export function SidebarSessionName({ title }: Props) {
 
     const run = () => {
       const contentW = measure.scrollWidth;
-      const visible = Math.max(8, outer.clientWidth - HOVER_ACTIONS_RESERVE_PX);
+      const visible = Math.max(8, outer.clientWidth);
       const overflow = contentW - visible;
       const needsScroll = overflow > 2;
       setScrollable(needsScroll);

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -194,6 +194,22 @@ describe("tree-reveal CSS", () => {
     );
   });
 
+  it("uses the selected row surface for session actions without a solid fade", () => {
+    const actions = css.match(/\.tree-l3__actions\s*\{[^}]*\}/s)?.[0];
+    const sessionName = readFileSync(
+      resolve(__dirname, "../components/SidebarSessionName.tsx"),
+      "utf8",
+    );
+    expect(actions).toBeTruthy();
+    expect(actions).not.toMatch(/(?:background|mask-image|--bg-sidebar-solid)/);
+    expect(css).not.toContain(".tree-l3__actions::before");
+    expect(css).toMatch(
+      /\.tree-l3:hover:has\(\.tree-l3__actions\):not\(\.tree-l3--renaming\)[\s\S]*padding-right:\s*80px/,
+    );
+    expect(sessionName).not.toContain("HOVER_ACTIONS_RESERVE_PX");
+    expect(sessionName).not.toMatch(/outer\.clientWidth\s*-/);
+  });
+
   it("interpolates the inline height tuple — not 0fr/1fr, which WKWebView snaps", () => {
     expect(TREE_REVEAL_MS).toBe(200);
     expect(TREE_REVEAL_CLOSE_MS).toBe(200);

--- a/src/styles/sidebar.part1b.css
+++ b/src/styles/sidebar.part1b.css
@@ -539,12 +539,4 @@
   white-space: nowrap;
 }
 
-/*
- * Session rows: overlay actions on hover (do not hard-reserve width).
- *
- * --bg-hover / --bg-active are translucent tints — using them alone lets the
- * marquee title bleed through. Composite an opaque strip:
- *   [hover/active tint] over [--bg-sidebar-solid]
- * so the whole button block is solid, matching the hovered row surface.
- * Only the LEFT edge fades to transparent (mask), not a frosted glass fill.
- */
+/* Session actions overlay the row; the title yields only while they are visible. */

--- a/src/styles/sidebar.part2.css
+++ b/src/styles/sidebar.part2.css
@@ -1,8 +1,6 @@
 /* domain CSS chunk (move-only split; selectors unchanged) */
 
 .tree-l3__actions {
-  --tree-l3-overlay-base: var(--bg-sidebar-solid, var(--bg-elevated, var(--bg-app)));
-  --tree-l3-overlay-tint: var(--bg-hover);
   position: absolute;
   right: 2px;
   top: 0;
@@ -22,31 +20,6 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 120ms ease;
-  /* Opaque composite: solid sidebar base + hover/active tint on top */
-  background-color: var(--tree-l3-overlay-base);
-  background-image: linear-gradient(
-    var(--tree-l3-overlay-tint),
-    var(--tree-l3-overlay-tint)
-  );
-  border-radius: 0 8px 8px 0;
-}
-
-/* Left edge only: same solid composite, mask fades to transparent (no blur glass) */
-.tree-l3__actions::before {
-  content: "";
-  position: absolute;
-  right: 100%;
-  top: 0;
-  bottom: 0;
-  width: 28px;
-  pointer-events: none;
-  background-color: var(--tree-l3-overlay-base);
-  background-image: linear-gradient(
-    var(--tree-l3-overlay-tint),
-    var(--tree-l3-overlay-tint)
-  );
-  mask-image: linear-gradient(to right, transparent 0%, black 100%);
-  -webkit-mask-image: linear-gradient(to right, transparent 0%, black 100%);
 }
 
 /* pin + archive + menu — width from content, not reserved layout */
@@ -62,27 +35,10 @@
   pointer-events: auto;
 }
 
-/* Hover chrome only on real pointer hover — not sticky :focus-within after click
- * (selected row used to look “hovered” because the row keeps keyboard focus).
- * Keyboard: still reveal when focus is inside the actions cluster. */
-.tree-l3:hover {
-  --tree-l3-overlay-tint: var(--bg-hover);
-}
-
-.tree-l3--active,
-.tree-l3--checked {
-  --tree-l3-overlay-tint: var(--bg-active);
-}
-
-.tree-l3--active:hover,
-.tree-l3--checked:hover {
-  --tree-l3-overlay-tint: var(--bg-active);
-}
-
 .tree-l3:hover .tree-l3__actions,
 .tree-l3:has(.tree-l3__actions:focus-within) .tree-l3__actions {
   opacity: 1;
-  /* Container ignores clicks in the fade zone; only icon buttons receive them */
+  /* The container ignores clicks; only icon buttons receive them. */
   pointer-events: none;
 }
 
@@ -91,11 +47,18 @@
   pointer-events: auto;
 }
 
-/* Relative time yields to hover actions (still keeps layout until hidden) */
+/* The metadata column yields to the actions; the title reserves their width. */
 .tree-l3:hover .tree-l3__time,
 .tree-l3:has(.tree-l3__actions:focus-within) .tree-l3__time {
-  opacity: 0;
-  transition: opacity 100ms ease;
+  display: none;
+}
+
+.tree-l3:hover:has(.tree-l3__actions):not(.tree-l3--renaming)
+  .tree-l3__title,
+.tree-l3:has(.tree-l3__actions:focus-within):not(.tree-l3--renaming)
+  .tree-l3__title {
+  box-sizing: border-box;
+  padding-right: 80px;
 }
 
 .tree-icon-btn {
@@ -502,7 +465,6 @@ html[data-sidebar-density="compact"] .tree-date-group__head {
   opacity: 0.9;
   font-variant-numeric: tabular-nums;
   pointer-events: none;
-  transition: opacity 100ms ease;
 }
 
 /* In-progress session: always-visible spinner on the right (replaces hover actions). */

--- a/src/styles/sidebar.part4.css
+++ b/src/styles/sidebar.part4.css
@@ -30,7 +30,14 @@ html[data-sidebar-density="compact"] .tree-l3 .tree-icon-btn {
   height: 20px;
 }
 
-
+html[data-sidebar-density="compact"]
+  .tree-l3:hover:has(.tree-l3__actions):not(.tree-l3--renaming)
+  .tree-l3__title,
+html[data-sidebar-density="compact"]
+  .tree-l3:has(.tree-l3__actions:focus-within):not(.tree-l3--renaming)
+  .tree-l3__title {
+  padding-right: 68px;
+}
 
 html[data-sidebar-density="compact"] .session-list {
   gap: 0;
@@ -718,4 +725,3 @@ html[data-sidebar-density="compact"] .session-row__meta {
 .user-meta__hint {
   display: none;
 }
-


### PR DESCRIPTION
## 背景

侧栏会话选中态在深色主题下渐变过黑，会遮挡标题和操作；侧栏较窄时 hover 标题还会出现“PR PR”重复。

## 修改

- 让会话操作区复用父行选中态，删除额外不透明/渐变遮罩
- 同步清理浅色、深色主题的旧覆盖
- 为操作按钮预留真实宽度，按可见宽度决定标题滚动
- 修复短标题在窄栏 hover 时重复显示

## 验证

- Vitest：35/35 通过
- ESLint：通过
- TypeScript typecheck：通过
- git diff --check：通过

## 范围

本 PR 不包含新的固定左右侧栏触发器。
