### PR TITLE
refactor(workbench): extract MCP doctor chrome

### DIFF
--- a/docs/plans/2026-09-07-appworkbench-w32-mcp-doctor.md
+++ b/docs/plans/2026-09-07-appworkbench-w32-mcp-doctor.md
@@ -1,0 +1,11 @@
+# AppWorkbench 继续拆解 — WP-W32 MCP doctor
+
+**日期**：2026-09-07  
+**基线**：`origin/main` @ `0a484d1a`（W31 #1058）  
+**执行位置**：分支 `refactor/appworkbench-w32-mcp-doctor`
+
+MCP 检查列表 + doctor 报告仍堆在 host。弹层 JSX 已在 `WorkbenchSessionModals`。本刀抽 state / inspect / `mcpDoctor()`。
+
+新建 `useMcpDoctorChrome`：`showMcpModal`、servers/error/loading、doctor report/error/loading/focus、`refreshMcpModal` / `openMcpModal` / `runMcpDoctor`。
+
+`tr` 晚绑。`projectPath` 入参。下一步 W33 setup / boot。

--- a/docs/plans/CODE-QUALITY-PROGRESS.md
+++ b/docs/plans/CODE-QUALITY-PROGRESS.md
@@ -12,7 +12,7 @@
 | Spec | `docs/plans/2026-08-01-code-quality-remediation-GOAL.md` |
 | Started | `2026-08-01` |
 | Current wave | `workbench-decomp` |
-| Current WP | `WP-W31` |
+| Current WP | `WP-W32` |
 | **FINAL** | **PASS** (honest orchestration metrics; decreasing ceilings) |
 
 ## Wave checklist
@@ -77,6 +77,7 @@
 | WP-W29 | Side Workbench chrome into useSideWorkbenchChrome | PASS |  | #1042; 14416→14258 lines; useState 122→116; useEffect 75→71; plan `docs/plans/2026-09-06-appworkbench-w29-side-workbench.md` |
 | WP-W30 | Session chrome badges into useSessionChromeBadges | PASS |  | main@#1050 14262→14062 lines; useState 116→113; useEffect 71→65; plan `docs/plans/2026-09-07-appworkbench-w30-session-badges.md` |
 | WP-W31 | Account / quota chrome into useAccountQuotaChrome | PASS |  | 14062→13759 lines; useState 113→104; useEffect 65→63; plan `docs/plans/2026-09-07-appworkbench-w31-account-quota.md` |
+| WP-W32 | MCP inspect + doctor into useMcpDoctorChrome | PASS |  | 13759→13714 lines; useState 104→96; useEffect 63; plan `docs/plans/2026-09-07-appworkbench-w32-mcp-doctor.md` |
 
 ## Metrics log (append-only)
 
@@ -119,6 +120,7 @@
 | 2026-09-06 W29 | 14258 (shell 21 + wb 14237) | 116 | 71 | 12 | dir | dir | 29 | 9 | 80 |
 | 2026-09-07 W30 | 14062 (shell 21 + wb 14041) | 113 | 65 | 12 | dir | dir | 29 | 9 | 80 |
 | 2026-09-07 W31 | 13759 (shell 21 + wb 13738) | 104 | 63 | 12 | dir | dir | 29 | 9 | 80 |
+| 2026-09-07 W32 | 13714 (shell 21 + wb 13693) | 96 | 63 | 12 | dir | dir | 29 | 9 | 80 |
 
 ## Blockers
 
