### PR TITLE
保持新建会话时的侧栏折叠状态

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -3297,7 +3297,6 @@ export function AppWorkbench() {
     connectHost.setSessionJsonSchema = setSessionJsonSchema;
     connectHost.setActiveProject = setActiveProject;
     connectHost.setExpandedProjects = setExpandedProjects;
-    connectHost.setHistoryOpen = setHistoryOpen;
     connectHost.refreshSessions = refreshSessions;
     const host = sessionNavHostRef.current;
     host.chrome.goToChat = () => {

--- a/src/hooks/useSessionConnect.ts
+++ b/src/hooks/useSessionConnect.ts
@@ -64,7 +64,6 @@ export type SessionConnectHost = {
   setSessionJsonSchema: Dispatch<SetStateAction<string | null>>;
   setActiveProject: Dispatch<SetStateAction<Project | null>>;
   setExpandedProjects: Dispatch<SetStateAction<Record<string, boolean>>>;
-  setHistoryOpen: Dispatch<SetStateAction<boolean>>;
   refreshSessions: () => void | Promise<void>;
 };
 
@@ -96,7 +95,6 @@ function emptyHost(): SessionConnectHost {
     setSessionJsonSchema: noop,
     setActiveProject: noop,
     setExpandedProjects: noop,
-    setHistoryOpen: noop,
     refreshSessions: noop,
   };
 }
@@ -314,8 +312,6 @@ export function useSessionConnect(opts: {
                 ...e,
                 [connectProject.id]: true,
               }));
-            } else {
-              h.setHistoryOpen(true);
             }
           }
           await h.refreshSessions();

--- a/src/hooks/useSessionNavigation.ts
+++ b/src/hooks/useSessionNavigation.ts
@@ -490,7 +490,7 @@ export function useSessionNavigation(opts: {
       }
       host.chrome.closePhoneDrawerIfNeeded();
       host.catalog.setActiveProject(proj);
-      host.catalog.revealInSidebar(proj);
+      if (proj) host.catalog.revealInSidebar(proj);
 
       bumpViewEpoch();
       invalidateOpenPipelines();

--- a/src/lib/treeReveal.test.ts
+++ b/src/lib/treeReveal.test.ts
@@ -233,6 +233,28 @@ describe("Other sessions tree wrap", () => {
     "utf8",
   );
 
+  it("preserves the user's Other-sessions fold state for a new orphan chat", () => {
+    const navigation = readFileSync(
+      resolve(__dirname, "../hooks/useSessionNavigation.ts"),
+      "utf8",
+    );
+    const connect = readFileSync(
+      resolve(__dirname, "../hooks/useSessionConnect.ts"),
+      "utf8",
+    );
+    const newChat = navigation.slice(
+      navigation.indexOf("  const newChat = useCallback("),
+      navigation.indexOf("  const openSessionRef = useRef(openSession);"),
+    );
+    const ensureConnected = connect.slice(
+      connect.indexOf("  const ensureConnected = useCallback("),
+      connect.indexOf("  const retryAgentConnect = useCallback("),
+    );
+
+    expect(newChat).toContain("if (proj) host.catalog.revealInSidebar(proj);");
+    expect(ensureConnected).not.toContain("setHistoryOpen");
+  });
+
   it("wraps the Other-sessions reveal in a block .tree-orphan like .tree-project", () => {
     expect(src).toContain('className="tree-orphan"');
     expect(src).toMatch(


### PR DESCRIPTION
## 为什么修改

在主页面新建会话时，两条初始化路径会无条件展开“其他会话”，覆盖用户当前的折叠选择。

## 根因与改动

- `useSessionNavigation.newChat` 只在项目会话场景展开对应项目，不再通过 `revealInSidebar(null)` 展开“其他会话”。
- `useSessionConnect` 首次物化孤立会话时不再强制 `setHistoryOpen(true)`。
- 删除 `ConnectHost` 中因此失去用途的 setter。
- 增加回归守卫，覆盖新建与首次连接两条路径。

## 验证

- Vitest：4 个相关文件，40/40 通过。
- 目标 ESLint 通过。
- `pnpm typecheck` 通过。
- `git diff --check origin/main...HEAD` 通过。

## 边界

本 PR 只保持已有折叠状态，不改变项目会话应展开对应项目的行为，也不包含侧栏按钮固定或未读标记。
