### PR TITLE
fix: 输入框换行不再把整行挪到下一行

### DIFF
--- a/src/components/ComposerEditor.newline.test.ts
+++ b/src/components/ComposerEditor.newline.test.ts
@@ -1,8 +1,12 @@
+/**
+ * @vitest-environment jsdom
+ */
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  insertComposerLineBreakInPlace,
   storedTextToEditorNodes,
 } from "./ComposerEditor";
 
@@ -59,5 +63,56 @@ describe("Shift+Enter must not rewrite the editor from a stale snapshot", () => 
       /const draft = lastValue\.current;\s*\n\s*const caret = getComposerCaretIndex/,
     );
     expect(composerEditorSrc).toMatch(/insertComposerLineBreakInPlace/);
+  });
+
+  it("uses visual end, not editor-root offset 0, so typed text stays on the first line", () => {
+    expect(composerEditorSrc).toMatch(
+      /const visuallyAtEnd = isCaretAtEditorEnd\(el\)/,
+    );
+    expect(composerEditorSrc).toMatch(
+      /visuallyAtEnd[\s\S]*ensureComposerLineDivs\(el\)/,
+    );
+  });
+});
+
+function setCaret(node: Node, offset: number) {
+  const sel = window.getSelection();
+  if (!sel) throw new Error("no selection");
+  const range = document.createRange();
+  range.setStart(node, offset);
+  range.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+function lineBodies(el: HTMLElement): string[] {
+  return Array.from(el.children)
+    .filter((c): c is HTMLElement => c instanceof HTMLElement && c.tagName === "DIV")
+    .map((c) => (c.textContent ?? "").replace(/\u200B/g, ""));
+}
+
+describe("insertComposerLineBreakInPlace", () => {
+  it("keeps typed text on the first line when Enter is at the end", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const text = document.createTextNode("hello");
+    el.appendChild(text);
+    setCaret(text, 5);
+    expect(insertComposerLineBreakInPlace(el)).toBe(true);
+    expect(lineBodies(el)[0]).toBe("hello");
+    expect(lineBodies(el).length).toBe(2);
+    el.remove();
+  });
+
+  it("splits in the middle of a line instead of moving the whole line", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const text = document.createTextNode("hello world");
+    el.appendChild(text);
+    setCaret(text, 5);
+    expect(insertComposerLineBreakInPlace(el)).toBe(true);
+    expect(lineBodies(el)[0]).toBe("hello");
+    expect(lineBodies(el)[1].replace(/^\s/, "")).toBe("world");
+    el.remove();
   });
 });

--- a/src/components/ComposerEditor.tsx
+++ b/src/components/ComposerEditor.tsx
@@ -492,6 +492,11 @@ function lineDivForCaret(el: HTMLElement, range: Range): HTMLElement | null {
 /**
  * Split the current line DIV at the caret. Does **not** clear the editor —
  * rewriting from a React snapshot was deleting live typed text on Shift+Enter.
+ *
+ * WebKit often reports the caret on the editor root (`startContainer === el`,
+ * offset 0) after wrapping a typed line. Treating that as "start of line"
+ * extracted the whole line onto the next row. If the caret is visually at
+ * the end, insert an empty next line instead of moving the text.
  */
 export function insertComposerLineBreakInPlace(el: HTMLElement): boolean {
   const sel = window.getSelection();
@@ -501,9 +506,30 @@ export function insertComposerLineBreakInPlace(el: HTMLElement): boolean {
     return false;
   }
 
+  const visuallyAtEnd = isCaretAtEditorEnd(el);
+  const anchorNode = range.startContainer;
+  const anchorOff = range.startOffset;
+
   ensureComposerLineDivs(el);
   if (sel.rangeCount === 0) return false;
-  range = sel.getRangeAt(0);
+  if (
+    anchorNode.nodeType === Node.TEXT_NODE &&
+    el.contains(anchorNode)
+  ) {
+    try {
+      const restored = document.createRange();
+      const max = (anchorNode.textContent ?? "").length;
+      restored.setStart(anchorNode, Math.max(0, Math.min(anchorOff, max)));
+      restored.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(restored);
+      range = restored;
+    } catch {
+      range = sel.getRangeAt(0);
+    }
+  } else {
+    range = sel.getRangeAt(0);
+  }
   if (!range.collapsed) {
     range.deleteContents();
     if (sel.rangeCount === 0) return false;
@@ -513,13 +539,24 @@ export function insertComposerLineBreakInPlace(el: HTMLElement): boolean {
   const line = lineDivForCaret(el, range);
   if (!line) return false;
 
+  const next = document.createElement("div");
+  if (visuallyAtEnd) {
+    padEmptyComposerLine(line);
+    next.appendChild(document.createElement("br"));
+    line.insertAdjacentElement("afterend", next);
+    markTrailingEmptyComposerLine(el);
+    placeCaretInLine(next, true);
+    return true;
+  }
+
   const tail = document.createRange();
   try {
     if (line.contains(range.startContainer) || range.startContainer === line) {
       tail.setStart(range.startContainer, range.startOffset);
     } else if (range.startContainer === el) {
-      // Offset at the editor root: end of last line vs start of this line.
-      if (range.startOffset >= el.childNodes.length) {
+      // (el, i) = before child i. Past this line → split at end; else start.
+      const lineIndex = lineDivsOf(el).indexOf(line);
+      if (range.startOffset > lineIndex) {
         tail.setStart(line, line.childNodes.length);
       } else {
         tail.setStart(line, 0);
@@ -533,7 +570,6 @@ export function insertComposerLineBreakInPlace(el: HTMLElement): boolean {
   }
 
   const contents = tail.extractContents();
-  const next = document.createElement("div");
   next.appendChild(contents);
   padEmptyComposerLine(line);
   padEmptyComposerLine(next);
@@ -808,7 +844,7 @@ function isCaretAtEditorEnd(el: HTMLElement): boolean {
   const frag = after.cloneContents();
   const tmp = document.createElement("div");
   tmp.appendChild(frag);
-  const rest = stripEditorGhostChars(tmp.innerText ?? tmp.textContent ?? "")
+  const rest = stripEditorGhostChars(tmp.innerText || tmp.textContent || "")
     .replace(/\u00a0/g, " ")
     .replace(/[\n\r]+/g, "");
   return rest.length === 0;
@@ -826,7 +862,7 @@ function isCaretAtEditorStart(el: HTMLElement): boolean {
   const frag = before.cloneContents();
   const tmp = document.createElement("div");
   tmp.appendChild(frag);
-  const head = stripEditorGhostChars(tmp.innerText ?? tmp.textContent ?? "")
+  const head = stripEditorGhostChars(tmp.innerText || tmp.textContent || "")
     .replace(/\u00a0/g, " ")
     .replace(/[\n\r]+/g, "");
   return head.length === 0;


### PR DESCRIPTION
## 摘要
输入框按换行时，WebKit 常把光标报到编辑器根节点 offset 0，整行被抽到下一行，变成空行 + 原文。

先判断视觉行尾并还原文本节点光标，再拆行。行尾换行保留原文；行中换行从光标切开。

## 改动类型
- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构 / 杂项

## 检查
- [x] 已跑 `pnpm test`（换行相关）
- [ ] 已在 `src-tauri` 跑 `cargo test`（纯前端）
- [x] 用户可见文案走 i18n（本 PR 无新文案）
- [x] 未使用 `window.confirm` / `prompt` / `alert`
- [x] 无密钥文件