### PR TITLE
fix(session): keep partial forks trimmed

### DIFF
--- a/src-tauri/src/cli_sessions.rs
+++ b/src-tauri/src/cli_sessions.rs
@@ -1765,6 +1765,15 @@ pub fn reconcile_journal_from_chat_history(
     Ok(changed)
 }
 
+/// Linked reconcile may rebuild the App journal from agent `chat_history`.
+/// Skip while a **partial** fork is still pending (`fork_agent_session` plus a
+/// rewind index): the child journal is intentionally shorter than parent
+/// history, so a reconcile would overwrite the cut. Full forks and ordinary
+/// linked sessions stay eligible.
+fn linked_reconcile_allowed(meta: &SessionMeta) -> bool {
+    !(meta.fork_agent_session && meta.fork_rewind_prompt_index.is_some())
+}
+
 /// Best-effort reconcile when opening an App session that is linked to an agent.
 /// Never fails the load path — missing agent dir is normal for brand-new chats.
 pub fn try_reconcile_linked_session(app_session_id: &str) -> u32 {
@@ -1774,6 +1783,9 @@ pub fn try_reconcile_linked_session(app_session_id: &str) -> u32 {
     let Some(meta) = meta else {
         return 0;
     };
+    if !linked_reconcile_allowed(&meta) {
+        return 0;
+    }
     let Some(agent_id) = meta.agent_session_id.as_deref().filter(|s| !s.is_empty()) else {
         return 0;
     };
@@ -2837,5 +2849,30 @@ Total: 1
             "/home/name/projects/grok-app",
             ""
         ));
+    }
+
+    fn fork_meta(fork: bool, rewind: Option<u32>) -> SessionMeta {
+        let mut meta: SessionMeta = serde_json::from_str(
+            r#"{"id":"s1","projectId":null,"title":"t","agentSessionId":"agent-1","createdAt":"2020-01-01T00:00:00Z","updatedAt":"2020-01-01T00:00:00Z"}"#,
+        )
+        .expect("session meta");
+        meta.fork_agent_session = fork;
+        meta.fork_rewind_prompt_index = rewind;
+        meta
+    }
+
+    #[test]
+    fn linked_reconcile_skips_pending_partial_fork() {
+        assert!(!linked_reconcile_allowed(&fork_meta(true, Some(4))));
+    }
+
+    #[test]
+    fn linked_reconcile_allows_pending_full_fork() {
+        assert!(linked_reconcile_allowed(&fork_meta(true, None)));
+    }
+
+    #[test]
+    fn linked_reconcile_allows_ordinary_linked_session() {
+        assert!(linked_reconcile_allowed(&fork_meta(false, None)));
     }
 }

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -1166,11 +1166,6 @@ impl SessionManager {
         )
         .await;
 
