### PR TITLE
fix(composer): Mac steer is Ctrl+Enter only (#946)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
+- Mac Steer is Ctrl+Enter only, matching Grok Build CLI. Cmd+Enter no longer steers (#946).
 - Windows wallpaper frost reaches the sidebar and empty chat. WebView2 skipped container blur.
 - Fork from a middle turn no longer brings back later parent messages.
 - Rapid follow-up messages no longer lose the next reply.
 
 **中文 · 修复**
+- 修复 Mac 引导快捷键。对标 Grok Build CLI，只用 Ctrl+Enter，不再认 ⌘Enter（#946）。
 - 修复 Windows 壁纸透过侧栏和空会话。WebView2 会跳过容器模糊。
 - 修复从中间分叉时后面的父会话消息又回来。
 - 修复连续快速发送时下一条回复丢失。

--- a/src/lib/composerSendKey.test.ts
+++ b/src/lib/composerSendKey.test.ts
@@ -109,8 +109,14 @@ describe("shouldSteerOnKeydown — Grok Build CLI Ctrl+Enter", () => {
     expect(shouldSteerOnKeydown(key({ ctrlKey: true }))).toBe(true);
   });
 
-  it("also steers on Cmd+Enter (macOS App modifier)", () => {
-    expect(shouldSteerOnKeydown(key({ metaKey: true }))).toBe(true);
+  it("does not steer on Cmd+Enter (CLI chord is Ctrl, not Cmd)", () => {
+    expect(shouldSteerOnKeydown(key({ metaKey: true }))).toBe(false);
+  });
+
+  it("does not treat Ctrl+Cmd+Enter as steer", () => {
+    expect(shouldSteerOnKeydown(key({ ctrlKey: true, metaKey: true }))).toBe(
+      false,
+    );
   });
 
   it("does not steal plain Enter (that still sends / queues)", () => {
@@ -195,5 +201,22 @@ describe("resolveComposerSubmitAction", () => {
         sessionState: "ready",
       }),
     ).toBe(false);
+  });
+
+  it("live turn: Cmd+Enter does not steal steer (Mac send pref can still send)", () => {
+    expect(
+      resolveComposerSubmitAction({
+        event: key({ metaKey: true }),
+        sendPref: "mod-enter",
+        canSteer: true,
+      }),
+    ).toBe("send");
+    expect(
+      resolveComposerSubmitAction({
+        event: key({ metaKey: true }),
+        sendPref: "enter",
+        canSteer: true,
+      }),
+    ).toBe("none");
   });
 });

--- a/src/lib/composerSendKey.ts
+++ b/src/lib/composerSendKey.ts
@@ -74,19 +74,22 @@ export function shouldSendOnKeydown(
  * family Ctrl+L as terminal-specific alts).
  *
  * Independent of the Composer send-key preference. While a turn is live,
- * this chord steers (`sessionInterject`) instead of queueing. Cmd+Enter is
- * accepted too so macOS App users hit the same modifier as other App chords.
+ * this chord steers (`sessionInterject`) instead of queueing.
+ *
+ * Ctrl only — not Cmd. Grok Build CLI uses Ctrl+Enter on every platform,
+ * including macOS (Apple Terminal falls back to Ctrl+O). Cmd+Enter stays
+ * the optional Composer send key (`mod-enter`).
  */
 export function shouldSteerOnKeydown(e: ComposerSendKeyEvent): boolean {
   if (e.key !== "Enter") return false;
   if (e.shiftKey || e.altKey) return false;
-  return e.ctrlKey || e.metaKey;
+  return e.ctrlKey && !e.metaKey;
 }
 
 export type ComposerSubmitAction = "steer" | "send" | "none";
 
 /**
- * Whether the Ctrl/Cmd+Enter chord should be dispatched to `steerFromComposer`.
+ * Whether the Ctrl+Enter chord should be dispatched to `steerFromComposer`.
  * Permission waits stay **true** — that handler toasts and refuses to write.
  * Pre-filtering `awaiting_permission` here made the chord a silent no-op.
  */


### PR DESCRIPTION
Fixes #946

## Summary

Mid-turn Steer on Mac is **Ctrl+Enter** only, same as Grok Build CLI. ⌘Enter no longer steers.

#741 bound `ctrlKey || metaKey` so Mac would “feel like other App chords.” The shortcuts catalog already shows `⌃ ↵`, and the Settings note already says Steer is Ctrl+Enter. Cmd+Enter also ate the optional Composer send preference while a turn was live.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist
- [x] `vitest run src/lib/composerSendKey.test.ts src/lib/shortcuts.test.ts` — 63 passed
- [x] No new user-facing strings
- [x] CHANGELOG Unreleased updated
- [x] No secrets
