### PR TITLE
fix(chat): drop duplicate user bubbles on image prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ See `docs/llm-wiki/release.md`.
 
 ### Fixed
 - Windows Explorer drag-drop works again (sidebar add project, chat attach). No more forbidden cursor after a hidden window create (#1017).
+- Image prompts no longer paint two user bubbles (#1021).
 
 **中文 · 修复**
 - Windows 从资源管理器拖文件/文件夹恢复可用（侧栏加项目、聊天加附件），不再显示禁止光标（#1017）。
+- 带图发送不再画出两条用户气泡（#1021）。
 
 ## [0.2.31] - 2026-09-04
 

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -51,6 +51,7 @@ import {
   filterEchoedUserAttachments,
   isImagePath,
   isMediaPath,
+  parseAttachmentsFromContent,
   pathBasename,
 } from "@/lib/attachments";
 import {
@@ -426,7 +427,9 @@ const UserBodyText = memo(function UserBodyText({
   findActiveOccurrence?: number | null;
 }) {
   const chatLookup = useAttachedChatLookup();
-  const hydrated = hydrateDisplayContent(content);
+  const hydrated = hydrateDisplayContent(
+    parseAttachmentsFromContent(content).text,
+  );
   const segs = parseStoredContent(hydrated);
   if (
     !segs.some(

--- a/src/lib/session.projection.test.ts
+++ b/src/lib/session.projection.test.ts
@@ -799,6 +799,97 @@ describe("session projection", () => {
     expect(out[0]!.role).toBe("user");
   });
 
+  it("reconcileOptimisticDuplicates matches image send when journal dual-wrote @path", () => {
+    const shot =
+      "/Users/me/Library/Application Support/com.grokapp.grok-app/attachments/paste/shot.png";
+    const body =
+      "Grok-app有个新发现的bug，带图片的prompt好像有的时候会有个重复的出现";
+    const att = { path: shot, name: "shot.png", isDir: false };
+    const msgs: ChatMessage[] = [
+      {
+        id: "u-1757088205000",
+        role: "user",
+        content: body,
+        attachments: [att],
+      },
+      {
+        id: "a-pending-1757088205000",
+        role: "assistant",
+        content: "",
+        streaming: true,
+      },
+      {
+        id: "9a5ea6bf-22b7-443f-ba90-8522011d9642",
+        role: "user",
+        content: `${body}\n\n@${shot}`,
+        attachments: [att],
+      },
+    ];
+    const out = reconcileOptimisticDuplicates(msgs);
+    const users = out.filter((m) => m.role === "user");
+    expect(users).toHaveLength(1);
+    expect(users[0]!.id).toBe("9a5ea6bf-22b7-443f-ba90-8522011d9642");
+    expect(users[0]!.content).toBe(body);
+    expect(users[0]!.content.includes("@/")).toBe(false);
+    expect(users[0]!.attachments?.map((a) => a.path)).toEqual([shot]);
+    expect(out.some((m) => m.id.startsWith("a-pending-"))).toBe(true);
+  });
+
+  it("preferSessionMessages drops optimistic image prompt when disk has @path dual-write", () => {
+    const shot = "/tmp/paste.png";
+    const body = "see this screenshot";
+    const att = { path: shot, name: "paste.png", isDir: false };
+    const cached: ChatMessage[] = [
+      {
+        id: "u-1710000000002",
+        role: "user",
+        content: body,
+        attachments: [att],
+      },
+      {
+        id: "a-pending-1710000000002",
+        role: "assistant",
+        content: "",
+        streaming: true,
+      },
+    ];
+    const stored: ChatMessage[] = [
+      {
+        id: "host-user-uuid",
+        role: "user",
+        content: `${body}\n\n@${shot}`,
+        attachments: [att],
+      },
+    ];
+    const out = preferSessionMessages(cached, stored);
+    const users = out.filter((m) => m.role === "user");
+    expect(users).toHaveLength(1);
+    expect(users[0]!.id).toBe("host-user-uuid");
+    expect(users[0]!.content).toBe(body);
+  });
+
+  it("applyInterjection strips dual-written @path from steer-with-image", () => {
+    const shot = "/tmp/guide.png";
+    const messages = applyInterjection(
+      [
+        { id: "u1", role: "user", content: "look" },
+        { id: "a1", role: "assistant", content: "Working", streaming: true },
+      ],
+      {
+        id: "i1",
+        role: "user",
+        content: `用这个图片\n\n@${shot}`,
+        marker: "interjection",
+        attachments: [{ path: shot, name: "guide.png", isDir: false }],
+      },
+      "host-post",
+    );
+    const steer = messages.find((m) => m.id === "i1");
+    expect(steer?.content).toBe("用这个图片");
+    expect(steer?.content.includes("@/")).toBe(false);
+    expect(steer?.attachments?.map((a) => a.path)).toEqual([shot]);
+  });
+
   it("applyRemoteUserMessage appends mirror user + live shell (#1001)", () => {
     const out = applyRemoteUserMessage(
       [],

--- a/src/lib/session/rewind.ts
+++ b/src/lib/session/rewind.ts
@@ -1,3 +1,7 @@
+import {
+  mergeAttachments,
+  parseAttachmentsFromContent,
+} from "../attachments";
 import type { ChatMessage, MessageSegment, SessionState } from "./types";
 import { isTurnPromptMessage } from "./types";
 import {
@@ -294,6 +298,47 @@ export function stripClientOptimistic(
 }
 
 /**
+ * Peel trailing sole-line `@/abs/path` dual-write off a user bubble and fold
+ * those paths into structured attachments. Host journal stores both; the
+ * optimistic composer row only has the display body + cards.
+ */
+export function stripUserAttachmentRefs(message: ChatMessage): ChatMessage {
+  if (message.role !== "user") return message;
+  const parsed = parseAttachmentsFromContent(message.content ?? "");
+  const merged = mergeAttachments(parsed.attachments, message.attachments ?? []);
+  const nextContent = parsed.text;
+  const sameText = nextContent === (message.content ?? "");
+  const sameAtts =
+    merged.length === (message.attachments?.length ?? 0) &&
+    merged.every((a, i) => a.path === message.attachments?.[i]?.path);
+  if (sameText && sameAtts) return message;
+  return {
+    ...message,
+    content: nextContent,
+    attachments: merged.length ? merged : message.attachments,
+  };
+}
+
+/**
+ * Match optimistic `u-${ts}` rows to the host UUID even when journal
+ * dual-wrote `@/path` lines the composer never showed.
+ */
+function userBubbleDedupeKey(message: ChatMessage): string {
+  const parsed = parseAttachmentsFromContent(message.content ?? "");
+  const text = parsed.text.trim();
+  const paths = new Set<string>();
+  for (const a of message.attachments ?? []) {
+    if (a.path) paths.add(a.path);
+  }
+  for (const a of parsed.attachments) {
+    if (a.path) paths.add(a.path);
+  }
+  return `${text}\n---\n${[...paths].sort().join("\n")}`;
+}
+
+const EMPTY_USER_KEY = "\n---\n";
+
+/**
  * Remove optimistic user/pending-assistant rows that host journal already
  * replaced under a different id (same body). Fixes: switch away after a turn
  * completes → switch back → first user bubble duplicated at the end.
@@ -307,9 +352,10 @@ export function reconcileOptimisticDuplicates(
   const realUsersByContent = new Map<string, ChatMessage>();
   for (const m of messages) {
     if (m.role === "user" && !isClientOptimisticId(m.id)) {
-      const key = m.content.trim();
-      if (key && !realUsersByContent.has(key)) {
-        realUsersByContent.set(key, m);
+      const key = userBubbleDedupeKey(m);
+      if (key === EMPTY_USER_KEY) continue;
+      if (!realUsersByContent.has(key)) {
+        realUsersByContent.set(key, stripUserAttachmentRefs(m));
       }
     }
   }
@@ -324,7 +370,7 @@ export function reconcileOptimisticDuplicates(
 
   for (const m of messages) {
     if (m.role === "user" && isClientOptimisticId(m.id)) {
-      const real = realUsersByContent.get(m.content.trim());
+      const real = realUsersByContent.get(userBubbleDedupeKey(m));
       if (real) {
         if (!placedRealUserIds.has(real.id)) {
           out.push(real);
@@ -337,7 +383,7 @@ export function reconcileOptimisticDuplicates(
     }
     if (m.role === "user" && !isClientOptimisticId(m.id)) {
       if (placedRealUserIds.has(m.id)) continue;
-      out.push(m);
+      out.push(stripUserAttachmentRefs(m));
       placedRealUserIds.add(m.id);
       continue;
     }

--- a/src/lib/session/stream.ts
+++ b/src/lib/session/stream.ts
@@ -6,6 +6,7 @@ import type {
   StreamPayload,
 } from "./types";
 import { isTurnPromptMessage } from "./types";
+import { stripUserAttachmentRefs } from "./rewind";
 import {
   appendContentToSegments,
   appendThoughtToSegments,
@@ -268,6 +269,7 @@ export function applyInterjection(
   interjection: ChatMessage,
   postStreamMessageId?: string | null,
 ): ChatMessage[] {
+  interjection = stripUserAttachmentRefs(interjection);
   const existingIndex = messages.findIndex(
     (message) => message.id === interjection.id,
   );


### PR DESCRIPTION
Fixes #1021

Rebased replacement for #1022 (fork head was conflicting / unwritable).

## Summary
- Match optimistic `u-${ts}` rows to host UUID on stripped body + attachment paths
- Peel trailing `@path` dual-writes; hide them in the user bubble as a last pass
- Tests live in `session.projection.test.ts` (main already split session tests)

## Test
- `pnpm exec vitest run src/lib/session.projection.test.ts` — 42 passed
- `pnpm typecheck` — pass