### PR TITLE
feat(chat): turn process summary with compact tail line

### DIFF
--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -167,10 +167,12 @@ import {
   toolSegmentIsRunning,
 } from "./TimelineToolRow";
 import { TimelinePhaseBlock } from "./TimelinePhaseBlock";
+import { TurnTail } from "./TurnTail";
 import {
   buildAssistantTimeline,
   shouldShowTrailingLiveThinking,
 } from "@/lib/timelinePhases";
+import { estimateDurationSecFromTimestamps } from "@/lib/formatWorkDuration";
 import { resolveChatTranscriptEmptyState } from "@/lib/chatTranscriptEmpty";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -1741,6 +1743,26 @@ const TranscriptMessageRow = memo(function TranscriptMessageRow({
               >
                 {tr("message.replyLength", { words, chars })}
               </div>
+            );
+          })()}
+          {(() => {
+            if (m.streaming) return null;
+            const stamps: Array<string | undefined | null> = [m.createdAt];
+            for (const u of timelineUnits) {
+              if (u.kind === "phase") {
+                for (const t of u.tools) stamps.push(t.createdAt);
+              } else if (u.kind === "tool") {
+                stamps.push(u.tool.createdAt);
+              }
+            }
+            const durationSec = estimateDurationSecFromTimestamps(stamps);
+            return (
+              <TurnTail
+                units={timelineUnits}
+                locale={locale}
+                streaming={!!m.streaming}
+                durationSec={durationSec}
+              />
             );
           })()}
         </div>

--- a/src/components/lobe-chat/TurnTail.tsx
+++ b/src/components/lobe-chat/TurnTail.tsx
@@ -1,0 +1,61 @@
+/**
+ * Turn tail — DSH-inspired `turn-tail` footer for finished assistant turns.
+ *
+ * Shows `Worked for Xs · Ran N tools` (existing `chat.*` keys only, no new
+ * catalog entries). Pure summary line; the full Worked-for rail stays as the
+ * expandable activity source. Renders nothing while streaming or for turns
+ * without real work.
+ */
+
+import { memo, useMemo } from "react";
+import type { Locale } from "@/i18n";
+import { createT } from "@/i18n";
+import { formatWorkDuration } from "@/lib/formatWorkDuration";
+import type { TimelineUnit } from "@/lib/timelinePhases";
+import {
+  buildTurnProcessSummary,
+  shouldCompactTurnProcess,
+} from "@/lib/turnProcess";
+
+export const TurnTail = memo(function TurnTail({
+  units,
+  locale,
+  streaming,
+  durationSec,
+}: {
+  units: TimelineUnit[];
+  locale: Locale;
+  streaming?: boolean;
+  /** History duration seconds (phase rail already computes this). */
+  durationSec?: number | null;
+}) {
+  const tr = useMemo(() => createT(locale), [locale]);
+  const summary = useMemo(() => buildTurnProcessSummary(units), [units]);
+  if (streaming) return null;
+  if (!shouldCompactTurnProcess(summary)) return null;
+  const parts: string[] = [];
+  if (durationSec != null && Number.isFinite(durationSec) && durationSec > 0) {
+    parts.push(
+      tr("chat.workedFor", {
+        duration: formatWorkDuration(durationSec, locale),
+      }),
+    );
+  }
+  if (summary.toolCount > 0) {
+    parts.push(
+      tr("chat.ranTools", {
+        n: summary.toolCount,
+      }),
+    );
+  }
+  if (!parts.length) return null;
+  return (
+    <div
+      className="lobe-chat-reply-length"
+      data-testid="turn-tail"
+      aria-label={parts.join(" · ")}
+    >
+      {parts.join(" · ")}
+    </div>
+  );
+});

--- a/src/lib/turnProcess.test.ts
+++ b/src/lib/turnProcess.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineUnit } from "./timelinePhases";
+import { buildTurnProcessSummary, shouldCompactTurnProcess } from "./turnProcess";
+
+function tool(id: string, toolKind: string): TimelineUnit {
+  return {
+    kind: "tool",
+    si: 0,
+    tool: {
+      kind: "tool",
+      toolCallId: id,
+      title: toolKind,
+      toolKind,
+      status: "completed",
+    },
+  };
+}
+
+describe("turnProcess", () => {
+  it("counts tools by bucket and replies", () => {
+    const units: TimelineUnit[] = [
+      tool("a", "read_file"),
+      tool("b", "grep"),
+      { kind: "content", text: "hello", si: 2, streaming: false },
+    ];
+    const s = buildTurnProcessSummary(units);
+    expect(s.toolCount).toBe(2);
+    expect(s.readCount).toBe(1);
+    expect(s.searchCount).toBe(1);
+    expect(s.replyCount).toBe(1);
+    expect(s.hasFinalAnswer).toBe(true);
+    expect(shouldCompactTurnProcess(s)).toBe(true);
+  });
+
+  it("does not compact tool-only turns (no final answer)", () => {
+    const s = buildTurnProcessSummary([tool("a", "read_file")]);
+    expect(s.hasFinalAnswer).toBe(false);
+    expect(shouldCompactTurnProcess(s)).toBe(false);
+  });
+
+  it("dedupes repeated toolCallId updates", () => {
+    const s = buildTurnProcessSummary([
+      tool("same", "read_file"),
+      tool("same", "read_file"),
+    ]);
+    expect(s.toolCount).toBe(1);
+  });
+});

