### PR TITLE
refactor(workbench): extract Side Workbench chrome

### DIFF
--- a/docs/plans/2026-09-06-appworkbench-w29-side-workbench.md
+++ b/docs/plans/2026-09-06-appworkbench-w29-side-workbench.md
@@ -1,0 +1,171 @@
+# AppWorkbench 继续拆解 — WP-W29 Side Workbench
+
+**日期**：2026-09-06  
+**基线**：`origin/main` @ `f7d4060a`（`fix(worktree): actually run GC on confirm (#1038)`）  
+**来源**：HANDOFF `docs/plans/HANDOFF-appworkbench-decomposition.md` · 软件设计哲学（深模块 / 信息隐藏）  
+**执行位置**：worktree `D:/code/grok-app-appworkbench-w29-side-workbench` · 分支 `refactor/appworkbench-w29-side-workbench`  
+**状态**：W29 代码已在该 worktree 写完、未提交、未开 PR、不 merge `main`
+
+---
+
+## 1. 问题
+
+`src/app/AppWorkbench.tsx` 行数大是症状。根因是**信息未被隐藏**：域的 state / effect / 持久化 / 动词仍堆在 host 顶层。改 Side Workbench 必须在 100+ 个 `useState` 里判断耦合。
+
+约束（不可破）：
+
+- AGENTS.md §7：App shell + AppWorkbench **合计行数只降不升**；新状态进域模块，禁止再往 host 加 `useState` / 大功能块。
+- 按**知识归属**抽深 hook（state + effect + persist + 少量动词），不切 80-prop Stage 壳，不按「读-算-写」切浅 helper。
+- `files_ge_1000` 闸门 ≤80、顶格；新文件必须 <1000 行。
+- 一次一个域。`wwwww` 独立 worktree。禁止 merge `main`，除非用户明确说。
+- UI 文案走 `createT` / `t()`；无 `window.confirm` / `prompt` / `alert`。
+
+---
+
+## 2. 同步
+
+`git fetch origin main` 后 `origin/main` 仍是 `f7d4060a`（W28 #1034 + shortcuts #1036 + worktree GC #1038）。W29 worktree 已在该 SHA，**无需 rebase**。
+
+---
+
+## 3. 剩余域（W29 前快照，main @ f7d4060a）
+
+W28 后 host 约 **14416 行 / 122 useState / 75 useEffect**。内聚、可独立隐藏的簇：
+
+| 优先级 | 域 | 自持知识 | 为何现在切 / 不切 |
+|--------|----|----------|-------------------|
+| **W29（本刀）** | Side Workbench | tabs、dock composer、Review focus、⌘W 关 tab、git 探测、chat→side 路由、项目隔离 | 产品边界清楚；hostRef 晚绑已有 W27/W28 先例 |
+| W30 | 会话徽章 | mute / unread / plan-pending 的 Set、localStorage、CustomEvent、tray/dock 计数、clear-all | 下一刀。自持 persist，不碰 chat 正文 |
+| W31 | 账号 / 配额 | `account`、loading/busy、heatmap/probe error、loginHint、boot 缓存再 refresh | 已有 `useAccountQuotaAutoRefresh`；host 仍持投影 state |
+| W32 | MCP doctor | report / error / loading / focus + `mcpDoctor()` | 弹层已在 chrome overlays，state 仍回流 host |
+| W33 | setup / boot | `appGate`、bootDetect*、`setupCliSeed`、`setSetup` | 与 first-run 向导、CLI 探测缠在一起，后切 |
+| **留 host** | `sessionChangesById` | chat 线程 + Review 面板共用 | 两边都写都读；抽走会变成双写或 80-prop |
+| **留 host** | `gitDirtySummary` | composer chip；W28 经 `applyStatusBranch` 补 branch | 与 worktree chrome 只共享 gitStatus 结果，不是同一产品动作 |
+
+**否决的切法**：再拆 `WorkbenchResourcesAside` 的 props 袋（浅模块，接口成本上升）；把 dock 高度测量塞进 Side hook（测量依赖 `composerWrapRef` / attachments / welcome，是 composer 知识）。
+
+---
+
+## 4. W29 锁定方案
+
+### 4.1 模块
+
+新建 `src/hooks/useSideWorkbenchChrome.ts`（深 hook，对标 `useGitWorktreeChrome` / `useSessionConnect`）：
+
+自持：
+
+- `sideWorkbench` + 项目隔离（已有 `useSideWorkbenchProjectIsolation`，改为 hook 内调用）
+- `sideDockComposer` / `sideDockComposerH`
+- `sideIsGitProject`（`api.gitStatus` 探测）
+- `reviewFocus`（path / token / pinnedPaths）
+- `closeActiveSideRequest` + ⌘W / Ctrl+W 监听（`APP_CLOSE_TAB_OR_WINDOW_EVENT`）
+- chat `resourceOpenTarget` → `applySideContextOpen` 路由（aside 折叠时开栏并保留 target，#998）
+
+对外动词（host 只调这些）：
+
+`openSkills` · `openPlan` · `openPicker` · `openReview` · `focusReviewPath` · `onAsideCloseExtras` · `onExpandedChange` · `toggleDockComposer` · `consumeCloseActive` · `closeSideTabOrWindow`
+
+### 4.2 hostRef 晚绑
+
+`showToast` / `openAsidePane` / `tr` 声明点分散。沿用 W27 模式：
+
+```ts
+type SideWorkbenchChromeHost = {
+  tr: TFn;
+  showToast: (msg: string, ms?: number) => void;
+  openAsidePane: () => void;
+  setResourceOpenTarget: Dispatch<SetStateAction<ResourceOpenTarget | null>>;
+  setPlanFocusKey: Dispatch<SetStateAction<number>>;
+  asideCollapsed: () => boolean; // 读 layoutRef，避免关 tab 读到过期 collapsed
+};
+```
+
+每轮 render 在 `gitWorktreeHostRef` 填充块旁写入 `sideWorkbenchHostRef`。effects 在 commit 后跑，此时袋已满。
+
+### 4.3 明确仍留 host 的薄封装
+
+| 点 | 原因 |
+|----|------|
+| `openSideSkillsPanel` | 先关 composer `+` / slash，再 `openSkills()`。关菜单是 composer 知识 |
+| dock 高度 `ResizeObserver` | 读 `composerWrapRef`、attachments、welcome。setter 仍来自 hook |
+| `onThreadOpenSessionChanges` / `onThreadOpenModifiedPath` | 先 `seedSessionChangesForReview`（host 的 changes 表），再 `openReview` + `focusReviewPath` |
+| `sessionChangesById` / `gitDirtySummary` | 见 §3 |
+
+Aside / Main 继续吃 `sideWorkbench` + `setSideWorkbench`（视图要改 tab 条）。本刀不收成 80-prop 壳。
+
+### 4.4 测试
+
+`src/hooks/useSideWorkbenchChrome.test.ts`（jsdom），对标 W28：
+
+1. `openSkills` 建 skills tab 并 `openAsidePane`
+2. `openPlan` 建 plan tab 并 bump `setPlanFocusKey`
+3. `openPicker("file")` 建 file tab 且 `treeVisible`
+4. `openPicker("review")` 在 git 未确认时不建 tab
+5. git probe `available: true` 后 review picker 建 tab
+6. aside 折叠时 file `resourceOpenTarget` 路由进 files tab
+7. `focusReviewPath` pin + token+1
+8. `onAsideCloseExtras` 收 expand 与 dock
+
+### 4.5 闸门
+
+实测（W29 接线后）：
+
+| | W28 main | W29 worktree | 新天花板 |
+|--|----------|--------------|----------|
+| 行数 | 14416 | **14258** | 14650 → **14400** |
+| useState | 122 | **116** | 130 → **120** |
+| useEffect | 75 | **71** | 80 → **74** |
+
+ledger：`docs/plans/CODE-QUALITY-PROGRESS.md` 追加 W29 行；`HANDOFF` 记本刀并写「下一步会话徽章」。
+
+---
+
+## 5. 已改文件（worktree 现状）
+
+| 文件 | 作用 |
+|------|------|
+| `src/hooks/useSideWorkbenchChrome.ts` | 新深 hook（未跟踪） |
+| `src/hooks/useSideWorkbenchChrome.test.ts` | 8 测（未跟踪） |
+| `src/app/AppWorkbench.tsx` | 净删接线；host 只填袋 + 薄封装 |
+| `scripts/check-code-quality-gates.py` | 天花板下调 |
+| `docs/plans/CODE-QUALITY-PROGRESS.md` | WP-W29 + metrics log |
+| `docs/plans/HANDOFF-appworkbench-decomposition.md` | W29 一行 |
+| `docs/plans/2026-09-06-appworkbench-w29-side-workbench.md` | 本方案 |
+
+`android/capacitor.settings.gradle` 不存在，`skip-worktree` 跳过。
+
+---
+
+## 6. 验收（W29）
+
+- 改 Side tabs / dock / Review / ⌘W / git 探测 / chat→side 路由，不必打开 host 函数体（host 只填 `sideWorkbenchHostRef`）。
+- 行为与抽前一致：非 git 时 review picker 仍不建 tab；#998 带 path 的 changes 开 Review 不弹吓人 toast；⌘W 先关 tab 再关窗。
+- `python scripts/check-code-quality-gates.py --mode final` PASS。
+- `tsc --noEmit`、eslint（改动文件 `--max-warnings 0`）、相关 vitest（hook 8 + sideWorkbench/sideContextOpen/reviewFocusPaths/sideFloatComposer 共 50）PASS。
+- 新文件 <1000 行；`files_ge_1000` 仍 80。
+- **不做**：浏览器点选（Tauri；本环境无桌面探测）。用单测代替。
+
+当前 worktree 上列检查已过。
+
+---
+
+## 7. 流程
+
+1. 本方案落在 `docs/plans/2026-09-06-appworkbench-w29-side-workbench.md`。
+2. 代码已在该 worktree；不新开第二棵。不 merge `main`。
+3. 用户未叫 `cmttt` / 提 issue+PR：默认不提交。需要时再 Conventional Commit，例如 `refactor(workbench): extract Side Workbench chrome`。
+4. 本机无 `pi`：按 HANDOFF 记录跳过，不挡本刀。
+5. Windows 全量 `pnpm test` 的 CRLF source-guard 与本地 `TaskDialogIndirect` 是环境问题，不以它们为 W29 出口。
+
+---
+
+## 8. 后续（不在本刀）
+
+**W30 会话徽章**（HANDOFF 已写下一步）：
+
+- 新 `useSessionChromeBadges`（名可在动手时按仓库词汇微调）。
+- 自持 `mutedSessionIds` / `unreadSessionIds` / `planPendingSessionIds`、storage 事件、`applyClearSessionUnread` / `applyMarkSessionUnread` / `markPlanPendingBadge`、tray/dock `busyCount`。
+- host 只把 Set 和动词传给 sidebar / UserMenu。
+- `manualUnreadHoldIdsRef` 跟着走（与「当前正在看」绑定，经 hostRef 读 `viewingSessionIdRef`）。
+
+其后 W31 账号配额 → W32 MCP doctor → W33 setup/boot。`sessionChangesById` 与 `gitDirtySummary` 继续留 host，直到 Review 与 composer chip 不再双边写入。

