### PR TITLE
fix(shortcuts): allow newChat/settings while composer focused

### DIFF
--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -1584,7 +1584,6 @@ export function AppWorkbench() {
         shortcutRemapsRef.current,
         {
           voiceHotkeyEnabled: voiceHotkeyEnabledRef.current,
-          settingsOpen: escapeStopLiveRef.current.settingsOpen,
         },
       );
       if (!matched) return;

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -301,10 +301,16 @@ describe("matchGlobalShortcut", () => {
     ).toBe("toggleSidebar");
   });
 
-  it("allows find/search/help/doctor/copy/live/sidebar/side-pane while typing", () => {
+  it("allows find/newChat/settings/search/help/doctor/copy/live/sidebar/side-pane while typing", () => {
     expect(
       matchGlobalShortcut(chord({ key: "f", typing: true }), noRemaps),
     ).toBe("findInChat");
+    expect(
+      matchGlobalShortcut(chord({ key: "n", typing: true }), noRemaps),
+    ).toBe("newChat");
+    expect(
+      matchGlobalShortcut(chord({ key: ",", typing: true }), noRemaps),
+    ).toBe("settings");
     expect(
       matchGlobalShortcut(chord({ key: "k", typing: true }), noRemaps),
     ).toBe("search");
@@ -341,28 +347,6 @@ describe("matchGlobalShortcut", () => {
     expect(
       matchGlobalShortcut(chord({ key: "`", typing: true }), noRemaps),
     ).toBe("sideTerminal");
-  });
-
-  it("skips newChat and settings while typing", () => {
-    expect(
-      matchGlobalShortcut(chord({ key: "n", typing: true }), noRemaps),
-    ).toBeNull();
-    expect(
-      matchGlobalShortcut(chord({ key: ",", typing: true }), noRemaps),
-    ).toBeNull();
-  });
-
-  it("matches settings while typing when settings are already open", () => {
-    expect(
-      matchGlobalShortcut(chord({ key: ",", typing: true }), noRemaps, {
-        settingsOpen: true,
-      }),
-    ).toBe("settings");
-    expect(
-      matchGlobalShortcut(chord({ key: "n", typing: true }), noRemaps, {
-        settingsOpen: true,
-      }),
-    ).toBeNull();
   });
 
   it("does not match without mod", () => {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -395,11 +395,6 @@ export type MatchGlobalShortcutOpts = {
    * (composer / slash / menus stay available). Defaults to loaded pref / true.
    */
   voiceHotkeyEnabled?: boolean;
-  /**
-   * Settings page is showing. The settings chord still matches while a
-   * settings field is focused so ⌘, / Ctrl+, can leave the page.
-   */
-  settingsOpen?: boolean;
 };
 
 function resolveVoiceHotkeyEnabled(explicit?: boolean): boolean {
@@ -424,15 +419,13 @@ function resolveVoiceHotkeyEnabled(explicit?: boolean): boolean {
  * ({@link loadShortcutRemaps}). Pass `remaps` explicitly in tests; runtime
  * loads from localStorage when omitted.
  *
- * Behavior preserved from the previous inline App handler (with defaults):
- * - findInChat works while typing
- * - newChat / settings skip when typing, except settings still matches
- *   while typing when {@link MatchGlobalShortcutOpts.settingsOpen} is true
- *   (toggle / leave Settings from a focused field)
- * - search / help / doctor / copyLastReply / liveVoice / toggleSidebar /
- *   sideFiles / sideBrowser / sideTerminal work while typing
- *   (layout + side / bottom-terminal chords are not blocked by composers)
+ * Behavior (mod chords — safe while the composer or other fields own focus):
+ * - findInChat / newChat / settings / search / help / doctor / copyLastReply /
+ *   liveVoice / toggleSidebar / sideFiles / sideBrowser / sideTerminal all
+ *   match while typing (⌘/Ctrl required; does not steal plain keystrokes)
  * - liveVoice is suppressed when {@link shouldFireLiveVoiceHotkey} is false
+ * - App still toggles Settings open/closed from the matched id (leave Settings
+ *   from a focused settings field via the same chord)
  */
 export function matchGlobalShortcut(
   ctx: ShortcutChordContext,
@@ -461,12 +454,6 @@ export function matchGlobalShortcut(
       })
     ) {
       continue;
-    }
-    // newChat / settings: skip while typing (same as pre-remap handler).
-    // Settings chord still fires while typing if the page is already open
-    // so the same shortcut can leave Settings from a focused field.
-    if ((id === "newChat" || id === "settings") && ctx.typing) {
-      if (!(id === "settings" && opts?.settingsOpen)) continue;
     }
     // Live Voice hotkey can be disabled in Settings (composer / menus still work).
     if (id === "liveVoice" && !shouldFireLiveVoiceHotkey(voiceHotkeyEnabled)) {


### PR DESCRIPTION
## Summary
- Allow `newChat` and `settings` global mod chords while the composer (or any typing target) owns focus.
- Other global mod chords already worked while typing; these two were the legacy exception.
- Drop unused `settingsOpen` gate from `matchGlobalShortcut` (App still toggles open/close from the matched id).

Closes #1035

## Test plan
- [x] `pnpm exec vitest run src/lib/shortcuts.test.ts`
- [ ] Focus composer → ⌘N / Ctrl+N creates a new chat
- [ ] Focus composer → ⌘, / Ctrl+, opens Settings; same chord closes when already open
- [ ] Plain typing in composer unchanged (no stolen keystrokes)

## Checklist
- [x] `pnpm exec vitest run src/lib/shortcuts.test.ts`
- [ ] Full CI on PR