### PR TITLE
feat: 打开环境信息时对话列让出 316px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ See `docs/llm-wiki/release.md`.
 - **自定义外观**：设置 → 外观 → 主题可改文字颜色（默认跟随浅/深色近黑/近白）和字体阴影（默认关）。「恢复默认」需二次确认，会把这两项恢复出厂。这两项会随 `.grokskin` 导入导出。
 
 ### Changed
+- **Environment info is a pinned dock**: the env panel hangs in the chat column (not a dropdown). Opening the right rail parks it with a reverse-fold animation; closing the rail brings it back unless dismissed.
 - **Agent question no longer covers the transcript (#891)**: `_x.ai/ask_user_question` sits above the composer like the permission bar. Chat stays scrollable. Collapse to a chip (not Dismiss) keeps the draft. The question is the title; options sit on the left with Dismiss / Submit on the right (Submit pinned to the bottom of the card). Short chips stay in a row. Selection uses the theme accent fill; Enter submits except while an IME is committing a candidate.
 - **Dock icons from authored black / white appiconsets**: production `icon.icns` / `icon.ico` pack the black 16–1024 rasters; `pnpm dev` packs the white set into `icons/dev`. Pixel sizes are not resampled (`scripts/pack_appiconset.py`).
 - **Linux AppImage runtime packages (#899)**: README documents the host apt line for a clean Debian/Ubuntu (`libegl1`, `libgles2`, `libwebkit2gtk-4.1-0`, `libayatana-appindicator3-1`) when the official AppImage exits with `libEGL.so.1: cannot open shared object file`. Distinct from the Wayland black-window / `EGL_BAD_PARAMETER` notes.
@@ -26,6 +27,7 @@ See `docs/llm-wiki/release.md`.
 - **Unused AI Elements widgets (#907)**: drop seven unreachable UI files (`button`, `collapsible`, `marker`, `message`, `message-response`, `reasoning`, `shimmer`) and their exclusive deps (`streamdown`, `@radix-ui/react-collapsible`, `@radix-ui/react-slot`, `class-variance-authority`). The `mermaid` pnpm override went with `streamdown`. Chat still uses `MarkdownBody` / Lobe thread.
 
 **中文 · 变更**
+- **环境信息改为钉板**：挂在对话列里，不再是下拉。打开右侧栏会 park 收起，关掉侧栏再转回来（用户关掉的除外）。
 - **Agent 提问不再挡住会话（#891）**：`_x.ai/ask_user_question` 放到输入框上方，和权限条一样。会话可滚动。收成一条不算忽略，草稿还在。问题当标题；选项在左、忽略/提交在右（提交贴容器底）。短芯片横排。选中用主题色填充；回车提交，中文输入法选词回车不提交。
 - **Dock 图标改用已调好的黑 / 白 appiconset**：正式版 `icon.icns` / `icon.ico` 打黑色 16–1024；`pnpm dev` 打白色到 `icons/dev`。按原像素封装，不再缩放（`scripts/pack_appiconset.py`）。
 - **Linux AppImage 运行时包（#899）**：README 补上干净 Debian/Ubuntu 的 apt 行（`libegl1`、`libgles2`、`libwebkit2gtk-4.1-0`、`libayatana-appindicator3-1`）。官方 AppImage 缺 `libEGL.so.1` 会立刻退出；这与 Wayland 黑窗 / `EGL_BAD_PARAMETER` 不是同一类问题。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ See `docs/llm-wiki/release.md`.
 
 ### Changed
 - **Environment info is a pinned dock**: the env panel hangs in the chat column (not a dropdown). Opening the right rail parks it with a reverse-fold animation; closing the rail brings it back unless dismissed.
+- **Open env dock leaves room for the thread**: the chat stage takes a 316px right margin so welcome / composer recenter instead of sitting under the card.
 - **Agent question no longer covers the transcript (#891)**: `_x.ai/ask_user_question` sits above the composer like the permission bar. Chat stays scrollable. Collapse to a chip (not Dismiss) keeps the draft. The question is the title; options sit on the left with Dismiss / Submit on the right (Submit pinned to the bottom of the card). Short chips stay in a row. Selection uses the theme accent fill; Enter submits except while an IME is committing a candidate.
 - **Dock icons from authored black / white appiconsets**: production `icon.icns` / `icon.ico` pack the black 16–1024 rasters; `pnpm dev` packs the white set into `icons/dev`. Pixel sizes are not resampled (`scripts/pack_appiconset.py`).
 - **Linux AppImage runtime packages (#899)**: README documents the host apt line for a clean Debian/Ubuntu (`libegl1`, `libgles2`, `libwebkit2gtk-4.1-0`, `libayatana-appindicator3-1`) when the official AppImage exits with `libEGL.so.1: cannot open shared object file`. Distinct from the Wayland black-window / `EGL_BAD_PARAMETER` notes.
@@ -28,6 +29,7 @@ See `docs/llm-wiki/release.md`.
 
 **中文 · 变更**
 - **环境信息改为钉板**：挂在对话列里，不再是下拉。打开右侧栏会 park 收起，关掉侧栏再转回来（用户关掉的除外）。
+- **环境信息打开时对话列让位**：主列右边预留 316px，欢迎页和输入框重新居中，不再压在卡片上。
 - **Agent 提问不再挡住会话（#891）**：`_x.ai/ask_user_question` 放到输入框上方，和权限条一样。会话可滚动。收成一条不算忽略，草稿还在。问题当标题；选项在左、忽略/提交在右（提交贴容器底）。短芯片横排。选中用主题色填充；回车提交，中文输入法选词回车不提交。
 - **Dock 图标改用已调好的黑 / 白 appiconset**：正式版 `icon.icns` / `icon.ico` 打黑色 16–1024；`pnpm dev` 打白色到 `icons/dev`。按原像素封装，不再缩放（`scripts/pack_appiconset.py`）。
 - **Linux AppImage 运行时包（#899）**：README 补上干净 Debian/Ubuntu 的 apt 行（`libegl1`、`libgles2`、`libwebkit2gtk-4.1-0`、`libayatana-appindicator3-1`）。官方 AppImage 缺 `libEGL.so.1` 会立刻退出；这与 Wayland 黑窗 / `EGL_BAD_PARAMETER` 不是同一类问题。

--- a/src/app/WorkbenchMain.tsx
+++ b/src/app/WorkbenchMain.tsx
@@ -370,6 +370,7 @@ export function WorkbenchMain(props: WorkbenchMainProps) {
               {mainPane === "chat" ? (
                 <EnvInfoButton
                   locale={locale}
+                  asideOpen={!layout.asideCollapsed}
                   projectPath={effectiveProjectPath}
                   projectName={
                     activeProject

--- a/src/components/side-workbench/EnvInfoButton.tsx
+++ b/src/components/side-workbench/EnvInfoButton.tsx
@@ -1,11 +1,12 @@
 /**
- * Main chrome `env` control — environment info dropdown (image-7 five rows).
+ * Main chrome `env` control — environment info dock (five rows).
  * Phase 3: display collected git/session status + jump callbacks; no full git write ops.
  */
 
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -16,6 +17,7 @@ import { createT, type Locale } from "@/i18n";
 import {
   IconBrandGithub,
   IconChevronDown,
+  IconClose,
   IconDeviceDesktop,
   IconEnv,
   IconFileDiff,
@@ -24,7 +26,6 @@ import {
 } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
 import * as api from "@/lib/api";
-import { useFloatingMenu } from "@/lib/floatingMenu";
 import { useOpenPresence } from "@/lib/openPresence";
 import { pathBaseName } from "@/lib/sessionChanges";
 import { envReviewJumpEnabled } from "@/lib/sideWorkbench";
@@ -54,6 +55,8 @@ export type EnvInfoButtonProps = {
   changeSummary?: EnvChangeSummary | null;
   /** Optional branch override; when omitted, loaded from git status on open. */
   branch?: string | null;
+  /** Right rail open — parks the dock instead of closing it. */
+  asideOpen?: boolean;
   className?: string;
   onJump?: (jump: EnvInfoJump) => void;
 };
@@ -83,35 +86,50 @@ export function EnvInfoButton({
   isGitProject = false,
   changeSummary = null,
   branch: branchProp = null,
+  asideOpen = false,
   className = "",
   onJump,
 }: EnvInfoButtonProps) {
   const tr = useMemo(() => createT(locale as Locale), [locale]);
   const [open, setOpen] = useState(false);
+  const [parked, setParked] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const loadGen = useRef(0);
+  const asideOpenRef = useRef(asideOpen);
+  const [host, setHost] = useState<HTMLElement | null>(null);
 
   const [snap, setSnap] = useState<EnvSnapshot>(() =>
     emptySnapshot(isGitProject),
   );
 
   const presence = useOpenPresence(open);
-  const { pos, style, settled } = useFloatingMenu({
-    open: presence.mounted,
-    triggerRef,
-    panelRef,
-    onClose: () => setOpen(false),
-    placement: "down",
-    // Chrome trailing control: hang panel so right edges match the env icon.
-    align: "end",
-    fitContent: true,
-    minWidth: 280,
-    estHeight: 320,
-    gap: 6,
-  });
-  const enter = useOpenPresence(Boolean(open && settled));
-  const entered = enter.entered;
+  const entered = presence.entered;
+
+  useLayoutEffect(() => {
+    const el = document.querySelector(".main");
+    setHost(el instanceof HTMLElement ? el : document.body);
+  }, []);
+
+  useLayoutEffect(() => {
+    const wasOpen = asideOpenRef.current;
+    asideOpenRef.current = asideOpen;
+    if (!open) {
+      setParked(false);
+      return;
+    }
+    if (!wasOpen && asideOpen) setParked(true);
+    if (wasOpen && !asideOpen) setParked(false);
+  }, [asideOpen, open]);
+
+  useEffect(() => {
+    if (!presence.mounted) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [presence.mounted]);
 
   const localLabel = useMemo(() => {
     const named = (projectName || "").trim();
@@ -303,20 +321,30 @@ export function EnvInfoButton({
           <IconEnv size={16} />
         </button>
       </Tip>
-      {presence.mounted && pos
+      {presence.mounted && host
         ? createPortal(
+            <div className="sw-env-dock" aria-hidden={parked || !entered}>
             <div
               ref={panelRef}
               className={
-                "sw-env-menu menu-panel" + (entered ? " is-open" : "")
+                "sw-env-menu menu-panel" +
+                (entered ? " is-open" : "") +
+                (parked ? " is-parked" : "")
               }
-              style={style}
               role="dialog"
               aria-label={tr("side.envTitle")}
               data-testid="env-info-menu"
             >
               <div className="sw-env-menu__head">
                 <span className="sw-env-menu__title">{tr("side.envTitle")}</span>
+                <button
+                  type="button"
+                  className="chrome-btn sw-env-menu__close"
+                  aria-label={tr("common.close")}
+                  onClick={() => setOpen(false)}
+                >
+                  <IconClose size={14} />
+                </button>
               </div>
               <div className="sw-env-menu__body">
                 {row(
@@ -376,8 +404,9 @@ export function EnvInfoButton({
                   gitReady,
                 )}
               </div>
+            </div>
             </div>,
-            document.body,
+            host,
           )
         : null}
     </>

--- a/src/styles/side-workbench.part2.css
+++ b/src/styles/side-workbench.part2.css
@@ -68,36 +68,60 @@ html[data-wallpaper="1"]
   flex-direction: column;
 }
 
-/* Env menu — solid panel (same family as .sw-plus-menu / context menus).
- * Bare .menu-panel has no surface; without this the rows float over chat. */
+/*
+ * Env dock: pinned in `.main`. `.is-parked` when the right rail opens;
+ * closing the rail restores it unless the user dismissed it.
+ */
+.sw-env-dock {
+  position: absolute;
+  inset: 0;
+  z-index: 8;
+  pointer-events: none;
+  perspective: 900px;
+  perspective-origin: 100% 0%;
+  overflow: hidden;
+}
+
 .sw-env-menu.menu-panel,
 .menu-panel.sw-env-menu {
-  z-index: 13000;
+  position: absolute;
+  top: calc(var(--titlebar-height, 40px) + 8px);
+  right: 16px;
+  bottom: auto;
+  width: 300px;
+  max-width: 300px;
+  max-height: calc(
+    100% - var(--titlebar-height, 40px) - var(--composer-float-pad, 168px) - 16px
+  );
   min-width: 0;
-  max-width: min(var(--menu-max-width, 360px), calc(100vw - 16px));
-  width: max-content;
-  background: var(--menu-context-bg, var(--bg-elevated, var(--bg-card)));
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated, var(--bg-card));
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  border: 1px solid var(--menu-context-border, var(--border-subtle));
-  box-shadow: var(--menu-context-shadow, 0 8px 28px rgba(0, 0, 0, 0.45));
-  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-pop, 0 8px 28px rgba(0, 0, 0, 0.18));
+  border-radius: 24px;
   padding: 10px 8px 8px;
   box-sizing: border-box;
-  opacity: 0;
-  transform: translateY(-8px) scale(0.97);
   transform-origin: top right;
+  opacity: 0;
+  transform: translateX(100%) scale(0.8) rotateY(-22deg);
   transition:
     opacity var(--motion-normal) var(--motion-pane-ease),
     transform var(--motion-normal) var(--motion-pane-ease);
   pointer-events: none;
 }
 
-.sw-env-menu.menu-panel.is-open,
-.menu-panel.sw-env-menu.is-open {
+.sw-env-menu.menu-panel.is-open:not(.is-parked),
+.menu-panel.sw-env-menu.is-open:not(.is-parked) {
   opacity: 1;
   transform: none;
   pointer-events: auto;
+}
+
+body > .sw-env-dock {
+  position: fixed;
 }
 
 .sw-env-menu__head {
@@ -113,10 +137,19 @@ html[data-wallpaper="1"]
   font-weight: 600;
 }
 
+.sw-env-menu__close {
+  width: 24px;
+  height: 24px;
+  margin-left: auto;
+}
+
 .sw-env-menu__body {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
 }
 
 .sw-env-menu__row {

--- a/src/styles/side-workbench.part2.css
+++ b/src/styles/side-workbench.part2.css
@@ -71,6 +71,9 @@ html[data-wallpaper="1"]
 /*
  * Env dock: pinned in `.main`. `.is-parked` when the right rail opens;
  * closing the rail restores it unless the user dismissed it.
+ * Open (not parked) reserves 316px (300 panel + 16 end pad) via stage
+ * margin-right so the centered thread recenters. Padding would not inset
+ * the absolutely positioned composer.
  */
 .sw-env-dock {
   position: absolute;
@@ -82,14 +85,28 @@ html[data-wallpaper="1"]
   overflow: hidden;
 }
 
+.main {
+  --env-summary-width: 300px;
+  --env-summary-gutter: 0px;
+}
+
+.main:has(.sw-env-menu.is-open:not(.is-parked)) {
+  --env-summary-gutter: 316px;
+}
+
+.main > .main__stage {
+  margin-right: var(--env-summary-gutter);
+  transition: margin-right var(--motion-pane) var(--motion-pane-ease);
+}
+
 .sw-env-menu.menu-panel,
 .menu-panel.sw-env-menu {
   position: absolute;
   top: calc(var(--titlebar-height, 40px) + 8px);
   right: 16px;
   bottom: auto;
-  width: 300px;
-  max-width: 300px;
+  width: var(--env-summary-width);
+  max-width: var(--env-summary-width);
   max-height: calc(
     100% - var(--titlebar-height, 40px) - var(--composer-float-pad, 168px) - 16px
   );
@@ -238,6 +255,10 @@ body > .sw-env-dock {
   .sw-env-menu.menu-panel,
   .menu-panel.sw-env-menu {
     transform: none;
+    transition: none;
+  }
+
+  .main > .main__stage {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary
Depends on https://github.com/RongleCat/grok-app/pull/917 — 请先合钉板，再合本 PR。本分支叠在 #917 之上，对 `main` 会多看到钉板那一笔。

钉板打开且未 park 时，`.main__stage` 右边预留 316px（300 卡片 + 16 边距），欢迎页 / 输入框 / 对话在剩余宽度里重新居中，不再压在环境信息上。

不含对话进度条、设置自定义图标。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included