### PR TITLE
perf(chat): memoize the full-journal scans in the transcript render body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ See `docs/llm-wiki/release.md`.
 
 ### Changed
 - Missing translations are filled in. SSH, IM security, permission rules, and Doctor checks follow the UI language.
+- Scrolling a long chat does less work per frame. Three full-journal scans no longer run on every render.
 
 **中文 · 变更**
 - 补上缺的翻译。SSH、IM 安全、权限规则和 Doctor 检查跟界面语言。
+- 长会话滚动每帧少做一些活。三处全量遍历不再每次渲染都跑。
 
 ### Fixed
 - CLI update banner and empty side-tab hint follow Appearance text color on wallpaper. They sat outside the old chrome list and used tertiary ink.

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -2603,9 +2603,33 @@ export function ConversationThread({
     return turnBusy ? lastAssistantId : null;
   }, [messages, turnBusy]);
 
-  const hasStreamingAssistant = messages.some(
-    (m) => m.role === "assistant" && m.streaming,
+  // Scanned the whole journal on every render. The virtualizer re-renders this
+  // thread on each window shift, so during a fling that was one O(n) pass per
+  // frame on top of the mount and measure work.
+  const hasStreamingAssistant = useMemo(
+    () => messages.some((m) => m.role === "assistant" && m.streaming),
+    [messages],
   );
+
+  /**
+   * True when the live tool already owns a row in the transcript, so the
+   * standalone `LiveToolText` must not double-render it.
+   *
+   * Two full-journal scans that used to sit in the JSX and therefore ran on
+   * every render, including every virtual window shift while scrolling.
+   */
+  const liveToolHasRow = useMemo(() => {
+    const toolCallId = liveTool?.toolCallId;
+    if (!liveTool) return false;
+    if (toolCallId && isToolInlinedInAssistants(messages, toolCallId)) {
+      return true;
+    }
+    return messages.some(
+      (x) =>
+        isToolStepMessage(x) &&
+        (x.toolCallId === toolCallId || x.id === `tool-${toolCallId}`),
+    );
+  }, [messages, liveTool]);
 
   /**
    * Map short path tokens → absolute using tool_step abs paths in this session.
@@ -3149,19 +3173,7 @@ export function ConversationThread({
             : null}
 
           {/* Tool before any assistant bubble — only if not already a message row. */}
-          {showToolChrome &&
-          liveTool &&
-          !activeAssistantId &&
-          !(
-            liveTool.toolCallId &&
-            isToolInlinedInAssistants(messages, liveTool.toolCallId)
-          ) &&
-          !messages.some(
-            (x) =>
-              isToolStepMessage(x) &&
-              (x.toolCallId === liveTool.toolCallId ||
-                x.id === `tool-${liveTool.toolCallId}`),
-          ) ? (
+          {showToolChrome && liveTool && !activeAssistantId && !liveToolHasRow ? (
             <LiveToolText message={liveTool} locale={locale} />
           ) : null}
 


### PR DESCRIPTION
Refs #853

Three full-journal scans sat in `ConversationThread`'s render body, so they ran on **every** render of the thread. The virtualizer re-renders the thread on each window shift, so a fling through a long chat paid all three O(n) passes per frame on top of the mount and measure work.

## Changes

- `hasStreamingAssistant` (`ConversationThread.tsx:2606`) moves into a `useMemo` on `[messages]`.
- The two scans inlined in the JSX at `:3159` — `isToolInlinedInAssistants(messages, …)` and a `messages.some(…)` looking for an existing tool row — collapse into one `liveToolHasRow` memo on `[messages, liveTool]`. `liveTool` is itself a `useMemo`, so its identity is stable while scrolling and the memo actually holds.

## Behaviour

Identical. The JSX predicate was `!(toolCallId && inlined) && !some(...)`, i.e. `!A && !B`; `liveToolHasRow` returns `A || B` and the JSX now reads `!liveToolHasRow`. The `toolCallId === undefined` case takes the same branches as before.

One small improvement falls out: the memo returns early when there is no live tool, so the scans are skipped entirely in the common case rather than running and finding nothing.

## Scope note

I looked at the `MessageNodeRail` scroll sync as well (`:157-170`) and deliberately left it alone. The `getBoundingClientRect()` calls there are consecutive reads with no interleaved writes, so they cost one layout flush per frame rather than one per row — much less than it first looks. Making it cheaper means either relying on `[data-message-id]` rows having monotonically increasing `top` in DOM order (which nested rows would break, and `pickActiveNodeIdFromRects` deliberately takes the *last* match), or plumbing the virtualizer's offset table into the rail. Both belong in their own change with a measurement to back them, not bundled here.

## Local CI (all green on macOS arm64)

| Check | Result |
| --- | --- |
| `pnpm typecheck` | pass |
| `pnpm test` | 559 files, 6870 tests pass |
| `pnpm lint` | pass (`--max-warnings 0`) |
| `check-code-quality-gates.py --mode final` | PASS |
| `pnpm build:ui` | pass |

CHANGELOG updated under Unreleased → Changed, en + zh, within the 90-character What's New limit.

Made with [Cursor](https://cursor.com)