### PR TITLE
fix(rewind): bound agent RPCs and block rewind on background mid-turn chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ See `docs/llm-wiki/release.md`.
 - Chat no longer jumps while the agent is streaming. Switching away and back no longer lands in the middle.
 - Live thinking is not clipped in a 220px box. The transcript follows the stream.
 - Opening an SSH path chip no longer blanks the window. The files pane shows a loading state instead of an empty Suspense.
+- Rollback no longer spins for minutes when the agent is slow to answer. Forking a chat also stops holding up other chats' sends.
+- Rewind is refused while a chat you switched away from is still streaming. It used to cut that chat's history mid-turn.
 
 **中文 · 修复**
 - 壁纸上 CLI 更新条和「未打开标签」跟外观文字色。原先不在暴露层名单里，用了过淡的 tertiary。
@@ -40,6 +42,8 @@ See `docs/llm-wiki/release.md`.
 - 修复对话输出时屏幕往上跳、切出 App 再回来落到中间。正在看历史时不会被拽回底部。
 - 修复 Live Thinking 被 220px 小框截断。主对话跟着流式输出走。
 - 修复点 SSH 路径 chip 整窗变白。文件面板先显示加载，不再空白。
+- 修复回退在 agent 迟迟不应答时转好几分钟。分叉会话也不再占住别的会话的发送。
+- 修复切走的会话还在输出时仍允许回退。原先会截断那条会话的历史。
 
 ## [0.2.28] - 2026-08-29
 

