### PR TITLE
fix(chat): settle bottom overscroll without hiding the tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ See `docs/llm-wiki/release.md`.
 - Windows wallpaper frost reaches the sidebar and empty chat. WebView2 skipped container blur.
 - Fork from a middle turn no longer brings back later parent messages.
 - Rapid follow-up messages no longer lose the next reply.
+- Bottom overscroll no longer rebounds above hidden chat content.
 
 **中文 · 修复**
 - 修复 Windows 壁纸透过侧栏和空会话。WebView2 会跳过容器模糊。
 - 修复从中间分叉时后面的父会话消息又回来。
 - 修复连续快速发送时下一条回复丢失。
+- 修复底部超滚回弹后仍有聊天内容被遮挡。
 
 ## [0.2.27] - 2026-08-27
 

--- a/src/hooks/useStickToBottom.test.tsx
+++ b/src/hooks/useStickToBottom.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { STICK_BOTTOM_REBOUND_SETTLE_MS } from "@/lib/stickToBottom";
+import { useStickToBottom } from "./useStickToBottom";
+
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe("useStickToBottom bottom rebound", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("ResizeObserver", NoopResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("snaps to the latest max after a downward overscroll rebounds upward", () => {
+    const viewport = document.createElement("div");
+    const content = document.createElement("div");
+    viewport.appendChild(content);
+    let scrollTop = 600;
+    let scrollHeight = 1000;
+    Object.defineProperties(viewport, {
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+      scrollHeight: {
+        configurable: true,
+        get: () => scrollHeight,
+      },
+      clientHeight: {
+        configurable: true,
+        get: () => 400,
+      },
+      clientWidth: {
+        configurable: true,
+        get: () => 800,
+      },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ keyName }) => useStickToBottom({ conversationKey: keyName }),
+      { initialProps: { keyName: "before-attach" } },
+    );
+    Object.assign(result.current.viewportRef, { current: viewport });
+    Object.assign(result.current.contentRef, { current: content });
+
+    // Re-run effects after refs point at the real WebView scroll container.
+    rerender({ keyName: "attached" });
+    act(() => vi.advanceTimersByTime(40));
+    scrollTop = 600;
+
+    act(() => {
+      viewport.dispatchEvent(new WheelEvent("wheel", { deltaY: 40 }));
+      // Queue/composer grows during the elastic settle: true max is now 640.
+      scrollHeight = 1040;
+      scrollTop = 620;
+      viewport.dispatchEvent(new Event("scroll"));
+      scrollTop = 600;
+      viewport.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(STICK_BOTTOM_REBOUND_SETTLE_MS + 1);
+    });
+
+    expect(scrollTop).toBe(640);
+    expect(result.current.isPinnedRef.current).toBe(true);
+  });
+
+  it("keeps a real upward wheel gesture escaped", () => {
+    const viewport = document.createElement("div");
+    const content = document.createElement("div");
+    viewport.appendChild(content);
+    let scrollTop = 600;
+    Object.defineProperties(viewport, {
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+      scrollHeight: { configurable: true, get: () => 1000 },
+      clientHeight: { configurable: true, get: () => 400 },
+      clientWidth: { configurable: true, get: () => 800 },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ keyName }) => useStickToBottom({ conversationKey: keyName }),
+      { initialProps: { keyName: "before-attach" } },
+    );
+    Object.assign(result.current.viewportRef, { current: viewport });
+    Object.assign(result.current.contentRef, { current: content });
+    rerender({ keyName: "attached" });
+    act(() => vi.advanceTimersByTime(40));
+    scrollTop = 600;
+
+    act(() => {
+      viewport.dispatchEvent(new WheelEvent("wheel", { deltaY: 40 }));
+      viewport.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }));
+      scrollTop = 550;
+      viewport.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(STICK_BOTTOM_REBOUND_SETTLE_MS + 20);
+    });
+
+    expect(scrollTop).toBe(550);
+    expect(result.current.isPinnedRef.current).toBe(false);
+  });
+});

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -22,6 +22,8 @@ import {
 import {
   STICK_ESCAPE_MIN_DELTA_PX,
   STICK_ESCAPE_WHEEL_DELTA,
+  STICK_BOTTOM_REBOUND_INTENT_MS,
+  STICK_BOTTOM_REBOUND_SETTLE_MS,
   STICK_OPEN_FOLLOW_MS,
   STICK_TO_BOTTOM_THRESHOLD_PX,
   bottomScrollTop,
@@ -34,6 +36,7 @@ import {
   shouldClampPinnedOverscroll,
   shouldClampPinnedStreamDrift,
   shouldEscapePinnedScroll,
+  shouldSettleBottomRebound,
   takeProgrammaticStickScroll,
 } from "@/lib/stickToBottom";
 
@@ -62,6 +65,13 @@ export type UseStickToBottomResult = {
   subscribeShowBack: (cb: (val: boolean) => void) => () => void;
 };
 
+function stickNowMs(): number {
+  return typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
 export function useStickToBottom(
   options: UseStickToBottomOptions = {},
 ): UseStickToBottomResult {
@@ -87,6 +97,8 @@ export function useStickToBottom(
    * final scroll event has no positive delta.
    */
   const userIntentDownRef = useRef(false);
+  /** Recent real wheel/touch intent toward the tail; survives elastic rebound. */
+  const bottomIntentUntilRef = useRef(0);
   const lastScrollTopRef = useRef(0);
   /** scrollTop we just wrote — used to ignore synthetic scroll events. */
   const ignoreScrollTopRef = useRef<number | undefined>(undefined);
@@ -107,6 +119,7 @@ export function useStickToBottom(
     escapedRef.current = false;
     isPinnedRef.current = true;
     userIntentDownRef.current = false;
+    bottomIntentUntilRef.current = 0;
     lastScrollTopRef.current = 0;
     const now =
       typeof performance !== "undefined" && typeof performance.now === "function"
@@ -223,6 +236,43 @@ export function useStickToBottom(
     const el = viewportRef.current;
     if (!el) return;
 
+    let bottomReboundTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearBottomRebound = () => {
+      bottomIntentUntilRef.current = 0;
+      if (bottomReboundTimer != null) {
+        clearTimeout(bottomReboundTimer);
+        bottomReboundTimer = null;
+      }
+    };
+    const armBottomIntent = () => {
+      bottomIntentUntilRef.current =
+        stickNowMs() + STICK_BOTTOM_REBOUND_INTENT_MS;
+    };
+    const scheduleBottomReboundSettle = () => {
+      if (bottomReboundTimer != null) clearTimeout(bottomReboundTimer);
+      bottomReboundTimer = setTimeout(() => {
+        bottomReboundTimer = null;
+        const v = viewportRef.current;
+        if (!v || stickNowMs() > bottomIntentUntilRef.current) return;
+        if (
+          !isNearBottom(
+            v.scrollTop,
+            v.scrollHeight,
+            v.clientHeight,
+            thresholdRef.current,
+          )
+        ) {
+          return;
+        }
+        escapedRef.current = false;
+        isPinnedRef.current = true;
+        userIntentDownRef.current = false;
+        bottomIntentUntilRef.current = 0;
+        applyScrollTop(bottomScrollTop(v.scrollHeight, v.clientHeight));
+        syncShowBack();
+      }, STICK_BOTTOM_REBOUND_SETTLE_MS);
+    };
+
     const handleScroll = () => {
       const scrollTop = el.scrollTop;
       let lastScrollTop = lastScrollTopRef.current;
@@ -237,6 +287,23 @@ export function useStickToBottom(
       }
 
       const maxTop = bottomScrollTop(el.scrollHeight, el.clientHeight);
+      const isMovingUp = scrollTop < lastScrollTop - 0.5;
+      const bottomRebound = shouldSettleBottomRebound({
+        downIntentActive: stickNowMs() <= bottomIntentUntilRef.current,
+        scrollTop,
+        previousScrollTop: lastScrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        thresholdPx: thresholdRef.current,
+      });
+      if (bottomRebound) {
+        if (scrollDebounceTimerRef.current != null) {
+          clearTimeout(scrollDebounceTimerRef.current);
+          scrollDebounceTimerRef.current = null;
+        }
+        scheduleBottomReboundSettle();
+        return;
+      }
       // Default 10px event + slow-trackpad accumulation from the locked
       // bottom. Never use a sub-pixel minDelta: thinking / tool collapse and
       // the next body round routinely move 2–8px off hard bottom, and that
@@ -249,7 +316,6 @@ export function useStickToBottom(
         scrollHeight: el.scrollHeight,
         clientHeight: el.clientHeight,
       });
-      const isMovingUp = scrollTop < lastScrollTop - 0.5;
       const meaningfulDown =
         scrollTop - lastScrollTop >= STICK_ESCAPE_MIN_DELTA_PX;
 
@@ -359,6 +425,7 @@ export function useStickToBottom(
         e.deltaY <= -STICK_ESCAPE_WHEEL_DELTA &&
         el.scrollHeight > el.clientHeight
       ) {
+        clearBottomRebound();
         userIntentDownRef.current = false;
         if (isPinnedRef.current) {
           escapedRef.current = true;
@@ -370,6 +437,7 @@ export function useStickToBottom(
       // deltaY > 0 → scrolling toward latest. Mark intent so a no-delta
       // hard-bottom landing (max scrollTop) still re-pins.
       if (e.deltaY >= STICK_ESCAPE_WHEEL_DELTA) {
+        armBottomIntent();
         userIntentDownRef.current = true;
         if (escapedRef.current) {
           requestAnimationFrame(() => {
@@ -405,6 +473,7 @@ export function useStickToBottom(
       // Require a clear drag so a light touch at the locked bottom does not
       // unstick and then snap back (bounce + flash).
       if (dy > STICK_ESCAPE_MIN_DELTA_PX) {
+        clearBottomRebound();
         userIntentDownRef.current = false;
         if (isPinnedRef.current) {
           escapedRef.current = true;
@@ -413,6 +482,7 @@ export function useStickToBottom(
         }
       } else if (dy < -STICK_ESCAPE_MIN_DELTA_PX) {
         // Finger moves up → content moves down (toward latest)
+        armBottomIntent();
         userIntentDownRef.current = true;
       }
       touchY = y;
@@ -453,6 +523,10 @@ export function useStickToBottom(
       if (scrollDebounceTimerRef.current != null) {
         clearTimeout(scrollDebounceTimerRef.current);
         scrollDebounceTimerRef.current = null;
+      }
+      if (bottomReboundTimer != null) {
+        clearTimeout(bottomReboundTimer);
+        bottomReboundTimer = null;
       }
     };
   }, [enabled, conversationKey, syncShowBack, applyScrollTop]);

--- a/src/lib/stickToBottom.test.ts
+++ b/src/lib/stickToBottom.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   STICK_ESCAPE_MIN_DELTA_PX,
+  STICK_BOTTOM_REBOUND_INTENT_MS,
+  STICK_BOTTOM_REBOUND_SETTLE_MS,
   STICK_HEIGHT_NOISE_PX,
   STICK_HARD_BOTTOM_PX,
   STICK_TO_BOTTOM_THRESHOLD_PX,
@@ -23,6 +25,7 @@ import {
   shouldReleaseStickOnScrollUp,
   shouldReleaseStickOnSlowScrollUp,
   shouldSnapPinnedLayoutToBottom,
+  shouldSettleBottomRebound,
   isConversationOpenFollowActive,
   transcriptStickIdentity,
   shouldFollowPinnedMediaReveal,
@@ -32,6 +35,60 @@ import {
   markProgrammaticStickScroll,
   takeProgrammaticStickScroll,
 } from "./stickToBottom";
+
+describe("bottom overscroll rebound", () => {
+  it("settles a recent downward rebound inside the tail band", () => {
+    expect(
+      shouldSettleBottomRebound({
+        downIntentActive: true,
+        previousScrollTop: 610,
+        scrollTop: 590,
+        scrollHeight: 1000,
+        clientHeight: 400,
+      }),
+    ).toBe(true);
+  });
+
+  it("covers a queue/composer height increase during the rebound", () => {
+    // Old bottom was 600. Queue chrome adds 40px before the elastic settle.
+    expect(
+      shouldSettleBottomRebound({
+        downIntentActive: true,
+        previousScrollTop: 620,
+        scrollTop: 600,
+        scrollHeight: 1040,
+        clientHeight: 400,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not steal a real reverse gesture or history scroll", () => {
+    expect(
+      shouldSettleBottomRebound({
+        downIntentActive: false,
+        previousScrollTop: 620,
+        scrollTop: 600,
+        scrollHeight: 1040,
+        clientHeight: 400,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSettleBottomRebound({
+        downIntentActive: true,
+        previousScrollTop: 500,
+        scrollTop: 450,
+        scrollHeight: 1200,
+        clientHeight: 400,
+      }),
+    ).toBe(false);
+  });
+
+  it("uses a grace longer than the quiet settle window", () => {
+    expect(STICK_BOTTOM_REBOUND_INTENT_MS).toBeGreaterThan(
+      STICK_BOTTOM_REBOUND_SETTLE_MS,
+    );
+  });
+});
 
 describe("distanceFromBottom", () => {
   it("is 0 at bottom", () => {

--- a/src/lib/stickToBottom.ts
+++ b/src/lib/stickToBottom.ts
@@ -61,6 +61,16 @@ export const STICK_ESCAPE_MIN_DELTA_PX = 10;
  */
 export const STICK_ESCAPE_WHEEL_DELTA = 10;
 
+/**
+ * Keep a recent gesture toward the tail alive across compositor rubber-band.
+ * WebView2 may report the rebound as a decreasing `scrollTop` even though the
+ * user never reversed direction.
+ */
+export const STICK_BOTTOM_REBOUND_INTENT_MS = 320;
+
+/** Quiet window after the last rebound scroll event before snapping to max. */
+export const STICK_BOTTOM_REBOUND_SETTLE_MS = 96;
+
 /** True when the upward scroll is large enough to intentionally leave the bottom. */
 export function isMeaningfulScrollUp(
   scrollTop: number,
@@ -80,6 +90,30 @@ export function shouldClampPinnedOverscroll(
   maxTop: number,
 ): boolean {
   return scrollTop > maxTop + 0.5;
+}
+
+/**
+ * A downward wheel/touch gesture can overshoot the tail and rebound upward.
+ * That decreasing `scrollTop` is not a request to read history. Recover only
+ * inside the near-bottom band and only while the downward intent is current;
+ * a real reverse wheel/touch gesture clears that intent before scroll events.
+ */
+export function shouldSettleBottomRebound(input: {
+  downIntentActive: boolean;
+  scrollTop: number;
+  previousScrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  thresholdPx?: number;
+}): boolean {
+  if (!input.downIntentActive) return false;
+  if (input.previousScrollTop - input.scrollTop < 0.5) return false;
+  return isNearBottom(
+    input.scrollTop,
+    input.scrollHeight,
+    input.clientHeight,
+    input.thresholdPx,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- preserve a recent wheel/touch intent toward the tail across WebView2 rubber-band rebound
- wait for a short quiet window, then recompute the latest `scrollHeight - clientHeight` and restore the bottom pin
- clear the rebound latch immediately on a real upward wheel/touch gesture so history browsing is never yanked back
- cover dynamic composer/queue height growth with pure-policy and DOM-hook regression tests

## Root cause

The floating composer changes the transcript's bottom padding through `ResizeObserver`. Near the tail, WebView2 can report elastic settle as a decreasing `scrollTop`. The scroll handler treated that reverse displacement as an intentional upward history gesture before the new composer padding had settled, set `escaped=true`, and stopped following. The viewport then rested above the true max while the last chat rows remained under the composer.

## Windows WebView2 runtime verification

Ran a side-by-side Tauri dev build with a distinct identifier, port, and data root. The runtime probe used the real `.lobe-chat__scroll`, `.lobe-chat__inner`, `.composer`, `ResizeObserver`, and wheel/scroll listeners:

- dynamic composer/queue-height probe changed max scroll position `1831 -> 1877`
- after downward overscroll + reverse settle: `scrollTop=1877`, bottom gap `0px`
- Back to latest button hidden after settle
- last content bottom `546px`, composer top `634px` (`88px` clear)
- explicit reverse upward wheel stayed at `max - 64px` and showed Back to latest

The isolated runtime process and WebView2 children were stopped after the smoke test.

## Automated verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:ui`
- focused scroll/virtualization suite: 128 passed, 0 failed
- changelog parser: 20 passed, 0 failed
- full frontend suite: 6,751 passed; the only three first-pass failures were two CRLF-sensitive source guards and one 5s parallel timeout
- LF guard rerun: 4 passed, 0 failed
- settings catalog isolated rerun: 16 passed, 0 failed

## Notes

The 320ms intent grace is longer than the 96ms quiet-settle window. A real direction reversal clears the grace synchronously in the wheel/touch handler, so the recovery path only applies to compositor rebound inside the existing near-bottom band.