### PR TITLE
perf(host): move worktree IPC commands onto the blocking pool

### DIFF
--- a/src-tauri/src/commands/worktree_agents_p1.rs
+++ b/src-tauri/src/commands/worktree_agents_p1.rs
@@ -647,6 +647,21 @@ pub async fn git_worktree_add(
     let start = sanitize_worktree_ref(start_point.as_deref())?;
     let layout_kind = normalize_worktree_layout(layout.as_deref());
 
+    // Worktree add materializes a full checkout (spawn + disk-heavy) — the
+    // blocking pool keeps it from stalling the async runtime.
+    tauri::async_runtime::spawn_blocking(move || {
+        git_worktree_add_blocking(project, safe_name, start, layout_kind)
+    })
+    .await
+    .map_err(|e| format!("git worktree add worker panicked: {e}"))?
+}
+
+fn git_worktree_add_blocking(
+    project: String,
+    safe_name: String,
+    start: Option<String>,
+    layout_kind: &'static str,
+) -> Result<GitWorktreeAddResult, String> {
     // Resolve main worktree path (first porcelain entry) for path placement.
     let list_out = crate::process_util::command("git")
         .args(["-C", &project, "worktree", "list", "--porcelain"])
@@ -777,6 +792,20 @@ pub async fn git_worktree_gc(
     let forced = force.unwrap_or(false);
     let age = sanitize_worktree_gc_max_age(max_age.as_deref())?;
 
+    // Prune scans + removes admin files across the repo — blocking pool.
+    tauri::async_runtime::spawn_blocking(move || {
+        git_worktree_gc_blocking(project, dry_run, forced, age)
+    })
+    .await
+    .map_err(|e| format!("git worktree gc worker panicked: {e}"))?
+}
+
+fn git_worktree_gc_blocking(
+    project: String,
+    dry_run: bool,
+    forced: bool,
+    age: Option<String>,
+) -> Result<GitWorktreeGcResult, String> {
     // Snapshot prunable entries before prune for UI preview / summary.
     let prunable = {
         let list_out = crate::process_util::command("git")
@@ -884,6 +913,19 @@ pub async fn git_worktree_remove(
         return Err("invalid worktree path".into());
     }
 
+    // `git worktree remove` deletes a full checkout tree — blocking pool.
+    tauri::async_runtime::spawn_blocking(move || {
+        git_worktree_remove_blocking(project, target, force.unwrap_or(false))
+    })
+    .await
+    .map_err(|e| format!("git worktree remove worker panicked: {e}"))?
+}
+
+fn git_worktree_remove_blocking(
+    project: String,
+    target: String,
+    forced: bool,
+) -> Result<GitWorktreeRemoveResult, String> {
     let list_out = crate::process_util::command("git")
         .args(["-C", &project, "worktree", "list", "--porcelain"])
         .output()
@@ -915,7 +957,6 @@ pub async fn git_worktree_remove(
         .map(|w| w.path.clone())
         .unwrap_or(target.clone());
 
-    let forced = force.unwrap_or(false);
     // Safe argv — never go through a shell.
     // `git worktree remove [--force] <path>`
     let mut args: Vec<String> = vec![

--- a/src-tauri/src/commands/worktree_agents_p2.rs
+++ b/src-tauri/src/commands/worktree_agents_p2.rs
@@ -70,6 +70,24 @@ pub async fn git_worktree_compare(
         return Ok(empty("could not resolve refs"));
     };
 
+    // Cross-worktree diff spans two checkouts — blocking pool.
+    let base_cloned = base.clone();
+    let other_cloned = other.clone();
+    let left_cloned = left.clone();
+    let right_cloned = right.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        git_worktree_compare_blocking(base_cloned, other_cloned, left_cloned, right_cloned)
+    })
+    .await
+    .map_err(|e| format!("git worktree compare worker panicked: {e}"))?
+}
+
+fn git_worktree_compare_blocking(
+    base: String,
+    other: String,
+    left: String,
+    right: String,
+) -> Result<GitWorktreeCompareResult, String> {
     // Safe argv — never go through a shell.
     // `git -C <base> diff --name-status <left>...<right>`
     let range = format!("{left}...{right}");


### PR DESCRIPTION
Follow-up to #990 / #991, same `spawn_blocking` pattern for `worktree_agents_p1/p2.rs`.

## What

- `git_worktree_add` — porcelain list, `mkdir -p`, `git worktree add` (materializes a full checkout), re-list
- `git_worktree_gc` — repo-wide prune scan + prune
- `git_worktree_remove` — deletes an entire checkout tree
- `git_worktree_compare` — cross-worktree `git diff --name-status`

All four ran on the async runtime worker, so creating/removing a worktree from the UI froze every other queued IPC command for the duration of the disk walk.

## How

Fast-path guards (path checks, name/ref sanitize, probe) stay on the runtime; spawns and disk walks move to `*_blocking` fns behind `tauri::async_runtime::spawn_blocking`. `git_push_branch` and `gh_pr_create` already used `spawn_blocking` and are untouched.

## Checks

- [x] `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`
- [x] `cargo test --lib` (1584 passed)