### PR TITLE
fix(ui): replace the last two native <select> dropdowns with the project Select

### DIFF
--- a/src/components/AgentDashboardModal.tsx
+++ b/src/components/AgentDashboardModal.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import type { Locale, MessageKey } from "@/i18n";
 import { createT } from "@/i18n";
 import { GlassModal } from "@/components/GlassModal";
+import { Select } from "@/components/Select";
 import { xEvidenceStats, type XEvidenceStats } from "@/lib/api";
 import {
   AGENT_DASHBOARD_STATUS_FILTERS,
@@ -614,25 +615,22 @@ export function AgentDashboardModal({
           ) : (
             <>
               <div className="agent-dash__dispatch-row">
-                <label className="agent-dash__dispatch-label" htmlFor="agent-dash-dispatch-project">
+                <span className="agent-dash__dispatch-label" id="agent-dash-dispatch-project-label">
                   {tr("dashboard.dispatch.projectLabel")}
-                </label>
-                <select
-                  id="agent-dash-dispatch-project"
-                  className="settings-input agent-dash__dispatch-select"
+                </span>
+                <Select
                   value={dispatchProjectId}
-                  onChange={(e) => {
-                    setDispatchProjectId(e.target.value);
+                  options={trustedProjects.map((p) => ({
+                    value: p.id,
+                    label: p.name || p.path || p.id,
+                  }))}
+                  onChange={(v) => {
+                    setDispatchProjectId(v);
                     setDispatchHint(null);
                   }}
                   aria-label={tr("dashboard.dispatch.projectLabel")}
-                >
-                  {trustedProjects.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name || p.path || p.id}
-                    </option>
-                  ))}
-                </select>
+                  className="agent-dash__dispatch-select"
+                />
               </div>
               <textarea
                 className="settings-input agent-dash__dispatch-prompt"

--- a/src/components/DoctorModal.tsx
+++ b/src/components/DoctorModal.tsx
@@ -14,6 +14,7 @@ import {
   IconRefresh,
 } from "@/components/icons";
 import { GlassModal } from "@/components/GlassModal";
+import { Select } from "@/components/Select";
 import { createT, intlLocale, type Locale, type MessageKey } from "@/i18n";
 import * as api from "@/lib/api";
 import type { DoctorLevel, DoctorReport } from "@/lib/api";
@@ -1370,29 +1371,25 @@ export function DoctorModal({
                     </button>
                   ))}
                 </div>
-                <label className="doctor-findings__category">
-                  <span className="sr-only">{t("doctor.filter.categoryAria")}</span>
-                  <select
-                    className="settings-input doctor-findings__select"
+                <div className="doctor-findings__category">
+                  <Select
                     value={categoryFilter}
-                    onChange={(e) =>
-                      setCategoryFilter(
-                        e.target.value as DoctorFindingCategoryFilter,
-                      )
-                    }
+                    options={[
+                      { value: "all", label: t("doctor.filter.categoryAll") },
+                      ...presentCategories.map((c) => ({
+                        value: c,
+                        label:
+                          t(CATEGORY_LABEL_KEYS[c]) +
+                          (findingCounts.byCategory[c]
+                            ? ` (${findingCounts.byCategory[c]})`
+                            : ""),
+                      })),
+                    ]}
+                    onChange={(v) => setCategoryFilter(v as DoctorFindingCategoryFilter)}
                     aria-label={t("doctor.filter.categoryAria")}
-                  >
-                    <option value="all">{t("doctor.filter.categoryAll")}</option>
-                    {presentCategories.map((c) => (
-                      <option key={c} value={c}>
-                        {t(CATEGORY_LABEL_KEYS[c])}
-                        {findingCounts.byCategory[c]
-                          ? ` (${findingCounts.byCategory[c]})`
-                          : ""}
-                      </option>
-                    ))}
-                  </select>
-                </label>
+                    className="doctor-findings__select"
+                  />
+                </div>
                 <label className="doctor-findings__issues">
                   <input
                     type="checkbox"


### PR DESCRIPTION
## Summary

`docs/llm-wiki/dialogs.md` forbids OS-default controls for product actions; the codebase had already migrated everywhere except two stragglers still rendering browser-native `<select>` dropdowns inside modals:

- `DoctorModal` — the findings category filter
- `AgentDashboardModal` — the dispatch target project picker

## What changed

Both now render the project's portaled [`Select`](src/components/Select.tsx) component (`menu-panel` + `listbox`, menu portaled to body so it is never clipped by modal overflow, same chrome as every other settings dropdown).

- Doctor filter keeps the per-category count suffixes `(n)` and its `aria-label`; the `<label>`+`sr-only` wrapper collapses into the Select's own accessible labeling.
- Dashboard picker keeps the dispatch-hint reset on change and its `aria-label`; the `htmlFor`/`id` pairing becomes a labeled span + Select.

## Test plan

- [x] `pnpm typecheck` ✅ · `pnpm lint` ✅
- [x] `npx vitest run src/components` — 209 passed
- [x] Repo-wide grep: zero native `<select>` outside comments remain
- [x] No copy changes — all strings still flow through i18n

## Type of change
- [x] Bug fix (dialog-policy compliance)
- [ ] New feature
- [ ] Documentation
