### PR TITLE
fix(chat): drop duplicate user bubbles on image prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ See `docs/llm-wiki/release.md`.
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com](https://grok-app.com)（无末尾斜杠）。
 
 ### Fixed
+- **Image prompts no longer paint two user bubbles**: Sending (or steering) with an attached image dual-writes `@/abs/path` into the journal. The optimistic composer row does not. Dedup now matches on display text + attachment paths, and the extra `@path` line is stripped from the bubble (cards stay).
 - **Agent questionnaire no longer freezes the workbench (#844)**: Answering or dismissing `_x.ai/ask_user_question` used to wait on the Host IPC with every control disabled. The modal now closes first and restores only if a failed accept is still the live request. Portaled overlays also opt out of the window-drag region so macOS titlebar drag cannot swallow clicks.
 - **Windows titlebar drag-up no longer grows height (#786)**: Follow-up to #783/#784. Caption maximize stayed up, but dragging the titlebar still stretched the frame. Windows skips JS `start_dragging` (`data-tauri-drag-region="false"`) and keeps compositor caption drag. Host `set_min_size` no longer runs on every `Moved` (tao re-applies inner size and double-counts the shadow offset); it skips while maximized, while the pointer is down, and when the min is unchanged.
 - **Desktop pet stays the chosen body, celebrates once, and no longer stalls on Windows**: Typing and in-progress tools no longer morph the mark into the catalog `!` or orbit/comet ribbons — the rest shape stays, with an attentive/curious face. Colorful belts fire only when the last live turn becomes unread-ready, then a corner pastille. Overlay paint throttles after idle, pauses while hidden, and cursor look events stay on the pet window (no duplicate still-cursor wakeups) so a long-running Windows overlay no longer freezes until restart.
@@ -107,6 +108,7 @@ See `docs/llm-wiki/release.md`.
 - **Windows Alt+Tab can type without a click first (#768)**: Tauri `unstable` (side-browser multi-webview) builds the page as a child `WRY_WEBVIEW`, so Alt-Tab / taskbar only activates the outer HWND. The host now forwards `WM_SETFOCUS` / `WM_ACTIVATE` into that child so composer and shortcuts work immediately.
 
 **中文 · 修复**
+- **带图发送不再画出两条用户气泡**：附件会在 journal 里双写 `@/abs/path`，乐观气泡没有这一行，去重对不上就会并排出现。现在按正文 + 附件路径对齐，气泡里不再露出 `@路径`（卡片还在）。
 - **Agent 提问弹窗不再卡住工作台（#844）**：回答或忽略 `_x.ai/ask_user_question` 以前会等 Host IPC，期间所有按钮都禁用。现在先关弹窗，只有失败的接受且仍是当前请求时才恢复。浮层也退出窗口拖动区，避免 macOS 标题栏拖动吞掉点击。
 - **Windows 标题栏往上拖不再把窗口拉高（#786）**：#783/#784 的后续。最大化能站住，但拖标题栏仍会拉长窗口。Windows 关掉 JS `start_dragging`（`data-tauri-drag-region="false"`），保留 compositor 标题栏拖动。`set_min_size` 不再在每次 `Moved` 里重设客户区（tao 会把阴影边框加两次）；最大化、按住鼠标、min 没变时都跳过。
 - **桌面宠物以本体为主、只在全部完成时撒彩带，Windows 长跑不再卡死**：打字和工具进行中不再把标记变成感叹号或轨道/彗星彩带，始终显示所选形体（专注/好奇脸）。彩带只在最后一个进行中的回合变成未读完成时播一次，然后右上角亮未读小圆点。空闲后降低绘制频率、隐藏时暂停，光标看向事件只发给宠物窗且静止不再重复唤醒，避免 Windows 透明浮层用久了卡顿卡死、重启才恢复。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ See `docs/llm-wiki/release.md`.
 - **仓库 About 与 README 挂上官网**：GitHub 仓库网站、`package.json` `homepage` 与各语言 README 现指向 [https://grok-app.com](https://grok-app.com)（无末尾斜杠）。
 
 ### Fixed
-- **Image prompts no longer paint two user bubbles**: Sending (or steering) with an attached image dual-writes `@/abs/path` into the journal. The optimistic composer row does not. Dedup now matches on display text + attachment paths, and the extra `@path` line is stripped from the bubble (cards stay).
+- **Image prompts no longer paint two user bubbles (#1021)**: Sending (or steering) with an attached image dual-writes `@/abs/path` into the journal. The optimistic composer row does not. Dedup now matches on display text + attachment paths, and the extra `@path` line is stripped from the bubble (cards stay).
 - **Agent questionnaire no longer freezes the workbench (#844)**: Answering or dismissing `_x.ai/ask_user_question` used to wait on the Host IPC with every control disabled. The modal now closes first and restores only if a failed accept is still the live request. Portaled overlays also opt out of the window-drag region so macOS titlebar drag cannot swallow clicks.
 - **Windows titlebar drag-up no longer grows height (#786)**: Follow-up to #783/#784. Caption maximize stayed up, but dragging the titlebar still stretched the frame. Windows skips JS `start_dragging` (`data-tauri-drag-region="false"`) and keeps compositor caption drag. Host `set_min_size` no longer runs on every `Moved` (tao re-applies inner size and double-counts the shadow offset); it skips while maximized, while the pointer is down, and when the min is unchanged.
 - **Desktop pet stays the chosen body, celebrates once, and no longer stalls on Windows**: Typing and in-progress tools no longer morph the mark into the catalog `!` or orbit/comet ribbons — the rest shape stays, with an attentive/curious face. Colorful belts fire only when the last live turn becomes unread-ready, then a corner pastille. Overlay paint throttles after idle, pauses while hidden, and cursor look events stay on the pet window (no duplicate still-cursor wakeups) so a long-running Windows overlay no longer freezes until restart.
@@ -108,7 +108,7 @@ See `docs/llm-wiki/release.md`.
 - **Windows Alt+Tab can type without a click first (#768)**: Tauri `unstable` (side-browser multi-webview) builds the page as a child `WRY_WEBVIEW`, so Alt-Tab / taskbar only activates the outer HWND. The host now forwards `WM_SETFOCUS` / `WM_ACTIVATE` into that child so composer and shortcuts work immediately.
 
 **中文 · 修复**
-- **带图发送不再画出两条用户气泡**：附件会在 journal 里双写 `@/abs/path`，乐观气泡没有这一行，去重对不上就会并排出现。现在按正文 + 附件路径对齐，气泡里不再露出 `@路径`（卡片还在）。
+- **带图发送不再画出两条用户气泡（#1021）**：附件会在 journal 里双写 `@/abs/path`，乐观气泡没有这一行，去重对不上就会并排出现。现在按正文 + 附件路径对齐，气泡里不再露出 `@路径`（卡片还在）。
 - **Agent 提问弹窗不再卡住工作台（#844）**：回答或忽略 `_x.ai/ask_user_question` 以前会等 Host IPC，期间所有按钮都禁用。现在先关弹窗，只有失败的接受且仍是当前请求时才恢复。浮层也退出窗口拖动区，避免 macOS 标题栏拖动吞掉点击。
 - **Windows 标题栏往上拖不再把窗口拉高（#786）**：#783/#784 的后续。最大化能站住，但拖标题栏仍会拉长窗口。Windows 关掉 JS `start_dragging`（`data-tauri-drag-region="false"`），保留 compositor 标题栏拖动。`set_min_size` 不再在每次 `Moved` 里重设客户区（tao 会把阴影边框加两次）；最大化、按住鼠标、min 没变时都跳过。
 - **桌面宠物以本体为主、只在全部完成时撒彩带，Windows 长跑不再卡死**：打字和工具进行中不再把标记变成感叹号或轨道/彗星彩带，始终显示所选形体（专注/好奇脸）。彩带只在最后一个进行中的回合变成未读完成时播一次，然后右上角亮未读小圆点。空闲后降低绘制频率、隐藏时暂停，光标看向事件只发给宠物窗且静止不再重复唤醒，避免 Windows 透明浮层用久了卡顿卡死、重启才恢复。

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -52,6 +52,7 @@ import {
   filterEchoedUserAttachments,
   isImagePath,
   isMediaPath,
+  parseAttachmentsFromContent,
   pathBasename,
 } from "@/lib/attachments";
 import {
@@ -406,7 +407,9 @@ const UserBodyText = memo(function UserBodyText({
   findActiveOccurrence?: number | null;
 }) {
   const chatLookup = useAttachedChatLookup();
-  const hydrated = hydrateDisplayContent(content);
+  const hydrated = hydrateDisplayContent(
+    parseAttachmentsFromContent(content).text,
+  );
   const segs = parseStoredContent(hydrated);
   if (!segs.some((s) => s.type === "skill" || s.type === "chat")) {
     if (findQuery?.trim()) {

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -789,6 +789,97 @@ describe("session projection", () => {
     expect(out[0]!.role).toBe("user");
   });
 
+  it("reconcileOptimisticDuplicates matches image send when journal dual-wrote @path", () => {
+    const shot =
+      "/Users/me/Library/Application Support/com.grokapp.grok-app/attachments/paste/shot.png";
+    const body =
+      "Grok-app有个新发现的bug，带图片的prompt好像有的时候会有个重复的出现";
+    const att = { path: shot, name: "shot.png", isDir: false };
+    const msgs: ChatMessage[] = [
+      {
+        id: "u-1757088205000",
+        role: "user",
+        content: body,
+        attachments: [att],
+      },
+      {
+        id: "a-pending-1757088205000",
+        role: "assistant",
+        content: "",
+        streaming: true,
+      },
+      {
+        id: "9a5ea6bf-22b7-443f-ba90-8522011d9642",
+        role: "user",
+        content: `${body}\n\n@${shot}`,
+        attachments: [att],
+      },
+    ];
+    const out = reconcileOptimisticDuplicates(msgs);
+    const users = out.filter((m) => m.role === "user");
+    expect(users).toHaveLength(1);
+    expect(users[0]!.id).toBe("9a5ea6bf-22b7-443f-ba90-8522011d9642");
+    expect(users[0]!.content).toBe(body);
+    expect(users[0]!.content.includes("@/")).toBe(false);
+    expect(users[0]!.attachments?.map((a) => a.path)).toEqual([shot]);
+    expect(out.some((m) => m.id.startsWith("a-pending-"))).toBe(true);
+  });
+
+  it("preferSessionMessages drops optimistic image prompt when disk has @path dual-write", () => {
+    const shot = "/tmp/paste.png";
+    const body = "see this screenshot";
+    const att = { path: shot, name: "paste.png", isDir: false };
+    const cached: ChatMessage[] = [
+      {
+        id: "u-1710000000002",
+        role: "user",
+        content: body,
+        attachments: [att],
+      },
+      {
+        id: "a-pending-1710000000002",
+        role: "assistant",
+        content: "",
+        streaming: true,
+      },
+    ];
+    const stored: ChatMessage[] = [
+      {
+        id: "host-user-uuid",
+        role: "user",
+        content: `${body}\n\n@${shot}`,
+        attachments: [att],
+      },
+    ];
+    const out = preferSessionMessages(cached, stored);
+    const users = out.filter((m) => m.role === "user");
+    expect(users).toHaveLength(1);
+    expect(users[0]!.id).toBe("host-user-uuid");
+    expect(users[0]!.content).toBe(body);
+  });
+
+  it("applyInterjection strips dual-written @path from steer-with-image", () => {
+    const shot = "/tmp/guide.png";
+    const messages = applyInterjection(
+      [
+        { id: "u1", role: "user", content: "look" },
+        { id: "a1", role: "assistant", content: "Working", streaming: true },
+      ],
+      {
+        id: "i1",
+        role: "user",
+        content: `用这个图片\n\n@${shot}`,
+        marker: "interjection",
+        attachments: [{ path: shot, name: "guide.png", isDir: false }],
+      },
+      "host-post",
+    );
+    const steer = messages.find((m) => m.id === "i1");
+    expect(steer?.content).toBe("用这个图片");
+    expect(steer?.content.includes("@/")).toBe(false);
+    expect(steer?.attachments?.map((a) => a.path)).toEqual([shot]);
+  });
+
   it("applyStreamChunk grows assistant text once per chunk", () => {
     let messages: ChatMessage[] = [];
     const chunks: StreamPayload[] = [

--- a/src/lib/session/rewind.ts
+++ b/src/lib/session/rewind.ts
@@ -1,3 +1,7 @@
+import {
+  mergeAttachments,
+  parseAttachmentsFromContent,
+} from "../attachments";
 import type { ChatMessage, MessageSegment, SessionState } from "./types";
 import { isTurnPromptMessage } from "./types";
 import { buildSegmentsFromLegacy } from "./segments";
@@ -226,6 +230,47 @@ export function stripClientOptimistic(
 }
 
 /**
+ * Peel trailing sole-line `@/abs/path` dual-write off a user bubble and fold
+ * those paths into structured attachments. Host journal stores both; the
+ * optimistic composer row only has the display body + cards.
+ */
+export function stripUserAttachmentRefs(message: ChatMessage): ChatMessage {
+  if (message.role !== "user") return message;
+  const parsed = parseAttachmentsFromContent(message.content ?? "");
+  const merged = mergeAttachments(parsed.attachments, message.attachments ?? []);
+  const nextContent = parsed.text;
+  const sameText = nextContent === (message.content ?? "");
+  const sameAtts =
+    merged.length === (message.attachments?.length ?? 0) &&
+    merged.every((a, i) => a.path === message.attachments?.[i]?.path);
+  if (sameText && sameAtts) return message;
+  return {
+    ...message,
+    content: nextContent,
+    attachments: merged.length ? merged : message.attachments,
+  };
+}
+
+/**
+ * Match optimistic `u-${ts}` rows to the host UUID even when journal
+ * dual-wrote `@/path` lines the composer never showed.
+ */
+function userBubbleDedupeKey(message: ChatMessage): string {
+  const parsed = parseAttachmentsFromContent(message.content ?? "");
+  const text = parsed.text.trim();
+  const paths = new Set<string>();
+  for (const a of message.attachments ?? []) {
+    if (a.path) paths.add(a.path);
+  }
+  for (const a of parsed.attachments) {
+    if (a.path) paths.add(a.path);
+  }
+  return `${text}\n---\n${[...paths].sort().join("\n")}`;
+}
+
+const EMPTY_USER_KEY = "\n---\n";
+
+/**
  * Remove optimistic user/pending-assistant rows that host journal already
  * replaced under a different id (same body). Fixes: switch away after a turn
  * completes → switch back → first user bubble duplicated at the end.
@@ -239,9 +284,10 @@ export function reconcileOptimisticDuplicates(
   const realUsersByContent = new Map<string, ChatMessage>();
   for (const m of messages) {
     if (m.role === "user" && !isClientOptimisticId(m.id)) {
-      const key = m.content.trim();
-      if (key && !realUsersByContent.has(key)) {
-        realUsersByContent.set(key, m);
+      const key = userBubbleDedupeKey(m);
+      if (key === EMPTY_USER_KEY) continue;
+      if (!realUsersByContent.has(key)) {
+        realUsersByContent.set(key, stripUserAttachmentRefs(m));
       }
     }
   }
@@ -256,7 +302,7 @@ export function reconcileOptimisticDuplicates(
 
   for (const m of messages) {
     if (m.role === "user" && isClientOptimisticId(m.id)) {
-      const real = realUsersByContent.get(m.content.trim());
+      const real = realUsersByContent.get(userBubbleDedupeKey(m));
       if (real) {
         if (!placedRealUserIds.has(real.id)) {
           out.push(real);
@@ -269,7 +315,7 @@ export function reconcileOptimisticDuplicates(
     }
     if (m.role === "user" && !isClientOptimisticId(m.id)) {
       if (placedRealUserIds.has(m.id)) continue;
-      out.push(m);
+      out.push(stripUserAttachmentRefs(m));
       placedRealUserIds.add(m.id);
       continue;
     }

--- a/src/lib/session/stream.ts
+++ b/src/lib/session/stream.ts
@@ -6,6 +6,7 @@ import type {
   StreamPayload,
 } from "./types";
 import { isTurnPromptMessage } from "./types";
+import { stripUserAttachmentRefs } from "./rewind";
 import {
   appendContentToSegments,
   appendThoughtToSegments,
@@ -191,6 +192,7 @@ export function applyInterjection(
   interjection: ChatMessage,
   postStreamMessageId?: string | null,
 ): ChatMessage[] {
+  interjection = stripUserAttachmentRefs(interjection);
   const existingIndex = messages.findIndex(
     (message) => message.id === interjection.id,
   );


### PR DESCRIPTION
Fixes #1021.

## Problem

Sending a prompt with an attached image can paint two user bubbles: the optimistic composer row (display text + card) and a host journal row that dual-wrote a trailing `@/abs/path` line. Dedup matched on exact `content.trim()`, so the extra `@path` kept both rows and sometimes showed in the bubble.

## Fix

- Match optimistic `u-${ts}` rows to the host UUID on stripped body + attachment paths.
- Peel `@path` off host / steer-with-image rows; cards stay.
- Hide those lines in the user bubble renderer as a last pass.

## Test

`pnpm exec vitest run src/lib/session.test.ts` — 110 passed (includes the dual-write / steer-with-image cases).

Screenshot on the issue.