### PR TITLE
test(menu): 清理测试结束后的菜单动画定时器

### DIFF
--- a/src-tauri/src/integration_test.rs
+++ b/src-tauri/src/integration_test.rs
@@ -135,29 +135,31 @@ mod integration {
 
     #[test]
     fn settings_default_factory_and_disk_roundtrip() {
-        let _ = ensure_app_dirs();
-        // Factory defaults (not necessarily what's already on disk)
-        let factory = AppSettings::default();
-        assert_eq!(factory.session_data_mode, "shared");
-        assert_eq!(factory.permission_policy, "ask");
-        assert_eq!(factory.sandbox_profile, "workspace");
-        assert!(!factory.reopen_last_session);
-        assert!(factory.last_session_id.is_none());
-        assert!(factory.sidebar_collapsed_project_ids.is_empty());
-        assert!(factory.sidebar_other_sessions_open);
-        assert!(factory.project_spaces.is_empty());
-        assert!(factory.active_project_space_id.is_none());
-        assert!(factory.project_space_by_id.is_empty());
-        // Disk load + save same content must not corrupt
-        let s = load_settings();
-        save_settings(&s).expect("save");
-        let s2 = load_settings();
-        assert_eq!(s2.session_data_mode, s.session_data_mode);
-        assert_eq!(s2.permission_policy, s.permission_policy);
-        assert_eq!(s2.sandbox_profile, s.sandbox_profile);
-        assert_eq!(s2.reopen_last_session, s.reopen_last_session);
-        let root = app_data_root();
-        assert!(!root.as_os_str().is_empty());
+        with_isolated_project_store(|| {
+            let _ = ensure_app_dirs();
+            // Factory defaults (not necessarily what's already on disk)
+            let factory = AppSettings::default();
+            assert_eq!(factory.session_data_mode, "shared");
+            assert_eq!(factory.permission_policy, "ask");
+            assert_eq!(factory.sandbox_profile, "workspace");
+            assert!(!factory.reopen_last_session);
+            assert!(factory.last_session_id.is_none());
+            assert!(factory.sidebar_collapsed_project_ids.is_empty());
+            assert!(factory.sidebar_other_sessions_open);
+            assert!(factory.project_spaces.is_empty());
+            assert!(factory.active_project_space_id.is_none());
+            assert!(factory.project_space_by_id.is_empty());
+            // Disk load + save same content must not corrupt
+            let s = load_settings();
+            save_settings(&s).expect("save");
+            let s2 = load_settings();
+            assert_eq!(s2.session_data_mode, s.session_data_mode);
+            assert_eq!(s2.permission_policy, s.permission_policy);
+            assert_eq!(s2.sandbox_profile, s.sandbox_profile);
+            assert_eq!(s2.reopen_last_session, s.reopen_last_session);
+            let root = app_data_root();
+            assert!(!root.as_os_str().is_empty());
+        });
     }
 
     #[test]

--- a/src/components/UserMenu.test.tsx
+++ b/src/components/UserMenu.test.tsx
@@ -2,10 +2,12 @@
  * @vitest-environment jsdom
  */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useState } from "react";
-import { expect, it, vi } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import { UserMenu } from "./UserMenu";
+
+afterEach(cleanup);
 
 vi.mock("@/lib/floatingMenu", () => ({
   FLOATING_MENU_Z_INDEX: 13_000,


### PR DESCRIPTION
## Summary

修复菜单组件测试结束后仍有退出动画定时器运行的问题。最后一个折叠侧栏用例没有卸载组件，定时器可能在 jsdom 已销毁后更新 React 状态，导致全量测试断言通过但退出时出现 `window is not defined`。

增加统一 `afterEach(cleanup)`，让组件卸载时执行已有定时器清理。只改测试，不改产品菜单或动画逻辑。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## 验证

- 菜单聚焦 3 项测试通过；补丁应用到壁纸组件拆分分支后，全量 7,055 项通过且不再发生退出异常。
- 本独立分支前端 7,055 项、Windows Rust 1,605 项（1 项原有 ignored）通过；类型检查、lint、UI 构建、质量门禁、网站自测、依赖检查/审计、Rust fmt/clippy 全部通过。
- 前置为 #1074 的设置目录隔离；请先合入前置，之后更新基底剔除重复差异。

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — 无新文案
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — 产品行为不变
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
