### PR TITLE
修复窄窗口计划面板覆盖残留

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -2245,6 +2245,8 @@ export function AppWorkbench() {
       asideOpen: true,
       asideWidth: asideOpenW,
     }).asideOverlay;
+  const sidePaneCoversMain =
+    hideChatForSideExpand || (asideOverlay && !layout.asideCollapsed);
   const { paneMotionClass } = usePaneSplitMotion({
     sidebarCollapsed: layout.sidebarCollapsed,
     asideCollapsed: layout.asideCollapsed,
@@ -13791,7 +13793,7 @@ export function AppWorkbench() {
         className={
           "workbench" +
           (phoneLayout ? " workbench--phone" : "") +
-          (hideChatForSideExpand ? " workbench--side-expanded" : "") +
+          (sidePaneCoversMain ? " workbench--side-expanded" : "") +
           (sideDockActive ? " workbench--side-dock" : "") +
           paneMotionClass
         }
@@ -13821,24 +13823,13 @@ export function AppWorkbench() {
             onClick={closePhoneDrawer}
           />
         ) : null}
-        {!phoneLayout &&
-        ((sidebarOverlay && !layout.sidebarCollapsed) ||
-          (asideOverlay && !layout.asideCollapsed)) ? (
+        {!phoneLayout && sidebarOverlay && !layout.sidebarCollapsed ? (
           <button
             type="button"
             className="workbench-pane-scrim"
-            aria-label={
-              sidebarOverlay && !layout.sidebarCollapsed
-                ? tr("phone.drawerClose")
-                : tr("main.rightPaneHide")
-            }
+            aria-label={tr("phone.drawerClose")}
             onClick={() => {
-              if (sidebarOverlay && !layout.sidebarCollapsed) {
-                closeSidebarPane();
-              }
-              if (asideOverlay && !layout.asideCollapsed) {
-                closeAsidePane();
-              }
+              closeSidebarPane();
             }}
           />
         ) : null}
@@ -13961,7 +13952,7 @@ export function AppWorkbench() {
           layout={layout}
           phoneLayout={phoneLayout}
           dragZone={dragZone}
-          hideChatForSideExpand={hideChatForSideExpand}
+          sidePaneCoversMain={sidePaneCoversMain}
           toast={toast}
           dragRegion={dragRegion}
           titlebarMax={titlebarMax}
@@ -14488,7 +14479,7 @@ export function AppWorkbench() {
           locale={locale}
           layout={layout}
           phoneLayout={phoneLayout}
-          hideChatForSideExpand={hideChatForSideExpand}
+          sidePaneCoversMain={sidePaneCoversMain}
           asideOverlay={asideOverlay}
           resizingAside={resizingAside}
           asideOpenW={asideOpenW}

--- a/src/app/WorkbenchMain.tsx
+++ b/src/app/WorkbenchMain.tsx
@@ -59,7 +59,7 @@ export type WorkbenchMainProps = {
   layout: { sidebarCollapsed: boolean; asideCollapsed: boolean };
   phoneLayout: boolean;
   dragZone: "sidebar" | "main" | null;
-  hideChatForSideExpand: boolean;
+  sidePaneCoversMain: boolean;
   toast: string | null;
   dragRegion: "false" | "deep";
   titlebarMax: TitlebarMax;
@@ -103,7 +103,7 @@ export function WorkbenchMain(props: WorkbenchMainProps) {
     layout,
     phoneLayout,
     dragZone,
-    hideChatForSideExpand,
+    sidePaneCoversMain,
     toast,
     dragRegion,
     titlebarMax,
@@ -156,11 +156,11 @@ export function WorkbenchMain(props: WorkbenchMainProps) {
         (layout.sidebarCollapsed ? " main--sidebar-hidden" : "") +
         (dragZone === "main" ? " is-drop-target" : "") +
         (dragZone === "sidebar" ? " is-drop-idle" : "") +
-        (hideChatForSideExpand ? " main--side-covered" : "")
+        (sidePaneCoversMain ? " main--side-covered" : "")
       }
-      aria-hidden={hideChatForSideExpand ? true : undefined}
+      aria-hidden={sidePaneCoversMain ? true : undefined}
       // Keep chat DOM mounted under the side overlay; block interaction.
-      inert={hideChatForSideExpand ? true : undefined}
+      inert={sidePaneCoversMain ? true : undefined}
     >
       {dragZone === "main" && (
         <div className="drop-overlay drop-overlay--attach" aria-hidden>

--- a/src/app/WorkbenchResourcesAside.tsx
+++ b/src/app/WorkbenchResourcesAside.tsx
@@ -25,7 +25,7 @@ export type WorkbenchResourcesAsideProps = {
   locale: Locale;
   layout: { asideCollapsed: boolean; asideWidth: number };
   phoneLayout: boolean;
-  hideChatForSideExpand: boolean;
+  sidePaneCoversMain: boolean;
   asideOverlay: boolean;
   resizingAside: boolean;
   asideOpenW: number;
@@ -67,7 +67,7 @@ export function WorkbenchResourcesAside(props: WorkbenchResourcesAsideProps) {
     locale,
     layout,
     phoneLayout,
-    hideChatForSideExpand,
+    sidePaneCoversMain,
     asideOverlay,
     resizingAside,
     asideOpenW,
@@ -111,13 +111,13 @@ export function WorkbenchResourcesAside(props: WorkbenchResourcesAsideProps) {
         (layout.asideCollapsed ? "aside aside--hidden" : "aside") +
         (resizingAside ? " is-resizing" : "") +
         (phoneLayout ? " aside--phone-overlay" : "") +
-        (hideChatForSideExpand ? " aside--side-expanded" : "") +
+        (sidePaneCoversMain ? " aside--side-expanded" : "") +
         (asideOverlay ? " aside--overlay" : "")
       }
       aria-label={tr("a11y.resourcesPane")}
       aria-hidden={layout.asideCollapsed}
       style={
-        phoneLayout || hideChatForSideExpand
+        phoneLayout || sidePaneCoversMain
           ? undefined
           : asideOverlay
             ? ({
@@ -136,7 +136,7 @@ export function WorkbenchResourcesAside(props: WorkbenchResourcesAsideProps) {
                 } as CSSProperties)
       }
     >
-      {!layout.asideCollapsed && !hideChatForSideExpand && !asideOverlay && (
+      {!layout.asideCollapsed && !sidePaneCoversMain && !asideOverlay && (
         <div
           className="aside-resizer"
           role="separator"

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -199,6 +199,43 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(hook).toContain("pendingWidthPanes.delete(pane)");
   });
 
+  it("promotes an open aside overlay to the existing full-cover mode", () => {
+    const app = readFileSync(
+      resolve(__dirname, "../app/AppWorkbench.tsx"),
+      "utf8",
+    );
+    const main = readFileSync(
+      resolve(__dirname, "../app/WorkbenchMain.tsx"),
+      "utf8",
+    );
+    const resources = readFileSync(
+      resolve(__dirname, "../app/WorkbenchResourcesAside.tsx"),
+      "utf8",
+    );
+    const aside = readFileSync(
+      resolve(__dirname, "../styles/chat.part6.css"),
+      "utf8",
+    );
+
+    expect(app).toMatch(
+      /const sidePaneCoversMain =\s*hideChatForSideExpand \|\|\s*\(asideOverlay && !layout\.asideCollapsed\)/,
+    );
+    expect(app).toContain(
+      'sidePaneCoversMain ? " workbench--side-expanded" : ""',
+    );
+    expect(app).toMatch(
+      /!phoneLayout && sidebarOverlay && !layout\.sidebarCollapsed \? \(\s*<button[\s\S]*?className="workbench-pane-scrim"/,
+    );
+    expect(app).toContain("sidePaneCoversMain={sidePaneCoversMain}");
+    expect(main).toContain("inert={sidePaneCoversMain ? true : undefined}");
+    expect(resources).toContain(
+      'sidePaneCoversMain ? " aside--side-expanded" : ""',
+    );
+    expect(aside).toMatch(
+      /\.aside\.aside--overlay\s*\{[^}]*top:\s*0;/s,
+    );
+  });
+
   it("mac sidebar seam is not a 1px layout border on vibrancy", () => {
     const sidebar = readFileSync(
       resolve(__dirname, "../styles/sidebar.part1.css"),

--- a/src/styles/chat.part6.css
+++ b/src/styles/chat.part6.css
@@ -598,7 +598,7 @@
 
 .aside.aside--overlay {
   position: absolute;
-  top: var(--titlebar-height, 40px);
+  top: 0;
   right: 0;
   bottom: 0;
   z-index: 41;


### PR DESCRIPTION
## 为什么修改

窄窗口下展开右侧计划面板时，旧 overlay 仍按定宽抽屉处理：主工作区继续绘制、顶端保留偏移并叠加 scrim，造成被遮盖内容透出和错误层级。

## 根因与改动

- 在 `AppWorkbench` 单点派生 `sidePaneCoversMain`，同步驱动主区和资源侧栏。
- 复用现有完整覆盖样式，使超过窗口一半后的计划面板直接覆盖主区。
- 移除旧的右栏 overlay scrim。
- 将 overlay 顶端归零，避免顶部残留。

## 验证

- 专项 Vitest：3 个文件，31/31 通过。
- 目标 ESLint 通过。
- `pnpm typecheck` 通过。
- `pnpm build:ui` 通过。
- `git diff --check` 通过。

## 边界与顺序

本 PR 不包含 resize 状态补跑、计划面板玻璃、展开动效或顶栏材质。无编译硬依赖，但与计划面板动效存在同文件改动，建议在 #892 与 #897 之后合并以减少冲突。
