### PR TITLE
fix(wallpaper): bypass WebView2 loopback fetch when applying local media

### DIFF
--- a/docs/llm-wiki/media-delivery.md
+++ b/docs/llm-wiki/media-delivery.md
@@ -43,6 +43,14 @@ Video covers remain separate (`video-posters` + ffmpeg).
 
 `media://` custom protocol remains registered for cold-start races only. Steady-state UI should use HTTP URLs.
 
+Full-file consumers that must construct a browser `Blob` / `File` may use the
+bounded raw-IPC pair `media_file_info` + `media_read_file_chunk`. This avoids a
+WebView2 local-network policy that can block page-script loopback `fetch()`
+before the request reaches the Host CORS handler. Raw IPC reads still require
+`path_scope`, return at most 8 MiB per chunk, and reject files over 200 MiB.
+Wallpaper preview remains on loopback HTTP; only “apply” uses the full-file IPC
+path.
+
 ## Security notes
 
 - Bind **only** loopback.

--- a/src-tauri/src/commands/session_p1.rs
+++ b/src-tauri/src/commands/session_p1.rs
@@ -1127,3 +1127,29 @@ pub async fn media_server_endpoint(
         .ok_or_else(|| "media server not running".to_string())?;
     Ok(handle.endpoint())
 }
+
+/// Metadata for a bounded raw-IPC media read.
+///
+/// Used by full-file consumers when WebView2 blocks JavaScript loopback fetch
+/// before the request can reach the media server's CORS handler.
+#[tauri::command]
+pub async fn media_file_info(path: String) -> Result<crate::media_server::MediaFileInfo, String> {
+    tauri::async_runtime::spawn_blocking(move || crate::media_server::ipc_file_info(&path))
+        .await
+        .map_err(|e| format!("media_file_info task failed: {e}"))?
+}
+
+/// Read one bounded raw byte chunk from an allowlisted local media file.
+#[tauri::command]
+pub async fn media_read_file_chunk(
+    path: String,
+    offset: u64,
+    length: u32,
+) -> Result<tauri::ipc::Response, String> {
+    let bytes = tauri::async_runtime::spawn_blocking(move || {
+        crate::media_server::ipc_read_file_chunk(&path, offset, length)
+    })
+    .await
+    .map_err(|e| format!("media_read_file_chunk task failed: {e}"))??;
+    Ok(tauri::ipc::Response::new(bytes))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1154,6 +1154,10 @@ pub fn run() {
 
             commands::media_server_endpoint,
 
+            commands::media_file_info,
+
+            commands::media_read_file_chunk,
+
             commands::settings_get,
 
             commands::store_take_quarantine,

--- a/src-tauri/src/media_server.rs
+++ b/src-tauri/src/media_server.rs
@@ -38,12 +38,29 @@ const MAX_CHUNK: u64 = 2 * 1024 * 1024; // 2 MiB
 /// MAX_CHUNK yields broken/empty thumbnails for common multi-MB photos.
 const MAX_FULL_BODY: u64 = 40 * 1024 * 1024; // 40 MiB
 
+/// Max bytes returned by one raw Tauri IPC read. Wallpaper application needs a
+/// complete `File`, but one unbounded IPC response would create a large memory
+/// spike for videos.
+pub const MAX_IPC_CHUNK: u32 = 8 * 1024 * 1024; // 8 MiB
+
+/// Same ceiling as wallpaper video preparation/download.
+const MAX_IPC_FILE: u64 = 200 * 1024 * 1024; // 200 MiB
+
 /// Endpoint published to the frontend (base URL + secret token).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaServerEndpoint {
     pub base_url: String,
     pub token: String,
+}
+
+/// Metadata used by bounded raw-IPC reads for full-file consumers.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaFileInfo {
+    pub bytes: u64,
+    pub mime: String,
+    pub name: String,
 }
 
 /// Managed Tauri state — process-wide media server.
@@ -136,6 +153,80 @@ pub fn url_for_path(endpoint: &MediaServerEndpoint, abs_path: &str) -> String {
         urlencoding_encode(&endpoint.token),
         urlencoding_encode(abs_path)
     )