@@ -144,7 +146,7 @@ Parallel non-overlapping tracks (multi-agent) — **landed**:
 | residual-resource-viewer | ResourceViewer + parts | **PASS** | 4938→modules |
 | residual-i18n | `src/i18n/**` | **PASS** | domain modules + barrels |
 | residual-settings | SettingsPage + settings/* | **PASS** | 8874→1817 |
-| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W31: account snapshot / login / quota extracted |
+| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W32: MCP inspect + doctor extracted |
 | residual-settings-catalog | settingsCatalog split | **PASS** | domain entries |
 
-Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **13900 / 108 useState / 66 useEffect**; `files_ge_1000` **≤80**. Shrink large files in follow-on waves — do not keep raising this budget.
+Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **13800 / 100 useState / 66 useEffect**; `files_ge_1000` **≤80**. Shrink large files in follow-on waves — do not keep raising this budget.

--- a/docs/plans/HANDOFF-appworkbench-decomposition.md
+++ b/docs/plans/HANDOFF-appworkbench-decomposition.md
@@ -62,7 +62,8 @@
    **WP-W28 已落地**：git worktree 列表 / 创建 / GC / ship / switch / remove / 徽章 → `useGitWorktreeChrome`。overlay 收成 `worktreeChrome` 一袋。git dirty 仍在 host，经 `applyStatusBranch` 补 branch chip。天花板 **14650 / 130 / 80**。下一步 Side Workbench。
    **WP-W29 已落地**：Side Workbench tabs / dock composer / Review focus / close-tab / git probe / chat→side 路由 → `useSideWorkbenchChrome`。host 只填 aside/open/toast 晚绑袋。`sessionChangesById` 与 git dirty 仍在 host。天花板 **14400 / 120 / 74**。方案见 [2026-09-06-appworkbench-w29-side-workbench.md](./2026-09-06-appworkbench-w29-side-workbench.md)。
    **WP-W30 已落地**：mute / unread / plan-pending Set、storage 事件、clear-on-view、tray/dock 计数 → `useSessionChromeBadges`。host 只填 tr / setAppDialog / viewing id。plan chrome 仍调 `markPlanPendingBadge`。天花板 **14200 / 116 / 68**。方案见 [2026-09-07-appworkbench-w30-session-badges.md](./2026-09-07-appworkbench-w30-session-badges.md)。
-   **WP-W31 已落地**：account 快照 / loading / loginHint / 已存账号 / 配额表 / 登录切换登出 / boot refresh → `useAccountQuotaChrome`。host 只填 toast / dialog / setup.auth / IDLE 壳。天花板 **13900 / 108 / 66**。方案见 [2026-09-07-appworkbench-w31-account-quota.md](./2026-09-07-appworkbench-w31-account-quota.md)。下一步 MCP doctor（W32）。
+   **WP-W31 已落地**：account 快照 / loading / loginHint / 已存账号 / 配额表 / 登录切换登出 / boot refresh → `useAccountQuotaChrome`。host 只填 toast / dialog / setup.auth / IDLE 壳。天花板 **13900 / 108 / 66**。方案见 [2026-09-07-appworkbench-w31-account-quota.md](./2026-09-07-appworkbench-w31-account-quota.md)。
+   **WP-W32 已落地**：MCP inspect 列表 + doctor 报告 → `useMcpDoctorChrome`。天花板 **13800 / 100 / 66**。方案见 [2026-09-07-appworkbench-w32-mcp-doctor.md](./2026-09-07-appworkbench-w32-mcp-doctor.md)。下一步 setup / boot（W33）。
    **pi**：协作者本机无 pi，按 owner 规则跳过。
    **5 个 worktree**：误会。远端 `main` 已含那些产品改动（本地只是 squash 后残留 SHA）。不挡大拆。
 5. 5.6k 行 JSX 拆为 view shell + 域容器；modals 先经既有 `useAppDialogs` 收口。

--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -43,8 +43,8 @@ APP_ORCH_FILES = (
 # Decreasing ceilings at current combined scale. Ratchet down each
 # workbench-extraction WP. The old 6000/100/50 numbers measured the 26-line
 # shell after the God Component was renamed — not a budget to grow into.
-APP_LINES_CEILING = 13900
-APP_USESTATE_CEILING = 108
+APP_LINES_CEILING = 13800
+APP_USESTATE_CEILING = 100
 APP_USEEFFECT_CEILING = 66
 
 

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -657,6 +657,10 @@ import {
   createAccountQuotaChromeHost,
   useAccountQuotaChrome,
 } from "@/hooks/useAccountQuotaChrome";
+import {
+  createMcpDoctorChromeHost,
+  useMcpDoctorChrome,
+} from "@/hooks/useMcpDoctorChrome";
 import { useWorkbenchDisplayPrefs } from "@/hooks/useWorkbenchDisplayPrefs";
 import { useWorkbenchLayout } from "@/hooks/useWorkbenchLayout";
 import { useSettingsNavigation } from "@/hooks/useSettingsNavigation";
@@ -1121,16 +1125,6 @@ export function AppWorkbench() {
   >(async () => false);
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [showUsageLimitModal, setShowUsageLimitModal] = useState(false);
-  const [showMcpModal, setShowMcpModal] = useState(false);
-  const [mcpServers, setMcpServers] = useState<api.McpDto[]>([]);
-  const [mcpError, setMcpError] = useState<string | null>(null);
-  const [mcpLoading, setMcpLoading] = useState(false);
-  /** MCP doctor report (coexists with inspect list; host `mcp_doctor`). */
-  const [mcpDoctorReport, setMcpDoctorReport] =
-    useState<api.McpDoctorReport | null>(null);
-  const [mcpDoctorError, setMcpDoctorError] = useState<string | null>(null);
-  const [mcpDoctorLoading, setMcpDoctorLoading] = useState(false);
-  const [mcpDoctorFocus, setMcpDoctorFocus] = useState<string | null>(null);
   /** Last user message open in inline edit (not main composer). */
   const [editingUserMessageId, setEditingUserMessageId] = useState<
     string | null