-        // One-shot flags: clear whether fork succeeded or fell through to new/load.
-        if meta.fork_agent_session {
-            let _ = store::clear_session_fork_agent_session(&meta.id);
-        }
-
         match open_result {
             Ok((mut agent_sid, resumed)) => {
                 let plan = child_trim_plan(rewind_index, resumed);
@@ -1325,6 +1320,11 @@ impl SessionManager {
                 Ok(self.snapshot())
             }
             Err(e) => {
+                // Failed open must drop the one-shot so the next connect does
+                // not retry session/fork forever. Success clears via live meta.
+                if meta.fork_agent_session {
+                    let _ = store::clear_session_fork_after_connect_failure(&meta.id);
+                }
                 tracing::warn!(
                     target: "session",
                     session = %meta.id,

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -2385,6 +2385,24 @@ pub fn clear_session_fork_agent_session(id: &str) -> Result<SessionMeta, String>
     set_session_fork_agent_session(id, false)
 }
 
+/// After a failed connect, drop the one-shot fork flags.
+///
+/// Partial forks (those with a rewind index) also drop `agent_session_id` so
+/// the next connect cannot resume the parent's agent id after a failed
+/// agent-side fork attempt. Full forks keep the parent agent id.
+pub fn clear_session_fork_after_connect_failure(id: &str) -> Result<SessionMeta, String> {
+    update_session_row(id, |s| {
+        let pending_partial = s.fork_agent_session && s.fork_rewind_prompt_index.is_some();
+        if pending_partial {
+            s.agent_session_id = None;
+        }
+        s.fork_agent_session = false;
+        s.fork_rewind_prompt_index = None;
+        s.updated_at = Utc::now();
+        Ok(s.clone())
+    })
+}
+
 // ─── Automations (scheduled tasks shell) ───────────────────────────────────
 
 /// Host-side scheduled automation. Execution is driven by the host scheduler
@@ -3778,24 +3796,24 @@ mod tests {
         let mut src = create_session(None, Some("src".into()), false).expect("create");
         src.agent_session_id = Some("agent-parent".into());
         update_session_meta(&src).expect("meta");
-        save_messages(
-            &src.id,
-            &[
-                stored_msg("u1", "user", "first", None),
-                stored_msg("a1", "assistant", "ok", None),
-                stored_msg("u2", "user", "second", None),
-            ],
-        )
-        .expect("msgs");
+        let parent_msgs: Vec<_> = (1u32..=8)
+            .flat_map(|i| {
+                [
+                    stored_msg(&format!("u{i}"), "user", &format!("q{i}"), None),
+                    stored_msg(&format!("a{i}"), "assistant", &format!("a{i}"), None),
+                ]
+            })
+            .collect();
+        save_messages(&src.id, &parent_msgs).expect("msgs");
 
-        let partial = fork_session(&src.id, Some(0), None, true).expect("partial");
+        let partial = fork_session(&src.id, Some(4), None, true).expect("partial");
         assert_eq!(partial.agent_session_id.as_deref(), Some("agent-parent"));
         assert!(partial.fork_agent_session);
-        assert_eq!(partial.fork_rewind_prompt_index, Some(0));
+        assert_eq!(partial.fork_rewind_prompt_index, Some(4));
         let kept = load_messages(&partial.id);
-        assert_eq!(kept.len(), 2, "through first turn only");
-        assert!(kept.iter().all(|m| m.content != "second"));
-        assert_eq!(load_messages(&src.id).len(), 3, "parent journal unchanged");
+        assert_eq!(kept.len(), 10, "through fifth turn only");
+        assert_eq!(kept.last().map(|m| m.content.as_str()), Some("a5"));
+        assert_eq!(load_messages(&src.id).len(), 16, "parent journal unchanged");
         assert_eq!(
             load_sessions_index()
                 .iter()
@@ -3808,12 +3826,13 @@ mod tests {
         let full = fork_session(&src.id, None, None, true).expect("full");
         assert!(full.fork_agent_session);
         assert_eq!(full.fork_rewind_prompt_index, None);
-        assert_eq!(load_messages(&full.id).len(), 3);
+        assert_eq!(load_messages(&full.id).len(), 16);
 
-        let journal_only = fork_session(&src.id, Some(0), None, false).expect("journal");
+        let journal_only = fork_session(&src.id, Some(4), None, false).expect("journal");
         assert!(!journal_only.fork_agent_session);
         assert_eq!(journal_only.fork_rewind_prompt_index, None);
         assert!(journal_only.agent_session_id.is_none());
+        assert_eq!(load_messages(&journal_only.id).len(), 10);
 
         std::env::remove_var("GROK_APP_HOME");
         let _ = fs::remove_dir_all(&tmp);
@@ -3851,6 +3870,66 @@ mod tests {
         assert!(!cleared.fork_agent_session);
         assert_eq!(cleared.fork_rewind_prompt_index, None);
         assert_eq!(cleared.agent_session_id.as_deref(), Some("agent-parent"));
+
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn clear_session_fork_after_connect_failure_partial_drops_agent_id() {
+        let _g = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-app-fork-fail-partial-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = ensure_app_dirs();
+
+        let mut meta = create_session(None, Some("partial-fail".into()), false).expect("create");
+        meta.agent_session_id = Some("agent-parent".into());
+        meta.fork_agent_session = true;
+        meta.fork_rewind_prompt_index = Some(4);
+        update_session_meta(&meta).expect("meta");
+
+        let cleared = clear_session_fork_after_connect_failure(&meta.id).expect("clear");
+        assert!(cleared.agent_session_id.is_none());
+        assert!(!cleared.fork_agent_session);
+        assert_eq!(cleared.fork_rewind_prompt_index, None);
+
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn clear_session_fork_after_connect_failure_full_keeps_agent_id() {
+        let _g = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-app-fork-fail-full-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = ensure_app_dirs();
+
+        let mut meta = create_session(None, Some("full-fail".into()), false).expect("create");
+        meta.agent_session_id = Some("agent-parent".into());
+        meta.fork_agent_session = true;
+        meta.fork_rewind_prompt_index = None;
+        update_session_meta(&meta).expect("meta");
+
+        let cleared = clear_session_fork_after_connect_failure(&meta.id).expect("clear");
+        assert_eq!(cleared.agent_session_id.as_deref(), Some("agent-parent"));
+        assert!(!cleared.fork_agent_session);
+        assert_eq!(cleared.fork_rewind_prompt_index, None);
 
         std::env::remove_var("GROK_APP_HOME");
         let _ = fs::remove_dir_all(&tmp);


### PR DESCRIPTION
## Summary

Fix partial conversation forks so later turns cannot be restored from the parent agent history while the child session is still being created.

## Root cause

`Fork from here` correctly truncated the App journal, but the new child temporarily retained the parent's agent session id. A deferred linked-history reconcile could run before child fork + rewind finished, merge the parent's full `chat_history`, and restore turns after the selected branch point.

The connect path also cleared the pending partial-fork metadata before the child rewind/bootstrap result and replacement agent id were persisted, widening that race.

## Changes

- Skip linked-agent history reconciliation while a partial fork is pending.
- Keep the pending trim metadata until the child agent id and rewind/bootstrap result are persisted together.
- On failed partial-fork connect, clear the inherited parent agent id as well as the one-shot flags, so a later reconnect bootstraps from the already-trimmed journal.
- Expand regression coverage to an 8-turn conversation forked through turn 5, plus pending/full reconcile and failed-connect lifecycle cases.

## Verification

- `pnpm typecheck`
- `pnpm dlx node@22 ./node_modules/vitest/vitest.mjs run` — 6,743 passed
- `pnpm build:ui`
- `pnpm deps:check`
- `rustfmt --edition 2021 --check` on the three changed Rust files
- Targeted Rust fork/reconcile/failure tests — 8 passed
- Full Rust library run — 1,522 passed, 1 ignored; one unrelated LAN-bind health test timed out because the local runner could not reach its own detected LAN address

Manual installed-app verification was not run; CI can exercise the repository matrix.