--- a/docs/plans/CODE-QUALITY-PROGRESS.md
+++ b/docs/plans/CODE-QUALITY-PROGRESS.md
@@ -12,7 +12,7 @@
 | Spec | `docs/plans/2026-08-01-code-quality-remediation-GOAL.md` |
 | Started | `2026-08-01` |
 | Current wave | `workbench-decomp` |
-| Current WP | `WP-W28` |
+| Current WP | `WP-W29` |
 | **FINAL** | **PASS** (honest orchestration metrics; decreasing ceilings) |
 
 ## Wave checklist
@@ -74,6 +74,7 @@
 | WP-W26 | Settings prefs hydrate into useAppSettingsPrefs | PASS | aae65cf4 | 15612→15471 lines; useState 209→156 |
 | WP-W27 | Session connect + live map into useSessionConnect | PASS | aae65cf4 | 15471→15183 lines; useState 156→155; useEffect 81→80 |
 | WP-W28 | Git worktree + ship chrome into useGitWorktreeChrome | PASS |  | #1033; 15237→14416 lines; useState 154→122; useEffect 78→75 |
+| WP-W29 | Side Workbench chrome into useSideWorkbenchChrome | PASS |  | #1042; 14416→14258 lines; useState 122→116; useEffect 75→71; plan `docs/plans/2026-09-06-appworkbench-w29-side-workbench.md` |
 
 ## Metrics log (append-only)
 
