### PR TITLE
feat(wallpaper): 增加 Responses 搜索灰度与可观测回退

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -19,8 +19,33 @@ and image validation; the existing output-drain/process-tree cleanup is retained
 The picker offers Cancel search, cancels on close/tab change/unmount, and ignores
 late results/errors/progress. Replacement searches invalidate the previous
 generation synchronously without waiting for a cancellation acknowledgement.
-There is no result cache or alternate route in this slice; account-sensitive
-caching belongs to the later routing implementation.
+There is no result cache in this slice; account-sensitive caching belongs to
+the later progressive-search implementation.
+
+## Responses preview
+
+The X picker exposes a persisted route setting. Missing or unknown settings use
+CLI. Only `responses_preview` enables the fixed Build compatibility endpoint
+`https://cli-chat-proxy.grok.com/v1/responses`, model `grok-4.6`, effort `low`, and
+the read-only `x_search` tool. Requests set `store: false`; no endpoint/model/tool
+or bearer is accepted from the frontend, and bearer redirects are disabled.
+
+`account/build_oauth.rs` reads canonical official credentials in the Host. It
+selects the current Build scope before the legacy scope, rejects issuer/client
+conflicts and expired credentials, and includes a private salted content tag in
+credential revisions. Tokens never cross IPC or enter logs. No refresh or login
+is attempted by wallpaper search.
+
+The client reads bounded response bodies and requires completed X tool-call
+evidence before accepting gallery JSON. The existing image quality pipeline
+validates the candidates. The first request permits two tool calls; an optional
+supplement permits one. This single-route slice is not the later parallel mode.
+
+Eligible failures fall back once to CLI. Rate limits, cancellation and tool-budget
+violations never trigger a second route. Three counted failures open a ten-minute
+circuit; credential content changes reset it. The picker reports the actual route,
+fallback reason and total duration. This compatibility endpoint may change; neither
+subscription availability nor account-risk guarantees are implied by preview mode.
 
 Hook and picker tests cover replacement, late responses, progress ownership and
 close/tab cancellation. Host tests cover UUIDs, pre-cancel expiry/capacity,

--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -1,6 +1,6 @@
 //! Official Grok Build account: profile, login/logout, billing snapshot, local usage.
 //!
-//! Profile is read from `~/.grok/auth.json` (tokens never leave this module).
+//! Profile is read from `~/.grok/auth.json` (tokens remain Host-only and never cross IPC).
 //! Billing is best-effort HTTP (same field shape as CLI `/usage` / billing extension).
 //! Heatmap + call logs are derived from local CLI session signals (and optional app journal).
 
@@ -21,6 +21,12 @@ use tracing::{info, warn};
 
 use crate::cli_probe;
 use crate::paths;
+
+mod build_oauth;
+pub(crate) use build_oauth::{
+    build_oauth_credential_revision, read_build_oauth_access_token, BuildOauthAccessToken,
+    BuildOauthCredentialRevision, BuildOauthTokenError,
+};
 
 /// Cancellation + optional stdin for a running `grok login`.
 ///

