### PR TITLE
fix: 对话列变窄时 stick 跟底，避免先上跳再抽回

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,14 @@ See `docs/llm-wiki/release.md`.
 - **未使用的 AI Elements 控件（#907）**：删除 7 个不可达 UI 文件及其独占依赖（`streamdown`、`@radix-ui/react-collapsible`、`@radix-ui/react-slot`、`class-variance-authority`）；`mermaid` override 随 `streamdown` 去掉。聊天仍走 `MarkdownBody` / Lobe 线程。
 
 ### Fixed
+- **Transcript stays pinned when the chat column width interpolates**: opening the right pane no longer jumps the thread up then snaps back to the bottom.
 - **Session API second turn no longer deadlocks on already-live connect (#905)**: `connect_inner` held `inner` and then called `snapshot()`, which locks `inner` again (`parking_lot` is not reentrant). The thread never returned, so `connect_lock` stayed busy forever and later `POST /turns` got 503 `retry_later`. Already-live and fork-busy now snapshot from the held lock.
 - **Unsigned-in startup no longer waits 24s on ACP `authenticate` (#898)**: Official route with no `auth.json` / no usable cached token used to send `authenticate(cached_token)` after `initialize`, time out at 12s, retry once, then soft-fail. Workbench still opened idle. Host now skips that RPC when the user is not signed in. Custom routes still skip; the signed-in-but-agent-home-stale path (#528) still re-syncs and retries once.
 - **Sidebar session selection and new-chat fold (#895, #897, #901)**: short titles no longer duplicate; resize during pane motion is replayed; creating a chat no longer forces “Other sessions” open.
 - **Narrow-window plan overlay leftover (#902)**: an open aside overlay now uses the existing full-cover mode instead of a leftover scrim over the main column.
 
 **中文 · 修复**
+- **对话列变窄时仍钉在底部**：打开右侧栏不再先把会话挤上去再抽回底部。
 - **Session API 第二轮不再在 already-live connect 上死锁（#905）**：`connect_inner` 握着 `inner` 再调 `snapshot()`，而 `snapshot()` 会再锁一次（`parking_lot` 不可重入）。线程回不来，`connect_lock` 一直 busy，后续 `POST /turns` 变成 503 `retry_later`。already-live / fork-busy 改为从已持有的锁做 snapshot。
 - **未登录启动不再为 ACP `authenticate` 空等约 24 秒（#898）**：官方路由在没有 `auth.json` / 没有可用 cached token 时仍会在 `initialize` 后发 `authenticate(cached_token)`，12 秒超时后再试一次，然后 soft-fail；工作台仍会打开。现在未登录就跳过该 RPC。自定义路由仍跳过；已登录但 agent-home 缺 token（#528）仍会同步并重试一次。
 - **侧栏选中、缩放与新建会话折叠（#895、#897、#901）**：短标题不再复制；分栏动画结束后补跑窗口缩放；新建会话不再强制展开「其他会话」。

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -531,12 +531,17 @@ export function useChatMessageVirtualizer(
     const ro =
       typeof ResizeObserver !== "undefined"
         ? new ResizeObserver(() => {
-            if (scrollingRef.current || isPaneSplitMotionActive()) {
-              if (isPaneSplitMotionActive()) {
-                runAfterPaneSplitMotion(() => {
-                  recomputeNow();
-                });
-              }
+            if (scrollingRef.current) {
+              return;
+            }
+            if (isPinnedRef.current) {
+              scheduleOnFrame(scrollFrameRef.current, () => recomputeNow());
+              return;
+            }
+            if (isPaneSplitMotionActive()) {
+              runAfterPaneSplitMotion(() => {
+                recomputeNow();
+              });
               return;
             }
             recompute();
@@ -612,6 +617,7 @@ export function useChatMessageVirtualizer(
     (index: number, el: HTMLElement, measuredHeight?: number) => {
       if (!virtualizedRef.current) return;
       if (
+        !isPinnedRef.current &&
         runAfterPaneSplitMotion(() =>
           commitRowHeight(index, el, measuredHeight),
         )

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -28,12 +28,12 @@ import {
   isHeightDeltaNoise,
   isNearBottom,
   nextStickPinState,
-  pinnedFollowDelayMs,
+  pinnedFollowDelayForLayout,
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
   shouldReleaseStickOnScrollUp,
 } from "@/lib/stickToBottom";
-import { runAfterPaneSplitMotion } from "@/lib/paneSplitMotion";
+
 
 export type UseStickToBottomOptions = {
   /** Re-pin when the conversation identity changes (session / first message). */
@@ -462,16 +462,24 @@ export function useStickToBottom(
     if (!el) return;
 
     let previousHeight: number | undefined;
+    let previousViewportWidth: number | undefined = el.clientWidth;
+    let viewportWidthChanged = false;
     let raf = 0;
     let mediaFollowTimer: ReturnType<typeof setTimeout> | null = null;
 
     const onHeightChange = (height: number) => {
+      const widthMoved = viewportWidthChanged;
+      viewportWidthChanged = false;
       const difference = height - (previousHeight ?? height);
       // Thought-stream / font / 1–3px reflow: skip full follow machinery so
       // micro reflows do not bounce — BUT still clamp if many small stream
       // deltas stacked and left us off hard bottom while pinned (smooth
       // thinking/body reveal is usually 2–7px per frame).
-      if (previousHeight != null && isHeightDeltaNoise(difference)) {
+      if (
+        previousHeight != null &&
+        isHeightDeltaNoise(difference) &&
+        !widthMoved
+      ) {
         previousHeight = height;
         if (
           shouldClampPinnedStreamDrift(
@@ -527,8 +535,13 @@ export function useStickToBottom(
       // Do NOT compensate scrollTop while escaped — stream growth is almost
       // always at the bottom; adding the full height delta would yank the
       // user down. Large jumps (image/PDF decode) wait so a storm of
-      // screenshots is one snap, not one per file.
-      const delay = pinnedFollowDelayMs(difference);
+      // screenshots is one snap, not one per file. Width interpolation
+      // (aside / env gutter) must follow this frame or the column jumps
+      // up until the motion ends, then snaps back.
+      const delay = pinnedFollowDelayForLayout({
+        heightDelta: difference,
+        viewportWidthChanged: widthMoved,
+      });
       if (delay <= 0) {
         if (mediaFollowTimer != null) {
           clearTimeout(mediaFollowTimer);
@@ -560,7 +573,6 @@ export function useStickToBottom(
     };
 
     const scheduleMeasure = () => {
-      if (runAfterPaneSplitMotion(scheduleMeasure)) return;
       if (raf) return;
       raf = requestAnimationFrame(() => {
         raf = 0;
@@ -568,10 +580,21 @@ export function useStickToBottom(
       });
     };
 
-    const ro = new ResizeObserver(() => {
+    const ro = new ResizeObserver((entries) => {
       // Coalesce multi-node notifications to one frame. Always read the
       // content column height from the DOM — viewport RO entries report
       // client box size, which is not what we want for grow/shrink.
+      for (const entry of entries) {
+        if (entry.target !== el) continue;
+        const w = entry.contentRect.width;
+        if (
+          previousViewportWidth != null &&
+          Math.abs(w - previousViewportWidth) >= 0.5
+        ) {
+          viewportWidthChanged = true;
+        }
+        previousViewportWidth = w;
+      }
       scheduleMeasure();
     });
 

--- a/src/lib/stickToBottom.test.ts
+++ b/src/lib/stickToBottom.test.ts
@@ -12,6 +12,7 @@ import {
   isNearBottom,
   nextStickPinState,
   pinnedFollowDelayMs,
+  pinnedFollowDelayForLayout,
   shouldBumpStickOnBusyEdge,
   stabilizeStickUserId,
   shouldClampPinnedOverscroll,
@@ -91,6 +92,26 @@ describe("pinnedFollowDelayMs", () => {
 
   it("treats non-finite as immediate", () => {
     expect(pinnedFollowDelayMs(Number.NaN)).toBe(0);
+  });
+});
+
+describe("pinnedFollowDelayForLayout", () => {
+  it("follows immediately when the viewport width is interpolating", () => {
+    expect(
+      pinnedFollowDelayForLayout({
+        heightDelta: 400,
+        viewportWidthChanged: true,
+      }),
+    ).toBe(0);
+  });
+
+  it("keeps the media delay when only height jumped", () => {
+    expect(
+      pinnedFollowDelayForLayout({
+        heightDelta: 400,
+        viewportWidthChanged: false,
+      }),
+    ).toBe(STICK_MEDIA_FOLLOW_DELAY_MS);
   });
 });
 

--- a/src/lib/stickToBottom.ts
+++ b/src/lib/stickToBottom.ts
@@ -266,6 +266,19 @@ export function pinnedFollowDelayMs(
 }
 
 /**
+ * Aside / env-gutter width interpolation reflows the column every frame.
+ * Media delay would wait until the interpolation stops, then snap — the
+ * transcript jumps up, then back to the bottom. Follow immediately.
+ */
+export function pinnedFollowDelayForLayout(input: {
+  heightDelta: number;
+  viewportWidthChanged: boolean;
+}): number {
+  if (input.viewportWidthChanged) return 0;
+  return pinnedFollowDelayMs(input.heightDelta);
+}
+
+/**
  * While stick is pinned, stream/thinking often grows a few px per frame
  * (smooth reveal). Those deltas are "noise" for bounce suppression, but
  * stacked they leave the viewport off the true bottom. Callers should still


### PR DESCRIPTION
## Summary
独立于环境信息 PR。打开右侧栏（以及之后环境信息让位）时，对话列宽度在插值，stick-to-bottom 以前等到动画结束才跟底，会话会先上跳再抽回底部。现在宽度在动的每一帧都钉在底部。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [ ] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [ ] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included