### PR TITLE
fix(composer): Mac Control+Return steers a live turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ See `docs/llm-wiki/release.md`.
 ## [Unreleased]
 
 ### Fixed
+- Mac Control+Return steers a live turn again (#1023).
 - Windows Explorer drag-drop works again (sidebar add project, chat attach). No more forbidden cursor after a hidden window create (#1017).
 
 **中文 · 修复**
+- Mac 上 Control+Return 又能引导当前回合（#1023）。
 - Windows 从资源管理器拖文件/文件夹恢复可用（侧栏加项目、聊天加附件），不再显示禁止光标（#1017）。
 
 ## [0.2.31] - 2026-09-04

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -7913,7 +7913,6 @@ export function AppWorkbench() {
   // with Host pick_interjection_target mid-turn, not streaming-only FSM.
   const canGuideQueuedMessage =
     !!session.sessionId &&
-    !connecting &&
     isSessionLiveStreaming(session.state) &&
     (liveHost.sessionId === session.sessionId
       ? isSessionLiveStreaming(liveHost.state) ||

--- a/src/components/ComposerEditor.tsx
+++ b/src/components/ComposerEditor.tsx
@@ -30,6 +30,10 @@ import {
   readClipboardMediaFiles,
 } from "@/lib/clipboardPaste";
 import {
+  installComposerControlHeldTracking,
+  shouldSteerOnKeydown,
+} from "@/lib/composerSendKey";
+import {
   composerEnterNextStored,
   detectSlashRangeOnStored,
   getStoredTextBeforeCaret,
@@ -1283,6 +1287,9 @@ export const ComposerEditor = memo(function ComposerEditor({
     };
   }, []);
 
+  // Mac WKWebView often drops `ctrlKey` on Control+Return; remember Control itself.
+  useEffect(() => installComposerControlHeldTracking(), []);
+
   useLayoutEffect(() => {
     const el = elRef.current;
     if (!el) return;
@@ -1535,7 +1542,12 @@ export const ComposerEditor = memo(function ComposerEditor({
         onKeyDown={(e) => {
           const el = elRef.current;
           const ne = e.nativeEvent;
-          if (ne.isComposing || ne.keyCode === 229 || composing.current) {
+          const steerChord = shouldSteerOnKeydown(e);
+          // IME must not swallow Control+Return (stuck composing.current / 229).
+          if (
+            !steerChord &&
+            (ne.isComposing || ne.keyCode === 229 || composing.current)
+          ) {
             return;
           }
           // WebKit: ArrowRight past the last glyph can inject U+FFFC (□) /
@@ -1564,8 +1576,14 @@ export const ComposerEditor = memo(function ComposerEditor({
             e.preventDefault();
             return;
           }
-          // Parent handles send / menus (may preventDefault).
+          // Parent handles send / steer / menus (may preventDefault).
           onKeyDown?.(e);
+          // Always eat Control+Return so WKWebView cannot insert a newline
+          // when the parent did not steer (idle, or chord mis-detected).
+          if (steerChord) {
+            e.preventDefault();
+            return;
+          }
           if (e.defaultPrevented) return;
 
           // Skill chips are contentEditable=false — native Backspace/Delete often

--- a/src/lib/composerSendKey.test.ts
+++ b/src/lib/composerSendKey.test.ts
@@ -4,6 +4,7 @@ import {
   loadComposerSendKeyPref,
   resolveComposerSubmitAction,
   saveComposerSendKeyPref,
+  setComposerControlHeldForTest,
   shouldSendOnKeydown,
   shouldSteerOnKeydown,
   type ComposerSendKeyEvent,
@@ -36,6 +37,11 @@ function key(
     metaKey: partial.metaKey ?? false,
     ctrlKey: partial.ctrlKey ?? false,
     altKey: partial.altKey ?? false,
+    code: partial.code,
+    keyCode: partial.keyCode,
+    which: partial.which,
+    getModifierState: partial.getModifierState,
+    nativeEvent: partial.nativeEvent,
   };
 }
 
@@ -134,6 +140,34 @@ describe("shouldSteerOnKeydown — Grok Build CLI Ctrl+Enter", () => {
 
   it("ignores non-Enter keys", () => {
     expect(shouldSteerOnKeydown(key({ key: "i", ctrlKey: true }))).toBe(false);
+  });
+
+  it("steers on WebKit LF keyCode 10 (Mac Control+Return)", () => {
+    expect(
+      shouldSteerOnKeydown(
+        key({ key: "Unidentified", keyCode: 10, ctrlKey: false }),
+      ),
+    ).toBe(true);
+  });
+
+  it("steers when getModifierState(Control) is true but ctrlKey is false", () => {
+    expect(
+      shouldSteerOnKeydown(
+        key({
+          ctrlKey: false,
+          getModifierState: (name) => name === "Control",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("steers when Control is held and Enter has no ctrlKey (Mac WKWebView)", () => {
+    setComposerControlHeldForTest(true);
+    try {
+      expect(shouldSteerOnKeydown(key({ ctrlKey: false }))).toBe(true);
+    } finally {
+      setComposerControlHeldForTest(false);
+    }
   });
 });
 

--- a/src/lib/composerSendKey.ts
+++ b/src/lib/composerSendKey.ts
@@ -48,7 +48,88 @@ export type ComposerSendKeyEvent = {
   metaKey: boolean;
   ctrlKey: boolean;
   altKey: boolean;
+  /** Physical key (`Enter` / `NumpadEnter`). WKWebView may omit `key === "Enter"`. */
+  code?: string;
+  /** 13 = Enter; 10 = LF (macOS WKWebView / some Windows Ctrl+Enter). */
+  keyCode?: number;
+  which?: number;
+  /** Method form stays compatible with React `KeyboardEvent.getModifierState(ModifierKey)`. */
+  getModifierState?(key: string): boolean;
+  nativeEvent?: {
+    key?: string;
+    code?: string;
+    keyCode?: number;
+    which?: number;
+    ctrlKey?: boolean;
+  };
 };
+
+/** True while the Control key is down (Control keydown itself, not the chord). */
+let controlKeyHeld = false;
+
+/** Test-only: pin Control-held for WKWebView cases where Enter has `ctrlKey: false`. */
+export function setComposerControlHeldForTest(held: boolean): void {
+  controlKeyHeld = held;
+}
+
+/**
+ * Track Control keydown/keyup on `window` so Mac Control+Return still counts
+ * when the Enter event drops `ctrlKey`.
+ */
+export function installComposerControlHeldTracking(): () => void {
+  if (typeof window === "undefined") return () => {};
+  const down = (e: KeyboardEvent) => {
+    if (e.key === "Control") controlKeyHeld = true;
+  };
+  const up = (e: KeyboardEvent) => {
+    if (e.key === "Control") controlKeyHeld = false;
+  };
+  const clear = () => {
+    controlKeyHeld = false;
+  };
+  window.addEventListener("keydown", down, true);
+  window.addEventListener("keyup", up, true);
+  window.addEventListener("blur", clear);
+  return () => {
+    window.removeEventListener("keydown", down, true);
+    window.removeEventListener("keyup", up, true);
+    window.removeEventListener("blur", clear);
+    controlKeyHeld = false;
+  };
+}
+
+function eventKeyCode(e: ComposerSendKeyEvent): number | undefined {
+  return e.keyCode ?? e.which ?? e.nativeEvent?.keyCode ?? e.nativeEvent?.which;
+}
+
+/** Enter / Return, including WebKit Ctrl+Return reported as LF (10). */
+export function isComposerEnterKey(e: ComposerSendKeyEvent): boolean {
+  const key = e.key || e.nativeEvent?.key || "";
+  const code = e.code || e.nativeEvent?.code || "";
+  const kc = eventKeyCode(e);
+  return (
+    key === "Enter" ||
+    key === "\n" ||
+    key === "\r" ||
+    code === "Enter" ||
+    code === "NumpadEnter" ||
+    kc === 13 ||
+    kc === 10
+  );
+}
+
+function isSteerControlDown(e: ComposerSendKeyEvent): boolean {
+  if (e.metaKey) return false;
+  if (e.ctrlKey || e.nativeEvent?.ctrlKey) return true;
+  try {
+    if (e.getModifierState?.("Control")) return true;
+  } catch {
+    /* jsdom */
+  }
+  if (controlKeyHeld) return true;
+  // LF keyCode is how some WebKits spell Control+Enter.
+  return eventKeyCode(e) === 10;
+}
 
 /**
  * Whether this keydown should submit the composer (not insert a newline).
@@ -59,13 +140,13 @@ export function shouldSendOnKeydown(
   e: ComposerSendKeyEvent,
   pref: ComposerSendKeyPref,
 ): boolean {
-  if (e.key !== "Enter") return false;
+  if (!isComposerEnterKey(e)) return false;
   if (e.shiftKey || e.altKey) return false;
   if (pref === "enter") {
-    return !e.metaKey && !e.ctrlKey;
+    return !e.metaKey && !isSteerControlDown(e);
   }
   // mod-enter
-  return e.metaKey || e.ctrlKey;
+  return e.metaKey || isSteerControlDown(e);
 }
 
 /**
@@ -79,11 +160,14 @@ export function shouldSendOnKeydown(
  * Ctrl only — not Cmd. Grok Build CLI uses Ctrl+Enter on every platform,
  * including macOS (Apple Terminal falls back to Ctrl+O). Cmd+Enter stays
  * the optional Composer send key (`mod-enter`).
+ *
+ * macOS WKWebView often reports Control+Return as `keyCode` 10, or Enter
+ * without `ctrlKey`. Match those so the catalog `⌃ ↵` actually fires.
  */
 export function shouldSteerOnKeydown(e: ComposerSendKeyEvent): boolean {
-  if (e.key !== "Enter") return false;
+  if (!isComposerEnterKey(e)) return false;
   if (e.shiftKey || e.altKey) return false;
-  return e.ctrlKey && !e.metaKey;
+  return isSteerControlDown(e) && !e.metaKey;
 }
 
 export type ComposerSubmitAction = "steer" | "send" | "none";


### PR DESCRIPTION
Fixes #1023

## 中文

Mac 上 Control+Return 没法引导当前回合。快捷键目录是 `⌃ ↵`，Grok Build CLI 也是 Ctrl+Enter，但 WKWebView 常把这个组合报成换行（`keyCode` 10）或不带 `ctrlKey` 的 Enter；输入法闸门还会吞掉，结果变成插入空行。

这个 PR：

- 认 Enter：`key` / `code` / `keyCode` 13 和 10
- 认 Control：`ctrlKey`、`getModifierState("Control")`、Control 键本身按住、以及 `keyCode` 10
- 输入法闸门不再挡住这条和弦；编辑器始终 `preventDefault`，避免原生插入空行
- 回合已经在 streaming 时，不再因为 `connecting` 把引导关掉

`composerSendKey.test.ts` 覆盖了 LF、`getModifierState`、Control 按住但 Enter 不带 `ctrlKey` 这几种 Mac 情况。

⌘Return 仍然不是引导（#946）。

## English

Mac Control+Return does not Steer a live turn. The catalog already shows `⌃ ↵` (Grok Build CLI Ctrl+Enter), but WKWebView often reports the chord as LF (`keyCode` 10) or Enter without `ctrlKey`. The IME gate can swallow it, and the editor inserts a newline.

This PR:

- Treats Enter as `key` / `code` / `keyCode` 13 or 10
- Treats Control as `ctrlKey`, `getModifierState("Control")`, Control-key held, or `keyCode` 10
- Does not let the IME gate drop the chord; always `preventDefault` so WebKit cannot insert a newline
- Allows Steer while the turn is already streaming even if `connecting` is still true

Tests cover LF, `getModifierState`, and Control held with `ctrlKey: false`.

⌘Return is still not Steer (#946).
