### PR TITLE
fix(chat): keep ordinary JSON fences in the transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ See `docs/llm-wiki/release.md`.
 
 ## [Unreleased]
 
+### Fixed
+- JSON examples in chat stay visible instead of being swallowed as schedule fences.
+
+**中文 · 修复**
+- 对话里的普通 JSON 示例会显示出来，不再被当成定时任务围栏剥掉。
+
 ## [0.2.33] - 2026-09-06
 
 > **Highlight:** Windows installers are back, with composer shortcuts and worktree GC fixes.

--- a/src/lib/automationSetup.test.ts
+++ b/src/lib/automationSetup.test.ts
@@ -63,6 +63,45 @@ describe("automationSetup", () => {
     expect(cleanText).toBe("确认一下");
   });
 
+  it("keeps ordinary json samples in the transcript", () => {
+    const payload = `{
+  "config": [
+    {
+      "kind": "Databus",
+      "metadata": { "name": "surreal_app_prefix_301_write_test" },
+      "spec": { "batch": { "max_events": 50, "timeout_secs": 1 } }
+    }
+  ]
+}`;
+    const text = `给了，就是这个：\n\n\`\`\`json\n${payload}\n\`\`\``;
+    const { input, cleanText, rawJson } = extractAutomationPayload(text);
+    expect(input).toBeNull();
+    expect(rawJson).toBeNull();
+    expect(cleanText).toContain("给了，就是这个：");
+    expect(cleanText).toContain("```json");
+    expect(cleanText).toContain('"kind": "Databus"');
+    expect(cleanText).toContain('"max_events": 50');
+  });
+
+  it("strips broken grok-automation fences but keeps nearby json samples", () => {
+    const text = [
+      "示例：",
+      "```json",
+      '{"hello":"world"}',
+      "```",
+      "",
+      "```grok-automation",
+      "{not-json",
+      "```",
+    ].join("\n");
+    const { input, cleanText } = extractAutomationPayload(text);
+    expect(input).toBeNull();
+    expect(cleanText).toContain("```json");
+    expect(cleanText).toContain('"hello":"world"');
+    expect(cleanText).not.toContain("grok-automation");
+    expect(cleanText).not.toContain("{not-json");
+  });
+
   it("parses real failed-session style fence", () => {
     const text = `好的，已设好。\n\n\`\`\`grok-automation\n{"title":"知识库美女提示词检索","prompt":"在用户的知识库检索","frequency":"once","time":"20:56","weekdays":[],"enabled":true}\n\`\`\``;
     const { input, cleanText } = extractAutomationPayload(text);

--- a/src/lib/automationSetup.ts
+++ b/src/lib/automationSetup.ts
@@ -46,9 +46,10 @@ export function wrapAutomationSetupAgentText(userVisibleText: string): string {
 
 /**
  * Match ```grok-automation / ```json fences (optional lang spacing; closing fence optional final newline).
+ * Group 1 = language, group 2 = body.
  */
 const FENCE_RE =
-  /```(?:grok-automation|json)[^\n\r]*\r?\n([\s\S]*?)```/gi;
+  /```(grok-automation|json)[^\n\r]*\r?\n([\s\S]*?)```/gi;
 
 export type AutomationFenceAction = "create" | "update" | "upsert";
 
@@ -230,34 +231,38 @@ export function extractAutomationPayload(text: string): ExtractedAutomation {
   let rawJson: string | null = null;
   let existingId: string | null = null;
   let action: AutomationFenceAction = "upsert";
-  FENCE_RE.lastIndex = 0;
-  const matches = [...text.matchAll(FENCE_RE)];
 
-  for (const m of matches) {
-    const body = (m[1] || "").trim();
-    // Model sometimes wraps JSON in an extra code fence or adds trailing prose
-    const jsonBody = body
-      .replace(/^```(?:json)?\s*/i, "")
-      .replace(/\s*```$/i, "")
-      .trim();
-    const parsed = parseAutomationConfigJson(jsonBody);
-    if (parsed) {
-      input = parsed;
-      rawJson = jsonBody;
-      try {
-        const o = JSON.parse(jsonBody) as Record<string, unknown>;
-        existingId =
-          typeof o.id === "string" && o.id.trim() ? o.id.trim() : null;
-        action = parseFenceAction(o.action);
-      } catch {
-        existingId = null;
-        action = "upsert";
+  FENCE_RE.lastIndex = 0;
+  let cleanText = text
+    .replace(FENCE_RE, (full, lang: string, body: string) => {
+      const jsonBody = (body || "")
+        .replace(/^```(?:json)?\s*/i, "")
+        .replace(/\s*```$/i, "")
+        .trim();
+      const parsed = parseAutomationConfigJson(jsonBody);
+      if (parsed) {
+        input = parsed;
+        rawJson = jsonBody;
+        try {
+          const o = JSON.parse(jsonBody) as Record<string, unknown>;
+          existingId =
+            typeof o.id === "string" && o.id.trim() ? o.id.trim() : null;
+          action = parseFenceAction(o.action);
+        } catch {
+          existingId = null;
+          action = "upsert";
+        }
+        return "";
       }
-    }
-  }
-
-  FENCE_RE.lastIndex = 0;
-  let cleanText = text.replace(FENCE_RE, "").replace(/\n{3,}/g, "\n\n").trimEnd();
+      // Internal protocol fence: never show, even if JSON is incomplete.
+      if (String(lang).toLowerCase() === AUTOMATION_FENCE_LANG) {
+        return "";
+      }
+      // Ordinary ```json samples (API payloads, configs) stay in the transcript.
+      return full;
+    })
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
   if (!cleanText.trim() && input) {
     cleanText = "";
   }


### PR DESCRIPTION
## Why

Assistant replies that include a ` ```json ` sample (API payloads, configs, etc.) never showed the JSON in the bubble. The model wrote it; the journal stored it; the UI stripped it.

`extractAutomationPayload` uses ` ```json ` as a fallback for schedule-task fences, then **always** deleted every matching fence from `cleanText` — including JSON that is not a scheduled task (`title` + `prompt` + `frequency`).

## Fix

- Strip ` ```grok-automation ` always (internal protocol).
- Strip ` ```json ` only when it parses as a real automation config.
- Leave ordinary JSON samples in the transcript.

## Test

`pnpm exec vitest run src/lib/automationSetup.test.ts`

Adds coverage that a Databus-style JSON example stays visible, while schedule JSON / broken grok-automation fences still disappear.

## Workaround until this ships

Copy the assistant message, or ask the model not to wrap the sample in a json fence.