### PR TITLE
fix(composer): quote Enter send + shared send-key pref (#1015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Changed
-- The quote comment box uses the same Enter / Ctrl+Enter send shortcut as the composer. A checkbox on the bar toggles it.
+- The quote comment box submits with Enter (Shift+Enter for a new line). It does not follow the composer send-key setting.
 
 **中文 · 变更**
-- 划词评论框与输入框共用 Enter / Ctrl+Enter 发送快捷键。栏上的复选框可切换。
+- 划词评论框用 Enter 提交（Shift+Enter 换行）。不跟输入框的发送快捷键设置走。
 
 ### Fixed
 - Windows Explorer drag-drop works again (sidebar add project, chat attach). No more forbidden cursor after a hidden window create (#1017).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Changed
-- The quote comment box submits with Enter (Shift+Enter for a new line). It does not follow the composer send-key setting.
+- The quote comment box uses the same Enter / Ctrl+Enter send shortcut as the composer.
 
 **中文 · 变更**
-- 划词评论框用 Enter 提交（Shift+Enter 换行）。不跟输入框的发送快捷键设置走。
+- 划词评论框与输入框共用 Enter / Ctrl+Enter 发送快捷键。
 
 ### Fixed
 - Windows Explorer drag-drop works again (sidebar add project, chat attach). No more forbidden cursor after a hidden window create (#1017).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ See `docs/llm-wiki/release.md`.
 
 ### Fixed
 - Windows Explorer drag-drop works again (sidebar add project, chat attach). No more forbidden cursor after a hidden window create (#1017).
+- Enter in the composer sends a quote card even when the input is empty.
 
 **中文 · 修复**
 - Windows 从资源管理器拖文件/文件夹恢复可用（侧栏加项目、聊天加附件），不再显示禁止光标（#1017）。
+- 只有引用卡、输入框是空的时候，回车也能发出去。
 
 ## [0.2.31] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Changed
+- The quote comment box uses the same Enter / Ctrl+Enter send shortcut as the composer. A checkbox on the bar toggles it.
+
+**中文 · 变更**
+- 划词评论框与输入框共用 Enter / Ctrl+Enter 发送快捷键。栏上的复选框可切换。
+
 ### Fixed
 - Windows Explorer drag-drop works again (sidebar add project, chat attach). No more forbidden cursor after a hidden window create (#1017).
 - Enter in the composer sends a quote card even when the input is empty.

--- a/src-tauri/src/win_file_drop.rs
+++ b/src-tauri/src/win_file_drop.rs
@@ -257,9 +257,7 @@ impl FileDropTarget {
             tymed: TYMED_HGLOBAL.0 as u32,
         };
 
-        let Some(obj) = data_obj.as_ref() else {
-            return None;
-        };
+        let obj = data_obj.as_ref()?;
         let medium = obj.GetData(&drop_format).ok()?;
         let hdrop = HDROP(medium.u.hGlobal.0 as _);
         let item_count = DragQueryFileW(hdrop, 0xFFFFFFFF, None);

--- a/src-tauri/src/win_file_drop.rs
+++ b/src-tauri/src/win_file_drop.rs
@@ -303,8 +303,7 @@ impl IDropTarget_Impl for FileDropTarget_Impl {
     ) -> windows::core::Result<()> {
         let (x, y) = FileDropTarget::client_point(self.hwnd, pt);
         let mut paths = Vec::new();
-        let hdrop =
-            unsafe { FileDropTarget::iterate_filenames(pDataObj, |path| paths.push(path)) };
+        let hdrop = unsafe { FileDropTarget::iterate_filenames(pDataObj, |path| paths.push(path)) };
         let enter_is_valid = hdrop.is_some() && !paths.is_empty();
         unsafe {
             *self.enter_is_valid.get() = enter_is_valid;

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -424,6 +424,7 @@ import {
 } from "@/lib/composerSessionDraft";
 import {
   appendQuotesToContent,
+  composerHasSendPayload,
   makeComposerQuoteId,
   serializeQuotesForAgent,
   type ComposerQuote,
@@ -12889,15 +12890,15 @@ export function AppWorkbench() {
 
   const onThreadAddQuote = useCallback(
     (quote: { text: string; comment: string; sourceMessageId?: string }) => {
-      setQuotes((prev) => [
-        ...prev,
-        {
-          id: makeComposerQuoteId(),
-          text: quote.text,
-          comment: quote.comment,
-          sourceMessageId: quote.sourceMessageId,
-        },
-      ]);
+      const next: ComposerQuote = {
+        id: makeComposerQuoteId(),
+        text: quote.text,
+        comment: quote.comment,
+        sourceMessageId: quote.sourceMessageId,
+      };
+      // Ref first so Enter-to-send in the same frame sees the card.
+      quotesRef.current = [...quotesRef.current, next];
+      setQuotes(quotesRef.current);
     },
     [setQuotes],
   );
@@ -13585,10 +13586,12 @@ export function AppWorkbench() {
     if (submit === "send") {
       e.preventDefault();
       const draftNow = getDraft();
-      const hasBody =
-        !isDraftEmpty(parseStoredContent(draftNow)) ||
-        attachments.length > 0 ||
-        chatAttachments.length > 0;
+      const hasBody = composerHasSendPayload({
+        draftEmpty: isDraftEmpty(parseStoredContent(draftNow)),
+        attachmentCount: attachments.length,
+        chatAttachmentCount: chatAttachments.length,
+        quoteCount: quotesRef.current.length,
+      });
       if (hasBody && session.state !== "awaiting_permission") {
         void send();
       }

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -12896,8 +12896,7 @@ export function AppWorkbench() {
         comment: quote.comment,
         sourceMessageId: quote.sourceMessageId,
       };
-      // Ref first so Enter-to-send in the same frame sees the card.
-      quotesRef.current = [...quotesRef.current, next];
+      quotesRef.current = [...quotesRef.current, next]; // same-frame Enter
       setQuotes(quotesRef.current);
     },
     [setQuotes],
@@ -13585,16 +13584,13 @@ export function AppWorkbench() {
     }
     if (submit === "send") {
       e.preventDefault();
-      const draftNow = getDraft();
       const hasBody = composerHasSendPayload({
-        draftEmpty: isDraftEmpty(parseStoredContent(draftNow)),
+        draftEmpty: isDraftEmpty(parseStoredContent(getDraft())),
         attachmentCount: attachments.length,
         chatAttachmentCount: chatAttachments.length,
         quoteCount: quotesRef.current.length,
       });
-      if (hasBody && session.state !== "awaiting_permission") {
-        void send();
-      }
+      if (hasBody && session.state !== "awaiting_permission") void send();
     }
     if (e.key === "Escape") {
       if (promptHistoryOpenRef.current) {

--- a/src/components/TranscriptSelectionToolbar.tsx
+++ b/src/components/TranscriptSelectionToolbar.tsx
@@ -7,11 +7,7 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { IconBlockquote, IconCopy } from "@/components/icons";
-import { UiCheck } from "@/components/settings/shared";
-import {
-  shouldSendOnKeydown,
-  type ComposerSendKeyPref,
-} from "@/lib/composerSendKey";
+import { shouldSendOnKeydown } from "@/lib/composerSendKey";
 
 export type TranscriptSelectionToolbarProps = {
   x: number;
@@ -22,14 +18,12 @@ export type TranscriptSelectionToolbarProps = {
   onCopy: () => void;
   onAddQuote: () => void;
   onClose: () => void;
-  sendPref: ComposerSendKeyPref;
-  onSendPrefChange: (next: ComposerSendKeyPref) => void;
   labels: {
     copy: string;
     addQuote: string;
     commentPlaceholder: string;
     commentSubmit: string;
-    enterToSubmit: string;
+    enterHint: string;
   };
 };
 
@@ -42,8 +36,6 @@ export function TranscriptSelectionToolbar({
   onCopy,
   onAddQuote,
   onClose,
-  sendPref,
-  onSendPrefChange,
   labels,
 }: TranscriptSelectionToolbarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -96,7 +88,7 @@ export function TranscriptSelectionToolbar({
                 ctrlKey: e.ctrlKey,
                 altKey: e.altKey,
               },
-              sendPref,
+              "enter",
             )
           ) {
             e.preventDefault();
@@ -119,12 +111,7 @@ export function TranscriptSelectionToolbar({
             {labels.addQuote}
           </button>
         </div>
-        <UiCheck
-          className="sel-toolbar__enter-pref"
-          checked={sendPref === "enter"}
-          onChange={(on) => onSendPrefChange(on ? "enter" : "mod-enter")}
-          label={labels.enterToSubmit}
-        />
+        <span className="sel-toolbar__enter-hint">{labels.enterHint}</span>
       </div>
     </div>,
     document.body,

--- a/src/components/TranscriptSelectionToolbar.tsx
+++ b/src/components/TranscriptSelectionToolbar.tsx
@@ -7,7 +7,10 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { IconBlockquote, IconCopy } from "@/components/icons";
-import { shouldSendOnKeydown } from "@/lib/composerSendKey";
+import {
+  shouldSendOnKeydown,
+  type ComposerSendKeyPref,
+} from "@/lib/composerSendKey";
 
 export type TranscriptSelectionToolbarProps = {
   x: number;
@@ -18,12 +21,14 @@ export type TranscriptSelectionToolbarProps = {
   onCopy: () => void;
   onAddQuote: () => void;
   onClose: () => void;
+  sendPref: ComposerSendKeyPref;
   labels: {
     copy: string;
     addQuote: string;
     commentPlaceholder: string;
     commentSubmit: string;
     enterHint: string;
+    modEnterHint: string;
   };
 };
 
@@ -36,6 +41,7 @@ export function TranscriptSelectionToolbar({
   onCopy,
   onAddQuote,
   onClose,
+  sendPref,
   labels,
 }: TranscriptSelectionToolbarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -88,7 +94,7 @@ export function TranscriptSelectionToolbar({
                 ctrlKey: e.ctrlKey,
                 altKey: e.altKey,
               },
-              "enter",
+              sendPref,
             )
           ) {
             e.preventDefault();
@@ -111,7 +117,9 @@ export function TranscriptSelectionToolbar({
             {labels.addQuote}
           </button>
         </div>
-        <span className="sel-toolbar__enter-hint">{labels.enterHint}</span>
+        <span className="sel-toolbar__enter-hint">
+          {sendPref === "mod-enter" ? labels.modEnterHint : labels.enterHint}
+        </span>
       </div>
     </div>,
     document.body,

--- a/src/components/TranscriptSelectionToolbar.tsx
+++ b/src/components/TranscriptSelectionToolbar.tsx
@@ -7,6 +7,11 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { IconBlockquote, IconCopy } from "@/components/icons";
+import { UiCheck } from "@/components/settings/shared";
+import {
+  shouldSendOnKeydown,
+  type ComposerSendKeyPref,
+} from "@/lib/composerSendKey";
 
 export type TranscriptSelectionToolbarProps = {
   x: number;
@@ -17,11 +22,14 @@ export type TranscriptSelectionToolbarProps = {
   onCopy: () => void;
   onAddQuote: () => void;
   onClose: () => void;
+  sendPref: ComposerSendKeyPref;
+  onSendPrefChange: (next: ComposerSendKeyPref) => void;
   labels: {
     copy: string;
     addQuote: string;
     commentPlaceholder: string;
     commentSubmit: string;
+    enterToSubmit: string;
   };
 };
 
@@ -34,6 +42,8 @@ export function TranscriptSelectionToolbar({
   onCopy,
   onAddQuote,
   onClose,
+  sendPref,
+  onSendPrefChange,
   labels,
 }: TranscriptSelectionToolbarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -77,25 +87,44 @@ export function TranscriptSelectionToolbar({
         placeholder={labels.commentPlaceholder}
         onChange={(e) => onCommentChange(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+          if (
+            shouldSendOnKeydown(
+              {
+                key: e.key,
+                shiftKey: e.shiftKey,
+                metaKey: e.metaKey,
+                ctrlKey: e.ctrlKey,
+                altKey: e.altKey,
+              },
+              sendPref,
+            )
+          ) {
             e.preventDefault();
             onAddQuote();
           }
         }}
       />
       <div className="sel-toolbar__row">
-        <button type="button" className="sel-toolbar__btn" onClick={onCopy}>
-          <IconCopy size={14} />
-          {labels.copy}
-        </button>
-        <button
-          type="button"
-          className="sel-toolbar__btn sel-toolbar__btn--primary"
-          onClick={onAddQuote}
-        >
-          <IconBlockquote size={14} />
-          {labels.addQuote}
-        </button>
+        <div className="sel-toolbar__actions">
+          <button type="button" className="sel-toolbar__btn" onClick={onCopy}>
+            <IconCopy size={14} />
+            {labels.copy}
+          </button>
+          <button
+            type="button"
+            className="sel-toolbar__btn sel-toolbar__btn--primary"
+            onClick={onAddQuote}
+          >
+            <IconBlockquote size={14} />
+            {labels.addQuote}
+          </button>
+        </div>
+        <UiCheck
+          className="sel-toolbar__enter-pref"
+          checked={sendPref === "enter"}
+          onChange={(on) => onSendPrefChange(on ? "enter" : "mod-enter")}
+          label={labels.enterToSubmit}
+        />
       </div>
     </div>,
     document.body,

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -187,12 +187,6 @@ import {
   loadTranscriptSelectionToolbarPref,
 } from "@/lib/transcriptSelectionToolbarPref";
 import {
-  COMPOSER_SEND_KEY_CHANGED_EVENT,
-  loadComposerSendKeyPref,
-  saveComposerSendKeyPref,
-  type ComposerSendKeyPref,
-} from "@/lib/composerSendKey";
-import {
   TOOL_STEPS_AUTO_COLLAPSE_CHANGE_EVENT,
   loadToolStepsAutoCollapsePref,
 } from "@/lib/toolStepsAutoCollapsePref";
@@ -2115,19 +2109,6 @@ export function ConversationThread({
       );
   }, []);
 
-  const [quoteSendPref, setQuoteSendPref] = useState<ComposerSendKeyPref>(() =>
-    loadComposerSendKeyPref(),
-  );
-  useEffect(() => {
-    const sync = () => setQuoteSendPref(loadComposerSendKeyPref());
-    window.addEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, sync);
-    window.addEventListener("storage", sync);
-    return () => {
-      window.removeEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, sync);
-      window.removeEventListener("storage", sync);
-    };
-  }, []);
-
   /** Finished tool steps start collapsed when true (default). */
   const [toolStepsAutoCollapse, setToolStepsAutoCollapse] = useState(() =>
     loadToolStepsAutoCollapsePref(),
@@ -3331,17 +3312,12 @@ export function ConversationThread({
             )
           }
           onClose={closeSelectionUi}
-          sendPref={quoteSendPref}
-          onSendPrefChange={(next) => {
-            setQuoteSendPref(next);
-            saveComposerSendKeyPref(next);
-          }}
           labels={{
             copy: tr("chat.selectionCopy"),
             addQuote: tr("chat.selectionAddToInput"),
             commentPlaceholder: tr("chat.selectionCommentPlaceholder"),
             commentSubmit: tr("chat.selectionCommentSubmit"),
-            enterToSubmit: tr("chat.selectionEnterToSubmit"),
+            enterHint: tr("chat.selectionEnterHint"),
           }}
         />
       ) : null}

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -187,6 +187,12 @@ import {
   loadTranscriptSelectionToolbarPref,
 } from "@/lib/transcriptSelectionToolbarPref";
 import {
+  COMPOSER_SEND_KEY_CHANGED_EVENT,
+  loadComposerSendKeyPref,
+  saveComposerSendKeyPref,
+  type ComposerSendKeyPref,
+} from "@/lib/composerSendKey";
+import {
   TOOL_STEPS_AUTO_COLLAPSE_CHANGE_EVENT,
   loadToolStepsAutoCollapsePref,
 } from "@/lib/toolStepsAutoCollapsePref";
@@ -2109,6 +2115,19 @@ export function ConversationThread({
       );
   }, []);
 
+  const [quoteSendPref, setQuoteSendPref] = useState<ComposerSendKeyPref>(() =>
+    loadComposerSendKeyPref(),
+  );
+  useEffect(() => {
+    const sync = () => setQuoteSendPref(loadComposerSendKeyPref());
+    window.addEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+
   /** Finished tool steps start collapsed when true (default). */
   const [toolStepsAutoCollapse, setToolStepsAutoCollapse] = useState(() =>
     loadToolStepsAutoCollapsePref(),
@@ -3312,11 +3331,17 @@ export function ConversationThread({
             )
           }
           onClose={closeSelectionUi}
+          sendPref={quoteSendPref}
+          onSendPrefChange={(next) => {
+            setQuoteSendPref(next);
+            saveComposerSendKeyPref(next);
+          }}
           labels={{
             copy: tr("chat.selectionCopy"),
             addQuote: tr("chat.selectionAddToInput"),
             commentPlaceholder: tr("chat.selectionCommentPlaceholder"),
             commentSubmit: tr("chat.selectionCommentSubmit"),
+            enterToSubmit: tr("chat.selectionEnterToSubmit"),
           }}
         />
       ) : null}

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -186,6 +186,7 @@ import {
   TRANSCRIPT_SELECTION_TOOLBAR_CHANGE_EVENT,
   loadTranscriptSelectionToolbarPref,
 } from "@/lib/transcriptSelectionToolbarPref";
+import { useComposerSendKeyPref } from "@/hooks/useComposerSendKeyPref";
 import {
   TOOL_STEPS_AUTO_COLLAPSE_CHANGE_EVENT,
   loadToolStepsAutoCollapsePref,
@@ -2092,6 +2093,7 @@ export function ConversationThread({
       window.removeEventListener(BACK_BOTTOM_ALWAYS_CHANGE_EVENT, onPref);
   }, []);
 
+  const quoteSendPref = useComposerSendKeyPref();
   const [selectionToolbar, setSelectionToolbar] = useState(() =>
     loadTranscriptSelectionToolbarPref(),
   );
@@ -3312,12 +3314,14 @@ export function ConversationThread({
             )
           }
           onClose={closeSelectionUi}
+          sendPref={quoteSendPref}
           labels={{
             copy: tr("chat.selectionCopy"),
             addQuote: tr("chat.selectionAddToInput"),
             commentPlaceholder: tr("chat.selectionCommentPlaceholder"),
             commentSubmit: tr("chat.selectionCommentSubmit"),
             enterHint: tr("chat.selectionEnterHint"),
+            modEnterHint: tr("chat.selectionModEnterHint"),
           }}
         />
       ) : null}

--- a/src/hooks/useComposerSendKeyPref.ts
+++ b/src/hooks/useComposerSendKeyPref.ts
@@ -1,0 +1,27 @@
+/**
+ * Live composer send-key preference (Enter vs ⌘/Ctrl+Enter).
+ * Settings and the quote comment box share this value.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  COMPOSER_SEND_KEY_CHANGED_EVENT,
+  loadComposerSendKeyPref,
+  type ComposerSendKeyPref,
+} from "@/lib/composerSendKey";
+
+export function useComposerSendKeyPref(): ComposerSendKeyPref {
+  const [pref, setPref] = useState<ComposerSendKeyPref>(() =>
+    typeof localStorage === "undefined" ? "enter" : loadComposerSendKeyPref(),
+  );
+  useEffect(() => {
+    const sync = () => setPref(loadComposerSendKeyPref());
+    window.addEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(COMPOSER_SEND_KEY_CHANGED_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+  return pref;
+}

--- a/src/i18n/messages/de/chat.ts
+++ b/src/i18n/messages/de/chat.ts
@@ -72,6 +72,7 @@ export const deChat = {
   "chat.selectionComment": "Kommentar",
   "chat.selectionCommentPlaceholder": "Kommentar zu diesem Auszug…",
   "chat.selectionCommentSubmit": "Kommentar hinzufügen",
+  "chat.selectionEnterToSubmit": "Enter zum Hinzufügen",
   "chat.selectionToolbar": "Auswahl",
   "message.edit": "Bearbeiten",
   "message.exportMd": "MD exportieren",

--- a/src/i18n/messages/de/chat.ts
+++ b/src/i18n/messages/de/chat.ts
@@ -72,7 +72,7 @@ export const deChat = {
   "chat.selectionComment": "Kommentar",
   "chat.selectionCommentPlaceholder": "Kommentar zu diesem Auszug…",
   "chat.selectionCommentSubmit": "Kommentar hinzufügen",
-  "chat.selectionEnterToSubmit": "Enter zum Hinzufügen",
+  "chat.selectionEnterHint": "Enter zum Hinzufügen",
   "chat.selectionToolbar": "Auswahl",
   "message.edit": "Bearbeiten",
   "message.exportMd": "MD exportieren",

--- a/src/i18n/messages/de/chat.ts
+++ b/src/i18n/messages/de/chat.ts
@@ -73,6 +73,7 @@ export const deChat = {
   "chat.selectionCommentPlaceholder": "Kommentar zu diesem Auszug…",
   "chat.selectionCommentSubmit": "Kommentar hinzufügen",
   "chat.selectionEnterHint": "Enter zum Hinzufügen",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter zum Hinzufügen",
   "chat.selectionToolbar": "Auswahl",
   "message.edit": "Bearbeiten",
   "message.exportMd": "MD exportieren",

--- a/src/i18n/messages/de/settings.ts
+++ b/src/i18n/messages/de/settings.ts
@@ -258,7 +258,7 @@ export const deSettings = {
   "settings.composerMinRows.5": "5 Zeilen",
   "settings.composerMinRows.8": "8 Zeilen",
   "settings.composerSendKey": "Nachricht senden mit",
-  "settings.composerSendKeyDesc": "Wählen, ob einfaches Enter sendet oder einen Zeilenumbruch einfügt (⌘/Ctrl+Enter sendet dann). Gilt für den Chat-Composer und das Zitat-Kommentarfeld.",
+  "settings.composerSendKeyDesc": "Wählen, ob einfaches Enter sendet oder einen Zeilenumbruch einfügt (⌘/Ctrl+Enter sendet dann). Gilt für den Chat-Composer.",
   "settings.composerSendKey.enter": "Enter zum Senden (Shift+Enter für Zeilenumbruch)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter zum Senden (Enter für Zeilenumbruch)",
   "settings.composerDraftStats": "Entwurfs-Zeichenzahl",

--- a/src/i18n/messages/de/settings.ts
+++ b/src/i18n/messages/de/settings.ts
@@ -258,7 +258,7 @@ export const deSettings = {
   "settings.composerMinRows.5": "5 Zeilen",
   "settings.composerMinRows.8": "8 Zeilen",
   "settings.composerSendKey": "Nachricht senden mit",
-  "settings.composerSendKeyDesc": "Wählen, ob einfaches Enter sendet oder einen Zeilenumbruch einfügt (⌘/Ctrl+Enter sendet dann). Gilt für den Chat-Composer.",
+  "settings.composerSendKeyDesc": "Wählen, ob einfaches Enter sendet oder einen Zeilenumbruch einfügt (⌘/Ctrl+Enter sendet dann). Gilt für den Chat-Composer und das Zitat-Kommentarfeld.",
   "settings.composerSendKey.enter": "Enter zum Senden (Shift+Enter für Zeilenumbruch)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter zum Senden (Enter für Zeilenumbruch)",
   "settings.composerDraftStats": "Entwurfs-Zeichenzahl",

--- a/src/i18n/messages/en/chat.ts
+++ b/src/i18n/messages/en/chat.ts
@@ -72,6 +72,7 @@ export const enChat = {
   "chat.selectionComment": "Comment",
   "chat.selectionCommentPlaceholder": "Write a comment on this excerpt…",
   "chat.selectionCommentSubmit": "Add comment",
+  "chat.selectionEnterToSubmit": "Enter to add",
   "chat.selectionToolbar": "Selection",
   "message.edit": "Edit",
   "message.exportMd": "Export MD",

--- a/src/i18n/messages/en/chat.ts
+++ b/src/i18n/messages/en/chat.ts
@@ -72,7 +72,7 @@ export const enChat = {
   "chat.selectionComment": "Comment",
   "chat.selectionCommentPlaceholder": "Write a comment on this excerpt…",
   "chat.selectionCommentSubmit": "Add comment",
-  "chat.selectionEnterToSubmit": "Enter to add",
+  "chat.selectionEnterHint": "Enter to add",
   "chat.selectionToolbar": "Selection",
   "message.edit": "Edit",
   "message.exportMd": "Export MD",

--- a/src/i18n/messages/en/chat.ts
+++ b/src/i18n/messages/en/chat.ts
@@ -73,6 +73,7 @@ export const enChat = {
   "chat.selectionCommentPlaceholder": "Write a comment on this excerpt…",
   "chat.selectionCommentSubmit": "Add comment",
   "chat.selectionEnterHint": "Enter to add",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter to add",
   "chat.selectionToolbar": "Selection",
   "message.edit": "Edit",
   "message.exportMd": "Export MD",

--- a/src/i18n/messages/en/settings.ts
+++ b/src/i18n/messages/en/settings.ts
@@ -281,7 +281,7 @@ export const enSettings = {
   "settings.composerMinRows.5": "5 rows",
   "settings.composerMinRows.8": "8 rows",
   "settings.composerSendKey": "Send message with",
-  "settings.composerSendKeyDesc": "Choose whether plain Enter sends, or inserts a newline (⌘/Ctrl+Enter sends instead). Applies to the chat composer.",
+  "settings.composerSendKeyDesc": "Choose whether plain Enter sends, or inserts a newline (⌘/Ctrl+Enter sends instead). Applies to the chat composer and the quote comment box.",
   "settings.composerSendKey.enter": "Enter to send (Shift+Enter for newline)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter to send (Enter for newline)",
   "settings.composerDraftStats": "Draft character count",

--- a/src/i18n/messages/en/settings.ts
+++ b/src/i18n/messages/en/settings.ts
@@ -281,7 +281,7 @@ export const enSettings = {
   "settings.composerMinRows.5": "5 rows",
   "settings.composerMinRows.8": "8 rows",
   "settings.composerSendKey": "Send message with",
-  "settings.composerSendKeyDesc": "Choose whether plain Enter sends, or inserts a newline (⌘/Ctrl+Enter sends instead). Applies to the chat composer and the quote comment box.",
+  "settings.composerSendKeyDesc": "Choose whether plain Enter sends, or inserts a newline (⌘/Ctrl+Enter sends instead). Applies to the chat composer.",
   "settings.composerSendKey.enter": "Enter to send (Shift+Enter for newline)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter to send (Enter for newline)",
   "settings.composerDraftStats": "Draft character count",

--- a/src/i18n/messages/es/chat.ts
+++ b/src/i18n/messages/es/chat.ts
@@ -73,6 +73,7 @@ export const esChat = {
   "chat.selectionCommentPlaceholder": "Escribe un comentario sobre este fragmento…",
   "chat.selectionCommentSubmit": "Añadir comentario",
   "chat.selectionEnterHint": "Intro para añadir",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Intro para añadir",
   "chat.selectionToolbar": "Selección",
   "message.edit": "Editar",
   "message.exportMd": "Exportar MD",

--- a/src/i18n/messages/es/chat.ts
+++ b/src/i18n/messages/es/chat.ts
@@ -72,6 +72,7 @@ export const esChat = {
   "chat.selectionComment": "Comentar",
   "chat.selectionCommentPlaceholder": "Escribe un comentario sobre este fragmento…",
   "chat.selectionCommentSubmit": "Añadir comentario",
+  "chat.selectionEnterToSubmit": "Intro para añadir",
   "chat.selectionToolbar": "Selección",
   "message.edit": "Editar",
   "message.exportMd": "Exportar MD",

--- a/src/i18n/messages/es/chat.ts
+++ b/src/i18n/messages/es/chat.ts
@@ -72,7 +72,7 @@ export const esChat = {
   "chat.selectionComment": "Comentar",
   "chat.selectionCommentPlaceholder": "Escribe un comentario sobre este fragmento…",
   "chat.selectionCommentSubmit": "Añadir comentario",
-  "chat.selectionEnterToSubmit": "Intro para añadir",
+  "chat.selectionEnterHint": "Intro para añadir",
   "chat.selectionToolbar": "Selección",
   "message.edit": "Editar",
   "message.exportMd": "Exportar MD",

--- a/src/i18n/messages/es/settings.ts
+++ b/src/i18n/messages/es/settings.ts
@@ -258,7 +258,7 @@ export const esSettings = {
   "settings.composerMinRows.5": "5 filas",
   "settings.composerMinRows.8": "8 filas",
   "settings.composerSendKey": "Enviar mensaje con",
-  "settings.composerSendKeyDesc": "Elige si Intro envía o inserta un salto de línea (⌘/Ctrl+Intro envía). Se aplica al cuadro de mensaje del chat.",
+  "settings.composerSendKeyDesc": "Elige si Intro envía o inserta un salto de línea (⌘/Ctrl+Intro envía). Se aplica al cuadro de mensaje del chat y al comentario de la cita.",
   "settings.composerSendKey.enter": "Intro para enviar (Mayús+Intro para salto de línea)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Intro para enviar (Intro para salto de línea)",
   "settings.composerDraftStats": "Recuento de caracteres del borrador",

--- a/src/i18n/messages/es/settings.ts
+++ b/src/i18n/messages/es/settings.ts
@@ -258,7 +258,7 @@ export const esSettings = {
   "settings.composerMinRows.5": "5 filas",
   "settings.composerMinRows.8": "8 filas",
   "settings.composerSendKey": "Enviar mensaje con",
-  "settings.composerSendKeyDesc": "Elige si Intro envía o inserta un salto de línea (⌘/Ctrl+Intro envía). Se aplica al cuadro de mensaje del chat y al comentario de la cita.",
+  "settings.composerSendKeyDesc": "Elige si Intro envía o inserta un salto de línea (⌘/Ctrl+Intro envía). Se aplica al cuadro de mensaje del chat.",
   "settings.composerSendKey.enter": "Intro para enviar (Mayús+Intro para salto de línea)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Intro para enviar (Intro para salto de línea)",
   "settings.composerDraftStats": "Recuento de caracteres del borrador",

--- a/src/i18n/messages/fil/chat.ts
+++ b/src/i18n/messages/fil/chat.ts
@@ -73,6 +73,7 @@ export const filChat = {
   "chat.selectionCommentPlaceholder": "Sumulat ng komento sa siping ito…",
   "chat.selectionCommentSubmit": "Magdagdag ng komento",
   "chat.selectionEnterHint": "Enter para idagdag",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter para idagdag",
   "chat.selectionToolbar": "Pagpili",
   "message.edit": "I-edit",
   "message.exportMd": "I-export ang MD",

--- a/src/i18n/messages/fil/chat.ts
+++ b/src/i18n/messages/fil/chat.ts
@@ -72,6 +72,7 @@ export const filChat = {
   "chat.selectionComment": "Komento",
   "chat.selectionCommentPlaceholder": "Sumulat ng komento sa siping ito…",
   "chat.selectionCommentSubmit": "Magdagdag ng komento",
+  "chat.selectionEnterToSubmit": "Enter para idagdag",
   "chat.selectionToolbar": "Pagpili",
   "message.edit": "I-edit",
   "message.exportMd": "I-export ang MD",

--- a/src/i18n/messages/fil/chat.ts
+++ b/src/i18n/messages/fil/chat.ts
@@ -72,7 +72,7 @@ export const filChat = {
   "chat.selectionComment": "Komento",
   "chat.selectionCommentPlaceholder": "Sumulat ng komento sa siping ito…",
   "chat.selectionCommentSubmit": "Magdagdag ng komento",
-  "chat.selectionEnterToSubmit": "Enter para idagdag",
+  "chat.selectionEnterHint": "Enter para idagdag",
   "chat.selectionToolbar": "Pagpili",
   "message.edit": "I-edit",
   "message.exportMd": "I-export ang MD",

--- a/src/i18n/messages/fil/settings.ts
+++ b/src/i18n/messages/fil/settings.ts
@@ -258,7 +258,7 @@ export const filSettings = {
   "settings.composerMinRows.5": "5 row",
   "settings.composerMinRows.8": "8 row",
   "settings.composerSendKey": "Ipadala ang mensahe gamit",
-  "settings.composerSendKeyDesc": "Piliin kung magpapadala ang simpleng Enter, o maglalagay ng bagong linya (⌘/Ctrl+Enter ang magpapadala). Naaapply sa composer ng chat.",
+  "settings.composerSendKeyDesc": "Piliin kung magpapadala ang simpleng Enter, o maglalagay ng bagong linya (⌘/Ctrl+Enter ang magpapadala). Naaapply sa composer ng chat at sa comment box ng quote.",
   "settings.composerSendKey.enter": "Enter para magpadala (Shift+Enter para sa bagong linya)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter para magpadala (Enter para sa bagong linya)",
   "settings.composerDraftStats": "Bilang ng character ng draft",

--- a/src/i18n/messages/fil/settings.ts
+++ b/src/i18n/messages/fil/settings.ts
@@ -258,7 +258,7 @@ export const filSettings = {
   "settings.composerMinRows.5": "5 row",
   "settings.composerMinRows.8": "8 row",
   "settings.composerSendKey": "Ipadala ang mensahe gamit",
-  "settings.composerSendKeyDesc": "Piliin kung magpapadala ang simpleng Enter, o maglalagay ng bagong linya (⌘/Ctrl+Enter ang magpapadala). Naaapply sa composer ng chat at sa comment box ng quote.",
+  "settings.composerSendKeyDesc": "Piliin kung magpapadala ang simpleng Enter, o maglalagay ng bagong linya (⌘/Ctrl+Enter ang magpapadala). Naaapply sa composer ng chat.",
   "settings.composerSendKey.enter": "Enter para magpadala (Shift+Enter para sa bagong linya)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter para magpadala (Enter para sa bagong linya)",
   "settings.composerDraftStats": "Bilang ng character ng draft",

--- a/src/i18n/messages/fr/chat.ts
+++ b/src/i18n/messages/fr/chat.ts
@@ -73,6 +73,7 @@ export const frChat = {
   "chat.selectionCommentPlaceholder": "Écrire un commentaire sur cet extrait…",
   "chat.selectionCommentSubmit": "Ajouter un commentaire",
   "chat.selectionEnterHint": "Entrée pour ajouter",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Entrée pour ajouter",
   "chat.selectionToolbar": "Sélection",
   "message.edit": "Modifier",
   "message.exportMd": "Exporter MD",

--- a/src/i18n/messages/fr/chat.ts
+++ b/src/i18n/messages/fr/chat.ts
@@ -72,6 +72,7 @@ export const frChat = {
   "chat.selectionComment": "Commenter",
   "chat.selectionCommentPlaceholder": "Écrire un commentaire sur cet extrait…",
   "chat.selectionCommentSubmit": "Ajouter un commentaire",
+  "chat.selectionEnterToSubmit": "Entrée pour ajouter",
   "chat.selectionToolbar": "Sélection",
   "message.edit": "Modifier",
   "message.exportMd": "Exporter MD",

--- a/src/i18n/messages/fr/chat.ts
+++ b/src/i18n/messages/fr/chat.ts
@@ -72,7 +72,7 @@ export const frChat = {
   "chat.selectionComment": "Commenter",
   "chat.selectionCommentPlaceholder": "Écrire un commentaire sur cet extrait…",
   "chat.selectionCommentSubmit": "Ajouter un commentaire",
-  "chat.selectionEnterToSubmit": "Entrée pour ajouter",
+  "chat.selectionEnterHint": "Entrée pour ajouter",
   "chat.selectionToolbar": "Sélection",
   "message.edit": "Modifier",
   "message.exportMd": "Exporter MD",

--- a/src/i18n/messages/fr/settings.ts
+++ b/src/i18n/messages/fr/settings.ts
@@ -258,7 +258,7 @@ export const frSettings = {
   "settings.composerMinRows.5": "5 lignes",
   "settings.composerMinRows.8": "8 lignes",
   "settings.composerSendKey": "Envoyer le message avec",
-  "settings.composerSendKeyDesc": "Choisir si Entrée seule envoie, ou insère un saut de ligne (⌘/Ctrl+Entrée envoie alors). S’applique à la zone de saisie du chat et à la boîte de commentaire de citation.",
+  "settings.composerSendKeyDesc": "Choisir si Entrée seule envoie, ou insère un saut de ligne (⌘/Ctrl+Entrée envoie alors). S’applique à la zone de saisie du chat.",
   "settings.composerSendKey.enter": "Entrée pour envoyer (Maj+Entrée pour nouvelle ligne)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Entrée pour envoyer (Entrée pour nouvelle ligne)",
   "settings.composerDraftStats": "Compte de caractères du brouillon",

--- a/src/i18n/messages/fr/settings.ts
+++ b/src/i18n/messages/fr/settings.ts
@@ -258,7 +258,7 @@ export const frSettings = {
   "settings.composerMinRows.5": "5 lignes",
   "settings.composerMinRows.8": "8 lignes",
   "settings.composerSendKey": "Envoyer le message avec",
-  "settings.composerSendKeyDesc": "Choisir si Entrée seule envoie, ou insère un saut de ligne (⌘/Ctrl+Entrée envoie alors). S’applique à la zone de saisie du chat.",
+  "settings.composerSendKeyDesc": "Choisir si Entrée seule envoie, ou insère un saut de ligne (⌘/Ctrl+Entrée envoie alors). S’applique à la zone de saisie du chat et à la boîte de commentaire de citation.",
   "settings.composerSendKey.enter": "Entrée pour envoyer (Maj+Entrée pour nouvelle ligne)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Entrée pour envoyer (Entrée pour nouvelle ligne)",
   "settings.composerDraftStats": "Compte de caractères du brouillon",

--- a/src/i18n/messages/id/chat.ts
+++ b/src/i18n/messages/id/chat.ts
@@ -73,6 +73,7 @@ export const idChat = {
   "chat.selectionCommentPlaceholder": "Tulis komentar pada kutipan ini…",
   "chat.selectionCommentSubmit": "Tambah komentar",
   "chat.selectionEnterHint": "Enter untuk menambahkan",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter untuk menambahkan",
   "chat.selectionToolbar": "Pilihan",
   "message.edit": "Sunting",
   "message.exportMd": "Ekspor MD",

--- a/src/i18n/messages/id/chat.ts
+++ b/src/i18n/messages/id/chat.ts
@@ -72,6 +72,7 @@ export const idChat = {
   "chat.selectionComment": "Komentar",
   "chat.selectionCommentPlaceholder": "Tulis komentar pada kutipan ini…",
   "chat.selectionCommentSubmit": "Tambah komentar",
+  "chat.selectionEnterToSubmit": "Enter untuk menambahkan",
   "chat.selectionToolbar": "Pilihan",
   "message.edit": "Sunting",
   "message.exportMd": "Ekspor MD",

--- a/src/i18n/messages/id/chat.ts
+++ b/src/i18n/messages/id/chat.ts
@@ -72,7 +72,7 @@ export const idChat = {
   "chat.selectionComment": "Komentar",
   "chat.selectionCommentPlaceholder": "Tulis komentar pada kutipan ini…",
   "chat.selectionCommentSubmit": "Tambah komentar",
-  "chat.selectionEnterToSubmit": "Enter untuk menambahkan",
+  "chat.selectionEnterHint": "Enter untuk menambahkan",
   "chat.selectionToolbar": "Pilihan",
   "message.edit": "Sunting",
   "message.exportMd": "Ekspor MD",

--- a/src/i18n/messages/id/settings.ts
+++ b/src/i18n/messages/id/settings.ts
@@ -258,7 +258,7 @@ export const idSettings = {
   "settings.composerMinRows.5": "5 baris",
   "settings.composerMinRows.8": "8 baris",
   "settings.composerSendKey": "Kirim pesan dengan",
-  "settings.composerSendKeyDesc": "Pilih apakah Enter biasa mengirim, atau menyisipkan baris baru (⌘/Ctrl+Enter mengirim sebagai gantinya). Berlaku untuk composer obrolan.",
+  "settings.composerSendKeyDesc": "Pilih apakah Enter biasa mengirim, atau menyisipkan baris baru (⌘/Ctrl+Enter mengirim sebagai gantinya). Berlaku untuk composer obrolan dan kotak komentar kutipan.",
   "settings.composerSendKey.enter": "Enter untuk mengirim (Shift+Enter untuk baris baru)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter untuk mengirim (Enter untuk baris baru)",
   "settings.composerDraftStats": "Hitungan karakter draf",

--- a/src/i18n/messages/id/settings.ts
+++ b/src/i18n/messages/id/settings.ts
@@ -258,7 +258,7 @@ export const idSettings = {
   "settings.composerMinRows.5": "5 baris",
   "settings.composerMinRows.8": "8 baris",
   "settings.composerSendKey": "Kirim pesan dengan",
-  "settings.composerSendKeyDesc": "Pilih apakah Enter biasa mengirim, atau menyisipkan baris baru (⌘/Ctrl+Enter mengirim sebagai gantinya). Berlaku untuk composer obrolan dan kotak komentar kutipan.",
+  "settings.composerSendKeyDesc": "Pilih apakah Enter biasa mengirim, atau menyisipkan baris baru (⌘/Ctrl+Enter mengirim sebagai gantinya). Berlaku untuk composer obrolan.",
   "settings.composerSendKey.enter": "Enter untuk mengirim (Shift+Enter untuk baris baru)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter untuk mengirim (Enter untuk baris baru)",
   "settings.composerDraftStats": "Hitungan karakter draf",

--- a/src/i18n/messages/it/chat.ts
+++ b/src/i18n/messages/it/chat.ts
@@ -72,7 +72,7 @@ export const itChat = {
   "chat.selectionComment": "Commento",
   "chat.selectionCommentPlaceholder": "Scrivi un commento su questo estratto…",
   "chat.selectionCommentSubmit": "Aggiungi commento",
-  "chat.selectionEnterToSubmit": "Invio per aggiungere",
+  "chat.selectionEnterHint": "Invio per aggiungere",
   "chat.selectionToolbar": "Selezione",
   "message.edit": "Modifica",
   "message.exportMd": "Esporta MD",

--- a/src/i18n/messages/it/chat.ts
+++ b/src/i18n/messages/it/chat.ts
@@ -73,6 +73,7 @@ export const itChat = {
   "chat.selectionCommentPlaceholder": "Scrivi un commento su questo estratto…",
   "chat.selectionCommentSubmit": "Aggiungi commento",
   "chat.selectionEnterHint": "Invio per aggiungere",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Invio per aggiungere",
   "chat.selectionToolbar": "Selezione",
   "message.edit": "Modifica",
   "message.exportMd": "Esporta MD",

--- a/src/i18n/messages/it/chat.ts
+++ b/src/i18n/messages/it/chat.ts
@@ -72,6 +72,7 @@ export const itChat = {
   "chat.selectionComment": "Commento",
   "chat.selectionCommentPlaceholder": "Scrivi un commento su questo estratto…",
   "chat.selectionCommentSubmit": "Aggiungi commento",
+  "chat.selectionEnterToSubmit": "Invio per aggiungere",
   "chat.selectionToolbar": "Selezione",
   "message.edit": "Modifica",
   "message.exportMd": "Esporta MD",

--- a/src/i18n/messages/it/settings.ts
+++ b/src/i18n/messages/it/settings.ts
@@ -258,7 +258,7 @@ export const itSettings = {
   "settings.composerMinRows.5": "5 righe",
   "settings.composerMinRows.8": "8 righe",
   "settings.composerSendKey": "Invia messaggio con",
-  "settings.composerSendKeyDesc": "Scegli se Invio semplice invia, oppure inserisce una nuova riga (⌘/Ctrl+Invio invia invece). Si applica al composer della chat e al commento della citazione.",
+  "settings.composerSendKeyDesc": "Scegli se Invio semplice invia, oppure inserisce una nuova riga (⌘/Ctrl+Invio invia invece). Si applica al composer della chat.",
   "settings.composerSendKey.enter": "Invio per inviare (Maiusc+Invio per nuova riga)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Invio per inviare (Invio per nuova riga)",
   "settings.composerDraftStats": "Conteggio caratteri della bozza",

--- a/src/i18n/messages/it/settings.ts
+++ b/src/i18n/messages/it/settings.ts
@@ -258,7 +258,7 @@ export const itSettings = {
   "settings.composerMinRows.5": "5 righe",
   "settings.composerMinRows.8": "8 righe",
   "settings.composerSendKey": "Invia messaggio con",
-  "settings.composerSendKeyDesc": "Scegli se Invio semplice invia, oppure inserisce una nuova riga (⌘/Ctrl+Invio invia invece). Si applica al composer della chat.",
+  "settings.composerSendKeyDesc": "Scegli se Invio semplice invia, oppure inserisce una nuova riga (⌘/Ctrl+Invio invia invece). Si applica al composer della chat e al commento della citazione.",
   "settings.composerSendKey.enter": "Invio per inviare (Maiusc+Invio per nuova riga)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Invio per inviare (Invio per nuova riga)",
   "settings.composerDraftStats": "Conteggio caratteri della bozza",

--- a/src/i18n/messages/ja/chat.ts
+++ b/src/i18n/messages/ja/chat.ts
@@ -73,6 +73,7 @@ export const jaChat = {
   "chat.selectionCommentPlaceholder": "この抜粋にコメントを書く…",
   "chat.selectionCommentSubmit": "コメントを追加",
   "chat.selectionEnterHint": "Enter で追加",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter で追加",
   "chat.selectionToolbar": "選択",
   "message.edit": "編集",
   "message.exportMd": "MD を書き出し",

--- a/src/i18n/messages/ja/chat.ts
+++ b/src/i18n/messages/ja/chat.ts
@@ -72,7 +72,7 @@ export const jaChat = {
   "chat.selectionComment": "コメント",
   "chat.selectionCommentPlaceholder": "この抜粋にコメントを書く…",
   "chat.selectionCommentSubmit": "コメントを追加",
-  "chat.selectionEnterToSubmit": "Enter で追加",
+  "chat.selectionEnterHint": "Enter で追加",
   "chat.selectionToolbar": "選択",
   "message.edit": "編集",
   "message.exportMd": "MD を書き出し",

--- a/src/i18n/messages/ja/chat.ts
+++ b/src/i18n/messages/ja/chat.ts
@@ -72,6 +72,7 @@ export const jaChat = {
   "chat.selectionComment": "コメント",
   "chat.selectionCommentPlaceholder": "この抜粋にコメントを書く…",
   "chat.selectionCommentSubmit": "コメントを追加",
+  "chat.selectionEnterToSubmit": "Enter で追加",
   "chat.selectionToolbar": "選択",
   "message.edit": "編集",
   "message.exportMd": "MD を書き出し",

--- a/src/i18n/messages/ja/settings.ts
+++ b/src/i18n/messages/ja/settings.ts
@@ -258,7 +258,7 @@ export const jaSettings = {
   "settings.composerMinRows.5": "5 行",
   "settings.composerMinRows.8": "8 行",
   "settings.composerSendKey": "メッセージ送信キー",
-  "settings.composerSendKeyDesc": "素の Enter で送るか、改行を入れるか（⌘/Ctrl+Enter で送信）。チャットコンポーザーに適用されます。",
+  "settings.composerSendKeyDesc": "素の Enter で送るか、改行を入れるか（⌘/Ctrl+Enter で送信）。チャット入力と引用コメント欄に適用されます。",
   "settings.composerSendKey.enter": "Enter で送信（Shift+Enter で改行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter で送信（Enter で改行）",
   "settings.composerDraftStats": "下書きの文字数",

--- a/src/i18n/messages/ja/settings.ts
+++ b/src/i18n/messages/ja/settings.ts
@@ -258,7 +258,7 @@ export const jaSettings = {
   "settings.composerMinRows.5": "5 行",
   "settings.composerMinRows.8": "8 行",
   "settings.composerSendKey": "メッセージ送信キー",
-  "settings.composerSendKeyDesc": "素の Enter で送るか、改行を入れるか（⌘/Ctrl+Enter で送信）。チャット入力と引用コメント欄に適用されます。",
+  "settings.composerSendKeyDesc": "素の Enter で送るか、改行を入れるか（⌘/Ctrl+Enter で送信）。チャットコンポーザーに適用されます。",
   "settings.composerSendKey.enter": "Enter で送信（Shift+Enter で改行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter で送信（Enter で改行）",
   "settings.composerDraftStats": "下書きの文字数",

--- a/src/i18n/messages/ko/chat.ts
+++ b/src/i18n/messages/ko/chat.ts
@@ -73,6 +73,7 @@ export const koChat = {
   "chat.selectionCommentPlaceholder": "이 발췌에 대한 댓글을 작성하세요…",
   "chat.selectionCommentSubmit": "댓글 추가",
   "chat.selectionEnterHint": "Enter로 추가",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter로 추가",
   "chat.selectionToolbar": "선택",
   "message.edit": "편집",
   "message.exportMd": "MD보내기",

--- a/src/i18n/messages/ko/chat.ts
+++ b/src/i18n/messages/ko/chat.ts
@@ -72,7 +72,7 @@ export const koChat = {
   "chat.selectionComment": "댓글",
   "chat.selectionCommentPlaceholder": "이 발췌에 대한 댓글을 작성하세요…",
   "chat.selectionCommentSubmit": "댓글 추가",
-  "chat.selectionEnterToSubmit": "Enter로 추가",
+  "chat.selectionEnterHint": "Enter로 추가",
   "chat.selectionToolbar": "선택",
   "message.edit": "편집",
   "message.exportMd": "MD보내기",

--- a/src/i18n/messages/ko/chat.ts
+++ b/src/i18n/messages/ko/chat.ts
@@ -72,6 +72,7 @@ export const koChat = {
   "chat.selectionComment": "댓글",
   "chat.selectionCommentPlaceholder": "이 발췌에 대한 댓글을 작성하세요…",
   "chat.selectionCommentSubmit": "댓글 추가",
+  "chat.selectionEnterToSubmit": "Enter로 추가",
   "chat.selectionToolbar": "선택",
   "message.edit": "편집",
   "message.exportMd": "MD보내기",

--- a/src/i18n/messages/ko/settings.ts
+++ b/src/i18n/messages/ko/settings.ts
@@ -258,7 +258,7 @@ export const koSettings = {
   "settings.composerMinRows.5": "5행",
   "settings.composerMinRows.8": "8행",
   "settings.composerSendKey": "메시지 보내기",
-  "settings.composerSendKeyDesc": "일반 Enter가 보낼지, 줄 바꿈을 넣을지 선택하세요(대신 ⌘/Ctrl+Enter가 보냄). 채팅 작성기에 적용됩니다.",
+  "settings.composerSendKeyDesc": "일반 Enter가 보낼지, 줄 바꿈을 넣을지 선택하세요(대신 ⌘/Ctrl+Enter가 보냄). 채팅 입력과 인용 댓글 상자에 적용됩니다.",
   "settings.composerSendKey.enter": "Enter로 보내기(Shift+Enter는 줄 바꿈)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter로 보내기(Enter는 줄 바꿈)",
   "settings.composerDraftStats": "초안 글자 수",

--- a/src/i18n/messages/ko/settings.ts
+++ b/src/i18n/messages/ko/settings.ts
@@ -258,7 +258,7 @@ export const koSettings = {
   "settings.composerMinRows.5": "5행",
   "settings.composerMinRows.8": "8행",
   "settings.composerSendKey": "메시지 보내기",
-  "settings.composerSendKeyDesc": "일반 Enter가 보낼지, 줄 바꿈을 넣을지 선택하세요(대신 ⌘/Ctrl+Enter가 보냄). 채팅 입력과 인용 댓글 상자에 적용됩니다.",
+  "settings.composerSendKeyDesc": "일반 Enter가 보낼지, 줄 바꿈을 넣을지 선택하세요(대신 ⌘/Ctrl+Enter가 보냄). 채팅 작성기에 적용됩니다.",
   "settings.composerSendKey.enter": "Enter로 보내기(Shift+Enter는 줄 바꿈)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter로 보내기(Enter는 줄 바꿈)",
   "settings.composerDraftStats": "초안 글자 수",

--- a/src/i18n/messages/pt-BR/chat.ts
+++ b/src/i18n/messages/pt-BR/chat.ts
@@ -73,6 +73,7 @@ export const ptBRChat = {
   "chat.selectionCommentPlaceholder": "Escreva um comentário sobre este trecho…",
   "chat.selectionCommentSubmit": "Adicionar comentário",
   "chat.selectionEnterHint": "Enter para adicionar",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter para adicionar",
   "chat.selectionToolbar": "Seleção",
   "message.edit": "Editar",
   "message.exportMd": "Exportar MD",

--- a/src/i18n/messages/pt-BR/chat.ts
+++ b/src/i18n/messages/pt-BR/chat.ts
@@ -72,6 +72,7 @@ export const ptBRChat = {
   "chat.selectionComment": "Comentar",
   "chat.selectionCommentPlaceholder": "Escreva um comentário sobre este trecho…",
   "chat.selectionCommentSubmit": "Adicionar comentário",
+  "chat.selectionEnterToSubmit": "Enter para adicionar",
   "chat.selectionToolbar": "Seleção",
   "message.edit": "Editar",
   "message.exportMd": "Exportar MD",

--- a/src/i18n/messages/pt-BR/chat.ts
+++ b/src/i18n/messages/pt-BR/chat.ts
@@ -72,7 +72,7 @@ export const ptBRChat = {
   "chat.selectionComment": "Comentar",
   "chat.selectionCommentPlaceholder": "Escreva um comentário sobre este trecho…",
   "chat.selectionCommentSubmit": "Adicionar comentário",
-  "chat.selectionEnterToSubmit": "Enter para adicionar",
+  "chat.selectionEnterHint": "Enter para adicionar",
   "chat.selectionToolbar": "Seleção",
   "message.edit": "Editar",
   "message.exportMd": "Exportar MD",

--- a/src/i18n/messages/pt-BR/settings.ts
+++ b/src/i18n/messages/pt-BR/settings.ts
@@ -258,7 +258,7 @@ export const ptBRSettings = {
   "settings.composerMinRows.5": "5 linhas",
   "settings.composerMinRows.8": "8 linhas",
   "settings.composerSendKey": "Enviar mensagem com",
-  "settings.composerSendKeyDesc": "Escolha se o Enter simples envia, ou insere uma nova linha (⌘/Ctrl+Enter envia). Aplica-se ao compositor do chat.",
+  "settings.composerSendKeyDesc": "Escolha se o Enter simples envia, ou insere uma nova linha (⌘/Ctrl+Enter envia). Aplica-se ao compositor do chat e à caixa de comentário da citação.",
   "settings.composerSendKey.enter": "Enter para enviar (Shift+Enter para nova linha)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter para enviar (Enter para nova linha)",
   "settings.composerDraftStats": "Contagem de caracteres do rascunho",

--- a/src/i18n/messages/pt-BR/settings.ts
+++ b/src/i18n/messages/pt-BR/settings.ts
@@ -258,7 +258,7 @@ export const ptBRSettings = {
   "settings.composerMinRows.5": "5 linhas",
   "settings.composerMinRows.8": "8 linhas",
   "settings.composerSendKey": "Enviar mensagem com",
-  "settings.composerSendKeyDesc": "Escolha se o Enter simples envia, ou insere uma nova linha (⌘/Ctrl+Enter envia). Aplica-se ao compositor do chat e à caixa de comentário da citação.",
+  "settings.composerSendKeyDesc": "Escolha se o Enter simples envia, ou insere uma nova linha (⌘/Ctrl+Enter envia). Aplica-se ao compositor do chat.",
   "settings.composerSendKey.enter": "Enter para enviar (Shift+Enter para nova linha)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter para enviar (Enter para nova linha)",
   "settings.composerDraftStats": "Contagem de caracteres do rascunho",

--- a/src/i18n/messages/ru/chat.ts
+++ b/src/i18n/messages/ru/chat.ts
@@ -72,7 +72,7 @@ export const ruChat = {
   "chat.selectionComment": "Комментарий",
   "chat.selectionCommentPlaceholder": "Добавьте комментарий к этому фрагменту…",
   "chat.selectionCommentSubmit": "Добавить комментарий",
-  "chat.selectionEnterToSubmit": "Enter — добавить",
+  "chat.selectionEnterHint": "Enter — добавить",
   "chat.selectionToolbar": "Выделенный текст",
   "message.edit": "Изменить",
   "message.exportMd": "Экспортировать MD",

--- a/src/i18n/messages/ru/chat.ts
+++ b/src/i18n/messages/ru/chat.ts
@@ -73,6 +73,7 @@ export const ruChat = {
   "chat.selectionCommentPlaceholder": "Добавьте комментарий к этому фрагменту…",
   "chat.selectionCommentSubmit": "Добавить комментарий",
   "chat.selectionEnterHint": "Enter — добавить",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter — добавить",
   "chat.selectionToolbar": "Выделенный текст",
   "message.edit": "Изменить",
   "message.exportMd": "Экспортировать MD",

--- a/src/i18n/messages/ru/chat.ts
+++ b/src/i18n/messages/ru/chat.ts
@@ -72,6 +72,7 @@ export const ruChat = {
   "chat.selectionComment": "Комментарий",
   "chat.selectionCommentPlaceholder": "Добавьте комментарий к этому фрагменту…",
   "chat.selectionCommentSubmit": "Добавить комментарий",
+  "chat.selectionEnterToSubmit": "Enter — добавить",
   "chat.selectionToolbar": "Выделенный текст",
   "message.edit": "Изменить",
   "message.exportMd": "Экспортировать MD",

--- a/src/i18n/messages/ru/settings.ts
+++ b/src/i18n/messages/ru/settings.ts
@@ -258,7 +258,7 @@ export const ruSettings = {
   "settings.composerMinRows.5": "5 строк",
   "settings.composerMinRows.8": "8 строк",
   "settings.composerSendKey": "Отправка сообщения",
-  "settings.composerSendKeyDesc": "Выберите, отправляет ли обычный Enter сообщение или вставляет новую строку.",
+  "settings.composerSendKeyDesc": "Выберите, отправляет ли обычный Enter сообщение или вставляет новую строку (⌘/Ctrl+Enter — отправка). Действует в поле чата и в комментарии к цитате.",
   "settings.composerSendKey.enter": "Enter — отправить (Shift+Enter — новая строка)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter — отправить (Enter — новая строка)",
   "settings.composerDraftStats": "Счётчик текста черновика",

--- a/src/i18n/messages/ru/settings.ts
+++ b/src/i18n/messages/ru/settings.ts
@@ -258,7 +258,7 @@ export const ruSettings = {
   "settings.composerMinRows.5": "5 строк",
   "settings.composerMinRows.8": "8 строк",
   "settings.composerSendKey": "Отправка сообщения",
-  "settings.composerSendKeyDesc": "Выберите, отправляет ли обычный Enter сообщение или вставляет новую строку (⌘/Ctrl+Enter — отправка). Действует в поле чата и в комментарии к цитате.",
+  "settings.composerSendKeyDesc": "Выберите, отправляет ли обычный Enter сообщение или вставляет новую строку.",
   "settings.composerSendKey.enter": "Enter — отправить (Shift+Enter — новая строка)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter — отправить (Enter — новая строка)",
   "settings.composerDraftStats": "Счётчик текста черновика",

--- a/src/i18n/messages/ta/chat.ts
+++ b/src/i18n/messages/ta/chat.ts
@@ -72,6 +72,7 @@ export const taChat = {
   "chat.selectionComment": "கருத்து",
   "chat.selectionCommentPlaceholder": "இந்த பகுதிக்கு ஒரு கருத்தை எழுதுங்கள்…",
   "chat.selectionCommentSubmit": "கருத்தைச் சேர்",
+  "chat.selectionEnterToSubmit": "Enter சேர்",
   "chat.selectionToolbar": "தேர்வு",
   "message.edit": "திருத்து",
   "message.exportMd": "ஏற்றுமதி எம்.டி",

--- a/src/i18n/messages/ta/chat.ts
+++ b/src/i18n/messages/ta/chat.ts
@@ -73,6 +73,7 @@ export const taChat = {
   "chat.selectionCommentPlaceholder": "இந்த பகுதிக்கு ஒரு கருத்தை எழுதுங்கள்…",
   "chat.selectionCommentSubmit": "கருத்தைச் சேர்",
   "chat.selectionEnterHint": "Enter சேர்",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter சேர்",
   "chat.selectionToolbar": "தேர்வு",
   "message.edit": "திருத்து",
   "message.exportMd": "ஏற்றுமதி எம்.டி",

--- a/src/i18n/messages/ta/chat.ts
+++ b/src/i18n/messages/ta/chat.ts
@@ -72,7 +72,7 @@ export const taChat = {
   "chat.selectionComment": "கருத்து",
   "chat.selectionCommentPlaceholder": "இந்த பகுதிக்கு ஒரு கருத்தை எழுதுங்கள்…",
   "chat.selectionCommentSubmit": "கருத்தைச் சேர்",
-  "chat.selectionEnterToSubmit": "Enter சேர்",
+  "chat.selectionEnterHint": "Enter சேர்",
   "chat.selectionToolbar": "தேர்வு",
   "message.edit": "திருத்து",
   "message.exportMd": "ஏற்றுமதி எம்.டி",

--- a/src/i18n/messages/ta/settings.ts
+++ b/src/i18n/messages/ta/settings.ts
@@ -258,7 +258,7 @@ export const taSettings = {
   "settings.composerMinRows.5": "5 வரிசைகள்",
   "settings.composerMinRows.8": "8 வரிசைகள்",
   "settings.composerSendKey": "உடன் செய்தி அனுப்பு",
-  "settings.composerSendKeyDesc": "ப்ளைன் என்டர் அனுப்புகிறதா அல்லது புதிய வரியைச் செருகுகிறதா என்பதைத் தேர்வுசெய்யவும் (⌘/Ctrl+Enter அதற்குப் பதிலாக அனுப்புகிறது). உரையாடல் எழுதிக்குப் பொருந்தும்.",
+  "settings.composerSendKeyDesc": "ப்ளைன் என்டர் அனுப்புகிறதா அல்லது புதிய வரியைச் செருகுகிறதா என்பதைத் தேர்வுசெய்யவும் (⌘/Ctrl+Enter அதற்குப் பதிலாக அனுப்புகிறது). உரையாடல் எழுதிக்கும் மேற்கோள் கருத்துப் பெட்டிக்கும் பொருந்தும்.",
   "settings.composerSendKey.enter": "அனுப்ப உள்ளிடவும் (புதிய வரிக்கு Shift+Enter)",
   "settings.composerSendKey.modEnter": "அனுப்ப ⌘/Ctrl+Enter (புதிய வரிக்கு உள்ளிடவும்)",
   "settings.composerDraftStats": "வரைவு எழுத்து எண்ணிக்கை",

--- a/src/i18n/messages/ta/settings.ts
+++ b/src/i18n/messages/ta/settings.ts
@@ -258,7 +258,7 @@ export const taSettings = {
   "settings.composerMinRows.5": "5 வரிசைகள்",
   "settings.composerMinRows.8": "8 வரிசைகள்",
   "settings.composerSendKey": "உடன் செய்தி அனுப்பு",
-  "settings.composerSendKeyDesc": "ப்ளைன் என்டர் அனுப்புகிறதா அல்லது புதிய வரியைச் செருகுகிறதா என்பதைத் தேர்வுசெய்யவும் (⌘/Ctrl+Enter அதற்குப் பதிலாக அனுப்புகிறது). உரையாடல் எழுதிக்கும் மேற்கோள் கருத்துப் பெட்டிக்கும் பொருந்தும்.",
+  "settings.composerSendKeyDesc": "ப்ளைன் என்டர் அனுப்புகிறதா அல்லது புதிய வரியைச் செருகுகிறதா என்பதைத் தேர்வுசெய்யவும் (⌘/Ctrl+Enter அதற்குப் பதிலாக அனுப்புகிறது). உரையாடல் எழுதிக்குப் பொருந்தும்.",
   "settings.composerSendKey.enter": "அனுப்ப உள்ளிடவும் (புதிய வரிக்கு Shift+Enter)",
   "settings.composerSendKey.modEnter": "அனுப்ப ⌘/Ctrl+Enter (புதிய வரிக்கு உள்ளிடவும்)",
   "settings.composerDraftStats": "வரைவு எழுத்து எண்ணிக்கை",

--- a/src/i18n/messages/uk/chat.ts
+++ b/src/i18n/messages/uk/chat.ts
@@ -73,6 +73,7 @@ export const ukChat = {
   "chat.selectionCommentPlaceholder": "Напишіть коментар до цього уривка…",
   "chat.selectionCommentSubmit": "Додати коментар",
   "chat.selectionEnterHint": "Enter — додати",
+  "chat.selectionModEnterHint": "⌘/Ctrl+Enter — додати",
   "chat.selectionToolbar": "Виділення",
   "message.edit": "Редагувати",
   "message.exportMd": "Експортувати MD",

--- a/src/i18n/messages/uk/chat.ts
+++ b/src/i18n/messages/uk/chat.ts
@@ -72,6 +72,7 @@ export const ukChat = {
   "chat.selectionComment": "Коментар",
   "chat.selectionCommentPlaceholder": "Напишіть коментар до цього уривка…",
   "chat.selectionCommentSubmit": "Додати коментар",
+  "chat.selectionEnterToSubmit": "Enter — додати",
   "chat.selectionToolbar": "Виділення",
   "message.edit": "Редагувати",
   "message.exportMd": "Експортувати MD",

--- a/src/i18n/messages/uk/chat.ts
+++ b/src/i18n/messages/uk/chat.ts
@@ -72,7 +72,7 @@ export const ukChat = {
   "chat.selectionComment": "Коментар",
   "chat.selectionCommentPlaceholder": "Напишіть коментар до цього уривка…",
   "chat.selectionCommentSubmit": "Додати коментар",
-  "chat.selectionEnterToSubmit": "Enter — додати",
+  "chat.selectionEnterHint": "Enter — додати",
   "chat.selectionToolbar": "Виділення",
   "message.edit": "Редагувати",
   "message.exportMd": "Експортувати MD",

--- a/src/i18n/messages/uk/settings.ts
+++ b/src/i18n/messages/uk/settings.ts
@@ -258,7 +258,7 @@ export const ukSettings = {
   "settings.composerMinRows.5": "5 рядків",
   "settings.composerMinRows.8": "8 рядків",
   "settings.composerSendKey": "Надсилати повідомлення",
-  "settings.composerSendKeyDesc": "Виберіть, чи простий Enter надсилає чи вставляє новий рядок (натомість ⌘/Ctrl+Enter надсилає). Застосовується до автора чату.",
+  "settings.composerSendKeyDesc": "Виберіть, чи простий Enter надсилає чи вставляє новий рядок (натомість ⌘/Ctrl+Enter надсилає). Застосовується до чату й поля коментаря цитати.",
   "settings.composerSendKey.enter": "Enter — надіслати (Shift+Enter — новий рядок)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter — надіслати (Enter — новий рядок)",
   "settings.composerDraftStats": "Лічильник символів чернетки",

--- a/src/i18n/messages/uk/settings.ts
+++ b/src/i18n/messages/uk/settings.ts
@@ -258,7 +258,7 @@ export const ukSettings = {
   "settings.composerMinRows.5": "5 рядків",
   "settings.composerMinRows.8": "8 рядків",
   "settings.composerSendKey": "Надсилати повідомлення",
-  "settings.composerSendKeyDesc": "Виберіть, чи простий Enter надсилає чи вставляє новий рядок (натомість ⌘/Ctrl+Enter надсилає). Застосовується до чату й поля коментаря цитати.",
+  "settings.composerSendKeyDesc": "Виберіть, чи простий Enter надсилає чи вставляє новий рядок (натомість ⌘/Ctrl+Enter надсилає). Застосовується до автора чату.",
   "settings.composerSendKey.enter": "Enter — надіслати (Shift+Enter — новий рядок)",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter — надіслати (Enter — новий рядок)",
   "settings.composerDraftStats": "Лічильник символів чернетки",

--- a/src/i18n/messages/zh-TW/chat.ts
+++ b/src/i18n/messages/zh-TW/chat.ts
@@ -72,7 +72,7 @@ export const zhTWChat = {
   "chat.selectionComment": "寫評論",
   "chat.selectionCommentPlaceholder": "針對這段摘錄寫評論…",
   "chat.selectionCommentSubmit": "新增評論",
-  "chat.selectionEnterToSubmit": "Enter 提交",
+  "chat.selectionEnterHint": "Enter 提交",
   "chat.selectionToolbar": "選取文字",
   "message.edit": "編輯",
   "message.exportMd": "匯出 MD",

--- a/src/i18n/messages/zh-TW/chat.ts
+++ b/src/i18n/messages/zh-TW/chat.ts
@@ -73,6 +73,7 @@ export const zhTWChat = {
   "chat.selectionCommentPlaceholder": "針對這段摘錄寫評論…",
   "chat.selectionCommentSubmit": "新增評論",
   "chat.selectionEnterHint": "Enter 提交",
+  "chat.selectionModEnterHint": "Ctrl+Enter 新增",
   "chat.selectionToolbar": "選取文字",
   "message.edit": "編輯",
   "message.exportMd": "匯出 MD",

--- a/src/i18n/messages/zh-TW/chat.ts
+++ b/src/i18n/messages/zh-TW/chat.ts
@@ -72,6 +72,7 @@ export const zhTWChat = {
   "chat.selectionComment": "寫評論",
   "chat.selectionCommentPlaceholder": "針對這段摘錄寫評論…",
   "chat.selectionCommentSubmit": "新增評論",
+  "chat.selectionEnterToSubmit": "Enter 提交",
   "chat.selectionToolbar": "選取文字",
   "message.edit": "編輯",
   "message.exportMd": "匯出 MD",

--- a/src/i18n/messages/zh-TW/settings.ts
+++ b/src/i18n/messages/zh-TW/settings.ts
@@ -282,7 +282,7 @@ export const zhTWSettings = {
   "settings.composerMinRows.5": "5 行",
   "settings.composerMinRows.8": "8 行",
   "settings.composerSendKey": "傳送訊息快捷鍵",
-  "settings.composerSendKeyDesc": "選擇 Enter 直接傳送，或 Enter 換行、⌘/Ctrl+Enter 傳送。對話輸入框和劃詞評論框都生效。",
+  "settings.composerSendKeyDesc": "選擇 Enter 直接傳送，或 Enter 換行、⌘/Ctrl+Enter 傳送。僅作用於對話輸入框。",
   "settings.composerSendKey.enter": "Enter 傳送（Shift+Enter 換行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 傳送（Enter 換行）",
   "settings.composerDraftStats": "草稿字數",

--- a/src/i18n/messages/zh-TW/settings.ts
+++ b/src/i18n/messages/zh-TW/settings.ts
@@ -282,7 +282,7 @@ export const zhTWSettings = {
   "settings.composerMinRows.5": "5 行",
   "settings.composerMinRows.8": "8 行",
   "settings.composerSendKey": "傳送訊息快捷鍵",
-  "settings.composerSendKeyDesc": "選擇 Enter 直接傳送，或 Enter 換行、⌘/Ctrl+Enter 傳送。僅作用於對話輸入框。",
+  "settings.composerSendKeyDesc": "選擇 Enter 直接傳送，或 Enter 換行、⌘/Ctrl+Enter 傳送。對話輸入框和劃詞評論框都生效。",
   "settings.composerSendKey.enter": "Enter 傳送（Shift+Enter 換行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 傳送（Enter 換行）",
   "settings.composerDraftStats": "草稿字數",

--- a/src/i18n/messages/zh/chat.ts
+++ b/src/i18n/messages/zh/chat.ts
@@ -72,7 +72,7 @@ export const zhChat = {
   "chat.selectionComment": "写评论",
   "chat.selectionCommentPlaceholder": "针对这段摘录写评论…",
   "chat.selectionCommentSubmit": "添加评论",
-  "chat.selectionEnterToSubmit": "Enter 提交",
+  "chat.selectionEnterHint": "Enter 提交",
   "chat.selectionToolbar": "选中文字",
   "message.edit": "编辑",
   "message.exportMd": "导出 MD",

--- a/src/i18n/messages/zh/chat.ts
+++ b/src/i18n/messages/zh/chat.ts
@@ -72,6 +72,7 @@ export const zhChat = {
   "chat.selectionComment": "写评论",
   "chat.selectionCommentPlaceholder": "针对这段摘录写评论…",
   "chat.selectionCommentSubmit": "添加评论",
+  "chat.selectionEnterToSubmit": "Enter 提交",
   "chat.selectionToolbar": "选中文字",
   "message.edit": "编辑",
   "message.exportMd": "导出 MD",

--- a/src/i18n/messages/zh/chat.ts
+++ b/src/i18n/messages/zh/chat.ts
@@ -73,6 +73,7 @@ export const zhChat = {
   "chat.selectionCommentPlaceholder": "针对这段摘录写评论…",
   "chat.selectionCommentSubmit": "添加评论",
   "chat.selectionEnterHint": "Enter 提交",
+  "chat.selectionModEnterHint": "Ctrl+Enter 添加",
   "chat.selectionToolbar": "选中文字",
   "message.edit": "编辑",
   "message.exportMd": "导出 MD",

--- a/src/i18n/messages/zh/settings.ts
+++ b/src/i18n/messages/zh/settings.ts
@@ -281,7 +281,7 @@ export const zhSettings = {
   "settings.composerMinRows.5": "5 行",
   "settings.composerMinRows.8": "8 行",
   "settings.composerSendKey": "发送消息快捷键",
-  "settings.composerSendKeyDesc": "选择 Enter 直接发送，还是 Enter 换行、⌘/Ctrl+Enter 发送。对话输入框和划词评论框都生效。",
+  "settings.composerSendKeyDesc": "选择 Enter 直接发送，还是 Enter 换行、⌘/Ctrl+Enter 发送。仅作用于对话输入框。",
   "settings.composerSendKey.enter": "Enter 发送（Shift+Enter 换行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 发送（Enter 换行）",
   "settings.composerSpellcheck": "拼写检查",

--- a/src/i18n/messages/zh/settings.ts
+++ b/src/i18n/messages/zh/settings.ts
@@ -281,7 +281,7 @@ export const zhSettings = {
   "settings.composerMinRows.5": "5 行",
   "settings.composerMinRows.8": "8 行",
   "settings.composerSendKey": "发送消息快捷键",
-  "settings.composerSendKeyDesc": "选择 Enter 直接发送，还是 Enter 换行、⌘/Ctrl+Enter 发送。仅作用于对话输入框。",
+  "settings.composerSendKeyDesc": "选择 Enter 直接发送，还是 Enter 换行、⌘/Ctrl+Enter 发送。对话输入框和划词评论框都生效。",
   "settings.composerSendKey.enter": "Enter 发送（Shift+Enter 换行）",
   "settings.composerSendKey.modEnter": "⌘/Ctrl+Enter 发送（Enter 换行）",
   "settings.composerSpellcheck": "拼写检查",

--- a/src/lib/composerQuotes.test.ts
+++ b/src/lib/composerQuotes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   appendQuotesToContent,
+  composerHasSendPayload,
   parseQuotesFromContent,
   serializeQuotesForAgent,
   type ComposerQuote,
@@ -37,6 +38,30 @@ describe("append / parse quotes", () => {
       text: "just a prompt",
       quotes: [],
     });
+  });
+});
+
+describe("composerHasSendPayload", () => {
+  it("treats a quote card as enough to send, even with an empty draft", () => {
+    expect(
+      composerHasSendPayload({
+        draftEmpty: true,
+        attachmentCount: 0,
+        chatAttachmentCount: 0,
+        quoteCount: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays false when draft, files, chats, and quotes are all empty", () => {
+    expect(
+      composerHasSendPayload({
+        draftEmpty: true,
+        attachmentCount: 0,
+        chatAttachmentCount: 0,
+        quoteCount: 0,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/lib/composerQuotes.ts
+++ b/src/lib/composerQuotes.ts
@@ -56,6 +56,21 @@ export function normalizeComposerQuote(raw: unknown): ComposerQuote | null {
   };
 }
 
+/** Enter / Send: quote cards count as a body, same as files. */
+export function composerHasSendPayload(opts: {
+  draftEmpty: boolean;
+  attachmentCount: number;
+  chatAttachmentCount?: number;
+  quoteCount: number;
+}): boolean {
+  return (
+    !opts.draftEmpty ||
+    opts.attachmentCount > 0 ||
+    (opts.chatAttachmentCount ?? 0) > 0 ||
+    opts.quoteCount > 0
+  );
+}
+
 export function normalizeComposerQuotes(raw: unknown): ComposerQuote[] {
   if (!Array.isArray(raw)) return [];
   const out: ComposerQuote[] = [];

--- a/src/lib/settingsCatalog/entries/general.ts
+++ b/src/lib/settingsCatalog/entries/general.ts
@@ -82,6 +82,8 @@ export const GENERAL_ENTRIES: readonly SettingsEntry[] = [
       "send",
       "enter",
       "mod-enter",
+      "quote",
+      "comment",
       "cmd enter",
       "ctrl enter",
       "newline",

--- a/src/lib/settingsCatalog/entries/general.ts
+++ b/src/lib/settingsCatalog/entries/general.ts
@@ -82,8 +82,6 @@ export const GENERAL_ENTRIES: readonly SettingsEntry[] = [
       "send",
       "enter",
       "mod-enter",
-      "quote",
-      "comment",
       "cmd enter",
       "ctrl enter",
       "newline",

--- a/src/styles/chat.part2b.css
+++ b/src/styles/chat.part2b.css
@@ -425,7 +425,21 @@
 .sel-toolbar__row {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.sel-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
   gap: 4px;
+}
+
+.sel-toolbar__enter-pref {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-tertiary);
 }
 
 .sel-toolbar__btn,

--- a/src/styles/chat.part2b.css
+++ b/src/styles/chat.part2b.css
@@ -436,10 +436,11 @@
   gap: 4px;
 }
 
-.sel-toolbar__enter-pref {
+.sel-toolbar__enter-hint {
   margin-left: auto;
   font-size: 11px;
   color: var(--text-tertiary);
+  white-space: nowrap;
 }
 
 .sel-toolbar__btn,


### PR DESCRIPTION
Fixes #1015

Split from #1014 — quote submit UX, not the selection-toolbar perf work.

## Summary
- Enter in the composer sends a quote-only draft (Send button already did)
- Quote comment box uses the **same** Enter / Ctrl+Enter preference as the composer (Settings → General → Composer)
- The bar shows a hint for the current chord (no checkbox)

## Type of change
- [x] Bug fix

## Test plan
- [x] `pnpm exec vitest run src/lib/composerQuotes.test.ts src/lib/composerSendKey.test.ts src/i18n/messages.test.ts`
- [ ] Manual: add quote with comment, focus composer, Enter with empty input → sends
- [ ] Manual: change send-key in Settings; comment box Enter vs Ctrl+Enter matches the composer