### PR TITLE
refactor(workbench): extract git worktree and ship chrome

### DIFF
--- a/docs/plans/CODE-QUALITY-PROGRESS.md
+++ b/docs/plans/CODE-QUALITY-PROGRESS.md
@@ -12,7 +12,7 @@
 | Spec | `docs/plans/2026-08-01-code-quality-remediation-GOAL.md` |
 | Started | `2026-08-01` |
 | Current wave | `workbench-decomp` |
-| Current WP | `WP-W27` |
+| Current WP | `WP-W28` |
 | **FINAL** | **PASS** (honest orchestration metrics; decreasing ceilings) |
 
 ## Wave checklist
@@ -73,6 +73,7 @@
 | WP-W25 | Settings overlay nav into useSettingsNavigation | PASS | 5003a52a | 15956→15612 lines; useState 214→209; useEffect 83→81 |
 | WP-W26 | Settings prefs hydrate into useAppSettingsPrefs | PASS | aae65cf4 | 15612→15471 lines; useState 209→156 |
 | WP-W27 | Session connect + live map into useSessionConnect | PASS | aae65cf4 | 15471→15183 lines; useState 156→155; useEffect 81→80 |
+| WP-W28 | Git worktree + ship chrome into useGitWorktreeChrome | PASS |  | #1033; 15237→14416 lines; useState 154→122; useEffect 78→75 |
 
 ## Metrics log (append-only)
 
@@ -111,6 +112,7 @@
 | 2026-08-24 W25 | 15612 (shell 18 + wb 15594) | 209 | 81 | 11 | dir | dir | 28 | 9 | 69 |
 | 2026-08-24 W26 | 15471 (shell 18 + wb 15453) | 156 | 81 | 11 | dir | dir | 28 | 9 | 69 |
 | 2026-08-24 W27 | 15183 (shell 18 + wb 15165) | 155 | 80 | 11 | dir | dir | 28 | 9 | 69 |
+| 2026-09-05 W28 | 14416 (shell 21 + wb 14395) | 122 | 75 | 12 | dir | dir | 29 | 9 | 80 |
 
 ## Blockers
 
@@ -136,7 +138,7 @@ Parallel non-overlapping tracks (multi-agent) — **landed**:
 | residual-resource-viewer | ResourceViewer + parts | **PASS** | 4938→modules |
 | residual-i18n | `src/i18n/**` | **PASS** | domain modules + barrels |
 | residual-settings | SettingsPage + settings/* | **PASS** | 8874→1817 |
-| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W27: settings nav/prefs + connect/live map extracted; #870 closed |
+| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W28: git worktree list/create/GC/ship extracted; #870 closed |
 | residual-settings-catalog | settingsCatalog split | **PASS** | domain entries |
 
-Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **15350 / 160 useState / 83 useEffect**; `files_ge_1000` **≤80** (0.2.31 tree count 79; was ≤77 at 0.2.28). #870 closed. Shrink large files in follow-on waves — do not keep raising this budget.
+Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **14650 / 130 useState / 80 useEffect**; `files_ge_1000` **≤80** (0.2.31 tree count 79; was ≤77 at 0.2.28). #870 closed. Shrink large files in follow-on waves — do not keep raising this budget.

--- a/docs/plans/HANDOFF-appworkbench-decomposition.md
+++ b/docs/plans/HANDOFF-appworkbench-decomposition.md
@@ -59,6 +59,7 @@
    **WP-W25 已落地**：Settings 开合 / section / tab / focus / hash / last-route / native cover → `useSettingsNavigation`。labels 袋 → `settingsLabels.ts`。host 仍持 settingsGet 水合与 prefs 值。天花板 **15790 / 214 / 84**。
    **WP-W26 已落地**：Host AppSettings prefs 水合 → `parseAppSettingsPrefs` + `useAppSettingsPrefs`。locale/composer chips/CLI probe 仍在 boot。天花板见 W27。
    **WP-W27 已落地**：ensureConnected + connecting claims + liveMap 订阅 → `useSessionConnect`。#870 验收：改 settings 导航/prefs/connect 不必打开 host 函数体。天花板 **15350 / 160 / 83**。
+   **WP-W28 已落地**：git worktree 列表 / 创建 / GC / ship / switch / remove / 徽章 → `useGitWorktreeChrome`。overlay 收成 `worktreeChrome` 一袋。git dirty 仍在 host，经 `applyStatusBranch` 补 branch chip。天花板 **14650 / 130 / 80**。下一步 Side Workbench。
    **pi**：协作者本机无 pi，按 owner 规则跳过。
    **5 个 worktree**：误会。远端 `main` 已含那些产品改动（本地只是 squash 后残留 SHA）。不挡大拆。
 5. 5.6k 行 JSX 拆为 view shell + 域容器；modals 先经既有 `useAppDialogs` 收口。

--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -43,9 +43,9 @@ APP_ORCH_FILES = (
 # Decreasing ceilings at current combined scale. Ratchet down each
 # workbench-extraction WP. The old 6000/100/50 numbers measured the 26-line
 # shell after the God Component was renamed — not a budget to grow into.
-APP_LINES_CEILING = 15350
-APP_USESTATE_CEILING = 160
-APP_USEEFFECT_CEILING = 83
+APP_LINES_CEILING = 14650
+APP_USESTATE_CEILING = 130
+APP_USEEFFECT_CEILING = 80
 
 
 def lines_of(path: Path) -> int:

--- a/src-tauri/src/mac_ime_fn_bridge.rs
+++ b/src-tauri/src/mac_ime_fn_bridge.rs
@@ -148,8 +148,7 @@ unsafe fn post_right_option_tap(ns_app: *mut objc2::runtime::AnyObject) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
-    let empty: *mut AnyObject =
-        msg_send![class!(NSString), stringWithUTF8String: b"\0".as_ptr() as *const i8];
+    let empty: *mut AnyObject = msg_send![class!(NSString), stringWithUTF8String: c"".as_ptr()];
     let loc = CGPoint { x: 0.0, y: 0.0 };
     for ty in [NS_EVENT_TYPE_KEY_DOWN, NS_EVENT_TYPE_KEY_UP] {
         let ev: *mut AnyObject = msg_send![

--- a/src-tauri/src/mac_ime_fn_bridge.rs
+++ b/src-tauri/src/mac_ime_fn_bridge.rs
@@ -12,8 +12,8 @@
 
 #![cfg(target_os = "macos")]
 
-use std::sync::Once;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Once;
 
 /// Hardware Fn / Globe (kVK_Function). WebKit ignores this in flagsChanged.
 pub const FN_KEY_CODE: u16 = 63;
@@ -174,7 +174,7 @@ unsafe fn post_right_option_tap(ns_app: *mut objc2::runtime::AnyObject) {
 
 #[cfg(test)]
 mod tests {
-    use super::{FN_KEY_CODE, RIGHT_OPTION_KEY_CODE, input_source_looks_like_doubao};
+    use super::{input_source_looks_like_doubao, FN_KEY_CODE, RIGHT_OPTION_KEY_CODE};
 
     #[test]
     fn fn_keycode_is_apple_function_key() {
@@ -189,6 +189,8 @@ mod tests {
         ));
         assert!(input_source_looks_like_doubao("com.foo.Doubao.bar"));
         assert!(!input_source_looks_like_doubao("com.apple.keylayout.ABC"));
-        assert!(!input_source_looks_like_doubao("com.sogou.inputmethod.pinyin"));
+        assert!(!input_source_looks_like_doubao(
+            "com.sogou.inputmethod.pinyin"
+        ));
     }
 }

--- a/src-tauri/src/win_file_drop.rs
+++ b/src-tauri/src/win_file_drop.rs
@@ -33,10 +33,10 @@ use windows::{
         Foundation::{HWND, LPARAM, POINT, POINTL},
         Graphics::Gdi::ScreenToClient,
         System::{
-            Com::{IDataObject, ReleaseStgMedium, DVASPECT_CONTENT, FORMATETC, TYMED_HGLOBAL},
+            Com::{IDataObject, DVASPECT_CONTENT, FORMATETC, TYMED_HGLOBAL},
             Ole::{
-                IDropTarget, IDropTarget_Impl, OleInitialize, RegisterDragDrop, RevokeDragDrop,
-                CF_HDROP, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_NONE,
+                IDropTarget, IDropTarget_Impl, OleInitialize, RegisterDragDrop, ReleaseStgMedium,
+                RevokeDragDrop, CF_HDROP, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_NONE,
             },
             SystemServices::MODIFIERKEYS_FLAGS,
         },
@@ -176,7 +176,7 @@ fn inject_hwnd(hwnd: HWND, coordinate_hwnd: HWND, listener: Rc<dyn Fn(DropKind)>
     if hwnd.0.is_null() {
         return false;
     }
-    let target: IDropTarget = FileDropTarget::new(hwnd, coordinate_hwnd, listener).into();
+    let target: IDropTarget = FileDropTarget::new(coordinate_hwnd, listener).into();
     // Best-effort revoke (hwnd may never have been a drop target — that is OK).
     let _ = unsafe { RevokeDragDrop(hwnd) };
     match unsafe { RegisterDragDrop(hwnd, &target) } {
@@ -230,7 +230,6 @@ fn enum_child_hwnds(parent: HWND) -> Vec<HWND> {
 
 #[implement(IDropTarget)]
 struct FileDropTarget {
-    hwnd: HWND,
     coordinate_hwnd: HWND,
     listener: Rc<dyn Fn(DropKind)>,
     cursor_effect: UnsafeCell<DROPEFFECT>,
@@ -238,9 +237,8 @@ struct FileDropTarget {
 }
 
 impl FileDropTarget {
-    fn new(hwnd: HWND, coordinate_hwnd: HWND, listener: Rc<dyn Fn(DropKind)>) -> Self {
+    fn new(coordinate_hwnd: HWND, listener: Rc<dyn Fn(DropKind)>) -> Self {
         Self {
-            hwnd,
             coordinate_hwnd,
             listener,
             cursor_effect: UnsafeCell::new(DROPEFFECT_NONE),

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -461,7 +461,6 @@ import type { MessageKey } from "@/i18n";
 import { ImageViewerProvider } from "@/components/ImageViewer";
 import {
   type SidebarSessionRowLabels,
-  type SidebarSessionWorktreeBadgeProp,
 } from "@/components/SidebarSessionRow";
 import { sidebarSessionRowMetrics } from "@/lib/sidebarDensity";
 import { sortSessionsForSidebar } from "@/lib/sidebarDateGroups";
@@ -482,36 +481,9 @@ import {
 } from "@/components/ComposerEditor";
 
 import {
-  applyGitStatusBranch,
-  buildWorktreePath,
-  canRemoveWorktree,
-  mainWorktreePath,
-  normalizeWorktreeLayout,
   pathsEqual,
-  resolveSessionWorktreeBadge,
-  sanitizeWorktreeName,
-  sanitizeWorktreeRef,
-  sessionWorktreeTooltip,
   worktreeEntryForPath,
-  worktreeRemoveErrorSuggestsForce,
-  type SessionWorktreeBadge,
-  type WorktreeLayout,
 } from "@/lib/gitWorktree";
-import { filterCliWorktreesForProject } from "@/lib/cliWorktrees";
-import {
-  canShipWorktree,
-  combineShipOutcome,
-  defaultPrTitleFromBranch,
-  redactShipOutput,
-  sanitizePrBody,
-  sanitizePrTitle,
-  shipOutcomeSummary,
-} from "@/lib/wtShipFlow";
-import {
-  PR_HUB_ANCHOR_ID,
-  buildPrHubDeepLink,
-  parseGithubPrNumber,
-} from "@/lib/prHubDeepLink";
 import {
   buildForkWorktreeName,
   canRestoreCodeOnFork,
@@ -695,6 +667,10 @@ import type { ContextMenuState } from "@/lib/app/appDialogTypes";
 import { useSessionRuntime } from "@/hooks/useSessionRuntime";
 import { sessionTranscriptStore } from "@/lib/sessionTranscriptStore";
 import { useSessionConnect, createSessionConnectHost } from "@/hooks/useSessionConnect";
+import {
+  createGitWorktreeChromeHost,
+  useGitWorktreeChrome,
+} from "@/hooks/useGitWorktreeChrome";
 import { useComposerController } from "@/hooks/useComposerController";
 import { useTypeToFocusComposer } from "@/hooks/useTypeToFocusComposer";
 import { useAppDialogs } from "@/hooks/useAppDialogs";
@@ -1414,6 +1390,7 @@ export function AppWorkbench() {
   const automationAppliedRef = useRef(new Set<string>());
   const sessionNavHostRef = useRef(createSessionNavHost());
   const sessionConnectHostRef = useRef(createSessionConnectHost());
+  const gitWorktreeHostRef = useRef(createGitWorktreeChromeHost());
   const {
     openSession,
     newChat,
@@ -2092,62 +2069,31 @@ export function AppWorkbench() {
   const [batchAgentsOpen, setBatchAgentsOpen] = useState(false);
   /** Ops hub (palette open-ops) — routes to tasks / dashboard / board / batch. */
   const [opsEntryOpen, setOpsEntryOpen] = useState(false);
