### PR TITLE
feat(wallpaper): 接入许可图片来源后端与安全媒体链路

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -126,3 +126,35 @@ The final result is appended only after the Host validates its identity. Existin
 images remain visible/selectable while enrichment runs; errors keep them intact,
 and an empty batch displays the localized no-more hint. Closing/cancelling rejects
 late results. This slice does not automatically prefetch or repeat enrichment.
+
+
+## Public image provider Host contract
+
+Openverse and Pexels have separate fixed-endpoint adapters under
+`wallpaper_provider_search`. The Host accepts a source, bounded query and request
+ID through `wallpaper_remote_search`, `wallpaper_remote_search_more`, and cancel.
+Web search is rejected in this slice. Source-picker controls arrive separately;
+this change registers the working Host commands without exposing a new UI.
+
+The provider query removes generic wallpaper/size terms. Each page targets 20
+verified images (two 20-candidate Openverse pages, or 40 Pexels candidates), with
+at most 10 simultaneous image probes, an 8-second per-probe timeout, 12-second
+validation budget, and 30-second overall search budget. Results may be fewer
+when candidates fail validation. The API key is supplied only to Pexels' fixed
+endpoint; redirects on credentialed requests are rejected.
+
+Only validated image DTOs and source/author/license links cross IPC. The shared
+media path checks public HTTPS destinations and redirect hops, MIME/signature,
+response completeness and body limits. Thumbnails use bounded Host decoding;
+original images are written in the selected source directory. Cancellation
+covers search, probes, media reads and thumbnail work; request IDs isolate late
+events. Search/page caches are bounded to 64 entries with a 10-minute TTL and
+Pexels credential revision in their identity. The Host retains continuation
+cursors, buffered results and source Referer origins; credentials/cursors are
+not returned to the renderer. Media request cancellation supports bounded
+pre-cancellation before registration.
+
+This batch supplies explicit pagination only. Automatic one-page-ahead loading,
+provider UI, Web search, catalog metadata and generation integrations are
+separate changes. Tests use synthetic provider responses and media fixtures;
+passing tests do not claim live provider availability or account validation.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,6 +224,10 @@ mod voice_stt;
 
 mod voice_tools;
 
+mod wallpaper_provider_search;
+mod wallpaper_remote_commands;
+mod wallpaper_remote_media;
+mod wallpaper_remote_search;
 mod wallpaper_source;
 mod wallpaper_x_responses;
 mod wallpaper_x_search;
