### PR TITLE
feat(secrets): 支持 Pexels 凭据安全存储与配置状态

### DIFF
--- a/docs/llm-wiki/account.md
+++ b/docs/llm-wiki/account.md
@@ -195,3 +195,14 @@ All strings via `src/i18n/messages.ts` (`account.*` keys). See [i18n.md](./i18n.
 - Profile DTO never includes `key` / `refresh_token` / raw access tokens.
 - Login stdout/stderr must not be dumped to app logs if they may contain secrets.
 - Doctor / export still go through existing redact paths.
+
+
+### Pexels credential storage
+
+The Host secrets API accepts an optional `pexelsApiKey`: omitted leaves the
+existing value untouched, a blank string clears it, and a nonblank string is
+trimmed before storage. `secrets_get_masked` exposes `hasPexelsKey` only. The key
+follows the existing OS keychain/plaintext fallback policy, participates in
+migration and cache merging, and is stripped from the disk payload when the
+keychain is used. This is storage groundwork for the separate wallpaper provider
+integration; it does not add a source picker or perform a Pexels request.

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -586,6 +586,7 @@ pub async fn secrets_get_masked() -> Result<serde_json::Value, String> {
         "hasOfficialKey": crate::secrets::has_official_key_configured(&s),
         "hasRelayKey": has_provider_key
             || crate::secrets::has_relay_key_configured(&s),
+        "hasPexelsKey": crate::secrets::has_pexels_key_configured(&s),
         "hasSttCustomKey": crate::secrets::has_stt_custom_key_configured(&s),
         "sttCustomKeys": crate::secrets::stt_custom_key_presence(&s),
         "relayBaseUrl": relay_base,
@@ -609,6 +610,7 @@ pub async fn secrets_set(
     official_api_key: Option<String>,
     relay_base_url: Option<String>,
     relay_api_key: Option<String>,
+    pexels_api_key: Option<String>,
     default_model: Option<String>,
     stt_custom_api_key: Option<String>,
     stt_custom_api_key_provider: Option<String>,
@@ -631,6 +633,9 @@ pub async fn secrets_set(
         } else {
             Some(k)
         };
+    }
+    if let Some(k) = pexels_api_key {
+        s.pexels_api_key = if k.trim().is_empty() { None } else { Some(k.trim().to_string()) };
     }
     if let Some(m) = default_model {
         s.default_model = if m.is_empty() { None } else { Some(m) };

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -29,6 +29,7 @@ const KEYRING_SERVICE: &str = "com.grokapp.grok-app";
 
 const KEY_OFFICIAL: &str = "official_api_key";
 const KEY_RELAY: &str = "relay_api_key";
+const KEY_PEXELS: &str = "pexels_api_key";
 const KEY_STT_CUSTOM: &str = "stt_custom_api_key";
 
 /// Where sensitive fields were last successfully written (for diagnostics only).
@@ -221,7 +222,10 @@ pub fn sync_stt_presence(s: &mut SecretsFile) {
 
 /// True when the on-disk payload still holds plaintext API keys that should migrate.
 pub fn disk_has_plaintext_keys(disk: &SecretsFile) -> bool {
-    non_empty(&disk.official_api_key) || non_empty(&disk.relay_api_key) || stt_keys_non_empty(disk)
+    non_empty(&disk.official_api_key)
+        || non_empty(&disk.relay_api_key)
+        || non_empty(&disk.pexels_api_key)
+        || stt_keys_non_empty(disk)
 }
 
 /// Whether UI / setup should treat an official key as configured.
@@ -235,6 +239,11 @@ pub fn has_relay_key_configured(disk: &SecretsFile) -> bool {
     non_empty(&disk.relay_api_key) || disk.keychain_has_relay
 }
 
+/// Whether a Pexels key is configured (disk plaintext or keychain flag).
+pub fn has_pexels_key_configured(disk: &SecretsFile) -> bool {
+    non_empty(&disk.pexels_api_key) || disk.keychain_has_pexels
+}
+
 /// Whether a custom STT key is configured (disk plaintext or keychain flag).
 pub fn has_stt_custom_key_configured(disk: &SecretsFile) -> bool {
     stt_keys_non_empty(disk) || disk.keychain_has_stt_custom
@@ -245,6 +254,7 @@ pub fn strip_keys_for_disk(s: &SecretsFile) -> SecretsFile {
     SecretsFile {
         official_api_key: None,
         relay_api_key: None,
+        pexels_api_key: None,
         stt_custom_api_key: None,
         stt_custom_api_keys: std::collections::HashMap::new(),
         stt_custom_key_presence: s.stt_custom_key_presence.clone(),
@@ -252,6 +262,7 @@ pub fn strip_keys_for_disk(s: &SecretsFile) -> SecretsFile {
         default_model: s.default_model.clone(),
         keychain_has_official: s.keychain_has_official,
         keychain_has_relay: s.keychain_has_relay,
+        keychain_has_pexels: s.keychain_has_pexels,
         keychain_has_stt_custom: s.keychain_has_stt_custom,
     }
 }
@@ -266,6 +277,10 @@ pub fn merge_secrets(disk: SecretsFile, from_keychain: SecretsFile) -> SecretsFi
         .relay_api_key
         .filter(|k| !k.is_empty())
         .or(disk.relay_api_key.filter(|k| !k.is_empty()));
+    let pexels = from_keychain
+        .pexels_api_key
+        .filter(|k| !k.is_empty())
+        .or(disk.pexels_api_key.filter(|k| !k.is_empty()));
     // Per-provider: keychain wins per key; disk map supplies the rest.
     let mut stt_custom_keys = disk.stt_custom_api_keys;
     for (k, v) in from_keychain.stt_custom_api_keys {
@@ -294,11 +309,15 @@ pub fn merge_secrets(disk: SecretsFile, from_keychain: SecretsFile) -> SecretsFi
         keychain_has_relay: non_empty(&relay)
             || disk.keychain_has_relay
             || from_keychain.keychain_has_relay,
+        keychain_has_pexels: non_empty(&pexels)
+            || disk.keychain_has_pexels
+            || from_keychain.keychain_has_pexels,
         keychain_has_stt_custom: stt_present
             || disk.keychain_has_stt_custom
             || from_keychain.keychain_has_stt_custom,
         official_api_key: official,
         relay_api_key: relay,
+        pexels_api_key: pexels,
         stt_custom_api_key: stt_custom,
         stt_custom_api_keys: stt_custom_keys,
         stt_custom_key_presence: stt_presence,
@@ -389,6 +408,26 @@ pub fn migrate_plaintext_keys_to_keychain(disk: &mut SecretsFile) -> usize {
                 tracing::warn!(
                     target: "grok_app::secrets",
                     field = KEY_RELAY,
+                    error = %e,
+                    "failed to migrate secret field to OS keychain; leaving on disk"
+                );
+            }
+        }
+    }
+
+    if non_empty(&disk.pexels_api_key) {
+        let key = disk.pexels_api_key.as_deref().unwrap();
+        match keychain_set(KEY_PEXELS, key) {
+            Ok(()) => {
+                disk.pexels_api_key = None;
+                disk.keychain_has_pexels = true;
+                migrated += 1;
+            }
+            Err(e) => {
+                failed = true;
+                tracing::warn!(
+                    target: "grok_app::secrets",
+                    field = KEY_PEXELS,
                     error = %e,
                     "failed to migrate secret field to OS keychain; leaving on disk"
                 );
@@ -487,6 +526,11 @@ pub fn load_secrets() -> SecretsFile {
     } else {
         None
     };
+    let pexels = if disk.keychain_has_pexels || non_empty(&disk.pexels_api_key) {
+        keychain_get(KEY_PEXELS)
+    } else {
+        None
+    };
     // Keychain holds the per-provider map as JSON. Older entries stored the
     // raw single key — parse failure folds that into the `custom` slot.
     let stt_keys: std::collections::HashMap<String, String> =
@@ -503,11 +547,13 @@ pub fn load_secrets() -> SecretsFile {
     let from_kc = SecretsFile {
         official_api_key: official,
         relay_api_key: relay,
+        pexels_api_key: pexels,
         stt_custom_api_key: None,
         stt_custom_api_keys: stt_keys,
         stt_custom_key_presence: disk.stt_custom_key_presence.clone(),
         keychain_has_official: disk.keychain_has_official,
         keychain_has_relay: disk.keychain_has_relay,
+        keychain_has_pexels: disk.keychain_has_pexels,
         keychain_has_stt_custom: disk.keychain_has_stt_custom,
         relay_base_url: None,
         default_model: None,
@@ -554,6 +600,18 @@ pub fn save_secrets(s: &SecretsFile) -> Result<(), String> {
                 disk.keychain_has_relay = false;
             }
         }
+        match &s.pexels_api_key {
+            Some(k) if !k.is_empty() => {
+                keychain_set(KEY_PEXELS, k)?;
+                disk.keychain_has_pexels = true;
+            }
+            _ => {
+                if s.keychain_has_pexels || non_empty(&s.pexels_api_key) {
+                    keychain_delete(KEY_PEXELS)?;
+                }
+                disk.keychain_has_pexels = false;
+            }
+        }
         match &s.stt_custom_api_keys {
             m if !m.values().any(|k| !k.is_empty()) => {
                 if s.keychain_has_stt_custom || stt_keys_non_empty(&s) {
@@ -572,6 +630,7 @@ pub fn save_secrets(s: &SecretsFile) -> Result<(), String> {
         let cached = SecretsFile {
             official_api_key: s.official_api_key.clone(),
             relay_api_key: s.relay_api_key.clone(),
+            pexels_api_key: s.pexels_api_key.clone(),
             stt_custom_api_key: None,
             stt_custom_api_keys: s.stt_custom_api_keys.clone(),
             stt_custom_key_presence: disk.stt_custom_key_presence.clone(),
@@ -579,6 +638,7 @@ pub fn save_secrets(s: &SecretsFile) -> Result<(), String> {
             default_model: disk.default_model.clone(),
             keychain_has_official: disk.keychain_has_official,
             keychain_has_relay: disk.keychain_has_relay,
+            keychain_has_pexels: disk.keychain_has_pexels,
             keychain_has_stt_custom: disk.keychain_has_stt_custom,
         };
         *SESSION_CACHE.lock() = Some(cached);
@@ -588,13 +648,20 @@ pub fn save_secrets(s: &SecretsFile) -> Result<(), String> {
         let mut file = s.clone();
         sync_stt_presence(&mut file);
         migrate_legacy_stt_key(&mut file);
-        if file.keychain_has_official || file.keychain_has_relay || file.keychain_has_stt_custom {
+        if file.keychain_has_official
+            || file.keychain_has_relay
+            || file.keychain_has_pexels
+            || file.keychain_has_stt_custom
+        {
             // Pull values if caller only had flags (shouldn't happen after load).
             if !non_empty(&file.official_api_key) && file.keychain_has_official {
                 file.official_api_key = keychain_get(KEY_OFFICIAL);
             }
             if !non_empty(&file.relay_api_key) && file.keychain_has_relay {
                 file.relay_api_key = keychain_get(KEY_RELAY);
+            }
+            if !non_empty(&file.pexels_api_key) && file.keychain_has_pexels {
+                file.pexels_api_key = keychain_get(KEY_PEXELS);
             }
             if file.stt_custom_api_keys.is_empty() && file.keychain_has_stt_custom {
                 file.stt_custom_api_keys = keychain_get(KEY_STT_CUSTOM)
@@ -604,11 +671,13 @@ pub fn save_secrets(s: &SecretsFile) -> Result<(), String> {
             if keychain_platform_ok() {
                 let _ = keychain_delete(KEY_OFFICIAL);
                 let _ = keychain_delete(KEY_RELAY);
+                let _ = keychain_delete(KEY_PEXELS);
                 let _ = keychain_delete(KEY_STT_CUSTOM);
             }
         }
         file.keychain_has_official = false;
         file.keychain_has_relay = false;
+        file.keychain_has_pexels = false;
         file.keychain_has_stt_custom = false;
         write_disk_secrets(&path, &file)?;
         *SESSION_CACHE.lock() = Some(file);
@@ -654,6 +723,9 @@ pub fn apply_keychain_preference(enabled: bool) -> Result<(), String> {
         if disk.keychain_has_relay && !non_empty(&disk.relay_api_key) {
             disk.relay_api_key = keychain_get(KEY_RELAY);
         }
+        if disk.keychain_has_pexels && !non_empty(&disk.pexels_api_key) {
+            disk.pexels_api_key = keychain_get(KEY_PEXELS);
+        }
         if disk.keychain_has_stt_custom && disk.stt_custom_api_keys.is_empty() {
             disk.stt_custom_api_keys = keychain_get(KEY_STT_CUSTOM)
                 .and_then(|json| serde_json::from_str(&json).ok())
@@ -665,6 +737,7 @@ pub fn apply_keychain_preference(enabled: bool) -> Result<(), String> {
         let mut meta = strip_keys_for_disk(&disk);
         let mut official = disk.official_api_key.clone();
         let mut relay = disk.relay_api_key.clone();
+        let mut pexels = disk.pexels_api_key.clone();
         let mut stt_keys = disk.stt_custom_api_keys.clone();
 
         if non_empty(&official) {
@@ -674,6 +747,10 @@ pub fn apply_keychain_preference(enabled: bool) -> Result<(), String> {
         if non_empty(&relay) {
             keychain_set(KEY_RELAY, relay.as_deref().unwrap())?;
             meta.keychain_has_relay = true;
+        }
+        if non_empty(&pexels) {
+            keychain_set(KEY_PEXELS, pexels.as_deref().unwrap())?;
+            meta.keychain_has_pexels = true;
         }
         if !stt_keys.is_empty() {
             let json = serde_json::to_string(&stt_keys).map_err(|e| e.to_string())?;
@@ -685,6 +762,7 @@ pub fn apply_keychain_preference(enabled: bool) -> Result<(), String> {
         *SESSION_CACHE.lock() = Some(SecretsFile {
             official_api_key: official.take(),
             relay_api_key: relay.take(),
+            pexels_api_key: pexels.take(),
             stt_custom_api_key: None,
             stt_custom_api_keys: std::mem::take(&mut stt_keys),
             stt_custom_key_presence: meta.stt_custom_key_presence.clone(),
@@ -692,6 +770,7 @@ pub fn apply_keychain_preference(enabled: bool) -> Result<(), String> {
             default_model: meta.default_model,
             keychain_has_official: meta.keychain_has_official,
             keychain_has_relay: meta.keychain_has_relay,
+            keychain_has_pexels: meta.keychain_has_pexels,
             keychain_has_stt_custom: meta.keychain_has_stt_custom,
         });
         tracing::info!(target: "grok_app::secrets", "API keys storage: OS keychain");
@@ -708,6 +787,11 @@ pub fn apply_keychain_preference(enabled: bool) -> Result<(), String> {
                     disk.relay_api_key = Some(k);
                 }
             }
+            if disk.keychain_has_pexels || non_empty(&disk.pexels_api_key) {
+                if let Some(k) = keychain_get(KEY_PEXELS) {
+                    disk.pexels_api_key = Some(k);
+                }
+            }
             if disk.keychain_has_stt_custom || !disk.stt_custom_api_keys.is_empty() {
                 if let Some(json) = keychain_get(KEY_STT_CUSTOM) {
                     disk.stt_custom_api_keys = serde_json::from_str(&json).unwrap_or_else(|_| {
@@ -717,12 +801,14 @@ pub fn apply_keychain_preference(enabled: bool) -> Result<(), String> {
             }
             let _ = keychain_delete(KEY_OFFICIAL);
             let _ = keychain_delete(KEY_RELAY);
+            let _ = keychain_delete(KEY_PEXELS);
             let _ = keychain_delete(KEY_STT_CUSTOM);
         }
         sync_stt_presence(&mut disk);
         migrate_legacy_stt_key(&mut disk);
         disk.keychain_has_official = false;
         disk.keychain_has_relay = false;
+        disk.keychain_has_pexels = false;
         disk.keychain_has_stt_custom = false;
         write_disk_secrets(&path, &disk)?;
         *SESSION_CACHE.lock() = Some(disk);
@@ -735,7 +821,7 @@ pub fn apply_keychain_preference(enabled: bool) -> Result<(), String> {
 pub fn clear_keychain_secrets() {
     invalidate_session_cache();
     if keychain_platform_ok() {
-        for account in [KEY_OFFICIAL, KEY_RELAY, KEY_STT_CUSTOM] {
+        for account in [KEY_OFFICIAL, KEY_RELAY, KEY_PEXELS, KEY_STT_CUSTOM] {
             if let Err(e) = keychain_delete(account) {
                 tracing::warn!(
                     target: "grok_app::secrets",
@@ -751,9 +837,11 @@ pub fn clear_keychain_secrets() {
         let mut disk = read_disk_secrets(&path);
         disk.keychain_has_official = false;
         disk.keychain_has_relay = false;
+        disk.keychain_has_pexels = false;
         disk.keychain_has_stt_custom = false;
         disk.official_api_key = None;
         disk.relay_api_key = None;
+        disk.pexels_api_key = None;
         disk.stt_custom_api_key = None;
         disk.stt_custom_api_keys.clear();
         let _ = write_disk_secrets(&path, &disk);
@@ -803,6 +891,12 @@ mod tests {
             ..Default::default()
         };
         assert!(disk_has_plaintext_keys(&only_relay));
+
+        let only_pexels = SecretsFile {
+            pexels_api_key: Some("pexels-test".into()),
+            ..Default::default()
+        };
+        assert!(disk_has_plaintext_keys(&only_pexels));
     }
 
     #[test]
@@ -810,10 +904,12 @@ mod tests {
         let disk = SecretsFile {
             keychain_has_official: true,
             keychain_has_relay: false,
+            keychain_has_pexels: true,
             ..Default::default()
         };
         assert!(has_official_key_configured(&disk));
         assert!(!has_relay_key_configured(&disk));
+        assert!(has_pexels_key_configured(&disk));
         assert!(!disk_has_plaintext_keys(&disk));
     }
 
@@ -822,10 +918,12 @@ mod tests {
         let s = SecretsFile {
             official_api_key: Some("sk-secret".into()),
             relay_api_key: Some("rk-secret".into()),
+            pexels_api_key: Some("pexels-secret".into()),
             relay_base_url: Some("https://relay.example".into()),
             default_model: Some("grok-4".into()),
             keychain_has_official: true,
             keychain_has_relay: true,
+            keychain_has_pexels: true,
             stt_custom_api_key: None,
             stt_custom_api_keys: HashMap::new(),
             stt_custom_key_presence: HashMap::new(),
@@ -834,6 +932,7 @@ mod tests {
         let disk = strip_keys_for_disk(&s);
         assert!(disk.official_api_key.is_none());
         assert!(disk.relay_api_key.is_none());
+        assert!(disk.pexels_api_key.is_none());
         assert_eq!(
             disk.relay_base_url.as_deref(),
             Some("https://relay.example")
@@ -841,6 +940,7 @@ mod tests {
         assert_eq!(disk.default_model.as_deref(), Some("grok-4"));
         assert!(disk.keychain_has_official);
         assert!(disk.keychain_has_relay);
+        assert!(disk.keychain_has_pexels);
     }
 
     #[test]
@@ -848,10 +948,12 @@ mod tests {
         let disk = SecretsFile {
             official_api_key: Some("disk-old".into()),
             relay_api_key: None,
+            pexels_api_key: Some("disk-pexels".into()),
             relay_base_url: Some("https://example.com".into()),
             default_model: Some("m1".into()),
             keychain_has_official: false,
             keychain_has_relay: false,
+            keychain_has_pexels: false,
             stt_custom_api_key: None,
             stt_custom_api_keys: HashMap::new(),
             stt_custom_key_presence: HashMap::new(),
@@ -860,15 +962,18 @@ mod tests {
         let kc = SecretsFile {
             official_api_key: Some("kc-new".into()),
             relay_api_key: Some("kc-relay".into()),
+            pexels_api_key: Some("kc-pexels".into()),
             ..Default::default()
         };
         let m = merge_secrets(disk, kc);
         assert_eq!(m.official_api_key.as_deref(), Some("kc-new"));
         assert_eq!(m.relay_api_key.as_deref(), Some("kc-relay"));
+        assert_eq!(m.pexels_api_key.as_deref(), Some("kc-pexels"));
         assert_eq!(m.relay_base_url.as_deref(), Some("https://example.com"));
         assert_eq!(m.default_model.as_deref(), Some("m1"));
         assert!(m.keychain_has_official);
         assert!(m.keychain_has_relay);
+        assert!(m.keychain_has_pexels);
     }
 
     #[test]
@@ -891,10 +996,12 @@ mod tests {
         let s = SecretsFile {
             official_api_key: Some("sk-should-not-serialize".into()),
             relay_api_key: Some("rk-nope".into()),
+            pexels_api_key: Some("pexels-nope".into()),
             relay_base_url: Some("https://relay.example".into()),
             default_model: Some("g".into()),
             keychain_has_official: true,
             keychain_has_relay: false,
+            keychain_has_pexels: true,
             stt_custom_api_key: None,
             stt_custom_api_keys: HashMap::new(),
             stt_custom_key_presence: HashMap::new(),
@@ -904,6 +1011,7 @@ mod tests {
         let json = serde_json::to_string(&disk).unwrap();
         assert!(!json.contains("sk-should-not-serialize"));
         assert!(!json.contains("rk-nope"));
+        assert!(!json.contains("pexels-nope"));
         assert!(json.contains("relay.example") || json.contains("relayBaseUrl"));
         assert!(json.contains("keychainHasOfficial") || json.contains("true"));
     }

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -902,6 +902,9 @@ impl Default for AppSettings {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretsFile {
+    /// Pexels wallpaper-library API credential, retained only in Host secrets.
+    #[serde(default)]
+    pub pexels_api_key: Option<String>,
     pub official_api_key: Option<String>,
     pub relay_base_url: Option<String>,
     pub relay_api_key: Option<String>,
@@ -925,6 +928,8 @@ pub struct SecretsFile {
     /// Relay API key lives in OS keychain (value not on disk).
     #[serde(default)]
     pub keychain_has_relay: bool,
+    #[serde(default)]
+    pub keychain_has_pexels: bool,
     /// Custom STT key lives in OS keychain (value not on disk).
     #[serde(default)]
     pub keychain_has_stt_custom: bool,

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -356,6 +356,7 @@ export async function secretsGetMasked() {
   return invoke<{
     hasOfficialKey: boolean;
     hasRelayKey: boolean;
+    hasPexelsKey: boolean;
     hasSttCustomKey: boolean;
     /** Per-provider-preset custom STT key presence (ADR-0001). */
     sttCustomKeys?: Record<string, boolean>;
@@ -368,6 +369,7 @@ export async function secretsSet(body: {
   officialApiKey?: string;
   relayBaseUrl?: string;
   relayApiKey?: string;
+  pexelsApiKey?: string;
   defaultModel?: string;
   sttCustomApiKey?: string;
   /** Provider preset id the custom STT key belongs to (ADR-0001). */
@@ -377,6 +379,7 @@ export async function secretsSet(body: {
     officialApiKey: body.officialApiKey ?? null,
     relayBaseUrl: body.relayBaseUrl ?? null,
     relayApiKey: body.relayApiKey ?? null,
+    pexelsApiKey: body.pexelsApiKey ?? null,
     defaultModel: body.defaultModel ?? null,
     sttCustomApiKey: body.sttCustomApiKey ?? null,
     sttCustomApiKeyProvider: body.sttCustomApiKeyProvider ?? null,


### PR DESCRIPTION
## Summary

为后续 Pexels 壁纸来源补齐凭据存储，复用现有 secrets API、系统钥匙串和降级存储策略，不新增页面入口。

- `secrets_set` 支持可选 `pexelsApiKey`：省略保留原值、空白清除、非空去除首尾空白后保存。
- `secrets_get_masked` 仅返回 `hasPexelsKey`；前端读取接口不返回密钥。
- 接入钥匙串读写/删除、旧明文迁移、会话缓存合并和磁盘脱敏；补充对应回归断言。
- 更新账户开发文档。本 PR 不执行 Pexels 网络请求，来源搜索和页面交互单独提交。

本主题独立基于 main，不依赖 #1088–#1092。共 5 文件 +135/-3。已搜索所有状态的 Pexels Issues，无直接对应条目，不使用自动关闭引用。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Validation

Rust 1,651 项通过（另 1 项既有 ignored），通过当前产物的 Windows manifest harness 实际执行。typecheck、lint、build:ui、质量门禁、网站自测、依赖检查/审计、cargo fmt/clippy 均通过。前端全量 7,070 项通过（589 个文件，4 workers）。未进行真实 Pexels 账号请求或各平台系统钥匙串实机验收。

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included