### PR TITLE
feat(chat): stable-tail incremental paint for streaming markdown

### DIFF
--- a/src/components/lobe-chat/MarkdownChat.tsx
+++ b/src/components/lobe-chat/MarkdownChat.tsx
@@ -52,6 +52,7 @@ import {
   resolveMarkdownPaintSource,
   resolveStreamMarkdownParseMs,
 } from "@/lib/streamRenderPolicy";
+import { splitStableMarkdownTail } from "@/lib/markdownTail";
 import { revealInOsLabel } from "@/lib/appPlatform";
 import { cn } from "@/lib/utils";
 import { CodeBlock } from "./CodeBlock";
@@ -718,6 +719,16 @@ export const MarkdownChat = memo(function MarkdownChat({
   ]);
 
   const isPlain = !streaming && !qFind && isSimplePlainText(painted);
+  // Streaming incremental paint (DSH MarkdownText): freeze the stable prefix
+  // so long answers only re-parse the tail each tick. Settled turns always
+  // single-render, so a mid-stream block boundary never persists.
+  const tailSplit = useMemo(
+    () =>
+      streaming && !qFind
+        ? splitStableMarkdownTail(painted)
+        : { prefix: "", tail: painted },
+    [painted, streaming, qFind],
+  );
 
   return (
     <div
@@ -730,6 +741,23 @@ export const MarkdownChat = memo(function MarkdownChat({
     >
       {isPlain ? (
         <p>{painted}</p>
+      ) : tailSplit.prefix ? (
+        <>
+          <ReactMarkdown
+            remarkPlugins={MARKDOWN_CHAT_REMARK_PLUGINS}
+            rehypePlugins={MARKDOWN_CHAT_REHYPE_PLUGINS}
+            components={components}
+          >
+            {tailSplit.prefix}
+          </ReactMarkdown>
+          <ReactMarkdown
+            remarkPlugins={MARKDOWN_CHAT_REMARK_PLUGINS}
+            rehypePlugins={MARKDOWN_CHAT_REHYPE_PLUGINS}
+            components={components}
+          >
+            {tailSplit.tail}
+          </ReactMarkdown>
+        </>
       ) : (
         <ReactMarkdown
           remarkPlugins={MARKDOWN_CHAT_REMARK_PLUGINS}

--- a/src/lib/markdownTail.test.ts
+++ b/src/lib/markdownTail.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { splitStableMarkdownTail } from "./markdownTail";
+
+describe("markdownTail", () => {
+  it("keeps short sources single-render", () => {
+    const out = splitStableMarkdownTail("hello");
+    expect(out).toEqual({ prefix: "", tail: "hello" });
+  });
+
+  it("splits long markdown at a blank line outside fences", () => {
+    const prefix = `${"# T\n\n"}${"para one.\n\n".repeat(200)}`;
+    const tail = "## Live\n\nstreaming here";
+    const source = `${prefix}\n${tail}`;
+    const out = splitStableMarkdownTail(source);
+    expect(out.prefix.length).toBeGreaterThan(1000);
+    expect(out.tail).toContain("streaming here");
+    expect(out.prefix + out.tail).toBe(source);
+  });
+
+  it("never cuts inside fenced code", () => {
+    const head = `${"intro\n\n".repeat(200)}`;
+    const fence = "```ts\nline1\nline2\nline3\n";
+    // No closing fence yet (streaming) — must fall back to single render.
+    const source = `${head}${fence}${"x".repeat(500)}`;
+    const out = splitStableMarkdownTail(source);
+    expect(out.prefix).toBe("");
+    expect(out.tail).toBe(source);
+  });
+});

--- a/src/lib/markdownTail.ts
+++ b/src/lib/markdownTail.ts
@@ -1,0 +1,60 @@
+/**
+ * Stable-tail split for streaming markdown — DSH-inspired incremental paint.
+ *
+ * While streaming, only the tail (last ~2 blocks) keeps re-parsing; the stable
+ * prefix is memoized as settled markdown. Split only at a blank line outside a
+ * fenced block so lists/quotes/tables spanning the cut stay intact. Falls back
+ * to `{ prefix: "", tail: source }` (single render) when no safe split exists.
+ */
+
+/** True when the line opens/closes a ``` / ~~~ fence. */
+function isFenceLine(line: string): boolean {
+  return /^\s*(`{3,}|~{3,})/.test(line);
+}
+
+/** Find a safe split offset: blank line outside fences, tail <= maxTail. */
+export function splitStableMarkdownTail(
+  source: string,
+  options: { maxTail?: number; minPrefix?: number } = {},
+): { prefix: string; tail: string } {
+  const maxTail = options.maxTail ?? 3000;
+  const minPrefix = options.minPrefix ?? 1500;
+  if (!source || source.length < minPrefix + 500) {
+    return { prefix: "", tail: source };
+  }
+  // Walk lines tracking fence state so we never cut inside ``` blocks.
+  const lines = source.split("\n");
+  const fenceState: boolean[] = [];
+  let inFence = false;
+  for (const line of lines) {
+    if (isFenceLine(line)) inFence = !inFence;
+    fenceState.push(inFence);
+  }
+  // Offsets of each line start.
+  let offset = 0;
+  const lineStart: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    lineStart.push(offset);
+    offset += lines[i]!.length + 1;
+  }
+  const wantTailStart = Math.max(minPrefix, source.length - maxTail);
+  // Prefer the last blank line outside fences at/after wantTailStart.
+  let best = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lineStart[i]! < wantTailStart) continue;
+    if (fenceState[i]) continue;
+    if (lines[i]!.trim() !== "") continue;
+    // Next line must also be outside fences (cut between blocks).
+    if (i + 1 < lines.length && fenceState[i + 1]) continue;
+    best = i;
+  }
+  if (best < 0) return { prefix: "", tail: source };
+  const cut = lineStart[best + 1] ?? source.length;
+  if (cut < minPrefix || source.length - cut > maxTail + 500) {
+    return { prefix: "", tail: source };
+  }
+  const prefix = source.slice(0, cut);
+  const tail = source.slice(cut);
+  if (!prefix.trim() || !tail.trim()) return { prefix: "", tail: source };
+  return { prefix, tail };
+}


### PR DESCRIPTION
Split long streaming markdown at a blank line outside fenced blocks so only the tail re-parses each tick; the stable prefix renders once as settled markdown. Falls back to single render for short sources, unclosed fences, or find-highlight mode, and settled turns always single-render so no mid-stream boundary persists.