@@ -113,6 +114,7 @@
 | 2026-08-24 W26 | 15471 (shell 18 + wb 15453) | 156 | 81 | 11 | dir | dir | 28 | 9 | 69 |
 | 2026-08-24 W27 | 15183 (shell 18 + wb 15165) | 155 | 80 | 11 | dir | dir | 28 | 9 | 69 |
 | 2026-09-05 W28 | 14416 (shell 21 + wb 14395) | 122 | 75 | 12 | dir | dir | 29 | 9 | 80 |
+| 2026-09-06 W29 | 14258 (shell 21 + wb 14237) | 116 | 71 | 12 | dir | dir | 29 | 9 | 80 |
 
 ## Blockers
 

--- a/docs/plans/HANDOFF-appworkbench-decomposition.md
+++ b/docs/plans/HANDOFF-appworkbench-decomposition.md
@@ -60,6 +60,7 @@
    **WP-W26 已落地**：Host AppSettings prefs 水合 → `parseAppSettingsPrefs` + `useAppSettingsPrefs`。locale/composer chips/CLI probe 仍在 boot。天花板见 W27。
    **WP-W27 已落地**：ensureConnected + connecting claims + liveMap 订阅 → `useSessionConnect`。#870 验收：改 settings 导航/prefs/connect 不必打开 host 函数体。天花板 **15350 / 160 / 83**。
    **WP-W28 已落地**：git worktree 列表 / 创建 / GC / ship / switch / remove / 徽章 → `useGitWorktreeChrome`。overlay 收成 `worktreeChrome` 一袋。git dirty 仍在 host，经 `applyStatusBranch` 补 branch chip。天花板 **14650 / 130 / 80**。下一步 Side Workbench。
+   **WP-W29 已落地**：Side Workbench tabs / dock composer / Review focus / close-tab / git probe / chat→side 路由 → `useSideWorkbenchChrome`。host 只填 aside/open/toast 晚绑袋。`sessionChangesById` 与 git dirty 仍在 host。天花板 **14400 / 120 / 74**。方案见 [2026-09-06-appworkbench-w29-side-workbench.md](./2026-09-06-appworkbench-w29-side-workbench.md)。下一步会话徽章（mute / unread / plan-pending）。
    **pi**：协作者本机无 pi，按 owner 规则跳过。
    **5 个 worktree**：误会。远端 `main` 已含那些产品改动（本地只是 squash 后残留 SHA）。不挡大拆。
 5. 5.6k 行 JSX 拆为 view shell + 域容器；modals 先经既有 `useAppDialogs` 收口。

