### PR TITLE
fix(media): 将本地媒体服务绑定到浏览器安全端口

### DIFF
--- a/docs/llm-wiki/media-delivery.md
+++ b/docs/llm-wiki/media-delivery.md
@@ -9,7 +9,12 @@
 
 ## Delivery: loopback HTTP (primary)
 
-Host starts a process-local axum server on `127.0.0.1:0` at app boot (`media_server.rs`).
+Host starts a process-local axum server on a random available port in the
+browser-safe dynamic/private range `127.0.0.1:49152-65535` at app boot
+(`media_server.rs`). Do not bind `127.0.0.1:0`: hosts with a customized
+ephemeral range can return Chromium-blocked service ports such as `3659`, and
+WebView2 then rejects media with `ERR_UNSAFE_PORT` before the request reaches
+the server.
 
 ```
 GET http://127.0.0.1:{port}/v1/media?t={token}&p={urlencode(absPath)}

--- a/src-tauri/src/integration_test.rs
+++ b/src-tauri/src/integration_test.rs
@@ -135,29 +135,31 @@ mod integration {
 
     #[test]
     fn settings_default_factory_and_disk_roundtrip() {
-        let _ = ensure_app_dirs();
-        // Factory defaults (not necessarily what's already on disk)
-        let factory = AppSettings::default();
-        assert_eq!(factory.session_data_mode, "shared");
-        assert_eq!(factory.permission_policy, "ask");
-        assert_eq!(factory.sandbox_profile, "workspace");
-        assert!(!factory.reopen_last_session);
-        assert!(factory.last_session_id.is_none());
-        assert!(factory.sidebar_collapsed_project_ids.is_empty());
-        assert!(factory.sidebar_other_sessions_open);
-        assert!(factory.project_spaces.is_empty());
-        assert!(factory.active_project_space_id.is_none());
-        assert!(factory.project_space_by_id.is_empty());
-        // Disk load + save same content must not corrupt
-        let s = load_settings();
-        save_settings(&s).expect("save");
-        let s2 = load_settings();
-        assert_eq!(s2.session_data_mode, s.session_data_mode);
-        assert_eq!(s2.permission_policy, s.permission_policy);
-        assert_eq!(s2.sandbox_profile, s.sandbox_profile);
-        assert_eq!(s2.reopen_last_session, s.reopen_last_session);
-        let root = app_data_root();
-        assert!(!root.as_os_str().is_empty());
+        with_isolated_project_store(|| {
+            let _ = ensure_app_dirs();
+            // Factory defaults (not necessarily what's already on disk)
+            let factory = AppSettings::default();
+            assert_eq!(factory.session_data_mode, "shared");
+            assert_eq!(factory.permission_policy, "ask");
+            assert_eq!(factory.sandbox_profile, "workspace");
+            assert!(!factory.reopen_last_session);
+            assert!(factory.last_session_id.is_none());
+            assert!(factory.sidebar_collapsed_project_ids.is_empty());
+            assert!(factory.sidebar_other_sessions_open);
+            assert!(factory.project_spaces.is_empty());
+            assert!(factory.active_project_space_id.is_none());
+            assert!(factory.project_space_by_id.is_empty());
+            // Disk load + save same content must not corrupt
+            let s = load_settings();
+            save_settings(&s).expect("save");
+            let s2 = load_settings();
+            assert_eq!(s2.session_data_mode, s.session_data_mode);
+            assert_eq!(s2.permission_policy, s.permission_policy);
+            assert_eq!(s2.sandbox_profile, s.sandbox_profile);
+            assert_eq!(s2.reopen_last_session, s.reopen_last_session);
+            let root = app_data_root();
+            assert!(!root.as_os_str().is_empty());
+        });
     }
 
     #[test]

--- a/src-tauri/src/media_server.rs
+++ b/src-tauri/src/media_server.rs
@@ -33,6 +33,14 @@ use tokio::sync::oneshot;
 /// Max bytes returned per Range request (keeps memory bounded — video/audio/PDF).
 const MAX_CHUNK: u64 = 2 * 1024 * 1024; // 2 MiB
 
+/// Browser-safe dynamic/private port range. Binding port `0` can return a
+/// Chromium-blocked service port on hosts with a customized ephemeral range
+/// (for example 3659), causing every media request to fail with
+/// `ERR_UNSAFE_PORT` before it reaches the loopback server.
+const MEDIA_PORT_MIN: u16 = 49_152;
+const MEDIA_PORT_MAX: u16 = 65_535;
+const MEDIA_PORT_BIND_ATTEMPTS: u32 = 64;
+
 /// Max full-body response without Range (chat images, small binaries).
 /// `<img>` tags do not reassemble multi-Range responses — truncating at
 /// MAX_CHUNK yields broken/empty thumbnails for common multi-MB photos.
@@ -98,7 +106,47 @@ struct MediaQuery {
     p: String,
 }
 
-/// Bind `127.0.0.1:0`, spawn axum serve task, return handle.
+fn is_browser_safe_media_port(port: u16) -> bool {
+    (MEDIA_PORT_MIN..=MEDIA_PORT_MAX).contains(&port)
+}
+
+fn browser_safe_media_port_candidate(start: u32, step: u32, offset: u32) -> u16 {
+    let span = u32::from(MEDIA_PORT_MAX) - u32::from(MEDIA_PORT_MIN) + 1;
+    debug_assert!(start < span);
+    debug_assert!(step < span && step % 2 == 1);
+    (u32::from(MEDIA_PORT_MIN) + ((start + offset * step) % span)) as u16
+}
+
+async fn bind_browser_safe_loopback() -> Result<TcpListener, String> {
+    let span = u32::from(MEDIA_PORT_MAX) - u32::from(MEDIA_PORT_MIN) + 1;
+    let (start, step) = {
+        let mut rng = rand::thread_rng();
+        // The range contains 2^14 ports, so any odd step walks unique values.
+        // Spreading attempts avoids failing inside one large Hyper-V/WSL
+        // excluded-port block even when plenty of safe ports remain elsewhere.
+        (rng.next_u32() % span, (rng.next_u32() % span) | 1)
+    };
+    let mut last_error = None;
+
+    for offset in 0..MEDIA_PORT_BIND_ATTEMPTS {
+        let port = browser_safe_media_port_candidate(start, step, offset);
+        debug_assert!(is_browser_safe_media_port(port));
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        match TcpListener::bind(addr).await {
+            Ok(listener) => return Ok(listener),
+            Err(error) => last_error = Some(error),
+        }
+    }
+
+    let detail = last_error
+        .map(|error| format!(": {error}"))
+        .unwrap_or_default();
+    Err(format!(
+        "media server bind: no browser-safe loopback port available after {MEDIA_PORT_BIND_ATTEMPTS} attempts{detail}"
+    ))
+}
+
+/// Bind a browser-safe loopback port, spawn axum serve task, return handle.
 pub async fn start() -> Result<MediaServerHandle, String> {
     let token = random_token();
     let state = ServerState {
@@ -114,10 +162,7 @@ pub async fn start() -> Result<MediaServerHandle, String> {
         .fallback(fallback_not_found)
         .with_state(state);
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 0));
-    let listener = TcpListener::bind(addr)
-        .await
-        .map_err(|e| format!("media server bind: {e}"))?;
+    let listener = bind_browser_safe_loopback().await?;
     let bound = listener
         .local_addr()
         .map_err(|e| format!("media server local_addr: {e}"))?
@@ -377,7 +422,6 @@ async fn media_get(
         .get(header::RANGE)
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
-
     // File I/O off the async runtime.
     let result = tokio::task::spawn_blocking(move || {
         read_file_chunk(&path, range_hdr.as_deref(), method == Method::HEAD)
@@ -636,6 +680,26 @@ mod tests {
     use std::io::Write;
 
     #[test]
+    fn media_server_ports_stay_out_of_chromium_blocked_ranges() {
+        assert!(!is_browser_safe_media_port(3659));
+        assert!(!is_browser_safe_media_port(MEDIA_PORT_MIN - 1));
+        assert!(is_browser_safe_media_port(MEDIA_PORT_MIN));
+        assert!(is_browser_safe_media_port(MEDIA_PORT_MAX));
+    }
+
+    #[test]
+    fn media_server_attempts_are_unique_and_spread_across_the_safe_range() {
+        let ports = (0..MEDIA_PORT_BIND_ATTEMPTS)
+            .map(|offset| browser_safe_media_port_candidate(0, 257, offset))
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(ports.len(), MEDIA_PORT_BIND_ATTEMPTS as usize);
+        assert!(ports.iter().all(|port| is_browser_safe_media_port(*port)));
+        let min = u32::from(*ports.iter().min().unwrap());
+        let max = u32::from(*ports.iter().max().unwrap());
+        assert!(max - min > MEDIA_PORT_BIND_ATTEMPTS);
+    }
+
+    #[test]
     fn parse_range_suffix_and_cap() {
         assert_eq!(parse_range("bytes=0-9", 100), Some((0, 9)));
         assert_eq!(
@@ -719,6 +783,13 @@ mod tests {
         crate::path_scope::grant_path(&file);
 
         let handle = start().await.expect("start");
+        let port = handle
+            .endpoint
+            .base_url
+            .rsplit_once(':')
+            .and_then(|(_, value)| value.parse::<u16>().ok())
+            .expect("media server port");
+        assert!(is_browser_safe_media_port(port));
         let url = url_for_path(&handle.endpoint(), &file.to_string_lossy());
         let client = reqwest::Client::new();
         let res = client.get(&url).send().await.expect("get");


### PR DESCRIPTION
## Summary

修复本地媒体服务偶尔分配到 Chromium 禁用端口后，图片、视频和附件预览报 `ERR_UNSAFE_PORT` 的问题。自定义系统临时端口范围可能让绑定端口 `0` 返回 `3659` 等端口，WebView2 会在请求到达服务前拒绝访问。

改为在 `49152–65535` 范围随机选择起点和奇数步长，最多尝试 64 个不重复端口，以分散避开占用或系统保留区间。监听仍限定回环地址，沿用现有 token、路径权限和 Range 行为。

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / chore

## 验证与范围

- 覆盖候选端口范围、候选唯一性/分散性，以及真实服务启动和媒体读取。
- 前端 586 文件、7,055 项测试通过；类型检查、lint、UI 构建、质量门禁、网站自测、依赖卫生与审计通过。
- Windows Rust fmt/clippy 通过；原生测试 1,607 项通过、1 项原有 ignored。尚未在此独立分支进行手动桌面播放验证。
- 前置依赖：#1074。为保证并行原生测试可靠，本分支保留该独立测试修复提交；媒体修复是后一个提交，可单独审查。请先合入 #1074，再合入本 PR；前置合入后将更新基底，去除重复差异。

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — 无新界面文案
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
