### PR TITLE
fix(windows): 完善拖放介质释放和失败状态清理

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -102,6 +102,7 @@ windows = { version = "0.61", features = [
     "Win32_System_Com_StructuredStorage",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Kernel",
+    "Win32_System_Memory",
     "Win32_System_Ole",
     "Win32_System_SystemServices",
     "Win32_UI_Input_KeyboardAndMouse",

--- a/src-tauri/src/integration_test.rs
+++ b/src-tauri/src/integration_test.rs
@@ -135,29 +135,31 @@ mod integration {
 
     #[test]
     fn settings_default_factory_and_disk_roundtrip() {
-        let _ = ensure_app_dirs();
-        // Factory defaults (not necessarily what's already on disk)
-        let factory = AppSettings::default();
-        assert_eq!(factory.session_data_mode, "shared");
-        assert_eq!(factory.permission_policy, "ask");
-        assert_eq!(factory.sandbox_profile, "workspace");
-        assert!(!factory.reopen_last_session);
-        assert!(factory.last_session_id.is_none());
-        assert!(factory.sidebar_collapsed_project_ids.is_empty());
-        assert!(factory.sidebar_other_sessions_open);
-        assert!(factory.project_spaces.is_empty());
-        assert!(factory.active_project_space_id.is_none());
-        assert!(factory.project_space_by_id.is_empty());
-        // Disk load + save same content must not corrupt
-        let s = load_settings();
-        save_settings(&s).expect("save");
-        let s2 = load_settings();
-        assert_eq!(s2.session_data_mode, s.session_data_mode);
-        assert_eq!(s2.permission_policy, s.permission_policy);
-        assert_eq!(s2.sandbox_profile, s.sandbox_profile);
-        assert_eq!(s2.reopen_last_session, s.reopen_last_session);
-        let root = app_data_root();
-        assert!(!root.as_os_str().is_empty());
+        with_isolated_project_store(|| {
+            let _ = ensure_app_dirs();
+            // Factory defaults (not necessarily what's already on disk)
+            let factory = AppSettings::default();
+            assert_eq!(factory.session_data_mode, "shared");
+            assert_eq!(factory.permission_policy, "ask");
+            assert_eq!(factory.sandbox_profile, "workspace");
+            assert!(!factory.reopen_last_session);
+            assert!(factory.last_session_id.is_none());
+            assert!(factory.sidebar_collapsed_project_ids.is_empty());
+            assert!(factory.sidebar_other_sessions_open);
+            assert!(factory.project_spaces.is_empty());
+            assert!(factory.active_project_space_id.is_none());
+            assert!(factory.project_space_by_id.is_empty());
+            // Disk load + save same content must not corrupt
+            let s = load_settings();
+            save_settings(&s).expect("save");
+            let s2 = load_settings();
+            assert_eq!(s2.session_data_mode, s.session_data_mode);
+            assert_eq!(s2.permission_policy, s.permission_policy);
+            assert_eq!(s2.sandbox_profile, s.sandbox_profile);
+            assert_eq!(s2.reopen_last_session, s.reopen_last_session);
+            let root = app_data_root();
+            assert!(!root.as_os_str().is_empty());
+        });
     }
 
     #[test]

--- a/src-tauri/src/win_file_drop.rs
+++ b/src-tauri/src/win_file_drop.rs
@@ -33,7 +33,7 @@ use windows::{
         Foundation::{HWND, LPARAM, POINT, POINTL},
         Graphics::Gdi::ScreenToClient,
         System::{
-            Com::{IDataObject, DVASPECT_CONTENT, FORMATETC, TYMED_HGLOBAL},
+            Com::{IDataObject, DVASPECT_CONTENT, FORMATETC, STGMEDIUM, TYMED_HGLOBAL},
             Ole::{
                 IDropTarget, IDropTarget_Impl, OleInitialize, RegisterDragDrop, ReleaseStgMedium,
                 RevokeDragDrop, CF_HDROP, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_NONE,
@@ -172,6 +172,15 @@ enum DropKind {
     Leave,
 }
 
+struct DropMedium(STGMEDIUM);
+
+impl Drop for DropMedium {
+    fn drop(&mut self) {
+        // IDataObject can delegate ownership through pUnkForRelease.
+        unsafe { ReleaseStgMedium(&mut self.0) };
+    }
+}
+
 fn inject_hwnd(hwnd: HWND, coordinate_hwnd: HWND, listener: Rc<dyn Fn(DropKind)>) -> bool {
     if hwnd.0.is_null() {
         return false;
@@ -246,13 +255,7 @@ impl FileDropTarget {
         }
     }
 
-    unsafe fn iterate_filenames<F>(
-        data_obj: windows_core::Ref<'_, IDataObject>,
-        mut callback: F,
-    ) -> bool
-    where
-        F: FnMut(PathBuf),
-    {
+    unsafe fn read_paths(data_obj: windows_core::Ref<'_, IDataObject>) -> Option<Vec<String>> {
         let drop_format = FORMATETC {
             cfFormat: CF_HDROP.0,
             ptd: ptr::null_mut(),
@@ -261,22 +264,29 @@ impl FileDropTarget {
             tymed: TYMED_HGLOBAL.0 as u32,
         };
 
-        let Some(obj) = data_obj.as_ref() else {
-            return false;
-        };
-        let Ok(mut medium) = obj.GetData(&drop_format) else {
-            return false;
-        };
-        let hdrop = HDROP(medium.u.hGlobal.0 as _);
+        let obj = data_obj.as_ref()?;
+        let medium = obj.GetData(&drop_format).ok()?;
+        Self::paths_from_medium(medium)
+    }
+
+    unsafe fn paths_from_medium(medium: STGMEDIUM) -> Option<Vec<String>> {
+        let medium = DropMedium(medium);
+        if medium.0.tymed != TYMED_HGLOBAL.0 as u32 || medium.0.u.hGlobal.0.is_null() {
+            return None;
+        }
+        let hdrop = HDROP(medium.0.u.hGlobal.0);
         let item_count = DragQueryFileW(hdrop, 0xFFFFFFFF, None);
+        let mut paths = Vec::new();
         for i in 0..item_count {
             let character_count = DragQueryFileW(hdrop, i, None) as usize;
             let mut path_buf = vec![0u16; character_count + 1];
-            DragQueryFileW(hdrop, i, Some(&mut path_buf));
-            callback(OsString::from_wide(&path_buf[..character_count]).into());
+            let copied = DragQueryFileW(hdrop, i, Some(&mut path_buf)) as usize;
+            if copied == 0 || copied != character_count {
+                return None;
+            }
+            paths.push(OsString::from_wide(&path_buf[..copied]).into());
         }
-        ReleaseStgMedium(&mut medium);
-        true
+        Some(Self::paths_as_strings(paths))
     }
 
     fn client_point(hwnd: HWND, pt: &POINTL) -> (i32, i32) {
@@ -309,19 +319,13 @@ impl IDropTarget_Impl for FileDropTarget_Impl {
         pdwEffect: *mut DROPEFFECT,
     ) -> windows::core::Result<()> {
         let (x, y) = FileDropTarget::client_point(self.coordinate_hwnd, pt);
-        let mut paths = Vec::new();
-        let has_data =
-            unsafe { FileDropTarget::iterate_filenames(pDataObj, |path| paths.push(path)) };
-        let enter_is_valid = has_data && !paths.is_empty();
+        let paths = unsafe { FileDropTarget::read_paths(pDataObj) }.unwrap_or_default();
+        let enter_is_valid = !paths.is_empty();
         unsafe {
             *self.enter_is_valid.get() = enter_is_valid;
         }
         let effect = if enter_is_valid {
-            (self.listener)(DropKind::Enter {
-                paths: FileDropTarget::paths_as_strings(paths),
-                x,
-                y,
-            });
+            (self.listener)(DropKind::Enter { paths, x, y });
             DROPEFFECT_COPY
         } else {
             DROPEFFECT_NONE
@@ -352,9 +356,10 @@ impl IDropTarget_Impl for FileDropTarget_Impl {
     fn DragLeave(&self) -> windows::core::Result<()> {
         if unsafe { *self.enter_is_valid.get() } {
             (self.listener)(DropKind::Leave);
-            unsafe {
-                *self.enter_is_valid.get() = false;
-            }
+        }
+        unsafe {
+            *self.enter_is_valid.get() = false;
+            *self.cursor_effect.get() = DROPEFFECT_NONE;
         }
         Ok(())
     }
@@ -366,21 +371,21 @@ impl IDropTarget_Impl for FileDropTarget_Impl {
         pt: &POINTL,
         pdwEffect: *mut DROPEFFECT,
     ) -> windows::core::Result<()> {
+        let mut effect = DROPEFFECT_NONE;
         if unsafe { *self.enter_is_valid.get() } {
             let (x, y) = FileDropTarget::client_point(self.coordinate_hwnd, pt);
-            let mut paths = Vec::new();
-            unsafe { FileDropTarget::iterate_filenames(pDataObj, |path| paths.push(path)) };
-            (self.listener)(DropKind::Drop {
-                paths: FileDropTarget::paths_as_strings(paths),
-                x,
-                y,
-            });
-            unsafe {
-                *self.enter_is_valid.get() = false;
+            let paths = unsafe { FileDropTarget::read_paths(pDataObj) }.unwrap_or_default();
+            if !paths.is_empty() {
+                (self.listener)(DropKind::Drop { paths, x, y });
+                effect = DROPEFFECT_COPY;
+            } else {
+                (self.listener)(DropKind::Leave);
             }
         }
         unsafe {
-            *pdwEffect = *self.cursor_effect.get();
+            *self.enter_is_valid.get() = false;
+            *self.cursor_effect.get() = DROPEFFECT_NONE;
+            *pdwEffect = effect;
         }
         Ok(())
     }
@@ -388,8 +393,124 @@ impl IDropTarget_Impl for FileDropTarget_Impl {
 
 #[cfg(test)]
 mod tests {
-    use super::FileDropTarget;
-    use std::path::PathBuf;
+    use super::*;
+    use std::{cell::Cell, mem::ManuallyDrop};
+    use windows::{
+        core::Interface,
+        Win32::{
+            Foundation::{GlobalFree, HGLOBAL},
+            System::{
+                Com::STGMEDIUM_0,
+                Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE, GMEM_ZEROINIT},
+            },
+            UI::Shell::DROPFILES,
+        },
+    };
+
+    struct MediumOwner {
+        handle: HGLOBAL,
+        releases: Rc<Cell<usize>>,
+    }
+
+    impl Drop for MediumOwner {
+        fn drop(&mut self) {
+            // GlobalFree returns a null handle on success, which the generated
+            // windows Result wrapper represents as an HRESULT-shaped error.
+            let _ = unsafe { GlobalFree(Some(self.handle)) };
+            self.releases.set(self.releases.get() + 1);
+        }
+    }
+
+    fn file_medium(paths: &[&str], releases: Rc<Cell<usize>>) -> STGMEDIUM {
+        let file_list: Vec<u16> = paths
+            .iter()
+            .flat_map(|path| path.encode_utf16().chain([0]))
+            .chain([0])
+            .collect();
+        let header_size = size_of::<DROPFILES>();
+        let handle = unsafe {
+            GlobalAlloc(
+                GMEM_MOVEABLE | GMEM_ZEROINIT,
+                header_size + file_list.len() * size_of::<u16>(),
+            )
+            .unwrap()
+        };
+        let owner = MediumOwner { handle, releases };
+        unsafe {
+            let buffer = GlobalLock(handle).cast::<u8>();
+            assert!(!buffer.is_null());
+            buffer.cast::<DROPFILES>().write_unaligned(DROPFILES {
+                pFiles: header_size as u32,
+                fWide: true.into(),
+                ..Default::default()
+            });
+            ptr::copy_nonoverlapping(
+                file_list.as_ptr().cast::<u8>(),
+                buffer.add(header_size),
+                file_list.len() * size_of::<u16>(),
+            );
+            let _ = GlobalUnlock(handle);
+        }
+        // Reuse a COM object whose last release also frees the test's HGLOBAL.
+        let release_target: IDropTarget = FileDropTarget::new(
+            HWND(ptr::null_mut()),
+            Rc::new(move |_| {
+                let _ = &owner;
+            }),
+        )
+        .into();
+        STGMEDIUM {
+            tymed: TYMED_HGLOBAL.0 as u32,
+            u: STGMEDIUM_0 { hGlobal: handle },
+            pUnkForRelease: ManuallyDrop::new(Some(release_target.cast().unwrap())),
+        }
+    }
+
+    #[test]
+    fn copied_paths_release_delegated_medium_exactly_once() {
+        let releases = Rc::new(Cell::new(0));
+        let medium = file_medium(&[r"C:\Work\one.jpg", r"C:\Work\two.png"], releases.clone());
+        let paths = unsafe { FileDropTarget::paths_from_medium(medium) }.unwrap();
+        assert_eq!(paths, vec![r"C:\Work\one.jpg", r"C:\Work\two.png"]);
+        assert_eq!(releases.get(), 1);
+    }
+
+    #[test]
+    fn invalid_medium_still_releases_delegated_owner() {
+        let releases = Rc::new(Cell::new(0));
+        let mut medium = file_medium(&[r"C:\Work\one.jpg"], releases.clone());
+        medium.u.hGlobal = HGLOBAL(ptr::null_mut());
+        assert!(unsafe { FileDropTarget::paths_from_medium(medium) }.is_none());
+        assert_eq!(releases.get(), 1);
+    }
+
+    #[test]
+    fn missing_drop_data_clears_hover_and_rejects_copy() {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let listener_events = events.clone();
+        let target = FileDropTarget::new(
+            HWND(ptr::null_mut()),
+            Rc::new(move |event| listener_events.borrow_mut().push(event)),
+        );
+        // The data source disappears after a valid DragEnter.
+        unsafe {
+            *target.enter_is_valid.get() = true;
+            *target.cursor_effect.get() = DROPEFFECT_COPY;
+        }
+        let target: IDropTarget = target.into();
+        let mut effect = DROPEFFECT_COPY;
+        unsafe {
+            target
+                .Drop(None, MODIFIERKEYS_FLAGS(0), POINTL::default(), &mut effect)
+                .unwrap();
+            assert_eq!(effect, DROPEFFECT_NONE);
+            target
+                .DragOver(MODIFIERKEYS_FLAGS(0), POINTL::default(), &mut effect)
+                .unwrap();
+        }
+        assert_eq!(effect, DROPEFFECT_NONE);
+        assert!(matches!(&events.borrow()[..], [DropKind::Leave]));
+    }
 
     #[test]
     fn paths_as_strings_normalizes_and_dedupes() {


### PR DESCRIPTION
## Summary

完善 Windows 原生文件拖放的数据释放和失败状态清理。将 `STGMEDIUM` 的释放收拢到 RAII 守卫，在成功和无效数据分支都调用 `ReleaseStgMedium`，并遵守数据源通过 `pUnkForRelease` 委托的 COM 所有权；文件路径在释放前复制。

如果有效拖入后数据源在放下时失效，发送离开事件并返回 `DROPEFFECT_NONE`，清除悬停和复制状态，避免发送空文件列表后仍显示成功复制。

相关历史 Issue：#1017（已关闭）。该问题的延迟注册修复已在上游，本 PR 是同一原生拖放模块的资源和状态清理补强，不重复提交其注册逻辑，也不宣称重新解决原 Issue。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## 验证与范围

- 原生回归覆盖多文件路径复制、委托资源恰好释放一次、无效介质释放、数据源消失后清理悬停和复制效果。
- 前端 586 文件、7,055 项测试及类型检查、lint、UI 构建、质量门禁、网站自测、依赖卫生与审计通过。
- Windows Rust fmt/clippy 通过；原生测试 1,608 项通过、1 项原有 ignored。本分支尚未进行手动资源管理器拖入验证。
- 前置依赖：#1074。为保证并行原生测试可靠，本分支保留该独立测试修复提交；拖放修复是后一个提交，可单独审查。请先合入 #1074，再合入本 PR；前置合入后将更新基底，去除重复差异。

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — 无新界面文案
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — 无产品契约变更
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