--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -43,9 +43,9 @@ APP_ORCH_FILES = (
 # Decreasing ceilings at current combined scale. Ratchet down each
 # workbench-extraction WP. The old 6000/100/50 numbers measured the 26-line
 # shell after the God Component was renamed — not a budget to grow into.
-APP_LINES_CEILING = 14650
-APP_USESTATE_CEILING = 130
-APP_USEEFFECT_CEILING = 80
+APP_LINES_CEILING = 14400
+APP_USESTATE_CEILING = 120
+APP_USEEFFECT_CEILING = 74
 
 
 def lines_of(path: Path) -> int:

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -47,7 +47,6 @@ import { writeOpenTargetStorage } from "@/lib/openEditorHonesty";
 import { buildContinueAgentPrompt } from "@/lib/continueInterruptedTurn";
 import {
   APP_CLOSE_REQUESTED_EVENT,
-  APP_CLOSE_TAB_OR_WINDOW_EVENT,
   loadAlwaysQuitWithoutAskingPref,
   shouldConfirmQuit,
 } from "@/lib/confirmQuit";
@@ -553,18 +552,11 @@ import {
 } from "@/lib/providerBalanceFormat";
 import type { ResourceOpenTarget } from "@/components/ResourceViewer";
 import {
-  applySideStripClose,
-  emptySideWorkbenchState,
-  openSideTab,
-  openSideTabFromPicker,
   type SidePickerKind,
-  type SideWorkbenchState,
 } from "@/lib/sideWorkbench";
 import {
-  isSideDockComposerActive,
   shouldHideChatForSideExpand,
 } from "@/lib/sideFloatComposer";
-import { applySideContextOpen } from "@/lib/sideContextOpen";
 import { resolveSidePathDeepLink } from "@/lib/sidePathDeepLink";
 
 import { WorkbenchAppDialogStage } from "@/app/WorkbenchAppDialogStage";
@@ -576,7 +568,7 @@ import {
   summarizeSessionChanges,
   type SessionFileChange,
 } from "@/lib/sessionChanges";
-import { pinReviewFocusPath } from "@/lib/reviewFocusPaths";
+
 import {
   gitDirtySummariesEqual,
   summarizeGitDirty,
@@ -653,7 +645,10 @@ import {
 import { useSidebarProjectReorder } from "@/hooks/useSidebarProjectReorder";
 import { useSessionMoveProject } from "@/hooks/useSessionMoveProject";
 import { useSidebarSessionMoveDrag } from "@/hooks/useSidebarSessionMoveDrag";
-import { useSideWorkbenchProjectIsolation } from "@/hooks/useSideWorkbenchProjectIsolation";
+import {
+  createSideWorkbenchChromeHost,
+  useSideWorkbenchChrome,
+} from "@/hooks/useSideWorkbenchChrome";
 import { useBottomTerminal } from "@/hooks/useBottomTerminal";
 import { useProjectSpaces } from "@/hooks/useProjectSpaces";
 import {
@@ -984,29 +979,6 @@ export function AppWorkbench() {
   } = useWorkbenchLayout({
     onAsideClose: () => asideCloseExtrasRef.current(),
   });
-  /** Side Workbench multi-kind tabs (session-local; Phase 0+). */
-  const [sideWorkbench, setSideWorkbench] = useState<SideWorkbenchState>(
-    emptySideWorkbenchState,
-  );
-  const sideWorkbenchRef = useRef(sideWorkbench);
-  sideWorkbenchRef.current = sideWorkbench;
-  const [closeActiveSideRequest, setCloseActiveSideRequest] = useState<{
-    token: number;
-  } | null>(null);
-  const closeActiveSideTokenRef = useRef(0);
-  /**
-   * When side is expanded: optional bottom-docked compressed composer (icon toggle).
-   * Resets whenever expand ends.
-   */
-  const [sideDockComposer, setSideDockComposer] = useState(false);
-  /**
-   * Measured height of the docked composer strip.
-   * Drives --sw-dock-composer-h so the side pane ends above it.
-   */
-  const [sideDockComposerH, setSideDockComposerH] = useState(0);
-  /** Git work tree gate for Review picker entry. */
-  const [sideIsGitProject, setSideIsGitProject] = useState(false);
-
   /**
    * Secondary session window (`session-*` label / `#/session/<id>` deep link).
    * Live-capable (session-keyed Host pool): send / stop / warm-connect use the
@@ -1073,16 +1045,6 @@ export function AppWorkbench() {
   const [sessionChangesById, setSessionChangesById] = useState<
     Record<string, SessionFileChange[]>
   >({});
-  /**
-   * Turn changed-files chip → Review focus (#998).
-   * Lifted out of SideWorkbench so open races cannot drop the path.
-   * `pinnedPaths` always appear in Review even when sessionChanges is empty.
-   */
-  const [reviewFocus, setReviewFocus] = useState<{
-    path: string;
-    token: number;
-    pinnedPaths: string[];
-  } | null>(null);
   /**
    * Workspace git dirty summary for the active project (composer chip).
    * Null when not a repo, unavailable, clean, or no active project.
@@ -1280,11 +1242,6 @@ export function AppWorkbench() {
     sessions,
   });
   const [activeProject, setActiveProject] = useState<Project | null>(null);
-  useSideWorkbenchProjectIsolation(
-    activeProject?.id,
-    sideWorkbench,
-    setSideWorkbench,
-  );
   const bottomTerminal = useBottomTerminal(activeProject?.id);
   const [bottomTerminalMounted, setBottomTerminalMounted] = useState(false);
   useEffect(() => {
@@ -1302,26 +1259,6 @@ export function AppWorkbench() {
   /** Effective agent / resource root: bound project, else general workspace dir. */
   const effectiveProjectPath =
     activeProject?.path?.trim() || generalWorkspacePath || null;
-  /** Probe git so Side Workbench Review entry is gated. */
-  useEffect(() => {
-    const path = effectiveProjectPath?.trim();
-    if (!path) {
-      setSideIsGitProject(false);
-      return;
-    }
-    let cancelled = false;
-    void api
-      .gitStatus(path)
-      .then((r) => {
-        if (!cancelled) setSideIsGitProject(!!r?.available);
-      })
-      .catch(() => {
-        if (!cancelled) setSideIsGitProject(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [effectiveProjectPath]);
   const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({});
   /** Avoid writing collapse prefs before settings hydrate on launch. */
   const expandedProjectsHydratedRef = useRef(false);
@@ -1391,6 +1328,7 @@ export function AppWorkbench() {
   const sessionNavHostRef = useRef(createSessionNavHost());
   const sessionConnectHostRef = useRef(createSessionConnectHost());
   const gitWorktreeHostRef = useRef(createGitWorktreeChromeHost());
+  const sideWorkbenchHostRef = useRef(createSideWorkbenchChromeHost());
   const {
     openSession,
     newChat,
@@ -1856,17 +1794,35 @@ export function AppWorkbench() {
     useState<ResourceOpenTarget | null>(null);
   /** Bump to force ResourceViewer into Plan review mode (详情 / auto-open). */
   const [planFocusKey, setPlanFocusKey] = useState(0);
-  /**
-   * True when we expanded the right resource pane for this plan cycle
-   * (auto-open on review or 详情). Hard-dismiss collapses it so the next
-   * open is a clean files pane, not a stuck Plan workbench.
-   */
-  const planOpenedAsideRef = useRef(false);
-  asideCloseExtrasRef.current = () => {
-    planOpenedAsideRef.current = false;
-    setSideWorkbench((s) => (s.expanded ? { ...s, expanded: false } : s));
-    setSideDockComposer(false);
-  };
+  const {
+    sideWorkbench,
+    setSideWorkbench,
+    closeActiveSideRequest,
+    sideDockComposer,
+    sideDockComposerH,
+    setSideDockComposerH,
+    sideIsGitProject,
+    reviewFocus,
+    planOpenedAsideRef,
+    sideDockActive,
+    openSkills,
+    openPlan,
+    openPicker,
+    openReview,
+    focusReviewPath,
+    onAsideCloseExtras,
+    onExpandedChange,
+    toggleDockComposer,
+    consumeCloseActive,
+  } = useSideWorkbenchChrome({
+    hostRef: sideWorkbenchHostRef,
+    projectId: activeProject?.id,
+    projectPath: effectiveProjectPath,
+    asideCollapsed: layout.asideCollapsed,
+    phoneLayout,
+    resourceOpenTarget,
+  });
+  asideCloseExtrasRef.current = onAsideCloseExtras;
   /** Live drag-drop target for zone overlays (null = not dragging). */
   const [dragZone, setDragZone] = useState<"sidebar" | "main" | null>(null);
   const [toast, setToast] = useState<string | null>(null);
@@ -2254,35 +2210,6 @@ export function AppWorkbench() {
   });
   const dragRegion = tauriDragRegion(platform);
   const [windowMaximized, setWindowMaximized] = useState(false);
-
-  /**
-   * Route chat context opens into Side Workbench tabs.
-   * When the aside is collapsed, open it and keep `resourceOpenTarget` so
-   * SideWorkbench can consume path (e.g. Review focus for #998). Clearing
-   * here dropped path and left Review empty / unfocused.
-   */
-  useEffect(() => {
-    if (!resourceOpenTarget) return;
-    if (!layout.asideCollapsed) return;
-    const result = applySideContextOpen(sideWorkbench, resourceOpenTarget, {
-      isGitProject: sideIsGitProject,
-    });
-    // Turn-chip opens with a path still work without git — skip the scary toast (#998).
-    const skipNotGitToast =
-      resourceOpenTarget.type === "changes" &&
-      !!(resourceOpenTarget.path || "").trim();
-    if (result.noticeKey && !skipNotGitToast) {
-      showToast(tr(result.noticeKey), 2400);
-    }
-    if (result.needAsideOpen) {
-      setSideWorkbench(result.state);
-      openAsidePane();
-      // Keep target — SideWorkbench openRequest effect consumes path + clears.
-      return;
-    }
-    setResourceOpenTarget(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- consume once per target
-  }, [resourceOpenTarget, layout.asideCollapsed]);
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -6685,14 +6612,13 @@ export function AppWorkbench() {
     setSlashQuery(null);
     setLiveSlash({ present: false, query: "", start: 0, end: 0 });
     liveSlashRef.current = { present: false, query: "", start: 0, end: 0 };
-    setSideWorkbench((s) => openSideTab(s, "skills"));
-    openAsidePane();
+    openSkills();
   }, [
     setShowComposerPlus,
     setSlashQuery,
     setLiveSlash,
     liveSlashRef,
-    openAsidePane,
+    openSkills,
   ]);
 
   const atMenuOpen = liveAt.present && !composerMenuOpen;
@@ -7598,16 +7524,6 @@ export function AppWorkbench() {
       },
     });
   }, [archivePlanDecision, tr, writePlanForViewing]);
-
-  /** Open Side Workbench Plan tab (review / waiting empty / open-in-resources). */
-  const openPlanInResource = useCallback(() => {
-    planOpenedAsideRef.current = true;
-    setSideWorkbench((s) =>
-      openSideTab(s, "plan", { name: "side.tab.plan" }),
-    );
-    openAsidePane();
-    setPlanFocusKey((k) => k + 1);
-  }, [openAsidePane]);
 
   /**
    * Exit the bare “计划模式” chip (mode === "plan", no plan content yet).
@@ -9804,22 +9720,10 @@ export function AppWorkbench() {
       : layout.sidebarWidth || SIDEBAR_DEFAULT_WIDTH;
   const asidePaint =
     layout.asideCollapsed || asideOverlay ? 0 : layout.asideWidth;
-  const sideDockActive = isSideDockComposerActive({
-    expanded: sideWorkbench.expanded,
-    dockComposer: sideDockComposer,
-    phoneLayout,
-  });
   const dockSidebarOccupied =
     phoneLayout || layout.sidebarCollapsed || sidebarOverlay
       ? 0
       : layout.sidebarWidth;
-
-  // Expand ends → close dock toggle.
-  useEffect(() => {
-    if (sideWorkbench.expanded) return;
-    setSideDockComposer(false);
-    setSideDockComposerH(0);
-  }, [sideWorkbench.expanded]);
 
   // Dock on: measure composer height → shrink side pane bottom.
   // Webview host follows aside height (no native hole-punch).
@@ -9858,10 +9762,6 @@ export function AppWorkbench() {
     showComposerPlus,
     welcomeSession,
   ]);
-
-  const onToggleSideDockComposer = useCallback(() => {
-    setSideDockComposer((on) => !on);
-  }, []);
 
   const stop = async () => {
     const now = Date.now();
@@ -10211,6 +10111,15 @@ export function AppWorkbench() {
     h.navigateSettings = navigateSettings;
     h.setPrHubHighlightPr = setPrHubHighlightPr;
     h.setSettingsFocusAnchor = setSettingsFocusAnchor;
+  }
+  {
+    const h = sideWorkbenchHostRef.current;
+    h.tr = tr;
+    h.showToast = showToast;
+    h.openAsidePane = openAsidePane;
+    h.setResourceOpenTarget = setResourceOpenTarget;
+    h.setPlanFocusKey = setPlanFocusKey;
+    h.asideCollapsed = () => layoutRef.current.asideCollapsed;
   }
 
   /**
@@ -10798,14 +10707,7 @@ export function AppWorkbench() {
       closeAsidePane();
     },
     openSidePicker: (kind: SidePickerKind) => {
-      setSideWorkbench((s) => {
-        const next = openSideTabFromPicker(s, kind, {
-          isGitProject: sideIsGitProject,
-        });
-        if (!("created" in next)) return s;
-        return next;
-      });
-      openAsidePane();
+      openPicker(kind);
     },
     toggleBottomTerminal: () => {
       bottomTerminal.toggle();
@@ -11028,52 +10930,6 @@ export function AppWorkbench() {
     onArm: () => showToast(tr("app.quitPressAgain"), QUIT_DOUBLE_PRESS_MS),
     onQuit: () => requestAppQuit("shortcut"),
   });
-
-  /**
-   * Host menu ⌘W / Ctrl+W (replaces native Close Window). Browser-like:
-   * active side tab first when the strip is non-empty and the aside is open;
-   * empty strip (or collapsed leftover tabs) falls through to window close.
-   * Decision is pure — see {@link applySideStripClose}.
-   */
-  const closeSideTabOrWindow = useCallback(() => {
-    const s = sideWorkbenchRef.current;
-    const result = applySideStripClose(s, {
-      asideCollapsed: layoutRef.current.asideCollapsed,
-    });
-    if (result.closeWindow) {
-      void (async () => {
-        try {
-          const { getCurrentWindow } = await import("@tauri-apps/api/window");
-          await getCurrentWindow().close();
-        } catch (e) {
-          console.warn("close window after empty side tabs failed", e);
-        }
-      })();
-      return;
-    }
-    closeActiveSideTokenRef.current += 1;
-    setCloseActiveSideRequest({ token: closeActiveSideTokenRef.current });
-  }, []);
-
-  useEffect(() => {
-    if (!api.isTauri()) return;
-    let cancelled = false;
-    let unlisten: (() => void) | undefined;
-    void (async () => {
-      try {
-        unlisten = await api.listen(APP_CLOSE_TAB_OR_WINDOW_EVENT, () => {
-          closeSideTabOrWindow();
-        });
-        if (cancelled) unlisten();
-      } catch (e) {
-        console.warn("close-tab-or-window listener failed", e);
-      }
-    })();
-    return () => {
-      cancelled = true;
-      unlisten?.();
-    };
-  }, [closeSideTabOrWindow]);
 
   const error = session.lastError;
   const errorBanner = useMemo(
@@ -12092,28 +11948,20 @@ export function AppWorkbench() {
   const onThreadOpenSessionChanges = useCallback(() => {
     seedSessionChangesForReview(null);
     // Open Review synchronously — do not rely only on openRequest races (#998).
-    setSideWorkbench((s) => openSideTab(s, "review"));
-    openAsidePane();
+    openReview();
     setResourceOpenTarget({ type: "changes" });
-  }, [openAsidePane, seedSessionChangesForReview]);
+  }, [openReview, seedSessionChangesForReview]);
 
   const onThreadOpenModifiedPath = useCallback(
     (path: string) => {
       const p = (path || "").trim();
       seedSessionChangesForReview(p);
       // Synchronously ensure Review tab exists before aside paint (#998).
-      setSideWorkbench((s) => openSideTab(s, "review"));
-      openAsidePane();
-      if (p) {
-        setReviewFocus((prev) => ({
-          path: p,
-          token: (prev?.token ?? 0) + 1,
-          pinnedPaths: pinReviewFocusPath(prev?.pinnedPaths ?? [], p),
-        }));
-      }
+      openReview();
+      if (p) focusReviewPath(p);
       setResourceOpenTarget({ type: "changes", path: p || undefined });
     },
-    [openAsidePane, seedSessionChangesForReview],
+    [focusReviewPath, openReview, seedSessionChangesForReview],
   );
 
   const onThreadOpenResource = useCallback(
@@ -13492,7 +13340,7 @@ export function AppWorkbench() {
             onThreadOpenSessionChanges={onThreadOpenSessionChanges}
             onThreadRemoveEditAttachment={onThreadRemoveEditAttachment}
             openExternalLinkFromChat={openExternalLinkFromChat}
-            openPlanInResource={openPlanInResource}
+            openPlanInResource={openPlan}
             openReliability={openReliability}
             openRequestPlanChanges={openRequestPlanChanges}
             openSession={openSession}
@@ -13777,7 +13625,7 @@ export function AppWorkbench() {
           sideWorkbench={sideWorkbench}
           setSideWorkbench={setSideWorkbench}
           sideDockComposer={sideDockComposer}
-          onToggleSideDockComposer={onToggleSideDockComposer}
+          onToggleSideDockComposer={toggleDockComposer}
           sessionChanges={
             sessionChangesById[reviewSessionId] ??
             sessionChangesById[session.sessionId || ""] ??
@@ -13800,14 +13648,9 @@ export function AppWorkbench() {
           resourceOpenTarget={resourceOpenTarget}
           onOpenRequestConsumed={() => setResourceOpenTarget(null)}
           closeActiveSideRequest={closeActiveSideRequest}
-          onCloseActiveRequestConsumed={() =>
-            setCloseActiveSideRequest(null)
-          }
+          onCloseActiveRequestConsumed={consumeCloseActive}
           onToggleSide={layout.asideCollapsed ? openAsidePane : closeAsidePane}
-          onExpandedChange={(expanded) => {
-            if (phoneLayout) return;
-            if (!expanded) setSideDockComposer(false);
-          }}
+          onExpandedChange={onExpandedChange}
           skillInfos={skillInfos}
           skillsLoading={skillsLoading}
           skillsLoadError={skillsLoadError}

--- a/src/hooks/useSideWorkbenchChrome.test.ts
+++ b/src/hooks/useSideWorkbenchChrome.test.ts
@@ -1,0 +1,163 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Side Workbench tab/dock/review verbs live here. Host supplies aside open
+ * and toasts. Git probe is a no-op off Tauri unless gitStatus is mocked.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createT } from "@/i18n";
+import * as api from "@/lib/api";
+import {
+  createSideWorkbenchChromeHost,
+  useSideWorkbenchChrome,
+} from "./useSideWorkbenchChrome";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    isTauri: vi.fn(() => false),
+    gitStatus: vi.fn(),
+  };
+});
+
+type SideResourceTarget = Parameters<
+  typeof useSideWorkbenchChrome
+>[0]["resourceOpenTarget"];
+
+function setup(opts?: {
+  asideCollapsed?: boolean;
+  phoneLayout?: boolean;
+  resourceOpenTarget?: SideResourceTarget;
+}) {
+  const host = createSideWorkbenchChromeHost();
+  host.tr = createT("en");
+  host.showToast = vi.fn();
+  host.openAsidePane = vi.fn();
+  host.setResourceOpenTarget = vi.fn();
+  host.setPlanFocusKey = vi.fn();
+  host.asideCollapsed = () => opts?.asideCollapsed ?? true;
+  const hostRef = { current: host };
+  const hook = renderHook(
+    (props: { resourceOpenTarget: SideResourceTarget }) =>
+      useSideWorkbenchChrome({
+        hostRef,
+        projectId: "p1",
+        projectPath: "/repo",
+        asideCollapsed: opts?.asideCollapsed ?? true,
+        phoneLayout: opts?.phoneLayout ?? false,
+        resourceOpenTarget: props.resourceOpenTarget ?? null,
+      }),
+    { initialProps: { resourceOpenTarget: opts?.resourceOpenTarget ?? null } },
+  );
+  return { ...hook, host };
+}
+
+describe("useSideWorkbenchChrome", () => {
+  beforeEach(() => {
+    vi.mocked(api.isTauri).mockReturnValue(false);
+    vi.mocked(api.gitStatus).mockReset();
+    vi.mocked(api.gitStatus).mockRejectedValue(new Error("no git"));
+  });
+
+  it("openSkills creates a skills tab and opens the aside", () => {
+    const { result, host } = setup();
+    act(() => {
+      result.current.openSkills();
+    });
+    expect(result.current.sideWorkbench.tabs.some((t) => t.kind === "skills")).toBe(
+      true,
+    );
+    expect(host.openAsidePane).toHaveBeenCalled();
+  });
+
+  it("openPlan opens the plan tab and bumps plan focus", () => {
+    const { result, host } = setup();
+    act(() => {
+      result.current.openPlan();
+    });
+    expect(result.current.sideWorkbench.tabs.some((t) => t.kind === "plan")).toBe(
+      true,
+    );
+    expect(host.openAsidePane).toHaveBeenCalled();
+    expect(host.setPlanFocusKey).toHaveBeenCalled();
+  });
+
+  it("openPicker(file) creates a files tab", () => {
+    const { result, host } = setup();
+    act(() => {
+      result.current.openPicker("file");
+    });
+    expect(result.current.sideWorkbench.tabs.some((t) => t.kind === "file")).toBe(
+      true,
+    );
+    expect(result.current.sideWorkbench.treeVisible).toBe(true);
+    expect(host.openAsidePane).toHaveBeenCalled();
+  });
+
+  it("openPicker(review) is a no-op until git is confirmed", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.openPicker("review");
+    });
+    expect(result.current.sideWorkbench.tabs).toEqual([]);
+  });
+
+  it("openPicker(review) opens after git probe succeeds", async () => {
+    vi.mocked(api.gitStatus).mockResolvedValue({
+      available: true,
+      files: [],
+    });
+    const { result } = setup();
+    await waitFor(() => {
+      expect(result.current.sideIsGitProject).toBe(true);
+    });
+    act(() => {
+      result.current.openPicker("review");
+    });
+    expect(
+      result.current.sideWorkbench.tabs.some((t) => t.kind === "review"),
+    ).toBe(true);
+  });
+
+  it("routes a collapsed-aside file target into a files tab", () => {
+    const { result, host, rerender } = setup();
+    act(() => {
+      rerender({
+        resourceOpenTarget: { type: "file", path: "/repo/a.ts", title: "a.ts" },
+      });
+    });
+    expect(result.current.sideWorkbench.tabs.some((t) => t.kind === "file")).toBe(
+      true,
+    );
+    expect(host.openAsidePane).toHaveBeenCalled();
+  });
+
+  it("focusReviewPath pins the path and bumps the token", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.focusReviewPath("src/a.ts");
+    });
+    expect(result.current.reviewFocus?.path).toMatch(/src\/a\.ts$/);
+    const token = result.current.reviewFocus?.token ?? 0;
+    act(() => {
+      result.current.focusReviewPath("src/b.ts");
+    });
+    expect(result.current.reviewFocus?.token).toBe(token + 1);
+    expect(result.current.reviewFocus?.pinnedPaths[0]).toMatch(/src\/b\.ts$/);
+  });
+
+  it("onAsideCloseExtras collapses expand and dock", () => {
+    const { result } = setup();
+    act(() => {
+      result.current.setSideWorkbench((s) => ({ ...s, expanded: true }));
+      result.current.setSideDockComposer(true);
+    });
+    act(() => {
+      result.current.onAsideCloseExtras();
+    });
+    expect(result.current.sideWorkbench.expanded).toBe(false);
+    expect(result.current.sideDockComposer).toBe(false);
+  });
+});

--- a/src/hooks/useSideWorkbenchChrome.ts
+++ b/src/hooks/useSideWorkbenchChrome.ts
@@ -1,0 +1,279 @@
+/**
+ * Side Workbench chrome: tabs, dock composer, Review focus, close-tab.
+ * Host fills {@link SideWorkbenchChromeHost} in place so aside/open/toast
+ * verbs stay late-bound. Session file-change lists stay on the host.
+ */
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import { createT } from "@/i18n";
+import type { ResourceOpenTarget } from "@/components/ResourceViewer";
+import * as api from "@/lib/api";
+import { APP_CLOSE_TAB_OR_WINDOW_EVENT } from "@/lib/confirmQuit";
+import { pinReviewFocusPath } from "@/lib/reviewFocusPaths";
+import { applySideContextOpen } from "@/lib/sideContextOpen";
+import { isSideDockComposerActive } from "@/lib/sideFloatComposer";
+import {
+  applySideStripClose,
+  emptySideWorkbenchState,
+  openSideTab,
+  openSideTabFromPicker,
+  type SidePickerKind,
+  type SideWorkbenchState,
+} from "@/lib/sideWorkbench";
+import { useSideWorkbenchProjectIsolation } from "@/hooks/useSideWorkbenchProjectIsolation";
+
+type TFn = ReturnType<typeof createT>;
+
+export type SideReviewFocus = {
+  path: string;
+  token: number;
+  pinnedPaths: string[];
+};
+
+export type SideWorkbenchChromeHost = {
+  tr: TFn;
+  showToast: (msg: string, ms?: number) => void;
+  openAsidePane: () => void;
+  setResourceOpenTarget: Dispatch<SetStateAction<ResourceOpenTarget | null>>;
+  setPlanFocusKey: Dispatch<SetStateAction<number>>;
+  asideCollapsed: () => boolean;
+};
+
+function emptyHost(): SideWorkbenchChromeHost {
+  const noop = () => {};
+  return {
+    tr: ((k: string) => k) as TFn,
+    showToast: noop,
+    openAsidePane: noop,
+    setResourceOpenTarget: noop,
+    setPlanFocusKey: noop,
+    asideCollapsed: () => true,
+  };
+}
+
+export function createSideWorkbenchChromeHost(): SideWorkbenchChromeHost {
+  return emptyHost();
+}
+
+export function useSideWorkbenchChrome(opts: {
+  hostRef: MutableRefObject<SideWorkbenchChromeHost>;
+  projectId: string | null | undefined;
+  projectPath: string | null;
+  asideCollapsed: boolean;
+  phoneLayout: boolean;
+  resourceOpenTarget: ResourceOpenTarget | null;
+}) {
+  const hostRef = opts.hostRef;
+  const [sideWorkbench, setSideWorkbench] = useState<SideWorkbenchState>(
+    emptySideWorkbenchState,
+  );
+  const sideWorkbenchRef = useRef(sideWorkbench);
+  sideWorkbenchRef.current = sideWorkbench;
+  const [closeActiveSideRequest, setCloseActiveSideRequest] = useState<{
+    token: number;
+  } | null>(null);
+  const closeActiveSideTokenRef = useRef(0);
+  const [sideDockComposer, setSideDockComposer] = useState(false);
+  const [sideDockComposerH, setSideDockComposerH] = useState(0);
+  const [sideIsGitProject, setSideIsGitProject] = useState(false);
+  const [reviewFocus, setReviewFocus] = useState<SideReviewFocus | null>(null);
+  const planOpenedAsideRef = useRef(false);
+
+  useSideWorkbenchProjectIsolation(
+    opts.projectId,
+    sideWorkbench,
+    setSideWorkbench,
+  );
+
+  useEffect(() => {
+    const path = opts.projectPath?.trim();
+    if (!path) {
+      setSideIsGitProject(false);
+      return;
+    }
+    let cancelled = false;
+    void api
+      .gitStatus(path)
+      .then((r) => {
+        if (!cancelled) setSideIsGitProject(!!r?.available);
+      })
+      .catch(() => {
+        if (!cancelled) setSideIsGitProject(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [opts.projectPath]);
+
+  useEffect(() => {
+    const target = opts.resourceOpenTarget;
+    if (!target) return;
+    if (!opts.asideCollapsed) return;
+    const h = hostRef.current;
+    const result = applySideContextOpen(sideWorkbench, target, {
+      isGitProject: sideIsGitProject,
+    });
+    const skipNotGitToast =
+      target.type === "changes" && !!(target.path || "").trim();
+    if (result.noticeKey && !skipNotGitToast) {
+      h.showToast(h.tr(result.noticeKey), 2400);
+    }
+    if (result.needAsideOpen) {
+      setSideWorkbench(result.state);
+      h.openAsidePane();
+      return;
+    }
+    h.setResourceOpenTarget(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- consume once per target
+  }, [opts.resourceOpenTarget, opts.asideCollapsed]);
+
+  useEffect(() => {
+    if (sideWorkbench.expanded) return;
+    setSideDockComposer(false);
+    setSideDockComposerH(0);
+  }, [sideWorkbench.expanded]);
+
+  const openSkills = useCallback(() => {
+    setSideWorkbench((s) => openSideTab(s, "skills"));
+    hostRef.current.openAsidePane();
+  }, [hostRef]);
+
+  const openPlan = useCallback(() => {
+    planOpenedAsideRef.current = true;
+    setSideWorkbench((s) =>
+      openSideTab(s, "plan", { name: "side.tab.plan" }),
+    );
+    hostRef.current.openAsidePane();
+    hostRef.current.setPlanFocusKey((k) => k + 1);
+  }, [hostRef]);
+
+  const openPicker = useCallback(
+    (kind: SidePickerKind) => {
+      setSideWorkbench((s) => {
+        const next = openSideTabFromPicker(s, kind, {
+          isGitProject: sideIsGitProject,
+        });
+        if (!("created" in next)) return s;
+        return next;
+      });
+      hostRef.current.openAsidePane();
+    },
+    [hostRef, sideIsGitProject],
+  );
+
+  const openReview = useCallback(() => {
+    setSideWorkbench((s) => openSideTab(s, "review"));
+    hostRef.current.openAsidePane();
+  }, [hostRef]);
+
+  const focusReviewPath = useCallback((path: string) => {
+    const p = path.trim();
+    if (!p) return;
+    setReviewFocus((prev) => ({
+      path: p,
+      token: (prev?.token ?? 0) + 1,
+      pinnedPaths: pinReviewFocusPath(prev?.pinnedPaths ?? [], p),
+    }));
+  }, []);
+
+  const onAsideCloseExtras = useCallback(() => {
+    planOpenedAsideRef.current = false;
+    setSideWorkbench((s) => (s.expanded ? { ...s, expanded: false } : s));
+    setSideDockComposer(false);
+  }, []);
+
+  const onExpandedChange = useCallback(
+    (expanded: boolean) => {
+      if (opts.phoneLayout) return;
+      if (!expanded) setSideDockComposer(false);
+    },
+    [opts.phoneLayout],
+  );
+
+  const toggleDockComposer = useCallback(() => {
+    setSideDockComposer((on) => !on);
+  }, []);
+
+  const consumeCloseActive = useCallback(() => {
+    setCloseActiveSideRequest(null);
+  }, []);
+
+  const closeSideTabOrWindow = useCallback(() => {
+    const s = sideWorkbenchRef.current;
+    const result = applySideStripClose(s, {
+      asideCollapsed: hostRef.current.asideCollapsed(),
+    });
+    if (result.closeWindow) {
+      void (async () => {
+        try {
+          const { getCurrentWindow } = await import("@tauri-apps/api/window");
+          await getCurrentWindow().close();
+        } catch (e) {
+          console.warn("close window after empty side tabs failed", e);
+        }
+      })();
+      return;
+    }
+    closeActiveSideTokenRef.current += 1;
+    setCloseActiveSideRequest({ token: closeActiveSideTokenRef.current });
+  }, [hostRef]);
+
+  useEffect(() => {
+    if (!api.isTauri()) return;
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      try {
+        unlisten = await api.listen(APP_CLOSE_TAB_OR_WINDOW_EVENT, () => {
+          closeSideTabOrWindow();
+        });
+        if (cancelled) unlisten();
+      } catch (e) {
+        console.warn("close-tab-or-window listener failed", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [closeSideTabOrWindow]);
+
+  const sideDockActive = isSideDockComposerActive({
+    expanded: sideWorkbench.expanded,
+    dockComposer: sideDockComposer,
+    phoneLayout: opts.phoneLayout,
+  });
+
+  return {
+    sideWorkbench,
+    setSideWorkbench,
+    sideWorkbenchRef,
+    closeActiveSideRequest,
+    sideDockComposer,
+    setSideDockComposer,
+    sideDockComposerH,
+    setSideDockComposerH,
+    sideIsGitProject,
+    reviewFocus,
+    setReviewFocus,
+    planOpenedAsideRef,
+    sideDockActive,
+    openSkills,
+    openPlan,
+    openPicker,
+    openReview,
+    focusReviewPath,
+    onAsideCloseExtras,
+    onExpandedChange,
+    toggleDockComposer,
+    consumeCloseActive,
+    closeSideTabOrWindow,
+  };
+}


### PR DESCRIPTION
## Summary
WP-W29 of AppWorkbench decomposition. Side Workbench tabs / dock composer / Review focus / close-tab / git probe / chat-to-side routing move into `useSideWorkbenchChrome`. Host fills a late-bound aside/open/toast bag. `sessionChangesById` and git dirty stay on the host.

Closes #1042

## Metrics (vs current main)
- Orchestration lines 14416 → 14258
- useState 122 → 116
- useEffect 75 → 71
- APP_* ceilings 14650/130/80 → 14400/120/74
- New hook 279 lines (under 1000)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / chore

## Checklist
- [x] I ran `pnpm typecheck` and related vitest (50 tests: hook + sideWorkbench/sideContextOpen/reviewFocusPaths/sideFloatComposer). Full `pnpm test` on Windows has known CRLF source-guard / timeout flakes that CI Linux does not.
- [ ] I ran `cargo test` in `src-tauri` (no Rust changes)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/plans/HANDOFF-appworkbench-decomposition.md` + `docs/plans/2026-09-06-appworkbench-w29-side-workbench.md` updated
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
- [x] `python scripts/check-code-quality-gates.py --mode final` PASS
- [x] `pnpm lint` and `pnpm build:ui` PASS

## Notes
- `openSideSkillsPanel` stays a thin host wrapper (closes composer +/slash, then `openSkills`).
- Dock height ResizeObserver stays on the host (reads composer wrap).
- Next suggested cut: session badges (mute / unread / plan-pending), as its own PR after this lands.