### PR TITLE
perf(chat): make the transcript open-reveal settle event-driven

### DIFF
--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -110,6 +110,7 @@ import {
   shouldHoldTranscriptOpenReveal,
   transcriptOpenRevealHasMedia,
   transcriptOpenRevealSettleMs,
+  TRANSCRIPT_OPEN_REVEAL_FALLBACK_POLL_MS,
   TRANSCRIPT_OPEN_REVEAL_TIMEOUT_MS,
 } from "@/lib/transcriptOpenReveal";
 import { useChatMessageVirtualizer } from "@/hooks/useChatMessageVirtualizer";
@@ -3022,7 +3023,12 @@ export function ConversationThread({
     root.addEventListener("load", onMediaEvent, true);
     root.addEventListener("error", onMediaEvent, true);
     root.addEventListener("loadedmetadata", onMediaEvent, true);
-    const poll = window.setInterval(consider, 80);
+    // Media settle is event-driven (mutation classes + load/error events);
+    // the interval is a fallback safety net, so it can idle at 500ms.
+    const poll = window.setInterval(
+      consider,
+      TRANSCRIPT_OPEN_REVEAL_FALLBACK_POLL_MS,
+    );
     const timeout = window.setTimeout(finish, TRANSCRIPT_OPEN_REVEAL_TIMEOUT_MS);
     consider();
 

--- a/src/lib/transcriptOpenReveal.test.ts
+++ b/src/lib/transcriptOpenReveal.test.ts
@@ -7,6 +7,8 @@ import {
   shouldHoldTranscriptOpenReveal,
   transcriptOpenRevealHasMedia,
   transcriptOpenRevealSettleMs,
+  TRANSCRIPT_OPEN_REVEAL_FALLBACK_POLL_MS,
+  TRANSCRIPT_OPEN_REVEAL_TIMEOUT_MS,
 } from "./transcriptOpenReveal";
 
 describe("shouldHoldTranscriptOpenReveal", () => {
@@ -89,6 +91,14 @@ describe("transcriptOpenRevealSettleMs", () => {
   it("waits longer when media cards were present (attachment refine)", () => {
     expect(transcriptOpenRevealSettleMs(true)).toBeGreaterThan(
       transcriptOpenRevealSettleMs(false),
+    );
+  });
+});
+
+describe("fallback poll budget", () => {
+  it("safety-net poll stays far below the reveal timeout", () => {
+    expect(TRANSCRIPT_OPEN_REVEAL_FALLBACK_POLL_MS).toBeLessThanOrEqual(
+      TRANSCRIPT_OPEN_REVEAL_TIMEOUT_MS / 10,
     );
   });
 });

--- a/src/lib/transcriptOpenReveal.ts
+++ b/src/lib/transcriptOpenReveal.ts
@@ -8,6 +8,15 @@
 
 export const TRANSCRIPT_OPEN_REVEAL_TIMEOUT_MS = 8000;
 
+/**
+ * Media state changes announce themselves: image frames flip `is-pending` →
+ * `is-ready` / `is-broken` (class), `<img>` fires `load` / `error`, `<video>`
+ * fires `loadedmetadata`, and cards mount/unmount (childList). The fallback
+ * poll only has to be frequent enough not to stall the reveal, not fast
+ * enough to feel instant — it is a safety net, not the driver.
+ */
+export const TRANSCRIPT_OPEN_REVEAL_FALLBACK_POLL_MS = 500;
+
 /** Extra wait after the last pending card so late attachment refine can mount. */
 export function transcriptOpenRevealSettleMs(hadMedia: boolean): number {
   return hadMedia ? 280 : 48;


### PR DESCRIPTION
## What

When opening a historical session with media, the transcript is kept hidden until image/video cards have a measurable box, then scrolls once and reveals. While holding, a `setInterval(consider, 80)` swept the DOM 12.5×/s for up to 8s — per session open — competing with the very first paint this path is meant to protect.

## How

The sweep already has event drivers: frames flip `is-pending` → `is-ready`/`is-broken` classes (captured by the existing `MutationObserver` on `class`/`src`), `<img>` fires `load`/`error`, `<video>` fires `loadedmetadata`, and cards mount/unmount (childList). The interval is only a safety net for anything that slips through, so it now idles at **500ms** instead of 80ms. New constant `TRANSCRIPT_OPEN_REVEAL_FALLBACK_POLL_MS` with a test locking it to ≤ timeout/10.

Reveal latency is unchanged in the common case (events fire `consider()` immediately); worst case for an event-less straggler settles within 500ms, still far below the 8s timeout.

## Checks

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `python3 scripts/check-code-quality-gates.py --mode final`
- [x] `pnpm build:ui`

No user-facing strings; no behavior change to when the reveal finishes.