### PR TITLE
feat(wallpaper): 支持追加搜索并保留已有图片交互

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -49,7 +49,7 @@ to prevent an additional CLI request. Cancellation drops all pending lanes.
 The picker displays batches as they arrive; the final invoke result is authoritative.
 The hook rejects malformed, duplicate and foreign-request batches and clears them
 on replacement/cancel. Batch event failure cannot prevent the final result from
-showing. Load-more and prefetch are separate follow-up slices.
+showing. Automatic prefetch is a separate follow-up slice.
 
 Eligible failures fall back once to CLI. Rate limits, cancellation and tool-budget
 violations never trigger a second route. Three counted failures open a ten-minute
@@ -104,3 +104,25 @@ reports cacheHit, the new requestId, lookup duration and zero new search calls;
 the picker labels the result as cached. Cache reuse saves repeat searches only;
 it does not improve the first live request or guarantee an old CDN URL remains
 reachable. Existing preview/download validation continues to handle expired media.
+
+## Explicit Responses enrichment
+
+A successful initial result offers one additional eight-item request. The Host
+returns an opaque continuationId only when its bounded cache stores that gallery;
+the frontend submits that id and a new requestId, not query text or media URLs.
+Changing query/sort hides the previous continuation. Default CLI never offers it.
+
+A continuation is an exclusive lease bound to the original credential revision.
+In-flight entries survive TTL/eviction and cannot be overwritten by another search.
+Cancellation, network failures and dropped futures restore the opportunity to retry;
+success or a confirmed empty batch consumes it once. A consumed cached result no
+longer advertises continuation. The provider uses the validated OAuth snapshot;
+credential validity and revision are checked again before returning its result.
+
+Enrichment performs one Responses request with at most three X tool calls, using
+the existing media/post identities as exclusions. It validates and deduplicates
+against the original gallery, never falls back to CLI and never auto-retries.
+The final result is appended only after the Host validates its identity. Existing
+images remain visible/selectable while enrichment runs; errors keep them intact,
+and an empty batch displays the localized no-more hint. Closing/cancelling rejects
+late results. This slice does not automatically prefetch or repeat enrichment.

--- a/src-tauri/src/commands/misc_p1.rs
+++ b/src-tauri/src/commands/misc_p1.rs
@@ -1121,6 +1121,13 @@ pub async fn wallpaper_x_search(
 }
 
 #[tauri::command]
+pub async fn wallpaper_x_search_more(app: tauri::AppHandle, request_id: String, continuation_id: String) -> Result<crate::wallpaper_source::WallpaperSearchResult, String> {
+    let request_id = crate::wallpaper_x_search::request_id(Some(&request_id))?;
+    let continuation_id = crate::wallpaper_x_search::request_id(Some(&continuation_id))?;
+    crate::wallpaper_x_search::search_more(&app, &request_id, &continuation_id).await
+}
+
+#[tauri::command]
 pub fn wallpaper_x_search_cancel(request_id: String) -> Result<bool, String> {
     let request_id = crate::wallpaper_x_search::request_id(Some(&request_id))?;
     Ok(crate::wallpaper_x_search::cancel(&request_id))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1701,6 +1701,7 @@ pub fn run() {
 
             commands::wallpaper_x_search,
             commands::wallpaper_x_search_cancel,
+            commands::wallpaper_x_search_more,
 
             commands::wallpaper_fetch_media,
 

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -102,6 +102,8 @@ pub struct WallpaperSearchMeta {
     pub fallback_reason: Option<String>,
     pub duration_ms: u64,
     pub cache_hit: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continuation_id: Option<String>,
     pub search_calls: Option<u32>,
     pub candidate_count: usize,
     pub valid_count: usize,

--- a/src-tauri/src/wallpaper_x_responses.rs
+++ b/src-tauri/src/wallpaper_x_responses.rs
@@ -2,6 +2,9 @@
 //! endpoint. This module is Host-internal until the wallpaper search router
 //! explicitly opts into it.
 
+mod more;
+pub(crate) use more::search_more;
+
 use std::future::Future;
 use std::time::Duration;
 

--- a/src-tauri/src/wallpaper_x_responses/more.rs
+++ b/src-tauri/src/wallpaper_x_responses/more.rs
@@ -1,0 +1,113 @@
+//! One user-triggered Responses enrichment batch.
+//!
+//! This is deliberately separate from the initial three-lane search: it runs
+//! only after explicit user intent, never retries automatically, and never
+//! falls back to the CLI.
+
+use super::*;
+use crate::wallpaper_source::x_gallery_reference_ids;
+
+const LOAD_MORE_LANE_INDEX: usize = 4;
+
+pub(crate) async fn search_more(
+    query: &str,
+    sort: Option<&str>,
+    existing: &[WallpaperGalleryItem],
+    runtime: &WallpaperXSearchRuntime,
+    auth: &BuildOauthAccessToken,
+) -> Result<ResponsesSearchSuccess, ResponsesSearchError> {
+    if runtime.is_cancelled() {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::Cancelled,
+            None,
+        ));
+    }
+
+    let client = responses_client(RESPONSES_TIMEOUT, Some(auth.revision.clone()))?;
+    let excluded_ids = x_gallery_reference_ids(existing);
+    let mut result = search_with_client(
+        ResponsesSearchRequest {
+            query,
+            sort,
+            endpoint: RESPONSES_ENDPOINT,
+            max_search_calls: RESPONSES_LANE_MAX_X_SEARCH_CALLS,
+            lane_index: LOAD_MORE_LANE_INDEX,
+            target_count: RESPONSES_LANE_TARGET_COUNT,
+            excluded_ids: &excluded_ids,
+            cancellation: runtime.cancellation(),
+        },
+        &client,
+        auth.expose_to_build_proxy(),
+        auth.revision.clone(),
+    )
+    .await?;
+
+    runtime.report(WallpaperXSearchStage::Validating);
+    let validated =
+        filter_reachable_gallery_items_cancellable(result.items, Some(runtime.cancellation()))
+            .await;
+    if runtime.is_cancelled() {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::Cancelled,
+            Some(auth.revision.clone()),
+        ));
+    }
+
+    result.items = new_more_items(existing, validated);
+    if result.items.is_empty() {
+        return Err(ResponsesSearchError::new(
+            ResponsesSearchErrorKind::Empty,
+            Some(auth.revision.clone()),
+        )
+        .with_observed_search_calls(result.search_calls));
+    }
+    result.valid_count = result.items.len();
+    Ok(result)
+}
+
+fn new_more_items(
+    existing: &[WallpaperGalleryItem],
+    candidates: Vec<WallpaperGalleryItem>,
+) -> Vec<WallpaperGalleryItem> {
+    let candidates = merge_rank_x_gallery_items_with_limit(candidates, RESPONSES_LANE_TARGET_COUNT);
+    x_gallery_new_items(existing, &candidates)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: &str, status_id: &str) -> WallpaperGalleryItem {
+        WallpaperGalleryItem {
+            id: id.into(),
+            thumb_url: format!("https://pbs.twimg.com/media/{id}.jpg?name=small"),
+            full_url: format!("https://pbs.twimg.com/media/{id}.jpg?name=orig"),
+            kind: "image".into(),
+            width: None,
+            height: None,
+            source: "x".into(),
+            username: None,
+            post_url: Some(format!("https://x.com/example/status/{status_id}")),
+            text_preview: None,
+            likes: None,
+            local_path: None,
+            prompt: None,
+            status_id: Some(status_id.into()),
+            media_index: Some(1),
+            media_quality: None,
+        }
+    }
+
+    #[test]
+    fn wallpaper_x_responses_load_more_dedupes_existing_media_and_status() {
+        let existing = vec![item("same-media", "10000001")];
+        let mut same_status = item("different-media", "10000001");
+        same_status.media_index = Some(1);
+        let fresh = item("fresh", "10000002");
+
+        let result = new_more_items(&existing, vec![existing[0].clone(), same_status, fresh]);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "fresh");
+    }
+}

