### PR TITLE
feat(wallpaper): 预取许可来源的下一页结果

### DIFF
--- a/docs/llm-wiki/wallpaper-search.md
+++ b/docs/llm-wiki/wallpaper-search.md
@@ -154,8 +154,17 @@ cursors, buffered results and source Referer origins; credentials/cursors are
 not returned to the renderer. Media request cancellation supports bounded
 pre-cancellation before registration.
 
-This batch supplies explicit pagination only. Automatic one-page-ahead loading,
-provider UI, Web search, catalog metadata and generation integrations are
+The UI follow-up keeps exactly one provider page ahead after every successful
+page while leaving it hidden until the user chooses “load more”. A click waits
+for an in-flight prefetch or consumes a completed one without another Host
+request, then starts at most one replacement prefetch when more pages remain.
+Hidden progress and failures are not surfaced as foreground state. A failed
+prefetch is discarded, so an explicit click makes one fresh foreground request;
+that request is never auto-retried and its failure preserves existing cards and
+the continuation. Query/source changes, close and cancellation invalidate late
+prefetch results and cancel the active Host request.
+
+Web search, Grok Saved, catalog metadata and generation integrations are
 separate changes. Tests use synthetic provider responses and media fixtures;
 passing tests do not claim live provider availability or account validation.
 
@@ -178,5 +187,6 @@ author and licence links separate from the image-preview action. A thumbnail
 failure leaves the result card available so selecting it can still fetch the
 validated original. Initial searches replace the old gallery; explicit “load
 more” appends deduplicated results while leaving current cards selectable.
-Paging failures preserve the gallery and continuation for retry. This UI slice
-does not automatically prefetch the next provider page.
+Paging failures preserve the gallery and continuation for retry. The separate
+prefetch follow-up described above adds one-page-ahead loading without changing
+this page's visible controls.

