### PR TITLE
fix: do not snapshot() while holding inner (connect no-op deadlock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- **Session API second turn no longer deadlocks on already-live connect (#905)**: `connect_inner` held `inner` and then called `snapshot()`, which locks `inner` again (`parking_lot` is not reentrant). The thread never returned, so `connect_lock` stayed busy forever and later `POST /turns` got 503 `retry_later`. Already-live and fork-busy now snapshot from the held lock.
+
+**中文 · 修复**
+- **Session API 第二轮不再在 already-live connect 上死锁（#905）**：`connect_inner` 握着 `inner` 再调 `snapshot()`，而 `snapshot()` 会再锁一次（`parking_lot` 不可重入）。线程回不来，`connect_lock` 一直 busy，后续 `POST /turns` 变成 503 `retry_later`。already-live / fork-busy 改为从已持有的锁做 snapshot。
+
 ## [0.2.26] - 2026-08-24
 
 > **Highlight:** Import Grok Build CLI sessions from Account; phone mirror on the same Wi-Fi; Windows permission/rewind clicks; long chats stay scrollable.

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -2092,7 +2092,7 @@ mod connect_preserve_tests {
         let mut guard = mgr.inner.lock();
         *guard = Some(ready_live_for_snapshot_lock("sess-already-live"));
         let t0 = Instant::now();
-        let snap = SessionManager::snapshot_locked(&*guard);
+        let snap = SessionManager::snapshot_locked(&guard);
         assert!(
             t0.elapsed() < Duration::from_millis(200),
             "snapshot_locked must not re-acquire inner; took {:?}",

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -345,7 +345,8 @@ impl SessionManager {
                                 "connect fork pending but live mid-turn; deferring fork sid={}",
                                 meta.id
                             );
-                            return Ok(self.snapshot());
+                            // `inner` is held — never `self.snapshot()` (non-reentrant).
+                            return Ok(Self::snapshot_from_live(s));
                         }
                         let process_id = s.process_id.clone();
                         let acp = s.acp.take();
@@ -430,7 +431,8 @@ impl SessionManager {
                             Self::live_session_is_busy(s),
                             preserve
                         );
-                        return Ok(self.snapshot());
+                        // `inner` is held — never `self.snapshot()` (non-reentrant).
+                        return Ok(Self::snapshot_from_live(s));
                     }
                 }
             }
