### PR TITLE
修正外观契约守卫与当前设计不一致

### DIFF
--- a/src-tauri/src/skin_pack.rs
+++ b/src-tauri/src/skin_pack.rs
@@ -235,7 +235,10 @@ fn parse_font_shadow(v: &serde_json::Value) -> bool {
         serde_json::Value::Bool(b) => *b,
         serde_json::Value::Number(n) => n.as_i64() == Some(1),
         serde_json::Value::String(s) => {
-            matches!(s.trim().to_ascii_lowercase().as_str(), "1" | "true" | "on" | "yes")
+            matches!(
+                s.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "on" | "yes"
+            )
         }
         _ => false,
     }

--- a/src/lib/kanbanBoard.test.ts
+++ b/src/lib/kanbanBoard.test.ts
@@ -345,9 +345,6 @@ describe("agent kanban surface is not a todo list", () => {
     expect(css).toMatch(
       /html\[data-wallpaper="1"\]\s+\.agent-kanban-page\s+:is\([^)]*\.agent-kanban__none[^)]*\.agent-kanban__card-age[^)]*\)\s*\{[^}]*color:\s*var\(--text-secondary\)/s,
     );
-    expect(css).toMatch(
-      /html\[data-theme="dark"\]\[data-wallpaper="1"\]\s+\.agent-kanban-page\s+:is\(\.auto-page__title, \.auto-page__subtitle\)\s*\{[^}]*color:\s*var\(--text-primary\)[^}]*text-shadow:/s,
-    );
   });
 
   it("page uses live agent columns + i18n, not a GlassModal todo list", () => {

--- a/src/lib/settingsOverlayFill.guard.test.ts
+++ b/src/lib/settingsOverlayFill.guard.test.ts
@@ -28,10 +28,10 @@ describe("settings overlay fills the window with wallpaper on", () => {
     expect(css).toMatch(/\.app-settings-stage\s*\{[^}]*inset:\s*0/s);
   });
 
-  it("lightly frosts the still-mounted workbench behind settings", () => {
+  it("keeps the settings stage solid above the mounted workbench", () => {
     const css = readFileSync(join(STYLES, "skins.css"), "utf8");
     expect(css).toMatch(
-      /html\[data-wallpaper="1"\] \.app-settings-stage\s*\{[^}]*backdrop-filter:\s*blur\(var\(--wallpaper-settings-blur, 14px\)\)/s,
+      /html\[data-wallpaper="1"\] \.app-settings-stage\s*\{[^}]*background:\s*var\(--bg-main\)[^}]*backdrop-filter:\s*none/s,
     );
   });
 


### PR DESCRIPTION
## 问题

当前 main 存在两类发布门禁基线失败：外观测试仍要求已废弃的常驻阴影/设置模糊，以及 `skin_pack.rs` 未通过 rustfmt。

## 变更

- 智能体看板守卫不再强制常驻文字阴影
- 设置层守卫改为验证实色背景与禁用模糊
- 按 rustfmt 展开皮肤包布尔解析的 `matches!`，不改变逻辑

## 验证

- 相关 3 个测试文件：30 项通过
- `cargo fmt --all -- --check`：通过
- `git diff --check`：通过