### PR TITLE
feat: 模型按钮改为组合芯片并支持高级悬停侧栏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Changed
+- Composer model chip is one control for model + effort. Advanced opens a hub; hover a row to pick on the side. Empty and active chats share the same width.
+
+**中文 · 变更**
+- 输入框模型按钮改为模型+推理一颗芯片。高级是悬停侧出的设置层。空对话和进行中对话同一列宽。
+
 ### Added
 - **SSH remote hosts**: Settings → Runtime → SSH lists `~/.ssh/config` Host aliases. Test connection, then watch a host to list remote Grok sessions in the sidebar, open/resume them, start a new chat in a remote folder, and run `grok agent stdio` on the host via OpenSSH. macOS/Linux reuse a ControlMaster; Windows opens a fresh connection per action. Persistence is `grok agent leader`, not tmux. Remote paths are never treated as local disk.
 

--- a/src/app/WorkbenchComposerColumn.tsx
+++ b/src/app/WorkbenchComposerColumn.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/askUserSettle";
 import { type CSSProperties, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { ComposerModelMenu } from "@/components/ComposerModelMenu";
 import { WorkbenchComposerShell } from "@/app/WorkbenchComposerShell";
 
 export type WorkbenchComposerColumnProps = {
@@ -85,6 +86,18 @@ export function WorkbenchComposerColumn(p: WorkbenchComposerColumnProps) {
     mainPane,
     tr,
     session,
+    locale,
+    modelId,
+    effort,
+    availableModels,
+    composerProviderInputs,
+    providerActiveSource,
+    providerActiveId,
+    channelEffortOptions,
+    currentModelWindow,
+    handleContextWindow,
+    handleModelPick,
+    handleEffortPick,
   } = p;
   const [permBusy, setPermBusy] = useState(false);
   const [permError, setPermError] = useState<string | null>(null);
@@ -339,18 +352,25 @@ export function WorkbenchComposerColumn(p: WorkbenchComposerColumnProps) {
                 (!!sessionChangesSummary || !!gitDirtySummary);
               const showContextBar =
                 showComposerProjectRow || showChangesChips;
+              // Desktop: workspace cluster left, model/effort right.
+              // Phone keeps model/access in PhoneComposerToolsSheet.
+              const showComposerChrome = !phoneLayout;
               return (
             <div
               className={
                 "composer-stack" +
-                (showContextBar ? " composer-stack--with-context" : "")
+                (showContextBar || showComposerChrome
+                  ? " composer-stack--with-context"
+                  : "")
               }
             >
+            {showComposerChrome ? (
+            <div className="composer__chrome">
             {/* Workspace / branch + session/workspace change chips.
                 Hidden entirely when the bar would be empty. */}
             {showContextBar ? (
               <div
-                className="composer__context-bar"
+                className="composer__context-bar composer__chip-shell"
                 aria-label={
                   showComposerProjectRow
                     ? tr("composer.pickProject")
@@ -612,6 +632,61 @@ export function WorkbenchComposerColumn(p: WorkbenchComposerColumnProps) {
                   </div>
                 ) : null}
               </div>
+            ) : null}
+              <div
+                className="composer__model-bar composer__chip-shell"
+                aria-label={tr("composer.model")}
+              >
+                <ComposerModelMenu
+                  locale={locale}
+                  modelId={modelId}
+                  effort={effort}
+                  models={availableModels}
+                  providers={composerProviderInputs}
+                  activeSource={providerActiveSource}
+                  activeProviderId={providerActiveId}
+                  channelEfforts={channelEffortOptions}
+                  contextWindow={currentModelWindow}
+                  contextWindowEditable={customRouteActive}
+                  onContextWindow={handleContextWindow}
+                  labels={{
+                    model: tr("composer.model"),
+                    modelGroupOfficial: tr("composer.modelGroupOfficial"),
+                    modelViaProvider: tr("composer.modelViaProvider"),
+                    effort: tr("composer.effort"),
+                    effortHigh: tr("effort.high"),
+                    effortMedium: tr("effort.medium"),
+                    effortLow: tr("effort.low"),
+                    effortXhigh: tr("effort.xhigh"),
+                    effortMax: tr("effort.max"),
+                    modelSearchPlaceholder: tr(
+                      "composer.modelSearchPlaceholder",
+                    ),
+                    modelSearchEmpty: tr("composer.modelSearchEmpty"),
+                    contextWindow: tr("composer.contextWindow"),
+                    contextWindowOfficial: tr(
+                      "composer.contextWindowOfficial",
+                    ),
+                    contextWindowCustom: tr("composer.contextWindowCustom"),
+                    contextWindowPlaceholder: tr(
+                      "composer.contextWindowPlaceholder",
+                    ),
+                    contextWindowSave: tr("composer.contextWindowSave"),
+                    contextWindowOfficialHint: tr(
+                      "composer.contextWindowOfficialHint",
+                    ),
+                    advanced: tr("composer.advanced"),
+                    effortHint: tr("composer.effortPanelHint"),
+                    effortFaster: tr("composer.effortFaster"),
+                    effortSmarter: tr("composer.effortSmarter"),
+                  }}
+                  onModelPick={(pick) => {
+                    void handleModelPick(pick);
+                  }}
+                  onEffort={handleEffortPick}
+                />
+              </div>
+            </div>
             ) : null}
             <WorkbenchComposerShell {...p} />
             </div>

--- a/src/app/WorkbenchComposerShell.tsx
+++ b/src/app/WorkbenchComposerShell.tsx
@@ -12,7 +12,7 @@ import { ChatRefChip } from "@/components/ChatRefChip";
 import { ComposerAtPanel } from "@/components/ComposerAtPanel";
 import { ComposerClearDraftButton, ComposerDraftStats, ComposerSendCluster } from "@/components/ComposerDraftChrome";
 import { ComposerDraftEditor } from "@/components/ComposerDraftEditor";
-import { ComposerAccessMenu, ComposerModelMenu } from "@/components/ComposerModelMenu";
+import { ComposerAccessMenu } from "@/components/ComposerModelMenu";
 import { ComposerPlusPanel } from "@/components/ComposerPlusPanel";
 import { ComposerQuoteCards } from "@/components/ComposerQuoteCards";
 import { ContextUsageChip } from "@/components/ContextUsageChip";
@@ -56,9 +56,8 @@ export function WorkbenchComposerShell(p: WorkbenchComposerShellProps) {
     attachScopeLabel,
     attachableSessions,
     attachments,
-    availableModels,
+
     canGuideQueuedMessage,
-    channelEffortOptions,
     chatAttachments,
     clearSlashFilters,
     closeAttachChat,
@@ -77,31 +76,23 @@ export function WorkbenchComposerShell(p: WorkbenchComposerShellProps) {
     promptHistoryIndexRef,
     slashFilterQuery,
     composerPlusTriggerRef,
-    composerProviderInputs,
     composerShellRef,
     composerSpellcheck,
     connecting,
     contextUsageDisplay,
-    currentModelWindow,
-    customRouteActive,
     cycleAttachedChatScope,
     dragZone,
     effectiveCanSend,
     effectiveCanStop,
-    effort,
     goalMode,
     guideQueuedMessage,
     guidingQueueItemId,
-    handleContextWindow,
-    handleEffortPick,
-    handleModelPick,
     layout,
     liveAt,
     liveSlash,
     liveVoiceOpen,
     locale,
     mode,
-    modelId,
     onComposerContextMenu,
     onComposerDraftChange,
     onComposerKeyDown,
@@ -125,8 +116,6 @@ export function WorkbenchComposerShell(p: WorkbenchComposerShellProps) {
     promptHistoryPos,
     promptHistoryScope,
     promptHistoryUnfilteredCount,
-    providerActiveId,
-    providerActiveSource,
     queueEditItemId,
     queuePreviewLabels,
     quotes,
@@ -665,84 +654,6 @@ export function WorkbenchComposerShell(p: WorkbenchComposerShellProps) {
                 ) : null}
                 {!phoneLayout ? (
                   <>
-                    {goalMode ? (
-                      <Tip label={tr("composer.goalHint")}>
-                        <button
-                          type="button"
-                          className="chip chip--goal"
-                          onClick={() => setGoalMode(false)}
-                          aria-label={tr("composer.goalClear")}
-                        >
-                          <IconImagine size={14} />
-                          <span className="chip__label">
-                            {tr("composer.goal")}
-                          </span>
-                          <IconClose size={12} />
-                        </button>
-                      </Tip>
-                    ) : null}
-                    {sessionJsonSchema ? (
-                      <Tip
-                        label={sessionJsonSchema}
-                        className="ui-tip--wrap ui-tip--mono"
-                      >
-                        <button
-                          type="button"
-                          className="icon-btn chip--json-schema is-active"
-                          onClick={() => {
-                            setJsonSchemaDraft(sessionJsonSchema);
-                            setShowJsonSchemaModal(true);
-                          }}
-                          aria-label={tr("composer.jsonSchemaActive")}
-                        >
-                          <IconCode size={16} />
-                        </button>
-                      </Tip>
-                    ) : null}
-                    <ComposerModelMenu
-                      locale={locale}
-                      modelId={modelId}
-                      effort={effort}
-                      models={availableModels}
-                      providers={composerProviderInputs}
-                      activeSource={providerActiveSource}
-                      activeProviderId={providerActiveId}
-                      channelEfforts={channelEffortOptions}
-                      contextWindow={currentModelWindow}
-                      contextWindowEditable={customRouteActive}
-                      onContextWindow={handleContextWindow}
-                      labels={{
-                        model: tr("composer.model"),
-                        modelGroupOfficial: tr("composer.modelGroupOfficial"),
-                        modelViaProvider: tr("composer.modelViaProvider"),
-                        effort: tr("composer.effort"),
-                        effortHigh: tr("effort.high"),
-                        effortMedium: tr("effort.medium"),
-                        effortLow: tr("effort.low"),
-                        effortXhigh: tr("effort.xhigh"),
-                        effortMax: tr("effort.max"),
-                        modelSearchPlaceholder: tr(
-                          "composer.modelSearchPlaceholder",
-                        ),
-                        modelSearchEmpty: tr("composer.modelSearchEmpty"),
-                        contextWindow: tr("composer.contextWindow"),
-                        contextWindowOfficial: tr(
-                          "composer.contextWindowOfficial",
-                        ),
-                        contextWindowCustom: tr("composer.contextWindowCustom"),
-                        contextWindowPlaceholder: tr(
-                          "composer.contextWindowPlaceholder",
-                        ),
-                        contextWindowSave: tr("composer.contextWindowSave"),
-                        contextWindowOfficialHint: tr(
-                          "composer.contextWindowOfficialHint",
-                        ),
-                      }}
-                      onModelPick={(pick) => {
-                        void handleModelPick(pick);
-                      }}
-                      onEffort={handleEffortPick}
-                    />
                     <ComposerAccessMenu
                       mode={mode}
                       policy={policy}
@@ -795,6 +706,40 @@ export function WorkbenchComposerShell(p: WorkbenchComposerShellProps) {
                         applyPermissionPolicy(v);
                       }}
                     />
+                    {goalMode ? (
+                      <Tip label={tr("composer.goalHint")}>
+                        <button
+                          type="button"
+                          className="chip chip--goal"
+                          onClick={() => setGoalMode(false)}
+                          aria-label={tr("composer.goalClear")}
+                        >
+                          <IconImagine size={14} />
+                          <span className="chip__label">
+                            {tr("composer.goal")}
+                          </span>
+                          <IconClose size={12} />
+                        </button>
+                      </Tip>
+                    ) : null}
+                    {sessionJsonSchema ? (
+                      <Tip
+                        label={sessionJsonSchema}
+                        className="ui-tip--wrap ui-tip--mono"
+                      >
+                        <button
+                          type="button"
+                          className="icon-btn chip--json-schema is-active"
+                          onClick={() => {
+                            setJsonSchemaDraft(sessionJsonSchema);
+                            setShowJsonSchemaModal(true);
+                          }}
+                          aria-label={tr("composer.jsonSchemaActive")}
+                        >
+                          <IconCode size={16} />
+                        </button>
+                      </Tip>
+                    ) : null}
                     <ContextUsageChip
                       display={contextUsageDisplay}
                       locale={locale}

--- a/src/components/ComposerModelMenu.tsx
+++ b/src/components/ComposerModelMenu.tsx
@@ -1,13 +1,15 @@
 /**
- * Composer chip menus (Codex-style):
- * - Model (+effort)
+ * Composer chip menus (Codex combined model+effort + Claude neon slider):
+ * - One trigger: model + effort
+ * - Simple open: pixel-neon effort slider, Advanced for explicit lists
  * - Access: session mode + permission in one panel
  * Narrow composer widths compress triggers to icon (+ short label).
  */
 
 import {
   useEffect,
-  useId,
+  useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -19,11 +21,11 @@ import {
   PERMISSION_POLICIES,
   SESSION_MODES,
   effortDisplayLabel,
-  effortUiOptionIsActive,
-  effortUiOptionsForCatalog,
+  effortPickerStops,
   effortsForModel,
   findModel,
   spawnIdToEffortUiSlot,
+  type EffortPickerStop,
   type ModelOption,
   type PermissionPolicyId,
 } from "@/lib/grokCatalog";
@@ -43,62 +45,111 @@ import {
   IconCheck,
   IconChevronDown,
   IconChevronRight,
+  IconChevronUp,
   IconHandStop,
   IconList,
   IconRobot,
   IconShield,
   IconShieldCheck,
 } from "@/components/icons";
-import { useFloatingMenu, type FloatingPos } from "@/lib/floatingMenu";
+import {
+  ComposerPortalPop,
+  useComposerPortalMenu,
+  type ComposerPortalMenu,
+} from "@/components/ComposerPortalPop";
+import { FLOATING_MENU_Z_INDEX } from "@/lib/floatingMenu";
 
-type Nested = "model" | "effort" | "window" | null;
+type Pane = "simple" | "advanced";
+type HubFlyout = "models" | "effort" | "window";
 
-function usePortalMenu(
-  estHeight = 220,
-  minWidth = 200,
-  nestedKey?: string,
-) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const popRef = useRef<HTMLDivElement>(null);
-  const popId = useId();
+const FLYOUT_GAP = 8;
+const FLYOUT_EDGE = 8;
+const FLYOUT_MIN_W = 168;
 
-  const { pos, style: popStyle } = useFloatingMenu({
-    open,
-    triggerRef,
-    panelRef: popRef,
-    roots: [rootRef],
-    onClose: () => setOpen(false),
-    placement: "auto",
-    fitContent: true,
-    minWidth,
-    estHeight,
-    gap: 8,
-    deps: [nestedKey],
-  });
+function flyoutPreferredWidth(kind: HubFlyout, measured: number): number {
+  if (measured > 0) return measured;
+  return kind === "models" ? 220 : 200;
+}
 
-  return {
-    open,
-    setOpen,
-    pos,
-    popStyle: popStyle as CSSProperties | undefined,
-    rootRef,
-    triggerRef,
-    popRef,
-    popId,
+/**
+ * Nested-menu placement (Codex / macOS):
+ * 1. Prefer the right of the hub when the full panel fits.
+ * 2. Flip to the left when the right would clip (small window / chip on the
+ *    trailing edge).
+ * 3. If neither side fits, clamp into the viewport so the panel stays fully
+ *    on-screen (may overlap the hub).
+ * Vertical: align to the opening *row*, not the hub top — otherwise the
+ * context-window row is unreachable.
+ */
+export function placeHubFlyout(
+  hub: DOMRect,
+  flyout: HTMLElement | null,
+  kind: HubFlyout,
+  row?: DOMRect | null,
+): { pos: CSSProperties; side: "left" | "right" } {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const wantW = flyoutPreferredWidth(kind, flyout?.offsetWidth ?? 0);
+  const innerRight = hub.right + FLYOUT_GAP;
+  const innerLeft = hub.left - FLYOUT_GAP;
+  const rightFits = innerRight + wantW <= vw - FLYOUT_EDGE;
+  const leftFits = innerLeft - wantW >= FLYOUT_EDGE;
+  const spaceRight = vw - FLYOUT_EDGE - innerRight;
+  const spaceLeft = innerLeft - FLYOUT_EDGE;
+  const side: "left" | "right" = rightFits
+    ? "right"
+    : leftFits
+      ? "left"
+      : spaceLeft > spaceRight
+        ? "left"
+        : "right";
+  const panelW = Math.min(
+    wantW,
+    Math.max(FLYOUT_MIN_W, vw - FLYOUT_EDGE * 2),
+  );
+  const cap = kind === "models" ? 240 : 280;
+  const flyH = flyout?.offsetHeight ?? 0;
+  const preferredH = flyH > 0 ? flyH : Math.min(120, cap);
+  const anchorTop =
+    row && Number.isFinite(row.top) ? row.top : hub.top;
+  let top = Math.max(FLYOUT_EDGE, anchorTop);
+  const usedH = Math.min(preferredH, cap, vh - FLYOUT_EDGE * 2);
+  if (top + usedH > vh - FLYOUT_EDGE) {
+    top = Math.max(FLYOUT_EDGE, vh - FLYOUT_EDGE - usedH);
+  }
+  const maxH = Math.min(cap, Math.max(96, vh - FLYOUT_EDGE - top));
+  const pos: CSSProperties = {
+    position: "fixed",
+    top,
+    zIndex: FLOATING_MENU_Z_INDEX,
+    maxHeight: maxH,
+    maxWidth: panelW,
+    width: panelW,
+    boxSizing: "border-box",
   };
+  if (side === "left") {
+    let rightEdge = innerLeft;
+    if (rightEdge - panelW < FLYOUT_EDGE) {
+      rightEdge = FLYOUT_EDGE + panelW;
+    }
+    if (rightEdge > vw - FLYOUT_EDGE) {
+      rightEdge = vw - FLYOUT_EDGE;
+    }
+    pos.right = vw - rightEdge;
+    pos.left = "auto";
+  } else {
+    let left = innerRight;
+    if (left + panelW > vw - FLYOUT_EDGE) {
+      left = vw - FLYOUT_EDGE - panelW;
+    }
+    if (left < FLYOUT_EDGE) left = FLYOUT_EDGE;
+    pos.left = left;
+  }
+  return { pos, side };
 }
 
 function MenuShell({
-  open,
-  setOpen,
-  rootRef,
-  triggerRef,
-  popRef,
-  popId,
-  pos,
-  popStyle,
+  menu,
   triggerIcon,
   triggerText,
   triggerShort,
@@ -110,15 +161,13 @@ function MenuShell({
   className = "",
   /** Applied on the portaled panel (body), not the trigger root. */
   panelClassName = "",
+  tipClassName,
+  /** Pin the pop to the parent chip-shell instead of the inner button. */
+  pinParent,
+  /** Keep the trigger as wide as the widest effort label so xhigh does not jump. */
+  widthCandidates,
 }: {
-  open: boolean;
-  setOpen: (v: boolean | ((p: boolean) => boolean)) => void;
-  rootRef: React.RefObject<HTMLDivElement | null>;
-  triggerRef: React.RefObject<HTMLButtonElement | null>;
-  popRef: React.RefObject<HTMLDivElement | null>;
-  popId: string;
-  pos: FloatingPos | null;
-  popStyle: CSSProperties | undefined;
+  menu: ComposerPortalMenu;
   triggerIcon?: ReactNode;
   /** Full label (wide layout) */
   triggerText: string;
@@ -131,42 +180,91 @@ function MenuShell({
   onOpenChange?: (open: boolean) => void;
   className?: string;
   panelClassName?: string;
+  tipClassName?: string;
+  pinParent?: boolean;
+  widthCandidates?: string[];
 }) {
-  const panel =
-    open && pos && typeof document !== "undefined"
-      ? createPortal(
-          <div
-            ref={popRef}
-            className={["cmm__pop", "cmm__pop--portal", panelClassName]
-              .filter(Boolean)
-              .join(" ")}
-            id={popId}
-            role="dialog"
-            aria-label={ariaLabel}
-            style={popStyle}
-          >
-            {children}
-          </div>,
-          document.body,
-        )
-      : null;
-
+  const { open, setOpen, requestClose, exiting, rootRef, triggerRef, positionRef, popId } =
+    menu;
+  const measureRef = useRef<HTMLDivElement>(null);
+  const compactW = useRef(0);
+  const [maxW, setMaxW] = useState(0);
   const tipLabel = title ?? ariaLabel;
+  const expanded = open && !exiting;
+
+  useLayoutEffect(() => {
+    positionRef.current = pinParent
+      ? (rootRef.current?.parentElement ?? rootRef.current)
+      : null;
+  });
+
+  useLayoutEffect(() => {
+    if (!pinParent) return;
+    const shell = rootRef.current?.parentElement;
+    if (!shell) return;
+    const ease = "width var(--motion-pane) var(--motion-pane-ease)";
+    if (expanded) {
+      const id = requestAnimationFrame(() => {
+        shell.style.transition = ease;
+        shell.style.width = "280px";
+      });
+      return () => cancelAnimationFrame(id);
+    }
+    const to = compactW.current;
+    if (!to) {
+      shell.style.width = "";
+      shell.style.transition = "";
+      return;
+    }
+    shell.style.transition = ease;
+    shell.style.width = `${to}px`;
+    const onEnd = (e: TransitionEvent) => {
+      if (e.propertyName !== "width") return;
+      shell.style.width = "";
+      shell.style.transition = "";
+      shell.removeEventListener("transitionend", onEnd);
+    };
+    shell.addEventListener("transitionend", onEnd);
+    return () => shell.removeEventListener("transitionend", onEnd);
+  }, [expanded, pinParent]);
+
+  useLayoutEffect(() => {
+    const root = measureRef.current;
+    if (!root || !widthCandidates?.length) return;
+    let max = 0;
+    for (const btn of root.querySelectorAll("button")) {
+      max = Math.max(max, Math.ceil(btn.getBoundingClientRect().width));
+    }
+    if (max) setMaxW(max);
+  }, [widthCandidates, triggerText]);
+
   const trigger = (
     <button
       ref={triggerRef}
       type="button"
       className="cmm__trigger"
       aria-haspopup="dialog"
-      aria-expanded={open}
+      aria-expanded={open && !exiting}
       aria-controls={popId}
       aria-label={ariaLabel}
+      style={maxW ? { minWidth: maxW } : undefined}
       onClick={() => {
-        setOpen((v) => {
-          const next = !v;
-          onOpenChange?.(next);
-          return next;
-        });
+        if (open && !exiting) {
+          requestClose();
+          onOpenChange?.(false);
+          return;
+        }
+        if (pinParent) {
+          const shell = rootRef.current?.parentElement;
+          if (shell) {
+            const from = Math.round(shell.getBoundingClientRect().width);
+            compactW.current = from;
+            shell.style.transition = "none";
+            shell.style.width = `${from}px`;
+          }
+        }
+        setOpen(true);
+        onOpenChange?.(true);
       }}
     >
       {triggerIcon ? (
@@ -191,10 +289,49 @@ function MenuShell({
   return (
     <div
       ref={rootRef}
-      className={`cmm ${open ? "is-open" : ""} ${danger ? "cmm--danger" : ""} ${className}`.trim()}
+      className={`cmm ${expanded ? "is-open" : ""} ${danger ? "cmm--danger" : ""} ${className}`.trim()}
     >
-      {tipLabel ? <Tip label={tipLabel}>{trigger}</Tip> : trigger}
-      {panel}
+      {tipLabel ? (
+        <Tip label={tipLabel} disabled={open} className={tipClassName}>
+          {trigger}
+        </Tip>
+      ) : (
+        trigger
+      )}
+      {widthCandidates && widthCandidates.length > 0 ? (
+        <div ref={measureRef} className="cmm__measure" aria-hidden>
+          {widthCandidates.map((text) => (
+            <button
+              key={text}
+              type="button"
+              tabIndex={-1}
+              className="cmm__trigger"
+              data-current={text === triggerText ? "1" : undefined}
+            >
+              {triggerIcon ? (
+                <span className="cmm__icon" aria-hidden>
+                  {triggerIcon}
+                </span>
+              ) : null}
+              <span className="cmm__trigger-text cmm__trigger-text--full">
+                {text}
+              </span>
+              <span className="cmm__chev" aria-hidden>
+                <IconChevronDown size={12} />
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <ComposerPortalPop
+        menu={menu}
+        className={panelClassName}
+        id={popId}
+        role="dialog"
+        ariaLabel={ariaLabel}
+      >
+        {children}
+      </ComposerPortalPop>
     </div>
   );
 }
@@ -219,7 +356,9 @@ export interface ComposerModelMenuProps {
     effortLow: string;
     effortXhigh?: string;
     effortMax?: string;
-    /** Search field placeholder in the model nested list. */
+    /** @deprecated Strongest stop shows the catalog spawn id (xhigh), not Extra. */
+    effortExtra?: string;
+    /** Search field placeholder in the model flyout list. */
     modelSearchPlaceholder: string;
     /** Empty state when filter matches nothing. */
     modelSearchEmpty: string;
@@ -234,6 +373,11 @@ export interface ComposerModelMenuProps {
     contextWindowPlaceholder: string;
     contextWindowSave: string;
     contextWindowOfficialHint: string;
+    /** Codex simple-view slider + Advanced toggle. */
+    advanced?: string;
+    effortHint?: string;
+    effortFaster?: string;
+    effortSmarter?: string;
   };
   /** Resolved UI locale — token window uses K/M (en) vs 万/千 (zh). */
   locale?: string;
@@ -254,7 +398,7 @@ export interface ComposerModelMenuProps {
   onEffort: (id: string) => void;
   /**
    * Apply-path honesty when a live agent is attached (e.g. soft-respawn /
-   * immediate set_model). Shown as a footer note in nested lists when set.
+   * immediate set_model). Shown as a footer note in Advanced flyouts when set.
    */
   applyNotes?: {
     model?: string | null;
@@ -282,6 +426,132 @@ function resolveEffortLabel(
   return effortDisplayLabel(slot ?? spawnId, effortI18n(labels));
 }
 
+/** Claude desktop Effort picker: snap-to-stops, Faster ↔ Smarter. */
+function EffortStopPicker({
+  stops,
+  value,
+  onChange,
+  tickLabels,
+  fasterLabel,
+  smarterLabel,
+  ariaLabel,
+  valueText,
+}: {
+  stops: EffortPickerStop[];
+  value: string;
+  onChange: (spawnId: string) => void;
+  tickLabels: string[];
+  fasterLabel: string;
+  smarterLabel: string;
+  ariaLabel: string;
+  valueText: string;
+}) {
+  const railRef = useRef<HTMLDivElement>(null);
+  const n = stops.length;
+  const index = Math.max(
+    0,
+    stops.findIndex((s) => s.spawnId === value),
+  );
+  const t = n <= 1 ? 0 : index / (n - 1);
+
+  const applyFromClientX = (clientX: number) => {
+    const el = railRef.current;
+    if (!el || n === 0) return;
+    const rect = el.getBoundingClientRect();
+    const pad = 8;
+    const span = Math.max(1, rect.width - pad * 2);
+    const x = (clientX - rect.left - pad) / span;
+    const next = Math.round(Math.max(0, Math.min(1, x)) * (n - 1));
+    const pick = stops[next];
+    if (pick) onChange(pick.spawnId);
+  };
+
+  return (
+    <div className="cmm__stops">
+      <div className="cmm__stops-axis">
+        <span>{fasterLabel}</span>
+        <span>{smarterLabel}</span>
+      </div>
+      <div
+        ref={railRef}
+        className={
+          "cmm__stops-rail" + (stops[index]?.accent === "ultra" ? " is-ultra" : "")
+        }
+        role="slider"
+        tabIndex={0}
+        aria-label={ariaLabel}
+        aria-valuemin={0}
+        aria-valuemax={Math.max(0, n - 1)}
+        aria-valuenow={index}
+        aria-valuetext={valueText}
+        style={{ ["--cmm-stop-t" as string]: String(t) }}
+        onPointerDown={(e) => {
+          e.preventDefault();
+          e.currentTarget.setPointerCapture(e.pointerId);
+          applyFromClientX(e.clientX);
+        }}
+        onPointerMove={(e) => {
+          if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
+          applyFromClientX(e.clientX);
+        }}
+        onKeyDown={(e) => {
+          if (n === 0) return;
+          if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
+            e.preventDefault();
+            const next = stops[Math.max(0, index - 1)];
+            if (next) onChange(next.spawnId);
+          } else if (e.key === "ArrowRight" || e.key === "ArrowUp") {
+            e.preventDefault();
+            const next = stops[Math.min(n - 1, index + 1)];
+            if (next) onChange(next.spawnId);
+          } else if (e.key === "Home") {
+            e.preventDefault();
+            if (stops[0]) onChange(stops[0].spawnId);
+          } else if (e.key === "End") {
+            e.preventDefault();
+            const last = stops[n - 1];
+            if (last) onChange(last.spawnId);
+          }
+        }}
+      >
+        <div className="cmm__stops-dots" aria-hidden>
+          {stops.map((s, i) => (
+            <span
+              key={s.id}
+              className={
+                "cmm__stops-dot" +
+                (i === index ? " is-active" : "") +
+                (s.accent === "ultra" ? " is-ultra" : "")
+              }
+            />
+          ))}
+        </div>
+        <span
+          className={
+            "cmm__stops-thumb" +
+            (stops[index]?.accent === "ultra" ? " is-ultra" : "")
+          }
+          aria-hidden
+        />
+        {stops.map((s, i) => (
+          <button
+            key={s.id}
+            type="button"
+            className="cmm__stops-hit"
+            style={{
+              left: `calc((100% - 12px) * ${n <= 1 ? 0 : i / (n - 1)} + 6px)`,
+            }}
+            aria-label={tickLabels[i] ?? s.id}
+            aria-pressed={i === index}
+            tabIndex={-1}
+            onClick={() => onChange(s.spawnId)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function ComposerModelMenu({
   modelId,
   effort,
@@ -300,12 +570,50 @@ export function ComposerModelMenu({
   contextWindowEditable = false,
   onContextWindow,
 }: ComposerModelMenuProps) {
-  const [nested, setNested] = useState<Nested>(null);
+  const [pane, setPane] = useState<Pane>("simple");
   const [modelQuery, setModelQuery] = useState("");
   const [windowDraft, setWindowDraft] = useState("");
   const modelSearchRef = useRef<HTMLInputElement>(null);
-  /* Wider min so long custom model ids render fully in the root rows. */
-  const menu = usePortalMenu(240, 200, nested ?? "root");
+  const stageRef = useRef<HTMLDivElement>(null);
+  const flyoutRef = useRef<HTMLDivElement>(null);
+  const modelsRowRef = useRef<HTMLButtonElement>(null);
+  const effortRowRef = useRef<HTMLButtonElement>(null);
+  const windowRowRef = useRef<HTMLButtonElement>(null);
+  const [hubFlyout, setHubFlyout] = useState<HubFlyout | null>(null);
+  const [flyPos, setFlyPos] = useState<CSSProperties>();
+  const [flySide, setFlySide] = useState<"left" | "right">("right");
+  const flyLeave = useRef(0);
+  const [bodyH, setBodyH] = useState<number | undefined>(undefined);
+  const modelMenu = useComposerPortalMenu({
+    estHeight: 320,
+    width: 280,
+    minWidth: 240,
+    fitContent: false,
+    align: "end",
+    placement: "up",
+    anchor: "bottom",
+    // Titlebar is 40px; keep the panel below it when the pop opens upward.
+    margin: 52,
+    deps: [pane],
+    extraRoots: [flyoutRef],
+    exitMs: 320,
+  });
+
+  const goPane = (next: Pane) => {
+    const el = stageRef.current;
+    if (el) setBodyH(el.offsetHeight);
+    setHubFlyout(null);
+    setPane(next);
+  };
+
+  const showFlyout = (id: HubFlyout) => {
+    window.clearTimeout(flyLeave.current);
+    setHubFlyout(id);
+  };
+  const hideFlyoutSoon = () => {
+    window.clearTimeout(flyLeave.current);
+    flyLeave.current = window.setTimeout(() => setHubFlyout(null), 140);
+  };
   const modelList = models.length > 0 ? models : GROK_BUILD_MODELS;
   const groups = buildComposerModelGroups({
     officialModels: modelList,
@@ -318,8 +626,7 @@ export function ComposerModelMenu({
     activeSource === "custom" && channelEfforts && channelEfforts.length > 0
       ? effortsForModel(null, channelEfforts)
       : effortsForModel(activeModel);
-  /** Ordered UI ladder (3 or 4 slots); spawnId is the real model value. */
-  const effortUiList = effortUiOptionsForCatalog(effortCatalog);
+  const pickerStops = effortPickerStops(effortCatalog);
 
   const clearModelQuery = () => setModelQuery("");
 
@@ -329,45 +636,98 @@ export function ComposerModelMenu({
     } else if (pick.kind === "official" && onModel) {
       onModel(pick.modelId);
     }
-    // Close the whole menu (root + nested), not just pop back to stage 1.
-    setNested(null);
-    menu.setOpen(false);
   };
 
   useEffect(() => {
-    if (!menu.open) {
-      setNested(null);
-      clearModelQuery();
-    }
-  }, [menu.open]);
+    if (modelMenu.open && !modelMenu.exiting) return;
+    setHubFlyout(null);
+    if (modelMenu.open) return;
+    setPane("simple");
+    setBodyH(undefined);
+    clearModelQuery();
+  }, [modelMenu.open, modelMenu.exiting]);
 
-  // Clear filter when leaving the model nested list (back / effort / select).
-  useEffect(() => {
-    if (nested !== "model") clearModelQuery();
-  }, [nested]);
+  useEffect(() => () => window.clearTimeout(flyLeave.current), []);
 
-  // Autofocus search when entering the model list.
-  useEffect(() => {
-    if (!menu.open || nested !== "model") return;
-    const id = requestAnimationFrame(() => {
-      modelSearchRef.current?.focus();
-    });
+  useLayoutEffect(() => {
+    if (!modelMenu.open) return;
+    const el = stageRef.current;
+    const next = el?.offsetHeight;
+    if (!next) return;
+    if (bodyH == null) return;
+    const id = requestAnimationFrame(() => setBodyH(next));
     return () => cancelAnimationFrame(id);
-  }, [menu.open, nested]);
+  }, [pane, modelMenu.open, bodyH]);
+
+  useLayoutEffect(() => {
+    if (!hubFlyout || pane !== "advanced" || modelMenu.exiting) {
+      setFlyPos(undefined);
+      return;
+    }
+    const hubEl = modelMenu.popRef.current;
+    if (!hubEl) {
+      setFlyPos(undefined);
+      return;
+    }
+    const apply = () => {
+      const hub = hubEl.getBoundingClientRect();
+      const rowEl =
+        hubFlyout === "models"
+          ? modelsRowRef.current
+          : hubFlyout === "effort"
+            ? effortRowRef.current
+            : windowRowRef.current;
+      const row = rowEl?.getBoundingClientRect() ?? null;
+      const { pos, side } = placeHubFlyout(
+        hub,
+        flyoutRef.current,
+        hubFlyout,
+        row,
+      );
+      setFlySide(side);
+      setFlyPos((prev) => {
+        if (
+          prev &&
+          prev.left === pos.left &&
+          prev.right === pos.right &&
+          prev.top === pos.top &&
+          prev.maxHeight === pos.maxHeight &&
+          prev.zIndex === pos.zIndex
+        ) {
+          return prev;
+        }
+        return pos;
+      });
+    };
+    apply();
+    const id = requestAnimationFrame(apply);
+    return () => cancelAnimationFrame(id);
+  }, [hubFlyout, pane, modelMenu.exiting, modelMenu.pos]);
 
   useEffect(() => {
-    if (!menu.open) return;
+    if (hubFlyout !== "models") clearModelQuery();
+  }, [hubFlyout]);
+
+  useEffect(() => {
+    if (!modelMenu.open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && nested) {
-        // Capture + stopImmediate so floatingMenu does not close the whole panel.
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        setNested(null);
-        return;
+      if (e.key === "Escape") {
+        if (hubFlyout) {
+          e.preventDefault();
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+          setHubFlyout(null);
+          return;
+        }
+        if (pane === "advanced") {
+          e.preventDefault();
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+          goPane("simple");
+          return;
+        }
       }
-      // Typing while on model list focuses the filter (e.g. after tabbing to a row).
-      if (nested !== "model") return;
+      if (hubFlyout !== "models") return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (e.key.length !== 1) return;
       const active = document.activeElement;
@@ -382,10 +742,9 @@ export function ComposerModelMenu({
       setModelQuery((q) => q + e.key);
       modelSearchRef.current?.focus();
     };
-    // Capture so Escape wins over useFloatingMenu's bubble listener.
     document.addEventListener("keydown", onKey, true);
     return () => document.removeEventListener("keydown", onKey, true);
-  }, [menu.open, nested]);
+  }, [modelMenu.open, pane, hubFlyout]);
 
   const activeCustom =
     activeSource === "custom" && activeProviderId
@@ -411,269 +770,375 @@ export function ComposerModelMenu({
     officialLabel,
     activeCustom,
   });
-  const eLabel = resolveEffortLabel(effort, effortCatalog, labels);
-  // Compact trigger: model + short effort (locale), no middle-dot noise.
+  const stopLabelFor = (stop: EffortPickerStop) => {
+    if (stop.id === "xhigh" || stop.id === "max") return stop.spawnId;
+    return effortDisplayLabel(stop.id, effortI18n(labels));
+  };
+  const activeStop =
+    pickerStops.find((s) => s.spawnId === effort) ?? pickerStops[0] ?? null;
+  const eLabel = activeStop
+    ? stopLabelFor(activeStop)
+    : resolveEffortLabel(effort, effortCatalog, labels);
   const triggerText = `${modelLabel} ${eLabel}`;
-  const title = `${labels.model}: ${modelLabel} · ${labels.effort}: ${eLabel}`;
+  const advancedLabel = labels.advanced ?? "Advanced";
+  const tickLabels = pickerStops.map((s) => stopLabelFor(s));
+  const fasterLabel = labels.effortFaster ?? labels.effortLow;
+  const smarterLabel = labels.effortSmarter ?? labels.effortHigh;
+  const widthCandidates = useMemo(() => {
+    const efforts = tickLabels.length > 0 ? tickLabels : [eLabel];
+    return [...new Set(efforts.map((label) => `${modelLabel} ${label}`))];
+  }, [modelLabel, tickLabels, eLabel]);
 
   return (
     <MenuShell
-      {...menu}
-      className="cmm--model"
-      panelClassName="cmm__pop--model"
+      menu={modelMenu}
+      className={
+        "cmm--model" + (activeStop?.accent === "ultra" ? " cmm--extra" : "")
+      }
+      panelClassName={
+        "cmm__pop--model" + (pane === "advanced" ? " cmm__pop--hub" : "")
+      }
+      tipClassName="ui-tip--flat"
+      pinParent
       triggerIcon={<IconBolt size={14} />}
       triggerText={triggerText}
       triggerShort={eLabel}
+      widthCandidates={widthCandidates}
       ariaLabel={labels.model}
-      title={title}
-      onOpenChange={(o) => {
-        if (!o) {
-          setNested(null);
-          clearModelQuery();
-        }
-      }}
+      title={`${labels.model}: ${modelLabel} · ${labels.effort}: ${eLabel}`}
     >
-      {nested === null ? (
-        <>
-          <button
-            type="button"
-            className="cmm__row"
-            onClick={() => setNested("model")}
-          >
-            <span>{labels.model}</span>
-            <span className="cmm__row-val">
-              <span className="cmm__row-val-text" title={modelLabel}>
-                {modelLabel}
+      <div
+        style={{
+          height: bodyH,
+          overflow: "hidden",
+          transition:
+            bodyH == null
+              ? "none"
+              : "height var(--motion-pane) var(--motion-pane-ease)",
+        }}
+      >
+        <div
+          className={"cmm__stage" + (pane === "advanced" ? " is-hub" : "")}
+          ref={stageRef}
+        >
+          <div className="cmm__simple-body" aria-hidden={pane !== "simple"}>
+            <div className="cmm__simple-head">
+              <span
+                className={
+                  "cmm__simple-title" +
+                  (activeStop?.accent === "ultra" ? " is-ultra" : "")
+                }
+              >
+                {labels.effort} {eLabel}
               </span>
-              <IconChevronRight size={14} />
-            </span>
-          </button>
-          <button
-            type="button"
-            className="cmm__row"
-            onClick={() => setNested("effort")}
+            </div>
+            {pickerStops.length > 0 ? (
+              <EffortStopPicker
+                stops={pickerStops}
+                value={effort}
+                onChange={onEffort}
+                tickLabels={tickLabels}
+                fasterLabel={fasterLabel}
+                smarterLabel={smarterLabel}
+                ariaLabel={labels.effort}
+                valueText={eLabel}
+              />
+            ) : null}
+          </div>
+          <div
+            className="cmm__hub-body cmm__hub"
+            aria-hidden={pane !== "advanced"}
+            onMouseLeave={hideFlyoutSoon}
           >
-            <span>{labels.effort}</span>
-            <span className="cmm__row-val">
-              <span className="cmm__row-val-text">{eLabel}</span>
-              <IconChevronRight size={14} />
-            </span>
-          </button>
-          <button
-            type="button"
-            className="cmm__row"
-            onClick={() => {
-              setWindowDraft(
-                contextWindowEditable && contextWindow
-                  ? String(contextWindow)
-                  : "",
-              );
-              setNested("window");
-            }}
-          >
-            <span>{labels.contextWindow}</span>
-            <span className="cmm__row-val">
-              <span className="cmm__row-val-text">
-                {contextWindow ? formatTokenCount(contextWindow, locale) : "—"}
+            <button
+              ref={modelsRowRef}
+              type="button"
+              className={
+                "cmm__row" + (hubFlyout === "models" ? " is-fly" : "")
+              }
+              aria-haspopup="true"
+              aria-expanded={hubFlyout === "models"}
+              onMouseEnter={() => showFlyout("models")}
+              onFocus={() => showFlyout("models")}
+              onClick={() => showFlyout("models")}
+            >
+              <span>{labels.model}</span>
+              <span className="cmm__row-val">
+                <span className="cmm__row-val-text">{modelLabel}</span>
+                <IconChevronRight size={14} />
               </span>
-              <IconChevronRight size={14} />
-            </span>
-          </button>
-        </>
-      ) : (
-        <div className="cmm__nested">
-          <button
-            type="button"
-            className="cmm__back"
-            onClick={() => setNested(null)}
-          >
-            {nested === "model"
-              ? labels.model
-              : nested === "window"
-                ? labels.contextWindow
-                : labels.effort}
-          </button>
-          {nested === "model" &&
-            (groups.length === 0 ? (
-              <div className="cmm__opt cmm__opt--muted" role="status">
-                <span className="cmm__opt-main">
-                  <span className="cmm__opt-title">{modelId || "—"}</span>
+            </button>
+            <button
+              ref={effortRowRef}
+              type="button"
+              className={
+                "cmm__row" + (hubFlyout === "effort" ? " is-fly" : "")
+              }
+              aria-haspopup="true"
+              aria-expanded={hubFlyout === "effort"}
+              onMouseEnter={() => showFlyout("effort")}
+              onFocus={() => showFlyout("effort")}
+              onClick={() => showFlyout("effort")}
+            >
+              <span>{labels.effort}</span>
+              <span className="cmm__row-val">
+                <span
+                  className={
+                    "cmm__row-val-text" +
+                    (activeStop?.accent === "ultra" ? " is-ultra" : "")
+                  }
+                >
+                  {eLabel}
                 </span>
+                <IconChevronRight size={14} />
+              </span>
+            </button>
+            <button
+              ref={windowRowRef}
+              type="button"
+              className={
+                "cmm__row" + (hubFlyout === "window" ? " is-fly" : "")
+              }
+              aria-haspopup="true"
+              aria-expanded={hubFlyout === "window"}
+              onMouseEnter={() => {
+                setWindowDraft(
+                  contextWindowEditable && contextWindow
+                    ? String(contextWindow)
+                    : "",
+                );
+                showFlyout("window");
+              }}
+              onFocus={() => showFlyout("window")}
+              onClick={() => showFlyout("window")}
+            >
+              <span>{labels.contextWindow}</span>
+              <span className="cmm__row-val">
+                <span className="cmm__row-val-text">
+                  {contextWindow
+                    ? formatTokenCount(contextWindow, locale)
+                    : "—"}
+                </span>
+                <IconChevronRight size={14} />
+              </span>
+            </button>
+            {applyNotes?.model ? (
+              <div className="cmm__apply-note" role="note">
+                {applyNotes.model}
               </div>
+            ) : null}
+            {applyNotes?.effort ? (
+              <div className="cmm__apply-note" role="note">
+                {applyNotes.effort}
+              </div>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            className="cmm__advanced"
+            onClick={() =>
+              goPane(pane === "advanced" ? "simple" : "advanced")
+            }
+          >
+            {advancedLabel}
+            {pane === "advanced" ? (
+              <IconChevronUp size={14} />
             ) : (
-              <>
-                <div className="cmm__search">
-                  <input
-                    ref={modelSearchRef}
-                    type="search"
-                    className="cmm__search-input"
-                    value={modelQuery}
-                    onChange={(e) => setModelQuery(e.target.value)}
-                    placeholder={labels.modelSearchPlaceholder}
-                    aria-label={labels.modelSearchPlaceholder}
-                    autoComplete="off"
-                    spellCheck={false}
-                    // Keep menu open / avoid accidental form submit.
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") e.preventDefault();
-                    }}
-                  />
-                </div>
-                {filteredGroups.length === 0 ? (
+              <IconChevronRight size={14} />
+            )}
+          </button>
+        </div>
+      {hubFlyout && flyPos && pane === "advanced" && !modelMenu.exiting
+        ? createPortal(
+            <div
+              ref={flyoutRef}
+              className={
+                "cmm__pop cmm__pop--portal cmm__pop--flyout" +
+                (hubFlyout === "models" ? " cmm__pop--flyout-models" : "")
+              }
+              data-side={flySide}
+              data-kind={hubFlyout}
+              style={flyPos}
+              onMouseEnter={() => hubFlyout && showFlyout(hubFlyout)}
+              onMouseLeave={hideFlyoutSoon}
+            >
+              {hubFlyout === "models" ? (
+                groups.length === 0 ? (
                   <div className="cmm__opt cmm__opt--muted" role="status">
                     <span className="cmm__opt-main">
-                      <span className="cmm__opt-title">
-                        {labels.modelSearchEmpty}
-                      </span>
+                      <span className="cmm__opt-title">{modelId || "—"}</span>
                     </span>
                   </div>
                 ) : (
-                  filteredGroups.map((group) => (
-                    <div key={group.key}>
-                      <div className="cmm__section">{group.title}</div>
-                      {group.entries.map((entry) => {
-                        const active = isComposerModelEntryActive(entry, {
-                          activeSource,
-                          activeProviderId,
-                          activeRequestModel,
-                          modelId,
-                        });
-                        return (
-                          <button
-                            key={entry.key}
-                            type="button"
-                            className={"cmm__opt" + (active ? " is-active" : "")}
-                            onClick={() => selectPick(entry.pick)}
-                          >
-                            <span className="cmm__opt-main">
-                              <span className="cmm__opt-title">
-                                {entry.title}
-                              </span>
-                              {entry.subtitle ? (
-                                <span className="cmm__opt-desc">
-                                  {entry.subtitle}
-                                </span>
-                              ) : null}
-                            </span>
-                            {active ? (
-                              <span className="cmm__opt-check" aria-hidden>
-                                <IconCheck size={16} />
-                              </span>
-                            ) : null}
-                          </button>
-                        );
-                      })}
+                  <div className="cmm__flyout-stack">
+                    <div className="cmm__search">
+                      <input
+                        ref={modelSearchRef}
+                        type="search"
+                        className="cmm__search-input"
+                        value={modelQuery}
+                        onChange={(e) => setModelQuery(e.target.value)}
+                        placeholder={labels.modelSearchPlaceholder}
+                        aria-label={labels.modelSearchPlaceholder}
+                        autoComplete="off"
+                        spellCheck={false}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") e.preventDefault();
+                        }}
+                      />
                     </div>
-                  ))
-                )}
-              </>
-            ))}
-          {nested === "effort" &&
-            effortUiList.map((e) => {
-              const active = effortUiOptionIsActive(
-                e,
-                effort,
-                effortCatalog,
-              );
-              return (
-                <button
-                  key={e.uiId}
-                  type="button"
-                  className={"cmm__opt" + (active ? " is-active" : "")}
-                  onClick={() => {
-                    onEffort(e.spawnId);
-                    // Close whole menu after second-stage pick (same as model).
-                    setNested(null);
-                    menu.setOpen(false);
-                  }}
-                >
-                  <span className="cmm__opt-main">
-                    <span className="cmm__opt-title">
-                      {effortDisplayLabel(e.uiId, effortI18n(labels))}
-                    </span>
-                  </span>
-                  {active ? (
-                    <span className="cmm__opt-check" aria-hidden>
-                      <IconCheck size={16} />
-                    </span>
-                  ) : null}
-                </button>
-              );
-            })}
-          {nested === "window" && (
-            <div className="cmm__opt cmm__opt--muted">
-              {contextWindowEditable ? (
-                <>
-                  <span className="cmm__opt-main">
-                    <span className="cmm__opt-title">
-                      {labels.contextWindowCustom}
-                    </span>
-                  </span>
-                  <div className="cmm__inline-edit">
-                    <input
-                      type="number"
-                      inputMode="numeric"
-                      min={1}
-                      value={windowDraft}
-                      placeholder={labels.contextWindowPlaceholder}
-                      onChange={(e) => setWindowDraft(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                          const n = parseInt(windowDraft, 10);
-                          if (Number.isFinite(n) && n > 0) {
-                            onContextWindow?.(n);
-                            setNested(null);
-                            menu.setOpen(false);
-                          }
-                        }
-                      }}
-                    />
-                    <button
-                      type="button"
-                      className="cmm__inline-save"
-                      disabled={!Number.isFinite(parseInt(windowDraft, 10))}
-                      onClick={() => {
-                        const n = parseInt(windowDraft, 10);
-                        if (Number.isFinite(n) && n > 0) {
-                          onContextWindow?.(n);
-                          setNested(null);
-                          menu.setOpen(false);
-                        }
-                      }}
-                    >
-                      {labels.contextWindowSave}
-                    </button>
+                    <div className="cmm__flyout-list">
+                      {filteredGroups.length === 0 ? (
+                        <div className="cmm__opt cmm__opt--muted" role="status">
+                          <span className="cmm__opt-main">
+                            <span className="cmm__opt-title">
+                              {labels.modelSearchEmpty}
+                            </span>
+                          </span>
+                        </div>
+                      ) : (
+                        filteredGroups.map((group) => (
+                          <div key={group.key}>
+                            {filteredGroups.length > 1 ? (
+                              <div className="cmm__section">{group.title}</div>
+                            ) : null}
+                            {group.entries.map((entry) => {
+                              const active = isComposerModelEntryActive(
+                                entry,
+                                {
+                                  activeSource,
+                                  activeProviderId,
+                                  activeRequestModel,
+                                  modelId,
+                                },
+                              );
+                              return (
+                                <button
+                                  key={entry.key}
+                                  type="button"
+                                  className={
+                                    "cmm__opt" + (active ? " is-active" : "")
+                                  }
+                                  title={
+                                    entry.subtitle
+                                      ? `${entry.title} · ${entry.subtitle}`
+                                      : entry.title
+                                  }
+                                  onClick={() => selectPick(entry.pick)}
+                                >
+                                  <span className="cmm__opt-main">
+                                    <span className="cmm__opt-title">
+                                      {entry.title}
+                                    </span>
+                                  </span>
+                                  {active ? (
+                                    <span
+                                      className="cmm__opt-check"
+                                      aria-hidden
+                                    >
+                                      <IconCheck size={16} />
+                                    </span>
+                                  ) : null}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        ))
+                      )}
+                    </div>
                   </div>
-                </>
+                )
+              ) : hubFlyout === "effort" ? (
+                pickerStops.map((s) => {
+                  const active = s.spawnId === effort;
+                  return (
+                    <button
+                      key={s.id}
+                      type="button"
+                      className={"cmm__opt" + (active ? " is-active" : "")}
+                      onClick={() => onEffort(s.spawnId)}
+                    >
+                      <span className="cmm__opt-main">
+                        <span
+                          className={
+                            "cmm__opt-title" +
+                            (s.accent === "ultra" ? " is-ultra" : "")
+                          }
+                        >
+                          {stopLabelFor(s)}
+                        </span>
+                      </span>
+                      {active ? (
+                        <span className="cmm__opt-check" aria-hidden>
+                          <IconCheck size={16} />
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })
               ) : (
-                <span className="cmm__opt-main">
-                  <span className="cmm__opt-title">
-                    {contextWindow
-                      ? formatTokenCount(contextWindow, locale)
-                      : "—"}
-                  </span>
-                  <span className="cmm__opt-desc">
-                    {contextWindow
-                      ? labels.contextWindowOfficial
-                      : labels.contextWindowOfficialHint}
-                  </span>
-                </span>
+                <div className="cmm__opt cmm__opt--muted">
+                  {contextWindowEditable ? (
+                    <>
+                      <span className="cmm__opt-main">
+                        <span className="cmm__opt-title">
+                          {labels.contextWindowCustom}
+                        </span>
+                      </span>
+                      <div className="cmm__inline-edit">
+                        <input
+                          type="number"
+                          inputMode="numeric"
+                          min={1}
+                          value={windowDraft}
+                          placeholder={labels.contextWindowPlaceholder}
+                          onChange={(e) => setWindowDraft(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              e.preventDefault();
+                              const n = parseInt(windowDraft, 10);
+                              if (Number.isFinite(n) && n > 0) {
+                                onContextWindow?.(n);
+                              }
+                            }
+                          }}
+                        />
+                        <button
+                          type="button"
+                          className="cmm__inline-save"
+                          disabled={!Number.isFinite(parseInt(windowDraft, 10))}
+                          onClick={() => {
+                            const n = parseInt(windowDraft, 10);
+                            if (Number.isFinite(n) && n > 0) {
+                              onContextWindow?.(n);
+                            }
+                          }}
+                        >
+                          {labels.contextWindowSave}
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <span className="cmm__opt-main">
+                      <span className="cmm__opt-title">
+                        {contextWindow
+                          ? formatTokenCount(contextWindow, locale)
+                          : "—"}
+                      </span>
+                      <span className="cmm__opt-desc">
+                        {contextWindow
+                          ? labels.contextWindowOfficial
+                          : labels.contextWindowOfficialHint}
+                      </span>
+                    </span>
+                  )}
+                </div>
               )}
-            </div>
-          )}
-          {nested === "model" && applyNotes?.model ? (
-            <div className="cmm__apply-note" role="note">
-              {applyNotes.model}
-            </div>
-          ) : null}
-          {nested === "effort" && applyNotes?.effort ? (
-            <div className="cmm__apply-note" role="note">
-              {applyNotes.effort}
-            </div>
-          ) : null}
-        </div>
-      )}
+            </div>,
+            document.body,
+          )
+        : null}
+      </div>
     </MenuShell>
   );
 }
@@ -820,7 +1285,12 @@ export function ComposerAccessMenu({
   onPolicy,
 }: ComposerAccessMenuProps) {
   /* Wider dual-column sheet: mode | permission side by side. */
-  const menu = usePortalMenu(320, 520);
+  const menu = useComposerPortalMenu({
+    estHeight: 280,
+    width: 300,
+    minWidth: 260,
+    fitContent: false,
+  });
   const isDanger = policy === "always_approve";
   const full = policyLabel(policy, labels);
   const short = policyShort(policy, labels);
@@ -828,7 +1298,7 @@ export function ComposerAccessMenu({
 
   return (
     <MenuShell
-      {...menu}
+      menu={menu}
       className="cmm--access"
       panelClassName="cmm__pop--access"
       triggerIcon={policyIcon(policy)}
@@ -852,6 +1322,7 @@ export function ComposerAccessMenu({
               className={
                 "cmm__opt cmm__opt--access" + (m.id === mode ? " is-active" : "")
               }
+              title={modeDesc(m.id, labels)}
               onClick={() => onMode(m.id)}
             >
               <span className="cmm__opt-icon" aria-hidden>
@@ -885,6 +1356,7 @@ export function ComposerAccessMenu({
                 (p.id === policy ? " is-active" : "") +
                 (p.dangerous ? " is-danger" : "")
               }
+              title={policyDesc(p.id, labels)}
               onClick={() => {
                 onPolicy(p.id);
                 menu.setOpen(false);

--- a/src/components/ComposerPortalPop.test.tsx
+++ b/src/components/ComposerPortalPop.test.tsx
@@ -1,0 +1,533 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Portal contract for composer-row chip menus (dialogs.md hard rules):
+ * every chip pop must portal directly into document.body (never clipped by
+ * overflow parents), carry the glass-listed `cmm__pop cmm__pop--portal`
+ * material classes plus its chip-specific class, sit on the floating-menu
+ * z-index layer, keep trigger aria wiring, and close on Escape / outside
+ * mousedown while clicks inside the panel keep working.
+ *
+ * Written against the per-file portal copies first; now guards the shared
+ * ComposerPortalPop layer so a refactor cannot silently drop the material
+ * class (transparent panel) or the body portal (clipped menu).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@/test/jsdomStubs";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  ComposerModelMenu,
+  placeHubFlyout,
+} from "@/components/ComposerModelMenu";
+import { ComposerProjectMenu } from "@/components/ComposerProjectMenu";
+import { ComposerWorktreeMenu } from "@/components/ComposerWorktreeMenu";
+import { ContextUsageChip } from "@/components/ContextUsageChip";
+import { FLOATING_MENU_Z_INDEX } from "@/lib/floatingMenu";
+import type { ContextUsageDisplay } from "@/lib/contextUsage";
+
+afterEach(cleanup);
+
+/** The chip pop must be a direct child of body — that is the portal contract. */
+function bodyPop(): HTMLElement | null {
+  return document.body.querySelector<HTMLElement>(":scope > .cmm__pop");
+}
+
+function renderProjectMenu() {
+  const onSelect = vi.fn();
+  render(
+    <ComposerProjectMenu
+      activeProject={null}
+      projects={[
+        {
+          id: "p1",
+          name: "grok-app",
+          path: "/code/grok-app",
+          trusted: true,
+          pathOk: true,
+        },
+      ]}
+      labels={{
+        noProject: "Default workspace",
+        pickProject: "Project folder",
+        addProject: "Add project",
+      }}
+      variant="context"
+      onSelect={onSelect}
+      onAdd={vi.fn()}
+    />,
+  );
+  return { onSelect };
+}
+
+describe("composer chip portal pops", () => {
+  it("project chip portals a material cmm pop into document.body", async () => {
+    const user = userEvent.setup();
+    renderProjectMenu();
+    expect(bodyPop()).toBeNull();
+
+    const trigger = screen.getByRole("button", { name: "Default workspace" });
+    expect(trigger.getAttribute("aria-haspopup")).toBe("menu");
+    await user.click(trigger);
+
+    const pop = bodyPop();
+    expect(pop).not.toBeNull();
+    expect(pop!.parentElement).toBe(document.body);
+    expect(pop!.className).toBe("cmm__pop cmm__pop--portal cpm__pop");
+    expect(pop!.getAttribute("role")).toBe("menu");
+    expect(pop!.getAttribute("aria-label")).toBe("Project folder");
+    expect(pop!.style.position).toBe("fixed");
+    expect(pop!.style.zIndex).toBe(String(FLOATING_MENU_Z_INDEX));
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("project chip closes on Escape and returns aria-expanded=false", async () => {
+    const user = userEvent.setup();
+    renderProjectMenu();
+    const trigger = screen.getByRole("button", { name: "Default workspace" });
+    await user.click(trigger);
+    expect(bodyPop()).not.toBeNull();
+
+    await user.keyboard("{Escape}");
+    expect(bodyPop()).toBeNull();
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("project chip closes on outside mousedown but not on inside clicks", async () => {
+    const user = userEvent.setup();
+    const { onSelect } = renderProjectMenu();
+    const trigger = screen.getByRole("button", { name: "Default workspace" });
+
+    await user.click(trigger);
+    fireEvent.mouseDown(document.body);
+    expect(bodyPop()).toBeNull();
+
+    await user.click(trigger);
+    const row = screen.getByRole("menuitem", { name: "grok-app" });
+    await user.click(row);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "p1" }),
+    );
+    expect(bodyPop()).toBeNull();
+  });
+
+  it("worktree chip portals its cwm pop with menu semantics", async () => {
+    const user = userEvent.setup();
+    render(
+      <ComposerWorktreeMenu
+        activePath="/code/grok-app"
+        worktrees={[
+          {
+            path: "/code/grok-app",
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            detached: false,
+            locked: false,
+            prunable: false,
+          },
+        ]}
+        worktreesAvailable={true}
+        variant="context"
+        labels={{
+          worktrees: "Git worktrees",
+          worktreesEmpty: "No linked worktrees",
+          worktreesUnavailable: "Worktrees unavailable",
+          worktreeCurrent: "current",
+          worktreeMain: "main",
+          worktreeDetached: "detached",
+          worktreeTip: "Switch git worktree",
+          worktreeNew: "New worktree",
+          worktreeNewChat: "New worktree & chat",
+          worktreeGc: "Clean stale worktrees",
+        }}
+        onSwitch={vi.fn()}
+        onCreate={vi.fn()}
+        onCreateAndChat={vi.fn()}
+        onGc={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Switch git worktree" }),
+    );
+    const pop = bodyPop();
+    expect(pop).not.toBeNull();
+    expect(pop!.parentElement).toBe(document.body);
+    expect(pop!.className).toBe("cmm__pop cmm__pop--portal cwm__pop");
+    expect(pop!.getAttribute("role")).toBe("menu");
+    expect(pop!.getAttribute("aria-label")).toBe("Git worktrees");
+  });
+
+  it("context usage chip portals its ctx pop on the same layer", async () => {
+    const user = userEvent.setup();
+    const display: ContextUsageDisplay = {
+      tokens: 12000,
+      source: "known",
+      label: "12k",
+      lastCompact: null,
+      breakdown: null,
+      knownUsage: null,
+      windowSize: 100000,
+      percent: 12,
+      cacheHitRate: null,
+      cachedReadTokens: null,
+    };
+    render(
+      <ContextUsageChip
+        display={display}
+        labels={{
+          aria: "Context",
+          tipUnknown: "unknown",
+          tipEstimated: "estimated",
+          tipKnown: "known",
+          menuTitle: "Context usage",
+          current: "Current",
+          sourceKnown: "known",
+          sourceEstimated: "estimated",
+          sourceUnknown: "unknown",
+          lastCompact: "Last compact",
+          lastCompactNone: "never",
+          tokensRange: "{before} → {after}",
+          compactAction: "Compact now",
+          heuristicNote: "heuristic",
+          auto: "auto",
+          manual: "manual",
+          breakdownUser: "User",
+          breakdownAssistant: "Assistant",
+          breakdownThought: "Thought",
+          breakdownEstimatedNote: "estimated rows",
+          window: "Window",
+          percentUsed: "Used",
+          cacheHit: "Cache hit",
+        }}
+        onCompact={vi.fn()}
+        locale="en"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Context: 12k" }));
+    const pop = bodyPop();
+    expect(pop).not.toBeNull();
+    expect(pop!.parentElement).toBe(document.body);
+    expect(pop!.className).toBe("cmm__pop cmm__pop--portal ctx-chip__pop");
+    expect(pop!.getAttribute("role")).toBe("menu");
+    expect(pop!.getAttribute("aria-label")).toBe("Context usage");
+    expect(pop!.style.zIndex).toBe(String(FLOATING_MENU_Z_INDEX));
+  });
+
+  it("model chip keeps dialog semantics and aria-controls wiring", async () => {
+    const user = userEvent.setup();
+    render(
+      <ComposerModelMenu
+        modelId="test-model"
+        effort="high"
+        labels={{
+          model: "Model",
+          effort: "Effort",
+          effortHigh: "High",
+          effortMedium: "Medium",
+          effortLow: "Low",
+          modelSearchPlaceholder: "Search models",
+          modelSearchEmpty: "No models",
+          modelGroupOfficial: "Official",
+          contextWindow: "Context window",
+          contextWindowOfficial: "official",
+          contextWindowCustom: "custom",
+          contextWindowPlaceholder: "tokens",
+          contextWindowSave: "Save",
+          contextWindowOfficialHint: "unknown",
+        }}
+        onEffort={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Model" });
+    expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
+    await user.click(trigger);
+
+    const pop = bodyPop();
+    expect(pop).not.toBeNull();
+    expect(pop!.parentElement).toBe(document.body);
+    expect(pop!.classList.contains("cmm__pop")).toBe(true);
+    expect(pop!.classList.contains("cmm__pop--portal")).toBe(true);
+    expect(pop!.classList.contains("cmm__pop--model")).toBe(true);
+    expect(pop!.getAttribute("role")).toBe("dialog");
+    expect(pop!.getAttribute("aria-label")).toBe("Model");
+    expect(pop!.id).not.toBe("");
+    expect(trigger.getAttribute("aria-controls")).toBe(pop!.id);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("opens a combined model menu with an effort slider and Advanced", async () => {
+    const user = userEvent.setup();
+    render(
+      <ComposerModelMenu
+        modelId="test-model"
+        effort="high"
+        labels={{
+          model: "Model",
+          effort: "Effort",
+          effortHigh: "High",
+          effortMedium: "Medium",
+          effortLow: "Low",
+          modelSearchPlaceholder: "Search models",
+          modelSearchEmpty: "No models",
+          modelGroupOfficial: "Official",
+          contextWindow: "Context window",
+          contextWindowOfficial: "official",
+          contextWindowCustom: "custom",
+          contextWindowPlaceholder: "tokens",
+          contextWindowSave: "Save",
+          contextWindowOfficialHint: "unknown",
+          advanced: "Advanced",
+        }}
+        onEffort={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Effort" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Model" }));
+    const pop = bodyPop();
+    expect(pop).not.toBeNull();
+    expect(pop!.querySelector('[role="slider"]')).not.toBeNull();
+    expect(pop!.textContent ?? "").toMatch(/Effort High/);
+    expect(screen.getByRole("button", { name: "Advanced" })).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Advanced" }));
+    expect(screen.queryByRole("searchbox", { name: "Search models" })).toBeNull();
+    expect(pop!.textContent ?? "").toMatch(/Model/);
+    expect(pop!.textContent ?? "").toMatch(/Effort/);
+    expect(pop!.classList.contains("cmm__pop--hub")).toBe(true);
+    const hubModel = pop!.querySelector(".cmm__row");
+    expect(hubModel).not.toBeNull();
+    fireEvent.mouseEnter(hubModel!);
+    const flyout = await waitFor(() => {
+      const el = document.body.querySelector<HTMLElement>(
+        ":scope > .cmm__pop--flyout",
+      );
+      expect(el).not.toBeNull();
+      return el!;
+    });
+    expect(flyout.parentElement).toBe(document.body);
+    expect(flyout.style.zIndex).toBe(pop!.style.zIndex);
+    expect(flyout.classList.contains("cmm__pop--flyout-models")).toBe(true);
+    expect(
+      screen.getByRole("searchbox", { name: "Search models" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps Advanced hub and model flyout open after picking a model", async () => {
+    const user = userEvent.setup();
+    const onModel = vi.fn();
+    render(
+      <ComposerModelMenu
+        modelId="grok-4.6"
+        effort="high"
+        labels={{
+          model: "Model",
+          effort: "Effort",
+          effortHigh: "High",
+          effortMedium: "Medium",
+          effortLow: "Low",
+          modelSearchPlaceholder: "Search models",
+          modelSearchEmpty: "No models",
+          modelGroupOfficial: "Official",
+          contextWindow: "Context window",
+          contextWindowOfficial: "official",
+          contextWindowCustom: "custom",
+          contextWindowPlaceholder: "tokens",
+          contextWindowSave: "Save",
+          contextWindowOfficialHint: "unknown",
+          advanced: "Advanced",
+        }}
+        onModel={onModel}
+        onEffort={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Model" }));
+    await user.click(screen.getByRole("button", { name: "Advanced" }));
+    const pop = bodyPop();
+    expect(pop).not.toBeNull();
+    fireEvent.mouseEnter(pop!.querySelector(".cmm__row")!);
+    const pick = await waitFor(() => {
+      const el = screen.getByRole("button", { name: /Grok 4\.5/ });
+      expect(el).toBeTruthy();
+      return el;
+    });
+    await user.click(pick);
+    expect(onModel).toHaveBeenCalledWith("grok-4.5");
+    expect(bodyPop()).not.toBeNull();
+    expect(bodyPop()!.classList.contains("cmm__pop--hub")).toBe(true);
+    expect(
+      document.body.querySelector(":scope > .cmm__pop--flyout"),
+    ).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Advanced" })).toBeTruthy();
+    expect(
+      screen.getByRole("searchbox", { name: "Search models" }),
+    ).toBeTruthy();
+  });
+
+  it("pins a left flyout to the hub inner edge on the same z layer", () => {
+    const hub = {
+      left: 720,
+      right: 1000,
+      top: 200,
+      bottom: 360,
+      width: 280,
+      height: 160,
+      x: 720,
+      y: 200,
+      toJSON() {
+        return this;
+      },
+    } as DOMRect;
+    const prev = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1024 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+    const { pos, side } = placeHubFlyout(hub, null, "effort");
+    expect(side).toBe("left");
+    expect(pos.zIndex).toBe(FLOATING_MENU_Z_INDEX);
+    expect(pos.left).toBe("auto");
+    expect(pos.right).toBe(1024 - 720 + 8);
+    expect(pos.top).toBe(200);
+    expect(pos.maxHeight).toBeLessThanOrEqual(280);
+    const rightHub = { ...hub, left: 80, right: 360, x: 80 } as DOMRect;
+    const right = placeHubFlyout(rightHub, null, "models");
+    expect(right.side).toBe("right");
+    expect(right.pos.left).toBe(360 + 8);
+    expect(right.pos.maxHeight).toBe(240);
+    const windowRow = {
+      ...hub,
+      top: 292,
+      bottom: 324,
+      y: 292,
+      height: 32,
+    } as DOMRect;
+    const windowFly = placeHubFlyout(hub, null, "window", windowRow);
+    expect(windowFly.side).toBe("left");
+    expect(windowFly.pos.top).toBe(292);
+    expect(windowFly.pos.right).toBe(1024 - 720 + 8);
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 });
+    const tight = {
+      ...hub,
+      left: 420,
+      right: 700,
+      x: 420,
+      width: 280,
+    } as DOMRect;
+    const flipped = placeHubFlyout(tight, null, "models");
+    expect(flipped.side).toBe("left");
+    expect(flipped.pos.left).toBe("auto");
+    const flippedRight = Number(flipped.pos.right);
+    const flippedW = Number(flipped.pos.width);
+    expect(800 - flippedRight).toBeLessThanOrEqual(800 - 8);
+    expect(800 - flippedRight - flippedW).toBeGreaterThanOrEqual(8);
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 400 });
+    const squeezedHub = {
+      ...hub,
+      left: 40,
+      right: 320,
+      x: 40,
+      width: 280,
+    } as DOMRect;
+    const clamped = placeHubFlyout(squeezedHub, null, "models");
+    const cLeft = Number(clamped.pos.left === "auto" ? 8 : clamped.pos.left);
+    const cW = Number(clamped.pos.width);
+    if (clamped.pos.left === "auto") {
+      const rightEdge = 400 - Number(clamped.pos.right);
+      expect(rightEdge - cW).toBeGreaterThanOrEqual(8);
+      expect(rightEdge).toBeLessThanOrEqual(400 - 8);
+    } else {
+      expect(cLeft).toBeGreaterThanOrEqual(8);
+      expect(cLeft + cW).toBeLessThanOrEqual(400 - 8);
+    }
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: prev });
+  });
+
+  it("reopens the effort slider after closing from Advanced", async () => {
+    const user = userEvent.setup();
+    render(
+      <ComposerModelMenu
+        modelId="test-model"
+        effort="high"
+        labels={{
+          model: "Model",
+          effort: "Effort",
+          effortHigh: "High",
+          effortMedium: "Medium",
+          effortLow: "Low",
+          modelSearchPlaceholder: "Search models",
+          modelSearchEmpty: "No models",
+          modelGroupOfficial: "Official",
+          contextWindow: "Context window",
+          contextWindowOfficial: "official",
+          contextWindowCustom: "custom",
+          contextWindowPlaceholder: "tokens",
+          contextWindowSave: "Save",
+          contextWindowOfficialHint: "unknown",
+          advanced: "Advanced",
+        }}
+        onEffort={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Model" });
+    await user.click(trigger);
+    await user.click(screen.getByRole("button", { name: "Advanced" }));
+    expect(screen.queryByRole("searchbox", { name: "Search models" })).toBeNull();
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => expect(bodyPop()).toBeNull(), { timeout: 1000 });
+    await user.click(trigger);
+    const pop = bodyPop();
+    expect(pop).not.toBeNull();
+    expect(pop!.querySelector('[role="slider"]')).not.toBeNull();
+    expect(screen.queryByRole("searchbox", { name: "Search models" })).toBeNull();
+  });
+
+  it("shows grok-4.6 xhigh as xhigh and keeps Advanced to models only", async () => {
+    const user = userEvent.setup();
+    render(
+      <ComposerModelMenu
+        modelId="grok-4.6"
+        effort="xhigh"
+        labels={{
+          model: "Model",
+          effort: "Effort",
+          effortHigh: "High",
+          effortMedium: "Medium",
+          effortLow: "Low",
+          effortXhigh: "Extra high",
+          effortExtra: "Extra",
+          modelSearchPlaceholder: "Search models",
+          modelSearchEmpty: "No models",
+          modelGroupOfficial: "Official",
+          contextWindow: "Context window",
+          contextWindowOfficial: "official",
+          contextWindowCustom: "custom",
+          contextWindowPlaceholder: "tokens",
+          contextWindowSave: "Save",
+          contextWindowOfficialHint: "unknown",
+          advanced: "Advanced",
+        }}
+        onEffort={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Model" }));
+    const pop = bodyPop();
+    expect(pop).not.toBeNull();
+    expect(pop!.textContent ?? "").toMatch(/Effort xhigh/);
+    expect(pop!.textContent ?? "").not.toMatch(/Extra/);
+    await user.click(screen.getByRole("button", { name: "Advanced" }));
+    expect(screen.queryByRole("searchbox", { name: "Search models" })).toBeNull();
+    expect(pop!.textContent ?? "").toMatch(/xhigh/);
+    expect(pop!.textContent ?? "").not.toMatch(/Extra/);
+  });
+});

--- a/src/components/ComposerPortalPop.tsx
+++ b/src/components/ComposerPortalPop.tsx
@@ -1,0 +1,162 @@
+/**
+ * Shared portal layer for composer-row chip menus (model / access / project /
+ * worktree / context-usage). Owns the open state, trigger/panel refs and
+ * viewport positioning (useComposerPortalMenu), and renders the portaled
+ * `.cmm__pop.cmm__pop--portal` panel into document.body (ComposerPortalPop)
+ * so overflow parents never clip it — see docs/llm-wiki/dialogs.md.
+ *
+ * Menu business/content stays in each caller; only the portal plumbing that
+ * used to be copied per chip lives here.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type Dispatch,
+  type ReactNode,
+  type RefObject,
+  type SetStateAction,
+} from "react";
+import { createPortal } from "react-dom";
+import {
+  useFloatingMenu,
+  type FloatingPos,
+  type UseFloatingMenuOptions,
+} from "@/lib/floatingMenu";
+
+/** Positioning knobs a chip menu tunes; open/refs/onClose are owned here. */
+type ComposerPortalMenuOptions = Omit<
+  UseFloatingMenuOptions,
+  "open" | "triggerRef" | "panelRef" | "roots" | "onClose"
+>;
+
+export interface ComposerPortalMenu {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  requestClose: () => void;
+  exiting: boolean;
+  pos: FloatingPos | null;
+  popStyle: CSSProperties | undefined;
+  settled: boolean;
+  rootRef: RefObject<HTMLDivElement | null>;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  /** Visual box to pin against (chip shell). Falls back to the click trigger. */
+  positionRef: RefObject<HTMLElement | null>;
+  popRef: RefObject<HTMLDivElement | null>;
+  popId: string;
+}
+
+export function useComposerPortalMenu(
+  options: ComposerPortalMenuOptions & {
+    exitMs?: number;
+    extraRoots?: Array<RefObject<HTMLElement | null>>;
+  } = {},
+): ComposerPortalMenu {
+  const { exitMs = 0, extraRoots = [], ...floatingOpts } = options;
+  const [open, setOpen] = useState(false);
+  const [exiting, setExiting] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const positionRef = useRef<HTMLElement | null>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+  const popId = useId();
+  const closeTimer = useRef<number>(0);
+
+  const requestClose = useCallback(() => {
+    if (!open || exiting) return;
+    if (!exitMs) {
+      setOpen(false);
+      return;
+    }
+    setExiting(true);
+    window.clearTimeout(closeTimer.current);
+    closeTimer.current = window.setTimeout(() => {
+      setOpen(false);
+      setExiting(false);
+    }, exitMs);
+  }, [open, exiting, exitMs]);
+
+  useEffect(() => () => window.clearTimeout(closeTimer.current), []);
+
+  const { pos, style, settled } = useFloatingMenu({
+    open: open || exiting,
+    triggerRef,
+    positionRef,
+    panelRef: popRef,
+    roots: [rootRef, ...extraRoots],
+    onClose: requestClose,
+    // Composer chips sit 8px off the trigger (floatingMenu default is 6).
+    gap: 8,
+    ...floatingOpts,
+  });
+
+  return {
+    open,
+    setOpen,
+    requestClose,
+    exiting,
+    pos,
+    popStyle: style,
+    settled,
+    rootRef,
+    triggerRef,
+    positionRef,
+    popRef,
+    popId,
+  };
+}
+
+/**
+ * Portaled chip panel. Mounts only once a floating position exists so the
+ * first painted frame is already anchored (no unstyled flash). The material
+ * classes `cmm__pop cmm__pop--portal` are fixed — dropping them would render
+ * a transparent panel (forbidden, dialogs.md).
+ */
+export function ComposerPortalPop({
+  menu,
+  className,
+  id,
+  role = "menu",
+  ariaLabel,
+  children,
+}: {
+  menu: ComposerPortalMenu;
+  /** Chip-specific pop class (e.g. `cpm__pop`). */
+  className?: string;
+  /** Set to menu.popId when the trigger wires aria-controls. */
+  id?: string;
+  /** Chip menus are `menu`; the model/access sheets are `dialog`. */
+  role?: "menu" | "dialog";
+  ariaLabel: string;
+  children: ReactNode;
+}) {
+  if ((!menu.open && !menu.exiting) || !menu.pos || typeof document === "undefined") {
+    return null;
+  }
+  const modelPop = className?.includes("cmm__pop--model");
+  return createPortal(
+    <div
+      ref={menu.popRef}
+      className={[
+        "cmm__pop",
+        "cmm__pop--portal",
+        className,
+        modelPop && menu.exiting ? "is-out" : "",
+        modelPop && menu.settled && !menu.exiting ? "is-in" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      id={id}
+      role={role}
+      aria-label={ariaLabel}
+      style={menu.popStyle}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -178,6 +178,13 @@ export function Tip({
 
   useEffect(() => () => clearTimers(), [clearTimers]);
 
+  useEffect(() => {
+    if (!disabled) return;
+    clearTimers();
+    setOpen(false);
+    setSettled(false);
+  }, [disabled, clearTimers]);
+
   // After mount / content change: measure real tip size and clamp into viewport.
   useLayoutEffect(() => {
     if (!open) {

--- a/src/i18n/messages/de/composer.ts
+++ b/src/i18n/messages/de/composer.ts
@@ -212,6 +212,8 @@ export const deComposer = {
   "composer.access": "Zugriff",
   "composer.accessHint": "Wie soll der Agent laufen und Freigabe holen?",
   "composer.advanced": "Erweitert",
+  "composer.effortFaster": "Schneller",
+  "composer.effortSmarter": "Klüger",
   "composer.permissionTitle": "Abgestimmt auf Grok Build: Standard Nachfragen; Änderungen akzeptieren; Sitzung erlauben; dontAsk; YOLO-Bypass.",
   "composer.dropAttachTitle": "An Nachricht anhängen",
   "composer.dropAttachHint": "Dateien oder Ordner ablegen — sie gehen mit der nächsten Nachricht",

--- a/src/i18n/messages/en/composer.ts
+++ b/src/i18n/messages/en/composer.ts
@@ -215,6 +215,8 @@ export const enComposer = {
   "composer.access": "Access",
   "composer.accessHint": "How should the agent run and get approval?",
   "composer.advanced": "Advanced",
+  "composer.effortFaster": "Faster",
+  "composer.effortSmarter": "Smarter",
   "composer.permissionTitle": "Aligned with Grok Build: default Ask; accept edits; session allow; dontAsk; YOLO bypass.",
   "composer.dropAttachTitle": "Attach to message",
   "composer.dropAttachHint": "Drop files or folders — they will be sent with your next message",

--- a/src/i18n/messages/es/composer.ts
+++ b/src/i18n/messages/es/composer.ts
@@ -212,6 +212,8 @@ export const esComposer = {
   "composer.access": "Acceso",
   "composer.accessHint": "¿Cómo debería ejecutarse el agente y obtener aprobación?",
   "composer.advanced": "Avanzado",
+  "composer.effortFaster": "Más rápido",
+  "composer.effortSmarter": "Más inteligente",
   "composer.permissionTitle": "Alineado con Grok Build: Preguntar predeterminado; aceptar ediciones; permitir en la sesión; dontAsk; bypass YOLO.",
   "composer.dropAttachTitle": "Adjuntar al mensaje",
   "composer.dropAttachHint": "Suelta archivos o carpetas — se enviarán con tu siguiente mensaje",

--- a/src/i18n/messages/fil/composer.ts
+++ b/src/i18n/messages/fil/composer.ts
@@ -212,6 +212,8 @@ export const filComposer = {
   "composer.access": "Access",
   "composer.accessHint": "Paano dapat tumakbo at makakuha ng pag-apruba ang agent?",
   "composer.advanced": "Advanced",
+  "composer.effortFaster": "Mas mabilis",
+  "composer.effortSmarter": "Mas matalino",
   "composer.permissionTitle": "Tugma sa Grok Build: default na Magtanong; tanggapin ang mga edit; payagan sa session; dontAsk; YOLO bypass.",
   "composer.dropAttachTitle": "I-attach sa mensahe",
   "composer.dropAttachHint": "I-drop ang mga file o folder — ipapadala sila kasama ng iyong susunod na mensahe",

--- a/src/i18n/messages/fr/composer.ts
+++ b/src/i18n/messages/fr/composer.ts
@@ -212,6 +212,8 @@ export const frComposer = {
   "composer.access": "Accès",
   "composer.accessHint": "Comment l’agent doit-il s’exécuter et obtenir l’approbation ?",
   "composer.advanced": "Avancé",
+  "composer.effortFaster": "Plus rapide",
+  "composer.effortSmarter": "Plus intelligent",
   "composer.permissionTitle": "Aligné sur Grok Build : Demander par défaut ; accepter les modifications ; autoriser pour la session ; dontAsk ; contournement YOLO.",
   "composer.dropAttachTitle": "Joindre au message",
   "composer.dropAttachHint": "Déposez des fichiers ou dossiers — ils seront envoyés avec votre prochain message",

--- a/src/i18n/messages/id/composer.ts
+++ b/src/i18n/messages/id/composer.ts
@@ -212,6 +212,8 @@ export const idComposer = {
   "composer.access": "Akses",
   "composer.accessHint": "Bagaimana agen harus berjalan dan mendapat persetujuan?",
   "composer.advanced": "Lanjutan",
+  "composer.effortFaster": "Lebih cepat",
+  "composer.effortSmarter": "Lebih cerdas",
   "composer.permissionTitle": "Selaras dengan Grok Build: bawaan Tanya; terima suntingan; izinkan sesi; dontAsk; bypass YOLO.",
   "composer.dropAttachTitle": "Lampirkan ke pesan",
   "composer.dropAttachHint": "Jatuhkan berkas atau folder — akan dikirim bersama pesan berikutnya",

--- a/src/i18n/messages/it/composer.ts
+++ b/src/i18n/messages/it/composer.ts
@@ -212,6 +212,8 @@ export const itComposer = {
   "composer.access": "Accesso",
   "composer.accessHint": "Come deve eseguire e ottenere approvazione l’agente?",
   "composer.advanced": "Avanzate",
+  "composer.effortFaster": "Più veloce",
+  "composer.effortSmarter": "Più intelligente",
   "composer.permissionTitle": "Allineato a Grok Build: default Chiedi; accetta modifiche; consenti per sessione; dontAsk; bypass YOLO.",
   "composer.dropAttachTitle": "Allega al messaggio",
   "composer.dropAttachHint": "Trascina file o cartelle — verranno inviati con il prossimo messaggio",

--- a/src/i18n/messages/ja/composer.ts
+++ b/src/i18n/messages/ja/composer.ts
@@ -212,6 +212,8 @@ export const jaComposer = {
   "composer.access": "アクセス",
   "composer.accessHint": "エージェントの実行と承認はどうしますか？",
   "composer.advanced": "詳細",
+  "composer.effortFaster": "より速く",
+  "composer.effortSmarter": "より賢く",
   "composer.permissionTitle": "Grok Build に合わせています: 既定の Ask、編集を承認、セッション許可、dontAsk、YOLO bypass。",
   "composer.dropAttachTitle": "メッセージに添付",
   "composer.dropAttachHint": "ファイルまたはフォルダーをドロップ — 次のメッセージと一緒に送ります",

--- a/src/i18n/messages/ko/composer.ts
+++ b/src/i18n/messages/ko/composer.ts
@@ -212,6 +212,8 @@ export const koComposer = {
   "composer.access": "접근",
   "composer.accessHint": "에이전트가 어떻게 실행되고 승인을 받을까요?",
   "composer.advanced": "고급",
+  "composer.effortFaster": "더 빠르게",
+  "composer.effortSmarter": "더 똑똑하게",
   "composer.permissionTitle": "Grok Build와 맞춤: 기본 묻기; 편집 수락; 세션 허용; dontAsk; YOLO 우회.",
   "composer.dropAttachTitle": "메시지에 첨부",
   "composer.dropAttachHint": "파일이나 폴더를 놓으면 다음 메시지와 함께 보내집니다",

--- a/src/i18n/messages/pt-BR/composer.ts
+++ b/src/i18n/messages/pt-BR/composer.ts
@@ -212,6 +212,8 @@ export const ptBRComposer = {
   "composer.access": "Acesso",
   "composer.accessHint": "Como o agente deve executar e obter aprovação?",
   "composer.advanced": "Avançado",
+  "composer.effortFaster": "Mais rápido",
+  "composer.effortSmarter": "Mais inteligente",
   "composer.permissionTitle": "Alinhado ao Grok Build: Perguntar por padrão; aceitar edições; permitir na sessão; dontAsk; bypass YOLO.",
   "composer.dropAttachTitle": "Anexar à mensagem",
   "composer.dropAttachHint": "Solte arquivos ou pastas — eles serão enviados com a próxima mensagem",

--- a/src/i18n/messages/ru/composer.ts
+++ b/src/i18n/messages/ru/composer.ts
@@ -212,6 +212,8 @@ export const ruComposer = {
   "composer.access": "Доступ",
   "composer.accessHint": "Как агент должен работать и получать разрешения?",
   "composer.advanced": "Дополнительно",
+  "composer.effortFaster": "Быстрее",
+  "composer.effortSmarter": "Умнее",
   "composer.permissionTitle": "Как в Grok Build: по умолчанию Ask; принимать правки; разрешение на сессию; dontAsk; обход YOLO.",
   "composer.dropAttachTitle": "Прикрепить к сообщению",
   "composer.dropAttachHint": "Перетащите файлы или папки — они будут отправлены со следующим сообщением",

--- a/src/i18n/messages/ta/composer.ts
+++ b/src/i18n/messages/ta/composer.ts
@@ -212,6 +212,8 @@ export const taComposer = {
   "composer.access": "அணுகல்",
   "composer.accessHint": "முகவர் எவ்வாறு இயங்கி ஒப்புதல் பெற வேண்டும்?",
   "composer.advanced": "மேம்பட்டவை",
+  "composer.effortFaster": "வேகமாக",
+  "composer.effortSmarter": "புத்திசாலித்தனமாக",
   "composer.permissionTitle": "Grok Build உடன் சீரமைக்கப்பட்டது: இயல்புநிலை கேளுங்கள்; திருத்தங்களை ஏற்றுக்கொள்; அமர்வு அனுமதி; dontAsk; YOLO பைபாஸ்.",
   "composer.dropAttachTitle": "செய்தியுடன் இணைக்கவும்",
   "composer.dropAttachHint": "கோப்புகள் அல்லது கோப்புறைகளை கைவிடவும் - அவை உங்கள் அடுத்த செய்தியுடன் அனுப்பப்படும்",

--- a/src/i18n/messages/uk/composer.ts
+++ b/src/i18n/messages/uk/composer.ts
@@ -212,6 +212,8 @@ export const ukComposer = {
   "composer.access": "Доступ",
   "composer.accessHint": "Як агент має працювати й отримувати схвалення?",
   "composer.advanced": "Додатково",
+  "composer.effortFaster": "Швидше",
+  "composer.effortSmarter": "Розумніше",
   "composer.permissionTitle": "Узгоджено з Grok Build: типово Ask; accept edits; session allow; dontAsk; обхід YOLO.",
   "composer.dropAttachTitle": "Прикріпити до повідомлення",
   "composer.dropAttachHint": "Перетягніть файли або теки — їх буде надіслано з наступним повідомленням",

--- a/src/i18n/messages/zh-TW/composer.ts
+++ b/src/i18n/messages/zh-TW/composer.ts
@@ -214,6 +214,8 @@ export const zhTWComposer = {
   "composer.access": "存取",
   "composer.accessHint": "應如何執行並核准 Agent 操作？",
   "composer.advanced": "進階",
+  "composer.effortFaster": "更快",
+  "composer.effortSmarter": "更聰明",
   "composer.permissionTitle": "對齊 Grok Build：default Ask / acceptEdits / 對話允許 / dontAsk / YOLO bypass。",
   "composer.dropAttachTitle": "附加到訊息",
   "composer.dropAttachHint": "拖入檔案或資料夾，將隨下一則訊息傳給 Agent",

--- a/src/i18n/messages/zh/composer.ts
+++ b/src/i18n/messages/zh/composer.ts
@@ -214,6 +214,8 @@ export const zhComposer = {
   "composer.access": "访问",
   "composer.accessHint": "应如何运行并批准 Agent 操作？",
   "composer.advanced": "高级",
+  "composer.effortFaster": "更快",
+  "composer.effortSmarter": "更聪明",
   "composer.permissionTitle": "对齐 Grok Build：default Ask / acceptEdits / 会话允许 / dontAsk / YOLO bypass。",
   "composer.dropAttachTitle": "附加到消息",
   "composer.dropAttachHint": "拖入文件或文件夹，将随下一条消息发给 Agent",

--- a/src/lib/composerColumn.guard.test.ts
+++ b/src/lib/composerColumn.guard.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const styles = join(__dirname, "../styles");
+const chat1 = readFileSync(join(styles, "chat.part1.css"), "utf8");
+const chat2 = readFileSync(join(styles, "chat.part2.css"), "utf8");
+const chat4 = readFileSync(join(styles, "chat.part4.css"), "utf8");
+const lobe3 = readFileSync(
+  join(__dirname, "../components/lobe-chat/lobe-chat.part3.css"),
+  "utf8",
+);
+const column = readFileSync(
+  join(__dirname, "../app/WorkbenchComposerColumn.tsx"),
+  "utf8",
+);
+const shell = readFileSync(
+  join(__dirname, "../app/WorkbenchComposerShell.tsx"),
+  "utf8",
+);
+const app = column + shell;
+const modelMenu = readFileSync(
+  join(__dirname, "../components/ComposerModelMenu.tsx"),
+  "utf8",
+);
+const composer1 = readFileSync(join(styles, "composer.part1.css"), "utf8");
+
+describe("composer column matches chat width", () => {
+  it("publishes --chat-width-max on html so composer inherits it", () => {
+    expect(lobe3).toMatch(/html\s*\{[^}]*--chat-width-max:\s*800px/s);
+    expect(lobe3).toMatch(
+      /html\[data-chat-width="medium"\],\s*\.lobe-chat\[data-chat-width="medium"\]\s*\{[^}]*--chat-width-max:\s*800px/s,
+    );
+    expect(lobe3).toMatch(
+      /html\[data-chat-width="full"\],\s*\.lobe-chat\[data-chat-width="full"\]\s*\{[^}]*--chat-width-max:\s*none/s,
+    );
+  });
+
+  it("caps empty and active composer on the same token as the transcript", () => {
+    expect(chat1).toMatch(
+      /\.composer-stack\s*\{[^}]*max-width:\s*var\(--chat-width-max, 800px\)/s,
+    );
+    expect(chat1).toMatch(
+      /\.composer-wrap--welcome \.composer-stack\s*\{[^}]*max-width:\s*var\(--chat-width-max, 800px\)/s,
+    );
+    expect(chat1).not.toMatch(
+      /\.composer-wrap--welcome[^{]*\{[^}]*max-width:\s*42rem/s,
+    );
+    expect(chat2).toMatch(
+      /\.composer\s*\{[^}]*max-width:\s*var\(--chat-width-max, 800px\)/s,
+    );
+  });
+
+  it("keeps the workspace bar as a menu-radius shell, not a pill", () => {
+    expect(chat2).toMatch(
+      /\.composer__chip-shell\s*\{[^}]*--composer-context-radius:\s*var\(--menu-radius, 12px\)[^}]*border-radius:\s*var\(--composer-context-radius\)/s,
+    );
+    expect(chat2).toMatch(
+      /\.composer__chip-shell::before\s*\{[^}]*var\(--composer-opacity-mix, 100%\)/s,
+    );
+    expect(chat2).toMatch(
+      /\.composer\s*\{[^}]*background:\s*transparent[^}]*border-radius:\s*var\(--menu-radius, 12px\)/s,
+    );
+    expect(chat2).toMatch(
+      /\.composer::before\s*\{[^}]*var\(--composer-opacity-mix, 100%\)/s,
+    );
+  });
+
+  it("splits workspace and model chips into content-sized chrome shells", () => {
+    expect(chat2).toMatch(
+      /\.composer__chrome\s*\{[^}]*justify-content:\s*space-between/s,
+    );
+    expect(chat2).toMatch(
+      /\.composer__chip-shell\s*\{[^}]*width:\s*max-content/s,
+    );
+    expect(chat1).toMatch(
+      /\.composer-stack\s*\{[^}]*container-name:\s*composer/s,
+    );
+    expect(app).toContain('className="composer__chrome"');
+    expect(app).toContain(
+      'className="composer__model-bar composer__chip-shell"',
+    );
+    expect(modelMenu).not.toContain("cmm__nested");
+    expect(modelMenu).toContain("cmm__hub");
+    expect(modelMenu).toContain("cmm__stage");
+    expect(modelMenu).toContain("cmm__pop--flyout");
+    expect(modelMenu).toContain('showFlyout("models")');
+    expect(modelMenu).not.toContain('goPane("models")');
+    const modelIdx = app.indexOf("<ComposerModelMenu");
+    const accessIdx = app.indexOf("<ComposerAccessMenu");
+    const shellIdx = app.indexOf("ref={composerShellRef}");
+    expect(modelIdx).toBeGreaterThan(-1);
+    expect(accessIdx).toBeGreaterThan(-1);
+    expect(modelIdx).toBeLessThan(shellIdx);
+    expect(accessIdx).toBeGreaterThan(shellIdx);
+    expect(app.indexOf("<ComposerModelMenu", modelIdx + 1)).toBe(-1);
+    expect(modelMenu).toContain("cmm__stops");
+    expect(modelMenu).toMatch(
+      /const triggerText = `\$\{modelLabel\} \$\{eLabel\}`/,
+    );
+    expect(modelMenu).toContain("pinParent");
+    expect(modelMenu).not.toContain('className="cmm--effort"');
+    expect(chat2).toMatch(
+      /\.composer__model-bar:has\(\.is-open\)\s*\{[^}]*width:\s*280px/s,
+    );
+    expect(chat2).toMatch(
+      /\.composer__model-bar \.cmm__trigger\s*\{[^}]*justify-content:\s*center/s,
+    );
+  });
+
+  it("keeps composer chip pops as compact dropdowns", () => {
+    expect(composer1).not.toMatch(/max-width:\s*min\(720px/);
+    expect(composer1).toMatch(
+      /\.cmm__pop(?:\.cmm__pop--model|--model)\s*\{[^}]*max-width:\s*min\(280px/s,
+    );
+    expect(modelMenu).toMatch(/align:\s*"end"/);
+    expect(modelMenu).toMatch(/anchor:\s*"bottom"/);
+    expect(composer1).toMatch(
+      /\.cmm__pop\.cmm__pop--access\s*\{[^}]*width:\s*300px/s,
+    );
+    expect(composer1).toMatch(/\.cmm__stops-rail/);
+    expect(composer1).toMatch(/@keyframes cmm-pop-up/);
+    expect(composer1).toMatch(
+      /\.cmm__pop\.cmm__pop--portal\.cmm__pop--flyout/,
+    );
+    expect(composer1).not.toMatch(/\.cmm__nested\s*\{/);
+    expect(composer1).not.toMatch(/\.cmm__back\s*\{/);
+  });
+
+  it("shows composer icon wells only on hover or open", () => {
+    expect(chat4).toMatch(
+      /\.composer \.icon-btn:not\(\.icon-btn--primary\):not\(\.icon-btn--danger\):not\(\s*\.chip--json-schema\s*\)\s*\{[^}]*background:\s*transparent/s,
+    );
+    expect(chat4).toContain("-webkit-tap-highlight-color: transparent");
+  });
+});

--- a/src/lib/floatingMenu.test.ts
+++ b/src/lib/floatingMenu.test.ts
@@ -204,4 +204,32 @@ describe("floatingStyle", () => {
     expect(s?.minWidth).toBe(120);
     expect(s?.maxWidth).toBe(800);
   });
+
+  it("pins the panel bottom above the trigger so height grows upward", () => {
+    const r = {
+      x: 100,
+      y: 400,
+      top: 400,
+      bottom: 432,
+      left: 100,
+      right: 300,
+      width: 200,
+      height: 32,
+      toJSON() {
+        return this;
+      },
+    } as DOMRect;
+    const pos = computeFloatingPos(r, {
+      anchor: "bottom",
+      placement: "up",
+      width: 280,
+      fitContent: false,
+      gap: 8,
+    });
+    expect(pos.bottom).toBeGreaterThan(0);
+    expect(pos.placeAbove).toBe(false);
+    const s = floatingStyle(pos);
+    expect(s?.bottom).toBe(pos.bottom);
+    expect(s?.top).toBeUndefined();
+  });
 });

--- a/src/lib/floatingMenu.ts
+++ b/src/lib/floatingMenu.ts
@@ -31,6 +31,8 @@ export type FloatingAlign = "start" | "end";
 export interface FloatingPos {
   left: number;
   top: number;
+  /** Distance from viewport bottom; when set, `top` is unused. */
+  bottom?: number;
   /** Fixed width when not fit-content; 0 means content-sized. */
   width: number;
   placeAbove: boolean;
@@ -67,6 +69,8 @@ export interface ComputeFloatingOptions {
   align?: FloatingAlign;
   gap?: number;
   margin?: number;
+  /** Pin the panel's bottom edge above the trigger (grows upward). */
+  anchor?: "top" | "bottom";
 }
 
 export function computeFloatingPos(
@@ -122,6 +126,20 @@ export function computeFloatingPos(
     align === "end" ? trigger.right - width : trigger.left;
   left = Math.max(margin, Math.min(left, vw - width - margin));
 
+  if (opts.anchor === "bottom") {
+    return {
+      left,
+      top: 0,
+      bottom: Math.max(margin, vh - trigger.top + gap),
+      width: fitContent ? 0 : width,
+      placeAbove: false,
+      maxHeight,
+      maxWidth,
+      fitContent,
+      align,
+    };
+  }
+
   if (placeAbove) {
     return {
       left,
@@ -150,6 +168,7 @@ function posEqual(a: FloatingPos, b: FloatingPos): boolean {
   return (
     a.left === b.left &&
     a.top === b.top &&
+    a.bottom === b.bottom &&
     a.width === b.width &&
     a.placeAbove === b.placeAbove &&
     a.maxHeight === b.maxHeight &&
@@ -178,11 +197,15 @@ export function floatingStyle(
   const base: CSSProperties = {
     position: "fixed",
     left: pos.left,
-    top: pos.top,
     maxHeight: pos.maxHeight,
     maxWidth: pos.maxWidth,
     zIndex: FLOATING_MENU_Z_INDEX,
   };
+  if (typeof pos.bottom === "number") {
+    base.bottom = pos.bottom;
+  } else {
+    base.top = pos.top;
+  }
   if (pos.fitContent) {
     base.width = "max-content";
     if (extras?.minWidth) base.minWidth = extras.minWidth;
@@ -209,6 +232,8 @@ export interface UseFloatingMenuOptions {
   open: boolean;
   /** Trigger element used for positioning. */
   triggerRef: RefObject<HTMLElement | null>;
+  /** If set, measure this box instead of the click trigger (e.g. chip shell). */
+  positionRef?: RefObject<HTMLElement | null>;
   /** Panel element (for outside-click + ignore + overflow clamp). */
   panelRef: RefObject<HTMLElement | null>;
   /** Optional extra roots that count as "inside" (e.g. trigger wrapper). */
@@ -224,6 +249,9 @@ export interface UseFloatingMenuOptions {
   fitContent?: boolean;
   estHeight?: number;
   gap?: number;
+  /** Pin panel bottom above the trigger so height changes grow upward. */
+  anchor?: "top" | "bottom";
+  margin?: number;
   /**
    * When false, do not apply the placeAbove `translateY(-100%)` positioning
    * transform. Needed when the panel itself animates transform.
@@ -239,6 +267,7 @@ export interface UseFloatingMenuOptions {
 export function useFloatingMenu({
   open,
   triggerRef,
+  positionRef,
   panelRef,
   roots = [],
   onClose,
@@ -250,6 +279,8 @@ export function useFloatingMenu({
   fitContent = true,
   estHeight = 240,
   gap = 6,
+  anchor = "top",
+  margin: marginOpt = 8,
   anchorTransform = true,
   deps = [],
 }: UseFloatingMenuOptions): {
@@ -271,6 +302,8 @@ export function useFloatingMenu({
     placement,
     align,
     gap,
+    anchor,
+    margin: marginOpt,
   });
   optsRef.current = {
     width,
@@ -281,6 +314,8 @@ export function useFloatingMenu({
     placement,
     align,
     gap,
+    anchor,
+    margin: marginOpt,
   };
 
   const applyPos = (next: FloatingPos) => {
@@ -288,13 +323,13 @@ export function useFloatingMenu({
   };
 
   const update = (markSettled: boolean) => {
-    const el = triggerRef.current;
+    const el = positionRef?.current ?? triggerRef.current;
     if (!el) return;
     const r = el.getBoundingClientRect();
     setTriggerW(r.width);
     const o = optsRef.current;
     const gap = o.gap ?? 6;
-    const margin = 8;
+    const margin = o.margin ?? 8;
     let next = computeFloatingPos(r, {
       width: o.width,
       minWidth: o.minWidth,
@@ -304,6 +339,8 @@ export function useFloatingMenu({
       placement: o.placement,
       align: o.align,
       gap,
+      margin,
+      anchor: o.anchor,
     });
 
     // Refine with real panel box once mounted (absolute top when above; clamp left).
@@ -318,7 +355,19 @@ export function useFloatingMenu({
       const ph = panel.offsetHeight || panel.getBoundingClientRect().height;
       const pw = panel.offsetWidth || panel.getBoundingClientRect().width;
 
-      if (next.placeAbove || o.placement === "up") {
+      if (o.anchor === "bottom") {
+        const vh =
+          typeof globalThis.innerHeight === "number"
+            ? globalThis.innerHeight
+            : 768;
+        next = {
+          ...next,
+          top: 0,
+          bottom: Math.max(margin, vh - r.top + gap),
+          placeAbove: false,
+          maxHeight: Math.max(120, r.top - gap - margin),
+        };
+      } else if (next.placeAbove || o.placement === "up") {
         /**
          * Prefer flush above the trigger:
          *   top = trigger.top - gap - panelHeight
@@ -389,7 +438,7 @@ export function useFloatingMenu({
     // Re-anchor when either anchor or content changes size. Pane dragging can
     // resize the trigger without resizing the window.
     let ro: ResizeObserver | null = null;
-    const trigger = triggerRef.current;
+    const trigger = positionRef?.current ?? triggerRef.current;
     const panel = panelRef.current;
     if (typeof ResizeObserver !== "undefined" && (trigger || panel)) {
       ro = new ResizeObserver(() => update(true));
@@ -414,6 +463,8 @@ export function useFloatingMenu({
     fitContent,
     estHeight,
     gap,
+    anchor,
+    marginOpt,
     ...deps,
   ]);
 

--- a/src/lib/grokCatalog.test.ts
+++ b/src/lib/grokCatalog.test.ts
@@ -9,6 +9,7 @@ import {
   effortCatalogForRoute,
   effortCatalogKind,
   effortDisplayLabel,
+  effortPickerStops,
   effortUiOptionIsActive,
   effortUiOptionsForCatalog,
   effortsForModel,
@@ -186,6 +187,32 @@ describe("effort UI ladder", () => {
     { id: "xhigh" },
     { id: "max" },
   ];
+
+  it("builds picker stops from catalog ids; purple is the strongest stop", () => {
+    expect(
+      effortPickerStops(GROK_BUILD_EFFORTS).map((s) => [
+        s.id,
+        s.spawnId,
+        s.accent ?? "",
+      ]),
+    ).toEqual([
+      ["low", "low", ""],
+      ["medium", "medium", ""],
+      ["high", "high", "ultra"],
+    ]);
+    expect(
+      effortPickerStops(GROK_4_6_EFFORTS).map((s) => [
+        s.id,
+        s.spawnId,
+        s.accent ?? "",
+      ]),
+    ).toEqual([
+      ["low", "low", ""],
+      ["medium", "medium", ""],
+      ["high", "high", ""],
+      ["xhigh", "xhigh", "ultra"],
+    ]);
+  });
 
   it("orders Grok as 低/中/高 without 极高", () => {
     expect(effortUiOptionsForCatalog(GROK_BUILD_EFFORTS).map((o) => o.uiId)).toEqual(

--- a/src/lib/grokCatalog.ts
+++ b/src/lib/grokCatalog.ts
@@ -149,6 +149,20 @@ export type EffortUiOption = {
   spawnId: string;
 };
 
+/**
+ * Discrete Faster↔Smarter stops for the composer Effort popover.
+ * Labels use catalog spawn ids (`xhigh`, `max`) — not Claude's Extra name.
+ * Purple (`accent: "ultra"`) marks the strongest stop in this catalog.
+ */
+export type EffortPickerStopId = "low" | "medium" | "high" | "xhigh" | "max";
+
+export type EffortPickerStop = {
+  id: EffortPickerStopId;
+  spawnId: string;
+  /** Strongest stop in this catalog (purple thumb). */
+  accent?: "ultra";
+};
+
 /** Product session modes (desktop shell). */
 export const SESSION_MODES: SessionModeOption[] = [
   { id: "agent" },
@@ -377,6 +391,36 @@ export function effortUiOptionsForCatalog(
     out.push({ uiId, spawnId });
   }
   return out;
+}
+
+/** Discrete Faster↔Smarter stops for the composer Effort popover. */
+export function effortPickerStops(
+  catalogEfforts?: EffortOption[] | null,
+): EffortPickerStop[] {
+  const list = effortsForModel(null, catalogEfforts);
+  const byLower = new Map(
+    list.map((e) => [e.id.trim().toLowerCase(), e.id] as const),
+  );
+  const stops: EffortPickerStop[] = [];
+  const take = (
+    key: string,
+    id: EffortPickerStopId,
+    accent?: EffortPickerStop["accent"],
+  ) => {
+    const spawn = byLower.get(key);
+    if (spawn) stops.push({ id, spawnId: spawn, accent });
+  };
+  take("low", "low");
+  take("medium", "medium");
+  take("high", "high");
+  take("xhigh", "xhigh");
+  const maxSpawn = byLower.get("max");
+  if (maxSpawn && !stops.some((s) => s.spawnId === maxSpawn)) {
+    stops.push({ id: "max", spawnId: maxSpawn });
+  }
+  const last = stops[stops.length - 1];
+  if (last) last.accent = "ultra";
+  return stops;
 }
 
 /** True when this UI row is the selected effort (at most one row). */

--- a/src/lib/wallpaperThemeContrast.guard.test.ts
+++ b/src/lib/wallpaperThemeContrast.guard.test.ts
@@ -160,16 +160,16 @@ describe("wallpaper theme contrast CSS", () => {
 
   it("washes composer hover like chrome-btn, without isolation layers", () => {
     expect(composerBtnCss).toMatch(
-      /\.composer\s+\.icon-btn:not\(\.icon-btn--primary\):not\(\.icon-btn--danger\):hover:not\(\s*:disabled\s*\)[\s\S]{0,160}background:\s*var\(--bg-hover\)/s,
+      /\.composer[\s\S]*?\.icon-btn:not\(\.icon-btn--primary\):not\(\.icon-btn--danger\)[\s\S]{0,280}background:\s*var\(--bg-hover\)/s,
     );
     expect(composerBtnCss).not.toMatch(
       /\.composer \.icon-btn:not\(\.icon-btn--primary\):not\(\.icon-btn--danger\)::after/s,
     );
     expect(composerBtnCss).not.toMatch(
-      /\.composer \.icon-btn:not\(\.icon-btn--primary\):not\(\.icon-btn--danger\)\s*\{[^}]*isolation:\s*isolate/s,
+      /\.composer \.icon-btn:not\(\.icon-btn--primary\):not\(\.icon-btn--danger\)[\s\S]{0,80}\{[^}]*isolation:\s*isolate/s,
     );
     expect(composerBtnCss).toMatch(
-      /\.composer \.icon-btn:not\(\.icon-btn--primary\):not\(\.icon-btn--danger\)\s*\{[^}]*-webkit-appearance:\s*none/s,
+      /\.composer \.icon-btn:not\(\.icon-btn--primary\):not\(\.icon-btn--danger\)[\s\S]{0,80}\{[^}]*-webkit-appearance:\s*none/s,
     );
     expect(composerChromeCss).toMatch(
       /\.composer__context-item:hover:not\(:disabled\),\s*\.composer__context-item\.is-open\s*\{[^}]*background:\s*var\(--bg-hover\)/s,
@@ -257,10 +257,10 @@ describe("wallpaper theme contrast CSS", () => {
 
   it("keeps the composer on an independent opacity mix, not wallpaper scrim", () => {
     expect(css).toMatch(
-      /html\[data-wallpaper="1"\] :is\(\.composer, \.composer__context-bar\)\s*\{[^}]*background:\s*transparent[^}]*backdrop-filter:\s*none/s,
+      /html\[data-wallpaper="1"\] :is\(\.composer, \.composer__chip-shell\)\s*\{[^}]*background:\s*transparent[^}]*backdrop-filter:\s*none/s,
     );
     expect(composerChromeCss).toMatch(
-      /\.composer__context-bar::before\s*\{[^}]*var\(--composer-opacity-mix, 100%\)/s,
+      /\.composer__chip-shell::before\s*\{[^}]*var\(--composer-opacity-mix, 100%\)/s,
     );
     expect(composerChromeCss).toMatch(
       /\.composer::before\s*\{[^}]*var\(--composer-opacity-mix, 100%\)/s,
@@ -379,10 +379,10 @@ describe("wallpaper theme contrast CSS", () => {
 
   it("nests the workspace chip as a rounded rect inside a uniform inset", () => {
     expect(composerChromeCss).toMatch(
-      /\.composer__context-bar\s*\{[^}]*--composer-context-pad:\s*4px;[^}]*--composer-context-radius:\s*var\(--menu-radius, 12px\);[^}]*padding:\s*var\(--composer-context-pad\);[^}]*border-radius:\s*var\(--composer-context-radius\)/s,
+      /\.composer__chip-shell\s*\{[^}]*--composer-context-pad:\s*4px;[^}]*--composer-context-radius:\s*var\(--menu-radius, 12px\);[^}]*padding:\s*var\(--composer-context-pad\);[^}]*border-radius:\s*var\(--composer-context-radius\)/s,
     );
     expect(composerChromeCss).not.toMatch(
-      /\.composer__context-bar\s*\{[^}]*padding:\s*4px 10px/s,
+      /\.composer__chip-shell\s*\{[^}]*padding:\s*4px 10px/s,
     );
     expect(composerChromeCss).toMatch(
       /\.composer__context-item\s*\{[^}]*border-radius:\s*calc\(\s*var\(--composer-context-radius, 12px\)\s*-\s*var\(--composer-context-pad, 4px\)\s*\)/s,

--- a/src/lib/welcomeIntro.guard.test.ts
+++ b/src/lib/welcomeIntro.guard.test.ts
@@ -45,7 +45,7 @@ describe("new-chat welcome intro", () => {
     );
     expect(riseKeyframes?.[1]?.trim()).toBe(baseTransform);
     expect(css).toMatch(
-      /\.composer-welcome-mark\s*\{[\s\S]*?width: 100%;[\s\S]*?max-width: 42rem;/,
+      /\.composer-welcome-mark\s*\{[\s\S]*?width: 100%;[\s\S]*?max-width: var\(--chat-width-max, 800px\);/,
     );
     expect(css).toMatch(
       /\.composer-welcome-mark\s*\{[\s\S]*?flex-direction: column;[\s\S]*?gap: 12px;/,
@@ -55,6 +55,18 @@ describe("new-chat welcome intro", () => {
     );
     expect(css).not.toMatch(
       /\.composer-welcome-prompt\s*\{[^}]*position:\s*absolute/s,
+    );
+    expect(css).toMatch(
+      /\.composer-wrap--welcome\s*\{[^}]*justify-content:\s*flex-end/s,
+    );
+    expect(css).toMatch(
+      /\.composer-wrap--welcome\s*\{[^}]*padding-bottom:\s*max\(72px, 14vh\)/s,
+    );
+    expect(css).toMatch(
+      /\.composer-wrap--welcome \.composer-welcome-mark\s*\{[^}]*flex:\s*1 1 auto/s,
+    );
+    expect(phoneCss).toMatch(
+      /\.app-shell--phone \.composer-wrap--welcome\s*\{[^}]*padding-top:\s*24px/s,
     );
     expect(css).not.toMatch(
       /\.composer-welcome-mark\.is-entering \.composer-welcome-prompt\s*\{[^}]*will-change:\s*clip-path/s,

--- a/src/styles/chat.part1.css
+++ b/src/styles/chat.part1.css
@@ -622,7 +622,8 @@
   gap: 10px;
 }
 
-/* Empty / new session: logo + composer vertically centered in the stage */
+/* Empty / new session: composer sits in the lower half; SuperGrok + prompt
+ * stay centered in the free space above it (same idea as phone). */
 .composer-wrap--welcome {
   top: 0;
   bottom: 0;
@@ -633,9 +634,11 @@
   );
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   gap: 22px;
-  padding: 24px 16px;
+  padding: 24px 20px;
+  padding-top: max(48px, 8vh);
+  padding-bottom: max(72px, 14vh);
 }
 
 /* Wallpaper clicks pass through the wrap onto .lobe-chat (user-select:text).
@@ -650,25 +653,24 @@
   pointer-events: auto;
 }
 
-.composer-wrap--welcome .composer {
-  width: 100%;
+.composer-wrap--welcome .composer-welcome-mark {
+  flex: 1 1 auto;
+  min-height: 0;
+  justify-content: center;
 }
 
-/* Empty session keeps the classic ~42rem input; active threads match transcript. */
+.composer-wrap--welcome .composer,
 .composer-wrap--welcome .composer-stack {
-  max-width: 42rem;
-}
-
-.composer-wrap--welcome .composer-stack .composer,
-.composer-wrap--welcome > .composer {
-  max-width: 42rem;
+  width: 100%;
+  max-width: var(--chat-width-max, 800px);
+  flex-shrink: 0;
 }
 
 .composer-welcome-mark {
   pointer-events: none;
   position: relative;
   width: 100%;
-  max-width: 42rem;
+  max-width: var(--chat-width-max, 800px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -898,6 +900,8 @@
   flex-direction: column;
   align-items: stretch;
   gap: 0;
+  container-type: inline-size;
+  container-name: composer;
 }
 
 .composer-stack--with-context {

--- a/src/styles/chat.part2.css
+++ b/src/styles/chat.part2.css
@@ -6,18 +6,36 @@
   max-width: none;
 }
 
-/* Desktop composer: project / default workspace / branch bar above input.
- * Rounded rect, not a stadium: shell radius stays below half the bar
+/* Desktop composer chrome: workspace cluster left, model/effort right.
+ * Each cluster is a content-sized chip-shell — not a full-width bar. */
+.composer__chrome {
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+}
+
+.composer__chrome > * {
+  pointer-events: auto;
+}
+
+/* Rounded rect, not a stadium: shell radius stays below half the bar
  * height and matches --menu-radius (dropdown). Inner chip = shell − pad
  * so hover fill is concentric with the outer corner. */
-.composer__context-bar {
+.composer__chip-shell {
   --composer-context-pad: 4px;
   --composer-context-radius: var(--menu-radius, 12px);
   pointer-events: auto;
   display: flex;
   align-items: center;
   gap: var(--composer-context-pad);
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  width: max-content;
+  max-width: 100%;
+  min-width: 0;
   min-height: calc(28px + 2 * var(--composer-context-pad));
   padding: var(--composer-context-pad);
   border-radius: var(--composer-context-radius);
@@ -28,7 +46,7 @@
   color: var(--text-secondary);
 }
 
-.composer__context-bar::before {
+.composer__chip-shell::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -42,9 +60,37 @@
   z-index: 0;
 }
 
-.composer__context-bar > * {
+.composer__chip-shell > * {
   position: relative;
   z-index: 1;
+}
+
+.composer__context-bar {
+  flex: 0 1 auto;
+}
+
+.composer__model-bar {
+  flex: 0 0 auto;
+  width: max-content;
+  max-width: 100%;
+  margin-left: auto;
+  box-sizing: border-box;
+  justify-content: center;
+}
+
+.composer__model-bar:has(.is-open) {
+  width: 280px;
+  max-width: 280px;
+}
+
+.composer__chip-shell .cmm__trigger {
+  border-radius: calc(
+    var(--composer-context-radius, 12px) - var(--composer-context-pad, 4px)
+  );
+}
+
+.composer__model-bar .cmm__trigger {
+  justify-content: center;
 }
 
 /* Session / workspace change chips live in the context bar (not the input). */
@@ -52,7 +98,6 @@
   display: inline-flex;
   align-items: center;
   gap: 2px;
-  margin-left: auto;
   flex-shrink: 0;
   min-width: 0;
 }
@@ -68,7 +113,7 @@
   font-variant-numeric: tabular-nums;
 }
 
-[data-theme="light"] .composer__context-bar {
+[data-theme="light"] .composer__chip-shell {
   background: transparent;
   border-color: color-mix(in srgb, var(--border-subtle) 80%, transparent);
 }

--- a/src/styles/chat.part4.css
+++ b/src/styles/chat.part4.css
@@ -291,7 +291,9 @@
  * Rest: no disc on the glass plate (same as .chrome-btn). Hover uses the
  * composer-wrap --bg-hover token (rgba on wallpaper, not color-mix).
  */
-.composer .icon-btn:not(.icon-btn--primary):not(.icon-btn--danger) {
+.composer .icon-btn:not(.icon-btn--primary):not(.icon-btn--danger):not(
+    .chip--json-schema
+  ) {
   background: transparent;
   appearance: none;
   -webkit-appearance: none;
@@ -299,7 +301,9 @@
 }
 
 .composer
-  .icon-btn:not(.icon-btn--primary):not(.icon-btn--danger):hover:not(:disabled),
+  .icon-btn:not(.icon-btn--primary):not(.icon-btn--danger):not(
+    .chip--json-schema
+  ):is(:hover, :focus-visible, .is-open, [aria-pressed="true"]):not(:disabled),
 .composer .icon-btn--plus.is-open {
   background: var(--bg-hover);
   color: var(--text-primary);

--- a/src/styles/chat.part6.css
+++ b/src/styles/chat.part6.css
@@ -676,6 +676,20 @@
   flex-shrink: 0;
 }
 
+.cmm__measure {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  visibility: hidden;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.cmm__measure .cmm__trigger {
+  position: static;
+  max-width: none;
+}
+
 /* Flat control (no capsule border) — hover wash matches .chrome-btn. */
 .cmm__trigger {
   display: inline-flex;
@@ -706,6 +720,10 @@
 .cmm.is-open .cmm__trigger {
   background: var(--bg-hover);
   color: var(--text-primary);
+}
+
+.cmm--model.is-open .cmm__trigger {
+  background: transparent;
 }
 
 .cmm--danger .cmm__trigger {
@@ -794,6 +812,31 @@
   }
 }
 
+/* Chrome chips keep labels: they are no longer in the crowded input row. */
+.composer__model-bar .cmm--model .cmm__trigger-text--full {
+  display: inline;
+}
+
+.composer__model-bar .cmm--model .cmm__trigger-text--short {
+  display: none;
+}
+
+@container composer (max-width: 380px) {
+  .composer__model-bar .cmm--model .cmm__trigger {
+    width: auto;
+    max-width: min(140px, 34vw);
+    padding: 0 7px;
+    gap: 4px;
+    justify-content: center;
+  }
+  .composer__model-bar .cmm--model .cmm__trigger-text--full {
+    display: inline;
+  }
+  .composer__model-bar .cmm--model .cmm__chev {
+    display: none;
+  }
+}
+
 .cmm__header {
   padding: 8px 12px 6px;
 }
@@ -835,6 +878,13 @@
 /* Portaled to body — escapes all overflow parents */
 .cmm__pop--portal {
   position: fixed;
+  animation: ui-tip-in var(--motion-pane) var(--motion-pane-ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cmm__pop--portal {
+    animation: none;
+  }
 }
 
 .cmm__row {

--- a/src/styles/composer.part1.css
+++ b/src/styles/composer.part1.css
@@ -27,80 +27,442 @@
 /*
  * Model menu is portaled to body — styles must target `.cmm__pop--model`
  * (panel), not `.cmm--model` (trigger root outside the portal).
- * Width follows content (max-content); only clamp to viewport.
+ * Compact dropdown: fixed width, ellipsis long ids (title still has the full
+ * string). Do not grow with the longest custom model id.
  */
-.cmm__pop--model {
-  width: max-content;
-  /* Beat default --menu-max-width (360px); inline floating style also clamps. */
-  max-width: min(720px, calc(100vw - 16px));
+.cmm__pop.cmm__pop--model {
+  width: 280px;
+  max-width: min(280px, calc(100vw - 16px));
+  max-height: min(52vh, calc(100vh - 88px));
+  overflow-x: hidden;
+  overflow-y: auto;
+  transform-origin: bottom center;
+  animation: none;
+  opacity: 0;
+  transform: scaleY(0.2);
 }
 
-/* Root row: show full model id — panel grows with the longest value. */
+.cmm__pop.cmm__pop--model.is-in {
+  animation: cmm-pop-up var(--motion-pane) var(--motion-pane-ease) both;
+}
+
+.cmm__pop.cmm__pop--model.is-out {
+  animation: cmm-pop-up var(--motion-pane) var(--motion-pane-ease) reverse both;
+}
+
+@keyframes cmm-pop-up {
+  from {
+    opacity: 0;
+    transform: scaleY(0.2);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 .cmm__pop--model .cmm__row {
-  width: max-content;
-  min-width: 100%;
+  width: 100%;
+  min-width: 0;
+  min-height: 32px;
+  padding: 6px 10px;
   box-sizing: border-box;
 }
 
 .cmm__pop--model .cmm__row-val {
-  max-width: none;
-  flex: 0 0 auto;
+  max-width: 46%;
+  flex: 1 1 auto;
   justify-content: flex-end;
-  overflow: visible;
+  overflow: hidden;
   min-width: 0;
 }
 
 .cmm__pop--model .cmm__row-val-text {
-  overflow: visible;
-  text-overflow: clip;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Nested option titles: wrap long ids instead of clipping mid-token. */
 .cmm__pop--model .cmm__opt-title {
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  white-space: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
 .cmm__pop--model .cmm__opt-desc {
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  display: none;
 }
 
-/* Nested list still fills the content-sized panel. */
-.cmm__pop--model .cmm__nested,
 .cmm__pop--model .cmm__opt,
 .cmm__pop--model .cmm__search,
-.cmm__pop--model .cmm__back {
-  min-width: 100%;
+.cmm__pop--flyout .cmm__opt,
+.cmm__pop--flyout .cmm__search {
+  min-width: 0;
+  width: 100%;
   box-sizing: border-box;
 }
 
-.cmm__row--sub {
-  padding-left: 20px;
-  font-size: 12px;
+.cmm__pop--model .cmm__opt,
+.cmm__pop--effort .cmm__opt,
+.cmm__pop--flyout .cmm__opt {
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+}
+
+.cmm__pop--model .cmm__row.is-fly {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* Combined model chip: Effort popover (Claude desktop) + Advanced. */
+.cmm__stage {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px 8px;
+}
+
+.cmm__simple-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cmm__hub-body {
+  display: none;
+  flex-direction: column;
+}
+
+.cmm__stage.is-hub .cmm__simple-body {
+  display: none;
+}
+
+.cmm__stage.is-hub .cmm__hub-body {
+  display: flex;
+  animation: cmm-hub-in var(--motion-pane) var(--motion-pane-ease);
+}
+
+.cmm__stage.is-hub .cmm__advanced {
+  order: -1;
+  align-self: flex-end;
+}
+
+@keyframes cmm-hub-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 /*
- * Access menu (mode | permission) — dual-column sheet.
+ * Tertiary flyout sits on the same floating layer as the Advanced hub.
+ * Shadows are biased away from the hub so the two cards do not stain
+ * each other. Left placement pins the inner edge (CSS `right`) so the
+ * gap matches the right-side layout.
+ */
+.cmm__pop.cmm__pop--model.cmm__pop--hub,
+.cmm__pop.cmm__pop--portal.cmm__pop--flyout {
+  isolation: auto;
+  /* Downward-biased shadow so hub + flyout stay coplanar (no side stain). */
+  box-shadow:
+    0 0 0 0.5px color-mix(in srgb, var(--text-primary) 10%, transparent) inset,
+    0 10px 22px color-mix(in srgb, #000 18%, transparent);
+}
+
+.cmm__pop.cmm__pop--portal.cmm__pop--flyout {
+  width: max-content;
+  min-width: 168px;
+  max-width: 220px;
+  padding: 6px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  transform: translateZ(0);
+  animation: cmm-fly-in-right var(--motion-pane) var(--motion-pane-ease) both;
+  box-shadow:
+    0 0 0 0.5px color-mix(in srgb, var(--text-primary) 10%, transparent) inset,
+    8px 10px 22px color-mix(in srgb, #000 16%, transparent);
+}
+
+.cmm__pop.cmm__pop--portal.cmm__pop--flyout[data-side="left"] {
+  animation-name: cmm-fly-in-left;
+  box-shadow:
+    0 0 0 0.5px color-mix(in srgb, var(--text-primary) 10%, transparent) inset,
+    -8px 10px 22px color-mix(in srgb, #000 16%, transparent);
+}
+
+.cmm__pop.cmm__pop--flyout-models {
+  width: 220px;
+  min-width: 168px;
+  max-width: 220px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.cmm__flyout-stack {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: 100%;
+}
+
+.cmm__flyout-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.cmm__pop--flyout .cmm__search {
+  padding: 2px 2px 6px;
+}
+
+.cmm__pop--flyout .cmm__search-input {
+  height: 28px;
+  font-size: 12px;
+}
+
+.cmm__pop--flyout .cmm__section {
+  padding: 4px 8px 2px;
+}
+
+.cmm__pop--flyout .cmm__opt-check {
+  margin-top: 0;
+}
+
+.cmm__pop--flyout .cmm__opt-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@keyframes cmm-fly-in-right {
+  from {
+    opacity: 0;
+    transform: translateX(-6px) translateZ(0);
+  }
+  to {
+    opacity: 1;
+    transform: translateZ(0);
+  }
+}
+
+@keyframes cmm-fly-in-left {
+  from {
+    opacity: 0;
+    transform: translateX(6px) translateZ(0);
+  }
+  to {
+    opacity: 1;
+    transform: translateZ(0);
+  }
+}
+
+.cmm__simple-head {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.cmm__simple-title {
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cmm__simple-title.is-ultra,
+.cmm--extra .cmm__trigger,
+.cmm--extra.is-open .cmm__trigger,
+.cmm--extra .cmm__trigger:hover {
+  color: #c4a0ff;
+}
+
+[data-theme="light"] .cmm__simple-title.is-ultra,
+[data-theme="light"] .cmm--extra .cmm__trigger,
+[data-theme="light"] .cmm--extra.is-open .cmm__trigger,
+[data-theme="light"] .cmm--extra .cmm__trigger:hover {
+  color: #7c4dff;
+}
+
+.cmm__advanced {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  align-self: flex-end;
+  height: 28px;
+  padding: 0 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 550;
+  cursor: pointer;
+}
+
+.cmm__advanced:hover {
+  color: var(--text-primary);
+}
+
+.cmm__row-val-text.is-ultra,
+.cmm__opt-title.is-ultra {
+  color: #c4a0ff;
+}
+
+[data-theme="light"] .cmm__row-val-text.is-ultra,
+[data-theme="light"] .cmm__opt-title.is-ultra {
+  color: #7c4dff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cmm__stops-rail,
+  .cmm__stops-thumb,
+  .composer__model-bar {
+    transition: none;
+  }
+  .cmm__pop.cmm__pop--model,
+  .cmm__pop.cmm__pop--flyout,
+  .cmm__stage.is-hub .cmm__hub-body {
+    animation: none;
+  }
+  .cmm__advanced {
+    transition: none;
+  }
+}
+
+/* Claude desktop Effort popover: capsule track, dots, sliding pill. */
+.cmm__stops {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cmm__stops-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+@property --cmm-stop-t {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 0;
+}
+
+.cmm__stops-rail {
+  --cmm-thumb: 28px;
+  position: relative;
+  height: 28px;
+  padding: 0 6px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+  cursor: pointer;
+  touch-action: none;
+  transition: --cmm-stop-t var(--motion-pane) var(--motion-pane-ease);
+}
+
+.cmm__stops-dots {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 100%;
+  padding: 0 8px;
+  pointer-events: none;
+}
+
+.cmm__stops-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--text-primary) 28%, transparent);
+}
+
+.cmm__stops-dot.is-active {
+  opacity: 0;
+}
+
+.cmm__stops-dot.is-ultra {
+  background: #c4a0ff;
+}
+
+.cmm__stops-thumb {
+  position: absolute;
+  z-index: 2;
+  top: 4px;
+  height: 20px;
+  width: var(--cmm-thumb);
+  border-radius: 12px;
+  background: var(--bg-elevated, #fff);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.16);
+  left: calc(
+    6px + (100% - 12px - var(--cmm-thumb)) * var(--cmm-stop-t, 0)
+  );
+  pointer-events: none;
+  transition: background var(--motion-fast) ease;
+}
+
+.cmm__stops-thumb.is-ultra {
+  background: #c4a0ff;
+}
+
+.cmm__stops-hit {
+  position: absolute;
+  z-index: 3;
+  top: 0;
+  bottom: 0;
+  width: 28px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  transform: translateX(-50%);
+  cursor: pointer;
+}
+
+[data-theme="light"] .cmm__stops-rail {
+  background: #e6e4df;
+}
+
+[data-theme="light"] .cmm__stops-thumb {
+  background: #fff;
+}
+
+[data-theme="light"] .cmm__stops-dot.is-ultra,
+[data-theme="light"] .cmm__stops-thumb.is-ultra {
+  background: #7c4dff;
+}
+
+/*
+ * Access menu (mode | permission) — compact dual-column dropdown.
  * Portaled panel class `.cmm__pop--access` (not trigger `.cmm--access`).
- * Double class beats `.cmm__pop { max-width: var(--menu-max-width) }`.
+ * Descriptions stay in the DOM for a11y; visually title-only.
  */
 .cmm__pop.cmm__pop--access {
-  width: min(560px, calc(100vw - 16px));
-  min-width: min(480px, calc(100vw - 16px));
-  max-width: min(600px, calc(100vw - 16px));
-  padding: 6px 8px 10px;
+  width: 300px;
+  min-width: 0;
+  max-width: min(300px, calc(100vw - 16px));
+  padding: 4px 6px 8px;
+  overflow-x: hidden;
 }
 
 .cmm__pop--access .cmm__header {
-  padding: 6px 10px 8px;
+  padding: 4px 8px 2px;
 }
 
 .cmm__pop--access .cmm__header-title {
-  font-size: 12px;
-  line-height: 1.35;
+  font-size: 11px;
+  line-height: 1.3;
 }
 
 .cmm__access-cols {
@@ -130,36 +492,48 @@
 
 /* Compact option rows for dual columns */
 .cmm__opt--access {
-  gap: 8px;
-  padding: 8px 8px;
-  border-radius: 10px;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 6px;
+  border-radius: 8px;
 }
 
 .cmm__opt--access .cmm__opt-icon {
-  margin-top: 2px;
+  margin-top: 0;
+}
+
+.cmm__opt--access .cmm__opt-icon svg {
+  width: 14px;
+  height: 14px;
 }
 
 .cmm__opt--access .cmm__opt-title {
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 550;
   line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .cmm__opt--access .cmm__opt-desc {
-  font-size: 11px;
-  line-height: 1.35;
-  color: var(--text-tertiary);
+  display: none;
 }
 
 .cmm__opt--access .cmm__opt-check {
-  margin-top: 2px;
+  margin-top: 0;
+}
+
+.cmm__opt--access .cmm__opt-check svg {
+  width: 14px;
+  height: 14px;
 }
 
 /* Narrow viewports: stack mode above permission */
 @media (max-width: 520px) {
   .cmm__pop.cmm__pop--access {
-    width: min(360px, calc(100vw - 16px));
-    min-width: min(280px, calc(100vw - 16px));
+    width: min(280px, calc(100vw - 16px));
+    min-width: 0;
   }
 
   .cmm__access-cols {
@@ -173,12 +547,6 @@
     padding-top: 6px;
     padding-left: 4px;
   }
-}
-
-.cmm__nested {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
 }
 
 .cmm__search {
@@ -247,18 +615,6 @@
   cursor: not-allowed;
 }
 
-.cmm__back {
-  padding: 8px 12px;
-  text-align: left;
-  font-size: 12px;
-  color: var(--text-tertiary);
-  border-radius: 8px;
-}
-
-.cmm__back:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
 
 .cmm__opt {
   display: flex;

--- a/src/styles/phone.part1.css
+++ b/src/styles/phone.part1.css
@@ -149,6 +149,7 @@
     align-items: center;
     background: transparent;
     gap: 0;
+    padding-top: 24px;
   }
 
   .app-shell--phone .composer-wrap--welcome .composer-welcome-mark {

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -111,6 +111,13 @@ button:disabled {
   box-sizing: border-box;
 }
 
+/* Hover label above a chip — no shadow, so it does not read as selected. */
+.ui-tip--flat {
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
 /* Settings help: longer descriptions wrap instead of ellipsizing */
 .ui-tip--wrap {
   white-space: normal;

--- a/src/styles/skins.css
+++ b/src/styles/skins.css
@@ -457,7 +457,7 @@ html[data-wallpaper="1"].platform-mac[data-theme="light"] .main {
 }
 
 /* Composer + workspace bar: independent slider, never merged with scrim. */
-html[data-wallpaper="1"] :is(.composer, .composer__context-bar) {
+html[data-wallpaper="1"] :is(.composer, .composer__chip-shell) {
   background: transparent;
   backdrop-filter: none;
   -webkit-backdrop-filter: none;


### PR DESCRIPTION
## 动机

桌面输入框把模型和推理拆成两颗芯片，高级是点进去再选。对照 Codex：一颗芯片、展开同宽菜单、高级行悬停侧出选项，空对话和进行中对话同一列宽。

## 改动

- 工作区芯片在左、模型+推理在右，打开时芯片向左拉到 280px，菜单从底边展开
- 简单层是 Faster↔Smarter 滑条；高级是 hub，悬停模型/推理/上下文在侧边选
- 侧栏对齐当前行；窗口窄时翻到另一侧或夹进视口，避免裁切
- 高级里换模型不关二级/三级层
- 空对话 SuperGrok 仍居中，输入框靠下，列宽跟 `--chat-width-max`

基于 `origin/main`（含 `WorkbenchComposerColumn` / `WorkbenchComposerShell` 拆分），保留本地这套模型按钮实现，未带入宠物等无关改动。

## 验证

- `pnpm exec vitest run`：ComposerPortalPop、composerColumn.guard、floatingMenu、grokCatalog、welcomeIntro、wallpaperThemeContrast、i18n（92 + 44 通过）
- 相关文件 `tsc` 无新增错误

本机 `pi` 不在 PATH，未能跑 AGENTS.md 要求的 pi 审核。