### PR TITLE
修复侧栏展开完成后的边界闪烁

### DIFF
--- a/src/hooks/usePaneSplitMotion.test.tsx
+++ b/src/hooks/usePaneSplitMotion.test.tsx
@@ -93,6 +93,38 @@ describe("usePaneSplitMotion", () => {
     expect(isPaneSplitMotionActive()).toBe(false);
   });
 
+  it("does not cover a closed aside when sidebar opening changes its prospective overlay", () => {
+    const closedAside = {
+      ...initialProps,
+      sidebarCollapsed: true,
+      asideCollapsed: true,
+      asideOverlay: false,
+    };
+    const { result, rerender } = renderHook(
+      (props) => usePaneSplitMotion(props),
+      { initialProps: closedAside },
+    );
+
+    rerender({
+      ...closedAside,
+      sidebarCollapsed: false,
+      asideOverlay: true,
+    });
+
+    expect(result.current.paneMotionClass).toContain(
+      "workbench--sidebar-motion",
+    );
+    expect(nativeWebviewCoverDepth()).toBe(0);
+    expect(isPaneSplitMotionActive()).toBe(true);
+
+    act(() => dispatchWidthTransitionEnd("sidebar"));
+    expect(result.current.paneMotionClass).not.toContain(
+      "workbench--sidebar-motion",
+    );
+    expect(nativeWebviewCoverDepth()).toBe(0);
+    expect(isPaneSplitMotionActive()).toBe(false);
+  });
+
   it("covers native webviews while an in-flow aside interpolates", () => {
     const props = {
       ...initialProps,

--- a/src/hooks/usePaneSplitMotion.ts
+++ b/src/hooks/usePaneSplitMotion.ts
@@ -47,7 +47,8 @@ export function usePaneSplitMotion(opts: {
 
   const key = `${opts.sidebarCollapsed}:${opts.asideCollapsed}`;
   const asideOverlay = Boolean(opts.asideOverlay);
-  const asideOverlayModeChanged = asideOverlayRef.current !== asideOverlay;
+  const asideOverlayModeChanged =
+    !opts.asideCollapsed && asideOverlayRef.current !== asideOverlay;
   const asideOverlayMotionChanged =
     asideOverlayModeChanged && (asideOverlay || opts.asideInFlow);
   const sideExpandedChanged = sideExpandedRef.current !== opts.sideExpanded;

--- a/src/hooks/useWorkbenchLayout.ts
+++ b/src/hooks/useWorkbenchLayout.ts
@@ -388,7 +388,7 @@ export function useWorkbenchLayout(opts?: { onAsideClose?: () => void }) {
         ? cur.asideWidth
         : Math.max(cur.asideWidth || 0, DEFAULT_LAYOUT.asideWidth),
     };
-    if (overlay.sidebarOverlay) return;
+    if (overlay.sidebarOverlay || overlay.asideOverlay) return;
     const fitGen = ++sidebarFitGenRef.current;
     void fitWindowThenClampAside(projected).then((width) => {
       if (sidebarFitGenRef.current !== fitGen) return;

--- a/src/lib/openPresence.test.ts
+++ b/src/lib/openPresence.test.ts
@@ -129,7 +129,10 @@ describe("floating pop CSS", () => {
     const blur =
       /backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)\s*saturate\(var\(--sidebar-saturate\)\)/;
     expect(workbenchCss).toMatch(
-      /\.platform-mac \.sidebar\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/,
+      /\.platform-mac \.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/,
+    );
+    expect(workbenchCss).toMatch(
+      /\.platform-mac \.sidebar\.sidebar--overlay,\s*\.platform-mac \.sidebar\.sidebar--phone-drawer\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/s,
     );
     expect(workbenchCss).toMatch(
       /\.platform-mac \.settings-page__nav\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/,

--- a/src/lib/paneOverlay.test.ts
+++ b/src/lib/paneOverlay.test.ts
@@ -1,6 +1,13 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { MAIN_CHAT_MIN_WIDTH } from "@/lib/layout";
 import { resolveWorkbenchPaneOverlay } from "./paneOverlay";
+
+const workbenchLayout = readFileSync(
+  resolve(__dirname, "../hooks/useWorkbenchLayout.ts"),
+  "utf8",
+);
 
 describe("resolveWorkbenchPaneOverlay", () => {
   it("keeps both panes in flow when the window fits chat plus both", () => {
@@ -49,5 +56,15 @@ describe("resolveWorkbenchPaneOverlay", () => {
         asideWidth: 400,
       }),
     ).toEqual({ sidebarOverlay: false, asideOverlay: false });
+  });
+
+  it("does not grow the window when opening the sidebar leaves the aside overlaid", () => {
+    const start = workbenchLayout.indexOf("const openSidebarPane = useCallback");
+    const end = workbenchLayout.indexOf("const closeSidebarPane", start);
+    const openSidebarPane = workbenchLayout.slice(start, end);
+
+    expect(openSidebarPane).toContain(
+      "if (overlay.sidebarOverlay || overlay.asideOverlay) return;",
+    );
   });
 });

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -74,9 +74,10 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(sidebar).toMatch(/\.sidebar__clip/);
     expect(sidebar).toMatch(/opacity:\s*0/);
     expect(sidebar).not.toMatch(/repeating-linear-gradient/);
-    expect(chat).toMatch(
-      /\.workbench--sidebar-motion \.sidebar:not\(\.is-resizing\) \.sidebar__clip/,
+    expect(sidebar).toMatch(
+      /\.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\):not\(\.is-resizing\)[^{]*\.sidebar__clip\s*>\s*\*/s,
     );
+    expect(sidebar).toMatch(/--sidebar-rail-min/);
     expect(chat).toMatch(
       /\.workbench--aside-motion \.aside:not\(\.is-resizing\) \.aside__inner/,
     );
@@ -127,11 +128,11 @@ describe("desktop hidden CSS must not force width 0", () => {
       resolve(__dirname, "../styles/sidebar.part1.css"),
       "utf8",
     );
-    expect(ruleBody(sidebar, "\n.sidebar {")).not.toMatch(
-      /width var\(--motion-pane\)/,
+    expect(ruleBody(sidebar, "\n.sidebar {")).toMatch(
+      /width var\(--motion-pane\)[^,]*,[^}]*min-width var\(--motion-pane\)[^,]*,[^}]*max-width var\(--motion-pane\)[^,]*,[^}]*flex-basis var\(--motion-pane\)/s,
     );
-    expect(sidebar).toMatch(
-      /\.workbench--sidebar-motion\s+\.sidebar:not\(\.is-resizing\):not\(\.sidebar--overlay\)\s*\{[^}]*width var\(--motion-pane\)[^,]*,[^}]*min-width var\(--motion-pane\)[^,]*,[^}]*max-width var\(--motion-pane\)[^,]*,[^}]*flex-basis var\(--motion-pane\)/s,
+    expect(sidebar).not.toMatch(
+      /^\s*\.workbench--sidebar-motion[^\n{]*\.sidebar/m,
     );
     expect(sidebar).not.toMatch(
       /\.sidebar\.sidebar--overlay[^}]*width var\(--motion-pane\)/s,
@@ -333,7 +334,66 @@ describe("desktop hidden CSS must not force width 0", () => {
     );
   });
 
-  it("sidebar-only motion does not overflow-hidden or contain a stable aside", () => {
+  it("does not toggle size transitions on the blur-owning in-flow sidebar", () => {
+    /**
+     * WKWebView rebuilds the backdrop-filter layer when `transition` is
+     * added or removed on `.sidebar`. Size interpolation must live on
+     * `.sidebar` itself; drag still uses `.is-resizing`.
+     */
+    const sidebar = readFileSync(
+      resolve(__dirname, "../styles/sidebar.part1.css"),
+      "utf8",
+    );
+    const body = ruleBody(sidebar, "\n.sidebar {");
+    expect(body).toMatch(/width var\(--motion-pane\)/);
+    expect(body).toMatch(/min-width var\(--motion-pane\)/);
+    expect(body).toMatch(/max-width var\(--motion-pane\)/);
+    expect(body).toMatch(/flex-basis var\(--motion-pane\)/);
+    expect(sidebar).not.toMatch(
+      /^\s*\.workbench--sidebar-motion[^\n{]*\.sidebar/m,
+    );
+  });
+
+  it("does not put backdrop-filter on the interpolating in-flow sidebar", () => {
+    /**
+     * Resizing a blur-owning box flashes (toggle end, live drag, or a
+     * paused drag). In-flow frost is the rail max so its layer never
+     * changes size; extra sits under .main.
+     */
+    const sidebar = readFileSync(
+      resolve(__dirname, "../styles/sidebar.part1.css"),
+      "utf8",
+    );
+    const tokens = readFileSync(
+      resolve(__dirname, "../styles/tokens.css"),
+      "utf8",
+    );
+    expect(tokens).toMatch(/--sidebar-width-max:\s*420px/);
+    const inFlow = ruleBody(
+      sidebar,
+      ".platform-mac .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {",
+    );
+    expect(inFlow).toMatch(/backdrop-filter:\s*none/);
+    expect(inFlow).not.toMatch(/overflow:\s*hidden/);
+    expect(sidebar).toMatch(
+      /\.platform-mac \.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before\s*\{[^}]*width:\s*var\(--sidebar-width-max[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/s,
+    );
+    expect(sidebar).not.toMatch(
+      /\.sidebar\.is-resizing[^{]*::before[^{]*\{[^}]*width:\s*100%/s,
+    );
+    expect(sidebar).not.toMatch(
+      /\.platform-mac \.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before\s*\{[^}]*\btransition\s*:/s,
+    );
+    expect(sidebar).toMatch(
+      /\.platform-mac \.sidebar\.sidebar--overlay,\s*\.platform-mac \.sidebar\.sidebar--phone-drawer\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/s,
+    );
+  });
+
+  it("clips the sidebar contents without changing the blur-owning pane", () => {
+    const sidebar = readFileSync(
+      resolve(__dirname, "../styles/sidebar.part1.css"),
+      "utf8",
+    );
     const css = readFileSync(
       resolve(__dirname, "../styles/chat.part6.css"),
       "utf8",
@@ -341,6 +401,16 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(css).not.toMatch(
       /\.workbench--pane-motion \.aside,\s*\.workbench--pane-motion \.sidebar/,
     );
+    expect(css).not.toMatch(
+      /\.workbench--pane-motion \.sidebar\s*\{[^}]*overflow:\s*hidden/s,
+    );
+    expect(ruleBody(sidebar, "\n.sidebar--hidden,")).not.toMatch(
+      /overflow:\s*hidden/,
+    );
+    expect(ruleBody(sidebar, "\n.sidebar__clip {")).toMatch(
+      /overflow:\s*hidden/,
+    );
+    expect(css).not.toMatch(/\.workbench--sidebar-motion[^,{]*\.sidebar__clip/);
     expect(css).not.toMatch(/\.workbench--sidebar-motion[^{]*\{[^}]*contain:/);
   });
 });

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -166,7 +166,10 @@ describe("wallpaper theme contrast CSS", () => {
 
   it("keeps an expanded wallpaper side pane frosted without exposing chat", () => {
     expect(css).toMatch(
-      /html\[data-wallpaper="1"\]\s+:is\(\.sidebar, \.aside\)\s*\{[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-sidebar-blur, 22px\)\)/s,
+      /html\[data-wallpaper="1"\] \.aside,\s*html\[data-wallpaper="1"\] \.sidebar\.sidebar--overlay,\s*html\[data-wallpaper="1"\] \.sidebar\.sidebar--phone-drawer\s*\{[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-sidebar-blur, 22px\)\)/s,
+    );
+    expect(css).toMatch(
+      /html\[data-wallpaper="1"\]\s+\.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before\s*\{[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-sidebar-blur, 22px\)\)/s,
     );
     expect(css).toMatch(
       /html\[data-stream-perf="1"\]\[data-wallpaper="1"\] \.aside,/,

--- a/src/styles/chat.part6.css
+++ b/src/styles/chat.part6.css
@@ -617,27 +617,13 @@
   pointer-events: none;
 }
 
-/* Clip only the pane whose box is interpolating. Overflow-hidden on a
- * stable aside (file preview / native browser) during sidebar motion
- * changes clientWidth and kicks webview setPosition every frame.
+/* Clip only the right pane whose box is interpolating. Overflow-hidden on
+ * a stable aside (file preview / native browser) during sidebar motion changes
+ * clientWidth and kicks webview setPosition every frame.
  * Do not `contain: layout` the aside — persist-host height:100% then
  * resolves against the full pane and the native webview covers chrome. */
-.workbench--pane-motion .sidebar,
 .workbench--aside-motion .aside {
   overflow: hidden;
-}
-
-/*
- * Click / shortcut collapse is a clip + fade, not a live resize.
- * Inner rail stays at the last open width so labels do not wrap.
- * Drag keeps `.is-resizing` and still reflows.
- */
-.workbench--sidebar-motion .sidebar:not(.is-resizing) .sidebar__clip {
-  width: var(--sidebar-rail-min, 268px);
-  min-width: var(--sidebar-rail-min, 268px);
-  max-width: none;
-  flex-shrink: 0;
-  box-sizing: border-box;
 }
 
 .workbench--aside-motion .aside:not(.is-resizing) .aside__inner {

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -417,14 +417,12 @@ html.platform-win .window-edge-n {
   /* No outer padding — chrome / brand / scroll / footer own their insets */
   padding: 0;
   gap: 0;
-  transition:
-    border-color var(--motion-pane) ease,
-    opacity 180ms ease,
-    filter 180ms ease;
-  z-index: 1;
-}
-
-.workbench--sidebar-motion .sidebar:not(.is-resizing):not(.sidebar--overlay) {
+  /*
+   * Size interpolation lives here. Backdrop-filter must not: WKWebView
+   * rebuilds that layer when a blur-owning box finishes a width
+   * transition (one-frame edge retreat / flash). Overlay / phone /
+   * .is-resizing override this shorthand.
+   */
   transition:
     width var(--motion-pane) var(--motion-pane-ease),
     min-width var(--motion-pane) var(--motion-pane-ease),
@@ -433,6 +431,7 @@ html.platform-win .window-edge-n {
     border-color var(--motion-pane) ease,
     opacity 180ms ease,
     filter 180ms ease;
+  z-index: 1;
 }
 
 /*
@@ -518,13 +517,42 @@ html.platform-win .window-edge-n {
  * Overlay / phone drawers keep their drop shadow (set below).
  */
 .platform-mac .sidebar {
-  -webkit-backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
-  backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
   border-right: none;
 }
 
+.platform-mac .sidebar.sidebar--overlay,
+.platform-mac .sidebar.sidebar--phone-drawer {
+  -webkit-backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
+  backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
+}
+
+/*
+ * In-flow frost is the rail max, not the current width. Resizing the
+ * blur box (toggle interpolation, live drag, or stopping a drag)
+ * rebuilds the WKWebView backdrop layer. Extra frost sits under .main
+ * (z-index 2). Overlay / phone keep blur on the pane (transform).
+ */
 .platform-mac .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {
+  overflow: visible;
+  background: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   box-shadow: var(--sidebar-edge-shadow);
+}
+
+.platform-mac .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer)::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: var(--sidebar-width-max, 420px);
+  background: var(--bg-sidebar);
+  -webkit-backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
+  backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
+  pointer-events: none;
+  z-index: 0;
+  border-radius: inherit;
 }
 
 .platform-mac .sidebar.sidebar--overlay {
@@ -562,7 +590,7 @@ html.platform-mac[data-theme="light"] .workbench {
 
 html.platform-mac[data-theme="light"] .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer),
 .platform-mac[data-theme="light"] .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {
-  background: var(--bg-sidebar);
+  background: transparent;
   border-right: none;
   box-shadow: var(--sidebar-edge-shadow);
 }
@@ -629,7 +657,6 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 .sidebar--collapsed {
   padding: 0 !important;
   border-right-color: transparent;
-  overflow: hidden;
   pointer-events: none;
 }
 
@@ -639,8 +666,21 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   flex: 1;
   min-height: 0;
   min-width: 0;
+  overflow: hidden;
+  box-sizing: border-box;
+  position: relative;
+  z-index: 1;
   opacity: 1;
   transition: opacity var(--motion-pane) ease;
+}
+
+.sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer):not(.is-resizing)
+  .sidebar__clip
+  > * {
+  width: var(--sidebar-rail-min, 268px);
+  min-width: var(--sidebar-rail-min, 268px);
+  max-width: none;
+  box-sizing: border-box;
 }
 
 .sidebar--hidden .sidebar__clip,
@@ -835,4 +875,3 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   background: var(--bg-hover);
   color: var(--text-primary);
 }
-

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -118,6 +118,10 @@ html[data-wallpaper="1"] .sidebar {
     var(--text-primary) 62%,
     transparent
   );
+}
+
+html[data-wallpaper="1"] .sidebar.sidebar--overlay,
+html[data-wallpaper="1"] .sidebar.sidebar--phone-drawer {
   background: color-mix(
     in srgb,
     var(--bg-sidebar-solid, var(--bg-sidebar))
@@ -126,7 +130,27 @@ html[data-wallpaper="1"] .sidebar {
   ) !important;
 }
 
-html[data-wallpaper="1"] :is(.sidebar, .aside) {
+html[data-wallpaper="1"]
+  .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {
+  background: transparent !important;
+}
+
+html[data-wallpaper="1"]
+  .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer)::before {
+  background: color-mix(
+    in srgb,
+    var(--bg-sidebar-solid, var(--bg-sidebar))
+      var(--wallpaper-theme-mix-sidebar),
+    transparent
+  ) !important;
+  backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px)) saturate(1.25);
+  -webkit-backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px))
+    saturate(1.25);
+}
+
+html[data-wallpaper="1"] .aside,
+html[data-wallpaper="1"] .sidebar.sidebar--overlay,
+html[data-wallpaper="1"] .sidebar.sidebar--phone-drawer {
   backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px)) saturate(1.25);
   -webkit-backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px))
     saturate(1.25);
@@ -249,6 +273,7 @@ html[data-wallpaper="1"] .platform-mac .settings-page__nav {
  */
 html[data-stream-perf="1"][data-wallpaper="1"] .app-settings-stage,
 html[data-stream-perf="1"][data-wallpaper="1"] .sidebar,
+html[data-stream-perf="1"][data-wallpaper="1"] .sidebar::before,
 html[data-stream-perf="1"][data-wallpaper="1"] .aside,
 html[data-stream-perf="1"][data-wallpaper="1"] .settings-page__nav,
 html[data-stream-perf="1"][data-wallpaper="1"] .platform-win .settings-page__nav,
@@ -331,6 +356,7 @@ html[data-wallpaper="1"][data-wallpaper-clear="1"] .app-shell::after {
 
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .app-settings-stage,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .sidebar,
+html[data-wallpaper="1"][data-wallpaper-clear="1"] .sidebar::before,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .main,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .aside,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .settings-page,

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -27,8 +27,9 @@
   --space-7: 32px;
   --space-8: 48px;
 
-  /* Keep in sync with SIDEBAR_DEFAULT_WIDTH in layout.ts */
+  /* Keep in sync with SIDEBAR_DEFAULT_WIDTH / SIDEBAR_WIDTH_MAX in layout.ts */
   --sidebar-width: 268px;
+  --sidebar-width-max: 420px;
   /*
    * Sidebar tree columns (nav icons, L1 chevron, L2 name, L3 title).
    * Change values here only — consumers use var() with no px fallback.


### PR DESCRIPTION
## 问题

WKWebView 在带 backdrop-filter 的侧栏宽度层结束插值时会重建模糊图层，导致侧栏右边界到位后回退并闪烁；关闭状态的右栏模式变化还会误触发原生视图遮盖。

## 改动

- 将流内侧栏的模糊固定到不参与宽度插值的伪元素，内容裁切下沉到内部 clip
- 仅在右栏实际打开时处理 overlay 模式变化
- 双侧 overlay 场景不再触发窗口扩宽
- 清理旧侧栏动效分支，并同步壁纸与 stream-perf 样式
- 测试跟随当前 useWorkbenchLayout 公共布局入口

## 验证

- 相关 Vitest：5 个文件、62 项通过
- pnpm lint
- pnpm typecheck
- pnpm build:ui
- final quality gate
- git diff --check
- 用户在 macOS Tauri 开发版实机确认闪烁消失

## 风险边界

WKWebView 合成行为无法由 jsdom 单测完整模拟，已由实机验证覆盖。