--- a/src-tauri/src/wallpaper_x_search.rs
+++ b/src-tauri/src/wallpaper_x_search.rs
@@ -1,5 +1,6 @@
 //! Request ownership, progress and cancellation for CLI wallpaper searches.
 mod cache;
+mod more;
 use crate::account::BuildOauthCredentialRevision;
 use crate::wallpaper_source::{
     self, WallpaperSearchCancellation, WallpaperSearchResult, WallpaperXSearchRuntime,
@@ -10,6 +11,7 @@ use crate::wallpaper_x_responses::{
     ResponsesSearchError, ResponsesSearchErrorKind, ResponsesSearchSuccess,
 };
 use crate::{account, store, wallpaper_x_responses};
+pub(crate) use more::search_more;
 use std::future::Future;
 const CIRCUIT_FAILURE_THRESHOLD: u8 = 3;
 const CIRCUIT_OPEN_DURATION: Duration = Duration::from_secs(10 * 60);
@@ -137,34 +139,7 @@ pub(crate) async fn search(
     sort: Option<&str>,
 ) -> Result<WallpaperSearchResult, String> {
     let request = register_request(request_id)?;
-    let event_app = app.clone();
-    let event_request_id = request_id.to_string();
-    let batch_app = app.clone();
-    let batch_request_id = request_id.to_string();
-    let runtime = WallpaperXSearchRuntime::new(
-        request.cancellation.clone(),
-        Arc::new(move |stage| {
-            let _ = event_app.emit(
-                WALLPAPER_X_SEARCH_PROGRESS_EVENT,
-                WallpaperXSearchProgress {
-                    request_id: event_request_id.clone(),
-                    stage,
-                },
-            );
-        }),
-        Arc::new(move |batch| {
-            let _ = batch_app.emit(
-                WALLPAPER_X_SEARCH_BATCH_EVENT,
-                WallpaperXSearchBatchEvent {
-                    request_id: batch_request_id.clone(),
-                    batch_index: batch.batch_index,
-                    items: batch.items,
-                    accumulated_count: batch.accumulated_count,
-                    done: batch.done,
-                },
-            );
-        }),
-    );
+    let runtime = search_runtime(app, request_id, request.cancellation.clone());
     runtime.report(WallpaperXSearchStage::Preparing);
     let settings = store::load_settings();
     let mode = store::normalize_wallpaper_x_search_mode(&settings.wallpaper_x_search_mode);
@@ -347,6 +322,7 @@ where
                     fallback_reason: None,
                     duration_ms: elapsed_ms(started),
                     cache_hit: false,
+                    continuation_id: None,
                     search_calls: Some(result.search_calls),
                     candidate_count: result.candidate_count,
                     valid_count: result.valid_count,
@@ -397,6 +373,7 @@ where
                     fallback_reason: None,
                     duration_ms: elapsed_ms(started),
                     cache_hit: false,
+                    continuation_id: None,
                     search_calls: None,
                     candidate_count: 0,
                     valid_count: 0,
@@ -433,6 +410,7 @@ fn finish_cli(
         fallback_reason: fallback_reason.map(str::to_string),
         duration_ms: elapsed_ms(started),
         cache_hit: false,
+        continuation_id: None,
         // Grok Build does not currently expose a reliable hosted X call count
         // or selected official model through this headless result contract.
         search_calls: None,
@@ -460,6 +438,7 @@ fn cancelled_result(
             fallback_reason: None,
             duration_ms: elapsed_ms(started),
             cache_hit: false,
+            continuation_id: None,
             search_calls: None,
             candidate_count: 0,
             valid_count: 0,
@@ -472,6 +451,41 @@ fn cancelled_result(
 
 fn elapsed_ms(started: Instant) -> u64 {
     started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+fn search_runtime(
+    app: &tauri::AppHandle,
+    request_id: &str,
+    cancellation: WallpaperSearchCancellation,
+) -> WallpaperXSearchRuntime {
+    let event_app = app.clone();
+    let event_request_id = request_id.to_string();
+    let batch_app = app.clone();
+    let batch_request_id = request_id.to_string();
+    WallpaperXSearchRuntime::new(
+        cancellation,
+        Arc::new(move |stage| {
+            let _ = event_app.emit(
+                WALLPAPER_X_SEARCH_PROGRESS_EVENT,
+                WallpaperXSearchProgress {
+                    request_id: event_request_id.clone(),
+                    stage,
+                },
+            );
+        }),
+        Arc::new(move |batch| {
+            let _ = batch_app.emit(
+                WALLPAPER_X_SEARCH_BATCH_EVENT,
+                WallpaperXSearchBatchEvent {
+                    request_id: batch_request_id.clone(),
+                    batch_index: batch.batch_index,
+                    items: batch.items,
+                    accumulated_count: batch.accumulated_count,
+                    done: batch.done,
+                },
+            );
+        }),
+    )
 }
 
 #[cfg(test)]

--- a/src-tauri/src/wallpaper_x_search/cache.rs
+++ b/src-tauri/src/wallpaper_x_search/cache.rs
@@ -1,5 +1,7 @@
 //! Bounded, credential-scoped metadata cache. No tokens or image bytes are stored.
 use super::*;
+mod continuation;
+pub(super) use continuation::claim;
 
 const CAPACITY: usize = 32;
 const TTL: Duration = Duration::from_secs(10 * 60);
@@ -13,6 +15,9 @@ struct Key {
 
 struct Entry {
     inserted: Instant,
+    continuation: String,
+    in_flight: bool,
+    consumed: bool,
     result: WallpaperSearchResult,
 }
 
@@ -25,40 +30,60 @@ struct Cache {
 impl Cache {
     fn purge(&mut self, now: Instant) {
         self.entries
-            .retain(|_, entry| now.duration_since(entry.inserted) < TTL);
+            .retain(|_, entry| entry.in_flight || now.duration_since(entry.inserted) < TTL);
         self.lru.retain(|key| self.entries.contains_key(key));
     }
 
     fn get(&mut self, key: &Key, now: Instant) -> Option<WallpaperSearchResult> {
         self.purge(now);
-        let result = self.entries.get(key)?.result.clone();
+        let entry = self.entries.get(key)?;
+        let mut result = entry.result.clone();
+        if let Some(meta) = result.meta.as_mut() {
+            meta.continuation_id =
+                (!entry.in_flight && !entry.consumed).then(|| entry.continuation.clone());
+        }
         self.lru.retain(|other| other != key);
         self.lru.push_back(key.clone());
         Some(result)
     }
 
-    fn insert(&mut self, key: Key, mut result: WallpaperSearchResult, now: Instant) {
+    fn insert(
+        &mut self,
+        key: Key,
+        mut result: WallpaperSearchResult,
+        now: Instant,
+    ) -> Option<String> {
         self.purge(now);
+        if self.entries.get(&key).is_some_and(|entry| entry.in_flight) {
+            return None;
+        }
         self.lru.retain(|other| other != &key);
         while self.entries.len() >= CAPACITY && !self.entries.contains_key(&key) {
-            if let Some(oldest) = self.lru.pop_front() {
-                self.entries.remove(&oldest);
-            } else {
-                break;
-            }
+            let evict = self
+                .lru
+                .iter()
+                .find(|k| self.entries.get(*k).is_some_and(|e| !e.in_flight))
+                .cloned()?;
+            self.lru.retain(|k| k != &evict);
+            self.entries.remove(&evict);
         }
         if let Some(meta) = result.meta.as_mut() {
             meta.request_id = None;
             meta.cache_hit = false;
         }
+        let continuation = uuid::Uuid::new_v4().to_string();
         self.entries.insert(
             key.clone(),
             Entry {
                 inserted: now,
+                continuation: continuation.clone(),
+                in_flight: false,
+                consumed: false,
                 result,
             },
         );
         self.lru.push_back(key);
+        Some(continuation)
     }
 }
 
@@ -70,6 +95,11 @@ pub(super) struct CacheRequest<'a> {
     pub runtime: &'a WallpaperXSearchRuntime,
 }
 
+fn shared_cache() -> &'static Mutex<Cache> {
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    CACHE.get_or_init(Default::default)
+}
+
 pub(super) async fn search_cached<F, Fut>(
     request: CacheRequest<'_>,
     run: F,
@@ -78,10 +108,9 @@ where
     F: FnOnce() -> Fut,
     Fut: Future<Output = WallpaperSearchResult>,
 {
-    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
     run_cached(
         request,
-        CACHE.get_or_init(Default::default),
+        shared_cache(),
         || {
             // Parsing validates scope and expiry, unlike file revision alone.
             account::read_build_oauth_access_token()
@@ -150,7 +179,7 @@ where
             return result;
         }
     }
-    let result = run().await;
+    let mut result = run().await;
     if runtime.is_cancelled() {
         return cancelled_result(mode, "responses", started);
     }
@@ -163,15 +192,18 @@ where
     {
         if let Some(key) = key {
             // Never associate a response with a different or now-expired login.
-            if revision().as_ref() == Some(&key.credential)
-                && runtime
+            if revision().as_ref() == Some(&key.credential) {
+                let inserted = runtime
                     .cancellation()
-                    .commit_if_active(|| {
-                        cache.lock().insert(key, result.clone(), Instant::now());
-                    })
-                    .is_none()
-            {
-                return cancelled_result(mode, "responses", started);
+                    .commit_if_active(|| cache.lock().insert(key, result.clone(), Instant::now()));
+                match inserted {
+                    None => return cancelled_result(mode, "responses", started),
+                    Some(id) => {
+                        if let Some(meta) = result.meta.as_mut() {
+                            meta.continuation_id = id;
+                        }
+                    }
+                }
             }
         }
     }

--- a/src-tauri/src/wallpaper_x_search/cache/continuation.rs
+++ b/src-tauri/src/wallpaper_x_search/cache/continuation.rs
@@ -1,0 +1,121 @@
+//! One exclusive continuation per cached gallery. Failed/abandoned work restores it.
+use super::*;
+
+pub(in crate::wallpaper_x_search) struct Lease<'a> {
+    cache: &'a Mutex<Cache>,
+    key: Key,
+    id: String,
+    pub query: String,
+    pub sort: &'static str,
+    pub items: Vec<wallpaper_source::WallpaperGalleryItem>,
+}
+
+pub(in crate::wallpaper_x_search) fn claim(
+    id: &str,
+    revision: &BuildOauthCredentialRevision,
+) -> Option<Lease<'static>> {
+    claim_from(shared_cache(), id, revision, Instant::now())
+}
+
+fn claim_from<'a>(
+    cache: &'a Mutex<Cache>,
+    id: &str,
+    revision: &BuildOauthCredentialRevision,
+    now: Instant,
+) -> Option<Lease<'a>> {
+    let mut entries = cache.lock();
+    entries.purge(now);
+    let (key, entry) = entries.entries.iter_mut().find(|(key, entry)| {
+        key.credential == *revision
+            && entry.continuation == id
+            && !entry.in_flight
+            && !entry.consumed
+    })?;
+    entry.in_flight = true;
+    Some(Lease {
+        cache,
+        key: key.clone(),
+        id: id.into(),
+        query: key.query.clone(),
+        sort: if key.latest { "latest" } else { "top" },
+        items: entry.result.items.clone(),
+    })
+}
+
+impl Lease<'_> {
+    pub(in crate::wallpaper_x_search) fn consume(&self, runtime: &WallpaperXSearchRuntime) -> bool {
+        runtime
+            .cancellation()
+            .commit_if_active(|| {
+                let mut cache = self.cache.lock();
+                if let Some(entry) = cache
+                    .entries
+                    .get_mut(&self.key)
+                    .filter(|entry| entry.continuation == self.id)
+                {
+                    entry.consumed = true;
+                    entry.in_flight = false;
+                }
+            })
+            .is_some()
+    }
+}
+
+impl Drop for Lease<'_> {
+    fn drop(&mut self) {
+        let mut cache = self.cache.lock();
+        if let Some(entry) = cache
+            .entries
+            .get_mut(&self.key)
+            .filter(|entry| entry.continuation == self.id && entry.in_flight)
+        {
+            entry.in_flight = false;
+            // Preserve a retry opportunity even if the network call outlived TTL.
+            entry.inserted = Instant::now();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{revision, success};
+    use super::*;
+
+    #[test]
+    fn lease_is_exclusive_restores_on_drop_and_consumes_once() {
+        let cache = Mutex::new(Cache::default());
+        let key = Key {
+            query: "sky".into(),
+            latest: false,
+            credential: revision(1),
+        };
+        let now = Instant::now();
+        let id = cache.lock().insert(key.clone(), success(), now).unwrap();
+        assert!(claim_from(&cache, &id, &revision(2), now).is_none());
+        let lease = claim_from(&cache, &id, &revision(1), now).unwrap();
+        assert!(claim_from(&cache, &id, &revision(1), now).is_none());
+        cache.lock().purge(now + TTL);
+        assert!(cache
+            .lock()
+            .insert(key.clone(), success(), now + TTL)
+            .is_none());
+        drop(lease);
+        let lease = claim_from(&cache, &id, &revision(1), Instant::now()).unwrap();
+        let runtime = WallpaperXSearchRuntime::quiet();
+        runtime.cancellation().cancel();
+        assert!(!lease.consume(&runtime));
+        drop(lease);
+        let lease = claim_from(&cache, &id, &revision(1), Instant::now()).unwrap();
+        assert!(lease.consume(&WallpaperXSearchRuntime::quiet()));
+        drop(lease);
+        assert!(claim_from(&cache, &id, &revision(1), Instant::now()).is_none());
+        assert!(cache
+            .lock()
+            .get(&key, Instant::now())
+            .unwrap()
+            .meta
+            .unwrap()
+            .continuation_id
+            .is_none());
+    }
+}

--- a/src-tauri/src/wallpaper_x_search/cache/tests.rs
+++ b/src-tauri/src/wallpaper_x_search/cache/tests.rs
@@ -1,11 +1,11 @@
 use super::*;
 use std::cell::Cell;
 
-fn revision(value: u8) -> BuildOauthCredentialRevision {
+pub(super) fn revision(value: u8) -> BuildOauthCredentialRevision {
     BuildOauthCredentialRevision::for_test(1, Some(1), value)
 }
 
-fn success() -> WallpaperSearchResult {
+pub(super) fn success() -> WallpaperSearchResult {
     let item = wallpaper_source::parse_gallery_items(
         &serde_json::json!({"items": [{
             "fullUrl": "https://pbs.twimg.com/media/sky.jpg", "kind": "image"
@@ -24,6 +24,7 @@ fn success() -> WallpaperSearchResult {
             fallback_reason: None,
             duration_ms: 9000,
             cache_hit: false,
+            continuation_id: None,
             search_calls: Some(6),
             candidate_count: 1,
             valid_count: 1,

--- a/src-tauri/src/wallpaper_x_search/more.rs
+++ b/src-tauri/src/wallpaper_x_search/more.rs
@@ -1,0 +1,150 @@
+//! Explicit enrichment: one request, no retries and no CLI fallback.
+use super::*;
+
+pub(crate) async fn search_more(
+    app: &tauri::AppHandle,
+    request_id: &str,
+    continuation_id: &str,
+) -> Result<WallpaperSearchResult, String> {
+    let request = register_request(request_id)?;
+    let runtime = search_runtime(app, request_id, request.cancellation.clone());
+    let started = Instant::now();
+    let settings = store::load_settings();
+    let mode = store::normalize_wallpaper_x_search_mode(&settings.wallpaper_x_search_mode);
+    let mut result = if runtime.is_cancelled() {
+        cancelled_result(mode, "responses", started)
+    } else if mode != "responses_preview" {
+        error_result("load_more_unavailable", started)
+    } else {
+        match account::read_build_oauth_access_token() {
+            Err(error) => error_result(error.code(), started),
+            Ok(auth) => match cache::claim(continuation_id, &auth.revision) {
+                None => error_result("load_more_unavailable", started),
+                Some(lease) => {
+                    if !responses_circuit()
+                        .lock()
+                        .allows_attempt(Some(auth.revision.clone()), Instant::now())
+                    {
+                        error_result(CIRCUIT_OPEN_REASON, started)
+                    } else {
+                        runtime.report(WallpaperXSearchStage::SearchingX);
+                        let outcome = wallpaper_x_responses::search_more(
+                            &lease.query,
+                            Some(lease.sort),
+                            &lease.items,
+                            &runtime,
+                            &auth,
+                        )
+                        .await;
+                        let result = if account::read_build_oauth_access_token()
+                            .ok()
+                            .map(|current| current.revision)
+                            .as_ref()
+                            == Some(&auth.revision)
+                        {
+                            finish(outcome, started)
+                        } else {
+                            error_result("load_more_unavailable", started)
+                        };
+                        if runtime.is_cancelled() || (consumes(&result) && !lease.consume(&runtime))
+                        {
+                            cancelled_result(mode, "responses", started)
+                        } else {
+                            result
+                        }
+                    }
+                }
+            },
+        }
+    };
+    if let Some(meta) = result.meta.as_mut() {
+        meta.request_id = Some(request_id.into());
+    }
+    runtime.report(WallpaperXSearchStage::Done);
+    Ok(result)
+}
+
+fn consumes(result: &WallpaperSearchResult) -> bool {
+    result.error_code.is_none() || result.error_code.as_deref() == Some("empty")
+}
+
+fn finish(
+    outcome: Result<ResponsesSearchSuccess, ResponsesSearchError>,
+    started: Instant,
+) -> WallpaperSearchResult {
+    match outcome {
+        Ok(success) => {
+            responses_circuit()
+                .lock()
+                .record_success(success.credential_revision);
+            let mut result = error_result("", started);
+            result.error_code = None;
+            result.items = success.items;
+            let meta = result.meta.as_mut().expect("more result metadata");
+            meta.search_calls = Some(success.search_calls);
+            meta.candidate_count = success.candidate_count;
+            meta.valid_count = success.valid_count;
+            result
+        }
+        Err(error) => {
+            if error.kind != ResponsesSearchErrorKind::Empty {
+                responses_circuit().lock().record_failure(
+                    error.kind,
+                    error.credential_revision,
+                    Instant::now(),
+                );
+            }
+            let code = if error.kind == ResponsesSearchErrorKind::Empty {
+                "empty"
+            } else {
+                error.kind.code()
+            };
+            let mut result = error_result(code, started);
+            result
+                .meta
+                .as_mut()
+                .expect("more result metadata")
+                .search_calls = error.observed_search_calls;
+            result
+        }
+    }
+}
+
+fn error_result(code: &str, started: Instant) -> WallpaperSearchResult {
+    WallpaperSearchResult {
+        items: Vec::new(),
+        error_code: Some(code.into()),
+        message: None,
+        meta: Some(WallpaperSearchMeta {
+            request_id: None,
+            requested_mode: "responses_preview".into(),
+            route_used: "responses".into(),
+            fallback_reason: None,
+            duration_ms: elapsed_ms(started),
+            cache_hit: false,
+            continuation_id: None,
+            search_calls: None,
+            candidate_count: 0,
+            valid_count: 0,
+            model: Some(wallpaper_x_responses::RESPONSES_MODEL.into()),
+            effort: Some(wallpaper_x_responses::RESPONSES_EFFORT.into()),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn failure_does_not_consume_continuation_but_empty_does() {
+        assert!(consumes(&error_result("empty", Instant::now())));
+        for error in [
+            "responses_network",
+            "responses_rate_limited",
+            "cancelled",
+            "load_more_unavailable",
+        ] {
+            assert!(!consumes(&error_result(error, Instant::now())));
+        }
+    }
+}

--- a/src/components/WallpaperSourceModal.more.test.tsx
+++ b/src/components/WallpaperSourceModal.more.test.tsx
@@ -1,0 +1,87 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import "@/test/jsdomStubs";
+import type { WallpaperSearchResult } from "@/lib/wallpaperSource";
+
+const mocks = vi.hoisted(() => ({ search: vi.fn(), more: vi.fn(), cancel: vi.fn(async () => true), preview: vi.fn() }));
+vi.mock("@/lib/api", () => ({
+  isDesktopHost: () => true,
+  isTauri: () => false,
+  settingsGet: vi.fn(async () => ({ wallpaperXSearchMode: "responses_preview" })),
+  settingsSet: vi.fn(async () => ({})),
+  wallpaperXSearch: mocks.search, wallpaperXSearchMore: mocks.more, wallpaperXSearchCancel: mocks.cancel,
+  listenWallpaperXSearchProgress: vi.fn(async () => () => {}),
+  listenWallpaperXSearchBatch: vi.fn(async () => () => {}),
+  wallpaperFetchMedia: vi.fn(async () => ({ path: "C:/cache/sky.jpg", mime: "image/jpeg", name: "sky.jpg" })),
+  wallpaperImagine: vi.fn(), wallpaperLibraryList: vi.fn(), wallpaperLibraryDelete: vi.fn(), openExternalUrl: vi.fn(),
+}));
+vi.mock("@/components/ImageViewerContext", () => ({ useImageViewerOptional: () => ({ open: mocks.preview }) }));
+vi.mock("@/components/Select", () => ({ Select: ({ value }: { value: string }) => <span>{value}</span> }));
+vi.mock("@/components/GlassModal", () => ({
+  GlassModal: ({ open, children, footer, onClose }: { open: boolean; children: React.ReactNode; footer?: React.ReactNode; onClose: () => void }) => open ? <div><button onClick={onClose}>close-modal</button>{children}{footer}</div> : null,
+}));
+import { WallpaperSourceModal } from "./WallpaperSourceModal";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(yes => { resolve = yes; });
+  return { promise, resolve };
+}
+const item = (id: string) => ({ id, kind: "image", source: "x", fullUrl: `https://pbs.twimg.com/media/${id}.jpg`, thumbUrl: `https://pbs.twimg.com/media/${id}.jpg` });
+const t = (key: string) => key;
+const moreButton = () => screen.getByRole("button", { name: "settings.wallpaperSource.loadMore" });
+const cards = () => screen.getAllByRole("button", { name: "settings.wallpaperSource.openPreview" });
+async function initial() {
+  mocks.search.mockResolvedValue({ items: [item("first")], meta: { routeUsed: "responses", durationMs: 1, continuationId: "context-1" } });
+  const view = render(<WallpaperSourceModal open t={t as never} onClose={vi.fn()} onPickFile={vi.fn()} />);
+  const input = screen.getByPlaceholderText("settings.wallpaperSource.xPlaceholder");
+  fireEvent.change(input, { target: { value: "sky" } });
+  await waitFor(() => expect((screen.getByRole("button", { name: "settings.wallpaperSource.search" }) as HTMLButtonElement).disabled).toBe(false));
+  fireEvent.click(screen.getByRole("button", { name: "settings.wallpaperSource.search" }));
+  await screen.findByRole("button", { name: "settings.wallpaperSource.loadMore" });
+  return view;
+}
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+it("preserves selectable images during enrichment and appends distinct final results", async () => {
+  const pending = deferred<WallpaperSearchResult>();
+  mocks.more.mockReturnValue(pending.promise);
+  await initial();
+  fireEvent.click(moreButton());
+  await waitFor(() => expect(mocks.more).toHaveBeenCalledTimes(1));
+  expect(mocks.more.mock.calls[0][0]).toBe("context-1");
+  expect((cards()[0] as HTMLButtonElement).disabled).toBe(false);
+  fireEvent.click(cards()[0]);
+  await waitFor(() => expect(mocks.preview).toHaveBeenCalledTimes(1));
+  pending.resolve({ items: [item("first"), item("second")] });
+  await waitFor(() => expect(cards()).toHaveLength(2));
+  expect(screen.queryByRole("button", { name: "settings.wallpaperSource.loadMore" })).toBeNull();
+});
+
+it("keeps old gallery and allows retry after network failure, then consumes empty completion", async () => {
+  mocks.more.mockResolvedValueOnce({ items: [], errorCode: "responses_network" }).mockResolvedValueOnce({ items: [], errorCode: "empty" });
+  await initial();
+  fireEvent.click(moreButton());
+  await waitFor(() => expect(screen.queryByRole("button", { name: "settings.wallpaperSource.cancelSearch" })).toBeNull());
+  expect(cards()).toHaveLength(1);
+  fireEvent.click(moreButton());
+  await screen.findByText("settings.wallpaperSource.noMore");
+  expect(cards()).toHaveLength(1);
+  expect(mocks.more).toHaveBeenCalledTimes(2);
+});
+
+it("hides continuation for a changed query and discards a late result after close", async () => {
+  const pending = deferred<WallpaperSearchResult>();
+  mocks.more.mockReturnValue(pending.promise);
+  await initial();
+  const input = screen.getByPlaceholderText("settings.wallpaperSource.xPlaceholder");
+  fireEvent.change(input, { target: { value: "sea" } });
+  expect(screen.queryByRole("button", { name: "settings.wallpaperSource.loadMore" })).toBeNull();
+  fireEvent.change(input, { target: { value: "sky" } });
+  fireEvent.click(moreButton());
+  fireEvent.click(screen.getByRole("button", { name: "close-modal" }));
+  await waitFor(() => expect(mocks.cancel).toHaveBeenCalled());
+  pending.resolve({ items: [item("late")] });
+  await waitFor(() => expect(cards()).toHaveLength(1));
+});

--- a/src/components/WallpaperSourceModal.tsx
+++ b/src/components/WallpaperSourceModal.tsx
@@ -22,6 +22,7 @@ import * as api from "@/lib/api";
 import { isDesktopHost } from "@/lib/api";
 import {
   dedupeGalleryItems,
+  appendWallpaperGalleryItems,
   errorCodeFromSearchResult,
   fileFromAbsolutePath,
   libraryEntriesToGalleryItems,
@@ -116,10 +117,13 @@ export function WallpaperSourceModal({
   /** True after at least one search/generate finished this open. */
   const [hasSearched, setHasSearched] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [continuation, setContinuation] = useState<{ id: string; query: string; sort: "top" | "latest" } | null>(null);
   const [operationBusy, setBusy] = useState(false);
   const [routeSaving, setRouteSaving] = useState(false);
   const {
     busy: xBusy,
+    loadingMore,
+    loadMore: searchMore,
     stage: xStage,
     progressiveItems,
     search: searchX,
@@ -156,9 +160,10 @@ export function WallpaperSourceModal({
     setKindFilter(initialTab === "library" ? "image" : "all");
     setHasSearched(false);
     setItems([]);
+    setContinuation(null);
   }, [open, initialTab]);
 
-  const galleryItems = xBusy && progressiveItems.length > 0 ? progressiveItems : items;
+  const galleryItems = xBusy && !loadingMore && progressiveItems.length > 0 ? progressiveItems : items;
   const kindCounts = useMemo(() => countGalleryByKind(galleryItems), [galleryItems]);
 
   const visibleItems = useMemo(
@@ -234,6 +239,8 @@ export function WallpaperSourceModal({
   );
 
   const runXSearch = useCallback(async () => {
+    if (xBusy || operationBusy || routeSaving) return;
+    setContinuation(null);
     const q = query.trim();
     if (!q) {
       setErrorCode("empty");
@@ -294,6 +301,7 @@ export function WallpaperSourceModal({
         );
       } else {
         setItems(list);
+        if (res.meta?.continuationId) setContinuation({ id: res.meta.continuationId, query: q, sort });
         setError(null);
         setErrorCode(null);
         const counts = countWallpaperXCitations(list);
@@ -319,7 +327,7 @@ export function WallpaperSourceModal({
       setErrorCode(code);
       setError(errorMessage(t, code));
     }
-  }, [query, sort, t, searchX]);
+  }, [query, sort, t, searchX, xBusy, operationBusy, routeSaving]);
 
   const runImagine = useCallback(async () => {
     const p = prompt.trim();
@@ -467,7 +475,7 @@ export function WallpaperSourceModal({
    */
   const openItemPreview = useCallback(
     async (item: WallpaperGalleryItem) => {
-      if (busy || applying || previewingId) return;
+      if (operationBusy || routeSaving || (xBusy && !loadingMore) || applying || previewingId) return;
       if (!isDesktopHost()) {
         setErrorCode("generic");
         setError(t("settings.wallpaperSource.err.desktopOnly"));
@@ -533,7 +541,7 @@ export function WallpaperSourceModal({
         setStatusHint(null);
       }
     },
-    [busy, applying, previewingId, visibleItems, t, viewer, dropItem],
+    [operationBusy, routeSaving, xBusy, loadingMore, applying, previewingId, visibleItems, t, viewer, dropItem],
   );
 
   const openXStatus = useCallback((url: string) => {
@@ -584,8 +592,37 @@ export function WallpaperSourceModal({
     }
   }, [selected, t, onPickFile, onClose]);
 
+  const runLoadMore = useCallback(async () => {
+    if (!continuation || xBusy || operationBusy || applying || routeSaving) return;
+    setError(null);
+    setErrorCode(null);
+    try {
+      const result = await searchMore(continuation.id);
+      if (!result) return;
+      if (!result.errorCode) {
+        setItems(previous => appendWallpaperGalleryItems(previous, result.items));
+        setContinuation(null);
+        setCiteSummary(null);
+        setStatusHint(null);
+      } else if (result.errorCode === "empty") {
+        setContinuation(null);
+        setStatusHint(t("settings.wallpaperSource.noMore"));
+      } else {
+        if (result.errorCode === "load_more_unavailable" || result.errorCode.startsWith("oauth_")) setContinuation(null);
+        const code = parseWallpaperSourceError(result.errorCode);
+        setErrorCode(code);
+        setError(errorMessage(t, code));
+      }
+    } catch (error) {
+      const code = parseWallpaperSourceError(error);
+      setErrorCode(code);
+      setError(errorMessage(t, code));
+    }
+  }, [continuation, xBusy, operationBusy, applying, routeSaving, searchMore, t]);
+
   const authNeeded = errorCode === "auth_required";
   const locked = busy || applying || previewingId !== null;
+  const galleryLocked = operationBusy || routeSaving || (xBusy && !loadingMore) || applying || previewingId !== null;
   const showGalleryFilters = galleryItems.length > 0 || filtersActive;
   const softFailError =
     galleryErrorKind != null && isWallpaperGallerySoftFail(galleryErrorKind);
@@ -613,7 +650,7 @@ export function WallpaperSourceModal({
         <WallpaperSourceFooter
           t={t}
           selected={selected !== null}
-          locked={locked}
+          locked={galleryLocked}
           applying={applying}
           onClose={close}
           applySelected={applySelected}
@@ -821,11 +858,17 @@ export function WallpaperSourceModal({
         </div>
       ) : null}
 
+      {tab === "x" && continuation && continuation.query === query.trim() && continuation.sort === sort ? (
+        <button type="button" className="btn btn--ghost" disabled={xBusy || operationBusy || applying || routeSaving} onClick={() => void runLoadMore()}>
+          {t(loadingMore ? "settings.wallpaperSource.searching" : "settings.wallpaperSource.loadMore")}
+        </button>
+      ) : null}
+
       <WallpaperSourceGallery
         t={t}
         tab={tab}
         busy={busy}
-        locked={locked}
+        locked={galleryLocked}
         visibleItems={visibleItems}
         selectedId={selectedId}
         previewingId={previewingId}

--- a/src/hooks/useWallpaperXSearch.test.tsx
+++ b/src/hooks/useWallpaperXSearch.test.tsx
@@ -18,6 +18,7 @@ function harness() {
   const unlisten = vi.fn();
   const client: WallpaperXSearchClient = {
     listenBatch: vi.fn(async (handler) => { emitBatch = handler; return () => {}; }),
+    loadMore: vi.fn(),
     search: vi.fn(), cancel: vi.fn(async () => true),
     listenProgress: vi.fn(async (handler) => { emit = handler; return unlisten; }),
   };
@@ -117,4 +118,18 @@ it("resets batches for replacement and trusts the final invoke result", async ()
   expect(h.hook.result.current.busy).toBe(false);
   act(() => h.emitBatch(batch("2", 2, ["too-late"])));
   expect(h.hook.result.current.progressiveItems.map(item => item.id)).toEqual(["preview"]);
+});
+
+it("uses a separate more command and cancels it without losing the next request", async () => {
+  const h = harness();
+  const pending = deferred<WallpaperSearchResult>();
+  vi.mocked(h.client.loadMore).mockReturnValue(pending.promise);
+  let result!: Promise<WallpaperSearchResult | null>;
+  act(() => { result = h.hook.result.current.loadMore("context"); });
+  expect(h.client.loadMore).toHaveBeenCalledWith("context", "1");
+  expect(h.client.search).not.toHaveBeenCalled();
+  expect(h.hook.result.current.loadingMore).toBe(true);
+  await act(async () => { await h.hook.result.current.cancel(); });
+  expect(h.hook.result.current.loadingMore).toBe(false);
+  await act(async () => { pending.resolve({ items: [] }); expect(await result).toBeNull(); });
 });

--- a/src/hooks/useWallpaperXSearch.ts
+++ b/src/hooks/useWallpaperXSearch.ts
@@ -4,6 +4,7 @@ import { createWallpaperXSearchRequestId, isWallpaperXSearchBatch, type Wallpape
 import { dedupeGalleryItems, type WallpaperGalleryItem, type WallpaperSearchResult } from "@/lib/wallpaperSource";
 
 export type WallpaperXSearchClient = {
+  loadMore: (continuationId: string, requestId: string) => Promise<WallpaperSearchResult>;
   search: (query: string, sort: "top" | "latest", requestId: string) => Promise<WallpaperSearchResult>;
   listenBatch: (handler: (batch: WallpaperXSearchBatch) => void) => Promise<() => void>;
   cancel: (requestId: string) => Promise<boolean>;
@@ -12,6 +13,7 @@ export type WallpaperXSearchClient = {
 
 const DEFAULT_CLIENT: WallpaperXSearchClient = {
   search: api.wallpaperXSearch,
+  loadMore: api.wallpaperXSearchMore,
   cancel: api.wallpaperXSearchCancel,
   listenProgress: api.listenWallpaperXSearchProgress,
   listenBatch: api.listenWallpaperXSearchBatch,
@@ -64,6 +66,7 @@ export function useWallpaperXSearch(
   client: WallpaperXSearchClient = DEFAULT_CLIENT,
   requestIdFactory: () => string = createWallpaperXSearchRequestId,
 ) {
+  const [loadingMore, setLoadingMore] = useState(false);
   const [busy, setBusy] = useState(false);
   const [stage, setStage] = useState<WallpaperXSearchStage | null>(null);
   const [progressive, dispatchProgressive] = useReducer(progressiveReducer, EMPTY_PROGRESSIVE_STATE);
@@ -108,13 +111,14 @@ export function useWallpaperXSearch(
     active.current = null;
     if (mounted.current) {
       dispatchProgressive({ type: "reset" });
+      setLoadingMore(false);
       setBusy(false);
       setStage(null);
     }
     return id ? client.cancel(id).catch(() => false) : Promise.resolve(false);
   }, [client]);
 
-  const search = useCallback(async (query: string, sort: "top" | "latest") => {
+  const run = useCallback(async (query: string, sort: "top" | "latest", continuationId?: string) => {
     if (!mounted.current) return null;
     // Invalidate synchronously: a slow cancel acknowledgement must not delay
     // replacement or let a third request be overwritten by a waiting second.
@@ -122,11 +126,12 @@ export function useWallpaperXSearch(
     const id = requestIdFactory();
     const revision = ++generation.current;
     active.current = id;
+    setLoadingMore(continuationId !== undefined);
     setBusy(true);
     setStage("preparing");
     const current = () => mounted.current && generation.current === revision && active.current === id;
     try {
-      const result = await client.search(query, sort, id);
+      const result = continuationId === undefined ? await client.search(query, sort, id) : await client.loadMore(continuationId, id);
       return current() && result.errorCode !== "cancelled" ? result : null;
     } catch (error) {
       if (!current()) return null;
@@ -134,11 +139,14 @@ export function useWallpaperXSearch(
     } finally {
       if (current()) {
         active.current = null;
-        setBusy(false);
+        setLoadingMore(false);
+      setBusy(false);
         setStage(null);
       }
     }
   }, [cancel, client, requestIdFactory]);
 
-  return { busy, stage, search, cancel, progressiveItems: progressive.items };
+  const search = useCallback((query: string, sort: "top" | "latest") => run(query, sort), [run]);
+  const loadMore = useCallback((id: string) => run("", "top", id), [run]);
+  return { busy, loadingMore, stage, search, loadMore, cancel, progressiveItems: progressive.items };
 }

--- a/src/i18n/messages/de/settings-ui.ts
+++ b/src/i18n/messages/de/settings-ui.ts
@@ -7,6 +7,8 @@ export const deSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Responses-Vorschau · {seconds} s",
   "settings.wallpaperSource.route.cached": "Aus dem Cache geladen · {route}",
+  "settings.wallpaperSource.loadMore": "Mehr laden",
+  "settings.wallpaperSource.noMore": "Keine weiteren Bilder gefunden.",
   "settings.wallpaperSource.route.fallback": "Auf Grok Build CLI zurückgefallen ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "offizielle Anmeldung fehlt oder ist abgelaufen",
   "settings.wallpaperSource.route.fallback.network": "Responses-Netzwerk nicht erreichbar",

--- a/src/i18n/messages/en/settings-ui.ts
+++ b/src/i18n/messages/en/settings-ui.ts
@@ -7,6 +7,8 @@ export const enSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds}s",
   "settings.wallpaperSource.route.responses": "Responses preview · {seconds}s",
   "settings.wallpaperSource.route.cached": "Loaded from cache · {route}",
+  "settings.wallpaperSource.loadMore": "Load more",
+  "settings.wallpaperSource.noMore": "No more images found.",
   "settings.wallpaperSource.route.fallback": "Fell back to Grok Build CLI ({reason}) · {seconds}s",
   "settings.wallpaperSource.route.fallback.auth": "official sign-in unavailable or expired",
   "settings.wallpaperSource.route.fallback.network": "Responses network unavailable",

--- a/src/i18n/messages/es/settings-ui.ts
+++ b/src/i18n/messages/es/settings-ui.ts
@@ -7,6 +7,8 @@ export const esSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Vista previa de Responses · {seconds} s",
   "settings.wallpaperSource.route.cached": "Cargado desde la caché · {route}",
+  "settings.wallpaperSource.loadMore": "Cargar más",
+  "settings.wallpaperSource.noMore": "No se encontraron más imágenes.",
   "settings.wallpaperSource.route.fallback": "Se usó Grok Build CLI como alternativa ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "inicio de sesión oficial no disponible o caducado",
   "settings.wallpaperSource.route.fallback.network": "red de Responses no disponible",

--- a/src/i18n/messages/fil/settings-ui.ts
+++ b/src/i18n/messages/fil/settings-ui.ts
@@ -7,6 +7,8 @@ export const filSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds}s",
   "settings.wallpaperSource.route.responses": "Responses preview · {seconds}s",
   "settings.wallpaperSource.route.cached": "Na-load mula sa cache · {route}",
+  "settings.wallpaperSource.loadMore": "Mag-load pa",
+  "settings.wallpaperSource.noMore": "Wala nang ibang larawang nahanap.",
   "settings.wallpaperSource.route.fallback": "Bumalik sa Grok Build CLI ({reason}) · {seconds}s",
   "settings.wallpaperSource.route.fallback.auth": "hindi available o paso ang opisyal na sign-in",
   "settings.wallpaperSource.route.fallback.network": "hindi available ang Responses network",

--- a/src/i18n/messages/fr/settings-ui.ts
+++ b/src/i18n/messages/fr/settings-ui.ts
@@ -7,6 +7,8 @@ export const frSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Aperçu Responses · {seconds} s",
   "settings.wallpaperSource.route.cached": "Chargé depuis le cache · {route}",
+  "settings.wallpaperSource.loadMore": "Charger plus",
+  "settings.wallpaperSource.noMore": "Aucune autre image trouvée.",
   "settings.wallpaperSource.route.fallback": "Repli sur Grok Build CLI ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "connexion officielle indisponible ou expirée",
   "settings.wallpaperSource.route.fallback.network": "réseau Responses indisponible",

--- a/src/i18n/messages/id/settings-ui.ts
+++ b/src/i18n/messages/id/settings-ui.ts
@@ -7,6 +7,8 @@ export const idSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} dtk",
   "settings.wallpaperSource.route.responses": "Pratinjau Responses · {seconds} dtk",
   "settings.wallpaperSource.route.cached": "Dimuat dari cache · {route}",
+  "settings.wallpaperSource.loadMore": "Muat lainnya",
+  "settings.wallpaperSource.noMore": "Tidak ada gambar lain yang ditemukan.",
   "settings.wallpaperSource.route.fallback": "Beralih kembali ke Grok Build CLI ({reason}) · {seconds} dtk",
   "settings.wallpaperSource.route.fallback.auth": "login resmi tidak tersedia atau kedaluwarsa",
   "settings.wallpaperSource.route.fallback.network": "jaringan Responses tidak tersedia",

--- a/src/i18n/messages/it/settings-ui.ts
+++ b/src/i18n/messages/it/settings-ui.ts
@@ -7,6 +7,8 @@ export const itSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Anteprima Responses · {seconds} s",
   "settings.wallpaperSource.route.cached": "Caricato dalla cache · {route}",
+  "settings.wallpaperSource.loadMore": "Carica altro",
+  "settings.wallpaperSource.noMore": "Nessun'altra immagine trovata.",
   "settings.wallpaperSource.route.fallback": "Ripiego su Grok Build CLI ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "accesso ufficiale non disponibile o scaduto",
   "settings.wallpaperSource.route.fallback.network": "rete Responses non disponibile",

--- a/src/i18n/messages/ja/settings-ui.ts
+++ b/src/i18n/messages/ja/settings-ui.ts
@@ -7,6 +7,8 @@ export const jaSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI・{seconds}秒",
   "settings.wallpaperSource.route.responses": "Responses プレビュー・{seconds}秒",
   "settings.wallpaperSource.route.cached": "キャッシュから読み込み · {route}",
+  "settings.wallpaperSource.loadMore": "さらに読み込む",
+  "settings.wallpaperSource.noMore": "これ以上画像は見つかりませんでした。",
   "settings.wallpaperSource.route.fallback": "Grok Build CLI に切り替えました（{reason}）・{seconds}秒",
   "settings.wallpaperSource.route.fallback.auth": "公式ログインが利用できないか期限切れ",
   "settings.wallpaperSource.route.fallback.network": "Responses のネットワークを利用不可",

--- a/src/i18n/messages/ko/settings-ui.ts
+++ b/src/i18n/messages/ko/settings-ui.ts
@@ -7,6 +7,8 @@ export const koSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds}초",
   "settings.wallpaperSource.route.responses": "Responses 미리보기 · {seconds}초",
   "settings.wallpaperSource.route.cached": "캐시에서 불러옴 · {route}",
+  "settings.wallpaperSource.loadMore": "더 불러오기",
+  "settings.wallpaperSource.noMore": "더 이상 이미지를 찾지 못했습니다.",
   "settings.wallpaperSource.route.fallback": "Grok Build CLI로 대체됨({reason}) · {seconds}초",
   "settings.wallpaperSource.route.fallback.auth": "공식 로그인을 사용할 수 없거나 만료됨",
   "settings.wallpaperSource.route.fallback.network": "Responses 네트워크를 사용할 수 없음",

--- a/src/i18n/messages/pt-BR/settings-ui.ts
+++ b/src/i18n/messages/pt-BR/settings-ui.ts
@@ -7,6 +7,8 @@ export const ptBRSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} s",
   "settings.wallpaperSource.route.responses": "Prévia de Responses · {seconds} s",
   "settings.wallpaperSource.route.cached": "Carregado do cache · {route}",
+  "settings.wallpaperSource.loadMore": "Carregar mais",
+  "settings.wallpaperSource.noMore": "Nenhuma outra imagem foi encontrada.",
   "settings.wallpaperSource.route.fallback": "Retorno ao Grok Build CLI ({reason}) · {seconds} s",
   "settings.wallpaperSource.route.fallback.auth": "login oficial indisponível ou expirado",
   "settings.wallpaperSource.route.fallback.network": "rede de Responses indisponível",

--- a/src/i18n/messages/ru/settings-ui.ts
+++ b/src/i18n/messages/ru/settings-ui.ts
@@ -7,6 +7,8 @@ export const ruSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} с",
   "settings.wallpaperSource.route.responses": "Предпросмотр Responses · {seconds} с",
   "settings.wallpaperSource.route.cached": "Загружено из кеша · {route}",
+  "settings.wallpaperSource.loadMore": "Загрузить ещё",
+  "settings.wallpaperSource.noMore": "Других изображений не найдено.",
   "settings.wallpaperSource.route.fallback": "Выполнен откат к Grok Build CLI ({reason}) · {seconds} с",
   "settings.wallpaperSource.route.fallback.auth": "официальный вход недоступен или истёк",
   "settings.wallpaperSource.route.fallback.network": "сеть Responses недоступна",

--- a/src/i18n/messages/ta/settings-ui.ts
+++ b/src/i18n/messages/ta/settings-ui.ts
@@ -7,6 +7,8 @@ export const taSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} வி",
   "settings.wallpaperSource.route.responses": "Responses முன்னோட்டம் · {seconds} வி",
   "settings.wallpaperSource.route.cached": "தற்காலிக சேமிப்பிலிருந்து ஏற்றப்பட்டது · {route}",
+  "settings.wallpaperSource.loadMore": "மேலும் ஏற்று",
+  "settings.wallpaperSource.noMore": "மேலும் படங்கள் கிடைக்கவில்லை.",
   "settings.wallpaperSource.route.fallback": "Grok Build CLI-க்கு மாற்றப்பட்டது ({reason}) · {seconds} வி",
   "settings.wallpaperSource.route.fallback.auth": "அதிகாரப்பூர்வ உள்நுழைவு கிடைக்கவில்லை அல்லது காலாவதியானது",
   "settings.wallpaperSource.route.fallback.network": "Responses பிணையம் கிடைக்கவில்லை",

--- a/src/i18n/messages/uk/settings-ui.ts
+++ b/src/i18n/messages/uk/settings-ui.ts
@@ -7,6 +7,8 @@ export const ukSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} с",
   "settings.wallpaperSource.route.responses": "Перегляд Responses · {seconds} с",
   "settings.wallpaperSource.route.cached": "Завантажено з кешу · {route}",
+  "settings.wallpaperSource.loadMore": "Завантажити ще",
+  "settings.wallpaperSource.noMore": "Інших зображень не знайдено.",
   "settings.wallpaperSource.route.fallback": "Перехід до Grok Build CLI ({reason}) · {seconds} с",
   "settings.wallpaperSource.route.fallback.auth": "офіційний вхід недоступний або прострочений",
   "settings.wallpaperSource.route.fallback.network": "мережа Responses недоступна",

--- a/src/i18n/messages/zh-TW/settings-ui.ts
+++ b/src/i18n/messages/zh-TW/settings-ui.ts
@@ -7,6 +7,8 @@ export const zhTWSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} 秒",
   "settings.wallpaperSource.route.responses": "Responses 預覽 · {seconds} 秒",
   "settings.wallpaperSource.route.cached": "已從快取載入 · {route}",
+  "settings.wallpaperSource.loadMore": "載入更多",
+  "settings.wallpaperSource.noMore": "找不到更多圖片。",
   "settings.wallpaperSource.route.fallback": "已退回 Grok Build CLI（{reason}）· {seconds} 秒",
   "settings.wallpaperSource.route.fallback.auth": "官方登入無法使用或已過期",
   "settings.wallpaperSource.route.fallback.network": "Responses 網路無法使用",

--- a/src/i18n/messages/zh/settings-ui.ts
+++ b/src/i18n/messages/zh/settings-ui.ts
@@ -7,6 +7,8 @@ export const zhSettingsUi = {
   "settings.wallpaperSource.route.cli": "Grok Build CLI · {seconds} 秒",
   "settings.wallpaperSource.route.responses": "Responses 预览 · {seconds} 秒",
   "settings.wallpaperSource.route.cached": "已从缓存加载 · {route}",
+  "settings.wallpaperSource.loadMore": "加载更多",
+  "settings.wallpaperSource.noMore": "没有找到更多图片。",
   "settings.wallpaperSource.route.fallback": "已回退 Grok Build CLI（{reason}）· {seconds} 秒",
   "settings.wallpaperSource.route.fallback.auth": "官方登录不可用或已过期",
   "settings.wallpaperSource.route.fallback.network": "Responses 网络不可用",

--- a/src/lib/api/wallpaper.ts
+++ b/src/lib/api/wallpaper.ts
@@ -164,3 +164,7 @@ export async function listenWallpaperXSearchBatch(
 ): Promise<() => void> {
   return listen<import("../wallpaperXSearch").WallpaperXSearchBatch>("wallpaper://x-search-batch", handler);
 }
+
+export async function wallpaperXSearchMore(continuationId: string, requestId: string): Promise<WallpaperSearchResult> {
+  return invoke<WallpaperSearchResult>("wallpaper_x_search_more", { continuationId, requestId });
+}

--- a/src/lib/wallpaperSource.ts
+++ b/src/lib/wallpaperSource.ts
@@ -27,6 +27,7 @@ export type WallpaperSearchResult = {
     fallbackReason?: string | null;
     durationMs: number;
     cacheHit?: boolean;
+    continuationId?: string | null;
   } | null;
   items: WallpaperGalleryItem[];
   errorCode?: string | null;
@@ -135,6 +136,23 @@ export function dedupeGalleryItems(
     out.push(it);
   }
   return out;
+}
+
+/** Append remote results without duplicating an already-materialized card. */
+export function appendWallpaperGalleryItems(
+  existing: WallpaperGalleryItem[],
+  incoming: WallpaperGalleryItem[],
+): WallpaperGalleryItem[] {
+  const ids = new Set(existing.map(item => `${item.source}:${item.id}`));
+  const urls = new Set(existing.map(item => item.fullUrl));
+  const fresh = incoming.filter(item => {
+    const id = `${item.source}:${item.id}`;
+    if (ids.has(id) || urls.has(item.fullUrl)) return false;
+    ids.add(id);
+    urls.add(item.fullUrl);
+    return true;
+  });
+  return dedupeGalleryItems([...existing, ...fresh]);
 }
 
 function mimeFromName(name: string): string {
@@ -509,4 +527,3 @@ export function libraryEntriesToGalleryItems(
       : [...entries];
   return dedupeGalleryItems(ordered.map(libraryEntryToGalleryItem));
 }
-


### PR DESCRIPTION
## Summary

为成功的 Responses 壁纸搜索增加一次显式“加载更多”：点击后追加一批目标 8 张的图片，保留已有图库；加载期间仍可点开原图和选用壁纸，失败可重试，无新图时显示提示。

- Host 返回绑定原始图库与官方凭据的 opaque continuationId；前端仅提交该 ID 与新的 requestId，修改搜索词/排序后不再显示旧追加入口。
- 上下文采用独占租约，防重复提交；执行期间不被 TTL/LRU/同主题搜索覆盖。取消、网络失败或 future 丢弃归还租约，成功/确认空结果消费一次。
- 单次追加只发一个 Responses 请求，最多三次 X 工具调用，按已见媒体/帖子身份排除并经过原有质量校验。不自动重试、不回退 CLI，不自动预取。
- 使用已验证的凭据快照发请求，返回前再次检查有效期与 revision，身份变化时不交付追加结果。
- 追加合并保留原图本地路径与选中状态，修复加载期间打开原图后出现重复卡片的问题。补齐 15 语言，无 App/AppWorkbench 状态增长。

依赖 #1088/#1089/#1090；目标上游 main，当前含未合入前置，最后一个提交为本主题，前置合入后 rebase 去重。保持 UI hold，由维护者审核；不请求自动合并。已搜索开放/关闭 wallpaper load more Issues，无直接对应项，不添加自动关闭引用。

## Type of change
- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Validation

本主题 32 文件 +731/-61，包含租约/去重/交互回归和 30 行翻译。7,079 项前端、1,692 项 Rust 测试通过（另 1 项原有 ignored）；typecheck、lint、UI build、Rust fmt/clippy、质量门禁、网站 self-test、依赖检查及生产审计全部通过。Windows harness 按仓库 CI 嵌入 Common Controls manifest。22 项定向回归覆盖追加期间预览、保留已下载图不重复、错误重试/空结果、改词隐藏入口、关闭迟到结果隔离；Host 覆盖独占租约、TTL 期间保护、取消归还、单次消费与已见媒体/帖子去重。尚未执行真实账号端到端或桌面手动验收，结果数量和耗时取决于服务返回。本批仅提供一次手动追加；预加载及后续来源/目录/生成仍按后续主题交付。

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

