### PR TITLE
feat(wallpaper): 接入可取消的 X 搜索与请求进度隔离

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -4,6 +4,30 @@ The existing Appearance wallpaper search uses Grok Build CLI. The Host parses
 model candidates, validates image responses, merges duplicates, and ranks the
 remaining items before returning the existing gallery IPC shape.
 
+## Request lifecycle
+
+`wallpaper_x_search` accepts an optional UUID requestId (older callers may omit
+it). `wallpaper_x_search_cancel` cancels only that request. A bounded 30-second
+pre-cancel record handles cancellation arriving before registration; duplicate
+active identifiers are rejected and request guards clean up on completion/drop.
+
+The Host emits `wallpaper://x-search-progress` with requestId and stage:
+preparing, searching_x, validating, supplementing, done. Progress is advisory;
+the invoke result remains authoritative. Cancellation interrupts CLI execution
+and image validation; the existing output-drain/process-tree cleanup is retained.
+
+The picker offers Cancel search, cancels on close/tab change/unmount, and ignores
+late results/errors/progress. Replacement searches invalidate the previous
+generation synchronously without waiting for a cancellation acknowledgement.
+There is no result cache or alternate route in this slice; account-sensitive
+caching belongs to the later routing implementation.
+
+Hook and picker tests cover replacement, late responses, progress ownership and
+close/tab cancellation. Host tests cover UUIDs, pre-cancel expiry/capacity,
+registry cleanup, waiter wakeup, and cancellation of a synthetic CLI process.
+
+## Image quality
+
 - The first CLI round requests two X search tool calls. When fewer than six
   validated images remain, one supplementary round requests one further call
   and includes already-seen references. These are prompt budgets, not a promise

