### PR TITLE
fix(ui): stop expanded tool steps stacking title and command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
+- Expanded tool steps no longer stack title and command on one line. The last row in a Worked-for list keeps its real height.
 - Thinking no longer stays on screen as the final reply. The real answer paints in place; switching chats is not required (#968).
 - Settings search finds Chinese keywords for permission, telemetry, login, and more. Bilingual keywords stay locked by catalog test (#970).
 - Queue edit and other glass dialogs stay above the embedded browser. Native webviews hide while the modal is open (#976).
 - Doctor and the agent dashboard no longer use native dropdowns. They use the same app Select as settings (#981).
 
 **中文 · 修复**
+- 展开的工具步骤不再把标题和命令叠在同一行。工作列表最后一行会按真实高度排开。
 - 思考结束后不再把思考过程当成最终回复。正文会直接画出来，不用切走再切回来（#968）。
 - 设置搜索补上了中文关键词，权限、遥测、登录等能搜到了。目录测试会锁住双语关键词（#970）。
 - 打开内置浏览器时，队列编辑等毛玻璃弹窗不再被挡住。弹窗打开期间会暂时藏起原生页面（#976）。

--- a/src/components/lobe-chat/TimelineToolRow.tsx
+++ b/src/components/lobe-chat/TimelineToolRow.tsx
@@ -157,6 +157,7 @@ export const TimelineToolRow = memo(function TimelineToolRow({
         "grok-act__step lobe-timeline-tool" +
         (failed ? " is-error" : "") +
         (running ? " is-running" : "") +
+        (showBody ? " is-expanded" : "") +
         " is-last"
       }
       role="status"

--- a/src/components/lobe-chat/lobe-chat.part2.css
+++ b/src/components/lobe-chat/lobe-chat.part2.css
@@ -112,6 +112,27 @@
   content-visibility: auto;
   contain-intrinsic-size: auto 36px;
 }
+/* Expanded / speech rows cannot keep the collapsed 36px intrinsic size.
+ * WebView2 then paints the title, command, and child steps in one box
+ * (stacked glyphs on the last tool). */
+.grok-act__step.is-expanded,
+.grok-act__step[data-expanded="1"],
+.grok-act__step--speech {
+  content-visibility: visible;
+  contain-intrinsic-size: none;
+  min-height: min-content;
+  height: auto;
+  max-height: none;
+  overflow: visible;
+}
+.grok-act__steps--virtual .grok-act__step.is-expanded,
+.grok-act__steps--virtual .grok-act__step[data-expanded="1"],
+.grok-act__steps--virtual .grok-act__step--speech {
+  height: auto;
+  min-height: min-content;
+  max-height: none;
+  overflow: visible;
+}
 .grok-act__step.is-error {
   color: var(--chat-danger, #c44);
 }

--- a/src/lib/chatAnswerOverlap.guard.test.ts
+++ b/src/lib/chatAnswerOverlap.guard.test.ts
@@ -68,6 +68,21 @@ describe("chat answer overlap guard", () => {
     );
   });
 
+  it("does not keep content-visibility 36px on expanded tool steps", () => {
+    const src = css("lobe-chat.part2.css");
+    // Collapsed rows may skip paint; expanded rows must use real height so
+    // the title and command/children cannot stack in one 36px box.
+    expect(src).toMatch(
+      /\.grok-act__step\.is-expanded\s*,[\s\S]*?content-visibility:\s*visible/,
+    );
+    expect(src).toMatch(
+      /\.grok-act__step\[data-expanded="1"\][\s\S]*?content-visibility:\s*visible/,
+    );
+    expect(src).toMatch(
+      /\.grok-act__steps--virtual\s+\.grok-act__step\.is-expanded[\s\S]*?max-height:\s*none/,
+    );
+  });
+
   it("does not nest a 220px scroller on live thinking", () => {
     const src = css("lobe-chat.part2.css");
     expect(src).toMatch(


### PR DESCRIPTION
## Summary
Expanded tool rows in the Worked-for list stacked title, command, and child steps on one line (garbled last row on Windows WebView2).

Root cause: `.grok-act__step` uses `content-visibility: auto` with `contain-intrinsic-size: auto 36px`. After expand, WebView2 kept the collapsed 36px box and painted the body over the label.

## Changes
- Expanded / speech steps force `content-visibility: visible` and real height (including the virtual 36px override).
- Bare `TimelineToolRow` gets `is-expanded` when the body is open.
- Guard test + CHANGELOG Unreleased.

## Test plan
- [x] `pnpm typecheck`
- [x] Related vitest (`chatAnswerOverlap.guard`, `whatsNew`, `grokActivityVirtualize`)
- [x] `pnpm lint`
- [x] `python scripts/check-code-quality-gates.py --mode final`
- [x] `python scripts/publish-website-downloads.py --self-test`
- [x] `pnpm build:ui`
- [x] `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` in `src-tauri`
- [ ] Full `pnpm test`: 2 pre-existing Windows failures (CRLF source-guard matches in `welcomeIntro.guard` / `extensionsSurface.guard`); not from this change. Linux CI is the authority.
- [ ] `cargo test`: Windows `STATUS_ENTRYPOINT_NOT_FOUND` (pre-existing); clippy/fmt clean. Linux/mac CI runs tests.
- [ ] Manual: expand the last tool in a Worked-for list — title on one line, command/output below, no stacked glyphs.

## 中文
展开的工具步骤不再把标题和命令叠在同一行。工作列表最后一行会按真实高度排开。