### PR TITLE
fix(session): paint the answer instead of leftover thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ See `docs/llm-wiki/release.md`.
 
 **What's New popup:** each bullet's **first sentence** is what users see. Keep that sentence to one short line (added / fixed / improved — no paths, no implementation, no issue piles). A second short sentence is allowed for GitHub / this file only. Do **not** rewrite already-shipped `## [X.Y.Z]` sections.
 
+## [Unreleased]
+
+### Fixed
+- Thinking no longer stays on screen as the final reply. The real answer paints in place; switching chats is not required (#968).
+
+**中文 · 修复**
+- 思考结束后不再把思考过程当成最终回复。正文会直接画出来，不用切走再切回来（#968）。
+
 ## [0.2.29] - 2026-08-31
 
 > **Highlight:** One-click CLI install, complete translations, and smoother long chats.

--- a/docs/qa/issue-thinking-as-final-reply.md
+++ b/docs/qa/issue-thinking-as-final-reply.md
@@ -1,0 +1,36 @@
+Suggested labels: `bug` / `priority:p1` / `area:session`
+
+### Describe the bug
+
+Sometimes when a turn finishes thinking, the real answer is already in the session, but the chat still shows the thinking text as the final reply. Leave the session and open it again and the answer is there, folded correctly.
+
+This is the same family as #697 (late body missing until remount). That fix covered empty thinking-only / tool-only bubbles. This path is different: live `segments` stay thought-only (or thought leaked into `content`) while the answer already sits on the message field / journal. Paint uses segments, so CoT looks like the reply until remount rebuilds from disk.
+
+**中文：** 思考结束了，最终回复其实已经有了，界面却把刚才的思考过程当成最终回复。退出会话再点进来就正常。#697 修过「空泡不画正文」，这条是直播时间线还停在思考上。
+
+### Steps to reproduce
+
+1. Open Grok App 0.2.29 (or current `main`).
+2. Send a prompt that thinks for a while, then writes a real answer (high reasoning, optional tools).
+3. Wait until thinking ends. Do not switch sessions.
+4. If the bubble still shows the reasoning as the reply, switch to another session and back.
+
+Intermittent. Easier on long thinking turns where the body lands around the same time Host goes `ready`.
+
+### Expected behavior
+
+When thinking ends, the answer should paint in that bubble. Thinking collapses to “Thought for Ns”. Switching sessions should not be required.
+
+**中文：** 思考一结束，正文应出现在同一条气泡里。思考折成「思考了 Ns」。不用切走再切回来。
+
+### App version
+
+0.2.29 (also current `main`)
+
+### Grok Build CLI version (if known)
+
+n/a (UI projection)
+
+### OS
+
+Windows / macOS / Linux (not OS-specific)

--- a/docs/qa/pr-thinking-as-final-reply.md
+++ b/docs/qa/pr-thinking-as-final-reply.md
@@ -1,0 +1,26 @@
+## Summary
+
+Fixes #968. After thinking ends, the real answer can already be on the message / journal while the live timeline still paints CoT as the reply. Switching sessions remounts from disk and looks right. Same family as #697; this path is thought-only live `segments` (or thought leaked into `content`) winning over the body field.
+
+Paint uses `messageSegments`. If `segments` is thought-only, the content field is ignored. Weave can also derive-wipe the body. Late assistant tokens after settle used to mint a second bubble or get dropped. Stream `done` could flush before pending thought.
+
+## Type of change
+- [x] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / chore
+
+## What changed
+
+- `messageSegments` / `ensureSegments` append a content segment when the field has a real answer and live segs do not.
+- Late body tokens bind to the settled current-turn assistant. Late thought does not re-open 思考中.
+- Journal heal still lifts when live content *is* the thought, even if it is longer than the journal answer. Heal window covers Host post-turn reconcile.
+- Stream coalescer drains the other kind (thought vs assistant) before a `done` tick.
+
+## Checklist
+- [x] I ran `pnpm typecheck` and `pnpm test` (targeted session/stream tests; 133 passed)
+- [ ] I ran `cargo test` in `src-tauri` (no Host change)
+- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
+- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
+- [x] Docs / `docs/llm-wiki` updated if behavior changed
+- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

--- a/src/hooks/useSessionHostEvents.ts
+++ b/src/hooks/useSessionHostEvents.ts
@@ -1017,8 +1017,13 @@ export function useSessionHostEvents(ctx: SessionHostEventsCtx) {
        track(
           listenWithRetry<StreamPayload>("session://stream", (chunk) => {
             if (cancelled) return;
-            // Turn-end honesty: drain pending tool progress before applying done.
-            if (chunk.done) toolEventCoalescer?.flushAll();
+            // Turn-end honesty: drain pending tool + thought/body before done
+            // settles the bubble. Leaving thought in the coalesce buffer made
+            // CoT paint as the final reply until remount.
+            if (chunk.done) {
+              toolEventCoalescer?.flushAll();
+              streamCoalescer?.flushAll();
+            }
             streamCoalescer?.push(chunk);
           }),
         );

--- a/src/lib/session.thinkingAsReply.test.ts
+++ b/src/lib/session.thinkingAsReply.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyStreamChunk,
+  contentLooksLikeThought,
+  messageSegments,
+  toolSegmentFromFields,
+  upgradeMessagesFromJournal,
+  weaveToolsIntoAssistantSegments,
+  type ChatMessage,
+} from "./session";
+import { StreamCoalescer } from "./streamCoalesce";
+import { buildAssistantTimeline } from "./timelinePhases";
+
+describe("thinking painted as the final reply until remount", () => {
+  it("contentLooksLikeThought catches leaked CoT in the body field", () => {
+    expect(contentLooksLikeThought("plan the pdf", "plan the pdf")).toBe(true);
+    expect(contentLooksLikeThought("FINAL", "plan")).toBe(false);
+    expect(contentLooksLikeThought("", "plan")).toBe(false);
+    // A short real reply that happens to prefix CoT is still an answer.
+    expect(contentLooksLikeThought("Yes", "Yes, and then the rest of the plan")).toBe(
+      false,
+    );
+  });
+
+  it("messageSegments lifts a real answer that only lives on the content field", () => {
+    // Live thought-only segs + content field already filled (heal / late
+    // journal). Paint used segs, so CoT looked like the reply until remount
+    // rebuilt from fields.
+    const segs = messageSegments({
+      id: "a1",
+      role: "assistant",
+      content: "FINAL ANSWER",
+      thought: "plan the layout",
+      streaming: false,
+      segments: [{ kind: "thought", text: "plan the layout" }],
+    });
+    expect(segs.some((s) => s.kind === "content" && s.text.includes("FINAL"))).toBe(
+      true,
+    );
+    expect(segs.some((s) => s.kind === "thought" && s.text.includes("plan"))).toBe(
+      true,
+    );
+  });
+
+  it("does not promote leaked thought text into a content segment", () => {
+    const thought = "plan the layout";
+    const segs = messageSegments({
+      id: "a1",
+      role: "assistant",
+      content: thought,
+      thought,
+      streaming: false,
+      segments: [{ kind: "thought", text: thought }],
+    });
+    expect(segs.filter((s) => s.kind === "content")).toEqual([]);
+    expect(segs).toEqual([{ kind: "thought", text: thought }]);
+  });
+
+  it("weave keeps the answer when live segs are still thought-only", () => {
+    const woven = weaveToolsIntoAssistantSegments([
+      { id: "u1", role: "user", content: "write pdf" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Here is the PDF.",
+        thought: "plan the layout",
+        streaming: false,
+        segments: [{ kind: "thought", text: "plan the layout" }],
+      },
+      {
+        id: "tool-t1",
+        role: "tool",
+        content: "tool_step|completed|write|pdf",
+        marker: "tool_step",
+        toolCallId: "t1",
+        toolKind: "write",
+        toolStatus: "completed",
+      },
+    ]);
+    const asst = woven.find((m) => m.id === "a1")!;
+    expect(asst.content).toContain("PDF");
+    const segs = messageSegments(asst);
+    expect(segs.some((s) => s.kind === "content" && s.text.includes("PDF"))).toBe(
+      true,
+    );
+    const units = buildAssistantTimeline(segs, { streaming: false });
+    expect(units.some((u) => u.kind === "content")).toBe(true);
+  });
+
+  it("applyStreamChunk fills a settled thought-only bubble without remount", () => {
+    const msgs: ChatMessage[] = [
+      { id: "u1", role: "user", content: "write pdf" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "",
+        thought: "plan the layout",
+        streaming: false,
+        segments: [{ kind: "thought", text: "plan the layout" }],
+      },
+    ];
+    const out = applyStreamChunk(msgs, {
+      sessionId: "s1",
+      messageId: "a-new",
+      text: "Here is the PDF.",
+      done: true,
+      kind: "assistant",
+    });
+    const asst = out.find((m) => m.role === "assistant")!;
+    expect(out.filter((m) => m.role === "assistant")).toHaveLength(1);
+    expect(asst.content).toContain("PDF");
+    expect(asst.streaming).toBe(false);
+    expect(
+      messageSegments(asst).some(
+        (s) => s.kind === "content" && s.text.includes("PDF"),
+      ),
+    ).toBe(true);
+  });
+
+  it("late thought after settle does not re-open 思考中", () => {
+    const msgs: ChatMessage[] = [
+      { id: "u1", role: "user", content: "q" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "done",
+        thought: "plan",
+        streaming: false,
+        segments: [
+          { kind: "thought", text: "plan" },
+          { kind: "content", text: "done" },
+        ],
+      },
+    ];
+    const out = applyStreamChunk(msgs, {
+      sessionId: "s1",
+      messageId: "a1",
+      text: " leftover",
+      done: false,
+      kind: "thought",
+    });
+    expect(out.find((m) => m.id === "a1")?.streaming).toBe(false);
+    expect(out.find((m) => m.id === "a1")?.content).toBe("done");
+  });
+
+  it("upgradeMessagesFromJournal adds a content segment when the field is already filled", () => {
+    const ui: ChatMessage[] = [
+      { id: "u1", role: "user", content: "write pdf" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Here is the PDF.",
+        thought: "plan the layout",
+        streaming: false,
+        segments: [
+          { kind: "thought", text: "plan the layout" },
+          toolSegmentFromFields({
+            toolCallId: "t1",
+            title: "write",
+            status: "completed",
+          }),
+        ],
+      },
+    ];
+    const journal: ChatMessage[] = [
+      { id: "u1", role: "user", content: "write pdf" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Here is the PDF.",
+        thought: "plan the layout",
+      },
+    ];
+    const out = upgradeMessagesFromJournal(ui, journal);
+    const asst = out.find((m) => m.id === "a1")!;
+    expect(
+      messageSegments(asst).some(
+        (s) => s.kind === "content" && s.text.includes("PDF"),
+      ),
+    ).toBe(true);
+  });
+
+  it("upgradeMessagesFromJournal replaces thought-as-body with the journal answer", () => {
+    const thought = "planning fonts and margins for a long time…";
+    const ui: ChatMessage[] = [
+      { id: "u1", role: "user", content: "write pdf" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: thought,
+        thought,
+        streaming: false,
+        segments: [{ kind: "thought", text: thought }],
+      },
+    ];
+    const journal: ChatMessage[] = [
+      { id: "u1", role: "user", content: "write pdf" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Here is the PDF.",
+        thought,
+      },
+    ];
+    const out = upgradeMessagesFromJournal(ui, journal);
+    const asst = out.find((m) => m.id === "a1")!;
+    expect(asst.content).toBe("Here is the PDF.");
+    expect(
+      messageSegments(asst).some(
+        (s) => s.kind === "content" && s.text.includes("PDF"),
+      ),
+    ).toBe(true);
+  });
+
+  it("stream coalescer flushes pending thought before a done assistant tick", () => {
+    const out: Array<{ kind?: string | null; text?: string | null; done?: boolean | null }> =
+      [];
+    const c = new StreamCoalescer({
+      flushMs: 1000,
+      onFlush: (ch) => out.push({ kind: ch.kind, text: ch.text, done: ch.done }),
+    });
+    c.push({
+      sessionId: "s",
+      messageId: "m",
+      kind: "thought",
+      text: "plan",
+    });
+    c.push({
+      sessionId: "s",
+      messageId: "m",
+      kind: "assistant",
+      text: "answer",
+      done: true,
+    });
+    expect(out.map((x) => x.kind)).toEqual(["thought", "assistant"]);
+    expect(out[0]!.text).toBe("plan");
+    expect(out[1]!.text).toBe("answer");
+    expect(out[1]!.done).toBe(true);
+    c.dispose();
+  });
+});

--- a/src/lib/session/rewind.ts
+++ b/src/lib/session/rewind.ts
@@ -1,6 +1,10 @@
 import type { ChatMessage, MessageSegment, SessionState } from "./types";
 import { isTurnPromptMessage } from "./types";
-import { buildSegmentsFromLegacy } from "./segments";
+import {
+  buildSegmentsFromLegacy,
+  contentLooksLikeThought,
+  syncContentIntoSegments,
+} from "./segments";
 
 export function truncateBeforeLastUser(messages: ChatMessage[]): ChatMessage[] {
   let cut = messages.length;
@@ -484,11 +488,26 @@ export function upgradeMessagesFromJournal(
     const jContent = j.content ?? "";
     const uiThought = m.thought ?? "";
     const jThought = j.thought ?? "";
-    const richerContent = jContent.length > uiContent.length;
+    const liveThoughtAsBody = contentLooksLikeThought(uiContent, uiThought);
+    const journalHasRealBody =
+      !!jContent.trim() && !contentLooksLikeThought(jContent, jThought);
+    const richerContent =
+      jContent.length > uiContent.length ||
+      (liveThoughtAsBody && journalHasRealBody && jContent !== uiContent);
     const richerThought = jThought.length > uiThought.length;
     const richerAtts =
       (j.attachments?.length ?? 0) > (m.attachments?.length ?? 0);
-    if (!richerContent && !richerThought && !richerAtts) return m;
+    const segsMissingBody =
+      !!jContent.trim() &&
+      !!m.segments?.length &&
+      !m.segments.some(
+        (s) =>
+          s.kind === "content" &&
+          (s.text.includes(jContent) || jContent.includes(s.text.trim())),
+      );
+    if (!richerContent && !richerThought && !richerAtts && !segsMissingBody) {
+      return m;
+    }
 
     changed = true;
     let out: ChatMessage = {
@@ -515,24 +534,31 @@ export function upgradeMessagesFromJournal(
           out.thoughtPhases,
         ),
       };
-    } else if (richerContent) {
+    } else {
       const segs = (out.segments ?? []).map((s) =>
         s.kind === "content" || s.kind === "thought" || s.kind === "tool"
           ? { ...s }
           : s,
       ) as MessageSegment[];
-      let found = false;
-      for (let i = segs.length - 1; i >= 0; i--) {
-        if (segs[i]!.kind === "content") {
-          segs[i] = { kind: "content", text: jContent };
-          found = true;
-          break;
+      if (richerContent) {
+        let found = false;
+        for (let i = segs.length - 1; i >= 0; i--) {
+          if (segs[i]!.kind === "content") {
+            segs[i] = { kind: "content", text: out.content };
+            found = true;
+            break;
+          }
         }
+        if (!found && out.content) {
+          segs.push({ kind: "content", text: out.content });
+        }
+        out = { ...out, segments: segs };
+      } else {
+        out = {
+          ...out,
+          segments: syncContentIntoSegments(segs, out.content, out.thought),
+        };
       }
-      if (!found && jContent) {
-        segs.push({ kind: "content", text: jContent });
-      }
-      out = { ...out, segments: segs };
     }
     return out;
   });
@@ -571,7 +597,17 @@ export function upgradeMessagesFromJournal(
     }
     const uiContent = uiAsst.content ?? "";
     const jContent = bestJ.content ?? "";
-    if (jContent.length > uiContent.length) {
+    const liveThoughtAsBody = contentLooksLikeThought(
+      uiContent,
+      uiAsst.thought,
+    );
+    const journalHasRealBody =
+      !!jContent.trim() &&
+      !contentLooksLikeThought(jContent, bestJ.thought);
+    const shouldLift =
+      jContent.length > uiContent.length ||
+      (liveThoughtAsBody && journalHasRealBody && jContent !== uiContent);
+    if (shouldLift) {
       changed = true;
       let out: ChatMessage = {
         ...uiAsst,

--- a/src/lib/session/segments.ts
+++ b/src/lib/session/segments.ts
@@ -208,14 +208,61 @@ export function buildSegmentsFromLegacy(
   return segs;
 }
 
+/**
+ * True when the `content` field is just leaked CoT — the real answer is
+ * still missing. Used so we do not paint thought text as the body, and so
+ * late answer tokens are not treated as post-turn replay.
+ */
+export function contentLooksLikeThought(
+  content: string | null | undefined,
+  thought: string | null | undefined,
+): boolean {
+  const c = (content ?? "").trim();
+  const t = (thought ?? "").trim();
+  if (!c || !t) return false;
+  return c === t;
+}
+
+/**
+ * Live rows can hold the final answer on `content` while `segments` still
+ * only has thought (heal copied the field; stream never opened a content
+ * segment). Paint uses segments, so the thought looks like the reply until
+ * remount rebuilds from fields.
+ */
+export function syncContentIntoSegments(
+  segs: MessageSegment[],
+  content: string | null | undefined,
+  thought?: string | null,
+): MessageSegment[] {
+  const body = content ?? "";
+  if (!body.trim()) return segs;
+  if (contentLooksLikeThought(body, thought)) return segs;
+  // Live interleave can have several content pieces. Never fold the joined
+  // `content` field over them (that mashed "hello " + "world" into one).
+  if (segs.some((s) => s.kind === "content" && s.text.trim())) return segs;
+  return compactMessageSegments([...segs, { kind: "content", text: body }]);
+}
+
 /** Prefer live segments; otherwise reconstruct from legacy fields. */
 export function messageSegments(m: ChatMessage): MessageSegment[] {
-  if (m.segments?.length) return compactMessageSegments(m.segments);
+  if (m.segments?.length) {
+    return syncContentIntoSegments(
+      compactMessageSegments(m.segments),
+      m.content,
+      m.thought,
+    );
+  }
   return buildSegmentsFromLegacy(m.content, m.thought, m.thoughtPhases);
 }
 
 export function ensureSegments(prev: ChatMessage): MessageSegment[] {
-  if (prev.segments?.length) return prev.segments.map((s) => ({ ...s }));
+  if (prev.segments?.length) {
+    return syncContentIntoSegments(
+      prev.segments.map((s) => ({ ...s })),
+      prev.content,
+      prev.thought,
+    );
+  }
   return buildSegmentsFromLegacy(prev.content, prev.thought, prev.thoughtPhases);
 }
 

--- a/src/lib/session/stream.ts
+++ b/src/lib/session/stream.ts
@@ -308,7 +308,7 @@ export function applyStreamChunk(
 
   if (chunk.kind === "thought") {
     if (!chunk.text) return messages;
-    const idx = findCurrentTurnStreamingAssistant(messages, chunk.messageId);
+    const idx = findCurrentTurnAssistantForStream(messages, chunk.messageId);
     const phaseHint = chunk.thoughtPhase || "open";
     const appendThought = (prev: ChatMessage): ChatMessage => {
       const segs = compactMessageSegments(
@@ -324,7 +324,9 @@ export function applyStreamChunk(
         id: adoptHostStreamMessageId(messages, prev, chunk.messageId),
         ...derived,
         segments: segs,
-        streaming: true,
+        // Late coalesced thought after Host settled must not re-open 思考中
+        // over an answer that is already on the row.
+        streaming: keepThoughtStreaming(prev),
       };
     };
     if (idx != null) {
@@ -356,14 +358,14 @@ export function applyStreamChunk(
     : -1;
   // Host id may not match optimistic pending — bind only within current turn.
   if (idx < 0) {
-    const fallback = findCurrentTurnStreamingAssistant(messages, undefined);
+    const fallback = findCurrentTurnAssistantForStream(messages, undefined);
     idx = fallback ?? -1;
   } else {
     // Refuse to append onto an assistant from a previous turn (stale id reuse)
     // or a frozen pre-steer bubble (interjection sits after it).
     const bindFloor = lastUserRowIndex(messages);
     if (idx <= bindFloor) {
-      const fallback = findCurrentTurnStreamingAssistant(messages, undefined);
+      const fallback = findCurrentTurnAssistantForStream(messages, undefined);
       idx = fallback ?? -1;
     }
   }
@@ -445,4 +447,28 @@ function findCurrentTurnStreamingAssistant(
   }
   // No current-segment streaming bubble — do NOT fall back to older turns.
   return undefined;
+}
+
+/**
+ * Bind late thought/body tokens to this turn's assistant even after Host
+ * settled the row (streaming=false). Creating a second bubble left the
+ * thought-only row on screen until remount.
+ */
+function findCurrentTurnAssistantForStream(
+  messages: ChatMessage[],
+  messageId: string | undefined,
+): number | undefined {
+  const live = findCurrentTurnStreamingAssistant(messages, messageId);
+  if (live != null) return live;
+  const bindFloor = lastUserRowIndex(messages);
+  for (let i = messages.length - 1; i > bindFloor; i--) {
+    const m = messages[i]!;
+    if (m.role === "assistant" && !m.isError) return i;
+  }
+  return undefined;
+}
+
+/** Late thought after settle must not flip a finished answer back to 思考中. */
+function keepThoughtStreaming(prev: ChatMessage): boolean {
+  return !!prev.streaming;
 }

--- a/src/lib/streamCoalesce.ts
+++ b/src/lib/streamCoalesce.ts
@@ -110,6 +110,22 @@ export class StreamCoalescer {
 
   push(chunk: CoalesceStreamChunk): void {
     if (this.disposed) return;
+    // Thought and assistant use different keys. A done tick must not settle
+    // the bubble while the other kind is still buffered — that left CoT on
+    // screen as the "final" reply until remount.
+    if (chunk.done) {
+      const sid = chunk.sessionId ?? "";
+      const selfKey = streamCoalesceKey(chunk);
+      const others: CoalesceStreamChunk[] = [];
+      for (const [k, v] of this.pending) {
+        if (k === selfKey) continue;
+        if ((v.sessionId ?? "") === sid) {
+          others.push(v);
+          this.pending.delete(k);
+        }
+      }
+      for (const v of others) this.onFlush(v);
+    }
     const key = streamCoalesceKey(chunk);
     const existing = this.pending.get(key);
     if (existing) {

--- a/src/lib/streamLateToken.test.ts
+++ b/src/lib/streamLateToken.test.ts
@@ -80,6 +80,25 @@ describe("shouldApplyLateStreamText", () => {
     ).toBe(false);
   });
 
+  it("applies late answer when content is just the leaked thought", () => {
+    const thought = "planning the pdf layout and fonts…";
+    expect(
+      shouldApplyLateStreamText({
+        hostLiveStreaming: false,
+        chunkIsForFocusedHost: true,
+        messages: [
+          { role: "user", content: "write pdf" },
+          {
+            role: "assistant",
+            streaming: false,
+            content: thought,
+            thought,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
   it("applies late answer after a tool-only bubble was settled by early ready", () => {
     // Repro: long tool turn → stream done / host ready first → real answer
     // tokens. Old code treated empty+no-thought as "settled final" and
@@ -197,8 +216,9 @@ describe("shouldHealJournalOnStreamDone", () => {
 
   it("retries long enough to cover Host post-turn journal flush", () => {
     const total = JOURNAL_REHYDRATE_RETRY_GAPS_MS.reduce((a, b) => a + b, 0);
-    expect(JOURNAL_REHYDRATE_RETRY_GAPS_MS).toEqual([400, 500]);
-    expect(total).toBeGreaterThanOrEqual(750);
+    expect(JOURNAL_REHYDRATE_RETRY_GAPS_MS).toEqual([400, 500, 800]);
+    // Host POST_TURN_RECONCILE last delay is 750ms; disk write can trail it.
+    expect(total).toBeGreaterThanOrEqual(1250);
   });
 
   it("does not re-parse agent jsonl on end-of-turn rehydrate (#754)", () => {

--- a/src/lib/streamLateToken.ts
+++ b/src/lib/streamLateToken.ts
@@ -1,3 +1,5 @@
+import { contentLooksLikeThought } from "./session/segments";
+
 /**
  * Decide whether a stream text chunk may still be applied when the focused
  * Host session is no longer "live streaming" (ready/idle after early
@@ -54,10 +56,13 @@ export function shouldApplyLateStreamText(opts: {
 
   if (turnAsst.streaming) return true;
 
-  const bodyEmpty = !((turnAsst.content ?? "").trim());
+  const content = (turnAsst.content ?? "").trim();
+  const thought = (turnAsst.thought ?? "").trim();
+  const bodyEmpty = !content || contentLooksLikeThought(content, thought);
   // Empty body after early ready: thinking-only *or* tool-only. A long tool
   // turn settles the bubble (streaming=false, no thought) before the real
-  // answer tokens arrive. Dropping those tokens left the viewed chat blank
+  // answer tokens arrive. Thought leaked into `content` is not a settled
+  // answer either — dropping the real tail left CoT painted as the reply
   // until the user switched sessions and remounted from disk.
   if (bodyEmpty) return true;
 
@@ -79,8 +84,9 @@ export function shouldHealJournalOnStreamDone(opts: {
   return opts.streamDone && opts.isViewingSession;
 }
 
-/** Gaps after attempt 0: 400ms then +500ms (900ms), covering Host's 750ms flush. */
-export const JOURNAL_REHYDRATE_RETRY_GAPS_MS = [400, 500] as const;
+/** Gaps after attempt 0: 400 + 500 + 800ms (1700ms). Host post-turn reconcile
+ *  last delay is 750ms and the disk write can still be in flight after that. */
+export const JOURNAL_REHYDRATE_RETRY_GAPS_MS = [400, 500, 800] as const;
 
 /**
  * End-of-turn UI rehydrate must not re-parse agent `chat_history` / `updates`.


### PR DESCRIPTION
## Summary

Fixes #968. After thinking ends, the real answer can already be on the message / journal while the live timeline still paints CoT as the reply. Switching sessions remounts from disk and looks right. Same family as #697; this path is thought-only live `segments` (or thought leaked into `content`) winning over the body field.

Paint uses `messageSegments`. If `segments` is thought-only, the content field is ignored. Weave can also derive-wipe the body. Late assistant tokens after settle used to mint a second bubble or get dropped. Stream `done` could flush before pending thought.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## What changed

- `messageSegments` / `ensureSegments` append a content segment when the field has a real answer and live segs do not.
- Late body tokens bind to the settled current-turn assistant. Late thought does not re-open 思考中.
- Journal heal still lifts when live content *is* the thought, even if it is longer than the journal answer. Heal window covers Host post-turn reconcile.
- Stream coalescer drains the other kind (thought vs assistant) before a `done` tick.

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (targeted session/stream tests; 133 passed)
- [ ] I ran `cargo test` in `src-tauri` (no Host change)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