@@ -2000,6 +2002,109 @@ mod connect_preserve_tests {
         assert!(!s.prompt_in_flight);
         assert!(s.streaming_message_id.is_none());
         assert!(!SessionManager::should_preserve_live_process(&s));
+    }
+
+    fn ready_live_for_snapshot_lock(id: &str) -> LiveSession {
+        let mut fsm = SessionFsm::new();
+        let _ = fsm.start_connect();
+        let _ = fsm.handshake_ok();
+        let now = Instant::now();
+        LiveSession {
+            app_session_id: id.into(),
+            process_id: "process-already-live".into(),
+            meta: SessionMeta {
+                id: id.into(),
+                project_id: None,
+                title: "Already live".into(),
+                agent_session_id: Some("agent-1".into()),
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                model_id: None,
+                archived: false,
+                pinned: false,
+                effort: None,
+                mode: None,
+                permission_policy: None,
+                json_schema: None,
+                scheduled: false,
+                worktree_path: None,
+                worktree_branch: None,
+                is_worktree_session: false,
+                plugin_dirs: Vec::new(),
+                extra_rules: None,
+                max_agent_turns: None,
+                system_prompt_override: None,
+                fork_agent_session: false,
+                fork_rewind_prompt_index: None,
+                no_ask_user: None,
+            },
+            fsm,
+            backend: "grok_agent_stdio".into(),
+            acp: None,
+            mock_stream: None,
+            streaming_message_id: None,
+            active_turn_id: None,
+            stream_message_id_locked: false,
+            stream_buf: String::new(),
+            stream_thought: String::new(),
+            stream_last_was_assistant: false,
+            stream_attachments: Vec::new(),
+            model_id: None,
+            effort: None,
+            product_mode: None,
+            project_path: Some("/tmp".into()),
+            allow_cache: SessionAllowCache::default(),
+            policy: PermissionPolicy::default(),
+            provider_retry_attempt: 0,
+            provider_retry_aborted: false,
+            needs_history_bootstrap: false,
+            pending_plan_rpc_id: None,
+            pending_permission_rpc_id: None,
+            pending_permission_options: None,
+            pending_permission_tool_name: None,
+            pending_permission_ui: None,
+            pending_ask_user_rpc_id: None,
+            last_activity: now,
+            last_stream_progress: now,
+            last_stall_emit: None,
+            stall_soft_emits: 0,
+            journal_throttle: JournalWriteThrottle::with_default_interval(),
+            open_tool_ids: HashSet::new(),
+            open_tool_seen_at: HashMap::new(),
+            terminal_tool_ids: HashSet::new(),
+            deferred_prompt_complete: None,
+            tools_this_turn: 0,
+            saw_model_output: false,
+            prompt_in_flight: false,
+            sent_prompt_this_visit: false,
+            pending_stream_emit: None,
+            stream_emit_flush_gen: 0,
+            last_tool_heartbeat_emit: None,
+        }
+    }
+
+    #[test]
+    fn already_live_snapshot_while_holding_inner_does_not_relock() {
+        // Repro #905: already-live / fork-busy used to `return Ok(self.snapshot())`
+        // while `inner` was held. `snapshot()` re-locks `inner`; parking_lot is
+        // not reentrant → connect_inner never returns → connect_lock wedges.
+        let mgr = SessionManager::new();
+        let mut guard = mgr.inner.lock();
+        *guard = Some(ready_live_for_snapshot_lock("sess-already-live"));
+        let t0 = Instant::now();
+        let snap = SessionManager::snapshot_locked(&*guard);
+        assert!(
+            t0.elapsed() < Duration::from_millis(200),
+            "snapshot_locked must not re-acquire inner; took {:?}",
+            t0.elapsed()
+        );
+        assert_eq!(snap.session_id.as_deref(), Some("sess-already-live"));
+        assert_eq!(snap.state, SessionState::Ready);
+        assert_eq!(snap.agent_session_id.as_deref(), Some("agent-1"));
+        // Same helper the already-live / fork-busy returns now use.
+        let from_live = SessionManager::snapshot_from_live(guard.as_ref().unwrap());
+        assert_eq!(from_live.session_id, snap.session_id);
+        assert_eq!(from_live.state, snap.state);
     }
 }
 

--- a/src-tauri/src/session_manager/process.rs
+++ b/src-tauri/src/session_manager/process.rs
@@ -1223,8 +1223,16 @@ impl SessionManager {
     }
 
     pub fn snapshot(&self) -> SessionSnapshot {
-        let guard = self.inner.lock();
-        match guard.as_ref() {
+        Self::snapshot_locked(&self.inner.lock())
+    }
+
+    /// Snapshot from an already-held `inner` guard.
+    ///
+    /// `parking_lot::Mutex` is not reentrant — callers that already hold
+    /// `inner` must use this (or [`Self::snapshot_from_live`]) instead of
+    /// [`Self::snapshot`], which would deadlock.
+    pub(super) fn snapshot_locked(inner: &Option<LiveSession>) -> SessionSnapshot {
+        match inner.as_ref() {
             None => SessionSnapshot {
                 session_id: None,
                 agent_session_id: None,
@@ -1236,17 +1244,7 @@ impl SessionManager {
                 project_path: None,
                 title: String::new(),
             },
-            Some(s) => SessionSnapshot {
-                session_id: Some(s.app_session_id.clone()),
-                agent_session_id: s.meta.agent_session_id.clone(),
-                state: s.fsm.state(),
-                last_error: s.fsm.last_error().cloned(),
-                streaming_message_id: s.streaming_message_id.clone(),
-                backend: s.backend.clone(),
-                model_id: s.model_id.clone(),
-                project_path: s.project_path.clone(),
-                title: s.meta.title.clone(),
-            },
+            Some(s) => Self::snapshot_from_live(s),
         }
     }
 


### PR DESCRIPTION
Fixes #905

## Problem
On the already-live path, `connect` held the `parking_lot` `inner` lock and then called `snapshot()`, which tries to lock `inner` again. `parking_lot` mutexes are not reentrant, so the thread self-deadlocked while still holding `connect_lock`. The first turn appeared to hang, and any second Session API turn deadlocked on `connect_lock` (surfacing as retry_later / no-op connect never returning).

## Fix
Take the snapshot from data already available under the held lock instead of re-locking: use `snapshot_from_live` / `snapshot_locked` in the already-live branch, so `inner` is locked exactly once and `connect_lock` is released normally.

The fork-busy branch had the same pattern (holding `inner` and calling `snapshot()`) and is fixed the same way.