### PR TITLE
refactor(workbench): extract account and quota chrome

### DIFF
--- a/docs/plans/2026-09-07-appworkbench-w31-account-quota.md
+++ b/docs/plans/2026-09-07-appworkbench-w31-account-quota.md
@@ -1,0 +1,40 @@
+# AppWorkbench 继续拆解 — WP-W31 账号 / 配额
+
+**日期**：2026-09-07  
+**基线**：`origin/main` @ `3ec81c67`（W30 #1054）  
+**来源**：HANDOFF · W29 表「W31 账号 / 配额」  
+**执行位置**：worktree `D:/code/grok-app-appworkbench-w30-session-badges` · 分支 `refactor/appworkbench-w31-account-quota`
+
+---
+
+## 1. 问题
+
+`account` 快照、loading/busy、heatmap/probe error、loginHint、已存账号 / 额度表、boot 缓存再 refresh、登录切换登出仍堆在 host。已有 `useAccountQuotaAutoRefresh` 只管 10 分钟 tick，投影 state 仍回流。
+
+---
+
+## 2. 本刀
+
+新建 `src/hooks/useAccountQuotaChrome.ts`：
+
+自持：account 快照 + loading/busy + errors + loginHint + savedAccounts / activeId / quotas；`refreshAccount*`；boot 两段 refresh；Account 设置页打开时 refresh；10 分钟 auto-refresh；login / logout / switch / save / add / remove / cancel / paste code。
+
+晚绑 host：`tr` · `showToast` · `setAppDialog` · `noteAccountConnected`（写 setup.auth/cli）· `resetFocusedSession`（登录成功后 IDLE 壳）。
+
+入参：`manualCliPath`、`accountSettingsOpen`。
+
+**不抽**：`importChatTranscript`（会话导入，只借用 busy 动词）；provider 余额；setup / boot 闸门（W33）。
+
+---
+
+## 3. 后续
+
+实测（W31 接线后）：
+
+| | W30 main | W31 worktree | 新天花板 |
+|--|----------|--------------|----------|
+| 行数 | 14062 | **13759** | 14200 → **13900** |
+| useState | 113 | **104** | 116 → **108** |
+| useEffect | 65 | **63** | 68 → **66** |
+
+其后 W32 MCP doctor → W33 setup / boot。

--- a/docs/plans/CODE-QUALITY-PROGRESS.md
+++ b/docs/plans/CODE-QUALITY-PROGRESS.md
@@ -12,7 +12,7 @@
 | Spec | `docs/plans/2026-08-01-code-quality-remediation-GOAL.md` |
 | Started | `2026-08-01` |
 | Current wave | `workbench-decomp` |
-| Current WP | `WP-W30` |
+| Current WP | `WP-W31` |
 | **FINAL** | **PASS** (honest orchestration metrics; decreasing ceilings) |
 
 ## Wave checklist
@@ -76,6 +76,7 @@
 | WP-W28 | Git worktree + ship chrome into useGitWorktreeChrome | PASS |  | #1033; 15237→14416 lines; useState 154→122; useEffect 78→75 |
 | WP-W29 | Side Workbench chrome into useSideWorkbenchChrome | PASS |  | #1042; 14416→14258 lines; useState 122→116; useEffect 75→71; plan `docs/plans/2026-09-06-appworkbench-w29-side-workbench.md` |
 | WP-W30 | Session chrome badges into useSessionChromeBadges | PASS |  | main@#1050 14262→14062 lines; useState 116→113; useEffect 71→65; plan `docs/plans/2026-09-07-appworkbench-w30-session-badges.md` |
+| WP-W31 | Account / quota chrome into useAccountQuotaChrome | PASS |  | 14062→13759 lines; useState 113→104; useEffect 65→63; plan `docs/plans/2026-09-07-appworkbench-w31-account-quota.md` |
 
 ## Metrics log (append-only)
 
@@ -117,6 +118,7 @@
 | 2026-09-05 W28 | 14416 (shell 21 + wb 14395) | 122 | 75 | 12 | dir | dir | 29 | 9 | 80 |
 | 2026-09-06 W29 | 14258 (shell 21 + wb 14237) | 116 | 71 | 12 | dir | dir | 29 | 9 | 80 |
 | 2026-09-07 W30 | 14062 (shell 21 + wb 14041) | 113 | 65 | 12 | dir | dir | 29 | 9 | 80 |
+| 2026-09-07 W31 | 13759 (shell 21 + wb 13738) | 104 | 63 | 12 | dir | dir | 29 | 9 | 80 |
 
 ## Blockers
 
