### PR TITLE
refactor(workbench): extract session chrome badges

### DIFF
--- a/docs/plans/2026-09-07-appworkbench-w30-session-badges.md
+++ b/docs/plans/2026-09-07-appworkbench-w30-session-badges.md
@@ -1,0 +1,73 @@
+# AppWorkbench 继续拆解 — WP-W30 会话徽章
+
+**日期**：2026-09-07  
+**基线**：`origin/main` @ `030f656d`（`feat(sidebar): pin SuperGrok quota on the expanded rail (#1050)`）  
+**来源**：HANDOFF · W29 后续「会话徽章」· 软件设计哲学（深模块 / 信息隐藏）  
+**执行位置**：worktree `D:/code/grok-app-appworkbench-w30-session-badges` · 分支 `refactor/appworkbench-w30-session-badges`
+
+---
+
+## 1. 问题
+
+Mute / unread / plan-pending 的 Set、localStorage、CustomEvent、tray/dock 计数、clear-on-view 仍堆在 `AppWorkbench` 顶层。改侧栏圆点必须在 100+ 个 `useState` 里判断耦合。
+
+约束（不可破）：
+
+- AGENTS.md §7：App shell + AppWorkbench **合计行数只降不升**；禁止再往 host 加 `useState` / 大功能块。
+- 按**知识归属**抽深 hook（state + effect + persist + 少量动词），不切 80-prop Stage 壳。
+- `files_ge_1000` ≤80；新文件 <1000 行。
+- 一次一个域。不 merge `main`，除非用户明确说。
+- UI 文案走 `createT` / `t()`；无 `window.confirm` / `prompt` / `alert`。
+
+---
+
+## 2. 本刀锁定
+
+新建 `src/hooks/useSessionChromeBadges.ts`（对标 `useSideWorkbenchChrome`）：
+
+自持：
+
+- `mutedSessionIds` + `SESSION_MUTE_CHANGE_EVENT`
+- `unreadSessionIds` + `SESSION_UNREAD_CHANGE_EVENT`
+- `planPendingSessionIds` + `markPlanPendingBadge`
+- `manualUnreadHoldIdsRef`（当前正在看时手动标未读，离开再开才清）
+- `applyClearSessionUnread` / `applyMarkSessionUnread`
+- mute toggle、clear-all（含 `setAppDialog` 确认）
+- 前台绑定 / focus / visibility 清未读
+- tray / Windows taskbar `busyCount`（count = unread size）
+
+`viewingSessionId` / `tr` / `setAppDialog` 晚绑在 `SessionChromeBadgesHost`。
+
+`session.sessionId`、`isSecondaryWindow`、`trayBusyBadge`、`winTaskbarOverlay` 作 hook 入参（设置项与窗口角色不是徽章知识）。
+
+Host 仍调 `markPlanPendingBadge`（plan chrome / host events / restore）。`sessionChangesById` 与 git dirty 仍留 host。
+
+---
+
+## 3. 测试
+
+`src/hooks/useSessionChromeBadges.test.ts`（jsdom）：
+
+1. 存储事件同步 mute set
+2. `applyClearSessionUnread` 立刻从 set 去掉
+3. 正在看时 `applyMarkSessionUnread` 打 hold，不清
+4. 绑定前台会话清未读
+5. `markPlanPendingBadge` 按 plan gate 增删
+6. 超过阈值的 clear-all 走 `setAppDialog`
+7. unread size 驱动 `traySetBusyCount`
+
+---
+
+## 4. 后续（不在本刀）
+
+实测（W30 接线后）：
+
+| | W29 ledger | W30 worktree | 新天花板 |
+|--|----------|--------------|----------|
+| 行数 | 14258（main@#1050 实为 14262） | **14062** | 14400 → **14200** |
+| useState | 116 | **113** | 120 → **116** |
+| useEffect | 71 | **65** | 74 → **68** |
+
+新 hook 295 行。
+
+其后 W31 账号 / 配额 → W32 MCP doctor → W33 setup / boot。

--- a/docs/plans/CODE-QUALITY-PROGRESS.md
+++ b/docs/plans/CODE-QUALITY-PROGRESS.md
@@ -12,7 +12,7 @@
 | Spec | `docs/plans/2026-08-01-code-quality-remediation-GOAL.md` |
 | Started | `2026-08-01` |
 | Current wave | `workbench-decomp` |
-| Current WP | `WP-W29` |
+| Current WP | `WP-W30` |
 | **FINAL** | **PASS** (honest orchestration metrics; decreasing ceilings) |
 
 ## Wave checklist
@@ -75,6 +75,7 @@
 | WP-W27 | Session connect + live map into useSessionConnect | PASS | aae65cf4 | 15471→15183 lines; useState 156→155; useEffect 81→80 |
 | WP-W28 | Git worktree + ship chrome into useGitWorktreeChrome | PASS |  | #1033; 15237→14416 lines; useState 154→122; useEffect 78→75 |
 | WP-W29 | Side Workbench chrome into useSideWorkbenchChrome | PASS |  | #1042; 14416→14258 lines; useState 122→116; useEffect 75→71; plan `docs/plans/2026-09-06-appworkbench-w29-side-workbench.md` |