--- a/src-tauri/src/account/build_oauth.rs
+++ b/src-tauri/src/account/build_oauth.rs
@@ -1,0 +1,884 @@
+//! Host-only credentials for the fixed Grok Build Responses route.
+use super::{cli_default_auth_json_path, jwt_payload_unverified};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use rand::RngCore;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::{
+    fs,
+    path::Path,
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
+static BUILD_OAUTH_REVISION_SALT: OnceLock<[u8; 32]> = OnceLock::new();
+
+const XAI_OAUTH_ISSUER: &str = "https://auth.x.ai";
+const XAI_OAUTH_CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+const XAI_BUILD_AUTH_SCOPE: &str = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828";
+const LEGACY_XAI_AUTH_SCOPE: &str = "https://accounts.x.ai/sign-in";
+const BUILD_OAUTH_EXPIRY_SKEW_SECS: i64 = 60;
+const BUILD_OAUTH_FALLBACK_TTL_DAYS: i64 = 30;
+
+/// Non-secret identity of the canonical Grok Build credential file.
+///
+/// The wallpaper Responses router uses this to forget credential-specific
+/// failures after Grok Build refreshes or replaces `auth.json`. It intentionally
+/// contains neither the path nor any credential material.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct BuildOauthCredentialRevision {
+    file_len: u64,
+    modified_ms: Option<u128>,
+    content_tag: [u8; 32],
+}
+
+impl BuildOauthCredentialRevision {
+    #[cfg(test)]
+    pub(crate) fn for_test(file_len: u64, modified_ms: Option<u128>, tag: u8) -> Self {
+        Self {
+            file_len,
+            modified_ms,
+            content_tag: [tag; 32],
+        }
+    }
+}
+
+impl std::fmt::Debug for BuildOauthCredentialRevision {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("BuildOauthCredentialRevision")
+            .field("file_len", &self.file_len)
+            .field("modified_ms", &self.modified_ms)
+            .field("content_tag", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Host-only Build OAuth access-token snapshot.
+///
+/// Deliberately does not implement `Debug` or `Serialize`: the token must never
+/// cross IPC, enter diagnostics, or be formatted into an error/log message.
+pub(crate) struct BuildOauthAccessToken {
+    token: String,
+    pub(crate) revision: BuildOauthCredentialRevision,
+}
+
+impl BuildOauthAccessToken {
+    pub(crate) fn expose_to_build_proxy(&self) -> &str {
+        &self.token
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BuildOauthTokenError {
+    Unavailable,
+    Expired,
+}
+
+impl BuildOauthTokenError {
+    pub(crate) fn code(self) -> &'static str {
+        match self {
+            Self::Unavailable => "oauth_unavailable",
+            Self::Expired => "oauth_expired",
+        }
+    }
+}
+
+/// Read the canonical Grok Build OAuth access token for Host-only side routes.
+///
+/// This intentionally ignores process `GROK_HOME`: a custom provider or an
+/// independent agent home must never redirect the official wallpaper side
+/// route to different credentials. Tokens expiring within 60 seconds are
+/// rejected so a long-running search does not start with a stale credential.
+pub(crate) fn read_build_oauth_access_token() -> Result<BuildOauthAccessToken, BuildOauthTokenError>
+{
+    read_build_oauth_access_token_from_path_at(&cli_default_auth_json_path(), Utc::now())
+}
+
+/// Current non-secret revision of canonical Grok Build credentials.
+pub(crate) fn build_oauth_credential_revision() -> Option<BuildOauthCredentialRevision> {
+    build_oauth_credential_revision_from_path(&cli_default_auth_json_path())
+}
+
+fn build_oauth_credential_revision_from_path(path: &Path) -> Option<BuildOauthCredentialRevision> {
+    let raw = fs::read(path).ok()?;
+    build_oauth_credential_revision_from_bytes(path, &raw)
+}
+
+fn build_oauth_credential_revision_from_bytes(
+    path: &Path,
+    raw: &[u8],
+) -> Option<BuildOauthCredentialRevision> {
+    let metadata = fs::metadata(path).ok()?;
+    let salt = BUILD_OAUTH_REVISION_SALT.get_or_init(|| {
+        let mut salt = [0_u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut salt);
+        salt
+    });
+    let mut digest = Sha256::new();
+    digest.update(salt);
+    digest.update(raw);
+    Some(BuildOauthCredentialRevision {
+        file_len: metadata.len(),
+        modified_ms: metadata.modified().ok().and_then(system_time_millis),
+        content_tag: digest.finalize().into(),
+    })
+}
+
+fn read_build_oauth_access_token_from_path_at(
+    path: &Path,
+    now: DateTime<Utc>,
+) -> Result<BuildOauthAccessToken, BuildOauthTokenError> {
+    let raw = fs::read_to_string(path).map_err(|_| BuildOauthTokenError::Unavailable)?;
+    let value: Value = serde_json::from_str(&raw).map_err(|_| BuildOauthTokenError::Unavailable)?;
+    let token = select_build_oauth_access_token(&value, &now)?.to_string();
+    let revision = build_oauth_credential_revision_from_bytes(path, raw.as_bytes())
+        .ok_or(BuildOauthTokenError::Unavailable)?;
+
+    Ok(BuildOauthAccessToken { token, revision })
+}
+
+fn system_time_millis(value: SystemTime) -> Option<u128> {
+    value.duration_since(UNIX_EPOCH).ok().map(|d| d.as_millis())
+}
+
+fn access_token_from_auth_entry(entry: &Value) -> Option<&str> {
+    entry
+        .get("key")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            entry
+                .get("access_token")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+        })
+}
+
+struct BuildOauthTokenCandidate<'a> {
+    token: &'a str,
+}
+
+enum BuildOauthCandidateVerdict<'a> {
+    Ignore,
+    Expired,
+    Valid(BuildOauthTokenCandidate<'a>),
+}
+
+/// Select only a production xAI credential suitable for the fixed Build proxy.
+///
+/// Match Grok Build's current-scope then legacy-scope lookup order. Unverified
+/// JWT claims are used only to reject an explicit issuer, audience, or expiry
+/// conflict before any bearer is sent.
+fn select_build_oauth_access_token<'a>(
+    value: &'a Value,
+    now: &DateTime<Utc>,
+) -> Result<&'a str, BuildOauthTokenError> {
+    let entries = value.as_object().ok_or(BuildOauthTokenError::Unavailable)?;
+    let mut saw_expired_xai_token = false;
+
+    for (scope, legacy) in [(XAI_BUILD_AUTH_SCOPE, false), (LEGACY_XAI_AUTH_SCOPE, true)] {
+        let Some(entry) = entries.get(scope) else {
+            continue;
+        };
+        match classify_build_oauth_candidate(entry, legacy, now) {
+            BuildOauthCandidateVerdict::Ignore => {}
+            BuildOauthCandidateVerdict::Expired => saw_expired_xai_token = true,
+            BuildOauthCandidateVerdict::Valid(candidate) => return Ok(candidate.token),
+        }
+    }
+
+    if saw_expired_xai_token {
+        Err(BuildOauthTokenError::Expired)
+    } else {
+        Err(BuildOauthTokenError::Unavailable)
+    }
+}
+
+fn classify_build_oauth_candidate<'a>(
+    entry: &'a Value,
+    legacy: bool,
+    now: &DateTime<Utc>,
+) -> BuildOauthCandidateVerdict<'a> {
+    let Some(token) = access_token_from_auth_entry(entry) else {
+        return BuildOauthCandidateVerdict::Ignore;
+    };
+
+    if !entry
+        .get("auth_mode")
+        .and_then(Value::as_str)
+        .is_some_and(|mode| matches!(mode, "oidc" | "external"))
+    {
+        return BuildOauthCandidateVerdict::Ignore;
+    }
+
+    match entry.get("oidc_issuer") {
+        Some(Value::String(issuer))
+            if if legacy {
+                is_xai_issuer(issuer)
+            } else {
+                is_current_xai_issuer(issuer)
+            } => {}
+        Some(_) => return BuildOauthCandidateVerdict::Ignore,
+        None => {}
+    }
+
+    match entry.get("oidc_client_id") {
+        Some(Value::String(client_id)) if client_id.trim() == XAI_OAUTH_CLIENT_ID => {}
+        Some(_) => return BuildOauthCandidateVerdict::Ignore,
+        None => {}
+    }
+
+    let stored_expiry = match entry.get("expires_at") {
+        Some(Value::String(value)) => match DateTime::parse_from_rfc3339(value) {
+            Ok(value) => Some(value.with_timezone(&Utc)),
+            Err(_) => return BuildOauthCandidateVerdict::Expired,
+        },
+        Some(_) => return BuildOauthCandidateVerdict::Expired,
+        None => None,
+    };
+    let jwt_expiry = match build_oauth_jwt_expiry(token, legacy) {
+        Ok(value) => value,
+        Err(()) => return BuildOauthCandidateVerdict::Ignore,
+    };
+    let fallback_expiry = if stored_expiry.is_none() && jwt_expiry.is_none() {
+        match entry.get("create_time").and_then(Value::as_str) {
+            Some(value) => DateTime::parse_from_rfc3339(value)
+                .ok()
+                .map(|value| value.with_timezone(&Utc))
+                .and_then(|value| {
+                    value.checked_add_signed(ChronoDuration::days(BUILD_OAUTH_FALLBACK_TTL_DAYS))
+                }),
+            None => None,
+        }
+    } else {
+        None
+    };
+    let Some(expires_at) = earliest_expiry(stored_expiry, jwt_expiry).or(fallback_expiry) else {
+        return BuildOauthCandidateVerdict::Expired;
+    };
+    if expires_at <= *now + ChronoDuration::seconds(BUILD_OAUTH_EXPIRY_SKEW_SECS) {
+        return BuildOauthCandidateVerdict::Expired;
+    }
+
+    BuildOauthCandidateVerdict::Valid(BuildOauthTokenCandidate { token })
+}
+
+fn earliest_expiry(
+    left: Option<DateTime<Utc>>,
+    right: Option<DateTime<Utc>>,
+) -> Option<DateTime<Utc>> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+fn is_current_xai_issuer(value: &str) -> bool {
+    value
+        .trim()
+        .trim_end_matches('/')
+        .eq_ignore_ascii_case(XAI_OAUTH_ISSUER)
+}
+
+fn is_xai_issuer(value: &str) -> bool {
+    let value = value.trim().trim_end_matches('/');
+    is_current_xai_issuer(value)
+        || value.eq_ignore_ascii_case("https://accounts.x.ai")
+        || value.eq_ignore_ascii_case(LEGACY_XAI_AUTH_SCOPE)
+}
+
+fn build_oauth_jwt_expiry(token: &str, legacy: bool) -> Result<Option<DateTime<Utc>>, ()> {
+    let Some(payload) = jwt_payload_unverified(token) else {
+        return Ok(None);
+    };
+
+    if let Some(issuer) = payload.get("iss") {
+        let Some(issuer) = issuer.as_str() else {
+            return Err(());
+        };
+        let issuer_matches = if legacy {
+            is_xai_issuer(issuer)
+        } else {
+            is_current_xai_issuer(issuer)
+        };
+        if !issuer_matches {
+            return Err(());
+        }
+    }
+    if let Some(audience) = payload.get("aud") {
+        if !build_oauth_audience_matches(audience) {
+            return Err(());
+        }
+    }
+
+    match payload.get("exp") {
+        Some(value) => {
+            let seconds = value
+                .as_i64()
+                .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+                .ok_or(())?;
+            DateTime::from_timestamp(seconds, 0).map(Some).ok_or(())
+        }
+        None => Ok(None),
+    }
+}
+
+fn build_oauth_audience_matches(audience: &Value) -> bool {
+    match audience {
+        Value::String(value) => value == XAI_OAUTH_CLIENT_ID,
+        Value::Array(values) => values.iter().any(|value| {
+            value
+                .as_str()
+                .is_some_and(|value| value == XAI_OAUTH_CLIENT_ID)
+        }),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    fn fake_jwt(payload: Value) -> String {
+        use base64::Engine;
+
+        let encoder = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let header = encoder.encode(r#"{"alg":"RS256","typ":"JWT"}"#);
+        let payload = encoder.encode(serde_json::to_vec(&payload).expect("serialize JWT payload"));
+        format!("{header}.{payload}.test-signature")
+    }
+
+    fn temp_auth_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "grok-app-build-oauth-{label}-{}-{}.json",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ))
+    }
+    fn fixed_oauth_now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-08-28T00:00:00Z")
+            .expect("fixed timestamp")
+            .with_timezone(&Utc)
+    }
+
+    fn expect_build_oauth_error(
+        result: Result<BuildOauthAccessToken, BuildOauthTokenError>,
+    ) -> BuildOauthTokenError {
+        match result {
+            Ok(_) => panic!("expected Build OAuth token read to fail"),
+            Err(error) => error,
+        }
+    }
+
+    fn build_oauth_entries(entries: &[(&str, Value)]) -> Value {
+        Value::Object(
+            entries
+                .iter()
+                .map(|(scope, entry)| ((*scope).to_string(), entry.clone()))
+                .collect(),
+        )
+    }
+
+    fn read_build_oauth_fixture(
+        label: &str,
+        value: &Value,
+    ) -> Result<BuildOauthAccessToken, BuildOauthTokenError> {
+        let path = temp_auth_path(label);
+        fs::write(&path, value.to_string()).expect("write auth fixture");
+        let result = read_build_oauth_access_token_from_path_at(&path, fixed_oauth_now());
+        fs::remove_file(path).expect("remove auth fixture");
+        result
+    }
+
+    #[test]
+    fn build_oauth_current_scope_wins_over_fresher_legacy_entry() {
+        let value = build_oauth_entries(&[
+            (
+                XAI_BUILD_AUTH_SCOPE,
+                serde_json::json!({
+                    "key": "current-token",
+                    "auth_mode": "oidc",
+                    "expires_at": "2026-08-28T01:00:00Z"
+                }),
+            ),
+            (
+                LEGACY_XAI_AUTH_SCOPE,
+                serde_json::json!({
+                    "key": "legacy-token",
+                    "auth_mode": "external",
+                    "expires_at": "2026-08-28T02:00:00Z"
+                }),
+            ),
+        ]);
+
+        let snapshot = read_build_oauth_fixture("current-before-legacy", &value)
+            .expect("current Build credential");
+        assert_eq!(snapshot.expose_to_build_proxy(), "current-token");
+        assert!(snapshot.revision.file_len > 0);
+    }
+
+    #[test]
+    fn build_oauth_ignores_foreign_entries_and_other_xai_client_scopes() {
+        let value = build_oauth_entries(&[
+            (
+                "tokens",
+                serde_json::json!({
+                    "access_token": "foreign-top-level-token",
+                    "auth_mode": "oidc",
+                    "expires_at": "2026-08-29T00:00:00Z"
+                }),
+            ),
+            (
+                "https://auth.openai.com::openai-client",
+                serde_json::json!({
+                    "access_token": "foreign-issuer-token",
+                    "auth_mode": "oidc",
+                    "oidc_issuer": "https://auth.openai.com",
+                    "expires_at": "2026-08-29T00:00:00Z"
+                }),
+            ),
+            (
+                "https://auth.x.ai::other-client",
+                serde_json::json!({
+                    "key": "other-xai-client-token",
+                    "auth_mode": "oidc",
+                    "oidc_issuer": XAI_OAUTH_ISSUER,
+                    "expires_at": "2026-08-29T00:00:00Z"
+                }),
+            ),
+        ]);
+
+        assert_eq!(
+            expect_build_oauth_error(read_build_oauth_fixture("ignored-scopes", &value)),
+            BuildOauthTokenError::Unavailable
+        );
+    }
+
+    #[test]
+    fn build_oauth_falls_back_to_legacy_when_current_entry_is_unusable() {
+        let current_entries = [
+            (
+                "expired-current",
+                serde_json::json!({
+                    "key": "expired-current-token",
+                    "auth_mode": "oidc",
+                    "expires_at": "2026-08-27T23:59:59Z"
+                }),
+            ),
+            (
+                "invalid-current",
+                serde_json::json!({
+                    "key": "invalid-current-token",
+                    "auth_mode": "oidc",
+                    "oidc_issuer": LEGACY_XAI_AUTH_SCOPE,
+                    "expires_at": "2026-08-28T02:00:00Z"
+                }),
+            ),
+        ];
+
+        for (label, current_entry) in current_entries {
+            let value = build_oauth_entries(&[
+                (XAI_BUILD_AUTH_SCOPE, current_entry),
+                (
+                    LEGACY_XAI_AUTH_SCOPE,
+                    serde_json::json!({
+                        "key": "valid-legacy-token",
+                        "auth_mode": "external",
+                        "expires_at": "2026-08-28T02:00:00Z"
+                    }),
+                ),
+            ]);
+            let snapshot =
+                read_build_oauth_fixture(label, &value).expect("valid legacy Build credential");
+            assert_eq!(snapshot.expose_to_build_proxy(), "valid-legacy-token");
+        }
+    }
+
+    #[test]
+    fn build_oauth_rejects_entry_issuer_and_client_id_conflicts() {
+        let conflicting_entries = [
+            (
+                "entry-issuer-conflict",
+                serde_json::json!({
+                    "key": "issuer-conflict-token",
+                    "auth_mode": "oidc",
+                    "oidc_issuer": LEGACY_XAI_AUTH_SCOPE,
+                    "expires_at": "2026-08-28T02:00:00Z"
+                }),
+            ),
+            (
+                "entry-client-conflict",
+                serde_json::json!({
+                    "key": "client-conflict-token",
+                    "auth_mode": "oidc",
+                    "oidc_issuer": XAI_OAUTH_ISSUER,
+                    "oidc_client_id": "another-client",
+                    "expires_at": "2026-08-28T02:00:00Z"
+                }),
+            ),
+        ];
+
+        for (label, entry) in conflicting_entries {
+            let value = build_oauth_entries(&[(XAI_BUILD_AUTH_SCOPE, entry)]);
+            assert_eq!(
+                expect_build_oauth_error(read_build_oauth_fixture(label, &value)),
+                BuildOauthTokenError::Unavailable
+            );
+        }
+    }
+
+    #[test]
+    fn build_oauth_rejects_conflicting_jwt_issuer_and_audience() {
+        let cases = [
+            (
+                "foreign-jwt-issuer",
+                fake_jwt(serde_json::json!({
+                    "iss": "https://auth.openai.com",
+                    "aud": XAI_OAUTH_CLIENT_ID,
+                    "exp": fixed_oauth_now().timestamp() + 3600
+                })),
+            ),
+            (
+                "legacy-root-jwt-issuer-on-current-scope",
+                fake_jwt(serde_json::json!({
+                    "iss": "https://accounts.x.ai",
+                    "aud": XAI_OAUTH_CLIENT_ID,
+                    "exp": fixed_oauth_now().timestamp() + 3600
+                })),
+            ),
+            (
+                "legacy-sign-in-jwt-issuer-on-current-scope",
+                fake_jwt(serde_json::json!({
+                    "iss": LEGACY_XAI_AUTH_SCOPE,
+                    "aud": XAI_OAUTH_CLIENT_ID,
+                    "exp": fixed_oauth_now().timestamp() + 3600
+                })),
+            ),
+            (
+                "foreign-jwt-audience",
+                fake_jwt(serde_json::json!({
+                    "iss": XAI_OAUTH_ISSUER,
+                    "aud": "https://api.openai.com/v1",
+                    "exp": fixed_oauth_now().timestamp() + 3600
+                })),
+            ),
+        ];
+
+        for (label, token) in cases {
+            let value = build_oauth_entries(&[(
+                XAI_BUILD_AUTH_SCOPE,
+                serde_json::json!({
+                        "key": token,
+                        "auth_mode": "oidc",
+                        "oidc_issuer": XAI_OAUTH_ISSUER,
+                        "oidc_client_id": XAI_OAUTH_CLIENT_ID,
+                        "expires_at": "2026-08-28T02:00:00Z"
+                }),
+            )]);
+
+            assert_eq!(
+                expect_build_oauth_error(read_build_oauth_fixture(label, &value)),
+                BuildOauthTokenError::Unavailable
+            );
+        }
+    }
+
+    #[test]
+    fn build_oauth_accepts_exact_build_client_audience_as_string_or_array() {
+        for (label, audience) in [
+            (
+                "string-client-audience",
+                serde_json::json!(XAI_OAUTH_CLIENT_ID),
+            ),
+            (
+                "array-client-audience",
+                serde_json::json!(["other", XAI_OAUTH_CLIENT_ID]),
+            ),
+        ] {
+            let token = fake_jwt(serde_json::json!({
+                "iss": XAI_OAUTH_ISSUER,
+                "aud": audience,
+                "exp": fixed_oauth_now().timestamp() + 3600
+            }));
+            let value = build_oauth_entries(&[(
+                XAI_BUILD_AUTH_SCOPE,
+                serde_json::json!({
+                        "key": token,
+                        "auth_mode": "oidc",
+                        "oidc_issuer": XAI_OAUTH_ISSUER,
+                        "oidc_client_id": XAI_OAUTH_CLIENT_ID
+                }),
+            )]);
+
+            read_build_oauth_fixture(label, &value).expect("exact Build JWT audience");
+        }
+    }
+
+    #[test]
+    fn build_oauth_rejects_alias_and_service_url_jwt_audiences() {
+        for (label, audience) in [
+            ("api-grok-audience", "api://grok"),
+            (
+                "grok-service-url-audience",
+                "https://cli-chat-proxy.grok.com/v1",
+            ),
+            ("xai-service-url-audience", "https://api.x.ai/v1"),
+        ] {
+            let token = fake_jwt(serde_json::json!({
+                "iss": XAI_OAUTH_ISSUER,
+                "aud": audience,
+                "exp": fixed_oauth_now().timestamp() + 3600
+            }));
+            let value = build_oauth_entries(&[(
+                XAI_BUILD_AUTH_SCOPE,
+                serde_json::json!({
+                    "key": token,
+                    "auth_mode": "oidc",
+                    "expires_at": "2026-08-28T02:00:00Z"
+                }),
+            )]);
+
+            assert_eq!(
+                expect_build_oauth_error(read_build_oauth_fixture(label, &value)),
+                BuildOauthTokenError::Unavailable
+            );
+        }
+    }
+
+    #[test]
+    fn build_oauth_legacy_scope_accepts_oidc_and_external_modes() {
+        for (label, auth_mode, issuer) in [
+            ("legacy-oidc", "oidc", LEGACY_XAI_AUTH_SCOPE),
+            ("legacy-external", "external", "https://accounts.x.ai"),
+            ("legacy-current-issuer", "oidc", XAI_OAUTH_ISSUER),
+        ] {
+            let token = fake_jwt(serde_json::json!({
+                "iss": issuer,
+                "aud": XAI_OAUTH_CLIENT_ID,
+                "exp": fixed_oauth_now().timestamp() + 3600
+            }));
+            let value = build_oauth_entries(&[(
+                LEGACY_XAI_AUTH_SCOPE,
+                serde_json::json!({
+                    "key": token,
+                    "auth_mode": auth_mode,
+                    "oidc_issuer": issuer,
+                    "oidc_client_id": XAI_OAUTH_CLIENT_ID
+                }),
+            )]);
+
+            read_build_oauth_fixture(label, &value).expect("supported legacy auth mode");
+        }
+    }
+
+    #[test]
+    fn build_oauth_legacy_scope_rejects_non_oauth_and_missing_modes() {
+        for (label, auth_mode) in [
+            ("legacy-web-login", Some("web_login")),
+            ("legacy-grok-alias", Some("grok")),
+            ("legacy-api-key", Some("api_key")),
+            ("legacy-missing-mode", None),
+        ] {
+            let mut entry = serde_json::json!({
+                "key": "legacy-token",
+                "expires_at": "2026-08-28T02:00:00Z"
+            });
+            if let Some(auth_mode) = auth_mode {
+                entry["auth_mode"] = Value::String(auth_mode.to_string());
+            }
+            let value = build_oauth_entries(&[(LEGACY_XAI_AUTH_SCOPE, entry)]);
+
+            assert_eq!(
+                expect_build_oauth_error(read_build_oauth_fixture(label, &value)),
+                BuildOauthTokenError::Unavailable
+            );
+        }
+    }
+
+    #[test]
+    fn build_oauth_uses_the_earliest_stored_or_jwt_expiry() {
+        let cases = [
+            (
+                "jwt-expires-first",
+                fixed_oauth_now().timestamp() + BUILD_OAUTH_EXPIRY_SKEW_SECS,
+                "2026-08-28T02:00:00Z",
+            ),
+            (
+                "stored-expiry-first",
+                fixed_oauth_now().timestamp() + 3600,
+                "2026-08-28T00:01:00Z",
+            ),
+        ];
+
+        for (label, jwt_expiry, stored_expiry) in cases {
+            let token = fake_jwt(serde_json::json!({
+                "iss": XAI_OAUTH_ISSUER,
+                "aud": XAI_OAUTH_CLIENT_ID,
+                "exp": jwt_expiry
+            }));
+            let value = build_oauth_entries(&[(
+                XAI_BUILD_AUTH_SCOPE,
+                serde_json::json!({
+                    "key": token,
+                    "auth_mode": "oidc",
+                    "expires_at": stored_expiry
+                }),
+            )]);
+
+            assert_eq!(
+                expect_build_oauth_error(read_build_oauth_fixture(label, &value)),
+                BuildOauthTokenError::Expired
+            );
+        }
+    }
+
+    #[test]
+    fn build_oauth_falls_back_to_create_time_plus_thirty_days() {
+        let now = fixed_oauth_now();
+        let valid_create_time = now - ChronoDuration::days(BUILD_OAUTH_FALLBACK_TTL_DAYS)
+            + ChronoDuration::seconds(BUILD_OAUTH_EXPIRY_SKEW_SECS + 1);
+        let valid = build_oauth_entries(&[(
+            XAI_BUILD_AUTH_SCOPE,
+            serde_json::json!({
+                "key": "valid-fallback-token",
+                "auth_mode": "oidc",
+                "create_time": valid_create_time.to_rfc3339()
+            }),
+        )]);
+        let snapshot = read_build_oauth_fixture("valid-create-time-fallback", &valid)
+            .expect("credential within fallback lifetime");
+        assert_eq!(snapshot.expose_to_build_proxy(), "valid-fallback-token");
+
+        let boundary_create_time = now - ChronoDuration::days(BUILD_OAUTH_FALLBACK_TTL_DAYS)
+            + ChronoDuration::seconds(BUILD_OAUTH_EXPIRY_SKEW_SECS);
+        let expired_create_time = now - ChronoDuration::days(BUILD_OAUTH_FALLBACK_TTL_DAYS);
+        for (label, create_time) in [
+            (
+                "boundary-create-time-fallback",
+                Some(boundary_create_time.to_rfc3339()),
+            ),
+            (
+                "expired-create-time-fallback",
+                Some(expired_create_time.to_rfc3339()),
+            ),
+            (
+                "invalid-create-time-fallback",
+                Some("not-a-date".to_string()),
+            ),
+            ("missing-create-time-fallback", None),
+        ] {
+            let mut entry = serde_json::json!({
+                "key": "expired-fallback-token",
+                "auth_mode": "oidc"
+            });
+            if let Some(create_time) = create_time {
+                entry["create_time"] = Value::String(create_time);
+            }
+            let value = build_oauth_entries(&[(XAI_BUILD_AUTH_SCOPE, entry)]);
+
+            assert_eq!(
+                expect_build_oauth_error(read_build_oauth_fixture(label, &value)),
+                BuildOauthTokenError::Expired
+            );
+        }
+    }
+
+    #[test]
+    fn build_oauth_revision_distinguishes_same_metadata_different_content() {
+        let path = temp_auth_path("content-revision");
+        fs::write(&path, b"same-size-a").expect("write auth fixture");
+
+        // Use the same unchanged file metadata for both revisions. Only the
+        // in-memory bytes differ, modeling a same-size/same-mtime replacement.
+        let first = build_oauth_credential_revision_from_bytes(&path, b"same-size-a")
+            .expect("first revision");
+        let second = build_oauth_credential_revision_from_bytes(&path, b"same-size-b")
+            .expect("second revision");
+
+        assert_eq!(first.file_len, second.file_len);
+        assert_eq!(first.modified_ms, second.modified_ms);
+        assert_ne!(first, second);
+        let debug = format!("{first:?}");
+        assert!(debug.contains("[redacted]"));
+        assert!(!debug.contains(&hex::encode(first.content_tag)));
+
+        fs::remove_file(path).expect("remove auth fixture");
+    }
+
+    #[test]
+    fn build_oauth_rejects_missing_refresh_only_and_malformed_files() {
+        let missing = temp_auth_path("missing");
+        assert_eq!(
+            expect_build_oauth_error(read_build_oauth_access_token_from_path_at(
+                &missing,
+                fixed_oauth_now(),
+            )),
+            BuildOauthTokenError::Unavailable
+        );
+
+        let refresh_only = temp_auth_path("refresh-only");
+        let refresh_only_value = build_oauth_entries(&[(
+            XAI_BUILD_AUTH_SCOPE,
+            serde_json::json!({
+                "refresh_token": "refresh-only",
+                "auth_mode": "oidc"
+            }),
+        )]);
+        fs::write(&refresh_only, refresh_only_value.to_string())
+            .expect("write refresh-only fixture");
+        assert_eq!(
+            expect_build_oauth_error(read_build_oauth_access_token_from_path_at(
+                &refresh_only,
+                fixed_oauth_now(),
+            )),
+            BuildOauthTokenError::Unavailable
+        );
+        fs::remove_file(refresh_only).expect("remove refresh-only fixture");
+
+        let malformed = temp_auth_path("malformed");
+        fs::write(&malformed, "not-json").expect("write malformed fixture");
+        assert_eq!(
+            expect_build_oauth_error(read_build_oauth_access_token_from_path_at(
+                &malformed,
+                fixed_oauth_now(),
+            )),
+            BuildOauthTokenError::Unavailable
+        );
+        fs::remove_file(malformed).expect("remove malformed fixture");
+    }
+
+    #[test]
+    fn build_oauth_rejects_expired_near_expiry_and_invalid_expiry() {
+        for (label, expires_at) in [
+            ("expired", "2026-08-27T23:59:59Z"),
+            ("near-expiry", "2026-08-28T00:01:00Z"),
+            ("invalid-expiry", "not-a-date"),
+        ] {
+            let value = build_oauth_entries(&[(
+                XAI_BUILD_AUTH_SCOPE,
+                serde_json::json!({
+                    "access_token": "test-access-token",
+                    "auth_mode": "oidc",
+                    "expires_at": expires_at
+                }),
+            )]);
+            assert_eq!(
+                expect_build_oauth_error(read_build_oauth_fixture(label, &value)),
+                BuildOauthTokenError::Expired
+            );
+        }
+    }
+
+    #[test]
+    fn build_oauth_error_codes_are_stable_and_secret_free() {
+        assert_eq!(
+            BuildOauthTokenError::Unavailable.code(),
+            "oauth_unavailable"
+        );
+        assert_eq!(BuildOauthTokenError::Expired.code(), "oauth_expired");
+    }
+}

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -17,6 +17,8 @@ pub async fn settings_set(
 ) -> Result<AppSettings, String> {
     let prev = store::load_settings();
     let mut settings = settings;
+    settings.wallpaper_x_search_mode =
+        store::normalize_wallpaper_x_search_mode(&settings.wallpaper_x_search_mode).into();
     // Normalize denylist / allowlist so spawn / equality see stable lists.
     settings.disallowed_tools =
         crate::acp_client::normalize_disallowed_tools(&settings.disallowed_tools);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -225,6 +225,7 @@ mod voice_stt;
 mod voice_tools;
 
 mod wallpaper_source;
+mod wallpaper_x_responses;
 mod wallpaper_x_search;
 
 mod window_min;

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -414,6 +414,8 @@ pub struct AppSettings {
     /// enough (soft-fail older builds).
     #[serde(default = "default_background_wait_policy")]
     pub background_wait_policy: String,
+    #[serde(default = "default_wallpaper_x_search_mode")]
+    pub wallpaper_x_search_mode: String,
     /// Seconds for `--background-wait-timeout` when policy is `timeout`.
     /// Clamped 1–3600; default 600 (CLI default when waiting).
     #[serde(default = "default_background_wait_timeout_sec")]
@@ -701,6 +703,20 @@ fn default_plan_enabled() -> bool {
     true
 }
 
+pub(crate) const WALLPAPER_X_SEARCH_MODE_RESPONSES_PREVIEW: &str = "responses_preview";
+
+pub(crate) fn normalize_wallpaper_x_search_mode(value: &str) -> &'static str {
+    if value == WALLPAPER_X_SEARCH_MODE_RESPONSES_PREVIEW {
+        WALLPAPER_X_SEARCH_MODE_RESPONSES_PREVIEW
+    } else {
+        "cli"
+    }
+}
+
+fn default_wallpaper_x_search_mode() -> String {
+    "cli".into()
+}
+
 fn default_background_wait_policy() -> String {
     "wait".into()
 }
@@ -828,6 +844,7 @@ impl Default for AppSettings {
             two_pass_compaction_enabled: false,
             max_agent_turns: None,
             background_wait_policy: default_background_wait_policy(),
+            wallpaper_x_search_mode: default_wallpaper_x_search_mode(),
             background_wait_timeout_sec: default_background_wait_timeout_sec(),
             include_partial_messages: false,
             disable_web_search: false,

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -89,6 +89,24 @@ pub struct WallpaperSearchResult {
     pub error_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<WallpaperSearchMeta>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WallpaperSearchMeta {
+    pub request_id: Option<String>,
+    pub requested_mode: String,
+    pub route_used: String,
+    pub fallback_reason: Option<String>,
+    pub duration_ms: u64,
+    pub cache_hit: bool,
+    pub search_calls: Option<u32>,
+    pub candidate_count: usize,
+    pub valid_count: usize,
+    pub model: Option<String>,
+    pub effort: Option<String>,
 }
 
 #[derive(Clone)]
@@ -144,6 +162,7 @@ pub(crate) enum WallpaperXSearchStage {
     SearchingX,
     Validating,
     Supplementing,
+    FallingBack,
     Done,
 }
 
@@ -1863,6 +1882,7 @@ fn x_search_round(
             items: vec![],
             error_code: Some("empty".into()),
             message: Some("empty query".into()),
+            meta: None,
         };
     }
     let cli = match require_cli_ready() {
@@ -1872,6 +1892,7 @@ fn x_search_round(
                 items: vec![],
                 error_code: Some(code),
                 message: None,
+                meta: None,
             };
         }
     };
@@ -1924,6 +1945,7 @@ fn x_search_round(
                 items: vec![],
                 error_code: Some(code),
                 message: None,
+                meta: None,
             };
         }
     };
