### PR TITLE
perf(host): run git_worktrees_list on the blocking pool

### DIFF
--- a/src-tauri/src/commands/git_p2.rs
+++ b/src-tauri/src/commands/git_p2.rs
@@ -291,6 +291,16 @@ pub async fn git_worktrees_list(project_path: String) -> Result<GitWorktreesResu
         });
     }
 
+    // Porcelain list touches every registered worktree on disk — blocking pool.
+    tauri::async_runtime::spawn_blocking(move || git_worktrees_list_blocking(project, cli_grok_home))
+        .await
+        .map_err(|e| format!("git worktrees list worker panicked: {e}"))?
+}
+
+fn git_worktrees_list_blocking(
+    project: String,
+    cli_grok_home: Option<String>,
+) -> Result<GitWorktreesResult, String> {
     let out = crate::process_util::command("git")
         .args(["-C", &project, "worktree", "list", "--porcelain"])
         .output()


### PR DESCRIPTION
Follow-up to #990 / #991 / #992 — closes out the git IPC family.

## What

The composer branch chip calls `git_worktrees_list` whenever the git menu can appear. `git worktree list --porcelain` stats every registered worktree on disk. That ran directly on the async runtime worker, so on a slow disk / large repo the list delayed every other queued command.

## How

`git worktree list` + porcelain parsing move to `git_worktrees_list_blocking` behind `tauri::async_runtime::spawn_blocking`; fast guards (empty path, not a directory, probe) stay on the runtime. Response shape unchanged.

## Checks

- [x] `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`
- [x] `cargo test --lib` (1584 passed)