### PR TITLE
refactor(workbench): extract setup boot gate

### DIFF
--- a/docs/plans/2026-09-07-appworkbench-w33-setup-boot.md
+++ b/docs/plans/2026-09-07-appworkbench-w33-setup-boot.md
@@ -1,0 +1,8 @@
+# AppWorkbench 继续拆解 — WP-W33 setup / boot gate
+
+**日期**：2026-09-07  
+**基线**：`origin/main` @ `1cd77860`（W32 #1060）
+
+`appGate` / bootDetect* / `setupCliSeed` / `setSetup` 仍在 host。完整 boot hydration（projects/sessions/models）留 host——那是整棵 workbench 注水，不是闸门知识。抽闸门状态 + 就绪后通知权限 + retry/skip 动词。
+
+新建 `useSetupBootGate`。不抽 `sessionChangesById` / git dirty。

--- a/docs/plans/CODE-QUALITY-PROGRESS.md
+++ b/docs/plans/CODE-QUALITY-PROGRESS.md
@@ -12,7 +12,7 @@
 | Spec | `docs/plans/2026-08-01-code-quality-remediation-GOAL.md` |
 | Started | `2026-08-01` |
 | Current wave | `workbench-decomp` |
-| Current WP | `WP-W32` |
+| Current WP | `WP-W33` |
 | **FINAL** | **PASS** (honest orchestration metrics; decreasing ceilings) |
 
 ## Wave checklist
@@ -78,6 +78,7 @@
 | WP-W30 | Session chrome badges into useSessionChromeBadges | PASS |  | main@#1050 14262→14062 lines; useState 116→113; useEffect 71→65; plan `docs/plans/2026-09-07-appworkbench-w30-session-badges.md` |
 | WP-W31 | Account / quota chrome into useAccountQuotaChrome | PASS |  | 14062→13759 lines; useState 113→104; useEffect 65→63; plan `docs/plans/2026-09-07-appworkbench-w31-account-quota.md` |
 | WP-W32 | MCP inspect + doctor into useMcpDoctorChrome | PASS |  | 13759→13714 lines; useState 104→96; useEffect 63; plan `docs/plans/2026-09-07-appworkbench-w32-mcp-doctor.md` |
+| WP-W33 | Setup/boot gate into useSetupBootGate | PASS |  | 13714→13706 lines; useState 96→90; useEffect 63→62; plan `docs/plans/2026-09-07-appworkbench-w33-setup-boot.md` |
 
 ## Metrics log (append-only)
 
@@ -121,6 +122,7 @@
 | 2026-09-07 W30 | 14062 (shell 21 + wb 14041) | 113 | 65 | 12 | dir | dir | 29 | 9 | 80 |
 | 2026-09-07 W31 | 13759 (shell 21 + wb 13738) | 104 | 63 | 12 | dir | dir | 29 | 9 | 80 |
 | 2026-09-07 W32 | 13714 (shell 21 + wb 13693) | 96 | 63 | 12 | dir | dir | 29 | 9 | 80 |
+| 2026-09-07 W33 | 13706 (shell 21 + wb 13685) | 90 | 62 | 12 | dir | dir | 29 | 9 | 80 |
 
 ## Blockers
 
