### PR TITLE
统一右侧栏与侧栏的壁纸文字效果

### DIFF
--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -125,6 +125,12 @@ describe("wallpaper theme contrast CSS", () => {
       /html\[data-font-shadow="1"\][\s\S]*\.pane-toggle--pinned/s,
     );
     expect(css).toMatch(
+      /html\[data-wallpaper="1"\] \.aside :is\(\.rp-chrome, \.rp__empty-state\)\s*\{[^}]*--text-secondary:\s*color-mix\([^}]*--text-tertiary:\s*color-mix\([^}]*color:\s*var\(--text-primary\)/s,
+    );
+    expect(css).toMatch(
+      /html\[data-font-shadow="1"\][\s\S]*\.aside \.rp-chrome,[\s\S]*\.aside \.rp__empty-state[\s\S]*text-shadow:/s,
+    );
+    expect(css).toMatch(
       /html\[data-theme="light"\]\[data-wallpaper="1"\]\s+\.sidebar\s+\.user-avatar--logo\s+\.grok-logo\s+svg\s*\{[^}]*color:\s*var\(--text-inverse\)[^}]*filter:\s*none/s,
     );
     expect(css).toMatch(

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -364,6 +364,12 @@ html[data-wallpaper="1"][data-wallpaper-clear="1"].platform-mac[data-theme="ligh
 /* Wallpaper luminance is unknowable. Light/dark layouts stay structurally
  * identical; ink follows theme tokens (or a custom --text-primary). Optional
  * text shadow is html[data-font-shadow="1"]. */
+html[data-wallpaper="1"] .aside :is(.rp-chrome, .rp__empty-state) {
+  --text-secondary: color-mix(in srgb, var(--text-primary) 80%, transparent);
+  --text-tertiary: color-mix(in srgb, var(--text-primary) 62%, transparent);
+  color: var(--text-primary);
+}
+
 html[data-theme="light"][data-wallpaper="1"] .sidebar {
   --text-inverse: rgb(15 15 15 / 0.96);
   --bg-hover: rgb(0 0 0 / 0.14);
@@ -429,6 +435,8 @@ html[data-font-shadow="1"]
     .lobe-chat-empty,
     .main__stage > .conn-bar,
     .pane-toggle--pinned,
+    .aside .rp-chrome,
+    .aside .rp__empty-state,
     .auto-page :is(.auto-page__title, .auto-page__subtitle),
     .agent-kanban-page :is(.auto-page__title, .auto-page__subtitle)
   ) {
@@ -441,7 +449,9 @@ html[data-font-shadow="1"]
     .main__top,
     .composer-welcome-mark,
     .lobe-chat-assistant-timeline,
-    .pane-toggle--pinned
+    .pane-toggle--pinned,
+    .aside .rp-chrome,
+    .aside .rp__empty-state
   )
   svg {
   filter: drop-shadow(0 1px 1px rgb(0 0 0 / 0.45));


### PR DESCRIPTION
## 变更

- 右侧计划顶栏与公共空状态复用当前主题或自定义文字色
- secondary / tertiary 文字由同一主文字色派生
- 顶栏图标与空状态接入现有“字体阴影”开关，默认仍关闭
- 不修改实心计划、文件预览等内容面板

这是 `6cc840d1` 针对当前 main 文字颜色/阴影契约的最小兼容移植。

## 验证

- `wallpaperThemeContrast.guard.test.ts`：9 项通过
- ESLint：通过
- `git diff --check`：通过