+}
+
+/// Inspect one allowlisted local media file before reading it over raw IPC.
+///
+/// WebView2 can block JavaScript `fetch()` to the loopback server before the
+/// request reaches our CORS handler. Full-file consumers (wallpaper apply) use
+/// this bounded IPC path; normal `<img>` / `<video>` previews still use HTTP.
+pub fn ipc_file_info(path_raw: &str) -> Result<MediaFileInfo, String> {
+    let path = require_allowed_media_file(path_raw)?;
+    let meta = std::fs::metadata(&path).map_err(|e| format!("read_failed: stat: {e}"))?;
+    let bytes = meta.len();
+    if bytes > MAX_IPC_FILE {
+        return Err("read_failed: file too large".into());
+    }
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("wallpaper")
+        .to_string();
+    Ok(MediaFileInfo {
+        bytes,
+        mime: mime_from_path(&path.to_string_lossy()).to_string(),
+        name,
+    })
+}
+
+/// Read one bounded byte window for a full-file raw IPC consumer.
+pub fn ipc_read_file_chunk(path_raw: &str, offset: u64, length: u32) -> Result<Vec<u8>, String> {
+    if length == 0 || length > MAX_IPC_CHUNK {
+        return Err("read_failed: invalid chunk length".into());
+    }
+
+    let path = require_allowed_media_file(path_raw)?;
+    let mut file = std::fs::File::open(&path).map_err(|e| format!("read_failed: open: {e}"))?;
+    let total = file
+        .metadata()
+        .map_err(|e| format!("read_failed: stat: {e}"))?
+        .len();
+    if total > MAX_IPC_FILE {
+        return Err("read_failed: file too large".into());
+    }
+    if offset >= total {
+        return Err("read_failed: invalid chunk offset".into());
+    }
+
+    let expected = u64::from(length).min(total - offset) as usize;
+    let mut bytes = vec![0_u8; expected];
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|e| format!("read_failed: seek: {e}"))?;
+    file.read_exact(&mut bytes)
+        .map_err(|e| format!("read_failed: short read: {e}"))?;
+    Ok(bytes)
+}
+
+fn require_allowed_media_file(path_raw: &str) -> Result<PathBuf, String> {
+    let raw = path_raw.trim();
+    if raw.is_empty() {
+        return Err("read_failed: missing path".into());
+    }
+    let path = PathBuf::from(raw);
+
+    // Check scope before existence so IPC does not become a filesystem oracle.
+    if !crate::path_scope::is_allowed(&path) {
+        return Err("path_not_allowed".into());
+    }
+    if !path.exists() {
+        return Err("read_failed: file not found".into());
+    }
+    let canonical = crate::path_scope::require_allowed(&path).map_err(|_| "path_not_allowed")?;
+    if !canonical.is_file() {
+        return Err("read_failed: file not found".into());
+    }
+    Ok(canonical)
 }
 
 fn random_token() -> String {
@@ -570,6 +661,48 @@ mod tests {
         let u = url_for_path(&ep, "/Users/me/a b.png");
         assert!(u.contains("t=tok"));
         assert!(u.contains("p=%2FUsers%2Fme%2Fa%20b.png") || u.contains("a%20b"));
+    }
+
+    #[tokio::test]
+    async fn ipc_file_read_is_allowlisted_and_chunked() {
+        let _scope = crate::path_scope::TEST_LOCK.lock().await;
+        let dir = std::env::temp_dir().join(format!("grok-media-ipc-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("wallpaper.png");
+        std::fs::write(&file, b"abcdefghij").unwrap();
+        crate::path_scope::grant_path(&file);
+
+        let raw = file.to_string_lossy();
+        let info = ipc_file_info(&raw).expect("info");
+        assert_eq!(info.bytes, 10);
+        assert_eq!(info.mime, "image/png");
+        assert_eq!(info.name, "wallpaper.png");
+        assert_eq!(ipc_read_file_chunk(&raw, 2, 4).expect("chunk"), b"cdef");
+        assert_eq!(ipc_read_file_chunk(&raw, 8, 8).expect("last chunk"), b"ij");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn ipc_file_read_rejects_path_outside_allowlist() {
+        let _scope = crate::path_scope::TEST_LOCK.lock().await;
+        let missing = std::path::PathBuf::from(format!(
+            "/grok-app-untrusted-ipc-{}/nope.png",
+            uuid::Uuid::new_v4()
+        ));
+        let raw = missing.to_string_lossy();
+
+        assert_eq!(ipc_file_info(&raw).unwrap_err(), "path_not_allowed");
+        assert_eq!(
+            ipc_read_file_chunk(&raw, 0, 1).unwrap_err(),
+            "path_not_allowed"
+        );
+    }
+
+    #[test]
+    fn ipc_file_read_rejects_unbounded_chunk() {
+        let err = ipc_read_file_chunk("ignored", 0, MAX_IPC_CHUNK + 1).unwrap_err();
+        assert!(err.contains("invalid chunk length"));
     }
 
     #[tokio::test]

--- a/src/lib/wallpaperSource.test.ts
+++ b/src/lib/wallpaperSource.test.ts
@@ -6,9 +6,11 @@ import {
   isStaticImageLibraryEntry,
   libraryEntriesToGalleryItems,
   libraryEntryToGalleryItem,
+  MEDIA_IPC_CHUNK,
   MEDIA_PROTO_CHUNK,
   parseContentRangeTotal,
   parseWallpaperSourceError,
+  readLocalMediaBlobViaIpc,
   resolveApplySource,
   sortLibraryEntriesStaticFirst,
   type WallpaperGalleryItem,
@@ -162,6 +164,58 @@ describe("wallpaperSource", () => {
     expect(spy.mock.calls.length).toBeGreaterThanOrEqual(3);
     // production default remains 2 MiB
     expect(MEDIA_PROTO_CHUNK).toBe(2 * 1024 * 1024);
+  });
+
+  it("reassembles bounded raw IPC chunks without loopback fetch", async () => {
+    const bytes = Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const invoke = vi.fn(
+      async (command: string, args?: Record<string, unknown>): Promise<unknown> => {
+        if (command === "media_file_info") {
+          return { bytes: bytes.length, mime: "image/png", name: "wall.png" };
+        }
+        if (command === "media_read_file_chunk") {
+          const offset = Number(args?.offset);
+          const length = Number(args?.length);
+          return bytes.slice(offset, offset + length).buffer;
+        }
+        throw new Error(`unexpected command: ${command}`);
+      },
+    );
+
+    const { blob, info } = await readLocalMediaBlobViaIpc(
+      "C:/wallpapers/wall.png",
+      invoke,
+      { chunkSize: 4 },
+    );
+    expect(info).toEqual({
+      bytes: bytes.length,
+      mime: "image/png",
+      name: "wall.png",
+    });
+    expect(new Uint8Array(await blob.arrayBuffer())).toEqual(bytes);
+    expect(blob.type).toBe("image/png");
+    expect(invoke.mock.calls.map(([command]) => command)).toEqual([
+      "media_file_info",
+      "media_read_file_chunk",
+      "media_read_file_chunk",
+      "media_read_file_chunk",
+    ]);
+    expect(MEDIA_IPC_CHUNK).toBe(8 * 1024 * 1024);
+  });
+
+  it("rejects a short raw IPC chunk", async () => {
+    const invoke = vi.fn(
+      async (command: string): Promise<unknown> =>
+        command === "media_file_info"
+          ? { bytes: 4, mime: "image/png", name: "wall.png" }
+          : Uint8Array.from([1, 2, 3]).buffer,
+    );
+
+    await expect(
+      readLocalMediaBlobViaIpc("C:/wallpapers/wall.png", invoke, {
+        chunkSize: 4,
+      }),
+    ).rejects.toThrow("short IPC read (3/4 bytes at 0)");
   });
 
   it("maps library entries to gallery items (static first)", () => {

--- a/src/lib/wallpaperSource.ts
+++ b/src/lib/wallpaperSource.ts
@@ -232,20 +232,124 @@ export async function fetchEntireMediaBlob(
   return new Blob(parts);
 }
 
+/** Bounded raw Tauri IPC chunk size (must match Host `MAX_IPC_CHUNK`). */
+export const MEDIA_IPC_CHUNK = 8 * 1024 * 1024;
+
+/** Wallpaper video ceiling (must match Host `MAX_IPC_FILE`). */
+export const MEDIA_IPC_MAX_FILE = 200 * 1024 * 1024;
+
+type MediaFileInfo = {
+  bytes: number;
+  mime: string;
+  name: string;
+};
+
+type MediaInvoke = (
+  command: string,
+  args?: Record<string, unknown>,
+) => Promise<unknown>;
+
+function ipcBytesToArrayBuffer(value: unknown): ArrayBuffer {
+  if (value instanceof ArrayBuffer) return value;
+  if (ArrayBuffer.isView(value)) {
+    const view = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    const copy = new Uint8Array(view.byteLength);
+    copy.set(view);
+    return copy.buffer;
+  }
+  // Normalize test doubles and bridges that serialize byte buffers as arrays.
+  // Production Tauri returns an ArrayBuffer for `tauri::ipc::Response`.
+  if (
+    Array.isArray(value) &&
+    value.every(
+      (byte) => Number.isInteger(byte) && Number(byte) >= 0 && Number(byte) <= 255,
+    )
+  ) {
+    return Uint8Array.from(value as number[]).buffer;
+  }
+  throw new Error("read_failed: invalid IPC byte response");
+}
+
+/**
+ * Read a complete allowlisted media file through bounded raw Tauri IPC.
+ *
+ * WebView2 can reject page-script `fetch()` to 127.0.0.1 before the request
+ * reaches the Host CORS handler. Raw IPC avoids that browser network gate
+ * while the Host still enforces `path_scope` and a 200 MiB total cap.
+ * `opts.chunkSize` is for unit tests only.
+ */
+export async function readLocalMediaBlobViaIpc(
+  absolutePath: string,
+  invokeImpl?: MediaInvoke,
+  opts?: { chunkSize?: number },
+): Promise<{ blob: Blob; info: MediaFileInfo }> {
+  const invoke: MediaInvoke =
+    invokeImpl ?? ((await import("@tauri-apps/api/core")).invoke as MediaInvoke);
+  const rawInfo = await invoke("media_file_info", {
+    path: absolutePath,
+  });
+  if (!rawInfo || typeof rawInfo !== "object") {
+    throw new Error("read_failed: invalid media metadata");
+  }
+
+  const candidate = rawInfo as Partial<MediaFileInfo>;
+  const bytes = Number(candidate.bytes);
+  if (!Number.isSafeInteger(bytes) || bytes < 0 || bytes > MEDIA_IPC_MAX_FILE) {
+    throw new Error("read_failed: invalid media size");
+  }
+  const chunkSize = opts?.chunkSize ?? MEDIA_IPC_CHUNK;
+  if (
+    !Number.isSafeInteger(chunkSize) ||
+    chunkSize <= 0 ||
+    chunkSize > MEDIA_IPC_CHUNK
+  ) {
+    throw new Error("read_failed: invalid IPC chunk size");
+  }
+
+  const info: MediaFileInfo = {
+    bytes,
+    mime:
+      typeof candidate.mime === "string" && candidate.mime.trim()
+        ? candidate.mime
+        : "application/octet-stream",
+    name:
+      typeof candidate.name === "string" && candidate.name.trim()
+        ? candidate.name
+        : absolutePath.split(/[/\\]/).pop() || "wallpaper",
+  };
+
+  const parts: ArrayBuffer[] = [];
+  let got = 0;
+  for (let offset = 0; offset < bytes; offset += chunkSize) {
+    const length = Math.min(chunkSize, bytes - offset);
+    const raw = await invoke("media_read_file_chunk", {
+      path: absolutePath,
+      offset,
+      length,
+    });
+    const part = ipcBytesToArrayBuffer(raw);
+    if (part.byteLength !== length) {
+      throw new Error(
+        `read_failed: short IPC read (${part.byteLength}/${length} bytes at ${offset})`,
+      );
+    }
+    got += part.byteLength;
+    parts.push(part);
+  }
+  if (got !== bytes) {
+    throw new Error(`read_failed: short IPC read (${got}/${bytes} bytes)`);
+  }
+  return { blob: new Blob(parts, { type: info.mime }), info };
+}
+
 /**
  * Load a local absolute path into a File for prepareWallpaperFromFile.
- * Uses Host loopback media HTTP with **full Range reassembly** (not a single bare GET).
+ * Uses bounded raw Tauri IPC so WebView2 local-network policy cannot block it.
  */
 export async function fileFromAbsolutePath(
   absolutePath: string,
   opts?: { name?: string; mime?: string },
 ): Promise<File> {
-  const name =
-    opts?.name ||
-    absolutePath.split(/[/\\]/).pop() ||
-    "wallpaper.jpg";
-  const mime = opts?.mime || mimeFromName(name);
-
   // Browser / unit tests: no Tauri
   if (
     typeof window === "undefined" ||
@@ -254,27 +358,32 @@ export async function fileFromAbsolutePath(
     throw new Error("desktop_only");
   }
 
-  const { resolveImageSrc } = await import("@/lib/imageSrc");
-  const url = await resolveImageSrc(absolutePath);
-  if (!url) {
-    throw new Error("read_failed: cannot resolve local media URL");
-  }
-
-  let blob: Blob;
+  let result: Awaited<ReturnType<typeof readLocalMediaBlobViaIpc>>;
   try {
-    blob = await fetchEntireMediaBlob(url);
+    result = await readLocalMediaBlobViaIpc(absolutePath);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("path_not_allowed")) throw new Error("path_not_allowed");
     if (msg.startsWith("read_failed")) throw e instanceof Error ? e : new Error(msg);
     throw new Error(`read_failed: ${msg}`);
   }
 
+  const { blob, info } = result;
   if (!blob.size) {
     throw new Error("read_failed: empty file");
   }
 
+  const name =
+    opts?.name ||
+    info.name ||
+    absolutePath.split(/[/\\]/).pop() ||
+    "wallpaper.jpg";
+  const fallbackMime = mimeFromName(name);
   const type =
-    blob.type && blob.type !== "application/octet-stream" ? blob.type : mime;
+    opts?.mime ||
+    (blob.type && blob.type !== "application/octet-stream"
+      ? blob.type
+      : fallbackMime);
   return new File([blob], name, { type });
 }
 


### PR DESCRIPTION
## Summary

Fix wallpaper application when a local preview renders but **Set as background** fails on Windows. WebView2 can block a page-script loopback `fetch()` before the request reaches the Host CORS handler.

- Keep loopback HTTP for image/video previews and streaming.
- Read full wallpaper files through bounded raw Tauri IPC.
- Enforce `path_scope` for metadata and every chunk read.
- Cap each IPC response at 8 MiB and reject files over 200 MiB.
- Validate metadata and chunk assembly before constructing the browser `File`.
- Document the delivery split and add frontend/Host regression coverage.

The shared `fileFromAbsolutePath` helper is used by the wallpaper source modal and skin-pack wallpaper application, so both full-file consumers use the same bounded path.

## Root cause

The preview path is a normal `<img>` / `<video>` load and can succeed through the loopback media server. Applying a wallpaper needs to turn that same path into a browser `File`; its page-script `fetch()` can be rejected by WebView2 before the Host sees the request, making preview and apply behave differently.

## Security and compatibility

The Host re-checks `path_scope` on both metadata lookup and every chunk read. No filesystem paths, user directories, or Windows-only paths are hard-coded. Tauri raw IPC is cross-platform; WebView2 is the trigger for the fix, not a runtime requirement.

## Verification

- Manual Windows app verification: image preview, apply progress, modal close, settings thumbnail, and persisted workbench background all passed.
- `pnpm exec vitest run src/lib/wallpaperSource.test.ts` — 10 passed.
- `pnpm typecheck` — passed.
- `pnpm exec eslint src/lib/wallpaperSource.ts src/lib/wallpaperSource.test.ts --max-warnings 0` — passed.
- `pnpm build:ui` — passed.
- `rustfmt +1.95.0 --edition 2021 --check src/media_server.rs` — passed.
- Windows CI-style manifest harness: `media_server::tests` — 12 passed.
- Full local `pnpm test` was also attempted; five unrelated baseline/environment failures remain (native `canvas.node`, source-text guards, and a concurrent timeout). The affected wallpaper suite is green.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [ ] I ran `pnpm typecheck` and `pnpm test` (typecheck and affected tests pass; full-suite baseline failures are documented above)
- [ ] I ran `cargo test` in `src-tauri` (plain Windows harness startup is blocked by the repository's known `0xc0000139`; the repository CI manifest flow passes all 12 affected tests)
- [x] No new user-facing strings were added
- [x] No `window.confirm` / `prompt` / `alert` was added
- [x] `docs/llm-wiki/media-delivery.md` documents the behavior change
- [x] No secrets (`secrets.json`, tokens, `auth.json`) are included