### PR TITLE
fix(chat): show sent quote excerpts and comments inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ See `docs/llm-wiki/release.md`.
 - Ctrl+Tab 切回上一个用过的对话。按住 Ctrl 再点 Tab 继续循环；Ctrl+Shift+Tab 反向。
 
 ### Changed
+- Sent quotes show the excerpt and comment in the bubble, not a notes chip.
 - Streaming chat, heatmap hover, and SSH sidebar refresh do less re-rendering (#1073).
 - Default workspace uses a house icon in the sidebar and composer (#1069).
 - Sidebar Other now uses the same name as the composer chip: Default workspace (#1067).
@@ -61,6 +62,7 @@ See `docs/llm-wiki/release.md`.
 - Expanded sidebar pins remaining SuperGrok quota without opening the account menu (#1048). Settings is a footer gear; the account menu keeps theme and sign-in.
 
 **中文 · 变更**
+- 发送后的引用在气泡里直接显示摘录和评论，不再收成「N 条注释」。
 - 流式对话、热力图像悬停与 SSH 侧栏刷新减少无效重渲染（#1073）。
 - 默认工作区在侧栏和输入框改用小房子图标（#1069）。
 - 侧栏「其他会话」与输入框统一为「默认工作区」（#1067）。

--- a/src/components/ComposerQuoteCards.test.tsx
+++ b/src/components/ComposerQuoteCards.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import {
+  ComposerQuoteCards,
+  UserQuoteCards,
+} from "./ComposerQuoteCards";
+import {
+  appendQuotesToContent,
+  parseQuotesFromContent,
+  type ComposerQuote,
+} from "@/lib/composerQuotes";
+
+afterEach(() => {
+  cleanup();
+});
+
+const quote = (
+  text: string,
+  comment = "",
+  id = "q1",
+): ComposerQuote => ({ id, text, comment });
+
+describe("UserQuoteCards", () => {
+  it("shows excerpt and comment inline instead of a notes chip", () => {
+    render(
+      <UserQuoteCards
+        quotes={[quote("const x = 1", "why is this unused?")]}
+        listLabel="Quoted excerpts"
+      />,
+    );
+    expect(screen.getByText("const x = 1")).toBeInTheDocument();
+    expect(screen.getByText("why is this unused?")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText(/notes/i)).not.toBeInTheDocument();
+  });
+
+  it("omits the comment row when the note is empty", () => {
+    render(
+      <UserQuoteCards
+        quotes={[quote("selected line")]}
+        listLabel="Quoted excerpts"
+      />,
+    );
+    expect(screen.getByText("selected line")).toBeInTheDocument();
+    expect(document.querySelector(".user-quote__note")).toBeNull();
+  });
+
+  it("renders every quote without collapsing to a count", () => {
+    render(
+      <UserQuoteCards
+        quotes={[
+          quote("first excerpt", "first comment", "q1"),
+          quote("second excerpt", "second comment", "q2"),
+        ]}
+        listLabel="Quoted excerpts"
+      />,
+    );
+    expect(screen.getByText("first excerpt")).toBeInTheDocument();
+    expect(screen.getByText("first comment")).toBeInTheDocument();
+    expect(screen.getByText("second excerpt")).toBeInTheDocument();
+    expect(screen.getByText("second comment")).toBeInTheDocument();
+  });
+
+  it("renders journal fences as a visible excerpt and comment", () => {
+    const encoded = appendQuotesToContent("please fix this", [
+      quote("const x = 1", "why is this unused?"),
+    ]);
+    const parsed = parseQuotesFromContent(encoded);
+    render(
+      <UserQuoteCards quotes={parsed.quotes} listLabel="Quoted excerpts" />,
+    );
+    expect(screen.getByText("const x = 1")).toBeInTheDocument();
+    expect(screen.getByText("why is this unused?")).toBeInTheDocument();
+    expect(screen.queryByText("please fix this")).not.toBeInTheDocument();
+  });
+
+  it("highlights find hits in both excerpt and comment", () => {
+    render(
+      <UserQuoteCards
+        quotes={[quote("unused variable", "please delete unused")]}
+        listLabel="Quoted excerpts"
+        findQuery="unused"
+      />,
+    );
+    const hits = document.querySelectorAll("mark.chat-find-mark");
+    expect(hits.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("ComposerQuoteCards", () => {
+  it("keeps the compact count chip beside the draft", () => {
+    render(
+      <ComposerQuoteCards
+        quotes={[quote("const x = 1", "why is this unused?")]}
+        onCommentChange={() => {}}
+        onRemove={() => {}}
+        labels={{
+          list: "Quoted excerpts",
+          count: "1 notes",
+          remove: "Remove quote",
+          commentPlaceholder: "Comment on this excerpt…",
+        }}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "1 notes" })).toBeInTheDocument();
+    expect(screen.queryByText("why is this unused?")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ComposerQuoteCards.tsx
+++ b/src/components/ComposerQuoteCards.tsx
@@ -1,9 +1,11 @@
 /**
- * Compact annotation chips: show "N notes", hover/click to preview and edit.
+ * Composer: compact "N notes" chip (edit in a pop).
+ * Sent bubble: excerpt + comment inline — never hide the comment behind a count.
  */
 
 import { useEffect, useId, useRef, useState } from "react";
 import { IconBlockquote, IconClose } from "@/components/icons";
+import { HighlightedText } from "@/components/HighlightedText";
 import type { ComposerQuote } from "@/lib/composerQuotes";
 
 export function ComposerQuoteCards({
@@ -82,49 +84,38 @@ export function ComposerQuoteCards({
 
 export function UserQuoteCards({
   quotes,
-  countLabel,
+  listLabel,
+  findQuery,
 }: {
   quotes: ComposerQuote[];
-  countLabel: string;
+  listLabel: string;
+  findQuery?: string;
 }) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDoc = (e: MouseEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
-  }, [open]);
-
   if (!quotes.length) return null;
   return (
-    <div className="user-quote-list" ref={rootRef}>
-      <button
-        type="button"
-        className="user-quote-chip"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-        title={countLabel}
-      >
-        <IconBlockquote size={13} />
-        <span>{countLabel}</span>
-      </button>
-      {open ? (
-        <div className="user-quote-pop" role="dialog">
-          {quotes.map((q, i) => (
-            <article key={q.id} className="user-quote-pop__item">
-              <span className="composer-quote-pop__idx">{i + 1}</span>
-              <blockquote className="user-quote__text">{q.text}</blockquote>
-              {q.comment.trim() ? (
-                <p className="user-quote__note">{q.comment}</p>
-              ) : null}
-            </article>
-          ))}
-        </div>
-      ) : null}
+    <div className="user-quote-list" aria-label={listLabel}>
+      {quotes.map((q) => {
+        const note = q.comment.trim();
+        return (
+          <article key={q.id} className="user-quote">
+            <blockquote className="user-quote__text">
+              {quoteText(q.text, findQuery)}
+            </blockquote>
+            {note ? (
+              <p className="user-quote__note">{quoteText(note, findQuery)}</p>
+            ) : null}
+          </article>
+        );
+      })}
     </div>
   );
+}
+
+function quoteText(text: string, findQuery?: string) {
+  if (findQuery?.trim()) {
+    return (
+      <HighlightedText text={text} query={findQuery} activeOccurrence={null} />
+    );
+  }
+  return text;
 }

--- a/src/components/lobe-chat/ConversationThread.tsx
+++ b/src/components/lobe-chat/ConversationThread.tsx
@@ -543,7 +543,8 @@ const UserPlainOrSkills = memo(function UserPlainOrSkills({
     <>
       <UserQuoteCards
         quotes={quotes}
-        countLabel={tr("composer.quoteCount", { n: String(quotes.length) })}
+        listLabel={tr("composer.quotes")}
+        findQuery={findQuery}
       />
       {body.trim() || !quotes.length ? (
         <div

--- a/src/styles/chat.part2b.css
+++ b/src/styles/chat.part2b.css
@@ -256,8 +256,7 @@
   padding: 4px 4px 0;
 }
 
-.composer-quote-chip,
-.user-quote-chip {
+.composer-quote-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -272,15 +271,12 @@
 }
 
 .composer-quote-chip:hover,
-.user-quote-chip:hover,
-.composer-quote-chip[aria-expanded="true"],
-.user-quote-chip[aria-expanded="true"] {
+.composer-quote-chip[aria-expanded="true"] {
   color: var(--text-primary);
   border-color: var(--accent, #6b8afd);
 }
 
-.composer-quote-pop,
-.user-quote-pop {
+.composer-quote-pop {
   position: absolute;
   left: 0;
   bottom: calc(100% + 6px);
@@ -296,19 +292,25 @@
 }
 
 .user-quote-list {
-  position: relative;
   display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
   margin-bottom: 8px;
+  white-space: normal;
 }
 
-.composer-quote-pop__item,
-.user-quote-pop__item {
+.user-quote-list:last-child {
+  margin-bottom: 0;
+}
+
+.composer-quote-pop__item {
   padding: 8px;
   border-radius: 8px;
 }
 
-.composer-quote-pop__item + .composer-quote-pop__item,
-.user-quote-pop__item + .user-quote-pop__item {
+.composer-quote-pop__item + .composer-quote-pop__item {
   border-top: 1px solid var(--border-subtle);
 }
 
@@ -324,13 +326,21 @@
   color: var(--text-tertiary);
 }
 
-.composer-quote,
-.user-quote {
+.composer-quote {
   border: 1px solid var(--border-subtle);
   border-left: 3px solid var(--accent, #6b8afd);
   border-radius: 8px;
   background: var(--bg-hover);
   padding: 8px 10px 8px 10px;
+}
+
+.user-quote {
+  border: 0;
+  border-left: 3px solid
+    color-mix(in srgb, var(--chat-link, var(--accent, #6b8afd)) 72%, transparent);
+  border-radius: 0 8px 8px 0;
+  background: color-mix(in srgb, var(--chat-text, var(--text-primary)) 7%, transparent);
+  padding: 6px 10px 6px 12px;
 }
 
 .composer-quote__head {
@@ -369,8 +379,16 @@
   overflow: auto;
 }
 
-.composer-quote__note,
-.user-quote__note {
+.user-quote__text {
+  max-height: 12em;
+  color: color-mix(
+    in srgb,
+    var(--chat-text, var(--text-secondary)) 78%,
+    transparent
+  );
+}
+
+.composer-quote__note {
   margin: 8px 0 0;
   width: 100%;
   resize: vertical;
@@ -386,10 +404,15 @@
 }
 
 .user-quote__note {
-  border: 0;
-  background: transparent;
-  padding: 6px 0 0;
-  color: var(--text-primary);
+  margin: 8px 0 0;
+  padding: 8px 0 0;
+  border-top: 1px solid
+    color-mix(in srgb, var(--chat-text, var(--text-primary)) 12%, transparent);
+  font-size: var(--chat-fs, 13px);
+  line-height: var(--chat-lh, 1.45);
+  color: var(--chat-text, var(--text-primary));
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .sel-toolbar__btn--primary {


### PR DESCRIPTION
Fixes #1100.

## Why

After adding a transcript quote (optional comment) and sending, the user bubble collapsed to an **N notes** chip. The excerpt and comment were hidden behind a click, so a quotes-only send looked empty.

## What

- Sent bubbles render each quote as an inline card: excerpt + visible comment.
- Composer still uses the compact chip for editing.
- Tests cover excerpt, comment, multi-quote, find highlight, and journal round-trip.

## Verify

- `pnpm exec vitest run src/components/ComposerQuoteCards.test.tsx src/lib/whatsNew.test.ts`
- `pnpm typecheck`
- `pnpm exec eslint src/components/ComposerQuoteCards.tsx src/components/ComposerQuoteCards.test.tsx src/components/lobe-chat/ConversationThread.tsx --max-warnings 0`