### PR TITLE
fix(windows): prevent theme editor window deadlock

### DIFF
--- a/src-tauri/src/theme_editor_window.rs
+++ b/src-tauri/src/theme_editor_window.rs
@@ -70,7 +70,7 @@ fn place_over_main_right(app: &AppHandle, win: &WebviewWindow) {
 
 /// Open or focus the appearance editor as a real OS window.
 #[tauri::command]
-pub fn open_theme_editor_window(app: AppHandle) -> Result<(), String> {
+pub async fn open_theme_editor_window(app: AppHandle) -> Result<(), String> {
     if let Some(existing) = app.get_webview_window(THEME_EDITOR_WINDOW_LABEL) {
         let _ = existing.show();
         let _ = existing.unminimize();


### PR DESCRIPTION
## Summary
- Run `open_theme_editor_window` as an async Tauri command.
- Prevent Windows WebView2 creation from blocking the event loop it needs for initialization.
- Preserve the existing window reuse, focus, placement, and live theme synchronization behavior.

## Root cause
The synchronous command ran on Tauri's event-loop thread. `WebviewWindowBuilder::build()` then waited for that same loop while WebView2 initialized, leaving a native white window and freezing the main UI. Declaring the command async moves command execution out of that event-loop dispatch context without adding delays, platform-specific branches, or fallback behavior.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Verification
- [x] Windows manual test: cold open renders fully and the main window remains responsive
- [x] Close/reopen works; opening again focuses the existing editor instead of duplicating it
- [x] Theme changes synchronize with the main window
- [x] `pnpm typecheck`
- [x] `pnpm test` — 559 files, 6870 tests passed
- [x] `pnpm lint`
- [x] `py -3 scripts/check-code-quality-gates.py --mode final`
- [x] `py -3 scripts/publish-website-downloads.py --self-test`
- [x] `pnpm build:ui`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Windows Rust CI path — 1586 passed, 0 failed, 1 ignored after embedding `windows-test-manifest.xml`

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran the Windows Rust test path used by CI
- [x] No user-facing strings were added
- [x] No `window.confirm` / `prompt` / `alert` was added
- [x] No documentation update is required for this deadlock fix
- [x] No secrets (`secrets.json`, tokens, `auth.json`) are included