### PR TITLE
fix(linux): prefer host WebKitGTK in AppImage to avoid SIGBUS on quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ See `docs/llm-wiki/release.md`.
 ### Fixed
 - Opening a file in Review keeps the macOS title bar visible. Focus scrolls only inside Review (#1041).
 - Advanced context-window Save stays fully clickable. The flyout no longer clips the button (#1047).
+- Linux AppImage prefers host WebKitGTK to avoid black screens and SIGBUS on quit. Helpers stay on disk so FUSE unmount is safe (#539).
 
 **中文 · 修复**
 - 在 Review 中打开文件时，macOS 标题栏保持可见。只滚动 Review 内部列表（#1041）。
 - Advanced 里上下文窗口的「保存」可正常点到。浮层不再裁掉按钮（#1047）。
+- Linux AppImage 优先用本机 WebKitGTK，避免黑屏和退出时 SIGBUS。子进程不再映射在 squashfs 上（#539）。
 
 ### Added
 - Ctrl+Tab jumps back to the last chat you used. Hold Ctrl and tap Tab to cycle further; Ctrl+Shift+Tab goes the other way.

--- a/README.md
+++ b/README.md
@@ -210,10 +210,12 @@ If the process never starts and you see `libEGL.so.1: cannot open shared object 
 
 On certain Wayland desktop setups (such as Hyprland with AMD GPUs), the universal AppImage may encounter rendering conflicts with the host Mesa/DRI stack:
 - **Recommended**: Use system-integrated **`.deb`** or **`.rpm`** packages which link against your distribution's native WebKitGTK.
+- The AppImage itself will use **host WebKitGTK 4.1** when that package is installed (`webkit2gtk-4.1` on Arch, `libwebkit2gtk-4.1-0` on Debian/Ubuntu). That avoids the bundled-WebKit `EGL_BAD_PARAMETER` black window (#539) and `SIGBUS` in leftover `WebKitNetworkProcess` when the squashfs unmounts. Opt out with `GROK_SKIP_SYSTEM_WEBKIT=1`.
 - When running the AppImage, you can try disabling hardware compositing:
 ```bash
 WEBKIT_DISABLE_DMABUF_RENDERER=1 ./Grok_*.AppImage
 ```
+- Do not wrap the AppImage with `--appimage-mount` and then kill the mount while WebKit helpers are still running — that is the SIGBUS path. Prefer this script, which **extracts** to a real directory: `scripts/run-linux-appimage-system-webkit.sh`.
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -210,10 +210,12 @@ If the process never starts and you see `libEGL.so.1: cannot open shared object 
 
 On certain Wayland desktop setups (such as Hyprland with AMD GPUs), the universal AppImage may encounter rendering conflicts with the host Mesa/DRI stack:
 - **Recommended**: Use system-integrated **`.deb`** or **`.rpm`** packages which link against your distribution's native WebKitGTK.
+- The AppImage itself will use **host WebKitGTK 4.1** when that package is installed (`webkit2gtk-4.1` on Arch, `libwebkit2gtk-4.1-0` on Debian/Ubuntu). That avoids the bundled-WebKit `EGL_BAD_PARAMETER` black window (#539) and `SIGBUS` in leftover `WebKitNetworkProcess` when the squashfs unmounts. Opt out with `GROK_SKIP_SYSTEM_WEBKIT=1`.
 - When running the AppImage, you can try disabling hardware compositing:
 ```bash
 WEBKIT_DISABLE_DMABUF_RENDERER=1 ./Grok_*.AppImage
 ```
+- Do not wrap the AppImage with `--appimage-mount` and then kill the mount while WebKit helpers are still running — that is the SIGBUS path. Prefer this script, which **extracts** to a real directory: `scripts/run-linux-appimage-system-webkit.sh`.
 
 ---
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -210,10 +210,12 @@ sudo apt-get install -y libegl1 libgles2 libwebkit2gtk-4.1-0 libayatana-appindic
 
 В некоторых окружениях Wayland (например, Hyprland на видеокартах AMD) пакет AppImage может испытывать сложности взаимодействия с драйверами Mesa:
 - **Рекомендуется**: Использовать системные пакеты **`.deb`** или **`.rpm`**, скомпонованные с системной версией WebKitGTK.
+- AppImage сам переключается на **системный WebKitGTK 4.1**, если пакет установлен. Так обходятся чёрное окно `EGL_BAD_PARAMETER` (#539) и `SIGBUS` в оставшемся `WebKitNetworkProcess` при размонтировании squashfs. Отключение: `GROK_SKIP_SYSTEM_WEBKIT=1`.
 - При использовании AppImage можно запустить приложение с отключением аппаратного композитинга:
 ```bash
 WEBKIT_DISABLE_DMABUF_RENDERER=1 ./Grok_*.AppImage
 ```
+- Не оборачивайте AppImage в `--appimage-mount` и не убивайте mount, пока живы процессы WebKit — это путь к SIGBUS. Используйте скрипт, который **распаковывает** образ в обычный каталог: `scripts/run-linux-appimage-system-webkit.sh`.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -210,10 +210,12 @@ sudo apt-get install -y libegl1 libgles2 libwebkit2gtk-4.1-0 libayatana-appindic
 
 部分运行 Wayland（如 Hyprland + AMD 显卡）的 Linux 环境下，AppImage 可能会因容器打包版本与主机 Mesa 驱动兼容性问题出现显示异常：
 - **推荐方案**：优先使用与系统包管理器契合的 **`.deb`** 或 **`.rpm`** 安装包（链接系统原生 WebKitGTK）。
+- AppImage 若检测到本机 WebKitGTK 4.1（Arch：`webkit2gtk-4.1`，Debian/Ubuntu：`libwebkit2gtk-4.1-0`），会改用系统库，避免内置 WebKit 的 `EGL_BAD_PARAMETER` 黑屏（#539），以及 squashfs 卸载时残留 `WebKitNetworkProcess` 的 `SIGBUS`。可用 `GROK_SKIP_SYSTEM_WEBKIT=1` 退回内置库。
 - 如使用 AppImage，可尝试添加环境变量运行：
 ```bash
 WEBKIT_DISABLE_DMABUF_RENDERER=1 ./Grok_*.AppImage
 ```
+- 不要用 `--appimage-mount` 包一层再在 WebKit 子进程还活着时卸挂载，那会 SIGBUS。请用会**解压**到真实目录的 `scripts/run-linux-appimage-system-webkit.sh`。
 
 ---
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -96,7 +96,7 @@ Issue [#539](https://github.com/RongleCat/grok-app/issues/539) 对照实验：�
 用户侧缓解：各 README 的「Linux blank/black window」段，或仓库脚本  
 `scripts/run-linux-appimage-system-webkit.sh`。
 
-长期方向（未合入）：CI 打包后改写 AppRun，在检测到系统 WebKit 时优先加载（需多机验证，且重打包后需重签 updater `.sig`）。不要为了此问题单独把 Linux CI 升到 Ubuntu 24.04——会抬高 glibc 底线，且不保证 bundled-vs-system 类问题消失。
+AppImage 宿主进程在启动时若检测到系统 WebKitGTK 4.1，会带 `WEBKIT_EXEC_PATH` / `LD_LIBRARY_PATH` 再 exec 自身（`src-tauri/src/linux_webkit.rs`）。这覆盖 #539 黑屏，也避免退出时 FUSE 卸载仍映射在 squashfs 上的 `WebKitNetworkProcess`（SIGBUS / `BUS_ADRERR`）。`GROK_SKIP_SYSTEM_WEBKIT=1` 可退回内置 WebKit。不要为了此问题单独把 Linux CI 升到 Ubuntu 24.04——会抬高 glibc 底线。
 
 ## 2. 本地构建命令
 

--- a/scripts/run-linux-appimage-system-webkit.sh
+++ b/scripts/run-linux-appimage-system-webkit.sh
@@ -5,6 +5,10 @@
 # (EGL_BAD_PARAMETER from the CI-bundled WebKit). See issue #539 and
 # README "Linux blank/black window (WebKit)".
 #
+# Extract to a real directory — do **not** `--appimage-mount` and then kill the
+# mount. Leftover WebKitNetworkProcess mappings into that squashfs SIGBUS
+# (BUS_ADRERR) when FUSE tears down.
+#
 # Usage:
 #   bash scripts/run-linux-appimage-system-webkit.sh ./Grok_0.2.11_amd64.AppImage
 #   bash scripts/run-linux-appimage-system-webkit.sh ./Grok_*.AppImage -- --some-flag

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -208,6 +208,9 @@ mod turn_lease;
 
 mod host_runtime;
 
+#[cfg(target_os = "linux")]
+mod linux_webkit;
+
 mod win_crash;
 
 mod updater;
@@ -262,9 +265,17 @@ pub fn run() {
         std::process::exit(session_api::run_cli());
     }
 
+    // Before host_runtime: a successful exec replaces this process, so it must
+    // not write a heartbeat the successor would treat as an unclean shutdown.
+    #[cfg(target_os = "linux")]
+    crate::linux_webkit::maybe_reexec_for_system_webkit();
+
     let _ = paths::ensure_app_dirs();
 
     logging::init();
+
+    #[cfg(target_os = "linux")]
+    crate::linux_webkit::log_system_webkit_choice();
 
     crate::host_runtime::on_process_start();
     crate::win_crash::install();
@@ -1847,6 +1858,9 @@ pub fn run() {
                     host.inner().stop_sync();
 
                 }
+
+                #[cfg(target_os = "linux")]
+                crate::linux_webkit::wait_for_appimage_webkit_helpers();
 
             }
 

--- a/src-tauri/src/linux_webkit.rs
+++ b/src-tauri/src/linux_webkit.rs
@@ -1,0 +1,272 @@
+//! AppImage WebKitGTK helpers on Linux.
+//!
+//! Two related failures show up on Wayland hosts (Hyprland + AMD, Arch):
+//!
+//! 1. The CI-bundled Ubuntu WebKitGTK aborts the UI process with
+//!    `Could not create default EGL display: EGL_BAD_PARAMETER` (#539).
+//! 2. `WebKitNetworkProcess` / `WebKitWebProcess` keep file-backed mappings
+//!    into the AppImage squashfs. When the FUSE mount is torn down on quit
+//!    (or a wrapper kills `--appimage-mount`), the leftover helper gets
+//!    `SIGBUS`/`BUS_ADRERR`.
+//!
+//! When the host has WebKitGTK 4.1, re-exec with `LD_LIBRARY_PATH` +
+//! `WEBKIT_EXEC_PATH` pointing at it — same combo as
+//! `scripts/run-linux-appimage-system-webkit.sh`. Helpers then live on the
+//! host filesystem, so FUSE teardown cannot yank their code pages.
+//!
+//! On bundled-WebKit fallback, wait for those helpers before the process
+//! returns so the AppImage runtime unmounts a quiet tree.
+//!
+//! Opt out: `GROK_SKIP_SYSTEM_WEBKIT=1`.
+
+use std::env;
+use std::fs;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const SKIP_ENV: &str = "GROK_SKIP_SYSTEM_WEBKIT";
+const APPLIED_ENV: &str = "GROK_SYSTEM_WEBKIT";
+
+const LIB_CANDIDATES: &[&str] = &["/usr/lib/x86_64-linux-gnu", "/usr/lib64", "/usr/lib"];
+
+const EXEC_CANDIDATES: &[&str] = &[
+    "/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1",
+    "/usr/lib64/webkit2gtk-4.1",
+    "/usr/lib/webkit2gtk-4.1",
+];
+
+const HELPER_WAIT: Duration = Duration::from_secs(3);
+const HELPER_POLL: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemWebkit {
+    pub lib_dir: PathBuf,
+    pub exec_dir: PathBuf,
+}
+
+pub fn detect_system_webkit() -> Option<SystemWebkit> {
+    detect_system_webkit_in(LIB_CANDIDATES, EXEC_CANDIDATES)
+}
+
+pub fn detect_system_webkit_in(lib_dirs: &[&str], exec_dirs: &[&str]) -> Option<SystemWebkit> {
+    let lib_dir = lib_dirs.iter().map(Path::new).find(|d| {
+        d.join("libwebkit2gtk-4.1.so.0").is_file() || d.join("libwebkit2gtk-4.1.so").is_file()
+    })?;
+    let exec_dir = exec_dirs.iter().map(Path::new).find(|d| {
+        d.join("WebKitNetworkProcess").is_file() || d.join("WebKitWebProcess").is_file()
+    })?;
+    Some(SystemWebkit {
+        lib_dir: lib_dir.to_path_buf(),
+        exec_dir: exec_dir.to_path_buf(),
+    })
+}
+
+pub fn running_inside_appimage() -> bool {
+    env::var_os("APPDIR").is_some() || env::var_os("APPIMAGE").is_some()
+}
+
+/// Re-exec this binary against host WebKitGTK when launched from an AppImage.
+///
+/// Must run **before** [`crate::host_runtime::on_process_start`]: the first
+/// process is replaced, so it must not write a heartbeat the successor would
+/// treat as an unclean shutdown.
+pub fn maybe_reexec_for_system_webkit() {
+    if env::var_os(SKIP_ENV).is_some() || env::var_os(APPLIED_ENV).is_some() {
+        return;
+    }
+    if !running_inside_appimage() {
+        return;
+    }
+    let Some(paths) = detect_system_webkit() else {
+        return;
+    };
+
+    let exe = match env::current_exe() {
+        Ok(p) => p,
+        Err(_) => PathBuf::from("/proc/self/exe"),
+    };
+    let mut cmd = Command::new(exe);
+    cmd.args(env::args_os().skip(1));
+    cmd.env(APPLIED_ENV, "1");
+    cmd.env("WEBKIT_EXEC_PATH", &paths.exec_dir);
+
+    let mut ld = paths.lib_dir.display().to_string();
+    if let Ok(old) = env::var("LD_LIBRARY_PATH") {
+        if !old.is_empty() {
+            ld.push(':');
+            ld.push_str(&old);
+        }
+    }
+    cmd.env("LD_LIBRARY_PATH", ld);
+
+    if env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        cmd.env("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+    if env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
+        cmd.env("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+    }
+
+    let err = cmd.exec();
+    eprintln!("grok-app: system WebKit re-exec failed: {err}");
+}
+
+pub fn log_system_webkit_choice() {
+    if env::var_os(SKIP_ENV).is_some() {
+        tracing::info!("Linux WebKit: GROK_SKIP_SYSTEM_WEBKIT set; using bundled libraries");
+        return;
+    }
+    if env::var_os(APPLIED_ENV).is_some() {
+        tracing::info!(
+            exec = env::var("WEBKIT_EXEC_PATH").ok(),
+            "Linux WebKit: re-exec'd against host WebKitGTK 4.1"
+        );
+        return;
+    }
+    if running_inside_appimage() {
+        tracing::info!(
+            "Linux WebKit: AppImage host has no WebKitGTK 4.1; bundled helpers may SIGBUS on unmount"
+        );
+    }
+}
+
+pub fn is_appimage_webkit_helper(exe: &Path, appdir: &Path) -> bool {
+    let Some(name) = exe.file_name().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    if name != "WebKitNetworkProcess" && name != "WebKitWebProcess" {
+        return false;
+    }
+    exe.starts_with(appdir)
+}
+
+fn running_appimage_webkit_helper_pids(appdir: &Path) -> Vec<i32> {
+    let mut out = Vec::new();
+    let Ok(proc) = fs::read_dir("/proc") else {
+        return out;
+    };
+    let self_pid = std::process::id() as i32;
+    for ent in proc.flatten() {
+        let pid: i32 = match ent.file_name().to_str().and_then(|s| s.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        if pid == self_pid {
+            continue;
+        }
+        let Ok(exe) = fs::read_link(ent.path().join("exe")) else {
+            continue;
+        };
+        if is_appimage_webkit_helper(&exe, appdir) {
+            out.push(pid);
+        }
+    }
+    out
+}
+
+fn libc_kill(pid: i32, sig: i32) {
+    unsafe {
+        libc::kill(pid, sig);
+    }
+}
+
+/// Block until AppImage-backed WebKit helpers exit, then SIGTERM stragglers.
+///
+/// Call from `RunEvent::Exit` so the AppImage runtime unmounts after mappings
+/// are gone. No-op when not inside an AppImage.
+pub fn wait_for_appimage_webkit_helpers() {
+    let Some(appdir) = env::var_os("APPDIR") else {
+        return;
+    };
+    let appdir = PathBuf::from(appdir);
+    let deadline = Instant::now() + HELPER_WAIT;
+    loop {
+        let pids = running_appimage_webkit_helper_pids(&appdir);
+        if pids.is_empty() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            tracing::warn!(
+                count = pids.len(),
+                "Linux WebKit: AppImage helpers still mapped; sending SIGTERM before unmount"
+            );
+            for pid in pids {
+                libc_kill(pid, libc::SIGTERM);
+            }
+            thread::sleep(HELPER_POLL);
+            return;
+        }
+        thread::sleep(HELPER_POLL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+
+    fn tmp() -> PathBuf {
+        let p = env::temp_dir().join(format!(
+            "grok-linux-webkit-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn detect_requires_lib_and_helper() {
+        let root = tmp();
+        let lib = root.join("lib");
+        let exec = root.join("webkit2gtk-4.1");
+        fs::create_dir_all(&lib).unwrap();
+        fs::create_dir_all(&exec).unwrap();
+        File::create(lib.join("libwebkit2gtk-4.1.so.0")).unwrap();
+        File::create(exec.join("WebKitNetworkProcess")).unwrap();
+
+        let found = detect_system_webkit_in(&[lib.to_str().unwrap()], &[exec.to_str().unwrap()])
+            .expect("detect");
+        assert_eq!(found.lib_dir, lib);
+        assert_eq!(found.exec_dir, exec);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn detect_none_without_helper_binary() {
+        let root = tmp();
+        let lib = root.join("lib");
+        let exec = root.join("webkit2gtk-4.1");
+        fs::create_dir_all(&lib).unwrap();
+        fs::create_dir_all(&exec).unwrap();
+        File::create(lib.join("libwebkit2gtk-4.1.so.0")).unwrap();
+        assert!(
+            detect_system_webkit_in(&[lib.to_str().unwrap()], &[exec.to_str().unwrap()]).is_none()
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn helper_match_is_appdir_scoped() {
+        let appdir = Path::new("/tmp/.mount_Grok.XXXX");
+        assert!(is_appimage_webkit_helper(
+            &appdir.join("usr/lib/webkit2gtk-4.1/WebKitNetworkProcess"),
+            appdir
+        ));
+        assert!(is_appimage_webkit_helper(
+            &appdir.join("usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/WebKitWebProcess"),
+            appdir
+        ));
+        assert!(!is_appimage_webkit_helper(
+            Path::new("/usr/lib/webkit2gtk-4.1/WebKitNetworkProcess"),
+            appdir
+        ));
+        assert!(!is_appimage_webkit_helper(
+            &appdir.join("usr/bin/grok-app"),
+            appdir
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
Linux AppImage was SIGBUS-ing leftover `WebKitNetworkProcess` when the squashfs unmounted (`BUS_ADRERR` in bundled `libsqlite3`, same second as FUSE teardown). Related to the Hyprland/AMD `EGL_BAD_PARAMETER` black window (#539).

When host WebKitGTK 4.1 is present, re-exec against it so helpers are not mapped from the AppImage. Otherwise wait for AppImage-backed helpers before exit. Opt out: `GROK_SKIP_SYSTEM_WEBKIT=1`.

Verified on Arch + Hyprland: extract/system-WebKit launcher keeps `WebKitNetworkProcess` and `WebKitWebProcess` on `/usr/lib/webkit2gtk-4.1`, UI loads, no new coredump.

## Type of change
- [x] Bug fix

## Checklist
- [x] I ran `cargo test` in `src-tauri` (`linux_webkit` unit tests)
- [x] `cargo clippy --lib -- -D warnings`
- [x] Docs / `docs/BUILD.md` / CHANGELOG [Unreleased] updated
- [x] No secrets included