### PR TITLE
fix: 防止内置浏览器遮挡队列编辑弹窗

### DIFF
--- a/docs/superpowers/specs/2026-08-31-browser-modal-native-cover-design.md
+++ b/docs/superpowers/specs/2026-08-31-browser-modal-native-cover-design.md
@@ -1,117 +1,84 @@
-# Browser-Safe GlassModal Native Cover
+# GlassModal 遮盖内置浏览器原生层设计
 
-## Problem
+## 问题
 
-When the built-in Browser side pane is open, opening the send-queue edit
-dialog leaves the dialog and its backdrop underneath the browser page. The
-right side of the dialog is visually clipped and its controls cannot be used.
+打开内置浏览器侧栏后，再打开会话队列的消息编辑弹窗，浏览器页面会盖在弹窗和背景遮罩之上。弹窗右半部分被浏览器遮住，用户无法查看或操作其中的控件。
 
-Reproduction:
+复现步骤：
 
-1. Open a session with the Browser side pane visible.
-2. Add a message to the session send queue.
-3. Choose Edit for the queued message.
-4. Observe that the browser page paints over the dialog and backdrop.
+1. 打开一个会话，并保持右侧的内置浏览器可见。
+2. 向当前会话的发送队列添加一条消息。
+3. 点击该队列消息的“编辑”。
+4. 可以看到浏览器页面覆盖了弹窗及其背景遮罩。
 
-## Root Cause
+## 根因
 
-`QueueEditModal` renders through the shared `GlassModal` component. The modal
-is correctly portaled to `document.body` and uses the established modal
-z-index, but the embedded browser is a Tauri child WebView. Native child
-WebViews paint above the main DOM WebView, so no CSS z-index can place a DOM
-modal above them.
+`QueueEditModal` 通过公共组件 `GlassModal` 渲染。该弹窗已经正确 Portal 到 `document.body`，并使用了项目约定的弹窗 `z-index`，但内置浏览器实际是 Tauri 创建的原生子 WebView。原生子 WebView 绘制在主 DOM WebView 之上，因此无论把 DOM 弹窗的 CSS `z-index` 调到多高，都无法盖住它。
 
-The project already solves this boundary with the reference-counted
-`nativeWebviewCover` protocol. `EmbeddedBrowser` subscribes to that protocol
-and temporarily hides its native surface while a cover token is held. Floating
-menus, Settings navigation, pane motion, and `ThemeEditorModal` already use the
-protocol. Shared `GlassModal` dialogs do not, which leaves every standard modal
-susceptible to the same layering bug.
+项目已有解决该边界问题的 `nativeWebviewCover` 引用计数协议。`EmbeddedBrowser` 订阅该协议：只要存在 cover token，就临时隐藏原生浏览器表面。浮动菜单、设置页导航、面板动画以及 `ThemeEditorModal` 已经使用这套协议；公共 `GlassModal` 尚未接入，因此所有标准 `GlassModal` 弹窗都可能遇到同类遮挡问题。
 
-## Requirements
+## 需求
 
-- Every open `GlassModal` must acquire one native WebView cover token.
-- Closing or unmounting the modal must release exactly that token.
-- Multiple simultaneously mounted modals must remain covered until the final
-  modal releases its token.
-- Opening and closing a modal must preserve the embedded browser instance,
-  URL, history, and page state; only native visibility changes.
-- Existing focus trapping, Escape handling, overlay click handling, portals,
-  styling, and public `GlassModal` props must remain unchanged.
-- The queue editor must receive the behavior through `GlassModal`, without a
-  queue-specific workaround.
-- No new state may be added to `App.tsx` or `AppWorkbench.tsx`.
-- No new user-facing copy or i18n keys are needed.
+- 每个处于打开状态的 `GlassModal` 必须申请一个原生 WebView cover token。
+- 弹窗关闭或卸载时，必须准确释放自己申请的 token。
+- 多个弹窗同时存在时，必须等最后一个弹窗释放 token 后才能恢复浏览器。
+- 弹窗打开和关闭期间必须保留内置浏览器实例、URL、历史记录和页面状态，只改变原生表面的可见性。
+- 现有焦点陷阱、Escape 关闭、点击遮罩关闭、Portal、样式和 `GlassModal` 公共 props 必须保持不变。
+- 队列编辑弹窗必须通过公共 `GlassModal` 自动获得该行为，不能增加队列专用补丁。
+- 不得向 `App.tsx` 或 `AppWorkbench.tsx` 添加新状态。
+- 本次不需要新增任何用户可见文案或 i18n key。
 
