### PR TITLE
fix(session): recover partial fork after rewind fallback

### DIFF
--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -16,7 +16,9 @@ use crate::process_limits::{can_spawn_process, normalize_max_concurrent, process
 use crate::session_fsm::{SessionFsm, SessionState};
 use crate::store::{self};
 
-use super::fork_trim::{child_trim_plan, fork_trimmed_outcome, ChildTrimPlan};
+use super::fork_trim::{
+    apply_child_rewind_fail_safe, child_trim_plan, fork_trimmed_outcome, ChildTrimPlan,
+};
 use super::*;
 
 /// Drops `connect_lock` holder diagnostics when the lock guard goes out of
@@ -1197,9 +1199,31 @@ impl SessionManager {
                                     target: "session",
                                     session = %meta.id,
                                     agent = %agent_sid,
+                                    prompt_index,
                                     error = %e,
-                                    "child rewind failed; session/new + bootstrap (will not keep untrimmed fork)"
+                                    "child rewind failed; will not keep untrimmed fork"
                                 );
+                                let fail_safe =
+                                    apply_child_rewind_fail_safe(&meta.id, prompt_index);
+                                match &fail_safe {
+                                    Ok(fs) => tracing::info!(
+                                        target: "session",
+                                        session = %meta.id,
+                                        prompt_index,
+                                        before = fs.before_len,
+                                        after = fs.after_len,
+                                        persisted = fs.persisted,
+                                        need_bootstrap = fs.need_bootstrap,
+                                        "rewind-fail child journal re-cut before session/new"
+                                    ),
+                                    Err(trim_err) => tracing::warn!(
+                                        target: "session",
+                                        session = %meta.id,
+                                        prompt_index,
+                                        error = %trim_err,
+                                        "rewind-fail child journal re-cut failed; refusing bootstrap"
+                                    ),
+                                }
                                 match Self::with_handshake_budget(
                                     client.open_session_at(None, false, &cwd_str),
                                 )
@@ -1207,7 +1231,8 @@ impl SessionManager {
                                 {
                                     Ok((new_sid, _)) => {
                                         agent_sid = new_sid;
-                                        need_bootstrap = journal_has_history;
+                                        need_bootstrap =
+                                            fail_safe.map(|fs| fs.need_bootstrap).unwrap_or(false);
                                         skip_set_mode = false;
                                     }
                                     Err(new_err) => {

--- a/src-tauri/src/session_manager/fork_trim.rs
+++ b/src-tauri/src/session_manager/fork_trim.rs
@@ -18,6 +18,36 @@ pub fn child_trim_plan(rewind_index: Option<u32>, open_resumed: bool) -> ChildTr
     }
 }
 
+/// Result of the rewind-fail journal fail-safe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChildRewindFailSafe {
+    pub before_len: usize,
+    pub after_len: usize,
+    pub persisted: bool,
+    pub need_bootstrap: bool,
+}
+
+/// After a successful re-cut, bootstrap the truncated journal into session/new.
+/// Callers skip bootstrap only when the helper itself fails.
+pub fn need_bootstrap_after_rewind_fail(after_len: usize) -> bool {
+    after_len > 0
+}
+
+/// Re-cut an inflated child journal after rewind fails, then decide bootstrap.
+pub fn apply_child_rewind_fail_safe(
+    session_id: &str,
+    through_user_prompt_index: u32,
+) -> Result<ChildRewindFailSafe, String> {
+    let (before_len, after_len, persisted) =
+        crate::store::retruncate_child_journal_to_cut(session_id, through_user_prompt_index)?;
+    Ok(ChildRewindFailSafe {
+        before_len,
+        after_len,
+        persisted,
+        need_bootstrap: need_bootstrap_after_rewind_fail(after_len),
+    })
+}
+
 /// After a failed child rewind, do not keep the untrimmed forked agent id.
 #[cfg(test)]
 pub fn child_trim_after_rewind_error(rewind_ok: bool) -> ChildTrimPlan {
@@ -43,6 +73,13 @@ pub fn fork_trimmed_outcome(plan: ChildTrimPlan, rewind_ok: Option<bool>) -> Opt
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::{
+        create_session, fork_session, load_messages, replace_messages, save_messages,
+        update_session_meta, ChatMessageStored,
+    };
+    use chrono::Utc;
+    use std::fs;
+    use uuid::Uuid;
 
     #[test]
     fn trim_plan_rewinds_only_resumed_partial() {
@@ -65,6 +102,12 @@ mod tests {
     }
 
     #[test]
+    fn cut_journal_bootstraps_after_rewind_fail() {
+        assert!(need_bootstrap_after_rewind_fail(10));
+        assert!(!need_bootstrap_after_rewind_fail(0));
+    }
+
+    #[test]
     fn trimmed_outcome_is_silent_on_uncut_and_honest_on_bootstrap() {
         assert_eq!(fork_trimmed_outcome(ChildTrimPlan::Skip, None), None);
         assert_eq!(
@@ -83,5 +126,65 @@ mod tests {
             fork_trimmed_outcome(ChildTrimPlan::RewindChild { prompt_index: 0 }, None),
             Some("bootstrap")
         );
+    }
+
+    fn stored_msg(id: &str, role: &str, content: &str) -> ChatMessageStored {
+        ChatMessageStored {
+            id: id.into(),
+            role: role.into(),
+            content: content.into(),
+            thought: None,
+            created_at: Utc::now(),
+            is_error: false,
+            attachments: None,
+            marker: None,
+        }
+    }
+
+    #[test]
+    fn rewind_fail_inflated_child_bootstraps_cut_and_keeps_ten_turns() {
+        let _g = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-app-rewind-fail-safe-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = crate::paths::ensure_app_dirs();
+
+        let mut src = create_session(None, Some("src".into()), false).expect("create");
+        src.agent_session_id = Some("agent-parent".into());
+        update_session_meta(&src).expect("meta");
+        let parent_msgs: Vec<_> = (1u32..=8)
+            .flat_map(|i| {
+                [
+                    stored_msg(&format!("u{i}"), "user", &format!("q{i}")),
+                    stored_msg(&format!("a{i}"), "assistant", &format!("a{i}")),
+                ]
+            })
+            .collect();
+        save_messages(&src.id, &parent_msgs).expect("msgs");
+        let child = fork_session(&src.id, Some(4), None, true).expect("partial");
+        replace_messages(&child.id, &parent_msgs).expect("inflate");
+        assert_eq!(load_messages(&child.id).len(), 16);
+
+        let fs = apply_child_rewind_fail_safe(&child.id, 4).expect("fail-safe");
+        assert_eq!(fs.before_len, 16);
+        assert_eq!(fs.after_len, 10);
+        assert!(fs.persisted);
+        assert!(
+            fs.need_bootstrap,
+            "cut journal must bootstrap after rewind fail"
+        );
+        let kept = load_messages(&child.id);
+        assert_eq!(kept.len(), 10);
+        assert_eq!(kept.last().map(|m| m.content.as_str()), Some("a5"));
+
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -2233,6 +2233,35 @@ pub fn truncate_through_user_prompt(
     Ok(messages[..end].to_vec())
 }
 
+/// Re-cut a child journal to `through_user_prompt_index` if it grew past the cut.
+///
+/// Partial-fork children can be inflated back to the parent transcript (for
+/// example by a linked reconcile). After a failed child rewind, call this
+/// before `session/new` / history bootstrap so the new agent cannot ingest the
+/// untrimmed copy. Read, truncate, and optional persist share the messages-path
+/// exclusive lock so a concurrent append cannot sneak in and then be dropped.
+/// Persists only when the stored journal is longer than the intended cut.
+///
+/// Returns `(before_len, after_len, persisted)`.
+pub fn retruncate_child_journal_to_cut(
+    session_id: &str,
+    through_user_prompt_index: u32,
+) -> Result<(usize, usize, bool), String> {
+    let path = session_dir(session_id).join("messages.json");
+    crate::store_lock::with_exclusive_lock(&path, || {
+        let msgs: Vec<ChatMessageStored> = read_json_recover(&path);
+        let before_len = msgs.len();
+        let truncated = truncate_through_user_prompt(&msgs, through_user_prompt_index)?;
+        let after_len = truncated.len();
+        if after_len < before_len {
+            write_messages_locked(&path, &truncated)?;
+            Ok((before_len, after_len, true))
+        } else {
+            Ok((before_len, after_len, false))
+        }
+    })
+}
+
 /// Count real user prompts (excludes mid-turn `interjection` markers).
 pub fn user_prompt_count(messages: &[ChatMessageStored]) -> u32 {
     messages
@@ -2378,11 +2407,6 @@ pub fn set_session_fork_agent_session(
         s.updated_at = Utc::now();
         Ok(s.clone())
     })
-}
-
-/// Clear the one-shot fork flag after a connect attempt (success or fallthrough).
-pub fn clear_session_fork_agent_session(id: &str) -> Result<SessionMeta, String> {
-    set_session_fork_agent_session(id, false)
 }
 
 /// After a failed connect, drop the one-shot fork flags.
@@ -3838,6 +3862,90 @@ mod tests {
         let _ = fs::remove_dir_all(&tmp);
     }
 
+    fn eight_turn_parent_msgs() -> Vec<ChatMessageStored> {
+        (1u32..=8)
+            .flat_map(|i| {
+                [
+                    stored_msg(&format!("u{i}"), "user", &format!("q{i}"), None),
+                    stored_msg(&format!("a{i}"), "assistant", &format!("a{i}"), None),
+                ]
+            })
+            .collect()
+    }
+
+    #[test]
+    fn retruncate_child_journal_to_cut_persists_inflated_partial_fork() {
+        let _g = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-app-retruncate-inflated-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = ensure_app_dirs();
+
+        let mut src = create_session(None, Some("src".into()), false).expect("create");
+        src.agent_session_id = Some("agent-parent".into());
+        update_session_meta(&src).expect("meta");
+        let parent_msgs = eight_turn_parent_msgs();
+        save_messages(&src.id, &parent_msgs).expect("msgs");
+
+        let child = fork_session(&src.id, Some(4), None, true).expect("partial");
+        assert_eq!(load_messages(&child.id).len(), 10);
+        replace_messages(&child.id, &parent_msgs).expect("inflate");
+        assert_eq!(load_messages(&child.id).len(), 16);
+
+        let (before, after, persisted) =
+            retruncate_child_journal_to_cut(&child.id, 4).expect("retruncate");
+        assert_eq!(before, 16);
+        assert_eq!(after, 10, "through fifth turn only");
+        assert!(persisted);
+        let kept = load_messages(&child.id);
+        assert_eq!(kept.len(), 10);
+        assert_eq!(kept.last().map(|m| m.content.as_str()), Some("a5"));
+        assert_eq!(load_messages(&src.id).len(), 16, "parent journal unchanged");
+
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn retruncate_child_journal_to_cut_skips_unchanged_partial_fork() {
+        let _g = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "grok-app-retruncate-unchanged-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("tmp home");
+        std::env::set_var("GROK_APP_HOME", &tmp);
+        let _ = ensure_app_dirs();
+
+        let mut src = create_session(None, Some("src".into()), false).expect("create");
+        src.agent_session_id = Some("agent-parent".into());
+        update_session_meta(&src).expect("meta");
+        save_messages(&src.id, &eight_turn_parent_msgs()).expect("msgs");
+        let child = fork_session(&src.id, Some(4), None, true).expect("partial");
+        assert_eq!(load_messages(&child.id).len(), 10);
+
+        let (before, after, persisted) =
+            retruncate_child_journal_to_cut(&child.id, 4).expect("retruncate");
+        assert_eq!(before, 10);
+        assert_eq!(after, 10);
+        assert!(!persisted);
+        assert_eq!(load_messages(&child.id).len(), 10);
+
+        std::env::remove_var("GROK_APP_HOME");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
     #[test]
     fn clear_fork_oneshots_clears_rewind_index() {
         let _g = crate::paths::APP_HOME_ENV_LOCK
@@ -3866,7 +3974,7 @@ mod tests {
         .expect("msgs");
         let child = fork_session(&src.id, Some(0), None, true).expect("partial");
         assert_eq!(child.fork_rewind_prompt_index, Some(0));
-        let cleared = clear_session_fork_agent_session(&child.id).expect("clear");
+        let cleared = set_session_fork_agent_session(&child.id, false).expect("clear");
         assert!(!cleared.fork_agent_session);
         assert_eq!(cleared.fork_rewind_prompt_index, None);
         assert_eq!(cleared.agent_session_id.as_deref(), Some("agent-parent"));

--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -7,7 +7,8 @@ import { useEffect, useRef } from "react";
 import * as api from "@/lib/api";
 import { isMirrorClient } from "@/lib/mirrorTransport";
 import { isValidAskUserPayload } from "@/lib/askUserPayload";
-import { forkTrimmedToastKey } from "@/lib/sessionFork";
+import { planForkTrimmedFollowUp } from "@/lib/sessionFork";
+import { projectTrimmedJournalToChat } from "@/lib/sessionJournalHydrate";
 import {
   applyContextCompact,
   applyGeneratedImage,
@@ -1334,10 +1335,29 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
             "session://fork_trimmed",
             (p) => {
               if (cancelled || !p) return;
-              const key = forkTrimmedToastKey(p.outcome);
-              if (!key) return;
-              c.setToast(c.tr(key));
-              window.setTimeout(() => c.setToast(null), 4200);
+              const followUp = planForkTrimmedFollowUp(p);
+              if (followUp.toastKey) {
+                c.setToast(c.tr(followUp.toastKey));
+                window.setTimeout(() => c.setToast(null), 4200);
+              }
+              const sid = followUp.sessionId;
+              if (!sid) return;
+              // Disk is the cut journal. Do not merge/upgrade the live cache —
+              // leftover parent turns would stick.
+              void api
+                .sessionMessages(sid, { reconcile: false })
+                .then((stored) => {
+                  if (cancelled) return;
+                  const woven = projectTrimmedJournalToChat(stored);
+                  c.patchSessionMessages(sid, () => woven);
+                  if (c.viewingSessionIdRef.current === sid) {
+                    void c.tryApplyAutomationFromSession(sid);
+                    applyResolvedRelativeMedia(sid, woven);
+                  }
+                })
+                .catch(() => {
+                  /* disk reload is best-effort */
+                });
             },
           ),
         );

--- a/src/lib/sessionFork.test.ts
+++ b/src/lib/sessionFork.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildForkWorktreeName,
@@ -12,6 +14,7 @@ import {
   isGitWorkingTreeDirty,
   isWorktreeNameCollisionError,
   keepForkDialogOpenOnSoftFail,
+  planForkTrimmedFollowUp,
   resolveForkAgentCheckbox,
   resolveForkAgentSession,
   resolveForkCliOnConfirm,
@@ -405,5 +408,56 @@ describe("forkSuccessToastKey / resumeRestoreSuccessToastKey", () => {
     expect(forkTrimmedToastKey("rewound")).toBe(null);
     expect(forkTrimmedToastKey("bootstrap")).toBe("session.forkOkBootstrap");
     expect(forkTrimmedToastKey("nope")).toBe(null);
+  });
+
+  it("planForkTrimmedFollowUp reloads disk for both outcomes, toasts only bootstrap", () => {
+    expect(planForkTrimmedFollowUp(null)).toEqual({
+      sessionId: null,
+      toastKey: null,
+    });
+    expect(planForkTrimmedFollowUp({ outcome: "bootstrap" })).toEqual({
+      sessionId: null,
+      toastKey: "session.forkOkBootstrap",
+    });
+    expect(
+      planForkTrimmedFollowUp({ sessionId: "  ", outcome: "rewound" }),
+    ).toEqual({ sessionId: null, toastKey: null });
+    expect(
+      planForkTrimmedFollowUp({
+        sessionId: " child-1 ",
+        outcome: "rewound",
+      }),
+    ).toEqual({ sessionId: "child-1", toastKey: null });
+    expect(
+      planForkTrimmedFollowUp({
+        sessionId: "child-2",
+        outcome: "bootstrap",
+      }),
+    ).toEqual({
+      sessionId: "child-2",
+      toastKey: "session.forkOkBootstrap",
+    });
+    expect(
+      planForkTrimmedFollowUp({ sessionId: "child-3", outcome: "nope" }),
+    ).toEqual({ sessionId: "child-3", toastKey: null });
+  });
+});
+
+describe("session://fork_trimmed host listener", () => {
+  it("reloads the cut journal from disk instead of only toasting", () => {
+    const src = readFileSync(
+      resolve(__dirname, "../hooks/useSessionHostEvents.ts"),
+      "utf8",
+    );
+    const start = src.indexOf('"session://fork_trimmed"');
+    expect(start).toBeGreaterThan(0);
+    const block = src.slice(start, start + 1600);
+    expect(block).toContain("planForkTrimmedFollowUp");
+    expect(block).toContain("sessionMessages");
+    expect(block).toContain("reconcile: false");
+    expect(block).toContain("projectTrimmedJournalToChat");
+    expect(block).toContain("patchSessionMessages");
+    expect(block).not.toContain("forkTrimmedToastKey(");
+    expect(block).not.toContain("scheduleJournalRehydrate");
   });
 });

--- a/src/lib/sessionFork.ts
+++ b/src/lib/sessionFork.ts
@@ -718,6 +718,37 @@ export function forkTrimmedToastKey(
   return outcome === "bootstrap" ? "session.forkOkBootstrap" : null;
 }
 
+export type ForkTrimmedFollowUp = {
+  /** Child App session to reload from disk; null skips the reload. */
+  sessionId: string | null;
+  toastKey: "session.forkOkBootstrap" | null;
+};
+
+/**
+ * `session://fork_trimmed` follow-up.
+ *
+ * Partial forks already cut the child journal on disk. The UI must reload
+ * that cut copy — a toast-only handler leaves the parent's later turns
+ * painted from the in-memory cache.
+ */
+export function planForkTrimmedFollowUp(
+  payload:
+    | {
+        sessionId?: string | null;
+        outcome?: string | null;
+      }
+    | null
+    | undefined,
+): ForkTrimmedFollowUp {
+  const raw = payload?.sessionId;
+  const sessionId =
+    typeof raw === "string" && raw.trim() ? raw.trim() : null;
+  return {
+    sessionId,
+    toastKey: forkTrimmedToastKey(payload?.outcome),
+  };
+}
+
 /**
  * Success toast key for resume-with-code restore.
  * Never claims “new agent session” without the fork flag.

--- a/src/lib/sessionJournalHydrate.test.ts
+++ b/src/lib/sessionJournalHydrate.test.ts
@@ -6,6 +6,7 @@ import {
   hydrateSessionJournal,
   journalHasScheduledUser,
   projectJournalToChat,
+  projectTrimmedJournalToChat,
   refineJournalAttachments,
   stripAutomationFences,
   type JournalIo,
@@ -279,5 +280,32 @@ describe("hydrateSessionJournal", () => {
     });
     expect(out[0]?.content).toBe("partial");
     expect(out[0]?.streaming).toBe(true);
+  });
+
+  it("projectTrimmedJournalToChat drops later parent turns that cache still holds", () => {
+    const disk = [
+      stored({ id: "u1", role: "user", content: "q1" }),
+      stored({ id: "a1", role: "assistant", content: "a1" }),
+    ];
+    const cached = [
+      user("u1", "q1"),
+      assistant("a1", "a1"),
+      user("u2", "q2"),
+      assistant("a2", "a2"),
+    ];
+    const leaked = projectJournalToChat({
+      stored: disk,
+      cached,
+      liveState: "idle",
+    });
+    expect(leaked.map((m) => m.id)).toEqual(["u1", "a1", "u2", "a2"]);
+
+    const trimmed = projectTrimmedJournalToChat(disk);
+    expect(trimmed.map((m) => m.id)).toEqual(["u1", "a1"]);
+    expect(trimmed.map((m) => m.content)).toEqual(["q1", "a1"]);
+    // patchSessionMessages reducer must ignore prev — same as this helper.
+    expect(projectTrimmedJournalToChat(disk).map((m) => m.id)).toEqual(
+      cached.slice(0, 2).map((m) => m.id),
+    );
   });
 });

--- a/src/lib/sessionJournalHydrate.ts
+++ b/src/lib/sessionJournalHydrate.ts
@@ -113,6 +113,19 @@ export function projectJournalToChat(opts: {
 }
 
 /**
+ * Partial-fork follow-up: Host already cut the child journal. Disk is
+ * authoritative — never prefer/merge the in-memory cache, which can still
+ * hold the parent's later turns.
+ */
+export function projectTrimmedJournalToChat(
+  stored: StoredJournalMessage[],
+): ChatMessage[] {
+  return stripAutomationFences(
+    weaveToolsIntoAssistantSegments(mapStoredMessagesToChat(stored)),
+  );
+}
+
+/**
  * Drop missing local thumbs; keep http(s); on classify failure keep only
  * displayable paths. Relative-media resolve is applied first when present.
  */


### PR DESCRIPTION
## Summary

Follow-up to #936. Keep a partial fork cut at the selected turn when agent rewind fails, and replace the UI transcript from the cut child journal.

## Real failure path

On the installed macOS app, the child fork succeeded but rewind was unavailable. Before the fallback session/new path, the child journal could be reconciled back to the full parent history. The fallback then bootstrapped that inflated journal, while the UI kept later parent turns in its live cache.

## Changes

- Re-cut the child journal under one exclusive lock before session/new bootstrap after rewind failure.
- Bootstrap only from that re-cut journal; never send the inflated parent copy to the replacement agent.
- On session://fork_trimmed, reload the child journal without reconcile and replace the UI cache instead of merging it.
- Add the exact regression: 8 turns, fork through turn 5, inflate to 8, rewind fails, recover back to 5 while leaving the parent unchanged.

## Verification

- Full frontend suite: 542 files, 6,746 tests passed.
- Targeted frontend fork and journal tests: 43 passed.
- Typecheck and lint passed.
- Targeted Rust recovery tests passed.
- Full Rust library run: 1,525 passed, 1 ignored; one unrelated process cancellation test timed out once and passed on isolated rerun.
- Production UI build and dependency hygiene check passed.
- macOS arm64 app built from this PR head, ad-hoc signed, signature verified, installed over the earlier local test build, and launched from /Applications/Grok.app.
- The exact isolated 8-turn to 5-turn regression passes; existing user conversations were not modified for manual testing.

## CI baseline note

The current red checks are existing main-branch gates, not changed files in this PR: rustfmt reports models_aux.rs, process_util.rs, and providers.rs; the frontend gate reports 74 existing files over 1,000 lines against a budget of 69.