### PR TITLE
fix(settings): 统一旧代理模式的前后端迁移

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -43,6 +43,9 @@ pub async fn settings_set(
         crate::acp_client::normalize_compaction_mode(&settings.compaction_mode).to_string();
     settings.compaction_detail =
         crate::acp_client::normalize_compaction_detail(&settings.compaction_detail).to_string();
+    // Keep Host routing, returned IPC settings, and persisted JSON on the same
+    // canonical proxy mode. Legacy `use` needs proxyUrl context to migrate.
+    store::normalize_proxy_settings(&mut settings);
     // Audit ledger retention presets: 7 / 30 / 90 / 0 (unlimited).
     settings.audit_ledger_retention_days =
         crate::audit_ledger::normalize_retention_days(settings.audit_ledger_retention_days);

--- a/src-tauri/src/integration_test.rs
+++ b/src-tauri/src/integration_test.rs
@@ -135,29 +135,31 @@ mod integration {
 
     #[test]
     fn settings_default_factory_and_disk_roundtrip() {
-        let _ = ensure_app_dirs();
-        // Factory defaults (not necessarily what's already on disk)
-        let factory = AppSettings::default();
-        assert_eq!(factory.session_data_mode, "shared");
-        assert_eq!(factory.permission_policy, "ask");
-        assert_eq!(factory.sandbox_profile, "workspace");
-        assert!(!factory.reopen_last_session);
-        assert!(factory.last_session_id.is_none());
-        assert!(factory.sidebar_collapsed_project_ids.is_empty());
-        assert!(factory.sidebar_other_sessions_open);
-        assert!(factory.project_spaces.is_empty());
-        assert!(factory.active_project_space_id.is_none());
-        assert!(factory.project_space_by_id.is_empty());
-        // Disk load + save same content must not corrupt
-        let s = load_settings();
-        save_settings(&s).expect("save");
-        let s2 = load_settings();
-        assert_eq!(s2.session_data_mode, s.session_data_mode);
-        assert_eq!(s2.permission_policy, s.permission_policy);
-        assert_eq!(s2.sandbox_profile, s.sandbox_profile);
-        assert_eq!(s2.reopen_last_session, s.reopen_last_session);
-        let root = app_data_root();
-        assert!(!root.as_os_str().is_empty());
+        with_isolated_project_store(|| {
+            let _ = ensure_app_dirs();
+            // Factory defaults (not necessarily what's already on disk)
+            let factory = AppSettings::default();
+            assert_eq!(factory.session_data_mode, "shared");
+            assert_eq!(factory.permission_policy, "ask");
+            assert_eq!(factory.sandbox_profile, "workspace");
+            assert!(!factory.reopen_last_session);
+            assert!(factory.last_session_id.is_none());
+            assert!(factory.sidebar_collapsed_project_ids.is_empty());
+            assert!(factory.sidebar_other_sessions_open);
+            assert!(factory.project_spaces.is_empty());
+            assert!(factory.active_project_space_id.is_none());
+            assert!(factory.project_space_by_id.is_empty());
+            // Disk load + save same content must not corrupt
+            let s = load_settings();
+            save_settings(&s).expect("save");
+            let s2 = load_settings();
+            assert_eq!(s2.session_data_mode, s.session_data_mode);
+            assert_eq!(s2.permission_policy, s.permission_policy);
+            assert_eq!(s2.sandbox_profile, s.sandbox_profile);
+            assert_eq!(s2.reopen_last_session, s.reopen_last_session);
+            let root = app_data_root();
+            assert!(!root.as_os_str().is_empty());
+        });
     }
 
     #[test]

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -455,7 +455,7 @@ pub fn resolve_from(
         .filter(|s| !s.is_empty())
         .map(str::to_string);
 
-    match mode.trim().to_ascii_lowercase().as_str() {
+    match crate::store::normalize_proxy_mode(mode, manual_url) {
         "none" => ProxyResolution {
             decision: ProxyDecision::Direct,
             source: ProxySource::Direct,
@@ -710,6 +710,21 @@ mod tests {
                 url: "http://127.0.0.1:7890".into(),
                 no_proxy: None
             }
+        );
+    }
+
+    #[test]
+    fn legacy_use_mode_only_routes_through_a_valid_saved_url() {
+        assert_eq!(
+            decision_from("use", Some("http://127.0.0.1:18080"), None),
+            ProxyDecision::Use {
+                url: "http://127.0.0.1:18080".into(),
+                no_proxy: None,
+            }
+        );
+        assert_eq!(
+            crate::store::normalize_proxy_mode("use", Some("127.0.0.1:18080")),
+            crate::store::PROXY_MODE_SYSTEM
         );
     }
 

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -629,7 +629,10 @@ pub struct AppSettings {
     /// this, restricted-network users cannot reach Grok backends at all —
     /// Windows system proxy is registry-based and never reaches child
     /// processes as env vars.
-    #[serde(default = "default_proxy_mode")]
+    #[serde(
+        default = "default_proxy_mode",
+        deserialize_with = "deserialize_proxy_mode"
+    )]
     pub proxy_mode: String,
     /// Proxy URL for `manual` mode, e.g. `http://127.0.0.1:7890`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -723,7 +726,59 @@ fn default_close_to_tray() -> bool {
 }
 
 fn default_proxy_mode() -> String {
-    "system".into()
+    PROXY_MODE_SYSTEM.into()
+}
+
+pub const PROXY_MODE_SYSTEM: &str = "system";
+pub const PROXY_MODE_MANUAL: &str = "manual";
+pub const PROXY_MODE_NONE: &str = "none";
+const LEGACY_PROXY_MODE_USE: &str = "use";
+
+/// Normalize persisted / IPC proxy modes. The legacy effective-decision label
+/// `use` is only treated as Manual when a valid saved URL proves that intent;
+/// without one it safely falls back to System.
+pub fn normalize_proxy_mode(raw: &str, proxy_url: Option<&str>) -> &'static str {
+    let mode = raw.trim().to_ascii_lowercase();
+    match mode.as_str() {
+        PROXY_MODE_MANUAL | "custom" | "url" => PROXY_MODE_MANUAL,
+        PROXY_MODE_NONE | "direct" | "off" | "disabled" | "no-proxy" | "noproxy" | "no_proxy" => {
+            PROXY_MODE_NONE
+        }
+        LEGACY_PROXY_MODE_USE
+            if proxy_url
+                .map(str::trim)
+                .filter(|url| !url.is_empty())
+                .is_some_and(crate::proxy::is_valid_proxy_url) =>
+        {
+            PROXY_MODE_MANUAL
+        }
+        PROXY_MODE_SYSTEM | "os" | "auto" | "default" | "" => PROXY_MODE_SYSTEM,
+        _ => PROXY_MODE_SYSTEM,
+    }
+}
+
+/// Canonicalize the cross-field proxy contract after AppSettings has been
+/// deserialized. Returns true when the in-memory value changed.
+pub fn normalize_proxy_settings(settings: &mut AppSettings) -> bool {
+    let normalized = normalize_proxy_mode(&settings.proxy_mode, settings.proxy_url.as_deref());
+    if settings.proxy_mode == normalized {
+        return false;
+    }
+    settings.proxy_mode = normalized.into();
+    true
+}
+
+/// Preserve string values long enough for cross-field normalization to inspect
+/// `proxy_url`; non-string values fail closed to System.
+fn deserialize_proxy_mode<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(value
+        .as_str()
+        .map(|raw| raw.trim().to_ascii_lowercase())
+        .unwrap_or_else(default_proxy_mode))
 }
 
 fn default_todo_gate_max_fires() -> u32 {
@@ -953,6 +1008,16 @@ fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
 pub fn load_settings() -> AppSettings {
     let _ = ensure_app_dirs();
     let mut s: AppSettings = read_json(&settings_file());
+    // Compatibility: `use` was an effective network decision label, never a
+    // persisted settings mode. Some local snapshots nevertheless contain it.
+    // A valid saved URL is the only evidence that it represented Manual.
+    if normalize_proxy_settings(&mut s) {
+        tracing::info!(
+            "settings migration: normalized proxyMode to {}",
+            s.proxy_mode
+        );
+        let _ = write_json(&settings_file(), &s);
+    }
     // One-time: installs that already stored keys in keychain before the opt-in
     // keep keychain mode so keys remain reachable without a silent loss.
     if !s.store_api_keys_in_keychain {
@@ -1222,7 +1287,9 @@ pub fn clamp_effort_for_model(model_id: &str, effort: &str) -> String {
 
 pub fn save_settings(s: &AppSettings) -> Result<(), String> {
     let _ = ensure_app_dirs();
-    write_json(&settings_file(), s)
+    let mut normalized = s.clone();
+    normalize_proxy_settings(&mut normalized);
+    write_json(&settings_file(), &normalized)
 }
 
 /// Stable pin partition: all pinned first, then unpinned.
@@ -3217,7 +3284,64 @@ pub fn save_composer_prefs(
 mod tests {
     use super::*;
     use chrono::TimeZone;
-    use std::thread;
+    use std::{
+        ffi::OsString,
+        path::{Path, PathBuf},
+        thread,
+    };
+
+    struct TempAppHome {
+        path: PathBuf,
+        previous: Option<OsString>,
+    }
+
+    impl Drop for TempAppHome {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("GROK_APP_HOME", value),
+                None => std::env::remove_var("GROK_APP_HOME"),
+            }
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn with_temp_app_home<R>(label: &str, f: impl FnOnce(&Path) -> R) -> R {
+        let _lock = crate::paths::APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let path = std::env::temp_dir().join(format!(
+            "grok-app-{label}-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&path).expect("create isolated app home");
+        let home = TempAppHome {
+            previous: std::env::var_os("GROK_APP_HOME"),
+            path,
+        };
+        std::env::set_var("GROK_APP_HOME", &home.path);
+        ensure_app_dirs().expect("initialize isolated app home");
+        f(&home.path)
+    }
+
+    fn write_proxy_settings_fixture(mode: &str, proxy_url: Option<&str>) {
+        let mut value = serde_json::to_value(AppSettings::default()).expect("settings fixture");
+        let object = value.as_object_mut().expect("settings object");
+        object.insert("proxyMode".into(), serde_json::json!(mode));
+        match proxy_url {
+            Some(url) => {
+                object.insert("proxyUrl".into(), serde_json::json!(url));
+            }
+            None => {
+                object.remove("proxyUrl");
+            }
+        }
+        fs::write(
+            settings_file(),
+            serde_json::to_vec_pretty(&value).expect("serialize settings fixture"),
+        )
+        .expect("write settings fixture");
+    }
 
     #[test]
     fn non_plan_mode_heals_plan_default() {
@@ -3352,6 +3476,65 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn proxy_mode_legacy_use_requires_a_valid_saved_url() {
+        assert_eq!(
+            normalize_proxy_mode(" USE ", Some(" http://127.0.0.1:18080 ")),
+            PROXY_MODE_MANUAL
+        );
+        assert_eq!(
+            normalize_proxy_mode("use", Some("127.0.0.1:18080")),
+            PROXY_MODE_SYSTEM
+        );
+        assert_eq!(normalize_proxy_mode("use", None), PROXY_MODE_SYSTEM);
+        assert_eq!(normalize_proxy_mode("direct", None), PROXY_MODE_NONE);
+        assert_eq!(
+            normalize_proxy_mode("future_mode", Some("http://127.0.0.1:1")),
+            PROXY_MODE_SYSTEM
+        );
+    }
+
+    #[test]
+    fn load_settings_migrates_legacy_proxy_fixture_without_real_home() {
+        with_temp_app_home("proxy-mode-load", |_| {
+            write_proxy_settings_fixture("use", Some("http://127.0.0.1:18080"));
+
+            let loaded = load_settings();
+            assert_eq!(loaded.proxy_mode, PROXY_MODE_MANUAL);
+            assert_eq!(loaded.proxy_url.as_deref(), Some("http://127.0.0.1:18080"));
+
+            let persisted: serde_json::Value =
+                serde_json::from_slice(&fs::read(settings_file()).expect("read migrated settings"))
+                    .expect("parse migrated settings");
+            assert_eq!(persisted["proxyMode"], PROXY_MODE_MANUAL);
+
+            write_proxy_settings_fixture("use", None);
+            let no_url = load_settings();
+            assert_eq!(no_url.proxy_mode, PROXY_MODE_SYSTEM);
+            let persisted: serde_json::Value =
+                serde_json::from_slice(&fs::read(settings_file()).expect("read no-url migration"))
+                    .expect("parse no-url migration");
+            assert_eq!(persisted["proxyMode"], PROXY_MODE_SYSTEM);
+        });
+    }
+
+    #[test]
+    fn save_settings_never_persists_legacy_proxy_mode() {
+        with_temp_app_home("proxy-mode-save", |_| {
+            let settings = AppSettings {
+                proxy_mode: LEGACY_PROXY_MODE_USE.into(),
+                proxy_url: Some("http://127.0.0.1:18080".into()),
+                ..AppSettings::default()
+            };
+            save_settings(&settings).expect("save normalized settings");
+
+            let persisted: serde_json::Value =
+                serde_json::from_slice(&fs::read(settings_file()).expect("read saved settings"))
+                    .expect("parse saved settings");
+            assert_eq!(persisted["proxyMode"], PROXY_MODE_MANUAL);
+        });
     }
 
     #[test]

--- a/src/components/settings/RuntimeSection.tsx
+++ b/src/components/settings/RuntimeSection.tsx
@@ -393,7 +393,7 @@ export function RuntimeSection() {
                   <Select
                     className="settings-select"
                     aria-label={t("settings.proxyMode")}
-                    value={normalizeProxyMode(proxyMode)}
+                    value={normalizeProxyMode(proxyMode, proxyUrl)}
                     onChange={(v) => onProxyMode?.(normalizeProxyMode(v))}
                     options={[
                       {
@@ -432,7 +432,7 @@ export function RuntimeSection() {
                     );
                   })()}
                 </div>
-                {normalizeProxyMode(proxyMode) === "manual" && (
+                {normalizeProxyMode(proxyMode, proxyUrl) === "manual" && (
                   <>
                     <div className="settings-row settings-row--stack">
                       <div className="settings-row__text">

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -226,6 +226,12 @@ export interface AppSettings {
   notifyOnTurnDone?: boolean;
   /** Desktop notification when the agent requests permission (default true). */
   notifyOnPermission?: boolean;
+  /** Outbound route: system | manual | none. */
+  proxyMode?: string;
+  /** Proxy URL used by Manual mode. */
+  proxyUrl?: string | null;
+  /** Comma-separated hosts bypassing the proxy. */
+  proxyNoProxy?: string | null;
   /**
    * Allow CLI install when the mirror has no published SHA-256 (default false).
    * Mismatch always fails. Prefer fixing the mirror over enabling this.

--- a/src/lib/appSettingsHydrate.test.ts
+++ b/src/lib/appSettingsHydrate.test.ts
@@ -19,6 +19,18 @@ function settings(over: Partial<AppSettings> = {}): AppSettings {
 }
 
 describe("parseAppSettingsPrefs", () => {
+  it("hydrates the legacy use proxy mode only with a valid saved URL", () => {
+    expect(parseAppSettingsPrefs(settings({
+      proxyMode: "use", proxyUrl: "http://127.0.0.1:18080",
+    })).proxyMode).toBe("manual");
+    expect(parseAppSettingsPrefs(settings({
+      proxyMode: "use", proxyUrl: "127.0.0.1:18080",
+    })).proxyMode).toBe("system");
+    expect(parseAppSettingsPrefs(settings({
+      proxyMode: "use", proxyUrl: null,
+    })).proxyMode).toBe("system");
+  });
+
   it("uses documented defaults for missing fields", () => {
     const p = parseAppSettingsPrefs(settings());
     expect(p.sessionDataMode).toBe("shared");

--- a/src/lib/appSettingsHydrate.ts
+++ b/src/lib/appSettingsHydrate.ts
@@ -14,13 +14,14 @@ import {
   DEFAULT_SESSION_DATA_MODE,
   normalizeSessionDataMode,
 } from "@/lib/sessionDataMode";
+import { normalizeProxyMode, type ProxyMode } from "@/lib/networkProxy";
 
 export type AppSettingsPrefsSnapshot = {
   sessionDataMode: ReturnType<typeof normalizeSessionDataMode>;
   defaultOpenTarget: string;
   prefsScope: ComposerPrefsScope | null;
   acpServerAddr: string;
-  proxyMode: string;
+  proxyMode: ProxyMode;
   proxyUrl: string;
   proxyNoProxy: string;
   maxConcurrentAgents: number;
@@ -93,11 +94,7 @@ export function parseAppSettingsPrefs(
     Array.isArray(xs)
       ? xs.filter((x): x is string => typeof x === "string")
       : [];
-  const proxy = settings as AppSettings & {
-    proxyMode?: string;
-    proxyUrl?: string | null;
-    proxyNoProxy?: string | null;
-  };
+  const proxyUrl = settings.proxyUrl || "";
 
   return {
     sessionDataMode: normalizeSessionDataMode(
@@ -110,9 +107,9 @@ export function parseAppSettingsPrefs(
         ? settings.composerPrefsScope
         : null,
     acpServerAddr: settings.acpServerAddr || "",
-    proxyMode: proxy.proxyMode || "system",
-    proxyUrl: proxy.proxyUrl || "",
-    proxyNoProxy: proxy.proxyNoProxy || "",
+    proxyMode: normalizeProxyMode(settings.proxyMode, proxyUrl),
+    proxyUrl,
+    proxyNoProxy: settings.proxyNoProxy || "",
     maxConcurrentAgents:
       typeof settings.maxConcurrentAgents === "number" &&
       settings.maxConcurrentAgents >= 1

--- a/src/lib/networkProxy.test.ts
+++ b/src/lib/networkProxy.test.ts
@@ -37,6 +37,15 @@ describe("normalizeProxyMode", () => {
     expect(normalizeProxyMode("auto")).toBe("system");
   });
 
+  it("only migrates legacy use when a valid manual URL exists", () => {
+    expect(
+      normalizeProxyMode(" USE ", " http://127.0.0.1:18080 "),
+    ).toBe("manual");
+    expect(normalizeProxyMode("use", "127.0.0.1:18080")).toBe("system");
+    expect(normalizeProxyMode("use", "")).toBe("system");
+    expect(normalizeProxyMode("use")).toBe("system");
+  });
+
   it("defaults unknown / empty to system", () => {
     expect(normalizeProxyMode(null)).toBe(DEFAULT_PROXY_MODE);
     expect(normalizeProxyMode(undefined)).toBe(DEFAULT_PROXY_MODE);
@@ -117,6 +126,7 @@ describe("manualProxyUrlSoftFail", () => {
     expect(manualProxyUrlSoftFail("system", "")).toBeNull();
     expect(manualProxyUrlSoftFail("none", "nope")).toBeNull();
     expect(manualProxyUrlSoftFail("manual", "http://127.0.0.1:7890")).toBeNull();
+    expect(manualProxyUrlSoftFail("use", "http://127.0.0.1:18080")).toBeNull();
     expect(manualProxyUrlSoftFail("manual", "")).toBe("empty");
     expect(manualProxyUrlSoftFail("manual", "127.0.0.1:7890")).toBe(
       "missing_scheme",

--- a/src/lib/networkProxy.ts
+++ b/src/lib/networkProxy.ts
@@ -45,13 +45,21 @@ export function isProxyMode(raw: unknown): raw is ProxyMode {
 
 /**
  * Normalize a settings / host value to a known proxy mode.
- * Unknown / empty → {@link DEFAULT_PROXY_MODE} (`system`).
+ * Unknown / empty → {@link DEFAULT_PROXY_MODE} (`system`). The legacy
+ * effective-decision label `use` only means Manual when it is paired with a
+ * valid persisted URL; otherwise it safely falls back to System.
  */
-export function normalizeProxyMode(raw: unknown): ProxyMode {
+export function normalizeProxyMode(
+  raw: unknown,
+  proxyUrl?: string | null,
+): ProxyMode {
   if (raw == null) return DEFAULT_PROXY_MODE;
   const s = String(raw).trim().toLowerCase();
   if (!s) return DEFAULT_PROXY_MODE;
   if (PROXY_MODE_SET.has(s)) return s as ProxyMode;
+  if (s === "use") {
+    return isValidProxyUrl(proxyUrl) ? "manual" : DEFAULT_PROXY_MODE;
+  }
   const alias = MODE_ALIASES[s];
   if (alias) return alias;
   return DEFAULT_PROXY_MODE;
@@ -136,7 +144,7 @@ export function manualProxyUrlSoftFail(
   mode: unknown,
   url: string | null | undefined,
 ): ProxyUrlError | null {
-  if (normalizeProxyMode(mode) !== "manual") return null;
+  if (normalizeProxyMode(mode, url) !== "manual") return null;
   const v = validateProxyUrl(url);
   if (v.ok) return null;
   return v.error;

--- a/src/lib/networkProxyPro.ts
+++ b/src/lib/networkProxyPro.ts
@@ -173,7 +173,7 @@ export function resolveProxyApplyHonesty(input: {
   valid?: boolean;
   url?: string | null;
 }): ProxyApplyHonesty {
-  const mode = normalizeProxyMode(input.mode);
+  const mode = normalizeProxyMode(input.mode, input.url);
   let valid: boolean;
   if (typeof input.valid === "boolean") {
     valid = input.valid;


### PR DESCRIPTION
## Summary

修复旧设置中 `proxyMode: use` 无法被现有设置界面和 Host 一致识别的问题。只有保存了有效代理 URL 时才迁移为 `manual`；缺少或无效 URL 时使用 `system`。统一加载、保存、IPC 返回值和路由解析，写盘继续使用已有原子写入。

不写入固定代理地址，不修改用户真实网络配置，不加入相册专用路由。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## 验证

- 前端 7,057 项测试、类型检查、lint、构建、质量门禁、网站自测、依赖检查及审计通过。
- Windows Rust 1,609 项通过、1 项原有 ignored；fmt/clippy 通过。设置读写回归使用隔离临时目录。
- #1046 已关闭且属于功能入口咨询，不是本次迁移问题，不添加自动关闭引用。
- 前置测试修复为 #1074；本 PR 保留其独立提交以保证并行测试可靠，请先合入 #1074，届时更新基底移除重复差异。代理修复可单独审查后一个提交。

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — 无新文案
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — 保持现有代理模式契约
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
