### PR TITLE
fix: 宠物浮层文案跟随应用语言

### DIFF
--- a/src-tauri/src/pet_window.rs
+++ b/src-tauri/src/pet_window.rs
@@ -70,10 +70,14 @@ fn pet_init_script(prefs: &PetPrefs) -> String {
         "bubbleShape": prefs.bubble_shape,
         "bubbleStyle": prefs.bubble_style,
     });
+    let locale = crate::tray_i18n::Locale::parse(&crate::store::load_settings().locale);
     format!(
-        "{prefix}window.__GROK_PET_BOOT__={boot};}}catch(e){{}}}})();",
+        "{prefix}window.__GROK_PET_BOOT__={boot};window.__GROK_BOOT_LOCALE__={locale:?};window.__GROK_BOOT_OS_LANG__={os:?};var d=document.documentElement;if(d)d.setAttribute(\"lang\",{html:?});}}catch(e){{}}}})();",
         prefix = PET_INIT_SCRIPT_PREFIX,
-        boot = boot
+        boot = boot,
+        locale = locale.as_tag(),
+        os = crate::tray_i18n::detect_os_lang_tag(),
+        html = locale.html_lang(),
     )
 }
 
@@ -1494,6 +1498,8 @@ mod tests {
         assert!(script.contains("transparent"));
         assert!(script.contains("display:none"));
         assert!(script.contains("__GROK_PET_BOOT__"));
+        assert!(script.contains("__GROK_BOOT_LOCALE__"));
+        assert!(script.contains("__GROK_BOOT_OS_LANG__"));
         assert!(script.contains("green"));
     }
 

--- a/src/components/pet/PetApp.tsx
+++ b/src/components/pet/PetApp.tsx
@@ -18,7 +18,14 @@ import {
   type PetFocus,
   type PetTask,
 } from "@/lib/pet";
-import { resolveLocale, type Locale } from "@/i18n";
+import {
+  htmlLangForLocale,
+  loadLocaleCatalog,
+  parseLocalePreference,
+  resolveLocale,
+  resolveLocalePreference,
+  type Locale,
+} from "@/i18n";
 import { settingsGet } from "@/lib/api/settings";
 import { PetOverlay } from "./PetOverlay";
 import "@/styles/pet.css";
@@ -32,8 +39,12 @@ const IDLE: PetFocus = {
   updatedAt: 0,
 };
 
-function readLocale(): Locale {
+function readBootLocale(): Locale {
   try {
+    const w = window as Window & { __GROK_BOOT_LOCALE__?: string };
+    if (typeof w.__GROK_BOOT_LOCALE__ === "string" && w.__GROK_BOOT_LOCALE__.trim()) {
+      return resolveLocale(w.__GROK_BOOT_LOCALE__);
+    }
     return resolveLocale(document.documentElement.lang);
   } catch {
     return "en";
@@ -44,7 +55,8 @@ export function PetApp() {
   const [focus, setFocus] = useState<PetFocus>(IDLE);
   const [tasks, setTasks] = useState<PetTask[]>([]);
   const [prefs, setPrefs] = useState<PetPrefs>(readPetBootPrefs);
-  const [locale, setLocale] = useState<Locale>(readLocale);
+  const [locale, setLocale] = useState<Locale>(readBootLocale);
+  const [localeCatalogRev, setLocaleCatalogRev] = useState(0);
   const [policy, setPolicy] = useState<PetOverlayPolicy>(PET_OVERLAY_POLICY_FULL);
 
   useEffect(() => {
@@ -107,12 +119,25 @@ export function PetApp() {
 
   useEffect(() => {
     let gone = false;
+    void loadLocaleCatalog(locale).then(() => {
+      if (!gone) setLocaleCatalogRev((n) => n + 1);
+    });
+    document.documentElement.setAttribute("lang", htmlLangForLocale(locale));
+    return () => {
+      gone = true;
+    };
+  }, [locale]);
+
+  useEffect(() => {
+    let gone = false;
     void settingsGet()
       .then((s) => {
-        if (!gone) setLocale(resolveLocale(s.locale));
+        if (!gone) {
+          setLocale(resolveLocalePreference(parseLocalePreference(s.locale)));
+        }
       })
       .catch(() => {
-        if (!gone) setLocale(readLocale());
+        if (!gone) setLocale(readBootLocale());
       });
     return () => {
       gone = true;
@@ -125,6 +150,7 @@ export function PetApp() {
       tasks={tasks}
       prefs={prefs}
       locale={locale}
+      localeCatalogRev={localeCatalogRev}
       policy={policy}
     />
   );

--- a/src/components/pet/PetOverlay.tsx
+++ b/src/components/pet/PetOverlay.tsx
@@ -67,15 +67,20 @@ export function PetOverlay({
   tasks = [],
   prefs,
   locale = "en",
+  localeCatalogRev = 0,
   policy = PET_OVERLAY_POLICY_FULL,
 }: {
   focus: PetFocus;
   tasks?: readonly PetTask[];
   prefs: PetPrefs;
   locale?: Locale;
+  localeCatalogRev?: number;
   policy?: PetOverlayPolicy;
 }) {
-  const t = useMemo(() => createT(locale), [locale]);
+  const t = useMemo(
+    () => createT(locale),
+    [locale, localeCatalogRev],
+  );
   const shape = isPetShape(prefs.shape) ? prefs.shape : "hex";
   const color = isPetColor(prefs.color) ? prefs.color : "green";
   const eyeColor = normalizePetEyeColor(prefs.eyeColor);

--- a/src/components/pet/petApp.guard.test.ts
+++ b/src/components/pet/petApp.guard.test.ts
@@ -9,4 +9,12 @@ describe("PetApp first paint", () => {
     expect(src).toContain("readPetBootPrefs");
     expect(src).toContain("useState<PetPrefs>(readPetBootPrefs)");
   });
+
+  it("loads the UI catalog so pet copy follows the app language", () => {
+    expect(src).toContain("loadLocaleCatalog");
+    expect(src).toContain("parseLocalePreference");
+    expect(src).toContain("resolveLocalePreference");
+    expect(src).toContain("__GROK_BOOT_LOCALE__");
+    expect(src).toContain("localeCatalogRev");
+  });
 });

--- a/src/components/pet/petOverlay.guard.test.ts
+++ b/src/components/pet/petOverlay.guard.test.ts
@@ -39,6 +39,11 @@ describe("PetOverlay drag hit target", () => {
     expect(src).toContain("pet.menu.emote");
   });
 
+  it("rebuilds copy after the locale catalog loads", () => {
+    expect(src).toContain("localeCatalogRev");
+    expect(src).toMatch(/createT\(locale\),\s*\[locale, localeCatalogRev\]/);
+  });
+
   it("nudges on Wayland instead of startDragging after slop", () => {
     expect(src).toContain("petShouldManualDrag");
     expect(src).toContain("petPointerStep");


### PR DESCRIPTION
## 摘要
宠物是独立 webview。主界面已是中文时，浮层菜单仍掉回英文：启动脚本没写入语言，overlay 也不加载非英文 catalog，`t()` 只能走英文表。

启动时注入与主窗相同的 `__GROK_BOOT_LOCALE__` / OS 语言，并按设置解析 `system`；加载对应 catalog 后再刷新文案。

## 改动类型
- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构 / 杂项

## 检查
- [x] 已跑 `pnpm test`（宠物 locale 守卫）
- [x] 已在 `src-tauri` 跑 `cargo test pet_init_script`
- [x] 用户可见文案走 i18n（本 PR 无新文案）
- [x] 未使用 `window.confirm` / `prompt` / `alert`
- [x] 无密钥文件