### PR TITLE
feat: 计划顶框改为浮层玻璃底

### DIFF
--- a/src/components/PlanStatusBar.tsx
+++ b/src/components/PlanStatusBar.tsx
@@ -1,6 +1,6 @@
-/** Sticky plan/goal strip — stays put while the in-thread plan card scrolls away. */
+/** Overlay plan/goal card — floats over chat; padding is measured to match. */
 
-import { useMemo } from "react";
+import { useLayoutEffect, useMemo, useRef } from "react";
 import { IconCheck, IconPlan, IconClose } from "@/components/icons";
 import {
   formatPlanFraction,
@@ -101,6 +101,26 @@ export function PlanStatusBar({
     [goalMode, mode, planVisible, planWaiting, planRpcId, planNeedsResume, entries],
   );
 
+  const barRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!shouldShowPlanBar(model)) return;
+    const el = barRef.current;
+    const main = el?.closest(".main");
+    if (!el || !(main instanceof HTMLElement)) return;
+    const apply = () => {
+      const h = Math.ceil(el.getBoundingClientRect().height);
+      main.style.setProperty("--plan-bar-float-pad", `${h + 8}px`);
+    };
+    apply();
+    const ro = new ResizeObserver(apply);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      main.style.removeProperty("--plan-bar-float-pad");
+    };
+  }, [model]);
+
   if (!shouldShowPlanBar(model)) return null;
 
   const fraction = formatPlanFraction(model.progress);