-## Design
+## 设计
 
-Add a `useEffect` to `GlassModal` that follows the same lifecycle pattern as
-the existing dialog focus effect:
+在 `GlassModal` 中增加一个与现有焦点管理 effect 生命周期一致的 `useEffect`：
 
-1. If `open` is false, do nothing.
-2. If `open` becomes true, call `acquireNativeWebviewCover()`.
-3. Return the idempotent release function as the effect cleanup.
+1. `open` 为 `false` 时不做任何处理。
+2. `open` 变为 `true` 时调用 `acquireNativeWebviewCover()`。
+3. 将幂等的 release 函数直接作为 effect cleanup 返回。
 
-`nativeWebviewCover` already owns reference counting and event delivery.
-`EmbeddedBrowser` already reacts to cover state by calling `hide()` and restores
-the same WebView through its normal visibility synchronization when the cover
-depth returns to zero. No CSS, browser command, or queue state change is
-required.
+`nativeWebviewCover` 已经负责引用计数和事件分发。`EmbeddedBrowser` 已经会在 cover 生效时调用 `hide()`，并在 cover 深度归零后通过既有可见性同步逻辑恢复同一个 WebView。因此无需修改 CSS、浏览器命令或队列状态。
 
-This belongs in `GlassModal` rather than `QueueEditModal`: the invariant is
-"a DOM modal must paint above native child WebViews", and `GlassModal` is the
-shared ownership boundary for that invariant.
+该逻辑应该放在 `GlassModal`，而不是 `QueueEditModal`。真正需要维护的不变量是“DOM 弹窗必须能够显示在原生子 WebView 之上”，`GlassModal` 才是负责这一公共不变量的正确边界。
 
-## Alternatives Considered
+## 已考虑方案
 
-### Queue-only cover
+### 仅处理队列弹窗
 
-Acquire a cover token in `QueueEditModal`. This fixes the reported path but
-leaves every other `GlassModal` vulnerable and duplicates infrastructure
-knowledge in a business component. Rejected.
+在 `QueueEditModal` 内申请 cover token。它能修复本次报告的路径，但其他 `GlassModal` 仍会遇到同类问题，而且会把底层原生层知识复制到业务组件中。因此不采用。
 
-### Higher modal z-index
+### 提高弹窗 z-index
 
-Raise `.overlay` above the browser. Native child WebViews do not participate in
-the DOM stacking context, so this cannot fix the bug. Rejected.
+把 `.overlay` 的层级调到浏览器之上。原生子 WebView 不参与 DOM 的 stacking context，这种修改无法修复问题。因此不采用。
 
-### Observe modal DOM globally
+### 全局观察弹窗 DOM
 
-Use a mutation observer or global overlay registry to infer when native
-surfaces should hide. This adds timing races and couples behavior to CSS class
-names. The explicit component lifecycle is simpler and deterministic. Rejected.
+通过 MutationObserver 或全局 overlay 注册表推断何时隐藏原生表面。这会引入时序竞争，并把行为绑定到 CSS class 约定。直接使用组件生命周期更简单、明确且可预测。因此不采用。
 
-## Test Strategy
+## 测试策略
 
-Add a jsdom component test for `QueueEditModal`, exercising the real reported
-entry point while asserting the shared cover contract:
+为 `QueueEditModal` 新增 jsdom 组件测试。测试使用用户实际触发的队列编辑入口，同时验证公共 cover 协议：
 