@@ -146,7 +148,7 @@ Parallel non-overlapping tracks (multi-agent) — **landed**:
 | residual-resource-viewer | ResourceViewer + parts | **PASS** | 4938→modules |
 | residual-i18n | `src/i18n/**` | **PASS** | domain modules + barrels |
 | residual-settings | SettingsPage + settings/* | **PASS** | 8874→1817 |
-| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W32: MCP inspect + doctor extracted |
+| residual-appworkbench | AppWorkbench + hooks | **PASS** | WP-W33: setup/boot gate extracted; planned W-wave done |
 | residual-settings-catalog | settingsCatalog split | **PASS** | domain entries |
 
-Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **13800 / 100 useState / 66 useEffect**; `files_ge_1000` **≤80**. Shrink large files in follow-on waves — do not keep raising this budget.
+Follow-on: `docs/plans/HANDOFF-appworkbench-decomposition.md`. Decreasing ceilings now **13750 / 94 useState / 65 useEffect**; `files_ge_1000` **≤80**. Planned W-wave cuts through W33 are done; `sessionChangesById` and git dirty stay on the host.

--- a/docs/plans/HANDOFF-appworkbench-decomposition.md
+++ b/docs/plans/HANDOFF-appworkbench-decomposition.md
@@ -63,7 +63,8 @@
    **WP-W29 已落地**：Side Workbench tabs / dock composer / Review focus / close-tab / git probe / chat→side 路由 → `useSideWorkbenchChrome`。host 只填 aside/open/toast 晚绑袋。`sessionChangesById` 与 git dirty 仍在 host。天花板 **14400 / 120 / 74**。方案见 [2026-09-06-appworkbench-w29-side-workbench.md](./2026-09-06-appworkbench-w29-side-workbench.md)。
    **WP-W30 已落地**：mute / unread / plan-pending Set、storage 事件、clear-on-view、tray/dock 计数 → `useSessionChromeBadges`。host 只填 tr / setAppDialog / viewing id。plan chrome 仍调 `markPlanPendingBadge`。天花板 **14200 / 116 / 68**。方案见 [2026-09-07-appworkbench-w30-session-badges.md](./2026-09-07-appworkbench-w30-session-badges.md)。
    **WP-W31 已落地**：account 快照 / loading / loginHint / 已存账号 / 配额表 / 登录切换登出 / boot refresh → `useAccountQuotaChrome`。host 只填 toast / dialog / setup.auth / IDLE 壳。天花板 **13900 / 108 / 66**。方案见 [2026-09-07-appworkbench-w31-account-quota.md](./2026-09-07-appworkbench-w31-account-quota.md)。
-   **WP-W32 已落地**：MCP inspect 列表 + doctor 报告 → `useMcpDoctorChrome`。天花板 **13800 / 100 / 66**。方案见 [2026-09-07-appworkbench-w32-mcp-doctor.md](./2026-09-07-appworkbench-w32-mcp-doctor.md)。下一步 setup / boot（W33）。
+   **WP-W32 已落地**：MCP inspect 列表 + doctor 报告 → `useMcpDoctorChrome`。天花板 **13800 / 100 / 66**。方案见 [2026-09-07-appworkbench-w32-mcp-doctor.md](./2026-09-07-appworkbench-w32-mcp-doctor.md)。
+   **WP-W33 已落地**：first-run `appGate` / bootDetect / CLI seed / setup flags → `useSetupBootGate`。列表/模型 hydration 仍在 host。天花板 **13750 / 94 / 65**。方案见 [2026-09-07-appworkbench-w33-setup-boot.md](./2026-09-07-appworkbench-w33-setup-boot.md)。计划表 W29–W33 收口；`sessionChangesById` 与 git dirty 留 host。
    **pi**：协作者本机无 pi，按 owner 规则跳过。
    **5 个 worktree**：误会。远端 `main` 已含那些产品改动（本地只是 squash 后残留 SHA）。不挡大拆。
 5. 5.6k 行 JSX 拆为 view shell + 域容器；modals 先经既有 `useAppDialogs` 收口。

--- a/scripts/check-code-quality-gates.py
+++ b/scripts/check-code-quality-gates.py
@@ -43,9 +43,9 @@ APP_ORCH_FILES = (
 # Decreasing ceilings at current combined scale. Ratchet down each
 # workbench-extraction WP. The old 6000/100/50 numbers measured the 26-line
 # shell after the God Component was renamed — not a budget to grow into.
-APP_LINES_CEILING = 13800
-APP_USESTATE_CEILING = 100
-APP_USEEFFECT_CEILING = 66
+APP_LINES_CEILING = 13750
+APP_USESTATE_CEILING = 94
+APP_USEEFFECT_CEILING = 65
 
 
 def lines_of(path: Path) -> int:

--- a/src/app/AppWorkbench.tsx
+++ b/src/app/AppWorkbench.tsx
@@ -294,7 +294,6 @@ import {
   VOICE_HOTKEY_STORAGE_KEY,
 } from "@/lib/voiceHotkeyPref";
 import {
-  ensureNotifyPermission,
   listenForNativeNotifyClicks,
   setDesktopNotifySessionFocusHandler,
 } from "@/lib/desktopNotify";
@@ -661,6 +660,7 @@ import {
   createMcpDoctorChromeHost,
   useMcpDoctorChrome,
 } from "@/hooks/useMcpDoctorChrome";
+import { useSetupBootGate } from "@/hooks/useSetupBootGate";
 import { useWorkbenchDisplayPrefs } from "@/hooks/useWorkbenchDisplayPrefs";
 import { useWorkbenchLayout } from "@/hooks/useWorkbenchLayout";
 import { useSettingsNavigation } from "@/hooks/useSettingsNavigation";
@@ -1519,24 +1519,20 @@ export function AppWorkbench() {
     return () => document.removeEventListener("keydown", onKey, true);
   }, []);
 
-  /** First-run gate: loading → setup wizard → ready (home). Mirror forces ready. */
-  const [appGate, setAppGate] = useState<"loading" | "setup" | "ready">(() => {
-    if (typeof window === "undefined") return "loading";
-    if (isMirrorClient()) return "ready";
-    // Vite HMR / host heartbeats used to remount this splash forever in `tauri dev`.
-    if (import.meta.env.DEV) return "ready";
-    return "loading";
-  });
-  /** Boot probe hung / timed out — show retry on the loading gate. */
-  const [bootDetectTimedOut, setBootDetectTimedOut] = useState(false);
-  const [bootDetectSlow, setBootDetectSlow] = useState(false);
-  const [bootRetryNonce, setBootRetryNonce] = useState(0);
-  // Ask once for notification permission after first ready.
-  useEffect(() => {
-    if (appGate !== "ready") return;
-    void ensureNotifyPermission();
-  }, [appGate]);
-  const [setupCliSeed, setSetupCliSeed] = useState<SetupCliInfo | null>(null);
+  const {
+    appGate,
+    setAppGate,
+    bootDetectTimedOut,
+    setBootDetectTimedOut,
+    bootDetectSlow,
+    setBootDetectSlow,
+    bootRetryNonce,
+    setupCliSeed,
+    setSetupCliSeed,
+    setSetup,
+    retryBootDetect,
+    skipToSetup,
+  } = useSetupBootGate();
   const [showDoctor, setShowDoctor] = useState(false);
   const [showTraces, setShowTraces] = useState(false);
   /** Local plan review archive (approved / abandoned / completed). */