+| WP-W30 | Session chrome badges into useSessionChromeBadges | PASS |  | main@#1050 14262→14062 lines; useState 116→113; useEffect 71→65; plan `docs/plans/2026-09-07-appworkbench-w30-session-badges.md` |
 
 ## Metrics log (append-only)
 
@@ -115,6 +116,7 @@
 | 2026-08-24 W27 | 15183 (shell 18 + wb 15165) | 155 | 80 | 11 | dir | dir | 28 | 9 | 69 |
 | 2026-09-05 W28 | 14416 (shell 21 + wb 14395) | 122 | 75 | 12 | dir | dir | 29 | 9 | 80 |
 | 2026-09-06 W29 | 14258 (shell 21 + wb 14237) | 116 | 71 | 12 | dir | dir | 29 | 9 | 80 |
+| 2026-09-07 W30 | 14062 (shell 21 + wb 14041) | 113 | 65 | 12 | dir | dir | 29 | 9 | 80 |
 
 ## Blockers
 
@@ -140,7 +142,7 @@ Parallel non-overlapping tracks (multi-agent) — **landed**:
 | residual-resource-viewer | ResourceViewer + parts | **PASS** | 4938→modules |
 | residual-i18n | `src/i18n/**` | **PASS** | domain modules + barrels |
 | residual-settings | SettingsPage + settings/* | **PASS** | 8874→1817 |
-| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W28: git worktree list/create/GC/ship extracted; #870 closed |
+| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W30: session mute/unread/plan-pending badges extracted |
 | residual-settings-catalog | settingsCatalog split | **PASS** | domain entries |
 
-Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **14650 / 130 useState / 80 useEffect**; `files_ge_1000` **≤80** (0.2.31 tree count 79; was ≤77 at 0.2.28). #870 closed. Shrink large files in follow-on waves — do not keep raising this budget.
+Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **14200 / 116 useState / 68 useEffect**; `files_ge_1000` **≤80**. Shrink large files in follow-on waves — do not keep raising this budget.

--- a/docs/plans/HANDOFF-appworkbench-decomposition.md
+++ b/docs/plans/HANDOFF-appworkbench-decomposition.md
@@ -60,7 +60,8 @@
    **WP-W26 已落地**：Host AppSettings prefs 水合 → `parseAppSettingsPrefs` + `useAppSettingsPrefs`。locale/composer chips/CLI probe 仍在 boot。天花板见 W27。
    **WP-W27 已落地**：ensureConnected + connecting claims + liveMap 订阅 → `useSessionConnect`。#870 验收：改 settings 导航/prefs/connect 不必打开 host 函数体。天花板 **15350 / 160 / 83**。
    **WP-W28 已落地**：git worktree 列表 / 创建 / GC / ship / switch / remove / 徽章 → `useGitWorktreeChrome`。overlay 收成 `worktreeChrome` 一袋。git dirty 仍在 host，经 `applyStatusBranch` 补 branch chip。天花板 **14650 / 130 / 80**。下一步 Side Workbench。
-   **WP-W29 已落地**：Side Workbench tabs / dock composer / Review focus / close-tab / git probe / chat→side 路由 → `useSideWorkbenchChrome`。host 只填 aside/open/toast 晚绑袋。`sessionChangesById` 与 git dirty 仍在 host。天花板 **14400 / 120 / 74**。方案见 [2026-09-06-appworkbench-w29-side-workbench.md](./2026-09-06-appworkbench-w29-side-workbench.md)。下一步会话徽章（mute / unread / plan-pending）。
+   **WP-W29 已落地**：Side Workbench tabs / dock composer / Review focus / close-tab / git probe / chat→side 路由 → `useSideWorkbenchChrome`。host 只填 aside/open/toast 晚绑袋。`sessionChangesById` 与 git dirty 仍在 host。天花板 **14400 / 120 / 74**。方案见 [2026-09-06-appworkbench-w29-side-workbench.md](./2026-09-06-appworkbench-w29-side-workbench.md)。
+   **WP-W30 已落地**：mute / unread / plan-pending Set、storage 事件、clear-on-view、tray/dock 计数 → `useSessionChromeBadges`。host 只填 tr / setAppDialog / viewing id。plan chrome 仍调 `markPlanPendingBadge`。天花板 **14200 / 116 / 68**。方案见 [2026-09-07-appworkbench-w30-session-badges.md](./2026-09-07-appworkbench-w30-session-badges.md)。下一步账号 / 配额（W31）。
    **pi**：协作者本机无 pi，按 owner 规则跳过。
    **5 个 worktree**：误会。远端 `main` 已含那些产品改动（本地只是 squash 后残留 SHA）。不挡大拆。
 5. 5.6k 行 JSX 拆为 view shell + 域容器；modals 先经既有 `useAppDialogs` 收口。

--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -43,9 +43,9 @@ APP_ORCH_FILES = (
 # Decreasing ceilings at current combined scale. Ratchet down each
 # workbench-extraction WP. The old 6000/100/50 numbers measured the 26-line
 # shell after the God Component was renamed — not a budget to grow into.
-APP_LINES_CEILING = 14400
-APP_USESTATE_CEILING = 120
-APP_USEEFFECT_CEILING = 74
+APP_LINES_CEILING = 14200
+APP_USESTATE_CEILING = 116
+APP_USEEFFECT_CEILING = 68
 
 
 def lines_of(path: Path) -> int:

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -26,6 +26,7 @@ import {
   resolveChatcutLinkClick,
 } from "@/lib/chatcutHandoff";
 import { loadStopAllSkipConfirmPref } from "@/lib/stopAllSkipConfirmPref";
+
 import {
   planStopAllBusySessions,
   stopAllDialogKeys,
@@ -119,7 +120,6 @@ import {
   type ContextUsageState,
 } from "@/lib/contextUsage";
 import {
-  applyPlanPendingMembership,
   closedSessionPlan,
   emptySessionPlan,
   invalidatePlanGate,
@@ -133,7 +133,7 @@ import {
   countQuitBlockingSessions,
   stoppableActivitySessions,
 } from "@/lib/agentActivity";
-import { resolveTrayBusyBadgeCount } from "@/lib/trayNotifyPro";
+
 import {
   collectAgentDashboardRows,
   countBusyDashboardRows,
@@ -302,22 +302,7 @@ import {
   listenForNativeNotifyClicks,
   setDesktopNotifySessionFocusHandler,
 } from "@/lib/desktopNotify";
-import {
-  clearAllMutes as clearAllSessionMutes,
-  loadMutedSessionIds,
-  SESSION_MUTE_CHANGE_EVENT,
-  shouldConfirmClearAllMutes,
-  toggle as toggleSessionMute,
-} from "@/lib/sessionMute";
-import {
-  clearAllUnread as clearAllSessionUnread,
-  clearUnread as clearSessionUnread,
-  isWorkbenchForeground,
-  loadUnreadSessionIds,
-  markUnread as markSessionUnread,
-  SESSION_UNREAD_CHANGE_EVENT,
-  shouldConfirmClearAllUnread,
-} from "@/lib/sessionUnread";
+
 import {
   clearNote as clearSessionNote,
   getNote as getSessionNote,
@@ -646,6 +631,10 @@ import { useSidebarProjectReorder } from "@/hooks/useSidebarProjectReorder";
 import { useSessionMoveProject } from "@/hooks/useSessionMoveProject";
 import { useSidebarSessionMoveDrag } from "@/hooks/useSidebarSessionMoveDrag";
 import {
+  createSessionChromeBadgesHost,
+  useSessionChromeBadges,
+} from "@/hooks/useSessionChromeBadges";
+import {
   createSideWorkbenchChromeHost,
   useSideWorkbenchChrome,
 } from "@/hooks/useSideWorkbenchChrome";
@@ -794,84 +783,6 @@ export function AppWorkbench() {
         /* non-Tauri / server down */
       });
   }, []);