-- closed queue modal leaves cover depth at zero;
-- opening the queue modal acquires a cover token;
-- closing/unmounting releases the token;
-- two open queue modals increment depth independently and one closing does not
-  uncover the remaining modal.
+- 队列弹窗关闭时，cover 深度保持为零；
+- 打开队列弹窗时，会申请一个 cover token；
+- 关闭或卸载弹窗时，会释放该 token；
+- 同时打开两个队列弹窗时会分别增加深度，关闭其中一个不能提前恢复浏览器。
 
-The regression test must fail against the current upstream implementation
-before production code changes. Existing `nativeWebviewCover` unit tests remain
-the authority for idempotent reference counting and subscriber notifications.
+在修改生产代码之前，新增的回归测试必须先在当前上游实现上按预期失败。现有 `nativeWebviewCover` 单元测试继续负责验证幂等引用计数和订阅事件。
 
-Verification after implementation:
+实现后的验证范围：
 
-- new queue modal regression test;
-- existing native cover and modal component tests;
-- full Vitest suite;
-- TypeScript typecheck;
-- ESLint with zero warnings;
-- UI production build;
-- Tauri runtime check with Browser open: backdrop covers the whole workbench,
-  the queue edit dialog is fully visible and interactive, and the same browser
-  page returns after the dialog closes.
+- 新增的队列弹窗回归测试；
+- 现有原生 cover 和弹窗组件测试；
+- 完整 Vitest 测试套件；
+- TypeScript 类型检查；
+- ESLint 零警告检查；
+- UI 生产构建；
+- Tauri 真机验证：打开内置浏览器后，背景遮罩覆盖整个工作台，队列编辑弹窗完整可见且可操作；关闭弹窗后，浏览器恢复到原页面，页面状态不丢失。
 
-## Non-Goals
+## 非目标
 
-- Rebuilding the embedded browser as an iframe.
-- Destroying and recreating the browser WebView around dialogs.
-- Changing modal appearance, dimensions, copy, or keyboard behavior.
-- Refactoring unrelated ad-hoc overlays that do not use `GlassModal`.
-- Changing the native cover protocol or its reference-count implementation.
+- 不把内置浏览器重构为 iframe。
+- 不在弹窗打开和关闭时销毁或重建浏览器 WebView。
+- 不修改弹窗外观、尺寸、文案或键盘行为。
+- 不顺带重构未使用 `GlassModal` 的其他临时浮层。
+- 不修改原生 cover 协议及其引用计数实现。