@@ -1699,6 +1703,13 @@ pub fn run() {
 
             remote_im::remote_im_doctor,
 
+            wallpaper_remote_commands::wallpaper_remote_search,
+            wallpaper_remote_commands::wallpaper_remote_search_more,
+            wallpaper_remote_commands::wallpaper_remote_search_cancel,
+            wallpaper_remote_commands::wallpaper_remote_fetch_media,
+            wallpaper_remote_commands::wallpaper_remote_thumbnail,
+            wallpaper_remote_commands::wallpaper_remote_cancel_media_requests,
+            wallpaper_remote_commands::wallpaper_remote_cancel_all_media_requests,
             commands::wallpaper_x_search,
             commands::wallpaper_x_search_cancel,
             commands::wallpaper_x_search_more,

--- a/src-tauri/src/wallpaper_provider_search.rs
+++ b/src-tauri/src/wallpaper_provider_search.rs
@@ -1,0 +1,971 @@
+//! Fixed-endpoint Openverse and Pexels wallpaper-library adapters.
+//!
+//! Provider credentials, paging cursors, raw responses, and query strings stay
+//! inside the Host. Only validated image DTOs cross IPC.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use futures_util::stream::{FuturesUnordered, StreamExt};
+use hyper::header::HeaderValue;
+use parking_lot::Mutex;
+use sha2::{Digest, Sha256};
+use tauri::AppHandle;
+
+use crate::wallpaper_remote_search::{
+    self as remote_search, RemoteSearchBatch, RemoteSearchResult, RemoteSearchRuntime,
+    RemoteSearchStage, RemoteWallpaperSource,
+};
+use crate::wallpaper_source::{WallpaperGalleryItem, WallpaperSearchCancellation};
+
+mod probe;
+mod request_url;
+mod response;
+mod transport;
+
+use probe::validate_candidates;
+#[cfg(test)]
+use probe::{validate_probe_outputs, visit_probes_as_completed};
+#[cfg(test)]
+use request_url::{provider_request_url, provider_url, PEXELS_CACHE_BUST_PARAM};
+#[cfg(test)]
+use response::{parse_openverse_page, parse_pexels_page, safe_url};
+use transport::{fetch_api_page, provider_client};
+
+const PEXELS_LICENSE_URL: &str = "https://www.pexels.com/license/";
+const CONTRACT_VERSION: u8 = 3;
+const RESULT_LIMIT: usize = 20;
+const OPENVERSE_PAGE_SIZE: usize = 20;
+const OPENVERSE_PAGES_PER_BATCH: usize = 2;
+const PEXELS_PAGE_SIZE: usize = 40;
+const MAX_CANDIDATES: usize = 40;
+const MAX_CONCURRENT_PROBES: usize = 10;
+const PROGRESS_BATCH_SIZE: usize = 4;
+const IMAGE_PROBE_TIMEOUT: Duration = Duration::from_secs(8);
+const IMAGE_VALIDATION_BUDGET: Duration = Duration::from_secs(12);
+const PROVIDER_SEARCH_TIMEOUT: Duration = Duration::from_secs(30);
+const CACHE_TTL: Duration = Duration::from_secs(10 * 60);
+const CACHE_CAPACITY: usize = 64;
+const PRE_CANCEL_TTL: Duration = Duration::from_secs(30);
+const PRE_CANCEL_CAPACITY: usize = 64;
+const MAX_EMPTY_VALIDATED_BATCHES: usize = 3;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct SearchKey {
+    source: RemoteWallpaperSource,
+    query: String,
+    credential_revision: Option<String>,
+    contract_version: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct PageKey {
+    search: SearchKey,
+    first_page: usize,
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    key: PageKey,
+    inserted: Instant,
+    result: RemoteSearchResult,
+    continuation: Option<ProviderContinuation>,
+}
+
+#[derive(Clone)]
+struct ContinuationEntry {
+    key: SearchKey,
+    inserted: Instant,
+    continuation: ProviderContinuation,
+}
+
+#[derive(Clone)]
+struct ProviderContinuation {
+    next_page: usize,
+    buffered_items: Vec<WallpaperGalleryItem>,
+    upstream_has_more: bool,
+}
+
+impl ProviderContinuation {
+    fn is_available(&self) -> bool {
+        self.upstream_has_more || !self.buffered_items.is_empty()
+    }
+}
+
+#[derive(Default)]
+struct SearchCache {
+    entries: VecDeque<CacheEntry>,
+    continuations: VecDeque<ContinuationEntry>,
+}
+
+impl SearchCache {
+    fn purge_expired(&mut self, now: Instant) {
+        self.entries
+            .retain(|entry| now.duration_since(entry.inserted) <= CACHE_TTL);
+        self.continuations
+            .retain(|entry| now.duration_since(entry.inserted) <= CACHE_TTL);
+    }
+
+    fn get(
+        &mut self,
+        key: &PageKey,
+        now: Instant,
+    ) -> Option<(RemoteSearchResult, Option<ProviderContinuation>)> {
+        self.purge_expired(now);
+        let index = self.entries.iter().position(|entry| &entry.key == key)?;
+        let entry = self.entries.remove(index)?;
+        let result = entry.result.clone();
+        let continuation = entry.continuation.clone();
+        self.entries.push_front(entry);
+        Some((result, continuation))
+    }
+
+    fn insert(
+        &mut self,
+        key: PageKey,
+        result: RemoteSearchResult,
+        continuation: Option<ProviderContinuation>,
+        now: Instant,
+    ) {
+        self.purge_expired(now);
+        self.entries.retain(|entry| entry.key != key);
+        self.entries.push_front(CacheEntry {
+            key,
+            inserted: now,
+            result,
+            continuation,
+        });
+        self.entries.truncate(CACHE_CAPACITY);
+    }
+
+    fn continuation(&mut self, key: &SearchKey, now: Instant) -> Option<ProviderContinuation> {
+        self.purge_expired(now);
+        let index = self
+            .continuations
+            .iter()
+            .position(|entry| &entry.key == key)?;
+        let entry = self.continuations.remove(index)?;
+        let continuation = entry.continuation.clone();
+        self.continuations.push_front(entry);
+        Some(continuation)
+    }
+
+    fn update_continuation(
+        &mut self,
+        key: &SearchKey,
+        continuation: Option<ProviderContinuation>,
+        now: Instant,
+    ) {
+        self.purge_expired(now);
+        self.continuations.retain(|entry| &entry.key != key);
+        if let Some(continuation) = continuation.filter(ProviderContinuation::is_available) {
+            self.continuations.push_front(ContinuationEntry {
+                key: key.clone(),
+                inserted: now,
+                continuation,
+            });
+            self.continuations.truncate(CACHE_CAPACITY);
+        }
+    }
+}
+
+struct ProviderContext {
+    search_key: SearchKey,
+    api_key: Option<String>,
+}
+
+#[derive(Clone)]
+struct ActiveRequest {
+    token: uuid::Uuid,
+    cancellation: WallpaperSearchCancellation,
+}
+
+#[derive(Default)]
+struct RequestRegistry {
+    active: HashMap<String, ActiveRequest>,
+    pre_cancelled: VecDeque<(String, Instant)>,
+}
+
+impl RequestRegistry {
+    fn purge_pre_cancelled(&mut self, now: Instant) {
+        self.pre_cancelled
+            .retain(|(_, created)| now.duration_since(*created) < PRE_CANCEL_TTL);
+    }
+
+    fn record_pre_cancel(&mut self, request_id: &str, now: Instant) {
+        self.purge_pre_cancelled(now);
+        self.pre_cancelled.retain(|(id, _)| id != request_id);
+        while self.pre_cancelled.len() >= PRE_CANCEL_CAPACITY {
+            self.pre_cancelled.pop_front();
+        }
+        self.pre_cancelled.push_back((request_id.to_string(), now));
+    }
+
+    fn take_pre_cancel(&mut self, request_id: &str, now: Instant) -> bool {
+        self.purge_pre_cancelled(now);
+        let found = self.pre_cancelled.iter().any(|(id, _)| id == request_id);
+        self.pre_cancelled.retain(|(id, _)| id != request_id);
+        found
+    }
+}
+
+#[derive(Clone)]
+struct ProviderCandidate {
+    upstream_id: String,
+    image_url: String,
+    source_url: String,
+    source_name: &'static str,
+    title: Option<String>,
+    author_name: String,
+    author_url: Option<String>,
+    license: String,
+    license_url: String,
+}
+
+struct ApiPage {
+    candidates: Vec<ProviderCandidate>,
+    has_more: bool,
+}
+
+struct CandidateBatch {
+    candidates: Vec<ProviderCandidate>,
+    has_more: bool,
+    next_page: usize,
+}
+
+struct ValidatedPage {
+    items: Vec<WallpaperGalleryItem>,
+    buffered_items: Vec<WallpaperGalleryItem>,
+    upstream_has_more: bool,
+    next_page: usize,
+}
+
+#[derive(Default)]
+struct ProviderPartialState {
+    completed_items: Vec<(usize, WallpaperGalleryItem)>,
+    next_page: usize,
+    upstream_has_more: bool,
+    last_emitted_batch_index: usize,
+}
+
+#[derive(Clone)]
+struct ProviderPartialResults {
+    state: Arc<Mutex<ProviderPartialState>>,
+}
+
+struct RecoveredProviderPage {
+    page: ValidatedPage,
+    terminal_batch_index: usize,
+}
+
+impl ProviderPartialResults {
+    fn new(first_page: usize) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(ProviderPartialState {
+                next_page: first_page,
+                ..ProviderPartialState::default()
+            })),
+        }
+    }
+
+    fn begin_batch(&self, next_page: usize, upstream_has_more: bool) {
+        let mut state = self.state.lock();
+        state.completed_items.clear();
+        state.next_page = next_page;
+        state.upstream_has_more = upstream_has_more;
+        state.last_emitted_batch_index = 0;
+    }
+
+    fn record(&self, index: usize, item: WallpaperGalleryItem) {
+        self.state.lock().completed_items.push((index, item));
+    }
+
+    fn mark_batch_emitted(&self, batch_index: usize) {
+        self.state.lock().last_emitted_batch_index = batch_index;
+    }
+
+    fn recover_timeout_page(&self) -> Option<RecoveredProviderPage> {
+        let state = self.state.lock();
+        let mut completed_items = state.completed_items.clone();
+        let next_page = state.next_page;
+        let upstream_has_more = state.upstream_has_more;
+        let terminal_batch_index = state.last_emitted_batch_index.saturating_add(1);
+        drop(state);
+
+        completed_items.sort_by_key(|(index, _)| *index);
+        let mut seen_urls = HashSet::new();
+        let mut seen_fingerprints = HashSet::new();
+        let mut items = completed_items
+            .into_iter()
+            .filter_map(|(_, item)| {
+                let fingerprint = item.media_fingerprint.clone().unwrap_or_default();
+                if !seen_urls.insert(item.full_url.clone())
+                    || (!fingerprint.is_empty() && !seen_fingerprints.insert(fingerprint))
+                {
+                    return None;
+                }
+                Some(item)
+            })
+            .collect::<Vec<_>>();
+        if items.is_empty() {
+            return None;
+        }
+        let buffered_items = if items.len() > RESULT_LIMIT {
+            items.split_off(RESULT_LIMIT)
+        } else {
+            Vec::new()
+        };
+        Some(RecoveredProviderPage {
+            page: ValidatedPage {
+                items,
+                buffered_items,
+                upstream_has_more,
+                next_page,
+            },
+            terminal_batch_index,
+        })
+    }
+}
+
+impl ValidatedPage {
+    fn continuation(&self) -> Option<ProviderContinuation> {
+        let continuation = ProviderContinuation {
+            next_page: self.next_page,
+            buffered_items: self.buffered_items.clone(),
+            upstream_has_more: self.upstream_has_more,
+        };
+        continuation.is_available().then_some(continuation)
+    }
+
+    fn has_more(&self) -> bool {
+        self.upstream_has_more || !self.buffered_items.is_empty()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProviderError {
+    Cancelled,
+    PexelsKeyMissing,
+    PexelsKeyInvalid,
+    RateLimited,
+    Timeout,
+    Network,
+    ServiceUnavailable,
+    Protocol,
+}
+
+impl ProviderError {
+    fn code(self) -> &'static str {
+        match self {
+            Self::Cancelled => "cancelled",
+            Self::PexelsKeyMissing => "pexels_key_missing",
+            Self::PexelsKeyInvalid => "pexels_key_invalid",
+            Self::RateLimited => "provider_rate_limited",
+            Self::Timeout => "provider_timeout",
+            Self::Network => "provider_network",
+            Self::ServiceUnavailable => "provider_service_unavailable",
+            Self::Protocol => "provider_protocol",
+        }
+    }
+}
+
+static ACTIVE: OnceLock<Mutex<RequestRegistry>> = OnceLock::new();
+static CACHE: OnceLock<Mutex<SearchCache>> = OnceLock::new();
+
+fn active() -> &'static Mutex<RequestRegistry> {
+    ACTIVE.get_or_init(|| Mutex::new(RequestRegistry::default()))
+}
+
+fn cache() -> &'static Mutex<SearchCache> {
+    CACHE.get_or_init(|| Mutex::new(SearchCache::default()))
+}
+
+fn begin_request(request_id: &str) -> (uuid::Uuid, WallpaperSearchCancellation) {
+    let mut requests = active().lock();
+    for (_, request) in requests.active.drain() {
+        request.cancellation.cancel();
+    }
+    let token = uuid::Uuid::new_v4();
+    let cancellation = WallpaperSearchCancellation::default();
+    if requests.take_pre_cancel(request_id, Instant::now()) {
+        cancellation.cancel();
+    }
+    requests.active.insert(
+        request_id.to_string(),
+        ActiveRequest {
+            token,
+            cancellation: cancellation.clone(),
+        },
+    );
+    (token, cancellation)
+}
+
+fn finish_request(request_id: &str, token: uuid::Uuid) {
+    let mut requests = active().lock();
+    if requests
+        .active
+        .get(request_id)
+        .is_some_and(|request| request.token == token)
+    {
+        requests.active.remove(request_id);
+    }
+}
+
+pub(crate) fn cancel(request_id: &str) -> bool {
+    let mut requests = active().lock();
+    let request = requests.active.remove(request_id);
+    if let Some(request) = request {
+        drop(requests);
+        request.cancellation.cancel();
+    } else {
+        requests.record_pre_cancel(request_id, Instant::now());
+    }
+    true
+}
+
+fn library_provider_query(query: &str) -> String {
+    const CJK_WALLPAPER_TERMS: [&str; 4] = ["壁纸", "壁紙", "桌布", "배경화면"];
+
+    let mut stripped = query.to_string();
+    for term in CJK_WALLPAPER_TERMS {
+        stripped = stripped.replace(term, " ");
+    }
+
+    let normalized = stripped
+        .split_whitespace()
+        .filter(|token| {
+            let comparison = token
+                .trim_matches(|ch: char| !ch.is_alphanumeric())
+                .to_ascii_lowercase();
+            !comparison.is_empty()
+                && !matches!(
+                    comparison.as_str(),
+                    "wallpaper" | "wallpapers" | "4k" | "8k" | "uhd"
+                )
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if normalized.is_empty() {
+        query.trim().to_string()
+    } else {
+        normalized
+    }
+}
+
+fn provider_context(
+    source: RemoteWallpaperSource,
+    query: &str,
+) -> Result<ProviderContext, ProviderError> {
+    let (api_key, credential_revision) = match source {
+        RemoteWallpaperSource::Openverse => (None, None),
+        RemoteWallpaperSource::Pexels => {
+            let key = crate::store::load_secrets()
+                .pexels_api_key
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty() && value.len() <= 512)
+                .ok_or(ProviderError::PexelsKeyMissing)?;
+            HeaderValue::from_str(&key).map_err(|_| ProviderError::PexelsKeyInvalid)?;
+            let revision = hex::encode(Sha256::digest(key.as_bytes()));
+            (Some(key), Some(revision))
+        }
+        RemoteWallpaperSource::Web => return Err(ProviderError::Protocol),
+    };
+    Ok(ProviderContext {
+        search_key: SearchKey {
+            source,
+            query: remote_search::normalized_query(query),
+            credential_revision,
+            contract_version: CONTRACT_VERSION,
+        },
+        api_key,
+    })
+}
+
+pub(crate) async fn search(
+    app: &AppHandle,
+    source: RemoteWallpaperSource,
+    request_id: &str,
+    query: &str,
+) -> Result<RemoteSearchResult, String> {
+    let query = remote_search::validate_query(query)?;
+    let provider_query = library_provider_query(&query);
+    let started = Instant::now();
+    let context = match provider_context(source, &query) {
+        Ok(context) => context,
+        Err(error) => {
+            return Ok(RemoteSearchResult::error(
+                source.as_str(),
+                error.code(),
+                elapsed_ms(started),
+            ));
+        }
+    };
+    let (token, cancellation) = begin_request(request_id);
+    let runtime = remote_search::runtime(app, request_id, source, cancellation);
+    runtime.report(RemoteSearchStage::Preparing);
+    let page_key = PageKey {
+        search: context.search_key.clone(),
+        first_page: 1,
+    };
+
+    if runtime.is_cancelled() {
+        finish_request(request_id, token);
+        return Ok(RemoteSearchResult::error(
+            source.as_str(),
+            "cancelled",
+            elapsed_ms(started),
+        ));
+    }
+    let cached = match remote_search::read_cache_if_active(runtime.cancellation(), || {
+        cache().lock().get(&page_key, Instant::now())
+    }) {
+        Ok(cached) => cached,
+        Err(()) => {
+            finish_request(request_id, token);
+            return Ok(RemoteSearchResult::error(
+                source.as_str(),
+                "cancelled",
+                elapsed_ms(started),
+            ));
+        }
+    };
+    if let Some((mut result, continuation)) = cached {
+        result.cache_hit = true;
+        result.duration_ms = elapsed_ms(started);
+        if runtime
+            .cancellation()
+            .commit_if_active(|| {
+                cache().lock().update_continuation(
+                    &context.search_key,
+                    continuation,
+                    Instant::now(),
+                );
+            })
+            .is_none()
+        {
+            result = RemoteSearchResult::error(source.as_str(), "cancelled", elapsed_ms(started));
+            runtime.report(RemoteSearchStage::Done);
+            finish_request(request_id, token);
+            return Ok(result);
+        }
+        emit_cached_batch(&runtime, &result);
+        runtime.report(RemoteSearchStage::Done);
+        finish_request(request_id, token);
+        return Ok(result);
+    }
+
+    let partial = ProviderPartialResults::new(1);
+    let page = with_provider_deadline(
+        runtime.cancellation(),
+        PROVIDER_SEARCH_TIMEOUT,
+        search_page(
+            source,
+            &provider_query,
+            1,
+            context.api_key.as_deref(),
+            &runtime,
+            &partial,
+        ),
+    )
+    .await;
+    let page = recover_provider_timeout(page, &partial, &runtime);
+    let mut result = result_from_page(source, page.as_ref(), started);
+    if let Ok(page) = page {
+        let continuation = page.continuation();
+        let committed = runtime.cancellation().commit_if_active(|| {
+            let mut cache = cache().lock();
+            cache.update_continuation(&context.search_key, continuation.clone(), Instant::now());
+            if !page.items.is_empty() {
+                cache.insert(page_key, result.clone(), continuation, Instant::now());
+            }
+        });
+        if committed.is_none() {
+            result = RemoteSearchResult::error(source.as_str(), "cancelled", elapsed_ms(started));
+        }
+    } else {
+        let committed = runtime.cancellation().commit_if_active(|| {
+            cache()
+                .lock()
+                .update_continuation(&context.search_key, None, Instant::now());
+        });
+        if committed.is_none() {
+            result = RemoteSearchResult::error(source.as_str(), "cancelled", elapsed_ms(started));
+        }
+    }
+    runtime.report(RemoteSearchStage::Done);
+    finish_request(request_id, token);
+    Ok(result)
+}
+
+pub(crate) async fn search_more(
+    app: &AppHandle,
+    source: RemoteWallpaperSource,
+    request_id: &str,
+    query: &str,
+) -> Result<RemoteSearchResult, String> {
+    let query = remote_search::validate_query(query)?;
+    let provider_query = library_provider_query(&query);
+    let started = Instant::now();
+    let context = match provider_context(source, &query) {
+        Ok(context) => context,
+        Err(error) => {
+            return Ok(RemoteSearchResult::error(
+                source.as_str(),
+                error.code(),
+                elapsed_ms(started),
+            ));
+        }
+    };
+    let (token, cancellation) = begin_request(request_id);
+    let runtime = remote_search::runtime(app, request_id, source, cancellation);
+    runtime.report(RemoteSearchStage::LoadingMore);
+    if runtime.is_cancelled() {
+        finish_request(request_id, token);
+        return Ok(RemoteSearchResult::error(
+            source.as_str(),
+            "cancelled",
+            elapsed_ms(started),
+        ));
+    }
+    let continuation = match remote_search::read_cache_if_active(runtime.cancellation(), || {
+        cache()
+            .lock()
+            .continuation(&context.search_key, Instant::now())
+    }) {
+        Ok(continuation) => continuation,
+        Err(()) => {
+            finish_request(request_id, token);
+            return Ok(RemoteSearchResult::error(
+                source.as_str(),
+                "cancelled",
+                elapsed_ms(started),
+            ));
+        }
+    };
+    let Some(continuation) = continuation else {
+        finish_request(request_id, token);
+        return Ok(RemoteSearchResult::error(
+            source.as_str(),
+            "provider_no_continuation",
+            elapsed_ms(started),
+        ));
+    };
+    if let Some((items, next_continuation)) = take_buffered_page(continuation.clone()) {
+        let mut result = RemoteSearchResult::success(
+            source.as_str(),
+            items,
+            next_continuation.is_some(),
+            elapsed_ms(started),
+        );
+        result.cache_hit = true;
+        if runtime
+            .cancellation()
+            .commit_if_active(|| {
+                cache().lock().update_continuation(
+                    &context.search_key,
+                    next_continuation,
+                    Instant::now(),
+                );
+            })
+            .is_none()
+        {
+            result = RemoteSearchResult::error(source.as_str(), "cancelled", elapsed_ms(started));
+            runtime.report(RemoteSearchStage::Done);
+            finish_request(request_id, token);
+            return Ok(result);
+        }
+        emit_cached_batch(&runtime, &result);
+        runtime.report(RemoteSearchStage::Done);
+        finish_request(request_id, token);
+        return Ok(result);
+    }
+    let first_page = continuation.next_page;
+    let page_key = PageKey {
+        search: context.search_key.clone(),
+        first_page,
+    };
+
+    let cached = match remote_search::read_cache_if_active(runtime.cancellation(), || {
+        cache().lock().get(&page_key, Instant::now())
+    }) {
+        Ok(cached) => cached,
+        Err(()) => {
+            finish_request(request_id, token);
+            return Ok(RemoteSearchResult::error(
+                source.as_str(),
+                "cancelled",
+                elapsed_ms(started),
+            ));
+        }
+    };
+    if let Some((mut result, continuation)) = cached {
+        result.cache_hit = true;
+        result.duration_ms = elapsed_ms(started);
+        if runtime
+            .cancellation()
+            .commit_if_active(|| {
+                cache().lock().update_continuation(
+                    &context.search_key,
+                    continuation,
+                    Instant::now(),
+                );
+            })
+            .is_none()
+        {
+            result = RemoteSearchResult::error(source.as_str(), "cancelled", elapsed_ms(started));
+            runtime.report(RemoteSearchStage::Done);
+            finish_request(request_id, token);
+            return Ok(result);
+        }
+        emit_cached_batch(&runtime, &result);
+        runtime.report(RemoteSearchStage::Done);
+        finish_request(request_id, token);
+        return Ok(result);
+    }
+
+    let partial = ProviderPartialResults::new(first_page);
+    let page = with_provider_deadline(
+        runtime.cancellation(),
+        PROVIDER_SEARCH_TIMEOUT,
+        search_page(
+            source,
+            &provider_query,
+            first_page,
+            context.api_key.as_deref(),
+            &runtime,
+            &partial,
+        ),
+    )
+    .await;
+    let page = recover_provider_timeout(page, &partial, &runtime);
+    let mut result = result_from_page(source, page.as_ref(), started);
+    if let Ok(page) = page {
+        let continuation = page.continuation();
+        let committed = runtime.cancellation().commit_if_active(|| {
+            let mut cache = cache().lock();
+            cache.update_continuation(&context.search_key, continuation.clone(), Instant::now());
+            if !page.items.is_empty() {
+                cache.insert(page_key, result.clone(), continuation, Instant::now());
+            }
+        });
+        if committed.is_none() {
+            result = RemoteSearchResult::error(source.as_str(), "cancelled", elapsed_ms(started));
+        }
+    } else if runtime.is_cancelled() {
+        result = RemoteSearchResult::error(source.as_str(), "cancelled", elapsed_ms(started));
+    }
+    runtime.report(RemoteSearchStage::Done);
+    finish_request(request_id, token);
+    Ok(result)
+}
+
+fn emit_cached_batch(runtime: &RemoteSearchRuntime, result: &RemoteSearchResult) {
+    runtime.report_batch(RemoteSearchBatch {
+        batch_index: 1,
+        items: result.items.clone(),
+        accumulated_count: result.items.len(),
+        done: true,
+    });
+}
+
+fn take_buffered_page(
+    mut continuation: ProviderContinuation,
+) -> Option<(Vec<WallpaperGalleryItem>, Option<ProviderContinuation>)> {
+    if continuation.buffered_items.is_empty() {
+        return None;
+    }
+    let remainder = if continuation.buffered_items.len() > RESULT_LIMIT {
+        continuation.buffered_items.split_off(RESULT_LIMIT)
+    } else {
+        Vec::new()
+    };
+    let items = std::mem::replace(&mut continuation.buffered_items, remainder);
+    let next = continuation.is_available().then_some(continuation);
+    Some((items, next))
+}
+
+fn result_from_page(
+    source: RemoteWallpaperSource,
+    page: Result<&ValidatedPage, &ProviderError>,
+    started: Instant,
+) -> RemoteSearchResult {
+    match page {
+        Ok(page) if !page.items.is_empty() => RemoteSearchResult::success(
+            source.as_str(),
+            page.items.clone(),
+            page.has_more(),
+            elapsed_ms(started),
+        ),
+        Ok(page) => {
+            RemoteSearchResult::empty(source.as_str(), page.has_more(), elapsed_ms(started))
+        }
+        Err(error) => RemoteSearchResult::error(source.as_str(), error.code(), elapsed_ms(started)),
+    }
+}
+
+fn recover_provider_timeout(
+    result: Result<ValidatedPage, ProviderError>,
+    partial: &ProviderPartialResults,
+    runtime: &RemoteSearchRuntime,
+) -> Result<ValidatedPage, ProviderError> {
+    if !matches!(&result, Err(ProviderError::Timeout)) {
+        return result;
+    }
+    let Some(recovered) = partial.recover_timeout_page() else {
+        return result;
+    };
+    runtime.report_batch(RemoteSearchBatch {
+        batch_index: recovered.terminal_batch_index,
+        items: Vec::new(),
+        accumulated_count: recovered.page.items.len(),
+        done: true,
+    });
+    Ok(recovered.page)
+}
+
+async fn with_provider_deadline<T, F>(
+    cancellation: &WallpaperSearchCancellation,
+    timeout: Duration,
+    operation: F,
+) -> Result<T, ProviderError>
+where
+    F: std::future::Future<Output = Result<T, ProviderError>>,
+{
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => Err(ProviderError::Cancelled),
+        result = tokio::time::timeout(timeout, operation) => {
+            result.unwrap_or(Err(ProviderError::Timeout))
+        },
+    }
+}
+
+async fn search_page(
+    source: RemoteWallpaperSource,
+    query: &str,
+    first_page: usize,
+    api_key: Option<&str>,
+    runtime: &RemoteSearchRuntime,
+    partial: &ProviderPartialResults,
+) -> Result<ValidatedPage, ProviderError> {
+    if runtime.is_cancelled() {
+        return Err(ProviderError::Cancelled);
+    }
+    runtime.report(if first_page == 1 {
+        RemoteSearchStage::SearchingProvider
+    } else {
+        RemoteSearchStage::LoadingMore
+    });
+    let mut page = first_page;
+    for _ in 0..MAX_EMPTY_VALIDATED_BATCHES {
+        let batch = fetch_candidate_batch(source, query, page, api_key, runtime).await?;
+        partial.begin_batch(batch.next_page, batch.has_more);
+        runtime.report(RemoteSearchStage::ValidatingImages);
+        let mut items = validate_candidates(source, batch.candidates, runtime, partial).await?;
+        let buffered_items = if items.len() > RESULT_LIMIT {
+            items.split_off(RESULT_LIMIT)
+        } else {
+            Vec::new()
+        };
+        let validated = ValidatedPage {
+            items,
+            buffered_items,
+            upstream_has_more: batch.has_more,
+            next_page: batch.next_page,
+        };
+        if !validated.items.is_empty() || !validated.has_more() {
+            return Ok(validated);
+        }
+        page = validated.next_page;
+        runtime.report(RemoteSearchStage::LoadingMore);
+    }
+    Ok(ValidatedPage {
+        items: Vec::new(),
+        buffered_items: Vec::new(),
+        upstream_has_more: true,
+        next_page: page,
+    })
+}
+
+async fn fetch_candidate_batch(
+    source: RemoteWallpaperSource,
+    query: &str,
+    first_page: usize,
+    api_key: Option<&str>,
+    runtime: &RemoteSearchRuntime,
+) -> Result<CandidateBatch, ProviderError> {
+    let pages_per_batch = match source {
+        RemoteWallpaperSource::Openverse => OPENVERSE_PAGES_PER_BATCH,
+        RemoteWallpaperSource::Pexels => 1,
+        RemoteWallpaperSource::Web => return Err(ProviderError::Protocol),
+    };
+    let client = Arc::new(provider_client());
+    let mut requests = FuturesUnordered::new();
+    for page in first_page..first_page + pages_per_batch {
+        let client = Arc::clone(&client);
+        let cancellation = runtime.cancellation().clone();
+        let api_key = api_key.map(str::to_string);
+        let query = query.to_string();
+        requests.push(async move {
+            let result = fetch_api_page(
+                client.as_ref(),
+                source,
+                &query,
+                page,
+                api_key.as_deref(),
+                &cancellation,
+            )
+            .await;
+            (page, result)
+        });
+    }
+
+    let mut completed = HashMap::new();
+    while let Some((page, result)) = tokio::select! {
+        biased;
+        _ = runtime.cancellation().cancelled() => return Err(ProviderError::Cancelled),
+        result = requests.next() => result,
+    } {
+        completed.insert(page, result);
+    }
+
+    let mut candidates = Vec::new();
+    let mut has_more = false;
+    let mut next_page = first_page;
+    for page_number in first_page..first_page + pages_per_batch {
+        let Some(result) = completed.remove(&page_number) else {
+            break;
+        };
+        match result {
+            Ok(page) => {
+                candidates.extend(page.candidates);
+                next_page = page_number + 1;
+                has_more = page.has_more;
+                if !has_more {
+                    break;
+                }
+            }
+            Err(error) if page_number == first_page => return Err(error),
+            Err(_) => {
+                has_more = true;
+                next_page = page_number;
+                break;
+            }
+        }
+    }
+    candidates.truncate(MAX_CANDIDATES);
+    Ok(CandidateBatch {
+        candidates,
+        has_more,
+        next_page,
+    })
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().min(u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/wallpaper_provider_search/probe.rs
+++ b/src-tauri/src/wallpaper_provider_search/probe.rs
@@ -1,0 +1,173 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use url::Url;
+
+use super::response::provider_item;
+use super::{
+    ProviderCandidate, ProviderError, ProviderPartialResults, IMAGE_PROBE_TIMEOUT,
+    IMAGE_VALIDATION_BUDGET, MAX_CONCURRENT_PROBES, PROGRESS_BATCH_SIZE, RESULT_LIMIT,
+};
+use crate::wallpaper_remote_media::{self, RemoteImageProber};
+use crate::wallpaper_remote_search::{
+    RemoteSearchBatch, RemoteSearchRuntime, RemoteWallpaperSource,
+};
+use crate::wallpaper_source::WallpaperGalleryItem;
+
+pub(super) async fn visit_probes_as_completed<I, F, Fut, Visit>(
+    inputs: I,
+    concurrency: usize,
+    budget: Duration,
+    mut probe: F,
+    mut visit: Visit,
+) where
+    I: IntoIterator,
+    F: FnMut(I::Item) -> Fut,
+    Fut: std::future::Future,
+    Visit: FnMut(usize, Fut::Output),
+{
+    let probes = futures_util::stream::iter(inputs.into_iter().enumerate())
+        .map(|(index, input)| {
+            let future = probe(input);
+            async move { (index, future.await) }
+        })
+        .buffer_unordered(concurrency.max(1));
+    tokio::pin!(probes);
+    let deadline = tokio::time::sleep(budget);
+    tokio::pin!(deadline);
+    loop {
+        let next = tokio::select! {
+            biased;
+            _ = &mut deadline => break,
+            next = probes.next() => next,
+        };
+        let Some(output) = next else {
+            break;
+        };
+        visit(output.0, output.1);
+    }
+}
+
+pub(super) async fn validate_candidates(
+    source: RemoteWallpaperSource,
+    candidates: Vec<ProviderCandidate>,
+    runtime: &RemoteSearchRuntime,
+    partial: &ProviderPartialResults,
+) -> Result<Vec<WallpaperGalleryItem>, ProviderError> {
+    let prober = Arc::new(RemoteImageProber::new());
+    let cancellation = runtime.cancellation().clone();
+    validate_probe_outputs(
+        candidates,
+        MAX_CONCURRENT_PROBES,
+        IMAGE_VALIDATION_BUDGET,
+        runtime,
+        partial,
+        |candidate| {
+            let prober = Arc::clone(&prober);
+            let cancellation = cancellation.clone();
+            async move {
+                let referer = Url::parse(&candidate.source_url)
+                    .ok()
+                    .as_ref()
+                    .and_then(wallpaper_remote_media::origin_referer);
+                let probe = tokio::time::timeout(
+                    IMAGE_PROBE_TIMEOUT,
+                    prober.probe_image(&candidate.image_url, referer.as_deref(), &cancellation),
+                )
+                .await
+                .ok()
+                .and_then(Result::ok)?;
+                if !wallpaper_remote_media::is_wallpaper_quality_candidate(&probe) {
+                    return None;
+                }
+                Some(provider_item(source, candidate, probe))
+            }
+        },
+    )
+    .await
+}
+
+pub(super) async fn validate_probe_outputs<I, F, Fut>(
+    inputs: I,
+    concurrency: usize,
+    budget: Duration,
+    runtime: &RemoteSearchRuntime,
+    partial: &ProviderPartialResults,
+    probe: F,
+) -> Result<Vec<WallpaperGalleryItem>, ProviderError>
+where
+    I: IntoIterator,
+    F: FnMut(I::Item) -> Fut,
+    Fut: std::future::Future<Output = Option<WallpaperGalleryItem>>,
+{
+    let mut completed_items = Vec::new();
+    let mut pending = Vec::new();
+    let mut progressive_seen_urls = HashSet::new();
+    let mut progressive_seen_fingerprints = HashSet::new();
+    let mut progressive_count = 0;
+    let mut batch_index = 1;
+
+    let visit = visit_probes_as_completed(inputs, concurrency, budget, probe, |index, item| {
+        let Some(item) = item else {
+            return;
+        };
+        completed_items.push((index, item.clone()));
+        partial.record(index, item.clone());
+        if progressive_count >= RESULT_LIMIT {
+            return;
+        }
+        let fingerprint = item.media_fingerprint.clone().unwrap_or_default();
+        if !progressive_seen_urls.insert(item.full_url.clone())
+            || (!fingerprint.is_empty() && !progressive_seen_fingerprints.insert(fingerprint))
+        {
+            return;
+        }
+        progressive_count += 1;
+        pending.push(item);
+        if pending.len() >= PROGRESS_BATCH_SIZE {
+            partial.mark_batch_emitted(batch_index);
+            runtime.report_batch(RemoteSearchBatch {
+                batch_index,
+                items: std::mem::take(&mut pending),
+                accumulated_count: progressive_count,
+                done: false,
+            });
+            batch_index += 1;
+        }
+    });
+    tokio::select! {
+        biased;
+        _ = runtime.cancellation().cancelled() => return Err(ProviderError::Cancelled),
+        _ = visit => {}
+    }
+    if runtime.is_cancelled() {
+        return Err(ProviderError::Cancelled);
+    }
+
+    // Progress favors latency; the invoke result remains the relevance-ordered
+    // authority used to reconcile the temporary completion-ordered cards.
+    completed_items.sort_by_key(|(index, _)| *index);
+    let mut items = Vec::with_capacity(completed_items.len());
+    let mut seen_urls = HashSet::new();
+    let mut seen_fingerprints = HashSet::new();
+    for (_, item) in completed_items {
+        let fingerprint = item.media_fingerprint.clone().unwrap_or_default();
+        if !seen_urls.insert(item.full_url.clone())
+            || (!fingerprint.is_empty() && !seen_fingerprints.insert(fingerprint))
+        {
+            continue;
+        }
+        items.push(item);
+    }
+
+    partial.mark_batch_emitted(batch_index);
+    runtime.report_batch(RemoteSearchBatch {
+        batch_index,
+        items: pending,
+        accumulated_count: items.len().min(RESULT_LIMIT),
+        done: true,
+    });
+    Ok(items)
+}

--- a/src-tauri/src/wallpaper_provider_search/request_url.rs
+++ b/src-tauri/src/wallpaper_provider_search/request_url.rs
@@ -1,0 +1,66 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::LazyLock;
+
+use url::Url;
+
+use super::{ProviderError, OPENVERSE_PAGE_SIZE, PEXELS_PAGE_SIZE};
+use crate::wallpaper_remote_search::RemoteWallpaperSource;
+
+const OPENVERSE_ENDPOINT: &str = "https://api.openverse.org/v1/images/";
+const PEXELS_ENDPOINT: &str = "https://api.pexels.com/v1/search";
+pub(super) const PEXELS_CACHE_BUST_PARAM: &str = "_grokapp_cache_bust";
+
+static PEXELS_CACHE_BUST_PREFIX: LazyLock<String> =
+    LazyLock::new(|| uuid::Uuid::new_v4().simple().to_string());
+static PEXELS_CACHE_BUST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+pub(super) fn provider_request_url(
+    source: RemoteWallpaperSource,
+    query: &str,
+    page: usize,
+) -> Result<Url, ProviderError> {
+    let pexels_cache_bust = (source == RemoteWallpaperSource::Pexels).then(next_pexels_cache_bust);
+    provider_url(source, query, page, pexels_cache_bust.as_deref())
+}
+
+fn next_pexels_cache_bust() -> String {
+    let sequence = PEXELS_CACHE_BUST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("{}{sequence:016x}", PEXELS_CACHE_BUST_PREFIX.as_str())
+}
+
+pub(super) fn provider_url(
+    source: RemoteWallpaperSource,
+    query: &str,
+    page: usize,
+    pexels_cache_bust: Option<&str>,
+) -> Result<Url, ProviderError> {
+    let (endpoint, page_size) = match source {
+        RemoteWallpaperSource::Openverse => (OPENVERSE_ENDPOINT, OPENVERSE_PAGE_SIZE),
+        RemoteWallpaperSource::Pexels => (PEXELS_ENDPOINT, PEXELS_PAGE_SIZE),
+        RemoteWallpaperSource::Web => return Err(ProviderError::Protocol),
+    };
+    let mut url = Url::parse(endpoint).map_err(|_| ProviderError::Protocol)?;
+    {
+        let mut pairs = url.query_pairs_mut();
+        pairs.append_pair("page", &page.max(1).to_string());
+        if source == RemoteWallpaperSource::Openverse {
+            if pexels_cache_bust.is_some() {
+                return Err(ProviderError::Protocol);
+            }
+            pairs.append_pair("q", query);
+            pairs.append_pair("page_size", &page_size.to_string());
+            pairs.append_pair("mature", "false");
+        } else {
+            let cache_bust = pexels_cache_bust
+                .filter(|value| {
+                    value.len() == 48 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+                })
+                .ok_or(ProviderError::Protocol)?;
+            pairs.append_pair("query", query);
+            pairs.append_pair("per_page", &page_size.to_string());
+            pairs.append_pair("orientation", "landscape");
+            pairs.append_pair(PEXELS_CACHE_BUST_PARAM, cache_bust);
+        }
+    }
+    Ok(url)
+}

--- a/src-tauri/src/wallpaper_provider_search/response.rs
+++ b/src-tauri/src/wallpaper_provider_search/response.rs
@@ -1,0 +1,242 @@
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use super::{
+    ApiPage, ProviderCandidate, ProviderError, OPENVERSE_PAGE_SIZE, PEXELS_LICENSE_URL,
+    PEXELS_PAGE_SIZE,
+};
+use crate::wallpaper_remote_media::{self, RemoteImageProbe};
+use crate::wallpaper_remote_search::RemoteWallpaperSource;
+use crate::wallpaper_source::{WallpaperGalleryItem, WallpaperProvenance};
+
+pub(super) fn parse_api_page(
+    source: RemoteWallpaperSource,
+    value: &Value,
+    page: usize,
+) -> Result<ApiPage, ProviderError> {
+    match source {
+        RemoteWallpaperSource::Openverse => parse_openverse_page(value, page),
+        RemoteWallpaperSource::Pexels => parse_pexels_page(value, page),
+        RemoteWallpaperSource::Web => Err(ProviderError::Protocol),
+    }
+}
+
+pub(super) fn parse_openverse_page(value: &Value, page: usize) -> Result<ApiPage, ProviderError> {
+    let results = value
+        .get("results")
+        .and_then(Value::as_array)
+        .ok_or(ProviderError::Protocol)?;
+    let page_count = value.get("page_count").and_then(Value::as_u64);
+    let has_more = page_count
+        .map(|count| (page as u64) < count)
+        .unwrap_or(results.len() >= OPENVERSE_PAGE_SIZE);
+    let mut candidates = Vec::new();
+    for raw in results.iter().take(OPENVERSE_PAGE_SIZE) {
+        if raw.get("mature").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        let Some(image_url) = raw.get("url").and_then(Value::as_str).and_then(safe_url) else {
+            continue;
+        };
+        let Some(source_url) = raw
+            .get("foreign_landing_url")
+            .and_then(Value::as_str)
+            .and_then(safe_url)
+        else {
+            continue;
+        };
+        let Some(author_name) = clean_text(raw.get("creator").and_then(Value::as_str), 160) else {
+            continue;
+        };
+        let Some(license_url) = raw
+            .get("license_url")
+            .and_then(Value::as_str)
+            .and_then(safe_url)
+        else {
+            continue;
+        };
+        let Some(license) = openverse_license_label(
+            raw.get("license").and_then(Value::as_str),
+            raw.get("license_version").and_then(Value::as_str),
+        ) else {
+            continue;
+        };
+        let upstream_id = clean_text(raw.get("id").and_then(Value::as_str), 160)
+            .unwrap_or_else(|| opaque_id(&image_url));
+        candidates.push(ProviderCandidate {
+            upstream_id,
+            image_url,
+            source_url,
+            source_name: "Openverse",
+            title: clean_text(raw.get("title").and_then(Value::as_str), 240),
+            author_name,
+            author_url: raw
+                .get("creator_url")
+                .and_then(Value::as_str)
+                .and_then(safe_url),
+            license,
+            license_url,
+        });
+    }
+    Ok(ApiPage {
+        candidates,
+        has_more,
+    })
+}
+
+pub(super) fn parse_pexels_page(value: &Value, page: usize) -> Result<ApiPage, ProviderError> {
+    let results = value
+        .get("photos")
+        .and_then(Value::as_array)
+        .ok_or(ProviderError::Protocol)?;
+    let total = value.get("total_results").and_then(Value::as_u64);
+    let per_page = value
+        .get("per_page")
+        .and_then(Value::as_u64)
+        .unwrap_or(PEXELS_PAGE_SIZE as u64)
+        .max(1);
+    let has_more = total
+        .map(|count| (page as u64).saturating_mul(per_page) < count)
+        .unwrap_or_else(|| value.get("next_page").is_some_and(|next| !next.is_null()));
+    let mut candidates = Vec::new();
+    for raw in results.iter().take(PEXELS_PAGE_SIZE) {
+        let Some(image_url) = raw
+            .get("src")
+            .and_then(|src| src.get("original").or_else(|| src.get("large2x")))
+            .and_then(Value::as_str)
+            .and_then(safe_url)
+        else {
+            continue;
+        };
+        let Some(source_url) = raw.get("url").and_then(Value::as_str).and_then(safe_url) else {
+            continue;
+        };
+        let Some(author_name) = clean_text(raw.get("photographer").and_then(Value::as_str), 160)
+        else {
+            continue;
+        };
+        let upstream_id = raw
+            .get("id")
+            .and_then(|id| {
+                id.as_u64()
+                    .map(|value| value.to_string())
+                    .or_else(|| clean_text(id.as_str(), 160))
+            })
+            .unwrap_or_else(|| opaque_id(&image_url));
+        candidates.push(ProviderCandidate {
+            upstream_id,
+            image_url,
+            source_url,
+            source_name: "Pexels",
+            title: clean_text(raw.get("alt").and_then(Value::as_str), 240),
+            author_name,
+            author_url: raw
+                .get("photographer_url")
+                .and_then(Value::as_str)
+                .and_then(safe_url),
+            license: "Pexels License".into(),
+            license_url: PEXELS_LICENSE_URL.into(),
+        });
+    }
+    Ok(ApiPage {
+        candidates,
+        has_more,
+    })
+}
+
+pub(super) fn safe_url(raw: &str) -> Option<String> {
+    if raw.len() > 2_048 {
+        return None;
+    }
+    let mut url = Url::parse(raw.trim()).ok()?;
+    if url.scheme() != "https"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.host_str().is_none()
+        || url.port().is_some_and(|port| port != 443)
+    {
+        return None;
+    }
+    url.set_fragment(None);
+    Some(url.to_string())
+}
+
+fn clean_text(value: Option<&str>, limit: usize) -> Option<String> {
+    let value = value?.split_whitespace().collect::<Vec<_>>().join(" ");
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.chars().take(limit).collect())
+    }
+}
+
+fn openverse_license_label(code: Option<&str>, version: Option<&str>) -> Option<String> {
+    let code = code?.trim().to_ascii_lowercase();
+    if code.is_empty()
+        || !code
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        return None;
+    }
+    let version = version.map(str::trim).filter(|value| {
+        !value.is_empty()
+            && value
+                .chars()
+                .all(|character| character.is_ascii_digit() || character == '.')
+    });
+    let base = match code.as_str() {
+        "cc0" => "CC0".to_string(),
+        "pdm" => "Public Domain Mark".to_string(),
+        other => format!("CC {}", other.to_ascii_uppercase()),
+    };
+    Some(match version {
+        Some(version) => format!("{base} {version}"),
+        None => base,
+    })
+}
+
+pub(super) fn provider_item(
+    source: RemoteWallpaperSource,
+    candidate: ProviderCandidate,
+    probe: RemoteImageProbe,
+) -> WallpaperGalleryItem {
+    wallpaper_remote_media::register_media_source(source, &probe.final_url, &candidate.source_url);
+    let mut digest = Sha256::new();
+    digest.update(source.as_str().as_bytes());
+    digest.update(candidate.upstream_id.as_bytes());
+    digest.update(probe.content_fingerprint.as_bytes());
+    let identity = hex::encode(digest.finalize());
+    WallpaperGalleryItem {
+        id: format!("{}-{}", source.as_str(), &identity[..24]),
+        thumb_url: probe.final_url.clone(),
+        full_url: probe.final_url,
+        kind: "image".into(),
+        width: probe.width,
+        height: probe.height,
+        source: source.as_str().into(),
+        username: None,
+        post_url: None,
+        text_preview: candidate.title,
+        likes: None,
+        local_path: None,
+        prompt: None,
+        provenance: WallpaperProvenance {
+            source_url: Some(candidate.source_url),
+            source_name: Some(candidate.source_name.into()),
+            author_name: Some(candidate.author_name),
+            author_url: candidate.author_url,
+            license: Some(candidate.license),
+            license_url: Some(candidate.license_url),
+        },
+        status_id: None,
+        media_index: None,
+        media_quality: None,
+        media_fingerprint: Some(probe.content_fingerprint),
+    }
+}
+
+fn opaque_id(value: &str) -> String {
+    hex::encode(Sha256::digest(value.as_bytes()))
+}

