### PR TITLE
fix(i18n): route the last two hardcoded aria-labels through translations

### DIFF
--- a/src/app/WorkbenchResourcesAside.tsx
+++ b/src/app/WorkbenchResourcesAside.tsx
@@ -130,6 +130,8 @@ export function WorkbenchResourcesAside(props: WorkbenchResourcesAsideProps) {
     resetKey: sessionId || "",
   });
 
+  const t = createT(locale);
+
   return (
     <>
       {!phoneLayout ? (
@@ -192,7 +194,7 @@ export function WorkbenchResourcesAside(props: WorkbenchResourcesAsideProps) {
           className="aside-resizer"
           role="separator"
           aria-orientation="vertical"
-          aria-label="Resize files pane"
+          aria-label={t("resources.resizeFilesPane")}
           onPointerDown={(e) => {
             e.preventDefault();
             beginAsideResize(asideMin);

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -493,7 +493,7 @@ export function SetupWizard({
           <p className="setup-subtitle">{tr("setup.subtitle")}</p>
         </div>
 
-        <ol className="setup-steps" aria-label="Setup steps">
+        <ol className="setup-steps" aria-label={tr("setup.stepsAria")}>
           {(
             [
               ["runtime", "setup.step.runtime"],

--- a/src/i18n/messages/de/doctor.ts
+++ b/src/i18n/messages/de/doctor.ts
@@ -5,6 +5,7 @@ export const deDoctor = {
   "setup.step.runtime": "Runtime",
   "setup.step.account": "Konto",
   "setup.step.ready": "Bereit",
+  "setup.stepsAria": "Einrichtungsschritte",
   "setup.detecting": "Grok Build wird geprüft…",
   "setup.detectingSlow": "Prüft weiter… das dauert länger als üblich.",
   "setup.detectTimeout": "Startprüfung zeitüberschritten",

--- a/src/i18n/messages/de/workspace.ts
+++ b/src/i18n/messages/de/workspace.ts
@@ -37,6 +37,7 @@ export const deWorkspace = {
   "resources.collapseTree": "Dateibaum ausblenden",
   "resources.expandTree": "Dateibaum anzeigen",
   "resources.resizeTree": "Dateibaum anpassen",
+  "resources.resizeFilesPane": "Dateileiste in der Größe ändern",
   "resources.save": "Speichern",
   "resources.saving": "Speichern…",
   "resources.revert": "Zurücksetzen",

--- a/src/i18n/messages/en/doctor.ts
+++ b/src/i18n/messages/en/doctor.ts
@@ -5,6 +5,7 @@ export const enDoctor = {
   "setup.step.runtime": "Runtime",
   "setup.step.account": "Account",
   "setup.step.ready": "Ready",
+  "setup.stepsAria": "Setup steps",
   "setup.detecting": "Checking Grok Build…",
   "setup.detectingSlow": "Still checking… this is taking longer than usual.",
   "setup.detectTimeout": "Startup check timed out",

--- a/src/i18n/messages/en/workspace.ts
+++ b/src/i18n/messages/en/workspace.ts
@@ -37,6 +37,7 @@ export const enWorkspace = {
   "resources.collapseTree": "Hide file tree",
   "resources.expandTree": "Show file tree",
   "resources.resizeTree": "Resize file tree",
+  "resources.resizeFilesPane": "Resize files pane",
   "resources.save": "Save",
   "resources.saving": "Saving…",
   "resources.revert": "Revert",

--- a/src/i18n/messages/es/doctor.ts
+++ b/src/i18n/messages/es/doctor.ts
@@ -5,6 +5,7 @@ export const esDoctor = {
   "setup.step.runtime": "Ejecución",
   "setup.step.account": "Cuenta",
   "setup.step.ready": "Listo",
+  "setup.stepsAria": "Pasos de configuración",
   "setup.detecting": "Comprobando Grok Build…",
   "setup.detectingSlow": "Sigue comprobando… está tardando más de lo habitual.",
   "setup.detectTimeout": "La comprobación de arranque agotó el tiempo",

--- a/src/i18n/messages/es/workspace.ts
+++ b/src/i18n/messages/es/workspace.ts
@@ -37,6 +37,7 @@ export const esWorkspace = {
   "resources.collapseTree": "Ocultar árbol de archivos",
   "resources.expandTree": "Mostrar árbol de archivos",
   "resources.resizeTree": "Redimensionar árbol de archivos",
+  "resources.resizeFilesPane": "Cambiar tamaño del panel de archivos",
   "resources.save": "Guardar",
   "resources.saving": "Guardando…",
   "resources.revert": "Revertir",

--- a/src/i18n/messages/fil/doctor.ts
+++ b/src/i18n/messages/fil/doctor.ts
@@ -5,6 +5,7 @@ export const filDoctor = {
   "setup.step.runtime": "Runtime",
   "setup.step.account": "Account",
   "setup.step.ready": "Handa na",
+  "setup.stepsAria": "Mga hakbang sa setup",
   "setup.detecting": "Sini-check ang Grok Build…",
   "setup.detectingSlow": "Sini-check pa… mas matagal ito kaysa karaniwan.",
   "setup.detectTimeout": "Nag-timeout ang startup check",

--- a/src/i18n/messages/fil/workspace.ts
+++ b/src/i18n/messages/fil/workspace.ts
@@ -37,6 +37,7 @@ export const filWorkspace = {
   "resources.collapseTree": "Itago ang file tree",
   "resources.expandTree": "Ipakita ang file tree",
   "resources.resizeTree": "Baguhin ang laki ng file tree",
+  "resources.resizeFilesPane": "Baguhin ang laki ng files pane",
   "resources.save": "I-save",
   "resources.saving": "Sine-save…",
   "resources.revert": "Ibalik",

--- a/src/i18n/messages/fr/doctor.ts
+++ b/src/i18n/messages/fr/doctor.ts
@@ -5,6 +5,7 @@ export const frDoctor = {
   "setup.step.runtime": "Exécution",
   "setup.step.account": "Compte",
   "setup.step.ready": "Prêt",
+  "setup.stepsAria": "Étapes de configuration",
   "setup.detecting": "Vérification de Grok Build…",
   "setup.detectingSlow": "Toujours en cours… cela prend plus de temps que d’habitude.",
   "setup.detectTimeout": "Délai de la vérification de démarrage dépassé",

--- a/src/i18n/messages/fr/workspace.ts
+++ b/src/i18n/messages/fr/workspace.ts
@@ -37,6 +37,7 @@ export const frWorkspace = {
   "resources.collapseTree": "Masquer l’arbre des fichiers",
   "resources.expandTree": "Afficher l’arbre des fichiers",
   "resources.resizeTree": "Redimensionner l’arbre des fichiers",
+  "resources.resizeFilesPane": "Redimensionner le volet de fichiers",
   "resources.save": "Enregistrer",
   "resources.saving": "Enregistrement…",
   "resources.revert": "Rétablir",

--- a/src/i18n/messages/id/doctor.ts
+++ b/src/i18n/messages/id/doctor.ts
@@ -5,6 +5,7 @@ export const idDoctor = {
   "setup.step.runtime": "Runtime",
   "setup.step.account": "Akun",
   "setup.step.ready": "Siap",
+  "setup.stepsAria": "Langkah penyiapan",
   "setup.detecting": "Memeriksa Grok Build…",
   "setup.detectingSlow": "Masih memeriksa… ini lebih lama dari biasanya.",
   "setup.detectTimeout": "Pemeriksaan mulai kehabisan waktu",

--- a/src/i18n/messages/id/workspace.ts
+++ b/src/i18n/messages/id/workspace.ts
@@ -37,6 +37,7 @@ export const idWorkspace = {
   "resources.collapseTree": "Sembunyikan pohon berkas",
   "resources.expandTree": "Tampilkan pohon berkas",
   "resources.resizeTree": "Ubah ukuran pohon berkas",
+  "resources.resizeFilesPane": "Ubah ukuran panel file",
   "resources.save": "Simpan",
   "resources.saving": "Menyimpan…",
   "resources.revert": "Kembalikan",

--- a/src/i18n/messages/it/doctor.ts
+++ b/src/i18n/messages/it/doctor.ts
@@ -5,6 +5,7 @@ export const itDoctor = {
   "setup.step.runtime": "Runtime",
   "setup.step.account": "Account",
   "setup.step.ready": "Pronto",
+  "setup.stepsAria": "Fasi di configurazione",
   "setup.detecting": "Verifica di Grok Build…",
   "setup.detectingSlow": "Ancora in verifica… sta impiegando più del solito.",
   "setup.detectTimeout": "Timeout del controllo di avvio",

--- a/src/i18n/messages/it/workspace.ts
+++ b/src/i18n/messages/it/workspace.ts
@@ -37,6 +37,7 @@ export const itWorkspace = {
   "resources.collapseTree": "Nascondi albero file",
   "resources.expandTree": "Mostra albero file",
   "resources.resizeTree": "Ridimensiona albero file",
+  "resources.resizeFilesPane": "Ridimensiona pannello file",
   "resources.save": "Salva",
   "resources.saving": "Salvataggio…",
   "resources.revert": "Ripristina",

--- a/src/i18n/messages/ja/doctor.ts
+++ b/src/i18n/messages/ja/doctor.ts
@@ -5,6 +5,7 @@ export const jaDoctor = {
   "setup.step.runtime": "ランタイム",
   "setup.step.account": "アカウント",
   "setup.step.ready": "準備完了",
+  "setup.stepsAria": "セットアップのステップ",
   "setup.detecting": "Grok Build を確認中…",
   "setup.detectingSlow": "まだ確認中… いつもより時間がかかっています。",
   "setup.detectTimeout": "起動チェックがタイムアウトしました",

--- a/src/i18n/messages/ja/workspace.ts
+++ b/src/i18n/messages/ja/workspace.ts
@@ -37,6 +37,7 @@ export const jaWorkspace = {
   "resources.collapseTree": "ファイルツリーを隠す",
   "resources.expandTree": "ファイルツリーを表示",
   "resources.resizeTree": "ファイルツリーのサイズを変更",
+  "resources.resizeFilesPane": "ファイルペインのサイズを変更",
   "resources.save": "保存",
   "resources.saving": "保存中…",
   "resources.revert": "元に戻す",

--- a/src/i18n/messages/ko/doctor.ts
+++ b/src/i18n/messages/ko/doctor.ts
@@ -5,6 +5,7 @@ export const koDoctor = {
   "setup.step.runtime": "런타임",
   "setup.step.account": "계정",
   "setup.step.ready": "준비됨",
+  "setup.stepsAria": "설정 단계",
   "setup.detecting": "Grok Build 확인 중…",
   "setup.detectingSlow": "아직 확인 중… 평소보다 오래 걸리고 있습니다.",
   "setup.detectTimeout": "시작 확인 시간 초과",

--- a/src/i18n/messages/ko/workspace.ts
+++ b/src/i18n/messages/ko/workspace.ts
@@ -37,6 +37,7 @@ export const koWorkspace = {
   "resources.collapseTree": "파일 트리 숨기기",
   "resources.expandTree": "파일 트리 표시",
   "resources.resizeTree": "파일 트리 크기 조절",
+  "resources.resizeFilesPane": "파일 패널 크기 조정",
   "resources.save": "저장",
   "resources.saving": "저장 중…",
   "resources.revert": "되돌리기",

--- a/src/i18n/messages/pt-BR/doctor.ts
+++ b/src/i18n/messages/pt-BR/doctor.ts
@@ -5,6 +5,7 @@ export const ptBRDoctor = {
   "setup.step.runtime": "Runtime",
   "setup.step.account": "Conta",
   "setup.step.ready": "Pronto",
+  "setup.stepsAria": "Etapas de configuração",
   "setup.detecting": "Verificando o Grok Build…",
   "setup.detectingSlow": "Ainda verificando… isto está demorando mais que o usual.",
   "setup.detectTimeout": "A verificação de inicialização expirou",

--- a/src/i18n/messages/pt-BR/workspace.ts
+++ b/src/i18n/messages/pt-BR/workspace.ts
@@ -37,6 +37,7 @@ export const ptBRWorkspace = {
   "resources.collapseTree": "Ocultar árvore de arquivos",
   "resources.expandTree": "Mostrar árvore de arquivos",
   "resources.resizeTree": "Redimensionar árvore de arquivos",
+  "resources.resizeFilesPane": "Redimensionar painel de arquivos",
   "resources.save": "Salvar",
   "resources.saving": "Salvando…",
   "resources.revert": "Reverter",

--- a/src/i18n/messages/ru/doctor.ts
+++ b/src/i18n/messages/ru/doctor.ts
@@ -5,6 +5,7 @@ export const ruDoctor = {
   "setup.step.runtime": "Среда выполнения",
   "setup.step.account": "Аккаунт",
   "setup.step.ready": "Готово",
+  "setup.stepsAria": "Шаги настройки",
   "setup.detecting": "Проверка Grok Build…",
   "setup.detectingSlow": "Проверка всё ещё идёт… это занимает больше времени, чем обычно.",
   "setup.detectTimeout": "Проверка при запуске превысила время ожидания",

--- a/src/i18n/messages/ru/workspace.ts
+++ b/src/i18n/messages/ru/workspace.ts
@@ -37,6 +37,7 @@ export const ruWorkspace = {
   "resources.collapseTree": "Скрыть дерево файлов",
   "resources.expandTree": "Показать дерево файлов",
   "resources.resizeTree": "Изменить ширину дерева файлов",
+  "resources.resizeFilesPane": "Изменить размер панели файлов",
   "resources.save": "Сохранить",
   "resources.saving": "Сохранение…",
   "resources.revert": "Отменить изменения",

--- a/src/i18n/messages/ta/doctor.ts
+++ b/src/i18n/messages/ta/doctor.ts
@@ -5,6 +5,7 @@ export const taDoctor = {
   "setup.step.runtime": "இயக்கநேரம்",
   "setup.step.account": "கணக்கு",
   "setup.step.ready": "தயார்",
+  "setup.stepsAria": "அமைவு படிகள்",
   "setup.detecting": "Grok Build ஐச் சரிபார்க்கிறது…",
   "setup.detectingSlow": "இன்னும் சரிபார்க்கிறது… இதற்கு வழக்கத்தை விட அதிக நேரம் எடுக்கிறது.",
   "setup.detectTimeout": "தொடக்கச் சரிபார்ப்பு நேரம் முடிந்தது",

--- a/src/i18n/messages/ta/workspace.ts
+++ b/src/i18n/messages/ta/workspace.ts
@@ -37,6 +37,7 @@ export const taWorkspace = {
   "resources.collapseTree": "கோப்பு மரத்தை மறை",
   "resources.expandTree": "கோப்பு மரத்தைக் காட்டு",
   "resources.resizeTree": "கோப்பு மரத்தின் அளவை மாற்று",
+  "resources.resizeFilesPane": "கோப்பு பலகை அளவை மாற்று",
   "resources.save": "சேமி",
   "resources.saving": "சேமிக்கிறது…",
   "resources.revert": "திரும்பவும்",

--- a/src/i18n/messages/uk/doctor.ts
+++ b/src/i18n/messages/uk/doctor.ts
@@ -5,6 +5,7 @@ export const ukDoctor = {
   "setup.step.runtime": "Середовище",
   "setup.step.account": "Обліковий запис",
   "setup.step.ready": "Готово",
+  "setup.stepsAria": "Кроки налаштування",
   "setup.detecting": "Перевірка Grok Build…",
   "setup.detectingSlow": "Усе ще перевіряємо… це триває довше, ніж зазвичай.",
   "setup.detectTimeout": "Час очікування перевірки запуску вичерпано",

--- a/src/i18n/messages/uk/workspace.ts
+++ b/src/i18n/messages/uk/workspace.ts
@@ -37,6 +37,7 @@ export const ukWorkspace = {
   "resources.collapseTree": "Сховати дерево файлів",
   "resources.expandTree": "Показати дерево файлів",
   "resources.resizeTree": "Змінити ширину дерева файлів",
+  "resources.resizeFilesPane": "Змінити розмір панелі файлів",
   "resources.save": "Зберегти",
   "resources.saving": "Збереження…",
   "resources.revert": "Відкотити",

--- a/src/i18n/messages/zh-TW/doctor.ts
+++ b/src/i18n/messages/zh-TW/doctor.ts
@@ -5,6 +5,7 @@ export const zhTWDoctor = {
   "setup.step.runtime": "執行環境",
   "setup.step.account": "帳戶",
   "setup.step.ready": "就緒",
+  "setup.stepsAria": "設定步驟",
   "setup.detecting": "正在偵測 Grok Build…",
   "setup.detectingSlow": "仍在偵測…耗時比預期更長。",
   "setup.detectTimeout": "啟動偵測逾時",

--- a/src/i18n/messages/zh-TW/workspace.ts
+++ b/src/i18n/messages/zh-TW/workspace.ts
@@ -37,6 +37,7 @@ export const zhTWWorkspace = {
   "resources.collapseTree": "收合檔案樹",
   "resources.expandTree": "展開檔案樹",
   "resources.resizeTree": "調整檔案樹寬度",
+  "resources.resizeFilesPane": "調整檔案面板大小",
   "resources.save": "儲存",
   "resources.saving": "儲存中…",
   "resources.revert": "還原",

--- a/src/i18n/messages/zh/doctor.ts
+++ b/src/i18n/messages/zh/doctor.ts
@@ -5,6 +5,7 @@ export const zhDoctor = {
   "setup.step.runtime": "运行时",
   "setup.step.account": "账户",
   "setup.step.ready": "就绪",
+  "setup.stepsAria": "设置步骤",
   "setup.detecting": "正在检测 Grok Build…",
   "setup.detectingSlow": "仍在检测…耗时比预期更长。",
   "setup.detectTimeout": "启动检测超时",

--- a/src/i18n/messages/zh/workspace.ts
+++ b/src/i18n/messages/zh/workspace.ts
@@ -37,6 +37,7 @@ export const zhWorkspace = {
   "resources.collapseTree": "收起文件树",
   "resources.expandTree": "展开文件树",
   "resources.resizeTree": "调整文件树宽度",
+  "resources.resizeFilesPane": "调整文件面板大小",
   "resources.save": "保存",
   "resources.saving": "保存中…",
   "resources.revert": "还原",


### PR DESCRIPTION
## Summary

Two `aria-label`s bypassed `src/i18n` and stayed English no matter the UI language, contrary to the repo rule that every UI string flows through `createT`/`t()`:

- `WorkbenchResourcesAside` resizer separator: `aria-label="Resize files pane"` → new key `resources.resizeFilesPane` (the sibling key `resources.resizeTree` already existed and was translated — this resizer had been missed)
- `SetupWizard` step list: `aria-label="Setup steps"` → new key `setup.stepsAria`

## What changed

- Both new keys added to **all 15 locale catalogs** in lockstep with `en` (zh 调整文件面板大小/設置步驟, ja ファイルペインのサイズを変更/セットアップのステップ, ko, de, fr, es, pt-BR, it, ru, uk, ta, fil, id).
- The resizer component had no translator in scope — `createT(locale)` is now instantiated from the existing `locale` prop; `SetupWizard` already had `tr`.

## Test plan

- [x] `pnpm typecheck` ✅ · `pnpm lint` ✅
- [x] `npx vitest run src/i18n src/components` — 255 passed (key-parity invariants confirm the new keys exist in every locale)
- [x] No visual change; screen-reader labels now follow the UI language

## Type of change
- [x] Bug fix (i18n compliance)
- [ ] New feature
- [ ] Documentation