--- a/src-tauri/src/session_manager/connect.rs
+++ b/src-tauri/src/session_manager/connect.rs
@@ -1261,9 +1261,16 @@ impl SessionManager {
 
                 match plan {
                     ChildTrimPlan::RewindChild { prompt_index } => {
-                        match client
-                            .rewind_execute_for(&agent_sid, prompt_index, false)
-                            .await
+                        // Post-open RPC, so it runs outside `with_handshake_budget`
+                        // while `connect_lock` is still held. Unbounded, it pinned
+                        // the lock for the handshake *plus* the rewind probe chain,
+                        // stalling every other chat's send/connect behind one fork.
+                        match Self::with_soft_rpc_budget(client.rewind_execute_for(
+                            &agent_sid,
+                            prompt_index,
+                            false,
+                        ))
+                        .await
                         {
                             Ok(_) => {
                                 rewind_ok = Some(true);

--- a/src-tauri/src/session_manager/journal.rs
+++ b/src-tauri/src/session_manager/journal.rs
@@ -11,7 +11,28 @@ use crate::store::{self};
 
 use super::*;
 
+/// Budget for a single agent rewind RPC. `AcpClient::request` already allows
+/// `HANDSHAKE_TIMEOUT_SECS` per method name and `rewind_execute_for` probes
+/// several names, so an unbounded await can park a rewind command for minutes
+/// with the rollback dialog spinning. The local journal is the UI source of
+/// truth, so exceeding the budget degrades to "agent rewind failed" instead.
+const REWIND_AGENT_RPC_BUDGET: std::time::Duration = std::time::Duration::from_secs(8);
+
 impl SessionManager {
+    /// True when a rewind must be refused because a turn is still running for
+    /// `app_sid` — whether that chat holds the live slot or was demoted to
+    /// background when the user switched away.
+    ///
+    /// Reading only `inner` reported idle for a demoted chat, so the journal was
+    /// truncated underneath a turn that was still streaming and the agent's
+    /// memory stopped matching the transcript. `live_session_is_busy` is also
+    /// authoritative where the FSM is not: it honours `prompt_in_flight` after
+    /// an early `prompt_complete`.
+    pub(super) fn rewind_blocked_by_running_turn(&self, app_sid: &str) -> bool {
+        self.with_session_mut(app_sid, |s| Self::live_session_is_busy(s))
+            .unwrap_or(false)
+    }
+
     pub async fn rewind_drop_last_user_turn(
         self: &Arc<Self>,
         app: AppHandle,
@@ -57,15 +78,29 @@ impl SessionManager {
                 let exec_index =
                     store::drop_last_user_prompt_exec_index(user_prompt_count).unwrap_or(0);
                 let sid = agent_sid.as_deref().ok_or("chat has no agent session id")?;
-                match client.rewind_execute_for(sid, exec_index, false).await {
-                    Ok(_) => {
+                let first = tokio::time::timeout(
+                    REWIND_AGENT_RPC_BUDGET,
+                    client.rewind_execute_for(sid, exec_index, false),
+                )
+                .await;
+                match first {
+                    Ok(Ok(_)) => {
                         agent_rewind_ok = Some(true);
                         tracing::info!(
                             target: "session",
                             "rewind_drop_last_user_turn: agent rewound target={exec_index} (user_turns={user_prompt_count})"
                         );
                     }
-                    Err(e) => {
+                    Err(_) => {
+                        // Timed out: spending a second budget on the fallback
+                        // index would double the stall the user already felt.
+                        agent_rewind_ok = Some(false);
+                        tracing::warn!(
+                            target: "session",
+                            "rewind_execute({exec_index}) timed out; leaving local journal intact"
+                        );
+                    }
+                    Ok(Err(e)) => {
                         agent_rewind_ok = Some(false);
                         if crate::acp_client::rpc_looks_like_method_not_found(&e) {
                             tracing::warn!(
@@ -80,15 +115,26 @@ impl SessionManager {
                                 error = %e,
                                 "rewind_execute({exec_index}) failed; trying last-turn index {target}"
                             );
-                            match client.rewind_execute_for(sid, target, false).await {
-                                Ok(_) => {
+                            match tokio::time::timeout(
+                                REWIND_AGENT_RPC_BUDGET,
+                                client.rewind_execute_for(sid, target, false),
+                            )
+                            .await
+                            {
+                                Ok(Ok(_)) => {
                                     agent_rewind_ok = Some(true);
                                 }
-                                Err(e2) => {
+                                Ok(Err(e2)) => {
                                     tracing::warn!(
                                         target: "session",
                                         error = %e2,
                                         "agent rewind failed; leaving local journal intact"
+                                    );
+                                }
+                                Err(_) => {
+                                    tracing::warn!(
+                                        target: "session",
+                                        "agent rewind timed out; leaving local journal intact"
                                     );
                                 }
                             }
@@ -188,27 +234,22 @@ impl SessionManager {
             }
         };
 
-        // Block if *this* session is mid-turn on the live host.
-        let (live_match, backend, acp, agent_sid, busy) = {
-            let guard = self.inner.lock();
-            match guard.as_ref() {
-                Some(s) if s.app_session_id == app_sid => {
-                    let busy = s.fsm.state() == SessionState::Streaming
-                        || s.fsm.state() == SessionState::AwaitingPermission;
-                    (
-                        true,
-                        s.backend.clone(),
-                        s.acp.clone(),
-                        s.meta.agent_session_id.clone(),
-                        busy,
-                    )
-                }
-                _ => (false, String::new(), None, None, false),
-            }
-        };
-        if busy {
+        if self.rewind_blocked_by_running_turn(&app_sid) {
             return Err("cannot rewind while a turn is running".into());
         }
+
+        let (live_match, backend, acp, agent_sid) = {
+            let guard = self.inner.lock();
+            match guard.as_ref() {
+                Some(s) if s.app_session_id == app_sid => (
+                    true,
+                    s.backend.clone(),
+                    s.acp.clone(),
+                    s.meta.agent_session_id.clone(),
+                ),
+                _ => (false, String::new(), None, None),
+            }
+        };
 
         let msgs = store::load_messages(&app_sid);
         let user_count = store::user_prompt_count(&msgs);
@@ -230,7 +271,7 @@ impl SessionManager {
         if live_match && backend != "mock_acp" && !AcpClient::use_mock() {
             if let (Some(client), Some(sid)) = (acp, agent_sid) {
                 match tokio::time::timeout(
-                    std::time::Duration::from_secs(8),
+                    REWIND_AGENT_RPC_BUDGET,
                     client.rewind_execute_for(&sid, target_prompt_index, restore_files),
                 )
                 .await

--- a/src-tauri/src/session_manager/routing_tests_p2.rs
+++ b/src-tauri/src/session_manager/routing_tests_p2.rs
@@ -513,3 +513,44 @@ fn stream_journal_prepare_snapshots_and_throttles_without_disk_io() {
     assert!(final_pending.message.created_at >= pending.message.created_at);
     assert!(final_pending.meta.updated_at >= pending.meta.updated_at);
 }
+
+/// Regression: `rewind_to_prompt_index` read busy state from the live slot
+/// only. A chat demoted to background mid-turn (the user switched away while
+/// it streamed) therefore reported idle, and the rewind truncated its journal
+/// underneath the running turn — the agent's memory no longer matched the
+/// transcript, so the next send hung or showed a phantom 「思考中」.
+#[test]
+fn rewind_busy_check_sees_background_mid_turn_session() {
+    let mgr = Arc::new(SessionManager::new());
+    let mut demoted = bare_live_session("bg-rewind", "p-1");
+    // Authoritative mid-turn marker: the prompt RPC has not resolved yet.
+    demoted.prompt_in_flight = true;
+    mgr.background.lock().insert("bg-rewind".into(), demoted);
+
+    // Precondition that made the old check wrong: nothing holds the live slot,
+    // so a live-slot-only read sees no session at all and answers "idle".
+    assert!(
+        mgr.inner.lock().is_none(),
+        "fixture must leave the live slot empty"
+    );
+
+    assert!(
+        mgr.rewind_blocked_by_running_turn("bg-rewind"),
+        "a background session mid-turn must still block rewind"
+    );
+}
+
+/// A demoted session that finished its turn must not keep rewind locked out.
+#[test]
+fn rewind_busy_check_allows_idle_background_session() {
+    let mgr = Arc::new(SessionManager::new());
+    mgr.background
+        .lock()
+        .insert("bg-idle".into(), bare_live_session("bg-idle", "p-1"));
+
+    assert!(!mgr.rewind_blocked_by_running_turn("bg-idle"));
+    assert!(
+        !mgr.rewind_blocked_by_running_turn("never-seen"),
+        "an unknown chat has no running turn to protect"
+    );
+}


### PR DESCRIPTION
Fixes #961

Three defects in the rewind path. Each already had a sibling in the same file doing the right thing, so every fix reuses the existing in-repo idiom rather than inventing a new one.

## 1. Unbounded agent rewind RPCs (`journal.rs`)

`rewind_drop_last_user_turn` awaited `rewind_execute_for` with no timeout, and awaited a **second** unbounded call on the fallback index. `AcpClient::request` allows 45s per method name and `rewind_execute_for` probes several, so the rollback dialog could spin for minutes.

Both calls now use the 8s budget that `rewind_to_prompt_index` already applied inline, hoisted to `REWIND_AGENT_RPC_BUDGET` so all three call sites in the file share one number. A timeout on the first attempt **skips** the fallback index — spending a second budget would double a stall the user already felt.

## 2. Fork child rewind pinned `connect_lock` (`connect.rs`)

`initialize_and_open_session` is wrapped in `with_handshake_budget`, but the post-open child rewind was not, and `connect_lock` is held for all of `connect_inner`. One fork-with-rewind could therefore pin the global lock for the handshake **plus** the rewind probe chain, stalling every other chat's send/connect.

Now wrapped in `with_soft_rpc_budget`, whose doc comment states its purpose exactly: *"Soft-fail RPCs (set_model / set_mode) must not pin `connect_lock`."* A timeout lands on the existing `Err` arm, so the established `rewind_ok = Some(false)` fail-safe path handles it unchanged.

## 3. Rewind ignored background mid-turn chats (`journal.rs`)

`rewind_to_prompt_index` computed `busy` only when `inner` held a matching session; every other case fell through to `false`. A chat demoted to `background` while streaming reported **idle**, and the local truncate ran anyway — the agent's memory stopped matching the transcript, so the next send hangs or shows a phantom 「思考中」.

Extracted `rewind_blocked_by_running_turn`, which routes through `with_session_mut` (live **and** background — its doc comment describes this very bug class) and uses `live_session_is_busy`, which is authoritative where the FSM is not: it honours `prompt_in_flight` after an early `prompt_complete`.

`live_match` semantics are unchanged, so the agent-rewind path and the meta touch still apply only to the focused live chat.

## Tests

Two regression tests in `routing_tests_p2.rs`, using the existing `bare_live_session` fixture:

- `rewind_busy_check_sees_background_mid_turn_session` — seeds a demoted session with `prompt_in_flight = true` and asserts rewind is blocked. **Verified to fail** when `rewind_blocked_by_running_turn` is reverted to the live-slot-only read, and pass with the fix.
- `rewind_busy_check_allows_idle_background_session` — an idle demoted chat, and an unknown chat id, must not be blocked.

## Local CI (all green on macOS arm64)

| Check | Result |
| --- | --- |
| `pnpm typecheck` | pass |
| `pnpm test` | 559 files, 6870 tests pass |
| `pnpm lint` | pass (`--max-warnings 0`) |
| `check-code-quality-gates.py --mode final` | PASS |
| `publish-website-downloads.py --self-test` | OK |
| `pnpm build:ui` | pass |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | 0 warnings |
| `cargo test` | 1582 pass, 0 fail (1580 before, +2 new) |

CHANGELOG updated under Unreleased → Fixed, en + zh, first sentences within the 90-character What's New limit (`whatsNew.test.ts` passes).

## Notes

- No behaviour change for the happy path: a responsive agent completes well inside 8s and takes the same branches as before.
- Only rewind paths are touched; no drive-by refactors.
- I did not change the 60s `with_soft_rpc_budget` value for the fork rewind — bounded by the existing idiom seemed better than introducing a new number. Happy to tighten it to a dedicated budget if you prefer.

Made with [Cursor](https://cursor.com)