### PR TITLE
feat(wallpaper): 并发搜索并逐批展示已校验图片

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -38,8 +38,18 @@ is attempted by wallpaper search.
 
 The client reads bounded response bodies and requires completed X tool-call
 evidence before accepting gallery JSON. The existing image quality pipeline
-validates the candidates. The first request permits two tool calls; an optional
-supplement permits one. This single-route slice is not the later parallel mode.
+validates the candidates. Responses runs three concurrent lanes sharing one OAuth
+read and HTTP client. Each lane targets eight images and permits at most three X
+tool calls (nine across the request). Direct, visual variation and discovery
+prompts diversify results. Each validated lane emits a request-scoped batch;
+results are deduplicated and ranked to at most 24 images. A failed lane preserves
+useful results from the other lanes. If all fail, rate/budget errors take priority
+to prevent an additional CLI request. Cancellation drops all pending lanes.
+
+The picker displays batches as they arrive; the final invoke result is authoritative.
+The hook rejects malformed, duplicate and foreign-request batches and clears them
+on replacement/cancel. Batch event failure cannot prevent the final result from
+showing. Load-more, caching and prefetch are separate follow-up slices.
 
 Eligible failures fall back once to CLI. Rate limits, cancellation and tool-budget
 violations never trigger a second route. Three counted failures open a ten-minute
@@ -57,7 +67,7 @@ registry cleanup, waiter wakeup, and cancellation of a synthetic CLI process.
   validated images remain, one supplementary round requests one further call
   and includes already-seen references. These are prompt budgets, not a promise
   that the model performs exactly that many calls or returns a fixed count.