--- a/src-tauri/src/wallpaper_provider_search/tests.rs
+++ b/src-tauri/src/wallpaper_provider_search/tests.rs
@@ -1,0 +1,833 @@
+use super::*;
+use serde_json::json;
+use url::Url;
+
+fn gallery_item(id: usize) -> WallpaperGalleryItem {
+    WallpaperGalleryItem {
+        id: format!("item-{id}"),
+        thumb_url: format!("https://images.example/{id}.jpg"),
+        full_url: format!("https://images.example/{id}.jpg"),
+        kind: "image".into(),
+        width: Some(1920),
+        height: Some(1080),
+        source: "pexels".into(),
+        username: None,
+        post_url: None,
+        text_preview: None,
+        likes: None,
+        local_path: None,
+        prompt: None,
+        provenance: crate::wallpaper_source::WallpaperProvenance::empty(),
+        status_id: None,
+        media_index: None,
+        media_quality: None,
+        media_fingerprint: None,
+    }
+}
+
+#[test]
+fn endpoints_and_page_sizes_are_fixed() {
+    let openverse = provider_url(RemoteWallpaperSource::Openverse, "misty lake", 3, None).unwrap();
+    assert_eq!(openverse.host_str(), Some("api.openverse.org"));
+    assert_eq!(openverse.path(), "/v1/images/");
+    assert!(openverse.as_str().contains("page_size=20"));
+    assert!(openverse.as_str().contains("page=3"));
+    assert_eq!(
+        openverse
+            .query_pairs()
+            .find(|(key, _)| key == PEXELS_CACHE_BUST_PARAM),
+        None
+    );
+
+    let pexels = provider_url(
+        RemoteWallpaperSource::Pexels,
+        "misty lake",
+        2,
+        Some("000000000000000000000000000000010000000000000001"),
+    )
+    .unwrap();
+    assert_eq!(pexels.host_str(), Some("api.pexels.com"));
+    assert_eq!(pexels.path(), "/v1/search");
+    assert!(pexels.as_str().contains("per_page=40"));
+    assert!(pexels.as_str().contains("orientation=landscape"));
+    assert_eq!(
+        pexels
+            .query_pairs()
+            .find(|(key, _)| key == "query")
+            .map(|(_, value)| value.into_owned())
+            .as_deref(),
+        Some("misty lake")
+    );
+    assert!(!pexels.query_pairs().any(|(key, _)| key == "q"));
+}
+
+#[test]
+fn pexels_requests_use_fresh_credential_free_cache_busters() {
+    let first = provider_request_url(RemoteWallpaperSource::Pexels, "misty lake", 1).unwrap();
+    let second = provider_request_url(RemoteWallpaperSource::Pexels, "misty lake", 1).unwrap();
+    let nonce = |url: &Url| {
+        url.query_pairs()
+            .find(|(key, _)| key == PEXELS_CACHE_BUST_PARAM)
+            .map(|(_, value)| value.into_owned())
+            .unwrap()
+    };
+    let first_nonce = nonce(&first);
+    let second_nonce = nonce(&second);
+
+    assert_ne!(first_nonce, second_nonce);
+    for value in [&first_nonce, &second_nonce] {
+        assert_eq!(value.len(), 48);
+        assert!(value.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+    assert!(provider_url(RemoteWallpaperSource::Pexels, "misty lake", 1, None).is_err());
+    assert!(provider_url(
+        RemoteWallpaperSource::Pexels,
+        "misty lake",
+        1,
+        Some("pexels-api-key-sentinel"),
+    )
+    .is_err());
+}
+
+#[test]
+fn library_queries_drop_wallpaper_and_resolution_modifiers() {
+    assert_eq!(
+        library_provider_query("aurora mountain lake wallpaper"),
+        "aurora mountain lake"
+    );
+    assert_eq!(
+        library_provider_query("极光雪山湖泊 4K 壁纸"),
+        "极光雪山湖泊"
+    );
+    assert_eq!(library_provider_query("富士山 壁紙 8K"), "富士山");
+    assert_eq!(library_provider_query("海岸 桌布 UHD"), "海岸");
+    assert_eq!(library_provider_query("오로라 배경화면 4k"), "오로라");
+    assert_eq!(library_provider_query("wallpaper"), "wallpaper");
+    assert_eq!(library_provider_query("wallpaper !!!"), "wallpaper !!!");
+}
+
+#[test]
+fn openverse_parser_requires_real_provenance_and_license() {
+    let page = parse_openverse_page(
+        &json!({
+            "page_count": 3,
+            "results": [{
+                "id": "asset-1",
+                "title": "Misty mountain",
+                "creator": "Photographer",
+                "creator_url": "https://creator.example/profile",
+                "url": "https://images.example/mountain.jpg",
+                "foreign_landing_url": "https://source.example/photo/1",
+                "license": "by-sa",
+                "license_version": "4.0",
+                "license_url": "https://creativecommons.org/licenses/by-sa/4.0/",
+                "mature": false
+            }, {
+                "id": "missing-license",
+                "creator": "Unknown",
+                "url": "https://images.example/no-license.jpg",
+                "foreign_landing_url": "https://source.example/photo/2"
+            }]
+        }),
+        1,
+    )
+    .unwrap();
+    assert!(page.has_more);
+    assert_eq!(page.candidates.len(), 1);
+    let item = &page.candidates[0];
+    assert_eq!(item.source_name, "Openverse");
+    assert_eq!(item.license, "CC BY-SA 4.0");
+    assert_eq!(item.author_name, "Photographer");
+}
+
+#[test]
+fn pexels_parser_ignores_upstream_next_url_and_uses_fixed_license() {
+    let page = parse_pexels_page(
+        &json!({
+            "page": 1,
+            "per_page": 40,
+            "total_results": 80,
+            "next_page": "https://attacker.invalid/next",
+            "photos": [{
+                "id": 42,
+                "url": "https://www.pexels.com/photo/misty-lake-42/",
+                "photographer": "Photographer",
+                "photographer_url": "https://www.pexels.com/@photographer/",
+                "alt": "Misty lake",
+                "src": {"original": "https://images.pexels.com/photos/42/image.jpeg"}
+            }]
+        }),
+        1,
+    )
+    .unwrap();
+    assert!(page.has_more);
+    assert_eq!(page.candidates.len(), 1);
+    assert_eq!(page.candidates[0].license, "Pexels License");
+    assert_eq!(page.candidates[0].license_url, PEXELS_LICENSE_URL);
+}
+
+#[test]
+fn provider_links_reject_insecure_userinfo_and_non_default_ports() {
+    assert!(safe_url("http://example.test/image.jpg").is_none());
+    assert!(safe_url("https://user:pass@example.test/image.jpg").is_none());
+    assert!(safe_url("https://example.test:444/image.jpg").is_none());
+    assert_eq!(
+        safe_url("https://example.test:443/image.jpg#fragment").as_deref(),
+        Some("https://example.test/image.jpg")
+    );
+}
+
+#[test]
+fn cache_expires_and_keeps_the_host_owned_cursor() {
+    let search = SearchKey {
+        source: RemoteWallpaperSource::Openverse,
+        query: "misty lake".into(),
+        credential_revision: None,
+        contract_version: CONTRACT_VERSION,
+    };
+    let key = PageKey {
+        search,
+        first_page: 1,
+    };
+    let result = RemoteSearchResult::success("openverse", Vec::new(), true, 5);
+    let now = Instant::now();
+    let mut cache = SearchCache::default();
+    cache.insert(
+        key.clone(),
+        result,
+        Some(ProviderContinuation {
+            next_page: 3,
+            buffered_items: vec![gallery_item(1)],
+            upstream_has_more: true,
+        }),
+        now,
+    );
+    let continuation = cache
+        .get(&key, now)
+        .and_then(|(_, continuation)| continuation)
+        .expect("cached continuation");
+    assert_eq!(continuation.next_page, 3);
+    assert_eq!(continuation.buffered_items.len(), 1);
+    assert!(continuation.upstream_has_more);
+    assert!(cache
+        .get(&key, now + CACHE_TTL + Duration::from_secs(1))
+        .is_none());
+}
+
+#[test]
+fn provider_initial_cache_hit_is_linearized_before_a_later_cancellation() {
+    let key = PageKey {
+        search: SearchKey {
+            source: RemoteWallpaperSource::Openverse,
+            query: "misty lake".into(),
+            credential_revision: None,
+            contract_version: CONTRACT_VERSION,
+        },
+        first_page: 1,
+    };
+    let mut cache = SearchCache::default();
+    cache.insert(
+        key.clone(),
+        RemoteSearchResult::success("openverse", vec![gallery_item(1)], true, 1),
+        None,
+        Instant::now(),
+    );
+    let cancellation = WallpaperSearchCancellation::default();
+    let guarded =
+        remote_search::read_cache_if_active(&cancellation, || cache.get(&key, Instant::now()));
+
+    assert!(guarded.is_ok());
+    cancellation.cancel();
+    assert!(cancellation.is_cancelled());
+}
+
+#[test]
+fn provider_load_more_cache_hit_is_linearized_before_a_later_cancellation() {
+    let search = SearchKey {
+        source: RemoteWallpaperSource::Openverse,
+        query: "misty lake".into(),
+        credential_revision: None,
+        contract_version: CONTRACT_VERSION,
+    };
+    let key = PageKey {
+        search: search.clone(),
+        first_page: 2,
+    };
+    let mut cache = SearchCache::default();
+    cache.update_continuation(
+        &search,
+        Some(ProviderContinuation {
+            next_page: 2,
+            buffered_items: Vec::new(),
+            upstream_has_more: true,
+        }),
+        Instant::now(),
+    );
+    cache.insert(
+        key.clone(),
+        RemoteSearchResult::success("openverse", vec![gallery_item(2)], true, 1),
+        None,
+        Instant::now(),
+    );
+    let cancellation = WallpaperSearchCancellation::default();
+    let guarded = remote_search::read_cache_if_active(&cancellation, || {
+        let continuation = cache.continuation(&search, Instant::now());
+        continuation.and_then(|_| cache.get(&key, Instant::now()))
+    });
+
+    assert!(guarded.is_ok());
+    cancellation.cancel();
+    assert!(cancellation.is_cancelled());
+}
+
+#[test]
+fn overfetched_results_are_paged_before_advancing_upstream() {
+    let continuation = ProviderContinuation {
+        next_page: 3,
+        buffered_items: (0..25).map(gallery_item).collect(),
+        upstream_has_more: false,
+    };
+
+    let (first, continuation) = take_buffered_page(continuation).expect("first buffered page");
+    assert_eq!(first.len(), RESULT_LIMIT);
+    assert_eq!(first.first().map(|item| item.id.as_str()), Some("item-0"));
+    assert_eq!(first.last().map(|item| item.id.as_str()), Some("item-19"));
+
+    let (second, continuation) = take_buffered_page(continuation.expect("remaining buffered page"))
+        .expect("second buffered page");
+    assert_eq!(second.len(), 5);
+    assert_eq!(second.first().map(|item| item.id.as_str()), Some("item-20"));
+    assert!(continuation.is_none());
+}
+
+#[test]
+fn continuation_cache_is_ttl_bound_lru_and_credential_scoped() {
+    let now = Instant::now();
+    let mut cache = SearchCache::default();
+    for index in 0..=CACHE_CAPACITY {
+        cache.update_continuation(
+            &SearchKey {
+                source: RemoteWallpaperSource::Pexels,
+                query: format!("query-{index}"),
+                credential_revision: Some(format!("revision-{index}")),
+                contract_version: CONTRACT_VERSION,
+            },
+            Some(ProviderContinuation {
+                next_page: 2,
+                buffered_items: Vec::new(),
+                upstream_has_more: true,
+            }),
+            now,
+        );
+    }
+    assert_eq!(cache.continuations.len(), CACHE_CAPACITY);
+    let evicted = SearchKey {
+        source: RemoteWallpaperSource::Pexels,
+        query: "query-0".into(),
+        credential_revision: Some("revision-0".into()),
+        contract_version: CONTRACT_VERSION,
+    };
+    assert!(cache.continuation(&evicted, now).is_none());
+
+    let newest = SearchKey {
+        source: RemoteWallpaperSource::Pexels,
+        query: format!("query-{CACHE_CAPACITY}"),
+        credential_revision: Some(format!("revision-{CACHE_CAPACITY}")),
+        contract_version: CONTRACT_VERSION,
+    };
+    let changed_credential = SearchKey {
+        credential_revision: Some("rotated".into()),
+        ..newest.clone()
+    };
+    assert!(cache.continuation(&changed_credential, now).is_none());
+    assert_eq!(
+        cache
+            .continuation(&newest, now)
+            .map(|continuation| continuation.next_page),
+        Some(2)
+    );
+    assert!(cache
+        .continuation(&newest, now + CACHE_TTL + Duration::from_secs(1))
+        .is_none());
+}
+
+#[test]
+fn provider_cancel_before_begin_remains_sticky_and_bounded() {
+    let now = Instant::now();
+    let mut registry = RequestRegistry::default();
+    registry.record_pre_cancel("late-provider", now);
+    assert!(registry.take_pre_cancel("late-provider", now));
+    assert!(!registry.take_pre_cancel("late-provider", now));
+
+    for index in 0..=PRE_CANCEL_CAPACITY {
+        registry.record_pre_cancel(&format!("request-{index}"), now);
+    }
+    assert_eq!(registry.pre_cancelled.len(), PRE_CANCEL_CAPACITY);
+    assert!(!registry.take_pre_cancel("request-0", now));
+    assert!(!registry.take_pre_cancel("request-1", now + PRE_CANCEL_TTL + Duration::from_secs(1),));
+}
+
+#[tokio::test]
+async fn concurrent_provider_probes_report_completion_order() {
+    let mut output = Vec::new();
+    visit_probes_as_completed(
+        [("first", 30_u64), ("second", 0_u64), ("third", 5_u64)],
+        3,
+        Duration::from_millis(100),
+        |(name, delay_ms)| async move {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            name
+        },
+        |_, item| output.push(item),
+    )
+    .await;
+
+    assert_eq!(output, ["second", "third", "first"]);
+}
+
+#[tokio::test]
+async fn provider_probe_concurrency_never_exceeds_the_configured_limit() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let max_in_flight = Arc::new(AtomicUsize::new(0));
+    let concurrency = 3;
+    visit_probes_as_completed(
+        0..9,
+        concurrency,
+        Duration::from_secs(1),
+        {
+            let in_flight = Arc::clone(&in_flight);
+            let max_in_flight = Arc::clone(&max_in_flight);
+            move |item| {
+                let in_flight = Arc::clone(&in_flight);
+                let max_in_flight = Arc::clone(&max_in_flight);
+                async move {
+                    let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_in_flight.fetch_max(current, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                    item
+                }
+            }
+        },
+        |_, _| {},
+    )
+    .await;
+
+    assert_eq!(max_in_flight.load(Ordering::SeqCst), concurrency);
+    assert_eq!(in_flight.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn slow_first_probe_does_not_hide_later_fast_successes() {
+    let mut output = Vec::new();
+    visit_probes_as_completed(
+        [("first", 200_u64), ("second", 1_u64), ("third", 5_u64)],
+        3,
+        Duration::from_millis(40),
+        |(name, delay_ms)| async move {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            name
+        },
+        |_, item| output.push(item),
+    )
+    .await;
+
+    assert_eq!(output, ["second", "third"]);
+}
+
+#[tokio::test]
+async fn validation_reports_fast_batch_before_slow_first_probe() {
+    let cancellation = WallpaperSearchCancellation::default();
+    let (batch_tx, mut batch_rx) = tokio::sync::mpsc::unbounded_channel();
+    let runtime = RemoteSearchRuntime::new(
+        cancellation,
+        Arc::new(|_| {}),
+        Arc::new(move |batch| {
+            let _ = batch_tx.send(batch);
+        }),
+    );
+    let channels = (0..5)
+        .map(|_| tokio::sync::oneshot::channel::<()>())
+        .collect::<Vec<_>>();
+    let (senders, receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+    let mut senders = senders.into_iter().map(Some).collect::<Vec<_>>();
+    let partial = ProviderPartialResults::new(1);
+    let validation = validate_probe_outputs(
+        receivers.into_iter().enumerate(),
+        5,
+        Duration::from_secs(5),
+        &runtime,
+        &partial,
+        |(index, ready)| async move {
+            ready.await.ok()?;
+            Some(gallery_item(index))
+        },
+    );
+    tokio::pin!(validation);
+
+    for sender in senders.iter_mut().skip(1) {
+        sender.take().expect("fast sender").send(()).unwrap();
+    }
+    let first_batch = tokio::select! {
+        batch = batch_rx.recv() => batch.expect("first progress batch"),
+        result = &mut validation => panic!("validation finished before slow head: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_secs(1)) => {
+            panic!("first progress batch waited for the slow head")
+        },
+    };
+
+    assert_eq!(first_batch.items.len(), 4);
+    assert!(!first_batch.done);
+    assert!(first_batch.items.iter().all(|item| item.id != "item-0"));
+    senders[0]
+        .take()
+        .expect("slow head sender")
+        .send(())
+        .unwrap();
+    let items = validation.await.expect("validation result");
+    assert_eq!(
+        items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        ["item-0", "item-1", "item-2", "item-3", "item-4"]
+    );
+}
+
+#[tokio::test]
+async fn all_slow_probes_stop_at_the_validation_budget() {
+    let started = Instant::now();
+    let mut output = Vec::new();
+    visit_probes_as_completed(
+        [1_u8, 2, 3, 4],
+        2,
+        Duration::from_millis(30),
+        |value| async move {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            value
+        },
+        |_, item| output.push(item),
+    )
+    .await;
+
+    assert!(output.is_empty());
+    assert!(
+        started.elapsed() < Duration::from_millis(500),
+        "elapsed={:?}",
+        started.elapsed()
+    );
+}
+
+#[tokio::test]
+async fn validation_reports_first_batch_before_slow_tail_finishes() {
+    let cancellation = WallpaperSearchCancellation::default();
+    let (batch_tx, mut batch_rx) = tokio::sync::mpsc::unbounded_channel();
+    let runtime = RemoteSearchRuntime::new(
+        cancellation,
+        Arc::new(|_| {}),
+        Arc::new(move |batch| {
+            let _ = batch_tx.send(batch);
+        }),
+    );
+    let channels = (0..5)
+        .map(|_| tokio::sync::oneshot::channel::<()>())
+        .collect::<Vec<_>>();
+    let (mut senders, receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+    let partial = ProviderPartialResults::new(1);
+    let validation = validate_probe_outputs(
+        receivers.into_iter().enumerate(),
+        5,
+        Duration::from_secs(5),
+        &runtime,
+        &partial,
+        |(index, ready)| async move {
+            ready.await.ok()?;
+            Some(gallery_item(index))
+        },
+    );
+    tokio::pin!(validation);
+
+    for sender in senders.drain(..4) {
+        sender.send(()).expect("release leading probe");
+    }
+    let first_batch = tokio::select! {
+        batch = batch_rx.recv() => batch.expect("first progress batch"),
+        result = &mut validation => panic!("validation finished before tail: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_secs(1)) => {
+            panic!("first progress batch waited for the slow tail")
+        },
+    };
+
+    assert_eq!(first_batch.batch_index, 1);
+    assert_eq!(first_batch.accumulated_count, 4);
+    assert!(!first_batch.done);
+    assert_eq!(
+        first_batch
+            .items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        ["item-0", "item-1", "item-2", "item-3"]
+    );
+
+    senders
+        .pop()
+        .expect("tail sender")
+        .send(())
+        .expect("release tail probe");
+    let items = validation.await.expect("validation result");
+    assert_eq!(
+        items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        ["item-0", "item-1", "item-2", "item-3", "item-4"]
+    );
+
+    let final_batch = tokio::time::timeout(Duration::from_secs(1), batch_rx.recv())
+        .await
+        .expect("final batch timeout")
+        .expect("final batch");
+    assert_eq!(final_batch.batch_index, 2);
+    assert_eq!(final_batch.accumulated_count, 5);
+    assert!(final_batch.done);
+    assert_eq!(
+        final_batch
+            .items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        ["item-4"]
+    );
+    assert!(batch_rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn validation_deduplicates_in_order_and_caps_progress_at_result_limit() {
+    let cancellation = WallpaperSearchCancellation::default();
+    let batches = Arc::new(Mutex::new(Vec::new()));
+    let reported_batches = Arc::clone(&batches);
+    let runtime = RemoteSearchRuntime::new(
+        cancellation,
+        Arc::new(|_| {}),
+        Arc::new(move |batch| reported_batches.lock().push(batch)),
+    );
+    let mut unique = (0..=RESULT_LIMIT).map(gallery_item).collect::<Vec<_>>();
+    unique[2].media_fingerprint = Some("same-media".into());
+    let mut duplicate_url = gallery_item(100);
+    duplicate_url.full_url = unique[1].full_url.clone();
+    let mut duplicate_fingerprint = gallery_item(101);
+    duplicate_fingerprint.media_fingerprint = Some("same-media".into());
+    let mut probes = Vec::new();
+    for (index, item) in unique.into_iter().enumerate() {
+        probes.push(item);
+        if index == 1 {
+            probes.push(duplicate_url.clone());
+        } else if index == 2 {
+            probes.push(duplicate_fingerprint.clone());
+        }
+    }
+
+    let items = validate_probe_outputs(
+        probes,
+        MAX_CONCURRENT_PROBES,
+        Duration::from_secs(1),
+        &runtime,
+        &ProviderPartialResults::new(1),
+        |item| std::future::ready(Some(item)),
+    )
+    .await
+    .expect("validation result");
+
+    assert_eq!(items.len(), RESULT_LIMIT + 1);
+    assert_eq!(
+        items.iter().map(|item| item.id.clone()).collect::<Vec<_>>(),
+        (0..=RESULT_LIMIT)
+            .map(|index| format!("item-{index}"))
+            .collect::<Vec<_>>()
+    );
+    let batches = batches.lock();
+    assert_eq!(batches.iter().filter(|batch| batch.done).count(), 1);
+    assert!(batches.last().is_some_and(|batch| batch.done));
+    assert_eq!(
+        batches
+            .iter()
+            .flat_map(|batch| batch.items.iter())
+            .map(|item| item.id.clone())
+            .collect::<Vec<_>>(),
+        (0..RESULT_LIMIT)
+            .map(|index| format!("item-{index}"))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn validation_cancellation_returns_cancelled_without_final_batch() {
+    let cancellation = WallpaperSearchCancellation::default();
+    let batches = Arc::new(Mutex::new(Vec::new()));
+    let reported_batches = Arc::clone(&batches);
+    let runtime = RemoteSearchRuntime::new(
+        cancellation.clone(),
+        Arc::new(|_| {}),
+        Arc::new(move |batch| reported_batches.lock().push(batch)),
+    );
+    cancellation.cancel();
+
+    let result = validate_probe_outputs(
+        [()],
+        1,
+        Duration::from_secs(5),
+        &runtime,
+        &ProviderPartialResults::new(1),
+        |_| std::future::pending::<Option<WallpaperGalleryItem>>(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(ProviderError::Cancelled)));
+    assert!(batches.lock().is_empty());
+}
+
+#[tokio::test]
+async fn validation_cancellation_after_progress_omits_final_batch() {
+    let cancellation = WallpaperSearchCancellation::default();
+    let (batch_tx, mut batch_rx) = tokio::sync::mpsc::unbounded_channel();
+    let runtime = RemoteSearchRuntime::new(
+        cancellation.clone(),
+        Arc::new(|_| {}),
+        Arc::new(move |batch| {
+            let _ = batch_tx.send(batch);
+        }),
+    );
+    let channels = (0..5)
+        .map(|_| tokio::sync::oneshot::channel::<()>())
+        .collect::<Vec<_>>();
+    let (mut senders, receivers): (Vec<_>, Vec<_>) = channels.into_iter().unzip();
+    let partial = ProviderPartialResults::new(1);
+    let validation = validate_probe_outputs(
+        receivers.into_iter().enumerate(),
+        5,
+        Duration::from_secs(5),
+        &runtime,
+        &partial,
+        |(index, ready)| async move {
+            ready.await.ok()?;
+            Some(gallery_item(index))
+        },
+    );
+    tokio::pin!(validation);
+
+    for sender in senders.drain(..4) {
+        sender.send(()).expect("release leading probe");
+    }
+    let first_batch = tokio::select! {
+        batch = batch_rx.recv() => batch.expect("first progress batch"),
+        result = &mut validation => panic!("validation finished before tail: {result:?}"),
+        _ = tokio::time::sleep(Duration::from_secs(1)) => panic!("first batch timeout"),
+    };
+    assert!(!first_batch.done);
+
+    cancellation.cancel();
+    assert!(matches!(validation.await, Err(ProviderError::Cancelled)));
+    assert!(batch_rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn provider_operation_timeout_is_classified() {
+    let cancellation = WallpaperSearchCancellation::default();
+    let result = with_provider_deadline(
+        &cancellation,
+        Duration::from_millis(20),
+        std::future::pending::<Result<(), ProviderError>>(),
+    )
+    .await;
+
+    assert_eq!(result, Err(ProviderError::Timeout));
+}
+
+#[test]
+fn provider_timeout_recovers_validated_items_and_closes_progress() {
+    let partial = ProviderPartialResults::new(2);
+    partial.begin_batch(4, true);
+    for index in 0..5 {
+        partial.record(index, gallery_item(index));
+    }
+    partial.mark_batch_emitted(1);
+
+    let recovered = partial
+        .recover_timeout_page()
+        .expect("validated progress should survive the provider deadline");
+
+    assert_eq!(
+        recovered
+            .page
+            .items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        ["item-0", "item-1", "item-2", "item-3", "item-4"]
+    );
+    assert_eq!(recovered.page.next_page, 4);
+    assert!(recovered.page.upstream_has_more);
+    assert_eq!(recovered.terminal_batch_index, 2);
+}
+
+#[tokio::test]
+async fn provider_deadline_keeps_reported_progress_and_emits_a_terminal_batch() {
+    let cancellation = WallpaperSearchCancellation::default();
+    let batches = Arc::new(Mutex::new(Vec::new()));
+    let reported_batches = Arc::clone(&batches);
+    let runtime = RemoteSearchRuntime::new(
+        cancellation.clone(),
+        Arc::new(|_| {}),
+        Arc::new(move |batch| reported_batches.lock().push(batch)),
+    );
+    let partial = ProviderPartialResults::new(2);
+    partial.begin_batch(4, true);
+    for index in 0..4 {
+        partial.record(index, gallery_item(index));
+    }
+    partial.mark_batch_emitted(1);
+    runtime.report_batch(RemoteSearchBatch {
+        batch_index: 1,
+        items: (0..4).map(gallery_item).collect(),
+        accumulated_count: 4,
+        done: false,
+    });
+
+    let timed_out = with_provider_deadline(
+        &cancellation,
+        Duration::from_millis(20),
+        std::future::pending::<Result<ValidatedPage, ProviderError>>(),
+    )
+    .await;
+    let recovered = recover_provider_timeout(timed_out, &partial, &runtime)
+        .expect("reported validated items should survive the outer deadline");
+
+    assert_eq!(
+        recovered
+            .items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        ["item-0", "item-1", "item-2", "item-3"]
+    );
+    assert!(recovered.has_more());
+    let batches = batches.lock();
+    assert_eq!(batches.len(), 2);
+    assert!(!batches[0].done);
+    assert!(batches[1].done);
+    assert_eq!(batches[1].batch_index, 2);
+    assert_eq!(batches[1].accumulated_count, 4);
+    assert!(batches[1].items.is_empty());
+}
+
+#[test]
+fn replacement_provider_request_cancels_the_previous_generation() {
+    let (_first_token, first) = begin_request("first-provider");
+    let (second_token, second) = begin_request("second-provider");
+    assert!(first.is_cancelled());
+    assert!(!second.is_cancelled());
+    finish_request("second-provider", second_token);
+}

--- a/src-tauri/src/wallpaper_provider_search/transport.rs
+++ b/src-tauri/src/wallpaper_provider_search/transport.rs
@@ -1,0 +1,123 @@
+use std::time::Duration;
+
+use hyper::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
+use serde_json::Value;
+
+use super::request_url::provider_request_url;
+use super::response::parse_api_page;
+use super::{ApiPage, ProviderError};
+use crate::safe_https_client::{
+    self, SafeHttpsClient, SafeHttpsError, SafeHttpsErrorKind, SafeHttpsResponse,
+};
+use crate::skin_net::{self, OriginPolicy};
+use crate::wallpaper_remote_search::RemoteWallpaperSource;
+use crate::wallpaper_source::WallpaperSearchCancellation;
+
+const HTTP_TIMEOUT: Duration = Duration::from_secs(25);
+const MAX_API_BYTES: usize = 2 * 1024 * 1024;
+
+pub(super) fn provider_client() -> SafeHttpsClient {
+    safe_https_client::shared()
+}
+
+pub(super) async fn fetch_api_page(
+    client: &SafeHttpsClient,
+    source: RemoteWallpaperSource,
+    query: &str,
+    page: usize,
+    api_key: Option<&str>,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<ApiPage, ProviderError> {
+    let url = provider_request_url(source, query, page)?;
+    let checked = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(ProviderError::Cancelled),
+        checked = skin_net::check_hop_async(url.as_str(), &OriginPolicy::AnyHttps) => {
+            checked.map_err(|_| ProviderError::Network)?
+        },
+    };
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_static("GrokApp/WallpaperProviderSearch"),
+    );
+    if source == RemoteWallpaperSource::Pexels {
+        let key = api_key.ok_or(ProviderError::PexelsKeyMissing)?;
+        let mut value = HeaderValue::from_str(key).map_err(|_| ProviderError::PexelsKeyInvalid)?;
+        value.set_sensitive(true);
+        headers.insert(AUTHORIZATION, value);
+    }
+    let response = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(ProviderError::Cancelled),
+        response = client.get(&checked, headers, HTTP_TIMEOUT) => {
+            response.map_err(|error| classify_transport_error(&error))?
+        },
+    };
+    let status = response.status();
+    if status.is_redirection() {
+        return Err(ProviderError::Protocol);
+    }
+    match status.as_u16() {
+        200..=299 => {}
+        401 | 403 if source == RemoteWallpaperSource::Pexels => {
+            return Err(ProviderError::PexelsKeyInvalid);
+        }
+        408 | 504 => return Err(ProviderError::Timeout),
+        429 => return Err(ProviderError::RateLimited),
+        500..=599 => return Err(ProviderError::ServiceUnavailable),
+        _ => return Err(ProviderError::Protocol),
+    }
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    if content_type != "application/json" && !content_type.ends_with("+json") {
+        return Err(ProviderError::Protocol);
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_API_BYTES as u64)
+    {
+        return Err(ProviderError::Protocol);
+    }
+    let bytes = read_bounded_body(response, cancellation).await?;
+    let value: Value = serde_json::from_slice(&bytes).map_err(|_| ProviderError::Protocol)?;
+    parse_api_page(source, &value, page)
+}
+
+async fn read_bounded_body(
+    mut response: SafeHttpsResponse,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<Vec<u8>, ProviderError> {
+    let mut bytes = Vec::new();
+    loop {
+        let chunk = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(ProviderError::Cancelled),
+            chunk = response.chunk() => chunk.map_err(|error| classify_transport_error(&error))?,
+        };
+        let Some(chunk) = chunk else {
+            break;
+        };
+        if bytes.len() + chunk.len() > MAX_API_BYTES {
+            return Err(ProviderError::Protocol);
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+fn classify_transport_error(error: &SafeHttpsError) -> ProviderError {
+    match error.kind() {
+        SafeHttpsErrorKind::Timeout => ProviderError::Timeout,
+        SafeHttpsErrorKind::Blocked | SafeHttpsErrorKind::Network => ProviderError::Network,
+    }
+}

--- a/src-tauri/src/wallpaper_remote_commands.rs
+++ b/src-tauri/src/wallpaper_remote_commands.rs
@@ -1,0 +1,95 @@
+//! Tauri boundary for independent Web and licensed-library wallpaper sources.
+
+use tauri::AppHandle;
+
+use crate::wallpaper_remote_search::{self, RemoteSearchResult, RemoteWallpaperSource};
+
+#[tauri::command]
+pub(crate) async fn wallpaper_remote_search(
+    app: AppHandle,
+    source: String,
+    query: String,
+    request_id: Option<String>,
+) -> Result<RemoteSearchResult, String> {
+    let source = RemoteWallpaperSource::parse(&source)?;
+    let request_id = wallpaper_remote_search::request_id(request_id.as_deref())?;
+    match source {
+        RemoteWallpaperSource::Web => Err("invalid_remote_source".into()),
+        RemoteWallpaperSource::Openverse | RemoteWallpaperSource::Pexels => {
+            crate::wallpaper_provider_search::search(&app, source, &request_id, &query).await
+        }
+    }
+}
+
+#[tauri::command]
+pub(crate) async fn wallpaper_remote_search_more(
+    app: AppHandle,
+    source: String,
+    query: String,
+    request_id: Option<String>,
+) -> Result<RemoteSearchResult, String> {
+    let source = RemoteWallpaperSource::parse(&source)?;
+    let request_id = wallpaper_remote_search::request_id(request_id.as_deref())?;
+    match source {
+        RemoteWallpaperSource::Web => Err("invalid_remote_source".into()),
+        RemoteWallpaperSource::Openverse | RemoteWallpaperSource::Pexels => {
+            crate::wallpaper_provider_search::search_more(&app, source, &request_id, &query).await
+        }
+    }
+}
+
+#[tauri::command]
+pub(crate) async fn wallpaper_remote_search_cancel(
+    source: String,
+    request_id: String,
+) -> Result<bool, String> {
+    let source = RemoteWallpaperSource::parse(&source)?;
+    let request_id = wallpaper_remote_search::request_id(Some(&request_id))?;
+    Ok(match source {
+        RemoteWallpaperSource::Web => return Err("invalid_remote_source".into()),
+        RemoteWallpaperSource::Openverse | RemoteWallpaperSource::Pexels => {
+            crate::wallpaper_provider_search::cancel(&request_id)
+        }
+    })
+}
+
+#[tauri::command]
+pub(crate) async fn wallpaper_remote_fetch_media(
+    source: String,
+    url: String,
+    request_id: String,
+) -> Result<crate::wallpaper_source::WallpaperFetchResult, String> {
+    let source = RemoteWallpaperSource::parse(&source)?;
+    let request_id = wallpaper_remote_search::request_id(Some(&request_id))?;
+    crate::wallpaper_source::ensure_wallpaper_dirs();
+    crate::wallpaper_remote_media::fetch_and_store_image(&url, source, &request_id).await
+}
+
+#[tauri::command]
+pub(crate) async fn wallpaper_remote_thumbnail(
+    source: String,
+    url: String,
+    request_id: String,
+) -> Result<crate::wallpaper_remote_media::RemoteWallpaperThumbnail, String> {
+    let source = RemoteWallpaperSource::parse(&source)?;
+    let request_id = wallpaper_remote_search::request_id(Some(&request_id))?;
+    crate::wallpaper_remote_media::fetch_thumbnail(&url, source, &request_id).await
+}
+
+#[tauri::command]
+pub(crate) async fn wallpaper_remote_cancel_media_requests(
+    request_ids: Vec<String>,
+) -> Result<usize, String> {
+    let request_ids = request_ids
+        .iter()
+        .map(|request_id| wallpaper_remote_search::request_id(Some(request_id)))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(crate::wallpaper_remote_media::cancel_media_requests(
+        &request_ids,
+    ))
+}
+
+#[tauri::command]
+pub(crate) async fn wallpaper_remote_cancel_all_media_requests() -> Result<usize, String> {
+    Ok(crate::wallpaper_remote_media::cancel_all_media_requests())
+}

--- a/src-tauri/src/wallpaper_remote_media.rs
+++ b/src-tauri/src/wallpaper_remote_media.rs
@@ -1,0 +1,924 @@
+//! Safe, source-agnostic remote image probing and download.
+//!
+//! Unlike the X/Imagine downloader, this path accepts arbitrary public HTTPS
+//! origins, so every redirect and DNS resolution is checked through
+//! `skin_net` before bytes are trusted.
+
+use std::collections::{HashMap, VecDeque};
+use std::fs;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use hyper::header::{
+    HeaderMap, HeaderValue, ACCEPT, ACCEPT_LANGUAGE, CONTENT_RANGE, CONTENT_TYPE, RANGE, REFERER,
+    USER_AGENT,
+};
+use hyper::StatusCode;
+use parking_lot::Mutex;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::safe_https_client::{
+    self, SafeHttpsClient, SafeHttpsError, SafeHttpsErrorKind, SafeHttpsResponse,
+};
+use crate::skin_net::{self, OriginPolicy};
+use crate::wallpaper_remote_search::RemoteWallpaperSource;
+use crate::wallpaper_source::{
+    validate_fetched_media_bytes, validate_image_prefix, ValidatedImagePrefix,
+    WallpaperFetchResult, WallpaperSearchCancellation, MAX_DOWNLOAD_BYTES,
+};
+
+const PROBE_BYTES: usize = 64 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(45);
+const THUMBNAIL_SOURCE_BYTES: u64 = 32 * 1024 * 1024;
+const THUMBNAIL_JPEG_BYTES: usize = 512 * 1024;
+const SOURCE_ORIGIN_TTL: Duration = Duration::from_secs(30 * 60);
+const SOURCE_ORIGIN_LIMIT: usize = 512;
+const PRE_CANCEL_TTL: Duration = Duration::from_secs(30);
+const PRE_CANCEL_CAPACITY: usize = 128;
+const BROWSER_IMAGE_USER_AGENT: &str =
+    "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 GrokApp/WallpaperDiscovery";
+const BROWSER_IMAGE_ACCEPT_LANGUAGE: &str = "en-US,en;q=0.9,*;q=0.5";
+
+#[derive(Clone)]
+struct ActiveMediaRequest {
+    token: uuid::Uuid,
+    cancellation: WallpaperSearchCancellation,
+}
+
+#[derive(Default)]
+struct MediaRequestRegistry {
+    active: HashMap<String, ActiveMediaRequest>,
+    pre_cancelled: VecDeque<(String, Instant)>,
+}
+
+impl MediaRequestRegistry {
+    fn purge_pre_cancelled(&mut self, now: Instant) {
+        self.pre_cancelled
+            .retain(|(_, created)| now.saturating_duration_since(*created) < PRE_CANCEL_TTL);
+    }
+
+    fn record_pre_cancel(&mut self, request_id: &str, now: Instant) {
+        self.purge_pre_cancelled(now);
+        self.pre_cancelled.retain(|(id, _)| id != request_id);
+        while self.pre_cancelled.len() >= PRE_CANCEL_CAPACITY {
+            self.pre_cancelled.pop_front();
+        }
+        self.pre_cancelled.push_back((request_id.to_string(), now));
+    }
+
+    fn take_pre_cancel(&mut self, request_id: &str, now: Instant) -> bool {
+        self.purge_pre_cancelled(now);
+        let found = self.pre_cancelled.iter().any(|(id, _)| id == request_id);
+        self.pre_cancelled.retain(|(id, _)| id != request_id);
+        found
+    }
+}
+
+static ACTIVE_MEDIA: OnceLock<Mutex<MediaRequestRegistry>> = OnceLock::new();
+
+#[derive(Clone, Debug)]
+struct RegisteredSourceOrigin {
+    origin: String,
+    last_seen: Instant,
+}
+
+#[derive(Default)]
+struct SourceOriginRegistry {
+    entries: HashMap<(RemoteWallpaperSource, String), RegisteredSourceOrigin>,
+}
+
+impl SourceOriginRegistry {
+    fn prune_expired(&mut self, now: Instant) {
+        self.entries
+            .retain(|_, entry| now.saturating_duration_since(entry.last_seen) < SOURCE_ORIGIN_TTL);
+    }
+
+    fn register(
+        &mut self,
+        source: RemoteWallpaperSource,
+        media_url: String,
+        origin: String,
+        now: Instant,
+    ) {
+        self.prune_expired(now);
+        self.entries.insert(
+            (source, media_url),
+            RegisteredSourceOrigin {
+                origin,
+                last_seen: now,
+            },
+        );
+        while self.entries.len() > SOURCE_ORIGIN_LIMIT {
+            let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_seen)
+                .map(|(key, _)| key.clone())
+            else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+    }
+
+    fn lookup(
+        &mut self,
+        source: RemoteWallpaperSource,
+        media_url: &str,
+        now: Instant,
+    ) -> Option<String> {
+        self.prune_expired(now);
+        let entry = self.entries.get_mut(&(source, media_url.to_string()))?;
+        entry.last_seen = now;
+        Some(entry.origin.clone())
+    }
+}
+
+static SOURCE_ORIGINS: OnceLock<Mutex<SourceOriginRegistry>> = OnceLock::new();
+
+fn active_media() -> &'static Mutex<MediaRequestRegistry> {
+    ACTIVE_MEDIA.get_or_init(|| Mutex::new(MediaRequestRegistry::default()))
+}
+
+fn source_origins() -> &'static Mutex<SourceOriginRegistry> {
+    SOURCE_ORIGINS.get_or_init(|| Mutex::new(SourceOriginRegistry::default()))
+}
+
+fn begin_media_request(request_id: &str) -> (uuid::Uuid, WallpaperSearchCancellation) {
+    let token = uuid::Uuid::new_v4();
+    let cancellation = WallpaperSearchCancellation::default();
+    let mut requests = active_media().lock();
+    if requests.take_pre_cancel(request_id, Instant::now()) {
+        cancellation.cancel();
+    }
+    if let Some(previous) = requests.active.insert(
+        request_id.to_string(),
+        ActiveMediaRequest {
+            token,
+            cancellation: cancellation.clone(),
+        },
+    ) {
+        previous.cancellation.cancel();
+    }
+    (token, cancellation)
+}
+
+fn finish_media_request(request_id: &str, token: uuid::Uuid) {
+    let mut requests = active_media().lock();
+    if requests
+        .active
+        .get(request_id)
+        .is_some_and(|request| request.token == token)
+    {
+        requests.active.remove(request_id);
+    }
+}
+
+pub(crate) fn cancel_media_requests(request_ids: &[String]) -> usize {
+    let mut requests = active_media().lock();
+    let mut active = Vec::new();
+    let now = Instant::now();
+    for request_id in request_ids {
+        if let Some(request) = requests.active.remove(request_id) {
+            active.push(request.cancellation);
+        } else {
+            requests.record_pre_cancel(request_id, now);
+        }
+    }
+    drop(requests);
+    let count = active.len();
+    for cancellation in active {
+        cancellation.cancel();
+    }
+    count
+}
+
+pub(crate) fn cancel_all_media_requests() -> usize {
+    let requests = active_media()
+        .lock()
+        .active
+        .drain()
+        .map(|(_, request)| request)
+        .collect::<Vec<_>>();
+    let count = requests.len();
+    for request in requests {
+        request.cancellation.cancel();
+    }
+    count
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RemoteImageProbe {
+    pub(crate) final_url: String,
+    pub(crate) width: Option<u32>,
+    pub(crate) height: Option<u32>,
+    pub(crate) content_length: Option<u64>,
+    pub(crate) content_fingerprint: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RemoteWallpaperThumbnail {
+    data_url: String,
+    width: u32,
+    height: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RemoteImageProbeFailure {
+    Cancelled,
+    Blocked,
+    Timeout,
+    Forbidden,
+    NotFound,
+    RateLimited,
+    HttpClient,
+    HttpServer,
+    Network,
+    InvalidImage,
+    TooLarge,
+    Redirect,
+}
+
+fn network_failure(error: &SafeHttpsError) -> RemoteImageProbeFailure {
+    match error.kind() {
+        SafeHttpsErrorKind::Blocked => RemoteImageProbeFailure::Blocked,
+        SafeHttpsErrorKind::Timeout => RemoteImageProbeFailure::Timeout,
+        SafeHttpsErrorKind::Network => RemoteImageProbeFailure::Network,
+    }
+}
+
+fn status_failure(status: StatusCode) -> RemoteImageProbeFailure {
+    match status.as_u16() {
+        403 => RemoteImageProbeFailure::Forbidden,
+        404 | 410 => RemoteImageProbeFailure::NotFound,
+        429 => RemoteImageProbeFailure::RateLimited,
+        400..=499 => RemoteImageProbeFailure::HttpClient,
+        500..=599 => RemoteImageProbeFailure::HttpServer,
+        _ => RemoteImageProbeFailure::Network,
+    }
+}
+
+pub(crate) fn origin_referer(source_page: &Url) -> Option<String> {
+    if source_page.scheme() != "https"
+        || !source_page.username().is_empty()
+        || source_page.password().is_some()
+        || source_page.host_str().is_none()
+    {
+        return None;
+    }
+    Some(format!("{}/", source_page.origin().ascii_serialization()))
+}
+
+fn canonical_media_url(raw: &str) -> Option<String> {
+    if raw.len() > 8_192 {
+        return None;
+    }
+    let mut url = Url::parse(raw.trim()).ok()?;
+    if url.scheme() != "https"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.host_str().is_none()
+        || url.port().is_some_and(|port| port != 443)
+    {
+        return None;
+    }
+    url.set_fragment(None);
+    Some(url.to_string())
+}
+
+fn verified_source_origin(raw: &str) -> Option<String> {
+    if raw.len() > 2_048 {
+        return None;
+    }
+    let url = Url::parse(raw.trim()).ok()?;
+    if url.port().is_some_and(|port| port != 443) {
+        return None;
+    }
+    origin_referer(&url)
+}
+
+/// Associate a validated result with only its source origin. Renderer IPC
+/// never supplies the Referer used by later thumbnail or original downloads.
+pub(crate) fn register_media_source(
+    source: RemoteWallpaperSource,
+    media_url: &str,
+    source_page: &str,
+) {
+    let (Some(media_url), Some(origin)) = (
+        canonical_media_url(media_url),
+        verified_source_origin(source_page),
+    ) else {
+        return;
+    };
+    source_origins()
+        .lock()
+        .register(source, media_url, origin, Instant::now());
+}
+
+fn registered_source_origin(source: RemoteWallpaperSource, media_url: &str) -> Option<String> {
+    let media_url = canonical_media_url(media_url)?;
+    source_origins()
+        .lock()
+        .lookup(source, &media_url, Instant::now())
+}
+
+pub(crate) fn is_wallpaper_quality_candidate(probe: &RemoteImageProbe) -> bool {
+    if let (Some(width), Some(height)) = (probe.width, probe.height) {
+        let long = width.max(height);
+        let short = width.min(height);
+        let ratio = width as f64 / height as f64;
+        long >= 900 && short >= 360 && (0.38..=3.2).contains(&ratio)
+    } else {
+        probe.content_length.is_some_and(|bytes| bytes >= 80 * 1024)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct RemoteImageProber {
+    client: SafeHttpsClient,
+}
+
+impl RemoteImageProber {
+    pub(crate) fn new() -> Self {
+        Self {
+            client: safe_https_client::shared(),
+        }
+    }
+
+    pub(crate) async fn probe_image(
+        &self,
+        start: &str,
+        referer_origin: Option<&str>,
+        cancellation: &WallpaperSearchCancellation,
+    ) -> Result<RemoteImageProbe, RemoteImageProbeFailure> {
+        probe_image_with_client(&self.client, start, referer_origin, cancellation).await
+    }
+}
+
+fn normalized_content_type(response: &SafeHttpsResponse) -> String {
+    response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn response_total_length(response: &SafeHttpsResponse) -> Option<u64> {
+    response
+        .headers()
+        .get(CONTENT_RANGE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.rsplit('/').next())
+        .and_then(|value| value.parse::<u64>().ok())
+        .or_else(|| response.content_length())
+}
+
+fn image_headers(
+    referer_origin: Option<&str>,
+    range: Option<&str>,
+) -> Result<HeaderMap, RemoteImageProbeFailure> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_static(BROWSER_IMAGE_USER_AGENT),
+    );
+    headers.insert(
+        ACCEPT,
+        HeaderValue::from_static(
+            "image/jpeg,image/png,image/webp;q=0.9,image/avif;q=0.8,image/*;q=0.7,*/*;q=0.5",
+        ),
+    );
+    headers.insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static(BROWSER_IMAGE_ACCEPT_LANGUAGE),
+    );
+    if let Some(range) = range {
+        headers.insert(
+            RANGE,
+            HeaderValue::from_str(range).map_err(|_| RemoteImageProbeFailure::Blocked)?,
+        );
+    }
+    if let Some(referer) = referer_origin {
+        headers.insert(
+            REFERER,
+            HeaderValue::from_str(referer).map_err(|_| RemoteImageProbeFailure::Blocked)?,
+        );
+    }
+    Ok(headers)
+}
+
+async fn read_prefix(
+    response: &mut SafeHttpsResponse,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<Vec<u8>, RemoteImageProbeFailure> {
+    let mut bytes = Vec::with_capacity(PROBE_BYTES);
+    while bytes.len() < PROBE_BYTES {
+        let next = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(RemoteImageProbeFailure::Cancelled),
+            chunk = response.chunk() => chunk,
+        }
+        .map_err(|error| network_failure(&error))?;
+        let Some(chunk) = next else {
+            break;
+        };
+        let remaining = PROBE_BYTES - bytes.len();
+        bytes.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+    }
+    Ok(bytes)
+}
+
+async fn check_image_hop(
+    raw: &str,
+    policy: &OriginPolicy,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<Url, RemoteImageProbeFailure> {
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => Err(RemoteImageProbeFailure::Cancelled),
+        checked = skin_net::check_hop_async(raw, policy) => {
+            checked.map_err(|_| RemoteImageProbeFailure::Blocked)
+        },
+    }
+}
+
+async fn probe_image_with_client(
+    client: &SafeHttpsClient,
+    start: &str,
+    referer_origin: Option<&str>,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<RemoteImageProbe, RemoteImageProbeFailure> {
+    if cancellation.is_cancelled() {
+        return Err(RemoteImageProbeFailure::Cancelled);
+    }
+    let policy = OriginPolicy::AnyHttps;
+    let mut current = check_image_hop(start, &policy, cancellation).await?;
+
+    for hop in 0..=skin_net::MAX_REDIRECTS {
+        let range = format!("bytes=0-{}", PROBE_BYTES - 1);
+        let headers = image_headers(referer_origin, Some(&range))?;
+        let mut response = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(RemoteImageProbeFailure::Cancelled),
+            response = client.get(&current, headers, REQUEST_TIMEOUT) => response,
+        }
+        .map_err(|error| network_failure(&error))?;
+
+        if response.status().is_redirection() {
+            if hop == skin_net::MAX_REDIRECTS {
+                return Err(RemoteImageProbeFailure::Redirect);
+            }
+            let location = response
+                .headers()
+                .get(hyper::header::LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .ok_or(RemoteImageProbeFailure::Redirect)?;
+            let next = current
+                .join(location)
+                .map_err(|_| RemoteImageProbeFailure::Redirect)?;
+            current = check_image_hop(next.as_str(), &policy, cancellation).await?;
+            continue;
+        }
+
+        if !matches!(response.status().as_u16(), 200 | 206) {
+            return Err(status_failure(response.status()));
+        }
+        let content_length = response_total_length(&response);
+        if content_length.is_some_and(|length| length > MAX_DOWNLOAD_BYTES) {
+            return Err(RemoteImageProbeFailure::TooLarge);
+        }
+        let content_type = normalized_content_type(&response);
+        let prefix = read_prefix(&mut response, cancellation).await?;
+        let ValidatedImagePrefix { dimensions, .. } = validate_image_prefix(&content_type, &prefix)
+            .ok_or(RemoteImageProbeFailure::InvalidImage)?;
+        let content_fingerprint = hex::encode(Sha256::digest(&prefix));
+        let (width, height) = dimensions
+            .map(|(width, height)| (Some(width), Some(height)))
+            .unwrap_or((None, None));
+        return Ok(RemoteImageProbe {
+            final_url: current.to_string(),
+            width,
+            height,
+            content_length,
+            content_fingerprint,
+        });
+    }
+
+    Err(RemoteImageProbeFailure::Redirect)
+}
+
+async fn fetch_remote_image_bytes_with_client(
+    client: &SafeHttpsClient,
+    start: &str,
+    referer_origin: Option<&str>,
+    max_bytes: u64,
+    cancellation: &WallpaperSearchCancellation,
+) -> Result<(String, String, Vec<u8>), RemoteImageProbeFailure> {
+    if cancellation.is_cancelled() {
+        return Err(RemoteImageProbeFailure::Cancelled);
+    }
+    let policy = OriginPolicy::AnyHttps;
+    let mut current = check_image_hop(start, &policy, cancellation).await?;
+
+    for hop in 0..=skin_net::MAX_REDIRECTS {
+        let headers = image_headers(referer_origin, None)?;
+        let mut response = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(RemoteImageProbeFailure::Cancelled),
+            response = client.get(&current, headers, REQUEST_TIMEOUT) => response,
+        }
+        .map_err(|error| network_failure(&error))?;
+
+        if response.status().is_redirection() {
+            if hop == skin_net::MAX_REDIRECTS {
+                return Err(RemoteImageProbeFailure::Redirect);
+            }
+            let location = response
+                .headers()
+                .get(hyper::header::LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .ok_or(RemoteImageProbeFailure::Redirect)?;
+            let next = current
+                .join(location)
+                .map_err(|_| RemoteImageProbeFailure::Redirect)?;
+            current = check_image_hop(next.as_str(), &policy, cancellation).await?;
+            continue;
+        }
+        if !crate::wallpaper_source::is_complete_download_response(
+            response.status().as_u16(),
+            response
+                .headers()
+                .contains_key(hyper::header::CONTENT_RANGE),
+        ) {
+            return Err(status_failure(response.status()));
+        }
+        if response_total_length(&response).is_some_and(|length| length > max_bytes) {
+            return Err(RemoteImageProbeFailure::TooLarge);
+        }
+        let content_type = normalized_content_type(&response);
+        let mut bytes = Vec::new();
+        while let Some(chunk) = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(RemoteImageProbeFailure::Cancelled),
+            chunk = response.chunk() => chunk,
+        }
+        .map_err(|error| network_failure(&error))?
+        {
+            if (bytes.len() as u64).saturating_add(chunk.len() as u64) > max_bytes {
+                return Err(RemoteImageProbeFailure::TooLarge);
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        validate_image_prefix(&content_type, &bytes)
+            .ok_or(RemoteImageProbeFailure::InvalidImage)?;
+        return Ok((current.to_string(), content_type, bytes));
+    }
+
+    Err(RemoteImageProbeFailure::Redirect)
+}
+
+fn remote_fetch_error(failure: RemoteImageProbeFailure) -> String {
+    match failure {
+        RemoteImageProbeFailure::Cancelled => "cancelled".into(),
+        RemoteImageProbeFailure::Blocked => "url_blocked".into(),
+        RemoteImageProbeFailure::TooLarge => "download_failed: too large".into(),
+        RemoteImageProbeFailure::InvalidImage => "download_failed: invalid image".into(),
+        _ => "download_failed: network".into(),
+    }
+}
+
+pub(crate) async fn fetch_image_bytes(
+    start: &str,
+    cancellation: Option<&WallpaperSearchCancellation>,
+) -> Result<(String, String, Vec<u8>), String> {
+    let default_cancellation = WallpaperSearchCancellation::default();
+    let cancellation = cancellation.unwrap_or(&default_cancellation);
+    fetch_remote_image_bytes_with_client(
+        &safe_https_client::shared(),
+        start,
+        None,
+        MAX_DOWNLOAD_BYTES,
+        cancellation,
+    )
+    .await
+    .map_err(remote_fetch_error)
+}
+
+pub(crate) async fn fetch_and_store_image(
+    start: &str,
+    source: RemoteWallpaperSource,
+    request_id: &str,
+) -> Result<WallpaperFetchResult, String> {
+    let (token, cancellation) = begin_media_request(request_id);
+    let result = async {
+        let referer = registered_source_origin(source, start);
+        let (final_url, content_type, bytes) = if let Some(referer) = referer.as_deref() {
+            let client = RemoteImageProber::new();
+            fetch_remote_image_bytes_with_client(
+                &client.client,
+                start,
+                Some(referer),
+                MAX_DOWNLOAD_BYTES,
+                &cancellation,
+            )
+            .await
+            .map_err(remote_fetch_error)?
+        } else {
+            fetch_image_bytes(start, Some(&cancellation)).await?
+        };
+        if cancellation.is_cancelled() {
+            return Err("cancelled".into());
+        }
+        save_image(&final_url, source, &content_type, bytes)
+    }
+    .await;
+    finish_media_request(request_id, token);
+    result
+}
+
+fn thumbnail_from_bytes(bytes: Vec<u8>) -> Result<RemoteWallpaperThumbnail, String> {
+    let (jpeg, width, height) = crate::image_thumb::thumbnail_jpeg_from_untrusted_bytes(&bytes)
+        .map_err(|_| "thumbnail_unavailable".to_string())?;
+    if jpeg.is_empty() || jpeg.len() > THUMBNAIL_JPEG_BYTES || width == 0 || height == 0 {
+        return Err("thumbnail_unavailable".into());
+    }
+    Ok(RemoteWallpaperThumbnail {
+        data_url: format!("data:image/jpeg;base64,{}", B64.encode(jpeg)),
+        width,
+        height,
+    })
+}
+
+pub(crate) async fn fetch_thumbnail(
+    start: &str,
+    source: RemoteWallpaperSource,
+    request_id: &str,
+) -> Result<RemoteWallpaperThumbnail, String> {
+    let (token, cancellation) = begin_media_request(request_id);
+    let result = async {
+        let client = RemoteImageProber::new();
+        let referer = registered_source_origin(source, start);
+        let (_, _, bytes) = fetch_remote_image_bytes_with_client(
+            &client.client,
+            start,
+            referer.as_deref(),
+            THUMBNAIL_SOURCE_BYTES,
+            &cancellation,
+        )
+        .await
+        .map_err(|failure| match failure {
+            RemoteImageProbeFailure::Cancelled => "cancelled".to_string(),
+            _ => "thumbnail_unavailable".to_string(),
+        })?;
+        if cancellation.is_cancelled() {
+            return Err("cancelled".into());
+        }
+        let thumbnail = tokio::task::spawn_blocking(move || thumbnail_from_bytes(bytes))
+            .await
+            .map_err(|_| "thumbnail_unavailable".to_string())??;
+        if cancellation.is_cancelled() {
+            return Err("cancelled".into());
+        }
+        Ok(thumbnail)
+    }
+    .await;
+    finish_media_request(request_id, token);
+    result
+}
+
+fn save_image(
+    final_url: &str,
+    source: RemoteWallpaperSource,
+    content_type: &str,
+    bytes: Vec<u8>,
+) -> Result<WallpaperFetchResult, String> {
+    let (mime, extension) = validate_fetched_media_bytes(content_type, &bytes)?;
+    if !mime.starts_with("image/") {
+        return Err("download_failed: image required".into());
+    }
+    let mut digest = Sha256::new();
+    digest.update(final_url.as_bytes());
+    digest.update(&bytes);
+    let hash = format!("{:x}", digest.finalize());
+    let day = chrono::Local::now().format("%Y-%m-%d").to_string();
+    let directory = crate::wallpaper_source::wallpapers_root()
+        .join(source.as_str())
+        .join(day);
+    fs::create_dir_all(&directory).map_err(|error| format!("write: {error}"))?;
+    let name = format!(
+        "{}-{}.{}",
+        chrono::Local::now().format("%H%M%S%3f"),
+        &hash[..16],
+        extension
+    );
+    let path = directory.join(&name);
+    let temporary = directory.join(format!(".{name}.{}.tmp", uuid::Uuid::new_v4().simple()));
+    fs::write(&temporary, &bytes).map_err(|error| format!("write: {error}"))?;
+    if let Err(error) = fs::rename(&temporary, &path) {
+        let _ = fs::remove_file(&temporary);
+        return Err(format!("write: {error}"));
+    }
+    crate::path_scope::grant_path(&path);
+    Ok(WallpaperFetchResult {
+        path: path.display().to_string(),
+        mime: mime.to_string(),
+        bytes: bytes.len() as u64,
+        name,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::path::Path;
+
+    use crate::paths::APP_HOME_ENV_LOCK;
+
+    use super::*;
+
+    #[test]
+    fn content_range_total_shape_is_stable() {
+        let parsed = "bytes 0-65535/1048576"
+            .rsplit('/')
+            .next()
+            .and_then(|value| value.parse::<u64>().ok());
+        assert_eq!(parsed, Some(1_048_576));
+    }
+
+    #[test]
+    fn full_remote_download_rejects_partial_response_shapes() {
+        assert!(crate::wallpaper_source::is_complete_download_response(
+            200, false
+        ));
+        assert!(!crate::wallpaper_source::is_complete_download_response(
+            206, true
+        ));
+        assert!(!crate::wallpaper_source::is_complete_download_response(
+            200, true
+        ));
+    }
+
+    #[test]
+    fn image_referer_contains_only_the_source_origin() {
+        let source = Url::parse("https://photos.example/private/path?query=secret").unwrap();
+        assert_eq!(
+            origin_referer(&source).as_deref(),
+            Some("https://photos.example/")
+        );
+        assert!(origin_referer(&Url::parse("http://photos.example/path").unwrap()).is_none());
+        assert_eq!(
+            verified_source_origin("https://photos.example/private/path?token=secret").as_deref(),
+            Some("https://photos.example/")
+        );
+    }
+
+    #[test]
+    fn source_registry_is_source_scoped_bounded_and_expires() {
+        let started = Instant::now();
+        let mut registry = SourceOriginRegistry::default();
+        registry.register(
+            RemoteWallpaperSource::Web,
+            "https://cdn.example/photo.jpg".into(),
+            "https://photos.example/".into(),
+            started,
+        );
+        assert_eq!(
+            registry
+                .lookup(
+                    RemoteWallpaperSource::Web,
+                    "https://cdn.example/photo.jpg",
+                    started + Duration::from_secs(1),
+                )
+                .as_deref(),
+            Some("https://photos.example/")
+        );
+        assert!(registry
+            .lookup(
+                RemoteWallpaperSource::Openverse,
+                "https://cdn.example/photo.jpg",
+                started + Duration::from_secs(1),
+            )
+            .is_none());
+        assert!(registry
+            .lookup(
+                RemoteWallpaperSource::Web,
+                "https://cdn.example/photo.jpg",
+                started + SOURCE_ORIGIN_TTL + Duration::from_secs(1),
+            )
+            .is_none());
+
+        for index in 0..=SOURCE_ORIGIN_LIMIT {
+            registry.register(
+                RemoteWallpaperSource::Pexels,
+                format!("https://cdn.example/{index}.jpg"),
+                "https://www.pexels.com/".into(),
+                started + Duration::from_millis(index as u64),
+            );
+        }
+        assert_eq!(registry.entries.len(), SOURCE_ORIGIN_LIMIT);
+        assert!(!registry.entries.contains_key(&(
+            RemoteWallpaperSource::Pexels,
+            "https://cdn.example/0.jpg".into(),
+        )));
+    }
+
+    #[test]
+    fn source_registry_rejects_renderer_style_header_inputs() {
+        assert_eq!(
+            canonical_media_url("https://cdn.example/photo.jpg#fragment").as_deref(),
+            Some("https://cdn.example/photo.jpg")
+        );
+        assert!(canonical_media_url("http://cdn.example/photo.jpg").is_none());
+        assert!(canonical_media_url("https://user:secret@cdn.example/photo.jpg").is_none());
+        assert!(verified_source_origin("https://photos.example:444/item").is_none());
+    }
+
+    #[test]
+    fn media_cancel_before_begin_is_sticky_bounded_and_expires() {
+        let now = Instant::now();
+        let mut registry = MediaRequestRegistry::default();
+        registry.record_pre_cancel("late-media", now);
+        assert!(registry.take_pre_cancel("late-media", now));
+        assert!(!registry.take_pre_cancel("late-media", now));
+
+        for index in 0..=PRE_CANCEL_CAPACITY {
+            registry.record_pre_cancel(&format!("request-{index}"), now);
+        }
+        assert_eq!(registry.pre_cancelled.len(), PRE_CANCEL_CAPACITY);
+        assert!(!registry.take_pre_cancel("request-0", now));
+        assert!(
+            !registry.take_pre_cancel("request-1", now + PRE_CANCEL_TTL + Duration::from_secs(1),)
+        );
+    }
+
+    #[test]
+    fn remote_thumbnail_is_bounded_jpeg_data_without_persisting() {
+        let image = image::DynamicImage::new_rgb8(1_600, 900);
+        let mut png = Cursor::new(Vec::new());
+        image
+            .write_to(&mut png, image::ImageFormat::Png)
+            .expect("encode test image");
+
+        let thumbnail = thumbnail_from_bytes(png.into_inner()).expect("build thumbnail");
+        assert_eq!((thumbnail.width, thumbnail.height), (1_600, 900));
+        assert!(thumbnail.data_url.starts_with("data:image/jpeg;base64,"));
+        assert!(thumbnail.data_url.len() <= 768 * 1024);
+    }
+
+    #[test]
+    fn probe_http_failures_have_stable_categories() {
+        assert_eq!(
+            status_failure(StatusCode::FORBIDDEN),
+            RemoteImageProbeFailure::Forbidden
+        );
+        assert_eq!(
+            status_failure(StatusCode::NOT_FOUND),
+            RemoteImageProbeFailure::NotFound
+        );
+        assert_eq!(
+            status_failure(StatusCode::TOO_MANY_REQUESTS),
+            RemoteImageProbeFailure::RateLimited
+        );
+        assert_eq!(
+            status_failure(StatusCode::BAD_GATEWAY),
+            RemoteImageProbeFailure::HttpServer
+        );
+    }
+
+    #[test]
+    fn stored_remote_images_stay_in_their_source_directory() {
+        let _environment = APP_HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let home = std::env::temp_dir().join(format!(
+            "grok-app-remote-image-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4().simple()
+        ));
+        // SAFETY: test-only mutation serialized by APP_HOME_ENV_LOCK.
+        unsafe { std::env::set_var("GROK_APP_HOME", &home) };
+        let mut png = vec![0u8; 128];
+        png[..8].copy_from_slice(b"\x89PNG\r\n\x1a\n");
+        let saved = save_image(
+            "https://images.example.test/wallpaper.png",
+            RemoteWallpaperSource::Web,
+            "image/png",
+            png,
+        )
+        .expect("save remote image");
+        assert!(Path::new(&saved.path).is_file());
+        assert!(Path::new(&saved.path).starts_with(home.join("wallpapers").join("web")));
+
+        unsafe { std::env::remove_var("GROK_APP_HOME") };
+        let _ = fs::remove_dir_all(home);
+    }
+}

--- a/src-tauri/src/wallpaper_remote_search.rs
+++ b/src-tauri/src/wallpaper_remote_search.rs
@@ -1,0 +1,304 @@
+//! Shared runtime contract for independent Web and licensed-library searches.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+
+use crate::wallpaper_source::{WallpaperGalleryItem, WallpaperSearchCancellation};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum RemoteWallpaperSource {
+    Web,
+    Openverse,
+    Pexels,
+}
+
+impl RemoteWallpaperSource {
+    pub(crate) fn parse(value: &str) -> Result<Self, String> {
+        match value.trim() {
+            "web" => Ok(Self::Web),
+            "openverse" => Ok(Self::Openverse),
+            "pexels" => Ok(Self::Pexels),
+            _ => Err("invalid_remote_source".into()),
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Web => "web",
+            Self::Openverse => "openverse",
+            Self::Pexels => "pexels",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RemoteSearchResult {
+    pub(crate) source: String,
+    pub(crate) items: Vec<WallpaperGalleryItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) message: Option<String>,
+    pub(crate) has_more: bool,
+    pub(crate) cache_hit: bool,
+    pub(crate) duration_ms: u64,
+}
+
+impl RemoteSearchResult {
+    pub(crate) fn success(
+        source: &str,
+        items: Vec<WallpaperGalleryItem>,
+        has_more: bool,
+        duration_ms: u64,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            items,
+            error_code: None,
+            message: None,
+            has_more,
+            cache_hit: false,
+            duration_ms,
+        }
+    }
+
+    pub(crate) fn error(source: &str, code: &str, duration_ms: u64) -> Self {
+        Self {
+            source: source.into(),
+            items: Vec::new(),
+            error_code: Some(code.into()),
+            message: None,
+            has_more: false,
+            cache_hit: false,
+            duration_ms,
+        }
+    }
+
+    pub(crate) fn empty(source: &str, has_more: bool, duration_ms: u64) -> Self {
+        let mut result = Self::error(source, "empty", duration_ms);
+        result.has_more = has_more;
+        result
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RemoteSearchStage {
+    Preparing,
+    SearchingProvider,
+    ValidatingImages,
+    LoadingMore,
+    Done,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RemoteSearchBatch {
+    pub(crate) batch_index: usize,
+    pub(crate) items: Vec<WallpaperGalleryItem>,
+    pub(crate) accumulated_count: usize,
+    pub(crate) done: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct RemoteSearchRuntime {
+    cancellation: WallpaperSearchCancellation,
+    progress: Arc<dyn Fn(RemoteSearchStage) + Send + Sync>,
+    batch: Arc<dyn Fn(RemoteSearchBatch) + Send + Sync>,
+}
+
+impl RemoteSearchRuntime {
+    pub(crate) fn new(
+        cancellation: WallpaperSearchCancellation,
+        progress: Arc<dyn Fn(RemoteSearchStage) + Send + Sync>,
+        batch: Arc<dyn Fn(RemoteSearchBatch) + Send + Sync>,
+    ) -> Self {
+        Self {
+            cancellation,
+            progress,
+            batch,
+        }
+    }
+
+    pub(crate) fn cancellation(&self) -> &WallpaperSearchCancellation {
+        &self.cancellation
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.cancellation.is_cancelled()
+    }
+
+    pub(crate) fn report(&self, stage: RemoteSearchStage) {
+        if !self.is_cancelled() || stage == RemoteSearchStage::Done {
+            (self.progress)(stage);
+        }
+    }
+
+    pub(crate) fn report_batch(&self, batch: RemoteSearchBatch) {
+        if !self.is_cancelled() {
+            (self.batch)(batch);
+        }
+    }
+}
+
+/// Linearize a synchronous cache lookup with cancellation. A cancellation
+/// that wins the shared gate prevents both the lookup's LRU mutation and use
+/// of its value; a lookup that wins has completed before cancellation.
+pub(crate) fn read_cache_if_active<T>(
+    cancellation: &WallpaperSearchCancellation,
+    read: impl FnOnce() -> T,
+) -> Result<T, ()> {
+    cancellation.commit_if_active(read).ok_or(())
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProgressEvent<'a> {
+    request_id: &'a str,
+    source: &'a str,
+    stage: RemoteSearchStage,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BatchEvent<'a> {
+    request_id: &'a str,
+    source: &'a str,
+    batch_index: usize,
+    items: &'a [WallpaperGalleryItem],
+    accumulated_count: usize,
+    done: bool,
+}
+
+pub(crate) fn runtime(
+    app: &AppHandle,
+    request_id: &str,
+    source: RemoteWallpaperSource,
+    cancellation: WallpaperSearchCancellation,
+) -> RemoteSearchRuntime {
+    let progress_app = app.clone();
+    let progress_request_id = request_id.to_string();
+    let batch_app = app.clone();
+    let batch_request_id = request_id.to_string();
+    let source_name = source.as_str();
+    RemoteSearchRuntime::new(
+        cancellation,
+        Arc::new(move |stage| {
+            let _ = progress_app.emit(
+                "wallpaper://remote-search-progress",
+                ProgressEvent {
+                    request_id: &progress_request_id,
+                    source: source_name,
+                    stage,
+                },
+            );
+        }),
+        Arc::new(move |batch| {
+            let _ = batch_app.emit(
+                "wallpaper://remote-search-batch",
+                BatchEvent {
+                    request_id: &batch_request_id,
+                    source: source_name,
+                    batch_index: batch.batch_index,
+                    items: &batch.items,
+                    accumulated_count: batch.accumulated_count,
+                    done: batch.done,
+                },
+            );
+        }),
+    )
+}
+
+pub(crate) fn normalized_query(query: &str) -> String {
+    query
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+pub(crate) fn validate_query(query: &str) -> Result<String, String> {
+    let query = query.split_whitespace().collect::<Vec<_>>().join(" ");
+    let count = query.chars().count();
+    if count == 0 {
+        return Err("empty".into());
+    }
+    if count > 240 {
+        return Err("query_too_long".into());
+    }
+    Ok(query)
+}
+
+pub(crate) fn request_id(value: Option<&str>) -> Result<String, String> {
+    let value = value.unwrap_or("").trim();
+    if value.is_empty() {
+        return Ok(uuid::Uuid::new_v4().to_string());
+    }
+    if value.len() > 128
+        || !value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "-_.:".contains(character))
+    {
+        return Err("invalid_request_id".into());
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_ids_are_bounded_and_secret_free() {
+        assert_eq!(request_id(Some("web-123")).unwrap(), "web-123");
+        assert!(request_id(Some("bad request")).is_err());
+        assert!(request_id(Some(&"x".repeat(129))).is_err());
+        assert!(!request_id(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn remote_sources_are_strictly_enumerated() {
+        assert_eq!(
+            RemoteWallpaperSource::parse("openverse").unwrap(),
+            RemoteWallpaperSource::Openverse
+        );
+        assert!(RemoteWallpaperSource::parse("x").is_err());
+        assert!(RemoteWallpaperSource::parse("https://example.test").is_err());
+    }
+
+    #[test]
+    fn queries_are_normalized_and_bounded() {
+        assert_eq!(validate_query("  Misty   Lake  ").unwrap(), "Misty Lake");
+        assert_eq!(normalized_query("  Misty   Lake  "), "misty lake");
+        assert!(validate_query("   ").is_err());
+        assert!(validate_query(&"x".repeat(241)).is_err());
+    }
+
+    #[test]
+    fn cache_read_is_skipped_when_already_cancelled() {
+        let cancellation = WallpaperSearchCancellation::default();
+        cancellation.cancel();
+        let mut read = false;
+
+        let result = read_cache_if_active(&cancellation, || {
+            read = true;
+            42
+        });
+
+        assert_eq!(result, Err(()));
+        assert!(!read);
+    }
+
+    #[test]
+    fn cache_read_is_linearized_before_a_later_cancellation() {
+        let cancellation = WallpaperSearchCancellation::default();
+
+        let result = read_cache_if_active(&cancellation, || 42);
+
+        assert_eq!(result, Ok(42));
+        cancellation.cancel();
+        assert!(cancellation.is_cancelled());
+    }
+}

--- a/src-tauri/src/wallpaper_source.rs
+++ b/src-tauri/src/wallpaper_source.rs
@@ -24,7 +24,7 @@ use crate::store;
 const MAX_WALLPAPER_CLI_STDOUT_BYTES: usize = 2 * 1024 * 1024;
 const WALLPAPER_CLI_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 /// Max bytes for a single wallpaper media download.
-const MAX_DOWNLOAD_BYTES: u64 = 200 * 1024 * 1024;
+pub(crate) const MAX_DOWNLOAD_BYTES: u64 = 200 * 1024 * 1024;
 /// Enough prefix data to verify a real image and usually recover dimensions,
 /// without buffering a full response when a CDN ignores Range.
 const MAX_IMAGE_PROBE_BYTES: usize = 64 * 1024;
@@ -39,6 +39,36 @@ pub(crate) const X_SEARCH_TOTAL_CALLS: u32 = X_SEARCH_FIRST_ROUND_CALLS + X_SEAR
 const X_SEARCH_TIMEOUT: Duration = Duration::from_secs(150);
 /// Headless Imagine budget.
 const IMAGINE_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WallpaperProvenance {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license_url: Option<String>,
+}
+
+impl WallpaperProvenance {
+    pub(crate) fn empty() -> Self {
+        Self {
+            source_url: None,
+            source_name: None,
+            author_name: None,
+            author_url: None,
+            license: None,
+            license_url: None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -64,6 +94,8 @@ pub struct WallpaperGalleryItem {
     pub local_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
+    #[serde(flatten)]
+    pub provenance: WallpaperProvenance,
     /// Host-only evidence used by the shared X quality pipeline. These fields
     /// never cross IPC and cannot expose extra account or post information.
     #[serde(skip)]
@@ -72,6 +104,8 @@ pub struct WallpaperGalleryItem {
     pub(crate) media_index: Option<u8>,
     #[serde(skip)]
     pub(crate) media_quality: Option<WallpaperMediaQuality>,
+    #[serde(skip)]
+    pub(crate) media_fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1300,6 +1334,8 @@ pub(crate) fn parse_gallery_items(
             status_id,
             media_index,
             media_quality: None,
+            provenance: crate::wallpaper_source::WallpaperProvenance::empty(),
+            media_fingerprint: None,
         });
     }
     dedupe_gallery_items(out, false)
@@ -1440,6 +1476,12 @@ struct ImageProbe {
     content_length: Option<u64>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct ValidatedImagePrefix {
+    pub(crate) mime: &'static str,
+    pub(crate) dimensions: Option<(u32, u32)>,
+}
+
 fn detect_media_signature(bytes: &[u8]) -> Option<DetectedMedia> {
     if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
         return Some(DetectedMedia::Jpeg);
@@ -1569,6 +1611,23 @@ fn content_type_matches_signature(content_type: &str, media: DetectedMedia) -> b
         DetectedMedia::Mp4 => matches!(content_type, "video/mp4" | "application/mp4"),
         DetectedMedia::Webm => content_type == "video/webm",
     }
+}
+
+pub(crate) fn validate_image_prefix(
+    content_type: &str,
+    bytes: &[u8],
+) -> Option<ValidatedImagePrefix> {
+    if bytes.len() < MIN_IMAGE_PROBE_BYTES {
+        return None;
+    }
+    let media = detect_media_signature(bytes)?;
+    if !media.is_image() || !content_type_matches_signature(content_type, media) {
+        return None;
+    }
+    Some(ValidatedImagePrefix {
+        mime: media.mime(),
+        dimensions: image_dimensions_from_prefix(bytes, media),
+    })
 }
 
 fn response_total_length(response: &reqwest::Response) -> Option<u64> {
@@ -2371,6 +2430,31 @@ pub async fn fetch_media(url: &str, source: Option<&str>) -> Result<WallpaperFet
     })
 }
 
+pub(crate) fn validate_fetched_media_bytes(
+    content_type: &str,
+    bytes: &[u8],
+) -> Result<(&'static str, &'static str), String> {
+    if bytes.len() as u64 > MAX_DOWNLOAD_BYTES {
+        return Err("download_failed: too large".into());
+    }
+    if bytes.is_empty() {
+        return Err("download_failed: empty body".into());
+    }
+    if bytes.len() < 64 {
+        return Err("download_failed: too small".into());
+    }
+    let normalized_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    let media = detect_media_signature(bytes)
+        .filter(|media| content_type_matches_signature(&normalized_type, *media))
+        .ok_or_else(|| "download_failed: invalid media signature".to_string())?;
+    Ok((media.mime(), media.extension()))
+}
+
 fn file_to_fetch_result(path: &Path) -> Result<WallpaperFetchResult, String> {
     let meta = fs::metadata(path).map_err(|e| format!("stat: {e}"))?;
     let name = path
@@ -2606,6 +2690,8 @@ fn scan_dir_as_gallery(
             status_id: None,
             media_index: None,
             media_quality: None,
+            provenance: crate::wallpaper_source::WallpaperProvenance::empty(),
+            media_fingerprint: None,
         });
     }
     out

--- a/src-tauri/src/wallpaper_x_responses/more.rs
+++ b/src-tauri/src/wallpaper_x_responses/more.rs
@@ -95,6 +95,8 @@ mod tests {
             status_id: Some(status_id.into()),
             media_index: Some(1),
             media_quality: None,
+            provenance: crate::wallpaper_source::WallpaperProvenance::empty(),
+            media_fingerprint: None,
         }
     }
 

--- a/src-tauri/src/wallpaper_x_responses/tests.rs
+++ b/src-tauri/src/wallpaper_x_responses/tests.rs
@@ -187,6 +187,8 @@ fn lane_item(id: &str) -> WallpaperGalleryItem {
         status_id: Some(id.into()),
         media_index: Some(1),
         media_quality: None,
+        provenance: crate::wallpaper_source::WallpaperProvenance::empty(),
+        media_fingerprint: None,
     }
 }
 


### PR DESCRIPTION
## Summary

为 Openverse / Pexels 壁纸来源提供完整 Host 搜索和媒体处理链路。两种来源与 X 搜索隔离；本批只注册后端命令，页面入口下一批单独送审。

- 固定 API 端点、Pexels 凭据只发送到对应端点且拒绝重定向，响应有界读取；查询清理、错误分类、请求 ID 与取消、进度及分批结果事件。
- 每页目标 20 张，Openverse 最多两页候选 / Pexels 40 个候选；并发探测、时间预算、图片签名与尺寸检查、内容去重，保留作者/来源/许可证链接。
- Host 内存分页与缓存（64 条、10 分钟、Pexels 凭据版本隔离）；失败可重试，取消保护缓存读写。明确分页不会自动预取。
- 共用公共 HTTPS 媒体探测、缩略图、下载：逐跳地址验证、有界响应、完整响应检查、来源 Referer、受限解码、取消注册及按来源落盘。
- 补充合成响应、媒体、缓存、取消、并发探测测试与开发文档。现有 X gallery 构造器只增加空来源元数据和内部指纹字段。

本提交自身 14 文件 +3865/-1，其中包含后端测试。依赖 #1088–#1093 的前置链（#1092/#1093 提供缩略图限制与密钥存储）；当前 PR 基于 main 展示包含前置提交，维护者合入后会 rebase 去重。仅本主题审阅请查看最新提交。未新增 App / AppWorkbench 状态。

检索 Openverse/Pexels/wallpaper 的所有状态 Issues，仅发现无直接关系的历史遮罩/布局问题，不使用自动关闭引用。Web 搜索、页面 UI、自动预取、相册、目录和生成各自后续提交，不宣称本 PR 已交付完整来源页面。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Validation

本地验证通过：前端 7,079 项（591 个测试文件）、Rust 1,735 项（另 1 项既有 ignored）；typecheck、lint、build:ui、代码质量门禁、网站自测、依赖检查与生产依赖审计、cargo fmt/clippy 均通过。Windows Rust 测试通过当前产物的 Common Controls manifest harness 实际执行。未执行真实提供商账号请求或手动桌面端到端验收。

## Checklist
- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included