--- a/src/components/WallpaperSourceModal.providers.test.tsx
+++ b/src/components/WallpaperSourceModal.providers.test.tsx
@@ -109,8 +109,12 @@ it("keeps provider pictures selectable during more and preserves the downloaded 
   expect(screen.queryByRole("button", { name: "settings.wallpaperSource.loadMore" })).toBeNull();
 });
 it("preserves provider results after paging failure and allows a fresh retry", async () => {
-  mocks.more.mockResolvedValueOnce({ ...result([]), errorCode: "provider_network" }).mockResolvedValueOnce(result(["second"], false));
+  mocks.more
+    .mockResolvedValueOnce({ ...result([]), errorCode: "provider_network" })
+    .mockResolvedValueOnce({ ...result([]), errorCode: "provider_network" })
+    .mockResolvedValueOnce(result(["second"], false));
   await initial();
+  await waitFor(() => expect(mocks.more).toHaveBeenCalledTimes(1));
   fireEvent.click(screen.getByRole("button", { name: "settings.wallpaperSource.loadMore" }));
   await screen.findByText("settings.wallpaperSource.err.search_failed");
   expect(cards()).toHaveLength(1);

--- a/src/hooks/useWallpaperProviderController.test.tsx
+++ b/src/hooks/useWallpaperProviderController.test.tsx
@@ -1,0 +1,291 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MessageKey } from "@/i18n";
+import type {
+  WallpaperRemoteSearchResult,
+  WallpaperRemoteSearchStage,
+  WallpaperRemoteSource,
+} from "@/lib/wallpaperRemoteSearch";
+import type {
+  WallpaperGalleryItem,
+  WallpaperSourceErrorCode,
+} from "@/lib/wallpaperSource";
+
+const remote = vi.hoisted(() => ({
+  busy: false,
+  source: null as WallpaperRemoteSource | null,
+  requestId: null as string | null,
+  stage: null as WallpaperRemoteSearchStage | null,
+  progressiveItems: [] as WallpaperGalleryItem[],
+  progressiveCount: 0,
+  progressiveDone: false,
+  search: vi.fn(),
+  loadMore: vi.fn(),
+  cancel: vi.fn(async () => true),
+}));
+
+vi.mock("./useWallpaperRemoteSearch", () => ({
+  useWallpaperRemoteSearch: () => remote,
+}));
+
+import { useWallpaperProviderController } from "./useWallpaperProviderController";
+
+function galleryItem(id: string): WallpaperGalleryItem {
+  return {
+    id,
+    kind: "image",
+    source: "openverse",
+    thumbUrl: `https://images.example.test/${id}.jpg`,
+    fullUrl: `https://images.example.test/${id}.jpg`,
+    sourceName: "Openverse",
+    sourceUrl: `https://openverse.example.test/${id}`,
+  };
+}
+
+function result(
+  ids: string[],
+  overrides: Partial<WallpaperRemoteSearchResult> = {},
+): WallpaperRemoteSearchResult {
+  return {
+    source: "openverse",
+    items: ids.map(galleryItem),
+    hasMore: false,
+    cacheHit: false,
+    durationMs: 1_000,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function translate(
+  key: MessageKey,
+  vars?: Record<string, string | number | undefined | null>,
+) {
+  const suffix = vars
+    ? Object.entries(vars)
+        .map(([name, value]) => `${name}=${value}`)
+        .join(",")
+    : "";
+  return suffix ? `${key}:${suffix}` : key;
+}
+
+function useHarness({
+  enabled = true,
+  source = "openverse" as WallpaperRemoteSource,
+  query = "misty coast",
+} = {}) {
+  const [items, setItems] = useState<WallpaperGalleryItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] =
+    useState<WallpaperSourceErrorCode | null>(null);
+  const [statusHint, setStatusHint] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>("old");
+  const controller = useWallpaperProviderController({
+    enabled,
+    source,
+    query,
+    items,
+    t: translate,
+    setItems,
+    setError,
+    setErrorCode,
+    setStatusHint,
+    setHasSearched,
+    setSelectedId,
+  });
+  return {
+    controller,
+    items,
+    error,
+    errorCode,
+    statusHint,
+    hasSearched,
+    selectedId,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  remote.busy = false;
+  remote.source = null;
+  remote.requestId = null;
+  remote.stage = null;
+  remote.progressiveItems = [];
+  remote.progressiveCount = 0;
+  remote.progressiveDone = false;
+  remote.search.mockReset();
+  remote.loadMore.mockReset();
+  remote.cancel.mockClear();
+});
+
+describe("useWallpaperProviderController prefetch", () => {
+  it("keeps one successful page ahead without revealing it early", async () => {
+    const nextPrefetch = deferred<WallpaperRemoteSearchResult | null>();
+    remote.search.mockResolvedValue(result(["first"], { hasMore: true }));
+    remote.loadMore
+      .mockResolvedValueOnce(result(["second"], { hasMore: true }))
+      .mockReturnValueOnce(nextPrefetch.promise);
+    const hook = renderHook(() => useHarness());
+
+    await act(async () => hook.result.current.controller.search());
+    await waitFor(() => expect(remote.loadMore).toHaveBeenCalledTimes(1));
+    expect(hook.result.current.items.map((item) => item.id)).toEqual(["first"]);
+
+    await act(async () => hook.result.current.controller.loadMore());
+
+    expect(hook.result.current.items.map((item) => item.id)).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(remote.loadMore).toHaveBeenCalledTimes(2);
+    expect(hook.result.current.controller.canLoadMore).toBe(true);
+
+    await act(async () => {
+      nextPrefetch.resolve(result(["third"]));
+      await nextPrefetch.promise;
+    });
+    expect(hook.result.current.items.map((item) => item.id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("awaits an in-flight prefetch instead of issuing a duplicate request", async () => {
+    const pending = deferred<WallpaperRemoteSearchResult | null>();
+    remote.search.mockResolvedValue(result(["first"], { hasMore: true }));
+    remote.loadMore.mockReturnValue(pending.promise);
+    const hook = renderHook(() => useHarness());
+
+    await act(async () => hook.result.current.controller.search());
+    let paging!: Promise<void>;
+    let duplicate!: Promise<void>;
+    act(() => {
+      paging = hook.result.current.controller.loadMore();
+      duplicate = hook.result.current.controller.loadMore();
+    });
+
+    expect(remote.loadMore).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(hook.result.current.controller.loadingMore).toBe(true),
+    );
+    await act(async () => {
+      pending.resolve(result(["second"]));
+      await Promise.all([paging, duplicate]);
+    });
+    expect(remote.loadMore).toHaveBeenCalledTimes(1);
+    expect(hook.result.current.items.map((item) => item.id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("does not expose progressive items from a hidden prefetch", async () => {
+    const pending = deferred<WallpaperRemoteSearchResult | null>();
+    remote.search.mockResolvedValue(result(["first"], { hasMore: true }));
+    remote.loadMore.mockReturnValue(pending.promise);
+    const hook = renderHook(() => useHarness());
+
+    await act(async () => hook.result.current.controller.search());
+    remote.busy = true;
+    remote.source = "openverse";
+    remote.progressiveItems = [galleryItem("hidden")];
+    hook.rerender();
+
+    expect(hook.result.current.items.map((item) => item.id)).toEqual(["first"]);
+    expect(hook.result.current.controller.busy).toBe(false);
+    expect(hook.result.current.controller.stage).toBeNull();
+
+    await act(async () => {
+      pending.resolve(result(["second"]));
+      await pending.promise;
+    });
+  });
+
+  it("retries foreground paging after a resolved prefetch error", async () => {
+    remote.search.mockResolvedValue(result(["first"], { hasMore: true }));
+    remote.loadMore
+      .mockResolvedValueOnce(result([], { errorCode: "provider_network" }))
+      .mockResolvedValueOnce(result(["second"]));
+    const hook = renderHook(() => useHarness());
+
+    await act(async () => hook.result.current.controller.search());
+    await waitFor(() => expect(remote.loadMore).toHaveBeenCalledTimes(1));
+    expect(hook.result.current.error).toBeNull();
+    await act(async () => hook.result.current.controller.loadMore());
+
+    expect(remote.loadMore).toHaveBeenCalledTimes(2);
+    expect(hook.result.current.items.map((item) => item.id)).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(hook.result.current.error).toBeNull();
+  });
+
+  it("retries foreground paging after a rejected prefetch", async () => {
+    remote.search.mockResolvedValue(result(["first"], { hasMore: true }));
+    remote.loadMore
+      .mockRejectedValueOnce(new Error("provider_timeout"))
+      .mockResolvedValueOnce(result(["second"]));
+    const hook = renderHook(() => useHarness());
+
+    await act(async () => hook.result.current.controller.search());
+    await waitFor(() => expect(remote.loadMore).toHaveBeenCalledTimes(1));
+    await act(async () => hook.result.current.controller.loadMore());
+
+    expect(remote.loadMore).toHaveBeenCalledTimes(2);
+    expect(hook.result.current.items.map((item) => item.id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("preserves cards and retry state when foreground paging also fails", async () => {
+    remote.search.mockResolvedValue(result(["survivor"], { hasMore: true }));
+    remote.loadMore
+      .mockResolvedValueOnce(result([], { errorCode: "provider_network" }))
+      .mockRejectedValueOnce(new Error("provider_timeout"));
+    const hook = renderHook(() => useHarness());
+
+    await act(async () => hook.result.current.controller.search());
+    await waitFor(() => expect(remote.loadMore).toHaveBeenCalledTimes(1));
+    await act(async () => hook.result.current.controller.loadMore());
+
+    expect(hook.result.current.items.map((item) => item.id)).toEqual([
+      "survivor",
+    ]);
+    expect(hook.result.current.errorCode).toBe("timeout");
+    expect(hook.result.current.controller.canLoadMore).toBe(true);
+  });
+
+  it("cancels and discards a late prefetch after the query changes", async () => {
+    const pending = deferred<WallpaperRemoteSearchResult | null>();
+    remote.search.mockResolvedValue(result(["first"], { hasMore: true }));
+    remote.loadMore.mockReturnValue(pending.promise);
+    const hook = renderHook(
+      ({ query }) => useHarness({ query }),
+      { initialProps: { query: "misty coast" } },
+    );
+
+    await act(async () => hook.result.current.controller.search());
+    remote.cancel.mockClear();
+    hook.rerender({ query: "desert" });
+    await waitFor(() => expect(remote.cancel).toHaveBeenCalledTimes(1));
+    expect(hook.result.current.controller.canLoadMore).toBe(false);
+
+    await act(async () => {
+      pending.resolve(result(["late"]));
+      await pending.promise;
+    });
+    expect(hook.result.current.items.map((item) => item.id)).toEqual(["first"]);
+  });
+});

--- a/src/hooks/useWallpaperProviderController.ts
+++ b/src/hooks/useWallpaperProviderController.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/wallpaperSource";
 import {
   wallpaperRemoteUiError,
+  type WallpaperRemoteSearchResult,
   type WallpaperRemoteSource,
 } from "@/lib/wallpaperRemoteSearch";
 import type { MessageKey } from "@/i18n";
@@ -36,6 +37,24 @@ type Options = {
   setSelectedId: Dispatch<SetStateAction<string | null>>;
 };
 
+type Continuation = {
+  source: WallpaperRemoteSource;
+  query: string;
+};
+
+type PrefetchOutcome = {
+  continuation: Continuation;
+  result: WallpaperRemoteSearchResult | null;
+  error: unknown | null;
+};
+
+function sameContinuation(
+  left: Continuation,
+  right: Continuation,
+): boolean {
+  return left.source === right.source && left.query === right.query;
+}
+
 export function useWallpaperProviderController({
   enabled,
   source,
@@ -51,30 +70,105 @@ export function useWallpaperProviderController({
 }: Options) {
   const remote = useWallpaperRemoteSearch();
   const generation = useRef(0);
-  const [continuation, setContinuation] = useState<{
-    source: WallpaperRemoteSource;
-    query: string;
-  } | null>(null);
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const continuationRef = useRef<Continuation | null>(null);
+  const [continuation, setContinuation] = useState<Continuation | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
+  const loadingMoreRef = useRef(false);
+  const [prefetching, setPrefetching] = useState(false);
+  const prefetchingRef = useRef(false);
+  const prefetchGeneration = useRef(0);
+  const prefetchOutcome = useRef<PrefetchOutcome | null>(null);
+  const prefetchPromise = useRef<Promise<PrefetchOutcome | null> | null>(null);
   const normalized = query.trim().replace(/\s+/g, " ");
+
+  const updateContinuation = useCallback((next: Continuation | null) => {
+    continuationRef.current = next;
+    setContinuation(next);
+  }, []);
+
+  const discardPrefetch = useCallback(() => {
+    prefetchGeneration.current += 1;
+    prefetchingRef.current = false;
+    prefetchOutcome.current = null;
+    prefetchPromise.current = null;
+    setPrefetching(false);
+  }, []);
+
+  const startPrefetch = useCallback(
+    (next: Continuation) => {
+      const revision = prefetchGeneration.current + 1;
+      prefetchGeneration.current = revision;
+      prefetchingRef.current = true;
+      prefetchOutcome.current = null;
+      setPrefetching(true);
+
+      let task: Promise<PrefetchOutcome | null>;
+      task = remote
+        .loadMore(next.source, next.query)
+        .then(
+          (result): PrefetchOutcome | null => {
+            if (prefetchGeneration.current !== revision) return null;
+            const outcome = {
+              continuation: next,
+              result,
+              error: null,
+            } satisfies PrefetchOutcome;
+            prefetchOutcome.current = outcome;
+            return outcome;
+          },
+          (error): PrefetchOutcome | null => {
+            if (prefetchGeneration.current !== revision) return null;
+            const outcome = {
+              continuation: next,
+              result: null,
+              error,
+            } satisfies PrefetchOutcome;
+            prefetchOutcome.current = outcome;
+            return outcome;
+          },
+        )
+        .finally(() => {
+          if (prefetchGeneration.current !== revision) return;
+          prefetchingRef.current = false;
+          if (prefetchPromise.current === task) prefetchPromise.current = null;
+          setPrefetching(false);
+        });
+      prefetchPromise.current = task;
+    },
+    [remote.loadMore],
+  );
 
   const cancel = useCallback(async () => {
     generation.current += 1;
+    loadingMoreRef.current = false;
     setLoadingMore(false);
+    discardPrefetch();
     return remote.cancel();
-  }, [remote.cancel]);
+  }, [discardPrefetch, remote.cancel]);
 
   useEffect(() => {
     generation.current += 1;
-    setContinuation(null);
+    discardPrefetch();
+    updateContinuation(null);
+    loadingMoreRef.current = false;
     setLoadingMore(false);
     void remote.cancel();
-  }, [enabled, source, normalized, remote.cancel]);
+  }, [
+    discardPrefetch,
+    enabled,
+    normalized,
+    remote.cancel,
+    source,
+    updateContinuation,
+  ]);
 
   useEffect(() => {
     if (
       !enabled ||
       !source ||
+      prefetchingRef.current ||
       remote.source !== source ||
       remote.progressiveItems.length === 0
     ) {
@@ -89,6 +183,7 @@ export function useWallpaperProviderController({
   }, [
     enabled,
     loadingMore,
+    prefetching,
     remote.progressiveItems,
     remote.source,
     setHasSearched,
@@ -96,114 +191,216 @@ export function useWallpaperProviderController({
     source,
   ]);
 
-  const run = useCallback(
-    async (more: boolean) => {
-      if (!enabled || !source || !normalized || remote.busy) return;
-      if (
-        more &&
-        (!continuation ||
-          continuation.source !== source ||
-          continuation.query !== normalized)
-      ) {
-        return;
-      }
-      const revision = ++generation.current;
-      const initialItems = items;
-      setError(null);
-      setErrorCode(null);
-      setStatusHint(null);
-      setLoadingMore(more);
-      if (!more) {
-        setItems([]);
-        setSelectedId(null);
-        setHasSearched(false);
-        setContinuation(null);
-      }
-      try {
-        const result = await (more
-          ? remote.loadMore(source, normalized)
-          : remote.search(source, normalized));
-        if (!result || revision !== generation.current) return;
-        setHasSearched(true);
-        const code = wallpaperRemoteUiError(result);
-        if (code && code !== "empty") {
-          setErrorCode(code);
-          setError(t(`settings.wallpaperSource.err.${code}` as MessageKey));
-          setStatusHint(null);
-          return;
-        }
-        const nextItems = more
-          ? appendWallpaperGalleryItems(initialItems, result.items)
-          : appendWallpaperGalleryItems([], result.items);
-        setItems(nextItems);
-        setContinuation(result.hasMore ? { source, query: normalized } : null);
-        if (code === "empty") {
-          if (more) {
-            setStatusHint(t("settings.wallpaperSource.noMore"));
-          } else {
-            setErrorCode("empty");
-            setError(t("settings.wallpaperSource.err.empty"));
-            setStatusHint(null);
-          }
-        } else {
-          setStatusHint(
-            more
-              ? t("settings.wallpaperSource.remote.loadedMore", {
-                  count: result.items.length,
-                  total: nextItems.length,
-                })
-              : t(
-                  result.cacheHit
-                    ? "settings.wallpaperSource.remote.completeCached"
-                    : "settings.wallpaperSource.remote.complete",
-                  {
-                    count: nextItems.length,
-                    seconds: (result.durationMs / 1000).toFixed(1),
-                  },
-                ),
-          );
-        }
-      } catch (error) {
-        if (revision !== generation.current) return;
-        const code = parseWallpaperSourceError(error);
+  const search = useCallback(async () => {
+    if (
+      !enabled ||
+      !source ||
+      !normalized ||
+      loadingMoreRef.current ||
+      (remote.busy && !prefetchingRef.current)
+    ) {
+      return;
+    }
+    const revision = ++generation.current;
+    discardPrefetch();
+    loadingMoreRef.current = false;
+    setError(null);
+    setErrorCode(null);
+    setStatusHint(null);
+    setLoadingMore(false);
+    setItems([]);
+    setSelectedId(null);
+    setHasSearched(false);
+    updateContinuation(null);
+    try {
+      const result = await remote.search(source, normalized);
+      if (!result || revision !== generation.current) return;
+      setHasSearched(true);
+      const code = wallpaperRemoteUiError(result);
+      if (code && code !== "empty") {
         setErrorCode(code);
         setError(t(`settings.wallpaperSource.err.${code}` as MessageKey));
         setStatusHint(null);
-      } finally {
-        if (revision === generation.current) setLoadingMore(false);
+        return;
       }
-    },
-    [
-      continuation,
-      enabled,
-      items,
-      normalized,
-      remote.busy,
-      remote.loadMore,
-      remote.search,
-      setError,
-      setErrorCode,
-      setHasSearched,
-      setItems,
-      setSelectedId,
-      setStatusHint,
-      source,
-      t,
-    ],
-  );
+      const nextItems = appendWallpaperGalleryItems([], result.items);
+      setItems(nextItems);
+      const nextContinuation = result.hasMore
+        ? { source, query: normalized }
+        : null;
+      updateContinuation(nextContinuation);
+      if (code === "empty") {
+        setErrorCode("empty");
+        setError(t("settings.wallpaperSource.err.empty"));
+        setStatusHint(null);
+        return;
+      }
+      setStatusHint(
+        t(
+          result.cacheHit
+            ? "settings.wallpaperSource.remote.completeCached"
+            : "settings.wallpaperSource.remote.complete",
+          {
+            count: nextItems.length,
+            seconds: (result.durationMs / 1000).toFixed(1),
+          },
+        ),
+      );
+      if (nextContinuation) startPrefetch(nextContinuation);
+    } catch (error) {
+      if (revision !== generation.current) return;
+      const code = parseWallpaperSourceError(error);
+      setErrorCode(code);
+      setError(t(`settings.wallpaperSource.err.${code}` as MessageKey));
+      setStatusHint(null);
+    }
+  }, [
+    discardPrefetch,
+    enabled,
+    normalized,
+    remote.busy,
+    remote.search,
+    setError,
+    setErrorCode,
+    setHasSearched,
+    setItems,
+    setSelectedId,
+    setStatusHint,
+    source,
+    startPrefetch,
+    t,
+    updateContinuation,
+  ]);
 
-  const search = useCallback(() => run(false), [run]);
-  const loadMore = useCallback(() => run(true), [run]);
+  const loadMore = useCallback(async () => {
+    const active = continuationRef.current;
+    if (
+      !enabled ||
+      !source ||
+      !active ||
+      active.source !== source ||
+      active.query !== normalized ||
+      loadingMoreRef.current ||
+      (remote.busy && !prefetchingRef.current)
+    ) {
+      return;
+    }
+    const revision = generation.current;
+    const prefetchRevision = prefetchGeneration.current;
+    const initialItems = itemsRef.current;
+    setError(null);
+    setErrorCode(null);
+    setStatusHint(null);
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    try {
+      let prefetched = prefetchOutcome.current;
+      if (!prefetched && prefetchPromise.current) {
+        prefetched = await prefetchPromise.current;
+      }
+      if (
+        revision !== generation.current ||
+        prefetchRevision !== prefetchGeneration.current ||
+        !continuationRef.current ||
+        !sameContinuation(continuationRef.current, active)
+      ) {
+        return;
+      }
+      if (
+        prefetched &&
+        !sameContinuation(prefetched.continuation, active)
+      ) {
+        prefetched = null;
+      }
+      if (prefetched) prefetchOutcome.current = null;
+
+      const prefetchedCode = prefetched?.result
+        ? wallpaperRemoteUiError(prefetched.result)
+        : null;
+      if (
+        prefetched?.error ||
+        (prefetchedCode !== null && prefetchedCode !== "empty")
+      ) {
+        prefetched = null;
+      }
+      const result =
+        prefetched?.result ??
+        (await remote.loadMore(active.source, active.query));
+      if (!result || revision !== generation.current) return;
+      if (
+        !continuationRef.current ||
+        !sameContinuation(continuationRef.current, active)
+      ) {
+        return;
+      }
+
+      setHasSearched(true);
+      const code = wallpaperRemoteUiError(result);
+      if (code && code !== "empty") {
+        setErrorCode(code);
+        setError(t(`settings.wallpaperSource.err.${code}` as MessageKey));
+        setStatusHint(null);
+        return;
+      }
+      const nextItems = appendWallpaperGalleryItems(initialItems, result.items);
+      setItems(nextItems);
+      const nextContinuation = result.hasMore ? active : null;
+      updateContinuation(nextContinuation);
+      if (code === "empty") {
+        if (result.hasMore) {
+          setErrorCode("empty");
+          setError(t("settings.wallpaperSource.err.empty"));
+          setStatusHint(null);
+        } else {
+          setStatusHint(t("settings.wallpaperSource.noMore"));
+        }
+        return;
+      }
+      setStatusHint(
+        t("settings.wallpaperSource.remote.loadedMore", {
+          count: result.items.length,
+          total: nextItems.length,
+        }),
+      );
+      if (nextContinuation) startPrefetch(nextContinuation);
+    } catch (error) {
+      if (revision !== generation.current) return;
+      const code = parseWallpaperSourceError(error);
+      setErrorCode(code);
+      setError(t(`settings.wallpaperSource.err.${code}` as MessageKey));
+      setStatusHint(null);
+    } finally {
+      if (revision === generation.current) {
+        loadingMoreRef.current = false;
+        setLoadingMore(false);
+      }
+    }
+  }, [
+    enabled,
+    normalized,
+    remote.busy,
+    remote.loadMore,
+    setError,
+    setErrorCode,
+    setHasSearched,
+    setItems,
+    setStatusHint,
+    source,
+    startPrefetch,
+    t,
+    updateContinuation,
+  ]);
+
   const canLoadMore =
     continuation?.source === source && continuation.query === normalized;
 
   return {
-    busy: remote.busy,
+    busy: loadingMore || (remote.busy && !prefetching),
     loadingMore,
     cancel,
     search,
     loadMore,
     canLoadMore,
-    stage: remote.stage,
+    stage: prefetching && !loadingMore ? null : remote.stage,
   };
 }


### PR DESCRIPTION
## Summary

- Openverse / Pexels 每次成功返回一页后，在后台只预取下一页并保持结果隐藏。
- 用户点击“加载更多”时复用已完成或在途预取，不重复请求；消费成功后仅在仍有后续页时补一份下一页预取。
- 后台进度和失败不污染前台状态；后台失败后，显式点击会发起一次新的前台请求，失败时保留已有图片和重试能力。
- 查询、来源、弹窗状态变化与取消会使迟到预取失效；同步拦截重复加载，加载期间已有图片仍可选择。
- 更新壁纸搜索开发契约并补齐状态机回归测试。

## 依赖与审查范围

这是堆叠 PR，依赖 #1092、#1093、#1094、#1095、#1096。

本 PR 独立提交为 f60025c；审查本层时请重点查看该提交。独立差异为 4 文件、+604/-102，其中 291 行为新的状态机测试。

本层不增加来源入口或可见控件，不包含 Web 搜索、Grok Saved、X 搜索预取、catalog 或生成能力。由于它依赖仍处于 UI hold 的 #1096，本 PR 同样不自动合并，留给维护者统一拍板。

## 验证

- pnpm test：599 个文件、7,113 项通过
- pnpm typecheck
- pnpm lint
- pnpm build:ui（仅仓库既有 chunk 警告）
- python scripts/check-code-quality-gates.py --mode final
- python scripts/publish-website-downloads.py --self-test
- pnpm deps:check
- pnpm audit:prod（无已知生产依赖漏洞）
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- Windows Rust manifest harness：1,735 项通过，另 1 项原有 ignored

测试使用合成 Provider 响应；未宣称真实 Openverse/Pexels 网络或完整桌面实机 E2E。

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Checklist

- [x] I ran `pnpm typecheck` and `pnpm test`
- [x] I ran `cargo test` in `src-tauri`（使用 Windows manifest harness）
- [x] User-facing strings go through `src/i18n/messages.ts`（本层无新增文案）
- [x] No `window.confirm` / `prompt` / `alert` for product dialogs
- [x] Docs / `docs/llm-wiki` updated if behavior changed
- [x] No secrets (`secrets.json`, tokens, `auth.json`) included