### PR TITLE
i18n(sidebar): house icon for Default workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,13 @@ See `docs/llm-wiki/release.md`.
 - Ctrl+Tab 切回上一个用过的对话。按住 Ctrl 再点 Tab 继续循环；Ctrl+Shift+Tab 反向。
 
 ### Changed
+- Default workspace uses a house icon in the sidebar and composer (#1069).
 - Sidebar Other now uses the same name as the composer chip: Default workspace (#1067).
 - Startup skips TipTap and markdown preloads; Office and Settings load on demand (#1055, #1063).
 - Expanded sidebar pins remaining SuperGrok quota without opening the account menu (#1048). Settings is a footer gear; the account menu keeps theme and sign-in.
 
 **中文 · 变更**
+- 默认工作区在侧栏和输入框改用小房子图标（#1069）。
 - 侧栏「其他会话」与输入框统一为「默认工作区」（#1067）。
 - 启动不再预载 TipTap / markdown；Office 与设置页按需加载（#1055、#1063）。
 - 展开左边栏即可看到 SuperGrok 剩余额度，不必再点开账户菜单（#1048）。设置改为脚注齿轮；账户菜单只留主题和登录。

--- a/src/app/WorkbenchSessionTree.tsx
+++ b/src/app/WorkbenchSessionTree.tsx
@@ -22,6 +22,7 @@ import {
   IconChevronRight,
   IconClose,
   IconFolder,
+  IconHome,
   IconListCheck,
   IconMore,
   IconPin,
@@ -632,6 +633,9 @@ export function WorkbenchSessionTree(props: WorkbenchSessionTreeProps) {
                   ) : (
                     <IconChevronRight size={14} />
                   )}
+                </span>
+                <span className="tree-l1__icon" aria-hidden>
+                  <IconHome size={14} />
                 </span>
                 <span className="tree-l1__label">
                   {tr("sidebar.otherSessions")}

--- a/src/components/ComposerProjectMenu.test.tsx
+++ b/src/components/ComposerProjectMenu.test.tsx
@@ -22,5 +22,6 @@ describe("ComposerProjectMenu", () => {
     expect(html).toContain("Default workspace");
     expect(html).toContain("composer__context-item--project");
     expect(html).toContain("is-muted");
+    expect(html).toContain("g-icon--home");
   });
 });

--- a/src/components/ComposerProjectMenu.tsx
+++ b/src/components/ComposerProjectMenu.tsx
@@ -9,6 +9,7 @@ import {
   IconCheck,
   IconChevronDown,
   IconFolder,
+  IconHome,
   IconPlus,
 } from "@/components/icons";
 import { Tip } from "@/components/ui/tooltip";
@@ -116,7 +117,7 @@ export function ComposerProjectMenu({
           aria-expanded={open}
           onClick={() => setOpen((v) => !v)}
         >
-          <IconFolder size={14} />
+          {activeProject ? <IconFolder size={14} /> : <IconHome size={14} />}
           <span className={isContext ? "composer__context-label" : "chip__label"}>
             {label}
           </span>
@@ -146,7 +147,7 @@ export function ComposerProjectMenu({
                   setOpen(false);
                 }}
               >
-                <IconFolder size={14} aria-hidden />
+                <IconHome size={14} aria-hidden />
                 <span>{labels.noProject}</span>
               </button>
               <button

--- a/src/components/PhoneComposerToolsSheet.tsx
+++ b/src/components/PhoneComposerToolsSheet.tsx
@@ -15,6 +15,7 @@ import {
   IconClose,
   IconFolder,
   IconHandStop,
+  IconHome,
   IconPlus,
 } from "@/components/icons";
 import { installDialogFocus } from "@/lib/a11yFocus";
@@ -395,7 +396,13 @@ export function PhoneComposerToolsSheet({
                 }}
               />
               <SheetRow
-                icon={<IconFolder size={20} />}
+                icon={
+                  activeProject ? (
+                    <IconFolder size={20} />
+                  ) : (
+                    <IconHome size={20} />
+                  )
+                }
                 label={labels.project}
                 value={activeProject?.name ?? labels.noProject}
                 chevron
@@ -430,7 +437,7 @@ export function PhoneComposerToolsSheet({
           {panel === "project" && (
             <>
               <SheetRow
-                icon={<IconCheck size={20} />}
+                icon={<IconHome size={20} />}
                 label={labels.noProject}
                 onClick={() => {
                   onSelectProject(null);

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -63,6 +63,7 @@ import {
   IconFolderPlus as TbFolderPlus,
   IconHandStop as TbHandStop,
   IconHelp as TbHelp,
+  IconHome as TbHome,
   IconHexagon as TbHexagon,
   IconInfoCircle as TbInfoCircle,
   IconKeyboard as TbKeyboard,
@@ -419,6 +420,8 @@ export const IconLanguage = wrap(TbLanguage);
 export const IconInfo = wrap(TbInfoCircle);
 /** Help / “?” tip trigger next to settings labels. */
 export const IconHelp = wrap(TbHelp);
+/** Unbound chats / Default workspace. */
+export const IconHome = wrap(TbHome, { className: "g-icon--home" });
 export const IconKeyboard = wrap(TbKeyboard);
 /** Slash palette / goal mode */
 export const IconTarget = wrap(TbTarget);

--- a/src/hooks/useSessionMoveProject.tsx
+++ b/src/hooks/useSessionMoveProject.tsx
@@ -8,7 +8,7 @@ import {
   type SetStateAction,
 } from "react";
 import type { ContextMenuItem } from "@/components/ContextMenu";
-import { IconFolder } from "@/components/icons";
+import { IconFolder, IconHome } from "@/components/icons";
 import type { AppDialog } from "@/lib/app/appDialogTypes";
 import {
   isGeneralProject,
@@ -236,6 +236,7 @@ export function useSessionMoveProject(opts: {
           children: targets.map((t) => ({
             id: t.id ? `move-${t.id}` : "move-orphan",
             label: t.id ? t.label : tr("sidebar.otherSessions"),
+            icon: t.id ? <IconFolder size={16} /> : <IconHome size={16} />,
             disabled: t.disabled || busyIds.has(row.id),
             onClick: () => requestMove([row], t.id),
           })),
@@ -277,6 +278,7 @@ export function useSessionMoveProject(opts: {
       return list.map((t) => ({
         id: t.id ? `bulk-move-${t.id}` : "bulk-move-orphan",
         label: t.label,
+        icon: t.id ? <IconFolder size={16} /> : <IconHome size={16} />,
         disabled: t.disabled,
         onClick: () => requestMove(rows, t.id),
       }));

--- a/src/styles/sidebar.part1b.css
+++ b/src/styles/sidebar.part1b.css
@@ -95,6 +95,16 @@
   justify-content: center;
 }
 
+.tree-l1__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  margin-right: 4px;
+  opacity: 0.9;
+  flex-shrink: 0;
+}
+
 .tree-l1__label {
   flex: 1;
 }


### PR DESCRIPTION
## Summary
Default workspace now uses a house icon so it does not look like another project folder.

Closes #1069

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / chore

Sidebar group, composer chip/picker, phone tools sheet, and move-to-Default-workspace items. Bound projects keep the folder icon.

## Checklist
- [x] `pnpm typecheck` / targeted tests / `pnpm lint`
- [x] User-facing strings unchanged (icon only)
- [x] No `window.confirm` / `prompt` / `alert`
- [x] No secrets