### PR TITLE
fix(settings): show CLI repair only when the binary is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Added
+- When the Grok Build CLI is missing, Runtime settings offers a one-click install.
+
+**中文 · 新增**
+- 找不到 Grok Build CLI 时，运行时设置里可以直接一键安装。
+
 ### Changed
 - Missing translations are filled in. SSH, IM security, permission rules, and Doctor checks follow the UI language.
 

--- a/src/components/CliRepairPanel.test.tsx
+++ b/src/components/CliRepairPanel.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Runtime → CLI repair CTA: only surfaces when the binary is missing, and a
+ * successful install re-probes the CLI so the parent card flips to found.
+ * Review notes on #954: account login rows must not appear here — the CLI
+ * card repairs the binary only.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as api from "@/lib/api";
+import { CliRepairPanel } from "./CliRepairPanel";
+import type { Vars } from "@/i18n";
+
+function t(k: string, vars?: Vars): string {
+  if (k === "settings.cliUpdateDone") return `done:${vars?.version ?? ""}`;
+  if (k === "settings.cliUpdateInstallFailed") {
+    return `failed:${vars?.error ?? ""}`;
+  }
+  return String(k);
+}
+
+const FOUND_CLI = {
+  found: true,
+  path: "/usr/local/bin/grok",
+  version: "1.0.8",
+  source: "PATH",
+  cliAuthPresent: true,
+};
+
+function renderPanel(
+  props: Partial<Parameters<typeof CliRepairPanel>[0]> = {},
+) {
+  const onCliInfoRefresh = vi.fn();
+  const showSettingsToast = vi.fn();
+  render(
+    <CliRepairPanel
+      onCliInfoRefresh={onCliInfoRefresh}
+      showSettingsToast={showSettingsToast}
+      t={t}
+      {...props}
+    />,
+  );
+  return { onCliInfoRefresh, showSettingsToast };
+}
+
+beforeEach(() => {
+  vi.spyOn(api, "isTauri").mockReturnValue(false);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("CliRepairPanel", () => {
+  it("renders the repair CTA with shared copy when the CLI is missing", () => {
+    renderPanel();
+    expect(screen.getByTestId("settings-cli-repair")).toBeInTheDocument();
+    expect(
+      screen.getByText("settings.cliVersion.missing"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("settings.cliUpdateNeedCli")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "setup.install" })).toBeEnabled();
+  });
+
+  it("calls cli_install_latest on click and re-probes so the parent card refreshes", async () => {
+    const installSpy = vi
+      .spyOn(api, "cliInstallLatest")
+      .mockResolvedValue({
+        ok: true,
+        path: "/usr/local/bin/grok",
+        version: "1.0.8",
+        mirrorUsed: null,
+        message: "",
+      });
+    vi.spyOn(api, "probeCli").mockResolvedValue(FOUND_CLI as api.CliProbeInfo);
+    const { onCliInfoRefresh, showSettingsToast } = renderPanel();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "setup.install" }),
+    );
+
+    expect(installSpy).toHaveBeenCalledWith(undefined);
+    await waitFor(() => {
+      expect(onCliInfoRefresh).toHaveBeenCalledWith(FOUND_CLI);
+    });
+    expect(showSettingsToast).toHaveBeenCalledWith("done:1.0.8", 3200);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("surfaces the failure message when the install command fails", async () => {
+    vi.spyOn(api, "cliInstallLatest").mockResolvedValue({
+      ok: false,
+      path: null,
+      version: null,
+      mirrorUsed: null,
+      message: "network down",
+    });
+    renderPanel();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "setup.install" }),
+    );
+
+    const warn = await screen.findByText("failed:network down");
+    expect(warn).toHaveClass("settings-row__hint--warn");
+  });
+
+  it("shows an in-flight progress line and disables the button while installing", async () => {
+    let resolveInstall: (v: api.CliInstallResult) => void = () => {};
+    vi.spyOn(api, "cliInstallLatest").mockReturnValue(
+      new Promise<api.CliInstallResult>((r) => {
+        resolveInstall = r;
+      }),
+    );
+    renderPanel();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "setup.install" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "setup.installing" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("setup.detecting");
+    resolveInstall({
+      ok: true,
+      path: "/usr/local/bin/grok",
+      version: "1.0.8",
+      mirrorUsed: null,
+      message: "",
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "setup.install" })).toBeEnabled();
+    });
+  });
+});