@@ -142,7 +144,7 @@ Parallel non-overlapping tracks (multi-agent) — **landed**:
 | residual-resource-viewer | ResourceViewer + parts | **PASS** | 4938→modules |
 | residual-i18n | `src/i18n/**` | **PASS** | domain modules + barrels |
 | residual-settings | SettingsPage + settings/* | **PASS** | 8874→1817 |
-| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W30: session mute/unread/plan-pending badges extracted |
+| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W31: account snapshot / login / quota extracted |
 | residual-settings-catalog | settingsCatalog split | **PASS** | domain entries |
 
-Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **14200 / 116 useState / 68 useEffect**; `files_ge_1000` **≤80**. Shrink large files in follow-on waves — do not keep raising this budget.
+Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **13900 / 108 useState / 66 useEffect**; `files_ge_1000` **≤80**. Shrink large files in follow-on waves — do not keep raising this budget.

--- a/docs/plans/HANDOFF-appworkbench-decomposition.md
+++ b/docs/plans/HANDOFF-appworkbench-decomposition.md
@@ -61,7 +61,8 @@
    **WP-W27 已落地**：ensureConnected + connecting claims + liveMap 订阅 → `useSessionConnect`。#870 验收：改 settings 导航/prefs/connect 不必打开 host 函数体。天花板 **15350 / 160 / 83**。
    **WP-W28 已落地**：git worktree 列表 / 创建 / GC / ship / switch / remove / 徽章 → `useGitWorktreeChrome`。overlay 收成 `worktreeChrome` 一袋。git dirty 仍在 host，经 `applyStatusBranch` 补 branch chip。天花板 **14650 / 130 / 80**。下一步 Side Workbench。
    **WP-W29 已落地**：Side Workbench tabs / dock composer / Review focus / close-tab / git probe / chat→side 路由 → `useSideWorkbenchChrome`。host 只填 aside/open/toast 晚绑袋。`sessionChangesById` 与 git dirty 仍在 host。天花板 **14400 / 120 / 74**。方案见 [2026-09-06-appworkbench-w29-side-workbench.md](./2026-09-06-appworkbench-w29-side-workbench.md)。
-   **WP-W30 已落地**：mute / unread / plan-pending Set、storage 事件、clear-on-view、tray/dock 计数 → `useSessionChromeBadges`。host 只填 tr / setAppDialog / viewing id。plan chrome 仍调 `markPlanPendingBadge`。天花板 **14200 / 116 / 68**。方案见 [2026-09-07-appworkbench-w30-session-badges.md](./2026-09-07-appworkbench-w30-session-badges.md)。下一步账号 / 配额（W31）。
+   **WP-W30 已落地**：mute / unread / plan-pending Set、storage 事件、clear-on-view、tray/dock 计数 → `useSessionChromeBadges`。host 只填 tr / setAppDialog / viewing id。plan chrome 仍调 `markPlanPendingBadge`。天花板 **14200 / 116 / 68**。方案见 [2026-09-07-appworkbench-w30-session-badges.md](./2026-09-07-appworkbench-w30-session-badges.md)。
+   **WP-W31 已落地**：account 快照 / loading / loginHint / 已存账号 / 配额表 / 登录切换登出 / boot refresh → `useAccountQuotaChrome`。host 只填 toast / dialog / setup.auth / IDLE 壳。天花板 **13900 / 108 / 66**。方案见 [2026-09-07-appworkbench-w31-account-quota.md](./2026-09-07-appworkbench-w31-account-quota.md)。下一步 MCP doctor（W32）。
    **pi**：协作者本机无 pi，按 owner 规则跳过。
    **5 个 worktree**：误会。远端 `main` 已含那些产品改动（本地只是 squash 后残留 SHA）。不挡大拆。
 5. 5.6k 行 JSX 拆为 view shell + 域容器；modals 先经既有 `useAppDialogs` 收口。

--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -43,9 +43,9 @@ APP_ORCH_FILES = (
 # Decreasing ceilings at current combined scale. Ratchet down each
 # workbench-extraction WP. The old 6000/100/50 numbers measured the 26-line
 # shell after the God Component was renamed — not a budget to grow into.
-APP_LINES_CEILING = 14200
-APP_USESTATE_CEILING = 116
-APP_USEEFFECT_CEILING = 68
+APP_LINES_CEILING = 13900
+APP_USESTATE_CEILING = 108
+APP_USEEFFECT_CEILING = 66
 
 
 def lines_of(path: Path) -> int:

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -16,10 +16,6 @@ import { useFloatingMenu } from "@/lib/floatingMenu";
 import { restoreSessionGate } from "@/lib/sessionGateRestore";
 import { DEFAULT_WALLPAPER_FOCUS } from "@/lib/themeSkin";
 import { formatRelativeTime } from "@/lib/accountUi";
-import {
-  canFetchOfficialQuota,
-  mergeAccountStatusPreservingLocalUsage,
-} from "@/lib/accountQuotaRefresh";
 import { loadConfirmExternalLinksPref } from "@/lib/externalLinkPref";
 import {
   chatcutHandoffToResourceOpenTarget,
@@ -583,16 +579,12 @@ import {
   preferPermissionFocus,
   trapTabKey,
 } from "@/lib/a11yFocus";
-import {
-  quotaFromHostItem,
-  type SwitcherQuota,
-} from "@/lib/accountSwitcherQuota";
+
 import {
   type SettingsSectionId,
 } from "@/components/SettingsPage";
 import { isSettingsSectionId } from "@/lib/settingsCatalog";
 import {
-  isAccountConnected,
   loadCachedSuperGrokBrand,
   resolveWelcomeBrandKind,
   saveCachedSuperGrokBrand,
@@ -661,7 +653,10 @@ import { useAppDialogs } from "@/hooks/useAppDialogs";
 import { useSessionHostEvents } from "@/hooks/useSessionHostEvents";
 import { useSessionSpend } from "@/hooks/useSessionSpend";
 import { useGhostStreamingHeal } from "@/hooks/useGhostStreamingHeal";
-import { useAccountQuotaAutoRefresh } from "@/hooks/useAccountQuotaAutoRefresh";
+import {
+  createAccountQuotaChromeHost,
+  useAccountQuotaChrome,
+} from "@/hooks/useAccountQuotaChrome";
 import { useWorkbenchDisplayPrefs } from "@/hooks/useWorkbenchDisplayPrefs";
 import { useWorkbenchLayout } from "@/hooks/useWorkbenchLayout";
 import { useSettingsNavigation } from "@/hooks/useSettingsNavigation";
@@ -1593,11 +1588,6 @@ export function AppWorkbench() {
   }, [appGate]);
   /** In-conversation find (Cmd/Ctrl+F) — not the palette/session search. */
   const [showChatFind, setShowChatFind] = useState(false);
-  const [savedAccounts, setSavedAccounts] = useState<api.SavedAccount[]>([]);
-  const [activeAccountId, setActiveAccountId] = useState<string | null>(null);
-  const [accountQuotas, setAccountQuotas] = useState<
-    Record<string, SwitcherQuota>
-  >({});
   const [perm, setPerm] = useState<PermissionPayload | null>(null);
   const permBarRef = useRef<HTMLDivElement | null>(null);
   const [askUser, setAskUser] = useState<AskUserPayload | null>(null);
