### PR TITLE
fix(composer): localize top reasoning effort label in model menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
+- Desktop composer reasoning menu no longer shows the raw spawn id for the top tier. It uses the localized label (e.g. Extra high / 极高) like the other effort stops (#994).
 - Project chats no longer inherit the default-workspace sandbox. Writes inside the selected project work again (#986).
 - Expanded tool steps no longer stack title and command on one line. The last row in a Worked-for list keeps its real height (#983).
 - Thinking no longer stays on screen as the final reply. The real answer paints in place; switching chats is not required (#968).
@@ -23,6 +24,7 @@ See `docs/llm-wiki/release.md`.
 - Screen-reader labels for the files pane and setup steps follow the UI language. They no longer stay English (#982).
 
 **中文 · 修复**
+- 桌面 Composer 推理强度最高档不再显示原始 `xhigh`，会走本地化文案（如「极高」），与其它档位一致（#994）。
 - 项目会话不再误用默认工作区的沙箱。在选中项目里写文件又能成功了（#986）。
 - 展开的工具步骤不再把标题和命令叠在同一行。工作列表最后一行会按真实高度排开（#983）。
 - 思考结束后不再把思考过程当成最终回复。正文会直接画出来，不用切走再切回来（#968）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
-- Desktop composer reasoning menu no longer shows the raw spawn id for the top tier. It uses the localized label (e.g. Extra high / 极高) like the other effort stops (#994).
+- Desktop composer now shows localized labels for all reasoning tiers. The top tier no longer shows a raw internal id (#994).
 - Project chats no longer inherit the default-workspace sandbox. Writes inside the selected project work again (#986).
 - Expanded tool steps no longer stack title and command on one line. The last row in a Worked-for list keeps its real height (#983).
 - Thinking no longer stays on screen as the final reply. The real answer paints in place; switching chats is not required (#968).
@@ -24,7 +24,7 @@ See `docs/llm-wiki/release.md`.
 - Screen-reader labels for the files pane and setup steps follow the UI language. They no longer stay English (#982).
 
 **中文 · 修复**
-- 桌面 Composer 推理强度最高档不再显示原始 `xhigh`，会走本地化文案（如「极高」），与其它档位一致（#994）。
+- 桌面 Composer 推理强度最高档已与其它档位一样显示本地化名称。例如最高档显示「极高」（#994）。
 - 项目会话不再误用默认工作区的沙箱。在选中项目里写文件又能成功了（#986）。
 - 展开的工具步骤不再把标题和命令叠在同一行。工作列表最后一行会按真实高度排开（#983）。
 - 思考结束后不再把思考过程当成最终回复。正文会直接画出来，不用切走再切回来（#968）。

--- a/src/components/ComposerModelMenu.tsx
+++ b/src/components/ComposerModelMenu.tsx
@@ -770,10 +770,8 @@ export function ComposerModelMenu({
     officialLabel,
     activeCustom,
   });
-  const stopLabelFor = (stop: EffortPickerStop) => {
-    if (stop.id === "xhigh" || stop.id === "max") return stop.spawnId;
-    return effortDisplayLabel(stop.id, effortI18n(labels));
-  };
+  const stopLabelFor = (stop: EffortPickerStop) =>
+    effortDisplayLabel(stop.id, effortI18n(labels));
   const activeStop =
     pickerStops.find((s) => s.spawnId === effort) ?? pickerStops[0] ?? null;
   const eLabel = activeStop

--- a/src/components/ComposerPortalPop.test.tsx
+++ b/src/components/ComposerPortalPop.test.tsx
@@ -491,7 +491,7 @@ describe("composer chip portal pops", () => {
     expect(screen.queryByRole("searchbox", { name: "Search models" })).toBeNull();
   });
 
-  it("shows grok-4.6 xhigh as xhigh and keeps Advanced to models only", async () => {
+  it("localizes grok-4.6 xhigh via effort i18n in composer menu", async () => {
     const user = userEvent.setup();
     render(
       <ComposerModelMenu
@@ -523,11 +523,11 @@ describe("composer chip portal pops", () => {
     await user.click(screen.getByRole("button", { name: "Model" }));
     const pop = bodyPop();
     expect(pop).not.toBeNull();
-    expect(pop!.textContent ?? "").toMatch(/Effort xhigh/);
-    expect(pop!.textContent ?? "").not.toMatch(/Extra/);
+    expect(pop!.textContent ?? "").toMatch(/Effort Extra high/);
+    expect(pop!.textContent ?? "").not.toMatch(/\bxhigh\b/);
     await user.click(screen.getByRole("button", { name: "Advanced" }));
     expect(screen.queryByRole("searchbox", { name: "Search models" })).toBeNull();
-    expect(pop!.textContent ?? "").toMatch(/xhigh/);
-    expect(pop!.textContent ?? "").not.toMatch(/Extra/);
+    expect(pop!.textContent ?? "").toMatch(/Extra high/);
+    expect(pop!.textContent ?? "").not.toMatch(/\bxhigh\b/);
   });
 });


### PR DESCRIPTION
Fixes #994

## Summary
- Desktop composer model menu no longer shows the raw spawn id `xhigh` for the top reasoning tier.
- `stopLabelFor` now uses `effortDisplayLabel` for all stops, matching phone composer and `docs/llm-wiki/catalog.md`.

## Type of change
- [x] Bug fix

## Test plan
- [x] `pnpm exec vitest run src/components/ComposerPortalPop.test.tsx src/lib/grokCatalog.test.ts` (51 passed)
- [ ] Manual: zh locale → Model menu → Advanced → Reasoning shows 低/中/高/极高 (not `xhigh`)
