### PR TITLE
perf(workbench): pause the git dirty poll while the window is hidden

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -606,6 +606,7 @@ import {
   summarizeGitDirty,
   type GitDirtySummary,
 } from "@/lib/workspaceGit";
+import { startVisibilityPoll } from "@/lib/visibilityPoll";
 
 const AutomationsPage = lazy(async () => {
   const m = await import("@/components/AutomationsPage");
@@ -10379,26 +10380,24 @@ export function AppWorkbench() {
     void refreshGitDirtyStatus();
     // Soft poll while a project is bound; refresh sooner on focus.
     // Faster while a turn is live — agent may `git switch` mid-session.
+    // Ticks pause while the window is hidden — a minimized app has nothing
+    // to paint, and `git status` is a process spawn per poll.
     const path = activeProject?.path?.trim() || null;
     if (!path || !api.isTauri()) return;
     const busy =
       session.state === "streaming" || session.state === "awaiting_permission";
     const intervalMs = busy ? 2000 : 8000;
-    const id = window.setInterval(() => {
-      void refreshGitDirtyStatus();
-    }, intervalMs);
+    const poll = startVisibilityPoll({
+      tick: () => void refreshGitDirtyStatus(),
+      setIntervalFn: (handler) => window.setInterval(handler, intervalMs),
+    });
     const onFocus = () => {
       void refreshGitDirtyStatus();
     };
-    const onVisibility = () => {
-      if (document.visibilityState === "visible") onFocus();
-    };
     window.addEventListener("focus", onFocus);
-    document.addEventListener("visibilitychange", onVisibility);
     return () => {
-      window.clearInterval(id);
+      poll.dispose();
       window.removeEventListener("focus", onFocus);
-      document.removeEventListener("visibilitychange", onVisibility);
     };
   }, [
     activeProject?.path,

--- a/src/lib/visibilityPoll.test.ts
+++ b/src/lib/visibilityPoll.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  shouldPollTickVisible,
+  startVisibilityPoll,
+} from "./visibilityPoll";
+
+describe("shouldPollTickVisible", () => {
+  it("runs for visible / unknown states and skips hidden", () => {
+    expect(shouldPollTickVisible("visible")).toBe(true);
+    expect(shouldPollTickVisible(null)).toBe(true);
+    expect(shouldPollTickVisible(undefined)).toBe(true);
+    expect(shouldPollTickVisible("hidden")).toBe(false);
+  });
+});
+
+describe("startVisibilityPoll", () => {
+  type Handler = () => void;
+  let intervalHandler: Handler | null = null;
+  let visibilityHandler: Handler | null = null;
+  let cleared: unknown[] = [];
+  let visible = true;
+
+  const harness = () => ({
+    isVisible: () => visible,
+    addListener: (h: Handler) => {
+      visibilityHandler = h;
+    },
+    removeListener: (h: Handler) => {
+      if (visibilityHandler === h) visibilityHandler = null;
+    },
+    setIntervalFn: (h: Handler) => {
+      intervalHandler = h;
+      return 7;
+    },
+    clearIntervalFn: (id: unknown) => {
+      cleared.push(id);
+    },
+  });
+
+  beforeEach(() => {
+    intervalHandler = null;
+    visibilityHandler = null;
+    cleared = [];
+    visible = true;
+  });
+
+  it("ticks on the interval while visible and skips while hidden", () => {
+    const tick = vi.fn();
+    const handle = startVisibilityPoll({ tick, ...harness() });
+    expect(intervalHandler).toBeTruthy();
+
+    intervalHandler!();
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    visible = false;
+    intervalHandler!();
+    intervalHandler!();
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    handle.dispose();
+    expect(cleared).toEqual([7]);
+  });
+
+  it("fires a catch-up tick when the window becomes visible again", () => {
+    const tick = vi.fn();
+    const handle = startVisibilityPoll({ tick, ...harness() });
+    expect(tick).toHaveBeenCalledTimes(0);
+
+    visible = false;
+    visibilityHandler!();
+    expect(tick).toHaveBeenCalledTimes(0);
+
+    visible = true;
+    visibilityHandler!();
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    handle.dispose();
+  });
+
+  it("dispose removes the visibility listener", () => {
+    const tick = vi.fn();
+    const handle = startVisibilityPoll({ tick, ...harness() });
+    handle.dispose();
+    expect(visibilityHandler).toBeNull();
+  });
+});

--- a/src/lib/visibilityPoll.ts
+++ b/src/lib/visibilityPoll.ts
@@ -1,0 +1,81 @@
+/**
+ * Visibility-aware background polling policy.
+ *
+ * Hidden windows (minimized / covered / another Space) should not burn
+ * foreground work: interval ticks are skipped while hidden and a refresh is
+ * requested once when the window becomes visible again. Tauri windows report
+ * `document.visibilityState` reliably, so no native listeners are needed.
+ */
+
+/** Whether a tick may run right now (window actually visible). */
+export function shouldPollTickVisible(
+  visibilityState: string | null | undefined,
+): boolean {
+  return visibilityState !== "hidden";
+}
+
+export type VisibilityPollSchedule = {
+  tick: () => void;
+  /** Can a tick run? Defaults to `document.visibilityState !== "hidden"`. */
+  isVisible?: () => boolean;
+  /** Subscribe to visibility changes. Defaults to `visibilitychange`. */
+  addListener?: (handler: () => void) => void;
+  removeListener?: (handler: () => void) => void;
+  setIntervalFn?: (handler: () => void, ms: number) => unknown;
+  clearIntervalFn?: (id: unknown) => void;
+};
+
+export type VisibilityPollHandle = {
+  dispose: () => void;
+};
+
+/**
+ * Interval that pauses while the window is hidden.
+ *
+ * - Interval stays scheduled (cheap); ticks no-op while hidden.
+ * - On becoming visible, `tick()` fires once immediately so data caught up
+ *   during the pause refreshes right away (the next interval beat may be a
+ *   full period away).
+ * - In-flight refreshes stay the caller's concern (reqId guards upstream).
+ */
+export function startVisibilityPoll(
+  opts: VisibilityPollSchedule,
+): VisibilityPollHandle {
+  const isVisible =
+    opts.isVisible ??
+    (() =>
+      typeof document === "undefined" ||
+      document.visibilityState !== "hidden");
+  const addListener =
+    opts.addListener ??
+    ((handler: () => void) => {
+      document.addEventListener("visibilitychange", handler);
+    });
+  const removeListener =
+    opts.removeListener ??
+    ((handler: () => void) => {
+      document.removeEventListener("visibilitychange", handler);
+    });
+  const setIntervalFn =
+    opts.setIntervalFn ??
+    ((handler: () => void, ms: number) => window.setInterval(handler, ms));
+  const clearIntervalFn =
+    opts.clearIntervalFn ?? ((id: unknown) => window.clearInterval(id as number));
+
+  const onInterval = () => {
+    if (isVisible()) opts.tick();
+  };
+  const onVisibility = () => {
+    if (isVisible()) opts.tick();
+  };
+
+  const intervalId = setIntervalFn(onInterval, 1000);
+  addListener(onVisibility);
+
+  return {
+    dispose() {
+      clearIntervalFn(intervalId);
+      removeListener(onVisibility);
+    },
+  };
+}


### PR DESCRIPTION
## What

The composer dirty chip polls `git_status` every 2–8s for the active project. The interval kept firing while the window was hidden (minimized / covered / another Space), spending a git process spawn + porcelain parse per tick on a chip nobody can see.

## How

- New shared helper `src/lib/visibilityPoll.ts`: interval ticks no-op while `document.visibilityState === "hidden"`, and one catch-up refresh fires on becoming visible (so data changed while hidden is not a full period stale).
- The dirty-poll effect in `AppWorkbench` now uses it; the focus listener is unchanged. Net effect: zero `git status` spawns while hidden, same freshness while visible.

## Checks

- [x] `pnpm typecheck`
- [x] `pnpm test` (6893 passed)
- [x] `pnpm lint`
- [x] `python3 scripts/check-code-quality-gates.py --mode final`
- [x] `python3 scripts/publish-website-downloads.py --self-test`
- [x] `pnpm build:ui`
- [x] New unit tests in `src/lib/visibilityPoll.test.ts`

No user-facing strings; no UI chrome changes.