@@ -2110,18 +2100,39 @@ export function AppWorkbench() {
     asideInFlow: !phoneLayout && !hideChatForSideExpand && !asideOverlay,
     sideExpanded: hideChatForSideExpand,
   });
-  const [account, setAccount] = useState<api.AccountStatus | null>(null);
+  const accountQuotaHostRef = useRef(createAccountQuotaChromeHost());
+  const {
+    account,
+    accountLoading,
+    accountBusy,
+    accountHeatmapError,
+    accountProbeError,
+    loginHint,
+    savedAccounts,
+    activeAccountId,
+    accountQuotas,
+    applyAccountSnapshot,
+    runWithAccountBusy,
+    refreshAccount,
+    refreshSavedAccounts,
+    refreshAccountQuotas,
+    runAccountLogin,
+    cancelAccountLogin,
+    submitAccountLoginCode,
+    runSaveAccount,
+    runAddAccount,
+    runSwitchAccount,
+    runRemoveAccount,
+    runAccountLogout,
+  } = useAccountQuotaChrome({
+    hostRef: accountQuotaHostRef,
+    manualCliPath,
+    accountSettingsOpen: settingsOpen && settingsSection === "account",
+  });
   voiceSignedInRef.current = !!account?.profile?.signedIn;
   useEffect(() => {
     void refreshVoiceGate();
   }, [account?.profile?.signedIn, refreshVoiceGate]);
-  const [accountLoading, setAccountLoading] = useState(false);
-  const [accountBusy, setAccountBusy] = useState(false);
-  /** Soft-fail heatmap / account_status error (never invents activity or quota). */
-  const [accountHeatmapError, setAccountHeatmapError] = useState<unknown>(null);
-  /** Soft-fail last account_status / billing probe error (never invents quota %). */
-  const [accountProbeError, setAccountProbeError] = useState<unknown>(null);
-  const [loginHint, setLoginHint] = useState<string | null>(null);
   const platform = useMemo(() => detectAppPlatform(), []);
   const settingsShortcutHint = useMemo(
     () =>
@@ -2387,7 +2398,7 @@ export function AppWorkbench() {
         const st = await api
           .accountStatus({ refreshBilling: false })
           .catch(() => null);
-        if (st) setAccount(st);
+        if (st) applyAccountSnapshot(st);
       } catch {
         /* never reset gate — soft-fail optional RPCs */
       }
@@ -9925,6 +9936,18 @@ export function AppWorkbench() {
     h.setAppDialog = setAppDialog;
     h.viewingSessionId = () => viewingSessionIdRef.current;
   }
+  {
+    const h = accountQuotaHostRef.current;
+    h.tr = tr;
+    h.showToast = showToast;
+    h.setAppDialog = setAppDialog;
+    h.noteAccountConnected = ({ auth, cliFound }) => {
+      setSetup((s) => ({ ...s, auth, cli: cliFound || s.cli }));
+    };
+    h.resetFocusedSession = () => {
+      setSession({ ...IDLE_SNAPSHOT });
+    };
+  }
 
   /**
    * Pick folder → add project (name = folder basename; no rename prompt).
@@ -11106,106 +11129,13 @@ export function AppWorkbench() {
     ],
   );
 
-  const refreshAccount = useCallback(
-    async (opts?: {
-      refreshBilling?: boolean;
-      /** No spinner / error flash — background quota tick. */
-      quiet?: boolean;
-      /** Skip heatmap / call-log walk (billing-only). */
-      includeLocalUsage?: boolean;
-      /** Drop Host reply after unmount / superseded probe. */
-      isCurrent?: () => boolean;
-    }) => {
-      if (!api.isTauri()) {
-        // Browser preview: soft-fail host_only — never invent heatmap/quota.
-        setAccountHeatmapError({ code: "host_only", message: "need tauri" });
-        // Browser / non-host: soft-fail host_only so Account never invents %.
-        setAccountProbeError({
-          code: "host_only",
-          message: "Account requires Tauri desktop runtime",
-        });
-        return;
-      }
-      const quiet = opts?.quiet === true;
-      const includeLocalUsage = opts?.includeLocalUsage ?? true;
-      if (!quiet) setAccountLoading(true);
-      try {
-        const st = await api.accountStatus({
-          refreshBilling: opts?.refreshBilling ?? true,
-          includeLocalUsage,
-          manualCliPath: manualCliPath || null,
-        });
-        if (opts?.isCurrent && !opts.isCurrent()) return;
-        setAccount((prev) =>
-          includeLocalUsage
-            ? st
-            : mergeAccountStatusPreservingLocalUsage(prev, st),
-        );
-        if (!quiet) setAccountHeatmapError(null);
-        setAccountProbeError(null);
-        setSetup((s) => ({
-          ...s,
-          auth: isAccountConnected(st),
-          cli: st.cliFound || s.cli,
-        }));
-        if (!quiet) {
-          try {
-            const list = await api.accountsList();
-            setSavedAccounts(list.profiles ?? []);
-            setActiveAccountId(list.activeId ?? null);
-          } catch {
-            // multi-account list is best-effort
-          }
-        }
-        // Usage line on tray menu (Codex-style)
-        void api.trayRefresh();
-      } catch (e) {
-        if (opts?.isCurrent && !opts.isCurrent()) return;
-        console.warn("account status failed", e);
-        if (!quiet) {
-          setAccountHeatmapError(e);
-          setAccountProbeError(e);
-        }
-      } finally {
-        if (!quiet) setAccountLoading(false);
-      }
-    },
-    [manualCliPath],
-  );
-
-  const refreshSavedAccounts = useCallback(async () => {
-    if (!api.isTauri()) return;
-    try {
-      const list = await api.accountsList();
-      setSavedAccounts(list.profiles ?? []);
-      setActiveAccountId(list.activeId ?? null);
-    } catch {
-      /* ignore */
-    }
-  }, []);
-
-  const refreshAccountQuotas = useCallback(async () => {
-    if (!api.isTauri()) return;
-    try {
-      const r = await api.accountsQuota();
-      const map: Record<string, SwitcherQuota> = {};
-      for (const item of r.items ?? []) {
-        map[item.id] = quotaFromHostItem(item);
-      }
-      setAccountQuotas(map);
-    } catch {
-      /* ignore — rows stay on live seed / em dash */
-    }
-  }, []);
-
   /** Import markdown/JSON transcript as a new local session (from PR #24). */
   const importChatTranscript = useCallback(async () => {
     if (!api.isTauri()) {
       showToast(tr("error.needTauri"));
       return;
     }
-    setAccountBusy(true);
-    try {
+    await runWithAccountBusy(async () => {
       const created = await api.sessionImportTranscriptFile(
         null,
         activeProject?.id ?? null,
@@ -11219,15 +11149,13 @@ export function AppWorkbench() {
           projects.find((p) => p.id === (hit.projectId ?? undefined)) ?? null;
         void openSession(hit, proj ?? undefined);
       }
-    } catch (e) {
+    }).catch((e) => {
       showToast(
         `${tr("account.importChatFailed")}: ${String(e)}`,
         5000,
       );
-    } finally {
-      setAccountBusy(false);
-    }
-  }, [activeProject?.id, projects, showToast, tr]);
+    });
+  }, [activeProject?.id, projects, runWithAccountBusy, showToast, tr]);
 
   const unarchivedAppSessionCount = sessions.filter((s) => !s.archived).length;
   const linkedAgentIds = sessions
