### PR TITLE
统一计划面板普通与全屏顶栏材质

### DIFF
--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -3,6 +3,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const css = readFileSync(join(__dirname, "../styles/skins.css"), "utf8");
+const sideWorkbenchCss = readFileSync(
+  join(__dirname, "../styles/side-workbench.part1.css"),
+  "utf8",
+);
 
 describe("wallpaper theme contrast CSS", () => {
   it("maps light wallpaper to its own white veil and pane curves", () => {
@@ -102,6 +106,15 @@ describe("wallpaper theme contrast CSS", () => {
   it("does not paint a light fade beneath the floating wallpaper composer", () => {
     expect(css).toMatch(
       /html\[data-theme="light"\]\[data-wallpaper="1"\] \.composer-wrap--float\s*\{[^}]*background:\s*transparent/s,
+    );
+  });
+
+  it("uses one right-pane chrome material in rail and full-cover modes", () => {
+    expect(sideWorkbenchCss).toMatch(
+      /html:not\(\[data-wallpaper="1"\]\) \.aside \.rp-chrome\s*\{[^}]*background:\s*var\(--bg-card\) !important[^}]*backdrop-filter:\s*none !important/s,
+    );
+    expect(sideWorkbenchCss).toMatch(
+      /html\[data-wallpaper="1"\] \.aside \.rp-chrome\s*\{[^}]*background:\s*transparent !important/s,
     );
   });
 });

--- a/src/styles/side-workbench.part1.css
+++ b/src/styles/side-workbench.part1.css
@@ -128,12 +128,15 @@ html[data-wallpaper="1"].platform-mac[data-theme="light"]
   background: var(--bg-aside) !important;
 }
 
-/* Top tab strip: solid chrome (not glass mix over wallpaper) */
-.workbench--side-expanded .aside .rp-chrome,
-.workbench--side-expanded .aside .rp-chrome.sw-chrome {
+/* Shared right-pane chrome: rail and full-cover modes use one material. */
+html:not([data-wallpaper="1"]) .aside .rp-chrome {
   background: var(--bg-card) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
+}
+
+html[data-wallpaper="1"] .aside .rp-chrome {
+  background: transparent !important;
 }
 
 /* Expanded pane starts at x=0 when the sidebar is hidden/overlayed. */
@@ -988,4 +991,3 @@ html[data-theme="light"] .sw-terminal--pty {
 .sw-terminal__xterm .xterm-scrollable-element > .scrollbar > .slider {
   box-shadow: none !important;
 }
-


### PR DESCRIPTION
## 为什么修改

计划面板普通侧栏与全屏状态分别维护顶栏材质规则，颜色和透明度会随状态切换而不一致。

## 具体改动

- 将 rail 与 full-cover 状态的 `.aside .rp-chrome` 收敛为同一套无壁纸/壁纸规则。
- 删除全屏状态与 `.sw-chrome` 的重复分支。
- 增加公共材质守卫，防止两个状态再次分叉。

## 验证

- Vitest：3 个相关文件，54 项通过。
- 目标 ESLint 通过。
- `pnpm typecheck` 通过。
- `git diff --check origin/main...HEAD` 通过。

## 边界

本 PR 只统一顶栏材质，不包含计划面板玻璃、展开动效、窄窗覆盖或 resize 状态补跑。
