### PR TITLE
refactor(wallpaper): 拆分来源弹窗的控制区画廊和底部操作

### DIFF
--- a/src/components/WallpaperSourceControls.tsx
+++ b/src/components/WallpaperSourceControls.tsx
@@ -1,0 +1,147 @@
+import { useMemo } from "react";
+import { Select } from "@/components/Select";
+import type { WallpaperSourceModalProps, WallpaperSourceTab } from "./WallpaperSourceModal";
+
+type Props = {
+  t: WallpaperSourceModalProps["t"];
+  tab: WallpaperSourceTab;
+  query: string;
+  sort: "top" | "latest";
+  prompt: string;
+  aspect: string;
+  busy: boolean;
+  locked: boolean;
+  setQuery: (value: string) => void;
+  setSort: (value: "top" | "latest") => void;
+  setPrompt: (value: string) => void;
+  setAspect: (value: string) => void;
+  runXSearch: () => Promise<void>;
+  runImagine: () => Promise<void>;
+  loadLibrary: () => Promise<void>;
+};
+
+export function WallpaperSourceControls({
+  t, tab, query, sort, prompt, aspect, busy, locked,
+  setQuery, setSort, setPrompt, setAspect, runXSearch, runImagine, loadLibrary,
+}: Props) {
+  const sortOptions = useMemo(
+    () => [
+      { value: "top", label: t("settings.wallpaperSource.sortTop") },
+      { value: "latest", label: t("settings.wallpaperSource.sortLatest") },
+    ],
+    [t],
+  );
+
+  const aspectOptions = useMemo(
+    () => [
+      { value: "16:9", label: "16:9" },
+      { value: "9:16", label: "9:16" },
+      { value: "1:1", label: "1:1" },
+      { value: "4:3", label: "4:3" },
+      { value: "auto", label: "auto" },
+    ],
+    [],
+  );
+
+  return (
+    <>
+      {tab === "x" ? (
+        <div className="wallpaper-source-form">
+          <p className="wallpaper-source-form__hint">
+            {t("settings.wallpaperSource.xHint")}
+          </p>
+          <div className="wallpaper-source-form__row">
+            <input
+              type="search"
+              className="wallpaper-source-form__input"
+              value={query}
+              placeholder={t("settings.wallpaperSource.xPlaceholder")}
+              disabled={locked}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void runXSearch();
+                }
+              }}
+            />
+            <Select
+              className="wallpaper-source-form__select"
+              value={sort}
+              options={sortOptions}
+              disabled={locked}
+              aria-label={t("settings.wallpaperSource.sort")}
+              onChange={(v) => setSort(v === "latest" ? "latest" : "top")}
+              placement="down"
+            />
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={locked || !query.trim()}
+              onClick={() => void runXSearch()}
+            >
+              {busy
+                ? t("settings.wallpaperSource.searching")
+                : t("settings.wallpaperSource.search")}
+            </button>
+          </div>
+        </div>
+      ) : tab === "imagine" ? (
+        <div className="wallpaper-source-form">
+          <p className="wallpaper-source-form__hint">
+            {t("settings.wallpaperSource.imagineHint")}
+          </p>
+          <textarea
+            className="wallpaper-source-form__textarea"
+            value={prompt}
+            placeholder={t("settings.wallpaperSource.imaginePlaceholder")}
+            disabled={locked}
+            rows={3}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+          <div className="wallpaper-source-form__row">
+            <Select
+              className="wallpaper-source-form__select"
+              value={aspect}
+              options={aspectOptions}
+              disabled={locked}
+              aria-label={t("settings.wallpaperSource.aspect")}
+              onChange={setAspect}
+              placement="down"
+            />
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={locked || !prompt.trim()}
+              onClick={() => void runImagine()}
+            >
+              {busy
+                ? t("settings.wallpaperSource.generating")
+                : t("settings.wallpaperSource.generate")}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="wallpaper-source-form">
+          <p className="wallpaper-source-form__hint">
+            {t("settings.wallpaperSource.libraryHint")}
+          </p>
+          <div className="wallpaper-source-form__row">
+            <button
+              type="button"
+              className="btn btn--solid"
+              disabled={locked}
+              onClick={() => void loadLibrary()}
+            >
+              {busy
+                ? t("settings.wallpaperSource.libraryLoading")
+                : t("settings.wallpaperSource.libraryRefresh")}
+            </button>
+          </div>
+        </div>
+      )}
+
+
+    </>
+  );
+}

