### PR TITLE
修复 macOS 侧栏宽度动画的 vibrancy 闪烁

### DIFF
--- a/src/lib/openPresence.test.ts
+++ b/src/lib/openPresence.test.ts
@@ -125,9 +125,9 @@ describe("floating pop CSS", () => {
     expect(settings).not.toMatch(/settings-stage-(?:enter|leave)/);
   });
 
-  it("keeps mac workbench sidebar frost; settings nav is solid", () => {
+  it("uses native vibrancy for mac workbench panes but keeps overlay drawer frost", () => {
     expect(workbenchCss).toMatch(
-      /\.platform-mac \.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/,
+      /\.platform-mac \.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)\s*\{[^}]*backdrop-filter:\s*none/s,
     );
     expect(workbenchCss).toMatch(
       /\.platform-mac \.sidebar\.sidebar--overlay,\s*\.platform-mac \.sidebar\.sidebar--phone-drawer\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/s,

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -360,33 +360,22 @@ describe("desktop hidden CSS must not force width 0", () => {
 
   it("does not put backdrop-filter on the interpolating in-flow sidebar", () => {
     /**
-     * Resizing a blur-owning box flashes (toggle end, live drag, or a
-     * paused drag). In-flow frost is the rail max so its layer never
-     * changes size; extra sits under .main.
+     * ChatGPT-desktop model: window vibrancy + tint. CSS blur must not sit
+     * on a box whose width interpolates (WKWebView seam flash). Overlay /
+     * phone still frost because they animate transform.
      */
     const sidebar = readFileSync(
       resolve(__dirname, "../styles/sidebar.part1.css"),
       "utf8",
     );
-    const tokens = readFileSync(
-      resolve(__dirname, "../styles/tokens.css"),
-      "utf8",
-    );
-    expect(tokens).toMatch(/--sidebar-width-max:\s*420px/);
     const inFlow = ruleBody(
       sidebar,
       ".platform-mac .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {",
     );
     expect(inFlow).toMatch(/backdrop-filter:\s*none/);
-    expect(inFlow).not.toMatch(/overflow:\s*hidden/);
-    expect(sidebar).toMatch(
-      /\.platform-mac \.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before\s*\{[^}]*width:\s*var\(--sidebar-width-max[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/s,
-    );
+    expect(inFlow).toMatch(/background:\s*var\(--bg-sidebar\)/);
     expect(sidebar).not.toMatch(
-      /\.sidebar\.is-resizing[^{]*::before[^{]*\{[^}]*width:\s*100%/s,
-    );
-    expect(sidebar).not.toMatch(
-      /\.platform-mac \.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before\s*\{[^}]*\btransition\s*:/s,
+      /\.platform-mac \.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before/,
     );
     expect(sidebar).toMatch(
       /\.platform-mac \.sidebar\.sidebar--overlay,\s*\.platform-mac \.sidebar\.sidebar--phone-drawer\s*\{[^}]*backdrop-filter:\s*blur\(var\(--sidebar-blur\)\)/s,

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -174,10 +174,13 @@ describe("wallpaper theme contrast CSS", () => {
 
   it("keeps an expanded wallpaper side pane frosted without exposing chat", () => {
     expect(css).toMatch(
-      /html\[data-wallpaper="1"\] \.aside,\s*html\[data-wallpaper="1"\] \.sidebar\.sidebar--overlay,\s*html\[data-wallpaper="1"\] \.sidebar\.sidebar--phone-drawer\s*\{[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-sidebar-blur, 22px\)\)/s,
+      /html\[data-wallpaper="1"\] \.app-wallpaper-media\s*\{[^}]*filter:\s*blur\(var\(--wallpaper-sidebar-blur, 22px\)\)/s,
     );
     expect(css).toMatch(
-      /html\[data-wallpaper="1"\]\s+\.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before\s*\{[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-sidebar-blur, 22px\)\)/s,
+      /html\[data-wallpaper="1"\] \.sidebar\.sidebar--overlay,\s*html\[data-wallpaper="1"\] \.sidebar\.sidebar--phone-drawer\s*\{[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-sidebar-blur, 22px\)\)/s,
+    );
+    expect(css).not.toMatch(
+      /html\[data-wallpaper="1"\]\s+\.sidebar:not\(\.sidebar--overlay\):not\(\.sidebar--phone-drawer\)::before/,
     );
     expect(css).toMatch(
       /html\[data-stream-perf="1"\]\[data-wallpaper="1"\] \.aside,/,

--- a/src/styles/chat.part6.css
+++ b/src/styles/chat.part6.css
@@ -553,6 +553,13 @@
   z-index: 3;
 }
 
+/* mac in-flow: same window-vibrancy tint as the left rail (ChatGPT chrome). */
+.platform-mac .aside:not(.aside--overlay) {
+  background: var(--bg-sidebar);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
 .aside.is-resizing {
   transition: none;
 }

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -513,48 +513,27 @@ html.platform-win .window-edge-n {
 }
 
 /*
- * mac rail: same frost as Settings nav — CSS blur + tint over native Sidebar.
- * Do not wait on native vibrancy alone: a sibling opaque .main (or a parent
- * opacity/transform) makes the rail look like a flat tint of the chat column.
- * Overlay / phone drawers keep their drop shadow (set below).
+ * ChatGPT-desktop model (mac in-flow): window already has
+ * NSVisualEffectMaterial::Sidebar. Rails are a translucent tint over that
+ * window glass — no CSS backdrop-filter on a box whose width interpolates
+ * (WKWebView rebuilds that layer and the seam flashes). Overlay / phone
+ * still use CSS blur because they animate transform, not flex width.
  */
 .platform-mac .sidebar {
   border-right: none;
+}
+
+.platform-mac .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {
+  background: var(--bg-sidebar);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  box-shadow: var(--sidebar-edge-shadow);
 }
 
 .platform-mac .sidebar.sidebar--overlay,
 .platform-mac .sidebar.sidebar--phone-drawer {
   -webkit-backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
   backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
-}
-
-/*
- * In-flow frost is the rail max, not the current width. Resizing the
- * blur box (toggle interpolation, live drag, or stopping a drag)
- * rebuilds the WKWebView backdrop layer. Extra frost sits under .main
- * (z-index 2). Overlay / phone keep blur on the pane (transform).
- */
-.platform-mac .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {
-  overflow: visible;
-  background: transparent;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-  box-shadow: var(--sidebar-edge-shadow);
-}
-
-.platform-mac .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer)::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: var(--sidebar-width-max, 420px);
-  background: var(--bg-sidebar);
-  -webkit-backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
-  backdrop-filter: blur(var(--sidebar-blur)) saturate(var(--sidebar-saturate));
-  pointer-events: none;
-  z-index: 0;
-  border-radius: inherit;
 }
 
 .platform-mac .sidebar.sidebar--overlay {
@@ -592,7 +571,7 @@ html.platform-mac[data-theme="light"] .workbench {
 
 html.platform-mac[data-theme="light"] .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer),
 .platform-mac[data-theme="light"] .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {
-  background: transparent;
+  background: var(--bg-sidebar);
   border-right: none;
   box-shadow: var(--sidebar-edge-shadow);
 }
@@ -613,7 +592,7 @@ html.platform-mac[data-theme="light"] .app-shell--phone .main {
 }
 
 html.platform-mac[data-theme="light"] .aside {
-  background: #ffffff;
+  background: var(--bg-sidebar);
   border-left: 1px solid rgba(0, 0, 0, 0.05);
   z-index: 2;
 }

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -72,6 +72,12 @@ html[data-wallpaper="1"] .app-shell::after {
   pointer-events: none;
 }
 
+/* One static frost behind both rails — not on the interpolating pane boxes. */
+html[data-wallpaper="1"] .app-wallpaper-media {
+  filter: blur(var(--wallpaper-sidebar-blur, 22px));
+  transform: scale(1.06);
+}
+
 .app-wallpaper-media__el {
   display: block;
   /* Compositor-friendly; avoid filters that force software decode on video. */
@@ -117,10 +123,6 @@ html[data-wallpaper="1"] .sidebar {
     var(--text-primary) 62%,
     transparent
   );
-}
-
-html[data-wallpaper="1"] .sidebar.sidebar--overlay,
-html[data-wallpaper="1"] .sidebar.sidebar--phone-drawer {
   background: color-mix(
     in srgb,
     var(--bg-sidebar-solid, var(--bg-sidebar))
@@ -129,25 +131,6 @@ html[data-wallpaper="1"] .sidebar.sidebar--phone-drawer {
   ) !important;
 }
 
-html[data-wallpaper="1"]
-  .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer) {
-  background: transparent !important;
-}
-
-html[data-wallpaper="1"]
-  .sidebar:not(.sidebar--overlay):not(.sidebar--phone-drawer)::before {
-  background: color-mix(
-    in srgb,
-    var(--bg-sidebar-solid, var(--bg-sidebar))
-      var(--wallpaper-theme-mix-sidebar),
-    transparent
-  ) !important;
-  backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px)) saturate(1.25);
-  -webkit-backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px))
-    saturate(1.25);
-}
-
-html[data-wallpaper="1"] .aside,
 html[data-wallpaper="1"] .sidebar.sidebar--overlay,
 html[data-wallpaper="1"] .sidebar.sidebar--phone-drawer {
   backdrop-filter: blur(var(--wallpaper-sidebar-blur, 22px)) saturate(1.25);
@@ -257,7 +240,6 @@ html[data-wallpaper="1"] .platform-mac .settings-page__nav {
  */
 html[data-stream-perf="1"][data-wallpaper="1"] .app-settings-stage,
 html[data-stream-perf="1"][data-wallpaper="1"] .sidebar,
-html[data-stream-perf="1"][data-wallpaper="1"] .sidebar::before,
 html[data-stream-perf="1"][data-wallpaper="1"] .aside,
 html[data-stream-perf="1"][data-wallpaper="1"] .settings-page__nav,
 html[data-stream-perf="1"][data-wallpaper="1"] .platform-win .settings-page__nav,
@@ -265,6 +247,11 @@ html[data-stream-perf="1"][data-wallpaper="1"] .platform-other .settings-page__n
 html[data-stream-perf="1"][data-wallpaper="1"] .platform-mac .settings-page__nav {
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
+}
+
+html[data-stream-perf="1"][data-wallpaper="1"] .app-wallpaper-media {
+  filter: none;
+  transform: none;
 }
 
 html[data-wallpaper="1"] .settings-page__content,
@@ -349,7 +336,6 @@ html[data-wallpaper="1"][data-wallpaper-clear="1"].platform-mac[data-theme="ligh
 }
 
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .sidebar,
-html[data-wallpaper="1"][data-wallpaper-clear="1"] .sidebar::before,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .main,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .aside,
 html[data-wallpaper="1"][data-wallpaper-clear="1"] .setup-gate,
@@ -359,6 +345,11 @@ html[data-wallpaper="1"][data-wallpaper-clear="1"].platform-mac[data-theme="ligh
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
   box-shadow: none !important;
+}
+
+html[data-wallpaper="1"][data-wallpaper-clear="1"] .app-wallpaper-media {
+  filter: none;
+  transform: none;
 }
 
 /* Wallpaper luminance is unknowable. Light/dark layouts stay structurally


### PR DESCRIPTION
## 变更

- macOS 左右常驻栏复用窗口原生 vibrancy，只保留半透明 tint，避免在宽度插值盒子上运行 CSS backdrop-filter
- overlay 与 phone drawer 继续使用 CSS blur
- 壁纸模糊迁移到静态媒体层，并保持性能模式与清空壁纸状态
- 更新相关 CSS 契约测试

## 验证

- `openPresence.test.ts`、`paneSplitMotion.test.ts`、`wallpaperThemeContrast.guard.test.ts`：49 项通过
- `pnpm build:ui`：通过
- `git diff --check origin/main...HEAD`：通过

## 已知基线

当前 `origin/main@ca576354` 的全量测试自身存在智能体看板文字阴影守卫失败；本 PR 未修改该模块，相关基线修正将独立提交。