### PR TITLE
feat(wallpaper): 增加许可来源前端协议与缩略图缓存

### DIFF
--- a/src/hooks/useWallpaperRemoteSearch.test.tsx
+++ b/src/hooks/useWallpaperRemoteSearch.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  useWallpaperRemoteSearch,
+  type WallpaperRemoteSearchClient,
+} from "./useWallpaperRemoteSearch";
+import type {
+  WallpaperRemoteSearchBatch,
+  WallpaperRemoteSearchProgress,
+  WallpaperRemoteSearchResult,
+} from "@/lib/wallpaperRemoteSearch";
+
+afterEach(() => cleanup());
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function result(
+  source: "web" | "openverse" | "pexels",
+): WallpaperRemoteSearchResult {
+  return {
+    source,
+    items: [],
+    hasMore: false,
+    cacheHit: false,
+    durationMs: 1,
+  };
+}
+
+function harness() {
+  let progressHandler:
+    | ((progress: WallpaperRemoteSearchProgress) => void)
+    | null = null;
+  let batchHandler: ((batch: WallpaperRemoteSearchBatch) => void) | null = null;
+  const unlisten = vi.fn();
+  const client: WallpaperRemoteSearchClient = {
+    search: vi.fn(),
+    searchMore: vi.fn(),
+    cancel: vi.fn(async () => true),
+    listenProgress: vi.fn(async (handler) => {
+      progressHandler = handler;
+      return unlisten;
+    }),
+    listenBatch: vi.fn(async (handler) => {
+      batchHandler = handler;
+      return unlisten;
+    }),
+  };
+  return {
+    client,
+    progress(value: WallpaperRemoteSearchProgress) {
+      progressHandler?.(value);
+    },
+    batch(value: WallpaperRemoteSearchBatch) {
+      batchHandler?.(value);
+    },
+    unlisten,
+  };
+}
+
+describe("useWallpaperRemoteSearch", () => {
+  it("isolates events by both request id and source", async () => {
+    const pending = deferred<WallpaperRemoteSearchResult>();
+    const test = harness();
+    vi.mocked(test.client.search).mockReturnValue(pending.promise);
+    const hook = renderHook(() =>
+      useWallpaperRemoteSearch(test.client, () => "remote-active"),
+    );
+    act(() => {
+      void hook.result.current.search("web", "mountains");
+    });
+    await waitFor(() => expect(hook.result.current.busy).toBe(true));
+    await waitFor(() => expect(test.client.listenBatch).toHaveBeenCalled());
+
+    act(() => {
+      test.progress({
+        requestId: "remote-active",
+        source: "openverse",
+        stage: "loading_more",
+      });
+      test.batch({
+        requestId: "remote-active",
+        source: "openverse",
+        batchIndex: 1,
+        items: [],
+        accumulatedCount: 0,
+        done: true,
+      });
+    });
+    expect(hook.result.current.stage).toBe("preparing");
+    expect(hook.result.current.progressiveDone).toBe(false);
+
+    act(() => {
+      test.progress({
+        requestId: "remote-active",
+        source: "web",
+        stage: "validating_images",
+      });
+      test.batch({
+        requestId: "remote-active",
+        source: "web",
+        batchIndex: 1,
+        items: [
+          {
+            id: "one",
+            thumbUrl: "https://images.example.test/one.jpg",
+            fullUrl: "https://images.example.test/one.jpg",
+            kind: "image",
+            source: "web",
+          },
+        ],
+        accumulatedCount: 1,
+        done: true,
+      });
+    });
+    expect(hook.result.current.stage).toBe("validating_images");
+    expect(hook.result.current.progressiveItems).toHaveLength(1);
+    expect(hook.result.current.progressiveDone).toBe(true);
+
+    pending.resolve(result("web"));
+    await waitFor(() => expect(hook.result.current.busy).toBe(false));
+  });
+
+  it("cancels a generation and rejects its late result", async () => {
+    const pending = deferred<WallpaperRemoteSearchResult>();
+    const test = harness();
+    vi.mocked(test.client.search).mockReturnValue(pending.promise);
+    const hook = renderHook(() =>
+      useWallpaperRemoteSearch(test.client, () => "remote-cancel"),
+    );
+    let searchPromise!: Promise<WallpaperRemoteSearchResult | null>;
+    act(() => {
+      searchPromise = hook.result.current.search("web", "ocean");
+    });
+    await waitFor(() => expect(hook.result.current.busy).toBe(true));
+    await act(async () => {
+      expect(await hook.result.current.cancel()).toBe(true);
+    });
+    expect(test.client.cancel).toHaveBeenCalledWith("web", "remote-cancel");
+    pending.resolve(result("web"));
+    await expect(searchPromise).resolves.toBeNull();
+  });
+
+  it("cancels the prior source before replacement and cleans up on unmount", async () => {
+    const first = deferred<WallpaperRemoteSearchResult>();
+    const second = deferred<WallpaperRemoteSearchResult>();
+    const test = harness();
+    vi.mocked(test.client.search)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const ids = ["remote-old", "remote-new"];
+    const hook = renderHook(() =>
+      useWallpaperRemoteSearch(
+        test.client,
+        () => ids.shift() ?? "remote-extra",
+      ),
+    );
+    let oldPromise!: Promise<WallpaperRemoteSearchResult | null>;
+    act(() => {
+      oldPromise = hook.result.current.search("web", "old");
+    });
+    await waitFor(() => expect(hook.result.current.busy).toBe(true));
+    act(() => {
+      void hook.result.current.search("openverse", "new");
+    });
+    await waitFor(() =>
+      expect(test.client.cancel).toHaveBeenCalledWith("web", "remote-old"),
+    );
+    second.resolve(result("openverse"));
+    await waitFor(() => expect(hook.result.current.busy).toBe(false));
+    first.resolve(result("web"));
+    await expect(oldPromise).resolves.toBeNull();
+    hook.unmount();
+    expect(test.unlisten).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let an invocation waiting for cancellation replace a newer search", async () => {
+    const first = deferred<WallpaperRemoteSearchResult>();
+    const newest = deferred<WallpaperRemoteSearchResult>();
+    const cancellation = deferred<boolean>();
+    const test = harness();
+    vi.mocked(test.client.search)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(newest.promise);
+    vi.mocked(test.client.cancel).mockReturnValue(cancellation.promise);
+    const ids = ["remote-first", "remote-newest"];
+    const hook = renderHook(() =>
+      useWallpaperRemoteSearch(
+        test.client,
+        () => ids.shift() ?? "remote-unexpected",
+      ),
+    );
+
+    let firstPromise!: Promise<WallpaperRemoteSearchResult | null>;
+    let supersededPromise!: Promise<WallpaperRemoteSearchResult | null>;
+    let newestPromise!: Promise<WallpaperRemoteSearchResult | null>;
+    act(() => {
+      firstPromise = hook.result.current.search("web", "first");
+    });
+    await waitFor(() => expect(hook.result.current.busy).toBe(true));
+    act(() => {
+      supersededPromise = hook.result.current.search("openverse", "superseded");
+    });
+    await waitFor(() =>
+      expect(test.client.cancel).toHaveBeenCalledWith("web", "remote-first"),
+    );
+    act(() => {
+      newestPromise = hook.result.current.search("pexels", "newest");
+    });
+    await waitFor(() => expect(test.client.search).toHaveBeenCalledTimes(2));
+    expect(test.client.search).toHaveBeenLastCalledWith(
+      "pexels",
+      "newest",
+      "remote-newest",
+    );
+
+    await act(async () => cancellation.resolve(true));
+    await expect(supersededPromise).resolves.toBeNull();
+    expect(test.client.search).toHaveBeenCalledTimes(2);
+
+    newest.resolve(result("pexels"));
+    await expect(newestPromise).resolves.toEqual(result("pexels"));
+    first.resolve(result("web"));
+    await expect(firstPromise).resolves.toBeNull();
+  });
+});

