### PR TITLE
feat(wallpaper): 缓存已验证的 Responses 搜索结果

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -49,7 +49,7 @@ to prevent an additional CLI request. Cancellation drops all pending lanes.
 The picker displays batches as they arrive; the final invoke result is authoritative.
 The hook rejects malformed, duplicate and foreign-request batches and clears them
 on replacement/cancel. Batch event failure cannot prevent the final result from
-showing. Load-more, caching and prefetch are separate follow-up slices.
+showing. Load-more and prefetch are separate follow-up slices.
 
 Eligible failures fall back once to CLI. Rate limits, cancellation and tool-budget
 violations never trigger a second route. Three counted failures open a ten-minute
@@ -85,3 +85,22 @@ Tests in `src-tauri/src/wallpaper_source.rs` cover URL identity, deduplication,
 ranking, supplement thresholds, signatures, dimensions, redirects and rejection
 of partial download responses. Network availability, model relevance and actual
 result counts still depend on the live service and require manual verification.
+
+## Responses result cache
+
+Explicit Responses preview searches reuse successful validated galleries for ten
+minutes in a Host-only LRU with at most 32 entries. Keys include normalized query,
+sort and the salted credential content revision. Only metadata is kept in memory;
+no token, image bytes or disk cache is added. CLI/default/auto and CLI fallbacks
+are not cached because their account/provider scope differs from official OAuth.
+
+Every lookup revalidates OAuth scope and expiry. Expired/missing/replaced credentials
+cannot retrieve the old entry. A credential change during a request prevents cache
+insertion. Failures and cancelled work are not cached; cancellation and cache writes
+share a commit gate. Reads update LRU order but never extend the ten-minute TTL.
+
+A hit emits a request-scoped terminal batch and the normal final result. Metadata
+reports cacheHit, the new requestId, lookup duration and zero new search calls;
+the picker labels the result as cached. Cache reuse saves repeat searches only;
+it does not improve the first live request or guarantee an old CDN URL remains
+reachable. Existing preview/download validation continues to handle expired media.

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -117,6 +117,7 @@ pub(crate) struct WallpaperSearchCancellation {
 struct WallpaperSearchCancellationInner {
     cancelled: AtomicBool,
     signal: tokio::sync::watch::Sender<bool>,
+    commit_gate: parking_lot::Mutex<()>,
 }
 
 impl Default for WallpaperSearchCancellation {
@@ -126,6 +127,7 @@ impl Default for WallpaperSearchCancellation {
             inner: Arc::new(WallpaperSearchCancellationInner {
                 cancelled: AtomicBool::new(false),
                 signal,
+                commit_gate: parking_lot::Mutex::new(()),
             }),
         }
     }
@@ -133,6 +135,7 @@ impl Default for WallpaperSearchCancellation {
 
 impl WallpaperSearchCancellation {
     pub(crate) fn cancel(&self) {
+        let _commit_guard = self.inner.commit_gate.lock();
         if !self.inner.cancelled.swap(true, Ordering::AcqRel) {
             self.inner.signal.send_replace(true);
         }
@@ -140,6 +143,15 @@ impl WallpaperSearchCancellation {
 
     pub(crate) fn is_cancelled(&self) -> bool {
         self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn commit_if_active<T>(&self, commit: impl FnOnce() -> T) -> Option<T> {
+        let _commit_guard = self.inner.commit_gate.lock();
+        if self.is_cancelled() {
+            None
+        } else {
+            Some(commit())
+        }
     }
 
     pub(crate) async fn cancelled(&self) {

--- a/src-tauri/src/wallpaper_x_search.rs
+++ b/src-tauri/src/wallpaper_x_search.rs
@@ -1,4 +1,5 @@
 //! Request ownership, progress and cancellation for CLI wallpaper searches.
+mod cache;
 use crate::account::BuildOauthCredentialRevision;
 use crate::wallpaper_source::{
     self, WallpaperSearchCancellation, WallpaperSearchResult, WallpaperXSearchRuntime,
@@ -167,13 +168,25 @@ pub(crate) async fn search(
     runtime.report(WallpaperXSearchStage::Preparing);
     let settings = store::load_settings();
     let mode = store::normalize_wallpaper_x_search_mode(&settings.wallpaper_x_search_mode);
-    let mut result = route_with_providers(
-        mode,
-        account::build_oauth_credential_revision(),
-        responses_circuit(),
-        &runtime,
-        || wallpaper_x_responses::search(query, sort, &runtime),
-        || wallpaper_source::x_search_cli_outcome(query, sort, Some(&runtime)),
+    let mut result = cache::search_cached(
+        cache::CacheRequest {
+            request_id,
+            query,
+            sort,
+            mode,
+            runtime: &runtime,
+        },
+        || async {
+            route_with_providers(
+                mode,
+                account::build_oauth_credential_revision(),
+                responses_circuit(),
+                &runtime,
+                || wallpaper_x_responses::search(query, sort, &runtime),
+                || wallpaper_source::x_search_cli_outcome(query, sort, Some(&runtime)),
+            )
+            .await
+        },
     )
     .await;
     if let Some(meta) = result.meta.as_mut() {

--- a/src-tauri/src/wallpaper_x_search/cache.rs
+++ b/src-tauri/src/wallpaper_x_search/cache.rs
@@ -1,0 +1,182 @@
+//! Bounded, credential-scoped metadata cache. No tokens or image bytes are stored.
+use super::*;
+
+const CAPACITY: usize = 32;
+const TTL: Duration = Duration::from_secs(10 * 60);
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct Key {
+    query: String,
+    latest: bool,
+    credential: BuildOauthCredentialRevision,
+}
+
+struct Entry {
+    inserted: Instant,
+    result: WallpaperSearchResult,
+}
+
+#[derive(Default)]
+struct Cache {
+    entries: HashMap<Key, Entry>,
+    lru: VecDeque<Key>,
+}
+
+impl Cache {
+    fn purge(&mut self, now: Instant) {
+        self.entries
+            .retain(|_, entry| now.duration_since(entry.inserted) < TTL);
+        self.lru.retain(|key| self.entries.contains_key(key));
+    }
+
+    fn get(&mut self, key: &Key, now: Instant) -> Option<WallpaperSearchResult> {
+        self.purge(now);
+        let result = self.entries.get(key)?.result.clone();
+        self.lru.retain(|other| other != key);
+        self.lru.push_back(key.clone());
+        Some(result)
+    }
+
+    fn insert(&mut self, key: Key, mut result: WallpaperSearchResult, now: Instant) {
+        self.purge(now);
+        self.lru.retain(|other| other != &key);
+        while self.entries.len() >= CAPACITY && !self.entries.contains_key(&key) {
+            if let Some(oldest) = self.lru.pop_front() {
+                self.entries.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+        if let Some(meta) = result.meta.as_mut() {
+            meta.request_id = None;
+            meta.cache_hit = false;
+        }
+        self.entries.insert(
+            key.clone(),
+            Entry {
+                inserted: now,
+                result,
+            },
+        );
+        self.lru.push_back(key);
+    }
+}
+
+pub(super) struct CacheRequest<'a> {
+    pub request_id: &'a str,
+    pub query: &'a str,
+    pub sort: Option<&'a str>,
+    pub mode: &'a str,
+    pub runtime: &'a WallpaperXSearchRuntime,
+}
+
+pub(super) async fn search_cached<F, Fut>(
+    request: CacheRequest<'_>,
+    run: F,
+) -> WallpaperSearchResult
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = WallpaperSearchResult>,
+{
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    run_cached(
+        request,
+        CACHE.get_or_init(Default::default),
+        || {
+            // Parsing validates scope and expiry, unlike file revision alone.
+            account::read_build_oauth_access_token()
+                .ok()
+                .map(|auth| auth.revision)
+        },
+        run,
+    )
+    .await
+}
+
+async fn run_cached<F, Fut, R>(
+    request: CacheRequest<'_>,
+    cache: &Mutex<Cache>,
+    revision: R,
+    run: F,
+) -> WallpaperSearchResult
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = WallpaperSearchResult>,
+    R: Fn() -> Option<BuildOauthCredentialRevision>,
+{
+    let CacheRequest {
+        request_id,
+        query,
+        sort,
+        mode,
+        runtime,
+    } = request;
+    let started = Instant::now();
+    if runtime.is_cancelled() {
+        return cancelled_result(mode, "responses", started);
+    }
+    // CLI/custom routes have different identity semantics and must not share
+    // an official-account cache. Only an explicit preview can read or write it.
+    if mode != "responses_preview" {
+        return run().await;
+    }
+    let key = revision().map(|credential| Key {
+        query: query
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase(),
+        latest: matches!(sort, Some("latest" | "Latest")),
+        credential,
+    });
+    if let Some(key) = key.as_ref() {
+        let hit = cache.lock().get(key, Instant::now());
+        if let Some(mut result) = hit {
+            if runtime.is_cancelled() {
+                return cancelled_result(mode, "responses", started);
+            }
+            if let Some(meta) = result.meta.as_mut() {
+                meta.request_id = Some(request_id.into());
+                meta.cache_hit = true;
+                meta.duration_ms = elapsed_ms(started);
+                meta.search_calls = Some(0);
+            }
+            runtime.report_batch(wallpaper_source::WallpaperXSearchBatch {
+                batch_index: 1,
+                accumulated_count: result.items.len(),
+                items: result.items.clone(),
+                done: true,
+            });
+            return result;
+        }
+    }
+    let result = run().await;
+    if runtime.is_cancelled() {
+        return cancelled_result(mode, "responses", started);
+    }
+    if result.error_code.is_none()
+        && !result.items.is_empty()
+        && result
+            .meta
+            .as_ref()
+            .is_some_and(|meta| meta.route_used == "responses")
+    {
+        if let Some(key) = key {
+            // Never associate a response with a different or now-expired login.
+            if revision().as_ref() == Some(&key.credential)
+                && runtime
+                    .cancellation()
+                    .commit_if_active(|| {
+                        cache.lock().insert(key, result.clone(), Instant::now());
+                    })
+                    .is_none()
+            {
+                return cancelled_result(mode, "responses", started);
+            }
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/wallpaper_x_search/cache/tests.rs
+++ b/src-tauri/src/wallpaper_x_search/cache/tests.rs
@@ -1,0 +1,212 @@
+use super::*;
+use std::cell::Cell;
+
+fn revision(value: u8) -> BuildOauthCredentialRevision {
+    BuildOauthCredentialRevision::for_test(1, Some(1), value)
+}
+
+fn success() -> WallpaperSearchResult {
+    let item = wallpaper_source::parse_gallery_items(
+        &serde_json::json!({"items": [{
+            "fullUrl": "https://pbs.twimg.com/media/sky.jpg", "kind": "image"
+        }]}),
+        "x",
+    )
+    .remove(0);
+    WallpaperSearchResult {
+        items: vec![item],
+        error_code: None,
+        message: None,
+        meta: Some(WallpaperSearchMeta {
+            request_id: Some("old".into()),
+            requested_mode: "responses_preview".into(),
+            route_used: "responses".into(),
+            fallback_reason: None,
+            duration_ms: 9000,
+            cache_hit: false,
+            search_calls: Some(6),
+            candidate_count: 1,
+            valid_count: 1,
+            model: Some("grok-4.6".into()),
+            effort: Some("low".into()),
+        }),
+    }
+}
+
+fn request(runtime: &WallpaperXSearchRuntime) -> CacheRequest<'_> {
+    CacheRequest {
+        request_id: "new",
+        query: " blue  SKY ",
+        sort: Some("top"),
+        mode: "responses_preview",
+        runtime,
+    }
+}
+
+#[tokio::test]
+async fn repeat_search_uses_validated_cache_without_provider_calls() {
+    let runtime = WallpaperXSearchRuntime::quiet();
+    let cache = Mutex::new(Cache::default());
+    let first = run_cached(
+        request(&runtime),
+        &cache,
+        || Some(revision(1)),
+        || async { success() },
+    )
+    .await;
+    assert!(!first.meta.unwrap().cache_hit);
+    let second = run_cached(
+        request(&runtime),
+        &cache,
+        || Some(revision(1)),
+        || async { panic!("cache hit must not call provider") },
+    )
+    .await;
+    let meta = second.meta.unwrap();
+    assert!(meta.cache_hit);
+    assert_eq!(meta.request_id.as_deref(), Some("new"));
+    assert_eq!(meta.search_calls, Some(0));
+    assert_eq!(second.items.len(), 1);
+}
+
+#[tokio::test]
+async fn changed_or_expired_credentials_never_receive_old_results() {
+    let runtime = WallpaperXSearchRuntime::quiet();
+    let cache = Mutex::new(Cache::default());
+    run_cached(
+        request(&runtime),
+        &cache,
+        || Some(revision(1)),
+        || async { success() },
+    )
+    .await;
+    for identity in [Some(revision(2)), None] {
+        let called = Cell::new(false);
+        let result = run_cached(
+            request(&runtime),
+            &cache,
+            || identity.clone(),
+            || async {
+                called.set(true);
+                success()
+            },
+        )
+        .await;
+        assert!(called.get());
+        assert!(!result.meta.unwrap().cache_hit);
+    }
+}
+
+#[tokio::test]
+async fn credential_change_during_search_prevents_cache_write() {
+    let runtime = WallpaperXSearchRuntime::quiet();
+    let cache = Mutex::new(Cache::default());
+    let identity = Cell::new(1);
+    run_cached(
+        request(&runtime),
+        &cache,
+        || Some(revision(identity.get())),
+        || async {
+            identity.set(2);
+            success()
+        },
+    )
+    .await;
+    assert!(cache.lock().entries.is_empty());
+}
+
+#[tokio::test]
+async fn cancellation_wins_over_hits_and_provider_completion() {
+    let cache = Mutex::new(Cache::default());
+    let active = WallpaperXSearchRuntime::quiet();
+    run_cached(
+        request(&active),
+        &cache,
+        || Some(revision(1)),
+        || async { success() },
+    )
+    .await;
+    let cancelled = WallpaperXSearchRuntime::quiet();
+    cancelled.cancellation().cancel();
+    let hit = run_cached(
+        request(&cancelled),
+        &cache,
+        || Some(revision(1)),
+        || async { panic!("pre-cancel") },
+    )
+    .await;
+    assert_eq!(hit.error_code.as_deref(), Some("cancelled"));
+    let cache = Mutex::new(Cache::default());
+    let result = run_cached(
+        request(&active),
+        &cache,
+        || Some(revision(1)),
+        || async {
+            active.cancellation().cancel();
+            success()
+        },
+    )
+    .await;
+    assert_eq!(result.error_code.as_deref(), Some("cancelled"));
+    assert!(cache.lock().entries.is_empty());
+    assert!(active
+        .cancellation()
+        .commit_if_active(|| panic!("cancelled commit"))
+        .is_none());
+}
+
+#[tokio::test]
+async fn failures_cli_and_fallbacks_are_not_cached() {
+    let cache = Mutex::new(Cache::default());
+    let runtime = WallpaperXSearchRuntime::quiet();
+    for mode in ["cli", "auto", "responses_preview"] {
+        let mut req = request(&runtime);
+        req.mode = mode;
+        run_cached(
+            req,
+            &cache,
+            || Some(revision(1)),
+            || async {
+                let mut result = success();
+                result.meta.as_mut().unwrap().route_used = "cli".into();
+                result
+            },
+        )
+        .await;
+    }
+    run_cached(
+        request(&runtime),
+        &cache,
+        || Some(revision(1)),
+        || async {
+            let mut result = success();
+            result.error_code = Some("responses_network".into());
+            result
+        },
+    )
+    .await;
+    assert!(cache.lock().entries.is_empty());
+}
+
+#[test]
+fn cache_bounds_lru_and_ttl_without_extending_expiry_on_reads() {
+    let now = Instant::now();
+    let mut cache = Cache::default();
+    let key = |i| Key {
+        query: format!("{i}"),
+        latest: false,
+        credential: revision(1),
+    };
+    for i in 0..CAPACITY {
+        cache.insert(key(i), success(), now);
+    }
+    assert!(cache.get(&key(0), now + TTL / 2).is_some());
+    cache.insert(key(CAPACITY), success(), now + TTL / 2);
+    assert_eq!(cache.entries.len(), CAPACITY);
+    assert!(cache.get(&key(1), now + TTL / 2).is_none());
+    assert!(cache.get(&key(0), now + TTL).is_none());
+    assert!(cache.get(&key(CAPACITY), now + TTL).is_some());
+    let mut wrong_sort = key(CAPACITY);
+    wrong_sort.latest = true;
+    assert!(cache.get(&wrong_sort, now + TTL).is_none());
+}

--- a/src/components/WallpaperSourceModal.tsx
+++ b/src/components/WallpaperSourceModal.tsx
@@ -265,12 +265,13 @@ export function WallpaperSourceModal({
             : fallbackReason?.includes("empty") ? "empty"
               : /network|timeout|tls|server/.test(fallbackReason ?? "") ? "network"
                 : "compatibility";
-        setStatusHint(t(fallbackReason
+        const routeLabel = t(fallbackReason
           ? "settings.wallpaperSource.route.fallback"
           : routeUsed === "responses" ? "settings.wallpaperSource.route.responses" : "settings.wallpaperSource.route.cli", {
           seconds: (durationMs / 1000).toFixed(1),
           reason: t(`settings.wallpaperSource.route.fallback.${reason}` as MessageKey),
-        }));
+        });
+        setStatusHint(res.meta.cacheHit ? t("settings.wallpaperSource.route.cached", { route: routeLabel }) : routeLabel);
       }
       const list = dedupeGalleryItems(res.items || []);
       const code = errorCodeFromSearchResult({ ...res, items: list });

--- a/src/i18n/messages/de/settings-ui.ts
+++ b/src/i18n/messages/de/settings-ui.ts
@@ -6,6 +6,7 @@ export const deSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (Vorschau)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Responses-Vorschau · {seconds} s",
+  "settings.wallpaperSource.route.cached": "Aus dem Cache geladen · {route}",
   "settings.wallpaperSource.route.fallback": "Auf Grok Build CLI zurückgefallen ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "offizielle Anmeldung fehlt oder ist abgelaufen",
   "settings.wallpaperSource.route.fallback.network": "Responses-Netzwerk nicht erreichbar",

--- a/src/i18n/messages/en/settings-ui.ts
+++ b/src/i18n/messages/en/settings-ui.ts
@@ -6,6 +6,7 @@ export const enSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (preview)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds}s",
   "settings.wallpaperSource.route.responses": "Responses preview · {seconds}s",
+  "settings.wallpaperSource.route.cached": "Loaded from cache · {route}",
   "settings.wallpaperSource.route.fallback": "Fell back to Grok Build CLI ({reason}) · {seconds}s",
   "settings.wallpaperSource.route.fallback.auth": "official sign-in unavailable or expired",
   "settings.wallpaperSource.route.fallback.network": "Responses network unavailable",

--- a/src/i18n/messages/es/settings-ui.ts
+++ b/src/i18n/messages/es/settings-ui.ts
@@ -6,6 +6,7 @@ export const esSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (vista previa)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Vista previa de Responses · {seconds} s",
+  "settings.wallpaperSource.route.cached": "Cargado desde la caché · {route}",
   "settings.wallpaperSource.route.fallback": "Se usó Grok Build CLI como alternativa ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "inicio de sesión oficial no disponible o caducado",
   "settings.wallpaperSource.route.fallback.network": "red de Responses no disponible",

--- a/src/i18n/messages/fil/settings-ui.ts
+++ b/src/i18n/messages/fil/settings-ui.ts
@@ -6,6 +6,7 @@ export const filSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (preview)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds}s",
   "settings.wallpaperSource.route.responses": "Responses preview · {seconds}s",
+  "settings.wallpaperSource.route.cached": "Na-load mula sa cache · {route}",
   "settings.wallpaperSource.route.fallback": "Bumalik sa Grok Build CLI ({reason}) · {seconds}s",
   "settings.wallpaperSource.route.fallback.auth": "hindi available o paso ang opisyal na sign-in",
   "settings.wallpaperSource.route.fallback.network": "hindi available ang Responses network",

--- a/src/i18n/messages/fr/settings-ui.ts
+++ b/src/i18n/messages/fr/settings-ui.ts
@@ -6,6 +6,7 @@ export const frSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (aperçu)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Aperçu Responses · {seconds} s",
+  "settings.wallpaperSource.route.cached": "Chargé depuis le cache · {route}",
   "settings.wallpaperSource.route.fallback": "Repli sur Grok Build CLI ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "connexion officielle indisponible ou expirée",
   "settings.wallpaperSource.route.fallback.network": "réseau Responses indisponible",

--- a/src/i18n/messages/id/settings-ui.ts
+++ b/src/i18n/messages/id/settings-ui.ts
@@ -6,6 +6,7 @@ export const idSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (pratinjau)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} dtk",
   "settings.wallpaperSource.route.responses": "Pratinjau Responses · {seconds} dtk",
+  "settings.wallpaperSource.route.cached": "Dimuat dari cache · {route}",
   "settings.wallpaperSource.route.fallback": "Beralih kembali ke Grok Build CLI ({reason}) · {seconds} dtk",
   "settings.wallpaperSource.route.fallback.auth": "login resmi tidak tersedia atau kedaluwarsa",
   "settings.wallpaperSource.route.fallback.network": "jaringan Responses tidak tersedia",

--- a/src/i18n/messages/it/settings-ui.ts
+++ b/src/i18n/messages/it/settings-ui.ts
@@ -6,6 +6,7 @@ export const itSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (anteprima)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Anteprima Responses · {seconds} s",
+  "settings.wallpaperSource.route.cached": "Caricato dalla cache · {route}",
   "settings.wallpaperSource.route.fallback": "Ripiego su Grok Build CLI ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "accesso ufficiale non disponibile o scaduto",
   "settings.wallpaperSource.route.fallback.network": "rete Responses non disponibile",

--- a/src/i18n/messages/ja/settings-ui.ts
+++ b/src/i18n/messages/ja/settings-ui.ts
@@ -6,6 +6,7 @@ export const jaSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API（プレビュー）",
   "settings.wallpaperSource.route.cli": "Grok Build CLI・{seconds}秒",
   "settings.wallpaperSource.route.responses": "Responses プレビュー・{seconds}秒",
+  "settings.wallpaperSource.route.cached": "キャッシュから読み込み · {route}",
   "settings.wallpaperSource.route.fallback": "Grok Build CLI に切り替えました（{reason}）・{seconds}秒",
   "settings.wallpaperSource.route.fallback.auth": "公式ログインが利用できないか期限切れ",
   "settings.wallpaperSource.route.fallback.network": "Responses のネットワークを利用不可",

--- a/src/i18n/messages/ko/settings-ui.ts
+++ b/src/i18n/messages/ko/settings-ui.ts
@@ -6,6 +6,7 @@ export const koSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API(미리보기)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds}초",
   "settings.wallpaperSource.route.responses": "Responses 미리보기 · {seconds}초",
+  "settings.wallpaperSource.route.cached": "캐시에서 불러옴 · {route}",
   "settings.wallpaperSource.route.fallback": "Grok Build CLI로 대체됨({reason}) · {seconds}초",
   "settings.wallpaperSource.route.fallback.auth": "공식 로그인을 사용할 수 없거나 만료됨",
   "settings.wallpaperSource.route.fallback.network": "Responses 네트워크를 사용할 수 없음",

--- a/src/i18n/messages/pt-BR/settings-ui.ts
+++ b/src/i18n/messages/pt-BR/settings-ui.ts
@@ -6,6 +6,7 @@ export const ptBRSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (prévia)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Prévia de Responses · {seconds} s",
+  "settings.wallpaperSource.route.cached": "Carregado do cache · {route}",
   "settings.wallpaperSource.route.fallback": "Retorno ao Grok Build CLI ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "login oficial indisponível ou expirado",
   "settings.wallpaperSource.route.fallback.network": "rede de Responses indisponível",

--- a/src/i18n/messages/ru/settings-ui.ts
+++ b/src/i18n/messages/ru/settings-ui.ts
@@ -6,6 +6,7 @@ export const ruSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (предпросмотр)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} с",
   "settings.wallpaperSource.route.responses": "Предпросмотр Responses · {seconds} с",
+  "settings.wallpaperSource.route.cached": "Загружено из кеша · {route}",
   "settings.wallpaperSource.route.fallback": "Выполнен откат к Grok Build CLI ({reason}) · {seconds} с",
   "settings.wallpaperSource.route.fallback.auth": "официальный вход недоступен или истёк",
   "settings.wallpaperSource.route.fallback.network": "сеть Responses недоступна",

--- a/src/i18n/messages/ta/settings-ui.ts
+++ b/src/i18n/messages/ta/settings-ui.ts
@@ -6,6 +6,7 @@ export const taSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (முன்னோட்டம்)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} வி",
   "settings.wallpaperSource.route.responses": "Responses முன்னோட்டம் · {seconds} வி",
+  "settings.wallpaperSource.route.cached": "தற்காலிக சேமிப்பிலிருந்து ஏற்றப்பட்டது · {route}",
   "settings.wallpaperSource.route.fallback": "Grok Build CLI-க்கு மாற்றப்பட்டது ({reason}) · {seconds} வி",
   "settings.wallpaperSource.route.fallback.auth": "அதிகாரப்பூர்வ உள்நுழைவு கிடைக்கவில்லை அல்லது காலாவதியானது",
   "settings.wallpaperSource.route.fallback.network": "Responses பிணையம் கிடைக்கவில்லை",

--- a/src/i18n/messages/uk/settings-ui.ts
+++ b/src/i18n/messages/uk/settings-ui.ts
@@ -6,6 +6,7 @@ export const ukSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API (перегляд)",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} с",
   "settings.wallpaperSource.route.responses": "Перегляд Responses · {seconds} с",
+  "settings.wallpaperSource.route.cached": "Завантажено з кешу · {route}",
   "settings.wallpaperSource.route.fallback": "Перехід до Grok Build CLI ({reason}) · {seconds} с",
   "settings.wallpaperSource.route.fallback.auth": "офіційний вхід недоступний або прострочений",
   "settings.wallpaperSource.route.fallback.network": "мережа Responses недоступна",

--- a/src/i18n/messages/zh-TW/settings-ui.ts
+++ b/src/i18n/messages/zh-TW/settings-ui.ts
@@ -6,6 +6,7 @@ export const zhTWSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API（預覽）",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} 秒",
   "settings.wallpaperSource.route.responses": "Responses 預覽 · {seconds} 秒",
+  "settings.wallpaperSource.route.cached": "已從快取載入 · {route}",
   "settings.wallpaperSource.route.fallback": "已退回 Grok Build CLI（{reason}）· {seconds} 秒",
   "settings.wallpaperSource.route.fallback.auth": "官方登入無法使用或已過期",
   "settings.wallpaperSource.route.fallback.network": "Responses 網路無法使用",

--- a/src/i18n/messages/zh/settings-ui.ts
+++ b/src/i18n/messages/zh/settings-ui.ts
@@ -6,6 +6,7 @@ export const zhSettingsUi = {
   "settings.wallpaperXSearchMode.responsesPreview": "Responses API（预览）",
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} 秒",
   "settings.wallpaperSource.route.responses": "Responses 预览 · {seconds} 秒",
+  "settings.wallpaperSource.route.cached": "已从缓存加载 · {route}",
   "settings.wallpaperSource.route.fallback": "已回退 Grok Build CLI（{reason}）· {seconds} 秒",
   "settings.wallpaperSource.route.fallback.auth": "官方登录不可用或已过期",
   "settings.wallpaperSource.route.fallback.network": "Responses 网络不可用",

--- a/src/lib/wallpaperSource.ts
+++ b/src/lib/wallpaperSource.ts
@@ -26,6 +26,7 @@ export type WallpaperSearchResult = {
     routeUsed: "cli" | "responses";
     fallbackReason?: string | null;
     durationMs: number;
+    cacheHit?: boolean;
   } | null;
   items: WallpaperGalleryItem[];
   errorCode?: string | null;


### PR DESCRIPTION
## Summary

为显式启用 Responses 的壁纸搜索加入 Host 内存缓存，同一主题和排序再次搜索时直接复用已验证结果，避免重复请求。缓存命中在界面明确标注，并报告本次读取耗时和零次新增搜索调用。

- 最多 32 条，十分钟 TTL；读取只更新 LRU 顺序，不延长过期时间。仅存图片元数据，不持久化 token 或图片内容。
- 每次命中前重新验证官方凭据作用域与有效期，以带盐的凭据内容 revision 隔离账号；凭据缺失/过期/变化不读取旧结果，请求期间变化不写入缓存。
- 默认 CLI、保留的 auto、失败和 CLI 回退均不缓存；它们的身份作用域不能混入官方凭据缓存。
- 取消与缓存写入通过同一提交锁串行化，取消后不能写回。缓存命中继续走原有请求 ID 批次和最终结果通道。
- 缓存提示补齐 15 语言，App/AppWorkbench 未增加状态。

本主题是后续继续搜索的独立前置，不包含加载更多或自动预加载。依赖 #1088/#1089，目标上游 main，目前含未合入前置；最后一个提交是本主题差异，前置合入后更新基线去重。不自动合并，交由维护者审阅。

已搜索开放和关闭的 wallpaper cache Issues，没有直接对应项，不添加自动关闭引用。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Validation

本主题 22 文件 +465/-10，包含 212 行回归测试和 15 行翻译。7,075 项前端、1,689 项 Rust 测试通过（另 1 项原有 ignored）；typecheck、lint、UI build、Rust fmt/clippy、质量门禁、网站 self-test、依赖检查和生产审计均通过。Windows 使用仓库 Common Controls manifest 执行原生 harness。回归覆盖复用不调 provider、凭据过期/替换、请求期间身份变化、取消优先于命中和写入、默认/回退/失败不缓存、容量/LRU/TTL。未进行真实账号端到端或桌面手动验收。缓存改善重复搜索，不承诺首轮加速或缓存期间 CDN 图片一直可用；预览/下载仍使用既有校验。

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

