### PR TITLE
fix(search): 忽略搜索面板关闭后的迟到结果

### DIFF
--- a/src-tauri/src/integration_test.rs
+++ b/src-tauri/src/integration_test.rs
@@ -135,29 +135,31 @@ mod integration {
 
     #[test]
     fn settings_default_factory_and_disk_roundtrip() {
-        let _ = ensure_app_dirs();
-        // Factory defaults (not necessarily what's already on disk)
-        let factory = AppSettings::default();
-        assert_eq!(factory.session_data_mode, "shared");
-        assert_eq!(factory.permission_policy, "ask");
-        assert_eq!(factory.sandbox_profile, "workspace");
-        assert!(!factory.reopen_last_session);
-        assert!(factory.last_session_id.is_none());
-        assert!(factory.sidebar_collapsed_project_ids.is_empty());
-        assert!(factory.sidebar_other_sessions_open);
-        assert!(factory.project_spaces.is_empty());
-        assert!(factory.active_project_space_id.is_none());
-        assert!(factory.project_space_by_id.is_empty());
-        // Disk load + save same content must not corrupt
-        let s = load_settings();
-        save_settings(&s).expect("save");
-        let s2 = load_settings();
-        assert_eq!(s2.session_data_mode, s.session_data_mode);
-        assert_eq!(s2.permission_policy, s.permission_policy);
-        assert_eq!(s2.sandbox_profile, s.sandbox_profile);
-        assert_eq!(s2.reopen_last_session, s.reopen_last_session);
-        let root = app_data_root();
-        assert!(!root.as_os_str().is_empty());
+        with_isolated_project_store(|| {
+            let _ = ensure_app_dirs();
+            // Factory defaults (not necessarily what's already on disk)
+            let factory = AppSettings::default();
+            assert_eq!(factory.session_data_mode, "shared");
+            assert_eq!(factory.permission_policy, "ask");
+            assert_eq!(factory.sandbox_profile, "workspace");
+            assert!(!factory.reopen_last_session);
+            assert!(factory.last_session_id.is_none());
+            assert!(factory.sidebar_collapsed_project_ids.is_empty());
+            assert!(factory.sidebar_other_sessions_open);
+            assert!(factory.project_spaces.is_empty());
+            assert!(factory.active_project_space_id.is_none());
+            assert!(factory.project_space_by_id.is_empty());
+            // Disk load + save same content must not corrupt
+            let s = load_settings();
+            save_settings(&s).expect("save");
+            let s2 = load_settings();
+            assert_eq!(s2.session_data_mode, s.session_data_mode);
+            assert_eq!(s2.permission_policy, s.permission_policy);
+            assert_eq!(s2.sandbox_profile, s.sandbox_profile);
+            assert_eq!(s2.reopen_last_session, s.reopen_last_session);
+            let root = app_data_root();
+            assert!(!root.as_os_str().is_empty());
+        });
     }
 
     #[test]

--- a/src/hooks/useSearchPalette.test.ts
+++ b/src/hooks/useSearchPalette.test.ts
@@ -4,11 +4,23 @@
  * Palette open/query/filters live in this hook. AppWorkbench only supplies
  * action dispatch and session/project pick.
  */
-import { describe, expect, it, vi } from "vitest";
-import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { createT } from "@/i18n";
+import { sessionsSearch } from "@/lib/api";
 import { useSearchPalette } from "./useSearchPalette";
 import type { PaletteActionDef } from "@/lib/paletteActions";
+
+vi.mock("@/lib/api", () => ({
+  sessionsSearch: vi.fn(async () => []),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  localStorage.clear();
+});
 
 function setup(onRunAction = vi.fn()) {
   return renderHook(() =>
@@ -26,6 +38,43 @@ function setup(onRunAction = vi.fn()) {
 }
 
 describe("useSearchPalette", () => {
+  it.each(["close", "clear", "title"] as const)(
+    "ignores an in-flight content search after %s stops scanning",
+    async (stop) => {
+      vi.useFakeTimers();
+      let finish!: (hits: Awaited<ReturnType<typeof sessionsSearch>>) => void;
+      vi.mocked(sessionsSearch).mockReturnValueOnce(
+        new Promise((resolve) => { finish = resolve; }),
+      );
+      const { result } = setup();
+      act(() => {
+        result.current.openBlank();
+        result.current.setQuery("needle");
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(280); });
+      expect(sessionsSearch).toHaveBeenCalledWith("needle", 20);
+      expect(result.current.contentLoading).toBe(true);
+      act(() => {
+        if (stop === "close") result.current.closePalette();
+        if (stop === "clear") result.current.setQuery("");
+        if (stop === "title") result.current.applyMode("title");
+      });
+      await act(async () => {
+        finish([{
+          id: "late-content",
+          title: "needle",
+          projectId: null,
+          snippet: "needle in the journal",
+          matchCount: 1,
+          updatedAt: "2026-09-06T00:00:00Z",
+          archived: false,
+        }]);
+      });
+      expect(result.current.sessionHits.map((hit) => hit.id)).not.toContain("late-content");
+      expect(result.current.contentLoading).toBe(false);
+    },
+  );
+
   it("openBlank clears the query and opens", () => {
     const { result } = setup();
     act(() => {

--- a/src/hooks/useSearchPalette.ts
+++ b/src/hooks/useSearchPalette.ts
@@ -209,7 +209,12 @@ export function useSearchPalette(opts: {
         }
       })();
     }, 280);
-    return () => window.clearTimeout(t);
+    return () => {
+      // A dispatched IPC cannot be cancelled by clearing its debounce timer.
+      // Invalidate late success, failure and finally callbacks on close/unmount.
+      contentSeq.current += 1;
+      window.clearTimeout(t);
+    };
   }, [query, open, mode]);
 
   const searchHits = useMemo(


### PR DESCRIPTION
## Summary

修复会话搜索面板关闭、查询清空或切换到仅标题搜索后，已发出的内容搜索仍可能回写旧结果的问题。清除防抖计时器只能阻止未发出的请求，不能取消已经发出的 IPC。

在 effect 清理时递增请求序号，让旧请求的成功、失败及 loading 清理回调失效。没有改变正常搜索的防抖时长、排序和结果数量。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## 验证与范围

- 新增关闭、清空和切换模式三种迟到结果回归，聚焦测试 6 项通过；全量前端 586 文件、7,058 项测试通过。
- 类型检查、lint、UI 构建、质量门禁、网站自测、依赖卫生与审计通过。
- Windows Rust fmt/clippy 通过；原生测试 1,605 项通过、1 项原有 ignored。
- 这是通用会话搜索修复，与壁纸渠道接入独立。前置测试修复为 #1074；本 PR 保留其独立提交以保证并行测试可靠，请先合入 #1074，届时更新基底移除重复差异。业务修复可单独审查后一个提交。

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — 无新界面文案
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — 无产品契约变更
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
