### PR TITLE
feat: 加强对话行内代码在壁纸上的可读性

### DIFF
--- a/src/components/lobe-chat/lobe-chat.part1.css
+++ b/src/components/lobe-chat/lobe-chat.part1.css
@@ -80,7 +80,7 @@
 [data-theme="dark"] .lobe-chat {
   --chat-code-bg: color-mix(in srgb, var(--bg-code, #0a0a0a) 55%, #2a2a2e);
   --chat-code-fg: var(--text-primary, #e8e8ea);
-  --chat-inline-code-bg: rgba(255, 255, 255, 0.08);
+  --chat-inline-code-bg: rgba(255, 255, 255, 0.14);
   --chat-inline-code-fg: var(--chat-code-fg);
 }
 
@@ -90,7 +90,7 @@
   --chat-code-fg: var(--text-primary, #1d1d1f);
   --chat-code-bar: color-mix(in srgb, var(--chat-code-bg) 92%, #000 8%);
   --chat-code-border: var(--border-subtle, rgba(0, 0, 0, 0.08));
-  --chat-inline-code-bg: rgba(0, 0, 0, 0.06);
+  --chat-inline-code-bg: rgba(0, 0, 0, 0.09);
   --chat-inline-code-fg: var(--chat-code-fg);
   --chat-bubble: var(--bg-user-bubble, rgba(0, 0, 0, 0.05));
   --chat-card: var(--bg-card, #f5f5f7);
@@ -509,19 +509,22 @@ html[data-msg-actions="always"] .lobe-chat-item__actions {
   text-underline-offset: 2px;
 }
 
-/* Inline code / tags — always readable on both themes */
+/* Inline code / tags — chip language, slightly stronger than body copy */
 .chat-md__inline-code,
 .chat-md :not(pre) > code {
   display: inline;
-  padding: 0.12em 0.45em;
+  padding: 0.12em 0.5em;
   border-radius: 6px;
   background: var(--chat-inline-code-bg);
   border: 1px solid var(--chat-code-border);
   font-family: var(--chat-mono);
   font-size: 0.9em;
+  font-weight: 500;
   color: var(--chat-inline-code-fg);
   box-shadow: none;
   outline: none;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 /* ── Code / path block (theme-aware chrome) ── */

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -157,6 +157,9 @@ describe("wallpaper theme contrast CSS", () => {
     expect(carriedSurface).toContain("--chat-text-3: var(--text-tertiary)");
     expect(carriedSurface).toContain("text-shadow: none");
     expect(css).toMatch(
+      /html\[data-wallpaper="1"\]\s+\.lobe-chat\s+\.lobe-chat-assistant-timeline\s+:is\(\.chat-md__inline-code, \.chat-md :not\(pre\) > code\)\s*\{[^}]*background:\s*color-mix\([^;]*--bg-elevated\) 82%[^}]*text-shadow:\s*none/s,
+    );
+    expect(css).toMatch(
       /html\[data-wallpaper="1"\]\s+\.lobe-chat\s+\.lobe-chat-assistant-timeline\s+:is\([^{]*\.lobe-chat-plan,[^{]*\.struct-json,[^{]*\.att-card,[^{]*\.file-path-card[^)]*\)\s+svg\s*\{[^}]*filter:\s*none/s,
     );
     expect(workbenchCss).toMatch(

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -170,6 +170,19 @@ html[data-wallpaper="1"]
   text-shadow: none;
 }
 
+/* Inline `code` chips sit on wallpaper — give them a real well so they
+ * read as tokens, not a smear of the surrounding chrome ink. */
+html[data-wallpaper="1"]
+  .lobe-chat
+  .lobe-chat-assistant-timeline
+  :is(.chat-md__inline-code, .chat-md :not(pre) > code) {
+  background: color-mix(in srgb, var(--bg-elevated) 82%, transparent);
+  color: var(--text-primary);
+  -webkit-text-fill-color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--text-primary) 18%, transparent);
+  text-shadow: none;
+}
+
 html[data-wallpaper="1"]
   .lobe-chat
   .lobe-chat-assistant-timeline


### PR DESCRIPTION
## 摘要
对话里的行内代码（如 `gh auth status`、数字 token）在壁纸上几乎只剩一层淡灰，不像特殊格式。

同一套 chip 语言：底和边略加深，壁纸下用 elevated 底板并去掉文字阴影。

## 改动类型
- [x] 新功能
- [ ] Bug 修复
- [ ] 文档
- [ ] 重构 / 杂项

## 检查
- [x] 已跑 `pnpm test`（壁纸对比守卫 + MarkdownChat）
- [ ] 已在 `src-tauri` 跑 `cargo test`（纯前端）
- [x] 用户可见文案走 i18n（本 PR 无新文案）
- [x] 未使用 `window.confirm` / `prompt` / `alert`
- [x] 无密钥文件