### PR TITLE
fix(chat): arm rebound intent when suppressing a pinned-bottom wheel

### DIFF
--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -423,6 +423,14 @@ export function useStickToBottom(
         })
       ) {
         e.preventDefault();
+        // The gesture is still suppressed, but WebView2 can overscroll
+        // elastically anyway and report the rebound as a decreasing
+        // `scrollTop`. Arm the intent now, otherwise that rebound has no
+        // recovery path and the tail settles above a bottom that grew during
+        // the elastic settle (composer / queue height). Arming alone never
+        // snaps — the settle only fires on a real upward scroll near bottom.
+        armBottomIntent();
+        userIntentDownRef.current = true;
         return;
       }
       // Small ticks at the locked bottom (trackpad / elastic) — stay pinned.


### PR DESCRIPTION
## What

Two lines. `handleWheel` now arms the bottom-rebound intent before it returns from the suppressed-pinned-wheel branch.

## The bug

`src/hooks/useStickToBottom.test.tsx` has been failing on `main` — `expected 600 to be 640`. It is not a bad test; it is a real gap in the shipped bottom-overscroll fix.

`handleWheel` suppresses a downward gesture at the locked bottom via `shouldPreventPinnedBottomWheel` and then **returns immediately** — before reaching `armBottomIntent()` further down:

```ts
if (shouldPreventPinnedBottomWheel({ ... })) {
  e.preventDefault();
  return;                       // ← intent never armed
}
...
if (e.deltaY >= STICK_ESCAPE_WHEEL_DELTA) {
  armBottomIntent();            // unreachable in this case
```

Suppressing the wheel is correct — it stops rubber-banding. But WebView2 overscrolls elastically regardless, and reports the rebound as a *decreasing* `scrollTop`. That is precisely the case `shouldSettleBottomRebound` was written to recover from, and the comment at `stickToBottom.ts:66` describes it. With no intent armed, `downIntentActive` is false, so the recovery never runs.

**User-visible effect:** overscroll at the bottom, then the composer or send queue grows during the elastic settle — the viewport settles ~40px above the new bottom and the last lines sit hidden under the composer. The Unreleased entry *"Bottom overscroll no longer rebounds above hidden chat content"* shipped the guard without its recovery half.

## The fix

```ts
if (shouldPreventPinnedBottomWheel({ ... })) {
  e.preventDefault();
  armBottomIntent();
  userIntentDownRef.current = true;
  return;
}
```

The wheel is still prevented, so nothing rubber-bands. Arming alone never snaps:

- `scheduleBottomReboundSettle` only fires from `handleScroll` when `shouldSettleBottomRebound` is true, which requires an actual upward scroll **and** being inside the near-bottom band (100px).
- A reverse wheel takes the `deltaY <= -STICK_ESCAPE_WHEEL_DELTA` branch, which calls `clearBottomRebound()` first.
- If the platform never overscrolls, the intent simply expires after `STICK_BOTTOM_REBOUND_INTENT_MS` (320ms).

`userIntentDownRef` is set to match the sibling `deltaY >= STICK_ESCAPE_WHEEL_DELTA` branch, so a suppressed down-wheel can't leave it stale-false while intent is armed.

## Verification

- `src/hooks/useStickToBottom.test.tsx` — **2/2 pass** (was 1 failed / 1 passed on `main`, `expected 600 to be 640`)
- `src/lib/stickToBottom.test.ts` — 80/80 pass (pure helpers untouched)
- `src/hooks/useChatMessageVirtualizer.test.tsx` — 6/6 pass (the hook's other consumer)
- `pnpm typecheck` and `pnpm lint` — clean

No new test: the existing failing test *is* the regression test for this behavior.

## Note

Two other tests fail on `main` and are unrelated to this change — `FilesWorkspace.test.tsx:200` and `settingsCatalog.test.ts:29` (the latter is the `globSync` scan over `src/`, sensitive to sandbox conditions). I left both alone.