@@ -11819,237 +11747,6 @@ export function AppWorkbench() {
     (seconds: string) => tr("perm.autoDenyCountdown", { seconds }),
     [tr],
   );
-
-  const runAccountLogin = useCallback(
-    async (method: "oauth" | "device" = "oauth"): Promise<boolean> => {
-      if (!api.isTauri()) {
-        showToast(tr("error.needTauri"));
-        return false;
-      }
-      setAccountBusy(true);
-      setLoginHint(null);
-      try {
-        const res = await api.accountLogin(method);
-        if (res.ok) {
-          setLoginHint(null);
-        } else if (res.timedOut) {
-          const msg = `${tr("account.loginTimeout")} ${tr(
-            "account.loginUnreachableHint",
-          )}`;
-          setLoginHint(msg);
-          showToast(msg, 10000);
-        } else {
-          const msg = res.message || tr("account.loginFailed");
-          setLoginHint(msg);
-          showToast(msg, 6000);
-        }
-        if (res.deviceUrl) {
-          try {
-            await api.openExternalUrl(res.deviceUrl);
-          } catch {
-            /* host may already open it */
-          }
-        }
-        await refreshAccount({ refreshBilling: true });
-        await refreshSavedAccounts();
-        // Host account_login recycles live/bg/parked/prewarm on success
-        // (`account_auth`) so warm CLIs cannot keep stale/missing OIDC.
-        // Reset focused shell snapshot only — do not sessionDisconnect (that
-        // parks processes and used to leave prewarm alive for reuse).
-        if (res.ok) {
-          setSession({ ...IDLE_SNAPSHOT });
-        }
-        return !!res.ok;
-      } catch (e) {
-        const msg = String(e);
-        setLoginHint(msg);
-        showToast(msg, 4500);
-        return false;
-      } finally {
-        setAccountBusy(false);
-      }
-    },
-    [refreshAccount, refreshSavedAccounts, showToast, tr],
-  );
-
-  /** Abort a running login (OAuth/device) so the user can pick another method
-   *  without restarting the app. The backend kills the `grok login` child. */
-  const cancelAccountLogin = useCallback(async () => {
-    try {
-      await api.accountLoginCancel();
-    } catch {
-      /* ignore — still unlock UI */
-    }
-    setAccountBusy(false);
-  }, []);
-
-  /**
-   * Paste a browser-shown verification code into the running `grok login`.
-   * auth.x.ai sometimes asks to “copy this code into Grok Build” instead of
-   * completing via localhost callback.
-   */
-  const submitAccountLoginCode = useCallback(
-    async (code: string) => {
-      if (!api.isTauri()) {
-        showToast(tr("error.needTauri"));
-        return;
-      }
-      try {
-        await api.accountLoginSubmitCode(code);
-        showToast(tr("account.loginPasteOk"), 4000);
-      } catch (e) {
-        const msg = `${tr("account.loginPasteFailed")}: ${String(e)}`;
-        setLoginHint(msg);
-        showToast(msg, 5000);
-      }
-    },
-    [showToast, tr],
-  );
-
-  const runSaveAccount = useCallback(async () => {
-    if (!api.isTauri()) return;
-    setAccountBusy(true);
-    try {
-      await api.accountSaveCurrent();
-      await refreshSavedAccounts();
-    } catch (e) {
-      showToast(String(e), 4500);
-    } finally {
-      setAccountBusy(false);
-    }
-  }, [refreshSavedAccounts, showToast, tr]);
-
-  /**
-   * Save current login (if any), then start OAuth so the user can add another
-   * account without losing the previous snapshot.
-   */
-  const runAddAccount = useCallback(async () => {
-    if (!api.isTauri()) {
-      showToast(tr("error.needTauri"));
-      return;
-    }
-    // Snapshot current auth first so switcher keeps it.
-    if (account?.profile?.signedIn) {
-      setAccountBusy(true);
-      try {
-        await api.accountSaveCurrent();
-        await refreshSavedAccounts();
-      } catch (e) {
-        // Still try login — user may want a fresh account even if save fails.
-        showToast(String(e), 3500);
-      } finally {
-        setAccountBusy(false);
-      }
-    }
-    await runAccountLogin("oauth");
-  }, [
-    account?.profile?.signedIn,
-    refreshSavedAccounts,
-    runAccountLogin,
-    showToast,
-    tr,
-  ]);
-
-  const runSwitchAccount = useCallback(
-    async (id: string) => {
-      if (!api.isTauri()) return;
-      setAccountBusy(true);
-      try {
-        await api.accountSwitch(id);
-        await refreshAccount({ refreshBilling: true });
-        await refreshSavedAccounts();
-        // Host account_switch recycles all agents (account_auth).
-        setSession({ ...IDLE_SNAPSHOT });
-      } catch (e) {
-        showToast(String(e), 4500);
-      } finally {
-        setAccountBusy(false);
-      }
-    },
-    [refreshAccount, refreshSavedAccounts, showToast, tr],
-  );
-
-  const runRemoveAccount = useCallback(
-    (id: string) => {
-      if (!api.isTauri()) return;
-      const label =
-        savedAccounts.find((a) => a.id === id)?.label || id.slice(0, 8);
-      setAppDialog({
-        kind: "confirm",
-        title: tr("account.profileRemove"),
-        message: tr("account.profilesHint"),
-        confirmLabel: tr("account.profileRemove"),
-        danger: true,
-        onConfirm: async () => {
-          setAccountBusy(true);
-          try {
-            await api.accountRemove(id);
-            await refreshSavedAccounts();
-          } catch (e) {
-            showToast(String(e), 4500);
-          } finally {
-            setAccountBusy(false);
-          }
-        },
-      });
-      void label;
-    },
-    [refreshSavedAccounts, savedAccounts, showToast, tr],
-  );
-
-  const runAccountLogout = useCallback(async () => {
-    if (!api.isTauri()) return;
-    setAccountBusy(true);
-    try {
-      await api.accountLogout();
-      await refreshAccount({ refreshBilling: false });
-      await refreshSavedAccounts();
-      // Host account_logout recycles all agents (account_auth).
-      setSession({ ...IDLE_SNAPSHOT });
-    } catch (e) {
-      showToast(String(e), 4500);
-    } finally {
-      setAccountBusy(false);
-    }
-  }, [refreshAccount, refreshSavedAccounts, showToast]);
-
-  // Account boot: paint fast from disk cache first, then refresh quota on network.
-  // Welcome SuperGrok logo depends on billing tier — waiting only on the slow
-  // path made the mark look like a "slow image" even though it is inline SVG.
-  useEffect(() => {
-    if (!api.isTauri()) return;
-    let cancelled = false;
-    void (async () => {
-      const isCurrent = () => !cancelled;
-      await refreshAccount({ refreshBilling: false, isCurrent });
-      if (cancelled) return;
-      await refreshAccount({ refreshBilling: true, isCurrent });
-      if (cancelled) return;
-      await refreshSavedAccounts();
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [refreshAccount, refreshSavedAccounts]);
-
-  useEffect(() => {
-    if (settingsOpen && settingsSection === "account") {
-      void refreshAccount({ refreshBilling: true });
-      void refreshSavedAccounts();
-    }
-  }, [settingsOpen, settingsSection, refreshAccount, refreshSavedAccounts]);
-
-  useAccountQuotaAutoRefresh({
-    enabled: api.isTauri(),
-    canFetch: canFetchOfficialQuota(account),
-    refresh: (isCurrent) =>
-      refreshAccount({
-        refreshBilling: true,
-        quiet: true,
-        includeLocalUsage: false,
-        isCurrent,
-      }),
-  });
 
   // Keep Esc→stop gate current for the capture-phase shortcut listener.
   escapeStopLiveRef.current = {

--- a/src/hooks/useAccountQuotaChrome.test.ts
+++ b/src/hooks/useAccountQuotaChrome.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Account snapshot / login verbs live here. Host supplies toast, dialog,
+ * setup-gate, and focused-session reset.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createT } from "@/i18n";
+import * as api from "@/lib/api";
+import {
+  createAccountQuotaChromeHost,
+  useAccountQuotaChrome,
+} from "./useAccountQuotaChrome";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    isTauri: vi.fn(() => false),
+    accountStatus: vi.fn(),
+    accountsList: vi.fn(),
+    accountsQuota: vi.fn(),
+    accountLogin: vi.fn(),
+    accountLogout: vi.fn(),
+    accountSwitch: vi.fn(),
+    accountRemove: vi.fn(),
+    accountSaveCurrent: vi.fn(),
+    accountLoginCancel: vi.fn(),
+    accountLoginSubmitCode: vi.fn(),
+    trayRefresh: vi.fn(async () => {}),
+    openExternalUrl: vi.fn(async () => {}),
+  };
+});
+
+function signedOutStatus(): api.AccountStatus {
+  return {
+    profile: {
+      signedIn: false,
+      authMode: null,
+      email: null,
+      displayName: null,
+      userId: null,
+      teamId: null,
+      principalType: null,
+      expiresAt: null,
+      expired: false,
+      hasRefresh: false,
+      oidcIssuer: null,
+    },
+    hasOfficialKey: false,
+    hasRelayKey: false,
+    relayBaseUrl: null,
+    cliAuthPresent: false,
+    cliFound: true,
+    cliPath: "/cli",
+    channel: "none",
+    billing: {
+      available: false,
+      source: "test",
+      message: null,
+      subscriptionTier: null,
+      creditUsagePercent: null,
+      remainingPercent: null,
+      monthlyLimit: null,
+      includedUsed: null,
+      totalUsed: null,
+      prepaidBalance: null,
+      onDemandEnabled: null,
+      onDemandCap: null,
+      onDemandUsed: null,
+      billingPeriodStart: null,
+      billingPeriodEnd: null,
+      resetsAt: null,
+      isUnifiedBillingUser: null,
+      products: [],
+      manageUrl: "",
+      subscribeUrl: "",
+      fetchedAt: null,
+    },
+    heatmap: [],
+    callLogs: [],
+    usageManageUrl: "",
+    subscribeUrl: "",
+  };
+}
+
+function setup() {
+  const host = createAccountQuotaChromeHost();
+  host.tr = createT("en");
+  host.showToast = vi.fn();
+  host.setAppDialog = vi.fn();
+  host.noteAccountConnected = vi.fn();
+  host.resetFocusedSession = vi.fn();
+  const hostRef = { current: host };
+  const hook = renderHook(() =>
+    useAccountQuotaChrome({
+      hostRef,
+      manualCliPath: null,
+      accountSettingsOpen: false,
+    }),
+  );
+  return { ...hook, host };
+}
+
+describe("useAccountQuotaChrome", () => {
+  beforeEach(() => {
+    vi.mocked(api.isTauri).mockReturnValue(false);
+    vi.mocked(api.accountStatus).mockResolvedValue(signedOutStatus());
+    vi.mocked(api.accountsList).mockResolvedValue({
+      profiles: [],
+      activeId: null,
+    });
+    vi.mocked(api.accountLogin).mockReset();
+    vi.mocked(api.trayRefresh).mockClear();
+  });
+
+  it("marks host_only errors when not running under Tauri", async () => {
+    const { result } = setup();
+    await act(async () => {
+      await result.current.refreshAccount();
+    });
+    expect(result.current.accountProbeError).toMatchObject({
+      code: "host_only",
+    });
+    expect(api.accountStatus).not.toHaveBeenCalled();
+  });
+
+  it("stores the Host snapshot and notes setup auth", async () => {
+    const st = signedOutStatus();
+    st.cliFound = true;
+    vi.mocked(api.isTauri).mockReturnValue(true);
+    vi.mocked(api.accountStatus).mockResolvedValue(st);
+    vi.mocked(api.accountsList).mockResolvedValue({
+      profiles: [],
+      activeId: null,
+    });
+    const { result, host } = setup();
+    await act(async () => {
+      await result.current.refreshAccount({ refreshBilling: false });
+    });
+    await waitFor(() => {
+      expect(result.current.account?.cliFound).toBe(true);
+    });
+    expect(host.noteAccountConnected).toHaveBeenCalledWith({
+      auth: false,
+      cliFound: true,
+    });
+  });
+
+  it("resets the focused session after a successful login", async () => {
+    vi.mocked(api.isTauri).mockReturnValue(true);
+    vi.mocked(api.accountLogin).mockResolvedValue({
+      ok: true,
+      method: "oauth",
+      message: "",
+      deviceUrl: null,
+      deviceCode: null,
+      profile: null,
+    });
+    vi.mocked(api.accountStatus).mockResolvedValue(signedOutStatus());
+    vi.mocked(api.accountsList).mockResolvedValue({
+      profiles: [],
+      activeId: null,
+    });
+    const { result, host } = setup();
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.runAccountLogin("oauth");
+    });
+    expect(ok).toBe(true);
+    expect(host.resetFocusedSession).toHaveBeenCalled();
+  });
+
+  it("opens a confirm dialog before removing a saved account", () => {
+    vi.mocked(api.isTauri).mockReturnValue(true);
+    const { result, host } = setup();
+    act(() => {
+      result.current.runRemoveAccount("acc-1");
+    });
+    expect(host.setAppDialog).toHaveBeenCalled();
+    const dialog = vi.mocked(host.setAppDialog).mock.calls[0]?.[0];
+    expect(dialog).toMatchObject({ kind: "confirm", danger: true });
+  });
+});