--- a/src-tauri/src/commands/misc_p1.rs
+++ b/src-tauri/src/commands/misc_p1.rs
@@ -1110,11 +1110,20 @@ pub async fn marketplace_plugin_meta_index() -> Result<serde_json::Value, String
 
 #[tauri::command]
 pub async fn wallpaper_x_search(
+    app: tauri::AppHandle,
     query: String,
     sort: Option<String>,
+    request_id: Option<String>,
 ) -> Result<crate::wallpaper_source::WallpaperSearchResult, String> {
     crate::wallpaper_source::ensure_wallpaper_dirs();
-    Ok(crate::wallpaper_source::x_search_async(&query, sort.as_deref()).await)
+    let request_id = crate::wallpaper_x_search::request_id(request_id.as_deref())?;
+    crate::wallpaper_x_search::search(&app, &request_id, &query, sort.as_deref()).await
+}
+
+#[tauri::command]
+pub fn wallpaper_x_search_cancel(request_id: String) -> Result<bool, String> {
+    let request_id = crate::wallpaper_x_search::request_id(Some(&request_id))?;
+    Ok(crate::wallpaper_x_search::cancel(&request_id))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -225,6 +225,7 @@ mod voice_stt;
 mod voice_tools;
 
 mod wallpaper_source;
+mod wallpaper_x_search;
 
 mod window_min;
 
@@ -1698,6 +1699,7 @@ pub fn run() {
             remote_im::remote_im_doctor,
 
             commands::wallpaper_x_search,
+            commands::wallpaper_x_search_cancel,
 
             commands::wallpaper_fetch_media,
 

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -91,6 +91,99 @@ pub struct WallpaperSearchResult {
     pub message: Option<String>,
 }
 
+#[derive(Clone)]
+pub(crate) struct WallpaperSearchCancellation {
+    inner: Arc<WallpaperSearchCancellationInner>,
+}
+
+struct WallpaperSearchCancellationInner {
+    cancelled: AtomicBool,
+    signal: tokio::sync::watch::Sender<bool>,
+}
+
+impl Default for WallpaperSearchCancellation {
+    fn default() -> Self {
+        let (signal, _receiver) = tokio::sync::watch::channel(false);
+        Self {
+            inner: Arc::new(WallpaperSearchCancellationInner {
+                cancelled: AtomicBool::new(false),
+                signal,
+            }),
+        }
+    }
+}
+
+impl WallpaperSearchCancellation {
+    pub(crate) fn cancel(&self) {
+        if !self.inner.cancelled.swap(true, Ordering::AcqRel) {
+            self.inner.signal.send_replace(true);
+        }
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        if self.is_cancelled() {
+            return;
+        }
+        let mut receiver = self.inner.signal.subscribe();
+        while !self.is_cancelled() && !*receiver.borrow() {
+            if receiver.changed().await.is_err() {
+                break;
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WallpaperXSearchStage {
+    Preparing,
+    SearchingX,
+    Validating,
+    Supplementing,
+    Done,
+}
+
+#[derive(Clone)]
+pub(crate) struct WallpaperXSearchRuntime {
+    cancellation: WallpaperSearchCancellation,
+    progress: Arc<dyn Fn(WallpaperXSearchStage) + Send + Sync>,
+}
+
+impl WallpaperXSearchRuntime {
+    pub(crate) fn new(
+        cancellation: WallpaperSearchCancellation,
+        progress: Arc<dyn Fn(WallpaperXSearchStage) + Send + Sync>,
+    ) -> Self {
+        Self {
+            cancellation,
+            progress,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn quiet() -> Self {
+        Self::new(WallpaperSearchCancellation::default(), Arc::new(|_| {}))
+    }
+
+    pub(crate) fn cancellation(&self) -> &WallpaperSearchCancellation {
+        &self.cancellation
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.cancellation.is_cancelled()
+    }
+
+    pub(crate) fn report(&self, stage: WallpaperXSearchStage) {
+        if !self.is_cancelled() || stage == WallpaperXSearchStage::Done {
+            (self.progress)(stage);
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct WallpaperCliSearchOutcome {
     pub(crate) result: WallpaperSearchResult,
@@ -961,6 +1054,21 @@ pub(crate) fn run_grok_headless(
     timeout: Duration,
     cwd: Option<&Path>,
 ) -> Result<String, String> {
+    run_grok_headless_cancellable(cli_path, prompt, schema, max_turns, timeout, cwd, None)
+}
+
+pub(crate) fn run_grok_headless_cancellable(
+    cli_path: &str,
+    prompt: &str,
+    schema: &str,
+    max_turns: u32,
+    timeout: Duration,
+    cwd: Option<&Path>,
+    cancellation: Option<&WallpaperSearchCancellation>,
+) -> Result<String, String> {
+    if cancellation.is_some_and(WallpaperSearchCancellation::is_cancelled) {
+        return Err("cancelled".into());
+    }
     let mut cmd = Command::new(cli_path);
     cmd.arg("-p")
         .arg(prompt)
@@ -998,9 +1106,17 @@ pub(crate) fn run_grok_headless(
     let mut child = cmd.spawn().map_err(|e| format!("cli spawn: {e}"))?;
     let output_readers = WallpaperCliOutputReaders::start(&mut child)?;
     loop {
+        if cancellation.is_some_and(WallpaperSearchCancellation::is_cancelled) {
+            terminate_wallpaper_process_tree(&mut child);
+            output_readers.stop();
+            return Err("cancelled".into());
+        }
         match child.try_wait() {
             Ok(Some(status)) => {
                 let stdout = output_readers.finish()?;
+                if cancellation.is_some_and(WallpaperSearchCancellation::is_cancelled) {
+                    return Err("cancelled".into());
+                }
                 if !status.success() && stdout.trim().is_empty() {
                     tracing::warn!("wallpaper source cli failed");
                     return Err("search_failed".into());
@@ -1657,11 +1773,15 @@ pub(crate) fn x_gallery_needs_supplement(valid_count: usize) -> bool {
 }
 
 /// Drop items whose fullUrl cannot be fetched as an image.
-pub async fn filter_reachable_gallery_items(
+pub(crate) async fn filter_reachable_gallery_items_cancellable(
     mut items: Vec<WallpaperGalleryItem>,
+    cancellation: Option<&WallpaperSearchCancellation>,
 ) -> Vec<WallpaperGalleryItem> {
     if items.is_empty() {
         return items;
+    }
+    if cancellation.is_some_and(WallpaperSearchCancellation::is_cancelled) {
+        return Vec::new();
     }
     filter_gallery_candidates(&mut items);
     items = dedupe_gallery_items(items, false);
@@ -1686,7 +1806,16 @@ pub async fn filter_reachable_gallery_items(
                 }
             })
             .collect();
-        let results = futures_util::future::join_all(futs).await;
+        let joined = futures_util::future::join_all(futs);
+        let results = if let Some(cancellation) = cancellation {
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => return Vec::new(),
+                results = joined => results,
+            }
+        } else {
+            joined.await
+        };
         for (probe, mut it) in results {
             if let Some(probe) = probe {
                 if let Some((width, height)) = probe.dimensions {
@@ -1704,8 +1833,17 @@ pub async fn filter_reachable_gallery_items(
                 tracing::debug!("wallpaper gallery: drop unreachable media");
             }
         }
+        if cancellation.is_some_and(WallpaperSearchCancellation::is_cancelled) {
+            return Vec::new();
+        }
     }
     merge_rank_x_gallery_items(out)
+}
+
+pub async fn filter_reachable_gallery_items(
+    items: Vec<WallpaperGalleryItem>,
+) -> Vec<WallpaperGalleryItem> {
+    filter_reachable_gallery_items_cancellable(items, None).await
 }
 
 fn x_search_round(
@@ -1714,7 +1852,11 @@ fn x_search_round(
     max_search_calls: u32,
     is_supplement: bool,
     seen_ids: &[String],
+    cancellation: Option<&WallpaperSearchCancellation>,
 ) -> WallpaperSearchResult {
+    if cancellation.is_some_and(WallpaperSearchCancellation::is_cancelled) {
+        return cancelled_search_result();
+    }
     let q = query.trim();
     if q.is_empty() {
         return WallpaperSearchResult {
@@ -1767,7 +1909,15 @@ fn x_search_round(
 
     let prompt = build_x_search_prompt(q, sort, max_search_calls, is_supplement, seen_ids);
 
-    let stdout = match run_grok_headless(&cli, &prompt, schema, 14, X_SEARCH_TIMEOUT, None) {
+    let stdout = match run_grok_headless_cancellable(
+        &cli,
+        &prompt,
+        schema,
+        14,
+        X_SEARCH_TIMEOUT,
+        None,
+        cancellation,
+    ) {
         Ok(s) => s,
         Err(code) => {
             return WallpaperSearchResult {
@@ -1815,7 +1965,7 @@ fn x_search_round(
 /// Sync first-round headless search only (no network probe). Prefer
 /// [`x_search_async`] for the complete quality and supplement pipeline.
 pub fn x_search(query: &str, sort: Option<&str>) -> WallpaperSearchResult {
-    x_search_round(query, sort, X_SEARCH_FIRST_ROUND_CALLS, false, &[])
+    x_search_round(query, sort, X_SEARCH_FIRST_ROUND_CALLS, false, &[], None)
 }
 
 fn extract_media_index_from_status_url(url: &str) -> Option<u8> {
@@ -1898,15 +2048,36 @@ pub(crate) fn x_gallery_reference_ids(items: &[WallpaperGalleryItem]) -> Vec<Str
 
 /// Headless X search + drop unreachable media URLs before returning to UI.
 pub async fn x_search_async(query: &str, sort: Option<&str>) -> WallpaperSearchResult {
-    x_search_cli_outcome(query, sort).await.result
+    x_search_cli_outcome(query, sort, None).await.result
+}
+
+fn cancelled_search_result() -> WallpaperSearchResult {
+    WallpaperSearchResult {
+        items: Vec::new(),
+        error_code: Some("cancelled".into()),
+        message: None,
+    }
+}
+
+fn cancelled_cli_outcome() -> WallpaperCliSearchOutcome {
+    WallpaperCliSearchOutcome {
+        result: cancelled_search_result(),
+        candidate_count: 0,
+        valid_count: 0,
+    }
 }
 
 pub(crate) async fn x_search_cli_outcome(
     query: &str,
     sort: Option<&str>,
+    runtime: Option<&WallpaperXSearchRuntime>,
 ) -> WallpaperCliSearchOutcome {
+    if runtime.is_some_and(WallpaperXSearchRuntime::is_cancelled) {
+        return cancelled_cli_outcome();
+    }
     let first_query = query.to_string();
     let first_sort = sort.map(str::to_string);
+    let first_cancellation = runtime.map(|runtime| runtime.cancellation().clone());
     let mut result = match tauri::async_runtime::spawn_blocking(move || {
         x_search_round(
             &first_query,
@@ -1914,6 +2085,7 @@ pub(crate) async fn x_search_cli_outcome(
             X_SEARCH_FIRST_ROUND_CALLS,
             false,
             &[],
+            first_cancellation.as_ref(),
         )
     })
     .await
@@ -1932,6 +2104,12 @@ pub(crate) async fn x_search_cli_outcome(
         }
     };
 
+    if runtime.is_some_and(WallpaperXSearchRuntime::is_cancelled)
+        || result.error_code.as_deref() == Some("cancelled")
+    {
+        return cancelled_cli_outcome();
+    }
+
     let mut candidate_count = result.items.len();
     if result
         .error_code
@@ -1946,11 +2124,25 @@ pub(crate) async fn x_search_cli_outcome(
     }
 
     let seen_ids = x_gallery_reference_ids(&result.items);
-    let mut filtered = filter_reachable_gallery_items(std::mem::take(&mut result.items)).await;
+    if let Some(runtime) = runtime {
+        runtime.report(WallpaperXSearchStage::Validating);
+    }
+    let mut filtered = filter_reachable_gallery_items_cancellable(
+        std::mem::take(&mut result.items),
+        runtime.map(WallpaperXSearchRuntime::cancellation),
+    )
+    .await;
+    if runtime.is_some_and(WallpaperXSearchRuntime::is_cancelled) {
+        return cancelled_cli_outcome();
+    }
     if x_gallery_needs_supplement(filtered.len()) {
+        if let Some(runtime) = runtime {
+            runtime.report(WallpaperXSearchStage::Supplementing);
+        }
         let supplement_query = query.to_string();
         let supplement_sort = sort.map(str::to_string);
         let supplement_seen = seen_ids;
+        let supplement_cancellation = runtime.map(|runtime| runtime.cancellation().clone());
         if let Ok(supplement) = tauri::async_runtime::spawn_blocking(move || {
             x_search_round(
                 &supplement_query,
@@ -1958,14 +2150,30 @@ pub(crate) async fn x_search_cli_outcome(
                 X_SEARCH_SUPPLEMENT_CALLS,
                 true,
                 &supplement_seen,
+                supplement_cancellation.as_ref(),
             )
         })
         .await
         {
+            if runtime.is_some_and(WallpaperXSearchRuntime::is_cancelled)
+                || supplement.error_code.as_deref() == Some("cancelled")
+            {
+                return cancelled_cli_outcome();
+            }
             candidate_count = candidate_count.saturating_add(supplement.items.len());
             if supplement.error_code.is_none() || supplement.error_code.as_deref() == Some("empty")
             {
-                let supplement_items = filter_reachable_gallery_items(supplement.items).await;
+                if let Some(runtime) = runtime {
+                    runtime.report(WallpaperXSearchStage::Validating);
+                }
+                let supplement_items = filter_reachable_gallery_items_cancellable(
+                    supplement.items,
+                    runtime.map(WallpaperXSearchRuntime::cancellation),
+                )
+                .await;
+                if runtime.is_some_and(WallpaperXSearchRuntime::is_cancelled) {
+                    return cancelled_cli_outcome();
+                }
                 filtered.extend(supplement_items);
                 filtered = merge_rank_x_gallery_items(filtered);
             }
@@ -2436,6 +2644,88 @@ pub fn ensure_wallpaper_dirs() {
 
 #[cfg(test)]
 mod tests {
+    #[tokio::test]
+    async fn cancellation_wakes_waiters_and_prevents_cli_start() {
+        let cancellation = WallpaperSearchCancellation::default();
+        let waiter = cancellation.clone();
+        let task = tokio::spawn(async move { waiter.cancelled().await });
+        cancellation.cancel();
+        cancellation.cancel();
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            run_grok_headless_cancellable(
+                "missing-cli-must-not-start",
+                "query",
+                "{}",
+                1,
+                Duration::from_secs(1),
+                None,
+                Some(&cancellation),
+            )
+            .unwrap_err(),
+            "cancelled"
+        );
+        let runtime = WallpaperXSearchRuntime::new(cancellation, Arc::new(|_| {}));
+        let result = x_search_cli_outcome("sky", None, Some(&runtime)).await;
+        assert_eq!(result.result.error_code.as_deref(), Some("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn active_cli_cancellation_returns_before_execution_timeout() {
+        let test_dir =
+            std::env::temp_dir().join(format!("wallpaper-cancel-{}", uuid::Uuid::new_v4()));
+        fs::create_dir(&test_dir).unwrap();
+        #[cfg(windows)]
+        let cli = test_dir.join("grok.cmd");
+        #[cfg(windows)]
+        fs::write(
+            &cli,
+            "@echo off\r\nif \"%~1\"==\"--version\" (echo 0.2.117 & exit /b 0)\r\necho ready>\"%~dp0started\"\r\npowershell -NoProfile -Command \"Start-Sleep -Seconds 30\"\r\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        let cli = test_dir.join("grok");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::write(&cli, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 0.2.117; exit 0; fi\necho ready > \"$(dirname \"$0\")/started\"\nsleep 30\n").unwrap();
+            fs::set_permissions(&cli, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let cancellation = WallpaperSearchCancellation::default();
+        let signal = cancellation.clone();
+        let cli_path = cli.to_string_lossy().to_string();
+        let task = tokio::task::spawn_blocking(move || {
+            run_grok_headless_cancellable(
+                &cli_path,
+                "cancel",
+                "{}",
+                1,
+                Duration::from_secs(30),
+                None,
+                Some(&signal),
+            )
+        });
+        let started = test_dir.join("started");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !started.exists() && Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let did_start = started.exists();
+        cancellation.cancel();
+        let result = tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.unwrap_err(), "cancelled");
+        assert!(did_start, "synthetic CLI never reached its execution phase");
+        fs::remove_file(started).unwrap();
+        fs::remove_file(cli).unwrap();
+        fs::remove_dir(test_dir).unwrap();
+    }
+
     #[test]
     fn wallpaper_cli_drains_large_stdout_and_stderr_before_exit() {
         let test_dir = std::env::temp_dir().join(format!(

--- a/src-tauri/src/wallpaper_x_search.rs
+++ b/src-tauri/src/wallpaper_x_search.rs
@@ -1,0 +1,180 @@
+//! Request ownership, progress and cancellation for CLI wallpaper searches.
+use crate::wallpaper_source::{
+    self, WallpaperSearchCancellation, WallpaperSearchResult, WallpaperXSearchRuntime,
+    WallpaperXSearchStage,
+};
+use parking_lot::Mutex;
+use serde::Serialize;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+use tauri::Emitter;
+const PRE_CANCEL_TTL: Duration = Duration::from_secs(30);
+const PRE_CANCEL_CAPACITY: usize = 64;
+pub(crate) const WALLPAPER_X_SEARCH_PROGRESS_EVENT: &str = "wallpaper://x-search-progress";
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WallpaperXSearchProgress {
+    request_id: String,
+    stage: WallpaperXSearchStage,
+}
+#[derive(Default)]
+struct RequestRegistry {
+    active: HashMap<String, WallpaperSearchCancellation>,
+    pre_cancelled: VecDeque<(String, Instant)>,
+}
+
+impl RequestRegistry {
+    fn purge_pre_cancelled(&mut self, now: Instant) {
+        self.pre_cancelled
+            .retain(|(_, created)| now.duration_since(*created) < PRE_CANCEL_TTL);
+    }
+
+    fn record_pre_cancel(&mut self, request_id: &str, now: Instant) {
+        self.purge_pre_cancelled(now);
+        self.pre_cancelled.retain(|(id, _)| id != request_id);
+        while self.pre_cancelled.len() >= PRE_CANCEL_CAPACITY {
+            self.pre_cancelled.pop_front();
+        }
+        self.pre_cancelled.push_back((request_id.to_string(), now));
+    }
+
+    fn take_pre_cancel(&mut self, request_id: &str, now: Instant) -> bool {
+        self.purge_pre_cancelled(now);
+        let found = self.pre_cancelled.iter().any(|(id, _)| id == request_id);
+        self.pre_cancelled.retain(|(id, _)| id != request_id);
+        found
+    }
+}
+
+fn active_requests() -> &'static Mutex<RequestRegistry> {
+    static REQUESTS: OnceLock<Mutex<RequestRegistry>> = OnceLock::new();
+    REQUESTS.get_or_init(|| Mutex::new(RequestRegistry::default()))
+}
+
+struct ActiveRequestGuard {
+    request_id: String,
+    cancellation: WallpaperSearchCancellation,
+}
+
+impl Drop for ActiveRequestGuard {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+        active_requests().lock().active.remove(&self.request_id);
+    }
+}
+
+fn register_request(request_id: &str) -> Result<ActiveRequestGuard, String> {
+    let cancellation = WallpaperSearchCancellation::default();
+    let mut requests = active_requests().lock();
+    if requests.active.contains_key(request_id) {
+        return Err("wallpaper_request_in_use".into());
+    }
+    if requests.take_pre_cancel(request_id, Instant::now()) {
+        cancellation.cancel();
+    }
+    requests
+        .active
+        .insert(request_id.to_string(), cancellation.clone());
+    Ok(ActiveRequestGuard {
+        request_id: request_id.to_string(),
+        cancellation,
+    })
+}
+
+pub(crate) fn request_id(raw: Option<&str>) -> Result<String, String> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(uuid::Uuid::new_v4().to_string());
+    };
+    uuid::Uuid::parse_str(raw)
+        .map(|id| id.to_string())
+        .map_err(|_| "invalid_wallpaper_request_id".to_string())
+}
+
+pub(crate) fn cancel(request_id: &str) -> bool {
+    let mut requests = active_requests().lock();
+    let cancellation = requests.active.get(request_id).cloned();
+    if let Some(cancellation) = cancellation {
+        drop(requests);
+        cancellation.cancel();
+        true
+    } else {
+        // IPC can deliver cancel just before the async search command reaches
+        // registration. Keep a short, bounded tombstone so close/switch still
+        // prevents that request from starting network or CLI work.
+        requests.record_pre_cancel(request_id, Instant::now());
+        true
+    }
+}
+
+pub(crate) async fn search(
+    app: &tauri::AppHandle,
+    request_id: &str,
+    query: &str,
+    sort: Option<&str>,
+) -> Result<WallpaperSearchResult, String> {
+    let request = register_request(request_id)?;
+    let event_app = app.clone();
+    let event_request_id = request_id.to_string();
+    let runtime = WallpaperXSearchRuntime::new(
+        request.cancellation.clone(),
+        Arc::new(move |stage| {
+            let _ = event_app.emit(
+                WALLPAPER_X_SEARCH_PROGRESS_EVENT,
+                WallpaperXSearchProgress {
+                    request_id: event_request_id.clone(),
+                    stage,
+                },
+            );
+        }),
+    );
+    runtime.report(WallpaperXSearchStage::Preparing);
+    runtime.report(WallpaperXSearchStage::SearchingX);
+    let result = wallpaper_source::x_search_cli_outcome(query, sort, Some(&runtime))
+        .await
+        .result;
+    runtime.report(WallpaperXSearchStage::Done);
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn request_ids_are_validated_and_canonicalized() {
+        assert!(request_id(Some("invalid")).is_err());
+        let id = uuid::Uuid::new_v4();
+        assert_eq!(
+            request_id(Some(&id.to_string().to_uppercase())).unwrap(),
+            id.to_string()
+        );
+        assert!(uuid::Uuid::parse_str(&request_id(None).unwrap()).is_ok());
+    }
+    #[test]
+    fn cancel_before_register_and_guard_cleanup() {
+        let id = uuid::Uuid::new_v4().to_string();
+        assert!(cancel(&id));
+        let request = register_request(&id).unwrap();
+        assert!(request.cancellation.is_cancelled());
+        assert!(register_request(&id).is_err());
+        drop(request);
+        assert!(!active_requests().lock().active.contains_key(&id));
+        let request = register_request(&id).unwrap();
+        assert!(!request.cancellation.is_cancelled());
+        assert!(cancel(&id));
+        assert!(request.cancellation.is_cancelled());
+    }
+    #[test]
+    fn pre_cancel_is_bounded_and_expires() {
+        let mut registry = RequestRegistry::default();
+        let now = Instant::now();
+        for index in 0..PRE_CANCEL_CAPACITY + 2 {
+            registry.record_pre_cancel(&index.to_string(), now);
+        }
+        assert_eq!(registry.pre_cancelled.len(), PRE_CANCEL_CAPACITY);
+        assert!(!registry.take_pre_cancel("0", now));
+        assert!(registry.take_pre_cancel("2", now));
+        assert!(!registry.take_pre_cancel("3", now + PRE_CANCEL_TTL));
+        assert!(registry.pre_cancelled.is_empty());
+    }
+}

--- a/src/components/WallpaperSourceControls.tsx
+++ b/src/components/WallpaperSourceControls.tsx
@@ -10,19 +10,23 @@ type Props = {
   prompt: string;
   aspect: string;
   busy: boolean;
+  /** True only while an X search request is in flight (enables Cancel). */
+  xBusy?: boolean;
   locked: boolean;
   setQuery: (value: string) => void;
   setSort: (value: "top" | "latest") => void;
   setPrompt: (value: string) => void;
   setAspect: (value: string) => void;
   runXSearch: () => Promise<void>;
+  cancelXSearch?: () => Promise<boolean>;
   runImagine: () => Promise<void>;
   loadLibrary: () => Promise<void>;
 };
 
 export function WallpaperSourceControls({
-  t, tab, query, sort, prompt, aspect, busy, locked,
-  setQuery, setSort, setPrompt, setAspect, runXSearch, runImagine, loadLibrary,
+  t, tab, query, sort, prompt, aspect, busy, xBusy = false, locked,
+  setQuery, setSort, setPrompt, setAspect, runXSearch, cancelXSearch,
+  runImagine, loadLibrary,
 }: Props) {
   const sortOptions = useMemo(
     () => [
@@ -77,12 +81,17 @@ export function WallpaperSourceControls({
             <button
               type="button"
               className="btn btn--solid"
-              disabled={locked || !query.trim()}
-              onClick={() => void runXSearch()}
+              disabled={!xBusy && (locked || !query.trim())}
+              onClick={() => {
+                if (xBusy) void cancelXSearch?.();
+                else void runXSearch();
+              }}
             >
-              {busy
-                ? t("settings.wallpaperSource.searching")
-                : t("settings.wallpaperSource.search")}
+              {xBusy
+                ? t("settings.wallpaperSource.cancelSearch")
+                : busy
+                  ? t("settings.wallpaperSource.searching")
+                  : t("settings.wallpaperSource.search")}
             </button>
           </div>
         </div>

--- a/src/components/WallpaperSourceModal.test.tsx
+++ b/src/components/WallpaperSourceModal.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@/test/jsdomStubs";
+
+const cancelSearch = vi.hoisted(() => vi.fn(async () => true));
+
+vi.mock("@/hooks/useWallpaperXSearch", () => ({
+  useWallpaperXSearch: () => ({
+    busy: true,
+    requestId: "request-active",
+    stage: "validating",
+    search: vi.fn(),
+    cancel: cancelSearch,
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  isDesktopHost: () => true,
+  wallpaperFetchMedia: vi.fn(),
+  wallpaperImagine: vi.fn(),
+  wallpaperLibraryList: vi.fn(),
+  wallpaperLibraryDelete: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("@/components/ImageViewerContext", () => ({
+  useImageViewerOptional: () => ({ open: vi.fn() }),
+}));
+
+vi.mock("@/components/Select", () => ({
+  Select: ({ value }: { value: string }) => <span>{value}</span>,
+}));
+
+vi.mock("@/components/GlassModal", () => ({
+  GlassModal: ({
+    open,
+    onClose,
+    children,
+    footer,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+  }) =>
+    open ? (
+      <div>
+        <button type="button" onClick={onClose}>
+          modal-close
+        </button>
+        {children}
+        {footer}
+      </div>
+    ) : null,
+}));
+
+import { WallpaperSourceModal } from "./WallpaperSourceModal";
+
+afterEach(() => {
+  cleanup();
+  cancelSearch.mockClear();
+});
+
+describe("WallpaperSourceModal X search lifecycle", () => {
+  const t = (key: string) => key;
+
+  it("shows real progress and exposes an explicit cancel-search action", () => {
+    render(
+      <WallpaperSourceModal
+        open
+        t={t as never}
+        onClose={vi.fn()}
+        onPickFile={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("settings.wallpaperSource.progress.validating"),
+    ).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "settings.wallpaperSource.cancelSearch",
+      }),
+    );
+    expect(cancelSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels an active X search when switching tabs or closing", () => {
+    const onClose = vi.fn();
+    render(
+      <WallpaperSourceModal
+        open
+        t={t as never}
+        onClose={onClose}
+        onPickFile={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("tab", { name: "settings.wallpaperImagine" }),
+    );
+    expect(cancelSearch).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "modal-close" }));
+    expect(cancelSearch).toHaveBeenCalledTimes(2);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/WallpaperSourceModal.tsx
+++ b/src/components/WallpaperSourceModal.tsx
@@ -13,6 +13,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { WallpaperSourceGallery } from "./WallpaperSourceGallery";
 import { WallpaperSourceFooter } from "./WallpaperSourceFooter";
+import { useWallpaperXSearch } from "@/hooks/useWallpaperXSearch";
 import { GlassModal } from "@/components/GlassModal";
 import { WallpaperSourceControls } from "./WallpaperSourceControls";
 import { useImageViewerOptional } from "@/components/ImageViewerContext";
@@ -114,7 +115,21 @@ export function WallpaperSourceModal({
   /** True after at least one search/generate finished this open. */
   const [hasSearched, setHasSearched] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
+  const [operationBusy, setBusy] = useState(false);
+  const {
+    busy: xBusy,
+    stage: xStage,
+    search: searchX,
+    cancel: cancelX,
+  } = useWallpaperXSearch();
+  const busy = operationBusy || xBusy;
+  const close = useCallback(() => {
+    void cancelX();
+    onClose();
+  }, [cancelX, onClose]);
+  useEffect(() => {
+    if (!open || tab !== "x") void cancelX();
+  }, [open, tab, cancelX]);
   const [applying, setApplying] = useState(false);
   const [previewingId, setPreviewingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -228,16 +243,16 @@ export function WallpaperSourceModal({
       setCiteSummary(null);
       return;
     }
-    setBusy(true);
     setError(null);
     setErrorCode(null);
     setCiteSummary(null);
-    setStatusHint(t("settings.wallpaperSource.searching"));
+    setStatusHint(null);
     setSelectedId(null);
     setGalleryFilter("");
     setKindFilter("all");
     try {
-      const res = await api.wallpaperXSearch(q, sort);
+      const res = await searchX(q, sort);
+      if (!res) return;
       const list = dedupeGalleryItems(res.items || []);
       const code = errorCodeFromSearchResult({ ...res, items: list });
       setHasSearched(true);
@@ -283,11 +298,8 @@ export function WallpaperSourceModal({
       const code = parseWallpaperSourceError(e);
       setErrorCode(code);
       setError(errorMessage(t, code));
-    } finally {
-      setBusy(false);
-      setStatusHint(null);
     }
-  }, [query, sort, t]);
+  }, [query, sort, t, searchX]);
 
   const runImagine = useCallback(async () => {
     const p = prompt.trim();
@@ -570,7 +582,7 @@ export function WallpaperSourceModal({
     <>
     <GlassModal
       open={open}
-      onClose={onClose}
+      onClose={close}
       title={t("settings.wallpaperSource.title")}
       size="lg"
       className="wallpaper-source-modal"
@@ -583,7 +595,7 @@ export function WallpaperSourceModal({
           selected={selected !== null}
           locked={locked}
           applying={applying}
-          onClose={onClose}
+          onClose={close}
           applySelected={applySelected}
         />
       }
@@ -605,7 +617,7 @@ export function WallpaperSourceModal({
             setError(null);
             setErrorCode(null);
           }}
-          disabled={locked}
+          disabled={operationBusy || applying || previewingId !== null}
         >
           {t("settings.wallpaperFromX")}
         </button>
@@ -625,7 +637,7 @@ export function WallpaperSourceModal({
             setError(null);
             setErrorCode(null);
           }}
-          disabled={locked}
+          disabled={operationBusy || applying || previewingId !== null}
         >
           {t("settings.wallpaperImagine")}
         </button>
@@ -642,7 +654,7 @@ export function WallpaperSourceModal({
             setError(null);
             setErrorCode(null);
           }}
-          disabled={locked}
+          disabled={operationBusy || applying || previewingId !== null}
         >
           {t("settings.wallpaperLibrary")}
         </button>
@@ -656,16 +668,31 @@ export function WallpaperSourceModal({
         prompt={prompt}
         aspect={aspect}
         busy={busy}
+        xBusy={xBusy}
         locked={locked}
         setQuery={setQuery}
         setSort={setSort}
         setPrompt={setPrompt}
         setAspect={setAspect}
         runXSearch={runXSearch}
+        cancelXSearch={cancelX}
         runImagine={runImagine}
         loadLibrary={loadLibrary}
       />
 
+      {xBusy && xStage ? (
+        <p className="wallpaper-source-status" role="status">
+          {t(
+            xStage === "validating"
+              ? "settings.wallpaperSource.progress.validating"
+              : xStage === "supplementing"
+                ? "settings.wallpaperSource.progress.supplementing"
+                : xStage === "preparing"
+                  ? "settings.wallpaperSource.progress.preparing"
+                  : "settings.wallpaperSource.searching",
+          )}
+        </p>
+      ) : null}
       {statusHint ? (
         <p className="wallpaper-source-status" role="status">
           {statusHint}

--- a/src/hooks/useWallpaperXSearch.test.tsx
+++ b/src/hooks/useWallpaperXSearch.test.tsx
@@ -1,0 +1,73 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { useWallpaperXSearch, type WallpaperXSearchClient } from "./useWallpaperXSearch";
+import type { WallpaperSearchResult } from "@/lib/wallpaperSource";
+import type { WallpaperXSearchProgress } from "@/lib/wallpaperXSearch";
+
+afterEach(cleanup);
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+function harness() {
+  let emit!: (event: WallpaperXSearchProgress) => void;
+  const unlisten = vi.fn();
+  const client: WallpaperXSearchClient = {
+    search: vi.fn(), cancel: vi.fn(async () => true),
+    listenProgress: vi.fn(async (handler) => { emit = handler; return unlisten; }),
+  };
+  let nextId = 0;
+  const hook = renderHook(() => useWallpaperXSearch(client, () => String(++nextId)));
+  return { client, hook, unlisten, emit: (event: WallpaperXSearchProgress) => emit(event) };
+}
+
+it("accepts progress only for the active request and ignores late success after cancel", async () => {
+  const h = harness();
+  const pending = deferred<WallpaperSearchResult>();
+  vi.mocked(h.client.search).mockReturnValue(pending.promise);
+  let result!: Promise<WallpaperSearchResult | null>;
+  act(() => { result = h.hook.result.current.search("sky", "top"); });
+  act(() => h.emit({ requestId: "other", stage: "validating" }));
+  expect(h.hook.result.current.stage).toBe("preparing");
+  act(() => h.emit({ requestId: "1", stage: "validating" }));
+  expect(h.hook.result.current.stage).toBe("validating");
+  await act(async () => { await h.hook.result.current.cancel(); });
+  expect(h.hook.result.current.busy).toBe(false);
+  await act(async () => { pending.resolve({ items: [] }); expect(await result).toBeNull(); });
+  expect(h.client.cancel).toHaveBeenCalledWith("1");
+});
+
+it("starts replacements without waiting for cancel and rejects their late errors", async () => {
+  const h = harness();
+  const calls = [deferred<WallpaperSearchResult>(), deferred<WallpaperSearchResult>(), deferred<WallpaperSearchResult>()];
+  const cancelAck = deferred<boolean>();
+  vi.mocked(h.client.cancel).mockReturnValue(cancelAck.promise);
+  calls.forEach(call => vi.mocked(h.client.search).mockReturnValueOnce(call.promise));
+  const results: Promise<WallpaperSearchResult | null>[] = [];
+  act(() => { for (let i = 0; i < 3; i++) results.push(h.hook.result.current.search(String(i), "top")); });
+  expect(h.client.search).toHaveBeenCalledTimes(3);
+  await act(async () => {
+    calls[0].reject(new Error("old failure")); calls[1].resolve({ items: [] });
+    expect(await results[0]).toBeNull(); expect(await results[1]).toBeNull();
+  });
+  expect(h.hook.result.current.busy).toBe(true);
+  await act(async () => { calls[2].resolve({ items: [] }); expect(await results[2]).toEqual({ items: [] }); cancelAck.resolve(true); });
+  expect(h.hook.result.current.busy).toBe(false);
+});
+
+it("unmount cancels the Host and late listener registration cleans itself up", async () => {
+  const h = harness();
+  const pending = deferred<WallpaperSearchResult>();
+  vi.mocked(h.client.search).mockReturnValue(pending.promise);
+  let result!: Promise<WallpaperSearchResult | null>;
+  act(() => { result = h.hook.result.current.search("sky", "top"); });
+  h.hook.unmount();
+  expect(h.client.cancel).toHaveBeenCalledWith("1");
+  pending.resolve({ items: [] });
+  expect(await result).toBeNull();
+  await Promise.resolve();
+  expect(h.unlisten).toHaveBeenCalledTimes(1);
+});

--- a/src/hooks/useWallpaperXSearch.ts
+++ b/src/hooks/useWallpaperXSearch.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as api from "@/lib/api";
+import { createWallpaperXSearchRequestId, isWallpaperXSearchProgress, type WallpaperXSearchProgress, type WallpaperXSearchStage } from "@/lib/wallpaperXSearch";
+import type { WallpaperSearchResult } from "@/lib/wallpaperSource";
+
+export type WallpaperXSearchClient = {
+  search: (query: string, sort: "top" | "latest", requestId: string) => Promise<WallpaperSearchResult>;
+  cancel: (requestId: string) => Promise<boolean>;
+  listenProgress: (handler: (progress: WallpaperXSearchProgress) => void) => Promise<() => void>;
+};
+
+const DEFAULT_CLIENT: WallpaperXSearchClient = {
+  search: api.wallpaperXSearch,
+  cancel: api.wallpaperXSearchCancel,
+  listenProgress: api.listenWallpaperXSearchProgress,
+};
+
+export function useWallpaperXSearch(
+  client: WallpaperXSearchClient = DEFAULT_CLIENT,
+  requestIdFactory: () => string = createWallpaperXSearchRequestId,
+) {
+  const [busy, setBusy] = useState(false);
+  const [stage, setStage] = useState<WallpaperXSearchStage | null>(null);
+  const active = useRef<string | null>(null);
+  const generation = useRef(0);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void client.listenProgress((event) => {
+      if (!disposed && isWallpaperXSearchProgress(event) && event.requestId === active.current) {
+        setStage(event.stage);
+      }
+    }).then((cleanup) => {
+      if (disposed) cleanup();
+      else unlisten = cleanup;
+    }).catch(() => { /* Progress is advisory; the invoke result is authoritative. */ });
+    return () => {
+      disposed = true;
+      mounted.current = false;
+      generation.current += 1;
+      const id = active.current;
+      active.current = null;
+      unlisten?.();
+      if (id) void client.cancel(id).catch(() => false);
+    };
+  }, [client]);
+
+  const cancel = useCallback((): Promise<boolean> => {
+    const id = active.current;
+    generation.current += 1;
+    active.current = null;
+    if (mounted.current) {
+      setBusy(false);
+      setStage(null);
+    }
+    return id ? client.cancel(id).catch(() => false) : Promise.resolve(false);
+  }, [client]);
+
+  const search = useCallback(async (query: string, sort: "top" | "latest") => {
+    if (!mounted.current) return null;
+    // Invalidate synchronously: a slow cancel acknowledgement must not delay
+    // replacement or let a third request be overwritten by a waiting second.
+    void cancel();
+    const id = requestIdFactory();
+    const revision = ++generation.current;
+    active.current = id;
+    setBusy(true);
+    setStage("preparing");
+    const current = () => mounted.current && generation.current === revision && active.current === id;
+    try {
+      const result = await client.search(query, sort, id);
+      return current() && result.errorCode !== "cancelled" ? result : null;
+    } catch (error) {
+      if (!current()) return null;
+      throw error;
+    } finally {
+      if (current()) {
+        active.current = null;
+        setBusy(false);
+        setStage(null);
+      }
+    }
+  }, [cancel, client, requestIdFactory]);
+
+  return { busy, stage, search, cancel };
+}

--- a/src/i18n/messages/de/settings-ui.ts
+++ b/src/i18n/messages/de/settings-ui.ts
@@ -1,5 +1,9 @@
 /** de messages — domain: settings-ui */
 export const deSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Suche abbrechen",
+  "settings.wallpaperSource.progress.preparing": "Suche wird vorbereitet…",
+  "settings.wallpaperSource.progress.validating": "Bildqualität wird geprüft…",
+  "settings.wallpaperSource.progress.supplementing": "Weitere geeignete Bilder werden gesucht…",
   "settings.nav.general": "Allgemein",
   "settings.nav.appearance": "Erscheinungsbild",
   "settings.nav.account": "Konto",

--- a/src/i18n/messages/en/settings-ui.ts
+++ b/src/i18n/messages/en/settings-ui.ts
@@ -1,5 +1,9 @@
 /** English messages — domain: settings-ui */
 export const enSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Cancel search",
+  "settings.wallpaperSource.progress.preparing": "Preparing search…",
+  "settings.wallpaperSource.progress.validating": "Checking image quality…",
+  "settings.wallpaperSource.progress.supplementing": "Searching again for more usable images…",
   "settings.nav.general": "General",
   "settings.nav.appearance": "Appearance",
   "settings.nav.account": "Account",

--- a/src/i18n/messages/es/settings-ui.ts
+++ b/src/i18n/messages/es/settings-ui.ts
@@ -1,5 +1,9 @@
 /** es messages — domain: settings-ui */
 export const esSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Cancelar búsqueda",
+  "settings.wallpaperSource.progress.preparing": "Preparando la búsqueda…",
+  "settings.wallpaperSource.progress.validating": "Comprobando la calidad de las imágenes…",
+  "settings.wallpaperSource.progress.supplementing": "Buscando más imágenes utilizables…",
   "settings.nav.general": "General",
   "settings.nav.appearance": "Apariencia",
   "settings.nav.account": "Cuenta",

--- a/src/i18n/messages/fil/settings-ui.ts
+++ b/src/i18n/messages/fil/settings-ui.ts
@@ -1,5 +1,9 @@
 /** fil messages — domain: settings-ui */
 export const filSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Kanselahin ang paghahanap",
+  "settings.wallpaperSource.progress.preparing": "Inihahanda ang paghahanap…",
+  "settings.wallpaperSource.progress.validating": "Sinusuri ang kalidad ng larawan…",
+  "settings.wallpaperSource.progress.supplementing": "Naghahanap pa ng magagamit na mga larawan…",
   "settings.nav.general": "Pangkalahatan",
   "settings.nav.appearance": "Hitsura",
   "settings.nav.account": "Account",

--- a/src/i18n/messages/fr/settings-ui.ts
+++ b/src/i18n/messages/fr/settings-ui.ts
@@ -1,5 +1,9 @@
 /** fr messages — domain: settings-ui */
 export const frSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Annuler la recherche",
+  "settings.wallpaperSource.progress.preparing": "Préparation de la recherche…",
+  "settings.wallpaperSource.progress.validating": "Vérification de la qualité des images…",
+  "settings.wallpaperSource.progress.supplementing": "Recherche d’autres images utilisables…",
   "settings.nav.general": "Général",
   "settings.nav.appearance": "Apparence",
   "settings.nav.account": "Compte",

--- a/src/i18n/messages/id/settings-ui.ts
+++ b/src/i18n/messages/id/settings-ui.ts
@@ -1,5 +1,9 @@
 /** id messages — domain: settings-ui */
 export const idSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Batalkan pencarian",
+  "settings.wallpaperSource.progress.preparing": "Menyiapkan pencarian…",
+  "settings.wallpaperSource.progress.validating": "Memeriksa kualitas gambar…",
+  "settings.wallpaperSource.progress.supplementing": "Mencari lagi gambar yang dapat digunakan…",
   "settings.nav.general": "Umum",
   "settings.nav.appearance": "Tampilan",
   "settings.nav.account": "Akun",

--- a/src/i18n/messages/it/settings-ui.ts
+++ b/src/i18n/messages/it/settings-ui.ts
@@ -1,5 +1,9 @@
 /** it messages — domain: settings-ui */
 export const itSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Annulla ricerca",
+  "settings.wallpaperSource.progress.preparing": "Preparazione della ricerca…",
+  "settings.wallpaperSource.progress.validating": "Verifica della qualità delle immagini…",
+  "settings.wallpaperSource.progress.supplementing": "Ricerca di altre immagini utilizzabili…",
   "settings.nav.general": "Generali",
   "settings.nav.appearance": "Aspetto",
   "settings.nav.account": "Account",

--- a/src/i18n/messages/ja/settings-ui.ts
+++ b/src/i18n/messages/ja/settings-ui.ts
@@ -1,5 +1,9 @@
 /** ja messages — domain: settings-ui */
 export const jaSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "検索をキャンセル",
+  "settings.wallpaperSource.progress.preparing": "検索を準備中…",
+  "settings.wallpaperSource.progress.validating": "画像品質を確認中…",
+  "settings.wallpaperSource.progress.supplementing": "利用可能な画像を追加検索中…",
   "settings.nav.general": "一般",
   "settings.nav.appearance": "外観",
   "settings.nav.account": "アカウント",

--- a/src/i18n/messages/ko/settings-ui.ts
+++ b/src/i18n/messages/ko/settings-ui.ts
@@ -1,5 +1,9 @@
 /** ko messages — domain: settings-ui */
 export const koSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "검색 취소",
+  "settings.wallpaperSource.progress.preparing": "검색 준비 중…",
+  "settings.wallpaperSource.progress.validating": "이미지 품질 확인 중…",
+  "settings.wallpaperSource.progress.supplementing": "사용 가능한 이미지를 추가로 검색 중…",
   "settings.nav.general": "일반",
   "settings.nav.appearance": "모양",
   "settings.nav.account": "계정",

--- a/src/i18n/messages/pt-BR/settings-ui.ts
+++ b/src/i18n/messages/pt-BR/settings-ui.ts
@@ -1,5 +1,9 @@
 /** pt-BR messages — domain: settings-ui */
 export const ptBRSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Cancelar busca",
+  "settings.wallpaperSource.progress.preparing": "Preparando a busca…",
+  "settings.wallpaperSource.progress.validating": "Verificando a qualidade das imagens…",
+  "settings.wallpaperSource.progress.supplementing": "Buscando mais imagens utilizáveis…",
   "settings.nav.general": "Geral",
   "settings.nav.appearance": "Aparência",
   "settings.nav.account": "Conta",

--- a/src/i18n/messages/ru/settings-ui.ts
+++ b/src/i18n/messages/ru/settings-ui.ts
@@ -1,5 +1,9 @@
 /** ru messages — domain: settings-ui */
 export const ruSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Отменить поиск",
+  "settings.wallpaperSource.progress.preparing": "Подготовка поиска…",
+  "settings.wallpaperSource.progress.validating": "Проверка качества изображений…",
+  "settings.wallpaperSource.progress.supplementing": "Поиск дополнительных подходящих изображений…",
   "settings.nav.general": "Основные",
   "settings.nav.appearance": "Оформление",
   "settings.nav.account": "Аккаунт",

--- a/src/i18n/messages/ta/settings-ui.ts
+++ b/src/i18n/messages/ta/settings-ui.ts
@@ -1,5 +1,9 @@
 /** ta messages — domain: settings-ui */
 export const taSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "தேடலை ரத்துசெய்",
+  "settings.wallpaperSource.progress.preparing": "தேடல் தயாராகிறது…",
+  "settings.wallpaperSource.progress.validating": "படத் தரம் சரிபார்க்கப்படுகிறது…",
+  "settings.wallpaperSource.progress.supplementing": "மேலும் பயன்படுத்தக்கூடிய படங்கள் தேடப்படுகின்றன…",
   "settings.nav.general": "பொது",
   "settings.nav.appearance": "தோற்றம்",
   "settings.nav.account": "கணக்கு",

--- a/src/i18n/messages/uk/settings-ui.ts
+++ b/src/i18n/messages/uk/settings-ui.ts
@@ -1,5 +1,9 @@
 /** uk messages — domain: settings-ui */
 export const ukSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "Скасувати пошук",
+  "settings.wallpaperSource.progress.preparing": "Підготовка пошуку…",
+  "settings.wallpaperSource.progress.validating": "Перевірка якості зображень…",
+  "settings.wallpaperSource.progress.supplementing": "Пошук додаткових придатних зображень…",
   "settings.nav.general": "Загальні",
   "settings.nav.appearance": "Оформлення",
   "settings.nav.account": "Обліковий запис",

--- a/src/i18n/messages/zh-TW/settings-ui.ts
+++ b/src/i18n/messages/zh-TW/settings-ui.ts
@@ -1,5 +1,9 @@
 /** Traditional Chinese messages — domain: settings-ui */
 export const zhTWSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "取消搜尋",
+  "settings.wallpaperSource.progress.preparing": "正在準備搜尋…",
+  "settings.wallpaperSource.progress.validating": "正在檢查圖片品質…",
+  "settings.wallpaperSource.progress.supplementing": "可用圖片較少，正在補充搜尋…",
   "settings.nav.general": "一般",
   "settings.nav.appearance": "外觀",
   "settings.nav.account": "帳戶",

--- a/src/i18n/messages/zh/settings-ui.ts
+++ b/src/i18n/messages/zh/settings-ui.ts
@@ -1,5 +1,9 @@
 /** Simplified Chinese messages — domain: settings-ui */
 export const zhSettingsUi = {
+  "settings.wallpaperSource.cancelSearch": "取消搜索",
+  "settings.wallpaperSource.progress.preparing": "正在准备搜索…",
+  "settings.wallpaperSource.progress.validating": "正在检查图片质量…",
+  "settings.wallpaperSource.progress.supplementing": "有效图片较少，正在补充搜索…",
   "settings.nav.general": "常规",
   "settings.nav.appearance": "外观",
   "settings.nav.account": "账户",

--- a/src/lib/api/wallpaper.ts
+++ b/src/lib/api/wallpaper.ts
@@ -2,6 +2,7 @@
 
 import {
   invoke,
+  listen,
 } from "./host";
 
 import type {
@@ -21,11 +22,25 @@ export type {
 export async function wallpaperXSearch(
   query: string,
   sort?: "top" | "latest",
+  requestId?: string,
 ): Promise<WallpaperSearchResult> {
   return invoke<WallpaperSearchResult>("wallpaper_x_search", {
     query,
     sort: sort ?? null,
+    requestId: requestId ?? null,
   });
+}
+
+export async function wallpaperXSearchCancel(requestId: string): Promise<boolean> {
+  return invoke<boolean>("wallpaper_x_search_cancel", { requestId });
+}
+
+export async function listenWallpaperXSearchProgress(
+  handler: (progress: import("../wallpaperXSearch").WallpaperXSearchProgress) => void,
+): Promise<() => void> {
+  return listen<import("../wallpaperXSearch").WallpaperXSearchProgress>(
+    "wallpaper://x-search-progress", handler,
+  );
 }
 
 export async function wallpaperFetchMedia(

--- a/src/lib/wallpaperXSearch.ts
+++ b/src/lib/wallpaperXSearch.ts
@@ -1,0 +1,23 @@
+export type WallpaperXSearchStage =
+  | "preparing"
+  | "searching_x"
+  | "validating"
+  | "supplementing"
+  | "done";
+
+export type WallpaperXSearchProgress = {
+  requestId: string;
+  stage: WallpaperXSearchStage;
+};
+
+export function createWallpaperXSearchRequestId(): string {
+  return crypto.randomUUID();
+}
+
+export function isWallpaperXSearchProgress(value: unknown): value is WallpaperXSearchProgress {
+  if (!value || typeof value !== "object") return false;
+  const event = value as Record<string, unknown>;
+  return typeof event.requestId === "string" && event.requestId.length > 0 &&
+    typeof event.stage === "string" &&
+    ["preparing", "searching_x", "validating", "supplementing", "done"].includes(event.stage);
+}


### PR DESCRIPTION
## Summary

X 壁纸搜索现在可以在执行期间取消，切换来源或关闭弹窗也会取消当前请求。Host 和前端共同按 requestId 隔离结果，避免旧请求在重新搜索、关闭后回写；界面显示准备、搜索、图片校验和补搜进度。

- Host 注册请求并校验 UUID，处理取消先于搜索到达的 IPC 顺序；预取消记录最多 64 项、30 秒过期，重复活动 ID 被拒绝，结束时释放记录。
- CLI 执行和图片探测响应取消，保留进程树清理和有界管道读取。
- 前端同步作废旧请求，不等待慢取消确认才发起下一次搜索；忽略旧成功、失败及进度事件。
- 15 种语言完整接入，仍使用现有来源、代理、CLI 参数和图库协议。此次没有加入缓存、Responses 设置或未实现的来源按钮。

已更新到上游 main `8a211eb0`，#1074/#1082/#1086 已由维护者合入并从差异移除。目前仅依赖 #1085 的图片质量主题；本次新增生命周期为 26 文件 +927/-25，当前相对 main 还包含 #1085，合入后继续去重。本任务未执行上游合并。

已检索开放/关闭的 wallpaper cancel Issue，没有直接对应项，不添加自动关闭引用。

## Type of change
- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Validation

前端 7,060 项、最终定向 5 项、Rust 1,623 项测试通过（另 1 项原有 ignored）；typecheck、lint、UI build、质量门禁、网站自测、依赖检查/审计及 Rust fmt/clippy 通过。Windows 全部测试 harness 按仓库 CI 嵌入 Common Controls manifest 执行。

更新主干后重新通过 typecheck、5 项定向前端回归、Rust fmt/clippy 和 1,651 项 Rust 测试（另 1 ignored）；测试 mock 同步迁移到上游 ImageViewerContext。更新后的远端 CI 仍需完成。

测试覆盖关闭/切换来源、迟到成功/错误、慢取消期间连续重搜、进度归属、监听器延迟注册清理；Host 覆盖预取消、容量/过期、UUID、注册清理、等待器唤醒和合成 CLI 真实执行阶段取消。未对本拆分分支执行真实账号搜索及手动桌面验收，不将单元测试等同线上搜索体验验证。

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