@@ -1167,6 +1161,24 @@ export function AppWorkbench() {
     sessions,
   });
   const [activeProject, setActiveProject] = useState<Project | null>(null);
+  const mcpDoctorHostRef = useRef(createMcpDoctorChromeHost());
+  const {
+    showMcpModal,
+    setShowMcpModal,
+    mcpServers,
+    mcpError,
+    mcpLoading,
+    mcpDoctorReport,
+    mcpDoctorError,
+    mcpDoctorLoading,
+    mcpDoctorFocus,
+    refreshMcpModal,
+    openMcpModal,
+    runMcpDoctor,
+  } = useMcpDoctorChrome({
+    hostRef: mcpDoctorHostRef,
+    projectPath: activeProject?.path ?? null,
+  });
   const bottomTerminal = useBottomTerminal(activeProject?.id);
   const [bottomTerminalMounted, setBottomTerminalMounted] = useState(false);
   useEffect(() => {
@@ -6686,67 +6698,6 @@ export function AppWorkbench() {
     });
   }, [composerMenuEntries.length]);
 
-  /** Re-run inspect list only — does not clear doctor findings. */
-  const refreshMcpModal = useCallback(async () => {
-    setMcpLoading(true);
-    setMcpError(null);
-    try {
-      const res = await api.inspectMcp(activeProject?.path ?? null);
-      // Host list only — never invent placeholder servers.
-      setMcpServers(res.servers ?? []);
-      if (res.error) setMcpError(res.error);
-    } catch (e) {
-      setMcpServers([]);
-      setMcpError(String(e));
-    } finally {
-      setMcpLoading(false);
-    }
-  }, [activeProject?.path]);
-
-  const openMcpModal = useCallback(async () => {
-    setShowMcpModal(true);
-    // Keep prior doctor results when re-opening; only refresh inspect list.
-    await refreshMcpModal();
-  }, [refreshMcpModal]);
-
-  /**
-   * Run `grok mcp doctor --json [name]`. Optional name focuses one server
-   * (must already exist in CLI config — host does not invent servers).
-   */
-  const runMcpDoctor = useCallback(
-    async (
-      name?: string | null,
-    ): Promise<{
-      report: api.McpDoctorReport | null;
-      error: string | null;
-    }> => {
-      if (!api.isTauri()) {
-        const error = tr("ext.needTauri");
-        setMcpDoctorError(error);
-        // Soft-fail: modal classifies host_only; no window.alert.
-        return { report: null, error };
-      }
-      const focus = name?.trim() || null;
-      setMcpDoctorFocus(focus);
-      setMcpDoctorLoading(true);
-      setMcpDoctorError(null);
-      try {
-        const report = await api.mcpDoctor(focus);
-        setMcpDoctorReport(report);
-        return { report, error: null };
-      } catch (e) {
-        const error = String(e);
-        // Soft-fail CLI missing / too old / timeout is classified in the modal.
-        setMcpDoctorReport(null);
-        setMcpDoctorError(error);
-        return { report: null, error };
-      } finally {
-        setMcpDoctorLoading(false);
-      }
-    },
-    [],
-  );
-
   const showToast = useCallback((msg: string, ms = 3200) => {
     setToast(msg);
     window.setTimeout(() => {
@@ -9947,6 +9898,10 @@ export function AppWorkbench() {
     h.resetFocusedSession = () => {
       setSession({ ...IDLE_SNAPSHOT });
     };
+  }
+  {
+    const h = mcpDoctorHostRef.current;
+    h.tr = tr;
   }
 
   /**

--- a/src/hooks/useMcpDoctorChrome.test.ts
+++ b/src/hooks/useMcpDoctorChrome.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { createT } from "@/i18n";
+import * as api from "@/lib/api";
+import {
+  createMcpDoctorChromeHost,
+  useMcpDoctorChrome,
+} from "./useMcpDoctorChrome";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    isTauri: vi.fn(() => false),
+    inspectMcp: vi.fn(),
+    mcpDoctor: vi.fn(),
+  };
+});
+
+function setup(projectPath: string | null = "/repo") {
+  const host = createMcpDoctorChromeHost();
+  host.tr = createT("en");
+  const hostRef = { current: host };
+  const hook = renderHook(() =>
+    useMcpDoctorChrome({ hostRef, projectPath }),
+  );
+  return { ...hook, host };
+}
+
+describe("useMcpDoctorChrome", () => {
+  beforeEach(() => {
+    vi.mocked(api.isTauri).mockReturnValue(false);
+    vi.mocked(api.inspectMcp).mockReset();
+    vi.mocked(api.mcpDoctor).mockReset();
+  });
+
+  it("opens the modal and loads the inspect list", async () => {
+    vi.mocked(api.inspectMcp).mockResolvedValue({
+      servers: [{ name: "fs" } as api.McpDto],
+    });
+    const { result } = setup();
+    await act(async () => {
+      await result.current.openMcpModal();
+    });
+    expect(result.current.showMcpModal).toBe(true);
+    expect(result.current.mcpServers.map((s) => s.name)).toEqual(["fs"]);
+  });
+
+  it("soft-fails doctor off Tauri without calling Host", async () => {
+    const { result } = setup();
+    let out: { report: unknown; error: string | null } = {
+      report: null,
+      error: null,
+    };
+    await act(async () => {
+      out = await result.current.runMcpDoctor("fs");
+    });
+    expect(api.mcpDoctor).not.toHaveBeenCalled();
+    expect(out.report).toBeNull();
+    expect(out.error).toBeTruthy();
+    expect(result.current.mcpDoctorError).toBe(out.error);
+  });
+
+  it("stores a doctor report from Host", async () => {
+    vi.mocked(api.isTauri).mockReturnValue(true);
+    vi.mocked(api.mcpDoctor).mockResolvedValue({
+      ok: true,
+      servers: [],
+      issues: [],
+    });
+    const { result } = setup();
+    await act(async () => {
+      await result.current.runMcpDoctor("fs");
+    });
+    expect(result.current.mcpDoctorFocus).toBe("fs");
+    expect(result.current.mcpDoctorReport?.ok).toBe(true);
+    expect(result.current.mcpDoctorError).toBeNull();
+  });
+});

--- a/src/hooks/useMcpDoctorChrome.ts
+++ b/src/hooks/useMcpDoctorChrome.ts
@@ -1,0 +1,117 @@
+/**
+ * MCP inspect list + doctor report for the status modal.
+ *
+ * Host fills {@link McpDoctorChromeHost} so `tr` stays late-bound.
+ * Does not invent servers — inspect/doctor only report what the CLI has.
+ */
+import {
+  useCallback,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import { createT } from "@/i18n";
+import * as api from "@/lib/api";
+
+type TFn = ReturnType<typeof createT>;
+
+export type McpDoctorChromeHost = {
+  tr: TFn;
+};
+
+function emptyHost(): McpDoctorChromeHost {
+  return { tr: ((k: string) => k) as TFn };
+}
+
+export function createMcpDoctorChromeHost(): McpDoctorChromeHost {
+  return emptyHost();
+}
+
+export function useMcpDoctorChrome(opts: {
+  hostRef: MutableRefObject<McpDoctorChromeHost>;
+  projectPath: string | null | undefined;
+}) {
+  const hostRef = opts.hostRef;
+  const [showMcpModal, setShowMcpModal] = useState(false);
+  const [mcpServers, setMcpServers] = useState<api.McpDto[]>([]);
+  const [mcpError, setMcpError] = useState<string | null>(null);
+  const [mcpLoading, setMcpLoading] = useState(false);
+  const [mcpDoctorReport, setMcpDoctorReport] =
+    useState<api.McpDoctorReport | null>(null);
+  const [mcpDoctorError, setMcpDoctorError] = useState<string | null>(null);
+  const [mcpDoctorLoading, setMcpDoctorLoading] = useState(false);
+  const [mcpDoctorFocus, setMcpDoctorFocus] = useState<string | null>(null);
+
+  /** Re-run inspect list only — does not clear doctor findings. */
+  const refreshMcpModal = useCallback(async () => {
+    setMcpLoading(true);
+    setMcpError(null);
+    try {
+      const res = await api.inspectMcp(opts.projectPath ?? null);
+      setMcpServers(res.servers ?? []);
+      if (res.error) setMcpError(res.error);
+    } catch (e) {
+      setMcpServers([]);
+      setMcpError(String(e));
+    } finally {
+      setMcpLoading(false);
+    }
+  }, [opts.projectPath]);
+
+  const openMcpModal = useCallback(async () => {
+    setShowMcpModal(true);
+    await refreshMcpModal();
+  }, [refreshMcpModal]);
+
+  /**
+   * Run `grok mcp doctor --json [name]`. Optional name focuses one server
+   * that already exists in CLI config.
+   */
+  const runMcpDoctor = useCallback(
+    async (
+      name?: string | null,
+    ): Promise<{
+      report: api.McpDoctorReport | null;
+      error: string | null;
+    }> => {
+      if (!api.isTauri()) {
+        const error = hostRef.current.tr("ext.needTauri");
+        setMcpDoctorError(error);
+        return { report: null, error };
+      }
+      const focus = name?.trim() || null;
+      setMcpDoctorFocus(focus);
+      setMcpDoctorLoading(true);
+      setMcpDoctorError(null);
+      try {
+        const report = await api.mcpDoctor(focus);
+        setMcpDoctorReport(report);
+        return { report, error: null };
+      } catch (e) {
+        const error = String(e);
+        setMcpDoctorReport(null);
+        setMcpDoctorError(error);
+        return { report: null, error };
+      } finally {
+        setMcpDoctorLoading(false);
+      }
+    },
+    [hostRef],
+  );
+
+  return {
+    showMcpModal,
+    setShowMcpModal: setShowMcpModal as Dispatch<SetStateAction<boolean>>,
+    mcpServers,
+    mcpError,
+    mcpLoading,
+    mcpDoctorReport,
+    mcpDoctorError,
+    mcpDoctorLoading,
+    mcpDoctorFocus,
+    refreshMcpModal,
+    openMcpModal,
+    runMcpDoctor,
+  };
+}


### PR DESCRIPTION
## Summary
WP-W32 of AppWorkbench decomposition. MCP inspect list, modal open, and doctor report/error/focus move into `useMcpDoctorChrome`. Host fills `tr`.

Closes #1059

## Metrics (vs current main)
- Orchestration lines 13759 → 13714
- useState 104 → 96
- useEffect 63 (unchanged)
- APP_* ceilings 13900/108/66 → 13800/100/66

## Type of change
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` and hook vitest (3 tests)
- [x] quality gates `--mode final` PASS
- [x] eslint on changed TS
- [x] No `window.confirm` / `prompt` / `alert`
- [x] Docs updated
- [x] No secrets

## Notes
Next: setup / boot (W33).