### PR TITLE
fix(sidebar): unify header into one titlebar row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
+- Desktop sidebar header is a single titlebar row: brand on the left, search and pane toggle grouped on the right (#996).
 - Desktop composer now shows localized labels for all reasoning tiers. The top tier no longer shows a raw internal id (#994).
 - Project chats no longer inherit the default-workspace sandbox. Writes inside the selected project work again (#986).
 - Expanded tool steps no longer stack title and command on one line. The last row in a Worked-for list keeps its real height (#983).
@@ -24,6 +25,7 @@ See `docs/llm-wiki/release.md`.
 - Screen-reader labels for the files pane and setup steps follow the UI language. They no longer stay English (#982).
 
 **中文 · 修复**
+- 桌面侧栏顶栏收成一行：左 logo、右搜索和侧栏按钮挨着，不再单独占一行（#996）。
 - 桌面 Composer 推理强度最高档已与其它档位一样显示本地化名称。例如最高档显示「极高」（#994）。
 - 项目会话不再误用默认工作区的沙箱。在选中项目里写文件又能成功了（#986）。
 - 展开的工具步骤不再把标题和命令叠在同一行。工作列表最后一行会按真实高度排开（#983）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
-- Desktop sidebar header is a single titlebar row: brand on the left, search and pane toggle grouped on the right (#996).
+- Sidebar header is now one row: logo, search, and pane toggle. Search sits next to the toggle on the right (#996).
 - Desktop composer now shows localized labels for all reasoning tiers. The top tier no longer shows a raw internal id (#994).
 - Project chats no longer inherit the default-workspace sandbox. Writes inside the selected project work again (#986).
 - Expanded tool steps no longer stack title and command on one line. The last row in a Worked-for list keeps its real height (#983).
@@ -25,7 +25,7 @@ See `docs/llm-wiki/release.md`.
 - Screen-reader labels for the files pane and setup steps follow the UI language. They no longer stay English (#982).
 
 **中文 · 修复**
-- 桌面侧栏顶栏收成一行：左 logo、右搜索和侧栏按钮挨着，不再单独占一行（#996）。
+- 桌面侧栏顶栏收成一行，搜索与侧栏按钮同在右侧。折叠时仍可在主栏左上角打开侧栏（#996）。
 - 桌面 Composer 推理强度最高档已与其它档位一样显示本地化名称。例如最高档显示「极高」（#994）。
 - 项目会话不再误用默认工作区的沙箱。在选中项目里写文件又能成功了（#986）。
 - 展开的工具步骤不再把标题和命令叠在同一行。工作列表最后一行会按真实高度排开（#983）。

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -13970,6 +13970,8 @@ export function AppWorkbench() {
           activeCustomProvider={activeCustomProvider}
           mainPane={mainPane}
           onOpenSearch={() => searchPalette.openBlank()}
+          sidebarToggleUnread={unreadSessionIds.size > 0}
+          onToggleSidebar={closeSidebarPane}
           onNewChat={() => void newChat(null)}
           onNavigateAutomations={navigateAutomations}
           onNavigateKanban={navigateKanban}

--- a/src/app/WorkbenchMain.tsx
+++ b/src/app/WorkbenchMain.tsx
@@ -150,19 +150,15 @@ export function WorkbenchMain(props: WorkbenchMainProps) {
 
   return (
     <>
-      {!phoneLayout ? (
+      {!phoneLayout && layout.sidebarCollapsed ? (
         <PaneToggleButton
           side="left"
-          open={!layout.sidebarCollapsed}
+          open={false}
           unread={sidebarToggleUnread}
-          label={tr(
-            layout.sidebarCollapsed ? "main.leftPaneShow" : "main.leftPaneHide",
-          )}
+          label={tr("main.leftPaneShow")}
           unreadLabel={tr("main.paneUnread")}
           controlsId="workbench-sidebar"
-          onToggle={
-            layout.sidebarCollapsed ? openSidebarPane : closePhoneDrawer
-          }
+          onToggle={openSidebarPane}
         />
       ) : null}
       <main

--- a/src/app/WorkbenchSidebar.tsx
+++ b/src/app/WorkbenchSidebar.tsx
@@ -11,6 +11,7 @@ import {
   type SetStateAction,
 } from "react";
 import { Tip } from "@/components/ui/tooltip";
+import { PaneToggleButton } from "@/components/PaneToggleButton";
 import { SidebarBrand } from "@/components/SidebarBrand";
 import { SidebarUpdateButton } from "@/components/SidebarUpdateButton";
 import { ThemeEditorModal } from "@/components/ThemeEditorModal";
@@ -88,6 +89,8 @@ export type WorkbenchSidebarProps = {
   activeCustomProvider: CustomProvider | null;
   mainPane: "chat" | "automations" | "kanban";
   onOpenSearch: () => void;
+  sidebarToggleUnread?: boolean;
+  onToggleSidebar?: () => void;
   onNewChat: () => void;
   onNavigateAutomations: () => void;
   onNavigateKanban: () => void;
@@ -149,6 +152,8 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
     activeCustomProvider,
     mainPane,
     onOpenSearch,
+    sidebarToggleUnread = false,
+    onToggleSidebar,
     onNewChat,
     onNavigateAutomations,
     onNavigateKanban,
@@ -253,14 +258,6 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
           data-tauri-drag-region={dragRegion}
           {...titlebarMax}
         >
-          <div
-            className="sidebar-chrome__drag"
-            data-tauri-drag-region={dragRegion}
-            {...titlebarMax}
-          />
-        </div>
-
-        <div className="sidebar-brand-row">
           <div className="sidebar-brand-row__left">
             <SidebarBrand
               replaceLogo={replaceProviderBrandLogo}
@@ -285,16 +282,35 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
             />
             <SidebarUpdateButton t={tr} />
           </div>
-          <Tip label={tr("sidebar.search")}>
-            <button
-              type="button"
-              className="chrome-btn"
-              aria-label={tr("sidebar.search")}
-              onClick={onOpenSearch}
-            >
-              <IconSearch size={16} />
-            </button>
-          </Tip>
+          <div
+            className="sidebar-chrome__drag"
+            data-tauri-drag-region={dragRegion}
+            {...titlebarMax}
+          />
+          <div className="sidebar-chrome__actions">
+            <Tip label={tr("sidebar.search")}>
+              <button
+                type="button"
+                className="chrome-btn"
+                aria-label={tr("sidebar.search")}
+                onClick={onOpenSearch}
+              >
+                <IconSearch size={16} />
+              </button>
+            </Tip>
+            {!phoneLayout && onToggleSidebar ? (
+              <PaneToggleButton
+                side="left"
+                pinned={false}
+                open={!layout.sidebarCollapsed}
+                unread={sidebarToggleUnread}
+                label={tr("main.leftPaneHide")}
+                unreadLabel={tr("main.paneUnread")}
+                controlsId="workbench-sidebar"
+                onToggle={onToggleSidebar}
+              />
+            ) : null}
+          </div>
         </div>
 
         <div className="sidebar-nav">

--- a/src/lib/paneSplitMotion.test.ts
+++ b/src/lib/paneSplitMotion.test.ts
@@ -460,10 +460,14 @@ describe("desktop hidden CSS must not force width 0", () => {
     expect(app).toContain(
       "sidebarToggleUnread={unreadSessionIds.size > 0}",
     );
-    expect(sidebar).not.toContain("main__pane-toggle");
+    expect(sidebar).not.toContain("pane-toggle--pinned");
+    expect(sidebar).toContain("<PaneToggleButton");
+    expect(sidebar).toContain('pinned={false}');
     expect(main).not.toContain('testId="main-side-toggle"');
     expect(main.match(/<PaneToggleButton/g) ?? []).toHaveLength(2);
-    expect(main).toMatch(/<PaneToggleButton\s+side="left"/);
+    expect(main).toMatch(
+      /<PaneToggleButton\s+side="left"[\s\S]*layout\.sidebarCollapsed/,
+    );
     expect(main).not.toMatch(
       /layout\.asideCollapsed\s*\?\s*\(\s*<Tip label=\{tr\("main\.rightPane/s,
     );

--- a/src/styles/sidebar.part1.css
+++ b/src/styles/sidebar.part1.css
@@ -675,7 +675,7 @@ html.platform-mac[data-theme="light"] .settings-page__content {
 .sidebar-chrome {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 8px;
   height: var(--titlebar-height, 40px);
   min-height: var(--titlebar-height, 40px);
   max-height: var(--titlebar-height, 40px);
@@ -701,18 +701,14 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   min-width: 8px;
 }
 
-/* Row 2: logo left, search right */
-.sidebar-brand-row {
+.sidebar-chrome__actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  height: 36px;
-  padding: 0 12px 4px;
-  margin-bottom: 2px;
+  gap: 2px;
   flex-shrink: 0;
 }
 
+/* Brand block lives inside the single titlebar row (logo left, actions right). */
 .sidebar-brand-row__left {
   display: flex;
   align-items: center;
@@ -722,6 +718,7 @@ html.platform-mac[data-theme="light"] .settings-page__content {
   font-size: 14px;
   color: var(--text-primary);
   letter-spacing: -0.02em;
+  flex-shrink: 1;
 }
 
 /* Swappable provider brand marks — height-locked for size parity.


### PR DESCRIPTION
Fixes #996

## Summary
- Merge sidebar brand, search, and left pane toggle into a single 40px titlebar row (logo left; search + toggle grouped on the right).
- Show the pinned left toggle on the main pane only when the sidebar is collapsed (unchanged reopen behavior).
- Phone drawer layout unchanged.

## Type of change
- [x] Bug fix / UX (layout)

## Test plan
- [x] `pnpm exec vitest run src/lib/paneSplitMotion.test.ts src/components/PaneToggleButton.test.tsx` (30 passed)
- [ ] Manual desktop: sidebar open → one header row; collapse → pinned toggle top-left on main; search still opens palette
