### PR TITLE
修复账户菜单跟随侧栏宽度与收起生命周期

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -1361,6 +1361,10 @@ export function AppWorkbench() {
     null,
   );
   const [showUserMenu, setShowUserMenu] = useState(false);
+  useEffect(() => {
+    if (!layout.sidebarCollapsed) return;
+    setShowUserMenu(false);
+  }, [layout.sidebarCollapsed]);
   /** Desktop Connect panel (AC7) — close does not stop host. */
 
   /** Phone mirror chrome: WS link + host account summary. */
@@ -13859,7 +13863,7 @@ export function AppWorkbench() {
           onNavigateRemoteIm={() => navigateSettings("remote_im", "im")}
           showUserMenu={showUserMenu}
           setShowUserMenu={setShowUserMenu}
-          closeImmediately={settingsOpen}
+          closeImmediately={settingsOpen || layout.sidebarCollapsed}
           theme={theme}
           themePreference={themePreference}
           account={account}

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -1361,10 +1361,6 @@ export function AppWorkbench() {
     null,
   );
   const [showUserMenu, setShowUserMenu] = useState(false);
-  useEffect(() => {
-    if (!layout.sidebarCollapsed) return;
-    setShowUserMenu(false);
-  }, [layout.sidebarCollapsed]);
   /** Desktop Connect panel (AC7) — close does not stop host. */
 
   /** Phone mirror chrome: WS link + host account summary. */

--- a/src/components/UserMenu.test.tsx
+++ b/src/components/UserMenu.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { expect, it, vi } from "vitest";
+import { UserMenu } from "./UserMenu";
+
+vi.mock("@/lib/floatingMenu", () => ({
+  FLOATING_MENU_Z_INDEX: 13_000,
+  useFloatingMenu: () => ({
+    pos: { top: 100, left: 10 },
+    style: { position: "fixed" },
+    settled: true,
+  }),
+}));
+
+const labels = {
+  settings: "Settings",
+  theme: "Theme",
+  themeSystem: "System",
+  themeLight: "Light",
+  themeDark: "Dark",
+  local: "Local",
+  signedIn: "Signed in",
+  signedOut: "Signed out",
+  login: "Log in",
+  logout: "Log out",
+  remaining: "remaining",
+  profileActive: "Active",
+  switchTo: "Switch to",
+  customProvider: "Custom provider",
+  resetsAt: "Resets",
+};
+
+function Harness({ collapsed }: { collapsed: boolean }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <output data-testid="open">{String(open)}</output>
+      <UserMenu
+        open={open}
+        closeImmediately={collapsed}
+        onClose={() => setOpen(false)}
+        theme="dark"
+        themePreference="dark"
+        locale="en"
+        labels={labels}
+        account={null}
+        activeProvider={null}
+        accountBusy={false}
+        onSettings={() => undefined}
+        onAccountSettings={() => undefined}
+        onTheme={() => undefined}
+        onLogin={() => undefined}
+        onLogout={() => undefined}
+      >
+        <button type="button">Account</button>
+      </UserMenu>
+    </>
+  );
+}
+
+it("clears an open account menu when the sidebar collapses", async () => {
+  const view = render(<Harness collapsed={false} />);
+  expect(document.querySelector(".user-menu__pop--portal")).not.toBeNull();
+
+  view.rerender(<Harness collapsed />);
+  expect(document.querySelector(".user-menu__pop--portal")).toBeNull();
+  await waitFor(() =>
+    expect(screen.getByTestId("open").textContent).toBe("false"),
+  );
+
+  view.rerender(<Harness collapsed={false} />);
+  expect(document.querySelector(".user-menu__pop--portal")).toBeNull();
+});

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -266,9 +266,9 @@ export function UserMenu({
     roots: [rootRef, themeFlyoutRef],
     onClose,
     placement: "up",
-    fitContent: true,
+    width: 0,
+    fitContent: false,
     matchTriggerWidth: true,
-    minWidth: 220,
     estHeight: savedAccounts.length > 1 ? 360 : 260,
     gap: 6,
     // CSS owns transform (rise from the footer). Do not apply placeAbove -100%.

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -201,6 +201,10 @@ export function UserMenu({
     if (!open) setThemeSubOpen(false);
   }, [open]);
 
+  useEffect(() => {
+    if (closeImmediately && open) onClose();
+  }, [closeImmediately, onClose, open]);
+
   const clearCloseTimer = useCallback(() => {
     if (closeTimerRef.current != null) {
       window.clearTimeout(closeTimerRef.current);

--- a/src/lib/floatingMenu.resize.test.tsx
+++ b/src/lib/floatingMenu.resize.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { useFloatingMenu } from "./floatingMenu";
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  readonly targets: Element[] = [];
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.targets.push(target);
+  }
+
+  disconnect() {}
+
+  notify() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+afterEach(() => {
+  FakeResizeObserver.instances = [];
+  vi.unstubAllGlobals();
+});
+
+it("remeasures a matched panel when its trigger width changes", () => {
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+
+  let width = 208;
+  const trigger = document.createElement("div");
+  const panel = document.createElement("div");
+  trigger.getBoundingClientRect = () =>
+    ({
+      top: 600,
+      bottom: 636,
+      left: 10,
+      right: 10 + width,
+      width,
+      height: 36,
+    }) as DOMRect;
+  Object.defineProperties(panel, {
+    offsetWidth: { value: 208 },
+    offsetHeight: { value: 260 },
+  });
+
+  const { result } = renderHook(() =>
+    useFloatingMenu({
+      open: true,
+      triggerRef: { current: trigger },
+      panelRef: { current: panel },
+      onClose: () => undefined,
+      placement: "up",
+      width: 0,
+      fitContent: false,
+      matchTriggerWidth: true,
+    }),
+  );
+
+  const observer = FakeResizeObserver.instances.find((item) =>
+    item.targets.includes(trigger),
+  );
+  expect(observer).toBeDefined();
+  expect(result.current.style?.width).toBe(208);
+
+  act(() => {
+    width = 320;
+    observer?.notify();
+  });
+
+  expect(result.current.style?.width).toBe(320);
+});

--- a/src/lib/floatingMenu.resize.test.tsx
+++ b/src/lib/floatingMenu.resize.test.tsx
@@ -2,13 +2,15 @@
  * @vitest-environment jsdom
  */
 
-import { act, renderHook } from "@testing-library/react";
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { useRef } from "react";
 import { afterEach, expect, it, vi } from "vitest";
 import { useFloatingMenu } from "./floatingMenu";
 
 class FakeResizeObserver {
   static instances: FakeResizeObserver[] = [];
   readonly targets: Element[] = [];
+  disconnected = false;
 
   constructor(private readonly callback: ResizeObserverCallback) {
     FakeResizeObserver.instances.push(this);
@@ -18,7 +20,9 @@ class FakeResizeObserver {
     this.targets.push(target);
   }
 
-  disconnect() {}
+  disconnect() {
+    this.disconnected = true;
+  }
 
   notify() {
     this.callback([], this as unknown as ResizeObserver);
@@ -75,4 +79,91 @@ it("remeasures a matched panel when its trigger width changes", () => {
   });
 
   expect(result.current.style?.width).toBe(320);
+});
+
+it("observes a panel mounted after the first position pass", async () => {
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+
+  let panelHeight = 120;
+  function Harness({ open }: { open: boolean }) {
+    const triggerRef = useRef<HTMLDivElement>(null);
+    const panelRef = useRef<HTMLDivElement>(null);
+    const { pos } = useFloatingMenu({
+      open,
+      triggerRef,
+      panelRef,
+      onClose: () => undefined,
+      placement: "up",
+      width: 200,
+      fitContent: false,
+    });
+
+    return (
+      <>
+        <div
+          data-testid="trigger"
+          ref={(node) => {
+            triggerRef.current = node;
+            if (!node) return;
+            node.getBoundingClientRect = () =>
+              ({
+                top: 600,
+                bottom: 636,
+                left: 10,
+                right: 210,
+                width: 200,
+                height: 36,
+              }) as DOMRect;
+          }}
+        />
+        {pos ? (
+          <div
+            data-testid="panel"
+            ref={(node) => {
+              panelRef.current = node;
+              if (!node) return;
+              Object.defineProperties(node, {
+                offsetWidth: { configurable: true, get: () => 200 },
+                offsetHeight: {
+                  configurable: true,
+                  get: () => panelHeight,
+                },
+              });
+            }}
+          />
+        ) : null}
+        <output data-testid="top">{pos?.top}</output>
+      </>
+    );
+  }
+
+  const view = render(<Harness open />);
+  const trigger = screen.getByTestId("trigger");
+  const panel = await screen.findByTestId("panel");
+  const panelObserver = await waitFor(() => {
+    const observer = FakeResizeObserver.instances.find((item) =>
+      item.targets.includes(trigger) && item.targets.includes(panel),
+    );
+    expect(observer).toBeDefined();
+    return observer!;
+  });
+  expect(screen.getByTestId("top").textContent).toBe("474");
+
+  act(() => {
+    panelHeight = 200;
+    panelObserver.notify();
+  });
+  expect(screen.getByTestId("top").textContent).toBe("394");
+
+  const openObservers = FakeResizeObserver.instances.slice();
+  view.rerender(<Harness open={false} />);
+  expect(openObservers.every((item) => item.disconnected)).toBe(true);
+
+  view.rerender(<Harness open />);
+  await screen.findByTestId("panel");
+  const reopenedObservers = FakeResizeObserver.instances.filter(
+    (item) => !item.disconnected,
+  );
+  view.unmount();
+  expect(reopenedObservers.every((item) => item.disconnected)).toBe(true);
 });

--- a/src/lib/floatingMenu.test.ts
+++ b/src/lib/floatingMenu.test.ts
@@ -84,6 +84,17 @@ describe("computeFloatingPos", () => {
     expect(pos.width).toBeGreaterThanOrEqual(280);
   });
 
+  it("can match the trigger width exactly", () => {
+    const r = rect({ top: 100, left: 20, width: 208, height: 32 });
+    const pos = computeFloatingPos(r, {
+      width: 0,
+      matchTriggerWidth: true,
+      fitContent: false,
+      placement: "down",
+    });
+    expect(pos.width).toBe(208);
+  });
+
   it("fitContent leaves width 0 (CSS max-content)", () => {
     const r = rect({ top: 100, left: 40, width: 80, height: 28 });
     const pos = computeFloatingPos(r, { placement: "down", fitContent: true });

--- a/src/lib/floatingMenu.ts
+++ b/src/lib/floatingMenu.ts
@@ -386,13 +386,15 @@ export function useFloatingMenu({
     window.addEventListener("resize", onResize);
     window.addEventListener("scroll", onScroll, true);
 
-    // Re-anchor when panel content height changes (e.g. filter shrinks from
-    // 50 rows to 3 — must drop back down to sit on the input, not stay at top).
+    // Re-anchor when either anchor or content changes size. Pane dragging can
+    // resize the trigger without resizing the window.
     let ro: ResizeObserver | null = null;
+    const trigger = triggerRef.current;
     const panel = panelRef.current;
-    if (typeof ResizeObserver !== "undefined" && panel) {
+    if (typeof ResizeObserver !== "undefined" && (trigger || panel)) {
       ro = new ResizeObserver(() => update(true));
-      ro.observe(panel);
+      if (trigger) ro.observe(trigger);
+      if (panel) ro.observe(panel);
     }
 
     return () => {

--- a/src/lib/floatingMenu.ts
+++ b/src/lib/floatingMenu.ts
@@ -405,6 +405,7 @@ export function useFloatingMenu({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     open,
+    !!pos,
     placement,
     align,
     width,

--- a/src/lib/openPresence.test.ts
+++ b/src/lib/openPresence.test.ts
@@ -157,8 +157,11 @@ describe("floating pop CSS", () => {
     expect(appWorkbench).toMatch(
       /closeImmediately=\{settingsOpen \|\| layout\.sidebarCollapsed\}/,
     );
-    expect(appWorkbench).toMatch(
+    expect(appWorkbench).not.toMatch(
       /useEffect\(\(\) => \{\s*if \(!layout\.sidebarCollapsed\) return;\s*setShowUserMenu\(false\);\s*\}, \[layout\.sidebarCollapsed\]\);/,
+    );
+    expect(userMenu).toMatch(
+      /useEffect\(\(\) => \{\s*if \(closeImmediately && open\) onClose\(\);\s*\}, \[closeImmediately, onClose, open\]\);/,
     );
     expect(userMenu).toMatch(
       /useOpenPresence\(\s*open,\s*true,\s*closeImmediately \? 0 : OPEN_PRESENCE_MS,\s*\)/,

--- a/src/lib/openPresence.test.ts
+++ b/src/lib/openPresence.test.ts
@@ -153,11 +153,20 @@ describe("floating pop CSS", () => {
     );
   });
 
-  it("closes the account portal immediately when settings takes over", () => {
-    expect(appWorkbench).toMatch(/closeImmediately=\{settingsOpen\}/);
+  it("closes the account portal immediately when its sidebar disappears", () => {
+    expect(appWorkbench).toMatch(
+      /closeImmediately=\{settingsOpen \|\| layout\.sidebarCollapsed\}/,
+    );
+    expect(appWorkbench).toMatch(
+      /useEffect\(\(\) => \{\s*if \(!layout\.sidebarCollapsed\) return;\s*setShowUserMenu\(false\);\s*\}, \[layout\.sidebarCollapsed\]\);/,
+    );
     expect(userMenu).toMatch(
       /useOpenPresence\(\s*open,\s*true,\s*closeImmediately \? 0 : OPEN_PRESENCE_MS,\s*\)/,
     );
+    expect(userMenu).toMatch(
+      /placement:\s*"up",\s*width:\s*0,\s*fitContent:\s*false,\s*matchTriggerWidth:\s*true,/,
+    );
+    expect(userMenu).not.toMatch(/minWidth:\s*220/);
     expect(userMenu).toMatch(
       /const panel\s*=\s*!closeImmediately\s*&&\s*panelPresence\.mounted/,
     );


### PR DESCRIPTION
## 变更说明

- 账户菜单宽度精确匹配侧栏底部触发区，并通过 ResizeObserver 随侧栏拖拽同步更新。
- 侧栏收起或设置页接管时立即卸载账户菜单，并由 UserMenu 自身清理打开状态。
- 浮层首次定位后重新观察实际挂载的 portal 面板；内容高度变化时重新定位，关闭与卸载时断开观察器。
- 补充宽度变化、延迟挂载、高度变化、收起及观察器断开的回归测试。

## 原因与影响

原实现只在菜单打开时读取一次触发器尺寸，侧栏拖拽后菜单宽度不会同步；收起侧栏时也可能保留已打开的浮层。此次将尺寸观察与浮层生命周期集中到现有 floating menu 能力中，避免 UserMenu 维护重复状态和定位逻辑。

## 验证

- 目标测试：4 个测试文件、30 个测试通过。
- pnpm test：525 个测试文件、6665 个测试通过。
- pnpm lint：通过。
- pnpm typecheck：通过。
- pnpm build:ui：通过；保留既有 Vite chunk 与动态导入提示。
- pnpm deps:check：通过。
- python3 scripts/check-code-quality-gates.py --mode final：通过。
- cargo fmt --all -- --check：通过。
- cargo clippy --all-targets -- -D warnings：通过。
- git diff --check：通过。

## 已知验证边界

- cargo test：1507 个测试通过、1 个失败、1 个忽略。
- 失败用例为 mirror::lan_bind_test::lan_bind_accepts_detected_ipv4；本机检测到 LAN IPv4 时，loopback 监听仍返回 HTTP 200，单独复跑结果相同。
- 本 PR 不含任何 Rust 变更，失败测试文件与 origin/main 的 blob 完全一致，因此未把 cargo test 描述为本 PR 已通过；请主仓 CI 在标准环境复核。

## 范围说明

- 本 PR 不包含 #896 应用图标相关改动。