--- a/docs/superpowers/specs/2026-08-31-browser-modal-native-cover-design.md
+++ b/docs/superpowers/specs/2026-08-31-browser-modal-native-cover-design.md
@@ -1,0 +1,117 @@
+# Browser-Safe GlassModal Native Cover
+
+## Problem
+
+When the built-in Browser side pane is open, opening the send-queue edit
+dialog leaves the dialog and its backdrop underneath the browser page. The
+right side of the dialog is visually clipped and its controls cannot be used.
+
+Reproduction:
+
+1. Open a session with the Browser side pane visible.
+2. Add a message to the session send queue.
+3. Choose Edit for the queued message.
+4. Observe that the browser page paints over the dialog and backdrop.
+
+## Root Cause
+
+`QueueEditModal` renders through the shared `GlassModal` component. The modal
+is correctly portaled to `document.body` and uses the established modal
+z-index, but the embedded browser is a Tauri child WebView. Native child
+WebViews paint above the main DOM WebView, so no CSS z-index can place a DOM
+modal above them.
+
+The project already solves this boundary with the reference-counted
+`nativeWebviewCover` protocol. `EmbeddedBrowser` subscribes to that protocol
+and temporarily hides its native surface while a cover token is held. Floating
+menus, Settings navigation, pane motion, and `ThemeEditorModal` already use the
+protocol. Shared `GlassModal` dialogs do not, which leaves every standard modal
+susceptible to the same layering bug.
+
+## Requirements
+
+- Every open `GlassModal` must acquire one native WebView cover token.
+- Closing or unmounting the modal must release exactly that token.
+- Multiple simultaneously mounted modals must remain covered until the final
+  modal releases its token.
+- Opening and closing a modal must preserve the embedded browser instance,
+  URL, history, and page state; only native visibility changes.
+- Existing focus trapping, Escape handling, overlay click handling, portals,
+  styling, and public `GlassModal` props must remain unchanged.
+- The queue editor must receive the behavior through `GlassModal`, without a
+  queue-specific workaround.
+- No new state may be added to `App.tsx` or `AppWorkbench.tsx`.
+- No new user-facing copy or i18n keys are needed.
+
+## Design
+
+Add a `useEffect` to `GlassModal` that follows the same lifecycle pattern as
+the existing dialog focus effect:
+
+1. If `open` is false, do nothing.
+2. If `open` becomes true, call `acquireNativeWebviewCover()`.
+3. Return the idempotent release function as the effect cleanup.
+
+`nativeWebviewCover` already owns reference counting and event delivery.
+`EmbeddedBrowser` already reacts to cover state by calling `hide()` and restores
+the same WebView through its normal visibility synchronization when the cover
+depth returns to zero. No CSS, browser command, or queue state change is
+required.
+
+This belongs in `GlassModal` rather than `QueueEditModal`: the invariant is
+"a DOM modal must paint above native child WebViews", and `GlassModal` is the
+shared ownership boundary for that invariant.
+
+## Alternatives Considered
+
+### Queue-only cover
+
+Acquire a cover token in `QueueEditModal`. This fixes the reported path but
+leaves every other `GlassModal` vulnerable and duplicates infrastructure
+knowledge in a business component. Rejected.
+
+### Higher modal z-index
+
+Raise `.overlay` above the browser. Native child WebViews do not participate in
+the DOM stacking context, so this cannot fix the bug. Rejected.
+
+### Observe modal DOM globally
+
+Use a mutation observer or global overlay registry to infer when native
+surfaces should hide. This adds timing races and couples behavior to CSS class
+names. The explicit component lifecycle is simpler and deterministic. Rejected.
+
+## Test Strategy
+
+Add a jsdom component test for `QueueEditModal`, exercising the real reported
+entry point while asserting the shared cover contract:
+
+- closed queue modal leaves cover depth at zero;
+- opening the queue modal acquires a cover token;
+- closing/unmounting releases the token;
+- two open queue modals increment depth independently and one closing does not
+  uncover the remaining modal.
+
+The regression test must fail against the current upstream implementation
+before production code changes. Existing `nativeWebviewCover` unit tests remain
+the authority for idempotent reference counting and subscriber notifications.
+
+Verification after implementation:
+
+- new queue modal regression test;
+- existing native cover and modal component tests;
+- full Vitest suite;
+- TypeScript typecheck;
+- ESLint with zero warnings;
+- UI production build;
+- Tauri runtime check with Browser open: backdrop covers the whole workbench,
+  the queue edit dialog is fully visible and interactive, and the same browser
+  page returns after the dialog closes.
+
+## Non-Goals
+
+- Rebuilding the embedded browser as an iframe.
+- Destroying and recreating the browser WebView around dialogs.
+- Changing modal appearance, dimensions, copy, or keyboard behavior.
+- Refactoring unrelated ad-hoc overlays that do not use `GlassModal`.
+- Changing the native cover protocol or its reference-count implementation.

--- a/src/components/GlassModal.tsx
+++ b/src/components/GlassModal.tsx
@@ -27,6 +27,7 @@ import {
   installDialogFocus,
   type InstallDialogFocusOptions,
 } from "@/lib/a11yFocus";
+import { acquireNativeWebviewCover } from "@/lib/nativeWebviewCover";
 
 export type GlassModalSize = "sm" | "md" | "lg";
 
@@ -101,6 +102,11 @@ export function GlassModal({
       initialFocus: initialFocusRef.current ?? "first",
       restoreFocus: true,
     });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    return acquireNativeWebviewCover();
   }, [open]);
 
   if (!open || typeof document === "undefined") return null;

