### PR TITLE
feat(sidebar): pin SuperGrok quota on the expanded rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ See `docs/llm-wiki/release.md`.
 **中文 · 新增**
 - Ctrl+Tab 切回上一个用过的对话。按住 Ctrl 再点 Tab 继续循环；Ctrl+Shift+Tab 反向。
 
+### Changed
+- Expanded sidebar pins remaining SuperGrok quota without opening the account menu (#1048). Settings is a footer gear; the account menu keeps theme and sign-in.
+
+**中文 · 变更**
+- 展开左边栏即可看到 SuperGrok 剩余额度，不必再点开账户菜单（#1048）。设置改为脚注齿轮；账户菜单只留主题和登录。
+
 ## [0.2.33] - 2026-09-06
 
 > **Highlight:** Windows installers are back, with composer shortcuts and worktree GC fixes.

--- a/docs/llm-wiki/account.md
+++ b/docs/llm-wiki/account.md
@@ -6,7 +6,9 @@ Product rules for **official login, membership, quota, and usage** in Grok App.
 
 1. Sign in with the **same** Grok Build CLI auth (`grok login`), not a parallel OAuth stack.
 2. Show account + membership at two depths:
-   - **User menu sheet** (sidebar footer click): compact identity, plan, quota bar, login/logout, jump to settings.
+   - **Expanded sidebar pin**: plan + reset on the first row; quota bar + remaining % (or custom balance) on the second. No avatar / display name. Click opens Account settings. Signed-out / local has no pin.
+   - **Sidebar footer**: identity opens the user menu; settings gear on the right.
+   - **User menu sheet** (identity click): what's new, tour, theme, login/logout. Quota and Settings are not in this menu — pin + footer gear cover them. Switch accounts in Settings → Account.
    - **Settings → Account**: full profile, subscription, quota, token activity heatmap, recent session call logs, CLI path, Doctor.
 3. Never log tokens, API keys, or `auth.json` secrets (redact).
 

--- a/docs/llm-wiki/providers.md
+++ b/docs/llm-wiki/providers.md
@@ -191,7 +191,7 @@ Host must rebind both sides on every switch and before each ACP spawn (`prepare_
 | When | Channel id/host is DeepSeek (`deepseek` / `api.deepseek.com`) — **not** DeepSeek models on OpenCode Go / 火山方舟 |
 | Endpoint | `GET https://api.deepseek.com/user/balance` (origin root; strip `/v1` from stored base) |
 | Auth | Bearer `api_key` from agent-home (or form draft) |
-| UI | Settings → Custom providers **Check balance** (full lines); sidebar footer + UserMenu one-liner `110.00 CNY` when active |
+| UI | Settings → Custom providers **Check balance** (full lines); expanded-sidebar pin chip `110.00 CNY` when active |
 | Cache | Session memory, 5 min TTL; refresh on UserMenu open / explicit button; no disk, no polling |
 | Honesty | Never invent `0.00` on failure; amounts stay **strings** |
 

--- a/src/app/WorkbenchSidebar.footer.test.tsx
+++ b/src/app/WorkbenchSidebar.footer.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { AccountStatus } from "@/lib/api";
+import { createT } from "@/i18n";
+import { WorkbenchSidebar, type WorkbenchSidebarProps } from "./WorkbenchSidebar";
+
+vi.mock("@/lib/floatingMenu", () => ({
+  FLOATING_MENU_Z_INDEX: 13_000,
+  useFloatingMenu: () => ({
+    pos: { top: 100, left: 10 },
+    style: { position: "fixed" },
+    settled: true,
+  }),
+}));
+
+vi.mock("@/components/SidebarUpdateButton", () => ({
+  SidebarUpdateButton: () => null,
+}));
+
+afterEach(cleanup);
+
+const tr = createT("en");
+
+function signedInAccount(): AccountStatus {
+  return {
+    profile: {
+      signedIn: true,
+      authMode: "oauth",
+      email: "ada@x.ai",
+      displayName: "Ada",
+      userId: "u1",
+      teamId: null,
+      principalType: null,
+      expiresAt: null,
+      expired: false,
+      hasRefresh: true,
+      oidcIssuer: null,
+    },
+    hasOfficialKey: false,
+    hasRelayKey: false,
+    relayBaseUrl: null,
+    cliAuthPresent: true,
+    cliFound: true,
+    cliPath: "/usr/bin/grok",
+    channel: "official_oauth",
+    billing: {
+      available: true,
+      source: "remote",
+      message: null,
+      subscriptionTier: "SuperGrok",
+      creditUsagePercent: 11,
+      remainingPercent: 89,
+      monthlyLimit: null,
+      includedUsed: null,
+      totalUsed: null,
+      prepaidBalance: null,
+      onDemandEnabled: null,
+      onDemandCap: null,
+      onDemandUsed: null,
+      billingPeriodStart: null,
+      billingPeriodEnd: null,
+      resetsAt: "2026-09-07T04:32:00.000Z",
+      isUnifiedBillingUser: true,
+      products: [],
+      manageUrl: "https://grok.com/?_s=usage",
+      subscribeUrl: "https://grok.com/supergrok",
+      fetchedAt: "2026-09-06T00:00:00.000Z",
+    },
+    heatmap: [],
+    callLogs: [],
+    usageManageUrl: "https://grok.com/?_s=usage",
+    subscribeUrl: "https://grok.com/supergrok",
+  };
+}
+
+function props(
+  override: Partial<WorkbenchSidebarProps> = {},
+): WorkbenchSidebarProps {
+  return {
+    tr,
+    locale: "en",
+    children: <div>sessions</div>,
+    layout: { sidebarCollapsed: false, sidebarWidth: 280 },
+    phoneLayout: false,
+    sidebarOverlay: false,
+    resizingSidebar: false,
+    dragZone: null,
+    sidebarOpenW: 280,
+    sidebarPaint: 280,
+    beginSidebarResize: () => undefined,
+    dragRegion: "false",
+    titlebarMax: {
+      onDoubleClick: () => undefined,
+      onMouseDown: () => undefined,
+    },
+    replaceProviderBrandLogo: false,
+    customRouteActive: false,
+    activeCustomProvider: null,
+    mainPane: "chat",
+    onOpenSearch: () => undefined,
+    onNewChat: () => undefined,
+    onNavigateAutomations: () => undefined,
+    onNavigateKanban: () => undefined,
+    onNavigateRemoteIm: () => undefined,
+    showUserMenu: false,
+    setShowUserMenu: () => undefined,
+    theme: "dark",
+    themePreference: "dark",
+    account: signedInAccount(),
+    accountBusy: false,
+    providerBalanceCache: null,
+    providerBalanceBusy: false,
+    providerBalanceError: null,
+    loadProviderBalance: () => undefined,
+    applyThemeChoice: () => undefined,
+    onSettings: () => undefined,
+    onAccountSettings: () => undefined,
+    onTutorial: () => undefined,
+    onLogin: () => undefined,
+    onLogout: () => undefined,
+    savedAccounts: [],
+    activeAccountId: null,
+    accountQuotas: {},
+    onSwitchAccount: () => undefined,
+    onUserMenuOpened: () => undefined,
+    ...override,
+  };
+}
+
+it("pins plan + reset, with remaining % on the bar row", () => {
+  const onSettings = vi.fn();
+  const onAccountSettings = vi.fn();
+  render(
+    <WorkbenchSidebar
+      {...props({ onSettings, onAccountSettings })}
+    />,
+  );
+
+  const pin = document.querySelector(".sidebar__quota-pin");
+  expect(pin).toBeTruthy();
+  expect(pin?.textContent).toContain("SuperGrok");
+  expect(pin?.textContent).toContain("Resets");
+  expect(pin?.textContent).not.toContain("Ada");
+  expect(pin?.textContent).not.toContain("89% remaining");
+  expect(
+    document.querySelector(".sidebar__quota-pin__remain")?.textContent,
+  ).toBe("89%");
+  expect(document.querySelector(".sidebar__footer-remain")).toBeNull();
+
+  fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+  expect(onSettings).toHaveBeenCalledTimes(1);
+  expect(onAccountSettings).not.toHaveBeenCalled();
+
+  fireEvent.click(pin as HTMLElement);
+  expect(onAccountSettings).toHaveBeenCalledTimes(1);
+});
+
+it("does not pin a quota card when signed out, but still shows settings", () => {
+  const account = signedInAccount();
+  account.profile.signedIn = false;
+  render(<WorkbenchSidebar {...props({ account })} />);
+  expect(document.querySelector(".sidebar__quota-pin")).toBeNull();
+  expect(screen.getByRole("button", { name: "Settings" })).toBeTruthy();
+});

--- a/src/app/WorkbenchSidebar.tsx
+++ b/src/app/WorkbenchSidebar.tsx
@@ -14,7 +14,7 @@ import { Tip } from "@/components/ui/tooltip";
 import { SidebarBrand } from "@/components/SidebarBrand";
 import { SidebarUpdateButton } from "@/components/SidebarUpdateButton";
 import { ThemeEditorModal } from "@/components/ThemeEditorModal";
-import { UserMenu, remainingPercent } from "@/components/UserMenu";
+import { UserMenu } from "@/components/UserMenu";
 import { GrokLogo } from "@/components/GrokLogo";
 import {
   ProviderBrandIcon,
@@ -27,6 +27,7 @@ import {
   IconNewChat,
   IconScheduled,
   IconSearch,
+  IconSettings,
 } from "@/components/icons";
 import { createT } from "@/i18n";
 import {
@@ -36,7 +37,16 @@ import {
   type SavedAccount,
 } from "@/lib/api";
 import { openThemeEditorWindow } from "@/lib/api/system";
-import { accountDisplayName, accountInitials } from "@/lib/accountUi";
+import {
+  accountDisplayName,
+  accountInitials,
+  formatQuotaResetTime,
+  tierLabel,
+} from "@/lib/accountUi";
+import {
+  formatQuotaRemainLabel,
+  resolveQuotaPercents,
+} from "@/lib/accountQuotaHonesty";
 import type { SwitcherQuota } from "@/lib/accountSwitcherQuota";
 import {
   formatProviderBalanceLine,
@@ -53,6 +63,12 @@ import type { Theme, ThemePreference } from "@/lib/theme";
 import { requestWhatsNewOpen } from "@/lib/whatsNew";
 
 type TFn = ReturnType<typeof createT>;
+
+function quotaBarFillClass(usedPercent: number | null): string {
+  if (usedPercent != null && usedPercent >= 90) return " is-danger";
+  if (usedPercent != null && usedPercent >= 70) return " is-warn";
+  return "";
+}
 
 type SidebarLayout = {
   sidebarCollapsed: boolean;
@@ -161,19 +177,12 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
     account,
     accountBusy,
     providerBalanceCache,
-    providerBalanceBusy,
-    providerBalanceError,
-    loadProviderBalance,
     applyThemeChoice,
     onSettings,
     onAccountSettings,
     onTutorial,
     onLogin,
     onLogout,
-    savedAccounts,
-    activeAccountId,
-    accountQuotas,
-    onSwitchAccount,
     onUserMenuOpened,
   } = props;
 
@@ -183,7 +192,49 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
       providerId: activeCustomProvider.id,
       baseUrl: activeCustomProvider.baseUrl,
     });
-
+  const signedInOfficial =
+    !customRouteActive && !!account?.profile?.signedIn;
+  const pinQuota = customRouteActive
+    ? providerSupportsBalance
+    : signedInOfficial;
+  const livePercents = resolveQuotaPercents(account?.billing ?? null);
+  const remainLabel = formatQuotaRemainLabel(livePercents.remainingPercent);
+  const resetTime = formatQuotaResetTime(
+    account?.billing?.resetsAt,
+    locale,
+  );
+  const officialName = account?.profile
+    ? accountDisplayName(account.profile, tr("common.local"))
+    : tr("common.local");
+  const customName =
+    activeCustomProvider?.name.trim() ||
+    activeCustomProvider?.id ||
+    tr("prov.customProvider");
+  const pinPlan = customRouteActive
+    ? `${tr("prov.customProvider")}${
+        activeCustomProvider?.model
+          ? ` / ${activeCustomProvider.model}`
+          : ""
+      }`
+    : account?.billing
+      ? tierLabel(account.billing, account.channel ?? "none")
+      : "Grok Build";
+  const pinResetText =
+    signedInOfficial && resetTime
+      ? `${tr("account.resetsAt")} ${resetTime}`
+      : null;
+  const providerBalance =
+    providerBalanceCache != null &&
+    providerBalanceCache.providerId === activeCustomProvider?.id
+      ? providerBalanceCache.result
+      : null;
+  const pinRemain = customRouteActive
+    ? formatProviderBalanceLine(providerBalance)
+    : remainLabel;
+  const remainLow =
+    !customRouteActive &&
+    livePercents.remainingPercent != null &&
+    livePercents.remainingPercent <= 10;
   return (
     <aside
       id="workbench-sidebar"
@@ -355,175 +406,169 @@ export function WorkbenchSidebar(props: WorkbenchSidebarProps) {
 
         {children}
 
-        <UserMenu
-          open={showUserMenu}
-          onClose={() => setShowUserMenu(false)}
-          closeImmediately={closeImmediately}
-          theme={theme}
-          themePreference={themePreference}
-          locale={locale}
-          account={account}
-          activeProvider={activeCustomProvider}
-          accountBusy={accountBusy}
-          providerBalance={
-            providerBalanceCache != null &&
-            providerBalanceCache.providerId === activeCustomProvider?.id
-              ? providerBalanceCache.result
-              : null
-          }
-          providerBalanceBusy={providerBalanceBusy}
-          providerBalanceError={
-            providerSupportsBalance ? providerBalanceError : null
-          }
-          onRefreshProviderBalance={
-            providerSupportsBalance
-              ? () => {
-                  void loadProviderBalance({ force: true });
-                }
-              : undefined
-          }
-          labels={{
-            settings: tr("sidebar.settings"),
-            whatsNew: tr("whatsNew.menu"),
-            tutorial: tr("tutorial.menu"),
-            theme: tr("user.theme"),
-            themeSystem: tr("settings.themeSystem"),
-            themeLight: tr("settings.themeLight"),
-            themeDark: tr("settings.themeDark"),
-            themeEditor: tr("user.themeEditor"),
-            local: tr("common.local"),
-            signedIn: tr("account.signedIn"),
-            signedOut: tr("account.signedOut"),
-            login: tr("account.login"),
-            logout: tr("account.logout"),
-            remaining: tr("account.quotaRemaining"),
-            profileActive: tr("account.profileActive"),
-            switchTo: tr("account.switchTo"),
-            customProvider: tr("prov.customProvider"),
-            resetsAt: tr("account.resetsAt"),
-            balanceAvailable: tr("prov.balance.available"),
-            balanceUnavailable: tr("prov.balance.unavailable"),
-            balanceGranted: tr("prov.balance.granted"),
-            balanceToppedUp: tr("prov.balance.toppedUp"),
-            balanceRefresh: tr("prov.balance.refresh"),
-            balanceChecking: tr("prov.balance.checking"),
-          }}
-          onSettings={onSettings}
-          onAccountSettings={onAccountSettings}
-          onWhatsNew={() => requestWhatsNewOpen()}
-          onTutorial={onTutorial}
-          onTheme={applyThemeChoice}
-          onThemeEditor={() => {
-            if (isDesktopHost()) {
-              void openThemeEditorWindow().catch(() => {
-                setThemeEditorOpen(true);
-              });
-              return;
-            }
-            setThemeEditorOpen(true);
-          }}
-          onLogin={onLogin}
-          onLogout={onLogout}
-          savedAccounts={savedAccounts}
-          activeAccountId={activeAccountId}
-          accountQuotas={accountQuotas}
-          onSwitchAccount={onSwitchAccount}
-        >
-          <Tip label={tr("user.menu")}>
+        <div className="sidebar__account">
+          {pinQuota ? (
             <button
               type="button"
-              className={
-                "sidebar__footer" + (showUserMenu ? " is-open" : "")
+              className="sidebar__quota-pin"
+              aria-label={
+                [pinPlan, pinRemain, pinResetText]
+                  .filter(Boolean)
+                  .join(", ")
               }
-              aria-haspopup="menu"
-              aria-expanded={showUserMenu}
-              onClick={() => {
-                setShowUserMenu((v) => !v);
-                if (!showUserMenu) onUserMenuOpened();
-              }}
+              onClick={onAccountSettings}
             >
-              <div
-                className={
-                  "user-avatar" +
-                  (activeCustomProvider &&
-                  resolveProviderBrandId({
-                    providerId: activeCustomProvider.id,
-                    baseUrl: activeCustomProvider.baseUrl,
-                  })
-                    ? " user-avatar--logo"
-                    : account?.profile?.signedIn
-                      ? " user-avatar--logo"
-                      : "")
-                }
-                aria-hidden
-              >
-                {activeCustomProvider ? (
-                  resolveProviderBrandId({
-                    providerId: activeCustomProvider.id,
-                    baseUrl: activeCustomProvider.baseUrl,
-                  }) ? (
-                    <ProviderBrandIcon
-                      providerId={activeCustomProvider.id}
-                      baseUrl={activeCustomProvider.baseUrl}
-                      size={20}
-                    />
-                  ) : (
-                    providerAvatarLetter(
-                      activeCustomProvider.name.trim() ||
-                        activeCustomProvider.id,
-                    )
-                  )
-                ) : account?.profile?.signedIn ? (
-                  <GrokLogo size={20} />
-                ) : account?.profile ? (
-                  accountInitials(account.profile)
-                ) : (
-                  "G"
-                )}
-              </div>
-              <div className="user-meta">
-                <span className="user-meta__name">
-                  {activeCustomProvider
-                    ? activeCustomProvider.name.trim() ||
-                      activeCustomProvider.id
-                    : account?.profile
-                      ? accountDisplayName(
-                          account.profile,
-                          tr("common.local"),
-                        )
-                      : tr("common.local")}
+              <span className="sidebar__quota-pin__row">
+                <span className="sidebar__quota-pin__plan">{pinPlan}</span>
+                {pinResetText ? (
+                  <span className="sidebar__quota-pin__reset">
+                    {pinResetText}
+                  </span>
+                ) : null}
+              </span>
+              {pinRemain ||
+              (!customRouteActive &&
+                livePercents.remainingPercent != null) ? (
+                <span className="sidebar__quota-pin__meter">
+                  {!customRouteActive &&
+                  livePercents.remainingPercent != null ? (
+                    <div
+                      className="account-quota-bar account-quota-bar--sm"
+                      aria-hidden
+                    >
+                      <div
+                        className={
+                          "account-quota-bar__fill" +
+                          quotaBarFillClass(livePercents.usedPercent)
+                        }
+                        style={{
+                          width: `${Math.min(100, livePercents.usedPercent ?? 0)}%`,
+                        }}
+                      />
+                    </div>
+                  ) : null}
+                  {pinRemain ? (
+                    <span
+                      className={
+                        "sidebar__quota-pin__remain" +
+                        (remainLow ? " is-low" : "")
+                      }
+                    >
+                      {pinRemain}
+                    </span>
+                  ) : null}
                 </span>
-                {(() => {
-                  if (customRouteActive && activeCustomProvider) {
-                    if (
-                      !supportsProviderBalance({
+              ) : null}
+            </button>
+          ) : null}
+          <div className="sidebar__footer-row">
+            <UserMenu
+              open={showUserMenu}
+              onClose={() => setShowUserMenu(false)}
+              closeImmediately={closeImmediately}
+              theme={theme}
+              themePreference={themePreference}
+              account={account}
+              activeProvider={activeCustomProvider}
+              accountBusy={accountBusy}
+              labels={{
+                whatsNew: tr("whatsNew.menu"),
+                tutorial: tr("tutorial.menu"),
+                theme: tr("user.theme"),
+                themeSystem: tr("settings.themeSystem"),
+                themeLight: tr("settings.themeLight"),
+                themeDark: tr("settings.themeDark"),
+                themeEditor: tr("user.themeEditor"),
+                login: tr("account.login"),
+                logout: tr("account.logout"),
+              }}
+              onWhatsNew={() => requestWhatsNewOpen()}
+              onTutorial={onTutorial}
+              onTheme={applyThemeChoice}
+              onThemeEditor={() => {
+                if (isDesktopHost()) {
+                  void openThemeEditorWindow().catch(() => {
+                    setThemeEditorOpen(true);
+                  });
+                  return;
+                }
+                setThemeEditorOpen(true);
+              }}
+              onLogin={onLogin}
+              onLogout={onLogout}
+            >
+              <Tip label={tr("user.menu")}>
+                <button
+                  type="button"
+                  className={
+                    "sidebar__footer" + (showUserMenu ? " is-open" : "")
+                  }
+                  aria-haspopup="menu"
+                  aria-expanded={showUserMenu}
+                  onClick={() => {
+                    setShowUserMenu((v) => !v);
+                    if (!showUserMenu) onUserMenuOpened();
+                  }}
+                >
+                  <div
+                    className={
+                      "user-avatar" +
+                      (activeCustomProvider &&
+                      resolveProviderBrandId({
                         providerId: activeCustomProvider.id,
                         baseUrl: activeCustomProvider.baseUrl,
                       })
-                    ) {
-                      return null;
+                        ? " user-avatar--logo"
+                        : account?.profile?.signedIn
+                          ? " user-avatar--logo"
+                          : "")
                     }
-                    const line =
-                      providerBalanceCache?.providerId ===
-                      activeCustomProvider.id
-                        ? formatProviderBalanceLine(
-                            providerBalanceCache.result,
-                          )
-                        : null;
-                    return line ? (
-                      <span className="user-meta__quota">{line}</span>
-                    ) : null;
-                  }
-                  if (!account?.profile?.signedIn) return null;
-                  const rem = remainingPercent(account);
-                  return rem != null ? (
-                    <span className="user-meta__quota">{rem.toFixed(0)}%</span>
-                  ) : null;
-                })()}
-              </div>
-            </button>
-          </Tip>
-        </UserMenu>
+                    aria-hidden
+                  >
+                    {activeCustomProvider ? (
+                      resolveProviderBrandId({
+                        providerId: activeCustomProvider.id,
+                        baseUrl: activeCustomProvider.baseUrl,
+                      }) ? (
+                        <ProviderBrandIcon
+                          providerId={activeCustomProvider.id}
+                          baseUrl={activeCustomProvider.baseUrl}
+                          size={20}
+                        />
+                      ) : (
+                        providerAvatarLetter(
+                          activeCustomProvider.name.trim() ||
+                            activeCustomProvider.id,
+                        )
+                      )
+                    ) : account?.profile?.signedIn ? (
+                      <GrokLogo size={20} />
+                    ) : account?.profile ? (
+                      accountInitials(account.profile)
+                    ) : (
+                      "G"
+                    )}
+                  </div>
+                  <div className="user-meta">
+                    <span className="user-meta__name">
+                      {customRouteActive ? customName : officialName}
+                    </span>
+                  </div>
+                </button>
+              </Tip>
+            </UserMenu>
+            <Tip label={tr("sidebar.settings")}>
+              <button
+                type="button"
+                className="sidebar__footer-settings chrome-btn"
+                aria-label={tr("sidebar.settings")}
+                onClick={onSettings}
+              >
+                <IconSettings size={16} />
+              </button>
+            </Tip>
+          </div>
+        </div>
       </div>
       {themeEditorOpen ? (
         <ThemeEditorModal

--- a/src/components/UserMenu.test.tsx
+++ b/src/components/UserMenu.test.tsx
@@ -17,21 +17,12 @@ vi.mock("@/lib/floatingMenu", () => ({
 }));
 
 const labels = {
-  settings: "Settings",
   theme: "Theme",
   themeSystem: "System",
   themeLight: "Light",
   themeDark: "Dark",
-  local: "Local",
-  signedIn: "Signed in",
-  signedOut: "Signed out",
   login: "Log in",
   logout: "Log out",
-  remaining: "remaining",
-  profileActive: "Active",
-  switchTo: "Switch to",
-  customProvider: "Custom provider",
-  resetsAt: "Resets",
 };
 
 function Harness({ collapsed }: { collapsed: boolean }) {
@@ -45,13 +36,10 @@ function Harness({ collapsed }: { collapsed: boolean }) {
         onClose={() => setOpen(false)}
         theme="dark"
         themePreference="dark"
-        locale="en"
         labels={labels}
         account={null}
         activeProvider={null}
         accountBusy={false}
-        onSettings={() => undefined}
-        onAccountSettings={() => undefined}
         onTheme={() => undefined}
         onLogin={() => undefined}
         onLogout={() => undefined}
@@ -70,13 +58,10 @@ it("opens the theme editor from the theme submenu footer group", async () => {
       onClose={() => undefined}
       theme="dark"
       themePreference="dark"
-      locale="en"
       labels={{ ...labels, themeEditor: "Theme editor" }}
       account={null}
       activeProvider={null}
       accountBusy={false}
-      onSettings={() => undefined}
-      onAccountSettings={() => undefined}
       onTheme={() => undefined}
       onThemeEditor={onThemeEditor}
       onLogin={() => undefined}
@@ -91,6 +76,71 @@ it("opens the theme editor from the theme submenu footer group", async () => {
   expect(document.querySelector(".user-menu__flyout-sep")).not.toBeNull();
   fireEvent.click(editor);
   expect(onThemeEditor).toHaveBeenCalledTimes(1);
+  view.rerender(
+    <UserMenu
+      open={false}
+      onClose={() => undefined}
+      theme="dark"
+      themePreference="dark"
+      labels={{ ...labels, themeEditor: "Theme editor" }}
+      account={null}
+      activeProvider={null}
+      accountBusy={false}
+      onTheme={() => undefined}
+      onThemeEditor={onThemeEditor}
+      onLogin={() => undefined}
+      onLogout={() => undefined}
+    >
+      <button type="button">Account</button>
+    </UserMenu>,
+  );
+  await waitFor(() =>
+    expect(document.querySelector(".user-menu__pop--portal")).toBeNull(),
+  );
+  view.unmount();
+});
+
+it("does not put quota or settings in the account menu", async () => {
+  const view = render(
+    <UserMenu
+      open
+      onClose={() => undefined}
+      theme="dark"
+      themePreference="dark"
+      labels={labels}
+      account={null}
+      activeProvider={null}
+      accountBusy={false}
+      onTheme={() => undefined}
+      onLogin={() => undefined}
+      onLogout={() => undefined}
+    >
+      <button type="button">Account</button>
+    </UserMenu>,
+  );
+  expect(document.querySelector(".user-menu__account")).toBeNull();
+  expect(screen.queryByRole("menuitem", { name: "Settings" })).toBeNull();
+  expect(screen.getByRole("menuitem", { name: "Theme" })).toBeTruthy();
+  view.rerender(
+    <UserMenu
+      open={false}
+      onClose={() => undefined}
+      theme="dark"
+      themePreference="dark"
+      labels={labels}
+      account={null}
+      activeProvider={null}
+      accountBusy={false}
+      onTheme={() => undefined}
+      onLogin={() => undefined}
+      onLogout={() => undefined}
+    >
+      <button type="button">Account</button>
+    </UserMenu>,
+  );
+  await waitFor(() =>
+    expect(document.querySelector(".user-menu__pop--portal")).toBeNull(),
+  );
   view.unmount();
 });
 

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,12 +1,12 @@
 /**
- * Personal center — compact upward menu: account card · settings · theme · logout.
+ * Personal center — compact upward menu: what's new · theme · login/logout.
+ * Quota and Settings live on the expanded sidebar footer, not here.
  */
 
 import {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -17,44 +17,17 @@ import {
   IconCheck,
   IconChevronRight,
   IconHelp,
-  IconSettings,
   IconSparkles,
   IconThemeMoon,
   IconThemeSun,
 } from "@/components/icons";
 import type { Theme, ThemePreference } from "@/lib/theme";
-import { GrokLogo } from "@/components/GrokLogo";
 import {
   FLOATING_MENU_Z_INDEX,
   useFloatingMenu,
 } from "@/lib/floatingMenu";
 import { OPEN_PRESENCE_MS, useOpenPresence } from "@/lib/openPresence";
-import type {
-  AccountStatus,
-  CustomProvider,
-  ProviderBalanceResult,
-  SavedAccount,
-} from "@/lib/api";
-import {
-  accountDisplayName,
-  accountInitials,
-  formatQuotaResetTime,
-  tierLabel,
-} from "@/lib/accountUi";
-import {
-  formatQuotaRemainLabel,
-  resolveQuotaPercents,
-} from "@/lib/accountQuotaHonesty";
-import {
-  formatProviderBalanceDetailParts,
-  formatProviderBalanceLine,
-} from "@/lib/providerBalanceFormat";
-import {
-  mergeAccountQuota,
-  switcherDisplayName,
-  type SwitcherQuota,
-} from "@/lib/accountSwitcherQuota";
-import { formatShortcutHint } from "@/lib/shortcuts";
+import type { AccountStatus, CustomProvider } from "@/lib/api";
 
 export interface UserMenuProps {
   open: boolean;
@@ -65,10 +38,7 @@ export interface UserMenuProps {
   theme: Theme;
   /** Preference driving the theme submenu selection. */
   themePreference: ThemePreference;
-  /** App locale, so the quota reset clock follows Settings. */
-  locale: string;
   labels: {
-    settings: string;
     /** Optional what's-new entry (account menu, above the tour). */
     whatsNew?: string;
     /** Optional product tour entry label */
@@ -79,35 +49,12 @@ export interface UserMenuProps {
     themeDark: string;
     /** Opens the floating appearance editor. */
     themeEditor?: string;
-    local: string;
-    signedIn: string;
-    signedOut: string;
     login: string;
     logout: string;
-    remaining: string;
-    profileActive: string;
-    switchTo: string;
-    customProvider: string;
-    /** Prefix for quota refresh time, e.g. 重置 / Resets */
-    resetsAt: string;
-    /** DeepSeek balance (optional) */
-    balanceAvailable?: string;
-    balanceUnavailable?: string;
-    balanceGranted?: string;
-    balanceToppedUp?: string;
-    balanceRefresh?: string;
-    balanceChecking?: string;
   };
   account: AccountStatus | null;
   activeProvider: CustomProvider | null;
   accountBusy: boolean;
-  /** Active custom provider balance (DeepSeek); null when N/A or failed. */
-  providerBalance?: ProviderBalanceResult | null;
-  providerBalanceBusy?: boolean;
-  providerBalanceError?: string | null;
-  onRefreshProviderBalance?: () => void;
-  onSettings: () => void;
-  onAccountSettings: () => void;
   /** Re-open the current version's update notes. */
   onWhatsNew?: () => void;
   /** Open optional in-app product tour */
@@ -117,16 +64,7 @@ export interface UserMenuProps {
   onThemeEditor?: () => void;
   onLogin: () => void;
   onLogout: () => void;
-  savedAccounts?: SavedAccount[];
-  activeAccountId?: string | null;
-  accountQuotas?: Record<string, SwitcherQuota>;
-  onSwitchAccount?: (id: string) => void;
   children: ReactNode;
-}
-
-/** Honest remaining % — never invents 0 / 100 when Host billing is silent. */
-export function remainingPercent(account: AccountStatus | null): number | null {
-  return resolveQuotaPercents(account?.billing ?? null).remainingPercent;
 }
 
 const THEME_OPTIONS: ThemePreference[] = ["system", "light", "dark"];
@@ -172,27 +110,16 @@ export function UserMenu({
   onClose,
   theme,
   themePreference,
-  locale,
   labels,
   account,
   activeProvider,
   accountBusy,
-  providerBalance = null,
-  providerBalanceBusy = false,
-  providerBalanceError = null,
-  onRefreshProviderBalance,
-  onSettings,
-  onAccountSettings,
   onWhatsNew,
   onTutorial,
   onTheme,
   onThemeEditor,
   onLogin,
   onLogout,
-  savedAccounts = [],
-  activeAccountId = null,
-  accountQuotas = {},
-  onSwitchAccount,
   children,
 }: UserMenuProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -203,10 +130,6 @@ export function UserMenu({
   const [themeSubOpen, setThemeSubOpen] = useState(false);
   const [flyoutStyle, setFlyoutStyle] = useState<CSSProperties | null>(null);
   const closeTimerRef = useRef<number | null>(null);
-  const settingsHint = useMemo(
-    () => (open ? formatShortcutHint("settings") : ""),
-    [open],
-  );
 
   useEffect(() => {
     if (!open) setThemeSubOpen(false);
@@ -284,7 +207,7 @@ export function UserMenu({
     width: 0,
     fitContent: false,
     matchTriggerWidth: true,
-    estHeight: savedAccounts.length > 1 ? 360 : 260,
+    estHeight: 220,
     gap: 6,
     // CSS owns transform (rise from the footer). Do not apply placeAbove -100%.
     anchorTransform: false,
@@ -295,35 +218,8 @@ export function UserMenu({
     closeImmediately ? 0 : OPEN_PRESENCE_MS,
   ).entered;
 
-  const profile = account?.profile;
   const isCustomProvider = activeProvider != null;
-  const signedIn = !isCustomProvider && !!profile?.signedIn;
-  const providerName =
-    activeProvider?.name.trim() || activeProvider?.id.trim() || labels.customProvider;
-  const name = isCustomProvider
-    ? providerName
-    : profile
-      ? accountDisplayName(profile, labels.local)
-      : labels.local;
-  const initials = isCustomProvider
-    ? Array.from(providerName)[0]?.toUpperCase() || "P"
-    : profile
-      ? accountInitials(profile)
-      : "G";
-  const channel = account?.channel ?? "none";
-  const billing = account?.billing;
-  const livePercents = resolveQuotaPercents(billing ?? null);
-  const usedPct = livePercents.usedPercent;
-  const remaining = livePercents.remainingPercent;
-  const resetTime = formatQuotaResetTime(billing?.resetsAt, locale);
-  const remainLabel = formatQuotaRemainLabel(remaining);
-  const remainText = remainLabel ? `${remainLabel} ${labels.remaining}` : "—";
-  const showSavedOfficialAccounts = signedIn && savedAccounts.length > 0;
-  const tier = billing
-    ? tierLabel(billing, channel)
-    : signedIn
-      ? "Grok Build"
-      : "—";
+  const signedIn = !isCustomProvider && !!account?.profile?.signedIn;
 
   const themeLabel = (pref: ThemePreference) => {
     if (pref === "system") return labels.themeSystem;
@@ -421,287 +317,6 @@ export function UserMenu({
             role="menu"
             style={style}
           >
-            {showSavedOfficialAccounts ? (
-              <div className="user-menu__accounts">
-                {savedAccounts.map((saved) => {
-                  const active = saved.id === activeAccountId;
-                  const rowName = switcherDisplayName(saved);
-                  const q = mergeAccountQuota(
-                    saved.id,
-                    saved.email,
-                    accountQuotas,
-                    {
-                      id: activeAccountId,
-                      email: profile?.email,
-                      remaining,
-                      used: usedPct,
-                      resetsAt: billing?.resetsAt ?? null,
-                    },
-                  );
-                  const rowRemain = q?.remainingPercent ?? null;
-                  const rowUsed = q?.usedPercent ?? null;
-                  const rowReset = formatQuotaResetTime(q?.resetsAt, locale);
-                  const rowRemainLabel = formatQuotaRemainLabel(rowRemain);
-                  const low = rowRemain != null && rowRemain <= 10;
-                  return (
-                    <button
-                      key={saved.id}
-                      type="button"
-                      className={
-                        "user-menu__account" +
-                        (active ? " is-active" : "") +
-                        (low ? " is-low" : "")
-                      }
-                      role="menuitem"
-                      disabled={accountBusy}
-                      aria-current={active ? "true" : undefined}
-                      aria-label={
-                        active
-                          ? `${rowName}, ${labels.profileActive}`
-                          : `${labels.switchTo}: ${rowName}`
-                      }
-                      onClick={() => {
-                        if (active) {
-                          onClose();
-                          onAccountSettings();
-                          return;
-                        }
-                        if (!onSwitchAccount) return;
-                        onClose();
-                        onSwitchAccount(saved.id);
-                      }}
-                    >
-                      <div className="user-menu__account-top">
-                        <div
-                          className="account-avatar account-avatar--sm"
-                          aria-hidden
-                        >
-                          {active && signedIn ? (
-                            <GrokLogo size={17} />
-                          ) : (
-                            rowName.slice(0, 1).toUpperCase()
-                          )}
-                        </div>
-                        <div className="user-menu__account-text">
-                          <div className="user-menu__account-name-row">
-                            <div className="user-menu__account-id">
-                              <div className="user-menu__account-name">
-                                {rowName}
-                              </div>
-                              {active ? (
-                                <span className="user-menu__current">
-                                  {labels.profileActive}
-                                </span>
-                              ) : null}
-                            </div>
-                            {rowReset ? (
-                              <span className="user-menu__quota-reset">
-                                {labels.resetsAt} {rowReset}
-                              </span>
-                            ) : null}
-                          </div>
-                          <div className="user-menu__quota">
-                            <div className="user-menu__quota-row">
-                              <span className="user-menu__tier">
-                                {active
-                                  ? tier
-                                  : saved.email && saved.email !== rowName
-                                    ? saved.email
-                                    : "\u00a0"}
-                              </span>
-                              <span className="user-menu__remain">
-                                {rowRemainLabel
-                                  ? `${rowRemainLabel} ${labels.remaining}`
-                                  : "—"}
-                              </span>
-                            </div>
-                            {rowRemainLabel ? (
-                              <div
-                                className="account-quota-bar account-quota-bar--sm"
-                                aria-hidden
-                              >
-                                <div
-                                  className={
-                                    "account-quota-bar__fill" +
-                                    (rowUsed != null && rowUsed >= 90
-                                      ? " is-danger"
-                                      : rowUsed != null && rowUsed >= 70
-                                        ? " is-warn"
-                                        : "")
-                                  }
-                                  style={{
-                                    width: `${Math.min(100, rowUsed ?? 0)}%`,
-                                  }}
-                                />
-                              </div>
-                            ) : null}
-                          </div>
-                        </div>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            ) : (
-            <button
-              type="button"
-              className="user-menu__account"
-              role="menuitem"
-              onClick={() => {
-                onClose();
-                onAccountSettings();
-              }}
-            >
-              <div className="user-menu__account-top">
-                <div className="account-avatar account-avatar--sm" aria-hidden>
-                  {signedIn ? <GrokLogo size={17} /> : initials}
-                </div>
-                <div className="user-menu__account-text">
-                  <div className="user-menu__account-name-row">
-                    <div className="user-menu__account-name">{name}</div>
-                    {signedIn && resetTime ? (
-                      <span className="user-menu__quota-reset">
-                        {labels.resetsAt} {resetTime}
-                      </span>
-                    ) : null}
-                  </div>
-                  {isCustomProvider ? (
-                    <>
-                      <div className="user-menu__account-sub">
-                        {labels.customProvider}
-                        {activeProvider.model
-                          ? ` / ${activeProvider.model}`
-                          : ""}
-                      </div>
-                      {(() => {
-                        const line = formatProviderBalanceLine(providerBalance);
-                        const detail =
-                          formatProviderBalanceDetailParts(providerBalance);
-                        const showBalanceBlock =
-                          onRefreshProviderBalance != null ||
-                          line != null ||
-                          providerBalanceError != null ||
-                          providerBalanceBusy;
-                        if (!showBalanceBlock) return null;
-                        return (
-                          <div className="user-menu__balance">
-                            <div className="user-menu__quota-row">
-                              <span className="user-menu__remain">
-                                {line
-                                  ? line
-                                  : providerBalanceBusy
-                                    ? (labels.balanceChecking ?? "…")
-                                    : "—"}
-                              </span>
-                              {providerBalance?.ok &&
-                              providerBalance.isAvailable === false &&
-                              labels.balanceUnavailable ? (
-                                <span className="user-menu__balance-warn">
-                                  {labels.balanceUnavailable}
-                                </span>
-                              ) : providerBalance?.ok &&
-                                labels.balanceAvailable ? (
-                                <span className="user-menu__tier">
-                                  {labels.balanceAvailable}
-                                </span>
-                              ) : null}
-                            </div>
-                            {detail &&
-                            (detail.granted || detail.toppedUp) ? (
-                              <div className="user-menu__account-sub user-menu__balance-detail">
-                                {[
-                                  detail.granted && labels.balanceGranted
-                                    ? `${labels.balanceGranted} ${detail.granted}`
-                                    : null,
-                                  detail.toppedUp && labels.balanceToppedUp
-                                    ? `${labels.balanceToppedUp} ${detail.toppedUp}`
-                                    : null,
-                                ]
-                                  .filter(Boolean)
-                                  .join(" · ")}
-                              </div>
-                            ) : null}
-                            {providerBalanceError ? (
-                              <div className="user-menu__balance-err">
-                                {providerBalanceError}
-                              </div>
-                            ) : null}
-                            {onRefreshProviderBalance ? (
-                              <button
-                                type="button"
-                                className="user-menu__balance-refresh"
-                                disabled={providerBalanceBusy}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  onRefreshProviderBalance();
-                                }}
-                              >
-                                {providerBalanceBusy
-                                  ? (labels.balanceChecking ?? "…")
-                                  : (labels.balanceRefresh ?? "Refresh")}
-                              </button>
-                            ) : null}
-                          </div>
-                        );
-                      })()}
-                    </>
-                  ) : !signedIn ? (
-                    <div className="user-menu__account-sub">
-                      {labels.signedOut}
-                    </div>
-                  ) : (
-                    <div className="user-menu__quota">
-                      <div className="user-menu__quota-row">
-                        <span className="user-menu__tier">{tier}</span>
-                        <span className="user-menu__remain">
-                          {remainText}
-                        </span>
-                      </div>
-                      {remaining != null && (
-                        <div
-                          className="account-quota-bar account-quota-bar--sm"
-                          aria-hidden
-                        >
-                          <div
-                            className={
-                              "account-quota-bar__fill" +
-                              (usedPct != null && usedPct >= 90
-                                ? " is-danger"
-                                : usedPct != null && usedPct >= 70
-                                  ? " is-warn"
-                                  : "")
-                            }
-                            style={{
-                              width: `${Math.min(100, usedPct ?? 0)}%`,
-                            }}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </button>
-            )}
-
-            <button
-              type="button"
-              className="user-menu__item"
-              role="menuitem"
-              onClick={() => {
-                onClose();
-                onSettings();
-              }}
-            >
-              <IconSettings size={16} />
-              <span className="user-menu__item-label">{labels.settings}</span>
-              {settingsHint ? (
-                <kbd className="menu-shortcut" aria-hidden>
-                  {settingsHint}
-                </kbd>
-              ) : null}
-            </button>
-
             {onWhatsNew && labels.whatsNew ? (
               <button
                 type="button"

--- a/src/styles/phone.part1.css
+++ b/src/styles/phone.part1.css
@@ -317,6 +317,11 @@
     min-height: 52px;
   }
 
+  .app-shell--phone .sidebar__footer-settings {
+    width: 36px;
+    height: 36px;
+  }
+
   .app-shell--phone .tree-l3__name,
   .app-shell--phone .tree-l2__name {
     font-size: 15px;

--- a/src/styles/sidebar.part4.css
+++ b/src/styles/sidebar.part4.css
@@ -372,12 +372,114 @@ html[data-sidebar-density="compact"] .session-row__meta {
 }
 
 /* Footer account row — solid separator, inset hover (Codex / ChatGPT style) */
+.sidebar__account {
+  flex-shrink: 0;
+  margin-top: 0;
+  padding: 8px 10px 10px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebar__footer-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sidebar__quota-pin {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  margin: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: var(--bg-hover);
+  color: inherit;
+  text-align: left;
+}
+
+.sidebar__quota-pin:hover {
+  background: var(--bg-active);
+}
+
+.sidebar__quota-pin__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.sidebar__quota-pin__plan {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text-primary);
+}
+
+.sidebar__quota-pin__reset {
+  flex-shrink: 0;
+  font-size: 10px;
+  line-height: 1.3;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+.sidebar__quota-pin__meter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.sidebar__quota-pin__meter .account-quota-bar {
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar__quota-pin__remain {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.sidebar__quota-pin__remain.is-low {
+  color: var(--danger, #e25555);
+}
+
+.sidebar__footer-settings {
+  flex-shrink: 0;
+}
+
 .user-menu {
   position: relative;
   flex-shrink: 0;
   margin-top: 0;
   padding: 8px 10px 10px;
   border-top: 1px solid var(--border-subtle);
+}
+
+.sidebar__account .user-menu {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border-top: none;
+  margin: 0;
 }
 
 .sidebar__footer {
@@ -866,16 +968,6 @@ html[data-sidebar-density="compact"] .session-row__meta {
   white-space: nowrap;
   line-height: 1.2;
   min-width: 0;
-}
-
-/* Remaining SuperGrok % on the footer row — single number only */
-.user-meta__quota {
-  flex-shrink: 0;
-  font-size: 12px;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-  color: var(--text-secondary);
-  letter-spacing: -0.02em;
 }
 
 /* Status line lives in popover only — keep footer single-line */


### PR DESCRIPTION
Closes #1048

## Summary
Pin SuperGrok remaining quota on the expanded left sidebar so you do not have to open the account menu to see plan, reset time, or remaining %.

- First row: plan name + reset clock
- Second row: quota bar + remaining % (custom-provider balance when that route is active)
- Footer: avatar + name, settings gear on the right
- Account popover no longer repeats the quota card or Settings. Theme, What's New, tour, and login/logout stay. Switch accounts in Settings → Account.

Signed-out / local has no pin.

## Type of change
- [x] New feature
- [x] Documentation

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test` (related tests + whatsNew; full suite has pre-existing Windows CRLF guard flakes)
- [x] `cargo fmt --check` and `cargo clippy -D warnings` (no Rust product changes)
- [x] User-facing strings go through `src/i18n` (no new keys)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] `docs/llm-wiki` account + providers updated
- [x] No secrets

## Notes
This is a sidebar IA/visual change. Local Windows QA used a side-by-side `grok-app-latest` install.