### PR TITLE
修复侧栏动画期间窗口缩放状态丢失

### DIFF
--- a/src/hooks/useWorkbenchLayout.ts
+++ b/src/hooks/useWorkbenchLayout.ts
@@ -49,6 +49,7 @@ import { isDesktopHost } from "@/lib/api";
 import {
   bumpPaneSplitMotion,
   isPaneSplitMotionActive,
+  runAfterPaneSplitMotion,
 } from "@/lib/paneSplitMotion";
 
 function initialLayout(): LayoutPrefs {
@@ -483,22 +484,29 @@ export function useWorkbenchLayout(opts?: { onAsideClose?: () => void }) {
   useEffect(() => {
     if (phoneLayout) return;
     let resizeTimer: number | null = null;
+    let cancelled = false;
+    const applyResizeClamp = () => {
+      if (cancelled || isWindowFitSuppressed()) return;
+      if (runAfterPaneSplitMotion(applyResizeClamp)) return;
+      const opts = asideClampOpts();
+      setLayout((l) => {
+        if (l.asideCollapsed) return l;
+        const next = clampAsideWidth(l.asideWidth, opts);
+        if (next === l.asideWidth) return l;
+        return persist({ ...l, asideWidth: next });
+      });
+    };
     const onResize = () => {
-      if (isWindowFitSuppressed() || isPaneSplitMotionActive()) return;
+      if (isWindowFitSuppressed()) return;
       if (resizeTimer != null) window.clearTimeout(resizeTimer);
       resizeTimer = window.setTimeout(() => {
-        if (isWindowFitSuppressed() || isPaneSplitMotionActive()) return;
-        const opts = asideClampOpts();
-        setLayout((l) => {
-          if (l.asideCollapsed) return l;
-          const next = clampAsideWidth(l.asideWidth, opts);
-          if (next === l.asideWidth) return l;
-          return persist({ ...l, asideWidth: next });
-        });
+        resizeTimer = null;
+        applyResizeClamp();
       }, 150);
     };
     window.addEventListener("resize", onResize);
     return () => {
+      cancelled = true;
       window.removeEventListener("resize", onResize);
       if (resizeTimer != null) window.clearTimeout(resizeTimer);
     };

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -199,6 +199,19 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(hook).toContain("pendingWidthPanes.delete(pane)");
   });
 
+  it("replays a window resize clamp after pane motion settles", () => {
+    const layoutHook = readFileSync(
+      resolve(__dirname, "../hooks/useWorkbenchLayout.ts"),
+      "utf8",
+    );
+    expect(layoutHook).toMatch(
+      /const applyResizeClamp = \(\) => \{[\s\S]*?runAfterPaneSplitMotion\(applyResizeClamp\)[\s\S]*?clampAsideWidth/,
+    );
+    expect(layoutHook).not.toMatch(
+      /const onResize = \(\) => \{\s*if \(isWindowFitSuppressed\(\) \|\| isPaneSplitMotionActive\(\)\) return;/,
+    );
+  });
+
   it("mac sidebar seam is not a 1px layout border on vibrancy", () => {
     const sidebar = readFileSync(
       resolve(__dirname, "../styles/sidebar.part1.css"),


### PR DESCRIPTION
## 为什么修改

侧栏分割动画期间如果窗口尺寸发生变化，布局钳制会因为动画保护直接返回，动画结束后也不会补跑，导致侧栏宽度与新窗口尺寸不一致。

## 具体改动

- 复用现有 `runAfterPaneSplitMotion`，在动画结束后补跑一次 resize clamp。
- 卸载时通过取消标记阻止延迟回调继续写入状态。
- 增加入口守卫，固定该补跑路径。

## 验证

- Vitest：3 个相关文件，45 项通过。
- 目标 ESLint 通过。
- `pnpm typecheck` 通过。
- `pnpm build:ui` 通过；仅有既有 chunk 与 dynamic-import 警告。
- `git diff --check` 通过。

## 边界

本 PR 只处理动画期间窗口缩放状态丢失，不包含计划面板窄窗覆盖、顶栏材质或固定侧栏触发器。