--- a/src/hooks/useWallpaperRemoteSearch.ts
+++ b/src/hooks/useWallpaperRemoteSearch.ts
@@ -1,0 +1,304 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import * as api from "@/lib/api";
+import {
+  createWallpaperRemoteSearchRequestId,
+  isWallpaperRemoteSearchBatch,
+  isWallpaperRemoteSearchProgress,
+  type WallpaperRemoteSearchBatch,
+  type WallpaperRemoteSearchProgress,
+  type WallpaperRemoteSearchResult,
+  type WallpaperRemoteSearchStage,
+  type WallpaperRemoteSource,
+} from "@/lib/wallpaperRemoteSearch";
+import {
+  dedupeGalleryItems,
+  type WallpaperGalleryItem,
+} from "@/lib/wallpaperSource";
+
+export type WallpaperRemoteSearchClient = {
+  search: (
+    source: WallpaperRemoteSource,
+    query: string,
+    requestId: string,
+  ) => Promise<WallpaperRemoteSearchResult>;
+  searchMore: (
+    source: WallpaperRemoteSource,
+    query: string,
+    requestId: string,
+  ) => Promise<WallpaperRemoteSearchResult>;
+  cancel: (
+    source: WallpaperRemoteSource,
+    requestId: string,
+  ) => Promise<boolean>;
+  listenProgress: (
+    handler: (progress: WallpaperRemoteSearchProgress) => void,
+  ) => Promise<() => void>;
+  listenBatch: (
+    handler: (batch: WallpaperRemoteSearchBatch) => void,
+  ) => Promise<() => void>;
+};
+
+const DEFAULT_CLIENT: WallpaperRemoteSearchClient = {
+  search: api.wallpaperRemoteSearch,
+  searchMore: api.wallpaperRemoteSearchMore,
+  cancel: api.wallpaperRemoteSearchCancel,
+  listenProgress: api.listenWallpaperRemoteSearchProgress,
+  listenBatch: api.listenWallpaperRemoteSearchBatch,
+};
+
+type ActiveRequest = {
+  source: WallpaperRemoteSource;
+  requestId: string;
+};
+
+type ProgressiveState = {
+  items: WallpaperGalleryItem[];
+  accumulatedCount: number;
+  done: boolean;
+  seenBatchIndexes: ReadonlySet<number>;
+};
+
+type ProgressiveAction =
+  | { type: "reset" }
+  | { type: "batch"; batch: WallpaperRemoteSearchBatch };
+
+const EMPTY_PROGRESSIVE: ProgressiveState = {
+  items: [],
+  accumulatedCount: 0,
+  done: false,
+  seenBatchIndexes: new Set(),
+};
+
+function progressiveReducer(
+  state: ProgressiveState,
+  action: ProgressiveAction,
+): ProgressiveState {
+  if (action.type === "reset") return EMPTY_PROGRESSIVE;
+  const { batch } = action;
+  if (state.seenBatchIndexes.has(batch.batchIndex)) {
+    return batch.done && !state.done ? { ...state, done: true } : state;
+  }
+  const seenBatchIndexes = new Set(state.seenBatchIndexes);
+  seenBatchIndexes.add(batch.batchIndex);
+  const items = dedupeGalleryItems([...state.items, ...batch.items]);
+  return {
+    items,
+    accumulatedCount: Math.max(
+      state.accumulatedCount,
+      batch.accumulatedCount,
+      items.length,
+    ),
+    done: state.done || batch.done,
+    seenBatchIndexes,
+  };
+}
+
+export type UseWallpaperRemoteSearchResult = {
+  busy: boolean;
+  source: WallpaperRemoteSource | null;
+  requestId: string | null;
+  stage: WallpaperRemoteSearchStage | null;
+  progressiveItems: WallpaperGalleryItem[];
+  progressiveCount: number;
+  progressiveDone: boolean;
+  search: (
+    source: WallpaperRemoteSource,
+    query: string,
+  ) => Promise<WallpaperRemoteSearchResult | null>;
+  loadMore: (
+    source: WallpaperRemoteSource,
+    query: string,
+  ) => Promise<WallpaperRemoteSearchResult | null>;
+  cancel: () => Promise<boolean>;
+};
+
+export function useWallpaperRemoteSearch(
+  client: WallpaperRemoteSearchClient = DEFAULT_CLIENT,
+  requestIdFactory: () => string = createWallpaperRemoteSearchRequestId,
+): UseWallpaperRemoteSearchResult {
+  const [busy, setBusy] = useState(false);
+  const [activeSource, setActiveSource] =
+    useState<WallpaperRemoteSource | null>(null);
+  const [requestId, setRequestId] = useState<string | null>(null);
+  const [stage, setStage] = useState<WallpaperRemoteSearchStage | null>(null);
+  const [progressive, dispatchProgressive] = useReducer(
+    progressiveReducer,
+    EMPTY_PROGRESSIVE,
+  );
+  const activeRef = useRef<ActiveRequest | null>(null);
+  const generationRef = useRef(0);
+  const invocationRef = useRef(0);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlistenProgress: (() => void) | null = null;
+    let unlistenBatch: (() => void) | null = null;
+    void client
+      .listenProgress((progress) => {
+        const active = activeRef.current;
+        if (
+          !isWallpaperRemoteSearchProgress(progress) ||
+          !active ||
+          progress.requestId !== active.requestId ||
+          progress.source !== active.source ||
+          !mountedRef.current
+        ) {
+          return;
+        }
+        setStage(progress.stage);
+      })
+      .then((cleanup) => {
+        if (disposed) cleanup();
+        else unlistenProgress = cleanup;
+      })
+      .catch(() => undefined);
+    void client
+      .listenBatch((batch) => {
+        const active = activeRef.current;
+        if (
+          !isWallpaperRemoteSearchBatch(batch) ||
+          !active ||
+          batch.requestId !== active.requestId ||
+          batch.source !== active.source ||
+          !mountedRef.current
+        ) {
+          return;
+        }
+        dispatchProgressive({ type: "batch", batch });
+      })
+      .then((cleanup) => {
+        if (disposed) cleanup();
+        else unlistenBatch = cleanup;
+      })
+      .catch(() => undefined);
+    return () => {
+      disposed = true;
+      unlistenProgress?.();
+      unlistenBatch?.();
+    };
+  }, [client]);
+
+  const clearUi = useCallback(() => {
+    if (!mountedRef.current) return;
+    setBusy(false);
+    setActiveSource(null);
+    setRequestId(null);
+    setStage(null);
+    dispatchProgressive({ type: "reset" });
+  }, []);
+
+  const cancelActive = useCallback(async (): Promise<boolean> => {
+    const active = activeRef.current;
+    if (!active) return false;
+    generationRef.current += 1;
+    activeRef.current = null;
+    clearUi();
+    try {
+      return await client.cancel(active.source, active.requestId);
+    } catch {
+      return false;
+    }
+  }, [clearUi, client]);
+
+  const cancel = useCallback((): Promise<boolean> => {
+    invocationRef.current += 1;
+    return cancelActive();
+  }, [cancelActive]);
+
+  const run = useCallback(
+    async (
+      operation: "initial" | "more",
+      source: WallpaperRemoteSource,
+      query: string,
+    ): Promise<WallpaperRemoteSearchResult | null> => {
+      const invocation = invocationRef.current + 1;
+      invocationRef.current = invocation;
+      if (activeRef.current) await cancelActive();
+      if (!mountedRef.current || invocationRef.current !== invocation) {
+        return null;
+      }
+      const nextRequestId = requestIdFactory();
+      const generation = generationRef.current + 1;
+      generationRef.current = generation;
+      activeRef.current = { source, requestId: nextRequestId };
+      if (mountedRef.current) {
+        setBusy(true);
+        setActiveSource(source);
+        setRequestId(nextRequestId);
+        setStage("preparing");
+        dispatchProgressive({ type: "reset" });
+      }
+      try {
+        const result = await (operation === "more"
+          ? client.searchMore(source, query, nextRequestId)
+          : client.search(source, query, nextRequestId));
+        if (
+          generationRef.current !== generation ||
+          activeRef.current?.requestId !== nextRequestId ||
+          activeRef.current.source !== source ||
+          result.source !== source
+        ) {
+          return null;
+        }
+        return result;
+      } catch (error) {
+        if (
+          generationRef.current !== generation ||
+          activeRef.current?.requestId !== nextRequestId
+        ) {
+          return null;
+        }
+        throw error;
+      } finally {
+        if (
+          generationRef.current === generation &&
+          activeRef.current?.requestId === nextRequestId
+        ) {
+          activeRef.current = null;
+          clearUi();
+        }
+      }
+    },
+    [cancelActive, clearUi, client, requestIdFactory],
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      invocationRef.current += 1;
+      generationRef.current += 1;
+      const active = activeRef.current;
+      activeRef.current = null;
+      if (active) {
+        void client.cancel(active.source, active.requestId).catch(() => false);
+      }
+    };
+  }, [client]);
+
+  const search = useCallback(
+    (source: WallpaperRemoteSource, query: string) =>
+      run("initial", source, query),
+    [run],
+  );
+
+  const loadMore = useCallback(
+    (source: WallpaperRemoteSource, query: string) =>
+      run("more", source, query),
+    [run],
+  );
+
+  return {
+    busy,
+    source: activeSource,
+    requestId,
+    stage,
+    progressiveItems: progressive.items,
+    progressiveCount: progressive.accumulatedCount,
+    progressiveDone: progressive.done,
+    search,
+    loadMore,
+    cancel,
+  };
+}