-  /** Per-session desktop notification mute (localStorage Set). */
-  const [mutedSessionIds, setMutedSessionIds] = useState<Set<string>>(
-    () => loadMutedSessionIds(),
-  );
-  useEffect(() => {
-    const onChange = () => setMutedSessionIds(loadMutedSessionIds());
-    window.addEventListener(SESSION_MUTE_CHANGE_EVENT, onChange);
-    return () => window.removeEventListener(SESSION_MUTE_CHANGE_EVENT, onChange);
-  }, []);
-  /**
-   * Sessions that finished a turn while not viewed (localStorage Set).
-   * Independent of mute — muted chats still show the sidebar unread dot.
-   */
-  const [unreadSessionIds, setUnreadSessionIds] = useState<Set<string>>(
-    () => loadUnreadSessionIds(),
-  );
-  useEffect(() => {
-    const onChange = () => setUnreadSessionIds(loadUnreadSessionIds());
-    window.addEventListener(SESSION_UNREAD_CHANGE_EVENT, onChange);
-    return () =>
-      window.removeEventListener(SESSION_UNREAD_CHANGE_EVENT, onChange);
-  }, []);
-  /**
-   * Clear one session's unread marker and sync React state immediately so
-   * sidebar dots + dock/tray badge count drop without waiting solely on the
-   * storage CustomEvent (open / focus / mark-as-read paths share this).
-   */
-  const applyClearSessionUnread = useCallback(
-    (sessionId: string | null | undefined) => {
-      const id = typeof sessionId === "string" ? sessionId.trim() : "";
-      if (!id) return;
-      clearSessionUnread(id);
-      setUnreadSessionIds((prev) => {
-        if (!prev.has(id)) return prev;
-        const next = new Set(prev);
-        next.delete(id);
-        return next;
-      });
-    },
-    [],
-  );
-  /**
-   * Manual "mark as unread" while the chat is still open: hold the badge until
-   * the user leaves and re-opens the thread (auto clear-on-view still applies).
-   */
-  const manualUnreadHoldIdsRef = useRef<Set<string>>(new Set());
-  const applyMarkSessionUnread = useCallback(
-    (sessionId: string | null | undefined) => {
-      const id = typeof sessionId === "string" ? sessionId.trim() : "";
-      if (!id) return;
-      markSessionUnread(id);
-      setUnreadSessionIds((prev) => {
-        if (prev.has(id)) return prev;
-        const next = new Set(prev);
-        next.add(id);
-        return next;
-      });
-      if (viewingSessionIdRef.current === id) {
-        manualUnreadHoldIdsRef.current.add(id);
-      }
-    },
-    [],
-  );
-  /**
-   * Sessions with an open plan review gate (or restored re-park wait).
-   * Sidebar badge only — does not change open/busy/select interactions.
-   */
-  const [planPendingSessionIds, setPlanPendingSessionIds] = useState<
-    Set<string>
-  >(() => new Set());
-  const markPlanPendingBadge = useCallback(
-    (sessionId: string | null | undefined, plan: SessionPlanState) => {
-      setPlanPendingSessionIds((prev) =>
-        applyPlanPendingMembership(prev, sessionId, plan),
-      );
-    },
-    [],
-  );
   const {
     appDialog,
     setAppDialog,
@@ -1033,6 +944,25 @@ export function AppWorkbench() {
     effectiveCanStop,
     transcriptMeta,
   } = useSessionRuntime({ isSecondaryWindow });
+  const sessionChromeBadgesHostRef = useRef(createSessionChromeBadgesHost());
+  const {
+    mutedSessionIds,
+    unreadSessionIds,
+    planPendingSessionIds,
+    applyClearSessionUnread,
+    markPlanPendingBadge,
+    handleToggleSessionMute,
+    handleClearSessionUnread,
+    handleMarkSessionUnread,
+    handleClearAllSessionUnread,
+    handleClearAllSessionMutes,
+  } = useSessionChromeBadges({
+    hostRef: sessionChromeBadgesHostRef,
+    viewedSessionId: session.sessionId,
+    isSecondaryWindow,
+    trayBusyBadge,
+    winTaskbarOverlay,
+  });
 
   /** Context usage chip — known tokens from compact events + estimate fallback. */
   const [contextUsage, setContextUsage] = useState<ContextUsageState>(
@@ -2373,32 +2303,6 @@ export function AppWorkbench() {
       cancelled = true;
     };
   }, []);