--- a/src/hooks/useAccountQuotaChrome.ts
+++ b/src/hooks/useAccountQuotaChrome.ts
@@ -1,0 +1,400 @@
+/**
+ * Official account snapshot, quota probe, and multi-account switcher.
+ *
+ * Owns the Account page / user-menu projection. Host fills
+ * {@link AccountQuotaChromeHost} so setup-gate and focused-session reset
+ * stay late-bound. Transcript import is not account knowledge — host may
+ * call {@link runWithAccountBusy} for the shared spinner.
+ */
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type MutableRefObject,
+} from "react";
+import { createT } from "@/i18n";
+import * as api from "@/lib/api";
+import type { AppDialog } from "@/lib/app/appDialogTypes";
+import {
+  canFetchOfficialQuota,
+  mergeAccountStatusPreservingLocalUsage,
+} from "@/lib/accountQuotaRefresh";
+import {
+  quotaFromHostItem,
+  type SwitcherQuota,
+} from "@/lib/accountSwitcherQuota";
+import { isAccountConnected } from "@/lib/accountUi";
+import { useAccountQuotaAutoRefresh } from "@/hooks/useAccountQuotaAutoRefresh";
+
+type TFn = ReturnType<typeof createT>;
+
+export type AccountQuotaChromeHost = {
+  tr: TFn;
+  showToast: (msg: string, ms?: number) => void;
+  setAppDialog: (dialog: AppDialog) => void;
+  noteAccountConnected: (next: { auth: boolean; cliFound: boolean }) => void;
+  resetFocusedSession: () => void;
+};
+
+function emptyHost(): AccountQuotaChromeHost {
+  const noop = () => {};
+  return {
+    tr: ((k: string) => k) as TFn,
+    showToast: noop,
+    setAppDialog: noop,
+    noteAccountConnected: noop,
+    resetFocusedSession: noop,
+  };
+}
+
+export function createAccountQuotaChromeHost(): AccountQuotaChromeHost {
+  return emptyHost();
+}
+
+export function useAccountQuotaChrome(opts: {
+  hostRef: MutableRefObject<AccountQuotaChromeHost>;
+  manualCliPath: string | null | undefined;
+  accountSettingsOpen: boolean;
+}) {
+  const hostRef = opts.hostRef;
+  const manualCliPath = opts.manualCliPath ?? null;
+
+  const [account, setAccount] = useState<api.AccountStatus | null>(null);
+  const [accountLoading, setAccountLoading] = useState(false);
+  const [accountBusy, setAccountBusy] = useState(false);
+  const [accountHeatmapError, setAccountHeatmapError] = useState<unknown>(null);
+  const [accountProbeError, setAccountProbeError] = useState<unknown>(null);
+  const [loginHint, setLoginHint] = useState<string | null>(null);
+  const [savedAccounts, setSavedAccounts] = useState<api.SavedAccount[]>([]);
+  const [activeAccountId, setActiveAccountId] = useState<string | null>(null);
+  const [accountQuotas, setAccountQuotas] = useState<
+    Record<string, SwitcherQuota>
+  >({});
+
+  const applyAccountSnapshot = useCallback((st: api.AccountStatus | null) => {
+    if (st) setAccount(st);
+  }, []);
+
+  const runWithAccountBusy = useCallback(async (fn: () => Promise<void>) => {
+    setAccountBusy(true);
+    try {
+      await fn();
+    } finally {
+      setAccountBusy(false);
+    }
+  }, []);
+
+  const refreshAccount = useCallback(
+    async (refreshOpts?: {
+      refreshBilling?: boolean;
+      quiet?: boolean;
+      includeLocalUsage?: boolean;
+      isCurrent?: () => boolean;
+    }) => {
+      if (!api.isTauri()) {
+        setAccountHeatmapError({ code: "host_only", message: "need tauri" });
+        setAccountProbeError({
+          code: "host_only",
+          message: "Account requires Tauri desktop runtime",
+        });
+        return;
+      }
+      const quiet = refreshOpts?.quiet === true;
+      const includeLocalUsage = refreshOpts?.includeLocalUsage ?? true;
+      if (!quiet) setAccountLoading(true);
+      try {
+        const st = await api.accountStatus({
+          refreshBilling: refreshOpts?.refreshBilling ?? true,
+          includeLocalUsage,
+          manualCliPath: manualCliPath || null,
+        });
+        if (refreshOpts?.isCurrent && !refreshOpts.isCurrent()) return;
+        setAccount((prev) =>
+          includeLocalUsage
+            ? st
+            : mergeAccountStatusPreservingLocalUsage(prev, st),
+        );
+        if (!quiet) setAccountHeatmapError(null);
+        setAccountProbeError(null);
+        hostRef.current.noteAccountConnected({
+          auth: isAccountConnected(st),
+          cliFound: !!st?.cliFound,
+        });
+        if (!quiet) {
+          try {
+            const list = await api.accountsList();
+            setSavedAccounts(list.profiles ?? []);
+            setActiveAccountId(list.activeId ?? null);
+          } catch {
+            /* multi-account list is best-effort */
+          }
+        }
+        void api.trayRefresh();
+      } catch (e) {
+        if (refreshOpts?.isCurrent && !refreshOpts.isCurrent()) return;
+        console.warn("account status failed", e);
+        if (!quiet) {
+          setAccountHeatmapError(e);
+          setAccountProbeError(e);
+        }
+      } finally {
+        if (!quiet) setAccountLoading(false);
+      }
+    },
+    [hostRef, manualCliPath],
+  );
+
+  const refreshSavedAccounts = useCallback(async () => {
+    if (!api.isTauri()) return;
+    try {
+      const list = await api.accountsList();
+      setSavedAccounts(list.profiles ?? []);
+      setActiveAccountId(list.activeId ?? null);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const refreshAccountQuotas = useCallback(async () => {
+    if (!api.isTauri()) return;
+    try {
+      const r = await api.accountsQuota();
+      const map: Record<string, SwitcherQuota> = {};
+      for (const item of r.items ?? []) {
+        map[item.id] = quotaFromHostItem(item);
+      }
+      setAccountQuotas(map);
+    } catch {
+      /* rows stay on live seed / em dash */
+    }
+  }, []);
+
+  const runAccountLogin = useCallback(
+    async (method: "oauth" | "device" = "oauth"): Promise<boolean> => {
+      const h = hostRef.current;
+      if (!api.isTauri()) {
+        h.showToast(h.tr("error.needTauri"));
+        return false;
+      }
+      setAccountBusy(true);
+      setLoginHint(null);
+      try {
+        const res = await api.accountLogin(method);
+        if (res.ok) {
+          setLoginHint(null);
+        } else if (res.timedOut) {
+          const msg = `${h.tr("account.loginTimeout")} ${h.tr(
+            "account.loginUnreachableHint",
+          )}`;
+          setLoginHint(msg);
+          h.showToast(msg, 10000);
+        } else {
+          const msg = res.message || h.tr("account.loginFailed");
+          setLoginHint(msg);
+          h.showToast(msg, 6000);
+        }
+        if (res.deviceUrl) {
+          try {
+            await api.openExternalUrl(res.deviceUrl);
+          } catch {
+            /* host may already open it */
+          }
+        }
+        await refreshAccount({ refreshBilling: true });
+        await refreshSavedAccounts();
+        if (res.ok) h.resetFocusedSession();
+        return !!res.ok;
+      } catch (e) {
+        const msg = String(e);
+        setLoginHint(msg);
+        h.showToast(msg, 4500);
+        return false;
+      } finally {
+        setAccountBusy(false);
+      }
+    },
+    [hostRef, refreshAccount, refreshSavedAccounts],
+  );
+
+  const cancelAccountLogin = useCallback(async () => {
+    try {
+      await api.accountLoginCancel();
+    } catch {
+      /* still unlock UI */
+    }
+    setAccountBusy(false);
+  }, []);
+
+  const submitAccountLoginCode = useCallback(
+    async (code: string) => {
+      const h = hostRef.current;
+      if (!api.isTauri()) {
+        h.showToast(h.tr("error.needTauri"));
+        return;
+      }
+      try {
+        await api.accountLoginSubmitCode(code);
+        h.showToast(h.tr("account.loginPasteOk"), 4000);
+      } catch (e) {
+        const msg = `${h.tr("account.loginPasteFailed")}: ${String(e)}`;
+        setLoginHint(msg);
+        h.showToast(msg, 5000);
+      }
+    },
+    [hostRef],
+  );
+
+  const runSaveAccount = useCallback(async () => {
+    if (!api.isTauri()) return;
+    const h = hostRef.current;
+    setAccountBusy(true);
+    try {
+      await api.accountSaveCurrent();
+      await refreshSavedAccounts();
+    } catch (e) {
+      h.showToast(String(e), 4500);
+    } finally {
+      setAccountBusy(false);
+    }
+  }, [hostRef, refreshSavedAccounts]);
+
+  const runAddAccount = useCallback(async () => {
+    const h = hostRef.current;
+    if (!api.isTauri()) {
+      h.showToast(h.tr("error.needTauri"));
+      return;
+    }
+    if (account?.profile?.signedIn) {
+      setAccountBusy(true);
+      try {
+        await api.accountSaveCurrent();
+        await refreshSavedAccounts();
+      } catch (e) {
+        h.showToast(String(e), 3500);
+      } finally {
+        setAccountBusy(false);
+      }
+    }
+    await runAccountLogin("oauth");
+  }, [account?.profile?.signedIn, hostRef, refreshSavedAccounts, runAccountLogin]);
+
+  const runSwitchAccount = useCallback(
+    async (id: string) => {
+      if (!api.isTauri()) return;
+      const h = hostRef.current;
+      setAccountBusy(true);
+      try {
+        await api.accountSwitch(id);
+        await refreshAccount({ refreshBilling: true });
+        await refreshSavedAccounts();
+        h.resetFocusedSession();
+      } catch (e) {
+        h.showToast(String(e), 4500);
+      } finally {
+        setAccountBusy(false);
+      }
+    },
+    [hostRef, refreshAccount, refreshSavedAccounts],
+  );
+
+  const runRemoveAccount = useCallback(
+    (id: string) => {
+      if (!api.isTauri()) return;
+      const h = hostRef.current;
+      h.setAppDialog({
+        kind: "confirm",
+        title: h.tr("account.profileRemove"),
+        message: h.tr("account.profilesHint"),
+        confirmLabel: h.tr("account.profileRemove"),
+        danger: true,
+        onConfirm: async () => {
+          setAccountBusy(true);
+          try {
+            await api.accountRemove(id);
+            await refreshSavedAccounts();
+          } catch (e) {
+            h.showToast(String(e), 4500);
+          } finally {
+            setAccountBusy(false);
+          }
+        },
+      });
+    },
+    [hostRef, refreshSavedAccounts],
+  );
+
+  const runAccountLogout = useCallback(async () => {
+    if (!api.isTauri()) return;
+    const h = hostRef.current;
+    setAccountBusy(true);
+    try {
+      await api.accountLogout();
+      await refreshAccount({ refreshBilling: false });
+      await refreshSavedAccounts();
+      h.resetFocusedSession();
+    } catch (e) {
+      h.showToast(String(e), 4500);
+    } finally {
+      setAccountBusy(false);
+    }
+  }, [hostRef, refreshAccount, refreshSavedAccounts]);
+
+  useEffect(() => {
+    if (!api.isTauri()) return;
+    let cancelled = false;
+    void (async () => {
+      const isCurrent = () => !cancelled;
+      await refreshAccount({ refreshBilling: false, isCurrent });
+      if (cancelled) return;
+      await refreshAccount({ refreshBilling: true, isCurrent });
+      if (cancelled) return;
+      await refreshSavedAccounts();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshAccount, refreshSavedAccounts]);
+
+  useEffect(() => {
+    if (!opts.accountSettingsOpen) return;
+    void refreshAccount({ refreshBilling: true });
+    void refreshSavedAccounts();
+  }, [opts.accountSettingsOpen, refreshAccount, refreshSavedAccounts]);
+
+  useAccountQuotaAutoRefresh({
+    enabled: api.isTauri(),
+    canFetch: canFetchOfficialQuota(account),
+    refresh: (isCurrent) =>
+      refreshAccount({
+        refreshBilling: true,
+        quiet: true,
+        includeLocalUsage: false,
+        isCurrent,
+      }),
+  });
+
+  return {
+    account,
+    accountLoading,
+    accountBusy,
+    accountHeatmapError,
+    accountProbeError,
+    loginHint,
+    savedAccounts,
+    activeAccountId,
+    accountQuotas,
+    applyAccountSnapshot,
+    runWithAccountBusy,
+    refreshAccount,
+    refreshSavedAccounts,
+    refreshAccountQuotas,
+    runAccountLogin,
+    cancelAccountLogin,
+    submitAccountLoginCode,
+    runSaveAccount,
+    runAddAccount,
+    runSwitchAccount,
+    runRemoveAccount,
+    runAccountLogout,
+  };
+}


### PR DESCRIPTION
## Summary
WP-W31 of AppWorkbench decomposition. Official account snapshot, quota probe, saved-account switcher, and login/logout verbs move into `useAccountQuotaChrome`. Host fills toast / dialog / setup.auth / focused-session IDLE reset. Transcript import stays on the host and only borrows `runWithAccountBusy`.

Closes #1057

## Metrics (vs current main)
- Orchestration lines 14062 → 13759
- useState 113 → 104
- useEffect 65 → 63
- APP_* ceilings 14200/116/68 → 13900/108/66
- New hook 400 lines (under 1000)

## Type of change
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` and hook vitest (4 tests)
- [x] `python scripts/check-code-quality-gates.py --mode final` PASS
- [x] `pnpm exec eslint` on changed TS (max-warnings 0)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] Docs / HANDOFF + CODE-QUALITY-PROGRESS + W31 plan updated
- [x] No secrets

## Notes
- `sessionChangesById` and git dirty stay on the host.
- Next suggested cut: MCP doctor (W32).