### PR TITLE
清理聊天界面零消费 CSS 样式

### DIFF
--- a/src/components/lobe-chat/lobe-chat.part1.css
+++ b/src/components/lobe-chat/lobe-chat.part1.css
@@ -509,29 +509,6 @@ html[data-msg-actions="always"] .lobe-chat-item__actions {
   text-underline-offset: 2px;
 }
 
-/* File path / name links (blue + doc icon) */
-.chat-md__file-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  color: var(--chat-link);
-  text-decoration: none;
-  font-size: var(--chat-fs);
-  line-height: var(--chat-lh);
-  vertical-align: baseline;
-  max-width: 100%;
-}
-.chat-md__file-link:hover {
-  color: var(--chat-link-hover);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-.chat-md__file-link span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 /* Inline code / tags — always readable on both themes */
 .chat-md__inline-code,
 .chat-md :not(pre) > code {

--- a/src/components/lobe-chat/lobe-chat.part2b.css
+++ b/src/components/lobe-chat/lobe-chat.part2b.css
@@ -173,7 +173,7 @@
   line-height: 0;
   color: currentColor;
 }
-/* Collapse wrap() size so SVG fills the 14×14 slot (same as live-tool mark). */
+/* Collapse wrap() size so SVG fills the 14×14 end-turn mark slot. */
 .lobe-end-turn__mark .g-icon {
   width: 14px !important;
   height: 14px !important;

--- a/src/components/lobe-chat/lobe-chat.part2b.css
+++ b/src/components/lobe-chat/lobe-chat.part2b.css
@@ -146,69 +146,7 @@
   white-space: nowrap;
 }
 
-/* Quiet thinking / cancel rows (shared chrome) */
-.lobe-chat-live-tool {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-  margin: 2px 0 6px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--chat-text-2);
-  font-size: var(--chat-fs-sm);
-  line-height: 1.35;
-  min-height: 20px;
-}
-.lobe-chat-live-tool__mark {
-  display: inline-flex;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  width: 14px;
-  height: 14px;
-  color: var(--chat-text-3);
-}
-.lobe-chat-live-tool__title {
-  min-width: 0;
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--chat-text-2);
-  font-weight: 400;
-}
-.lobe-chat-live-tool.is-running .lobe-chat-live-tool__title,
-.lobe-chat-live-tool__title--pulse {
-  color: var(--chat-text);
-}
-/* Must match .lobe-chat-thinking__dot--live (was 1.4s vs 1.2s → visible desync). */
-.lobe-chat-live-tool__title--pulse {
-  animation: chat-live-pulse 1.2s ease-in-out infinite;
-}
-.lobe-chat-live-tool__done {
-  display: block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: color-mix(in srgb, var(--chat-text-3, #6e6e73) 55%, transparent);
-}
-.lobe-chat-live-tool__x {
-  font-size: 12px;
-  line-height: 1;
-  color: var(--chat-danger, #e55);
-}
-.lobe-chat-live-tool.is-failed .lobe-chat-live-tool__title {
-  color: var(--chat-danger, #e55);
-}
-.lobe-chat-live-tool--cancel {
-  color: var(--chat-text-3);
-}
-
-/* End-of-turn chip — match .lobe-chat-live-tool quiet chrome metrics */
+/* End-of-turn chip — quiet chrome metrics (20px row, 14px mark, fs-sm) */
 .lobe-end-turn {
   display: flex;
   align-items: center;
@@ -533,4 +471,3 @@
 .lobe-msg-rail__list {
   pointer-events: auto;
 }
-

--- a/src/components/lobe-chat/lobe-chat.part3.css
+++ b/src/components/lobe-chat/lobe-chat.part3.css
@@ -452,12 +452,6 @@
   line-height: 1.2;
 }
 
-.lobe-chat .att-card__path,
-.lobe-chat .att-card__sub,
-.lobe-chat .att-card__open {
-  display: none !important;
-}
-
 .lobe-chat .att-card__btn--image,
 .lobe-chat .att-card__thumb {
   width: var(--attach-h);

--- a/src/styles/chat.part2.css
+++ b/src/styles/chat.part2.css
@@ -525,28 +525,3 @@ button.skill-chip__chat-main--btn {
   color: var(--text-primary);
   background: var(--bg-hover);
 }
-
-.composer__editing-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 2px 4px 0;
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-
-.composer__editing-cancel {
-  border: none;
-  background: transparent;
-  padding: 2px 6px;
-  border-radius: 6px;
-  font-size: 12px;
-  color: var(--accent);
-  cursor: pointer;
-}
-
-.composer__editing-cancel:hover {
-  background: var(--bg-hover);
-}
-

--- a/src/styles/chat.part3.css
+++ b/src/styles/chat.part3.css
@@ -208,12 +208,6 @@
   text-align: left;
 }
 
-/* Path available via tooltip */
-.att-card__path,
-.att-card__sub {
-  display: none;
-}
-
 /* Markdown inline images — STABLE CHAT FRAME
  *
  * Chat cards: fixed 150px height (inline style) so image decode / natural-ratio
@@ -586,17 +580,6 @@
   line-height: 1.35;
 }
 
-/* Path never shown on card */
-.file-path-card__sub,
-.file-path-card__path {
-  display: none !important;
-}
-
-.file-path-card--missing {
-  opacity: 0.72;
-  border-style: dashed;
-}
-
 /* Details dialog for file / URL cards */
 .file-path-details-overlay {
   z-index: 13000;
@@ -762,10 +745,6 @@ html[data-composer-min-rows="8"] .composer__input {
 /* Auth / provider gate soft-unavailable — still clickable for toast honesty. */
 .composer__voice.composer__voice--unavailable {
   opacity: 0.45;
-}
-
-.composer__voice-live.is-on {
-  color: var(--accent, #5b8def);
 }
 
 @keyframes composer-voice-pulse {

--- a/src/styles/chat.part4.css
+++ b/src/styles/chat.part4.css
@@ -90,28 +90,6 @@
   color: var(--text-tertiary);
 }
 
-/* Session file-changes chip (composer row) — opens Resources → Changes */
-.chip--changes {
-  font-variant-numeric: tabular-nums;
-  max-width: 120px;
-}
-
-.chip--changes .chip__label--nums {
-  font-feature-settings: "tnum";
-  letter-spacing: 0.01em;
-}
-
-/* Workspace git dirty chip (composer row) — opens Resources → Changes */
-.chip--git-dirty {
-  font-variant-numeric: tabular-nums;
-  max-width: 120px;
-}
-
-.chip--git-dirty .chip__label--nums {
-  font-feature-settings: "tnum";
-  letter-spacing: 0.01em;
-}
-
 .ctx-chip {
   display: inline-flex;
   flex-shrink: 0;

--- a/src/styles/chat.part6.css
+++ b/src/styles/chat.part6.css
@@ -369,35 +369,6 @@
   filter: brightness(1.06);
 }
 
-.entry-grid {
-  display: grid;
-  gap: 10px;
-  margin: var(--space-4) 0;
-}
-
-.entry-card {
-  text-align: left;
-  padding: 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-main);
-}
-
-.entry-card:hover {
-  border-color: var(--border-strong);
-  background: var(--bg-hover);
-}
-
-.entry-card__t {
-  font-weight: 600;
-  margin-bottom: 4px;
-}
-
-.entry-card__d {
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-
 .field {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 基线

- 基于官方 `main@fcfa63d3`。
- 本批仅清理聊天与 composer 样式分片，不改变组件行为或数据逻辑。

## 改动

- 删除已无运行时消费者的旧 file link、live tool、附件路径、编辑栏、changes/git chip、voice live 与 entry card 样式。
- 保留并复核现行 `composer__context-item--*`、`composer__voice--live`、附件/文件卡、`lobe-end-turn` 与 ResourceViewer changes 样式。
- 共修改 7 个 CSS 文件，净删除 189 行。

## 验证

- `pnpm test`：523 个测试文件、6661 项通过。
- `pnpm lint` 通过。
- `pnpm typecheck` 通过。
- `pnpm build:ui` 通过。
- `python3 scripts/check-code-quality-gates.py --mode final` 通过。
- 聊天 CSS 守卫：3 个文件、17 项通过。
- `git diff --check` 通过。