--- a/src/lib/api/wallpaper.ts
+++ b/src/lib/api/wallpaper.ts
@@ -1,3 +1,10 @@
+import type {
+  WallpaperRemoteSearchBatch,
+  WallpaperRemoteSearchProgress,
+  WallpaperRemoteSearchResult,
+  WallpaperRemoteSource,
+  WallpaperRemoteThumbnail,
+} from "../wallpaperRemoteSearch";
 /** API domain: wallpaper */
 
 import {
@@ -167,4 +174,92 @@ export async function listenWallpaperXSearchBatch(
 
 export async function wallpaperXSearchMore(continuationId: string, requestId: string): Promise<WallpaperSearchResult> {
   return invoke<WallpaperSearchResult>("wallpaper_x_search_more", { continuationId, requestId });
+}
+
+export async function wallpaperRemoteSearch(
+  source: WallpaperRemoteSource,
+  query: string,
+  requestId?: string,
+): Promise<WallpaperRemoteSearchResult> {
+  return invoke<WallpaperRemoteSearchResult>("wallpaper_remote_search", {
+    source,
+    query,
+    requestId: requestId ?? null,
+  });
+}
+
+export async function wallpaperRemoteSearchMore(
+  source: WallpaperRemoteSource,
+  query: string,
+  requestId?: string,
+): Promise<WallpaperRemoteSearchResult> {
+  return invoke<WallpaperRemoteSearchResult>("wallpaper_remote_search_more", {
+    source,
+    query,
+    requestId: requestId ?? null,
+  });
+}
+
+export async function wallpaperRemoteSearchCancel(
+  source: WallpaperRemoteSource,
+  requestId: string,
+): Promise<boolean> {
+  return invoke<boolean>("wallpaper_remote_search_cancel", {
+    source,
+    requestId,
+  });
+}
+
+export function listenWallpaperRemoteSearchProgress(
+  handler: (progress: WallpaperRemoteSearchProgress) => void,
+): Promise<() => void> {
+  return listen<WallpaperRemoteSearchProgress>(
+    "wallpaper://remote-search-progress",
+    handler,
+  );
+}
+
+export function listenWallpaperRemoteSearchBatch(
+  handler: (batch: WallpaperRemoteSearchBatch) => void,
+): Promise<() => void> {
+  return listen<WallpaperRemoteSearchBatch>(
+    "wallpaper://remote-search-batch",
+    handler,
+  );
+}
+
+export async function wallpaperRemoteFetchMedia(
+  source: WallpaperRemoteSource,
+  url: string,
+  requestId: string,
+): Promise<WallpaperFetchResult> {
+  return invoke<WallpaperFetchResult>("wallpaper_remote_fetch_media", {
+    source,
+    url,
+    requestId,
+  });
+}
+
+export async function wallpaperRemoteThumbnail(
+  source: WallpaperRemoteSource,
+  url: string,
+  requestId: string,
+): Promise<WallpaperRemoteThumbnail> {
+  return invoke<WallpaperRemoteThumbnail>("wallpaper_remote_thumbnail", {
+    source,
+    url,
+    requestId,
+  });
+}
+
+export async function wallpaperRemoteCancelMediaRequests(
+  requestIds: string[],
+): Promise<number> {
+  return invoke<number>("wallpaper_remote_cancel_media_requests", {
+    requestIds,
+  });
+}
+
+export async function wallpaperRemoteCancelAllMediaRequests(): Promise<number> {
+  return invoke<number>("wallpaper_remote_cancel_all_media_requests");
 }

--- a/src/lib/remoteWallpaperThumbnail.test.ts
+++ b/src/lib/remoteWallpaperThumbnail.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WallpaperGalleryItem } from "./wallpaperSource";
+
+const fetchThumbnail = vi.hoisted(() => vi.fn());
+const cancelThumbnails = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({
+  wallpaperRemoteThumbnail: fetchThumbnail,
+  wallpaperRemoteCancelMediaRequests: cancelThumbnails,
+}));
+
+import {
+  clearRemoteWallpaperThumbnailCache,
+  peekRemoteWallpaperThumbnail,
+  remoteWallpaperThumbnailQueueState,
+  resolveRemoteWallpaperThumbnail,
+} from "./remoteWallpaperThumbnail";
+
+const DATA_URL = `data:image/jpeg;base64,${"A".repeat(64)}`;
+const ITEM: WallpaperGalleryItem = {
+  id: "web-image",
+  thumbUrl: "https://cdn.example.test/photo.jpg",
+  fullUrl: "https://cdn.example.test/photo.jpg",
+  kind: "image",
+  source: "web",
+  sourceUrl: "https://photos.example.test/gallery/item",
+};
+
+beforeEach(() => {
+  clearRemoteWallpaperThumbnailCache();
+  fetchThumbnail.mockReset();
+  cancelThumbnails.mockReset();
+  cancelThumbnails.mockResolvedValue(0);
+});
+
+afterEach(() => {
+  clearRemoteWallpaperThumbnailCache();
+});
+
+describe("remote wallpaper thumbnail delivery", () => {
+  it("uses the Host once and keeps only the bounded data URL in memory", async () => {
+    fetchThumbnail.mockResolvedValue({
+      dataUrl: DATA_URL,
+      width: 1920,
+      height: 1080,
+    });
+
+    await expect(resolveRemoteWallpaperThumbnail(ITEM)).resolves.toBe(DATA_URL);
+    await expect(resolveRemoteWallpaperThumbnail(ITEM)).resolves.toBe(DATA_URL);
+
+    expect(fetchThumbnail).toHaveBeenCalledTimes(1);
+    expect(fetchThumbnail).toHaveBeenCalledWith(
+      "web",
+      "https://cdn.example.test/photo.jpg",
+      expect.stringMatching(/^[0-9a-f-]{36}$/),
+    );
+    expect(peekRemoteWallpaperThumbnail(ITEM)).toBe(DATA_URL);
+    expect(remoteWallpaperThumbnailQueueState().cached).toBe(1);
+  });
+
+  it("rejects unsafe media URLs before invoking the Host", async () => {
+    await expect(
+      resolveRemoteWallpaperThumbnail({
+        ...ITEM,
+        thumbUrl: "http://cdn.example.test/photo.jpg",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      resolveRemoteWallpaperThumbnail({
+        ...ITEM,
+        thumbUrl: "https://user:secret@cdn.example.test/photo.jpg",
+      }),
+    ).resolves.toBeNull();
+    expect(fetchThumbnail).not.toHaveBeenCalled();
+  });
+
+  it("does not cache malformed Host payloads", async () => {
+    fetchThumbnail.mockResolvedValue({
+      dataUrl: "https://cdn.example.test/not-inline.jpg",
+      width: 1920,
+      height: 1080,
+    });
+
+    await expect(resolveRemoteWallpaperThumbnail(ITEM)).resolves.toBeNull();
+    expect(remoteWallpaperThumbnailQueueState().cached).toBe(0);
+  });
+
+  it("normalizes fragments out of the source-scoped cache key", async () => {
+    fetchThumbnail.mockResolvedValue({
+      dataUrl: DATA_URL,
+      width: 1920,
+      height: 1080,
+    });
+
+    await resolveRemoteWallpaperThumbnail({
+      ...ITEM,
+      thumbUrl: `${ITEM.thumbUrl}#preview`,
+    });
+    await resolveRemoteWallpaperThumbnail(ITEM);
+
+    expect(fetchThumbnail).toHaveBeenCalledTimes(1);
+    expect(fetchThumbnail).toHaveBeenCalledWith(
+      "web",
+      ITEM.thumbUrl,
+      expect.stringMatching(/^[0-9a-f-]{36}$/),
+    );
+  });
+});

--- a/src/lib/remoteWallpaperThumbnail.ts
+++ b/src/lib/remoteWallpaperThumbnail.ts
@@ -1,0 +1,98 @@
+import * as api from "@/lib/api";
+import {
+  isWallpaperRemoteSource,
+  type WallpaperRemoteSource,
+} from "@/lib/wallpaperRemoteSearch";
+import type { WallpaperGalleryItem } from "@/lib/wallpaperSource";
+import { createWallpaperThumbnailCache } from "@/lib/wallpaperThumbnailCache";
+
+const thumbnails = createWallpaperThumbnailCache({
+  cancelRequests: api.wallpaperRemoteCancelMediaRequests,
+});
+
+type RemoteThumbnailInput = Pick<
+  WallpaperGalleryItem,
+  "source" | "thumbUrl" | "fullUrl"
+>;
+
+type RemoteThumbnailTarget = {
+  key: string;
+  source: WallpaperRemoteSource;
+  url: string;
+};
+
+function safeHttpsUrl(raw: string | null | undefined): string | null {
+  const value = raw?.trim();
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== "https:" ||
+      url.username ||
+      url.password ||
+      (url.port && url.port !== "443")
+    ) {
+      return null;
+    }
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function targetFor(input: RemoteThumbnailInput): RemoteThumbnailTarget | null {
+  if (!isWallpaperRemoteSource(input.source)) return null;
+  const url = safeHttpsUrl(input.thumbUrl || input.fullUrl);
+  if (!url) return null;
+  return {
+    source: input.source,
+    url,
+    key: `${input.source}\u0000${url}`,
+  };
+}
+
+export function peekRemoteWallpaperThumbnail(
+  input: RemoteThumbnailInput,
+): string | null {
+  const target = targetFor(input);
+  return target ? thumbnails.peek(target.key) : null;
+}
+
+export function subscribeRemoteWallpaperThumbnail(
+  input: RemoteThumbnailInput,
+  listener: () => void,
+): () => void {
+  const target = targetFor(input);
+  return target ? thumbnails.subscribe(target.key, listener) : () => undefined;
+}
+
+export function resolveRemoteWallpaperThumbnail(
+  input: RemoteThumbnailInput,
+): Promise<string | null> {
+  const target = targetFor(input);
+  if (!target) return Promise.resolve(null);
+  return thumbnails.resolve(target.key, (requestId) =>
+    api.wallpaperRemoteThumbnail(target.source, target.url, requestId),
+  );
+}
+
+export function forgetRemoteWallpaperThumbnail(
+  input: RemoteThumbnailInput,
+): void {
+  const target = targetFor(input);
+  if (target) thumbnails.forget(target.key);
+}
+
+export function clearRemoteWallpaperThumbnailCache(): void {
+  thumbnails.clear();
+}
+
+/** Test helper. */
+export function remoteWallpaperThumbnailQueueState(): {
+  active: number;
+  queued: number;
+  cached: number;
+} {
+  return thumbnails.state();
+}

--- a/src/lib/wallpaperRemoteSearch.test.ts
+++ b/src/lib/wallpaperRemoteSearch.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  createWallpaperRemoteSearchRequestId,
+  isWallpaperRemoteSearchBatch,
+  isWallpaperRemoteSearchProgress,
+  isWallpaperRemoteSource,
+  wallpaperRemoteProgressMessageKey,
+  wallpaperRemoteUiError,
+} from "./wallpaperRemoteSearch";
+
+describe("wallpaper remote search contract", () => {
+  it("strictly enumerates independent remote sources", () => {
+    expect(isWallpaperRemoteSource("web")).toBe(true);
+    expect(isWallpaperRemoteSource("openverse")).toBe(true);
+    expect(isWallpaperRemoteSource("pexels")).toBe(true);
+    expect(isWallpaperRemoteSource("x")).toBe(false);
+    expect(isWallpaperRemoteSource("https://example.test")).toBe(false);
+  });
+
+  it("accepts only matching source progress and batches", () => {
+    const requestId = createWallpaperRemoteSearchRequestId();
+    expect(
+      isWallpaperRemoteSearchProgress({
+        requestId,
+        source: "web",
+        stage: "fetching_sources",
+      }),
+    ).toBe(true);
+    expect(
+      isWallpaperRemoteSearchProgress({
+        requestId,
+        source: "web",
+        stage: "searching_x",
+      }),
+    ).toBe(false);
+
+    const item = {
+      id: "web-image",
+      thumbUrl: "https://images.example.test/thumb.jpg",
+      fullUrl: "https://images.example.test/full.jpg",
+      kind: "image",
+      source: "web",
+      sourceUrl: "https://example.test/photo",
+      sourceName: "example.test",
+    };
+    expect(
+      isWallpaperRemoteSearchBatch({
+        requestId,
+        source: "web",
+        batchIndex: 1,
+        items: [item],
+        accumulatedCount: 1,
+        done: false,
+      }),
+    ).toBe(true);
+    expect(
+      isWallpaperRemoteSearchBatch({
+        requestId,
+        source: "openverse",
+        batchIndex: 1,
+        items: [item],
+        accumulatedCount: 1,
+        done: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("maps stable Host errors without exposing protocol details", () => {
+    const result = {
+      source: "web" as const,
+      items: [],
+      hasMore: false,
+      cacheHit: false,
+      durationMs: 1,
+    };
+    expect(
+      wallpaperRemoteUiError({ ...result, errorCode: "oauth_expired" }),
+    ).toBe("auth_required");
+    expect(
+      wallpaperRemoteUiError({
+        ...result,
+        errorCode: "responses_rate_limited",
+      }),
+    ).toBe("rate_limited");
+    expect(
+      wallpaperRemoteUiError({ ...result, errorCode: "responses_network" }),
+    ).toBe("search_failed");
+    expect(
+      wallpaperRemoteUiError({ ...result, errorCode: "pexels_key_missing" }),
+    ).toBe("pexels_key_required");
+    expect(
+      wallpaperRemoteUiError({ ...result, errorCode: "pexels_key_invalid" }),
+    ).toBe("pexels_key_invalid");
+    expect(
+      wallpaperRemoteUiError({
+        ...result,
+        errorCode: "responses_tool_budget_exceeded",
+      }),
+    ).toBe("service_unavailable");
+    expect(
+      wallpaperRemoteUiError({ ...result, errorCode: "responses_protocol" }),
+    ).toBe("service_unavailable");
+    expect(wallpaperRemoteUiError({ ...result, errorCode: "empty" })).toBe(
+      "empty",
+    );
+    expect(
+      wallpaperRemoteUiError({
+        ...result,
+        items: [
+          {
+            id: "one",
+            thumbUrl: "https://images.example.test/one.jpg",
+            fullUrl: "https://images.example.test/one.jpg",
+            kind: "image",
+            source: "web",
+          },
+        ],
+        errorCode: "responses_network",
+      }),
+    ).toBeNull();
+  });
+
+  it("maps only visible progress stages to copy", () => {
+    expect(wallpaperRemoteProgressMessageKey("searching_web")).toBe(
+      "settings.wallpaperSource.remote.progress.searchingWeb",
+    );
+    expect(wallpaperRemoteProgressMessageKey("done")).toBeNull();
+  });
+});

--- a/src/lib/wallpaperRemoteSearch.ts
+++ b/src/lib/wallpaperRemoteSearch.ts
@@ -1,0 +1,203 @@
+import type { WallpaperGalleryItem } from "./wallpaperSource";
+import { createWallpaperRequestId } from "./wallpaperRequest";
+
+export const WALLPAPER_REMOTE_SOURCES = [
+  "web",
+  "openverse",
+  "pexels",
+] as const;
+
+export type WallpaperRemoteSource = (typeof WALLPAPER_REMOTE_SOURCES)[number];
+
+export const WALLPAPER_REMOTE_SEARCH_STAGES = [
+  "preparing",
+  "searching_web",
+  "searching_provider",
+  "fetching_sources",
+  "validating_images",
+  "loading_more",
+  "done",
+] as const;
+
+export type WallpaperRemoteSearchStage =
+  (typeof WALLPAPER_REMOTE_SEARCH_STAGES)[number];
+
+export type WallpaperRemoteSearchResult = {
+  source: WallpaperRemoteSource;
+  items: WallpaperGalleryItem[];
+  errorCode?: string | null;
+  message?: string | null;
+  hasMore: boolean;
+  cacheHit: boolean;
+  durationMs: number;
+};
+
+export type WallpaperRemoteThumbnail = {
+  dataUrl: string;
+  width: number;
+  height: number;
+};
+
+export type WallpaperRemoteSearchProgress = {
+  requestId: string;
+  source: WallpaperRemoteSource;
+  stage: WallpaperRemoteSearchStage;
+};
+
+export type WallpaperRemoteSearchBatch = {
+  requestId: string;
+  source: WallpaperRemoteSource;
+  batchIndex: number;
+  items: WallpaperGalleryItem[];
+  accumulatedCount: number;
+  done: boolean;
+};
+
+export function createWallpaperRemoteSearchRequestId(): string {
+  return createWallpaperRequestId();
+}
+
+export function isWallpaperRemoteSource(
+  value: unknown,
+): value is WallpaperRemoteSource {
+  return WALLPAPER_REMOTE_SOURCES.includes(value as WallpaperRemoteSource);
+}
+
+function isGalleryItem(value: unknown): value is WallpaperGalleryItem {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<WallpaperGalleryItem>;
+  return (
+    typeof item.id === "string" &&
+    item.id.length > 0 &&
+    typeof item.thumbUrl === "string" &&
+    item.thumbUrl.length > 0 &&
+    typeof item.fullUrl === "string" &&
+    item.fullUrl.length > 0 &&
+    typeof item.kind === "string" &&
+    item.kind.length > 0 &&
+    isWallpaperRemoteSource(item.source)
+  );
+}
+
+export function isWallpaperRemoteSearchProgress(
+  value: unknown,
+): value is WallpaperRemoteSearchProgress {
+  if (!value || typeof value !== "object") return false;
+  const progress = value as Partial<WallpaperRemoteSearchProgress>;
+  return (
+    typeof progress.requestId === "string" &&
+    progress.requestId.length > 0 &&
+    isWallpaperRemoteSource(progress.source) &&
+    WALLPAPER_REMOTE_SEARCH_STAGES.includes(
+      progress.stage as WallpaperRemoteSearchStage,
+    )
+  );
+}
+
+export function isWallpaperRemoteSearchBatch(
+  value: unknown,
+): value is WallpaperRemoteSearchBatch {
+  if (!value || typeof value !== "object") return false;
+  const batch = value as Partial<WallpaperRemoteSearchBatch>;
+  return (
+    typeof batch.requestId === "string" &&
+    batch.requestId.length > 0 &&
+    isWallpaperRemoteSource(batch.source) &&
+    Number.isInteger(batch.batchIndex) &&
+    (batch.batchIndex ?? 0) >= 1 &&
+    Array.isArray(batch.items) &&
+    batch.items.every(
+      (item) => isGalleryItem(item) && item.source === batch.source,
+    ) &&
+    Number.isInteger(batch.accumulatedCount) &&
+    (batch.accumulatedCount ?? -1) >= batch.items.length &&
+    typeof batch.done === "boolean"
+  );
+}
+
+export type WallpaperRemoteProgressMessageKey =
+  | "settings.wallpaperSource.remote.progress.preparing"
+  | "settings.wallpaperSource.remote.progress.searchingWeb"
+  | "settings.wallpaperSource.remote.progress.searchingOpenverse"
+  | "settings.wallpaperSource.remote.progress.searchingPexels"
+  | "settings.wallpaperSource.remote.progress.fetchingSources"
+  | "settings.wallpaperSource.remote.progress.validatingImages"
+  | "settings.wallpaperSource.remote.progress.loadingMore";
+
+export function wallpaperRemoteProgressMessageKey(
+  stage: WallpaperRemoteSearchStage | null | undefined,
+  source?: WallpaperRemoteSource | null,
+): WallpaperRemoteProgressMessageKey | null {
+  switch (stage) {
+    case "preparing":
+      return "settings.wallpaperSource.remote.progress.preparing";
+    case "searching_web":
+      return "settings.wallpaperSource.remote.progress.searchingWeb";
+    case "searching_provider":
+      return source === "pexels"
+        ? "settings.wallpaperSource.remote.progress.searchingPexels"
+        : "settings.wallpaperSource.remote.progress.searchingOpenverse";
+    case "fetching_sources":
+      return "settings.wallpaperSource.remote.progress.fetchingSources";
+    case "validating_images":
+      return "settings.wallpaperSource.remote.progress.validatingImages";
+    case "loading_more":
+      return "settings.wallpaperSource.remote.progress.loadingMore";
+    default:
+      return null;
+  }
+}
+
+export type WallpaperRemoteUiError =
+  | "auth_required"
+  | "pexels_key_required"
+  | "pexels_key_invalid"
+  | "rate_limited"
+  | "timeout"
+  | "empty"
+  | "search_failed"
+  | "service_unavailable"
+  | "generic";
+
+export function wallpaperRemoteUiError(
+  result: WallpaperRemoteSearchResult,
+): WallpaperRemoteUiError | null {
+  if (result.items.length > 0) return null;
+  const code = (result.errorCode ?? "").trim().toLowerCase();
+  if (!code || code === "empty" || code === "responses_empty") return "empty";
+  if (
+    code === "oauth_unavailable" ||
+    code === "oauth_expired" ||
+    code === "responses_unauthorized"
+  ) {
+    return "auth_required";
+  }
+  if (code === "pexels_key_missing") return "pexels_key_required";
+  if (code === "pexels_key_invalid") return "pexels_key_invalid";
+  if (code === "responses_rate_limited" || code === "provider_rate_limited") {
+    return "rate_limited";
+  }
+  if (code === "responses_timeout" || code === "provider_timeout") {
+    return "timeout";
+  }
+  if (
+    code === "responses_network" ||
+    code === "responses_tls" ||
+    code === "provider_network"
+  ) {
+    return "search_failed";
+  }
+  if (
+    code === "responses_server_error" ||
+    code === "responses_bad_request" ||
+    code === "responses_invalid_json" ||
+    code === "responses_protocol" ||
+    code === "responses_tool_not_called" ||
+    code === "responses_tool_budget_exceeded" ||
+    code === "provider_service_unavailable" ||
+    code === "provider_protocol"
+  ) {
+    return "service_unavailable";
+  }
+  return "generic";
+}

--- a/src/lib/wallpaperRequest.ts
+++ b/src/lib/wallpaperRequest.ts
@@ -1,0 +1,17 @@
+/** Create an RFC 4122 v4 request id without depending on a package runtime. */
+export function createWallpaperRequestId(): string {
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256);
+    }
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (value) =>
+    value.toString(16).padStart(2, "0"),
+  ).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/src/lib/wallpaperSource.ts
+++ b/src/lib/wallpaperSource.ts
@@ -18,6 +18,12 @@ export type WallpaperGalleryItem = {
   likes?: number | null;
   localPath?: string | null;
   prompt?: string | null;
+  sourceUrl?: string | null;
+  sourceName?: string | null;
+  authorName?: string | null;
+  authorUrl?: string | null;
+  license?: string | null;
+  licenseUrl?: string | null;
 };
 
 export type WallpaperSearchResult = {
@@ -51,6 +57,9 @@ export type WallpaperLibraryEntry = {
 };
 
 export type WallpaperSourceErrorCode =
+  | "pexels_key_required"
+  | "pexels_key_invalid"
+  | "service_unavailable"
   | "rate_limited"
   | "auth_required"
   | "cli_missing"
@@ -143,9 +152,9 @@ export function appendWallpaperGalleryItems(
   existing: WallpaperGalleryItem[],
   incoming: WallpaperGalleryItem[],
 ): WallpaperGalleryItem[] {
-  const ids = new Set(existing.map(item => `${item.source}:${item.id}`));
-  const urls = new Set(existing.map(item => item.fullUrl));
-  const fresh = incoming.filter(item => {
+  const ids = new Set(existing.map((item) => `${item.source}:${item.id}`));
+  const urls = new Set(existing.map((item) => item.fullUrl));
+  const fresh = incoming.filter((item) => {
     const id = `${item.source}:${item.id}`;
     if (ids.has(id) || urls.has(item.fullUrl)) return false;
     ids.add(id);

--- a/src/lib/wallpaperThumbnailCache.ts
+++ b/src/lib/wallpaperThumbnailCache.ts
@@ -1,0 +1,231 @@
+import { createWallpaperRequestId } from "@/lib/wallpaperRequest";
+
+export type WallpaperThumbnailPayload = {
+  dataUrl: string;
+  width: number;
+  height: number;
+};
+
+type CacheListener = () => void;
+
+type QueueJob = {
+  revision: number;
+  run: () => void;
+  cancel: () => void;
+};
+
+export type WallpaperThumbnailCacheOptions = {
+  cancelRequests: (requestIds: string[]) => Promise<number>;
+  maxConcurrent?: number;
+  maxEntries?: number;
+  maxDataUrlLength?: number;
+  failureCooldownMs?: number;
+};
+
+export type WallpaperThumbnailCache = {
+  peek: (key: string) => string | null;
+  subscribe: (key: string, listener: CacheListener) => () => void;
+  resolve: (
+    key: string,
+    load: (requestId: string) => Promise<WallpaperThumbnailPayload>,
+  ) => Promise<string | null>;
+  forget: (key: string) => void;
+  clear: () => void;
+  state: () => { active: number; queued: number; cached: number };
+};
+
+const DEFAULT_MAX_CONCURRENT = 4;
+const DEFAULT_MAX_ENTRIES = 80;
+const DEFAULT_MAX_DATA_URL_LENGTH = 768 * 1024;
+const DEFAULT_FAILURE_COOLDOWN_MS = 15_000;
+
+function validThumbnailResult(
+  input: WallpaperThumbnailPayload,
+  maxDataUrlLength: number,
+): boolean {
+  return (
+    typeof input?.dataUrl === "string" &&
+    input.dataUrl.length > "data:image/jpeg;base64,".length &&
+    input.dataUrl.length <= maxDataUrlLength &&
+    input.dataUrl.startsWith("data:image/jpeg;base64,") &&
+    Number.isFinite(input.width) &&
+    input.width > 0 &&
+    Number.isFinite(input.height) &&
+    input.height > 0
+  );
+}
+
+export function createWallpaperThumbnailCache({
+  cancelRequests,
+  maxConcurrent = DEFAULT_MAX_CONCURRENT,
+  maxEntries = DEFAULT_MAX_ENTRIES,
+  maxDataUrlLength = DEFAULT_MAX_DATA_URL_LENGTH,
+  failureCooldownMs = DEFAULT_FAILURE_COOLDOWN_MS,
+}: WallpaperThumbnailCacheOptions): WallpaperThumbnailCache {
+  const resolved = new Map<string, string>();
+  const pending = new Map<string, Promise<string | null>>();
+  const failedUntil = new Map<string, number>();
+  const queue: QueueJob[] = [];
+  const activeRequestIds = new Set<string>();
+  const listeners = new Map<string, Set<CacheListener>>();
+  let activeJobs = 0;
+  let revision = 0;
+
+  const notify = (key: string) => {
+    for (const listener of Array.from(listeners.get(key) ?? [])) listener();
+  };
+
+  const remember = (key: string, dataUrl: string, shouldNotify = true) => {
+    const changed = resolved.get(key) !== dataUrl;
+    resolved.delete(key);
+    resolved.set(key, dataUrl);
+    while (resolved.size > maxEntries) {
+      const oldest = resolved.keys().next().value as string | undefined;
+      if (!oldest) break;
+      resolved.delete(oldest);
+    }
+    if (shouldNotify && changed) notify(key);
+  };
+
+  const peek = (key: string): string | null => {
+    const normalized = key.trim();
+    const hit = resolved.get(normalized);
+    if (!hit) return null;
+    remember(normalized, hit, false);
+    return hit;
+  };
+
+  const pumpQueue = () => {
+    while (activeJobs < maxConcurrent && queue.length > 0) {
+      const job = queue.shift();
+      if (!job) return;
+      if (job.revision !== revision) {
+        job.cancel();
+        continue;
+      }
+      activeJobs += 1;
+      job.run();
+    }
+  };
+
+  const enqueue = <T>(
+    requestRevision: number,
+    run: () => Promise<T>,
+  ): Promise<T | null> =>
+    new Promise<T | null>((resolve, reject) => {
+      let settled = false;
+      const resolveOnce = (value: T | null) => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+      };
+      queue.push({
+        revision: requestRevision,
+        cancel: () => resolveOnce(null),
+        run: () => {
+          void run()
+            .then(resolveOnce, reject)
+            .finally(() => {
+              activeJobs = Math.max(0, activeJobs - 1);
+              pumpQueue();
+            });
+        },
+      });
+      pumpQueue();
+    });
+
+  const resolve = (
+    key: string,
+    load: (requestId: string) => Promise<WallpaperThumbnailPayload>,
+  ): Promise<string | null> => {
+    const normalized = key.trim();
+    if (!normalized) return Promise.resolve(null);
+    const hit = peek(normalized);
+    if (hit) return Promise.resolve(hit);
+    const inFlight = pending.get(normalized);
+    if (inFlight) return inFlight;
+    if ((failedUntil.get(normalized) || 0) > Date.now()) {
+      return Promise.resolve(null);
+    }
+
+    const requestRevision = revision;
+    const requestId = createWallpaperRequestId();
+    const request = enqueue(requestRevision, async () => {
+      if (requestRevision !== revision) return null;
+      activeRequestIds.add(requestId);
+      try {
+        const result = await load(requestId);
+        if (
+          requestRevision !== revision ||
+          !validThumbnailResult(result, maxDataUrlLength)
+        ) {
+          return null;
+        }
+        remember(normalized, result.dataUrl);
+        failedUntil.delete(normalized);
+        return result.dataUrl;
+      } catch {
+        if (requestRevision === revision) {
+          failedUntil.set(normalized, Date.now() + failureCooldownMs);
+        }
+        return null;
+      } finally {
+        activeRequestIds.delete(requestId);
+      }
+    }).finally(() => {
+      if (pending.get(normalized) === request) pending.delete(normalized);
+    });
+    pending.set(normalized, request);
+    return request;
+  };
+
+  const subscribe = (key: string, listener: CacheListener): (() => void) => {
+    const normalized = key.trim();
+    let entries = listeners.get(normalized);
+    if (!entries) {
+      entries = new Set();
+      listeners.set(normalized, entries);
+    }
+    entries.add(listener);
+    return () => {
+      entries?.delete(listener);
+      if (entries?.size === 0) listeners.delete(normalized);
+    };
+  };
+
+  const forget = (key: string) => {
+    const normalized = key.trim();
+    resolved.delete(normalized);
+    failedUntil.set(normalized, Date.now() + failureCooldownMs);
+    notify(normalized);
+  };
+
+  const clear = () => {
+    revision += 1;
+    const subscribedKeys = Array.from(listeners.keys());
+    const requestIds = Array.from(activeRequestIds);
+    if (requestIds.length > 0) {
+      void cancelRequests(requestIds).catch(() => {
+        // Revision guards still reject late Host results.
+      });
+    }
+    for (const job of queue.splice(0)) job.cancel();
+    resolved.clear();
+    pending.clear();
+    failedUntil.clear();
+    for (const key of subscribedKeys) notify(key);
+  };
+
+  return {
+    peek,
+    subscribe,
+    resolve,
+    forget,
+    clear,
+    state: () => ({
+      active: activeJobs,
+      queued: queue.length,
+      cached: resolved.size,
+    }),
+  };
+}


### PR DESCRIPTION
## Summary

- 增加 Openverse、Pexels 等远程壁纸来源的前端 IPC 类型、请求生命周期与进度/批次事件校验。
- 为搜索、加载更多、取消和迟到结果建立 requestId/source 隔离，避免旧请求覆盖当前页面。
- 增加 Host 缩略图客户端缓存：限制并发、条目数和 data URL 大小，失败进入短暂冷却，清空时取消仍在执行的请求。
- 扩展图库条目的来源、作者和许可元数据，并提供稳定的追加去重逻辑。

本 PR 只交付内部前端协议与缓存，不新增可见入口。Openverse/Pexels 页面与 Pexels Key 控件将在后续独立 PR 中接入。

前置依赖：#1092、#1093、#1094。当前为堆叠分支；本 PR 的独立改动是提交 `4cdcddfd`。

已检索 open/closed Issues（wallpaper search、background image search、Openverse、Pexels、壁纸搜索），未发现被本 PR 精确解决的既有 Issue，因此不添加 `Fixes`。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Verification

- `pnpm typecheck`
- `pnpm test`：594 个测试文件、7,091 项通过
- `pnpm lint`
- `pnpm build:ui`
- `python scripts/check-code-quality-gates.py --mode final`
- `python scripts/publish-website-downloads.py --self-test`
- `pnpm deps:check`
- `pnpm audit:prod`：无已知漏洞
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- Windows manifest harness：1,735 项 Rust 测试通过，另 1 项原有 ignored

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri` (or `cargo check` for docs-only)
- [x] User-facing strings go through `src/i18n/messages.ts` (en + zh)
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included

## Remaining boundary

- 不包含 Openverse/Pexels 可见页面、Pexels Key 管理、Web 搜索、Grok Saved 相册或自动预取。
- 测试使用合成事件与媒体响应；没有宣称真实账号、真实 Provider 网络或桌面端到端已在本 PR 中验证。