@@ -1935,6 +1957,7 @@ fn x_search_round(
                 items: vec![],
                 error_code: Some("search_failed".into()),
                 message: Some("could not parse search JSON".into()),
+                meta: None,
             };
         }
     };
@@ -1952,6 +1975,7 @@ fn x_search_round(
             items: vec![],
             error_code: Some("empty".into()),
             message: Some("no images found".into()),
+            meta: None,
         };
     }
 
@@ -1959,6 +1983,7 @@ fn x_search_round(
         items,
         error_code: None,
         message: None,
+        meta: None,
     }
 }
 
@@ -2056,6 +2081,7 @@ fn cancelled_search_result() -> WallpaperSearchResult {
         items: Vec::new(),
         error_code: Some("cancelled".into()),
         message: None,
+        meta: None,
     }
 }
 
@@ -2097,6 +2123,7 @@ pub(crate) async fn x_search_cli_outcome(
                     items: vec![],
                     error_code: Some("search_failed".into()),
                     message: Some(format!("join: {e}")),
+                    meta: None,
                 },
                 candidate_count: 0,
                 valid_count: 0,
@@ -2185,6 +2212,7 @@ pub(crate) async fn x_search_cli_outcome(
                 items: vec![],
                 error_code: Some("empty".into()),
                 message: Some("no downloadable images".into()),
+                meta: None,
             },
             candidate_count,
             valid_count: 0,
@@ -2304,6 +2332,7 @@ pub fn imagine(prompt: &str, aspect_ratio: Option<&str>) -> WallpaperSearchResul
             items: vec![],
             error_code: Some("empty".into()),
             message: Some("empty prompt".into()),
+            meta: None,
         };
     }
     let cli = match require_cli_ready() {
@@ -2313,6 +2342,7 @@ pub fn imagine(prompt: &str, aspect_ratio: Option<&str>) -> WallpaperSearchResul
                 items: vec![],
                 error_code: Some(code),
                 message: None,
+                meta: None,
             };
         }
     };
@@ -2377,6 +2407,7 @@ Requirements:
                 items: vec![],
                 error_code: Some(code),
                 message: None,
+                meta: None,
             };
         }
     };
@@ -2391,12 +2422,14 @@ Requirements:
                     items: vec![],
                     error_code: Some("imagine_failed".into()),
                     message: Some("could not parse imagine result".into()),
+                    meta: None,
                 };
             }
             return WallpaperSearchResult {
                 items: scanned,
                 error_code: None,
                 message: None,
+                meta: None,
             };
         }
     };
@@ -2431,12 +2464,14 @@ Requirements:
                 items: vec![],
                 error_code: Some("empty".into()),
                 message: Some("no image produced".into()),
+                meta: None,
             };
         }
         return WallpaperSearchResult {
             items: scanned,
             error_code: None,
             message: None,
+            meta: None,
         };
     }
 
@@ -2444,6 +2479,7 @@ Requirements:
         items,
         error_code: None,
         message: None,
+        meta: None,
     }
 }
 

