### PR TITLE
perf(session): compact completed tool stdout in memory (#1029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ See `docs/llm-wiki/release.md`.
 - Long chats stay smoother when no session files changed. An empty change list no longer rebuilds every transcript row.
 - The quote comment box uses the same Enter / Ctrl+Enter shortcut as the composer (#1015).
 - Tool steps stay collapsed by default while running, so long tool output is less likely to inflate WebContent RAM (#1018).
+- Completed tool stdout in memory matches the expand preview (and drops the duplicate standalone copy), so long turns use less WebContent RAM (#1029).
 
 **中文 · 变更**
 - 对话划词时，引用工具栏不再跟着拖选每一帧刷新。松开鼠标后再出现；键盘划选仍可用。
@@ -26,6 +27,7 @@ See `docs/llm-wiki/release.md`.
 - 没有文件变更时长对话更顺。空的变更列表不再重渲每一行。
 - 划词评论框与输入框共用 Enter / Ctrl+Enter 发送快捷键（#1015）。
 - 工具步骤运行中默认保持折叠，减轻长 stdout 撑大 WebContent 内存（#1018）。
+- 工具结束后内存里只保留与展开预览相同的 stdout，并去掉重复副本，长回合更省 WebContent 内存（#1029）。
 
 ### Fixed
 - Mac Control+Return steers a live turn again (#1023).

--- a/src/lib/mapStoredMessages.ts
+++ b/src/lib/mapStoredMessages.ts
@@ -25,6 +25,7 @@ import {
   type ChatMessage,
   type MessageAttachment,
 } from "@/lib/session";
+import { maybeCompactToolOutputForMemory } from "@/lib/toolOutputMemory";
 
 /** Wire shape from `session_messages` / disk journal. */
 export type StoredJournalMessage = {
@@ -122,7 +123,10 @@ export function mapStoredMessageToChat(
     toolDetail: toolParsed?.detail,
     toolPath: toolParsed?.path,
     toolInput: toolParsed?.input,
-    toolOutput: toolParsed?.output,
+    // Compact on hydrate so journal reloads do not re-inflate WebContent (#1029).
+    toolOutput: toolParsed?.output
+      ? maybeCompactToolOutputForMemory(toolParsed.output, false)
+      : undefined,
     streaming: false,
   };
 }

--- a/src/lib/session.tools.test.ts
+++ b/src/lib/session.tools.test.ts
@@ -674,3 +674,53 @@ describe("tool history replay kind recovery", () => {
     expect(tool.title).toBeTruthy();
   });
 });
+
+describe("tool output memory (#1029)", () => {
+  it("compacts completed toolOutput and drops the standalone duplicate after weave", () => {
+    const long = Array.from({ length: 500 }, (_, i) => `line-${i}`).join("\n");
+    const withAsst: ChatMessage[] = [
+      { id: "u1", role: "user", content: "run" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "",
+        streaming: true,
+        segments: [{ kind: "thought", text: "…" }],
+      },
+    ];
+    const running = applyToolEvent(withAsst, {
+      toolCallId: "t-big",
+      title: "bash",
+      kind: "bash",
+      status: "in_progress",
+      output: long.slice(0, 200),
+    });
+    const runAsst = running.find((m) => m.id === "a1");
+    const runSeg = runAsst?.segments?.find(
+      (s) => s.kind === "tool" && s.toolCallId === "t-big",
+    );
+    // While running, keep the raw growing buffer on the segment (not compacted).
+    expect(runSeg && runSeg.kind === "tool" ? runSeg.output : "").toBe(
+      long.slice(0, 200),
+    );
+
+    const done = applyToolEvent(running, {
+      toolCallId: "t-big",
+      title: "bash",
+      kind: "bash",
+      status: "completed",
+      output: long,
+    });
+    const asst = done.find((m) => m.id === "a1");
+    const seg = asst?.segments?.find(
+      (s) => s.kind === "tool" && s.toolCallId === "t-big",
+    );
+    expect(seg && seg.kind === "tool" ? seg.output : "").toContain("line-0");
+    expect(
+      seg && seg.kind === "tool" ? (seg.output || "").length : 0,
+    ).toBeLessThan(long.length);
+    // Standalone row no longer keeps a second full copy.
+    const step = done.find((m) => m.id === "tool-t-big");
+    expect(step?.toolOutput).toBeUndefined();
+  });
+});

--- a/src/lib/session/tools.ts
+++ b/src/lib/session/tools.ts
@@ -1,5 +1,9 @@
 import { currentTurnHasEndMarker } from "../endOfTurn";
 import { bashArgFromToolTitle, inferKindFromToolCallId } from "../toolDisplay";
+import {
+  maybeCompactToolOutputForMemory,
+  shouldCompactToolOutputForMemory,
+} from "../toolOutputMemory";
 import type {
   ChatMessage,
   ContextCompactMeta,
@@ -217,6 +221,9 @@ export function upsertToolInSegments(
       path: tool.path || prev.path,
       // Status-only ticks must not wipe a known call argument.
       input: tool.input || prev.input,
+      // Same for stdout: sparse ticks omit output; after #1029 the standalone
+      // row may also have cleared toolOutput once woven — never erase segment.
+      output: (tool.output || "").trim() ? tool.output : prev.output,
       meta: tool.meta || prev.meta,
       toolKind: tool.toolKind || prev.toolKind,
     };
@@ -336,6 +343,8 @@ function toolSegmentFromMessageRow(row: ChatMessage): MessageToolSegment | null 
     if (parsed.input && !input) input = parsed.input;
     if (parsed.output && !output) output = parsed.output;
   }
+  // History rows are terminal — compact before weaving into the assistant.
+  output = maybeCompactToolOutputForMemory(output, false);
   return toolSegmentFromFields({
     toolCallId: tcid,
     title: toolStepDisplayTitle(row) || row.content || tcid,
@@ -556,12 +565,58 @@ export function weaveToolsIntoAssistantSegments(
     if (m.role !== "assistant" || m.isError || m.streaming) continue;
     const segs = m.segments?.length ? m.segments : ensureSegments(m);
     const nextSegs = reorderSegmentsToHistoryLayout(segs);
+    const compacted = compactCompletedToolSegmentOutputs(nextSegs);
     // Same array reference ⇒ already history-shaped and had segments.
-    if (nextSegs === segs && m.segments?.length) continue;
-    const derived = deriveFieldsFromSegments(nextSegs);
-    out[k] = { ...m, ...derived, segments: nextSegs };
+    if (compacted === segs && nextSegs === segs && m.segments?.length) continue;
+    const derived = deriveFieldsFromSegments(compacted);
+    out[k] = { ...m, ...derived, segments: compacted };
   }
-  return out;
+  // Standalone tool_step rows keep a second full copy after weave — drop it.
+  return releaseInlinedToolStepOutputs(out);
+}
+
+/** Compact completed tool segment stdout in place (identity-stable when clean). */
+export function compactCompletedToolSegmentOutputs(
+  segs: MessageSegment[],
+): MessageSegment[] {
+  let changed = false;
+  const next = segs.map((s) => {
+    if (s.kind !== "tool" || s.streaming) return s;
+    if (!shouldCompactToolOutputForMemory(s.output)) return s;
+    changed = true;
+    return {
+      ...s,
+      output: maybeCompactToolOutputForMemory(s.output, false),
+    };
+  });
+  return changed ? next : segs;
+}
+
+/**
+ * After tools are woven into the assistant timeline, clear `toolOutput` on the
+ * matching standalone `tool_step` rows so React does not hold two full copies.
+ * Journal on disk is unchanged; paint already hides these rows.
+ */
+export function releaseInlinedToolStepOutputs(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  const inlined = new Set<string>();
+  for (const m of messages) {
+    if (m.role !== "assistant" || !m.segments?.length) continue;
+    for (const s of m.segments) {
+      if (s.kind === "tool" && s.toolCallId) inlined.add(s.toolCallId);
+    }
+  }
+  if (!inlined.size) return messages;
+  let changed = false;
+  const next = messages.map((m) => {
+    if (!isToolStepMessage(m) || !m.toolOutput) return m;
+    const id = toolCallIdOf(m);
+    if (!id || !inlined.has(id)) return m;
+    changed = true;
+    return { ...m, toolOutput: undefined };
+  });
+  return changed ? next : messages;
 }
 
 /**
@@ -903,9 +958,12 @@ export function applyToolEvent(
   // erase it, and prefer the longer body when the host streams in chunks.
   const prevOutput = (prev?.toolOutput || "").trim();
   const nextOutput = (payload.output || "").trim();
-  const toolOutput =
+  const mergedRawOutput =
     (nextOutput.length >= prevOutput.length ? nextOutput : prevOutput) ||
     undefined;
+  // Terminal only: shrink to expand-UI size so WebContent does not keep 20k×N
+  // duplicates while rows stay collapsed (#1029). Running ticks keep raw growth.
+  const toolOutput = maybeCompactToolOutputForMemory(mergedRawOutput, running);
   const isError = status === "failed" || status === "error";
   // Explicit Host presentation meta wins; otherwise keep the previous row's
   // meta so a later sparse tick never wipes the typed card.
@@ -1042,7 +1100,8 @@ export function applyToolEvent(
     ...derived,
     segments: segs,
   };
-  return copy;
+  // Drop the standalone row's stdout copy once the segment holds it (#1029).
+  return releaseInlinedToolStepOutputs(copy);
 }
 
 export function applyTurnMarker(

--- a/src/lib/toolDisplay.ts
+++ b/src/lib/toolDisplay.ts
@@ -504,8 +504,11 @@ export function toolOutputBody(
   if (!raw) return "";
   const lines = raw.split("\n");
   if (lines.length <= maxLines) return raw;
-  const head = Math.ceil(maxLines * 0.7);
-  const tail = maxLines - head;
+  // Reserve one line for the elision marker so the result stays ≤ maxLines
+  // (keeps compactToolOutputForMemory / expand body idempotent).
+  const room = Math.max(2, maxLines - 1);
+  const head = Math.ceil(room * 0.7);
+  const tail = room - head;
   const elided = lines.length - head - tail;
   return [
     ...lines.slice(0, head),

--- a/src/lib/toolOutputMemory.test.ts
+++ b/src/lib/toolOutputMemory.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  TOOL_OUTPUT_MEMORY_MAX_CHARS,
+  compactToolOutputForMemory,
+  maybeCompactToolOutputForMemory,
+  shouldCompactToolOutputForMemory,
+} from "./toolOutputMemory";
+
+describe("compactToolOutputForMemory", () => {
+  it("leaves short output alone", () => {
+    expect(compactToolOutputForMemory("ok\n")).toBe("ok");
+    expect(shouldCompactToolOutputForMemory("ok")).toBe(false);
+  });
+
+  it("elides the middle of many lines like expand UI", () => {
+    const lines = Array.from({ length: 900 }, (_, i) => `L${i}`);
+    const out = compactToolOutputForMemory(lines.join("\n"));
+    expect(out).toContain("L0");
+    expect(out).toContain("L899");
+    expect(out).toMatch(/more lines/);
+    expect(out.split("\n").length).toBeLessThan(900);
+    expect(shouldCompactToolOutputForMemory(lines.join("\n"))).toBe(true);
+  });
+
+  it("caps very long lines by characters", () => {
+    const long = "x".repeat(TOOL_OUTPUT_MEMORY_MAX_CHARS + 5000);
+    const out = compactToolOutputForMemory(long);
+    expect(out.length).toBeLessThanOrEqual(TOOL_OUTPUT_MEMORY_MAX_CHARS);
+    expect(out.startsWith("xxx")).toBe(true);
+    expect(out.endsWith("xxx")).toBe(true);
+    expect(out).toContain("…");
+  });
+
+  it("is idempotent", () => {
+    const lines = Array.from({ length: 600 }, (_, i) => `row-${i}`).join("\n");
+    const once = compactToolOutputForMemory(lines);
+    expect(compactToolOutputForMemory(once)).toBe(once);
+  });
+});
+
+describe("maybeCompactToolOutputForMemory", () => {
+  it("keeps raw output while running", () => {
+    const long = Array.from({ length: 500 }, (_, i) => `L${i}`).join("\n");
+    expect(maybeCompactToolOutputForMemory(long, true)).toBe(long);
+  });
+
+  it("compacts on terminal status", () => {
+    const long = Array.from({ length: 500 }, (_, i) => `L${i}`).join("\n");
+    const out = maybeCompactToolOutputForMemory(long, false)!;
+    expect(out.length).toBeLessThan(long.length);
+    expect(out).toContain("L0");
+  });
+});

--- a/src/lib/toolOutputMemory.ts
+++ b/src/lib/toolOutputMemory.ts
@@ -1,0 +1,59 @@
+/**
+ * Keep completed tool stdout small in React / WebContent heap (#1029).
+ *
+ * Host already caps each tool at ~20k chars, but live state often holds that
+ * twice (standalone `tool_step.toolOutput` + assistant `segments[].output`).
+ * Expand UI only ever paints {@link toolOutputBody} (≤400 lines), so storing
+ * anything larger than that elided form wastes RAM without changing expand UX.
+ *
+ * Running tools keep the growing raw buffer; we compact only on terminal
+ * status so a mid-run expand still sees the latest chunks.
+ */
+
+import { toolOutputBody } from "@/lib/toolDisplay";
+
+/** Line budget — same as expand body so compact ≡ what the user already sees. */
+export const TOOL_OUTPUT_MEMORY_MAX_LINES = 400;
+
+/**
+ * Hard char ceiling after line elide (very long lines can still bloat 400 rows).
+ * Head-heavy so errors / file headers stay visible.
+ */
+export const TOOL_OUTPUT_MEMORY_MAX_CHARS = 8_000;
+
+/** Compact stdout for in-memory chat state (idempotent). */
+export function compactToolOutputForMemory(
+  output: string,
+  maxLines: number = TOOL_OUTPUT_MEMORY_MAX_LINES,
+  maxChars: number = TOOL_OUTPUT_MEMORY_MAX_CHARS,
+): string {
+  const byLines = toolOutputBody(output, maxLines);
+  if (byLines.length <= maxChars) return byLines;
+  const marker = "\n…\n";
+  const budget = maxChars - marker.length;
+  if (budget < 64) return byLines.slice(0, maxChars);
+  const head = Math.ceil(budget * 0.7);
+  const tail = budget - head;
+  return byLines.slice(0, head).trimEnd() + marker + byLines.slice(-tail).trimStart();
+}
+
+/** True when compacting would shrink the string (skip no-ops). */
+export function shouldCompactToolOutputForMemory(
+  output: string | null | undefined,
+): boolean {
+  if (!output) return false;
+  return compactToolOutputForMemory(output) !== output;
+}
+
+/**
+ * Apply memory compact when the tool is no longer running.
+ * Returns `output` unchanged while pending / in_progress.
+ */
+export function maybeCompactToolOutputForMemory(
+  output: string | null | undefined,
+  running: boolean,
+): string | undefined {
+  if (!output) return output || undefined;
+  if (running) return output;
+  return compactToolOutputForMemory(output);
+}


### PR DESCRIPTION
Fixes #1029

## Summary
Codex (`gpt-6-astra`) + codebase diagnosis agreed on a tiered approach:

1. **While running** — keep raw growing stdout on the segment  
2. **On completed/failed** — replace in-memory output with the same elided form expand already paints (`toolOutputBody`, ≤400 lines / 8k chars)  
3. **After weave** — clear `toolOutput` on standalone `tool_step` rows so React does not hold two copies  
4. **Journal hydrate** — compact on `mapStoredMessages` so reloads do not re-inflate the heap  

Spill-to-disk deferred: expand already shows the elided body, so compact ≡ UX. Disk spill only needed if we later add “open full unelided output”.

Also fixes `toolOutputBody` off-by-one (result was `maxLines+1`), making compact idempotent.

## Test
- `pnpm exec vitest run` toolOutputMemory / session.tools / mapStoredMessages / toolDisplay — 63 passed  
- `pnpm typecheck` — pass  
- code-quality gates — PASS  