-
-  // Dock / tray badge: unread sessions that finished a turn in the background.
-  // Only updates after turn end (markUnread), never on send / while streaming.
-  // Secondary windows must not overwrite the dock badge (main owns chrome).
-  // Count is clamped for display (TRAY-NOTIFY-PRO); pref off clears to 0.
-  useEffect(() => {
-    const resolved = resolveTrayBusyBadgeCount({
-      enabled: trayBusyBadge,
-      busyCount: unreadSessionIds.size,
-      isSecondaryWindow,
-    });
-    if (!resolved.apply) return;
-    void api.traySetBusyCount(resolved.count);
-  }, [unreadSessionIds.size, trayBusyBadge, isSecondaryWindow]);
-
-  // Windows taskbar *button* overlay: independent of trayBusyBadge (default off).
-  // Secondary windows must not apply. Pref off sends 0 (clear).
-  useEffect(() => {
-    const resolved = resolveTrayBusyBadgeCount({
-      enabled: winTaskbarOverlay,
-      busyCount: unreadSessionIds.size,
-      isSecondaryWindow,
-    });
-    if (!resolved.apply) return;
-    void api.traySetWindowsOverlay(resolved.count);
-  }, [unreadSessionIds.size, winTaskbarOverlay, isSecondaryWindow]);
 
   const applyComposerPrefs = useCallback(
     (prefs: api.ComposerPrefs, catalog: ModelOption[]) => {
@@ -5419,116 +5323,6 @@ export function AppWorkbench() {
     }),
     [tr],
   );
