### PR TITLE
fix(wallpaper): 规范化 X 图片地址并收紧下载 URL 契约

### DIFF
--- a/src-tauri/src/integration_test.rs
+++ b/src-tauri/src/integration_test.rs
@@ -135,29 +135,31 @@ mod integration {
 
     #[test]
     fn settings_default_factory_and_disk_roundtrip() {
-        let _ = ensure_app_dirs();
-        // Factory defaults (not necessarily what's already on disk)
-        let factory = AppSettings::default();
-        assert_eq!(factory.session_data_mode, "shared");
-        assert_eq!(factory.permission_policy, "ask");
-        assert_eq!(factory.sandbox_profile, "workspace");
-        assert!(!factory.reopen_last_session);
-        assert!(factory.last_session_id.is_none());
-        assert!(factory.sidebar_collapsed_project_ids.is_empty());
-        assert!(factory.sidebar_other_sessions_open);
-        assert!(factory.project_spaces.is_empty());
-        assert!(factory.active_project_space_id.is_none());
-        assert!(factory.project_space_by_id.is_empty());
-        // Disk load + save same content must not corrupt
-        let s = load_settings();
-        save_settings(&s).expect("save");
-        let s2 = load_settings();
-        assert_eq!(s2.session_data_mode, s.session_data_mode);
-        assert_eq!(s2.permission_policy, s.permission_policy);
-        assert_eq!(s2.sandbox_profile, s.sandbox_profile);
-        assert_eq!(s2.reopen_last_session, s.reopen_last_session);
-        let root = app_data_root();
-        assert!(!root.as_os_str().is_empty());
+        with_isolated_project_store(|| {
+            let _ = ensure_app_dirs();
+            // Factory defaults (not necessarily what's already on disk)
+            let factory = AppSettings::default();
+            assert_eq!(factory.session_data_mode, "shared");
+            assert_eq!(factory.permission_policy, "ask");
+            assert_eq!(factory.sandbox_profile, "workspace");
+            assert!(!factory.reopen_last_session);
+            assert!(factory.last_session_id.is_none());
+            assert!(factory.sidebar_collapsed_project_ids.is_empty());
+            assert!(factory.sidebar_other_sessions_open);
+            assert!(factory.project_spaces.is_empty());
+            assert!(factory.active_project_space_id.is_none());
+            assert!(factory.project_space_by_id.is_empty());
+            // Disk load + save same content must not corrupt
+            let s = load_settings();
+            save_settings(&s).expect("save");
+            let s2 = load_settings();
+            assert_eq!(s2.session_data_mode, s.session_data_mode);
+            assert_eq!(s2.permission_policy, s.permission_policy);
+            assert_eq!(s2.sandbox_profile, s.sandbox_profile);
+            assert_eq!(s2.reopen_last_session, s.reopen_last_session);
+            let root = app_data_root();
+            assert!(!root.as_os_str().is_empty());
+        });
     }
 
     #[test]

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -114,25 +114,26 @@ pub fn normalize_media_url(url: &str) -> String {
             }
         }
         if let Ok(mut u) = url::Url::parse(trimmed) {
-            let mut pairs: Vec<(String, String)> = u
+            let format = u
                 .query_pairs()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect();
-            let mut found_name = false;
-            for (k, v) in pairs.iter_mut() {
-                if k == "name" {
-                    *v = "orig".into();
-                    found_name = true;
+                .find(|(key, _)| key.eq_ignore_ascii_case("format"))
+                .map(|(_, value)| value.into_owned());
+            u.set_fragment(None);
+            u.set_query(None);
+            {
+                let mut query = u.query_pairs_mut();
+                if let Some(format) = format.filter(|value| !value.trim().is_empty()) {
+                    query.append_pair("format", &format);
                 }
-            }
-            if !found_name {
-                pairs.push(("name".into(), "orig".into()));
-            }
-            u.query_pairs_mut().clear();
-            for (k, v) in pairs {
-                u.query_pairs_mut().append_pair(&k, &v);
+                query.append_pair("name", "orig");
             }
             return u.to_string();
+        }
+    }
+    if trimmed.starts_with("https://") || trimmed.starts_with("http://") {
+        if let Ok(mut parsed) = url::Url::parse(trimmed) {
+            parsed.set_fragment(None);
+            return parsed.to_string();
         }
     }
     trimmed.to_string()
@@ -143,7 +144,11 @@ pub fn is_allowed_media_url(url: &str) -> bool {
     let Ok(u) = url::Url::parse(url.trim()) else {
         return false;
     };
-    if u.scheme() != "https" && u.scheme() != "http" {
+    if u.scheme() != "https"
+        || !u.username().is_empty()
+        || u.password().is_some()
+        || u.port_or_known_default() != Some(443)
+    {
         return false;
     }
     let host = match u.host_str() {
@@ -1470,6 +1475,50 @@ mod tests {
         ));
         assert!(!is_allowed_media_url("https://evil.example/a.jpg"));
         assert!(!is_allowed_media_url("file:///etc/passwd"));
+    }
+
+    #[test]
+    fn media_urls_require_https_without_credentials_or_nonstandard_ports() {
+        for raw in [
+            "http://pbs.twimg.com/media/a.jpg",
+            "https://user@pbs.twimg.com/media/a.jpg",
+            "https://user:password@pbs.twimg.com/media/a.jpg",
+            "https://pbs.twimg.com:8443/media/a.jpg",
+            "https://pbs.twimg.com.evil.example/media/a.jpg",
+        ] {
+            assert!(!is_allowed_media_url(raw), "{raw}");
+        }
+        assert!(is_allowed_media_url(
+            "https://pbs.twimg.com:443/media/a.jpg"
+        ));
+    }
+
+    #[test]
+    fn normalization_preserves_format_and_collapses_query_and_fragment_variants() {
+        assert_eq!(
+            normalize_media_url(
+                "https://pbs.twimg.com/media/a?FORMAT=png&name=small&name=large&tracking=1#preview"
+            ),
+            "https://pbs.twimg.com/media/a?format=png&name=orig"
+        );
+        assert_eq!(
+            normalize_media_url("https://cdn.grok.com/image.png?signature=abc#preview"),
+            "https://cdn.grok.com/image.png?signature=abc"
+        );
+    }
+
+    #[test]
+    fn gallery_dedupes_tracking_and_size_variants_of_the_same_x_image() {
+        let value = json!({"items": [
+            {"fullUrl": "https://pbs.twimg.com/media/a?format=jpg&name=small&tracking=1#one"},
+            {"fullUrl": "https://pbs.twimg.com/media/a?name=large&format=jpg&tracking=2#two"}
+        ]});
+        let items = parse_gallery_items(&value, "x");
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].full_url,
+            "https://pbs.twimg.com/media/a?format=jpg&name=orig"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

修复 X 壁纸结果中同一张图片因尺寸、跟踪参数或锚点不同而重复出现的问题。规范化 Twitter 图片地址时仅保留格式参数并统一 `name=orig`；其他媒体地址只移除锚点，保留签名等查询参数。

下载 URL 仅接受白名单主机的标准 HTTPS 地址，拒绝内嵌用户名/密码和非 443 端口。现有 CLI 搜索解析与媒体下载直接使用这些规则，不依赖 Responses 接入。

这是搜索质量的第一小步，不包含新增搜索路数、数量调优、可达性排序或渠道切换。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## 验证

- 前端 7,055 项测试、类型检查、lint、UI 构建、质量门禁、网站自测、依赖检查和审计通过。
- Rust fmt/clippy 通过；1,608 项原生测试通过、1 项原有 ignored，覆盖 URL 协议/凭据/端口、参数规范化，以及真实解析入口去重。
- 未发起真实账号搜索请求；本 PR 不调整模型参数。
- 前置测试修复为 #1074，保留独立提交供验证；请先合入 #1074，之后更新基底剔除重复差异。
- 已检索相关 Issue，未发现直接对应条目。

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — 无新文案
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — 范围在本说明中记录
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