--- a/src/components/WallpaperSourceFooter.tsx
+++ b/src/components/WallpaperSourceFooter.tsx
@@ -1,0 +1,42 @@
+import type { WallpaperSourceModalProps } from "./WallpaperSourceModal";
+
+type Props = {
+  t: WallpaperSourceModalProps["t"];
+  selected: boolean;
+  locked: boolean;
+  applying: boolean;
+  onClose: () => void;
+  applySelected: () => Promise<void>;
+};
+
+export function WallpaperSourceFooter({
+  t, selected, locked, applying, onClose, applySelected,
+}: Props) {
+  return (
+        <>
+          <span className="wallpaper-source-footer-hint">
+            {selected
+              ? t("settings.wallpaperSource.previewThenApply")
+              : t("settings.wallpaperSource.clickToPreview")}
+          </span>
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={onClose}
+            disabled={applying}
+          >
+            {t("common.cancel")}
+          </button>
+          <button
+            type="button"
+            className="btn btn--solid"
+            disabled={!selected || locked}
+            onClick={() => void applySelected()}
+          >
+            {applying
+              ? t("settings.wallpaperSource.applying")
+              : t("settings.wallpaperSource.apply")}
+          </button>
+        </>
+  );
+}

--- a/src/components/WallpaperSourceGallery.tsx
+++ b/src/components/WallpaperSourceGallery.tsx
@@ -1,0 +1,216 @@
+import type { MouseEvent } from "react";
+import type { MessageKey } from "@/i18n";
+import type { WallpaperSourceModalProps, WallpaperSourceTab } from "./WallpaperSourceModal";
+import type { WallpaperGalleryItem } from "@/lib/wallpaperSource";
+import type { WallpaperGalleryEmptyPresentation } from "@/lib/wallpaperGalleryPro";
+import { resolveWallpaperXCitation } from "@/lib/xEvidenceCitation";
+import { resolveImageSrcSync } from "@/lib/imageSrc";
+
+type Props = {
+  t: WallpaperSourceModalProps["t"];
+  tab: WallpaperSourceTab;
+  busy: boolean;
+  locked: boolean;
+  visibleItems: WallpaperGalleryItem[];
+  selectedId: string | null;
+  previewingId: string | null;
+  showEmptyBlock: boolean;
+  emptyState: WallpaperGalleryEmptyPresentation | null;
+  clearGalleryFilters: () => void;
+  openItemPreview: (item: WallpaperGalleryItem) => Promise<void>;
+  dropItem: (id: string) => void;
+  openXStatus: (url: string) => void;
+  requestDeleteLibraryItem: (item: WallpaperGalleryItem, event: MouseEvent) => void;
+};
+
+/** Thumb / list preview (remote thumb OK). */
+function itemThumbSrc(item: WallpaperGalleryItem): string {
+  if (item.localPath) {
+    return (
+      resolveImageSrcSync(item.localPath) ||
+      item.thumbUrl ||
+      item.fullUrl
+    );
+  }
+  if (item.fullUrl.startsWith("file://")) {
+    const p = decodeURIComponent(item.fullUrl.replace(/^file:\/\//, ""));
+    return resolveImageSrcSync(p) || item.thumbUrl || item.fullUrl;
+  }
+  return item.thumbUrl || item.fullUrl;
+}
+
+export function WallpaperSourceGallery({
+  t, tab, busy, locked, visibleItems, selectedId, previewingId,
+  showEmptyBlock, emptyState, clearGalleryFilters, openItemPreview,
+  dropItem, openXStatus, requestDeleteLibraryItem,
+}: Props) {
+  const isImagineLayout = tab === "imagine";
+  const isLibraryTab = tab === "library";
+  return (
+    <>
+      {/*
+        Scroll shell must wrap multi-column masonry. Putting overflow-y +
+        max-height on the column-count element packs overflow into extra
+        horizontal columns that get clipped (only the first few thumbs show).
+      */}
+      <div
+        className="wallpaper-masonry-scroll"
+        role="list"
+        aria-label={t("settings.wallpaperSource.gallery")}
+        aria-busy={busy || previewingId !== null}
+        tabIndex={visibleItems.length > 0 ? 0 : undefined}
+      >
+        <div
+          className={
+            "wallpaper-masonry" +
+            (isImagineLayout ? " wallpaper-masonry--full" : "")
+          }
+        >
+          {showEmptyBlock && emptyState ? (
+            <div
+              className={
+                "wallpaper-masonry__empty" +
+                (emptyState.kind === "filter_empty"
+                  ? " wallpaper-masonry__empty--filter"
+                  : "") +
+                (emptyState.kind === "error"
+                  ? " wallpaper-masonry__empty--error"
+                  : "")
+              }
+              data-kind={emptyState.kind}
+              data-soft-fail={emptyState.softFail ? "1" : "0"}
+            >
+              <p className="wallpaper-masonry__empty-title">
+                {t(emptyState.titleKey as MessageKey)}
+              </p>
+              {emptyState.hintKey ? (
+                <p className="wallpaper-masonry__empty-hint">
+                  {t(emptyState.hintKey as MessageKey)}
+                </p>
+              ) : null}
+              {emptyState.showClearFilters ? (
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  onClick={clearGalleryFilters}
+                >
+                  {t("settings.wallpaperSource.clearFilters")}
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+          {visibleItems.map((item) => {
+            const active = item.id === selectedId;
+            const loadingThis = previewingId === item.id;
+            const src = itemThumbSrc(item);
+            const cite =
+              item.source === "x" || (!item.source && tab === "x")
+                ? resolveWallpaperXCitation(item)
+                : null;
+            return (
+              <div
+                key={item.id}
+                className={
+                  "wallpaper-masonry__card-wrap" +
+                  (isLibraryTab ? " wallpaper-masonry__card-wrap--library" : "")
+                }
+                role="listitem"
+              >
+                <button
+                  type="button"
+                  className={
+                    "wallpaper-masonry__card" +
+                    (active ? " wallpaper-masonry__card--selected" : "") +
+                    (loadingThis ? " wallpaper-masonry__card--loading" : "")
+                  }
+                  disabled={locked && !loadingThis}
+                  onClick={() => void openItemPreview(item)}
+                  aria-label={t("settings.wallpaperSource.openPreview")}
+                >
+                  <img
+                    src={src}
+                    alt={item.textPreview || item.prompt || item.username || ""}
+                    className="wallpaper-masonry__img"
+                    loading="lazy"
+                    referrerPolicy="no-referrer"
+                    onError={() => {
+                      // Thumb failed — remove undownloadable / broken entry
+                      dropItem(item.id);
+                    }}
+                  />
+                  <span className="wallpaper-masonry__meta">
+                    {loadingThis
+                      ? t("settings.wallpaperSource.loadingOriginal")
+                      : null}
+                    {!loadingThis && item.username
+                      ? `@${item.username}`
+                      : null}
+                    {!loadingThis && item.likes != null
+                      ? ` · ♥ ${item.likes}`
+                      : null}
+                    {!loadingThis &&
+                    !isLibraryTab &&
+                    item.source === "imagine"
+                      ? t("settings.wallpaperImagine")
+                      : null}
+                    {!loadingThis && isLibraryTab
+                      ? item.source === "imagine"
+                        ? t("settings.wallpaperImagine")
+                        : item.source === "x"
+                          ? t("settings.wallpaperFromX")
+                          : t("settings.wallpaperLibrary")
+                      : null}
+                  </span>
+                </button>
+                {cite && !loadingThis ? (
+                  <div
+                    className={
+                      "wallpaper-masonry__cite" +
+                      (cite.state === "verified"
+                        ? " wallpaper-masonry__cite--verified"
+                        : " wallpaper-masonry__cite--unverified")
+                    }
+                    title={t(cite.hintKey as MessageKey)}
+                  >
+                    {cite.state === "verified" && cite.statusUrl ? (
+                      <button
+                        type="button"
+                        className="wallpaper-masonry__cite-btn"
+                        disabled={locked}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          openXStatus(cite.statusUrl!);
+                        }}
+                        title={t("settings.wallpaperSource.cite.openPost")}
+                        aria-label={t("settings.wallpaperSource.cite.openPost")}
+                      >
+                        {t(cite.labelKey as MessageKey)}
+                      </button>
+                    ) : (
+                      <span className="wallpaper-masonry__cite-badge">
+                        {t(cite.labelKey as MessageKey)}
+                      </span>
+                    )}
+                  </div>
+                ) : null}
+                {isLibraryTab ? (
+                  <button
+                    type="button"
+                    className="wallpaper-masonry__delete"
+                    disabled={locked}
+                    onClick={(e) => requestDeleteLibraryItem(item, e)}
+                    aria-label={t("settings.wallpaperSource.delete")}
+                    title={t("settings.wallpaperSource.delete")}
+                  >
+                    ×
+                  </button>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/WallpaperSourceModal.tsx
+++ b/src/components/WallpaperSourceModal.tsx
@@ -11,8 +11,10 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { WallpaperSourceGallery } from "./WallpaperSourceGallery";
+import { WallpaperSourceFooter } from "./WallpaperSourceFooter";
 import { GlassModal } from "@/components/GlassModal";
-import { Select } from "@/components/Select";
+import { WallpaperSourceControls } from "./WallpaperSourceControls";
 import { useImageViewerOptional } from "@/components/ImageViewerContext";
 import * as api from "@/lib/api";
 import { isDesktopHost } from "@/lib/api";
@@ -41,12 +43,10 @@ import {
 import {
   countWallpaperXCitations,
   recordWallpaperXEvidencePick,
-  resolveWallpaperXCitation,
   wallpaperXEvidenceFromGalleryItem,
   wallpaperXSearchCitationSummaryKey,
 } from "@/lib/xEvidenceCitation";
 import { WallpaperPrepareError } from "@/lib/themeSkin";
-import { resolveImageSrcSync } from "@/lib/imageSrc";
 import type { MessageKey } from "@/i18n";
 
 export type WallpaperSourceTab = "x" | "imagine" | "library";
@@ -72,22 +72,6 @@ function errorMessage(
   const key = `settings.wallpaperSource.err.${code}` as MessageKey;
   const msg = t(key);
   return msg === key ? t("settings.wallpaperSource.err.generic") : msg;
-}
-
-/** Thumb / list preview (remote thumb OK). */
-function itemThumbSrc(item: WallpaperGalleryItem): string {
-  if (item.localPath) {
-    return (
-      resolveImageSrcSync(item.localPath) ||
-      item.thumbUrl ||
-      item.fullUrl
-    );
-  }
-  if (item.fullUrl.startsWith("file://")) {
-    const p = decodeURIComponent(item.fullUrl.replace(/^file:\/\//, ""));
-    return resolveImageSrcSync(p) || item.thumbUrl || item.fullUrl;
-  }
-  return item.thumbUrl || item.fullUrl;
 }
 
 /**
@@ -228,25 +212,6 @@ export function WallpaperSourceModal({
   const selected = useMemo(
     () => visibleItems.find((i) => i.id === selectedId) ?? null,
     [visibleItems, selectedId],
-  );
-
-  const sortOptions = useMemo(
-    () => [
-      { value: "top", label: t("settings.wallpaperSource.sortTop") },
-      { value: "latest", label: t("settings.wallpaperSource.sortLatest") },
-    ],
-    [t],
-  );
-
-  const aspectOptions = useMemo(
-    () => [
-      { value: "16:9", label: "16:9" },
-      { value: "9:16", label: "9:16" },
-      { value: "1:1", label: "1:1" },
-      { value: "4:3", label: "4:3" },
-      { value: "auto", label: "auto" },
-    ],
-    [],
   );
 
   const runXSearch = useCallback(async () => {
@@ -589,8 +554,6 @@ export function WallpaperSourceModal({
 
   const authNeeded = errorCode === "auth_required";
   const locked = busy || applying || previewingId !== null;
-  const isImagineLayout = tab === "imagine";
-  const isLibraryTab = tab === "library";
   const showGalleryFilters = items.length > 0 || filtersActive;
   const softFailError =
     galleryErrorKind != null && isWallpaperGallerySoftFail(galleryErrorKind);
@@ -615,31 +578,14 @@ export function WallpaperSourceModal({
       bodyClassName="wallpaper-source-modal__body"
       closeLabel={t("common.close")}
       footer={
-        <>
-          <span className="wallpaper-source-footer-hint">
-            {selected
-              ? t("settings.wallpaperSource.previewThenApply")
-              : t("settings.wallpaperSource.clickToPreview")}
-          </span>
-          <button
-            type="button"
-            className="btn btn--ghost"
-            onClick={onClose}
-            disabled={applying}
-          >
-            {t("common.cancel")}
-          </button>
-          <button
-            type="button"
-            className="btn btn--solid"
-            disabled={!selected || locked}
-            onClick={() => void applySelected()}
-          >
-            {applying
-              ? t("settings.wallpaperSource.applying")
-              : t("settings.wallpaperSource.apply")}
-          </button>
-        </>
+        <WallpaperSourceFooter
+          t={t}
+          selected={selected !== null}
+          locked={locked}
+          applying={applying}
+          onClose={onClose}
+          applySelected={applySelected}
+        />
       }
     >
       <div className="wallpaper-source-tabs" role="tablist">
@@ -702,101 +648,23 @@ export function WallpaperSourceModal({
         </button>
       </div>
 
-      {tab === "x" ? (
-        <div className="wallpaper-source-form">
-          <p className="wallpaper-source-form__hint">
-            {t("settings.wallpaperSource.xHint")}
-          </p>
-          <div className="wallpaper-source-form__row">
-            <input
-              type="search"
-              className="wallpaper-source-form__input"
-              value={query}
-              placeholder={t("settings.wallpaperSource.xPlaceholder")}
-              disabled={locked}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  void runXSearch();
-                }
-              }}
-            />
-            <Select
-              className="wallpaper-source-form__select"
-              value={sort}
-              options={sortOptions}
-              disabled={locked}
-              aria-label={t("settings.wallpaperSource.sort")}
-              onChange={(v) => setSort(v === "latest" ? "latest" : "top")}
-              placement="down"
-            />
-            <button
-              type="button"
-              className="btn btn--solid"
-              disabled={locked || !query.trim()}
-              onClick={() => void runXSearch()}
-            >
-              {busy
-                ? t("settings.wallpaperSource.searching")
-                : t("settings.wallpaperSource.search")}
-            </button>
-          </div>
-        </div>
-      ) : tab === "imagine" ? (
-        <div className="wallpaper-source-form">
-          <p className="wallpaper-source-form__hint">
-            {t("settings.wallpaperSource.imagineHint")}
-          </p>
-          <textarea
-            className="wallpaper-source-form__textarea"
-            value={prompt}
-            placeholder={t("settings.wallpaperSource.imaginePlaceholder")}
-            disabled={locked}
-            rows={3}
-            onChange={(e) => setPrompt(e.target.value)}
-          />
-          <div className="wallpaper-source-form__row">
-            <Select
-              className="wallpaper-source-form__select"
-              value={aspect}
-              options={aspectOptions}
-              disabled={locked}
-              aria-label={t("settings.wallpaperSource.aspect")}
-              onChange={setAspect}
-              placement="down"
-            />
-            <button
-              type="button"
-              className="btn btn--solid"
-              disabled={locked || !prompt.trim()}
-              onClick={() => void runImagine()}
-            >
-              {busy
-                ? t("settings.wallpaperSource.generating")
-                : t("settings.wallpaperSource.generate")}
-            </button>
-          </div>
-        </div>
-      ) : (
-        <div className="wallpaper-source-form">
-          <p className="wallpaper-source-form__hint">
-            {t("settings.wallpaperSource.libraryHint")}
-          </p>
-          <div className="wallpaper-source-form__row">
-            <button
-              type="button"
-              className="btn btn--solid"
-              disabled={locked}
-              onClick={() => void loadLibrary()}
-            >
-              {busy
-                ? t("settings.wallpaperSource.libraryLoading")
-                : t("settings.wallpaperSource.libraryRefresh")}
-            </button>
-          </div>
-        </div>
-      )}
+      <WallpaperSourceControls
+        t={t}
+        tab={tab}
+        query={query}
+        sort={sort}
+        prompt={prompt}
+        aspect={aspect}
+        busy={busy}
+        locked={locked}
+        setQuery={setQuery}
+        setSort={setSort}
+        setPrompt={setPrompt}
+        setAspect={setAspect}
+        runXSearch={runXSearch}
+        runImagine={runImagine}
+        loadLibrary={loadLibrary}
+      />
 
       {statusHint ? (
         <p className="wallpaper-source-status" role="status">
@@ -903,169 +771,22 @@ export function WallpaperSourceModal({
         </div>
       ) : null}
 
-      {/*
-        Scroll shell must wrap multi-column masonry. Putting overflow-y +
-        max-height on the column-count element packs overflow into extra
-        horizontal columns that get clipped (only the first few thumbs show).
-      */}
-      <div
-        className="wallpaper-masonry-scroll"
-        role="list"
-        aria-label={t("settings.wallpaperSource.gallery")}
-        aria-busy={busy || previewingId !== null}
-        tabIndex={visibleItems.length > 0 ? 0 : undefined}
-      >
-        <div
-          className={
-            "wallpaper-masonry" +
-            (isImagineLayout ? " wallpaper-masonry--full" : "")
-          }
-        >
-          {showEmptyBlock && emptyState ? (
-            <div
-              className={
-                "wallpaper-masonry__empty" +
-                (emptyState.kind === "filter_empty"
-                  ? " wallpaper-masonry__empty--filter"
-                  : "") +
-                (emptyState.kind === "error"
-                  ? " wallpaper-masonry__empty--error"
-                  : "")
-              }
-              data-kind={emptyState.kind}
-              data-soft-fail={emptyState.softFail ? "1" : "0"}
-            >
-              <p className="wallpaper-masonry__empty-title">
-                {t(emptyState.titleKey as MessageKey)}
-              </p>
-              {emptyState.hintKey ? (
-                <p className="wallpaper-masonry__empty-hint">
-                  {t(emptyState.hintKey as MessageKey)}
-                </p>
-              ) : null}
-              {emptyState.showClearFilters ? (
-                <button
-                  type="button"
-                  className="btn btn--ghost btn--sm"
-                  onClick={clearGalleryFilters}
-                >
-                  {t("settings.wallpaperSource.clearFilters")}
-                </button>
-              ) : null}
-            </div>
-          ) : null}
-          {visibleItems.map((item) => {
-            const active = item.id === selectedId;
-            const loadingThis = previewingId === item.id;
-            const src = itemThumbSrc(item);
-            const cite =
-              item.source === "x" || (!item.source && tab === "x")
-                ? resolveWallpaperXCitation(item)
-                : null;
-            return (
-              <div
-                key={item.id}
-                className={
-                  "wallpaper-masonry__card-wrap" +
-                  (isLibraryTab ? " wallpaper-masonry__card-wrap--library" : "")
-                }
-                role="listitem"
-              >
-                <button
-                  type="button"
-                  className={
-                    "wallpaper-masonry__card" +
-                    (active ? " wallpaper-masonry__card--selected" : "") +
-                    (loadingThis ? " wallpaper-masonry__card--loading" : "")
-                  }
-                  disabled={locked && !loadingThis}
-                  onClick={() => void openItemPreview(item)}
-                  aria-label={t("settings.wallpaperSource.openPreview")}
-                >
-                  <img
-                    src={src}
-                    alt={item.textPreview || item.prompt || item.username || ""}
-                    className="wallpaper-masonry__img"
-                    loading="lazy"
-                    referrerPolicy="no-referrer"
-                    onError={() => {
-                      // Thumb failed — remove undownloadable / broken entry
-                      dropItem(item.id);
-                    }}
-                  />
-                  <span className="wallpaper-masonry__meta">
-                    {loadingThis
-                      ? t("settings.wallpaperSource.loadingOriginal")
-                      : null}
-                    {!loadingThis && item.username
-                      ? `@${item.username}`
-                      : null}
-                    {!loadingThis && item.likes != null
-                      ? ` · ♥ ${item.likes}`
-                      : null}
-                    {!loadingThis &&
-                    !isLibraryTab &&
-                    item.source === "imagine"
-                      ? t("settings.wallpaperImagine")
-                      : null}
-                    {!loadingThis && isLibraryTab
-                      ? item.source === "imagine"
-                        ? t("settings.wallpaperImagine")
-                        : item.source === "x"
-                          ? t("settings.wallpaperFromX")
-                          : t("settings.wallpaperLibrary")
-                      : null}
-                  </span>
-                </button>
-                {cite && !loadingThis ? (
-                  <div
-                    className={
-                      "wallpaper-masonry__cite" +
-                      (cite.state === "verified"
-                        ? " wallpaper-masonry__cite--verified"
-                        : " wallpaper-masonry__cite--unverified")
-                    }
-                    title={t(cite.hintKey as MessageKey)}
-                  >
-                    {cite.state === "verified" && cite.statusUrl ? (
-                      <button
-                        type="button"
-                        className="wallpaper-masonry__cite-btn"
-                        disabled={locked}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          openXStatus(cite.statusUrl!);
-                        }}
-                        title={t("settings.wallpaperSource.cite.openPost")}
-                        aria-label={t("settings.wallpaperSource.cite.openPost")}
-                      >
-                        {t(cite.labelKey as MessageKey)}
-                      </button>
-                    ) : (
-                      <span className="wallpaper-masonry__cite-badge">
-                        {t(cite.labelKey as MessageKey)}
-                      </span>
-                    )}
-                  </div>
-                ) : null}
-                {isLibraryTab ? (
-                  <button
-                    type="button"
-                    className="wallpaper-masonry__delete"
-                    disabled={locked}
-                    onClick={(e) => requestDeleteLibraryItem(item, e)}
-                    aria-label={t("settings.wallpaperSource.delete")}
-                    title={t("settings.wallpaperSource.delete")}
-                  >
-                    ×
-                  </button>
-                ) : null}
-              </div>
-            );
-          })}
-        </div>
-      </div>
+      <WallpaperSourceGallery
+        t={t}
+        tab={tab}
+        busy={busy}
+        locked={locked}
+        visibleItems={visibleItems}
+        selectedId={selectedId}
+        previewingId={previewingId}
+        showEmptyBlock={showEmptyBlock}
+        emptyState={emptyState}
+        clearGalleryFilters={clearGalleryFilters}
+        openItemPreview={openItemPreview}
+        dropItem={dropItem}
+        openXStatus={openXStatus}
+        requestDeleteLibraryItem={requestDeleteLibraryItem}
+      />
     </GlassModal>
     <GlassModal
       open={!!deleteConfirm}


### PR DESCRIPTION
## Summary

将壁纸来源弹窗中的控制区、画廊和底部操作抽为 `WallpaperSourceControls`、`WallpaperSourceGallery`、`WallpaperSourceFooter`。原弹窗保留搜索、生成、下载、预览、应用和删除状态及回调，各子组件通过明确类型的属性连接。

这是保持行为的组件拆分，沿用现有 DOM/CSS、翻译、筛选、空态和三种来源。没有增加未接通的渠道或改变页面布局，为后续逐项接入搜索渠道减少同一文件的冲突。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / chore

## 验证

- 前端 586 文件、7,055 项测试，类型检查、lint、UI 构建、质量门禁、网站自测、依赖检查和审计通过。
- Windows Rust 1,605 项通过、1 项原有 ignored；Rust fmt/clippy 通过。
- 前置测试修复：#1074（设置目录隔离）、#1083（菜单动画清理）。本分支保留这两个独立提交供全量验证，请先合入前置，再更新基底消除重复差异。组件拆分仅在 `729f860f` 提交中，可独立审查。
- 尚未在该独立分支执行手动视觉对照。

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh) — 沿用原文案
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed — 行为保持
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
