### PR TITLE
perf(host): run git_status on the blocking pool

### DIFF
--- a/src-tauri/src/commands/git_p1.rs
+++ b/src-tauri/src/commands/git_p1.rs
@@ -441,6 +441,10 @@ fn join_project_rel(project: &str, rel: &str) -> String {
 
 /// List modified / untracked / added files under a project (Workspace Changes).
 /// Soft-fails when git is missing or the path is not a repo.
+///
+/// `git status` is a process spawn + full worktree walk (untracked dirs
+/// included) and the dirty chip polls it every few seconds. It runs on the
+/// blocking pool so a big repo cannot stall the async runtime.
 #[tauri::command]
 pub async fn git_status(project_path: String) -> Result<GitStatusResult, String> {
     let project = normalize_fs_path(&project_path);
@@ -471,6 +475,12 @@ pub async fn git_status(project_path: String) -> Result<GitStatusResult, String>
         });
     }
 
+    tauri::async_runtime::spawn_blocking(move || git_status_blocking(project))
+        .await
+        .map_err(|e| format!("git status worker panicked: {e}"))?
+}
+
+fn git_status_blocking(project: String) -> Result<GitStatusResult, String> {
     let branch = crate::process_util::command("git")
         .args(["-C", &project, "rev-parse", "--abbrev-ref", "HEAD"])
         .output()


### PR DESCRIPTION
## What

The `git_status` Tauri command spawned `git` and parsed porcelain output directly on the async runtime worker — `async fn` with no `await` inside the hot path. The composer dirty chip calls it every 2–8s per open project, so a large repo (or cold disk cache) blocked that runtime worker for the whole walk and stalled every other command queued behind it.

## How

Split the blocking body into `git_status_blocking(project: String)` and wrap it with `tauri::async_runtime::spawn_blocking`, the same pattern already used by `cli_worktrees_list` and the doctor commands. Soft-fail responses (not a repo, git missing) are unchanged; a panic in the worker now maps to the command's `Err` channel instead of dropping the call.

## Checks

- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test` (1583 passed; the two full-suite runs before the final green run hit a pre-existing env-dependent flake in `remote_grok_home_matches_app_session_data_mode` / `settings_default_factory_and_disk_roundtrip` — both pass in isolation and the final full run is green)
- [x] `pnpm test`, `pnpm typecheck`, `pnpm lint`, quality gates final PASS, `pnpm build:ui`

No behavior change; host-side scheduling only.