### PR TITLE
feat: 标题栏已断开与打开位置对齐 chip 样式

### DIFF
--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -41,7 +41,7 @@ describe("wallpaper theme contrast CSS", () => {
 
   it("keeps light controls readable without adding structural surfaces", () => {
     const material = css.match(
-      /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\(\.composer, \.composer__context-bar, \.main__top \.status-pill\)\s*\{[^}]*\}/s,
+      /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\(\.composer, \.composer__context-bar\)\s*\{[^}]*\}/s,
     )?.[0];
     expect(material).toContain(
       "background: var(--wallpaper-light-elevated-surface)",
@@ -49,6 +49,9 @@ describe("wallpaper theme contrast CSS", () => {
     expect(material).not.toContain("backdrop-filter");
     expect(css).not.toMatch(
       /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\([^)]*, \.status-pill\)\s*\{/s,
+    );
+    expect(css).not.toMatch(
+      /html\[data-theme="light"\]\[data-wallpaper="1"\][^{]*:is\([^)]*\.open-loc[^)]*\)\s*\{[^}]*--wallpaper-light-elevated-surface/s,
     );
     expect(css).toMatch(
       /--wallpaper-light-elevated-surface:\s*color-mix\(\s*in srgb,\s*var\(--bg-elevated\) 74%,\s*transparent/s,

--- a/src/styles/chat.part5.css
+++ b/src/styles/chat.part5.css
@@ -563,19 +563,20 @@
   color: var(--danger);
 }
 
-/* Connection status pill in main chrome */
+/* Connection status — same flat chip language as .chip / .chrome-btn */
 .status-pill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 22px;
+  height: 28px;
   padding: 0 8px;
-  border-radius: 999px;
-  font-size: 11px;
+  border-radius: var(--radius-md);
+  font-size: 12px;
   color: var(--text-secondary);
-  border: 1px solid var(--border-subtle);
-  background: color-mix(in srgb, var(--bg-elevated) 55%, transparent);
+  border: none;
+  background: transparent;
   flex-shrink: 0;
+  transition: background 120ms ease, color 120ms ease;
 }
 
 .status-pill__dot {
@@ -601,15 +602,15 @@
 .status-pill--action {
   margin: 0;
   cursor: pointer;
-  font: inherit;
+  font-family: inherit;
+  font-weight: inherit;
   appearance: none;
   -webkit-appearance: none;
 }
 
 .status-pill--action:hover {
   color: var(--text-primary);
-  border-color: var(--border-strong, var(--border-subtle));
-  background: color-mix(in srgb, var(--bg-elevated) 80%, transparent);
+  background: var(--bg-hover);
 }
 
 .status-pill--action:focus-visible {

--- a/src/styles/phone.part1.css
+++ b/src/styles/phone.part1.css
@@ -324,7 +324,7 @@
 
   .app-shell--phone .status-pill {
     font-size: 13px;
-    padding: 6px 10px;
+    padding: 0 10px;
   }
 
   /*

--- a/src/styles/settings.part5.css
+++ b/src/styles/settings.part5.css
@@ -495,30 +495,30 @@
   opacity: 0.92;
 }
 
-/* ===== Codex-style open-location split control =====
-   Height / radius / icon metrics match .chrome-btn (28×28) so it sits
-   evenly next to pane toggles in main__top-actions and rp-chrome__actions. */
+/* Open-location split — same flat chip language as .chip / .chrome-btn */
 .open-loc {
-  --open-loc-h: 28px;
   position: relative;
   display: inline-flex;
   align-items: stretch;
-  height: var(--open-loc-h);
+  height: 28px;
   box-sizing: border-box;
-  border-radius: var(--radius-sm, 6px); /* same as .chrome-btn */
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-elevated, var(--bg-hover));
-  color: var(--text-primary);
-  font-size: 12.5px;
+  border-radius: var(--radius-md);
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
   font-weight: 500;
   flex-shrink: 0;
-  overflow: hidden;
-  box-shadow: none; /* avoid extra visual bulk vs flat chrome-btn */
+  transition: background 120ms ease, color 120ms ease;
 }
 
-.open-loc:hover,
+.open-loc:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
 .open-loc.is-open {
-  border-color: var(--border-strong, var(--border-subtle));
+  color: var(--text-primary);
   background: var(--bg-active, var(--bg-hover));
 }
 
@@ -531,7 +531,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px; /* match chrome / chip internal gaps */
-  padding: 0 8px 0 8px;
+  padding: 0 8px;
   border: 0;
   background: transparent;
   color: inherit;
@@ -544,8 +544,10 @@
   box-sizing: border-box;
 }
 
-.open-loc__main:hover {
-  background: rgba(127, 127, 127, 0.08);
+.open-loc__main:focus-visible,
+.open-loc__caret:focus-visible {
+  outline: 2px solid var(--focus-ring, var(--accent));
+  outline-offset: 2px;
 }
 
 .open-loc__app-ico {
@@ -581,14 +583,16 @@
   padding: 0 6px 0 2px;
   border: 0;
   background: transparent;
-  color: var(--text-tertiary);
+  color: inherit;
+  opacity: 0.62;
   cursor: pointer;
   box-sizing: border-box;
 }
 
+.open-loc:hover .open-loc__caret,
+.open-loc.is-open .open-loc__caret,
 .open-loc__caret:hover {
-  color: var(--text-primary);
-  background: rgba(127, 127, 127, 0.08);
+  opacity: 1;
 }
 
 .open-loc--compact {

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -285,7 +285,7 @@ html[data-wallpaper="1"].platform-mac[data-theme="light"] .aside {
 /* Light wallpaper controls share one translucent elevated material. It stays
  * readable when stream-perf removes pane blur and when the scrim is low. */
 html[data-theme="light"][data-wallpaper="1"]
-  :is(.composer, .composer__context-bar, .main__top .status-pill) {
+  :is(.composer, .composer__context-bar) {
   background: var(--wallpaper-light-elevated-surface);
 }
 
@@ -306,16 +306,6 @@ html[data-stream-perf="1"][data-wallpaper="1"]
   :is(.composer, .composer__context-bar) {
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
-}
-
-html[data-theme="light"][data-wallpaper="1"]
-  .main__top
-  .status-pill--action:hover {
-  background: color-mix(
-    in srgb,
-    var(--wallpaper-light-elevated-surface) 90%,
-    var(--text-primary) 10%
-  );
 }
 
 /*


### PR DESCRIPTION
## 摘要
标题栏「已断开」胶囊和「打开位置」实心底与当前 chrome-btn / `.chip` 不一致。

改成 28px、无描边、透明底、hover 只洗一层。壁纸下不再给 status-pill 套 elevated 底板。

## 改动类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档
- [ ] 重构 / 杂项

## 检查
- [x] 已跑 `pnpm test`（壁纸对比守卫）
- [ ] 已在 `src-tauri` 跑 `cargo test`（纯前端）
- [x] 用户可见文案走 i18n（本 PR 无新文案）
- [x] 未使用 `window.confirm` / `prompt` / `alert`
- [x] 无密钥文件