### PR TITLE
feat(chat): typed tool presentation with explicit meta passthrough

### DIFF
--- a/src/lib/grokActivitySteps.ts
+++ b/src/lib/grokActivitySteps.ts
@@ -21,6 +21,10 @@ import {
   toolPathBase,
   type ToolDisplayKind,
 } from "./toolDisplay";
+import {
+  resolveToolPresentation,
+  toolBucketForCard,
+} from "./toolPresentation";
 
 export type GrokActivityStep =
   | {
@@ -476,12 +480,23 @@ function buildStepsInternal(
       }
     }
 
-    // Browse page
+    // Browse page — prefer explicit presentation meta (DSH seam), else derive.
     if (isBrowseToolKind(tool.toolKind, tool.title, tool.toolCallId)) {
+      const presentation = resolveToolPresentation(
+        {
+          toolCallId: tool.toolCallId,
+          toolKind: tool.toolKind,
+          title: tool.title,
+          input: tool.input,
+          path: tool.path,
+          detail: tool.detail,
+        },
+        tool.meta,
+      );
       steps.push({
         type: "browse",
         key: tool.toolCallId || `browse-${i}`,
-        url: extractBrowseUrl(tool),
+        url: extractBrowseUrl(tool) || presentation.query || "page",
         failed: toolFailed(tool),
         running: stepRunning(tool, messageStreaming),
       });
@@ -489,9 +504,21 @@ function buildStepsInternal(
       continue;
     }
 
-    // Web search
+    // Web search — typed card facts win over string re-parsing (log replay).
     if (isSearchToolKind(tool.toolKind, tool.title, tool.toolCallId)) {
-      const query = extractSearchQuery(tool);
+      const presentationOf = (t: MessageToolSegment) =>
+        resolveToolPresentation(
+          {
+            toolCallId: t.toolCallId,
+            toolKind: t.toolKind,
+            title: t.title,
+            input: t.input,
+            path: t.path,
+            detail: t.detail,
+          },
+          t.meta,
+        );
+      const query = presentationOf(tool).query ?? extractSearchQuery(tool);
       // Consecutive searches without per-query text → collapse "Ran N searches"
       // Single search WITH query → "Searched web for …"
       // Peek consecutive
@@ -508,7 +535,7 @@ function buildStepsInternal(
         if (isBrowseToolKind(n.tool.toolKind, n.tool.title, n.tool.toolCallId))
           break;
         count += 1;
-        const q = extractSearchQuery(n.tool);
+        const q = presentationOf(n.tool).query ?? extractSearchQuery(n.tool);
         if (q) queries.push(q);
         if (toolFailed(n.tool)) failed = true;
         if (stepRunning(n.tool, messageStreaming)) running = true;
@@ -523,23 +550,25 @@ function buildStepsInternal(
             k === 0
               ? tool
               : (items[i + k] as { kind: "tool"; tool: MessageToolSegment }).tool;
+          const p = presentationOf(t);
           steps.push({
             type: "web-search",
             key: t.toolCallId || `ws-${i}-${k}`,
             query: queries[k]!,
-            resultCount: extractSearchResultCount(t),
-            resultDomains: extractResultDomains(t),
+            resultCount: p.resultCount ?? extractSearchResultCount(t),
+            resultDomains: p.resultDomains ?? extractResultDomains(t),
             failed: toolFailed(t),
             running: stepRunning(t, messageStreaming),
           });
         }
       } else if (count === 1 && query) {
+        const p = presentationOf(tool);
         steps.push({
           type: "web-search",
           key: tool.toolCallId || `ws-${i}`,
           query,
-          resultCount: extractSearchResultCount(tool),
-          resultDomains: extractResultDomains(tool),
+          resultCount: p.resultCount ?? extractSearchResultCount(tool),
+          resultDomains: p.resultDomains ?? extractResultDomains(tool),
           failed,
           running,
         });
@@ -556,13 +585,28 @@ function buildStepsInternal(
       continue;
     }
 
+    const presentation = resolveToolPresentation(
+      {
+        toolCallId: tool.toolCallId,
+        toolKind: tool.toolKind,
+        title: tool.title,
+        input: tool.input,
+        path: tool.path,
+        detail: tool.detail,
+      },
+      tool.meta,
+    );
+    const bucket =
+      presentation.card === "generic"
+        ? classifyToolKind(tool.toolKind, tool.title, tool.toolCallId)
+        : toolBucketForCard(presentation.card);
     steps.push({
       type: "tool",
       key: tool.toolCallId || `tool-${i}`,
       summary: toolOneLine(tool),
-      bucket: classifyToolKind(tool.toolKind, tool.title, tool.toolCallId),
-      inputLabel: toolInputDisplay(tool.input, classifyToolKind(tool.toolKind, tool.title, tool.toolCallId)),
-      pathBase: toolPathBase(tool.path),
+      bucket,
+      inputLabel: toolInputDisplay(tool.input, bucket),
+      pathBase: presentation.pathBase ?? toolPathBase(tool.path),
       failed: toolFailed(tool),
       running: stepRunning(tool, messageStreaming),
       tool,

--- a/src/lib/session/segments.ts
+++ b/src/lib/session/segments.ts
@@ -91,6 +91,7 @@ function preferRicherTool(
     ...pick,
     input: pick.input || other.input,
     path: pick.path || other.path,
+    meta: pick.meta || other.meta,
     output:
       (pick.output || "").length >= (other.output || "").length
         ? pick.output || other.output
@@ -138,6 +139,7 @@ export function compactMessageSegments(
           path: raw.path || prev.path,
           // Coalesce must not wipe a known call argument.
           input: raw.input || prev.input,
+          meta: raw.meta || prev.meta,
           // …nor the captured output (terminal tick carries it; later sparse
           // status ticks would otherwise blank the expand body).
           output:

--- a/src/lib/session/tools.ts
+++ b/src/lib/session/tools.ts
@@ -150,6 +150,7 @@ export function toolSegmentFromFields(fields: {
   path?: string;
   input?: string;
   output?: string;
+  meta?: import("../toolPresentation").ToolPresentationMeta;
   streaming?: boolean;
   isError?: boolean;
   createdAt?: string;
@@ -164,6 +165,7 @@ export function toolSegmentFromFields(fields: {
     path: fields.path,
     input: fields.input,
     output: fields.output,
+    meta: fields.meta,
     streaming: !!fields.streaming,
     isError: !!fields.isError,
     createdAt: fields.createdAt,
@@ -215,6 +217,7 @@ export function upsertToolInSegments(
       path: tool.path || prev.path,
       // Status-only ticks must not wipe a known call argument.
       input: tool.input || prev.input,
+      meta: tool.meta || prev.meta,
       toolKind: tool.toolKind || prev.toolKind,
     };
     return next;
@@ -342,6 +345,7 @@ function toolSegmentFromMessageRow(row: ChatMessage): MessageToolSegment | null 
     path,
     input,
     output,
+    meta: row.toolMeta,
     streaming: false,
     isError: !!row.isError || status === "failed" || status === "error",
     createdAt: row.createdAt,
@@ -823,6 +827,7 @@ export function syncTurnToolsIntoAssistant(
       path: m.toolPath,
       input: m.toolInput,
       output: m.toolOutput,
+      meta: m.toolMeta,
       streaming: !!m.streaming,
       isError: !!m.isError || status === "failed" || status === "error",
       createdAt: m.createdAt,
@@ -902,6 +907,9 @@ export function applyToolEvent(
     (nextOutput.length >= prevOutput.length ? nextOutput : prevOutput) ||
     undefined;
   const isError = status === "failed" || status === "error";
+  // Explicit Host presentation meta wins; otherwise keep the previous row's
+  // meta so a later sparse tick never wipes the typed card.
+  const toolMeta = payload.meta || prev?.toolMeta || undefined;
 
   // Host vision / X: **only** live on the assistant timeline. A separate
   // tool_step row + inlined segment was painting "搜索 X 信息" twice.
@@ -934,6 +942,7 @@ export function applyToolEvent(
         toolPath,
         toolInput,
         toolOutput,
+        toolMeta,
         toolParentId: parentId,
         streaming: running,
         marker: "tool_step",
@@ -952,6 +961,7 @@ export function applyToolEvent(
       path: toolPath,
       input: toolInput,
       output: toolOutput,
+      meta: toolMeta,
       streaming: running,
       isError,
       createdAt: prev?.createdAt || now,
@@ -975,6 +985,7 @@ export function applyToolEvent(
     toolPath,
     toolInput,
     toolOutput,
+    toolMeta,
     toolParentId: parentId,
     streaming: running,
     marker: "tool_step",
@@ -996,6 +1007,7 @@ export function applyToolEvent(
       toolPath: toolPath || prev!.toolPath,
       toolInput: toolInput || prev!.toolInput,
       toolOutput: toolOutput || prev!.toolOutput,
+      toolMeta: toolMeta || prev!.toolMeta,
       toolKind: toolKind || prev!.toolKind,
       toolParentId: parentId || prev!.toolParentId,
     };
@@ -1015,6 +1027,7 @@ export function applyToolEvent(
     path: row.toolPath,
     input: row.toolInput,
     output: row.toolOutput,
+    meta: row.toolMeta,
     streaming: running,
     isError: !!row.isError,
     createdAt: row.createdAt || prev?.createdAt || now,

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -57,6 +57,12 @@ export interface MessageToolSegment {
    * This is the expandable body — never part of the one-line primary label.
    */
   output?: string;
+  /**
+   * Typed presentation facts (DSH `tool/result.meta` seam). Explicit Host meta
+   * wins; otherwise the UI derives via `resolveToolPresentation`. Optional so
+   * old journals keep rendering via derivation + generic fallback.
+   */
+  meta?: import("../toolPresentation").ToolPresentationMeta;
   streaming?: boolean;
   isError?: boolean;
   /** ISO time when the tool row was created (history duration). */
@@ -114,6 +120,11 @@ export interface ChatMessage {
   /** Real tool output (ACP `content[]`) — expandable body, not a label. */
   toolOutput?: string;
   /**
+   * Typed presentation facts (DSH `tool/result.meta` seam). Persisted so log
+   * replay paints the same typed card as live; UI falls back to derivation.
+   */
+  toolMeta?: import("../toolPresentation").ToolPresentationMeta;
+  /**
    * Parent tool call id when the host/ACP marks nested tools (e.g. subagent
    * children). Optional — Tasks panel may infer when missing.
    */
@@ -132,6 +143,8 @@ export interface ToolEventPayload {
   input?: string | null;
   /** Real tool output (ACP `content[]`) from live session://tool. */
   output?: string | null;
+  /** Typed presentation facts from the Host (validated, bounded JSON). */
+  meta?: import("../toolPresentation").ToolPresentationMeta | null;
   /** Parent tool call id when the wire event includes nesting. */
   parentId?: string | null;
 }

--- a/src/lib/toolPresentation.test.ts
+++ b/src/lib/toolPresentation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  presentToolCall,
+  resolveToolPresentation,
+  toolBucketForCard,
+  toolCardForBucket,
+} from "./toolPresentation";
+
+describe("toolPresentation", () => {
+  it("maps buckets to typed cards", () => {
+    expect(toolCardForBucket("bash")).toBe("terminal");
+    expect(toolCardForBucket("edit")).toBe("diff");
+    expect(toolCardForBucket("read")).toBe("read");
+    expect(toolCardForBucket("search")).toBe("search");
+    expect(toolCardForBucket("browse")).toBe("web");
+    expect(toolCardForBucket("fallback")).toBe("generic");
+    expect(toolBucketForCard("terminal")).toBe("bash");
+    expect(toolBucketForCard("generic")).toBe("fallback");
+  });
+
+  it("derives search query/count/domains without throwing", () => {
+    const meta = presentToolCall({
+      toolKind: "web_search",
+      title: "Web search: hello",
+      detail: "12 results\nhttps://a.com/x\nhttps://b.com/y",
+    });
+    expect(meta.card).toBe("search");
+    expect(meta.query).toBe("hello");
+    expect(meta.resultCount).toBe(12);
+    expect(meta.resultDomains).toEqual(["a.com", "b.com"]);
+  });
+
+  it("falls back to generic for unknown tools (never throws)", () => {
+    const meta = presentToolCall({
+      toolKind: "enter_plan_mode",
+      title: "tool",
+    });
+    expect(meta.card).toBe("generic");
+    expect(meta.toolKind).toBe("enter_plan_mode");
+  });
+
+  it("prefers explicit Host meta but fills gaps from derivation", () => {
+    const out = resolveToolPresentation(
+      { toolKind: "web_search", title: "Web search: q", detail: "5 results" },
+      { card: "search" },
+    );
+    expect(out.card).toBe("search");
+    expect(out.query).toBe("q");
+    expect(out.resultCount).toBe(5);
+  });
+
+  it("rejects malformed explicit meta to derivation", () => {
+    const out = resolveToolPresentation(
+      { toolKind: "read_file", path: "/a/b.ts" },
+      { card: "nope" } as unknown as { card: "search" },
+    );
+    expect(out.card).toBe("read");
+    expect(out.pathBase).toBe("b.ts");
+  });
+
+  it("prefers browse path URL over generic Fetch title", () => {
+    const meta = presentToolCall({
+      toolKind: "web_fetch",
+      title: "Fetch",
+      path: "https://developer.apple.com/cn/programs/enroll/",
+    });
+    expect(meta.card).toBe("web");
+    expect(meta.query).toBe("https://developer.apple.com/cn/programs/enroll/");
+  });
+});

--- a/src/lib/toolPresentation.ts
+++ b/src/lib/toolPresentation.ts
@@ -1,0 +1,265 @@
+/**
+ * Tool presentation meta — DSH-inspired presenter/card split.
+ *
+ * `presentToolCall` is a pure view-model derivation from recorded call fields
+ * (kind/title/input/path/detail). An explicit `meta` from the Host (future
+ * `tool/result.meta`) always wins via `resolveToolPresentation`; otherwise we
+ * derive so replayed journals still get a typed card instead of bare generic.
+ *
+ * No I/O, no session reads, no clock — safe for live stream + log replay.
+ */
+
+import {
+  classifyToolKind,
+  toolInputDisplay,
+  toolPathBase,
+  type ToolDisplayKind,
+} from "./toolDisplay";
+
+/** Typed card the Web UI should paint for a tool call. */
+export type ToolPresentationCard =
+  | "terminal"
+  | "diff"
+  | "read"
+  | "search"
+  | "web"
+  | "generic";
+
+/**
+ * Bounded structured facts for the card. Only plain JSON — never React props,
+ * selection state, or raw stdout bodies (those stay in `output`/`detail`).
+ */
+export interface ToolPresentationMeta {
+  card: ToolPresentationCard;
+  /** Search/browse query (target file / command / url already in input/path). */
+  query?: string;
+  /** Parsed `N results` count from detail when present. */
+  resultCount?: number;
+  /** Host domains mentioned in detail (max 3, for favicon chips). */
+  resultDomains?: string[];
+  /** File/dir base name when the tool acted on a path. */
+  pathBase?: string;
+  /** Machine tool name that produced this card (e.g. enter_plan_mode). */
+  toolKind?: string;
+}
+
+export interface ToolPresentationSource {
+  toolCallId?: string | null;
+  toolKind?: string | null;
+  title?: string | null;
+  input?: string | null;
+  path?: string | null;
+  detail?: string | null;
+}
+
+function extractQuery(
+  source: ToolPresentationSource,
+  bucket: ToolDisplayKind,
+): string | undefined {
+  if (bucket !== "search" && bucket !== "browse") return undefined;
+  const fromInput = (source.input || "").trim();
+  if (fromInput) {
+    // Input may be a full URL for browse — keep it clipped, UI shortens host.
+    return fromInput.length > 120 ? `${fromInput.slice(0, 119)}…` : fromInput;
+  }
+  // Browse prefers an explicit URL in path/detail over a generic title like
+  // "Fetch" (ACP `Fetch: https://…` titles aside — those carry the URL).
+  if (bucket === "browse") {
+    const pathUrl = (source.path || "").trim();
+    if (pathUrl) return pathUrl.slice(0, 120);
+    const titleFetch = (source.title || "").match(
+      /^fetch:\s*(https?:\/\/\S+)/i,
+    );
+    if (titleFetch?.[1]?.trim()) return titleFetch[1].trim().slice(0, 120);
+  }
+  const title = (source.title || "").trim();
+  const m = title.match(/^(?:web\s*search|search|x\s*search)\s*[:：]\s*(.+)$/i);
+  if (m?.[1]?.trim()) return m[1].trim().slice(0, 120);
+  if (
+    title &&
+    !/^tool$/i.test(title) &&
+    !/^web\s*search:?$/i.test(title) &&
+    !/^search$/i.test(title) &&
+    // Generic browse placeholders must not become the query/URL.
+    !/^(fetch|browse|open(\s+page|\s+url)?|web\s*fetch)$/i.test(title)
+  ) {
+    return title.slice(0, 120);
+  }
+  const detail = (source.detail || "").trim();
+  if (detail) {
+    for (const line of detail.split(/\r?\n/)) {
+      const t = line.trim();
+      if (!t) continue;
+      if (/^https?:\/\//i.test(t)) continue;
+      if (/^\d+\s*results?/i.test(t)) continue;
+      return t.slice(0, 120);
+    }
+  }
+  return undefined;
+}
+
+function extractResultCount(detail: string | null | undefined): number | undefined {
+  const blob = `${detail || ""}`;
+  const m = blob.match(/(\d+)\s*results?/i);
+  if (!m) return undefined;
+  const n = Number(m[1]);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function extractResultDomains(
+  detail: string | null | undefined,
+  max = 3,
+): string[] | undefined {
+  const blob = detail || "";
+  if (!blob) return undefined;
+  const found: string[] = [];
+  const re = /https?:\/\/([^/\s)\]"'<>]+)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(blob)) && found.length < max) {
+    const host = m[1]!.toLowerCase().replace(/^www\./, "");
+    if (host && !found.includes(host)) found.push(host);
+  }
+  return found.length ? found : undefined;
+}
+
+export function toolCardForBucket(bucket: ToolDisplayKind): ToolPresentationCard {
+  switch (bucket) {
+    case "bash":
+      return "terminal";
+    case "edit":
+      return "diff";
+    case "read":
+      return "read";
+    case "search":
+      return "search";
+    case "browse":
+      return "web";
+    default:
+      return "generic";
+  }
+}
+
+export function toolBucketForCard(card: ToolPresentationCard): ToolDisplayKind {
+  switch (card) {
+    case "terminal":
+      return "bash";
+    case "diff":
+      return "edit";
+    case "read":
+      return "read";
+    case "search":
+      return "search";
+    case "web":
+      return "browse";
+    default:
+      return "fallback";
+  }
+}
+
+/**
+ * Pure derivation: recorded call fields → typed card + bounded facts.
+ * Never throws; unknown tools fall back to `generic` (DSH GenericToolCard).
+ */
+export function presentToolCall(
+  source: ToolPresentationSource,
+): ToolPresentationMeta {
+  const bucket = classifyToolKind(
+    source.toolKind,
+    source.title,
+    source.toolCallId,
+  );
+  const card = toolCardForBucket(bucket);
+  const meta: ToolPresentationMeta = { card };
+  const kind = (source.toolKind || "").trim();
+  if (kind) meta.toolKind = kind;
+  const query = extractQuery(source, bucket);
+  if (query) meta.query = query;
+  // Search/web cards benefit from parsed counts/domains without re-scanning
+  // strings at paint time (log replay + live share one path).
+  if (card === "search" || card === "web") {
+    const count = extractResultCount(source.detail);
+    if (count != null) meta.resultCount = count;
+    const domains = extractResultDomains(source.detail);
+    if (domains) meta.resultDomains = domains;
+  }
+  // Keep the specific call detail alongside the card for the one-line label:
+  // prefer input-derived basename, fall back to path basename.
+  const specific = toolInputDisplay(source.input, bucket);
+  const base = toolPathBase(source.path);
+  const label = specific || base;
+  if (label && card !== "search" && card !== "web") {
+    // Path-ish cards surface basename; terminal keeps full snippet in input.
+    if (card === "read" || card === "diff") meta.pathBase = label;
+    else if (card === "terminal" && source.input?.trim()) {
+      // Terminal card title already shows the command via input display.
+    } else if (card === "generic" && label) {
+      meta.pathBase = label;
+    }
+  } else if (base && (card === "read" || card === "diff")) {
+    meta.pathBase = base;
+  }
+  return meta;
+}
+
+/**
+ * Resolve the card to paint: explicit Host meta wins (validated shape only),
+ * otherwise derive. Never throws; malformed explicit meta falls back to
+ * derivation (then generic) — the transcript must never break on old logs.
+ */
+export function resolveToolPresentation(
+  source: ToolPresentationSource,
+  explicit?: ToolPresentationMeta | null,
+): ToolPresentationMeta {
+  if (explicit && typeof explicit === "object") {
+    const card = explicit.card;
+    if (
+      card === "terminal" ||
+      card === "diff" ||
+      card === "read" ||
+      card === "search" ||
+      card === "web" ||
+      card === "generic"
+    ) {
+      const out: ToolPresentationMeta = { card };
+      if (typeof explicit.query === "string" && explicit.query.trim()) {
+        out.query = explicit.query.slice(0, 120);
+      }
+      if (
+        typeof explicit.resultCount === "number" &&
+        Number.isFinite(explicit.resultCount) &&
+        explicit.resultCount >= 0
+      ) {
+        out.resultCount = Math.floor(explicit.resultCount);
+      }
+      if (Array.isArray(explicit.resultDomains)) {
+        const domains = explicit.resultDomains
+          .filter((d): d is string => typeof d === "string" && !!d.trim())
+          .map((d) => d.trim().slice(0, 64))
+          .slice(0, 3);
+        if (domains.length) out.resultDomains = domains;
+      }
+      if (typeof explicit.pathBase === "string" && explicit.pathBase.trim()) {
+        out.pathBase = explicit.pathBase.slice(0, 64);
+      }
+      if (typeof explicit.toolKind === "string" && explicit.toolKind.trim()) {
+        out.toolKind = explicit.toolKind.slice(0, 64);
+      } else if ((source.toolKind || "").trim()) {
+        out.toolKind = source.toolKind!.trim().slice(0, 64);
+      }
+      // Explicit card without query still benefits from derived query/counts.
+      if (!out.query || out.resultCount == null || !out.resultDomains) {
+        const derived = presentToolCall(source);
+        return {
+          ...derived,
+          ...out,
+          query: out.query ?? derived.query,
+          resultCount: out.resultCount ?? derived.resultCount,
+          resultDomains: out.resultDomains ?? derived.resultDomains,
+          pathBase: out.pathBase ?? derived.pathBase,
+        };
+      }
+      return out;
+    }
+  }
+  return presentToolCall(source);
+}


### PR DESCRIPTION
Introduce a pure tool presentation layer: recorded call fields derive a typed card (terminal/diff/read/search/web/generic) with bounded facts (query, result count/domains, path base). An explicit host meta field on tool events/segments/rows wins when present and is preserved across live updates, coalescing, weaving, and replay; otherwise the UI derives the same card so old journals keep a typed icon/label instead of bare generic. Activity rail prefers the typed facts with existing string parsing as fallback.