### PR TITLE
perf(chat): patch row offsets in place instead of rebuilding the prefix sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ See `docs/llm-wiki/release.md`.
 
 ### Changed
 - Missing translations are filled in. SSH, IM security, permission rules, and Doctor checks follow the UI language.
+- Long chats scroll more smoothly. Measuring one row no longer re-adds every row above it.
 
 **中文 · 变更**
 - 补上缺的翻译。SSH、IM 安全、权限规则和 Doctor 检查跟界面语言。
+- 长会话滚动更顺。测量一行不再把它上面所有行的高度重新加一遍。
 
 ### Fixed
 - CLI update banner and empty side-tab hint follow Appearance text color on wallpaper. They sat outside the old chrome list and used tertiary ink.

--- a/src/hooks/useChatMessageVirtualizer.ts
+++ b/src/hooks/useChatMessageVirtualizer.ts
@@ -40,6 +40,7 @@ import {
   chatOpenPinWindow,
   computeChatVirtualWindow,
   cumulativeOffsets,
+  shiftOffsetsAfter,
   resolveChatOverscanPx,
   shouldCommitRowHeight,
   shouldVirtualizeChat,
@@ -707,7 +708,27 @@ export function useChatMessageVirtualizer(
       const delta = nextH - prevH;
       heightsRef.current.set(key, nextH);
       heightsVersionRef.current += 1;
-      offsetsCacheRef.current = null;
+
+      // Only this row changed, so patch the suffix instead of paying a height
+      // lookup per row on the next read. The shift is derived from the height
+      // already inside `offsetsBefore` rather than from `delta`, because an
+      // unmeasured row contributes its *unrounded* estimate there while `prevH`
+      // is rounded — using `delta` would drift the suffix on every commit.
+      const nextOffsets =
+        index >= 0 && index + 1 < offsetsBefore.length
+          ? shiftOffsetsAfter(
+              offsetsBefore,
+              index,
+              nextH - ((offsetsBefore[index + 1] ?? 0) - rowOffset),
+            )
+          : null;
+      offsetsCacheRef.current = nextOffsets
+        ? {
+            version: heightsVersionRef.current,
+            count: itemCountRef.current,
+            offsets: nextOffsets,
+          }
+        : null;
 
       // Compensate height changes for rows above the viewport
       if (!isPinnedRef.current && isFullyAboveViewport && Math.abs(delta) > 0.5) {

--- a/src/lib/chatVirtualList.test.ts
+++ b/src/lib/chatVirtualList.test.ts
@@ -10,6 +10,7 @@ import {
   chatOpenPinWindow,
   computeChatVirtualWindow,
   cumulativeOffsets,
+  shiftOffsetsAfter,
   estimateChatRowHeight,
   findEndIndex,
   findStartIndex,
@@ -475,6 +476,45 @@ describe("scrollTopAfterHeightChange", () => {
 describe("cumulativeOffsets", () => {
   it("builds prefix sums", () => {
     expect(cumulativeOffsets(3, (i) => (i + 1) * 10)).toEqual([0, 10, 30, 60]);
+  });
+});
+
+describe("shiftOffsetsAfter", () => {
+  it("matches a full rebuild after a row grows", () => {
+    const heights = [40, 120, 80, 200, 60];
+    const before = cumulativeOffsets(heights.length, (i) => heights[i] ?? 0);
+
+    heights[2] = 300;
+    const patched = shiftOffsetsAfter(before, 2, 300 - 80);
+
+    expect(patched).toEqual(
+      cumulativeOffsets(heights.length, (i) => heights[i] ?? 0),
+    );
+  });
+
+  it("leaves the rows above the change untouched", () => {
+    const before = cumulativeOffsets(4, () => 100);
+    // A shrink must not move any offset at or below the edited row, otherwise
+    // the rows already on screen above it visibly jump.
+    expect(shiftOffsetsAfter(before, 2, -30)).toEqual([0, 100, 200, 270, 370]);
+  });
+
+  it("does not mutate the offsets handed to it", () => {
+    const before = cumulativeOffsets(3, () => 10);
+    shiftOffsetsAfter(before, 0, 999);
+    expect(before).toEqual([0, 10, 20, 30]);
+  });
+
+  it("stays exact across repeated fractional commits", () => {
+    // Unmeasured rows contribute an unrounded estimate, so a shift computed
+    // from a rounded row height would drift a fraction per commit and the
+    // error would accumulate down the suffix.
+    let offsets = cumulativeOffsets(4, () => 120.4);
+    for (let i = 0; i < 3; i++) {
+      const height = (offsets[i + 1] ?? 0) - (offsets[i] ?? 0);
+      offsets = shiftOffsetsAfter(offsets, i, 120 - height);
+    }
+    expect(offsets).toEqual([0, 120, 240, 360, 480.4]);
   });
 });
 

--- a/src/lib/chatVirtualList.ts
+++ b/src/lib/chatVirtualList.ts
@@ -223,6 +223,32 @@ export function cumulativeOffsets(
 }
 
 /**
+ * Apply a single row's height change to an existing offsets table.
+ *
+ * `offsets[i]` is the sum of the heights below `i`, so changing one row leaves
+ * every offset up to and including that row untouched and moves the whole
+ * suffix by the same amount. Rebuilding with {@link cumulativeOffsets} instead
+ * costs a height lookup per row, which is what made a mount storm re-derive the
+ * entire prefix sum on every ResizeObserver commit.
+ *
+ * `delta` must be measured against the height already recorded in `offsets`,
+ * not against a rounded row height — otherwise estimate rounding drifts the
+ * suffix a fraction of a pixel per commit and the drift accumulates.
+ */
+export function shiftOffsetsAfter(
+  offsets: readonly number[],
+  index: number,
+  delta: number,
+): number[] {
+  const next = offsets.slice();
+  if (delta === 0) return next;
+  for (let i = index + 1; i < next.length; i++) {
+    next[i] = (next[i] ?? 0) + delta;
+  }
+  return next;
+}
+
+/**
  * Adaptive overscan in px.
  * Scales with viewport so large monitors do not mount multi-screen markdown
  * windows, while short viewports still get enough runway for fling.


### PR DESCRIPTION
## Problem

`commitRowHeight` already knows which row changed and by how much, but it throws away the entire offsets cache:

```ts
heightsVersionRef.current += 1;
offsetsCacheRef.current = null;
```

The next `getOffsets()` therefore re-derives the whole table through `cumulativeOffsets(count, getHeight)`, and `getHeight` is not cheap per row — a `Map` lookup, then an `estimateRef` callback, then the fallback chain.

The commits that matter arrive in bursts: a `ResizeObserver` batch when a window of markdown rows mounts. Each commit in the burst triggers one full rebuild of a table whose length is the whole transcript.

## Fix

`offsets[i]` is the sum of the heights below `i`. Changing one row leaves every offset up to and including that row untouched and moves the whole suffix by the same amount, so the cache can be patched instead of rebuilt — no per-row height lookup, and only the rows after the edited one are touched. Commits near the end of a long thread (the common case while reading recent messages) touch almost nothing.

### The rounding trap

The shift is deliberately **not** `nextH - prevH`. `getHeight` returns the estimate *unrounded* for a row that has never been measured:

```ts
if (est != null && Number.isFinite(est) && est >= 0) return est;
```

while `commitRowHeight` rounds it into `prevH`. With a 120.4px estimate the naive delta is off by 0.4px, and since each patch feeds the next, the error accumulates down the suffix. The shift is instead derived from the height already recorded in the cached table, which is exact by construction regardless of rounding.

Falls back to the old invalidation when `index` is out of the cached table's range.

## Behavior

None intended. The patched table is value-identical to a rebuild; only the cost of producing it changes. `shiftOffsetsAfter` copies rather than mutating, so callers holding the previous array are unaffected.

## Tests

4 cases on `shiftOffsetsAfter` in `src/lib/chatVirtualList.test.ts`, including equivalence with a full `cumulativeOffsets` rebuild and the accumulating-drift case that pins the derivation above.

## Local CI

- `pnpm typecheck` clean
- `pnpm test` — 6874 passed / 559 files
- `pnpm lint` clean (`--max-warnings 0`)
- `whatsNew` CHANGELOG gate green

No Rust files touched.

Made with [Cursor](https://cursor.com)