### PR TITLE
修复会话完成后文件树刷新延迟

### DIFF
--- a/src/components/side-workbench/FilesWorkspace.test.tsx
+++ b/src/components/side-workbench/FilesWorkspace.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@/test/jsdomStubs";
+import type { SessionFileChange } from "@/lib/sessionChanges";
+import { FilesWorkspace } from "./FilesWorkspace";
+
+const apiMocks = vi.hoisted(() => ({
+  fsListDir: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  isTauri: () => true,
+  fsListDir: apiMocks.fsListDir,
+  settingsGet: vi.fn(),
+  settingsSet: vi.fn(),
+}));
+
+vi.mock("@/components/OpenLocationButton", () => ({
+  OpenLocationButton: () => null,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/components/resource-viewer/useResourceFileTabs", () => ({
+  useResourceFileTabs: () => ({
+    activeTab: null,
+    openFile: vi.fn(),
+    openAbsoluteFile: vi.fn(),
+    updateActiveDraft: vi.fn(),
+    saveActiveFile: vi.fn(),
+    revertActiveDraft: vi.fn(),
+    toggleActiveEditMode: vi.fn(),
+    filesTabsEmpty: null,
+    dirtyPaths: [],
+    closeByPath: vi.fn(() => true),
+    discardTabId: null,
+    setDiscardTabId: vi.fn(),
+    closeTabForced: vi.fn(),
+    conflictTabId: null,
+    setConflictTabId: vi.fn(),
+    reloadActiveFile: vi.fn(),
+  }),
+}));
+
+const dir = (name: string) => ({
+  name,
+  relativePath: name,
+  isDir: true,
+  size: 0,
+  ext: "",
+});
+
+const file = (path: string) => ({
+  name: path.split("/").at(-1) || path,
+  relativePath: path,
+  isDir: false,
+  size: 1,
+  ext: "ts",
+});
+
+const change = (path: string, updatedAt: string): SessionFileChange => ({
+  path,
+  name: path.split("/").at(-1) || path,
+  toolKind: "write",
+  status: "completed",
+  updatedAt,
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  apiMocks.fsListDir.mockReset();
+});
+
+describe("FilesWorkspace session-change refresh", () => {
+  it("refreshes once per path set, catches up after hidden, and preserves expanded children on failure", async () => {
+    let phase = 0;
+    apiMocks.fsListDir.mockImplementation(
+      async (_projectPath: string, relativePath: string) => {
+        if (!relativePath) {
+          return [dir("src"), ...(phase > 0 ? [file("README.md")] : [])];
+        }
+        if (relativePath !== "src") return [];
+        if (phase === 3) throw new Error("nested read failed");
+        return [
+          file("src/old.ts"),
+          ...(phase > 0 ? [file("src/fresh.ts")] : []),
+          ...(phase > 1 ? [file("src/hidden.ts")] : []),
+        ];
+      },
+    );
+
+    const props = {
+      locale: "en",
+      projectPath: "/repo",
+      projectName: "repo",
+      treeVisible: true,
+      onTreeVisibleChange: vi.fn(),
+      paneActive: true,
+      sessionChanges: [] as SessionFileChange[],
+    };
+    const view = render(<FilesWorkspace {...props} />);
+
+    const src = await screen.findByText("src");
+    await userEvent.click(src.closest("button")!);
+    expect(await screen.findByText("old.ts")).toBeInTheDocument();
+    expect(apiMocks.fsListDir).toHaveBeenCalledTimes(2);
+
+    phase = 1;
+    view.rerender(
+      <FilesWorkspace
+        {...props}
+        sessionChanges={[change("src/fresh.ts", "2026-08-25T01:00:00Z")]}
+      />,
+    );
+    expect(await screen.findByText("fresh.ts")).toBeInTheDocument();
+    expect(apiMocks.fsListDir).toHaveBeenCalledTimes(4);
+
+    view.rerender(
+      <FilesWorkspace
+        {...props}
+        sessionChanges={[change("src/fresh.ts", "2026-08-25T02:00:00Z")]}
+      />,
+    );
+    await waitFor(() => expect(apiMocks.fsListDir).toHaveBeenCalledTimes(4));
+
+    phase = 2;
+    view.rerender(
+      <FilesWorkspace
+        {...props}
+        paneActive={false}
+        sessionChanges={[change("src/hidden.ts", "2026-08-25T03:00:00Z")]}
+      />,
+    );
+    await waitFor(() => expect(apiMocks.fsListDir).toHaveBeenCalledTimes(4));
+
+    view.rerender(
+      <FilesWorkspace
+        {...props}
+        sessionChanges={[change("src/hidden.ts", "2026-08-25T03:00:00Z")]}
+      />,
+    );
+    expect(await screen.findByText("hidden.ts")).toBeInTheDocument();
+    expect(apiMocks.fsListDir).toHaveBeenCalledTimes(6);
+
+    phase = 3;
+    view.rerender(
+      <FilesWorkspace
+        {...props}
+        sessionChanges={[change("src/failed.ts", "2026-08-25T04:00:00Z")]}
+      />,
+    );
+    await waitFor(() => expect(apiMocks.fsListDir).toHaveBeenCalledTimes(8));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "nested read failed",
+    );
+    expect(screen.getByText("hidden.ts")).toBeInTheDocument();
+  });
+});