-- Each round retains at most 40 candidates; the ranked gallery returns at most
+- Each CLI round retains at most 40 candidates; the ranked CLI gallery returns at most
   16 images. Supplement failure preserves usable first-round results.
 - Image probes read at most 64 KiB of response data, including when the server
   ignores Range. Signatures and declared MIME must agree; HTML/error responses

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -166,26 +166,41 @@ pub(crate) enum WallpaperXSearchStage {
     Done,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct WallpaperXSearchBatch {
+    pub(crate) batch_index: usize,
+    pub(crate) items: Vec<WallpaperGalleryItem>,
+    pub(crate) accumulated_count: usize,
+    pub(crate) done: bool,
+}
+
 #[derive(Clone)]
 pub(crate) struct WallpaperXSearchRuntime {
     cancellation: WallpaperSearchCancellation,
     progress: Arc<dyn Fn(WallpaperXSearchStage) + Send + Sync>,
+    batch: Arc<dyn Fn(WallpaperXSearchBatch) + Send + Sync>,
 }
 
 impl WallpaperXSearchRuntime {
     pub(crate) fn new(
         cancellation: WallpaperSearchCancellation,
         progress: Arc<dyn Fn(WallpaperXSearchStage) + Send + Sync>,
+        batch: Arc<dyn Fn(WallpaperXSearchBatch) + Send + Sync>,
     ) -> Self {
         Self {
             cancellation,
             progress,
+            batch,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn quiet() -> Self {
-        Self::new(WallpaperSearchCancellation::default(), Arc::new(|_| {}))
+        Self::new(
+            WallpaperSearchCancellation::default(),
+            Arc::new(|_| {}),
+            Arc::new(|_| {}),
+        )
     }
 
     pub(crate) fn cancellation(&self) -> &WallpaperSearchCancellation {
@@ -199,6 +214,12 @@ impl WallpaperXSearchRuntime {
     pub(crate) fn report(&self, stage: WallpaperXSearchStage) {
         if !self.is_cancelled() || stage == WallpaperXSearchStage::Done {
             (self.progress)(stage);
+        }
+    }
+
+    pub(crate) fn report_batch(&self, batch: WallpaperXSearchBatch) {
+        if !self.is_cancelled() {
+            (self.batch)(batch);
         }
     }
 }
@@ -1781,10 +1802,38 @@ fn gallery_rank_score(item: &WallpaperGalleryItem) -> i64 {
 pub(crate) fn merge_rank_x_gallery_items(
     items: Vec<WallpaperGalleryItem>,
 ) -> Vec<WallpaperGalleryItem> {
+    merge_rank_x_gallery_items_with_limit(items, MAX_X_GALLERY_RESULTS)
+}
+
+pub(crate) fn merge_rank_x_gallery_items_with_limit(
+    items: Vec<WallpaperGalleryItem>,
+    max_results: usize,
+) -> Vec<WallpaperGalleryItem> {
     let mut items = dedupe_gallery_items(items, true);
     items.sort_by_key(|item| std::cmp::Reverse(gallery_rank_score(item)));
-    items.truncate(MAX_X_GALLERY_RESULTS);
+    items.truncate(max_results.min(MAX_X_GALLERY_CANDIDATES));
     items
+}
+
+pub(crate) fn x_gallery_new_items(
+    previous: &[WallpaperGalleryItem],
+    current: &[WallpaperGalleryItem],
+) -> Vec<WallpaperGalleryItem> {
+    current
+        .iter()
+        .filter(|candidate| {
+            let media_key = normalized_media_identity(&candidate.full_url);
+            let status_key = status_media_identity(candidate);
+            !previous.iter().any(|existing| {
+                let same_media = media_key.is_some()
+                    && normalized_media_identity(&existing.full_url) == media_key;
+                let same_status =
+                    status_key.is_some() && status_media_identity(existing) == status_key;
+                same_media || same_status
+            })
+        })
+        .cloned()
+        .collect()
 }
 
 pub(crate) fn x_gallery_needs_supplement(valid_count: usize) -> bool {
@@ -2704,7 +2753,8 @@ mod tests {
             .unwrap_err(),
             "cancelled"
         );
-        let runtime = WallpaperXSearchRuntime::new(cancellation, Arc::new(|_| {}));
+        let runtime =
+            WallpaperXSearchRuntime::new(cancellation, Arc::new(|_| {}), Arc::new(|_| {}));
         let result = x_search_cli_outcome("sky", None, Some(&runtime)).await;
         assert_eq!(result.result.error_code.as_deref(), Some("cancelled"));
     }

--- a/src-tauri/src/wallpaper_x_responses.rs
+++ b/src-tauri/src/wallpaper_x_responses.rs
@@ -2,9 +2,10 @@
 //! endpoint. This module is Host-internal until the wallpaper search router
 //! explicitly opts into it.
 
-use std::error::Error as _;
+use std::future::Future;
 use std::time::Duration;
 
+use futures_util::stream::{FuturesUnordered, StreamExt};
 use reqwest::StatusCode;
 use serde_json::{json, Value};
 
@@ -13,19 +14,21 @@ use crate::account::{
 };
 use crate::proxy;
 use crate::wallpaper_source::{
-    filter_reachable_gallery_items_cancellable, merge_rank_x_gallery_items, parse_gallery_items,
-    x_gallery_needs_supplement, x_gallery_reference_ids, WallpaperGalleryItem,
-    WallpaperSearchCancellation, WallpaperXSearchRuntime, WallpaperXSearchStage,
-    X_SEARCH_FIRST_ROUND_CALLS, X_SEARCH_SUPPLEMENT_CALLS, X_SEARCH_TOTAL_CALLS,
+    filter_reachable_gallery_items_cancellable, merge_rank_x_gallery_items_with_limit,
+    parse_gallery_items, x_gallery_new_items, WallpaperGalleryItem, WallpaperSearchCancellation,
+    WallpaperXSearchBatch, WallpaperXSearchRuntime, WallpaperXSearchStage,
 };
 
 pub(crate) const RESPONSES_ENDPOINT: &str = "https://cli-chat-proxy.grok.com/v1/responses";
 pub(crate) const RESPONSES_MODEL: &str = "grok-4.6";
 pub(crate) const RESPONSES_EFFORT: &str = "low";
-pub(crate) const RESPONSES_MAX_X_SEARCH_CALLS: u32 = X_SEARCH_TOTAL_CALLS;
+pub(crate) const RESPONSES_LANE_COUNT: usize = 3;
+pub(crate) const RESPONSES_LANE_TARGET_COUNT: usize = 8;
+pub(crate) const RESPONSES_LANE_MAX_X_SEARCH_CALLS: u32 = 3;
 
 const RESPONSES_TIMEOUT: Duration = Duration::from_secs(90);
 const RESPONSES_MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
+const RESPONSES_MAX_RESULTS: usize = RESPONSES_LANE_COUNT * RESPONSES_LANE_TARGET_COUNT;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ResponsesSearchErrorKind {
@@ -72,6 +75,7 @@ impl ResponsesSearchErrorKind {
 pub(crate) struct ResponsesSearchError {
     pub(crate) kind: ResponsesSearchErrorKind,
     pub(crate) credential_revision: Option<BuildOauthCredentialRevision>,
+    pub(crate) observed_search_calls: Option<u32>,
 }
 
 impl ResponsesSearchError {
@@ -82,7 +86,13 @@ impl ResponsesSearchError {
         Self {
             kind,
             credential_revision,
+            observed_search_calls: None,
         }
+    }
+
+    fn with_observed_search_calls(mut self, search_calls: u32) -> Self {
+        self.observed_search_calls = Some(search_calls);
+        self
     }
 
     pub(crate) fn code(&self) -> &'static str {
@@ -101,6 +111,17 @@ pub(crate) struct ResponsesSearchSuccess {
     pub(crate) credential_revision: BuildOauthCredentialRevision,
 }
 
+struct ResponsesSearchRequest<'a> {
+    query: &'a str,
+    sort: Option<&'a str>,
+    endpoint: &'a str,
+    max_search_calls: u32,
+    lane_index: usize,
+    target_count: usize,
+    excluded_ids: &'a [String],
+    cancellation: &'a WallpaperSearchCancellation,
+}
+
 /// Run the fixed, read-only Responses preview request.
 ///
 /// No endpoint, model, tool, or credential is accepted from the frontend.
@@ -116,96 +137,135 @@ pub(crate) async fn search(
         ));
     }
     let auth = account::read_build_oauth_access_token().map_err(auth_error)?;
-    let mut first = search_with_auth(
-        query,
-        sort,
-        &auth,
-        RESPONSES_ENDPOINT,
-        RESPONSES_TIMEOUT,
-        SearchOptions {
-            max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
-            is_supplement: false,
-            seen_ids: &[],
+    let client = responses_client(RESPONSES_TIMEOUT, Some(auth.revision.clone()))?;
+    run_parallel_lanes(runtime, auth.revision.clone(), |lane_index| {
+        search_lane(query, sort, lane_index, &client, &auth, runtime)
+    })
+    .await
+}
+
+async fn search_lane(
+    query: &str,
+    sort: Option<&str>,
+    lane_index: usize,
+    client: &reqwest::Client,
+    auth: &BuildOauthAccessToken,
+    runtime: &WallpaperXSearchRuntime,
+) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
+    let mut result = search_with_client(
+        ResponsesSearchRequest {
+            query,
+            sort,
+            endpoint: RESPONSES_ENDPOINT,
+            max_search_calls: RESPONSES_LANE_MAX_X_SEARCH_CALLS,
+            lane_index,
+            target_count: RESPONSES_LANE_TARGET_COUNT,
+            excluded_ids: &[],
             cancellation: runtime.cancellation(),
         },
+        client,
+        auth.expose_to_build_proxy(),
+        auth.revision.clone(),
     )
     .await?;
-    let mut candidate_count = first.candidate_count;
-    let mut search_calls = first.search_calls;
-    let seen_ids = x_gallery_reference_ids(&first.items);
     runtime.report(WallpaperXSearchStage::Validating);
-    let mut items = filter_reachable_gallery_items_cancellable(
-        std::mem::take(&mut first.items),
-        Some(runtime.cancellation()),
-    )
-    .await;
+    result.items =
+        filter_reachable_gallery_items_cancellable(result.items, Some(runtime.cancellation()))
+            .await;
     if runtime.is_cancelled() {
         return Err(ResponsesSearchError::new(
             ResponsesSearchErrorKind::Cancelled,
             Some(auth.revision.clone()),
         ));
     }
-
-    if x_gallery_needs_supplement(items.len()) {
-        runtime.report(WallpaperXSearchStage::Supplementing);
-        match search_with_auth(
-            query,
-            sort,
-            &auth,
-            RESPONSES_ENDPOINT,
-            RESPONSES_TIMEOUT,
-            SearchOptions {
-                max_search_calls: X_SEARCH_SUPPLEMENT_CALLS,
-                is_supplement: true,
-                seen_ids: &seen_ids,
-                cancellation: runtime.cancellation(),
-            },
+    if result.items.is_empty() {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::Empty,
+            Some(auth.revision.clone()),
         )
-        .await
-        {
-            Ok(mut supplement) => {
-                search_calls = search_calls.saturating_add(supplement.search_calls);
-                if search_calls > RESPONSES_MAX_X_SEARCH_CALLS {
-                    return Err(ResponsesSearchError::new(
-                        ResponsesSearchErrorKind::SearchBudgetExceeded,
-                        Some(auth.revision.clone()),
-                    ));
-                }
-                candidate_count = candidate_count.saturating_add(supplement.candidate_count);
-                runtime.report(WallpaperXSearchStage::Validating);
-                let supplement_items = filter_reachable_gallery_items_cancellable(
-                    std::mem::take(&mut supplement.items),
-                    Some(runtime.cancellation()),
-                )
-                .await;
-                if runtime.is_cancelled() {
-                    return Err(ResponsesSearchError::new(
-                        ResponsesSearchErrorKind::Cancelled,
-                        Some(auth.revision.clone()),
-                    ));
-                }
-                items.extend(supplement_items);
-                items = merge_rank_x_gallery_items(items);
+        .with_observed_search_calls(result.search_calls));
+    }
+    result.valid_count = result.items.len();
+    Ok(result)
+}
+
+async fn run_parallel_lanes<F, Fut>(
+    runtime: &WallpaperXSearchRuntime,
+    credential_revision: BuildOauthCredentialRevision,
+    run_lane: F,
+) -> Result<ResponsesSearchSuccess, ResponsesSearchError>
+where
+    F: Fn(usize) -> Fut,
+    Fut: Future<Output = Result<ResponsesSearchSuccess, ResponsesSearchError>>,
+{
+    let mut lanes = FuturesUnordered::new();
+    for lane_index in 1..=RESPONSES_LANE_COUNT {
+        let lane = run_lane(lane_index);
+        lanes.push(async move { (lane_index, lane.await) });
+    }
+
+    let mut items = Vec::new();
+    let mut candidate_count = 0usize;
+    let mut search_calls = 0u32;
+    let mut errors = Vec::new();
+    loop {
+        let next = tokio::select! {
+            biased;
+            _ = runtime.cancellation().cancelled() => {
+                return Err(ResponsesSearchError::new(
+                    ResponsesSearchErrorKind::Cancelled,
+                    Some(credential_revision.clone()),
+                ));
             }
-            Err(error)
-                if error.kind == ResponsesSearchErrorKind::Cancelled
-                    || items.is_empty()
-                    || error.kind == ResponsesSearchErrorKind::SearchBudgetExceeded =>
-            {
+            next = lanes.next() => next,
+        };
+        let Some((lane_index, outcome)) = next else {
+            break;
+        };
+        let is_last = lanes.is_empty();
+        match outcome {
+            Ok(lane) => {
+                candidate_count = candidate_count.saturating_add(lane.candidate_count);
+                search_calls = search_calls.saturating_add(lane.search_calls);
+                let previous = items.clone();
+                let mut combined = previous.clone();
+                combined.extend(lane.items);
+                items = merge_rank_x_gallery_items_with_limit(combined, RESPONSES_MAX_RESULTS);
+                let batch_items = x_gallery_new_items(&previous, &items);
+                runtime.report_batch(WallpaperXSearchBatch {
+                    batch_index: lane_index,
+                    items: batch_items,
+                    accumulated_count: items.len(),
+                    done: is_last,
+                });
+            }
+            Err(error) if error.kind == ResponsesSearchErrorKind::Cancelled => {
                 return Err(error);
             }
-            Err(_) => {
-                // A useful partial first round is better than discarding honest
-                // results because the optional supplement failed.
+            Err(error) => {
+                search_calls =
+                    search_calls.saturating_add(error.observed_search_calls.unwrap_or_default());
+                errors.push(error);
+                if is_last {
+                    runtime.report_batch(WallpaperXSearchBatch {
+                        batch_index: lane_index,
+                        items: Vec::new(),
+                        accumulated_count: items.len(),
+                        done: true,
+                    });
+                }
             }
         }
     }
 
-    if items.is_empty() {
+    if runtime.is_cancelled() {
         return Err(ResponsesSearchError::new(
-            ResponsesSearchErrorKind::Empty,
-            Some(auth.revision.clone()),
+            ResponsesSearchErrorKind::Cancelled,
+            Some(credential_revision),
         ));
+    }
+    if items.is_empty() {
+        return Err(select_parallel_error(errors, credential_revision));
     }
 
     Ok(ResponsesSearchSuccess {
@@ -215,8 +275,40 @@ pub(crate) async fn search(
         search_calls,
         model: RESPONSES_MODEL,
         effort: RESPONSES_EFFORT,
-        credential_revision: auth.revision.clone(),
+        credential_revision,
     })
+}
+
+fn select_parallel_error(
+    errors: Vec<ResponsesSearchError>,
+    credential_revision: BuildOauthCredentialRevision,
+) -> ResponsesSearchError {
+    errors
+        .into_iter()
+        .min_by_key(|error| parallel_error_priority(error.kind))
+        .unwrap_or_else(|| {
+            ResponsesSearchError::new(ResponsesSearchErrorKind::Empty, Some(credential_revision))
+        })
+}
+
+fn parallel_error_priority(kind: ResponsesSearchErrorKind) -> u8 {
+    match kind {
+        ResponsesSearchErrorKind::Cancelled => 0,
+        ResponsesSearchErrorKind::RateLimited => 1,
+        ResponsesSearchErrorKind::SearchBudgetExceeded => 2,
+        ResponsesSearchErrorKind::Unauthorized
+        | ResponsesSearchErrorKind::OauthUnavailable
+        | ResponsesSearchErrorKind::OauthExpired => 3,
+        ResponsesSearchErrorKind::BadRequest
+        | ResponsesSearchErrorKind::InvalidJson
+        | ResponsesSearchErrorKind::Protocol
+        | ResponsesSearchErrorKind::ToolNotCalled => 4,
+        ResponsesSearchErrorKind::ServerError
+        | ResponsesSearchErrorKind::Timeout
+        | ResponsesSearchErrorKind::Tls
+        | ResponsesSearchErrorKind::Network => 5,
+        ResponsesSearchErrorKind::Empty => 6,
+    }
 }
 
 fn auth_error(error: BuildOauthTokenError) -> ResponsesSearchError {
@@ -227,50 +319,22 @@ fn auth_error(error: BuildOauthTokenError) -> ResponsesSearchError {
     ResponsesSearchError::new(kind, None)
 }
 
-struct SearchOptions<'a> {
-    max_search_calls: u32,
-    is_supplement: bool,
-    seen_ids: &'a [String],
-    cancellation: &'a WallpaperSearchCancellation,
-}
-
-async fn search_with_auth(
-    query: &str,
-    sort: Option<&str>,
-    auth: &BuildOauthAccessToken,
-    endpoint: &str,
-    timeout: Duration,
-    options: SearchOptions<'_>,
-) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
-    search_with_credentials(
-        query,
-        sort,
-        Ok((auth.expose_to_build_proxy(), auth.revision.clone())),
-        endpoint,
-        timeout,
-        options,
-    )
-    .await
-}
-
+#[cfg(test)]
 async fn search_with_credentials(
-    query: &str,
-    sort: Option<&str>,
-    credentials: Result<(&str, BuildOauthCredentialRevision), BuildOauthTokenError>,
-    endpoint: &str,
+    request: ResponsesSearchRequest<'_>,
     timeout: Duration,
-    options: SearchOptions<'_>,
+    credentials: Result<(&str, BuildOauthCredentialRevision), BuildOauthTokenError>,
 ) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
-    let SearchOptions {
-        max_search_calls,
-        is_supplement,
-        seen_ids,
-        cancellation,
-    } = options;
     let (token, credential_revision) = credentials.map_err(auth_error)?;
-    let error_revision = || Some(credential_revision.clone());
+    let client = responses_client(timeout, Some(credential_revision.clone()))?;
+    search_with_client(request, &client, token, credential_revision).await
+}
 
-    let client = proxy::apply_to_reqwest(
+fn responses_client(
+    timeout: Duration,
+    credential_revision: Option<BuildOauthCredentialRevision>,
+) -> Result<reqwest::Client, ResponsesSearchError> {
+    proxy::apply_to_reqwest(
         reqwest::Client::builder()
             .timeout(timeout)
             .connect_timeout(timeout.min(Duration::from_secs(20)))
@@ -280,11 +344,29 @@ async fn search_with_credentials(
             .redirect(reqwest::redirect::Policy::none()),
     )
     .build()
-    .map_err(|_| ResponsesSearchError::new(ResponsesSearchErrorKind::Network, error_revision()))?;
+    .map_err(|_| ResponsesSearchError::new(ResponsesSearchErrorKind::Network, credential_revision))
+}
 
-    let request = client
-        .post(endpoint)
-        .bearer_auth(token)
+async fn search_with_client(
+    request: ResponsesSearchRequest<'_>,
+    client: &reqwest::Client,
+    token: &str,
+    credential_revision: BuildOauthCredentialRevision,
+) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
+    let ResponsesSearchRequest {
+        query,
+        sort,
+        endpoint,
+        max_search_calls,
+        lane_index,
+        target_count,
+        excluded_ids,
+        cancellation,
+    } = request;
+    let error_revision = || Some(credential_revision.clone());
+
+    let request = client.post(endpoint).bearer_auth(token);
+    let request = request
         .header("x-grok-client-mode", "cli")
         .header("x-grok-client-identifier", "grok-shell")
         .header("x-grok-client-version", "1.0.5")
@@ -292,8 +374,9 @@ async fn search_with_credentials(
             query,
             sort,
             max_search_calls,
-            is_supplement,
-            seen_ids,
+            lane_index,
+            target_count,
+            excluded_ids,
         ))
         .send();
     let response = tokio::select! {
@@ -356,13 +439,15 @@ async fn search_with_credentials(
         return Err(ResponsesSearchError::new(
             ResponsesSearchErrorKind::ToolNotCalled,
             error_revision(),
-        ));
+        )
+        .with_observed_search_calls(search_calls));
     }
     if search_calls > max_search_calls {
         return Err(ResponsesSearchError::new(
             ResponsesSearchErrorKind::SearchBudgetExceeded,
             error_revision(),
-        ));
+        )
+        .with_observed_search_calls(search_calls));
     }
 
     let gallery = gallery_from_output(output)
@@ -392,12 +477,20 @@ fn responses_request(
     query: &str,
     sort: Option<&str>,
     max_search_calls: u32,
-    is_supplement: bool,
-    seen_ids: &[String],
+    lane_index: usize,
+    target_count: usize,
+    excluded_ids: &[String],
 ) -> Value {
     json!({
         "model": RESPONSES_MODEL,
-        "input": responses_prompt(query, sort, max_search_calls, is_supplement, seen_ids),
+        "input": responses_prompt(
+            query,
+            sort,
+            max_search_calls,
+            lane_index,
+            target_count,
+            excluded_ids,
+        ),
         "tools": [{ "type": "x_search" }],
         "tool_choice": "auto",
         "max_tool_calls": max_search_calls,
@@ -410,7 +503,7 @@ fn responses_request(
                 "type": "json_schema",
                 "name": "wallpaper_gallery",
                 "strict": true,
-                "schema": gallery_schema()
+                "schema": gallery_schema(target_count)
             }
         },
         "store": false
@@ -421,24 +514,28 @@ fn responses_prompt(
     query: &str,
     sort: Option<&str>,
     max_search_calls: u32,
-    is_supplement: bool,
-    seen_ids: &[String],
+    lane_index: usize,
+    target_count: usize,
+    excluded_ids: &[String],
 ) -> String {
     let sort = match sort.unwrap_or("top") {
         "latest" | "Latest" => "Latest",
         _ => "Top",
     };
-    let round_guidance = if is_supplement {
-        format!(
-            "Supplement round: use one new query with a different visual angle (alternate composition, lighting, setting, season, or medium). Exclude candidates carrying these opaque media/post ids: {}",
-            if seen_ids.is_empty() {
-                "none from the empty first round".to_string()
-            } else {
-                seen_ids.join(", ")
-            }
-        )
+    let lane_guidance = match lane_index {
+        1 => "Concurrent batch 1 of 3. Primary batch: search the strongest direct interpretation of the topic and prioritize immediately recognizable wallpaper candidates.",
+        2 => "Concurrent batch 2 of 3. Visual-variation batch: avoid repeating the primary lane; emphasize alternate composition, lighting, season, or medium.",
+        3 => "Concurrent batch 3 of 3. Discovery batch: use different viewpoint, palette, time or weather, cultural framing, or bilingual keywords; avoid the obvious direct and visual-variation queries.",
+        4 => "User-requested load-more batch: search fresh long-tail variants with a different viewpoint, palette, setting, time, weather, cultural framing, or bilingual keywords. Do not repeat the initial three batches.",
+        _ => "Concurrent wallpaper batch: use complementary direct and visual/style query variants.",
+    };
+    let exclusion_guidance = if excluded_ids.is_empty() {
+        String::new()
     } else {
-        "First round: use complementary direct and visual/style query variants.".to_string()
+        format!(
+            "\nExclude candidates carrying these opaque media/post ids from the existing validated gallery: {}",
+            excluded_ids.join(", ")
+        )
     };
     format!(
         r#"You collect high-quality still images from X (Twitter) for a wallpaper picker.
@@ -446,20 +543,21 @@ fn responses_prompt(
 User topic: {query}
 Sort preference: {sort}
 
-{round_guidance}
+{lane_guidance}{exclusion_guidance}
 
 Use X search only. Use no more than {max_search_calls} x_search call(s) in this request. Search useful query variants with image filters. Prefer real photography or polished AI art suitable as wallpaper. Prefer posts that include both a prompt and attached images when relevant. Skip memes, screenshots, text cards, avatars, emoji packs, ads, blurry thumbnails, videos, and placeholder links.
 
-Return 8-16 distinct items when possible. fullUrl must be a direct HTTPS full-size image CDN URL, preferably https://pbs.twimg.com/media/... with name=orig. postUrl must be a confirmed canonical https://x.com/<user>/status/<id>; omit it rather than guessing. Include mediaIndex 1-4 only when the status media position is known. Return metadata only and do not download files."#
+Return {target_count} distinct items when possible. Return fewer only when you cannot confirm enough candidates; never pad, duplicate, or guess metadata. fullUrl must be a direct HTTPS full-size image CDN URL, preferably https://pbs.twimg.com/media/... with name=orig. postUrl must be a confirmed canonical https://x.com/<user>/status/<id>; omit it rather than guessing. Include mediaIndex 1-4 only when the status media position is known. Return metadata only and do not download files."#
     )
 }
 
-fn gallery_schema() -> Value {
+fn gallery_schema(target_count: usize) -> Value {
     json!({
         "type": "object",
         "properties": {
             "items": {
                 "type": "array",
+                "maxItems": target_count,
                 "items": {
                     "type": "object",
                     "properties": {
@@ -514,10 +612,17 @@ fn status_error_kind(status: StatusCode) -> ResponsesSearchErrorKind {
 }
 
 fn transport_error_kind(error: &reqwest::Error) -> ResponsesSearchErrorKind {
-    if error.is_timeout() {
+    classify_transport_error(error.is_timeout(), error)
+}
+
+fn classify_transport_error(
+    is_timeout: bool,
+    error: &(dyn std::error::Error + 'static),
+) -> ResponsesSearchErrorKind {
+    if is_timeout {
         return ResponsesSearchErrorKind::Timeout;
     }
-    let mut source = error.source();
+    let mut source = Some(error);
     while let Some(cause) = source {
         let message = cause.to_string().to_ascii_lowercase();
         if message.contains("tls")
@@ -600,450 +705,4 @@ fn gallery_from_output(output: &[Value]) -> Result<Value, ResponsesSearchErrorKi
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex};
-
-    use axum::body::{Body, Bytes};
-    use axum::extract::State;
-    use axum::http::{HeaderMap, HeaderValue};
-    use axum::response::{IntoResponse, Response};
-    use axum::routing::post;
-    use axum::Router;
-    use tokio::net::TcpListener;
-    use tokio::task::JoinHandle;
-
-    use super::*;
-
-    #[derive(Clone)]
-    struct MockState {
-        status: StatusCode,
-        response_body: Arc<String>,
-        delay: Duration,
-        requests: Arc<AtomicUsize>,
-        authorization_ok: Arc<AtomicBool>,
-        request_body: Arc<Mutex<Option<Value>>>,
-    }
-
-    async fn mock_responses(
-        State(state): State<MockState>,
-        headers: HeaderMap,
-        body: Bytes,
-    ) -> Response {
-        state.requests.fetch_add(1, Ordering::SeqCst);
-        state.authorization_ok.store(
-            headers
-                .get(reqwest::header::AUTHORIZATION)
-                .and_then(|value| value.to_str().ok())
-                == Some("Bearer test-token"),
-            Ordering::SeqCst,
-        );
-        if let Ok(value) = serde_json::from_slice::<Value>(&body) {
-            *state.request_body.lock().expect("request body lock") = Some(value);
-        }
-        if !state.delay.is_zero() {
-            tokio::time::sleep(state.delay).await;
-        }
-        (state.status, state.response_body.as_str().to_string()).into_response()
-    }
-
-    async fn spawn_mock(
-        status: StatusCode,
-        body: impl Into<String>,
-        delay: Duration,
-    ) -> (String, MockState, JoinHandle<()>) {
-        let state = MockState {
-            status,
-            response_body: Arc::new(body.into()),
-            delay,
-            requests: Arc::new(AtomicUsize::new(0)),
-            authorization_ok: Arc::new(AtomicBool::new(false)),
-            request_body: Arc::new(Mutex::new(None)),
-        };
-        let app = Router::new()
-            .route("/v1/responses", post(mock_responses))
-            .with_state(state.clone());
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
-        let address = listener.local_addr().expect("mock address");
-        let task = tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
-        });
-        (format!("http://{address}/v1/responses"), state, task)
-    }
-
-    fn test_revision() -> BuildOauthCredentialRevision {
-        BuildOauthCredentialRevision::for_test(123, Some(456), 1)
-    }
-
-    fn success_payload(search_calls: usize) -> String {
-        let mut output = Vec::new();
-        for _ in 0..search_calls {
-            output.push(json!({ "type": "x_search_call", "status": "completed" }));
-        }
-        output.push(json!({
-            "type": "message",
-            "content": [{
-                "type": "output_text",
-                "text": serde_json::to_string(&json!({
-                    "items": [{
-                        "fullUrl": "https://pbs.twimg.com/media/test.jpg?name=small",
-                        "thumbUrl": "https://pbs.twimg.com/media/test.jpg?name=small",
-                        "username": "alice",
-                        "postUrl": "https://x.com/alice/status/1234567890123456789",
-                        "kind": "image"
-                    }]
-                })).expect("gallery json")
-            }]
-        }));
-        json!({
-            "model": RESPONSES_MODEL,
-            "output": output
-        })
-        .to_string()
-    }
-
-    async fn test_search(
-        endpoint: &str,
-        timeout: Duration,
-    ) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
-        let cancellation = WallpaperSearchCancellation::default();
-        search_with_credentials(
-            "misty mountains",
-            Some("top"),
-            Ok(("test-token", test_revision())),
-            endpoint,
-            timeout,
-            SearchOptions {
-                max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
-                is_supplement: false,
-                seen_ids: &[],
-                cancellation: &cancellation,
-            },
-        )
-        .await
-    }
-
-    #[tokio::test]
-    async fn gallery_without_completed_x_call_is_rejected() {
-        let (endpoint, _, task) =
-            spawn_mock(StatusCode::OK, success_payload(0), Duration::ZERO).await;
-        let result = test_search(&endpoint, Duration::from_secs(2)).await;
-        task.abort();
-        assert_eq!(
-            result.unwrap_err().kind,
-            ResponsesSearchErrorKind::ToolNotCalled
-        );
-        assert_eq!(
-            count_x_search_calls(&[
-                json!({"type": "x_search_call", "status": "in_progress"}),
-                json!({"type": "custom_tool_result", "status": "completed"}),
-                json!({"type": "server_tool_call", "name": "web_search", "status": "completed"}),
-            ]),
-            0
-        );
-    }
-
-    #[tokio::test]
-    async fn wallpaper_x_responses_success_parses_gallery_and_fixed_contract() {
-        assert_eq!(
-            count_x_search_calls(&[json!({ "type": "custom_tool_call", "status": "completed" })]),
-            1
-        );
-        let (endpoint, state, task) =
-            spawn_mock(StatusCode::OK, success_payload(2), Duration::ZERO).await;
-        let result = test_search(&endpoint, Duration::from_secs(2))
-            .await
-            .expect("responses success");
-        task.abort();
-
-        assert_eq!(result.items.len(), 1);
-        assert_eq!(result.candidate_count, 1);
-        assert_eq!(result.valid_count, 1);
-        assert_eq!(result.search_calls, 2);
-        assert_eq!(result.model, "grok-4.6");
-        assert_eq!(result.effort, "low");
-        assert!(result.items[0].full_url.contains("name=orig"));
-        assert_eq!(state.requests.load(Ordering::SeqCst), 1);
-        assert!(state.authorization_ok.load(Ordering::SeqCst));
-
-        let request = state
-            .request_body
-            .lock()
-            .expect("request body lock")
-            .clone()
-            .expect("captured request");
-        assert_eq!(request.get("model"), Some(&json!("grok-4.6")));
-        assert_eq!(request.pointer("/reasoning/effort"), Some(&json!("low")));
-        assert_eq!(request.get("store"), Some(&json!(false)));
-        assert_eq!(request.get("max_tool_calls"), Some(&json!(2)));
-        assert_eq!(request.pointer("/tools/0/type"), Some(&json!("x_search")));
-        assert_eq!(
-            request.pointer("/text/format/type"),
-            Some(&json!("json_schema"))
-        );
-        assert_eq!(request.pointer("/text/format/strict"), Some(&json!(true)));
-        assert_eq!(
-            request.pointer("/text/format/schema/additionalProperties"),
-            Some(&json!(false))
-        );
-        assert!(request
-            .get("input")
-            .and_then(Value::as_str)
-            .is_some_and(|prompt| prompt.contains("no more than 2 x_search call")));
-        let supplement = responses_request(
-            "misty mountains",
-            Some("top"),
-            X_SEARCH_SUPPLEMENT_CALLS,
-            true,
-            &["twimg:seen-id".into(), "status:12345678".into()],
-        );
-        assert_eq!(supplement.get("max_tool_calls"), Some(&json!(1)));
-        assert!(supplement
-            .get("input")
-            .and_then(Value::as_str)
-            .is_some_and(|prompt| {
-                prompt.contains("different visual angle")
-                    && prompt.contains("twimg:seen-id")
-                    && prompt.contains("no more than 1 x_search call")
-            }));
-        assert_eq!(RESPONSES_MAX_X_SEARCH_CALLS, 3);
-    }
-
-    #[tokio::test]
-    async fn wallpaper_x_responses_classifies_http_failures() {
-        for (status, expected) in [
-            (
-                StatusCode::BAD_REQUEST,
-                ResponsesSearchErrorKind::BadRequest,
-            ),
-            (
-                StatusCode::UNAUTHORIZED,
-                ResponsesSearchErrorKind::Unauthorized,
-            ),
-            (
-                StatusCode::FORBIDDEN,
-                ResponsesSearchErrorKind::Unauthorized,
-            ),
-            (
-                StatusCode::TOO_MANY_REQUESTS,
-                ResponsesSearchErrorKind::RateLimited,
-            ),
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                ResponsesSearchErrorKind::ServerError,
-            ),
-        ] {
-            let (endpoint, _state, task) = spawn_mock(status, "redacted", Duration::ZERO).await;
-            let error = test_search(&endpoint, Duration::from_secs(2))
-                .await
-                .expect_err("http status must fail");
-            task.abort();
-            assert_eq!(error.kind, expected);
-            assert_eq!(error.code(), expected.code());
-        }
-    }
-
-    #[tokio::test]
-    async fn wallpaper_x_responses_classifies_timeout_invalid_json_and_empty() {
-        let (endpoint, _state, task) = spawn_mock(
-            StatusCode::OK,
-            success_payload(1),
-            Duration::from_millis(150),
-        )
-        .await;
-        let error = test_search(&endpoint, Duration::from_millis(25))
-            .await
-            .expect_err("request must time out");
-        task.abort();
-        assert_eq!(error.kind, ResponsesSearchErrorKind::Timeout);
-
-        let (endpoint, _state, task) = spawn_mock(StatusCode::OK, "not-json", Duration::ZERO).await;
-        let error = test_search(&endpoint, Duration::from_secs(2))
-            .await
-            .expect_err("invalid json must fail");
-        task.abort();
-        assert_eq!(error.kind, ResponsesSearchErrorKind::InvalidJson);
-
-        let (endpoint, _state, task) = spawn_mock(StatusCode::OK, "", Duration::ZERO).await;
-        let error = test_search(&endpoint, Duration::from_secs(2))
-            .await
-            .expect_err("empty response must fail");
-        task.abort();
-        assert_eq!(error.kind, ResponsesSearchErrorKind::Empty);
-    }
-
-    #[tokio::test]
-    async fn wallpaper_x_responses_cancellation_aborts_inflight_http() {
-        let (endpoint, state, task) =
-            spawn_mock(StatusCode::OK, success_payload(1), Duration::from_secs(10)).await;
-        let cancellation = WallpaperSearchCancellation::default();
-        let cancellation_for_request = cancellation.clone();
-        let request = tokio::spawn(async move {
-            search_with_credentials(
-                "misty mountains",
-                Some("top"),
-                Ok(("test-token", test_revision())),
-                &endpoint,
-                Duration::from_secs(30),
-                SearchOptions {
-                    max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
-                    is_supplement: false,
-                    seen_ids: &[],
-                    cancellation: &cancellation_for_request,
-                },
-            )
-            .await
-        });
-
-        tokio::time::timeout(Duration::from_secs(2), async {
-            while state.requests.load(Ordering::SeqCst) == 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("mock request did not start");
-        cancellation.cancel();
-        let error = tokio::time::timeout(Duration::from_secs(2), request)
-            .await
-            .expect("cancelled request did not return")
-            .expect("request task panicked")
-            .expect_err("cancelled request must fail");
-        task.abort();
-        assert_eq!(error.kind, ResponsesSearchErrorKind::Cancelled);
-    }
-
-    #[tokio::test]
-    async fn wallpaper_x_responses_rejects_bad_structured_output_and_tool_overrun() {
-        let invalid_output = json!({
-            "output": [{ "type": "x_search_call", "status": "completed" }, {
-                "type": "message",
-                "content": [{ "type": "output_text", "text": "not-json" }]
-            }]
-        })
-        .to_string();
-        let (endpoint, _state, task) =
-            spawn_mock(StatusCode::OK, invalid_output, Duration::ZERO).await;
-        let error = test_search(&endpoint, Duration::from_secs(2))
-            .await
-            .expect_err("bad structured output must fail");
-        task.abort();
-        assert_eq!(error.kind, ResponsesSearchErrorKind::InvalidJson);
-
-        let (endpoint, _state, task) =
-            spawn_mock(StatusCode::OK, success_payload(4), Duration::ZERO).await;
-        let error = test_search(&endpoint, Duration::from_secs(2))
-            .await
-            .expect_err("tool overrun must fail");
-        task.abort();
-        assert_eq!(error.kind, ResponsesSearchErrorKind::SearchBudgetExceeded);
-    }
-
-    #[tokio::test]
-    async fn wallpaper_x_responses_oauth_failure_sends_no_request() {
-        let (endpoint, state, task) =
-            spawn_mock(StatusCode::OK, success_payload(1), Duration::ZERO).await;
-        for (oauth_error, expected) in [
-            (
-                BuildOauthTokenError::Unavailable,
-                ResponsesSearchErrorKind::OauthUnavailable,
-            ),
-            (
-                BuildOauthTokenError::Expired,
-                ResponsesSearchErrorKind::OauthExpired,
-            ),
-        ] {
-            let cancellation = WallpaperSearchCancellation::default();
-            let error = search_with_credentials(
-                "misty mountains",
-                Some("top"),
-                Err(oauth_error),
-                &endpoint,
-                Duration::from_secs(2),
-                SearchOptions {
-                    max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
-                    is_supplement: false,
-                    seen_ids: &[],
-                    cancellation: &cancellation,
-                },
-            )
-            .await
-            .expect_err("oauth failure must stop before HTTP");
-            assert_eq!(error.kind, expected);
-        }
-        task.abort();
-        assert_eq!(state.requests.load(Ordering::SeqCst), 0);
-    }
-
-    #[derive(Clone)]
-    struct RedirectState {
-        target: String,
-        source_requests: Arc<AtomicUsize>,
-        target_requests: Arc<AtomicUsize>,
-        target_saw_authorization: Arc<AtomicBool>,
-    }
-
-    async fn redirect_source(State(state): State<RedirectState>) -> Response {
-        state.source_requests.fetch_add(1, Ordering::SeqCst);
-        let mut response = Response::new(Body::empty());
-        *response.status_mut() = StatusCode::TEMPORARY_REDIRECT;
-        response.headers_mut().insert(
-            reqwest::header::LOCATION,
-            HeaderValue::from_str(&state.target).expect("redirect target header"),
-        );
-        response
-    }
-
-    async fn redirect_target(State(state): State<RedirectState>, headers: HeaderMap) -> Response {
-        state.target_requests.fetch_add(1, Ordering::SeqCst);
-        state.target_saw_authorization.store(
-            headers.contains_key(reqwest::header::AUTHORIZATION),
-            Ordering::SeqCst,
-        );
-        (StatusCode::OK, success_payload(1)).into_response()
-    }
-
-    #[tokio::test]
-    async fn wallpaper_x_responses_never_replays_authorization_across_redirect() {
-        let target_listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind redirect target");
-        let target_address = target_listener.local_addr().expect("target address");
-        let state = RedirectState {
-            target: format!("http://{target_address}/target"),
-            source_requests: Arc::new(AtomicUsize::new(0)),
-            target_requests: Arc::new(AtomicUsize::new(0)),
-            target_saw_authorization: Arc::new(AtomicBool::new(false)),
-        };
-        let target_app = Router::new()
-            .route("/target", post(redirect_target))
-            .with_state(state.clone());
-        let target_task = tokio::spawn(async move {
-            let _ = axum::serve(target_listener, target_app).await;
-        });
-
-        let source_listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind redirect source");
-        let source_address = source_listener.local_addr().expect("source address");
-        let source_app = Router::new()
-            .route("/v1/responses", post(redirect_source))
-            .with_state(state.clone());
-        let source_task = tokio::spawn(async move {
-            let _ = axum::serve(source_listener, source_app).await;
-        });
-
-        let error = test_search(
-            &format!("http://{source_address}/v1/responses"),
-            Duration::from_secs(2),
-        )
-        .await
-        .expect_err("redirect must be a protocol failure");
-        source_task.abort();
-        target_task.abort();
-
-        assert_eq!(error.kind, ResponsesSearchErrorKind::Protocol);
-        assert_eq!(state.source_requests.load(Ordering::SeqCst), 1);
-        assert_eq!(state.target_requests.load(Ordering::SeqCst), 0);
-        assert!(!state.target_saw_authorization.load(Ordering::SeqCst));
-    }
-}
+mod tests;

--- a/src-tauri/src/wallpaper_x_responses/tests.rs
+++ b/src-tauri/src/wallpaper_x_responses/tests.rs
@@ -1,0 +1,776 @@
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use axum::body::{Body, Bytes};
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::Router;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+use super::*;
+use crate::wallpaper_source::X_SEARCH_FIRST_ROUND_CALLS;
+
+#[derive(Clone)]
+struct MockState {
+    status: StatusCode,
+    response_body: Arc<String>,
+    delay: Duration,
+    requests: Arc<AtomicUsize>,
+    authorization_ok: Arc<AtomicBool>,
+    request_body: Arc<Mutex<Option<Value>>>,
+}
+
+struct FailingDnsResolver;
+
+#[derive(Debug)]
+struct SyntheticTransportError(&'static str);
+
+impl std::fmt::Display for SyntheticTransportError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+impl std::error::Error for SyntheticTransportError {}
+
+impl reqwest::dns::Resolve for FailingDnsResolver {
+    fn resolve(&self, _name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        Box::pin(async {
+            let error: Box<dyn std::error::Error + Send + Sync> = Box::new(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "synthetic DNS failure",
+            ));
+            Err::<reqwest::dns::Addrs, _>(error)
+        })
+    }
+}
+
+async fn spawn_raw_response(
+    response: &'static [u8],
+    delay: Duration,
+) -> (SocketAddr, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind raw server");
+    let address = listener.local_addr().expect("raw server address");
+    let task = tokio::spawn(async move {
+        let Ok((mut stream, _)) = listener.accept().await else {
+            return;
+        };
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+        let _ = stream.write_all(response).await;
+    });
+    (address, task)
+}
+
+async fn mock_responses(
+    State(state): State<MockState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    state.requests.fetch_add(1, Ordering::SeqCst);
+    state.authorization_ok.store(
+        headers
+            .get(reqwest::header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            == Some("Bearer test-token"),
+        Ordering::SeqCst,
+    );
+    if let Ok(value) = serde_json::from_slice::<Value>(&body) {
+        *state.request_body.lock().expect("request body lock") = Some(value);
+    }
+    if !state.delay.is_zero() {
+        tokio::time::sleep(state.delay).await;
+    }
+    (state.status, state.response_body.as_str().to_string()).into_response()
+}
+
+async fn spawn_mock(
+    status: StatusCode,
+    body: impl Into<String>,
+    delay: Duration,
+) -> (String, MockState, JoinHandle<()>) {
+    let state = MockState {
+        status,
+        response_body: Arc::new(body.into()),
+        delay,
+        requests: Arc::new(AtomicUsize::new(0)),
+        authorization_ok: Arc::new(AtomicBool::new(false)),
+        request_body: Arc::new(Mutex::new(None)),
+    };
+    let app = Router::new()
+        .route("/v1/responses", post(mock_responses))
+        .with_state(state.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+    let address = listener.local_addr().expect("mock address");
+    let task = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{address}/v1/responses"), state, task)
+}
+
+fn test_revision() -> BuildOauthCredentialRevision {
+    BuildOauthCredentialRevision::for_test(123, Some(456), 7)
+}
+
+fn success_payload(search_calls: usize) -> String {
+    let mut output = Vec::new();
+    for _ in 0..search_calls {
+        output.push(json!({ "type": "x_search_call", "status": "completed" }));
+    }
+    output.push(json!({
+        "type": "message",
+        "content": [{
+            "type": "output_text",
+            "text": serde_json::to_string(&json!({
+                "items": [{
+                    "fullUrl": "https://pbs.twimg.com/media/test.jpg?name=small",
+                    "thumbUrl": "https://pbs.twimg.com/media/test.jpg?name=small",
+                    "username": "alice",
+                    "postUrl": "https://x.com/alice/status/1234567890123456789",
+                    "kind": "image"
+                }]
+            })).expect("gallery json")
+        }]
+    }));
+    json!({
+        "model": RESPONSES_MODEL,
+        "output": output
+    })
+    .to_string()
+}
+
+async fn test_search(
+    endpoint: &str,
+    timeout: Duration,
+) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
+    let cancellation = WallpaperSearchCancellation::default();
+    search_with_credentials(
+        ResponsesSearchRequest {
+            query: "misty mountains",
+            sort: Some("top"),
+            endpoint,
+            max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
+            lane_index: 1,
+            target_count: 16,
+            excluded_ids: &[],
+            cancellation: &cancellation,
+        },
+        timeout,
+        Ok(("test-token", test_revision())),
+    )
+    .await
+}
+
+fn lane_item(id: &str) -> WallpaperGalleryItem {
+    WallpaperGalleryItem {
+        id: id.into(),
+        thumb_url: format!("https://pbs.twimg.com/media/{id}.jpg?name=small"),
+        full_url: format!("https://pbs.twimg.com/media/{id}.jpg?name=orig"),
+        kind: "image".into(),
+        width: None,
+        height: None,
+        source: "x".into(),
+        username: None,
+        post_url: Some(format!("https://x.com/example/status/{id}")),
+        text_preview: None,
+        likes: None,
+        local_path: None,
+        prompt: None,
+        status_id: Some(id.into()),
+        media_index: Some(1),
+        media_quality: None,
+    }
+}
+
+fn lane_success(ids: &[&str], search_calls: u32) -> ResponsesSearchSuccess {
+    ResponsesSearchSuccess {
+        items: ids.iter().map(|id| lane_item(id)).collect(),
+        candidate_count: ids.len(),
+        valid_count: ids.len(),
+        search_calls,
+        model: RESPONSES_MODEL,
+        effort: RESPONSES_EFFORT,
+        credential_revision: test_revision(),
+    }
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_parallel_lanes_emit_completion_order_and_dedupe() {
+    let captured = Arc::new(Mutex::new(Vec::<WallpaperXSearchBatch>::new()));
+    let captured_batches = Arc::clone(&captured);
+    let runtime = WallpaperXSearchRuntime::new(
+        WallpaperSearchCancellation::default(),
+        Arc::new(|_| {}),
+        Arc::new(move |batch| {
+            captured_batches
+                .lock()
+                .expect("batch capture lock")
+                .push(batch);
+        }),
+    );
+
+    let result = run_parallel_lanes(&runtime, test_revision(), |lane_index| async move {
+        match lane_index {
+            1 => {
+                tokio::time::sleep(Duration::from_millis(30)).await;
+                Ok(lane_success(&["a", "shared"], 2))
+            }
+            2 => {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                Ok(lane_success(&["b", "shared"], 2))
+            }
+            _ => {
+                tokio::time::sleep(Duration::from_millis(15)).await;
+                Err(ResponsesSearchError::new(
+                    ResponsesSearchErrorKind::Empty,
+                    Some(test_revision()),
+                )
+                .with_observed_search_calls(1))
+            }
+        }
+    })
+    .await
+    .expect("two useful lanes should return partial success");
+
+    assert_eq!(result.candidate_count, 4);
+    assert_eq!(result.valid_count, 3);
+    assert_eq!(result.search_calls, 5);
+    let mut ids = result
+        .items
+        .iter()
+        .map(|item| item.id.as_str())
+        .collect::<Vec<_>>();
+    ids.sort_unstable();
+    assert_eq!(ids, ["a", "b", "shared"]);
+
+    let batches = captured.lock().expect("batch capture lock");
+    assert_eq!(batches.len(), 2);
+    assert_eq!(batches[0].batch_index, 2);
+    assert_eq!(batches[0].items.len(), 2);
+    assert_eq!(batches[0].accumulated_count, 2);
+    assert!(!batches[0].done);
+    assert_eq!(batches[1].batch_index, 1);
+    assert_eq!(batches[1].items.len(), 1);
+    assert_eq!(batches[1].items[0].id, "a");
+    assert_eq!(batches[1].accumulated_count, 3);
+    assert!(batches[1].done);
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_parallel_cancellation_stops_all_lanes_without_batches() {
+    let captured = Arc::new(Mutex::new(Vec::<WallpaperXSearchBatch>::new()));
+    let captured_batches = Arc::clone(&captured);
+    let cancellation = WallpaperSearchCancellation::default();
+    let runtime = WallpaperXSearchRuntime::new(
+        cancellation.clone(),
+        Arc::new(|_| {}),
+        Arc::new(move |batch| {
+            captured_batches
+                .lock()
+                .expect("batch capture lock")
+                .push(batch);
+        }),
+    );
+    let run = run_parallel_lanes(&runtime, test_revision(), |_| async {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        Ok(lane_success(&["late"], 1))
+    });
+    let cancel = async {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancellation.cancel();
+    };
+    let (result, ()) = tokio::join!(run, cancel);
+
+    assert_eq!(
+        result.expect_err("cancelled lanes must fail").kind,
+        ResponsesSearchErrorKind::Cancelled
+    );
+    assert!(
+        captured.lock().expect("batch capture lock").is_empty(),
+        "cancelled lanes must not emit late batches"
+    );
+}
+
+#[test]
+fn wallpaper_x_responses_parallel_error_priority_prevents_cli_double_spend() {
+    let error = select_parallel_error(
+        vec![
+            ResponsesSearchError::new(ResponsesSearchErrorKind::Network, Some(test_revision())),
+            ResponsesSearchError::new(ResponsesSearchErrorKind::RateLimited, Some(test_revision())),
+        ],
+        test_revision(),
+    );
+    assert_eq!(error.kind, ResponsesSearchErrorKind::RateLimited);
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_success_parses_gallery_and_fixed_contract() {
+    assert_eq!(
+        count_x_search_calls(&[json!({
+            "type": "custom_tool_call",
+            "status": "completed"
+        })]),
+        1
+    );
+    let (endpoint, state, task) =
+        spawn_mock(StatusCode::OK, success_payload(2), Duration::ZERO).await;
+    let result = test_search(&endpoint, Duration::from_secs(2))
+        .await
+        .expect("responses success");
+    task.abort();
+
+    assert_eq!(result.items.len(), 1);
+    assert_eq!(result.candidate_count, 1);
+    assert_eq!(result.valid_count, 1);
+    assert_eq!(result.search_calls, 2);
+    assert_eq!(result.model, "grok-4.6");
+    assert_eq!(result.effort, "low");
+    assert!(result.items[0].full_url.contains("name=orig"));
+    assert_eq!(state.requests.load(Ordering::SeqCst), 1);
+    assert!(state.authorization_ok.load(Ordering::SeqCst));
+
+    let request = state
+        .request_body
+        .lock()
+        .expect("request body lock")
+        .clone()
+        .expect("captured request");
+    assert_eq!(request.get("model"), Some(&json!("grok-4.6")));
+    assert_eq!(request.pointer("/reasoning/effort"), Some(&json!("low")));
+    assert_eq!(request.get("store"), Some(&json!(false)));
+    assert_eq!(request.get("max_tool_calls"), Some(&json!(2)));
+    assert_eq!(request.pointer("/tools/0/type"), Some(&json!("x_search")));
+    assert_eq!(
+        request.pointer("/text/format/type"),
+        Some(&json!("json_schema"))
+    );
+    assert_eq!(request.pointer("/text/format/strict"), Some(&json!(true)));
+    assert_eq!(
+        request.pointer("/text/format/schema/additionalProperties"),
+        Some(&json!(false))
+    );
+    assert!(request
+        .get("input")
+        .and_then(Value::as_str)
+        .is_some_and(|prompt| prompt.contains("no more than 2 x_search call")));
+    let visual_lane = responses_request(
+        "misty mountains",
+        Some("top"),
+        RESPONSES_LANE_MAX_X_SEARCH_CALLS,
+        2,
+        RESPONSES_LANE_TARGET_COUNT,
+        &[],
+    );
+    assert_eq!(visual_lane.get("max_tool_calls"), Some(&json!(3)));
+    assert_eq!(
+        visual_lane.pointer("/text/format/schema/properties/items/maxItems"),
+        Some(&json!(8))
+    );
+    assert!(visual_lane
+        .get("input")
+        .and_then(Value::as_str)
+        .is_some_and(|prompt| {
+            prompt.contains("Visual-variation batch") && prompt.contains("Return 8 distinct items")
+        }));
+    assert_eq!(
+        RESPONSES_LANE_COUNT as u32 * RESPONSES_LANE_MAX_X_SEARCH_CALLS,
+        9
+    );
+    let excluded = vec!["twimg:seen-id".into(), "status:12345678:1".into()];
+    let load_more = responses_request(
+        "misty mountains",
+        Some("top"),
+        RESPONSES_LANE_MAX_X_SEARCH_CALLS,
+        4,
+        RESPONSES_LANE_TARGET_COUNT,
+        &excluded,
+    );
+    assert!(load_more
+        .get("input")
+        .and_then(Value::as_str)
+        .is_some_and(|prompt| {
+            prompt.contains("User-requested load-more batch")
+                && prompt.contains("twimg:seen-id")
+                && prompt.contains("status:12345678:1")
+        }));
+}
+
+#[test]
+fn wallpaper_x_responses_counts_only_completed_call_records() {
+    let output = [
+        json!({ "type": "x_search_result", "status": "completed" }),
+        json!({ "type": "x_search_call", "status": "in_progress" }),
+        json!({ "type": "custom_tool_result", "status": "completed" }),
+        json!({ "type": "custom_tool_call_extra", "status": "completed" }),
+        json!({ "type": "tool_call", "name": "other", "status": "completed" }),
+        json!({ "type": "x_search_call", "status": "completed" }),
+        json!({
+            "type": "server_tool_use",
+            "name": "x_search",
+            "status": "completed"
+        }),
+    ];
+
+    assert_eq!(count_x_search_calls(&output), 2);
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_classifies_http_failures() {
+    for (status, expected) in [
+        (
+            StatusCode::BAD_REQUEST,
+            ResponsesSearchErrorKind::BadRequest,
+        ),
+        (
+            StatusCode::UNAUTHORIZED,
+            ResponsesSearchErrorKind::Unauthorized,
+        ),
+        (
+            StatusCode::FORBIDDEN,
+            ResponsesSearchErrorKind::Unauthorized,
+        ),
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            ResponsesSearchErrorKind::RateLimited,
+        ),
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ResponsesSearchErrorKind::ServerError,
+        ),
+    ] {
+        let (endpoint, _state, task) = spawn_mock(status, "redacted", Duration::ZERO).await;
+        let error = test_search(&endpoint, Duration::from_secs(2))
+            .await
+            .expect_err("http status must fail");
+        task.abort();
+        assert_eq!(error.kind, expected);
+        assert_eq!(error.code(), expected.code());
+    }
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_classifies_timeout_invalid_json_and_empty() {
+    let (endpoint, _state, task) = spawn_mock(
+        StatusCode::OK,
+        success_payload(1),
+        Duration::from_millis(150),
+    )
+    .await;
+    let error = test_search(&endpoint, Duration::from_millis(25))
+        .await
+        .expect_err("request must time out");
+    task.abort();
+    assert_eq!(error.kind, ResponsesSearchErrorKind::Timeout);
+
+    let (endpoint, _state, task) = spawn_mock(StatusCode::OK, "not-json", Duration::ZERO).await;
+    let error = test_search(&endpoint, Duration::from_secs(2))
+        .await
+        .expect_err("invalid json must fail");
+    task.abort();
+    assert_eq!(error.kind, ResponsesSearchErrorKind::InvalidJson);
+
+    let (endpoint, _state, task) = spawn_mock(StatusCode::OK, "", Duration::ZERO).await;
+    let error = test_search(&endpoint, Duration::from_secs(2))
+        .await
+        .expect_err("empty response must fail");
+    task.abort();
+    assert_eq!(error.kind, ResponsesSearchErrorKind::Empty);
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_classifies_proxy_dns_and_connection_failures_as_network() {
+    let (proxy_address, proxy_task) = spawn_raw_response(
+        b"HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        Duration::ZERO,
+    )
+    .await;
+    let proxy_client = reqwest::Client::builder()
+        .no_proxy()
+        .proxy(reqwest::Proxy::all(format!("http://{proxy_address}")).expect("synthetic proxy URL"))
+        .timeout(Duration::from_secs(1))
+        .build()
+        .expect("proxy client");
+    let proxy_error = proxy_client
+        .get("https://wallpaper-search.invalid")
+        .send()
+        .await
+        .expect_err("proxy must reject the CONNECT request");
+    proxy_task.abort();
+    assert_eq!(
+        transport_error_kind(&proxy_error),
+        ResponsesSearchErrorKind::Network,
+        "proxy error: {proxy_error:?}"
+    );
+
+    let dns_client = reqwest::Client::builder()
+        .no_proxy()
+        .dns_resolver(Arc::new(FailingDnsResolver))
+        .timeout(Duration::from_secs(1))
+        .build()
+        .expect("DNS client");
+    let dns_error = dns_client
+        .get("http://wallpaper-search.invalid")
+        .send()
+        .await
+        .expect_err("synthetic DNS must fail");
+    assert_eq!(
+        transport_error_kind(&dns_error),
+        ResponsesSearchErrorKind::Network
+    );
+
+    let (reset_address, reset_task) = spawn_raw_response(
+        b"HTTP/1.1 200 OK\r\nContent-Length: 64\r\nConnection: close\r\n\r\npartial",
+        Duration::ZERO,
+    )
+    .await;
+    let reset_client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("reset client");
+    let reset_error = match reset_client
+        .get(format!("http://{reset_address}"))
+        .send()
+        .await
+    {
+        Ok(response) => response
+            .bytes()
+            .await
+            .expect_err("truncated response body must fail"),
+        Err(error) => error,
+    };
+    reset_task.abort();
+    assert_eq!(
+        transport_error_kind(&reset_error),
+        ResponsesSearchErrorKind::Network
+    );
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_classifies_tls_markers_and_timeout_transport_failures() {
+    for message in [
+        "TLS handshake failed",
+        "invalid peer certificate: UnknownIssuer",
+    ] {
+        assert_eq!(
+            classify_transport_error(false, &SyntheticTransportError(message)),
+            ResponsesSearchErrorKind::Tls
+        );
+    }
+    assert_eq!(
+        classify_transport_error(false, &SyntheticTransportError("connection reset by peer")),
+        ResponsesSearchErrorKind::Network
+    );
+
+    let (timeout_address, timeout_task) =
+        spawn_raw_response(b"HTTP/1.1 204 No Content\r\n\r\n", Duration::from_secs(1)).await;
+    let timeout_error = reqwest::Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_millis(25))
+        .build()
+        .expect("timeout client")
+        .get(format!("http://{timeout_address}"))
+        .send()
+        .await
+        .expect_err("delayed response must time out");
+    timeout_task.abort();
+    assert_eq!(
+        transport_error_kind(&timeout_error),
+        ResponsesSearchErrorKind::Timeout
+    );
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_cancellation_aborts_inflight_http() {
+    let (endpoint, state, task) =
+        spawn_mock(StatusCode::OK, success_payload(1), Duration::from_secs(10)).await;
+    let cancellation = WallpaperSearchCancellation::default();
+    let cancellation_for_request = cancellation.clone();
+    let request = tokio::spawn(async move {
+        search_with_credentials(
+            ResponsesSearchRequest {
+                query: "misty mountains",
+                sort: Some("top"),
+                endpoint: &endpoint,
+                max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
+                lane_index: 1,
+                target_count: 16,
+                excluded_ids: &[],
+                cancellation: &cancellation_for_request,
+            },
+            Duration::from_secs(30),
+            Ok(("test-token", test_revision())),
+        )
+        .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while state.requests.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("mock request did not start");
+    cancellation.cancel();
+    let error = tokio::time::timeout(Duration::from_secs(2), request)
+        .await
+        .expect("cancelled request did not return")
+        .expect("request task panicked")
+        .expect_err("cancelled request must fail");
+    task.abort();
+    assert_eq!(error.kind, ResponsesSearchErrorKind::Cancelled);
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_rejects_bad_structured_output_and_tool_overrun() {
+    let invalid_output = json!({
+        "output": [
+            { "type": "x_search_call", "status": "completed" },
+            {
+                "type": "message",
+                "content": [{ "type": "output_text", "text": "not-json" }]
+            }
+        ]
+    })
+    .to_string();
+    let (endpoint, _state, task) = spawn_mock(StatusCode::OK, invalid_output, Duration::ZERO).await;
+    let error = test_search(&endpoint, Duration::from_secs(2))
+        .await
+        .expect_err("bad structured output must fail");
+    task.abort();
+    assert_eq!(error.kind, ResponsesSearchErrorKind::InvalidJson);
+
+    let (endpoint, _state, task) =
+        spawn_mock(StatusCode::OK, success_payload(0), Duration::ZERO).await;
+    let error = test_search(&endpoint, Duration::from_secs(2))
+        .await
+        .expect_err("structured output without a real X tool call must fail");
+    task.abort();
+    assert_eq!(error.kind, ResponsesSearchErrorKind::ToolNotCalled);
+    assert_eq!(error.observed_search_calls, Some(0));
+
+    let (endpoint, _state, task) =
+        spawn_mock(StatusCode::OK, success_payload(4), Duration::ZERO).await;
+    let error = test_search(&endpoint, Duration::from_secs(2))
+        .await
+        .expect_err("tool overrun must fail");
+    task.abort();
+    assert_eq!(error.kind, ResponsesSearchErrorKind::SearchBudgetExceeded);
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_oauth_failure_sends_no_request() {
+    let (endpoint, state, task) =
+        spawn_mock(StatusCode::OK, success_payload(1), Duration::ZERO).await;
+    for (oauth_error, expected) in [
+        (
+            BuildOauthTokenError::Unavailable,
+            ResponsesSearchErrorKind::OauthUnavailable,
+        ),
+        (
+            BuildOauthTokenError::Expired,
+            ResponsesSearchErrorKind::OauthExpired,
+        ),
+    ] {
+        let cancellation = WallpaperSearchCancellation::default();
+        let error = search_with_credentials(
+            ResponsesSearchRequest {
+                query: "misty mountains",
+                sort: Some("top"),
+                endpoint: &endpoint,
+                max_search_calls: X_SEARCH_FIRST_ROUND_CALLS,
+                lane_index: 1,
+                target_count: 16,
+                excluded_ids: &[],
+                cancellation: &cancellation,
+            },
+            Duration::from_secs(2),
+            Err(oauth_error),
+        )
+        .await
+        .expect_err("oauth failure must stop before HTTP");
+        assert_eq!(error.kind, expected);
+    }
+    task.abort();
+    assert_eq!(state.requests.load(Ordering::SeqCst), 0);
+}
+
+#[derive(Clone)]
+struct RedirectState {
+    target: String,
+    source_requests: Arc<AtomicUsize>,
+    target_requests: Arc<AtomicUsize>,
+    target_saw_authorization: Arc<AtomicBool>,
+}
+
+async fn redirect_source(State(state): State<RedirectState>) -> Response {
+    state.source_requests.fetch_add(1, Ordering::SeqCst);
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = StatusCode::TEMPORARY_REDIRECT;
+    response.headers_mut().insert(
+        reqwest::header::LOCATION,
+        HeaderValue::from_str(&state.target).expect("redirect target header"),
+    );
+    response
+}
+
+async fn redirect_target(State(state): State<RedirectState>, headers: HeaderMap) -> Response {
+    state.target_requests.fetch_add(1, Ordering::SeqCst);
+    state.target_saw_authorization.store(
+        headers.contains_key(reqwest::header::AUTHORIZATION),
+        Ordering::SeqCst,
+    );
+    (StatusCode::OK, success_payload(1)).into_response()
+}
+
+#[tokio::test]
+async fn wallpaper_x_responses_never_replays_authorization_across_redirect() {
+    let target_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind redirect target");
+    let target_address = target_listener.local_addr().expect("target address");
+    let state = RedirectState {
+        target: format!("http://{target_address}/target"),
+        source_requests: Arc::new(AtomicUsize::new(0)),
+        target_requests: Arc::new(AtomicUsize::new(0)),
+        target_saw_authorization: Arc::new(AtomicBool::new(false)),
+    };
+    let target_app = Router::new()
+        .route("/target", post(redirect_target))
+        .with_state(state.clone());
+    let target_task = tokio::spawn(async move {
+        let _ = axum::serve(target_listener, target_app).await;
+    });
+
+    let source_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind redirect source");
+    let source_address = source_listener.local_addr().expect("source address");
+    let source_app = Router::new()
+        .route("/v1/responses", post(redirect_source))
+        .with_state(state.clone());
+    let source_task = tokio::spawn(async move {
+        let _ = axum::serve(source_listener, source_app).await;
+    });
+
+    let error = test_search(
+        &format!("http://{source_address}/v1/responses"),
+        Duration::from_secs(2),
+    )
+    .await
+    .expect_err("redirect must be a protocol failure");
+    source_task.abort();
+    target_task.abort();
+
+    assert_eq!(error.kind, ResponsesSearchErrorKind::Protocol);
+    assert_eq!(state.source_requests.load(Ordering::SeqCst), 1);
+    assert_eq!(state.target_requests.load(Ordering::SeqCst), 0);
+    assert!(!state.target_saw_authorization.load(Ordering::SeqCst));
+}

--- a/src-tauri/src/wallpaper_x_search.rs
+++ b/src-tauri/src/wallpaper_x_search.rs
@@ -28,6 +28,18 @@ struct WallpaperXSearchProgress {
     request_id: String,
     stage: WallpaperXSearchStage,
 }
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WallpaperXSearchBatchEvent {
+    request_id: String,
+    batch_index: usize,
+    items: Vec<wallpaper_source::WallpaperGalleryItem>,
+    accumulated_count: usize,
+    done: bool,
+}
+
+const WALLPAPER_X_SEARCH_BATCH_EVENT: &str = "wallpaper://x-search-batch";
+
 #[derive(Default)]
 struct RequestRegistry {
     active: HashMap<String, WallpaperSearchCancellation>,
@@ -126,6 +138,8 @@ pub(crate) async fn search(
     let request = register_request(request_id)?;
     let event_app = app.clone();
     let event_request_id = request_id.to_string();
+    let batch_app = app.clone();
+    let batch_request_id = request_id.to_string();
     let runtime = WallpaperXSearchRuntime::new(
         request.cancellation.clone(),
         Arc::new(move |stage| {
@@ -134,6 +148,18 @@ pub(crate) async fn search(
                 WallpaperXSearchProgress {
                     request_id: event_request_id.clone(),
                     stage,
+                },
+            );
+        }),
+        Arc::new(move |batch| {
+            let _ = batch_app.emit(
+                WALLPAPER_X_SEARCH_BATCH_EVENT,
+                WallpaperXSearchBatchEvent {
+                    request_id: batch_request_id.clone(),
+                    batch_index: batch.batch_index,
+                    items: batch.items,
+                    accumulated_count: batch.accumulated_count,
+                    done: batch.done,
                 },
             );
         }),
@@ -485,6 +511,7 @@ mod tests {
                     Err(ResponsesSearchError {
                         kind,
                         credential_revision: None,
+                        observed_search_calls: None,
                     })
                 },
                 || async { panic!("must not double-request after limit") },
@@ -508,6 +535,7 @@ mod tests {
                 Err(ResponsesSearchError {
                     kind: ResponsesSearchErrorKind::Network,
                     credential_revision: None,
+                    observed_search_calls: None,
                 })
             },
             || async {

--- a/src/components/WallpaperSourceModal.test.tsx
+++ b/src/components/WallpaperSourceModal.test.tsx
@@ -5,10 +5,12 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@/test/jsdomStubs";
 
+const progressive = vi.hoisted(() => ({ items: [] as Array<{ id: string; source: string; kind: string; fullUrl: string; thumbUrl: string; textPreview: string }> }));
 const cancelSearch = vi.hoisted(() => vi.fn(async () => true));
 
 vi.mock("@/hooks/useWallpaperXSearch", () => ({
   useWallpaperXSearch: () => ({
+    progressiveItems: progressive.items,
     busy: true,
     requestId: "request-active",
     stage: "validating",
@@ -64,6 +66,7 @@ import { WallpaperSourceModal } from "./WallpaperSourceModal";
 afterEach(() => {
   cleanup();
   cancelSearch.mockClear();
+  progressive.items = [];
 });
 
 describe("WallpaperSourceModal X search lifecycle", () => {
@@ -110,4 +113,11 @@ describe("WallpaperSourceModal X search lifecycle", () => {
     expect(cancelSearch).toHaveBeenCalledTimes(2);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+});
+
+it("renders validated batches while the request is still running", () => {
+  progressive.items = [{ id: "early", source: "x", kind: "image", fullUrl: "https://pbs.twimg.com/media/early.jpg", thumbUrl: "https://pbs.twimg.com/media/early.jpg", textPreview: "Early mountain image" }];
+  render(<WallpaperSourceModal open t={((key: string) => key) as never} onClose={vi.fn()} onPickFile={vi.fn()} />);
+  expect(screen.getByRole("list").getAttribute("aria-busy")).toBe("true");
+  expect(screen.getByRole("img").getAttribute("src")).toBe("https://pbs.twimg.com/media/early.jpg");
 });

--- a/src/components/WallpaperSourceModal.tsx
+++ b/src/components/WallpaperSourceModal.tsx
@@ -121,6 +121,7 @@ export function WallpaperSourceModal({
   const {
     busy: xBusy,
     stage: xStage,
+    progressiveItems,
     search: searchX,
     cancel: cancelX,
   } = useWallpaperXSearch();
@@ -157,15 +158,16 @@ export function WallpaperSourceModal({
     setItems([]);
   }, [open, initialTab]);
 
-  const kindCounts = useMemo(() => countGalleryByKind(items), [items]);
+  const galleryItems = xBusy && progressiveItems.length > 0 ? progressiveItems : items;
+  const kindCounts = useMemo(() => countGalleryByKind(galleryItems), [galleryItems]);
 
   const visibleItems = useMemo(
     () =>
-      filterGalleryItems(items, {
+      filterGalleryItems(galleryItems, {
         query: galleryFilter,
         kind: kindFilter,
       }),
-    [items, galleryFilter, kindFilter],
+    [galleryItems, galleryFilter, kindFilter],
   );
 
   const filtersActive = wallpaperGalleryHasActiveFilters({
@@ -181,7 +183,7 @@ export function WallpaperSourceModal({
       error: errorCode
         ? { code: errorCode, message: error ?? errorCode }
         : error,
-      totalCount: items.length,
+      totalCount: galleryItems.length,
       kindFilter,
       hasSearched,
     });
@@ -204,7 +206,7 @@ export function WallpaperSourceModal({
     visibleItems.length,
     errorCode,
     error,
-    items.length,
+    galleryItems.length,
     kindFilter,
     hasSearched,
     tab,
@@ -583,7 +585,7 @@ export function WallpaperSourceModal({
 
   const authNeeded = errorCode === "auth_required";
   const locked = busy || applying || previewingId !== null;
-  const showGalleryFilters = items.length > 0 || filtersActive;
+  const showGalleryFilters = galleryItems.length > 0 || filtersActive;
   const softFailError =
     galleryErrorKind != null && isWallpaperGallerySoftFail(galleryErrorKind);
   // Error banner already carries detail for empty/error — avoid stacking the

--- a/src/hooks/useWallpaperXSearch.test.tsx
+++ b/src/hooks/useWallpaperXSearch.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { useWallpaperXSearch, type WallpaperXSearchClient } from "./useWallpaperXSearch";
 import type { WallpaperSearchResult } from "@/lib/wallpaperSource";
-import type { WallpaperXSearchProgress } from "@/lib/wallpaperXSearch";
+import type { WallpaperXSearchProgress, WallpaperXSearchBatch } from "@/lib/wallpaperXSearch";
 
 afterEach(cleanup);
 function deferred<T>() {
@@ -13,15 +13,17 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 function harness() {
+  let emitBatch!: (event: WallpaperXSearchBatch) => void;
   let emit!: (event: WallpaperXSearchProgress) => void;
   const unlisten = vi.fn();
   const client: WallpaperXSearchClient = {
+    listenBatch: vi.fn(async (handler) => { emitBatch = handler; return () => {}; }),
     search: vi.fn(), cancel: vi.fn(async () => true),
     listenProgress: vi.fn(async (handler) => { emit = handler; return unlisten; }),
   };
   let nextId = 0;
   const hook = renderHook(() => useWallpaperXSearch(client, () => String(++nextId)));
-  return { client, hook, unlisten, emit: (event: WallpaperXSearchProgress) => emit(event) };
+  return { client, hook, unlisten, emitBatch: (event: WallpaperXSearchBatch) => emitBatch(event), emit: (event: WallpaperXSearchProgress) => emit(event) };
 }
 
 it("accepts progress only for the active request and ignores late success after cancel", async () => {
@@ -70,4 +72,49 @@ it("unmount cancels the Host and late listener registration cleans itself up", a
   expect(await result).toBeNull();
   await Promise.resolve();
   expect(h.unlisten).toHaveBeenCalledTimes(1);
+});
+
+function batch(requestId: string, batchIndex: number, ids: string[], done = false): WallpaperXSearchBatch {
+  return { requestId, batchIndex, done, accumulatedCount: ids.length,
+    items: ids.map(id => ({ id, source: "x", kind: "image", fullUrl: `https://pbs.twimg.com/media/${id}.jpg`, thumbUrl: `https://pbs.twimg.com/media/${id}.jpg` })) };
+}
+
+it("shows out-of-order batches once and ignores foreign, malformed and cancelled batches", async () => {
+  const h = harness();
+  const pending = deferred<WallpaperSearchResult>();
+  vi.mocked(h.client.search).mockReturnValue(pending.promise);
+  let result!: Promise<WallpaperSearchResult | null>;
+  act(() => { result = h.hook.result.current.search("sky", "top"); });
+  act(() => {
+    h.emitBatch(batch("other", 1, ["foreign"]));
+    h.emitBatch({ ...batch("1", 1, ["bad"]), batchIndex: -1 });
+    h.emitBatch(batch("1", 2, ["b", "shared"]));
+    h.emitBatch(batch("1", 2, ["duplicate-event"]));
+    h.emitBatch(batch("1", 1, ["a", "shared"], true));
+  });
+  expect(h.hook.result.current.progressiveItems.map(item => item.id)).toEqual(["b", "shared", "a"]);
+  expect(h.hook.result.current.busy).toBe(true);
+  await act(async () => { await h.hook.result.current.cancel(); });
+  act(() => h.emitBatch(batch("1", 3, ["late"], true)));
+  expect(h.hook.result.current.progressiveItems).toEqual([]);
+  await act(async () => { pending.resolve({ items: [] }); expect(await result).toBeNull(); });
+});
+
+it("resets batches for replacement and trusts the final invoke result", async () => {
+  const h = harness();
+  const first = deferred<WallpaperSearchResult>();
+  const second = deferred<WallpaperSearchResult>();
+  vi.mocked(h.client.search).mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+  let a!: Promise<WallpaperSearchResult | null>;
+  let b!: Promise<WallpaperSearchResult | null>;
+  act(() => { a = h.hook.result.current.search("sky", "top"); });
+  act(() => h.emitBatch(batch("1", 1, ["old"])));
+  act(() => { b = h.hook.result.current.search("sea", "top"); });
+  expect(h.hook.result.current.progressiveItems).toEqual([]);
+  act(() => { h.emitBatch(batch("1", 2, ["late"])); h.emitBatch(batch("2", 1, ["preview"])); });
+  const final = { items: batch("2", 1, ["final"]).items };
+  await act(async () => { first.resolve({ items: [] }); second.resolve(final); expect(await a).toBeNull(); expect(await b).toEqual(final); });
+  expect(h.hook.result.current.busy).toBe(false);
+  act(() => h.emitBatch(batch("2", 2, ["too-late"])));
+  expect(h.hook.result.current.progressiveItems.map(item => item.id)).toEqual(["preview"]);
 });

--- a/src/hooks/useWallpaperXSearch.ts
+++ b/src/hooks/useWallpaperXSearch.ts
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import * as api from "@/lib/api";
-import { createWallpaperXSearchRequestId, isWallpaperXSearchProgress, type WallpaperXSearchProgress, type WallpaperXSearchStage } from "@/lib/wallpaperXSearch";
-import type { WallpaperSearchResult } from "@/lib/wallpaperSource";
+import { createWallpaperXSearchRequestId, isWallpaperXSearchBatch, type WallpaperXSearchBatch, isWallpaperXSearchProgress, type WallpaperXSearchProgress, type WallpaperXSearchStage } from "@/lib/wallpaperXSearch";
+import { dedupeGalleryItems, type WallpaperGalleryItem, type WallpaperSearchResult } from "@/lib/wallpaperSource";
 
 export type WallpaperXSearchClient = {
   search: (query: string, sort: "top" | "latest", requestId: string) => Promise<WallpaperSearchResult>;
+  listenBatch: (handler: (batch: WallpaperXSearchBatch) => void) => Promise<() => void>;
   cancel: (requestId: string) => Promise<boolean>;
   listenProgress: (handler: (progress: WallpaperXSearchProgress) => void) => Promise<() => void>;
 };
@@ -13,7 +14,51 @@ const DEFAULT_CLIENT: WallpaperXSearchClient = {
   search: api.wallpaperXSearch,
   cancel: api.wallpaperXSearchCancel,
   listenProgress: api.listenWallpaperXSearchProgress,
+  listenBatch: api.listenWallpaperXSearchBatch,
 };
+
+type ProgressiveState = {
+  items: WallpaperGalleryItem[];
+  accumulatedCount: number;
+  done: boolean;
+  seenBatchIndexes: ReadonlySet<number>;
+};
+
+type ProgressiveAction =
+  | { type: "reset" }
+  | { type: "batch"; batch: WallpaperXSearchBatch };
+
+const EMPTY_PROGRESSIVE_STATE: ProgressiveState = {
+  items: [],
+  accumulatedCount: 0,
+  done: false,
+  seenBatchIndexes: new Set(),
+};
+
+function progressiveReducer(
+  state: ProgressiveState,
+  action: ProgressiveAction,
+): ProgressiveState {
+  if (action.type === "reset") return EMPTY_PROGRESSIVE_STATE;
+  const { batch } = action;
+  if (state.seenBatchIndexes.has(batch.batchIndex)) {
+    const done = state.done || batch.done;
+    return done === state.done ? state : { ...state, done };
+  }
+  const items = dedupeGalleryItems([...state.items, ...batch.items]);
+  const seenBatchIndexes = new Set(state.seenBatchIndexes);
+  seenBatchIndexes.add(batch.batchIndex);
+  return {
+    items,
+    accumulatedCount: Math.max(
+      state.accumulatedCount,
+      batch.accumulatedCount,
+      items.length,
+    ),
+    done: state.done || batch.done,
+    seenBatchIndexes,
+  };
+}
 
 export function useWallpaperXSearch(
   client: WallpaperXSearchClient = DEFAULT_CLIENT,
@@ -21,6 +66,7 @@ export function useWallpaperXSearch(
 ) {
   const [busy, setBusy] = useState(false);
   const [stage, setStage] = useState<WallpaperXSearchStage | null>(null);
+  const [progressive, dispatchProgressive] = useReducer(progressiveReducer, EMPTY_PROGRESSIVE_STATE);
   const active = useRef<string | null>(null);
   const generation = useRef(0);
   const mounted = useRef(true);
@@ -29,6 +75,13 @@ export function useWallpaperXSearch(
     mounted.current = true;
     let disposed = false;
     let unlisten: (() => void) | undefined;
+    let unlistenBatch: (() => void) | undefined;
+    void client.listenBatch((event) => {
+      if (!disposed && mounted.current && isWallpaperXSearchBatch(event) && event.requestId === active.current) {
+        dispatchProgressive({ type: "batch", batch: event });
+      }
+    }).then((cleanup) => { if (disposed) cleanup(); else unlistenBatch = cleanup; })
+      .catch(() => { /* Invoke result remains authoritative if event registration fails. */ });
     void client.listenProgress((event) => {
       if (!disposed && isWallpaperXSearchProgress(event) && event.requestId === active.current) {
         setStage(event.stage);
@@ -44,6 +97,7 @@ export function useWallpaperXSearch(
       const id = active.current;
       active.current = null;
       unlisten?.();
+      unlistenBatch?.();
       if (id) void client.cancel(id).catch(() => false);
     };
   }, [client]);
@@ -53,6 +107,7 @@ export function useWallpaperXSearch(
     generation.current += 1;
     active.current = null;
     if (mounted.current) {
+      dispatchProgressive({ type: "reset" });
       setBusy(false);
       setStage(null);
     }
@@ -85,5 +140,5 @@ export function useWallpaperXSearch(
     }
   }, [cancel, client, requestIdFactory]);
 
-  return { busy, stage, search, cancel };
+  return { busy, stage, search, cancel, progressiveItems: progressive.items };
 }

--- a/src/lib/api/wallpaper.ts
+++ b/src/lib/api/wallpaper.ts
@@ -158,3 +158,9 @@ export async function wallpaperLibraryDelete(path: string): Promise<void> {
   await invoke<void>("wallpaper_library_delete", { path });
 }
 
+
+export async function listenWallpaperXSearchBatch(
+  handler: (batch: import("../wallpaperXSearch").WallpaperXSearchBatch) => void,
+): Promise<() => void> {
+  return listen<import("../wallpaperXSearch").WallpaperXSearchBatch>("wallpaper://x-search-batch", handler);
+}

--- a/src/lib/wallpaperXSearch.ts
+++ b/src/lib/wallpaperXSearch.ts
@@ -1,3 +1,5 @@
+import type { WallpaperGalleryItem } from "./wallpaperSource";
+
 export type WallpaperXSearchStage =
   | "preparing"
   | "searching_x"
@@ -21,4 +23,47 @@ export function isWallpaperXSearchProgress(value: unknown): value is WallpaperXS
   return typeof event.requestId === "string" && event.requestId.length > 0 &&
     typeof event.stage === "string" &&
     ["preparing", "searching_x", "validating", "supplementing", "falling_back", "done"].includes(event.stage);
+}
+
+export type WallpaperXSearchBatch = {
+  requestId: string;
+  batchIndex: number;
+  items: WallpaperGalleryItem[];
+  accumulatedCount: number;
+  done: boolean;
+};
+
+export function isWallpaperXSearchBatch(
+  value: unknown,
+): value is WallpaperXSearchBatch {
+  if (!value || typeof value !== "object") return false;
+  const batch = value as Partial<WallpaperXSearchBatch>;
+  return (
+    typeof batch.requestId === "string" &&
+    batch.requestId.length > 0 &&
+    Number.isInteger(batch.batchIndex) &&
+    (batch.batchIndex ?? 0) >= 1 &&
+    Array.isArray(batch.items) &&
+    batch.items.every(isWallpaperGalleryItem) &&
+    Number.isInteger(batch.accumulatedCount) &&
+    (batch.accumulatedCount ?? -1) >= batch.items.length &&
+    typeof batch.done === "boolean"
+  );
+}
+
+function isWallpaperGalleryItem(value: unknown): value is WallpaperGalleryItem {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<WallpaperGalleryItem>;
+  return (
+    typeof item.id === "string" &&
+    item.id.length > 0 &&
+    typeof item.thumbUrl === "string" &&
+    item.thumbUrl.length > 0 &&
+    typeof item.fullUrl === "string" &&
+    item.fullUrl.length > 0 &&
+    typeof item.kind === "string" &&
+    item.kind.length > 0 &&
+    typeof item.source === "string" &&
+    item.source.length > 0
+  );
 }


### PR DESCRIPTION
## Summary

Responses 预览搜索由等待完整单路结果改为三路并发，每路目标 8 张，图片通过原有质量校验后逐批显示；最终最多保留 24 张。三路共用一次官方凭据读取和 HTTP client，默认 CLI 路线不变。

- 每路最多三次 X 工具调用，总上限九次；分别覆盖直接主题、视觉变化、延伸发现。数量是目标，不足时不伪造结果。
- 按完成顺序发送批次，Host 按媒体/帖子身份去重并保留部分成功。所有路都失败时优先报告限流/预算错误，避免额外 CLI 请求；取消会丢弃全部未完成请求。
- 前端按 requestId 隔离，处理乱序/重复批次，取消或重搜立即失效，最终 invoke 结果为准。没有增加 App/AppWorkbench 状态。
- 原客户端测试移到子模块，继续保留完成工具证据、固定地址/模型、token 不重定向、有界输出和网络分类测试。

依赖 #1088；目标为上游 main，当前包含该未合入前置。只审本批可查看最后一个提交；#1088 合入后会立即更新基线并移除重复差异。新功能保持 UI hold，不请求自动合并。本批只包含首轮三路与渐进显示，加载更多、预加载、其他来源继续分批交付。

已检索开放/关闭 wallpaper Issues，没有直接对应本主题的 Issue，不添加自动关闭引用。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Validation

本批提交 33f473b4：11 文件 +1296/-608，包含客户端测试迁移到 776 行子模块。7,075 项前端测试、1,683 项 Rust 测试通过（另 1 项原有 ignored）；typecheck、lint、UI build、Rust fmt/clippy、质量门禁、网站 self-test、依赖检查及生产审计均通过。Windows harness 使用仓库 Common Controls manifest。覆盖批次乱序/重复/取消/替换、真实渐进卡片、并发部分成功与去重、限流优先级、HTTP 超时/错误/工具证据/重定向。未进行真实账号端到端或桌面手动验收，不把自动测试视为线上耗时、结果数量或账号风险保证。

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included