-
-  const handleToggleSessionMute = useCallback((sessionId: string) => {
-    toggleSessionMute(sessionId);
-    setMutedSessionIds(loadMutedSessionIds());
-  }, []);
-
-  const applyClearAllSessionUnread = useCallback(() => {
-    clearAllSessionUnread();
-    manualUnreadHoldIdsRef.current.clear();
-    setUnreadSessionIds(loadUnreadSessionIds());
-  }, []);
-
-  const handleClearAllSessionUnread = useCallback(() => {
-    const n = unreadSessionIds.size;
-    if (n <= 0) {
-      return;
-    }
-    if (shouldConfirmClearAllUnread(n)) {
-      setAppDialog({
-        kind: "confirm",
-        title: tr("session.clearAllUnreadTitle"),
-        message: tr("session.clearAllUnreadBody", { n: String(n) }),
-        confirmLabel: tr("session.clearAllUnreadAction"),
-        onConfirm: () => {
-          applyClearAllSessionUnread();
-        },
-      });
-      return;
-    }
-    applyClearAllSessionUnread();
-  }, [unreadSessionIds.size, tr, applyClearAllSessionUnread]);
-
-  const applyClearAllSessionMutes = useCallback(() => {
-    clearAllSessionMutes();
-    setMutedSessionIds(loadMutedSessionIds());
-  }, []);
-
-  const handleClearAllSessionMutes = useCallback(() => {
-    const n = mutedSessionIds.size;
-    if (n <= 0) {
-      return;
-    }
-    if (shouldConfirmClearAllMutes(n)) {
-      setAppDialog({
-        kind: "confirm",
-        title: tr("session.clearAllMutesTitle"),
-        message: tr("session.clearAllMutesBody", { n: String(n) }),
-        confirmLabel: tr("session.clearAllMutesAction"),
-        onConfirm: () => {
-          applyClearAllSessionMutes();
-        },
-      });
-      return;
-    }
-    applyClearAllSessionMutes();
-  }, [mutedSessionIds.size, tr, applyClearAllSessionMutes]);
-
-  const handleClearSessionUnread = useCallback(
-    (sessionId: string) => {
-      // Explicit "mark as read" also drops any manual hold.
-      manualUnreadHoldIdsRef.current.delete(sessionId);
-      applyClearSessionUnread(sessionId);
-    },
-    [applyClearSessionUnread],
-  );
-
-  const handleMarkSessionUnread = useCallback(
-    (sessionId: string) => {
-      applyMarkSessionUnread(sessionId);
-    },
-    [applyMarkSessionUnread],
-  );
-
-  // Binding a session while the workbench is in front clears its unread
-  // (sidebar + dock/tray badge + pet done-bubble). Hidden / unfocused
-  // windows are not a read — the bubble stays until they click it or
-  // actually view this chat with the window focused.
-  useEffect(() => {
-    if (!session.sessionId) return;
-    manualUnreadHoldIdsRef.current.delete(session.sessionId);
-    if (!isWorkbenchForeground()) return;
-    applyClearSessionUnread(session.sessionId);
-  }, [session.sessionId, applyClearSessionUnread]);
-
-  // Dock/taskbar or OS focus while already on a finished chat: clear that
-  // session's unread so the badge and pet bubble drop without re-clicking.
-  useEffect(() => {
-    const clearViewingIfPresent = () => {
-      const id = viewingSessionIdRef.current;
-      if (!id) return;
-      // Keep manual "mark as unread" until the user leaves this thread.
-      if (manualUnreadHoldIdsRef.current.has(id)) return;
-      if (!isWorkbenchForeground()) return;
-      applyClearSessionUnread(id);
-    };
-    const onVis = () => {
-      if (
-        typeof document !== "undefined" &&
-        document.visibilityState === "visible"
-      ) {
-        clearViewingIfPresent();
-      }
-    };
-    window.addEventListener("focus", clearViewingIfPresent);
-    document.addEventListener("visibilitychange", onVis);
-    return () => {
-      window.removeEventListener("focus", clearViewingIfPresent);
-      document.removeEventListener("visibilitychange", onVis);
-    };
-  }, [applyClearSessionUnread]);
 
   const openProjectMenu = (e: ReactMouseEvent, proj: Project) => {
     e.preventDefault();
@@ -10124,6 +9918,12 @@ export function AppWorkbench() {
     h.setResourceOpenTarget = setResourceOpenTarget;
     h.setPlanFocusKey = setPlanFocusKey;
     h.asideCollapsed = () => layoutRef.current.asideCollapsed;
+  }
+  {
+    const h = sessionChromeBadgesHostRef.current;
+    h.tr = tr;
+    h.setAppDialog = setAppDialog;
+    h.viewingSessionId = () => viewingSessionIdRef.current;
   }
 
   /**

--- a/src/hooks/useSessionChromeBadges.test.ts
+++ b/src/hooks/useSessionChromeBadges.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Mute / unread / plan-pending live here. Host supplies tr, dialog, viewing id.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { createT } from "@/i18n";
+import * as api from "@/lib/api";
+import { emptySessionPlan } from "@/lib/planSession";
+import {
+  SESSION_MUTE_STORAGE_KEY,
+  toggle as toggleSessionMute,
+} from "@/lib/sessionMute";
+import {
+  SESSION_UNREAD_STORAGE_KEY,
+  isWorkbenchForeground,
+  markUnread,
+} from "@/lib/sessionUnread";
+import {
+  createSessionChromeBadgesHost,
+  useSessionChromeBadges,
+} from "./useSessionChromeBadges";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    traySetBusyCount: vi.fn(async () => {}),
+    traySetWindowsOverlay: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("@/lib/sessionUnread", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/sessionUnread")>(
+      "@/lib/sessionUnread",
+    );
+  return {
+    ...actual,
+    isWorkbenchForeground: vi.fn(() => true),
+  };
+});
+
+function setup(opts?: {
+  viewedSessionId?: string | null;
+  viewingSessionId?: string | null;
+  isSecondaryWindow?: boolean;
+  trayBusyBadge?: boolean;
+}) {
+  const host = createSessionChromeBadgesHost();
+  host.tr = createT("en");
+  host.setAppDialog = vi.fn();
+  host.viewingSessionId = () => opts?.viewingSessionId ?? opts?.viewedSessionId ?? null;
+  const hostRef = { current: host };
+  const hook = renderHook(
+    (props: { viewedSessionId: string | null }) =>
+      useSessionChromeBadges({
+        hostRef,
+        viewedSessionId: props.viewedSessionId,
+        isSecondaryWindow: opts?.isSecondaryWindow ?? false,
+        trayBusyBadge: opts?.trayBusyBadge ?? true,
+        winTaskbarOverlay: false,
+      }),
+    {
+      initialProps: {
+        viewedSessionId: opts?.viewedSessionId ?? null,
+      },
+    },
+  );
+  return { ...hook, host };
+}
+
+describe("useSessionChromeBadges", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(isWorkbenchForeground).mockReturnValue(true);
+    vi.mocked(api.traySetBusyCount).mockClear();
+    vi.mocked(api.traySetWindowsOverlay).mockClear();
+  });
+
+  it("hydrates mute from storage and follows the change event", () => {
+    localStorage.setItem(SESSION_MUTE_STORAGE_KEY, JSON.stringify(["a"]));
+    const { result } = setup();
+    expect(result.current.mutedSessionIds.has("a")).toBe(true);
+    act(() => {
+      toggleSessionMute("b");
+    });
+    expect(result.current.mutedSessionIds.has("b")).toBe(true);
+  });
+
+  it("applyClearSessionUnread drops the id immediately", () => {
+    localStorage.setItem(SESSION_UNREAD_STORAGE_KEY, JSON.stringify(["s1"]));
+    const { result } = setup({ viewedSessionId: null });
+    expect(result.current.unreadSessionIds.has("s1")).toBe(true);
+    act(() => {
+      result.current.applyClearSessionUnread("s1");
+    });
+    expect(result.current.unreadSessionIds.has("s1")).toBe(false);
+  });
+
+  it("keeps a manual unread hold while that chat is still viewed", () => {
+    const { result } = setup({
+      viewedSessionId: "s1",
+      viewingSessionId: "s1",
+    });
+    act(() => {
+      result.current.applyMarkSessionUnread("s1");
+    });
+    expect(result.current.unreadSessionIds.has("s1")).toBe(true);
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(result.current.unreadSessionIds.has("s1")).toBe(true);
+  });
+
+  it("clears unread when binding a foreground session", () => {
+    localStorage.setItem(SESSION_UNREAD_STORAGE_KEY, JSON.stringify(["s2"]));
+    const { result, rerender } = setup({ viewedSessionId: null });
+    expect(result.current.unreadSessionIds.has("s2")).toBe(true);
+    act(() => {
+      rerender({ viewedSessionId: "s2" });
+    });
+    expect(result.current.unreadSessionIds.has("s2")).toBe(false);
+  });
+
+  it("markPlanPendingBadge follows the plan review gate", () => {
+    const { result } = setup();
+    const pending = { ...emptySessionPlan("t"), rpcId: 7 };
+    act(() => {
+      result.current.markPlanPendingBadge("s1", pending);
+    });
+    expect(result.current.planPendingSessionIds.has("s1")).toBe(true);
+    act(() => {
+      result.current.markPlanPendingBadge("s1", emptySessionPlan("t"));
+    });
+    expect(result.current.planPendingSessionIds.has("s1")).toBe(false);
+  });
+
+  it("asks for confirm when clearing more unread than the threshold", () => {
+    localStorage.setItem(
+      SESSION_UNREAD_STORAGE_KEY,
+      JSON.stringify(["a", "b", "c", "d"]),
+    );
+    const { result, host } = setup({ viewedSessionId: null });
+    act(() => {
+      result.current.handleClearAllSessionUnread();
+    });
+    expect(host.setAppDialog).toHaveBeenCalled();
+    expect(result.current.unreadSessionIds.size).toBe(4);
+  });
+
+  it("pushes unread count to the tray on the main window", () => {
+    markUnread("bg");
+    setup({ viewedSessionId: null, trayBusyBadge: true });
+    expect(api.traySetBusyCount).toHaveBeenCalled();
+    const last = vi.mocked(api.traySetBusyCount).mock.calls.at(-1);
+    expect(last?.[0]).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/hooks/useSessionChromeBadges.ts
+++ b/src/hooks/useSessionChromeBadges.ts
@@ -1,0 +1,295 @@
+/**
+ * Session chrome badges: mute, unread, plan-pending.
+ *
+ * Owns the Sets, localStorage sync, clear-on-view, and dock/tray count.
+ * Host fills {@link SessionChromeBadgesHost} in place so tr / dialog /
+ * viewing-id stay late-bound. Plan chrome still lives on the host and
+ * only calls {@link markPlanPendingBadge}.
+ */
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
+import { createT } from "@/i18n";
+import * as api from "@/lib/api";
+import type { AppDialog } from "@/lib/app/appDialogTypes";
+import {
+  applyPlanPendingMembership,
+  type SessionPlanState,
+} from "@/lib/planSession";
+import {
+  clearAllMutes as clearAllSessionMutes,
+  loadMutedSessionIds,
+  SESSION_MUTE_CHANGE_EVENT,
+  shouldConfirmClearAllMutes,
+  toggle as toggleSessionMute,
+} from "@/lib/sessionMute";
+import {
+  clearAllUnread as clearAllSessionUnread,
+  clearUnread as clearSessionUnread,
+  isWorkbenchForeground,
+  loadUnreadSessionIds,
+  markUnread as markSessionUnread,
+  SESSION_UNREAD_CHANGE_EVENT,
+  shouldConfirmClearAllUnread,
+} from "@/lib/sessionUnread";
+import { resolveTrayBusyBadgeCount } from "@/lib/trayNotifyPro";
+
+type TFn = ReturnType<typeof createT>;
+
+export type SessionChromeBadgesHost = {
+  tr: TFn;
+  setAppDialog: (dialog: AppDialog) => void;
+  viewingSessionId: () => string | null | undefined;
+};
+
+function emptyHost(): SessionChromeBadgesHost {
+  const noop = () => {};
+  return {
+    tr: ((k: string) => k) as TFn,
+    setAppDialog: noop,
+    viewingSessionId: () => null,
+  };
+}
+
+export function createSessionChromeBadgesHost(): SessionChromeBadgesHost {
+  return emptyHost();
+}
+
+export function useSessionChromeBadges(opts: {
+  hostRef: MutableRefObject<SessionChromeBadgesHost>;
+  viewedSessionId: string | null | undefined;
+  isSecondaryWindow: boolean;
+  trayBusyBadge: boolean;
+  winTaskbarOverlay: boolean;
+}) {
+  const hostRef = opts.hostRef;
+
+  const [mutedSessionIds, setMutedSessionIds] = useState<Set<string>>(
+    () => loadMutedSessionIds(),
+  );
+  useEffect(() => {
+    const onChange = () => setMutedSessionIds(loadMutedSessionIds());
+    window.addEventListener(SESSION_MUTE_CHANGE_EVENT, onChange);
+    return () => window.removeEventListener(SESSION_MUTE_CHANGE_EVENT, onChange);
+  }, []);
+
+  /**
+   * Sessions that finished a turn while not viewed (localStorage Set).
+   * Independent of mute — muted chats still show the sidebar unread dot.
+   */
+  const [unreadSessionIds, setUnreadSessionIds] = useState<Set<string>>(
+    () => loadUnreadSessionIds(),
+  );
+  useEffect(() => {
+    const onChange = () => setUnreadSessionIds(loadUnreadSessionIds());
+    window.addEventListener(SESSION_UNREAD_CHANGE_EVENT, onChange);
+    return () =>
+      window.removeEventListener(SESSION_UNREAD_CHANGE_EVENT, onChange);
+  }, []);
+
+  /**
+   * Clear one session's unread marker and sync React state immediately so
+   * sidebar dots + dock/tray badge count drop without waiting solely on the
+   * storage CustomEvent (open / focus / mark-as-read paths share this).
+   */
+  const applyClearSessionUnread = useCallback(
+    (sessionId: string | null | undefined) => {
+      const id = typeof sessionId === "string" ? sessionId.trim() : "";
+      if (!id) return;
+      clearSessionUnread(id);
+      setUnreadSessionIds((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    },
+    [],
+  );
+
+  /**
+   * Manual "mark as unread" while the chat is still open: hold the badge until
+   * the user leaves and re-opens the thread (auto clear-on-view still applies).
+   */
+  const manualUnreadHoldIdsRef = useRef<Set<string>>(new Set());
+  const applyMarkSessionUnread = useCallback(
+    (sessionId: string | null | undefined) => {
+      const id = typeof sessionId === "string" ? sessionId.trim() : "";
+      if (!id) return;
+      markSessionUnread(id);
+      setUnreadSessionIds((prev) => {
+        if (prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.add(id);
+        return next;
+      });
+      if (hostRef.current.viewingSessionId() === id) {
+        manualUnreadHoldIdsRef.current.add(id);
+      }
+    },
+    [hostRef],
+  );
+
+  /**
+   * Sessions with an open plan review gate (or restored re-park wait).
+   * Sidebar badge only — does not change open/busy/select interactions.
+   */
+  const [planPendingSessionIds, setPlanPendingSessionIds] = useState<
+    Set<string>
+  >(() => new Set());
+  const markPlanPendingBadge = useCallback(
+    (sessionId: string | null | undefined, plan: SessionPlanState) => {
+      setPlanPendingSessionIds((prev) =>
+        applyPlanPendingMembership(prev, sessionId, plan),
+      );
+    },
+    [],
+  );
+
+  const handleToggleSessionMute = useCallback((sessionId: string) => {
+    toggleSessionMute(sessionId);
+    setMutedSessionIds(loadMutedSessionIds());
+  }, []);
+
+  const applyClearAllUnread = useCallback(() => {
+    clearAllSessionUnread();
+    manualUnreadHoldIdsRef.current.clear();
+    setUnreadSessionIds(loadUnreadSessionIds());
+  }, []);
+
+  const handleClearAllSessionUnread = useCallback(() => {
+    const n = unreadSessionIds.size;
+    if (n <= 0) return;
+    const h = hostRef.current;
+    if (shouldConfirmClearAllUnread(n)) {
+      h.setAppDialog({
+        kind: "confirm",
+        title: h.tr("session.clearAllUnreadTitle"),
+        message: h.tr("session.clearAllUnreadBody", { n: String(n) }),
+        confirmLabel: h.tr("session.clearAllUnreadAction"),
+        onConfirm: () => {
+          applyClearAllUnread();
+        },
+      });
+      return;
+    }
+    applyClearAllUnread();
+  }, [unreadSessionIds.size, hostRef, applyClearAllUnread]);
+
+  const applyClearAllMutes = useCallback(() => {
+    clearAllSessionMutes();
+    setMutedSessionIds(loadMutedSessionIds());
+  }, []);
+
+  const handleClearAllSessionMutes = useCallback(() => {
+    const n = mutedSessionIds.size;
+    if (n <= 0) return;
+    const h = hostRef.current;
+    if (shouldConfirmClearAllMutes(n)) {
+      h.setAppDialog({
+        kind: "confirm",
+        title: h.tr("session.clearAllMutesTitle"),
+        message: h.tr("session.clearAllMutesBody", { n: String(n) }),
+        confirmLabel: h.tr("session.clearAllMutesAction"),
+        onConfirm: () => {
+          applyClearAllMutes();
+        },
+      });
+      return;
+    }
+    applyClearAllMutes();
+  }, [mutedSessionIds.size, hostRef, applyClearAllMutes]);
+
+  const handleClearSessionUnread = useCallback(
+    (sessionId: string) => {
+      manualUnreadHoldIdsRef.current.delete(sessionId);
+      applyClearSessionUnread(sessionId);
+    },
+    [applyClearSessionUnread],
+  );
+
+  const handleMarkSessionUnread = useCallback(
+    (sessionId: string) => {
+      applyMarkSessionUnread(sessionId);
+    },
+    [applyMarkSessionUnread],
+  );
+
+  // Binding a session while the workbench is in front clears its unread
+  // (sidebar + dock/tray badge + pet done-bubble). Hidden / unfocused
+  // windows are not a read — the bubble stays until they click it or
+  // actually view this chat with the window focused.
+  useEffect(() => {
+    if (!opts.viewedSessionId) return;
+    manualUnreadHoldIdsRef.current.delete(opts.viewedSessionId);
+    if (!isWorkbenchForeground()) return;
+    applyClearSessionUnread(opts.viewedSessionId);
+  }, [opts.viewedSessionId, applyClearSessionUnread]);
+
+  // Dock/taskbar or OS focus while already on a finished chat: clear that
+  // session's unread so the badge and pet bubble drop without re-clicking.
+  useEffect(() => {
+    const clearViewingIfPresent = () => {
+      const id = hostRef.current.viewingSessionId();
+      if (!id) return;
+      if (manualUnreadHoldIdsRef.current.has(id)) return;
+      if (!isWorkbenchForeground()) return;
+      applyClearSessionUnread(id);
+    };
+    const onVis = () => {
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "visible"
+      ) {
+        clearViewingIfPresent();
+      }
+    };
+    window.addEventListener("focus", clearViewingIfPresent);
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      window.removeEventListener("focus", clearViewingIfPresent);
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, [applyClearSessionUnread, hostRef]);
+
+  // Dock / tray badge: unread sessions that finished a turn in the background.
+  // Secondary windows must not overwrite the dock badge (main owns chrome).
+  useEffect(() => {
+    const resolved = resolveTrayBusyBadgeCount({
+      enabled: opts.trayBusyBadge,
+      busyCount: unreadSessionIds.size,
+      isSecondaryWindow: opts.isSecondaryWindow,
+    });
+    if (!resolved.apply) return;
+    void api.traySetBusyCount(resolved.count);
+  }, [unreadSessionIds.size, opts.trayBusyBadge, opts.isSecondaryWindow]);
+
+  // Windows taskbar overlay: independent of trayBusyBadge (default off).
+  useEffect(() => {
+    const resolved = resolveTrayBusyBadgeCount({
+      enabled: opts.winTaskbarOverlay,
+      busyCount: unreadSessionIds.size,
+      isSecondaryWindow: opts.isSecondaryWindow,
+    });
+    if (!resolved.apply) return;
+    void api.traySetWindowsOverlay(resolved.count);
+  }, [unreadSessionIds.size, opts.winTaskbarOverlay, opts.isSecondaryWindow]);
+
+  return {
+    mutedSessionIds,
+    unreadSessionIds,
+    planPendingSessionIds,
+    applyClearSessionUnread,
+    applyMarkSessionUnread,
+    markPlanPendingBadge,
+    handleToggleSessionMute,
+    handleClearSessionUnread,
+    handleMarkSessionUnread,
+    handleClearAllSessionUnread,
+    handleClearAllSessionMutes,
+  };
+}


### PR DESCRIPTION
## Summary
WP-W30 of AppWorkbench decomposition. Mute / unread / plan-pending Sets, storage events, clear-on-view, and tray/dock counts move into `useSessionChromeBadges`. Host fills a late-bound tr / dialog / viewing bag. Plan chrome stays on the host and only calls `markPlanPendingBadge`.

Closes #1053

## Metrics (vs current main)
- Orchestration lines 14262 → 14062
- useState 116 → 113
- useEffect 71 → 65
- APP_* ceilings 14400/120/74 → 14200/116/68
- New hook 295 lines (under 1000)

## Type of change
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` and hook vitest (7 tests)
- [x] `python scripts/check-code-quality-gates.py --mode final` PASS
- [x] `pnpm exec eslint` on changed TS (max-warnings 0)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] Docs / HANDOFF + CODE-QUALITY-PROGRESS + W30 plan updated
- [x] No secrets

## Notes
- `sessionChangesById` and git dirty stay on the host.
- Next suggested cut: account / quota (W31).