@@ -1762,7 +1758,6 @@ export function AppWorkbench() {
   /** Tauri OS drop timestamp — HTML5 fallback must not double-attach. */
   const lastNativeDropAtRef = useRef(0);
   const html5DragDepthRef = useRef(0);
-  const [, setSetup] = useState({ cli: false, auth: false, project: false });
   const [localError, setLocalError] = useState<string | null>(null);
 
   const newRemoteChat = useCallback(
@@ -12126,10 +12121,8 @@ export function AppWorkbench() {
                     className="btn btn--primary"
                     data-testid="setup-boot-retry"
                     onClick={() => {
-                      setBootDetectTimedOut(false);
-                      setBootDetectSlow(false);
                       setLocalError(null);
-                      setBootRetryNonce((n) => n + 1);
+                      retryBootDetect();
                     }}
                   >
                     {tr("setup.detectRetry")}
@@ -12139,8 +12132,7 @@ export function AppWorkbench() {
                     className="btn btn--ghost"
                     style={{ marginLeft: 8 }}
                     onClick={() => {
-                      setBootDetectTimedOut(false);
-                      setAppGate("setup");
+                      skipToSetup();
                     }}
                   >
                     {tr("setup.cli.required")}

--- a/src/hooks/useSetupBootGate.test.ts
+++ b/src/hooks/useSetupBootGate.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSetupBootGate } from "./useSetupBootGate";
+
+vi.mock("@/lib/desktopNotify", () => ({
+  ensureNotifyPermission: vi.fn(async () => {}),
+}));
+
+describe("useSetupBootGate", () => {
+  it("retryBootDetect clears timeout flags and bumps the nonce", () => {
+    const { result } = renderHook(() => useSetupBootGate());
+    const before = result.current.bootRetryNonce;
+    act(() => {
+      result.current.setBootDetectTimedOut(true);
+      result.current.setBootDetectSlow(true);
+    });
+    act(() => {
+      result.current.retryBootDetect();
+    });
+    expect(result.current.bootDetectTimedOut).toBe(false);
+    expect(result.current.bootDetectSlow).toBe(false);
+    expect(result.current.bootRetryNonce).toBe(before + 1);
+  });
+
+  it("skipToSetup opens the wizard", () => {
+    const { result } = renderHook(() => useSetupBootGate());
+    act(() => {
+      result.current.skipToSetup();
+    });
+    expect(result.current.appGate).toBe("setup");
+    expect(result.current.bootDetectTimedOut).toBe(false);
+  });
+});

--- a/src/hooks/useSetupBootGate.ts
+++ b/src/hooks/useSetupBootGate.ts
@@ -1,0 +1,71 @@
+/**
+ * First-run gate: loading → setup wizard → ready.
+ *
+ * Owns gate phase, CLI seed, boot-detect flags, and the ready-once
+ * notification permission. Workbench list/model hydration stays on the host.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { isMirrorClient } from "@/lib/api";
+import { ensureNotifyPermission } from "@/lib/desktopNotify";
+import type { SetupCliInfo } from "@/components/SetupWizard";
+
+export type AppGatePhase = "loading" | "setup" | "ready";
+
+export type SetupFlags = {
+  cli: boolean;
+  auth: boolean;
+  project: boolean;
+};
+
+function initialGate(): AppGatePhase {
+  if (typeof window === "undefined") return "loading";
+  if (isMirrorClient()) return "ready";
+  // Vite HMR / host heartbeats used to remount this splash forever in `tauri dev`.
+  if (import.meta.env.DEV) return "ready";
+  return "loading";
+}
+
+export function useSetupBootGate() {
+  const [appGate, setAppGate] = useState<AppGatePhase>(initialGate);
+  const [bootDetectTimedOut, setBootDetectTimedOut] = useState(false);
+  const [bootDetectSlow, setBootDetectSlow] = useState(false);
+  const [bootRetryNonce, setBootRetryNonce] = useState(0);
+  const [setupCliSeed, setSetupCliSeed] = useState<SetupCliInfo | null>(null);
+  const [setup, setSetup] = useState<SetupFlags>({
+    cli: false,
+    auth: false,
+    project: false,
+  });
+
+  useEffect(() => {
+    if (appGate !== "ready") return;
+    void ensureNotifyPermission();
+  }, [appGate]);
+
+  const retryBootDetect = useCallback(() => {
+    setBootDetectTimedOut(false);
+    setBootDetectSlow(false);
+    setBootRetryNonce((n) => n + 1);
+  }, []);
+
+  const skipToSetup = useCallback(() => {
+    setBootDetectTimedOut(false);
+    setAppGate("setup");
+  }, []);
+
+  return {
+    appGate,
+    setAppGate,
+    bootDetectTimedOut,
+    setBootDetectTimedOut,
+    bootDetectSlow,
+    setBootDetectSlow,
+    bootRetryNonce,
+    setupCliSeed,
+    setSetupCliSeed,
+    setup,
+    setSetup,
+    retryBootDetect,
+    skipToSetup,
+  };
+}


### PR DESCRIPTION
## Summary
WP-W33 of AppWorkbench decomposition. First-run `appGate`, boot-detect flags, CLI seed, and setup flags move into `useSetupBootGate`. Workbench list/model hydration stays on the host.

Closes #1061

## Metrics (vs current main)
- Orchestration lines 13714 → 13706
- useState 96 → 90
- useEffect 63 → 62
- APP_* ceilings 13800/100/66 → 13750/94/65

## Type of change
- [x] Refactor / chore

## Checklist
- [x] `pnpm typecheck` and hook vitest (2 tests)
- [x] quality gates `--mode final` PASS
- [x] eslint on changed TS
- [x] No `window.confirm` / `prompt` / `alert`
- [x] Docs updated
- [x] No secrets

## Notes
Planned W29–W33 cuts are done. `sessionChangesById` and git dirty stay on the host.