### PR TITLE
fix: skip ACP authenticate when unsigned-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ See `docs/llm-wiki/release.md`.
 
 ### Fixed
 - **Session API second turn no longer deadlocks on already-live connect (#905)**: `connect_inner` held `inner` and then called `snapshot()`, which locks `inner` again (`parking_lot` is not reentrant). The thread never returned, so `connect_lock` stayed busy forever and later `POST /turns` got 503 `retry_later`. Already-live and fork-busy now snapshot from the held lock.
+- **Unsigned-in startup no longer waits 24s on ACP `authenticate` (#898)**: Official route with no `auth.json` / no usable cached token used to send `authenticate(cached_token)` after `initialize`, time out at 12s, retry once, then soft-fail. Workbench still opened idle. Host now skips that RPC when the user is not signed in. Custom routes still skip; the signed-in-but-agent-home-stale path (#528) still re-syncs and retries once.
 
 **中文 · 修复**
 - **Session API 第二轮不再在 already-live connect 上死锁（#905）**：`connect_inner` 握着 `inner` 再调 `snapshot()`，而 `snapshot()` 会再锁一次（`parking_lot` 不可重入）。线程回不来，`connect_lock` 一直 busy，后续 `POST /turns` 变成 503 `retry_later`。already-live / fork-busy 改为从已持有的锁做 snapshot。
+- **未登录启动不再为 ACP `authenticate` 空等约 24 秒（#898）**：官方路由在没有 `auth.json` / 没有可用 cached token 时仍会在 `initialize` 后发 `authenticate(cached_token)`，12 秒超时后再试一次，然后 soft-fail；工作台仍会打开。现在未登录就跳过该 RPC。自定义路由仍跳过；已登录但 agent-home 缺 token（#528）仍会同步并重试一次。
 
 ## [0.2.26] - 2026-08-24
 

--- a/docs/llm-wiki/account.md
+++ b/docs/llm-wiki/account.md
@@ -33,6 +33,8 @@ Host **must** sync `auth.json` into agent-home on login and before each ACP spaw
 
 **Custom route + official login:** keep `~/.grok/auth.json` (billing / official-aux) but do **not** copy it into the custom main agent-home, and do **not** call ACP `authenticate(cached_token)` on that process. `cached_token` reads `~/.grok/auth.json` even when `GROK_HOME` is agent-home; Grok Build then sends OIDC to the relay (`HTTP 400 Incorrect API key` / 401). Symptom: relay works until the user signs in, and works again immediately after logout.
 
+**Unsigned-in official route:** if `read_auth_profile().signed_in` is false (no `auth.json`, or no usable `key` / `access_token` / `refresh_token`), **do not** send `authenticate(cached_token)`. The CLI has nothing to load; the RPC waits 12s, retries once after a no-op re-sync, then soft-fails (~24s of ERROR logs) while the workbench still opens idle. This is **not** the #528 “logged in but agent-home missing token” path — that still authenticates, re-syncs `~/.grok` → agent-home, and retries once. An official API key / keychain key is not a cached token and must not trigger this RPC.
+
 ### Warm process recycle after auth change
 
 Syncing the file is not enough while multi-session **parked** / **prewarm** CLI processes still hold credentials loaded at spawn time. Connect prefers a Ready prewarm when policy/effort/route match.

--- a/src-tauri/src/acp_client.rs
+++ b/src-tauri/src/acp_client.rs
@@ -1100,13 +1100,31 @@ fn apply_grok_build_proxy_env(
 
 /// Whether this ACP process should call `authenticate(cached_token)`.
 ///
-/// Custom relays must not load official OIDC. Grok Build sends OIDC once
-/// `cached_token` succeeds — even when the request URL is a custom relay
-/// (HTTP 400 Incorrect API key / 401). `cached_token` reads `~/.grok/auth.json`,
-/// which official login must keep for Account billing / official-aux. Clearing
-/// only agent-home `auth.json` is not enough.
-pub fn should_authenticate_cached_token(custom_route: bool) -> bool {
-    !custom_route
+/// Skip when:
+/// - **custom relay** — Grok Build sends OIDC once `cached_token` succeeds,
+///   even when the request URL is a custom relay (HTTP 400 Incorrect API key
+///   / 401). `cached_token` reads `~/.grok/auth.json`, which official login
+///   must keep for Account billing / official-aux. Clearing only agent-home
+///   `auth.json` is not enough.
+/// - **unsigned-in** — no usable cached token (`auth.json` missing, or no
+///   `key` / `access_token` / `refresh_token`). The CLI has nothing to load;
+///   sending `authenticate` waits `AUTH_TIMEOUT_SECS` twice then soft-fails
+///   (~24s of ERROR logs) while the workbench still opens idle.
+///
+/// Keep the call when the official route is signed in. The #528
+/// signed-in-but-agent-home-stale path still re-syncs and retries once.
+pub fn should_authenticate_cached_token(custom_route: bool, has_cached_token: bool) -> bool {
+    !custom_route && has_cached_token
+}
+
+/// Host-side probe: official OIDC material exists for `cached_token`.
+///
+/// Uses [`crate::account::read_auth_profile`] (canonical `~/.grok/auth.json`
+/// preferred over an empty agent-home copy). Does not unlock the App keychain
+/// or treat an official API key as a cached token — those are not what
+/// `authenticate(cached_token)` loads.
+pub fn has_cached_token_for_authenticate() -> bool {
+    crate::account::read_auth_profile().signed_in
 }
 
 impl AcpClient {
@@ -2828,7 +2846,11 @@ impl AcpClient {
         // Custom relays must skip this: `cached_token` reads ~/.grok/auth.json
         // (still present after official login for billing). Grok Build then
         // sends OIDC to the relay and the user sees “works until I sign in”.
-        if should_authenticate_cached_token(self.custom_route) {
+        //
+        // Unsigned-in official route must also skip: there is no token to
+        // load, and the CLI authenticate RPC times out at 12s × 2.
+        let has_cached_token = has_cached_token_for_authenticate();
+        if should_authenticate_cached_token(self.custom_route, has_cached_token) {
             match self
                 .request_timeout(
                     "authenticate",
@@ -2861,8 +2883,10 @@ impl AcpClient {
                     }
                 }
             }
-        } else {
+        } else if self.custom_route {
             info!("acp authenticate skipped (custom route: api_key only)");
+        } else {
+            info!("acp authenticate skipped (unsigned-in: no cached_token)");
         }
         Ok(init)
     }
@@ -6934,8 +6958,18 @@ mod cached_token_route_tests {
         // cached_token reads that file even when GROK_HOME is agent-home.
         // Loading OIDC into a custom-relay process makes Grok Build send OIDC
         // to the relay (HTTP 400/401) — "works until I sign in".
-        assert!(!should_authenticate_cached_token(true));
-        assert!(should_authenticate_cached_token(false));
+        assert!(!should_authenticate_cached_token(true, true));
+        assert!(!should_authenticate_cached_token(true, false));
+    }
+
+    #[test]
+    fn official_route_authenticates_only_when_cached_token_exists() {
+        // Signed-in official: still send authenticate (and keep the #528
+        // re-sync + one retry on soft-fail).
+        assert!(should_authenticate_cached_token(false, true));
+        // Unsigned-in (no auth.json / no usable token): skip entirely.
+        // Sending authenticate here is a 12s × 2 timeout then soft-fail.
+        assert!(!should_authenticate_cached_token(false, false));
     }
 }
 


### PR DESCRIPTION
Fixes #898

Grok app v0.2.26 on Debian 13, Grok CLI 1.0.5, no auth.json/token.

Every workbench launch sent ACP authenticate, 12s timeout, retry, then soft-fail (~24s ERROR).

Logs (UTC): acp authenticate id=2 at 2026-08-24T13:24:35Z, timeout 13:24:47Z, retry id=3 timeout + soft-fail 13:24:59Z.

Expected: no authenticate RPC when not signed in. This PR skips authenticate when read_auth_profile().signed_in is false; signed-in missing-token path (#528) unchanged.