--- a/src/components/side-workbench/FilesWorkspace.test.tsx
+++ b/src/components/side-workbench/FilesWorkspace.test.tsx
@@ -3,7 +3,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@/test/jsdomStubs";
 import type { SessionFileChange } from "@/lib/sessionChanges";
@@ -65,12 +65,18 @@ const file = (path: string) => ({
   ext: "ts",
 });
 
-const change = (path: string, updatedAt: string): SessionFileChange => ({
+const change = (
+  path: string,
+  updatedAt: string,
+  status = "completed",
+  toolCallId = `call:${path}`,
+): SessionFileChange => ({
   path,
   name: path.split("/").at(-1) || path,
   toolKind: "write",
-  status: "completed",
+  status,
   updatedAt,
+  toolCallId,
 });
 
 afterEach(() => {
@@ -117,7 +123,30 @@ describe("FilesWorkspace session-change refresh", () => {
     view.rerender(
       <FilesWorkspace
         {...props}
-        sessionChanges={[change("src/fresh.ts", "2026-08-25T01:00:00Z")]}
+        sessionChanges={[
+          change(
+            "src/fresh.ts",
+            "2026-08-25T01:00:00Z",
+            "in_progress",
+            "call:fresh",
+          ),
+        ]}
+      />,
+    );
+    await waitFor(() => expect(apiMocks.fsListDir).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText("fresh.ts")).not.toBeInTheDocument();
+
+    view.rerender(
+      <FilesWorkspace
+        {...props}
+        sessionChanges={[
+          change(
+            "src/fresh.ts",
+            "2026-08-25T01:00:01Z",
+            "completed",
+            "call:fresh",
+          ),
+        ]}
       />,
     );
     expect(await screen.findByText("fresh.ts")).toBeInTheDocument();
@@ -126,7 +155,14 @@ describe("FilesWorkspace session-change refresh", () => {
     view.rerender(
       <FilesWorkspace
         {...props}
-        sessionChanges={[change("src/fresh.ts", "2026-08-25T02:00:00Z")]}
+        sessionChanges={[
+          change(
+            "src/fresh.ts",
+            "2026-08-25T02:00:00Z",
+            "completed",
+            "call:fresh",
+          ),
+        ]}
       />,
     );
     await waitFor(() => expect(apiMocks.fsListDir).toHaveBeenCalledTimes(4));
@@ -162,5 +198,63 @@ describe("FilesWorkspace session-change refresh", () => {
       "nested read failed",
     );
     expect(screen.getByText("hidden.ts")).toBeInTheDocument();
+  });
+
+  it("discards an older soft refresh when a newer completed revision wins", async () => {
+    let resolveStale!: (value: ReturnType<typeof file>[]) => void;
+    const staleRead = new Promise<ReturnType<typeof file>[]>((resolve) => {
+      resolveStale = resolve;
+    });
+    let rootReads = 0;
+    apiMocks.fsListDir.mockImplementation(
+      async (_projectPath: string, relativePath: string) => {
+        if (relativePath) return [];
+        rootReads += 1;
+        if (rootReads === 1) return [file("base.ts")];
+        if (rootReads === 2) return staleRead;
+        return [file("latest.ts")];
+      },
+    );
+
+    const props = {
+      locale: "en",
+      projectPath: "/repo",
+      projectName: "repo",
+      treeVisible: true,
+      onTreeVisibleChange: vi.fn(),
+      paneActive: true,
+      sessionChanges: [] as SessionFileChange[],
+    };
+    const view = render(<FilesWorkspace {...props} />);
+    expect(await screen.findByText("base.ts")).toBeInTheDocument();
+
+    view.rerender(
+      <FilesWorkspace
+        {...props}
+        sessionChanges={[
+          change("same.ts", "2026-08-25T05:00:00Z", "completed", "call:1"),
+        ]}
+      />,
+    );
+    await waitFor(() => expect(apiMocks.fsListDir).toHaveBeenCalledTimes(2));
+
+    view.rerender(
+      <FilesWorkspace
+        {...props}
+        sessionChanges={[
+          change("same.ts", "2026-08-25T05:00:01Z", "completed", "call:2"),
+        ]}
+      />,
+    );
+    expect(await screen.findByText("latest.ts")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveStale([file("stale.ts")]);
+      await staleRead;
+    });
+    await waitFor(() => {
+      expect(screen.getByText("latest.ts")).toBeInTheDocument();
+      expect(screen.queryByText("stale.ts")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/side-workbench/FilesWorkspace.tsx
+++ b/src/components/side-workbench/FilesWorkspace.tsx
@@ -229,33 +229,59 @@ export function FilesWorkspace({
     saveTreeExpanded(projectPath, expanded);
   }, [expanded, projectPath]);
 
-  const sessionChangeKey = useMemo(
-    () => sessionChangePathsKey(sessionChanges.map((change) => change.path)),
-    [sessionChanges],
-  );
-  const sessionChangeKeySeen = useRef("");
+  const { sessionChangeRevisionKey, completedChangeRevisionKey } = useMemo(() => {
+    const revisions = sessionChanges.map((change) => {
+      const status = change.status.trim().toLowerCase();
+      return {
+        key: `${change.path}\u001f${change.toolCallId?.trim() || ""}\u001f${status}`,
+        status,
+      };
+    });
+    return {
+      sessionChangeRevisionKey: sessionChangePathsKey(
+        revisions.map((revision) => revision.key),
+      ),
+      completedChangeRevisionKey: sessionChangePathsKey(
+        revisions
+          .filter((revision) => revision.status === "completed")
+          .map((revision) => revision.key),
+      ),
+    };
+  }, [sessionChanges]);
+  const sessionChangeRevisionSeen = useRef("");
+  const completedChangeRevisionSeen = useRef("");
+  const softRefreshGeneration = useRef(0);
   const expandedRef = useRef(expanded);
   const rootRef = useRef(root);
   expandedRef.current = expanded;
   rootRef.current = root;
 
   useEffect(() => {
-    sessionChangeKeySeen.current = "";
+    sessionChangeRevisionSeen.current = "";
+    completedChangeRevisionSeen.current = "";
+    softRefreshGeneration.current += 1;
   }, [projectPath]);
 
   const softRefreshTree = useCallback(async () => {
     if (!projectPath) return;
+    const generation = ++softRefreshGeneration.current;
+    const isCurrent = () => generation === softRefreshGeneration.current;
     const previousRoot = rootRef.current;
+    let refreshError: string | null = null;
     try {
       let next = await loadDir("");
+      if (!isCurrent()) return;
       const openDirs = Object.entries(expandedRef.current)
         .filter(([, open]) => open)
         .map(([path]) => path)
         .filter(Boolean);
       for (const dir of openDirs) {
         try {
-          next = replaceResourceTreeChildren(next, dir, await loadDir(dir));
+          const children = await loadDir(dir);
+          if (!isCurrent()) return;
+          next = replaceResourceTreeChildren(next, dir, children);
         } catch (e) {
+          if (!isCurrent()) return;
           const find = (nodes: TreeNode[]): TreeNode | undefined => {
             for (const node of nodes) {
               if (node.relativePath === dir) return node;
@@ -270,22 +296,33 @@ export function FilesWorkspace({
           if (previousChildren) {
             next = replaceResourceTreeChildren(next, dir, previousChildren);
           }
-          setError(String(e));
+          refreshError = String(e);
         }
       }
+      if (!isCurrent()) return;
+      if (refreshError) setError(refreshError);
       setRoot(next);
     } catch (e) {
-      setError(String(e));
+      if (isCurrent()) setError(String(e));
     }
   }, [loadDir, projectPath]);
 
   useEffect(() => {
     if (!projectPath || !paneActive) return;
-    if (sessionChangeKeySeen.current === sessionChangeKey) return;
-    sessionChangeKeySeen.current = sessionChangeKey;
-    if (!sessionChangeKey) return;
+    if (sessionChangeRevisionSeen.current === sessionChangeRevisionKey) return;
+    sessionChangeRevisionSeen.current = sessionChangeRevisionKey;
+    const completedChanged =
+      completedChangeRevisionSeen.current !== completedChangeRevisionKey;
+    completedChangeRevisionSeen.current = completedChangeRevisionKey;
+    if (!completedChanged || !completedChangeRevisionKey) return;
     void softRefreshTree();
-  }, [sessionChangeKey, projectPath, paneActive, softRefreshTree]);
+  }, [
+    sessionChangeRevisionKey,
+    completedChangeRevisionKey,
+    projectPath,
+    paneActive,
+    softRefreshTree,
+  ]);
 
   // Focus/open when Side Workbench active file path changes.
   // Directories (project root / folder tab) stay on empty preview — never "not a file".

--- a/src/components/side-workbench/FilesWorkspace.tsx
+++ b/src/components/side-workbench/FilesWorkspace.tsx
@@ -51,10 +51,15 @@ import {
   flattenVisibleResourceTree,
   loadTreeExpanded,
   mergeTreeExpandedForFilter,
+  replaceResourceTreeChildren,
   saveTreeExpanded,
+  sessionChangePathsKey,
 } from "@/lib/resourceTree";
 import { isResourceDraftDirty } from "@/lib/resourceEdit";
-import { pathBaseName } from "@/lib/sessionChanges";
+import {
+  pathBaseName,
+  type SessionFileChange,
+} from "@/lib/sessionChanges";
 
 export type FilesWorkspaceProps = {
   locale: Locale | string;
@@ -82,6 +87,7 @@ export type FilesWorkspaceProps = {
   closePathRequest?: { path: string; token: number } | null;
   onClosePathResult?: (path: string, closed: boolean) => void;
   paneActive?: boolean;
+  sessionChanges: SessionFileChange[];
 };
 
 const NOOP = () => {};
@@ -101,6 +107,7 @@ export function FilesWorkspace({
   closePathRequest,
   onClosePathResult,
   paneActive = true,
+  sessionChanges,
 }: FilesWorkspaceProps) {
   const tr = useMemo(() => createT(locale as Locale), [locale]);
   const [root, setRoot] = useState<TreeNode[]>([]);
@@ -181,21 +188,16 @@ export function FilesWorkspace({
   const loadDir = useCallback(
     async (relative: string): Promise<TreeNode[]> => {
       if (!projectPath || !api.isTauri()) return [];
-      try {
-        const entries = await api.fsListDir(projectPath, relative);
-        return (entries || []).map((e) => ({
-          name: e.name,
-          relativePath: e.relativePath || e.name,
-          isDir: !!e.isDir,
-          size: typeof e.size === "number" ? e.size : 0,
-          ext: e.ext || "",
-          children: e.isDir ? [] : undefined,
-          loaded: !e.isDir,
-        }));
-      } catch (e) {
-        setError(String(e));
-        return [];
-      }
+      const entries = await api.fsListDir(projectPath, relative);
+      return (entries || []).map((e) => ({
+        name: e.name,
+        relativePath: e.relativePath || e.name,
+        isDir: !!e.isDir,
+        size: typeof e.size === "number" ? e.size : 0,
+        ext: e.ext || "",
+        children: e.isDir ? [] : undefined,
+        loaded: !e.isDir,
+      }));
     },
     [projectPath],
   );
@@ -206,9 +208,13 @@ export function FilesWorkspace({
       return;
     }
     setLoadingTree(true);
-    const nodes = await loadDir("");
-    setRoot(nodes);
-    setLoadingTree(false);
+    try {
+      setRoot(await loadDir(""));
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoadingTree(false);
+    }
   }, [loadDir, projectPath]);
 
   useEffect(() => {
@@ -222,6 +228,64 @@ export function FilesWorkspace({
     if (!projectPath) return;
     saveTreeExpanded(projectPath, expanded);
   }, [expanded, projectPath]);
+
+  const sessionChangeKey = useMemo(
+    () => sessionChangePathsKey(sessionChanges.map((change) => change.path)),
+    [sessionChanges],
+  );
+  const sessionChangeKeySeen = useRef("");
+  const expandedRef = useRef(expanded);
+  const rootRef = useRef(root);
+  expandedRef.current = expanded;
+  rootRef.current = root;
+
+  useEffect(() => {
+    sessionChangeKeySeen.current = "";
+  }, [projectPath]);
+
+  const softRefreshTree = useCallback(async () => {
+    if (!projectPath) return;
+    const previousRoot = rootRef.current;
+    try {
+      let next = await loadDir("");
+      const openDirs = Object.entries(expandedRef.current)
+        .filter(([, open]) => open)
+        .map(([path]) => path)
+        .filter(Boolean);
+      for (const dir of openDirs) {
+        try {
+          next = replaceResourceTreeChildren(next, dir, await loadDir(dir));
+        } catch (e) {
+          const find = (nodes: TreeNode[]): TreeNode | undefined => {
+            for (const node of nodes) {
+              if (node.relativePath === dir) return node;
+              const nested = node.children?.length
+                ? find(node.children)
+                : undefined;
+              if (nested) return nested;
+            }
+            return undefined;
+          };
+          const previousChildren = find(previousRoot)?.children;
+          if (previousChildren) {
+            next = replaceResourceTreeChildren(next, dir, previousChildren);
+          }
+          setError(String(e));
+        }
+      }
+      setRoot(next);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, [loadDir, projectPath]);
+
+  useEffect(() => {
+    if (!projectPath || !paneActive) return;
+    if (sessionChangeKeySeen.current === sessionChangeKey) return;
+    sessionChangeKeySeen.current = sessionChangeKey;
+    if (!sessionChangeKey) return;
+    void softRefreshTree();
+  }, [sessionChangeKey, projectPath, paneActive, softRefreshTree]);
 
   // Focus/open when Side Workbench active file path changes.
   // Directories (project root / folder tab) stay on empty preview — never "not a file".
@@ -280,18 +344,12 @@ export function FilesWorkspace({
       }
       setExpanded((e) => ({ ...e, [key]: true }));
       if (!node.loaded) {
-        const kids = await loadDir(node.relativePath);
-        const mark = (list: TreeNode[]): TreeNode[] =>
-          list.map((n) => {
-            if (n.relativePath === key) {
-              return { ...n, children: kids, loaded: true };
-            }
-            if (n.children?.length) {
-              return { ...n, children: mark(n.children) };
-            }
-            return n;
-          });
-        setRoot((r) => mark(r));
+        try {
+          const kids = await loadDir(node.relativePath);
+          setRoot((r) => replaceResourceTreeChildren(r, key, kids));
+        } catch (e) {
+          setError(String(e));
+        }
       }
     },
     [expanded, loadDir],

--- a/src/components/side-workbench/SideWorkbench.tsx
+++ b/src/components/side-workbench/SideWorkbench.tsx
@@ -396,6 +396,7 @@ export function SideWorkbench({
                   }
                   onClosePathResult={onClosePathResult}
                   paneActive={paneActive && active.kind === "file"}
+                  sessionChanges={sessionChanges}
                 />
               </div>
             ) : null}


### PR DESCRIPTION
## 问题

关联：#863

Issue #863 的软刷新逻辑仍停留在未被实际界面使用的 ResourceViewer，当前 SideWorkbench 的 FilesWorkspace 没有消费会话文件变化。因此 Agent 新建文件后，右侧文件树需要关闭再打开才能看到。

## 改动

- 将 sessionChanges 传入实际使用的 FilesWorkspace。
- 编辑工具进入 completed 终态后，软刷新根目录和当前已展开目录。
- 保留展开状态、文件选择和读取失败目录的旧子项；隐藏期间的变化在重新显示后补刷。
- 使用 path、toolCallId、status 组成修订键，避免 in_progress 提前消费完成事件。
- 使用代次守卫丢弃过期异步刷新结果，避免旧请求覆盖新文件树。
- 增加终态转换、隐藏补刷、失败保留和并发竞态回归测试。

## 验证

- 初始实现：pnpm test（524 个测试文件 / 6662 项）、pnpm lint、pnpm typecheck、pnpm build:ui、git diff --check。
- 终态与竞态修订：4 个相关测试文件 / 71 项、pnpm lint、pnpm typecheck、git diff --check。

本 PR 仅关联 Issue，不自动关闭。