### PR TITLE
docs(linux): list AppImage EGL/WebKit runtime packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Changed
+- **Linux AppImage runtime packages (#899)**: README documents the host apt line for a clean Debian/Ubuntu (`libegl1`, `libgles2`, `libwebkit2gtk-4.1-0`, `libayatana-appindicator3-1`) when the official AppImage exits with `libEGL.so.1: cannot open shared object file`. Distinct from the Wayland black-window / `EGL_BAD_PARAMETER` notes.
+
+**中文 · 变更**
+- **Linux AppImage 运行时包（#899）**：README 补上干净 Debian/Ubuntu 的 apt 行（`libegl1`、`libgles2`、`libwebkit2gtk-4.1-0`、`libayatana-appindicator3-1`）。官方 AppImage 缺 `libEGL.so.1` 会立刻退出；这与 Wayland 黑窗 / `EGL_BAD_PARAMETER` 不是同一类问题。
+
 ### Fixed
 - **Session API second turn no longer deadlocks on already-live connect (#905)**: `connect_inner` held `inner` and then called `snapshot()`, which locks `inner` again (`parking_lot` is not reentrant). The thread never returned, so `connect_lock` stayed busy forever and later `POST /turns` got 503 `retry_later`. Already-live and fork-busy now snapshot from the held lock.
 - **Unsigned-in startup no longer waits 24s on ACP `authenticate` (#898)**: Official route with no `auth.json` / no usable cached token used to send `authenticate(cached_token)` after `initialize`, time out at 12s, retry once, then soft-fail. Workbench still opened idle. Host now skips that RPC when the user is not signed in. Custom routes still skip; the signed-in-but-agent-home-stale path (#528) still re-syncs and retries once.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Get-FileHash .\Grok_*_x64-setup.exe -Algorithm SHA256
 #### Requirements
 - Local **Grok Build CLI** (`grok`) **0.2.112 or newer** (run `grok update` in terminal to upgrade).
 - Windows: Requires **WebView2 Runtime** (pre-installed on Windows 11; bootstrapped by the installer if missing).
+- Linux AppImage: host `libEGL.so.1` plus WebKitGTK 4.1 / Ayatana — see [Linux runtime libraries](#linux-runtime-libraries-appimage).
 
 #### Network & Proxy Configuration
 In restricted network environments where Grok services cannot be reached directly:
@@ -184,7 +185,29 @@ For unsigned community packages, Windows SmartScreen may display a warning on in
 
 ---
 
+### Linux runtime libraries (AppImage)
+
+The official AppImage does **not** bundle host EGL / WebKit / tray libraries. On a **clean Debian / Ubuntu** install the binary can exit immediately:
+
+```text
+error while loading shared libraries: libEGL.so.1: cannot open shared object file
+```
+
+Install the runtime packages the `.deb` already expects, plus EGL/GLES (confirmed on **Debian 13 (trixie) x86_64** with official `Grok_0.2.26_amd64.AppImage`):
+
+```bash
+sudo apt-get install -y libegl1 libgles2 libwebkit2gtk-4.1-0 libayatana-appindicator3-1
+```
+
+Then `chmod +x` and run the AppImage (or the extracted `usr/bin/grok-app`). The `.deb` already lists `libwebkit2gtk-4.1-0` and `libgtk-3-0`.
+
+This is a **missing shared library at process start**. It is not the Wayland black-window / `EGL_BAD_PARAMETER` case in [Linux Display Notes](#linux-display-notes-webkitgtk--wayland). See issue [#899](https://github.com/RongleCat/grok-app/issues/899).
+
+---
+
 ### Linux Display Notes (WebKitGTK / Wayland)
+If the process never starts and you see `libEGL.so.1: cannot open shared object file`, that is a missing host library — see [Linux runtime libraries](#linux-runtime-libraries-appimage).
+
 On certain Wayland desktop setups (such as Hyprland with AMD GPUs), the universal AppImage may encounter rendering conflicts with the host Mesa/DRI stack:
 - **Recommended**: Use system-integrated **`.deb`** or **`.rpm`** packages which link against your distribution's native WebKitGTK.
 - When running the AppImage, you can try disabling hardware compositing:

--- a/README_EN.md
+++ b/README_EN.md
@@ -157,6 +157,7 @@ Get-FileHash .\Grok_*_x64-setup.exe -Algorithm SHA256
 #### Requirements
 - Local **Grok Build CLI** (`grok`) **0.2.112 or newer** (run `grok update` in terminal to upgrade).
 - Windows: Requires **WebView2 Runtime** (pre-installed on Windows 11; bootstrapped by the installer if missing).
+- Linux AppImage: host `libEGL.so.1` plus WebKitGTK 4.1 / Ayatana — see [Linux runtime libraries](#linux-runtime-libraries-appimage).
 
 #### Network & Proxy Configuration
 In restricted network environments where Grok services cannot be reached directly:
@@ -184,7 +185,29 @@ For unsigned community packages, Windows SmartScreen may display a warning on in
 
 ---
 
+### Linux runtime libraries (AppImage)
+
+The official AppImage does **not** bundle host EGL / WebKit / tray libraries. On a **clean Debian / Ubuntu** install the binary can exit immediately:
+
+```text
+error while loading shared libraries: libEGL.so.1: cannot open shared object file
+```
+
+Install the runtime packages the `.deb` already expects, plus EGL/GLES (confirmed on **Debian 13 (trixie) x86_64** with official `Grok_0.2.26_amd64.AppImage`):
+
+```bash
+sudo apt-get install -y libegl1 libgles2 libwebkit2gtk-4.1-0 libayatana-appindicator3-1
+```
+
+Then `chmod +x` and run the AppImage (or the extracted `usr/bin/grok-app`). The `.deb` already lists `libwebkit2gtk-4.1-0` and `libgtk-3-0`.
+
+This is a **missing shared library at process start**. It is not the Wayland black-window / `EGL_BAD_PARAMETER` case in [Linux Display Notes](#linux-display-notes-webkitgtk--wayland). See issue [#899](https://github.com/RongleCat/grok-app/issues/899).
+
+---
+
 ### Linux Display Notes (WebKitGTK / Wayland)
+If the process never starts and you see `libEGL.so.1: cannot open shared object file`, that is a missing host library — see [Linux runtime libraries](#linux-runtime-libraries-appimage).
+
 On certain Wayland desktop setups (such as Hyprland with AMD GPUs), the universal AppImage may encounter rendering conflicts with the host Mesa/DRI stack:
 - **Recommended**: Use system-integrated **`.deb`** or **`.rpm`** packages which link against your distribution's native WebKitGTK.
 - When running the AppImage, you can try disabling hardware compositing:

--- a/README_RU.md
+++ b/README_RU.md
@@ -157,6 +157,7 @@ Get-FileHash .\Grok_*_x64-setup.exe -Algorithm SHA256
 #### Системные требования
 - Установленный **Grok Build CLI** (`grok`) версии **0.2.112 или новее** (для обновления выполните `grok update` в терминале).
 - Для Windows требуется **WebView2 Runtime** (в Windows 11 предустановлен; в более ранних версиях установщик предложит инсталляцию).
+- Linux AppImage: системные `libEGL.so.1`, WebKitGTK 4.1 и Ayatana — см. [библиотеки runtime](#linux-библиотеки-runtime-appimage).
 
 #### Настройка сетевого прокси
 Если сервисы Grok недоступны напрямую из-за ограничений сети:
@@ -184,7 +185,29 @@ open /Applications/Grok.app
 
 ---
 
+### Linux: библиотеки runtime (AppImage)
+
+Официальный AppImage **не** содержит системные EGL / WebKit / tray-библиотеки. На **чистой Debian / Ubuntu** процесс может сразу завершиться:
+
+```text
+error while loading shared libraries: libEGL.so.1: cannot open shared object file
+```
+
+Установите runtime-пакеты, которые уже ожидает `.deb`, плюс EGL/GLES (проверено на **Debian 13 (trixie) x86_64**, официальный `Grok_0.2.26_amd64.AppImage`):
+
+```bash
+sudo apt-get install -y libegl1 libgles2 libwebkit2gtk-4.1-0 libayatana-appindicator3-1
+```
+
+Затем `chmod +x` и запустите AppImage (или распакованный `usr/bin/grok-app`). В `.deb` уже указаны `libwebkit2gtk-4.1-0` и `libgtk-3-0`.
+
+Это **отсутствие shared library при старте**, а не чёрное окно Wayland / `EGL_BAD_PARAMETER` из раздела [графика в Linux](#особенности-графики-в-linux-webkitgtk--wayland). См. issue [#899](https://github.com/RongleCat/grok-app/issues/899).
+
+---
+
 ### Особенности графики в Linux (WebKitGTK / Wayland)
+Если процесс вообще не стартует и в выводе `libEGL.so.1: cannot open shared object file`, это отсутствие системной библиотеки — см. [библиотеки runtime](#linux-библиотеки-runtime-appimage).
+
 В некоторых окружениях Wayland (например, Hyprland на видеокартах AMD) пакет AppImage может испытывать сложности взаимодействия с драйверами Mesa:
 - **Рекомендуется**: Использовать системные пакеты **`.deb`** или **`.rpm`**, скомпонованные с системной версией WebKitGTK.
 - При использовании AppImage можно запустить приложение с отключением аппаратного композитинга:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -157,6 +157,7 @@ Get-FileHash .\Grok_*_x64-setup.exe -Algorithm SHA256
 #### 系统与依赖要求
 - 本机已安装 **Grok Build CLI**（`grok`）**0.2.112 或更高版本**（可通过终端运行 `grok update` 进行更新）。
 - Windows 环境需要 **WebView2 Runtime**（Windows 11 通常已内置；若缺失安装包会自动引导安装）。
+- Linux AppImage：宿主需要 `libEGL.so.1` 以及 WebKitGTK 4.1 / Ayatana，见 [Linux 运行时库](#linux-运行时库appimage)。
 
 #### 网络代理设置（网络受限环境）
 若所处网络无法直连 Grok 官方服务（如部分地区）：
@@ -184,7 +185,29 @@ open /Applications/Grok.app
 
 ---
 
+### Linux 运行时库（AppImage）
+
+官方 AppImage **不会**打包宿主的 EGL / WebKit / 托盘库。在**干净的 Debian / Ubuntu** 上可能一启动就退出：
+
+```text
+error while loading shared libraries: libEGL.so.1: cannot open shared object file
+```
+
+先装运行时包（`.deb` 已依赖 WebKit；再补 EGL/GLES）。已在 **Debian 13（trixie）x86_64**、官方 `Grok_0.2.26_amd64.AppImage` 上确认：
+
+```bash
+sudo apt-get install -y libegl1 libgles2 libwebkit2gtk-4.1-0 libayatana-appindicator3-1
+```
+
+然后 `chmod +x` 再运行 AppImage（或解压后的 `usr/bin/grok-app`）。`.deb` 已声明 `libwebkit2gtk-4.1-0` 与 `libgtk-3-0`。
+
+这是**进程启动时缺共享库**，不是下面 [Linux 渲染提示](#linux-渲染提示-webkitgtk) 的 Wayland / `EGL_BAD_PARAMETER` 情况。见 [#899](https://github.com/RongleCat/grok-app/issues/899)。
+
+---
+
 ### Linux 渲染提示 (WebKitGTK)
+如果进程根本起不来，报错是 `libEGL.so.1: cannot open shared object file`，那是缺宿主库——见 [Linux 运行时库](#linux-运行时库appimage)。
+
 部分运行 Wayland（如 Hyprland + AMD 显卡）的 Linux 环境下，AppImage 可能会因容器打包版本与主机 Mesa 驱动兼容性问题出现显示异常：
 - **推荐方案**：优先使用与系统包管理器契合的 **`.deb`** 或 **`.rpm`** 安装包（链接系统原生 WebKitGTK）。
 - 如使用 AppImage，可尝试添加环境变量运行：

--- a/scripts/run-linux-appimage-system-webkit.sh
+++ b/scripts/run-linux-appimage-system-webkit.sh
@@ -59,11 +59,17 @@ error: system WebKitGTK 4.1 not found.
 
 Install it, then re-run:
   Arch / Manjaro:  sudo pacman -S webkit2gtk-4.1
-  Debian / Ubuntu: sudo apt install libwebkit2gtk-4.1-0
+  Debian / Ubuntu: sudo apt-get install -y libegl1 libgles2 libwebkit2gtk-4.1-0 libayatana-appindicator3-1
   Fedora:          sudo dnf install webkit2gtk4.1
 
 Prefer .deb / .rpm from the same Release when possible (they already use system WebKit).
 EOF
+  exit 1
+fi
+
+# Stock AppImage / extracted grok-app also need host libEGL.so.1 (Debian 13 #899).
+if [[ ! -e "$LIB_DIR/libEGL.so.1" && ! -e /usr/lib/x86_64-linux-gnu/libEGL.so.1 && ! -e /usr/lib64/libEGL.so.1 && ! -e /usr/lib/libEGL.so.1 ]]; then
+  echo "error: libEGL.so.1 not found. Debian/Ubuntu: sudo apt-get install -y libegl1 libgles2 libwebkit2gtk-4.1-0 libayatana-appindicator3-1" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Fixes #899

Repro:

Official Grok v0.2.26 AppImage on clean Debian 13 (trixie) x86_64 fails immediately:

```
./Grok_0.2.26_amd64.AppImage --appimage-extract-and-run
error while loading shared libraries: libEGL.so.1: cannot open shared object file
```

After `apt-get install libegl1 libgles2 libwebkit2gtk-4.1-0 libayatana-appindicator3-1` it starts.

README Linux notes did not list these runtime packages. This PR documents them.