-  const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
-  /** null = unknown/loading; true = git work tree; false = not a git repo. */
-  const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
-    boolean | null
-  >(null);
-  const [gitWorktreesLoading, setGitWorktreesLoading] = useState(false);
-  const [gitWorktreesReason, setGitWorktreesReason] = useState<string | null>(
-    null,
-  );
-  /** New worktree dialog (name + optional start-point + layout). */
-  const [worktreeCreateOpen, setWorktreeCreateOpen] = useState(false);
-  const [worktreeCreateName, setWorktreeCreateName] = useState("");
-  const [worktreeCreateRef, setWorktreeCreateRef] = useState("");
-  /** Default CLI-aligned (`~/.grok/worktrees`); optional sibling. */
-  const [worktreeCreateLayout, setWorktreeCreateLayout] =
-    useState<WorktreeLayout>("cli");
-  const [worktreeCreateBusy, setWorktreeCreateBusy] = useState(false);
-  const [worktreeCreateError, setWorktreeCreateError] = useState<string | null>(
-    null,
-  );
-  /** When true, after create bind cwd and open a draft chat on that path. */
-  const [worktreeCreateStartChat, setWorktreeCreateStartChat] = useState(false);
-  /** Absolute `~/.grok` from host list (CLI path preview + badge detection). */
-  const [cliGrokHome, setCliGrokHome] = useState<string | null>(null);
-  /** CLI-tracked worktrees from `grok worktree list` (soft-fail). */
-  const [cliWorktrees, setCliWorktrees] = useState<api.CliWorktreeEntry[]>([]);
-  const [cliWorktreesAvailable, setCliWorktreesAvailable] = useState<
-    boolean | null
-  >(null);
-  const [cliWorktreesLoading, setCliWorktreesLoading] = useState(false);
-  const [cliWorktreesReason, setCliWorktreesReason] = useState<string | null>(
-    null,
-  );
-  /** Clean stale worktrees (git worktree prune) dialog. */
-  const [worktreeGcOpen, setWorktreeGcOpen] = useState(false);
-  const [worktreeGcForce, setWorktreeGcForce] = useState(false);
-  const [worktreeGcBusy, setWorktreeGcBusy] = useState(false);
-  const [worktreeGcPreviewBusy, setWorktreeGcPreviewBusy] = useState(false);
-  const [worktreeGcError, setWorktreeGcError] = useState<string | null>(null);
-  const [worktreeGcPreview, setWorktreeGcPreview] =
-    useState<api.GitWorktreeGcResult | null>(null);
-  /** Worktree ship flow (push + Open PR) dialog. */
-  const [shipOpen, setShipOpen] = useState(false);
-  const [shipTitle, setShipTitle] = useState("");
-  const [shipBody, setShipBody] = useState("");
-  const [shipDraft, setShipDraft] = useState(false);
-  const [shipCreatePr, setShipCreatePr] = useState(true);
-  const [shipBusy, setShipBusy] = useState(false);
-  const [shipError, setShipError] = useState<string | null>(null);
-  const [shipBranch, setShipBranch] = useState<string | null>(null);
-  const [shipStatus, setShipStatus] = useState<string | null>(null);
-  /** After successful `gh pr create` — success panel with URL + Open in PR hub. */
-  const [shipSuccess, setShipSuccess] = useState<{
-    prUrl: string;
-    prNumber: number | null;
-  } | null>(null);
+  const {
+    gitWorktrees,
+    gitWorktreesAvailable,
+    gitWorktreesLoading,
+    gitWorktreesReason,
+    cliWorktrees,
+    cliWorktreesAvailable,
+    cliWorktreesLoading,
+    cliWorktreesReason,
+    openWorktreeCreate,
+    openWorktreeGc,
+    openShipFlow,
+    confirmRemoveWorktree,
+    switchToWorktree,
+    markSessionWorktree,
+    sessionWorktreeBadgeFor,
+    buildSidebarWorktreeBadge,
+    refreshGitWorktrees,
+    refreshCliWorktrees,
+    applyStatusBranch,
+    worktreeChrome,
+  } = useGitWorktreeChrome({
+    hostRef: gitWorktreeHostRef,
+    projectPath: activeProject?.path ?? null,
+  });
   /** Host stream-stall prompt (I06); null when dismissed or not stalled. */
   const [streamStall, setStreamStall] = useState<{
     sessionId?: string;
@@ -10130,125 +10076,6 @@ export function AppWorkbench() {
     [requestMove, session.sessionId, sessions],
   );
 
-  const gitWorktreesReqRef = useRef(0);
-  const gitWorktreesPathRef = useRef<string | null>(null);
-  const refreshGitWorktrees = useCallback(async () => {
-    const path = activeProject?.path?.trim() || null;
-    if (!path || !api.isTauri()) {
-      gitWorktreesReqRef.current += 1;
-      gitWorktreesPathRef.current = null;
-      setGitWorktrees([]);
-      setGitWorktreesAvailable(null);
-      setGitWorktreesReason(null);
-      setCliGrokHome(null);
-      setGitWorktreesLoading(false);
-      return;
-    }
-    const reqId = ++gitWorktreesReqRef.current;
-    // Drop stale rows when the active project path changes; soft-refresh keeps
-    // the previous list for the same path so the menu does not flash empty.
-    if (gitWorktreesPathRef.current !== path) {
-      gitWorktreesPathRef.current = path;
-      setGitWorktrees([]);
-      setGitWorktreesAvailable(null);
-      setGitWorktreesReason(null);
-    }
-    setGitWorktreesLoading(true);
-    try {
-      const res = await api.gitWorktreesList(path);
-      if (reqId !== gitWorktreesReqRef.current) return;
-      const home = (res.cliGrokHome || "").trim() || null;
-      if (home) setCliGrokHome(home);
-      if (!res.available) {
-        setGitWorktrees([]);
-        setGitWorktreesAvailable(false);
-        setGitWorktreesReason(res.reason?.trim() || "unavailable");
-      } else {
-        setGitWorktrees(res.worktrees ?? []);
-        setGitWorktreesAvailable(true);
-        setGitWorktreesReason(null);
-      }
-    } catch (e) {
-      if (reqId !== gitWorktreesReqRef.current) return;
-      setGitWorktrees([]);
-      setGitWorktreesAvailable(false);
-      setGitWorktreesReason(String(e));
-    } finally {
-      if (reqId === gitWorktreesReqRef.current) {
-        setGitWorktreesLoading(false);
-      }
-    }
-  }, [activeProject?.path]);
-
-  useEffect(() => {
-    void refreshGitWorktrees();
-  }, [refreshGitWorktrees]);
-
-  const cliWorktreesReqRef = useRef(0);
-  const refreshCliWorktrees = useCallback(async () => {
-    if (!api.isTauri()) {
-      cliWorktreesReqRef.current += 1;
-      setCliWorktrees([]);
-      setCliWorktreesAvailable(null);
-      setCliWorktreesReason(null);
-      setCliWorktreesLoading(false);
-      return;
-    }
-    const reqId = ++cliWorktreesReqRef.current;
-    setCliWorktreesLoading(true);
-    try {
-      const projectPath = activeProject?.path?.trim() || null;
-      const repoSlug = projectPath
-        ? projectPath.replace(/\\/g, "/").split("/").filter(Boolean).pop() ||
-          null
-        : null;
-      const res = await api.cliWorktreesList({
-        all: false,
-        // CLI --repo matches repo_name (e.g. grok-app), not folder basename.
-        // Leave unfiltered; UI filters by source path / worktrees slug.
-        repo: null,
-      });
-      if (reqId !== cliWorktreesReqRef.current) return;
-      if (!res.available) {
-        setCliWorktrees([]);
-        setCliWorktreesAvailable(false);
-        setCliWorktreesReason(res.reason?.trim() || "unavailable");
-      } else {
-        // Prefer rows for the active project when we can match source/repo.
-        const filtered = filterCliWorktreesForProject(
-          res.worktrees ?? [],
-          projectPath,
-          repoSlug,
-        );
-        setCliWorktrees(filtered);
-        setCliWorktreesAvailable(true);
-        setCliWorktreesReason(null);
-      }
-    } catch (e) {
-      if (reqId !== cliWorktreesReqRef.current) return;
-      setCliWorktrees([]);
-      setCliWorktreesAvailable(false);
-      setCliWorktreesReason(String(e));
-    } finally {
-      if (reqId === cliWorktreesReqRef.current) {
-        setCliWorktreesLoading(false);
-      }
-    }
-  }, [activeProject?.path]);
-
-  useEffect(() => {
-    // Load CLI list when the branch menu can appear (git work tree confirmed).
-    if (gitWorktreesAvailable === true) {
-      void refreshCliWorktrees();
-    } else if (gitWorktreesAvailable === false) {
-      cliWorktreesReqRef.current += 1;
-      setCliWorktrees([]);
-      setCliWorktreesAvailable(null);
-      setCliWorktreesReason(null);
-      setCliWorktreesLoading(false);
-    }
-  }, [gitWorktreesAvailable, refreshCliWorktrees]);
-
   /**
    * Poll workspace git status for the active project so the composer dirty chip
    * stays current (hide when clean / not a repo). Soft-fail; no toast spam.
@@ -10271,12 +10098,12 @@ export function AppWorkbench() {
       );
       // Same poll already has HEAD. Patch the composer branch chip so an
       // in-place checkout does not stay stale until the menu is clicked.
-      setGitWorktrees((prev) => applyGitStatusBranch(prev, path, status));
+      applyStatusBranch(path, status);
     } catch {
       if (reqId !== gitDirtyReqRef.current) return;
       setGitDirtySummary((prev) => (prev == null ? prev : null));
     }
-  }, [activeProject?.path]);
+  }, [activeProject?.path, applyStatusBranch]);
 
   useEffect(() => {
     void refreshGitDirtyStatus();
@@ -10365,611 +10192,27 @@ export function AppWorkbench() {
     ],
   );
 
-  /** Open gc dialog and run dry-run preview. */
-  const openWorktreeGc = useCallback(() => {
-    setWorktreeGcForce(false);
-    setWorktreeGcError(null);
-    setWorktreeGcBusy(false);
-    setWorktreeGcPreview(null);
-    setWorktreeGcOpen(true);
-  }, []);
-
-  /** Open Ship… dialog for the active project / worktree cwd. */
-  const openShipFlow = useCallback(() => {
-    if (!api.isTauri() || !activeProject?.path) {
-      showToast(tr("composer.worktreeShipNeedProject"), 3500);
-      return;
-    }
-    const current =
-      gitWorktrees.find((w) => pathsEqual(w.path, activeProject.path)) ?? null;
-    const branch =
-      current?.branch?.trim() ||
-      (session.sessionId
-        ? sessions.find((s) => s.id === session.sessionId)?.worktreeBranch
-        : null) ||
-      null;
-    if (
-      !canShipWorktree({
-        branch,
-        detached: current?.detached ?? !branch,
-        available: gitWorktreesAvailable,
-      })
-    ) {
-      // Still allow open with empty title if branch unknown — host resolves HEAD.
-      // But refuse detached when we know it.
-      if (current?.detached) {
-        showToast(tr("composer.worktreeShipDetached"), 4000);
-        return;
-      }
-    }
-    setShipBranch(branch);
-    setShipTitle(defaultPrTitleFromBranch(branch));
-    setShipBody("");
-    setShipDraft(false);
-    setShipCreatePr(true);
-    setShipError(null);
-    setShipStatus(null);
-    setShipSuccess(null);
-    setShipBusy(false);
-    setShipOpen(true);
-  }, [
-    activeProject?.path,
-    gitWorktrees,
-    gitWorktreesAvailable,
-    session.sessionId,
-    sessions,
-    showToast,
-    tr,
-  ]);
-
-  /** Close ship dialog and clear transient success state. */
-  const closeShipFlow = useCallback(() => {
-    if (shipBusy) return;
-    setShipOpen(false);
-    setShipError(null);
-    setShipStatus(null);
-    setShipSuccess(null);
-  }, [shipBusy]);
-
-  /**
-   * Navigate to Settings → Runtime → Tools PR hub for the active project,
-   * optionally highlighting a PR number. Soft-fails with a toast (never throws).
-   */
-  const openPrHubFromShip = useCallback(
-    (prNumber: number | null) => {
-      try {
-        if (!activeProject?.path?.trim()) {
-          showToast(tr("composer.worktreeShipOpenHubFailed"), 4000);
-          return;
-        }
-        setPrHubHighlightPr(prNumber);
-        setSettingsFocusAnchor(PR_HUB_ANCHOR_ID);
-        navigateSettings("runtime", "tools");
-        if (typeof window !== "undefined") {
-          const hash = buildPrHubDeepLink({ prNumber });
-          if (window.location.hash !== hash) {
-            window.location.hash = hash;
-          }
-        }
-        setShipOpen(false);
-        setShipSuccess(null);
-        setShipError(null);
-        setShipStatus(null);
-      } catch {
-        showToast(tr("composer.worktreeShipOpenHubFailed"), 4000);
-      }
-    },
-    [activeProject?.path, navigateSettings, showToast, tr],
-  );
-
-  const submitShipFlow = useCallback(async () => {
-    if (!api.isTauri() || !activeProject?.path) return;
-    let title: string;
-    let body: string;
-    try {
-      title = sanitizePrTitle(shipTitle);
-      body = sanitizePrBody(shipBody);
-    } catch (e) {
-      setShipError(String(e));
-      return;
-    }
-    setShipBusy(true);
-    setShipError(null);
-    setShipSuccess(null);
-    setShipStatus(tr("composer.worktreeShipPushing"));
-    try {
-      const push = await api.gitPushBranch(activeProject.path);
-      let pr: api.GhPrCreateResult | null = null;
-      if (shipCreatePr) {
-        setShipStatus(tr("composer.worktreeShipCreatingPr"));
-        pr = await api.ghPrCreate({
-          projectPath: activeProject.path,
-          title,
-          body,
-          draft: shipDraft,
-          base: "main",
-        });
-      }
-      const outcome = combineShipOutcome(push, pr, {
-        createPr: shipCreatePr,
-      });
-      const summary = shipOutcomeSummary(outcome);
-      if (outcome.ok) {
-        setShipStatus(null);
-        if (outcome.prUrl) {
-          // Success panel: PR URL + Open in PR hub (do not force-close).
-          const prNumber = parseGithubPrNumber(outcome.prUrl);
-          setShipSuccess({ prUrl: outcome.prUrl, prNumber });
-        } else {
-          setShipOpen(false);
-          setShipSuccess(null);
-        }
-      } else {
-        const detail = redactShipOutput(
-          outcome.failReason ||
-            pr?.reason ||
-            push.reason ||
-            summary ||
-            "ship failed",
-          600,
-        );
-        setShipError(detail);
-        setShipStatus(null);
-        // Honest toast — never claim PR opened when gh failed.
-        showToast(
-          shipCreatePr
-            ? tr("composer.worktreeShipFailed", { reason: detail })
-            : tr("composer.worktreeShipPushFailed", { reason: detail }),
-          6000,
-        );
-      }
-    } catch (e) {
-      const msg = redactShipOutput(String(e), 600);
-      setShipError(msg);
-      setShipStatus(null);
-      showToast(tr("composer.worktreeShipFailed", { reason: msg }), 6000);
-    } finally {
-      setShipBusy(false);
-    }
-  }, [
-    activeProject?.path,
-    shipBody,
-    shipCreatePr,
-    shipDraft,
-    shipTitle,
-    showToast,
-    tr,
-  ]);
-
-  /** Dry-run `git worktree prune` for the modal preview. */
-  const refreshWorktreeGcPreview = useCallback(async () => {
-    if (!api.isTauri() || !activeProject?.path || !worktreeGcOpen) return;
-    setWorktreeGcPreviewBusy(true);
-    setWorktreeGcError(null);
-    try {
-      const res = await api.gitWorktreeGc(
-        activeProject.path,
-        true,
-        worktreeGcForce,
-      );
-      setWorktreeGcPreview(res);
-    } catch (e) {
-      setWorktreeGcPreview(null);
-      setWorktreeGcError(String(e));
-    } finally {
-      setWorktreeGcPreviewBusy(false);
-    }
-  }, [activeProject?.path, worktreeGcForce, worktreeGcOpen]);
-
-  useEffect(() => {
-    if (!worktreeGcOpen) return;
-    void refreshWorktreeGcPreview();
-  }, [worktreeGcOpen, refreshWorktreeGcPreview]);
-
-  /** Apply prune (non-dry-run), refresh list, toast. */
-  const submitWorktreeGc = useCallback(async () => {
-    if (!api.isTauri() || !activeProject?.path) return;
-    setWorktreeGcBusy(true);
-    setWorktreeGcError(null);
-    try {
-      setWorktreeGcOpen(false);
-      setWorktreeGcPreview(null);
-      setWorktreeGcForce(false);
-      await refreshGitWorktrees();
-    } catch (e) {
-      setWorktreeGcError(String(e));
-    } finally {
-      setWorktreeGcBusy(false);
-    }
-  }, [
-    activeProject?.path,
-    refreshGitWorktrees,
-    showToast,
-    tr,
-    worktreeGcForce,
-  ]);
-
-  /** Open a linked worktree as project cwd (reuse existing project if path matches). */
-  const switchToWorktree = useCallback(
-    async (wt: api.GitWorktreeEntry) => {
-      if (!api.isTauri()) return;
-      const path = wt.path?.trim();
-      if (!path) return;
-      try {
-        const existing = projects.find((p) => pathsEqual(p.path, path));
-        if (existing) {
-          await bindSessionProject(existing);
-          return;
-        }
-        const trust = !!activeProject?.trusted;
-        const added = (await api.projectAdd(path, trust)) as Project;
-        const list = mapProjectsList((await api.projectsList()) as Project[]);
-        setProjects(list);
-        projectSpaces.assignNewProjects([added.id]);
-        const proj = list.find((p) => p.id === added.id) ?? added;
-        if (!proj.trusted) {
-          await finalizeAddedProject(proj, { bindSession: true });
-        } else {
-          await bindSessionProject(proj);
-        }
-      } catch (e) {
-        showToast(String(e), 4500);
-      }
-    },
-    [
-      activeProject?.trusted,
-      bindSessionProject,
-      finalizeAddedProject,
-      projects,
-      showToast,
-      tr,
-    ],
-  );
-
-  /**
-   * Remove a live linked worktree via host `git_worktree_remove`.
-   * Never removes main. Dirty trees: first attempt without force, then
-   * in-app confirm for force. If the active cwd is removed, switch to main.
-   */
-  const executeWorktreeRemove = useCallback(
-    async (wt: api.GitWorktreeEntry, force: boolean) => {
-      if (!api.isTauri() || !canRemoveWorktree(wt)) return;
-      const mainPath =
-        mainWorktreePath(gitWorktrees) || activeProject?.path?.trim() || "";
-      if (!mainPath) {
-        showToast(tr("composer.worktreeRemoveFailed"), 4000);
-        return;
-      }
-      const wasCurrent = pathsEqual(wt.path, activeProject?.path);
-      try {
-        await api.gitWorktreeRemove({
-          projectPath: mainPath,
-          worktreePath: wt.path,
-          force,
-        });
-        // Drop WT meta on sessions that pointed at the removed tree.
-        try {
-          const linked = sessions.filter(
-            (s) =>
-              s.isWorktreeSession ||
-              pathsEqual(s.worktreePath, wt.path),
-          );
-          for (const s of linked) {
-            if (
-              pathsEqual(s.worktreePath, wt.path) ||
-              (!s.worktreePath &&
-                pathsEqual(
-                  projects.find((p) => p.id === s.projectId)?.path,
-                  wt.path,
-                ))
-            ) {
-              await api.sessionSetWorktree(s.id, {
-                worktreePath: null,
-                worktreeBranch: null,
-              });
-            }
-          }
-          if (linked.length) await refreshSessions();
-        } catch {
-          /* soft-fail */
-        }
-        if (wasCurrent) {
-          const main =
-            gitWorktrees.find((w) => w.isMain) ??
-            gitWorktrees.find((w) => pathsEqual(w.path, mainPath)) ??
-            null;
-          if (main) {
-            await switchToWorktree(main);
-          } else {
-            await refreshGitWorktrees();
-          }
-        } else {
-          await refreshGitWorktrees();
-        }
-      } catch (e) {
-        const err = String(e);
-        if (!force && worktreeRemoveErrorSuggestsForce(err)) {
-          setAppDialog({
-            kind: "confirm",
-            title: tr("composer.worktreeRemoveTitle"),
-            message: `${tr("composer.worktreeRemoveForce")}\n\n${err}`,
-            confirmLabel: tr("composer.worktreeRemove"),
-            danger: true,
-            onConfirm: () => {
-              void executeWorktreeRemove(wt, true);
-            },
-          });
-          return;
-        }
-        showToast(
-          `${tr("composer.worktreeRemoveFailed")}: ${err}`,
-          5000,
-        );
-      }
-    },
-    [
-      activeProject?.path,
-      gitWorktrees,
-      projects,
-      // refreshSessions via closure
-      sessions,
-      refreshGitWorktrees,
-      showToast,
-      switchToWorktree,
-      tr,
-    ],
-  );
-
-  const confirmRemoveWorktree = useCallback(
-    (wt: api.GitWorktreeEntry) => {
-      if (!canRemoveWorktree(wt)) return;
-      const branch =
-        wt.branch?.trim() || tr("composer.worktreeDetached");
-      const isCurrent = pathsEqual(wt.path, activeProject?.path);
-      const parts = [
-        tr("composer.worktreeRemoveHint"),
-        tr("composer.worktreeRemoveConfirm", {
-          branch,
-          path: wt.path,
-        }),
-      ];
-      if (isCurrent) {
-        parts.push(tr("composer.worktreeRemoveCurrentWarn"));
-      }
-      setAppDialog({
-        kind: "confirm",
-        title: tr("composer.worktreeRemoveTitle"),
-        message: parts.join("\n\n"),
-        confirmLabel: tr("composer.worktreeRemove"),
-        danger: true,
-        onConfirm: () => {
-          void executeWorktreeRemove(wt, false);
-        },
-      });
-    },
-    [activeProject?.path, executeWorktreeRemove, tr],
-  );
-
-  const openWorktreeCreate = useCallback((opts?: { startNewChat?: boolean }) => {
-    setWorktreeCreateName("");
-    setWorktreeCreateRef("");
-    setWorktreeCreateLayout("cli");
-    setWorktreeCreateError(null);
-    setWorktreeCreateBusy(false);
-    setWorktreeCreateStartChat(!!opts?.startNewChat);
-    setWorktreeCreateOpen(true);
-  }, []);
-
-  const worktreeCreatePreviewPath = (() => {
-    try {
-      const main = mainWorktreePath(gitWorktrees) || activeProject?.path || "";
-      if (!main || !worktreeCreateName.trim()) return null;
-      const layout = normalizeWorktreeLayout(worktreeCreateLayout);
-      if (layout === "cli" && !cliGrokHome) {
-        // Host has not reported home yet — show tilde form for CLI layout.
-        return buildWorktreePath(
-          "cli",
-          main,
-          worktreeCreateName.trim(),
-          "~/.grok",
-        );
-      }
-      return buildWorktreePath(
-        layout,
-        main,
-        worktreeCreateName.trim(),
-        cliGrokHome,
-      );
-    } catch {
-      return null;
-    }
-  })();
-
-  /**
-   * Persist worktree path/branch on a session (sidebar WT badge + manage menu).
-   * Soft-fails so create/switch UX is never blocked by meta write errors.
-   */
-  const markSessionWorktree = useCallback(
-    async (
-      sessionId: string | null | undefined,
-      path: string,
-      branch: string | null | undefined,
-    ) => {
-      if (!sessionId || !api.isTauri()) return;
-      const p = path.trim();
-      if (!p) return;
-      try {
-        await api.sessionSetWorktree(sessionId, {
-          worktreePath: p,
-          worktreeBranch: (branch || "").trim() || null,
-        });
-        await refreshSessions();
-      } catch {
-        /* soft-fail */
-      }
-    },
-    // refreshSessions is stable enough via closure
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-
-  /** Resolve WT/CLI badge for a session row (meta first, git list fallback). */
-  const sessionWorktreeBadgeFor = useCallback(
-    (s: SessionRow): SessionWorktreeBadge | null => {
-      const proj = s.projectId
-        ? projects.find((p) => p.id === s.projectId) ?? null
-        : null;
-      return resolveSessionWorktreeBadge(
-        {
-          worktreePath: s.worktreePath,
-          worktreeBranch: s.worktreeBranch,
-          isWorktreeSession: s.isWorktreeSession,
-        },
-        proj?.path ?? s.worktreePath,
-        gitWorktrees,
-        { grokHome: cliGrokHome },
-      );
-    },
-    [cliGrokHome, gitWorktrees, projects],
-  );
-
-  /** Pre-translated worktree chip for memoized SidebarSessionRow. */
-  const buildSidebarWorktreeBadge = useCallback(
-    (s: SessionRow): SidebarSessionWorktreeBadgeProp | null => {
-      const wtBadge = sessionWorktreeBadgeFor(s);
-      if (!wtBadge) return null;
-      const title = sessionWorktreeTooltip(wtBadge, {
-        detachedLabel: tr("composer.worktreeDetached"),
-        cliLayoutLabel: tr("session.worktreeLayoutCli"),
-        siblingLayoutLabel: tr("session.worktreeLayoutSibling"),
-        otherLayoutLabel: tr("session.worktreeBadge"),
-      });
-      const ariaKey =
-        wtBadge.layoutKind === "cli"
-          ? "session.worktreeBadgeCliAria"
-          : "session.worktreeBadgeAria";
-      return {
-        label: wtBadge.label,
-        branch: wtBadge.branch,
-        layoutKind: wtBadge.layoutKind,
-        title,
-        ariaLabel: tr(ariaKey, {
-          branch: wtBadge.branch || tr("composer.worktreeDetached"),
-        }),
-      };
-    },
-    [sessionWorktreeBadgeFor, tr],
-  );
-
-  /**
-   * Create worktree → refresh list → add as project (trust inherited) →
-   * either bind current session or start a draft chat on that path.
-   * Worktree+chat creates a real session immediately so meta can be persisted.
-   */
-  const submitWorktreeCreate = useCallback(async () => {
-    if (!api.isTauri() || !activeProject?.path) return;
-    const rawName = worktreeCreateName.trim();
-    if (!rawName) {
-      setWorktreeCreateError(tr("composer.worktreeNameRequired"));
-      return;
-    }
-    let safeName: string;
-    try {
-      safeName = sanitizeWorktreeName(rawName);
-    } catch {
-      setWorktreeCreateError(tr("composer.worktreeNameInvalid"));
-      return;
-    }
-    let start: string | null;
-    try {
-      start = sanitizeWorktreeRef(worktreeCreateRef);
-    } catch {
-      setWorktreeCreateError(tr("composer.worktreeRefInvalid"));
-      return;
-    }
-    const layout = normalizeWorktreeLayout(worktreeCreateLayout);
-    setWorktreeCreateBusy(true);
-    setWorktreeCreateError(null);
-    try {
-      const created = await api.gitWorktreeAdd(
-        activeProject.path,
-        safeName,
-        start,
-        layout,
-      );
-      setWorktreeCreateOpen(false);
-      await refreshGitWorktrees();
-
-      const path = created.path;
-      const branch =
-        created.branch?.trim() ||
-        created.name ||
-        tr("composer.worktreeDetached");
-      const trust = !!activeProject.trusted;
-      const startChat = worktreeCreateStartChat;
-      const existing = projects.find((p) => pathsEqual(p.path, path));
-      let target: Project | null = existing ?? null;
-      if (!target) {
-        const added = (await api.projectAdd(path, trust)) as Project;
-        const list = mapProjectsList((await api.projectsList()) as Project[]);
-        setProjects(list);
-        projectSpaces.assignNewProjects([added.id]);
-        target = list.find((p) => p.id === added.id) ?? added;
-      }
-
-      if (!target.trusted) {
-        // Trust prompt first; bind only (chat requires trusted project).
-        await finalizeAddedProject(target, { bindSession: true });
-        return;
-      }
-
-      if (startChat) {
-        // Materialize session now so worktree meta survives before first send.
-        const meta = (await api.sessionCreate(
-          target.id,
-          tr("session.new"),
-        )) as SessionRow & { id: string; title?: string };
-        await markSessionWorktree(meta.id, path, branch);
-        const row = normalizeSessionRow({
-          ...meta,
-          projectId: target.id,
-          worktreePath: path,
-          worktreeBranch: branch,
-          isWorktreeSession: true,
-        });
-        setExpandedProjects((e) => ({ ...e, [target!.id]: true }));
-        await openSession(row, target);
-      } else {
-        await bindSessionProject(target);
-        // Tag the currently open chat when switching cwd into the new worktree.
-        const liveId =
-          viewingSessionIdRef.current || session.sessionId || null;
-        if (liveId) {
-          await markSessionWorktree(liveId, path, branch);
-        }
-      }
-    } catch (e) {
-      setWorktreeCreateError(String(e));
-    } finally {
-      setWorktreeCreateBusy(false);
-    }
-  }, [
-    activeProject?.path,
-    activeProject?.trusted,
-    bindSessionProject,
-    finalizeAddedProject,
-    markSessionWorktree,
-    openSession,
-    projects,
-    refreshGitWorktrees,
-    session.sessionId,
-    showToast,
-    tr,
-    worktreeCreateLayout,
-    worktreeCreateName,
-    worktreeCreateRef,
-    worktreeCreateStartChat,
-  ]);
+  {
+    const h = gitWorktreeHostRef.current;
+    h.tr = tr;
+    h.activeProject = activeProject;
+    h.projects = projects;
+    h.session = session;
+    h.sessions = sessions;
+    h.showToast = showToast;
+    h.setAppDialog = setAppDialog;
+    h.bindSessionProject = bindSessionProject;
+    h.finalizeAddedProject = finalizeAddedProject;
+    h.setProjects = setProjects;
+    h.setExpandedProjects = setExpandedProjects;
+    h.assignNewProjects = projectSpaces.assignNewProjects;
+    h.refreshSessions = refreshSessions;
+    h.openSession = openSession;
+    h.viewingSessionIdRef = viewingSessionIdRef;
+    h.navigateSettings = navigateSettings;
+    h.setPrHubHighlightPr = setPrHubHighlightPr;
+    h.setSettingsFocusAnchor = setSettingsFocusAnchor;
+  }
 
   /**
    * Pick folder → add project (name = folder basename; no rename prompt).
@@ -13180,9 +12423,9 @@ export function AppWorkbench() {
         rewindConfirm ||
         forkConfirm ||
         resumeRestoreConfirm ||
-        worktreeCreateOpen ||
-        worktreeGcOpen ||
-        shipOpen ||
+        worktreeChrome.create.open ||
+        worktreeChrome.gc.open ||
+        worktreeChrome.ship.open ||
         projectRulesTarget ||
         agentDashboardOpen ||
         taskBoardOpen ||
@@ -14749,71 +13992,7 @@ export function AppWorkbench() {
           if (!archiveAgeConfirm) return;
           void runArchiveAgePlan(archiveAgeConfirm);
         }}
-        worktreeCreateOpen={worktreeCreateOpen}
-        worktreeCreateBusy={worktreeCreateBusy}
-        worktreeCreateStartChat={worktreeCreateStartChat}
-        worktreeCreateName={worktreeCreateName}
-        worktreeCreateLayout={worktreeCreateLayout}
-        worktreeCreateRef={worktreeCreateRef}
-        worktreeCreatePreviewPath={worktreeCreatePreviewPath}
-        worktreeCreateError={worktreeCreateError}
-        closeWorktreeCreate={() => setWorktreeCreateOpen(false)}
-        submitWorktreeCreate={() => {
-          void submitWorktreeCreate();
-        }}
-        onWorktreeCreateNameChange={(value) => {
-          setWorktreeCreateName(value);
-          setWorktreeCreateError(null);
-        }}
-        onWorktreeCreateLayoutChange={(value) => {
-          setWorktreeCreateLayout(value);
-          setWorktreeCreateError(null);
-        }}
-        onWorktreeCreateRefChange={(value) => {
-          setWorktreeCreateRef(value);
-          setWorktreeCreateError(null);
-        }}
-        worktreeGcOpen={worktreeGcOpen}
-        worktreeGcBusy={worktreeGcBusy}
-        worktreeGcPreviewBusy={worktreeGcPreviewBusy}
-        worktreeGcForce={worktreeGcForce}
-        worktreeGcPreview={worktreeGcPreview}
-        worktreeGcError={worktreeGcError}
-        closeWorktreeGc={() => {
-          setWorktreeGcOpen(false);
-          setWorktreeGcError(null);
-          setWorktreeGcPreview(null);
-          setWorktreeGcForce(false);
-        }}
-        submitWorktreeGc={() => {
-          void submitWorktreeGc();
-        }}
-        setWorktreeGcForce={setWorktreeGcForce}
-        shipOpen={shipOpen}
-        shipBusy={shipBusy}
-        shipSuccess={shipSuccess}
-        shipTitle={shipTitle}
-        shipBody={shipBody}
-        shipCreatePr={shipCreatePr}
-        shipDraft={shipDraft}
-        shipBranch={shipBranch}
-        shipStatus={shipStatus}
-        shipError={shipError}
-        closeShip={closeShipFlow}
-        submitShip={() => {
-          void submitShipFlow();
-        }}
-        onShipTitleChange={(value) => {
-          setShipTitle(value);
-          setShipError(null);
-        }}
-        onShipBodyChange={(value) => {
-          setShipBody(value);
-          setShipError(null);
-        }}
-        setShipCreatePr={setShipCreatePr}
-        setShipDraft={setShipDraft}
-        onOpenPrHubFromShip={openPrHubFromShip}
+        worktreeChrome={worktreeChrome}
         showToast={showToast}
         showShortcuts={showShortcuts}
         composerSendKeyPref={composerSendKeyPref}

--- a/src/app/WorkbenchChromeOverlays.tsx
+++ b/src/app/WorkbenchChromeOverlays.tsx
@@ -11,15 +11,11 @@ import { PromptHistoryClearModal } from "@/components/workbench-modals/PromptHis
 import { ShortcutsHelpModal } from "@/components/workbench-modals/ShortcutsHelpModal";
 import { WorktreeCreateModal } from "@/components/workbench-modals/WorktreeCreateModal";
 import { WorktreeGcModal } from "@/components/workbench-modals/WorktreeGcModal";
-import {
-  WorktreeShipModal,
-  type WorktreeShipSuccess,
-} from "@/components/workbench-modals/WorktreeShipModal";
+import { WorktreeShipModal } from "@/components/workbench-modals/WorktreeShipModal";
 import type { Locale } from "@/i18n";
-import type { GitWorktreeGcResult } from "@/lib/api";
 import type { AppPlatform } from "@/lib/appPlatform";
 import type { ComposerSendKeyPref } from "@/lib/composerSendKey";
-import type { WorktreeLayout } from "@/lib/gitWorktree";
+import type { GitWorktreeChromeOverlay } from "@/hooks/useGitWorktreeChrome";
 import type { ArchiveAgePlan } from "@/lib/sessionArchiveAge";
 import type { ShortcutRemapMap } from "@/lib/shortcutRemap";
 import type { VoiceSessionChipInput } from "@/lib/voiceCommandCenter";
@@ -69,45 +65,7 @@ export type WorkbenchChromeOverlaysProps = {
   archiveAgeBusy: boolean;
   closeArchiveAge: () => void;
   onConfirmArchiveAge: () => void;
-  worktreeCreateOpen: boolean;
-  worktreeCreateBusy: boolean;
-  worktreeCreateStartChat: boolean;
-  worktreeCreateName: string;
-  worktreeCreateLayout: WorktreeLayout;
-  worktreeCreateRef: string;
-  worktreeCreatePreviewPath: string | null;
-  worktreeCreateError: string | null;
-  closeWorktreeCreate: () => void;
-  submitWorktreeCreate: () => void;
-  onWorktreeCreateNameChange: (value: string) => void;
-  onWorktreeCreateLayoutChange: (value: WorktreeLayout) => void;
-  onWorktreeCreateRefChange: (value: string) => void;
-  worktreeGcOpen: boolean;
-  worktreeGcBusy: boolean;
-  worktreeGcPreviewBusy: boolean;
-  worktreeGcForce: boolean;
-  worktreeGcPreview: GitWorktreeGcResult | null;
-  worktreeGcError: string | null;
-  closeWorktreeGc: () => void;
-  submitWorktreeGc: () => void;
-  setWorktreeGcForce: (value: boolean) => void;
-  shipOpen: boolean;
-  shipBusy: boolean;
-  shipSuccess: WorktreeShipSuccess | null;
-  shipTitle: string;
-  shipBody: string;
-  shipCreatePr: boolean;
-  shipDraft: boolean;
-  shipBranch: string | null;
-  shipStatus: string | null;
-  shipError: string | null;
-  closeShip: () => void;
-  submitShip: () => void;
-  onShipTitleChange: (value: string) => void;
-  onShipBodyChange: (value: string) => void;
-  setShipCreatePr: (value: boolean) => void;
-  setShipDraft: (value: boolean) => void;
-  onOpenPrHubFromShip: (prNumber: number | null) => void;
+  worktreeChrome: GitWorktreeChromeOverlay;
   showToast: (message: string, ms: number) => void;
   showShortcuts: boolean;
   composerSendKeyPref: ComposerSendKeyPref;
@@ -144,6 +102,7 @@ export function WorkbenchChromeOverlays(p: WorkbenchChromeOverlaysProps) {
     setupOpen: p.setupOpen,
     tutorialOpen: p.showProductTutorial,
   });
+  const wt = p.worktreeChrome;
   return (
     <>
       {p.showDoctor ? (
@@ -184,51 +143,51 @@ export function WorkbenchChromeOverlays(p: WorkbenchChromeOverlaysProps) {
       />
       <WorktreeCreateModal
         locale={p.locale}
-        open={p.worktreeCreateOpen}
-        busy={p.worktreeCreateBusy}
-        startChat={p.worktreeCreateStartChat}
-        name={p.worktreeCreateName}
-        layout={p.worktreeCreateLayout}
-        startRef={p.worktreeCreateRef}
-        previewPath={p.worktreeCreatePreviewPath}
-        error={p.worktreeCreateError}
-        onClose={p.closeWorktreeCreate}
-        onSubmit={p.submitWorktreeCreate}
-        onNameChange={p.onWorktreeCreateNameChange}
-        onLayoutChange={p.onWorktreeCreateLayoutChange}
-        onRefChange={p.onWorktreeCreateRefChange}
+        open={wt.create.open}
+        busy={wt.create.busy}
+        startChat={wt.create.startChat}
+        name={wt.create.name}
+        layout={wt.create.layout}
+        startRef={wt.create.startRef}
+        previewPath={wt.create.previewPath}
+        error={wt.create.error}
+        onClose={wt.create.close}
+        onSubmit={wt.create.submit}
+        onNameChange={wt.create.setName}
+        onLayoutChange={wt.create.setLayout}
+        onRefChange={wt.create.setRef}
       />
       <WorktreeGcModal
         locale={p.locale}
-        open={p.worktreeGcOpen}
-        busy={p.worktreeGcBusy}
-        previewBusy={p.worktreeGcPreviewBusy}
-        force={p.worktreeGcForce}
-        preview={p.worktreeGcPreview}
-        error={p.worktreeGcError}
-        onClose={p.closeWorktreeGc}
-        onSubmit={p.submitWorktreeGc}
-        onForceChange={p.setWorktreeGcForce}
+        open={wt.gc.open}
+        busy={wt.gc.busy}
+        previewBusy={wt.gc.previewBusy}
+        force={wt.gc.force}
+        preview={wt.gc.preview}
+        error={wt.gc.error}
+        onClose={wt.gc.close}
+        onSubmit={wt.gc.submit}
+        onForceChange={wt.gc.setForce}
       />
       <WorktreeShipModal
         locale={p.locale}
-        open={p.shipOpen}
-        busy={p.shipBusy}
-        success={p.shipSuccess}
-        title={p.shipTitle}
-        body={p.shipBody}
-        createPr={p.shipCreatePr}
-        draft={p.shipDraft}
-        branch={p.shipBranch}
-        status={p.shipStatus}
-        error={p.shipError}
-        onClose={p.closeShip}
-        onSubmit={p.submitShip}
-        onTitleChange={p.onShipTitleChange}
-        onBodyChange={p.onShipBodyChange}
-        onCreatePrChange={p.setShipCreatePr}
-        onDraftChange={p.setShipDraft}
-        onOpenPrHub={p.onOpenPrHubFromShip}
+        open={wt.ship.open}
+        busy={wt.ship.busy}
+        success={wt.ship.success}
+        title={wt.ship.title}
+        body={wt.ship.body}
+        createPr={wt.ship.createPr}
+        draft={wt.ship.draft}
+        branch={wt.ship.branch}
+        status={wt.ship.status}
+        error={wt.ship.error}
+        onClose={wt.ship.close}
+        onSubmit={wt.ship.submit}
+        onTitleChange={wt.ship.setTitle}
+        onBodyChange={wt.ship.setBody}
+        onCreatePrChange={wt.ship.setCreatePr}
+        onDraftChange={wt.ship.setDraft}
+        onOpenPrHub={wt.ship.openPrHub}
         onToast={p.showToast}
       />
       <ShortcutsHelpModal

--- a/src/hooks/useGitWorktreeChrome.test.ts
+++ b/src/hooks/useGitWorktreeChrome.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Create / ship verbs live in this hook. Host only supplies project bind
+ * and session open. List refresh is a no-op off Tauri.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { createT } from "@/i18n";
+import type { Project } from "@/lib/app/sidebarModels";
+import {
+  createGitWorktreeChromeHost,
+  useGitWorktreeChrome,
+} from "./useGitWorktreeChrome";
+
+const PROJECT: Project = {
+  id: "p1",
+  name: "app",
+  path: "/Users/me/app",
+  trusted: true,
+  pathOk: true,
+};
+
+function setup(hostPatch?: Partial<ReturnType<typeof createGitWorktreeChromeHost>>) {
+  const host = createGitWorktreeChromeHost();
+  host.tr = createT("en");
+  host.activeProject = PROJECT;
+  host.showToast = vi.fn();
+  Object.assign(host, hostPatch);
+  const hostRef = { current: host };
+  const hook = renderHook(() =>
+    useGitWorktreeChrome({
+      hostRef,
+      projectPath: host.activeProject?.path ?? null,
+    }),
+  );
+  return { ...hook, host };
+}
+
+describe("useGitWorktreeChrome", () => {
+  it("openCreate resets the form and opens the dialog", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.openWorktreeCreate();
+    });
+    expect(result.current.worktreeChrome.create.open).toBe(true);
+    expect(result.current.worktreeChrome.create.name).toBe("");
+    expect(result.current.worktreeChrome.create.startChat).toBe(false);
+    expect(result.current.worktreeChrome.create.layout).toBe("cli");
+    act(() => {
+      result.current.worktreeChrome.create.setName("feat-x");
+    });
+    expect(result.current.worktreeChrome.create.previewPath).toContain(
+      "feat-x",
+    );
+    expect(result.current.worktreeChrome.create.previewPath).toMatch(
+      /\.grok\/worktrees\//,
+    );
+  });
+
+  it("openCreate({ startNewChat: true }) marks startChat", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.openWorktreeCreate({ startNewChat: true });
+    });
+    expect(result.current.worktreeChrome.create.startChat).toBe(true);
+  });
+
+  it("openShipFlow toasts when no project is bound", () => {
+    const { result, host } = setup({ activeProject: null });
+    act(() => {
+      result.current.openShipFlow();
+    });
+    expect(result.current.worktreeChrome.ship.open).toBe(false);
+    expect(host.showToast).toHaveBeenCalled();
+  });
+
+  it("closeShip is a no-op while ship is closed", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.worktreeChrome.ship.close();
+    });
+    expect(result.current.worktreeChrome.ship.open).toBe(false);
+  });
+});

--- a/src/hooks/useGitWorktreeChrome.ts
+++ b/src/hooks/useGitWorktreeChrome.ts
@@ -1,0 +1,984 @@
+/**
+ * Git worktree chrome: list, create, GC, ship, switch/remove, session badges.
+ * Host fills {@link GitWorktreeChromeHost} in place so bind/open/settings
+ * verbs stay late-bound at the composition root.
+ */
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import { createT } from "@/i18n";
+import type { SidebarSessionWorktreeBadgeProp } from "@/components/SidebarSessionRow";
+import * as api from "@/lib/api";
+import type { AppDialog } from "@/lib/app/appDialogTypes";
+import {
+  mapProjectsList,
+  normalizeSessionRow,
+  type Project,
+  type SessionRow,
+} from "@/lib/app/sidebarModels";
+import { filterCliWorktreesForProject } from "@/lib/cliWorktrees";
+import {
+  applyGitStatusBranch,
+  buildWorktreePath,
+  canRemoveWorktree,
+  mainWorktreePath,
+  normalizeWorktreeLayout,
+  pathsEqual,
+  resolveSessionWorktreeBadge,
+  sanitizeWorktreeName,
+  sanitizeWorktreeRef,
+  sessionWorktreeTooltip,
+  worktreeRemoveErrorSuggestsForce,
+  type SessionWorktreeBadge,
+  type WorktreeLayout,
+} from "@/lib/gitWorktree";
+import {
+  PR_HUB_ANCHOR_ID,
+  buildPrHubDeepLink,
+  parseGithubPrNumber,
+} from "@/lib/prHubDeepLink";
+import type { SettingsSectionId } from "@/lib/settingsCatalog";
+import {
+  canShipWorktree,
+  combineShipOutcome,
+  defaultPrTitleFromBranch,
+  redactShipOutput,
+  sanitizePrBody,
+  sanitizePrTitle,
+  shipOutcomeSummary,
+} from "@/lib/wtShipFlow";
+
+type TFn = ReturnType<typeof createT>;
+
+type GitStatusPatch = {
+  available?: boolean | null;
+  branch?: string | null;
+};
+
+export type GitWorktreeCreateOverlay = {
+  open: boolean;
+  busy: boolean;
+  startChat: boolean;
+  name: string;
+  layout: WorktreeLayout;
+  startRef: string;
+  previewPath: string | null;
+  error: string | null;
+  close: () => void;
+  submit: () => void;
+  setName: (value: string) => void;
+  setLayout: (value: WorktreeLayout) => void;
+  setRef: (value: string) => void;
+};
+
+export type GitWorktreeGcOverlay = {
+  open: boolean;
+  busy: boolean;
+  previewBusy: boolean;
+  force: boolean;
+  preview: api.GitWorktreeGcResult | null;
+  error: string | null;
+  close: () => void;
+  submit: () => void;
+  setForce: (value: boolean) => void;
+};
+
+export type GitWorktreeShipOverlay = {
+  open: boolean;
+  busy: boolean;
+  success: { prUrl: string; prNumber: number | null } | null;
+  title: string;
+  body: string;
+  createPr: boolean;
+  draft: boolean;
+  branch: string | null;
+  status: string | null;
+  error: string | null;
+  close: () => void;
+  submit: () => void;
+  setTitle: (value: string) => void;
+  setBody: (value: string) => void;
+  setCreatePr: (value: boolean) => void;
+  setDraft: (value: boolean) => void;
+  openPrHub: (prNumber: number | null) => void;
+};
+
+export type GitWorktreeChromeOverlay = {
+  create: GitWorktreeCreateOverlay;
+  gc: GitWorktreeGcOverlay;
+  ship: GitWorktreeShipOverlay;
+};
+
+export type GitWorktreeChromeHost = {
+  tr: TFn;
+  activeProject: Project | null;
+  projects: Project[];
+  session: { sessionId: string | null };
+  sessions: SessionRow[];
+  showToast: (msg: string, ms?: number) => void;
+  setAppDialog: (dialog: NonNullable<AppDialog>) => void;
+  bindSessionProject: (proj: Project | null) => void | Promise<void>;
+  finalizeAddedProject: (
+    p: Project,
+    opts: { bindSession: boolean },
+  ) => void | Promise<void>;
+  setProjects: Dispatch<SetStateAction<Project[]>>;
+  setExpandedProjects: Dispatch<SetStateAction<Record<string, boolean>>>;
+  assignNewProjects: (ids: readonly string[]) => void;
+  refreshSessions: () => void | Promise<void>;
+  openSession: (
+    row: SessionRow,
+    project?: Project | null,
+  ) => void | Promise<void>;
+  viewingSessionIdRef: MutableRefObject<string | null>;
+  navigateSettings: (
+    section?: SettingsSectionId | null,
+    tab?: string | null,
+  ) => void;
+  setPrHubHighlightPr: (n: number | null) => void;
+  setSettingsFocusAnchor: (id: string | null) => void;
+};
+
+function emptyHost(): GitWorktreeChromeHost {
+  const noop = () => {};
+  return {
+    tr: ((k: string) => k) as TFn,
+    activeProject: null,
+    projects: [],
+    session: { sessionId: null },
+    sessions: [],
+    showToast: noop,
+    setAppDialog: noop,
+    bindSessionProject: noop,
+    finalizeAddedProject: noop,
+    setProjects: noop,
+    setExpandedProjects: noop,
+    assignNewProjects: noop,
+    refreshSessions: noop,
+    openSession: noop,
+    viewingSessionIdRef: { current: null },
+    navigateSettings: noop,
+    setPrHubHighlightPr: noop,
+    setSettingsFocusAnchor: noop,
+  };
+}
+
+export function createGitWorktreeChromeHost(): GitWorktreeChromeHost {
+  return emptyHost();
+}
+
+export function useGitWorktreeChrome(opts: {
+  hostRef: MutableRefObject<GitWorktreeChromeHost>;
+  projectPath: string | null;
+}) {
+  const hostRef = opts.hostRef;
+  const [gitWorktrees, setGitWorktrees] = useState<api.GitWorktreeEntry[]>([]);
+  const [gitWorktreesAvailable, setGitWorktreesAvailable] = useState<
+    boolean | null
+  >(null);
+  const [gitWorktreesLoading, setGitWorktreesLoading] = useState(false);
+  const [gitWorktreesReason, setGitWorktreesReason] = useState<string | null>(
+    null,
+  );
+  const [worktreeCreateOpen, setWorktreeCreateOpen] = useState(false);
+  const [worktreeCreateName, setWorktreeCreateName] = useState("");
+  const [worktreeCreateRef, setWorktreeCreateRef] = useState("");
+  const [worktreeCreateLayout, setWorktreeCreateLayout] =
+    useState<WorktreeLayout>("cli");
+  const [worktreeCreateBusy, setWorktreeCreateBusy] = useState(false);
+  const [worktreeCreateError, setWorktreeCreateError] = useState<string | null>(
+    null,
+  );
+  const [worktreeCreateStartChat, setWorktreeCreateStartChat] = useState(false);
+  const [cliGrokHome, setCliGrokHome] = useState<string | null>(null);
+  const [cliWorktrees, setCliWorktrees] = useState<api.CliWorktreeEntry[]>([]);
+  const [cliWorktreesAvailable, setCliWorktreesAvailable] = useState<
+    boolean | null
+  >(null);
+  const [cliWorktreesLoading, setCliWorktreesLoading] = useState(false);
+  const [cliWorktreesReason, setCliWorktreesReason] = useState<string | null>(
+    null,
+  );
+  const [worktreeGcOpen, setWorktreeGcOpen] = useState(false);
+  const [worktreeGcForce, setWorktreeGcForce] = useState(false);
+  const [worktreeGcBusy, setWorktreeGcBusy] = useState(false);
+  const [worktreeGcPreviewBusy, setWorktreeGcPreviewBusy] = useState(false);
+  const [worktreeGcError, setWorktreeGcError] = useState<string | null>(null);
+  const [worktreeGcPreview, setWorktreeGcPreview] =
+    useState<api.GitWorktreeGcResult | null>(null);
+  const [shipOpen, setShipOpen] = useState(false);
+  const [shipTitle, setShipTitle] = useState("");
+  const [shipBody, setShipBody] = useState("");
+  const [shipDraft, setShipDraft] = useState(false);
+  const [shipCreatePr, setShipCreatePr] = useState(true);
+  const [shipBusy, setShipBusy] = useState(false);
+  const [shipError, setShipError] = useState<string | null>(null);
+  const [shipBranch, setShipBranch] = useState<string | null>(null);
+  const [shipStatus, setShipStatus] = useState<string | null>(null);
+  const [shipSuccess, setShipSuccess] = useState<{
+    prUrl: string;
+    prNumber: number | null;
+  } | null>(null);
+
+  const gitWorktreesReqRef = useRef(0);
+  const gitWorktreesPathRef = useRef<string | null>(null);
+  const refreshGitWorktrees = useCallback(async () => {
+    const path = opts.projectPath?.trim() || null;
+    if (!path || !api.isTauri()) {
+      gitWorktreesReqRef.current += 1;
+      gitWorktreesPathRef.current = null;
+      setGitWorktrees([]);
+      setGitWorktreesAvailable(null);
+      setGitWorktreesReason(null);
+      setCliGrokHome(null);
+      setGitWorktreesLoading(false);
+      return;
+    }
+    const reqId = ++gitWorktreesReqRef.current;
+    // Drop stale rows when the active path changes; same-path refresh keeps
+    // the previous list so the menu does not flash empty.
+    if (gitWorktreesPathRef.current !== path) {
+      gitWorktreesPathRef.current = path;
+      setGitWorktrees([]);
+      setGitWorktreesAvailable(null);
+      setGitWorktreesReason(null);
+    }
+    setGitWorktreesLoading(true);
+    try {
+      const res = await api.gitWorktreesList(path);
+      if (reqId !== gitWorktreesReqRef.current) return;
+      const home = (res.cliGrokHome || "").trim() || null;
+      if (home) setCliGrokHome(home);
+      if (!res.available) {
+        setGitWorktrees([]);
+        setGitWorktreesAvailable(false);
+        setGitWorktreesReason(res.reason?.trim() || "unavailable");
+      } else {
+        setGitWorktrees(res.worktrees ?? []);
+        setGitWorktreesAvailable(true);
+        setGitWorktreesReason(null);
+      }
+    } catch (e) {
+      if (reqId !== gitWorktreesReqRef.current) return;
+      setGitWorktrees([]);
+      setGitWorktreesAvailable(false);
+      setGitWorktreesReason(String(e));
+    } finally {
+      if (reqId === gitWorktreesReqRef.current) {
+        setGitWorktreesLoading(false);
+      }
+    }
+  }, [opts.projectPath]);
+
+  useEffect(() => {
+    void refreshGitWorktrees();
+  }, [refreshGitWorktrees]);
+
+  const cliWorktreesReqRef = useRef(0);
+  const refreshCliWorktrees = useCallback(async () => {
+    const h = hostRef.current;
+    if (!api.isTauri()) {
+      cliWorktreesReqRef.current += 1;
+      setCliWorktrees([]);
+      setCliWorktreesAvailable(null);
+      setCliWorktreesReason(null);
+      setCliWorktreesLoading(false);
+      return;
+    }
+    const reqId = ++cliWorktreesReqRef.current;
+    setCliWorktreesLoading(true);
+    try {
+      const projectPath = h.activeProject?.path?.trim() || null;
+      const repoSlug = projectPath
+        ? projectPath.replace(/\\/g, "/").split("/").filter(Boolean).pop() ||
+          null
+        : null;
+      const res = await api.cliWorktreesList({
+        all: false,
+        // CLI --repo matches repo_name, not folder basename. Leave unfiltered;
+        // UI filters by source path / worktrees slug.
+        repo: null,
+      });
+      if (reqId !== cliWorktreesReqRef.current) return;
+      if (!res.available) {
+        setCliWorktrees([]);
+        setCliWorktreesAvailable(false);
+        setCliWorktreesReason(res.reason?.trim() || "unavailable");
+      } else {
+        const filtered = filterCliWorktreesForProject(
+          res.worktrees ?? [],
+          projectPath,
+          repoSlug,
+        );
+        setCliWorktrees(filtered);
+        setCliWorktreesAvailable(true);
+        setCliWorktreesReason(null);
+      }
+    } catch (e) {
+      if (reqId !== cliWorktreesReqRef.current) return;
+      setCliWorktrees([]);
+      setCliWorktreesAvailable(false);
+      setCliWorktreesReason(String(e));
+    } finally {
+      if (reqId === cliWorktreesReqRef.current) {
+        setCliWorktreesLoading(false);
+      }
+    }
+  }, [hostRef]);
+
+  useEffect(() => {
+    if (gitWorktreesAvailable === true) {
+      void refreshCliWorktrees();
+    } else if (gitWorktreesAvailable === false) {
+      cliWorktreesReqRef.current += 1;
+      setCliWorktrees([]);
+      setCliWorktreesAvailable(null);
+      setCliWorktreesReason(null);
+      setCliWorktreesLoading(false);
+    }
+  }, [gitWorktreesAvailable, refreshCliWorktrees]);
+
+  const applyStatusBranch = useCallback(
+    (path: string, status: GitStatusPatch | null | undefined) => {
+      setGitWorktrees((prev) => applyGitStatusBranch(prev, path, status));
+    },
+    [],
+  );
+
+  const openWorktreeGc = useCallback(() => {
+    setWorktreeGcForce(false);
+    setWorktreeGcError(null);
+    setWorktreeGcBusy(false);
+    setWorktreeGcPreview(null);
+    setWorktreeGcOpen(true);
+  }, []);
+
+  const openShipFlow = useCallback(() => {
+    const h = hostRef.current;
+    if (!api.isTauri() || !h.activeProject?.path) {
+      h.showToast(h.tr("composer.worktreeShipNeedProject"), 3500);
+      return;
+    }
+    const current =
+      gitWorktrees.find((w) => pathsEqual(w.path, h.activeProject!.path)) ??
+      null;
+    const branch =
+      current?.branch?.trim() ||
+      (h.session.sessionId
+        ? h.sessions.find((s) => s.id === h.session.sessionId)?.worktreeBranch
+        : null) ||
+      null;
+    if (
+      !canShipWorktree({
+        branch,
+        detached: current?.detached ?? !branch,
+        available: gitWorktreesAvailable,
+      })
+    ) {
+      if (current?.detached) {
+        h.showToast(h.tr("composer.worktreeShipDetached"), 4000);
+        return;
+      }
+    }
+    setShipBranch(branch);
+    setShipTitle(defaultPrTitleFromBranch(branch));
+    setShipBody("");
+    setShipDraft(false);
+    setShipCreatePr(true);
+    setShipError(null);
+    setShipStatus(null);
+    setShipSuccess(null);
+    setShipBusy(false);
+    setShipOpen(true);
+  }, [gitWorktrees, gitWorktreesAvailable, hostRef]);
+
+  const closeShipFlow = useCallback(() => {
+    if (shipBusy) return;
+    setShipOpen(false);
+    setShipError(null);
+    setShipStatus(null);
+    setShipSuccess(null);
+  }, [shipBusy]);
+
+  const openPrHubFromShip = useCallback(
+    (prNumber: number | null) => {
+      const h = hostRef.current;
+      try {
+        if (!h.activeProject?.path?.trim()) {
+          h.showToast(h.tr("composer.worktreeShipOpenHubFailed"), 4000);
+          return;
+        }
+        h.setPrHubHighlightPr(prNumber);
+        h.setSettingsFocusAnchor(PR_HUB_ANCHOR_ID);
+        h.navigateSettings("runtime", "tools");
+        if (typeof window !== "undefined") {
+          const hash = buildPrHubDeepLink({ prNumber });
+          if (window.location.hash !== hash) {
+            window.location.hash = hash;
+          }
+        }
+        setShipOpen(false);
+        setShipSuccess(null);
+        setShipError(null);
+        setShipStatus(null);
+      } catch {
+        h.showToast(h.tr("composer.worktreeShipOpenHubFailed"), 4000);
+      }
+    },
+    [hostRef],
+  );
+
+  const submitShipFlow = useCallback(async () => {
+    const h = hostRef.current;
+    if (!api.isTauri() || !h.activeProject?.path) return;
+    let title: string;
+    let body: string;
+    try {
+      title = sanitizePrTitle(shipTitle);
+      body = sanitizePrBody(shipBody);
+    } catch (e) {
+      setShipError(String(e));
+      return;
+    }
+    setShipBusy(true);
+    setShipError(null);
+    setShipSuccess(null);
+    setShipStatus(h.tr("composer.worktreeShipPushing"));
+    try {
+      const push = await api.gitPushBranch(h.activeProject.path);
+      let pr: api.GhPrCreateResult | null = null;
+      if (shipCreatePr) {
+        setShipStatus(h.tr("composer.worktreeShipCreatingPr"));
+        pr = await api.ghPrCreate({
+          projectPath: h.activeProject.path,
+          title,
+          body,
+          draft: shipDraft,
+          base: "main",
+        });
+      }
+      const outcome = combineShipOutcome(push, pr, {
+        createPr: shipCreatePr,
+      });
+      const summary = shipOutcomeSummary(outcome);
+      if (outcome.ok) {
+        setShipStatus(null);
+        if (outcome.prUrl) {
+          const prNumber = parseGithubPrNumber(outcome.prUrl);
+          setShipSuccess({ prUrl: outcome.prUrl, prNumber });
+        } else {
+          setShipOpen(false);
+          setShipSuccess(null);
+        }
+      } else {
+        const detail = redactShipOutput(
+          outcome.failReason ||
+            pr?.reason ||
+            push.reason ||
+            summary ||
+            "ship failed",
+          600,
+        );
+        setShipError(detail);
+        setShipStatus(null);
+        h.showToast(
+          shipCreatePr
+            ? h.tr("composer.worktreeShipFailed", { reason: detail })
+            : h.tr("composer.worktreeShipPushFailed", { reason: detail }),
+          6000,
+        );
+      }
+    } catch (e) {
+      const msg = redactShipOutput(String(e), 600);
+      setShipError(msg);
+      setShipStatus(null);
+      h.showToast(h.tr("composer.worktreeShipFailed", { reason: msg }), 6000);
+    } finally {
+      setShipBusy(false);
+    }
+  }, [hostRef, shipBody, shipCreatePr, shipDraft, shipTitle]);
+
+  const refreshWorktreeGcPreview = useCallback(async () => {
+    const h = hostRef.current;
+    if (!api.isTauri() || !h.activeProject?.path || !worktreeGcOpen) return;
+    setWorktreeGcPreviewBusy(true);
+    setWorktreeGcError(null);
+    try {
+      const res = await api.gitWorktreeGc(
+        h.activeProject.path,
+        true,
+        worktreeGcForce,
+      );
+      setWorktreeGcPreview(res);
+    } catch (e) {
+      setWorktreeGcPreview(null);
+      setWorktreeGcError(String(e));
+    } finally {
+      setWorktreeGcPreviewBusy(false);
+    }
+  }, [hostRef, worktreeGcForce, worktreeGcOpen]);
+
+  useEffect(() => {
+    if (!worktreeGcOpen) return;
+    void refreshWorktreeGcPreview();
+  }, [worktreeGcOpen, refreshWorktreeGcPreview]);
+
+  const submitWorktreeGc = useCallback(async () => {
+    const h = hostRef.current;
+    if (!api.isTauri() || !h.activeProject?.path) return;
+    setWorktreeGcBusy(true);
+    setWorktreeGcError(null);
+    try {
+      setWorktreeGcOpen(false);
+      setWorktreeGcPreview(null);
+      setWorktreeGcForce(false);
+      await refreshGitWorktrees();
+    } catch (e) {
+      setWorktreeGcError(String(e));
+    } finally {
+      setWorktreeGcBusy(false);
+    }
+  }, [hostRef, refreshGitWorktrees]);
+
+  const switchToWorktree = useCallback(
+    async (wt: api.GitWorktreeEntry) => {
+      const h = hostRef.current;
+      if (!api.isTauri()) return;
+      const path = wt.path?.trim();
+      if (!path) return;
+      try {
+        const existing = h.projects.find((p) => pathsEqual(p.path, path));
+        if (existing) {
+          await h.bindSessionProject(existing);
+          return;
+        }
+        const trust = !!h.activeProject?.trusted;
+        const added = (await api.projectAdd(path, trust)) as Project;
+        const list = mapProjectsList((await api.projectsList()) as Project[]);
+        h.setProjects(list);
+        h.assignNewProjects([added.id]);
+        const proj = list.find((p) => p.id === added.id) ?? added;
+        if (!proj.trusted) {
+          await h.finalizeAddedProject(proj, { bindSession: true });
+        } else {
+          await h.bindSessionProject(proj);
+        }
+      } catch (e) {
+        h.showToast(String(e), 4500);
+      }
+    },
+    [hostRef],
+  );
+
+  const executeWorktreeRemove = useCallback(
+    async (wt: api.GitWorktreeEntry, force: boolean) => {
+      const h = hostRef.current;
+      if (!api.isTauri() || !canRemoveWorktree(wt)) return;
+      const mainPath =
+        mainWorktreePath(gitWorktrees) || h.activeProject?.path?.trim() || "";
+      if (!mainPath) {
+        h.showToast(h.tr("composer.worktreeRemoveFailed"), 4000);
+        return;
+      }
+      const wasCurrent = pathsEqual(wt.path, h.activeProject?.path);
+      try {
+        await api.gitWorktreeRemove({
+          projectPath: mainPath,
+          worktreePath: wt.path,
+          force,
+        });
+        try {
+          const linked = h.sessions.filter(
+            (s) =>
+              s.isWorktreeSession || pathsEqual(s.worktreePath, wt.path),
+          );
+          for (const s of linked) {
+            if (
+              pathsEqual(s.worktreePath, wt.path) ||
+              (!s.worktreePath &&
+                pathsEqual(
+                  h.projects.find((p) => p.id === s.projectId)?.path,
+                  wt.path,
+                ))
+            ) {
+              await api.sessionSetWorktree(s.id, {
+                worktreePath: null,
+                worktreeBranch: null,
+              });
+            }
+          }
+          if (linked.length) await h.refreshSessions();
+        } catch {
+          /* soft-fail */
+        }
+        if (wasCurrent) {
+          const main =
+            gitWorktrees.find((w) => w.isMain) ??
+            gitWorktrees.find((w) => pathsEqual(w.path, mainPath)) ??
+            null;
+          if (main) {
+            await switchToWorktree(main);
+          } else {
+            await refreshGitWorktrees();
+          }
+        } else {
+          await refreshGitWorktrees();
+        }
+      } catch (e) {
+        const err = String(e);
+        if (!force && worktreeRemoveErrorSuggestsForce(err)) {
+          h.setAppDialog({
+            kind: "confirm",
+            title: h.tr("composer.worktreeRemoveTitle"),
+            message: `${h.tr("composer.worktreeRemoveForce")}\n\n${err}`,
+            confirmLabel: h.tr("composer.worktreeRemove"),
+            danger: true,
+            onConfirm: () => {
+              void executeWorktreeRemove(wt, true);
+            },
+          });
+          return;
+        }
+        h.showToast(`${h.tr("composer.worktreeRemoveFailed")}: ${err}`, 5000);
+      }
+    },
+    [gitWorktrees, hostRef, refreshGitWorktrees, switchToWorktree],
+  );
+
+  const confirmRemoveWorktree = useCallback(
+    (wt: api.GitWorktreeEntry) => {
+      const h = hostRef.current;
+      if (!canRemoveWorktree(wt)) return;
+      const branch = wt.branch?.trim() || h.tr("composer.worktreeDetached");
+      const isCurrent = pathsEqual(wt.path, h.activeProject?.path);
+      const parts = [
+        h.tr("composer.worktreeRemoveHint"),
+        h.tr("composer.worktreeRemoveConfirm", {
+          branch,
+          path: wt.path,
+        }),
+      ];
+      if (isCurrent) {
+        parts.push(h.tr("composer.worktreeRemoveCurrentWarn"));
+      }
+      h.setAppDialog({
+        kind: "confirm",
+        title: h.tr("composer.worktreeRemoveTitle"),
+        message: parts.join("\n\n"),
+        confirmLabel: h.tr("composer.worktreeRemove"),
+        danger: true,
+        onConfirm: () => {
+          void executeWorktreeRemove(wt, false);
+        },
+      });
+    },
+    [executeWorktreeRemove, hostRef],
+  );
+
+  const openWorktreeCreate = useCallback((optsCreate?: { startNewChat?: boolean }) => {
+    setWorktreeCreateName("");
+    setWorktreeCreateRef("");
+    setWorktreeCreateLayout("cli");
+    setWorktreeCreateError(null);
+    setWorktreeCreateBusy(false);
+    setWorktreeCreateStartChat(!!optsCreate?.startNewChat);
+    setWorktreeCreateOpen(true);
+  }, []);
+
+  let worktreeCreatePreviewPath: string | null = null;
+  try {
+    const main =
+      mainWorktreePath(gitWorktrees) || opts.projectPath || "";
+    if (main && worktreeCreateName.trim()) {
+      const layout = normalizeWorktreeLayout(worktreeCreateLayout);
+      if (layout === "cli" && !cliGrokHome) {
+        worktreeCreatePreviewPath = buildWorktreePath(
+          "cli",
+          main,
+          worktreeCreateName.trim(),
+          "~/.grok",
+        );
+      } else {
+        worktreeCreatePreviewPath = buildWorktreePath(
+          layout,
+          main,
+          worktreeCreateName.trim(),
+          cliGrokHome,
+        );
+      }
+    }
+  } catch {
+    worktreeCreatePreviewPath = null;
+  }
+
+  const markSessionWorktree = useCallback(
+    async (
+      sessionId: string | null | undefined,
+      path: string,
+      branch: string | null | undefined,
+    ) => {
+      const h = hostRef.current;
+      if (!sessionId || !api.isTauri()) return;
+      const p = path.trim();
+      if (!p) return;
+      try {
+        await api.sessionSetWorktree(sessionId, {
+          worktreePath: p,
+          worktreeBranch: (branch || "").trim() || null,
+        });
+        await h.refreshSessions();
+      } catch {
+        /* soft-fail */
+      }
+    },
+    [hostRef],
+  );
+
+  const sessionWorktreeBadgeFor = useCallback(
+    (s: SessionRow): SessionWorktreeBadge | null => {
+      const h = hostRef.current;
+      const proj = s.projectId
+        ? (h.projects.find((p) => p.id === s.projectId) ?? null)
+        : null;
+      return resolveSessionWorktreeBadge(
+        {
+          worktreePath: s.worktreePath,
+          worktreeBranch: s.worktreeBranch,
+          isWorktreeSession: s.isWorktreeSession,
+        },
+        proj?.path ?? s.worktreePath,
+        gitWorktrees,
+        { grokHome: cliGrokHome },
+      );
+    },
+    [cliGrokHome, gitWorktrees, hostRef],
+  );
+
+  const buildSidebarWorktreeBadge = useCallback(
+    (s: SessionRow): SidebarSessionWorktreeBadgeProp | null => {
+      const h = hostRef.current;
+      const wtBadge = sessionWorktreeBadgeFor(s);
+      if (!wtBadge) return null;
+      const title = sessionWorktreeTooltip(wtBadge, {
+        detachedLabel: h.tr("composer.worktreeDetached"),
+        cliLayoutLabel: h.tr("session.worktreeLayoutCli"),
+        siblingLayoutLabel: h.tr("session.worktreeLayoutSibling"),
+        otherLayoutLabel: h.tr("session.worktreeBadge"),
+      });
+      const ariaKey =
+        wtBadge.layoutKind === "cli"
+          ? "session.worktreeBadgeCliAria"
+          : "session.worktreeBadgeAria";
+      return {
+        label: wtBadge.label,
+        branch: wtBadge.branch,
+        layoutKind: wtBadge.layoutKind,
+        title,
+        ariaLabel: h.tr(ariaKey, {
+          branch: wtBadge.branch || h.tr("composer.worktreeDetached"),
+        }),
+      };
+    },
+    [hostRef, sessionWorktreeBadgeFor],
+  );
+
+  const submitWorktreeCreate = useCallback(async () => {
+    const h = hostRef.current;
+    if (!api.isTauri() || !h.activeProject?.path) return;
+    const rawName = worktreeCreateName.trim();
+    if (!rawName) {
+      setWorktreeCreateError(h.tr("composer.worktreeNameRequired"));
+      return;
+    }
+    let safeName: string;
+    try {
+      safeName = sanitizeWorktreeName(rawName);
+    } catch {
+      setWorktreeCreateError(h.tr("composer.worktreeNameInvalid"));
+      return;
+    }
+    let start: string | null;
+    try {
+      start = sanitizeWorktreeRef(worktreeCreateRef);
+    } catch {
+      setWorktreeCreateError(h.tr("composer.worktreeRefInvalid"));
+      return;
+    }
+    const layout = normalizeWorktreeLayout(worktreeCreateLayout);
+    setWorktreeCreateBusy(true);
+    setWorktreeCreateError(null);
+    try {
+      const created = await api.gitWorktreeAdd(
+        h.activeProject.path,
+        safeName,
+        start,
+        layout,
+      );
+      setWorktreeCreateOpen(false);
+      await refreshGitWorktrees();
+
+      const path = created.path;
+      const branch =
+        created.branch?.trim() ||
+        created.name ||
+        h.tr("composer.worktreeDetached");
+      const trust = !!h.activeProject.trusted;
+      const startChat = worktreeCreateStartChat;
+      const existing = h.projects.find((p) => pathsEqual(p.path, path));
+      let target: Project | null = existing ?? null;
+      if (!target) {
+        const added = (await api.projectAdd(path, trust)) as Project;
+        const list = mapProjectsList((await api.projectsList()) as Project[]);
+        h.setProjects(list);
+        h.assignNewProjects([added.id]);
+        target = list.find((p) => p.id === added.id) ?? added;
+      }
+
+      if (!target.trusted) {
+        await h.finalizeAddedProject(target, { bindSession: true });
+        return;
+      }
+
+      if (startChat) {
+        // Materialize session now so worktree meta survives before first send.
+        const meta = (await api.sessionCreate(
+          target.id,
+          h.tr("session.new"),
+        )) as SessionRow & { id: string; title?: string };
+        await markSessionWorktree(meta.id, path, branch);
+        const row = normalizeSessionRow({
+          ...meta,
+          projectId: target.id,
+          worktreePath: path,
+          worktreeBranch: branch,
+          isWorktreeSession: true,
+        });
+        h.setExpandedProjects((e) => ({ ...e, [target!.id]: true }));
+        await h.openSession(row, target);
+      } else {
+        await h.bindSessionProject(target);
+        const liveId =
+          h.viewingSessionIdRef.current || h.session.sessionId || null;
+        if (liveId) {
+          await markSessionWorktree(liveId, path, branch);
+        }
+      }
+    } catch (e) {
+      setWorktreeCreateError(String(e));
+    } finally {
+      setWorktreeCreateBusy(false);
+    }
+  }, [
+    hostRef,
+    markSessionWorktree,
+    refreshGitWorktrees,
+    worktreeCreateLayout,
+    worktreeCreateName,
+    worktreeCreateRef,
+    worktreeCreateStartChat,
+  ]);
+
+  const worktreeChrome: GitWorktreeChromeOverlay = {
+    create: {
+      open: worktreeCreateOpen,
+      busy: worktreeCreateBusy,
+      startChat: worktreeCreateStartChat,
+      name: worktreeCreateName,
+      layout: worktreeCreateLayout,
+      startRef: worktreeCreateRef,
+      previewPath: worktreeCreatePreviewPath,
+      error: worktreeCreateError,
+      close: () => setWorktreeCreateOpen(false),
+      submit: () => {
+        void submitWorktreeCreate();
+      },
+      setName: (value) => {
+        setWorktreeCreateName(value);
+        setWorktreeCreateError(null);
+      },
+      setLayout: (value) => {
+        setWorktreeCreateLayout(value);
+        setWorktreeCreateError(null);
+      },
+      setRef: (value) => {
+        setWorktreeCreateRef(value);
+        setWorktreeCreateError(null);
+      },
+    },
+    gc: {
+      open: worktreeGcOpen,
+      busy: worktreeGcBusy,
+      previewBusy: worktreeGcPreviewBusy,
+      force: worktreeGcForce,
+      preview: worktreeGcPreview,
+      error: worktreeGcError,
+      close: () => {
+        setWorktreeGcOpen(false);
+        setWorktreeGcError(null);
+        setWorktreeGcPreview(null);
+        setWorktreeGcForce(false);
+      },
+      submit: () => {
+        void submitWorktreeGc();
+      },
+      setForce: setWorktreeGcForce,
+    },
+    ship: {
+      open: shipOpen,
+      busy: shipBusy,
+      success: shipSuccess,
+      title: shipTitle,
+      body: shipBody,
+      createPr: shipCreatePr,
+      draft: shipDraft,
+      branch: shipBranch,
+      status: shipStatus,
+      error: shipError,
+      close: closeShipFlow,
+      submit: () => {
+        void submitShipFlow();
+      },
+      setTitle: (value) => {
+        setShipTitle(value);
+        setShipError(null);
+      },
+      setBody: (value) => {
+        setShipBody(value);
+        setShipError(null);
+      },
+      setCreatePr: setShipCreatePr,
+      setDraft: setShipDraft,
+      openPrHub: openPrHubFromShip,
+    },
+  };
+
+  return {
+    gitWorktrees,
+    gitWorktreesAvailable,
+    gitWorktreesLoading,
+    gitWorktreesReason,
+    cliGrokHome,
+    cliWorktrees,
+    cliWorktreesAvailable,
+    cliWorktreesLoading,
+    cliWorktreesReason,
+    openWorktreeCreate,
+    openWorktreeGc,
+    openShipFlow,
+    confirmRemoveWorktree,
+    switchToWorktree,
+    markSessionWorktree,
+    sessionWorktreeBadgeFor,
+    buildSidebarWorktreeBadge,
+    refreshGitWorktrees,
+    refreshCliWorktrees,
+    applyStatusBranch,
+    worktreeChrome,
+  };
+}


### PR DESCRIPTION
## Summary
WP-W28 of AppWorkbench decomposition. Git worktree list / create / GC / ship / switch / remove / session badges move into `useGitWorktreeChrome`. Overlay chrome takes one `worktreeChrome` bag instead of ~40 props. Host git dirty poll still owns the composer chip and only calls `applyStatusBranch`.

Rebased onto `origin/main` (v0.2.32). No merge conflicts.

Closes #1033

## Metrics (vs current main)
- Orchestration lines 15237 → 14416
- useState 154 → 122
- useEffect 78 → 75
- APP_* ceilings 15350/160/83 → 14650/130/80
- New hook 984 lines (under 1000)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (hook tests + isolated re-run of load-flake files; full suite had Windows CRLF source-guard / timeout flakes that CI Linux does not)
- [ ] I ran `cargo test` in `src-tauri` (no Rust changes)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/plans/HANDOFF-appworkbench-decomposition.md` updated
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
- [x] `python scripts/check-code-quality-gates.py --mode final` PASS
- [x] `pnpm lint` and `pnpm build:ui` PASS

## Notes
- Session-fork worktree restore stays on the host (different domain).
- Next suggested cut: Side Workbench.