@@ -112,17 +132,19 @@ export function PlanStatusBar({
         ? "plan-bar--review"
         : model.kind === "plan_progress"
           ? "plan-bar--progress"
-          : "plan-bar--mode";
+          : "";
 
   return (
-    <div
-      className={`plan-bar ${kindClass}`}
-      role="status"
-      aria-live="polite"
-      aria-label={labels.aria}
-      data-testid="plan-status-bar"
-      data-kind={model.kind}
-    >
+    <div className="plan-bar-host">
+      <div
+        ref={barRef}
+        className={["plan-bar", kindClass].filter(Boolean).join(" ")}
+        role="status"
+        aria-live="polite"
+        aria-label={labels.aria}
+        data-testid="plan-status-bar"
+        data-kind={model.kind}
+      >
       <div className="plan-bar__main">
         <span className="plan-bar__icon" aria-hidden>
           {model.headlineKey === "planBar.done" ? (
@@ -234,6 +256,7 @@ export function PlanStatusBar({
             <IconClose size={14} />
           </button>
         ) : null}
+      </div>
       </div>
     </div>
   );

--- a/src/styles/settings.part5.css
+++ b/src/styles/settings.part5.css
@@ -650,6 +650,11 @@
   padding-bottom: calc(var(--composer-float-pad, 168px) + 16px);
 }
 
+/* Clear the overlay plan card — pad matches measured card height, not a full-width strip. */
+.main:has(.plan-bar) .main__stage .lobe-chat__inner {
+  padding-top: calc(var(--plan-bar-float-pad, 80px) + 8px);
+}
+
 /* Welcome: composer is centered, not bottom-docked — no extra chat pad */
 .main__stage:has(.composer-wrap--welcome) .lobe-chat__inner {
   padding-bottom: 16px;

--- a/src/styles/settings.part6.css
+++ b/src/styles/settings.part6.css
@@ -347,37 +347,55 @@
   word-break: break-word;
 }
 
-/* Sticky plan/goal bar above the chat stage — accent blue-violet, theme-aware */
+/* Overlay host — zero flow size so the card cannot reserve a full-width strip. */
+.plan-bar-host {
+  flex: 0 0 0;
+  height: 0;
+  width: 100%;
+  position: relative;
+  z-index: 12;
+  pointer-events: none;
+  overflow: visible;
+}
+
+/* Sticky plan/goal card — frosted overlay. No transform (breaks backdrop-filter). */
 .plan-bar {
+  position: absolute;
+  top: 8px;
+  left: 0;
+  right: var(--env-summary-gutter, 0px);
+  margin-left: auto;
+  margin-right: auto;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px 12px;
-  /* Clear main__top: leave breathing room under titlebar chrome */
-  margin: 12px var(--space-5) 10px;
-  padding: 8px 12px;
-  border-radius: 12px;
-  border: 1px solid var(--plan-bar-border, var(--border-subtle));
-  background: var(--plan-bar-bg, var(--bg-card, var(--bg-elevated)));
+  width: min(42rem, calc(100% - 2 * var(--space-5)));
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border-radius: 18px;
+  border: 1px solid var(--glass-border, var(--border-subtle));
+  background: color-mix(in srgb, var(--bg-elevated) 78%, transparent);
+  backdrop-filter: blur(var(--wallpaper-settings-blur, 18px))
+    saturate(var(--glass-saturate, 1.4));
+  -webkit-backdrop-filter: blur(var(--wallpaper-settings-blur, 18px))
+    saturate(var(--glass-saturate, 1.4));
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.04),
+    0 8px 24px rgba(0, 0, 0, 0.08);
   min-width: 0;
+  overflow: hidden;
+  pointer-events: auto;
 }
 
-.plan-bar--goal,
-.plan-bar--mode,
-.plan-bar--progress,
+[data-theme="light"] .plan-bar {
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.04),
+    0 10px 28px rgba(0, 0, 0, 0.06);
+}
+
 .plan-bar--review {
-  border-color: color-mix(in srgb, var(--accent) 36%, var(--border-subtle));
-  background: color-mix(in srgb, var(--accent) 10%, var(--bg-card, var(--bg-elevated)));
-}
-
-.plan-bar--review {
-  /* Slightly stronger fill when action is required */
-  border-color: color-mix(in srgb, var(--accent) 48%, var(--border-subtle));
-  background: color-mix(in srgb, var(--accent) 14%, var(--bg-card, var(--bg-elevated)));
-}
-
-.plan-bar--progress {
-  border-color: color-mix(in srgb, var(--accent) 32%, var(--border-subtle));
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border-subtle));
 }
 
 .plan-bar__main {
@@ -392,10 +410,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
-  margin-top: 1px;
-  border-radius: 6px;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
   color: var(--text-secondary);
   background: var(--bg-hover);
   flex-shrink: 0;
@@ -461,9 +478,9 @@
 .plan-bar__meter {
   flex: 1 1 100%;
   order: 3;
-  height: 3px;
+  height: 2px;
   border-radius: 999px;
-  background: var(--bg-hover);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
   overflow: hidden;
 }
 
@@ -488,9 +505,18 @@
 }
 
 .plan-bar__btn {
-  height: 26px;
+  height: 28px;
   padding: 0 10px;
   font-size: 12px;
+}
+
+.plan-bar__btn.btn--ghost {
+  border: none;
+  background: transparent;
+}
+
+.plan-bar__btn.btn--ghost:hover:not(:disabled) {
+  background: var(--bg-hover);
 }
 
 .plan-bar__btn--clear-goal {
@@ -500,9 +526,16 @@
 }
 
 .plan-bar__close {
-  width: 26px;
-  height: 26px;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
+  background: transparent;
   color: var(--text-tertiary);
+}
+
+.plan-bar__close:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--bg-hover);
 }
 
 /* Plan review workbench (resource pane) */

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -302,6 +302,19 @@ html[data-theme="dark"][data-wallpaper="1"]
     saturate(var(--glass-saturate));
 }
 
+html[data-theme="light"][data-wallpaper="1"] .plan-bar {
+  background: var(--wallpaper-light-elevated-surface);
+}
+
+html[data-theme="dark"][data-wallpaper="1"] .plan-bar {
+  background: color-mix(in srgb, var(--bg-elevated) 72%, transparent);
+}
+
+html[data-stream-perf="1"] .plan-bar {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
 html[data-stream-perf="1"][data-wallpaper="1"]
   :is(.composer, .composer__context-bar) {
   backdrop-filter: none !important;


### PR DESCRIPTION
## 摘要
计划完成顶框缩成卡片后仍占对话整行，两侧空出很大一块，看起来遮盖面积远大于卡片本身。

改为对话上的浮层玻璃卡片（42rem），列表只按实测高度让位。流式输出时关掉 blur。

## 改动类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档
- [ ] 重构 / 杂项

## 检查
- [x] 已跑 `pnpm test`（壁纸对比守卫）
- [ ] 已在 `src-tauri` 跑 `cargo test`（纯前端）
- [x] 用户可见文案走 i18n（本 PR 无新文案）
- [x] 未使用 `window.confirm` / `prompt` / `alert`
- [x] 无密钥文件