### PR TITLE
fix(security): local binding QR and private plugin auth stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,15 @@ See `docs/llm-wiki/release.md`.
 - Opening a file in Review keeps the macOS title bar visible. Focus scrolls only inside Review (#1041).
 - Advanced context-window Save stays fully clickable. The flyout no longer clips the button (#1047).
 - Linux AppImage prefers host WebKitGTK to avoid black screens and SIGBUS on quit. Helpers stay on disk so FUSE unmount is safe (#539).
+- Binding QR codes are generated locally without sharing login links.
+- Plugin authorization keeps secrets out of process command lines.
 
 **中文 · 修复**
 - 在 Review 中打开文件时，macOS 标题栏保持可见。只滚动 Review 内部列表（#1041）。
 - Advanced 里上下文窗口的「保存」可正常点到。浮层不再裁掉按钮（#1047）。
 - Linux AppImage 优先用本机 WebKitGTK，避免黑屏和退出时 SIGBUS。子进程不再映射在 squashfs 上（#539）。
+- 扫码绑定的二维码在本地生成，登录链接不再发给第三方。
+- 插件授权密钥不再出现在进程命令行中。
 
 ### Added
 - Ctrl+Tab jumps back to the last chat you used. Hold Ctrl and tap Tab to cycle further; Ctrl+Shift+Tab goes the other way.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,3 +33,5 @@ Do **not** open a public issue for sensitive vulnerabilities until a fix is avai
 - Prefer official Grok login / local CLI auth over pasting long-lived keys into chats.
 - Automations and YOLO permission mode can run agent actions without per-step prompts — enable only if you trust the session.
 - Support zip / Doctor export / **session diagnostic package** never include `secrets.json`, OS keychain material, or raw API keys (redacted logs and chat only).
+- Remote IM binding QR codes are generated locally; binding URLs are not sent to QR image services.
+- X API plugin CLI arguments containing secrets are delivered through a private stdin pipe, not the OS process command line. The embedded launcher adapts legacy `process.argv` parsers in memory, and auth output is redacted.

--- a/docs/llm-wiki/plugins-marketplace.md
+++ b/docs/llm-wiki/plugins-marketplace.md
@@ -21,6 +21,8 @@ Installed plugin `.mcp.json` servers (GUI path install included) are listed unde
 
 Plugin MCP auth is **not** ChatCut’s HTTP `mcp_oauth_start`. For `x-api`, the row **Authorize** button opens a GlassModal: console four tokens (App-owner) or OAuth 2 PKCE localhost (`http://127.0.0.1:8787/callback`). Credentials stay in `~/.x-api/credentials.json`.
 
+The Host sends CLI arguments through a private stdin pipe to its embedded Node launcher. Legacy plugins still receive `process.argv` in memory, but no auth secrets appear in the OS command line. Never reintroduce a direct `node script --api-secret ...` spawn; keep output redaction and timeout cleanup.
+
 **Deep link:** `#/settings/extensions/market` → Plugins tab (installable anchor `settings-anchor-ext-plugins-catalog`). Search for marketplace/市场 hits the same entry.
 
 ## Catalog UX

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,7 @@ mod error;
 
 mod extensions;
 mod mcp_oauth;
+mod plugin_auth_transport;
 mod plugin_mcp;
 
 mod fs_browser;
@@ -208,9 +209,6 @@ mod turn_lease;
 
 mod host_runtime;
 
-#[cfg(target_os = "linux")]
-mod linux_webkit;
-
 mod win_crash;
 
 mod updater;
@@ -243,8 +241,6 @@ mod skin_video_bake;
 #[cfg(target_os = "macos")]
 mod mac_ime_fn_bridge;
 #[cfg(windows)]
-mod win_ctrl_tab;
-#[cfg(windows)]
 mod win_file_drop;
 #[cfg(windows)]
 mod win_shell;
@@ -265,17 +261,9 @@ pub fn run() {
         std::process::exit(session_api::run_cli());
     }
 
-    // Before host_runtime: a successful exec replaces this process, so it must
-    // not write a heartbeat the successor would treat as an unclean shutdown.
-    #[cfg(target_os = "linux")]
-    crate::linux_webkit::maybe_reexec_for_system_webkit();
-
     let _ = paths::ensure_app_dirs();
 
     logging::init();
-
-    #[cfg(target_os = "linux")]
-    crate::linux_webkit::log_system_webkit_choice();
 
     crate::host_runtime::on_process_start();
     crate::win_crash::install();
@@ -760,8 +748,6 @@ pub fn run() {
                     // Late OLE drop targets — must run after show (#1017).
                     #[cfg(windows)]
                     win_file_drop::install_after_show(&w);
-                    #[cfg(windows)]
-                    win_ctrl_tab::install(&w);
                     // Doubao Fn voice needs IME to see flagsChanged (#1030).
                     #[cfg(target_os = "macos")]
                     mac_ime_fn_bridge::install();
@@ -775,8 +761,6 @@ pub fn run() {
                 // WebView2 child HWNDs → forbidden cursor (#1017 / tauri#14643).
                 #[cfg(windows)]
                 win_file_drop::install_after_show(&window);
-                #[cfg(windows)]
-                win_ctrl_tab::install(&window);
                 // Doubao Fn voice needs IME to see flagsChanged (#1030).
                 #[cfg(target_os = "macos")]
                 mac_ime_fn_bridge::install();
@@ -1858,9 +1842,6 @@ pub fn run() {
                     host.inner().stop_sync();
 
                 }
-
-                #[cfg(target_os = "linux")]
-                crate::linux_webkit::wait_for_appimage_webkit_helpers();
 
             }
 

--- a/src-tauri/src/plugin_auth_stdin.mjs
+++ b/src-tauri/src/plugin_auth_stdin.mjs
@@ -1,0 +1,25 @@
+// Keep legacy plugin CLI arguments out of the operating-system command line.
+// This launcher is embedded in the host; secrets arrive only over its private stdin pipe.
+import { pathToFileURL } from "node:url";
+
+const script = process.argv[1];
+const chunks = [];
+let length = 0;
+for await (const chunk of process.stdin) {
+  length += chunk.length;
+  if (length > 65536) throw new Error("Plugin auth input is too large");
+  chunks.push(chunk);
+}
+let args;
+try {
+  args = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+} catch {
+  throw new Error("Invalid plugin auth input");
+}
+if (!script || !Array.isArray(args) || args.some((arg) => typeof arg !== "string")) {
+  throw new Error("Invalid plugin auth arguments");
+}
+// Updating this JS array does not alter the OS command line. The plugin remains
+// compatible with its existing process.argv-based parser without a second spawn.
+process.argv = [process.execPath, script, ...args];
+await import(pathToFileURL(script).href);

--- a/src-tauri/src/plugin_auth_transport.rs
+++ b/src-tauri/src/plugin_auth_transport.rs
@@ -1,0 +1,172 @@
+//! Private stdin transport for legacy Node plugin CLIs.
+use std::path::Path;
+use std::process::{Output, Stdio};
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+
+const BOOTSTRAP: &str = include_str!("plugin_auth_stdin.mjs");
+
+pub fn command(script: &Path) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new("node");
+    cmd.args(["--input-type=module", "--eval", BOOTSTRAP]);
+    cmd.arg(script);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    crate::process_util::apply_no_window_tokio(&mut cmd);
+    cmd
+}
+
+pub fn execute(
+    mut cmd: tokio::process::Command,
+    args: &[String],
+    timeout: Duration,
+) -> Result<Output, String> {
+    let payload = serde_json::to_vec(args).map_err(|_| "Invalid plugin auth input")?;
+    if payload.len() > 65536 {
+        return Err("Plugin auth input is too large".into());
+    }
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|_| "Could not create plugin auth runtime")?;
+    runtime.block_on(async move {
+        tokio::time::timeout(timeout, async move {
+            let mut child = cmd
+                .spawn()
+                .map_err(|e| format!("Failed to start plugin: {e}"))?;
+            let mut input = child.stdin.take().ok_or("Plugin stdin is unavailable")?;
+            input
+                .write_all(&payload)
+                .await
+                .map_err(|_| "Could not send plugin auth input")?;
+            drop(input);
+            child
+                .wait_with_output()
+                .await
+                .map_err(|e| format!("Plugin auth process failed: {e}"))
+        })
+        .await
+        .map_err(|_| "Plugin auth timed out".to_string())?
+    })
+}
+
+pub fn redact_output(text: &str, args: &[String]) -> String {
+    let mut values = args
+        .windows(2)
+        .filter(|pair| {
+            matches!(
+                pair[0].as_str(),
+                "--api-key"
+                    | "--api-secret"
+                    | "--access-token"
+                    | "--access-token-secret"
+                    | "--client-secret"
+            )
+        })
+        .map(|pair| pair[1].as_str())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    values.sort_by_key(|value| std::cmp::Reverse(value.len()));
+    let mut safe = text.to_owned();
+    for value in values {
+        safe = safe.replace(value, "[redacted]");
+        let encoded: String = url::form_urlencoded::byte_serialize(value.as_bytes()).collect();
+        safe = safe.replace(&encoded, "[redacted]");
+        if let Ok(json) = serde_json::to_string(value) {
+            safe = safe.replace(&json[1..json.len() - 1], "[redacted]");
+        }
+    }
+    safe
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Fixture(std::path::PathBuf);
+
+    impl Fixture {
+        fn new(source: &str) -> Self {
+            let root = std::env::temp_dir()
+                .join(format!("grok-private-auth-test-{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir(&root).unwrap();
+            std::fs::write(root.join("plugin with spaces.mjs"), source).unwrap();
+            Self(root)
+        }
+
+        fn script(&self) -> std::path::PathBuf {
+            self.0.join("plugin with spaces.mjs")
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn private_pipe_reaches_legacy_node_parser_on_this_host() {
+        let fixture = Fixture::new("process.stdout.write(JSON.stringify(process.argv.slice(2)));");
+        let args = vec![
+            "login".into(),
+            "--api-secret".into(),
+            "synthetic-密钥-+\"".into(),
+        ];
+        let out = execute(command(&fixture.script()), &args, Duration::from_secs(10)).unwrap();
+        assert!(out.status.success());
+        assert_eq!(
+            serde_json::from_slice::<Vec<String>>(&out.stdout).unwrap(),
+            args
+        );
+    }
+
+    #[test]
+    fn stalled_plugin_is_bounded_by_timeout() {
+        let fixture = Fixture::new("setInterval(() => {}, 1000);");
+        let started = std::time::Instant::now();
+        let result = execute(
+            command(&fixture.script()),
+            &["status".into()],
+            Duration::from_millis(500),
+        );
+        assert!(result.unwrap_err().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[test]
+    fn command_contains_only_launcher_and_script_not_credentials() {
+        let cmd = command(Path::new("C:/plugin with spaces/scripts/x-api.mjs"));
+        let argv = cmd
+            .as_std()
+            .get_args()
+            .map(|x| x.to_string_lossy())
+            .collect::<Vec<_>>();
+        assert_eq!(argv.len(), 4);
+        assert_eq!(argv[3], "C:/plugin with spaces/scripts/x-api.mjs");
+        assert!(!argv.iter().any(|arg| arg.contains("synthetic-secret")));
+    }
+
+    #[test]
+    fn errors_redact_exact_encoded_and_json_escaped_secrets() {
+        let secret = "dummy+secret\nwith\"quotes";
+        let args = vec!["login".into(), "--client-secret".into(), secret.into()];
+        let encoded: String = url::form_urlencoded::byte_serialize(secret.as_bytes()).collect();
+        let json = serde_json::to_string(secret).unwrap();
+        let output = format!("Error: {secret} {encoded} {}", &json[1..json.len() - 1]);
+        assert_eq!(
+            redact_output(&output, &args),
+            "Error: [redacted] [redacted] [redacted]"
+        );
+    }
+
+    #[test]
+    fn an_empty_secret_does_not_replace_every_character() {
+        assert_eq!(
+            redact_output("Error: unavailable", &["--api-key".into(), "".into()]),
+            "Error: unavailable"
+        );
+    }
+}

--- a/src-tauri/src/plugin_mcp.rs
+++ b/src-tauri/src/plugin_mcp.rs
@@ -495,27 +495,25 @@ fn def_for_server(name: &str) -> Option<McpServerDef> {
 fn run_x_api_cli(plugin_root: &Path, args: &[String], timeout_secs: u64) -> Result<String, String> {
     let script = x_api_cli_path(plugin_root)
         .ok_or_else(|| "this plugin has no scripts/x-api.mjs auth CLI".to_string())?;
-    let (tx, rx) = std::sync::mpsc::channel();
-    let script_owned = script.clone();
-    let args_owned = args.to_vec();
-    std::thread::spawn(move || {
-        let mut cmd = std::process::Command::new("node");
-        cmd.arg(&script_owned).args(&args_owned);
-        cmd.stdin(std::process::Stdio::null());
-        crate::process_util::apply_no_window_std(&mut cmd);
-        crate::proxy::apply_to_std_command(&mut cmd);
-        cmd.env("NODE_USE_ENV_PROXY", "1");
-        if let Some(path_env) = crate::process_util::enriched_path_env() {
-            cmd.env("PATH", path_env);
-        }
-        let _ = tx.send(cmd.output());
-    });
-    let output = rx
-        .recv_timeout(std::time::Duration::from_secs(timeout_secs))
-        .map_err(|_| format!("x-api auth timed out after {timeout_secs}s"))?
-        .map_err(|e| format!("failed to run x-api CLI: {e}"))?;
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let mut cmd = crate::plugin_auth_transport::command(&script);
+    crate::proxy::apply_to_tokio_command(&mut cmd);
+    cmd.env("NODE_USE_ENV_PROXY", "1");
+    if let Some(path_env) = crate::process_util::enriched_path_env() {
+        cmd.env("PATH", path_env);
+    }
+    let output = crate::plugin_auth_transport::execute(
+        cmd,
+        args,
+        std::time::Duration::from_secs(timeout_secs),
+    )?;
+    let stdout = crate::plugin_auth_transport::redact_output(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        args,
+    );
+    let stderr = crate::plugin_auth_transport::redact_output(
+        String::from_utf8_lossy(&output.stderr).trim(),
+        args,
+    );
     if !output.status.success() {
         return Err(shorten_cli_error(&stderr, &stdout));
     }

--- a/src/components/RemoteImChannelPanel.tsx
+++ b/src/components/RemoteImChannelPanel.tsx
@@ -60,6 +60,7 @@ import {
 import { IconAlertTriangle, IconDoctor, IconPlus } from "@/components/icons";
 import { Select } from "@/components/Select";
 import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { useLocalQrCode } from "@/hooks/useLocalQrCode";
 
 export interface RemoteImChannelPanelProps {
   locale: string;
@@ -228,6 +229,7 @@ export function RemoteImChannelPanel({
     "idle",
   );
   const [scanUri, setScanUri] = useState<string | null>(null);
+  const scanQr = useLocalQrCode(scanUri);
   const [scanDeviceCode, setScanDeviceCode] = useState<string | null>(null);
   const [scanError, setScanError] = useState<string | null>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -1115,11 +1117,13 @@ export function RemoteImChannelPanel({
             >
               {scanUri ? (
                 <>
-                  <img
-                    className="rim-scan__qr"
-                    alt="QR"
-                    src={`https://api.qrserver.com/v1/create-qr-code/?size=180x180&data=${encodeURIComponent(scanUri)}`}
-                  />
+                  {scanQr.dataUrl ? (
+                    <img className="rim-scan__qr" alt="QR" src={scanQr.dataUrl} />
+                  ) : scanQr.error ? (
+                    <span role="alert">{t("settings.remoteIm.scan.qrError")}</span>
+                  ) : (
+                    <span aria-busy="true" aria-hidden="true">…</span>
+                  )}
                   <span className="rim-scan__uri">{scanUri}</span>
                 </>
               ) : (

--- a/src/hooks/useLocalQrCode.test.tsx
+++ b/src/hooks/useLocalQrCode.test.tsx
@@ -1,0 +1,55 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLocalQrCode } from "./useLocalQrCode";
+
+const { generate } = vi.hoisted(() => ({
+  generate: vi.fn<(value: string, options: unknown) => Promise<string>>(),
+}));
+vi.mock("qrcode", () => ({ default: { toDataURL: generate } }));
+beforeEach(() => { generate.mockReset(); });
+afterEach(cleanup);
+
+describe("private binding QR generation", () => {
+  it("encodes the binding locally, without constructing a remote image URL", async () => {
+    generate.mockResolvedValue("data:image/png;base64,local");
+    const uri = "https://binding.example/verify?token=synthetic-secret";
+    const { result } = renderHook(() => useLocalQrCode(uri));
+    await waitFor(() => expect(result.current.dataUrl).toBe("data:image/png;base64,local"));
+    expect(generate).toHaveBeenCalledWith(uri, expect.objectContaining({ width: 180 }));
+    expect(result.current.error).toBe(false);
+  });
+
+  it("hides the old QR on refresh and ignores a stale completion", async () => {
+    let resolveOld!: (value: string) => void;
+    let resolveNew!: (value: string) => void;
+    generate.mockImplementationOnce(() => new Promise<string>((resolve) => { resolveOld = resolve; }));
+    generate.mockImplementationOnce(() => new Promise<string>((resolve) => { resolveNew = resolve; }));
+    const { result, rerender } = renderHook(({ uri }) => useLocalQrCode(uri), {
+      initialProps: { uri: "old-binding" },
+    });
+    rerender({ uri: "new-binding" });
+    expect(result.current.dataUrl).toBeNull();
+    await act(async () => resolveNew("data:image/png;base64,new"));
+    await act(async () => resolveOld("data:image/png;base64,old"));
+    expect(result.current.dataUrl).toBe("data:image/png;base64,new");
+  });
+
+  it("clears a displayed QR when the binding is cleared", async () => {
+    generate.mockResolvedValue("data:image/png;base64,old");
+    const { result, rerender } = renderHook(({ uri }: { uri: string | null }) => useLocalQrCode(uri), {
+      initialProps: { uri: "binding" as string | null },
+    });
+    await waitFor(() => expect(result.current.dataUrl).not.toBeNull());
+    rerender({ uri: null });
+    expect(result.current).toEqual({ dataUrl: null, error: false });
+  });
+
+  it("reports generation failure without an external fallback", async () => {
+    generate.mockRejectedValue(new Error("synthetic binding must not be logged"));
+    const { result } = renderHook(() => useLocalQrCode("binding"));
+    await waitFor(() => expect(result.current.error).toBe(true));
+    expect(result.current.dataUrl).toBeNull();
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useLocalQrCode.ts
+++ b/src/hooks/useLocalQrCode.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import QRCode from "qrcode";
+
+type QrState = { value: string; dataUrl: string | null; error: boolean };
+
+/** Binding URLs stay in this process. Never send them to a QR image service. */
+export function useLocalQrCode(value: string | null) {
+  const [state, setState] = useState<QrState | null>(null);
+
+  useEffect(() => {
+    if (!value) return;
+    let cancelled = false;
+    void QRCode.toDataURL(value, {
+      width: 180,
+      margin: 2,
+      errorCorrectionLevel: "M",
+      color: { dark: "#111111", light: "#ffffff" },
+    })
+      .then((dataUrl) => {
+        if (!cancelled) setState({ value, dataUrl, error: false });
+      })
+      .catch(() => {
+        // Do not log errors that could contain the binding URL.
+        if (!cancelled) setState({ value, dataUrl: null, error: true });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value]);
+
+  // Hide the previous QR immediately when a binding refreshes, even before effects run.
+  return state && value && state.value === value
+    ? { dataUrl: state.dataUrl, error: state.error }
+    : { dataUrl: null, error: false };
+}

--- a/src/i18n/messages/de/settings-remoteIm.ts
+++ b/src/i18n/messages/de/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const deSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Remote-IM-Bridge-Backend ist nicht die Rust-Runtime. Grok App neu starten.",
   "settings.remoteIm.bridge.agentConnectMissing": "Remote-IM-Bridge-Backend ist nicht die Rust-Runtime. Grok App neu starten.",
   "settings.remoteIm.scan.openLink": "Link öffnen",
+  "settings.remoteIm.scan.qrError": "Der QR-Code konnte nicht lokal erstellt werden. Verwenden Sie unten „Link öffnen“.",
   "settings.remoteIm.scan.needHost": "Scan braucht die Desktop-App (Tauri-Host). Im Browser-only-Modus Credentials einfügen.",
   "settings.remoteIm.scan.start": "Scan starten",
   "settings.remoteIm.scan.doneBtn": "Ich habe fertig gescannt",

--- a/src/i18n/messages/en/settings-remoteIm.ts
+++ b/src/i18n/messages/en/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const enSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Remote IM bridge backend is not the Rust runtime. Restart Grok App.",
   "settings.remoteIm.bridge.agentConnectMissing": "Remote IM bridge backend is not the Rust runtime. Restart Grok App.",
   "settings.remoteIm.scan.openLink": "Open link",
+  "settings.remoteIm.scan.qrError": "Could not generate the QR code locally. Use Open link below.",
   "settings.remoteIm.scan.needHost": "Scan requires the desktop app (Tauri host). Use paste credentials in browser-only mode.",
   "settings.remoteIm.scan.start": "Start scan",
   "settings.remoteIm.scan.doneBtn": "I finished scanning",

--- a/src/i18n/messages/es/settings-remoteIm.ts
+++ b/src/i18n/messages/es/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const esSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "El backend del bridge de Remote IM no es el runtime de Rust. Reinicia Grok App.",
   "settings.remoteIm.bridge.agentConnectMissing": "El backend del bridge de Remote IM no es el runtime de Rust. Reinicia Grok App.",
   "settings.remoteIm.scan.openLink": "Abrir enlace",
+  "settings.remoteIm.scan.qrError": "No se pudo generar el código QR localmente. Use «Abrir enlace» abajo.",
   "settings.remoteIm.scan.needHost": "Escanear requiere la aplicación de escritorio (host Tauri). Usa pegar credenciales en el modo solo navegador.",
   "settings.remoteIm.scan.start": "Iniciar escaneo",
   "settings.remoteIm.scan.doneBtn": "Ya he escaneado",

--- a/src/i18n/messages/fil/settings-remoteIm.ts
+++ b/src/i18n/messages/fil/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const filSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Hindi Rust runtime ang backend ng Remote IM bridge. I-restart ang Grok App.",
   "settings.remoteIm.bridge.agentConnectMissing": "Hindi Rust runtime ang backend ng Remote IM bridge. I-restart ang Grok App.",
   "settings.remoteIm.scan.openLink": "Buksan ang link",
+  "settings.remoteIm.scan.qrError": "Hindi magawa ang QR code nang lokal. Gamitin ang Buksan ang link sa ibaba.",
   "settings.remoteIm.scan.needHost": "Kailangan ng desktop app (Tauri host) ang scan. Gamitin ang paste credentials sa browser-only mode.",
   "settings.remoteIm.scan.start": "Simulan ang scan",
   "settings.remoteIm.scan.doneBtn": "Tapos na akong mag-scan",

--- a/src/i18n/messages/fr/settings-remoteIm.ts
+++ b/src/i18n/messages/fr/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const frSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Le backend Bridge Remote IM n’est pas le runtime Rust. Redémarrez Grok App.",
   "settings.remoteIm.bridge.agentConnectMissing": "Le backend Bridge Remote IM n’est pas le runtime Rust. Redémarrez Grok App.",
   "settings.remoteIm.scan.openLink": "Ouvrir le lien",
+  "settings.remoteIm.scan.qrError": "Impossible de générer le code QR localement. Utilisez « Ouvrir le lien » ci-dessous.",
   "settings.remoteIm.scan.needHost": "Le scan nécessite l’application de bureau (hôte Tauri). Utilisez coller les identifiants en mode navigateur uniquement.",
   "settings.remoteIm.scan.start": "Lancer le scan",
   "settings.remoteIm.scan.doneBtn": "J’ai fini de scanner",

--- a/src/i18n/messages/id/settings-remoteIm.ts
+++ b/src/i18n/messages/id/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const idSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Backend bridge Remote IM bukan runtime Rust. Mulai ulang Grok App.",
   "settings.remoteIm.bridge.agentConnectMissing": "Backend bridge Remote IM bukan runtime Rust. Mulai ulang Grok App.",
   "settings.remoteIm.scan.openLink": "Buka tautan",
+  "settings.remoteIm.scan.qrError": "Kode QR tidak dapat dibuat secara lokal. Gunakan Buka tautan di bawah.",
   "settings.remoteIm.scan.needHost": "Pindai memerlukan aplikasi desktop (host Tauri). Gunakan tempel kredensial di mode hanya-peramban.",
   "settings.remoteIm.scan.start": "Mulai pindai",
   "settings.remoteIm.scan.doneBtn": "Saya selesai memindai",

--- a/src/i18n/messages/it/settings-remoteIm.ts
+++ b/src/i18n/messages/it/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const itSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Il backend Bridge Remote IM non è il runtime Rust. Riavvia Grok App.",
   "settings.remoteIm.bridge.agentConnectMissing": "Il backend Bridge Remote IM non è il runtime Rust. Riavvia Grok App.",
   "settings.remoteIm.scan.openLink": "Apri link",
+  "settings.remoteIm.scan.qrError": "Impossibile generare il codice QR in locale. Usa «Apri link» qui sotto.",
   "settings.remoteIm.scan.needHost": "La scansione richiede l’app desktop (host Tauri). Usa incolla credenziali in modalità solo browser.",
   "settings.remoteIm.scan.start": "Avvia scansione",
   "settings.remoteIm.scan.doneBtn": "Ho finito di scansionare",

--- a/src/i18n/messages/ja/settings-remoteIm.ts
+++ b/src/i18n/messages/ja/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const jaSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Remote IM の Bridge バックエンドが Rust ランタイムではありません。Grok App を再起動してください。",
   "settings.remoteIm.bridge.agentConnectMissing": "Remote IM の Bridge バックエンドが Rust ランタイムではありません。Grok App を再起動してください。",
   "settings.remoteIm.scan.openLink": "リンクを開く",
+  "settings.remoteIm.scan.qrError": "QR コードをローカルで生成できませんでした。下の「リンクを開く」を使用してください。",
   "settings.remoteIm.scan.needHost": "スキャンにはデスクトップアプリ（Tauri host）が必要です。ブラウザのみの場合は「認証情報を貼り付け」を使ってください。",
   "settings.remoteIm.scan.start": "スキャンを開始",
   "settings.remoteIm.scan.doneBtn": "スキャン完了",

--- a/src/i18n/messages/ko/settings-remoteIm.ts
+++ b/src/i18n/messages/ko/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const koSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Remote IM 브릿지 백엔드가 Rust 런타임이 아닙니다. Grok App을 다시 시작하세요.",
   "settings.remoteIm.bridge.agentConnectMissing": "Remote IM 브릿지 백엔드가 Rust 런타임이 아닙니다. Grok App을 다시 시작하세요.",
   "settings.remoteIm.scan.openLink": "링크 열기",
+  "settings.remoteIm.scan.qrError": "QR 코드를 로컬에서 생성하지 못했습니다. 아래의 링크 열기를 사용하세요.",
   "settings.remoteIm.scan.needHost": "스캔은 데스크톱 앱(Tauri 호스트)이 필요합니다. 브라우저 전용 모드에서는 자격 증명 붙여넣기를 사용하세요.",
   "settings.remoteIm.scan.start": "스캔 시작",
   "settings.remoteIm.scan.doneBtn": "스캔을 마쳤습니다",

--- a/src/i18n/messages/pt-BR/settings-remoteIm.ts
+++ b/src/i18n/messages/pt-BR/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const ptBRSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "O backend do Remote IM Bridge não é o runtime Rust. Reinicie o Grok App.",
   "settings.remoteIm.bridge.agentConnectMissing": "O backend do Remote IM Bridge não é o runtime Rust. Reinicie o Grok App.",
   "settings.remoteIm.scan.openLink": "Abrir link",
+  "settings.remoteIm.scan.qrError": "Não foi possível gerar o código QR localmente. Use Abrir link abaixo.",
   "settings.remoteIm.scan.needHost": "Escanear exige o app de desktop (host Tauri). Use colar credenciais no modo só navegador.",
   "settings.remoteIm.scan.start": "Iniciar varredura",
   "settings.remoteIm.scan.doneBtn": "Terminei de escanear",

--- a/src/i18n/messages/ru/settings-remoteIm.ts
+++ b/src/i18n/messages/ru/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const ruSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Бэкенд моста Remote IM — не среда Rust. Перезапустите Grok App.",
   "settings.remoteIm.bridge.agentConnectMissing": "Бэкенд моста Remote IM — не среда Rust. Перезапустите Grok App.",
   "settings.remoteIm.scan.openLink": "Открыть ссылку",
+  "settings.remoteIm.scan.qrError": "Не удалось создать QR-код локально. Используйте «Открыть ссылку» ниже.",
   "settings.remoteIm.scan.needHost": "Сканирование доступно только в настольном приложении (Tauri Host). В режиме только браузера вставьте учётные данные.",
   "settings.remoteIm.scan.start": "Начать сканирование",
   "settings.remoteIm.scan.doneBtn": "Сканирование завершено",

--- a/src/i18n/messages/ta/settings-remoteIm.ts
+++ b/src/i18n/messages/ta/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const taSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "ரிமோட் IM பிரிட்ஜ் பின்தளமானது ரஸ்ட் இயக்க நேரம் அல்ல. Grok பயன்பாட்டை மறுதொடக்கம் செய்யுங்கள்.",
   "settings.remoteIm.bridge.agentConnectMissing": "ரிமோட் IM பிரிட்ஜ் பின்தளமானது ரஸ்ட் இயக்க நேரம் அல்ல. Grok பயன்பாட்டை மறுதொடக்கம் செய்யுங்கள்.",
   "settings.remoteIm.scan.openLink": "இணைப்பைத் திற",
+  "settings.remoteIm.scan.qrError": "QR குறியீட்டை உள்ளூரில் உருவாக்க முடியவில்லை. கீழே உள்ள இணைப்பைத் திற என்பதைப் பயன்படுத்தவும்.",
   "settings.remoteIm.scan.needHost": "ஸ்கேன் செய்ய டெஸ்க்டாப் செயலி (Tauri ஹோஸ்ட்) தேவை. உலாவி மட்டும் பயன்முறையில் பேஸ்ட் சான்றுகளைப் பயன்படுத்தவும்.",
   "settings.remoteIm.scan.start": "ஸ்கேன் தொடங்கவும்",
   "settings.remoteIm.scan.doneBtn": "ஸ்கேன் செய்து முடித்தேன்",

--- a/src/i18n/messages/uk/settings-remoteIm.ts
+++ b/src/i18n/messages/uk/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const ukSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "Remote IM bridge backend не є середовищем виконання Rust. Перезапустіть застосунок Grok.",
   "settings.remoteIm.bridge.agentConnectMissing": "Remote IM bridge backend не є середовищем виконання Rust. Перезапустіть застосунок Grok.",
   "settings.remoteIm.scan.openLink": "Відкрити посилання",
+  "settings.remoteIm.scan.qrError": "Не вдалося створити QR-код локально. Скористайтеся дією «Відкрити посилання» нижче.",
   "settings.remoteIm.scan.needHost": "Для сканування потрібна настільний застосунок (хост Tauri). Вставте облікові дані лише в режимі браузера.",
   "settings.remoteIm.scan.start": "Почати сканування",
   "settings.remoteIm.scan.doneBtn": "Я завершив сканування",

--- a/src/i18n/messages/zh-TW/settings-remoteIm.ts
+++ b/src/i18n/messages/zh-TW/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const zhTWSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "遠端 IM 未使用 Rust 內建橋。請重啟 Grok App。",
   "settings.remoteIm.bridge.agentConnectMissing": "遠端 IM 未使用 Rust 內建橋。請重啟 Grok App。",
   "settings.remoteIm.scan.openLink": "開啟連結",
+  "settings.remoteIm.scan.qrError": "無法在本機產生 QR 碼，請使用下方「開啟連結」。",
   "settings.remoteIm.scan.needHost": "掃碼需要桌面端 Host。僅瀏覽器模式請使用「貼上憑證」。",
   "settings.remoteIm.scan.start": "開始掃碼",
   "settings.remoteIm.scan.doneBtn": "我已完成",

--- a/src/i18n/messages/zh/settings-remoteIm.ts
+++ b/src/i18n/messages/zh/settings-remoteIm.ts
@@ -206,6 +206,7 @@ export const zhSettingsRemoteIm = {
   "settings.remoteIm.bridge.remoteBridgeMissing": "远程 IM 未使用 Rust 内置桥。请重启 Grok App。",
   "settings.remoteIm.bridge.agentConnectMissing": "远程 IM 未使用 Rust 内置桥。请重启 Grok App。",
   "settings.remoteIm.scan.openLink": "打开链接",
+  "settings.remoteIm.scan.qrError": "无法在本地生成二维码，请使用下方“打开链接”。",
   "settings.remoteIm.scan.needHost": "扫码需要桌面端 Host。仅浏览器模式请使用「粘贴凭证」。",
   "settings.remoteIm.scan.start": "开始扫码",
   "settings.remoteIm.scan.doneBtn": "我已完成",

--- a/src/lib/extensionsSurface.guard.test.ts
+++ b/src/lib/extensionsSurface.guard.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const read = (path: string) => readFileSync(resolve(__dirname, path), "utf8");
+const read = (path: string) => readFileSync(resolve(__dirname, path), "utf8").replace(/\r\n/g, "\n");
 
 describe("extensions settings surface guard", () => {
   it("wraps every extension tab in the shared opaque settings card", () => {

--- a/src/lib/pluginAuthTransport.test.ts
+++ b/src/lib/pluginAuthTransport.test.ts
@@ -1,0 +1,54 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+const bootstrap = readFileSync(new URL("../../src-tauri/src/plugin_auth_stdin.mjs", import.meta.url), "utf8");
+const fixtureRoot = mkdtempSync(join(tmpdir(), "grok-auth-transport-test-"));
+const fixture = join(fixtureRoot, "plugin with spaces.mjs");
+writeFileSync(fixture, `
+import { execFileSync } from "node:child_process";
+const commandLine = process.platform === "win32"
+  ? execFileSync("powershell.exe", ["-NoProfile", "-Command",
+      '(Get-CimInstance Win32_Process -Filter "ProcessId=' + process.pid + '").CommandLine'],
+      { encoding: "utf8", windowsHide: true }).trim()
+  : null;
+console.log(JSON.stringify({ args: process.argv.slice(2), commandLine }));
+`, "utf8");
+afterAll(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+
+describe("plugin auth private pipe on the real Node process", () => {
+  it("preserves CLI compatibility while secrets are absent from the OS command line", () => {
+    const args = ["login", "--tokens", "--api-key", "SIMULATED-KEY-987654321",
+      "--api-secret", "SIMULATED-SECRET-中文-\"-+", "--access-token", "SIMULATED-TOKEN-123456789"];
+    const out = execFileSync(process.execPath, ["--input-type=module", "--eval", bootstrap, fixture], {
+      input: JSON.stringify(args), encoding: "utf8", timeout: 20000, windowsHide: true,
+    });
+    const result = JSON.parse(out);
+    expect(result.args).toEqual(args);
+    if (process.platform === "win32") {
+      expect(result.commandLine).toContain("--input-type=module");
+      expect(result.commandLine).not.toContain("SIMULATED-");
+      expect(result.commandLine).not.toContain("--api-key");
+    }
+  }, 25000);
+
+  it("rejects malformed input without repeating any payload in the error", () => {
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", bootstrap, fixture], {
+      input: "{INVALID_SYNTHETIC_SECRET", encoding: "utf8", timeout: 10000, windowsHide: true,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Invalid plugin auth input");
+    expect(result.stderr).not.toContain("INVALID_SYNTHETIC_SECRET");
+  });
+
+  it("limits private input before importing the plugin", () => {
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", bootstrap, fixture], {
+      input: JSON.stringify(["X".repeat(70000)]), encoding: "utf8", timeout: 10000, windowsHide: true,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Plugin auth input is too large");
+    expect(result.stdout).toBe("");
+  });
+});

--- a/src/lib/welcomeIntro.guard.test.ts
+++ b/src/lib/welcomeIntro.guard.test.ts
@@ -2,9 +2,9 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const app = readFileSync(resolve(__dirname, "../app/AppWorkbench.tsx"), "utf8") +
+const app = (readFileSync(resolve(__dirname, "../app/AppWorkbench.tsx"), "utf8") +
   readFileSync(resolve(__dirname, "../app/WorkbenchComposerColumn.tsx"), "utf8") +
-  readFileSync(resolve(__dirname, "../hooks/useSessionNavigation.ts"), "utf8");
+  readFileSync(resolve(__dirname, "../hooks/useSessionNavigation.ts"), "utf8")).replace(/\r\n/g, "\n");
 const css = readFileSync(resolve(__dirname, "../styles/chat.part1.css"), "utf8");
 const phoneCss = readFileSync(
   resolve(__dirname, "../styles/phone.part1.css"),


### PR DESCRIPTION
## Summary
Maintainer slice of draft #1049 (@Johnny-dot): only the **safe, no-UX-default** parts.

### Included (A + B)
- Remote IM binding QR generated locally (`useLocalQrCode` + `qrcode`); no `api.qrserver.com`
- X API plugin auth args via private stdin pipe (`plugin_auth_transport` + embedded launcher); output redaction + timeout

### Explicitly NOT included (stay on #1049)
- CLI install: missing checksum fail-closed by default (overturns #227)
- Keychain default `true` for new settings

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/hooks/useLocalQrCode.test.tsx src/lib/pluginAuthTransport.test.ts src/lib/whatsNew.test.ts src/i18n/messages.test.ts`
- [x] `cargo test --lib plugin_auth_transport`
- [x] `python3 scripts/check-code-quality-gates.py --mode final`
- [ ] CI green

Partial of #1049