--- a/src-tauri/src/wallpaper_x_responses.rs
+++ b/src-tauri/src/wallpaper_x_responses.rs
@@ -1,0 +1,1049 @@
+//! Read-only wallpaper search through the Grok Build Responses compatibility
+//! endpoint. This module is Host-internal until the wallpaper search router
+//! explicitly opts into it.
+
+use std::error::Error as _;
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+use crate::account::{
+    self, BuildOauthAccessToken, BuildOauthCredentialRevision, BuildOauthTokenError,
+};
+use crate::proxy;
+use crate::wallpaper_source::{
+    filter_reachable_gallery_items_cancellable, merge_rank_x_gallery_items, parse_gallery_items,
+    x_gallery_needs_supplement, x_gallery_reference_ids, WallpaperGalleryItem,
+    WallpaperSearchCancellation, WallpaperXSearchRuntime, WallpaperXSearchStage,
+    X_SEARCH_FIRST_ROUND_CALLS, X_SEARCH_SUPPLEMENT_CALLS, X_SEARCH_TOTAL_CALLS,
+};
+
+pub(crate) const RESPONSES_ENDPOINT: &str = "https://cli-chat-proxy.grok.com/v1/responses";
+pub(crate) const RESPONSES_MODEL: &str = "grok-4.6";
+pub(crate) const RESPONSES_EFFORT: &str = "low";
+pub(crate) const RESPONSES_MAX_X_SEARCH_CALLS: u32 = X_SEARCH_TOTAL_CALLS;
+
+const RESPONSES_TIMEOUT: Duration = Duration::from_secs(90);
+const RESPONSES_MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ResponsesSearchErrorKind {
+    OauthUnavailable,
+    OauthExpired,
+    BadRequest,
+    Unauthorized,
+    RateLimited,
+    ServerError,
+    Timeout,
+    Tls,
+    Network,
+    Empty,
+    InvalidJson,
+    Protocol,
+    ToolNotCalled,
+    SearchBudgetExceeded,
+    Cancelled,
+}
+
+impl ResponsesSearchErrorKind {
+    pub(crate) fn code(self) -> &'static str {
+        match self {
+            Self::OauthUnavailable => "oauth_unavailable",
+            Self::OauthExpired => "oauth_expired",
+            Self::BadRequest => "responses_bad_request",
+            Self::Unauthorized => "responses_unauthorized",
+            Self::RateLimited => "responses_rate_limited",
+            Self::ServerError => "responses_server_error",
+            Self::Timeout => "responses_timeout",
+            Self::Tls => "responses_tls",
+            Self::Network => "responses_network",
+            Self::Empty => "responses_empty",
+            Self::InvalidJson => "responses_invalid_json",
+            Self::Protocol => "responses_protocol",
+            Self::ToolNotCalled => "responses_tool_not_called",
+            Self::SearchBudgetExceeded => "responses_search_budget_exceeded",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResponsesSearchError {
+    pub(crate) kind: ResponsesSearchErrorKind,
+    pub(crate) credential_revision: Option<BuildOauthCredentialRevision>,
+}
+
+impl ResponsesSearchError {
+    fn new(
+        kind: ResponsesSearchErrorKind,
+        credential_revision: Option<BuildOauthCredentialRevision>,
+    ) -> Self {
+        Self {
+            kind,
+            credential_revision,
+        }
+    }
+
+    pub(crate) fn code(&self) -> &'static str {
+        self.kind.code()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResponsesSearchSuccess {
+    pub(crate) items: Vec<WallpaperGalleryItem>,
+    pub(crate) candidate_count: usize,
+    pub(crate) valid_count: usize,
+    pub(crate) search_calls: u32,
+    pub(crate) model: &'static str,
+    pub(crate) effort: &'static str,
+    pub(crate) credential_revision: BuildOauthCredentialRevision,
+}
+
+/// Run the fixed, read-only Responses preview request.
+///
+/// No endpoint, model, tool, or credential is accepted from the frontend.
+pub(crate) async fn search(
+    query: &str,
+    sort: Option<&str>,
+    runtime: &WallpaperXSearchRuntime,
+) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
+    if runtime.is_cancelled() {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::Cancelled,
+            None,
+        ));
+    }
+    let auth = account::read_build_oauth_access_token().map_err(auth_error)?;
+    let mut first = search_with_auth(
+        query,
+        sort,
+        &auth,
+        RESPONSES_ENDPOINT,
+        RESPONSES_TIMEOUT,
+        SearchOptions {
+            max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
+            is_supplement: false,
+            seen_ids: &[],
+            cancellation: runtime.cancellation(),
+        },
+    )
+    .await?;
+    let mut candidate_count = first.candidate_count;
+    let mut search_calls = first.search_calls;
+    let seen_ids = x_gallery_reference_ids(&first.items);
+    runtime.report(WallpaperXSearchStage::Validating);
+    let mut items = filter_reachable_gallery_items_cancellable(
+        std::mem::take(&mut first.items),
+        Some(runtime.cancellation()),
+    )
+    .await;
+    if runtime.is_cancelled() {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::Cancelled,
+            Some(auth.revision.clone()),
+        ));
+    }
+
+    if x_gallery_needs_supplement(items.len()) {
+        runtime.report(WallpaperXSearchStage::Supplementing);
+        match search_with_auth(
+            query,
+            sort,
+            &auth,
+            RESPONSES_ENDPOINT,
+            RESPONSES_TIMEOUT,
+            SearchOptions {
+                max_search_calls: X_SEARCH_SUPPLEMENT_CALLS,
+                is_supplement: true,
+                seen_ids: &seen_ids,
+                cancellation: runtime.cancellation(),
+            },
+        )
+        .await
+        {
+            Ok(mut supplement) => {
+                search_calls = search_calls.saturating_add(supplement.search_calls);
+                if search_calls > RESPONSES_MAX_X_SEARCH_CALLS {
+                    return Err(ResponsesSearchError::new(
+                        ResponsesSearchErrorKind::SearchBudgetExceeded,
+                        Some(auth.revision.clone()),
+                    ));
+                }
+                candidate_count = candidate_count.saturating_add(supplement.candidate_count);
+                runtime.report(WallpaperXSearchStage::Validating);
+                let supplement_items = filter_reachable_gallery_items_cancellable(
+                    std::mem::take(&mut supplement.items),
+                    Some(runtime.cancellation()),
+                )
+                .await;
+                if runtime.is_cancelled() {
+                    return Err(ResponsesSearchError::new(
+                        ResponsesSearchErrorKind::Cancelled,
+                        Some(auth.revision.clone()),
+                    ));
+                }
+                items.extend(supplement_items);
+                items = merge_rank_x_gallery_items(items);
+            }
+            Err(error)
+                if error.kind == ResponsesSearchErrorKind::Cancelled
+                    || items.is_empty()
+                    || error.kind == ResponsesSearchErrorKind::SearchBudgetExceeded =>
+            {
+                return Err(error);
+            }
+            Err(_) => {
+                // A useful partial first round is better than discarding honest
+                // results because the optional supplement failed.
+            }
+        }
+    }
+
+    if items.is_empty() {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::Empty,
+            Some(auth.revision.clone()),
+        ));
+    }
+
+    Ok(ResponsesSearchSuccess {
+        valid_count: items.len(),
+        items,
+        candidate_count,
+        search_calls,
+        model: RESPONSES_MODEL,
+        effort: RESPONSES_EFFORT,
+        credential_revision: auth.revision.clone(),
+    })
+}
+
+fn auth_error(error: BuildOauthTokenError) -> ResponsesSearchError {
+    let kind = match error {
+        BuildOauthTokenError::Unavailable => ResponsesSearchErrorKind::OauthUnavailable,
+        BuildOauthTokenError::Expired => ResponsesSearchErrorKind::OauthExpired,
+    };
+    ResponsesSearchError::new(kind, None)
+}
+
+struct SearchOptions<'a> {
+    max_search_calls: u32,
+    is_supplement: bool,
+    seen_ids: &'a [String],
+    cancellation: &'a WallpaperSearchCancellation,
+}
+
+async fn search_with_auth(
+    query: &str,
+    sort: Option<&str>,
+    auth: &BuildOauthAccessToken,
+    endpoint: &str,
+    timeout: Duration,
+    options: SearchOptions<'_>,
+) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
+    search_with_credentials(
+        query,
+        sort,
+        Ok((auth.expose_to_build_proxy(), auth.revision.clone())),
+        endpoint,
+        timeout,
+        options,
+    )
+    .await
+}
+
+async fn search_with_credentials(
+    query: &str,
+    sort: Option<&str>,
+    credentials: Result<(&str, BuildOauthCredentialRevision), BuildOauthTokenError>,
+    endpoint: &str,
+    timeout: Duration,
+    options: SearchOptions<'_>,
+) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
+    let SearchOptions {
+        max_search_calls,
+        is_supplement,
+        seen_ids,
+        cancellation,
+    } = options;
+    let (token, credential_revision) = credentials.map_err(auth_error)?;
+    let error_revision = || Some(credential_revision.clone());
+
+    let client = proxy::apply_to_reqwest(
+        reqwest::Client::builder()
+            .timeout(timeout)
+            .connect_timeout(timeout.min(Duration::from_secs(20)))
+            // A Build bearer token is valid only for the fixed proxy endpoint.
+            // Returning a 3xx is a protocol error; the credential is never
+            // replayed to a redirect target.
+            .redirect(reqwest::redirect::Policy::none()),
+    )
+    .build()
+    .map_err(|_| ResponsesSearchError::new(ResponsesSearchErrorKind::Network, error_revision()))?;
+
+    let request = client
+        .post(endpoint)
+        .bearer_auth(token)
+        .header("x-grok-client-mode", "cli")
+        .header("x-grok-client-identifier", "grok-shell")
+        .header("x-grok-client-version", "1.0.5")
+        .json(&responses_request(
+            query,
+            sort,
+            max_search_calls,
+            is_supplement,
+            seen_ids,
+        ))
+        .send();
+    let response = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => {
+            return Err(ResponsesSearchError::new(
+                ResponsesSearchErrorKind::Cancelled,
+                error_revision(),
+            ));
+        }
+        response = request => response,
+    }
+    .map_err(|error| ResponsesSearchError::new(transport_error_kind(&error), error_revision()))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(ResponsesSearchError::new(
+            status_error_kind(status),
+            error_revision(),
+        ));
+    }
+
+    if response
+        .content_length()
+        .is_some_and(|length| length > RESPONSES_MAX_BODY_BYTES.try_into().unwrap_or(u64::MAX))
+    {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::Protocol,
+            error_revision(),
+        ));
+    }
+
+    let body = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => {
+            return Err(ResponsesSearchError::new(
+                ResponsesSearchErrorKind::Cancelled,
+                error_revision(),
+            ));
+        }
+        body = read_bounded_body(response, error_revision()) => body?,
+    };
+    if body.is_empty() {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::Empty,
+            error_revision(),
+        ));
+    }
+    let payload: Value = serde_json::from_slice(&body).map_err(|_| {
+        ResponsesSearchError::new(ResponsesSearchErrorKind::InvalidJson, error_revision())
+    })?;
+    let output = payload
+        .get("output")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            ResponsesSearchError::new(ResponsesSearchErrorKind::Protocol, error_revision())
+        })?;
+    let search_calls = count_x_search_calls(output);
+    if search_calls == 0 {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::ToolNotCalled,
+            error_revision(),
+        ));
+    }
+    if search_calls > max_search_calls {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::SearchBudgetExceeded,
+            error_revision(),
+        ));
+    }
+
+    let gallery = gallery_from_output(output)
+        .map_err(|kind| ResponsesSearchError::new(kind, error_revision()))?;
+    let candidate_count = gallery
+        .get("items")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .ok_or_else(|| {
+            ResponsesSearchError::new(ResponsesSearchErrorKind::Protocol, error_revision())
+        })?;
+    let items = parse_gallery_items(&gallery, "x");
+    let valid_count = items.len();
+
+    Ok(ResponsesSearchSuccess {
+        items,
+        candidate_count,
+        valid_count,
+        search_calls,
+        model: RESPONSES_MODEL,
+        effort: RESPONSES_EFFORT,
+        credential_revision,
+    })
+}
+
+fn responses_request(
+    query: &str,
+    sort: Option<&str>,
+    max_search_calls: u32,
+    is_supplement: bool,
+    seen_ids: &[String],
+) -> Value {
+    json!({
+        "model": RESPONSES_MODEL,
+        "input": responses_prompt(query, sort, max_search_calls, is_supplement, seen_ids),
+        "tools": [{ "type": "x_search" }],
+        "tool_choice": "auto",
+        "max_tool_calls": max_search_calls,
+        "reasoning": {
+            "effort": RESPONSES_EFFORT,
+            "summary": "concise"
+        },
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "wallpaper_gallery",
+                "strict": true,
+                "schema": gallery_schema()
+            }
+        },
+        "store": false
+    })
+}
+
+fn responses_prompt(
+    query: &str,
+    sort: Option<&str>,
+    max_search_calls: u32,
+    is_supplement: bool,
+    seen_ids: &[String],
+) -> String {
+    let sort = match sort.unwrap_or("top") {
+        "latest" | "Latest" => "Latest",
+        _ => "Top",
+    };
+    let round_guidance = if is_supplement {
+        format!(
+            "Supplement round: use one new query with a different visual angle (alternate composition, lighting, setting, season, or medium). Exclude candidates carrying these opaque media/post ids: {}",
+            if seen_ids.is_empty() {
+                "none from the empty first round".to_string()
+            } else {
+                seen_ids.join(", ")
+            }
+        )
+    } else {
+        "First round: use complementary direct and visual/style query variants.".to_string()
+    };
+    format!(
+        r#"You collect high-quality still images from X (Twitter) for a wallpaper picker.
+
+User topic: {query}
+Sort preference: {sort}
+
+{round_guidance}
+
+Use X search only. Use no more than {max_search_calls} x_search call(s) in this request. Search useful query variants with image filters. Prefer real photography or polished AI art suitable as wallpaper. Prefer posts that include both a prompt and attached images when relevant. Skip memes, screenshots, text cards, avatars, emoji packs, ads, blurry thumbnails, videos, and placeholder links.
+
+Return 8-16 distinct items when possible. fullUrl must be a direct HTTPS full-size image CDN URL, preferably https://pbs.twimg.com/media/... with name=orig. postUrl must be a confirmed canonical https://x.com/<user>/status/<id>; omit it rather than guessing. Include mediaIndex 1-4 only when the status media position is known. Return metadata only and do not download files."#
+    )
+}
+
+fn gallery_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "fullUrl": { "type": "string" },
+                        "thumbUrl": { "type": "string" },
+                        "username": { "type": "string" },
+                        "postUrl": { "type": "string" },
+                        "textPreview": { "type": "string" },
+                        "likes": { "type": "number" },
+                        "kind": { "type": "string" },
+                        "width": { "type": "number" },
+                        "height": { "type": "number" },
+                        "mediaIndex": { "type": "number" }
+                    },
+                    "required": ["fullUrl"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["items"],
+        "additionalProperties": false
+    })
+}
+
+async fn read_bounded_body(
+    mut response: reqwest::Response,
+    credential_revision: Option<BuildOauthCredentialRevision>,
+) -> Result<Vec<u8>, ResponsesSearchError> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        ResponsesSearchError::new(transport_error_kind(&error), credential_revision.clone())
+    })? {
+        if body.len().saturating_add(chunk.len()) > RESPONSES_MAX_BODY_BYTES {
+            return Err(ResponsesSearchError::new(
+                ResponsesSearchErrorKind::Protocol,
+                credential_revision,
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn status_error_kind(status: StatusCode) -> ResponsesSearchErrorKind {
+    match status.as_u16() {
+        400 => ResponsesSearchErrorKind::BadRequest,
+        401 | 403 => ResponsesSearchErrorKind::Unauthorized,
+        429 => ResponsesSearchErrorKind::RateLimited,
+        500..=599 => ResponsesSearchErrorKind::ServerError,
+        _ => ResponsesSearchErrorKind::Protocol,
+    }
+}
+
+fn transport_error_kind(error: &reqwest::Error) -> ResponsesSearchErrorKind {
+    if error.is_timeout() {
+        return ResponsesSearchErrorKind::Timeout;
+    }
+    let mut source = error.source();
+    while let Some(cause) = source {
+        let message = cause.to_string().to_ascii_lowercase();
+        if message.contains("tls")
+            || message.contains("certificate")
+            || message.contains("cert ")
+            || message.contains("handshake")
+        {
+            return ResponsesSearchErrorKind::Tls;
+        }
+        source = cause.source();
+    }
+    ResponsesSearchErrorKind::Network
+}
+
+fn count_x_search_calls(output: &[Value]) -> u32 {
+    output
+        .iter()
+        .filter(|item| {
+            let item_type = item
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_ascii_lowercase();
+            if item.get("status").and_then(Value::as_str) != Some("completed") {
+                return false;
+            }
+            if matches!(item_type.as_str(), "x_search_call" | "x_search_tool_call") {
+                return true;
+            }
+            // The fixed request registers only x_search. Build compatibility
+            // responses can represent that call as an unnamed custom call,
+            // but accept only the exact completed call item, never result or
+            // arbitrary custom_tool-prefixed shapes.
+            if item_type == "custom_tool_call" {
+                return true;
+            }
+            matches!(
+                item_type.as_str(),
+                "server_tool_use" | "server_tool_call" | "tool_use" | "tool_call"
+            ) && ["name", "tool_name", "tool"]
+                .iter()
+                .filter_map(|field| item.get(field).and_then(Value::as_str))
+                .any(|name| name.eq_ignore_ascii_case("x_search"))
+        })
+        .count()
+        .try_into()
+        .unwrap_or(u32::MAX)
+}
+
+fn gallery_from_output(output: &[Value]) -> Result<Value, ResponsesSearchErrorKind> {
+    let mut saw_invalid_json = false;
+    for item in output.iter().rev() {
+        let Some(content) = item.get("content").and_then(Value::as_array) else {
+            continue;
+        };
+        for part in content.iter().rev() {
+            if part.get("type").and_then(Value::as_str) != Some("output_text") {
+                continue;
+            }
+            let Some(text) = part.get("text").and_then(Value::as_str) else {
+                continue;
+            };
+            if text.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Value>(text) {
+                Ok(value) if value.get("items").and_then(Value::as_array).is_some() => {
+                    return Ok(value);
+                }
+                Ok(_) => return Err(ResponsesSearchErrorKind::Protocol),
+                Err(_) => saw_invalid_json = true,
+            }
+        }
+    }
+    if saw_invalid_json {
+        Err(ResponsesSearchErrorKind::InvalidJson)
+    } else {
+        Err(ResponsesSearchErrorKind::Empty)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use axum::body::{Body, Bytes};
+    use axum::extract::State;
+    use axum::http::{HeaderMap, HeaderValue};
+    use axum::response::{IntoResponse, Response};
+    use axum::routing::post;
+    use axum::Router;
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct MockState {
+        status: StatusCode,
+        response_body: Arc<String>,
+        delay: Duration,
+        requests: Arc<AtomicUsize>,
+        authorization_ok: Arc<AtomicBool>,
+        request_body: Arc<Mutex<Option<Value>>>,
+    }
+
+    async fn mock_responses(
+        State(state): State<MockState>,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Response {
+        state.requests.fetch_add(1, Ordering::SeqCst);
+        state.authorization_ok.store(
+            headers
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                == Some("Bearer test-token"),
+            Ordering::SeqCst,
+        );
+        if let Ok(value) = serde_json::from_slice::<Value>(&body) {
+            *state.request_body.lock().expect("request body lock") = Some(value);
+        }
+        if !state.delay.is_zero() {
+            tokio::time::sleep(state.delay).await;
+        }
+        (state.status, state.response_body.as_str().to_string()).into_response()
+    }
+
+    async fn spawn_mock(
+        status: StatusCode,
+        body: impl Into<String>,
+        delay: Duration,
+    ) -> (String, MockState, JoinHandle<()>) {
+        let state = MockState {
+            status,
+            response_body: Arc::new(body.into()),
+            delay,
+            requests: Arc::new(AtomicUsize::new(0)),
+            authorization_ok: Arc::new(AtomicBool::new(false)),
+            request_body: Arc::new(Mutex::new(None)),
+        };
+        let app = Router::new()
+            .route("/v1/responses", post(mock_responses))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+        let address = listener.local_addr().expect("mock address");
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{address}/v1/responses"), state, task)
+    }
+
+    fn test_revision() -> BuildOauthCredentialRevision {
+        BuildOauthCredentialRevision::for_test(123, Some(456), 1)
+    }
+
+    fn success_payload(search_calls: usize) -> String {
+        let mut output = Vec::new();
+        for _ in 0..search_calls {
+            output.push(json!({ "type": "x_search_call", "status": "completed" }));
+        }
+        output.push(json!({
+            "type": "message",
+            "content": [{
+                "type": "output_text",
+                "text": serde_json::to_string(&json!({
+                    "items": [{
+                        "fullUrl": "https://pbs.twimg.com/media/test.jpg?name=small",
+                        "thumbUrl": "https://pbs.twimg.com/media/test.jpg?name=small",
+                        "username": "alice",
+                        "postUrl": "https://x.com/alice/status/1234567890123456789",
+                        "kind": "image"
+                    }]
+                })).expect("gallery json")
+            }]
+        }));
+        json!({
+            "model": RESPONSES_MODEL,
+            "output": output
+        })
+        .to_string()
+    }
+
+    async fn test_search(
+        endpoint: &str,
+        timeout: Duration,
+    ) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
+        let cancellation = WallpaperSearchCancellation::default();
+        search_with_credentials(
+            "misty mountains",
+            Some("top"),
+            Ok(("test-token", test_revision())),
+            endpoint,
+            timeout,
+            SearchOptions {
+                max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
+                is_supplement: false,
+                seen_ids: &[],
+                cancellation: &cancellation,
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn gallery_without_completed_x_call_is_rejected() {
+        let (endpoint, _, task) =
+            spawn_mock(StatusCode::OK, success_payload(0), Duration::ZERO).await;
+        let result = test_search(&endpoint, Duration::from_secs(2)).await;
+        task.abort();
+        assert_eq!(
+            result.unwrap_err().kind,
+            ResponsesSearchErrorKind::ToolNotCalled
+        );
+        assert_eq!(
+            count_x_search_calls(&[
+                json!({"type": "x_search_call", "status": "in_progress"}),
+                json!({"type": "custom_tool_result", "status": "completed"}),
+                json!({"type": "server_tool_call", "name": "web_search", "status": "completed"}),
+            ]),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn wallpaper_x_responses_success_parses_gallery_and_fixed_contract() {
+        assert_eq!(
+            count_x_search_calls(&[json!({ "type": "custom_tool_call", "status": "completed" })]),
+            1
+        );
+        let (endpoint, state, task) =
+            spawn_mock(StatusCode::OK, success_payload(2), Duration::ZERO).await;
+        let result = test_search(&endpoint, Duration::from_secs(2))
+            .await
+            .expect("responses success");
+        task.abort();
+
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.candidate_count, 1);
+        assert_eq!(result.valid_count, 1);
+        assert_eq!(result.search_calls, 2);
+        assert_eq!(result.model, "grok-4.6");
+        assert_eq!(result.effort, "low");
+        assert!(result.items[0].full_url.contains("name=orig"));
+        assert_eq!(state.requests.load(Ordering::SeqCst), 1);
+        assert!(state.authorization_ok.load(Ordering::SeqCst));
+
+        let request = state
+            .request_body
+            .lock()
+            .expect("request body lock")
+            .clone()
+            .expect("captured request");
+        assert_eq!(request.get("model"), Some(&json!("grok-4.6")));
+        assert_eq!(request.pointer("/reasoning/effort"), Some(&json!("low")));
+        assert_eq!(request.get("store"), Some(&json!(false)));
+        assert_eq!(request.get("max_tool_calls"), Some(&json!(2)));
+        assert_eq!(request.pointer("/tools/0/type"), Some(&json!("x_search")));
+        assert_eq!(
+            request.pointer("/text/format/type"),
+            Some(&json!("json_schema"))
+        );
+        assert_eq!(request.pointer("/text/format/strict"), Some(&json!(true)));
+        assert_eq!(
+            request.pointer("/text/format/schema/additionalProperties"),
+            Some(&json!(false))
+        );
+        assert!(request
+            .get("input")
+            .and_then(Value::as_str)
+            .is_some_and(|prompt| prompt.contains("no more than 2 x_search call")));
+        let supplement = responses_request(
+            "misty mountains",
+            Some("top"),
+            X_SEARCH_SUPPLEMENT_CALLS,
+            true,
+            &["twimg:seen-id".into(), "status:12345678".into()],
+        );
+        assert_eq!(supplement.get("max_tool_calls"), Some(&json!(1)));
+        assert!(supplement
+            .get("input")
+            .and_then(Value::as_str)
+            .is_some_and(|prompt| {
+                prompt.contains("different visual angle")
+                    && prompt.contains("twimg:seen-id")
+                    && prompt.contains("no more than 1 x_search call")
+            }));
+        assert_eq!(RESPONSES_MAX_X_SEARCH_CALLS, 3);
+    }
+
+    #[tokio::test]
+    async fn wallpaper_x_responses_classifies_http_failures() {
+        for (status, expected) in [
+            (
+                StatusCode::BAD_REQUEST,
+                ResponsesSearchErrorKind::BadRequest,
+            ),
+            (
+                StatusCode::UNAUTHORIZED,
+                ResponsesSearchErrorKind::Unauthorized,
+            ),
+            (
+                StatusCode::FORBIDDEN,
+                ResponsesSearchErrorKind::Unauthorized,
+            ),
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                ResponsesSearchErrorKind::RateLimited,
+            ),
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ResponsesSearchErrorKind::ServerError,
+            ),
+        ] {
+            let (endpoint, _state, task) = spawn_mock(status, "redacted", Duration::ZERO).await;
+            let error = test_search(&endpoint, Duration::from_secs(2))
+                .await
+                .expect_err("http status must fail");
+            task.abort();
+            assert_eq!(error.kind, expected);
+            assert_eq!(error.code(), expected.code());
+        }
+    }
+
+    #[tokio::test]
+    async fn wallpaper_x_responses_classifies_timeout_invalid_json_and_empty() {
+        let (endpoint, _state, task) = spawn_mock(
+            StatusCode::OK,
+            success_payload(1),
+            Duration::from_millis(150),
+        )
+        .await;
+        let error = test_search(&endpoint, Duration::from_millis(25))
+            .await
+            .expect_err("request must time out");
+        task.abort();
+        assert_eq!(error.kind, ResponsesSearchErrorKind::Timeout);
+
+        let (endpoint, _state, task) = spawn_mock(StatusCode::OK, "not-json", Duration::ZERO).await;
+        let error = test_search(&endpoint, Duration::from_secs(2))
+            .await
+            .expect_err("invalid json must fail");
+        task.abort();
+        assert_eq!(error.kind, ResponsesSearchErrorKind::InvalidJson);
+
+        let (endpoint, _state, task) = spawn_mock(StatusCode::OK, "", Duration::ZERO).await;
+        let error = test_search(&endpoint, Duration::from_secs(2))
+            .await
+            .expect_err("empty response must fail");
+        task.abort();
+        assert_eq!(error.kind, ResponsesSearchErrorKind::Empty);
+    }
+
+    #[tokio::test]
+    async fn wallpaper_x_responses_cancellation_aborts_inflight_http() {
+        let (endpoint, state, task) =
+            spawn_mock(StatusCode::OK, success_payload(1), Duration::from_secs(10)).await;
+        let cancellation = WallpaperSearchCancellation::default();
+        let cancellation_for_request = cancellation.clone();
+        let request = tokio::spawn(async move {
+            search_with_credentials(
+                "misty mountains",
+                Some("top"),
+                Ok(("test-token", test_revision())),
+                &endpoint,
+                Duration::from_secs(30),
+                SearchOptions {
+                    max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
+                    is_supplement: false,
+                    seen_ids: &[],
+                    cancellation: &cancellation_for_request,
+                },
+            )
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while state.requests.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("mock request did not start");
+        cancellation.cancel();
+        let error = tokio::time::timeout(Duration::from_secs(2), request)
+            .await
+            .expect("cancelled request did not return")
+            .expect("request task panicked")
+            .expect_err("cancelled request must fail");
+        task.abort();
+        assert_eq!(error.kind, ResponsesSearchErrorKind::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn wallpaper_x_responses_rejects_bad_structured_output_and_tool_overrun() {
+        let invalid_output = json!({
+            "output": [{ "type": "x_search_call", "status": "completed" }, {
+                "type": "message",
+                "content": [{ "type": "output_text", "text": "not-json" }]
+            }]
+        })
+        .to_string();
+        let (endpoint, _state, task) =
+            spawn_mock(StatusCode::OK, invalid_output, Duration::ZERO).await;
+        let error = test_search(&endpoint, Duration::from_secs(2))
+            .await
+            .expect_err("bad structured output must fail");
+        task.abort();
+        assert_eq!(error.kind, ResponsesSearchErrorKind::InvalidJson);
+
+        let (endpoint, _state, task) =
+            spawn_mock(StatusCode::OK, success_payload(4), Duration::ZERO).await;
+        let error = test_search(&endpoint, Duration::from_secs(2))
+            .await
+            .expect_err("tool overrun must fail");
+        task.abort();
+        assert_eq!(error.kind, ResponsesSearchErrorKind::SearchBudgetExceeded);
+    }
+
+    #[tokio::test]
+    async fn wallpaper_x_responses_oauth_failure_sends_no_request() {
+        let (endpoint, state, task) =
+            spawn_mock(StatusCode::OK, success_payload(1), Duration::ZERO).await;
+        for (oauth_error, expected) in [
+            (
+                BuildOauthTokenError::Unavailable,
+                ResponsesSearchErrorKind::OauthUnavailable,
+            ),
+            (
+                BuildOauthTokenError::Expired,
+                ResponsesSearchErrorKind::OauthExpired,
+            ),
+        ] {
+            let cancellation = WallpaperSearchCancellation::default();
+            let error = search_with_credentials(
+                "misty mountains",
+                Some("top"),
+                Err(oauth_error),
+                &endpoint,
+                Duration::from_secs(2),
+                SearchOptions {
+                    max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
+                    is_supplement: false,
+                    seen_ids: &[],
+                    cancellation: &cancellation,
+                },
+            )
+            .await
+            .expect_err("oauth failure must stop before HTTP");
+            assert_eq!(error.kind, expected);
+        }
+        task.abort();
+        assert_eq!(state.requests.load(Ordering::SeqCst), 0);
+    }
+
+    #[derive(Clone)]
+    struct RedirectState {
+        target: String,
+        source_requests: Arc<AtomicUsize>,
+        target_requests: Arc<AtomicUsize>,
+        target_saw_authorization: Arc<AtomicBool>,
+    }
+
+    async fn redirect_source(State(state): State<RedirectState>) -> Response {
+        state.source_requests.fetch_add(1, Ordering::SeqCst);
+        let mut response = Response::new(Body::empty());
+        *response.status_mut() = StatusCode::TEMPORARY_REDIRECT;
+        response.headers_mut().insert(
+            reqwest::header::LOCATION,
+            HeaderValue::from_str(&state.target).expect("redirect target header"),
+        );
+        response
+    }
+
+    async fn redirect_target(State(state): State<RedirectState>, headers: HeaderMap) -> Response {
+        state.target_requests.fetch_add(1, Ordering::SeqCst);
+        state.target_saw_authorization.store(
+            headers.contains_key(reqwest::header::AUTHORIZATION),
+            Ordering::SeqCst,
+        );
+        (StatusCode::OK, success_payload(1)).into_response()
+    }
+
+    #[tokio::test]
+    async fn wallpaper_x_responses_never_replays_authorization_across_redirect() {
+        let target_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind redirect target");
+        let target_address = target_listener.local_addr().expect("target address");
+        let state = RedirectState {
+            target: format!("http://{target_address}/target"),
+            source_requests: Arc::new(AtomicUsize::new(0)),
+            target_requests: Arc::new(AtomicUsize::new(0)),
+            target_saw_authorization: Arc::new(AtomicBool::new(false)),
+        };
+        let target_app = Router::new()
+            .route("/target", post(redirect_target))
+            .with_state(state.clone());
+        let target_task = tokio::spawn(async move {
+            let _ = axum::serve(target_listener, target_app).await;
+        });
+
+        let source_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind redirect source");
+        let source_address = source_listener.local_addr().expect("source address");
+        let source_app = Router::new()
+            .route("/v1/responses", post(redirect_source))
+            .with_state(state.clone());
+        let source_task = tokio::spawn(async move {
+            let _ = axum::serve(source_listener, source_app).await;
+        });
+
+        let error = test_search(
+            &format!("http://{source_address}/v1/responses"),
+            Duration::from_secs(2),
+        )
+        .await
+        .expect_err("redirect must be a protocol failure");
+        source_task.abort();
+        target_task.abort();
+
+        assert_eq!(error.kind, ResponsesSearchErrorKind::Protocol);
+        assert_eq!(state.source_requests.load(Ordering::SeqCst), 1);
+        assert_eq!(state.target_requests.load(Ordering::SeqCst), 0);
+        assert!(!state.target_saw_authorization.load(Ordering::SeqCst));
+    }
+}

--- a/src-tauri/src/wallpaper_x_search.rs
+++ b/src-tauri/src/wallpaper_x_search.rs
@@ -1,8 +1,18 @@
 //! Request ownership, progress and cancellation for CLI wallpaper searches.
+use crate::account::BuildOauthCredentialRevision;
 use crate::wallpaper_source::{
     self, WallpaperSearchCancellation, WallpaperSearchResult, WallpaperXSearchRuntime,
     WallpaperXSearchStage,
 };
+use crate::wallpaper_source::{WallpaperCliSearchOutcome, WallpaperSearchMeta};
+use crate::wallpaper_x_responses::{
+    ResponsesSearchError, ResponsesSearchErrorKind, ResponsesSearchSuccess,
+};
+use crate::{account, store, wallpaper_x_responses};
+use std::future::Future;
+const CIRCUIT_FAILURE_THRESHOLD: u8 = 3;
+const CIRCUIT_OPEN_DURATION: Duration = Duration::from_secs(10 * 60);
+const CIRCUIT_OPEN_REASON: &str = "responses_circuit_open";
 use parking_lot::Mutex;
 use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
@@ -129,17 +139,402 @@ pub(crate) async fn search(
         }),
     );
     runtime.report(WallpaperXSearchStage::Preparing);
-    runtime.report(WallpaperXSearchStage::SearchingX);
-    let result = wallpaper_source::x_search_cli_outcome(query, sort, Some(&runtime))
-        .await
-        .result;
+    let settings = store::load_settings();
+    let mode = store::normalize_wallpaper_x_search_mode(&settings.wallpaper_x_search_mode);
+    let mut result = route_with_providers(
+        mode,
+        account::build_oauth_credential_revision(),
+        responses_circuit(),
+        &runtime,
+        || wallpaper_x_responses::search(query, sort, &runtime),
+        || wallpaper_source::x_search_cli_outcome(query, sort, Some(&runtime)),
+    )
+    .await;
+    if let Some(meta) = result.meta.as_mut() {
+        meta.request_id = Some(request_id.to_string());
+    }
     runtime.report(WallpaperXSearchStage::Done);
     Ok(result)
+}
+
+#[derive(Default)]
+struct ResponsesCircuitBreaker {
+    credential_revision: Option<BuildOauthCredentialRevision>,
+    consecutive_failures: u8,
+    open_until: Option<Instant>,
+}
+
+impl ResponsesCircuitBreaker {
+    fn reset_for_revision(&mut self, revision: Option<BuildOauthCredentialRevision>) {
+        if self.credential_revision == revision {
+            return;
+        }
+        self.credential_revision = revision;
+        self.consecutive_failures = 0;
+        self.open_until = None;
+    }
+
+    fn allows_attempt(
+        &mut self,
+        revision: Option<BuildOauthCredentialRevision>,
+        now: Instant,
+    ) -> bool {
+        self.reset_for_revision(revision);
+        match self.open_until {
+            Some(until) if now < until => false,
+            Some(_) => {
+                self.open_until = None;
+                self.consecutive_failures = 0;
+                true
+            }
+            None => true,
+        }
+    }
+
+    fn record_success(&mut self, revision: BuildOauthCredentialRevision) {
+        self.credential_revision = Some(revision);
+        self.consecutive_failures = 0;
+        self.open_until = None;
+    }
+
+    fn record_failure(
+        &mut self,
+        kind: ResponsesSearchErrorKind,
+        revision: Option<BuildOauthCredentialRevision>,
+        now: Instant,
+    ) {
+        self.reset_for_revision(revision);
+        if kind == ResponsesSearchErrorKind::BadRequest {
+            self.consecutive_failures = CIRCUIT_FAILURE_THRESHOLD;
+            self.open_until = Some(now + CIRCUIT_OPEN_DURATION);
+            return;
+        }
+        if !counts_toward_circuit(kind) {
+            return;
+        }
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        if self.consecutive_failures >= CIRCUIT_FAILURE_THRESHOLD {
+            self.open_until = Some(now + CIRCUIT_OPEN_DURATION);
+        }
+    }
+}
+
+fn responses_circuit() -> &'static Mutex<ResponsesCircuitBreaker> {
+    static CIRCUIT: OnceLock<Mutex<ResponsesCircuitBreaker>> = OnceLock::new();
+    CIRCUIT.get_or_init(|| Mutex::new(ResponsesCircuitBreaker::default()))
+}
+
+fn counts_toward_circuit(kind: ResponsesSearchErrorKind) -> bool {
+    matches!(
+        kind,
+        ResponsesSearchErrorKind::ServerError
+            | ResponsesSearchErrorKind::Timeout
+            | ResponsesSearchErrorKind::Tls
+            | ResponsesSearchErrorKind::Network
+            | ResponsesSearchErrorKind::Empty
+            | ResponsesSearchErrorKind::InvalidJson
+            | ResponsesSearchErrorKind::ToolNotCalled
+            | ResponsesSearchErrorKind::Protocol
+            | ResponsesSearchErrorKind::SearchBudgetExceeded
+    )
+}
+
+fn should_fallback(kind: ResponsesSearchErrorKind) -> bool {
+    !matches!(
+        kind,
+        ResponsesSearchErrorKind::RateLimited
+            | ResponsesSearchErrorKind::SearchBudgetExceeded
+            | ResponsesSearchErrorKind::Cancelled
+    )
+}
+
+async fn route_with_providers<R, RFut, C, CFut>(
+    requested_mode: &str,
+    credential_revision: Option<BuildOauthCredentialRevision>,
+    circuit: &Mutex<ResponsesCircuitBreaker>,
+    runtime: &WallpaperXSearchRuntime,
+    responses: R,
+    cli: C,
+) -> WallpaperSearchResult
+where
+    R: FnOnce() -> RFut,
+    RFut: Future<Output = Result<ResponsesSearchSuccess, ResponsesSearchError>>,
+    C: FnOnce() -> CFut,
+    CFut: Future<Output = WallpaperCliSearchOutcome>,
+{
+    let started = Instant::now();
+    let requested_mode = store::normalize_wallpaper_x_search_mode(requested_mode);
+    if runtime.is_cancelled() {
+        return cancelled_result(requested_mode, "cli", started);
+    }
+
+    // `auto` stays protocol-reserved until QA explicitly enables it. Both it
+    // and the public default execute the established CLI route.
+    if requested_mode != store::WALLPAPER_X_SEARCH_MODE_RESPONSES_PREVIEW {
+        runtime.report(WallpaperXSearchStage::SearchingX);
+        return finish_cli(cli().await, requested_mode, None, started);
+    }
+
+    if !circuit
+        .lock()
+        .allows_attempt(credential_revision.clone(), Instant::now())
+    {
+        runtime.report(WallpaperXSearchStage::FallingBack);
+        return finish_cli(
+            cli().await,
+            requested_mode,
+            Some(CIRCUIT_OPEN_REASON),
+            started,
+        );
+    }
+
+    runtime.report(WallpaperXSearchStage::SearchingX);
+    match responses().await {
+        Ok(result) if !result.items.is_empty() && result.valid_count > 0 => {
+            if runtime.is_cancelled() {
+                return cancelled_result(requested_mode, "responses", started);
+            }
+            circuit
+                .lock()
+                .record_success(result.credential_revision.clone());
+            WallpaperSearchResult {
+                items: result.items,
+                error_code: None,
+                message: None,
+                meta: Some(WallpaperSearchMeta {
+                    request_id: None,
+                    requested_mode: requested_mode.into(),
+                    route_used: "responses".into(),
+                    fallback_reason: None,
+                    duration_ms: elapsed_ms(started),
+                    cache_hit: false,
+                    search_calls: Some(result.search_calls),
+                    candidate_count: result.candidate_count,
+                    valid_count: result.valid_count,
+                    model: Some(result.model.into()),
+                    effort: Some(result.effort.into()),
+                }),
+            }
+        }
+        Ok(result) => {
+            if runtime.is_cancelled() {
+                return cancelled_result(requested_mode, "responses", started);
+            }
+            circuit.lock().record_failure(
+                ResponsesSearchErrorKind::Empty,
+                Some(result.credential_revision),
+                Instant::now(),
+            );
+            runtime.report(WallpaperXSearchStage::FallingBack);
+            if runtime.is_cancelled() {
+                return cancelled_result(requested_mode, "responses", started);
+            }
+            finish_cli(
+                cli().await,
+                requested_mode,
+                Some(ResponsesSearchErrorKind::Empty.code()),
+                started,
+            )
+        }
+        Err(error) if error.kind == ResponsesSearchErrorKind::Cancelled => {
+            cancelled_result(requested_mode, "responses", started)
+        }
+        Err(error) if !should_fallback(error.kind) => {
+            if counts_toward_circuit(error.kind) {
+                circuit.lock().record_failure(
+                    error.kind,
+                    error.credential_revision.clone().or(credential_revision),
+                    Instant::now(),
+                );
+            }
+            WallpaperSearchResult {
+                items: Vec::new(),
+                error_code: Some(error.code().into()),
+                message: None,
+                meta: Some(WallpaperSearchMeta {
+                    request_id: None,
+                    requested_mode: requested_mode.into(),
+                    route_used: "responses".into(),
+                    fallback_reason: None,
+                    duration_ms: elapsed_ms(started),
+                    cache_hit: false,
+                    search_calls: None,
+                    candidate_count: 0,
+                    valid_count: 0,
+                    model: Some(wallpaper_x_responses::RESPONSES_MODEL.into()),
+                    effort: Some(wallpaper_x_responses::RESPONSES_EFFORT.into()),
+                }),
+            }
+        }
+        Err(error) => {
+            circuit.lock().record_failure(
+                error.kind,
+                error.credential_revision.clone().or(credential_revision),
+                Instant::now(),
+            );
+            runtime.report(WallpaperXSearchStage::FallingBack);
+            if runtime.is_cancelled() {
+                return cancelled_result(requested_mode, "responses", started);
+            }
+            finish_cli(cli().await, requested_mode, Some(error.code()), started)
+        }
+    }
+}
+
+fn finish_cli(
+    mut outcome: WallpaperCliSearchOutcome,
+    requested_mode: &str,
+    fallback_reason: Option<&str>,
+    started: Instant,
+) -> WallpaperSearchResult {
+    outcome.result.meta = Some(WallpaperSearchMeta {
+        request_id: None,
+        requested_mode: requested_mode.into(),
+        route_used: "cli".into(),
+        fallback_reason: fallback_reason.map(str::to_string),
+        duration_ms: elapsed_ms(started),
+        cache_hit: false,
+        // Grok Build does not currently expose a reliable hosted X call count
+        // or selected official model through this headless result contract.
+        search_calls: None,
+        candidate_count: outcome.candidate_count,
+        valid_count: outcome.valid_count,
+        model: None,
+        effort: Some("low".into()),
+    });
+    outcome.result
+}
+
+fn cancelled_result(
+    requested_mode: &str,
+    route_used: &str,
+    started: Instant,
+) -> WallpaperSearchResult {
+    WallpaperSearchResult {
+        items: Vec::new(),
+        error_code: Some("cancelled".into()),
+        message: None,
+        meta: Some(WallpaperSearchMeta {
+            request_id: None,
+            requested_mode: store::normalize_wallpaper_x_search_mode(requested_mode).into(),
+            route_used: route_used.into(),
+            fallback_reason: None,
+            duration_ms: elapsed_ms(started),
+            cache_hit: false,
+            search_calls: None,
+            candidate_count: 0,
+            valid_count: 0,
+            model: (route_used == "responses")
+                .then(|| wallpaper_x_responses::RESPONSES_MODEL.into()),
+            effort: Some("low".into()),
+        }),
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cli_outcome() -> WallpaperCliSearchOutcome {
+        WallpaperCliSearchOutcome {
+            result: WallpaperSearchResult {
+                items: vec![],
+                error_code: Some("empty".into()),
+                message: None,
+                meta: None,
+            },
+            candidate_count: 0,
+            valid_count: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn default_and_unknown_mode_do_not_call_responses() {
+        for mode in ["cli", "", "auto", "unknown"] {
+            let runtime = WallpaperXSearchRuntime::quiet();
+            let result = route_with_providers(
+                mode,
+                None,
+                &Mutex::new(ResponsesCircuitBreaker::default()),
+                &runtime,
+                || async { panic!("default must not request Responses") },
+                || async { cli_outcome() },
+            )
+            .await;
+            assert_eq!(result.meta.unwrap().route_used, "cli");
+        }
+    }
+
+    #[tokio::test]
+    async fn rate_limits_and_budget_failures_never_trigger_cli() {
+        for kind in [
+            ResponsesSearchErrorKind::RateLimited,
+            ResponsesSearchErrorKind::SearchBudgetExceeded,
+        ] {
+            let runtime = WallpaperXSearchRuntime::quiet();
+            let result = route_with_providers(
+                "responses_preview",
+                None,
+                &Mutex::new(ResponsesCircuitBreaker::default()),
+                &runtime,
+                || async {
+                    Err(ResponsesSearchError {
+                        kind,
+                        credential_revision: None,
+                    })
+                },
+                || async { panic!("must not double-request after limit") },
+            )
+            .await;
+            assert_eq!(result.error_code.as_deref(), Some(kind.code()));
+            assert_eq!(result.meta.unwrap().route_used, "responses");
+        }
+    }
+
+    #[tokio::test]
+    async fn network_failure_falls_back_once_and_reports_reason() {
+        let runtime = WallpaperXSearchRuntime::quiet();
+        let calls = std::sync::atomic::AtomicUsize::new(0);
+        let result = route_with_providers(
+            "responses_preview",
+            None,
+            &Mutex::new(ResponsesCircuitBreaker::default()),
+            &runtime,
+            || async {
+                Err(ResponsesSearchError {
+                    kind: ResponsesSearchErrorKind::Network,
+                    credential_revision: None,
+                })
+            },
+            || async {
+                calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                cli_outcome()
+            },
+        )
+        .await;
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(
+            result.meta.unwrap().fallback_reason.as_deref(),
+            Some("responses_network")
+        );
+    }
+
+    #[test]
+    fn credential_content_change_resets_circuit_even_with_same_metadata() {
+        let first = BuildOauthCredentialRevision::for_test(10, Some(1), 1);
+        let second = BuildOauthCredentialRevision::for_test(10, Some(1), 2);
+        let now = Instant::now();
+        let mut circuit = ResponsesCircuitBreaker::default();
+        for _ in 0..3 {
+            circuit.record_failure(ResponsesSearchErrorKind::Network, Some(first.clone()), now);
+        }
+        assert!(!circuit.allows_attempt(Some(first), now));
+        assert!(circuit.allows_attempt(Some(second), now));
+    }
     #[test]
     fn request_ids_are_validated_and_canonicalized() {
         assert!(request_id(Some("invalid")).is_err());

--- a/src/components/WallpaperSourceControls.tsx
+++ b/src/components/WallpaperSourceControls.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import { Select } from "@/components/Select";
 import type { WallpaperSourceModalProps, WallpaperSourceTab } from "./WallpaperSourceModal";
 
@@ -13,6 +13,7 @@ type Props = {
   /** True only while an X search request is in flight (enables Cancel). */
   xBusy?: boolean;
   locked: boolean;
+  xRouteControl?: ReactNode;
   setQuery: (value: string) => void;
   setSort: (value: "top" | "latest") => void;
   setPrompt: (value: string) => void;
@@ -26,7 +27,7 @@ type Props = {
 export function WallpaperSourceControls({
   t, tab, query, sort, prompt, aspect, busy, xBusy = false, locked,
   setQuery, setSort, setPrompt, setAspect, runXSearch, cancelXSearch,
-  runImagine, loadLibrary,
+  runImagine, loadLibrary, xRouteControl,
 }: Props) {
   const sortOptions = useMemo(
     () => [
@@ -54,6 +55,7 @@ export function WallpaperSourceControls({
           <p className="wallpaper-source-form__hint">
             {t("settings.wallpaperSource.xHint")}
           </p>
+          {xRouteControl}
           <div className="wallpaper-source-form__row">
             <input
               type="search"

--- a/src/components/WallpaperSourceModal.test.tsx
+++ b/src/components/WallpaperSourceModal.test.tsx
@@ -19,6 +19,8 @@ vi.mock("@/hooks/useWallpaperXSearch", () => ({
 
 vi.mock("@/lib/api", () => ({
   isDesktopHost: () => true,
+  settingsGet: vi.fn(async () => ({ wallpaperXSearchMode: "cli" })),
+  settingsSet: vi.fn(async () => ({})),
   wallpaperFetchMedia: vi.fn(),
   wallpaperImagine: vi.fn(),
   wallpaperLibraryList: vi.fn(),

--- a/src/components/WallpaperSourceModal.tsx
+++ b/src/components/WallpaperSourceModal.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { WallpaperSourceGallery } from "./WallpaperSourceGallery";
 import { WallpaperSourceFooter } from "./WallpaperSourceFooter";
 import { useWallpaperXSearch } from "@/hooks/useWallpaperXSearch";
+import { WallpaperXRouteControl } from "./WallpaperXRouteControl";
 import { GlassModal } from "@/components/GlassModal";
 import { WallpaperSourceControls } from "./WallpaperSourceControls";
 import { useImageViewerOptional } from "@/components/ImageViewerContext";
@@ -116,13 +117,14 @@ export function WallpaperSourceModal({
   const [hasSearched, setHasSearched] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [operationBusy, setBusy] = useState(false);
+  const [routeSaving, setRouteSaving] = useState(false);
   const {
     busy: xBusy,
     stage: xStage,
     search: searchX,
     cancel: cancelX,
   } = useWallpaperXSearch();
-  const busy = operationBusy || xBusy;
+  const busy = operationBusy || xBusy || routeSaving;
   const close = useCallback(() => {
     void cancelX();
     onClose();
@@ -253,6 +255,21 @@ export function WallpaperSourceModal({
     try {
       const res = await searchX(q, sort);
       if (!res) return;
+      if (res.meta) {
+        const { routeUsed, durationMs, fallbackReason } = res.meta;
+        const reason = fallbackReason?.includes("oauth") || fallbackReason?.includes("unauthorized")
+          ? "auth"
+          : fallbackReason?.includes("circuit") ? "circuit"
+            : fallbackReason?.includes("empty") ? "empty"
+              : /network|timeout|tls|server/.test(fallbackReason ?? "") ? "network"
+                : "compatibility";
+        setStatusHint(t(fallbackReason
+          ? "settings.wallpaperSource.route.fallback"
+          : routeUsed === "responses" ? "settings.wallpaperSource.route.responses" : "settings.wallpaperSource.route.cli", {
+          seconds: (durationMs / 1000).toFixed(1),
+          reason: t(`settings.wallpaperSource.route.fallback.${reason}` as MessageKey),
+        }));
+      }
       const list = dedupeGalleryItems(res.items || []);
       const code = errorCodeFromSearchResult({ ...res, items: list });
       setHasSearched(true);
@@ -662,6 +679,7 @@ export function WallpaperSourceModal({
 
       <WallpaperSourceControls
         t={t}
+        xRouteControl={open && isDesktopHost() ? <WallpaperXRouteControl t={t} disabled={locked} onSavingChange={setRouteSaving} /> : null}
         tab={tab}
         query={query}
         sort={sort}
@@ -683,7 +701,9 @@ export function WallpaperSourceModal({
       {xBusy && xStage ? (
         <p className="wallpaper-source-status" role="status">
           {t(
-            xStage === "validating"
+            xStage === "falling_back"
+              ? "settings.wallpaperSource.progress.fallingBack"
+              : xStage === "validating"
               ? "settings.wallpaperSource.progress.validating"
               : xStage === "supplementing"
                 ? "settings.wallpaperSource.progress.supplementing"

--- a/src/components/WallpaperXRouteControl.test.tsx
+++ b/src/components/WallpaperXRouteControl.test.tsx
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+const get = vi.hoisted(() => vi.fn());
+const set = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api", () => ({ settingsGet: get, settingsSet: set }));
+vi.mock("@/components/Select", () => ({ Select: ({ value, disabled, onChange }: {
+  value: string; disabled: boolean; onChange: (value: string) => void;
+}) => <button disabled={disabled} onClick={() => onChange("responses_preview")}>{value}</button> }));
+import { WallpaperXRouteControl } from "./WallpaperXRouteControl";
+afterEach(cleanup);
+beforeEach(() => { vi.resetAllMocks(); get.mockResolvedValue({ wallpaperXSearchMode: "cli", theme: "dark" }); set.mockResolvedValue({}); });
+
+it("preserves current settings and displays preview only after successful save", async () => {
+  const saving = vi.fn();
+  render(<WallpaperXRouteControl t={(key) => key} disabled={false} onSavingChange={saving} />);
+  await waitFor(() => expect(screen.getByRole("button").hasAttribute("disabled")).toBe(false));
+  fireEvent.click(screen.getByRole("button"));
+  await screen.findByText("responses_preview");
+  expect(set).toHaveBeenCalledWith({ wallpaperXSearchMode: "responses_preview", theme: "dark" });
+  expect(saving.mock.calls).toEqual([[true], [false]]);
+});
+
+it("failed persistence keeps the saved mode and restores interaction", async () => {
+  set.mockRejectedValue(new Error("disk full"));
+  render(<WallpaperXRouteControl t={(key) => key} disabled={false} onSavingChange={vi.fn()} />);
+  await waitFor(() => expect(screen.getByRole("button").hasAttribute("disabled")).toBe(false));
+  fireEvent.click(screen.getByRole("button"));
+  await screen.findByRole("alert");
+  expect(screen.getByRole("button").textContent).toBe("cli");
+  expect(screen.getByRole("button").hasAttribute("disabled")).toBe(false);
+});

--- a/src/components/WallpaperXRouteControl.tsx
+++ b/src/components/WallpaperXRouteControl.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { Select } from "@/components/Select";
+import * as api from "@/lib/api";
+import type { WallpaperSourceModalProps } from "./WallpaperSourceModal";
+
+type Mode = "cli" | "responses_preview";
+
+export function WallpaperXRouteControl({ t, disabled, onSavingChange }: {
+  t: WallpaperSourceModalProps["t"];
+  disabled: boolean;
+  onSavingChange: (saving: boolean) => void;
+}) {
+  const [mode, setMode] = useState<Mode>("cli");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  useEffect(() => {
+    let active = true;
+    void api.settingsGet().then((settings) => {
+      if (active) setMode(settings.wallpaperXSearchMode === "responses_preview" ? "responses_preview" : "cli");
+    }).catch(() => { if (active) setError(true); }).finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  async function save(value: string) {
+    const next: Mode = value === "responses_preview" ? "responses_preview" : "cli";
+    setLoading(true);
+    onSavingChange(true);
+    setError(false);
+    try {
+      const current = await api.settingsGet();
+      await api.settingsSet({ ...current, wallpaperXSearchMode: next });
+      setMode(next);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+      onSavingChange(false);
+    }
+  }
+
+  return <div className="wallpaper-source-form">
+    <label>{t("settings.wallpaperXSearchMode")}</label>
+    <Select value={mode} disabled={disabled || loading}
+      aria-label={t("settings.wallpaperXSearchMode")}
+      options={[
+        { value: "cli", label: t("settings.wallpaperXSearchMode.cli") },
+        { value: "responses_preview", label: t("settings.wallpaperXSearchMode.responsesPreview") },
+      ]}
+      onChange={(value) => { void save(value); }} />
+    <p className="wallpaper-source-form__hint">{t("settings.wallpaperXSearchModeDesc")}</p>
+    {error ? <p role="alert">{t("settings.wallpaperSource.err.generic")}</p> : null}
+  </div>;
+}

--- a/src/i18n/messages/de/settings-ui.ts
+++ b/src/i18n/messages/de/settings-ui.ts
@@ -1,5 +1,19 @@
 /** de messages — domain: settings-ui */
 export const deSettingsUi = {
+  "settings.wallpaperXSearchMode": "X-Suchroute",
+  "settings.wallpaperXSearchModeDesc": "Legt fest, wie die Suche auf X ausgeführt wird. Die Responses-Vorschau verwendet die bestehende Grok-Build-Anmeldung am fest vorgegebenen offiziellen Kompatibilitätsendpunkt. Sie kann sich ändern und fällt, wenn sicher, auf die CLI zurück; bei Limits wird keine zweite Suche gestartet.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stabil)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (Vorschau)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
+  "settings.wallpaperSource.route.responses": "Responses-Vorschau · {seconds} s",
+  "settings.wallpaperSource.route.fallback": "Auf Grok Build CLI zurückgefallen ({reason}) · {seconds} s",
+  "settings.wallpaperSource.route.fallback.auth": "offizielle Anmeldung fehlt oder ist abgelaufen",
+  "settings.wallpaperSource.route.fallback.network": "Responses-Netzwerk nicht erreichbar",
+  "settings.wallpaperSource.route.fallback.compatibility": "Responses-Kompatibilität hat sich geändert",
+  "settings.wallpaperSource.route.fallback.empty": "Responses lieferte keine nutzbaren Bilder",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses nach wiederholten Fehlern vorübergehend pausiert",
+  "settings.wallpaperSource.route.fallback.other": "Responses-Vorschau nicht verfügbar",
+  "settings.wallpaperSource.err.rate_limited": "Die Responses API ist begrenzt. Um keine zweite Abonnementanfrage auszulösen, wurde nicht auf die CLI zurückgefallen. Bitte später erneut versuchen.",
   "settings.wallpaperSource.cancelSearch": "Suche abbrechen",
   "settings.wallpaperSource.progress.preparing": "Suche wird vorbereitet…",
   "settings.wallpaperSource.progress.validating": "Bildqualität wird geprüft…",
@@ -636,4 +650,5 @@ export const deSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "Kein ffmpeg auf diesem Computer, daher ist das geteilte Video die Originaldatei mit Zuschnitt und Clip. Das Aussehen bleibt gleich; das Paket ist nur größer. ffmpeg installieren, um einen zugeschnittenen Clip zu exportieren.",
   "settings.skinPack.warn.unknown_skin": "Dieses Paket nennt ein unbekanntes Skin. Standard wird verwendet.",
   "settings.skinPack.warn.will_clear_wallpaper": "Dieses Erscheinungsbild anzuwenden entfernt deinen aktuellen Hintergrund (einschließlich Video).",
+  "settings.wallpaperSource.progress.fallingBack": "Responses nicht verfügbar; Wechsel zu Grok Build CLI…",
 };

--- a/src/i18n/messages/en/settings-ui.ts
+++ b/src/i18n/messages/en/settings-ui.ts
@@ -1,5 +1,19 @@
 /** English messages — domain: settings-ui */
 export const enSettingsUi = {
+  "settings.wallpaperXSearchMode": "X search route",
+  "settings.wallpaperXSearchModeDesc": "Choose how Search on X runs. Responses preview uses your existing Grok Build sign-in with the fixed official compatibility endpoint. It may change and falls back to the CLI when safe; rate limits never start a second search.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stable)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (preview)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds}s",
+  "settings.wallpaperSource.route.responses": "Responses preview · {seconds}s",
+  "settings.wallpaperSource.route.fallback": "Fell back to Grok Build CLI ({reason}) · {seconds}s",
+  "settings.wallpaperSource.route.fallback.auth": "official sign-in unavailable or expired",
+  "settings.wallpaperSource.route.fallback.network": "Responses network unavailable",
+  "settings.wallpaperSource.route.fallback.compatibility": "Responses compatibility changed",
+  "settings.wallpaperSource.route.fallback.empty": "Responses returned no usable images",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses temporarily paused after repeated failures",
+  "settings.wallpaperSource.route.fallback.other": "Responses preview unavailable",
+  "settings.wallpaperSource.err.rate_limited": "Responses API is rate-limited. No CLI fallback was started, to avoid a second subscription request. Try again later.",
   "settings.wallpaperSource.cancelSearch": "Cancel search",
   "settings.wallpaperSource.progress.preparing": "Preparing search…",
   "settings.wallpaperSource.progress.validating": "Checking image quality…",
@@ -636,4 +650,5 @@ export const enSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "No ffmpeg on this computer, so the shared video is the original file with crop and clip kept. The look still matches; the pack is just larger. Install ffmpeg to export a cropped, trimmed clip.",
   "settings.skinPack.warn.unknown_skin": "This pack names an unknown skin. Default will be used.",
   "settings.skinPack.warn.will_clear_wallpaper": "Applying this look will remove your current background (including video).",
+  "settings.wallpaperSource.progress.fallingBack": "Responses unavailable; switching to Grok Build CLI…",
 } as const;

--- a/src/i18n/messages/es/settings-ui.ts
+++ b/src/i18n/messages/es/settings-ui.ts
@@ -1,5 +1,19 @@
 /** es messages — domain: settings-ui */
 export const esSettingsUi = {
+  "settings.wallpaperXSearchMode": "Ruta de búsqueda en X",
+  "settings.wallpaperXSearchModeDesc": "Elige cómo se ejecuta Buscar en X. La vista previa de Responses usa tu inicio de sesión actual de Grok Build con el endpoint oficial de compatibilidad fijado. Puede cambiar y vuelve a la CLI cuando es seguro; los límites no inician una segunda búsqueda.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (estable)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (vista previa)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
+  "settings.wallpaperSource.route.responses": "Vista previa de Responses · {seconds} s",
+  "settings.wallpaperSource.route.fallback": "Se usó Grok Build CLI como alternativa ({reason}) · {seconds} s",
+  "settings.wallpaperSource.route.fallback.auth": "inicio de sesión oficial no disponible o caducado",
+  "settings.wallpaperSource.route.fallback.network": "red de Responses no disponible",
+  "settings.wallpaperSource.route.fallback.compatibility": "cambió la compatibilidad de Responses",
+  "settings.wallpaperSource.route.fallback.empty": "Responses no devolvió imágenes utilizables",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses está en pausa tras varios fallos",
+  "settings.wallpaperSource.route.fallback.other": "vista previa de Responses no disponible",
+  "settings.wallpaperSource.err.rate_limited": "La Responses API alcanzó su límite. No se inició la alternativa por CLI para evitar una segunda solicitud de suscripción. Inténtalo más tarde.",
   "settings.wallpaperSource.cancelSearch": "Cancelar búsqueda",
   "settings.wallpaperSource.progress.preparing": "Preparando la búsqueda…",
   "settings.wallpaperSource.progress.validating": "Comprobando la calidad de las imágenes…",
@@ -636,4 +650,5 @@ export const esSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "No hay ffmpeg en este equipo, así que el vídeo compartido es el original con recorte y clip. El look coincide; el paquete solo es más grande. Instala ffmpeg para exportar un clip recortado.",
   "settings.skinPack.warn.unknown_skin": "Este paquete nombra un skin desconocido. Se usará el predeterminado.",
   "settings.skinPack.warn.will_clear_wallpaper": "Aplicar este look quitará tu fondo actual (incluido el vídeo).",
+  "settings.wallpaperSource.progress.fallingBack": "Responses no está disponible; cambiando a Grok Build CLI…",
 };

--- a/src/i18n/messages/fil/settings-ui.ts
+++ b/src/i18n/messages/fil/settings-ui.ts
@@ -1,5 +1,19 @@
 /** fil messages — domain: settings-ui */
 export const filSettingsUi = {
+  "settings.wallpaperXSearchMode": "Ruta ng paghahanap sa X",
+  "settings.wallpaperXSearchModeDesc": "Piliin kung paano tatakbo ang Search on X. Ginagamit ng Responses preview ang kasalukuyang Grok Build sign-in sa nakapirming opisyal na compatibility endpoint. Maaari itong magbago at babalik sa CLI kapag ligtas; hindi magsisimula ng ikalawang search kapag rate-limited.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stable)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (preview)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds}s",
+  "settings.wallpaperSource.route.responses": "Responses preview · {seconds}s",
+  "settings.wallpaperSource.route.fallback": "Bumalik sa Grok Build CLI ({reason}) · {seconds}s",
+  "settings.wallpaperSource.route.fallback.auth": "hindi available o paso ang opisyal na sign-in",
+  "settings.wallpaperSource.route.fallback.network": "hindi available ang Responses network",
+  "settings.wallpaperSource.route.fallback.compatibility": "nagbago ang compatibility ng Responses",
+  "settings.wallpaperSource.route.fallback.empty": "walang magagamit na larawang ibinalik ang Responses",
+  "settings.wallpaperSource.route.fallback.circuit": "pansamantalang naka-pause ang Responses matapos ang paulit-ulit na error",
+  "settings.wallpaperSource.route.fallback.other": "hindi available ang Responses preview",
+  "settings.wallpaperSource.err.rate_limited": "Na-rate-limit ang Responses API. Hindi nagsimula ang CLI fallback upang maiwasan ang ikalawang subscription request. Subukan muli mamaya.",
   "settings.wallpaperSource.cancelSearch": "Kanselahin ang paghahanap",
   "settings.wallpaperSource.progress.preparing": "Inihahanda ang paghahanap…",
   "settings.wallpaperSource.progress.validating": "Sinusuri ang kalidad ng larawan…",
@@ -636,4 +650,5 @@ export const filSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "Walang ffmpeg sa computer na ito, kaya ang ibinabahaging video ay ang orihinal na file na may crop at clip. Pareho pa rin ang hitsura; mas malaki lang ang pack. Mag-install ng ffmpeg para mag-export ng na-crop na clip.",
   "settings.skinPack.warn.unknown_skin": "May unknown skin ang pack na ito. Gagamitin ang default.",
   "settings.skinPack.warn.will_clear_wallpaper": "Ang pag-apply ng hitsurang ito ay mag-aalis ng kasalukuyan mong background (kasama ang video).",
+  "settings.wallpaperSource.progress.fallingBack": "Hindi available ang Responses; lilipat sa Grok Build CLI…",
 };

--- a/src/i18n/messages/fr/settings-ui.ts
+++ b/src/i18n/messages/fr/settings-ui.ts
@@ -1,5 +1,19 @@
 /** fr messages — domain: settings-ui */
 export const frSettingsUi = {
+  "settings.wallpaperXSearchMode": "Route de recherche X",
+  "settings.wallpaperXSearchModeDesc": "Choisissez comment la recherche sur X s’exécute. L’aperçu Responses utilise votre connexion Grok Build existante avec le point de compatibilité officiel fixe. Il peut évoluer et revient à la CLI lorsque c’est sûr ; une limitation ne lance jamais une seconde recherche.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stable)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (aperçu)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
+  "settings.wallpaperSource.route.responses": "Aperçu Responses · {seconds} s",
+  "settings.wallpaperSource.route.fallback": "Repli sur Grok Build CLI ({reason}) · {seconds} s",
+  "settings.wallpaperSource.route.fallback.auth": "connexion officielle indisponible ou expirée",
+  "settings.wallpaperSource.route.fallback.network": "réseau Responses indisponible",
+  "settings.wallpaperSource.route.fallback.compatibility": "compatibilité Responses modifiée",
+  "settings.wallpaperSource.route.fallback.empty": "Responses n’a renvoyé aucune image exploitable",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses temporairement suspendu après plusieurs échecs",
+  "settings.wallpaperSource.route.fallback.other": "aperçu Responses indisponible",
+  "settings.wallpaperSource.err.rate_limited": "La Responses API est limitée. Aucun repli CLI n’a été lancé afin d’éviter une seconde requête d’abonnement. Réessayez plus tard.",
   "settings.wallpaperSource.cancelSearch": "Annuler la recherche",
   "settings.wallpaperSource.progress.preparing": "Préparation de la recherche…",
   "settings.wallpaperSource.progress.validating": "Vérification de la qualité des images…",
@@ -636,4 +650,5 @@ export const frSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "Pas de ffmpeg sur cet ordinateur, donc la vidéo partagée est le fichier original avec recadrage et clip. Le rendu est le même ; le paquet est juste plus gros. Installez ffmpeg pour exporter un clip recadré.",
   "settings.skinPack.warn.unknown_skin": "Ce paquet nomme un skin inconnu. Le défaut sera utilisé.",
   "settings.skinPack.warn.will_clear_wallpaper": "Appliquer ce look supprimera votre fond actuel (y compris la vidéo).",
+  "settings.wallpaperSource.progress.fallingBack": "Responses indisponible ; passage à Grok Build CLI…",
 };

--- a/src/i18n/messages/id/settings-ui.ts
+++ b/src/i18n/messages/id/settings-ui.ts
@@ -1,5 +1,19 @@
 /** id messages — domain: settings-ui */
 export const idSettingsUi = {
+  "settings.wallpaperXSearchMode": "Rute pencarian X",
+  "settings.wallpaperXSearchModeDesc": "Pilih cara Pencarian di X dijalankan. Pratinjau Responses memakai login Grok Build yang ada pada endpoint kompatibilitas resmi yang tetap. Fitur ini dapat berubah dan kembali ke CLI jika aman; pembatasan tidak memulai pencarian kedua.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stabil)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (pratinjau)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} dtk",
+  "settings.wallpaperSource.route.responses": "Pratinjau Responses · {seconds} dtk",
+  "settings.wallpaperSource.route.fallback": "Beralih kembali ke Grok Build CLI ({reason}) · {seconds} dtk",
+  "settings.wallpaperSource.route.fallback.auth": "login resmi tidak tersedia atau kedaluwarsa",
+  "settings.wallpaperSource.route.fallback.network": "jaringan Responses tidak tersedia",
+  "settings.wallpaperSource.route.fallback.compatibility": "kompatibilitas Responses berubah",
+  "settings.wallpaperSource.route.fallback.empty": "Responses tidak memberi gambar yang dapat digunakan",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses dijeda sementara setelah kegagalan berulang",
+  "settings.wallpaperSource.route.fallback.other": "pratinjau Responses tidak tersedia",
+  "settings.wallpaperSource.err.rate_limited": "Responses API sedang dibatasi. Fallback CLI tidak dimulai agar tidak membuat permintaan langganan kedua. Coba lagi nanti.",
   "settings.wallpaperSource.cancelSearch": "Batalkan pencarian",
   "settings.wallpaperSource.progress.preparing": "Menyiapkan pencarian…",
   "settings.wallpaperSource.progress.validating": "Memeriksa kualitas gambar…",
@@ -636,4 +650,5 @@ export const idSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "Tidak ada ffmpeg di komputer ini, jadi video yang dibagikan adalah berkas asli dengan potongan dan klip. Tampilan tetap sama; paketnya hanya lebih besar. Pasang ffmpeg untuk mengekspor klip yang sudah dipotong.",
   "settings.skinPack.warn.unknown_skin": "Paket ini menamai skin yang tidak dikenal. Default akan dipakai.",
   "settings.skinPack.warn.will_clear_wallpaper": "Menerapkan tampilan ini akan menghapus latar belakang Anda saat ini (termasuk video).",
+  "settings.wallpaperSource.progress.fallingBack": "Responses tidak tersedia; beralih ke Grok Build CLI…",
 };

--- a/src/i18n/messages/it/settings-ui.ts
+++ b/src/i18n/messages/it/settings-ui.ts
@@ -1,5 +1,19 @@
 /** it messages — domain: settings-ui */
 export const itSettingsUi = {
+  "settings.wallpaperXSearchMode": "Percorso di ricerca X",
+  "settings.wallpaperXSearchModeDesc": "Scegli come eseguire la ricerca su X. L’anteprima Responses usa l’accesso Grok Build esistente con l’endpoint ufficiale di compatibilità fisso. Può cambiare e torna alla CLI quando è sicuro; i limiti non avviano una seconda ricerca.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (stabile)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (anteprima)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
+  "settings.wallpaperSource.route.responses": "Anteprima Responses · {seconds} s",
+  "settings.wallpaperSource.route.fallback": "Ripiego su Grok Build CLI ({reason}) · {seconds} s",
+  "settings.wallpaperSource.route.fallback.auth": "accesso ufficiale non disponibile o scaduto",
+  "settings.wallpaperSource.route.fallback.network": "rete Responses non disponibile",
+  "settings.wallpaperSource.route.fallback.compatibility": "compatibilità Responses cambiata",
+  "settings.wallpaperSource.route.fallback.empty": "Responses non ha restituito immagini utilizzabili",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses sospeso temporaneamente dopo errori ripetuti",
+  "settings.wallpaperSource.route.fallback.other": "anteprima Responses non disponibile",
+  "settings.wallpaperSource.err.rate_limited": "La Responses API è soggetta a limite. Non è stato avviato il ripiego CLI per evitare una seconda richiesta all’abbonamento. Riprova più tardi.",
   "settings.wallpaperSource.cancelSearch": "Annulla ricerca",
   "settings.wallpaperSource.progress.preparing": "Preparazione della ricerca…",
   "settings.wallpaperSource.progress.validating": "Verifica della qualità delle immagini…",
@@ -636,4 +650,5 @@ export const itSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "Nessun ffmpeg su questo computer, quindi il video condiviso è il file originale con ritaglio e clip. Il look è uguale; il pacchetto è solo più grande. Installa ffmpeg per esportare un clip ritagliato.",
   "settings.skinPack.warn.unknown_skin": "Questo pacchetto indica uno skin sconosciuto. Verrà usato quello predefinito.",
   "settings.skinPack.warn.will_clear_wallpaper": "Applicare questo look rimuoverà lo sfondo attuale (incluso il video).",
+  "settings.wallpaperSource.progress.fallingBack": "Responses non disponibile; passaggio a Grok Build CLI…",
 };

--- a/src/i18n/messages/ja/settings-ui.ts
+++ b/src/i18n/messages/ja/settings-ui.ts
@@ -1,5 +1,19 @@
 /** ja messages — domain: settings-ui */
 export const jaSettingsUi = {
+  "settings.wallpaperXSearchMode": "X 検索ルート",
+  "settings.wallpaperXSearchModeDesc": "X 検索の実行方法を選びます。Responses プレビューは、既存の Grok Build ログインを固定の公式互換エンドポイントで使用します。仕様は変更される可能性があり、安全な場合は CLI にフォールバックします。レート制限時に 2 回目の検索は行いません。",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI（安定版）",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API（プレビュー）",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI・{seconds}秒",
+  "settings.wallpaperSource.route.responses": "Responses プレビュー・{seconds}秒",
+  "settings.wallpaperSource.route.fallback": "Grok Build CLI に切り替えました（{reason}）・{seconds}秒",
+  "settings.wallpaperSource.route.fallback.auth": "公式ログインが利用できないか期限切れ",
+  "settings.wallpaperSource.route.fallback.network": "Responses のネットワークを利用不可",
+  "settings.wallpaperSource.route.fallback.compatibility": "Responses の互換性が変更された",
+  "settings.wallpaperSource.route.fallback.empty": "Responses に利用可能な画像がない",
+  "settings.wallpaperSource.route.fallback.circuit": "繰り返し失敗したため Responses を一時停止中",
+  "settings.wallpaperSource.route.fallback.other": "Responses プレビューを利用不可",
+  "settings.wallpaperSource.err.rate_limited": "Responses API がレート制限されています。サブスクリプションへの 2 回目のリクエストを避けるため、CLI フォールバックは開始していません。後でもう一度お試しください。",
   "settings.wallpaperSource.cancelSearch": "検索をキャンセル",
   "settings.wallpaperSource.progress.preparing": "検索を準備中…",
   "settings.wallpaperSource.progress.validating": "画像品質を確認中…",
@@ -636,4 +650,5 @@ export const jaSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "このコンピュータに ffmpeg がないため、共有される動画は元ファイルのまま（トリミングとクリップ付き）です。見た目は同じで、パックが大きいだけです。切り出したクリップを書き出すには ffmpeg を入れてください。",
   "settings.skinPack.warn.unknown_skin": "このパックは未知のスキンを指定しています。デフォルトを使います。",
   "settings.skinPack.warn.will_clear_wallpaper": "この見た目を適用すると、現在の背景（動画を含む）が削除されます。",
+  "settings.wallpaperSource.progress.fallingBack": "Responses を利用できないため Grok Build CLI に切り替え中…",
 };

--- a/src/i18n/messages/ko/settings-ui.ts
+++ b/src/i18n/messages/ko/settings-ui.ts
@@ -1,5 +1,19 @@
 /** ko messages — domain: settings-ui */
 export const koSettingsUi = {
+  "settings.wallpaperXSearchMode": "X 검색 경로",
+  "settings.wallpaperXSearchModeDesc": "X 검색 실행 방식을 선택합니다. Responses 미리보기는 기존 Grok Build 로그인을 고정된 공식 호환 엔드포인트에서 사용합니다. 동작이 바뀔 수 있으며 안전할 때 CLI로 대체합니다. 요청 제한 시 두 번째 검색은 시작하지 않습니다.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI(안정)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API(미리보기)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds}초",
+  "settings.wallpaperSource.route.responses": "Responses 미리보기 · {seconds}초",
+  "settings.wallpaperSource.route.fallback": "Grok Build CLI로 대체됨({reason}) · {seconds}초",
+  "settings.wallpaperSource.route.fallback.auth": "공식 로그인을 사용할 수 없거나 만료됨",
+  "settings.wallpaperSource.route.fallback.network": "Responses 네트워크를 사용할 수 없음",
+  "settings.wallpaperSource.route.fallback.compatibility": "Responses 호환성이 변경됨",
+  "settings.wallpaperSource.route.fallback.empty": "Responses가 사용 가능한 이미지를 반환하지 않음",
+  "settings.wallpaperSource.route.fallback.circuit": "반복 실패로 Responses가 일시 중지됨",
+  "settings.wallpaperSource.route.fallback.other": "Responses 미리보기를 사용할 수 없음",
+  "settings.wallpaperSource.err.rate_limited": "Responses API가 요청 제한 상태입니다. 구독에 두 번째 요청을 보내지 않도록 CLI 대체 검색은 시작하지 않았습니다. 나중에 다시 시도하세요.",
   "settings.wallpaperSource.cancelSearch": "검색 취소",
   "settings.wallpaperSource.progress.preparing": "검색 준비 중…",
   "settings.wallpaperSource.progress.validating": "이미지 품질 확인 중…",
@@ -636,4 +650,5 @@ export const koSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "이 컴퓨터에 ffmpeg가 없어 공유 동영상은 자르기/클립이 남은 원본입니다. 모습은 같고 팩만 더 큽니다. 자른 클립을 내보내려면 ffmpeg를 설치하세요.",
   "settings.skinPack.warn.unknown_skin": "이 팩은 알 수 없는 스킨을 지정합니다. 기본값이 사용됩니다.",
   "settings.skinPack.warn.will_clear_wallpaper": "이 모습을 적용하면 현재 배경(동영상 포함)이 제거됩니다.",
+  "settings.wallpaperSource.progress.fallingBack": "Responses를 사용할 수 없어 Grok Build CLI로 전환 중…",
 };

--- a/src/i18n/messages/pt-BR/settings-ui.ts
+++ b/src/i18n/messages/pt-BR/settings-ui.ts
@@ -1,5 +1,19 @@
 /** pt-BR messages — domain: settings-ui */
 export const ptBRSettingsUi = {
+  "settings.wallpaperXSearchMode": "Rota de pesquisa no X",
+  "settings.wallpaperXSearchModeDesc": "Escolha como a Pesquisa no X é executada. A prévia de Responses usa seu login atual do Grok Build no endpoint oficial de compatibilidade fixo. Ela pode mudar e recorre à CLI quando for seguro; limites não iniciam uma segunda pesquisa.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (estável)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (prévia)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
+  "settings.wallpaperSource.route.responses": "Prévia de Responses · {seconds} s",
+  "settings.wallpaperSource.route.fallback": "Retorno ao Grok Build CLI ({reason}) · {seconds} s",
+  "settings.wallpaperSource.route.fallback.auth": "login oficial indisponível ou expirado",
+  "settings.wallpaperSource.route.fallback.network": "rede de Responses indisponível",
+  "settings.wallpaperSource.route.fallback.compatibility": "compatibilidade de Responses alterada",
+  "settings.wallpaperSource.route.fallback.empty": "Responses não retornou imagens utilizáveis",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses pausado temporariamente após falhas repetidas",
+  "settings.wallpaperSource.route.fallback.other": "prévia de Responses indisponível",
+  "settings.wallpaperSource.err.rate_limited": "A Responses API atingiu o limite. O retorno à CLI não foi iniciado para evitar uma segunda solicitação da assinatura. Tente novamente mais tarde.",
   "settings.wallpaperSource.cancelSearch": "Cancelar busca",
   "settings.wallpaperSource.progress.preparing": "Preparando a busca…",
   "settings.wallpaperSource.progress.validating": "Verificando a qualidade das imagens…",
@@ -636,4 +650,5 @@ export const ptBRSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "Não há ffmpeg neste computador, então o vídeo compartilhado é o original com recorte e clipe. O visual é o mesmo; o pacote só fica maior. Instale ffmpeg para exportar um clipe recortado.",
   "settings.skinPack.warn.unknown_skin": "Este pacote nomeia um skin desconhecido. O padrão será usado.",
   "settings.skinPack.warn.will_clear_wallpaper": "Aplicar este visual removerá seu fundo atual (incluindo vídeo).",
+  "settings.wallpaperSource.progress.fallingBack": "Responses indisponível; mudando para o Grok Build CLI…",
 };

--- a/src/i18n/messages/ru/settings-ui.ts
+++ b/src/i18n/messages/ru/settings-ui.ts
@@ -1,5 +1,19 @@
 /** ru messages — domain: settings-ui */
 export const ruSettingsUi = {
+  "settings.wallpaperXSearchMode": "Маршрут поиска в X",
+  "settings.wallpaperXSearchModeDesc": "Выберите способ поиска в X. Предпросмотр Responses использует текущий вход Grok Build и фиксированный официальный endpoint совместимости. Интерфейс может измениться и при безопасной возможности откатывается к CLI; при лимите второй поиск не запускается.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (стабильный)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (предпросмотр)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} с",
+  "settings.wallpaperSource.route.responses": "Предпросмотр Responses · {seconds} с",
+  "settings.wallpaperSource.route.fallback": "Выполнен откат к Grok Build CLI ({reason}) · {seconds} с",
+  "settings.wallpaperSource.route.fallback.auth": "официальный вход недоступен или истёк",
+  "settings.wallpaperSource.route.fallback.network": "сеть Responses недоступна",
+  "settings.wallpaperSource.route.fallback.compatibility": "совместимость Responses изменилась",
+  "settings.wallpaperSource.route.fallback.empty": "Responses не вернул подходящих изображений",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses временно приостановлен после повторных ошибок",
+  "settings.wallpaperSource.route.fallback.other": "предпросмотр Responses недоступен",
+  "settings.wallpaperSource.err.rate_limited": "Responses API ограничен по частоте. Откат к CLI не запускался, чтобы избежать второго запроса по подписке. Повторите позже.",
   "settings.wallpaperSource.cancelSearch": "Отменить поиск",
   "settings.wallpaperSource.progress.preparing": "Подготовка поиска…",
   "settings.wallpaperSource.progress.validating": "Проверка качества изображений…",
@@ -636,4 +650,5 @@ export const ruSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "На этом компьютере нет ffmpeg, поэтому общее видео — исходный файл с кадрированием и клипом. Вид тот же; пакет просто больше. Установите ffmpeg, чтобы экспортировать обрезанный клип.",
   "settings.skinPack.warn.unknown_skin": "Этот пакет указывает неизвестный скин. Будет использован скин по умолчанию.",
   "settings.skinPack.warn.will_clear_wallpaper": "Применение этого вида удалит текущий фон (включая видео).",
+  "settings.wallpaperSource.progress.fallingBack": "Responses недоступен; переключение на Grok Build CLI…",
 };

--- a/src/i18n/messages/ta/settings-ui.ts
+++ b/src/i18n/messages/ta/settings-ui.ts
@@ -1,5 +1,19 @@
 /** ta messages — domain: settings-ui */
 export const taSettingsUi = {
+  "settings.wallpaperXSearchMode": "X தேடல் வழி",
+  "settings.wallpaperXSearchModeDesc": "X தேடல் எவ்வாறு இயங்க வேண்டும் என்பதைத் தேர்ந்தெடுக்கவும். Responses முன்னோட்டம் உங்கள் தற்போதைய Grok Build உள்நுழைவை நிலையான அதிகாரப்பூர்வ இணக்க endpoint உடன் பயன்படுத்துகிறது. இது மாறக்கூடும்; பாதுகாப்பானபோது CLI-க்கு மாறும். வரம்பு ஏற்பட்டால் இரண்டாவது தேடல் தொடங்காது.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (நிலையானது)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (முன்னோட்டம்)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} வி",
+  "settings.wallpaperSource.route.responses": "Responses முன்னோட்டம் · {seconds} வி",
+  "settings.wallpaperSource.route.fallback": "Grok Build CLI-க்கு மாற்றப்பட்டது ({reason}) · {seconds} வி",
+  "settings.wallpaperSource.route.fallback.auth": "அதிகாரப்பூர்வ உள்நுழைவு கிடைக்கவில்லை அல்லது காலாவதியானது",
+  "settings.wallpaperSource.route.fallback.network": "Responses பிணையம் கிடைக்கவில்லை",
+  "settings.wallpaperSource.route.fallback.compatibility": "Responses இணக்கத்தன்மை மாறியுள்ளது",
+  "settings.wallpaperSource.route.fallback.empty": "Responses பயன்படுத்தக்கூடிய படங்களை வழங்கவில்லை",
+  "settings.wallpaperSource.route.fallback.circuit": "தொடர் தோல்விகளுக்குப் பிறகு Responses தற்காலிகமாக இடைநிறுத்தப்பட்டது",
+  "settings.wallpaperSource.route.fallback.other": "Responses முன்னோட்டம் கிடைக்கவில்லை",
+  "settings.wallpaperSource.err.rate_limited": "Responses API கோரிக்கை வரம்பை எட்டியுள்ளது. சந்தாவுக்கு இரண்டாவது கோரிக்கை செல்லாமல் இருக்க CLI மாற்றுத் தேடல் தொடங்கப்படவில்லை. பின்னர் மீண்டும் முயலவும்.",
   "settings.wallpaperSource.cancelSearch": "தேடலை ரத்துசெய்",
   "settings.wallpaperSource.progress.preparing": "தேடல் தயாராகிறது…",
   "settings.wallpaperSource.progress.validating": "படத் தரம் சரிபார்க்கப்படுகிறது…",
@@ -636,4 +650,5 @@ export const taSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "இந்தக் கணினியில் ffmpeg இல்லை, எனவே பகிரப்படும் வீடியோ அசல் கோப்பே (வெட்டு/கிளிப்புடன்). தோற்றம் ஒன்றே; பொதி மட்டும் பெரியது. வெட்டிய கிளிப்பை ஏற்றுமதி செய்ய ffmpeg நிறுவவும்.",
   "settings.skinPack.warn.unknown_skin": "இந்தப் பொதி தெரியாத ஸ்கினைக் குறிக்கிறது. இயல்புநிலை பயன்படுத்தப்படும்.",
   "settings.skinPack.warn.will_clear_wallpaper": "இந்தத் தோற்றத்தைப் பயன்படுத்தினால் தற்போதைய பின்னணி (வீடியோ உட்பட) அகற்றப்படும்.",
+  "settings.wallpaperSource.progress.fallingBack": "Responses கிடைக்கவில்லை; Grok Build CLI-க்கு மாறுகிறது…",
 };

--- a/src/i18n/messages/uk/settings-ui.ts
+++ b/src/i18n/messages/uk/settings-ui.ts
@@ -1,5 +1,19 @@
 /** uk messages — domain: settings-ui */
 export const ukSettingsUi = {
+  "settings.wallpaperXSearchMode": "Маршрут пошуку в X",
+  "settings.wallpaperXSearchModeDesc": "Виберіть спосіб пошуку в X. Попередній перегляд Responses використовує чинний вхід Grok Build і фіксований офіційний endpoint сумісності. Інтерфейс може змінитися й безпечно повертається до CLI; за обмеження запитів другий пошук не запускається.",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI (стабільний)",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API (перегляд)",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} с",
+  "settings.wallpaperSource.route.responses": "Перегляд Responses · {seconds} с",
+  "settings.wallpaperSource.route.fallback": "Перехід до Grok Build CLI ({reason}) · {seconds} с",
+  "settings.wallpaperSource.route.fallback.auth": "офіційний вхід недоступний або прострочений",
+  "settings.wallpaperSource.route.fallback.network": "мережа Responses недоступна",
+  "settings.wallpaperSource.route.fallback.compatibility": "сумісність Responses змінилася",
+  "settings.wallpaperSource.route.fallback.empty": "Responses не повернув придатних зображень",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses тимчасово призупинено після повторних збоїв",
+  "settings.wallpaperSource.route.fallback.other": "перегляд Responses недоступний",
+  "settings.wallpaperSource.err.rate_limited": "Responses API обмежено за частотою. Перехід до CLI не запускався, щоб уникнути другого запиту за підпискою. Спробуйте пізніше.",
   "settings.wallpaperSource.cancelSearch": "Скасувати пошук",
   "settings.wallpaperSource.progress.preparing": "Підготовка пошуку…",
   "settings.wallpaperSource.progress.validating": "Перевірка якості зображень…",
@@ -636,4 +650,5 @@ export const ukSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "На цьому комп’ютері немає ffmpeg, тож поширене відео — оригінальний файл із кадруванням і кліпом. Вигляд той самий; пакет лише більший. Встановіть ffmpeg, щоб експортувати обрізаний кліп.",
   "settings.skinPack.warn.unknown_skin": "Цей пакет вказує невідомий скін. Буде використано типовий.",
   "settings.skinPack.warn.will_clear_wallpaper": "Застосування цього вигляду видалить ваш поточний фон (включно з відео).",
+  "settings.wallpaperSource.progress.fallingBack": "Responses недоступний; перемикання на Grok Build CLI…",
 };

--- a/src/i18n/messages/zh-TW/settings-ui.ts
+++ b/src/i18n/messages/zh-TW/settings-ui.ts
@@ -1,5 +1,19 @@
 /** Traditional Chinese messages — domain: settings-ui */
 export const zhTWSettingsUi = {
+  "settings.wallpaperXSearchMode": "X 搜尋管道",
+  "settings.wallpaperXSearchModeDesc": "選擇「從 X 搜尋」的執行方式。Responses 預覽會使用現有 Grok Build 登入，並固定請求官方相容端點；介面可能變更，條件允許時會安全退回 CLI。遇到限流時不會再發起第二次搜尋。",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI（穩定）",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API（預覽）",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} 秒",
+  "settings.wallpaperSource.route.responses": "Responses 預覽 · {seconds} 秒",
+  "settings.wallpaperSource.route.fallback": "已退回 Grok Build CLI（{reason}）· {seconds} 秒",
+  "settings.wallpaperSource.route.fallback.auth": "官方登入無法使用或已過期",
+  "settings.wallpaperSource.route.fallback.network": "Responses 網路無法使用",
+  "settings.wallpaperSource.route.fallback.compatibility": "Responses 相容協定已變更",
+  "settings.wallpaperSource.route.fallback.empty": "Responses 未傳回可用圖片",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses 連續失敗後已暫時停用",
+  "settings.wallpaperSource.route.fallback.other": "Responses 預覽無法使用",
+  "settings.wallpaperSource.err.rate_limited": "Responses API 目前受到限流。為避免對同一訂閱再次發出請求，本次不會退回 CLI，請稍後再試。",
   "settings.wallpaperSource.cancelSearch": "取消搜尋",
   "settings.wallpaperSource.progress.preparing": "正在準備搜尋…",
   "settings.wallpaperSource.progress.validating": "正在檢查圖片品質…",
@@ -636,4 +650,5 @@ export const zhTWSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "這台電腦沒有 ffmpeg，所以分享的是原影片，並保留裁切和片段參數。畫面效果不變，只是檔案較大。裝上 ffmpeg 後即可匯出裁好的小體積片段。",
   "settings.skinPack.warn.unknown_skin": "這個包指定了未知皮膚，將使用預設皮膚。",
   "settings.skinPack.warn.will_clear_wallpaper": "套用後將移除你目前的背景（含影片）。",
+  "settings.wallpaperSource.progress.fallingBack": "Responses 無法使用，正在切換到 Grok Build CLI…",
 };

--- a/src/i18n/messages/zh/settings-ui.ts
+++ b/src/i18n/messages/zh/settings-ui.ts
@@ -1,5 +1,19 @@
 /** Simplified Chinese messages — domain: settings-ui */
 export const zhSettingsUi = {
+  "settings.wallpaperXSearchMode": "X 搜索渠道",
+  "settings.wallpaperXSearchModeDesc": "选择“从 X 搜索”的执行方式。Responses 预览会使用现有 Grok Build 登录，并固定请求官方兼容端点；接口可能变化，条件允许时会安全回退 CLI。遇到限流时不会再发起第二次搜索。",
+  "settings.wallpaperXSearchMode.cli": "Grok Build CLI（稳定）",
+  "settings.wallpaperXSearchMode.responsesPreview": "Responses API（预览）",
+  "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} 秒",
+  "settings.wallpaperSource.route.responses": "Responses 预览 · {seconds} 秒",
+  "settings.wallpaperSource.route.fallback": "已回退 Grok Build CLI（{reason}）· {seconds} 秒",
+  "settings.wallpaperSource.route.fallback.auth": "官方登录不可用或已过期",
+  "settings.wallpaperSource.route.fallback.network": "Responses 网络不可用",
+  "settings.wallpaperSource.route.fallback.compatibility": "Responses 兼容协议已变化",
+  "settings.wallpaperSource.route.fallback.empty": "Responses 未返回可用图片",
+  "settings.wallpaperSource.route.fallback.circuit": "Responses 连续失败后已暂时停用",
+  "settings.wallpaperSource.route.fallback.other": "Responses 预览不可用",
+  "settings.wallpaperSource.err.rate_limited": "Responses API 当前限流。为避免对同一订阅再次发起请求，本次不会回退 CLI，请稍后重试。",
   "settings.wallpaperSource.cancelSearch": "取消搜索",
   "settings.wallpaperSource.progress.preparing": "正在准备搜索…",
   "settings.wallpaperSource.progress.validating": "正在检查图片质量…",
@@ -636,4 +650,5 @@ export const zhSettingsUi = {
   "settings.skinPack.warn.ffmpeg_unavailable": "这台电脑没有 ffmpeg，所以分享的是原视频，并保留裁切和片段参数。画面效果不变，只是文件更大。装上 ffmpeg 后即可导出裁好的小体积片段。",
   "settings.skinPack.warn.unknown_skin": "这个包指定了未知皮肤，将使用默认皮肤。",
   "settings.skinPack.warn.will_clear_wallpaper": "应用后将移除你当前的背景（含视频）。",
+  "settings.wallpaperSource.progress.fallingBack": "Responses 不可用，正在切换到 Grok Build CLI…",
 };

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -8,6 +8,7 @@ import {
 export type ComposerPrefsScope = "global" | "project" | "session";
 
 export interface AppSettings {
+  wallpaperXSearchMode?: string;
   theme: string;
   locale: string;
   sessionDataMode: string;

--- a/src/lib/settingsCatalog/entries/appearance.ts
+++ b/src/lib/settingsCatalog/entries/appearance.ts
@@ -84,6 +84,9 @@ export const APPEARANCE_ENTRIES: readonly SettingsEntry[] = [
       "settings.wallpaperBlurDesc",
       "settings.wallpaperBlurMacHint",
       "settings.wallpaperFromX",
+      "settings.wallpaperXSearchMode",
+      "settings.wallpaperXSearchModeDesc",
+      "settings.wallpaperXSearchMode.responsesPreview",
       "settings.wallpaperImagine",
     ],
     keywords: [

--- a/src/lib/wallpaperSource.ts
+++ b/src/lib/wallpaperSource.ts
@@ -21,6 +21,12 @@ export type WallpaperGalleryItem = {
 };
 
 export type WallpaperSearchResult = {
+  meta?: {
+    requestId?: string | null;
+    routeUsed: "cli" | "responses";
+    fallbackReason?: string | null;
+    durationMs: number;
+  } | null;
   items: WallpaperGalleryItem[];
   errorCode?: string | null;
   message?: string | null;
@@ -43,6 +49,7 @@ export type WallpaperLibraryEntry = {
 };
 
 export type WallpaperSourceErrorCode =
+  | "rate_limited"
   | "auth_required"
   | "cli_missing"
   | "search_failed"
@@ -64,6 +71,7 @@ export function parseWallpaperSourceError(err: unknown): WallpaperSourceErrorCod
           ? String((err as { message: unknown }).message)
           : "";
   const s = raw.toLowerCase();
+  if (s.includes("rate_limited")) return "rate_limited";
   if (s.includes("auth_required")) return "auth_required";
   if (s.includes("cli_missing")) return "cli_missing";
   if (
@@ -109,6 +117,7 @@ export function errorCodeFromSearchResult(
   if (code === "imagine_failed") return "imagine_failed";
   if (code === "empty") return "empty";
   if (code === "timeout") return "timeout";
+  if (code.includes("rate_limited")) return "rate_limited";
   return "generic";
 }
 

--- a/src/lib/wallpaperXSearch.ts
+++ b/src/lib/wallpaperXSearch.ts
@@ -3,6 +3,7 @@ export type WallpaperXSearchStage =
   | "searching_x"
   | "validating"
   | "supplementing"
+  | "falling_back"
   | "done";
 
 export type WallpaperXSearchProgress = {
@@ -19,5 +20,5 @@ export function isWallpaperXSearchProgress(value: unknown): value is WallpaperXS
   const event = value as Record<string, unknown>;
   return typeof event.requestId === "string" && event.requestId.length > 0 &&
     typeof event.stage === "string" &&
-    ["preparing", "searching_x", "validating", "supplementing", "done"].includes(event.stage);
+    ["preparing", "searching_x", "validating", "supplementing", "falling_back", "done"].includes(event.stage);
 }


### PR DESCRIPTION
## Summary

为 X 壁纸搜索增加显式启用的 Responses API 预览路线。默认仍为 Grok Build CLI；在搜索弹窗选择预览并保存后，使用已有官方登录向固定 Build 兼容接口请求，显示实际路线、回退原因和总耗时。

- Host 独立读取官方凭据：当前作用域优先、校验 issuer/client/有效期、凭据内容变化重置熔断；token 不经 IPC、不记录到日志，不接受前端传入地址/模型/工具。
- 固定 grok-4.6、low、x_search、store=false；禁止 bearer 重定向，响应体有界读取，要求已完成的 X 工具调用，候选仍经过现有图片质量校验。
- 首轮最多两次 X 调用，不足时一次补搜。允许的错误回退 CLI 一次；限流、取消、工具预算超限不触发第二条路线。三次计入失败后熔断十分钟，凭据变化重置。
- 设置成功保存后才切换 UI，保存期间禁止搜索；保存失败保留旧值。入口与说明补齐 15 语言并注册外观设置检索。

已 rebase 到最新 upstream/main（a248f395，含 #1084/#1085/#1087），移除全部已合入前置差异。当前独立差异 33 文件 +2775/-12，其中凭据/客户端测试约占一半，翻译 225 行。保留上游 Controls/Gallery/Footer 拆分，通过控件插槽接入路线设置。本批不包含三路返回、加载更多和预取，它们作为后续主题交付。

已搜索开放/关闭的 Responses wallpaper、wallpaper API Issue，没有直接对应项，不添加自动关闭引用。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Validation

最终 7,072 项前端测试、1,678 项 Rust 测试通过（另 1 项原有 ignored）。typecheck、lint、UI build、Rust fmt/clippy、质量门禁、网站 self-test 与依赖检查/审计均通过。Windows 全量测试 harness 按仓库 CI 嵌入 Common Controls manifest 执行。

本次 rebase 的 Rust 树与上一验证版本完全一致；前端重新通过 typecheck、7 项相关回归、lint、UI build 和质量门禁。新功能与设置 IA 保持 UI hold，等待维护者审核。

覆盖固定请求参数、认证/超时/重定向、完成工具证据、输出格式/预算、HTTP 取消、默认路线、限流禁止回退、网络回退次数、凭据变化重置熔断及设置保存失败。未对本拆分分支执行真实账号端到端或手动桌面验收；兼容接口可变化，不把自动测试等同线上可用性或账号风险保证。

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
