### PR TITLE
fix(worktree): run GC prune on confirm

### DIFF
--- a/src/hooks/useGitWorktreeChrome.test.ts
+++ b/src/hooks/useGitWorktreeChrome.test.ts
@@ -1,17 +1,28 @@
 /**
  * @vitest-environment jsdom
  *
- * Create / ship verbs live in this hook. Host only supplies project bind
- * and session open. List refresh is a no-op off Tauri.
+ * Create / ship / GC verbs live in this hook. Host only supplies project bind
+ * and session open. List refresh is a no-op off Tauri unless isTauri is mocked.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { createT } from "@/i18n";
 import type { Project } from "@/lib/app/sidebarModels";
+import * as api from "@/lib/api";
 import {
   createGitWorktreeChromeHost,
   useGitWorktreeChrome,
 } from "./useGitWorktreeChrome";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    isTauri: vi.fn(() => false),
+    gitWorktreeGc: vi.fn(),
+    gitWorktreesList: vi.fn(),
+  };
+});
 
 const PROJECT: Project = {
   id: "p1",
@@ -38,6 +49,12 @@ function setup(hostPatch?: Partial<ReturnType<typeof createGitWorktreeChromeHost
 }
 
 describe("useGitWorktreeChrome", () => {
+  beforeEach(() => {
+    vi.mocked(api.isTauri).mockReturnValue(false);
+    vi.mocked(api.gitWorktreeGc).mockReset();
+    vi.mocked(api.gitWorktreesList).mockReset();
+  });
+
   it("openCreate resets the form and opens the dialog", () => {
     const { result } = setup();
     act(() => {
@@ -81,5 +98,34 @@ describe("useGitWorktreeChrome", () => {
       result.current.worktreeChrome.ship.close();
     });
     expect(result.current.worktreeChrome.ship.open).toBe(false);
+  });
+
+  it("submit GC runs non-dry-run prune then closes", async () => {
+    vi.mocked(api.isTauri).mockReturnValue(true);
+    vi.mocked(api.gitWorktreeGc).mockResolvedValue({
+      dryRun: false,
+      prunedCount: 2,
+      prunable: [],
+      output: "",
+    });
+    vi.mocked(api.gitWorktreesList).mockResolvedValue({
+      available: true,
+      worktrees: [],
+    });
+    const { result, host } = setup();
+    act(() => {
+      result.current.openWorktreeGc();
+      result.current.worktreeChrome.gc.setForce(true);
+    });
+    await act(async () => {
+      await result.current.worktreeChrome.gc.submit();
+    });
+    expect(api.gitWorktreeGc).toHaveBeenCalledWith({
+      projectPath: PROJECT.path,
+      dryRun: false,
+      force: true,
+    });
+    expect(host.showToast).toHaveBeenCalled();
+    expect(result.current.worktreeChrome.gc.open).toBe(false);
   });
 });

--- a/src/hooks/useGitWorktreeChrome.ts
+++ b/src/hooks/useGitWorktreeChrome.ts
@@ -510,11 +510,12 @@ export function useGitWorktreeChrome(opts: {
     setWorktreeGcPreviewBusy(true);
     setWorktreeGcError(null);
     try {
-      const res = await api.gitWorktreeGc(
-        h.activeProject.path,
-        true,
-        worktreeGcForce,
-      );
+      // Object form — positional (path, force, dryRun) is easy to invert.
+      const res = await api.gitWorktreeGc({
+        projectPath: h.activeProject.path,
+        dryRun: true,
+        force: worktreeGcForce,
+      });
       setWorktreeGcPreview(res);
     } catch (e) {
       setWorktreeGcPreview(null);
@@ -535,6 +536,18 @@ export function useGitWorktreeChrome(opts: {
     setWorktreeGcBusy(true);
     setWorktreeGcError(null);
     try {
+      const res = await api.gitWorktreeGc({
+        projectPath: h.activeProject.path,
+        dryRun: false,
+        force: worktreeGcForce,
+      });
+      const pruned = res.prunedCount ?? res.pruned ?? 0;
+      h.showToast(
+        pruned > 0
+          ? h.tr("composer.worktreeGcDone", { n: String(pruned) })
+          : h.tr("composer.worktreeGcDoneNone"),
+        4000,
+      );
       setWorktreeGcOpen(false);
       setWorktreeGcPreview(null);
       setWorktreeGcForce(false);
@@ -544,7 +557,7 @@ export function useGitWorktreeChrome(opts: {
     } finally {
       setWorktreeGcBusy(false);
     }
-  }, [hostRef, refreshGitWorktrees]);
+  }, [hostRef, refreshGitWorktrees, worktreeGcForce]);
 
   const switchToWorktree = useCallback(
     async (wt: api.GitWorktreeEntry) => {


### PR DESCRIPTION
## Summary
- `submitWorktreeGc` now calls `api.gitWorktreeGc({ dryRun: false, force })` instead of only closing the modal.
- Preview + submit use the object form so positional `(path, force, dryRun)` cannot be inverted.
- Toast `composer.worktreeGcDone` / `DoneNone`; keep the dialog open on error.
- Hook test asserts confirm invokes non-dry-run GC.

Closes #1037

## Test plan
- [x] `pnpm exec vitest run src/hooks/useGitWorktreeChrome.test.ts`
- [ ] Open Worktree GC → Confirm → stale records actually pruned
- [ ] Force checkbox still maps to `--expire now`
- [ ] Failure keeps modal open with error text