--- a/src/components/workbench-modals/QueueEditModal.test.tsx
+++ b/src/components/workbench-modals/QueueEditModal.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import {
+  nativeWebviewCoverDepth,
+  resetNativeWebviewCoverForTests,
+} from "@/lib/nativeWebviewCover";
+import { QueueEditModal } from "./QueueEditModal";
+
+beforeEach(() => {
+  resetNativeWebviewCoverForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  resetNativeWebviewCoverForTests();
+});
+
+function modalProps(open: boolean) {
+  return {
+    locale: "en" as const,
+    open,
+    text: "queued message",
+    textareaRef: createRef<HTMLTextAreaElement>(),
+    onTextChange: vi.fn(),
+    onClose: vi.fn(),
+    onSave: vi.fn(),
+  };
+}
+
+describe("QueueEditModal native webview cover", () => {
+  it("covers the native browser only while the queue editor is open", () => {
+    const { rerender } = render(<QueueEditModal {...modalProps(false)} />);
+    expect(nativeWebviewCoverDepth()).toBe(0);
+
+    rerender(<QueueEditModal {...modalProps(true)} />);
+    expect(nativeWebviewCoverDepth()).toBe(1);
+
+    rerender(<QueueEditModal {...modalProps(false)} />);
+    expect(nativeWebviewCoverDepth()).toBe(0);
+  });
+
+  it("keeps the browser covered until the last stacked editor unmounts", () => {
+    const { rerender, unmount } = render(
+      <>
+        <QueueEditModal {...modalProps(true)} />
+        <QueueEditModal {...modalProps(true)} />
+      </>,
+    );
+    expect(nativeWebviewCoverDepth()).toBe(2);
+
+    rerender(
+      <>
+        <QueueEditModal {...modalProps(false)} />
+        <QueueEditModal {...modalProps(true)} />
+      </>,
+    );
+    expect(nativeWebviewCoverDepth()).toBe(1);
+
+    unmount();
+    expect(nativeWebviewCoverDepth()).toBe(0);
+  });
+});


### PR DESCRIPTION
## 变更摘要

- 修复内置浏览器打开时，队列消息编辑弹窗被原生 WebView 覆盖、无法正常操作的问题。
- 在公共 `GlassModal` 打开时复用现有 native webview cover；关闭或卸载时自动释放。引用计数保证多个叠加弹窗不会提前恢复浏览器。
- 新增队列编辑弹窗回归测试，并补充中文设计说明。

## 变更类型

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / chore

## 验证

- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm test`（562 个测试文件，6893 项测试全部通过）
- [x] `corepack pnpm lint`
- [x] `python3 scripts/check-code-quality-gates.py --mode final`
- [x] `python3 scripts/publish-website-downloads.py --self-test`
- [x] `corepack pnpm build:ui`（8099 个模块）
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`（1583 项通过，0 项失败，1 项按项目标记忽略）
- [x] Tauri Dev 打开态实机验证：Browser 原生页面被隐藏，队列编辑弹窗完整可见

关闭后的 Browser 恢复路径由 `nativeWebviewCover` 引用计数测试和 `QueueEditModal` cleanup 回归测试覆盖。由于当前 macOS 终端没有辅助访问权限，本次未通过自动点击做关闭态实机复核。

本机 Rust 测试使用一次性 `GROK_APP_HOME` 隔离用户数据，并为 loopback 显式设置 `NO_PROXY`，避免正在运行的 App 和 macOS system proxy 干扰测试。

## 检查清单

- [x] 已运行 `pnpm typecheck` 和 `pnpm test`
- [x] 已在 `src-tauri` 运行 `cargo test`
- [x] 本次未新增用户可见文案；现有文案继续通过 `src/i18n/messages.ts`
- [x] 未使用 `window.confirm` / `prompt` / `alert`
- [x] 行为设计说明已更新
- [x] 未包含 secrets、tokens、`auth.json` 或本地 agent home