--- a/src/lib/turnProcess.ts
+++ b/src/lib/turnProcess.ts
@@ -1,0 +1,97 @@
+/**
+ * Turn-process summary — DSH-inspired compact control bar model.
+ *
+ * Pure counts derived from the assistant timeline (tools + body), so the UI
+ * can collapse a long pre-answer work burst behind `Tool N · Reply M` instead
+ * of painting every row. No i18n here; components localize via existing
+ * `chat.*` keys (`chat.ranTools`, `chat.workedFor`, …).
+ */
+
+import type { MessageToolSegment } from "./session";
+import { classifyToolKind } from "./toolDisplay";
+import type { TimelineUnit } from "./timelinePhases";
+
+export interface TurnProcessSummary {
+  toolCount: number;
+  searchCount: number;
+  readCount: number;
+  editCount: number;
+  bashCount: number;
+  browseCount: number;
+  subagentCount: number;
+  errorCount: number;
+  runningCount: number;
+  /** Non-empty assistant body fragments (final-answer candidates). */
+  replyCount: number;
+  /** True when the turn already shows a visible final answer. */
+  hasFinalAnswer: boolean;
+}
+
+function toolFailed(t: MessageToolSegment): boolean {
+  if (t.isError) return true;
+  const s = (t.status || "").toLowerCase();
+  return s === "failed" || s === "error" || s === "rejected" || s === "denied";
+}
+
+function toolRunning(t: MessageToolSegment): boolean {
+  if (t.streaming) return true;
+  const s = (t.status || "").toLowerCase().trim();
+  if (!s) return false;
+  return s === "in_progress" || s === "pending" || s === "running";
+}
+
+/** Summarize one assistant message's timeline units (phase-aware). */
+export function buildTurnProcessSummary(units: TimelineUnit[]): TurnProcessSummary {
+  const summary: TurnProcessSummary = {
+    toolCount: 0,
+    searchCount: 0,
+    readCount: 0,
+    editCount: 0,
+    bashCount: 0,
+    browseCount: 0,
+    subagentCount: 0,
+    errorCount: 0,
+    runningCount: 0,
+    replyCount: 0,
+    hasFinalAnswer: false,
+  };
+  const seenTools = new Set<string>();
+  const countTool = (t: MessageToolSegment) => {
+    const key = t.toolCallId || `${t.toolKind}:${t.title}`;
+    if (seenTools.has(key)) return;
+    seenTools.add(key);
+    summary.toolCount += 1;
+    const bucket = classifyToolKind(t.toolKind, t.title, t.toolCallId);
+    if (bucket === "search") summary.searchCount += 1;
+    else if (bucket === "read") summary.readCount += 1;
+    else if (bucket === "edit") summary.editCount += 1;
+    else if (bucket === "bash") summary.bashCount += 1;
+    else if (bucket === "browse") summary.browseCount += 1;
+    else if (bucket === "subagent") summary.subagentCount += 1;
+    if (toolFailed(t)) summary.errorCount += 1;
+    if (toolRunning(t)) summary.runningCount += 1;
+  };
+  for (const u of units) {
+    if (u.kind === "phase") {
+      for (const t of u.tools) countTool(t);
+    } else if (u.kind === "tool") {
+      countTool(u.tool);
+    } else if (u.kind === "content") {
+      if (u.text.trim()) {
+        summary.replyCount += 1;
+        summary.hasFinalAnswer = true;
+      }
+    }
+  }
+  return summary;
+}
+
+/**
+ * Whether the compact control bar is worthwhile (vs the full Worked-for rail).
+ * Matches DSH Compact: collapse pre-answer work when there is real work and a
+ * visible answer; keep full rail for tool-only / thinking-only turns.
+ */
+export function shouldCompactTurnProcess(summary: TurnProcessSummary): boolean {
+  if (!summary.hasFinalAnswer) return false;
+  return summary.toolCount >= 2;
+}


### PR DESCRIPTION
Add a pure turn-process summary (tool counts by bucket, errors, running, reply presence) with a compact threshold for turns that already show a final answer. Render a muted tail line under finished assistant turns (Worked for duration, Ran N tools) using existing chat copy, reusing the reply-length style. No new catalog keys and no journal format change.