--- a/src/components/CliRepairPanel.tsx
+++ b/src/components/CliRepairPanel.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { CliInstallProgress, CliProbeInfo } from "@/lib/api";
+import * as api from "@/lib/api";
+import type { SettingsViewModel } from "@/components/settings/types";
+type Props = {
+  allowUnverifiedCliInstall?: boolean;
+  onCliInfoRefresh?: (cli: CliProbeInfo) => void;
+  showSettingsToast?: SettingsViewModel["showSettingsToast"];
+  t: SettingsViewModel["t"];
+};
+
+/** One-click reinstall shown in Runtime → CLI only when the binary is missing. */
+export function CliRepairPanel({
+  allowUnverifiedCliInstall,
+  onCliInfoRefresh,
+  showSettingsToast,
+  t,
+}: Props) {
+  const [installing, setInstalling] = useState(false);
+  const [progress, setProgress] = useState<CliInstallProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const alive = useRef(true);
+
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+
+  const refreshCli = useCallback(
+    async (path?: string | null) => {
+      try {
+        const next = await api.probeCli(path || undefined);
+        if (alive.current) onCliInfoRefresh?.(next);
+        return next;
+      } catch {
+        return null;
+      }
+    },
+    [onCliInfoRefresh],
+  );
+
+  // Live install progress from Host (same channel as SetupWizard).
+  useEffect(() => {
+    if (!api.isTauri()) return;
+    let unlisten: (() => void) | undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { listen } = await import("@tauri-apps/api/event");
+        unlisten = await listen<CliInstallProgress>(
+          "setup://cli-install-progress",
+          (event) => {
+            if (!cancelled) setProgress(event.payload);
+          },
+        );
+      } catch {
+        // Preview builds do not expose the Tauri event bus.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  const install = useCallback(async () => {
+    if (installing) return;
+    setInstalling(true);
+    setError(null);
+    setProgress({ phase: "resolving", message: t("setup.detecting"), percent: 0 });
+    try {
+      const result = await api.cliInstallLatest(
+        allowUnverifiedCliInstall ? { allowUnverified: true } : undefined,
+      );
+      if (!result.ok) {
+        const message = result.message || t("settings.cliUpdateNeedCli");
+        setError(t("settings.cliUpdateInstallFailed", { error: message }));
+        return;
+      }
+      const next = await refreshCli(result.path);
+      if (!next?.found) {
+        setError(t("settings.cliVersion.missing"));
+        return;
+      }
+      showSettingsToast?.(
+        t("settings.cliUpdateDone", {
+          version: next.version || result.version || "—",
+        }),
+        3200,
+      );
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(t("settings.cliUpdateInstallFailed", { error: message }));
+    } finally {
+      if (alive.current) setInstalling(false);
+    }
+  }, [allowUnverifiedCliInstall, installing, refreshCli, showSettingsToast, t]);
+
+  return (
+    <div
+      className="settings-row settings-row--stack settings-row--compact"
+      data-testid="settings-cli-repair"
+    >
+      <div className="settings-row__text">
+        <div className="settings-row__label">{t("settings.cliVersion.missing")}</div>
+        <div className="settings-row__desc">{t("settings.cliUpdateNeedCli")}</div>
+      </div>
+      <div className="settings-row__actions">
+        <button
+          type="button"
+          className="btn btn--solid btn--sm"
+          disabled={installing}
+          onClick={() => void install()}
+        >
+          {installing ? t("setup.installing") : t("setup.install")}
+        </button>
+      </div>
+      {installing && progress?.message ? (
+        <div className="settings-row__hint" role="status">
+          {progress.message}
+          {typeof progress.percent === "number"
+            ? ` · ${Math.round(progress.percent)}%`
+            : ""}
+        </div>
+      ) : null}
+      {error ? (
+        <div className="settings-row__hint settings-row__hint--warn">{error}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/settings/RuntimeSection.tsx
+++ b/src/components/settings/RuntimeSection.tsx
@@ -17,6 +17,7 @@ import { CliWorktreeDbPanel } from "@/components/CliWorktreeDbPanel";
 import { SdkConnectWizard } from "@/components/SdkConnectWizard";
 import { SessionApiPanel } from "@/components/SessionApiPanel";
 import { CliUpdateRow } from "@/components/CliUpdateRow";
+import { CliRepairPanel } from "@/components/CliRepairPanel";
 import { CostRollupPanel } from "@/components/CostRollupPanel";
 import { StreamingMessagesJsonPanel } from "@/components/StreamingMessagesJsonPanel";
 import { StreamingAcpNdjsonPanel } from "@/components/StreamingAcpNdjsonPanel";
@@ -234,6 +235,14 @@ export function RuntimeSection() {
                     </div>
                   ) : null}
                 </div>
+                {!cliInfo.found ? (
+                  <CliRepairPanel
+                    allowUnverifiedCliInstall={allowUnverifiedCliInstall}
+                    onCliInfoRefresh={onCliInfoRefresh}
+                    showSettingsToast={showSettingsToast}
+                    t={t}
+                  />
+                ) : null}
                 {detectAppPlatform() === "win" ? (
                   <div
                     className={


### PR DESCRIPTION
## Summary
Addresses the review notes on #954 (install-missing-CLI repair flow) so the good part — one-click reinstall from Runtime → CLI — can land:

- **Surface condition**: the repair row now appears **only when `!cliInfo.found`**. No `!cliAuthPresent` trigger — account is a soft gate, and OAuth / Device / `loginHint` / `accountBusy` are removed entirely. Login stays in Settings → Account; the CLI card repairs the binary only.
- **Copy reuse**: no new locale rows. Title `settings.cliVersion.missing`, desc `settings.cliUpdateNeedCli`, buttons `setup.install` / `setup.installing`, errors reuse `settings.cliUpdateInstallFailed` / success toasts `settings.cliUpdateDone`. Progress follows the same `setup://cli-install-progress` channel as the Setup wizard.
- **CHANGELOG**: one short sentence under `## [Unreleased]` → Added (en + 中文), within the 90-char popup guard (`whatsNew.test.ts`).
- **Tests** (`src/components/CliRepairPanel.test.tsx`, 4 cases): renders CTA with shared copy when missing; hidden-when-found is guaranteed by the `!cliInfo.found` gate in `RuntimeSection` (nothing else mounts the panel); install calls `cli_install_latest` (mocked `api`) then re-probes and calls `onCliInfoRefresh` + success toast; failure renders the warn hint; in-flight state disables the button and shows the progress line.

Placement is unchanged from #954: inside the `activeTab === "cli"` CLI card, right after the path/version rows — no `App.tsx` / `AppWorkbench.tsx` edits, no new settings-catalog entry.

## Type of change
- [x] Bug fix

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (6859 passed)
- [x] I ran `cargo check` in `src-tauri` (no Rust changes in this PR)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — reused existing keys only
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — no product-rule change
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

Refs #954